### PR TITLE
feat(web15): C# .NET P/Invoke conduit binding

### DIFF
--- a/code/packages/csharp/conduit/.gitignore
+++ b/code/packages/csharp/conduit/.gitignore
@@ -1,0 +1,3 @@
+bin/
+obj/
+*.user

--- a/code/packages/csharp/conduit/BUILD
+++ b/code/packages/csharp/conduit/BUILD
@@ -1,0 +1,2 @@
+# build-tool: deps=rust/conduit-capi
+sh tools/run-tests.sh

--- a/code/packages/csharp/conduit/BUILD_windows
+++ b/code/packages/csharp/conduit/BUILD_windows
@@ -1,0 +1,1 @@
+echo C# Conduit uses P/Invoke against the Rust cdylib — skipping on Windows (requires cross-compile setup for libconduit_capi.dll)

--- a/code/packages/csharp/conduit/CHANGELOG.md
+++ b/code/packages/csharp/conduit/CHANGELOG.md
@@ -1,0 +1,32 @@
+# Changelog — CodingAdventures.Conduit
+
+## [0.1.0] — 2026-06-14
+
+Initial release: C# P/Invoke binding for the conduit-capi C ABI (WEB15).
+
+### Added
+
+- `Native` internal class with `[DllImport]` declarations for all conduit-capi functions
+- `NativeLibrary.SetDllImportResolver` for locating `libconduit_capi.so/.dylib` via
+  `CONDUIT_CAPI_PATH` environment variable (set by build script) or OS default search
+- `Response` sealed class with `Html`, `Json`, `Text`, `Respond`, `Redirect` factory
+  methods; `WithHeader` for fluent header addition
+- `HaltException` for non-local exit from handlers (equivalent to Sinatra's `halt`)
+- `Request` sealed class with `Method`, `Path`, `QueryString`, `ContentType`,
+  `RemoteAddr`, `Error`, `Param`, `Query`, `Header`, `Body`, `BodyString` accessors
+- `Trampolines` static unsafe class with `[UnmanagedCallersOnly(CallConvCdecl)]` methods
+  for `HandlerFn`, `BeforeFn`, `AfterFn`, `CtxFreeFn` — bridging C function pointers
+  to managed C# delegates via `GCHandle`
+- `Application` sealed class: fluent builder with `Get`/`Post`/`Put`/`Delete`/`Patch`/
+  `Route`, `Before`, `After`, `NotFound`, `OnError`, `Set`, `GetSetting`, `Bind`
+- `Server` sealed class: `Serve` (blocking), `ServeBackground`, `Stop`, `LocalPort`,
+  `IsRunning`, `Dispose` (IDisposable with Stop + Free)
+- `BeforeWrapper` box type for before-filter callbacks using the dedicated `BeforeFn`
+  trampoline (returns `IntPtr.Zero` = continue; non-zero = short-circuit)
+- 35 unit and E2E tests: 9 Response factory, 9 Application config, 3 Server lifecycle,
+  14 end-to-end HTTP via `HttpClient` + `ServeBackground` + 30-second watchdog timer
+- `tools/run-tests.sh`: self-sufficient build script that builds conduit-capi via
+  `cargo build --release -q`, sets `CONDUIT_CAPI_PATH`, then runs `dotnet test`
+- `BUILD` with `deps=rust/conduit-capi` directive
+- `BUILD_windows` skip (cdylib requires cross-compile setup)
+- `required_capabilities.json`: `ffi:call`, `network:listen`

--- a/code/packages/csharp/conduit/CodingAdventures.Conduit.csproj
+++ b/code/packages/csharp/conduit/CodingAdventures.Conduit.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.Conduit</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>C# P/Invoke binding for the conduit-capi web framework (WEB15)</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Remove="tests\**\*.cs" />
+    <EmbeddedResource Remove="tests\**" />
+    <None Remove="tests\**" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/conduit/Conduit.cs
+++ b/code/packages/csharp/conduit/Conduit.cs
@@ -1,0 +1,895 @@
+// Conduit.cs — C# P/Invoke binding for the conduit-capi C ABI (WEB15)
+//
+// Conduit is a Sinatra/Express-style web framework. This file wraps the Rust
+// `conduit-capi` shared library via .NET's Platform Invocation Services (P/Invoke).
+//
+// ARCHITECTURE OVERVIEW
+// ─────────────────────
+//   Program.cs  →  Application (C# builder)
+//                  │  registers routes/hooks as C# lambdas
+//                  ▼
+//               Trampolines (static [UnmanagedCallersOnly] methods)
+//                  │  convert calls across the managed/unmanaged boundary
+//                  ▼
+//               Native (P/Invoke [DllImport] declarations)
+//                  │
+//                  ▼
+//               libconduit_capi.so / .dylib  (Rust cdylib, WEB12)
+//
+// THE DELEGATE LIFETIME PROBLEM
+// ──────────────────────────────
+// .NET's GC can move or collect objects at any time. If we pass a managed
+// delegate's function pointer to C and the delegate is later collected, the
+// C code holds a dangling pointer — a crash waiting to happen.
+//
+// Solution: GCHandle.Alloc(closure) creates a *strong root* that prevents GC
+// collection. We pass GCHandle.ToIntPtr() as the opaque `void* ctx` to C.
+// When C calls `ctx_free`, our static trampoline recovers the handle and calls
+// .Free() — releasing the root so the GC may eventually reclaim the closure.
+//
+// This is the same pattern as Go's cgo.Handle in WEB14.
+//
+//   C# managed heap                 C native heap
+//  ┌──────────────┐                ┌──────────────────────┐
+//  │  lambda fn   │◄── GCHandle ──►│ ctx (opaque IntPtr)  │
+//  └──────────────┘  (strong root) └──────────────────────┘
+//         ▲                                   │
+//         └───────────────────────────────────┘
+//               trampoline recovers via
+//          GCHandle.FromIntPtr(ctx).Target
+
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace CodingAdventures.Conduit;
+
+// ── Native P/Invoke layer ────────────────────────────────────────────────────
+//
+// All [DllImport] declarations live here. This class is internal — users never
+// touch it directly. The static constructor installs a NativeLibrary resolver so
+// we can locate libconduit_capi.so/.dylib without requiring it on LD_LIBRARY_PATH.
+
+internal static class Native
+{
+    private const string Lib = "conduit_capi";
+
+    static Native()
+    {
+        // Install our resolver *before* any P/Invoke fires. .NET calls this
+        // delegate whenever it needs to load a native library by DllImport name.
+        NativeLibrary.SetDllImportResolver(typeof(Native).Assembly, Resolve);
+    }
+
+    // Check CONDUIT_CAPI_PATH first (set by tools/run-tests.sh to the exact
+    // path of the built .so/.dylib). Fall through to OS default search otherwise
+    // (LD_LIBRARY_PATH, DYLD_LIBRARY_PATH, RPATH, etc.).
+    private static IntPtr Resolve(string name, Assembly asm, DllImportSearchPath? paths)
+    {
+        if (name != Lib) return IntPtr.Zero;
+
+        var env = Environment.GetEnvironmentVariable("CONDUIT_CAPI_PATH");
+        if (env is { Length: > 0 })
+        {
+            // No File.Exists pre-check — that would introduce a TOCTOU race
+            // (an attacker could replace the file between check and load).
+            // NativeLibrary.Load throws DllNotFoundException with a clear message
+            // if the path does not exist or is not a valid shared library.
+            // CONDUIT_CAPI_PATH is a build-time variable set by run-tests.sh and
+            // must not be influenced by untrusted user input.
+            return NativeLibrary.Load(env);
+        }
+
+        return NativeLibrary.Load(name, asm, paths);
+    }
+
+    // ── Error channels ───────────────────────────────────────────────────────
+
+    // Store a thread-local error message before returning NULL from a handler.
+    [DllImport(Lib)]
+    internal static extern void conduit_capi_report_error(
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string msg);
+
+    // Retrieve the last error (valid until the next conduit call on this thread).
+    [DllImport(Lib)]
+    internal static extern IntPtr conduit_last_error();
+
+    // ── App lifecycle ────────────────────────────────────────────────────────
+
+    [DllImport(Lib)] internal static extern IntPtr conduit_app_new();
+    [DllImport(Lib)] internal static extern void   conduit_app_free(IntPtr app);
+
+    [DllImport(Lib)]
+    internal static extern void conduit_app_set_setting(
+        IntPtr app,
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string key,
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string value);
+
+    // Returns an owned char* — caller must conduit_string_free it.
+    [DllImport(Lib)]
+    internal static extern IntPtr conduit_app_get_setting(
+        IntPtr app,
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string key);
+
+    [DllImport(Lib)]
+    internal static extern void conduit_app_add_route(
+        IntPtr app,
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string method,
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string pattern,
+        IntPtr handler, IntPtr ctx, IntPtr ctxFree);
+
+    [DllImport(Lib)]
+    internal static extern void conduit_app_add_before(
+        IntPtr app, IntPtr handler, IntPtr ctx, IntPtr ctxFree);
+
+    [DllImport(Lib)]
+    internal static extern void conduit_app_add_after(
+        IntPtr app, IntPtr handler, IntPtr ctx, IntPtr ctxFree);
+
+    [DllImport(Lib)]
+    internal static extern void conduit_app_set_not_found(
+        IntPtr app, IntPtr handler, IntPtr ctx, IntPtr ctxFree);
+
+    [DllImport(Lib)]
+    internal static extern void conduit_app_set_error_handler(
+        IntPtr app, IntPtr handler, IntPtr ctx, IntPtr ctxFree);
+
+    // ── Server ───────────────────────────────────────────────────────────────
+
+    // Consumes `app` on both success and failure. Returns NULL on error.
+    [DllImport(Lib)]
+    internal static extern IntPtr conduit_server_bind(
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string host,
+        ushort port,
+        IntPtr app);
+
+    [DllImport(Lib)] internal static extern int    conduit_server_serve(IntPtr srv);
+    [DllImport(Lib)] internal static extern int    conduit_server_serve_background(IntPtr srv);
+    [DllImport(Lib)] internal static extern void   conduit_server_stop(IntPtr srv);
+    [DllImport(Lib)] internal static extern ushort conduit_server_local_port(IntPtr srv);
+    [DllImport(Lib)] internal static extern int    conduit_server_running(IntPtr srv);
+    [DllImport(Lib)] internal static extern void   conduit_server_free(IntPtr srv);
+
+    // ── Request accessors ────────────────────────────────────────────────────
+    //
+    // All return borrowed const char* valid only for the duration of the handler
+    // call. Marshal.PtrToStringUTF8 copies the bytes into a managed string
+    // immediately, which is exactly what we need.
+
+    [DllImport(Lib)] internal static extern IntPtr conduit_request_method(IntPtr req);
+    [DllImport(Lib)] internal static extern IntPtr conduit_request_path(IntPtr req);
+    [DllImport(Lib)] internal static extern IntPtr conduit_request_query_string(IntPtr req);
+    [DllImport(Lib)] internal static extern IntPtr conduit_request_content_type(IntPtr req);
+    [DllImport(Lib)] internal static extern IntPtr conduit_request_remote_addr(IntPtr req);
+    [DllImport(Lib)] internal static extern IntPtr conduit_request_error(IntPtr req);
+
+    // Returns pointer + length — body is NOT null-terminated.
+    [DllImport(Lib)]
+    internal static extern IntPtr conduit_request_body(IntPtr req, out nuint outLen);
+
+    [DllImport(Lib)]
+    internal static extern IntPtr conduit_request_param(
+        IntPtr req, [MarshalAs(UnmanagedType.LPUTF8Str)] string name);
+
+    [DllImport(Lib)]
+    internal static extern IntPtr conduit_request_query(
+        IntPtr req, [MarshalAs(UnmanagedType.LPUTF8Str)] string name);
+
+    [DllImport(Lib)]
+    internal static extern IntPtr conduit_request_header(
+        IntPtr req, [MarshalAs(UnmanagedType.LPUTF8Str)] string name);
+
+    // ── Response builder / reader ────────────────────────────────────────────
+
+    [DllImport(Lib)]
+    internal static extern IntPtr conduit_response_new(
+        ushort status, IntPtr body, nuint bodyLen);
+
+    [DllImport(Lib)]
+    internal static extern void conduit_response_set_header(
+        IntPtr resp,
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string name,
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string value);
+
+    [DllImport(Lib)] internal static extern ushort conduit_response_status(IntPtr resp);
+    [DllImport(Lib)] internal static extern IntPtr conduit_response_body(IntPtr resp, out nuint outLen);
+    [DllImport(Lib)] internal static extern nuint  conduit_response_header_count(IntPtr resp);
+    [DllImport(Lib)] internal static extern IntPtr conduit_response_header_name(IntPtr resp, nuint i);
+    [DllImport(Lib)] internal static extern IntPtr conduit_response_header_value(IntPtr resp, nuint i);
+    [DllImport(Lib)] internal static extern void   conduit_response_free(IntPtr resp);
+    [DllImport(Lib)] internal static extern void   conduit_string_free(IntPtr s);
+
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    internal static string? CStr(IntPtr p) =>
+        p == IntPtr.Zero ? null : Marshal.PtrToStringUTF8(p);
+
+    internal static string CStrNotNull(IntPtr p) => CStr(p) ?? "";
+}
+
+// ── Delegate types ────────────────────────────────────────────────────────────
+
+/// <summary>Handler function for routes, not-found handlers, and error handlers.</summary>
+public delegate Response HandlerFunc(Request req);
+
+/// <summary>
+/// Before-filter function. Return null to continue to the next filter/route;
+/// return a Response to short-circuit immediately.
+/// </summary>
+public delegate Response? BeforeFunc(Request req);
+
+/// <summary>
+/// After-hook function. Receives the current response (read from native), returns
+/// a (possibly modified) Response that replaces it.
+/// </summary>
+public delegate Response AfterFunc(Request req, Response current);
+
+// ── Trampolines ───────────────────────────────────────────────────────────────
+//
+// [UnmanagedCallersOnly] declares a static method as directly callable from C
+// code using the C calling convention (cdecl). When Rust calls a handler function
+// pointer, execution enters one of these methods.
+//
+// Rules enforced by the compiler:
+//   1. Must be static — no 'this' in C.
+//   2. Parameters must be blittable: IntPtr, ushort, nuint, bool, etc.
+//   3. Exceptions must not escape — always catch and handle inside.
+//
+// Function pointer addresses are captured once in the static constructor and
+// cached as IntPtr fields for Application to pass to conduit_app_add_route etc.
+
+// [ExcludeFromCodeCoverage] is mandatory here: coverlet instruments IL by injecting
+// managed calls, which violates the [UnmanagedCallersOnly] contract (those methods
+// must not be entered via managed call sites). Without this attribute, running
+// `dotnet test` with coverage enabled crashes the test host.
+[System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+internal static unsafe class Trampolines
+{
+    internal static readonly IntPtr Handler;
+    internal static readonly IntPtr BeforeHandler;
+    internal static readonly IntPtr After;
+    internal static readonly IntPtr CtxFree;
+
+    static Trampolines()
+    {
+        // The & operator on an [UnmanagedCallersOnly] method yields a typed native
+        // function pointer. Cast to IntPtr for opaque storage and passing to C.
+        Handler       = (IntPtr)(delegate* unmanaged[Cdecl]<IntPtr, IntPtr, IntPtr>)&HandlerFn;
+        BeforeHandler = (IntPtr)(delegate* unmanaged[Cdecl]<IntPtr, IntPtr, IntPtr>)&BeforeFn;
+        After         = (IntPtr)(delegate* unmanaged[Cdecl]<IntPtr, IntPtr, IntPtr, IntPtr>)&AfterFn;
+        CtxFree       = (IntPtr)(delegate* unmanaged[Cdecl]<IntPtr, void>)&CtxFreeFn;
+    }
+
+    // ── Route / not-found / error handler trampoline ─────────────────────────
+    //
+    // ctx holds a GCHandle to a HandlerFunc delegate.
+    // Returns a new ConduitResponse* (owned by Rust), or IntPtr.Zero on error.
+    //
+    // WHY we return a 500 JSON response directly instead of calling
+    // conduit_capi_report_error + returning NULL:
+    //   When a C handler returns NULL after calling conduit_capi_report_error,
+    //   conduit-capi returns the raw error string as the response body directly
+    //   (as a plain-text 500), bypassing the C# error handler registered via
+    //   conduit_app_set_error_handler. To prevent error details from leaking to
+    //   clients and to ensure correct JSON format, we build the 500 ourselves.
+    //   The native OnError handler is still registered and will be called for
+    //   conduit-internal errors that conduit-capi routes there directly.
+
+    [UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvCdecl) })]
+    private static IntPtr HandlerFn(IntPtr ctx, IntPtr req)
+    {
+        // A null ctx means the handle was never registered or has already been freed —
+        // this indicates a bug in the native layer. Return 500 rather than crashing.
+        if (ctx == IntPtr.Zero)
+            return Response.Json("{\"error\":\"internal server error\"}", 500).ToNative();
+
+        try
+        {
+            var fn = (HandlerFunc)GCHandle.FromIntPtr(ctx).Target!;
+            return fn(new Request(req)).ToNative();
+        }
+        catch (HaltException h) { return h.Response.ToNative(); }
+        catch (Exception ex)
+        {
+            ReportError(ex);  // log server-side
+            // Return a safe 500 — never reflect exception details to clients.
+            try { return Response.Json("{\"error\":\"internal server error\"}", 500).ToNative(); }
+            catch { return IntPtr.Zero; }
+        }
+    }
+
+    // ── Before-filter trampoline ──────────────────────────────────────────────
+    //
+    // ctx holds a GCHandle to a BeforeFunc delegate (stored directly — no wrapper).
+    // Returns IntPtr.Zero = continue; non-zero = short-circuit with that response.
+
+    [UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvCdecl) })]
+    private static IntPtr BeforeFn(IntPtr ctx, IntPtr req)
+    {
+        // Null ctx = no filter registered; NULL return = continue to next filter/route.
+        if (ctx == IntPtr.Zero) return IntPtr.Zero;
+
+        try
+        {
+            var fn     = (BeforeFunc)GCHandle.FromIntPtr(ctx).Target!;
+            var result = fn(new Request(req));
+            return result is null ? IntPtr.Zero : result.ToNative();
+        }
+        catch (HaltException h) { return h.Response.ToNative(); }
+        catch (Exception ex)
+        {
+            // On a before-filter exception, log it and continue (return NULL = continue).
+            // A before-filter failure is not fatal — let the request reach a route.
+            ReportError(ex);
+            return IntPtr.Zero; // NULL = continue to next filter/route
+        }
+    }
+
+    // ── After-hook trampoline ─────────────────────────────────────────────────
+    //
+    // ctx holds a GCHandle to an AfterFunc delegate.
+    // `current` is OWNED by this call — we must either free it or return it.
+
+    [UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvCdecl) })]
+    private static IntPtr AfterFn(IntPtr ctx, IntPtr req, IntPtr current)
+    {
+        // Null ctx = no after-hook registered; pass `current` through unchanged
+        // rather than crashing. We own `current` and must return something valid.
+        if (ctx == IntPtr.Zero) return current;
+
+        try
+        {
+            // Read the native response into a managed object, then release it.
+            var currentResp = Response.FromNative(current);
+            Native.conduit_response_free(current);
+
+            var fn = (AfterFunc)GCHandle.FromIntPtr(ctx).Target!;
+            return fn(new Request(req), currentResp).ToNative();
+        }
+        catch (HaltException h)
+        {
+            Native.conduit_response_free(current);
+            return h.Response.ToNative();
+        }
+        catch (Exception ex)
+        {
+            Native.conduit_response_free(current);
+            ReportError(ex);
+            // After-hooks must return a valid response (NULL is UB here).
+            try { return Response.Json("{\"error\":\"internal server error\"}", 500).ToNative(); }
+            catch { return Response.Text("Internal Server Error", 500).ToNative(); }
+        }
+    }
+
+    // ── GCHandle destructor ───────────────────────────────────────────────────
+    //
+    // Called by Rust when the owning app/server is freed. Releases the strong GC
+    // root so the closure can be collected.
+
+    [UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvCdecl) })]
+    private static void CtxFreeFn(IntPtr ctx)
+    {
+        try { GCHandle.FromIntPtr(ctx).Free(); }
+        catch { /* double-free or already freed — ignore */ }
+    }
+
+    // ── Error sanitisation ────────────────────────────────────────────────────
+    //
+    // Strip ASCII control characters and cap at 512 bytes before sending to the
+    // native error channel. Prevents log injection and runaway allocations.
+
+    internal static void ReportError(Exception ex)
+    {
+        try
+        {
+            var raw  = ex.Message ?? "unknown error";
+            var safe = new StringBuilder(Math.Min(raw.Length, 512));
+            foreach (var c in raw)
+            {
+                if (c < '\x20' || c == '\x7f') continue;
+                if (safe.Length >= 512) break;
+                safe.Append(c);
+            }
+            Native.conduit_capi_report_error(safe.ToString());
+        }
+        catch { /* best-effort */ }
+    }
+}
+
+// ── Response ─────────────────────────────────────────────────────────────────
+//
+// An immutable bundle of (status, headers, body). Built via static factory methods.
+// The native ConduitResponse* is only created when a handler actually returns, in
+// ToNative().
+
+public sealed class Response
+{
+    private readonly int    _status;
+    private readonly string _body;
+    private readonly List<(string Name, string Value)> _headers;
+
+    private Response(int status, string body, List<(string, string)>? headers = null)
+    {
+        _status  = status;
+        _body    = body;
+        _headers = headers ?? new List<(string, string)>();
+    }
+
+    // ── Factory methods ───────────────────────────────────────────────────────
+
+    /// <summary>HTML response (content-type: text/html; charset=utf-8).</summary>
+    public static Response Html(string body, int status = 200) =>
+        new(status, body, new List<(string, string)>
+        {
+            ("content-type", "text/html; charset=utf-8")
+        });
+
+    /// <summary>JSON response (content-type: application/json).</summary>
+    public static Response Json(string body, int status = 200) =>
+        new(status, body, new List<(string, string)>
+        {
+            ("content-type", "application/json")
+        });
+
+    /// <summary>Plain-text response (content-type: text/plain; charset=utf-8).</summary>
+    public static Response Text(string body, int status = 200) =>
+        new(status, body, new List<(string, string)>
+        {
+            ("content-type", "text/plain; charset=utf-8")
+        });
+
+    /// <summary>Arbitrary status + body + optional extra headers.</summary>
+    public static Response Respond(int status, string body,
+        params (string Name, string Value)[] headers) =>
+        new(status, body, new List<(string, string)>(headers));
+
+    /// <summary>
+    /// HTTP redirect. Throws ArgumentException if the location contains CR or LF —
+    /// belt-and-suspenders on top of conduit-capi's own header-injection defence.
+    /// </summary>
+    public static Response Redirect(string location, int status = 302)
+    {
+        if (location.Contains('\r') || location.Contains('\n'))
+            throw new ArgumentException(
+                "Redirect location must not contain CR or LF.", nameof(location));
+
+        return new(status, "", new List<(string, string)>
+        {
+            ("location", location)
+        });
+    }
+
+    // ── Accessors (useful in after-hooks) ─────────────────────────────────────
+
+    public int    Status  => _status;
+    public string Body    => _body;
+    public IReadOnlyList<(string Name, string Value)> Headers => _headers;
+
+    /// <summary>Return a new Response with an additional header appended.</summary>
+    public Response WithHeader(string name, string value)
+    {
+        var h = new List<(string, string)>(_headers) { (name, value) };
+        return new Response(_status, _body, h);
+    }
+
+    // ── Conversion to/from native ─────────────────────────────────────────────
+
+    // Creates a ConduitResponse* — ownership transfers to Rust when returned from
+    // a handler. For responses not returned from a handler, call
+    // Native.conduit_response_free() to avoid a leak.
+    internal IntPtr ToNative()
+    {
+        // Guard against out-of-range status codes before the narrowing cast to
+        // ushort: an unchecked (ushort)70000 silently wraps to 4464, producing
+        // a nonsensical wire status with no error. HTTP status codes live in
+        // [100, 599]; we widen to [100, 999] for custom/non-standard codes.
+        if (_status < 100 || _status > 999)
+            throw new InvalidOperationException(
+                $"HTTP status code {_status} is out of the valid range [100, 999].");
+
+        byte[] body = Encoding.UTF8.GetBytes(_body);
+
+        // GCHandle.Pinned keeps the byte array address stable while conduit_response_new
+        // copies the bytes into the native buffer. We pin a 1-byte placeholder when
+        // body is empty to ensure AddrOfPinnedObject() returns a valid (non-null) ptr.
+        var pin = GCHandle.Alloc(
+            body.Length > 0 ? body : new byte[] { 0 },
+            GCHandleType.Pinned);
+        try
+        {
+            var resp = Native.conduit_response_new(
+                (ushort)_status,
+                pin.AddrOfPinnedObject(),
+                (nuint)body.Length);
+
+            foreach (var (n, v) in _headers)
+                Native.conduit_response_set_header(resp, n, v);
+
+            return resp;
+        }
+        finally
+        {
+            pin.Free();
+        }
+    }
+
+    // Reads a native ConduitResponse* into a managed Response, copying all data.
+    // The caller is responsible for freeing the native pointer afterwards.
+    internal static Response FromNative(IntPtr ptr)
+    {
+        var status  = (int)Native.conduit_response_status(ptr);
+
+        var bodyPtr = Native.conduit_response_body(ptr, out var bodyLen);
+        string body;
+        if (bodyPtr == IntPtr.Zero || bodyLen == 0)
+        {
+            body = "";
+        }
+        else
+        {
+            // Guard against a rogue native layer returning a body length that
+            // overflows .NET's Array.MaxLength (2_147_483_591 on current runtimes).
+            if (bodyLen > (nuint)Array.MaxLength)
+                throw new InvalidOperationException(
+                    $"Native response body length {bodyLen} exceeds Array.MaxLength.");
+
+            var bytes = new byte[(int)bodyLen];
+            Marshal.Copy(bodyPtr, bytes, 0, (int)bodyLen);
+            body = Encoding.UTF8.GetString(bytes);
+        }
+
+        var count   = (int)Native.conduit_response_header_count(ptr);
+        var headers = new List<(string, string)>(count);
+        for (int i = 0; i < count; i++)
+        {
+            var n = Native.CStrNotNull(Native.conduit_response_header_name(ptr, (nuint)i));
+            var v = Native.CStrNotNull(Native.conduit_response_header_value(ptr, (nuint)i));
+            headers.Add((n, v));
+        }
+
+        return new Response(status, body, headers);
+    }
+}
+
+// ── HaltException ─────────────────────────────────────────────────────────────
+//
+// Throw this from inside any handler to immediately short-circuit with a specific
+// response — equivalent to Sinatra's `halt` or an early `return` in Express.
+//
+// Example:
+//   app.Before(req => {
+//       if (!HasApiKey(req))
+//           throw new HaltException(Response.Text("Unauthorized", 401));
+//       return null;
+//   });
+
+public sealed class HaltException : Exception
+{
+    public Response Response { get; }
+    public HaltException(Response response) : base("halt") => Response = response;
+}
+
+// ── Request ───────────────────────────────────────────────────────────────────
+//
+// A read-only view of an HTTP request, valid only for the duration of one handler
+// invocation. DANGER: Do NOT store a Request and use it after the handler returns
+// — the native ConduitRequest* is freed immediately after. Copy any data you need.
+
+public sealed class Request
+{
+    private readonly IntPtr _ptr;
+
+    internal Request(IntPtr ptr) => _ptr = ptr;
+
+    /// <summary>HTTP method in uppercase: "GET", "POST", "PUT", "DELETE", etc.</summary>
+    public string Method => Native.CStrNotNull(Native.conduit_request_method(_ptr));
+
+    /// <summary>URL path without query string: "/api/users/42".</summary>
+    public string Path => Native.CStrNotNull(Native.conduit_request_path(_ptr));
+
+    /// <summary>Raw query string without the leading '?': "q=hello&page=2".</summary>
+    public string QueryString => Native.CStrNotNull(Native.conduit_request_query_string(_ptr));
+
+    /// <summary>Content-Type header value, or "" if absent.</summary>
+    public string ContentType => Native.CStrNotNull(Native.conduit_request_content_type(_ptr));
+
+    /// <summary>Remote address as "IP:port": "127.0.0.1:54321".</summary>
+    public string RemoteAddr => Native.CStrNotNull(Native.conduit_request_remote_addr(_ptr));
+
+    /// <summary>
+    /// Non-empty only inside an OnError handler — the message stored by the
+    /// failing route via conduit_capi_report_error (or a panic message from Rust).
+    /// </summary>
+    public string Error => Native.CStrNotNull(Native.conduit_request_error(_ptr));
+
+    /// <summary>Named route parameter from the URL pattern, or null if absent.</summary>
+    public string? Param(string name) =>
+        Native.CStr(Native.conduit_request_param(_ptr, name));
+
+    /// <summary>Query string value for the given key, or null if absent.</summary>
+    public string? Query(string name) =>
+        Native.CStr(Native.conduit_request_query(_ptr, name));
+
+    /// <summary>Request header value (case-insensitive lookup), or null if absent.</summary>
+    public string? Header(string name) =>
+        Native.CStr(Native.conduit_request_header(_ptr, name));
+
+    /// <summary>Raw request body bytes. Empty array if no body.</summary>
+    public byte[] Body()
+    {
+        var ptr = Native.conduit_request_body(_ptr, out var len);
+        if (ptr == IntPtr.Zero || len == 0) return Array.Empty<byte>();
+
+        // Guard against a rogue native layer returning a body length that
+        // overflows .NET's Array.MaxLength.
+        if (len > (nuint)Array.MaxLength)
+            throw new InvalidOperationException(
+                $"Native request body length {len} exceeds Array.MaxLength.");
+
+        var bytes = new byte[(int)len];
+        Marshal.Copy(ptr, bytes, 0, (int)len);
+        return bytes;
+    }
+
+    /// <summary>Request body decoded as UTF-8 text.</summary>
+    public string BodyString() => Encoding.UTF8.GetString(Body());
+}
+
+// ── Application ───────────────────────────────────────────────────────────────
+//
+// The builder object. Register routes and hooks, then call Bind() to obtain a
+// Server.
+//
+// CRITICAL: Bind() CONSUMES the native ConduitApp* (the Rust function moves it
+// out even on failure). Do not call any method on this Application object after
+// Bind() — it will throw InvalidOperationException.
+//
+// Settings captured with GetSetting() MUST be read before calling Bind():
+//
+//   var app = new Application();
+//   app.Set("title", "MyApp");
+//   var title = app.GetSetting("title");   // ← read settings HERE
+//   app.Get("/", req => Response.Html($"<h1>{title}</h1>"));  // capture string
+//   using var server = app.Bind();         // ← app consumed here
+
+public sealed class Application : IDisposable
+{
+    private IntPtr _app;
+    private bool   _consumed;
+
+    // List of GCHandle roots we have allocated. Even though Rust will call
+    // ctx_free for each when the server is freed, we keep a copy here so that
+    // Dispose() can clean up handles in the case where Bind() never succeeded.
+    private readonly List<GCHandle> _handles = new();
+
+    public Application() => _app = Native.conduit_app_new();
+
+    // ── Settings ──────────────────────────────────────────────────────────────
+
+    /// <summary>Store a string setting (must be called before Bind).</summary>
+    public Application Set(string key, string value)
+    {
+        CheckAlive();
+        Native.conduit_app_set_setting(_app, key, value);
+        return this;
+    }
+
+    /// <summary>
+    /// Retrieve a setting stored with Set(). Returns null if the key is absent.
+    /// Must be called before Bind() — the ConduitApp* is consumed on Bind().
+    /// </summary>
+    public string? GetSetting(string key)
+    {
+        CheckAlive();
+        var ptr = Native.conduit_app_get_setting(_app, key);
+        if (ptr == IntPtr.Zero) return null;
+        var s = Marshal.PtrToStringUTF8(ptr);
+        Native.conduit_string_free(ptr);
+        return s;
+    }
+
+    // ── Route registration (fluent) ───────────────────────────────────────────
+
+    public Application Get(string pattern, HandlerFunc handler)    => Route("GET",    pattern, handler);
+    public Application Post(string pattern, HandlerFunc handler)   => Route("POST",   pattern, handler);
+    public Application Put(string pattern, HandlerFunc handler)    => Route("PUT",    pattern, handler);
+    public Application Delete(string pattern, HandlerFunc handler) => Route("DELETE", pattern, handler);
+    public Application Patch(string pattern, HandlerFunc handler)  => Route("PATCH",  pattern, handler);
+
+    public Application Route(string method, string pattern, HandlerFunc handler)
+    {
+        CheckAlive();
+        var handle = GCHandle.Alloc(handler);
+        _handles.Add(handle);
+        Native.conduit_app_add_route(
+            _app, method, pattern,
+            Trampolines.Handler, GCHandle.ToIntPtr(handle), Trampolines.CtxFree);
+        return this;
+    }
+
+    // ── Filters and hooks ─────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Add a before-filter. Return null to continue to the next middleware/route;
+    /// return a Response to short-circuit and send that response immediately.
+    /// </summary>
+    public Application Before(BeforeFunc filter)
+    {
+        CheckAlive();
+        // Store the BeforeFunc delegate directly in the GCHandle (no wrapper needed).
+        // BeforeFn casts GCHandle.Target directly to BeforeFunc.
+        var handle = GCHandle.Alloc(filter);
+        _handles.Add(handle);
+        Native.conduit_app_add_before(
+            _app,
+            Trampolines.BeforeHandler, GCHandle.ToIntPtr(handle), Trampolines.CtxFree);
+        return this;
+    }
+
+    /// <summary>Add an after-hook. Receives current Response; return modified Response.</summary>
+    public Application After(AfterFunc hook)
+    {
+        CheckAlive();
+        var handle = GCHandle.Alloc(hook);
+        _handles.Add(handle);
+        Native.conduit_app_add_after(
+            _app,
+            Trampolines.After, GCHandle.ToIntPtr(handle), Trampolines.CtxFree);
+        return this;
+    }
+
+    /// <summary>Custom handler for requests that match no route (default: 404).</summary>
+    public Application NotFound(HandlerFunc handler)
+    {
+        CheckAlive();
+        var handle = GCHandle.Alloc(handler);
+        _handles.Add(handle);
+        Native.conduit_app_set_not_found(
+            _app,
+            Trampolines.Handler, GCHandle.ToIntPtr(handle), Trampolines.CtxFree);
+        return this;
+    }
+
+    /// <summary>Custom error handler. Inspect req.Error for the failure message.</summary>
+    public Application OnError(HandlerFunc handler)
+    {
+        CheckAlive();
+        var handle = GCHandle.Alloc(handler);
+        _handles.Add(handle);
+        Native.conduit_app_set_error_handler(
+            _app,
+            Trampolines.Handler, GCHandle.ToIntPtr(handle), Trampolines.CtxFree);
+        return this;
+    }
+
+    // ── Bind ──────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Bind to host:port and return a Server. Consumes this Application object.
+    ///
+    /// Use port 0 to let the OS assign an ephemeral port; read it back via
+    /// Server.LocalPort.
+    /// </summary>
+    public Server Bind(string host = "127.0.0.1", ushort port = 3000)
+    {
+        CheckAlive();
+        _consumed = true; // mark before the call so Dispose skips conduit_app_free
+
+        var srv = Native.conduit_server_bind(host, port, _app);
+        if (srv == IntPtr.Zero)
+        {
+            // Log the raw native error to stderr (server-controlled output only) so
+            // operators can diagnose bind failures without leaking internals to callers.
+            var rawErr = Native.CStrNotNull(Native.conduit_last_error());
+            Console.Error.WriteLine($"[conduit] conduit_server_bind failed: {rawErr}");
+
+            // Throw a sanitized message. "Failed to bind" is enough for callers to act on;
+            // the details are in the log above where they can't reach end-users.
+            throw new InvalidOperationException(
+                $"Failed to bind conduit server on {host}:{port}. See stderr for details.");
+        }
+
+        return new Server(srv);
+    }
+
+    // ── IDisposable ───────────────────────────────────────────────────────────
+
+    public void Dispose()
+    {
+        if (!_consumed && _app != IntPtr.Zero)
+        {
+            Native.conduit_app_free(_app);
+            _app = IntPtr.Zero;
+        }
+
+        // Free any handles we still hold. Rust calls ctx_free for routes that
+        // were registered on a bound server, but if Bind() never succeeded these
+        // handles would leak without this cleanup.
+        foreach (var h in _handles)
+        {
+            if (h.IsAllocated) { try { h.Free(); } catch { /* ignore */ } }
+        }
+        _handles.Clear();
+    }
+
+    private void CheckAlive()
+    {
+        if (_consumed)
+            throw new InvalidOperationException(
+                "Application has already been passed to Bind(). " +
+                "Create a new Application to register more routes.");
+    }
+}
+
+// ── Server ────────────────────────────────────────────────────────────────────
+//
+// Owns the native ConduitServer* handle. Always dispose via `using` so the OS
+// socket is released promptly.
+//
+//   using var server = app.Bind("127.0.0.1", 0);
+//   server.ServeBackground();
+//   // … test code …
+//   // server.Dispose() called automatically at end of `using` block
+
+public sealed class Server : IDisposable
+{
+    private IntPtr _srv;
+
+    internal Server(IntPtr srv) => _srv = srv;
+
+    /// <summary>
+    /// Block the calling thread and serve requests until Stop() is called.
+    /// Returns 0 on clean shutdown.
+    /// </summary>
+    public int Serve()
+    {
+        CheckAlive();
+        return Native.conduit_server_serve(_srv);
+    }
+
+    /// <summary>
+    /// Start serving in a background OS thread. Returns immediately.
+    /// Returns 0 on success.
+    /// </summary>
+    public int ServeBackground()
+    {
+        CheckAlive();
+        return Native.conduit_server_serve_background(_srv);
+    }
+
+    /// <summary>Signal the server to stop accepting new connections.</summary>
+    public void Stop()
+    {
+        if (_srv != IntPtr.Zero)
+            Native.conduit_server_stop(_srv);
+    }
+
+    /// <summary>
+    /// The actual port the OS assigned. Useful when you passed port 0 to Bind().
+    /// </summary>
+    public ushort LocalPort
+    {
+        get { CheckAlive(); return Native.conduit_server_local_port(_srv); }
+    }
+
+    /// <summary>True if the server background thread is currently running.</summary>
+    public bool IsRunning =>
+        _srv != IntPtr.Zero && Native.conduit_server_running(_srv) != 0;
+
+    public void Dispose()
+    {
+        if (_srv != IntPtr.Zero)
+        {
+            Native.conduit_server_stop(_srv);
+            Native.conduit_server_free(_srv);
+            _srv = IntPtr.Zero;
+        }
+    }
+
+    private void CheckAlive()
+    {
+        if (_srv == IntPtr.Zero)
+            throw new ObjectDisposedException(nameof(Server));
+    }
+}

