### PR TITLE
feat(lang-full): E2 (3/6) — iir-to-wasm wraps narrow-width arithmetic

### DIFF
--- a/code/packages/rust/iir-to-wasm/CHANGELOG.md
+++ b/code/packages/rust/iir-to-wasm/CHANGELOG.md
@@ -3,6 +3,25 @@
 All notable changes to this crate are documented here.  The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.14.0] — 2026-06-14 (LANG-FULL E2 — register width & wrap, backend 3 of 6)
+
+### Added — narrow-width arithmetic wraps mod-2ⁿ on real wasm
+
+WASM maps every narrow integer type to `i32`, and an `i32` op already wraps
+mod-2³² — so `u32`/`i32` arithmetic was already correct.  But `u8`/`u16` left a
+full 32-bit result, so a lowered `200u8 + 100u8` gave `300`, not `44`.
+
+This masks a narrow-width (`u4`/`u8`/`u16`) arithmetic / bitwise / shift / `neg`
+/ `not` result with `i32.const <mask>; i32.and` after the i32 op
+(`emit_wasm_width_mask`), mirroring vm-core's `mask_result` and jit-core's
+`MASK_WIDTH` — the register-arithmetic analogue of the existing byte-tape
+`i32.store8`.  `u4` is now mapped to `i32` (it was previously unrepresentable);
+`u32`/`i32` need no mask; `i64`/`u64`/floats are unchanged.
+
+Verified by **running** the lowered wasm on `wasm-runtime` (new dev-dependency):
+`tests/width_wrap.rs` executes `200u8+100u8=44`, `~0u8=255`, `1u8<<8=0`,
+u16/u4 wraps, the native u32 wrap, and `i64`-does-not-mask.
+
 ## [0.13.0] — 2026-06-12 (LANG-MATRIX LM-W Brainfuck — byte-tape ops on wasm)
 
 Adds the lowering Brainfuck needs to run on the WASM backend — the last code-gen

--- a/code/packages/rust/iir-to-wasm/Cargo.toml
+++ b/code/packages/rust/iir-to-wasm/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "iir-to-wasm"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
-description = "IIR → WASM backend — lowers IIRModule to WasmModule.  v0.13.0 (LANG-MATRIX LM-W Brainfuck): adds the byte-tape ops alloc_bytes/load_byte/store_byte over linear memory (with i32.wrap_i64 / i64.extend_i32_u at the byte boundary), i64-aware putchar/getchar, and width-correct i64 branch conditions (i64.eqz) + i64-widened comparison results — so the i64-widened Brainfuck runs on wasm.  v0.7.0 (G1): accept cmp_*-prefixed comparison opcodes.  v0.8.0 (G2): whitelist call_builtin print_i64 and route it to the env.__print_i64 host import that io_out uses, so BASIC's PRINT reaches real wasm bytecode."
+description = "IIR → WASM backend — lowers IIRModule to WasmModule.  v0.14.0 (LANG-FULL E2 — register width & wrap, backend 3/6): masks a narrow-width (u4/u8/u16) arithmetic / bitwise / neg / not result with `i32.const <mask>; i32.and` after the i32 op, so `200u8+100u8=44` and `~0u8=255` on real wasm (u32/i32 already wrap mod-2³² via the i32 op; u4 newly mapped to i32).  v0.13.0 (LANG-MATRIX LM-W Brainfuck): adds the byte-tape ops alloc_bytes/load_byte/store_byte over linear memory (with i32.wrap_i64 / i64.extend_i32_u at the byte boundary), i64-aware putchar/getchar, and width-correct i64 branch conditions (i64.eqz) + i64-widened comparison results — so the i64-widened Brainfuck runs on wasm.  v0.7.0 (G1): accept cmp_*-prefixed comparison opcodes.  v0.8.0 (G2): whitelist call_builtin print_i64 and route it to the env.__print_i64 host import that io_out uses, so BASIC's PRINT reaches real wasm bytecode."
 
 [lib]
 name = "iir_to_wasm"
@@ -15,6 +15,14 @@ wasm-module-encoder = { path = "../wasm-module-encoder" }
 wasm-leb128         = { path = "../wasm-leb128" }
 codegen-core        = { path = "../codegen-core" }
 
+[dev-dependencies]
+# Executes the lowered wasm to prove the width-wrap end-to-end (E2).
+wasm-runtime = { path = "../wasm-runtime" }
+
 [[test]]
 name = "test_backend"
 path = "tests/test_backend.rs"
+
+[[test]]
+name = "width_wrap"
+path = "tests/width_wrap.rs"

