### PR TITLE
feat(visicalc-xaml): VisiCalc WinUI computes live on the shared Rust engine via P/Invoke

### DIFF
--- a/demo/visicalc-xaml/.gitignore
+++ b/demo/visicalc-xaml/.gitignore
@@ -15,3 +15,7 @@ Generated/Grid_HVm.cs
 Generated/Grid_RowVm.cs
 Generated/Grid_VVm.cs
 Generated/BoolToVisibilityConverter.cs
+
+# Vendored engine — the C ABI dynamic library the .NET host P/Invokes, built
+# by scripts/build.sh from the spreadsheet-capi crate (cdylib). A build artifact.
+native/

--- a/demo/visicalc-xaml/Engine.cs
+++ b/demo/visicalc-xaml/Engine.cs
@@ -1,0 +1,209 @@
+// Engine.cs — the XAML/.NET host glue for the VisiCalc demo, computing on the
+// shared Rust `spreadsheet-core` engine through its C ABI (spreadsheet-capi),
+// reached via P/Invoke — the path WinUI / XAML use on Windows.
+//
+// This is the .NET sibling of the SwiftUI demo's Engine.swift, the Qt demo's
+// SpreadsheetModel, the Flutter demo's lib/engine.dart, and the Compose demo's
+// Engine.kt: it owns NO spreadsheet logic. The Rust engine (cells, dependency
+// graph, recalc, formulas) lives behind the C ABI; this file marshals .NET
+// strings across it and maps the engine's JSON value shape into display text.
+//
+// Deliberately free of any WinUI / Microsoft.UI dependency: it's plain
+// System.Runtime.InteropServices + System.Text.Json, so the same file compiles
+// into the WinUI app on Windows AND into the cross-platform console test
+// (test/EngineSmoke) that proves the engine path on macOS/Linux.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Text.Json;
+
+namespace Mosaic.Generated;
+
+/// P/Invoke surface over the C ABI. The library name "spreadsheet_capi" is
+/// resolved at load time to the vendored dynamic library (native/…), or to an
+/// explicit CAPI_LIB override — so the same bindings work whether the engine is
+/// a Windows .dll, a macOS .dylib, or a Linux .so.
+internal static class ScNative
+{
+    static ScNative()
+    {
+        NativeLibrary.SetDllImportResolver(typeof(ScNative).Assembly, (name, asm, searchPath) =>
+            name == "spreadsheet_capi" ? NativeLibrary.Load(ResolveLibraryPath()) : IntPtr.Zero);
+    }
+
+    [DllImport("spreadsheet_capi")] internal static extern IntPtr sc_session_new();
+    [DllImport("spreadsheet_capi")] internal static extern void sc_session_free(IntPtr s);
+
+    [DllImport("spreadsheet_capi")]
+    internal static extern IntPtr sc_set_cell(IntPtr s,
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string a1,
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string raw);
+
+    [DllImport("spreadsheet_capi")]
+    internal static extern IntPtr sc_get_value(IntPtr s,
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string a1);
+
+    [DllImport("spreadsheet_capi")]
+    internal static extern IntPtr sc_get_raw(IntPtr s,
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string a1);
+
+    [DllImport("spreadsheet_capi")] internal static extern void sc_string_free(IntPtr p);
+
+    /// Resolve the vendored engine library: an explicit CAPI_LIB env var, or
+    /// `native/<lib>` found by walking up from the app base directory and the
+    /// current directory. The filename is a hardcoded per-OS constant.
+    internal static string ResolveLibraryPath()
+    {
+        string name = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+            ? "spreadsheet_capi.dll"
+            : RuntimeInformation.IsOSPlatform(OSPlatform.OSX)
+                ? "libspreadsheet_capi.dylib"
+                : "libspreadsheet_capi.so";
+
+        string? env = Environment.GetEnvironmentVariable("CAPI_LIB");
+        if (!string.IsNullOrEmpty(env) && File.Exists(env)) return env;
+
+        foreach (var start in new[] { AppContext.BaseDirectory, Directory.GetCurrentDirectory() })
+        {
+            var dir = new DirectoryInfo(start);
+            for (int i = 0; i < 6 && dir is not null; i++, dir = dir.Parent)
+            {
+                var candidate = Path.Combine(dir.FullName, "native", name);
+                if (File.Exists(candidate)) return candidate;
+            }
+        }
+        return Path.Combine("native", name); // let NativeLibrary throw a clear error
+    }
+}
+
+/// A single spreadsheet session, owning the opaque C handle.
+public sealed class SpreadsheetSession : IDisposable
+{
+    private IntPtr _handle = ScNative.sc_session_new();
+
+    /// Read an engine-returned char* into a .NET string and free it with the
+    /// engine's allocator (sc_string_free — NOT the CLR's). NULL becomes "".
+    private static string Take(IntPtr p)
+    {
+        if (p == IntPtr.Zero) return string.Empty;
+        string s = Marshal.PtrToStringUTF8(p) ?? string.Empty;
+        ScNative.sc_string_free(p);
+        return s;
+    }
+
+    public string SetCell(string a1, string raw) => Take(ScNative.sc_set_cell(_handle, a1, raw));
+    public string GetValueJson(string a1) => Take(ScNative.sc_get_value(_handle, a1));
+    public string GetRaw(string a1) => Take(ScNative.sc_get_raw(_handle, a1));
+
+    /// The display string for a cell — what a spreadsheet should show. Parses
+    /// the engine's JSON (the fixed shape every backend's engine emits).
+    public string Display(string a1)
+    {
+        string json = GetValueJson(a1);
+        if (string.IsNullOrEmpty(json)) return string.Empty;
+        // The JSON is engine-emitted and well-formed, but parse defensively so a
+        // malformed/unexpected response degrades to "#ERR" rather than throwing
+        // up to the UI thread and crashing the window.
+        try
+        {
+            using var doc = JsonDocument.Parse(json);
+            var root = doc.RootElement;
+            if (!root.TryGetProperty("kind", out var kindEl)) return string.Empty;
+            switch (kindEl.GetString())
+            {
+                case "empty":
+                    return string.Empty;
+                case "number":
+                {
+                    double d = root.GetProperty("value").GetDouble();
+                    // Show integers without a trailing ".0".
+                    return (d == Math.Floor(d) && Math.Abs(d) < 1e15)
+                        ? ((long)d).ToString(System.Globalization.CultureInfo.InvariantCulture)
+                        : d.ToString(System.Globalization.CultureInfo.InvariantCulture);
+                }
+                case "text":
+                    return root.GetProperty("value").GetString() ?? string.Empty;
+                case "boolean":
+                    return root.GetProperty("value").GetBoolean() ? "TRUE" : "FALSE";
+                case "error":
+                    return root.GetProperty("code").GetString() ?? "#ERR";
+                default:
+                    return string.Empty;
+            }
+        }
+        catch (Exception ex) when (ex is JsonException or KeyNotFoundException or InvalidOperationException)
+        {
+            return "#ERR";
+        }
+    }
+
+    public void Dispose()
+    {
+        if (_handle != IntPtr.Zero)
+        {
+            ScNative.sc_session_free(_handle);
+            _handle = IntPtr.Zero;
+        }
+    }
+}
+
+/// An engine-backed 5×5 spreadsheet the XAML host drives. Mirrors the SwiftUI /
+/// Qt / Flutter / Compose models: seeds the cross-footing budget, exposes the
+/// computed display matrix, and writes through to the engine on edit.
+public sealed class SpreadsheetModel : IDisposable
+{
+    public const int Rows = 5;
+    public const int Cols = 5; // A..E
+
+    private readonly SpreadsheetSession _session = new();
+
+    public SpreadsheetModel() => Seed();
+
+    /// A1 address for grid display row `r` (0-based) and column `c` (1..5).
+    public static string Address(int r, int c) => $"{(char)('A' + c - 1)}{r + 1}";
+
+    /// The classic cross-footing budget — identical seed to every other demo.
+    private void Seed()
+    {
+        (string a1, string raw)[] cells =
+        {
+            ("A1", "15"), ("B1", "3"),  ("C1", "12"), ("D1", "8"),  ("E1", "=SUM(A1:D1)"),
+            ("A2", "8"),  ("B2", "14"), ("C2", "7"),  ("D2", "22"), ("E2", "=SUM(A2:D2)"),
+            ("A3", "12"), ("B3", "9"),  ("C3", "18"), ("D3", "6"),  ("E3", "=SUM(A3:D3)"),
+            ("A4", "4"),  ("B4", "11"), ("C4", "3"),  ("D4", "17"), ("E4", "=SUM(A4:D4)"),
+            ("A5", "=SUM(A1:A4)"), ("B5", "=SUM(B1:B4)"), ("C5", "=SUM(C1:C4)"),
+            ("D5", "=SUM(D1:D4)"), ("E5", "=SUM(E1:E4)"),
+        };
+        foreach (var (a1, raw) in cells) _session.SetCell(a1, raw);
+    }
+
+    /// Display matrix fed to the Grid: each row is [rowLabel, A, B, C, D, E].
+    public IReadOnlyList<IReadOnlyList<string>> ViewportRows()
+    {
+        var rows = new List<IReadOnlyList<string>>(Rows);
+        for (int r = 0; r < Rows; r++)
+        {
+            var row = new List<string> { (r + 1).ToString() };
+            for (int c = 1; c <= Cols; c++) row.Add(_session.Display(Address(r, c)));
+            rows.Add(row);
+        }
+        return rows;
+    }
+
+    /// The raw source of the cell at display row/col (col 1..5; 0 = gutter).
+    public string RawAt(int r, int c) => c < 1 ? string.Empty : _session.GetRaw(Address(r, c));
+
+    /// The value JSON of a cell — used by the verify harness to assert directly.
+    public string ValueJson(string a1) => _session.GetValueJson(a1);
+
+    /// Write `raw` into the cell at display row/col. The caller rebuilds the
+    /// display matrix afterwards via ViewportRows().
+    public void SetCell(int r, int c, string raw)
+    {
+        if (c >= 1) _session.SetCell(Address(r, c), raw);
+    }
+
+    public void Dispose() => _session.Dispose();
+}

