### PR TITLE
feat(visicalc-xaml): viewport primitive over P/Invoke (virtualized infinite sheet)

### DIFF
--- a/demo/visicalc-xaml/Engine.cs
+++ b/demo/visicalc-xaml/Engine.cs
@@ -49,6 +49,15 @@ internal static class ScNative
     internal static extern IntPtr sc_get_raw(IntPtr s,
         [MarshalAs(UnmanagedType.LPUTF8Str)] string a1);
 
+    // Viewport primitive: integer coords (uint32_t) and a u64 revision; JSON
+    // char* results, except sc_current_revision returns the u64 directly.
+    [DllImport("spreadsheet_capi")]
+    internal static extern IntPtr sc_get_window(IntPtr s, uint row0, uint col0, uint row1, uint col1);
+    [DllImport("spreadsheet_capi")] internal static extern IntPtr sc_used_range(IntPtr s);
+    [DllImport("spreadsheet_capi")] internal static extern IntPtr sc_column_letters(IntPtr s, uint index);
+    [DllImport("spreadsheet_capi")] internal static extern ulong sc_current_revision(IntPtr s);
+    [DllImport("spreadsheet_capi")] internal static extern IntPtr sc_changed_since(IntPtr s, ulong since);
+
     [DllImport("spreadsheet_capi")] internal static extern void sc_string_free(IntPtr p);
 
     /// Resolve the vendored engine library: an explicit CAPI_LIB env var, or
@@ -109,33 +118,111 @@ public sealed class SpreadsheetSession : IDisposable
         try
         {
             using var doc = JsonDocument.Parse(json);
-            var root = doc.RootElement;
-            if (!root.TryGetProperty("kind", out var kindEl)) return string.Empty;
-            switch (kindEl.GetString())
-            {
-                case "empty":
-                    return string.Empty;
-                case "number":
-                {
-                    double d = root.GetProperty("value").GetDouble();
-                    // Show integers without a trailing ".0".
-                    return (d == Math.Floor(d) && Math.Abs(d) < 1e15)
-                        ? ((long)d).ToString(System.Globalization.CultureInfo.InvariantCulture)
-                        : d.ToString(System.Globalization.CultureInfo.InvariantCulture);
-                }
-                case "text":
-                    return root.GetProperty("value").GetString() ?? string.Empty;
-                case "boolean":
-                    return root.GetProperty("value").GetBoolean() ? "TRUE" : "FALSE";
-                case "error":
-                    return root.GetProperty("code").GetString() ?? "#ERR";
-                default:
-                    return string.Empty;
-            }
+            return DisplayValue(doc.RootElement);
         }
         catch (Exception ex) when (ex is JsonException or KeyNotFoundException or InvalidOperationException)
         {
             return "#ERR";
+        }
+    }
+
+    // ── Viewport primitive (virtualized infinite sheet) ──────────────
+    // These mirror the engine's get_window / used_range / changed_since reads
+    // (1-based inclusive coords) so a windowed XAML grid (a virtualizing
+    // ItemsRepeater / ListView) can render only the visible rectangle of an
+    // unbounded sheet — the .NET sibling of the web/SwiftUI/Qt/Flutter/Compose
+    // infinite views.
+
+    /// Map one decoded value object (`{"kind":...}`) to its display string.
+    /// Shared by `Display` (one cell) and `Window` (a whole rectangle).
+    private static string DisplayValue(JsonElement obj)
+    {
+        if (!obj.TryGetProperty("kind", out var kindEl)) return string.Empty;
+        switch (kindEl.GetString())
+        {
+            case "empty":
+                return string.Empty;
+            case "number":
+            {
+                double d = obj.GetProperty("value").GetDouble();
+                return (d == Math.Floor(d) && Math.Abs(d) < 1e15)
+                    ? ((long)d).ToString(System.Globalization.CultureInfo.InvariantCulture)
+                    : d.ToString(System.Globalization.CultureInfo.InvariantCulture);
+            }
+            case "text":
+                return obj.GetProperty("value").GetString() ?? string.Empty;
+            case "boolean":
+                return obj.GetProperty("value").GetBoolean() ? "TRUE" : "FALSE";
+            case "error":
+                return obj.GetProperty("code").GetString() ?? "#ERR";
+            default:
+                return string.Empty;
+        }
+    }
+
+    /// Dense display strings for the inclusive 1-based rectangle, row-major
+    /// (empty cells become ""). Empty list on a bad/oversized request.
+    public IReadOnlyList<IReadOnlyList<string>> Window(uint row0, uint col0, uint row1, uint col1)
+    {
+        string json = Take(ScNative.sc_get_window(_handle, row0, col0, row1, col1));
+        var rows = new List<IReadOnlyList<string>>();
+        try
+        {
+            using var doc = JsonDocument.Parse(json);
+            if (!doc.RootElement.TryGetProperty("values", out var values)) return rows;
+            foreach (var rowEl in values.EnumerateArray())
+            {
+                var row = new List<string>();
+                foreach (var cell in rowEl.EnumerateArray()) row.Add(DisplayValue(cell));
+                rows.Add(row);
+            }
+        }
+        catch (Exception ex) when (ex is JsonException or KeyNotFoundException or InvalidOperationException) { /* bad/oversized request → empty */ }
+        return rows;
+    }
+
+    /// The data extent (1-based inclusive), or null if the sheet is empty.
+    public (uint minRow, uint minCol, uint maxRow, uint maxCol)? UsedRange()
+    {
+        string json = Take(ScNative.sc_used_range(_handle));
+        try
+        {
+            using var doc = JsonDocument.Parse(json);
+            var r = doc.RootElement;
+            if (r.ValueKind != JsonValueKind.Object) return null; // "null" → empty sheet
+            return (r.GetProperty("minRow").GetUInt32(), r.GetProperty("minCol").GetUInt32(),
+                    r.GetProperty("maxRow").GetUInt32(), r.GetProperty("maxCol").GetUInt32());
+        }
+        catch (Exception ex) when (ex is JsonException or KeyNotFoundException or InvalidOperationException)
+        {
+            return null;
+        }
+    }
+
+    /// Column letters for a 1-based index (`1` → `"A"`, `27` → `"AA"`).
+    public string ColumnLetters(uint index) => Take(ScNative.sc_column_letters(_handle, index));
+
+    /// The per-edit revision clock. Snapshot it, then pass to ChangedSince.
+    public ulong CurrentRevision() => ScNative.sc_current_revision(_handle);
+
+    /// Cells changed since `since`; `stale` means re-read the whole window.
+    public (IReadOnlyList<string> changed, bool stale) ChangedSince(ulong since)
+    {
+        string json = Take(ScNative.sc_changed_since(_handle, since));
+        try
+        {
+            using var doc = JsonDocument.Parse(json);
+            var r = doc.RootElement;
+            if (r.TryGetProperty("stale", out var st) && st.GetBoolean())
+                return (Array.Empty<string>(), true);
+            var changed = new List<string>();
+            if (r.TryGetProperty("changed", out var arr))
+                foreach (var c in arr.EnumerateArray()) changed.Add(c.GetString() ?? string.Empty);
+            return (changed, false);
+        }
+        catch (Exception ex) when (ex is JsonException or KeyNotFoundException or InvalidOperationException)
+        {
+            return (Array.Empty<string>(), false);
         }
     }
 