--- a/code/packages/rust/iir-to-wasm/README.md
+++ b/code/packages/rust/iir-to-wasm/README.md
@@ -26,12 +26,15 @@ through a deprecated intermediate.
 
 ## Features
 
-- **Full numeric type support**: `i8/i16/i32/u8/u16/u32/bool → i32`,
+- **Full numeric type support**: `u4/i8/i16/i32/u8/u16/u32/bool → i32`,
   `i64/u64 → i64`, `f32 → f32`, `f64 → f64`.
 - **Float constants supported** (unlike the BEAM backend): `f64.const` is
   emitted for `Operand::Float` and `f32.const` for narrower floats.
 - **All arithmetic and bitwise ops**: add, sub, mul, div, rem, and, or, xor,
-  shl, shr, for all numeric types.
+  shl, shr, for all numeric types. **Narrow-width results wrap mod-2ⁿ**
+  (LANG-FULL E2): a `u4`/`u8`/`u16` arithmetic/bitwise/`neg`/`not` result is
+  masked with `i32.const <mask>; i32.and` after the i32 op, so `200u8+100u8=44`
+  and `~0u8=255`. `u32`/`i32` already wrap mod-2³² via the i32 op.
 - **All comparison ops**: eq, ne, lt, le, gt, ge (signed and unsigned variants
   where applicable).
 - **Function calls**: `call` instructions are lowered to WASM `call`

--- a/code/packages/rust/iir-to-wasm/src/lower.rs
+++ b/code/packages/rust/iir-to-wasm/src/lower.rs
@@ -397,7 +397,7 @@ impl IIRWasmConfig {
 /// ```
 pub fn hint_to_value_type(hint: &str) -> Option<ValueType> {
     match hint {
-        "i8" | "i16" | "i32" | "u8" | "u16" | "u32" | "bool" => Some(ValueType::I32),
+        "u4" | "i8" | "i16" | "i32" | "u8" | "u16" | "u32" | "bool" => Some(ValueType::I32),
         "i64" | "u64" => Some(ValueType::I64),
         "f32" => Some(ValueType::F32),
         "f64" => Some(ValueType::F64),
@@ -426,7 +426,27 @@ fn is_i64_hint(hint: &str) -> bool {
 /// opcodes for `i32` types.  For `i64` we always use signed in v1 (matching
 /// the IIR spec's signed-default model).
 fn is_unsigned_hint(hint: &str) -> bool {
-    matches!(hint, "u8" | "u16" | "u32" | "u64")
+    matches!(hint, "u4" | "u8" | "u16" | "u32" | "u64")
+}
+
+/// Mask an `i32` arithmetic result down to a sub-32-bit width (LANG-FULL E2).
+///
+/// WASM maps every narrow integer type to `i32`, and an `i32` op already wraps
+/// mod-2³² — so `u32` (and `i32`) arithmetic is correct with no extra work.
+/// The smaller widths need an explicit `i32.const <mask>; i32.and` after the op
+/// so `200u8 + 100u8` becomes `44` and `~x` on a `u8` flips only 8 bits.  This
+/// mirrors vm-core's `mask_result` / jit-core's `MASK_WIDTH`, and is the
+/// register-arithmetic analogue of the byte-tape `i32.store8`.  `i64`/`u64`/
+/// float hints emit nothing (their op carries the correct width already).
+fn emit_wasm_width_mask(code: &mut Vec<u8>, type_hint: &str) {
+    let mask: i32 = match type_hint {
+        "u4" => 0xF,
+        "u8" => 0xFF,
+        "u16" => 0xFFFF,
+        _ => return,
+    };
+    code.extend(encode_i32_const(mask));
+    code.push(I32_AND);
 }
 
 /// Return `true` if the type hint represents a floating-point type.
@@ -866,6 +886,9 @@ fn emit_instr(
                 _ => unreachable!("matched outer pattern"),
             };
             code.push(opcode);
+            // E2: wrap a narrow-width result (`u4`/`u8`/`u16`) to its bit width;
+            // `u32`/`i32` already wrapped via the i32 op, `i64` carries i64 ops.
+            emit_wasm_width_mask(code, ty);
             code.extend(encode_local_set(rd));
         }
 
@@ -898,6 +921,9 @@ fn emit_instr(
                 _ => unreachable!(),
             };
             code.push(opcode);
+            // E2: a narrow left-shift can push bits past the width (`1u8 << 8`),
+            // so mask the result; `and`/`or`/`xor`/`shr` stay canonical too.
+            emit_wasm_width_mask(code, ty);
             code.extend(encode_local_set(rd));
         }
 
@@ -1012,6 +1038,8 @@ fn emit_instr(
                 code.extend(encode_local_get(r));
                 code.push(I32_SUB);
             }
+            // E2: a narrow `neg` is `(0 - r)` mod-2ⁿ — mask it to the width.
+            emit_wasm_width_mask(code, ty);
             code.extend(encode_local_set(rd));
         }
 
@@ -1036,6 +1064,9 @@ fn emit_instr(
                 code.extend(encode_i32_const(-1));
                 code.push(I32_XOR);
             }
+            // E2: `~x` on a narrow width must flip only its low bits
+            // (`~0u8 == 255`, not `0xFFFF_FFFF`) — mask after the XOR.
+            emit_wasm_width_mask(code, ty);
             code.extend(encode_local_set(rd));
         }
 

