### PR TITLE
feat(sir-regex): regex builtin → sir-runtime-regex (gated import)

### DIFF
--- a/code/packages/python/sir-runtime-regex/BUILD
+++ b/code/packages/python/sir-runtime-regex/BUILD
@@ -1,0 +1,5 @@
+uv venv --quiet --clear
+uv pip install -e .[dev] --quiet
+.venv/bin/python -m ruff check src tests
+.venv/bin/python -m mypy
+.venv/bin/python -m pytest tests/ -v

--- a/code/packages/python/sir-runtime-regex/BUILD_windows
+++ b/code/packages/python/sir-runtime-regex/BUILD_windows
@@ -1,0 +1,5 @@
+uv venv --quiet --clear
+uv pip install -e .[dev] --quiet
+.venv\Scripts\python.exe -m ruff check src tests
+.venv\Scripts\python.exe -m mypy
+.venv\Scripts\python.exe -m pytest tests/ -v

--- a/code/packages/python/sir-runtime-regex/CHANGELOG.md
+++ b/code/packages/python/sir-runtime-regex/CHANGELOG.md
@@ -1,0 +1,36 @@
+# Changelog
+
+## 0.1.0 — initial release
+
+First release of the SIR regex runtime for Python, per
+`code/specs/sir-runtime.md`. Provides the runtime landing point for the SIR
+`regex` builtin — the Ruby→SIR frontend lowers `/pat/flags` to
+`BuiltinCall("regex", [StrLit pattern, StrLit flags])`, which previously had no
+Python runtime, so emitted code using a regex failed. Python mirror of
+`@coding-adventures/sir-runtime-regex` (TypeScript).
+
+### Added
+
+- `compile(pattern, flags="") -> re.Pattern[str]` — compile a Ruby-dialect
+  pattern, translating Ruby inline flags to Python `re` flags (`i`→IGNORECASE,
+  `m`→DOTALL since Ruby `/m` is dot-matches-newline, `x`→VERBOSE; unknown chars
+  ignored) and **always** OR-ing in `re.MULTILINE` because Ruby's `^`/`$` are
+  always line anchors.
+- `is_match(pattern, string) -> bool` — unanchored search (Ruby `=~`/`match?`
+  semantics); accepts a compiled pattern or a raw string.
+- `match_data(pattern, string) -> str | None` — matched substring (group 0) or
+  `None`; minimal model of Ruby `String#match`.
+- `_compiled(pattern)` helper — pass through a compiled pattern, else compile a
+  raw value.
+- `Val` — the universal SIR value type alias at this boundary.
+- Full standard layout: `pyproject.toml` (src layout), `BUILD`, `BUILD_windows`,
+  `required_capabilities.json` (no capabilities), `py.typed`, README. pytest
+  suite at 100% coverage of `regex.py`; `mypy --strict` + `ruff` clean.
+
+### Design note
+
+`compile` intentionally shadows `builtins.compile` / `re.compile` because
+`regex` is the SIR builtin's name and emitted code addresses this package's
+`compile` by qualified name. The Ruby→Python divergence is concentrated in the
+flag mapping and the unconditional `re.MULTILINE` (Ruby line anchors); the
+shared Perl-compatible syntax passes straight through to the `re` engine.

--- a/code/packages/python/sir-runtime-regex/README.md
+++ b/code/packages/python/sir-runtime-regex/README.md
@@ -1,0 +1,81 @@
+# coding-adventures-sir-runtime-regex
+
+Regex runtime for **Semantic-IR-emitted Python**.
+
+The Ruby→SIR frontend lowers a regex literal `/pat/flags` to
+`BuiltinCall("regex", [StrLit pattern, StrLit flags])`. Emitted Python needs a
+runtime landing point for that builtin — one that compiles the pattern with
+Python's standard `re` engine while translating Ruby's flag spellings and
+line-anchor conventions. That runtime is this package.
+
+## Where it fits in the stack
+
+```
+Ruby source ─▶ ruby-to-semantic-ir ─▶ Semantic IR ─▶ semantic-ir-to-python ─▶ .py
+                                                                             │ imports
+                                                                             ▼
+                                                       coding-adventures-sir-runtime-regex
+```
+
+The Python backend emits an import of this package only when a module uses a
+regex; pure modules never gain the dependency.
+
+## Why a translation layer — Ruby's dialect differs from Python `re`
+
+Both engines are Perl-compatible, so the *syntax* (`\d`, `[a-z]`, `(?:...)`,
+`a|b`) is shared. They diverge in two places:
+
+| Ruby flag char | Python `re` flag | Meaning |
+|---|---|---|
+| `i` | `re.IGNORECASE` | Case-insensitive matching. |
+| `m` | `re.DOTALL` | Ruby `/m` ("multiline") makes `.` match a newline — this is Python's *DOTALL*, **not** Python's `re.MULTILINE`. The shared letter is a foot-gun. |
+| `x` | `re.VERBOSE` | "Extended" mode — unescaped whitespace and `#` comments ignored. |
+| (any other) | — | Unknown flag characters are silently dropped. |
+
+**The `^` / `$` nuance.** In Ruby, `^` and `$` *always* anchor to the start/end
+of a **line** — the whole-string anchors are `\A` and `\z`/`\Z`. In Python the
+default is the opposite (`^`/`$` anchor the whole string unless `re.MULTILINE`).
+So this package **always ORs in `re.MULTILINE`** to make Ruby patterns behave
+faithfully; `\A` / `\z` carry over unchanged for whole-string anchoring.
+
+**Match semantics.** Ruby's `=~` / `String#match?` perform an *unanchored
+search*, not a full-string match. `is_match` / `match_data` therefore use
+`re.Pattern.search`, never `fullmatch`.
+
+## API
+
+| Export | Purpose |
+|---|---|
+| `compile(pattern, flags="") -> re.Pattern[str]` | Compile a Ruby-dialect pattern under Ruby-dialect flags (always line-anchored). |
+| `is_match(pattern, string) -> bool` | True iff an unanchored search matches (Ruby `=~`/`match?`). Accepts a compiled pattern or a raw string. |
+| `match_data(pattern, string) -> str \| None` | The matched substring (group 0), or `None` on no match (minimal `String#match`). |
+| `Val` | The universal SIR value type alias (`Any`) at this boundary. |
+
+`compile` intentionally shadows `builtins.compile` / `re.compile`: `regex` is the
+SIR builtin's name and emitted code addresses this package's `compile` by
+qualified name, so the shadow is harmless.
+
+## Usage
+
+```python
+from coding_adventures_sir_runtime_regex import compile, is_match, match_data
+
+pat = compile(r"\d+", "i")        # Ruby /\d+/i
+is_match(pat, "abc 42")           # True   (unanchored search, like Ruby =~)
+is_match(r"\d+", "no digits")     # False  (raw string also accepted)
+match_data(r"\d+", "abc 42 xyz")  # "42"   (group 0)
+match_data(r"\d+", "none")        # None   (no match)
+```
+
+## Development
+
+```bash
+uv venv && uv pip install -e .[dev]
+.venv/bin/python -m ruff check src tests
+.venv/bin/python -m mypy
+.venv/bin/python -m pytest tests/ -v
+```
+
+## License
+
+MIT

--- a/code/packages/python/sir-runtime-regex/pyproject.toml
+++ b/code/packages/python/sir-runtime-regex/pyproject.toml
@@ -1,0 +1,57 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "coding-adventures-sir-runtime-regex"
+version = "0.1.0"
+description = "Regex runtime for Semantic-IR-emitted Python — the SIR `regex` builtin with Ruby→Python flag translation and unanchored-search match semantics"
+requires-python = ">=3.12"
+dependencies = []
+license = "MIT"
+authors = [{ name = "Adhithya Rajasekaran" }]
+readme = "README.md"
+keywords = ["sir", "semantic-ir", "runtime", "regex", "regexp", "compiler", "cross-language", "education"]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Education",
+    "Topic :: Education",
+    "Topic :: Software Development :: Compilers",
+    "Programming Language :: Python :: 3.12",
+    "License :: OSI Approved :: MIT License",
+    "Typing :: Typed",
+]
+
+[project.urls]
+Homepage = "https://github.com/adhithyan15/coding-adventures"
+Repository = "https://github.com/adhithyan15/coding-adventures"
+Documentation = "https://github.com/adhithyan15/coding-adventures/tree/main/code/specs/sir-runtime.md"
+
+[project.optional-dependencies]
+dev = ["pytest>=8.0", "pytest-cov>=5.0", "ruff>=0.4", "mypy>=1.10"]
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/coding_adventures_sir_runtime_regex"]
+
+[tool.ruff]
+target-version = "py312"
+line-length = 100
+
+[tool.ruff.lint]
+select = ["E", "W", "F", "I", "UP", "B", "SIM"]
+
+[tool.mypy]
+strict = true
+python_version = "3.12"
+files = ["src"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "--cov=coding_adventures_sir_runtime_regex --cov-report=term-missing --cov-fail-under=80"
+
+[tool.coverage.run]
+source = ["src/coding_adventures_sir_runtime_regex"]
+
+[tool.coverage.report]
+fail_under = 80
+show_missing = true

--- a/code/packages/python/sir-runtime-regex/required_capabilities.json
+++ b/code/packages/python/sir-runtime-regex/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "python/sir-runtime-regex",
+  "capabilities": [],
+  "justification": "Pure in-process regular-expression compilation using the standard `re` module with Ruby→Python flag translation. No filesystem, network, process, or environment access."
+}