--- a/demo/visicalc-xaml/README.md
+++ b/demo/visicalc-xaml/README.md
@@ -118,6 +118,22 @@ block in `MainWindow.xaml.cs` and the `<remarks>` on
 `Generated/Grid_VVm.cs`. The selected/editing cell-background
 highlight (state blocks) is also still React-only in the emitter.
 
+## Infinite virtualized sheet
+
+`SpreadsheetSession` (`Engine.cs`) also binds the engine's **viewport
+primitive** over P/Invoke — `Window(r0,c0,r1,c1)` (a dense
+`IReadOnlyList<IReadOnlyList<string>>` rectangle), `UsedRange()`,
+`ColumnLetters()`, `CurrentRevision()`, and `ChangedSince()` — so a windowed,
+virtualizing WinUI grid (an `ItemsRepeater` / `ListView`) can render only the
+visible rectangle of an unbounded sheet (the .NET sibling of the
+web/SwiftUI/Qt/Flutter/Compose infinite views), parsed with `System.Text.Json`.
+
+Headless proof (cross-platform, runs on macOS/Linux): `scripts/verify.sh` (the
+`test/` console harness) seeds far-flung sparse cells and asserts the window is
+engine-computed + dense (A1=15, E1=38, E5=169), a formula 1000 rows down
+(`Z1000` = 39) is reachable, the gaps are empty (sparse), column letters run
+AA/BA, and editing `A1` dirties the far dependent `Z1000` via `ChangedSince`.
+
 ## Where this fits in the cross-backend demo plan
 
 | Phase | Demo | Status |

--- a/demo/visicalc-xaml/test/Program.cs
+++ b/demo/visicalc-xaml/test/Program.cs
@@ -50,6 +50,43 @@ Contains("A1 div-by-0", model.ValueJson("A1"), "#DIV/0!");
 model.SetCell(0, 2, "=A1+1");              // B1
 Contains("B1 propagated", model.ValueJson("B1"), "#DIV/0!");
 Check("B1 display", model.ViewportRows()[0][2], "#DIV/0!");
