### PR TITLE
feat(visicalc-compose): VisiCalc Compose computes live on the shared Rust engine via Java FFM

### DIFF
--- a/demo/visicalc-compose/.gitignore
+++ b/demo/visicalc-compose/.gitignore
@@ -5,3 +5,8 @@ build/
 *.iml
 local.properties
 out/
+
+# Vendored engine — the C ABI dynamic library the Java FFM API loads, built
+# by scripts/build.sh from the spreadsheet-capi crate (cdylib). A build
+# artifact, like the SwiftUI/Qt demos' Vendor/.
+native/

--- a/demo/visicalc-compose/README.md
+++ b/demo/visicalc-compose/README.md
@@ -1,82 +1,86 @@
-# VisiCalc — Compose for Desktop demo
+# VisiCalc — Compose for Desktop demo (live, on the Rust engine)
 
-Sixth cross-backend visual demo (Phase 2 / VC2-compose), running on
-[Compose Multiplatform for Desktop](https://www.jetbrains.com/lp/compose-multiplatform/).
+The Compose Multiplatform (Desktop) VisiCalc demo, now **computing on the shared
+Rust `spreadsheet-core` engine** through its C ABI (`spreadsheet-capi`), reached
+via the **Java Foreign Function & Memory API** — the zero-JNI path Compose and
+Android use. The same engine the SwiftUI / Qt demos link natively, the Flutter
+demo loads via dart:ffi, and the web demos run as WebAssembly. Fourth native
+backend on the one engine.
 
 ## What it shows
 
-A `Window` (from `androidx.compose.ui.window`) containing:
+A `Window` (from `androidx.compose.ui.window`) mounting the auto-generated
+`FormulaBar` and `Grid` composables (`src/main/kotlin/generated/`, produced by
+`mosaic-compile --backend compose` from the shared `demo/visicalc/mosaic/*`
+sources).
 
-- A hand-written **`FormulaBar`** composable
-  (`src/main/kotlin/FormulaBar.kt`) — placeholder for the eventual
-  `mosaic-compile --backend compose` output.
-- A hand-written **`Grid`** composable (`src/main/kotlin/Grid.kt`),
-  visually matching what the eventual Compose Grid emitter should
-  produce.
+- The grid renders **engine-computed** values: the classic cross-footing budget
+  where column E totals each row, row 5 totals each column, and E5 is the grand
+  total (169) — all formulas evaluated by the Rust engine, not hard-coded.
+- Editing the formula bar writes through to the engine via
+  `SpreadsheetModel.setCell`; the host rebuilds `viewportRows` from the engine,
+  so Compose recomposes the grid with the recomputed values.
 
-Tap a cell — the formula bar updates with its value, the selected
-cell gets the excel-blue highlight. Type in the formula bar — it
-updates the local `mutableStateOf`.
+## How it's wired to the engine
 
-5×5 sample spreadsheet hard-coded in `src/main/kotlin/Main.kt`'s
-`sampleRows`, matching the data in every other VisiCalc demo so all
-seven look visually identical.
-
-## What this demo does NOT yet do
-
-- **No `mosaic-compile --backend compose`** exists in the repo.
-  Everything in `src/main/kotlin/` is hand-written.  When the
-  Compose emitter lands, `FormulaBar.kt` will be replaced by
-  `src/main/kotlin/generated/FormulaBar.kt` and this demo will
-  shift to a half-generated, half-hand-written shape like
-  `demo/visicalc-swiftui` does today.
-- **No strict-Flux dispatch yet.**  Local state via
-  `remember { mutableStateOf(...) }` for v0.1.0.  When the Compose
-  emitter is generating a real `dispatch: (Event) -> Unit`
-  parameter, the host will switch to a `MosaicStore<AppState>` from
-  the `mosaic-flux-compose` runtime (which is already pulled in as
-  an `includeBuild` composite-build dep, just not exercised yet).
-
-## How to run the app
-
-```bash
-./gradlew run                  # launches the desktop window
-./gradlew packageDistributionForCurrentOS    # native installer
+```
+Compose composables (generated)  ──  SpreadsheetModel / SpreadsheetSession (Engine.kt)
+   Grid(viewportRows = …)            │  sc_set_cell / sc_get_value … (Java FFM, String↔char*)
+                                     ▼
+   native/libspreadsheet_capi.dylib  ←  spreadsheet-capi (Rust C ABI)  ←  spreadsheet-core
 ```
 
-Compose Multiplatform handles the JVM + native bundling for macOS
-(`.dmg`), Linux (`.deb`), and Windows (`.msi`).
+`Engine.kt` binds the C ABI with `java.lang.foreign` (`Linker`/`SymbolLookup`/
+`Arena`) — **no third-party FFI dependency** — and maps the engine's JSON value
+shape into display text.
 
-## Prerequisites
+## Build, test, run
 
-- JDK 17+ (Compose 1.6 requires Java 17 minimum).
-- Gradle is fetched automatically by `./gradlew`; no system install
-  needed.
-- macOS / Linux / Windows.  No Android SDK required — Compose
-  Multiplatform for Desktop targets the JVM directly.
+Requires **JDK 21+** (the Java FFM API is preview on 21, final on 22) and a Rust
+toolchain to build the engine.
+
+```bash
+bash scripts/build.sh    # regenerate composables + build & vendor the engine (cdylib)
+bash scripts/verify.sh   # HEADLESS: compile Engine.kt + smoke, run via FFM — proves
+                         #   the grid is engine-computed and recomputes on edit
+gradle --no-daemon run   # launch the desktop window (FFM run args set in build.gradle.kts)
+```
+
+`scripts/verify.sh` compiles `Engine.kt` + `test/EngineSmoke.kt` with `kotlinc`
+(no Compose, no Gradle) and runs them with `--enable-preview
+--enable-native-access=ALL-UNNAMED`, loading the vendored engine. It asserts the
+grid is engine-computed (E1 = 38, A5 = 39, E5 = 169), that editing A1 15 → 115
+recomputes the totals (E5 → 269), and that a formula computes with binary-op
+error propagation (`=1/0` → `#DIV/0!`, and `=A1+1` over it → `#DIV/0!`).
 
 ## Why "Compose for Desktop" rather than Jetpack Compose for Android?
 
 Same `androidx.compose.*` packages, same composable functions, same
-`MaterialTheme`.  The runtime API is identical.  We target Desktop
-here so the demo runs locally with no emulator and screenshots come
-out of a real OS window.  An Android variant is a straight port:
-swap `WindowGroup`/`Window` for an `Activity` + `setContent`, the
-composables themselves are unchanged.
+`MaterialTheme`.  The runtime API is identical.  We target Desktop here so the
+demo runs locally with no emulator.  An Android variant is a straight UI port
+(swap `Window` for an `Activity` + `setContent`) — the one engine difference is
+that Android's runtime has no Java FFM, so the engine would be reached through a
+thin **JNI** bridge over the same C ABI, with the Rust library cross-compiled to
+a per-ABI `.so` and bundled under `jniLibs/`. The C ABI is unchanged; only the
+binding mechanism differs (FFM on the JVM, JNI on Android).
 
 ## File tree
 
 ```
 demo/visicalc-compose/
 ├── README.md                     ← this file
-├── BUILD                          ← `./gradlew run` from the build-tool
-├── .gitignore                     ← .gradle/, .gradle-out/, build/, etc.
+├── BUILD                          ← `gradle run` from the build-tool
+├── .gitignore                     ← .gradle/, .gradle-out/, build/, native/, …
 ├── settings.gradle.kts            ← includes ../../code/packages/kotlin/mosaic-flux-compose
-├── build.gradle.kts               ← kotlin("jvm") + org.jetbrains.compose plugin
+├── build.gradle.kts              ← kotlin("jvm") + compose plugin; JDK 21 + FFM run args
+├── native/                        ← vendored libspreadsheet_capi.* (git-ignored)
 ├── scripts/
-│   └── build.sh                   ← stub for future mosaic-compile --backend compose
+│   ├── build.sh                  ← mosaic-compile --backend compose + build/vendor engine
+│   └── verify.sh                 ← headless FFM smoke (kotlinc + java --enable-preview)
+├── test/
+│   └── EngineSmoke.kt            ← asserts the grid is engine-computed + recomputes
 └── src/main/kotlin/
-    ├── Main.kt                    ← `application { Window { ... } }`
-    ├── FormulaBar.kt              ← hand-written FormulaBar composable
-    └── Grid.kt                    ← hand-written Grid composable
+    ├── Main.kt                   ← `application { Window { ... } }`, binds the engine model
+    ├── Engine.kt                 ← Java FFM bindings + SpreadsheetModel
+    └── generated/                ← FormulaBar.kt + Grid.kt (mosaic-compile output)
 ```

--- a/demo/visicalc-compose/build.gradle.kts
+++ b/demo/visicalc-compose/build.gradle.kts
@@ -42,24 +42,33 @@ dependencies {
     implementation("org.mosaic.flux:mosaic-flux-compose:0.1.0")
 }
 
+// Target JDK 21: the engine is reached through the Java Foreign Function &
+// Memory API (Engine.kt), which is preview on JDK 21 and final on JDK 22.
 kotlin {
     compilerOptions {
-        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17)
+        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21)
     }
 }
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_17
-    targetCompatibility = JavaVersion.VERSION_17
+    sourceCompatibility = JavaVersion.VERSION_21
+    targetCompatibility = JavaVersion.VERSION_21
 }
 
 compose.desktop {
     application {
         mainClass = "MainKt"
 
-        // Native-distribution packaging (.dmg / .msi / .deb) is
-        // intentionally left unconfigured for v0.1.0.  The demo's
-        // sole job is to render the window via `./gradlew run`; the
-        // packaging story belongs to a follow-up PR.
+        // The demo computes on the Rust engine through the Java FFM API (see
+        // src/main/kotlin/Engine.kt). FFM is a preview feature on JDK 21, so
+        // pass --enable-preview at run time; --enable-native-access silences the
+        // restricted-method warning. (Both become unnecessary on JDK 22+, where
+        // FFM is final.) Engine.kt loads native/libspreadsheet_capi.* relative
+        // to the run directory.
+        jvmArgs += listOf("--enable-preview", "--enable-native-access=ALL-UNNAMED")
+
+        // Native-distribution packaging (.dmg / .msi / .deb) is intentionally
+        // left unconfigured; the demo's job is to render the window via
+        // `gradle run`.
     }
 }

