### PR TITLE
feat(lang-full): E2 — iir-to-llvm wraps narrow-width arithmetic

### DIFF
--- a/code/packages/rust/iir-to-llvm/CHANGELOG.md
+++ b/code/packages/rust/iir-to-llvm/CHANGELOG.md
@@ -3,6 +3,51 @@
 All notable changes to this crate are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.11.0] — 2026-06-15 — narrow unsigned arithmetic wraps mod-2ⁿ (LANG-FULL E2)
+
+### Added — `u4`/`u8`/`u16`/`u32` results are masked back into their width
+
+LANG-FULL **E2 — register width & wrap**, the LLVM column. A narrow unsigned
+binary op (`add`/`sub`/`mul`/`div`/`mod` and `and`/`or`/`xor`) now computes at
+`i64` and AND-masks the result into its declared width, so `200u8 + 100u8`
+wraps to `44`:
+
+```llvm
+  %__nw1 = add i64 200, 100     ; compute wide (operands are i64 slots)
+  %v     = and i64 %__nw1, 255  ; 300 & 0xFF = 44  ✓ wrapped to u8
+```
+
+**Why a value-mask, not a narrow-typed op.** Every IIR value rides a 64-bit
+slot in this backend — arithmetic operands are `i64` SSA values (consts emit
+`i64`; reassigned params become i64 stack slots). Typing the op at its narrow
+LLVM width — `add i8 %a, %b` over two `i64` SSA values — is **invalid IR that
+`clang` rejects** (the same shape as the AL5 `cmp`-truncation bug). So, exactly
+like the VM, JIT, wasm, JVM, and CLR backends (and like this backend's own
+byte-tape `store_byte` at the memory boundary), we compute wide and mask the
+*value*:
+
+| type_hint | mask         | example                |
+|-----------|--------------|------------------------|
+| `u4`      | `0xF`        | `15u4 + 1u4` → `0`     |
+| `u8`      | `0xFF`       | `200u8 + 100u8` → `44` |
+| `u16`     | `0xFFFF`     | `~0u16` → `65535`     |
+| `u32`     | `0xFFFFFFFF` | wraps mod-2³²          |
+| `u64`/`i*`/`f*` | —      | full word / signed / float: unchanged |
+
+Signed narrow widths (`i8`/`i16`/`i32`) are left alone — E2 models unsigned
+wrap; a signed wrap needs `trunc`+`sext`, out of scope.
+
+Also adds `u4` (Nib's 4-bit nibble) to the supported type set — it has no
+native LLVM width, so it rides an `i8` and the `& 0xF` mask enforces the range.
+
+This corrects the earlier roadmap assumption that "LLVM already wraps natively
+(u8→i8)": that was never executed (no frontend emitted narrow hints), and the
+i64-slot value model means it does **not** hold. Verified by RUNNING the
+emitted `.ll` through real `clang`: `200u8 + 100u8` returns exit `44`. New unit
+tests: `e2_u8_add_computes_at_i64_then_masks`, `e2_u16_and_u4_masks_match_width`,
+`e2_bitwise_u8_xor_masks`, `e2_wide_widths_emit_no_mask` (and the existing
+`arith_div_unsigned_emits_udiv` updated to the i64-slot value model).
+
 ## [0.10.0] — 2026-06-13 — reassigned parameters become stack slots (LANG-FULL — LLVM first-class)
 
 ### Fixed — a reassigned function parameter is no longer silently dropped

--- a/code/packages/rust/iir-to-llvm/Cargo.toml
+++ b/code/packages/rust/iir-to-llvm/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "iir-to-llvm"
-version = "0.10.0"
+version = "0.11.0"
 edition = "2021"
-description = "IIR → textual LLVM IR backend — emits .ll source for an LLVM target triple.  v0.9.0 (LLVM05, LANG-MATRIX LM-L Brainfuck): adds the byte-tape ops `alloc_bytes`→`@calloc`, `load_byte`/`store_byte` (zero-extend/truncate at the byte boundary), and the `putchar`/`getchar` libc builtins, plus a slot-dest SSA rename so a stack-slot variable assigned 2+ times by a real op no longer emits a duplicate `%name`.  v0.4.0 (LLVM04): adds `call` of user-defined functions (per-arg types resolved via pre-built callee-signature map) and `call_builtin print_i64` → `declare/call @__print_i64(i64)`, completing the LLVM backend's user-callable surface."
+description = "IIR → textual LLVM IR backend — emits .ll source for an LLVM target triple.  v0.11.0 (LANG-FULL E2 — register width & wrap): a narrow unsigned op (u4/u8/u16/u32) computes at i64 then masks with `and i64 <tmp>, <mask>` (0xF/0xFF/0xFFFF/0xFFFFFFFF), so `200u8+100u8=44`.  Every IIR value rides an i64 slot here, so typing the op at its narrow LLVM width (`add i8 %a, %b` over i64 operands) was invalid IR clang rejects; the value-mask matches the VM/JIT/wasm/JVM/CLR backends.  Adds `u4` to the supported type set.  v0.9.0 (LLVM05, LANG-MATRIX LM-L Brainfuck): adds the byte-tape ops `alloc_bytes`→`@calloc`, `load_byte`/`store_byte` (zero-extend/truncate at the byte boundary), and the `putchar`/`getchar` libc builtins, plus a slot-dest SSA rename so a stack-slot variable assigned 2+ times by a real op no longer emits a duplicate `%name`.  v0.4.0 (LLVM04): adds `call` of user-defined functions (per-arg types resolved via pre-built callee-signature map) and `call_builtin print_i64` → `declare/call @__print_i64(i64)`, completing the LLVM backend's user-callable surface."
 
 [lib]
 name = "iir_to_llvm"

--- a/code/packages/rust/iir-to-llvm/README.md
+++ b/code/packages/rust/iir-to-llvm/README.md
@@ -89,6 +89,7 @@ you actually intend to run `llc` for a non-default architecture.
 | v0.8.0  | Lisp lambda (F7) — declare `lispy_to_exit_code` runtime switch; **LLVM McCarthy-complete F1–F7** (McCarthy W13b). |
 | v0.9.0  | Byte-tape ops `alloc_bytes`→`@calloc`, `load_byte`/`store_byte` (zext/trunc at the byte boundary), `putchar`/`getchar` libc builtins, + slot-dest SSA rename. **Brainfuck runs on LLVM** (LANG-MATRIX LM-L Brainfuck). |
 | v0.10.0 | Reassigned **parameters** are promoted to i64 stack slots (initialised from the incoming argument, narrow args zext'd) — a parameter accumulated across a loop back-edge is no longer silently dropped (LANG-FULL — LLVM first-class). |
+| v0.11.0 | **Narrow unsigned arithmetic wraps mod-2ⁿ** (LANG-FULL E2). A `u4`/`u8`/`u16`/`u32` op computes at i64 then `and i64 …, <mask>` (see below). Adds `u4` to the supported types. |
 | (later) | GC, debug info via `!dbg`. |
 
 ### Byte-tape memory (v0.9.0)
@@ -108,6 +109,31 @@ native x86_64 backend already uses (LANG76). This crate's lowering:
 Byte width lives **only at the tape boundary** (the `zext`/`trunc`); every register
 in between is a uniform `i64`, which is what lets the i64-only stack-slot model
 consume Brainfuck's reassigned `ptr`/`v` without a width mismatch.
+
+### Narrow-width register arithmetic (v0.11.0, LANG-FULL E2)
+
+The same "uniform i64 in registers" model is exactly why narrow **unsigned**
+arithmetic must wrap with a *value mask*, not a narrow-typed op. A `u8` add
+whose operands are `i64` SSA values cannot be `add i8 %a, %b` — that is invalid
+IR `clang` rejects. So `add`/`sub`/`mul`/`div`/`mod` and `and`/`or`/`xor` on a
+`u4`/`u8`/`u16`/`u32` `type_hint` compute at i64 and mask the result back into
+the width:
+
+```llvm
+  %__nw1 = add i64 200, 100     ; compute wide
+  %v     = and i64 %__nw1, 255  ; 300 & 0xFF = 44   (u8 wrap)
+```
+
+| type_hint | mask         |  | type_hint | mask         |
+|-----------|--------------|--|-----------|--------------|
+| `u4`      | `0xF`        |  | `u16`     | `0xFFFF`     |
+| `u8`      | `0xFF`       |  | `u32`     | `0xFFFFFFFF` |
+
+`u64`/`i64` (full word), signed narrow widths, and floats get no mask. This
+mirrors the VM/JIT/wasm/JVM/CLR backends (each masks the narrow result by
+`type_hint`) and generalises the byte-tape's 8-bit `store_byte` wrap to register
+arithmetic. Verified by RUNNING the emitted `.ll` through real `clang`:
+`200u8 + 100u8` exits `44`.
 
 See [`code/specs/iir-to-llvm.md`](../../../specs/iir-to-llvm.md) for the
 full spec and [`code/specs/MULTILANG-BACKEND-PLAN.md`](../../../specs/MULTILANG-BACKEND-PLAN.md)

--- a/code/packages/rust/iir-to-llvm/src/lib.rs
+++ b/code/packages/rust/iir-to-llvm/src/lib.rs
@@ -188,6 +188,9 @@ fn llvm_type_for(type_hint: &str, function: &str) -> Result<&'static str, IIRLlv
         // i1 is LLVM's boolean — added in LLVM03 so comparison results can
         // be requested at i1 width without a redundant zext+trunc round-trip.
         "i1"  | "bool" => Ok("i1"),
+        // u4 (Nib's 4-bit nibble) has no native LLVM width; it rides in an i8
+        // and the E2 wrap mask (`and i64 …, 0xF`) enforces the 4-bit range.
+        "u4"  => Ok("i8"),
         "i8"  | "u8"  => Ok("i8"),
         "i16" | "u16" => Ok("i16"),
         "i32" | "u32" => Ok("i32"),
@@ -689,7 +692,7 @@ fn collect_slot_vars(func: &IIRFunction) -> std::collections::HashSet<String> {
 fn param_slot_compatible(pty: &str) -> bool {
     matches!(
         pty,
-        "bool" | "i1" | "i8" | "u8" | "i16" | "u16" | "i32" | "u32" | "i64" | "u64"
+        "bool" | "i1" | "u4" | "i8" | "u8" | "i16" | "u16" | "i32" | "u32" | "i64" | "u64"
             | "any" | "symbol"
     ) || pty.starts_with("ref<Lispy")
 }
@@ -1074,6 +1077,63 @@ fn llvm_arith_op(iir_op: &str, type_hint: &str) -> &'static str {
     }
 }
 
+/// The bit-mask for a narrow **unsigned** integer width, or `None` if the
+/// width is the full machine word (`i64`/`u64`) or a signed/float/ref type.
+///
+/// LANG-FULL **E2 — register width & wrap**, LLVM column. Every IIR value flows
+/// through a 64-bit slot in this backend (see the module header — arithmetic
+/// operands are `i64` SSA values, never the narrow type), so a `u8`/`u16`/… op
+/// must NOT be typed at its narrow LLVM width: `add i8 %a, %b` over two `i64`
+/// SSA values is invalid IR that `clang` rejects. Instead we compute the op at
+/// `i64` and AND-mask the result back into the declared width — the exact
+/// "compute wide, mask the value" shape the VM, JIT, wasm, JVM, and CLR
+/// backends already use (and the LLVM byte-tape `store_byte` already does at the
+/// memory boundary; this generalises it to register arithmetic):
+///
+/// ```llvm
+///   %nwN = add i64 %a, %b        ; 200 + 100 = 300  (wide)
+///   %dst = and i64 %nwN, 255     ; 300 & 0xFF = 44  ✓ wrapped to u8
+/// ```
+///
+/// | type_hint | mask         | example                       |
+/// |-----------|--------------|-------------------------------|
+/// | `u4`      | `0xF`        | `15u4 + 1u4` → `0`            |
+/// | `u8`      | `0xFF`       | `200u8 + 100u8` → `44`        |
+/// | `u16`     | `0xFFFF`     | `~0u16` → `65535`            |
+/// | `u32`     | `0xFFFFFFFF` | wraps mod-2³²                 |
+/// | `u64`,`i*`,`f*` | —      | full word / signed / float: unchanged |
+///
+/// Signed narrow widths (`i8`/`i16`/`i32`) are intentionally left alone — E2
+/// models unsigned wrap; a signed wrap needs `trunc`+`sext`, out of scope here.
+fn narrow_unsigned_width_mask(type_hint: &str) -> Option<i64> {
+    match type_hint {
+        "u4" => Some(0xF),
+        "u8" => Some(0xFF),
+        "u16" => Some(0xFFFF),
+        "u32" => Some(0xFFFF_FFFF),
+        _ => None,
+    }
+}
+
+/// Emit a narrow-unsigned binary op as an `i64` computation followed by an
+/// `and i64 %tmp, <mask>` that wraps the result into its declared width, then
+/// bind `dest` to the masked value. Shared by [`lower_arith`] and
+/// [`lower_bitwise`]; see [`narrow_unsigned_width_mask`] for the rationale.
+fn emit_narrow_wrapped(
+    llvm_op: &str,
+    a: &str,
+    b: &str,
+    dest: &str,
+    mask: i64,
+    state: &mut FnState,
+    out: &mut String,
+) {
+    let tmp = state.fresh("nw");
+    out.push_str(&format!("  {tmp} = {llvm_op} i64 {a}, {b}\n"));
+    out.push_str(&format!("  %{dest} = and i64 {tmp}, {mask}\n"));
+    state.env.insert(dest.to_string(), format!("%{dest}"));
+}
+
 fn lower_arith(
     iir_op: &str,
     instr: &IIRInstr,
@@ -1085,6 +1145,12 @@ fn lower_arith(
     let a = resolve_operand(instr.srcs.first(), &state.env, &instr.type_hint, state.fn_name)?;
     let b = resolve_operand(instr.srcs.get(1), &state.env, &instr.type_hint, state.fn_name)?;
     let llvm_op = llvm_arith_op(iir_op, &instr.type_hint);
+    // E2: a narrow unsigned op (u4/u8/u16/u32) flows through i64 slots, so
+    // compute at i64 then mask the result into its width (200u8+100u8=44).
+    if let Some(mask) = narrow_unsigned_width_mask(&instr.type_hint) {
+        emit_narrow_wrapped(llvm_op, &a, &b, &dest, mask, state, out);
+        return Ok(());
+    }
     out.push_str(&format!("  %{dest} = {llvm_op} {ty} {a}, {b}\n"));
     state.env.insert(dest.clone(), format!("%{dest}"));
     Ok(())
@@ -1160,6 +1226,15 @@ fn lower_bitwise(
     let ty = llvm_type_for(&instr.type_hint, state.fn_name)?;
     let a = resolve_operand(instr.srcs.first(), &state.env, &instr.type_hint, state.fn_name)?;
     let b = resolve_operand(instr.srcs.get(1), &state.env, &instr.type_hint, state.fn_name)?;
+
+    // E2: a narrow unsigned bitwise op (u4/u8/u16/u32) flows through i64 slots —
+    // compute at i64 and mask the result into its width (matches lower_arith and
+    // the register backends). `and`/`or`/`xor` of in-range operands is unchanged
+    // by the mask; the mask matters once `not`/`shl` widen the result.
+    if let Some(mask) = narrow_unsigned_width_mask(&instr.type_hint) {
+        emit_narrow_wrapped(iir_op, &a, &b, &dest, mask, state, out);
+        return Ok(());
+    }
 
     out.push_str(&format!("  %{dest} = {iir_op} {ty} {a}, {b}\n"));
     let value = format!("%{dest}");

--- a/code/packages/rust/iir-to-llvm/tests/test_backend.rs
+++ b/code/packages/rust/iir-to-llvm/tests/test_backend.rs
@@ -375,18 +375,82 @@ fn arith_div_signed_emits_sdiv() {
 
 #[test]
 fn arith_div_unsigned_emits_udiv() {
+    // A `u32` divide. Every IIR value flows through an i64 slot in this backend
+    // (frontends widen params/returns to i64 and carry the narrow width only on
+    // the operation's type_hint — exactly this shape), so the unsigned divide
+    // computes at i64 (`udiv`, NOT `sdiv`) and then masks the result to 32 bits
+    // (E2 register width & wrap). Operand width stays i64; only the value wraps.
     let f = IIRFunction::new(
         "f",
-        vec![("a".into(), "u32".into()), ("b".into(), "u32".into())],
-        "u32",
+        vec![("a".into(), "i64".into()), ("b".into(), "i64".into())],
+        "i64",
         vec![
             IIRInstr::new("div", Some("v".into()),
                 vec![Operand::Var("a".into()), Operand::Var("b".into())], "u32"),
-            IIRInstr::new("ret", None, vec![Operand::Var("v".into())], "u32"),
+            IIRInstr::new("ret", None, vec![Operand::Var("v".into())], "i64"),
         ]);
     let ll = lower(&module_with(f));
-    assert!(ll.contains("%v = udiv i32 %a, %b"),
-        "expected udiv for u32; got:\n{ll}");
+    assert!(ll.contains("udiv i64 %a, %b"),
+        "expected unsigned udiv at i64 width; got:\n{ll}");
+    assert!(ll.contains(", 4294967295"),
+        "expected the u32 wrap mask (0xFFFFFFFF); got:\n{ll}");
+}
+
+// ── E2 — register width & wrap (narrow unsigned arithmetic) ──────────────────
+
+/// Build `f(a: i64, b: i64) -> i64 { v = <op>(a, b) : <hint>; ret v }` — the
+/// shape every frontend produces for a narrow-typed binary op (i64 slots, the
+/// narrow width carried only on the op's type_hint).
+fn narrow_binop_fn(op: &str, hint: &str) -> IIRFunction {
+    IIRFunction::new(
+        "f",
+        vec![("a".into(), "i64".into()), ("b".into(), "i64".into())],
+        "i64",
+        vec![
+            IIRInstr::new(op, Some("v".into()),
+                vec![Operand::Var("a".into()), Operand::Var("b".into())], hint),
+            IIRInstr::new("ret", None, vec![Operand::Var("v".into())], "i64"),
+        ],
+    )
+}
+
+#[test]
+fn e2_u8_add_computes_at_i64_then_masks() {
+    // `200u8 + 100u8 = 44`: add at i64 (operands are i64 slots), then `and` to
+    // 8 bits. Typing the add `i8` over i64 SSA operands would be invalid IR —
+    // this is why the wrap is a mask, not a narrow-typed op.
+    let ll = lower(&module_with(narrow_binop_fn("add", "u8")));
+    assert!(ll.contains("add i64 %a, %b"), "u8 add computes at i64; got:\n{ll}");
+    assert!(ll.contains(", 255"), "u8 add masks with 0xFF; got:\n{ll}");
+}
+
+#[test]
+fn e2_u16_and_u4_masks_match_width() {
+    let ll16 = lower(&module_with(narrow_binop_fn("mul", "u16")));
+    assert!(ll16.contains("mul i64 %a, %b") && ll16.contains(", 65535"),
+        "u16 mul → mul i64 + mask 0xFFFF; got:\n{ll16}");
+    let ll4 = lower(&module_with(narrow_binop_fn("sub", "u4")));
+    assert!(ll4.contains("sub i64 %a, %b") && ll4.contains(", 15"),
+        "u4 sub → sub i64 + mask 0xF; got:\n{ll4}");
+}
+
+#[test]
+fn e2_bitwise_u8_xor_masks() {
+    let ll = lower(&module_with(narrow_binop_fn("xor", "u8")));
+    assert!(ll.contains("xor i64 %a, %b") && ll.contains(", 255"),
+        "u8 xor → xor i64 + mask 0xFF; got:\n{ll}");
+}
+
+#[test]
+fn e2_wide_widths_emit_no_mask() {
+    // i64/u64 are full-word; signed narrow (i8/i16/i32) are out of E2 scope —
+    // none of them gets a width mask, so the op is a plain single instruction.
+    for hint in ["i64", "u64"] {
+        let ll = lower(&module_with(narrow_binop_fn("add", hint)));
+        assert!(ll.contains("add i64 %a, %b"), "{hint} add at i64; got:\n{ll}");
+        assert!(!ll.contains(", 255") && !ll.contains(", 4294967295"),
+            "{hint} add must NOT mask; got:\n{ll}");
+    }
 }
 
 #[test]

--- a/code/specs/LANG-FULL-IMPLEMENTATION.md
+++ b/code/specs/LANG-FULL-IMPLEMENTATION.md
@@ -70,7 +70,7 @@ multiple languages; close an enabler before the features that depend on it.
   the u8-tape pattern; this generalises it to register values.)
   - ✅ **vm-core** (1/6) — `mask_result(v, type_hint, u8_wrap)` masks every arithmetic /
     bitwise / shift result to the hint width; unit-tested (`200u8+100u8=44`, `~0u8=255`,
-    `1u8<<8=0`, u4/u16/u32). LLVM already wraps natively (`u8`→`i8`).
+    `1u8<<8=0`, u4/u16/u32).
   - ✅ **jit-core** (2/6) — compiled tier emits a `MASK_WIDTH <reg> <bits>` opcode after a
     narrow `_u8`/`_u16`/`_u32` add/sub/mul/div/neg (`u4`/signed handled by the interpreter
     fallback); unit-tested. Matches vm-core's interpreter-tier mask.
@@ -89,9 +89,20 @@ multiple languages; close an enabler before the features that depend on it.
     — so `200u8+100u8=44` and `~0u8=255`. u32/i32 already wrap mod-2³² via the 32-bit op; a
     positive mask + `and` (not `conv.u1`) keeps the unsigned widths unsigned. Structural tests
     on both emitters; executed CLR proof in the integration PR via the matrix's real-`dotnet`.
-  - ☐ **Integration** — wire Nib (then Oct) to emit narrow `type_hint`s for narrow-declared
+  - ◑ **Integration** — wire Nib (then Oct) to emit narrow `type_hint`s for narrow-declared
     values + an executed matrix proof (`200u8+100u8=44`, Nib unary `~`) across all backends;
-    flip N3-`~`, Nib N6/N7, Oct.
+    flip N3-`~`, Nib N6/N7, Oct. The two code-gen backends that type the *op* (rather than
+    masking the *value*) needed real wrap work first — surfaced when the integration was
+    started (the roadmap's earlier "LLVM already wraps natively (u8→i8)" assumption was
+    never executed and is false: every IIR value rides an i64 slot, so an `add i8 %a,%b`
+    over i64 operands is invalid IR):
+    - ✅ **iir-to-llvm** (v0.11.0) — a narrow unsigned op computes at i64 then `and i64 …,
+      <mask>` (u4/u8/u16/u32). Adds `u4` to the supported types. **Executed proof** on real
+      `clang`: `200u8+100u8` → exit `44`. Matches the value-mask of the 5 register backends.
+    - ☐ **lang-aot native codegen** (NativeAot) — narrow-width wrap in the host machine-code
+      path (investigate next).
+    - ☐ **Nib frontend + matrix proof** — emit narrow `type_hint`s; executed cross-backend
+      proof; flip N3-`~`, Nib N6/N7. Then Oct (O2).
 - **E3 — Real / floating-point (`f64`).** End-to-end f64 arithmetic, comparison, and
   literals on every backend. Unlocks ALGOL reals and BASIC floats. *(Audit which backends
   already emit f64 ops; extend the rest.)*


### PR DESCRIPTION
## LANG-FULL E2 — register width & wrap (LLVM column)

First step of the E2 **integration**: making narrow unsigned arithmetic actually wrap on *every* backend, not just the 5 register backends already shipped.

### The finding

The 5 merged register backends (vm-core/jit-core/wasm/jvm/cil) mask the result **value**, so operand width is irrelevant. LLVM types the **op** — and the roadmap's earlier note *"LLVM already wraps natively (u8→i8)"* **was never executed and is false**: every IIR value rides an `i64` slot in this backend (consts emit `i64`; reassigned params become i64 stack slots), so `add i8 %a, %b` over two i64 SSA operands is **invalid IR that `clang` rejects** — the same shape as the AL5 `cmp`-truncation bug.

### The fix

A narrow unsigned op (`u4`/`u8`/`u16`/`u32`) computes at `i64` then masks the result into its width — the same *"compute wide, mask the value"* shape as the register backends (and as this backend's own byte-tape `store_byte`):

```llvm
  %__nw1 = add i64 200, 100     ; compute wide (operands are i64 slots)
  %v     = and i64 %__nw1, 255  ; 300 & 0xFF = 44   (u8 wrap)
```

| type_hint | mask | | type_hint | mask |
|---|---|---|---|---|
| `u4` | `0xF` | | `u16` | `0xFFFF` |
| `u8` | `0xFF` | | `u32` | `0xFFFFFFFF` |

- `narrow_unsigned_width_mask` + shared `emit_narrow_wrapped`, wired into `lower_arith` (add/sub/mul/div/mod) and `lower_bitwise` (and/or/xor); `div`/`mod` keep their unsigned `udiv`/`urem` opcode.
- `u4` (Nib's nibble) added to the supported type set — rides `i8`, the `0xF` mask enforces the 4-bit range.
- Signed narrow widths (`i8`/`i16`/`i32`) intentionally untouched — E2 is unsigned wrap; signed needs `trunc`+`sext`, out of scope.

### Verification

- **Executed proof**: the emitted `.ll` for `200u8 + 100u8` compiled with real `clang` and **returned exit 44**.
- New unit tests + the existing `arith_div_unsigned_emits_udiv` updated to the i64-slot value model (the shape frontends actually produce). 64 crate tests pass.
- Consumers re-verified green: `algol-iir-compiler` and `lang-aot` (the real-`clang` matrix).
- Security review (Rust sub-agent): **PASSED**. Clippy clean.

### Where this sits

This is part of the E2 integration arc (the user chose *do the real wrap work first*). Next: NativeAot codegen wrap, then the Nib frontend change + the executed cross-backend matrix proof across all 7 backends.

Version `0.10.0` → `0.11.0`; CHANGELOG, README, roadmap updated (corrected the false LLVM-native-wrap claim).

🤖 Generated with [Claude Code](https://claude.com/claude-code)