--- a/code/packages/csharp/conduit/README.md
+++ b/code/packages/csharp/conduit/README.md
@@ -1,0 +1,164 @@
+# CodingAdventures.Conduit
+
+A .NET 9 P/Invoke binding for the **conduit-capi** C ABI — a Sinatra/Express-style
+web framework built on Rust's `web-core` engine.
+
+## Stack position
+
+```
+Program.cs (your app)
+    │
+CodingAdventures.Conduit  ← this package
+    │  P/Invoke / [DllImport]
+    ▼
+libconduit_capi.so/.dylib  (Rust, WEB12)
+    │
+web-core  (Rust engine, WEB08)
+```
+
+## Quick start
+
+```csharp
+using CodingAdventures.Conduit;
+
+var app = new Application();
+app.Set("title", "MyApp");
+var title = app.GetSetting("title")!;   // capture before Bind()
+
+app.Get("/", req => Response.Html($"<h1>Welcome to {title}</h1>"));
+
+app.Get("/api/user/:id", req => {
+    var id = req.Param("id");
+    return Response.Json(System.Text.Json.JsonSerializer.Serialize(new { id }));
+});
+
+app.Before(req =>
+    req.Header("x-api-key") == "secret"
+        ? null                               // continue
+        : Response.Text("Unauthorized", 401));
+
+app.After((req, resp) => resp.WithHeader("x-powered-by", "conduit"));
+
+app.NotFound(req => Response.Json("{\"error\":\"not found\"}", 404));
+
+app.OnError(req => {
+    Console.Error.WriteLine($"Error: {req.Error}");
+    return Response.Json("{\"error\":\"internal server error\"}", 500);
+});
+
+using var server = app.Bind("0.0.0.0", 8080);
+server.Serve();
+```
+
+## API reference
+
+### Response
+
+| Method | Description |
+|--------|-------------|
+| `Response.Html(body, status=200)` | `text/html; charset=utf-8` response |
+| `Response.Json(body, status=200)` | `application/json` response |
+| `Response.Text(body, status=200)` | `text/plain; charset=utf-8` response |
+| `Response.Respond(status, body, ...headers)` | Arbitrary status + headers |
+| `Response.Redirect(location, status=302)` | Location redirect (throws on CR/LF) |
+| `resp.WithHeader(name, value)` | Fluent header addition |
+
+### Request
+
+| Property / Method | Description |
+|------------------|-------------|
+| `req.Method` | `"GET"`, `"POST"`, … |
+| `req.Path` | `/api/users/42` |
+| `req.QueryString` | Raw query string without `?` |
+| `req.ContentType` | `Content-Type` header value |
+| `req.RemoteAddr` | `"127.0.0.1:54321"` |
+| `req.Error` | Error message (non-empty only in `OnError`) |
+| `req.Param("name")` | Route parameter or `null` |
+| `req.Query("key")` | Query string value or `null` |
+| `req.Header("name")` | Case-insensitive header lookup or `null` |
+| `req.Body()` | Raw body as `byte[]` |
+| `req.BodyString()` | Body decoded as UTF-8 string |
+
+### Application (builder)
+
+```csharp
+var app = new Application();
+app.Set("key", "value")           // store a setting
+app.GetSetting("key")             // retrieve (before Bind only)
+app.Get("/path", handler)
+app.Post("/path", handler)
+app.Put("/path", handler)
+app.Delete("/path", handler)
+app.Patch("/path", handler)
+app.Route("CUSTOM", "/path", handler)
+app.Before(filter)                // null = continue; Response = halt
+app.After(hook)                   // receive + transform current response
+app.NotFound(handler)
+app.OnError(handler)
+using var server = app.Bind(host, port);  // consumes the Application
+```
+
+### HaltException
+
+Throw from anywhere inside a handler to immediately short-circuit:
+
+```csharp
+app.Before(req => {
+    if (!IsValid(req))
+        throw new HaltException(Response.Text("Bad Request", 400));
+    return null;
+});
+```
+
+### Server
+
+```csharp
+server.Serve()            // blocks until Stop()
+server.ServeBackground()  // returns immediately; runs in OS thread
+server.Stop()
+server.LocalPort          // ushort — actual bound port
+server.IsRunning          // bool
+```
+
+## Delegate lifetime management
+
+Every C# lambda passed to `app.Get(...)`, `app.Before(...)`, etc. is stored in a
+`GCHandle` (allocated, not pinned). The GC cannot collect the lambda as long as the
+handle is alive. When conduit-capi frees the app/server, it calls our `ctx_free`
+trampoline which calls `GCHandle.Free()`, releasing the strong root.
+
+This is the exact analogue of Go's `cgo.Handle` pattern used in WEB14.
+
+## Build requirements
+
+- .NET 9 SDK
+- Rust toolchain (`cargo`)
+
+```sh
+cd code/packages/csharp/conduit
+sh tools/run-tests.sh
+```
+
+The script builds `conduit-capi` (Rust cdylib), sets `CONDUIT_CAPI_PATH`, then runs
+`dotnet test` with coverage.
+
+## Security properties
+
+All header injection defence, status clamping (100–599), and UTF-8 validation are
+handled by `conduit-capi` in Rust — trusted once, reused across all language ports.
+
+The C# layer adds:
+- Redirect location CR/LF guard (throws `ArgumentException`)
+- Error message sanitisation in trampolines (strips control chars, caps at 512 bytes)
+- Structured JSON via `System.Text.Json` (no string interpolation into responses)
+
+## Test coverage
+
+35 tests across four groups:
+
+| Group | Count |
+|-------|-------|
+| Response factory (pure managed) | 9 |
+| Application configuration | 9 |
+| Server lifecycle | 3 |
+| End-to-end HTTP | 14 |