--- a/demo/visicalc-compose/scripts/build.sh
+++ b/demo/visicalc-compose/scripts/build.sh
@@ -88,9 +88,25 @@ TMP="$OUT_DIR/Grid.kt.tmp"
 } > "$TMP"
 mv "$TMP" "$OUT_DIR/Grid.kt"
 
-echo "Done. Generated:"
+echo "Building the spreadsheet engine (Rust → dynamic lib) and vendoring it..."
+# The C ABI dynamic library the Kotlin host loads through the Java FFM API (see
+# Engine.kt), built from the spreadsheet-capi crate (cdylib) and copied into
+# native/ (git-ignored). Java FFM's SymbolLookup.libraryLookup needs a
+# .dylib/.so/.dll, the same dynamic packaging the Flutter demo uses.
+RUST="$REPO_ROOT/code/packages/rust"
+(cd "$RUST" && cargo build -p spreadsheet-capi --release)
+mkdir -p "$DEMO_DIR/native"
+case "$(uname -s)" in
+  Darwin) LIB="libspreadsheet_capi.dylib" ;;
+  *)      LIB="libspreadsheet_capi.so" ;;
+esac
+cp "$RUST/target/release/$LIB" "$DEMO_DIR/native/$LIB"
+
+echo "Done. Generated composables + vendored engine:"
 ls -la "$OUT_DIR"
