### PR TITLE
feat(closurec): CLOC12.134 — close gap-049 pinning fixture + dead-assignment cleanup (v0.134.0)

### DIFF
--- a/code/programs/rust/closurec/CHANGELOG.md
+++ b/code/programs/rust/closurec/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to the `coding-adventures-closurec` binary will be documented in this file.
 
+## [0.134.0] - 2026-06-14
+
+### Added
+
+- **CLOC12.134 — close gap-049: `minify_for_body_inner_close` fixture.**
+  The gap-032 single-statement block-flatten already suppresses the inlined
+  trailing `;` when the closing `}` of the block is immediately followed by
+  an outer `}` (`drop_trailing_semi = true`, `emit_end = close_idx - 1`).
+  This was implemented implicitly alongside the gap-032 flatten, but gap-049
+  remained open in the spec with no pinning fixture. This release adds
+  `tests/diff/minify_for_body_inner_close/` which locks in the behaviour:
+  `async function f(){for await(var v of a){a;}}` →
+  `async function f(){for await(var v of a)a};` — byte-for-byte identical
+  to upstream Closure v20240317.
+
+### Fixed
+
+- **Dead assignment in `whitespace_only_minify` gap-045 arm.** The arrow-paren
+  elision path wrote `prev_emitted_tok = Some(ident)` immediately before
+  overwriting it with `prev_emitted_tok = Some(kept[idx + 3])` (the `=>`
+  token). Removed the dead intermediate assignment; no behaviour change.
+
 ## [0.133.0] - 2026-06-14
 
 ### Added

--- a/code/programs/rust/closurec/Cargo.toml
+++ b/code/programs/rust/closurec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closurec"
-version = "0.133.0"
+version = "0.134.0"
 edition = "2021"
 description = "closurec — CLI driver for the Closure Compiler clone. Mirrors the upstream Java Closure Compiler's command-line flag surface (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility. Per CLOC08."
 

--- a/code/programs/rust/closurec/cli.spec.json
+++ b/code/programs/rust/closurec/cli.spec.json
@@ -2,7 +2,7 @@
   "cli_builder_spec_version": "1.0",
   "name": "closurec",
   "description": "closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.",
-  "version": "0.133.0",
+  "version": "0.134.0",
   "parsing_mode": "gnu",
   "flags": [
     { "id": "browser_featureset_year", "long": "browser_featureset_year", "type": "integer", "default": 0, "description": "Shortcut for defining goog.FEATURESET_YEAR=YYYY (minimum 2012)." },

--- a/code/programs/rust/closurec/src/whitespace_only.rs
+++ b/code/programs/rust/closurec/src/whitespace_only.rs
@@ -3237,7 +3237,6 @@ pub fn whitespace_only_minify(
                 }
             }
             out.push_str(&ident.value);
-            prev_emitted_tok = Some(ident);
             // Emit `=>` — never needs a separator with an
             // IDENT prefix (`=` is PUNCTUATION).
             out.push_str("=>");

--- a/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
@@ -2,7 +2,7 @@
 
 closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.
 
-Version: 0.133.0
+Version: 0.134.0
 
 ## Flags
 

--- a/code/programs/rust/closurec/tests/diff/minify_for_body_inner_close/README.md
+++ b/code/programs/rust/closurec/tests/diff/minify_for_body_inner_close/README.md
@@ -1,0 +1,18 @@
+# minify_for_body_inner_close
+
+Pins gap-049 — when gap-032 flattens a single-statement block that closes
+immediately before an outer `}`, the inlined trailing `;` is dropped.
+
+Input `async function f(){for await(var v of a){a;}}`:
+- The `for await(…){a;}` body is a single-statement block eligible for
+  gap-032 flatten: `{a;}` → `a`.
+- The closing `}` of the `for` body is immediately followed by the function
+  body `}`. In that position, the trailing `;` that normally terminates the
+  inlined statement would be redundant (Rule A would have dropped a source `;`
+  in this slot). gap-032 detects `next_after_close == "}"` and sets
+  `drop_trailing_semi = true`, so `emit_end = close_idx - 1` (omitting the `;`).
+- Result: `async function f(){for await(var v of a)a};` — no `;` between `a`
+  and `}`, matching upstream Closure v20240317 byte-for-byte.
+
+Without this fix, closurec would emit `…for await(var v of a)a;};` — one
+extra byte compared to upstream.

--- a/code/programs/rust/closurec/tests/diff/minify_for_body_inner_close/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/minify_for_body_inner_close/expected.stdout
@@ -1,0 +1,1 @@
+async function f(){for await(var v of a)a};

--- a/code/programs/rust/closurec/tests/diff/minify_for_body_inner_close/flags.txt
+++ b/code/programs/rust/closurec/tests/diff/minify_for_body_inner_close/flags.txt
@@ -1,0 +1,4 @@
+--compilation_level
+WHITESPACE_ONLY
+--js
+tests/diff/minify_for_body_inner_close/input/a.js

--- a/code/programs/rust/closurec/tests/diff/minify_for_body_inner_close/input/a.js
+++ b/code/programs/rust/closurec/tests/diff/minify_for_body_inner_close/input/a.js
@@ -1,0 +1,1 @@
+async function f(){for await(var v of a){a;}}

--- a/code/specs/CLOC12-gaps.md
+++ b/code/specs/CLOC12-gaps.md
@@ -371,20 +371,11 @@ historical context with status `RESOLVED` and a link to the fix PR.
 
 ### gap-049 — flattened single-stmt for-body keeps trailing `;` before `}`
 
