### PR TITLE
[codex] Add Thread attach route audit summary

### DIFF
--- a/code/packages/rust/thread-mle/CHANGELOG.md
+++ b/code/packages/rust/thread-mle/CHANGELOG.md
@@ -39,5 +39,7 @@ All notable changes to this package will be documented in this file.
   supervision-plan clearance for runtime handoff checks.
 - Thread attach route-handoff summaries that combine attach completion with
   Network Data readiness, routing surface, and parent/router anchor checks.
+- Thread attach route audit summaries that turn route-handoff readiness into
+  final route audit checks.
 - Neighbor table primitives for parent/child/router relationships, stale
   timeout expiry, link margin tracking, and parent-candidate selection.

--- a/code/packages/rust/thread-mle/README.md
+++ b/code/packages/rust/thread-mle/README.md
@@ -36,6 +36,8 @@ This crate starts the D27 Thread control-plane layer above 6LoWPAN:
   supervision-plan clearance for runtime handoff checks
 - attach route-handoff summaries that combine attach completion with Thread
   Network Data readiness and routing-anchor checks
+- attach route audit summaries that turn route-handoff readiness into final
+  route audit checks
 - deterministic parent/child attach-state skeleton
 - neighbor table primitives for parent/child/router relationships, link margin,
   timeout freshness, and parent-candidate selection

