### PR TITLE
feat(mycin-cc2): fold dose feasibility into the treatment COP — undosable drugs leave the cover

### DIFF
--- a/code/specs/data/mycin-2026/treatment/antibiotics/chart_to_cop.py
+++ b/code/specs/data/mycin-2026/treatment/antibiotics/chart_to_cop.py
@@ -67,6 +67,8 @@ class Cop:
     organisms: list[str] = field(default_factory=list)
     exclusions: set[str] = field(default_factory=set)
     defeated: set[tuple[str, str]] = field(default_factory=set)
+    risks: set[str] = field(default_factory=set)             # CC-2 dose-ceiling risks
+    weight: float = 70.0                                      # kg; for the mg dose window
     constraints: list[dict] = field(default_factory=list)   # provenance per constraint
     discards: list[dict] = field(default_factory=list)       # facts not mapped + reason
 
@@ -109,6 +111,36 @@ def compile_cop(facts: list[ChartFact]) -> Cop:
             else:
                 cop.discards.append({"fact": f"allergy={f.value}",
                                      "reason": "no grounded drug-class exclusion rule for this allergen yet (CC-3)"})
+        elif f.kind == "renal_status":
+            # renal impairment shrinks the safe dose ceiling (CC-2 dose feasibility).
+            if f.value in ("renal_severe", "renal_moderate"):
+                cop.risks.add(f.value)
+                cop.constraints.append({"type": "dose_risk", "from": f"renal_status={f.value}",
+                                        "rule": "renal impairment lowers the safe dose ceiling", "span": f.span})
+            else:
+                cop.discards.append({"fact": f"renal_status={f.value}",
+                                     "reason": "unrecognized renal status (want renal_severe/renal_moderate)"})
+        elif f.kind == "interaction":
+            # an additive-toxicity interaction (e.g. another nephrotoxin) lowers the ceiling.
+            if f.value == "nephrotoxin_interaction":
+                cop.risks.add(f.value)
+                cop.constraints.append({"type": "dose_risk", "from": "interaction=nephrotoxin_interaction",
+                                        "rule": "additive nephrotoxicity lowers the safe dose ceiling", "span": f.span})
+            else:
+                cop.discards.append({"fact": f"interaction={f.value}",
+                                     "reason": "no grounded dose-interaction rule for this interaction yet (CC-3)"})
+        elif f.kind == "weight":
+            try:
+                w = float(f.value)
+            except (TypeError, ValueError):
+                w = float("nan")
+            # A body weight feeds the displayed mg dose range — accept only a finite,
+            # physiologically plausible value, else discard (don't anchor on a nonsense weight).
+            if 0.0 < w < 1000.0:
+                cop.weight = w
+            else:
+                cop.discards.append({"fact": f"weight={f.value}",
+                                     "reason": "implausible or non-numeric body weight (kg)"})
         elif f.kind == "culture_resistance":
             # value is "drug:organism" — an in-vitro resistance result voids that edge.
             drug, _, org = f.value.partition(":")
@@ -138,16 +170,39 @@ def compile_cop(facts: list[ChartFact]) -> Cop:
     return cop
 
 