--- a/code/packages/python/sir-runtime-regex/src/coding_adventures_sir_runtime_regex/__init__.py
+++ b/code/packages/python/sir-runtime-regex/src/coding_adventures_sir_runtime_regex/__init__.py
@@ -1,0 +1,36 @@
+"""coding-adventures-sir-runtime-regex — the SIR ``regex`` builtin for Python.
+
+The Ruby→SIR frontend lowers a regex literal ``/pat/flags`` to
+``BuiltinCall("regex", [StrLit pattern, StrLit flags])``.  This package is the
+Python runtime for that builtin: it compiles the pattern with the standard
+:mod:`re` engine while translating Ruby's flag spellings and line-anchor
+conventions::
+
+    from coding_adventures_sir_runtime_regex import compile, is_match, match_data
+    pat = compile(r"\\d+", "i")     # Ruby /\\d+/i  → re.Pattern
+    is_match(pat, "abc 42")          # True  (unanchored search, like Ruby =~)
+    match_data(r"\\d+", "abc 42")    # "42"  (group 0, or None on no match)
+
+Ruby's regex dialect differs from Python ``re`` chiefly in how inline flags are
+spelled (Ruby ``/m`` is Python ``DOTALL``, not ``MULTILINE``) and in that
+``^`` / ``$`` are *always* line anchors — see :mod:`coding_adventures_sir_runtime_regex.regex`
+for the full mapping table and the ``\\A`` / ``\\z`` nuance.
+
+Note :func:`compile` deliberately shadows :func:`builtins.compile` /
+:func:`re.compile`: ``regex`` is the SIR builtin name and emitted code addresses
+this package's ``compile`` by qualified name, so the shadow is intentional and
+harmless.
+
+See ``code/specs/sir-runtime.md``.
+"""
+
+from __future__ import annotations
+
+from .regex import Val, compile, is_match, match_data
+
+__all__ = [
+    "Val",
+    "compile",
+    "is_match",
+    "match_data",
+]

