### PR TITLE
feat(adj-lang-cli): REL-3 — binding-query recall with citations + IEM end-to-end

### DIFF
--- a/code/packages/rust/adj-lang-cli/CHANGELOG.md
+++ b/code/packages/rust/adj-lang-cli/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [0.6.0] - 2026-06-14 — relational recall: binding-query `"recall"` output (MYCIN-2026 REL-3)
+
+### Added
+
+- **`"recall"` JSON section** for relational recall binding queries. A query goal
+  containing a `$variable` (`? deficient_in(tay_sachs, $Enzyme)`) is routed out of
+  the differential and resolved by SLD enumeration over the grounded knowledge
+  graph; each answer reports its variable **bindings** and the **citations** of
+  the edge(s) that prove it (source/locator/trust). An empty answer set is
+  explicit **abstention** (`"abstained": true`) — no grounded edge supports an
+  answer, so none is fabricated. 0 answer-time model calls.
+- Ground hypothesis queries are unaffected (still flow to the differential
+  `ranked`/`decision`); the `"queries"` echo lists every query (ground + binding).
+
 ## [0.5.0] - 2026-06-12 — `import`-aware compile + the filesystem trust boundary (MYCIN-2026 M3)
 
 ### Added

--- a/code/packages/rust/adj-lang-cli/Cargo.toml
+++ b/code/packages/rust/adj-lang-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adj-lang-cli"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 description = "Command-line driver for the adj-lang adjudication DSL. Reads a .adj program (rulebook clauses + observe/query), compiles it through the adj-lang frontend, runs the logic-engine differential on the CPU, and emits the decision plus a byte-cited proof DAG as JSON. Argument parsing is declarative via cli-builder. Zero answer-time model calls — this is the CPU-bound reasoner that the MYCIN-2026 prototype shells out to."
 

--- a/code/packages/rust/adj-lang-cli/src/main.rs
+++ b/code/packages/rust/adj-lang-cli/src/main.rs
@@ -34,10 +34,10 @@ use adj_constraint_solver::{
     check, optimize, solve, FeasibilityOutcome, OptimizeOutcome, SolveOutcome,
 };
 use adj_lang::{compile_with_imports, decide, ImportLimits, ImportProvider};
-use logic_core::{atom, Term};
+use logic_core::{atom, LogicVar, Term};
 use logic_engine::{
-    DerivationOrigin, DifferentialDecision, Fact, KnowledgeBase, LRAggregateResult, Provenance,
-    TrustTier,
+    enumerate_all, DerivationOrigin, DifferentialDecision, Fact, KnowledgeBase, LRAggregateResult,
+    Provenance, TrustTier,
 };
 
 const SPEC: &str = r#"{
@@ -366,6 +366,25 @@ fn main() -> ExitCode {
         }
     };
 
+    // Partition the queries (MYCIN-2026 REL-3). A query containing a `$variable`
+    // is a RELATIONAL RECALL binding query — resolved by SLD enumeration to a
+    // `"recall"` section (bindings + the citing edge's provenance). A ground
+    // hypothesis query flows to the differential as before. We snapshot all query
+    // strings first (so the `"queries"` echo lists every query), then route the
+    // binding queries out of `lowered.queries` so `decide` only sees hypotheses.
+    let all_query_strs: Vec<String> = lowered
+        .queries
+        .iter()
+        .map(|q| format!("\"{}\"", esc(&format!("{}", q))))
+        .collect();
+    let binding_queries: Vec<Term> = lowered
+        .queries
+        .iter()
+        .filter(|q| contains_var(q))
+        .cloned()
+        .collect();
+    lowered.queries.retain(|q| !contains_var(q));
+
     // ---- Constraint engine FIRST, so its verdict can feed the differential
     // (ADJ constraints E2 — feed-a-verdict). The constraint outcomes are
     // computed up front; each maps to a STATUS atom (`feasible` / `infeasible`
@@ -429,11 +448,22 @@ fn main() -> ExitCode {
         ),
     };
 
-    let queries: Vec<String> = lowered
-        .queries
+    // The `"queries"` echo lists every query the program declared (ground +
+    // binding), captured before the partition above.
+    let queries: Vec<String> = all_query_strs;
+
+    // Relational recall: each binding query resolves to its bindings + the citing
+    // edge's provenance (or abstains with an empty answer set). 0 answer-time
+    // model calls — pure SLD over the grounded knowledge graph.
+    let recall: Vec<String> = binding_queries
         .iter()
