### PR TITLE
feat(visicalc-swiftui): run on iOS too — same code + Rust engine on iPhone

### DIFF
--- a/demo/visicalc-swiftui/Package.swift
+++ b/demo/visicalc-swiftui/Package.swift
@@ -36,8 +36,12 @@ let package = Package(
             dependencies: ["CSpreadsheetEngine"],
             path: "Sources/VisiCalc",
             linkerSettings: [
-                // Link the Rust static library vendored by scripts/build.sh.
-                .unsafeFlags(["-L\(packageDir)/Vendor", "-lspreadsheet_capi"]),
+                // Link the Rust static library vendored by scripts/build.sh,
+                // per platform (the engine is cross-compiled for each target):
+                //   macOS → Vendor/macos     (cargo --target <host>)
+                //   iOS   → Vendor/ios-sim   (cargo --target aarch64-apple-ios-sim)
+                .unsafeFlags(["-L\(packageDir)/Vendor/macos", "-lspreadsheet_capi"], .when(platforms: [.macOS])),
+                .unsafeFlags(["-L\(packageDir)/Vendor/ios-sim", "-lspreadsheet_capi"], .when(platforms: [.iOS])),
             ]
         ),
         .testTarget(
@@ -45,7 +49,8 @@ let package = Package(
             dependencies: ["VisiCalc"],
             path: "Tests/VisiCalcTests",
             linkerSettings: [
-                .unsafeFlags(["-L\(packageDir)/Vendor", "-lspreadsheet_capi"]),
+                // Tests run on the host (macOS).
+                .unsafeFlags(["-L\(packageDir)/Vendor/macos", "-lspreadsheet_capi"], .when(platforms: [.macOS])),
             ]
         ),
     ]

--- a/demo/visicalc-swiftui/README.md
+++ b/demo/visicalc-swiftui/README.md
@@ -38,9 +38,10 @@ the static library.
 ## Build, test, run
 
 ```bash
-bash scripts/build.sh   # regenerate views + build & vendor the engine
+bash scripts/build.sh   # regenerate views + build & vendor the engine (macOS + iOS slices)
 swift test              # HEADLESS: proves the grid is engine-computed + recomputes
 swift run               # launch the SwiftUI app (macOS)
+bash scripts/run-ios.sh # build + launch on the iOS Simulator (same code + engine)
 ```
 
 `swift test` (`Tests/VisiCalcTests`) asserts the grid values come from the
@@ -48,6 +49,15 @@ engine (E1 = 38, A5 = 39, E5 = 169), that editing A1 15 → 115 recomputes the
 totals (E5 → 269), and that a formula entry computes with binary-op error
 propagation (`=1/0` → `#DIV/0!`, and `=A1+1` over it → `#DIV/0!`). Requires
 Swift 5.9+ / Xcode 15+.
+
+**iOS**: the same SwiftUI code and the same Rust engine run on iPhone — the
+engine is cross-compiled for `aarch64-apple-ios-sim` (so the iOS slice links
+its own `libspreadsheet_capi.a`) and `Package.swift` links the right slice per
+platform. `scripts/run-ios.sh` builds it, wraps the executable in a `.app`, and
+installs + launches it on a booted iOS Simulator. Verified: the grid computes
+on iOS and edits recompute (the desktop window is sized 720pt, so on a narrow
+iPhone the right-hand total column scrolls off — a cosmetic layout note, not an
+engine one).
 
 ## Notes
 

--- a/demo/visicalc-swiftui/scripts/build.sh
+++ b/demo/visicalc-swiftui/scripts/build.sh
@@ -63,20 +63,31 @@ echo "Compiling Grid (SwiftUI)..."
   -o "$OUT_DIR/Grid.swift"
 
 echo "Building the spreadsheet engine (Rust → static lib) and vendoring it..."
-# The C ABI static library the SwiftUI app links (see Package.swift). Built
-# from the spreadsheet-capi crate and copied into Vendor/ (git-ignored).
-(cd "$REPO_ROOT/code/packages/rust" && cargo build -p spreadsheet-capi --release)
-mkdir -p "$DEMO_DIR/Vendor"
-cp "$REPO_ROOT/code/packages/rust/target/release/libspreadsheet_capi.a" "$DEMO_DIR/Vendor/"
+# The C ABI static library the app links (see Package.swift), built from the
+# spreadsheet-capi crate per platform and copied into Vendor/ (git-ignored):
+#   Vendor/macos   — the host target, for `swift run` / `swift test`.
+#   Vendor/ios-sim — aarch64-apple-ios-sim, for the iOS Simulator build.
+RUST="$REPO_ROOT/code/packages/rust"
+mkdir -p "$DEMO_DIR/Vendor/macos" "$DEMO_DIR/Vendor/ios-sim"
+
+(cd "$RUST" && cargo build -p spreadsheet-capi --release)
+cp "$RUST/target/release/libspreadsheet_capi.a" "$DEMO_DIR/Vendor/macos/"
+
+# iOS Simulator slice (skipped if the target isn't installed — macOS still works).
+if rustup target list --installed 2>/dev/null | grep -q aarch64-apple-ios-sim; then
+  (cd "$RUST" && cargo build -p spreadsheet-capi --release --target aarch64-apple-ios-sim)
+  cp "$RUST/target/aarch64-apple-ios-sim/release/libspreadsheet_capi.a" "$DEMO_DIR/Vendor/ios-sim/"
+else
+  echo "  (iOS slice skipped — run 'rustup target add aarch64-apple-ios-sim' for iOS)"
+fi
+
 # Refresh the C header the CSpreadsheetEngine module exposes.
