### PR TITLE
feat(visicalc-flutter): viewport primitive over dart:ffi (virtualized infinite sheet)

### DIFF
--- a/demo/visicalc-flutter/README.md
+++ b/demo/visicalc-flutter/README.md
@@ -89,6 +89,21 @@ Volatile per-platform caches (`android/.gradle/`, `ios/Pods/`,
 `xcuserdata/`, etc.) are gitignored — `flutter build` regenerates
 them on first run.
 
+## Infinite virtualized sheet
+
+`SpreadsheetSession` (`lib/engine.dart`) also binds the engine's **viewport
+primitive** over dart:ffi — `window(r0,c0,r1,c1)` (a dense `List<List<String>>`
+rectangle), `usedRange()`, `columnLetters()`, `currentRevision()`, and
+`changedSince()` — so a windowed Flutter grid can render only the visible
+rectangle of an unbounded sheet (the Flutter sibling of the web/SwiftUI/Qt
+infinite views).
+
+Headless proof: `test/window_test.dart` seeds far-flung sparse cells and asserts
+the window is engine-computed + dense (A1=15, E1=38, E5=169), a formula 1000
+rows down (`Z1000` = 39) is reachable, the gaps are empty (sparse), column
+letters run AA/BA, and editing `A1` dirties the far dependent `Z1000` via
+`changedSince`. Run with `flutter test test/window_test.dart`.
+
 ## Where this fits in the cross-backend demo plan
 
 | Backend | Engine | Status |

--- a/demo/visicalc-flutter/lib/engine.dart
+++ b/demo/visicalc-flutter/lib/engine.dart
@@ -48,6 +48,20 @@ typedef _MallocD = Pointer<Uint8> Function(int);
 typedef _FreeC = Void Function(Pointer<Uint8>);
 typedef _FreeD = void Function(Pointer<Uint8>);
 
