### PR TITLE
feat(visicalc-compose): viewport primitive over Java FFM (virtualized infinite sheet)

### DIFF
--- a/demo/visicalc-compose/README.md
+++ b/demo/visicalc-compose/README.md
@@ -53,6 +53,22 @@ grid is engine-computed (E1 = 38, A5 = 39, E5 = 169), that editing A1 15 → 115
 recomputes the totals (E5 → 269), and that a formula computes with binary-op
 error propagation (`=1/0` → `#DIV/0!`, and `=A1+1` over it → `#DIV/0!`).
 
+## Infinite virtualized sheet
+
+`SpreadsheetSession` (`Engine.kt`) also binds the engine's **viewport
+primitive** over Java FFM — `window(r0,c0,r1,c1)` (a dense `List<List<String>>`
+rectangle), `usedRange()`, `columnLetters()`, `currentRevision()`, and
+`changedSince()` — so a windowed Compose grid can render only the visible
+rectangle of an unbounded sheet (the Compose sibling of the web/SwiftUI/Qt/
+Flutter infinite views). The window JSON is nested, so it's parsed by a tiny
+in-file JSON reader rather than `display()`'s per-value regex.
+
+Headless proof: `scripts/verify.sh` (kotlinc + FFM) seeds far-flung sparse cells
+and asserts the window is engine-computed + dense (A1=15, E1=38, E5=169), a
+formula 1000 rows down (`Z1000` = 39) is reachable, the gaps are empty (sparse),
+column letters run AA/BA, and editing `A1` dirties the far dependent `Z1000` via
+`changedSince`.
+
 ## Why "Compose for Desktop" rather than Jetpack Compose for Android?
 
 Same `androidx.compose.*` packages, same composable functions, same

--- a/demo/visicalc-compose/src/main/kotlin/Engine.kt
+++ b/demo/visicalc-compose/src/main/kotlin/Engine.kt
@@ -40,6 +40,16 @@ class SpreadsheetSession(libraryPath: String = resolveLibraryPath()) : AutoClose
     private val scGetRaw = handle("sc_get_raw", FunctionDescriptor.of(ptr, ptr, ptr))
     private val scStrFree = handle("sc_string_free", FunctionDescriptor.ofVoid(ptr))
 
+    // Viewport primitive: integer coords (JAVA_INT) and a u64 revision
+    // (JAVA_LONG); JSON char* results, except current_revision returns the long.
+    private val i32 = ValueLayout.JAVA_INT
+    private val i64 = ValueLayout.JAVA_LONG
+    private val scGetWindow = handle("sc_get_window", FunctionDescriptor.of(ptr, ptr, i32, i32, i32, i32))
+    private val scUsedRange = handle("sc_used_range", FunctionDescriptor.of(ptr, ptr))
+    private val scColumnLetters = handle("sc_column_letters", FunctionDescriptor.of(ptr, ptr, i32))
+    private val scCurrentRevision = handle("sc_current_revision", FunctionDescriptor.of(i64, ptr))
+    private val scChangedSince = handle("sc_changed_since", FunctionDescriptor.of(ptr, ptr, i64))
+
     private val session = scNew.invoke() as MemorySegment
 
     /// Read an engine-returned char* into a Kotlin String and free it with the
@@ -85,6 +95,53 @@ class SpreadsheetSession(libraryPath: String = resolveLibraryPath()) : AutoClose
             "error" -> Regex("\"code\":\"([^\"]+)\"").find(json)?.groupValues?.get(1) ?: "#ERR"
             else -> ""
         }
