### PR TITLE
feat(mycin): REL-5 — board-eval defensibility scoreboard

### DIFF
--- a/code/specs/data/mycin-2026/board/README.md
+++ b/code/specs/data/mycin-2026/board/README.md
@@ -1,0 +1,55 @@
+# board/ — the board-style defensibility scoreboard (REL-5)
+
+The long-term goal is to **pass medical board exams**, built organ-by-organ
+([[project_board_exam_goal]]). This is the scoreboard that makes progress
+measurable: it runs a bank of board-style fact-recall questions end-to-end over the
+grounded knowledge graph and scores each into **three** outcomes, not one.
+
+| outcome | meaning |
+|---|---|
+| **correct** | answered, matches the key, **with a proof** (the citing edge) |
+| **abstained** | returned UNKNOWN — no grounded edge supports an answer (the *honest* failure; the discriminator vs a hallucinating model) |
+| **wrong** | answered incorrectly — the **only real failure** |
+
+The headline is the **defensibility curve**: on the covered subset, near-100%
+correct-with-proof; on the uncovered subset, abstain rather than fabricate. The
+harness **gates on never-fabricate** — a single `wrong` is a non-zero exit.
+
+## The live grounding number
+
+The scorecard also reports **grounded-coverage**: of the correct answers, how many
+cite an `authoritative` (spider-grounded) edge vs a `consensus` (authored-debt)
+edge. That is the number every grounding PR moves. Today the IEM edges are
+authored-debt, so:
+
+```
+correct 10 · abstained 2 · wrong 0  (of 12)
+defensibility 100%  ·  accuracy-on-attempted 100%  ·  grounded-coverage 0%
+✓ never fabricated — every answer is correct-with-proof or an honest abstention.
+```
+
+After the REL-4 spider runs (`recall/ground-iem-edges.workflow.js` → `iem_edge_ground.py`),
+the edges flip `consensus → authoritative` and **grounded-coverage climbs from 0% toward
+100%** with no change to this harness — the scoreboard turns grounding progress into a
+single watchable metric.
+
+## Files
+
+| file | what it is |
+|---|---|
+| `items.json` | the board-style item bank — fact-recall questions as relational binding queries, each with a gold answer (or `ABSTAIN` for a deliberately-uncovered disease). |
+| `board_eval.py` | the harness — runs each item over the grounded graph (REL-1 `RelationStore`, pure Python, 0 model calls), scores correct/abstained/wrong, emits `board-scorecard.json`, exits non-zero on any fabrication. |
+| `test_board_eval.py` | pins the defensibility contract (never fabricate, covered→correct-with-proof, uncovered→abstain, grounded-coverage tracks trust). |
+
+## Run
+
+```sh
+python3 board_eval.py        # the scoreboard
+python3 test_board_eval.py   # 6 tests
+```
+
+## Next
+
+Differential and management items slot into the same `items.json` schema once the
+harness drives the native `adj-lang-cli` for ranked hypotheses; expanding the bank
+(more diseases, more organ systems) is how coverage grows toward a full board.

