### PR TITLE
feat(mycin): REL-6 — expand the board bank to 12 diseases (6 new IEM)

### DIFF
--- a/code/specs/data/mycin-2026/board/README.md
+++ b/code/specs/data/mycin-2026/board/README.md
@@ -19,19 +19,20 @@ harness **gates on never-fabricate** — a single `wrong` is a non-zero exit.
 
 The scorecard also reports **grounded-coverage**: of the correct answers, how many
 cite an `authoritative` (spider-grounded) edge vs a `consensus` (authored-debt)
-edge. That is the number every grounding PR moves. Today the IEM edges are
-authored-debt, so:
+edge. That is the number every grounding/expansion PR moves:
 
 ```
-correct 10 · abstained 2 · wrong 0  (of 12)
-defensibility 100%  ·  accuracy-on-attempted 100%  ·  grounded-coverage 0%
+correct 18 · abstained 2 · wrong 0  (of 20)
+defensibility 100%  ·  accuracy-on-attempted 100%  ·  grounded-coverage 50%
 ✓ never fabricated — every answer is correct-with-proof or an honest abstention.
 ```
 
-After the REL-4 spider runs (`recall/ground-iem-edges.workflow.js` → `iem_edge_ground.py`),
-the edges flip `consensus → authoritative` and **grounded-coverage climbs from 0% toward
-100%** with no change to this harness — the scoreboard turns grounding progress into a
-single watchable metric.
+The number tracks **both levers**, honestly. The REL-4b spider grounded 9 of the
+original answers (`consensus → authoritative`). REL-6 then expanded the bank from 6 to
+**12 diseases** — the 6 new disease sets enter as authored-debt, so grounded-coverage
+**dipped 90% → 50%**. Re-running `recall/ground-iem-edges.workflow.js` →
+`iem_edge_ground.py` on the new edges climbs it back. **Expansion adds debt; grounding
+retires it; the scoreboard shows both** — with no change to this harness.
 
 ## Files
 