--- a/code/packages/python/sir-runtime-regex/src/coding_adventures_sir_runtime_regex/regex.py
+++ b/code/packages/python/sir-runtime-regex/src/coding_adventures_sir_runtime_regex/regex.py
@@ -1,0 +1,118 @@
+"""Regular expressions — the SIR ``regex`` builtin (Ruby dialect on Python ``re``).
+
+The Ruby→SIR frontend lowers a regex literal ``/pat/flags`` to
+``BuiltinCall("regex", [StrLit pattern, StrLit flags])``.  This module is the
+*Python* landing point for that builtin: it compiles the pattern with Python's
+standard :mod:`re` engine, translating Ruby's flag and anchoring conventions so
+the compiled object behaves the way the Ruby source intended.
+
+**Why a translation layer at all — Ruby's dialect differs from Python's.**
+Both engines descend from Perl-compatible regular expressions, so the *syntax*
+(``\\d``, ``[a-z]``, ``(?:...)``, ``a|b``, ``+ * ?``) is almost entirely
+shared.  Where they diverge is in **how the inline flags are spelled** and **what
+the line anchors ``^`` / ``$`` mean by default**:
+
+================  =====================  ==========================================
+Ruby flag char    Python ``re`` flag     Meaning
+================  =====================  ==========================================
+``i``             :data:`re.IGNORECASE`  Case-insensitive matching.
+``m``             :data:`re.DOTALL`      Ruby ``/m`` ("multiline") makes ``.`` match
+                                         a newline.  This is Python's *DOTALL*, **not**
+                                         Python's :data:`re.MULTILINE`.  This is the
+                                         classic foot-gun: the same letter means
+                                         different things in the two engines.
+``x``             :data:`re.VERBOSE`     "Extended" mode — unescaped whitespace and
+                                         ``#`` comments in the pattern are ignored.
+(any other)       — (ignored)            Unknown flag characters are silently dropped.
+================  =====================  ==========================================
+
+**The ``^`` / ``$`` nuance.**  In Ruby, ``^`` and ``$`` *always* anchor to the
+start/end of a **line**, not the whole string — there is no flag to turn that
+off; the whole-string anchors are the separate escapes ``\\A`` (start of string)
+and ``\\z`` / ``\\Z`` (end of string).  In Python the default is the opposite:
+``^`` / ``$`` anchor to the *whole string* unless :data:`re.MULTILINE` is set.
+To make a Ruby pattern behave faithfully we therefore **always OR in**
+:data:`re.MULTILINE`, regardless of the flag string.  (``\\A`` / ``\\z`` carry
+over unchanged, so whole-string anchoring is still available to the pattern
+author.)
+
+**Match semantics.**  Ruby's ``=~`` and ``String#match?`` perform an *unanchored
+search* — a hit anywhere in the string counts — not a full-string match.  The
+:func:`is_match` and :func:`match_data` helpers below therefore use
+:func:`re.Pattern.search`, never ``fullmatch``.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+# The SIR universal value type at this package's boundary.  A "pattern" handed
+# to the match helpers may be either a precompiled :class:`re.Pattern` or a raw
+# pattern string, so we accept the widest type and narrow internally.
+Val = Any
+
+
+def compile(pattern: str, flags: str = "") -> re.Pattern[str]:
+    """Compile a Ruby-dialect regex ``pattern`` under Ruby-dialect ``flags``.
+
+    ``flags`` is the inline-flag *string* exactly as it trails a Ruby literal —
+    e.g. the ``"imx"`` of ``/.../imx``.  Each recognised character contributes a
+    Python :mod:`re` flag per the truth table in the module docstring; unknown
+    characters are ignored.  :data:`re.MULTILINE` is *always* included so that
+    Ruby's line-anchored ``^`` / ``$`` behave correctly (see the module
+    docstring's ``\\A`` / ``\\z`` note).
+
+    Note this function intentionally shadows the builtin :func:`compile` and
+    :func:`re.compile`: ``regex`` is the SIR builtin's name, and this module is
+    addressed as ``coding_adventures_sir_runtime_regex.compile`` by emitted
+    code, so the shadow never bites a caller.
+    """
+    # Map of Ruby inline-flag characters to their Python re equivalents.  Built
+    # as a dict (not a chain of ifs) so the table reads like the docstring's.
+    mapping = {
+        "i": re.IGNORECASE,
+        "m": re.DOTALL,  # Ruby /m == dot-matches-newline == Python DOTALL.
+        "x": re.VERBOSE,
+    }
+    # Ruby's ^/$ are always line anchors, so MULTILINE is unconditional.
+    py_flags = re.MULTILINE
+    for ch in flags:
+        # Unknown characters contribute nothing (mapping.get default 0).
+        py_flags |= mapping.get(ch, 0)
+    return re.compile(pattern, py_flags)
+
+
+def _compiled(pattern: Any) -> re.Pattern[str]:
+    """Coerce ``pattern`` to a compiled :class:`re.Pattern`.
+
+    Accepts either an already-compiled pattern (returned untouched, so a
+    caller's flags are preserved) or a raw value compiled on the spot with the
+    default Ruby flag set (empty string ⇒ just the unconditional
+    :data:`re.MULTILINE`).
+    """
+    if isinstance(pattern, re.Pattern):
+        return pattern
+    return compile(str(pattern))
+
+
+def is_match(pattern: Any, string: str) -> bool:
+    """True iff ``pattern`` matches anywhere in ``string`` (Ruby ``=~`` / ``match?``).
+
+    This is an *unanchored search*, mirroring Ruby semantics — a hit anywhere in
+    the string counts, not a full-string match.  ``pattern`` may be a compiled
+    :class:`re.Pattern` or a raw pattern string.
+    """
+    return _compiled(pattern).search(string) is not None
+
+
+def match_data(pattern: Any, string: str) -> str | None:
+    """Return the matched substring (group 0), or ``None`` if there is no match.
+
+    A minimal model of Ruby's ``String#match``: Ruby returns a truthy
+    ``MatchData`` (whose ``[0]`` is the matched text) or ``nil``.  Here we expose
+    just the matched substring, which is the most common thing emitted code
+    needs, and ``None`` for the no-match (``nil``) case.
+    """
+    m = _compiled(pattern).search(string)
+    return m.group(0) if m is not None else None

--- a/code/packages/python/sir-runtime-regex/tests/test_regex.py
+++ b/code/packages/python/sir-runtime-regex/tests/test_regex.py
@@ -1,0 +1,90 @@
+"""Unit tests for the SIR Python regex runtime."""
+
+from __future__ import annotations
+
+import re
+
+from coding_adventures_sir_runtime_regex import (
+    compile,
+    is_match,
+    match_data,
+)
+
+
+class TestFlagTranslation:
+    def test_no_flags_still_always_multiline(self) -> None:
+        # Ruby's ^/$ are always line anchors, so MULTILINE is unconditional even
+        # with an empty flag string — and nothing else is set.
+        p = compile("a")
+        assert p.flags & re.MULTILINE
+        assert not (p.flags & re.IGNORECASE)
+        assert not (p.flags & re.DOTALL)
+        assert not (p.flags & re.VERBOSE)
+
+    def test_i_maps_to_ignorecase(self) -> None:
+        p = compile("a", "i")
+        assert p.flags & re.IGNORECASE
+        assert p.flags & re.MULTILINE  # still always on
+
+    def test_m_maps_to_dotall_not_python_multiline_semantics(self) -> None:
+        # Ruby /m means "dot matches newline" == Python DOTALL. (Python's own
+        # re.MULTILINE is the always-on line-anchor flag, set independently.)
+        p = compile(".", "m")
+        assert p.flags & re.DOTALL
+        # Proof of behaviour: with DOTALL, "." now spans a newline.
+        assert p.search("\n") is not None
+        # Without /m, "." would not match a newline.
+        assert compile(".").search("\n") is None
+
+    def test_x_maps_to_verbose(self) -> None:
+        p = compile("a", "x")
+        assert p.flags & re.VERBOSE
+
+    def test_combined_flags(self) -> None:
+        p = compile("a", "imx")
+        assert p.flags & re.IGNORECASE
+        assert p.flags & re.DOTALL
+        assert p.flags & re.VERBOSE
+        assert p.flags & re.MULTILINE
+
+    def test_unknown_flag_chars_are_ignored(self) -> None:
+        # 'z', 'o', 'u' are not in the mapping; they must contribute nothing
+        # (but MULTILINE remains on, and a real flag alongside still applies).
+        p = compile("a", "zoiu")
+        assert p.flags & re.IGNORECASE
+        assert p.flags & re.MULTILINE
+
+    def test_verbose_ignores_unescaped_whitespace(self) -> None:
+        # Under VERBOSE, the spaces in the pattern are not literal, so this still
+        # matches "ab" with no spaces.
+        p = compile("a b", "x")
+        assert p.search("ab") is not None
+
+
+class TestIsMatch:
+    def test_true_unanchored_search(self) -> None:
+        # Ruby =~ is an unanchored search: a hit anywhere counts, not fullmatch.
+        assert is_match(r"\d+", "abc 42 xyz") is True
+
+    def test_false_when_no_match(self) -> None:
+        assert is_match(r"\d+", "no digits here") is False
+
+    def test_accepts_a_precompiled_pattern(self) -> None:
+        pat = compile(r"\d+", "")
+        assert is_match(pat, "x9") is True
+        assert is_match(pat, "none") is False
+
+    def test_accepts_a_raw_string_pattern(self) -> None:
+        assert is_match("foo", "a foo b") is True
+
+
+class TestMatchData:
+    def test_returns_group_zero(self) -> None:
+        assert match_data(r"\d+", "abc 42 xyz") == "42"
+
+    def test_returns_none_on_no_match(self) -> None:
+        assert match_data(r"\d+", "no digits") is None
+
+    def test_accepts_a_precompiled_pattern(self) -> None:
+        pat = compile(r"[a-z]+", "")
+        assert match_data(pat, "  HELLO world") == "world"

--- a/code/packages/rust/semantic-ir-to-python/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-python/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## 0.1.10 — regex builtin → sir-runtime-regex (gated import)
+
+The Ruby `/pat/flags` literal lowers to `BuiltinCall("regex", [pattern,
+flags])`, which previously hit the unknown-builtin dispatch and raised at
+runtime. It now emits a call into the new `coding-adventures-sir-runtime-regex`
+package (native `re` compile with Ruby→Python flag translation), per
+`code/specs/sir-runtime.md`.
+
+- `BuiltinCall("regex", …)` → `_sir_regex_compile(pattern, flags)`.
+- New gated `RUNTIME_REGEX` import header, appended **only** when a module calls
+  the `regex` builtin. Because regex carries no SIR `Feature`, the gate
+  (`uses_regex`) is a content walk — an exhaustive `Stmt`/`Expr` recursion that
+  finds a `BuiltinCall` by name (the compiler forces every node to be handled,
+  so a new node can't silently hide a use).
+- New direct-SIR tests assert the gated import + `_sir_regex_compile("ab+c",
+  "i")` and that a non-regex module omits the import. Exec-proofed on CPython
+  against the real package (case-insensitive search, unanchored `is_match`).
+
 ## 0.1.9 — pairs extracted to sir-runtime-pairs (gated import)
 
 Cons pairs (`cons`/`car`/`cdr`/`pair?`) now ship in the dedicated

--- a/code/packages/rust/semantic-ir-to-python/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-python/src/emit.rs
@@ -44,6 +44,113 @@ fn uses_pairs(m: &Module) -> bool {
     m.manifest.contains(Feature::Pairs)
 }
 
+/// True if the module calls the `regex` builtin (a Ruby `/pat/flags` literal
+/// lowers to `BuiltinCall("regex", …)`).  Regex is not a SIR `Feature`, so we
+/// detect it by walking for the builtin name; a positive result gates the
+/// `coding-adventures-sir-runtime-regex` import.
+fn uses_regex(m: &Module) -> bool {
+    module_uses_builtin(m, "regex")
+}
+
+/// Walk every function body looking for a `BuiltinCall` named `name`.  Used to
+/// gate per-concern runtime imports for builtins that carry no `Feature` flag
+/// (e.g. `regex`).  Exhaustive over `Stmt`/`Expr` so a new node can't silently
+/// hide a use (the compiler forces every arm to be handled).
+fn module_uses_builtin(m: &Module, name: &str) -> bool {
+    m.functions.iter().any(|f| block_uses_builtin(&f.body, name))
+}
+
+fn block_uses_builtin(b: &Block, name: &str) -> bool {
+    b.stmts.iter().any(|s| stmt_uses_builtin(s, name)) || expr_uses_builtin(&b.value, name)
+}
+
+fn stmts_use_builtin(stmts: &[Stmt], name: &str) -> bool {
+    stmts.iter().any(|s| stmt_uses_builtin(s, name))
+}
+
+fn stmt_uses_builtin(s: &Stmt, name: &str) -> bool {
+    match s {
+        Stmt::LetBinding { value, .. }
+        | Stmt::LetStarBinding { value, .. }
+        | Stmt::Assign { value, .. } => expr_uses_builtin(value, name),
+        Stmt::ExprStmt { expr, .. } => expr_uses_builtin(expr, name),
+        Stmt::While { cond, body, .. } => {
+            expr_uses_builtin(cond, name) || block_uses_builtin(body, name)
+        }
+        Stmt::ForRange { start, stop, step, body, .. } => {
+            expr_uses_builtin(start, name)
+                || expr_uses_builtin(stop, name)
+                || expr_uses_builtin(step, name)
+                || block_uses_builtin(body, name)
+        }
+        Stmt::ForEach { iter, body, .. } => {
+            expr_uses_builtin(iter, name) || block_uses_builtin(body, name)
+        }
+        Stmt::SeqSet { seq, index, value, .. } => {
+            expr_uses_builtin(seq, name)
+                || expr_uses_builtin(index, name)
+                || expr_uses_builtin(value, name)
+        }
+        Stmt::MapSet { map, key, value, .. } => {
+            expr_uses_builtin(map, name)
+                || expr_uses_builtin(key, name)
+                || expr_uses_builtin(value, name)
+        }
+        Stmt::ClassDef { body, .. }
+        | Stmt::ModuleDef { body, .. }
+        | Stmt::SingletonClassDef { body, .. } => stmts_use_builtin(body, name),
+        Stmt::TryCatch { body, rescues, ensure_body, .. } => {
+            stmts_use_builtin(body, name)
+                || rescues.iter().any(|r| stmts_use_builtin(&r.body, name))
+                || ensure_body.as_deref().is_some_and(|e| stmts_use_builtin(e, name))
+        }
+    }
+}
+
+fn expr_uses_builtin(e: &Expr, name: &str) -> bool {
+    match e {
+        Expr::BuiltinCall { name: n, args, .. } => {
+            n == name || args.iter().any(|a| expr_uses_builtin(a, name))
+        }
+        Expr::DirectCall { args, .. } => args.iter().any(|a| expr_uses_builtin(a, name)),
+        Expr::IndirectCall { target, args, .. } => {
+            expr_uses_builtin(target, name) || args.iter().any(|a| expr_uses_builtin(a, name))
+        }
+        Expr::If { cond, then_branch, else_branch, .. } => {
+            expr_uses_builtin(cond, name)
+                || block_uses_builtin(then_branch, name)
+                || block_uses_builtin(else_branch, name)
+        }
+        Expr::Block(b) => block_uses_builtin(b, name),
+        Expr::MakeClosure { captures, .. } => {
+            captures.iter().any(|c| expr_uses_builtin(&c.value, name))
+        }
+        Expr::SeqLit { items, .. } => items.iter().any(|i| expr_uses_builtin(i, name)),
+        Expr::SeqIndex { seq, index, .. } => {
+            expr_uses_builtin(seq, name) || expr_uses_builtin(index, name)
+        }
+        Expr::SeqLen { seq, .. } => expr_uses_builtin(seq, name),
+        Expr::MapLit { entries, .. } => entries
+            .iter()
+            .any(|en| expr_uses_builtin(&en.key, name) || expr_uses_builtin(&en.value, name)),
+        Expr::MapGet { map, key, .. } => {
+            expr_uses_builtin(map, name) || expr_uses_builtin(key, name)
+        }
+        Expr::LogicalAnd { lhs, rhs, .. } | Expr::LogicalOr { lhs, rhs, .. } => {
+            expr_uses_builtin(lhs, name) || expr_uses_builtin(rhs, name)
+        }
+        Expr::StrConcat { parts, .. } => parts.iter().any(|p| expr_uses_builtin(p, name)),
+        Expr::Intrinsic { args, .. } => args.iter().any(|a| expr_uses_builtin(a, name)),
+        Expr::IntLit { .. }
+        | Expr::FloatLit { .. }
+        | Expr::BoolLit { .. }
+        | Expr::NilLit { .. }
+        | Expr::SymLit { .. }
+        | Expr::StrLit { .. }
+        | Expr::VarRef { .. } => false,
+    }
+}
+
 /// Emit a SIR module as Python 3 source.  Caller is responsible
 /// for prior validation; this function assumes the module is valid.
 pub fn emit_module(m: &Module) -> String {
@@ -72,6 +179,10 @@ pub fn emit_module(m: &Module) -> String {
     // Only pair-using modules import the pairs runtime.
     if uses_pairs(m) {
         out.push_str(crate::runtime::RUNTIME_PAIRS);
+    }
+    // Only regex-using modules import the regex runtime.
+    if uses_regex(m) {
+        out.push_str(crate::runtime::RUNTIME_REGEX);
     }
     emit_globals(&mut out, &m.globals);
     for f in &m.functions {
@@ -693,6 +804,15 @@ fn emit_builtin_call(out: &mut String, name: &str, args: &[Expr], indent: usize)
                 emit_expr(out, other, indent);
             }
         }
+        out.push(')');
+        return;
+    }
+    // `regex` (a Ruby `/pat/flags` literal) → compile via the regex runtime.
+    // Args are `[pattern, flags]` (both string literals); routes to the
+    // dedicated package's `compile`, gated by `uses_regex`.
+    if name == "regex" {
+        out.push_str("_sir_regex_compile(");
+        emit_args(out, args, indent);
         out.push(')');
         return;
     }

--- a/code/packages/rust/semantic-ir-to-python/src/lib.rs
+++ b/code/packages/rust/semantic-ir-to-python/src/lib.rs
@@ -951,4 +951,37 @@ mod tests {
         let a = compile(&module).expect("compile");
         assert!(!a.source.contains("sir_runtime_pairs"), "got:\n{}", a.source);
     }
+
+    // ─── SIR regex builtin → sir-runtime-regex (Q8b) ────────────────────────
+
+    #[test]
+    fn regex_builtin_emits_regex_runtime_py() {
+        // `/ab+c/i` lowers to BuiltinCall("regex", [pattern, flags]).
+        let rx = Expr::BuiltinCall {
+            name: "regex".into(),
+            args: vec![
+                Expr::StrLit { value: "ab+c".into(), span: s() },
+                Expr::StrLit { value: "i".into(), span: s() },
+            ],
+            effects: EffectSet::PURE,
+            span: s(),
+        };
+        let m = module_with_main_body(vec![], rx, &[Feature::Strings]);
+        let a = compile(&m).expect("compile");
+        let src = &a.source;
+        assert!(
+            src.contains("from coding_adventures_sir_runtime_regex import"),
+            "got:\n{}",
+            src
+        );
+        assert!(src.contains("compile as _sir_regex_compile"), "got:\n{}", src);
+        assert!(src.contains("_sir_regex_compile(\"ab+c\", \"i\")"), "got:\n{}", src);
+    }
+
+    #[test]
+    fn non_regex_module_omits_regex_import_py() {
+        let module = twig_to_semantic_ir::compile_source("(print (+ 1 2))", "demo").expect("lower");
+        let a = compile(&module).expect("compile");
+        assert!(!a.source.contains("sir_runtime_regex"), "got:\n{}", a.source);
+    }
 }

--- a/code/packages/rust/semantic-ir-to-python/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-python/src/runtime.rs
@@ -53,6 +53,17 @@ from coding_adventures_sir_runtime_pairs import (
 )
 "##;
 
+/// The regex-runtime import header, appended **only** when a module calls the
+/// `regex` builtin (a Ruby `/pat/flags` literal).  Provides a target-native
+/// compiler with Ruby→Python flag translation; see `code/specs/sir-runtime.md`.
+pub const RUNTIME_REGEX: &str = r##"# ── SIR regex runtime (imported from coding-adventures-sir-runtime-regex) ──
+from coding_adventures_sir_runtime_regex import (
+    compile as _sir_regex_compile,
+    is_match as _sir_regex_is_match,
+    match_data as _sir_regex_match_data,
+)
+"##;
+
 pub const RUNTIME: &str = r##"# ── SIR runtime (imported from coding-adventures-sir-runtime-core) ──
 from coding_adventures_sir_runtime_core import (
     truthy as _sir_truthy,

--- a/code/packages/rust/semantic-ir-to-typescript/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-typescript/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## 0.1.9 — regex builtin → sir-runtime-regex (gated import)
+
+The Ruby `/pat/flags` literal lowers to `BuiltinCall("regex", [pattern,
+flags])`, which previously hit the unknown-builtin dispatch and threw at
+runtime. It now emits a call into the new `@coding-adventures/sir-runtime-regex`
+package (native `RegExp` compile with Ruby→JS flag translation), per
+`code/specs/sir-runtime.md`.
+
+- `BuiltinCall("regex", …)` → `__SirRegex.compile(pattern, flags)`.
+- New gated `RUNTIME_REGEX` import, emitted **only** when a module calls the
+  `regex` builtin. Because regex carries no SIR `Feature`, the gate
+  (`uses_regex`) is a content walk — an exhaustive `Stmt`/`Expr` recursion that
+  finds a `BuiltinCall` by name.
+- New direct-SIR tests assert the gated import + `__SirRegex.compile("ab+c",
+  "i")` and that a non-regex module omits the import. The runtime package's own
+  vitest suite (100%) covers flag translation and unanchored matching.
+
 ## 0.1.8 — pairs extracted to sir-runtime-pairs (gated import)
 
 Cons pairs (`cons`/`car`/`cdr`/`pair?`) now ship in the dedicated

--- a/code/packages/rust/semantic-ir-to-typescript/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-typescript/src/emit.rs
@@ -53,6 +53,112 @@ fn uses_pairs(m: &Module) -> bool {
     m.manifest.contains(Feature::Pairs)
 }
 
+/// True if the module calls the `regex` builtin (a Ruby `/pat/flags` literal
+/// lowers to `BuiltinCall("regex", …)`).  Regex carries no SIR `Feature`, so we
+/// detect it by walking for the builtin name; a positive result gates the
+/// `@coding-adventures/sir-runtime-regex` import.
+fn uses_regex(m: &Module) -> bool {
+    module_uses_builtin(m, "regex")
+}
+
+/// Walk every function body for a `BuiltinCall` named `name` — gates
+/// per-concern imports for builtins that carry no `Feature` flag.  Exhaustive
+/// over `Stmt`/`Expr` so a new node can't silently hide a use.
+fn module_uses_builtin(m: &Module, name: &str) -> bool {
+    m.functions.iter().any(|f| block_uses_builtin(&f.body, name))
+}
+
+fn block_uses_builtin(b: &Block, name: &str) -> bool {
+    b.stmts.iter().any(|s| stmt_uses_builtin(s, name)) || expr_uses_builtin(&b.value, name)
+}
+
+fn stmts_use_builtin(stmts: &[Stmt], name: &str) -> bool {
+    stmts.iter().any(|s| stmt_uses_builtin(s, name))
+}
+
+fn stmt_uses_builtin(s: &Stmt, name: &str) -> bool {
+    match s {
+        Stmt::LetBinding { value, .. }
+        | Stmt::LetStarBinding { value, .. }
+        | Stmt::Assign { value, .. } => expr_uses_builtin(value, name),
+        Stmt::ExprStmt { expr, .. } => expr_uses_builtin(expr, name),
+        Stmt::While { cond, body, .. } => {
+            expr_uses_builtin(cond, name) || block_uses_builtin(body, name)
+        }
+        Stmt::ForRange { start, stop, step, body, .. } => {
+            expr_uses_builtin(start, name)
+                || expr_uses_builtin(stop, name)
+                || expr_uses_builtin(step, name)
+                || block_uses_builtin(body, name)
+        }
+        Stmt::ForEach { iter, body, .. } => {
+            expr_uses_builtin(iter, name) || block_uses_builtin(body, name)
+        }
+        Stmt::SeqSet { seq, index, value, .. } => {
+            expr_uses_builtin(seq, name)
+                || expr_uses_builtin(index, name)
+                || expr_uses_builtin(value, name)
+        }
+        Stmt::MapSet { map, key, value, .. } => {
+            expr_uses_builtin(map, name)
+                || expr_uses_builtin(key, name)
+                || expr_uses_builtin(value, name)
+        }
+        Stmt::ClassDef { body, .. }
+        | Stmt::ModuleDef { body, .. }
+        | Stmt::SingletonClassDef { body, .. } => stmts_use_builtin(body, name),
+        Stmt::TryCatch { body, rescues, ensure_body, .. } => {
+            stmts_use_builtin(body, name)
+                || rescues.iter().any(|r| stmts_use_builtin(&r.body, name))
+                || ensure_body.as_deref().is_some_and(|e| stmts_use_builtin(e, name))
+        }
+    }
+}
+
+fn expr_uses_builtin(e: &Expr, name: &str) -> bool {
+    match e {
+        Expr::BuiltinCall { name: n, args, .. } => {
+            n == name || args.iter().any(|a| expr_uses_builtin(a, name))
+        }
+        Expr::DirectCall { args, .. } => args.iter().any(|a| expr_uses_builtin(a, name)),
+        Expr::IndirectCall { target, args, .. } => {
+            expr_uses_builtin(target, name) || args.iter().any(|a| expr_uses_builtin(a, name))
+        }
+        Expr::If { cond, then_branch, else_branch, .. } => {
+            expr_uses_builtin(cond, name)
+                || block_uses_builtin(then_branch, name)
+                || block_uses_builtin(else_branch, name)
+        }
+        Expr::Block(b) => block_uses_builtin(b, name),
+        Expr::MakeClosure { captures, .. } => {
+            captures.iter().any(|c| expr_uses_builtin(&c.value, name))
+        }
+        Expr::SeqLit { items, .. } => items.iter().any(|i| expr_uses_builtin(i, name)),
+        Expr::SeqIndex { seq, index, .. } => {
+            expr_uses_builtin(seq, name) || expr_uses_builtin(index, name)
+        }
+        Expr::SeqLen { seq, .. } => expr_uses_builtin(seq, name),
+        Expr::MapLit { entries, .. } => entries
+            .iter()
+            .any(|en| expr_uses_builtin(&en.key, name) || expr_uses_builtin(&en.value, name)),
+        Expr::MapGet { map, key, .. } => {
+            expr_uses_builtin(map, name) || expr_uses_builtin(key, name)
+        }
+        Expr::LogicalAnd { lhs, rhs, .. } | Expr::LogicalOr { lhs, rhs, .. } => {
+            expr_uses_builtin(lhs, name) || expr_uses_builtin(rhs, name)
+        }
+        Expr::StrConcat { parts, .. } => parts.iter().any(|p| expr_uses_builtin(p, name)),
+        Expr::Intrinsic { args, .. } => args.iter().any(|a| expr_uses_builtin(a, name)),
+        Expr::IntLit { .. }
+        | Expr::FloatLit { .. }
+        | Expr::BoolLit { .. }
+        | Expr::NilLit { .. }
+        | Expr::SymLit { .. }
+        | Expr::StrLit { .. }
+        | Expr::VarRef { .. } => false,
+    }
+}
+
 thread_local! {
     /// Monotonic counter for synthesised loop temporaries (the
     /// once-evaluated `__stop`/`__step` bounds of a `ForRange`).  Reset
@@ -93,6 +199,10 @@ pub fn emit_module(m: &Module) -> String {
     // Only pair-using modules import the pairs runtime.
     if uses_pairs(m) {
         out.push_str(crate::runtime::RUNTIME_PAIRS);
+    }
+    // Only regex-using modules import the regex runtime.
+    if uses_regex(m) {
+        out.push_str(crate::runtime::RUNTIME_REGEX);
     }
     emit_globals(&mut out, &m.globals);
     for f in &m.functions {
@@ -823,6 +933,15 @@ fn emit_builtin_call(out: &mut String, name: &str, args: &[Expr], indent: usize)
                 emit_expr(out, other, indent);
             }
         }
+        out.push(')');
+        return;
+    }
+    // `regex` (a Ruby `/pat/flags` literal) → compile via the regex runtime.
+    // Args are `[pattern, flags]`; routes to `__SirRegex.compile`, gated by
+    // `uses_regex`.
+    if name == "regex" {
+        out.push_str("__SirRegex.compile(");
+        emit_args(out, args, indent);
         out.push(')');
         return;
     }

--- a/code/packages/rust/semantic-ir-to-typescript/src/lib.rs
+++ b/code/packages/rust/semantic-ir-to-typescript/src/lib.rs
@@ -842,4 +842,35 @@ mod tests {
         let a = compile(&module).expect("compile");
         assert!(!a.source.contains("sir-runtime-pairs"), "got:\n{}", a.source);
     }
+
+    // ─── SIR regex builtin → sir-runtime-regex (Q8b) ────────────────────────
+
+    #[test]
+    fn regex_builtin_emits_regex_runtime_ts() {
+        let rx = Expr::BuiltinCall {
+            name: "regex".into(),
+            args: vec![
+                Expr::StrLit { value: "ab+c".into(), span: s() },
+                Expr::StrLit { value: "i".into(), span: s() },
+            ],
+            effects: EffectSet::PURE,
+            span: s(),
+        };
+        let m = module_with_main_body(vec![], rx, &[Feature::Strings]);
+        let a = compile(&m).expect("compile");
+        let src = &a.source;
+        assert!(
+            src.contains(r#"import * as __SirRegex from "@coding-adventures/sir-runtime-regex";"#),
+            "got:\n{}",
+            src
+        );
+        assert!(src.contains(r#"__SirRegex.compile("ab+c", "i")"#), "got:\n{}", src);
+    }
+
+    #[test]
+    fn non_regex_module_omits_regex_import_ts() {
+        let module = twig_to_semantic_ir::compile_source("(print (+ 1 2))", "demo").expect("lower");
+        let a = compile(&module).expect("compile");
+        assert!(!a.source.contains("sir-runtime-regex"), "got:\n{}", a.source);
+    }
 }

--- a/code/packages/rust/semantic-ir-to-typescript/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-typescript/src/runtime.rs
@@ -41,6 +41,13 @@ pub const RUNTIME_EXC: &str = r##"import * as __SirExc from "@coding-adventures/
 pub const RUNTIME_PAIRS: &str = r##"import * as __SirPairs from "@coding-adventures/sir-runtime-pairs";
 "##;
 
+/// The regex-runtime import, emitted **only** when a module calls the `regex`
+/// builtin (a Ruby `/pat/flags` literal).  Bound as `__SirRegex`; provides a
+/// native `RegExp` compiler with Ruby→JS flag translation.  See
+/// `code/specs/sir-runtime.md`.
+pub const RUNTIME_REGEX: &str = r##"import * as __SirRegex from "@coding-adventures/sir-runtime-regex";
+"##;
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/code/packages/typescript/sir-runtime-regex/BUILD
+++ b/code/packages/typescript/sir-runtime-regex/BUILD
@@ -1,0 +1,10 @@
+load("code/packages/starlark/library-rules/typescript_library.star", "ts_library")
+
+_targets = [
+    ts_library(
+        name = "sir-runtime-regex",
+        srcs = ["src/**/*.ts", "tests/**/*.ts"],
+        deps = [],
+        test_runner = "vitest",
+    ),
+]

--- a/code/packages/typescript/sir-runtime-regex/BUILD_windows
+++ b/code/packages/typescript/sir-runtime-regex/BUILD_windows
@@ -1,0 +1,3 @@
+npm ci --quiet
+npx tsc --noEmit
+npx vitest run --coverage

--- a/code/packages/typescript/sir-runtime-regex/CHANGELOG.md
+++ b/code/packages/typescript/sir-runtime-regex/CHANGELOG.md
@@ -1,0 +1,35 @@
+# Changelog
+
+## 0.1.0 — initial release
+
+First release of the SIR regex runtime for TypeScript/JavaScript, per
+`code/specs/sir-runtime.md`. Provides the runtime landing point for the SIR
+`regex` builtin — the Ruby→SIR frontend lowers `/pat/flags` to
+`BuiltinCall("regex", [StrLit pattern, StrLit flags])`, which previously had no
+TypeScript runtime, so emitted code using a regex failed.
+
+### Added
+
+- `compile(pattern, flags=""): RegExp` — build a Ruby-dialect `RegExp`,
+  translating Ruby inline flags to JS flags (`i`→`i`, `m`→`s` since Ruby `/m` is
+  dot-matches-newline/dotAll, `x`→strip whitespace+comments since JS has no
+  extended flag; unknown chars ignored) and **always** including the JS `m` flag
+  because Ruby's `^`/`$` are always line anchors. Flags are de-duplicated.
+- `isMatch(pattern, s): boolean` — unanchored search (Ruby `=~`/`match?`
+  semantics); accepts a `RegExp` or a raw string; a `RegExp` is cloned without
+  `g`/`y` so a stale `lastIndex` cannot leak across calls.
+- `matchData(pattern, s): string | null` — matched substring (`match[0]`) or
+  `null`; minimal model of Ruby `String#match`.
+- `stripExtended(pattern): string` — best-effort `/x` subset: strip unescaped
+  whitespace and `#` comments while preserving escaped whitespace/`#`.
+- `Val` — the universal SIR value type alias at this boundary.
+- Full standard layout: `package.json`, `tsconfig.json`, `vitest.config.ts`,
+  `BUILD`, `BUILD_windows`, `required_capabilities.json` (no capabilities),
+  README. vitest suite at 100% coverage; `tsc --strict` clean.
+
+### Design note
+
+The Ruby→JS divergence is concentrated in the flag mapping, the unconditional
+JS `m` flag (Ruby line anchors), and the `x`/extended approximation (JS has no
+extended-mode flag). The shared Perl-compatible syntax passes straight through
+to the `RegExp` engine.

--- a/code/packages/typescript/sir-runtime-regex/README.md
+++ b/code/packages/typescript/sir-runtime-regex/README.md
@@ -1,0 +1,78 @@
+# @coding-adventures/sir-runtime-regex
+
+Regex runtime for **Semantic-IR-emitted TypeScript/JavaScript**.
+
+The Ruby→SIR frontend lowers a regex literal `/pat/flags` to
+`BuiltinCall("regex", [StrLit pattern, StrLit flags])`. Emitted TypeScript needs
+a runtime landing point for that builtin — one that builds a native `RegExp`
+while translating Ruby's flag spellings and line-anchor conventions. That
+runtime is this package.
+
+## Where it fits in the stack
+
+```
+Ruby source ─▶ ruby-to-semantic-ir ─▶ Semantic IR ─▶ semantic-ir-to-typescript ─▶ .ts
+                                                                                  │ imports
+                                                                                  ▼
+                                                              @coding-adventures/sir-runtime-regex
+```
+
+The TypeScript backend emits an import of this package only when a module uses a
+regex; pure modules never gain the dependency.
+
+## Why a translation layer — Ruby's dialect differs from JS `RegExp`
+
+Both engines are Perl-compatible, so most *syntax* (`\d`, `[a-z]`, `(?:...)`,
+`a|b`) is shared. They diverge in three places:
+
+| Ruby flag char | JS flag | Meaning |
+|---|---|---|
+| `i` | `i` | Case-insensitive matching. |
+| `m` | `s` | Ruby `/m` ("multiline") makes `.` match a newline — this is JS's *dotAll* (`s`), **not** JS's `m`. The shared letter is a foot-gun. |
+| `x` | (none) | "Extended" mode — ignore unescaped whitespace and `#` comments. JS has no equivalent flag, so the pattern text is preprocessed with `stripExtended` (best-effort subset). |
+| (any other) | — | Unknown flag characters are silently dropped. |
+
+**The `^` / `$` nuance.** In Ruby, `^` and `$` *always* anchor to the start/end
+of a **line** — the whole-string anchors are `\A` and `\z`/`\Z`. In JS the
+default is the opposite (`^`/`$` anchor the whole string unless `m` is set). So
+this package **always includes the JS `m` flag** to make Ruby patterns behave
+faithfully.
+
+**Match semantics.** Ruby's `=~` / `String#match?` perform an *unanchored
+search*, not a full-string match. `isMatch` / `matchData` therefore use
+`.test` / `.exec` on a fresh non-global RegExp (so a stale `lastIndex` from a
+global/sticky regex never leaks across calls).
+
+## API
+
+| Export | Purpose |
+|---|---|
+| `compile(pattern, flags=""): RegExp` | Build a Ruby-dialect `RegExp` under Ruby-dialect flags (always line-anchored; `x` strips ignorable whitespace/comments). |
+| `isMatch(pattern, s): boolean` | True iff an unanchored search matches (Ruby `=~`/`match?`). Accepts a `RegExp` or a raw string. |
+| `matchData(pattern, s): string \| null` | The matched substring (`match[0]`), or `null` on no match (minimal `String#match`). |
+| `stripExtended(pattern): string` | Best-effort `/x` subset: strip unescaped whitespace and `#` comments. |
+| `Val` | The universal SIR value type alias (`any`) at this boundary. |
+
+## Usage
+
+```ts
+import { compile, isMatch, matchData } from "@coding-adventures/sir-runtime-regex";
+
+const re = compile("\\d+", "i");     // Ruby /\d+/i
+isMatch(re, "abc 42");               // true   (unanchored search, like Ruby =~)
+isMatch("\\d+", "no digits");        // false  (raw string also accepted)
+matchData("\\d+", "abc 42 xyz");     // "42"   (group 0)
+matchData("\\d+", "none");           // null   (no match)
+```
+
+## Development
+
+```bash
+npm ci
+npx tsc --noEmit      # strict typecheck
+npx vitest run --coverage
+```
+
+## License
+
+MIT

--- a/code/packages/typescript/sir-runtime-regex/package-lock.json
+++ b/code/packages/typescript/sir-runtime-regex/package-lock.json
@@ -1,0 +1,1552 @@
+{
+  "name": "@coding-adventures/sir-runtime-regex",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@coding-adventures/sir-runtime-regex",
+      "version": "0.1.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@vitest/coverage-v8": "^4.1.0",
+        "typescript": "^5.0.0",
+        "vitest": "^4.1.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.7"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.5.tgz",
+      "integrity": "sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.133.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.133.0.tgz",
+      "integrity": "sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.3.tgz",
+      "integrity": "sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.3.tgz",
+      "integrity": "sha512-PcAhP+ynjURNyy8SKGl5DQP94aGuB/7JrXJb/t7P+hanXvQVMWzUvRRhBAcg/lNRadBhoUPqSoP4xw5tR/KBEA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.3.tgz",
+      "integrity": "sha512-9YpfeUvSE2RS7wysJ81uOZkXJz7f7Q55H2Gvp3VEw/EsahqDtrphrZ0EwDLK5vvKOzaCrBsjF8JmnMLcUt78Gg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.3.tgz",
+      "integrity": "sha512-yB1IlAsSNHncV6SCTL27/MVGR5htvQsoGxIv5KMGXALp+Ll1wYsn+x98M9MW7qa+NdSbvrrY7ANI4wLJ0n1e6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.3.tgz",
+      "integrity": "sha512-Yi30IVAAfLUCy2MseFjbB1jAMDl1VMCAas5StnYp8da9+CKvMd2H2cbEjWcw5NPaPqzvYkVIaF1nNUG+b7u/sw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.3.tgz",
+      "integrity": "sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.3.tgz",
+      "integrity": "sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.3.tgz",
+      "integrity": "sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.3.tgz",
+      "integrity": "sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.3.tgz",
+      "integrity": "sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.3.tgz",
+      "integrity": "sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.3.tgz",
+      "integrity": "sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.3.tgz",
+      "integrity": "sha512-JTtb8BWFynicNSoPrehsCzBtOKjZ6jhMiPFEmOiuXg1Fl8dn2KHQob+GuPSGR0dryQa1PQJbzjF3dqO/whhjLg==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.3.tgz",
+      "integrity": "sha512-gEdFFEN70A/jxb2svrWsN3aDL7OUtmvlOy+6fa2jxG8K0wQ1ZbdeLGnidov6Yu5/733dI5ySfzFlQ/cb0bSz1g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.3.tgz",
+      "integrity": "sha512-eXB7CHuaQdqmJcc3koCNtNPmT/bj2gc999kUFgBxG8Ac0NdgXc4rkCHhqrgrhN3zddvvvrgzj1e90SuSfmyIXA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
+      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.9.tgz",
+      "integrity": "sha512-G9/lgqibheLVBDRuya45EbsEXTYcWoSG+TLg7i2axuzx0Eq62eXn+aWXyaVdV5vKvFSWd6ywcX8hA7la9Pvu8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.1.9",
+        "ast-v8-to-istanbul": "^1.0.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.1.9",
+        "vitest": "4.1.9"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.9.tgz",
+      "integrity": "sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.9.tgz",
+      "integrity": "sha512-EVkXzBjrPGM+cK8/ANWgBrkUCfJfb38/EfTSO8h7pWvKkyPkpWxvR7BkD2MyItMF62C97zAEoqdpUixwR/e+Rw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.9.tgz",
+      "integrity": "sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.9.tgz",
+      "integrity": "sha512-KXLMDtc7oe70+3mJfGrPUWPesswH+3sTxAMAMl8DG7I8IUQT4XW718dY5ID3vPUcmlu27CcKfY4P3h3I29SLJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.9",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.9.tgz",
+      "integrity": "sha512-Jc7RKGNBo8Z28WYIm0Niej4xdSPByRf6mU58VpHQkd6Zh05rlnA+twjbK5HyeIGHxrzsc3mJgS43uM0CZKzaIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.9.tgz",
+      "integrity": "sha512-fHpsS6mIi+PiEW+vcRVOMkX1oSaPKne3VOclSFICPcGOmfKgXPU5iAah+wcNcj2xPrCCmfq99IDGf+EojhhvhA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.9.tgz",
+      "integrity": "sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.9",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.4.tgz",
+      "integrity": "sha512-0bC0/4bTSrnwdhU3IsZDwEdojvuPrSg59OYZfKsLRtJZ0u8VBx9DebfqqG8bRdCC0I7vjgxmPi41P0lpkhJHtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.3.tgz",
+      "integrity": "sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.3",
+        "@babel/types": "^7.29.0",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
+      "integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.3.tgz",
+      "integrity": "sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.133.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.0.3",
+        "@rolldown/binding-darwin-arm64": "1.0.3",
+        "@rolldown/binding-darwin-x64": "1.0.3",
+        "@rolldown/binding-freebsd-x64": "1.0.3",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.3",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.3",
+        "@rolldown/binding-linux-arm64-musl": "1.0.3",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.3",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.3",
+        "@rolldown/binding-linux-x64-gnu": "1.0.3",
+        "@rolldown/binding-linux-x64-musl": "1.0.3",
+        "@rolldown/binding-openharmony-arm64": "1.0.3",
+        "@rolldown/binding-wasm32-wasi": "1.0.3",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.3",
+        "@rolldown/binding-win32-x64-msvc": "1.0.3"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
+      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/vite": {
+      "version": "8.0.16",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.16.tgz",
+      "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.15",
+        "rolldown": "1.0.3",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.1.18",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.9.tgz",
+      "integrity": "sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.9",
+        "@vitest/mocker": "4.1.9",
+        "@vitest/pretty-format": "4.1.9",
+        "@vitest/runner": "4.1.9",
+        "@vitest/snapshot": "4.1.9",
+        "@vitest/spy": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.9",
+        "@vitest/browser-preview": "4.1.9",
+        "@vitest/browser-webdriverio": "4.1.9",
+        "@vitest/coverage-istanbul": "4.1.9",
+        "@vitest/coverage-v8": "4.1.9",
+        "@vitest/ui": "4.1.9",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    }
+  }
+}

--- a/code/packages/typescript/sir-runtime-regex/package.json
+++ b/code/packages/typescript/sir-runtime-regex/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@coding-adventures/sir-runtime-regex",
+  "version": "0.1.0",
+  "description": "Regex runtime for Semantic-IR-emitted TypeScript/JavaScript — the SIR `regex` builtin with Ruby→JS flag translation and unanchored-search match semantics",
+  "type": "module",
+  "main": "src/index.ts",
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage"
+  },
+  "keywords": [
+    "sir",
+    "semantic-ir",
+    "runtime",
+    "regex",
+    "regexp",
+    "compiler",
+    "cross-language",
+    "education"
+  ],
+  "author": "Adhithya Rajasekaran",
+  "license": "MIT",
+  "devDependencies": {
+    "typescript": "^5.0.0",
+    "vitest": "^4.1.0",
+    "@vitest/coverage-v8": "^4.1.0"
+  }
+}

--- a/code/packages/typescript/sir-runtime-regex/required_capabilities.json
+++ b/code/packages/typescript/sir-runtime-regex/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "typescript/sir-runtime-regex",
+  "capabilities": [],
+  "justification": "Pure in-process regular-expression compilation using the built-in RegExp engine with Ruby→JavaScript flag translation. No filesystem, network, process, or environment access."
+}

--- a/code/packages/typescript/sir-runtime-regex/src/index.ts
+++ b/code/packages/typescript/sir-runtime-regex/src/index.ts
@@ -1,0 +1,145 @@
+/**
+ * Regular expressions — the SIR `regex` builtin (Ruby dialect on JS `RegExp`).
+ *
+ * The Ruby→SIR frontend lowers a regex literal `/pat/flags` to
+ * `BuiltinCall("regex", [StrLit pattern, StrLit flags])`. This module is the
+ * *TypeScript/JavaScript* landing point for that builtin: it builds a native
+ * `RegExp`, translating Ruby's flag and anchoring conventions so the compiled
+ * object behaves the way the Ruby source intended.
+ *
+ * **Why a translation layer — Ruby's dialect differs from JS `RegExp`.** Both
+ * descend from Perl-compatible regular expressions, so most *syntax* (`\d`,
+ * `[a-z]`, `(?:...)`, `a|b`, `+ * ?`) is shared. They diverge in how inline
+ * flags are spelled, in what `^`/`$` mean by default, and in extended mode:
+ *
+ * | Ruby flag | JS flag | Meaning |
+ * |-----------|---------|---------|
+ * | `i`       | `i`     | Case-insensitive matching. |
+ * | `m`       | `s`     | Ruby `/m` ("multiline") makes `.` match a newline — that is JS's *dotAll* (`s`), **not** JS's `m`. The shared letter is a foot-gun. |
+ * | `x`       | (none)  | "Extended" mode: ignore unescaped whitespace and `#` comments. JS has no equivalent flag, so we approximate by stripping them from the pattern text (best-effort subset — see {@link stripExtended}). |
+ * | (other)   | —       | Unknown flag characters are silently dropped. |
+ *
+ * **The `^`/`$` nuance.** In Ruby, `^` and `$` *always* anchor to the
+ * start/end of a **line** — the whole-string anchors are the separate escapes
+ * `\A` and `\z`/`\Z`. In JS the default is the opposite (`^`/`$` anchor the
+ * whole string unless the `m` flag is set). To behave faithfully we therefore
+ * **always include the JS `m` flag**. (`\A`/`\z` are not valid JS escapes, but
+ * the unconditional `m` covers the common Ruby line-anchor case.)
+ *
+ * **Match semantics.** Ruby's `=~` and `String#match?` perform an *unanchored
+ * search* — a hit anywhere counts, not a full-string match. {@link isMatch} and
+ * {@link matchData} therefore use `.test` / `.exec` on a non-global RegExp.
+ */
+
+/** The SIR universal value type at this package's boundary. */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type Val = any;
+
+/**
+ * Approximate Ruby's `/x` (extended / "verbose") mode by stripping the parts of
+ * the pattern that extended mode ignores: unescaped whitespace and `#`-to-end-of-line
+ * comments. JavaScript's `RegExp` has no extended flag, so this is a *best-effort
+ * subset* — it handles the common cases (laying a pattern out across lines with
+ * comments) but does not implement every nuance (e.g. whitespace inside a
+ * character class, which Ruby keeps literal, is also stripped here).
+ *
+ * A backslash escapes the following character, so `\#` keeps a literal `#` and
+ * `\ ` keeps a literal space; both are preserved verbatim.
+ */
+export function stripExtended(pattern: string): string {
+  let out = "";
+  let i = 0;
+  while (i < pattern.length) {
+    const ch = pattern[i];
+    if (ch === "\\") {
+      // An escape: keep the backslash and whatever it escapes, untouched.
+      out += pattern.slice(i, i + 2);
+      i += 2;
+      continue;
+    }
+    if (ch === "#") {
+      // A comment runs to the end of the line; drop it.
+      while (i < pattern.length && pattern[i] !== "\n") {
+        i += 1;
+      }
+      continue;
+    }
+    if (/\s/.test(ch)) {
+      // Unescaped whitespace is ignored in extended mode.
+      i += 1;
+      continue;
+    }
+    out += ch;
+    i += 1;
+  }
+  return out;
+}
+
+/**
+ * Compile a Ruby-dialect regex `pattern` under Ruby-dialect `flags`.
+ *
+ * `flags` is the inline-flag *string* exactly as it trails a Ruby literal —
+ * e.g. the `"imx"` of `/.../imx`. Each recognised character maps to a JS flag
+ * per the table in the module doc comment; unknown characters are ignored. The
+ * JS `m` flag is *always* included so Ruby's line-anchored `^`/`$` behave
+ * correctly. For `x` there is no JS flag, so the pattern text is preprocessed
+ * with {@link stripExtended} instead.
+ */
+export function compile(pattern: string, flags = ""): RegExp {
+  // Ruby's ^/$ are always line anchors, so 'm' is unconditional. A Set keeps
+  // the JS flag string de-duplicated and order-independent.
+  const jsFlags = new Set<string>(["m"]);
+  let source = pattern;
+  for (const ch of flags) {
+    if (ch === "i") {
+      jsFlags.add("i");
+    } else if (ch === "m") {
+      jsFlags.add("s"); // Ruby /m == dotAll == JS 's'.
+    } else if (ch === "x") {
+      // No JS equivalent: approximate by stripping ignorable whitespace/comments.
+      source = stripExtended(source);
+    }
+    // Any other character contributes nothing.
+  }
+  return new RegExp(source, [...jsFlags].join(""));
+}
+
+/**
+ * Build a fresh, non-global `RegExp` from `pattern`.
+ *
+ * Accepting a raw string compiles it with the default Ruby flag set (just the
+ * unconditional `m`). Accepting an existing `RegExp` clones it *without* the
+ * `g`/`y` flags — a global/sticky regex carries a mutable `lastIndex`, so
+ * reusing the caller's instance across `.test`/`.exec` calls would make results
+ * depend on prior calls. The clone makes each match independent.
+ */
+function fresh(pattern: RegExp | string): RegExp {
+  if (pattern instanceof RegExp) {
+    const flags = pattern.flags.replace(/[gy]/g, "");
+    return new RegExp(pattern.source, flags);
+  }
+  return compile(pattern);
+}
+
+/**
+ * True iff `pattern` matches anywhere in `s` (Ruby `=~` / `match?`).
+ *
+ * This is an *unanchored search*, mirroring Ruby semantics. `pattern` may be a
+ * `RegExp` or a raw pattern string; a `RegExp` is tested via a fresh non-global
+ * clone so a stale `lastIndex` cannot leak across calls.
+ */
+export function isMatch(pattern: RegExp | string, s: string): boolean {
+  return fresh(pattern).test(s);
+}
+
+/**
+ * Return the matched substring (match[0]), or `null` if there is no match.
+ *
+ * A minimal model of Ruby's `String#match`, which returns a truthy `MatchData`
+ * (whose `[0]` is the matched text) or `nil`. `pattern` may be a `RegExp` or a
+ * raw pattern string.
+ */
+export function matchData(pattern: RegExp | string, s: string): string | null {
+  const m = fresh(pattern).exec(s);
+  return m === null ? null : m[0];
+}

--- a/code/packages/typescript/sir-runtime-regex/tests/regex.test.ts
+++ b/code/packages/typescript/sir-runtime-regex/tests/regex.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from "vitest";
+import { compile, isMatch, matchData, stripExtended } from "../src/index.js";
+
+describe("compile — flag translation", () => {
+  it("always includes the JS 'm' flag even with no flags", () => {
+    // Ruby's ^/$ are always line anchors, so 'm' is unconditional.
+    const r = compile("a");
+    expect(r.flags).toContain("m");
+    expect(r.flags).not.toContain("i");
+    expect(r.flags).not.toContain("s");
+  });
+
+  it("maps 'i' to the JS 'i' flag", () => {
+    const r = compile("a", "i");
+    expect(r.flags).toContain("i");
+    expect(r.flags).toContain("m"); // still always on
+  });
+
+  it("maps Ruby 'm' to the JS 's' (dotAll) flag, not JS 'm' semantics", () => {
+    // Ruby /m means "dot matches newline" == JS dotAll ('s').
+    const r = compile(".", "m");
+    expect(r.flags).toContain("s");
+    expect(r.test("\n")).toBe(true); // dotAll lets "." span a newline
+    // Without Ruby /m, "." does not match a newline.
+    expect(compile(".").test("\n")).toBe(false);
+  });
+
+  it("maps 'x' by stripping whitespace/comments (no JS flag added)", () => {
+    const r = compile("a b", "x");
+    // No 'x'-equivalent flag exists in JS, so flags stay just 'm'.
+    expect(r.flags).not.toContain("x");
+    // The space was stripped, so the pattern matches "ab".
+    expect(r.test("ab")).toBe(true);
+  });
+
+  it("combines flags and de-duplicates", () => {
+    const r = compile("a", "iimm");
+    expect(r.flags).toContain("i");
+    expect(r.flags).toContain("s");
+    expect(r.flags).toContain("m");
+    // No duplicate characters in the JS flag string.
+    expect(new Set(r.flags).size).toBe(r.flags.length);
+  });
+
+  it("ignores unknown flag characters", () => {
+    const r = compile("a", "zoiu");
+    expect(r.flags).toContain("i");
+    expect(r.flags).toContain("m");
+  });
+});
+
+describe("stripExtended", () => {
+  it("removes unescaped whitespace and # comments", () => {
+    expect(stripExtended("a b\tc")).toBe("abc");
+    expect(stripExtended("a # this is a comment\nb")).toBe("ab");
+  });
+
+  it("preserves escaped whitespace and escaped #", () => {
+    expect(stripExtended("a\\ b")).toBe("a\\ b");
+    expect(stripExtended("a\\#b")).toBe("a\\#b");
+  });
+});
+
+describe("isMatch — unanchored search", () => {
+  it("is true when the pattern matches anywhere", () => {
+    // Ruby =~ is unanchored: a hit anywhere counts, not fullmatch.
+    expect(isMatch("\\d+", "abc 42 xyz")).toBe(true);
+  });
+
+  it("is false when there is no match", () => {
+    expect(isMatch("\\d+", "no digits here")).toBe(false);
+  });
+
+  it("accepts a precompiled RegExp without a lastIndex bug across calls", () => {
+    // A global regex carries a mutable lastIndex; fresh() must clone away 'g'
+    // so repeated calls are independent.
+    const re = /\d+/g;
+    expect(isMatch(re, "a1")).toBe(true);
+    expect(isMatch(re, "a1")).toBe(true); // would flip to false if lastIndex leaked
+    expect(isMatch(re, "none")).toBe(false);
+  });
+});
+
+describe("matchData — group 0 or null", () => {
+  it("returns the matched substring", () => {
+    expect(matchData("\\d+", "abc 42 xyz")).toBe("42");
+  });
+
+  it("returns null on no match", () => {
+    expect(matchData("\\d+", "no digits")).toBe(null);
+  });
+
+  it("accepts a precompiled RegExp", () => {
+    expect(matchData(/[a-z]+/, "  HELLO world")).toBe("world");
+  });
+});

--- a/code/packages/typescript/sir-runtime-regex/tsconfig.json
+++ b/code/packages/typescript/sir-runtime-regex/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}

--- a/code/packages/typescript/sir-runtime-regex/vitest.config.ts
+++ b/code/packages/typescript/sir-runtime-regex/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    coverage: {
+      provider: "v8",
+      thresholds: {
+        lines: 80,
+      },
+    },
+  },
+});


### PR DESCRIPTION
## Q8(b) — `regex` builtin → `sir-runtime-regex`

Probe-first confirmed the Ruby frontend lowers `/pat/flags` to
`BuiltinCall("regex", [pattern, flags])`, which previously hit the
unknown-builtin dispatch and failed at runtime. Now emitted code calls a
dedicated per-concern regex runtime.

### New packages: `sir-runtime-regex` (py + ts)
Full standard layout; **14 + 14 tests @ 100%; `mypy --strict`/`ruff` + `tsc --strict` clean; dependency-free.**
- `compile(pattern, flags)` → native `re.Pattern` / `RegExp` with Ruby→target flag translation (`i`→IGNORECASE/`i`, `m`→DOTALL/`s`, `x`→VERBOSE / extended-strip; Ruby line-anchored `^`/`$` → always MULTILINE/`m`; unknown flags ignored).
- `is_match`/`isMatch` (unanchored search, Ruby `=~` semantics) and `match_data`/`matchData` (group 0 or nil); accept a precompiled pattern or a raw string.

### Backends (`semantic-ir-to-python` 0.1.10, `semantic-ir-to-typescript` 0.1.9)
- `BuiltinCall("regex", …)` → `_sir_regex_compile(...)` / `__SirRegex.compile(...)`.
- New gated `RUNTIME_REGEX` import emitted **only** when a module calls the `regex` builtin. Regex carries no SIR `Feature`, so the gate (`uses_regex`) is an **exhaustive content walk** over `Stmt`/`Expr` finding a `BuiltinCall` by name (compiler enforces completeness — no silent under-gating).

### Verification
- `cargo test`: typescript **346**, python **49**, ruby-to-semantic-ir **59** — all green. New direct-SIR emit + omit-import tests both backends.
- Python emitted-call **exec-proofed on CPython** against the real package (case-insensitive search + unanchored `is_match`); TS covered by the package's own vitest (100%).
- `/security-review`: PASSED (pattern/flags escaped via `quote_*_string`; ReDoS surface is author-supplied patterns only — no new untrusted path; exhaustive non-panicking content-walk; no eval/network/fs).

### Remaining Q8
`sir-runtime-shell` (backtick) and the builtin audit land in follow-up PRs (probe-first).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
