### PR TITLE
feat(lang-full): E2 (1/6) — vm-core masks narrow-width register arithmetic

### DIFF
--- a/code/packages/rust/vm-core/CHANGELOG.md
+++ b/code/packages/rust/vm-core/CHANGELOG.md
@@ -1,5 +1,34 @@
 # Changelog — vm-core
 
+## [0.5.0] — 2026-06-14 (LANG-FULL E2 — register width & wrap, backend 1 of 6)
+
+### Added — narrow-width integer arithmetic wraps mod-2ⁿ by `type_hint`
+
+Until now integer arithmetic ran at full `i64` width regardless of the
+instruction's `type_hint`, so `200u8 + 100u8` produced `300` instead of `44`
+and `~x` on a `u8` flipped 64 bits.  Narrow types existed only at the byte-tape
+boundary (`store_byte` masks `& 0xFF`).
+
+This is the first backend in the **E2 (integer width & wrap)** enabler: a new
+`mask_result(v, type_hint, u8_wrap)` masks every integer arithmetic / bitwise /
+shift result to the width its `type_hint` names —
+
+| hint | mask | example |
+|------|------|---------|
+| `u4` | `& 0xF` | `10 + 10` → `4` |
+| `u8` | `& 0xFF` | `200 + 100` → `44`; `~0` → `255`; `1 << 8` → `0` |
+| `u16` | `& 0xFFFF` | `60000 + 10000` → `4464` |
+| `u32` | `& 0xFFFF_FFFF` | `2³²` → `0` |
+| other (`i64`/`u64`/`any`) | — | full machine width, unchanged |
+
+— the register-arithmetic analogue of the byte-tape `store_byte` mask.  Applied
+in `add`/`sub`/`mul`/`div`/`mod`/`neg`/`and`/`or`/`xor`/`not`/`shl`/`shr`.  The
+legacy whole-module `u8_wrap` flag (Brainfuck's cell wrap, whose frontend widens
+its hint to `i64`) is preserved and applied last, so Brainfuck is unaffected.
+Signed narrow types (`i8`/`i16`/`i32`) are intentionally not masked here —
+correct two's-complement wrap needs sign-extension via the `cast` op; the
+LANG-FULL frontends use the unsigned widths.
+
 ## [0.4.0] — 2026-06-13 (LANG-MATRIX Phase V — byte-tape ops; Brainfuck on the VM)
 
 Adds the lowered byte-tape ops to the dispatch table so the **generic** register VM runs

--- a/code/packages/rust/vm-core/Cargo.toml
+++ b/code/packages/rust/vm-core/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "vm-core"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
-description = "Generic register interpreter for InterpreterIR — the vm-core of the LANG pipeline.  v0.4.0 (LANG-MATRIX Phase V): adds the byte-tape ops alloc_bytes/load_byte/store_byte over the flat memory address space (a cell is memory[base+idx], store_byte masks to a byte for Brainfuck's 8-bit wrap), so the generic VM runs Brainfuck — every matrix language now runs on this one register interpreter."
+description = "Generic register interpreter for InterpreterIR — the vm-core of the LANG pipeline.  v0.5.0 (LANG-FULL E2 — register width & wrap, backend 1/6): integer arithmetic / bitwise / shift handlers now mask their result to the width named by the instruction's type_hint (u4→&0xF, u8→&0xFF, u16, u32), so a u8-typed `add` of 200+100 yields 44 and `~x` on a u8 flips 8 bits — the register-arithmetic analogue of the existing byte-tape store_byte mask, on top of the legacy whole-module u8_wrap flag.  v0.4.0 (LANG-MATRIX Phase V): adds the byte-tape ops alloc_bytes/load_byte/store_byte over the flat memory address space (a cell is memory[base+idx], store_byte masks to a byte for Brainfuck's 8-bit wrap), so the generic VM runs Brainfuck — every matrix language now runs on this one register interpreter."
 
 [lib]
 name = "vm_core"

