### PR TITLE
feat(closurec): close gap-083 — precedence-aware operand paren elision (v0.130.0)

### DIFF
--- a/code/programs/rust/closurec/CHANGELOG.md
+++ b/code/programs/rust/closurec/CHANGELOG.md
@@ -2,6 +2,42 @@
 
 All notable changes to the `coding-adventures-closurec` binary will be documented in this file.
 
+## [0.130.0] - 2026-06-14
+
+### Fixed
+
+- **CLOSES gap-083 (WHITESPACE_ONLY)** — precedence-aware operand paren elision.
+  When a binary operator's right operand is parenthesised and every top-level
+  binary operator inside has **strictly greater** precedence than the outer
+  operator, the grouping parens are redundant and are now dropped.
+
+  **Example:** `a==(b+c)` → `a==b+c`
+  - Outer `==` has precedence 9; inner `+` has precedence 12.
+  - `12 > 9` → parens dropped.
+
+  **Kept correctly:** `a*(b+c)` stays `a*(b+c)`
+  - Outer `*` has precedence 13; inner `+` has precedence 12.
+  - `12 < 13` → parens kept (inner is weaker; removing changes grouping).
+
+  **Implementation:** two new `pub(crate)`-adjacent helpers added to
+  `whitespace_only.rs`:
+  - `binary_op_prec(tok)` — returns the JS binary operator precedence (3–14)
+    for recognised symbol operators; `None` for unrecognised tokens, assignment
+    operators, and comma.
+  - `min_toplevel_binary_prec(span)` — scans the span for top-level binary
+    operators (depth-0 w.r.t. nested `()`/`[]`/`{}`), returns the minimum
+    precedence found.
+
+  The existing gap-078 drop block is extended: after the atomic-operand check
+  fails, `is_binary_sym` guards a second attempt that calls both helpers.  Only
+  BINARY outer operators participate (prefix-unary operators like `-(b+c)` are
+  excluded).
+
+  `minify_precedence_operand` fixture is now **enforced** in CI.
+  Updated existing `gap078_operator_operand_kept` test (now
+  `gap083_precedence_aware_paren_elision`) to reflect the resolved behaviour
+  and add boundary cases.
+
 ## [0.129.0] - 2026-06-14
 
 ### Fixed

--- a/code/programs/rust/closurec/Cargo.toml
+++ b/code/programs/rust/closurec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closurec"
-version = "0.129.0"
+version = "0.130.0"
 edition = "2021"
 description = "closurec — CLI driver for the Closure Compiler clone. Mirrors the upstream Java Closure Compiler's command-line flag surface (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility. Per CLOC08."
 

--- a/code/programs/rust/closurec/cli.spec.json
+++ b/code/programs/rust/closurec/cli.spec.json
@@ -2,7 +2,7 @@
   "cli_builder_spec_version": "1.0",
   "name": "closurec",
   "description": "closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.",
