### PR TITLE
feat(sharded-echo-bench): CPU-bound mode proves req/s scales with shards

### DIFF
--- a/code/programs/rust/sharded-echo-bench/CHANGELOG.md
+++ b/code/programs/rust/sharded-echo-bench/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 All notable changes to this package will be documented in this file.
 
+## [0.2.0] - 2026-06-14
+
+### Added
+
+- **CPU-bound workload mode** (`BenchParams::work_per_request`, env var
+  `BENCH_WORK`, default `0`). The echo handler optionally does `N` rounds of a
+  cheap hash over the payload before replying, turning each request from a
+  latency-bound loopback round-trip into real CPU work. This is the regime where
+  adding reactor shards actually adds throughput.
+- **The throughput-scaling proof.** With `BENCH_WORK=20000` on a 14-core macOS box,
+  `req/s` scales near-linearly with shards — `800 → 1588 → 2962 → 5830` across
+  `1 → 2 → 4 → 8` shards (≈7.3× at 8×), with `p50` latency falling in lockstep
+  (39.5 ms → 5.4 ms). The default `BENCH_WORK=0` run stays flat; the two side by
+  side close the loop the 0.1.0 finding left open ("even distribution is necessary
+  but not sufficient — you need CPU-bound work to see req/s scale").
+- Test `cpu_bound_mode_still_echoes_correctly` — proves the CPU-work path doesn't
+  corrupt the response (bytes still round-trip) and the run still reports.
+
+### Changed
+
+- `run_sweep` gains a `work_per_request` parameter; the CLI prints the
+  `work/req` setting and a one-line regime description (latency-bound vs CPU-bound).
+
 ## [0.1.0] - 2026-06-14
 
 ### Added

--- a/code/programs/rust/sharded-echo-bench/Cargo.toml
+++ b/code/programs/rust/sharded-echo-bench/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sharded-echo-bench"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "Scaling benchmark for the multi-core ShardedTcpRuntime: throughput/latency at 1..N reactor shards"
 publish = false

--- a/code/programs/rust/sharded-echo-bench/README.md
+++ b/code/programs/rust/sharded-echo-bench/README.md
@@ -27,7 +27,12 @@ count), so it is *not* what CI runs — CI runs only a fast `#[test]` smoke:
 cargo run -p sharded-echo-bench --release
 # tunables:
 BENCH_CLIENTS=128 BENCH_PAYLOAD=64 BENCH_SECONDS=3 cargo run -p sharded-echo-bench --release