+    }
+
+    // ── Viewport primitive (virtualized infinite sheet) ──────────────
+    // These mirror the engine's get_window / used_range / changed_since reads
+    // (1-based inclusive coords) so a windowed Compose grid can render only the
+    // visible rectangle of an unbounded sheet — the Compose sibling of the
+    // web/SwiftUI/Qt/Flutter infinite views. The window JSON is nested, so these
+    // use the small JSON parser below rather than display()'s per-value regex.
+
+    /// Dense display strings for the inclusive 1-based rectangle, row-major
+    /// (empty cells become ""). Empty list on a bad/oversized request.
+    fun window(row0: Int, col0: Int, row1: Int, col1: Int): List<List<String>> {
+        val json = take(scGetWindow.invoke(session, row0, col0, row1, col1) as MemorySegment)
+        val obj = parseJson(json) as? Map<*, *> ?: return emptyList()
+        val values = obj["values"] as? List<*> ?: return emptyList()
+        return values.map { row ->
+            (row as List<*>).map { valueToDisplay(it as Map<*, *>) }
+        }
+    }
+
+    /// The data extent {minRow,minCol,maxRow,maxCol}, or null if the sheet is
+    /// empty (the engine returns the JSON literal `null`).
+    fun usedRange(): Map<String, Int>? {
+        val obj = parseJson(take(scUsedRange.invoke(session) as MemorySegment)) as? Map<*, *>
+            ?: return null
+        return mapOf(
+            "minRow" to (obj["minRow"] as Number).toInt(),
+            "minCol" to (obj["minCol"] as Number).toInt(),
+            "maxRow" to (obj["maxRow"] as Number).toInt(),
+            "maxCol" to (obj["maxCol"] as Number).toInt(),
+        )
+    }
+
+    /// Column letters for a 1-based index (1 -> "A", 27 -> "AA").
+    fun columnLetters(index: Int): String =
+        take(scColumnLetters.invoke(session, index) as MemorySegment)
+
+    /// The per-edit revision clock. Snapshot it, then pass to changedSince.
+    fun currentRevision(): Long = scCurrentRevision.invoke(session) as Long
+
+    /// Cells changed since `since`; the Boolean is `stale` (re-read everything).
+    fun changedSince(since: Long): Pair<List<String>, Boolean> {
+        val obj = parseJson(take(scChangedSince.invoke(session, since) as MemorySegment))
+            as? Map<*, *> ?: return Pair(emptyList(), false)
+        if (obj["stale"] == true) return Pair(emptyList(), true)
+        val changed = (obj["changed"] as? List<*>)?.map { it as String } ?: emptyList()
+        return Pair(changed, false)
     }
 
     override fun close() {
@@ -163,5 +220,108 @@ class SpreadsheetModel(
 
         /// A1 address for grid display row `r` (0-based) and column `c` (1..5).
         fun address(r: Int, c: Int): String = "${'A' + c - 1}${r + 1}"
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// A small JSON reader, just enough for the engine's output (objects,
+// arrays, strings, numbers, true/false/null). The window read is nested
+// (`{"values":[[{…},…],…]}`), which display()'s per-value regex can't
+// handle; rather than add a dependency, we parse it here. The engine emits
+// ASCII cell text and no \uXXXX escapes, so the minimal escape handling is
+// sufficient for this trusted input.
+// ─────────────────────────────────────────────────────────────────────
+
+/// Map one decoded value object (`{"kind":...}`) to the display string.
+private fun valueToDisplay(obj: Map<*, *>): String = when (obj["kind"]) {
+    "empty" -> ""
+    "number" -> {
+        val d = (obj["value"] as Number).toDouble()
+        if (d == Math.floor(d) && Math.abs(d) < 1e15) d.toLong().toString() else d.toString()
+    }
+    "text" -> obj["value"] as? String ?: ""
+    "boolean" -> if (obj["value"] == true) "TRUE" else "FALSE"
+    "error" -> obj["code"] as? String ?: "#ERR"
+    else -> ""
+}
+
+private fun parseJson(s: String): Any? = if (s.isEmpty()) null else JsonReader(s).readValue()
+
+private class JsonReader(private val s: String) {
+    private var i = 0
+    private fun ws() { while (i < s.length && s[i].isWhitespace()) i++ }
+
+    fun readValue(): Any? {
+        ws()
+        return when (s[i]) {
+            '{' -> readObject()
+            '[' -> readArray()
+            '"' -> readString()
+            't' -> { i += 4; true }
+            'f' -> { i += 5; false }
+            'n' -> { i += 4; null }
+            else -> readNumber()
+        }
+    }
+
+    private fun readObject(): Map<String, Any?> {
+        val m = LinkedHashMap<String, Any?>()
+        i++ // {
+        ws()
+        if (s[i] == '}') { i++; return m }
+        while (true) {
+            ws()
+            val k = readString()
+            ws(); i++ // :
+            m[k] = readValue()
+            ws()
+            if (s[i] == ',') { i++; continue }
+            i++ // }
+            break
+        }
+        return m
+    }
+
+    private fun readArray(): List<Any?> {
+        val l = ArrayList<Any?>()
+        i++ // [
+        ws()
+        if (s[i] == ']') { i++; return l }
+        while (true) {
+            l.add(readValue())
+            ws()
+            if (s[i] == ',') { i++; continue }
+            i++ // ]
+            break
+        }
+        return l
+    }
+
+    private fun readString(): String {
+        val sb = StringBuilder()
+        i++ // opening quote
+        while (s[i] != '"') {
+            if (s[i] == '\\') {
+                i++
+                sb.append(
+                    when (s[i]) {
+                        'n' -> '\n'; 't' -> '\t'; 'r' -> '\r'
+                        '"' -> '"'; '\\' -> '\\'; '/' -> '/'
+                        else -> s[i]
+                    }
+                )
+            } else {
+                sb.append(s[i])
+            }
+            i++
+        }
+        i++ // closing quote
+        return sb.toString()
+    }
+
+    private fun readNumber(): Double {
+        val start = i
+        while (i < s.length && (s[i].isDigit() || s[i] in "-+.eE")) i++
+        return s.substring(start, i).toDouble()
     }
 }

--- a/demo/visicalc-compose/test/EngineSmoke.kt
+++ b/demo/visicalc-compose/test/EngineSmoke.kt
@@ -53,8 +53,44 @@ fun main() {
     model.setCell(0, 2, "=A1+1")              // B1
     checkContains("B1 propagated", model.valueJson("B1"), "#DIV/0!")
     check("B1 display", model.viewportRows()[0][2], "#DIV/0!")
-
     model.close()
+
+    // ── Viewport primitive (virtualized infinite sheet) ──────────────
+    // A fresh session seeded with the cross-foot budget + a far-flung formula at
+    // Z1000 (row 1000, col 26), to exercise the windowed reads.
+    val s = SpreadsheetSession()
+    for ((a, v) in listOf(
+        "A1" to "15", "B1" to "3", "C1" to "12", "D1" to "8", "E1" to "=SUM(A1:D1)",
+        "A2" to "8", "B2" to "14", "C2" to "7", "D2" to "22", "E2" to "=SUM(A2:D2)",
+        "A3" to "12", "B3" to "9", "C3" to "18", "D3" to "6", "E3" to "=SUM(A3:D3)",
+        "A4" to "4", "B4" to "11", "C4" to "3", "D4" to "17", "E4" to "=SUM(A4:D4)",
+        "A5" to "=SUM(A1:A4)", "E5" to "=SUM(E1:E4)", "Z1000" to "=SUM(A1:A4)",
+    )) s.setCell(a, v)
+
+    // Window over A1:E5 — engine-computed and dense.
+    val w = s.window(1, 1, 5, 5)
+    check("window A1", w[0][0], "15")
+    check("window E1", w[0][4], "38")
+    check("window E5", w[4][4], "169")
+    // A window 1000 rows down reaches the far formula; the gap is empty.
+    check("window Z1000", s.window(998, 24, 1002, 28)[2][2], "39")
+    check("window gap empty", s.window(100, 1, 110, 10)[5][5], "")
+    // Extent + letters past Z.
+    val u = s.usedRange()!!
+    check("usedRange maxRow", u["maxRow"].toString(), "1000")
+    check("usedRange maxCol", u["maxCol"].toString(), "26")
+    check("columnLetters 27", s.columnLetters(27), "AA")
+    check("columnLetters 53", s.columnLetters(53), "BA")
+    // Editing A1 dirties the far dependent Z1000 via changedSince.
+    val rev = s.currentRevision()
+    s.setCell("A1", "115")
+    val (changed, stale) = s.changedSince(rev)
+    check("changedSince not stale", stale.toString(), "false")
+    checkContains("changedSince has A1", changed.joinToString(","), "A1")
+    checkContains("changedSince reaches Z1000", changed.joinToString(","), "Z1000")
+    check("window Z1000 after edit", s.window(1000, 26, 1000, 26)[0][0], "139")
+    s.close()
+
     println(if (failures == 0) "\nALL PASS" else "\n$failures FAILURE(S)")
     kotlin.system.exitProcess(if (failures == 0) 0 else 1)
 }


### PR DESCRIPTION
Fourth native backend on the **infinite virtualized sheet**. Compose's `SpreadsheetSession` binds the engine's windowed reads over the **Java FFM API** (the C ABI's `sc_get_window` / `sc_used_range` / `sc_column_letters` / `sc_current_revision` / `sc_changed_since`) so a windowed Compose grid can render only the visible rectangle of an unbounded sheet.

## What
- `Engine.kt`: `window(r0,c0,r1,c1)` → dense `List<List<String>>`, `usedRange()`, `columnLetters()`, `currentRevision()` → `Long`, `changedSince()` → `Pair<List<String>, Boolean(stale)>`. Integer-only downcall args; every returned `char*` routes through the existing `take()` free-once chokepoint (read **before** parse). Added a **tiny in-file `JsonReader`** because the window JSON is nested (the per-value regex `display()` uses can't handle nested arrays); a shared `valueToDisplay()` formats cells.
- `test/EngineSmoke.kt`: the `verify.sh` harness (kotlinc + FFM) gains windowed checks.

## Verification
- **`scripts/verify.sh` ALL PASS**: window engine-computed + dense (A1=15, E1=38, E5=169), a formula 1000 rows down (`Z1000`=39) reachable, gaps empty (sparse), letters AA/BA, editing `A1` dirties far dependent `Z1000` via `changedSince`.
- `/security-review` passed (FFM free-once char* handling, correct `JAVA_INT`/`JAVA_LONG` layouts, bounded recursion on trusted depth-limited engine output, no injection).

Four down (SwiftUI [#5838](https://github.com/adhithyan15/coding-adventures/pull/5838), Qt [#5839](https://github.com/adhithyan15/coding-adventures/pull/5839), Flutter [#5841](https://github.com/adhithyan15/coding-adventures/pull/5841), Compose). XAML last.

🤖 Generated with [Claude Code](https://claude.com/claude-code)