### PR TITLE
feat(spreadsheet facades): expose the viewport primitive through WASM + C ABI

### DIFF
--- a/code/packages/rust/spreadsheet-capi/CHANGELOG.md
+++ b/code/packages/rust/spreadsheet-capi/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 0.2.0
+
+Viewport C ABI for the virtualized infinite sheet, mirroring
+`spreadsheet-core-wasm` 0.2.0 (`include/spreadsheet.h` now pulls in `<stdint.h>`
+for the integer widths):
+
+- `sc_get_window(s, row0, col0, row1, col1) -> char*` (window JSON; `{"error":..}`
+  on a bad/oversized request).
+- `sc_used_range(s) -> char*` (extent JSON or the literal `null`).
+- `sc_column_letters(s, index) -> char*` (1-based index → `"A"`/`"AA"`/…).
+- `sc_current_revision(s) -> uint64_t` (the per-edit clock; 0 if `s` is NULL).
+- `sc_changed_since(s, since) -> char*` (changed-cells JSON).
+
+Each `char*` is freed with `sc_string_free`, per the existing contract; a NULL
+session yields NULL / 0 rather than a crash.
+
 ## 0.1.0
 
 Initial release — the stable C ABI over the spreadsheet engine, for the native

--- a/code/packages/rust/spreadsheet-capi/Cargo.toml
+++ b/code/packages/rust/spreadsheet-capi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spreadsheet-capi"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "Stable C ABI over the spreadsheet engine, for the native VisiCalc demos (Swift/Kotlin-JNI/Dart-FFI/.NET/C++)"
 license = "MIT"

--- a/code/packages/rust/spreadsheet-capi/include/spreadsheet.h
+++ b/code/packages/rust/spreadsheet-capi/include/spreadsheet.h
@@ -21,6 +21,8 @@
 #ifndef SPREADSHEET_CAPI_H
 #define SPREADSHEET_CAPI_H
 
+#include <stdint.h> /* uint32_t / uint64_t for the viewport calls */
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -37,6 +39,18 @@ char *sc_set_cell(ScSession *s, const char *a1, const char *raw); /* -> {"ok":..
 char *sc_get_value(ScSession *s, const char *a1);                 /* -> value JSON  */
 char *sc_get_raw(ScSession *s, const char *a1);                   /* -> typed source */
 char *sc_get_values(ScSession *s);                                /* -> {a1: value} */
+
+/* Viewport primitive — read just the visible window of the unbounded sheet.
+   Coordinates are 1-based and inclusive. Each char* result must be freed with
+   sc_string_free(). */
+/* -> {"row0":..,"col0":..,"rows":R,"cols":C,"values":[[value,..],..]} | {"error":".."} */
+char *sc_get_window(ScSession *s, uint32_t row0, uint32_t col0,
+                    uint32_t row1, uint32_t col1);
+char *sc_used_range(ScSession *s);              /* -> {"minRow":..,..} | null            */
+char *sc_column_letters(ScSession *s, uint32_t index); /* 1-based index -> "A"/"AA"/...   */
+uint64_t sc_current_revision(ScSession *s);     /* per-edit revision clock (0 if s==NULL) */
+char *sc_changed_since(ScSession *s, uint64_t since);  /* -> {"revision":N,"changed":[..]} |
+                                                            {"revision":N,"stale":true}    */
 
 /* Free a string returned by any sc_* function. */
 void  sc_string_free(char *p);

--- a/code/packages/rust/spreadsheet-capi/src/lib.rs
+++ b/code/packages/rust/spreadsheet-capi/src/lib.rs
@@ -157,6 +157,82 @@ pub unsafe extern "C" fn sc_get_values(s: *mut ScSession) -> *mut c_char {
     into_cstr((*s).inner.get_values())
 }
 
+// ── Viewport primitive (virtualized infinite sheet) ──────────────────
+// Integer coordinates (1-based, inclusive) so a native scrolling host can fetch
+// just the visible window of an unbounded sheet.
+
+/// `get_window(row0, col0, row1, col1)` → window JSON. See
+/// [`SpreadsheetSession::get_window`]. Returns null only on a null `s`.
+///
+/// # Safety
+/// `s` must be a valid session.
+#[no_mangle]
+pub unsafe extern "C" fn sc_get_window(
+    s: *mut ScSession,
+    row0: u32,
+    col0: u32,
+    row1: u32,
+    col1: u32,
+) -> *mut c_char {
+    if s.is_null() {
+        return ptr::null_mut();
+    }
+    into_cstr((*s).inner.get_window(row0, col0, row1, col1))
+}
+
+/// `used_range()` → data-extent JSON, or the literal `null`. See
+/// [`SpreadsheetSession::used_range`].
+///
+/// # Safety
+/// `s` must be a valid session.
+#[no_mangle]
+pub unsafe extern "C" fn sc_used_range(s: *mut ScSession) -> *mut c_char {
+    if s.is_null() {
+        return ptr::null_mut();
+    }
+    into_cstr((*s).inner.used_range())
+}
+
+/// `column_letters(index)` → `"A"`/`"AA"`/… for a 1-based column index. See
+/// [`SpreadsheetSession::column_letters`].
+///
+/// # Safety
+/// `s` must be a valid session.
+#[no_mangle]
+pub unsafe extern "C" fn sc_column_letters(s: *mut ScSession, index: u32) -> *mut c_char {
+    if s.is_null() {
+        return ptr::null_mut();
+    }
+    into_cstr((*s).inner.column_letters(index))
+}
+
+/// `current_revision()` → the per-edit revision clock (a plain integer, not a
+/// string). Returns 0 on a null session. See
+/// [`SpreadsheetSession::current_revision`].
+///
+/// # Safety
+/// `s` must be a valid session (or null).
+#[no_mangle]
+pub unsafe extern "C" fn sc_current_revision(s: *mut ScSession) -> u64 {
+    if s.is_null() {
+        return 0;
+    }
+    (*s).inner.current_revision()
+}
+
+/// `changed_since(since)` → changed-cells JSON. See
+/// [`SpreadsheetSession::changed_since`].
+///
+/// # Safety
+/// `s` must be a valid session.
+#[no_mangle]
+pub unsafe extern "C" fn sc_changed_since(s: *mut ScSession, since: u64) -> *mut c_char {
+    if s.is_null() {
+        return ptr::null_mut();
+    }
+    into_cstr((*s).inner.changed_since(since))
+}
+
 // ---------------------------------------------------------------------------
 // Host-target tests: drive the C ABI from Rust (so they run under `cargo test`
 // without a C compiler). A separate test/smoke.c exercises the same calls from