-        .map(|q| format!("\"{}\"", esc(&format!("{}", q))))
+        .map(|q| recall_json(q, &lowered.kb))
         .collect();
+    let recall_section = if recall.is_empty() {
+        String::new()
+    } else {
+        format!(",\"recall\":[{}]", recall.join(","))
+    };
 
     // Render the constraint sections from the outcomes computed above (the
     // solvers are not re-run). Absent a constraint system / `check` / objective,
@@ -452,15 +482,87 @@ fn main() -> ExitCode {
     };
 
     println!(
-        "{{\"queries\":[{}],\"ranked\":[{}],\"decision\":{}{}{}{}}}",
+        "{{\"queries\":[{}],\"ranked\":[{}],\"decision\":{}{}{}{}{}}}",
         queries.join(","),
         ranked.join(","),
         decision,
         solve_section,
         check_section,
-        optimize_section
+        optimize_section,
+        recall_section
     );
     ExitCode::SUCCESS
+}
+
+/// True if a query goal contains a logic variable — i.e. it is a relational
+/// recall *binding* query rather than a ground hypothesis query.
+fn contains_var(t: &Term) -> bool {
+    match t {
+        Term::Var(_) => true,
+        Term::Compound { args, .. } => args.iter().any(contains_var),
+        _ => false,
+    }
+}
+
+/// Collect the distinct logic variables of a goal, in first-appearance order, so
+/// each binding can be labelled by the variable's surface name.
+fn collect_vars(t: &Term, out: &mut Vec<LogicVar>) {
+    match t {
+        Term::Var(v) => {
+            if !out.iter().any(|x| x == v) {
+                out.push(v.clone());
+            }
+        }
+        Term::Compound { args, .. } => {
+            for a in args {
+                collect_vars(a, out);
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Resolve a relational recall binding query against the grounded knowledge graph
+/// and render it as JSON: every answer (the variable bindings) plus the citing
+/// edge's provenance — the proof. An empty answer set is honest **abstention**
+/// (`"abstained": true`): no grounded edge supports an answer, so none is
+/// fabricated. 0 answer-time model calls — pure SLD over the CAS-grounded facts.
+fn recall_json(query: &Term, kb: &KnowledgeBase) -> String {
+    let dag = enumerate_all(query, kb);
+    let mut vars: Vec<LogicVar> = Vec::new();
+    collect_vars(query, &mut vars);
+    let mut answers: Vec<String> = Vec::new();
+    for proof in &dag.proofs {
+        let binds: Vec<String> = vars
+            .iter()
+            .map(|v| {
+                let name = v.display_name.clone().unwrap_or_default();
+                format!(
+                    "\"{}\":\"{}\"",
+                    esc(&name),
+                    esc(&format!("{}", proof.bindings.walk_var(v)))
+                )
+            })
+            .collect();
+        // The citing edge(s): each fact this proof relied on, with its provenance.
+        let cites: Vec<String> = proof
+            .via_facts
+            .iter()
+            .filter_map(|fid| kb.fact(*fid))
+            .map(|f| format!("{{{}}}", prov(&f.provenance)))
+            .collect();
+        answers.push(format!(
+            "{{\"bindings\":{{{}}},\"citations\":[{}]}}",
+            binds.join(","),
+            cites.join(",")
+        ));
+    }
+    format!(
+        "{{\"query\":\"{}\",\"answers\":[{}],\"abstained\":{}}}",
+        esc(&format!("{}", query)),
+        answers.join(","),
+        dag.proofs.is_empty()
+    )
 }
 
 /// Render a [`SolveOutcome`] as JSON. A solved system lists each unknown's

--- a/code/packages/rust/adj-lang-cli/tests/recall_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/recall_e2e.rs
@@ -1,0 +1,101 @@
+//! End-to-end tests for relational recall (MYCIN-2026 REL-3) through the built
+//! CLI binary: a `relate`-edge knowledge graph + a `$variable` binding query
+//! resolves to a `"recall"` section carrying the bindings AND the citing edge's
+//! provenance, with 0 answer-time model calls. Abstention (no grounded edge) is
+//! an explicit empty answer set, not a fabricated value.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_recall_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn write(dir: &PathBuf, name: &str, src: &str) {
+    std::fs::write(dir.join(name), src).unwrap();
+}
+
+fn run(program: &PathBuf) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+#[test]
+fn forward_recall_binds_the_enzyme_with_a_citation() {
+    let dir = scratch("forward");
+    write(
+        &dir,
+        "case.adj",
+        "relate deficient_in(tay_sachs, hexosaminidase_a)\n\
+             source \"Tay-Sachs results from deficient hexosaminidase A.\"\n\
+             trust authoritative\n\
+         relate deficient_in(gaucher, glucocerebrosidase) trust authoritative\n\
+         ? deficient_in(tay_sachs, $Enzyme)\n",
+    );
+    let (ok, out) = run(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}");
+    assert!(out.contains("\"recall\""), "has a recall section: {out}");
+    assert!(
+        out.contains("\"Enzyme\":\"hexosaminidase_a\""),
+        "binds the enzyme: {out}"
+    );
+    // The answer carries its proof — the citing edge's source.
+    assert!(
+        out.contains("deficient hexosaminidase A"),
+        "carries the citation: {out}"
+    );
+    assert!(
+        out.contains("\"abstained\":false"),
+        "not an abstention: {out}"
+    );
+}
+
+#[test]
+fn recall_abstains_on_an_ungrounded_disease() {
+    let dir = scratch("abstain");
+    write(
+        &dir,
+        "case.adj",
+        "relate deficient_in(tay_sachs, hexosaminidase_a) trust authoritative\n\
+         ? deficient_in(niemann_pick, $Enzyme)\n",
+    );
+    let (ok, out) = run(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}");
+    // No grounded edge → empty answers → explicit abstention, no fabricated enzyme.
+    assert!(out.contains("\"abstained\":true"), "must abstain: {out}");
+    assert!(
+        out.contains("\"answers\":[]"),
+        "no fabricated answer: {out}"
+    );
+}
+
+#[test]
+fn binding_query_under_a_dictionary_use_scope_is_accepted() {
+    // A relation-typed query inside a `use`d vocabulary must not be rejected as a
+    // non-hypothesis (REL-3 enforce_vocabulary fix).
+    let dir = scratch("scoped");
+    write(
+        &dir,
+        "case.adj",
+        "dictionary bio {\n\
+             define disease : entity\n\
+             define enzyme : entity\n\
+             define deficient_in : relation from disease to enzyme\n\
+         }\n\
+         use bio\n\
+         relate deficient_in(tay_sachs, hexosaminidase_a) trust authoritative\n\
+         ? deficient_in(tay_sachs, $Enzyme)\n",
+    );
+    let (ok, out) = run(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed (no UndefinedTerm): {out}");
+    assert!(
+        out.contains("\"Enzyme\":\"hexosaminidase_a\""),
+        "binds under use-scope: {out}"
+    );
+}

--- a/code/packages/rust/adj-lang/CHANGELOG.md
+++ b/code/packages/rust/adj-lang/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [0.13.0] - 2026-06-14 — relational queries pass vocabulary enforcement (MYCIN-2026 REL-3)
+
+### Changed
+
+- **`enforce_vocabulary` accepts a binding query over a defined `relation`.** A
+  query whose functor is a `define`d relation (`? deficient_in(tay_sachs, $E)`) is
+  now valid under a `use`d vocabulary, alongside the existing hypothesis queries —
+  relational recall is the single-hop special case of the differential, so the
+  vocabulary check accepts either. Previously a relational query inside a `use`
+  scope was wrongly rejected as a non-hypothesis (`UndefinedTerm`).
+
 ## [0.12.0] - 2026-06-14 — relational recall: `relate` edges + binding queries (MYCIN-2026 REL-2)
 
 ### Added

--- a/code/packages/rust/adj-lang/Cargo.toml
+++ b/code/packages/rust/adj-lang/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adj-lang"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 description = "Surface-syntax frontend for the adjudication framework's probabilistic-logic rulebooks. Lexes, parses, and lowers a domain-expert-readable DSL into a `logic-engine` KnowledgeBase. Dissolves ADJ46 awkwardness items A10 (rulebook syntax) and A4 (joint contributions syntactically distinct)."
 

--- a/code/packages/rust/adj-lang/src/lower.rs
+++ b/code/packages/rust/adj-lang/src/lower.rs
@@ -507,10 +507,23 @@ fn enforce_vocabulary<'a>(
         }
     };
 
+    // A query is valid if it names a defined HYPOTHESIS (the differential query)
+    // OR a defined RELATION (a binding query, `? deficient_in(tay_sachs, $E)`).
+    // Relational recall is the single-hop special case of the differential, so the
+    // vocabulary check accepts either rather than forcing every query to be a
+    // hypothesis.
+    let check_query = |t: &AstTerm| -> Result<(), LowerError> {
+        let (functor, _) = term_functor_value(t);
+        match dict.get(functor) {
+            Some(DefineKind::Relation { .. }) => Ok(()),
+            _ => check_hypothesis(t),
+        }
+    };
+
     for stmt in statements {
         match stmt {
             Statement::Prior { conclusion, .. } => check_hypothesis(conclusion)?,
-            Statement::Query { conclusion } => check_hypothesis(conclusion)?,
+            Statement::Query { conclusion } => check_query(conclusion)?,
             Statement::Contributes {
                 evidence,
                 conclusion,

--- a/code/packages/rust/logic-engine/CHANGELOG.md
+++ b/code/packages/rust/logic-engine/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.16.0] - 2026-06-14 — `KnowledgeBase::fact(id)` accessor (MYCIN-2026 REL-3)
+
+### Added
+
+- **`KnowledgeBase::fact(&self, id: FactId) -> Option<&Fact>`** — resolve a
+  proof's `via_facts` (or a `DerivationOrigin::FromFact`) back to the firing fact,
+  in particular its `provenance`, so a relational recall binding query's answer
+  can be returned WITH the citing edge's source.
+
 ## [0.15.0] - 2026-06-14 — mandatory `Fact::provenance` for relational edges (MYCIN-2026 REL-2)
 
 ### Added / Changed (breaking)

--- a/code/packages/rust/logic-engine/Cargo.toml
+++ b/code/packages/rust/logic-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "logic-engine"
-version = "0.15.0"
+version = "0.16.0"
 edition = "2021"
 description = "Probability-aware facts, rules, KB, SLD find-first/enumerate + WMC posterior + LP19e likelihood-ratio Bayesian aggregation."
 

--- a/code/packages/rust/logic-engine/src/lib.rs
+++ b/code/packages/rust/logic-engine/src/lib.rs
@@ -347,6 +347,15 @@ impl KnowledgeBase {
         id
     }
 
+    /// Look up a Fact by its `FactId`. Used to resolve a proof's `via_facts` (or
+    /// a `DerivationOrigin::FromFact`) back to the firing fact — in particular its
+    /// [`Fact::provenance`], so a binding query's answer can be returned WITH the
+    /// citing edge's source. Facts are bucketed by clause index, so this scans the
+    /// (small) fact store; callers needing it in a hot loop should cache.
+    pub fn fact(&self, id: FactId) -> Option<&Fact> {
+        self.facts.values().flatten().find(|f| f.id == id)
+    }
+
     /// Insert a Rule, assigning it a fresh `RuleId`.
     pub fn add_rule(&mut self, mut rule: Rule) -> RuleId {
         let id = RuleId(self.next_rule_id);

--- a/code/specs/data/mycin-2026/recall/README.md
+++ b/code/specs/data/mycin-2026/recall/README.md
@@ -27,9 +27,19 @@ python3 test_recall.py   # 7 tests, all deterministic
 
 ## Status & what's next
 
-REL-1 proves the **semantics** in Python before touching the Rust grammar/engine.
-Staged next: REL-2 (grammar: `entity`/`relation` dictionary kinds, the `relate` clause, the
-`$`-variable token, binding queries) → REL-3 (engine: SLD resolver + native CLI) → REL-4
-(spider-ground the IEM edges, retiring the authored-debt) → REL-5 (board-eval harness scoring
-recall + differential with an abstention metric). Every edge enters the CAS only through the
-grounding pipeline — nothing is human-authored in the end state.
+REL-1 proves the **semantics** in Python. **REL-2 + REL-3 make it native:** the adj-lang
+grammar now has the `relate` clause, `$`-variable binding queries, and `entity`/`relation`
+dictionary kinds; the `adj-lang-cli` resolves a binding query to a `"recall"` JSON section
+(bindings + the citing edge's provenance, or honest abstention). Run the native end-to-end with:
+
+```sh
+# from code/packages/rust:  the IEM graph + binding queries, answered with citations
+target/debug/adj-lang-cli ../../specs/data/mycin-2026/recall/iem-recall-case.adj
+```
+
+`iem-recall-case.adj` imports `iem-edges.adj` and asks `? deficient_in(tay_sachs, $Enzyme)` —
+the engine binds `hexosaminidase_a` with its citation, 0 answer-time model calls.
+
+Staged next: **REL-4** (spider-ground the IEM edges, retiring the authored-debt) → **REL-5**
+(board-eval harness scoring recall + differential with an abstention metric). Every edge enters
+the CAS only through the grounding pipeline — nothing is human-authored in the end state.

--- a/code/specs/data/mycin-2026/recall/iem-recall-case.adj
+++ b/code/specs/data/mycin-2026/recall/iem-recall-case.adj
@@ -1,0 +1,30 @@
+% ============================================================================
+% iem-recall-case — relational recall, end-to-end through the adj-lang engine.
+% ============================================================================
+% MYCIN-2026 REL-3. The native counterpart of the REL-1 Python prototype: this
+% imports the grounded inborn-errors-of-metabolism knowledge graph and asks, as
+% a BINDING QUERY, "which enzyme is deficient in Tay-Sachs?".
+%
+%   adj_lang_cli iem-recall-case.adj
+%     → {"recall":[{"query":"deficient_in(tay_sachs, Enzyme)",
+%                   "answers":[{"bindings":{"Enzyme":"hexosaminidase_a"},
+%                               "citations":[{"source":"...","trust":"consensus"}]}],
+%                   "abstained":false}], ...}
+%
+% Fact recall as the single-hop special case of the differential — answered on
+% the CPU with 0 answer-time model calls, every answer carrying its citing edge
+% as a proof. Ask about an ungrounded disease and the engine abstains (empty
+% answers, "abstained": true) rather than fabricating an enzyme.
+% ============================================================================
+
+import "iem-edges.adj"
+
+% Forward recall — bind the deficient enzyme.
+? deficient_in(tay_sachs, $Enzyme)
+
+% The full edge star for one disease (enzyme / accumulated substrate / inheritance).
+? accumulates(tay_sachs, $Substrate)
+? inherited_as(tay_sachs, $Pattern)
+
+% Reverse lookup is free — which disease lacks this enzyme?
+? deficient_in($Disease, hexosaminidase_a)


### PR DESCRIPTION
## What

Wires **relational recall through the native engine + CLI** (REL-1 spec → REL-2 grammar → **REL-3 the runnable pipeline**). A `$variable` binding query now resolves to a `"recall"` JSON section carrying the variable bindings **and the citing edge's provenance** — fact recall answered on the CPU with **0 answer-time model calls**, every answer proven by the grounded edge that justifies it.

Real run (`adj-lang-cli recall/iem-recall-case.adj`):
```json
"recall": [{
  "query": "deficient_in(tay_sachs, Enzyme)",
  "answers": [{
    "bindings": { "Enzyme": "hexosaminidase_a" },
    "citations": [{ "source": "Tay-Sachs disease results from deficiency of the enzyme hexosaminidase A (HEXA).", "trust": "consensus" }]
  }],
  "abstained": false
}]
```

## Changes

**adj-lang-cli (0.5.0 → 0.6.0)** — binding queries (goals with a `$variable`) are routed out of the differential and resolved by SLD enumeration (`enumerate_all`) over the grounded KB. New `"recall"` section: per query, the answers (bindings + `citations`: source/locator/trust) or honest **abstention** (`"abstained": true`, empty answers — no grounded edge → no fabricated value). Ground hypothesis queries unchanged; the `"queries"` echo lists every query.

**logic-engine (0.15.0 → 0.16.0)** — `KnowledgeBase::fact(id)` accessor, to resolve a proof's `via_facts` back to the firing fact's provenance so the CLI can cite the edge that answered.

**adj-lang (0.12.0 → 0.13.0)** — `enforce_vocabulary` accepts a binding query over a defined `relation` (not just a hypothesis), so a relational query inside a `use`d vocabulary is valid rather than rejected as `UndefinedTerm`.

## End-to-end

`recall/iem-recall-case.adj` imports the IEM edge graph and asks `? deficient_in(tay_sachs, $Enzyme)` → binds `hexosaminidase_a` **with its citation** (plus accumulated substrate, inheritance, and the free reverse lookup).

## Verification

- **logic-engine 124, adj-lang 64, adj-lang-cli 47 (3 new `recall_e2e` tests), adj-constraint-solver 56** — all pass.
- New CLI tests: forward recall with citation, **abstention on an ungrounded disease**, binding query under a dictionary `use` scope.
- `cargo fmt --check` clean on my additions (reverted unrelated fmt churn per repo lesson).
- `/security-review` **PASSED** — every attacker-influenced string (binding names/values, provenance fields) flows through the JSON escaper; no panics/injection/DoS.

## Scope

This is the runnable native pipeline. **REL-4** spider-grounds the IEM edges (retiring the authored-debt); **REL-5** is the board-eval harness with the abstention metric.

🤖 Generated with [Claude Code](https://claude.com/claude-code)