### PR TITLE
feat(lang-full): E2 (4/6) — iir-to-jvm wraps narrow-width arithmetic

### DIFF
--- a/code/packages/rust/iir-to-jvm-class-file/CHANGELOG.md
+++ b/code/packages/rust/iir-to-jvm-class-file/CHANGELOG.md
@@ -3,6 +3,28 @@
 All notable changes to this crate are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.12.0] — 2026-06-14 (LANG-FULL E2 — register width & wrap, backend 4 of 6)
+
+### Added — narrow-width arithmetic wraps mod-2ⁿ on the JVM
+
+JVM `int` arithmetic (`iadd`/`imul`/…) wraps mod-2³², so `u32`/`i32` were
+already correct.  But `u8`/`u16` left a full 32-bit result, so a lowered
+`200u8 + 100u8` gave `300`, not `44`.
+
+`emit_jvm_width_mask` now appends `iconst/sipush/ldc <mask>; iand` after a
+narrow-width (`u4`→0xF, `u8`→0xFF, `u16`→0xFFFF) `add`/`sub`/`mul`/`div`/`mod` /
+`neg` / `and`/`or`/`xor` / `not` / `shl`/`shr` result — mirroring vm-core's
+`mask_result`, jit-core's `MASK_WIDTH`, the wasm `i32.and`, and the byte-tape
+`baload`+mask precedent.  The mask uses a **positive constant + `iand`**, not
+`i2b`/`i2s` (those sign-extend, giving a signed byte — wrong for the unsigned
+narrow types the LANG-FULL frontends use).  `0xFFFF` exceeds `sipush` range, so
+it loads from the constant pool via `emit_iconst_cp`.  `u32`/`i32` need no mask;
+`i64`/`u64`/floats are unchanged.
+
+Tests assert the lowering emits the `sipush 255; iand` byte mask for a `u8`
+add / not / shl and omits it for `i64`/`u32`.  (The executed cross-backend JVM
+proof lands in the E2 integration PR via lang-aot's real-`java` `run_jvm`.)
+
 ## [0.11.0] — 2026-06-12 (LANG-MATRIX LM-J Brainfuck — byte-tape ops on the JVM)
 
 Adds the lowering Brainfuck needs to run on the JVM backend — the last code-gen

--- a/code/packages/rust/iir-to-jvm-class-file/Cargo.toml
+++ b/code/packages/rust/iir-to-jvm-class-file/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "iir-to-jvm-class-file"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2021"
-description = "IIR → JVM class file backend — lowers IIRModule to JvmClassFile.  v0.11.0 (LANG-MATRIX LM-J Brainfuck): adds the lowered byte-tape ops alloc_bytes (no-op — the tape is the static env/BFRuntime.__tape field), load_byte/store_byte (baload/bastore with l2i/i2l conversions for the widened i64 value model), and width-correct i64 branch conditions (lcmp before ifeq/ifne) — so the i64-widened Brainfuck runs on the JVM.  v0.7.0 (G3): whitelist call_builtin print_i64 and lower it to invokestatic env/BasicRuntime.println(J)V, mirroring iir-to-wasm v0.8.0's env.__print_i64 host import.  Together they let BASIC's PRINT reach real JVM and wasm bytecode."
+description = "IIR → JVM class file backend — lowers IIRModule to JvmClassFile.  v0.12.0 (LANG-FULL E2 — register width & wrap, backend 4/6): masks a narrow-width (u4/u8/u16) arithmetic / bitwise / neg / not / shl result with `iconst/sipush/ldc <mask>; iand` after the int op, so `200u8+100u8=44` and `~0u8=255` (u32/i32 already wrap mod-2³² via the int op; uses a positive mask + iand, not i2b, to keep the unsigned widths unsigned).  v0.11.0 (LANG-MATRIX LM-J Brainfuck): adds the lowered byte-tape ops alloc_bytes (no-op — the tape is the static env/BFRuntime.__tape field), load_byte/store_byte (baload/bastore with l2i/i2l conversions for the widened i64 value model), and width-correct i64 branch conditions (lcmp before ifeq/ifne) — so the i64-widened Brainfuck runs on the JVM.  v0.7.0 (G3): whitelist call_builtin print_i64 and lower it to invokestatic env/BasicRuntime.println(J)V, mirroring iir-to-wasm v0.8.0's env.__print_i64 host import.  Together they let BASIC's PRINT reach real JVM and wasm bytecode."
 
 [lib]
 name = "iir_to_jvm_class_file"

--- a/code/packages/rust/iir-to-jvm-class-file/README.md
+++ b/code/packages/rust/iir-to-jvm-class-file/README.md
@@ -129,6 +129,12 @@ the JVM (LANG-MATRIX LM-J): the tape is a host-provided static `byte[]`, `baload
 index it (masking the sign-extended load back to an unsigned cell), and `.`/`,` call the
 `env.BFRuntime` host class — the JVM sibling of the LLVM libc / wasm `env.putchar` I/O.
 
+**Narrow-width register arithmetic wraps mod-2ⁿ** (LANG-FULL E2): a `u4`/`u8`/`u16`
+arithmetic/bitwise/`neg`/`not`/`shl` result is masked with `iconst/sipush/ldc <mask>;
+iand` after the `int` op, so `200u8+100u8=44` and `~0u8=255`. JVM `int` ops already wrap
+mod-2³², so `u32`/`i32` need no mask. A positive mask + `iand` is used (not `i2b`/`i2s`,
+which sign-extend) to keep the unsigned widths unsigned.
+
 ## Closures (LANG36)
 
 The JVM backend supports **first-class closures** via a `long[]`-based

--- a/code/packages/rust/iir-to-jvm-class-file/src/lower.rs
+++ b/code/packages/rust/iir-to-jvm-class-file/src/lower.rs
@@ -918,6 +918,27 @@ fn emit_iconst_cp(code: &mut Vec<u8>, cp: &mut ConstantPoolBuilder, value: i32) 
     }
 }
 
+/// Mask the `int` on top of the operand stack to a narrow width (LANG-FULL E2).
+///
+/// JVM `int` arithmetic (`iadd`/`imul`/…) wraps mod-2³², so `u32`/`i32` are
+/// already correct.  The smaller widths (`u4`/`u8`/`u16`) need an explicit
+/// `iconst/sipush/ldc <mask>; iand` after the op so `200u8 + 100u8` becomes
+/// `44` and `~0u8` is `255` — mirroring vm-core's `mask_result`, jit-core's
+/// `MASK_WIDTH`, and the wasm `i32.and`, and the byte-tape `baload`+mask
+/// precedent.  We deliberately use a positive mask + `iand` rather than `i2b`/
+/// `i2s` (which sign-extend, giving a *signed* byte — wrong for the unsigned
+/// narrow types the LANG-FULL frontends use).  `i64`/`u64`/floats emit nothing.
+fn emit_jvm_width_mask(code: &mut Vec<u8>, cp: &mut ConstantPoolBuilder, type_hint: &str) {
+    let mask: i32 = match type_hint {
+        "u4" => 0xF,
+        "u8" => 0xFF,
+        "u16" => 0xFFFF,
+        _ => return,
+    };
+    emit_iconst_cp(code, cp, mask);
+    code.push(IAND);
+}
+
 /// Emit a long constant push.
 ///
 /// JVM only has short forms for `0L` and `1L`.  Anything else needs an
@@ -1749,6 +1770,9 @@ fn lower_function(
                     _ => IADD, // fallback
                 };
                 code.push(opcode);
+                // E2: wrap a narrow (u4/u8/u16) result; u32/i32 already wrap via
+                // the i32 op, i64 via the long op.
+                emit_jvm_width_mask(&mut code, cp, &instr.type_hint);
 
                 if let Some(dest) = &instr.dest {
                     let (dest_slot, _) = lookup_var(dest)?;
@@ -1769,6 +1793,8 @@ fn lower_function(
                     _ => INEG,
                 };
                 code.push(opcode);
+                // E2: a narrow `neg` is `(0 - r)` mod-2ⁿ — mask it to the width.
+                emit_jvm_width_mask(&mut code, cp, &instr.type_hint);
                 if let Some(dest) = &instr.dest {
                     let (dest_slot, _) = lookup_var(dest)?;
                     emit_typed_store(&mut code, dest_slot, instr_jtype);
@@ -1792,6 +1818,8 @@ fn lower_function(
                     _ => IAND,
                 };
                 code.push(opcode);
+                // E2: keep a narrow bitwise result canonical for its width.
+                emit_jvm_width_mask(&mut code, cp, &instr.type_hint);
                 if let Some(dest) = &instr.dest {
                     let (dest_slot, _) = lookup_var(dest)?;
                     emit_typed_store(&mut code, dest_slot, instr_jtype);
@@ -1814,6 +1842,9 @@ fn lower_function(
                     emit_iconst(&mut code, -1);
                     code.push(IXOR);
                 }
+                // E2: `~x` on a narrow width must flip only its low bits
+                // (`~0u8 == 255`, not `-1`) — mask after the XOR.
+                emit_jvm_width_mask(&mut code, cp, &instr.type_hint);
                 if let Some(dest) = &instr.dest {
                     let (dest_slot, _) = lookup_var(dest)?;
                     emit_typed_store(&mut code, dest_slot, instr_jtype);
@@ -1836,6 +1867,9 @@ fn lower_function(
                     _ => ISHL,
                 };
                 code.push(opcode);
+                // E2: a narrow left-shift can push bits past the width
+                // (`1u8 << 8`), so mask the result.
+                emit_jvm_width_mask(&mut code, cp, &instr.type_hint);
                 if let Some(dest) = &instr.dest {
                     let (dest_slot, _) = lookup_var(dest)?;
                     emit_typed_store(&mut code, dest_slot, instr_jtype);

--- a/code/packages/rust/iir-to-jvm-class-file/tests/test_backend.rs
+++ b/code/packages/rust/iir-to-jvm-class-file/tests/test_backend.rs
@@ -2557,3 +2557,70 @@ fn i64_loop_guard_branches_via_lcmp() {
     let code = code_bytes(&class);
     assert!(code.contains(&0x94), "expected LCMP (0x94) reducing the i64 guard to an int before ifeq");
 }
+
+// ---------------------------------------------------------------------------
+// E2 (LANG-FULL): narrow-width arithmetic emits a width mask
+//
+// JVM `int` arithmetic (iadd/imul/…) wraps mod-2³², so u32/i32 are already
+// correct.  The smaller widths (u4/u8/u16) get an explicit
+// `iconst/sipush/ldc <mask>; iand` after the op.  These tests assert the
+// lowering injects that mask (the executed cross-backend proof lands in the
+// integration PR via lang-aot's real-`java` run_jvm).
+// ---------------------------------------------------------------------------
+
+/// `main` = `const 200; const 100; <op> [ty]; ret [ty]`.
+fn e2_binop_fn(op: &str, ty: &str) -> IIRFunction {
+    IIRFunction::new(
+        "main",
+        vec![],
+        ty,
+        vec![
+            IIRInstr::new("const", Some("a".into()), vec![Operand::Int(200)], ty),
+            IIRInstr::new("const", Some("b".into()), vec![Operand::Int(100)], ty),
+            IIRInstr::new(op, Some("c".into()),
+                vec![Operand::Var("a".into()), Operand::Var("b".into())], ty),
+            IIRInstr::new("ret", None, vec![Operand::Var("c".into())], ty),
+        ],
+    )
+}
+
+// The u8 mask is `sipush 0x00FF; iand` → bytes [0x11, 0x00, 0xFF, 0x7E].
+const U8_MASK_SEQ: [u8; 4] = [0x11, 0x00, 0xFF, 0x7E];
+
+fn has_seq(code: &[u8], seq: &[u8]) -> bool {
+    code.windows(seq.len()).any(|w| w == seq)
+}
+
+#[test]
+fn e2_u8_add_emits_iand_width_mask() {
+    let class = lower(&module_with(e2_binop_fn("add", "u8")));
+    let code = code_bytes(&class);
+    assert!(has_seq(&code, &U8_MASK_SEQ),
+        "u8 `add` must emit `sipush 255; iand` to wrap mod-256");
+}
+
+#[test]
+fn e2_u8_not_and_shl_emit_width_mask() {
+    // `not` (synthesised as XOR -1) and a left shift both need the byte mask.
+    let not_fn = IIRFunction::new("main", vec![], "u8", vec![
+        IIRInstr::new("const", Some("a".into()), vec![Operand::Int(0)], "u8"),
+        IIRInstr::new("not", Some("c".into()), vec![Operand::Var("a".into())], "u8"),
+        IIRInstr::new("ret", None, vec![Operand::Var("c".into())], "u8"),
+    ]);
+    let class = lower(&module_with(not_fn));
+    assert!(has_seq(&code_bytes(&class), &U8_MASK_SEQ), "u8 `not` must mask to a byte");
+
+    let shl_class = lower(&module_with(e2_binop_fn("shl", "u8")));
+    assert!(has_seq(&code_bytes(&shl_class), &U8_MASK_SEQ), "u8 `shl` must mask to a byte");
+}
+
+#[test]
+fn e2_i64_and_u32_add_have_no_byte_mask() {
+    // i64 uses the long opcodes; u32 wraps natively via the 32-bit i32 op — so
+    // neither emits the `sipush 255; iand` byte mask.
+    for ty in ["i64", "u32"] {
+        let class = lower(&module_with(e2_binop_fn("add", ty)));
+        assert!(!has_seq(&code_bytes(&class), &U8_MASK_SEQ),
+            "{ty} `add` must not emit a byte-width mask");
+    }
+}

--- a/code/specs/LANG-FULL-IMPLEMENTATION.md
+++ b/code/specs/LANG-FULL-IMPLEMENTATION.md
@@ -74,8 +74,13 @@ multiple languages; close an enabler before the features that depend on it.
   - ✅ **jit-core** (2/6) — compiled tier emits a `MASK_WIDTH <reg> <bits>` opcode after a
     narrow `_u8`/`_u16`/`_u32` add/sub/mul/div/neg (`u4`/signed handled by the interpreter
     fallback); unit-tested. Matches vm-core's interpreter-tier mask.
-  - ☐ **iir-to-wasm**, ☐ **iir-to-jvm-class-file**, ☐ **iir-to-cil-bytecode**
-    (mirror the per-backend byte-tape mask onto register arithmetic).
+  - ☐ **iir-to-wasm** (3/6, in flight #5812 — `i32.and` width mask).
+  - ✅ **iir-to-jvm-class-file** (4/6) — `emit_jvm_width_mask` appends `iconst/sipush/ldc
+    <mask>; iand` after a narrow `u4`/`u8`/`u16` arith/bitwise/neg/not/shl `int` op (positive
+    mask + `iand`, not `i2b`, to keep unsigned widths unsigned; `0xFFFF` via the constant
+    pool). u32/i32 already wrap via the int op. Structural tests; executed JVM proof in the
+    integration PR via the matrix's real-`java` run_jvm.
+  - ☐ **iir-to-cil-bytecode** (mirror the per-backend byte-tape mask onto register arithmetic).
   - ☐ **Integration** — wire Nib (then Oct) to emit narrow `type_hint`s for narrow-declared
     values + an executed matrix proof (`200u8+100u8=44`, Nib unary `~`) across all backends;
     flip N3-`~`, Nib N6/N7, Oct.


### PR DESCRIPTION
## What

**Fourth backend of the E2 (integer width & wrap) enabler** (approach B). JVM `int` arithmetic (`iadd`/`imul`/…) wraps mod-2³², so `u32`/`i32` were already correct, but `u8`/`u16` left a full 32-bit result, so a lowered `200u8 + 100u8` gave `300`, not `44`.

`emit_jvm_width_mask` appends `iconst/sipush/ldc <mask>; iand` after a narrow (`u4`→0xF, `u8`→0xFF, `u16`→0xFFFF) `add`/`sub`/`mul`/`div`/`mod`/`neg`/`and`/`or`/`xor`/`not`/`shl`/`shr` int result — mirroring vm-core's `mask_result`, jit-core's `MASK_WIDTH`, the wasm `i32.and`, and the byte-tape `baload`+mask precedent.

Key correctness detail: it uses a **positive constant + `iand`**, not `i2b`/`i2s` — those sign-extend (giving a *signed* byte), which is wrong for the unsigned narrow types the LANG-FULL frontends use. `0xFFFF` exceeds `sipush` range, so it loads via the constant pool. `u32`/`i32` need no mask; `i64`/`u64`/floats unchanged.

## Tests
Structural tests assert the lowering emits `sipush 255; iand` for a `u8` add/not/shl and omits it for `i64`/`u32` (the executed cross-backend JVM proof lands in the E2 integration PR via lang-aot's real-`java` `run_jvm`). No regression: matrix (JVM column) + jvm consumers (iir-codegen-adapters, twig-to-jvm, iir-to-cil). clippy clean.

`/security-review` passed — confirmed the appended `<push>; iand` keeps the operand stack balanced and typed (mask only fires for `JvmType::Int`), stays under the fixed `max_stack=8`, and the constant-pool `0xFFFF` entry is deduped.

## E2 roadmap
- ✅ vm-core (1/6, #5799), ✅ jit-core (2/6, #5808), 🔵 iir-to-wasm (3/6, #5812), ✅ **iir-to-jvm (this PR, 4/6)**. LLVM already wraps via `i8`.
- ☐ iir-to-cil (5/6, `ldc.i4 mask; and`), then integration (6/6: Nib/Oct emit narrow type_hints + cross-backend matrix proof).

Note: parallel with #5812; both touch only the E2 roadmap checklist line — trivial rebase for whichever merges second.

🤖 Generated with [Claude Code](https://claude.com/claude-code)