### PR TITLE
feat(sir): boolean/unary operator builtins + hardened dispatch error (Q8d audit)

### DIFF
--- a/code/packages/python/sir-runtime-core/CHANGELOG.md
+++ b/code/packages/python/sir-runtime-core/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to `coding-adventures-sir-runtime-core` are documented here.
 
+## [0.1.2] - 2026-06-15
+
+### Changed
+
+- `call_builtin` now raises a descriptive error for an unregistered SIR builtin
+  — it names the builtin, lists the known ones, and explains it indicates a
+  backend coverage gap (the emitter produced a `call_builtin` for something it
+  does not lower natively or via a per-concern runtime package), rather than a
+  bare `unknown builtin: <name>`.
+
 ## [0.1.1] - 2026-06-15
 
 ### Changed

--- a/code/packages/python/sir-runtime-core/pyproject.toml
+++ b/code/packages/python/sir-runtime-core/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-sir-runtime-core"
-version = "0.1.1"
+version = "0.1.2"
 description = "Core runtime for Semantic-IR-emitted Python — SIR truthiness, symbols, equality, display, arithmetic, closures, globals"
 requires-python = ">=3.12"
 dependencies = ["coding-adventures-sir-runtime-pairs"]

--- a/code/packages/python/sir-runtime-core/src/coding_adventures_sir_runtime_core/runtime.py
+++ b/code/packages/python/sir-runtime-core/src/coding_adventures_sir_runtime_core/runtime.py
@@ -106,10 +106,25 @@ _builtins: dict[str, Callable[..., Any]] = {
 
 
 def call_builtin(name: str, args: list[Any]) -> Any:
-    """Invoke a builtin by SIR name with a list of arguments."""
+    """Invoke a builtin by SIR name with a list of arguments.
+
+    The SIR backends translate most builtins to native code or route them to a
+    dedicated per-concern runtime package, so this generic dispatch only fires
+    for the small set the core registers (arithmetic / pairs / print / type
+    predicates).  An unregistered name means the emitting backend produced a
+    `call_builtin("<name>", …)` for a builtin it does not yet lower — a backend
+    coverage gap, not a user error — so the message names the builtin and points
+    there rather than reading like a missing Python name.
+    """
     fn = _builtins.get(name)
     if fn is None:
-        raise NameError(f"unknown builtin: {name}")
+        known = ", ".join(sorted(_builtins))
+        raise NameError(
+            f"SIR builtin {name!r} is not implemented in sir-runtime-core's "
+            f"dispatch table (known: {known}). The backend emitted a "
+            f"call_builtin for a builtin it does not lower natively or via a "
+            f"per-concern runtime package; this is a backend coverage gap."
+        )
     return fn(*args)
 
 

--- a/code/packages/rust/semantic-ir-to-python/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-python/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## 0.1.12 — boolean/unary operator builtins (audit close-out)
+
+Builtin-coverage audit of what the Ruby frontend actually emits as a
+`BuiltinCall` reaching this backend.  Ruby `&&`/`and`, `||`/`or`, `!`/`not`,
+and unary minus lower to `BuiltinCall("and"/"or"/"not"/"neg", …)` — previously
+they fell through to the eager `call_builtin` dispatch and raised at runtime
+(so any program using a boolean operator emitted crashing code).  Now they
+lower **natively**:
+
+- `and`/`or` → the same truthy-guarded short-circuiting lambda as
+  `Expr::LogicalAnd`/`LogicalOr` (Ruby short-circuit + SIR truthiness; the rhs
+  is not evaluated when the lhs decides the result — eager dispatch could not
+  preserve this).
+- `not` → `(not _sir_truthy(x))` (always a bool); `neg` → `(-(x))`.
+- The remaining builtins the audit found reaching the backend — `range`,
+  `splat`, `double_splat`, `block_pass`, `yield`, `lambda`, `defined?` — are
+  call-ABI / control-flow shaped and tracked as a follow-up tranche; until then
+  they hit core's now-descriptive unknown-builtin error (names the builtin +
+  flags a backend coverage gap) instead of a cryptic failure.
+
+New direct-SIR tests for `and`/`or`/`not`/`neg` native lowering.
+
 ## 0.1.11 — backtick builtin → sir-runtime-shell (gated import)
 
 The Ruby `` `cmd` `` backtick literal lowers to `BuiltinCall("backtick",

--- a/code/packages/rust/semantic-ir-to-python/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-python/src/emit.rs
@@ -835,6 +835,42 @@ fn emit_builtin_call(out: &mut String, name: &str, args: &[Expr], indent: usize)
         out.push(')');
         return;
     }
+    // Ruby `&&`/`and` and `||`/`or` lower to `BuiltinCall("and"/"or", [lhs,
+    // rhs])`.  They must **short-circuit** (rhs not evaluated when lhs decides
+    // it) and use SIR truthiness, so they emit the same truthy-guarded
+    // immediately-invoked lambda as `Expr::LogicalAnd`/`LogicalOr` rather than
+    // routing through the eager `call_builtin` dispatch (which would evaluate
+    // both operands and lose Ruby semantics).
+    if name == "and" && args.len() == 2 {
+        out.push_str("(lambda __l: (");
+        emit_expr(out, &args[1], indent);
+        out.push_str(") if _sir_truthy(__l) else __l)(");
+        emit_expr(out, &args[0], indent);
+        out.push(')');
+        return;
+    }
+    if name == "or" && args.len() == 2 {
+        out.push_str("(lambda __l: __l if _sir_truthy(__l) else (");
+        emit_expr(out, &args[1], indent);
+        out.push_str("))(");
+        emit_expr(out, &args[0], indent);
+        out.push(')');
+        return;
+    }
+    // `!`/`not` → SIR-truthiness negation, always a bool (never Python's
+    // operand-returning `not`).  `-x` (unary minus) → numeric negation.
+    if name == "not" && args.len() == 1 {
+        out.push_str("(not _sir_truthy(");
+        emit_expr(out, &args[0], indent);
+        out.push_str("))");
+        return;
+    }
+    if name == "neg" && args.len() == 1 {
+        out.push_str("(-(");
+        emit_expr(out, &args[0], indent);
+        out.push_str("))");
+        return;
+    }
     let helper = match name {
         "+" => "_sir_plus",
         "-" => "_sir_minus",

--- a/code/packages/rust/semantic-ir-to-python/src/lib.rs
+++ b/code/packages/rust/semantic-ir-to-python/src/lib.rs
@@ -1013,4 +1013,34 @@ mod tests {
         let a = compile(&module).expect("compile");
         assert!(!a.source.contains("sir_runtime_shell"), "got:\n{}", a.source);
     }
+
+    // ─── boolean / unary operator builtins (Q8d audit) ──────────────────────
+
+    fn bc(name: &str, args: Vec<Expr>) -> Expr {
+        Expr::BuiltinCall { name: name.into(), args, effects: EffectSet::PURE, span: s() }
+    }
+
+    #[test]
+    fn and_or_not_neg_builtins_lower_natively_py() {
+        // Ruby `&&`/`and`/`||`/`or`/`!`/unary-minus reach the backend as these
+        // builtins; they must lower natively (and/or short-circuit via SIR
+        // truthiness), never route to the dispatch table.
+        let and = bc("and", vec![Expr::BoolLit { value: true, span: s() }, Expr::IntLit { value: 1, span: s() }]);
+        let a = compile(&module_with_main_body(vec![], and, &[])).expect("compile");
+        assert!(a.source.contains("if _sir_truthy(__l) else __l"), "and: got:\n{}", a.source);
+
+        let or = bc("or", vec![Expr::BoolLit { value: false, span: s() }, Expr::IntLit { value: 2, span: s() }]);
+        let a = compile(&module_with_main_body(vec![], or, &[])).expect("compile");
+        assert!(a.source.contains("__l if _sir_truthy(__l) else"), "or: got:\n{}", a.source);
+
+        let not = bc("not", vec![Expr::BoolLit { value: true, span: s() }]);
+        let a = compile(&module_with_main_body(vec![], not, &[])).expect("compile");
+        assert!(a.source.contains("(not _sir_truthy(True))"), "not: got:\n{}", a.source);
+
+        let neg = bc("neg", vec![Expr::IntLit { value: 5, span: s() }]);
+        let a = compile(&module_with_main_body(vec![], neg, &[])).expect("compile");
+        assert!(a.source.contains("(-(5))"), "neg: got:\n{}", a.source);
+        // None of these route through the eager dispatch table.
+        assert!(!a.source.contains("_sir_call_builtin(\"neg\""), "got:\n{}", a.source);
+    }
 }

--- a/code/packages/rust/semantic-ir-to-typescript/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-typescript/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## 0.1.11 — boolean/unary operator builtins (audit close-out)
+
+Builtin-coverage audit of what the Ruby frontend emits as a `BuiltinCall`
+reaching this backend.  Ruby `&&`/`and`, `||`/`or`, `!`/`not`, and unary minus
+lower to `BuiltinCall("and"/"or"/"not"/"neg", …)` — previously they fell
+through to the eager `callBuiltin` dispatch and threw at runtime.  Now native:
+
+- `and`/`or` → the same truthy-guarded short-circuiting arrow IIFE as
+  `Expr::LogicalAnd`/`LogicalOr` (Ruby short-circuit + SIR truthiness).
+- `not` → `(!__Sir.truthy(x))`; `neg` → `(-(x))`.
+- Remaining audit-found builtins (`range`, `splat`, `double_splat`,
+  `block_pass`, `yield`, `lambda`, `defined?`) are call-ABI / control-flow
+  shaped and tracked as a follow-up; until then they hit core's now-descriptive
+  unknown-builtin error rather than a cryptic failure.
+
+New direct-SIR tests for `and`/`or`/`not`/`neg` native lowering.
+
 ## 0.1.10 — backtick builtin → sir-runtime-shell (gated import)
 
 The Ruby `` `cmd` `` backtick literal lowers to `BuiltinCall("backtick",

--- a/code/packages/rust/semantic-ir-to-typescript/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-typescript/src/emit.rs
@@ -964,6 +964,40 @@ fn emit_builtin_call(out: &mut String, name: &str, args: &[Expr], indent: usize)
         out.push(')');
         return;
     }
+    // Ruby `&&`/`and` and `||`/`or` lower to `BuiltinCall("and"/"or", [lhs,
+    // rhs])`.  They must **short-circuit** and use SIR truthiness, so they
+    // emit the same truthy-guarded arrow IIFE as `Expr::LogicalAnd`/`LogicalOr`
+    // rather than routing through the eager `callBuiltin` dispatch.
+    if name == "and" && args.len() == 2 {
+        out.push_str("((__l: __Sir.Val) => __Sir.truthy(__l) ? (");
+        emit_expr(out, &args[1], indent);
+        out.push_str(") : __l)(");
+        emit_expr(out, &args[0], indent);
+        out.push(')');
+        return;
+    }
+    if name == "or" && args.len() == 2 {
+        out.push_str("((__l: __Sir.Val) => __Sir.truthy(__l) ? __l : (");
+        emit_expr(out, &args[1], indent);
+        out.push_str("))(");
+        emit_expr(out, &args[0], indent);
+        out.push(')');
+        return;
+    }
+    // `!`/`not` → SIR-truthiness negation (always boolean); `-x` (unary minus)
+    // → numeric negation.
+    if name == "not" && args.len() == 1 {
+        out.push_str("(!__Sir.truthy(");
+        emit_expr(out, &args[0], indent);
+        out.push_str("))");
+        return;
+    }
+    if name == "neg" && args.len() == 1 {
+        out.push_str("(-(");
+        emit_expr(out, &args[0], indent);
+        out.push_str("))");
+        return;
+    }
     let helper = match name {
         "+" => "__Sir.add",
         "-" => "__Sir.sub",

--- a/code/packages/rust/semantic-ir-to-typescript/src/lib.rs
+++ b/code/packages/rust/semantic-ir-to-typescript/src/lib.rs
@@ -901,4 +901,30 @@ mod tests {
         let a = compile(&module).expect("compile");
         assert!(!a.source.contains("sir-runtime-shell"), "got:\n{}", a.source);
     }
+
+    // ─── boolean / unary operator builtins (Q8d audit) ──────────────────────
+
+    fn bc(name: &str, args: Vec<Expr>) -> Expr {
+        Expr::BuiltinCall { name: name.into(), args, effects: EffectSet::PURE, span: s() }
+    }
+
+    #[test]
+    fn and_or_not_neg_builtins_lower_natively_ts() {
+        let and = bc("and", vec![Expr::BoolLit { value: true, span: s() }, Expr::IntLit { value: 1, span: s() }]);
+        let a = compile(&module_with_main_body(vec![], and, &[])).expect("compile");
+        assert!(a.source.contains("__Sir.truthy(__l) ? (1) : __l"), "and: got:\n{}", a.source);
+
+        let or = bc("or", vec![Expr::BoolLit { value: false, span: s() }, Expr::IntLit { value: 2, span: s() }]);
+        let a = compile(&module_with_main_body(vec![], or, &[])).expect("compile");
+        assert!(a.source.contains("__Sir.truthy(__l) ? __l : (2)"), "or: got:\n{}", a.source);
+
+        let not = bc("not", vec![Expr::BoolLit { value: true, span: s() }]);
+        let a = compile(&module_with_main_body(vec![], not, &[])).expect("compile");
+        assert!(a.source.contains("(!__Sir.truthy(true))"), "not: got:\n{}", a.source);
+
+        let neg = bc("neg", vec![Expr::IntLit { value: 5, span: s() }]);
+        let a = compile(&module_with_main_body(vec![], neg, &[])).expect("compile");
+        assert!(a.source.contains("(-(5))"), "neg: got:\n{}", a.source);
+        assert!(!a.source.contains("__Sir.callBuiltin(\"neg\""), "got:\n{}", a.source);
+    }
 }

--- a/code/packages/typescript/sir-runtime-core/CHANGELOG.md
+++ b/code/packages/typescript/sir-runtime-core/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to `@coding-adventures/sir-runtime-core` are documented here.
 
+## [0.1.3] - 2026-06-15
+
+### Changed
+
+- `callBuiltin` now throws a descriptive error for an unregistered SIR builtin
+  — naming the builtin, listing the known ones, and explaining it indicates a
+  backend coverage gap — rather than a bare `unknown builtin: <name>`.
+
 ## [0.1.2] - 2026-06-15
 
 ### Changed

--- a/code/packages/typescript/sir-runtime-core/package-lock.json
+++ b/code/packages/typescript/sir-runtime-core/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@coding-adventures/sir-runtime-core",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@coding-adventures/sir-runtime-core",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "license": "MIT",
       "dependencies": {
         "@coding-adventures/sir-runtime-pairs": "file:../sir-runtime-pairs"

--- a/code/packages/typescript/sir-runtime-core/package.json
+++ b/code/packages/typescript/sir-runtime-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coding-adventures/sir-runtime-core",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Core runtime for Semantic-IR-emitted TypeScript/JavaScript — SIR truthiness, symbols, pairs, equality, display, arithmetic, closures, globals",
   "type": "module",
   "main": "src/index.ts",

--- a/code/packages/typescript/sir-runtime-core/src/runtime.ts
+++ b/code/packages/typescript/sir-runtime-core/src/runtime.ts
@@ -101,7 +101,18 @@ const builtins: Record<string, (...args: Val[]) => Val> = {
 export function callBuiltin(name: string, args: Val[]): Val {
   const fn = builtins[name];
   if (fn === undefined) {
-    throw new Error(`unknown builtin: ${name}`);
+    // The SIR backends translate most builtins to native code or a dedicated
+    // per-concern runtime package, so this generic dispatch only fires for the
+    // small set core registers. An unregistered name means the backend emitted
+    // a `callBuiltin("<name>", …)` for a builtin it does not yet lower — a
+    // backend coverage gap, not a user error — so name it and point there.
+    const known = Object.keys(builtins).sort().join(", ");
+    throw new Error(
+      `SIR builtin "${name}" is not implemented in sir-runtime-core's dispatch ` +
+        `table (known: ${known}). The backend emitted a callBuiltin for a ` +
+        `builtin it does not lower natively or via a per-concern runtime ` +
+        `package; this is a backend coverage gap.`,
+    );
   }
   return fn(...args);
 }


### PR DESCRIPTION
## Q8(d) — builtin audit: boolean/unary operators + hardened dispatch error

Closes out the Q8 builtin audit. I probed the Ruby frontend to enumerate which
exotic builtins actually reach the SIR backends as a `BuiltinCall`.

**Key finding:** Ruby `&&`/`and`, `||`/`or`, `!`/`not`, and unary minus lower to
`BuiltinCall("and"/"or"/"not"/"neg", …)` — and these fell through to the eager
`call_builtin`/`callBuiltin` dispatch (unregistered → runtime error). So **any
program using a boolean operator emitted code that crashed at runtime.** Now
they lower **natively** in both backends:

- `and`/`or` → the same truthy-guarded **short-circuiting** lambda / arrow-IIFE as `Expr::LogicalAnd`/`LogicalOr` (Ruby short-circuit semantics + SIR truthiness — the rhs is not evaluated when the lhs decides the result, which the eager dispatch table could not preserve).
- `not` → `(not _sir_truthy(x))` / `(!__Sir.truthy(x))` (always boolean); `neg` → `(-(x))`.

**Hardened unknown-builtin error** (`sir-runtime-core` py 0.1.2, ts 0.1.3): `call_builtin`/`callBuiltin` now name the builtin, list the known ones, and explain an unregistered name signals a *backend coverage gap* — instead of a bare `unknown builtin: <name>`.

**Remaining audit-found builtins** — `range`, `splat`, `double_splat`, `block_pass`, `yield`, `lambda`, `defined?` — are call-ABI / control-flow shaped (they interact with the call convention, iteration, and block protocol) and are a **documented follow-up tranche**, not silently dropped. Until lowered they now hit the descriptive error rather than a cryptic failure. (`=~` does not currently parse in the frontend.)

### Backends
`semantic-ir-to-python` 0.1.12, `semantic-ir-to-typescript` 0.1.11.

### Verification
- `cargo test`: semantic-ir-to-typescript **346 + 52**, semantic-ir-to-python **62** — all green. New direct-SIR tests for `and`/`or`/`not`/`neg` native lowering (incl. that they don't route to the dispatch table).
- Core packages: py **30** / ts **18** tests green (the descriptive-error change breaks no existing test).
- `/security-review`: PASSED (operands escaped via the shared `emit_expr`; arity-guarded arms fall through safely; error message interpolates only the already-visible builtin name + the static known-builtin list — no injection/leak; no new unsafe/panic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