--- a/demo/visicalc-xaml/MainWindow.xaml.cs
+++ b/demo/visicalc-xaml/MainWindow.xaml.cs
@@ -23,14 +23,13 @@ namespace Mosaic.Generated;
 public partial class MainWindow : Window
 {
     // 5x5 sample spreadsheet — same data as the other VC2-* demos.
-    private static readonly string[][] SampleRows = new[]
-    {
-        new[] { "15", "3",  "12", "8",  "5"  },
-        new[] { "8",  "14", "7",  "22", "11" },
-        new[] { "12", "9",  "18", "6",  "25" },
-        new[] { "4",  "11", "3",  "17", "9"  },
-        new[] { "7",  "5",  "13", "10", "19" },
-    };
+    // The 5x5 spreadsheet is computed by the shared Rust engine, reached through
+    // the C ABI via P/Invoke (see Engine.cs). The model seeds the same
+    // cross-footing budget every other VC2-* demo shows (column E totals each
+    // row, row 5 totals each column, E5 = 169) and recomputes on edit. Column
+    // indices here are 0-based data columns (0 = A), so calls into the model —
+    // whose columns are 1-based (1 = A) — add one.
+    private readonly SpreadsheetModel _model = new();
 
     // Column headers: a blank gutter ("") + the five data columns.
     private static readonly string[] Headers = { "", "A", "B", "C", "D", "E" };
@@ -42,7 +41,7 @@ public partial class MainWindow : Window
 
     private int _selectedRow;
     private int _selectedCol;
-    private string _formula = "=SUM(B1:B5)";
+    private string _formula = string.Empty;
 
     // Edit state mirrors the Grid.mil contract: editRow == -1 means
     // "not editing". The live edit buffer is _editContent.
@@ -55,6 +54,8 @@ public partial class MainWindow : Window
     public MainWindow()
     {
         InitializeComponent();
+        // Show the selected cell's source (A1 → "15") in the bar on launch.
+        _formula = _model.RawAt(_selectedRow, _selectedCol + 1);
         WireFormulaBar();
         WireGrid();
     }
@@ -80,7 +81,7 @@ public partial class MainWindow : Window
                 // no-op for v1
                 break;
             case FormulaBarEvent.Cancel:
-                _formula = SampleRows[_selectedRow][_selectedCol];
+                _formula = _model.RawAt(_selectedRow, _selectedCol + 1);
                 FormulaBarControl.Formula = _formula;
                 break;
         }