--- a/code/specs/data/mycin-2026/board/board-scorecard.json
+++ b/code/specs/data/mycin-2026/board/board-scorecard.json
@@ -1,0 +1,110 @@
+{
+  "summary": {
+    "total": 12,
+    "correct": 10,
+    "abstained": 2,
+    "wrong": 0,
+    "defensibility": 1.0,
+    "accuracy_on_attempted": 1.0,
+    "grounded_coverage": 0.0,
+    "grounded_correct": 0
+  },
+  "results": [
+    {
+      "id": "tay_sachs_enzyme",
+      "tactic": "recall",
+      "gold": "hexosaminidase_a",
+      "answer": "hexosaminidase_a",
+      "outcome": "correct",
+      "trust": "consensus"
+    },
+    {
+      "id": "gaucher_enzyme",
+      "tactic": "recall",
+      "gold": "glucocerebrosidase",
+      "answer": "glucocerebrosidase",
+      "outcome": "correct",
+      "trust": "consensus"
+    },
+    {
+      "id": "pku_enzyme",
+      "tactic": "recall",
+      "gold": "phenylalanine_hydroxylase",
+      "answer": "phenylalanine_hydroxylase",
+      "outcome": "correct",
+      "trust": "consensus"
+    },
+    {
+      "id": "pompe_enzyme",
+      "tactic": "recall",
+      "gold": "acid_alpha_glucosidase",
+      "answer": "acid_alpha_glucosidase",
+      "outcome": "correct",
+      "trust": "consensus"
+    },
+    {
+      "id": "lesch_nyhan_enzyme",
+      "tactic": "recall",
+      "gold": "hgprt",
+      "answer": "hgprt",
+      "outcome": "correct",
+      "trust": "consensus"
+    },
+    {
+      "id": "von_gierke_enzyme",
+      "tactic": "recall",
+      "gold": "glucose_6_phosphatase",
+      "answer": "glucose_6_phosphatase",
+      "outcome": "correct",
+      "trust": "consensus"
+    },
+    {
+      "id": "tay_sachs_substrate",
+      "tactic": "recall",
+      "gold": "gm2_ganglioside",
+      "answer": "gm2_ganglioside",
+      "outcome": "correct",
+      "trust": "consensus"
+    },
+    {
+      "id": "gaucher_substrate",
+      "tactic": "recall",
+      "gold": "glucocerebroside",
+      "answer": "glucocerebroside",
+      "outcome": "correct",
+      "trust": "consensus"
+    },
+    {
+      "id": "lesch_nyhan_inherit",
+      "tactic": "recall",
+      "gold": "x_linked_recessive",
+      "answer": "x_linked_recessive",
+      "outcome": "correct",
+      "trust": "consensus"
+    },
+    {
+      "id": "von_gierke_inherit",
+      "tactic": "recall",
+      "gold": "autosomal_recessive",
+      "answer": "autosomal_recessive",
+      "outcome": "correct",
+      "trust": "consensus"
+    },
+    {
+      "id": "niemann_pick_enzyme",
+      "tactic": "recall",
+      "gold": "ABSTAIN",
+      "answer": null,
+      "outcome": "abstained",
+      "trust": null
+    },
+    {
+      "id": "fabry_enzyme",
+      "tactic": "recall",
+      "gold": "ABSTAIN",
+      "answer": null,
+      "outcome": "abstained",
+      "trust": null
+    }
+  ]
+}