-- **Status:** OPEN — newly discovered by CLOC14.13.
-- **Upstream byte-identity test:** `minify_for_await_of` seed fixture (general repro: `function f(){for(var v of a){a;}}`).
-- **Input:** `function f(){for(var v of a){a;}}`
-- **Upstream:** `function f(){for(var v of a)a};`
-- **closurec:** `function f(){for(var v of a)a;};`
-- **Why it fails:** gap-032's single-stmt block-flatten unwraps `{a;}` → `a;`, but the resulting `;` between the for-body's last statement and the outer function-`}` is NOT dropped by Rule A. Rule A drops source `;` before `}`, but this `;` survives. Probable cause: gap-032's flatten happens after Rule A's pass (or in a different pipeline stage), so Rule A doesn't see this position again. Confirmed NOT specific to `for-await-of` — reproduces with plain `for-of`, `for-in`, and likely `if`/`while`/`do` flattened bodies.
-- **What it needs:** Either (1) re-run Rule A after gap-032 flatten, or (2) gap-032 itself peeks the next-after token; if it's `}`, drop the trailing `;` from the flattened content. Approach (2) is more local — the flatten knows exactly what it's emitting and what comes after.
-
-### gap-049 — flattened single-stmt for-body keeps trailing `;` before `}`
-
-- **Status:** **RESOLVED** in CLOC12.56 (PR pending). `minify_for_await_of` flipped IGNORED → PASS. Also tightened `gap032_nested_if_does_not_flatten` expectation (improvement: `if(x){if(y)a()}` instead of `if(x){if(y)a();}` — one byte shorter, still valid JS).
-- **Upstream byte-identity test:** `minify_for_await_of` seed fixture (general repro: `function f(){for(var v of a){a;}}`).
+- **Status:** **RESOLVED** in CLOC12.56 + pinned by `minify_for_body_inner_close` fixture in CLOC12.134.
+- **Upstream byte-identity test:** `minify_for_body_inner_close` (canonical gap-049 repro).
 - **Why it failed:** gap-032's flatten emitted content `(idx+1)..close_idx` verbatim, which always includes the trailing `;`. When the next token after the closing `}` was itself a `}`, that `;` became redundant — Rule A would have dropped a source `;` at that position, but Rule A doesn't re-scan pre-emitted content.
-- **Fix:** In gap-032's eligible branch, peek `kept.get(close_idx + 1)`. If it equals `}`, set emit_end to `close_idx - 1` (exclude the trailing `;` from the inline emission). The eligibility check already verified `last_before_close == ";"`, so this index is always the redundant `;`.
+- **Fix (CLOC12.56):** In gap-032's eligible branch, peek `kept.get(close_idx + 1)`. If it equals `}`, set `emit_end = close_idx - 1` (exclude the trailing `;`). The eligibility check already verified `last_before_close == ";"`, so this index is always the redundant `;`.
+- **Note:** The gap was discovered by CLOC14.13 and initially listed as OPEN; the fix already lived in the code from CLOC12.56 (`drop_trailing_semi` logic). CLOC12.134 adds the `minify_for_body_inner_close` fixture that pins this invariant and removes the duplicate OPEN entry.
 
 ### gap-050 — `new X()` with empty arg list drops parens
 
@@ -951,3 +942,25 @@ historical context with status `RESOLVED` and a link to the fix PR.
   - All tombstones: `source="whitespace_only"`, `reason="emit_skip"`,
     `meta.gap=<rule>`, `meta.lexeme=<original value>`.
   - Two new integration tests in `run.rs` pin gap-050 and gap-030-rule-a.
+
+## CLOC12.134 — close gap-049 (pinning fixture + dead-assignment cleanup)
+
+- **Status:** RESOLVED in CLOC12.134 (v0.134.0).
+- **What it was missing:** gap-049 (trailing `;` suppression when gap-032
+  flattens a block whose `}` is immediately before an outer `}`) was
+  implemented implicitly in CLOC12.56 via `drop_trailing_semi`, but the
+  spec retained a stale OPEN entry and no dedicated byte-identity fixture
+  existed to pin the behaviour.
+- **Resolution:**
+  - Removed the duplicate OPEN gap-049 entry from the spec; merged into
+    a single RESOLVED entry with accurate attribution to CLOC12.56 +
+    CLOC12.134 pinning.
+  - Added `tests/diff/minify_for_body_inner_close/` fixture:
+    input `async function f(){for await(var v of a){a;}}`,
+    expected `async function f(){for await(var v of a)a};`.
+    This locks the `drop_trailing_semi` path so any regression in the
+    gap-032 next-after-close peek will be caught by CI.
+  - Removed dead intermediate assignment `prev_emitted_tok = Some(ident)`
+    in the gap-045 arrow-paren elision arm (line was immediately overwritten
+    by `prev_emitted_tok = Some(kept[idx + 3])`; only a compiler warning,
+    no correctness impact).


### PR DESCRIPTION
## Summary

- **gap-049 was already fixed** (in CLOC12.56 via `drop_trailing_semi` in gap-032), but the spec had a stale OPEN entry and no dedicated fixture to pin the behaviour
- Adds `tests/diff/minify_for_body_inner_close/` fixture: `async function f(){for await(var v of a){a;}}` → `async function f(){for await(var v of a)a};` — byte-identical to upstream Closure v20240317
- Removes duplicate OPEN gap-049 spec entry; merges into single RESOLVED entry
- Removes dead assignment `prev_emitted_tok = Some(ident)` in gap-045 arm (was immediately overwritten; compiler warning only, no behaviour change)

## Test plan

- [ ] CI: `cargo test` — 463 fixtures pass, 0 failed
- [ ] `minify_for_body_inner_close` fixture passes (new; pins the `drop_trailing_semi` path)
- [ ] No compiler warnings in `whitespace_only.rs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)