### PR TITLE
feat(irc): run the IRC server multi-core on ShardedTcpRuntime (multi-core 3/5)

### DIFF
--- a/code/packages/rust/irc-net-reactor/CHANGELOG.md
+++ b/code/packages/rust/irc-net-reactor/CHANGELOG.md
@@ -37,3 +37,30 @@ All notable changes to this package will be documented in this file.
   transport layer is new.
 - See `code/specs/irc-net-reactor.md` for the full design and the native-binding
   roadmap (Python/Ruby/Node first; JVM/Swift/Elixir/Perl later).
+
+## [0.1.1] - 2026-06-14
+
+### Changed
+
+- **The IRC server is now multi-core by default.** It runs on a
+  `ShardedTcpRuntime` with one reactor shard per CPU — N independent reactors on N
+  threads, each its own kqueue/epoll/IOCP instance, with the kernel load-balancing
+  connections across them via `SO_REUSEPORT`. TCP accept, reads, CRLF framing, and
+  parsing run in parallel across cores; only the `IRCServer` state transition is
+  serialized by the single shared mutex (and serialization + mailbox dispatch
+  already happen outside that lock). A single shared brain keeps nick/channel
+  namespaces server-global; cross-shard broadcast is automatic because each
+  `ConnectionId` encodes its owning shard and the `TcpMailbox` routes to it.
+- `IrcReactorServer::bind` now picks the shard count from
+  `std::thread::available_parallelism()`; the new
+  `IrcReactorServer::bind_with_worker_count(config, n)` pins it (`n = 1`
+  reproduces the original single-reactor engine, `n` clamped to ≥ 1), and
+  `worker_count()` reports the chosen count. `IrcConfig` is unchanged, so all
+  language bindings keep working without modification.
+
+### Added
+
+- Tests: `broadcast_works_across_multiple_shards` (forces 4 shards so cross-shard
+  fan-out is exercised even on a single-core runner) and
+  `worker_count_is_configured_and_clamped`. All existing broadcast / QUIT /
+  RST-survival / poison-recovery tests pass unchanged under default sharding.

--- a/code/packages/rust/irc-net-reactor/README.md
+++ b/code/packages/rust/irc-net-reactor/README.md
@@ -26,9 +26,23 @@ full design, including the broadcast mechanism and concurrency model.
 ## Why a reactor instead of threads
 
 `irc-net-stdlib` spends one OS thread (and its multi-MB stack) per connection.
-`irc-net-reactor` uses a single event-loop thread that the kernel wakes only when
-a socket is readable — the reactor pattern behind nginx, Redis, and Node.js. The
-IRC *logic* is unchanged; only the transport differs.
+`irc-net-reactor` uses event-loop threads that the kernel wakes only when a socket
+is readable — the reactor pattern behind nginx, Redis, and Node.js. The IRC
+*logic* is unchanged; only the transport differs.
+
+## Multi-core
+
+By default the server runs **one reactor shard per CPU** (a `ShardedTcpRuntime`):
+N independent reactors on N threads, each with its own kqueue/epoll/IOCP instance,
+with the kernel load-balancing accepted connections across them via
+`SO_REUSEPORT`. TCP accept, reads, CRLF framing, and parsing all run in parallel
+across cores; only the `IRCServer` state transition is serialized (by a single
+shared mutex), and that critical section is small relative to the per-message
+I/O. Because every `ConnectionId` encodes its owning shard, a response destined
+for a client on another reactor is routed straight there by the shard-aware
+`TcpMailbox` — so cross-shard broadcast just works. Use
+`IrcReactorServer::bind_with_worker_count(config, n)` to pin the shard count
+(`n = 1` reproduces the original single-reactor engine).
 
 ## The broadcast mechanism
 

--- a/code/packages/rust/irc-net-reactor/src/lib.rs
+++ b/code/packages/rust/irc-net-reactor/src/lib.rs
@@ -80,8 +80,8 @@ use irc_framing::Framer;
 use irc_proto::{parse, serialize, ParseError};
 use irc_server::{ConnId, IRCServer, Response};
 use tcp_runtime::{
-    ConnectionId, PlatformError, StopHandle, TcpConnectionInfo, TcpHandlerResult, TcpMailbox,
-    TcpRuntime, TcpRuntimeOptions,
+    ConnectionId, PlatformError, ShardedStopHandle, ShardedTcpRuntime, TcpConnectionInfo,
+    TcpHandlerResult, TcpMailbox, TcpRuntime, TcpRuntimeOptions,
 };
 
 // ──────────────────────────────────────────────────────────────────────────────