+ls -la "$DEMO_DIR/native"
 echo
-echo "To run the demo:"
-echo "  cd $DEMO_DIR"
-echo "  gradle --no-daemon run"
+echo "Verify (headless: grid is engine-computed + recomputes; needs JDK 21+):"
+echo "  cd $DEMO_DIR && bash scripts/verify.sh"
+echo "Run the desktop app (needs JDK 21+ for the FFM API):"
+echo "  cd $DEMO_DIR && gradle --no-daemon run"

--- a/demo/visicalc-compose/scripts/verify.sh
+++ b/demo/visicalc-compose/scripts/verify.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+#
+# verify.sh — headless proof that the Compose VisiCalc demo does REAL formula
+# work on the shared Rust engine, with no Compose/Gradle in the loop.
+#
+# It compiles the engine glue (Engine.kt) plus the smoke harness
+# (test/EngineSmoke.kt) — both plain Kotlin, no Compose — with kotlinc, then
+# runs them on the JVM with the Java FFM API enabled, loading the vendored
+# engine library. This is the Compose equivalent of the SwiftUI demo's
+# `swift test`, the Qt demo's tst_model, and the Flutter demo's `flutter test`.
+#
+# Requires: JDK 21+ (the FFM API is preview in 21, stable in 22) and kotlinc.
+# Run scripts/build.sh first so native/libspreadsheet_capi.* exists.
+#
+# Usage:
+#   cd demo/visicalc-compose && bash scripts/verify.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DEMO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$DEMO_DIR"
+
+case "$(uname -s)" in
+  Darwin) LIB="native/libspreadsheet_capi.dylib" ;;
+  *)      LIB="native/libspreadsheet_capi.so" ;;
+esac
+if [ ! -f "$LIB" ]; then
+  echo "Engine library $LIB not found — run scripts/build.sh first." >&2
+  exit 1
+fi
+export CAPI_LIB="$DEMO_DIR/$LIB"
+
+OUT="$(mktemp -d)/smoke.jar"
+echo "Compiling Engine.kt + test/EngineSmoke.kt..."
+kotlinc src/main/kotlin/Engine.kt test/EngineSmoke.kt -include-runtime -d "$OUT"
+
+echo "Running the FFM smoke (JDK 21 preview FFM)..."
+java --enable-preview --enable-native-access=ALL-UNNAMED -cp "$OUT" EngineSmokeKt

