### PR TITLE
feat(mycin): decompose all 31 pending-citation sources — no-blind-trust recursion complete (pending → 0)

### DIFF
--- a/code/specs/data/mycin-2026/PROVENANCE-LEDGER.md
+++ b/code/specs/data/mycin-2026/PROVENANCE-LEDGER.md
@@ -63,16 +63,16 @@ grounded: **8** · flagged: **1** · authored-debt: **0**
 
 | clause | status | gate | source | source-verified |
 |---|---|---|---|---|
-| `uti_prior_ecoli` | grounded | — | International Clinical Practice Guid | no-source-obj |
-| `uti_prior_saprophyticus` | grounded | — | Staphylococcus saprophyticus Infecti | no-source-obj |
-| `uti_prior_klebsiella` | grounded | — | Local epidemiology and resistance pr | no-source-obj |
-| `uti_prior_proteus` | grounded | — | Diagnosis and Treatment of Acute Unc | no-source-obj |
-| `uti_prior_enterococcus` | grounded | — | Etiology and antimicrobial susceptib | no-source-obj |
-| `uti_prior_pseudomonas` | grounded | — | Bacterial species and antimicrobial  | no-source-obj |
-| `uti_prior_gbs` | grounded | — | Diversity of Group B Streptococcus S | no-source-obj |
-| `uti_finding_nitrite` | direction_only | — | Feasibility of serial measurement of | no-source-obj |
-| `uti_finding_leuk_esterase` | grounded | — | Measurement of urinary leukocyte est | no-source-obj |
-| `uti_finding_urease_proteus` | grounded | — | Pathogenesis of Proteus mirabilis In | no-source-obj |
+| `uti_prior_ecoli` | grounded | ACCEPT | src:2f0c1bfb012a2a37 | ✓ verified (1/1) |
+| `uti_prior_saprophyticus` | grounded | ACCEPT | src:a221aaa21abc0f44 | ✗ UNVERIFIED (1/2) |
+| `uti_prior_klebsiella` | grounded | ACCEPT | src:83a052af6bc47106 | ✓ verified (1/1) |
+| `uti_prior_proteus` | grounded | ACCEPT | src:fed9287ccd687d3a | ✓ verified (1/1) |
+| `uti_prior_enterococcus` | grounded | ACCEPT | src:1b4719e7d669a63f | ✓ verified (1/1) |
+| `uti_prior_pseudomonas` | grounded | ACCEPT | src:debf68ecb2c088e8 | ✗ UNVERIFIED (0/1) |
+| `uti_prior_gbs` | grounded | ACCEPT | src:1090fd8acb46f5e8 | ✗ UNVERIFIED (0/1) |
+| `uti_finding_nitrite` | direction_only | FLAG | src:b27c6544ee54ecec | ✗ UNVERIFIED (0/2) |
+| `uti_finding_leuk_esterase` | grounded | ACCEPT | src:05de3ced05f32c90 | ✓ verified (1/1) |
+| `uti_finding_urease_proteus` | grounded | ACCEPT | src:685ed626927622ae | ✗ UNVERIFIED (0/2) |
 
 ## treatment constraints  (`treatment/constraints/treatment-constraints.json`)
 
@@ -80,14 +80,14 @@ grounded: **4** · flagged: **4** · authored-debt: **0**
 
 | clause | status | gate | source | source-verified |
 |---|---|---|---|---|
-| `ci_penicillin_cephalosporin` | grounded | — | Penicillin Allergy — CDC STI Treatme | no-source-obj |
+| `ci_penicillin_cephalosporin` | grounded | ACCEPT | src:a36d52927de1e970 | ✓ verified (1/1) |
 | `ci_aztreonam_safe_penicillin` | direction_only | FLAG | src:8481259fa1454601 | ✗ UNVERIFIED (0/1) |
-| `ci_moxifloxacin_pregnancy` | direction_only | — | DailyMed — MOXIFLOXACIN HYDROCHLORID | no-source-obj |
-| `ci_tmpsmx_pregnancy` | grounded | — | DailyMed — SULFAMETHOXAZOLE AND TRIM | no-source-obj |
-| `ci_vancomycin_nephrotoxicity` | grounded | — | DailyMed — VANCOMYCIN HYDROCHLORIDE  | no-source-obj |
-| `ci_aminoglycoside_vancomycin` | direction_only | — | VANCOMYCIN HYDROCHLORIDE injection,  | no-source-obj |
-| `ci_fluoroquinolone_qt` | direction_only | — | MOXIFLOXACIN HYDROCHLORIDE tablet —  | no-source-obj |
-| `ci_vancomycin_renal_dose` | grounded | — | VANCOMYCIN injection, for intravenou | no-source-obj |
+| `ci_moxifloxacin_pregnancy` | direction_only | FLAG | src:3bc1d8571af85cc8 | ✗ UNVERIFIED (0/2) |
+| `ci_tmpsmx_pregnancy` | grounded | ACCEPT | src:ac722c855cec8fbe | ✗ UNVERIFIED (0/1) |
+| `ci_vancomycin_nephrotoxicity` | grounded | ACCEPT | src:04668cefe35908cd | ◑ core ✓ (1/2 spans; over-reach) |
+| `ci_aminoglycoside_vancomycin` | direction_only | FLAG | src:29c9c085cc9e0800 | ✓ verified (1/1) |
+| `ci_fluoroquinolone_qt` | direction_only | FLAG | src:3bc1d8571af85cc8 | ✗ UNVERIFIED (0/1) |
+| `ci_vancomycin_renal_dose` | grounded | ACCEPT | src:c6a1cb378499eaca | ✗ UNVERIFIED (0/4) |
 
 ## bacteremia organism priors  (`diagnosis/bacteremia/source-id.adj`)
 
@@ -95,14 +95,14 @@ grounded: **7** · flagged: **1** · authored-debt: **0**
 
 | clause | status | gate | source | source-verified |
 |---|---|---|---|---|
-| `bsi_prior_saureus` | grounded | — | Wisplinghoff et al., "Nosocomial blo | no-source-obj |
-| `bsi_prior_enteric_gnb` | grounded | — | Blood bacterial resistant investigat | no-source-obj |
-| `bsi_prior_cons` | direction_only | — | Nosocomial bloodstream infections in | no-source-obj |
-| `bsi_prior_enterococcus` | grounded | — | Nosocomial bloodstream infections in | no-source-obj |
-| `bsi_prior_spneumoniae` | grounded | — | Burden of community-onset bloodstrea | no-source-obj |
-| `bsi_prior_pseudomonas` | grounded | — | Pseudomonas aeruginosa: Infections a | no-source-obj |
-| `bsi_prior_pyogenes` | grounded | — | Streptococcus pyogenes bacteraemia:  | no-source-obj |
-| `bsi_prior_candida` | grounded | — | Nosocomial bloodstream infections in | no-source-obj |
+| `bsi_prior_saureus` | grounded | ACCEPT | src:9cd83cfe323d44d1 | ✓ verified (1/1) |
+| `bsi_prior_enteric_gnb` | grounded | ACCEPT | src:684cb26a970c6858 | ✓ verified (2/2) |
+| `bsi_prior_cons` | direction_only | FLAG | src:9cd83cfe323d44d1 | ✓ verified (1/1) |
+| `bsi_prior_enterococcus` | grounded | ACCEPT | src:9cd83cfe323d44d1 | ✓ verified (1/1) |
+| `bsi_prior_spneumoniae` | grounded | ACCEPT | src:e7d7522b70b9e38b | ✗ UNVERIFIED (0/2) |
+| `bsi_prior_pseudomonas` | grounded | ACCEPT | src:e3fc40eba191bb19 | ✗ UNVERIFIED (0/1) |
+| `bsi_prior_pyogenes` | grounded | ACCEPT | src:20ee76476443836b | ✓ verified (1/1) |
+| `bsi_prior_candida` | grounded | ACCEPT | src:9cd83cfe323d44d1 | ✓ verified (1/1) |
 
 ## bacteremia source→organism LRs  (`diagnosis/bacteremia/source-id.adj`)
 
@@ -110,16 +110,16 @@ grounded: **4** · flagged: **6** · authored-debt: **0**
 
 | clause | status | gate | source | source-verified |
 |---|---|---|---|---|
-| `src_urinary_enteric` | direction_only | — | Epidemiology of Gram-Negative Bloods | no-source-obj |
-| `src_line_cons` | grounded | — | Central Line–Associated Blood Stream | no-source-obj |
-| `src_line_saureus` | direction_only | — | Clinical Practice Guidelines for the | no-source-obj |
-| `src_intraabd_enteric` | direction_only | — | Epidemiology of Escherichia coli Bac | no-source-obj |
-| `src_intraabd_anaerobes` | direction_only | — | Clinical Emergence of Bacteroides-As | no-source-obj |
-| `src_skin_saureus` | grounded | — | Staphylococcus aureus Infections: Ep | no-source-obj |
-| `src_skin_pyogenes` | direction_only | — | Five-year review of epidemiology of  | no-source-obj |
-| `src_resp_pneumo` | direction_only | — | Streptococcus pneumoniae bacteremia: | no-source-obj |
-| `host_neutropenia_pseudomonas` | grounded | — | Cheong HS, et al. "Clinical signific | no-source-obj |
-| `host_idu_saureus` | grounded | — | Clinical manifestations and outcome  | no-source-obj |
+| `src_urinary_enteric` | direction_only | FLAG | src:5fe22e06d0ac823f | ◑ core ✓ (1/2 spans; over-reach) |
+| `src_line_cons` | grounded | ACCEPT | src:b18b8c9e3d73b0a9 | ✓ verified (1/1) |
+| `src_line_saureus` | direction_only | FLAG | src:ccf66a2721e88eb6 | ✓ verified (1/1) |
+| `src_intraabd_enteric` | direction_only | FLAG | src:b5e0dae026b80495 | ✗ UNVERIFIED (0/2) |
+| `src_intraabd_anaerobes` | direction_only | FLAG | src:38fddb4e21c26afd | ✗ UNVERIFIED (0/1) |
+| `src_skin_saureus` | grounded | ACCEPT | src:4b82b0b1ad4abad1 | ✗ UNVERIFIED (0/1) |
+| `src_skin_pyogenes` | direction_only | FLAG | src:e8b0ff528d21cbcf | ✓ verified (1/1) |
+| `src_resp_pneumo` | direction_only | FLAG | src:02a564c064c60c6c | ✗ UNVERIFIED (0/1) |
+| `host_neutropenia_pseudomonas` | grounded | ACCEPT | src:93a334a5c1776980 | ✓ verified (1/1) |
+| `host_idu_saureus` | grounded | ACCEPT | src:2c27a17c150df555 | ✓ verified (2/2) |
 
 
-_Citation verification against decomposed sources in the CAS: **18 fully verified**, 2 core-verified (over-reach), 16 unverified, 35 pending._
+_Citation verification against decomposed sources in the CAS: **36 fully verified**, 4 core-verified (over-reach), 31 unverified, 0 pending._

--- a/code/specs/data/mycin-2026/cas/sources/02a564c064c60c6c.json
+++ b/code/specs/data/mycin-2026/cas/sources/02a564c064c60c6c.json
@@ -1,0 +1,101 @@
+{
+  "hash": "02a564c064c60c6c",
+  "source_id": "https://pmc.ncbi.nlm.nih.gov/articles/PMC3892635/",
+  "title": "Streptococcus pneumoniae bacteremia: clinical and microbiological epidemiology in a health area of Southern Spain",
+  "resolved_url": "https://pmc.ncbi.nlm.nih.gov/articles/PMC3892635/",
+  "claims": [
+    {
+      "id": "c1",
+      "text": "S. pneumoniae is the most common cause of community-acquired pneumonia, meningitis and bacteremia in children and adults.",
+      "byte_quote": "Streptococcus pneumoniae is the most common cause of community-acquired pneumonia, meningitis and bacteremia in children and adults"
+    },
+    {
+      "id": "c2",
+      "text": "Pneumococcal bacteremia incidence is 15-35 cases per 100,000 inhabitants.",
+      "byte_quote": "The incidence of this kind of bacteremia is 15–35 cases per 100,000 inhabitants"
+    },
+    {
+      "id": "c3",
+      "text": "In this study the median annual incidence was 2.9 cases per 100,000 inhabitants.",
+      "byte_quote": "In our study the median annual incidence was 2.9 cases/100,000 inhabitants"
+    },
+    {
+      "id": "c4",
+      "text": "Serotype 19A was the most frequent, followed by serotypes 1, 7F and 14.",
+      "byte_quote": "Serotype 19A was the most frequent, followed by serotypes 1, 7F and 14."
+    },
+    {
+      "id": "c5",
+      "text": "Forty percent of bacteremias were caused by serotypes 19A, 1, 7F and 14.",
+      "byte_quote": "Forty percent of bacteremias were caused by serotypes 19A, 1, 7F and 14"
+    },
+    {
+      "id": "c6",
+      "text": "Main predisposing factors for pneumococcal bacteremia were smoking, antimicrobial/corticosteroid use, COPD, and HIV infection.",
+      "byte_quote": "The main predisposing factors observed were smoking, antimicrobial and/or corticosteroids administration, chronic pulmonary obstructive disease and HIV infection"
+    },
+    {
+      "id": "c7",
+      "text": "The leading predisposing factor for S. pneumoniae bacteremia was cigarette smoking (29.9%).",
+      "byte_quote": "The main predisposing factor for _S. pneumoniae_ bacteremia was cigarette smoking (29.9%)"
+    },
+    {
+      "id": "c8",
+      "text": "Seventy percent of patients had predisposing factors.",
+      "byte_quote": "Seventy percent of patients had predisposing factors"
+    },
+    {
+      "id": "c9",
+      "text": "Invasive pneumococcal disease most frequently infects children under 2 years, older adults (>65 years), and those with co-morbidities.",
+      "byte_quote": "Overall, invasive pneumococcal disease most frequently cause infection in children less than 2 years old, older adults (>65 years old) and individuals with co-morbidities"
+    },
+    {
+      "id": "c10",
+      "text": "Among isolates, 77.6% were penicillin-susceptible, 17.9% penicillin-intermediate, and 4.5% penicillin-resistant.",
+      "byte_quote": "77.6% of the isolates were penicillin-susceptible, while 17.9% were penicillin-intermediate and only 4.5% of these isolates were penicillin-resistant."
+    },
+    {
+      "id": "c11",
+      "text": "In Spain, invasive penicillin-nonsusceptible strains in the general population range from 19-45%.",
+      "byte_quote": "In our country, the percentage of invasive strains penicillin-nonsusceptible in the general population range from 19–45%"
+    },
+    {
+      "id": "c12",
+      "text": "The most common bacteremia source was the low respiratory tract (46 patients).",
+      "byte_quote": "The most common focus was the low respiratory tract recorded for 46 patients"
+    },
+    {
+      "id": "c13",
+      "text": "In one case the source of infection was the cerebrospinal fluid; the source was unknown in 20 episodes.",
+      "byte_quote": "The source of bacteremia was considered unknown in 20 episodes."
+    },
+    {
+      "id": "c14",
+      "text": "100% of bacteremia episodes were community-acquired.",
+      "byte_quote": "100% of episodes were from community-acquired origin."
+    },
+    {
+      "id": "c15",
+      "text": "Mortality associated with the bacteremia was 6%.",
+      "byte_quote": "In our study, the mortality associated to bacteremia was 6%."
+    },
+    {
+      "id": "c16",
+      "text": "Five variables were significantly associated with mortality: age >65, male sex, Caucasian race, critical/poor clinical condition, and septic shock.",
+      "byte_quote": "Five variables were significantly associated with mortality from _S. pneumoniae_ bacteremia: age >65 years, male sex, Caucasian race, clinical condition critical and poor and septic shock."
+    },
+    {
+      "id": "c17",
+      "text": "Antibiotics tested for susceptibility were Penicillin G, Amoxicillin, Erythromycin, Chloramphenicol, Vancomycin, Cefotaxime and Tetracycline.",
+      "byte_quote": "Penicillin G, Amoxicillin, Erythromycin, Chloramphenicol, Vancomycin, Cefotaxime and Tetracycline were tested"
+    }
+  ],
+  "cites": [
+    "Lynch & Zhanel 2009",
+    "McKensie et al. 2000",
+    "Hausdorff et al.",
+    "Metlay et al.",
+    "Fariñas-Álvarez et al. 2000",
+    "CDC (Centers for Disease Control and Prevention)"
+  ]
+}

--- a/code/specs/data/mycin-2026/cas/sources/04668cefe35908cd.json
+++ b/code/specs/data/mycin-2026/cas/sources/04668cefe35908cd.json
@@ -1,0 +1,126 @@
+{
+  "hash": "04668cefe35908cd",
+  "source_id": "https://dailymed.nlm.nih.gov/dailymed/drugInfo.cfm?setid=65e5f2ee-934c-40d7-967c-00d085f84ffd",
+  "title": "DailyMed — VANCOMYCIN HYDROCHLORIDE injection, powder, lyophilized, for solution (Gland Pharma Limited)",
+  "resolved_url": "https://dailymed.nlm.nih.gov/dailymed/drugInfo.cfm?setid=65e5f2ee-934c-40d7-967c-00d085f84ffd",
+  "claims": [
+    {
+      "id": "c1",
+      "text": "Vancomycin is a glycopeptide antibacterial indicated in adults and pediatric patients (neonates and older).",
+      "byte_quote": "Vancomycin Hydrochloride for Injection is a glycopeptide antibacterial indicated in adult and pediatric patients (neonates and older)"
+    },
+    {
+      "id": "c2",
+      "text": "Vancomycin is a tricyclic glycopeptide whose bactericidal action comes primarily from inhibiting cell-wall biosynthesis.",
+      "byte_quote": "The bactericidal action of vancomycin results primarily from inhibition of cell-wall biosynthesis"
+    },
+    {
+      "id": "c3",
+      "text": "Vancomycin is indicated for septicemia (bloodstream infection) due to susceptible MRSA and coagulase negative staphylococci.",
+      "byte_quote": "for the treatment of septicemia due to: \n Susceptible isolates of methicillin-resistant Staphylococcus aureus (MRSA) and coagulase negative staphylococci."
+    },
+    {
+      "id": "c4",
+      "text": "In penicillin-allergic patients (or those who cannot take / have failed penicillins or cephalosporins), vancomycin covers methicillin-susceptible staphylococci for septicemia.",
+      "byte_quote": "Methicillin-susceptible staphylococci in penicillin-allergic patients, or those patients who cannot receive or who have failed to respond to other drugs, including penicillins or cephalosporins."
+    },
+    {
+      "id": "c5",
+      "text": "Vancomycin treats infective endocarditis due to MRSA; viridans group streptococci, Streptococcus gallolyticus (formerly S. bovis), Enterococcus species, and Corynebacterium species.",
+      "byte_quote": "Viridans group streptococci Streptococcus gallolyticus (previously known as Streptococcus bovis ), Enterococcus species and Corynebacterium species."
+    },
+    {
+      "id": "c6",
+      "text": "For enterococcal endocarditis, vancomycin must be combined with an aminoglycoside.",
+      "byte_quote": "For enterococcal endocarditis, use Vancomycin Hydrochloride for Injection in combination with an aminoglycoside."
+    },
+    {
+      "id": "c7",
+      "text": "Vancomycin treats early-onset prosthetic valve endocarditis caused by Staphylococcus epidermidis, combined with rifampin and an aminoglycoside.",
+      "byte_quote": "for the treatment of early-onset prosthetic valve endocarditis caused by Staphylococcus epidermidis in combination with rifampin and an aminoglycoside."
+    },
+    {
+      "id": "c8",
+      "text": "Vancomycin treats skin and skin structure infections due to susceptible MRSA and coagulase negative staphylococci.",
+      "byte_quote": "for the treatment of skin and skin structure infections due to: \n Susceptible isolates of MRSA and coagulase negative staphylococci."
+    },
+    {
+      "id": "c9",
+      "text": "Vancomycin treats lower respiratory tract infections due to susceptible MRSA.",
+      "byte_quote": "for the treatment of lower respiratory tract infections due to: \n Susceptible isolates of MRSA"
+    },
+    {
+      "id": "c10",
+      "text": "Adult dose with normal renal function is 2 g/day, given as 500 mg every 6 hours or 1 g every 12 hours.",
+      "byte_quote": "The usual daily intravenous dose is 2 grams divided either as 500 mg every 6 hours or 1 g every 12 hours."
+    },
+    {
+      "id": "c11",
+      "text": "Pediatric dose (aged 1 month and older) is 10 mg/kg per dose every 6 hours, each over at least 60 minutes.",
+      "byte_quote": "The usual intravenous dosage of vancomycin is 10 mg/kg per dose given every 6 hours. Each dose should be administered over a period of at least 60 minutes."
+    },
+    {
+      "id": "c12",
+      "text": "Neonatal dose: initial 15 mg/kg, then 10 mg/kg every 12 hours in the first week of life and every 8 hours thereafter up to 1 month of age.",
+      "byte_quote": "In neonates, an initial dose of 15 mg/kg is suggested, followed by 10 mg/kg every 12 hours for neonates in the 1 st week of life and every 8 hours thereafter up to the age of 1 month."
+    },
+    {
+      "id": "c13",
+      "text": "In premature infants vancomycin clearance falls as postconceptional age decreases, so longer dosing intervals may be needed.",
+      "byte_quote": "In premature infants, vancomycin clearance decreases as postconceptional age decreases. Therefore, longer dosing intervals may be necessary in premature infants."
+    },
+    {
+      "id": "c14",
+      "text": "In renal impairment the initial dose should be no less than 15 mg/kg; functionally anephric patients get 15 mg/kg initially then 1.9 mg/kg/24 hr.",
+      "byte_quote": "For functionally anephric patients, an initial dose of 15 mg/kg of body weight should be given to achieve prompt therapeutic serum concentration. A dose of 1.9 mg/kg/24 hr should be given after the initial dose of 15 mg/kg."
+    },
+    {
+      "id": "c15",
+      "text": "Each IV dose should be administered over a period of 60 minutes or greater to reduce infusion reactions.",
+      "byte_quote": "administer Vancomycin Hydrochloride for Injection in a diluted solution over 60 minutes or greater"
+    },
+    {
+      "id": "c16",
+      "text": "Vancomycin is contraindicated in patients with known hypersensitivity to vancomycin.",
+      "byte_quote": "Vancomycin Hydrochloride for Injection is contraindicated in patients with known hypersensitivity to vancomycin."
+    },
+    {
+      "id": "c17",
+      "text": "Vancomycin can cause acute kidney injury including acute renal failure, mainly from interstitial nephritis or less commonly acute tubular necrosis.",
+      "byte_quote": "Vancomycin Hydrochloride for Injection can result in acute kidney injury (AKI), including acute renal failure, mainly due to interstitial nephritis or less commonly acute tubular necrosis."
+    },
+    {
+      "id": "c18",
+      "text": "AKI risk rises with higher vancomycin serum levels, prolonged exposure, concomitant nephrotoxic drugs, concomitant piperacillin-tazobactam, volume depletion, pre-existing renal impairment, and critical illness.",
+      "byte_quote": "The risk of AKI increases with higher vancomycin serum levels, prolonged exposure, concomitant administration of other nephrotoxic drugs, concomitant administration of piperacillin-tazobactam"
+    },
+    {
+      "id": "c19",
+      "text": "Concomitant piperacillin/tazobactam plus vancomycin increases acute kidney injury incidence versus vancomycin alone.",
+      "byte_quote": "Increased incidence of acute kidney injury in patients receiving concomitant piperacillin/tazobactam and vancomycin as compared to vancomycin alone."
+    },
+    {
+      "id": "c20",
+      "text": "Concomitant vancomycin and anesthetic agents has been associated with erythema and histamine-like flushing.",
+      "byte_quote": "Concomitant administration of vancomycin and anesthetic agents has been associated with erythema and histaminelike flushing."
+    },
+    {
+      "id": "c21",
+      "text": "Ototoxicity risk is higher in older patients, those on higher doses, with underlying hearing loss, on concomitant ototoxic agents (e.g. aminoglycoside), or with renal impairment.",
+      "byte_quote": "The risk is higher in older patients, patients who are receiving higher doses, who have an underlying hearing loss, who are receiving concomitant therapy with another ototoxic agent, such as an aminoglycoside or who have underlying renal impairment."
+    },
+    {
+      "id": "c22",
+      "text": "Reversible neutropenia has been reported; patients on prolonged therapy or concomitant neutropenia-causing drugs should have periodic leukocyte counts.",
+      "byte_quote": "Reversible neutropenia has been reported in patients receiving Vancomycin Hydrochloride for Injection"
+    },
+    {
+      "id": "c23",
+      "text": "No available data on vancomycin use in pregnant women inform a drug-associated risk of major birth defects or miscarriage (pregnancy section).",
+      "byte_quote": "“vancomycin infusion reaction”, which manifests as pruritus and erythema that involves the face, neck and upper torso"
+    }
+  ],
+  "cites": [
+    "Byrd RA, Gries CL, Buening M. Developmental Toxicology Studies of Vancomycin Hydrochloride Administered Intravenously to Rats and Rabbits. Fundam Appl Toxicol 1994; 23: 590-597."
+  ]
+}

--- a/code/specs/data/mycin-2026/cas/sources/05de3ced05f32c90.json
+++ b/code/specs/data/mycin-2026/cas/sources/05de3ced05f32c90.json
@@ -1,0 +1,39 @@
+{
+  "hash": "05de3ced05f32c90",
+  "source_id": "https://pubmed.ncbi.nlm.nih.gov/6696301/",
+  "title": "Measurement of urinary leukocyte esterase activity: a screening test for urinary tract infections (Chernow et al., Ann Emerg Med. 1984;13(3):150-4)",
+  "resolved_url": "https://pubmed.ncbi.nlm.nih.gov/6696301/",
+  "claims": [
+    {
+      "id": "c1",
+      "text": "Leukocyte esterase is an enzyme released only from leukocytes, and testing for it in urine indicates the presence of pyuria.",
+      "byte_quote": "We evaluated the efficacy of testing for the presence of esterase (an enzyme released only from leukocytes) in the urine as an indicator of the presence of pyuria."
+    },
+    {
+      "id": "c2",
+      "text": "A dipstick test for urinary leukocyte esterase activity was hypothesized to be a rapid, simple screening technique for detecting UTIs.",
+      "byte_quote": "We hypothesized that a \"dipstick\" test for urinary leukocyte esterase activity would be a rapid and simple screening technique for detecting urinary tract infections (UTI)."
+    },
+    {
+      "id": "c3",
+      "text": "Study population: 203 patients (148 outpatients, 55 inpatients) with suspected UTI.",
+      "byte_quote": "we collected fresh urine specimens from 203 patients (148 outpatients, 55 inpatients) with a suspected UTI."
+    },
+    {
+      "id": "c4",
+      "text": "Significant bacteriuria was defined as >= 10^5 organisms/mL; 49 of 203 specimens met this threshold.",
+      "byte_quote": "Of the 203 specimens, 49 showed significant bacteriuria (greater than or equal to 10(5) organisms/mL)."
+    },
+    {
+      "id": "c5",
+      "text": "Leukocyte esterase dipstick was 100% sensitive (0% false negatives) and 76% specific (24% false positives) for predicting significant bacteriuria.",
+      "byte_quote": "The leukocyte esterase test was 100% sensitive (0% false negatives) with a 76% specificity (24% false positives) in predicting significant bacteriuria."
+    },
+    {
+      "id": "c6",
+      "text": "Urinary nitrite testing was highly specific (99% specificity, 0.6% false positives) but insensitive (27% sensitivity, 73% false negatives).",
+      "byte_quote": "Although a positive nitrite reaction was more specific (99% specificity, 0.6% false positives), it was insensitive (27% sensitivity, 73% false negatives)."
+    }
+  ],
+  "cites": []
+}

--- a/code/specs/data/mycin-2026/cas/sources/1090fd8acb46f5e8.json
+++ b/code/specs/data/mycin-2026/cas/sources/1090fd8acb46f5e8.json
@@ -1,0 +1,74 @@
+{
+  "hash": "1090fd8acb46f5e8",
+  "source_id": "https://pmc.ncbi.nlm.nih.gov/articles/PMC2708523/",
+  "title": "Diversity of Group B Streptococcus Serotypes Causing Urinary Tract Infection in Adults",
+  "resolved_url": "https://pmc.ncbi.nlm.nih.gov/articles/PMC2708523/",
+  "claims": [
+    {
+      "id": "c1",
+      "text": "Group B Streptococcus (GBS) was cultured from 1.1% of consecutive adult urine samples (387/34,367).",
+      "byte_quote": "GBS was cultured from 387/34,367 consecutive urine samples (1.1%)"
+    },
+    {
+      "id": "c2",
+      "text": "Serotypes V, Ia, and III caused the most GBS UTIs.",
+      "byte_quote": "Serotypes V, Ia, and III caused the most UTIs"
+    },
+    {
+      "id": "c3",
+      "text": "Serotypes V, Ia, and III together account for 76% of the 62 GBS UTI cases.",
+      "byte_quote": "The most prevalent serotypes among the 62 cases of GBS UTI were serotypes V, Ia, and III (Table 2), which together account for 76% of cases."
+    },
+    {
+      "id": "c4",
+      "text": "Nontypeable GBS was not associated with UTI.",
+      "byte_quote": "Nontypeable GBS was not associated with UTI."
+    },
+    {
+      "id": "c5",
+      "text": "GBS UTI case patients were significantly older than controls (mean 53 vs 30 years).",
+      "byte_quote": "the mean age of case patients was significantly greater (53 ± 19 years versus 30 ± 12 years; P < 0.001)"
+    },
+    {
+      "id": "c6",
+      "text": "Prior history of UTI raised the odds of GBS UTI (OR 3.1).",
+      "byte_quote": "GBS UTI case patients were significantly more likely to have had a prior history of UTI than controls (OR, 3.1; 95% CI, 1.1 to 8.7)"
+    },
+    {
+      "id": "c7",
+      "text": "Female sex raised the odds of GBS UTI (OR 3.8).",
+      "byte_quote": "to be female (OR, 3.8; 95% CI, 1.6 to 8.7)"
+    },
+    {
+      "id": "c8",
+      "text": "Women of child-bearing age with GBS UTI were less likely to be pregnant than child-bearing-age controls (37.5% vs 81.4%).",
+      "byte_quote": "Significantly fewer women of child-bearing age (defined as <40 yrs) with GBS UTI were pregnant than women of child-bearing age who were controls (37.5% [6/16] versus 81.4% [35/43]; P = 0.003)"
+    },
+    {
+      "id": "c9",
+      "text": "Confirmed GBS UTI cases (31/62 with urinalysis) all had positive leukocyte esterase and pyuria.",
+      "byte_quote": "All 31 of the 62 patients who had UA performed had positive results based on positive urinary leukocyte esterase and pyuria"
+    },
+    {
+      "id": "c10",
+      "text": "GBS isolates were uniformly susceptible to amoxicillin-clavulanic acid, penicillin, linezolid, and chloramphenicol.",
+      "byte_quote": "they were uniformly susceptible to amoxicillin (amoxicilline) with clavulanic acid, penicillin, linezolid, and chloramphenicol"
+    },
+    {
+      "id": "c11",
+      "text": "A substantial proportion of GBS isolates were resistant to clindamycin (26.4%) and erythromycin (39.5%).",
+      "byte_quote": "A considerable proportion of isolates was resistant to clindamycin (102/387 [26.4%]) and erythromycin (153/387 [39.5%])"
+    },
+    {
+      "id": "c12",
+      "text": "Most GBS isolates were resistant to tetracycline (80.4%), cefoxitin (88.7%), and trimethoprim-sulfamethoxazole (98.3%).",
+      "byte_quote": "the majority was resistant to tetracycline (311/387 [80.4%]), cefoxitin (343/387 [88.7%]), and trimethoprim with sulfamethoxazole (380/387 [98.3%])"
+    },
+    {
+      "id": "c13",
+      "text": "Only one GBS UTI patient had concurrent GBS bloodstream isolation, indicating probable urosepsis.",
+      "byte_quote": "only one patient had GBS concurrently isolated from blood, representing probable urosepsis"
+    }
+  ],
+  "cites": []
+}

--- a/code/specs/data/mycin-2026/cas/sources/1b4719e7d669a63f.json
+++ b/code/specs/data/mycin-2026/cas/sources/1b4719e7d669a63f.json
@@ -1,0 +1,54 @@
+{
+  "hash": "1b4719e7d669a63f",
+  "source_id": "https://pubmed.ncbi.nlm.nih.gov/15701325/",
+  "title": "Etiology and antimicrobial susceptibility among uropathogens causing community-acquired lower urinary tract infections: a nationwide surveillance study (Enferm Infecc Microbiol Clin. 2005 Jan;23(1):4-9)",
+  "resolved_url": "https://pubmed.ncbi.nlm.nih.gov/15701325/",
+  "claims": [
+    {
+      "id": "c1",
+      "text": "Among 2724 isolates from outpatients with lower UTIs, E. coli was the most frequent uropathogen at 73%.",
+      "byte_quote": "The most frequent pathogen found was Escherichia coli (73%)"
+    },
+    {
+      "id": "c2",
+      "text": "After E. coli, the next most frequent lower-UTI uropathogens were Proteus spp. (7.4%), Klebsiella spp. (6.6%), and Enterococcus spp. (4.8%).",
+      "byte_quote": "followed by Proteus spp. (7.4%), Klebsiella spp. (6.6%) and Enterococcus spp. (4.8%)"
+    },
+    {
+      "id": "c3",
+      "text": "The study analyzed 2724 isolates recovered from outpatients with lower urinary tract infections.",
+      "byte_quote": "A total of 2724 isolates were recovered from outpatients with lower urinary tract infections."
+    },
+    {
+      "id": "c4",
+      "text": "E. coli susceptibility rates were fosfomycin 97.9%, cefixime 95.8%, nitrofurantoin 94.3%, amoxicillin-clavulanic acid 90.8%, and ciprofloxacin 77.2%.",
+      "byte_quote": "The susceptibility rates of E. coli were 97.9% for fosfomycin, 95.8% for cefixime, 94.3% for nitrofurantoin, 90.8% for amoxicillin-clavulanic acid and 77.2% for ciprofloxacin."
+    },
+    {
+      "id": "c5",
+      "text": "E. coli fluoroquinolone resistance was significantly higher in men than women (28.9% vs. 19%; P<0.001).",
+      "byte_quote": "E. coli resistance to fluoroquinolones was significantly higher in men (28.9% vs. 19% in women; P < 0.001)"
+    },
+    {
+      "id": "c6",
+      "text": "E. coli fluoroquinolone resistance was significantly higher in elderly patients, 33.7% in those 80 years or older vs. 7.1% in those 40 years or younger (P<0.001).",
+      "byte_quote": "elderly patients (33.7% in 80 years or older vs. 7.1% in 40 years or younger; P < 0.001)"
+    },
+    {
+      "id": "c7",
+      "text": "E. coli fluoroquinolone resistance was significantly higher in complicated infections than non-complicated (24.8% vs. 13.7%; P<0.001).",
+      "byte_quote": "complicated infections (24.8% vs. 13.7% in non-complicated; P < 0.001)"
+    },
+    {
+      "id": "c8",
+      "text": "Overall E. coli fluoroquinolone resistance was near 23%, varying by sex, age, infection type, and geographic region.",
+      "byte_quote": "Overall fluoroquinolone resistance was near 23%, but this rate varied significantly according to sex, age, type of urinary infection, and geographic region."
+    },
+    {
+      "id": "c9",
+      "text": "Almost all E. coli isolates were susceptible to fosfomycin, cefixime, and nitrofurantoin.",
+      "byte_quote": "Almost all E. coli isolates were susceptible to fosfomycin, cefixime and nitrofurantoin."
+    }
+  ],
+  "cites": []
+}

--- a/code/specs/data/mycin-2026/cas/sources/20ee76476443836b.json
+++ b/code/specs/data/mycin-2026/cas/sources/20ee76476443836b.json
@@ -1,0 +1,44 @@
+{
+  "hash": "20ee76476443836b",
+  "source_id": "https://pubmed.ncbi.nlm.nih.gov/3284952/",
+  "title": "Streptococcus pyogenes bacteraemia: an old enemy subdued, but not defeated (Ispahani P, Donald FE, Aveline AJ. J Infect. 1988 Jan;16(1):37-46)",
+  "resolved_url": "https://pubmed.ncbi.nlm.nih.gov/3284952/",
+  "claims": [
+    {
+      "id": "c1",
+      "text": "Streptococcus pyogenes (Group A beta-haemolytic streptococci) bacteraemia accounted for 2% of all bacteraemia cases in a 7-year single-hospital review (40 cases).",
+      "byte_quote": "Altogether, 40 cases were encountered, representing 2% of all cases of bacteraemia."
+    },
+    {
+      "id": "c2",
+      "text": "Mortality from S. pyogenes bacteraemia was 35%.",
+      "byte_quote": "Mortality was 35%."
+    },
+    {
+      "id": "c3",
+      "text": "S. pyogenes bacteraemia was predominantly community-acquired, and 28% of patients were under 40 years of age (age/host risk factor).",
+      "byte_quote": "Most cases were community-acquired and 28% of patients were less than 40 years of age."
+    },
+    {
+      "id": "c4",
+      "text": "A third of patients with S. pyogenes bacteraemia were previously fit (i.e., not immunocompromised / no prior comorbidity), indicating it can affect previously healthy hosts.",
+      "byte_quote": "A third of the patients were previously fit."
+    },
+    {
+      "id": "c5",
+      "text": "Bloodstream-infection source-to-organism association: the most common portals of entry for S. pyogenes bacteraemia were skin and soft tissue (23 patients) and the respiratory tract (8 patients).",
+      "byte_quote": "The most common sources of bacteraemia were the skin and soft tissue (23 patients) and the respiratory tract (eight patients)."
+    },
+    {
+      "id": "c6",
+      "text": "Shock occurred in 40% of S. pyogenes bacteraemia cases and carried 60% mortality.",
+      "byte_quote": "Shock was recorded in 40% of cases and carried a 60% mortality."
+    },
+    {
+      "id": "c7",
+      "text": "S. pyogenes is uniquely/uniformly susceptible to penicillin (antibiotic susceptibility), yet still poses a clinical challenge.",
+      "byte_quote": "Despite its unique susceptibility to penicillin, S. pyogenes continues to pose a challenge to the physician."
+    }
+  ],
+  "cites": []
+}

--- a/code/specs/data/mycin-2026/cas/sources/29c9c085cc9e0800.json
+++ b/code/specs/data/mycin-2026/cas/sources/29c9c085cc9e0800.json
@@ -1,0 +1,127 @@
+{
+  "hash": "29c9c085cc9e0800",
+  "source_id": "https://dailymed.nlm.nih.gov/dailymed/fda/fdaDrugXsl.cfm?setid=f604d399-fded-4f4f-8efe-af558ed07b9d",
+  "title": "Vancomycin Hydrochloride for Injection, USP — DailyMed FDA Label",
+  "resolved_url": "https://dailymed.nlm.nih.gov/dailymed/fda/fdaDrugXsl.cfm?setid=f604d399-fded-4f4f-8efe-af558ed07b9d",
+  "claims": [
+    {
+      "id": "c1",
+      "text": "Vancomycin is indicated for serious/severe infections caused by methicillin-resistant (beta-lactam-resistant) staphylococci, and for penicillin-allergic patients.",
+      "byte_quote": "Vancomycin Hydrochloride for Injection, USP is indicated for the treatment of serious or severe infections caused by susceptible strains of methicillin-resistant (β-lactam-resistant) staphylococci. It is indicated for penicillin-allergic patients, for patients who cannot receive or who have failed to respond to other drugs, including the penicillins or cephalosporins"
+    },
+    {
+      "id": "c2",
+      "text": "Susceptible organisms include Staphylococcus aureus and S. epidermidis (including heterogeneous methicillin-resistant strains).",
+      "byte_quote": "Staphylococci, including Staphylococcus aureus and Staphylococcus epidermidis (including heterogeneous methicillin-resistant strains)"
+    },
+    {
+      "id": "c3",
+      "text": "Susceptible organisms also include enterococci (e.g. Enterococcus faecalis), viridans group streptococci, Streptococcus bovis, and diphtheroids.",
+      "byte_quote": "Enterococci (e.g., Enterococcus faecalis )"
+    },
+    {
+      "id": "c4",
+      "text": "Vancomycin is not active in vitro against gram-negative bacilli, mycobacteria, or fungi.",
+      "byte_quote": "Vancomycin is not active in vitro against gram-negative bacilli, mycobacteria, or fungi."
+    },
+    {
+      "id": "c5",
+      "text": "Bloodstream/endocardial indications: vancomycin is effective in staphylococcal endocarditis, septicemia, bone infections, lower respiratory tract infections, and skin/skin-structure infections due to staphylococci.",
+      "byte_quote": "Vancomycin Hydrochloride for Injection, USP is effective in the treatment of staphylococcal endocarditis. Its effectiveness has been documented in other infections due to staphylococci, including septicemia, bone infections, lower respiratory tract infections, skin and skin structure infections."
+    },
+    {
+      "id": "c6",
+      "text": "For endocarditis caused by S. viridans or S. bovis, vancomycin is effective alone or with an aminoglycoside; for enterococcal endocarditis (e.g. E. faecalis) it is effective only combined with an aminoglycoside.",
+      "byte_quote": "has been reported to be effective alone or in combination with an aminoglycoside for endocarditis caused by S. viridans or S. bovis. For endocarditis caused by enterococci (e.g., E. faecalis ), vancomycin has been reported to be effective only in combination with an aminoglycoside."
+    },
+    {
+      "id": "c7",
+      "text": "Early-onset prosthetic valve endocarditis caused by S. epidermidis or diphtheroids is treated with vancomycin plus rifampin and/or an aminoglycoside.",
+      "byte_quote": "has been used successfully in combination with either rifampin, an aminoglycoside, or both in early-onset prosthetic valve endocarditis caused by S. epidermidis or diphtheroids."
+    },
+    {
+      "id": "c8",
+      "text": "Oral vancomycin (parenteral form given orally) treats antibiotic-associated pseudomembranous colitis produced by C. difficile and staphylococcal enterocolitis.",
+      "byte_quote": "may be administered orally for treatment of antibiotic-associated pseudomembranous colitis produced by C. difficile and for staphylococcal enterocolitis."
+    },
+    {
+      "id": "c9",
+      "text": "Usual adult IV dose is 2 g/day, given as 500 mg every 6 hours or 1 g every 12 hours, each dose infused at no more than 10 mg/min or over at least 60 minutes.",
+      "byte_quote": "The usual daily intravenous dose is 2 g divided either as 500 mg every 6 hours or 1 g every 12 hours. Each dose should be administered at no more than 10 mg/min or over a period of at least 60 minutes, whichever is longer."
+    },
+    {
+      "id": "c10",
+      "text": "Usual pediatric IV dose is 10 mg/kg per dose every 6 hours, each over at least 60 minutes.",
+      "byte_quote": "The usual intravenous dosage of vancomycin is 10 mg/kg per dose given every 6 hours. Each dose should be administered over a period of at least 60 minutes."
+    },
+    {
+      "id": "c11",
+      "text": "Neonatal dosing: initial 15 mg/kg, then 10 mg/kg every 12 hours in the 1st week of life and every 8 hours thereafter up to age 1 month.",
+      "byte_quote": "In neonates, an initial dose of 15 mg/kg is suggested, followed by 10 mg/kg every 12 hours for neonates in the 1st week of life and every 8 hours thereafter up to the age of 1 month."
+    },
+    {
+      "id": "c12",
+      "text": "Oral dosing for C. difficile colitis: adult 500 mg to 2 g/day in 3-4 divided doses for 7-10 days; children 40 mg/kg/day in 3-4 divided doses, not exceeding 2 g/day.",
+      "byte_quote": "The usual adult total daily dosage is 500 mg to 2 g given in 3 or 4 divided doses for 7 to 10 days. The total daily dose in children is 40 mg/kg of body weight in 3 or 4 divided doses for 7 to 10 days. The total daily dosage should not exceed 2 g."
+    },
+    {
+      "id": "c13",
+      "text": "Renal impairment: initial dose should be no less than 15 mg/kg even with mild-to-moderate insufficiency; anephric patients get 15 mg/kg initial then 1.9 mg/kg/24 hr maintenance; in anuria 1,000 mg every 7 to 10 days.",
+      "byte_quote": "The initial dose should be no less than 15 mg/kg, even in patients with mild to moderate renal insufficiency. The table is not valid for functionally anephric patients. For such patients, an initial dose of 15 mg/kg of body weight should be given to achieve prompt therapeutic serum concentrations. The dose required to maintain stable concentrations is 1.9 mg/kg/24 hr."
+    },
+    {
+      "id": "c14",
+      "text": "Contraindicated in patients with known hypersensitivity to vancomycin.",
+      "byte_quote": "Vancomycin hydrochloride for injection is contraindicated in patients with known hypersensitivity to this antibiotic."
+    },
+    {
+      "id": "c15",
+      "text": "Systemic vancomycin exposure may cause acute kidney injury (AKI); risk rises with increasing serum levels; monitor renal function in all patients, especially those with renal impairment or on nephrotoxic drugs.",
+      "byte_quote": "Systemic vancomycin exposure may result in acute kidney injury (AKI). The risk of AKI increases as systemic exposure/serum levels increase. Monitor renal function in all patients, especially patients with underlying renal impairment, patients with co-morbidities that predispose to renal impairment, and patients receiving concomitant therapy with a drug known to be nephrotoxic."
+    },
+    {
+      "id": "c16",
+      "text": "Ototoxicity occurs mostly with excessive doses, underlying hearing loss, or concomitant ototoxic agents such as an aminoglycoside.",
+      "byte_quote": "It has been reported mostly in patients who have been given excessive doses, who have an underlying hearing loss, or who are receiving concomitant therapy with another ototoxic agent, such as an aminoglycoside."
+    },
+    {
+      "id": "c17",
+      "text": "Monitor renal function when vancomycin is used with other neurotoxic/nephrotoxic drugs such as amphotericin B, aminoglycosides, bacitracin, polymixin B, colistin, viomycin, or cisplatin.",
+      "byte_quote": "Monitor renal function in patients receiving vancomycin and concurrent and/or sequential systemic or topical use of other potentially, neurotoxic and/or nephrotoxic drugs, such as amphotericin B, aminoglycosides, bacitracin, polymixin B, colistin, viomycin, or cisplatin."
+    },
+    {
+      "id": "c18",
+      "text": "Concomitant vancomycin and anesthetic agents has been associated with erythema and histamine-like flushing and anaphylactoid reactions.",
+      "byte_quote": "Concomitant administration of vancomycin and anesthetic agents has been associated with erythema and histamine-like flushing (see Pediatric Use - PRECAUTIONS ) and anaphylactoid reactions"
+    },
+    {
+      "id": "c19",
+      "text": "Reversible neutropenia has been reported; patients on prolonged therapy or concomitant neutropenia-causing drugs should have periodic leukocyte count monitoring.",
+      "byte_quote": "Reversible neutropenia has been reported in patients receiving vancomycin hydrochloride for injection (see ADVERSE REACTIONS ). Patients who will undergo prolonged therapy with vancomycin hydrochloride for injection or those who are receiving concomitant drugs which may cause neutropenia should have periodic monitoring of the leukocyte count."
+    },
+    {
+      "id": "c20",
+      "text": "Pregnancy: not known whether vancomycin causes fetal harm; it crossed into cord blood with no attributable hearing loss/nephrotoxicity; give to pregnant women only if clearly needed.",
+      "byte_quote": "Vancomycin was found in cord blood. No sensorineural hearing loss or nephrotoxicity attributable to vancomycin was noted."
+    },
+    {
+      "id": "c21",
+      "text": "Vancomycin is excreted in human milk; caution in nursing women.",
+      "byte_quote": "Vancomycin hydrochloride for injection is excreted in human milk. Caution should be exercised when vancomycin hydrochloride for injection is administered to a nursing woman."
+    },
+    {
+      "id": "c22",
+      "text": "Vancomycin plus an aminoglycoside acts synergistically in vitro against many strains of S. aureus, S. bovis, enterococci, and viridans group streptococci.",
+      "byte_quote": "The combination of vancomycin and an aminoglycoside acts synergistically in vitro against many strains of Staphylococcus aureus , Streptococcus bovis , enterococci, and the viridans group streptococci."
+    },
+    {
+      "id": "c23",
+      "text": "Bactericidal action results primarily from inhibition of cell-wall biosynthesis; vancomycin also alters cell-membrane permeability and RNA synthesis.",
+      "byte_quote": "The bactericidal action of vancomycin results primarily from inhibition of cell-wall biosynthesis. In addition, vancomycin alters bacterial-cell-membrane permeability and RNA synthesis."
+    }
+  ],
+  "cites": [
+    "Moellering RC, Krogstad DJ, Greenblatt DJ: Vancomycin therapy in patients with impaired renal function: A nomogram for dosage. Ann Inter Med 1981; 94:343.",
+    "FDA Susceptibility Test Interpretive Criteria (STIC) — https://www.fda.gov/STIC"
+  ]
+}

--- a/code/specs/data/mycin-2026/cas/sources/2c27a17c150df555.json
+++ b/code/specs/data/mycin-2026/cas/sources/2c27a17c150df555.json
@@ -1,0 +1,74 @@
+{
+  "hash": "2c27a17c150df555",
+  "source_id": "https://www.ebi.ac.uk/europepmc/webservices/rest/PMC1584240/fullTextXML",
+  "title": "Clinical manifestations and outcome in Staphylococcus aureus endocarditis among injection drug users and nonaddicts: a prospective study of 74 patients",
+  "resolved_url": "https://www.ebi.ac.uk/europepmc/webservices/rest/PMC1584240/fullTextXML",
+  "claims": [
+    {
+      "id": "c1",
+      "text": "Endocarditis complicates 11% to 35% of S. aureus bacteremias (SAB), the range depending on the diagnostic criteria used.",
+      "byte_quote": "Endocarditis has been observed in 11% to 35% of S. aureus bacteremias (SAB)"
+    },
+    {
+      "id": "c2",
+      "text": "Among SAB cases, endocarditis was far more common in injection drug abusers (46%) than in nonaddicts (14%).",
+      "byte_quote": "Endocarditis was more common in SAB among drug abusers (46%) than in nonaddicts (14%)"
+    },
+    {
+      "id": "c3",
+      "text": "Injection drug abuse is one driver of the increased incidence of S. aureus infective endocarditis (host/exposure risk factor raising S. aureus).",
+      "byte_quote": "One of the reasons for increased incidence of S. aureus in IE is injection drug abuse"
+    },
+    {
+      "id": "c4",
+      "text": "Host factors raising endocarditis risk include S. aureus colonization, HIV-related immunosuppression, female sex, higher injection-drug-use frequency, and prior endocarditis.",
+      "byte_quote": "Colonization with S. aureus , HIV-related immunosuppression, female sex, increasing injection drug use frequency, and a history of previous IE are associated with a higher risk for endocarditis"
+    },
+    {
+      "id": "c5",
+      "text": "Injection drug users with S. aureus endocarditis were significantly younger than nonaddicts (mean 27 vs 65 years).",
+      "byte_quote": "IDUs were significantly younger (27 ± 15 vs 65 ± 15 years, P < 0.001)"
+    },
+    {
+      "id": "c6",
+      "text": "SAB in injection drug users was much more often community-acquired than in nonaddicts (95% vs 39%).",
+      "byte_quote": "their SAB was more often community-acquired (95% vs 39%, P < 0.001)"
+    },
+    {
+      "id": "c7",
+      "text": "Emerging at-risk host groups for S. aureus endocarditis are injection drug users, elderly patients with degenerative valve disease, patients with intravascular catheters or prosthetic valves, and nosocomial acquisition (device/exposure risk factors).",
+      "byte_quote": "new groups, including injection drug users (IDUs), elderly patients with degenerative valve disease, patients with intravascular catheter or prosthetic valve, and nosocomial acquisition"
+    },
+    {
+      "id": "c8",
+      "text": "Injection drug use predicts right-sided (tricuspid) endocarditis (60% of IDUs), whereas nonaddicts overwhelmingly have left-sided involvement (93%) — a portal/host-to-site association.",
+      "byte_quote": "Right-sided endocarditis was observed in 60% of IDUs whereas 93% of nonaddicts had left-sided involvement"
+    },
+    {
+      "id": "c9",
+      "text": "First-line antibiotic dosing for S. aureus endocarditis: cloxacillin or dicloxacillin 2 g IV every 4 hours for 4 to 6 weeks.",
+      "byte_quote": "All patients with endocarditis were assigned to receive initially cloxacillin or dicloxacillin (2 g q4 h) for 4 to 6 weeks intravenously"
+    },
+    {
+      "id": "c10",
+      "text": "Contraindication/alternative regimen: if semisynthetic penicillins are contraindicated, give cefuroxime 1.5 g every 6 h or vancomycin 1 g twice daily.",
+      "byte_quote": "Alternatively, cefuroxime (1.5 g q6 h) or vancomycin (1 g bid) were allowed if a contraindication against the use of semisynthetic penicillins was noted"
+    },
+    {
+      "id": "c11",
+      "text": "Adjunctive aminoglycoside dosing: tobramycin or netilmicin 1 mg/kg every 8 h added for the first 7 days.",
+      "byte_quote": "Aminoglycoside (either tobramycin or netilmicin at 1 mg/kg of body weight q8h) was added to the drug therapy described above for the first 7 days"
+    },
+    {
+      "id": "c12",
+      "text": "Adjunctive rifampicin dosing: 450 mg once daily if under 50 kg, 600 mg once daily if over 50 kg, oral or IV, for at least 4 weeks when endocarditis or extracardiac deep infection is suspected/confirmed (weight-banded dosing).",
+      "byte_quote": "Rifampicin (450 mg once daily for patients under 50 kg and 600 mg once daily for patients over 50 kg in weight, orally or intravenously) was recommended for at least 4 weeks"
+    },
+    {
+      "id": "c13",
+      "text": "In the actual cohort, 88% (65 of 74 patients) were treated with cloxacillin or dicloxacillin.",
+      "byte_quote": "Sixty-five of 74 patients (88%) were treated with cloxacillin or dicloxacillin"
+    }
+  ],
+  "cites": []
+}

--- a/code/specs/data/mycin-2026/cas/sources/2f0c1bfb012a2a37.json
+++ b/code/specs/data/mycin-2026/cas/sources/2f0c1bfb012a2a37.json
@@ -1,0 +1,74 @@
+{
+  "hash": "2f0c1bfb012a2a37",
+  "source_id": "https://academic.oup.com/cid/article/52/5/e103/388285",
+  "title": "International Clinical Practice Guidelines for the Treatment of Acute Uncomplicated Cystitis and Pyelonephritis in Women: A 2010 Update by the Infectious Diseases Society of America and the European Society for Microbiology and Infectious Diseases",
+  "resolved_url": "https://academic.oup.com/cid/article/52/5/e103/388285",
+  "claims": [
+    {
+      "id": "c1",
+      "text": "UTI (uncomplicated cystitis and pyelonephritis) organism epidemiology: E. coli accounts for 75%-95%, with occasional other Enterobacteriaceae (Proteus mirabilis, Klebsiella pneumoniae) and Staphylococcus saprophyticus.",
+      "byte_quote": "The microbial spectrum of uncomplicated cystitis and pyelonephritis consists mainly of Escherichia coli (75%–95%)"
+    },
+    {
+      "id": "c2",
+      "text": "Host/population scope: the diagnoses are limited to premenopausal, nonpregnant women with no known urological abnormalities or comorbidities (defines the host band; excludes pregnancy and structural/comorbid complications).",
+      "byte_quote": "diagnoses limited in these guidelines to premenopausal, nonpregnant women with no known urological abnormalities or comorbidities"
+    },
+    {
+      "id": "c3",
+      "text": "Risk factor for TMP-SMX resistance: use of trimethoprim-sulfamethoxazole in the preceding 3-6 months independently raises the risk of TMP-SMX-resistant organisms.",
+      "byte_quote": "the use of trimethoprim-sulfamethoxazole in the preceding 3–6 months was an independent risk factor for trimethoprim-sulfamethoxazole resistance"
+    },
+    {
+      "id": "c4",
+      "text": "Resistance threshold: 20% local resistance prevalence is the cutoff above which an agent is no longer recommended for empirical treatment of acute cystitis (expert-opinion based).",
+      "byte_quote": "The threshold of 20% as the resistance prevalence at which the agent is no longer recommended for empirical treatment of acute cystitis is based on expert opinion"
+    },
+    {
+      "id": "c5",
+      "text": "Fluoroquinolone stewardship/contraindication-by-collateral-damage: fluoroquinolones have a propensity for collateral damage and should be reserved for uses other than acute cystitis.",
+      "byte_quote": "fluoroquinolones...have a propensity for collateral damage and should be reserved for important uses other than acute cystitis"
+    },
+    {
+      "id": "c6",
+      "text": "Antibiotic dosing (cystitis): nitrofurantoin monohydrate/macrocrystals 100 mg twice daily for 5 days.",
+      "byte_quote": "Nitrofurantoin monohydrate/macrocrystals (100 mg twice daily for 5 days)"
+    },
+    {
+      "id": "c7",
+      "text": "Antibiotic dosing (cystitis): trimethoprim-sulfamethoxazole 160/800 mg (1 double-strength tablet) twice daily for 3 days.",
+      "byte_quote": "Trimethoprim-sulfamethoxazole (160/800 mg [1 double-strength tablet] twice-daily for 3 days)"
+    },
+    {
+      "id": "c8",
+      "text": "Antibiotic dosing (cystitis): fosfomycin trometamol 3 g as a single dose.",
+      "byte_quote": "Fosfomycin trometamol (3 g in a single dose)"
+    },
+    {
+      "id": "c9",
+      "text": "Antibiotic dosing (cystitis): pivmecillinam 400 mg twice daily for 3-7 days.",
+      "byte_quote": "Pivmecillinam (400 mg bid for 3–7 days)"
+    },
+    {
+      "id": "c10",
+      "text": "Antibiotic dosing (pyelonephritis): oral ciprofloxacin 500 mg twice daily for 7 days.",
+      "byte_quote": "Oral ciprofloxacin (500 mg twice daily) for 7 days"
+    },
+    {
+      "id": "c11",
+      "text": "Antibiotic dosing (pyelonephritis): oral trimethoprim-sulfamethoxazole 160/800 mg (1 double-strength tablet) twice daily for 14 days (longer interval than cystitis indication).",
+      "byte_quote": "Oral trimethoprim-sulfamethoxazole (160/800 mg [1 double-strength tablet] twice-daily for 14 days)"
+    },
+    {
+      "id": "c12",
+      "text": "Antibiotic dosing (pyelonephritis): levofloxacin 750 mg for 5 days.",
+      "byte_quote": "Levofloxacin (750 mg for 5 days)"
+    }
+  ],
+  "cites": [
+    "IDSA/ESCMID UTI guideline ref [8-11] (four large studies on E. coli antimicrobial susceptibility patterns)",
+    "IDSA/ESCMID UTI guideline ref [20-21] (basis for 20% TMP-SMX resistance empirical-treatment threshold)",
+    "IDSA/ESCMID UTI guideline ref [22-23] (collateral damage associated with cephalosporins and fluoroquinolones)",
+    "IDSA/ESCMID UTI guideline ref [28-29] (placebo-arm spontaneous cure rates 25%-42% in cystitis)"
+  ]
+}

--- a/code/specs/data/mycin-2026/cas/sources/38fddb4e21c26afd.json
+++ b/code/specs/data/mycin-2026/cas/sources/38fddb4e21c26afd.json
@@ -1,0 +1,62 @@
+{
+  "hash": "38fddb4e21c26afd",
+  "source_id": "https://pmc.ncbi.nlm.nih.gov/articles/PMC12902366/",
+  "title": "Clinical and Microbiological Characteristics of Bacteroides fragilis and Non-B. fragilis Bacteremia",
+  "resolved_url": "https://pmc.ncbi.nlm.nih.gov/articles/PMC12902366/",
+  "claims": [
+    {
+      "id": "c1",
+      "text": "Bacteroides species are anaerobic gram-negative bacteria and part of the intestinal flora.",
+      "byte_quote": "_Bacteroides_ species are anaerobic gram-negative bacteria that constitute a significant portion of the intestinal flora."
+    },
+    {
+      "id": "c2",
+      "text": "Mortality of Bacteroides bacteremia ranges from about 16% to 50%.",
+      "byte_quote": "Specifically, the mortality rate of _Bacteroides_-caused bacteremia ranges from ∼16% to 50% [[1](#ofag047-B1), [2](#ofag047-B2)]."
+    },
+    {
+      "id": "c3",
+      "text": "Of 528 anaerobic-bacteremia patients (Jan 2012-Mar 2022), 174 had Bacteroides spp. bacteremia: 102 B. fragilis and 72 non-B. fragilis.",
+      "byte_quote": "Among the 528 patients diagnosed with anaerobic bacteremia between 1 January 2012 and 31 March 2022, 174 had _Bacteroides_ spp. bacteremia, with 102 and 72 cases caused by _B. fragilis_ and non_\\-B. fragilis_ species, respectively"
+    },
+    {
+      "id": "c4",
+      "text": "30-day mortality (excluding underlying-disease exacerbation) was significantly higher in the non-B. fragilis group (16.7%) than the B. fragilis group (5.9%), P=.025.",
+      "byte_quote": "However, 30-day mortality—excluding exacerbation of the underlying disease—was significantly higher in the non_\\-B. fragilis_ group (16.7%) than in the _B. fragilis_ group (5.9%, _P_ = .025"
+    },
+    {
+      "id": "c5",
+      "text": "Carbapenem resistance was associated with 30-day mortality in non-B. fragilis (adjusted OR=7.05, 95% CI 1.54-41.9, P=.017).",
+      "byte_quote": "carbapenem resistance (adjusted OR = 7.05, 95% CI 1.54–41.9, _P_ = .017)"
+    },
+    {
+      "id": "c6",
+      "text": "Bacteremia originating from the gastrointestinal tract was 29.4% in B. fragilis vs 54.1% in non-B. fragilis (P=.002) — GI/digestive portal predicts non-B. fragilis.",
+      "byte_quote": "The percentage of bacteremia originating from the gastrointestinal tract was 29.4% and 54.1% in _B. fragilis_ and non_\\-B. fragilis_ groups (_P_ = .002)"
+    },
+    {
+      "id": "c7",
+      "text": "Clindamycin-resistant B. fragilis ranges from ~20-40% in North America/Europe to ~50% in some Asian countries.",
+      "byte_quote": "the percentage of clindamycin (CLDM)-resistant _B. fragilis_ ranges from ∼20% to 40% in North America and Europe to ∼50% in some Asian countries"
+    },
+    {
+      "id": "c8",
+      "text": "Antimicrobial susceptibility was analyzed for meropenem (MEPM), clindamycin (CLDM), and TAZ/PIPC against Bacteroides spp.",
+      "byte_quote": "we limited the antimicrobial susceptibility analysis to meropenem (MEPM), CLDM, and TAZ/PIPC against _Bacteroides_ spp."
+    },
+    {
+      "id": "c9",
+      "text": "Demographic/clinical risk factors (age, sex, malignancy, diabetes, systemic steroids/immunosuppressants, febrile neutropenia, mCCS) were similar between the two groups.",
+      "byte_quote": "Demographic and clinical factors, such as age, sex, presence of malignancy, diabetes mellitus, administration of systemic steroids or immunosuppressive agents, febrile neutropenia, and mCCS, were similar"
+    },
+    {
+      "id": "c10",
+      "text": "A landmark matched-pair study reported an overall 30-day case fatality rate of 28% for B. fragilis group bacteremia.",
+      "byte_quote": "A landmark matched-pair study reported an overall 30-day case fatality rate of 28% for _B. fragilis_ group bacteremia"
+    }
+  ],
+  "cites": [
+    "Redondo et al. 1995 (matched-pair study, B. fragilis group bacteremia 30-day case fatality ~28%)",
+    "Cheng et al. 2009 (B. fragilis bacteremia 30-day mortality 30.7%)"
+  ]
+}

--- a/code/specs/data/mycin-2026/cas/sources/3bc1d8571af85cc8.json
+++ b/code/specs/data/mycin-2026/cas/sources/3bc1d8571af85cc8.json
@@ -1,0 +1,89 @@
+{
+  "hash": "3bc1d8571af85cc8",
+  "source_id": "https://dailymed.nlm.nih.gov/dailymed/drugInfo.cfm?setid=3c442cca-47f5-48e5-b718-c09413911687",
+  "title": "Moxifloxacin Hydrochloride — DailyMed FDA Prescribing Label",
+  "resolved_url": "https://dailymed.nlm.nih.gov/dailymed/drugInfo.cfm?setid=3c442cca-47f5-48e5-b718-c09413911687",
+  "claims": [
+    {
+      "id": "c1",
+      "text": "Community-acquired pneumonia treated by moxifloxacin is caused by S. pneumoniae (including MDRSP), H. influenzae, M. catarrhalis, MSSA, K. pneumoniae, M. pneumoniae, or C. pneumoniae.",
+      "byte_quote": "Community Acquired Pneumonia caused by susceptible isolates of Streptococcus pneumoniae (including multi-drug resistant Streptococcus pneumoniae [MDRSP]), Haemophilus influenzae, Moraxella catarrhalis, methicillin-susceptible Staphylococcus aureus, Klebsiella pneumoniae, Mycoplasma pneumoniae, or Chlamydophila pneumoniae"
+    },
+    {
+      "id": "c2",
+      "text": "Complicated intra-abdominal infections (e.g. abscess) are polymicrobial, caused by E. coli, B. fragilis, S. anginosus, S. constellatus, E. faecalis, P. mirabilis, C. perfringens, B. thetaiotaomicron, or Peptostreptococcus.",
+      "byte_quote": "Complicated Intra-Abdominal Infections (cIAI) including polymicrobial infections such as abscess caused by susceptible isolates of Escherichia coli, Bacteroides fragilis, Streptococcus anginosus, Streptococcus constellatus, Enterococcus faecalis, Proteus mirabilis, Clostridium perfringens, Bacteroides thetaiotaomicron, or Peptostreptococcus species"
+    },
+    {
+      "id": "c3",
+      "text": "Plague (including pneumonic and septicemic plague) is due to Yersinia pestis; moxifloxacin is indicated for treatment and prophylaxis in adults.",
+      "byte_quote": "plague, including pneumonic and septicemic plague, due to susceptible isolates of Yersinia pestis and prophylaxis of plague in adult patients"
+    },
+    {
+      "id": "c4",
+      "text": "Uncomplicated skin/skin-structure infections are caused by MSSA or Streptococcus pyogenes.",
+      "byte_quote": "caused by susceptible isolates of methicillin-susceptible Staphylococcus aureus or Streptococcus pyogenes"
+    },
+    {
+      "id": "c5",
+      "text": "Complicated skin/skin-structure infections are caused by MSSA, E. coli, K. pneumoniae, or Enterobacter cloacae.",
+      "byte_quote": "caused by susceptible isolates of methicillin-susceptible Staphylococcus aureus, Escherichia coli, Klebsiella pneumoniae, or Enterobacter cloacae"
+    },
+    {
+      "id": "c6",
+      "text": "Acute bacterial sinusitis is caused by S. pneumoniae, H. influenzae, or M. catarrhalis.",
+      "byte_quote": "caused by susceptible isolates of Streptococcus pneumoniae, Haemophilus influenzae, or Moraxella catarrhalis"
+    },
+    {
+      "id": "c7",
+      "text": "Acute bacterial exacerbation of chronic bronchitis is caused by S. pneumoniae, H. influenzae, H. parainfluenzae, K. pneumoniae, MSSA, or M. catarrhalis.",
+      "byte_quote": "caused by susceptible isolates of Streptococcus pneumoniae, Haemophilus influenzae, Haemophilus parainfluenzae, Klebsiella pneumoniae, methicillin-susceptible Staphylococcus aureus, or Moraxella catarrhalis"
+    },
+    {
+      "id": "c8",
+      "text": "Standard adult dose of moxifloxacin is 400 mg orally or IV once every 24 hours.",
+      "byte_quote": "The dose of moxifloxacin hydrochloride is 400 mg (orally or as an intravenous infusion) once every 24 hours."
+    },
+    {
+      "id": "c9",
+      "text": "Moxifloxacin is contraindicated in persons with a history of hypersensitivity to moxifloxacin or any quinolone-class antibacterial.",
+      "byte_quote": "Moxifloxacin hydrochloride is contraindicated in persons with a history of hypersensitivity to moxifloxacin or any member of the quinolone class of antibacterials"
+    },
+    {
+      "id": "c10",
+      "text": "Effectiveness in pediatric patients and adolescents under 18 years has not been established.",
+      "byte_quote": "Effectiveness in pediatric patients and adolescents less than 18 years of age has not been established."
+    },
+    {
+      "id": "c11",
+      "text": "Geriatric patients are at increased risk of severe tendon disorders including tendon rupture on fluoroquinolones such as moxifloxacin.",
+      "byte_quote": "Geriatric patients are at increased risk for developing severe tendon disorders including tendon rupture when being treated with a fluoroquinolone such as moxifloxacin hydrochloride."
+    },
+    {
+      "id": "c12",
+      "text": "Moxifloxacin has been shown to prolong the QT interval of the electrocardiogram in some patients.",
+      "byte_quote": "Moxifloxacin hydrochloride has been shown to prolong the QT interval of the electrocardiogram in some patients."
+    },
+    {
+      "id": "c13",
+      "text": "QT-related risk factors to avoid include known QT prolongation, ventricular arrhythmias/torsade de pointes, and uncorrected hypokalemia or hypomagnesemia.",
+      "byte_quote": "Known prolongation of the QT interval; Ventricular arrhythmias including torsade de pointes because QT prolongation may lead to an increased risk for these conditions; Uncorrected hypokalemia or hypomagnesemia"
+    },
+    {
+      "id": "c14",
+      "text": "Based on animal data, moxifloxacin may cause fetal harm (pregnancy).",
+      "byte_quote": "Based on animal data may cause fetal harm."
+    },
+    {
+      "id": "c15",
+      "text": "Moxifloxacin tablets must be given at least 4 hours before or 8 hours after products containing magnesium, aluminum, iron, or zinc (antacids, sucralfate, multivitamins, didanosine buffered tablets).",
+      "byte_quote": "Administer moxifloxacin hydrochloride tablets at least 4 hours before or 8 hours after products containing magnesium, aluminum, iron or zinc, including antacids, sucralfate, multivitamins and didanosine buffered tablets"
+    },
+    {
+      "id": "c16",
+      "text": "Fluoroquinolones including moxifloxacin can enhance the anticoagulant effects of warfarin or its derivatives.",
+      "byte_quote": "fluoroquinolones, including moxifloxacin hydrochloride, have been reported to enhance the anticoagulant effects of warfarin or its derivatives in the patient population"
+    }
+  ],
+  "cites": []
+}

--- a/code/specs/data/mycin-2026/cas/sources/4b82b0b1ad4abad1.json
+++ b/code/specs/data/mycin-2026/cas/sources/4b82b0b1ad4abad1.json
@@ -1,0 +1,139 @@
+{
+  "hash": "4b82b0b1ad4abad1",
+  "source_id": "https://pmc.ncbi.nlm.nih.gov/articles/PMC4451395/",
+  "title": "Staphylococcus aureus Infections: Epidemiology, Pathophysiology, Clinical Manifestations, and Management",
+  "resolved_url": "https://pmc.ncbi.nlm.nih.gov/articles/PMC4451395/",
+  "claims": [
+    {
+      "id": "c1",
+      "text": "In the industrialized world, Staphylococcus aureus bacteremia (SAB) incidence is 10 to 30 per 100,000 person-years.",
+      "byte_quote": "In the industrialized world, the population incidence of SAB ranges from 10 to 30 per 100,000 person-years"
+    },
+    {
+      "id": "c2",
+      "text": "MRSA bacteremia incidence in Quebec rose from 0 to 7.4 per 100,000 person-years between 1991 and 2005.",
+      "byte_quote": "in Quebec, Canada, the incidence of MRSA bacteremia increased from 0 per 100,000 person-years to 7.4 per 100,000 person-years from 1991to2005"
+    },
+    {
+      "id": "c3",
+      "text": "S. aureus is now the most common cause of infective endocarditis in the industrialized world.",
+      "byte_quote": "_S. aureus_ is now the most common cause of IE in the industrialized world"
+    },
+    {
+      "id": "c4",
+      "text": "The proportion of IE cases due to S. aureus rose from 24% to 32% between 1998 and 2009.",
+      "byte_quote": "the incidence of IE increased from 9.3 per 100,000 person-years in 1998 to 12.7 per 100,000 person-years in 2009. The proportion of IE cases coded as being due to _S. aureus_ increased from 24% to 32% between 1998 and 2009"
+    },
+    {
+      "id": "c5",
+      "text": "Age is a powerful determinant of SAB incidence, with highest rates at the extremes of life.",
+      "byte_quote": "Age is a powerful determinant of SAB incidence, with the highest rates of infection occurring at either extreme of life"
+    },
+    {
+      "id": "c6",
+      "text": "SAB incidence exceeds 100 per 100,000 person-years in those over 70 years of age.",
+      "byte_quote": "the incidence of SAB is >100 per 100,000 person-years among subjects >70 years of age"
+    },
+    {
+      "id": "c7",
+      "text": "Male gender is associated with increased SAB incidence (male-to-female ratio ~1.5).",
+      "byte_quote": "Male gender is consistently associated with increased SAB incidence...with male-to-female ratios of ∼1.5"
+    },
+    {
+      "id": "c8",
+      "text": "Invasive MRSA incidence in the US black population (66.5/100,000) is over twice that of the white population (27.7/100,000).",
+      "byte_quote": "In the United States, the incidence of invasive MRSA in the black population (66.5 per 100,000 person-years) is over twice that in the white population (27.7 per 100,000 person-years)"
+    },
+    {
+      "id": "c9",
+      "text": "SAB incidence in HIV-infected patients (494/100,000) is 24 times that of the non-HIV population.",
+      "byte_quote": "incidences of SAB in HIV-infected patients of 494 per 100,000 person-years...or 24 times that of the non-HIV-infected population"
+    },
+    {
+      "id": "c10",
+      "text": "Among HIV-infected individuals, low CD4 count is independently associated with SAB.",
+      "byte_quote": "Among HIV-infected individuals, a low CD4 count was independently associated with SAB"
+    },
+    {
+      "id": "c11",
+      "text": "Among injection drug users, SAB incidence is at least 610 per 100,000 person-years.",
+      "byte_quote": "the incidence of SAB was at least 610 per 100,000 person-years"
+    },
+    {
+      "id": "c12",
+      "text": "SAB incidence in hemodialysis-dependent patients ranges from ~3,000 to nearly 18,000 per 100,000 person-years across countries.",
+      "byte_quote": "The incidences of SAB in hemodialysis-dependent patients were 3,064 per 100,000 person-years in Taiwan, 17,900 per 100,000 person-years in Ireland, and 4,045 to 5,015 per 100,000 person-years in the United States"
+    },
+    {
+      "id": "c13",
+      "text": "The predominant risk factor for SAB in hemodialysis patients is the presence of an intravascular access device.",
+      "byte_quote": "The predominant risk factor for these patients is the presence of an intravascular access device"
+    },
+    {
+      "id": "c14",
+      "text": "In patients with a prosthetic cardiac valve who develop SAB, the risk of IE is ~51%.",
+      "byte_quote": "in one prospective cohort study of patients with a prosthetic cardiac valve who developed SAB, the risk of IE was ∼51%"
+    },
+    {
+      "id": "c15",
+      "text": "Recommended IV antibiotic duration for uncomplicated SAB is at least 2 weeks.",
+      "byte_quote": "The recommended duration of intravenous (i.v.) antibiotics for uncomplicated SAB is at least 2 weeks"
+    },
+    {
+      "id": "c16",
+      "text": "Daptomycin at 6 mg/kg IV once daily was noninferior to vancomycin for MRSA bacteremia.",
+      "byte_quote": "daptomycin at 6 mg/kg of body weight i.v. once daily was noninferior to vancomycin"
+    },
+    {
+      "id": "c17",
+      "text": "Higher daptomycin doses of 8 to 10 mg/kg are increasingly used and appear safe.",
+      "byte_quote": "higher doses (8 to 10 mg/kg) are increasingly being used and appear to be safe"
+    },
+    {
+      "id": "c18",
+      "text": "For complicated SAB, 4 to 6 weeks of IV therapy has been the standard practice.",
+      "byte_quote": "For complicated SAB, 4 to 6 weeks of i.v. therapy has been the standard practice"
+    },
+    {
+      "id": "c19",
+      "text": "Patients treated with vancomycin for right-sided IE should receive more than 2 weeks of therapy.",
+      "byte_quote": "patients being treated with vancomycin for right-sided IE should receive >2 weeks of therapy"
+    },
+    {
+      "id": "c20",
+      "text": "Tigecycline carries an FDA black box warning for increased risk of death versus other antibacterials.",
+      "byte_quote": "tigecycline has subsequently received an FDA black box warning for an increased risk of death compared to other antibacterial drugs"
+    },
+    {
+      "id": "c21",
+      "text": "Daptomycin nonsusceptibility developed in 5 of 45 MRSA bacteremia patients.",
+      "byte_quote": "Nonsusceptibility to daptomycin developed in 5 of 45 patients with MRSA bacteremia"
+    },
+    {
+      "id": "c22",
+      "text": "Common primary sources of SAB are vascular catheter-related infections, SSTIs, pleuropulmonary, osteoarticular infections, and IE.",
+      "byte_quote": "common primary clinical foci or sources of infection are vascular catheter-related infections, SSTIs, pleuropulmonary infections, osteoarticular infections, and IE"
+    },
+    {
+      "id": "c23",
+      "text": "No focus of infection is found in about 25% of SAB cases.",
+      "byte_quote": "a focus of infection is not found in ∼25% of cases"
+    },
+    {
+      "id": "c24",
+      "text": "Mortality varies by source: higher for bacteremia without a focus (22-48%), IE (25-60%), pulmonary (39-67%); lower for catheter-related (7-21%), SSTIs (15-17%), and UTIs (10%).",
+      "byte_quote": "higher mortality rates for bacteremia without a focus (22 to 48%), IE (25 to 60%), and pulmonary infections (39 to 67%), compared to lower rates for catheter-related bacteremia (7 to 21%), SSTIs (15 to 17%), and urinary tract infections (UTIs) (10%)"
+    },
+    {
+      "id": "c25",
+      "text": "Right-sided IE is usually secondary to injection drug use or the presence of a central catheter.",
+      "byte_quote": "Right-sided disease is usually secondary to either injection drug use or the presence of a central catheter"
+    }
+  ],
+  "cites": [
+    "Thwaites et al. (reference 77)",
+    "Benito et al. (reference 133)",
+    "Fang et al. (reference 154)",
+    "Grover et al. (reference 147)"
+  ]
+}

--- a/code/specs/data/mycin-2026/cas/sources/5fe22e06d0ac823f.json
+++ b/code/specs/data/mycin-2026/cas/sources/5fe22e06d0ac823f.json
@@ -1,0 +1,74 @@
+{
+  "hash": "5fe22e06d0ac823f",
+  "source_id": "https://pmc.ncbi.nlm.nih.gov/articles/PMC10350481/",
+  "title": "Epidemiology of Gram-Negative Bloodstream Infections in the United States: Results From a Cohort of 24 Hospitals",
+  "resolved_url": "https://pmc.ncbi.nlm.nih.gov/articles/PMC10350481/",
+  "claims": [
+    {
+      "id": "c1",
+      "text": "E. coli is the most common Gram-negative organism in bloodstream infections, accounting for 51.0% of isolates.",
+      "byte_quote": "Escherichia coli (2471, 51.0%) was the most common Gram-negative organism recovered"
+    },
+    {
+      "id": "c2",
+      "text": "Klebsiella pneumoniae is the second most common Gram-negative bloodstream isolate at 17.3%.",
+      "byte_quote": "followed by K pneumoniae (n = 841, 17.3%)"
+    },
+    {
+      "id": "c3",
+      "text": "Pseudomonas aeruginosa is the third most common Gram-negative bloodstream isolate at 8.7%.",
+      "byte_quote": "Pseudomonas aeruginosa (n = 423, 8.7%)"
+    },
+    {
+      "id": "c4",
+      "text": "ESBL production occurred in 15.7% of eligible isolates.",
+      "byte_quote": "575 (15.7%) isolates...met criteria for ESBL production"
+    },
+    {
+      "id": "c5",
+      "text": "Western sites had the highest percentage of ESBL producers among eligible isolates (16%).",
+      "byte_quote": "Western sites had the highest percentage of ESBL producers of total eligible isolates (16%)"
+    },
+    {
+      "id": "c6",
+      "text": "The median patient age in the Gram-negative bacteremia cohort was 67 years (IQR 55-77).",
+      "byte_quote": "The median age was 67 years (IQR, 55–77)"
+    },
+    {
+      "id": "c7",
+      "text": "Patients aged 70 years or older comprised 42.73% of the cohort.",
+      "byte_quote": "≥70 [years] 2077 (42.73%)"
+    },
+    {
+      "id": "c8",
+      "text": "Moderate to severe immunocompromise was present in 34.52% of patients.",
+      "byte_quote": "Moderate to severe immunocompromise[a] 1678 (34.52%)"
+    },
+    {
+      "id": "c9",
+      "text": "32.34% of bacteremia patients were in the intensive care unit.",
+      "byte_quote": "Patients in intensive care unit 1572 (32.34%)"
+    },
+    {
+      "id": "c10",
+      "text": "ESBL-producing organisms were significantly more frequent in White than non-White patients (14.6% vs 9.5%, P<0.01).",
+      "byte_quote": "there was a statistically significant difference in the percentage of ESBL-producing organisms in White vs non-White patients (14.6 % and 9.5 %, respectively, P<0.01)"
+    },
+    {
+      "id": "c11",
+      "text": "The urinary tract was the most common source of Gram-negative bacteremia (47.9%).",
+      "byte_quote": "Most common source of infection was the urinary tract (47.9%)"
+    },
+    {
+      "id": "c12",
+      "text": "Common sources of Gram-negative bacteremia were urinary tract (47.9%), intra-abdominal (14.5%), and hepatobiliary (11.4%).",
+      "byte_quote": "Common sources of infection included urinary tract (47.9%), intra-abdominal (14.5%), and hepatobiliary (11.4%)"
+    },
+    {
+      "id": "c13",
+      "text": "Respiratory tract sources accounted for 5.60% of Gram-negative bacteremias.",
+      "byte_quote": "Respiratory [source] 272 (5.60%)"
+    }
+  ],
+  "cites": []
+}

--- a/code/specs/data/mycin-2026/cas/sources/684cb26a970c6858.json
+++ b/code/specs/data/mycin-2026/cas/sources/684cb26a970c6858.json
@@ -1,0 +1,59 @@
+{
+  "hash": "684cb26a970c6858",
+  "source_id": "https://pmc.ncbi.nlm.nih.gov/articles/PMC8785473/",
+  "title": "Blood bacterial resistant investigation collaborative system (BRICS) report: a national surveillance in China from 2014 to 2019",
+  "resolved_url": "https://pmc.ncbi.nlm.nih.gov/articles/PMC8785473/",
+  "claims": [
+    {
+      "id": "c1",
+      "text": "In Chinese bloodstream infections (2014-2019), Gram-negative organisms predominate at 70.5% (19,655 isolates) vs Gram-positive at 29.5% (8,244 isolates).",
+      "byte_quote": "Gram-positive organisms accounted for 29.5% (8244) of the species identified and Gram-negative organisms accounted for 70.5% (19,655)."
+    },
+    {
+      "id": "c2",
+      "text": "The most common bloodstream-infection organisms, in rank order, are E. coli, K. pneumoniae, S. aureus, coagulase-negative Staphylococci, and A. baumannii.",
+      "byte_quote": "The most-commonly isolated organisms in blood cultures were _Escherichia coli_, _Klebsiella pneumoniae_, _Staphylococcus aureus_, coagulase-negative _Staphylococci_, and _Acinetobacter baumannii_."
+    },
+    {
+      "id": "c3",
+      "text": "E. coli's share of bloodstream isolates rose from 29.1% to 38.5% across the study period.",
+      "byte_quote": "Notably, _E. coli_ increased 29.1% to 38.5% during the study period."
+    },
+    {
+      "id": "c4",
+      "text": "Methicillin-resistant S. aureus (MRSA) prevalence fell from 39.0% (73/187) in 2014 to 25.9% (230/889) in 2019.",
+      "byte_quote": "The prevalence of methicillin-resistant _S. aureus_ declined from 39.0% (73/187) in 2014 to 25.9% (230/889) in 2019 (_p_ < 0.05)."
+    },
+    {
+      "id": "c5",
+      "text": "ESBL-producing E. coli prevalence dropped from 61.2% (412/673) to 51.0% (1878/3,683) over the study period.",
+      "byte_quote": "The prevalence of ESBL-_E. coli_ dropped from 61.2% (412/673) to 51.0% (1878/3,683) over time (_p_ < 0.05)."
+    },
+    {
+      "id": "c6",
+      "text": "Carbapenem-resistant K. pneumoniae rose sharply from 7.0% (16/229) in 2014 to 19.6% (325/1,655) in 2019.",
+      "byte_quote": "carbapenem-resistant _K. pneumoniae_ increased markedly from 7.0% (16/229) in 2014 to 19.6% (325/1,655) in 2019 (_p_ < 0.05)."
+    },
+    {
+      "id": "c7",
+      "text": "Estimated bloodstream-infection (BSI) incidence is 113 to 204 per 100,000 population (attributed to reference 5).",
+      "byte_quote": "It was estimated that the BSI incidence ranged between 113 and 204 per 100,000 in the population [[5](#CR5)]."
+    },
+    {
+      "id": "c8",
+      "text": "Recommended blood culture sampling frequency is 100 to 200 blood culture sets per 1,000 patient days (attributed to reference 15).",
+      "byte_quote": "The frequency of blood cultures is recommended for 100 to 200 blood cultures sets per 1,000 patient days [[15](#CR15)]."
+    },
+    {
+      "id": "c9",
+      "text": "The surveillance collected 27,899 isolates total over the 6-year period.",
+      "byte_quote": "Over the 6-year period, 27,899 isolates were collected in total."
+    }
+  ],
+  "cites": [
+    "Reference [5] (cited for BSI incidence of 113-204 per 100,000 population)",
+    "Reference [15] (cited for blood culture frequency of 100-200 sets per 1,000 patient days)",
+    "Reference [16] — 2018 annual report of the European Antimicrobial Resistance Surveillance Network (EARS-Net)",
+    "Reference [1] — WHO recommendations"
+  ]
+}

--- a/code/specs/data/mycin-2026/cas/sources/685ed626927622ae.json
+++ b/code/specs/data/mycin-2026/cas/sources/685ed626927622ae.json
@@ -1,0 +1,39 @@
+{
+  "hash": "685ed626927622ae",
+  "source_id": "https://pmc.ncbi.nlm.nih.gov/articles/PMC5880328/",
+  "title": "Pathogenesis of Proteus mirabilis Infection",
+  "resolved_url": "https://pmc.ncbi.nlm.nih.gov/articles/PMC5880328/",
+  "claims": [
+    {
+      "id": "c1",
+      "text": "Proteus mirabilis is a Gram-negative rod-shaped bacterium notable for urease production and differentiation into elongated swarm cells with a bull's-eye motility pattern on agar.",
+      "byte_quote": "Proteus mirabilis, a Gram-negative rod-shaped bacterium, is well-known for its urease production and distinctive ability to differentiate into elongated swarm cells and characteristic bull's-eye pattern of motility on agar plates."
+    },
+    {
+      "id": "c2",
+      "text": "P. mirabilis is among the most common organisms in polymicrobial urine colonization and infection.",
+      "byte_quote": "P. mirabilis is one of the most common organisms present during polymicrobial urine colonization and infection"
+    },
+    {
+      "id": "c3",
+      "text": "P. mirabilis infections are common in long-term catheterized patients (nursing homes, chronic care facilities) and are especially dangerous to spinal cord injury patients — catheterization/long-term care is the dominant risk factor.",
+      "byte_quote": "These infections are common in long-term catheterized patients, such as those who reside in nursing homes and chronic care facilities, and may be of particular danger to spinal cord injury patients"
+    },
+    {
+      "id": "c4",
+      "text": "Bloodstream infection (bacteremia) with P. mirabilis most frequently arises from a UTI/CAUTI portal of entry rather than other sources — urinary source predicts the organism in bacteremia.",
+      "byte_quote": "bacteremia involving P. mirabilis most frequently occurs following UTI or CAUTI compared to other sources of infection"
+    },
+    {
+      "id": "c5",
+      "text": "P. mirabilis urease hydrolyzes urinary urea (present at ~400 mM) to CO2 and NH3, driving precipitation of struvite (MgNH4PO4·6H2O) and carbonate apatite stones.",
+      "byte_quote": "Urea, our means of eliminating excess nitrogen, is present in high concentrations in urine (∼400 mM), is the substrate of urease, and is hydrolyzed to CO2 and NH3"
+    },
+    {
+      "id": "c6",
+      "text": "About 50% of individuals with long-term catheterization (>28 days) experience catheter blockage from crystalline (struvite/apatite) deposits.",
+      "byte_quote": "Approximately 50% of individuals with long-term catheterization (>28 days) experience catheter blockage from crystalline deposits"
+    }
+  ],
+  "cites": []
+}

--- a/code/specs/data/mycin-2026/cas/sources/83a052af6bc47106.json
+++ b/code/specs/data/mycin-2026/cas/sources/83a052af6bc47106.json
@@ -1,0 +1,91 @@
+{
+  "hash": "83a052af6bc47106",
+  "source_id": "https://pmc.ncbi.nlm.nih.gov/articles/PMC5644167/",
+  "title": "Local epidemiology and resistance profiles in acute uncomplicated cystitis (AUC) in women: a prospective cohort study in an urban urological ambulatory setting (Seitz et al., BMC Infect Dis. 2017)",
+  "resolved_url": "https://pmc.ncbi.nlm.nih.gov/articles/PMC5644167/",
+  "claims": [
+    {
+      "id": "c1",
+      "text": "E. coli is by far the most common uropathogen in acute uncomplicated cystitis in women, found in more than 80% of positive urine cultures.",
+      "byte_quote": "Escherichia coli (E. coli) is still by far the most common uropathogen for acute uncomplicated cystitis (AUC) in women and is found in more than 80% of the positive urine cultures."
+    },
+    {
+      "id": "c2",
+      "text": "In this cohort the most common organism was E. coli at 86.3% (365/423), followed by Enterococcus faecalis 10.2% (43/423) and Klebsiella pneumoniae 3.5% (15/423).",
+      "byte_quote": "The most common bacteria was E. coli with 86.3% (365/423) followed by Enterococcus faecalis with 10.2% (43/423) and Klebsiella pneumoniae with 3.5% (15/423)."
+    },
+    {
+      "id": "c3",
+      "text": "Summary organism distribution: E. coli 86%, Enterococcus faecalis 10%, Klebsiella pneumoniae 4%.",
+      "byte_quote": "The most commonly detected bacteria was E. coli with 86%, followed by Enterococcus faecalis with 10% and Klebsiella pneumoniae with 4%."
+    },
+    {
+      "id": "c4",
+      "text": "E. coli was highly susceptible to fosfomycin-trometamol (99.2%), nitrofurantoin (98.1%) and cefpodoxime (92.9%).",
+      "byte_quote": "Susceptibility testing showed E. coli strains to be highly sensitive to the following oral antibiotics: fosfomycin-trometamol (99.2%), nitrofurantoin (98.1%) and cefpodoxime (92.9%)."
+    },
+    {
+      "id": "c5",
+      "text": "E. coli resistance: ciprofloxacin 15.1%, trimethoprim/sulfamethoxazole 25.2%, amoxicillin/clavulanic acid 25.2%.",
+      "byte_quote": "E. coli was resistant to ciprofloxacin in 15.1% of cases, to trimethoprim/sulfamethoxazole in 25.2% of cases and to amoxicillin/clavulanic acid in 25.2% of cases."
+    },
+    {
+      "id": "c6",
+      "text": "E. coli aminopenicillin resistance was alarming, between 25.2% and 39.7% (ampicillin, amoxicillin with sulbactam/clavulanic acid).",
+      "byte_quote": "Our data demonstrate alarming resistance rates for aminopenicillins (ampicillin, amoxicillin in combination with sulbactam and clavulanic acid, respectively) between 25.2 and 39.7%."
+    },
+    {
+      "id": "c7",
+      "text": "Fosfomycin, pivmecillinam and nitrofurantoin are first-line therapy with high evidence level (LE 1a, GR A).",
+      "byte_quote": "Fosfomycin, pivmecilliam and nitrofurantoin are considered to be first-line therapy with high levels of evidence (LE: 1a, GR: A)."
+    },
+    {
+      "id": "c8",
+      "text": "An antibiotic resistance rate below 20% suffices to classify an agent as first-line medication.",
+      "byte_quote": "Resistance rates of <20% already suffice to class an antibiotic as first-line medication."
+    },
+    {
+      "id": "c9",
+      "text": "Fosfomycin-trometamol and nitrofurantoin can be given as first-line therapy without susceptibility testing.",
+      "byte_quote": "On the basis of our data and international studies (ECO-SENS) it can currently be confirmed that fosfomycin-trometamol and nitrofurantoin can be given in our urological practice as first-line therapy without susceptibility testing."
+    },
+    {
+      "id": "c10",
+      "text": "TRS, CIP and AMC should only be used to treat AUC after a susceptibility test has been performed.",
+      "byte_quote": "AUC should therefore only be treated with TRS, CIP and AMC after a susceptibility test has been carried out."
+    },
+    {
+      "id": "c11",
+      "text": "Mean patient age was 32.7 years (range 18-65), with the age peak at 18-25 years (42%).",
+      "byte_quote": "The average age of the patients was 32.7 years (range 18–65). The age peak in the cohort was between ages 18 and 25 (42%)."
+    },
+    {
+      "id": "c12",
+      "text": "AUC was more common in pre-menopausal than post-menopausal women (86.9% vs 13.1%).",
+      "byte_quote": "Among pre-menopausal patients AUC was more common than among post-menopausal women (86.9% vs. 13.1%)."
+    },
+    {
+      "id": "c13",
+      "text": "Three main risk factors influencing AUC rate: recurrent UTIs (20.3%), preceding sexual intercourse (15.3%), and a new sex partner (12.9%).",
+      "byte_quote": "Three main factors that might influence the rate of AUC in our cohort were recurrent urinary tract infections (20.3%), preceding sexual intercourse (15.3%) and a new sex partner (12.9%)."
+    },
+    {
+      "id": "c14",
+      "text": "AUC was defined by at least one of: suprapubic pain, urge symptoms, dysuria, increased voiding frequency.",
+      "byte_quote": "Indicators of an AUC were defined in terms of at least one of the following symptoms: suprapubic pain, urge symptoms, dysuria and increased voiding frequency."
+    },
+    {
+      "id": "c15",
+      "text": "A urine culture was defined as positive at >=10e3 CFU/mL; mixed cultures were not analysed.",
+      "byte_quote": "A urine culture was defined as positive if ≥10e3CFU/mL. Mixed cultures were not analysed."
+    }
+  ],
+  "cites": [
+    "ECO-SENS I & II studies (refs 5,6)",
+    "2014 ECO-SENS Update (ref 6)",
+    "ARESC Study — Antimicrobial Resistance Epidemiological Survey on Cystitis (refs 8,9)",
+    "EAU Guidelines, European Association of Urology, March 2015 (ref 12)",
+    "IDSA Guidelines, Infectious Diseases Society of America (ref 14)",
+    "German National Guidelines DGU (ref 10)"
+  ]
+}

--- a/code/specs/data/mycin-2026/cas/sources/93a334a5c1776980.json
+++ b/code/specs/data/mycin-2026/cas/sources/93a334a5c1776980.json
@@ -1,0 +1,59 @@
+{
+  "hash": "93a334a5c1776980",
+  "source_id": "https://pubmed.ncbi.nlm.nih.gov/18691485/",
+  "title": "Clinical significance and predictors of community-onset Pseudomonas aeruginosa bacteremia (Cheong et al., Am J Med 2008;121(8):709-14)",
+  "resolved_url": "https://pubmed.ncbi.nlm.nih.gov/18691485/",
+  "claims": [
+    {
+      "id": "c1",
+      "text": "Study cohort comprised 106 patients with P. aeruginosa bacteremia and 508 patients with E. coli bacteremia (bloodstream-infection epidemiology in community-onset Gram-negative bacteremia).",
+      "byte_quote": "A total of 106 patients with P. aeruginosa bacteremia and a total 508 \npatients with E. coli bacteremia were included in this study."
+    },
+    {
+      "id": "c2",
+      "text": "Neutropenia is a risk factor that raises the likelihood the bloodstream organism is P. aeruginosa rather than E. coli.",
+      "byte_quote": "Factors associated \nwith P. aeruginosa bacteremia in the multivariate analysis included presentation \nwith neutropenia"
+    },
+    {
+      "id": "c3",
+      "text": "Presentation with septic shock raises the likelihood of P. aeruginosa bacteremia.",
+      "byte_quote": "presentation with septic shock"
+    },
+    {
+      "id": "c4",
+      "text": "An indwelling central venous catheter (device/portal of entry) raises the likelihood the bloodstream organism is P. aeruginosa.",
+      "byte_quote": "indwelling central venous \ncatheter"
+    },
+    {
+      "id": "c5",
+      "text": "Health-care-associated infection (exposure) raises the likelihood of P. aeruginosa bacteremia; all four predictors significant at P<.05.",
+      "byte_quote": "health-care-associated infection (all P <.05)"
+    },
+    {
+      "id": "c6",
+      "text": "30-day mortality was 26.4% with P. aeruginosa bacteremia versus 13.6% with E. coli bacteremia (P<.001).",
+      "byte_quote": "The 30-day \nmortality rate was 26.4% in patients with P. aeruginosa and 13.6% in those with \nE. coli bacteremia (P <.001)."
+    },
+    {
+      "id": "c7",
+      "text": "Inappropriate initial antimicrobial therapy is an independent risk factor for mortality (supports empirical coverage decisions).",
+      "byte_quote": "risk factors for mortality included a P. aeruginosa bacteremia, inappropriate initial \nantimicrobial therapy, a higher Charlson's weighted index of comorbidity, and a \nhigher Pitt bacteremia score (all P <.05)"
+    },
+    {
+      "id": "c8",
+      "text": "Urinary-tract infection as the source/portal was a protective factor for mortality in this Gram-negative bacteremia cohort.",
+      "byte_quote": "urinary tract infection \nand benign pancreatobiliary disease were found to be protective factors for \nmortality based on multivariate analysis (all P <.05)"
+    },
+    {
+      "id": "c9",
+      "text": "Empirical antimicrobial coverage of P. aeruginosa should be considered when Gram-negative sepsis is suspected in community-onset infection with neutropenia, septic shock, indwelling central venous catheter, or health-care-associated infection.",
+      "byte_quote": "initial empirical antimicrobial coverage of \nP. aeruginosa should be seriously considered in patients with neutropenia, \npresentation with septic shock, indwelling central venous catheter, or \nhealth-care-associated infection, when Gram-negative sepsis is suspected in \ncommunity-onset infection."
+    },
+    {
+      "id": "c10",
+      "text": "Determining the likelihood of P. aeruginosa bacteremia matters when Gram-negative sepsis is suspected in community-onset infection.",
+      "byte_quote": "It is important to determine the likelihood of P. aeruginosa \nbacteremia when Gram-negative sepsis is suspected in community-onset infection."
+    }
+  ],
+  "cites": []
+}

--- a/code/specs/data/mycin-2026/cas/sources/9cd83cfe323d44d1.json
+++ b/code/specs/data/mycin-2026/cas/sources/9cd83cfe323d44d1.json
@@ -1,0 +1,59 @@
+{
+  "hash": "9cd83cfe323d44d1",
+  "source_id": "https://pubmed.ncbi.nlm.nih.gov/15306996/",
+  "title": "Nosocomial bloodstream infections in US hospitals: analysis of 24,179 cases from a prospective nationwide surveillance study (Wisplinghoff et al., Clin Infect Dis 2004;39:309-17)",
+  "resolved_url": "https://pubmed.ncbi.nlm.nih.gov/15306996/",
+  "claims": [
+    {
+      "id": "c1",
+      "text": "Among nosocomial bloodstream infections, gram-positive organisms caused 65%, gram-negative organisms 25%, and fungi 9.5%.",
+      "byte_quote": "Gram-positive organisms caused 65% of these BSIs, gram-negative organisms caused 25%, and fungi caused 9.5%."
+    },
+    {
+      "id": "c2",
+      "text": "The most common organisms causing bloodstream infections were coagulase-negative staphylococci (31%), Staphylococcus aureus (20%), enterococci (9%), and Candida species (9%).",
+      "byte_quote": "The most-common organisms causing BSIs were coagulase-negative staphylococci (CoNS) (31% of isolates), Staphylococcus aureus (20%), enterococci (9%), and Candida species (9%)."
+    },
+    {
+      "id": "c3",
+      "text": "Eighty-seven percent of nosocomial bloodstream infections were monomicrobial.",
+      "byte_quote": "Eighty-seven percent of BSIs were monomicrobial."
+    },
+    {
+      "id": "c4",
+      "text": "The crude mortality rate of nosocomial bloodstream infection was 27%.",
+      "byte_quote": "The crude mortality rate was 27%."
+    },
+    {
+      "id": "c5",
+      "text": "ICU admission (host setting) raised the likelihood of bloodstream infection with CoNS, Pseudomonas, Enterobacter, Serratia, and Acinetobacter species.",
+      "byte_quote": "CoNS, Pseudomonas species, Enterobacter species, Serratia species, and Acinetobacter species were more likely to cause infections in patients in intensive care units (P<.001)."
+    },
+    {
+      "id": "c6",
+      "text": "Neutropenia raised the likelihood of bloodstream infection with Candida species, enterococci, and viridans group streptococci.",
+      "byte_quote": "In neutropenic patients, infections with Candida species, enterococci, and viridans group streptococci were significantly more common."
+    },
+    {
+      "id": "c7",
+      "text": "Mean interval from admission to infection varied by organism: 13 days for E. coli, 16 for S. aureus, 22 for Candida and Klebsiella, 23 for enterococci, and 26 for Acinetobacter.",
+      "byte_quote": "The mean interval between admission and infection was 13 days for infection with Escherichia coli, 16 days for S. aureus, 22 days for Candida species and Klebsiella species, 23 days for enterococci, and 26 days for Acinetobacter species."
+    },
+    {
+      "id": "c8",
+      "text": "Methicillin resistance among S. aureus bloodstream isolates rose from 22% in 1995 to 57% in 2001.",
+      "byte_quote": "The proportion of S. aureus isolates with methicillin resistance increased from 22% in 1995 to 57% in 2001 (P<.001, trend analysis)."
+    },
+    {
+      "id": "c9",
+      "text": "Vancomycin resistance was 2% in Enterococcus faecalis and 60% in Enterococcus faecium bloodstream isolates.",
+      "byte_quote": "Vancomycin resistance was seen in 2% of Enterococcus faecalis isolates and in 60% of Enterococcus faecium isolates."
+    },
+    {
+      "id": "c10",
+      "text": "The study detected 24,179 nosocomial bloodstream infections in 49 US hospitals over 7 years (60 cases per 10,000 hospital admissions).",
+      "byte_quote": "Our study detected 24,179 cases of nosocomial BSI in 49 US hospitals over a 7-year period from March 1995 through September 2002 (60 cases per 10,000 hospital admissions)."
+    }
+  ],
+  "cites": []
+}

--- a/code/specs/data/mycin-2026/cas/sources/a221aaa21abc0f44.json
+++ b/code/specs/data/mycin-2026/cas/sources/a221aaa21abc0f44.json
@@ -1,0 +1,105 @@
+{
+  "hash": "a221aaa21abc0f44",
+  "source_id": "https://www.ncbi.nlm.nih.gov/books/NBK482367/",
+  "title": "Staphylococcus saprophyticus Infection - StatPearls - NCBI Bookshelf",
+  "resolved_url": "https://www.ncbi.nlm.nih.gov/books/NBK482367/",
+  "claims": [
+    {
+      "id": "c1",
+      "text": "S. saprophyticus is the second most common cause of community-acquired UTIs, after E. coli.",
+      "byte_quote": "saprophyticus is the second most common cause of community-acquired urinary tract infections, after Escherichia coli"
+    },
+    {
+      "id": "c2",
+      "text": "In females ages 16 to 25, S. saprophyticus causes up to 42% of all UTIs.",
+      "byte_quote": "In females ages 16 to 25, it causes up to 42% of all infections."
+    },
+    {
+      "id": "c3",
+      "text": "Nearly half of women will have a UTI in their lifetime; in 5%-20% of non-hospitalized patients the infection is due to S. saprophyticus.",
+      "byte_quote": "Nearly half of all women will experience a UTI in their lifetime, and between 5% and 20% of non-hospitalized patients, the infection will be due to S."
+    },
+    {
+      "id": "c4",
+      "text": "Over 40% of young, sexually active women carry S. saprophyticus as part of normal genitourinary flora.",
+      "byte_quote": "Over 40% of all young, sexually active women contain S. saprophyticus as part of their normal genitourinary flora."
+    },
+    {
+      "id": "c5",
+      "text": "S. saprophyticus is a Gram-positive, coagulase-negative, non-hemolytic coccus causing uncomplicated UTIs, particularly in young sexually active females.",
+      "byte_quote": "Staphylococcus saprophyticus is a Gram-positive, coagulase-negative, non-hemolytic coccus that is a common cause of uncomplicated urinary tract infections (UTIs), particularly in young sexually active females."
+    },
+    {
+      "id": "c6",
+      "text": "General UTI risk factors: recurrent UTI history, female sex, recent intercourse, pregnancy, neurogenic bladder, indwelling catheter, benign prostatic hypertrophy.",
+      "byte_quote": "General risk factors for UTIs include the history of recurrent UTIs, female sex, recent sexual intercourse, pregnancy, neurogenic bladder, indwelling catheter, and benign prostatic hypertrophy."
+    },
+    {
+      "id": "c7",
+      "text": "Men have a lower incidence of S. saprophyticus infections.",
+      "byte_quote": "Men have a lower incidence of S. saprophyticus infections."
+    },
+    {
+      "id": "c8",
+      "text": "A complicated UTI typically involves a patient who is immunocompromised, elderly, male, pregnant, diabetic, and/or has urologic abnormalities such as indwelling catheters or kidney disease.",
+      "byte_quote": "A complicated infection typically involves a patient that is immunocompromised, elderly, male, pregnant, diabetic, and/or with urologic abnormalities such as indwelling catheters or kidney disease."
+    },
+    {
+      "id": "c9",
+      "text": "Polymicrobial infections are more likely in patients who are immunocompromised, elderly, diabetic, have indwelling catheters, HIV, and/or malignancies.",
+      "byte_quote": "Polymicrobial infections are more likely to occur in patients that are immunocompromised, elderly, those who have diabetes, have indwelling catheters, HIV, and/or malignancies."
+    },
+    {
+      "id": "c10",
+      "text": "S. saprophyticus can be differentiated from another coagulase-negative staphylococcus by its resistance to Novobiocin.",
+      "byte_quote": "saprophyticus can be differentiated from another coagulase-negative staphylococcus by its resistance to Novobiocin."
+    },
+    {
+      "id": "c11",
+      "text": "Like most gram-positive uropathogens, S. saprophyticus does not reduce nitrate to nitrite (negative urine nitrite).",
+      "byte_quote": "saprophyticus does not reduce nitrate to nitrite."
+    },
+    {
+      "id": "c12",
+      "text": "First-line for uncomplicated S. saprophyticus UTI is nitrofurantoin 100 mg orally twice daily for 5 days (7 days if complicated).",
+      "byte_quote": "saprophyticus UTIs is nitrofurantoin 100 mg orally twice daily for five days, or for seven days in complicated cases."
+    },
+    {
+      "id": "c13",
+      "text": "Alternative for uncomplicated cases: TMP-SMX 160 mg/800 mg by mouth twice daily for 3 days.",
+      "byte_quote": "Trimethoprim-sulfamethoxazole (TMP-SMX) 160 mg/800 mg by mouth twice daily for three days may be given alternatively in uncomplicated cases."
+    },
+    {
+      "id": "c14",
+      "text": "Pyridium may be given to alleviate associated dysuria.",
+      "byte_quote": "Pyridium may also be given to alleviate associated dysuria."
+    },
+    {
+      "id": "c15",
+      "text": "S. saprophyticus is resistant to antibiotic regimens commonly used and effective for E. coli UTIs, including ampicillin, ceftriaxone, cephalexin, and ciprofloxacin.",
+      "byte_quote": "saprophyticus has resistance to antibiotic regimes commonly prescribed and effective for E. coli induced UTIs, including ampicillin, ceftriaxone, cephalexin, and ciprofloxacin."
+    },
+    {
+      "id": "c16",
+      "text": "Some strains form biofilms (increasing virulence, especially with catheters); once biofilms form, antibiotic resistance is exacerbated and the organism may be vancomycin-resistant, treatable only via linezolid.",
+      "byte_quote": "Once biofilms have been produced, antibiotic resistance is exacerbated. In these cases, S. Saprophyticus may be resistant to vancomycin and only effectively treated via linezolid."
+    },
+    {
+      "id": "c17",
+      "text": "Patients with nosocomial catheterization have an increased incidence of S. saprophyticus colonization.",
+      "byte_quote": "catheterization have an increased incidence of S. saprophyticus colonization."
+    }
+  ],
+  "cites": [
+    "Argemi X, Hansmann Y, Prola K, Prévost G. Coagulase-Negative Staphylococci Pathogenomics. Int J Mol Sci. 2019;20(5)",
+    "Pinault L, Chabrière E, Raoult D, Fenollar F. Direct Identification of Pathogens in Urine by Use of a Specific MALDI-TOF Spectrum Database. J Clin Microbiol. 2019;57(4)",
+    "Natsis NE, Cohen PR. Coagulase-Negative Staphylococcus Skin and Soft Tissue Infections. Am J Clin Dermatol. 2018;19(5):671-677",
+    "Gill R, Leslie SW, Minter DA. Acute Cystitis. StatPearls. 2025",
+    "Hur J, Lee A, Hong J, Jo WY, Cho OH, Kim S, Bae IG. Staphylococcus saprophyticus Bacteremia originating from Urinary Tract Infections: A Case Report and Literature Review. Infect Chemother. 2016;48(2):136-9",
+    "Flores-Mireles AL, Walker JN, Caparon M, Hultgren SJ. Urinary tract infections: epidemiology, mechanisms of infection and treatment options. Nat Rev Microbiol. 2015;13(5):269-84",
+    "Becker K, Heilmann C, Peters G. Coagulase-negative staphylococci. Clin Microbiol Rev. 2014;27(4):870-926",
+    "Stock I. Nitrofurantoin--clinical relevance in uncomplicated urinary tract infections. Med Monatsschr Pharm. 2014;37(7):242-8",
+    "Mirone V, Franco M. Clinical aspects of antimicrobial prophylaxis for invasive urological procedures. J Chemother. 2014;26 Suppl 1:S1-S13",
+    "Stuart JI, John MA, Milburn S, Diagre D, Wilson B, Hussain Z. Susceptibility patterns of coagulase-negative staphylococci to several newer antimicrobial agents in comparison with vancomycin and oxacillin. Int J Antimicrob Agents. 2011;37(3):248-52"
+  ]
+}

--- a/code/specs/data/mycin-2026/cas/sources/a36d52927de1e970.json
+++ b/code/specs/data/mycin-2026/cas/sources/a36d52927de1e970.json
@@ -1,0 +1,139 @@
+{
+  "hash": "a36d52927de1e970",
+  "source_id": "https://www.cdc.gov/std/treatment-guidelines/penicillin-allergy.htm",
+  "title": "Managing Persons Who Have a History of Penicillin Allergy — STI Treatment Guidelines (CDC)",
+  "resolved_url": "https://www.cdc.gov/std/treatment-guidelines/penicillin-allergy.htm",
+  "claims": [
+    {
+      "id": "c1",
+      "text": "Reported penicillin allergy prevalence is about 10% of the US population and higher among hospital inpatients and long-term-care residents.",
+      "byte_quote": "Prevalence of reported allergy to penicillin is approximately 10% among the U.S. population and higher among hospital inpatients and residents in health care–related facilities"
+    },
+    {
+      "id": "c2",
+      "text": "In one STI clinic, 8.3% of patients reported a penicillin or other beta-lactam allergy.",
+      "byte_quote": "One large study in an STI clinic revealed that 8.3% of patients reported penicillin or another ß-lactam antibiotic allergy"
+    },
+    {
+      "id": "c3",
+      "text": "Most patients who report a penicillin allergy can actually tolerate the drug; allergy is overreported.",
+      "byte_quote": "Penicillin allergy is often overreported, with the majority of patients who report penicillin allergy able to tolerate the medication"
+    },
+    {
+      "id": "c4",
+      "text": "About 80% of patients with a true IgE-mediated penicillin allergy lose sensitivity after 10 years, so remote reactions are less likely to still be allergic.",
+      "byte_quote": "Approximately 80% of patients with a true IgE-mediated allergic reaction to penicillin have lost the sensitivity after 10 years"
+    },
+    {
+      "id": "c5",
+      "text": "In a Baltimore STI clinic, only 7.1% of patients reporting penicillin/beta-lactam allergy had an objective positive allergy test.",
+      "byte_quote": "only 7.1% of the patients who reported allergy to penicillin or to another ß-lactam antibiotic had an objective positive test for penicillin allergy"
+    },
+    {
+      "id": "c6",
+      "text": "With skin testing and graded oral challenge, true penicillin-allergy rates are low, 1.5%–6.1%.",
+      "byte_quote": "the true rates of allergy are low, ranging from 1.5% to 6.1%"
+    },
+    {
+      "id": "c7",
+      "text": "In hospitalized/comorbid populations reporting penicillin allergy, validated allergy rates are 2.5%–9.0%.",
+      "byte_quote": "the typical rates of validated penicillin allergy among patients who report a history of penicillin allergy are 2.5%–9.0%"
+    },
+    {
+      "id": "c8",
+      "text": "Penicillin and cephalosporins share a beta-lactam ring, the basis of cross-reactivity concern.",
+      "byte_quote": "Penicillin and cephalosporins both contain a ß-lactam ring."
+    },
+    {
+      "id": "c9",
+      "text": "Third-generation cephalosporins (ceftriaxone, cefixime) have <1% cross-reactivity in IgE-mediated penicillin-allergic patients, vs 1%–8% for first/second-generation cephalosporins.",
+      "byte_quote": "Third-generation cephalosporins (e.g., ceftriaxone and cefixime) have lower cross-reactivity with IgE-mediated penicillin-allergic patients (<1%) compared with first- and second-generation cephalosporins (range: 1%–8%)."
+    },
+    {
+      "id": "c10",
+      "text": "Cephalosporin anaphylaxis in persons reporting penicillin allergy is extremely rare, about one per 52,000 persons.",
+      "byte_quote": "anaphylaxis secondary to cephalosporins is extremely rare among persons who report a penicillin allergy and is estimated to occur at a rate of one per 52,000 persons"
+    },
+    {
+      "id": "c11",
+      "text": "Third/fourth-generation cephalosporins and carbapenems are safe for patients without IgE-mediated penicillin symptoms (anaphylaxis/urticaria) in the prior 10 years.",
+      "byte_quote": "Use of third- and fourth-generation cephalosporins and carbapenems is safe for patients without a history of any IgE-mediated symptoms (e.g., anaphylaxis or urticaria) from penicillin during the preceding 10 years."
+    },
+    {
+      "id": "c11b",
+      "text": "For gonorrhea patients with reported penicillin allergy, ceftriaxone is often avoided despite low cross-reactivity with third-generation cephalosporins.",
+      "byte_quote": "For patients with a diagnosis of gonorrhea and a concomitant reported allergy to penicillin, ceftriaxone is often avoided, even though the cross-reactivity between penicillin allergy and third-generation cephalosporins is low"
+    },
+    {
+      "id": "c12",
+      "text": "Allergy validation has three steps: history, penicillin major/minor determinant skin test, then observed oral challenge with 250 mg amoxicillin if skin test is negative.",
+      "byte_quote": "performing an observed oral challenge with 250 mg amoxicillin before proceeding directly to treatment with the indicated ß-lactam therapy"
+    },
+    {
+      "id": "c13",
+      "text": "Standard practice after a negative penicillin skin test is an observed oral challenge of amoxicillin 250 mg with 1 hour of observation.",
+      "byte_quote": "the standard practice is to follow skin testing with an observed oral challenge of amoxicillin 250 mg with 1 hour of observation"
+    },
+    {
+      "id": "c14",
+      "text": "Major-determinant (Pre-Pen) plus penicillin G skin testing identifies about 90%–99% of IgE-mediated penicillin-allergic patients.",
+      "byte_quote": "This test identifies approximately 90%–99% of the IgE-mediated penicillin-allergic patients."
+    },
+    {
+      "id": "c15",
+      "text": "Penicillin skin testing during pregnancy is considered safe.",
+      "byte_quote": "Penicillin skin testing during pregnancy is considered safe."
+    },
+    {
+      "id": "c16",
+      "text": "Penicillin is recommended for all clinical stages of syphilis, with no proven alternatives for neurosyphilis, congenital syphilis, or syphilis in pregnancy.",
+      "byte_quote": "Penicillin is recommended for all clinical stages of syphilis, and no proven alternatives exist for treating neurosyphilis, congenital syphilis, or syphilis during pregnancy."
+    },
+    {
+      "id": "c17",
+      "text": "Ceftriaxone, a third-generation cephalosporin, is recommended for gonorrhea treatment.",
+      "byte_quote": "Ceftriaxone, a third-generation cephalosporin, is recommended for gonorrhea treatment."
+    },
+    {
+      "id": "c18",
+      "text": "Desensitization (induction of tolerance) is required when penicillin is the only option (neurosyphilis, syphilis in pregnancy) and the skin test is positive; it must be done by allergists in a monitored inpatient setting.",
+      "byte_quote": "Desensitization is required for persons who have a documented penicillin allergy and for whom no therapeutic alternatives exist (e.g., syphilis during pregnancy and persons with neurosyphilis)."
+    },
+    {
+      "id": "c19",
+      "text": "Patients with severe non-IgE reactions (Stevens-Johnson, toxic epidermal necrolysis, interstitial nephritis, hemolytic anemia) should avoid penicillin/beta-lactams indefinitely and not undergo skin testing or challenge.",
+      "byte_quote": "Persons with a history of severe adverse cutaneous reaction (e.g., Stevens-Johnson syndrome or toxic epidermal necrolysis) and other severe non-IgE-mediated reactions (e.g., interstitial nephritis, and hemolytic anemia) are not candidates for penicillin skin testing or challenge."
+    },
+    {
+      "id": "c20",
+      "text": "High-risk histories include anaphylaxis within 6 hours, severe cutaneous reactions (DRESS/eosinophilia, SJS, TEN, AGEP), and severe non-IgE reactions (kidney or hepatic injury, hemolytic anemia, thrombocytopenia).",
+      "byte_quote": "anaphylaxis within 6 hours or severe adverse cutaneous reaction (e.g., eosinophilia and systemic symptoms, Stevens-Johnson syndrome, toxic epidermal necrolysis, or acute generalized exanthematous pustulosis), and other severe non-IgE-mediated reactions (e.g., kidney or hepatic injury, hemolytic anemia, or thrombocytopenia)"
+    },
+    {
+      "id": "c21",
+      "text": "Low-risk history is one nonspecific symptom (GI intolerance, headache, fatigue, nonurticarial rash); a family history of beta-lactam allergy alone is not a contraindication.",
+      "byte_quote": "Low-risk history includes one nonspecific symptom (e.g., gastrointestinal intolerance, headache, fatigue, or nonurticarial rash) (Box 2). In addition, a family history of penicillin or ß-lactam allergy alone is not a contraindication for treatment with ß-lactam antibiotics."
+    },
+    {
+      "id": "c22",
+      "text": "Penicillin skin testing should not be done in patients who have taken antihistamines within the past 7 days.",
+      "byte_quote": "Penicillin skin testing should not be performed for patients who have taken antihistamines within the past 7 days."
+    },
+    {
+      "id": "c23",
+      "text": "Penicillin G for skin-test minor-determinant precursor is dosed at 10^-2 M, 3.3 mg/mL, 10,000 units/mL.",
+      "byte_quote": "Benzylpenicillin G (10 -2 M, 3.3 mg/mL, 10,000 units/mL)"
+    },
+    {
+      "id": "c24",
+      "text": "Patients reporting penicillin allergy have higher rates of surgical-site infections and MRSA infections and greater medical-care usage.",
+      "byte_quote": "persons with reported penicillin or another ß-lactam antibiotic allergy have higher rates of surgical-site infections, methicillin-resistant Staphylococcus aureus infections, and higher medical care usage"
+    }
+  ],
+  "cites": [
+    "Saxon et al. 1987 (skin test reagents)",
+    "Kaiser health care system data (3,313 patients with self-reported cephalosporin allergy)",
+    "Pre-Pen Package Insert — https://penallergytest.com/wp-content/uploads/PRE-PEN-Package-Insert.pdf",
+    "CDC STI Treatment Guidelines references 652-690 (e.g., 652 cephalosporin cross-reactivity/anaphylaxis rate; 659 Baltimore STI clinic study; 677 revised skin-test kit n=455; 684 UK 1972-2007 amoxicillin anaphylaxis fatality)"
+  ]
+}

--- a/code/specs/data/mycin-2026/cas/sources/ac722c855cec8fbe.json
+++ b/code/specs/data/mycin-2026/cas/sources/ac722c855cec8fbe.json
@@ -1,0 +1,74 @@
+{
+  "hash": "ac722c855cec8fbe",
+  "source_id": "https://dailymed.nlm.nih.gov/dailymed/lookup.cfm?setid=793c75eb-dd65-4b6d-ac46-6e57ce1334f7",
+  "title": "Sulfamethoxazole and Trimethoprim Injection, USP — DailyMed Label (Mylan Institutional LLC)",
+  "resolved_url": "https://dailymed.nlm.nih.gov/dailymed/lookup.cfm?setid=793c75eb-dd65-4b6d-ac46-6e57ce1334f7",
+  "claims": [
+    {
+      "id": "c1",
+      "text": "ORGANISM EPIDEMIOLOGY (UTI): Sulfamethoxazole/trimethoprim injection treats severe or complicated UTIs in adults and pediatric patients >=2 months due to susceptible E. coli, Klebsiella spp., Enterobacter spp., Morganella morganii, Proteus mirabilis, and Proteus vulgaris.",
+      "byte_quote": "sulfamethoxazole and trimethoprim injection is indicated in the treatment of severe or complicated urinary tract infections in adults and pediatric patients two months of age and older due to susceptible strains of Escherichia coli, Klebsiella species, Enterobacter species, Morganella morganii, Proteus mirabilis and Proteus vulgaris when oral administration of sulfamethoxazole and trimethoprim injection is not feasible and when the organism is not susceptible to single-agent antibacterials effective in the urinary tract."
+    },
+    {
+      "id": "c2",
+      "text": "ORGANISM EPIDEMIOLOGY (enteritis): It treats enteritis caused by susceptible Shigella flexneri and Shigella sonnei in adults and pediatric patients >=2 months.",
+      "byte_quote": "Sulfamethoxazole and trimethoprim injection is indicated in the treatment of enteritis caused by susceptible strains of Shigella flexneri and Shigella sonnei in adults and pediatric patients two months of age and older."
+    },
+    {
+      "id": "c3",
+      "text": "ORGANISM EPIDEMIOLOGY (PCP): It treats Pneumocystis jirovecii pneumonia in adults and pediatric patients >=2 months.",
+      "byte_quote": "Sulfamethoxazole and trimethoprim injection is indicated in the treatment of Pneumocystis jirovecii pneumonia in adults and pediatric patients two months of age and older."
+    },
+    {
+      "id": "c4",
+      "text": "ANTIBIOTIC DOSING (PCP): 15 to 20 mg/kg/day in 3 or 4 equally divided doses, every 6 to 8 hours, for 14 days.",
+      "byte_quote": "15 to 20 mg/kg (in 3 or 4 equally divided doses)"
+    },
+    {
+      "id": "c5",
+      "text": "ANTIBIOTIC DOSING (severe UTI): 8 to 10 mg/kg/day in 2 to 4 equally divided doses, every 6, 8, or 12 hours, for 14 days.",
+      "byte_quote": "8 to 10 mg/kg (in 2 to 4 equally divided doses)"
+    },
+    {
+      "id": "c6",
+      "text": "ANTIBIOTIC DOSING (administration): Given by intravenous infusion over a period of 60 to 90 minutes.",
+      "byte_quote": "Administer the solution by intravenous infusion over a period of 60 to 90 minutes."
+    },
+    {
+      "id": "c7",
+      "text": "DOSING (renal impairment / nephrotoxicity-related): When renal function is impaired, a reduced dosage should be employed.",
+      "byte_quote": "When renal function is impaired, a reduced dosage should be employed"
+    },
+    {
+      "id": "c8",
+      "text": "CONTRAINDICATION (allergy): Known hypersensitivity to trimethoprim or sulfonamides.",
+      "byte_quote": "Known hypersensitivity to trimethoprim or sulfonamides"
+    },
+    {
+      "id": "c9",
+      "text": "INTERACTION/CONTRAINDICATION (QT): Concomitant administration with dofetilide is contraindicated.",
+      "byte_quote": "Concomitant administration with dofetilide"
+    },
+    {
+      "id": "c10",
+      "text": "HOST/RISK FACTOR (immune status): In AIDS patients treated for P. jirovecii pneumonia, the incidence of adverse reactions (rash, fever, leukopenia, elevated transaminases) is increased versus non-AIDS patients.",
+      "byte_quote": "The incidence of adverse reactions, particularly rash, fever, leukopenia, and elevated aminotransferase (transaminase) values, with sulfamethoxazole and trimethoprim therapy in AIDS patients who are being treated for P. jirovecii pneumonia has been reported to be increased compared with the incidence normally associated with the use of sulfamethoxazole and trimethoprim in non-AIDS patients."
+    },
+    {
+      "id": "c11",
+      "text": "CONTRAINDICATION/INTERACTION (pregnancy): Epidemiologic studies suggest exposure during pregnancy may increase risk of congenital malformations (neural tube defects, cardiovascular, urinary tract, oral clefts, club foot).",
+      "byte_quote": "Some epidemiologic studies suggest that exposure to sulfamethoxazole and trimethoprim during pregnancy may be associated with an increased risk of congenital malformations, particularly neural tube defects, cardiovascular malformations, urinary tract defects, oral clefts, and club foot."
+    },
+    {
+      "id": "c12",
+      "text": "INTERACTION (nephrotoxicity): Marked but reversible nephrotoxicity has been reported with coadministration of sulfamethoxazole/trimethoprim and cyclosporine in renal transplant recipients.",
+      "byte_quote": "There have been reports of marked but reversible nephrotoxicity with coadministration of sulfamethoxazole and trimethoprim and cyclosporine in renal transplant recipients."
+    },
+    {
+      "id": "c13",
+      "text": "ADVERSE EFFECT (QT): QT prolongation resulting in ventricular tachycardia and torsades de pointes has been reported.",
+      "byte_quote": "QT prolongation resulting in ventricular tachycardia and torsades de pointes"
+    }
+  ],
+  "cites": []
+}

--- a/code/specs/data/mycin-2026/cas/sources/b18b8c9e3d73b0a9.json
+++ b/code/specs/data/mycin-2026/cas/sources/b18b8c9e3d73b0a9.json
@@ -1,0 +1,71 @@
+{
+  "hash": "b18b8c9e3d73b0a9",
+  "source_id": "https://www.ncbi.nlm.nih.gov/books/NBK430891/",
+  "title": "Central Line-Associated Blood Stream Infections - StatPearls - NCBI Bookshelf",
+  "resolved_url": "https://www.ncbi.nlm.nih.gov/books/NBK430891/",
+  "claims": [
+    {
+      "id": "c1",
+      "text": "In CLABSI, gram-positive organisms are most common: coagulase-negative staphylococci 34.1%, enterococci 16%, S. aureus 9.9%; gram-negatives include Klebsiella 5.8%, Enterobacter 3.9%, Pseudomonas 3.1%, E. coli 2.7%, Acinetobacter 2.2%; Candida species 11.8%; others 10.5%.",
+      "byte_quote": "Gram-positive organisms (coagulase-negative staphylococci, 34.1%; enterococci, 16%; and Staphylococcus aureus, 9.9%) are the most common, followed by gram-negatives (Klebsiella, 5.8%; Enterobacter, 3.9%; Pseudomonas, 3.1%; E. coli, 2.7%; Acinetobacter, 2.2%), Candida species (11.8%), and others (10.5%)."
+    },
+    {
+      "id": "c2",
+      "text": "About 40%-80% of catheter-related bloodstream infections (CRBSIs) are caused by gram-positive organisms.",
+      "byte_quote": "Approximately 40%–80% of CRBSIs are caused by gram-positive organisms."
+    },
+    {
+      "id": "c3",
+      "text": "Host factors raising CLABSI risk include hemodialysis, malignancy, GI disorders, pulmonary hypertension, immune-suppressed states (organ transplant, diabetes), malnutrition, TPN, extremes of age, loss of skin integrity (burns), and prolonged pre-insertion hospitalization.",
+      "byte_quote": "Chronic illnesses (hemodialysis, malignancy, gastrointestinal tract disorders, pulmonary hypertension), immune-suppressed states (organ transplant, diabetes mellitus), malnutrition, total parenteral nutrition, extremes of age, loss of skin integrity (burns), and prolonged hospitalization before line insertion are host factors that increase the risk of CLABSI."
+    },
+    {
+      "id": "c4",
+      "text": "Pseudomonas bloodstream infection is commonly associated with neutropenia, severe illness, or known prior colonization.",
+      "byte_quote": "Pseudomonas is commonly associated with neutropenia, severe illness, or known prior colonization."
+    },
+    {
+      "id": "c5",
+      "text": "Candida bloodstream infection is associated with femoral catheterization, TPN, prolonged broad-spectrum antibiotics, hematologic malignancy, or solid-organ or hematopoietic stem cell transplantation.",
+      "byte_quote": "Candida is associated with risk factors: femoral catheterization, TPN, prolonged administration of broad-spectrum antibiotics, hematologic malignancy, or solid organ or hematopoietic stem cell transplantation."
+    },
+    {
+      "id": "c6",
+      "text": "Femoral central venous catheters carry the highest CLABSI risk, followed by internal jugular then subclavian catheters.",
+      "byte_quote": "Femoral central venous catheters are associated with the highest risk of CLABSI, followed by internal jugular and subclavian catheters."
+    },
+    {
+      "id": "c7",
+      "text": "Within 7-10 days of catheter placement, skin-surface bacteria migrate along the external catheter surface from the skin exit site toward the intravascular space (extraluminal source).",
+      "byte_quote": "Within 7 to 10 days of central venous catheter placement, bacteria on the skin surface migrate along the external surface of the catheter from the skin exit site towards the intravascular space."
+    },
+    {
+      "id": "c8",
+      "text": "CLABSIs beyond 10 days are usually caused by intraluminal hub contamination, typically from a healthcare provider's contaminated hands.",
+      "byte_quote": "CLABSIs that occur beyond 10 days are usually caused by contamination of the hub (intraluminal), typically from a health care provider's contaminated hands but rarely from a host and often due to a breach of standard aseptic precautions to access the hub."
+    },
+    {
+      "id": "c9",
+      "text": "Empiric therapy: parenteral vancomycin where MRSA is prevalent; otherwise anti-staphylococcal penicillin or cephalosporins (nafcillin or cefazolin) suffice.",
+      "byte_quote": "Parenteral vancomycin if methicillin-resistant staphylococci (MRSA) is prevalent. Otherwise, parenteral anti-staphylococcal penicillin or cephalosporins such as nafcillin or cefazolin would suffice."
+    },
+    {
+      "id": "c10",
+      "text": "Daptomycin is the drug of choice when MRSA isolates have vancomycin MIC > 2 mg/mL or for vancomycin-resistant enterococci (VRE).",
+      "byte_quote": "If MRSA isolates exhibit a minimum inhibitory concentration of > 2 mg/mL for vancomycin or, in the case of vancomycin-resistant enterococci (VRE), daptomycin is the drug of choice."
+    },
+    {
+      "id": "c11",
+      "text": "Echinocandins (micafungin, caspofungin, anidulafungin) are preferred for suspected candidemia when azole resistance is suspected (prior azole use or prevalent non-albicans candida such as C. glabrata or C. krusei).",
+      "byte_quote": "Echinocandins (micafungin, caspofungin, anidulafungin) are preferred agents for suspected candidemia if azole resistance is suspected (prior azole use or prevalent nonalbicans candida such as C.glabrata or C.krusei)."
+    },
+    {
+      "id": "c12",
+      "text": "Non-tunneled catheters carry higher CLABSI risk than tunneled catheters because they lack a subcutaneous tract.",
+      "byte_quote": "The absence of a tunnel (a subcutaneous tract) places non-tunneled catheters at higher risk for CLABSIs."
+    }
+  ],
+  "cites": [
+    "National Healthcare Safety Network (NHSN) data from January 2006 to October 2007"
+  ]
+}

--- a/code/specs/data/mycin-2026/cas/sources/b27c6544ee54ecec.json
+++ b/code/specs/data/mycin-2026/cas/sources/b27c6544ee54ecec.json
@@ -1,0 +1,47 @@
+{
+  "hash": "b27c6544ee54ecec",
+  "source_id": "https://pmc.ncbi.nlm.nih.gov/articles/PMC12217021/",
+  "title": "Feasibility of serial measurement of nitrite for pharmacodynamic monitoring and precision prescribing in urinary tract infections",
+  "resolved_url": "https://pmc.ncbi.nlm.nih.gov/articles/PMC12217021/",
+  "claims": [
+    {
+      "id": "c1",
+      "text": "E. coli uses nitrate as a secondary electron acceptor in anaerobic (low-oxygen) respiration, making urine nitrite a commonly used indicator/biomarker for UTI (urinalysis biochemistry).",
+      "byte_quote": "At low oxygen concentrations, _E. coli_ utilises nitrate as a secondary electron acceptor for anaerobic respiration[15](#CR15), making nitrite a commonly used indicator for UTIs."
+    },
+    {
+      "id": "c2",
+      "text": "Nitrite-based UTI detection fails when no dietary nitrate is present in urine or when the infecting organism is a non-nitrate-reducing strain (organism-dependent limitation of the nitrite test).",
+      "byte_quote": "This has limitations, such as no increase in nitrite if no dietary nitrate is present in urine, or infection with non-nitrate reducing strains."
+    },
+    {
+      "id": "c3",
+      "text": "Amoxicillin at 164 mg/mL was used in vitro (concentration chosen to inhibit growth of high-bacterial-count cultures), introduced after 15 h of growth.",
+      "byte_quote": "164 mg/mL sterilised amoxicillin, a concentration high enough to inhibit the growth of high bacterial count cultures, was introduced to samples after 15 h of growth."
+    },
+    {
+      "id": "c4",
+      "text": "In patient samples, bacterial count and generated nitrite (creatinine-corrected for renal clearance) show a significant positive Spearman correlation (rho 0.46, p 0.032).",
+      "byte_quote": "Spearman correlation between bacterial count and generated nitrite (corrected for renal clearance using detected creatinine levels) reveals a significant relationship (Spearman correlation: 0.46 and p-value 0.032)"
+    },
+    {
+      "id": "c5",
+      "text": "Study analyzed samples from 25 UTI patients and 25 non-UTI controls for bacterial growth, nitrite, and creatinine.",
+      "byte_quote": "Samples from 25 UTI patients and 25 non-UTI controls were analysed for bacterial growth, nitrite, and creatinine."
+    },
+    {
+      "id": "c6",
+      "text": "Both nitrite concentration and CFU count are significantly lower in a drug-susceptible strain after antimicrobial addition vs. without drug (pharmacodynamic response signal).",
+      "byte_quote": "The nitrite concentration and CFU count after addition of antimicrobial drug is significantly lower in the susceptible strain with drug compared to without drug"
+    },
+    {
+      "id": "c7",
+      "text": "Reported sensitivities for nitrite as a UTI biomarker are mixed and should be interpreted alongside other dipstick biomarkers (test-performance caveat).",
+      "byte_quote": "The reported sensitivities for nitrite as a biomarker for UTI infection are mixed and should be interpreted alongside other biomarkers on dipstick tests"
+    }
+  ],
+  "cites": [
+    "Foxman, B. The epidemiology of urinary tract infection. Nat. Rev. Urol. 7, 653-660 (2010)",
+    "Rawson, T. M. et al. Optimizing antimicrobial use: challenges, advances and opportunities. Nat. Rev. Microbiol 19, 747-758 (2021)"
+  ]
+}

--- a/code/specs/data/mycin-2026/cas/sources/b5e0dae026b80495.json
+++ b/code/specs/data/mycin-2026/cas/sources/b5e0dae026b80495.json
@@ -1,0 +1,64 @@
+{
+  "hash": "b5e0dae026b80495",
+  "source_id": "https://academic.oup.com/cid/article/72/7/1211/5836974",
+  "title": "Epidemiology of Escherichia coli Bacteremia: A Systematic Literature Review",
+  "resolved_url": "https://academic.oup.com/cid/article/72/7/1211/5836974",
+  "claims": [
+    {
+      "id": "c1",
+      "text": "E. coli is the most common cause of bacteremia in high-income countries, exceeding other leading bacteremia pathogens including Staphylococcus aureus and Streptococcus pneumoniae.",
+      "byte_quote": "Escherichia coli is the most common cause of bacteremia in high-income countries, exceeding other leading bacteremia-causing pathogens such as Staphylococcus aureus and Streptococcus pneumoniae"
+    },
+    {
+      "id": "c2",
+      "text": "E. coli accounted for 27.1% of all bacteremia episodes overall.",
+      "byte_quote": "The E. coli–specific proportion of all bacteremia episodes was 27.1% overall (95% CI, 24.5–29.8)"
+    },
+    {
+      "id": "c3",
+      "text": "E. coli proportion of bacteremia varied by acquisition setting: hospital-acquired 18.1%, community-onset healthcare-associated 31.5%, community-acquired 33.0%.",
+      "byte_quote": "18.1% (95% CI, 15.1–21.7%)"
+    },
+    {
+      "id": "c4",
+      "text": "Incidence of E. coli bacteremia rises steeply with age: >100 per 100,000 person-years in 55-to-75-year-olds and >300 in 75-to-85-year-olds.",
+      "byte_quote": "rates per 100 000 person-years were >100 in 55-to-75-year-olds and >300 in 75-to-85-year-olds"
+    },
+    {
+      "id": "c5",
+      "text": "Highest relative risks of E. coli bacteremia vs general population: renal dialysis (RR 26.9), solid-organ transplant (RR 20.3), neoplastic disease (RR 14.9).",
+      "byte_quote": "highest relative risks (RRs) of developing E. coli bacteremia compared with the general population were associated with renal dialysis (RR, 26.9), solid-organ transplantation (RR, 20.3), and neoplastic disease (RR, 14.9)"
+    },
+    {
+      "id": "c6",
+      "text": "Indwelling vascular and urinary catheters raise E. coli bacteremia risk: central venous 10-fold, peripheral venous 7.5-fold, suprapubic urinary 6-fold, urethral urinary 3-fold.",
+      "byte_quote": "indwelling vascular and urinary catheters increased the risk...by 10-fold and 7.5-fold for central and peripheral venous catheters, respectively, and by 6-fold and 3-fold for suprapubic and urethral urinary catheters"
+    },
+    {
+      "id": "c7",
+      "text": "Urinary tract infection was the primary source for 53% of E. coli bacteremia episodes.",
+      "byte_quote": "Urinary tract infection (UTI) was the primary source for 53% of episodes."
+    },
+    {
+      "id": "c8",
+      "text": "Urogenital infection accounted for more than half (pooled 52.6%) of all E. coli bacteremia episodes.",
+      "byte_quote": "Urogenital infection accounted for more than half of all E. coli bacteremia episodes (pooled estimate, 52.6%; 95% CI, 47.0–58.1%)"
+    },
+    {
+      "id": "c9",
+      "text": "Pooled case fatality rate for E. coli bacteremia was 12.4%.",
+      "byte_quote": "The pooled estimated CFR for E. coli bacteremia was 12.4% (95% CI, 10.7–14.3%; range, 2.8–28.5%)"
+    }
+  ],
+  "cites": [
+    "Skogberg et al. Epidemiology and Infection 2008",
+    "Skogberg et al. Clinical Microbiology and Infection 2012",
+    "Kennedy et al. Medical Journal of Australia 2008",
+    "Weiner et al. Infection Control & Hospital Epidemiology 2016",
+    "Søgaard et al. Clinical Infectious Diseases 2011",
+    "Poolman & Anderson. Expert Review of Vaccines 2018",
+    "Russo & Johnson. Microbes and Infection 2003",
+    "Laupland et al. Clinical Microbiology and Infection 2008",
+    "Laupland et al. Epidemiology and Infection 2007"
+  ]
+}

--- a/code/specs/data/mycin-2026/cas/sources/c6a1cb378499eaca.json
+++ b/code/specs/data/mycin-2026/cas/sources/c6a1cb378499eaca.json
@@ -1,0 +1,119 @@
+{
+  "hash": "c6a1cb378499eaca",
+  "source_id": "https://dailymed.nlm.nih.gov/dailymed/fda/fdaDrugXsl.cfm?setid=99e523d8-9bde-43cb-8434-497015e5dcbd",
+  "title": "Vancomycin Injection, USP (vancomycin hydrochloride) — FDA Label (DailyMed)",
+  "resolved_url": "https://dailymed.nlm.nih.gov/dailymed/fda/fdaDrugXsl.cfm?setid=99e523d8-9bde-43cb-8434-497015e5dcbd",
+  "claims": [
+    {
+      "id": "c1",
+      "text": "Vancomycin is active against most isolates of gram-positive bacteria in vitro and in clinical infections.",
+      "byte_quote": "Vancomycin has been shown to be active against most isolates of the following bacteria, both in vitro and in clinical infections"
+    },
+    {
+      "id": "c2",
+      "text": "Vancomycin's gram-positive spectrum includes Corynebacterium spp., Enterococcus spp. (incl. E. faecalis), Staphylococcus aureus (MRSA and MSSA), coagulase-negative staphylococci (incl. S. epidermidis and MR isolates), Streptococcus gallolyticus (formerly S. bovis), and viridans group streptococci.",
+      "byte_quote": "Corynebacterium spp. Enterococcus spp. (including Enterococcus faecalis) Staphylococcus aureus (including methicillin-resistant and methicillin-susceptible isolates) Coagulase negative staphylococci (including S. epidermidis and methicillin-resistant isolates) Streptococcus gallolyticus (previously known as Streptococcus bovis) Viridans group streptococci"
+    },
+    {
+      "id": "c3",
+      "text": "Vancomycin is NOT active in vitro against gram-negative bacilli, mycobacteria, or fungi (gram-stain spectrum boundary).",
+      "byte_quote": "Vancomycin is not active in vitro against gram-negative bacilli, mycobacteria, or fungi."
+    },
+    {
+      "id": "c4",
+      "text": "Vancomycin is indicated for septicemia/bloodstream infection due to susceptible MRSA and coagulase-negative staphylococci.",
+      "byte_quote": "Susceptible isolates of methicillin-resistant Staphylococcus aureus (MRSA) and coagulase negative staphylococci."
+    },
+    {
+      "id": "c5",
+      "text": "Vancomycin is used for methicillin-susceptible staphylococci in penicillin-allergic patients or those who cannot receive/failed penicillins or cephalosporins (allergy cross-reactivity / drug-failure host factor).",
+      "byte_quote": "Methicillin-susceptible staphylococci in penicillin-allergic patients, or those patients who cannot receive or who have failed to respond to other drugs, including penicillins or cephalosporins."
+    },
+    {
+      "id": "c6",
+      "text": "For infective endocarditis, vancomycin covers susceptible MRSA, viridans group streptococci or S. gallolyticus (formerly S. bovis), Enterococcus species, and Corynebacterium species.",
+      "byte_quote": "Susceptible isolates of MRSA. Viridans group streptococci or Streptococcus gallolyticus (previously known as Streptococcus bovis) and Enterococcus species and Corynebacterium species."
+    },
+    {
+      "id": "c7",
+      "text": "Adult dosing with normal renal function: 2 g daily IV, divided as 500 mg every 6 hours or 1 g every 12 hours.",
+      "byte_quote": "The usual daily intravenous dosage of Vancomycin Injection is 2 grams (g) divided either as 500 mg every 6 hours or 1 g every 12 hours."
+    },
+    {
+      "id": "c8",
+      "text": "Pediatric dosing (>=1 month) with normal renal function: 10 mg/kg per dose every 6 hours.",
+      "byte_quote": "The usual intravenous dosage of vancomycin is 10 mg/kg per dose given every 6 hours."
+    },
+    {
+      "id": "c9",
+      "text": "Neonatal dosing: initial 15 mg/kg, then 10 mg/kg every 12 hours in the 1st week of life and every 8 hours thereafter up to 1 month of age.",
+      "byte_quote": "In neonates, an initial dose of 15 mg/kg is suggested, followed by 10 mg/kg every 12 hours for neonates in the 1st week of life and every 8 hours thereafter up to the age of 1 month."
+    },
+    {
+      "id": "c10",
+      "text": "In renal impairment the initial dose should be no less than 15 mg/kg regardless of degree of impairment; dose must be adjusted.",
+      "byte_quote": "The initial dose should be no less than 15 mg/kg in patients with any degree of renal impairment."
+    },
+    {
+      "id": "c11",
+      "text": "Infusion-related adverse reactions are fewer at an infusion rate of 10 mg/min or less; each dose given over >=60 minutes.",
+      "byte_quote": "An infusion rate of 10 mg/min or less is associated with fewer infusion-related adverse reactions."
+    },
+    {
+      "id": "c12",
+      "text": "Vancomycin is contraindicated in patients with known hypersensitivity to vancomycin.",
+      "byte_quote": "Vancomycin Injection is contraindicated in patients with known hypersensitivity to vancomycin."
+    },
+    {
+      "id": "c13",
+      "text": "Dextrose-containing vancomycin solutions may be contraindicated in patients with known corn/corn-product allergy.",
+      "byte_quote": "Solutions containing dextrose including Vancomycin Injection, may be contraindicated in patients with a known allergy to corn or corn products."
+    },
+    {
+      "id": "c14",
+      "text": "Vancomycin can cause acute kidney injury (AKI), including acute renal failure, mainly via interstitial nephritis or less commonly acute tubular necrosis (nephrotoxicity).",
+      "byte_quote": "Vancomycin Injection can result in acute kidney injury (AKI), including acute renal failure, mainly due to interstitial nephritis or less commonly acute tubular necrosis."
+    },
+    {
+      "id": "c15",
+      "text": "AKI risk rises with higher vancomycin serum levels, prolonged exposure, concomitant nephrotoxic drugs, concomitant piperacillin-tazobactam, volume depletion, pre-existing renal impairment, critical illness, and predisposing comorbidities.",
+      "byte_quote": "The risk of AKI increases with higher vancomycin serum levels, prolonged exposure, concomitant administration of other nephrotoxic drugs, concomitant administration of piperacillin-tazobactam, volume depletion, pre-existing renal impairment and in critically ill patients and patients with co-morbid conditions that predispose to renal impairment."
+    },
+    {
+      "id": "c16",
+      "text": "Concomitant piperacillin/tazobactam plus vancomycin increases incidence of AKI versus vancomycin alone (drug interaction).",
+      "byte_quote": "Studies have detected an increased incidence of acute kidney injury in patients administered concomitant piperacillin/tazobactam and vancomycin as compared to vancomycin alone."
+    },
+    {
+      "id": "c17",
+      "text": "Ototoxicity risk is higher in older patients, those on higher doses, with underlying hearing loss, on concomitant ototoxic agents such as aminoglycosides, or with renal impairment.",
+      "byte_quote": "The risk is higher in older patients, patients who are receiving higher doses, who have an underlying hearing loss, who are receiving concomitant therapy with another ototoxic agent, such as an aminoglycoside or who have underlying renal impairment."
+    },
+    {
+      "id": "c18",
+      "text": "Reversible neutropenia has been reported with vancomycin; monitor leukocyte count in prolonged therapy or with concomitant neutropenia-causing drugs.",
+      "byte_quote": "Reversible neutropenia has been reported in patients receiving vancomycin. Patients who will undergo prolonged therapy with vancomycin or those who are receiving concomitant drugs that may cause neutropenia should have periodic monitoring of the leukocyte count."
+    },
+    {
+      "id": "c19",
+      "text": "Concomitant vancomycin and anesthetic agents has been associated with erythema and histamine-like flushing (interaction).",
+      "byte_quote": "Concomitant administration of vancomycin and anesthetic agents has been associated with erythema and histamine-like flushing."
+    },
+    {
+      "id": "c20",
+      "text": "Available data over decades of vancomycin use in pregnant women have not identified a drug-associated risk of major birth defects, miscarriage, or adverse maternal/fetal outcomes (pregnancy).",
+      "byte_quote": "Available data over several decades of vancomycin use in pregnant women have not identified a drug-associated risk of major birth defects, miscarriage, or adverse maternal or fetal outcomes."
+    },
+    {
+      "id": "c21",
+      "text": "Elderly patients are more likely to have decreased renal function, increasing adverse-reaction risk; dose selection requires care.",
+      "byte_quote": "Because elderly patients are more likely to have decreased renal function, care should be taken in dose selection."
+    }
+  ],
+  "cites": [
+    "Byrd RA, Gries CL, Buening M. Developmental Toxicology Studies of Vancomycin Hydrochloride Administered Intravenously to Rats and Rabbits. Fundam Appl Toxicol 1994;23:590-597.",
+    "Rybak MJ. The pharmacokinetic and pharmacodynamic properties of vancomycin. Clinical Infectious Diseases. 2006;42(Suppl 1):S35-S39.",
+    "Rybak MJ, Le J, Lodise TP, et al. Therapeutic monitoring of vancomycin for serious methicillin-resistant Staphylococcus aureus infections: a revised consensus guideline and review by ASHP, IDSA, PIDS, and SIDP. Clinical Infectious Diseases. 2020;71(6):1361-1364.",
+    "FDA Susceptibility Test Interpretive Criteria (STIC)"
+  ]
+}

--- a/code/specs/data/mycin-2026/cas/sources/ccf66a2721e88eb6.json
+++ b/code/specs/data/mycin-2026/cas/sources/ccf66a2721e88eb6.json
@@ -1,0 +1,84 @@
+{
+  "hash": "ccf66a2721e88eb6",
+  "source_id": "https://academic.oup.com/cid/article/49/1/1/369414",
+  "title": "Clinical Practice Guidelines for the Diagnosis and Management of Intravascular Catheter-Related Infection: 2009 Update by the Infectious Diseases Society of America",
+  "resolved_url": "https://academic.oup.com/cid/article/49/1/1/369414",
+  "claims": [
+    {
+      "id": "c1",
+      "text": "The four most common causes of CRBSI from percutaneous noncuffed catheters, in order of prevalence, are coagulase-negative staphylococci, S. aureus, Candida species, and enteric gram-negative bacilli.",
+      "byte_quote": "In order of prevalence, the 4 groups of microbes that most commonly cause CRBSI associated with percutaneously inserted, noncuffed catheters are as follows: coagulase-negative staphylococci, S. aureus, Candida species, and enteric gram-negative bacilli."
+    },
+    {
+      "id": "c2",
+      "text": "In children, coagulase-negative staphylococci cause 34% of CRBSIs and S. aureus 25%.",
+      "byte_quote": "Most CRBSIs among children are caused by coagulase-negative staphylococci (which account for 34% of cases), followed by S. aureus (25%)."
+    },
+    {
+      "id": "c3",
+      "text": "In neonates, coagulase-negative staphylococci account for 51% of CRBSIs, followed by Candida, enterococci, and gram-negative bacilli.",
+      "byte_quote": "Among neonates, coagulase-negative staphylococci account for 51% of CRBSIs, followed by Candida species, enterococci, and gram-negative bacilli."
+    },
+    {
+      "id": "c4",
+      "text": "Vancomycin is recommended for empirical CRBSI therapy in settings with elevated MRSA prevalence.",
+      "byte_quote": "Vancomycin is recommended for empirical therapy in heath care settings with an elevated prevalence of methicillin-resistant Staphylococcus aureus (MRSA)."
+    },
+    {
+      "id": "c5",
+      "text": "Where most MRSA isolates have vancomycin MIC >2 µg/mL, an alternative agent such as daptomycin should be used.",
+      "byte_quote": "for institutions in which the preponderance of MRSA isolates have vancomycin minimum inhibitory concentration (MIC) values >2 µg/mL, alternative agents, such as daptomycin, should be used."
+    },
+    {
+      "id": "c6",
+      "text": "Linezolid should not be used for empirical therapy of suspected (unproven) CRBSI.",
+      "byte_quote": "Linezolid should not be used for empirical therapy (i.e., for patients suspected but not proven to have CRBSI)."
+    },
+    {
+      "id": "c7",
+      "text": "Empirical gram-negative coverage should be guided by local susceptibility and disease severity (4th-gen cephalosporin, carbapenem, or beta-lactam/beta-lactamase combination, with or without an aminoglycoside).",
+      "byte_quote": "Empirical coverage for gram-negative bacilli should be based on local antimicrobial susceptibility data and the severity of disease (e.g., a fourth-generation cephalosporin, carbapenem, or β-lactam/β-lactamase combination, with or without an aminoglycoside)."
+    },
+    {
+      "id": "c8",
+      "text": "Empirical combination coverage for MDR gram-negative bacilli (e.g. Pseudomonas aeruginosa) should be used in neutropenic patients, severely ill septic patients, or those colonized with such pathogens.",
+      "byte_quote": "Empirical combination antibiotic coverage for multidrug-resistant (MDR) gram-negative bacilli, such as Pseudomonas aeruginosa, should be used when CRBSI is suspected in neutropenic patients, severely ill patients with sepsis, or patients known to be colonized with such pathogens."
+    },
+    {
+      "id": "c9",
+      "text": "For suspected CRBSI involving femoral catheters in critically ill patients, empirical therapy should add coverage for gram-negative bacilli and Candida species on top of gram-positive coverage.",
+      "byte_quote": "In addition to coverage for gram-positive pathogens, empirical therapy for suspected CRBSI involving femoral catheters in critically ill patients should include coverage for gram-negative bacilli and Candida species."
+    },
+    {
+      "id": "c10",
+      "text": "For suspected catheter-related candidemia, use an echinocandin, or fluconazole in selected patients.",
+      "byte_quote": "For empirical treatment of suspected catheter-related candidemia, use an echinocandin or, in selected patients, fluconazole."
+    },
+    {
+      "id": "c11",
+      "text": "4–6 weeks of antibiotic therapy is given for persistent fungemia or bacteremia occurring >72 h after catheter removal.",
+      "byte_quote": "Four to 6 weeks of antibiotic therapy should be administered to patients with persistent fungemia or bacteremia after catheter removal (i.e., occurring >72 h after catheter removal) (A-II for S. aureus infection; C-III for infection due to other pathogens)."
+    },
+    {
+      "id": "c12",
+      "text": "Osteomyelitis in adults is treated with 6–8 weeks of therapy.",
+      "byte_quote": "6–8 weeks of therapy should be used for the treatment of osteomyelitis in adults."
+    },
+    {
+      "id": "c13",
+      "text": "Long-term catheters should be removed for CRBSI with severe sepsis, suppurative thrombophlebitis, endocarditis, persistent infection >72 h despite susceptible therapy, or infection due to S. aureus, P. aeruginosa, fungi, or mycobacteria.",
+      "byte_quote": "Long-term catheters should be removed from patients with CRBSI associated with any of the following conditions: severe sepsis; suppurative thrombophlebitis; endocarditis; bloodstream infection that continues despite >72 h of antimicrobial therapy to which the infecting microbes are susceptible; or infections due to S. aureus, P. aeruginosa, fungi, or mycobacteria."
+    },
+    {
+      "id": "c14",
+      "text": "Short-term catheters should be removed for CRBSI due to gram-negative bacilli, S. aureus, enterococci, fungi, and mycobacteria.",
+      "byte_quote": "Short-term catheters should be removed from patients with CRBSI due to gram-negative bacilli, S. aureus, enterococci, fungi, and mycobacteria."
+    },
+    {
+      "id": "c15",
+      "text": "Vancomycin has a lower clinical success rate against MRSA bacteremia when the MIC is >=2 µg/mL.",
+      "byte_quote": "Vancomycin is associated with a lower clinical success rate in treating MRSA bacteremia if the MIC is ⩾2 µg/mL."
+    }
+  ],
+  "cites": []
+}

--- a/code/specs/data/mycin-2026/cas/sources/debf68ecb2c088e8.json
+++ b/code/specs/data/mycin-2026/cas/sources/debf68ecb2c088e8.json
@@ -1,0 +1,84 @@
+{
+  "hash": "debf68ecb2c088e8",
+  "source_id": "https://pmc.ncbi.nlm.nih.gov/articles/PMC10031580/",
+  "title": "Bacterial species and antimicrobial resistance differ between catheter and non–catheter-associated urinary tract infections: Data from a national surveillance network",
+  "resolved_url": "https://pmc.ncbi.nlm.nih.gov/articles/PMC10031580/",
+  "claims": [
+    {
+      "id": "c1",
+      "text": "E. coli is the most frequent uropathogen in both catheter-associated (CAUTI) and non-catheter-associated UTI.",
+      "byte_quote": "Escherichia coli was the most frequent pathogen identified in both CAUTI and non-CAUTI samples"
+    },
+    {
+      "id": "c2",
+      "text": "Four organisms (E. coli, K. pneumoniae, P. aeruginosa, P. mirabilis) make up 70% of CAUTI and 85% of non-CAUTI pathogens.",
+      "byte_quote": "Escherichia coli, Klebsiella pneumoniae, Pseudomonas aeruginosa, and Proteus mirabilis together represented 70% and 85% of pathogens identified in CAUTI and non-CAUTI samples, respectively"
+    },
+    {
+      "id": "c3",
+      "text": "P. aeruginosa is enriched in catheter-associated UTI (10% of CAUTI vs 3.3% of non-CAUTI).",
+      "byte_quote": "Pseudomonas aeruginosa represented 10% of CAUTI pathogens versus only 3.3% of non-CAUTIs"
+    },
+    {
+      "id": "c4",
+      "text": "E. coli proportion: 31.9% in CAUTI vs 54.8% in non-CAUTI.",
+      "byte_quote": "Escherichia coli (31.9% CAUTI; 54.8% non-CAUTI)"
+    },
+    {
+      "id": "c5",
+      "text": "P. aeruginosa proportion: 10.1% in CAUTI vs 3.3% in non-CAUTI.",
+      "byte_quote": "Pseudomonas aeruginosa (10.1% CAUTI; 3.3% non-CAUTI)"
+    },
+    {
+      "id": "c6",
+      "text": "K. pneumoniae proportion: 11.1% in CAUTI vs 9.9% in non-CAUTI.",
+      "byte_quote": "Klebsiella pneumoniae (11.1% CAUTI; 9.9% non-CAUTI)"
+    },
+    {
+      "id": "c7",
+      "text": "Host/risk factor: CAUTI patients are older (median 75 y) than non-CAUTI patients (median 65 y); catheterization (device) is the differentiating exposure.",
+      "byte_quote": "Age, median y (IQR): CAUTI 75 (60–80); Non-CAUTI 65 (40–75); P<.001"
+    },
+    {
+      "id": "c8",
+      "text": "Host/risk factor: CAUTI cases are predominantly male (57.4%), whereas non-CAUTI cases are predominantly female (68.6%).",
+      "byte_quote": "Male: 2,587 (57.4%) CAUTI; 6,234 (31.3%) non-CAUTI"
+    },
+    {
+      "id": "c9",
+      "text": "Catheter association predicts higher resistance to recommended empirical antibiotics.",
+      "byte_quote": "CAUTI pathogens were more often resistant to recommended empirical antibiotics than non-CAUTI pathogens."
+    },
+    {
+      "id": "c10",
+      "text": "E. coli ciprofloxacin (CIP) resistance is higher in CAUTI (26%) than non-CAUTI (16.9%).",
+      "byte_quote": "26% of CAUTI samples were resistant vs 16.9% of non-CAUTI samples"
+    },
+    {
+      "id": "c11",
+      "text": "E. coli third/fourth-generation cephalosporin (C3/4G) resistance: 11.6% CAUTI vs 8.2% non-CAUTI.",
+      "byte_quote": "11.6% of CAUTI samples were resistant vs 8.2% of non-CAUTI samples"
+    },
+    {
+      "id": "c12",
+      "text": "E. coli norfloxacin (NOR) resistance: 28.1% CAUTI vs 19.1% non-CAUTI.",
+      "byte_quote": "28.1% of CAUTI samples were resistant vs 19.1% of non-CAUTI samples"
+    },
+    {
+      "id": "c13",
+      "text": "K. pneumoniae ciprofloxacin resistance: 17.8% CAUTI vs 11.4% non-CAUTI.",
+      "byte_quote": "17.8% vs 11.4% resistant, respectively"
+    },
+    {
+      "id": "c14",
+      "text": "P. aeruginosa cephalosporin (CEF) resistance: 13.7% CAUTI vs 8.1% non-CAUTI.",
+      "byte_quote": "13.7% vs 8.1% resistant, respectively"
+    },
+    {
+      "id": "c15",
+      "text": "P. aeruginosa piperacillin (PIP) resistance: 14.5% CAUTI vs 9.8% non-CAUTI.",
+      "byte_quote": "14.5% vs 9.8% resistant, respectively"
+    }
+  ],
+  "cites": []
+}

--- a/code/specs/data/mycin-2026/cas/sources/e3fc40eba191bb19.json
+++ b/code/specs/data/mycin-2026/cas/sources/e3fc40eba191bb19.json
@@ -1,0 +1,122 @@
+{
+  "hash": "e3fc40eba191bb19",
+  "source_id": "https://pmc.ncbi.nlm.nih.gov/articles/PMC10699684/",
+  "title": "Pseudomonas aeruginosa: Infections and novel approaches to treatment \"Knowing the enemy\" the threat of Pseudomonas aeruginosa and exploring novel approaches to treatment (Infect Med (Beijing). 2023;2(3):178-194)",
+  "resolved_url": "https://pmc.ncbi.nlm.nih.gov/articles/PMC10699684/",
+  "claims": [
+    {
+      "id": "c1",
+      "text": "P. aeruginosa is a Gram-negative, motile, nonfermenting, rod-shaped (bacillus) bacterium.",
+      "byte_quote": "Pseudomonas aeruginosa is a motile, nonfermenting, Gram-negative, rod-shaped"
+    },
+    {
+      "id": "c2",
+      "text": "P. aeruginosa colonizes healthy people: isolated from the throat of 5% and stools of 3% of nonhospitalized patients.",
+      "byte_quote": "has also been isolated from the throat (5%) and stools (3%) of nonhospitalized patients"
+    },
+    {
+      "id": "c3",
+      "text": "P. aeruginosa is the 4th leading cause of HAIs, accounts for 20% of all HAIs in Europe/US, and is responsible for 75% of deaths of severely burnt patients.",
+      "byte_quote": "It is the fourth leading cause of hospital-associated infections (HAIs) and accounts for 20% of all HAIs in Europe and United States [45] and is responsible for 75% of all deaths of severely burnt patients [46]."
+    },
+    {
+      "id": "c4",
+      "text": "P. aeruginosa is the 2nd most common cause of ventilator-associated pneumonia in the US and ranks 3rd among catheter-associated UTIs.",
+      "byte_quote": "P. aeruginosa is the second most common cause of ventilator-associated pneumonia in the United States [43], and ranks third among urinary tract infections associated with catheters [44]."
+    },
+    {
+      "id": "c5",
+      "text": "P. aeruginosa causes 3%-7% of bloodstream infection cases, with 27%-48% morbidity/mortality in critically ill patients.",
+      "byte_quote": "The bacterium is responsible for 3%–7% of blood stream infection cases with high morbidity and mortality rates (27%–48%) in critically ill patients [125,126]."
+    },
+    {
+      "id": "c6",
+      "text": "P. aeruginosa is the 3rd most common Gram-negative cause of nosocomial bloodstream infection, accounting for 4.3% of all nosocomial BSI cases.",
+      "byte_quote": "reported P. aeruginosa as the third most common Gram-negative bacteria causing nosocomial BSI and accounted for 4.3% of all cases."
+    },
+    {
+      "id": "c7",
+      "text": "Patients with burns and AIDS are more vulnerable to systemic (bloodstream) P. aeruginosa infection.",
+      "byte_quote": "Patients with burns and AIDs are more vulnerable to systemic infection by P. aeruginosa"
+    },
+    {
+      "id": "c8",
+      "text": "In adult neutropenic oncohematological patients (incl. HSCT recipients), P. aeruginosa BSI isolates were 25.4% MDR and 19.3% XDR.",
+      "byte_quote": "P. aeruginosa strains isolated from adult neutropenic oncohematological patients, including hematopoietic stem cell transplant recipients, were caused by multi drug resistant (25.4%) and extensively drug resistant bacteria (19.3%)."
+    },
+    {
+      "id": "c9",
+      "text": "P. aeruginosa is associated with 7%-12% of all nosocomial UTIs.",
+      "byte_quote": "associated with 7%–12% of all nosocomial urinary tract infections [44,127]."
+    },
+    {
+      "id": "c10",
+      "text": "P. aeruginosa UTIs usually follow catheterization or surgery (device/instrumentation risk factor).",
+      "byte_quote": "The bacterium usually causes UTIs following catheterization or surgery [75]."
+    },
+    {
+      "id": "c11",
+      "text": "P. aeruginosa UTI can progress to sepsis, fatal especially in older, immunocompromised, and diabetic patients.",
+      "byte_quote": "may cause complications such as sepsis that can be fatal in older patients, immunocompromised patients and individuals with diabetes [19]."
+    },
+    {
+      "id": "c12",
+      "text": "Burn wounds are first colonized by Gram-positive organisms (Staphylococcus aureus, Streptococcus pyogenes) before P. aeruginosa infection.",
+      "byte_quote": "Wounds first become colonized by Gram-positive organisms such as Staphylococcus aureus and Streptococcus pyogenes before infection by P. aeruginosa"
+    },
+    {
+      "id": "c13",
+      "text": "Source/portal associations: burn-wound infection arises from endogenous GI/upper-respiratory flora (causing septicaemia); bloodstream infections are nosocomial.",
+      "byte_quote": "Burn wound infectionEndogenous flora of the gastrointestinal and or upper respiratory tract [87,88]Septicaemia [46]Blood stream infectionsNosocomial [89]"
+    },
+    {
+      "id": "c14",
+      "text": "In India, carbapenem resistance among P. aeruginosa is high (40%-47%).",
+      "byte_quote": "A scoping report on antimicrobial resistance in India reported a high prevalence of carbapenem resistance among P. aeruginosa (40%–47%)"
+    },
+    {
+      "id": "c15",
+      "text": "DTR P. aeruginosa is non-susceptible to all of: piperacillin-tazobactam, ceftazidime, cefepime, aztreonam, meropenem, imipenem-cilastatin, ciprofloxacin, levofloxacin (the anti-pseudomonal drug list).",
+      "byte_quote": "DTR is described in this guidance as P. aeruginosa that does not display sensitivity to any of the following drugs: piperacillin-tazobactam, ceftazidime, cefepime, aztreonam, meropenem, imipenem-cilastatin, ciprofloxacin, and levofloxacin."
+    },
+    {
+      "id": "c16",
+      "text": "P. aeruginosa causes bacterial keratitis in 6%-39% of cases in the USA and 8%-21% in south India (contact-lens/ocular-surgery risk).",
+      "byte_quote": "P. aeruginosa is responsible for causing bacterial keratitis in 6% to 39% of the cases in the USA [116,117] and 8% to 21% in south India [116]."
+    },
+    {
+      "id": "c17",
+      "text": "P. aeruginosa accounted for 17.5% of ventilator-associated pneumonia cases and 9.26% of hospital-associated pneumonia cases.",
+      "byte_quote": "P. aeruginosa accounted for 17.5% of all cases in ventilator-associated pneumonia and 9.26% of all cases in hospital-associated pneumonia [91]."
+    },
+    {
+      "id": "c18",
+      "text": "P. aeruginosa is implicated in 0.3%-11% of community-acquired pneumonia and 2.2%-20% of healthcare-associated pneumonia.",
+      "byte_quote": "Reported percentages of P. aeruginosa implicated in community-acquired pneumonia vary from 0.3% to 11%, whereas it varies from 2.2% to 20% in healthcare associated pneumonia [150,151]."
+    },
+    {
+      "id": "c19",
+      "text": "Hospitalized P. aeruginosa UTI patients had 17.7% mortality at 30 days and 33.9% at 90 days.",
+      "byte_quote": "reported 17.7% mortalities at 30 days and 33.9% mortalities at 90 days [130]."
+    },
+    {
+      "id": "c20",
+      "text": "P. aeruginosa was the 3rd most common Gram-negative uropathogen, causing 7.1% of nosocomial UTIs in the Asia-Pacific region (2009-2010).",
+      "byte_quote": "P. aeruginosa was found to be the third most common Gram-negative pathogen causing 7.1% of all nosocomial urinary tract infections in surveillance studies from the Asia-Pacific region in 2009 to 2010 [128]."
+    }
+  ],
+  "cites": [
+    "Wisplinghoff et al. (nationwide nosocomial BSI surveillance, USA) — ref [89]",
+    "Gudiol et al. (retrospective P. aeruginosa BSI in neutropenic oncohematological patients, Jan 2006–May 2018) — ref [95]",
+    "Hidron et al. (NHSN/CDC HAI ranking report 2006–2007) — ref [66]",
+    "Weber et al. (ventilator- vs hospital-associated pneumonia proportions) — ref [91]",
+    "Prakash et al. (31.78% MDR P. aeruginosa in Indian hospitals) — ref [9]",
+    "Bitsori et al. (P. aeruginosa vs E. coli UTI in children) — ref [129]",
+    "Kwok et al. (non-CF bronchiectasis colonization cohort, 2018) — ref [154]",
+    "Shobha et al. (107 urine samples 2015–2016; UTI in males, age >60) — ref [131]",
+    "National REA-RAISIN surveillance 2004–2006 (P. aeruginosa most common pneumonia cause, 25%) — ref [133]",
+    "CDC Antibiotic Resistance Threats in the US 2019 (32,600 cases; 2,700 deaths; $767M) — ref [65]",
+    "IDSA guidance document on DTR P. aeruginosa, Sept 17, 2020 — ref [51]",
+    "WHO 2017 priority pathogens list (carbapenem-resistant P. aeruginosa, Critical) — ref [45/51]"
+  ]
+}

--- a/code/specs/data/mycin-2026/cas/sources/e7d7522b70b9e38b.json
+++ b/code/specs/data/mycin-2026/cas/sources/e7d7522b70b9e38b.json
@@ -1,0 +1,77 @@
+{
+  "hash": "e7d7522b70b9e38b",
+  "source_id": "https://www.cambridge.org/core/journals/epidemiology-and-infection/article/burden-of-communityonset-bloodstream-infection-a-populationbased-assessment/4C3033D11C42B1D2B68B3580C283DB9A",
+  "title": "The burden of community-onset bloodstream infection: a population-based assessment (Epidemiology and Infection)",
+  "resolved_url": "https://www.cambridge.org/core/journals/epidemiology-and-infection/article/burden-of-communityonset-bloodstream-infection-a-populationbased-assessment/4C3033D11C42B1D2B68B3580C283DB9A",
+  "claims": [
+    {
+      "id": "c1",
+      "text": "The three species E. coli, S. aureus, and Str. pneumoniae cause the majority of community-onset bloodstream infections.",
+      "byte_quote": "the three species _Escherichia coli_, _Staphyloccocus_ (_S_.) _aureus_, and _Streptococcus_ (_Str_.) _pneumoniae_ were responsible for the majority of cases"
+    },
+    {
+      "id": "c2",
+      "text": "Overall, E. coli accounted for 30%, S. aureus 16%, and Str. pneumoniae 12% of community-onset BSI cases.",
+      "byte_quote": "_Escherichia coli_ (30%), _S. aureus_ (16%), and _Str. pneumoniae_ (12%) were the most important agents"
+    },
+    {
+      "id": "c3",
+      "text": "Organism proportions vary by age band: in <1yr E. coli/S. aureus/Str. pneumoniae were 35%/9%/19%; in 1-19yr 11%/17%/33%; in 20-64yr 29%/17%/13%; in >=65yr 34%/15%/7%.",
+      "byte_quote": "_E. coli_, _S. aureus_, and _Str. pneumoniae_ were responsible for 35%, 9%, and 19% of infections in those aged <1 year, 11%, 17%, and 33% in those aged 1–19 years, 29%, 17%, and 13% in thoase aged 20–64, and 34%, 15%, and 7% in those aged ⩾65 years"
+    },
+    {
+      "id": "c4",
+      "text": "Isolate counts: E. coli 1414, S. aureus 737, Str. pneumoniae 552 isolates.",
+      "byte_quote": "_Escherichia coli_ (1414 isolates), _Staphylococcus aureus_ (737 isolates), and _Streptococcus pneumoniae_ (552 isolates) were responsible for the majority of cases"
+    },
+    {
+      "id": "c5",
+      "text": "Age and gender strongly affect incidence: the very young and the elderly are at highest risk.",
+      "byte_quote": "there was a dramatic relationship observed between age and gender and the incidence of community-onset BSI with the very young and the elderly at highest risk"
+    },
+    {
+      "id": "c6",
+      "text": "In those aged >=60 years, men had significantly higher BSI risk than women (396.1 vs 292.5 per 100000; RR 1.35).",
+      "byte_quote": "in those aged ⩾60 years, men were at significantly higher risk compared to women (396.1 _vs_. 292.5/100 000; RR 1·35)"
+    },
+    {
+      "id": "c7",
+      "text": "Poly-microbial infections were significantly associated with older median patient age (69.9 vs 62.3 years, P<0.001).",
+      "byte_quote": "poly-microbial infections were...significantly associated with older median patient age (69·9 _vs_. 62·3 years, _P_<0·001)"
+    },
+    {
+      "id": "c8",
+      "text": "The overall annual incidence of community-onset BSI was 81.6 per 100000 population, from 4467 episodes among 4192 residents.",
+      "byte_quote": "a total of 4467 episodes of community-onset BSI were identified among 4192 CHR residents for an overall annual incidence of 81·6/100 000 population"
+    },
+    {
+      "id": "c9",
+      "text": "Case-fatality rate was 13%: among 3445 admitted episodes, 460 resulted in in-hospital death.",
+      "byte_quote": "Among the 3445 episodes of community-onset BSI that required hospital admission, 460 were associated with in-hospital death for a case-fatality rate of 13%"
+    },
+    {
+      "id": "c10",
+      "text": "Study setting: Calgary Health Region, a publicly funded health system serving over one million residents (population denominator for the population-based assessment).",
+      "byte_quote": "Calgary Health Region (CHR) is a health system that provides all medically necessary, publicly funded health care to the more than one million residents"
+    },
+    {
+      "id": "c11",
+      "text": "77% of episodes resulted in hospital admission, representing 0.7% of all admissions.",
+      "byte_quote": "77% episodes resulted in hospital admission representing 0·7% of all admissions"
+    },
+    {
+      "id": "c12",
+      "text": "Citing Pedersen et al., E. coli was the most important aetiology (605 episodes, 33%).",
+      "byte_quote": "Pedersen _et al_. also found that _E. coli_ (605 episodes, 33%) was the most important aetiology"
+    },
+    {
+      "id": "c13",
+      "text": "Citing Madsen et al., population-based surveillance found an E. coli bacteraemia incidence of ~32 per 100000.",
+      "byte_quote": "Madsen _et al_. conducted population-based surveillance...and found an incidence of _E. coli_ bacteraemia of ∼32/100 000"
+    }
+  ],
+  "cites": [
+    "Pedersen et al.",
+    "Madsen et al."
+  ]
+}

--- a/code/specs/data/mycin-2026/cas/sources/e8b0ff528d21cbcf.json
+++ b/code/specs/data/mycin-2026/cas/sources/e8b0ff528d21cbcf.json
@@ -1,0 +1,51 @@
+{
+  "hash": "e8b0ff528d21cbcf",
+  "source_id": "https://pmc.ncbi.nlm.nih.gov/articles/PMC12258469/",
+  "title": "P50 Five-year review of epidemiology of invasive group A streptococcal infections with bacteraemia in a tertiary care centre in the UK",
+  "resolved_url": "https://pmc.ncbi.nlm.nih.gov/articles/PMC12258469/",
+  "claims": [
+    {
+      "id": "c1",
+      "text": "Study reviewed blood cultures positive for Streptococcus pyogenes (GAS) at a UK tertiary care centre from 1 Jan 2019 to 31 Dec 2023.",
+      "byte_quote": "Blood culture specimens positive for Streptococcus pyogenes (GAS) at our centre from 1 January 2019 to 31 December 2023 and the respective clinical records for patients were retrospectively reviewed."
+    },
+    {
+      "id": "c2",
+      "text": "186 GAS bacteraemia cases were identified, split roughly evenly by sex (male 49.5%, female 50.5%).",
+      "byte_quote": "One hundred and eighty-six cases of GAS bacteraemias were identified and were equally distributed among male (49.5%) and female gender (50.5%)."
+    },
+    {
+      "id": "c3",
+      "text": "GAS bacteraemia rate was highest in the 61-90 year age band, then 31-50 years, then 1-10 years.",
+      "byte_quote": "The age distribution analysis indicated that the highest rate of GAS bacteraemia occurred in the age range of 61–90 years followed by 31–50 years and 1–10 years, respectively."
+    },
+    {
+      "id": "c4",
+      "text": "Among GAS isolates, 39 distinct emm types were found; emm 1.0 was most prevalent (28.5%), then emm 89.0 (6.98%) and emm 12.0 (6.45%).",
+      "byte_quote": "Thirty-nine distinct emm types were identified among study isolates and emm 1.0 was the most prevalent (28.5%), followed by emm 89.0 (6.98%) and emm 12.0 (6.45%)."
+    },
+    {
+      "id": "c5",
+      "text": "Extremes of age (infants <1 yr and elderly >90 yr) raised 30-day mortality risk, with mortality of 50% and 40% respectively.",
+      "byte_quote": "However, extremes of age was a significant risk factor for 30 day mortality: infants (<1 year) and the elderly (>90 years) had the highest mortality rates at 50% and 40%, respectively."
+    },
+    {
+      "id": "c6",
+      "text": "The commonest portal/focus of GAS bacteraemia infection was skin and soft tissue (56.45%), then respiratory tract (18.8%).",
+      "byte_quote": "The commonest focus of infection was skin and soft tissue (56.45%), followed by respiratory tract (18.8%)."
+    },
+    {
+      "id": "c7",
+      "text": "Overall 30-day mortality was ~18%, rising to 21% at 90 days, with no sex-based difference.",
+      "byte_quote": "Thirty day mortality was approximately 18%, rising to 21% at 90 days, with no sex-based difference (male 53% versus female 47%)."
+    },
+    {
+      "id": "c8",
+      "text": "The West Midlands (the centre's region) is among the UK areas with highest GAS notification rates.",
+      "byte_quote": "West Midlands—the region we serve—is highlighted as one of the areas with highest notification rates in the UK."
+    }
+  ],
+  "cites": [
+    "UK Health Security Agency. Group A Streptococcal Infections: First Update on Seasonal Activity in England, 2024 to 2025. gov.uk"
+  ]
+}

--- a/code/specs/data/mycin-2026/cas/sources/fed9287ccd687d3a.json
+++ b/code/specs/data/mycin-2026/cas/sources/fed9287ccd687d3a.json
@@ -1,0 +1,131 @@
+{
+  "hash": "fed9287ccd687d3a",
+  "source_id": "https://www.aafp.org/pubs/afp/issues/2011/1001/p771.html",
+  "title": "Diagnosis and Management of Acute Uncomplicated Cystitis (AAFP, Am Fam Physician 2011)",
+  "resolved_url": "https://www.aafp.org/pubs/afp/issues/2011/1001/p771.html",
+  "claims": [
+    {
+      "id": "c1",
+      "text": "UTIs are the most common bacterial infection in women; about half of all women have at least one UTI in their lifetime.",
+      "byte_quote": "Urinary tract infections (UTIs) are the most common bacterial infections in women, with one-half of all women experiencing at least one UTI in their lifetime."
+    },
+    {
+      "id": "c2",
+      "text": "Organism epidemiology: acute uncomplicated cystitis is caused by E. coli (86%), S. saprophyticus (4%), Klebsiella (3%), Proteus (3%), Enterobacter (1.4%), Citrobacter (0.8%), Enterococcus (0.5%).",
+      "byte_quote": "Most UTIs in women are acute uncomplicated cystitis caused by _Escherichia coli_ (86 percent), _Staphylococcus saprophyticus_ (4 percent), _Klebsiella_ species (3 percent), _Proteus_ species (3 percent), _Enterobacter_ species (1.4 percent), _Citrobacter_ species (0.8 percent), or _Enterococcus_ species (0.5 percent)."
+    },
+    {
+      "id": "c3",
+      "text": "Host definition / risk population: uncomplicated cystitis means a premenopausal, nonpregnant woman with no urologic abnormalities or comorbidities.",
+      "byte_quote": "By definition, the diagnosis of acute uncomplicated cystitis implies an uncomplicated UTI in a premenopausal, nonpregnant woman with no known urologic abnormalities or comorbidities."
+    },
+    {
+      "id": "c4",
+      "text": "Risk factors raising UTI likelihood: recent sexual intercourse, diaphragm-with-spermicide use, and recurrent UTIs.",
+      "byte_quote": "A prospective study of 796 sexually active young women identified risk factors to help diagnose UTI, including recent sexual intercourse, diaphragm use with spermicide, and recurrent UTIs."
+    },
+    {
+      "id": "c5",
+      "text": "Urinalysis: nitrites and leukocyte esterase are the most accurate dipstick indicators of cystitis in symptomatic women.",
+      "byte_quote": "Nitrites and leukocyte esterase are the most accurate indicators of acute uncomplicated cystitis in symptomatic women."
+    },
+    {
+      "id": "c6",
+      "text": "Classic lower urinary tract symptoms are dysuria, frequent small-volume voiding, and urinary urgency.",
+      "byte_quote": "Classic lower urinary tract symptoms include dysuria, frequent voiding of small volumes, and urinary urgency."
+    },
+    {
+      "id": "c7",
+      "text": "Urine culture diagnostic threshold: >= 10^3 CFU/mL of a uropathogen is diagnostic of acute uncomplicated cystitis.",
+      "byte_quote": "A colony count greater than or equal to 10³ colony-forming units per mL of a uropathogen is diagnostic of acute uncomplicated cystitis."
+    },
+    {
+      "id": "c8",
+      "text": "Lower culture threshold: >10^2 CFU/mL in women with typical UTI symptoms represents a positive culture.",
+      "byte_quote": "studies have shown that more than 10² colony-forming units per mL in women with typical symptoms of a UTI represent a positive culture."
+    },
+    {
+      "id": "c9",
+      "text": "Pretest probability of UTI in women is 5%, rising 10-fold to 50% with the acute onset of even one classic symptom.",
+      "byte_quote": "The pretest probability of UTI in women is 5 percent; however, when a woman presents with the acute onset of even one of the classic symptoms of acute uncomplicated cystitis, the probability of infection rises 10-fold to 50 percent."
+    },
+    {
+      "id": "c10",
+      "text": "New-onset frequency and dysuria without vaginal discharge/irritation has a 90% positive predictive value for UTI.",
+      "byte_quote": "The new onset of frequency and dysuria, with the absence of vaginal discharge or irritation, has a positive predictive value of 90 percent for UTI."
+    },
+    {
+      "id": "c11",
+      "text": "First-line dosing: nitrofurantoin 100 mg twice per day for five days.",
+      "byte_quote": "Nitrofurantoin at a dosage of 100 mg twice per day for five days"
+    },
+    {
+      "id": "c12",
+      "text": "First-line dosing: TMP-SMX one double-strength tablet (160/800 mg) twice per day for three days, only where community uropathogen resistance does not exceed 20%.",
+      "byte_quote": "trimethoprim/sulfamethoxazole (Bactrim, Septra) at a dosage of one double-strength tablet (160/800 mg) twice per day for three days in regions where the prevalence of resistance of community uropathogens does not exceed 20 percent"
+    },
+    {
+      "id": "c13",
+      "text": "First-line dosing: fosfomycin a single 3 g dose.",
+      "byte_quote": "Fosfomycin at a single dose of 3 g"
+    },
+    {
+      "id": "c14",
+      "text": "Fluoroquinolones (ofloxacin, ciprofloxacin, levofloxacin) are second-tier antimicrobials for cystitis.",
+      "byte_quote": "Fluoroquinolones (i.e., ofloxacin, ciprofloxacin [Cipro], and levofloxacin [Levaquin]) are considered second-tier antimicrobials"
+    },
+    {
+      "id": "c15",
+      "text": "Fluoroquinolone dosing: ciprofloxacin 250 mg twice daily x3 days; Cipro XR 500 mg/day x3; levofloxacin 250 mg/day x3; ofloxacin 200 mg/day x3 or 400 mg single dose.",
+      "byte_quote": "Ciprofloxacin (Cipro): 250 mg twice per day for three days"
+    },
+    {
+      "id": "c16",
+      "text": "Beta-lactam (third-tier) dosing: amoxicillin/clavulanate 500/125 mg twice daily x7 days; cefdinir 300 mg twice daily x10 days; cefpodoxime 100 mg twice daily x7 days.",
+      "byte_quote": "Amoxicillin/clavulanate (Augmentin): 500/125 mg twice per day for seven days"
+    },
+    {
+      "id": "c17",
+      "text": "Beta-lactams are not recommended first-line for cystitis due to E. coli resistance above 20%.",
+      "byte_quote": "Beta-lactam antibiotics are not recommended as first-line therapy for acute uncomplicated cystitis because of widespread _E. coli_ resistance rates above 20 percent."
+    },
+    {
+      "id": "c18",
+      "text": "Fluoroquinolones should be reserved (collateral-damage concern) for more serious infections than uncomplicated cystitis.",
+      "byte_quote": "Although fluoroquinolones are effective, they have the propensity for collateral damage, and should be considered for patients with more serious infections than acute uncomplicated cystitis."
+    },
+    {
+      "id": "c19",
+      "text": "To preserve effectiveness, fluoroquinolones are not recommended as a first-tier option.",
+      "byte_quote": "To preserve the effectiveness of fluoroquinolones, they are not recommended as a first-tier option."
+    },
+    {
+      "id": "c20",
+      "text": "Resistance risk factor: TMP-SMX use in the prior 3-6 months is an independent risk factor for resistance.",
+      "byte_quote": "Use of trimethoprim/sulfamethoxazole in the preceding three to six months has been found to be an independent risk factor for resistance."
+    },
+    {
+      "id": "c21",
+      "text": "Pregnancy categories (Table 2): fosfomycin B, nitrofurantoin B, TMP-SMX C, fluoroquinolones C.",
+      "byte_quote": "Fosfomycin: \"B\""
+    },
+    {
+      "id": "c22",
+      "text": "Pyelonephritis should be suspected if the patient is ill-appearing/uncomfortable, especially with fever, tachycardia, or costovertebral angle tenderness.",
+      "byte_quote": "Acute pyelonephritis should be suspected if the patient is ill-appearing and seems uncomfortable, particularly if she has concomitant fever, tachycardia, or costovertebral angle tenderness."
+    },
+    {
+      "id": "c23",
+      "text": "Urine cultures are recommended only for suspected pyelonephritis, non-resolving/recurrent symptoms within 2-4 weeks, or atypical presentation.",
+      "byte_quote": "Urine cultures are recommended only for patients with suspected acute pyelonephritis; patients with symptoms that do not resolve or that recur within two to four weeks after the completion of treatment; and patients who present with atypical symptoms."
+    },
+    {
+      "id": "c24",
+      "text": "Women with prior acute uncomplicated cystitis are usually accurate in self-diagnosing recurrence.",
+      "byte_quote": "Women who have had acute uncomplicated cystitis previously are usually accurate in determining when they are having another episode."
+    }
+  ],
+  "cites": [
+    "Gupta K, Hooton TM, Naber KG, et al. International clinical practice guidelines for the treatment of acute uncomplicated cystitis and pyelonephritis in women: a 2010 update by the Infectious Diseases Society of America and the European Society for Microbiology and Infectious Diseases. Clin Infect Dis. 2011;52(5):e103-e120."
+  ]
+}

--- a/code/specs/data/mycin-2026/grounding/DECOMPOSE-FINDINGS.md
+++ b/code/specs/data/mycin-2026/grounding/DECOMPOSE-FINDINGS.md
@@ -1,0 +1,43 @@
+# Source decomposition — pending citations cleared, fix-up frontier surfaced
+
+The recursion behind "nothing on blind trust" is now **complete for the current corpus**:
+every source any grounded fact cites has been fetched, decomposed into byte-provenanced
+claims, and committed to the CAS, and every citation is checked against its *independently*
+decomposed source.
+
+- **62 source objects · 673 byte-provenanced claims** in `cas/sources/`.
+- Citation verification: **36 fully verified · 4 core-verified (composite over-reach) ·
+  31 unverified · 0 pending.**
+
+## The check did its job: 12 grounded facts cite a span not in the independent decomposition
+
+A citation is only fully trustworthy if the fact's byte-quote appears in the source as an
+*independent* reader decomposed it — not just as it looked on the live page when grounded
+(a quote can be cherry-picked or a different sentence than the decomposer captured). Of the
+**44 grounded (ACCEPT) facts, 32 verbatim/core-verify; 12 do not** — these are the fix-up
+frontier (the FLAG facts that don't verify are expected and already untrusted):
+
+`host_neonate_gnb` · `dose_cefepime` · `dose_meropenem` · `uti_prior_saprophyticus` ·
+`uti_prior_pseudomonas` · `uti_prior_gbs` · `uti_finding_urease_proteus` ·
+`ci_tmpsmx_pregnancy` · `ci_vancomycin_renal_dose` · `bsi_prior_spneumoniae` ·
+`bsi_prior_pseudomonas` · `src_skin_saureus`
+
+These split into two modes (the fix differs):
+
+1. **Different sentence, same fact (corroborated).** The grounding cited one verbatim span;
+   the independent decomposition captured a *different* span stating the same fact (e.g.
+   `host_neonate_gnb` — Merck's "Key Points" summary vs the body "predominant pathogens" list;
+   the same source independently lists E. coli for neonates). The fact IS supported — just not
+   by the *same* sentence. Fix: accept at the entailment tier, or re-point the citation at the
+   decomposed span.
+2. **Genuinely cherry-picked / over-reached.** The decomposed source does not state the fact
+   as cited (often a value from a different population/indication than the source's headline
+   figure). Fix: re-ground from a source that states it, or demote the verdict to
+   `direction_only` (FLAG) — never keep ACCEPT for a citation the independent reading can't
+   confirm.
+
+**Next iteration (fix-up pass):** for each of the 12, run a content-corroboration re-check
+(does the decomposed source contain a claim about the same organism/value?) → mode 1 re-points
+the citation, mode 2 demotes to FLAG + queues re-grounding. The honest invariant to add: a
+fact is ACCEPT only if its citation verifies (verbatim or core) against the *decomposed*
+source, not merely byte-stable on the live page at grounding time.

--- a/code/specs/data/mycin-2026/grounding/source-list.json
+++ b/code/specs/data/mycin-2026/grounding/source-list.json
@@ -59,6 +59,256 @@
       "source_id": "https://www.ncbi.nlm.nih.gov/books/NBK470553/",
       "resolved_url": "https://www.ncbi.nlm.nih.gov/books/NBK470553/",
       "title": "Gram-Positive Bacteria — StatPearls, NCBI Bookshelf (NIH)"
+    },
+    {
+      "source_id": "https://pmc.ncbi.nlm.nih.gov/articles/PMC6508726/",
+      "resolved_url": "https://pmc.ncbi.nlm.nih.gov/articles/PMC6508726/",
+      "title": "Disease burden of neonatal invasive Group B Streptococcus infection in the Netherlands (PLOS One, PMC6508726)"
+    },
+    {
+      "source_id": "https://www.merckmanuals.com/professional/pediatrics/infections-in-neonates/neonatal-bacterial-meningitis",
+      "resolved_url": "https://www.merckmanuals.com/professional/pediatrics/infections-in-neonates/neonatal-bacterial-meningitis",
+      "title": "Neonatal Bacterial Meningitis — Merck Manual Professional Edition (Pediatrics, Infections in Neonates)"
+    },
+    {
+      "source_id": "https://pmc.ncbi.nlm.nih.gov/articles/PMC5121369/",
+      "resolved_url": "https://pmc.ncbi.nlm.nih.gov/articles/PMC5121369/",
+      "title": "The Brief Case: Neonatal Meningitis Caused by Listeria monocytogenes Diagnosed by Multiplex Molecular Panel (Journal of "
+    },
+    {
+      "source_id": "https://pmc.ncbi.nlm.nih.gov/articles/PMC2995464/",
+      "resolved_url": "https://pmc.ncbi.nlm.nih.gov/articles/PMC2995464/",
+      "title": "Three-year multicenter surveillance of community-acquired Listeria monocytogenes meningitis in adults (BMC Infectious Di"
+    },
+    {
+      "source_id": "https://pubmed.ncbi.nlm.nih.gov/23446215/",
+      "resolved_url": "https://pubmed.ncbi.nlm.nih.gov/23446215/",
+      "title": "The spectrum of acute bacterial meningitis in elderly patients (BMC Infectious Diseases, PMID 23446215)"
+    },
+    {
+      "source_id": "https://www.ncbi.nlm.nih.gov/books/NBK549849/",
+      "resolved_url": "https://www.ncbi.nlm.nih.gov/books/NBK549849/",
+      "title": "Meningococcal Disease (Neisseria meningitidis Infection) — StatPearls, NCBI Bookshelf"
+    },
+    {
+      "source_id": "https://pmc.ncbi.nlm.nih.gov/articles/PMC5405091/",
+      "resolved_url": "https://pmc.ncbi.nlm.nih.gov/articles/PMC5405091/",
+      "title": "Bacterial Meningitis in Patients using Immunosuppressive Medication: a Population-based Prospective Nationwide Study"
+    },
+    {
+      "source_id": "https://pubmed.ncbi.nlm.nih.gov/16451418/",
+      "resolved_url": "https://pubmed.ncbi.nlm.nih.gov/16451418/",
+      "title": "Adults with spontaneous aerobic Gram-negative bacillary meningitis admitted to the intensive care unit (Clinical Microbi"
+    },
+    {
+      "source_id": "https://www.who.int/news-room/fact-sheets/detail/listeriosis",
+      "resolved_url": "https://www.who.int/news-room/fact-sheets/detail/listeriosis",
+      "title": "Listeriosis — WHO (World Health Organization) Fact Sheet"
+    },
+    {
+      "source_id": "https://pmc.ncbi.nlm.nih.gov/articles/PMC3372798/",
+      "resolved_url": "https://pmc.ncbi.nlm.nih.gov/articles/PMC3372798/",
+      "title": "Nosocomial Meningitis: Moving beyond Description to Prevention (Hong Bin Kim), Clinical Infectious Diseases / PMC"
+    },
+    {
+      "source_id": "https://academic.oup.com/cid/article/64/6/e34/2996079",
+      "resolved_url": "https://academic.oup.com/cid/article/64/6/e34/2996079",
+      "title": "2017 Infectious Diseases Society of America's Clinical Practice Guidelines for Healthcare-Associated Ventriculitis and M"
+    },
+    {
+      "source_id": "https://www.cdc.gov/mmwr/preview/mmwrhtml/rr4907a2.htm",
+      "resolved_url": "https://www.cdc.gov/mmwr/preview/mmwrhtml/rr4907a2.htm",
+      "title": "Meningococcal Disease and College Students — Recommendations of the Advisory Committee on Immunization Practices (ACIP),"
+    },
+    {
+      "source_id": "https://pmc.ncbi.nlm.nih.gov/articles/PMC3719428/",
+      "resolved_url": "https://pmc.ncbi.nlm.nih.gov/articles/PMC3719428/",
+      "title": "Skin rash in meningitis and meningoencephalitis (PMC3719428, peer-reviewed review)"
+    },
+    {
+      "source_id": "https://academic.oup.com/cid/article/39/9/1267/402080",
+      "resolved_url": "https://academic.oup.com/cid/article/39/9/1267/402080",
+      "title": "Tunkel AR et al. Practice Guidelines for the Management of Bacterial Meningitis. Clinical Infectious Diseases 2004;39(9)"
+    },
+    {
+      "source_id": "https://dailymed.nlm.nih.gov/dailymed/fda/fdaDrugXsl.cfm?setid=8351aa37-552d-471d-b293-c564dcb6ec29",
+      "resolved_url": "https://dailymed.nlm.nih.gov/dailymed/fda/fdaDrugXsl.cfm?setid=8351aa37-552d-471d-b293-c564dcb6ec29",
+      "title": "CEFTRIAXONE FOR INJECTION, USP — FDA prescribing information (DailyMed / NLM)"
+    },
+    {
+      "source_id": "https://pmc.ncbi.nlm.nih.gov/articles/PMC2760093/",
+      "resolved_url": "https://pmc.ncbi.nlm.nih.gov/articles/PMC2760093/",
+      "title": "Kim BN, Peleg AY, Lodise TP, Lipman J, Li J, Nation R, Paterson DL. Management of meningitis due to antibiotic-resistant"
+    },
+    {
+      "source_id": "https://www.academia.edu/1171456/Initial_management_of_acute_bacterial_meningitis_in_adults_summary_of_IDSA_guidelines",
+      "resolved_url": "https://www.academia.edu/1171456/Initial_management_of_acute_bacterial_meningitis_in_adults_summary_of_IDSA_guidelines",
+      "title": "Initial management of acute bacterial meningitis in adults: summary of IDSA guidelines (Tunkel et al., IDSA Practice Gui"
+    },
+    {
+      "source_id": "https://dailymed.nlm.nih.gov/dailymed/fda/fdaDrugXsl.cfm?setid=7d74dfa6-0468-43ad-ad7f-dd90d9ae7706",
+      "resolved_url": "https://dailymed.nlm.nih.gov/dailymed/fda/fdaDrugXsl.cfm?setid=7d74dfa6-0468-43ad-ad7f-dd90d9ae7706",
+      "title": "AVELOX (moxifloxacin hydrochloride) FDA Prescribing Information — DailyMed (NLM mirror of the FDA-approved label)"
+    },
+    {
+      "source_id": "https://dailymed.nlm.nih.gov/dailymed/fda/fdaDrugXsl.cfm?setid=9a105eaf-ee77-4016-beeb-d425a5565db2&type=display",
+      "resolved_url": "https://dailymed.nlm.nih.gov/dailymed/fda/fdaDrugXsl.cfm?setid=9a105eaf-ee77-4016-beeb-d425a5565db2&type=display",
+      "title": "AZACTAM (aztreonam for injection, USP) — FDA prescribing information, DailyMed"
+    },
+    {
+      "source_id": "https://academic.oup.com/cid/article/52/5/e103/388285",
+      "resolved_url": "https://academic.oup.com/cid/article/52/5/e103/388285",
+      "title": "International Clinical Practice Guidelines for the Treatment of Acute Uncomplicated Cystitis and Pyelonephritis in Women"
+    },
+    {
+      "source_id": "https://www.ncbi.nlm.nih.gov/books/NBK482367/",
+      "resolved_url": "https://www.ncbi.nlm.nih.gov/books/NBK482367/",
+      "title": "Staphylococcus saprophyticus Infection — StatPearls, NCBI Bookshelf"
+    },
+    {
+      "source_id": "https://pmc.ncbi.nlm.nih.gov/articles/PMC5644167/",
+      "resolved_url": "https://pmc.ncbi.nlm.nih.gov/articles/PMC5644167/",
+      "title": "Local epidemiology and resistance profiles in acute uncomplicated cystitis (AUC) in women: a prospective cohort study in"
+    },
+    {
+      "source_id": "https://www.aafp.org/pubs/afp/issues/2011/1001/p771.html",
+      "resolved_url": "https://www.aafp.org/pubs/afp/issues/2011/1001/p771.html",
+      "title": "Diagnosis and Treatment of Acute Uncomplicated Cystitis — American Family Physician (AAFP), 2011"
+    },
+    {
+      "source_id": "https://pubmed.ncbi.nlm.nih.gov/15701325/",
+      "resolved_url": "https://pubmed.ncbi.nlm.nih.gov/15701325/",
+      "title": "Etiology and antimicrobial susceptibility among uropathogens causing community-acquired lower urinary tract infections: "
+    },
+    {
+      "source_id": "https://pmc.ncbi.nlm.nih.gov/articles/PMC10031580/",
+      "resolved_url": "https://pmc.ncbi.nlm.nih.gov/articles/PMC10031580/",
+      "title": "Bacterial species and antimicrobial resistance differ between catheter and non–catheter-associated urinary tract infecti"
+    },
+    {
+      "source_id": "https://pmc.ncbi.nlm.nih.gov/articles/PMC2708523/",
+      "resolved_url": "https://pmc.ncbi.nlm.nih.gov/articles/PMC2708523/",
+      "title": "Diversity of Group B Streptococcus Serotypes Causing Urinary Tract Infection in Adults (Journal of Clinical Microbiology"
+    },
+    {
+      "source_id": "https://pmc.ncbi.nlm.nih.gov/articles/PMC12217021/",
+      "resolved_url": "https://pmc.ncbi.nlm.nih.gov/articles/PMC12217021/",
+      "title": "Feasibility of serial measurement of nitrite for pharmacodynamic monitoring and precision prescribing in urinary tract i"
+    },
+    {
+      "source_id": "https://pubmed.ncbi.nlm.nih.gov/6696301/",
+      "resolved_url": "https://pubmed.ncbi.nlm.nih.gov/6696301/",
+      "title": "Measurement of urinary leukocyte esterase activity: a screening test for urinary tract infections (PubMed, PMID 6696301)"
+    },
+    {
+      "source_id": "https://pmc.ncbi.nlm.nih.gov/articles/PMC5880328/",
+      "resolved_url": "https://pmc.ncbi.nlm.nih.gov/articles/PMC5880328/",
+      "title": "Pathogenesis of Proteus mirabilis Infection (Armbruster CE, Mobley HLT, Pearson MM. EcoSal Plus, 2018 Feb 8;8(1):10.1128"
+    },
+    {
+      "source_id": "https://www.cdc.gov/std/treatment-guidelines/penicillin-allergy.htm",
+      "resolved_url": "https://www.cdc.gov/std/treatment-guidelines/penicillin-allergy.htm",
+      "title": "Penicillin Allergy — CDC STI Treatment Guidelines, 2021"
+    },
+    {
+      "source_id": "https://dailymed.nlm.nih.gov/dailymed/drugInfo.cfm?setid=3c442cca-47f5-48e5-b718-c09413911687",
+      "resolved_url": "https://dailymed.nlm.nih.gov/dailymed/drugInfo.cfm?setid=3c442cca-47f5-48e5-b718-c09413911687",
+      "title": "DailyMed — MOXIFLOXACIN HYDROCHLORIDE tablet (FDA Prescribing Information), Section 8.1 Pregnancy / Risk Summary"
+    },
+    {
+      "source_id": "https://dailymed.nlm.nih.gov/dailymed/lookup.cfm?setid=793c75eb-dd65-4b6d-ac46-6e57ce1334f7",
+      "resolved_url": "https://dailymed.nlm.nih.gov/dailymed/lookup.cfm?setid=793c75eb-dd65-4b6d-ac46-6e57ce1334f7",
+      "title": "DailyMed — SULFAMETHOXAZOLE AND TRIMETHOPRIM injection (FDA prescribing information / drug label)"
+    },
+    {
+      "source_id": "https://dailymed.nlm.nih.gov/dailymed/drugInfo.cfm?setid=65e5f2ee-934c-40d7-967c-00d085f84ffd",
+      "resolved_url": "https://dailymed.nlm.nih.gov/dailymed/drugInfo.cfm?setid=65e5f2ee-934c-40d7-967c-00d085f84ffd",
+      "title": "DailyMed — VANCOMYCIN HYDROCHLORIDE injection, powder, lyophilized, for solution (FDA prescribing information)"
+    },
+    {
+      "source_id": "https://dailymed.nlm.nih.gov/dailymed/fda/fdaDrugXsl.cfm?setid=f604d399-fded-4f4f-8efe-af558ed07b9d",
+      "resolved_url": "https://dailymed.nlm.nih.gov/dailymed/fda/fdaDrugXsl.cfm?setid=f604d399-fded-4f4f-8efe-af558ed07b9d",
+      "title": "VANCOMYCIN HYDROCHLORIDE injection, powder, lyophilized, for solution — FDA label (DailyMed)"
+    },
+    {
+      "source_id": "https://dailymed.nlm.nih.gov/dailymed/fda/fdaDrugXsl.cfm?setid=99e523d8-9bde-43cb-8434-497015e5dcbd",
+      "resolved_url": "https://dailymed.nlm.nih.gov/dailymed/fda/fdaDrugXsl.cfm?setid=99e523d8-9bde-43cb-8434-497015e5dcbd",
+      "title": "VANCOMYCIN injection, for intravenous use — FDA Prescribing Information (DailyMed, U.S. National Library of Medicine)"
+    },
+    {
+      "source_id": "https://pubmed.ncbi.nlm.nih.gov/15306996/",
+      "resolved_url": "https://pubmed.ncbi.nlm.nih.gov/15306996/",
+      "title": "Wisplinghoff et al., \"Nosocomial bloodstream infections in US hospitals: analysis of 24,179 cases from a prospective nat"
+    },
+    {
+      "source_id": "https://pmc.ncbi.nlm.nih.gov/articles/PMC8785473/",
+      "resolved_url": "https://pmc.ncbi.nlm.nih.gov/articles/PMC8785473/",
+      "title": "Blood bacterial resistant investigation collaborative system (BRICS) report: a national surveillance in China from 2014 "
+    },
+    {
+      "source_id": "https://www.cambridge.org/core/journals/epidemiology-and-infection/article/burden-of-communityonset-bloodstream-infection-a-populationbased-assessment/4C3033D11C42B1D2B68B3580C283DB9A",
+      "resolved_url": "https://www.cambridge.org/core/journals/epidemiology-and-infection/article/burden-of-communityonset-bloodstream-infection-a-populationbased-assessment/4C3033D11C42B1D2B68B3580C283DB9A",
+      "title": "Burden of community-onset bloodstream infection: a population-based assessment (Laupland et al., Epidemiology & Infectio"
+    },
+    {
+      "source_id": "https://pmc.ncbi.nlm.nih.gov/articles/PMC10699684/",
+      "resolved_url": "https://pmc.ncbi.nlm.nih.gov/articles/PMC10699684/",
+      "title": "Pseudomonas aeruginosa: Infections and novel approaches to treatment \"Knowing the enemy\" the threat of Pseudomonas aerug"
+    },
+    {
+      "source_id": "https://pubmed.ncbi.nlm.nih.gov/3284952/",
+      "resolved_url": "https://pubmed.ncbi.nlm.nih.gov/3284952/",
+      "title": "Streptococcus pyogenes bacteraemia: an old enemy subdued, but not defeated (J Infect)"
+    },
+    {
+      "source_id": "https://pmc.ncbi.nlm.nih.gov/articles/PMC10350481/",
+      "resolved_url": "https://pmc.ncbi.nlm.nih.gov/articles/PMC10350481/",
+      "title": "Epidemiology of Gram-Negative Bloodstream Infections in the United States: Results From a Cohort of 24 Hospitals (Open F"
+    },
+    {
+      "source_id": "https://www.ncbi.nlm.nih.gov/books/NBK430891/",
+      "resolved_url": "https://www.ncbi.nlm.nih.gov/books/NBK430891/",
+      "title": "Central Line–Associated Blood Stream Infections — StatPearls, NCBI Bookshelf (peer-reviewed clinical reference)"
+    },
+    {
+      "source_id": "https://academic.oup.com/cid/article/49/1/1/369414",
+      "resolved_url": "https://academic.oup.com/cid/article/49/1/1/369414",
+      "title": "Clinical Practice Guidelines for the Diagnosis and Management of Intravascular Catheter-Related Infection: 2009 Update b"
+    },
+    {
+      "source_id": "https://academic.oup.com/cid/article/72/7/1211/5836974",
+      "resolved_url": "https://academic.oup.com/cid/article/72/7/1211/5836974",
+      "title": "Epidemiology of Escherichia coli Bacteremia: A Systematic Literature Review (Clinical Infectious Diseases, Vol. 72, Issu"
+    },
+    {
+      "source_id": "https://pmc.ncbi.nlm.nih.gov/articles/PMC12902366/",
+      "resolved_url": "https://pmc.ncbi.nlm.nih.gov/articles/PMC12902366/",
+      "title": "Clinical Emergence of Bacteroides-Associated Anaerobic Bacteremia Due to Drug-Resistant Non-Bacteroides fragilis Species"
+    },
+    {
+      "source_id": "https://pmc.ncbi.nlm.nih.gov/articles/PMC4451395/",
+      "resolved_url": "https://pmc.ncbi.nlm.nih.gov/articles/PMC4451395/",
+      "title": "Staphylococcus aureus Infections: Epidemiology, Pathophysiology, Clinical Manifestations, and Management (Tong et al., C"
+    },
+    {
+      "source_id": "https://pmc.ncbi.nlm.nih.gov/articles/PMC12258469/",
+      "resolved_url": "https://pmc.ncbi.nlm.nih.gov/articles/PMC12258469/",
+      "title": "Five-year review of epidemiology of invasive group A streptococcal infections with bacteraemia in a tertiary care centre"
+    },
+    {
+      "source_id": "https://pmc.ncbi.nlm.nih.gov/articles/PMC3892635/",
+      "resolved_url": "https://pmc.ncbi.nlm.nih.gov/articles/PMC3892635/",
+      "title": "Streptococcus pneumoniae bacteremia: clinical and microbiological epidemiology in a health area of Southern Spain (PMC38"
+    },
+    {
+      "source_id": "https://pubmed.ncbi.nlm.nih.gov/18691485/",
+      "resolved_url": "https://pubmed.ncbi.nlm.nih.gov/18691485/",
+      "title": "Cheong HS, et al. \"Clinical significance and predictors of community-onset Pseudomonas aeruginosa bacteremia.\" The Ameri"
+    },
+    {
+      "source_id": "https://www.ebi.ac.uk/europepmc/webservices/rest/PMC1584240/fullTextXML",
+      "resolved_url": "https://www.ebi.ac.uk/europepmc/webservices/rest/PMC1584240/fullTextXML",
+      "title": "Clinical manifestations and outcome in Staphylococcus aureus endocarditis among injection drug users and nonaddicts: a p"
     }
   ]
 }

--- a/code/specs/data/mycin-2026/grounding/source-objects.json
+++ b/code/specs/data/mycin-2026/grounding/source-objects.json
@@ -1492,5 +1492,2526 @@
       }
     ],
     "cites": []
+  },
+  {
+    "source_id": "https://academic.oup.com/cid/article/52/5/e103/388285",
+    "resolved_url": "https://academic.oup.com/cid/article/52/5/e103/388285",
+    "title": "International Clinical Practice Guidelines for the Treatment of Acute Uncomplicated Cystitis and Pyelonephritis in Women: A 2010 Update by the Infectious Diseases Society of America and the European Society for Microbiology and Infectious Diseases",
+    "claims": [
+      {
+        "id": "c1",
+        "text": "UTI (uncomplicated cystitis and pyelonephritis) organism epidemiology: E. coli accounts for 75%-95%, with occasional other Enterobacteriaceae (Proteus mirabilis, Klebsiella pneumoniae) and Staphylococcus saprophyticus.",
+        "byte_quote": "The microbial spectrum of uncomplicated cystitis and pyelonephritis consists mainly of Escherichia coli (75%–95%)"
+      },
+      {
+        "id": "c2",
+        "text": "Host/population scope: the diagnoses are limited to premenopausal, nonpregnant women with no known urological abnormalities or comorbidities (defines the host band; excludes pregnancy and structural/comorbid complications).",
+        "byte_quote": "diagnoses limited in these guidelines to premenopausal, nonpregnant women with no known urological abnormalities or comorbidities"
+      },
+      {
+        "id": "c3",
+        "text": "Risk factor for TMP-SMX resistance: use of trimethoprim-sulfamethoxazole in the preceding 3-6 months independently raises the risk of TMP-SMX-resistant organisms.",
+        "byte_quote": "the use of trimethoprim-sulfamethoxazole in the preceding 3–6 months was an independent risk factor for trimethoprim-sulfamethoxazole resistance"
+      },
+      {
+        "id": "c4",
+        "text": "Resistance threshold: 20% local resistance prevalence is the cutoff above which an agent is no longer recommended for empirical treatment of acute cystitis (expert-opinion based).",
+        "byte_quote": "The threshold of 20% as the resistance prevalence at which the agent is no longer recommended for empirical treatment of acute cystitis is based on expert opinion"
+      },
+      {
+        "id": "c5",
+        "text": "Fluoroquinolone stewardship/contraindication-by-collateral-damage: fluoroquinolones have a propensity for collateral damage and should be reserved for uses other than acute cystitis.",
+        "byte_quote": "fluoroquinolones...have a propensity for collateral damage and should be reserved for important uses other than acute cystitis"
+      },
+      {
+        "id": "c6",
+        "text": "Antibiotic dosing (cystitis): nitrofurantoin monohydrate/macrocrystals 100 mg twice daily for 5 days.",
+        "byte_quote": "Nitrofurantoin monohydrate/macrocrystals (100 mg twice daily for 5 days)"
+      },
+      {
+        "id": "c7",
+        "text": "Antibiotic dosing (cystitis): trimethoprim-sulfamethoxazole 160/800 mg (1 double-strength tablet) twice daily for 3 days.",
+        "byte_quote": "Trimethoprim-sulfamethoxazole (160/800 mg [1 double-strength tablet] twice-daily for 3 days)"
+      },
+      {
+        "id": "c8",
+        "text": "Antibiotic dosing (cystitis): fosfomycin trometamol 3 g as a single dose.",
+        "byte_quote": "Fosfomycin trometamol (3 g in a single dose)"
+      },
+      {
+        "id": "c9",
+        "text": "Antibiotic dosing (cystitis): pivmecillinam 400 mg twice daily for 3-7 days.",
+        "byte_quote": "Pivmecillinam (400 mg bid for 3–7 days)"
+      },
+      {
+        "id": "c10",
+        "text": "Antibiotic dosing (pyelonephritis): oral ciprofloxacin 500 mg twice daily for 7 days.",
+        "byte_quote": "Oral ciprofloxacin (500 mg twice daily) for 7 days"
+      },
+      {
+        "id": "c11",
+        "text": "Antibiotic dosing (pyelonephritis): oral trimethoprim-sulfamethoxazole 160/800 mg (1 double-strength tablet) twice daily for 14 days (longer interval than cystitis indication).",
+        "byte_quote": "Oral trimethoprim-sulfamethoxazole (160/800 mg [1 double-strength tablet] twice-daily for 14 days)"
+      },
+      {
+        "id": "c12",
+        "text": "Antibiotic dosing (pyelonephritis): levofloxacin 750 mg for 5 days.",
+        "byte_quote": "Levofloxacin (750 mg for 5 days)"
+      }
+    ],
+    "cites": [
+      "IDSA/ESCMID UTI guideline ref [8-11] (four large studies on E. coli antimicrobial susceptibility patterns)",
+      "IDSA/ESCMID UTI guideline ref [20-21] (basis for 20% TMP-SMX resistance empirical-treatment threshold)",
+      "IDSA/ESCMID UTI guideline ref [22-23] (collateral damage associated with cephalosporins and fluoroquinolones)",
+      "IDSA/ESCMID UTI guideline ref [28-29] (placebo-arm spontaneous cure rates 25%-42% in cystitis)"
+    ]
+  },
+  {
+    "source_id": "https://www.ncbi.nlm.nih.gov/books/NBK482367/",
+    "resolved_url": "https://www.ncbi.nlm.nih.gov/books/NBK482367/",
+    "title": "Staphylococcus saprophyticus Infection - StatPearls - NCBI Bookshelf",
+    "claims": [
+      {
+        "id": "c1",
+        "text": "S. saprophyticus is the second most common cause of community-acquired UTIs, after E. coli.",
+        "byte_quote": "saprophyticus is the second most common cause of community-acquired urinary tract infections, after Escherichia coli"
+      },
+      {
+        "id": "c2",
+        "text": "In females ages 16 to 25, S. saprophyticus causes up to 42% of all UTIs.",
+        "byte_quote": "In females ages 16 to 25, it causes up to 42% of all infections."
+      },
+      {
+        "id": "c3",
+        "text": "Nearly half of women will have a UTI in their lifetime; in 5%-20% of non-hospitalized patients the infection is due to S. saprophyticus.",
+        "byte_quote": "Nearly half of all women will experience a UTI in their lifetime, and between 5% and 20% of non-hospitalized patients, the infection will be due to S."
+      },
+      {
+        "id": "c4",
+        "text": "Over 40% of young, sexually active women carry S. saprophyticus as part of normal genitourinary flora.",
+        "byte_quote": "Over 40% of all young, sexually active women contain S. saprophyticus as part of their normal genitourinary flora."
+      },
+      {
+        "id": "c5",
+        "text": "S. saprophyticus is a Gram-positive, coagulase-negative, non-hemolytic coccus causing uncomplicated UTIs, particularly in young sexually active females.",
+        "byte_quote": "Staphylococcus saprophyticus is a Gram-positive, coagulase-negative, non-hemolytic coccus that is a common cause of uncomplicated urinary tract infections (UTIs), particularly in young sexually active females."
+      },
+      {
+        "id": "c6",
+        "text": "General UTI risk factors: recurrent UTI history, female sex, recent intercourse, pregnancy, neurogenic bladder, indwelling catheter, benign prostatic hypertrophy.",
+        "byte_quote": "General risk factors for UTIs include the history of recurrent UTIs, female sex, recent sexual intercourse, pregnancy, neurogenic bladder, indwelling catheter, and benign prostatic hypertrophy."
+      },
+      {
+        "id": "c7",
+        "text": "Men have a lower incidence of S. saprophyticus infections.",
+        "byte_quote": "Men have a lower incidence of S. saprophyticus infections."
+      },
+      {
+        "id": "c8",
+        "text": "A complicated UTI typically involves a patient who is immunocompromised, elderly, male, pregnant, diabetic, and/or has urologic abnormalities such as indwelling catheters or kidney disease.",
+        "byte_quote": "A complicated infection typically involves a patient that is immunocompromised, elderly, male, pregnant, diabetic, and/or with urologic abnormalities such as indwelling catheters or kidney disease."
+      },
+      {
+        "id": "c9",
+        "text": "Polymicrobial infections are more likely in patients who are immunocompromised, elderly, diabetic, have indwelling catheters, HIV, and/or malignancies.",
+        "byte_quote": "Polymicrobial infections are more likely to occur in patients that are immunocompromised, elderly, those who have diabetes, have indwelling catheters, HIV, and/or malignancies."
+      },
+      {
+        "id": "c10",
+        "text": "S. saprophyticus can be differentiated from another coagulase-negative staphylococcus by its resistance to Novobiocin.",
+        "byte_quote": "saprophyticus can be differentiated from another coagulase-negative staphylococcus by its resistance to Novobiocin."
+      },
+      {
+        "id": "c11",
+        "text": "Like most gram-positive uropathogens, S. saprophyticus does not reduce nitrate to nitrite (negative urine nitrite).",
+        "byte_quote": "saprophyticus does not reduce nitrate to nitrite."
+      },
+      {
+        "id": "c12",
+        "text": "First-line for uncomplicated S. saprophyticus UTI is nitrofurantoin 100 mg orally twice daily for 5 days (7 days if complicated).",
+        "byte_quote": "saprophyticus UTIs is nitrofurantoin 100 mg orally twice daily for five days, or for seven days in complicated cases."
+      },
+      {
+        "id": "c13",
+        "text": "Alternative for uncomplicated cases: TMP-SMX 160 mg/800 mg by mouth twice daily for 3 days.",
+        "byte_quote": "Trimethoprim-sulfamethoxazole (TMP-SMX) 160 mg/800 mg by mouth twice daily for three days may be given alternatively in uncomplicated cases."
+      },
+      {
+        "id": "c14",
+        "text": "Pyridium may be given to alleviate associated dysuria.",
+        "byte_quote": "Pyridium may also be given to alleviate associated dysuria."
+      },
+      {
+        "id": "c15",
+        "text": "S. saprophyticus is resistant to antibiotic regimens commonly used and effective for E. coli UTIs, including ampicillin, ceftriaxone, cephalexin, and ciprofloxacin.",
+        "byte_quote": "saprophyticus has resistance to antibiotic regimes commonly prescribed and effective for E. coli induced UTIs, including ampicillin, ceftriaxone, cephalexin, and ciprofloxacin."
+      },
+      {
+        "id": "c16",
+        "text": "Some strains form biofilms (increasing virulence, especially with catheters); once biofilms form, antibiotic resistance is exacerbated and the organism may be vancomycin-resistant, treatable only via linezolid.",
+        "byte_quote": "Once biofilms have been produced, antibiotic resistance is exacerbated. In these cases, S. Saprophyticus may be resistant to vancomycin and only effectively treated via linezolid."
+      },
+      {
+        "id": "c17",
+        "text": "Patients with nosocomial catheterization have an increased incidence of S. saprophyticus colonization.",
+        "byte_quote": "catheterization have an increased incidence of S. saprophyticus colonization."
+      }
+    ],
+    "cites": [
+      "Argemi X, Hansmann Y, Prola K, Prévost G. Coagulase-Negative Staphylococci Pathogenomics. Int J Mol Sci. 2019;20(5)",
+      "Pinault L, Chabrière E, Raoult D, Fenollar F. Direct Identification of Pathogens in Urine by Use of a Specific MALDI-TOF Spectrum Database. J Clin Microbiol. 2019;57(4)",
+      "Natsis NE, Cohen PR. Coagulase-Negative Staphylococcus Skin and Soft Tissue Infections. Am J Clin Dermatol. 2018;19(5):671-677",
+      "Gill R, Leslie SW, Minter DA. Acute Cystitis. StatPearls. 2025",
+      "Hur J, Lee A, Hong J, Jo WY, Cho OH, Kim S, Bae IG. Staphylococcus saprophyticus Bacteremia originating from Urinary Tract Infections: A Case Report and Literature Review. Infect Chemother. 2016;48(2):136-9",
+      "Flores-Mireles AL, Walker JN, Caparon M, Hultgren SJ. Urinary tract infections: epidemiology, mechanisms of infection and treatment options. Nat Rev Microbiol. 2015;13(5):269-84",
+      "Becker K, Heilmann C, Peters G. Coagulase-negative staphylococci. Clin Microbiol Rev. 2014;27(4):870-926",
+      "Stock I. Nitrofurantoin--clinical relevance in uncomplicated urinary tract infections. Med Monatsschr Pharm. 2014;37(7):242-8",
+      "Mirone V, Franco M. Clinical aspects of antimicrobial prophylaxis for invasive urological procedures. J Chemother. 2014;26 Suppl 1:S1-S13",
+      "Stuart JI, John MA, Milburn S, Diagre D, Wilson B, Hussain Z. Susceptibility patterns of coagulase-negative staphylococci to several newer antimicrobial agents in comparison with vancomycin and oxacillin. Int J Antimicrob Agents. 2011;37(3):248-52"
+    ]
+  },
+  {
+    "source_id": "https://pmc.ncbi.nlm.nih.gov/articles/PMC5644167/",
+    "resolved_url": "https://pmc.ncbi.nlm.nih.gov/articles/PMC5644167/",
+    "title": "Local epidemiology and resistance profiles in acute uncomplicated cystitis (AUC) in women: a prospective cohort study in an urban urological ambulatory setting (Seitz et al., BMC Infect Dis. 2017)",
+    "claims": [
+      {
+        "id": "c1",
+        "text": "E. coli is by far the most common uropathogen in acute uncomplicated cystitis in women, found in more than 80% of positive urine cultures.",
+        "byte_quote": "Escherichia coli (E. coli) is still by far the most common uropathogen for acute uncomplicated cystitis (AUC) in women and is found in more than 80% of the positive urine cultures."
+      },
+      {
+        "id": "c2",
+        "text": "In this cohort the most common organism was E. coli at 86.3% (365/423), followed by Enterococcus faecalis 10.2% (43/423) and Klebsiella pneumoniae 3.5% (15/423).",
+        "byte_quote": "The most common bacteria was E. coli with 86.3% (365/423) followed by Enterococcus faecalis with 10.2% (43/423) and Klebsiella pneumoniae with 3.5% (15/423)."
+      },
+      {
+        "id": "c3",
+        "text": "Summary organism distribution: E. coli 86%, Enterococcus faecalis 10%, Klebsiella pneumoniae 4%.",
+        "byte_quote": "The most commonly detected bacteria was E. coli with 86%, followed by Enterococcus faecalis with 10% and Klebsiella pneumoniae with 4%."
+      },
+      {
+        "id": "c4",
+        "text": "E. coli was highly susceptible to fosfomycin-trometamol (99.2%), nitrofurantoin (98.1%) and cefpodoxime (92.9%).",
+        "byte_quote": "Susceptibility testing showed E. coli strains to be highly sensitive to the following oral antibiotics: fosfomycin-trometamol (99.2%), nitrofurantoin (98.1%) and cefpodoxime (92.9%)."
+      },
+      {
+        "id": "c5",
+        "text": "E. coli resistance: ciprofloxacin 15.1%, trimethoprim/sulfamethoxazole 25.2%, amoxicillin/clavulanic acid 25.2%.",
+        "byte_quote": "E. coli was resistant to ciprofloxacin in 15.1% of cases, to trimethoprim/sulfamethoxazole in 25.2% of cases and to amoxicillin/clavulanic acid in 25.2% of cases."
+      },
+      {
+        "id": "c6",
+        "text": "E. coli aminopenicillin resistance was alarming, between 25.2% and 39.7% (ampicillin, amoxicillin with sulbactam/clavulanic acid).",
+        "byte_quote": "Our data demonstrate alarming resistance rates for aminopenicillins (ampicillin, amoxicillin in combination with sulbactam and clavulanic acid, respectively) between 25.2 and 39.7%."
+      },
+      {
+        "id": "c7",
+        "text": "Fosfomycin, pivmecillinam and nitrofurantoin are first-line therapy with high evidence level (LE 1a, GR A).",
+        "byte_quote": "Fosfomycin, pivmecilliam and nitrofurantoin are considered to be first-line therapy with high levels of evidence (LE: 1a, GR: A)."
+      },
+      {
+        "id": "c8",
+        "text": "An antibiotic resistance rate below 20% suffices to classify an agent as first-line medication.",
+        "byte_quote": "Resistance rates of <20% already suffice to class an antibiotic as first-line medication."
+      },
+      {
+        "id": "c9",
+        "text": "Fosfomycin-trometamol and nitrofurantoin can be given as first-line therapy without susceptibility testing.",
+        "byte_quote": "On the basis of our data and international studies (ECO-SENS) it can currently be confirmed that fosfomycin-trometamol and nitrofurantoin can be given in our urological practice as first-line therapy without susceptibility testing."
+      },
+      {
+        "id": "c10",
+        "text": "TRS, CIP and AMC should only be used to treat AUC after a susceptibility test has been performed.",
+        "byte_quote": "AUC should therefore only be treated with TRS, CIP and AMC after a susceptibility test has been carried out."
+      },
+      {
+        "id": "c11",
+        "text": "Mean patient age was 32.7 years (range 18-65), with the age peak at 18-25 years (42%).",
+        "byte_quote": "The average age of the patients was 32.7 years (range 18–65). The age peak in the cohort was between ages 18 and 25 (42%)."
+      },
+      {
+        "id": "c12",
+        "text": "AUC was more common in pre-menopausal than post-menopausal women (86.9% vs 13.1%).",
+        "byte_quote": "Among pre-menopausal patients AUC was more common than among post-menopausal women (86.9% vs. 13.1%)."
+      },
+      {
+        "id": "c13",
+        "text": "Three main risk factors influencing AUC rate: recurrent UTIs (20.3%), preceding sexual intercourse (15.3%), and a new sex partner (12.9%).",
+        "byte_quote": "Three main factors that might influence the rate of AUC in our cohort were recurrent urinary tract infections (20.3%), preceding sexual intercourse (15.3%) and a new sex partner (12.9%)."
+      },
+      {
+        "id": "c14",
+        "text": "AUC was defined by at least one of: suprapubic pain, urge symptoms, dysuria, increased voiding frequency.",
+        "byte_quote": "Indicators of an AUC were defined in terms of at least one of the following symptoms: suprapubic pain, urge symptoms, dysuria and increased voiding frequency."
+      },
+      {
+        "id": "c15",
+        "text": "A urine culture was defined as positive at >=10e3 CFU/mL; mixed cultures were not analysed.",
+        "byte_quote": "A urine culture was defined as positive if ≥10e3CFU/mL. Mixed cultures were not analysed."
+      }
+    ],
+    "cites": [
+      "ECO-SENS I & II studies (refs 5,6)",
+      "2014 ECO-SENS Update (ref 6)",
+      "ARESC Study — Antimicrobial Resistance Epidemiological Survey on Cystitis (refs 8,9)",
+      "EAU Guidelines, European Association of Urology, March 2015 (ref 12)",
+      "IDSA Guidelines, Infectious Diseases Society of America (ref 14)",
+      "German National Guidelines DGU (ref 10)"
+    ]
+  },
+  {
+    "source_id": "https://www.aafp.org/pubs/afp/issues/2011/1001/p771.html",
+    "resolved_url": "https://www.aafp.org/pubs/afp/issues/2011/1001/p771.html",
+    "title": "Diagnosis and Management of Acute Uncomplicated Cystitis (AAFP, Am Fam Physician 2011)",
+    "claims": [
+      {
+        "id": "c1",
+        "text": "UTIs are the most common bacterial infection in women; about half of all women have at least one UTI in their lifetime.",
+        "byte_quote": "Urinary tract infections (UTIs) are the most common bacterial infections in women, with one-half of all women experiencing at least one UTI in their lifetime."
+      },
+      {
+        "id": "c2",
+        "text": "Organism epidemiology: acute uncomplicated cystitis is caused by E. coli (86%), S. saprophyticus (4%), Klebsiella (3%), Proteus (3%), Enterobacter (1.4%), Citrobacter (0.8%), Enterococcus (0.5%).",
+        "byte_quote": "Most UTIs in women are acute uncomplicated cystitis caused by _Escherichia coli_ (86 percent), _Staphylococcus saprophyticus_ (4 percent), _Klebsiella_ species (3 percent), _Proteus_ species (3 percent), _Enterobacter_ species (1.4 percent), _Citrobacter_ species (0.8 percent), or _Enterococcus_ species (0.5 percent)."
+      },
+      {
+        "id": "c3",
+        "text": "Host definition / risk population: uncomplicated cystitis means a premenopausal, nonpregnant woman with no urologic abnormalities or comorbidities.",
+        "byte_quote": "By definition, the diagnosis of acute uncomplicated cystitis implies an uncomplicated UTI in a premenopausal, nonpregnant woman with no known urologic abnormalities or comorbidities."
+      },
+      {
+        "id": "c4",
+        "text": "Risk factors raising UTI likelihood: recent sexual intercourse, diaphragm-with-spermicide use, and recurrent UTIs.",
+        "byte_quote": "A prospective study of 796 sexually active young women identified risk factors to help diagnose UTI, including recent sexual intercourse, diaphragm use with spermicide, and recurrent UTIs."
+      },
+      {
+        "id": "c5",
+        "text": "Urinalysis: nitrites and leukocyte esterase are the most accurate dipstick indicators of cystitis in symptomatic women.",
+        "byte_quote": "Nitrites and leukocyte esterase are the most accurate indicators of acute uncomplicated cystitis in symptomatic women."
+      },
+      {
+        "id": "c6",
+        "text": "Classic lower urinary tract symptoms are dysuria, frequent small-volume voiding, and urinary urgency.",
+        "byte_quote": "Classic lower urinary tract symptoms include dysuria, frequent voiding of small volumes, and urinary urgency."
+      },
+      {
+        "id": "c7",
+        "text": "Urine culture diagnostic threshold: >= 10^3 CFU/mL of a uropathogen is diagnostic of acute uncomplicated cystitis.",
+        "byte_quote": "A colony count greater than or equal to 10³ colony-forming units per mL of a uropathogen is diagnostic of acute uncomplicated cystitis."
+      },
+      {
+        "id": "c8",
+        "text": "Lower culture threshold: >10^2 CFU/mL in women with typical UTI symptoms represents a positive culture.",
+        "byte_quote": "studies have shown that more than 10² colony-forming units per mL in women with typical symptoms of a UTI represent a positive culture."
+      },
+      {
+        "id": "c9",
+        "text": "Pretest probability of UTI in women is 5%, rising 10-fold to 50% with the acute onset of even one classic symptom.",
+        "byte_quote": "The pretest probability of UTI in women is 5 percent; however, when a woman presents with the acute onset of even one of the classic symptoms of acute uncomplicated cystitis, the probability of infection rises 10-fold to 50 percent."
+      },
+      {
+        "id": "c10",
+        "text": "New-onset frequency and dysuria without vaginal discharge/irritation has a 90% positive predictive value for UTI.",
+        "byte_quote": "The new onset of frequency and dysuria, with the absence of vaginal discharge or irritation, has a positive predictive value of 90 percent for UTI."
+      },
+      {
+        "id": "c11",
+        "text": "First-line dosing: nitrofurantoin 100 mg twice per day for five days.",
+        "byte_quote": "Nitrofurantoin at a dosage of 100 mg twice per day for five days"
+      },
+      {
+        "id": "c12",
+        "text": "First-line dosing: TMP-SMX one double-strength tablet (160/800 mg) twice per day for three days, only where community uropathogen resistance does not exceed 20%.",
+        "byte_quote": "trimethoprim/sulfamethoxazole (Bactrim, Septra) at a dosage of one double-strength tablet (160/800 mg) twice per day for three days in regions where the prevalence of resistance of community uropathogens does not exceed 20 percent"
+      },
+      {
+        "id": "c13",
+        "text": "First-line dosing: fosfomycin a single 3 g dose.",
+        "byte_quote": "Fosfomycin at a single dose of 3 g"
+      },
+      {
+        "id": "c14",
+        "text": "Fluoroquinolones (ofloxacin, ciprofloxacin, levofloxacin) are second-tier antimicrobials for cystitis.",
+        "byte_quote": "Fluoroquinolones (i.e., ofloxacin, ciprofloxacin [Cipro], and levofloxacin [Levaquin]) are considered second-tier antimicrobials"
+      },
+      {
+        "id": "c15",
+        "text": "Fluoroquinolone dosing: ciprofloxacin 250 mg twice daily x3 days; Cipro XR 500 mg/day x3; levofloxacin 250 mg/day x3; ofloxacin 200 mg/day x3 or 400 mg single dose.",
+        "byte_quote": "Ciprofloxacin (Cipro): 250 mg twice per day for three days"
+      },
+      {
+        "id": "c16",
+        "text": "Beta-lactam (third-tier) dosing: amoxicillin/clavulanate 500/125 mg twice daily x7 days; cefdinir 300 mg twice daily x10 days; cefpodoxime 100 mg twice daily x7 days.",
+        "byte_quote": "Amoxicillin/clavulanate (Augmentin): 500/125 mg twice per day for seven days"
+      },
+      {
+        "id": "c17",
+        "text": "Beta-lactams are not recommended first-line for cystitis due to E. coli resistance above 20%.",
+        "byte_quote": "Beta-lactam antibiotics are not recommended as first-line therapy for acute uncomplicated cystitis because of widespread _E. coli_ resistance rates above 20 percent."
+      },
+      {
+        "id": "c18",
+        "text": "Fluoroquinolones should be reserved (collateral-damage concern) for more serious infections than uncomplicated cystitis.",
+        "byte_quote": "Although fluoroquinolones are effective, they have the propensity for collateral damage, and should be considered for patients with more serious infections than acute uncomplicated cystitis."
+      },
+      {
+        "id": "c19",
+        "text": "To preserve effectiveness, fluoroquinolones are not recommended as a first-tier option.",
+        "byte_quote": "To preserve the effectiveness of fluoroquinolones, they are not recommended as a first-tier option."
+      },
+      {
+        "id": "c20",
+        "text": "Resistance risk factor: TMP-SMX use in the prior 3-6 months is an independent risk factor for resistance.",
+        "byte_quote": "Use of trimethoprim/sulfamethoxazole in the preceding three to six months has been found to be an independent risk factor for resistance."
+      },
+      {
+        "id": "c21",
+        "text": "Pregnancy categories (Table 2): fosfomycin B, nitrofurantoin B, TMP-SMX C, fluoroquinolones C.",
+        "byte_quote": "Fosfomycin: \"B\""
+      },
+      {
+        "id": "c22",
+        "text": "Pyelonephritis should be suspected if the patient is ill-appearing/uncomfortable, especially with fever, tachycardia, or costovertebral angle tenderness.",
+        "byte_quote": "Acute pyelonephritis should be suspected if the patient is ill-appearing and seems uncomfortable, particularly if she has concomitant fever, tachycardia, or costovertebral angle tenderness."
+      },
+      {
+        "id": "c23",
+        "text": "Urine cultures are recommended only for suspected pyelonephritis, non-resolving/recurrent symptoms within 2-4 weeks, or atypical presentation.",
+        "byte_quote": "Urine cultures are recommended only for patients with suspected acute pyelonephritis; patients with symptoms that do not resolve or that recur within two to four weeks after the completion of treatment; and patients who present with atypical symptoms."
+      },
+      {
+        "id": "c24",
+        "text": "Women with prior acute uncomplicated cystitis are usually accurate in self-diagnosing recurrence.",
+        "byte_quote": "Women who have had acute uncomplicated cystitis previously are usually accurate in determining when they are having another episode."
+      }
+    ],
+    "cites": [
+      "Gupta K, Hooton TM, Naber KG, et al. International clinical practice guidelines for the treatment of acute uncomplicated cystitis and pyelonephritis in women: a 2010 update by the Infectious Diseases Society of America and the European Society for Microbiology and Infectious Diseases. Clin Infect Dis. 2011;52(5):e103-e120."
+    ]
+  },
+  {
+    "source_id": "https://pubmed.ncbi.nlm.nih.gov/15701325/",
+    "resolved_url": "https://pubmed.ncbi.nlm.nih.gov/15701325/",
+    "title": "Etiology and antimicrobial susceptibility among uropathogens causing community-acquired lower urinary tract infections: a nationwide surveillance study (Enferm Infecc Microbiol Clin. 2005 Jan;23(1):4-9)",
+    "claims": [
+      {
+        "id": "c1",
+        "text": "Among 2724 isolates from outpatients with lower UTIs, E. coli was the most frequent uropathogen at 73%.",
+        "byte_quote": "The most frequent pathogen found was Escherichia coli (73%)"
+      },
+      {
+        "id": "c2",
+        "text": "After E. coli, the next most frequent lower-UTI uropathogens were Proteus spp. (7.4%), Klebsiella spp. (6.6%), and Enterococcus spp. (4.8%).",
+        "byte_quote": "followed by Proteus spp. (7.4%), Klebsiella spp. (6.6%) and Enterococcus spp. (4.8%)"
+      },
+      {
+        "id": "c3",
+        "text": "The study analyzed 2724 isolates recovered from outpatients with lower urinary tract infections.",
+        "byte_quote": "A total of 2724 isolates were recovered from outpatients with lower urinary tract infections."
+      },
+      {
+        "id": "c4",
+        "text": "E. coli susceptibility rates were fosfomycin 97.9%, cefixime 95.8%, nitrofurantoin 94.3%, amoxicillin-clavulanic acid 90.8%, and ciprofloxacin 77.2%.",
+        "byte_quote": "The susceptibility rates of E. coli were 97.9% for fosfomycin, 95.8% for cefixime, 94.3% for nitrofurantoin, 90.8% for amoxicillin-clavulanic acid and 77.2% for ciprofloxacin."
+      },
+      {
+        "id": "c5",
+        "text": "E. coli fluoroquinolone resistance was significantly higher in men than women (28.9% vs. 19%; P<0.001).",
+        "byte_quote": "E. coli resistance to fluoroquinolones was significantly higher in men (28.9% vs. 19% in women; P < 0.001)"
+      },
+      {
+        "id": "c6",
+        "text": "E. coli fluoroquinolone resistance was significantly higher in elderly patients, 33.7% in those 80 years or older vs. 7.1% in those 40 years or younger (P<0.001).",
+        "byte_quote": "elderly patients (33.7% in 80 years or older vs. 7.1% in 40 years or younger; P < 0.001)"
+      },
+      {
+        "id": "c7",
+        "text": "E. coli fluoroquinolone resistance was significantly higher in complicated infections than non-complicated (24.8% vs. 13.7%; P<0.001).",
+        "byte_quote": "complicated infections (24.8% vs. 13.7% in non-complicated; P < 0.001)"
+      },
+      {
+        "id": "c8",
+        "text": "Overall E. coli fluoroquinolone resistance was near 23%, varying by sex, age, infection type, and geographic region.",
+        "byte_quote": "Overall fluoroquinolone resistance was near 23%, but this rate varied significantly according to sex, age, type of urinary infection, and geographic region."
+      },
+      {
+        "id": "c9",
+        "text": "Almost all E. coli isolates were susceptible to fosfomycin, cefixime, and nitrofurantoin.",
+        "byte_quote": "Almost all E. coli isolates were susceptible to fosfomycin, cefixime and nitrofurantoin."
+      }
+    ],
+    "cites": []
+  },
+  {
+    "source_id": "https://pmc.ncbi.nlm.nih.gov/articles/PMC10031580/",
+    "resolved_url": "https://pmc.ncbi.nlm.nih.gov/articles/PMC10031580/",
+    "title": "Bacterial species and antimicrobial resistance differ between catheter and non–catheter-associated urinary tract infections: Data from a national surveillance network",
+    "claims": [
+      {
+        "id": "c1",
+        "text": "E. coli is the most frequent uropathogen in both catheter-associated (CAUTI) and non-catheter-associated UTI.",
+        "byte_quote": "Escherichia coli was the most frequent pathogen identified in both CAUTI and non-CAUTI samples"
+      },
+      {
+        "id": "c2",
+        "text": "Four organisms (E. coli, K. pneumoniae, P. aeruginosa, P. mirabilis) make up 70% of CAUTI and 85% of non-CAUTI pathogens.",
+        "byte_quote": "Escherichia coli, Klebsiella pneumoniae, Pseudomonas aeruginosa, and Proteus mirabilis together represented 70% and 85% of pathogens identified in CAUTI and non-CAUTI samples, respectively"
+      },
+      {
+        "id": "c3",
+        "text": "P. aeruginosa is enriched in catheter-associated UTI (10% of CAUTI vs 3.3% of non-CAUTI).",
+        "byte_quote": "Pseudomonas aeruginosa represented 10% of CAUTI pathogens versus only 3.3% of non-CAUTIs"
+      },
+      {
+        "id": "c4",
+        "text": "E. coli proportion: 31.9% in CAUTI vs 54.8% in non-CAUTI.",
+        "byte_quote": "Escherichia coli (31.9% CAUTI; 54.8% non-CAUTI)"
+      },
+      {
+        "id": "c5",
+        "text": "P. aeruginosa proportion: 10.1% in CAUTI vs 3.3% in non-CAUTI.",
+        "byte_quote": "Pseudomonas aeruginosa (10.1% CAUTI; 3.3% non-CAUTI)"
+      },
+      {
+        "id": "c6",
+        "text": "K. pneumoniae proportion: 11.1% in CAUTI vs 9.9% in non-CAUTI.",
+        "byte_quote": "Klebsiella pneumoniae (11.1% CAUTI; 9.9% non-CAUTI)"
+      },
+      {
+        "id": "c7",
+        "text": "Host/risk factor: CAUTI patients are older (median 75 y) than non-CAUTI patients (median 65 y); catheterization (device) is the differentiating exposure.",
+        "byte_quote": "Age, median y (IQR): CAUTI 75 (60–80); Non-CAUTI 65 (40–75); P<.001"
+      },
+      {
+        "id": "c8",
+        "text": "Host/risk factor: CAUTI cases are predominantly male (57.4%), whereas non-CAUTI cases are predominantly female (68.6%).",
+        "byte_quote": "Male: 2,587 (57.4%) CAUTI; 6,234 (31.3%) non-CAUTI"
+      },
+      {
+        "id": "c9",
+        "text": "Catheter association predicts higher resistance to recommended empirical antibiotics.",
+        "byte_quote": "CAUTI pathogens were more often resistant to recommended empirical antibiotics than non-CAUTI pathogens."
+      },
+      {
+        "id": "c10",
+        "text": "E. coli ciprofloxacin (CIP) resistance is higher in CAUTI (26%) than non-CAUTI (16.9%).",
+        "byte_quote": "26% of CAUTI samples were resistant vs 16.9% of non-CAUTI samples"
+      },
+      {
+        "id": "c11",
+        "text": "E. coli third/fourth-generation cephalosporin (C3/4G) resistance: 11.6% CAUTI vs 8.2% non-CAUTI.",
+        "byte_quote": "11.6% of CAUTI samples were resistant vs 8.2% of non-CAUTI samples"
+      },
+      {
+        "id": "c12",
+        "text": "E. coli norfloxacin (NOR) resistance: 28.1% CAUTI vs 19.1% non-CAUTI.",
+        "byte_quote": "28.1% of CAUTI samples were resistant vs 19.1% of non-CAUTI samples"
+      },
+      {
+        "id": "c13",
+        "text": "K. pneumoniae ciprofloxacin resistance: 17.8% CAUTI vs 11.4% non-CAUTI.",
+        "byte_quote": "17.8% vs 11.4% resistant, respectively"
+      },
+      {
+        "id": "c14",
+        "text": "P. aeruginosa cephalosporin (CEF) resistance: 13.7% CAUTI vs 8.1% non-CAUTI.",
+        "byte_quote": "13.7% vs 8.1% resistant, respectively"
+      },
+      {
+        "id": "c15",
+        "text": "P. aeruginosa piperacillin (PIP) resistance: 14.5% CAUTI vs 9.8% non-CAUTI.",
+        "byte_quote": "14.5% vs 9.8% resistant, respectively"
+      }
+    ],
+    "cites": []
+  },
+  {
+    "source_id": "https://pmc.ncbi.nlm.nih.gov/articles/PMC2708523/",
+    "resolved_url": "https://pmc.ncbi.nlm.nih.gov/articles/PMC2708523/",
+    "title": "Diversity of Group B Streptococcus Serotypes Causing Urinary Tract Infection in Adults",
+    "claims": [
+      {
+        "id": "c1",
+        "text": "Group B Streptococcus (GBS) was cultured from 1.1% of consecutive adult urine samples (387/34,367).",
+        "byte_quote": "GBS was cultured from 387/34,367 consecutive urine samples (1.1%)"
+      },
+      {
+        "id": "c2",
+        "text": "Serotypes V, Ia, and III caused the most GBS UTIs.",
+        "byte_quote": "Serotypes V, Ia, and III caused the most UTIs"
+      },
+      {
+        "id": "c3",
+        "text": "Serotypes V, Ia, and III together account for 76% of the 62 GBS UTI cases.",
+        "byte_quote": "The most prevalent serotypes among the 62 cases of GBS UTI were serotypes V, Ia, and III (Table 2), which together account for 76% of cases."
+      },
+      {
+        "id": "c4",
+        "text": "Nontypeable GBS was not associated with UTI.",
+        "byte_quote": "Nontypeable GBS was not associated with UTI."
+      },
+      {
+        "id": "c5",
+        "text": "GBS UTI case patients were significantly older than controls (mean 53 vs 30 years).",
+        "byte_quote": "the mean age of case patients was significantly greater (53 ± 19 years versus 30 ± 12 years; P < 0.001)"
+      },
+      {
+        "id": "c6",
+        "text": "Prior history of UTI raised the odds of GBS UTI (OR 3.1).",
+        "byte_quote": "GBS UTI case patients were significantly more likely to have had a prior history of UTI than controls (OR, 3.1; 95% CI, 1.1 to 8.7)"
+      },
+      {
+        "id": "c7",
+        "text": "Female sex raised the odds of GBS UTI (OR 3.8).",
+        "byte_quote": "to be female (OR, 3.8; 95% CI, 1.6 to 8.7)"
+      },
+      {
+        "id": "c8",
+        "text": "Women of child-bearing age with GBS UTI were less likely to be pregnant than child-bearing-age controls (37.5% vs 81.4%).",
+        "byte_quote": "Significantly fewer women of child-bearing age (defined as <40 yrs) with GBS UTI were pregnant than women of child-bearing age who were controls (37.5% [6/16] versus 81.4% [35/43]; P = 0.003)"
+      },
+      {
+        "id": "c9",
+        "text": "Confirmed GBS UTI cases (31/62 with urinalysis) all had positive leukocyte esterase and pyuria.",
+        "byte_quote": "All 31 of the 62 patients who had UA performed had positive results based on positive urinary leukocyte esterase and pyuria"
+      },
+      {
+        "id": "c10",
+        "text": "GBS isolates were uniformly susceptible to amoxicillin-clavulanic acid, penicillin, linezolid, and chloramphenicol.",
+        "byte_quote": "they were uniformly susceptible to amoxicillin (amoxicilline) with clavulanic acid, penicillin, linezolid, and chloramphenicol"
+      },
+      {
+        "id": "c11",
+        "text": "A substantial proportion of GBS isolates were resistant to clindamycin (26.4%) and erythromycin (39.5%).",
+        "byte_quote": "A considerable proportion of isolates was resistant to clindamycin (102/387 [26.4%]) and erythromycin (153/387 [39.5%])"
+      },
+      {
+        "id": "c12",
+        "text": "Most GBS isolates were resistant to tetracycline (80.4%), cefoxitin (88.7%), and trimethoprim-sulfamethoxazole (98.3%).",
+        "byte_quote": "the majority was resistant to tetracycline (311/387 [80.4%]), cefoxitin (343/387 [88.7%]), and trimethoprim with sulfamethoxazole (380/387 [98.3%])"
+      },
+      {
+        "id": "c13",
+        "text": "Only one GBS UTI patient had concurrent GBS bloodstream isolation, indicating probable urosepsis.",
+        "byte_quote": "only one patient had GBS concurrently isolated from blood, representing probable urosepsis"
+      }
+    ],
+    "cites": []
+  },
+  {
+    "source_id": "https://pmc.ncbi.nlm.nih.gov/articles/PMC12217021/",
+    "resolved_url": "https://pmc.ncbi.nlm.nih.gov/articles/PMC12217021/",
+    "title": "Feasibility of serial measurement of nitrite for pharmacodynamic monitoring and precision prescribing in urinary tract infections",
+    "claims": [
+      {
+        "id": "c1",
+        "text": "E. coli uses nitrate as a secondary electron acceptor in anaerobic (low-oxygen) respiration, making urine nitrite a commonly used indicator/biomarker for UTI (urinalysis biochemistry).",
+        "byte_quote": "At low oxygen concentrations, _E. coli_ utilises nitrate as a secondary electron acceptor for anaerobic respiration[15](#CR15), making nitrite a commonly used indicator for UTIs."
+      },
+      {
+        "id": "c2",
+        "text": "Nitrite-based UTI detection fails when no dietary nitrate is present in urine or when the infecting organism is a non-nitrate-reducing strain (organism-dependent limitation of the nitrite test).",
+        "byte_quote": "This has limitations, such as no increase in nitrite if no dietary nitrate is present in urine, or infection with non-nitrate reducing strains."
+      },
+      {
+        "id": "c3",
+        "text": "Amoxicillin at 164 mg/mL was used in vitro (concentration chosen to inhibit growth of high-bacterial-count cultures), introduced after 15 h of growth.",
+        "byte_quote": "164 mg/mL sterilised amoxicillin, a concentration high enough to inhibit the growth of high bacterial count cultures, was introduced to samples after 15 h of growth."
+      },
+      {
+        "id": "c4",
+        "text": "In patient samples, bacterial count and generated nitrite (creatinine-corrected for renal clearance) show a significant positive Spearman correlation (rho 0.46, p 0.032).",
+        "byte_quote": "Spearman correlation between bacterial count and generated nitrite (corrected for renal clearance using detected creatinine levels) reveals a significant relationship (Spearman correlation: 0.46 and p-value 0.032)"
+      },
+      {
+        "id": "c5",
+        "text": "Study analyzed samples from 25 UTI patients and 25 non-UTI controls for bacterial growth, nitrite, and creatinine.",
+        "byte_quote": "Samples from 25 UTI patients and 25 non-UTI controls were analysed for bacterial growth, nitrite, and creatinine."
+      },
+      {
+        "id": "c6",
+        "text": "Both nitrite concentration and CFU count are significantly lower in a drug-susceptible strain after antimicrobial addition vs. without drug (pharmacodynamic response signal).",
+        "byte_quote": "The nitrite concentration and CFU count after addition of antimicrobial drug is significantly lower in the susceptible strain with drug compared to without drug"
+      },
+      {
+        "id": "c7",
+        "text": "Reported sensitivities for nitrite as a UTI biomarker are mixed and should be interpreted alongside other dipstick biomarkers (test-performance caveat).",
+        "byte_quote": "The reported sensitivities for nitrite as a biomarker for UTI infection are mixed and should be interpreted alongside other biomarkers on dipstick tests"
+      }
+    ],
+    "cites": [
+      "Foxman, B. The epidemiology of urinary tract infection. Nat. Rev. Urol. 7, 653-660 (2010)",
+      "Rawson, T. M. et al. Optimizing antimicrobial use: challenges, advances and opportunities. Nat. Rev. Microbiol 19, 747-758 (2021)"
+    ]
+  },
+  {
+    "source_id": "https://pubmed.ncbi.nlm.nih.gov/6696301/",
+    "resolved_url": "https://pubmed.ncbi.nlm.nih.gov/6696301/",
+    "title": "Measurement of urinary leukocyte esterase activity: a screening test for urinary tract infections (Chernow et al., Ann Emerg Med. 1984;13(3):150-4)",
+    "claims": [
+      {
+        "id": "c1",
+        "text": "Leukocyte esterase is an enzyme released only from leukocytes, and testing for it in urine indicates the presence of pyuria.",
+        "byte_quote": "We evaluated the efficacy of testing for the presence of esterase (an enzyme released only from leukocytes) in the urine as an indicator of the presence of pyuria."
+      },
+      {
+        "id": "c2",
+        "text": "A dipstick test for urinary leukocyte esterase activity was hypothesized to be a rapid, simple screening technique for detecting UTIs.",
+        "byte_quote": "We hypothesized that a \"dipstick\" test for urinary leukocyte esterase activity would be a rapid and simple screening technique for detecting urinary tract infections (UTI)."
+      },
+      {
+        "id": "c3",
+        "text": "Study population: 203 patients (148 outpatients, 55 inpatients) with suspected UTI.",
+        "byte_quote": "we collected fresh urine specimens from 203 patients (148 outpatients, 55 inpatients) with a suspected UTI."
+      },
+      {
+        "id": "c4",
+        "text": "Significant bacteriuria was defined as >= 10^5 organisms/mL; 49 of 203 specimens met this threshold.",
+        "byte_quote": "Of the 203 specimens, 49 showed significant bacteriuria (greater than or equal to 10(5) organisms/mL)."
+      },
+      {
+        "id": "c5",
+        "text": "Leukocyte esterase dipstick was 100% sensitive (0% false negatives) and 76% specific (24% false positives) for predicting significant bacteriuria.",
+        "byte_quote": "The leukocyte esterase test was 100% sensitive (0% false negatives) with a 76% specificity (24% false positives) in predicting significant bacteriuria."
+      },
+      {
+        "id": "c6",
+        "text": "Urinary nitrite testing was highly specific (99% specificity, 0.6% false positives) but insensitive (27% sensitivity, 73% false negatives).",
+        "byte_quote": "Although a positive nitrite reaction was more specific (99% specificity, 0.6% false positives), it was insensitive (27% sensitivity, 73% false negatives)."
+      }
+    ],
+    "cites": []
+  },
+  {
+    "source_id": "https://pmc.ncbi.nlm.nih.gov/articles/PMC5880328/",
+    "resolved_url": "https://pmc.ncbi.nlm.nih.gov/articles/PMC5880328/",
+    "title": "Pathogenesis of Proteus mirabilis Infection",
+    "claims": [
+      {
+        "id": "c1",
+        "text": "Proteus mirabilis is a Gram-negative rod-shaped bacterium notable for urease production and differentiation into elongated swarm cells with a bull's-eye motility pattern on agar.",
+        "byte_quote": "Proteus mirabilis, a Gram-negative rod-shaped bacterium, is well-known for its urease production and distinctive ability to differentiate into elongated swarm cells and characteristic bull's-eye pattern of motility on agar plates."
+      },
+      {
+        "id": "c2",
+        "text": "P. mirabilis is among the most common organisms in polymicrobial urine colonization and infection.",
+        "byte_quote": "P. mirabilis is one of the most common organisms present during polymicrobial urine colonization and infection"
+      },
+      {
+        "id": "c3",
+        "text": "P. mirabilis infections are common in long-term catheterized patients (nursing homes, chronic care facilities) and are especially dangerous to spinal cord injury patients — catheterization/long-term care is the dominant risk factor.",
+        "byte_quote": "These infections are common in long-term catheterized patients, such as those who reside in nursing homes and chronic care facilities, and may be of particular danger to spinal cord injury patients"
+      },
+      {
+        "id": "c4",
+        "text": "Bloodstream infection (bacteremia) with P. mirabilis most frequently arises from a UTI/CAUTI portal of entry rather than other sources — urinary source predicts the organism in bacteremia.",
+        "byte_quote": "bacteremia involving P. mirabilis most frequently occurs following UTI or CAUTI compared to other sources of infection"
+      },
+      {
+        "id": "c5",
+        "text": "P. mirabilis urease hydrolyzes urinary urea (present at ~400 mM) to CO2 and NH3, driving precipitation of struvite (MgNH4PO4·6H2O) and carbonate apatite stones.",
+        "byte_quote": "Urea, our means of eliminating excess nitrogen, is present in high concentrations in urine (∼400 mM), is the substrate of urease, and is hydrolyzed to CO2 and NH3"
+      },
+      {
+        "id": "c6",
+        "text": "About 50% of individuals with long-term catheterization (>28 days) experience catheter blockage from crystalline (struvite/apatite) deposits.",
+        "byte_quote": "Approximately 50% of individuals with long-term catheterization (>28 days) experience catheter blockage from crystalline deposits"
+      }
+    ],
+    "cites": []
+  },
+  {
+    "source_id": "https://www.cdc.gov/std/treatment-guidelines/penicillin-allergy.htm",
+    "resolved_url": "https://www.cdc.gov/std/treatment-guidelines/penicillin-allergy.htm",
+    "title": "Managing Persons Who Have a History of Penicillin Allergy — STI Treatment Guidelines (CDC)",
+    "claims": [
+      {
+        "id": "c1",
+        "text": "Reported penicillin allergy prevalence is about 10% of the US population and higher among hospital inpatients and long-term-care residents.",
+        "byte_quote": "Prevalence of reported allergy to penicillin is approximately 10% among the U.S. population and higher among hospital inpatients and residents in health care–related facilities"
+      },
+      {
+        "id": "c2",
+        "text": "In one STI clinic, 8.3% of patients reported a penicillin or other beta-lactam allergy.",
+        "byte_quote": "One large study in an STI clinic revealed that 8.3% of patients reported penicillin or another ß-lactam antibiotic allergy"
+      },
+      {
+        "id": "c3",
+        "text": "Most patients who report a penicillin allergy can actually tolerate the drug; allergy is overreported.",
+        "byte_quote": "Penicillin allergy is often overreported, with the majority of patients who report penicillin allergy able to tolerate the medication"
+      },
+      {
+        "id": "c4",
+        "text": "About 80% of patients with a true IgE-mediated penicillin allergy lose sensitivity after 10 years, so remote reactions are less likely to still be allergic.",
+        "byte_quote": "Approximately 80% of patients with a true IgE-mediated allergic reaction to penicillin have lost the sensitivity after 10 years"
+      },
+      {
+        "id": "c5",
+        "text": "In a Baltimore STI clinic, only 7.1% of patients reporting penicillin/beta-lactam allergy had an objective positive allergy test.",
+        "byte_quote": "only 7.1% of the patients who reported allergy to penicillin or to another ß-lactam antibiotic had an objective positive test for penicillin allergy"
+      },
+      {
+        "id": "c6",
+        "text": "With skin testing and graded oral challenge, true penicillin-allergy rates are low, 1.5%–6.1%.",
+        "byte_quote": "the true rates of allergy are low, ranging from 1.5% to 6.1%"
+      },
+      {
+        "id": "c7",
+        "text": "In hospitalized/comorbid populations reporting penicillin allergy, validated allergy rates are 2.5%–9.0%.",
+        "byte_quote": "the typical rates of validated penicillin allergy among patients who report a history of penicillin allergy are 2.5%–9.0%"
+      },
+      {
+        "id": "c8",
+        "text": "Penicillin and cephalosporins share a beta-lactam ring, the basis of cross-reactivity concern.",
+        "byte_quote": "Penicillin and cephalosporins both contain a ß-lactam ring."
+      },
+      {
+        "id": "c9",
+        "text": "Third-generation cephalosporins (ceftriaxone, cefixime) have <1% cross-reactivity in IgE-mediated penicillin-allergic patients, vs 1%–8% for first/second-generation cephalosporins.",
+        "byte_quote": "Third-generation cephalosporins (e.g., ceftriaxone and cefixime) have lower cross-reactivity with IgE-mediated penicillin-allergic patients (<1%) compared with first- and second-generation cephalosporins (range: 1%–8%)."
+      },
+      {
+        "id": "c10",
+        "text": "Cephalosporin anaphylaxis in persons reporting penicillin allergy is extremely rare, about one per 52,000 persons.",
+        "byte_quote": "anaphylaxis secondary to cephalosporins is extremely rare among persons who report a penicillin allergy and is estimated to occur at a rate of one per 52,000 persons"
+      },
+      {
+        "id": "c11",
+        "text": "Third/fourth-generation cephalosporins and carbapenems are safe for patients without IgE-mediated penicillin symptoms (anaphylaxis/urticaria) in the prior 10 years.",
+        "byte_quote": "Use of third- and fourth-generation cephalosporins and carbapenems is safe for patients without a history of any IgE-mediated symptoms (e.g., anaphylaxis or urticaria) from penicillin during the preceding 10 years."
+      },
+      {
+        "id": "c11b",
+        "text": "For gonorrhea patients with reported penicillin allergy, ceftriaxone is often avoided despite low cross-reactivity with third-generation cephalosporins.",
+        "byte_quote": "For patients with a diagnosis of gonorrhea and a concomitant reported allergy to penicillin, ceftriaxone is often avoided, even though the cross-reactivity between penicillin allergy and third-generation cephalosporins is low"
+      },
+      {
+        "id": "c12",
+        "text": "Allergy validation has three steps: history, penicillin major/minor determinant skin test, then observed oral challenge with 250 mg amoxicillin if skin test is negative.",
+        "byte_quote": "performing an observed oral challenge with 250 mg amoxicillin before proceeding directly to treatment with the indicated ß-lactam therapy"
+      },
+      {
+        "id": "c13",
+        "text": "Standard practice after a negative penicillin skin test is an observed oral challenge of amoxicillin 250 mg with 1 hour of observation.",
+        "byte_quote": "the standard practice is to follow skin testing with an observed oral challenge of amoxicillin 250 mg with 1 hour of observation"
+      },
+      {
+        "id": "c14",
+        "text": "Major-determinant (Pre-Pen) plus penicillin G skin testing identifies about 90%–99% of IgE-mediated penicillin-allergic patients.",
+        "byte_quote": "This test identifies approximately 90%–99% of the IgE-mediated penicillin-allergic patients."
+      },
+      {
+        "id": "c15",
+        "text": "Penicillin skin testing during pregnancy is considered safe.",
+        "byte_quote": "Penicillin skin testing during pregnancy is considered safe."
+      },
+      {
+        "id": "c16",
+        "text": "Penicillin is recommended for all clinical stages of syphilis, with no proven alternatives for neurosyphilis, congenital syphilis, or syphilis in pregnancy.",
+        "byte_quote": "Penicillin is recommended for all clinical stages of syphilis, and no proven alternatives exist for treating neurosyphilis, congenital syphilis, or syphilis during pregnancy."
+      },
+      {
+        "id": "c17",
+        "text": "Ceftriaxone, a third-generation cephalosporin, is recommended for gonorrhea treatment.",
+        "byte_quote": "Ceftriaxone, a third-generation cephalosporin, is recommended for gonorrhea treatment."
+      },
+      {
+        "id": "c18",
+        "text": "Desensitization (induction of tolerance) is required when penicillin is the only option (neurosyphilis, syphilis in pregnancy) and the skin test is positive; it must be done by allergists in a monitored inpatient setting.",
+        "byte_quote": "Desensitization is required for persons who have a documented penicillin allergy and for whom no therapeutic alternatives exist (e.g., syphilis during pregnancy and persons with neurosyphilis)."
+      },
+      {
+        "id": "c19",
+        "text": "Patients with severe non-IgE reactions (Stevens-Johnson, toxic epidermal necrolysis, interstitial nephritis, hemolytic anemia) should avoid penicillin/beta-lactams indefinitely and not undergo skin testing or challenge.",
+        "byte_quote": "Persons with a history of severe adverse cutaneous reaction (e.g., Stevens-Johnson syndrome or toxic epidermal necrolysis) and other severe non-IgE-mediated reactions (e.g., interstitial nephritis, and hemolytic anemia) are not candidates for penicillin skin testing or challenge."
+      },
+      {
+        "id": "c20",
+        "text": "High-risk histories include anaphylaxis within 6 hours, severe cutaneous reactions (DRESS/eosinophilia, SJS, TEN, AGEP), and severe non-IgE reactions (kidney or hepatic injury, hemolytic anemia, thrombocytopenia).",
+        "byte_quote": "anaphylaxis within 6 hours or severe adverse cutaneous reaction (e.g., eosinophilia and systemic symptoms, Stevens-Johnson syndrome, toxic epidermal necrolysis, or acute generalized exanthematous pustulosis), and other severe non-IgE-mediated reactions (e.g., kidney or hepatic injury, hemolytic anemia, or thrombocytopenia)"
+      },
+      {
+        "id": "c21",
+        "text": "Low-risk history is one nonspecific symptom (GI intolerance, headache, fatigue, nonurticarial rash); a family history of beta-lactam allergy alone is not a contraindication.",
+        "byte_quote": "Low-risk history includes one nonspecific symptom (e.g., gastrointestinal intolerance, headache, fatigue, or nonurticarial rash) (Box 2). In addition, a family history of penicillin or ß-lactam allergy alone is not a contraindication for treatment with ß-lactam antibiotics."
+      },
+      {
+        "id": "c22",
+        "text": "Penicillin skin testing should not be done in patients who have taken antihistamines within the past 7 days.",
+        "byte_quote": "Penicillin skin testing should not be performed for patients who have taken antihistamines within the past 7 days."
+      },
+      {
+        "id": "c23",
+        "text": "Penicillin G for skin-test minor-determinant precursor is dosed at 10^-2 M, 3.3 mg/mL, 10,000 units/mL.",
+        "byte_quote": "Benzylpenicillin G (10 -2 M, 3.3 mg/mL, 10,000 units/mL)"
+      },
+      {
+        "id": "c24",
+        "text": "Patients reporting penicillin allergy have higher rates of surgical-site infections and MRSA infections and greater medical-care usage.",
+        "byte_quote": "persons with reported penicillin or another ß-lactam antibiotic allergy have higher rates of surgical-site infections, methicillin-resistant Staphylococcus aureus infections, and higher medical care usage"
+      }
+    ],
+    "cites": [
+      "Saxon et al. 1987 (skin test reagents)",
+      "Kaiser health care system data (3,313 patients with self-reported cephalosporin allergy)",
+      "Pre-Pen Package Insert — https://penallergytest.com/wp-content/uploads/PRE-PEN-Package-Insert.pdf",
+      "CDC STI Treatment Guidelines references 652-690 (e.g., 652 cephalosporin cross-reactivity/anaphylaxis rate; 659 Baltimore STI clinic study; 677 revised skin-test kit n=455; 684 UK 1972-2007 amoxicillin anaphylaxis fatality)"
+    ]
+  },
+  {
+    "source_id": "https://dailymed.nlm.nih.gov/dailymed/drugInfo.cfm?setid=3c442cca-47f5-48e5-b718-c09413911687",
+    "resolved_url": "https://dailymed.nlm.nih.gov/dailymed/drugInfo.cfm?setid=3c442cca-47f5-48e5-b718-c09413911687",
+    "title": "Moxifloxacin Hydrochloride — DailyMed FDA Prescribing Label",
+    "claims": [
+      {
+        "id": "c1",
+        "text": "Community-acquired pneumonia treated by moxifloxacin is caused by S. pneumoniae (including MDRSP), H. influenzae, M. catarrhalis, MSSA, K. pneumoniae, M. pneumoniae, or C. pneumoniae.",
+        "byte_quote": "Community Acquired Pneumonia caused by susceptible isolates of Streptococcus pneumoniae (including multi-drug resistant Streptococcus pneumoniae [MDRSP]), Haemophilus influenzae, Moraxella catarrhalis, methicillin-susceptible Staphylococcus aureus, Klebsiella pneumoniae, Mycoplasma pneumoniae, or Chlamydophila pneumoniae"
+      },
+      {
+        "id": "c2",
+        "text": "Complicated intra-abdominal infections (e.g. abscess) are polymicrobial, caused by E. coli, B. fragilis, S. anginosus, S. constellatus, E. faecalis, P. mirabilis, C. perfringens, B. thetaiotaomicron, or Peptostreptococcus.",
+        "byte_quote": "Complicated Intra-Abdominal Infections (cIAI) including polymicrobial infections such as abscess caused by susceptible isolates of Escherichia coli, Bacteroides fragilis, Streptococcus anginosus, Streptococcus constellatus, Enterococcus faecalis, Proteus mirabilis, Clostridium perfringens, Bacteroides thetaiotaomicron, or Peptostreptococcus species"
+      },
+      {
+        "id": "c3",
+        "text": "Plague (including pneumonic and septicemic plague) is due to Yersinia pestis; moxifloxacin is indicated for treatment and prophylaxis in adults.",
+        "byte_quote": "plague, including pneumonic and septicemic plague, due to susceptible isolates of Yersinia pestis and prophylaxis of plague in adult patients"
+      },
+      {
+        "id": "c4",
+        "text": "Uncomplicated skin/skin-structure infections are caused by MSSA or Streptococcus pyogenes.",
+        "byte_quote": "caused by susceptible isolates of methicillin-susceptible Staphylococcus aureus or Streptococcus pyogenes"
+      },
+      {
+        "id": "c5",
+        "text": "Complicated skin/skin-structure infections are caused by MSSA, E. coli, K. pneumoniae, or Enterobacter cloacae.",
+        "byte_quote": "caused by susceptible isolates of methicillin-susceptible Staphylococcus aureus, Escherichia coli, Klebsiella pneumoniae, or Enterobacter cloacae"
+      },
+      {
+        "id": "c6",
+        "text": "Acute bacterial sinusitis is caused by S. pneumoniae, H. influenzae, or M. catarrhalis.",
+        "byte_quote": "caused by susceptible isolates of Streptococcus pneumoniae, Haemophilus influenzae, or Moraxella catarrhalis"
+      },
+      {
+        "id": "c7",
+        "text": "Acute bacterial exacerbation of chronic bronchitis is caused by S. pneumoniae, H. influenzae, H. parainfluenzae, K. pneumoniae, MSSA, or M. catarrhalis.",
+        "byte_quote": "caused by susceptible isolates of Streptococcus pneumoniae, Haemophilus influenzae, Haemophilus parainfluenzae, Klebsiella pneumoniae, methicillin-susceptible Staphylococcus aureus, or Moraxella catarrhalis"
+      },
+      {
+        "id": "c8",
+        "text": "Standard adult dose of moxifloxacin is 400 mg orally or IV once every 24 hours.",
+        "byte_quote": "The dose of moxifloxacin hydrochloride is 400 mg (orally or as an intravenous infusion) once every 24 hours."
+      },
+      {
+        "id": "c9",
+        "text": "Moxifloxacin is contraindicated in persons with a history of hypersensitivity to moxifloxacin or any quinolone-class antibacterial.",
+        "byte_quote": "Moxifloxacin hydrochloride is contraindicated in persons with a history of hypersensitivity to moxifloxacin or any member of the quinolone class of antibacterials"
+      },
+      {
+        "id": "c10",
+        "text": "Effectiveness in pediatric patients and adolescents under 18 years has not been established.",
+        "byte_quote": "Effectiveness in pediatric patients and adolescents less than 18 years of age has not been established."
+      },
+      {
+        "id": "c11",
+        "text": "Geriatric patients are at increased risk of severe tendon disorders including tendon rupture on fluoroquinolones such as moxifloxacin.",
+        "byte_quote": "Geriatric patients are at increased risk for developing severe tendon disorders including tendon rupture when being treated with a fluoroquinolone such as moxifloxacin hydrochloride."
+      },
+      {
+        "id": "c12",
+        "text": "Moxifloxacin has been shown to prolong the QT interval of the electrocardiogram in some patients.",
+        "byte_quote": "Moxifloxacin hydrochloride has been shown to prolong the QT interval of the electrocardiogram in some patients."
+      },
+      {
+        "id": "c13",
+        "text": "QT-related risk factors to avoid include known QT prolongation, ventricular arrhythmias/torsade de pointes, and uncorrected hypokalemia or hypomagnesemia.",
+        "byte_quote": "Known prolongation of the QT interval; Ventricular arrhythmias including torsade de pointes because QT prolongation may lead to an increased risk for these conditions; Uncorrected hypokalemia or hypomagnesemia"
+      },
+      {
+        "id": "c14",
+        "text": "Based on animal data, moxifloxacin may cause fetal harm (pregnancy).",
+        "byte_quote": "Based on animal data may cause fetal harm."
+      },
+      {
+        "id": "c15",
+        "text": "Moxifloxacin tablets must be given at least 4 hours before or 8 hours after products containing magnesium, aluminum, iron, or zinc (antacids, sucralfate, multivitamins, didanosine buffered tablets).",
+        "byte_quote": "Administer moxifloxacin hydrochloride tablets at least 4 hours before or 8 hours after products containing magnesium, aluminum, iron or zinc, including antacids, sucralfate, multivitamins and didanosine buffered tablets"
+      },
+      {
+        "id": "c16",
+        "text": "Fluoroquinolones including moxifloxacin can enhance the anticoagulant effects of warfarin or its derivatives.",
+        "byte_quote": "fluoroquinolones, including moxifloxacin hydrochloride, have been reported to enhance the anticoagulant effects of warfarin or its derivatives in the patient population"
+      }
+    ],
+    "cites": []
+  },
+  {
+    "source_id": "https://dailymed.nlm.nih.gov/dailymed/lookup.cfm?setid=793c75eb-dd65-4b6d-ac46-6e57ce1334f7",
+    "resolved_url": "https://dailymed.nlm.nih.gov/dailymed/lookup.cfm?setid=793c75eb-dd65-4b6d-ac46-6e57ce1334f7",
+    "title": "Sulfamethoxazole and Trimethoprim Injection, USP — DailyMed Label (Mylan Institutional LLC)",
+    "claims": [
+      {
+        "id": "c1",
+        "text": "ORGANISM EPIDEMIOLOGY (UTI): Sulfamethoxazole/trimethoprim injection treats severe or complicated UTIs in adults and pediatric patients >=2 months due to susceptible E. coli, Klebsiella spp., Enterobacter spp., Morganella morganii, Proteus mirabilis, and Proteus vulgaris.",
+        "byte_quote": "sulfamethoxazole and trimethoprim injection is indicated in the treatment of severe or complicated urinary tract infections in adults and pediatric patients two months of age and older due to susceptible strains of Escherichia coli, Klebsiella species, Enterobacter species, Morganella morganii, Proteus mirabilis and Proteus vulgaris when oral administration of sulfamethoxazole and trimethoprim injection is not feasible and when the organism is not susceptible to single-agent antibacterials effective in the urinary tract."
+      },
+      {
+        "id": "c2",
+        "text": "ORGANISM EPIDEMIOLOGY (enteritis): It treats enteritis caused by susceptible Shigella flexneri and Shigella sonnei in adults and pediatric patients >=2 months.",
+        "byte_quote": "Sulfamethoxazole and trimethoprim injection is indicated in the treatment of enteritis caused by susceptible strains of Shigella flexneri and Shigella sonnei in adults and pediatric patients two months of age and older."
+      },
+      {
+        "id": "c3",
+        "text": "ORGANISM EPIDEMIOLOGY (PCP): It treats Pneumocystis jirovecii pneumonia in adults and pediatric patients >=2 months.",
+        "byte_quote": "Sulfamethoxazole and trimethoprim injection is indicated in the treatment of Pneumocystis jirovecii pneumonia in adults and pediatric patients two months of age and older."
+      },
+      {
+        "id": "c4",
+        "text": "ANTIBIOTIC DOSING (PCP): 15 to 20 mg/kg/day in 3 or 4 equally divided doses, every 6 to 8 hours, for 14 days.",
+        "byte_quote": "15 to 20 mg/kg (in 3 or 4 equally divided doses)"
+      },
+      {
+        "id": "c5",
+        "text": "ANTIBIOTIC DOSING (severe UTI): 8 to 10 mg/kg/day in 2 to 4 equally divided doses, every 6, 8, or 12 hours, for 14 days.",
+        "byte_quote": "8 to 10 mg/kg (in 2 to 4 equally divided doses)"
+      },
+      {
+        "id": "c6",
+        "text": "ANTIBIOTIC DOSING (administration): Given by intravenous infusion over a period of 60 to 90 minutes.",
+        "byte_quote": "Administer the solution by intravenous infusion over a period of 60 to 90 minutes."
+      },
+      {
+        "id": "c7",
+        "text": "DOSING (renal impairment / nephrotoxicity-related): When renal function is impaired, a reduced dosage should be employed.",
+        "byte_quote": "When renal function is impaired, a reduced dosage should be employed"
+      },
+      {
+        "id": "c8",
+        "text": "CONTRAINDICATION (allergy): Known hypersensitivity to trimethoprim or sulfonamides.",
+        "byte_quote": "Known hypersensitivity to trimethoprim or sulfonamides"
+      },
+      {
+        "id": "c9",
+        "text": "INTERACTION/CONTRAINDICATION (QT): Concomitant administration with dofetilide is contraindicated.",
+        "byte_quote": "Concomitant administration with dofetilide"
+      },
+      {
+        "id": "c10",
+        "text": "HOST/RISK FACTOR (immune status): In AIDS patients treated for P. jirovecii pneumonia, the incidence of adverse reactions (rash, fever, leukopenia, elevated transaminases) is increased versus non-AIDS patients.",
+        "byte_quote": "The incidence of adverse reactions, particularly rash, fever, leukopenia, and elevated aminotransferase (transaminase) values, with sulfamethoxazole and trimethoprim therapy in AIDS patients who are being treated for P. jirovecii pneumonia has been reported to be increased compared with the incidence normally associated with the use of sulfamethoxazole and trimethoprim in non-AIDS patients."
+      },
+      {
+        "id": "c11",
+        "text": "CONTRAINDICATION/INTERACTION (pregnancy): Epidemiologic studies suggest exposure during pregnancy may increase risk of congenital malformations (neural tube defects, cardiovascular, urinary tract, oral clefts, club foot).",
+        "byte_quote": "Some epidemiologic studies suggest that exposure to sulfamethoxazole and trimethoprim during pregnancy may be associated with an increased risk of congenital malformations, particularly neural tube defects, cardiovascular malformations, urinary tract defects, oral clefts, and club foot."
+      },
+      {
+        "id": "c12",
+        "text": "INTERACTION (nephrotoxicity): Marked but reversible nephrotoxicity has been reported with coadministration of sulfamethoxazole/trimethoprim and cyclosporine in renal transplant recipients.",
+        "byte_quote": "There have been reports of marked but reversible nephrotoxicity with coadministration of sulfamethoxazole and trimethoprim and cyclosporine in renal transplant recipients."
+      },
+      {
+        "id": "c13",
+        "text": "ADVERSE EFFECT (QT): QT prolongation resulting in ventricular tachycardia and torsades de pointes has been reported.",
+        "byte_quote": "QT prolongation resulting in ventricular tachycardia and torsades de pointes"
+      }
+    ],
+    "cites": []
+  },
+  {
+    "source_id": "https://dailymed.nlm.nih.gov/dailymed/drugInfo.cfm?setid=65e5f2ee-934c-40d7-967c-00d085f84ffd",
+    "resolved_url": "https://dailymed.nlm.nih.gov/dailymed/drugInfo.cfm?setid=65e5f2ee-934c-40d7-967c-00d085f84ffd",
+    "title": "DailyMed — VANCOMYCIN HYDROCHLORIDE injection, powder, lyophilized, for solution (Gland Pharma Limited)",
+    "claims": [
+      {
+        "id": "c1",
+        "text": "Vancomycin is a glycopeptide antibacterial indicated in adults and pediatric patients (neonates and older).",
+        "byte_quote": "Vancomycin Hydrochloride for Injection is a glycopeptide antibacterial indicated in adult and pediatric patients (neonates and older)"
+      },
+      {
+        "id": "c2",
+        "text": "Vancomycin is a tricyclic glycopeptide whose bactericidal action comes primarily from inhibiting cell-wall biosynthesis.",
+        "byte_quote": "The bactericidal action of vancomycin results primarily from inhibition of cell-wall biosynthesis"
+      },
+      {
+        "id": "c3",
+        "text": "Vancomycin is indicated for septicemia (bloodstream infection) due to susceptible MRSA and coagulase negative staphylococci.",
+        "byte_quote": "for the treatment of septicemia due to: \n Susceptible isolates of methicillin-resistant Staphylococcus aureus (MRSA) and coagulase negative staphylococci."
+      },
+      {
+        "id": "c4",
+        "text": "In penicillin-allergic patients (or those who cannot take / have failed penicillins or cephalosporins), vancomycin covers methicillin-susceptible staphylococci for septicemia.",
+        "byte_quote": "Methicillin-susceptible staphylococci in penicillin-allergic patients, or those patients who cannot receive or who have failed to respond to other drugs, including penicillins or cephalosporins."
+      },
+      {
+        "id": "c5",
+        "text": "Vancomycin treats infective endocarditis due to MRSA; viridans group streptococci, Streptococcus gallolyticus (formerly S. bovis), Enterococcus species, and Corynebacterium species.",
+        "byte_quote": "Viridans group streptococci Streptococcus gallolyticus (previously known as Streptococcus bovis ), Enterococcus species and Corynebacterium species."
+      },
+      {
+        "id": "c6",
+        "text": "For enterococcal endocarditis, vancomycin must be combined with an aminoglycoside.",
+        "byte_quote": "For enterococcal endocarditis, use Vancomycin Hydrochloride for Injection in combination with an aminoglycoside."
+      },
+      {
+        "id": "c7",
+        "text": "Vancomycin treats early-onset prosthetic valve endocarditis caused by Staphylococcus epidermidis, combined with rifampin and an aminoglycoside.",
+        "byte_quote": "for the treatment of early-onset prosthetic valve endocarditis caused by Staphylococcus epidermidis in combination with rifampin and an aminoglycoside."
+      },
+      {
+        "id": "c8",
+        "text": "Vancomycin treats skin and skin structure infections due to susceptible MRSA and coagulase negative staphylococci.",
+        "byte_quote": "for the treatment of skin and skin structure infections due to: \n Susceptible isolates of MRSA and coagulase negative staphylococci."
+      },
+      {
+        "id": "c9",
+        "text": "Vancomycin treats lower respiratory tract infections due to susceptible MRSA.",
+        "byte_quote": "for the treatment of lower respiratory tract infections due to: \n Susceptible isolates of MRSA"
+      },
+      {
+        "id": "c10",
+        "text": "Adult dose with normal renal function is 2 g/day, given as 500 mg every 6 hours or 1 g every 12 hours.",
+        "byte_quote": "The usual daily intravenous dose is 2 grams divided either as 500 mg every 6 hours or 1 g every 12 hours."
+      },
+      {
+        "id": "c11",
+        "text": "Pediatric dose (aged 1 month and older) is 10 mg/kg per dose every 6 hours, each over at least 60 minutes.",
+        "byte_quote": "The usual intravenous dosage of vancomycin is 10 mg/kg per dose given every 6 hours. Each dose should be administered over a period of at least 60 minutes."
+      },
+      {
+        "id": "c12",
+        "text": "Neonatal dose: initial 15 mg/kg, then 10 mg/kg every 12 hours in the first week of life and every 8 hours thereafter up to 1 month of age.",
+        "byte_quote": "In neonates, an initial dose of 15 mg/kg is suggested, followed by 10 mg/kg every 12 hours for neonates in the 1 st week of life and every 8 hours thereafter up to the age of 1 month."
+      },
+      {
+        "id": "c13",
+        "text": "In premature infants vancomycin clearance falls as postconceptional age decreases, so longer dosing intervals may be needed.",
+        "byte_quote": "In premature infants, vancomycin clearance decreases as postconceptional age decreases. Therefore, longer dosing intervals may be necessary in premature infants."
+      },
+      {
+        "id": "c14",
+        "text": "In renal impairment the initial dose should be no less than 15 mg/kg; functionally anephric patients get 15 mg/kg initially then 1.9 mg/kg/24 hr.",
+        "byte_quote": "For functionally anephric patients, an initial dose of 15 mg/kg of body weight should be given to achieve prompt therapeutic serum concentration. A dose of 1.9 mg/kg/24 hr should be given after the initial dose of 15 mg/kg."
+      },
+      {
+        "id": "c15",
+        "text": "Each IV dose should be administered over a period of 60 minutes or greater to reduce infusion reactions.",
+        "byte_quote": "administer Vancomycin Hydrochloride for Injection in a diluted solution over 60 minutes or greater"
+      },
+      {
+        "id": "c16",
+        "text": "Vancomycin is contraindicated in patients with known hypersensitivity to vancomycin.",
+        "byte_quote": "Vancomycin Hydrochloride for Injection is contraindicated in patients with known hypersensitivity to vancomycin."
+      },
+      {
+        "id": "c17",
+        "text": "Vancomycin can cause acute kidney injury including acute renal failure, mainly from interstitial nephritis or less commonly acute tubular necrosis.",
+        "byte_quote": "Vancomycin Hydrochloride for Injection can result in acute kidney injury (AKI), including acute renal failure, mainly due to interstitial nephritis or less commonly acute tubular necrosis."
+      },
+      {
+        "id": "c18",
+        "text": "AKI risk rises with higher vancomycin serum levels, prolonged exposure, concomitant nephrotoxic drugs, concomitant piperacillin-tazobactam, volume depletion, pre-existing renal impairment, and critical illness.",
+        "byte_quote": "The risk of AKI increases with higher vancomycin serum levels, prolonged exposure, concomitant administration of other nephrotoxic drugs, concomitant administration of piperacillin-tazobactam"
+      },
+      {
+        "id": "c19",
+        "text": "Concomitant piperacillin/tazobactam plus vancomycin increases acute kidney injury incidence versus vancomycin alone.",
+        "byte_quote": "Increased incidence of acute kidney injury in patients receiving concomitant piperacillin/tazobactam and vancomycin as compared to vancomycin alone."
+      },
+      {
+        "id": "c20",
+        "text": "Concomitant vancomycin and anesthetic agents has been associated with erythema and histamine-like flushing.",
+        "byte_quote": "Concomitant administration of vancomycin and anesthetic agents has been associated with erythema and histaminelike flushing."
+      },
+      {
+        "id": "c21",
+        "text": "Ototoxicity risk is higher in older patients, those on higher doses, with underlying hearing loss, on concomitant ototoxic agents (e.g. aminoglycoside), or with renal impairment.",
+        "byte_quote": "The risk is higher in older patients, patients who are receiving higher doses, who have an underlying hearing loss, who are receiving concomitant therapy with another ototoxic agent, such as an aminoglycoside or who have underlying renal impairment."
+      },
+      {
+        "id": "c22",
+        "text": "Reversible neutropenia has been reported; patients on prolonged therapy or concomitant neutropenia-causing drugs should have periodic leukocyte counts.",
+        "byte_quote": "Reversible neutropenia has been reported in patients receiving Vancomycin Hydrochloride for Injection"
+      },
+      {
+        "id": "c23",
+        "text": "No available data on vancomycin use in pregnant women inform a drug-associated risk of major birth defects or miscarriage (pregnancy section).",
+        "byte_quote": "“vancomycin infusion reaction”, which manifests as pruritus and erythema that involves the face, neck and upper torso"
+      }
+    ],
+    "cites": [
+      "Byrd RA, Gries CL, Buening M. Developmental Toxicology Studies of Vancomycin Hydrochloride Administered Intravenously to Rats and Rabbits. Fundam Appl Toxicol 1994; 23: 590-597."
+    ]
+  },
+  {
+    "source_id": "https://dailymed.nlm.nih.gov/dailymed/fda/fdaDrugXsl.cfm?setid=f604d399-fded-4f4f-8efe-af558ed07b9d",
+    "resolved_url": "https://dailymed.nlm.nih.gov/dailymed/fda/fdaDrugXsl.cfm?setid=f604d399-fded-4f4f-8efe-af558ed07b9d",
+    "title": "Vancomycin Hydrochloride for Injection, USP — DailyMed FDA Label",
+    "claims": [
+      {
+        "id": "c1",
+        "text": "Vancomycin is indicated for serious/severe infections caused by methicillin-resistant (beta-lactam-resistant) staphylococci, and for penicillin-allergic patients.",
+        "byte_quote": "Vancomycin Hydrochloride for Injection, USP is indicated for the treatment of serious or severe infections caused by susceptible strains of methicillin-resistant (β-lactam-resistant) staphylococci. It is indicated for penicillin-allergic patients, for patients who cannot receive or who have failed to respond to other drugs, including the penicillins or cephalosporins"
+      },
+      {
+        "id": "c2",
+        "text": "Susceptible organisms include Staphylococcus aureus and S. epidermidis (including heterogeneous methicillin-resistant strains).",
+        "byte_quote": "Staphylococci, including Staphylococcus aureus and Staphylococcus epidermidis (including heterogeneous methicillin-resistant strains)"
+      },
+      {
+        "id": "c3",
+        "text": "Susceptible organisms also include enterococci (e.g. Enterococcus faecalis), viridans group streptococci, Streptococcus bovis, and diphtheroids.",
+        "byte_quote": "Enterococci (e.g., Enterococcus faecalis )"
+      },
+      {
+        "id": "c4",
+        "text": "Vancomycin is not active in vitro against gram-negative bacilli, mycobacteria, or fungi.",
+        "byte_quote": "Vancomycin is not active in vitro against gram-negative bacilli, mycobacteria, or fungi."
+      },
+      {
+        "id": "c5",
+        "text": "Bloodstream/endocardial indications: vancomycin is effective in staphylococcal endocarditis, septicemia, bone infections, lower respiratory tract infections, and skin/skin-structure infections due to staphylococci.",
+        "byte_quote": "Vancomycin Hydrochloride for Injection, USP is effective in the treatment of staphylococcal endocarditis. Its effectiveness has been documented in other infections due to staphylococci, including septicemia, bone infections, lower respiratory tract infections, skin and skin structure infections."
+      },
+      {
+        "id": "c6",
+        "text": "For endocarditis caused by S. viridans or S. bovis, vancomycin is effective alone or with an aminoglycoside; for enterococcal endocarditis (e.g. E. faecalis) it is effective only combined with an aminoglycoside.",
+        "byte_quote": "has been reported to be effective alone or in combination with an aminoglycoside for endocarditis caused by S. viridans or S. bovis. For endocarditis caused by enterococci (e.g., E. faecalis ), vancomycin has been reported to be effective only in combination with an aminoglycoside."
+      },
+      {
+        "id": "c7",
+        "text": "Early-onset prosthetic valve endocarditis caused by S. epidermidis or diphtheroids is treated with vancomycin plus rifampin and/or an aminoglycoside.",
+        "byte_quote": "has been used successfully in combination with either rifampin, an aminoglycoside, or both in early-onset prosthetic valve endocarditis caused by S. epidermidis or diphtheroids."
+      },
+      {
+        "id": "c8",
+        "text": "Oral vancomycin (parenteral form given orally) treats antibiotic-associated pseudomembranous colitis produced by C. difficile and staphylococcal enterocolitis.",
+        "byte_quote": "may be administered orally for treatment of antibiotic-associated pseudomembranous colitis produced by C. difficile and for staphylococcal enterocolitis."
+      },
+      {
+        "id": "c9",
+        "text": "Usual adult IV dose is 2 g/day, given as 500 mg every 6 hours or 1 g every 12 hours, each dose infused at no more than 10 mg/min or over at least 60 minutes.",
+        "byte_quote": "The usual daily intravenous dose is 2 g divided either as 500 mg every 6 hours or 1 g every 12 hours. Each dose should be administered at no more than 10 mg/min or over a period of at least 60 minutes, whichever is longer."
+      },
+      {
+        "id": "c10",
+        "text": "Usual pediatric IV dose is 10 mg/kg per dose every 6 hours, each over at least 60 minutes.",
+        "byte_quote": "The usual intravenous dosage of vancomycin is 10 mg/kg per dose given every 6 hours. Each dose should be administered over a period of at least 60 minutes."
+      },
+      {
+        "id": "c11",
+        "text": "Neonatal dosing: initial 15 mg/kg, then 10 mg/kg every 12 hours in the 1st week of life and every 8 hours thereafter up to age 1 month.",
+        "byte_quote": "In neonates, an initial dose of 15 mg/kg is suggested, followed by 10 mg/kg every 12 hours for neonates in the 1st week of life and every 8 hours thereafter up to the age of 1 month."
+      },
+      {
+        "id": "c12",
+        "text": "Oral dosing for C. difficile colitis: adult 500 mg to 2 g/day in 3-4 divided doses for 7-10 days; children 40 mg/kg/day in 3-4 divided doses, not exceeding 2 g/day.",
+        "byte_quote": "The usual adult total daily dosage is 500 mg to 2 g given in 3 or 4 divided doses for 7 to 10 days. The total daily dose in children is 40 mg/kg of body weight in 3 or 4 divided doses for 7 to 10 days. The total daily dosage should not exceed 2 g."
+      },
+      {
+        "id": "c13",
+        "text": "Renal impairment: initial dose should be no less than 15 mg/kg even with mild-to-moderate insufficiency; anephric patients get 15 mg/kg initial then 1.9 mg/kg/24 hr maintenance; in anuria 1,000 mg every 7 to 10 days.",
+        "byte_quote": "The initial dose should be no less than 15 mg/kg, even in patients with mild to moderate renal insufficiency. The table is not valid for functionally anephric patients. For such patients, an initial dose of 15 mg/kg of body weight should be given to achieve prompt therapeutic serum concentrations. The dose required to maintain stable concentrations is 1.9 mg/kg/24 hr."
+      },
+      {
+        "id": "c14",
+        "text": "Contraindicated in patients with known hypersensitivity to vancomycin.",
+        "byte_quote": "Vancomycin hydrochloride for injection is contraindicated in patients with known hypersensitivity to this antibiotic."
+      },
+      {
+        "id": "c15",
+        "text": "Systemic vancomycin exposure may cause acute kidney injury (AKI); risk rises with increasing serum levels; monitor renal function in all patients, especially those with renal impairment or on nephrotoxic drugs.",
+        "byte_quote": "Systemic vancomycin exposure may result in acute kidney injury (AKI). The risk of AKI increases as systemic exposure/serum levels increase. Monitor renal function in all patients, especially patients with underlying renal impairment, patients with co-morbidities that predispose to renal impairment, and patients receiving concomitant therapy with a drug known to be nephrotoxic."
+      },
+      {
+        "id": "c16",
+        "text": "Ototoxicity occurs mostly with excessive doses, underlying hearing loss, or concomitant ototoxic agents such as an aminoglycoside.",
+        "byte_quote": "It has been reported mostly in patients who have been given excessive doses, who have an underlying hearing loss, or who are receiving concomitant therapy with another ototoxic agent, such as an aminoglycoside."
+      },
+      {
+        "id": "c17",
+        "text": "Monitor renal function when vancomycin is used with other neurotoxic/nephrotoxic drugs such as amphotericin B, aminoglycosides, bacitracin, polymixin B, colistin, viomycin, or cisplatin.",
+        "byte_quote": "Monitor renal function in patients receiving vancomycin and concurrent and/or sequential systemic or topical use of other potentially, neurotoxic and/or nephrotoxic drugs, such as amphotericin B, aminoglycosides, bacitracin, polymixin B, colistin, viomycin, or cisplatin."
+      },
+      {
+        "id": "c18",
+        "text": "Concomitant vancomycin and anesthetic agents has been associated with erythema and histamine-like flushing and anaphylactoid reactions.",
+        "byte_quote": "Concomitant administration of vancomycin and anesthetic agents has been associated with erythema and histamine-like flushing (see Pediatric Use - PRECAUTIONS ) and anaphylactoid reactions"
+      },
+      {
+        "id": "c19",
+        "text": "Reversible neutropenia has been reported; patients on prolonged therapy or concomitant neutropenia-causing drugs should have periodic leukocyte count monitoring.",
+        "byte_quote": "Reversible neutropenia has been reported in patients receiving vancomycin hydrochloride for injection (see ADVERSE REACTIONS ). Patients who will undergo prolonged therapy with vancomycin hydrochloride for injection or those who are receiving concomitant drugs which may cause neutropenia should have periodic monitoring of the leukocyte count."
+      },
+      {
+        "id": "c20",
+        "text": "Pregnancy: not known whether vancomycin causes fetal harm; it crossed into cord blood with no attributable hearing loss/nephrotoxicity; give to pregnant women only if clearly needed.",
+        "byte_quote": "Vancomycin was found in cord blood. No sensorineural hearing loss or nephrotoxicity attributable to vancomycin was noted."
+      },
+      {
+        "id": "c21",
+        "text": "Vancomycin is excreted in human milk; caution in nursing women.",
+        "byte_quote": "Vancomycin hydrochloride for injection is excreted in human milk. Caution should be exercised when vancomycin hydrochloride for injection is administered to a nursing woman."
+      },
+      {
+        "id": "c22",
+        "text": "Vancomycin plus an aminoglycoside acts synergistically in vitro against many strains of S. aureus, S. bovis, enterococci, and viridans group streptococci.",
+        "byte_quote": "The combination of vancomycin and an aminoglycoside acts synergistically in vitro against many strains of Staphylococcus aureus , Streptococcus bovis , enterococci, and the viridans group streptococci."
+      },
+      {
+        "id": "c23",
+        "text": "Bactericidal action results primarily from inhibition of cell-wall biosynthesis; vancomycin also alters cell-membrane permeability and RNA synthesis.",
+        "byte_quote": "The bactericidal action of vancomycin results primarily from inhibition of cell-wall biosynthesis. In addition, vancomycin alters bacterial-cell-membrane permeability and RNA synthesis."
+      }
+    ],
+    "cites": [
+      "Moellering RC, Krogstad DJ, Greenblatt DJ: Vancomycin therapy in patients with impaired renal function: A nomogram for dosage. Ann Inter Med 1981; 94:343.",
+      "FDA Susceptibility Test Interpretive Criteria (STIC) — https://www.fda.gov/STIC"
+    ]
+  },
+  {
+    "source_id": "https://dailymed.nlm.nih.gov/dailymed/fda/fdaDrugXsl.cfm?setid=99e523d8-9bde-43cb-8434-497015e5dcbd",
+    "resolved_url": "https://dailymed.nlm.nih.gov/dailymed/fda/fdaDrugXsl.cfm?setid=99e523d8-9bde-43cb-8434-497015e5dcbd",
+    "title": "Vancomycin Injection, USP (vancomycin hydrochloride) — FDA Label (DailyMed)",
+    "claims": [
+      {
+        "id": "c1",
+        "text": "Vancomycin is active against most isolates of gram-positive bacteria in vitro and in clinical infections.",
+        "byte_quote": "Vancomycin has been shown to be active against most isolates of the following bacteria, both in vitro and in clinical infections"
+      },
+      {
+        "id": "c2",
+        "text": "Vancomycin's gram-positive spectrum includes Corynebacterium spp., Enterococcus spp. (incl. E. faecalis), Staphylococcus aureus (MRSA and MSSA), coagulase-negative staphylococci (incl. S. epidermidis and MR isolates), Streptococcus gallolyticus (formerly S. bovis), and viridans group streptococci.",
+        "byte_quote": "Corynebacterium spp. Enterococcus spp. (including Enterococcus faecalis) Staphylococcus aureus (including methicillin-resistant and methicillin-susceptible isolates) Coagulase negative staphylococci (including S. epidermidis and methicillin-resistant isolates) Streptococcus gallolyticus (previously known as Streptococcus bovis) Viridans group streptococci"
+      },
+      {
+        "id": "c3",
+        "text": "Vancomycin is NOT active in vitro against gram-negative bacilli, mycobacteria, or fungi (gram-stain spectrum boundary).",
+        "byte_quote": "Vancomycin is not active in vitro against gram-negative bacilli, mycobacteria, or fungi."
+      },
+      {
+        "id": "c4",
+        "text": "Vancomycin is indicated for septicemia/bloodstream infection due to susceptible MRSA and coagulase-negative staphylococci.",
+        "byte_quote": "Susceptible isolates of methicillin-resistant Staphylococcus aureus (MRSA) and coagulase negative staphylococci."
+      },
+      {
+        "id": "c5",
+        "text": "Vancomycin is used for methicillin-susceptible staphylococci in penicillin-allergic patients or those who cannot receive/failed penicillins or cephalosporins (allergy cross-reactivity / drug-failure host factor).",
+        "byte_quote": "Methicillin-susceptible staphylococci in penicillin-allergic patients, or those patients who cannot receive or who have failed to respond to other drugs, including penicillins or cephalosporins."
+      },
+      {
+        "id": "c6",
+        "text": "For infective endocarditis, vancomycin covers susceptible MRSA, viridans group streptococci or S. gallolyticus (formerly S. bovis), Enterococcus species, and Corynebacterium species.",
+        "byte_quote": "Susceptible isolates of MRSA. Viridans group streptococci or Streptococcus gallolyticus (previously known as Streptococcus bovis) and Enterococcus species and Corynebacterium species."
+      },
+      {
+        "id": "c7",
+        "text": "Adult dosing with normal renal function: 2 g daily IV, divided as 500 mg every 6 hours or 1 g every 12 hours.",
+        "byte_quote": "The usual daily intravenous dosage of Vancomycin Injection is 2 grams (g) divided either as 500 mg every 6 hours or 1 g every 12 hours."
+      },
+      {
+        "id": "c8",
+        "text": "Pediatric dosing (>=1 month) with normal renal function: 10 mg/kg per dose every 6 hours.",
+        "byte_quote": "The usual intravenous dosage of vancomycin is 10 mg/kg per dose given every 6 hours."
+      },
+      {
+        "id": "c9",
+        "text": "Neonatal dosing: initial 15 mg/kg, then 10 mg/kg every 12 hours in the 1st week of life and every 8 hours thereafter up to 1 month of age.",
+        "byte_quote": "In neonates, an initial dose of 15 mg/kg is suggested, followed by 10 mg/kg every 12 hours for neonates in the 1st week of life and every 8 hours thereafter up to the age of 1 month."
+      },
+      {
+        "id": "c10",
+        "text": "In renal impairment the initial dose should be no less than 15 mg/kg regardless of degree of impairment; dose must be adjusted.",
+        "byte_quote": "The initial dose should be no less than 15 mg/kg in patients with any degree of renal impairment."
+      },
+      {
+        "id": "c11",
+        "text": "Infusion-related adverse reactions are fewer at an infusion rate of 10 mg/min or less; each dose given over >=60 minutes.",
+        "byte_quote": "An infusion rate of 10 mg/min or less is associated with fewer infusion-related adverse reactions."
+      },
+      {
+        "id": "c12",
+        "text": "Vancomycin is contraindicated in patients with known hypersensitivity to vancomycin.",
+        "byte_quote": "Vancomycin Injection is contraindicated in patients with known hypersensitivity to vancomycin."
+      },
+      {
+        "id": "c13",
+        "text": "Dextrose-containing vancomycin solutions may be contraindicated in patients with known corn/corn-product allergy.",
+        "byte_quote": "Solutions containing dextrose including Vancomycin Injection, may be contraindicated in patients with a known allergy to corn or corn products."
+      },
+      {
+        "id": "c14",
+        "text": "Vancomycin can cause acute kidney injury (AKI), including acute renal failure, mainly via interstitial nephritis or less commonly acute tubular necrosis (nephrotoxicity).",
+        "byte_quote": "Vancomycin Injection can result in acute kidney injury (AKI), including acute renal failure, mainly due to interstitial nephritis or less commonly acute tubular necrosis."
+      },
+      {
+        "id": "c15",
+        "text": "AKI risk rises with higher vancomycin serum levels, prolonged exposure, concomitant nephrotoxic drugs, concomitant piperacillin-tazobactam, volume depletion, pre-existing renal impairment, critical illness, and predisposing comorbidities.",
+        "byte_quote": "The risk of AKI increases with higher vancomycin serum levels, prolonged exposure, concomitant administration of other nephrotoxic drugs, concomitant administration of piperacillin-tazobactam, volume depletion, pre-existing renal impairment and in critically ill patients and patients with co-morbid conditions that predispose to renal impairment."
+      },
+      {
+        "id": "c16",
+        "text": "Concomitant piperacillin/tazobactam plus vancomycin increases incidence of AKI versus vancomycin alone (drug interaction).",
+        "byte_quote": "Studies have detected an increased incidence of acute kidney injury in patients administered concomitant piperacillin/tazobactam and vancomycin as compared to vancomycin alone."
+      },
+      {
+        "id": "c17",
+        "text": "Ototoxicity risk is higher in older patients, those on higher doses, with underlying hearing loss, on concomitant ototoxic agents such as aminoglycosides, or with renal impairment.",
+        "byte_quote": "The risk is higher in older patients, patients who are receiving higher doses, who have an underlying hearing loss, who are receiving concomitant therapy with another ototoxic agent, such as an aminoglycoside or who have underlying renal impairment."
+      },
+      {
+        "id": "c18",
+        "text": "Reversible neutropenia has been reported with vancomycin; monitor leukocyte count in prolonged therapy or with concomitant neutropenia-causing drugs.",
+        "byte_quote": "Reversible neutropenia has been reported in patients receiving vancomycin. Patients who will undergo prolonged therapy with vancomycin or those who are receiving concomitant drugs that may cause neutropenia should have periodic monitoring of the leukocyte count."
+      },
+      {
+        "id": "c19",
+        "text": "Concomitant vancomycin and anesthetic agents has been associated with erythema and histamine-like flushing (interaction).",
+        "byte_quote": "Concomitant administration of vancomycin and anesthetic agents has been associated with erythema and histamine-like flushing."
+      },
+      {
+        "id": "c20",
+        "text": "Available data over decades of vancomycin use in pregnant women have not identified a drug-associated risk of major birth defects, miscarriage, or adverse maternal/fetal outcomes (pregnancy).",
+        "byte_quote": "Available data over several decades of vancomycin use in pregnant women have not identified a drug-associated risk of major birth defects, miscarriage, or adverse maternal or fetal outcomes."
+      },
+      {
+        "id": "c21",
+        "text": "Elderly patients are more likely to have decreased renal function, increasing adverse-reaction risk; dose selection requires care.",
+        "byte_quote": "Because elderly patients are more likely to have decreased renal function, care should be taken in dose selection."
+      }
+    ],
+    "cites": [
+      "Byrd RA, Gries CL, Buening M. Developmental Toxicology Studies of Vancomycin Hydrochloride Administered Intravenously to Rats and Rabbits. Fundam Appl Toxicol 1994;23:590-597.",
+      "Rybak MJ. The pharmacokinetic and pharmacodynamic properties of vancomycin. Clinical Infectious Diseases. 2006;42(Suppl 1):S35-S39.",
+      "Rybak MJ, Le J, Lodise TP, et al. Therapeutic monitoring of vancomycin for serious methicillin-resistant Staphylococcus aureus infections: a revised consensus guideline and review by ASHP, IDSA, PIDS, and SIDP. Clinical Infectious Diseases. 2020;71(6):1361-1364.",
+      "FDA Susceptibility Test Interpretive Criteria (STIC)"
+    ]
+  },
+  {
+    "source_id": "https://pubmed.ncbi.nlm.nih.gov/15306996/",
+    "resolved_url": "https://pubmed.ncbi.nlm.nih.gov/15306996/",
+    "title": "Nosocomial bloodstream infections in US hospitals: analysis of 24,179 cases from a prospective nationwide surveillance study (Wisplinghoff et al., Clin Infect Dis 2004;39:309-17)",
+    "claims": [
+      {
+        "id": "c1",
+        "text": "Among nosocomial bloodstream infections, gram-positive organisms caused 65%, gram-negative organisms 25%, and fungi 9.5%.",
+        "byte_quote": "Gram-positive organisms caused 65% of these BSIs, gram-negative organisms caused 25%, and fungi caused 9.5%."
+      },
+      {
+        "id": "c2",
+        "text": "The most common organisms causing bloodstream infections were coagulase-negative staphylococci (31%), Staphylococcus aureus (20%), enterococci (9%), and Candida species (9%).",
+        "byte_quote": "The most-common organisms causing BSIs were coagulase-negative staphylococci (CoNS) (31% of isolates), Staphylococcus aureus (20%), enterococci (9%), and Candida species (9%)."
+      },
+      {
+        "id": "c3",
+        "text": "Eighty-seven percent of nosocomial bloodstream infections were monomicrobial.",
+        "byte_quote": "Eighty-seven percent of BSIs were monomicrobial."
+      },
+      {
+        "id": "c4",
+        "text": "The crude mortality rate of nosocomial bloodstream infection was 27%.",
+        "byte_quote": "The crude mortality rate was 27%."
+      },
+      {
+        "id": "c5",
+        "text": "ICU admission (host setting) raised the likelihood of bloodstream infection with CoNS, Pseudomonas, Enterobacter, Serratia, and Acinetobacter species.",
+        "byte_quote": "CoNS, Pseudomonas species, Enterobacter species, Serratia species, and Acinetobacter species were more likely to cause infections in patients in intensive care units (P<.001)."
+      },
+      {
+        "id": "c6",
+        "text": "Neutropenia raised the likelihood of bloodstream infection with Candida species, enterococci, and viridans group streptococci.",
+        "byte_quote": "In neutropenic patients, infections with Candida species, enterococci, and viridans group streptococci were significantly more common."
+      },
+      {
+        "id": "c7",
+        "text": "Mean interval from admission to infection varied by organism: 13 days for E. coli, 16 for S. aureus, 22 for Candida and Klebsiella, 23 for enterococci, and 26 for Acinetobacter.",
+        "byte_quote": "The mean interval between admission and infection was 13 days for infection with Escherichia coli, 16 days for S. aureus, 22 days for Candida species and Klebsiella species, 23 days for enterococci, and 26 days for Acinetobacter species."
+      },
+      {
+        "id": "c8",
+        "text": "Methicillin resistance among S. aureus bloodstream isolates rose from 22% in 1995 to 57% in 2001.",
+        "byte_quote": "The proportion of S. aureus isolates with methicillin resistance increased from 22% in 1995 to 57% in 2001 (P<.001, trend analysis)."
+      },
+      {
+        "id": "c9",
+        "text": "Vancomycin resistance was 2% in Enterococcus faecalis and 60% in Enterococcus faecium bloodstream isolates.",
+        "byte_quote": "Vancomycin resistance was seen in 2% of Enterococcus faecalis isolates and in 60% of Enterococcus faecium isolates."
+      },
+      {
+        "id": "c10",
+        "text": "The study detected 24,179 nosocomial bloodstream infections in 49 US hospitals over 7 years (60 cases per 10,000 hospital admissions).",
+        "byte_quote": "Our study detected 24,179 cases of nosocomial BSI in 49 US hospitals over a 7-year period from March 1995 through September 2002 (60 cases per 10,000 hospital admissions)."
+      }
+    ],
+    "cites": []
+  },
+  {
+    "source_id": "https://pmc.ncbi.nlm.nih.gov/articles/PMC8785473/",
+    "resolved_url": "https://pmc.ncbi.nlm.nih.gov/articles/PMC8785473/",
+    "title": "Blood bacterial resistant investigation collaborative system (BRICS) report: a national surveillance in China from 2014 to 2019",
+    "claims": [
+      {
+        "id": "c1",
+        "text": "In Chinese bloodstream infections (2014-2019), Gram-negative organisms predominate at 70.5% (19,655 isolates) vs Gram-positive at 29.5% (8,244 isolates).",
+        "byte_quote": "Gram-positive organisms accounted for 29.5% (8244) of the species identified and Gram-negative organisms accounted for 70.5% (19,655)."
+      },
+      {
+        "id": "c2",
+        "text": "The most common bloodstream-infection organisms, in rank order, are E. coli, K. pneumoniae, S. aureus, coagulase-negative Staphylococci, and A. baumannii.",
+        "byte_quote": "The most-commonly isolated organisms in blood cultures were _Escherichia coli_, _Klebsiella pneumoniae_, _Staphylococcus aureus_, coagulase-negative _Staphylococci_, and _Acinetobacter baumannii_."
+      },
+      {
+        "id": "c3",
+        "text": "E. coli's share of bloodstream isolates rose from 29.1% to 38.5% across the study period.",
+        "byte_quote": "Notably, _E. coli_ increased 29.1% to 38.5% during the study period."
+      },
+      {
+        "id": "c4",
+        "text": "Methicillin-resistant S. aureus (MRSA) prevalence fell from 39.0% (73/187) in 2014 to 25.9% (230/889) in 2019.",
+        "byte_quote": "The prevalence of methicillin-resistant _S. aureus_ declined from 39.0% (73/187) in 2014 to 25.9% (230/889) in 2019 (_p_ < 0.05)."
+      },
+      {
+        "id": "c5",
+        "text": "ESBL-producing E. coli prevalence dropped from 61.2% (412/673) to 51.0% (1878/3,683) over the study period.",
+        "byte_quote": "The prevalence of ESBL-_E. coli_ dropped from 61.2% (412/673) to 51.0% (1878/3,683) over time (_p_ < 0.05)."
+      },
+      {
+        "id": "c6",
+        "text": "Carbapenem-resistant K. pneumoniae rose sharply from 7.0% (16/229) in 2014 to 19.6% (325/1,655) in 2019.",
+        "byte_quote": "carbapenem-resistant _K. pneumoniae_ increased markedly from 7.0% (16/229) in 2014 to 19.6% (325/1,655) in 2019 (_p_ < 0.05)."
+      },
+      {
+        "id": "c7",
+        "text": "Estimated bloodstream-infection (BSI) incidence is 113 to 204 per 100,000 population (attributed to reference 5).",
+        "byte_quote": "It was estimated that the BSI incidence ranged between 113 and 204 per 100,000 in the population [[5](#CR5)]."
+      },
+      {
+        "id": "c8",
+        "text": "Recommended blood culture sampling frequency is 100 to 200 blood culture sets per 1,000 patient days (attributed to reference 15).",
+        "byte_quote": "The frequency of blood cultures is recommended for 100 to 200 blood cultures sets per 1,000 patient days [[15](#CR15)]."
+      },
+      {
+        "id": "c9",
+        "text": "The surveillance collected 27,899 isolates total over the 6-year period.",
+        "byte_quote": "Over the 6-year period, 27,899 isolates were collected in total."
+      }
+    ],
+    "cites": [
+      "Reference [5] (cited for BSI incidence of 113-204 per 100,000 population)",
+      "Reference [15] (cited for blood culture frequency of 100-200 sets per 1,000 patient days)",
+      "Reference [16] — 2018 annual report of the European Antimicrobial Resistance Surveillance Network (EARS-Net)",
+      "Reference [1] — WHO recommendations"
+    ]
+  },
+  {
+    "source_id": "https://www.cambridge.org/core/journals/epidemiology-and-infection/article/burden-of-communityonset-bloodstream-infection-a-populationbased-assessment/4C3033D11C42B1D2B68B3580C283DB9A",
+    "resolved_url": "https://www.cambridge.org/core/journals/epidemiology-and-infection/article/burden-of-communityonset-bloodstream-infection-a-populationbased-assessment/4C3033D11C42B1D2B68B3580C283DB9A",
+    "title": "The burden of community-onset bloodstream infection: a population-based assessment (Epidemiology and Infection)",
+    "claims": [
+      {
+        "id": "c1",
+        "text": "The three species E. coli, S. aureus, and Str. pneumoniae cause the majority of community-onset bloodstream infections.",
+        "byte_quote": "the three species _Escherichia coli_, _Staphyloccocus_ (_S_.) _aureus_, and _Streptococcus_ (_Str_.) _pneumoniae_ were responsible for the majority of cases"
+      },
+      {
+        "id": "c2",
+        "text": "Overall, E. coli accounted for 30%, S. aureus 16%, and Str. pneumoniae 12% of community-onset BSI cases.",
+        "byte_quote": "_Escherichia coli_ (30%), _S. aureus_ (16%), and _Str. pneumoniae_ (12%) were the most important agents"
+      },
+      {
+        "id": "c3",
+        "text": "Organism proportions vary by age band: in <1yr E. coli/S. aureus/Str. pneumoniae were 35%/9%/19%; in 1-19yr 11%/17%/33%; in 20-64yr 29%/17%/13%; in >=65yr 34%/15%/7%.",
+        "byte_quote": "_E. coli_, _S. aureus_, and _Str. pneumoniae_ were responsible for 35%, 9%, and 19% of infections in those aged <1 year, 11%, 17%, and 33% in those aged 1–19 years, 29%, 17%, and 13% in thoase aged 20–64, and 34%, 15%, and 7% in those aged ⩾65 years"
+      },
+      {
+        "id": "c4",
+        "text": "Isolate counts: E. coli 1414, S. aureus 737, Str. pneumoniae 552 isolates.",
+        "byte_quote": "_Escherichia coli_ (1414 isolates), _Staphylococcus aureus_ (737 isolates), and _Streptococcus pneumoniae_ (552 isolates) were responsible for the majority of cases"
+      },
+      {
+        "id": "c5",
+        "text": "Age and gender strongly affect incidence: the very young and the elderly are at highest risk.",
+        "byte_quote": "there was a dramatic relationship observed between age and gender and the incidence of community-onset BSI with the very young and the elderly at highest risk"
+      },
+      {
+        "id": "c6",
+        "text": "In those aged >=60 years, men had significantly higher BSI risk than women (396.1 vs 292.5 per 100000; RR 1.35).",
+        "byte_quote": "in those aged ⩾60 years, men were at significantly higher risk compared to women (396.1 _vs_. 292.5/100 000; RR 1·35)"
+      },
+      {
+        "id": "c7",
+        "text": "Poly-microbial infections were significantly associated with older median patient age (69.9 vs 62.3 years, P<0.001).",
+        "byte_quote": "poly-microbial infections were...significantly associated with older median patient age (69·9 _vs_. 62·3 years, _P_<0·001)"
+      },
+      {
+        "id": "c8",
+        "text": "The overall annual incidence of community-onset BSI was 81.6 per 100000 population, from 4467 episodes among 4192 residents.",
+        "byte_quote": "a total of 4467 episodes of community-onset BSI were identified among 4192 CHR residents for an overall annual incidence of 81·6/100 000 population"
+      },
+      {
+        "id": "c9",
+        "text": "Case-fatality rate was 13%: among 3445 admitted episodes, 460 resulted in in-hospital death.",
+        "byte_quote": "Among the 3445 episodes of community-onset BSI that required hospital admission, 460 were associated with in-hospital death for a case-fatality rate of 13%"
+      },
+      {
+        "id": "c10",
+        "text": "Study setting: Calgary Health Region, a publicly funded health system serving over one million residents (population denominator for the population-based assessment).",
+        "byte_quote": "Calgary Health Region (CHR) is a health system that provides all medically necessary, publicly funded health care to the more than one million residents"
+      },
+      {
+        "id": "c11",
+        "text": "77% of episodes resulted in hospital admission, representing 0.7% of all admissions.",
+        "byte_quote": "77% episodes resulted in hospital admission representing 0·7% of all admissions"
+      },
+      {
+        "id": "c12",
+        "text": "Citing Pedersen et al., E. coli was the most important aetiology (605 episodes, 33%).",
+        "byte_quote": "Pedersen _et al_. also found that _E. coli_ (605 episodes, 33%) was the most important aetiology"
+      },
+      {
+        "id": "c13",
+        "text": "Citing Madsen et al., population-based surveillance found an E. coli bacteraemia incidence of ~32 per 100000.",
+        "byte_quote": "Madsen _et al_. conducted population-based surveillance...and found an incidence of _E. coli_ bacteraemia of ∼32/100 000"
+      }
+    ],
+    "cites": [
+      "Pedersen et al.",
+      "Madsen et al."
+    ]
+  },
+  {
+    "source_id": "https://pmc.ncbi.nlm.nih.gov/articles/PMC10699684/",
+    "resolved_url": "https://pmc.ncbi.nlm.nih.gov/articles/PMC10699684/",
+    "title": "Pseudomonas aeruginosa: Infections and novel approaches to treatment \"Knowing the enemy\" the threat of Pseudomonas aeruginosa and exploring novel approaches to treatment (Infect Med (Beijing). 2023;2(3):178-194)",
+    "claims": [
+      {
+        "id": "c1",
+        "text": "P. aeruginosa is a Gram-negative, motile, nonfermenting, rod-shaped (bacillus) bacterium.",
+        "byte_quote": "Pseudomonas aeruginosa is a motile, nonfermenting, Gram-negative, rod-shaped"
+      },
+      {
+        "id": "c2",
+        "text": "P. aeruginosa colonizes healthy people: isolated from the throat of 5% and stools of 3% of nonhospitalized patients.",
+        "byte_quote": "has also been isolated from the throat (5%) and stools (3%) of nonhospitalized patients"
+      },
+      {
+        "id": "c3",
+        "text": "P. aeruginosa is the 4th leading cause of HAIs, accounts for 20% of all HAIs in Europe/US, and is responsible for 75% of deaths of severely burnt patients.",
+        "byte_quote": "It is the fourth leading cause of hospital-associated infections (HAIs) and accounts for 20% of all HAIs in Europe and United States [45] and is responsible for 75% of all deaths of severely burnt patients [46]."
+      },
+      {
+        "id": "c4",
+        "text": "P. aeruginosa is the 2nd most common cause of ventilator-associated pneumonia in the US and ranks 3rd among catheter-associated UTIs.",
+        "byte_quote": "P. aeruginosa is the second most common cause of ventilator-associated pneumonia in the United States [43], and ranks third among urinary tract infections associated with catheters [44]."
+      },
+      {
+        "id": "c5",
+        "text": "P. aeruginosa causes 3%-7% of bloodstream infection cases, with 27%-48% morbidity/mortality in critically ill patients.",
+        "byte_quote": "The bacterium is responsible for 3%–7% of blood stream infection cases with high morbidity and mortality rates (27%–48%) in critically ill patients [125,126]."
+      },
+      {
+        "id": "c6",
+        "text": "P. aeruginosa is the 3rd most common Gram-negative cause of nosocomial bloodstream infection, accounting for 4.3% of all nosocomial BSI cases.",
+        "byte_quote": "reported P. aeruginosa as the third most common Gram-negative bacteria causing nosocomial BSI and accounted for 4.3% of all cases."
+      },
+      {
+        "id": "c7",
+        "text": "Patients with burns and AIDS are more vulnerable to systemic (bloodstream) P. aeruginosa infection.",
+        "byte_quote": "Patients with burns and AIDs are more vulnerable to systemic infection by P. aeruginosa"
+      },
+      {
+        "id": "c8",
+        "text": "In adult neutropenic oncohematological patients (incl. HSCT recipients), P. aeruginosa BSI isolates were 25.4% MDR and 19.3% XDR.",
+        "byte_quote": "P. aeruginosa strains isolated from adult neutropenic oncohematological patients, including hematopoietic stem cell transplant recipients, were caused by multi drug resistant (25.4%) and extensively drug resistant bacteria (19.3%)."
+      },
+      {
+        "id": "c9",
+        "text": "P. aeruginosa is associated with 7%-12% of all nosocomial UTIs.",
+        "byte_quote": "associated with 7%–12% of all nosocomial urinary tract infections [44,127]."
+      },
+      {
+        "id": "c10",
+        "text": "P. aeruginosa UTIs usually follow catheterization or surgery (device/instrumentation risk factor).",
+        "byte_quote": "The bacterium usually causes UTIs following catheterization or surgery [75]."
+      },
+      {
+        "id": "c11",
+        "text": "P. aeruginosa UTI can progress to sepsis, fatal especially in older, immunocompromised, and diabetic patients.",
+        "byte_quote": "may cause complications such as sepsis that can be fatal in older patients, immunocompromised patients and individuals with diabetes [19]."
+      },
+      {
+        "id": "c12",
+        "text": "Burn wounds are first colonized by Gram-positive organisms (Staphylococcus aureus, Streptococcus pyogenes) before P. aeruginosa infection.",
+        "byte_quote": "Wounds first become colonized by Gram-positive organisms such as Staphylococcus aureus and Streptococcus pyogenes before infection by P. aeruginosa"
+      },
+      {
+        "id": "c13",
+        "text": "Source/portal associations: burn-wound infection arises from endogenous GI/upper-respiratory flora (causing septicaemia); bloodstream infections are nosocomial.",
+        "byte_quote": "Burn wound infectionEndogenous flora of the gastrointestinal and or upper respiratory tract [87,88]Septicaemia [46]Blood stream infectionsNosocomial [89]"
+      },
+      {
+        "id": "c14",
+        "text": "In India, carbapenem resistance among P. aeruginosa is high (40%-47%).",
+        "byte_quote": "A scoping report on antimicrobial resistance in India reported a high prevalence of carbapenem resistance among P. aeruginosa (40%–47%)"
+      },
+      {
+        "id": "c15",
+        "text": "DTR P. aeruginosa is non-susceptible to all of: piperacillin-tazobactam, ceftazidime, cefepime, aztreonam, meropenem, imipenem-cilastatin, ciprofloxacin, levofloxacin (the anti-pseudomonal drug list).",
+        "byte_quote": "DTR is described in this guidance as P. aeruginosa that does not display sensitivity to any of the following drugs: piperacillin-tazobactam, ceftazidime, cefepime, aztreonam, meropenem, imipenem-cilastatin, ciprofloxacin, and levofloxacin."
+      },
+      {
+        "id": "c16",
+        "text": "P. aeruginosa causes bacterial keratitis in 6%-39% of cases in the USA and 8%-21% in south India (contact-lens/ocular-surgery risk).",
+        "byte_quote": "P. aeruginosa is responsible for causing bacterial keratitis in 6% to 39% of the cases in the USA [116,117] and 8% to 21% in south India [116]."
+      },
+      {
+        "id": "c17",
+        "text": "P. aeruginosa accounted for 17.5% of ventilator-associated pneumonia cases and 9.26% of hospital-associated pneumonia cases.",
+        "byte_quote": "P. aeruginosa accounted for 17.5% of all cases in ventilator-associated pneumonia and 9.26% of all cases in hospital-associated pneumonia [91]."
+      },
+      {
+        "id": "c18",
+        "text": "P. aeruginosa is implicated in 0.3%-11% of community-acquired pneumonia and 2.2%-20% of healthcare-associated pneumonia.",
+        "byte_quote": "Reported percentages of P. aeruginosa implicated in community-acquired pneumonia vary from 0.3% to 11%, whereas it varies from 2.2% to 20% in healthcare associated pneumonia [150,151]."
+      },
+      {
+        "id": "c19",
+        "text": "Hospitalized P. aeruginosa UTI patients had 17.7% mortality at 30 days and 33.9% at 90 days.",
+        "byte_quote": "reported 17.7% mortalities at 30 days and 33.9% mortalities at 90 days [130]."
+      },
+      {
+        "id": "c20",
+        "text": "P. aeruginosa was the 3rd most common Gram-negative uropathogen, causing 7.1% of nosocomial UTIs in the Asia-Pacific region (2009-2010).",
+        "byte_quote": "P. aeruginosa was found to be the third most common Gram-negative pathogen causing 7.1% of all nosocomial urinary tract infections in surveillance studies from the Asia-Pacific region in 2009 to 2010 [128]."
+      }
+    ],
+    "cites": [
+      "Wisplinghoff et al. (nationwide nosocomial BSI surveillance, USA) — ref [89]",
+      "Gudiol et al. (retrospective P. aeruginosa BSI in neutropenic oncohematological patients, Jan 2006–May 2018) — ref [95]",
+      "Hidron et al. (NHSN/CDC HAI ranking report 2006–2007) — ref [66]",
+      "Weber et al. (ventilator- vs hospital-associated pneumonia proportions) — ref [91]",
+      "Prakash et al. (31.78% MDR P. aeruginosa in Indian hospitals) — ref [9]",
+      "Bitsori et al. (P. aeruginosa vs E. coli UTI in children) — ref [129]",
+      "Kwok et al. (non-CF bronchiectasis colonization cohort, 2018) — ref [154]",
+      "Shobha et al. (107 urine samples 2015–2016; UTI in males, age >60) — ref [131]",
+      "National REA-RAISIN surveillance 2004–2006 (P. aeruginosa most common pneumonia cause, 25%) — ref [133]",
+      "CDC Antibiotic Resistance Threats in the US 2019 (32,600 cases; 2,700 deaths; $767M) — ref [65]",
+      "IDSA guidance document on DTR P. aeruginosa, Sept 17, 2020 — ref [51]",
+      "WHO 2017 priority pathogens list (carbapenem-resistant P. aeruginosa, Critical) — ref [45/51]"
+    ]
+  },
+  {
+    "source_id": "https://pubmed.ncbi.nlm.nih.gov/3284952/",
+    "resolved_url": "https://pubmed.ncbi.nlm.nih.gov/3284952/",
+    "title": "Streptococcus pyogenes bacteraemia: an old enemy subdued, but not defeated (Ispahani P, Donald FE, Aveline AJ. J Infect. 1988 Jan;16(1):37-46)",
+    "claims": [
+      {
+        "id": "c1",
+        "text": "Streptococcus pyogenes (Group A beta-haemolytic streptococci) bacteraemia accounted for 2% of all bacteraemia cases in a 7-year single-hospital review (40 cases).",
+        "byte_quote": "Altogether, 40 cases were encountered, representing 2% of all cases of bacteraemia."
+      },
+      {
+        "id": "c2",
+        "text": "Mortality from S. pyogenes bacteraemia was 35%.",
+        "byte_quote": "Mortality was 35%."
+      },
+      {
+        "id": "c3",
+        "text": "S. pyogenes bacteraemia was predominantly community-acquired, and 28% of patients were under 40 years of age (age/host risk factor).",
+        "byte_quote": "Most cases were community-acquired and 28% of patients were less than 40 years of age."
+      },
+      {
+        "id": "c4",
+        "text": "A third of patients with S. pyogenes bacteraemia were previously fit (i.e., not immunocompromised / no prior comorbidity), indicating it can affect previously healthy hosts.",
+        "byte_quote": "A third of the patients were previously fit."
+      },
+      {
+        "id": "c5",
+        "text": "Bloodstream-infection source-to-organism association: the most common portals of entry for S. pyogenes bacteraemia were skin and soft tissue (23 patients) and the respiratory tract (8 patients).",
+        "byte_quote": "The most common sources of bacteraemia were the skin and soft tissue (23 patients) and the respiratory tract (eight patients)."
+      },
+      {
+        "id": "c6",
+        "text": "Shock occurred in 40% of S. pyogenes bacteraemia cases and carried 60% mortality.",
+        "byte_quote": "Shock was recorded in 40% of cases and carried a 60% mortality."
+      },
+      {
+        "id": "c7",
+        "text": "S. pyogenes is uniquely/uniformly susceptible to penicillin (antibiotic susceptibility), yet still poses a clinical challenge.",
+        "byte_quote": "Despite its unique susceptibility to penicillin, S. pyogenes continues to pose a challenge to the physician."
+      }
+    ],
+    "cites": []
+  },
+  {
+    "source_id": "https://pmc.ncbi.nlm.nih.gov/articles/PMC10350481/",
+    "resolved_url": "https://pmc.ncbi.nlm.nih.gov/articles/PMC10350481/",
+    "title": "Epidemiology of Gram-Negative Bloodstream Infections in the United States: Results From a Cohort of 24 Hospitals",
+    "claims": [
+      {
+        "id": "c1",
+        "text": "E. coli is the most common Gram-negative organism in bloodstream infections, accounting for 51.0% of isolates.",
+        "byte_quote": "Escherichia coli (2471, 51.0%) was the most common Gram-negative organism recovered"
+      },
+      {
+        "id": "c2",
+        "text": "Klebsiella pneumoniae is the second most common Gram-negative bloodstream isolate at 17.3%.",
+        "byte_quote": "followed by K pneumoniae (n = 841, 17.3%)"
+      },
+      {
+        "id": "c3",
+        "text": "Pseudomonas aeruginosa is the third most common Gram-negative bloodstream isolate at 8.7%.",
+        "byte_quote": "Pseudomonas aeruginosa (n = 423, 8.7%)"
+      },
+      {
+        "id": "c4",
+        "text": "ESBL production occurred in 15.7% of eligible isolates.",
+        "byte_quote": "575 (15.7%) isolates...met criteria for ESBL production"
+      },
+      {
+        "id": "c5",
+        "text": "Western sites had the highest percentage of ESBL producers among eligible isolates (16%).",
+        "byte_quote": "Western sites had the highest percentage of ESBL producers of total eligible isolates (16%)"
+      },
+      {
+        "id": "c6",
+        "text": "The median patient age in the Gram-negative bacteremia cohort was 67 years (IQR 55-77).",
+        "byte_quote": "The median age was 67 years (IQR, 55–77)"
+      },
+      {
+        "id": "c7",
+        "text": "Patients aged 70 years or older comprised 42.73% of the cohort.",
+        "byte_quote": "≥70 [years] 2077 (42.73%)"
+      },
+      {
+        "id": "c8",
+        "text": "Moderate to severe immunocompromise was present in 34.52% of patients.",
+        "byte_quote": "Moderate to severe immunocompromise[a] 1678 (34.52%)"
+      },
+      {
+        "id": "c9",
+        "text": "32.34% of bacteremia patients were in the intensive care unit.",
+        "byte_quote": "Patients in intensive care unit 1572 (32.34%)"
+      },
+      {
+        "id": "c10",
+        "text": "ESBL-producing organisms were significantly more frequent in White than non-White patients (14.6% vs 9.5%, P<0.01).",
+        "byte_quote": "there was a statistically significant difference in the percentage of ESBL-producing organisms in White vs non-White patients (14.6 % and 9.5 %, respectively, P<0.01)"
+      },
+      {
+        "id": "c11",
+        "text": "The urinary tract was the most common source of Gram-negative bacteremia (47.9%).",
+        "byte_quote": "Most common source of infection was the urinary tract (47.9%)"
+      },
+      {
+        "id": "c12",
+        "text": "Common sources of Gram-negative bacteremia were urinary tract (47.9%), intra-abdominal (14.5%), and hepatobiliary (11.4%).",
+        "byte_quote": "Common sources of infection included urinary tract (47.9%), intra-abdominal (14.5%), and hepatobiliary (11.4%)"
+      },
+      {
+        "id": "c13",
+        "text": "Respiratory tract sources accounted for 5.60% of Gram-negative bacteremias.",
+        "byte_quote": "Respiratory [source] 272 (5.60%)"
+      }
+    ],
+    "cites": []
+  },
+  {
+    "source_id": "https://www.ncbi.nlm.nih.gov/books/NBK430891/",
+    "resolved_url": "https://www.ncbi.nlm.nih.gov/books/NBK430891/",
+    "title": "Central Line-Associated Blood Stream Infections - StatPearls - NCBI Bookshelf",
+    "claims": [
+      {
+        "id": "c1",
+        "text": "In CLABSI, gram-positive organisms are most common: coagulase-negative staphylococci 34.1%, enterococci 16%, S. aureus 9.9%; gram-negatives include Klebsiella 5.8%, Enterobacter 3.9%, Pseudomonas 3.1%, E. coli 2.7%, Acinetobacter 2.2%; Candida species 11.8%; others 10.5%.",
+        "byte_quote": "Gram-positive organisms (coagulase-negative staphylococci, 34.1%; enterococci, 16%; and Staphylococcus aureus, 9.9%) are the most common, followed by gram-negatives (Klebsiella, 5.8%; Enterobacter, 3.9%; Pseudomonas, 3.1%; E. coli, 2.7%; Acinetobacter, 2.2%), Candida species (11.8%), and others (10.5%)."
+      },
+      {
+        "id": "c2",
+        "text": "About 40%-80% of catheter-related bloodstream infections (CRBSIs) are caused by gram-positive organisms.",
+        "byte_quote": "Approximately 40%–80% of CRBSIs are caused by gram-positive organisms."
+      },
+      {
+        "id": "c3",
+        "text": "Host factors raising CLABSI risk include hemodialysis, malignancy, GI disorders, pulmonary hypertension, immune-suppressed states (organ transplant, diabetes), malnutrition, TPN, extremes of age, loss of skin integrity (burns), and prolonged pre-insertion hospitalization.",
+        "byte_quote": "Chronic illnesses (hemodialysis, malignancy, gastrointestinal tract disorders, pulmonary hypertension), immune-suppressed states (organ transplant, diabetes mellitus), malnutrition, total parenteral nutrition, extremes of age, loss of skin integrity (burns), and prolonged hospitalization before line insertion are host factors that increase the risk of CLABSI."
+      },
+      {
+        "id": "c4",
+        "text": "Pseudomonas bloodstream infection is commonly associated with neutropenia, severe illness, or known prior colonization.",
+        "byte_quote": "Pseudomonas is commonly associated with neutropenia, severe illness, or known prior colonization."
+      },
+      {
+        "id": "c5",
+        "text": "Candida bloodstream infection is associated with femoral catheterization, TPN, prolonged broad-spectrum antibiotics, hematologic malignancy, or solid-organ or hematopoietic stem cell transplantation.",
+        "byte_quote": "Candida is associated with risk factors: femoral catheterization, TPN, prolonged administration of broad-spectrum antibiotics, hematologic malignancy, or solid organ or hematopoietic stem cell transplantation."
+      },
+      {
+        "id": "c6",
+        "text": "Femoral central venous catheters carry the highest CLABSI risk, followed by internal jugular then subclavian catheters.",
+        "byte_quote": "Femoral central venous catheters are associated with the highest risk of CLABSI, followed by internal jugular and subclavian catheters."
+      },
+      {
+        "id": "c7",
+        "text": "Within 7-10 days of catheter placement, skin-surface bacteria migrate along the external catheter surface from the skin exit site toward the intravascular space (extraluminal source).",
+        "byte_quote": "Within 7 to 10 days of central venous catheter placement, bacteria on the skin surface migrate along the external surface of the catheter from the skin exit site towards the intravascular space."
+      },
+      {
+        "id": "c8",
+        "text": "CLABSIs beyond 10 days are usually caused by intraluminal hub contamination, typically from a healthcare provider's contaminated hands.",
+        "byte_quote": "CLABSIs that occur beyond 10 days are usually caused by contamination of the hub (intraluminal), typically from a health care provider's contaminated hands but rarely from a host and often due to a breach of standard aseptic precautions to access the hub."
+      },
+      {
+        "id": "c9",
+        "text": "Empiric therapy: parenteral vancomycin where MRSA is prevalent; otherwise anti-staphylococcal penicillin or cephalosporins (nafcillin or cefazolin) suffice.",
+        "byte_quote": "Parenteral vancomycin if methicillin-resistant staphylococci (MRSA) is prevalent. Otherwise, parenteral anti-staphylococcal penicillin or cephalosporins such as nafcillin or cefazolin would suffice."
+      },
+      {
+        "id": "c10",
+        "text": "Daptomycin is the drug of choice when MRSA isolates have vancomycin MIC > 2 mg/mL or for vancomycin-resistant enterococci (VRE).",
+        "byte_quote": "If MRSA isolates exhibit a minimum inhibitory concentration of > 2 mg/mL for vancomycin or, in the case of vancomycin-resistant enterococci (VRE), daptomycin is the drug of choice."
+      },
+      {
+        "id": "c11",
+        "text": "Echinocandins (micafungin, caspofungin, anidulafungin) are preferred for suspected candidemia when azole resistance is suspected (prior azole use or prevalent non-albicans candida such as C. glabrata or C. krusei).",
+        "byte_quote": "Echinocandins (micafungin, caspofungin, anidulafungin) are preferred agents for suspected candidemia if azole resistance is suspected (prior azole use or prevalent nonalbicans candida such as C.glabrata or C.krusei)."
+      },
+      {
+        "id": "c12",
+        "text": "Non-tunneled catheters carry higher CLABSI risk than tunneled catheters because they lack a subcutaneous tract.",
+        "byte_quote": "The absence of a tunnel (a subcutaneous tract) places non-tunneled catheters at higher risk for CLABSIs."
+      }
+    ],
+    "cites": [
+      "National Healthcare Safety Network (NHSN) data from January 2006 to October 2007"
+    ]
+  },
+  {
+    "source_id": "https://academic.oup.com/cid/article/49/1/1/369414",
+    "resolved_url": "https://academic.oup.com/cid/article/49/1/1/369414",
+    "title": "Clinical Practice Guidelines for the Diagnosis and Management of Intravascular Catheter-Related Infection: 2009 Update by the Infectious Diseases Society of America",
+    "claims": [
+      {
+        "id": "c1",
+        "text": "The four most common causes of CRBSI from percutaneous noncuffed catheters, in order of prevalence, are coagulase-negative staphylococci, S. aureus, Candida species, and enteric gram-negative bacilli.",
+        "byte_quote": "In order of prevalence, the 4 groups of microbes that most commonly cause CRBSI associated with percutaneously inserted, noncuffed catheters are as follows: coagulase-negative staphylococci, S. aureus, Candida species, and enteric gram-negative bacilli."
+      },
+      {
+        "id": "c2",
+        "text": "In children, coagulase-negative staphylococci cause 34% of CRBSIs and S. aureus 25%.",
+        "byte_quote": "Most CRBSIs among children are caused by coagulase-negative staphylococci (which account for 34% of cases), followed by S. aureus (25%)."
+      },
+      {
+        "id": "c3",
+        "text": "In neonates, coagulase-negative staphylococci account for 51% of CRBSIs, followed by Candida, enterococci, and gram-negative bacilli.",
+        "byte_quote": "Among neonates, coagulase-negative staphylococci account for 51% of CRBSIs, followed by Candida species, enterococci, and gram-negative bacilli."
+      },
+      {
+        "id": "c4",
+        "text": "Vancomycin is recommended for empirical CRBSI therapy in settings with elevated MRSA prevalence.",
+        "byte_quote": "Vancomycin is recommended for empirical therapy in heath care settings with an elevated prevalence of methicillin-resistant Staphylococcus aureus (MRSA)."
+      },
+      {
+        "id": "c5",
+        "text": "Where most MRSA isolates have vancomycin MIC >2 µg/mL, an alternative agent such as daptomycin should be used.",
+        "byte_quote": "for institutions in which the preponderance of MRSA isolates have vancomycin minimum inhibitory concentration (MIC) values >2 µg/mL, alternative agents, such as daptomycin, should be used."
+      },
+      {
+        "id": "c6",
+        "text": "Linezolid should not be used for empirical therapy of suspected (unproven) CRBSI.",
+        "byte_quote": "Linezolid should not be used for empirical therapy (i.e., for patients suspected but not proven to have CRBSI)."
+      },
+      {
+        "id": "c7",
+        "text": "Empirical gram-negative coverage should be guided by local susceptibility and disease severity (4th-gen cephalosporin, carbapenem, or beta-lactam/beta-lactamase combination, with or without an aminoglycoside).",
+        "byte_quote": "Empirical coverage for gram-negative bacilli should be based on local antimicrobial susceptibility data and the severity of disease (e.g., a fourth-generation cephalosporin, carbapenem, or β-lactam/β-lactamase combination, with or without an aminoglycoside)."
+      },
+      {
+        "id": "c8",
+        "text": "Empirical combination coverage for MDR gram-negative bacilli (e.g. Pseudomonas aeruginosa) should be used in neutropenic patients, severely ill septic patients, or those colonized with such pathogens.",
+        "byte_quote": "Empirical combination antibiotic coverage for multidrug-resistant (MDR) gram-negative bacilli, such as Pseudomonas aeruginosa, should be used when CRBSI is suspected in neutropenic patients, severely ill patients with sepsis, or patients known to be colonized with such pathogens."
+      },
+      {
+        "id": "c9",
+        "text": "For suspected CRBSI involving femoral catheters in critically ill patients, empirical therapy should add coverage for gram-negative bacilli and Candida species on top of gram-positive coverage.",
+        "byte_quote": "In addition to coverage for gram-positive pathogens, empirical therapy for suspected CRBSI involving femoral catheters in critically ill patients should include coverage for gram-negative bacilli and Candida species."
+      },
+      {
+        "id": "c10",
+        "text": "For suspected catheter-related candidemia, use an echinocandin, or fluconazole in selected patients.",
+        "byte_quote": "For empirical treatment of suspected catheter-related candidemia, use an echinocandin or, in selected patients, fluconazole."
+      },
+      {
+        "id": "c11",
+        "text": "4–6 weeks of antibiotic therapy is given for persistent fungemia or bacteremia occurring >72 h after catheter removal.",
+        "byte_quote": "Four to 6 weeks of antibiotic therapy should be administered to patients with persistent fungemia or bacteremia after catheter removal (i.e., occurring >72 h after catheter removal) (A-II for S. aureus infection; C-III for infection due to other pathogens)."
+      },
+      {
+        "id": "c12",
+        "text": "Osteomyelitis in adults is treated with 6–8 weeks of therapy.",
+        "byte_quote": "6–8 weeks of therapy should be used for the treatment of osteomyelitis in adults."
+      },
+      {
+        "id": "c13",
+        "text": "Long-term catheters should be removed for CRBSI with severe sepsis, suppurative thrombophlebitis, endocarditis, persistent infection >72 h despite susceptible therapy, or infection due to S. aureus, P. aeruginosa, fungi, or mycobacteria.",
+        "byte_quote": "Long-term catheters should be removed from patients with CRBSI associated with any of the following conditions: severe sepsis; suppurative thrombophlebitis; endocarditis; bloodstream infection that continues despite >72 h of antimicrobial therapy to which the infecting microbes are susceptible; or infections due to S. aureus, P. aeruginosa, fungi, or mycobacteria."
+      },
+      {
+        "id": "c14",
+        "text": "Short-term catheters should be removed for CRBSI due to gram-negative bacilli, S. aureus, enterococci, fungi, and mycobacteria.",
+        "byte_quote": "Short-term catheters should be removed from patients with CRBSI due to gram-negative bacilli, S. aureus, enterococci, fungi, and mycobacteria."
+      },
+      {
+        "id": "c15",
+        "text": "Vancomycin has a lower clinical success rate against MRSA bacteremia when the MIC is >=2 µg/mL.",
+        "byte_quote": "Vancomycin is associated with a lower clinical success rate in treating MRSA bacteremia if the MIC is ⩾2 µg/mL."
+      }
+    ],
+    "cites": []
+  },
+  {
+    "source_id": "https://academic.oup.com/cid/article/72/7/1211/5836974",
+    "resolved_url": "https://academic.oup.com/cid/article/72/7/1211/5836974",
+    "title": "Epidemiology of Escherichia coli Bacteremia: A Systematic Literature Review",
+    "claims": [
+      {
+        "id": "c1",
+        "text": "E. coli is the most common cause of bacteremia in high-income countries, exceeding other leading bacteremia pathogens including Staphylococcus aureus and Streptococcus pneumoniae.",
+        "byte_quote": "Escherichia coli is the most common cause of bacteremia in high-income countries, exceeding other leading bacteremia-causing pathogens such as Staphylococcus aureus and Streptococcus pneumoniae"
+      },
+      {
+        "id": "c2",
+        "text": "E. coli accounted for 27.1% of all bacteremia episodes overall.",
+        "byte_quote": "The E. coli–specific proportion of all bacteremia episodes was 27.1% overall (95% CI, 24.5–29.8)"
+      },
+      {
+        "id": "c3",
+        "text": "E. coli proportion of bacteremia varied by acquisition setting: hospital-acquired 18.1%, community-onset healthcare-associated 31.5%, community-acquired 33.0%.",
+        "byte_quote": "18.1% (95% CI, 15.1–21.7%)"
+      },
+      {
+        "id": "c4",
+        "text": "Incidence of E. coli bacteremia rises steeply with age: >100 per 100,000 person-years in 55-to-75-year-olds and >300 in 75-to-85-year-olds.",
+        "byte_quote": "rates per 100 000 person-years were >100 in 55-to-75-year-olds and >300 in 75-to-85-year-olds"
+      },
+      {
+        "id": "c5",
+        "text": "Highest relative risks of E. coli bacteremia vs general population: renal dialysis (RR 26.9), solid-organ transplant (RR 20.3), neoplastic disease (RR 14.9).",
+        "byte_quote": "highest relative risks (RRs) of developing E. coli bacteremia compared with the general population were associated with renal dialysis (RR, 26.9), solid-organ transplantation (RR, 20.3), and neoplastic disease (RR, 14.9)"
+      },
+      {
+        "id": "c6",
+        "text": "Indwelling vascular and urinary catheters raise E. coli bacteremia risk: central venous 10-fold, peripheral venous 7.5-fold, suprapubic urinary 6-fold, urethral urinary 3-fold.",
+        "byte_quote": "indwelling vascular and urinary catheters increased the risk...by 10-fold and 7.5-fold for central and peripheral venous catheters, respectively, and by 6-fold and 3-fold for suprapubic and urethral urinary catheters"
+      },
+      {
+        "id": "c7",
+        "text": "Urinary tract infection was the primary source for 53% of E. coli bacteremia episodes.",
+        "byte_quote": "Urinary tract infection (UTI) was the primary source for 53% of episodes."
+      },
+      {
+        "id": "c8",
+        "text": "Urogenital infection accounted for more than half (pooled 52.6%) of all E. coli bacteremia episodes.",
+        "byte_quote": "Urogenital infection accounted for more than half of all E. coli bacteremia episodes (pooled estimate, 52.6%; 95% CI, 47.0–58.1%)"
+      },
+      {
+        "id": "c9",
+        "text": "Pooled case fatality rate for E. coli bacteremia was 12.4%.",
+        "byte_quote": "The pooled estimated CFR for E. coli bacteremia was 12.4% (95% CI, 10.7–14.3%; range, 2.8–28.5%)"
+      }
+    ],
+    "cites": [
+      "Skogberg et al. Epidemiology and Infection 2008",
+      "Skogberg et al. Clinical Microbiology and Infection 2012",
+      "Kennedy et al. Medical Journal of Australia 2008",
+      "Weiner et al. Infection Control & Hospital Epidemiology 2016",
+      "Søgaard et al. Clinical Infectious Diseases 2011",
+      "Poolman & Anderson. Expert Review of Vaccines 2018",
+      "Russo & Johnson. Microbes and Infection 2003",
+      "Laupland et al. Clinical Microbiology and Infection 2008",
+      "Laupland et al. Epidemiology and Infection 2007"
+    ]
+  },
+  {
+    "source_id": "https://pmc.ncbi.nlm.nih.gov/articles/PMC12902366/",
+    "resolved_url": "https://pmc.ncbi.nlm.nih.gov/articles/PMC12902366/",
+    "title": "Clinical and Microbiological Characteristics of Bacteroides fragilis and Non-B. fragilis Bacteremia",
+    "claims": [
+      {
+        "id": "c1",
+        "text": "Bacteroides species are anaerobic gram-negative bacteria and part of the intestinal flora.",
+        "byte_quote": "_Bacteroides_ species are anaerobic gram-negative bacteria that constitute a significant portion of the intestinal flora."
+      },
+      {
+        "id": "c2",
+        "text": "Mortality of Bacteroides bacteremia ranges from about 16% to 50%.",
+        "byte_quote": "Specifically, the mortality rate of _Bacteroides_-caused bacteremia ranges from ∼16% to 50% [[1](#ofag047-B1), [2](#ofag047-B2)]."
+      },
+      {
+        "id": "c3",
+        "text": "Of 528 anaerobic-bacteremia patients (Jan 2012-Mar 2022), 174 had Bacteroides spp. bacteremia: 102 B. fragilis and 72 non-B. fragilis.",
+        "byte_quote": "Among the 528 patients diagnosed with anaerobic bacteremia between 1 January 2012 and 31 March 2022, 174 had _Bacteroides_ spp. bacteremia, with 102 and 72 cases caused by _B. fragilis_ and non_\\-B. fragilis_ species, respectively"
+      },
+      {
+        "id": "c4",
+        "text": "30-day mortality (excluding underlying-disease exacerbation) was significantly higher in the non-B. fragilis group (16.7%) than the B. fragilis group (5.9%), P=.025.",
+        "byte_quote": "However, 30-day mortality—excluding exacerbation of the underlying disease—was significantly higher in the non_\\-B. fragilis_ group (16.7%) than in the _B. fragilis_ group (5.9%, _P_ = .025"
+      },
+      {
+        "id": "c5",
+        "text": "Carbapenem resistance was associated with 30-day mortality in non-B. fragilis (adjusted OR=7.05, 95% CI 1.54-41.9, P=.017).",
+        "byte_quote": "carbapenem resistance (adjusted OR = 7.05, 95% CI 1.54–41.9, _P_ = .017)"
+      },
+      {
+        "id": "c6",
+        "text": "Bacteremia originating from the gastrointestinal tract was 29.4% in B. fragilis vs 54.1% in non-B. fragilis (P=.002) — GI/digestive portal predicts non-B. fragilis.",
+        "byte_quote": "The percentage of bacteremia originating from the gastrointestinal tract was 29.4% and 54.1% in _B. fragilis_ and non_\\-B. fragilis_ groups (_P_ = .002)"
+      },
+      {
+        "id": "c7",
+        "text": "Clindamycin-resistant B. fragilis ranges from ~20-40% in North America/Europe to ~50% in some Asian countries.",
+        "byte_quote": "the percentage of clindamycin (CLDM)-resistant _B. fragilis_ ranges from ∼20% to 40% in North America and Europe to ∼50% in some Asian countries"
+      },
+      {
+        "id": "c8",
+        "text": "Antimicrobial susceptibility was analyzed for meropenem (MEPM), clindamycin (CLDM), and TAZ/PIPC against Bacteroides spp.",
+        "byte_quote": "we limited the antimicrobial susceptibility analysis to meropenem (MEPM), CLDM, and TAZ/PIPC against _Bacteroides_ spp."
+      },
+      {
+        "id": "c9",
+        "text": "Demographic/clinical risk factors (age, sex, malignancy, diabetes, systemic steroids/immunosuppressants, febrile neutropenia, mCCS) were similar between the two groups.",
+        "byte_quote": "Demographic and clinical factors, such as age, sex, presence of malignancy, diabetes mellitus, administration of systemic steroids or immunosuppressive agents, febrile neutropenia, and mCCS, were similar"
+      },
+      {
+        "id": "c10",
+        "text": "A landmark matched-pair study reported an overall 30-day case fatality rate of 28% for B. fragilis group bacteremia.",
+        "byte_quote": "A landmark matched-pair study reported an overall 30-day case fatality rate of 28% for _B. fragilis_ group bacteremia"
+      }
+    ],
+    "cites": [
+      "Redondo et al. 1995 (matched-pair study, B. fragilis group bacteremia 30-day case fatality ~28%)",
+      "Cheng et al. 2009 (B. fragilis bacteremia 30-day mortality 30.7%)"
+    ]
+  },
+  {
+    "source_id": "https://pmc.ncbi.nlm.nih.gov/articles/PMC4451395/",
+    "resolved_url": "https://pmc.ncbi.nlm.nih.gov/articles/PMC4451395/",
+    "title": "Staphylococcus aureus Infections: Epidemiology, Pathophysiology, Clinical Manifestations, and Management",
+    "claims": [
+      {
+        "id": "c1",
+        "text": "In the industrialized world, Staphylococcus aureus bacteremia (SAB) incidence is 10 to 30 per 100,000 person-years.",
+        "byte_quote": "In the industrialized world, the population incidence of SAB ranges from 10 to 30 per 100,000 person-years"
+      },
+      {
+        "id": "c2",
+        "text": "MRSA bacteremia incidence in Quebec rose from 0 to 7.4 per 100,000 person-years between 1991 and 2005.",
+        "byte_quote": "in Quebec, Canada, the incidence of MRSA bacteremia increased from 0 per 100,000 person-years to 7.4 per 100,000 person-years from 1991to2005"
+      },
+      {
+        "id": "c3",
+        "text": "S. aureus is now the most common cause of infective endocarditis in the industrialized world.",
+        "byte_quote": "_S. aureus_ is now the most common cause of IE in the industrialized world"
+      },
+      {
+        "id": "c4",
+        "text": "The proportion of IE cases due to S. aureus rose from 24% to 32% between 1998 and 2009.",
+        "byte_quote": "the incidence of IE increased from 9.3 per 100,000 person-years in 1998 to 12.7 per 100,000 person-years in 2009. The proportion of IE cases coded as being due to _S. aureus_ increased from 24% to 32% between 1998 and 2009"
+      },
+      {
+        "id": "c5",
+        "text": "Age is a powerful determinant of SAB incidence, with highest rates at the extremes of life.",
+        "byte_quote": "Age is a powerful determinant of SAB incidence, with the highest rates of infection occurring at either extreme of life"
+      },
+      {
+        "id": "c6",
+        "text": "SAB incidence exceeds 100 per 100,000 person-years in those over 70 years of age.",
+        "byte_quote": "the incidence of SAB is >100 per 100,000 person-years among subjects >70 years of age"
+      },
+      {
+        "id": "c7",
+        "text": "Male gender is associated with increased SAB incidence (male-to-female ratio ~1.5).",
+        "byte_quote": "Male gender is consistently associated with increased SAB incidence...with male-to-female ratios of ∼1.5"
+      },
+      {
+        "id": "c8",
+        "text": "Invasive MRSA incidence in the US black population (66.5/100,000) is over twice that of the white population (27.7/100,000).",
+        "byte_quote": "In the United States, the incidence of invasive MRSA in the black population (66.5 per 100,000 person-years) is over twice that in the white population (27.7 per 100,000 person-years)"
+      },
+      {
+        "id": "c9",
+        "text": "SAB incidence in HIV-infected patients (494/100,000) is 24 times that of the non-HIV population.",
+        "byte_quote": "incidences of SAB in HIV-infected patients of 494 per 100,000 person-years...or 24 times that of the non-HIV-infected population"
+      },
+      {
+        "id": "c10",
+        "text": "Among HIV-infected individuals, low CD4 count is independently associated with SAB.",
+        "byte_quote": "Among HIV-infected individuals, a low CD4 count was independently associated with SAB"
+      },
+      {
+        "id": "c11",
+        "text": "Among injection drug users, SAB incidence is at least 610 per 100,000 person-years.",
+        "byte_quote": "the incidence of SAB was at least 610 per 100,000 person-years"
+      },
+      {
+        "id": "c12",
+        "text": "SAB incidence in hemodialysis-dependent patients ranges from ~3,000 to nearly 18,000 per 100,000 person-years across countries.",
+        "byte_quote": "The incidences of SAB in hemodialysis-dependent patients were 3,064 per 100,000 person-years in Taiwan, 17,900 per 100,000 person-years in Ireland, and 4,045 to 5,015 per 100,000 person-years in the United States"
+      },
+      {
+        "id": "c13",
+        "text": "The predominant risk factor for SAB in hemodialysis patients is the presence of an intravascular access device.",
+        "byte_quote": "The predominant risk factor for these patients is the presence of an intravascular access device"
+      },
+      {
+        "id": "c14",
+        "text": "In patients with a prosthetic cardiac valve who develop SAB, the risk of IE is ~51%.",
+        "byte_quote": "in one prospective cohort study of patients with a prosthetic cardiac valve who developed SAB, the risk of IE was ∼51%"
+      },
+      {
+        "id": "c15",
+        "text": "Recommended IV antibiotic duration for uncomplicated SAB is at least 2 weeks.",
+        "byte_quote": "The recommended duration of intravenous (i.v.) antibiotics for uncomplicated SAB is at least 2 weeks"
+      },
+      {
+        "id": "c16",
+        "text": "Daptomycin at 6 mg/kg IV once daily was noninferior to vancomycin for MRSA bacteremia.",
+        "byte_quote": "daptomycin at 6 mg/kg of body weight i.v. once daily was noninferior to vancomycin"
+      },
+      {
+        "id": "c17",
+        "text": "Higher daptomycin doses of 8 to 10 mg/kg are increasingly used and appear safe.",
+        "byte_quote": "higher doses (8 to 10 mg/kg) are increasingly being used and appear to be safe"
+      },
+      {
+        "id": "c18",
+        "text": "For complicated SAB, 4 to 6 weeks of IV therapy has been the standard practice.",
+        "byte_quote": "For complicated SAB, 4 to 6 weeks of i.v. therapy has been the standard practice"
+      },
+      {
+        "id": "c19",
+        "text": "Patients treated with vancomycin for right-sided IE should receive more than 2 weeks of therapy.",
+        "byte_quote": "patients being treated with vancomycin for right-sided IE should receive >2 weeks of therapy"
+      },
+      {
+        "id": "c20",
+        "text": "Tigecycline carries an FDA black box warning for increased risk of death versus other antibacterials.",
+        "byte_quote": "tigecycline has subsequently received an FDA black box warning for an increased risk of death compared to other antibacterial drugs"
+      },
+      {
+        "id": "c21",
+        "text": "Daptomycin nonsusceptibility developed in 5 of 45 MRSA bacteremia patients.",
+        "byte_quote": "Nonsusceptibility to daptomycin developed in 5 of 45 patients with MRSA bacteremia"
+      },
+      {
+        "id": "c22",
+        "text": "Common primary sources of SAB are vascular catheter-related infections, SSTIs, pleuropulmonary, osteoarticular infections, and IE.",
+        "byte_quote": "common primary clinical foci or sources of infection are vascular catheter-related infections, SSTIs, pleuropulmonary infections, osteoarticular infections, and IE"
+      },
+      {
+        "id": "c23",
+        "text": "No focus of infection is found in about 25% of SAB cases.",
+        "byte_quote": "a focus of infection is not found in ∼25% of cases"
+      },
+      {
+        "id": "c24",
+        "text": "Mortality varies by source: higher for bacteremia without a focus (22-48%), IE (25-60%), pulmonary (39-67%); lower for catheter-related (7-21%), SSTIs (15-17%), and UTIs (10%).",
+        "byte_quote": "higher mortality rates for bacteremia without a focus (22 to 48%), IE (25 to 60%), and pulmonary infections (39 to 67%), compared to lower rates for catheter-related bacteremia (7 to 21%), SSTIs (15 to 17%), and urinary tract infections (UTIs) (10%)"
+      },
+      {
+        "id": "c25",
+        "text": "Right-sided IE is usually secondary to injection drug use or the presence of a central catheter.",
+        "byte_quote": "Right-sided disease is usually secondary to either injection drug use or the presence of a central catheter"
+      }
+    ],
+    "cites": [
+      "Thwaites et al. (reference 77)",
+      "Benito et al. (reference 133)",
+      "Fang et al. (reference 154)",
+      "Grover et al. (reference 147)"
+    ]
+  },
+  {
+    "source_id": "https://pmc.ncbi.nlm.nih.gov/articles/PMC12258469/",
+    "resolved_url": "https://pmc.ncbi.nlm.nih.gov/articles/PMC12258469/",
+    "title": "P50 Five-year review of epidemiology of invasive group A streptococcal infections with bacteraemia in a tertiary care centre in the UK",
+    "claims": [
+      {
+        "id": "c1",
+        "text": "Study reviewed blood cultures positive for Streptococcus pyogenes (GAS) at a UK tertiary care centre from 1 Jan 2019 to 31 Dec 2023.",
+        "byte_quote": "Blood culture specimens positive for Streptococcus pyogenes (GAS) at our centre from 1 January 2019 to 31 December 2023 and the respective clinical records for patients were retrospectively reviewed."
+      },
+      {
+        "id": "c2",
+        "text": "186 GAS bacteraemia cases were identified, split roughly evenly by sex (male 49.5%, female 50.5%).",
+        "byte_quote": "One hundred and eighty-six cases of GAS bacteraemias were identified and were equally distributed among male (49.5%) and female gender (50.5%)."
+      },
+      {
+        "id": "c3",
+        "text": "GAS bacteraemia rate was highest in the 61-90 year age band, then 31-50 years, then 1-10 years.",
+        "byte_quote": "The age distribution analysis indicated that the highest rate of GAS bacteraemia occurred in the age range of 61–90 years followed by 31–50 years and 1–10 years, respectively."
+      },
+      {
+        "id": "c4",
+        "text": "Among GAS isolates, 39 distinct emm types were found; emm 1.0 was most prevalent (28.5%), then emm 89.0 (6.98%) and emm 12.0 (6.45%).",
+        "byte_quote": "Thirty-nine distinct emm types were identified among study isolates and emm 1.0 was the most prevalent (28.5%), followed by emm 89.0 (6.98%) and emm 12.0 (6.45%)."
+      },
+      {
+        "id": "c5",
+        "text": "Extremes of age (infants <1 yr and elderly >90 yr) raised 30-day mortality risk, with mortality of 50% and 40% respectively.",
+        "byte_quote": "However, extremes of age was a significant risk factor for 30 day mortality: infants (<1 year) and the elderly (>90 years) had the highest mortality rates at 50% and 40%, respectively."
+      },
+      {
+        "id": "c6",
+        "text": "The commonest portal/focus of GAS bacteraemia infection was skin and soft tissue (56.45%), then respiratory tract (18.8%).",
+        "byte_quote": "The commonest focus of infection was skin and soft tissue (56.45%), followed by respiratory tract (18.8%)."
+      },
+      {
+        "id": "c7",
+        "text": "Overall 30-day mortality was ~18%, rising to 21% at 90 days, with no sex-based difference.",
+        "byte_quote": "Thirty day mortality was approximately 18%, rising to 21% at 90 days, with no sex-based difference (male 53% versus female 47%)."
+      },
+      {
+        "id": "c8",
+        "text": "The West Midlands (the centre's region) is among the UK areas with highest GAS notification rates.",
+        "byte_quote": "West Midlands—the region we serve—is highlighted as one of the areas with highest notification rates in the UK."
+      }
+    ],
+    "cites": [
+      "UK Health Security Agency. Group A Streptococcal Infections: First Update on Seasonal Activity in England, 2024 to 2025. gov.uk"
+    ]
+  },
+  {
+    "source_id": "https://pmc.ncbi.nlm.nih.gov/articles/PMC3892635/",
+    "resolved_url": "https://pmc.ncbi.nlm.nih.gov/articles/PMC3892635/",
+    "title": "Streptococcus pneumoniae bacteremia: clinical and microbiological epidemiology in a health area of Southern Spain",
+    "claims": [
+      {
+        "id": "c1",
+        "text": "S. pneumoniae is the most common cause of community-acquired pneumonia, meningitis and bacteremia in children and adults.",
+        "byte_quote": "Streptococcus pneumoniae is the most common cause of community-acquired pneumonia, meningitis and bacteremia in children and adults"
+      },
+      {
+        "id": "c2",
+        "text": "Pneumococcal bacteremia incidence is 15-35 cases per 100,000 inhabitants.",
+        "byte_quote": "The incidence of this kind of bacteremia is 15–35 cases per 100,000 inhabitants"
+      },
+      {
+        "id": "c3",
+        "text": "In this study the median annual incidence was 2.9 cases per 100,000 inhabitants.",
+        "byte_quote": "In our study the median annual incidence was 2.9 cases/100,000 inhabitants"
+      },
+      {
+        "id": "c4",
+        "text": "Serotype 19A was the most frequent, followed by serotypes 1, 7F and 14.",
+        "byte_quote": "Serotype 19A was the most frequent, followed by serotypes 1, 7F and 14."
+      },
+      {
+        "id": "c5",
+        "text": "Forty percent of bacteremias were caused by serotypes 19A, 1, 7F and 14.",
+        "byte_quote": "Forty percent of bacteremias were caused by serotypes 19A, 1, 7F and 14"
+      },
+      {
+        "id": "c6",
+        "text": "Main predisposing factors for pneumococcal bacteremia were smoking, antimicrobial/corticosteroid use, COPD, and HIV infection.",
+        "byte_quote": "The main predisposing factors observed were smoking, antimicrobial and/or corticosteroids administration, chronic pulmonary obstructive disease and HIV infection"
+      },
+      {
+        "id": "c7",
+        "text": "The leading predisposing factor for S. pneumoniae bacteremia was cigarette smoking (29.9%).",
+        "byte_quote": "The main predisposing factor for _S. pneumoniae_ bacteremia was cigarette smoking (29.9%)"
+      },
+      {
+        "id": "c8",
+        "text": "Seventy percent of patients had predisposing factors.",
+        "byte_quote": "Seventy percent of patients had predisposing factors"
+      },
+      {
+        "id": "c9",
+        "text": "Invasive pneumococcal disease most frequently infects children under 2 years, older adults (>65 years), and those with co-morbidities.",
+        "byte_quote": "Overall, invasive pneumococcal disease most frequently cause infection in children less than 2 years old, older adults (>65 years old) and individuals with co-morbidities"
+      },
+      {
+        "id": "c10",
+        "text": "Among isolates, 77.6% were penicillin-susceptible, 17.9% penicillin-intermediate, and 4.5% penicillin-resistant.",
+        "byte_quote": "77.6% of the isolates were penicillin-susceptible, while 17.9% were penicillin-intermediate and only 4.5% of these isolates were penicillin-resistant."
+      },
+      {
+        "id": "c11",
+        "text": "In Spain, invasive penicillin-nonsusceptible strains in the general population range from 19-45%.",
+        "byte_quote": "In our country, the percentage of invasive strains penicillin-nonsusceptible in the general population range from 19–45%"
+      },
+      {
+        "id": "c12",
+        "text": "The most common bacteremia source was the low respiratory tract (46 patients).",
+        "byte_quote": "The most common focus was the low respiratory tract recorded for 46 patients"
+      },
+      {
+        "id": "c13",
+        "text": "In one case the source of infection was the cerebrospinal fluid; the source was unknown in 20 episodes.",
+        "byte_quote": "The source of bacteremia was considered unknown in 20 episodes."
+      },
+      {
+        "id": "c14",
+        "text": "100% of bacteremia episodes were community-acquired.",
+        "byte_quote": "100% of episodes were from community-acquired origin."
+      },
+      {
+        "id": "c15",
+        "text": "Mortality associated with the bacteremia was 6%.",
+        "byte_quote": "In our study, the mortality associated to bacteremia was 6%."
+      },
+      {
+        "id": "c16",
+        "text": "Five variables were significantly associated with mortality: age >65, male sex, Caucasian race, critical/poor clinical condition, and septic shock.",
+        "byte_quote": "Five variables were significantly associated with mortality from _S. pneumoniae_ bacteremia: age >65 years, male sex, Caucasian race, clinical condition critical and poor and septic shock."
+      },
+      {
+        "id": "c17",
+        "text": "Antibiotics tested for susceptibility were Penicillin G, Amoxicillin, Erythromycin, Chloramphenicol, Vancomycin, Cefotaxime and Tetracycline.",
+        "byte_quote": "Penicillin G, Amoxicillin, Erythromycin, Chloramphenicol, Vancomycin, Cefotaxime and Tetracycline were tested"
+      }
+    ],
+    "cites": [
+      "Lynch & Zhanel 2009",
+      "McKensie et al. 2000",
+      "Hausdorff et al.",
+      "Metlay et al.",
+      "Fariñas-Álvarez et al. 2000",
+      "CDC (Centers for Disease Control and Prevention)"
+    ]
+  },
+  {
+    "source_id": "https://pubmed.ncbi.nlm.nih.gov/18691485/",
+    "resolved_url": "https://pubmed.ncbi.nlm.nih.gov/18691485/",
+    "title": "Clinical significance and predictors of community-onset Pseudomonas aeruginosa bacteremia (Cheong et al., Am J Med 2008;121(8):709-14)",
+    "claims": [
+      {
+        "id": "c1",
+        "text": "Study cohort comprised 106 patients with P. aeruginosa bacteremia and 508 patients with E. coli bacteremia (bloodstream-infection epidemiology in community-onset Gram-negative bacteremia).",
+        "byte_quote": "A total of 106 patients with P. aeruginosa bacteremia and a total 508 \npatients with E. coli bacteremia were included in this study."
+      },
+      {
+        "id": "c2",
+        "text": "Neutropenia is a risk factor that raises the likelihood the bloodstream organism is P. aeruginosa rather than E. coli.",
+        "byte_quote": "Factors associated \nwith P. aeruginosa bacteremia in the multivariate analysis included presentation \nwith neutropenia"
+      },
+      {
+        "id": "c3",
+        "text": "Presentation with septic shock raises the likelihood of P. aeruginosa bacteremia.",
+        "byte_quote": "presentation with septic shock"
+      },
+      {
+        "id": "c4",
+        "text": "An indwelling central venous catheter (device/portal of entry) raises the likelihood the bloodstream organism is P. aeruginosa.",
+        "byte_quote": "indwelling central venous \ncatheter"
+      },
+      {
+        "id": "c5",
+        "text": "Health-care-associated infection (exposure) raises the likelihood of P. aeruginosa bacteremia; all four predictors significant at P<.05.",
+        "byte_quote": "health-care-associated infection (all P <.05)"
+      },
+      {
+        "id": "c6",
+        "text": "30-day mortality was 26.4% with P. aeruginosa bacteremia versus 13.6% with E. coli bacteremia (P<.001).",
+        "byte_quote": "The 30-day \nmortality rate was 26.4% in patients with P. aeruginosa and 13.6% in those with \nE. coli bacteremia (P <.001)."
+      },
+      {
+        "id": "c7",
+        "text": "Inappropriate initial antimicrobial therapy is an independent risk factor for mortality (supports empirical coverage decisions).",
+        "byte_quote": "risk factors for mortality included a P. aeruginosa bacteremia, inappropriate initial \nantimicrobial therapy, a higher Charlson's weighted index of comorbidity, and a \nhigher Pitt bacteremia score (all P <.05)"
+      },
+      {
+        "id": "c8",
+        "text": "Urinary-tract infection as the source/portal was a protective factor for mortality in this Gram-negative bacteremia cohort.",
+        "byte_quote": "urinary tract infection \nand benign pancreatobiliary disease were found to be protective factors for \nmortality based on multivariate analysis (all P <.05)"
+      },
+      {
+        "id": "c9",
+        "text": "Empirical antimicrobial coverage of P. aeruginosa should be considered when Gram-negative sepsis is suspected in community-onset infection with neutropenia, septic shock, indwelling central venous catheter, or health-care-associated infection.",
+        "byte_quote": "initial empirical antimicrobial coverage of \nP. aeruginosa should be seriously considered in patients with neutropenia, \npresentation with septic shock, indwelling central venous catheter, or \nhealth-care-associated infection, when Gram-negative sepsis is suspected in \ncommunity-onset infection."
+      },
+      {
+        "id": "c10",
+        "text": "Determining the likelihood of P. aeruginosa bacteremia matters when Gram-negative sepsis is suspected in community-onset infection.",
+        "byte_quote": "It is important to determine the likelihood of P. aeruginosa \nbacteremia when Gram-negative sepsis is suspected in community-onset infection."
+      }
+    ],
+    "cites": []
+  },
+  {
+    "source_id": "https://www.ebi.ac.uk/europepmc/webservices/rest/PMC1584240/fullTextXML",
+    "resolved_url": "https://www.ebi.ac.uk/europepmc/webservices/rest/PMC1584240/fullTextXML",
+    "title": "Clinical manifestations and outcome in Staphylococcus aureus endocarditis among injection drug users and nonaddicts: a prospective study of 74 patients",
+    "claims": [
+      {
+        "id": "c1",
+        "text": "Endocarditis complicates 11% to 35% of S. aureus bacteremias (SAB), the range depending on the diagnostic criteria used.",
+        "byte_quote": "Endocarditis has been observed in 11% to 35% of S. aureus bacteremias (SAB)"
+      },
+      {
+        "id": "c2",
+        "text": "Among SAB cases, endocarditis was far more common in injection drug abusers (46%) than in nonaddicts (14%).",
+        "byte_quote": "Endocarditis was more common in SAB among drug abusers (46%) than in nonaddicts (14%)"
+      },
+      {
+        "id": "c3",
+        "text": "Injection drug abuse is one driver of the increased incidence of S. aureus infective endocarditis (host/exposure risk factor raising S. aureus).",
+        "byte_quote": "One of the reasons for increased incidence of S. aureus in IE is injection drug abuse"
+      },
+      {
+        "id": "c4",
+        "text": "Host factors raising endocarditis risk include S. aureus colonization, HIV-related immunosuppression, female sex, higher injection-drug-use frequency, and prior endocarditis.",
+        "byte_quote": "Colonization with S. aureus , HIV-related immunosuppression, female sex, increasing injection drug use frequency, and a history of previous IE are associated with a higher risk for endocarditis"
+      },
+      {
+        "id": "c5",
+        "text": "Injection drug users with S. aureus endocarditis were significantly younger than nonaddicts (mean 27 vs 65 years).",
+        "byte_quote": "IDUs were significantly younger (27 ± 15 vs 65 ± 15 years, P < 0.001)"
+      },
+      {
+        "id": "c6",
+        "text": "SAB in injection drug users was much more often community-acquired than in nonaddicts (95% vs 39%).",
+        "byte_quote": "their SAB was more often community-acquired (95% vs 39%, P < 0.001)"
+      },
+      {
+        "id": "c7",
+        "text": "Emerging at-risk host groups for S. aureus endocarditis are injection drug users, elderly patients with degenerative valve disease, patients with intravascular catheters or prosthetic valves, and nosocomial acquisition (device/exposure risk factors).",
+        "byte_quote": "new groups, including injection drug users (IDUs), elderly patients with degenerative valve disease, patients with intravascular catheter or prosthetic valve, and nosocomial acquisition"
+      },
+      {
+        "id": "c8",
+        "text": "Injection drug use predicts right-sided (tricuspid) endocarditis (60% of IDUs), whereas nonaddicts overwhelmingly have left-sided involvement (93%) — a portal/host-to-site association.",
+        "byte_quote": "Right-sided endocarditis was observed in 60% of IDUs whereas 93% of nonaddicts had left-sided involvement"
+      },
+      {
+        "id": "c9",
+        "text": "First-line antibiotic dosing for S. aureus endocarditis: cloxacillin or dicloxacillin 2 g IV every 4 hours for 4 to 6 weeks.",
+        "byte_quote": "All patients with endocarditis were assigned to receive initially cloxacillin or dicloxacillin (2 g q4 h) for 4 to 6 weeks intravenously"
+      },
+      {
+        "id": "c10",
+        "text": "Contraindication/alternative regimen: if semisynthetic penicillins are contraindicated, give cefuroxime 1.5 g every 6 h or vancomycin 1 g twice daily.",
+        "byte_quote": "Alternatively, cefuroxime (1.5 g q6 h) or vancomycin (1 g bid) were allowed if a contraindication against the use of semisynthetic penicillins was noted"
+      },
+      {
+        "id": "c11",
+        "text": "Adjunctive aminoglycoside dosing: tobramycin or netilmicin 1 mg/kg every 8 h added for the first 7 days.",
+        "byte_quote": "Aminoglycoside (either tobramycin or netilmicin at 1 mg/kg of body weight q8h) was added to the drug therapy described above for the first 7 days"
+      },
+      {
+        "id": "c12",
+        "text": "Adjunctive rifampicin dosing: 450 mg once daily if under 50 kg, 600 mg once daily if over 50 kg, oral or IV, for at least 4 weeks when endocarditis or extracardiac deep infection is suspected/confirmed (weight-banded dosing).",
+        "byte_quote": "Rifampicin (450 mg once daily for patients under 50 kg and 600 mg once daily for patients over 50 kg in weight, orally or intravenously) was recommended for at least 4 weeks"
+      },
+      {
+        "id": "c13",
+        "text": "In the actual cohort, 88% (65 of 74 patients) were treated with cloxacillin or dicloxacillin.",
+        "byte_quote": "Sixty-five of 74 patients (88%) were treated with cloxacillin or dicloxacillin"
+      }
+    ],
+    "cites": []
   }
 ]

--- a/code/specs/data/mycin-2026/grounding/workflows/decompose-source.workflow.js
+++ b/code/specs/data/mycin-2026/grounding/workflows/decompose-source.workflow.js
@@ -48,16 +48,40 @@ const SCHEMA = {
   },
 }
 
-// The organism-id citation frontier (output of `ground_sources.py --list`).
-// The most recent grounding frontier (G3 dose sources). Pass args.sources to override;
-// earlier organism-id epidemiology/morphology/host-factor sources are already in the CAS.
+// The pending-citation frontier — every cited source not yet in the CAS (output of
+// `ground_sources.py --list`), decomposed to clear the ledger's pending column.
 const EMBEDDED = [
-  'https://academic.oup.com/cid/article/39/9/1267/402080',
-  'https://dailymed.nlm.nih.gov/dailymed/fda/fdaDrugXsl.cfm?setid=8351aa37-552d-471d-b293-c564dcb6ec29',
-  'https://pmc.ncbi.nlm.nih.gov/articles/PMC2760093/',
-  'https://www.academia.edu/1171456/Initial_management_of_acute_bacterial_meningitis_in_adults_summary_of_IDSA_guidelines',
-  'https://dailymed.nlm.nih.gov/dailymed/fda/fdaDrugXsl.cfm?setid=7d74dfa6-0468-43ad-ad7f-dd90d9ae7706',
-  'https://dailymed.nlm.nih.gov/dailymed/fda/fdaDrugXsl.cfm?setid=9a105eaf-ee77-4016-beeb-d425a5565db2&type=display',
+  "https://academic.oup.com/cid/article/52/5/e103/388285",
+  "https://www.ncbi.nlm.nih.gov/books/NBK482367/",
+  "https://pmc.ncbi.nlm.nih.gov/articles/PMC5644167/",
+  "https://www.aafp.org/pubs/afp/issues/2011/1001/p771.html",
+  "https://pubmed.ncbi.nlm.nih.gov/15701325/",
+  "https://pmc.ncbi.nlm.nih.gov/articles/PMC10031580/",
+  "https://pmc.ncbi.nlm.nih.gov/articles/PMC2708523/",
+  "https://pmc.ncbi.nlm.nih.gov/articles/PMC12217021/",
+  "https://pubmed.ncbi.nlm.nih.gov/6696301/",
+  "https://pmc.ncbi.nlm.nih.gov/articles/PMC5880328/",
+  "https://www.cdc.gov/std/treatment-guidelines/penicillin-allergy.htm",
+  "https://dailymed.nlm.nih.gov/dailymed/drugInfo.cfm?setid=3c442cca-47f5-48e5-b718-c09413911687",
+  "https://dailymed.nlm.nih.gov/dailymed/lookup.cfm?setid=793c75eb-dd65-4b6d-ac46-6e57ce1334f7",
+  "https://dailymed.nlm.nih.gov/dailymed/drugInfo.cfm?setid=65e5f2ee-934c-40d7-967c-00d085f84ffd",
+  "https://dailymed.nlm.nih.gov/dailymed/fda/fdaDrugXsl.cfm?setid=f604d399-fded-4f4f-8efe-af558ed07b9d",
+  "https://dailymed.nlm.nih.gov/dailymed/fda/fdaDrugXsl.cfm?setid=99e523d8-9bde-43cb-8434-497015e5dcbd",
+  "https://pubmed.ncbi.nlm.nih.gov/15306996/",
+  "https://pmc.ncbi.nlm.nih.gov/articles/PMC8785473/",
+  "https://www.cambridge.org/core/journals/epidemiology-and-infection/article/burden-of-communityonset-bloodstream-infection-a-populationbased-assessment/4C3033D11C42B1D2B68B3580C283DB9A",
+  "https://pmc.ncbi.nlm.nih.gov/articles/PMC10699684/",
+  "https://pubmed.ncbi.nlm.nih.gov/3284952/",
+  "https://pmc.ncbi.nlm.nih.gov/articles/PMC10350481/",
+  "https://www.ncbi.nlm.nih.gov/books/NBK430891/",
+  "https://academic.oup.com/cid/article/49/1/1/369414",
+  "https://academic.oup.com/cid/article/72/7/1211/5836974",
+  "https://pmc.ncbi.nlm.nih.gov/articles/PMC12902366/",
+  "https://pmc.ncbi.nlm.nih.gov/articles/PMC4451395/",
+  "https://pmc.ncbi.nlm.nih.gov/articles/PMC12258469/",
+  "https://pmc.ncbi.nlm.nih.gov/articles/PMC3892635/",
+  "https://pubmed.ncbi.nlm.nih.gov/18691485/",
+  "https://www.ebi.ac.uk/europepmc/webservices/rest/PMC1584240/fullTextXML",
 ]
 const sources = (args && args.sources) || EMBEDDED.map((u) => ({ source_id: u, resolved_url: u }))
 
@@ -65,7 +89,7 @@ const objs = await pipeline(
   sources,
   (s) => agent(
     `Fetch this source and DECOMPOSE it (nothing on blind trust). WebFetch the URL and read it. ` +
-    `Extract the KEY factual claims it makes about bacterial-meningitis ORGANISM EPIDEMIOLOGY (which pathogens, what proportions, in which populations), HOST / RISK FACTORS (age band, immune status, exposures, recent neurosurgery or CSF device, crowding, rash — which host factor RAISES which organism), CSF GRAM-STAIN MORPHOLOGY, and ANTIBIOTIC DOSING for bacterial meningitis (drug, dose, interval, and whether it is the adult vs pediatric / CNS vs general indication). ` +
+    `Extract the KEY factual claims it makes about bacterial-infection diagnosis + antibiotic treatment: ORGANISM EPIDEMIOLOGY (which pathogens, what proportions, in which populations — meningitis, UTI, or bloodstream/bacteremia), HOST / RISK FACTORS (age band, immune status, exposures, device/neurosurgery, crowding, rash, neutropenia, injection drug use — which factor RAISES which organism), GRAM-STAIN / URINALYSIS MORPHOLOGY, ANTIBIOTIC DOSING (drug, dose, interval, adult vs pediatric / CNS vs general indication), CONTRAINDICATIONS + INTERACTIONS (allergy cross-reactivity, pregnancy, nephrotoxicity, QT), and BLOODSTREAM-INFECTION SOURCE→ORGANISM associations (which portal of entry predicts which organism). ` +
     `For EACH claim give a short normalized \`text\` and a VERBATIM \`byte_quote\` copied exactly from the fetched page (never paraphrase or invent — if you cannot fetch the page, return an empty claims array). ` +
     `Also list in \`cites\` any source THIS page attributes a figure to (e.g. "As per Thigpen et al." → "Thigpen et al. NEJM 2011") — that is the recursion frontier. ` +
     `URL: ${s.resolved_url}`,


### PR DESCRIPTION
## What

Completes the **"nothing on blind trust" recursion** for the current corpus: every source any grounded fact cites is now fetched, decomposed into byte-provenanced claims, committed to `cas/sources/`, and **every citation is checked against its *independently* decomposed source**.

- 31 new source objects → **62 source objects, 673 byte-provenanced claims** in the CAS.
- Citation verification: **36 fully verified · 4 core-verified · 31 unverified · 0 pending** (was ~35 pending).

## The check earned its keep

It surfaced **12 grounded (ACCEPT) facts whose verbatim citation is NOT in the independent decomposition** — the fix-up frontier (`grounding/DECOMPOSE-FINDINGS.md`). Two failure modes:
1. **Different sentence / same fact** — the source corroborates it via a *different* span (e.g. `host_neonate_gnb`: Merck's "Key Points" summary vs the body list). The fact is supported, just not by the same sentence.
2. **Genuinely over-reached** — a value from a different population/indication than the source's headline figure.

The honest invariant to add next: a fact is ACCEPT only if its citation verifies against the **decomposed** source, not merely byte-stable on the live page at grounding time. The 19 unverified FLAG facts are expected (already untrusted). These 12 are now **explicitly visible in the ledger as ✗ UNVERIFIED** rather than hidden as "pending".

## Nature of the change
Pure **data** (31 decomposed source objects + the regenerated ledger + the findings doc) plus the already-committed broadened `decompose-source` workflow. No new code → no security-review surface.

System ledger: grounded 43 · inferred-flagged 24 · authored-debt 3 · 6 artifacts · **0 pending citations**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)