@@ -111,19 +112,10 @@ public partial class MainWindow : Window
         SheetGrid.ViewportRows = BuildViewportRows();
     }
 
-    // Build the viewport rows: prefix each data row with its label.
-    //   row 0 -> [ "1", "15", "3", "12", "8", "5" ]
-    private static IReadOnlyList<IReadOnlyList<string>> BuildViewportRows()
-    {
-        var rows = new List<IReadOnlyList<string>>(SampleRows.Length);
-        for (int r = 0; r < SampleRows.Length; r++)
-        {
-            var row = new List<string> { (r + 1).ToString() };
-            row.AddRange(SampleRows[r]);
-            rows.Add(row);
-        }
-        return rows;
-    }
+    // The viewport rows come straight from the engine: each row is
+    //   [ rowLabel, A, B, C, D, E ]   e.g. row 0 -> [ "1", "15", "3", "12", "8", "38" ]
+    // with column E and row 5 being engine-computed formula totals.
+    private IReadOnlyList<IReadOnlyList<string>> BuildViewportRows() => _model.ViewportRows();
 
     // ───────────────────────────────────────────────────────────────
     // WINDOWS-DEV TODO — per-cell VM projection (Group C population).
@@ -190,7 +182,9 @@ public partial class MainWindow : Window
                 // leave edit mode.
                 if (_editRow >= 0 && _editCol >= 0)
                 {
-                    SampleRows[_editRow][_editCol] = _editContent;
+                    // Write the edit through to the engine; EndEdit re-feeds the
+                    // recomputed viewport so every dependent total updates.
+                    _model.SetCell(_editRow, _editCol + 1, _editContent);
                 }
                 EndEdit();
                 break;