--- a/code/specs/data/mycin-2026/board/board-scorecard.json
+++ b/code/specs/data/mycin-2026/board/board-scorecard.json
@@ -1,12 +1,12 @@
 {
   "summary": {
-    "total": 12,
-    "correct": 10,
+    "total": 20,
+    "correct": 18,
     "abstained": 2,
     "wrong": 0,
     "defensibility": 1.0,
     "accuracy_on_attempted": 1.0,
-    "grounded_coverage": 0.9,
+    "grounded_coverage": 0.5,
     "grounded_correct": 9
   },
   "results": [
@@ -91,7 +91,71 @@
       "trust": "authoritative"
     },
     {
+      "id": "fabry_enzyme",
+      "tactic": "recall",
+      "gold": "alpha_galactosidase_a",
+      "answer": "alpha_galactosidase_a",
+      "outcome": "correct",
+      "trust": "consensus"
+    },
+    {
+      "id": "fabry_substrate",
+      "tactic": "recall",
+      "gold": "globotriaosylceramide",
+      "answer": "globotriaosylceramide",
+      "outcome": "correct",
+      "trust": "consensus"
+    },
+    {
       "id": "niemann_pick_enzyme",
+      "tactic": "recall",
+      "gold": "acid_sphingomyelinase",
+      "answer": "acid_sphingomyelinase",
+      "outcome": "correct",
+      "trust": "consensus"
+    },
+    {
+      "id": "krabbe_enzyme",
+      "tactic": "recall",
+      "gold": "galactocerebrosidase",
+      "answer": "galactocerebrosidase",
+      "outcome": "correct",
+      "trust": "consensus"
+    },
+    {
+      "id": "hurler_enzyme",
+      "tactic": "recall",
+      "gold": "alpha_l_iduronidase",
+      "answer": "alpha_l_iduronidase",
+      "outcome": "correct",
+      "trust": "consensus"
+    },
+    {
+      "id": "msud_enzyme",
+      "tactic": "recall",
+      "gold": "branched_chain_ketoacid_dehydrogenase",
+      "answer": "branched_chain_ketoacid_dehydrogenase",
+      "outcome": "correct",
+      "trust": "consensus"
+    },
+    {
+      "id": "galactosemia_enzyme",
+      "tactic": "recall",
+      "gold": "galactose_1_phosphate_uridyltransferase",
+      "answer": "galactose_1_phosphate_uridyltransferase",
+      "outcome": "correct",
+      "trust": "consensus"
+    },
+    {
+      "id": "msud_inherit",
+      "tactic": "recall",
+      "gold": "autosomal_recessive",
+      "answer": "autosomal_recessive",
+      "outcome": "correct",
+      "trust": "consensus"
+    },
+    {
+      "id": "wilson_disease_enzyme",
       "tactic": "recall",
       "gold": "ABSTAIN",
       "answer": null,
@@ -99,7 +163,7 @@
       "trust": null
     },
     {
-      "id": "fabry_enzyme",
+      "id": "menkes_enzyme",
       "tactic": "recall",
       "gold": "ABSTAIN",
       "answer": null,

--- a/code/specs/data/mycin-2026/board/items.json
+++ b/code/specs/data/mycin-2026/board/items.json
@@ -1,17 +1,27 @@
 {
-  "_comment": "MYCIN-2026 REL-5 board-style item bank. Each item is a fact-recall question posed as a relational binding query over a grounded knowledge graph, with a gold answer (or ABSTAIN for a deliberately-uncovered disease). The harness scores correct / abstained / wrong: 'wrong' (a fabricated answer) is the only real failure; abstaining on an uncovered item is the honest, defensible outcome. Tactic is 'recall' for now; 'differential' items slot in via the same schema once the harness drives the native CLI for ranked hypotheses.",
+  "_comment": "MYCIN-2026 board-style item bank. Each item is a fact-recall question posed as a relational binding query over a grounded knowledge graph, with a gold answer (or ABSTAIN for a deliberately-uncovered disease). The harness scores correct / abstained / wrong: 'wrong' (a fabricated answer) is the only real failure; abstaining on an uncovered item is the honest, defensible outcome. Tactic is 'recall' for now; 'differential' items slot in via the same schema once the harness drives the native CLI for ranked hypotheses.",
   "items": [
-    {"id": "tay_sachs_enzyme",    "domain": "iem", "tactic": "recall", "relation": "deficient_in", "subject": "tay_sachs",       "var": "Enzyme",      "gold": "hexosaminidase_a"},
-    {"id": "gaucher_enzyme",      "domain": "iem", "tactic": "recall", "relation": "deficient_in", "subject": "gaucher",         "var": "Enzyme",      "gold": "glucocerebrosidase"},
-    {"id": "pku_enzyme",          "domain": "iem", "tactic": "recall", "relation": "deficient_in", "subject": "phenylketonuria", "var": "Enzyme",      "gold": "phenylalanine_hydroxylase"},
-    {"id": "pompe_enzyme",        "domain": "iem", "tactic": "recall", "relation": "deficient_in", "subject": "pompe",           "var": "Enzyme",      "gold": "acid_alpha_glucosidase"},
-    {"id": "lesch_nyhan_enzyme",  "domain": "iem", "tactic": "recall", "relation": "deficient_in", "subject": "lesch_nyhan",     "var": "Enzyme",      "gold": "hgprt"},
-    {"id": "von_gierke_enzyme",   "domain": "iem", "tactic": "recall", "relation": "deficient_in", "subject": "von_gierke",      "var": "Enzyme",      "gold": "glucose_6_phosphatase"},
-    {"id": "tay_sachs_substrate", "domain": "iem", "tactic": "recall", "relation": "accumulates",  "subject": "tay_sachs",       "var": "Substrate",   "gold": "gm2_ganglioside"},
-    {"id": "gaucher_substrate",   "domain": "iem", "tactic": "recall", "relation": "accumulates",  "subject": "gaucher",         "var": "Substrate",   "gold": "glucocerebroside"},
-    {"id": "lesch_nyhan_inherit", "domain": "iem", "tactic": "recall", "relation": "inherited_as", "subject": "lesch_nyhan",     "var": "Pattern",     "gold": "x_linked_recessive"},
-    {"id": "von_gierke_inherit",  "domain": "iem", "tactic": "recall", "relation": "inherited_as", "subject": "von_gierke",      "var": "Pattern",     "gold": "autosomal_recessive"},
-    {"id": "niemann_pick_enzyme", "domain": "iem", "tactic": "recall", "relation": "deficient_in", "subject": "niemann_pick",    "var": "Enzyme",      "gold": "ABSTAIN"},
-    {"id": "fabry_enzyme",        "domain": "iem", "tactic": "recall", "relation": "deficient_in", "subject": "fabry",           "var": "Enzyme",      "gold": "ABSTAIN"}
+    {"id": "tay_sachs_enzyme",    "domain": "iem", "tactic": "recall", "relation": "deficient_in", "subject": "tay_sachs",       "var": "Enzyme",    "gold": "hexosaminidase_a"},
+    {"id": "gaucher_enzyme",      "domain": "iem", "tactic": "recall", "relation": "deficient_in", "subject": "gaucher",         "var": "Enzyme",    "gold": "glucocerebrosidase"},
+    {"id": "pku_enzyme",          "domain": "iem", "tactic": "recall", "relation": "deficient_in", "subject": "phenylketonuria", "var": "Enzyme",    "gold": "phenylalanine_hydroxylase"},
+    {"id": "pompe_enzyme",        "domain": "iem", "tactic": "recall", "relation": "deficient_in", "subject": "pompe",           "var": "Enzyme",    "gold": "acid_alpha_glucosidase"},
+    {"id": "lesch_nyhan_enzyme",  "domain": "iem", "tactic": "recall", "relation": "deficient_in", "subject": "lesch_nyhan",     "var": "Enzyme",    "gold": "hgprt"},
+    {"id": "von_gierke_enzyme",   "domain": "iem", "tactic": "recall", "relation": "deficient_in", "subject": "von_gierke",      "var": "Enzyme",    "gold": "glucose_6_phosphatase"},
+    {"id": "tay_sachs_substrate", "domain": "iem", "tactic": "recall", "relation": "accumulates",  "subject": "tay_sachs",       "var": "Substrate", "gold": "gm2_ganglioside"},
+    {"id": "gaucher_substrate",   "domain": "iem", "tactic": "recall", "relation": "accumulates",  "subject": "gaucher",         "var": "Substrate", "gold": "glucocerebroside"},
+    {"id": "lesch_nyhan_inherit", "domain": "iem", "tactic": "recall", "relation": "inherited_as", "subject": "lesch_nyhan",     "var": "Pattern",   "gold": "x_linked_recessive"},
+    {"id": "von_gierke_inherit",  "domain": "iem", "tactic": "recall", "relation": "inherited_as", "subject": "von_gierke",      "var": "Pattern",   "gold": "autosomal_recessive"},
+
+    {"id": "fabry_enzyme",        "domain": "iem", "tactic": "recall", "relation": "deficient_in", "subject": "fabry",           "var": "Enzyme",    "gold": "alpha_galactosidase_a"},
+    {"id": "fabry_substrate",     "domain": "iem", "tactic": "recall", "relation": "accumulates",  "subject": "fabry",           "var": "Substrate", "gold": "globotriaosylceramide"},
+    {"id": "niemann_pick_enzyme", "domain": "iem", "tactic": "recall", "relation": "deficient_in", "subject": "niemann_pick",    "var": "Enzyme",    "gold": "acid_sphingomyelinase"},
+    {"id": "krabbe_enzyme",       "domain": "iem", "tactic": "recall", "relation": "deficient_in", "subject": "krabbe",          "var": "Enzyme",    "gold": "galactocerebrosidase"},
+    {"id": "hurler_enzyme",       "domain": "iem", "tactic": "recall", "relation": "deficient_in", "subject": "hurler",          "var": "Enzyme",    "gold": "alpha_l_iduronidase"},
+    {"id": "msud_enzyme",         "domain": "iem", "tactic": "recall", "relation": "deficient_in", "subject": "msud",            "var": "Enzyme",    "gold": "branched_chain_ketoacid_dehydrogenase"},
+    {"id": "galactosemia_enzyme", "domain": "iem", "tactic": "recall", "relation": "deficient_in", "subject": "galactosemia",    "var": "Enzyme",    "gold": "galactose_1_phosphate_uridyltransferase"},
+    {"id": "msud_inherit",        "domain": "iem", "tactic": "recall", "relation": "inherited_as", "subject": "msud",            "var": "Pattern",   "gold": "autosomal_recessive"},
+
+    {"id": "wilson_disease_enzyme", "domain": "iem", "tactic": "recall", "relation": "deficient_in", "subject": "wilson_disease", "var": "Enzyme", "gold": "ABSTAIN"},
+    {"id": "menkes_enzyme",         "domain": "iem", "tactic": "recall", "relation": "deficient_in", "subject": "menkes",         "var": "Enzyme", "gold": "ABSTAIN"}
   ]
 }

--- a/code/specs/data/mycin-2026/board/test_board_eval.py
+++ b/code/specs/data/mycin-2026/board/test_board_eval.py
@@ -38,15 +38,20 @@ def test_covered_items_answer_correctly_with_a_proof() -> None:
     assert by_id["tay_sachs_enzyme"].answer == "hexosaminidase_a"
     # A correct recall answer carries the citing edge's trust tier (its proof).
     assert by_id["tay_sachs_enzyme"].trust is not None
-    assert sum(1 for r in card.results if r.outcome == "correct") == 10
+    # REL-6 expanded the bank to 18 covered recall items across 12 diseases.
+    assert sum(1 for r in card.results if r.outcome == "correct") == 18
+    # A REL-6 disease answers correctly too (its edge is in the graph, consensus-tier).
+    assert by_id["fabry_enzyme"].outcome == "correct"
+    assert by_id["fabry_enzyme"].answer == "alpha_galactosidase_a"
 
 
 def test_uncovered_items_abstain_not_fabricate() -> None:
     card, _ = _card()
     by_id = {r.item_id: r for r in card.results}
-    assert by_id["niemann_pick_enzyme"].outcome == "abstained"
-    assert by_id["niemann_pick_enzyme"].answer is None
-    assert by_id["fabry_enzyme"].outcome == "abstained"
+    # Diseases genuinely absent from the graph must abstain, not fabricate.
+    assert by_id["wilson_disease_enzyme"].outcome == "abstained"
+    assert by_id["wilson_disease_enzyme"].answer is None
+    assert by_id["menkes_enzyme"].outcome == "abstained"
 
 
 def test_defensibility_is_full() -> None:
@@ -59,16 +64,17 @@ def test_defensibility_is_full() -> None:
 def test_grounded_coverage_is_the_live_grounding_number() -> None:
     card, _ = _card()
     s = card.summary()
-    # After the REL-4b spider, 16/18 IEM edges are spider-grounded (authoritative);
-    # 2 stayed direction_only → consensus (the adversarial verify could not confirm
-    # byte-stability). Of the 10 correct board items, 9 cite an authoritative edge —
-    # the lone holdout is lesch_nyhan_enzyme (deficient_in__lesch_nyhan, direction_only).
-    # This number IS the grounding progress: it moved 0% → 90% with no harness change.
-    assert s["grounded_coverage"] == 0.9
+    # The live number tracks BOTH levers. REL-4b spider-grounded 9 of the original
+    # board answers (authoritative). REL-6 then added 6 new diseases (8 new correct
+    # answers) as authored-debt (consensus) — so grounded-coverage DIPPED 90% → 50%
+    # (9 grounded / 18 correct). Re-running the spider on the new edges will climb it
+    # back up. Expansion adds debt; grounding retires it; the scoreboard shows both.
+    assert s["grounded_coverage"] == 0.5
     assert s["grounded_correct"] == 9
     by_id = {r.item_id: r for r in card.results}
-    assert by_id["lesch_nyhan_enzyme"].trust == "consensus"
-    assert by_id["tay_sachs_enzyme"].trust == "authoritative"
+    assert by_id["lesch_nyhan_enzyme"].trust == "consensus"   # direction_only holdout
+    assert by_id["tay_sachs_enzyme"].trust == "authoritative"  # spider-grounded
+    assert by_id["fabry_enzyme"].trust == "consensus"          # REL-6, not yet grounded
 
 
 def test_gate_exit_code_zero_when_no_fabrication() -> None:

--- a/code/specs/data/mycin-2026/recall/README.md
+++ b/code/specs/data/mycin-2026/recall/README.md
@@ -14,7 +14,7 @@ one engine, not two).
 
 | file | what it is |
 |---|---|
-| `iem-edges.adj` | the inborn-errors-of-metabolism knowledge-graph — 6 diseases × {deficient enzyme, accumulated substrate, inheritance}. **GENERATED** by `iem_edge_ground.py` (do not hand-edit). Each ungrounded edge is `trust consensus` + `% [FLAG: …]` (authored-debt, visible); a spider-grounded edge lifts to `trust authoritative` with its byte-quote + URL. |
+| `iem-edges.adj` | the inborn-errors-of-metabolism knowledge-graph — 12 diseases × {deficient enzyme, accumulated substrate, inheritance} (36 edges). **GENERATED** by `iem_edge_ground.py` (do not hand-edit). Each ungrounded edge is `trust consensus` + `% [FLAG: …]` (authored-debt, visible); a spider-grounded edge lifts to `trust authoritative` with its byte-quote + URL. |
 | `iem_edge_ground.py` | the REL-4 **write gate** — consumes `iem-edge-grounding.json` (the spider's output) and regenerates `iem-edges.adj` + `iem-edge-manifest.json`. `--check` verifies the committed file is up to date. Reuses the shared `organism_id_ground` gate helpers. |
 | `ground-iem-edges.workflow.js` | the REL-4 **spider** (opt-in, costs tokens + network): one agent per edge grounds it against a primary source (OMIM / biochemistry reference) with a verbatim byte-quote; an independent agent re-fetches + tries to refute. Produces `iem-edge-grounding.json`. |
 | `test_iem_edge_ground.py` | gate tests — ungrounded→consensus+FLAG, grounded→authoritative+quote+locator, refuted stays flagged, untrusted-quote escaping, committed-file `--check`. |

--- a/code/specs/data/mycin-2026/recall/ground-iem-edges.workflow.js
+++ b/code/specs/data/mycin-2026/recall/ground-iem-edges.workflow.js
@@ -65,6 +65,49 @@ const EDGES = [
     claim: 'Glycogen accumulates in liver and kidney in von Gierke disease.' },
   { id: 'inherited_as__von_gierke', rel: 'inherited_as', subj: 'von_gierke', obj: 'autosomal_recessive',
     claim: 'Von Gierke disease is inherited in an autosomal recessive manner.' },
+
+  // REL-6 expansion — a second high-yield disease set (must match iem_edge_ground.py GROUPS).
+  { id: 'deficient_in__fabry', rel: 'deficient_in', subj: 'fabry', obj: 'alpha_galactosidase_a',
+    claim: 'Fabry disease results from deficiency of the enzyme alpha-galactosidase A.' },
+  { id: 'accumulates__fabry', rel: 'accumulates', subj: 'fabry', obj: 'globotriaosylceramide',
+    claim: 'Globotriaosylceramide (Gb3 / ceramide trihexoside) accumulates in Fabry disease.' },
+  { id: 'inherited_as__fabry', rel: 'inherited_as', subj: 'fabry', obj: 'x_linked_recessive',
+    claim: 'Fabry disease is inherited in an X-linked recessive manner.' },
+
+  { id: 'deficient_in__niemann_pick', rel: 'deficient_in', subj: 'niemann_pick', obj: 'acid_sphingomyelinase',
+    claim: 'Niemann-Pick disease types A and B result from deficiency of acid sphingomyelinase (ASM / SMPD1).' },
+  { id: 'accumulates__niemann_pick', rel: 'accumulates', subj: 'niemann_pick', obj: 'sphingomyelin',
+    claim: 'Sphingomyelin accumulates in Niemann-Pick disease (types A/B).' },
+  { id: 'inherited_as__niemann_pick', rel: 'inherited_as', subj: 'niemann_pick', obj: 'autosomal_recessive',
+    claim: 'Niemann-Pick disease is inherited in an autosomal recessive manner.' },
+
+  { id: 'deficient_in__krabbe', rel: 'deficient_in', subj: 'krabbe', obj: 'galactocerebrosidase',
+    claim: 'Krabbe disease results from deficiency of galactocerebrosidase (galactosylceramidase / GALC).' },
+  { id: 'accumulates__krabbe', rel: 'accumulates', subj: 'krabbe', obj: 'psychosine',
+    claim: 'Psychosine (galactosylsphingosine) accumulates in Krabbe disease.' },
+  { id: 'inherited_as__krabbe', rel: 'inherited_as', subj: 'krabbe', obj: 'autosomal_recessive',
+    claim: 'Krabbe disease is inherited in an autosomal recessive manner.' },
+
+  { id: 'deficient_in__hurler', rel: 'deficient_in', subj: 'hurler', obj: 'alpha_l_iduronidase',
+    claim: 'Hurler syndrome (mucopolysaccharidosis type I) results from deficiency of alpha-L-iduronidase (IDUA).' },
+  { id: 'accumulates__hurler', rel: 'accumulates', subj: 'hurler', obj: 'glycosaminoglycans',
+    claim: 'Glycosaminoglycans (dermatan and heparan sulfate) accumulate in Hurler syndrome.' },
+  { id: 'inherited_as__hurler', rel: 'inherited_as', subj: 'hurler', obj: 'autosomal_recessive',
+    claim: 'Hurler syndrome is inherited in an autosomal recessive manner.' },
+
+  { id: 'deficient_in__msud', rel: 'deficient_in', subj: 'msud', obj: 'branched_chain_ketoacid_dehydrogenase',
+    claim: 'Maple syrup urine disease results from deficiency of branched-chain alpha-ketoacid dehydrogenase (BCKDH).' },
+  { id: 'accumulates__msud', rel: 'accumulates', subj: 'msud', obj: 'branched_chain_amino_acids',
+    claim: 'Branched-chain amino acids (leucine, isoleucine, valine) accumulate in maple syrup urine disease.' },
+  { id: 'inherited_as__msud', rel: 'inherited_as', subj: 'msud', obj: 'autosomal_recessive',
+    claim: 'Maple syrup urine disease is inherited in an autosomal recessive manner.' },
+
+  { id: 'deficient_in__galactosemia', rel: 'deficient_in', subj: 'galactosemia', obj: 'galactose_1_phosphate_uridyltransferase',
+    claim: 'Classic galactosemia results from deficiency of galactose-1-phosphate uridyltransferase (GALT).' },
+  { id: 'accumulates__galactosemia', rel: 'accumulates', subj: 'galactosemia', obj: 'galactose_1_phosphate',
+    claim: 'Galactose-1-phosphate accumulates in classic galactosemia.' },
+  { id: 'inherited_as__galactosemia', rel: 'inherited_as', subj: 'galactosemia', obj: 'autosomal_recessive',
+    claim: 'Classic galactosemia is inherited in an autosomal recessive manner.' },
 ]
 
 const GROUND_SCHEMA = {

--- a/code/specs/data/mycin-2026/recall/iem-edge-manifest.json
+++ b/code/specs/data/mycin-2026/recall/iem-edge-manifest.json
@@ -180,7 +180,187 @@
       "trust": "authoritative",
       "source": "This condition is inherited in an autosomal recessive pattern, which means both copies of the gene in each cell must have a variant to cause the disorder.",
       "url": "https://medlineplus.gov/genetics/condition/glycogen-storage-disease-type-i/"
+    },
+    "deficient_in__fabry": {
+      "relation": "deficient_in",
+      "subject": "fabry",
+      "object": "alpha_galactosidase_a",
+      "status": "pending",
+      "verdict": "FLAG",
+      "trust": "consensus",
+      "source": "Fabry disease results from deficiency of the enzyme alpha-galactosidase A.",
+      "url": null
+    },
+    "accumulates__fabry": {
+      "relation": "accumulates",
+      "subject": "fabry",
+      "object": "globotriaosylceramide",
+      "status": "pending",
+      "verdict": "FLAG",
+      "trust": "consensus",
+      "source": "Globotriaosylceramide (Gb3) accumulates in Fabry disease.",
+      "url": null
+    },
+    "inherited_as__fabry": {
+      "relation": "inherited_as",
+      "subject": "fabry",
+      "object": "x_linked_recessive",
+      "status": "pending",
+      "verdict": "FLAG",
+      "trust": "consensus",
+      "source": "Fabry disease is inherited in an X-linked recessive manner.",
+      "url": null
+    },
+    "deficient_in__niemann_pick": {
+      "relation": "deficient_in",
+      "subject": "niemann_pick",
+      "object": "acid_sphingomyelinase",
+      "status": "pending",
+      "verdict": "FLAG",
+      "trust": "consensus",
+      "source": "Niemann-Pick disease types A and B result from deficiency of acid sphingomyelinase.",
+      "url": null
+    },
+    "accumulates__niemann_pick": {
+      "relation": "accumulates",
+      "subject": "niemann_pick",
+      "object": "sphingomyelin",
+      "status": "pending",
+      "verdict": "FLAG",
+      "trust": "consensus",
+      "source": "Sphingomyelin accumulates in Niemann-Pick disease.",
+      "url": null
+    },
+    "inherited_as__niemann_pick": {
+      "relation": "inherited_as",
+      "subject": "niemann_pick",
+      "object": "autosomal_recessive",
+      "status": "pending",
+      "verdict": "FLAG",
+      "trust": "consensus",
+      "source": "Niemann-Pick disease is inherited in an autosomal recessive manner.",
+      "url": null
+    },
+    "deficient_in__krabbe": {
+      "relation": "deficient_in",
+      "subject": "krabbe",
+      "object": "galactocerebrosidase",
+      "status": "pending",
+      "verdict": "FLAG",
+      "trust": "consensus",
+      "source": "Krabbe disease results from deficiency of galactocerebrosidase (galactosylceramidase).",
+      "url": null
+    },
+    "accumulates__krabbe": {
+      "relation": "accumulates",
+      "subject": "krabbe",
+      "object": "psychosine",
+      "status": "pending",
+      "verdict": "FLAG",
+      "trust": "consensus",
+      "source": "Psychosine (galactosylsphingosine) accumulates in Krabbe disease.",
+      "url": null
+    },
+    "inherited_as__krabbe": {
+      "relation": "inherited_as",
+      "subject": "krabbe",
+      "object": "autosomal_recessive",
+      "status": "pending",
+      "verdict": "FLAG",
+      "trust": "consensus",
+      "source": "Krabbe disease is inherited in an autosomal recessive manner.",
+      "url": null
+    },
+    "deficient_in__hurler": {
+      "relation": "deficient_in",
+      "subject": "hurler",
+      "object": "alpha_l_iduronidase",
+      "status": "pending",
+      "verdict": "FLAG",
+      "trust": "consensus",
+      "source": "Hurler syndrome (mucopolysaccharidosis type I) results from deficiency of alpha-L-iduronidase.",
+      "url": null
+    },
+    "accumulates__hurler": {
+      "relation": "accumulates",
+      "subject": "hurler",
+      "object": "glycosaminoglycans",
+      "status": "pending",
+      "verdict": "FLAG",
+      "trust": "consensus",
+      "source": "Glycosaminoglycans (dermatan and heparan sulfate) accumulate in Hurler syndrome.",
+      "url": null
+    },
+    "inherited_as__hurler": {
+      "relation": "inherited_as",
+      "subject": "hurler",
+      "object": "autosomal_recessive",
+      "status": "pending",
+      "verdict": "FLAG",
+      "trust": "consensus",
+      "source": "Hurler syndrome is inherited in an autosomal recessive manner.",
+      "url": null
+    },
+    "deficient_in__msud": {
+      "relation": "deficient_in",
+      "subject": "msud",
+      "object": "branched_chain_ketoacid_dehydrogenase",
+      "status": "pending",
+      "verdict": "FLAG",
+      "trust": "consensus",
+      "source": "Maple syrup urine disease results from deficiency of branched-chain alpha-ketoacid dehydrogenase.",
+      "url": null
+    },
+    "accumulates__msud": {
+      "relation": "accumulates",
+      "subject": "msud",
+      "object": "branched_chain_amino_acids",
+      "status": "pending",
+      "verdict": "FLAG",
+      "trust": "consensus",
+      "source": "Branched-chain amino acids (leucine, isoleucine, valine) accumulate in maple syrup urine disease.",
+      "url": null
+    },
+    "inherited_as__msud": {
+      "relation": "inherited_as",
+      "subject": "msud",
+      "object": "autosomal_recessive",
+      "status": "pending",
+      "verdict": "FLAG",
+      "trust": "consensus",
+      "source": "Maple syrup urine disease is inherited in an autosomal recessive manner.",
+      "url": null
+    },
+    "deficient_in__galactosemia": {
+      "relation": "deficient_in",
+      "subject": "galactosemia",
+      "object": "galactose_1_phosphate_uridyltransferase",
+      "status": "pending",
+      "verdict": "FLAG",
+      "trust": "consensus",
+      "source": "Classic galactosemia results from deficiency of galactose-1-phosphate uridyltransferase (GALT).",
+      "url": null
+    },
+    "accumulates__galactosemia": {
+      "relation": "accumulates",
+      "subject": "galactosemia",
+      "object": "galactose_1_phosphate",
+      "status": "pending",
+      "verdict": "FLAG",
+      "trust": "consensus",
+      "source": "Galactose-1-phosphate accumulates in classic galactosemia.",
+      "url": null
+    },
+    "inherited_as__galactosemia": {
+      "relation": "inherited_as",
+      "subject": "galactosemia",
+      "object": "autosomal_recessive",
+      "status": "pending",
+      "verdict": "FLAG",
+      "trust": "consensus",
+      "source": "Classic galactosemia is inherited in an autosomal recessive manner.",
+      "url": null
     }
   },