@@ -90,6 +90,15 @@ use tcp_runtime::{
 // `tcp-runtime` is generic over the OS event backend.  We pick the right one per
 // target so the rest of the crate is platform-agnostic.  The per-connection
 // state parameter is `Framer` — each socket gets its own line reassembler.
+//
+// The runtime is a [`ShardedTcpRuntime`]: it runs *N* independent reactors on
+// *N* OS threads (one kqueue/epoll/IOCP instance each), with the kernel
+// load-balancing accepted connections across them via `SO_REUSEPORT`.  TCP
+// accept, reads, CRLF framing, and parsing all run in parallel across cores; only
+// the `IRCServer` state transition itself is serialized (by the shared mutex),
+// and that critical section is small relative to the per-message I/O.  A response
+// destined for a client on *another* shard is routed there by the shard-aware
+// `TcpMailbox` (each `ConnectionId` encodes its owning reactor).
 // ──────────────────────────────────────────────────────────────────────────────
 
 #[cfg(any(
@@ -99,13 +108,13 @@ use tcp_runtime::{
     target_os = "netbsd",
     target_os = "dragonfly"
 ))]
-type IrcRuntime = TcpRuntime<transport_platform::bsd::KqueueTransportPlatform, Framer>;
+type IrcRuntime = ShardedTcpRuntime<transport_platform::bsd::KqueueTransportPlatform, Framer>;
 
 #[cfg(target_os = "linux")]
-type IrcRuntime = TcpRuntime<transport_platform::linux::EpollTransportPlatform, Framer>;
+type IrcRuntime = ShardedTcpRuntime<transport_platform::linux::EpollTransportPlatform, Framer>;
 
 #[cfg(target_os = "windows")]
-type IrcRuntime = TcpRuntime<transport_platform::windows::WindowsTransportPlatform, Framer>;
+type IrcRuntime = ShardedTcpRuntime<transport_platform::windows::WindowsTransportPlatform, Framer>;
 
 // ──────────────────────────────────────────────────────────────────────────────
 // Configuration