+def dose_infeasible(cli: Path, drugs: list[str], risks: set[str], weight: float) -> dict:
+    """CC-2: the drugs with NO safe-and-effective dose for this patient — efficacy floor
+    exceeds the toxicity ceiling once `risks` shrink it (the engine's dose_window check
+    returns UNSAT). Returns {drug: window} for each excluded drug (for provenance)."""
+    out = {}
+    for d in drugs:
+        w = reg.dose_window(cli, d, weight, risks)
+        if not w["feasible"]:
+            out[d] = w
+    return out
+
+
 def derive(cli: Path, facts: list[ChartFact]) -> dict:
     """Compile the chart → COP, solve it, and return the regimen with provenance.
-    On INFEASIBLE, the engine's conflict core is surfaced (honest abstention)."""
+    Dose feasibility (CC-2) is folded into the cover: a drug with no safe-and-effective
+    dose under the chart's renal/interaction risks is excluded, so the optimizer
+    re-derives around it or abstains. On INFEASIBLE the engine's conflict core is
+    surfaced (honest abstention)."""
     cop = compile_cop(facts)
-    res = nsc.solve(cli, cop.organisms, cop.exclusions, cop.defeated)
+    # CC-2: drop drugs that can't be safely + effectively dosed for this patient.
+    undosable = dose_infeasible(cli, reg.candidates(cop.exclusions), cop.risks, cop.weight)
+    for d, w in undosable.items():
+        cop.constraints.append({
+            "type": "dose_infeasible", "from": f"risks={sorted(cop.risks)}", "detail": d,
+            "rule": f"no safe+effective dose: floor {w['floor_per_kg']} > ceiling "
+                    f"{w['ceiling_per_kg']} mg/kg"})
+    res = nsc.solve(cli, cop.organisms, cop.exclusions, cop.defeated, set(undosable))
     return {
         "regimen": res["regimen"], "outcome": res["outcome"],
         "cost": res.get("cost"), "conflict": res.get("iis"),
         "organisms": cop.organisms, "exclusions": sorted(cop.exclusions),
         "defeated": sorted(map(list, cop.defeated)),
+        "risks": sorted(cop.risks), "dose_infeasible": sorted(undosable),
         "constraints": cop.constraints, "discards": cop.discards,
     }
 

--- a/code/specs/data/mycin-2026/treatment/antibiotics/native_setcover.py
+++ b/code/specs/data/mycin-2026/treatment/antibiotics/native_setcover.py
@@ -54,7 +54,8 @@ def _sym(prefix: str, *parts: str) -> str:
 
 
 def emit_program(organisms: list[str], exclusions: set[str],
-                 defeated: set[tuple[str, str]] = frozenset()) -> tuple[str, dict, bool]:
+                 defeated: set[tuple[str, str]] = frozenset(),
+                 dose_excluded: set[str] = frozenset()) -> tuple[str, dict, bool]:
     """Emit the adj-lang integer program for this cover. Returns (program text,
     {x_var → drug}, feasible?) — feasible is False if some organism has no coverer
     (the program is then trivially infeasible and the engine will say so).
