### PR TITLE
feat(visicalc-qt): viewport primitive on the C++ model (virtualized infinite sheet)

### DIFF
--- a/demo/visicalc-qt/README.md
+++ b/demo/visicalc-qt/README.md
@@ -70,6 +70,25 @@ with binary-op error propagation (`=1/0` → `#DIV/0!`, and `=A1+1` over it →
 > runner can't expose the C++ `model` or link the engine, so its grid is empty.
 > Build and run the binary to see the live spreadsheet.
 
+## Infinite virtualized sheet
+
+`SpreadsheetModel` also exposes the engine's **viewport primitive** —
+`window(r0,c0,r1,c1)` (a dense `QVariantList` rectangle of display strings),
+`usedRange()`, `columnLetters()`, `currentRevision()`, and `changedSince()` —
+over the C ABI's `sc_get_window` / `sc_used_range` / `sc_changed_since`. These
+are `Q_INVOKABLE`, so a windowed QML grid (rendering only the visible rectangle
+of an unbounded sheet, the Qt sibling of the web/SwiftUI infinite views) binds
+to them directly.
+
+Headless proof: `test/tst_window.cpp` (qmake) seeds far-flung sparse cells and
+asserts the window is engine-computed + dense, a formula 1000 rows down
+(`Z1000` = 39) is reachable, the gaps are empty (sparse), column letters run
+AA/BA, and editing `A1` dirties the far dependent `Z1000` via `changedSince`:
+
+```bash
+cd test && qmake tst_window.pro && make && ./tst_window
+```
+
 ## Where this fits in the cross-backend demo plan
 
 | Backend | Engine | Status |

--- a/demo/visicalc-qt/src/SpreadsheetModel.cpp
+++ b/demo/visicalc-qt/src/SpreadsheetModel.cpp
@@ -11,6 +11,7 @@
 
 #include "SpreadsheetModel.h"
 
+#include <QJsonArray>
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QByteArray>
@@ -32,6 +33,31 @@ QString takeString(char *p) {
     QString s = QString::fromUtf8(p);
     sc_string_free(p);
     return s;
+}
+
+// Map one decoded value object (`{"kind":...}`) to the string a spreadsheet cell
+// should show. Shared by `display` (one cell) and `window` (a whole rectangle).
+QString displayValue(const QJsonObject &obj) {
+    const QString kind = obj.value(QStringLiteral("kind")).toString();
+    if (kind == QLatin1String("empty")) return QString();
+    if (kind == QLatin1String("number")) {
+        const double n = obj.value(QStringLiteral("value")).toDouble();
+        if (n == std::floor(n) && std::abs(n) < 1e15) {
+            return QString::number(static_cast<long long>(n));
+        }
+        return QString::number(n);
+    }
+    if (kind == QLatin1String("text")) {
+        return obj.value(QStringLiteral("value")).toString();
+    }
+    if (kind == QLatin1String("boolean")) {
+        return obj.value(QStringLiteral("value")).toBool() ? QStringLiteral("TRUE")
+                                                           : QStringLiteral("FALSE");
+    }
+    if (kind == QLatin1String("error")) {
+        return obj.value(QStringLiteral("code")).toString(QStringLiteral("#ERR"));
+    }
+    return QString();
 }
 
 } // namespace