@@ -159,16 +168,43 @@ impl Default for IrcConfig {
 pub struct IrcReactorServer {
     runtime: Arc<Mutex<Option<IrcRuntime>>>,
     local_addr: SocketAddr,
-    stop_handle: StopHandle,
+    stop_handle: ShardedStopHandle,
     serving: Arc<AtomicBool>,
+    worker_count: usize,
+}
+
+/// The default number of reactor shards: one per available CPU (falling back to
+/// 1 if the platform can't report it).  This is what [`IrcReactorServer::bind`]
+/// uses; call [`IrcReactorServer::bind_with_worker_count`] to choose explicitly.
+fn default_worker_count() -> usize {
+    std::thread::available_parallelism()
+        .map(|n| n.get())
+        .unwrap_or(1)
 }
 
 impl IrcReactorServer {
     /// Build the engine, bind the listener, and wire the IRC state machine onto
     /// the reactor.  The listener is bound here, so [`local_addr`](Self::local_addr)
     /// is valid as soon as this returns — before [`serve`](Self::serve) is called.
+    ///
+    /// Uses one reactor shard per CPU.  For a fixed shard count (e.g. in tests, or
+    /// to pin to a single thread) use [`bind_with_worker_count`](Self::bind_with_worker_count).
     pub fn bind(config: IrcConfig) -> io::Result<Self> {
-        // The IRC brain.  Shared (behind a Mutex) by all three reactor callbacks.
+        Self::bind_with_worker_count(config, default_worker_count())
+    }
+
+    /// Like [`bind`](Self::bind), but with an explicit number of reactor shards.
+    ///
+    /// `worker_count` is clamped to at least 1.  With `1`, the server runs a
+    /// single reactor (no `SO_REUSEPORT`), behaving like the original
+    /// single-threaded engine; with `N > 1`, the kernel load-balances connections
+    /// across `N` reactor threads.
+    pub fn bind_with_worker_count(config: IrcConfig, worker_count: usize) -> io::Result<Self> {
+        let worker_count = worker_count.max(1);
+
+        // The IRC brain.  A single shared state machine (behind a Mutex) serves
+        // *all* shards, so nick/channel namespaces stay server-global; the reactor
+        // threads contend on it only for the brief state transition per message.
         let server = Arc::new(Mutex::new(IRCServer::new(
             &config.server_name,
             config.motd.clone(),
@@ -183,14 +219,22 @@ impl IrcReactorServer {
         // connection, so the cell is always populated when a callback fires.
         let mailbox_cell: Arc<OnceLock<TcpMailbox>> = Arc::new(OnceLock::new());
 
-        let runtime = build_runtime(&config, Arc::clone(&server), Arc::clone(&mailbox_cell))
-            .map_err(into_io_error)?;
+        let runtime = build_runtime(
+            &config,
+            Arc::clone(&server),
+            Arc::clone(&mailbox_cell),
+            worker_count,
+        )
+        .map_err(into_io_error)?;
 
         let local_addr = runtime.local_addr();
         let stop_handle = runtime.stop_handle();
+        // Read back the actual shard count the runtime settled on.
+        let worker_count = runtime.worker_count();
 
         // Publish the mailbox.  `set` only fails if already set, which cannot
-        // happen here — we own the sole writer.
+        // happen here — we own the sole writer.  The mailbox is shard-aware, so a
+        // send to any connection is routed to the reactor that owns it.
         let _ = mailbox_cell.set(runtime.mailbox());
 
         Ok(Self {
@@ -198,6 +242,7 @@ impl IrcReactorServer {
             local_addr,
             stop_handle,
             serving: Arc::new(AtomicBool::new(false)),
+            worker_count,
         })
     }
 
@@ -243,6 +288,11 @@ impl IrcReactorServer {
     /// Whether the event loop is currently running.
     pub fn is_running(&self) -> bool {
         self.serving.load(Ordering::SeqCst)
+    }
+
+    /// The number of reactor shards (one OS thread each) this server runs.
+    pub fn worker_count(&self) -> usize {
+        self.worker_count
     }
 }
 
@@ -358,9 +408,11 @@ fn runtime_options(config: &IrcConfig) -> TcpRuntimeOptions {
 }
 
 /// Build the three reactor callbacks, each carrying its own clones of the shared
-/// `IRCServer` and mailbox cell, and bind the runtime.
+/// `IRCServer` and mailbox cell, and bind the sharded runtime.  The same callbacks
+/// run on every shard (they capture `Arc`s, so all shards share one brain and one
+/// mailbox cell), so no IRC logic is duplicated per reactor.
 macro_rules! bind_with {
-    ($bind:path, $config:expr, $server:expr, $mailbox:expr) => {{
+    ($bind:path, $config:expr, $worker_count:expr, $server:expr, $mailbox:expr) => {{
         let host = $config.host.clone();
 
         let connect_server = Arc::clone(&$server);
@@ -379,6 +431,7 @@ macro_rules! bind_with {
         $bind(
             (host.as_str(), $config.port),
             runtime_options($config),
+            $worker_count,
             move |info| {
                 catch_unwind(AssertUnwindSafe(|| {
                     handle_connect(&connect_server, &connect_mailbox, info)
@@ -415,8 +468,15 @@ fn build_runtime(
     config: &IrcConfig,
     server: Arc<Mutex<IRCServer>>,
     mailbox: Arc<OnceLock<TcpMailbox>>,
+    worker_count: usize,
 ) -> Result<IrcRuntime, PlatformError> {
-    bind_with!(TcpRuntime::bind_kqueue_with_state, config, server, mailbox)
+    bind_with!(
+        TcpRuntime::bind_kqueue_sharded_with_state,
+        config,
+        worker_count,
+        server,
+        mailbox
+    )
 }
 
 #[cfg(target_os = "linux")]
@@ -424,8 +484,15 @@ fn build_runtime(
     config: &IrcConfig,
     server: Arc<Mutex<IRCServer>>,
     mailbox: Arc<OnceLock<TcpMailbox>>,
+    worker_count: usize,
 ) -> Result<IrcRuntime, PlatformError> {
-    bind_with!(TcpRuntime::bind_epoll_with_state, config, server, mailbox)
+    bind_with!(
+        TcpRuntime::bind_epoll_sharded_with_state,
+        config,
+        worker_count,
+        server,
+        mailbox
+    )
 }
 
 #[cfg(target_os = "windows")]
@@ -433,8 +500,15 @@ fn build_runtime(
     config: &IrcConfig,
     server: Arc<Mutex<IRCServer>>,
     mailbox: Arc<OnceLock<TcpMailbox>>,
+    worker_count: usize,
 ) -> Result<IrcRuntime, PlatformError> {
-    bind_with!(TcpRuntime::bind_windows_with_state, config, server, mailbox)
+    bind_with!(
+        TcpRuntime::bind_windows_sharded_with_state,
+        config,
+        worker_count,
+        server,
+        mailbox
+    )
 }
 
 /// Translate a transport-layer [`PlatformError`] into a standard [`io::Error`]
@@ -478,6 +552,30 @@ mod tests {
             port: 0,
             ..IrcConfig::default()
         })
+        .expect("server binds");
+        let addr = server.local_addr();
+        let background = server.clone();
+        let handle = thread::spawn(move || background.serve());
+        (server, handle, addr)
+    }
+
+    /// Like `start_server`, but with an explicit number of reactor shards so a
+    /// test can deterministically exercise the multi-shard path regardless of how
+    /// many CPUs the runner has.
+    fn start_server_with_workers(
+        worker_count: usize,
+    ) -> (
+        IrcReactorServer,
+        thread::JoinHandle<io::Result<()>>,
+        SocketAddr,
+    ) {
+        let server = IrcReactorServer::bind_with_worker_count(
+            IrcConfig {
+                port: 0,
+                ..IrcConfig::default()
+            },
+            worker_count,
+        )
         .expect("server binds");
         let addr = server.local_addr();
         let background = server.clone();
@@ -593,6 +691,65 @@ mod tests {
 
         server.stop();
         handle.join().expect("server thread").expect("server exit");
+    }
+
+    #[test]
+    fn broadcast_works_across_multiple_shards() {
+        // Force 4 reactor shards so this exercises cross-shard fan-out even on a
+        // single-core CI runner: alice and bob may be accepted by DIFFERENT
+        // reactors, yet alice's PRIVMSG must still reach bob.  This is the
+        // end-to-end proof that the shard-routed mailbox delivers a response to
+        // the reactor that owns the target connection while one shared IRCServer
+        // brain keeps the channel membership consistent across shards.
+        let (server, handle, addr) = start_server_with_workers(4);
+        assert_eq!(server.worker_count(), 4);
+
+        let mut alice = connect(addr);
+        let mut bob = connect(addr);
+        register(&mut alice, "alice");
+        register(&mut bob, "bob");
+
+        alice.write_all(b"JOIN #shards\r\n").expect("alice joins");
+        bob.write_all(b"JOIN #shards\r\n").expect("bob joins");
+        let _ = read_until(&mut alice, "JOIN");
+        let _ = read_until(&mut bob, "JOIN");
+
+        alice
+            .write_all(b"PRIVMSG #shards :hello across shards\r\n")
+            .expect("alice privmsg");
+        let received = read_until(&mut bob, "hello across shards");
+        assert!(
+            received.contains("PRIVMSG") && received.contains("hello across shards"),
+            "bob should receive alice's broadcast across shards, got: {received:?}"
+        );
+
+        server.stop();
+        handle.join().expect("server thread").expect("server exit");
+    }
+
+    #[test]
+    fn worker_count_is_configured_and_clamped() {
+        let bind = |workers| {
+            IrcReactorServer::bind_with_worker_count(
+                IrcConfig {
+                    port: 0,
+                    ..IrcConfig::default()
+                },
+                workers,
+            )
+            .expect("server binds")
+        };
+        // 0 clamps to a single reactor; an explicit count is honoured verbatim.
+        assert_eq!(bind(0).worker_count(), 1);
+        assert_eq!(bind(1).worker_count(), 1);
+        assert_eq!(bind(3).worker_count(), 3);
+        // The default constructor picks at least one shard (one per CPU).
+        let default = IrcReactorServer::bind(IrcConfig {
+            port: 0,
+            ..IrcConfig::default()
+        })
+        .expect("server binds");
+        assert!(default.worker_count() >= 1);
     }
 
     #[test]

--- a/code/specs/irc-net-reactor.md
+++ b/code/specs/irc-net-reactor.md
@@ -133,12 +133,25 @@ later PRs.
 
 ## Concurrency & ordering
 
-- `event_loop_threads` defaults to 1 (single reactor thread): connection
-  callbacks are serialized, so the `IRCServer` mutex is never contended and
-  per-connection frame ordering is trivially preserved.
-- `TcpMailbox` sends are themselves thread-safe, so a future sharded variant
-  remains correct (the mutex still serializes state mutation; the mailbox
-  serializes writes per connection).
+- **Sharded by default.** The engine runs on a `ShardedTcpRuntime` with one
+  reactor shard per CPU (`bind`); `bind_with_worker_count(config, n)` pins the
+  count, and `n = 1` reproduces the original single-reactor engine. Each shard is
+  an independent reactor on its own thread with its own kqueue/epoll/IOCP
+  instance; the kernel load-balances accepted connections across them via
+  `SO_REUSEPORT`.
+- **One shared brain.** All shards share a single `Arc<Mutex<IRCServer>>`, so the
+  nick/channel namespaces stay server-global. The mutex is held only for the
+  per-message state transition (`on_connect` / `on_message` / `on_disconnect`);
+  message serialization and mailbox dispatch happen *after* the guard is dropped,
+  so the serialized critical section is small relative to the parallel work
+  (accept, read, CRLF framing, parse, socket writes).
+- **Cross-shard delivery is automatic.** Every `ConnectionId` encodes its owning
+  shard in its low bits, so `TcpMailbox` routes a response to the reactor that
+  owns the target connection — a client on shard A can broadcast to a client on
+  shard B with no shared connection registry.
+- Per-connection frame ordering is preserved because each connection is owned by
+  exactly one reactor and its `Framer` lives in that reactor's per-connection
+  state; connections never migrate between shards.
 
 ---
 


### PR DESCRIPTION
## Summary

**PR 3 of 5** toward a multi-core runtime — and the first one that makes **IRC itself** scale across cores. Moves `irc-net-reactor` off the single `TcpRuntime` onto the `ShardedTcpRuntime`: **one reactor shard per CPU** by default, N independent reactors on N threads (each its own kqueue/epoll/IOCP instance), kernel-load-balanced via `SO_REUSEPORT`.

## How (Option A: parallel IO + minimized lock)

- **Parallel across cores:** TCP accept, read, CRLF framing (per-connection `Framer` lives in the shard's state), and parse.
- **Serialized:** only the `IRCServer` state transition, behind the single shared `Arc<Mutex<IRCServer>>`. Message serialization + mailbox dispatch already happen *after* the guard drops (the lock was already minimal), so the critical section is small relative to per-message I/O.
- **One shared brain** keeps nick/channel namespaces server-global.
- **Cross-shard broadcast is automatic:** PR1 made every `ConnectionId` encode its owning shard, so the routed `TcpMailbox` delivers a response to the reactor that owns the target connection — a client on shard A broadcasts to a client on shard B with no shared registry.

This is the lowest-risk path; whether the brain lock is ever the bottleneck is for the **PR4 benchmark** to decide (and only then would the conditional PR5 actor-brain be worth it).

## API (no breaking changes)

- `IrcReactorServer::bind` now picks the shard count from `std::thread::available_parallelism()`.
- New `bind_with_worker_count(config, n)` pins it (`n` clamped to ≥1; `n=1` reproduces the original single-reactor engine); `worker_count()` reports it.
- **`IrcConfig` is unchanged**, so all seven language bindings keep compiling and working without modification (verified: `irc-server-capi` + `irc-server-native-jni` build; the C-ABI lib broadcast test passes through the now-multi-shard engine).

## Tests

- `broadcast_works_across_multiple_shards` — forces **4 shards** so cross-shard fan-out is exercised even on a single-core CI runner (stress-looped 10× locally, stable).
- `worker_count_is_configured_and_clamped`.
- All existing broadcast / QUIT / RST-survival / poison-recovery tests pass unchanged under default sharding. Clippy clean.

## Security

Reviewed (passed): ConnectionIds are globally unique and **never reused**, so even a poison-recovered/stale brain entry routes to a dead id and is dropped — never delivered to a *different live* client (no confidentiality leak). Mutex coverage is complete (every `IRCServer` access is locked); `worker_count` is clamped; no network-triggerable panic is newly reachable.

Spec `irc-net-reactor.md` + README concurrency model updated from "single reactor thread" to the sharded design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)