--- a/code/packages/rust/vm-core/README.md
+++ b/code/packages/rust/vm-core/README.md
@@ -68,6 +68,13 @@ masks to a byte; this is how Brainfuck runs on the VM, v0.4.0), `call`/`call_bui
 here unchanged — the matrix's six scalar languages all share this one interpreter
 (LANG-MATRIX Phase V).
 
+Integer arithmetic, bitwise, and shift results are **masked to the width named by
+the instruction's `type_hint`** (`u4`→`& 0xF`, `u8`→`& 0xFF`, `u16`, `u32`), so a
+`u8`-typed `add` of `200 + 100` wraps to `44` and `~x` on a `u8` flips 8 bits
+(LANG-FULL E2). Hints of `i64`/`u64`/`any` keep full machine width. This is the
+register-arithmetic analogue of the byte-tape `store_byte` mask, on top of the
+whole-module `with_u8_wrap()` flag below.
+
 ### `VMFrame` — per-call state
 
 One frame per active function call.  Holds a flat `registers: Vec<Value>` and a

--- a/code/packages/rust/vm-core/src/core.rs
+++ b/code/packages/rust/vm-core/src/core.rs
@@ -955,4 +955,79 @@ mod tests {
         let mut vm = VMCore::new();
         assert_eq!(vm.execute(&mut module, "main", &[]).unwrap(), Some(Value::Int(0)));
     }
+
+    // ---- E2: register-arithmetic width & wrap (mod-2ⁿ) ----
+
+    /// Run `op a b` with the given result `type_hint` and return the i64 value.
+    fn run_binop(op: &str, a: i64, b: i64, ty: &str) -> i64 {
+        let fn_ = IIRFunction::new(
+            "main", vec![], "i64",
+            vec![
+                IIRInstr::new("const", Some("a".into()), vec![Operand::Int(a)], "i64"),
+                IIRInstr::new("const", Some("b".into()), vec![Operand::Int(b)], "i64"),
+                IIRInstr::new(op, Some("r".into()),
+                    vec![Operand::Var("a".into()), Operand::Var("b".into())], ty),
+                IIRInstr::new("ret", None, vec![Operand::Var("r".into())], "i64"),
+            ],
+        );
+        let mut m = IIRModule::new("test", "test");
+        m.add_or_replace(fn_);
+        VMCore::new().execute(&mut m, "main", &[]).unwrap().unwrap().as_i64().unwrap()
+    }
+
+    /// Run `op a` (unary) with the given result `type_hint`.
+    fn run_unop(op: &str, a: i64, ty: &str) -> i64 {
+        let fn_ = IIRFunction::new(
+            "main", vec![], "i64",
+            vec![
+                IIRInstr::new("const", Some("a".into()), vec![Operand::Int(a)], "i64"),
+                IIRInstr::new(op, Some("r".into()), vec![Operand::Var("a".into())], ty),
+                IIRInstr::new("ret", None, vec![Operand::Var("r".into())], "i64"),
+            ],
+        );
+        let mut m = IIRModule::new("test", "test");
+        m.add_or_replace(fn_);
+        VMCore::new().execute(&mut m, "main", &[]).unwrap().unwrap().as_i64().unwrap()
+    }
+
+    #[test]
+    fn u8_arithmetic_wraps_mod_256() {
+        assert_eq!(run_binop("add", 200, 100, "u8"), 44);   // 300 & 0xFF
+        assert_eq!(run_binop("mul", 16, 16, "u8"), 0);      // 256 & 0xFF
+        assert_eq!(run_binop("sub", 0, 1, "u8"), 255);      // -1 & 0xFF
+        assert_eq!(run_binop("add", 255, 1, "u8"), 0);      // classic cell wrap
+    }
+
+    #[test]
+    fn u8_bitwise_not_flips_eight_bits() {
+        assert_eq!(run_unop("not", 0, "u8"), 255);          // ~0 over a byte
+        assert_eq!(run_unop("not", 0xF0, "u8"), 0x0F);
+    }
+
+    #[test]
+    fn u8_left_shift_masks_off_high_bits() {
+        assert_eq!(run_binop("shl", 1, 7, "u8"), 128);
+        assert_eq!(run_binop("shl", 1, 8, "u8"), 0);        // shifted past the byte
+        assert_eq!(run_binop("shl", 3, 6, "u8"), 192);      // 0b11000000
+    }
+
+    #[test]
+    fn u4_arithmetic_wraps_mod_16() {
+        assert_eq!(run_binop("add", 10, 10, "u4"), 4);      // 20 & 0xF
+        assert_eq!(run_unop("not", 0, "u4"), 15);
+    }
+
+    #[test]
+    fn u16_and_u32_widths_wrap() {
+        assert_eq!(run_binop("add", 60000, 10000, "u16"), 70000 & 0xFFFF); // 4464
+        assert_eq!(run_binop("mul", 0x1_0000, 0x1_0000, "u32"), 0);        // 2^32 & 0xFFFF_FFFF
+    }
+
+    #[test]
+    fn i64_hint_does_not_mask() {
+        // The width mask only fires for narrow hints; plain i64 keeps full width.
+        assert_eq!(run_binop("add", 200, 100, "i64"), 300);
+        assert_eq!(run_binop("mul", 16, 16, "i64"), 256);
+        assert_eq!(run_unop("not", 0, "i64"), -1);
+    }
 }

--- a/code/packages/rust/vm-core/src/dispatch.rs
+++ b/code/packages/rust/vm-core/src/dispatch.rs
@@ -128,9 +128,32 @@ fn resolve_src(frame: &VMFrame, srcs: &[Operand], idx: usize) -> Result<Value, V
 // Arithmetic helpers
 // ---------------------------------------------------------------------------
 
+/// Mask an integer result to the width named by an instruction's `type_hint`,
+/// then apply the legacy whole-module `u8_wrap` flag.
+///
+/// This is the register-arithmetic analogue of the byte-tape wrap (`store_byte`
+/// masks `& 0xFF`): a `u8`-typed `add` of `200 + 100` yields `44`, a `u4` op
+/// wraps mod-16, and `~x` on a `u8` flips only its 8 low bits.  Widths follow
+/// the same table as [`handle_cast`] (`u4`→`0xF`, `u8`→`0xFF`, `u16`→`0xFFFF`,
+/// `u32`→`0xFFFF_FFFF`); any other hint (`i64`, `u64`, `any`, …) is left at full
+/// machine width.  Signed narrow types (`i8`/`i16`/`i32`) are intentionally NOT
+/// masked here — correct two's-complement wrap needs sign-extension, which the
+/// `cast` op provides; the LANG-FULL frontends use the unsigned widths.
+///
+/// `u8_wrap` is the existing Brainfuck cell flag (the BF frontend widens its
+/// cell hint to `i64`, so its wrap comes from the flag, not the hint); applying
+/// it last keeps that behaviour intact while the hint mask handles typed
+/// register arithmetic.
 #[inline]
-fn wrap_int(v: i64, u8_wrap: bool) -> Value {
-    if u8_wrap { Value::Int(v & 0xFF) } else { Value::Int(v) }
+fn mask_result(v: i64, type_hint: &str, u8_wrap: bool) -> Value {
+    let v = match type_hint {
+        "u4" => v & 0xF,
+        "u8" => v & 0xFF,
+        "u16" => v & 0xFFFF,
+        "u32" => v & 0xFFFF_FFFF,
+        _ => v,
+    };
+    Value::Int(if u8_wrap { v & 0xFF } else { v })
 }
 
 fn int_srcs(
@@ -174,7 +197,7 @@ macro_rules! binary_arith_handler {
                 let frame = ctx.frames.last().ok_or_else(|| VMError::Custom("no frame".into()))?;
                 int_srcs(frame, &instr.srcs)?
             };
-            let result = wrap_int(a $op b, ctx.u8_wrap);
+            let result = mask_result(a $op b, &instr.type_hint, ctx.u8_wrap);
             if let Some(dest) = &instr.dest {
                 ctx.frames.last_mut().unwrap().assign(dest, result.clone());
             }
@@ -193,7 +216,7 @@ fn handle_div(ctx: &mut DispatchCtx, instr: &IIRInstr) -> Result<Option<Value>, 
         int_srcs(frame, &instr.srcs)?
     };
     if b == 0 { return Err(VMError::DivisionByZero); }
-    let result = wrap_int(a / b, ctx.u8_wrap);
+    let result = mask_result(a / b, &instr.type_hint, ctx.u8_wrap);
     if let Some(dest) = &instr.dest {
         ctx.frames.last_mut().unwrap().assign(dest, result.clone());
     }
@@ -206,7 +229,7 @@ fn handle_mod(ctx: &mut DispatchCtx, instr: &IIRInstr) -> Result<Option<Value>, 
         int_srcs(frame, &instr.srcs)?
     };
     if b == 0 { return Err(VMError::DivisionByZero); }
-    let result = wrap_int(a % b, ctx.u8_wrap);
+    let result = mask_result(a % b, &instr.type_hint, ctx.u8_wrap);
     if let Some(dest) = &instr.dest {
         ctx.frames.last_mut().unwrap().assign(dest, result.clone());
     }
@@ -220,7 +243,7 @@ fn handle_neg(ctx: &mut DispatchCtx, instr: &IIRInstr) -> Result<Option<Value>, 
             .as_i64()
             .ok_or_else(|| VMError::Custom("neg on non-integer".into()))?
     };
-    let result = wrap_int(-a, ctx.u8_wrap);
+    let result = mask_result(-a, &instr.type_hint, ctx.u8_wrap);
     if let Some(dest) = &instr.dest {
         ctx.frames.last_mut().unwrap().assign(dest, result.clone());
     }
@@ -236,7 +259,10 @@ macro_rules! binary_bitwise_handler {
                 let frame = ctx.frames.last().ok_or_else(|| VMError::Custom("no frame".into()))?;
                 int_srcs(frame, &instr.srcs)?
             };
-            let result = Value::Int(a $op b);
+            // Mask to the result width so a narrow-typed bitwise op stays in
+            // range (`&`/`|`/`^` of in-range operands can't grow, but a typed
+            // result is kept canonical for downstream width-sensitive ops).
+            let result = mask_result(a $op b, &instr.type_hint, ctx.u8_wrap);
             if let Some(dest) = &instr.dest {
                 ctx.frames.last_mut().unwrap().assign(dest, result.clone());
             }
@@ -256,7 +282,9 @@ fn handle_not(ctx: &mut DispatchCtx, instr: &IIRInstr) -> Result<Option<Value>, 
             .as_i64()
             .ok_or_else(|| VMError::Custom("not on non-integer".into()))?
     };
-    let result = Value::Int(!a);
+    // Bitwise NOT is the op that most needs the width mask: `~x` on a `u8`
+    // must flip exactly 8 bits (`~0 == 255`, not `-1`).
+    let result = mask_result(!a, &instr.type_hint, ctx.u8_wrap);
     if let Some(dest) = &instr.dest {
         ctx.frames.last_mut().unwrap().assign(dest, result.clone());
     }
@@ -272,7 +300,9 @@ fn handle_shl(ctx: &mut DispatchCtx, instr: &IIRInstr) -> Result<Option<Value>, 
     // Clamp to 0..63 to prevent a panic in debug mode.  Rust panics on
     // `i64 << n` when n >= 64, and `n as u32` wraps negative n to a huge value.
     let shift = n.clamp(0, 63) as u32;
-    let result = Value::Int(a << shift);
+    // A left shift can push bits past the result width — mask them off so
+    // `1u8 << 7` stays `128` and `1u8 << 8` wraps to `0`.
+    let result = mask_result(a << shift, &instr.type_hint, ctx.u8_wrap);
     if let Some(dest) = &instr.dest {
         ctx.frames.last_mut().unwrap().assign(dest, result.clone());
     }
@@ -287,7 +317,9 @@ fn handle_shr(ctx: &mut DispatchCtx, instr: &IIRInstr) -> Result<Option<Value>, 
     };
     // Same clamp as shl — prevents panic for out-of-range shift amounts.
     let shift = n.clamp(0, 63) as u32;
-    let result = Value::Int(a >> shift);
+    // A right shift never grows the value, but mask for consistency so the
+    // result stays canonical for its width.
+    let result = mask_result(a >> shift, &instr.type_hint, ctx.u8_wrap);
     if let Some(dest) = &instr.dest {
         ctx.frames.last_mut().unwrap().assign(dest, result.clone());
     }

--- a/code/specs/LANG-FULL-IMPLEMENTATION.md
+++ b/code/specs/LANG-FULL-IMPLEMENTATION.md
@@ -63,10 +63,19 @@ multiple languages; close an enabler before the features that depend on it.
   source→real-backend→execute for one `Prog` per language; this campaign adds many. No
   separate harness PR — every feature PR adds its executed `Prog`(s). *(Mechanism exists;
   enforced by the definition of done.)*
-- **E2 — Integer width & wrap semantics.** Model `u4`/`u8`/`u16`/`u32` wraparound
-  (mod-2ⁿ) consistently across all backends, so Nib/Oct arithmetic and bitwise-NOT are
-  *correct*, not "collapse to i64." (Brainfuck already proves the u8-tape pattern; this
-  generalises it to register values.)
+- **E2 — Integer width & wrap semantics.** ◑ *In progress (approach B — each backend
+  masks narrow-typed arithmetic by `type_hint`, mirroring the byte-tape precedent).* Model
+  `u4`/`u8`/`u16`/`u32` wraparound (mod-2ⁿ) consistently across all backends, so Nib/Oct
+  arithmetic and bitwise-NOT are *correct*, not "collapse to i64." (Brainfuck already proves
+  the u8-tape pattern; this generalises it to register values.)
+  - ✅ **vm-core** (1/6) — `mask_result(v, type_hint, u8_wrap)` masks every arithmetic /
+    bitwise / shift result to the hint width; unit-tested (`200u8+100u8=44`, `~0u8=255`,
+    `1u8<<8=0`, u4/u16/u32). LLVM already wraps natively (`u8`→`i8`).
+  - ☐ **jit-core**, ☐ **iir-to-wasm**, ☐ **iir-to-jvm-class-file**, ☐ **iir-to-cil-bytecode**
+    (mirror the per-backend byte-tape mask onto register arithmetic).
+  - ☐ **Integration** — wire Nib (then Oct) to emit narrow `type_hint`s for narrow-declared
+    values + an executed matrix proof (`200u8+100u8=44`, Nib unary `~`) across all backends;
+    flip N3-`~`, Nib N6/N7, Oct.
 - **E3 — Real / floating-point (`f64`).** End-to-end f64 arithmetic, comparison, and
   literals on every backend. Unlocks ALGOL reals and BASIC floats. *(Audit which backends
   already emit f64 ops; extend the rest.)*


### PR DESCRIPTION
## What

**First backend of the E2 (integer width & wrap) enabler** — you chose **approach B** (each backend masks narrow-typed arithmetic by `type_hint`, mirroring the existing byte-tape precedent).

vm-core ran integer arithmetic at full `i64` width regardless of the instruction's `type_hint`, so `200u8 + 100u8` produced `300` instead of `44` and `~x` on a `u8` flipped 64 bits. Narrow widths only existed at the byte-tape boundary (`store_byte` masks `& 0xFF`).

This adds `mask_result(v, type_hint, u8_wrap)` and wires it into **every** integer handler (`add`/`sub`/`mul`/`div`/`mod`/`neg`/`and`/`or`/`xor`/`not`/`shl`/`shr`):

| hint | mask | example |
|------|------|---------|
| `u4` | `& 0xF` | `10 + 10` → `4` |
| `u8` | `& 0xFF` | `200 + 100` → `44`; `~0` → `255`; `1 << 8` → `0` |
| `u16` | `& 0xFFFF` | `60000 + 10000` → `4464` |
| `u32` | `& 0xFFFF_FFFF` | `2³²` → `0` |
| `i64`/`u64`/`any` | — | full machine width, unchanged |

The register-arithmetic analogue of the byte-tape `store_byte` mask. The legacy whole-module `u8_wrap` flag (Brainfuck's cell wrap) is preserved and applied last, so **Brainfuck is unaffected**. Signed narrow types (`i8`/`i16`/`i32`) are intentionally not masked here (two's-complement wrap needs sign-extension via `cast`); the LANG-FULL frontends use the unsigned widths.

## Tests
6 new vm-core unit tests (u8/u4/u16/u32 wrap across add/sub/mul/not/shl, and `i64`-hint-does-not-mask). Verified **no regression**: lang-aot matrix (Brainfuck `u8_wrap` intact), jit-core, and all 8 execution-heavy vm-core consumers (frontends + twig-vm + aot-core). clippy clean on vm-core code; `/security-review` passed.

## E2 roadmap (this is 1 of ~6 PRs)
- ✅ **vm-core** (this PR). LLVM already wraps natively (`u8`→`i8`).
- ☐ jit-core, iir-to-wasm, iir-to-jvm-class-file, iir-to-cil-bytecode (same per-backend mask).
- ☐ Integration: wire Nib/Oct to emit narrow `type_hint`s + an executed cross-backend matrix proof (`200u8+100u8=44`, Nib unary `~`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)