+# make each request CPU-bound so req/s scales with shards (see the throughput proof below):
+BENCH_WORK=20000 cargo run -p sharded-echo-bench --release
 ```
+
+`BENCH_WORK` (default `0`) is rounds of synthetic CPU work per request: `0` is a
+pure echo (latency-bound), non-zero makes the load CPU-bound.
 
 ## The `shard balance` column is the headline
 
@@ -77,6 +82,35 @@ to saturate a core (real parsing, TLS, compute…). Even distribution is necessa
 for multi-core scaling; it is not sufficient on its own for a near-zero workload.
 Linux uses the kernel `SO_REUSEPORT` balancing and reaches the same even
 distribution by a different route.
+
+### The throughput proof: `BENCH_WORK` makes requests CPU-bound
+
+The claim above — "even distribution adds throughput *once the work saturates a
+core*" — is testable, so the benchmark tests it. `BENCH_WORK=N` makes the echo
+handler do `N` rounds of a cheap hash over the payload **before** replying, turning
+each request from a near-free loopback round-trip into real CPU work. Now the
+shards have something to parallelize, and `req/s` scales with the worker count:
+
+```
+$ BENCH_CLIENTS=32 BENCH_WORK=20000 cargo run -p sharded-echo-bench --release   # macOS, 14 cores
+
+ workers |   conns/s |     req/s |   MiB/s |  p50 µs |  p99 µs | shard balance
+---------+-----------+-----------+---------+---------+---------+---------------
+       1 |     36495 |       800 |     0.0 | 39543.7 | 47535.4 | [100%]
+       2 |     32686 |      1588 |     0.1 | 20229.1 | 21574.2 | [50% 50%]
+       4 |     31739 |      2962 |     0.2 | 10724.2 | 14313.7 | [25% 25% 25% 25%]
+       8 |     34985 |      5830 |     0.4 |  5423.8 |  6736.9 | [13% 13% 13% 13% 13% 13% 13% 13%]
+
+8-shard throughput is 7.29x the single-shard baseline.
+```
+
+That is the multi-core payoff, end to end: **800 → 1588 → 2962 → 5830 req/s** is
+near-linear scaling across `1 → 2 → 4 → 8` shards (≈7.3× at 8×), and `p50` latency
+falls in lockstep (39.5 ms → 5.4 ms) because eight reactors are draining the same
+offered load in parallel. Run the same sweep with `BENCH_WORK=0` (the default) and
+`req/s` stays flat — the two runs side by side are the whole thesis: a multi-core
+runtime turns parallel-izable work into throughput, and trivial work has none to
+turn.
 
 ## Reading the rest honestly
 

--- a/code/programs/rust/sharded-echo-bench/src/lib.rs
+++ b/code/programs/rust/sharded-echo-bench/src/lib.rs
@@ -80,6 +80,7 @@ fn shard_bits_for(worker_count: usize) -> u32 {
 fn bind_echo(
     worker_count: usize,
     shard_accepts: Arc<Vec<AtomicU64>>,
+    work_per_request: usize,
 ) -> Result<EchoRuntime, tcp_runtime::PlatformError> {
     let mask = (1u64 << shard_bits_for(worker_count)) - 1;
     let init = move |info: TcpConnectionInfo| {
@@ -88,8 +89,23 @@ fn bind_echo(
             counter.fetch_add(1, Ordering::Relaxed);
         }
     };
-    let handler =
-        |_info: TcpConnectionInfo, _state: &mut (), bytes: &[u8]| TcpHandlerResult::write(bytes.to_vec());
+    let handler = move |_info: TcpConnectionInfo, _state: &mut (), bytes: &[u8]| {
+        // Optional CPU work per request: `work_per_request` rounds of a cheap hash
+        // over the payload, kept from being optimised away by `black_box`.  This
+        // makes each request cost real CPU, so the load becomes CPU-bound and the
+        // reactor shards can each saturate a core in parallel — turning even
+        // connection distribution into actual throughput scaling.
+        if work_per_request > 0 {
+            let mut acc = 0u64;
+            for _ in 0..work_per_request {
+                for &byte in bytes {
+                    acc = acc.wrapping_mul(1_000_003).wrapping_add(byte as u64);
+                }
+            }
+            std::hint::black_box(acc);
+        }
+        TcpHandlerResult::write(bytes.to_vec())
+    };
     let on_close = |_info: TcpConnectionInfo, _state: ()| {};
 
     #[cfg(any(
@@ -146,6 +162,13 @@ pub struct BenchParams {
     pub payload_len: usize,
     /// How long the throughput phase runs.
     pub duration: Duration,
+    /// Synthetic CPU work per request: rounds of a cheap hash over the payload,
+    /// run inside the echo handler before replying.  `0` is a pure echo
+    /// (latency-bound on loopback, so distribution doesn't add throughput); a
+    /// non-zero value makes each request **CPU-bound**, which is the regime where
+    /// adding reactor shards actually adds throughput.  This is the knob that turns
+    /// "connections are evenly distributed" into "and req/s scales with cores".
+    pub work_per_request: usize,
 }
 
 /// The measured outcome of one run.
@@ -188,7 +211,7 @@ pub fn run_benchmark(params: BenchParams) -> Result<BenchResult, tcp_runtime::Pl
     let shard_accepts: Arc<Vec<AtomicU64>> =
         Arc::new((0..worker_count).map(|_| AtomicU64::new(0)).collect());
 
-    let mut runtime = bind_echo(worker_count, Arc::clone(&shard_accepts))?;
+    let mut runtime = bind_echo(worker_count, Arc::clone(&shard_accepts), params.work_per_request)?;
     let actual_workers = runtime.worker_count();
     let addr = runtime.local_addr();
     let stop: ShardedStopHandle = runtime.stop_handle();
@@ -347,8 +370,20 @@ pub fn format_table(results: &[BenchResult]) -> String {
 }
 
 /// Run the standard sweep (`worker_count = 1, 2, 4, 8`) with the given client
-/// pool / payload / duration, returning one result per shard count.
-pub fn run_sweep(clients: usize, payload_len: usize, duration: Duration) -> Vec<BenchResult> {
+/// pool / payload / duration / per-request CPU work, returning one result per
+/// shard count.
+///
+/// With `work_per_request = 0` the echo is latency-bound (loopback round-trip
+/// dominates) and `req/s` stays roughly flat across shard counts.  With a
+/// non-zero `work_per_request` each request burns real CPU, so the shards can
+/// each saturate a core and `req/s` climbs with the worker count — the
+/// throughput-scaling proof.
+pub fn run_sweep(
+    clients: usize,
+    payload_len: usize,
+    duration: Duration,
+    work_per_request: usize,
+) -> Vec<BenchResult> {
     [1usize, 2, 4, 8]
         .iter()
         .filter_map(|&worker_count| {
@@ -357,6 +392,7 @@ pub fn run_sweep(clients: usize, payload_len: usize, duration: Duration) -> Vec<
                 clients,
                 payload_len,
                 duration,
+                work_per_request,
             })
             .ok()
         })
@@ -378,6 +414,7 @@ mod tests {
             clients: 4,
             payload_len: 64,
             duration: Duration::from_millis(300),
+            work_per_request: 0,
         };
         let result = run_benchmark(params).expect("server binds");
 
@@ -401,11 +438,36 @@ mod tests {
             clients: 2,
             payload_len: 16,
             duration: Duration::from_millis(150),
+            work_per_request: 0,
         })
         .expect("server binds");
         assert_eq!(result.worker_count, 1);
         assert_eq!(result.shard_accepts.len(), 1);
         assert_eq!(result.shard_accepts[0], 2);
+    }
+
+    #[test]
+    fn cpu_bound_mode_still_echoes_correctly() {
+        // With `work_per_request > 0` the handler does real CPU work before
+        // echoing.  The point of this test is to prove the CPU-work path doesn't
+        // corrupt the response: the bytes must still round-trip unchanged (a
+        // mismatched echo errors the client and drops the request to zero), and
+        // the run must still complete and report.
+        let result = run_benchmark(BenchParams {
+            worker_count: 2,
+            clients: 3,
+            payload_len: 32,
+            duration: Duration::from_millis(200),
+            work_per_request: 50,
+        })
+        .expect("server binds");
+
+        assert_eq!(result.worker_count, 2);
+        assert!(
+            result.total_requests > 0,
+            "echoes must still complete with CPU work enabled"
+        );
+        assert_eq!(result.shard_accepts.iter().sum::<u64>(), 3);
     }
 
     #[test]

--- a/code/programs/rust/sharded-echo-bench/src/main.rs
+++ b/code/programs/rust/sharded-echo-bench/src/main.rs
@@ -11,7 +11,18 @@
 //! ```
 //!
 //! Tunables via env vars: `BENCH_CLIENTS` (default 64), `BENCH_PAYLOAD` (bytes,