--- a/demo/visicalc-compose/src/main/kotlin/Engine.kt
+++ b/demo/visicalc-compose/src/main/kotlin/Engine.kt
@@ -1,0 +1,167 @@
+// Engine.kt — the Compose/Kotlin host glue for the VisiCalc demo, computing on
+// the shared Rust `spreadsheet-core` engine through its C ABI (spreadsheet-capi).
+//
+// This is the Kotlin sibling of the SwiftUI demo's Engine.swift, the Qt demo's
+// SpreadsheetModel, and the Flutter demo's lib/engine.dart: it owns NO
+// spreadsheet logic. The Rust engine (cells, dependency graph, recalc, formulas)
+// lives behind the C ABI; this file marshals Kotlin Strings across it and maps
+// the engine's JSON value shape into display text — the same engine, and the
+// same JSON contract, the web demos drive as WebAssembly.
+//
+// It reaches the C ABI through the Java Foreign Function & Memory API
+// (java.lang.foreign) — the same zero-JNI path Compose Desktop and Android use.
+// On JDK 21 the FFM API is a preview feature, so run with
+//   --enable-preview --enable-native-access=ALL-UNNAMED
+// (it's stable from JDK 22). No third-party FFI dependency.
+
+import java.lang.foreign.Arena
+import java.lang.foreign.FunctionDescriptor
+import java.lang.foreign.Linker
+import java.lang.foreign.MemorySegment
+import java.lang.foreign.SymbolLookup
+import java.lang.foreign.ValueLayout
+import java.io.File
+
+/// A single spreadsheet session, owning the opaque C handle.
+class SpreadsheetSession(libraryPath: String = resolveLibraryPath()) : AutoCloseable {
+    private val linker = Linker.nativeLinker()
+    private val lib = SymbolLookup.libraryLookup(libraryPath, Arena.global())
+
+    private fun handle(name: String, desc: FunctionDescriptor) =
+        linker.downcallHandle(lib.find(name).get(), desc)
+
+    private val ptr = ValueLayout.ADDRESS
+    private val scNew = handle("sc_session_new", FunctionDescriptor.of(ptr))
+    private val scFree = handle("sc_session_free", FunctionDescriptor.ofVoid(ptr))
+    // sc_set_cell(session, a1, raw) -> char*
+    private val scSet = handle("sc_set_cell", FunctionDescriptor.of(ptr, ptr, ptr, ptr))
+    // sc_get_value(session, a1) -> char*  /  sc_get_raw(session, a1) -> char*
+    private val scGetValue = handle("sc_get_value", FunctionDescriptor.of(ptr, ptr, ptr))
+    private val scGetRaw = handle("sc_get_raw", FunctionDescriptor.of(ptr, ptr, ptr))
+    private val scStrFree = handle("sc_string_free", FunctionDescriptor.ofVoid(ptr))
+
+    private val session = scNew.invoke() as MemorySegment
+
+    /// Read an engine-returned char* into a Kotlin String and free it with the
+    /// engine's allocator (sc_string_free — NOT libc free). NULL becomes "".
+    private fun take(p: MemorySegment): String {
+        if (p.address() == 0L) return ""
+        // The returned pointer is unbounded; reinterpret so we can read the
+        // NUL-terminated string, then hand it back to the engine to free.
+        val s = p.reinterpret(Long.MAX_VALUE).getUtf8String(0)
+        scStrFree.invoke(p)
+        return s
+    }
+
+    fun setCell(a1: String, raw: String): String = Arena.ofConfined().use { a ->
+        take(scSet.invoke(session, a.allocateUtf8String(a1), a.allocateUtf8String(raw)) as MemorySegment)
+    }
+
+    fun getValueJson(a1: String): String = Arena.ofConfined().use { a ->
+        take(scGetValue.invoke(session, a.allocateUtf8String(a1)) as MemorySegment)
+    }
+
+    fun getRaw(a1: String): String = Arena.ofConfined().use { a ->
+        take(scGetRaw.invoke(session, a.allocateUtf8String(a1)) as MemorySegment)
+    }
+
+    /// The display string for a cell — what a spreadsheet should show. Parses
+    /// the engine's JSON (the fixed shape the TS/WASM/Swift/Qt/Flutter engines
+    /// emit); the keys are serde-sorted, so e.g. errors are {"code":…,"kind":…}.
+    fun display(a1: String): String {
+        val json = getValueJson(a1)
+        val kind = Regex("\"kind\":\"(\\w+)\"").find(json)?.groupValues?.get(1) ?: return ""
+        return when (kind) {
+            "empty" -> ""
+            "number" -> {
+                val raw = Regex("\"value\":(-?[0-9.eE+]+)").find(json)?.groupValues?.get(1)
+                    ?: return ""
+                val d = raw.toDouble()
+                // Show integers without a trailing ".0".
+                if (d == Math.floor(d) && Math.abs(d) < 1e15) d.toLong().toString() else d.toString()
+            }
+            "text" -> Regex("\"value\":\"(.*)\"").find(json)?.groupValues?.get(1) ?: ""
+            "boolean" -> if (json.contains("\"value\":true")) "TRUE" else "FALSE"
+            "error" -> Regex("\"code\":\"([^\"]+)\"").find(json)?.groupValues?.get(1) ?: "#ERR"
+            else -> ""
+        }
+    }
+
+    override fun close() {
+        scFree.invoke(session)
+    }
+
+    companion object {
+        /// Resolve the vendored engine library: an explicit CAPI_LIB env var, or
+        /// `native/libspreadsheet_capi.*` found by walking up from the working dir.
+        fun resolveLibraryPath(): String {
+            val os = System.getProperty("os.name").lowercase()
+            val name = when {
+                os.contains("mac") -> "libspreadsheet_capi.dylib"
+                os.contains("win") -> "spreadsheet_capi.dll"
+                else -> "libspreadsheet_capi.so"
+            }
+            System.getenv("CAPI_LIB")?.let { if (File(it).exists()) return it }
+            var dir: File? = File(System.getProperty("user.dir"))
+            repeat(5) {
+                val candidate = File(dir, "native/$name")
+                if (candidate.exists()) return candidate.absolutePath
+                dir = dir?.parentFile
+            }
+            return "native/$name"
+        }
+    }
+}
+
+/// An engine-backed 5×5 spreadsheet the Compose host drives. Mirrors the
+/// SwiftUI / Qt / Flutter models: seeds the cross-footing budget, exposes the
+/// computed display matrix, and writes through to the engine on edit.
+class SpreadsheetModel(
+    private val session: SpreadsheetSession = SpreadsheetSession(),
+) : AutoCloseable {
+
+    init {
+        seed()
+    }
+
+    /// The classic cross-footing budget — identical seed to every other demo:
+    /// column E totals each row, row 5 totals each column, E5 the grand total.
+    private fun seed() {
+        val cells = listOf(
+            "A1" to "15", "B1" to "3", "C1" to "12", "D1" to "8", "E1" to "=SUM(A1:D1)",
+            "A2" to "8", "B2" to "14", "C2" to "7", "D2" to "22", "E2" to "=SUM(A2:D2)",
+            "A3" to "12", "B3" to "9", "C3" to "18", "D3" to "6", "E3" to "=SUM(A3:D3)",
+            "A4" to "4", "B4" to "11", "C4" to "3", "D4" to "17", "E4" to "=SUM(A4:D4)",
+            "A5" to "=SUM(A1:A4)", "B5" to "=SUM(B1:B4)", "C5" to "=SUM(C1:C4)",
+            "D5" to "=SUM(D1:D4)", "E5" to "=SUM(E1:E4)",
+        )
+        for ((a1, raw) in cells) session.setCell(a1, raw)
+    }
+
+    /// Display matrix fed to the Grid: each row is [rowLabel, A, B, C, D, E].
+    fun viewportRows(): List<List<String>> = (0 until ROWS).map { r ->
+        listOf("${r + 1}") + (1..COLS).map { c -> session.display(address(r, c)) }
+    }
+
+    /// The raw source of the cell at display row/col (col 1..5; 0 = gutter).
+    fun rawAt(r: Int, c: Int): String = if (c < 1) "" else session.getRaw(address(r, c))
+
+    /// The value JSON of a cell — used by the verify harness to assert directly.
+    fun valueJson(a1: String): String = session.getValueJson(a1)
+
+    /// Write `raw` into the cell at display row/col. The caller rebuilds the
+    /// display matrix afterwards via [viewportRows].
+    fun setCell(r: Int, c: Int, raw: String) {
+        if (c >= 1) session.setCell(address(r, c), raw)
+    }
+
+    override fun close() = session.close()
+
+    companion object {
+        const val ROWS = 5
+        const val COLS = 5 // A..E
+
+        /// A1 address for grid display row `r` (0-based) and column `c` (1..5).
+        fun address(r: Int, c: Int): String = "${'A' + c - 1}${r + 1}"
+    }
+}