@@ -206,10 +200,9 @@ public partial class MainWindow : Window
     {
         _selectedRow = r;
         _selectedCol = c;
-        // The data cell at (r, c) is SampleRows[r][c]; the Grid's first
-        // column is the row-label gutter, so column 0 of the viewport
-        // is the label and data columns are 1..5.
-        _formula = SampleRows[r][c];
+        // Pull the newly-selected cell's source from the engine. `c` is a
+        // 0-based data column (0 = A); the model's columns are 1-based.
+        _formula = _model.RawAt(r, c + 1);
 
         SheetGrid.SelectedRow = r;
         SheetGrid.SelectedCol = c;

--- a/demo/visicalc-xaml/README.md
+++ b/demo/visicalc-xaml/README.md
@@ -1,25 +1,52 @@
-# VisiCalc — XAML (WinUI 3) demo
+# VisiCalc — XAML (WinUI 3) demo (live, on the Rust engine)
 
-Sixth and final per-backend cross-backend visual demo (Phase 2 /
-VC2-xaml), running on WinUI 3 / .NET 9 (Windows-only).
+The WinUI 3 / .NET 9 VisiCalc demo (Windows-only GUI), now **computing on the
+shared Rust `spreadsheet-core` engine** through its C ABI (`spreadsheet-capi`),
+reached via **P/Invoke** — the path WinUI / XAML use. The same engine the
+SwiftUI and Qt demos link natively, the Flutter demo loads via dart:ffi, the
+Compose demo reaches via Java FFM, and the web demos run as WebAssembly.
 
 ## What it shows
 
-A `Window` containing:
+A `Window` containing the auto-generated `FormulaBar` and `Grid` UserControls
+(`Generated/`, produced by `mosaic-compile --backend xaml`).
 
-- An auto-generated `FormulaBar` UserControl (from
-  `Generated/FormulaBar.{xaml,xaml.cs,Event.cs}`, produced by
-  `mosaic-compile --backend xaml`).
-- An auto-generated `Grid` UserControl (from
-  `Generated/Grid.{xaml,xaml.cs,Event.cs}` + `Grid_*Vm.cs` +
-  `BoolToVisibilityConverter.cs`), produced by the SAME
-  `mosaic-compile --backend xaml` pipeline from `mosaic-pkg-grid`
-  (`HostTable` + nested `For` + `Cell`). There is no hand-written
-  grid anymore — `MainWindow.xaml.cs` feeds the generated control's
-  dependency properties and handles its `Dispatch` event.
+- The grid is fed **engine-computed** values: the classic cross-footing budget
+  where column E totals each row, row 5 totals each column, and E5 is the grand
+  total (169) — all formulas evaluated by the Rust engine, not hard-coded.
+- `MainWindow.xaml.cs` feeds the generated control's dependency properties from
+  `SpreadsheetModel` (`Engine.cs`); committing an inline cell edit calls
+  `model.SetCell`, which writes to the engine and recomputes every dependent.
 
-Same hard-coded 5×5 sample data as the other VC2-* demos so the
-WinUI render matches React/HTML/WebComp/Flutter/Qt/SwiftUI.
+## How it's wired to the engine
+
+```
+WinUI controls (generated)  ──  SpreadsheetModel / SpreadsheetSession (Engine.cs)
+   Grid.ViewportRows = …         │  sc_set_cell / sc_get_value … (P/Invoke, string↔char*)
+                                 ▼
+   native/spreadsheet_capi.dll   ←  spreadsheet-capi (Rust C ABI)  ←  spreadsheet-core
+```
+
+`Engine.cs` is deliberately free of any WinUI dependency (just
+`System.Runtime.InteropServices` + `System.Text.Json`), so the same file
+compiles into the WinUI app on Windows AND into the cross-platform console test
+(`test/`) that proves the engine path on macOS/Linux.
+
+## Verify the engine path (cross-platform)
+
+The WinUI GUI is Windows-only, but the engine path is verifiable anywhere .NET 9
+runs:
+
+```bash
+bash scripts/build.sh    # regenerate controls + build & vendor the engine (cdylib)
+bash scripts/verify.sh   # runs test/ — P/Invokes the engine, asserts the grid is
+                         #   engine-computed (E1=38, A5=39, E5=169), recomputes on
+                         #   edit (E5 -> 269), and propagates =1/0 -> #DIV/0!
+```
+
+This is the .NET analog of the SwiftUI demo's `swift test`, the Qt demo's
+`tst_model`, the Flutter demo's `flutter test`, and the Compose demo's
+`verify.sh`. Verified green on macOS (12/12 checks).
 
 ## How to build the generated controls
 

--- a/demo/visicalc-xaml/VisiCalc.csproj
+++ b/demo/visicalc-xaml/VisiCalc.csproj
@@ -61,4 +61,13 @@
     </Page>
   </ItemGroup>
 
+  <!-- The cross-platform engine smoke under test/ is a SEPARATE console project
+       (test/EngineSmoke.csproj). Keep its sources out of this WinUI app's
+       default compile glob so the two projects don't double-compile Program.cs.
+       Engine.cs (project root) IS part of the app — it's the P/Invoke glue the
+       WinUI code-behind drives, shared verbatim with the console smoke. -->
+  <ItemGroup>
+    <Compile Remove="test/**/*.cs" />
+  </ItemGroup>
+
 </Project>

--- a/demo/visicalc-xaml/scripts/build.sh
+++ b/demo/visicalc-xaml/scripts/build.sh
@@ -68,9 +68,25 @@ echo "Compiling Grid (XAML)..."
   --package-search-path "$REPO_ROOT/code/packages" \
   -o "$OUT_DIR/Grid"
 
-echo "Done. Generated:"
+echo "Building the spreadsheet engine (Rust → dynamic lib) and vendoring it..."
+# The C ABI dynamic library the .NET host P/Invokes (see Engine.cs), built from
+# the spreadsheet-capi crate (cdylib) and copied into native/ (git-ignored). On
+# Windows the WinUI app needs spreadsheet_capi.dll; on this macOS/Linux checkout
+# we vendor the host slice so the cross-platform console test (test/) can run.
+RUST="$REPO_ROOT/code/packages/rust"
+(cd "$RUST" && cargo build -p spreadsheet-capi --release)
+mkdir -p "$DEMO_DIR/native"
+case "$(uname -s)" in
+  Darwin) LIB="libspreadsheet_capi.dylib" ;;
+  *)      LIB="libspreadsheet_capi.so" ;;
+esac
+cp "$RUST/target/release/$LIB" "$DEMO_DIR/native/$LIB"
+
+echo "Done. Generated controls + vendored engine:"
 ls -la "$OUT_DIR"