@@ -224,6 +300,42 @@ mod tests {
             assert!(sc_set_cell(ptr::null_mut(), ca.as_ptr(), ca.as_ptr()).is_null());
             sc_session_free(ptr::null_mut()); // no-op
             sc_string_free(ptr::null_mut()); // no-op
+        }
+    }
+
+    /// Call an `sc_*` getter returning a char* and return the freed string.
+    unsafe fn take(out: *mut c_char) -> String {
+        let str = CStr::from_ptr(out).to_string_lossy().into_owned();
+        sc_string_free(out);
+        str
+    }
+
+    #[test]
+    fn c_abi_viewport_round_trips() {
+        unsafe {
+            let s = sc_session_new();
+            set(s, "A1", "15");
+            set(s, "B1", "3");
+            set(s, "C1", "=SUM(A1:B1)"); // 18
+
+            let w = take(sc_get_window(s, 1, 1, 1, 3));
+            assert!(w.contains(r#""rows":1"#) && w.contains(r#""cols":3"#), "{w}");
+            assert!(w.contains(r#"{"kind":"number","value":18.0}"#), "{w}");
+
+            assert!(take(sc_used_range(s)).contains(r#""maxCol":3"#));
+            assert_eq!(take(sc_column_letters(s, 27)), "AA");
+
+            let snap = sc_current_revision(s);
+            set(s, "A1", "100");
+            let c = take(sc_changed_since(s, snap));
+            assert!(c.contains("\"A1\"") && c.contains("\"C1\""), "{c}");
+
+            // Bad window → error object; null handle → null / 0, never a crash.
+            assert_eq!(take(sc_get_window(s, 0, 0, 5, 5)), r##"{"error":"#REF!"}"##);
+            assert!(sc_get_window(ptr::null_mut(), 1, 1, 1, 1).is_null());
+            assert_eq!(sc_current_revision(ptr::null_mut()), 0);
+
+            sc_session_free(s);
         }
     }
 }

--- a/code/packages/rust/spreadsheet-core-wasm/CHANGELOG.md
+++ b/code/packages/rust/spreadsheet-core-wasm/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 0.2.0
+
+Viewport primitive (for the virtualized infinite sheet), wrapping
+`spreadsheet-core` 0.2.0's reads as string-in/JSON-out:
+
+- `get_window(row0, col0, row1, col1)` → `{"row0":..,"col0":..,"rows":R,"cols":C,
+  "values":[[<value>,..],..]}` (row-major, blanks included as `{"kind":"empty"}`),
+  or `{"error":"#REF!"}` on a bad/oversized request.
+- `used_range()` → `{"minRow":..,"minCol":..,"maxRow":..,"maxCol":..}` or `null`.
+- `column_letters(index)` → `"A"`/`"AA"`/… for a 1-based column index.
+- `current_revision()` + `changed_since(since)` →
+  `{"revision":N,"changed":["B2",..]}` or `{"revision":N,"stale":true}`.
+
 ## 0.1.0
 
 Initial release — the browser/WASM-facing JSON facade over `spreadsheet-core`.

--- a/code/packages/rust/spreadsheet-core-wasm/Cargo.toml
+++ b/code/packages/rust/spreadsheet-core-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spreadsheet-core-wasm"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "Browser/WASM-facing string-in / JSON-out facade over spreadsheet-core"
 license = "MIT"

--- a/code/packages/rust/spreadsheet-core-wasm/src/lib.rs
+++ b/code/packages/rust/spreadsheet-core-wasm/src/lib.rs
@@ -52,7 +52,9 @@ use std::collections::HashMap;
 use std::panic::{catch_unwind, AssertUnwindSafe};
 
 use serde_json::{json, Value};
-use spreadsheet_core::{CellAddress, CellValue, SheetId, SpreadsheetError, Workbook};
+use spreadsheet_core::{
+    column_index_to_letters, CellAddress, CellValue, ChangeSet, SheetId, SpreadsheetError, Workbook,
+};
 
 /// A single-sheet spreadsheet session with a JSON boundary.
 ///
@@ -161,6 +163,84 @@ impl SpreadsheetSession {
             map.insert(addr.to_a1(), value_to_json(&v));
         }
         Value::Object(map).to_string()
+    }
+
+    // ── Viewport primitive (virtualized infinite sheet) ──────────────
+    //
+    // These mirror the engine's `Workbook::get_window` / `used_range` /
+    // `changed_since` reads (1-based, inclusive coords) so a JS host can render
+    // only the visible window of an unbounded sheet. Coordinates are integers
+    // here, not A1 strings — a scrolling host computes them from pixel offsets.
+
+    /// Computed values for the inclusive 1-based rectangle, as JSON:
+    /// `{"row0":1,"col0":1,"rows":R,"cols":C,"values":[[<value>,…],…]}` where
+    /// each `<value>` is the usual value-object shape and `values` is a row-major
+    /// `R×C` array (empty cells included as `{"kind":"empty"}`). On a bad
+    /// request (inverted/oversized/0-coord) returns `{"error":"#REF!"}`.
+    pub fn get_window(&self, row0: u32, col0: u32, row1: u32, col1: u32) -> String {
+        match self.wb.get_window(self.sheet, row0, col0, row1, col1) {
+            Ok(w) => {
+                let mut rows = Vec::with_capacity(w.rows as usize);
+                for r in 0..w.rows {
+                    let mut row = Vec::with_capacity(w.cols as usize);
+                    for c in 0..w.cols {
+                        row.push(value_to_json(&w.values[(r * w.cols + c) as usize]));
+                    }
+                    rows.push(Value::Array(row));
+                }
+                json!({
+                    "row0": w.row0, "col0": w.col0,
+                    "rows": w.rows, "cols": w.cols,
+                    "values": rows,
+                })
+                .to_string()
+            }
+            Err(e) => json!({ "error": e.display() }).to_string(),
+        }
+    }
+
+    /// The data extent as JSON `{"minRow":…,"minCol":…,"maxRow":…,"maxCol":…}`,
+    /// or the JSON literal `null` if the sheet has no non-empty cells. A host
+    /// sizes its scrollable area to this.
+    pub fn used_range(&self) -> String {
+        match self.wb.used_range(self.sheet) {
+            Some(u) => json!({
+                "minRow": u.min_row, "minCol": u.min_col,
+                "maxRow": u.max_row, "maxCol": u.max_col,
+            })
+            .to_string(),
+            None => "null".to_string(),
+        }
+    }
+
+    /// The column letters for a 1-based column index (`1` → `"A"`, `27` → `"AA"`).
+    /// Hosts use this for the frozen header row instead of re-implementing the
+    /// base-26-bijective math.
+    pub fn column_letters(&self, index: u32) -> String {
+        column_index_to_letters(index)
+    }
+
+    /// The per-edit revision clock. A host snapshots this, then passes it to
+    /// [`changed_since`](Self::changed_since) to learn what changed in between.
+    pub fn current_revision(&self) -> u64 {
+        self.wb.current_revision()
+    }
+
+    /// Which cells changed since `since_revision`, as JSON:
+    /// `{"revision":N,"changed":["B2",…]}` (a complete deduped list), or
+    /// `{"revision":N,"stale":true}` when the query reaches before the retained
+    /// change log — the host then re-reads its whole visible window.
+    pub fn changed_since(&self, since_revision: u64) -> String {
+        match self.wb.changed_since(self.sheet, since_revision) {
+            ChangeSet::Delta { current_revision, changed } => {
+                let cells: Vec<Value> =
+                    changed.iter().map(|a| Value::String(a.to_a1())).collect();
+                json!({ "revision": current_revision, "changed": cells }).to_string()
+            }
+            ChangeSet::Stale { current_revision } => {
+                json!({ "revision": current_revision, "stale": true }).to_string()
+            }
+        }
     }
 }
 
@@ -331,5 +411,68 @@ mod tests {
         let mut s = SpreadsheetSession::new();
         s.set_cell("A1", "=SUM(A1:XFD1048576)");
         assert_eq!(s.get_value("A1"), r##"{"code":"#REF!","kind":"error"}"##);
+    }
+
+    // ── Viewport facade ──────────────────────────────────────────────
+
+    #[test]
+    fn get_window_returns_dense_row_major_json() {
+        let mut s = SpreadsheetSession::new();
+        s.set_cell("A1", "15");
+        s.set_cell("B1", "3");
+        s.set_cell("C1", "=SUM(A1:B1)"); // 18
+        // Window A1:C1 — one row, three columns, computed values, dense.
+        let out = s.get_window(1, 1, 1, 3);
+        assert_eq!(
+            out,
+            r#"{"col0":1,"cols":3,"row0":1,"rows":1,"values":[[{"kind":"number","value":15.0},{"kind":"number","value":3.0},{"kind":"number","value":18.0}]]}"#
+        );
+    }
+
+    #[test]
+    fn get_window_includes_blanks_and_rejects_bad_requests() {
+        let mut s = SpreadsheetSession::new();
+        s.set_cell("A1", "1"); // B1 left empty
+        let out = s.get_window(1, 1, 1, 2);
+        assert!(out.contains(r#"{"kind":"number","value":1.0}"#));
+        assert!(out.contains(r#"{"kind":"empty"}"#)); // blank cell present, not omitted
+        // 0-coord / oversized → an error object, never a panic.
+        assert_eq!(s.get_window(0, 0, 10, 10), r##"{"error":"#REF!"}"##);
+        assert_eq!(s.get_window(1, 1, 1000, 1000), r##"{"error":"#REF!"}"##);
+    }
+
+    #[test]
+    fn used_range_reports_extent_or_null() {
+        let mut s = SpreadsheetSession::new();
+        assert_eq!(s.used_range(), "null");
+        s.set_cell("A1", "1");
+        s.set_cell("Z100", "2");
+        assert_eq!(
+            s.used_range(),
+            r#"{"maxCol":26,"maxRow":100,"minCol":1,"minRow":1}"#
+        );
+    }
+
+    #[test]
+    fn column_letters_matches_excel() {
+        let s = SpreadsheetSession::new();
+        assert_eq!(s.column_letters(1), "A");
+        assert_eq!(s.column_letters(26), "Z");
+        assert_eq!(s.column_letters(27), "AA");
+        assert_eq!(s.column_letters(703), "AAA");
+    }
+
+    #[test]
+    fn changed_since_reports_delta_then_current_revision() {
+        let mut s = SpreadsheetSession::new();
+        s.set_cell("A1", "1");
+        s.set_cell("B1", "=A1*10");
+        let snap = s.current_revision();
+        s.set_cell("A1", "9"); // A1 + dependent B1
+        let out = s.changed_since(snap);
+        assert!(out.contains("\"changed\""));
+        assert!(out.contains("\"A1\""));
+        assert!(out.contains("\"B1\""));
+        assert!(!out.contains("\"stale\""));
     }
 }

--- a/code/packages/rust/spreadsheet-core/CHANGELOG.md
+++ b/code/packages/rust/spreadsheet-core/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## 0.2.0
+
+**Viewport primitive for the virtualized infinite sheet** (`viewport.rs`,
+`workbook.rs`). The sheet was already unbounded (u32 addresses, sparse storage);
+these reads let a host render only the visible window of it.
+
+- `Workbook::get_window(sheet, row0, col0, row1, col1) -> Window`: a dense,
+  row-major rectangle of computed values (empty cells included as
+  `CellValue::Empty`), `O(window)` not `O(sheet)`. Rejects inverted rectangles
+  and windows over `MAX_WINDOW_CELLS` (65 536 — a screen-scale safety cap), with
+  overflow-safe size checking.
+- `Workbook::used_range(sheet) -> Option<UsedRange>`: bounding box of
+  materialised non-empty cells, for scrollbar sizing.
+- `Workbook::current_revision()` + `Workbook::changed_since(sheet, since) ->
+  ChangeSet`: a per-edit revision clock (advances on every `set_value` /
+  `set_formula` / `clear_cell`, unlike `epoch` which only advances on
+  `recalc_all`) plus a bounded change log, so a host re-fetches only the cells
+  dirtied since its last render. Returns `ChangeSet::Stale` (re-read everything)
+  when a query reaches back before the retained log window (`CHANGELOG_RETAIN`).
+  v1 stamps on write (a no-op recompute may over-report a cell — safe; exact
+  old/new diffing is a future optimisation).
+- Re-exported `column_index_to_letters` / `column_letters_to_index` for hosts to
+  render identical A…Z, AA… headers without re-implementing the math.
+
 ## 0.1.0
 
 Initial release — Phase 1 headless spreadsheet engine.

--- a/code/packages/rust/spreadsheet-core/Cargo.toml
+++ b/code/packages/rust/spreadsheet-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spreadsheet-core"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "Headless spreadsheet engine — cell model, formula AST, dependency DAG, recalc, dispatch to Layer-1 cores. The engine VisiCalc Modern and any other Mosaic-rendered spreadsheet sits on top of."
 

--- a/code/packages/rust/spreadsheet-core/src/lib.rs
+++ b/code/packages/rust/spreadsheet-core/src/lib.rs
@@ -41,10 +41,12 @@ pub mod dispatch;
 pub mod errors;
 pub mod parser;
 pub mod recalc;
+pub mod viewport;
 pub mod workbook;
 
-pub use address::{CellAddress, CellRange, SheetId};
+pub use address::{column_index_to_letters, column_letters_to_index, CellAddress, CellRange, SheetId};
 pub use ast::{BinaryOp, FormulaAst, UnaryOp};
 pub use cell::{Cell, CellContent, CellValue};
 pub use errors::SpreadsheetError;
+pub use viewport::{ChangeSet, UsedRange, Window, CHANGELOG_RETAIN, MAX_WINDOW_CELLS};
 pub use workbook::Workbook;

--- a/code/packages/rust/spreadsheet-core/src/viewport.rs
+++ b/code/packages/rust/spreadsheet-core/src/viewport.rs
@@ -1,0 +1,112 @@
+//! Viewport primitives for the virtualized *infinite* sheet.
+//!
+//! The sheet is already unbounded at the storage layer: `CellAddress` is a pair
+//! of `u32`s (≈4.3 billion rows × 4.3 billion columns) and cells live in a
+//! sparse `HashMap`, so only the cells you actually touch exist. What a
+//! *virtualized* host needs on top of that is a way to read just the rectangle
+//! the user can currently see — not the whole sheet — plus enough metadata to
+//! size scrollbars and to refresh efficiently after an edit.
+//!
+//! This module defines the value types those reads return. The methods that
+//! produce them live on [`Workbook`](crate::Workbook):
+//!
+//! - [`Workbook::get_window`] — the dense rectangle the host renders.
+//! - [`Workbook::used_range`] — the data's bounding box, for scrollbar sizing.
+//! - [`Workbook::changed_since`] — which cells changed since a prior revision,
+//!   so a host re-fetches only the dirtied *visible* cells after an edit.
+//!
+//! Coordinates are **1-based and inclusive** everywhere here, matching the A1
+//! surface (`A1` is row 1, column 1).
+
+use crate::address::CellAddress;
+use crate::cell::CellValue;
+
+/// Maximum number of cells a single [`get_window`](crate::Workbook::get_window)
+/// may return. This is a *screen-scale* safety cap, not the data scale: a 4K
+/// display shows a few thousand cells, and 65 536 leaves generous headroom for
+/// overscan. A host clamps its request to the visible window long before this
+/// bites; the cap only stops a buggy or hostile caller from asking for a
+/// billion-cell rectangle and exhausting memory — the same role
+/// [`MAX_RANGE_CELLS`](crate::address::MAX_RANGE_CELLS) plays for formula ranges.
+pub const MAX_WINDOW_CELLS: u64 = 1 << 16; // 65,536
+
+/// How many change-log entries the workbook retains for
+/// [`changed_since`](crate::Workbook::changed_since) diffing. Past this, the
+/// oldest entries are dropped and a query reaching back before the retained
+/// window returns [`ChangeSet::Stale`] (the safe "re-read everything" signal)
+/// rather than silently missing a change.
+pub const CHANGELOG_RETAIN: usize = 4096;
+
+/// A dense rectangle of computed values, as returned by
+/// [`Workbook::get_window`]. Empty cells are included as [`CellValue::Empty`]
+/// (not omitted) so the host can index the result directly by position and
+/// render a solid grid. Values are stored **row-major**.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Window {
+    /// 1-based row of the top-left corner (echoes the request).
+    pub row0: u32,
+    /// 1-based column of the top-left corner (echoes the request).
+    pub col0: u32,
+    /// Number of rows in the window.
+    pub rows: u32,
+    /// Number of columns in the window.
+    pub cols: u32,
+    /// `rows * cols` values in row-major order: index `(r * cols + c)` is the
+    /// cell at absolute address `(row0 + r, col0 + c)`.
+    pub values: Vec<CellValue>,
+}
+
+impl Window {
+    /// The value at an absolute 1-based `(row, col)`, if it falls inside this
+    /// window. Convenience for tests and hosts that hold an address rather than
+    /// an offset.
+    pub fn get(&self, row: u32, col: u32) -> Option<&CellValue> {
+        if row < self.row0 || col < self.col0 {
+            return None;
+        }
+        let dr = row - self.row0;
+        let dc = col - self.col0;
+        if dr >= self.rows || dc >= self.cols {
+            return None;
+        }
+        self.values.get((dr * self.cols + dc) as usize)
+    }
+}
+
+/// The bounding box of all materialised, non-empty cells on a sheet, as
+/// returned by [`Workbook::used_range`]. 1-based and inclusive. A host sizes its
+/// scrollable area to this (plus a comfortable blank margin) so the scrollbar
+/// reflects the data while still letting the user scroll into empty space.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct UsedRange {
+    /// Topmost row containing a non-empty cell.
+    pub min_row: u32,
+    /// Leftmost column containing a non-empty cell.
+    pub min_col: u32,
+    /// Bottommost row containing a non-empty cell.
+    pub max_row: u32,
+    /// Rightmost column containing a non-empty cell.
+    pub max_col: u32,
+}
+
+/// The result of [`Workbook::changed_since`].
+///
+/// `Delta` lists exactly the cells whose value changed strictly after the
+/// queried revision. `Stale` means the query reached back before the retained
+/// change-log window, so completeness can't be guaranteed and the host should
+/// re-read its whole visible window — never silently miss a change.
+#[derive(Debug, Clone, PartialEq)]
+pub enum ChangeSet {
+    /// A complete list of changed addresses since the queried revision.
+    Delta {
+        /// The workbook's current revision (the host stores this for next time).
+        current_revision: u64,
+        /// Addresses whose value changed after the queried revision, deduped.
+        changed: Vec<CellAddress>,
+    },
+    /// The queried revision is older than the retained log; re-read the window.
+    Stale {
+        /// The workbook's current revision.
+        current_revision: u64,
+    },
+}

--- a/code/packages/rust/spreadsheet-core/src/workbook.rs
+++ b/code/packages/rust/spreadsheet-core/src/workbook.rs
@@ -5,7 +5,7 @@
 //! cells, dependency tracking, automatic-recalc-on-edit (the user
 //! can also call `recalc_all` for a full sweep).
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet, VecDeque};
 
 use crate::address::{CellAddress, SheetId};
 use crate::cell::{Cell, CellContent, CellValue};
@@ -13,6 +13,7 @@ use crate::dag::DependencyGraph;
 use crate::errors::SpreadsheetError;
 use crate::parser::{parse, ParseError};
 use crate::recalc::{collect_refs, evaluate};
+use crate::viewport::{ChangeSet, UsedRange, Window, CHANGELOG_RETAIN, MAX_WINDOW_CELLS};
 
 /// Top-level container — one or more sheets plus the dependency
 /// graph that spans them.
@@ -25,6 +26,18 @@ pub struct Workbook {
     graph: DependencyGraph,
     /// Recalc epoch; bumped after every successful `recalc_all`.
     epoch: u64,
+    /// Per-edit revision clock for viewport diffing. Unlike `epoch` (which only
+    /// advances on a full `recalc_all` sweep), `revision` advances once per
+    /// mutation (`set_value` / `set_formula` / `clear_cell`), so a virtualized
+    /// host can ask "what changed since the revision I last rendered?".
+    revision: u64,
+    /// Bounded change log: `(revision, sheet, addr)` for every cell whose value
+    /// was (re)written, newest at the back. Pruned to `CHANGELOG_RETAIN`.
+    changes: VecDeque<(u64, SheetId, CellAddress)>,
+    /// Highest revision whose entries have been dropped from `changes`. A
+    /// `changed_since(r)` with `r < dropped_revision` can't prove completeness
+    /// and must answer `Stale`.
+    dropped_revision: u64,
 }
 
 struct Sheet {
@@ -40,6 +53,9 @@ impl Workbook {
             sheet_by_name: HashMap::new(),
             graph: DependencyGraph::new(),
             epoch: 0,
+            revision: 0,
+            changes: VecDeque::new(),
+            dropped_revision: 0,
         }
     }
 
@@ -79,14 +95,141 @@ impl Workbook {
         self.epoch
     }
 
+    /// The per-edit revision clock, advanced once per mutation. A virtualized
+    /// host snapshots this, then later calls [`changed_since`](Self::changed_since)
+    /// with it to learn which cells changed in between.
+    pub fn current_revision(&self) -> u64 {
+        self.revision
+    }
+
+    /// Read a **dense** rectangle of computed values for the inclusive,
+    /// 1-based window `(row0..=row1, col0..=col1)`, row-major. Empty cells are
+    /// returned as [`CellValue::Empty`] so a host can index the result directly
+    /// and render a solid grid. This is `O(window)` — it looks each address up
+    /// in the sparse store — never `O(sheet)`.
+    ///
+    /// Errors with [`SpreadsheetError::Ref`] if the rectangle is inverted, the
+    /// sheet id is unknown, or the window exceeds
+    /// [`MAX_WINDOW_CELLS`](crate::viewport::MAX_WINDOW_CELLS) (the screen-scale
+    /// safety cap — a host clamps to the visible window well below it).
+    pub fn get_window(
+        &self,
+        sheet: SheetId,
+        row0: u32,
+        col0: u32,
+        row1: u32,
+        col1: u32,
+    ) -> Result<Window, SpreadsheetError> {
+        // Coordinates are 1-based (A1 = row 1, col 1), so a 0 is out of contract
+        // — and rejecting it also rules out the `row0 = 0` case that would let
+        // the span computation below span the full u32 range.
+        if row0 == 0 || col0 == 0 || row1 < row0 || col1 < col0 {
+            return Err(SpreadsheetError::Ref);
+        }
+        // Compute the span in u64. The operands MUST be widened to u64 *before*
+        // the `+ 1`: doing `(row1 - row0 + 1)` in u32 first overflows when
+        // `row1 - row0 == u32::MAX` (e.g. row0=1, row1=u32::MAX), wrapping to a
+        // bogus small count that would slip past the MAX_WINDOW_CELLS cap and
+        // send the loop over the entire u32 range — an OOM DoS. Widening first
+        // keeps the true count, so checked_mul + the cap reject it.
+        let rows = (row1 as u64 - row0 as u64) + 1;
+        let cols = (col1 as u64 - col0 as u64) + 1;
+        // `rows * cols` can still overflow u64 for a full-sheet request, so use
+        // checked_mul: an overflow is by definition past the cap.
+        match rows.checked_mul(cols) {
+            Some(n) if n <= MAX_WINDOW_CELLS => {}
+            _ => return Err(SpreadsheetError::Ref),
+        }
+        let s = self.sheets.get(sheet.0 as usize).ok_or(SpreadsheetError::Ref)?;
+        let mut values = Vec::with_capacity((rows * cols) as usize);
+        for r in row0..=row1 {
+            for c in col0..=col1 {
+                let v = s
+                    .cells
+                    .get(&CellAddress::new(r, c))
+                    .map(|cell| cell.current_value())
+                    .unwrap_or(CellValue::Empty);
+                values.push(v);
+            }
+        }
+        Ok(Window {
+            row0,
+            col0,
+            rows: rows as u32,
+            cols: cols as u32,
+            values,
+        })
+    }
+
+    /// The bounding box of all materialised, non-empty cells on `sheet`, or
+    /// `None` if the sheet is empty. 1-based inclusive. A host uses this to size
+    /// its scrollable area to the data. `O(materialised cells)`.
+    pub fn used_range(&self, sheet: SheetId) -> Option<UsedRange> {
+        let s = self.sheets.get(sheet.0 as usize)?;
+        let mut range: Option<UsedRange> = None;
+        for (addr, cell) in &s.cells {
+            if cell.current_value().is_empty() {
+                continue; // a present-but-empty cell doesn't extend the extent
+            }
+            match &mut range {
+                None => {
+                    range = Some(UsedRange {
+                        min_row: addr.row,
+                        min_col: addr.col,
+                        max_row: addr.row,
+                        max_col: addr.col,
+                    })
+                }
+                Some(r) => {
+                    r.min_row = r.min_row.min(addr.row);
+                    r.min_col = r.min_col.min(addr.col);
+                    r.max_row = r.max_row.max(addr.row);
+                    r.max_col = r.max_col.max(addr.col);
+                }
+            }
+        }
+        range
+    }
+
+    /// Which cells on `sheet` changed strictly after `since_revision`.
+    ///
+    /// Returns [`ChangeSet::Delta`] with a deduped address list when the log
+    /// still covers `since_revision`, or [`ChangeSet::Stale`] when the query
+    /// reaches back before the retained window — in which case the host must
+    /// re-read its whole visible window rather than risk missing a change.
+    pub fn changed_since(&self, sheet: SheetId, since_revision: u64) -> ChangeSet {
+        let current = self.revision;
+        // If anything at or before `since_revision` was pruned, a change in
+        // (since_revision, dropped_revision] may be gone — answer Stale. (When
+        // since >= dropped_revision, every change after it is still retained.)
+        if since_revision < self.dropped_revision {
+            return ChangeSet::Stale {
+                current_revision: current,
+            };
+        }
+        let mut seen = HashSet::new();
+        let mut changed = Vec::new();
+        for (rev, sid, addr) in &self.changes {
+            if *rev > since_revision && *sid == sheet && seen.insert(*addr) {
+                changed.push(*addr);
+            }
+        }
+        ChangeSet::Delta {
+            current_revision: current,
+            changed,
+        }
+    }
+
     /// Set a literal value (no formula). Updates the dependency
     /// graph (removes any prior edges from this cell) and triggers
     /// recalc of downstream cells.
     pub fn set_value(&mut self, sheet: SheetId, addr: CellAddress, value: CellValue) {
+        self.revision = self.revision.wrapping_add(1);
         let s = &mut self.sheets[sheet.0 as usize];
         s.cells.insert(addr, Cell::value(value));
         self.graph.remove((sheet, addr));
-        self.recalc_dependents_of(sheet, addr);
+        self.log_change(sheet, addr); // the literal itself changed
+        self.recalc_dependents_of(sheet, addr); // dependents log via set_cached
     }
 
     /// Set a formula. Parses the text; on a parse error, stores the
@@ -98,6 +241,7 @@ impl Workbook {
         text: &str,
     ) -> Result<(), ParseError> {
         let ast = parse(text)?;
+        self.revision = self.revision.wrapping_add(1);
         let s = &mut self.sheets[sheet.0 as usize];
         s.cells.insert(
             addr,
@@ -121,9 +265,11 @@ impl Workbook {
 
     /// Mark a cell empty.
     pub fn clear_cell(&mut self, sheet: SheetId, addr: CellAddress) {
+        self.revision = self.revision.wrapping_add(1);
         let s = &mut self.sheets[sheet.0 as usize];
         s.cells.remove(&addr);
         self.graph.remove((sheet, addr));
+        self.log_change(sheet, addr); // the cell became empty
         self.recalc_dependents_of(sheet, addr);
     }
 
@@ -144,6 +290,9 @@ impl Workbook {
 
     /// Recalculate every formula cell. Bumps the epoch on success.
     pub fn recalc_all(&mut self) {
+        // A full sweep is one revision-transaction too, so the cells it rewrites
+        // land in the change log under a single new revision.
+        self.revision = self.revision.wrapping_add(1);
         // Build a set of all formula cells.
         let mut all: std::collections::HashSet<(SheetId, CellAddress)> =
             std::collections::HashSet::new();
@@ -221,10 +370,29 @@ impl Workbook {
     }
 
     fn set_cached(&mut self, sheet: SheetId, addr: CellAddress, value: CellValue) {
-        let s = &mut self.sheets[sheet.0 as usize];
-        if let Some(cell) = s.cells.get_mut(&addr) {
-            if let CellContent::Formula { cached, .. } = &mut cell.content {
-                *cached = Some(value);
+        {
+            let s = &mut self.sheets[sheet.0 as usize];
+            if let Some(cell) = s.cells.get_mut(&addr) {
+                if let CellContent::Formula { cached, .. } = &mut cell.content {
+                    *cached = Some(value);
+                }
+            }
+        }
+        // Every recompute is a (potential) value change for viewport diffing.
+        // v1 stamps on write rather than diffing old vs new: a no-op recompute
+        // logs the cell even if its value is unchanged. That over-reports at
+        // worst — a host re-fetches a handful of identical cells, which is safe;
+        // exact old/new diffing is a future optimisation.
+        self.log_change(sheet, addr);
+    }
+
+    /// Append a change-log entry under the current revision, pruning the log to
+    /// `CHANGELOG_RETAIN` and tracking the highest dropped revision.
+    fn log_change(&mut self, sheet: SheetId, addr: CellAddress) {
+        self.changes.push_back((self.revision, sheet, addr));
+        while self.changes.len() > CHANGELOG_RETAIN {
+            if let Some((dropped, _, _)) = self.changes.pop_front() {
+                self.dropped_revision = self.dropped_revision.max(dropped);
             }
         }
     }
@@ -423,5 +591,166 @@ mod tests {
             wb.set_formula(s, cell(r, 1), &format!("=A{}+1", r - 1)).unwrap();
         }
         assert_eq!(wb.get_value(s, cell(N, 1)), Some(CellValue::Number(N as f64)));
+    }
+
+    // ── Viewport primitive (infinite virtualized sheet) ──────────────
+
+    #[test]
+    fn get_window_is_dense_with_blanks() {
+        let mut wb = Workbook::new();
+        let s = wb.add_sheet("S");
+        wb.set_value(s, cell(1, 1), CellValue::Number(1.0));
+        wb.set_value(s, cell(1, 3), CellValue::Number(3.0)); // B1 (col 2) left empty
+        let w = wb.get_window(s, 1, 1, 1, 3).unwrap();
+        assert_eq!((w.rows, w.cols), (1, 3));
+        assert_eq!(w.values, vec![
+            CellValue::Number(1.0), // A1
+            CellValue::Empty,       // B1 — blank, not omitted
+            CellValue::Number(3.0), // C1
+        ]);
+        assert_eq!(w.get(1, 2), Some(&CellValue::Empty));
+        assert_eq!(w.get(1, 3), Some(&CellValue::Number(3.0)));
+    }
+
+    #[test]
+    fn get_window_returns_computed_formula_values() {
+        let mut wb = Workbook::new();
+        let s = wb.add_sheet("S");
+        wb.set_value(s, cell(1, 1), CellValue::Number(15.0));
+        wb.set_value(s, cell(1, 2), CellValue::Number(3.0));
+        wb.set_formula(s, cell(1, 3), "=SUM(A1:B1)").unwrap();
+        let w = wb.get_window(s, 1, 3, 1, 3).unwrap();
+        assert_eq!(w.values, vec![CellValue::Number(18.0)]);
+    }
+
+    #[test]
+    fn get_window_far_flung_cell_is_cheap() {
+        // A cell at row 1,000,000, col 1000 is reachable without materialising
+        // the rectangle between it and the origin — the read is O(window).
+        let mut wb = Workbook::new();
+        let s = wb.add_sheet("S");
+        wb.set_value(s, cell(1_000_000, 1_000), CellValue::Number(42.0));
+        let w = wb.get_window(s, 1_000_000, 1_000, 1_000_000, 1_000).unwrap();
+        assert_eq!(w.values, vec![CellValue::Number(42.0)]);
+    }
+
+    #[test]
+    fn get_window_rejects_inverted_and_oversized() {
+        let mut wb = Workbook::new();
+        let s = wb.add_sheet("S");
+        assert!(wb.get_window(s, 2, 1, 1, 1).is_err()); // row1 < row0
+        assert!(wb.get_window(s, 1, 2, 1, 1).is_err()); // col1 < col0
+        // 400×400 = 160 000 > MAX_WINDOW_CELLS (65 536).
+        assert!(wb.get_window(s, 1, 1, 400, 400).is_err());
+        // Full-sheet request: rows*cols overflows u64 → still rejected, no panic.
+        assert!(wb.get_window(s, 1, 1, u32::MAX, u32::MAX).is_err());
+    }
+
+    #[test]
+    fn get_window_full_u32_span_is_rejected_not_a_dos() {
+        // Regression: the span must be computed in u64. A full-u32-span request
+        // (row1 - row0 == u32::MAX) would overflow the u32 `+ 1`, wrap to a bogus
+        // small count, slip past the cap, and loop over the entire u32 range
+        // (OOM in release, panic in debug). row0 = 0 is also out of the 1-based
+        // contract. All of these must return Err WITHOUT panicking or hanging.
+        let mut wb = Workbook::new();
+        let s = wb.add_sheet("S");
+        assert!(wb.get_window(s, 0, 0, u32::MAX, u32::MAX).is_err()); // row0=0 + full span
+        assert!(wb.get_window(s, 0, 1, 10, 10).is_err()); // 0 violates 1-based
+        assert!(wb.get_window(s, 1, 0, 10, 10).is_err());
+        assert!(wb.get_window(s, 1, 1, u32::MAX, 1).is_err()); // tall full-span column
+        assert!(wb.get_window(s, 1, 1, 1, u32::MAX).is_err()); // wide full-span row
+    }
+
+    #[test]
+    fn used_range_none_when_empty_some_when_scattered() {
+        let mut wb = Workbook::new();
+        let s = wb.add_sheet("S");
+        assert_eq!(wb.used_range(s), None);
+        wb.set_value(s, cell(1, 1), CellValue::Number(1.0)); // A1
+        wb.set_value(s, cell(100, 26), CellValue::Number(2.0)); // Z100
+        assert_eq!(wb.used_range(s), Some(UsedRange {
+            min_row: 1, min_col: 1, max_row: 100, max_col: 26,
+        }));
+    }
+
+    #[test]
+    fn used_range_skips_present_but_empty_cells() {
+        let mut wb = Workbook::new();
+        let s = wb.add_sheet("S");
+        wb.set_value(s, cell(1, 1), CellValue::Number(1.0));
+        wb.set_value(s, cell(9, 9), CellValue::Empty); // present but empty
+        // The Empty cell must not extend the extent.
+        assert_eq!(wb.used_range(s), Some(UsedRange {
+            min_row: 1, min_col: 1, max_row: 1, max_col: 1,
+        }));
+    }
+
+    #[test]
+    fn current_revision_advances_per_edit() {
+        let mut wb = Workbook::new();
+        let s = wb.add_sheet("S");
+        let r0 = wb.current_revision();
+        wb.set_value(s, cell(1, 1), CellValue::Number(1.0));
+        let r1 = wb.current_revision();
+        wb.set_value(s, cell(1, 2), CellValue::Number(2.0));
+        let r2 = wb.current_revision();
+        assert!(r1 > r0 && r2 > r1);
+    }
+
+    #[test]
+    fn changed_since_reports_edited_cell_and_its_dependents() {
+        let mut wb = Workbook::new();
+        let s = wb.add_sheet("S");
+        wb.set_value(s, cell(1, 1), CellValue::Number(1.0));
+        wb.set_formula(s, cell(1, 2), "=A1*10").unwrap();
+        let snap = wb.current_revision();
+        wb.set_value(s, cell(1, 1), CellValue::Number(9.0)); // A1 + dependent B1
+        match wb.changed_since(s, snap) {
+            ChangeSet::Delta { changed, .. } => {
+                assert!(changed.contains(&cell(1, 1)), "A1 changed");
+                assert!(changed.contains(&cell(1, 2)), "B1 (dependent) changed");
+                assert_eq!(changed.len(), 2, "deduped");
+            }
+            ChangeSet::Stale { .. } => panic!("should be a Delta"),
+        }
+    }
+
+    #[test]
+    fn changed_since_filters_by_sheet() {
+        let mut wb = Workbook::new();
+        let s1 = wb.add_sheet("S1");
+        let s2 = wb.add_sheet("S2");
+        let snap = wb.current_revision();
+        wb.set_value(s1, cell(1, 1), CellValue::Number(1.0));
+        // The edit on S1 must not appear when querying S2.
+        match wb.changed_since(s2, snap) {
+            ChangeSet::Delta { changed, .. } => assert!(changed.is_empty()),
+            ChangeSet::Stale { .. } => panic!("should be a Delta"),
+        }
+    }
+
+    #[test]
+    fn changed_since_goes_stale_past_the_retained_window() {
+        let mut wb = Workbook::new();
+        let s = wb.add_sheet("S");
+        let snap = wb.current_revision(); // 0
+        // Edit far more distinct cells than the log retains, forcing it to drop
+        // the oldest entries — a query reaching back to `snap` can't be proven
+        // complete, so it must answer Stale (re-read everything).
+        for i in 1..=(CHANGELOG_RETAIN as u32 + 100) {
+            wb.set_value(s, cell(i, 1), CellValue::Number(i as f64));
+        }
+        assert!(matches!(
+            wb.changed_since(s, snap),
+            ChangeSet::Stale { .. }
+        ));
+        // But a recent snapshot still returns a Delta.
+        let recent = wb.current_revision();
+        wb.set_value(s, cell(1, 1), CellValue::Number(0.0));
+        assert!(matches!(
+            wb.changed_since(s, recent),
+            ChangeSet::Delta { .. }
+        ));
     }
 }

--- a/code/packages/rust/spreadsheet-wasm/CHANGELOG.md
+++ b/code/packages/rust/spreadsheet-wasm/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.2.0
+
+Viewport entry points for the virtualized infinite sheet, mirroring
+`spreadsheet-core-wasm` 0.2.0. Integer coordinates are passed directly (no
+pointer marshalling); JSON results use the existing `[len][bytes]` pack:
+
+- `get_window(row0, col0, row1, col1) -> *mut u8` (packed window JSON).
+- `used_range() -> *mut u8`, `column_letters(index) -> *mut u8`.
+- `current_revision() -> u64` (returned directly, not packed).
+- `changed_since(since: u64) -> *mut u8`.
+
 ## 0.1.0
 
 Initial release — the `extern "C"` + linear-memory WASM ABI over the

--- a/code/packages/rust/spreadsheet-wasm/Cargo.toml
+++ b/code/packages/rust/spreadsheet-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spreadsheet-wasm"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "extern \"C\" + linear-memory WASM ABI over the spreadsheet-core-wasm JSON facade"
 license = "MIT"

--- a/code/packages/rust/spreadsheet-wasm/src/lib.rs
+++ b/code/packages/rust/spreadsheet-wasm/src/lib.rs
@@ -195,6 +195,46 @@ pub extern "C" fn get_values() -> *mut u8 {
     pack(SESSION.with(|s| s.borrow().get_values()))
 }
 
+// ── Viewport primitive (virtualized infinite sheet) ──────────────────
+// These take integer coordinates directly (no pointer marshalling), so a
+// scrolling JS host can fetch just the visible window of an unbounded sheet.
+
+/// `get_window(row0, col0, row1, col1)` → window JSON (1-based, inclusive). See
+/// [`SpreadsheetSession::get_window`].
+#[no_mangle]
+pub extern "C" fn get_window(row0: u32, col0: u32, row1: u32, col1: u32) -> *mut u8 {
+    pack(SESSION.with(|s| s.borrow().get_window(row0, col0, row1, col1)))
+}
+
+/// `used_range()` → data-extent JSON, or the literal `null`. See
+/// [`SpreadsheetSession::used_range`].
+#[no_mangle]
+pub extern "C" fn used_range() -> *mut u8 {
+    pack(SESSION.with(|s| s.borrow().used_range()))
+}
+
+/// `column_letters(index)` → `"A"`/`"AA"`/… for a 1-based column index. See
+/// [`SpreadsheetSession::column_letters`].
+#[no_mangle]
+pub extern "C" fn column_letters(index: u32) -> *mut u8 {
+    pack(SESSION.with(|s| s.borrow().column_letters(index)))
+}
+
+/// `current_revision()` → the per-edit revision clock, returned directly (it's a
+/// plain integer, not a packed string). See
+/// [`SpreadsheetSession::current_revision`].
+#[no_mangle]
+pub extern "C" fn current_revision() -> u64 {
+    SESSION.with(|s| s.borrow().current_revision())
+}
+
+/// `changed_since(since)` → changed-cells JSON. See
+/// [`SpreadsheetSession::changed_since`].
+#[no_mangle]
+pub extern "C" fn changed_since(since: u64) -> *mut u8 {
+    pack(SESSION.with(|s| s.borrow().changed_since(since)))
+}
+
 // ---------------------------------------------------------------------------
 // Host-target tests: exercise the ABI exactly as the JS loader would, but in
 // Rust (so they run under `cargo test` with no WASM toolchain). We drive the
@@ -298,5 +338,36 @@ mod tests {
         reset();
         set("A1", "=1/0");
         assert_eq!(value("A1"), r##"{"code":"#DIV/0!","kind":"error"}"##);
+    }
+
+    #[test]
+    fn abi_viewport_round_trips() {
+        reset();
+        set("A1", "15");
+        set("B1", "3");
+        set("C1", "=SUM(A1:B1)"); // 18
+
+        // get_window over A1:C1 — integer coords passed straight through.
+        let w = take(get_window(1, 1, 1, 3));
+        assert!(w.contains(r#""rows":1"#) && w.contains(r#""cols":3"#), "{w}");
+        assert!(w.contains(r#"{"kind":"number","value":18.0}"#), "{w}");
+
+        // used_range covers A1..C1.
+        let u = take(used_range());
+        assert!(u.contains(r#""minRow":1"#) && u.contains(r#""maxCol":3"#), "{u}");
+
+        // column_letters beyond Z.
+        assert_eq!(take(column_letters(27)), "AA");
+
+        // revision clock + changed_since diff: editing A1 dirties A1 and its
+        // dependent C1, but not B1.
+        let snap = current_revision();
+        set("A1", "100");
+        let c = take(changed_since(snap));
+        assert!(c.contains("\"A1\"") && c.contains("\"C1\""), "{c}");
+        assert!(!c.contains("\"stale\""), "{c}");
+
+        // A bad window surfaces an error object — never a panic/trap.
+        assert_eq!(take(get_window(0, 0, 5, 5)), r##"{"error":"#REF!"}"##);
     }
 }


### PR DESCRIPTION
Third PR of the **infinite virtualized sheet** arc (spec [#5805](https://github.com/adhithyan15/coding-adventures/pull/5805) merged · engine [#5810](https://github.com/adhithyan15/coding-adventures/pull/5810)). Surfaces the engine's viewport reads through **all three facades**, so every host — web (WASM) and the five native backends (C ABI) — fetches the visible window of an unbounded sheet through the same string-in/JSON-out contract.

> **Stacked on [#5810](https://github.com/adhithyan15/coding-adventures/pull/5810).** Base is `feat/infinite-sheet-engine` so the diff shows facade-only; it auto-retargets to `main` once the engine PR merges. Review/merge #5810 first.

## What

- **`spreadsheet-core-wasm` (0.2.0)** — five new `SpreadsheetSession` methods returning JSON: `get_window` → `{"row0","col0","rows","cols","values":[[<value>,…],…]}` (dense, row-major, blanks as `{"kind":"empty"}`) or `{"error":"#REF!"}`; `used_range` → extent or `null`; `column_letters` → `"A"`/`"AA"`; `current_revision` + `changed_since` → `{"revision":N,"changed":[…]}` | `{"revision":N,"stale":true}`.
- **`spreadsheet-wasm` (0.2.0)** — `#[no_mangle]` entry points taking integer coords directly (no pointer marshalling); JSON via the existing `[len][bytes]` pack; `current_revision` returns `u64` directly.
- **`spreadsheet-capi` (0.2.0)** — `sc_get_window` / `sc_used_range` / `sc_column_letters` / `sc_current_revision` / `sc_changed_since`, each null-checking the handle; `spreadsheet.h` gains `<stdint.h>` + declarations.

## Verification

- New round-trip tests in **all three facades** (core-wasm 17, wasm-abi 5, capi 4); full spreadsheet crate sweep green; clippy clean.
- `/security-review` **passed** — null-checks on every C-ABI entry, bounded marshalling (engine's 65 536 cap), serde auto-escaped JSON, `into_cstr`/`sc_string_free` contract intact, no new `unsafe`/panics.

## Next

PR-4: rebuild the `.wasm` + JS loader binding + **virtualize the web demo** — the live render proof (scroll thousands of rows, screenshot, assert via DOM-node count that only the visible window is materialized).

🤖 Generated with [Claude Code](https://claude.com/claude-code)