-//! default 64), `BENCH_SECONDS` (per shard count, default 3).
+//! default 64), `BENCH_SECONDS` (per shard count, default 3), `BENCH_WORK`
+//! (CPU-work rounds per request, default 0).
+//!
+//! `BENCH_WORK=0` is a pure echo — latency-bound on loopback, so `req/s` barely
+//! moves as you add shards (the connection setup parallelizes, the round-trip
+//! doesn't).  Set `BENCH_WORK` to a few thousand to make each request CPU-bound;
+//! that is the regime where adding reactor shards adds throughput, and the
+//! closing speedup line should climb toward the core count.  Example:
+//!
+//! ```text
+//! BENCH_WORK=20000 cargo run -p sharded-echo-bench --release
+//! ```
 
 use std::time::Duration;
 
@@ -28,11 +39,18 @@ fn main() {
     let clients = env_usize("BENCH_CLIENTS", 64);
     let payload = env_usize("BENCH_PAYLOAD", 64);
     let seconds = env_usize("BENCH_SECONDS", 3);
+    let work = env_usize("BENCH_WORK", 0);
     let duration = Duration::from_secs(seconds as u64);
 
+    let regime = if work == 0 {
+        "latency-bound pure echo — req/s stays ~flat; conns/s is what scales"
+    } else {
+        "CPU-bound — each request burns real CPU, so req/s should scale with shards"
+    };
     println!(
         "sharded-echo-bench — loopback echo, {clients} clients, {payload}B payload, \
-         {seconds}s per shard count\n\
+         {seconds}s per shard count, work/req = {work}\n\
+         ({regime})\n\
          (measures the runtime, not a NIC; SO_REUSEPORT balance is even on Linux, \
          skewed on macOS/BSD)\n"
     );
@@ -42,7 +60,7 @@ fn main() {
         .unwrap_or(1);
     println!("available_parallelism = {cores} core(s)\n");
 
-    let results = run_sweep(clients, payload, duration);
+    let results = run_sweep(clients, payload, duration, work);
     print!("{}", format_table(&results));
 
     // A one-line takeaway: speedup of the largest shard count vs a single shard.


### PR DESCRIPTION
## What

Adds a **CPU-bound workload mode** to `sharded-echo-bench` and uses it to demonstrate that the multi-core runtime's `req/s` actually scales with reactor shards — the one honest gap the 0.1.0 benchmark flagged but couldn't show.

## Why

The 0.1.0 benchmark proved the macOS/BSD **accept fan-out** distributes connections evenly across shards (`[13% × 8]`), but the trivial echo's steady-state `req/s` stayed flat. That was correct and honest: loopback echo is **latency-bound, not CPU-bound**, so even distribution is *necessary but not sufficient* — you need per-request work that can saturate a core before adding shards adds throughput.

This PR makes that testable, and tests it.

## How

`BENCH_WORK=N` (new env var, default `0`) makes the echo handler run `N` rounds of a cheap wrapping-hash over the payload before replying. `0` is the original pure echo; non-zero makes each request CPU-bound.

## The proof (macOS, 14 cores)

```
$ BENCH_CLIENTS=32 BENCH_WORK=20000 cargo run -p sharded-echo-bench --release

 workers |   conns/s |     req/s |   MiB/s |  p50 µs |  p99 µs | shard balance
---------+-----------+-----------+---------+---------+---------+---------------
       1 |     36495 |       800 |     0.0 | 39543.7 | 47535.4 | [100%]
       2 |     32686 |      1588 |     0.1 | 20229.1 | 21574.2 | [50% 50%]
       4 |     31739 |      2962 |     0.2 | 10724.2 | 14313.7 | [25% 25% 25% 25%]
       8 |     34985 |      5830 |     0.4 |  5423.8 |  6736.9 | [13% 13% 13% 13% 13% 13% 13% 13%]

8-shard throughput is 7.29x the single-shard baseline.
```

**800 → 1588 → 2962 → 5830 req/s** — near-linear across `1 → 2 → 4 → 8` shards (~7.3× at 8×), with `p50` latency falling in lockstep (39.5 ms → 5.4 ms). Run with `BENCH_WORK=0` and `req/s` stays flat — the two side by side are the whole multi-core thesis.

## Changes

- `lib.rs`: thread `work_per_request` through `bind_echo` (the handler), `BenchParams`, `run_benchmark`, `run_sweep`; new test `cpu_bound_mode_still_echoes_correctly` proves the CPU path doesn't corrupt the echoed bytes.
- `main.rs`: `BENCH_WORK` env var + a one-line regime description.
- README/CHANGELOG: the throughput-scaling proof beside the flat baseline; version bump `0.1.0 → 0.2.0`.

## Verification

- `cargo test -p sharded-echo-bench` — 5/5 pass (incl. the new CPU-bound echo-correctness test).
- `cargo clippy --all-targets` — clean.
- Security review (Rust): wrapping arithmetic (no overflow panic), `BENCH_WORK` parsed panic-safe with a default, all input loopback from the in-process load generator — no untrusted trust boundary. **PASSED**, no findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)