+ls -la "$DEMO_DIR/native"
 echo
-echo "To run the demo (Windows + .NET 9 + WindowsAppRuntime 1.7):"
-echo "  cd $DEMO_DIR"
-echo "  dotnet build && dotnet run"
+echo "Verify the engine path (cross-platform, runs on macOS/Linux/Windows):"
+echo "  cd $DEMO_DIR && bash scripts/verify.sh"
+echo "Run the WinUI app (Windows + .NET 9 + WindowsAppRuntime 1.7 only):"
+echo "  cd $DEMO_DIR && dotnet build && dotnet run"

--- a/demo/visicalc-xaml/scripts/verify.sh
+++ b/demo/visicalc-xaml/scripts/verify.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+#
+# verify.sh — headless proof that the XAML VisiCalc demo does REAL formula work
+# on the shared Rust engine, with no WinUI in the loop (WinUI is Windows-only).
+#
+# It runs the cross-platform console harness in test/, which compiles the
+# WinUI-free Engine.cs together with Program.cs and P/Invokes the vendored engine
+# library — so the .NET ↔ P/Invoke ↔ C ABI ↔ Rust path is verifiable on macOS /
+# Linux / Windows alike. This is the .NET equivalent of the SwiftUI demo's
+# `swift test`, the Qt demo's tst_model, and the Compose demo's verify.sh.
+#
+# Requires: .NET 9 SDK. Run scripts/build.sh first so native/libspreadsheet_capi.*
+# exists.
+#
+# Usage:
+#   cd demo/visicalc-xaml && bash scripts/verify.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DEMO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$DEMO_DIR"
+
+case "$(uname -s)" in
+  Darwin) LIB="native/libspreadsheet_capi.dylib" ;;
+  *)      LIB="native/libspreadsheet_capi.so" ;;
+esac
+if [ ! -f "$LIB" ]; then
+  echo "Engine library $LIB not found — run scripts/build.sh first." >&2
+  exit 1
+fi
+export CAPI_LIB="$DEMO_DIR/$LIB"
+
+echo "Running the .NET P/Invoke smoke (test/EngineSmoke.csproj)..."
+dotnet run --project test/EngineSmoke.csproj -c Release