--- a/code/packages/rust/thread-mle/src/lib.rs
+++ b/code/packages/rust/thread-mle/src/lib.rs
@@ -1801,6 +1801,88 @@ pub fn summarize_thread_attach_route_handoff(
     )
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ThreadAttachRouteAuditSummary {
+    pub handoff_summary: ThreadAttachRouteHandoffSummary,
+    pub required_audit_check_count: usize,
+    pub passed_audit_check_count: usize,
+    pub missing_audit_check_count: usize,
+    pub route_handoff_ready: bool,
+    pub attach_complete: bool,
+    pub network_data_ready: bool,
+    pub routing_surface_ready: bool,
+    pub parent_or_route_anchor_ready: bool,
+    pub route_audit_ready: bool,
+}
+
+impl ThreadAttachRouteAuditSummary {
+    pub fn from_handoff_summary(handoff_summary: ThreadAttachRouteHandoffSummary) -> Self {
+        let route_handoff_ready = handoff_summary.is_route_handoff_ready();
+        let attach_complete = !handoff_summary.needs_attach_completion();
+        let network_data_ready = !handoff_summary.needs_network_data();
+        let routing_surface_ready = !handoff_summary.needs_routing_surface();
+        let parent_or_route_anchor_ready = !handoff_summary.needs_parent_or_route_anchor();
+        let checks = [
+            route_handoff_ready,
+            attach_complete,
+            network_data_ready,
+            routing_surface_ready,
+            parent_or_route_anchor_ready,
+        ];
+        let passed_audit_check_count = checks.iter().filter(|ready| **ready).count();
+        let required_audit_check_count = checks.len();
+        let missing_audit_check_count = required_audit_check_count - passed_audit_check_count;
+        let route_audit_ready = missing_audit_check_count == 0;
+
+        Self {
+            handoff_summary,
+            required_audit_check_count,
+            passed_audit_check_count,
+            missing_audit_check_count,
+            route_handoff_ready,
+            attach_complete,
+            network_data_ready,
+            routing_surface_ready,
+            parent_or_route_anchor_ready,
+            route_audit_ready,
+        }
+    }
+
+    pub fn is_route_audit_ready(self) -> bool {
+        self.route_audit_ready
+    }
+
+    pub fn has_audit_gaps(self) -> bool {
+        self.missing_audit_check_count > 0
+    }
+
+    pub fn needs_route_handoff(self) -> bool {
+        !self.route_handoff_ready
+    }
+
+    pub fn needs_attach_completion(self) -> bool {
+        !self.attach_complete
+    }
+
+    pub fn needs_network_data(self) -> bool {
+        !self.network_data_ready
+    }
+
+    pub fn needs_routing_surface(self) -> bool {
+        !self.routing_surface_ready
+    }
+
+    pub fn needs_parent_or_route_anchor(self) -> bool {
+        !self.parent_or_route_anchor_ready
+    }
+}
+
+pub fn summarize_thread_attach_route_audit(
+    handoff_summary: ThreadAttachRouteHandoffSummary,
+) -> ThreadAttachRouteAuditSummary {
+    ThreadAttachRouteAuditSummary::from_handoff_summary(handoff_summary)
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ThreadDiagnosticSnapshot {
     pub captured_at_ms: u64,
@@ -3390,6 +3472,107 @@ mod tests {
         assert!(!summary.route_handoff_ready);
         assert!(!summary.is_route_handoff_ready());
         assert!(summary.has_handoff_gaps());
+        assert!(summary.needs_attach_completion());
+        assert!(summary.needs_network_data());
+        assert!(summary.needs_routing_surface());
+        assert!(summary.needs_parent_or_route_anchor());
+    }
+
+    #[test]
+    fn attach_route_audit_summary_marks_ready_route_audit() {
+        let mut table = NeighborTable::new(DeviceRole::Child);
+        table.upsert(ThreadNeighbor::new(
+            ThreadNeighborId(0x1000),
+            DeviceRole::Router,
+            NeighborRelationship::Parent,
+            1_200,
+            10_000,
+        ));
+        let action_summary = ThreadAttachActionSummary::from_summaries(
+            MleMessageBatchSummary::empty(),
+            table.summary_at(1_250),
+        );
+        let completion_summary = summarize_thread_attach_completion(
+            action_summary,
+            table
+                .diagnostic_snapshot(None, 1_250)
+                .unwrap()
+                .supervision_plan(),
+        );
+        let border_router =
+            NetworkDataTlv::new(NetworkDataTlvType::BorderRouter, true, vec![0xaa]).unwrap();
+        let context = NetworkDataTlv::new(NetworkDataTlvType::Context, true, vec![0x01]).unwrap();
+        let prefix = ThreadPrefixData::new(
+            true,
+            3,
+            64,
+            vec![0xfd, 0x00, 0xab, 0xcd, 0, 0, 0, 0],
+            vec![border_router, context],
+        )
+        .unwrap();
+        let network_data = ThreadNetworkData::from_tlvs(vec![prefix.to_tlv().unwrap()]).unwrap();
+        let network_data_readiness =
+            summarize_thread_network_data_readiness(&network_data).unwrap();
+        let handoff_summary =
+            summarize_thread_attach_route_handoff(completion_summary, network_data_readiness);
+
+        let summary = summarize_thread_attach_route_audit(handoff_summary);
+
+        assert_eq!(summary.handoff_summary, handoff_summary);
+        assert_eq!(summary.required_audit_check_count, 5);
+        assert_eq!(summary.passed_audit_check_count, 5);
+        assert_eq!(summary.missing_audit_check_count, 0);
+        assert!(summary.route_handoff_ready);
+        assert!(summary.attach_complete);
+        assert!(summary.network_data_ready);
+        assert!(summary.routing_surface_ready);
+        assert!(summary.parent_or_route_anchor_ready);
+        assert!(summary.route_audit_ready);
+        assert!(summary.is_route_audit_ready());
+        assert!(!summary.has_audit_gaps());
+        assert!(!summary.needs_route_handoff());
+        assert!(!summary.needs_attach_completion());
+        assert!(!summary.needs_network_data());
+        assert!(!summary.needs_routing_surface());
+        assert!(!summary.needs_parent_or_route_anchor());
+    }
+
+    #[test]
+    fn attach_route_audit_summary_routes_blocked_route_audit() {
+        let table = NeighborTable::new(DeviceRole::Child);
+        let action_summary = ThreadAttachActionSummary::from_summaries(
+            MleMessageBatchSummary::empty(),
+            table.summary_at(1_250),
+        );
+        let completion_summary = summarize_thread_attach_completion(
+            action_summary,
+            table
+                .diagnostic_snapshot(None, 1_250)
+                .unwrap()
+                .supervision_plan(),
+        );
+        let unknown = NetworkDataTlv::new(NetworkDataTlvType::Unknown(42), false, vec![3]).unwrap();
+        let network_data = ThreadNetworkData::from_tlvs(vec![unknown]).unwrap();
+        let network_data_readiness = network_data.summary().unwrap().readiness();
+        let handoff_summary = ThreadAttachRouteHandoffSummary::from_completion_and_network_data(
+            completion_summary,
+            network_data_readiness,
+        );
+
+        let summary = ThreadAttachRouteAuditSummary::from_handoff_summary(handoff_summary);
+
+        assert_eq!(summary.required_audit_check_count, 5);
+        assert_eq!(summary.passed_audit_check_count, 0);
+        assert_eq!(summary.missing_audit_check_count, 5);
+        assert!(!summary.route_handoff_ready);
+        assert!(!summary.attach_complete);
+        assert!(!summary.network_data_ready);
+        assert!(!summary.routing_surface_ready);
+        assert!(!summary.parent_or_route_anchor_ready);
+        assert!(!summary.route_audit_ready);
+        assert!(!summary.is_route_audit_ready());
+        assert!(summary.has_audit_gaps());
+        assert!(summary.needs_route_handoff());
         assert!(summary.needs_attach_completion());
         assert!(summary.needs_network_data());
         assert!(summary.needs_routing_surface());


### PR DESCRIPTION
## Summary
- Add a Thread attach route audit summary that wraps route-handoff readiness into final audit checks.
- Expose readiness/gap helpers for route handoff, attach completion, Network Data, routing surface, and parent/router anchor state.
- Document the new low-level Thread route audit surface in the crate README and changelog.

## Validation
- `cargo fmt --manifest-path code\packages\rust\thread-mle\Cargo.toml`
- `cargo test --manifest-path code\packages\rust\thread-mle\Cargo.toml`
- `git diff --check -- code\packages\rust\thread-mle\src\lib.rs code\packages\rust\thread-mle\README.md code\packages\rust\thread-mle\CHANGELOG.md`