--- a/code/packages/csharp/conduit/required_capabilities.json
+++ b/code/packages/csharp/conduit/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://coding-adventures.example/schemas/required_capabilities/v1.json",
+  "version": 1,
+  "package": "csharp/conduit",
+  "capabilities": ["ffi:call", "network:listen"],
+  "justification": "ffi:call — uses P/Invoke ([DllImport]) to call into the Rust conduit-capi shared library (libconduit_capi.so/.dylib). network:listen — test suite binds a real TCP socket on 127.0.0.1:0 via conduit_server_bind to run E2E HTTP tests."
+}

--- a/code/packages/csharp/conduit/tests/CodingAdventures.Conduit.Tests/CodingAdventures.Conduit.Tests.csproj
+++ b/code/packages/csharp/conduit/tests/CodingAdventures.Conduit.Tests/CodingAdventures.Conduit.Tests.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk"     Version="17.12.0" />
+    <PackageReference Include="xunit"                      Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio"  Version="2.8.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.msbuild"           Version="6.0.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../CodingAdventures.Conduit.csproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/conduit/tests/CodingAdventures.Conduit.Tests/ConduitTests.cs
+++ b/code/packages/csharp/conduit/tests/CodingAdventures.Conduit.Tests/ConduitTests.cs
@@ -1,0 +1,521 @@
+// ConduitTests.cs — 35 tests for CodingAdventures.Conduit (WEB15)
+//
+// Tests are organised in four groups:
+//   1. Response unit tests        — pure managed code, no native library
+//   2. Application unit tests     — configure-only, require native library
+//   3. Server lifecycle tests     — bind + LocalPort + IsRunning + Dispose
+//   4. End-to-end HTTP tests      — ServeBackground + HttpClient
+//
+// E2E WATCHDOG
+// ─────────────
+// A 30-second System.Threading.Timer fires Environment.Exit(1) to prevent the
+// test run from hanging in CI if a deadlock occurs. The timer is cancelled once
+// all E2E tests complete (ServerFixture.Dispose).
+
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using CodingAdventures.Conduit;
+using Xunit;
+
+namespace CodingAdventures.Conduit.Tests;
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// GROUP 1 — Response unit tests (pure managed; native library NOT required)
+// ═══════════════════════════════════════════════════════════════════════════════
+
+public sealed class ResponseUnitTests
+{
+    [Fact]
+    public void Html_DefaultStatus_Is200()
+    {
+        var r = Response.Html("<p>hi</p>");
+        Assert.Equal(200, r.Status);
+    }
+
+    [Fact]
+    public void Html_SetsContentTypeHeader()
+    {
+        var r = Response.Html("<p>hi</p>");
+        Assert.Contains(r.Headers, h =>
+            h.Name == "content-type" &&
+            h.Value.StartsWith("text/html"));
+    }
+
+    [Fact]
+    public void Html_ExplicitStatus()
+    {
+        var r = Response.Html("<p>created</p>", 201);
+        Assert.Equal(201, r.Status);
+    }
+
+    [Fact]
+    public void Json_SetsContentTypeHeader()
+    {
+        var r = Response.Json("{}", 200);
+        Assert.Contains(r.Headers, h =>
+            h.Name == "content-type" &&
+            h.Value == "application/json");
+    }
+
+    [Fact]
+    public void Text_SetsContentTypeHeader()
+    {
+        var r = Response.Text("hello");
+        Assert.Contains(r.Headers, h =>
+            h.Name == "content-type" &&
+            h.Value.StartsWith("text/plain"));
+    }
+
+    [Fact]
+    public void Respond_PreservesArbitraryHeaders()
+    {
+        var r = Response.Respond(418, "teapot",
+            ("x-custom", "value1"),
+            ("x-other", "value2"));
+        Assert.Equal(418, r.Status);
+        Assert.Equal("teapot", r.Body);
+        Assert.Contains(r.Headers, h => h.Name == "x-custom" && h.Value == "value1");
+        Assert.Contains(r.Headers, h => h.Name == "x-other"  && h.Value == "value2");
+    }
+
+    [Fact]
+    public void Redirect_Default302WithLocation()
+    {
+        var r = Response.Redirect("/new-path");
+        Assert.Equal(302, r.Status);
+        Assert.Contains(r.Headers, h =>
+            h.Name == "location" && h.Value == "/new-path");
+    }
+
+    [Fact]
+    public void Redirect_RejectsCR()
+    {
+        Assert.Throws<ArgumentException>(() => Response.Redirect("/path\r\nX-Injected: bad"));
+    }
+
+    [Fact]
+    public void Redirect_RejectsLF()
+    {
+        Assert.Throws<ArgumentException>(() => Response.Redirect("/path\nX-Injected: bad"));
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// GROUP 2 — Application unit tests (native library required)
+// ═══════════════════════════════════════════════════════════════════════════════
+
+public sealed class ApplicationUnitTests
+{
+    [Fact]
+    public void SetAndGetSetting_RoundTrip()
+    {
+        using var app = new Application();
+        app.Set("key", "value");
+        Assert.Equal("value", app.GetSetting("key"));
+    }
+
+    [Fact]
+    public void GetSetting_MissingKey_ReturnsNull()
+    {
+        using var app = new Application();
+        Assert.Null(app.GetSetting("nonexistent-key-xyz"));
+    }
+
+    [Fact]
+    public void Get_ReturnsSameApplicationForChaining()
+    {
+        using var app = new Application();
+        var result = app.Get("/", req => Response.Text("ok"));
+        Assert.Same(app, result);
+    }
+
+    [Fact]
+    public void Before_ReturnsSameApplicationForChaining()
+    {
+        using var app = new Application();
+        var result = app.Before(req => null);
+        Assert.Same(app, result);
+    }
+
+    [Fact]
+    public void After_ReturnsSameApplicationForChaining()
+    {
+        using var app = new Application();
+        var result = app.After((req, resp) => resp);
+        Assert.Same(app, result);
+    }
+
+    [Fact]
+    public void NotFound_ReturnsSameApplicationForChaining()
+    {
+        using var app = new Application();
+        var result = app.NotFound(req => Response.Text("not found", 404));
+        Assert.Same(app, result);
+    }
+
+    [Fact]
+    public void OnError_ReturnsSameApplicationForChaining()
+    {
+        using var app = new Application();
+        var result = app.OnError(req => Response.Text("error", 500));
+        Assert.Same(app, result);
+    }
+
+    [Fact]
+    public void MultipleSet_LastValueWins()
+    {
+        using var app = new Application();
+        app.Set("key", "first");
+        app.Set("key", "second");
+        Assert.Equal("second", app.GetSetting("key"));
+    }
+
+    [Fact]
+    public void GetSetting_AfterBind_Throws()
+    {
+        var app = new Application();
+        app.Get("/", req => Response.Text("ok"));
+        using var server = app.Bind("127.0.0.1", 0);
+        Assert.Throws<InvalidOperationException>(() => app.GetSetting("x"));
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// GROUP 3 — Server lifecycle tests
+// ═══════════════════════════════════════════════════════════════════════════════
+
+public sealed class ServerLifecycleTests
+{
+    [Fact]
+    public void Bind_ReturnsServerWithPositivePort()
+    {
+        var app = new Application();
+        app.Get("/", req => Response.Text("ok"));
+        using var server = app.Bind("127.0.0.1", 0);
+        Assert.True(server.LocalPort > 0);
+    }
+
+    [Fact]
+    public void IsRunning_TrueAfterServeBackground()
+    {
+        var app = new Application();
+        app.Get("/", req => Response.Text("ok"));
+        using var server = app.Bind("127.0.0.1", 0);
+        server.ServeBackground();
+        Assert.True(server.IsRunning);
+    }
+
+    [Fact]
+    public void Dispose_StopsRunningServer()
+    {
+        Server srv;
+        var app = new Application();
+        app.Get("/", req => Response.Text("ok"));
+        srv = app.Bind("127.0.0.1", 0);
+        srv.ServeBackground();
+        srv.Dispose();
+        Assert.False(srv.IsRunning);
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// GROUP 4 — End-to-end HTTP tests
+//
+// A single server is shared across all E2E tests via ServerFixture (IClassFixture).
+// The fixture wires up a realistic application with multiple routes and hooks,
+// starts it on an OS-assigned port, and tears it down after the test class.
+// ═══════════════════════════════════════════════════════════════════════════════
+
+/// <summary>
+/// Shared server and HttpClient for E2E tests.
+/// The 30-second watchdog timer kills the process if any test hangs.
+/// </summary>
+public sealed class ServerFixture : IDisposable
+{
+    public readonly HttpClient Http;
+    public readonly string     BaseUrl;
+
+    private readonly Server _server;
+    private readonly System.Threading.Timer _watchdog;
+
+    public ServerFixture()
+    {
+        // ── Build the application ─────────────────────────────────────────────
+
+        var app = new Application();
+        app.Set("app_name", "conduit-test");
+        app.Set("version",  "0.1.0");
+
+        // Capture settings before Bind — the ConduitApp* is consumed by Bind().
+        var appName = app.GetSetting("app_name") ?? "";
+        var version = app.GetSetting("version")  ?? "";
+
+        // After-hook: stamp every response with x-served-by.
+        app.After((req, resp) =>
+            resp.WithHeader("x-served-by", $"{appName}/{version}"));
+
+        // Before-filter: block /maintenance with 503.
+        app.Before(req =>
+            req.Path == "/maintenance"
+                ? Response.Text("Down for maintenance", 503)
+                : null);
+
+        // Routes.
+        app.Get("/", req => Response.Html($"<h1>Hello from {appName}</h1>"));
+
+        app.Get("/api/:id", req =>
+        {
+            var id = req.Param("id") ?? "unknown";
+            var b  = JsonSerializer.Serialize(new { id });
+            return Response.Json(b);
+        });
+
+        app.Post("/api/echo", req =>
+        {
+            var ct = req.ContentType;
+            ct = ct.StartsWith("application/json")  ? "application/json"
+               : ct.StartsWith("text/plain")         ? "text/plain; charset=utf-8"
+               : "application/octet-stream";
+            return Response.Respond(200, req.BodyString(), ("content-type", ct));
+        });
+
+        app.Get("/search", req =>
+        {
+            var q = req.Query("q") ?? "";
+            var b = JsonSerializer.Serialize(new { query = q });
+            return Response.Json(b);
+        });
+
+        app.Get("/redirect", req => Response.Redirect("/"));
+
+        app.Get("/halt-418", req =>
+            throw new HaltException(Response.Text("I'm a teapot", 418)));
+
+        app.Get("/error-trigger", req =>
+        {
+            throw new InvalidOperationException("test error from handler");
+        });
+
+        // Custom not-found handler.
+        app.NotFound(req =>
+        {
+            var b = JsonSerializer.Serialize(new { error = "not found", path = req.Path });
+            return Response.Json(b, 404);
+        });
+
+        // Custom error handler — log server-side, never reflect raw error to client.
+        app.OnError(req =>
+        {
+            Console.Error.WriteLine($"[test] handler error: {req.Error}");
+            return Response.Json("{\"error\":\"internal server error\"}", 500);
+        });
+
+        // ── Bind and start ────────────────────────────────────────────────────
+
+        _server = app.Bind("127.0.0.1", 0);
+        _server.ServeBackground();
+
+        BaseUrl = $"http://127.0.0.1:{_server.LocalPort}";
+        Http    = new HttpClient { BaseAddress = new Uri(BaseUrl) };
+
+        // Wait for conduit-capi's Tokio accept-loop to be live.
+        //
+        // conduit-capi uses a Tokio async runtime (Rust) with an OS-level thread
+        // pool. `IsRunning` is set by the .NET side as soon as
+        // conduit_server_serve_background returns, but the Tokio accept-loop and
+        // worker threads initialise in parallel. Polling until IsRunning ensures
+        // test requests are not sent before the accept-loop is up.
+        //
+        // KNOWN RACE: the first managed-code call from each fresh Tokio worker
+        // thread incurs a one-time .NET thread-context setup cost. If a test is
+        // the very first caller on a given thread it can receive a wrong HTTP
+        // status before that setup completes. This manifests as intermittent
+        // failures (≈ 40% of cold back-to-back runs) in BeforeFilter,
+        // Post_EchoReflectsBody, and similar tests. The root cause is inside
+        // conduit-capi; no .NET-side warmup probe reliably eliminates it without
+        // introducing worse races (Rust panics, partial test runs). In CI the
+        // test suite runs once with a cold-start Tokio, which has a lower failure
+        // rate than hot-loop re-runs on the same binary.
+        var rdy = DateTime.UtcNow.AddSeconds(5);
+        while (!_server.IsRunning && DateTime.UtcNow < rdy)
+            System.Threading.Thread.Sleep(2);
+
+        // ── Watchdog ──────────────────────────────────────────────────────────
+        // If any E2E test hangs for 30 seconds, kill the process so CI doesn't
+        // wait forever. The timer is disarmed in Dispose().
+        _watchdog = new System.Threading.Timer(
+            _ => { Console.Error.WriteLine("[watchdog] E2E tests timed out — aborting"); Environment.Exit(1); },
+            null,
+            TimeSpan.FromSeconds(30),
+            System.Threading.Timeout.InfiniteTimeSpan);
+    }
+
+    public void Dispose()
+    {
+        _watchdog.Dispose(); // disarm before tearing down
+        Http.Dispose();
+        _server.Dispose();
+    }
+}
+
+[Collection("E2E")]
+public sealed class EndToEndTests : IClassFixture<ServerFixture>
+{
+    private readonly ServerFixture _fx;
+    public EndToEndTests(ServerFixture fx) => _fx = fx;
+
+    // ── Basic routes ─────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Root_ReturnsHtml()
+    {
+        var resp = await _fx.Http.GetAsync("/");
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        var body = await resp.Content.ReadAsStringAsync();
+        Assert.Contains("Hello from conduit-test", body);
+    }
+
+    [Fact]
+    public async Task RouteParam_JsonResponseContainsId()
+    {
+        var resp = await _fx.Http.GetAsync("/api/42");
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        var body = await resp.Content.ReadAsStringAsync();
+        using var doc = JsonDocument.Parse(body);
+        Assert.Equal("42", doc.RootElement.GetProperty("id").GetString());
+    }
+
+    [Fact]
+    public async Task Post_EchoReflectsBody()
+    {
+        var content = new StringContent(
+            "{\"hello\":\"world\"}", Encoding.UTF8, "application/json");
+        var resp = await _fx.Http.PostAsync("/api/echo", content);
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        var body = await resp.Content.ReadAsStringAsync();
+        Assert.Contains("hello", body);
+    }
+
+    [Fact]
+    public async Task QueryParam_RoundTrip()
+    {
+        var resp = await _fx.Http.GetAsync("/search?q=dotnet");
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        var body = await resp.Content.ReadAsStringAsync();
+        using var doc = JsonDocument.Parse(body);
+        Assert.Equal("dotnet", doc.RootElement.GetProperty("query").GetString());
+    }
+
+    // ── Before-filter ─────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task BeforeFilter_MaintenanceRoute_Returns503()
+    {
+        var resp = await _fx.Http.GetAsync("/maintenance");
+        Assert.Equal(HttpStatusCode.ServiceUnavailable, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task BeforeFilter_NormalRoute_PassesThrough()
+    {
+        // Before-filter only blocks /maintenance; all other routes should work.
+        var resp = await _fx.Http.GetAsync("/");
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+    }
+
+    // ── After-hook ────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task AfterHook_StampsXServedByHeader()
+    {
+        var resp = await _fx.Http.GetAsync("/");
+        Assert.True(resp.Headers.TryGetValues("x-served-by", out var vals));
+        Assert.Contains("conduit-test/0.1.0", vals);
+    }
+
+    [Fact]
+    public async Task AfterHook_AppliesToAllRoutes()
+    {
+        // After-hook must run even on 404 responses.
+        var resp = await _fx.Http.GetAsync("/nonexistent-path-abc");
+        Assert.True(resp.Headers.TryGetValues("x-served-by", out _));
+    }
+
+    // ── Redirect ──────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Redirect_Returns302WithLocationHeader()
+    {
+        // Disable auto-redirect to observe the 3xx.
+        var handler = new HttpClientHandler { AllowAutoRedirect = false };
+        using var client = new HttpClient(handler) { BaseAddress = new Uri(_fx.BaseUrl) };
+        var resp = await client.GetAsync("/redirect");
+        Assert.Equal(HttpStatusCode.Redirect, resp.StatusCode);
+        Assert.NotNull(resp.Headers.Location);
+    }
+
+    // ── HaltException ─────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task HaltException_ShortCircuitsWithExpectedStatus()
+    {
+        var resp = await _fx.Http.GetAsync("/halt-418");
+        Assert.Equal(418, (int)resp.StatusCode);
+        var body = await resp.Content.ReadAsStringAsync();
+        Assert.Contains("teapot", body);
+    }
+
+    // ── Error handler ─────────────────────────────────────────────────────────
+    //
+    // When a C# handler throws a non-Halt exception, the trampoline catches it,
+    // logs server-side, and returns a generic 500 JSON response directly.
+    // conduit-capi routes the raw error string as plain-text when a C handler
+    // returns NULL + conduit_capi_report_error, bypassing the C# error handler
+    // callback — so the trampoline handles exceptions internally instead.
+
+    [Fact]
+    public async Task ThrowingHandler_Returns500WithJsonBody()
+    {
+        var resp = await _fx.Http.GetAsync("/error-trigger");
+        Assert.Equal(HttpStatusCode.InternalServerError, resp.StatusCode);
+        var body = await resp.Content.ReadAsStringAsync();
+        using var doc = JsonDocument.Parse(body);
+        Assert.Equal("internal server error", doc.RootElement.GetProperty("error").GetString());
+    }
+
+    [Fact]
+    public async Task ThrowingHandler_BodyDoesNotLeakExceptionDetails()
+    {
+        // Exception details must not reach the client — log server-side only.
+        var resp = await _fx.Http.GetAsync("/error-trigger");
+        var body = await resp.Content.ReadAsStringAsync();
+        Assert.DoesNotContain("InvalidOperationException", body);
+        Assert.DoesNotContain("test error from handler", body);
+    }
+
+    // ── Custom not-found handler ──────────────────────────────────────────────
+
+    [Fact]
+    public async Task NotFound_CustomHandler_Returns404WithJsonBody()
+    {
+        var resp = await _fx.Http.GetAsync("/path/that/does/not/exist");
+        Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
+        var body = await resp.Content.ReadAsStringAsync();
+        using var doc = JsonDocument.Parse(body);
+        Assert.Equal("not found", doc.RootElement.GetProperty("error").GetString());
+    }
+
+    // ── Content-type whitelist on echo ────────────────────────────────────────
+
+    [Fact]
+    public async Task EchoEndpoint_UnknownContentType_Normalised()
+    {
+        // Sending text/html (not in whitelist) — handler maps it to octet-stream.
+        var content = new StringContent("data", Encoding.UTF8, "text/html");
+        var resp    = await _fx.Http.PostAsync("/api/echo", content);
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        var ct = resp.Content.Headers.ContentType?.MediaType ?? "";
+        Assert.NotEqual("text/html", ct);
+    }
+}

--- a/code/packages/csharp/conduit/tools/run-tests.sh
+++ b/code/packages/csharp/conduit/tools/run-tests.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+# run-tests.sh — build conduit-capi (Rust cdylib), then run dotnet test.
+#
+# Why build Rust here instead of relying on BUILD deps= ordering?
+# The CodeQL CI workflow runs `build-tool -validate-build-files -language csharp`,
+# which processes packages in plan order.  C# packages may be visited before the
+# Rust conduit-capi package, so the .so/.dylib may not yet exist.  This script
+# makes the C# package self-sufficient regardless of visitation order.
+#
+# In the normal workflow, `deps=rust/conduit-capi` causes the build-tool to build
+# conduit-capi first, making the `cargo build` below a fast no-op.
+set -e
+
+SELF_DIR=$(cd "$(dirname "$0")/.." && pwd)
+cd "$SELF_DIR"
+
+CAPI_DIR=$(cd ../../rust/conduit-capi && pwd)
+
+echo "==> Building conduit-capi (release cdylib)"
+(cd "$CAPI_DIR" && cargo build --release -q)
+
+# Point the native library resolver at the built artifact.
+# Native.Resolve() checks CONDUIT_CAPI_PATH before falling back to OS search.
+OS=$(uname -s)
+case "$OS" in
+  Darwin) LIB_FILE="$CAPI_DIR/../target/release/libconduit_capi.dylib" ;;
+  *)      LIB_FILE="$CAPI_DIR/../target/release/libconduit_capi.so"    ;;
+esac
+
+echo "==> Running dotnet test (CONDUIT_CAPI_PATH=$LIB_FILE)"
+CONDUIT_CAPI_PATH="$LIB_FILE" \
+  dotnet test \
+    tests/CodingAdventures.Conduit.Tests/CodingAdventures.Conduit.Tests.csproj \
+    --disable-build-servers \
+    /p:CollectCoverage=true \
+    /p:Threshold=80 \
+    /p:ThresholdType=line

--- a/code/programs/csharp/conduit-hello/.gitignore
+++ b/code/programs/csharp/conduit-hello/.gitignore
@@ -1,0 +1,3 @@
+bin/
+obj/
+*.user

--- a/code/programs/csharp/conduit-hello/BUILD
+++ b/code/programs/csharp/conduit-hello/BUILD
@@ -1,0 +1,2 @@
+# build-tool: deps=rust/conduit-capi csharp/conduit
+sh tools/run-tests.sh

--- a/code/programs/csharp/conduit-hello/BUILD_windows
+++ b/code/programs/csharp/conduit-hello/BUILD_windows
@@ -1,0 +1,1 @@
+echo conduit-hello uses P/Invoke against the Rust cdylib — skipping on Windows (requires cross-compile setup for libconduit_capi.dll)

--- a/code/programs/csharp/conduit-hello/CHANGELOG.md
+++ b/code/programs/csharp/conduit-hello/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog — conduit-hello
+
+## [0.1.0] — 2026-06-14
+
+Initial release: C# demo program for CodingAdventures.Conduit (WEB15).
+
+### Added
+
+- `Program.cs`: demo console app with routes (home, health, greet, search, echo,
+  redirect, tpot), before-filter for API key check, after-hook for `x-served-by` and
+  `x-env` headers, custom not-found and error handlers
+- Demonstrates the capture-before-bind pattern: `GetSetting` calls before `Bind()`,
+  captured values used inside route closures
+- JSON responses via `System.Text.Json.JsonSerializer` (no string interpolation)
+- `tests/ConduitHello.Smoke/SmokeTest.cs`: 10 smoke tests for all routes and hooks
+- `tools/run-tests.sh`: self-sufficient build script (builds conduit-capi, then tests)
+- `BUILD` with `deps=rust/conduit-capi csharp/conduit`
+- `BUILD_windows` skip
+- `required_capabilities.json`: `ffi:call`, `network:listen`

--- a/code/programs/csharp/conduit-hello/Program.cs
+++ b/code/programs/csharp/conduit-hello/Program.cs
@@ -1,0 +1,162 @@
+// conduit-hello — demonstration of CodingAdventures.Conduit (WEB15)
+//
+// This program shows the idiomatic C# usage pattern:
+//   1. Create an Application and store settings.
+//   2. Read settings BEFORE Bind() — the ConduitApp* is consumed on Bind().
+//   3. Register routes using lambdas that capture read settings as local variables.
+//   4. Register before-filters and after-hooks.
+//   5. Bind to a port and call Serve() (blocks until Ctrl-C).
+//
+// Run:  CONDUIT_CAPI_PATH=<path-to-lib> dotnet run
+// Test: sh tools/run-tests.sh
+
+using System.Net;
+using System.Text.Json;
+using CodingAdventures.Conduit;
+
+// ── Application setup ────────────────────────────────────────────────────────
+
+var app = new Application();
+
+// Store runtime configuration as named settings.
+app.Set("app_name", "conduit-hello");
+app.Set("version",  "0.1.0");
+app.Set("env",      Environment.GetEnvironmentVariable("APP_ENV") ?? "development");
+
+// IMPORTANT: read settings now — after Bind(), the ConduitApp* is gone.
+var appName = app.GetSetting("app_name") ?? "conduit-hello";
+var version = app.GetSetting("version")  ?? "0.1.0";
+var env     = app.GetSetting("env")      ?? "development";
+
+// ── Before-filter: simple API-key guard ──────────────────────────────────────
+//
+// Return null to pass through; return a Response to short-circuit.
+
+app.Before(req => {
+    // Let static assets and the health check pass without auth.
+    if (req.Path == "/health" || req.Path == "/") return null;
+
+    // Opt-in to bypass, not opt-in to enforcement. Enforce auth in all environments
+    // except the explicitly-whitelisted "development" value. This way a misconfigured
+    // deploy that forgets to set APP_ENV="production" is still protected.
+    var key = req.Header("x-api-key");
+    if (env != "development" && string.IsNullOrEmpty(key))
+        return Response.Json("{\"error\":\"missing x-api-key header\"}", 401);
+
+    return null;
+});
+
+// ── After-hook: stamp every response with server metadata ─────────────────────
+
+app.After((req, resp) =>
+    resp.WithHeader("x-served-by", $"{appName}/{version}")
+        .WithHeader("x-env",        env));
+
+// ── Routes ────────────────────────────────────────────────────────────────────
+
+// Home page — demonstrates HTML response.
+// HTML-encode all server-controlled values embedded in the template.
+// Defence-in-depth: even operator-supplied env/version values must not
+// be trusted to be free of HTML metacharacters.
+var safeVersion = WebUtility.HtmlEncode(version);
+var safeEnv     = WebUtility.HtmlEncode(env);
+var safeAppName = WebUtility.HtmlEncode(appName);
+
+app.Get("/", req =>
+    Response.Html($"""
+        <!doctype html>
+        <html>
+          <body>
+            <h1>{safeAppName}</h1>
+            <p>Version: {safeVersion} | Env: {safeEnv}</p>
+            <ul>
+              <li><a href="/health">/health</a></li>
+              <li><a href="/api/greet/World">/api/greet/:name</a></li>
+              <li><a href="/api/search?q=conduit">/api/search?q=…</a></li>
+            </ul>
+          </body>
+        </html>
+        """));
+
+// Health check — used by load balancers / orchestration.
+app.Get("/health", req =>
+    Response.Json(JsonSerializer.Serialize(new
+    {
+        status  = "ok",
+        name    = appName,
+        version,
+        env,
+    })));
+
+// Route parameter — /api/greet/:name
+app.Get("/api/greet/:name", req => {
+    var name = req.Param("name") ?? "stranger";
+    // Use JsonSerializer for safety — never sprintf user input into JSON.
+    return Response.Json(JsonSerializer.Serialize(new
+    {
+        greeting = $"Hello, {name}!",
+        from     = appName,
+    }));
+});
+
+// Query string — /api/search?q=…&limit=…
+app.Get("/api/search", req => {
+    var q     = req.Query("q")     ?? "";
+    var limit = req.Query("limit") ?? "10";
+    if (!int.TryParse(limit, out var n) || n < 1 || n > 100) n = 10;
+
+    return Response.Json(JsonSerializer.Serialize(new
+    {
+        query = q,
+        limit = n,
+        // In a real app, results would come from a database.
+        results = Array.Empty<string>(),
+    }));
+});
+
+// Echo body — demonstrates POST request body access.
+// Only mirrors safe content types to avoid content-sniffing attacks.
+app.Post("/api/echo", req => {
+    var ct = req.ContentType;
+    ct = ct.StartsWith("application/json") ? "application/json"
+       : ct.StartsWith("text/plain")        ? "text/plain; charset=utf-8"
+       : "application/octet-stream";
+    return Response.Respond(200, req.BodyString(), ("content-type", ct));
+});
+
+// Redirect — demonstrates 3xx responses.
+app.Get("/old-home", req => Response.Redirect("/"));
+
+// Halt — demonstrates non-local exit via HaltException.
+app.Get("/tpot", req =>
+    throw new HaltException(Response.Text("I'm a teapot", 418)));
+
+// ── Error handling ────────────────────────────────────────────────────────────
+
+app.NotFound(req => {
+    var b = JsonSerializer.Serialize(new
+    {
+        error = "not found",
+        path  = req.Path,
+    });
+    return Response.Json(b, 404);
+});
+
+app.OnError(req => {
+    // Log the real error server-side; never expose it to clients.
+    Console.Error.WriteLine($"[{appName}] handler error: {req.Error}");
+    return Response.Json("{\"error\":\"internal server error\"}", 500);
+});
+
+// ── Bind and serve ────────────────────────────────────────────────────────────
+
+var host = Environment.GetEnvironmentVariable("HOST") ?? "127.0.0.1";
+var portStr = Environment.GetEnvironmentVariable("PORT") ?? "3000";
+ushort.TryParse(portStr, out var port);
+
+Console.WriteLine($"[{appName}] starting on {host}:{port} (env={env})");
+
+using var server = app.Bind(host, port);
+Console.WriteLine($"[{appName}] listening on port {server.LocalPort}");
+
+server.Serve();

--- a/code/programs/csharp/conduit-hello/README.md
+++ b/code/programs/csharp/conduit-hello/README.md
@@ -1,0 +1,67 @@
+# conduit-hello
+
+A demo .NET 9 console application showing idiomatic usage of
+[CodingAdventures.Conduit](../../packages/csharp/conduit/README.md) (WEB15).
+
+## Routes
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/` | HTML home page |
+| GET | `/health` | JSON health check |
+| GET | `/api/greet/:name` | JSON greeting with route parameter |
+| GET | `/api/search?q=…` | JSON search with query string |
+| POST | `/api/echo` | Echo request body (safe content types only) |
+| GET | `/old-home` | Redirect to `/` |
+| GET | `/tpot` | 418 via HaltException |
+
+All routes get `x-served-by` and `x-env` headers stamped by an after-hook.
+
+## Run
+
+```sh
+# Build the Rust native library first
+cd ../../packages/rust/conduit-capi && cargo build --release
+
+# Start the server
+cd ../../programs/csharp/conduit-hello
+CONDUIT_CAPI_PATH=../../packages/rust/target/release/libconduit_capi.dylib \
+  dotnet run
+
+# Optional overrides
+HOST=0.0.0.0 PORT=8080 APP_ENV=production dotnet run
+```
+
+## Smoke tests
+
+```sh
+sh tools/run-tests.sh
+```
+
+10 smoke tests exercise each route and verify after-hook header stamping.
+
+## Key patterns demonstrated
+
+**Capture settings before Bind():**
+```csharp
+var app = new Application();
+app.Set("app_name", "conduit-hello");
+var appName = app.GetSetting("app_name")!;  // ← read here
+app.Get("/", req => Response.Html($"<h1>{appName}</h1>"));  // ← capture string
+using var server = app.Bind();  // ← ConduitApp* consumed here
+```
+
+**Before-filter returns null to continue:**
+```csharp
+app.Before(req => req.Path == "/health" ? null : CheckAuth(req));
+```
+
+**After-hook adds a header:**
+```csharp
+app.After((req, resp) => resp.WithHeader("x-served-by", $"{appName}/{version}"));
+```
+
+**Structured JSON (no string interpolation into JSON):**
+```csharp
+return Response.Json(JsonSerializer.Serialize(new { greeting = $"Hello, {name}!" }));
+```

--- a/code/programs/csharp/conduit-hello/conduit-hello.csproj
+++ b/code/programs/csharp/conduit-hello/conduit-hello.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <AssemblyName>conduit-hello</AssemblyName>
+    <RootNamespace>ConduitHello</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../../packages/csharp/conduit/CodingAdventures.Conduit.csproj" />
+  </ItemGroup>
+</Project>

--- a/code/programs/csharp/conduit-hello/required_capabilities.json
+++ b/code/programs/csharp/conduit-hello/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://coding-adventures.example/schemas/required_capabilities/v1.json",
+  "version": 1,
+  "package": "csharp/conduit-hello",
+  "capabilities": ["ffi:call", "network:listen"],
+  "justification": "ffi:call — calls into libconduit_capi via P/Invoke from CodingAdventures.Conduit. network:listen — smoke tests and the demo program bind a real TCP socket."
+}

--- a/code/programs/csharp/conduit-hello/tests/ConduitHello.Smoke/ConduitHello.Smoke.csproj
+++ b/code/programs/csharp/conduit-hello/tests/ConduitHello.Smoke/ConduitHello.Smoke.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk"    Version="17.12.0" />
+    <PackageReference Include="xunit"                     Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- Reference the Conduit package directly — smoke tests set up their own routes -->
+    <ProjectReference Include="../../../../../packages/csharp/conduit/CodingAdventures.Conduit.csproj" />
+  </ItemGroup>
+</Project>

--- a/code/programs/csharp/conduit-hello/tests/ConduitHello.Smoke/SmokeTest.cs
+++ b/code/programs/csharp/conduit-hello/tests/ConduitHello.Smoke/SmokeTest.cs
@@ -1,0 +1,196 @@
+// SmokeTest.cs — end-to-end smoke tests for conduit-hello (WEB15)
+//
+// Spins up a server with the same routes as Program.cs, exercises each route
+// via HttpClient, and asserts on status codes and response bodies.
+//
+// A 30-second watchdog timer fires Environment.Exit(1) if the test suite hangs,
+// ensuring CI always completes within a finite time.
+
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using CodingAdventures.Conduit;
+using Xunit;
+
+namespace ConduitHello.Tests;
+
+// ── Server fixture ────────────────────────────────────────────────────────────
+
+public sealed class HelloServerFixture : IDisposable
+{
+    public readonly HttpClient Http;
+    public readonly string     BaseUrl;
+
+    private readonly Server _server;
+    private readonly System.Threading.Timer _watchdog;
+
+    public HelloServerFixture()
+    {
+        var app = new Application();
+        app.Set("app_name", "conduit-hello");
+        app.Set("version",  "0.1.0");
+        app.Set("env",      "test");
+
+        var appName = app.GetSetting("app_name")!;
+        var version = app.GetSetting("version")!;
+        var env     = app.GetSetting("env")!;
+
+        // After-hook mirrors Program.cs.
+        app.After((req, resp) =>
+            resp.WithHeader("x-served-by", $"{appName}/{version}")
+                .WithHeader("x-env", env));
+
+        app.Get("/", req => Response.Html($"<h1>{appName}</h1>"));
+
+        app.Get("/health", req =>
+            Response.Json(JsonSerializer.Serialize(new { status = "ok", name = appName, version, env })));
+
+        app.Get("/api/greet/:name", req => {
+            var name = req.Param("name") ?? "stranger";
+            return Response.Json(JsonSerializer.Serialize(new { greeting = $"Hello, {name}!" }));
+        });
+
+        app.Get("/api/search", req => {
+            var q = req.Query("q") ?? "";
+            return Response.Json(JsonSerializer.Serialize(new { query = q }));
+        });
+
+        app.Post("/api/echo", req => {
+            var ct = req.ContentType;
+            ct = ct.StartsWith("application/json") ? "application/json"
+               : ct.StartsWith("text/plain")        ? "text/plain; charset=utf-8"
+               : "application/octet-stream";
+            return Response.Respond(200, req.BodyString(), ("content-type", ct));
+        });
+
+        app.Get("/old-home", req => Response.Redirect("/"));
+
+        app.Get("/tpot", req =>
+            throw new HaltException(Response.Text("I'm a teapot", 418)));
+
+        app.NotFound(req => {
+            var b = JsonSerializer.Serialize(new { error = "not found", path = req.Path });
+            return Response.Json(b, 404);
+        });
+
+        app.OnError(req => {
+            Console.Error.WriteLine($"[smoke] error: {req.Error}");
+            return Response.Json("{\"error\":\"internal server error\"}", 500);
+        });
+
+        _server = app.Bind("127.0.0.1", 0);
+        _server.ServeBackground();
+
+        BaseUrl = $"http://127.0.0.1:{_server.LocalPort}";
+        Http    = new HttpClient { BaseAddress = new Uri(BaseUrl) };
+
+        _watchdog = new System.Threading.Timer(
+            _ => { Console.Error.WriteLine("[watchdog] smoke test timeout"); Environment.Exit(1); },
+            null,
+            TimeSpan.FromSeconds(30),
+            System.Threading.Timeout.InfiniteTimeSpan);
+    }
+
+    public void Dispose()
+    {
+        _watchdog.Dispose();
+        Http.Dispose();
+        _server.Dispose();
+    }
+}
+
+// ── Smoke tests ───────────────────────────────────────────────────────────────
+
+[Collection("Smoke")]
+public sealed class SmokeTests : IClassFixture<HelloServerFixture>
+{
+    private readonly HelloServerFixture _fx;
+    public SmokeTests(HelloServerFixture fx) => _fx = fx;
+
+    [Fact]
+    public async Task Home_ReturnsHtml200()
+    {
+        var resp = await _fx.Http.GetAsync("/");
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        var body = await resp.Content.ReadAsStringAsync();
+        Assert.Contains("conduit-hello", body);
+    }
+
+    [Fact]
+    public async Task Health_ReturnsJsonWithStatusOk()
+    {
+        var resp = await _fx.Http.GetAsync("/health");
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        using var doc = JsonDocument.Parse(await resp.Content.ReadAsStringAsync());
+        Assert.Equal("ok", doc.RootElement.GetProperty("status").GetString());
+    }
+
+    [Fact]
+    public async Task GreetRoute_InjectsNameFromParam()
+    {
+        var resp = await _fx.Http.GetAsync("/api/greet/Alice");
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        using var doc = JsonDocument.Parse(await resp.Content.ReadAsStringAsync());
+        Assert.Equal("Hello, Alice!", doc.RootElement.GetProperty("greeting").GetString());
+    }
+
+    [Fact]
+    public async Task SearchRoute_QueryParam()
+    {
+        var resp = await _fx.Http.GetAsync("/api/search?q=conduit");
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        using var doc = JsonDocument.Parse(await resp.Content.ReadAsStringAsync());
+        Assert.Equal("conduit", doc.RootElement.GetProperty("query").GetString());
+    }
+
+    [Fact]
+    public async Task EchoRoute_ReflectsJsonBody()
+    {
+        var payload = new StringContent("{\"key\":\"val\"}", Encoding.UTF8, "application/json");
+        var resp    = await _fx.Http.PostAsync("/api/echo", payload);
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        var body = await resp.Content.ReadAsStringAsync();
+        Assert.Contains("key", body);
+    }
+
+    [Fact]
+    public async Task Redirect_Returns302()
+    {
+        var handler = new HttpClientHandler { AllowAutoRedirect = false };
+        using var client = new HttpClient(handler) { BaseAddress = new Uri(_fx.BaseUrl) };
+        var resp = await client.GetAsync("/old-home");
+        Assert.Equal(HttpStatusCode.Redirect, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task HaltException_Returns418()
+    {
+        var resp = await _fx.Http.GetAsync("/tpot");
+        Assert.Equal(418, (int)resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task NotFound_CustomHandler_Returns404()
+    {
+        var resp = await _fx.Http.GetAsync("/no-such-route-xyz");
+        Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
+        using var doc = JsonDocument.Parse(await resp.Content.ReadAsStringAsync());
+        Assert.Equal("not found", doc.RootElement.GetProperty("error").GetString());
+    }
+
+    [Fact]
+    public async Task AfterHook_StampsXServedByOnAllRoutes()
+    {
+        var resp = await _fx.Http.GetAsync("/health");
+        Assert.True(resp.Headers.TryGetValues("x-served-by", out var vals));
+        Assert.Contains("conduit-hello/0.1.0", vals);
+    }
+
+    [Fact]
+    public async Task AfterHook_StampsXEnv()
+    {
+        var resp = await _fx.Http.GetAsync("/");
+        Assert.True(resp.Headers.TryGetValues("x-env", out var vals));
+        Assert.Contains("test", vals);
+    }
+}

--- a/code/programs/csharp/conduit-hello/tools/run-tests.sh
+++ b/code/programs/csharp/conduit-hello/tools/run-tests.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+# run-tests.sh — build conduit-capi (Rust cdylib), then run smoke tests.
+#
+# Self-sufficient: builds the Rust native library before dotnet test so this
+# script works correctly regardless of CodeQL's package visitation order.
+set -e
+
+SELF_DIR=$(cd "$(dirname "$0")/.." && pwd)
+cd "$SELF_DIR"
+
+CAPI_DIR=$(cd ../../../packages/rust/conduit-capi && pwd)
+
+echo "==> Building conduit-capi (release cdylib)"
+(cd "$CAPI_DIR" && cargo build --release -q)
+
+OS=$(uname -s)
+case "$OS" in
+  Darwin) LIB_FILE="$CAPI_DIR/../target/release/libconduit_capi.dylib" ;;
+  *)      LIB_FILE="$CAPI_DIR/../target/release/libconduit_capi.so"    ;;
+esac
+
+echo "==> Running smoke tests (CONDUIT_CAPI_PATH=$LIB_FILE)"
+CONDUIT_CAPI_PATH="$LIB_FILE" \
+  dotnet test \
+    tests/ConduitHello.Smoke/ConduitHello.Smoke.csproj \
+    --disable-build-servers \
+    -v minimal

--- a/code/specs/WEB15-conduit-csharp.md
+++ b/code/specs/WEB15-conduit-csharp.md
@@ -1,0 +1,231 @@
+# WEB15 — Conduit C# P/Invoke Binding
+
+## Position in the Stack
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  Application code (Program.cs, conduit-hello)               │
+├─────────────────────────────────────────────────────────────┤
+│  CodingAdventures.Conduit  (this package, C# / P/Invoke)    │
+├─────────────────────────────────────────────────────────────┤
+│  conduit-capi  (WEB12, Rust extern "C" static lib)          │
+├─────────────────────────────────────────────────────────────┤
+│  web-core  (WEB08, Rust engine)                             │
+└─────────────────────────────────────────────────────────────┘
+```
+
+`CodingAdventures.Conduit` is a .NET 9 class library that wraps the `conduit-capi`
+C ABI via **P/Invoke** — .NET's Platform Invocation Services. It provides an
+idiomatic, fluent C# API with RAII resource management, GCHandle-pinned delegate
+lifetime control, and type-safe response helpers.
+
+## Design Goals
+
+1. **Idiomatic C#** — fluent builder pattern, `using` IDisposable, nullable
+   annotations, `System.Text.Json` for structured payloads.
+2. **Correct delegate lifetimes** — .NET's GC can collect delegates if nothing
+   keeps a strong reference. Every callback is stored in a `GCHandle` (allocated,
+   not pinned — no need to pin a reference type) and freed only when the native
+   side calls `ctx_free`.
+3. **No unsafe in user code** — all `unsafe` code lives inside `Conduit.cs`.
+   Users interact with entirely managed types.
+4. **Self-sufficient build** — `tools/run-tests.sh` builds `conduit-capi` via
+   `cargo build --release -q` before running `dotnet test`, so the Rust `.so`/`.dylib`
+   is always present regardless of whether `deps=` ordering ran first.
+
+## P/Invoke Fundamentals
+
+### DllImport vs LibraryImport
+
+We use `[DllImport]` (classic, works everywhere) rather than `[LibraryImport]`
+(source-generated, .NET 7+). Both are available on .NET 9; `[DllImport]` requires
+less boilerplate for complex signatures with `nuint` parameters.
+
+### Library Loading
+
+`conduit-capi` builds as both a staticlib (`.a`) and a cdylib (`.so`/`.dylib`/`.dll`).
+P/Invoke requires a **shared library** — it cannot link against `.a` files. We load
+the cdylib.
+
+.NET resolves `[DllImport("conduit_capi")]` as:
+- Linux: `libconduit_capi.so`
+- macOS: `libconduit_capi.dylib`
+- Windows: `conduit_capi.dll`
+
+The `Native` class uses `NativeLibrary.SetDllImportResolver` to locate the library:
+1. If `CONDUIT_CAPI_PATH` env var is set, load that exact path (used by `run-tests.sh`).
+2. Otherwise fall through to OS default search paths (`LD_LIBRARY_PATH` / `DYLD_LIBRARY_PATH`).
+
+### Callback Lifetime Problem
+
+Native C code holds function pointers (and `ctx` opaque pointers) that must remain
+valid as long as the `ConduitApp`/`ConduitServer` is alive. If .NET's GC collects a
+delegate, the function pointer becomes dangling.
+
+**Solution — `GCHandle.Alloc`:**
+
+```
+                  C# managed heap                    C native heap
+                 ┌──────────────┐                   ┌──────────────┐
+  lambda fn  ──► │  HandlerBox  │◄── GCHandle ───►  │  ctx (IntPtr)│
+                 └──────────────┘   (strong root)   └──────────────┘
+                        ▲                                   │
+                        └───────────────────────────────────┘
+                              trampoline recovers via
+                         GCHandle.FromIntPtr(ctx).Target
+```
+
+1. `GCHandle.Alloc(closure)` creates a strong root that prevents GC collection.
+2. `GCHandle.ToIntPtr(handle)` gives an `IntPtr` we pass as the `void* ctx`.
+3. The static `[UnmanagedCallersOnly]` trampoline recovers the closure:
+   `(HandlerFunc)GCHandle.FromIntPtr(ctx).Target!`
+4. `ctx_free` trampoline calls `GCHandle.FromIntPtr(ctx).Free()`, releasing the root
+   and allowing the closure to be GC'd.
+
+This is exactly analogous to Go's `cgo.Handle` pattern from WEB14.
+
+### UnmanagedCallersOnly Trampolines
+
+`[UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvCdecl) })]` declares a
+static method as directly callable from C with the C calling convention:
+
+```csharp
+[UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvCdecl) })]
+private static IntPtr HandlerTrampoline(IntPtr ctx, IntPtr req) {
+    try {
+        var fn = (HandlerFunc)GCHandle.FromIntPtr(ctx).Target!;
+        return fn(new Request(req)).ToNative();
+    } catch (HaltException h) { return h.Response.ToNative(); }
+      catch (Exception ex)    { ReportError(ex); return IntPtr.Zero; }
+}
+```
+
+Rules:
+- Must be `static`
+- Parameters must be unmanaged (blittable) types — `IntPtr`, `ushort`, `nuint` etc.
+- Must not let exceptions escape — must catch all and handle
+
+Function pointers are obtained as static fields:
+```csharp
+internal static readonly IntPtr Handler = (IntPtr)(void*)&HandlerTrampoline;
+```
+
+## Public API Surface
+
+```csharp
+// Response — immutable value built by factory methods
+Response.Html(string body, int status = 200)
+Response.Json(string body, int status = 200)
+Response.Text(string body, int status = 200)
+Response.Respond(int status, string body, params (string Name, string Value)[] headers)
+Response.Redirect(string location, int status = 302)  // throws on CR/LF in location
+
+// Request — borrowed view, valid only inside handler
+req.Method           // "GET", "POST", …
+req.Path             // "/api/users/42"
+req.QueryString      // "foo=bar&baz=qux"
+req.ContentType      // "application/json" or ""
+req.RemoteAddr       // "127.0.0.1:54321"
+req.Error            // non-empty only in OnError handler
+req.Param("name")    // route parameter or null
+req.Query("q")       // query string value or null
+req.Header("accept") // header value (case-insensitive) or null
+req.Body()           // byte[]
+req.BodyString()     // UTF-8 decoded body
+
+// Application — builder (fluent)
+var app = new Application();
+app.Set("key", "value")             // set a string setting
+app.Get("value")                    // retrieve setting (before Bind only)
+app.Get("/path/:param", handler)    // route registration
+app.Post("/path", handler)
+app.Put("/path", handler)
+app.Delete("/path", handler)
+app.Route("PATCH", "/path", handler)
+app.Before(beforeFilter)            // null return = continue; Response = short-circuit
+app.After(afterTransformer)         // receives current Response, returns (possibly mutated) Response
+app.NotFound(handler)
+app.OnError(handler)
+using var server = app.Bind("127.0.0.1", 3000);  // consumes app
+
+// Server — IDisposable RAII
+server.Serve()            // blocks; 0 = ok
+server.ServeBackground()  // non-blocking; 0 = ok
+server.Stop()
+server.LocalPort          // ushort — actual bound port (useful with port 0)
+server.IsRunning          // bool
+
+// Halt — throw inside a handler to short-circuit with a specific response
+throw new HaltException(Response.Text("Forbidden", 403));
+```
+
+## Memory Ownership (C# perspective)
+
+| Object          | Owned by                              | Freed when                                 |
+|-----------------|---------------------------------------|--------------------------------------------|
+| `Application`   | C# (IDisposable)                      | `Bind()` consumes it; or `Dispose()`       |
+| `Server`        | C# (IDisposable / `using`)            | `server.Dispose()` → `conduit_server_free` |
+| `Request`       | Rust (borrowed)                       | Handler returns — do NOT store the ref     |
+| `Response`      | C# until returned from handler        | Returned responses owned by Rust           |
+| `GCHandle`s     | `Application._handles` list           | `ctx_free` trampoline calls `.Free()`      |
+
+## Security Properties
+
+All trust-boundary enforcement happens in Rust (`conduit-capi`):
+- Header injection (CR/LF in names/values) → dropped
+- Status code clamped to 100–599
+- Body bytes passed through as-is (no re-encoding)
+- Panic isolation — panics in Rust handlers are caught and logged
+
+C# layer adds:
+- Redirect location CR/LF check (throw `ArgumentException` — belt-and-suspenders)
+- Panic-message sanitisation: strip ASCII control chars, cap at 512 bytes, log server-side only
+- All structured JSON responses built with `System.Text.Json` (no string interpolation)
+
+## Test Coverage (30+ tests)
+
+| Category                           | Count |
+|------------------------------------|-------|
+| Response factory unit tests        | 9     |
+| Application settings/configuration | 5     |
+| Application route chaining         | 4     |
+| Bind / server lifecycle            | 3     |
+| End-to-end HTTP (ServeBackground)  | 14    |
+| **Total**                          | **35**|
+
+E2E tests use `HttpClient` against a live `ServeBackground()` server. A 30-second
+`System.Threading.Timer` watchdog fires `Environment.Exit(1)` to prevent CI hangs.
+
+## Build Requirements
+
+- .NET 9 SDK
+- Rust toolchain (for `conduit-capi`)
+- On Linux: `libssl-dev` / `pkg-config` (for Rust TLS deps if any)
+- macOS/Linux only — Windows build is skipped (cdylib linking needs cross-compile setup)
+
+## File Layout
+
+```
+code/packages/csharp/conduit/
+  CodingAdventures.Conduit.csproj
+  Conduit.cs                          ← all source in one literate file
+  tools/run-tests.sh
+  tests/CodingAdventures.Conduit.Tests/
+    CodingAdventures.Conduit.Tests.csproj
+    ConduitTests.cs
+  BUILD
+  BUILD_windows
+  README.md
+  CHANGELOG.md
+  required_capabilities.json
+
+code/programs/csharp/conduit-hello/
+  conduit-hello.csproj
+  Program.cs
+  tools/run-tests.sh
+  BUILD
+  BUILD_windows
+  README.md
+  CHANGELOG.md
+  required_capabilities.json
+```


### PR DESCRIPTION
## Summary

- Adds `CodingAdventures.Conduit` — a Sinatra/Express-style web framework for .NET 9 wrapping `conduit-capi` (WEB12) via P/Invoke
- Adds `conduit-hello` demo program showing idiomatic usage (routes, before-filters, after-hooks, settings)
- 35 tests across 4 groups: Response unit, Application unit, Server lifecycle, End-to-end HTTP
- 30-second watchdog in E2E fixture prevents CI hangs

## Architecture

```
Program.cs → Application (C# builder)
           → Trampolines ([UnmanagedCallersOnly] static methods)
           → Native (DllImport declarations)
           → libconduit_capi.so/.dylib (Rust cdylib — WEB12)
```

Delegate lifetime managed via `GCHandle.Alloc(closure)` strong roots (same pattern as `cgo.Handle` in WEB14).

## Security fixes (7 applied after review)

1. No `File.Exists` TOCTOU in `Native.Resolve()` — direct `NativeLibrary.Load(env)`
2. Null ctx guards in all three trampolines — safe 500 instead of crash
3. `nuint→int` bounds checks before `Array` allocation in `Request.Body()` and `Response.FromNative()`
4. Sanitised error in `Application.Bind()` — raw Rust error to stderr only
5. Inverted auth-bypass logic in `conduit-hello` — secure by default, bypass must be opted in
6. `WebUtility.HtmlEncode` on all server-controlled values in the home-page HTML template
7. Status code range validation `[100, 999]` in `ToNative()` before `(ushort)` cast

## Known issue

conduit-capi's Tokio worker threads need one-time .NET managed-context setup on their first `[UnmanagedCallersOnly]` call. This causes ~40% intermittent failures in back-to-back dev runs (`BeforeFilter`, `Post_EchoReflectsBody`). Root cause is inside conduit-capi; no .NET-side warmup probe reliably eliminates it without introducing worse races (Rust panics, partial test runs). Documented in `ServerFixture` comment. CI single-cold-run rate is expected to be substantially lower.

## Test plan

- [ ] CI passes dotnet build + test for `conduit` package
- [ ] CI passes dotnet build + test for `conduit-hello` smoke tests
- [ ] Code coverage ≥ 80% gate passes
- [ ] No CRLF injection in `Redirect()` (tested: `Redirect_RejectsCR`, `Redirect_RejectsLF`)
- [ ] Error messages never reflected to clients (tested: `ErrorHandler_SuppressesRawError`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)