--- a/code/packages/rust/iir-to-wasm/tests/width_wrap.rs
+++ b/code/packages/rust/iir-to-wasm/tests/width_wrap.rs
@@ -1,0 +1,87 @@
+//! E2 (LANG-FULL): the lowered WASM actually **wraps** narrow-width integer
+//! arithmetic when executed on a real wasm runtime.
+//!
+//! WASM maps every narrow integer type to `i32`, and an `i32` op already wraps
+//! mod-2³² — so `u32`/`i32` are correct for free.  The smaller widths
+//! (`u4`/`u8`/`u16`) get an explicit `i32.const <mask>; i32.and` after the op,
+//! which these tests prove end-to-end: lower → encode → run → check the value.
+
+use interpreter_ir::{IIRFunction, IIRInstr, IIRModule, Operand};
+use iir_to_wasm::{encode_module, lower_iir_to_wasm, IIRWasmConfig};
+use wasm_runtime::WasmRuntime;
+
+/// Build a single `main` function, lower it to wasm, run it, return `main`'s
+/// value.  Every register and the return type carry `ty` so the whole function
+/// runs at that width.
+fn module(ty: &str, instrs: Vec<IIRInstr>) -> Vec<u8> {
+    let f = IIRFunction::new("main", vec![], ty, instrs);
+    let m = IIRModule {
+        name: "e2".into(),
+        functions: vec![f],
+        entry_point: Some("main".into()),
+        language: "test".into(),
+        exports: vec![],
+        imports: vec![],
+    };
+    let wasm = lower_iir_to_wasm(&m, &IIRWasmConfig::default()).expect("lowering failed");
+    encode_module(&wasm).expect("encoding failed")
+}
+
+fn run_binop(op: &str, a: i64, b: i64, ty: &str) -> i64 {
+    let bytes = module(ty, vec![
+        IIRInstr::new("const", Some("a".into()), vec![Operand::Int(a)], ty),
+        IIRInstr::new("const", Some("b".into()), vec![Operand::Int(b)], ty),
+        IIRInstr::new(op, Some("c".into()),
+            vec![Operand::Var("a".into()), Operand::Var("b".into())], ty),
+        IIRInstr::new("ret", None, vec![Operand::Var("c".into())], ty),
+    ]);
+    WasmRuntime::new()
+        .load_and_run(&bytes, "main", &[])
+        .expect("wasm run failed")
+        .first()
+        .copied()
+        .expect("main returns a value")
+}
+
+fn run_unop(op: &str, a: i64, ty: &str) -> i64 {
+    let bytes = module(ty, vec![
+        IIRInstr::new("const", Some("a".into()), vec![Operand::Int(a)], ty),
+        IIRInstr::new(op, Some("c".into()), vec![Operand::Var("a".into())], ty),
+        IIRInstr::new("ret", None, vec![Operand::Var("c".into())], ty),
+    ]);
+    WasmRuntime::new()
+        .load_and_run(&bytes, "main", &[])
+        .expect("wasm run failed")
+        .first()
+        .copied()
+        .expect("main returns a value")
+}
+
+#[test]
+fn u8_arithmetic_wraps_on_real_wasm() {
+    assert_eq!(run_binop("add", 200, 100, "u8"), 44); // 300 & 0xFF
+    assert_eq!(run_binop("mul", 16, 16, "u8"), 0);    // 256 & 0xFF
+    assert_eq!(run_binop("sub", 0, 1, "u8"), 255);    // -1 & 0xFF
+    assert_eq!(run_binop("add", 255, 1, "u8"), 0);    // cell wrap
+}
+
+#[test]
+fn u8_not_and_shift_wrap_on_real_wasm() {
+    assert_eq!(run_unop("not", 0, "u8"), 255);      // ~0 over a byte
+    assert_eq!(run_binop("shl", 1, 7, "u8"), 128);
+    assert_eq!(run_binop("shl", 1, 8, "u8"), 0);    // shifted past the byte
+}
+
+#[test]
+fn u16_u32_u4_widths_on_real_wasm() {
+    assert_eq!(run_binop("add", 60000, 10000, "u16"), 70000 & 0xFFFF); // 4464
+    assert_eq!(run_binop("add", 10, 10, "u4"), 4);                     // 20 & 0xF
+    // u32 wraps natively via the i32 op — no explicit mask, still correct.
+    assert_eq!(run_binop("mul", 0x1_0000, 0x1_0000, "u32"), 0);        // 2³² & 0xFFFF_FFFF
+}
+
+#[test]
+fn i64_width_does_not_mask_on_real_wasm() {
+    assert_eq!(run_binop("add", 200, 100, "i64"), 300);
+    assert_eq!(run_binop("mul", 16, 16, "i64"), 256);
+}

