### PR TITLE
[codex] Add Z-Wave request tracker dispatch summary

### DIFF
--- a/code/packages/rust/zwave-serial-api/CHANGELOG.md
+++ b/code/packages/rust/zwave-serial-api/CHANGELOG.md
@@ -17,6 +17,8 @@ All notable changes to this package will be documented in this file.
 - `RequestTrackerDrainSummary` for controller dispatch handoff checks across
   request-loop readiness, callback/response drains, timeout drains, and pending
   function drains.
+- `RequestTrackerDispatchSummary` for payload-free controller dispatch
+  readiness over request-loop and drain completion checks.
 
 ## [0.1.0] - 2026-05-06
 

--- a/code/packages/rust/zwave-serial-api/README.md
+++ b/code/packages/rust/zwave-serial-api/README.md
@@ -30,6 +30,8 @@ control-plane layer:
   timeout-queue drain checks
 - request tracker drain summaries for controller dispatch handoff checks across
   request-loop, callback, response, timeout, and pending-function drains
+- request tracker dispatch summaries that turn completed drain checks into a
+  payload-free controller dispatch readiness view
 
 It does not yet open a serial port, interview nodes, handle inclusion, or decode
 command-class payload semantics.

--- a/code/packages/rust/zwave-serial-api/src/lib.rs
+++ b/code/packages/rust/zwave-serial-api/src/lib.rs
@@ -864,6 +864,101 @@ pub fn summarize_request_tracker_drain(tracker: &RequestTracker) -> RequestTrack
     RequestTrackerDrainSummary::from_tracker(tracker)
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RequestTrackerDispatchSummary {
+    pub drain_summary: RequestTrackerDrainSummary,
+    pub required_dispatch_check_count: usize,
+    pub passed_dispatch_check_count: usize,
+    pub blocked_dispatch_check_count: usize,
+    pub request_drain_ready: bool,
+    pub request_loop_ready: bool,
+    pub callback_drain_complete: bool,
+    pub response_drain_complete: bool,
+    pub timeout_drain_complete: bool,
+    pub pending_function_drain_complete: bool,
+    pub request_dispatch_ready: bool,
+}
+
+impl RequestTrackerDispatchSummary {
+    pub fn from_tracker(tracker: &RequestTracker) -> Self {
+        Self::from_drain_summary(summarize_request_tracker_drain(tracker))
+    }
+
+    pub fn from_drain_summary(drain_summary: RequestTrackerDrainSummary) -> Self {
+        let request_drain_ready = drain_summary.is_request_drain_ready();
+        let request_loop_ready = !drain_summary.needs_request_loop_readiness();
+        let callback_drain_complete = !drain_summary.needs_callback_drain();
+        let response_drain_complete = !drain_summary.needs_response_drain();
+        let timeout_drain_complete = !drain_summary.needs_timeout_drain();
+        let pending_function_drain_complete = !drain_summary.needs_pending_function_drain();
+        let checks = [
+            request_drain_ready,
+            request_loop_ready,
+            callback_drain_complete,
+            response_drain_complete,
+            timeout_drain_complete,
+            pending_function_drain_complete,
+        ];
+        let passed_dispatch_check_count = checks.iter().filter(|ready| **ready).count();
+        let required_dispatch_check_count = checks.len();
+        let blocked_dispatch_check_count =
+            required_dispatch_check_count - passed_dispatch_check_count;
+        let request_dispatch_ready = blocked_dispatch_check_count == 0;
+
+        Self {
+            drain_summary,
+            required_dispatch_check_count,
+            passed_dispatch_check_count,
+            blocked_dispatch_check_count,
+            request_drain_ready,
+            request_loop_ready,
+            callback_drain_complete,
+            response_drain_complete,
+            timeout_drain_complete,
+            pending_function_drain_complete,
+            request_dispatch_ready,
+        }
+    }
+
+    pub fn is_request_dispatch_ready(&self) -> bool {
+        self.request_dispatch_ready
+    }
+
+    pub fn has_blocked_dispatch_checks(&self) -> bool {
+        self.blocked_dispatch_check_count > 0
+    }
+
+    pub fn needs_request_drain(&self) -> bool {
+        !self.request_drain_ready
+    }
+
+    pub fn needs_request_loop_readiness(&self) -> bool {
+        !self.request_loop_ready
+    }
+
+    pub fn needs_callback_drain(&self) -> bool {
+        !self.callback_drain_complete
+    }
+
+    pub fn needs_response_drain(&self) -> bool {
+        !self.response_drain_complete
+    }
+
+    pub fn needs_timeout_drain(&self) -> bool {
+        !self.timeout_drain_complete
+    }
+
+    pub fn needs_pending_function_drain(&self) -> bool {
+        !self.pending_function_drain_complete
+    }
+}
+
+pub fn summarize_request_tracker_dispatch(
+    tracker: &RequestTracker,
+) -> RequestTrackerDispatchSummary {
+    RequestTrackerDispatchSummary::from_tracker(tracker)
+}
+
 #[derive(Debug, Clone, Default)]
 pub struct RequestTracker {
     pending: BTreeMap<RequestKey, PendingRequest>,
@@ -1721,6 +1816,73 @@ mod tests {
         assert!(!summary.request_drain_ready);
         assert!(!summary.is_request_drain_ready());
         assert!(summary.has_blocked_drain_checks());
+        assert!(summary.needs_request_loop_readiness());
+        assert!(summary.needs_callback_drain());
+        assert!(summary.needs_response_drain());
+        assert!(summary.needs_timeout_drain());
+        assert!(summary.needs_pending_function_drain());
+    }
+
+    #[test]
+    fn request_tracker_dispatch_summary_marks_idle_tracker_ready() {
+        let tracker = RequestTracker::new();
+
+        let summary = summarize_request_tracker_dispatch(&tracker);
+
+        assert_eq!(
+            summary.drain_summary,
+            summarize_request_tracker_drain(&tracker)
+        );
+        assert_eq!(summary.required_dispatch_check_count, 6);
+        assert_eq!(summary.passed_dispatch_check_count, 6);
+        assert_eq!(summary.blocked_dispatch_check_count, 0);
+        assert!(summary.request_drain_ready);
+        assert!(summary.request_loop_ready);
+        assert!(summary.callback_drain_complete);
+        assert!(summary.response_drain_complete);
+        assert!(summary.timeout_drain_complete);
+        assert!(summary.pending_function_drain_complete);
+        assert!(summary.request_dispatch_ready);
+        assert!(summary.is_request_dispatch_ready());
+        assert!(!summary.has_blocked_dispatch_checks());
+        assert!(!summary.needs_request_drain());
+        assert!(!summary.needs_request_loop_readiness());
+        assert!(!summary.needs_callback_drain());
+        assert!(!summary.needs_response_drain());
+        assert!(!summary.needs_timeout_drain());
+        assert!(!summary.needs_pending_function_drain());
+    }
+
+    #[test]
+    fn request_tracker_dispatch_summary_routes_pending_waits() {
+        let version = SerialMessage::request(FunctionId::GET_VERSION, Vec::new());
+        let send_data = SendDataRequest::new(
+            NodeId::Classic(2),
+            CommandClassFrame::new(CommandClassId::SWITCH_BINARY, 0x01, vec![0xff]),
+            TransmitOptions::reliable(),
+            0x44,
+        )
+        .to_message()
+        .unwrap();
+        let mut tracker = RequestTracker::new();
+        tracker.track(&version, 100, 500).unwrap();
+        tracker.track(&send_data, 120, 200).unwrap();
+
+        let summary = RequestTrackerDispatchSummary::from_tracker(&tracker);
+
+        assert_eq!(summary.required_dispatch_check_count, 6);
+        assert_eq!(summary.passed_dispatch_check_count, 0);
+        assert_eq!(summary.blocked_dispatch_check_count, 6);
+        assert!(!summary.request_drain_ready);
+        assert!(!summary.request_loop_ready);
+        assert!(!summary.callback_drain_complete);
+        assert!(!summary.response_drain_complete);
+        assert!(!summary.timeout_drain_complete);
+        assert!(!summary.pending_function_drain_complete);
+        assert!(!summary.request_dispatch_ready);
+        assert!(!summary.is_request_dispatch_ready());
+        assert!(summary.has_blocked_dispatch_checks());
+        assert!(summary.needs_request_drain());
         assert!(summary.needs_request_loop_readiness());
         assert!(summary.needs_callback_drain());
         assert!(summary.needs_response_drain());


### PR DESCRIPTION
## Summary

- add `RequestTrackerDispatchSummary` over request tracker drain readiness
- expose `summarize_request_tracker_dispatch` and dispatch blocker predicates
- document the new Z-Wave request tracker dispatch readiness view

## Validation

- `cargo fmt --manifest-path code\packages\rust\zwave-serial-api\Cargo.toml`
- `cargo test --manifest-path code\packages\rust\zwave-serial-api\Cargo.toml`
- `git diff --check -- code\packages\rust\zwave-serial-api\src\lib.rs code\packages\rust\zwave-serial-api\README.md code\packages\rust\zwave-serial-api\CHANGELOG.md`