-  "version": "0.129.0",
+  "version": "0.130.0",
   "parsing_mode": "gnu",
   "flags": [
     { "id": "browser_featureset_year", "long": "browser_featureset_year", "type": "integer", "default": 0, "description": "Shortcut for defining goog.FEATURESET_YEAR=YYYY (minimum 2012)." },

--- a/code/programs/rust/closurec/src/whitespace_only.rs
+++ b/code/programs/rust/closurec/src/whitespace_only.rs
@@ -905,7 +905,30 @@ pub fn whitespace_only_minify(
                 }
                 if let Some(close) = close {
                     let span = &kept[open + 1..close];
-                    if is_safe_unary_paren_operand(span) {
+                    // gap-075/078: atomic-operand elision (existing).
+                    // gap-083: precedence-aware elision — if the span has a
+                    // top-level binary operator whose minimum precedence is
+                    // STRICTLY GREATER than the outer operator's precedence,
+                    // the parens are redundant (inner binds tighter).
+                    // `a==(b+c)` → `a==b+c` (outer `==` prec 9, inner `+`
+                    // prec 12 > 9). Only applies to BINARY outer operators
+                    // (`is_binary_sym`); prefix-unary outer ops (gap-075)
+                    // are excluded — `-(b+c)` must never strip.
+                    let should_drop = if is_safe_unary_paren_operand(span) {
+                        true
+                    } else if is_binary_sym {
+                        if let (Some(outer_p), Some(inner_min_p)) = (
+                            binary_op_prec(kept[i]),
+                            min_toplevel_binary_prec(span),
+                        ) {
+                            inner_min_p > outer_p
+                        } else {
+                            false
+                        }
+                    } else {
+                        false
+                    };
+                    if should_drop {
                         drops.push(open);
                         drops.push(close);
                         i = close + 1;
@@ -5790,6 +5813,86 @@ fn is_regex(tok: &lexer::token::Token) -> bool {
 }
 
 // ---------------------------------------------------------------------------
+// gap-083: operator-precedence helpers
+// ---------------------------------------------------------------------------
+
+/// Returns the JS operator precedence for a BINARY SYMBOL operator token,
+/// or `None` if the token is not a recognised binary symbol operator.
+///
+/// Precedence table (higher number = tighter binding):
+///   `**`            → 14   (right-associative — kept conservative)
+///   `*` `/` `%`     → 13
+///   `+` `-`         → 12
+///   `<<` `>>` `>>>` → 11
+///   `<` `>` `<=` `>=` → 10
+///   `==` `!=` `===` `!==` → 9
+///   `&`             → 8
+///   `^`             → 7
+///   `|`             → 6
+///   `??`            → 5
+///   `&&`            → 4
+///   `||`            → 3
+///
+/// Assignment operators (`=`, `+=`, …) and the comma operator are NOT
+/// included — they are never safe to treat as "inner binds tighter"
+/// in the `a==(b+c)` shape.
+fn binary_op_prec(tok: &lexer::token::Token) -> Option<u8> {
+    if is_string_literal(tok) || is_word_like(tok) {
+        return None;
+    }
+    match tok.value.as_str() {
+        "**" => Some(14),
+        "*" | "/" | "%" => Some(13),
+        "+" | "-" => Some(12),
+        "<<" | ">>" | ">>>" => Some(11),
+        "<" | ">" | "<=" | ">=" => Some(10),
+        "==" | "!=" | "===" | "!==" => Some(9),
+        "&" => Some(8),
+        "^" => Some(7),
+        "|" => Some(6),
+        "??" => Some(5),
+        "&&" => Some(4),
+        "||" => Some(3),
+        _ => None,
+    }
+}
+
+/// Returns the MINIMUM precedence of any top-level binary operator found in
+/// `span`, or `None` if no such operator exists at depth 0.
+///
+/// "Top-level" means depth 0 with respect to `(`, `[`, `{` / `)`, `]`, `}`.
+/// Tokens inside nested brackets are invisible to this scan.
+///
+/// The minimum is the right metric because it determines the weakest binding
+/// at the outermost expression level — that is what must beat the outer
+/// operator's precedence for the parens to be elide-safe.
+fn min_toplevel_binary_prec(span: &[&lexer::token::Token]) -> Option<u8> {
+    let mut depth: i32 = 0;
+    let mut min_prec: Option<u8> = None;
+    for tok in span {
+        if is_structural_punct(tok, "(")
+            || is_structural_punct(tok, "[")
+            || is_structural_punct(tok, "{")
+        {
+            depth += 1;
+        } else if is_structural_punct(tok, ")")
+            || is_structural_punct(tok, "]")
+            || is_structural_punct(tok, "}")
+        {
+            depth -= 1;
+        } else if depth == 0 {
+            if let Some(p) = binary_op_prec(tok) {
+                min_prec = Some(match min_prec {
+                    None => p,
+                    Some(m) => m.min(p),
+                });
+            }
+        }
+    }
+    min_prec
+}
+
+// ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
@@ -8254,15 +8357,25 @@ mod tests {
         assert_eq!(minify("var x=a==(b.c);"), "var x=a==b.c;");
     }
 
-    /// gap-078 boundary (DEFERRED precedence-aware case): an operand
-    /// containing a top-level binary operator KEEPS its parens — the
-    /// conservative atomic-operand guard does not yet do the full
-    /// precedence analysis the JAR does (`a==(b+c)` → upstream
-    /// `a==b+c`). Output stays valid; just not byte-identical.
+    /// gap-083: precedence-aware paren elision — when the inner operator
+    /// has STRICTLY HIGHER precedence than the outer, the parens are
+    /// redundant. `==` (prec 9) wrapping `b+c` (inner `+` prec 12 > 9)
+    /// → parens dropped. `*` (prec 13) wrapping `b+c` (inner `+` prec
+    /// 12 < 13) → parens kept (inner is WEAKER; removing them would
+    /// change grouping).
     #[test]
-    fn gap078_operator_operand_kept() {
-        assert_eq!(minify("var x=a==(b+c);"), "var x=a==(b+c);");
+    fn gap083_precedence_aware_paren_elision() {
+        // Inner prec strictly greater → strip.
+        assert_eq!(minify("var x=a==(b+c);"), "var x=a==b+c;");
+        // Inner prec strictly less → keep.
         assert_eq!(minify("var x=a*(b+c);"), "var x=a*(b+c);");
+        // Inner prec equal → keep (conservative; `a==(b==c)` stays).
+        assert_eq!(minify("var x=a==(b==c);"), "var x=a==(b==c);");
+        // Multiple operators in span — min inner prec must beat outer.
+        // `||` (prec 3) outer, inner has `+` (12) AND `*` (13) → min = 12 > 3 → strip.
+        assert_eq!(minify("var x=a||(b+c*d);"), "var x=a||b+c*d;");
+        // `*` (13) outer, span has `+` (12) AND `&&` (4) → min = 4 < 13 → keep.
+        assert_eq!(minify("var x=a*(b+c&&d);"), "var x=a*(b+c&&d);");
     }
 
     /// gap-078 SAFETY: a string/regex literal whose CONTENT is an

--- a/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
@@ -2,7 +2,7 @@
 
 closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.
 
-Version: 0.129.0
+Version: 0.130.0
 
 ## Flags
 

--- a/code/programs/rust/closurec/tests/diff_minify.rs
+++ b/code/programs/rust/closurec/tests/diff_minify.rs
@@ -229,11 +229,12 @@ const IGNORE_FIXTURES: &[(&str, &str)] = &[
     // (`12345678901234567890` -> `1.2345678901234567E19`) never reaches
     // the arm (all-digits, no `.`). `minify_num_frac_trail_zero` /
     // `..._trail_zeros` / `..._lead_zero` now ENFORCED.
-    // gap-083 (CLOC14.38): PRECEDENCE-aware operand paren elision —
-    // `a==(b+c)` → `a==b+c` (the inner op binds tighter than the
-    // outer). Extends gap-077/078 beyond the atomic-operand guard;
-    // needs an operator-precedence table.
-    ("precedence_operand", "gap-083: precedence-aware operand paren elision"),
+    // gap-083 RESOLVED in CLOC12.130 — precedence-aware operand paren
+    // elision. When the inner operator's minimum precedence is STRICTLY
+    // GREATER than the outer binary operator's precedence, the grouping
+    // parens are redundant: `a==(b+c)` → `a==b+c` (`+` prec 12 > `==`
+    // prec 9). Implemented via `binary_op_prec` + `min_toplevel_binary_prec`
+    // helpers in `whitespace_only.rs`. `minify_precedence_operand` ENFORCED.
     // gap-108 RESOLVED in CLOC12.111 — a single-statement DO-body block
     // is flattened — `do{x()}while(a)` -> `do x();while(a)` — the same
     // single-statement-block-flatten family as gap-074 (loop body),

--- a/code/specs/CLOC12-gaps.md
+++ b/code/specs/CLOC12-gaps.md
@@ -635,9 +635,17 @@ historical context with status `RESOLVED` and a link to the fix PR.
 
 ### gap-083 — precedence-aware operand paren elision
 
-- **Status:** OPEN (discovered CLOC14.38). `minify_precedence_operand` ignored.
+- **Status:** RESOLVED in CLOC12.130. `minify_precedence_operand` now ENFORCED.
+- **Resolution:** When a binary operator's parenthesised right operand has a minimum
+  top-level operator precedence STRICTLY GREATER than the outer binary operator, the
+  parens are dropped. `a==(b+c)` → `a==b+c` (outer `==` prec 9 < inner `+` prec 12).
+  `a*(b+c)` keeps its parens (outer `*` prec 13 > inner `+` prec 12). Implemented
+  by extending the gap-078 drop block in `whitespace_only.rs` with two new helpers:
+  `binary_op_prec` (precedence table for symbol binary ops) and
+  `min_toplevel_binary_prec` (depth-0 scan for minimum precedence in a span).
+  Only BINARY outer operators participate; prefix-unary ops are excluded.
 - **Input:** `var x=a==(b+c);` → **Upstream:** `var x=a==b+c;` (also `a||(b&&c)` → `a||b&&c`, `(a*b)+c` → `a*b+c`).
-- **What it needs:** The fuller version of gap-077/078, which only strip an ATOMIC (self-delimiting) operand. Upstream also strips when the parenthesised operand's lowest-precedence operator binds *at least as tightly* as the outer operator (so removing the parens does not change grouping): `+` binds tighter than `==`, `&&` tighter than `||`, `*` tighter than `+`. Needs an operator-precedence table and an "outer op" lookup on both the left (`(a*b)+c`) and right (`a==(b+c)`) operand sides. Must still KEEP `a*(b+c)`, `a-(b-c)` (associativity/precedence would change).
+- **What it needed:** The fuller version of gap-077/078, which only strip an ATOMIC (self-delimiting) operand. Upstream also strips when the parenthesised operand's lowest-precedence operator binds *at least as tightly* as the outer operator (so removing the parens does not change grouping): `+` binds tighter than `==`, `&&` tighter than `||`, `*` tighter than `+`. Needs an operator-precedence table and an "outer op" lookup on both the left (`(a*b)+c`) and right (`a==(b+c)`) operand sides. Must still KEEP `a*(b+c)`, `a-(b-c)` (associativity/precedence would change).
 
 ### gap-084 — nested double-paren full strip around var-init RHS
 


### PR DESCRIPTION
## Summary

- Implements **gap-083**: precedence-aware operand paren elision for binary operators
- When a binary operator's right operand is parenthesised and the inner expression's minimum operator precedence is **strictly greater** than the outer operator's precedence, the grouping parens are dropped
- `a==(b+c)` → `a==b+c` (`+` prec 12 > `==` prec 9 → drop)
- `a*(b+c)` stays `a*(b+c)` (`+` prec 12 < `*` prec 13 → keep)
- Removes `precedence_operand` from `IGNORE_FIXTURES` — fixture now ENFORCED
- Bumps closurec to **v0.130.0** (skips v0.129.0 reserved by concurrent PR #5784)

## Implementation

Two new helpers in [`whitespace_only.rs`](code/programs/rust/closurec/src/whitespace_only.rs):

| Helper | Purpose |
|---|---|
| `binary_op_prec(tok)` | Precedence table for JS binary symbol operators (`**`=14 down to `\|\|`=3); excludes assignment and comma |
| `min_toplevel_binary_prec(span)` | Depth-0 scan of a token span, returns minimum `binary_op_prec` found |

The existing gap-078 drop block gets a second check: after `is_safe_unary_paren_operand` fails, if the outer op is binary (`is_binary_sym`), call both helpers; drop the parens only if `inner_min_prec > outer_prec` (strictly).

Prefix-unary outer ops (`-`, `+`, `!`, `~`) are excluded — `-(b+c)` must not strip.

## Boundary cases tested

- `a==(b+c)` → `a==b+c` ✓ (strip — inner `+`12 > outer `==`9)
- `a*(b+c)` → `a*(b+c)` ✓ (keep — inner `+`12 < outer `*`13)
- `a==(b==c)` → `a==(b==c)` ✓ (keep — equal prec, conservative)
- `a||(b+c*d)` → `a||b+c*d` ✓ (min inner = `+`12 > outer `||`3)
- `a*(b+c&&d)` → `a*(b+c&&d)` ✓ (min inner = `&&`4 < outer `*`13)

## Test plan

- [ ] `cargo test` passes locally (640 unit + all diff fixtures, 0 failed, 0 ignored)
- [ ] `minify_precedence_operand` fixture (`var x=a==(b+c);` → `var x=a==b+c;`) enforced
- [ ] CI build green

🤖 Generated with [Claude Code](https://claude.com/claude-code)