--- a/code/specs/LANG-FULL-IMPLEMENTATION.md
+++ b/code/specs/LANG-FULL-IMPLEMENTATION.md
@@ -74,7 +74,10 @@ multiple languages; close an enabler before the features that depend on it.
   - ✅ **jit-core** (2/6) — compiled tier emits a `MASK_WIDTH <reg> <bits>` opcode after a
     narrow `_u8`/`_u16`/`_u32` add/sub/mul/div/neg (`u4`/signed handled by the interpreter
     fallback); unit-tested. Matches vm-core's interpreter-tier mask.
-  - ☐ **iir-to-wasm** (3/6, in flight #5812 — `i32.and` width mask).
+  - ✅ **iir-to-wasm** (3/6) — masks a narrow `u4`/`u8`/`u16` arith/bitwise/neg/not result
+    with `i32.const <mask>; i32.and` after the i32 op (`u32`/`i32` already wrap mod-2³² via
+    the i32 op; `u4` newly mapped to i32). **Executed proof** on real `wasm-runtime`
+    (`200u8+100u8=44`, `~0u8=255`, `1u8<<8=0`).
   - ✅ **iir-to-jvm-class-file** (4/6) — `emit_jvm_width_mask` appends `iconst/sipush/ldc
     <mask>; iand` after a narrow `u4`/`u8`/`u16` arith/bitwise/neg/not/shl `int` op (positive
     mask + `iand`, not `i2b`, to keep unsigned widths unsigned; `0xFFFF` via the constant


### PR DESCRIPTION
## What

**Third backend of the E2 (integer width & wrap) enabler** (approach B). WASM maps every narrow integer type to `i32`, and an `i32` op already wraps mod-2³² — so `u32`/`i32` were already correct, but `u8`/`u16` left a full 32-bit result, so a lowered `200u8 + 100u8` gave `300`, not `44`.

`emit_wasm_width_mask(code, type_hint)` appends `i32.const <mask>; i32.and` after a narrow (`u4`→0xF, `u8`→0xFF, `u16`→0xFFFF) arithmetic / bitwise / shift / `neg` / `not` result — mirroring vm-core's `mask_result`, jit-core's `MASK_WIDTH`, and the byte-tape `i32.store8` precedent. The mask is i32→i32 and only fires for i32-mapped types, so the wasm value stack stays balanced and typed. `u4` is now mapped to `i32` (previously unrepresentable) and added to `is_unsigned_hint`.

## Verified by RUNNING (not structural)
`tests/width_wrap.rs` executes the lowered wasm on a real `wasm-runtime` (new dev-dep): `200u8+100u8=44`, `~0u8=255`, `1u8<<8=0`, u16/u4 wraps, the native u32 wrap, and `i64`-does-not-mask. Full iir-to-wasm suite (105) + lang-aot matrix (wasm column) green. clippy clean; `/security-review` passed (confirmed the appended `i32.const; i32.and` keeps the value stack balanced and never lands on an i64 value).

## E2 roadmap
- ✅ vm-core (1/6, merged #5799), 🔵 jit-core (2/6, #5808 in flight), ✅ **iir-to-wasm (this PR, 3/6)**. LLVM already wraps via `i8`.
- ☐ iir-to-jvm (4/6, i2b/mask), iir-to-cil (5/6, conv.u1/mask), then integration (6/6: Nib/Oct emit narrow type_hints + cross-backend matrix proof).

Note: parallel with #5808; both touch only the E2 roadmap checklist line — trivial rebase for whichever merges second.

🤖 Generated with [Claude Code](https://claude.com/claude-code)