### PR TITLE
feat(transport-platform): adopt_stream — adopt an externally-accepted socket (multi-core 5a)

### DIFF
--- a/code/packages/rust/transport-platform/CHANGELOG.md
+++ b/code/packages/rust/transport-platform/CHANGELOG.md
@@ -41,3 +41,20 @@ All notable changes to this package will be documented in this file.
   - epoll: duplicates the wakeup `eventfd` and `write`s the counter.
   - Default impl returns `Unsupported`; Windows/IOCP uses it for now (callers fall
     back to the poll timeout), so no platform is broken — they just wake later.
+
+## [0.1.2] - 2026-06-14
+
+### Added
+
+- `TransportPlatform::adopt_stream(fd)` — adopt an already-connected socket
+  (owned `AdoptableFd`: `OwnedFd` on Unix, `OwnedSocket` on Windows) as a managed
+  stream, returning its `StreamId`. This is the receiving half of an **accept
+  fan-out**: a single acceptor accepts on one listener (needed where
+  `SO_REUSEPORT` doesn't load-balance, e.g. macOS/BSD) and hands each accepted
+  socket to a worker platform on another thread, which adopts it and then drives
+  it like any other stream (`configure_stream` + `set_stream_interest`, exactly as
+  after `accept`). Implemented for the kqueue and epoll backends; the default
+  returns `Unsupported` (Windows/IOCP), so the trait stays cross-platform.
+- Test `adopts_externally_accepted_stream` (kqueue + epoll): a separate std
+  listener accepts a real loopback connection, its socket is adopted into the
+  platform, and the adopted stream reads/writes correctly.

--- a/code/packages/rust/transport-platform/src/lib.rs
+++ b/code/packages/rust/transport-platform/src/lib.rs
@@ -283,6 +283,15 @@ impl fmt::Debug for WakeHandle {
     }
 }
 
