### PR TITLE
[codex] Add Thread attach route approval summary

### DIFF
--- a/code/packages/rust/thread-mle/CHANGELOG.md
+++ b/code/packages/rust/thread-mle/CHANGELOG.md
@@ -53,5 +53,7 @@ All notable changes to this package will be documented in this file.
   readiness into final route validation checks.
 - Thread attach route certification summaries that turn route-validation
   readiness into final route certification checks.
+- Thread attach route approval summaries that turn route-certification
+  readiness into final route approval checks.
 - Neighbor table primitives for parent/child/router relationships, stale
   timeout expiry, link margin tracking, and parent-candidate selection.

--- a/code/packages/rust/thread-mle/README.md
+++ b/code/packages/rust/thread-mle/README.md
@@ -50,6 +50,8 @@ This crate starts the D27 Thread control-plane layer above 6LoWPAN:
   final route validation checks
 - attach route certification summaries that turn route-validation readiness into
   final route certification checks
+- attach route approval summaries that turn route-certification readiness into
+  final route approval checks
 - deterministic parent/child attach-state skeleton
 - neighbor table primitives for parent/child/router relationships, link margin,
   timeout freshness, and parent-candidate selection

--- a/code/packages/rust/thread-mle/src/lib.rs
+++ b/code/packages/rust/thread-mle/src/lib.rs
@@ -2552,6 +2552,147 @@ pub fn summarize_thread_attach_route_certification(
     ThreadAttachRouteCertificationSummary::from_validation_summary(validation_summary)
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ThreadAttachRouteApprovalSummary {
+    pub certification_summary: ThreadAttachRouteCertificationSummary,
+    pub required_route_approval_check_count: usize,
+    pub passed_route_approval_check_count: usize,
+    pub missing_route_approval_check_count: usize,
+    pub route_certification_ready: bool,
+    pub route_validation_ready: bool,
+    pub route_verification_ready: bool,
+    pub route_publication_ready: bool,
+    pub route_completion_ready: bool,
+    pub route_signoff_ready: bool,
+    pub route_audit_ready: bool,
+    pub route_handoff_ready: bool,
+    pub attach_complete: bool,
+    pub network_data_ready: bool,
+    pub routing_surface_ready: bool,
+    pub parent_or_route_anchor_ready: bool,
+    pub route_approval_ready: bool,
+}
+
+impl ThreadAttachRouteApprovalSummary {
+    pub fn from_certification_summary(
+        certification_summary: ThreadAttachRouteCertificationSummary,
+    ) -> Self {
+        let route_certification_ready = certification_summary.is_route_certification_ready();
+        let route_validation_ready = !certification_summary.needs_route_validation();
+        let route_verification_ready = !certification_summary.needs_route_verification();
+        let route_publication_ready = !certification_summary.needs_route_publication();
+        let route_completion_ready = !certification_summary.needs_route_completion();
+        let route_signoff_ready = !certification_summary.needs_route_signoff();
+        let route_audit_ready = !certification_summary.needs_route_audit();
+        let route_handoff_ready = !certification_summary.needs_route_handoff();
+        let attach_complete = !certification_summary.needs_attach_completion();
+        let network_data_ready = !certification_summary.needs_network_data();
+        let routing_surface_ready = !certification_summary.needs_routing_surface();
+        let parent_or_route_anchor_ready = !certification_summary.needs_parent_or_route_anchor();
+        let checks = [
+            route_certification_ready,
+            route_validation_ready,
+            route_verification_ready,
+            route_publication_ready,
+            route_completion_ready,
+            route_signoff_ready,
+            route_audit_ready,
+            route_handoff_ready,
+            attach_complete,
+            network_data_ready,
+            routing_surface_ready,
+            parent_or_route_anchor_ready,
+        ];
+        let passed_route_approval_check_count = checks.iter().filter(|ready| **ready).count();
+        let required_route_approval_check_count = checks.len();
+        let missing_route_approval_check_count =
+            required_route_approval_check_count - passed_route_approval_check_count;
+        let route_approval_ready = missing_route_approval_check_count == 0;
+
+        Self {
+            certification_summary,
+            required_route_approval_check_count,
+            passed_route_approval_check_count,
+            missing_route_approval_check_count,
+            route_certification_ready,
+            route_validation_ready,
+            route_verification_ready,
+            route_publication_ready,
+            route_completion_ready,
+            route_signoff_ready,
+            route_audit_ready,
+            route_handoff_ready,
+            attach_complete,
+            network_data_ready,
+            routing_surface_ready,
+            parent_or_route_anchor_ready,
+            route_approval_ready,
+        }
+    }
+
+    pub fn is_route_approval_ready(self) -> bool {
+        self.route_approval_ready
+    }
+
+    pub fn has_approval_gaps(self) -> bool {
+        self.missing_route_approval_check_count > 0
+    }
+
+    pub fn needs_route_certification(self) -> bool {
+        !self.route_certification_ready
+    }
+
+    pub fn needs_route_validation(self) -> bool {
+        !self.route_validation_ready
+    }
+
+    pub fn needs_route_verification(self) -> bool {
+        !self.route_verification_ready
+    }
+
+    pub fn needs_route_publication(self) -> bool {
+        !self.route_publication_ready
+    }
+
+    pub fn needs_route_completion(self) -> bool {
+        !self.route_completion_ready
+    }
+
+    pub fn needs_route_signoff(self) -> bool {
+        !self.route_signoff_ready
+    }
+
+    pub fn needs_route_audit(self) -> bool {
+        !self.route_audit_ready
+    }
+
+    pub fn needs_route_handoff(self) -> bool {
+        !self.route_handoff_ready
+    }
+
+    pub fn needs_attach_completion(self) -> bool {
+        !self.attach_complete
+    }
+
+    pub fn needs_network_data(self) -> bool {
+        !self.network_data_ready
+    }
+
+    pub fn needs_routing_surface(self) -> bool {
+        !self.routing_surface_ready
+    }
+
+    pub fn needs_parent_or_route_anchor(self) -> bool {
+        !self.parent_or_route_anchor_ready
+    }
+}
+
+pub fn summarize_thread_attach_route_approval(
+    certification_summary: ThreadAttachRouteCertificationSummary,
+) -> ThreadAttachRouteApprovalSummary {
+    ThreadAttachRouteApprovalSummary::from_certification_summary(certification_summary)
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ThreadDiagnosticSnapshot {
     pub captured_at_ms: u64,
@@ -4981,6 +5122,155 @@ mod tests {
         assert!(!summary.route_certification_ready);
         assert!(!summary.is_route_certification_ready());
         assert!(summary.has_certification_gaps());
+        assert!(summary.needs_route_validation());
+        assert!(summary.needs_route_verification());
+        assert!(summary.needs_route_publication());
+        assert!(summary.needs_route_completion());
+        assert!(summary.needs_route_signoff());
+        assert!(summary.needs_route_audit());
+        assert!(summary.needs_route_handoff());
+        assert!(summary.needs_attach_completion());
+        assert!(summary.needs_network_data());
+        assert!(summary.needs_routing_surface());
+        assert!(summary.needs_parent_or_route_anchor());
+    }
+
+    #[test]
+    fn attach_route_approval_summary_marks_ready_route_approval() {
+        let mut table = NeighborTable::new(DeviceRole::Child);
+        table.upsert(ThreadNeighbor::new(
+            ThreadNeighborId(0x1000),
+            DeviceRole::Router,
+            NeighborRelationship::Parent,
+            1_200,
+            10_000,
+        ));
+        let action_summary = ThreadAttachActionSummary::from_summaries(
+            MleMessageBatchSummary::empty(),
+            table.summary_at(1_250),
+        );
+        let completion_summary = summarize_thread_attach_completion(
+            action_summary,
+            table
+                .diagnostic_snapshot(None, 1_250)
+                .unwrap()
+                .supervision_plan(),
+        );
+        let border_router =
+            NetworkDataTlv::new(NetworkDataTlvType::BorderRouter, true, vec![0xaa]).unwrap();
+        let context = NetworkDataTlv::new(NetworkDataTlvType::Context, true, vec![0x01]).unwrap();
+        let prefix = ThreadPrefixData::new(
+            true,
+            3,
+            64,
+            vec![0xfd, 0x00, 0xab, 0xcd, 0, 0, 0, 0],
+            vec![border_router, context],
+        )
+        .unwrap();
+        let network_data = ThreadNetworkData::from_tlvs(vec![prefix.to_tlv().unwrap()]).unwrap();
+        let network_data_readiness =
+            summarize_thread_network_data_readiness(&network_data).unwrap();
+        let handoff_summary =
+            summarize_thread_attach_route_handoff(completion_summary, network_data_readiness);
+        let audit_summary = summarize_thread_attach_route_audit(handoff_summary);
+        let signoff_summary = summarize_thread_attach_route_signoff(audit_summary);
+        let completion_summary = summarize_thread_attach_route_completion(signoff_summary);
+        let publication_summary = summarize_thread_attach_route_publication(completion_summary);
+        let verification_summary = summarize_thread_attach_route_verification(publication_summary);
+        let validation_summary = summarize_thread_attach_route_validation(verification_summary);
+        let certification_summary = summarize_thread_attach_route_certification(validation_summary);
+
+        let summary = summarize_thread_attach_route_approval(certification_summary);
+
+        assert_eq!(summary.certification_summary, certification_summary);
+        assert_eq!(summary.required_route_approval_check_count, 12);
+        assert_eq!(summary.passed_route_approval_check_count, 12);
+        assert_eq!(summary.missing_route_approval_check_count, 0);
+        assert!(summary.route_certification_ready);
+        assert!(summary.route_validation_ready);
+        assert!(summary.route_verification_ready);
+        assert!(summary.route_publication_ready);
+        assert!(summary.route_completion_ready);
+        assert!(summary.route_signoff_ready);
+        assert!(summary.route_audit_ready);
+        assert!(summary.route_handoff_ready);
+        assert!(summary.attach_complete);
+        assert!(summary.network_data_ready);
+        assert!(summary.routing_surface_ready);
+        assert!(summary.parent_or_route_anchor_ready);
+        assert!(summary.route_approval_ready);
+        assert!(summary.is_route_approval_ready());
+        assert!(!summary.has_approval_gaps());
+        assert!(!summary.needs_route_certification());
+        assert!(!summary.needs_route_validation());
+        assert!(!summary.needs_route_verification());
+        assert!(!summary.needs_route_publication());
+        assert!(!summary.needs_route_completion());
+        assert!(!summary.needs_route_signoff());
+        assert!(!summary.needs_route_audit());
+        assert!(!summary.needs_route_handoff());
+        assert!(!summary.needs_attach_completion());
+        assert!(!summary.needs_network_data());
+        assert!(!summary.needs_routing_surface());
+        assert!(!summary.needs_parent_or_route_anchor());
+    }
+
+    #[test]
+    fn attach_route_approval_summary_routes_blocked_approval() {
+        let table = NeighborTable::new(DeviceRole::Child);
+        let action_summary = ThreadAttachActionSummary::from_summaries(
+            MleMessageBatchSummary::empty(),
+            table.summary_at(1_250),
+        );
+        let completion_summary = summarize_thread_attach_completion(
+            action_summary,
+            table
+                .diagnostic_snapshot(None, 1_250)
+                .unwrap()
+                .supervision_plan(),
+        );
+        let unknown = NetworkDataTlv::new(NetworkDataTlvType::Unknown(42), false, vec![3]).unwrap();
+        let network_data = ThreadNetworkData::from_tlvs(vec![unknown]).unwrap();
+        let network_data_readiness = network_data.summary().unwrap().readiness();
+        let handoff_summary = ThreadAttachRouteHandoffSummary::from_completion_and_network_data(
+            completion_summary,
+            network_data_readiness,
+        );
+        let audit_summary = ThreadAttachRouteAuditSummary::from_handoff_summary(handoff_summary);
+        let signoff_summary = ThreadAttachRouteSignoffSummary::from_audit_summary(audit_summary);
+        let completion_summary =
+            ThreadAttachRouteCompletionSummary::from_signoff_summary(signoff_summary);
+        let publication_summary =
+            ThreadAttachRoutePublicationSummary::from_completion_summary(completion_summary);
+        let verification_summary =
+            ThreadAttachRouteVerificationSummary::from_publication_summary(publication_summary);
+        let validation_summary =
+            ThreadAttachRouteValidationSummary::from_verification_summary(verification_summary);
+        let certification_summary =
+            ThreadAttachRouteCertificationSummary::from_validation_summary(validation_summary);
+
+        let summary =
+            ThreadAttachRouteApprovalSummary::from_certification_summary(certification_summary);
+
+        assert_eq!(summary.required_route_approval_check_count, 12);
+        assert_eq!(summary.passed_route_approval_check_count, 0);
+        assert_eq!(summary.missing_route_approval_check_count, 12);
+        assert!(!summary.route_certification_ready);
+        assert!(!summary.route_validation_ready);
+        assert!(!summary.route_verification_ready);
+        assert!(!summary.route_publication_ready);
+        assert!(!summary.route_completion_ready);
+        assert!(!summary.route_signoff_ready);
+        assert!(!summary.route_audit_ready);
+        assert!(!summary.route_handoff_ready);
+        assert!(!summary.attach_complete);
+        assert!(!summary.network_data_ready);
+        assert!(!summary.routing_surface_ready);
+        assert!(!summary.parent_or_route_anchor_ready);
+        assert!(!summary.route_approval_ready);
+        assert!(!summary.is_route_approval_ready());
+        assert!(summary.has_approval_gaps());
+        assert!(summary.needs_route_certification());
         assert!(summary.needs_route_validation());
         assert!(summary.needs_route_verification());
         assert!(summary.needs_route_publication());


### PR DESCRIPTION
## Summary
- add Thread attach route approval summaries on top of route certification readiness
- document the new Thread MLE approval summary surface in README and CHANGELOG
- cover ready and blocked approval paths

## Tests
- cargo test --manifest-path code\packages\rust\thread-mle\Cargo.toml