-  "hash": "10aa3579bf49f1ad"
+  "hash": "8882153dfd4643ec"
 }

--- a/code/specs/data/mycin-2026/recall/iem-edges.adj
+++ b/code/specs/data/mycin-2026/recall/iem-edges.adj
@@ -108,4 +108,70 @@ rulebook iem_facts {
         source "This condition is inherited in an autosomal recessive pattern, which means both copies of the gene in each cell must have a variant to cause the disorder."
         locator "https://medlineplus.gov/genetics/condition/glycogen-storage-disease-type-i/"
         trust authoritative
+
+    % --- Fabry disease ---------------------------------------------------
+    relate deficient_in(fabry, alpha_galactosidase_a)
+        source "Fabry disease results from deficiency of the enzyme alpha-galactosidase A."
+        trust consensus   % [FLAG: pending]
+    relate accumulates(fabry, globotriaosylceramide)
+        source "Globotriaosylceramide (Gb3) accumulates in Fabry disease."
+        trust consensus   % [FLAG: pending]
+    relate inherited_as(fabry, x_linked_recessive)
+        source "Fabry disease is inherited in an X-linked recessive manner."
+        trust consensus   % [FLAG: pending]
+
+    % --- Niemann-Pick disease (type A/B) ---------------------------------
+    relate deficient_in(niemann_pick, acid_sphingomyelinase)
+        source "Niemann-Pick disease types A and B result from deficiency of acid sphingomyelinase."
+        trust consensus   % [FLAG: pending]
+    relate accumulates(niemann_pick, sphingomyelin)
+        source "Sphingomyelin accumulates in Niemann-Pick disease."
+        trust consensus   % [FLAG: pending]
+    relate inherited_as(niemann_pick, autosomal_recessive)
+        source "Niemann-Pick disease is inherited in an autosomal recessive manner."
+        trust consensus   % [FLAG: pending]
+
+    % --- Krabbe disease --------------------------------------------------
+    relate deficient_in(krabbe, galactocerebrosidase)
+        source "Krabbe disease results from deficiency of galactocerebrosidase (galactosylceramidase)."
+        trust consensus   % [FLAG: pending]
+    relate accumulates(krabbe, psychosine)
+        source "Psychosine (galactosylsphingosine) accumulates in Krabbe disease."
+        trust consensus   % [FLAG: pending]
+    relate inherited_as(krabbe, autosomal_recessive)
+        source "Krabbe disease is inherited in an autosomal recessive manner."
+        trust consensus   % [FLAG: pending]
+
+    % --- Hurler syndrome (MPS I) -----------------------------------------
+    relate deficient_in(hurler, alpha_l_iduronidase)
+        source "Hurler syndrome (mucopolysaccharidosis type I) results from deficiency of alpha-L-iduronidase."
+        trust consensus   % [FLAG: pending]
+    relate accumulates(hurler, glycosaminoglycans)
+        source "Glycosaminoglycans (dermatan and heparan sulfate) accumulate in Hurler syndrome."
+        trust consensus   % [FLAG: pending]
+    relate inherited_as(hurler, autosomal_recessive)
+        source "Hurler syndrome is inherited in an autosomal recessive manner."
+        trust consensus   % [FLAG: pending]
+
+    % --- Maple syrup urine disease (MSUD) --------------------------------
+    relate deficient_in(msud, branched_chain_ketoacid_dehydrogenase)
+        source "Maple syrup urine disease results from deficiency of branched-chain alpha-ketoacid dehydrogenase."
+        trust consensus   % [FLAG: pending]
+    relate accumulates(msud, branched_chain_amino_acids)
+        source "Branched-chain amino acids (leucine, isoleucine, valine) accumulate in maple syrup urine disease."
+        trust consensus   % [FLAG: pending]
+    relate inherited_as(msud, autosomal_recessive)
+        source "Maple syrup urine disease is inherited in an autosomal recessive manner."
+        trust consensus   % [FLAG: pending]
+
+    % --- Classic galactosemia --------------------------------------------
+    relate deficient_in(galactosemia, galactose_1_phosphate_uridyltransferase)
+        source "Classic galactosemia results from deficiency of galactose-1-phosphate uridyltransferase (GALT)."
+        trust consensus   % [FLAG: pending]
+    relate accumulates(galactosemia, galactose_1_phosphate)
+        source "Galactose-1-phosphate accumulates in classic galactosemia."
+        trust consensus   % [FLAG: pending]
+    relate inherited_as(galactosemia, autosomal_recessive)
+        source "Classic galactosemia is inherited in an autosomal recessive manner."
+        trust consensus   % [FLAG: pending]
 }

