### PR TITLE
feat(sir-shell): backtick builtin → sir-runtime-shell (gated import)

### DIFF
--- a/code/packages/python/sir-runtime-shell/BUILD
+++ b/code/packages/python/sir-runtime-shell/BUILD
@@ -1,0 +1,5 @@
+uv venv --quiet --clear
+uv pip install -e .[dev] --quiet
+.venv/bin/python -m ruff check src tests
+.venv/bin/python -m mypy
+.venv/bin/python -m pytest tests/ -v

--- a/code/packages/python/sir-runtime-shell/BUILD_windows
+++ b/code/packages/python/sir-runtime-shell/BUILD_windows
@@ -1,0 +1,5 @@
+uv venv --quiet --clear
+uv pip install -e .[dev] --quiet
+.venv\Scripts\python.exe -m ruff check src tests
+.venv\Scripts\python.exe -m mypy
+.venv\Scripts\python.exe -m pytest tests/ -v

--- a/code/packages/python/sir-runtime-shell/CHANGELOG.md
+++ b/code/packages/python/sir-runtime-shell/CHANGELOG.md
@@ -1,0 +1,34 @@
+# Changelog
+
+## 0.1.0 — initial release
+
+First release of the SIR shell runtime for Python, per
+`code/specs/sir-runtime.md`. Provides the runtime landing point for the SIR
+`backtick` builtin — the Ruby→SIR frontend lowers a backtick literal `` `cmd` ``
+to `BuiltinCall("backtick", [StrLit cmd])`, which previously had no Python
+runtime, so emitted code using a backtick failed. Python mirror of
+`@coding-adventures/sir-runtime-shell` (TypeScript).
+
+### Added
+
+- `backtick(command) -> str` — run `command` via the system shell and return its
+  captured stdout as a `str`, modelling Ruby's `` `cmd` `` expression. Implemented
+  with `subprocess.run(command, shell=True, capture_output=True, text=True,
+  check=False)`. The child's exit status is ignored (`check=False`), so a non-zero
+  exit still returns whatever stdout was produced; stderr is captured by the call
+  but not returned (Ruby's backtick value is stdout only).
+- `Val` — the universal SIR value type alias at this boundary.
+- Full standard layout: `pyproject.toml` (src layout, hatchling), `BUILD`,
+  `BUILD_windows`, `required_capabilities.json` (one `process`/`spawn`
+  capability), `py.typed`, README. pytest suite at 100% coverage of `shell.py`;
+  `mypy --strict` + `ruff` clean.
+
+### Design note — `shell=True` is intentional
+
+`shell=True` is load-bearing, not an oversight: Ruby backtick is *defined* as
+"run via the system shell" (`/bin/sh -c`), so shell features (pipes,
+redirections, globbing, `$VAR`) are part of the builtin's contract. The
+`command` is author-supplied — the string literal from the compiled program's
+own Ruby source — and this package interpolates no external/untrusted runtime
+input, so it introduces no new injection surface beyond what Ruby itself grants.
+The package therefore declares a single `process`/`spawn` capability.

--- a/code/packages/python/sir-runtime-shell/README.md
+++ b/code/packages/python/sir-runtime-shell/README.md
@@ -1,0 +1,78 @@
+# coding-adventures-sir-runtime-shell
+
+Shell runtime for **Semantic-IR-emitted Python**.
+
+The Ruby→SIR frontend lowers a backtick literal `` `cmd` `` to
+`BuiltinCall("backtick", [StrLit cmd])`. Emitted Python needs a runtime landing
+point for that builtin — one that runs the command through the system shell and
+returns its stdout, exactly as Ruby's backtick expression does. That runtime is
+this package.
+
+## Where it fits in the stack
+
+```
+Ruby source ─▶ ruby-to-semantic-ir ─▶ Semantic IR ─▶ semantic-ir-to-python ─▶ .py
+                                                                             │ imports
+                                                                             ▼
+                                                       coding-adventures-sir-runtime-shell
+```
+
+The Python backend emits an import of this package only when a module uses a
+backtick; pure modules never gain the dependency.
+
+## What it does — Ruby backtick semantics
+
+In Ruby, `` `cmd` `` (and `%x{cmd}`) hands the whole command line to the system
+shell, waits for it, and evaluates to the command's **standard output** as a
+string. The child's exit status is recorded in `$?` but does *not* change the
+value — even a non-zero exit returns whatever was printed to stdout. Standard
+error is not captured by the expression. This package mirrors all of that:
+
+| Ruby backtick behaviour | Python implementation |
+|---|---|
+| runs via the system shell | `subprocess.run(..., shell=True)` |
+| returns captured stdout as a `str` | `capture_output=True, text=True` → `.stdout` |
+| ignores the child's exit status | `check=False` (never raises on non-zero exit) |
+| stderr goes to the parent | captured by the call but not returned |
+
+## Security — `shell=True` is intentional and author-supplied input only
+
+The internal `subprocess.run` uses `shell=True`. This is **load-bearing**: Ruby
+backtick is *defined* as "run via `/bin/sh -c`", so shell features (pipes,
+redirections, globbing, `$VAR`) are part of the builtin. Running without a shell
+would silently change the meaning of every compiled backtick.
+
+There is no new untrusted-input path. `command` is the string literal the
+programmer wrote inside the backticks of their *own* Ruby source, threaded
+verbatim through the compiler into the emitted Python. It carries exactly the
+trust level Ruby itself grants it — the author's own code — and this package
+interpolates **no** external or runtime-derived data into the command.
+
+## API
+
+| Export | Purpose |
+|---|---|
+| `backtick(command) -> str` | Run `command` via the system shell and return its captured stdout (Ruby `` `cmd` ``). Non-zero exits still return stdout. |
+| `Val` | The universal SIR value type alias (`Any`) at this boundary. |
+
+## Usage
+
+```python
+from coding_adventures_sir_runtime_shell import backtick
+
+backtick('python -c "print(123)"')   # "123\n"   (captured stdout)
+backtick('python -c "exit(1)"')      # ""        (non-zero exit → stdout still returned)
+```
+
+## Development
+
+```bash
+uv venv && uv pip install -e .[dev]
+.venv/bin/python -m ruff check src tests
+.venv/bin/python -m mypy
+.venv/bin/python -m pytest tests/ -v
+```
+
+## License
+
+MIT

--- a/code/packages/python/sir-runtime-shell/pyproject.toml
+++ b/code/packages/python/sir-runtime-shell/pyproject.toml
@@ -1,0 +1,57 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "coding-adventures-sir-runtime-shell"
+version = "0.1.0"
+description = "Shell runtime for Semantic-IR-emitted Python — the SIR `backtick` builtin runs a command via the system shell and returns its stdout (Ruby `cmd` semantics)"
+requires-python = ">=3.12"
+dependencies = []
+license = "MIT"
+authors = [{ name = "Adhithya Rajasekaran" }]
+readme = "README.md"
+keywords = ["sir", "semantic-ir", "runtime", "shell", "backtick", "subprocess", "compiler", "cross-language", "education"]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Education",
+    "Topic :: Education",
+    "Topic :: Software Development :: Compilers",
+    "Programming Language :: Python :: 3.12",
+    "License :: OSI Approved :: MIT License",
+    "Typing :: Typed",
+]
+
+[project.urls]
+Homepage = "https://github.com/adhithyan15/coding-adventures"
+Repository = "https://github.com/adhithyan15/coding-adventures"
+Documentation = "https://github.com/adhithyan15/coding-adventures/tree/main/code/specs/sir-runtime.md"
+
+[project.optional-dependencies]
+dev = ["pytest>=8.0", "pytest-cov>=5.0", "ruff>=0.4", "mypy>=1.10"]
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/coding_adventures_sir_runtime_shell"]
+
+[tool.ruff]
+target-version = "py312"
+line-length = 100
+
+[tool.ruff.lint]
+select = ["E", "W", "F", "I", "UP", "B", "SIM"]
+
+[tool.mypy]
+strict = true
+python_version = "3.12"
+files = ["src"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "--cov=coding_adventures_sir_runtime_shell --cov-report=term-missing --cov-fail-under=80"
+
+[tool.coverage.run]
+source = ["src/coding_adventures_sir_runtime_shell"]
+
+[tool.coverage.report]
+fail_under = 80
+show_missing = true

--- a/code/packages/python/sir-runtime-shell/required_capabilities.json
+++ b/code/packages/python/sir-runtime-shell/required_capabilities.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "python/sir-runtime-shell",
+  "capabilities": [
+    {
+      "category": "proc",
+      "action": "exec",
+      "target": "* (author-supplied command from a compiled Ruby backtick expression)",
+      "justification": "Implements Ruby backtick, which runs a command via the system shell and returns its stdout. The command is author-supplied from the compiled program's source (a string literal), mirroring Ruby's own backtick semantics; this package interpolates no external/untrusted runtime input."
+    }
+  ],
+  "justification": "Shells out via subprocess to implement the SIR `backtick` builtin (Ruby `cmd`): the author-supplied command is run through the system shell and its stdout returned. No filesystem, network, or environment access beyond spawning the one command."
+}