+model.Dispose();
+
+// ── Viewport primitive (virtualized infinite sheet) ──────────────
+// A fresh session seeded with the cross-foot budget + a far-flung formula at
+// Z1000 (row 1000, col 26), to exercise the windowed reads.
+using (var s = new SpreadsheetSession())
+{
+    foreach (var (a, v) in new[]
+    {
+        ("A1", "15"), ("B1", "3"), ("C1", "12"), ("D1", "8"), ("E1", "=SUM(A1:D1)"),
+        ("A2", "8"), ("B2", "14"), ("C2", "7"), ("D2", "22"), ("E2", "=SUM(A2:D2)"),
+        ("A3", "12"), ("B3", "9"), ("C3", "18"), ("D3", "6"), ("E3", "=SUM(A3:D3)"),
+        ("A4", "4"), ("B4", "11"), ("C4", "3"), ("D4", "17"), ("E4", "=SUM(A4:D4)"),
+        ("A5", "=SUM(A1:A4)"), ("E5", "=SUM(E1:E4)"), ("Z1000", "=SUM(A1:A4)"),
+    }) s.SetCell(a, v);
+
+    var w = s.Window(1, 1, 5, 5);
+    Check("window A1", w[0][0], "15");
+    Check("window E1", w[0][4], "38");
+    Check("window E5", w[4][4], "169");
+    Check("window Z1000", s.Window(998, 24, 1002, 28)[2][2], "39");
+    Check("window gap empty", s.Window(100, 1, 110, 10)[5][5], "");
+
+    var u = s.UsedRange()!.Value;
+    Check("usedRange maxRow", u.maxRow.ToString(), "1000");
+    Check("usedRange maxCol", u.maxCol.ToString(), "26");
+    Check("columnLetters 27", s.ColumnLetters(27), "AA");
+    Check("columnLetters 53", s.ColumnLetters(53), "BA");
+
+    ulong rev = s.CurrentRevision();
+    s.SetCell("A1", "115");
+    var (changed, stale) = s.ChangedSince(rev);
+    Check("changedSince not stale", stale.ToString(), "False");
+    Contains("changedSince has A1", string.Join(",", changed), "A1");
+    Contains("changedSince reaches Z1000", string.Join(",", changed), "Z1000");
+    Check("window Z1000 after edit", s.Window(1000, 26, 1000, 26)[0][0], "139");
+}
 
 Console.WriteLine(failures == 0 ? "\nALL PASS" : $"\n{failures} FAILURE(S)");
 return failures == 0 ? 0 : 1;


### PR DESCRIPTION
**Fifth and final native backend** on the infinite virtualized sheet. XAML's `SpreadsheetSession` binds the engine's windowed reads over **P/Invoke** (the C ABI's `sc_get_window` / `sc_used_range` / `sc_column_letters` / `sc_current_revision` / `sc_changed_since`) so a windowed, virtualizing WinUI grid (`ItemsRepeater` / `ListView`) can render only the visible rectangle of an unbounded sheet.

## What
- `Engine.cs`: `Window(r0,c0,r1,c1)` → dense `IReadOnlyList<IReadOnlyList<string>>`, `UsedRange()`, `ColumnLetters()`, `CurrentRevision()` → `ulong`, `ChangedSince()`. `uint`/`ulong` P/Invoke args; every returned `IntPtr` routes through the existing `Take()` free-once chokepoint (read **before** `JsonDocument.Parse`). Extracted a `DisplayValue(JsonElement)` shared by `Display()` and `Window()`; the viewport methods' defensive catch filters match `Display()`.
- `test/Program.cs`: the cross-platform console verify gains windowed checks.

## Verification (cross-platform, on macOS)
- **`scripts/verify.sh` ALL PASS**: window engine-computed + dense (A1=15, E1=38, E5=169), a formula 1000 rows down (`Z1000`=39) reachable, gaps empty (sparse), letters AA/BA, editing `A1` dirties far dependent `Z1000` via `ChangedSince`.
- `/security-review` passed (`Take()` free-once, correct `uint`/`ulong` marshalling, parity catch filters, no injection).

## The native virtualization arc is complete

All five native backends now virtualize the infinite sheet over the **same C ABI viewport primitive**: SwiftUI [#5838](https://github.com/adhithyan15/coding-adventures/pull/5838) · Qt [#5839](https://github.com/adhithyan15/coding-adventures/pull/5839) · Flutter [#5841](https://github.com/adhithyan15/coding-adventures/pull/5841) · Compose [#5842](https://github.com/adhithyan15/coding-adventures/pull/5842) · XAML (this) — each with a headless windowed-read proof, alongside the web (WASM) live render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)