### PR TITLE
[codex] Add Hue package release archive handoff summary

### DIFF
--- a/code/packages/rust/hue-core/CHANGELOG.md
+++ b/code/packages/rust/hue-core/CHANGELOG.md
@@ -57,6 +57,8 @@ All notable changes to this package will be documented in this file.
   into final package release archive signoff checks.
 - Hue package release archive closure summaries that turn archive signoff
   readiness into final package release archive closure checks.
+- Hue package release archive handoff summaries that turn archive closure
+  readiness into final package release archive handoff checks.
 - Hue discovery worker-run projection from generic `MdnsScanResult` envelopes,
   preserving scan parse failures as per-source D23 worker failures.
 - Hue discovery worker-run projection from aggregate `MdnsWorkerScanReport`

--- a/code/packages/rust/hue-core/README.md
+++ b/code/packages/rust/hue-core/README.md
@@ -97,6 +97,8 @@ packages a typed surface for:
   into final package release archive signoff checks
 - Hue package release archive closure summaries that turn archive signoff
   readiness into final package release archive closure checks
+- Hue package release archive handoff summaries that turn archive closure
+  readiness into final package release archive handoff checks
 
 ## Dependencies
 

--- a/code/packages/rust/hue-core/src/lib.rs
+++ b/code/packages/rust/hue-core/src/lib.rs
@@ -3298,6 +3298,129 @@ pub fn hue_package_release_archive_closure_summary(
     HuePackageReleaseArchiveClosureSummary::from_pairing_plan(plan)
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct HuePackageReleaseArchiveHandoffSummary {
+    pub archive_closure_summary: HuePackageReleaseArchiveClosureSummary,
+    pub required_archive_handoff_check_count: usize,
+    pub passed_archive_handoff_check_count: usize,
+    pub blocked_archive_handoff_check_count: usize,
+    pub release_archive_closure_ready: bool,
+    pub release_archive_signoff_ready: bool,
+    pub release_archive_ready: bool,
+    pub release_closure_ready: bool,
+    pub release_signoff_ready: bool,
+    pub release_audit_ready: bool,
+    pub operator_ready: bool,
+    pub coordination_ready: bool,
+    pub publish_gate_ready: bool,
+    pub release_archive_handoff_ready: bool,
+}
+
+impl HuePackageReleaseArchiveHandoffSummary {
+    pub fn from_pairing_plan(plan: &HueBridgePairingPlan) -> Self {
+        Self::from_archive_closure_summary(hue_package_release_archive_closure_summary(plan))
+    }
+
+    pub fn from_archive_closure_summary(
+        archive_closure_summary: HuePackageReleaseArchiveClosureSummary,
+    ) -> Self {
+        let release_archive_closure_ready =
+            archive_closure_summary.is_release_archive_closure_ready();
+        let release_archive_signoff_ready =
+            !archive_closure_summary.needs_release_archive_signoff();
+        let release_archive_ready = !archive_closure_summary.needs_release_archive();
+        let release_closure_ready = !archive_closure_summary.needs_release_closure();
+        let release_signoff_ready = !archive_closure_summary.needs_release_signoff();
+        let release_audit_ready = !archive_closure_summary.needs_release_audit();
+        let operator_ready = !archive_closure_summary.needs_operator_readiness();
+        let coordination_ready = !archive_closure_summary.needs_coordination();
+        let publish_gate_ready = !archive_closure_summary.needs_publish_gate();
+        let checks = [
+            release_archive_closure_ready,
+            release_archive_signoff_ready,
+            release_archive_ready,
+            release_closure_ready,
+            release_signoff_ready,
+            release_audit_ready,
+            operator_ready,
+            coordination_ready,
+            publish_gate_ready,
+        ];
+        let passed_archive_handoff_check_count = checks.iter().filter(|ready| **ready).count();
+        let required_archive_handoff_check_count = checks.len();
+        let blocked_archive_handoff_check_count =
+            required_archive_handoff_check_count - passed_archive_handoff_check_count;
+        let release_archive_handoff_ready = blocked_archive_handoff_check_count == 0;
+
+        Self {
+            archive_closure_summary,
+            required_archive_handoff_check_count,
+            passed_archive_handoff_check_count,
+            blocked_archive_handoff_check_count,
+            release_archive_closure_ready,
+            release_archive_signoff_ready,
+            release_archive_ready,
+            release_closure_ready,
+            release_signoff_ready,
+            release_audit_ready,
+            operator_ready,
+            coordination_ready,
+            publish_gate_ready,
+            release_archive_handoff_ready,
+        }
+    }
+
+    pub fn is_release_archive_handoff_ready(self) -> bool {
+        self.release_archive_handoff_ready
+    }
+
+    pub fn has_blocked_archive_handoff_checks(self) -> bool {
+        self.blocked_archive_handoff_check_count > 0
+    }
+
+    pub fn needs_release_archive_closure(self) -> bool {
+        !self.release_archive_closure_ready
+    }
+
+    pub fn needs_release_archive_signoff(self) -> bool {
+        !self.release_archive_signoff_ready
+    }
+
+    pub fn needs_release_archive(self) -> bool {
+        !self.release_archive_ready
+    }
+
+    pub fn needs_release_closure(self) -> bool {
+        !self.release_closure_ready
+    }
+
+    pub fn needs_release_signoff(self) -> bool {
+        !self.release_signoff_ready
+    }
+
+    pub fn needs_release_audit(self) -> bool {
+        !self.release_audit_ready
+    }
+
+    pub fn needs_operator_readiness(self) -> bool {
+        !self.operator_ready
+    }
+
+    pub fn needs_coordination(self) -> bool {
+        !self.coordination_ready
+    }
+
+    pub fn needs_publish_gate(self) -> bool {
+        !self.publish_gate_ready
+    }
+}
+
+pub fn hue_package_release_archive_handoff_summary(
+    plan: &HueBridgePairingPlan,
+) -> HuePackageReleaseArchiveHandoffSummary {
+    HuePackageReleaseArchiveHandoffSummary::from_pairing_plan(plan)
+}
+
 fn descriptor_declares_capability(descriptor: &IntegrationDescriptor, capability_id: &str) -> bool {
     descriptor
         .capabilities
@@ -7915,6 +8038,97 @@ mod tests {
         assert!(!summary.release_archive_closure_ready);
         assert!(!summary.is_release_archive_closure_ready());
         assert!(summary.has_blocked_archive_closure_checks());
+        assert!(summary.needs_release_archive_signoff());
+        assert!(summary.needs_release_archive());
+        assert!(summary.needs_release_closure());
+        assert!(summary.needs_release_signoff());
+        assert!(summary.needs_release_audit());
+        assert!(summary.needs_operator_readiness());
+        assert!(summary.needs_coordination());
+        assert!(summary.needs_publish_gate());
+    }
+
+    #[test]
+    fn hue_package_release_archive_handoff_summary_reports_ready_archive_handoff() {
+        let plan = hue_pairing_plan_for_discovered_bridge(
+            DiscoveredHueBridge {
+                bridge_id: "001788fffeabcdef".to_string(),
+                address: "https://192.0.2.10".to_string(),
+                hardware_model: Some("BSB002".to_string()),
+                firmware_version: Some("1.60".to_string()),
+            },
+            "chief-of-staff",
+            "desk",
+        );
+
+        let summary = hue_package_release_archive_handoff_summary(&plan);
+
+        assert_eq!(
+            summary.archive_closure_summary,
+            hue_package_release_archive_closure_summary(&plan)
+        );
+        assert_eq!(summary.required_archive_handoff_check_count, 9);
+        assert_eq!(summary.passed_archive_handoff_check_count, 9);
+        assert_eq!(summary.blocked_archive_handoff_check_count, 0);
+        assert!(summary.release_archive_closure_ready);
+        assert!(summary.release_archive_signoff_ready);
+        assert!(summary.release_archive_ready);
+        assert!(summary.release_closure_ready);
+        assert!(summary.release_signoff_ready);
+        assert!(summary.release_audit_ready);
+        assert!(summary.operator_ready);
+        assert!(summary.coordination_ready);
+        assert!(summary.publish_gate_ready);
+        assert!(summary.release_archive_handoff_ready);
+        assert!(summary.is_release_archive_handoff_ready());
+        assert!(!summary.has_blocked_archive_handoff_checks());
+        assert!(!summary.needs_release_archive_closure());
+        assert!(!summary.needs_release_archive_signoff());
+        assert!(!summary.needs_release_archive());
+        assert!(!summary.needs_release_closure());
+        assert!(!summary.needs_release_signoff());
+        assert!(!summary.needs_release_audit());
+        assert!(!summary.needs_operator_readiness());
+        assert!(!summary.needs_coordination());
+        assert!(!summary.needs_publish_gate());
+    }
+
+    #[test]
+    fn hue_package_release_archive_handoff_summary_routes_blocked_archive_handoff() {
+        let mut plan = hue_pairing_plan_for_discovered_bridge(
+            DiscoveredHueBridge {
+                bridge_id: "001788fffeabcdef".to_string(),
+                address: "https://192.0.2.10".to_string(),
+                hardware_model: Some("BSB002".to_string()),
+                firmware_version: Some("1.60".to_string()),
+            },
+            "chief-of-staff",
+            "desk",
+        );
+        plan.bridge.address = None;
+        plan.registration_request.path = "/wrong/api".to_string();
+        plan.application_key_header = "x-application-key".to_string();
+        plan.event_stream_path = "/wrong/eventstream".to_string();
+        plan.requires_user_presence = false;
+
+        let summary = HuePackageReleaseArchiveHandoffSummary::from_pairing_plan(&plan);
+
+        assert_eq!(summary.required_archive_handoff_check_count, 9);
+        assert_eq!(summary.passed_archive_handoff_check_count, 0);
+        assert_eq!(summary.blocked_archive_handoff_check_count, 9);
+        assert!(!summary.release_archive_closure_ready);
+        assert!(!summary.release_archive_signoff_ready);
+        assert!(!summary.release_archive_ready);
+        assert!(!summary.release_closure_ready);
+        assert!(!summary.release_signoff_ready);
+        assert!(!summary.release_audit_ready);
+        assert!(!summary.operator_ready);
+        assert!(!summary.coordination_ready);
+        assert!(!summary.publish_gate_ready);
+        assert!(!summary.release_archive_handoff_ready);
+        assert!(!summary.is_release_archive_handoff_ready());
+        assert!(summary.has_blocked_archive_handoff_checks());
+        assert!(summary.needs_release_archive_closure());
         assert!(summary.needs_release_archive_signoff());
         assert!(summary.needs_release_archive());
         assert!(summary.needs_release_closure());


### PR DESCRIPTION
## Summary

- add `HuePackageReleaseArchiveHandoffSummary` over archive closure readiness
- expose the `hue_package_release_archive_handoff_summary` helper and blocked-gate predicates
- document the new Hue package release archive handoff summary

## Validation

- `cargo fmt --manifest-path code\packages\rust\hue-core\Cargo.toml`
- `cargo test --manifest-path code\packages\rust\hue-core\Cargo.toml`
- `git diff --check -- code\packages\rust\hue-core\src\lib.rs code\packages\rust\hue-core\README.md code\packages\rust\hue-core\CHANGELOG.md`