### PR TITLE
feat(mini-sqlite): enforce PRAGMA query_only=1 read-only gate

### DIFF
--- a/code/packages/python/mini-sqlite/CHANGELOG.md
+++ b/code/packages/python/mini-sqlite/CHANGELOG.md
@@ -1,5 +1,36 @@
 # Changelog
 
+## [2.16.0] - 2026-05-24
+
+### Added
+
+- ``PRAGMA query_only = 1`` now enforces read-only mode.  Any DML
+  (INSERT / UPDATE / DELETE) or DDL (CREATE TABLE / DROP TABLE /
+  CREATE INDEX / DROP INDEX / ALTER TABLE / CREATE VIEW / DROP VIEW /
+  CREATE TRIGGER / DROP TRIGGER) executed while ``query_only = 1``
+  is active on the connection raises::
+
+      OperationalError: attempt to write a readonly database
+
+  — matching SQLite's ``SQLITE_READONLY`` (code 8) behaviour.
+  ``PRAGMA query_only = 0`` always lifts the gate, even while it is
+  engaged.  SELECT, BEGIN/COMMIT/ROLLBACK, SAVEPOINT/RELEASE, and
+  PRAGMA statements are never affected.
+
+  Lifts the "Scope limit" noted in the 2.13.0 entry.  Previously
+  the PRAGMA value round-tripped correctly but had no semantic
+  effect — writes silently executed regardless of the setting.
+
+### Fixed
+
+- ``Connection.close()`` now evicts per-connection PRAGMA state from
+  the engine's ``_PRAGMA_STATE`` dict.  Previously, if the underlying
+  backend object was garbage-collected and its memory address reused
+  by a new connection, the new connection could silently inherit the
+  closed connection's PRAGMA settings (e.g. ``query_only=1`` from a
+  previous test or caller).  A ``__del__`` hook ensures cleanup
+  even when ``close()`` is not called explicitly.
+
 ## [2.15.0] - 2026-05-24
 
 ### Fixed

--- a/code/packages/python/mini-sqlite/pyproject.toml
+++ b/code/packages/python/mini-sqlite/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-mini-sqlite"
-version = "2.15.0"
+version = "2.16.0"
 description = "PEP 249 DB-API 2.0 facade over the sql-lexer / parser / planner / optimizer / codegen / vm / backend stack."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/mini-sqlite/src/mini_sqlite/connection.py
+++ b/code/packages/python/mini-sqlite/src/mini_sqlite/connection.py
@@ -35,6 +35,7 @@ from storage_sqlite import SqliteFileBackend
 
 from .advisor import IndexAdvisor
 from .cursor import Cursor
+from .engine import _pragma_clear
 from .errors import OperationalError, ProgrammingError, translate
 from .policy import IndexPolicy
 
@@ -284,7 +285,21 @@ class Connection:
             with contextlib.suppress(Exception):
                 self._backend.rollback(self._txn)
             self._txn = None
+        # Evict per-connection PRAGMA state so that a future connection
+        # whose backend is allocated at the same memory address does not
+        # inherit this connection's PRAGMA settings (e.g. query_only=1).
+        _pragma_clear(self._backend)
         self._closed = True
+
+    def __del__(self) -> None:
+        # Best-effort cleanup so that PRAGMA state is evicted even when the
+        # caller drops the connection without calling close() explicitly.
+        # __del__ is called by CPython's reference-counting GC immediately
+        # when the last reference is dropped; the explicit close() call is
+        # still the safe path because GC order is not guaranteed in all
+        # implementations or across cycle-collected objects.
+        with contextlib.suppress(Exception):
+            self.close()
 
     def __enter__(self) -> Connection:
         self._assert_open()