@@ -64,8 +65,15 @@ def emit_program(organisms: list[str], exclusions: set[str],
     drug. A defeated edge is dropped before the cover is built, so the regimen
     re-derives around it (MYCIN's "culture-directed" refinement of empiric therapy).
     A combination is defeated for an organism if any of its members is resistant to
-    that organism (the synergy rationale is undercut)."""
-    cands = reg.candidates(exclusions)  # CSF-penetrant, not contraindicated
+    that organism (the synergy rationale is undercut).
+
+    `dose_excluded` (CC-2) is the set of drugs that have NO safe-and-effective dose for
+    this patient — their efficacy floor exceeds their toxicity ceiling once the chart's
+    renal/interaction risks shrink it (dose_window UNSAT). Such a drug is dropped from the
+    candidate set before the cover is built, so the optimizer re-derives around it (or
+    abstains if it was load-bearing) — dose feasibility folded INTO the cover, not a
+    post-hoc warning."""
+    cands = [d for d in reg.candidates(exclusions) if d not in dose_excluded]
     lines: list[str] = []
     xvar = {d: _sym("x", d) for d in cands}
     var_to_drug = {v: d for d, v in xvar.items()}
@@ -117,10 +125,12 @@ def emit_program(organisms: list[str], exclusions: set[str],
 
 
 def solve(cli: Path, organisms: list[str], exclusions: set[str],
-          defeated: set[tuple[str, str]] = frozenset()) -> dict:
+          defeated: set[tuple[str, str]] = frozenset(),
+          dose_excluded: set[str] = frozenset()) -> dict:
     """Run the emitted program through the engine; return the engine's regimen.
-    `defeated` carries culture-sensitivity results (resistant drug→organism edges)."""
-    program, var_to_drug, _ = emit_program(organisms, exclusions, defeated)
+    `defeated` carries culture-sensitivity results (resistant drug→organism edges);
+    `dose_excluded` carries drugs with no safe-and-effective dose for this patient (CC-2)."""
+    program, var_to_drug, _ = emit_program(organisms, exclusions, defeated, dose_excluded)
     fd, name = tempfile.mkstemp(suffix=".adj", prefix="_tmp_native_", dir=HERE)
     p = Path(name)
     try:

--- a/code/specs/data/mycin-2026/treatment/antibiotics/test_chart_to_cop.py
+++ b/code/specs/data/mycin-2026/treatment/antibiotics/test_chart_to_cop.py
@@ -50,6 +50,37 @@ def test_culture_resistance_becomes_defeated_edge():
     assert any(c["type"] == "defeated_edge" for c in cop.constraints)
 
 
+def test_dose_risk_facts_become_dose_constraints():
+    # renal + interaction facts compile into dose-ceiling risks + provenance.
+    cop = cc.compile_cop([cc.ChartFact("renal_status", "renal_severe", "eGFR 12"),
+                          cc.ChartFact("interaction", "nephrotoxin_interaction", "tacrolimus"),
+                          cc.ChartFact("weight", "80")])
+    assert cop.risks == {"renal_severe", "nephrotoxin_interaction"}, cop.risks
+    assert cop.weight == 80.0
+    assert sum(c["type"] == "dose_risk" for c in cop.constraints) == 2
+    # an unrecognized renal/interaction value is discarded, not silently turned into a risk.
+    bad = cc.compile_cop([cc.ChartFact("interaction", "qt_additive")])
+    assert not bad.risks and any("qt_additive" in d["fact"] for d in bad.discards)
+
+
+def test_dose_infeasibility_folds_into_the_cover():
+    cli = decide_mod.find_cli()
+    if cli is None:
+        return
+    # Control: no dose risks → vancomycin is dosable → the standard regimen stands.
+    base = cc.derive(cli, [cc.ChartFact("age_band", "adult")])
+    assert base["regimen"] and "vancomycin" in base["regimen"] and not base["dose_infeasible"]
+    # Severe renal + a concurrent nephrotoxin push vancomycin's ceiling below its efficacy
+    # floor → no safe+effective dose → excluded from the cover → honest abstention (the
+    # combination that covers resistant pneumococcus needs vancomycin), never a toxic dose.
+    risky = cc.derive(cli, [cc.ChartFact("age_band", "adult"),
+                            cc.ChartFact("renal_status", "renal_severe"),
+                            cc.ChartFact("interaction", "nephrotoxin_interaction")])
+    assert "vancomycin" in risky["dose_infeasible"], risky["dose_infeasible"]
+    assert risky["regimen"] is None and risky["outcome"] == "infeasible", risky
+    assert any(c["type"] == "dose_infeasible" for c in risky["constraints"])
+
+
 def test_unmapped_fact_is_discarded_not_ignored():
     # No silent drops: a fact with no rule lands in discards WITH a reason.
     cop = cc.compile_cop([cc.ChartFact("age_band", "adult"),
@@ -85,6 +116,8 @@ def main() -> int:
     test_scenario_selection_and_provenance()
     test_allergy_becomes_exclusion()
     test_culture_resistance_becomes_defeated_edge()
+    test_dose_risk_facts_become_dose_constraints()
+    test_dose_infeasibility_folds_into_the_cover()
     test_unmapped_fact_is_discarded_not_ignored()
     test_engine_reproduces_existing_regimens()
     return 0


### PR DESCRIPTION
## What (CC-2 of CHART-AS-CONSTRAINTS.md)

A drug with **no safe-and-effective dose for this patient** is now a real constraint in the cover, not a post-hoc warning. `dose_window` already solves `floor ≤ dose ≤ ceiling(renal/interaction risks)` via the engine's LIA check — but `derive()` only *printed* "switch agent" after choosing the regimen. CC-2 folds dose-infeasibility **back into the optimization**.

## How

- **`chart_to_cop.py`** — new chart-fact kinds `renal_status` (renal_severe/renal_moderate), `interaction` (nephrotoxin_interaction), `weight` → a `risks` set + body weight, each with provenance; unrecognized values are **discarded with a reason** (no silent risks). `derive()` computes which drugs are dose-UNSAT under those risks and excludes them, recording a `dose_infeasible` constraint per drug.
- **`native_setcover.py`** — new `dose_excluded` param (mirrors the existing `defeated` pattern) drops those drugs from the candidate set before the cover is built.

## Worked behaviour (engine-verified, 0 model calls)

| chart | vancomycin ceiling | result |
|---|---|---|
| no dose risks | 20 mg/kg ≥ floor 15 | standard regimen `{ceftriaxone, vancomycin}` (no regression) |
| **severe renal + concurrent nephrotoxin** | 20 − 6 − 6 = **8 < floor 15** | vancomycin **dose-infeasible** → excluded → the vanc+ceftriaxone combo for resistant pneumococcus is unavailable → **INFEASIBLE, conflict named** |

The optimizer **escalates rather than recommending a toxic dose** — decision support, honest abstention.

## Reuse, not rebuild
The dose-window LIA check + integer optimizer already exist; CC-2 only wires dose feasibility into the cover.

## Verification
- `test_chart_to_cop` (+2 new dose-feasibility tests), `test_native_setcover`, `test_abx` pass; `ruff` clean.
- `/security-review`: **PASSED** — weight bounded to a plausible kg range; risk strings closed-vocab, selecting only trusted formulary penalty integers.

Part of the chart-as-constraints arc (CC-1 #5797 merged). Next: CC-3 grounds the contraindication/interaction *rules* (pregnancy/QT/drug–drug) via the spider.

🤖 Generated with [Claude Code](https://claude.com/claude-code)