--- a/code/specs/data/mycin-2026/recall/iem_edge_ground.py
+++ b/code/specs/data/mycin-2026/recall/iem_edge_ground.py
@@ -104,6 +104,58 @@ GROUPS: list[tuple[str, list[tuple[str, str, str, str]]]] = [
         ("inherited_as", "von_gierke", "autosomal_recessive",
          "Von Gierke disease is inherited in an autosomal recessive manner."),
     ]),
+
+    # ---- REL-6 expansion: a second high-yield disease set (lysosomal storage +
+    # classic IEM). New edges enter as authored-debt (consensus + FLAG) until the
+    # spider grounds them; the board's grounded-coverage dips, then climbs again.
+    ("Fabry disease", [
+        ("deficient_in", "fabry", "alpha_galactosidase_a",
+         "Fabry disease results from deficiency of the enzyme alpha-galactosidase A."),
+        ("accumulates", "fabry", "globotriaosylceramide",
+         "Globotriaosylceramide (Gb3) accumulates in Fabry disease."),
+        ("inherited_as", "fabry", "x_linked_recessive",
+         "Fabry disease is inherited in an X-linked recessive manner."),
+    ]),
+    ("Niemann-Pick disease (type A/B)", [
+        ("deficient_in", "niemann_pick", "acid_sphingomyelinase",
+         "Niemann-Pick disease types A and B result from deficiency of acid sphingomyelinase."),
+        ("accumulates", "niemann_pick", "sphingomyelin",
+         "Sphingomyelin accumulates in Niemann-Pick disease."),
+        ("inherited_as", "niemann_pick", "autosomal_recessive",
+         "Niemann-Pick disease is inherited in an autosomal recessive manner."),
+    ]),
+    ("Krabbe disease", [
+        ("deficient_in", "krabbe", "galactocerebrosidase",
+         "Krabbe disease results from deficiency of galactocerebrosidase (galactosylceramidase)."),
+        ("accumulates", "krabbe", "psychosine",
+         "Psychosine (galactosylsphingosine) accumulates in Krabbe disease."),
+        ("inherited_as", "krabbe", "autosomal_recessive",
+         "Krabbe disease is inherited in an autosomal recessive manner."),
+    ]),
+    ("Hurler syndrome (MPS I)", [
+        ("deficient_in", "hurler", "alpha_l_iduronidase",
+         "Hurler syndrome (mucopolysaccharidosis type I) results from deficiency of alpha-L-iduronidase."),
+        ("accumulates", "hurler", "glycosaminoglycans",
+         "Glycosaminoglycans (dermatan and heparan sulfate) accumulate in Hurler syndrome."),
+        ("inherited_as", "hurler", "autosomal_recessive",
+         "Hurler syndrome is inherited in an autosomal recessive manner."),
+    ]),
+    ("Maple syrup urine disease (MSUD)", [
+        ("deficient_in", "msud", "branched_chain_ketoacid_dehydrogenase",
+         "Maple syrup urine disease results from deficiency of branched-chain alpha-ketoacid dehydrogenase."),
+        ("accumulates", "msud", "branched_chain_amino_acids",
+         "Branched-chain amino acids (leucine, isoleucine, valine) accumulate in maple syrup urine disease."),
+        ("inherited_as", "msud", "autosomal_recessive",
+         "Maple syrup urine disease is inherited in an autosomal recessive manner."),
+    ]),
+    ("Classic galactosemia", [
+        ("deficient_in", "galactosemia", "galactose_1_phosphate_uridyltransferase",
+         "Classic galactosemia results from deficiency of galactose-1-phosphate uridyltransferase (GALT)."),
+        ("accumulates", "galactosemia", "galactose_1_phosphate",
+         "Galactose-1-phosphate accumulates in classic galactosemia."),
+        ("inherited_as", "galactosemia", "autosomal_recessive",
+         "Classic galactosemia is inherited in an autosomal recessive manner."),
+    ]),
 ]
 
 HEADER = """\

--- a/code/specs/data/mycin-2026/recall/test_recall.py
+++ b/code/specs/data/mycin-2026/recall/test_recall.py
@@ -25,8 +25,8 @@ def _store() -> recall.RelationStore:
 
 def test_parse_loads_all_edges() -> None:
     store = _store()
-    # 6 diseases x 3 relations = 18 seed edges.
-    assert len(store.edges) == 18, f"expected 18 edges, got {len(store.edges)}"
+    # 12 diseases x 3 relations = 36 edges (REL-1 seed of 6 + REL-6 expansion of 6).
+    assert len(store.edges) == 36, f"expected 36 edges, got {len(store.edges)}"
     # Every edge carries a citation (source) and a trust tier.
     assert all(e.source for e in store.edges), "every edge must carry a source citation"
     assert all(e.trust for e in store.edges), "every edge must carry a trust tier"
@@ -64,9 +64,10 @@ def test_reverse_lookup_is_free() -> None:
 
 def test_abstains_on_ungrounded_disease() -> None:
     store = _store()
-    # Niemann-Pick is NOT in the seed — the store must abstain, not fabricate.
-    assert store.query("deficient_in", ["niemann_pick", "$Enzyme"]) == []
-    out = store.ask("deficient_in", ["niemann_pick", "$Enzyme"])
+    # Wilson disease is NOT in the graph — the store must abstain, not fabricate.
+    # (Niemann-Pick was the original example but is now a covered REL-6 disease.)
+    assert store.query("deficient_in", ["wilson_disease", "$Enzyme"]) == []
+    out = store.ask("deficient_in", ["wilson_disease", "$Enzyme"])
     assert "UNKNOWN" in out and "abstaining" in out
 
 


### PR DESCRIPTION
## What

Autonomous loop, next item: **grow recall coverage**. Adds a second high-yield inborn-errors-of-metabolism set — **Fabry, Niemann-Pick (A/B), Krabbe, Hurler (MPS I), maple syrup urine disease, classic galactosemia** — each with its deficient-enzyme / accumulated-substrate / inheritance edges (18 new edges → 36 total).

## The scoreboard tells the honest two-lever story

```
correct 18 · abstained 2 · wrong 0  (of 20)
defensibility 100%  ·  accuracy-on-attempted 100%  ·  grounded-coverage 50%
✓ never fabricated
```

- **REL-4b** spider-grounded 9 of the original answers (`consensus → authoritative`).
- **REL-6** expansion adds the 6 new disease sets as **authored-debt** (`consensus`), so grounded-coverage **dipped 90% → 50%** (9 grounded / 18 correct). Re-running the spider on the new edges climbs it back.
- **Expansion adds debt; grounding retires it; the scoreboard shows both** — with no harness change. Defensibility stays 100%: the system answers the new diseases correctly (their edges are in the graph) and abstains on the truly-absent ones.

## Changes

- **`recall/iem_edge_ground.py`** — 6 new disease `GROUPS`; gate regenerates `iem-edges.adj` (36 edges, new ones `consensus` + `[FLAG: pending]`).
- **`recall/ground-iem-edges.workflow.js`** — 18 matching spider CLAIMS, so the new edges can be grounded against OMIM/biochem on the next run.
- **`board/items.json`** — Fabry + Niemann-Pick flip from `ABSTAIN` to **covered**; +6 new recall items; +2 genuinely-absent diseases (Wilson, Menkes) keep the abstention test honest.
- Tests + READMEs updated.

## Verification

- recall **7/7**, gate **5/5**, board **6/6** — all pass; `ruff` clean; the 36-edge `.adj` parses through the real CLI.
- `/security-review` **PASSED** — new content is authored snake_case atoms + prose with no adj-lang metacharacters; flows through the already-reviewed `_esc()`; JS not executed.

## Next

Re-run the spider to ground the 6 new disease sets (climbs grounded-coverage back up), then add **differential + management tactics** to the scoreboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)