--- a/demo/visicalc-compose/src/main/kotlin/Main.kt
+++ b/demo/visicalc-compose/src/main/kotlin/Main.kt
@@ -46,19 +46,12 @@ import androidx.compose.ui.window.application
 import androidx.compose.ui.window.WindowState
 import androidx.compose.ui.window.rememberWindowState
 
-// The 5×5 sample dataset shared with every other visicalc-* demo.
-// Hard-coded here for the v0.1.0 visual parity exercise — when the
-// strict-Flux contract is wired up, this moves into `AppState.cells`.
-// The first cell of every row is the spreadsheet's row-number gutter
-// ("1".."5"), mirroring the row-label column the React / HTML / SwiftUI
-// demos render down the left edge.  The five data columns A–E follow.
-private val sampleRows: List<List<String>> = listOf(
-    listOf("1", "15", "3",  "12", "8",  "5"),
-    listOf("2", "8",  "14", "7",  "22", "11"),
-    listOf("3", "12", "9",  "18", "6",  "25"),
-    listOf("4", "4",  "11", "3",  "17", "9"),
-    listOf("5", "7",  "5",  "13", "10", "19"),
-)
+// The 5×5 spreadsheet is no longer hard-coded: it's computed by the shared Rust
+// engine, reached through the C ABI via the Java Foreign Function & Memory API
+// (see Engine.kt). The model seeds the same cross-footing budget every other
+// VC2-* demo shows (column E totals each row, row 5 totals each column,
+// E5 = 169), and editing the formula bar writes through to the engine and
+// recomputes every cell.
 
 fun main() = application {
     Window(
@@ -89,6 +82,12 @@ private fun VisiCalcApp() {
     // to `Double` and casts For-loop indices to `Double` too so
     // verbatim Expr like `r == editRow` compiles cleanly).  The
     // host mirrors that on its state for a clean pass-through.
+    // The engine-backed model. Its display matrix is held in `viewportRows`
+    // state, rebuilt from the engine after every edit so Compose recomposes the
+    // grid with freshly-computed values.
+    val model = remember { SpreadsheetModel() }
+    var viewportRows by remember { mutableStateOf(model.viewportRows()) }
+
     var selectedRow by remember { mutableStateOf(0.0) }
     // Column 0 is the row-number gutter, so the first *data* column (A)
     // is index 1.  Start with A1 selected to match the sibling demos.
@@ -96,7 +95,8 @@ private fun VisiCalcApp() {
     var editRow     by remember { mutableStateOf(-1.0) }
     var editCol     by remember { mutableStateOf(-1.0) }
     var editContent by remember { mutableStateOf("") }
-    var formulaText by remember { mutableStateOf("=SUM(B1:B5)") }
+    // Start showing the selected cell's source (A1 → "15") in the bar.
+    var formulaText by remember { mutableStateOf(model.rawAt(0, 1)) }
 
     Column(modifier = Modifier.fillMaxSize().padding(16.dp)) {
         // Title row — kebab-cased label up top, matching the
@@ -119,9 +119,15 @@ private fun VisiCalcApp() {
                 dispatch = { event ->
                     when (event) {
                         is FormulaBarEvent.FormulaChange -> formulaText = event.value
-                        is FormulaBarEvent.Commit -> { /* no-op for v0.1.0 */ }
+                        is FormulaBarEvent.Commit -> {
+                            // Write the edit to the engine, recompute the grid,
+                            // and reflect the cell's canonicalised source.
+                            model.setCell(selectedRow.toInt(), selectedCol.toInt(), formulaText)
+                            viewportRows = model.viewportRows()
+                            formulaText = model.rawAt(selectedRow.toInt(), selectedCol.toInt())
+                        }
                         is FormulaBarEvent.Cancel ->
-                            formulaText = sampleRows[selectedRow.toInt()][selectedCol.toInt()]
+                            formulaText = model.rawAt(selectedRow.toInt(), selectedCol.toInt())
                     }
                 },
             )
@@ -135,7 +141,7 @@ private fun VisiCalcApp() {
                 // Leading "" is the empty header above the row-number
                 // gutter column; A–E label the five data columns.
                 columnHeaders = listOf("", "A", "B", "C", "D", "E"),
-                viewportRows = sampleRows,
+                viewportRows = viewportRows,
                 columnWidths = listOf(48.0, 96.0, 96.0, 96.0, 96.0, 96.0),
                 totalHeight = 0.0,
                 selectedRow = selectedRow,
@@ -148,12 +154,8 @@ private fun VisiCalcApp() {
                         is GridEvent.Navigate -> {
                             selectedRow = event.row
                             selectedCol = event.col
-                            val r = event.row.toInt()
-                            val c = event.col.toInt()
-                            if (r in sampleRows.indices &&
-                                c in sampleRows[r].indices) {
-                                formulaText = sampleRows[r][c]
-                            }
+                            // Pull the newly-selected cell's source into the bar.
+                            formulaText = model.rawAt(event.row.toInt(), event.col.toInt())
                         }
                         is GridEvent.FormulaChange -> editContent = event.value
                         is GridEvent.EditCommit -> {

--- a/demo/visicalc-compose/test/EngineSmoke.kt
+++ b/demo/visicalc-compose/test/EngineSmoke.kt
@@ -1,0 +1,60 @@
+// EngineSmoke.kt — headless proof that the Compose VisiCalc demo does REAL
+// formula work on the shared Rust engine, with no Compose UI in the loop. This
+// is the Kotlin sibling of the SwiftUI demo's `swift test`, the Qt demo's
+// tst_model, and the Flutter demo's engine_test.dart: it drives the same
+// engine-backed SpreadsheetModel the Compose UI binds to (Engine.kt) and asserts
+// the values are engine-computed and recompute on edit.
+//
+// It's a plain `fun main()` — NOT a Compose app — so it compiles with kotlinc
+// and runs on the JVM with the Java FFM API enabled, loading the vendored engine
+// library. scripts/verify.sh wires it up:
+//
+//   kotlinc src/main/kotlin/Engine.kt test/EngineSmoke.kt -include-runtime -d t.jar
+//   java --enable-preview --enable-native-access=ALL-UNNAMED -cp t.jar EngineSmokeKt
+//
+// A green run proves the Kotlin ↔ Java FFM ↔ C ABI ↔ Rust path end-to-end.
+
+private var failures = 0
+
+private fun check(label: String, got: String, want: String) {
+    val ok = got == want
+    if (!ok) failures++
+    println("${if (ok) "ok  " else "FAIL"}  $label: got=\"$got\" want=\"$want\"")
+}
+
+private fun checkContains(label: String, got: String, needle: String) {
+    val ok = got.contains(needle)
+    if (!ok) failures++
+    println("${if (ok) "ok  " else "FAIL"}  $label: \"$got\" contains \"$needle\"")
+}
+
+fun main() {
+    val model = SpreadsheetModel()
+
+    // Seeded cross-footing budget — computed by the engine, not hard-coded.
+    var rows = model.viewportRows()
+    check("E1 row total", rows[0][5], "38")   // 15+3+12+8
+    check("E2 row total", rows[1][5], "51")   // 8+14+7+22
+    check("A5 col total", rows[4][1], "39")   // 15+8+12+4
+    check("E5 grand total", rows[4][5], "169")
+    check("row-label gutter", rows[0][0], "1")
+
+    // Editing A1 (display row 0, col 1) 15 -> 115 recomputes every dependent.
+    model.setCell(0, 1, "115")
+    rows = model.viewportRows()
+    check("A1 after edit", rows[0][1], "115")
+    check("E1 after edit", rows[0][5], "138") // 115+3+12+8
+    check("A5 after edit", rows[4][1], "139") // 115+8+12+4
+    check("E5 after edit", rows[4][5], "269") // 138+51+45+35
+
+    // A formula that divides by zero, and an error propagating through a binary op.
+    model.setCell(0, 1, "=1/0")               // A1
+    checkContains("A1 div-by-0", model.valueJson("A1"), "#DIV/0!")
+    model.setCell(0, 2, "=A1+1")              // B1
+    checkContains("B1 propagated", model.valueJson("B1"), "#DIV/0!")
+    check("B1 display", model.viewportRows()[0][2], "#DIV/0!")
+
+    model.close()
+    println(if (failures == 0) "\nALL PASS" else "\n$failures FAILURE(S)")
+    kotlin.system.exitProcess(if (failures == 0) 0 else 1)
+}


### PR DESCRIPTION
## What

Wires the **Compose for Desktop VisiCalc demo** to the shared Rust `spreadsheet-core` engine through its C ABI (`spreadsheet-capi`), reached via the **Java Foreign Function & Memory API** — the zero-JNI path Compose/Android use. The same engine the SwiftUI and Qt demos link natively and the Flutter demo loads via dart:ffi. Compose is the **fourth native backend** doing real formula work on the one engine.

## How it's wired

```
Compose composables (generated)  ──  SpreadsheetModel / SpreadsheetSession (Engine.kt)
   Grid(viewportRows = …)            │  sc_set_cell / sc_get_value … (Java FFM, String↔char*)
                                     ▼
   native/libspreadsheet_capi.dylib  ←  spreadsheet-capi (Rust C ABI)  ←  spreadsheet-core
```

- `src/main/kotlin/Engine.kt` binds the C ABI with `java.lang.foreign` (`Linker`/`SymbolLookup`/`Arena`) — **no third-party FFI dependency**. Engine-returned strings are freed with `sc_string_free`; inputs are scoped to a confined `Arena`.
- `Main.kt`: the generated Grid binds `viewportRows` to the engine's computed matrix held in Compose state; FormulaBar commit → `model.setCell` → host rebuilds `viewportRows` → grid recomposes. No more hard-coded `sampleRows`.
- `scripts/build.sh` builds `spreadsheet-capi` as a **cdylib** and vendors it into `native/` (git-ignored).
- `build.gradle.kts` targets JDK 21 and passes `--enable-preview --enable-native-access=ALL-UNNAMED` at run (FFM is preview on 21, final on 22).

## Verification

- **`scripts/verify.sh` 12/12 green** from a clean build: compiles `Engine.kt` + `test/EngineSmoke.kt` with kotlinc and runs them via FFM, asserting the grid is engine-computed (E1=38, A5=39, E5=169), recomputes on edit (A1 15→115 ⇒ E5 269), and propagates a binary-op error (`=1/0`→`#DIV/0!`, `=A1+1` over it →`#DIV/0!`). This is the Compose analog of the SwiftUI/Qt/Flutter headless proofs.
- `/security-review` **passed** — both sides of the FFI boundary checked: read-before-free in `take()`, single `sc_string_free` (matches Rust `CString::from_raw`), confined-arena inputs (Rust copies them), null-safe, no injection/ReDoS.

## Android note

The Android sibling reaches the **same C ABI** via a thin **JNI** bridge (Android's runtime has no Java FFM), with the Rust library cross-compiled to a per-ABI `.so` under `jniLibs/`. The C ABI is unchanged; only the binding mechanism differs. Documented in the README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)