@@ -79,30 +105,7 @@ QString SpreadsheetModel::display(const QString &a1) const {
     QJsonParseError err{};
     const QJsonDocument doc = QJsonDocument::fromJson(json.toUtf8(), &err);
     if (err.error != QJsonParseError::NoError || !doc.isObject()) return QString();
-    const QJsonObject obj = doc.object();
-
-    const QString kind = obj.value(QStringLiteral("kind")).toString();
-    if (kind == QLatin1String("empty")) return QString();
-    if (kind == QLatin1String("number")) {
-        const double n = obj.value(QStringLiteral("value")).toDouble();
-        // Show integers without a trailing ".0", matching the other demos.
-        if (n == std::floor(n) && std::abs(n) < 1e15) {
-            return QString::number(static_cast<long long>(n));
-        }
-        return QString::number(n);
-    }
-    if (kind == QLatin1String("text")) {
-        return obj.value(QStringLiteral("value")).toString();
-    }
-    if (kind == QLatin1String("boolean")) {
-        return obj.value(QStringLiteral("value")).toBool()
-                   ? QStringLiteral("TRUE")
-                   : QStringLiteral("FALSE");
-    }
-    if (kind == QLatin1String("error")) {
-        return obj.value(QStringLiteral("code")).toString(QStringLiteral("#ERR"));
-    }
-    return QString();
+    return displayValue(doc.object());
 }
 
 QString SpreadsheetModel::valueJson(const QString &a1) const {
@@ -141,6 +144,61 @@ void SpreadsheetModel::select(int row, int col) {
     selectedRow_ = std::max(0, std::min(Rows - 1, row));
     selectedCol_ = std::max(1, std::min(Cols, col));
     emit selectionChanged();
+}
+
+// ── Viewport primitive (virtualized infinite sheet) ──────────────────
+// These mirror the engine's get_window / used_range / changed_since reads so a
+// windowed QML grid can render only the visible rectangle of an unbounded sheet
+// — the Qt sibling of the SwiftUI/web infinite views. 1-based inclusive coords.
+
+QVariantList SpreadsheetModel::window(int row0, int col0, int row1, int col1) const {
+    const QString json = takeString(sc_get_window(
+        session_, static_cast<quint32>(row0), static_cast<quint32>(col0),
+        static_cast<quint32>(row1), static_cast<quint32>(col1)));
+    QVariantList rows;
+    const QJsonDocument doc = QJsonDocument::fromJson(json.toUtf8());
+    if (!doc.isObject()) return rows; // bad/oversized request → empty
+    const QJsonArray values = doc.object().value(QStringLiteral("values")).toArray();
+    for (const QJsonValue &rowVal : values) {
+        QVariantList row;
+        for (const QJsonValue &cell : rowVal.toArray()) {
+            row.append(displayValue(cell.toObject()));
+        }
+        rows.append(QVariant(row));
+    }
+    return rows;
+}
+
+QVariantMap SpreadsheetModel::usedRange() const {
+    const QString json = takeString(sc_used_range(session_));
+    const QJsonDocument doc = QJsonDocument::fromJson(json.toUtf8());
+    QVariantMap out;
+    if (!doc.isObject()) return out; // "null" (empty sheet) → empty map
+    const QJsonObject obj = doc.object();
+    out.insert(QStringLiteral("minRow"), obj.value(QStringLiteral("minRow")).toInt());
+    out.insert(QStringLiteral("minCol"), obj.value(QStringLiteral("minCol")).toInt());
+    out.insert(QStringLiteral("maxRow"), obj.value(QStringLiteral("maxRow")).toInt());
+    out.insert(QStringLiteral("maxCol"), obj.value(QStringLiteral("maxCol")).toInt());
+    return out;
+}
+
+QString SpreadsheetModel::columnLetters(int index) const {
+    return takeString(sc_column_letters(session_, static_cast<quint32>(index)));
+}
+
+quint64 SpreadsheetModel::currentRevision() const {
+    return sc_current_revision(session_);
+}
+
+QStringList SpreadsheetModel::changedSince(quint64 since) const {
+    const QString json = takeString(sc_changed_since(session_, since));
+    QStringList out;
+    const QJsonDocument doc = QJsonDocument::fromJson(json.toUtf8());
+    if (!doc.isObject()) return out;
+    for (const QJsonValue &v : doc.object().value(QStringLiteral("changed")).toArray()) {
+        out.append(v.toString());
+    }
+    return out;
 }
 
 void SpreadsheetModel::setSelected(const QString &raw) {

--- a/demo/visicalc-qt/src/SpreadsheetModel.h
+++ b/demo/visicalc-qt/src/SpreadsheetModel.h
@@ -22,7 +22,9 @@
 
 #include <QObject>
 #include <QString>
+#include <QStringList>
 #include <QVariantList>
+#include <QVariantMap>
 
 // The opaque session handle is forward-declared so this header doesn't drag the
 // C ABI header into every translation unit; SpreadsheetModel.cpp includes it.
@@ -71,6 +73,20 @@ public:
     // The raw value JSON the engine returns for a cell. Used by tests to assert
     // the engine contract directly.
     Q_INVOKABLE QString valueJson(const QString &a1) const;
+
+    // ── Viewport primitive (virtualized infinite sheet) ──
+    // A dense window of display strings (a list of rows, each a list of
+    // QString), 1-based inclusive coords — what a windowed QML grid renders.
+    Q_INVOKABLE QVariantList window(int row0, int col0, int row1, int col1) const;
+    // Data extent {minRow,minCol,maxRow,maxCol}, or an empty map if the sheet
+    // is empty. A host sizes its scrollable area to this.
+    Q_INVOKABLE QVariantMap usedRange() const;
+    // Column letters for a 1-based index (1 → "A", 27 → "AA").
+    Q_INVOKABLE QString columnLetters(int index) const;
+    // The per-edit revision clock; snapshot it, then pass to changedSince.
+    Q_INVOKABLE quint64 currentRevision() const;
+    // A1 addresses changed since `since` (empty if none / stale).
+    Q_INVOKABLE QStringList changedSince(quint64 since) const;
 
 signals:
     // viewportRows changed (after a recompute) — QML rebinds the grid.

--- a/demo/visicalc-qt/test/tst_window.cpp
+++ b/demo/visicalc-qt/test/tst_window.cpp
@@ -1,0 +1,85 @@
+// tst_window.cpp — headless proof that the Qt demo can drive a VIRTUALIZED
+// infinite sheet on the engine's viewport primitive (the C ABI's sc_get_window
+// / sc_used_range / sc_changed_since), with no GUI. The Qt sibling of the
+// SwiftUI demo's WindowedModelTests and the web demo's verify-infinite.mjs.
+//
+// It seeds deliberately far-flung, sparse cells on top of the model's default
+// cross-foot budget, then asserts the windowed reads are correct, bounded,
+// sparse, and diff on edit.
+//
+// Build & run (qmake — no CMake required):
+//   cd test && qmake tst_window.pro && make && ./tst_window
+
+#include <QtTest/QtTest>
+
+#include "SpreadsheetModel.h"
+
+class TstWindow : public QObject {
+    Q_OBJECT
+
+private slots:
+    void windowIsEngineComputedAndDense();
+    void farWindowReachesZ1000AndGapsAreSparse();
+    void extentColumnLettersAndChangedSince();
+};
+
+// Helper: the display string at window (1-based) cell (row, col), given the
+// window's origin (row0, col0).
+static QString at(const QVariantList &win, int row0, int col0, int row, int col) {
+    const QVariantList r = win.at(row - row0).toList();
+    return r.at(col - col0).toString();
+}
+
+void TstWindow::windowIsEngineComputedAndDense() {
+    SpreadsheetModel m;
+    // The default seed is the 5×5 cross-foot budget; a window over it is
+    // engine-computed and dense.
+    const QVariantList w = m.window(1, 1, 5, 5);
+    QCOMPARE(w.size(), 5);
+    QCOMPARE(at(w, 1, 1, 1, 1), QStringLiteral("15"));  // A1
+    QCOMPARE(at(w, 1, 1, 1, 5), QStringLiteral("38"));  // E1 = SUM(A1:D1)
+    QCOMPARE(at(w, 1, 1, 5, 5), QStringLiteral("169")); // E5 grand total
+}
+
+void TstWindow::farWindowReachesZ1000AndGapsAreSparse() {
+    SpreadsheetModel m;
+    // Plant a far-flung formula 1000 rows down (Z = col 26).
+    m.setCell("Z1000", "=SUM(A1:A4)"); // 15+8+12+4 = 39
+    // A window around it returns the computed value — reachable without
+    // materialising the millions of cells in between.
+    QCOMPARE(at(m.window(998, 24, 1002, 28), 998, 24, 1000, 26), QStringLiteral("39"));
+    // The gap between the two data islands is empty (the sheet is sparse).
+    const QVariantList gap = m.window(100, 1, 110, 10);
+    for (const QVariant &rowVar : gap) {
+        for (const QVariant &cell : rowVar.toList()) {
+            QCOMPARE(cell.toString(), QString());
+        }
+    }
+}
+
+void TstWindow::extentColumnLettersAndChangedSince() {
+    SpreadsheetModel m;
+    m.setCell("Z1000", "=SUM(A1:A4)");
+
+    // used_range extends to the far cell.
+    const QVariantMap u = m.usedRange();
+    QCOMPARE(u.value("maxRow").toInt(), 1000);
+    QCOMPARE(u.value("maxCol").toInt(), 26);
+
+    // Column letters past Z.
+    QCOMPARE(m.columnLetters(27), QStringLiteral("AA"));
+    QCOMPARE(m.columnLetters(53), QStringLiteral("BA"));
+
+    // Editing A1 dirties its far dependent Z1000 (=SUM(A1:A4)) via the diff.
+    const quint64 rev = m.currentRevision();
+    m.setCell("A1", "115");
+    const QStringList changed = m.changedSince(rev);
+    QVERIFY2(changed.contains("A1"), "A1 changed");
+    QVERIFY2(changed.contains("Z1000"),
+             qPrintable("far dependent recomputed: " + changed.join(",")));
+    // And the recomputed value shows through a fresh window read: 115+8+12+4.
+    QCOMPARE(at(m.window(1000, 26, 1000, 26), 1000, 26, 1000, 26), QStringLiteral("139"));
+}
+
+QTEST_MAIN(TstWindow)
+#include "tst_window.moc"

--- a/demo/visicalc-qt/test/tst_window.pro
+++ b/demo/visicalc-qt/test/tst_window.pro
@@ -1,0 +1,28 @@
+# tst_window.pro — qmake project for the headless Qt viewport (windowing) test.
+# Same shape as tst_model.pro: builds the engine-backed SpreadsheetModel plus the
+# QtTest harness and links the vendored Rust engine static library — no GUI.
+#
+# Build & run:
+#   bash ../scripts/build.sh   # regenerate QML + build & vendor the engine
+#   cd test && qmake tst_window.pro && make && ./tst_window
+
+QT       += core testlib
+QT       -= gui
+
+CONFIG   += console c++17
+CONFIG   -= app_bundle
+TEMPLATE  = app
+TARGET    = tst_window
+
+INCLUDEPATH += $$PWD/../src $$PWD/../Vendor
+
+SOURCES += \
+    tst_window.cpp \
+    $$PWD/../src/SpreadsheetModel.cpp
+
+HEADERS += \
+    $$PWD/../src/SpreadsheetModel.h
+
+LIBS += -L$$PWD/../Vendor -lspreadsheet_capi
+macx: LIBS += -framework CoreFoundation -framework Security -framework SystemConfiguration
+unix:!macx: LIBS += -ldl -lpthread -lm


### PR DESCRIPTION
Second native backend on the **infinite virtualized sheet**. Qt's C++ `SpreadsheetModel` gains the engine's windowed reads over the C ABI (`sc_get_window` / `sc_used_range` / `sc_column_letters` / `sc_current_revision` / `sc_changed_since`), all `Q_INVOKABLE` so a windowed QML grid can render only the visible rectangle of an unbounded sheet.

## What
- `SpreadsheetModel.{h,cpp}`: `window(r0,c0,r1,c1)` → dense `QVariantList` rows of display strings, `usedRange()`, `columnLetters()`, `currentRevision()`, `changedSince()`. Extracted a `displayValue(QJsonObject)` helper shared by `display()` and `window()`; every `char*` routes through the existing `takeString()` free-once chokepoint.
- `test/tst_window.{cpp,pro}`: headless QtTest (qmake).

## Verification
- **`tst_window` 5/5 green**: window engine-computed + dense (A1=15, E1=38, E5=169), a formula 1000 rows down (`Z1000`=39) reachable, gaps empty (sparse), letters AA/BA, editing `A1` dirties far dependent `Z1000` via `changedSince`.
- `tst_model` 5/5 still green (the `display()` refactor is behavior-preserving).
- The GUI app **compiles + links** with the new `Q_INVOKABLE` methods.
- `/security-review` passed (free-once char* handling, Qt null-safe JSON, non-object guards, no temporary-lifetime hazard).

Two down (SwiftUI [#5838](https://github.com/adhithyan15/coding-adventures/pull/5838), Qt). Flutter / Compose / XAML next, over the same C ABI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)