### PR TITLE
[codex] Add Hue archive validation summary

### DIFF
--- a/code/packages/rust/hue-core/CHANGELOG.md
+++ b/code/packages/rust/hue-core/CHANGELOG.md
@@ -71,6 +71,8 @@ All notable changes to this package will be documented in this file.
   readiness into final archive publication checks.
 - Hue package release archive verification summaries that turn archive
   publication readiness into final archive verification checks.
+- Hue package release archive validation summaries that turn archive
+  verification readiness into final archive validation checks.
 - Hue discovery worker-run projection from generic `MdnsScanResult` envelopes,
   preserving scan parse failures as per-source D23 worker failures.
 - Hue discovery worker-run projection from aggregate `MdnsWorkerScanReport`

--- a/code/packages/rust/hue-core/README.md
+++ b/code/packages/rust/hue-core/README.md
@@ -111,6 +111,8 @@ packages a typed surface for:
   readiness into final archive publication checks
 - Hue package release archive verification summaries that turn archive
   publication readiness into final archive verification checks
+- Hue package release archive validation summaries that turn archive
+  verification readiness into final archive validation checks
 
 ## Dependencies
 

--- a/code/packages/rust/hue-core/src/lib.rs
+++ b/code/packages/rust/hue-core/src/lib.rs
@@ -4350,6 +4350,194 @@ pub fn hue_package_release_archive_verification_summary(
     HuePackageReleaseArchiveVerificationSummary::from_pairing_plan(plan)
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct HuePackageReleaseArchiveValidationSummary {
+    pub archive_verification_summary: HuePackageReleaseArchiveVerificationSummary,
+    pub required_archive_validation_check_count: usize,
+    pub passed_archive_validation_check_count: usize,
+    pub blocked_archive_validation_check_count: usize,
+    pub release_archive_verification_ready: bool,
+    pub release_archive_publication_ready: bool,
+    pub release_archive_completion_ready: bool,
+    pub release_archive_supervisor_ready: bool,
+    pub release_archive_operator_ready: bool,
+    pub release_archive_dispatch_ready: bool,
+    pub release_archive_handoff_ready: bool,
+    pub release_archive_closure_ready: bool,
+    pub release_archive_signoff_ready: bool,
+    pub release_archive_ready: bool,
+    pub release_closure_ready: bool,
+    pub release_signoff_ready: bool,
+    pub release_audit_ready: bool,
+    pub operator_ready: bool,
+    pub coordination_ready: bool,
+    pub publish_gate_ready: bool,
+    pub release_archive_validation_ready: bool,
+}
+
+impl HuePackageReleaseArchiveValidationSummary {
+    pub fn from_pairing_plan(plan: &HueBridgePairingPlan) -> Self {
+        Self::from_archive_verification_summary(hue_package_release_archive_verification_summary(
+            plan,
+        ))
+    }
+
+    pub fn from_archive_verification_summary(
+        archive_verification_summary: HuePackageReleaseArchiveVerificationSummary,
+    ) -> Self {
+        let release_archive_verification_ready =
+            archive_verification_summary.is_release_archive_verification_ready();
+        let release_archive_publication_ready =
+            !archive_verification_summary.needs_release_archive_publication();
+        let release_archive_completion_ready =
+            !archive_verification_summary.needs_release_archive_completion();
+        let release_archive_supervisor_ready =
+            !archive_verification_summary.needs_release_archive_supervisor();
+        let release_archive_operator_ready =
+            !archive_verification_summary.needs_release_archive_operator();
+        let release_archive_dispatch_ready =
+            !archive_verification_summary.needs_release_archive_dispatch();
+        let release_archive_handoff_ready =
+            !archive_verification_summary.needs_release_archive_handoff();
+        let release_archive_closure_ready =
+            !archive_verification_summary.needs_release_archive_closure();
+        let release_archive_signoff_ready =
+            !archive_verification_summary.needs_release_archive_signoff();
+        let release_archive_ready = !archive_verification_summary.needs_release_archive();
+        let release_closure_ready = !archive_verification_summary.needs_release_closure();
+        let release_signoff_ready = !archive_verification_summary.needs_release_signoff();
+        let release_audit_ready = !archive_verification_summary.needs_release_audit();
+        let operator_ready = !archive_verification_summary.needs_operator_readiness();
+        let coordination_ready = !archive_verification_summary.needs_coordination();
+        let publish_gate_ready = !archive_verification_summary.needs_publish_gate();
+        let checks = [
+            release_archive_verification_ready,
+            release_archive_publication_ready,
+            release_archive_completion_ready,
+            release_archive_supervisor_ready,
+            release_archive_operator_ready,
+            release_archive_dispatch_ready,
+            release_archive_handoff_ready,
+            release_archive_closure_ready,
+            release_archive_signoff_ready,
+            release_archive_ready,
+            release_closure_ready,
+            release_signoff_ready,
+            release_audit_ready,
+            operator_ready,
+            coordination_ready,
+            publish_gate_ready,
+        ];
+        let passed_archive_validation_check_count = checks.iter().filter(|ready| **ready).count();
+        let required_archive_validation_check_count = checks.len();
+        let blocked_archive_validation_check_count =
+            required_archive_validation_check_count - passed_archive_validation_check_count;
+        let release_archive_validation_ready = blocked_archive_validation_check_count == 0;
+
+        Self {
+            archive_verification_summary,
+            required_archive_validation_check_count,
+            passed_archive_validation_check_count,
+            blocked_archive_validation_check_count,
+            release_archive_verification_ready,
+            release_archive_publication_ready,
+            release_archive_completion_ready,
+            release_archive_supervisor_ready,
+            release_archive_operator_ready,
+            release_archive_dispatch_ready,
+            release_archive_handoff_ready,
+            release_archive_closure_ready,
+            release_archive_signoff_ready,
+            release_archive_ready,
+            release_closure_ready,
+            release_signoff_ready,
+            release_audit_ready,
+            operator_ready,
+            coordination_ready,
+            publish_gate_ready,
+            release_archive_validation_ready,
+        }
+    }
+
+    pub fn is_release_archive_validation_ready(self) -> bool {
+        self.release_archive_validation_ready
+    }
+
+    pub fn has_blocked_archive_validation_checks(self) -> bool {
+        self.blocked_archive_validation_check_count > 0
+    }
+
+    pub fn needs_release_archive_verification(self) -> bool {
+        !self.release_archive_verification_ready
+    }
+
+    pub fn needs_release_archive_publication(self) -> bool {
+        !self.release_archive_publication_ready
+    }
+
+    pub fn needs_release_archive_completion(self) -> bool {
+        !self.release_archive_completion_ready
+    }
+
+    pub fn needs_release_archive_supervisor(self) -> bool {
+        !self.release_archive_supervisor_ready
+    }
+
+    pub fn needs_release_archive_operator(self) -> bool {
+        !self.release_archive_operator_ready
+    }
+
+    pub fn needs_release_archive_dispatch(self) -> bool {
+        !self.release_archive_dispatch_ready
+    }
+
+    pub fn needs_release_archive_handoff(self) -> bool {
+        !self.release_archive_handoff_ready
+    }
+
+    pub fn needs_release_archive_closure(self) -> bool {
+        !self.release_archive_closure_ready
+    }
+
+    pub fn needs_release_archive_signoff(self) -> bool {
+        !self.release_archive_signoff_ready
+    }
+
+    pub fn needs_release_archive(self) -> bool {
+        !self.release_archive_ready
+    }
+
+    pub fn needs_release_closure(self) -> bool {
+        !self.release_closure_ready
+    }
+
+    pub fn needs_release_signoff(self) -> bool {
+        !self.release_signoff_ready
+    }
+
+    pub fn needs_release_audit(self) -> bool {
+        !self.release_audit_ready
+    }
+
+    pub fn needs_operator_readiness(self) -> bool {
+        !self.operator_ready
+    }
+
+    pub fn needs_coordination(self) -> bool {
+        !self.coordination_ready
+    }
+
+    pub fn needs_publish_gate(self) -> bool {
+        !self.publish_gate_ready
+    }
+}
+
+pub fn hue_package_release_archive_validation_summary(
+    plan: &HueBridgePairingPlan,
+) -> HuePackageReleaseArchiveValidationSummary {
+    HuePackageReleaseArchiveValidationSummary::from_pairing_plan(plan)
+}
+
 fn descriptor_declares_capability(descriptor: &IntegrationDescriptor, capability_id: &str) -> bool {
     descriptor
         .capabilities
@@ -9681,6 +9869,125 @@ mod tests {
         assert!(!summary.release_archive_verification_ready);
         assert!(!summary.is_release_archive_verification_ready());
         assert!(summary.has_blocked_archive_verification_checks());
+        assert!(summary.needs_release_archive_publication());
+        assert!(summary.needs_release_archive_completion());
+        assert!(summary.needs_release_archive_supervisor());
+        assert!(summary.needs_release_archive_operator());
+        assert!(summary.needs_release_archive_dispatch());
+        assert!(summary.needs_release_archive_handoff());
+        assert!(summary.needs_release_archive_closure());
+        assert!(summary.needs_release_archive_signoff());
+        assert!(summary.needs_release_archive());
+        assert!(summary.needs_release_closure());
+        assert!(summary.needs_release_signoff());
+        assert!(summary.needs_release_audit());
+        assert!(summary.needs_operator_readiness());
+        assert!(summary.needs_coordination());
+        assert!(summary.needs_publish_gate());
+    }
+
+    #[test]
+    fn hue_package_release_archive_validation_summary_reports_ready_archive_validation() {
+        let plan = hue_pairing_plan_for_discovered_bridge(
+            DiscoveredHueBridge {
+                bridge_id: "001788fffeabcdef".to_string(),
+                address: "https://192.0.2.10".to_string(),
+                hardware_model: Some("BSB002".to_string()),
+                firmware_version: Some("1.60".to_string()),
+            },
+            "chief-of-staff",
+            "desk",
+        );
+
+        let summary = hue_package_release_archive_validation_summary(&plan);
+
+        assert_eq!(
+            summary.archive_verification_summary,
+            hue_package_release_archive_verification_summary(&plan)
+        );
+        assert_eq!(summary.required_archive_validation_check_count, 16);
+        assert_eq!(summary.passed_archive_validation_check_count, 16);
+        assert_eq!(summary.blocked_archive_validation_check_count, 0);
+        assert!(summary.release_archive_verification_ready);
+        assert!(summary.release_archive_publication_ready);
+        assert!(summary.release_archive_completion_ready);
+        assert!(summary.release_archive_supervisor_ready);
+        assert!(summary.release_archive_operator_ready);
+        assert!(summary.release_archive_dispatch_ready);
+        assert!(summary.release_archive_handoff_ready);
+        assert!(summary.release_archive_closure_ready);
+        assert!(summary.release_archive_signoff_ready);
+        assert!(summary.release_archive_ready);
+        assert!(summary.release_closure_ready);
+        assert!(summary.release_signoff_ready);
+        assert!(summary.release_audit_ready);
+        assert!(summary.operator_ready);
+        assert!(summary.coordination_ready);
+        assert!(summary.publish_gate_ready);
+        assert!(summary.release_archive_validation_ready);
+        assert!(summary.is_release_archive_validation_ready());
+        assert!(!summary.has_blocked_archive_validation_checks());
+        assert!(!summary.needs_release_archive_verification());
+        assert!(!summary.needs_release_archive_publication());
+        assert!(!summary.needs_release_archive_completion());
+        assert!(!summary.needs_release_archive_supervisor());
+        assert!(!summary.needs_release_archive_operator());
+        assert!(!summary.needs_release_archive_dispatch());
+        assert!(!summary.needs_release_archive_handoff());
+        assert!(!summary.needs_release_archive_closure());
+        assert!(!summary.needs_release_archive_signoff());
+        assert!(!summary.needs_release_archive());
+        assert!(!summary.needs_release_closure());
+        assert!(!summary.needs_release_signoff());
+        assert!(!summary.needs_release_audit());
+        assert!(!summary.needs_operator_readiness());
+        assert!(!summary.needs_coordination());
+        assert!(!summary.needs_publish_gate());
+    }
+
+    #[test]
+    fn hue_package_release_archive_validation_summary_routes_blocked_archive_validation() {
+        let mut plan = hue_pairing_plan_for_discovered_bridge(
+            DiscoveredHueBridge {
+                bridge_id: "001788fffeabcdef".to_string(),
+                address: "https://192.0.2.10".to_string(),
+                hardware_model: Some("BSB002".to_string()),
+                firmware_version: Some("1.60".to_string()),
+            },
+            "chief-of-staff",
+            "desk",
+        );
+        plan.bridge.address = None;
+        plan.registration_request.path = "/wrong/api".to_string();
+        plan.application_key_header = "x-application-key".to_string();
+        plan.event_stream_path = "/wrong/eventstream".to_string();
+        plan.requires_user_presence = false;
+
+        let summary = HuePackageReleaseArchiveValidationSummary::from_pairing_plan(&plan);
+
+        assert_eq!(summary.required_archive_validation_check_count, 16);
+        assert_eq!(summary.passed_archive_validation_check_count, 0);
+        assert_eq!(summary.blocked_archive_validation_check_count, 16);
+        assert!(!summary.release_archive_verification_ready);
+        assert!(!summary.release_archive_publication_ready);
+        assert!(!summary.release_archive_completion_ready);
+        assert!(!summary.release_archive_supervisor_ready);
+        assert!(!summary.release_archive_operator_ready);
+        assert!(!summary.release_archive_dispatch_ready);
+        assert!(!summary.release_archive_handoff_ready);
+        assert!(!summary.release_archive_closure_ready);
+        assert!(!summary.release_archive_signoff_ready);
+        assert!(!summary.release_archive_ready);
+        assert!(!summary.release_closure_ready);
+        assert!(!summary.release_signoff_ready);
+        assert!(!summary.release_audit_ready);
+        assert!(!summary.operator_ready);
+        assert!(!summary.coordination_ready);
+        assert!(!summary.publish_gate_ready);
+        assert!(!summary.release_archive_validation_ready);
+        assert!(!summary.is_release_archive_validation_ready());
+        assert!(summary.has_blocked_archive_validation_checks());
+        assert!(summary.needs_release_archive_verification());
         assert!(summary.needs_release_archive_publication());
         assert!(summary.needs_release_archive_completion());
         assert!(summary.needs_release_archive_supervisor());


### PR DESCRIPTION
Summary
- add Hue package release archive validation summaries on top of archive verification readiness
- expose archive validation gap counters and needs_* helpers
- document the new archive validation layer in hue-core docs

Validation
- cargo fmt --manifest-path code\packages\rust\hue-core\Cargo.toml
- cargo test --manifest-path code\packages\rust\hue-core\Cargo.toml
- git diff --check -- code\packages\rust\hue-core\src\lib.rs code\packages\rust\hue-core\README.md code\packages\rust\hue-core\CHANGELOG.md