--- a/demo/visicalc-xaml/test/EngineSmoke.csproj
+++ b/demo/visicalc-xaml/test/EngineSmoke.csproj
@@ -1,0 +1,22 @@
+<!-- EngineSmoke.csproj — a cross-platform console harness that proves the XAML
+     demo's engine path works, WITHOUT WinUI (which is Windows-only). It compiles
+     the WinUI-free ../Engine.cs together with Program.cs and runs on any OS that
+     has .NET 9, so the Kotlin↔P/Invoke↔C ABI↔Rust path is verifiable on macOS /
+     Linux / Windows alike. This is the .NET analog of the SwiftUI demo's
+     `swift test`, the Qt demo's tst_model, and the Compose demo's verify.sh. -->
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net9.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <RootNamespace>Mosaic.Generated.Test</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- The engine glue, shared verbatim with the WinUI app. -->
+    <Compile Include="../Engine.cs" />
+  </ItemGroup>
+
+</Project>

--- a/demo/visicalc-xaml/test/Program.cs
+++ b/demo/visicalc-xaml/test/Program.cs
@@ -1,0 +1,55 @@
+// Program.cs — headless proof that the XAML VisiCalc demo does REAL formula work
+// on the shared Rust engine, with no WinUI in the loop. It drives the same
+// engine-backed SpreadsheetModel the WinUI code-behind binds to (../Engine.cs)
+// and asserts the values are engine-computed and recompute on edit.
+//
+// Run (after scripts/build.sh has vendored native/libspreadsheet_capi.*):
+//   cd demo/visicalc-xaml && bash scripts/verify.sh
+// or directly:
+//   CAPI_LIB=$PWD/native/libspreadsheet_capi.dylib dotnet run --project test
+
+using Mosaic.Generated;
+
+int failures = 0;
+
+void Check(string label, string got, string want)
+{
+    bool ok = got == want;
+    if (!ok) failures++;
+    Console.WriteLine($"{(ok ? "ok  " : "FAIL")}  {label}: got=\"{got}\" want=\"{want}\"");
+}
+
+void Contains(string label, string got, string needle)
+{
+    bool ok = got.Contains(needle);
+    if (!ok) failures++;
+    Console.WriteLine($"{(ok ? "ok  " : "FAIL")}  {label}: \"{got}\" contains \"{needle}\"");
+}
+
+using var model = new SpreadsheetModel();
+
+// Seeded cross-footing budget — computed by the engine, not hard-coded.
+var rows = model.ViewportRows();
+Check("E1 row total", rows[0][5], "38");   // 15+3+12+8
+Check("E2 row total", rows[1][5], "51");   // 8+14+7+22
+Check("A5 col total", rows[4][1], "39");   // 15+8+12+4
+Check("E5 grand total", rows[4][5], "169");
+Check("row-label gutter", rows[0][0], "1");
+
+// Editing A1 (display row 0, col 1) 15 -> 115 recomputes every dependent.
+model.SetCell(0, 1, "115");
+rows = model.ViewportRows();
+Check("A1 after edit", rows[0][1], "115");
+Check("E1 after edit", rows[0][5], "138"); // 115+3+12+8
+Check("A5 after edit", rows[4][1], "139"); // 115+8+12+4
+Check("E5 after edit", rows[4][5], "269"); // 138+51+45+35
+
+// A formula that divides by zero, and an error propagating through a binary op.
+model.SetCell(0, 1, "=1/0");               // A1
+Contains("A1 div-by-0", model.ValueJson("A1"), "#DIV/0!");
+model.SetCell(0, 2, "=A1+1");              // B1
+Contains("B1 propagated", model.ValueJson("B1"), "#DIV/0!");
+Check("B1 display", model.ViewportRows()[0][2], "#DIV/0!");
+
+Console.WriteLine(failures == 0 ? "\nALL PASS" : $"\n{failures} FAILURE(S)");
+return failures == 0 ? 0 : 1;


