### PR TITLE
[codex] Add Hue package release closure summary

### DIFF
--- a/code/packages/rust/hue-core/CHANGELOG.md
+++ b/code/packages/rust/hue-core/CHANGELOG.md
@@ -49,6 +49,8 @@ All notable changes to this package will be documented in this file.
   audit/signoff checks.
 - Hue package release signoff summaries that turn audit readiness into final
   package release signoff checks.
+- Hue package release closure summaries that turn signoff readiness into final
+  package release closure checks.
 - Hue discovery worker-run projection from generic `MdnsScanResult` envelopes,
   preserving scan parse failures as per-source D23 worker failures.
 - Hue discovery worker-run projection from aggregate `MdnsWorkerScanReport`

--- a/code/packages/rust/hue-core/README.md
+++ b/code/packages/rust/hue-core/README.md
@@ -89,6 +89,8 @@ packages a typed surface for:
   audit/signoff checks
 - Hue package release signoff summaries that turn audit readiness into final
   package release signoff checks
+- Hue package release closure summaries that turn signoff readiness into final
+  package release closure checks
 
 ## Dependencies
 

--- a/code/packages/rust/hue-core/src/lib.rs
+++ b/code/packages/rust/hue-core/src/lib.rs
@@ -2885,6 +2885,108 @@ pub fn hue_package_release_signoff_summary(
     HuePackageReleaseSignoffSummary::from_pairing_plan(plan)
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct HuePackageReleaseClosureSummary {
+    pub signoff_summary: HuePackageReleaseSignoffSummary,
+    pub required_closure_check_count: usize,
+    pub passed_closure_check_count: usize,
+    pub blocked_closure_check_count: usize,
+    pub release_signoff_ready: bool,
+    pub release_audit_ready: bool,
+    pub operator_ready: bool,
+    pub dispatch_ready: bool,
+    pub coordination_ready: bool,
+    pub review_queues_clear: bool,
+    pub publish_gate_ready: bool,
+    pub release_closure_ready: bool,
+}
+
+impl HuePackageReleaseClosureSummary {
+    pub fn from_pairing_plan(plan: &HueBridgePairingPlan) -> Self {
+        Self::from_signoff_summary(hue_package_release_signoff_summary(plan))
+    }
+
+    pub fn from_signoff_summary(signoff_summary: HuePackageReleaseSignoffSummary) -> Self {
+        let release_signoff_ready = signoff_summary.is_release_signoff_ready();
+        let release_audit_ready = !signoff_summary.needs_release_audit();
+        let operator_ready = !signoff_summary.needs_operator_readiness();
+        let dispatch_ready = !signoff_summary.needs_dispatch();
+        let coordination_ready = !signoff_summary.needs_coordination();
+        let review_queues_clear = !signoff_summary.needs_review_queue_clearance();
+        let publish_gate_ready = !signoff_summary.needs_publish_gate();
+        let checks = [
+            release_signoff_ready,
+            release_audit_ready,
+            operator_ready,
+            dispatch_ready,
+            coordination_ready,
+            review_queues_clear,
+            publish_gate_ready,
+        ];
+        let passed_closure_check_count = checks.iter().filter(|ready| **ready).count();
+        let required_closure_check_count = checks.len();
+        let blocked_closure_check_count = required_closure_check_count - passed_closure_check_count;
+        let release_closure_ready = blocked_closure_check_count == 0;
+
+        Self {
+            signoff_summary,
+            required_closure_check_count,
+            passed_closure_check_count,
+            blocked_closure_check_count,
+            release_signoff_ready,
+            release_audit_ready,
+            operator_ready,
+            dispatch_ready,
+            coordination_ready,
+            review_queues_clear,
+            publish_gate_ready,
+            release_closure_ready,
+        }
+    }
+
+    pub fn is_release_closure_ready(self) -> bool {
+        self.release_closure_ready
+    }
+
+    pub fn has_blocked_closure_checks(self) -> bool {
+        self.blocked_closure_check_count > 0
+    }
+
+    pub fn needs_release_signoff(self) -> bool {
+        !self.release_signoff_ready
+    }
+
+    pub fn needs_release_audit(self) -> bool {
+        !self.release_audit_ready
+    }
+
+    pub fn needs_operator_readiness(self) -> bool {
+        !self.operator_ready
+    }
+
+    pub fn needs_dispatch(self) -> bool {
+        !self.dispatch_ready
+    }
+
+    pub fn needs_coordination(self) -> bool {
+        !self.coordination_ready
+    }
+
+    pub fn needs_review_queue_clearance(self) -> bool {
+        !self.review_queues_clear
+    }
+
+    pub fn needs_publish_gate(self) -> bool {
+        !self.publish_gate_ready
+    }
+}
+
+pub fn hue_package_release_closure_summary(
+    plan: &HueBridgePairingPlan,
+) -> HuePackageReleaseClosureSummary {
+    HuePackageReleaseClosureSummary::from_pairing_plan(plan)
+}
+
 fn descriptor_declares_capability(descriptor: &IntegrationDescriptor, capability_id: &str) -> bool {
     descriptor
         .capabilities
@@ -7172,6 +7274,89 @@ mod tests {
         assert!(!summary.release_signoff_ready);
         assert!(!summary.is_release_signoff_ready());
         assert!(summary.has_blocked_signoff_checks());
+        assert!(summary.needs_release_audit());
+        assert!(summary.needs_operator_readiness());
+        assert!(summary.needs_dispatch());
+        assert!(summary.needs_coordination());
+        assert!(summary.needs_review_queue_clearance());
+        assert!(summary.needs_publish_gate());
+    }
+
+    #[test]
+    fn hue_package_release_closure_summary_reports_ready_closure() {
+        let plan = hue_pairing_plan_for_discovered_bridge(
+            DiscoveredHueBridge {
+                bridge_id: "001788fffeabcdef".to_string(),
+                address: "https://192.0.2.10".to_string(),
+                hardware_model: Some("BSB002".to_string()),
+                firmware_version: Some("1.60".to_string()),
+            },
+            "chief-of-staff",
+            "desk",
+        );
+
+        let summary = hue_package_release_closure_summary(&plan);
+
+        assert_eq!(
+            summary.signoff_summary,
+            hue_package_release_signoff_summary(&plan)
+        );
+        assert_eq!(summary.required_closure_check_count, 7);
+        assert_eq!(summary.passed_closure_check_count, 7);
+        assert_eq!(summary.blocked_closure_check_count, 0);
+        assert!(summary.release_signoff_ready);
+        assert!(summary.release_audit_ready);
+        assert!(summary.operator_ready);
+        assert!(summary.dispatch_ready);
+        assert!(summary.coordination_ready);
+        assert!(summary.review_queues_clear);
+        assert!(summary.publish_gate_ready);
+        assert!(summary.release_closure_ready);
+        assert!(summary.is_release_closure_ready());
+        assert!(!summary.has_blocked_closure_checks());
+        assert!(!summary.needs_release_signoff());
+        assert!(!summary.needs_release_audit());
+        assert!(!summary.needs_operator_readiness());
+        assert!(!summary.needs_dispatch());
+        assert!(!summary.needs_coordination());
+        assert!(!summary.needs_review_queue_clearance());
+        assert!(!summary.needs_publish_gate());
+    }
+
+    #[test]
+    fn hue_package_release_closure_summary_routes_blocked_closure() {
+        let mut plan = hue_pairing_plan_for_discovered_bridge(
+            DiscoveredHueBridge {
+                bridge_id: "001788fffeabcdef".to_string(),
+                address: "https://192.0.2.10".to_string(),
+                hardware_model: Some("BSB002".to_string()),
+                firmware_version: Some("1.60".to_string()),
+            },
+            "chief-of-staff",
+            "desk",
+        );
+        plan.bridge.address = None;
+        plan.registration_request.path = "/wrong/api".to_string();
+        plan.application_key_header = "x-application-key".to_string();
+        plan.event_stream_path = "/wrong/eventstream".to_string();
+        plan.requires_user_presence = false;
+
+        let summary = HuePackageReleaseClosureSummary::from_pairing_plan(&plan);
+
+        assert_eq!(summary.required_closure_check_count, 7);
+        assert_eq!(summary.passed_closure_check_count, 0);
+        assert_eq!(summary.blocked_closure_check_count, 7);
+        assert!(!summary.release_signoff_ready);
+        assert!(!summary.release_audit_ready);
+        assert!(!summary.operator_ready);
+        assert!(!summary.dispatch_ready);
+        assert!(!summary.coordination_ready);
+        assert!(!summary.review_queues_clear);
+        assert!(!summary.publish_gate_ready);
+        assert!(!summary.release_closure_ready);
+        assert!(!summary.is_release_closure_ready());
+        assert!(summary.has_blocked_closure_checks());
+        assert!(summary.needs_release_signoff());
         assert!(summary.needs_release_audit());
         assert!(summary.needs_operator_readiness());
         assert!(summary.needs_dispatch());


### PR DESCRIPTION
## Summary
- Add a Hue package release closure summary that wraps release signoff readiness into a final package release closure gate.
- Expose closure readiness and blocker helpers for signoff, audit, operator, dispatch, coordination, review queue, and publish gate state.
- Document the new Hue package release closure surface in the crate README and changelog.

## Validation
- `cargo fmt --manifest-path code\packages\rust\hue-core\Cargo.toml`
- `cargo test --manifest-path code\packages\rust\hue-core\Cargo.toml`
- `git diff --check -- code\packages\rust\hue-core\src\lib.rs code\packages\rust\hue-core\README.md code\packages\rust\hue-core\CHANGELOG.md`