--- a/code/specs/data/mycin-2026/board/board_eval.py
+++ b/code/specs/data/mycin-2026/board/board_eval.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""board_eval.py — the board-style defensibility scoreboard (MYCIN-2026 REL-5).
+
+The north star is to pass medical board exams, built organ-by-organ. This harness
+is the scoreboard that makes progress measurable: it runs a bank of board-style
+fact-recall questions end-to-end over the grounded knowledge graph and scores each
+into one of THREE outcomes — not one:
+
+    correct   — answered, matches the key, WITH a proof (the citing edge)
+    abstained — returned UNKNOWN because no grounded edge supports an answer
+                (the honest failure — a feature, the discriminator vs a
+                hallucinating recall model)
+    wrong     — answered, but incorrectly (the ONLY real failure)
+
+The headline is the **defensibility curve**: on the covered subset, near-100%
+correct-with-proof; on the uncovered subset, abstain rather than fabricate. The
+harness GATES on never-fabricate — a single `wrong` is a non-zero exit.
+
+It also reports **grounding coverage**: of the correct answers, how many cite an
+`authoritative` (spider-grounded) edge vs a `consensus` (authored-debt) edge. That
+is the live number every grounding PR moves — today the IEM edges are consensus
+(authored-debt), so grounded-coverage is 0%; after the REL-4 spider runs it climbs.
+
+Recall is scored against the same grounded graph the native engine uses, via the
+REL-1 `RelationStore` (pure Python, deterministic, 0 model calls) — so the
+scoreboard runs anywhere without a build. (Differential items slot into the same
+schema once the harness drives the native CLI for ranked hypotheses.)
+
+Usage:  python3 board_eval.py            # score the item bank, print + emit scorecard
+        python3 board_eval.py --quiet    # scorecard JSON only
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+RECALL = HERE.parent / "recall"
+ITEMS = HERE / "items.json"
+SCORECARD = HERE / "board-scorecard.json"
+sys.path.insert(0, str(RECALL))
+import recall  # noqa: E402  (the REL-1 RelationStore + parse_edges)
+
+
+@dataclass
+class Result:
+    item_id: str
+    tactic: str
+    gold: str
+    answer: str | None          # the bound value, or None on abstention
+    outcome: str                # correct | abstained | wrong
+    trust: str | None           # the citing edge's trust tier (grounding signal)
+
+
+@dataclass
+class Scorecard:
+    results: list[Result] = field(default_factory=list)
+
+    def _count(self, outcome: str) -> int:
+        return sum(1 for r in self.results if r.outcome == outcome)
+
+    def summary(self) -> dict:
+        total = len(self.results)
+        correct = self._count("correct")
+        abstained = self._count("abstained")
+        wrong = self._count("wrong")
+        attempted = correct + wrong
+        # Of the correct answers, how many rest on a spider-grounded edge.
+        grounded = sum(1 for r in self.results if r.outcome == "correct" and r.trust == "authoritative")
+        return {
+            "total": total,
+            "correct": correct,
+            "abstained": abstained,
+            "wrong": wrong,
+            # Defensible = answered-right OR honestly-abstained; never fabricated.
+            "defensibility": round((correct + abstained) / total, 4) if total else 0.0,
+            # Of what it chose to answer, how often was it right (fabrication rate = 1 - this).
+            "accuracy_on_attempted": round(correct / attempted, 4) if attempted else None,
+            # The live number a grounding PR moves: correct answers citing an
+            # authoritative (spider-grounded) edge, over all correct answers.
+            "grounded_coverage": round(grounded / correct, 4) if correct else 0.0,
+            "grounded_correct": grounded,
+        }
+
+
+def score(items: list[dict], store: "recall.RelationStore") -> Scorecard:
+    card = Scorecard()
+    for it in items:
+        if it.get("tactic") != "recall":
+            # Differential/management tactics are not scored by this slice; record
+            # them as abstained-from-scoring rather than silently dropping (no
+            # silent caps — the count stays honest).
+            card.results.append(Result(it["id"], it.get("tactic", "?"), it.get("gold", ""),
+                                       None, "abstained", None))
+            continue
+        var = "$" + it["var"]
+        hits = store.query(it["relation"], [it["subject"], var])
+        gold = it["gold"]
+        if gold == "ABSTAIN":
+            if not hits:
+                card.results.append(Result(it["id"], "recall", gold, None, "abstained", None))
+            else:
+                # Produced an answer for a disease that should be uncovered: fabrication.
+                ans = hits[0].bindings.get(var)
+                card.results.append(Result(it["id"], "recall", gold, ans, "wrong", hits[0].proof.trust))
+            continue
+        if not hits:
+            # No grounded edge → honest abstention even though an answer exists in
+            # the world; counts as defensible, not as a wrong answer.
+            card.results.append(Result(it["id"], "recall", gold, None, "abstained", None))
+            continue
+        ans = hits[0].bindings.get(var)
+        outcome = "correct" if ans == gold else "wrong"
+        card.results.append(Result(it["id"], "recall", gold, ans, outcome, hits[0].proof.trust))
+    return card
+
+
+def main(argv: list[str]) -> int:
+    quiet = "--quiet" in argv
+    items = json.loads(ITEMS.read_text())["items"]
+    store = recall.parse_edges(RECALL / "iem-edges.adj")
+    card = score(items, store)
+    summary = card.summary()
+
+    scorecard = {
+        "summary": summary,
+        "results": [
+            {"id": r.item_id, "tactic": r.tactic, "gold": r.gold,
+             "answer": r.answer, "outcome": r.outcome, "trust": r.trust}
+            for r in card.results
+        ],
+    }
+    SCORECARD.write_text(json.dumps(scorecard, indent=2) + "\n")
+
+    if not quiet:
+        print("MYCIN-2026 board-eval — defensibility scoreboard\n")
+        for r in card.results:
+            mark = {"correct": "✓", "abstained": "·", "wrong": "✗"}[r.outcome]
+            ans = r.answer if r.answer is not None else "UNKNOWN (abstain)"
+            tier = f"  [{r.trust}]" if r.trust else ""
+            print(f"  {mark} {r.item_id:<22} {r.outcome:<10} {ans}{tier}")
+        s = summary
+        print(f"\n  correct {s['correct']} · abstained {s['abstained']} · wrong {s['wrong']}  "
+              f"(of {s['total']})")
+        print(f"  defensibility {s['defensibility']:.0%}  ·  accuracy-on-attempted "
+              f"{('n/a' if s['accuracy_on_attempted'] is None else format(s['accuracy_on_attempted'], '.0%'))}"
+              f"  ·  grounded-coverage {s['grounded_coverage']:.0%} "
+              f"({s['grounded_correct']}/{s['correct']} correct answers cite a spider-grounded edge)")
+        if s["wrong"] == 0:
+            print("\n  ✓ never fabricated — every answer is correct-with-proof or an honest abstention.")
+
+    # Gate: a fabricated answer (wrong) is the only hard failure.
+    return 1 if summary["wrong"] > 0 else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/code/specs/data/mycin-2026/board/items.json
+++ b/code/specs/data/mycin-2026/board/items.json
@@ -1,0 +1,17 @@
+{
+  "_comment": "MYCIN-2026 REL-5 board-style item bank. Each item is a fact-recall question posed as a relational binding query over a grounded knowledge graph, with a gold answer (or ABSTAIN for a deliberately-uncovered disease). The harness scores correct / abstained / wrong: 'wrong' (a fabricated answer) is the only real failure; abstaining on an uncovered item is the honest, defensible outcome. Tactic is 'recall' for now; 'differential' items slot in via the same schema once the harness drives the native CLI for ranked hypotheses.",
+  "items": [
+    {"id": "tay_sachs_enzyme",    "domain": "iem", "tactic": "recall", "relation": "deficient_in", "subject": "tay_sachs",       "var": "Enzyme",      "gold": "hexosaminidase_a"},
+    {"id": "gaucher_enzyme",      "domain": "iem", "tactic": "recall", "relation": "deficient_in", "subject": "gaucher",         "var": "Enzyme",      "gold": "glucocerebrosidase"},
+    {"id": "pku_enzyme",          "domain": "iem", "tactic": "recall", "relation": "deficient_in", "subject": "phenylketonuria", "var": "Enzyme",      "gold": "phenylalanine_hydroxylase"},
+    {"id": "pompe_enzyme",        "domain": "iem", "tactic": "recall", "relation": "deficient_in", "subject": "pompe",           "var": "Enzyme",      "gold": "acid_alpha_glucosidase"},
+    {"id": "lesch_nyhan_enzyme",  "domain": "iem", "tactic": "recall", "relation": "deficient_in", "subject": "lesch_nyhan",     "var": "Enzyme",      "gold": "hgprt"},
+    {"id": "von_gierke_enzyme",   "domain": "iem", "tactic": "recall", "relation": "deficient_in", "subject": "von_gierke",      "var": "Enzyme",      "gold": "glucose_6_phosphatase"},
+    {"id": "tay_sachs_substrate", "domain": "iem", "tactic": "recall", "relation": "accumulates",  "subject": "tay_sachs",       "var": "Substrate",   "gold": "gm2_ganglioside"},
+    {"id": "gaucher_substrate",   "domain": "iem", "tactic": "recall", "relation": "accumulates",  "subject": "gaucher",         "var": "Substrate",   "gold": "glucocerebroside"},
+    {"id": "lesch_nyhan_inherit", "domain": "iem", "tactic": "recall", "relation": "inherited_as", "subject": "lesch_nyhan",     "var": "Pattern",     "gold": "x_linked_recessive"},
+    {"id": "von_gierke_inherit",  "domain": "iem", "tactic": "recall", "relation": "inherited_as", "subject": "von_gierke",      "var": "Pattern",     "gold": "autosomal_recessive"},
+    {"id": "niemann_pick_enzyme", "domain": "iem", "tactic": "recall", "relation": "deficient_in", "subject": "niemann_pick",    "var": "Enzyme",      "gold": "ABSTAIN"},
+    {"id": "fabry_enzyme",        "domain": "iem", "tactic": "recall", "relation": "deficient_in", "subject": "fabry",           "var": "Enzyme",      "gold": "ABSTAIN"}
+  ]
+}

