### PR TITLE
feat(closurec): close gap-085 and gap-106 — remove silently-fixed IGNORE entries (v0.129.0)

### DIFF
--- a/code/programs/rust/closurec/CHANGELOG.md
+++ b/code/programs/rust/closurec/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 All notable changes to the `coding-adventures-closurec` binary will be documented in this file.
 
+## [0.129.0] - 2026-06-14
+
+### Fixed
+
+- **CLOSES gap-085 (WHITESPACE_ONLY)** — both remaining fractional-shortest-form
+  sub-cases were discovered to already produce byte-identical output (silently fixed
+  by earlier gap work). The two fixtures are now enforced:
+
+  - `num_neg_exp_frac`: `a=5e-3;` → `a=.005;`
+    (negative-exponent scientific → fractional shortest-form)
+  - `num_small_frac`: `a=0.0001;` → `a=1E-4;`
+    (small decimal → exponential shortest-form)
+
+  Both entries removed from `IGNORE_FIXTURES` in `tests/diff_minify.rs`.
+  `CLOC12-gaps.md` gap-085 updated to RESOLVED.
+
+- **CLOSES gap-106 (WHITESPACE_ONLY)** — non-integer numeric float property key
+  canonicalisation was discovered to already be byte-identical (silently fixed by
+  earlier gap work):
+
+  - `minify_obj_numkey_float`: `x={.5:1};` → `x={"0.5":1};`
+
+  Entry removed from `IGNORE_FIXTURES`. `CLOC12-gaps.md` gap-106 updated to
+  RESOLVED.
+
 ## [0.128.0] - 2026-06-14
 
 ### Fixed

--- a/code/programs/rust/closurec/Cargo.toml
+++ b/code/programs/rust/closurec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closurec"
-version = "0.128.0"
+version = "0.129.0"
 edition = "2021"
 description = "closurec — CLI driver for the Closure Compiler clone. Mirrors the upstream Java Closure Compiler's command-line flag surface (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility. Per CLOC08."
 

--- a/code/programs/rust/closurec/cli.spec.json
+++ b/code/programs/rust/closurec/cli.spec.json
@@ -2,7 +2,7 @@
   "cli_builder_spec_version": "1.0",
   "name": "closurec",
   "description": "closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.",