+/// An owned OS socket handle that can be adopted into a platform as a stream via
+/// [`TransportPlatform::adopt_stream`].  Unix: a file descriptor (`OwnedFd`);
+/// Windows: a socket handle (`OwnedSocket`).  The alias keeps the trait
+/// cross-platform while the meaningful implementations are the Unix backends.
+#[cfg(unix)]
+pub type AdoptableFd = std::os::fd::OwnedFd;
+#[cfg(windows)]
+pub type AdoptableFd = std::os::windows::io::OwnedSocket;
+
 pub trait TransportPlatform {
     fn native_event_provider(&self) -> NativeEventProvider {
         NativeEventProvider::ReadinessProbe
@@ -305,6 +314,26 @@ pub trait TransportPlatform {
     ) -> Result<(), PlatformError>;
 
     fn accept(&mut self, listener: ListenerId) -> Result<Option<AcceptedStream>, PlatformError>;
+
+    /// Adopt an already-connected socket as a managed stream, returning its
+    /// `StreamId`.  This is the receiving half of an **accept fan-out**: a single
+    /// acceptor accepts connections on one listener (e.g. where `SO_REUSEPORT`
+    /// doesn't load-balance, as on macOS/BSD) and hands the raw socket to a worker
+    /// platform on another thread, which adopts it here and then drives it like
+    /// any other stream — `configure_stream` + `set_stream_interest` exactly as it
+    /// would after `accept`.
+    ///
+    /// The default returns [`PlatformError::Unsupported`]; the kqueue and epoll
+    /// backends override it.  Taking the handle by value transfers ownership, so
+    /// the sender must relinquish it (e.g. `into`/`IntoRawFd`) and never close it.
+    fn adopt_stream(&mut self, fd: AdoptableFd) -> Result<StreamId, PlatformError> {
+        // Drop the handle (closing it) so an unsupported platform doesn't leak the
+        // socket, then report that adoption isn't available here.
+        drop(fd);
+        Err(PlatformError::Unsupported(
+            "adopt_stream not supported by this platform",
+        ))
+    }
 
     fn configure_stream(
         &mut self,
@@ -677,6 +706,28 @@ pub mod bsd {
                 Err(error) if error.kind() == io::ErrorKind::WouldBlock => Ok(None),
                 Err(error) => Err(PlatformError::from(error)),
             }
+        }
+
+        fn adopt_stream(&mut self, fd: AdoptableFd) -> Result<StreamId, PlatformError> {
+            // The fan-out acceptor handed us a freshly-`accept`ed socket from
+            // another thread.  Register it exactly like the tail of `accept`: wrap
+            // the owned fd as a `TcpStream`, make it non-blocking (an `accept`ed
+            // socket does not inherit O_NONBLOCK), allocate a local `StreamId`, and
+            // record it.  Interest starts at `none()`; the caller then
+            // `configure_stream` + `set_stream_interest`, exactly as `accept_ready`
+            // does after a normal accept.
+            let stream = TcpStream::from(fd);
+            stream.set_nonblocking(true)?;
+            let id = StreamId(self.alloc_token());
+            self.register_resource(id.0, ResourceId::Stream(id));
+            self.streams.insert(
+                id,
+                StreamState {
+                    socket: stream,
+                    interest: StreamInterest::none(),
+                },
+            );
+            Ok(id)
         }
 
         fn configure_stream(
@@ -1364,6 +1415,28 @@ pub mod linux {
                 Err(error) if error.kind() == io::ErrorKind::WouldBlock => Ok(None),
                 Err(error) => Err(PlatformError::from(error)),
             }
+        }
+
+        fn adopt_stream(&mut self, fd: AdoptableFd) -> Result<StreamId, PlatformError> {
+            // The fan-out acceptor handed us a freshly-`accept`ed socket from
+            // another thread.  Register it exactly like the tail of `accept`: wrap
+            // the owned fd as a `TcpStream`, make it non-blocking (an `accept`ed
+            // socket does not inherit O_NONBLOCK), allocate a local `StreamId`, and
+            // record it.  Interest starts at `none()`; the caller then
+            // `configure_stream` + `set_stream_interest`, exactly as `accept_ready`
+            // does after a normal accept.
+            let stream = TcpStream::from(fd);
+            stream.set_nonblocking(true)?;
+            let id = StreamId(self.alloc_token());
+            self.register_resource(id.0, ResourceId::Stream(id));
+            self.streams.insert(
+                id,
+                StreamState {
+                    socket: stream,
+                    interest: StreamInterest::none(),
+                },
+            );
+            Ok(id)
         }
 
         fn configure_stream(
@@ -2982,6 +3055,63 @@ mod tests {
         assert_eq!(&reply[..5], b"+OK\r\n");
     }
 
+    /// An externally-accepted connection, handed in via `adopt_stream`, reads and
+    /// writes exactly like one the platform `accept`ed itself.  This is the
+    /// foundation of the macOS/BSD accept fan-out: the acceptor thread does the
+    /// `accept`, the worker platform `adopt`s the socket.
+    #[cfg(unix)]
+    fn assert_adopts_external_stream<P: TransportPlatform>(platform: &mut P) {
+        use std::os::fd::OwnedFd;
+
+        // A separate std listener stands in for the fan-out acceptor: it accepts a
+        // real loopback connection, and we hand the accepted socket to `platform`.
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind std listener");
+        let addr = listener.local_addr().expect("listener addr");
+        let mut client = TcpStream::connect(addr).expect("connect client");
+        client
+            .set_read_timeout(Some(Duration::from_millis(200)))
+            .expect("read timeout");
+        let (server, _peer) = listener.accept().expect("accept on std listener");
+
+        // Transfer ownership of the accepted socket into the platform.
+        let owned: OwnedFd = server.into();
+        let stream = platform.adopt_stream(owned).expect("adopt external stream");
+        platform
+            .configure_stream(stream, StreamOptions::default())
+            .expect("configure adopted stream");
+        platform
+            .set_stream_interest(stream, StreamInterest::readable())
+            .expect("interest on adopted stream");
+
+        client.write_all(b"PING").expect("client write");
+        let events = poll_until(platform, Duration::from_secs(1), |events| {
+            events.iter().any(
+                |event| matches!(event, PlatformEvent::StreamReadable { stream: id } if *id == stream),
+            )
+        });
+        assert!(
+            events.iter().any(
+                |event| matches!(event, PlatformEvent::StreamReadable { stream: id } if *id == stream),
+            ),
+            "adopted stream never became readable",
+        );
+
+        let mut buffer = [0u8; 16];
+        assert_eq!(
+            platform.read(stream, &mut buffer).expect("read adopted stream"),
+            ReadOutcome::Read(4)
+        );
+        assert_eq!(&buffer[..4], b"PING");
+
+        assert_eq!(
+            write_until_progress(platform, stream, b"+OK\r\n"),
+            WriteOutcome::Wrote(5)
+        );
+        let mut reply = [0u8; 5];
+        client.read_exact(&mut reply).expect("client read reply");
+        assert_eq!(&reply, b"+OK\r\n");
+    }
+
     fn write_until_progress<P: TransportPlatform>(
         platform: &mut P,
         stream: StreamId,
@@ -3135,6 +3265,12 @@ mod tests {
         }
 
         #[test]
+        fn adopts_externally_accepted_stream() {
+            let mut platform = KqueueTransportPlatform::new().expect("create platform");
+            assert_adopts_external_stream(&mut platform);
+        }
+
+        #[test]
         fn close_event_is_reported_after_peer_shutdown() {
             let mut platform = KqueueTransportPlatform::new().expect("create platform");
             let listener = platform
@@ -3190,6 +3326,12 @@ mod tests {
         fn timer_and_wakeup_generate_events() {
             let mut platform = EpollTransportPlatform::new().expect("create platform");
             assert_timer_and_wakeup_generate_events(&mut platform);
+        }
+
+        #[test]
+        fn adopts_externally_accepted_stream() {
+            let mut platform = EpollTransportPlatform::new().expect("create platform");
+            assert_adopts_external_stream(&mut platform);
         }
 
         #[test]

--- a/code/packages/rust/transport-platform/src/lib.rs
+++ b/code/packages/rust/transport-platform/src/lib.rs
@@ -326,6 +326,11 @@ pub trait TransportPlatform {
     /// The default returns [`PlatformError::Unsupported`]; the kqueue and epoll
     /// backends override it.  Taking the handle by value transfers ownership, so
     /// the sender must relinquish it (e.g. `into`/`IntoRawFd`) and never close it.
+    ///
+    /// Like [`accept`](Self::accept), this is a low-level primitive that performs
+    /// **no admission control** — it registers the socket unconditionally.  The
+    /// connection cap is enforced one layer up (the reactor's accept/adopt path),
+    /// so callers are responsible for not adopting more streams than they intend.
     fn adopt_stream(&mut self, fd: AdoptableFd) -> Result<StreamId, PlatformError> {
         // Drop the handle (closing it) so an unsupported platform doesn't leak the
         // socket, then report that adoption isn't available here.


### PR DESCRIPTION
## Summary

**PR 5a** — the foundation for the **macOS/BSD accept fan-out** (the gap PR4's benchmark exposed: plain `SO_REUSEPORT` doesn't load-balance on macOS/BSD, so all connections land on one shard). The fix is an explicit fan-out — one acceptor accepts on a single listener and hands each accepted socket to a worker reactor. This PR adds the **receiving** primitive.

`TransportPlatform::adopt_stream(fd)` takes an **owned** socket handle (`AdoptableFd` = `OwnedFd` on Unix / `OwnedSocket` on Windows, so the trait stays cross-platform), wraps it as a `TcpStream`, makes it non-blocking, registers it, and returns a local `StreamId` — the exact tail of `accept()`, minus the `accept()` call. The caller then does `configure_stream` + `set_stream_interest` just as `accept_ready` does after a normal accept.

- Implemented for **kqueue + epoll**; the default returns `Unsupported` (Windows/IOCP) and `drop`s the handle so an unsupported platform doesn't leak the socket.
- **No `unsafe`** — uses the safe `From<OwnedFd> for TcpStream`. Ownership transfers by value, so the acceptor must relinquish the fd and never close it (the worker platform now owns it).
- Non-breaking (new trait method has a default), so `stream-reactor` / `tcp-runtime` / `irc-net-reactor` all still build.

## Test

`adopts_externally_accepted_stream` (kqueue + epoll, `#[cfg(unix)]` helper): a separate std listener accepts a real loopback connection, its socket is adopted into the platform, and the adopted stream becomes readable, reads `PING`, and writes a reply the client reads back. Clippy clean.

## Security

Reviewed (passed): fd accounting is correct on every path (success / `set_nonblocking` error / unsupported-default `drop`) — no double-close, no leak, no id reuse, no `unsafe`, no aliasing. `OwnedFd` is `Send` so the cross-thread handoff is sound; the owned-handle signature is misuse-resistant (the acceptor can't retain a valid fd after `into()`). Documented that admission control (the connection cap) is the caller's job, one layer up.

## The sequence

This is the first of 3:
- **5a (this PR)** — `adopt_stream` primitive.
- **5b** — stream-reactor `AdoptConnection` mailbox command (inject an fd into a running reactor).
- **5c** — tcp-runtime single-acceptor distributor wiring `ShardedTcpRuntime` on macOS/BSD (Linux keeps `SO_REUSEPORT`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)