-cp "$REPO_ROOT/code/packages/rust/spreadsheet-capi/include/spreadsheet.h" \
+cp "$RUST/spreadsheet-capi/include/spreadsheet.h" \
    "$DEMO_DIR/Sources/CSpreadsheetEngine/include/spreadsheet.h"
 
-echo "Done. Generated views + vendored engine:"
-ls -la "$OUT_DIR"
-ls -la "$DEMO_DIR/Vendor"
+echo "Done. Generated views + vendored engine."
 echo
-echo "To run the demo (Swift 5.9+ / Xcode 15+ required):"
-echo "  cd $DEMO_DIR"
-echo "  swift test    # headless: proves the grid is engine-computed + recomputes"
-echo "  swift run     # launches the SwiftUI app"
+echo "Run (Swift 5.9+ / Xcode 15+ required):"
+echo "  swift test                 # headless: grid is engine-computed + recomputes"
+echo "  swift run                  # launch the macOS SwiftUI app"
+echo "  bash scripts/run-ios.sh    # build + launch on the iOS Simulator"

--- a/demo/visicalc-swiftui/scripts/run-ios.sh
+++ b/demo/visicalc-swiftui/scripts/run-ios.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# run-ios.sh — build the VisiCalc SwiftUI app for the iOS Simulator (linking the
+# iOS slice of the Rust engine), wrap it in a .app, install, and launch it.
+# Proves the SAME SwiftUI code + Rust engine run on iOS. Requires Xcode + an
+# installed iOS Simulator runtime.
+set -euo pipefail
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$DIR"
+
+# Ensure the engine's iOS-sim slice is vendored.
+bash scripts/build.sh >/dev/null
+
+SIM="${1:-iPhone 17}"
+SIM_ID="$(xcrun simctl list devices available | grep "$SIM (" | head -1 | grep -oE '[0-9A-F-]{36}')"
+[ -n "$SIM_ID" ] || { echo "No available simulator matching '$SIM'"; exit 1; }
+xcrun simctl boot "$SIM_ID" 2>/dev/null || true
+open -a Simulator
+
+DD="$(mktemp -d)/dd"
+echo "Building for iOS Simulator…"
+xcodebuild -scheme VisiCalc -destination "platform=iOS Simulator,id=$SIM_ID" -derivedDataPath "$DD" build >/dev/null
+
+# Wrap the executable in a minimal .app (SwiftPM executables aren't .app bundles).
+APP="$(mktemp -d)/VisiCalc.app"
+mkdir -p "$APP"
+cp "$DD/Build/Products/Debug-iphonesimulator/visicalc" "$APP/visicalc"
+cat > "$APP/Info.plist" <<'PLIST'
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0"><dict>
+  <key>CFBundleExecutable</key><string>visicalc</string>
+  <key>CFBundleIdentifier</key><string>com.codingadventures.visicalc</string>
+  <key>CFBundleName</key><string>VisiCalc</string>
+  <key>CFBundleDisplayName</key><string>VisiCalc</string>
+  <key>CFBundleVersion</key><string>1.0</string>
+  <key>CFBundleShortVersionString</key><string>1.0</string>
+  <key>CFBundlePackageType</key><string>APPL</string>
+  <key>LSRequiresIPhoneOS</key><true/>
+  <key>MinimumOSVersion</key><string>17.0</string>
+  <key>UILaunchScreen</key><dict/>
+  <key>UIDeviceFamily</key><array><integer>1</integer></array>
+</dict></plist>
+PLIST
+codesign --force --sign - "$APP" >/dev/null 2>&1
+
+xcrun simctl install "$SIM_ID" "$APP"
+xcrun simctl launch "$SIM_ID" com.codingadventures.visicalc
+echo "Launched VisiCalc on the iOS Simulator ($SIM)."


### PR DESCRIPTION
The SwiftUI VisiCalc demo now also runs on the **iOS Simulator** — proving the *same* SwiftUI source and the *same* Rust spreadsheet engine work on iPhone (the engine is cross-compiled for the iOS-simulator target).

## What changed
- **`Package.swift`** links the engine static lib **per platform**: `Vendor/macos` for the host, `Vendor/ios-sim` (`aarch64-apple-ios-sim`) for iOS, via `.unsafeFlags(..., .when(platforms:))`.
- **`scripts/build.sh`** builds both slices (the iOS slice is skipped with a note if the `aarch64-apple-ios-sim` rustup target isn't installed, so macOS still works).
- **`scripts/run-ios.sh`** builds for the iOS Simulator (`xcodebuild`), wraps the executable in a minimal `.app`, installs + launches it on a booted simulator.

## Verified on the iPhone 17 simulator
The grid renders **engine-computed** values — column A total **39** = `SUM(A1:A4)`, computed by the Rust engine *running on iOS* — and editing a cell recomputes dependents live (observed A5 `39 → 24` when A1 became non-numeric).

![the iOS Simulator running VisiCalc, grid computed by the Rust engine]

The 720pt desktop layout clips the right-hand total column on a narrow iPhone — a cosmetic layout note, not an engine one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)