### PR DESCRIPTION
## What

Wires the **WinUI 3 / .NET 9 VisiCalc demo** to the shared Rust `spreadsheet-core` engine through its C ABI (`spreadsheet-capi`), reached via **P/Invoke** — the path WinUI/XAML use. The **fifth native backend** doing real formula work on the one engine, and the last per-backend VisiCalc demo.

## How it's wired

```
WinUI controls (generated)  ──  SpreadsheetModel / SpreadsheetSession (Engine.cs)
   Grid.ViewportRows = …         │  sc_set_cell / sc_get_value … (P/Invoke, string↔char*)
                                 ▼
   native/spreadsheet_capi.dll   ←  spreadsheet-capi (Rust C ABI)  ←  spreadsheet-core
```

- `Engine.cs` P/Invokes the C ABI (`DllImport` + `NativeLibrary.SetDllImportResolver`). Engine-returned strings are read with `Marshal.PtrToStringUTF8` then freed with `sc_string_free` (read-before-free, single free, engine allocator). It's **deliberately WinUI-free** (just `System.Runtime.InteropServices` + `System.Text.Json`), so the same file compiles into the app **and** the cross-platform console test.
- `MainWindow.xaml.cs` feeds the generated Grid's `ViewportRows` from the engine; an inline cell edit-commit calls `model.SetCell` then re-feeds the recomputed viewport. No more hard-coded `SampleRows`.
- `scripts/build.sh` builds `spreadsheet-capi` as a **cdylib** and vendors it into `native/` (git-ignored).

## Verification

The WinUI GUI is Windows-only, but the engine path is verifiable anywhere .NET 9 runs:

- **`scripts/verify.sh` 12/12 green on macOS** (`test/` console harness): P/Invokes the engine and asserts the grid is engine-computed (E1=38, A5=39, E5=169), recomputes on edit (A1 15→115 ⇒ E5 269), and propagates a binary-op error (`=1/0`→`#DIV/0!`, `=A1+1` over it →`#DIV/0!`). This is the .NET analog of the SwiftUI/Qt/Flutter/Compose headless proofs.
- `/security-review` **passed** — read-before-free, single `sc_string_free` (engine allocator, not CLR), idempotent `Dispose`, fixed-name library resolution, no injection. Hardened `Display()`'s JSON parse to degrade to `#ERR` on malformed responses.
- `VisiCalc.csproj` adds `<Compile Remove="test/**">` so the nested console project doesn't double-compile into the WinUI app.

## All five native backends now compute on the one Rust engine

SwiftUI (macOS/iOS, C ABI) · Qt (C++, C ABI) · Flutter (dart:ffi) · Compose (Java FFM) · XAML (P/Invoke) — plus HTML + WebComponent on WASM. One engine, every backend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)