### PR TITLE
[codex] Add Z-Wave request tracker supervisor summary

### DIFF
--- a/code/packages/rust/zwave-serial-api/CHANGELOG.md
+++ b/code/packages/rust/zwave-serial-api/CHANGELOG.md
@@ -21,6 +21,8 @@ All notable changes to this package will be documented in this file.
   readiness over request-loop and drain completion checks.
 - `RequestTrackerOperatorSummary` for final host-controller operator checks
   over request dispatch readiness and drain completion gates.
+- `RequestTrackerSupervisorSummary` for final supervised host-controller
+  checks over request operator readiness and drain completion gates.
 
 ## [0.1.0] - 2026-05-06
 

--- a/code/packages/rust/zwave-serial-api/README.md
+++ b/code/packages/rust/zwave-serial-api/README.md
@@ -34,6 +34,8 @@ control-plane layer:
   payload-free controller dispatch readiness view
 - request tracker operator summaries that turn dispatch readiness into final
   host-controller operator checks
+- request tracker supervisor summaries that turn operator readiness into final
+  supervised host-controller checks
 
 It does not yet open a serial port, interview nodes, handle inclusion, or decode
 command-class payload semantics.

--- a/code/packages/rust/zwave-serial-api/src/lib.rs
+++ b/code/packages/rust/zwave-serial-api/src/lib.rs
@@ -1062,6 +1062,117 @@ pub fn summarize_request_tracker_operator(
     RequestTrackerOperatorSummary::from_tracker(tracker)
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RequestTrackerSupervisorSummary {
+    pub operator_summary: RequestTrackerOperatorSummary,
+    pub required_supervisor_check_count: usize,
+    pub passed_supervisor_check_count: usize,
+    pub blocked_supervisor_check_count: usize,
+    pub request_operator_ready: bool,
+    pub request_dispatch_ready: bool,
+    pub request_drain_ready: bool,
+    pub request_loop_ready: bool,
+    pub callback_drain_complete: bool,
+    pub response_drain_complete: bool,
+    pub timeout_drain_complete: bool,
+    pub pending_function_drain_complete: bool,
+    pub request_supervisor_ready: bool,
+}
+
+impl RequestTrackerSupervisorSummary {
+    pub fn from_tracker(tracker: &RequestTracker) -> Self {
+        Self::from_operator_summary(summarize_request_tracker_operator(tracker))
+    }
+
+    pub fn from_operator_summary(operator_summary: RequestTrackerOperatorSummary) -> Self {
+        let request_operator_ready = operator_summary.is_request_operator_ready();
+        let request_dispatch_ready = !operator_summary.needs_request_dispatch();
+        let request_drain_ready = !operator_summary.needs_request_drain();
+        let request_loop_ready = !operator_summary.needs_request_loop_readiness();
+        let callback_drain_complete = !operator_summary.needs_callback_drain();
+        let response_drain_complete = !operator_summary.needs_response_drain();
+        let timeout_drain_complete = !operator_summary.needs_timeout_drain();
+        let pending_function_drain_complete = !operator_summary.needs_pending_function_drain();
+        let checks = [
+            request_operator_ready,
+            request_dispatch_ready,
+            request_drain_ready,
+            request_loop_ready,
+            callback_drain_complete,
+            response_drain_complete,
+            timeout_drain_complete,
+            pending_function_drain_complete,
+        ];
+        let passed_supervisor_check_count = checks.iter().filter(|ready| **ready).count();
+        let required_supervisor_check_count = checks.len();
+        let blocked_supervisor_check_count =
+            required_supervisor_check_count - passed_supervisor_check_count;
+        let request_supervisor_ready = blocked_supervisor_check_count == 0;
+
+        Self {
+            operator_summary,
+            required_supervisor_check_count,
+            passed_supervisor_check_count,
+            blocked_supervisor_check_count,
+            request_operator_ready,
+            request_dispatch_ready,
+            request_drain_ready,
+            request_loop_ready,
+            callback_drain_complete,
+            response_drain_complete,
+            timeout_drain_complete,
+            pending_function_drain_complete,
+            request_supervisor_ready,
+        }
+    }
+
+    pub fn is_request_supervisor_ready(&self) -> bool {
+        self.request_supervisor_ready
+    }
+
+    pub fn has_blocked_supervisor_checks(&self) -> bool {
+        self.blocked_supervisor_check_count > 0
+    }
+
+    pub fn needs_request_operator(&self) -> bool {
+        !self.request_operator_ready
+    }
+
+    pub fn needs_request_dispatch(&self) -> bool {
+        !self.request_dispatch_ready
+    }
+
+    pub fn needs_request_drain(&self) -> bool {
+        !self.request_drain_ready
+    }
+
+    pub fn needs_request_loop_readiness(&self) -> bool {
+        !self.request_loop_ready
+    }
+
+    pub fn needs_callback_drain(&self) -> bool {
+        !self.callback_drain_complete
+    }
+
+    pub fn needs_response_drain(&self) -> bool {
+        !self.response_drain_complete
+    }
+
+    pub fn needs_timeout_drain(&self) -> bool {
+        !self.timeout_drain_complete
+    }
+
+    pub fn needs_pending_function_drain(&self) -> bool {
+        !self.pending_function_drain_complete
+    }
+}
+
+pub fn summarize_request_tracker_supervisor(
+    tracker: &RequestTracker,
+) -> RequestTrackerSupervisorSummary {
+    RequestTrackerSupervisorSummary::from_tracker(tracker)
+}
+
 #[derive(Debug, Clone, Default)]
 pub struct RequestTracker {
     pending: BTreeMap<RequestKey, PendingRequest>,
@@ -2055,6 +2166,81 @@ mod tests {
         assert!(!summary.request_operator_ready);
         assert!(!summary.is_request_operator_ready());
         assert!(summary.has_blocked_operator_checks());
+        assert!(summary.needs_request_dispatch());
+        assert!(summary.needs_request_drain());
+        assert!(summary.needs_request_loop_readiness());
+        assert!(summary.needs_callback_drain());
+        assert!(summary.needs_response_drain());
+        assert!(summary.needs_timeout_drain());
+        assert!(summary.needs_pending_function_drain());
+    }
+
+    #[test]
+    fn request_tracker_supervisor_summary_marks_idle_tracker_ready() {
+        let tracker = RequestTracker::new();
+
+        let summary = summarize_request_tracker_supervisor(&tracker);
+
+        assert_eq!(
+            summary.operator_summary,
+            summarize_request_tracker_operator(&tracker)
+        );
+        assert_eq!(summary.required_supervisor_check_count, 8);
+        assert_eq!(summary.passed_supervisor_check_count, 8);
+        assert_eq!(summary.blocked_supervisor_check_count, 0);
+        assert!(summary.request_operator_ready);
+        assert!(summary.request_dispatch_ready);
+        assert!(summary.request_drain_ready);
+        assert!(summary.request_loop_ready);
+        assert!(summary.callback_drain_complete);
+        assert!(summary.response_drain_complete);
+        assert!(summary.timeout_drain_complete);
+        assert!(summary.pending_function_drain_complete);
+        assert!(summary.request_supervisor_ready);
+        assert!(summary.is_request_supervisor_ready());
+        assert!(!summary.has_blocked_supervisor_checks());
+        assert!(!summary.needs_request_operator());
+        assert!(!summary.needs_request_dispatch());
+        assert!(!summary.needs_request_drain());
+        assert!(!summary.needs_request_loop_readiness());
+        assert!(!summary.needs_callback_drain());
+        assert!(!summary.needs_response_drain());
+        assert!(!summary.needs_timeout_drain());
+        assert!(!summary.needs_pending_function_drain());
+    }
+
+    #[test]
+    fn request_tracker_supervisor_summary_routes_pending_waits() {
+        let version = SerialMessage::request(FunctionId::GET_VERSION, Vec::new());
+        let send_data = SendDataRequest::new(
+            NodeId::Classic(2),
+            CommandClassFrame::new(CommandClassId::SWITCH_BINARY, 0x01, vec![0xff]),
+            TransmitOptions::reliable(),
+            0x44,
+        )
+        .to_message()
+        .unwrap();
+        let mut tracker = RequestTracker::new();
+        tracker.track(&version, 100, 500).unwrap();
+        tracker.track(&send_data, 120, 200).unwrap();
+
+        let summary = RequestTrackerSupervisorSummary::from_tracker(&tracker);
+
+        assert_eq!(summary.required_supervisor_check_count, 8);
+        assert_eq!(summary.passed_supervisor_check_count, 0);
+        assert_eq!(summary.blocked_supervisor_check_count, 8);
+        assert!(!summary.request_operator_ready);
+        assert!(!summary.request_dispatch_ready);
+        assert!(!summary.request_drain_ready);
+        assert!(!summary.request_loop_ready);
+        assert!(!summary.callback_drain_complete);
+        assert!(!summary.response_drain_complete);
+        assert!(!summary.timeout_drain_complete);
+        assert!(!summary.pending_function_drain_complete);
+        assert!(!summary.request_supervisor_ready);
+        assert!(!summary.is_request_supervisor_ready());
+        assert!(summary.has_blocked_supervisor_checks());
+        assert!(summary.needs_request_operator());
         assert!(summary.needs_request_dispatch());
         assert!(summary.needs_request_drain());
         assert!(summary.needs_request_loop_readiness());


### PR DESCRIPTION
## Summary

- add `RequestTrackerSupervisorSummary` over request operator readiness
- expose the `summarize_request_tracker_supervisor` helper and blocked-gate predicates
- document the new Z-Wave request tracker supervisor summary

## Validation

- `cargo fmt --manifest-path code\packages\rust\zwave-serial-api\Cargo.toml`
- `cargo test --manifest-path code\packages\rust\zwave-serial-api\Cargo.toml`
- `git diff --check -- code\packages\rust\zwave-serial-api\src\lib.rs code\packages\rust\zwave-serial-api\README.md code\packages\rust\zwave-serial-api\CHANGELOG.md`