--- a/code/packages/python/sir-runtime-shell/src/coding_adventures_sir_runtime_shell/__init__.py
+++ b/code/packages/python/sir-runtime-shell/src/coding_adventures_sir_runtime_shell/__init__.py
@@ -1,0 +1,34 @@
+"""coding-adventures-sir-runtime-shell — the SIR ``backtick`` builtin for Python.
+
+The Ruby→SIR frontend lowers a backtick literal ``` `cmd` ``` to
+``BuiltinCall("backtick", [StrLit cmd])``.  This package is the Python runtime
+for that builtin: it runs the command through the system shell and returns the
+command's captured standard output as a ``str`` — Ruby ``` `cmd` ``` semantics::
+
+    from coding_adventures_sir_runtime_shell import backtick
+    backtick('python -c "print(123)"')   # "123\\n"
+
+**Shell semantics.**  Like Ruby's backtick, the command is handed to the system
+shell (``/bin/sh -c`` on POSIX, ``cmd.exe /c`` on Windows), so shell features —
+pipes, redirections, globbing, ``$VAR`` expansion — work.  The child's exit
+status is ignored: a non-zero exit still returns whatever stdout was produced.
+
+**Author-supplied command (SECURITY).**  ``command`` is the string literal the
+programmer wrote inside the backticks of their *own* Ruby source, threaded
+verbatim through the compiler into emitted Python.  It carries the same trust
+level it had in Ruby — the author's own code — and this package interpolates no
+external/untrusted runtime input.  The ``shell=True`` used internally is the
+intentional, faithful implementation of Ruby backtick; see
+:mod:`coding_adventures_sir_runtime_shell.shell` for the full SECURITY note.
+
+See ``code/specs/sir-runtime.md``.
+"""
+
+from __future__ import annotations
+
+from .shell import Val, backtick
+
+__all__ = [
+    "Val",
+    "backtick",
+]