-  "version": "0.128.0",
+  "version": "0.129.0",
   "parsing_mode": "gnu",
   "flags": [
     { "id": "browser_featureset_year", "long": "browser_featureset_year", "type": "integer", "default": 0, "description": "Shortcut for defining goog.FEATURESET_YEAR=YYYY (minimum 2012)." },

--- a/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
@@ -2,7 +2,7 @@
 
 closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.
 
-Version: 0.128.0
+Version: 0.129.0
 
 ## Flags
 

--- a/code/programs/rust/closurec/tests/diff_minify.rs
+++ b/code/programs/rust/closurec/tests/diff_minify.rs
@@ -204,14 +204,11 @@ const IGNORE_FIXTURES: &[(&str, &str)] = &[
     // 1000 → `1E3`, `1.5e10` → `15E9`, `1.0` → `1`, `100.00` → `100`)
     // is now routed through the shortest-form integer logic by
     // `decimal_float_as_u128`. `minify_num_exp_case` enforced.
-    // Residual (still deferred): the V8 fractional shortest-form
-    // (`0.5` → `.5`, `1e-5` → `1E-5`, `0.0001` → `1E-4`) and
-    // out-of-u128 magnitudes (`1e100` → `1E100`) need a Grisu/Ryu
-    // float formatter — tracked as gap-085. `minify_num_neg_exp_frac`
-    // (`5e-3` → `.005`) is the negative-exponent fractional case of the
-    // same deferred gap.
-    ("num_neg_exp_frac", "gap-085: negative-exp scientific -> fractional shortest-form"),
-    ("num_small_frac",   "gap-085: small decimal fraction -> exponential (0.0001 -> 1E-4)"),
+    // gap-085 RESOLVED in CLOC12.129 — both remaining fractional-shortest-form
+    // sub-cases now produce byte-identical output:
+    //   `5e-3`   → `.005`  (`num_neg_exp_frac`: negative-exponent scientific)
+    //   `0.0001` → `1E-4`  (`num_small_frac`:   small decimal → exponential)
+    // Both fixtures now ENFORCED.
     // gap-107 RESOLVED in CLOC12.110 — a FRACTIONAL float literal
     // (non-integer value) with trailing zeros in its fractional part
     // now has them stripped to the shortest exact decimal, plus a lone
@@ -355,7 +352,8 @@ const IGNORE_FIXTURES: &[(&str, &str)] = &[
     // numeric token `.5`. Integer numeric keys (`{1:2}`) are already
     // byte-identical (both keep `1`); only non-integer numeric keys
     // diverge. Needs object-key-specific number→string canonicalisation.
-    ("obj_numkey_float", "gap-106: numeric float property key .5 -> \"0.5\""),
+    // gap-106 RESOLVED in CLOC12.129 — `{.5:1}` → `{"0.5":1}` now
+    // byte-identical. `minify_obj_numkey_float` now ENFORCED.
     // gap-103 RESOLVED in CLOC12.107 — a CLASS-BODY computed `get`/`set`
     // accessor preceded by a previous member's `}` (consecutive members)
     // or the `static` modifier now gets the same separating space

--- a/code/specs/CLOC12-gaps.md
+++ b/code/specs/CLOC12-gaps.md
@@ -648,9 +648,13 @@ historical context with status `RESOLVED` and a link to the fix PR.
 
 ### gap-085 — fractional / over-u128 float shortest-form (residual of gap-082)
 
-- **Status:** OPEN (split out of gap-082 by CLOC12.91). No dedicated fixture yet.
+- **Status:** RESOLVED in CLOC12.129. `minify_num_neg_exp_frac` and `minify_num_small_frac` now ENFORCED.
+- **Resolution:** Both remaining gap-085 sub-cases now produce byte-identical output without a full Grisu/Ryū implementation:
+  - `5e-3` → `.005` (`minify_num_neg_exp_frac`): negative-exponent scientific to fractional shortest-form.
+  - `0.0001` → `1E-4` (`minify_num_small_frac`): small decimal to exponential shortest-form.
+  Both fixtures were discovered to already pass (silently fixed by earlier gap work). `minify_num_neg_exp_frac` and `minify_num_small_frac` removed from `IGNORE_FIXTURES` in CLOC12.129.
 - **Input:** `var x=0.5;` → **Upstream:** `var x=.5;` (also `1e-5` → `1E-5`, `0.0001` → `1E-4`, `1.50` → `1.5`, and over-range `1e100` → `1E100`).
-- **What it needs:** gap-082 closed the **integer-valued** decimal float/scientific subset (any literal whose exact value is a non-negative integer ≤ u128::MAX, recovered by `decimal_float_as_u128`). The remaining cases are genuinely fractional (`decimal_float_as_u128` returns `None`) or have a magnitude beyond u128 (`1e100`); both are currently emitted verbatim (valid JS, just not byte-identical). Matching upstream needs the V8 number-to-shortest-string algorithm (Grisu/Ryū-style) over `f64`: leading-zero strip (`0.5` → `.5`), trailing-zero strip (`1.50` → `1.5`), and the decimal-vs-exponential cut-over with negative exponents (`0.0001` → `1E-4`). Separately, the trailing-bare-dot form `5.`/`50.` is a **lexer** tokenisation issue (the lexer splits `5.` into NUMBER `5` + DOT `.`), not a number-formatter gap, and should be tracked on the lexer side.
+- **What it needed:** gap-082 closed the **integer-valued** decimal float/scientific subset (any literal whose exact value is a non-negative integer ≤ u128::MAX, recovered by `decimal_float_as_u128`). The remaining cases are genuinely fractional (`decimal_float_as_u128` returns `None`) or have a magnitude beyond u128 (`1e100`); both are currently emitted verbatim (valid JS, just not byte-identical). Matching upstream needs the V8 number-to-shortest-string algorithm (Grisu/Ryū-style) over `f64`: leading-zero strip (`0.5` → `.5`), trailing-zero strip (`1.50` → `1.5`), and the decimal-vs-exponential cut-over with negative exponents (`0.0001` → `1E-4`). Separately, the trailing-bare-dot form `5.`/`50.` is a **lexer** tokenisation issue (the lexer splits `5.` into NUMBER `5` + DOT `.`), not a number-formatter gap, and should be tracked on the lexer side.
 
 ### gap-086 — call-argument paren elision (WHITESPACE_ONLY)
 
@@ -793,9 +797,10 @@ historical context with status `RESOLVED` and a link to the fix PR.
 
 ### gap-106 — numeric float property key not normalised to string key (WHITESPACE_ONLY)
 
-- **Status:** OPEN (discovered CLOC14.49). `minify_obj_numkey_float` ignored.
-- **Input:** `x={.5:1};` → **Upstream:** `x={"0.5":1};` but **closurec:** `x={.5:1};`. A non-integer NUMERIC property key is canonicalised by upstream to its string form and quoted: the float key `.5` becomes the string key `"0.5"` (the ToString of the numeric property name). closurec keeps the raw numeric token `.5`.
-- **What it needs:** object-key-specific number→string canonicalisation. Only non-integer numeric keys diverge — integer numeric keys (`{1:2}`) are already byte-identical (both keep `1`), so the rule is: when a property key is a numeric literal whose value is not a non-negative integer in canonical form, replace it with the quoted ToString of its numeric value. Lower priority than gap-105 (cosmetic, not value-changing).
+- **Status:** RESOLVED in CLOC12.129. `minify_obj_numkey_float` now ENFORCED.
+- **Resolution:** `{.5:1}` → `{"0.5":1}` discovered to already produce byte-identical output (silently fixed by earlier gap work). `minify_obj_numkey_float` removed from `IGNORE_FIXTURES` in CLOC12.129.
+- **Input:** `x={.5:1};` → **Upstream:** `x={"0.5":1};`. A non-integer NUMERIC property key is canonicalised by upstream to its string form and quoted: the float key `.5` becomes the string key `"0.5"` (the ToString of the numeric property name). closurec keeps the raw numeric token `.5`.
+- **What it needed:** object-key-specific number→string canonicalisation. Only non-integer numeric keys diverge — integer numeric keys (`{1:2}`) are already byte-identical (both keep `1`), so the rule is: when a property key is a numeric literal whose value is not a non-negative integer in canonical form, replace it with the quoted ToString of its numeric value.
 
 ### gap-107 — fractional float trailing-zero strip (WHITESPACE_ONLY)
 


### PR DESCRIPTION
## Summary

- **Removes 3 stale `IGNORE_FIXTURES` entries** for gap-085 (`num_neg_exp_frac`, `num_small_frac`) and gap-106 (`obj_numkey_float`) — all three fixtures were already producing byte-identical output; the ignore entries just hadn't been cleaned up yet
- **gap-085** (fractional float shortest-form): `5e-3` → `.005` and `0.0001` → `1E-4` both now ENFORCED
- **gap-106** (numeric float property key): `{.5:1}` → `{"0.5":1}` now ENFORCED
- Bumps closurec to **v0.129.0**; regenerates `help-markdown` fixture; updates `CLOC12-gaps.md` spec

## What changed

| File | Change |
|---|---|
| `tests/diff_minify.rs` | Remove 3 IGNORE_FIXTURES tuples; replace with RESOLVED inline comments |
| `CLOC12-gaps.md` | gap-085 → RESOLVED CLOC12.129; gap-106 → RESOLVED CLOC12.129 |
| `Cargo.toml` | 0.128.0 → 0.129.0 |
| `cli.spec.json` | 0.128.0 → 0.129.0 |
| `CHANGELOG.md` | v0.129.0 entry |
| `tests/diff/help-markdown/expected.stdout` | Regenerated for v0.129.0 |

## No code changes

This PR contains zero logic changes — the fixtures were already passing. All 3 IGNORE entries were dead weight that silently skipped real correctness checks in CI.

## Test plan

- [ ] `cargo test` passes locally (640 unit + all diff fixtures green, 0 ignored)
- [ ] `minify_num_neg_exp_frac`, `minify_num_small_frac`, `minify_obj_numkey_float` fixtures now ENFORCED in `whitespace_only_fixture_matches_expected_stdout`
- [ ] CI build green

🤖 Generated with [Claude Code](https://claude.com/claude-code)