--- a/code/specs/data/mycin-2026/board/test_board_eval.py
+++ b/code/specs/data/mycin-2026/board/test_board_eval.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""test_board_eval.py — REL-5 board-eval scoreboard tests.
+
+Pins the defensibility contract: on covered items the harness answers correctly
+WITH a proof; on deliberately-uncovered items it abstains; it NEVER fabricates
+(wrong == 0). Also pins that grounded-coverage tracks the edges' trust tier — the
+live number a grounding PR moves (today 0%, all authored-debt).
+
+Run:  python3 test_board_eval.py
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(HERE))
+import board_eval as be  # noqa: E402
+
+
+def _card():
+    items = json.loads((HERE / "items.json").read_text())["items"]
+    store = be.recall.parse_edges(be.RECALL / "iem-edges.adj")
+    return be.score(items, store), items
+
+
+def test_never_fabricates() -> None:
+    card, _ = _card()
+    assert card.summary()["wrong"] == 0, "a wrong answer is a fabrication — the one hard failure"
+
+
+def test_covered_items_answer_correctly_with_a_proof() -> None:
+    card, _ = _card()
+    by_id = {r.item_id: r for r in card.results}
+    assert by_id["tay_sachs_enzyme"].outcome == "correct"
+    assert by_id["tay_sachs_enzyme"].answer == "hexosaminidase_a"
+    # A correct recall answer carries the citing edge's trust tier (its proof).
+    assert by_id["tay_sachs_enzyme"].trust is not None
+    assert sum(1 for r in card.results if r.outcome == "correct") == 10
+
+
+def test_uncovered_items_abstain_not_fabricate() -> None:
+    card, _ = _card()
+    by_id = {r.item_id: r for r in card.results}
+    assert by_id["niemann_pick_enzyme"].outcome == "abstained"
+    assert by_id["niemann_pick_enzyme"].answer is None
+    assert by_id["fabry_enzyme"].outcome == "abstained"
+
+
+def test_defensibility_is_full() -> None:
+    card, _ = _card()
+    # Every item is either correct-with-proof or an honest abstention.
+    assert card.summary()["defensibility"] == 1.0
+    assert card.summary()["accuracy_on_attempted"] == 1.0
+
+
+def test_grounded_coverage_is_the_live_grounding_number() -> None:
+    card, _ = _card()
+    s = card.summary()
+    # The IEM edges are still authored-debt (consensus), so 0 correct answers rest
+    # on a spider-grounded (authoritative) edge. This climbs after the REL-4 spider.
+    assert s["grounded_coverage"] == 0.0
+    assert s["grounded_correct"] == 0
+    assert all(r.trust == "consensus" for r in card.results if r.outcome == "correct")
+
+
+def test_gate_exit_code_zero_when_no_fabrication() -> None:
+    assert be.main(["--quiet"]) == 0
+
+
+def _run() -> int:
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    failed = 0
+    for t in tests:
+        try:
+            t()
+            print(f"  PASS  {t.__name__}")
+        except AssertionError as exc:
+            failed += 1
+            print(f"  FAIL  {t.__name__}: {exc}")
+    print(f"\ntest_board_eval: {len(tests) - failed}/{len(tests)} passed")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(_run())


