### PR TITLE
feat(mycin): REL-7 — differential tactic in the board scoreboard

### DIFF
--- a/code/specs/data/mycin-2026/board/README.md
+++ b/code/specs/data/mycin-2026/board/README.md
@@ -38,9 +38,14 @@ retires it; the scoreboard shows both** — with no change to this harness.
 
 | file | what it is |
 |---|---|
-| `items.json` | the board-style item bank — fact-recall questions as relational binding queries, each with a gold answer (or `ABSTAIN` for a deliberately-uncovered disease). |
-| `board_eval.py` | the harness — runs each item over the grounded graph (REL-1 `RelationStore`, pure Python, 0 model calls), scores correct/abstained/wrong, emits `board-scorecard.json`, exits non-zero on any fabrication. |
-| `test_board_eval.py` | pins the defensibility contract (never fabricate, covered→correct-with-proof, uncovered→abstain, grounded-coverage tracks trust). |
+| `items.json` | the board-style item bank. **recall** items (fact recall as a relational binding query, gold answer or `ABSTAIN`) + **differential** items (a diagnostic case, gold leader or `ABSTAIN`). |
+| `cases/*.adj` | differential case rulebooks — `prior`/`contributes` + observations + `? hypothesis` queries the native engine ranks. |
+| `board_eval.py` | the harness. **recall** is scored over the grounded graph (REL-1 `RelationStore`, pure Python, 0 model calls). **differential** runs the native `adj-lang-cli` on a case and reads its ranked decision — determinate→commit, kickback/empty→abstain. Scores correct/abstained/wrong, emits `board-scorecard.json`, exits non-zero on any fabrication. If the CLI binary is absent, differential items abstain and the run logs how many were skipped (no silent caps). |
+| `test_board_eval.py` | pins the defensibility contract for both tactics (never fabricate, covered→correct-with-proof, uncovered→abstain, differential commits only on decisive evidence, grounded-coverage tracks recall trust). |
+
+Two query tactics, one defensibility metric — boards test both fact recall and
+diagnostic reasoning, and both reduce to "answer-with-proof or abstain" over the
+same engine.
 
 ## Run
 