--- a/code/packages/python/sir-runtime-shell/src/coding_adventures_sir_runtime_shell/shell.py
+++ b/code/packages/python/sir-runtime-shell/src/coding_adventures_sir_runtime_shell/shell.py
@@ -1,0 +1,98 @@
+"""Shell-out — the SIR ``backtick`` builtin (Ruby ``` `cmd` ``` on Python ``subprocess``).
+
+The Ruby→SIR frontend lowers a backtick literal ``` `cmd` ``` to
+``BuiltinCall("backtick", [StrLit cmd])``.  This module is the *Python* landing
+point for that builtin: it runs the command through the system shell and returns
+the command's captured standard output as a ``str``, exactly as Ruby's backtick
+expression does.
+
+**What Ruby backtick does — the contract we mirror.**  In Ruby, ``` `cmd` ```
+(and its twin ``%x{cmd}``) hands the *whole command line* to the system shell —
+on a POSIX host that is ``/bin/sh -c cmd`` — waits for it to finish, and
+evaluates to the command's standard output as a string.  The child's exit status
+is recorded in ``$?`` but it does **not** affect the value: even a command that
+exits non-zero yields whatever it printed to stdout (often the empty string).
+Standard error is *not* captured by the expression; it flows to the parent's
+stderr.  We reproduce all of this below.
+
+.. rubric:: Ruby ↔ Python mapping
+
+================================  ===================================================
+Ruby backtick behaviour            Python implementation
+================================  ===================================================
+runs via the system shell          ``subprocess.run(..., shell=True)``
+returns captured stdout as a str   ``capture_output=True, text=True`` → ``.stdout``
+ignores the child's exit status    ``check=False`` (never raises on non-zero exit)
+stderr goes to the parent          ``capture_output=True`` captures it but we drop it
+================================  ===================================================
+
+.. rubric:: SECURITY — why ``shell=True`` is intentional and load-bearing
+
+``subprocess.run`` is invoked with ``shell=True``.  In most Python code that is a
+red flag, because it invites shell-injection when *untrusted runtime input* is
+interpolated into the command string.  Here it is the opposite — it is *required*
+for faithful semantics, and there is no new untrusted-input path:
+
+* **Ruby backtick is defined as "run via the shell."**  Ruby always routes
+  ``` `cmd` ``` through ``/bin/sh -c``.  Shell metacharacters (pipes ``|``,
+  redirections ``>``, globbing ``*``, ``$VAR`` expansion, ``;`` sequencing) are
+  part of the feature.  Running the command *without* a shell would silently
+  change the meaning of every compiled Ruby program that uses a backtick, so
+  ``shell=True`` is the only correct choice for this builtin.
+* **The command is author-supplied, not attacker-supplied.**  ``command`` is the
+  string literal that the programmer wrote *inside the backticks of their own
+  Ruby source*, threaded verbatim through the compiler into the emitted Python.
+  It carries exactly the trust level it had in the original Ruby program — the
+  author's own code — which is precisely the trust level Ruby itself grants it.
+  This package introduces **no** new path by which external or runtime-derived
+  data reaches the shell; it interpolates nothing.  An author who writes a
+  dangerous backtick in Ruby gets the same danger here, no more and no less.
+
+Because the regex sibling package selects only the ruff rule families
+``["E", "W", "F", "I", "UP", "B", "SIM"]`` (no flake8-bandit ``S`` rules), this
+``shell=True`` call is *not* flagged by ruff, so no ``# noqa: S602`` is needed —
+the comment is omitted deliberately to keep the source clean.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from typing import Any
+
+# The SIR universal value type at this package's boundary.  ``backtick`` deals in
+# plain ``str`` for its argument and result, but ``Val`` is re-exported so callers
+# and emitted code can refer to the SIR boundary type by a single shared name,
+# matching the other ``sir-runtime-*`` packages.
+Val = Any
+
+
+def backtick(command: str) -> str:
+    """Run ``command`` via the system shell and return its captured stdout.
+
+    This is the runtime for the SIR ``backtick`` builtin, modelling Ruby's
+    ``` `cmd` ``` expression.  The command is passed to the system shell
+    (``/bin/sh -c`` on POSIX, ``cmd.exe /c`` on Windows), run to completion, and
+    its standard output returned as a ``str``.
+
+    The child's exit status is **ignored** (``check=False``): like Ruby, a
+    command that exits non-zero still returns whatever it wrote to stdout (which
+    may be the empty string).  Standard error is captured by the subprocess call
+    but not returned — mirroring Ruby, where the backtick value is stdout only.
+
+    See the module docstring for the full Ruby↔Python mapping table and the
+    SECURITY note explaining why ``shell=True`` is intentional and safe here (the
+    command is author-supplied from the compiled program's own source, exactly as
+    in Ruby; no untrusted runtime input is interpolated).
+    """
+    # shell=True is intentional and load-bearing — Ruby backtick always runs the
+    # command through the system shell, so faithful SIR semantics require it. The
+    # command is author-supplied (a string literal from the compiled Ruby
+    # program); see the module-level SECURITY docstring.
+    result = subprocess.run(
+        command,
+        shell=True,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return result.stdout

--- a/code/packages/python/sir-runtime-shell/tests/test_shell.py
+++ b/code/packages/python/sir-runtime-shell/tests/test_shell.py
@@ -1,0 +1,71 @@
+"""Unit tests for the SIR Python shell (``backtick``) runtime.
+
+The commands are written with ``python -c "..."`` (via :data:`sys.executable`)
+rather than ``echo`` so they behave identically on Windows ``cmd.exe`` and POSIX
+``/bin/sh`` — ``echo``'s quoting and flag handling differ across those shells,
+whereas a Python one-liner is deterministic everywhere.
+"""
+
+from __future__ import annotations
+
+import sys
+
+from coding_adventures_sir_runtime_shell import Val, backtick
+
+
+def _py(code: str) -> str:
+    """Build a portable ``python -c "<code>"`` command line for the host shell."""
+    # Quote the interpreter path (it may contain spaces, e.g. on Windows) and
+    # wrap the code in double quotes; the code itself uses only single quotes.
+    return f'"{sys.executable}" -c "{code}"'
+
+
+class TestBacktick:
+    def test_returns_captured_stdout(self) -> None:
+        # The canonical case: stdout of the command comes back as a str.
+        out = backtick(_py("print(123)"))
+        assert "123" in out
+
+    def test_returns_str_type(self) -> None:
+        out = backtick(_py("print('hi')"))
+        assert isinstance(out, str)
+        assert "hi" in out
+
+    def test_no_trailing_newline_when_print_end_empty(self) -> None:
+        # Using end='' means the only output is the bare token, exactly.
+        out = backtick(_py("import sys; sys.stdout.write('exact')"))
+        assert out == "exact"
+
+    def test_multiline_output_preserved(self) -> None:
+        # Two print() calls yield two lines; both must survive in order.
+        out = backtick(_py("print('line1'); print('line2')"))
+        assert "line1" in out
+        assert "line2" in out
+        assert out.index("line1") < out.index("line2")
+
+    def test_nonzero_exit_still_returns_stdout(self) -> None:
+        # check=False: a command that prints then exits non-zero still yields
+        # its stdout (Ruby returns stdout regardless of $?).
+        out = backtick(
+            _py("import sys; sys.stdout.write('partial'); sys.exit(3)")
+        )
+        assert out == "partial"
+
+    def test_nonzero_exit_with_no_stdout_returns_empty(self) -> None:
+        # A failure that prints nothing to stdout yields the empty string, not
+        # an exception.
+        out = backtick(_py("import sys; sys.exit(5)"))
+        assert out == ""
+
+    def test_stderr_is_not_part_of_the_result(self) -> None:
+        # Only stdout is returned; data written to stderr must not leak in.
+        out = backtick(
+            _py("import sys; sys.stderr.write('ERR'); sys.stdout.write('OUT')")
+        )
+        assert out == "OUT"
+        assert "ERR" not in out
+
+    def test_val_is_exported(self) -> None:
+        # The SIR boundary type alias is re-exported for parity with the other
+        # sir-runtime-* packages.
+        assert Val is not None

--- a/code/packages/rust/semantic-ir-to-python/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-python/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## 0.1.11 — backtick builtin → sir-runtime-shell (gated import)
+
+The Ruby `` `cmd` `` backtick literal lowers to `BuiltinCall("backtick",
+[cmd])`, which previously hit the unknown-builtin dispatch and failed at
+runtime. It now emits a call into the new `coding-adventures-sir-runtime-shell`
+package (thin subprocess wrapper: run via the system shell, return stdout —
+Ruby backtick semantics), per `code/specs/sir-runtime.md`.
+
+- `BuiltinCall("backtick", …)` → `_sir_shell_backtick(cmd)`.
+- New gated `RUNTIME_SHELL` import header, appended **only** when a module calls
+  the `backtick` builtin (gate `uses_shell`, reusing the `module_uses_builtin`
+  content walk).
+- New direct-SIR tests assert the gated import + `_sir_shell_backtick("echo
+  hi")` and that a non-shell module omits the import. Exec-proofed on CPython
+  against the real package (`` `python -c "print(7*6)"` `` → `42`). The shell
+  command is **author-supplied** from the compiled program's source (a string
+  literal), mirroring Ruby's own backtick — no new untrusted-input path; the
+  package declares a `proc`/`exec` capability.
+
 ## 0.1.10 — regex builtin → sir-runtime-regex (gated import)
 
 The Ruby `/pat/flags` literal lowers to `BuiltinCall("regex", [pattern,

--- a/code/packages/rust/semantic-ir-to-python/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-python/src/emit.rs
@@ -52,6 +52,13 @@ fn uses_regex(m: &Module) -> bool {
     module_uses_builtin(m, "regex")
 }
 
+/// True if the module calls the `backtick` builtin (a Ruby `` `cmd` ``
+/// literal lowers to `BuiltinCall("backtick", [cmd])`).  Gates the
+/// `coding-adventures-sir-runtime-shell` import.
+fn uses_shell(m: &Module) -> bool {
+    module_uses_builtin(m, "backtick")
+}
+
 /// Walk every function body looking for a `BuiltinCall` named `name`.  Used to
 /// gate per-concern runtime imports for builtins that carry no `Feature` flag
 /// (e.g. `regex`).  Exhaustive over `Stmt`/`Expr` so a new node can't silently
@@ -183,6 +190,10 @@ pub fn emit_module(m: &Module) -> String {
     // Only regex-using modules import the regex runtime.
     if uses_regex(m) {
         out.push_str(crate::runtime::RUNTIME_REGEX);
+    }
+    // Only backtick-using modules import the shell runtime.
+    if uses_shell(m) {
+        out.push_str(crate::runtime::RUNTIME_SHELL);
     }
     emit_globals(&mut out, &m.globals);
     for f in &m.functions {
@@ -812,6 +823,14 @@ fn emit_builtin_call(out: &mut String, name: &str, args: &[Expr], indent: usize)
     // dedicated package's `compile`, gated by `uses_regex`.
     if name == "regex" {
         out.push_str("_sir_regex_compile(");
+        emit_args(out, args, indent);
+        out.push(')');
+        return;
+    }
+    // `backtick` (a Ruby `` `cmd` `` literal) → run via the shell runtime,
+    // returning the command's stdout.  Gated by `uses_shell`.
+    if name == "backtick" {
+        out.push_str("_sir_shell_backtick(");
         emit_args(out, args, indent);
         out.push(')');
         return;

--- a/code/packages/rust/semantic-ir-to-python/src/lib.rs
+++ b/code/packages/rust/semantic-ir-to-python/src/lib.rs
@@ -984,4 +984,33 @@ mod tests {
         let a = compile(&module).expect("compile");
         assert!(!a.source.contains("sir_runtime_regex"), "got:\n{}", a.source);
     }
+
+    // ─── SIR backtick builtin → sir-runtime-shell (Q8c) ─────────────────────
+
+    #[test]
+    fn backtick_builtin_emits_shell_runtime_py() {
+        // `` `echo hi` `` lowers to BuiltinCall("backtick", [cmd]).
+        let bt = Expr::BuiltinCall {
+            name: "backtick".into(),
+            args: vec![Expr::StrLit { value: "echo hi".into(), span: s() }],
+            effects: EffectSet::PURE,
+            span: s(),
+        };
+        let m = module_with_main_body(vec![], bt, &[Feature::Strings]);
+        let a = compile(&m).expect("compile");
+        let src = &a.source;
+        assert!(
+            src.contains("from coding_adventures_sir_runtime_shell import backtick as _sir_shell_backtick"),
+            "got:\n{}",
+            src
+        );
+        assert!(src.contains("_sir_shell_backtick(\"echo hi\")"), "got:\n{}", src);
+    }
+
+    #[test]
+    fn non_shell_module_omits_shell_import_py() {
+        let module = twig_to_semantic_ir::compile_source("(print (+ 1 2))", "demo").expect("lower");
+        let a = compile(&module).expect("compile");
+        assert!(!a.source.contains("sir_runtime_shell"), "got:\n{}", a.source);
+    }
 }

--- a/code/packages/rust/semantic-ir-to-python/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-python/src/runtime.rs
@@ -64,6 +64,14 @@ from coding_adventures_sir_runtime_regex import (
 )
 "##;
 
+/// The shell-runtime import header, appended **only** when a module calls the
+/// `backtick` builtin (a Ruby `` `cmd` `` literal).  Provides a thin
+/// subprocess wrapper that runs the command via the system shell and returns
+/// its stdout; see `code/specs/sir-runtime.md`.
+pub const RUNTIME_SHELL: &str = r##"# ── SIR shell runtime (imported from coding-adventures-sir-runtime-shell) ──
+from coding_adventures_sir_runtime_shell import backtick as _sir_shell_backtick
+"##;
+
 pub const RUNTIME: &str = r##"# ── SIR runtime (imported from coding-adventures-sir-runtime-core) ──
 from coding_adventures_sir_runtime_core import (
     truthy as _sir_truthy,

--- a/code/packages/rust/semantic-ir-to-typescript/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-typescript/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## 0.1.10 — backtick builtin → sir-runtime-shell (gated import)
+
+The Ruby `` `cmd` `` backtick literal lowers to `BuiltinCall("backtick",
+[cmd])`, which previously hit the unknown-builtin dispatch and threw at runtime.
+It now emits a call into the new `@coding-adventures/sir-runtime-shell` package
+(thin `child_process.execSync` wrapper: run via the system shell, return stdout
+— Ruby backtick semantics), per `code/specs/sir-runtime.md`.
+
+- `BuiltinCall("backtick", …)` → `__SirShell.backtick(cmd)`.
+- New gated `RUNTIME_SHELL` import, emitted **only** when a module calls the
+  `backtick` builtin (gate `uses_shell`, reusing the `module_uses_builtin`
+  content walk).
+- New direct-SIR tests assert the gated import + `__SirShell.backtick("echo
+  hi")` and that a non-shell module omits the import. The runtime package's own
+  vitest suite covers execution. The shell command is **author-supplied** from
+  the compiled program's source — no new untrusted-input path; the package
+  declares a `proc`/`exec` capability.
+
 ## 0.1.9 — regex builtin → sir-runtime-regex (gated import)
 
 The Ruby `/pat/flags` literal lowers to `BuiltinCall("regex", [pattern,

--- a/code/packages/rust/semantic-ir-to-typescript/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-typescript/src/emit.rs
@@ -61,6 +61,13 @@ fn uses_regex(m: &Module) -> bool {
     module_uses_builtin(m, "regex")
 }
 
+/// True if the module calls the `backtick` builtin (a Ruby `` `cmd` ``
+/// literal lowers to `BuiltinCall("backtick", [cmd])`).  Gates the
+/// `@coding-adventures/sir-runtime-shell` import.
+fn uses_shell(m: &Module) -> bool {
+    module_uses_builtin(m, "backtick")
+}
+
 /// Walk every function body for a `BuiltinCall` named `name` — gates
 /// per-concern imports for builtins that carry no `Feature` flag.  Exhaustive
 /// over `Stmt`/`Expr` so a new node can't silently hide a use.
@@ -203,6 +210,10 @@ pub fn emit_module(m: &Module) -> String {
     // Only regex-using modules import the regex runtime.
     if uses_regex(m) {
         out.push_str(crate::runtime::RUNTIME_REGEX);
+    }
+    // Only backtick-using modules import the shell runtime.
+    if uses_shell(m) {
+        out.push_str(crate::runtime::RUNTIME_SHELL);
     }
     emit_globals(&mut out, &m.globals);
     for f in &m.functions {
@@ -941,6 +952,14 @@ fn emit_builtin_call(out: &mut String, name: &str, args: &[Expr], indent: usize)
     // `uses_regex`.
     if name == "regex" {
         out.push_str("__SirRegex.compile(");
+        emit_args(out, args, indent);
+        out.push(')');
+        return;
+    }
+    // `backtick` (a Ruby `` `cmd` `` literal) → run via the shell runtime,
+    // returning the command's stdout.  Gated by `uses_shell`.
+    if name == "backtick" {
+        out.push_str("__SirShell.backtick(");
         emit_args(out, args, indent);
         out.push(')');
         return;

--- a/code/packages/rust/semantic-ir-to-typescript/src/lib.rs
+++ b/code/packages/rust/semantic-ir-to-typescript/src/lib.rs
@@ -873,4 +873,32 @@ mod tests {
         let a = compile(&module).expect("compile");
         assert!(!a.source.contains("sir-runtime-regex"), "got:\n{}", a.source);
     }
+
+    // ─── SIR backtick builtin → sir-runtime-shell (Q8c) ─────────────────────
+
+    #[test]
+    fn backtick_builtin_emits_shell_runtime_ts() {
+        let bt = Expr::BuiltinCall {
+            name: "backtick".into(),
+            args: vec![Expr::StrLit { value: "echo hi".into(), span: s() }],
+            effects: EffectSet::PURE,
+            span: s(),
+        };
+        let m = module_with_main_body(vec![], bt, &[Feature::Strings]);
+        let a = compile(&m).expect("compile");
+        let src = &a.source;
+        assert!(
+            src.contains(r#"import * as __SirShell from "@coding-adventures/sir-runtime-shell";"#),
+            "got:\n{}",
+            src
+        );
+        assert!(src.contains(r#"__SirShell.backtick("echo hi")"#), "got:\n{}", src);
+    }
+
+    #[test]
+    fn non_shell_module_omits_shell_import_ts() {
+        let module = twig_to_semantic_ir::compile_source("(print (+ 1 2))", "demo").expect("lower");
+        let a = compile(&module).expect("compile");
+        assert!(!a.source.contains("sir-runtime-shell"), "got:\n{}", a.source);
+    }
 }

--- a/code/packages/rust/semantic-ir-to-typescript/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-typescript/src/runtime.rs
@@ -48,6 +48,13 @@ pub const RUNTIME_PAIRS: &str = r##"import * as __SirPairs from "@coding-adventu
 pub const RUNTIME_REGEX: &str = r##"import * as __SirRegex from "@coding-adventures/sir-runtime-regex";
 "##;
 
+/// The shell-runtime import, emitted **only** when a module calls the
+/// `backtick` builtin (a Ruby `` `cmd` `` literal).  Bound as `__SirShell`;
+/// runs the command via the system shell and returns its stdout.  See
+/// `code/specs/sir-runtime.md`.
+pub const RUNTIME_SHELL: &str = r##"import * as __SirShell from "@coding-adventures/sir-runtime-shell";
+"##;
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/code/packages/typescript/sir-runtime-shell/BUILD
+++ b/code/packages/typescript/sir-runtime-shell/BUILD
@@ -1,0 +1,10 @@
+load("code/packages/starlark/library-rules/typescript_library.star", "ts_library")
+
+_targets = [
+    ts_library(
+        name = "sir-runtime-shell",
+        srcs = ["src/**/*.ts", "tests/**/*.ts"],
+        deps = [],
+        test_runner = "vitest",
+    ),
+]

--- a/code/packages/typescript/sir-runtime-shell/BUILD_windows
+++ b/code/packages/typescript/sir-runtime-shell/BUILD_windows
@@ -1,0 +1,3 @@
+npm ci --quiet
+npx tsc --noEmit
+npx vitest run --coverage

--- a/code/packages/typescript/sir-runtime-shell/CHANGELOG.md
+++ b/code/packages/typescript/sir-runtime-shell/CHANGELOG.md
@@ -1,0 +1,35 @@
+# Changelog
+
+## 0.1.0 — initial release
+
+First release of the SIR shell runtime for TypeScript/JavaScript, per
+`code/specs/sir-runtime.md`. Provides the runtime landing point for the SIR
+`backtick` builtin — the Ruby→SIR frontend lowers a backtick literal `` `cmd` ``
+to `BuiltinCall("backtick", [StrLit cmd])`, which previously had no TypeScript
+runtime, so emitted code using a backtick failed.
+
+### Added
+
+- `backtick(command): string` — run `command` via the system shell and return
+  its captured stdout as a string, modelling Ruby's `` `cmd` `` expression.
+  Implemented with `execSync(command, { encoding: "utf8" })` from the Node
+  built-in `node:child_process` (no third-party dependencies). The child's exit
+  status is ignored: `execSync` throws on a non-zero exit, so the error is caught
+  and its captured `stdout` returned (falling back to `""`), mirroring Ruby
+  returning stdout regardless of `$?`. Standard error is not part of the returned
+  value (Ruby's backtick value is stdout only).
+- `Val` — the universal SIR value type alias at this boundary.
+- Full standard layout: `package.json`, `tsconfig.json`, `vitest.config.ts`,
+  `BUILD`, `BUILD_windows`, `required_capabilities.json` (one `process`/`spawn`
+  capability), README. vitest suite at 100% coverage; `tsc --strict` clean.
+
+### Design note — running via the shell is intentional
+
+Using `execSync` (which routes through the system shell) is load-bearing, not an
+oversight: Ruby backtick is *defined* as "run via the system shell" (`/bin/sh -c`
+on POSIX, `cmd.exe /c` on Windows), so shell features (pipes, redirections,
+globbing, `$VAR`) are part of the builtin's contract. The `command` is
+author-supplied — the string literal from the compiled program's own Ruby source
+— and this package interpolates no external/untrusted runtime input, so it
+introduces no new injection surface beyond what Ruby itself grants. The package
+therefore declares a single `process`/`spawn` capability.

--- a/code/packages/typescript/sir-runtime-shell/README.md
+++ b/code/packages/typescript/sir-runtime-shell/README.md
@@ -1,0 +1,78 @@
+# @coding-adventures/sir-runtime-shell
+
+Shell runtime for **Semantic-IR-emitted TypeScript/JavaScript**.
+
+The Ruby→SIR frontend lowers a backtick literal `` `cmd` `` to
+`BuiltinCall("backtick", [StrLit cmd])`. Emitted TypeScript needs a runtime
+landing point for that builtin — one that runs the command through the system
+shell and returns its stdout, exactly as Ruby's backtick expression does. That
+runtime is this package.
+
+## Where it fits in the stack
+
+```
+Ruby source ─▶ ruby-to-semantic-ir ─▶ Semantic IR ─▶ semantic-ir-to-typescript ─▶ .ts
+                                                                                  │ imports
+                                                                                  ▼
+                                                              @coding-adventures/sir-runtime-shell
+```
+
+The TypeScript backend emits an import of this package only when a module uses a
+backtick; pure modules never gain the dependency.
+
+## What it does — Ruby backtick semantics
+
+In Ruby, `` `cmd` `` (and `%x{cmd}`) hands the whole command line to the system
+shell, waits for it, and evaluates to the command's **standard output** as a
+string. The child's exit status is recorded in `$?` but does *not* change the
+value — even a non-zero exit returns whatever was printed to stdout. Standard
+error is not captured by the expression. This package mirrors all of that with
+Node's built-in `node:child_process` (no third-party dependencies):
+
+| Ruby backtick behaviour | TypeScript implementation |
+|---|---|
+| runs via the system shell | `execSync` (spawns through the shell) |
+| returns captured stdout as a string | `{ encoding: "utf8" }` → return value |
+| ignores the child's exit status | `catch` the non-zero exit, return its `stdout` |
+| stderr goes to the parent | not included in the returned value |
+
+## Security — running via the shell is intentional and author-supplied input only
+
+`execSync` runs the command *through the system shell*. This is **load-bearing**:
+Ruby backtick is *defined* as "run via the shell", so shell features (pipes,
+redirections, globbing, `$VAR`) are part of the builtin. Running without a shell
+would silently change the meaning of every compiled backtick.
+
+There is no new untrusted-input path. `command` is the string literal the
+programmer wrote inside the backticks of their *own* Ruby source, threaded
+verbatim through the compiler into the emitted TypeScript. It carries exactly the
+trust level Ruby itself grants it — the author's own code — and this package
+interpolates **no** external or runtime-derived data into the command.
+
+## API
+
+| Export | Purpose |
+|---|---|
+| `backtick(command): string` | Run `command` via the system shell and return its captured stdout (Ruby `` `cmd` ``). Non-zero exits still return stdout. |
+| `Val` | The universal SIR value type alias (`any`) at this boundary. |
+
+## Usage
+
+```ts
+import { backtick } from "@coding-adventures/sir-runtime-shell";
+
+backtick(`"${process.execPath}" -e "process.stdout.write('123')"`); // "123"
+backtick(`"${process.execPath}" -e "process.exit(1)"`);             // ""  (non-zero exit → stdout still returned)
+```
+
+## Development
+
+```bash
+npm ci
+npx tsc --noEmit      # strict typecheck
+npx vitest run --coverage
+```
+
+## License
+
+MIT

--- a/code/packages/typescript/sir-runtime-shell/package-lock.json
+++ b/code/packages/typescript/sir-runtime-shell/package-lock.json
@@ -1,0 +1,1570 @@
+{
+  "name": "@coding-adventures/sir-runtime-shell",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@coding-adventures/sir-runtime-shell",
+      "version": "0.1.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@types/node": "^22.0.0",
+        "@vitest/coverage-v8": "^4.1.0",
+        "typescript": "^5.0.0",
+        "vitest": "^4.1.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.7"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.5.tgz",
+      "integrity": "sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.133.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.133.0.tgz",
+      "integrity": "sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.3.tgz",
+      "integrity": "sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.3.tgz",
+      "integrity": "sha512-PcAhP+ynjURNyy8SKGl5DQP94aGuB/7JrXJb/t7P+hanXvQVMWzUvRRhBAcg/lNRadBhoUPqSoP4xw5tR/KBEA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.3.tgz",
+      "integrity": "sha512-9YpfeUvSE2RS7wysJ81uOZkXJz7f7Q55H2Gvp3VEw/EsahqDtrphrZ0EwDLK5vvKOzaCrBsjF8JmnMLcUt78Gg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.3.tgz",
+      "integrity": "sha512-yB1IlAsSNHncV6SCTL27/MVGR5htvQsoGxIv5KMGXALp+Ll1wYsn+x98M9MW7qa+NdSbvrrY7ANI4wLJ0n1e6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.3.tgz",
+      "integrity": "sha512-Yi30IVAAfLUCy2MseFjbB1jAMDl1VMCAas5StnYp8da9+CKvMd2H2cbEjWcw5NPaPqzvYkVIaF1nNUG+b7u/sw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.3.tgz",
+      "integrity": "sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.3.tgz",
+      "integrity": "sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.3.tgz",
+      "integrity": "sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.3.tgz",
+      "integrity": "sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.3.tgz",
+      "integrity": "sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.3.tgz",
+      "integrity": "sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.3.tgz",
+      "integrity": "sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.3.tgz",
+      "integrity": "sha512-JTtb8BWFynicNSoPrehsCzBtOKjZ6jhMiPFEmOiuXg1Fl8dn2KHQob+GuPSGR0dryQa1PQJbzjF3dqO/whhjLg==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.3.tgz",
+      "integrity": "sha512-gEdFFEN70A/jxb2svrWsN3aDL7OUtmvlOy+6fa2jxG8K0wQ1ZbdeLGnidov6Yu5/733dI5ySfzFlQ/cb0bSz1g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.3.tgz",
+      "integrity": "sha512-eXB7CHuaQdqmJcc3koCNtNPmT/bj2gc999kUFgBxG8Ac0NdgXc4rkCHhqrgrhN3zddvvvrgzj1e90SuSfmyIXA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
+      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.21",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.21.tgz",
+      "integrity": "sha512-VMeFBSCKQKmm2swI2kW51SFusDqekC6q9trBCvJ/JliDchFSuoYYKN7yVNjPthP1HKZcx3U1gI/wTcEBjEFKTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.9.tgz",
+      "integrity": "sha512-G9/lgqibheLVBDRuya45EbsEXTYcWoSG+TLg7i2axuzx0Eq62eXn+aWXyaVdV5vKvFSWd6ywcX8hA7la9Pvu8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.1.9",
+        "ast-v8-to-istanbul": "^1.0.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.1.9",
+        "vitest": "4.1.9"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.9.tgz",
+      "integrity": "sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.9.tgz",
+      "integrity": "sha512-EVkXzBjrPGM+cK8/ANWgBrkUCfJfb38/EfTSO8h7pWvKkyPkpWxvR7BkD2MyItMF62C97zAEoqdpUixwR/e+Rw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.9.tgz",
+      "integrity": "sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.9.tgz",
+      "integrity": "sha512-KXLMDtc7oe70+3mJfGrPUWPesswH+3sTxAMAMl8DG7I8IUQT4XW718dY5ID3vPUcmlu27CcKfY4P3h3I29SLJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.9",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.9.tgz",
+      "integrity": "sha512-Jc7RKGNBo8Z28WYIm0Niej4xdSPByRf6mU58VpHQkd6Zh05rlnA+twjbK5HyeIGHxrzsc3mJgS43uM0CZKzaIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.9.tgz",
+      "integrity": "sha512-fHpsS6mIi+PiEW+vcRVOMkX1oSaPKne3VOclSFICPcGOmfKgXPU5iAah+wcNcj2xPrCCmfq99IDGf+EojhhvhA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.9.tgz",
+      "integrity": "sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.9",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.4.tgz",
+      "integrity": "sha512-0bC0/4bTSrnwdhU3IsZDwEdojvuPrSg59OYZfKsLRtJZ0u8VBx9DebfqqG8bRdCC0I7vjgxmPi41P0lpkhJHtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.3.tgz",
+      "integrity": "sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.3",
+        "@babel/types": "^7.29.0",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
+      "integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.3.tgz",
+      "integrity": "sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.133.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.0.3",
+        "@rolldown/binding-darwin-arm64": "1.0.3",
+        "@rolldown/binding-darwin-x64": "1.0.3",
+        "@rolldown/binding-freebsd-x64": "1.0.3",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.3",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.3",
+        "@rolldown/binding-linux-arm64-musl": "1.0.3",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.3",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.3",
+        "@rolldown/binding-linux-x64-gnu": "1.0.3",
+        "@rolldown/binding-linux-x64-musl": "1.0.3",
+        "@rolldown/binding-openharmony-arm64": "1.0.3",
+        "@rolldown/binding-wasm32-wasi": "1.0.3",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.3",
+        "@rolldown/binding-win32-x64-msvc": "1.0.3"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
+      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vite": {
+      "version": "8.0.16",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.16.tgz",
+      "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.15",
+        "rolldown": "1.0.3",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.1.18",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.9.tgz",
+      "integrity": "sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.9",
+        "@vitest/mocker": "4.1.9",
+        "@vitest/pretty-format": "4.1.9",
+        "@vitest/runner": "4.1.9",
+        "@vitest/snapshot": "4.1.9",
+        "@vitest/spy": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.9",
+        "@vitest/browser-preview": "4.1.9",
+        "@vitest/browser-webdriverio": "4.1.9",
+        "@vitest/coverage-istanbul": "4.1.9",
+        "@vitest/coverage-v8": "4.1.9",
+        "@vitest/ui": "4.1.9",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    }
+  }
+}

--- a/code/packages/typescript/sir-runtime-shell/package.json
+++ b/code/packages/typescript/sir-runtime-shell/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@coding-adventures/sir-runtime-shell",
+  "version": "0.1.0",
+  "description": "Shell runtime for Semantic-IR-emitted TypeScript/JavaScript — the SIR `backtick` builtin runs a command via the system shell and returns its stdout (Ruby `cmd` semantics)",
+  "type": "module",
+  "main": "src/index.ts",
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage"
+  },
+  "keywords": [
+    "sir",
+    "semantic-ir",
+    "runtime",
+    "shell",
+    "backtick",
+    "subprocess",
+    "compiler",
+    "cross-language",
+    "education"
+  ],
+  "author": "Adhithya Rajasekaran",
+  "license": "MIT",
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "typescript": "^5.0.0",
+    "vitest": "^4.1.0",
+    "@vitest/coverage-v8": "^4.1.0"
+  }
+}

--- a/code/packages/typescript/sir-runtime-shell/required_capabilities.json
+++ b/code/packages/typescript/sir-runtime-shell/required_capabilities.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "typescript/sir-runtime-shell",
+  "capabilities": [
+    {
+      "category": "proc",
+      "action": "exec",
+      "target": "* (author-supplied command from a compiled Ruby backtick expression)",
+      "justification": "Implements Ruby backtick, which runs a command via the system shell and returns its stdout. The command is author-supplied from the compiled program's source (a string literal), mirroring Ruby's own backtick semantics; this package interpolates no external/untrusted runtime input."
+    }
+  ],
+  "justification": "Shells out via node:child_process to implement the SIR `backtick` builtin (Ruby `cmd`): the author-supplied command is run through the system shell and its stdout returned. No filesystem, network, or environment access beyond spawning the one command."
+}

--- a/code/packages/typescript/sir-runtime-shell/src/index.ts
+++ b/code/packages/typescript/sir-runtime-shell/src/index.ts
@@ -1,0 +1,85 @@
+/**
+ * Shell-out — the SIR `backtick` builtin (Ruby `` `cmd` `` on Node `child_process`).
+ *
+ * The Ruby→SIR frontend lowers a backtick literal `` `cmd` `` to
+ * `BuiltinCall("backtick", [StrLit cmd])`. This module is the
+ * *TypeScript/JavaScript* landing point for that builtin: it runs the command
+ * through the system shell and returns the command's captured standard output as
+ * a string, exactly as Ruby's backtick expression does.
+ *
+ * **What Ruby backtick does — the contract we mirror.** In Ruby, `` `cmd` `` (and
+ * its twin `%x{cmd}`) hands the *whole command line* to the system shell — on a
+ * POSIX host that is `/bin/sh -c cmd` — waits for it to finish, and evaluates to
+ * the command's standard output as a string. The child's exit status is recorded
+ * in `$?` but does **not** affect the value: even a command that exits non-zero
+ * yields whatever it printed to stdout (often the empty string). Standard error
+ * is not captured by the expression. We reproduce all of this below.
+ *
+ * | Ruby backtick behaviour          | TypeScript implementation                     |
+ * |----------------------------------|-----------------------------------------------|
+ * | runs via the system shell        | `execSync` (spawns through the shell)         |
+ * | returns captured stdout as a str | `{ encoding: "utf8" }` → return value         |
+ * | ignores the child's exit status  | `catch` non-zero exit, return its `stdout`    |
+ * | stderr goes to the parent        | not included in the returned value            |
+ *
+ * **SECURITY — running via the shell is intentional and load-bearing.**
+ * `execSync` runs the command *through the system shell* (`/bin/sh -c` on POSIX,
+ * `cmd.exe /c` on Windows). In most Node code, building a shell command from
+ * *untrusted runtime input* is a shell-injection red flag. Here it is the
+ * opposite — it is *required* for faithful semantics, and there is no new
+ * untrusted-input path:
+ *
+ * - **Ruby backtick is defined as "run via the shell."** Ruby always routes
+ *   `` `cmd` `` through `/bin/sh -c`. Shell metacharacters (pipes `|`,
+ *   redirections `>`, globbing `*`, `$VAR` expansion, `;` sequencing) are part of
+ *   the feature. Running the command without a shell would silently change the
+ *   meaning of every compiled Ruby program that uses a backtick.
+ * - **The command is author-supplied, not attacker-supplied.** `command` is the
+ *   string literal the programmer wrote *inside the backticks of their own Ruby
+ *   source*, threaded verbatim through the compiler into the emitted TypeScript.
+ *   It carries exactly the trust level it had in the original Ruby program — the
+ *   author's own code — which is precisely the trust level Ruby itself grants it.
+ *   This package interpolates **no** external or runtime-derived data into the
+ *   command, so it introduces no new injection surface.
+ */
+
+import { execSync } from "node:child_process";
+
+/** The SIR universal value type at this package's boundary. */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type Val = any;
+
+/**
+ * Run `command` via the system shell and return its captured stdout.
+ *
+ * This is the runtime for the SIR `backtick` builtin, modelling Ruby's
+ * `` `cmd` `` expression. The command is passed to the system shell (`/bin/sh -c`
+ * on POSIX, `cmd.exe /c` on Windows) via {@link execSync}, run to completion, and
+ * its standard output returned as a UTF-8 string.
+ *
+ * The child's exit status is **ignored**: like Ruby, a command that exits
+ * non-zero still returns whatever it wrote to stdout (which may be the empty
+ * string). `execSync` *throws* on a non-zero exit, so we catch the error and
+ * recover its captured `stdout` — falling back to `""` when none is available.
+ * Standard error is not part of the returned value, mirroring Ruby, where the
+ * backtick value is stdout only.
+ *
+ * See the module doc comment for the full Ruby↔TS mapping table and the SECURITY
+ * note explaining why running via the shell is intentional and safe here (the
+ * command is author-supplied from the compiled program's own source, exactly as
+ * in Ruby; no untrusted runtime input is interpolated).
+ */
+export function backtick(command: string): string {
+  try {
+    // execSync runs the command through the system shell, matching Ruby
+    // backtick; encoding:"utf8" makes it return a string rather than a Buffer.
+    return execSync(command, { encoding: "utf8" });
+  } catch (err: unknown) {
+    // A non-zero exit makes execSync throw. Ruby returns stdout regardless of
+    // $?, so recover the captured stdout from the thrown error. The error is an
+    // ExecSyncError whose `stdout` may be a string or Buffer; narrow defensively
+    // and coerce to a string, defaulting to "" when no stdout was captured.
+    const stdout = (err as { stdout?: Buffer | string | null }).stdout;
+    return stdout?.toString() ?? "";
+  }
+}

--- a/code/packages/typescript/sir-runtime-shell/tests/shell.test.ts
+++ b/code/packages/typescript/sir-runtime-shell/tests/shell.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from "vitest";
+import { backtick } from "../src/index.js";
+
+/**
+ * Commands are built with `node -e "..."` (via `process.execPath`, the running
+ * Node binary) rather than the shell built-in `echo` so they behave identically
+ * on Windows `cmd.exe` and POSIX `/bin/sh` — `echo`'s quoting and flag handling
+ * differ across those shells, whereas a Node one-liner is deterministic.
+ */
+function node(code: string): string {
+  // Quote the interpreter path (it may contain spaces) and wrap the code in
+  // double quotes; the code itself uses only single quotes.
+  return `"${process.execPath}" -e "${code}"`;
+}
+
+describe("backtick — Ruby `cmd` semantics", () => {
+  it("returns the command's captured stdout", () => {
+    const out = backtick(node("process.stdout.write('123')"));
+    expect(out).toContain("123");
+  });
+
+  it("returns exactly what was written to stdout", () => {
+    const out = backtick(node("process.stdout.write('exact')"));
+    expect(out).toBe("exact");
+  });
+
+  it("returns a string", () => {
+    const out = backtick(node("process.stdout.write('hi')"));
+    expect(typeof out).toBe("string");
+  });
+
+  it("preserves multi-line output in order", () => {
+    const out = backtick(node("process.stdout.write('line1\\nline2')"));
+    expect(out).toContain("line1");
+    expect(out).toContain("line2");
+    expect(out.indexOf("line1")).toBeLessThan(out.indexOf("line2"));
+  });
+
+  it("returns stdout even when the command exits non-zero", () => {
+    // execSync throws on non-zero exit; backtick must recover the stdout, like
+    // Ruby returning stdout regardless of $?.
+    const out = backtick(
+      node("process.stdout.write('partial'); process.exit(3)"),
+    );
+    expect(out).toBe("partial");
+  });
+
+  it("returns empty string for a non-zero exit with no stdout", () => {
+    const out = backtick(node("process.exit(5)"));
+    expect(out).toBe("");
+  });
+
+  it("does not include stderr in the result", () => {
+    const out = backtick(
+      node("process.stderr.write('ERR'); process.stdout.write('OUT')"),
+    );
+    expect(out).toBe("OUT");
+    expect(out).not.toContain("ERR");
+  });
+
+  it("returns empty string when the command cannot be spawned at all", () => {
+    // A command the shell cannot run produces a thrown error whose `stdout` may
+    // be null/undefined (no child stdout was ever captured). The `?? ""`
+    // fallback must turn that into the empty string, never throwing.
+    const out = backtick(
+      "this-command-definitely-does-not-exist-xyzzy-42 --nope",
+    );
+    expect(out).toBe("");
+  });
+});

--- a/code/packages/typescript/sir-runtime-shell/tsconfig.json
+++ b/code/packages/typescript/sir-runtime-shell/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}

--- a/code/packages/typescript/sir-runtime-shell/vitest.config.ts
+++ b/code/packages/typescript/sir-runtime-shell/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    coverage: {
+      provider: "v8",
+      thresholds: {
+        lines: 80,
+      },
+    },
+  },
+});


### PR DESCRIPTION
## Q8(c) — `backtick` builtin → `sir-runtime-shell`

Probe-first confirmed the Ruby `` `cmd` `` backtick literal lowers to
`BuiltinCall("backtick", [StrLit cmd])`, which previously hit the
unknown-builtin dispatch and failed at runtime. Now emitted code calls a
dedicated per-concern shell runtime.

### New packages: `sir-runtime-shell` (py + ts)
Full standard layout; **8 + 8 tests @ 100%; `mypy --strict`/`ruff` + `tsc --strict` clean; dependency-free** (stdlib `subprocess` / `node:child_process`).
- `backtick(command)` → run via the system shell, return stdout (Ruby backtick). py: `subprocess.run(shell=True, capture_output, text, check=False).stdout`; ts: `execSync(cmd, {encoding:"utf8"})`, returning stdout even on non-zero exit.
- Shell execution is **load-bearing and by design** — Ruby backtick always runs via the system shell. The command is **author-supplied** from the compiled program's source (a string literal), mirroring Ruby itself; no new untrusted-input path. Each package declares a `proc`/`exec` required capability.

### Backends (`semantic-ir-to-python` 0.1.11, `semantic-ir-to-typescript` 0.1.10)
- `BuiltinCall("backtick", …)` → `_sir_shell_backtick(cmd)` / `__SirShell.backtick(cmd)`.
- New gated `RUNTIME_SHELL` import emitted **only** when a module calls the `backtick` builtin (`uses_shell`, reusing the exhaustive `module_uses_builtin` content walk).

### Verification
- `cargo test`: typescript **346**, python **51**, ruby-to-semantic-ir **61** — all green. New direct-SIR emit + omit-import tests both backends.
- Python emitted-call **exec-proofed on CPython** against the real package (`` `python -c "print(7*6)"` `` → `42`); TS covered by the package's own vitest.
- `/security-review`: PASSED — command escaped via `quote_*_string` (no second injection layer); `proc`/`exec` capability is schema-valid and correctly declared; shell-exec is gated + capability-declared + author-supplied-only (accepted by-design as faithful Ruby backtick).

### Remaining Q8
Q8d (builtin audit + harden core dispatch) closes out the queue next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