--- a/code/packages/python/mini-sqlite/src/mini_sqlite/engine.py
+++ b/code/packages/python/mini-sqlite/src/mini_sqlite/engine.py
@@ -34,15 +34,24 @@ from sql_optimizer import optimize
 from sql_parser import parse_sql
 from sql_planner import (
     AggregateExpr,
+    AlterTableStmt,
     CreateIndexStmt,
+    CreateTableStmt,
+    CreateTriggerStmt,
     CreateViewStmt,
+    DeleteStmt,
+    DropIndexStmt,
+    DropTableStmt,
+    DropTriggerStmt,
     DropViewStmt,
     IndexScan,
+    InsertSelectStmt,
     InsertValuesStmt,
     ReleaseSavepointStmt,
     RollbackToStmt,
     SavepointStmt,
     Scan,
+    UpdateStmt,
     plan,
 )
 from sql_planner.plan import (
@@ -69,7 +78,44 @@ from sql_vm import QueryEvent, QueryResult, execute  # noqa: F401 — QueryEvent
 
 from .adapter import to_statement
 from .binding import substitute
-from .errors import ProgrammingError, translate
+from .errors import (
+    READONLY_ERROR_MESSAGE,
+    OperationalError,
+    ProgrammingError,
+    translate,
+)
+
+# Statement types that SQLite considers "writes" — anything that mutates
+# the database file (rows OR schema).  When ``PRAGMA query_only = 1`` is
+# active on a connection, attempting any of these raises
+# ``OperationalError: attempt to write a readonly database`` (SQLITE_READONLY,
+# code 8) — matching the reference engine's stance.
+#
+# NOT included (these are deliberately allowed under query_only):
+#   * SelectStmt / UnionStmt / IntersectStmt / ExceptStmt — pure reads
+#   * BeginStmt / CommitStmt / RollbackStmt — transaction control
+#   * SavepointStmt / ReleaseSavepointStmt / RollbackToStmt — savepoint
+#     control (SQLite lets these through; the savepoint just brackets
+#     no writes)
+#   * PRAGMA, VACUUM/ANALYZE/REINDEX/EXPLAIN, ATTACH/DETACH — intercepted
+#     *before* parsing, so they never reach this gate at all.  This is
+#     important: ``PRAGMA query_only = 0`` must still work to lift the
+#     gate, and SQLite permits it.
+_WRITE_STMT_TYPES = (
+    InsertValuesStmt,
+    InsertSelectStmt,
+    UpdateStmt,
+    DeleteStmt,
+    CreateTableStmt,
+    DropTableStmt,
+    CreateIndexStmt,
+    DropIndexStmt,
+    CreateViewStmt,
+    DropViewStmt,
+    CreateTriggerStmt,
+    DropTriggerStmt,
+    AlterTableStmt,
+)
 
 if TYPE_CHECKING:
     from .advisor import IndexAdvisor
@@ -174,6 +220,26 @@ def run(
         )
         ast = parse_sql(bound)
         stmt = to_statement(ast, view_defs=view_defs)
+
+        # ``PRAGMA query_only = 1`` puts the connection into read-only mode.
+        # SQLite rejects any write (DML or DDL) with
+        # ``OperationalError: attempt to write a readonly database``
+        # (SQLITE_READONLY).  The gate must fire BEFORE the CREATE VIEW /
+        # DROP VIEW intercept below (CREATE VIEW is a write under SQLite's
+        # rules) and before planning so we never spin up a write program
+        # only to discard it.
+        #
+        # PRAGMAs, ATTACH/DETACH, VACUUM/ANALYZE/REINDEX/EXPLAIN, and
+        # BEGIN/COMMIT/ROLLBACK/SAVEPOINT are not subject to this gate —
+        # the first four are intercepted before parsing, and the
+        # transaction-control statements are intentionally not in
+        # ``_WRITE_STMT_TYPES`` (SQLite permits them under query_only).
+        # In particular, ``PRAGMA query_only = 0`` must still succeed so
+        # callers can lift the gate without re-opening the connection.
+        if isinstance(stmt, _WRITE_STMT_TYPES) and bool(
+            _pragma_get(backend, "query_only")
+        ):
+            raise OperationalError(READONLY_ERROR_MESSAGE)
 
         # CREATE VIEW / DROP VIEW are intercepted here — the planner and VM
         # never see them.  We update the connection's view registry and return
@@ -833,18 +899,24 @@ _PRAGMA_DEFAULTS: dict[str, tuple[object, str]] = {
     # it defensively before deciding whether to issue an explicit
     # ``PRAGMA read_uncommitted = 0`` for a clean baseline.
     "read_uncommitted": (0,                "integer"),  # bool; off by default
-    # query_only — when ON, SQLite rejects writes ("attempt to write a
-    # readonly database").  Mini-sqlite doesn't enforce the read-only
-    # semantics yet — the PRAGMA value just round-trips per connection,
-    # so callers that read it back to confirm settings see the value
-    # they wrote.  Enforcement is a future increment.
+    # query_only — when ON, SQLite rejects writes with
+    # ``OperationalError: attempt to write a readonly database``
+    # (SQLITE_READONLY).  Mini-sqlite honours this as of 2.16.0:
+    # any DML (INSERT/UPDATE/DELETE) or DDL (CREATE/DROP/ALTER)
+    # statement is rejected at the run-loop gate (see
+    # ``_WRITE_STMT_TYPES`` and the check in ``run()`` above).
+    # SELECTs, PRAGMAs, and transaction control still flow normally,
+    # so ``PRAGMA query_only = 0`` can always lift the gate.
     "query_only":       (0,                "integer"),  # bool; off by default
 }
 
 # Per-connection PRAGMA state.  Keyed by the backend object's id() so each
 # connection has its own values.  WeakValueDictionary would be ideal but
-# Backend isn't hashable in all implementations; we settle for id-keyed dict
-# and accept that values leak until the process exits.
+# Backend isn't hashable in all implementations; we settle for id-keyed dict.
+# Entries must be explicitly evicted when a connection closes (see
+# ``_pragma_clear``) to prevent id-reuse pollution: CPython can allocate a
+# new backend at the same address as a just-freed one, causing the new
+# connection to inherit the old connection's PRAGMA state.
 _PRAGMA_STATE: dict[int, dict[str, object]] = {}
 
 
@@ -861,6 +933,16 @@ def _pragma_set(backend: Backend, name: str, value: object) -> None:
     """Store *value* for *name* on this backend."""
     state = _PRAGMA_STATE.setdefault(id(backend), {})
     state[name] = value
+
+
+def _pragma_clear(backend: Backend) -> None:
+    """Remove all per-connection PRAGMA state for *backend*.
+
+    Called by :meth:`~mini_sqlite.connection.Connection.close` to prevent
+    stale state from leaking into a later connection whose backend object
+    happens to be allocated at the same memory address.
+    """
+    _PRAGMA_STATE.pop(id(backend), None)
 
 
 def _run_pragma(backend: Backend, sql: str, *, fk_child: dict | None = None) -> QueryResult:
@@ -1282,10 +1364,12 @@ def _run_pragma(backend: Backend, sql: str, *, fk_child: dict | None = None) -> 
         # level.  Mini-sqlite has no shared cache, so this is purely a
         # round-tripped value with no semantic effect.
         "read_uncommitted",
-        # ``query_only`` is meant to reject writes when ON.  Mini-sqlite
-        # round-trips the value but does NOT yet enforce the read-only
-        # gate — INSERT/UPDATE/DELETE will still execute even when
-        # ``query_only = 1``.  Enforcement is a future increment.
+        # ``query_only`` is enforced as of mini-sqlite 2.16.0 — when ON
+        # the run-loop gate in ``run()`` rejects any DML or DDL with
+        # ``OperationalError: attempt to write a readonly database``
+        # (SQLITE_READONLY).  The PRAGMA's value still round-trips here
+        # so callers can read it back and so ``PRAGMA query_only = 0``
+        # always lifts the gate.
         "query_only",
     }
     _INT_PRAGMAS = {

--- a/code/packages/python/mini-sqlite/src/mini_sqlite/errors.py
+++ b/code/packages/python/mini-sqlite/src/mini_sqlite/errors.py
@@ -57,6 +57,12 @@ class OperationalError(DatabaseError):
     """Errors related to the database's operation — runtime failures."""
 
 
+# Reused as the exact wording is constant across SQLite versions and is
+# what callers (and our oracle tests) match on.  Centralised so a future
+# message-text drift surfaces in exactly one place.
+READONLY_ERROR_MESSAGE = "attempt to write a readonly database"
+
+
 class IntegrityError(DatabaseError):
     """Constraint violations (unique, not-null, foreign key)."""
 

--- a/code/packages/python/mini-sqlite/tests/test_tier3_pragma_read_uncommitted_and_query_only.py
+++ b/code/packages/python/mini-sqlite/tests/test_tier3_pragma_read_uncommitted_and_query_only.py
@@ -1,12 +1,14 @@
 """Tests for ``PRAGMA read_uncommitted`` and ``PRAGMA query_only``.
 
 Both PRAGMAs are recognised as accept-and-store boolean settings
-that round-trip per connection (default ``0``).  Mini-sqlite does
-not honour the underlying semantics — ``read_uncommitted`` selects
-SQLite's shared-cache isolation level (mini-sqlite has no shared
-cache) and ``query_only`` should reject writes when ON (enforcement
-is a future increment).  Callers that read the PRAGMA back to
-confirm settings — common in ORMs and migration tools — see the
+that round-trip per connection (default ``0``).  ``read_uncommitted``
+selects SQLite's shared-cache isolation level — mini-sqlite has no
+shared cache so the value is purely round-tripped with no semantic
+effect.  ``query_only`` is **enforced** as of mini-sqlite 2.16.0:
+when ON, mini-sqlite raises ``OperationalError: attempt to write
+a readonly database`` for any DML or DDL statement, matching
+SQLite's behaviour.  Callers that read the PRAGMA back to confirm
+settings — common in ORMs and migration tools — see the
 SQLite-compatible values.
 
 Previously mini-sqlite returned ``[]`` for both reads (vs sqlite3's
@@ -128,21 +130,149 @@ class TestConnectionIsolation:
         assert a.execute("PRAGMA query_only").fetchall() == [(1,)]
 
 
-class TestQueryOnlyEnforcementNotIncluded:
-    """Document the scope limit: ``query_only`` does NOT yet block writes.
+class TestQueryOnlyEnforcement:
+    """``query_only = 1`` now rejects writes (mini-sqlite 2.16.0).
 
     SQLite raises ``OperationalError: attempt to write a readonly
     database`` when ``query_only = 1`` and a write is attempted.
-    Mini-sqlite currently allows the write through — enforcement is
-    deferred to a future increment.  Pin the current behaviour so a
-    future fix that wires the gate is detected (the test will need
-    updating then, with a matching CHANGELOG note).
+    The previous ``TestQueryOnlyEnforcementNotIncluded`` class pinned
+    the divergence; this class pins the matching SQLite-compatible
+    enforcement.  Coverage spans DML (INSERT/UPDATE/DELETE) and DDL
+    (CREATE TABLE / CREATE INDEX / DROP TABLE / ALTER / CREATE VIEW),
+    plus the negative-space checks (SELECT works, lifting the gate
+    works, isolation across connections).
     """
 
-    def test_query_only_does_not_block_writes_yet(self) -> None:
+    _ERR = "attempt to write a readonly database"
+
+    # ------------------------------------------------------------------
+    # DML: INSERT / UPDATE / DELETE all hit the gate
+    # ------------------------------------------------------------------
+
+    def _setup_with_row(self) -> mini_sqlite.Connection:
+        m = mini_sqlite.connect(":memory:")
+        m.execute("CREATE TABLE t (a INT)")
+        m.execute("INSERT INTO t VALUES (1)")
+        m.execute("PRAGMA query_only = 1")
+        return m
+
+    def test_insert_rejected(self) -> None:
+        m = self._setup_with_row()
+        try:
+            m.execute("INSERT INTO t VALUES (2)")
+        except mini_sqlite.OperationalError as e:
+            assert self._ERR in str(e)
+        else:
+            raise AssertionError("expected OperationalError")
+
+    def test_update_rejected(self) -> None:
+        m = self._setup_with_row()
+        try:
+            m.execute("UPDATE t SET a = 99")
+        except mini_sqlite.OperationalError as e:
+            assert self._ERR in str(e)
+        else:
+            raise AssertionError("expected OperationalError")
+
+    def test_delete_rejected(self) -> None:
+        m = self._setup_with_row()
+        try:
+            m.execute("DELETE FROM t")
+        except mini_sqlite.OperationalError as e:
+            assert self._ERR in str(e)
+        else:
+            raise AssertionError("expected OperationalError")
+
+    # ------------------------------------------------------------------
+    # DDL: CREATE TABLE / CREATE INDEX / DROP TABLE / ALTER / CREATE VIEW
+    # ------------------------------------------------------------------
+
+    def test_create_table_rejected(self) -> None:
+        m = mini_sqlite.connect(":memory:")
+        m.execute("PRAGMA query_only = 1")
+        try:
+            m.execute("CREATE TABLE t (a INT)")
+        except mini_sqlite.OperationalError as e:
+            assert self._ERR in str(e)
+        else:
+            raise AssertionError("expected OperationalError")
+
+    def test_create_index_rejected(self) -> None:
         m = mini_sqlite.connect(":memory:")
         m.execute("CREATE TABLE t (a INT)")
         m.execute("PRAGMA query_only = 1")
-        # Currently no error — mini-sqlite does not enforce read-only mode.
-        m.execute("INSERT INTO t VALUES (1)")
+        try:
+            m.execute("CREATE INDEX idx ON t(a)")
+        except mini_sqlite.OperationalError as e:
+            assert self._ERR in str(e)
+        else:
+            raise AssertionError("expected OperationalError")
+
+    def test_drop_table_rejected(self) -> None:
+        m = mini_sqlite.connect(":memory:")
+        m.execute("CREATE TABLE t (a INT)")
+        m.execute("PRAGMA query_only = 1")
+        try:
+            m.execute("DROP TABLE t")
+        except mini_sqlite.OperationalError as e:
+            assert self._ERR in str(e)
+        else:
+            raise AssertionError("expected OperationalError")
+
+    def test_alter_table_rejected(self) -> None:
+        m = mini_sqlite.connect(":memory:")
+        m.execute("CREATE TABLE t (a INT)")
+        m.execute("PRAGMA query_only = 1")
+        try:
+            m.execute("ALTER TABLE t RENAME TO t2")
+        except mini_sqlite.OperationalError as e:
+            assert self._ERR in str(e)
+        else:
+            raise AssertionError("expected OperationalError")
+
+    def test_create_view_rejected(self) -> None:
+        m = mini_sqlite.connect(":memory:")
+        m.execute("CREATE TABLE t (a INT)")
+        m.execute("PRAGMA query_only = 1")
+        try:
+            m.execute("CREATE VIEW v AS SELECT * FROM t")
+        except mini_sqlite.OperationalError as e:
+            assert self._ERR in str(e)
+        else:
+            raise AssertionError("expected OperationalError")
+
+    # ------------------------------------------------------------------
+    # Negative space: SELECT permitted; PRAGMA lift permitted; isolation
+    # ------------------------------------------------------------------
+
+    def test_select_still_permitted(self) -> None:
+        m = self._setup_with_row()
+        # SELECT is a pure read; the gate must let it through.
         assert m.execute("SELECT * FROM t").fetchall() == [(1,)]
+
+    def test_pragma_can_lift_gate(self) -> None:
+        m = self._setup_with_row()
+        # ``PRAGMA query_only = 0`` always succeeds, even when the
+        # gate is currently engaged — otherwise the connection would
+        # be wedged read-only with no escape.
+        m.execute("PRAGMA query_only = 0")
+        m.execute("INSERT INTO t VALUES (2)")
+        assert sorted(m.execute("SELECT a FROM t").fetchall()) == [(1,), (2,)]
+
+    def test_gate_is_per_connection(self) -> None:
+        # Connection A's query_only must not leak into connection B.
+        a = mini_sqlite.connect(":memory:")
+        b = mini_sqlite.connect(":memory:")
+        for c in (a, b):
+            c.execute("CREATE TABLE t (a INT)")
+        a.execute("PRAGMA query_only = 1")
+        # B's write proceeds normally.
+        b.execute("INSERT INTO t VALUES (7)")
+        assert b.execute("SELECT a FROM t").fetchall() == [(7,)]
+        # A's write is still gated.
+        try:
+            a.execute("INSERT INTO t VALUES (8)")
+        except mini_sqlite.OperationalError as e:
+            assert self._ERR in str(e)
+        else:
+            raise AssertionError("expected OperationalError on A")


### PR DESCRIPTION
## Summary

- `PRAGMA query_only = 1` now rejects writes with `OperationalError: attempt to write a readonly database`, matching SQLite's `SQLITE_READONLY` (code 8). Previously the value round-tripped but had no semantic effect.
- Fixes a `_PRAGMA_STATE` pollution bug where id-reuse between GC'd and new connections could cause the new connection to silently inherit the old connection's PRAGMA settings.

## What changed

**`engine.py`**
- Adds `_WRITE_STMT_TYPES` tuple: INSERT/UPDATE/DELETE/CREATE TABLE/DROP TABLE/CREATE INDEX/DROP INDEX/ALTER TABLE/CREATE VIEW/DROP VIEW/CREATE TRIGGER/DROP TRIGGER
- Adds `READONLY_ERROR_MESSAGE` constant in `errors.py` (centralised so message drift is caught in one place)
- Adds write gate in `run()` — fires after `to_statement()`, before CREATE VIEW intercept
- Adds `_pragma_clear(backend)` to evict `_PRAGMA_STATE` entries on close
- Updates `_PRAGMA_STATE` comment and `query_only` inline note to reflect enforcement

**`connection.py`**
- `close()` calls `_pragma_clear(self._backend)` to evict state while backend is still live
- `__del__` calls `close()` (best-effort, exception-suppressed) so cleanup fires even without explicit close

## Tests

Replaces `TestQueryOnlyEnforcementNotIncluded` (the old divergence pin) with `TestQueryOnlyEnforcement` (11 tests):
- DML gate: INSERT, UPDATE, DELETE rejected
- DDL gate: CREATE TABLE, CREATE INDEX, DROP TABLE, ALTER TABLE, CREATE VIEW rejected
- SELECT pass-through: reads still work
- Gate lift: `PRAGMA query_only = 0` unblocks writes
- Per-connection isolation: gate on connection A doesn't affect B

## Version

mini-sqlite 2.15.0 → 2.16.0

## Test plan

- [x] All 25 tests in `test_tier3_pragma_read_uncommitted_and_query_only.py` pass (run in deterministic order)
- [x] Ruff clean on all touched files
- [x] Security review: passed
- [ ] CI: build matrix + CodeQL green

🤖 Generated with [Claude Code](https://claude.com/claude-code)