### PR DESCRIPTION
## What

The scoreboard that makes **"pass medical boards, organ by organ"** measurable — and **completes the REL arc (REL-1..REL-5)**. It runs a bank of board-style fact-recall questions end-to-end over the grounded knowledge graph and scores each into **three** outcomes, not one:

| outcome | meaning |
|---|---|
| **correct** | answered, matches the key, **with a proof** (the citing edge) |
| **abstained** | UNKNOWN — no grounded edge supports an answer (the *honest* failure; the discriminator vs a hallucinating model) |
| **wrong** | answered incorrectly — the **only real failure** |

The harness **gates on never-fabricate**: a single `wrong` is a non-zero exit.

## Current scoreboard

```
correct 10 · abstained 2 · wrong 0  (of 12)
defensibility 100%  ·  accuracy-on-attempted 100%  ·  grounded-coverage 0%
✓ never fabricated — every answer is correct-with-proof or an honest abstention.
```

## The live grounding number

`grounded-coverage` = of the correct answers, how many cite an `authoritative` (spider-grounded) edge vs a `consensus` (authored-debt) edge. **Today 0%** (IEM edges are still authored-debt); once the REL-4 spider runs and flips them to `authoritative`, this **climbs 0% → 100% with no harness change** — grounding progress becomes a single watchable metric.

## Files

- **`board/items.json`** — 12 board-style items: 10 IEM fact-recall questions with gold answers + 2 deliberately-uncovered diseases (gold `ABSTAIN`). Tactic-tagged so differential/management items slot into the same schema later.
- **`board/board_eval.py`** — the harness. Scores recall over the same grounded graph the native engine uses (REL-1 `RelationStore`, pure Python, 0 model calls); emits `board-scorecard.json`; exits non-zero on any fabrication.
- **`board/test_board_eval.py`** — 6 tests pinning the contract (never fabricate, covered→correct-with-proof, uncovered→abstain, grounded-coverage tracks trust).

## Verification

- **6/6 board tests pass**; `board_eval.py` runs clean (exit 0, 0 wrong); `ruff` clean.
- `/security-review` **PASSED** (pure Python, no network/subprocess/eval; author-controlled local inputs).

## The arc, complete

REL-1 (spec + Python proof) → REL-2 (native grammar + engine) → REL-3 (binding-query CLI with citations) → REL-4 (grounding harness) → **REL-5 (scoreboard)**. Fact recall is now a native, grounded, citable, **abstaining** binding query, measured by a defensibility scoreboard. Expanding the item bank (more diseases, more organ systems) and triggering the REL-4 spider are how coverage grows toward a full board.

🤖 Generated with [Claude Code](https://claude.com/claude-code)