### PR TITLE
[codex] Add Hue archive verification summary

### DIFF
--- a/code/packages/rust/hue-core/CHANGELOG.md
+++ b/code/packages/rust/hue-core/CHANGELOG.md
@@ -69,6 +69,8 @@ All notable changes to this package will be documented in this file.
   readiness into final archive completion checks.
 - Hue package release archive publication summaries that turn archive completion
   readiness into final archive publication checks.
+- Hue package release archive verification summaries that turn archive
+  publication readiness into final archive verification checks.
 - Hue discovery worker-run projection from generic `MdnsScanResult` envelopes,
   preserving scan parse failures as per-source D23 worker failures.
 - Hue discovery worker-run projection from aggregate `MdnsWorkerScanReport`

--- a/code/packages/rust/hue-core/README.md
+++ b/code/packages/rust/hue-core/README.md
@@ -109,6 +109,8 @@ packages a typed surface for:
   readiness into final archive completion checks
 - Hue package release archive publication summaries that turn archive completion
   readiness into final archive publication checks
+- Hue package release archive verification summaries that turn archive
+  publication readiness into final archive verification checks
 
 ## Dependencies
 

--- a/code/packages/rust/hue-core/src/lib.rs
+++ b/code/packages/rust/hue-core/src/lib.rs
@@ -4171,6 +4171,185 @@ pub fn hue_package_release_archive_publication_summary(
     HuePackageReleaseArchivePublicationSummary::from_pairing_plan(plan)
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct HuePackageReleaseArchiveVerificationSummary {
+    pub archive_publication_summary: HuePackageReleaseArchivePublicationSummary,
+    pub required_archive_verification_check_count: usize,
+    pub passed_archive_verification_check_count: usize,
+    pub blocked_archive_verification_check_count: usize,
+    pub release_archive_publication_ready: bool,
+    pub release_archive_completion_ready: bool,
+    pub release_archive_supervisor_ready: bool,
+    pub release_archive_operator_ready: bool,
+    pub release_archive_dispatch_ready: bool,
+    pub release_archive_handoff_ready: bool,
+    pub release_archive_closure_ready: bool,
+    pub release_archive_signoff_ready: bool,
+    pub release_archive_ready: bool,
+    pub release_closure_ready: bool,
+    pub release_signoff_ready: bool,
+    pub release_audit_ready: bool,
+    pub operator_ready: bool,
+    pub coordination_ready: bool,
+    pub publish_gate_ready: bool,
+    pub release_archive_verification_ready: bool,
+}
+
+impl HuePackageReleaseArchiveVerificationSummary {
+    pub fn from_pairing_plan(plan: &HueBridgePairingPlan) -> Self {
+        Self::from_archive_publication_summary(hue_package_release_archive_publication_summary(
+            plan,
+        ))
+    }
+
+    pub fn from_archive_publication_summary(
+        archive_publication_summary: HuePackageReleaseArchivePublicationSummary,
+    ) -> Self {
+        let release_archive_publication_ready =
+            archive_publication_summary.is_release_archive_publication_ready();
+        let release_archive_completion_ready =
+            !archive_publication_summary.needs_release_archive_completion();
+        let release_archive_supervisor_ready =
+            !archive_publication_summary.needs_release_archive_supervisor();
+        let release_archive_operator_ready =
+            !archive_publication_summary.needs_release_archive_operator();
+        let release_archive_dispatch_ready =
+            !archive_publication_summary.needs_release_archive_dispatch();
+        let release_archive_handoff_ready =
+            !archive_publication_summary.needs_release_archive_handoff();
+        let release_archive_closure_ready =
+            !archive_publication_summary.needs_release_archive_closure();
+        let release_archive_signoff_ready =
+            !archive_publication_summary.needs_release_archive_signoff();
+        let release_archive_ready = !archive_publication_summary.needs_release_archive();
+        let release_closure_ready = !archive_publication_summary.needs_release_closure();
+        let release_signoff_ready = !archive_publication_summary.needs_release_signoff();
+        let release_audit_ready = !archive_publication_summary.needs_release_audit();
+        let operator_ready = !archive_publication_summary.needs_operator_readiness();
+        let coordination_ready = !archive_publication_summary.needs_coordination();
+        let publish_gate_ready = !archive_publication_summary.needs_publish_gate();
+        let checks = [
+            release_archive_publication_ready,
+            release_archive_completion_ready,
+            release_archive_supervisor_ready,
+            release_archive_operator_ready,
+            release_archive_dispatch_ready,
+            release_archive_handoff_ready,
+            release_archive_closure_ready,
+            release_archive_signoff_ready,
+            release_archive_ready,
+            release_closure_ready,
+            release_signoff_ready,
+            release_audit_ready,
+            operator_ready,
+            coordination_ready,
+            publish_gate_ready,
+        ];
+        let passed_archive_verification_check_count = checks.iter().filter(|ready| **ready).count();
+        let required_archive_verification_check_count = checks.len();
+        let blocked_archive_verification_check_count =
+            required_archive_verification_check_count - passed_archive_verification_check_count;
+        let release_archive_verification_ready = blocked_archive_verification_check_count == 0;
+
+        Self {
+            archive_publication_summary,
+            required_archive_verification_check_count,
+            passed_archive_verification_check_count,
+            blocked_archive_verification_check_count,
+            release_archive_publication_ready,
+            release_archive_completion_ready,
+            release_archive_supervisor_ready,
+            release_archive_operator_ready,
+            release_archive_dispatch_ready,
+            release_archive_handoff_ready,
+            release_archive_closure_ready,
+            release_archive_signoff_ready,
+            release_archive_ready,
+            release_closure_ready,
+            release_signoff_ready,
+            release_audit_ready,
+            operator_ready,
+            coordination_ready,
+            publish_gate_ready,
+            release_archive_verification_ready,
+        }
+    }
+
+    pub fn is_release_archive_verification_ready(self) -> bool {
+        self.release_archive_verification_ready
+    }
+
+    pub fn has_blocked_archive_verification_checks(self) -> bool {
+        self.blocked_archive_verification_check_count > 0
+    }
+
+    pub fn needs_release_archive_publication(self) -> bool {
+        !self.release_archive_publication_ready
+    }
+
+    pub fn needs_release_archive_completion(self) -> bool {
+        !self.release_archive_completion_ready
+    }
+
+    pub fn needs_release_archive_supervisor(self) -> bool {
+        !self.release_archive_supervisor_ready
+    }
+
+    pub fn needs_release_archive_operator(self) -> bool {
+        !self.release_archive_operator_ready
+    }
+
+    pub fn needs_release_archive_dispatch(self) -> bool {
+        !self.release_archive_dispatch_ready
+    }
+
+    pub fn needs_release_archive_handoff(self) -> bool {
+        !self.release_archive_handoff_ready
+    }
+
+    pub fn needs_release_archive_closure(self) -> bool {
+        !self.release_archive_closure_ready
+    }
+
+    pub fn needs_release_archive_signoff(self) -> bool {
+        !self.release_archive_signoff_ready
+    }
+
+    pub fn needs_release_archive(self) -> bool {
+        !self.release_archive_ready
+    }
+
+    pub fn needs_release_closure(self) -> bool {
+        !self.release_closure_ready
+    }
+
+    pub fn needs_release_signoff(self) -> bool {
+        !self.release_signoff_ready
+    }
+
+    pub fn needs_release_audit(self) -> bool {
+        !self.release_audit_ready
+    }
+
+    pub fn needs_operator_readiness(self) -> bool {
+        !self.operator_ready
+    }
+
+    pub fn needs_coordination(self) -> bool {
+        !self.coordination_ready
+    }
+
+    pub fn needs_publish_gate(self) -> bool {
+        !self.publish_gate_ready
+    }
+}
+
+pub fn hue_package_release_archive_verification_summary(
+    plan: &HueBridgePairingPlan,
+) -> HuePackageReleaseArchiveVerificationSummary {
+    HuePackageReleaseArchiveVerificationSummary::from_pairing_plan(plan)
+}
+
 fn descriptor_declares_capability(descriptor: &IntegrationDescriptor, capability_id: &str) -> bool {
     descriptor
         .capabilities
@@ -9388,6 +9567,121 @@ mod tests {
         assert!(!summary.release_archive_publication_ready);
         assert!(!summary.is_release_archive_publication_ready());
         assert!(summary.has_blocked_archive_publication_checks());
+        assert!(summary.needs_release_archive_completion());
+        assert!(summary.needs_release_archive_supervisor());
+        assert!(summary.needs_release_archive_operator());
+        assert!(summary.needs_release_archive_dispatch());
+        assert!(summary.needs_release_archive_handoff());
+        assert!(summary.needs_release_archive_closure());
+        assert!(summary.needs_release_archive_signoff());
+        assert!(summary.needs_release_archive());
+        assert!(summary.needs_release_closure());
+        assert!(summary.needs_release_signoff());
+        assert!(summary.needs_release_audit());
+        assert!(summary.needs_operator_readiness());
+        assert!(summary.needs_coordination());
+        assert!(summary.needs_publish_gate());
+    }
+
+    #[test]
+    fn hue_package_release_archive_verification_summary_reports_ready_archive_verification() {
+        let plan = hue_pairing_plan_for_discovered_bridge(
+            DiscoveredHueBridge {
+                bridge_id: "001788fffeabcdef".to_string(),
+                address: "https://192.0.2.10".to_string(),
+                hardware_model: Some("BSB002".to_string()),
+                firmware_version: Some("1.60".to_string()),
+            },
+            "chief-of-staff",
+            "desk",
+        );
+
+        let summary = hue_package_release_archive_verification_summary(&plan);
+
+        assert_eq!(
+            summary.archive_publication_summary,
+            hue_package_release_archive_publication_summary(&plan)
+        );
+        assert_eq!(summary.required_archive_verification_check_count, 15);
+        assert_eq!(summary.passed_archive_verification_check_count, 15);
+        assert_eq!(summary.blocked_archive_verification_check_count, 0);
+        assert!(summary.release_archive_publication_ready);
+        assert!(summary.release_archive_completion_ready);
+        assert!(summary.release_archive_supervisor_ready);
+        assert!(summary.release_archive_operator_ready);
+        assert!(summary.release_archive_dispatch_ready);
+        assert!(summary.release_archive_handoff_ready);
+        assert!(summary.release_archive_closure_ready);
+        assert!(summary.release_archive_signoff_ready);
+        assert!(summary.release_archive_ready);
+        assert!(summary.release_closure_ready);
+        assert!(summary.release_signoff_ready);
+        assert!(summary.release_audit_ready);
+        assert!(summary.operator_ready);
+        assert!(summary.coordination_ready);
+        assert!(summary.publish_gate_ready);
+        assert!(summary.release_archive_verification_ready);
+        assert!(summary.is_release_archive_verification_ready());
+        assert!(!summary.has_blocked_archive_verification_checks());
+        assert!(!summary.needs_release_archive_publication());
+        assert!(!summary.needs_release_archive_completion());
+        assert!(!summary.needs_release_archive_supervisor());
+        assert!(!summary.needs_release_archive_operator());
+        assert!(!summary.needs_release_archive_dispatch());
+        assert!(!summary.needs_release_archive_handoff());
+        assert!(!summary.needs_release_archive_closure());
+        assert!(!summary.needs_release_archive_signoff());
+        assert!(!summary.needs_release_archive());
+        assert!(!summary.needs_release_closure());
+        assert!(!summary.needs_release_signoff());
+        assert!(!summary.needs_release_audit());
+        assert!(!summary.needs_operator_readiness());
+        assert!(!summary.needs_coordination());
+        assert!(!summary.needs_publish_gate());
+    }
+
+    #[test]
+    fn hue_package_release_archive_verification_summary_routes_blocked_archive_verification() {
+        let mut plan = hue_pairing_plan_for_discovered_bridge(
+            DiscoveredHueBridge {
+                bridge_id: "001788fffeabcdef".to_string(),
+                address: "https://192.0.2.10".to_string(),
+                hardware_model: Some("BSB002".to_string()),
+                firmware_version: Some("1.60".to_string()),
+            },
+            "chief-of-staff",
+            "desk",
+        );
+        plan.bridge.address = None;
+        plan.registration_request.path = "/wrong/api".to_string();
+        plan.application_key_header = "x-application-key".to_string();
+        plan.event_stream_path = "/wrong/eventstream".to_string();
+        plan.requires_user_presence = false;
+
+        let summary = HuePackageReleaseArchiveVerificationSummary::from_pairing_plan(&plan);
+
+        assert_eq!(summary.required_archive_verification_check_count, 15);
+        assert_eq!(summary.passed_archive_verification_check_count, 0);
+        assert_eq!(summary.blocked_archive_verification_check_count, 15);
+        assert!(!summary.release_archive_publication_ready);
+        assert!(!summary.release_archive_completion_ready);
+        assert!(!summary.release_archive_supervisor_ready);
+        assert!(!summary.release_archive_operator_ready);
+        assert!(!summary.release_archive_dispatch_ready);
+        assert!(!summary.release_archive_handoff_ready);
+        assert!(!summary.release_archive_closure_ready);
+        assert!(!summary.release_archive_signoff_ready);
+        assert!(!summary.release_archive_ready);
+        assert!(!summary.release_closure_ready);
+        assert!(!summary.release_signoff_ready);
+        assert!(!summary.release_audit_ready);
+        assert!(!summary.operator_ready);
+        assert!(!summary.coordination_ready);
+        assert!(!summary.publish_gate_ready);
+        assert!(!summary.release_archive_verification_ready);
+        assert!(!summary.is_release_archive_verification_ready());
+        assert!(summary.has_blocked_archive_verification_checks());
+        assert!(summary.needs_release_archive_publication());
         assert!(summary.needs_release_archive_completion());
         assert!(summary.needs_release_archive_supervisor());
         assert!(summary.needs_release_archive_operator());


### PR DESCRIPTION
## Summary
- add a Hue package release archive verification summary on top of archive publication readiness
- expose ready/blocked archive verification helper predicates and coverage counts
- document the new Hue release archive verification step

## Tests
- cargo fmt --manifest-path code\\packages\\rust\\hue-core\\Cargo.toml
- cargo test --manifest-path code\\packages\\rust\\hue-core\\Cargo.toml