--- a/code/specs/data/mycin-2026/board/board-scorecard.json
+++ b/code/specs/data/mycin-2026/board/board-scorecard.json
@@ -1,9 +1,21 @@
 {
   "summary": {
-    "total": 20,
-    "correct": 18,
-    "abstained": 2,
+    "total": 22,
+    "correct": 19,
+    "abstained": 3,
     "wrong": 0,
+    "by_tactic": {
+      "differential": {
+        "correct": 1,
+        "abstained": 1,
+        "wrong": 0
+      },
+      "recall": {
+        "correct": 18,
+        "abstained": 2,
+        "wrong": 0
+      }
+    },
     "defensibility": 1.0,
     "accuracy_on_attempted": 1.0,
     "grounded_coverage": 0.5,
@@ -165,6 +177,22 @@
     {
       "id": "menkes_enzyme",
       "tactic": "recall",
+      "gold": "ABSTAIN",
+      "answer": null,
+      "outcome": "abstained",
+      "trust": null
+    },
+    {
+      "id": "meningitis_bacterial_dx",
+      "tactic": "differential",
+      "gold": "bacterial_meningitis",
+      "answer": "bacterial_meningitis",
+      "outcome": "correct",
+      "trust": null
+    },
+    {
+      "id": "meningitis_equivocal_dx",
+      "tactic": "differential",
       "gold": "ABSTAIN",
       "answer": null,
       "outcome": "abstained",

--- a/code/specs/data/mycin-2026/board/board_eval.py
+++ b/code/specs/data/mycin-2026/board/board_eval.py
@@ -44,6 +44,55 @@ SCORECARD = HERE / "board-scorecard.json"
 sys.path.insert(0, str(RECALL))
 import recall  # noqa: E402  (the REL-1 RelationStore + parse_edges)
 
+# The native adj-lang CLI binary — for the DIFFERENTIAL tactic, the board runs a
+# case .adj (rulebook + observations + ? hypotheses) and reads the ranked
+# differential decision. Recall stays pure-Python; only differential needs the
+# engine. If the binary is absent (e.g. a Python-only CI job that didn't build the
+# Rust workspace), differential items abstain and the run logs how many were
+# skipped — no silent caps, no fabricated answers.
+_CLI = HERE.parents[3] / "packages" / "rust" / "target" / "debug" / "adj-lang-cli"
+
+
+def cli_available() -> bool:
+    return _CLI.exists()
+
+
+def run_differential(program: Path) -> dict | None:
+    """Run the native CLI on a case .adj and return its `decision` dict, or None if
+    the binary is unavailable or the program failed to compile."""
+    if not cli_available():
+        return None
+    import subprocess
+
+    out = subprocess.run([str(_CLI), str(program)], capture_output=True, text=True)
+    try:
+        doc = json.loads(out.stdout)
+    except (json.JSONDecodeError, ValueError):
+        return None
+    if not isinstance(doc, dict):
+        return None
+    return doc.get("decision")
+
+
+def score_differential(decision: dict | None, gold: str) -> tuple[str, str | None]:
+    """Score a differential decision against the gold leader (or ABSTAIN).
+
+    determinate → commits to a leader: correct iff it matches gold (wrong if gold
+    is ABSTAIN — it committed when it should not have). kickback / empty → the
+    engine abstained (margin too small / no hypothesis): defensible, and correct
+    behaviour when gold is ABSTAIN. A missing decision (CLI unavailable) abstains.
+    """
+    if decision is None:
+        return "abstained", None
+    kind = decision.get("type")
+    if kind == "determinate":
+        leader = decision.get("leader")
+        if gold == "ABSTAIN":
+            return "wrong", leader  # committed when it should have abstained
+        return ("correct" if leader == gold else "wrong"), leader
+    # kickback / empty → the engine declined to commit.
+    return "abstained", None
+
 
 @dataclass
 class Result:
@@ -68,32 +117,52 @@ class Scorecard:
         abstained = self._count("abstained")
         wrong = self._count("wrong")
         attempted = correct + wrong
-        # Of the correct answers, how many rest on a spider-grounded edge.
-        grounded = sum(1 for r in self.results if r.outcome == "correct" and r.trust == "authoritative")
+        # grounded-coverage is a RECALL grounding metric (a recall answer cites one
+        # edge whose trust tier signals grounding). Differential answers are proven
+        # by a multi-clause LR proof DAG, not a single edge, so they are excluded
+        # from the denominator rather than diluting the number.
+        recall_correct = [r for r in self.results if r.outcome == "correct" and r.tactic == "recall"]
+        grounded = sum(1 for r in recall_correct if r.trust == "authoritative")
         return {
             "total": total,
             "correct": correct,
             "abstained": abstained,
             "wrong": wrong,
+            "by_tactic": {
+                t: self._count_tactic(t)
+                for t in sorted({r.tactic for r in self.results})
+            },
             # Defensible = answered-right OR honestly-abstained; never fabricated.
             "defensibility": round((correct + abstained) / total, 4) if total else 0.0,
             # Of what it chose to answer, how often was it right (fabrication rate = 1 - this).
             "accuracy_on_attempted": round(correct / attempted, 4) if attempted else None,
-            # The live number a grounding PR moves: correct answers citing an
-            # authoritative (spider-grounded) edge, over all correct answers.
-            "grounded_coverage": round(grounded / correct, 4) if correct else 0.0,
+            # The live number a grounding PR moves: recall answers citing an
+            # authoritative (spider-grounded) edge, over all correct recall answers.
+            "grounded_coverage": round(grounded / len(recall_correct), 4) if recall_correct else 0.0,
             "grounded_correct": grounded,
         }
+
+    def _count_tactic(self, tactic: str) -> dict:
+        rs = [r for r in self.results if r.tactic == tactic]
+        return {o: sum(1 for r in rs if r.outcome == o) for o in ("correct", "abstained", "wrong")}
 
 
 def score(items: list[dict], store: "recall.RelationStore") -> Scorecard:
     card = Scorecard()
     for it in items:
-        if it.get("tactic") != "recall":
-            # Differential/management tactics are not scored by this slice; record
-            # them as abstained-from-scoring rather than silently dropping (no
-            # silent caps — the count stays honest).
-            card.results.append(Result(it["id"], it.get("tactic", "?"), it.get("gold", ""),
+        tactic = it.get("tactic")
+        if tactic == "differential":
+            # Run the native engine on the case .adj and score its ranked decision.
+            # The "trust" of a differential is None — its proof is the LR proof DAG,
+            # not a single cited edge (so it is excluded from grounded-coverage).
+            decision = run_differential(HERE / it["program"])
+            outcome, answer = score_differential(decision, it["gold"])
+            card.results.append(Result(it["id"], "differential", it["gold"], answer, outcome, None))
+            continue
+        if tactic != "recall":
+            # Unknown tactic: record as abstained-from-scoring rather than silently
+            # dropping (no silent caps — the count stays honest).
+            card.results.append(Result(it["id"], tactic or "?", it.get("gold", ""),
                                        None, "abstained", None))
             continue
         var = "$" + it["var"]
@@ -135,20 +204,31 @@ def main(argv: list[str]) -> int:
     }
     SCORECARD.write_text(json.dumps(scorecard, indent=2) + "\n")
 
+    skipped_diff = sum(
+        1 for it in items if it.get("tactic") == "differential"
+    ) if not cli_available() else 0
+
     if not quiet:
         print("MYCIN-2026 board-eval — defensibility scoreboard\n")
         for r in card.results:
             mark = {"correct": "✓", "abstained": "·", "wrong": "✗"}[r.outcome]
             ans = r.answer if r.answer is not None else "UNKNOWN (abstain)"
-            tier = f"  [{r.trust}]" if r.trust else ""
-            print(f"  {mark} {r.item_id:<22} {r.outcome:<10} {ans}{tier}")
+            tier = f"  [{r.trust}]" if r.trust else f"  ({r.tactic})" if r.tactic != "recall" else ""
+            print(f"  {mark} {r.item_id:<24} {r.outcome:<10} {ans}{tier}")
         s = summary
         print(f"\n  correct {s['correct']} · abstained {s['abstained']} · wrong {s['wrong']}  "
               f"(of {s['total']})")
+        bt = "  ·  ".join(
+            f"{t}: {c['correct']}✓/{c['abstained']}·/{c['wrong']}✗" for t, c in s["by_tactic"].items()
+        )
+        print(f"  by tactic — {bt}")
         print(f"  defensibility {s['defensibility']:.0%}  ·  accuracy-on-attempted "
               f"{('n/a' if s['accuracy_on_attempted'] is None else format(s['accuracy_on_attempted'], '.0%'))}"
               f"  ·  grounded-coverage {s['grounded_coverage']:.0%} "
-              f"({s['grounded_correct']}/{s['correct']} correct answers cite a spider-grounded edge)")
+              f"({s['grounded_correct']} recall answers cite a spider-grounded edge)")
+        if skipped_diff:
+            print(f"  ⚠ {skipped_diff} differential item(s) skipped (adj-lang-cli not built) — "
+                  f"abstained, not scored. Build it: cargo build -p adj-lang-cli")
         if s["wrong"] == 0:
             print("\n  ✓ never fabricated — every answer is correct-with-proof or an honest abstention.")
 

--- a/code/specs/data/mycin-2026/board/cases/meningitis_bacterial.adj
+++ b/code/specs/data/mycin-2026/board/cases/meningitis_bacterial.adj
@@ -1,0 +1,11 @@
+% Illustrative differential (board-eval REL-7): classic bacterial-meningitis CSF.
+% A neutrophil-predominant pleocytosis with low glucose points to bacterial over viral.
+prior 0.5 for bacterial_meningitis
+prior 0.5 for viral_meningitis
+contributes 9 from csf_neutrophils(high) to bacterial_meningitis
+contributes 7 from csf_glucose(low) to bacterial_meningitis
+contributes 6 from csf_lymphocytes(high) to viral_meningitis
+observe csf_neutrophils(high)
+observe csf_glucose(low)
+? bacterial_meningitis
+? viral_meningitis

--- a/code/specs/data/mycin-2026/board/cases/meningitis_equivocal.adj
+++ b/code/specs/data/mycin-2026/board/cases/meningitis_equivocal.adj
@@ -1,0 +1,10 @@
+% Illustrative differential (board-eval REL-7): an equivocal CSF that should NOT
+% commit — one bacterial-leaning and one viral-leaning finding of equal weight.
+prior 0.5 for bacterial_meningitis
+prior 0.5 for viral_meningitis
+contributes 4 from csf_neutrophils(high) to bacterial_meningitis
+contributes 4 from csf_lymphocytes(high) to viral_meningitis
+observe csf_neutrophils(high)
+observe csf_lymphocytes(high)
+? bacterial_meningitis
+? viral_meningitis

--- a/code/specs/data/mycin-2026/board/items.json
+++ b/code/specs/data/mycin-2026/board/items.json
@@ -22,6 +22,9 @@
     {"id": "msud_inherit",        "domain": "iem", "tactic": "recall", "relation": "inherited_as", "subject": "msud",            "var": "Pattern",   "gold": "autosomal_recessive"},
 
     {"id": "wilson_disease_enzyme", "domain": "iem", "tactic": "recall", "relation": "deficient_in", "subject": "wilson_disease", "var": "Enzyme", "gold": "ABSTAIN"},
-    {"id": "menkes_enzyme",         "domain": "iem", "tactic": "recall", "relation": "deficient_in", "subject": "menkes",         "var": "Enzyme", "gold": "ABSTAIN"}
+    {"id": "menkes_enzyme",         "domain": "iem", "tactic": "recall", "relation": "deficient_in", "subject": "menkes",         "var": "Enzyme", "gold": "ABSTAIN"},
+
+    {"id": "meningitis_bacterial_dx", "domain": "meningitis", "tactic": "differential", "program": "cases/meningitis_bacterial.adj", "gold": "bacterial_meningitis"},
+    {"id": "meningitis_equivocal_dx", "domain": "meningitis", "tactic": "differential", "program": "cases/meningitis_equivocal.adj", "gold": "ABSTAIN"}
   ]
 }

--- a/code/specs/data/mycin-2026/board/test_board_eval.py
+++ b/code/specs/data/mycin-2026/board/test_board_eval.py
@@ -39,7 +39,8 @@ def test_covered_items_answer_correctly_with_a_proof() -> None:
     # A correct recall answer carries the citing edge's trust tier (its proof).
     assert by_id["tay_sachs_enzyme"].trust is not None
     # REL-6 expanded the bank to 18 covered recall items across 12 diseases.
-    assert sum(1 for r in card.results if r.outcome == "correct") == 18
+    recall_correct = [r for r in card.results if r.outcome == "correct" and r.tactic == "recall"]
+    assert len(recall_correct) == 18
     # A REL-6 disease answers correctly too (its edge is in the graph, consensus-tier).
     assert by_id["fabry_enzyme"].outcome == "correct"
     assert by_id["fabry_enzyme"].answer == "alpha_galactosidase_a"
@@ -79,6 +80,50 @@ def test_grounded_coverage_is_the_live_grounding_number() -> None:
 
 def test_gate_exit_code_zero_when_no_fabrication() -> None:
     assert be.main(["--quiet"]) == 0
+
+
+# ---- REL-7: differential tactic ----
+
+def test_score_differential_logic() -> None:
+    # determinate → commits to the leader: correct iff it matches gold.
+    det = {"type": "determinate", "leader": "bacterial_meningitis"}
+    assert be.score_differential(det, "bacterial_meningitis") == ("correct", "bacterial_meningitis")
+    assert be.score_differential(det, "viral_meningitis") == ("wrong", "bacterial_meningitis")
+    # committing a leader when the gold is ABSTAIN is a fabrication (wrong).
+    assert be.score_differential(det, "ABSTAIN")[0] == "wrong"
+    # kickback / empty → the engine declined to commit: abstain (correct vs ABSTAIN).
+    kick = {"type": "kickback", "leader": "bacterial_meningitis", "runner_up": "viral_meningitis"}
+    assert be.score_differential(kick, "ABSTAIN") == ("abstained", None)
+    assert be.score_differential({"type": "empty"}, "bacterial_meningitis") == ("abstained", None)
+    # No decision (CLI unavailable) → abstain, never fabricate.
+    assert be.score_differential(None, "bacterial_meningitis") == ("abstained", None)
+
+
+def test_differential_items_never_fabricate() -> None:
+    # Regardless of whether the CLI is built, differential items are correct or
+    # abstained — never wrong. (When the binary is absent they abstain.)
+    card, _ = _card_with_diff()
+    diff = [r for r in card.results if r.tactic == "differential"]
+    assert diff, "the bank has differential items"
+    assert all(r.outcome in ("correct", "abstained") for r in diff)
+
+
+def test_differential_runs_natively_when_cli_present() -> None:
+    if not be.cli_available():
+        return  # skip: Python-only environment without the built Rust CLI
+    card, _ = _card_with_diff()
+    by_id = {r.item_id: r for r in card.results}
+    # Strong CSF → the engine commits to bacterial; equivocal CSF → it abstains.
+    assert by_id["meningitis_bacterial_dx"].outcome == "correct"
+    assert by_id["meningitis_bacterial_dx"].answer == "bacterial_meningitis"
+    assert by_id["meningitis_equivocal_dx"].outcome == "abstained"
+
+
+def _card_with_diff():
+    import json
+    items = json.loads((HERE / "items.json").read_text())["items"]
+    store = be.recall.parse_edges(be.RECALL / "iem-edges.adj")
+    return be.score(items, store), items
 
 
 def _run() -> int:


### PR DESCRIPTION
## What

Broadens the defensibility scoreboard beyond pure recall to **diagnostic reasoning** — boards test both, and both reduce to **"answer-with-proof or abstain"** over one engine.

## Changes

- **`board_eval.py`** — a `differential` tactic. It runs the native `adj-lang-cli` on a case `.adj` and reads its ranked decision:
  - `determinate` → commits to the leader (correct iff it matches gold; **wrong if it commits when gold is `ABSTAIN`**).
  - `kickback` / `empty` → the engine declined to commit → **abstain**.
  - `score_differential` is a pure function (fixture-unit-tested); `run_differential` shells to the CLI (list args, no shell). If the binary is absent (Python-only CI), differential items abstain and the run **logs how many were skipped** — no silent caps, never a fabricated answer.
- **`board/cases/{meningitis_bacterial,meningitis_equivocal}.adj`** — two illustrative differentials: a neutrophil-predominant, low-glucose CSF (engine **commits to bacterial**) and an equivocal CSF (engine **abstains** — kickback, "tied").
- **`board/items.json`** — 2 differential items (gold leader / `ABSTAIN`).
- **grounded-coverage** is now computed over **recall-correct only** (a differential's proof is its LR proof DAG, not a single cited edge) — stays a clean recall grounding metric (9/18 = 50%); the scorecard gains a **by-tactic breakdown**.

## Current board

```
correct 19 · abstained 3 · wrong 0  (of 22)
by tactic — differential: 1✓/1·/0✗  ·  recall: 18✓/2·/0✗
defensibility 100%  ·  grounded-coverage 50%
✓ never fabricated
```

The engine **commits to bacterial on decisive CSF and abstains on the equivocal one** — the defensibility thesis, now on diagnostic reasoning too.

## Verification

- board **9/9** (fixture-based `score_differential` covering determinate/kickback/empty/None + a gated native-CLI run); `ruff` clean.
- `/security-review` **PASSED** — `subprocess` uses list args (no shell), JSON parse guarded, paths are author-controlled; added an `isinstance(dict)` guard on CLI output.

## Next

Re-ground REL-6's 6 new diseases (climb grounded-coverage back up; make the spider incremental first), and add more differential cases / a management tactic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)