+// Viewport primitive: integer coords in, JSON char* out (current_revision
+// returns a u64 directly). Uint32/Uint64 in the native signature; plain `int`
+// in the Dart signature.
+typedef _WindowC = Pointer<Uint8> Function(Pointer<Void>, Uint32, Uint32, Uint32, Uint32);
+typedef _WindowD = Pointer<Uint8> Function(Pointer<Void>, int, int, int, int);
+typedef _NoArgC = Pointer<Uint8> Function(Pointer<Void>);
+typedef _NoArgD = Pointer<Uint8> Function(Pointer<Void>);
+typedef _ColLettersC = Pointer<Uint8> Function(Pointer<Void>, Uint32);
+typedef _ColLettersD = Pointer<Uint8> Function(Pointer<Void>, int);
+typedef _CurrentRevC = Uint64 Function(Pointer<Void>);
+typedef _CurrentRevD = int Function(Pointer<Void>);
+typedef _ChangedSinceC = Pointer<Uint8> Function(Pointer<Void>, Uint64);
+typedef _ChangedSinceD = Pointer<Uint8> Function(Pointer<Void>, int);
+
 /// A single spreadsheet session, owning the opaque C handle.
 class SpreadsheetSession {
   final DynamicLibrary _lib;
@@ -58,6 +72,11 @@ class SpreadsheetSession {
   late final _GetD _getValue;
   late final _GetD _getRaw;
   late final _StringFreeD _stringFree;
+  late final _WindowD _getWindow;
+  late final _NoArgD _usedRangeFn;
+  late final _ColLettersD _columnLettersFn;
+  late final _CurrentRevD _currentRevisionFn;
+  late final _ChangedSinceD _changedSinceFn;
 
   static final DynamicLibrary _proc = DynamicLibrary.process();
   static final _MallocD _malloc =
@@ -71,6 +90,11 @@ class SpreadsheetSession {
     _getValue = _lib.lookupFunction<_GetC, _GetD>('sc_get_value');
     _getRaw = _lib.lookupFunction<_GetC, _GetD>('sc_get_raw');
     _stringFree = _lib.lookupFunction<_StringFreeC, _StringFreeD>('sc_string_free');
+    _getWindow = _lib.lookupFunction<_WindowC, _WindowD>('sc_get_window');
+    _usedRangeFn = _lib.lookupFunction<_NoArgC, _NoArgD>('sc_used_range');
+    _columnLettersFn = _lib.lookupFunction<_ColLettersC, _ColLettersD>('sc_column_letters');
+    _currentRevisionFn = _lib.lookupFunction<_CurrentRevC, _CurrentRevD>('sc_current_revision');
+    _changedSinceFn = _lib.lookupFunction<_ChangedSinceC, _ChangedSinceD>('sc_changed_since');
     _handle = sessionNew();
   }
 
@@ -163,13 +187,9 @@ class SpreadsheetSession {
     }
   }
 
-  /// The display string for a cell — what a spreadsheet should show. Parses the
-  /// engine's JSON (the same shape the TS/WASM/Swift/Qt engines emit).
-  String display(String a1) {
-    final json = getValueJson(a1);
-    if (json.isEmpty) return '';
-    final Object? obj = jsonDecode(json);
-    if (obj is! Map) return '';
+  /// Map one decoded value object (`{"kind":...}`) to the string a spreadsheet
+  /// cell should show. Shared by `display` (one cell) and `window` (a rectangle).
+  static String _displayValue(Map obj) {
     switch (obj['kind']) {
       case 'empty':
         return '';
@@ -189,6 +209,63 @@ class SpreadsheetSession {
       default:
         return '';
     }
+  }
+
+  /// The display string for a cell — what a spreadsheet should show. Parses the
+  /// engine's JSON (the same shape the TS/WASM/Swift/Qt engines emit).
+  String display(String a1) {
+    final json = getValueJson(a1);
+    if (json.isEmpty) return '';
+    final Object? obj = jsonDecode(json);
+    return (obj is Map) ? _displayValue(obj) : '';
+  }
+
+  // ── Viewport primitive (virtualized infinite sheet) ──────────────────
+  // These mirror the engine's get_window / used_range / changed_since reads (the
+  // C ABI's sc_get_window etc.), 1-based inclusive coords, so a windowed Flutter
+  // grid can render only the visible rectangle of an unbounded sheet.
+
+  /// Dense display strings for the inclusive 1-based rectangle, row-major
+  /// (empty cells become ''). Empty list on a bad/oversized request.
+  List<List<String>> window(int row0, int col0, int row1, int col1) {
+    final json = _takeString(_getWindow(_handle, row0, col0, row1, col1));
+    final Object? obj = jsonDecode(json);
+    if (obj is! Map || obj['values'] is! List) return const [];
+    return (obj['values'] as List)
+        .map<List<String>>((row) => (row as List)
+            .map<String>((c) => (c is Map) ? _displayValue(c) : '')
+            .toList())
+        .toList();
+  }
+
+  /// The data extent `{minRow,minCol,maxRow,maxCol}`, or null if the sheet is
+  /// empty (the engine returns the JSON literal `null`).
+  Map<String, int>? usedRange() {
+    final json = _takeString(_usedRangeFn(_handle));
+    final Object? obj = jsonDecode(json);
+    if (obj is! Map) return null;
+    return {
+      'minRow': obj['minRow'] as int,
+      'minCol': obj['minCol'] as int,
+      'maxRow': obj['maxRow'] as int,
+      'maxCol': obj['maxCol'] as int,
+    };
+  }
+
+  /// Column letters for a 1-based index (`1` → `"A"`, `27` → `"AA"`).
+  String columnLetters(int index) => _takeString(_columnLettersFn(_handle, index));
+
+  /// The per-edit revision clock. Snapshot it, then pass to [changedSince].
+  int currentRevision() => _currentRevisionFn(_handle);
+
+  /// Cells changed since [since]. `stale` means re-read the whole window.
+  ({List<String> changed, bool stale}) changedSince(int since) {
+    final json = _takeString(_changedSinceFn(_handle, since));
+    final Object? obj = jsonDecode(json);
+    if (obj is! Map) return (changed: const [], stale: false);
+    if (obj['stale'] == true) return (changed: const [], stale: true);
+    final list = (obj['changed'] as List?)?.cast<String>() ?? const [];
+    return (changed: list, stale: false);
   }
 }
 

--- a/demo/visicalc-flutter/test/window_test.dart
+++ b/demo/visicalc-flutter/test/window_test.dart
@@ -1,0 +1,71 @@
+// window_test.dart — headless proof that the Flutter demo can drive a
+// VIRTUALIZED infinite sheet on the engine's viewport primitive (via dart:ffi
+// over the C ABI's sc_get_window / sc_used_range / sc_changed_since), with no
+// widgets. The Flutter sibling of the SwiftUI WindowedModelTests and the web
+// demo's verify-infinite.mjs.
+//
+// Run (after `bash scripts/build.sh` vendors native/libspreadsheet_capi.*):
+//   flutter test test/window_test.dart
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:visicalc_flutter/engine.dart';
+
+void main() {
+  group('viewport primitive over dart:ffi', () {
+    SpreadsheetSession seed() {
+      final s = SpreadsheetSession();
+      // Cross-foot budget + a far-flung formula at Z1000 (row 1000, col 26).
+      const cells = {
+        'A1': '15', 'B1': '3', 'C1': '12', 'D1': '8', 'E1': '=SUM(A1:D1)',
+        'A2': '8', 'B2': '14', 'C2': '7', 'D2': '22', 'E2': '=SUM(A2:D2)',
+        'A3': '12', 'B3': '9', 'C3': '18', 'D3': '6', 'E3': '=SUM(A3:D3)',
+        'A4': '4', 'B4': '11', 'C4': '3', 'D4': '17', 'E4': '=SUM(A4:D4)',
+        'A5': '=SUM(A1:A4)', 'E5': '=SUM(E1:E4)',
+        'Z1000': '=SUM(A1:A4)', // 15+8+12+4 = 39
+      };
+      cells.forEach(s.setCell);
+      return s;
+    }
+
+    test('window is engine-computed and dense', () {
+      final s = seed();
+      addTearDown(s.dispose);
+      final w = s.window(1, 1, 5, 5);
+      expect(w[0][0], '15'); // A1
+      expect(w[0][4], '38'); // E1 = SUM(A1:D1)
+      expect(w[4][4], '169'); // E5 grand total
+      expect(w[0][1], '3'); // dense — B1
+    });
+
+    test('far window reaches Z1000 and the gaps are sparse', () {
+      final s = seed();
+      addTearDown(s.dispose);
+      // Around Z1000 (row 1000, col 26).
+      expect(s.window(998, 24, 1002, 28)[2][2], '39');
+      // The gap between the two data islands is empty.
+      for (final row in s.window(100, 1, 110, 10)) {
+        for (final cell in row) {
+          expect(cell, '');
+        }
+      }
+    });
+
+    test('extent, column letters and changed-since diff', () {
+      final s = seed();
+      addTearDown(s.dispose);
+      final u = s.usedRange()!;
+      expect(u['maxRow'], 1000);
+      expect(u['maxCol'], 26);
+      expect(s.columnLetters(27), 'AA');
+      expect(s.columnLetters(53), 'BA');
+
+      final rev = s.currentRevision();
+      s.setCell('A1', '115');
+      final diff = s.changedSince(rev);
+      expect(diff.stale, isFalse);
+      expect(diff.changed, contains('A1'));
+      expect(diff.changed, contains('Z1000')); // far dependent recomputed
+      expect(s.window(1000, 26, 1000, 26)[0][0], '139'); // 115+8+12+4
+    });
+  });
+}


### PR DESCRIPTION
Third native backend on the **infinite virtualized sheet**. Flutter's `SpreadsheetSession` binds the engine's windowed reads over **dart:ffi** (the C ABI's `sc_get_window` / `sc_used_range` / `sc_column_letters` / `sc_current_revision` / `sc_changed_since`) so a windowed Flutter grid can render only the visible rectangle of an unbounded sheet.

## What
- `lib/engine.dart`: `window(r0,c0,r1,c1)` → dense `List<List<String>>`, `usedRange()`, `columnLetters()`, `currentRevision()`, `changedSince()`. Integer-only args; every returned `Pointer<Uint8>` routes through the existing `_takeString()` free-once chokepoint (read-then-free **before** `jsonDecode`, so a malformed payload can't leak). Extracted a static `_displayValue(Map)` shared by `display()` and `window()`.
- `test/window_test.dart`: headless `flutter test`.

## Verification
- `flutter analyze` clean.
- **`flutter test` 6/6 green** (3 window + 3 existing `engine_test`, no regression): window engine-computed + dense (A1=15, E1=38, E5=169), a formula 1000 rows down (`Z1000`=39) reachable, gaps empty (sparse), letters AA/BA, editing `A1` dirties far dependent `Z1000` via `changedSince`.
- `/security-review` passed (free-once char* handling, correct `Uint32`/`Uint64`↔`int` typedef mapping, type-guarded JSON, no injection).

Three down (SwiftUI [#5838](https://github.com/adhithyan15/coding-adventures/pull/5838), Qt [#5839](https://github.com/adhithyan15/coding-adventures/pull/5839), Flutter). Compose / XAML next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)