### PR TITLE
feat(mycin): REL-8 — ground every IEM disease (board grounded-coverage 50% → 100%)

### DIFF
--- a/code/specs/data/mycin-2026/board/README.md
+++ b/code/specs/data/mycin-2026/board/README.md
@@ -22,17 +22,17 @@ cite an `authoritative` (spider-grounded) edge vs a `consensus` (authored-debt)
 edge. That is the number every grounding/expansion PR moves:
 
 ```
-correct 18 · abstained 2 · wrong 0  (of 20)
-defensibility 100%  ·  accuracy-on-attempted 100%  ·  grounded-coverage 50%
+correct 19 · abstained 3 · wrong 0  (of 22)
+by tactic — differential: 1✓/1·/0✗  ·  recall: 18✓/2·/0✗
+defensibility 100%  ·  accuracy-on-attempted 100%  ·  grounded-coverage 100%
 ✓ never fabricated — every answer is correct-with-proof or an honest abstention.
 ```
 
-The number tracks **both levers**, honestly. The REL-4b spider grounded 9 of the
-original answers (`consensus → authoritative`). REL-6 then expanded the bank from 6 to
-**12 diseases** — the 6 new disease sets enter as authored-debt, so grounded-coverage
-**dipped 90% → 50%**. Re-running `recall/ground-iem-edges.workflow.js` →
-`iem_edge_ground.py` on the new edges climbs it back. **Expansion adds debt; grounding
-retires it; the scoreboard shows both** — with no change to this harness.
+The number tracked the whole arc, honestly: REL-4b grounded 9 answers (→90%); REL-6
+expanded to **12 diseases**, adding authored-debt (→50%); **REL-8 re-ran the spider
+over every disease — now all 18 recall answers cite a spider-grounded (authoritative)
+edge: 100%.** Expansion adds debt; grounding retires it; the scoreboard shows both —
+with no change to this harness.
 
 ## Files
 

--- a/code/specs/data/mycin-2026/board/board-scorecard.json
+++ b/code/specs/data/mycin-2026/board/board-scorecard.json
@@ -18,8 +18,8 @@
     },
     "defensibility": 1.0,
     "accuracy_on_attempted": 1.0,
-    "grounded_coverage": 0.5,
-    "grounded_correct": 9
+    "grounded_coverage": 1.0,
+    "grounded_correct": 18
   },
   "results": [
     {
@@ -60,7 +60,7 @@
       "gold": "hgprt",
       "answer": "hgprt",
       "outcome": "correct",
-      "trust": "consensus"
+      "trust": "authoritative"
     },
     {
       "id": "von_gierke_enzyme",
@@ -108,7 +108,7 @@
       "gold": "alpha_galactosidase_a",
       "answer": "alpha_galactosidase_a",
       "outcome": "correct",
-      "trust": "consensus"
+      "trust": "authoritative"
     },
     {
       "id": "fabry_substrate",
@@ -116,7 +116,7 @@
       "gold": "globotriaosylceramide",
       "answer": "globotriaosylceramide",
       "outcome": "correct",
-      "trust": "consensus"
+      "trust": "authoritative"
     },
     {
       "id": "niemann_pick_enzyme",
@@ -124,7 +124,7 @@
       "gold": "acid_sphingomyelinase",
       "answer": "acid_sphingomyelinase",
       "outcome": "correct",
-      "trust": "consensus"
+      "trust": "authoritative"
     },
     {
       "id": "krabbe_enzyme",
@@ -132,7 +132,7 @@
       "gold": "galactocerebrosidase",
       "answer": "galactocerebrosidase",
       "outcome": "correct",
-      "trust": "consensus"
+      "trust": "authoritative"
     },
     {
       "id": "hurler_enzyme",
@@ -140,7 +140,7 @@
       "gold": "alpha_l_iduronidase",
       "answer": "alpha_l_iduronidase",
       "outcome": "correct",
-      "trust": "consensus"
+      "trust": "authoritative"
     },
     {
       "id": "msud_enzyme",
@@ -148,7 +148,7 @@
       "gold": "branched_chain_ketoacid_dehydrogenase",
       "answer": "branched_chain_ketoacid_dehydrogenase",
       "outcome": "correct",
-      "trust": "consensus"
+      "trust": "authoritative"
     },
     {
       "id": "galactosemia_enzyme",
@@ -156,7 +156,7 @@
       "gold": "galactose_1_phosphate_uridyltransferase",
       "answer": "galactose_1_phosphate_uridyltransferase",
       "outcome": "correct",
-      "trust": "consensus"
+      "trust": "authoritative"
     },
     {
       "id": "msud_inherit",
@@ -164,7 +164,7 @@
       "gold": "autosomal_recessive",
       "answer": "autosomal_recessive",
       "outcome": "correct",
-      "trust": "consensus"
+      "trust": "authoritative"
     },
     {
       "id": "wilson_disease_enzyme",

--- a/code/specs/data/mycin-2026/board/test_board_eval.py
+++ b/code/specs/data/mycin-2026/board/test_board_eval.py
@@ -65,17 +65,18 @@ def test_defensibility_is_full() -> None:
 def test_grounded_coverage_is_the_live_grounding_number() -> None:
     card, _ = _card()
     s = card.summary()
-    # The live number tracks BOTH levers. REL-4b spider-grounded 9 of the original
-    # board answers (authoritative). REL-6 then added 6 new diseases (8 new correct
-    # answers) as authored-debt (consensus) — so grounded-coverage DIPPED 90% → 50%
-    # (9 grounded / 18 correct). Re-running the spider on the new edges will climb it
-    # back up. Expansion adds debt; grounding retires it; the scoreboard shows both.
-    assert s["grounded_coverage"] == 0.5
-    assert s["grounded_correct"] == 9
+    # The live number tracked the whole arc: REL-4b grounded 9 (→90%), REL-6
+    # expansion added authored-debt (→50%), and REL-8 re-ran the spider over every
+    # disease — now ALL 18 recall board answers cite a spider-grounded (authoritative)
+    # edge. grounded-coverage = 100%. Expansion added debt; grounding retired it.
+    assert s["grounded_coverage"] == 1.0
+    assert s["grounded_correct"] == 18
     by_id = {r.item_id: r for r in card.results}
-    assert by_id["lesch_nyhan_enzyme"].trust == "consensus"   # direction_only holdout
-    assert by_id["tay_sachs_enzyme"].trust == "authoritative"  # spider-grounded
-    assert by_id["fabry_enzyme"].trust == "consensus"          # REL-6, not yet grounded
+    # Every recall answer is now spider-grounded — including the REL-6 diseases and
+    # the former lesch_nyhan direction_only holdout.
+    assert by_id["tay_sachs_enzyme"].trust == "authoritative"
+    assert by_id["lesch_nyhan_enzyme"].trust == "authoritative"
+    assert by_id["fabry_enzyme"].trust == "authoritative"
 
 
 def test_gate_exit_code_zero_when_no_fabrication() -> None:

--- a/code/specs/data/mycin-2026/recall/ground-iem-edges.workflow.js
+++ b/code/specs/data/mycin-2026/recall/ground-iem-edges.workflow.js
@@ -135,8 +135,17 @@ const VERIFY_SCHEMA = {
   },
 }
 
+// INCREMENTAL grounding (REL-8): the caller passes `args` = an array of edge ids
+// already grounded (the Workflow sandbox has no filesystem, so the skip-list is
+// injected, not read from iem-edge-grounding.json). Those edges are skipped so a
+// re-run only grounds the new / not-yet-grounded edges — no wasted re-fetching of
+// the 16 already-authoritative ones. With no args, every edge is grounded.
+const skip = new Set(Array.isArray(args) ? args : [])
+const todo = EDGES.filter((e) => !skip.has(e.id))
+log(`grounding ${todo.length} edge(s); skipping ${skip.size} already grounded`)
+
 const records = await pipeline(
-  EDGES,
+  todo,
   (e) => agent(
     `Ground this inborn-error-of-metabolism FACT against a PRIMARY source. Use WebSearch then WebFetch to actually READ a primary/authoritative source — OMIM (omim.org), a peer-reviewed reference, or an authoritative clinical-biochemistry text — NOT a secondary blog or a question bank. ` +
     `FACT [${e.id}]: ${e.claim} Confirm the source states this exact relation (${e.subj} → ${e.obj}). ` +

--- a/code/specs/data/mycin-2026/recall/iem-edge-grounding.json
+++ b/code/specs/data/mycin-2026/recall/iem-edge-grounding.json
@@ -10,21 +10,22 @@
       "grounded": {
         "id": "deficient_in__tay_sachs",
         "resolved_url": "https://www.ncbi.nlm.nih.gov/books/NBK1218/",
-        "source_title": "HEXA Disorders — GeneReviews®, NCBI Bookshelf (NIH)",
-        "byte_quote": "Biallelic pathogenic variants in HEXA lead to absent or reduced activity in β-hexosaminidase A, a lysosomal hydrolytic enzyme required for the breakdown of ganglioside GM2 in neurons. ... The alpha chain is encoded by HEXA; the beta chain is encoded by HEXB. Deficiency of HEX A can therefore be the result of pathogenic variants in HEXA or HEXB.",
+        "source_title": "HEXA Disorders - GeneReviews® - NCBI Bookshelf",
+        "byte_quote": "Biallelic pathogenic variants in HEXA lead to absent or reduced activity in β-hexosaminidase A, a lysosomal hydrolytic enzyme required for the breakdown of ganglioside GM2 in neurons.",
         "direction_correct": true,
         "verdict": "grounded",
         "discards": [
-          "https://www.omim.org/entry/272800 (OMIM Tay-Sachs Disease; TSD) — preferred primary source but returned HTTP 403 Forbidden to WebFetch; could not obtain a verbatim quote from the actual page, so not cited per no-fabrication rule.",
-          "https://www.omim.org/entry/606869 (OMIM HEXOSAMINIDASE A; HEXA) — also HTTP 403 Forbidden; unfetchable, discarded.",
-          "WebSearch result snippets (PMC3377590, StatPearls NBK564432, etc.) — secondary/derivative or not directly fetched; used only to locate the authoritative GeneReviews entry, not quoted as the grounding source."
+          "OMIM #272800 (Tay-Sachs Disease; TSD) at https://www.omim.org/entry/272800 and OMIM *606869 (HEXA) at https://omim.org/entry/606869 — these are the canonical primary references and the WebSearch snippet quoted them ('Tay-Sachs disease results in hexosaminidase A deficiency'), but both returned HTTP 403 Forbidden on WebFetch, so I could not READ the page myself to capture a verifiably verbatim quote. Discarded to avoid citing a quote I could not directly confirm on the source page.",
+          "NCBI Genes and Disease 'Tay-Sachs disease' (NBK22250) and StatPearls 'Tay-Sachs Disease' (NBK564432) — adequate but lower-tier than the peer-reviewed GeneReviews expert chapter; not fetched since GeneReviews already gave a directly-readable authoritative quote.",
+          "PubMed 27682588 (HEXA mutations target alpha chain to ERAD) — a primary research article on a specific mechanism, narrower than the general etiologic relation needed; discarded as not the cleanest statement of the disease→enzyme-deficiency edge.",
+          "WebSearch-generated summary prose (not from a fetched page body) — e.g. 'Tay-Sachs disease results in hexosaminidase A deficiency'; discarded as a search-engine synthesis, not a verbatim sentence I read on the actual source page."
         ],
-        "note": "ENTAILED. The FACT (tay_sachs -> deficiency of hexosaminidase A / HEXA) is directly entailed by the GeneReviews text. The page is the GeneReviews 'HEXA Disorders' entry whose classic clinical phenotype IS Tay-Sachs disease (TSD). The quote states biallelic HEXA pathogenic variants produce absent/reduced β-hexosaminidase A (HEX A) activity, and that the alpha chain of HEX A is encoded by HEXA — establishing both the enzyme (hexosaminidase A) and gene (HEXA) deficiency as the cause. Direction is correct: the disease results from the deficiency. Minor nuance (a slight LEAP, not affecting the verdict): the verbatim sentence ties HEXA variants to the disease continuum/HEX A deficiency at the gene/enzyme level rather than spelling out the literal string 'Tay-Sachs disease results from deficiency of hexosaminidase A'; the equivalence rests on this entry being the canonical HEXA/Tay-Sachs reference (alpha-subunit deficiency = classic TSD), which is standard and authoritative. GeneReviews is peer-reviewed (NCBI Bookshelf/NIH), an authoritative clinical-genetics source — not a blog or question bank. OMIM (the requested primary source) was attempted first but 403-blocked."
+        "note": "ENTAILED. The fact asserts the edge tay_sachs → deficiency of hexosaminidase A (HEXA). The fetched GeneReviews quote states biallelic pathogenic variants in HEXA lead to absent or reduced activity in β-hexosaminidase A (= hexosaminidase A / HEX A). 'Absent or reduced activity' of the enzyme IS enzyme deficiency, and the page title 'HEXA Disorders' plus the chapter's classic phenotype 'Tay-Sachs disease' tie this HEXA/HEX-A deficiency directly to Tay-Sachs disease (a second sentence on the page: 'HEX A is necessary for degradation of GM2 ganglioside; without well-functioning enzymes, GM2 ganglioside builds up'). Direction is correct: disease results FROM the enzyme deficiency. Note: GeneReviews and OMIM use the formal name β-hexosaminidase A (HEX A) for the enzyme the FACT calls 'hexosaminidase A (HEXA)' — same enzyme; HEXA is the gene encoding its alpha subunit, hexosaminidase A is the enzyme. Minor LEAP only in equating 'absent or reduced activity' with the FACT's word 'deficiency,' which is standard clinical-biochemistry usage and is corroborated by the OMIM snippet's explicit phrase 'Tay-Sachs disease results in hexosaminidase A deficiency.'"
       },
       "verify": {
         "id": "deficient_in__tay_sachs",
         "byte_stable": true,
-        "refute_attempt": "Strongest refutation: the quoted passage emphasizes that HEX A deficiency can arise from variants in EITHER HEXA or HEXB, and HEXB variants cause Sandhoff disease — not Tay-Sachs. So one might argue the quote describes the enzyme's two-gene basis generically rather than pinning Tay-Sachs specifically to HEXA, making the FACT's HEXA attribution an over-specification of what the bytes say. This refutation FAILS: sentence 1 — \"Biallelic pathogenic variants in HEXA lead to absent or reduced activity in β-hexosaminidase A, a lysosomal hydrolytic enzyme required for the breakdown of ganglioside GM2 in neurons\" — directly ties HEXA variants to deficient HEX A activity, the page is titled \"HEXA Disorders\" with Tay-Sachs (TSD) as the classic phenotype, and the page lists \"Beta-Hexosaminidase A Deficiency ... Tay-Sachs Disease\" as synonyms. The relation that Tay-Sachs results from deficiency of hexosaminidase A (alpha subunit encoded by HEXA) is explicitly stated.",
+        "refute_attempt": "Strongest refutation attempt: One could argue the byte_quote does not literally use the word \"Tay-Sachs\" or the word \"deficiency\" — it speaks of \"absent or reduced activity in β-hexosaminidase A\" from biallelic HEXA variants, not explicitly \"Tay-Sachs results from deficiency of HEXA.\" A skeptic might claim (a) \"absent or reduced activity\" is not strictly synonymous with \"deficiency,\" and (b) the quoted sentence frames HEXA as the gene whose variants reduce the enzyme, while the FACT phrases HEXA as the enzyme name (HEXA is the gene; β-hexosaminidase A / Hex A is the enzyme, with the alpha subunit encoded by HEXA). The refutation FAILS: the page is the GeneReviews entry titled for HEXA Disorders / Tay-Sachs disease, and explicitly elsewhere states \"Individuals with acute infantile TSD have no or extremely low HEX A enzymatic activity\" and diagnosis requires \"abnormally low HEX A activity ... and biallelic pathogenic variants in HEXA.\" The byte_quote itself directly ties HEXA variants to \"absent or reduced activity in β-hexosaminidase A,\" which is exactly the deficiency relation. The gene-vs-enzyme nuance (HEXA encodes the alpha subunit of Hex A) is a representational detail, not a refutation of the stated deficiency edge. The relation is genuinely and explicitly stated.",
         "final_verdict": "grounded"
       },
       "spider_status": "grounded"
@@ -37,25 +38,23 @@
       "claim": "GM2 ganglioside accumulates (in neurons) in Tay-Sachs disease.",
       "grounded": {
         "id": "accumulates__tay_sachs",
-        "resolved_url": "https://www.ncbi.nlm.nih.gov/books/NBK564432/",
-        "source_title": "Tay-Sachs Disease - StatPearls - NCBI Bookshelf",
-        "byte_quote": "Tay-Sachs disease is a progressive, lethal neurodegenerative disorder caused by a deficiency of the enzyme hexosaminidase-A that results in the accumulation of GM2 gangliosides. [...] deficiency of Hex A causes an accumulation of the gangliosides up to toxic levels, especially in the neurons.",
+        "resolved_url": "https://pmc.ncbi.nlm.nih.gov/articles/PMC12113087/",
+        "source_title": "Yeast-Produced Human Recombinant Lysosomal β-Hexosaminidase Efficiently Rescues GM2 Ganglioside Accumulation in Tay–Sachs Disease (Journal of Personalized Medicine, PMC12113087)",
+        "byte_quote": "TSD is a severe neurodegenerative disorder characterized by the progressive lysosomal accumulation of GM2 in neurons due to a deficiency of the HexA enzyme.",
         "direction_correct": true,
         "verdict": "grounded",
         "discards": [
-          "https://www.omim.org/entry/272800 (OMIM #272800 TAY-SACHS DISEASE; TSD) — the canonical primary genetic source and ideal citation, but WebFetch returned HTTP 403 Forbidden (OMIM blocks automated fetches). Could not obtain a verbatim quote from a page I actually read, so cannot cite it as the byte_quote source. Search-snippet text ('characterized by GM2-ganglioside accumulation, ballooned neurons') is consistent but unverified and was NOT used as the quote.",
-          "https://mirror.omim.org/clinicalSynopsis/272800 — OMIM clinical-synopsis mirror; also returned HTTP 403 Forbidden. Discarded for the same fetch-failure reason.",
-          "https://www.malacards.org/card/tay_sachs_disease — secondary aggregated database, not a primary/peer-reviewed source; discarded per primary-source requirement.",
-          "https://www.news-medical.net/health/Tay-Sachs-Disease-Pathophysiology.aspx — secondary health-news site, not authoritative primary literature; discarded.",
-          "https://rarediseases.org/rare-diseases/tay-sachs-disease/ (NORD) — patient-facing advocacy summary, not a primary source; discarded.",
-          "https://intrabio.com / https://blugenes.org / https://alextlc.org — disease-foundation / commercial pages, not authoritative references; discarded."
+          "https://omim.org/entry/272800 and mirror.omim.org (OMIM #272800 TAY-SACHS DISEASE; TSD) — the canonical primary genetic source and would directly state GM2-ganglioside accumulation + ballooned neurons, but OMIM returned HTTP 403 Forbidden to WebFetch (both main and mirror), so no VERBATIM quote could be retrieved from the page itself. Search-snippet text ('Analysis of CNS gangliosides demonstrates accumulation of GM2 ganglioside...') is a search-engine summary, not a fetched-page byte quote, so it is not used as the grounding quote.",
+          "https://www.ncbi.nlm.nih.gov/books/NBK564432/ (StatPearls 'Tay-Sachs Disease', Lui/Ramani/Sankaran, updated 2024-10-06) — successfully fetched and STRONGLY corroborates ('...accumulation of GM2 gangliosides' caused by hexosaminidase-A deficiency; '...accumulation of the gangliosides up to toxic levels, especially in the neurons'). Not chosen as resolved_url only because its neuron statement is split across two sentences; the PMC article states GM2+neurons+TSD in one clause. Retained as corroborating source, not discarded for unreliability.",
+          "en.wikipedia.org/wiki/Tay-Sachs_disease, en.wikipedia.org/wiki/HEXA, rarediseases.org (NORD), malacards.org, medlink.com — secondary/tertiary encyclopedic or aggregator sources; discarded in favor of peer-reviewed primary literature and NCBI Bookshelf per the primary-source requirement.",
+          "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC10846629/ (infantile GM2 gangliosidosis case report) — relevant but a single case report; the chosen PMC review-style article and StatPearls give cleaner general-mechanism statements."
         ],
-        "note": "ENTAILED. The fetched StatPearls page (peer-reviewed NCBI Bookshelf clinical-biochemistry reference) states the relation directly and in the correct direction: it names the disease (Tay-Sachs) as the subject and asserts the object — accumulation of GM2 gangliosides — as its result, then specifies the accumulation occurs 'especially in the neurons.' This forces the FACT tay_sachs -> gm2_ganglioside accumulates (in neurons) with no inferential leap; the subject->object direction matches the FACT exactly. Note: the ideal primary citation is OMIM #272800, which I attempted to fetch but which returned 403; the quote here comes from a page I actually read, and the verdict rests on that verifiable quote rather than the OMIM search snippet."
+        "note": "ENTAILED. The fetched quote explicitly names all three required elements in one clause: the subject (Tay-Sachs disease / TSD), the accumulating substance (GM2 ganglioside — 'GM2'), and the site (in neurons), stating GM2 'accumulation in neurons' as a defining characteristic of TSD. This forces the edge direction tay_sachs → gm2_ganglioside (the disease is characterized by GM2 accumulating, not GM2 causing the disease). No inferential leap is required. Corroborated independently by StatPearls (NCBI Bookshelf): 'accumulation of GM2 gangliosides' from hexosaminidase-A deficiency, 'especially in the neurons.' Note: the article writes 'GM2' (the ganglioside) where the FACT says 'GM2 ganglioside' — identical referent in this context (GM2 ganglioside = the substrate of HexA), so no semantic gap. Caveat: the OMIM primary entry (#272800) could not be byte-fetched (403); grounding rests on peer-reviewed literature + NCBI Bookshelf rather than OMIM itself, but both fetched sources state the exact relation verbatim, so verdict is grounded."
       },
       "verify": {
         "id": "accumulates__tay_sachs",
         "byte_stable": true,
-        "refute_attempt": "Strongest refutation: The localization clause (\"especially in the neurons\") attaches to \"the gangliosides\" via anaphora rather than re-naming \"GM2 gangliosides,\" so one could argue the page never literally writes \"GM2 accumulates in neurons\" in a single span. However, the antecedent of \"the gangliosides\" in the second quote is unambiguously the GM2 gangliosides named in the first quote, and both quotes appear verbatim. The first asserts GM2 ganglioside accumulation in Tay-Sachs; the second localizes that accumulation to neurons. The edge (accumulates) and the localization (in neurons) are both explicitly stated, with no negation or hedging. The refutation fails.",
+        "refute_attempt": "Attempted to refute on two grounds: (1) the quote writes \"GM2\" rather than \"GM2 ganglioside\" — but the same article's abstract explicitly says \"accumulation of GM2 ganglioside,\" so the entity is unambiguous; (2) whether the in-neurons accumulation relation is actually stated for TSD — the quote names TSD as subject and directly states \"progressive lysosomal accumulation of GM2 in neurons.\" Both refutations fail; the relation is explicitly stated, not inferred.",
         "final_verdict": "grounded"
       },
       "spider_status": "grounded"
@@ -69,22 +68,23 @@
       "grounded": {
         "id": "inherited_as__tay_sachs",
         "resolved_url": "https://medlineplus.gov/genetics/condition/tay-sachs-disease/",
-        "source_title": "Tay-Sachs disease: MedlinePlus Genetics (U.S. National Library of Medicine / NIH)",
+        "source_title": "Tay-Sachs disease: MedlinePlus Genetics",
         "byte_quote": "This condition is inherited in an autosomal recessive pattern, which means both copies of the gene in each cell have variants.",
         "direction_correct": true,
         "verdict": "grounded",
         "discards": [
-          "OMIM #272800 Entry and Clinical Synopsis (omim.org/entry/272800, omim.org/clinicalSynopsis/272800) and the OMIM mirror (mirror.omim.org) — the canonical primary genetics source and first choice, but all returned HTTP 403 Forbidden to WebFetch, so no verifiable verbatim quote could be extracted. Discarded to avoid fabricating a quote.",
-          "WebSearch result-summary text asserting 'Tay-Sachs disease is inherited in an autosomal recessive pattern' — discarded as a source because it is a search-engine-generated synthesis, not a verbatim quote from a fetched page; used only to locate candidate URLs.",
-          "StatPearls (ncbi.nlm.nih.gov/books/NBK564432/) and the PMC review PMC12298450 — authoritative but not fetched; the MedlinePlus Genetics page already provided a clean, explicit Inheritance-heading quote, so additional fetches were unnecessary.",
-          "MedlinePlus consumer pages (taysachsdisease.html, ency/article/001417.htm) — superseded by the more precise MedlinePlus Genetics 'Inheritance' section on the same NLM domain."
+          "https://omim.org/entry/272800 (OMIM TAY-SACHS DISEASE; TSD #272800) — the canonical primary genetics source and first-choice target; discarded because direct WebFetch returned HTTP 403 Forbidden, so no verbatim quote could be retrieved from the page body. Search-snippet text ('Tay-Sachs disease is an autosomal recessive, progressive neurodegenerative disorder...') would support the fact but is a search-engine summary, not bytes I fetched off the page — excluded to avoid fabricated/second-hand quoting.",
+          "https://mirror.omim.org/clinicalSynopsis/272800 (OMIM mirror clinical synopsis) — attempted as an OMIM fallback for the 'Inheritance: Autosomal recessive' synopsis line; also returned HTTP 403 Forbidden, no body retrieved.",
+          "https://www.ncbi.nlm.nih.gov/books/NBK564432/ (Tay-Sachs Disease, StatPearls / NCBI Bookshelf) — authoritative and would corroborate, but not fetched once MedlinePlus already yielded a clean verbatim inheritance quote; left unfetched rather than cited unread.",
+          "https://www.ncbi.nlm.nih.gov/books/NBK22250/ (Tay-Sachs disease, Genes and Disease, NCBI Bookshelf) — same reason; redundant, not fetched.",
+          "Secondary/question-bank and blog-style hits were not surfaced or used per the primary/authoritative-source constraint."
         ],
-        "note": "ENTAILED. The quote appears under the page's 'Inheritance' heading on the Tay-Sachs disease entry, so 'This condition' unambiguously refers to Tay-Sachs disease. The sentence states the exact relation tay_sachs -> autosomal_recessive ('inherited in an autosomal recessive pattern') with no inference required. Note on source tier: OMIM (the requested primary source) was unreachable via WebFetch (403); MedlinePlus Genetics is an authoritative NIH/NLM peer-reviewed reference that itself cites OMIM, satisfying the 'primary/authoritative, not blog/question-bank' requirement."
+        "note": "ENTAILED. The fetched MedlinePlus Genetics page states verbatim: 'This condition is inherited in an autosomal recessive pattern...' where 'This condition' is the page's subject, Tay-Sachs disease (page title 'Tay-Sachs disease'). This directly asserts the edge tay_sachs -> autosomal_recessive with no inference required; the quote forces the fact. Sourcing caveat (not a grounding gap): the preferred primary source OMIM #272800 was 403-blocked to WebFetch; MedlinePlus Genetics (U.S. National Library of Medicine / NIH) is an authoritative, peer-curated clinical-genetics reference — not a blog or question bank — and was actually fetched and read, satisfying the primary/authoritative-source requirement. Direction confirmed correct (subject = Tay-Sachs, attribute = autosomal recessive)."
       },
       "verify": {
         "id": "inherited_as__tay_sachs",
         "byte_stable": true,
-        "refute_attempt": "Tested whether the quote is generic MedlinePlus boilerplate (\"This condition is inherited in...\") that doesn't actually name Tay-Sachs, and whether the page truly states the edge. The quote appears verbatim on the fetched Tay-Sachs-disease condition page under its Inheritance heading, where \"This condition\" unambiguously refers to Tay-Sachs disease. The autosomal-recessive inheritance relation is genuinely and directly asserted for Tay-Sachs, not merely implied or adjacent. Refutation fails.",
+        "refute_attempt": "Strongest refutation attempt: Could the quote be present but NOT actually state the claimed edge (inherited_as: Tay-Sachs disease -> autosomal recessive)? The byte_quote reads \"This condition is inherited in an autosomal recessive pattern, which means both copies of the gene in each cell have variants.\" Three possible attacks: (1) \"This condition\" is anaphoric and might refer to something other than Tay-Sachs disease. Rejected: the page is the dedicated MedlinePlus Genetics condition page for Tay-Sachs disease, and the sentence appears under the \"Inheritance\" section heading for that condition, so \"This condition\" unambiguously resolves to Tay-Sachs disease. (2) The quote describes a \"pattern\" of inheritance rather than asserting the disease IS inherited that way. Rejected: \"is inherited in an autosomal recessive pattern\" is a direct factual assertion of the inheritance mode, exactly matching the FACT \"inherited in an autosomal recessive manner.\" (3) The quote might be misquoted/paraphrased on the page. Rejected: WebFetch confirmed the sentence appears verbatim, byte-for-byte, including the trailing clause. No successful refutation found.",
         "final_verdict": "grounded"
       },
       "spider_status": "grounded"
@@ -98,23 +98,23 @@
       "grounded": {
         "id": "deficient_in__gaucher",
         "resolved_url": "https://www.ncbi.nlm.nih.gov/books/NBK1269/",
-        "source_title": "Gaucher Disease — GeneReviews®, NCBI Bookshelf (NBK1269)",
-        "byte_quote": "Gaucher disease (GD) is caused by deficient glucocerebrosidase activity and the resultant accumulation of its undegraded substrate, GL1, and other glycolipids. ... GBA1 encodes glucocerebrosidase (also known as glucosylceramidase)",
+        "source_title": "Gaucher Disease — GeneReviews®, NCBI Bookshelf",
+        "byte_quote": "Gaucher disease (GD) is caused by deficient glucocerebrosidase activity and the resultant accumulation of its undegraded substrate, GL1, and other glycolipids. ... The diagnosis of GD relies on demonstration of deficient glucocerebrosidase (glucosylceramidase) enzyme activity in peripheral blood leukocytes or other nucleated cells, or by the identification of biallelic pathogenic variants in GBA1 on molecular genetic testing.",
         "direction_correct": true,
         "verdict": "grounded",
         "discards": [
-          "https://www.omim.org/entry/230800 (OMIM Gaucher disease type I, the canonical primary source that explicitly states 'deficient activity of beta-glucocerebrosidase' and names 'acid beta-glucosidase' / GBA) — DISCARDED because direct WebFetch returned HTTP 403 Forbidden; I could not retrieve a verbatim supporting quote from the page itself, only from the search-snippet, so I did not cite it as the grounding source.",
-          "https://www.omim.org/entry/606463 (OMIM *GBA gene entry, GLUCOSIDASE, BETA, ACID) — DISCARDED: relevant primary source for the 'acid beta-glucosidase' synonym but same OMIM 403 fetch barrier; not independently fetched.",
-          "https://www.ncbi.nlm.nih.gov/books/NBK448080/ (StatPearls Gaucher disease) — DISCARDED: secondary review-style chapter; GeneReviews is the higher-authority peer-reviewed clinical-genetics reference, so it was preferred.",
-          "https://www.ncbi.nlm.nih.gov/books/NBK22242/ (Genes and Disease, Gaucher) — DISCARDED: brief educational overview, lower authority than GeneReviews.",
-          "https://pubmed.ncbi.nlm.nih.gov/18338393/ and /34282371/ (GBA mutation-spectrum primary papers) — DISCARDED: about specific mutation catalogs, not the canonical enzyme-deficiency statement; tangential to the exact relation."
+          "https://www.omim.org/entry/230800 — OMIM Gaucher disease type I entry: the authoritative primary genetics database and ideal source, but WebFetch returned HTTP 403 Forbidden, so I could not obtain a verbatim quote from the page itself. Discarded to avoid fabricating a quote.",
+          "https://data.omim.org/entry/606463 — OMIM GBA gene entry: not fetched; OMIM domain blocks WebFetch (403). Not needed once GeneReviews supplied a direct supporting quote.",
+          "https://www.ncbi.nlm.nih.gov/books/NBK448080/ — StatPearls Gaucher Disease: a secondary review chapter; not fetched since GeneReviews (peer-reviewed expert-authored) is the stronger authoritative source.",
+          "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6376752/ and other PMC/PubMed research articles (Indian/Turkish/Egyptian cohort studies) — primary research papers on specific mutation cohorts, not authoritative reference statements of the disease→enzyme relation; discarded as off-target.",
+          "https://image-ppubs.uspto.gov/...downloadPdf/9387236 — a US patent on lysosomal-disease compositions; not an authoritative clinical/biochemistry reference; discarded."
         ],
-        "note": "ENTAILED. The verbatim quote 'Gaucher disease (GD) is caused by deficient glucocerebrosidase activity' directly states gaucher → glucocerebrosidase deficiency — no inference needed; the direction (disease caused by enzyme deficiency) matches the FACT exactly. The second verbatim clause 'GBA1 encodes glucocerebrosidase' grounds the enzyme↔gene identity (GBA). One minor naming nuance, NOT a grounding gap: this GeneReviews page does not use the synonym 'acid beta-glucosidase' — it uses 'glucocerebrosidase'/'glucosylceramidase'. The 'acid beta-glucosidase' alias in the FACT is the OMIM/EC-3.2.1.45 nomenclature (OMIM #230800 / *606463 confirm it via search snippet), but OMIM blocked WebFetch (403), so I grounded the core relation on GeneReviews instead. Synonym equivalence (glucocerebrosidase = acid beta-glucosidase = GBA = glucosylceramidase) is standard and uncontroversial, so the FACT as a whole is grounded; only the specific 'acid beta-glucosidase' token relies on the un-fetched OMIM/standard nomenclature rather than the cited page's literal bytes."
+        "note": "ENTAILED. The quote \"Gaucher disease (GD) is caused by deficient glucocerebrosidase activity\" directly and explicitly states the exact relation (gaucher → glucocerebrosidase deficiency), with no inference required. The second sentence corroborates by naming the same enzyme (glucocerebrosidase / glucosylceramidase) as the diagnostic deficiency and its gene GBA1, matching the FACT's \"acid beta-glucosidase / GBA\" synonyms. Source is GeneReviews (NCBI Bookshelf), a peer-reviewed expert-authored clinical-genetics reference — an authoritative primary source, not a blog or question bank. Direction is correct (disease is the subject, enzyme deficiency is the cause/object). No LEAP."
       },
       "verify": {
         "id": "deficient_in__gaucher",
         "byte_stable": true,
-        "refute_attempt": "Attempted to refute that the page actually states the edge \"Gaucher disease ← deficiency of glucocerebrosidase (GBA).\" Refutation fails: the page (GeneReviews NBK1269, Molecular Pathogenesis section) states verbatim and causally \"Gaucher disease (GD) is caused by deficient glucocerebrosidase activity...\" — a direct, unhedged causal relation, not mere association. It also states \"GBA1 encodes glucocerebrosidase (also known as glucosylceramidase),\" which grounds the GBA equivalence in the FACT. The only gap is the synonym \"acid beta-glucosidase,\" which did not surface verbatim in the fetched text; however, that synonym is auxiliary labeling and not the load-bearing causal edge, which is fully and explicitly stated.",
+        "refute_attempt": "Strongest refutation: the FACT names the enzyme \"acid beta-glucosidase / GBA,\" but the verbatim quote uses \"glucocerebrosidase (glucosylceramidase)\" and references the GBA1 gene — the exact string \"acid beta-glucosidase\" does not appear in the quoted bytes, so one could argue the GBA/acid-beta-glucosidase identity is supplied externally rather than by the source. This refutation FAILS: (1) the page states verbatim \"Gaucher disease (GD) is caused by deficient glucocerebrosidase activity,\" which is precisely the deficiency-causes-disease edge asserted; (2) glucocerebrosidase, glucosylceramidase, and acid beta-glucosidase are established synonyms for the same enzyme (EC 3.2.1.45), and the quote explicitly anchors it to the GBA1 gene via \"biallelic pathogenic variants in GBA1.\" The causal relation is stated outright, not merely implied or inferred.",
         "final_verdict": "grounded"
       },
       "spider_status": "grounded"
@@ -127,23 +127,23 @@
       "claim": "Glucocerebroside (glucosylceramide) accumulates in macrophages in Gaucher disease.",
       "grounded": {
         "id": "accumulates__gaucher",
-        "resolved_url": "https://www.ncbi.nlm.nih.gov/books/NBK448080/",
-        "source_title": "Gaucher Disease - StatPearls - NCBI Bookshelf (Stone DL, Mukkamalla SKR, Master SR)",
-        "byte_quote": "The lysosomes in the macrophages of patients with Gaucher disease become progressively enlarged and filled with undigested glucocerebroside.",
+        "resolved_url": "https://pmc.ncbi.nlm.nih.gov/articles/PMC4451492/",
+        "source_title": "Gaucher Disease and Gaucher Cells (Gözdaşoğlu S.), Turkish Journal of Hematology, 2015 — PMC4451492",
+        "byte_quote": "The storage and deposition of glucocerebroside within these cells, prominently macrophages, results in the appearance of Gaucher cells",
         "direction_correct": true,
         "verdict": "grounded",
         "discards": [
-          "OMIM entry #230800 (https://www.omim.org/entry/230800) — the canonical primary genetics source and ideal for this FACT, but WebFetch returned HTTP 403 Forbidden so no verbatim quote could be retrieved from the page itself; not cited to avoid fabricating a quote. Search-snippet text appeared supportive but snippets are not the fetched page.",
-          "PubMed abstracts (pubmed.ncbi.nlm.nih.gov/23622393, /28218669) — authoritative but only abstract-level; the StatPearls full-text gave a cleaner, directly-on-point verbatim sentence so these were not fetched.",
-          "PMC review articles (PMC5343975, PMC4717273) — peer-reviewed but secondary review/mechanism papers; StatPearls is the more direct authoritative clinical reference and already entailed the FACT.",
-          "biorxiv preprint (Gaucher Disease Protects Against Tuberculosis) — non-peer-reviewed preprint, discarded per primary-source requirement."
+          "https://omim.org/entry/230800 and https://mirror.omim.org/entry/230800 (OMIM #230800, GAUCHER DISEASE TYPE I) — the intended PRIMARY source, but both returned HTTP 403 Forbidden to WebFetch, so no verbatim quote could be extracted; not cited to avoid fabricating a quote from a page I could not actually read.",
+          "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4451492/ — pre-redirect URL for the cited article; discarded in favor of the canonical post-301 host pmc.ncbi.nlm.nih.gov which is the URL actually fetched.",
+          "WebSearch result-snippet summaries (e.g. 'intracellular accumulation of glucosylceramide ... within cells of mononuclear phagocyte origin') — discarded as byte_quote because search snippets are AI-paraphrased aggregations, not a verbatim sentence from a single fetched primary page.",
+          "https://pubmed.ncbi.nlm.nih.gov/28218669/ (Review of Gaucher Disease Pathophysiology) and NBK548625 (LiverTox) — credible corroborating peer-reviewed sources, not fetched because the cited PMC article already supplies a verbatim entailing quote; left as backup rather than over-fetching."
         ],
-        "note": "ENTAILED. The fetched StatPearls Etiology sentence explicitly states that in Gaucher disease, the macrophages' lysosomes are \"filled with undigested glucocerebroside,\" which directly asserts the relation gaucher -> glucocerebroside accumulating in macrophages. Direction is correct (subject = Gaucher disease, object = glucocerebroside accumulation in macrophages). The FACT's parenthetical equivalence \"glucocerebroside (glucosylceramide)\" is standard and corroborated by other fetched/searched sources; the quote alone uses \"glucocerebroside,\" which is the term in the FACT, so no leap is needed. Note: the ideal primary source (OMIM #230800) was blocked by 403; StatPearls (NIH/NCBI Bookshelf, authored peer-reviewed clinical reference) is an acceptable authoritative substitute and was actually fetched with a supporting verbatim quote."
+        "note": "ENTAILED. The quote states \"storage and deposition of glucocerebroside within these cells, prominently macrophages, results in the appearance of Gaucher cells.\" This directly asserts the subject→object edge (gaucher → glucocerebroside) AND the localization to macrophages, matching the FACT verbatim in substance — glucocerebroside (= glucosylceramide/glucosylcerebroside, used interchangeably in this article) accumulates in macrophages in Gaucher disease. No inferential leap: storage/deposition of glucocerebroside in macrophages IS the claimed accumulation. Direction is correct (Gaucher disease is the context; glucocerebroside is the accumulating substance). One minor note: the source is a peer-reviewed clinical-hematology paper rather than OMIM (OMIM was the preferred primary but was 403-blocked); the Turkish Journal of Hematology article is an authoritative peer-reviewed reference, satisfying the primary/authoritative requirement."
       },
       "verify": {
         "id": "accumulates__gaucher",
         "byte_stable": true,
-        "refute_attempt": "Tried to break the grounding three ways. (1) Verbatim presence: I bypassed the summarizing model and grepped the raw HTML via curl — the sentence \"The lysosomes in the macrophages of patients with Gaucher disease become progressively enlarged and filled with undigested glucocerebroside\" matches byte-for-byte, so byte_stable holds. (2) Does the quote state the EDGE (X accumulates in macrophages), or just mention the parts? It states it directly: glucocerebroside is the undigested substance filling lysosomes that are specifically located \"in the macrophages\" of Gaucher patients, and they \"become progressively enlarged and filled\" = accumulation. The FACT's verb \"accumulates\" is a faithful paraphrase of \"filled with undigested.\" Surrounding context reinforces (\"Lysosomes are abundant in macrophages\"; \"glucocerebroside-laden macrophages\"; \"glycolipid-laden Gaucher cells\"). (3) The FACT's parenthetical synonym \"(glucosylceramide)\" does not appear in this exact sentence — a potential gap. But it is standard nomenclature, and the same page uses \"glucosylceramide synthase\" and \"beta-glucosylceramidase,\" confirming the synonymy on-page; the cited edge rests on \"glucocerebroside,\" which is present. Refutation fails: the relation is explicitly asserted, not merely co-located.",
+        "refute_attempt": "Attempted to refute on the grounds that \"within these cells\" is a pronoun reference, so the macrophage identity rests on the appositive \"prominently macrophages\" rather than a standalone subject-verb-object claim, and that \"storage and deposition\" might not equal \"accumulates.\" Both fail: the appositive explicitly identifies the storage cells as macrophages, \"storage and deposition within\" is synonymous with accumulation, and the page independently reinforces the relation (\"glucosylceramide (glucocerebroside) is stored in the reticuloendothelial system due to a deficiency of the lysosomal enzyme β-glucocerebrosidase\"), confirming glucocerebroside=glucosylceramide and the Gaucher disease mechanism.",
         "final_verdict": "grounded"
       },
       "spider_status": "grounded"
@@ -157,22 +157,22 @@
       "grounded": {
         "id": "inherited_as__gaucher",
         "resolved_url": "https://www.ncbi.nlm.nih.gov/books/NBK1269/",
-        "source_title": "Gaucher Disease — GeneReviews® (NCBI Bookshelf)",
+        "source_title": "Gaucher Disease - GeneReviews® - NCBI Bookshelf",
         "byte_quote": "Gaucher disease (GD) is inherited in an autosomal recessive manner.",
         "direction_correct": true,
         "verdict": "grounded",
         "discards": [
-          "OMIM entries #230800 (GD Type I), #230900 (GD Type II), #231000 (GD Type III), #231005 (GD3C), #608013 (perinatal lethal), and their Clinical Synopses — these are the ideal primary source (curated, authoritative) and the search snippets corroborate autosomal recessive inheritance, but EVERY omim.org and mirror.omim.org URL returned HTTP 403 Forbidden to WebFetch. I could not READ a page to extract a verbatim quote, so per the 'never fabricate' rule I discarded them despite the secondary search-snippet support.",
-          "StatPearls 'Gaucher Disease' (NBK448080) — authoritative NCBI Bookshelf chapter, but not fetched; GeneReviews already provided a clean verbatim quote, so a second source was unnecessary.",
-          "NIH Genetic Testing Registry (GTR) condition pages and 'Genes and Disease' (NBK22242) — discarded as redundant once a direct, peer-reviewed verbatim quote was obtained from GeneReviews.",
-          "PubMed 20301446 — this is the PubMed citation stub for the same GeneReviews chapter; redundant with the fetched canonical Bookshelf page."
+          "OMIM #230800 / #230900 / #231000 (omim.org and mirror.omim.org) — these are the canonical primary genetic catalog entries and would be the ideal source, but every WebFetch returned HTTP 403 Forbidden (OMIM blocks automated/unauthenticated fetching). Could not obtain a verbatim quote, so discarded per the no-fabrication rule despite the search snippet asserting autosomal recessive inheritance.",
+          "StatPearls (NCBI Bookshelf, NBK448080) — authoritative but secondary to GeneReviews for the genetic-counseling/inheritance statement; not fetched since GeneReviews already yielded a clean verbatim quote.",
+          "MedlinePlus Genetics (medlineplus.gov/genetics/condition/gaucher-disease) — NLM consumer-health reference; authoritative but more consumer-facing than GeneReviews; not needed once GeneReviews quote secured.",
+          "Search-result summary text claiming 'Gaucher disease (GD) is inherited in an autosomal recessive manner' — used only as a pointer; the quote was independently confirmed by directly fetching the GeneReviews page itself, not taken from the search snippet."
         ],
-        "note": "ENTAILED. The fetched verbatim sentence 'Gaucher disease (GD) is inherited in an autosomal recessive manner.' is a direct, explicit statement of the exact relation (gaucher → autosomal_recessive); no inference or LEAP is required — the quote forces the fact. Sourcing note: the preferred primary source (OMIM) was unreachable (HTTP 403 on all omim.org/mirror.omim.org URLs via WebFetch), so I grounded against GeneReviews, a peer-reviewed, expert-authored clinical-genetics reference on the NCBI Bookshelf — a primary/authoritative source, not a blog or question bank. The quote was taken from the 'Mode of Inheritance' subsection of the Genetic Counseling section."
+        "note": "ENTAILED. The fetched GeneReviews page states verbatim, under the 'Mode of Inheritance' heading of the Genetic Counseling section: 'Gaucher disease (GD) is inherited in an autosomal recessive manner.' This names the exact subject (Gaucher disease) and exact relation/object (autosomal recessive inheritance) with no inference required — the quote directly forces the fact. Direction is correct (gaucher → autosomal_recessive). No LEAP. Source is a peer-reviewed authoritative primary reference (GeneReviews, NCBI Bookshelf), satisfying the primary-source requirement; OMIM was the first-choice catalog but was unfetchable (403)."
       },
       "verify": {
         "id": "inherited_as__gaucher",
         "byte_stable": true,
-        "refute_attempt": "Strongest refutation: argue the quote uses the abbreviation \"GD\" rather than the full term, so it might not bind to \"Gaucher disease,\" or that the sentence merely names a \"manner\" without asserting a true inheritance edge. This fails: the page explicitly defines GD = Gaucher disease, the quoted sentence appears verbatim under the \"Mode of Inheritance\" heading, and the edge is corroborated in two other places (Summary: \"GD is inherited in an autosomal recessive manner\"; Diagnosis: \"Family history is consistent with autosomal recessive inheritance\"). The subject, predicate (is inherited in), and object (autosomal recessive manner) are all present with no negation, hedge, or condition. The inherited_as(Gaucher disease, autosomal recessive) relation is directly and unambiguously stated.",
+        "refute_attempt": "Attempted to refute by checking whether the relation is hedged, conditional, negated, attributed to a different subject, or merely incidental. The quote \"Gaucher disease (GD) is inherited in an autosomal recessive manner.\" appears verbatim on NBK1269 (the GeneReviews entry for Gaucher Disease) in the \"Mode of Inheritance\" subsection, with no qualifier or negation. It is corroborated by a second verbatim summary statement \"GD is inherited in an autosomal recessive manner.\" Subject (Gaucher disease), predicate (is inherited in), and object (autosomal recessive manner) are all explicit and unhedged. The page is specifically about Gaucher disease, so subject attribution is unambiguous. No contradicting or weakening context was found. Refutation fails.",
         "final_verdict": "grounded"
       },
       "spider_status": "grounded"
@@ -186,22 +186,22 @@
       "grounded": {
         "id": "deficient_in__phenylketonuria",
         "resolved_url": "https://www.ncbi.nlm.nih.gov/books/NBK1504/",
-        "source_title": "Phenylalanine Hydroxylase Deficiency — GeneReviews®, NCBI Bookshelf (NBK1504)",
-        "byte_quote": "PAH deficiency is an inborn error of Phe metabolism caused by biallelic PAH pathogenic variants resulting in reduced activity of the enzyme PAH.",
+        "source_title": "Phenylalanine Hydroxylase Deficiency - GeneReviews® - NCBI Bookshelf",
+        "byte_quote": "PAH deficiency is an inborn error of Phe metabolism caused by biallelic PAH pathogenic variants resulting in reduced activity of the enzyme PAH. ... \"Phenylketonuria (PKU)\" refers specifically to severe PAH deficiency",
         "direction_correct": true,
         "verdict": "grounded",
         "discards": [
-          "OMIM #261600 (https://omim.org/entry/261600): the canonical primary source and it does state PKU 'results from a deficiency of PAH', but the live page returned HTTP 403 Forbidden to WebFetch, so I could not obtain a fetched verbatim byte_quote from it. The summary text returned by WebSearch is a search-engine synopsis, not a page I personally fetched, so I did not cite it as the byte_quote.",
-          "OMIM *612349 PHENYLALANINE HYDROXYLASE; PAH (https://omim.org/entry/612349): describes the PAH gene/enzyme (hydroxylation of Phe to Tyr) but is the gene entry, not the disease entry asserting the PKU->PAH-deficiency relation; also OMIM is fetch-blocked.",
-          "StatPearls Phenylketonuria (https://www.ncbi.nlm.nih.gov/books/NBK535378/): authoritative but is a clinical review chapter; GeneReviews is the more authoritative peer-reviewed expert-curated gene/disease reference, so preferred as primary.",
-          "NCBI Genes and Disease NBK22253 and GTR condition page: secondary/registry summaries, weaker than GeneReviews for a primary-source citation."
+          "https://omim.org/entry/261600 (OMIM PKU entry #261600) — the canonical primary source, but returned HTTP 403 Forbidden to WebFetch; could not retrieve a verbatim quote, so not citable as the grounded source.",
+          "https://mirror.omim.org/entry/261600 (OMIM mirror) — also returned HTTP 403 Forbidden; unfetchable.",
+          "https://omim.org/entry/612349 (OMIM PAH gene entry *612349) — describes the PAH gene/enzyme, not the disease→deficiency relation framing; not fetched for a quote and is the gene entry rather than the PKU disease entry.",
+          "WebSearch result snippet text (Google/OMIM search summary stating 'PKU... resulting from a deficiency of PAH') — discarded as a source: it is an aggregated/search-engine-generated summary, not a verbatim quote read off an authoritative page."
         ],
-        "note": "ENTAILED. The fetched GeneReviews sentence states PAH deficiency (the disease, of which phenylketonuria/PKU is the well-known eponym and the title of this very GeneReview, 'Phenylalanine Hydroxylase Deficiency') results from PAH pathogenic variants causing reduced activity of the enzyme PAH. This directly asserts the subject->object relation phenylketonuria -> deficiency of phenylalanine hydroxylase (PAH). Direction is correct: the disease results FROM the enzyme deficiency. The only minor LEAP is the eponym equivalence phenylketonuria == PAH deficiency, which is universally established (PKU is the classic/severe form of PAH deficiency and the GeneReview explicitly treats them as the same disorder spectrum). The canonical OMIM #261600 entry uses the even more on-the-nose phrasing 'results from a deficiency of PAH' but is fetch-blocked (HTTP 403), so GeneReviews is cited as the fetched authoritative primary source."
+        "note": "ENTAILED. GeneReviews (NCBI Bookshelf), a peer-reviewed authoritative clinical-genetics reference, states PAH deficiency results in 'reduced activity of the enzyme PAH' and that 'Phenylketonuria (PKU)' refers specifically to severe PAH deficiency. Composing the two: phenylketonuria = severe deficiency of phenylalanine hydroxylase (PAH). This forces the fact's exact relation (phenylketonuria → phenylalanine_hydroxylase) with correct direction; the disease is the deficient-state of the named enzyme. No leap. Note: the source frames the etiology as biallelic PAH pathogenic variants causing reduced PAH enzyme activity (i.e., enzyme deficiency is the proximate mechanism), which matches 'deficiency of phenylalanine hydroxylase.' The canonical OMIM #261600 entry corroborates this but was unfetchable (403); the substituted GeneReviews source is itself primary/authoritative."
       },
       "verify": {
         "id": "deficient_in__phenylketonuria",
         "byte_stable": true,
-        "refute_attempt": "Strongest refutation: the verbatim quote names \"PAH deficiency\" and \"reduced activity of the enzyme PAH\" rather than literally \"Phenylketonuria results from deficiency of phenylalanine hydroxylase.\" Two attack lines: (1) the quote never uses the word \"Phenylketonuria,\" so the subject may not be PKU; (2) \"reduced activity\" is not literally \"deficiency of\" the enzyme. Both fail. The page's title/synonyms list (\"PAH Deficiency, Phenylketonuria (PKU)\") and Nomenclature section (\"'Phenylketonuria (PKU)' refers specifically to severe PAH deficiency\") establish PKU IS PAH deficiency on this page. And \"PAH\" is the standard abbreviation for phenylalanine hydroxylase; \"reduced activity of the enzyme PAH\" is precisely a deficiency of phenylalanine hydroxylase function. The disease entity is even named \"PAH deficiency.\" The edge deficient_in(phenylketonuria, phenylalanine_hydroxylase) is directly and unambiguously stated.",
+        "refute_attempt": "Strongest refutation: the quote describes \"PAH deficiency\" broadly and only equates PKU with SEVERE PAH deficiency (plasma Phe >1,000 µmol/L), so one might argue the page does not state plain \"phenylketonuria results from PAH deficiency\" but rather a severe subset. However, this fails: PKU being \"severe PAH deficiency\" is still a deficiency of the enzyme PAH (phenylalanine hydroxylase), and the page's Molecular Pathogenesis section explicitly states the disorder is \"caused by biallelic PAH pathogenic variants resulting in reduced activity of the enzyme PAH\" where PAH = phenylalanine hydroxylase, \"the rate-limiting step in the conversion of phenylalanine (Phe) to tyrosine.\" The deficient_in(phenylketonuria, phenylalanine hydroxylase) edge is directly stated, not inferred.",
         "final_verdict": "grounded"
       },
       "spider_status": "grounded"
@@ -215,25 +215,25 @@
       "grounded": {
         "id": "accumulates__phenylketonuria",
         "resolved_url": "https://www.ncbi.nlm.nih.gov/books/NBK535378/",
-        "source_title": "Phenylketonuria (PKU) — StatPearls, NCBI Bookshelf (NIH)",
-        "byte_quote": "Loss of PAH activity due to biallelic pathogenic variants impairs phenylalanine metabolism, leading to the accumulation of phenylalanine and its toxic metabolites—phenylpyruvate, phenylacetate, and phenylactate—in the blood and brain. As a result, phenylalanine cannot be adequately metabolized, leading to its accumulation and reduced tyrosine production.",
+        "source_title": "Phenylketonuria (PKU) - StatPearls - NCBI Bookshelf",
+        "byte_quote": "Loss of PAH activity due to biallelic pathogenic variants impairs phenylalanine metabolism, leading to the accumulation of phenylalanine and its toxic metabolites.",
         "direction_correct": true,
         "verdict": "grounded",
         "discards": [
-          "OMIM #261600 (https://www.omim.org/entry/261600) — the canonical primary genetic reference and first-choice source; fetch returned HTTP 403 Forbidden (OMIM blocks automated WebFetch). Could not retrieve a verbatim supporting quote, so not citable here despite being authoritative.",
-          "Basic Neurochemistry, 'Phenylalanine Metabolism: Phenylketonuria' (https://www.ncbi.nlm.nih.gov/books/NBK28101/) — peer-reviewed biochemistry textbook on NCBI Bookshelf; fetched successfully but contains no sentence explicitly stating phenylalanine *accumulates*. It mentions 'excessive (>1 mM) blood phenylalanine concentrations' and effects of excess Phe, but does not state the accumulation relation directly, so it would force a LEAP rather than entail.",
-          "GeneReviews, 'Phenylalanine Hydroxylase Deficiency' (https://www.ncbi.nlm.nih.gov/books/NBK1504/) — authoritative peer-reviewed reference; fetched successfully and does confirm accumulation, but the cleanest retrievable quote ('accumulation of alternative products of Phe metabolism, including phenylacetic, phenylpyruvic, and phenyllactic acid') emphasizes the downstream metabolites rather than phenylalanine itself. StatPearls gave a more direct phenylalanine-accumulation statement, so this was kept as corroboration only.",
-          "OMIM search-result snippet text returned by WebSearch — not used as the grounding quote because it is search-engine-extracted summary text, not bytes I fetched and read from the page itself; citing it would risk quoting fabricated/aggregated content."
+          "https://www.omim.org/entry/261600 — OMIM primary entry for PKU (#261600): the ideal primary source, but the server returned HTTP 403 Forbidden to WebFetch, so I could not READ a page or extract a verbatim quote. Per instructions I do not fabricate a quote from an unfetched page; discarded in favor of a page I actually read.",
+          "https://www.ncbi.nlm.nih.gov/books/NBK1504/ — GeneReviews 'Phenylalanine Hydroxylase Deficiency' (peer-reviewed, equally authoritative): not fetched because StatPearls already yielded an explicit, on-point verbatim quote; held in reserve rather than used.",
+          "https://www.ncbi.nlm.nih.gov/books/NBK22253/ — NCBI 'Genes and Disease' chapter: secondary/educational summary, weaker than StatPearls/GeneReviews; not fetched.",
+          "Search-snippet text (e.g. 'concentration of phenylalanine in the body can build up to toxic levels') — discarded as evidence because it is aggregated search-result text, not bytes I fetched and read from the page itself."
         ],
-        "note": "ENTAILED. The quote states directly that in PKU/PAH deficiency 'phenylalanine cannot be adequately metabolized, leading to its accumulation,' and that loss of PAH activity leads to 'the accumulation of phenylalanine ... in the blood and brain.' This forces the exact FACT relation phenylketonuria → phenylalanine accumulates, in the stated subject→object direction; no inference or LEAP required. Source is StatPearls on NCBI Bookshelf (NIH-hosted, peer-reviewed clinical reference) — authoritative, not a blog or question bank. Caveat: the strictly-first-choice primary source (OMIM) was unfetchable (403); two other Bookshelf references corroborate accumulation, so confidence in the relation is high."
+        "note": "ENTAILED. The FACT is phenylketonuria → phenylalanine accumulates. The quote states that loss of PAH activity (the enzymatic defect that defines PKU; the same page titles the disorder 'Phenylketonuria (PKU)' and elsewhere calls it phenylalanine hydroxylase deficiency) leads 'to the accumulation of phenylalanine.' This is the exact subject→object relation with no inference required — the cause (PAH-deficient PKU) and the effect (phenylalanine accumulation) are both explicit in one sentence. Direction is correct: PKU is the condition, phenylalanine is what accumulates. A second corroborating verbatim quote on the same fetched page ('PKU is classified as an aminoacidopathy, or toxic accumulation disorder, in which excess substrate—phenylalanine and its metabolites—produce neurotoxicity if untreated') independently states phenylalanine accumulation in PKU. Minor LEAP element: the equivalence 'loss of PAH activity = phenylketonuria' is medical-definitional rather than spelled out in this single sentence, but the page's own title and classification make it the same disorder, so the grounding holds."
       },
       "verify": {
         "id": "accumulates__phenylketonuria",
-        "byte_stable": false,
-        "refute_attempt": "I attempted to refute on two axes. (1) Byte-stability: the provided byte_quote is a SINGLE string that concatenates two sentences which are NOT contiguous on the page. The first sentence (\"Loss of PAH activity due to biallelic pathogenic variants impairs phenylalanine metabolism, leading to the accumulation of phenylalanine and its toxic metabolites...in the blood and brain\") is in the Pathophysiology section and is immediately followed by \"Along with a relative tyrosine deficiency...\", NOT by \"As a result...\". The second sentence (\"As a result, phenylalanine cannot be adequately metabolized, leading to its accumulation and reduced tyrosine production\") is in the earlier Etiology section, preceded by the sentence about the PAH gene on chromosome 12q23.2. So the byte_quote as one verbatim block does not appear on the page — it is a stitched quote. byte_stable=false. (2) The relation itself: I tried to argue the edge is not stated, but this fails — each sentence individually appears verbatim, both explicitly say phenylalanine accumulates, and the page additionally describes PKU as 'a toxic accumulation disorder, in which excess substrate, specifically phenylalanine and its metabolites' accumulates. The relation 'phenylalanine accumulates in phenylketonuria' is unambiguously and repeatedly stated by the source. The substantive refutation does not succeed.",
-        "final_verdict": "direction_only"
+        "byte_stable": true,
+        "refute_attempt": "Strongest refutation: argue the quote attributes accumulation to \"loss of PAH activity,\" not nominally to \"phenylketonuria,\" so the edge could be about an enzyme defect rather than the named disease. This fails: NBK535378 is the StatPearls \"Phenylketonuria\" chapter, and \"loss of PAH activity due to biallelic pathogenic variants\" is the exact molecular definition of PKU (autosomal recessive PAH deficiency). The quote explicitly states \"leading to the accumulation of phenylalanine,\" directly asserting the accumulation relation. Corroborating on-page sentences (\"phenylalanine cannot be adequately metabolized, leading to its accumulation\"; \"Elevated phenylalanine readily crosses the blood-brain barrier\") reinforce it. The relation is stated, not merely implied.",
+        "final_verdict": "grounded"
       },
-      "spider_status": "direction_only"
+      "spider_status": "grounded"
     },
     {
       "id": "inherited_as__phenylketonuria",
@@ -244,22 +244,21 @@
       "grounded": {
         "id": "inherited_as__phenylketonuria",
         "resolved_url": "https://medlineplus.gov/genetics/condition/phenylketonuria/",
-        "source_title": "Phenylketonuria: MedlinePlus Genetics",
+        "source_title": "Phenylketonuria — MedlinePlus Genetics (U.S. National Library of Medicine, NIH)",
         "byte_quote": "This condition is inherited in an autosomal recessive pattern, which means both copies of the gene in each cell must have a variant to cause the disorder.",
         "direction_correct": true,
         "verdict": "grounded",
         "discards": [
-          "OMIM #261600 entry (https://omim.org/entry/261600) and its Clinical Synopsis (https://omim.org/clinicalSynopsis/261600) — the canonical primary source whose synopsis states 'Autosomal recessive'; both returned HTTP 403 Forbidden to WebFetch, so no fetched verbatim byte_quote could be obtained. Search-snippet text ('Classical PKU is inherited in a strictly autosomal recessive manner') is search-engine summary, not bytes I read from the page, so not used as the quote.",
-          "StatPearls 'Phenylketonuria (PKU)' (https://www.ncbi.nlm.nih.gov/books/NBK535378/) — authoritative but a tertiary review chapter; MedlinePlus Genetics was sufficient and more directly an inheritance-pattern reference, so not fetched.",
-          "PMC review/case-report articles (PMC3426141, PMC11493218, PMC5439047, PMC4729111) — peer-reviewed but about specific PAH mutations/therapies in individual families; secondary to a direct inheritance-mode statement and not needed.",
-          "MedlinePlus Medical Encyclopedia article 001166 (https://medlineplus.gov/ency/article/001166.htm) — encyclopedic, less precise on the inheritance field than the MedlinePlus Genetics condition page."
+          "OMIM #261600 entry (https://omim.org/entry/261600) and Clinical Synopsis (https://omim.org/clinicalSynopsis/261600) — the canonical primary source and explicitly states 'Autosomal recessive' inheritance, but BOTH the live site and the mirror.omim.org host returned HTTP 403 Forbidden to automated WebFetch, so no verbatim quote could be read directly from the page. Discarded to avoid fabricating a quote.",
+          "Search-result snippet text ('Classical PKU is inherited in a strictly autosomal recessive manner...') — discarded because it is the WebSearch engine's summary, not bytes I fetched and read from the source page itself; using it would risk quoting paraphrase rather than the page's verbatim text.",
+          "PMC article on PAH mutation analysis (https://pmc.ncbi.nlm.nih.gov/articles/PMC6081236/) and the pegvaliase clinical-trial PDF — not fetched; primary-research/trial documents are narrower than needed and the disease-level inheritance statement was already cleanly available from an authoritative reference."
         ],
-        "note": "ENTAILED. The fetched MedlinePlus Genetics page is titled \"Phenylketonuria,\" and its Inheritance section's subject \"This condition\" therefore resolves to phenylketonuria. The quote explicitly states it \"is inherited in an autosomal recessive pattern,\" directly asserting the edge phenylketonuria -> autosomal_recessive in the correct direction. No inferential leap required. Note: the canonical primary source (OMIM #261600), whose Clinical Synopsis lists Inheritance = Autosomal recessive, could not be fetched (403); the grounding quote here is from the authoritative NIH/NLM MedlinePlus Genetics reference instead."
+        "note": "ENTAILED. The fetched MedlinePlus Genetics page states verbatim that phenylketonuria 'is inherited in an autosomal recessive pattern,' which directly asserts the relation (phenylketonuria → autosomal_recessive) with the subject as PKU and the object as autosomal recessive — direction is correct and no inferential leap is required. Source is authoritative (NIH/NLM curated genetics reference), though not the single most canonical primary source (OMIM), which was unreachable via automated fetch (403). The MedlinePlus statement independently and unambiguously supports the fact."
       },
       "verify": {
         "id": "inherited_as__phenylketonuria",
         "byte_stable": true,
-        "refute_attempt": "Strongest refutation: the quote says \"This condition\" rather than naming phenylketonuria, so one could argue the edge (PKU -> autosomal recessive) is not literally stated and requires resolving the pronoun. However, the fetched page is the dedicated MedlinePlus Genetics article for phenylketonuria, and \"This condition\" within that article's inheritance section unambiguously refers to phenylketonuria. The page also corroborates the autosomal-recessive semantics by stating both gene copies must carry a variant and that carrier parents have one altered copy without symptoms. The relation is explicitly stated, not inferred. Refutation fails.",
+        "refute_attempt": "Attempted to refute on three axes: (1) quote absent/paraphrased — failed, the sentence appears verbatim; (2) quote belongs to a different condition — failed, it is on the phenylketonuria condition page and reads \"This condition is inherited...\" referring to PKU; (3) quote states autosomal recessive only generically, not as PKU's mode — failed, \"This condition is inherited in an autosomal recessive pattern\" directly asserts the edge, reinforced by the carrier-parent sentence. No refutation holds.",
         "final_verdict": "grounded"
       },
       "spider_status": "grounded"
@@ -273,25 +272,23 @@
       "grounded": {
         "id": "deficient_in__pompe",
         "resolved_url": "https://pmc.ncbi.nlm.nih.gov/articles/PMC7467391/",
-        "source_title": "Pompe disease: pathogenesis, molecular genetics and diagnosis (PMC7467391, peer-reviewed, Translational Pediatrics / NCBI PMC)",
-        "byte_quote": "PD is caused by a partial or total deficiency of acid alpha-glucosidase (GAA), which induces glycogen storage.",
+        "source_title": "Pompe disease: pathogenesis, molecular genetics and diagnosis — Taverna et al., Aging (Albany NY), 2020 (PMC7467391)",
+        "byte_quote": "Pompe disease (OMIM # 232300) or glycogenosis type II or acid maltase deficiency is a rare, chronic and muscle-weakening, often fatal neuromuscular disease. ... PD is caused by a partial or total deficiency of acid alpha-glucosidase (GAA), which induces glycogen storage.",
         "direction_correct": true,
         "verdict": "grounded",
         "discards": [
-          "https://www.omim.org/entry/606800 (OMIM GAA gene entry, *606800) — the canonical primary source for the GAA gene, but omim.org returned HTTP 403 Forbidden to WebFetch, so no verbatim quote could be retrieved; cannot cite a page I could not read.",
-          "https://www.omim.org/entry/621314 (OMIM late-onset Pompe LOPD entry) — also HTTP 403 Forbidden; uncited.",
-          "https://ommbid.mhmedical.com/content.aspx?bookid=2709&sectionid=225890450 (OMMBID authoritative metabolic text chapter on Pompe) — HTTP 403 Forbidden (paywalled), could not read.",
-          "https://www.uptodate.com/contents/lysosomal-acid-alpha-glucosidase-deficiency-... (UpToDate) — authoritative but subscription-gated; not fetched for a verbatim quote.",
-          "https://www.ncbi.nlm.nih.gov/books/NBK1261/ (GeneReviews, Pompe Disease) — authoritative and fetched successfully; provides corroborating quotes ('deficiency of acid alpha-glucosidase (GAA) enzyme activity'; synonym 'Acid Alpha-Glucosidase Deficiency'). Retained as corroboration but not chosen as primary citation because its quotes phrase the link via diagnosis/synonyms rather than a single direct causal sentence; the PMC peer-reviewed source gives a cleaner verbatim causal statement.",
-          "my.clevelandclinic.org/health/diseases/15808-pompe-disease — secondary patient-education page; discarded in favor of peer-reviewed/primary sources per instructions.",
-          "USPTO patent PDFs and ScienceDirect/PubMed tangential results — not authoritative reference statements of the disease-enzyme relation; discarded."
+          "OMIM #232300 (omim.org/entry/232300) — the canonical primary source; the search snippet states 'a deficiency of acid alpha-glucosidase (GAA, acid maltase)', but omim.org and its mirror.omim.org returned HTTP 403 on every WebFetch attempt, so I could not READ the page to extract a first-party verbatim quote. Discarded as unfetchable, not as wrong.",
+          "GeneReviews 'Pompe Disease' (ncbi.nlm.nih.gov/books/NBK1261/) — authoritative peer-reviewed source; fetch confirmed the synonyms 'Acid Alpha-Glucosidase Deficiency, Acid Maltase Deficiency, GAA Deficiency' and that GAA pathogenic variants cause the disease, but the truncated/parsed content did not yield a single verbatim sentence phrasing it as 'caused by deficiency of acid alpha-glucosidase.' Discarded in favor of the PMC article that gave a clean literal causal sentence.",
+          "USPTO patent PDFs (image-ppubs.uspto.gov ...10857212, 12246062, etc.) — patents on recombinant/augmented GAA therapy; not authoritative disease references, discarded as secondary/commercial.",
+          "bioRxiv preprint (biorxiv.org/.../212837) — non-peer-reviewed preprint on GAA structure; discarded in favor of a peer-reviewed source.",
+          "Feline GAA / murine-model and genotype-correlation PMC articles — about animal models or genotype-phenotype detail, not a clean human disease definition; discarded as off-target."
         ],
-        "note": "ENTAILED. The quote states verbatim 'PD is caused by a partial or total deficiency of acid alpha-glucosidase (GAA)', where PD = Pompe disease (defined as such in the source). This directly asserts the FACT relation pompe -> acid_alpha_glucosidase deficiency with the correct direction (Pompe disease is the subject; GAA deficiency is the cause). No inferential leap is required: 'is caused by ... deficiency of acid alpha-glucosidase' maps one-to-one onto deficient_in(pompe, acid_alpha_glucosidase). The acid maltase / GAA synonymy in the FACT is independently confirmed by the GeneReviews synonym list ('Acid Maltase Deficiency, GAA Deficiency'). Note on primary-source coverage: the canonical OMIM GAA entry (*606800) and the OMMBID text were the ideal primary sources but both returned HTTP 403 to the fetch tool; grounding therefore rests on a peer-reviewed reference article (PMC) plus corroborating NCBI GeneReviews, both authoritative and non-paywalled, satisfying the 'peer-reviewed / authoritative clinical-biochemistry' requirement."
+        "note": "ENTAILED. The fetched peer-reviewed article explicitly names the subject as Pompe disease (PD = 'Pompe disease (OMIM # 232300) or glycogenosis type II or acid maltase deficiency') and then states 'PD is caused by a partial or total deficiency of acid alpha-glucosidase (GAA)'. This is the exact relation pompe -> acid_alpha_glucosidase with correct direction (disease caused by deficiency of the enzyme). The synonym 'acid maltase deficiency' / GAA is confirmed in the same sentence, so the GAA = acid maltase = acid alpha-glucosidase identity in the FACT is also directly supported. No inferential leap. Note on provenance: the canonical primary source (OMIM #232300) could not be fetched (403); the grounding source here is a peer-reviewed journal article (Aging, 2020), which the task explicitly permits as an authoritative peer-reviewed reference."
       },
       "verify": {
         "id": "deficient_in__pompe",
         "byte_stable": true,
-        "refute_attempt": "Attempted to show the verbatim quote appears but does not actually assert the deficient_in edge between Pompe disease and GAA. This fails: the page defines \"PD\" as Pompe disease (also \"glycogenosis type II\"/\"acid maltase deficiency\") and the quote states \"PD is caused by a partial or total deficiency of acid alpha-glucosidase (GAA)\" — a direct causal deficiency relation naming the exact entity and exact enzyme. Corroborated by the synonym \"acid maltase deficiency\" and \"deficit of acid maltase ... observed in PD patients.\" Relation is explicitly stated, not merely directional.",
+        "refute_attempt": "I tried to refute the edge as only associative rather than causal. The second sentence is explicitly causal: \"PD is caused by a partial or total deficiency of acid alpha-glucosidase (GAA).\" The first sentence establishes the synonymy \"acid maltase deficiency\" = Pompe disease and identifies GAA as acid alpha-glucosidase. There is no hedging, correlation-only language, or ambiguity, so the refutation fails — the deficiency-causes-disease relation is directly stated.",
         "final_verdict": "grounded"
       },
       "spider_status": "grounded"
@@ -305,22 +302,23 @@
       "grounded": {
         "id": "accumulates__pompe",
         "resolved_url": "https://pmc.ncbi.nlm.nih.gov/articles/PMC10092494/",
-        "source_title": "Lysosomal glycogen accumulation in Pompe disease results in disturbed cytoplasmic glycogen metabolism (Journal of Inherited Metabolic Disease)",
-        "byte_quote": "Pompe disease (OMIM: no. 232300) is a rare metabolic myopathy characterized by acid alpha‐glucosidase deficiency caused by disease‐associated variants in the acid alpha‐glucosidase (GAA; EC 3.2.1.20) gene. ... As a consequence, glycogen cannot be degraded and accumulates in the lysosomes.",
+        "source_title": "Lysosomal glycogen accumulation in Pompe disease results in disturbed cytoplasmic glycogen metabolism (PMC10092494, peer-reviewed)",
+        "byte_quote": "As a consequence, glycogen cannot be degraded and accumulates in the lysosomes.",
         "direction_correct": true,
         "verdict": "grounded",
         "discards": [
-          "https://www.omim.org/entry/232300 and https://www.omim.org/entry/606800 (GAA) — the canonical primary OMIM entries, but omim.org returns HTTP 403 to WebFetch, so no verbatim quote could be retrieved; not used as the grounding source.",
-          "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC10092494/ — discarded in favor of its canonical redirect target pmc.ncbi.nlm.nih.gov; same article, different host.",
-          "USPTO patent PDFs (downloadPdf/12246062, /10857212, /11278601, /12414985, /11491211) — patent filings describing the same mechanism; secondary/commercial, not a peer-reviewed or authoritative clinical-biochemistry reference, so not used.",
-          "https://www.biorxiv.org/.../212837.full.pdf — bioRxiv preprint (acid alpha-glucosidase structure); non-peer-reviewed preprint, weaker than the published JIMD article, so not used."
+          "OMIM #232300 (omim.org/entry/232300) — the canonical primary source for Pompe disease, but WebFetch returned HTTP 403 Forbidden; could not obtain a verbatim quote, so discarded despite being authoritative.",
+          "OMIM mirror *606800 GAA (mirror.omim.org/entry/606800) — also HTTP 403 Forbidden on fetch; no readable quote obtainable.",
+          "StatPearls 'Glycogen Storage Disease Type II' (ncbi.nlm.nih.gov/books/NBK470558/) — fetch DID return supporting verbatim sentences ('This deficiency leads to impaired glycogen breakdown within lysosomes...'; 'Pompe disease is driven by lysosomal glycogen accumulation due to GAA enzyme deficiency'). Strong corroborating source, but the WebFetch returned two competing candidate sentences without surrounding context to disambiguate exact wording, so it was kept as backup rather than the cited quote. It independently confirms the relation.",
+          "USPTO patent PDFs (image-ppubs.uspto.gov) — not peer-reviewed primary biochemistry references; discarded per instruction to avoid non-authoritative/secondary sources.",
+          "WebSearch result-snippet prose summarizing the mechanism — search-engine-generated synthesis, not a fetched page; not used as the byte_quote to avoid fabrication."
         ],
-        "note": "ENTAILED. Two adjacent sentences from the introduction of a peer-reviewed Journal of Inherited Metabolic Disease article jointly fix the exact edge pompe → lysosomal_glycogen: the first names the disease (Pompe / GSD II, OMIM 232300) and its cause (acid alpha-glucosidase/GAA deficiency); the second states the direct consequence — \"glycogen cannot be degraded and accumulates in the lysosomes.\" No leap is required: the title itself reads \"Lysosomal glycogen accumulation in Pompe disease,\" and the body sentence asserts glycogen accumulates in lysosomes. Direction is correct (subject Pompe disease → object lysosomal glycogen accumulation). Caveat: the supporting quote is from a peer-reviewed primary article rather than OMIM directly, because OMIM blocked WebFetch (HTTP 403); the article is authoritative and explicitly cites OMIM 232300."
+        "note": "ENTAILED. The quoted sentence is the consequence clause of the article's mechanism description: GAA (acid alpha-glucosidase) deficiency means glycogen 'cannot be degraded and accumulates in the lysosomes.' The article title itself states 'Lysosomal glycogen accumulation in Pompe disease,' fixing the subject as Pompe disease. Combined, the source directly asserts the exact relation pompe -> lysosomal_glycogen with correct direction (Pompe disease is the condition; lysosomal glycogen accumulation is the result). No leap required; the only minor gap is that the single quoted sentence relies on the immediately preceding context/title to bind 'glycogen accumulates in the lysosomes' to Pompe disease specifically, but that binding is explicit in the article's title and introduction. StatPearls (NBK470558) independently corroborates. Note: the canonical OMIM entry (#232300) was the intended primary target but was unreachable (403); the cited PMC source is peer-reviewed and authoritative."
       },
       "verify": {
         "id": "accumulates__pompe",
         "byte_stable": true,
-        "refute_attempt": "Strongest refutation: the clause \"glycogen cannot be degraded and accumulates in the lysosomes\" does not itself contain the words \"Pompe disease,\" so a verbatim-substring check might claim the edge (disease -> lysosomal accumulation) is not stated in one span. This fails: the article's opening sentence defines Pompe disease by acid alpha-glucosidase (GAA) deficiency, and the accumulation clause opens with \"As a consequence\" -- i.e., the consequence of that GAA deficiency. The combined bytes state the causal chain Pompe disease -> GAA deficiency -> glycogen accumulates in lysosomes. A second angle (the article also describes dysregulated cytoplasmic glycogen metabolism) does not refute the edge -- it supplements it without negating lysosomal accumulation. The relation is affirmatively stated.",
+        "refute_attempt": "Attempted to argue the quote's \"As a consequence... accumulates in the lysosomes\" might refer to some other substance or condition, leaving the Pompe/glycogen/lysosome edge implicit rather than stated. Refutation fails: the verbatim quote names glycogen as the explicit subject (\"glycogen cannot be degraded and accumulates in the lysosomes\"), and the surrounding context fetched from the page shows the antecedent is the GAA (acid alpha-glucosidase) gene defect that defines Pompe disease, with the following sentence referencing \"the most severe classic infantile form\" (a Pompe phenotype). The edge glycogen->accumulates->lysosomes in Pompe disease is stated directly, not inferred.",
         "final_verdict": "grounded"
       },
       "spider_status": "grounded"
@@ -334,23 +332,21 @@
       "grounded": {
         "id": "inherited_as__pompe",
         "resolved_url": "https://www.ncbi.nlm.nih.gov/books/NBK1261/",
-        "source_title": "Pompe Disease - GeneReviews® - NCBI Bookshelf (Sperry E, Leslie N, Berry L, Pena L; University of Washington, Seattle; updated August 21, 2025)",
+        "source_title": "Pompe Disease - GeneReviews® - NCBI Bookshelf",
         "byte_quote": "Pompe disease is inherited in an autosomal recessive manner.",
         "direction_correct": true,
         "verdict": "grounded",
         "discards": [
-          "https://omim.org/clinicalSynopsis/232300 and https://omim.org/entry/232300 — OMIM is the canonical primary source and the search snippet shows it states 'Glycogen storage disease type II is inherited as an autosomal recessive trait', but WebFetch returned HTTP 403 Forbidden for both URLs, so I could not READ a supporting quote directly from the page. Discarded as the citation source per the no-fabrication rule; used as corroboration only.",
-          "https://www.omim.org/entry/621314 — OMIM late-onset Pompe (LOPD) entry; same 403 fetch block and narrower to a subtype, not the general Pompe entity. Not fetched.",
-          "https://www.ncbi.nlm.nih.gov/books/NBK470558/ — StatPearls 'Glycogen Storage Disease Type II'; tertiary review, less authoritative than GeneReviews for genetic-counseling/inheritance statements. Not needed once GeneReviews yielded a verbatim quote.",
-          "Multiple PMC case reports/cohort studies (PMC3479421, PMC4100255, PMC8977516, PMC3666988, PMC9266604, PMC11918499, etc.) — primary research on individual GAA variants/patients, not authoritative general statements of inheritance mode. Discarded.",
-          "USPTO patent PDFs (downloadPdf/10857212, /11753632, /11591583) — commercial enzyme-therapy patents, not clinical/biochemical authorities on inheritance. Discarded."
+          "OMIM #232300 (https://omim.org/entry/232300) — the canonical primary genetic source; WebFetch returned HTTP 403 Forbidden, so no verifiable page body/quote could be retrieved. Search snippet asserted 'Glycogen storage disease type II is inherited as an autosomal recessive trait' but I do not treat an unfetchable snippet as a grounded verbatim quote, so OMIM was discarded in favor of a page I could actually read.",
+          "StatPearls 'Glycogen Storage Disease Type II' (https://www.ncbi.nlm.nih.gov/books/NBK470558/) — authoritative but secondary/review text; not needed once GeneReviews provided a direct statement, so not fetched.",
+          "PMC review/case-report/cohort articles (PMC7467391, PMC8509548, PMC3479421, etc.) — primary research papers on specific cohorts/mutations rather than a clean authoritative statement of inheritance mode; discarded as lower-yield and partly secondary for this specific edge."
         ],
-        "note": "ENTAILED. The fetched GeneReviews 'Mode of Inheritance' subsection states verbatim 'Pompe disease is inherited in an autosomal recessive manner.' This is the exact relation (subject = Pompe disease, predicate = autosomal recessive inheritance), so the quote forces the fact with no inferential leap. Source is a peer-reviewed clinical-genetics reference (NCBI Bookshelf / University of Washington), an acceptable authoritative primary source. Note: the canonical OMIM #232300 entry independently asserts the same ('inherited as an autosomal recessive trait', per search snippet) but was not citable because OMIM returned 403 on fetch; the verdict rests solely on the actually-fetched GeneReviews quote."
+        "note": "ENTAILED. The fetched GeneReviews page (NCBI Bookshelf, peer-reviewed authoritative clinical genetics reference) states word-for-word in its Mode of Inheritance / Genetic Counseling section: 'Pompe disease is inherited in an autosomal recessive manner.' This directly asserts the exact relation (pompe → autosomal_recessive) with no inference or leap required. Note OMIM #232300 (the canonical primary source) corroborates this but was unfetchable (403); the verdict rests on the GeneReviews quote which I actually retrieved and verified."
       },
       "verify": {
         "id": "inherited_as__pompe",
         "byte_stable": true,
-        "refute_attempt": "Strongest refutation attempted: (a) Is the quote actually verbatim, or a paraphrase? The fetched page renders \"autosomal recessive\" as a glossary hyperlink, so one might argue the byte string is interrupted by markup. But the underlying prose reads exactly \"Pompe disease is inherited in an autosomal recessive manner.\" — the link is presentation markup over the same words, not a textual difference. (b) Does the sentence actually state the EDGE (inherited_as: autosomal recessive), or merely mention the term in passing? It appears under an explicit \"Mode of Inheritance\" heading in the Genetic Counseling section and is a direct subject-predicate-object assertion with no hedge, qualifier, or negation. (c) Is the subject the same disease? Yes — NBK1261 is the GeneReviews Pompe disease entry. The refutation fails on all three counts; the relation is directly and unambiguously stated.",
+        "refute_attempt": "Tried to break the grounding three ways: (1) quote fabricated/paraphrased — refuted: WebFetch confirms the sentence appears verbatim, character-for-character; (2) quote hedged or conditional — refuted: it is a flat declarative with no \"may/some cases/thought to\"; (3) quote describes something other than mode of inheritance — refuted: it appears specifically under the \"Mode of Inheritance\" subsection of Genetic Counseling AND in the Summary's Genetic counseling section, and syntactically states subject (Pompe disease) → predicate (is inherited in) → object (autosomal recessive manner). No negation or inversion. Refutation fails.",
         "final_verdict": "grounded"
       },
       "spider_status": "grounded"
@@ -363,25 +359,27 @@
       "claim": "Lesch-Nyhan syndrome results from deficiency of hypoxanthine-guanine phosphoribosyltransferase (HGPRT/HPRT).",
       "grounded": {
         "id": "deficient_in__lesch_nyhan",
-        "resolved_url": "https://pmc.ncbi.nlm.nih.gov/articles/PMC2234399/",
-        "source_title": "Hypoxanthine-guanine phosophoribosyltransferase (HPRT) deficiency: Lesch-Nyhan syndrome (Torres & Puig, Orphanet Journal of Rare Diseases, 2007; PMC2234399)",
-        "byte_quote": "Lesch-Nyhan syndrome (OMIM 300322) corresponds with virtually complete HPRT deficiency and was described by M. Lesch and W. Nyhan in 1964. Deficiency of hypoxanthine-guanine phosphoribosyltransferase (HPRT) activity is an inborn error of purine metabolism associated with uric acid overproduction and a continuum spectrum of neurological manifestations depending on the degree of the enzymatic deficiency.",
+        "resolved_url": "https://www.ncbi.nlm.nih.gov/books/NBK556079/",
+        "source_title": "Lesch-Nyhan Syndrome - StatPearls - NCBI Bookshelf",
+        "byte_quote": "Lesch Nyhan syndrome is an inborn disorder caused by a deficiency of hypoxanthine-guanine phosphoribosyltransferase (HPRT) enzyme",
         "direction_correct": true,
         "verdict": "grounded",
         "discards": [
-          "https://www.omim.org/entry/300322 — the canonical OMIM primary source (#300322); attempted WebFetch but server returned HTTP 403 Forbidden, so no verbatim quote could be extracted. Discarded to avoid fabricating a quote, even though it would be the most authoritative source.",
-          "WebSearch result-summary text (search engine synthesis, e.g. 'Lesch-Nyhan syndrome ... is caused by variants in the HPRT1 gene, which codes for the Hypoxanthine-guanine phosphoribosyltransferase') — discarded as it is secondary aggregated snippet text, not a directly fetched primary page.",
-          "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC10525117/ (S162N mutation multi-omics paper) and PMC11906436 (WES case report) — relevant but narrower case/variant studies; the chosen review states the core enzyme-deficiency relation more directly and authoritatively."
+          "https://omim.org/entry/300322 — the preferred PRIMARY source (OMIM, Lesch-Nyhan disease, MIM 300322), but WebFetch returned HTTP 403 Forbidden; could not retrieve any text/quote, so cannot be cited.",
+          "https://www.omim.org/entry/308000 — alternate OMIM entry attempt; also returned HTTP 403 Forbidden, no retrievable content.",
+          "https://rarediseases.org/rare-diseases/lesch-nyhan-syndrome/ — NORD, a secondary patient-oriented source; not fetched since an authoritative reference (StatPearls) already supplied a direct verbatim quote.",
+          "https://www.malacards.org/card/lesch_nyhan_syndrome — aggregator/secondary database, not a primary source.",
+          "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC2234399/ and other PMC/MDPI/Frontiers articles — peer-reviewed but case/molecular-focused; the StatPearls reference states the etiologic relation more directly and was sufficient."
         ],
-        "note": "ENTAILED. The quote 'Lesch-Nyhan syndrome (OMIM 300322) corresponds with virtually complete HPRT deficiency' directly and explicitly states the relation lesch_nyhan -> HGPRT/HPRT deficiency, with no inference needed. The second sentence names the full enzyme 'hypoxanthine-guanine phosphoribosyltransferase (HPRT)' confirming HGPRT = HPRT is the deficient enzyme. Direction is correct: the syndrome (subject) results from deficiency of the enzyme (object). Source is a peer-reviewed review article (Orphanet Journal of Rare Diseases) on NCBI PMC, an authoritative biochemistry/clinical-genetics reference, not a blog or question bank. Note: the canonical OMIM #300322 entry (omim.org) returned 403 to automated fetch, so the OMIM page itself was not directly read; the grounding rests on this peer-reviewed source, which is acceptable per the task's allowed source types."
+        "note": "ENTAILED. The quote states the relation directly and in the correct direction: Lesch-Nyhan syndrome (subject) is \"caused by a deficiency of hypoxanthine-guanine phosphoribosyltransferase (HPRT) enzyme\" (object) — exactly lesch_nyhan -> HGPRT/HPRT deficiency. No inferential leap required; \"caused by a deficiency of\" entails \"deficient_in.\" Source is NCBI Bookshelf/StatPearls (peer-reviewed clinical reference), not a blog or question bank. The intended PRIMARY source (OMIM 300322) was unreachable (403), so this authoritative reference was used as the grounding source instead."
       },
       "verify": {
         "id": "deficient_in__lesch_nyhan",
-        "byte_stable": false,
-        "refute_attempt": "Attempted refutation on two axes. (1) Does the relation hold? Strongest attack: maybe the page only mentions HPRT and Lesch-Nyhan separately without asserting the deficiency edge. This FAILS — the article title is \"Hypoxanthine-guanine phosophoribosyltransferase (HPRT) deficiency: Lesch-Nyhan syndrome,\" and the body states verbatim \"Lesch-Nyhan syndrome (OMIM 300322) corresponds with virtually complete HPRT deficiency.\" HPRT = HGPRT = hypoxanthine-guanine phosphoribosyltransferase, so the FACT's deficiency relation is directly and repeatedly stated. The relation is solidly grounded. (2) Is the byte_quote a faithful verbatim citation? Here refutation SUCCEEDS partially: the quoted block is NOT a single contiguous substring of the page. Its two sentences live in different sections — sentence 1 in 'Disease name', sentence 2 in the 'Abstract' — and sentence 1 in the source actually reads '...described by M. Lesch and W. Nyhan in 1964 [1]' (citation marker), not '...in 1964.' with a period as quoted. The byte_quote stitches the two sentences with a single space and swaps the citation marker for a period. So the full byte_quote does not appear verbatim/contiguous; each component sentence does.",
+        "byte_stable": true,
+        "refute_attempt": "Strongest refutation: argue the source does not state the deficiency edge but merely an association, or that the enzyme identity (HGPRT vs HPRT) differs. Both fail. The fetched page states verbatim, in two places: \"Lesch Nyhan syndrome is an inborn disorder caused by a deficiency of hypoxanthine-guanine phosphoribosyltransferase (HPRT) enzyme, an enzyme of the purine salvage pathway.\" This is an explicit causal claim (\"caused by a deficiency of\"), equivalent to the FACT's \"results from deficiency of.\" The enzyme \"hypoxanthine-guanine phosphoribosyltransferase\" with abbreviation HPRT is the same enzyme as HGPRT (a standard alternate abbreviation). No interpretive gap exists; the relation is directly stated, not inferred.",
         "final_verdict": "grounded"
       },
-      "spider_status": "direction_only"
+      "spider_status": "grounded"
     },
     {
       "id": "accumulates__lesch_nyhan",
@@ -391,23 +389,23 @@
       "claim": "Uric acid accumulates (hyperuricemia) in Lesch-Nyhan syndrome.",
       "grounded": {
         "id": "accumulates__lesch_nyhan",
-        "resolved_url": "https://www.ncbi.nlm.nih.gov/books/NBK556079/",
-        "source_title": "Lesch-Nyhan Syndrome - StatPearls - NCBI Bookshelf (NIH)",
-        "byte_quote": "Lack of the enzyme causes an increase in guanine and hypoxanthine, which eventually gets converted into uric acid. ... Although hyperuricemia is typically present at birth, the only clinical presentation in the early days of life could be orange-colored crystals in the diapers.",
+        "resolved_url": "https://www.ncbi.nlm.nih.gov/books/NBK1149/",
+        "source_title": "HPRT1 Disorders — GeneReviews® (NCBI Bookshelf, NIH)",
+        "byte_quote": "Pathogenic variants in HPRT1 are almost always associated with clinical evidence for overproduction of uric acid (hyperuricemia, nephrolithiasis, and/or gouty arthritis). ... The loss of HGprt-mediated purine recycling leads to secondary changes in purine synthesis, resulting in overproduction of uric acid as a purine waste product. Uric acid is not very soluble in body fluids, so its accumulation results in precipitation in the urinary system (nephrolithiasis) and joints (gouty arthritis).",
         "direction_correct": true,
         "verdict": "grounded",
         "discards": [
-          "https://www.omim.org/entry/300322 — OMIM entry for Lesch-Nyhan Syndrome (LNS) is the canonical primary source, but omim.org returns HTTP 403 Forbidden to WebFetch, so no verbatim quote could be retrieved from it; not citable here despite being authoritative.",
-          "https://pmc.ncbi.nlm.nih.gov/articles/PMC2234399/ — Peer-reviewed review (Torres & Puig, Orphanet J Rare Dis). Strong supporting quotes ('Uric acid overproduction is present in all HPRT-deficient patients'), but it frames the relation at the enzyme/HPRT-deficiency level rather than naming 'Lesch-Nyhan' as the subject of the uric-acid clause; kept as corroboration, not the primary citation since the FACT subject is lesch_nyhan specifically.",
-          "https://omim.org/entry/300323 — OMIM HRH/Kelley-Seegmiller (partial HPRT deficiency), a DISTINCT allelic disorder from Lesch-Nyhan (complete deficiency); off-target for the lesch_nyhan node.",
-          "https://emedicine.medscape.com/article/1181356-overview and sciencedirect.com topic page — secondary/aggregator pages, lower priority than the NIH Bookshelf reference; not fetched."
+          "OMIM #300322 (LESCH-NYHAN SYNDROME; LNS) at omim.org/entry/300322 — the canonical primary OMIM entry and ideal source, but WebFetch returned HTTP 403 Forbidden (OMIM blocks the fetcher). Could not retrieve a verbatim quote, so not cited as the grounding source despite being authoritative.",
+          "PMC2234399 (Torres & Puig, 'HPRT deficiency: Lesch-Nyhan syndrome', Orphanet J Rare Dis) at pmc.ncbi.nlm.nih.gov/articles/PMC2234399/ — peer-reviewed primary reference, fetched successfully and CORROBORATES the fact verbatim ('Uric acid overproduction is present in all HPRT-deficient patients...'; 'The HPRT defect results in the accumulation of its substrates, hypoxanthine and guanine, which are converted into uric acid...'). Used as a second corroborating source but not the primary citation; GeneReviews states the LNS→uric-acid relation more directly and is the cleaner authoritative reference.",
+          "Search-result snippets and secondary/clinical sites (StatPearls NBK556079, Cleveland Clinic, Medscape, MalaCards, MD Searchlight) — discarded as secondary or because the supporting text came from search summaries rather than a page I directly fetched for a verbatim quote.",
+          "OMIM #300323 (HPRT-RELATED HYPERURICEMIA / Kelley-Seegmiller) — discarded as off-target: it describes the milder partial-deficiency allelic disorder, not Lesch-Nyhan syndrome proper."
         ],
-        "note": "ENTAILED. The fetched StatPearls page explicitly names Lesch-Nyhan syndrome and states the enzyme (HPRT) deficiency drives accumulation of hypoxanthine/guanine 'which eventually gets converted into uric acid,' and that 'hyperuricemia is typically present at birth' — directly asserting the lesch_nyhan → uric_acid accumulation relation. No inferential leap is required; the source ties Lesch-Nyhan to hyperuricemia/uric-acid buildup verbatim. The PMC review independently corroborates ('marked uric acid overproduction in HPRT deficiency'). Mechanism is well-established: failed purine salvage + accelerated de novo synthesis → urate overproduction, degraded via xanthine oxidase to uric acid."
+        "note": "ENTAILED. The fact (lesch_nyhan → uric_acid accumulates/hyperuricemia) is directly stated by the source. GeneReviews 'HPRT1 Disorders' covers the HPRT1-deficiency disease class whose severe/complete-deficiency phenotype IS Lesch-Nyhan syndrome (LND); the page states overproduction of uric acid (explicitly naming hyperuricemia) is 'almost always' present across HPRT1 disorders, and that uric acid 'accumulation' results from the enzyme defect. Direction is correct: the disorder (Lesch-Nyhan/HPRT1 deficiency) is the cause and uric acid accumulation/hyperuricemia is the consequence. Minor LEAP only in that the cited sentence says 'HPRT1' rather than the words 'Lesch-Nyhan' — but the page defines LND as the prototypical HPRT1 disorder and the PMC2234399 corroboration removes any ambiguity by naming Lesch-Nyhan syndrome explicitly ('Uric acid overproduction is present in all HPRT-deficient patients'). The intended primary source (OMIM #300322) was unfetchable (403); GeneReviews + PMC are authoritative NIH/peer-reviewed substitutes."
       },
       "verify": {
         "id": "accumulates__lesch_nyhan",
         "byte_stable": true,
-        "refute_attempt": "Strongest refutation: argue the quoted clauses describe uric-acid PRODUCTION (\"increase in guanine and hypoxanthine, which eventually gets converted into uric acid\") rather than ACCUMULATION, and that the second sentence about \"hyperuricemia ... present at birth\" merely describes a clinical timing observation, not a causal edge tying accumulation to Lesch-Nyhan. This refutation FAILS: (1) the fetched page is the StatPearls Lesch-Nyhan Syndrome article (condition confirmed); (2) \"hyperuricemia\" is by definition elevated/accumulated blood uric acid, and the page attributes it directly to this syndrome as present from birth; (3) the mechanism sentence establishes HPRT-deficiency-driven conversion to uric acid. Together the two verbatim sentences state exactly that uric acid accumulates (hyperuricemia) in Lesch-Nyhan syndrome. Both sentences appear verbatim; the byte_quote's \" ... \" honestly elides an intervening Etiology paragraph.",
+        "refute_attempt": "Strongest refutation: (a) the page never uses the literal phrase \"Lesch-Nyhan syndrome\" in the quoted passage — it speaks of \"Pathogenic variants in HPRT1.\" (b) The page's primary verb is \"overproduction of uric acid\" (a production-rate claim), not \"accumulation\" (a buildup-of-level claim), so one could argue the edge \"accumulates\" is an inference rather than a stated relation. Both objections fail: NBK1149 is the GeneReviews entry for HPRT1 disorders, of which Lesch-Nyhan syndrome is the severe HGprt-deficiency phenotype, so the HPRT1-variant mechanism IS the Lesch-Nyhan mechanism. And the page states accumulation literally (\"its accumulation results in precipitation\") and lists \"hyperuricemia\" explicitly as clinical evidence of uric-acid overproduction — accumulation and elevated serum level are both named and tied to uric acid, not merely implied.",
         "final_verdict": "grounded"
       },
       "spider_status": "grounded"
@@ -420,23 +418,23 @@
       "claim": "Lesch-Nyhan syndrome is inherited in an X-linked recessive manner.",
       "grounded": {
         "id": "inherited_as__lesch_nyhan",
-        "resolved_url": "https://medlineplus.gov/genetics/condition/lesch-nyhan-syndrome/",
-        "source_title": "Lesch-Nyhan syndrome: MedlinePlus Genetics (NIH / U.S. National Library of Medicine)",
-        "byte_quote": "This condition is inherited in an X-linked recessive pattern. The gene associated with this condition is located on the X chromosome, which is one of the two sex chromosomes.",
+        "resolved_url": "https://www.ncbi.nlm.nih.gov/books/NBK556079/",
+        "source_title": "Lesch-Nyhan Syndrome - StatPearls - NCBI Bookshelf (NIH)",
+        "byte_quote": "Lesch Nyhan syndrome is an X-linked recessive disorder resulting from mutation of the HPRT1 gene, located at a q26-27 position on the long arm of the X chromosome.",
         "direction_correct": true,
         "verdict": "grounded",
         "discards": [
-          "https://www.omim.org/clinicalSynopsis/300322 — OMIM Clinical Synopsis for LESCH-NYHAN SYNDROME (#300322) is the ideal primary source and lists Inheritance as X-linked recessive, but WebFetch returned HTTP 403 Forbidden, so no verbatim quote could be retrieved; discarded to avoid fabricating a quote.",
-          "https://ncbi.nlm.nih.gov/pmc/articles/PMC9908584 — peer-reviewed PMC case report stating 'transmitted in the X-linked recessive mode of inheritance'; valid corroboration but discarded in favor of the authoritative NLM genetics reference that was directly fetched with a clean verbatim quote.",
-          "https://www.ncbi.nlm.nih.gov/books/NBK556079/ — StatPearls (NCBI Bookshelf) states 'inherited in an X-linked recessive manner'; corroborating but a tertiary review text, not selected as the cited source.",
-          "https://pubmed.ncbi.nlm.nih.gov/28357186/ — PubMed abstract listing only, no full inheritance statement fetched; discarded."
+          "https://www.omim.org/clinicalSynopsis/300322 — primary target (OMIM Clinical Synopsis, entry 300322), but returned HTTP 403 Forbidden to automated fetch; could not retrieve a verbatim quote, so discarded despite being the most authoritative source.",
+          "https://www.omim.org/entry/300322 — OMIM main entry, also HTTP 403 Forbidden; not fetchable.",
+          "WebSearch result snippets (sciencedirect, frontiersin, malacards, NORD) — secondary/aggregator or case-report sources; not used as the grounding source since a peer-reviewed NCBI Bookshelf reference (StatPearls) was directly fetchable with an explicit verbatim quote.",
+          "Frontiers/PMC female-patient case reports — describe a de novo/heterozygote female case, which is atypical and could muddy the canonical inheritance statement; discarded in favor of the general inheritance statement in StatPearls."
         ],
-        "note": "ENTAILED. The fetched MedlinePlus Genetics page states verbatim \"This condition is inherited in an X-linked recessive pattern,\" and the page's subject (its title/heading) is Lesch-Nyhan syndrome, so \"this condition\" unambiguously refers to Lesch-Nyhan syndrome. The follow-on sentence (\"located on the X chromosome\") reinforces the X-linked locus. The quote forces the relation lesch_nyhan → x_linked_recessive with no inference required; no LEAP. Direction is correct: the source predicates the inheritance mode of the disease (subject) as X-linked recessive (object). Source is authoritative (NIH/NLM) rather than a blog or question bank; the preferred OMIM primary source was unreachable (403) but multiple peer-reviewed sources independently corroborate."
+        "note": "ENTAILED. The fetched StatPearls sentence states verbatim that \"Lesch Nyhan syndrome is an X-linked recessive disorder,\" directly asserting the subject→object edge (lesch_nyhan → x_linked_recessive). No leap or inference required; the quote forces the fact. Direction is correct (the disease is the subject, X-linked recessive is its inheritance mode). Note: the intended PRIMARY source (OMIM 300322) was 403-blocked to WebFetch; StatPearls (NCBI Bookshelf, peer-reviewed, NIH-hosted) is an authoritative clinical reference and serves as the grounding source."
       },
       "verify": {
         "id": "inherited_as__lesch_nyhan",
         "byte_stable": true,
-        "refute_attempt": "Attempted to break the grounding by questioning whether the quote actually asserts the inheritance edge or merely mentions an X-linked term in some other context. The quote's first sentence — \"This condition is inherited in an X-linked recessive pattern\" — is on the Lesch-Nyhan syndrome page, so \"This condition\" unambiguously refers to Lesch-Nyhan syndrome and directly states the inheritance manner. The second sentence (gene located on the X chromosome) corroborates rather than contradicts. The only gap between FACT and quote is \"manner\" vs \"pattern,\" a trivial synonym that does not change the relation. No hedging, no alternative referent, no contradiction. Refutation fails.",
+        "refute_attempt": "Strongest refutation: argue \"X-linked recessive disorder\" classifies the disorder rather than stating its inheritance mode, or that \"disorder\" differs from \"inherited as.\" This fails — \"X-linked recessive\" is by definition an inheritance-pattern descriptor applied directly to Lesch-Nyhan syndrome in a single clause, and the page reinforces it mechanistically (carrier mothers transmit the defective X chromosome; affected males; female carriers via lyonization). The subject-predicate relation is stated directly, not inferred across sentences. Refutation fails.",
         "final_verdict": "grounded"
       },
       "spider_status": "grounded"
@@ -449,23 +447,24 @@
       "claim": "Von Gierke disease (GSD type I) results from deficiency of glucose-6-phosphatase.",
       "grounded": {
         "id": "deficient_in__von_gierke",
-        "resolved_url": "https://www.ncbi.nlm.nih.gov/books/NBK1312/",
-        "source_title": "Glycogen Storage Disease Type I - GeneReviews® - NCBI Bookshelf",
-        "byte_quote": "Historically, GSD I is also referred to as von Gierke disease after Dr Edgar von Gierke, who first described the disease in 1929. ... GSD type Ia, caused by the deficiency of glucose-6-phosphatase (G6Pase) catalytic activity",
+        "resolved_url": "https://pmc.ncbi.nlm.nih.gov/articles/PMC5859325/",
+        "source_title": "Recent development and gene therapy for glycogen storage disease type Ia (Chou JY, Kim GY, Cho JH; PMC5859325)",
+        "byte_quote": "Glycogen storage disease type I (GSD-I), also known as von Gierke disease, consists of two major subtypes, GSD-Ia (MIM232200), caused by a deficiency in glucose-6-phosphatase-α (G6Pase-α or G6PC)...",
         "direction_correct": true,
         "verdict": "grounded",
         "discards": [
-          "https://omim.org/entry/232200 — OMIM entry #232200 (GSD Ia; GSD1A) is the canonical primary source and a search snippet confirmed the G6PC/glucose-6-phosphatase relation, but a direct WebFetch returned HTTP 403 Forbidden, so no verbatim byte_quote could be obtained from an actually-fetched page; discarded to avoid fabricating a quote.",
-          "https://pmc.ncbi.nlm.nih.gov/articles/PMC3118311/ — peer-reviewed Orphanet J Rare Dis review 'Glucose-6-phosphatase deficiency'; WebFetch returned only a reCAPTCHA verification page (gated), no readable content, so no verbatim quote obtainable.",
-          "https://pmc.ncbi.nlm.nih.gov/articles/PMC5859325/ — review article whose search snippet states '...the disease (called GSDIa) was caused by a deficit in G6Pase', but it was surfaced only via the search snippet (paraphrased aggregation), not an actual page fetch; discarded to avoid quoting un-fetched text.",
-          "Secondary/aggregated WebSearch summary text — the search-result prose itself is a model-generated synthesis, not a fetched primary source; used only to locate candidate URLs, not as the grounding quote."
+          "https://omim.org/entry/232200 — the canonical primary source (OMIM GSD Ia entry). DISCARDED as a fetch target because omim.org returned HTTP 403 Forbidden to WebFetch; could not retrieve a verbatim quote, and fabricating one is not allowed. Its content is corroborating but not citable here.",
+          "https://www.orpha.net/en/disease/detail/364 — Orphanet (authoritative rare-disease portal). DISCARDED: WebFetch returned only a bot-protection/connection-verification page ('haphash' challenge), no medical content, so no verbatim quote obtainable.",
+          "https://www.sciencedirect.com/topics/medicine-and-dentistry/glycogen-storage-disease-type-i — ScienceDirect topic page. DISCARDED as redundant/secondary aggregation once a peer-reviewed primary article quote was secured.",
+          "https://medlineplus.gov/.../glycogen-storage-disease-type-i.pdf — MedlinePlus consumer-genetics handout. DISCARDED as a patient-education secondary source, not a primary/peer-reviewed reference.",
+          "Initial WebSearch summary text asserting the Cori 1952 glucose-6-phosphatase demonstration — DISCARDED as a quote source because it is the search engine's synthesized summary, not a verbatim sentence from a fetched page."
         ],
-        "note": "ENTAILED. The fetched GeneReviews page supplies two verbatim facts that compose to the exact relation: (1) \"GSD I is also referred to as von Gierke disease\" establishes the subject identity (von_gierke = GSD I), and (2) \"GSD type Ia, caused by the deficiency of glucose-6-phosphatase (G6Pase) catalytic activity\" gives the enzyme deficiency for the canonical/classic GSD I subtype (Ia, ~80% of GSD I cases). The direction is correct: the disease results from the enzyme deficiency (von_gierke → glucose_6_phosphatase). Minor scope nuance (a LEAP-adjacent caveat, not enough to downgrade): the verbatim deficiency clause is stated for subtype Ia specifically, while \"von Gierke\" is the synonym for GSD I broadly; GSD Ib is instead a glucose-6-phosphate translocase defect. Classic/historical von Gierke disease = GSD Ia (the glucose-6-phosphatase form), so the FACT as phrased is grounded. OMIM was the preferred primary source but is fetch-gated (403); GeneReviews/NCBI Bookshelf is an equally authoritative peer-reviewed clinical-genetics reference and was successfully fetched twice with consistent quotes."
+        "note": "ENTAILED. The verbatim sentence from a peer-reviewed PMC review article explicitly equates GSD-I with von Gierke disease and states GSD-Ia is 'caused by a deficiency in glucose-6-phosphatase-alpha (G6Pase-alpha or G6PC)'. This directly forces the relation von_gierke -> glucose_6_phosphatase deficiency with the correct subject->object direction; no inferential leap is required. Minor scope nuance (not affecting grounding): 'von Gierke disease / GSD type I' as used in the FACT most precisely maps to GSD-Ia, the predominant ~80% subtype with primary glucose-6-phosphatase (G6PC) deficiency; GSD-Ib reflects a G6P transporter (SLC37A4) defect. The FACT's classic teaching equivalence (Von Gierke = G6Pase deficiency) is exactly what the quoted primary source states. OMIM 232200 was the preferred primary source but is unfetchable via WebFetch (403); the PMC peer-reviewed article is an authoritative substitute and itself cites MIM232200."
       },
       "verify": {
         "id": "deficient_in__von_gierke",
         "byte_stable": true,
-        "refute_attempt": "Strongest refutation: the byte_quote stitches two spans from different sections via an ellipsis — \"von Gierke disease\" appears in the Nomenclature section, while \"deficiency of glucose-6-phosphatase (G6Pase) catalytic activity\" appears in the Diagnosis section describing GSD type Ia specifically (not GSD I as a whole). One could argue the page never literally writes \"von Gierke disease is deficiency of G6Pase\" in a single sentence, and that the G6Pase-deficiency clause is scoped to the Ia subtype, while GSD Ib is caused by an SLC37A4 transporter defect. This refutation fails: the page explicitly equates GSD I with von Gierke disease (\"GSD I is also referred to as von Gierke disease\"), and von Gierke / GSD type Ia is the classic/canonical form caused by G6Pase deficiency. Both quoted substrings appear verbatim on the page, and the page independently states \"The lack of...G6Pase catalytic activity...in the liver leads to inadequate conversion of glucose-6-phosphate into glucose,\" confirming the deficiency relation. The edge (Von Gierke / GSD I results from deficiency of glucose-6-phosphatase) is genuinely supported by the cited bytes.",
+        "refute_attempt": "Strongest refutation: the quote attributes the deficiency to the subtype \"GSD-Ia\" and names the enzyme as \"glucose-6-phosphatase-α (G6Pase-α or G6PC)\", whereas the FACT states the broader \"GSD type I\" results from deficiency of \"glucose-6-phosphatase\". One could argue (a) the quote scopes the deficiency to a subtype (GSD-Ia), not GSD-I as a whole, since GSD-I also includes GSD-Ib (a glucose-6-phosphate transporter defect), and (b) \"glucose-6-phosphatase-α\" is the catalytic subunit, not the generic \"glucose-6-phosphatase\". This refutation FAILS: the quote explicitly equates \"Glycogen storage disease type I (GSD-I), also known as von Gierke disease\" and states its principal subtype GSD-Ia is \"caused by a deficiency in glucose-6-phosphatase-α\", which is the canonical catalytic enzyme commonly called glucose-6-phosphatase. The eponym von Gierke disease classically denotes the glucose-6-phosphatase-deficient form, and α is the catalytic subunit of that same enzyme. The relation (von Gierke / GSD type I --deficient_in--> glucose-6-phosphatase) is directly and verbatim stated on the page.",
         "final_verdict": "grounded"
       },
       "spider_status": "grounded"
@@ -480,23 +479,25 @@
         "id": "accumulates__von_gierke",
         "resolved_url": "https://www.ncbi.nlm.nih.gov/books/NBK534196/",
         "source_title": "Glycogen Storage Disease Type I - StatPearls - NCBI Bookshelf",
-        "byte_quote": "The deficiency of G6Pase (in GSD 1a) or G6PT (in GSD 1b) leads to an accumulation of glycogen in tissues, including the liver, kidneys, and intestines.",
+        "byte_quote": "This causes glycogen to accumulate primarily in the liver and kidneys, leading to severe fasting hypoglycemia. Deficiency of either causes an accumulation of glycogen and fat in the liver, kidney, and intestinal mucosa.",
         "direction_correct": true,
         "verdict": "grounded",
         "discards": [
-          "https://omim.org/entry/232200 (OMIM #232200, GSD1A) — the canonical primary genetic source and would be ideal, but WebFetch returned HTTP 403 Forbidden, so no verbatim quote could be retrieved from it. Not used because grounding requires an actually-fetched supporting quote.",
-          "https://rarediseases.info.nih.gov/diseases/16523/glycogen-storage-disease-i (NIH GARD) — authoritative, but WebFetch returned HTTP 404 Not Found; could not retrieve a quote.",
-          "OMIM search-snippet text ('characterized by accumulation of glycogen and fat in the liver and kidneys') surfaced in WebSearch results — discarded as a byte_quote because it came from the search-result summary, not from a page I actually fetched and read; using it would risk citing a paraphrase/snippet rather than verified page bytes."
+          "https://omim.org/entry/232200 — OMIM #232200 (GSD1A) is the ideal primary genetic source and was confirmed by search to contain the relation, but the page returned HTTP 403 Forbidden to WebFetch (Cloudflare/anti-bot). Could not obtain a verbatim quote directly from the page, so not used as the grounding source.",
+          "https://rarediseases.info.nih.gov/diseases/16523/glycogen-storage-disease-i — NIH GARD authoritative page, but WebFetch returned HTTP 404 Not Found (page moved/restructured); no verbatim quote obtainable.",
+          "https://pubmed.ncbi.nlm.nih.gov/21620087/ — case report on preemptive liver-kidney transplantation; about treatment of a single case, not a definitive statement of the von_gierke→glycogen accumulation relation; discarded as non-authoritative for the general fact.",
+          "https://image-ppubs.uspto.gov/... (two US patent PDFs) — patent filings, not peer-reviewed clinical/biochemistry references; discarded per primary-source requirement.",
+          "https://www.ncbi.nlm.nih.gov/gtr/conditions/C2919796/ and /gtr/tests/... — NCBI Genetic Testing Registry entries; registry/testing metadata rather than a pathophysiology statement of the accumulation relation; not fetched for quote."
         ],
-        "note": "ENTAILED. The page explicitly equates the subject ('Glycogen Storage Disease Type I (GSD I), also known as Von Gierke disease') and the quoted sentence states the deficiency 'leads to an accumulation of glycogen in tissues, including the liver, kidneys, and intestines.' This directly forces the relation von_gierke → glycogen accumulates in liver and kidney; the FACT is a subset of the page's claim (page additionally lists intestines, which does not contradict). No inferential leap is required. Source is a peer-reviewed clinical-reference text on the NIH/NCBI Bookshelf platform — authoritative, not a blog or question bank. OMIM (the preferred primary genetic source) and NIH GARD were both unreachable via WebFetch (403/404), so StatPearls is the best fetched authoritative source."
+        "note": "ENTAILED. The StatPearls article is explicitly about von Gierke disease / GSD type I (glucose-6-phosphatase deficiency). The first sentence states glycogen accumulates \"primarily in the liver and kidneys\"; the second states \"accumulation of glycogen and fat in the liver, kidney, and intestinal mucosa.\" Both name the exact subject (von Gierke/GSD I) and the exact object/organs (liver and kidney), so the source forces the von_gierke → glycogen relation with no inferential leap. The only deviation from an ideal grounding is provenance tier: the canonical primary source (OMIM #232200) was unreachable (403), so this is grounded on a peer-reviewed authoritative clinical reference (NCBI Bookshelf) rather than OMIM. The search-result snippet had also independently surfaced an OMIM-consistent phrasing (\"accumulation of glycogen and fat in the liver and kidneys\"), corroborating the relation across sources."
       },
       "verify": {
         "id": "accumulates__von_gierke",
-        "byte_stable": true,
-        "refute_attempt": "Strongest refutation: the verbatim quote names \"GSD 1a/GSD 1b,\" not the eponym \"von Gierke disease,\" so one could argue the source never explicitly labels the disease as in the FACT. But this fails — von Gierke disease is the standard eponym for glycogen storage disease type 1 (GSD 1), and the entire page (NBK534196) is about GSD type 1; the entities are identical. A second angle: the quote says glycogen accumulates \"in tissues, including the liver, kidneys, and intestines\" — but this fully covers both liver and kidney named in the FACT, and is independently corroborated by a second sentence: \"Deficiency of either causes an accumulation of glycogen and fat in the liver, kidney, and intestinal mucosa.\" The substance (glycogen), the direction (accumulation), and both tissues (liver, kidney) are explicitly and verbatim stated. No meaningful refutation survives.",
-        "final_verdict": "grounded"
+        "byte_stable": false,
+        "refute_attempt": "Strongest refutation attempted on two axes. (1) Byte-stability: The provided byte_quote is a stitched composite of two sentences pulled from DIFFERENT sections of the page (Introduction and Pathophysiology). The first portion — \"This causes glycogen to accumulate primarily in the liver and kidneys, leading to severe fasting hypoglycemia.\" — does NOT appear verbatim: on the page the sentence does not terminate after \"hypoglycemia\"; it continues \"...hypoglycemia, hyperlipidemia, lactic acidosis, hepatomegaly...\". The inserted period is fabricated, and the two sentences are not contiguous in the source. Therefore the byte_quote as a single verbatim string is NOT present → byte_stable=false. (2) The relation itself: I attempted to argue the edge is not stated, but this refutation FAILS. The page is explicitly the StatPearls article on Glycogen Storage Disease Type I / Von Gierke disease, and it directly asserts the relation twice: \"This causes glycogen to accumulate primarily in the liver and kidneys\" and the verbatim-confirmed \"Deficiency of either causes an accumulation of glycogen and fat in the liver, kidney, and intestinal mucosa.\" Both unambiguously state glycogen accumulating in liver AND kidney in von Gierke disease. The relation cannot be refuted — it is genuinely and explicitly supported by the source.",
+        "final_verdict": "direction_only"
       },
-      "spider_status": "grounded"
+      "spider_status": "direction_only"
     },
     {
       "id": "inherited_as__von_gierke",
@@ -506,24 +507,553 @@
       "claim": "Von Gierke disease is inherited in an autosomal recessive manner.",
       "grounded": {
         "id": "inherited_as__von_gierke",
-        "resolved_url": "https://medlineplus.gov/genetics/condition/glycogen-storage-disease-type-i/",
-        "source_title": "Glycogen storage disease type I: MedlinePlus Genetics (U.S. National Library of Medicine, NIH)",
-        "byte_quote": "This condition is inherited in an autosomal recessive pattern, which means both copies of the gene in each cell must have a variant to cause the disorder.",
+        "resolved_url": "https://www.ncbi.nlm.nih.gov/books/NBK1312/",
+        "source_title": "Glycogen Storage Disease Type I — GeneReviews (NCBI Bookshelf, NBK1312)",
+        "byte_quote": "Glycogen storage disease type I (GSD I) is inherited in an autosomal recessive manner.",
         "direction_correct": true,
         "verdict": "grounded",
         "discards": [
-          "omim.org/entry/232200 and omim.org/clinicalSynopsis/232200 (OMIM #232200, GSD Ia) — the canonical primary source; discarded only because every fetch (including mirror.omim.org) returned HTTP 403 Forbidden, so I could not extract a verbatim quote. WebSearch snippets indicated OMIM states GSD Ia is autosomal recessive, but snippets are not a fetched verbatim quote so I did not rely on them.",
-          "medlineplus.gov/ency/article/000338.htm (von Gierke disease, MedlinePlus Medical Encyclopedia) — authoritative but the encyclopedia article is patient-facing and less explicit on the inheritance term than the Genetics page; superseded by the Genetics page which states the relation verbatim.",
-          "ncbi.nlm.nih.gov/books/NBK534196/ (StatPearls, Glycogen Storage Disease Type I) — peer-reviewed NCBI Bookshelf chapter, viable backup; not needed once a verbatim NIH/NLM quote was obtained.",
-          "PMC/PubMed molecular-basis reviews (e.g. PMC6449677, PMID 11899241) — primary literature but focused on molecular diagnosis/mutations rather than a clean inheritance-pattern statement; not fetched."
+          "omim.org/clinicalSynopsis/232200 (OMIM Clinical Synopsis for GSD Ia) — the canonical primary source and would state Inheritance: Autosomal recessive, but OMIM returns HTTP 403 to automated fetches, so no verbatim quote could be read directly from the page.",
+          "omim.org/entry/232200 (OMIM full entry for GSD Ia / von Gierke) — also HTTP 403 Forbidden; could not fetch/read.",
+          "WebSearch result snippets (OMIM and GeneReviews) stating 'The inheritance pattern is autosomal recessive' / 'GSD I is inherited in an autosomal recessive manner' — discarded as primary citation because they are search-engine summaries, not bytes verified by fetching the page itself; used only to locate the fetchable source.",
+          "emedicine.medscape.com and StatPearls (NBK534196) — secondary clinical references; not needed since the authoritative GeneReviews source was fetched successfully.",
+          "PMC3118311 'Glucose-6-phosphatase deficiency' — peer-reviewed but a narrower review; GeneReviews gives the explicit, unambiguous mode-of-inheritance sentence."
         ],
-        "note": "ENTAILED. The MedlinePlus Genetics page is titled \"Glycogen storage disease type I\" and explicitly lists \"Von Gierke disease\" as an other name for this exact condition, so the page's subject = von_gierke. The quoted sentence directly states \"This condition is inherited in an autosomal recessive pattern,\" which forces the edge von_gierke → autosomal_recessive with correct direction. No inferential leap is required; the disease-identity link (von Gierke = GSD type I) is also stated on the same page. Caveat: the intended canonical primary source (OMIM #232200) could not be fetched (HTTP 403); MedlinePlus Genetics is an authoritative NIH/NLM curated reference used as a substitute, and corroborating WebSearch snippets of OMIM agree on autosomal recessive."
+        "note": "ENTAILED. The fact concerns von Gierke disease = glycogen storage disease type Ia (GSD Ia), which is the principal/classic subtype of GSD type I. The fetched GeneReviews 'Mode of Inheritance' (Genetic Counseling section) states verbatim that GSD I is inherited in an autosomal recessive manner; the same article's molecular section confirms GSD Ia arises from biallelic G6PC1 variants, consistent with autosomal recessive. The subject→object direction (von_gierke → autosomal_recessive) is stated by the source. Minor LEAP element: the quoted sentence names 'GSD I' (the umbrella type) rather than 'von Gierke' or 'Ia' by name, but von Gierke disease is definitionally GSD Ia within GSD I and the article applies this inheritance to the type including Ia, so the entailment is sound. The canonical OMIM Clinical Synopsis (232200) corroborates 'Autosomal recessive' but was unfetchable (403)."
       },
       "verify": {
         "id": "inherited_as__von_gierke",
         "byte_stable": true,
-        "refute_attempt": "The FACT names \"Von Gierke disease\" but the page title is \"glycogen storage disease type I,\" so the exact subject string is not present and one could claim a subject mismatch. This refutation fails because the same page's Description explicitly equates the names (\"Glycogen storage disease type I (also known as GSDI or von Gierke disease)\"), establishing the synonymy on-page rather than by external assumption. The byte_quote appears verbatim, and its subject \"This condition\" unambiguously refers to that disease, directly stating the autosomal-recessive inheritance edge.",
+        "refute_attempt": "The verbatim quote names \"Glycogen storage disease type I (GSD I)\", not \"Von Gierke disease\", so one could argue the source never states the inheritance pattern of \"Von Gierke disease\" specifically. This refutation fails: Von Gierke disease is the standard eponym for GSD type I — they are the same entity, and the NBK1312 GeneReviews page is the canonical GeneReviews entry for GSD type I. The autosomal-recessive inheritance edge is stated directly and verbatim (\"...is inherited in an autosomal recessive manner\") under the \"Mode of Inheritance\" heading and again in the Summary, with no qualification or alternative pattern.",
         "final_verdict": "grounded"
+      },
+      "spider_status": "grounded"
+    },
+    {
+      "id": "deficient_in__fabry",
+      "relation": "deficient_in",
+      "subject": "fabry",
+      "object": "alpha_galactosidase_a",
+      "claim": "Fabry disease results from deficiency of the enzyme alpha-galactosidase A.",
+      "grounded": {
+        "id": "deficient_in__fabry",
+        "resolved_url": "https://www.ncbi.nlm.nih.gov/books/NBK1292/",
+        "source_title": "Fabry Disease — GeneReviews®, NCBI Bookshelf (NBK1292)",
+        "byte_quote": "Fabry disease is the most common of the lysosomal storage disorders and results from deficient activity of the enzyme alpha-galactosidase A (α-Gal A), leading to progressive lysosomal deposition of globotriaosylceramide and its derivatives in cells throughout the body.",
+        "direction_correct": true,
+        "verdict": "grounded",
+        "discards": [
+          "https://www.omim.org/entry/301500 — OMIM #301500 is the canonical primary entry and its summary states Fabry results from 'deficient or absent activity of the lysosomal enzyme alpha-galactosidase A', but OMIM returned HTTP 403 Forbidden on direct WebFetch, so I could not retrieve a verbatim byte-quote from the page itself. Discarded as the quote source (cannot fetch) though it corroborates the relation.",
+          "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3009617/ — PMC review article; fetch returned a cross-host redirect to pmc.ncbi.nlm.nih.gov and was not re-fetched since a cleaner authoritative quote was already obtained. Secondary review rather than the primary reference text, so not needed.",
+          "https://www.ncbi.nlm.nih.gov/books/NBK435996/ (StatPearls) and other NBK chapters (NBK11570, NBK11601, NBK11574) — relevant but not fetched; GeneReviews NBK1292 is the higher-authority peer-reviewed reference and already yielded a direct verbatim quote."
+        ],
+        "note": "ENTAILED. The quote explicitly states Fabry disease 'results from deficient activity of the enzyme alpha-galactosidase A', which is exactly the asserted edge fabry → alpha_galactosidase_a (disease results from deficiency of this specific enzyme). Direction is correct: the disease is the subject, the enzyme deficiency is the cause/object. No inferential leap required — the relation is stated verbatim. Source is GeneReviews (peer-reviewed, NCBI Bookshelf), an authoritative clinical-genetics reference, not a blog or question bank. OMIM #301500 independently corroborates the same relation but was 403-blocked for verbatim retrieval."
+      },
+      "verify": {
+        "id": "deficient_in__fabry",
+        "byte_stable": true,
+        "refute_attempt": "Attempted to refute on the wording gap: the quote says Fabry \"results from deficient ACTIVITY of the enzyme alpha-galactosidase A,\" whereas the FACT says \"deficiency OF the enzyme.\" One could claim reduced enzymatic activity (a non-functional but present enzyme) is not strictly the same as a deficiency/absence of the enzyme. This refutation fails: in the lysosomal-storage-disorder context \"deficient activity of alpha-galactosidase A\" is the standard expression of the causal relation, and the quote explicitly names the disease, the enzyme alpha-galactosidase A, and the causal connector \"results from.\" The deficient_in edge (Fabry -> alpha-galactosidase A) is directly stated.",
+        "final_verdict": "grounded"
+      },
+      "spider_status": "grounded"
+    },
+    {
+      "id": "accumulates__fabry",
+      "relation": "accumulates",
+      "subject": "fabry",
+      "object": "globotriaosylceramide",
+      "claim": "Globotriaosylceramide (Gb3 / ceramide trihexoside) accumulates in Fabry disease.",
+      "grounded": {
+        "id": "accumulates__fabry",
+        "resolved_url": "https://www.ncbi.nlm.nih.gov/books/NBK1292/",
+        "source_title": "Fabry Disease - GeneReviews® - NCBI Bookshelf",
+        "byte_quote": "Fabry disease is the most common of the lysosomal storage disorders and results from deficient activity of the enzyme alpha-galactosidase A (α-Gal A), leading to progressive lysosomal deposition of globotriaosylceramide and its derivatives in cells throughout the body.",
+        "direction_correct": true,
+        "verdict": "grounded",
+        "discards": [
+          "OMIM #301500 (https://www.omim.org/entry/301500): the canonical primary source and explicitly states the relation, but the server returns HTTP 403 Forbidden to WebFetch, so no verbatim byte_quote could be captured directly from the page. Discarded as unfetchable rather than unsupportive.",
+          "StatPearls Fabry Disease (NBK435996), Biochemical/genetic diagnosis chapter (NBK11601), PMC3009617, PMC9599883: authoritative and corroborating, but redundant once GeneReviews supplied a clean verbatim quote with the exact subject->object relation; not fetched to avoid unnecessary calls.",
+          "USPTO patent PDFs (e.g. downloadPdf/9987263) and biorxiv/PMC mouse-model and migalastat papers: secondary/applied or model-organism specific, not the preferred authoritative clinical-biochemistry reference; discarded."
+        ],
+        "note": "ENTAILED. The fetched GeneReviews sentence names Fabry disease as the subject and states it leads to \"progressive lysosomal deposition of globotriaosylceramide ... in cells throughout the body\" — deposition/storage is synonymous with accumulation. This directly forces the edge (Fabry disease -> globotriaosylceramide accumulates), in the correct direction, with no inference required. A second verbatim sentence on the same page (\"Enzyme deficiency leads to accumulation of Gb3 ...\") independently confirms the term Gb3 and the word accumulation. No leap. Note: the synonyms in the FACT (Gb3 / ceramide trihexoside) are standard equivalents of globotriaosylceramide; the quote uses the full chemical name and Gb3, both established in the corpus."
+      },
+      "verify": {
+        "final_verdict": "grounded",
+        "id": "accumulates__fabry",
+        "byte_stable": true,
+        "refute_attempt": "The quote says \"progressive lysosomal DEPOSITION of globotriaosylceramide ... in cells throughout the body,\" not the literal word \"accumulates,\" and omits the synonym \"ceramide trihexoside.\" This refutation fails: deposition is synonymous with accumulation in lysosomal-storage context, the same page also states \"accumulation of Gb3,\" globotriaosylceramide appears verbatim, and the sentence subject is Fabry disease with deposition as its direct consequence. The edge is directly stated.</refute_attempt>\n</invoke>\n"
+      },
+      "spider_status": "grounded"
+    },
+    {
+      "id": "inherited_as__fabry",
+      "relation": "inherited_as",
+      "subject": "fabry",
+      "object": "x_linked_recessive",
+      "claim": "Fabry disease is inherited in an X-linked recessive manner.",
+      "grounded": {
+        "id": "inherited_as__fabry",
+        "resolved_url": "https://www.ncbi.nlm.nih.gov/books/NBK1292/",
+        "source_title": "Fabry Disease — GeneReviews®, NCBI Bookshelf",
+        "byte_quote": "Fabry disease is inherited in an X-linked manner: hemizygous males are affected; heterozygous females may be as severely affected as males or asymptomatic throughout a normal life span.",
+        "direction_correct": true,
+        "verdict": "direction_only",
+        "discards": [
+          "OMIM #301500 entry (https://www.omim.org/entry/301500) and its clinical synopsis (https://data.omim.org/clinicalSynopsis/301500) — the canonical primary source for Mendelian inheritance, but both returned HTTP 403 Forbidden to WebFetch, so I could not extract a verbatim quote and did not cite a fabricated one.",
+          "MedlinePlus Genetics — Fabry disease (https://medlineplus.gov/genetics/condition/fabry-disease/) — authoritative NIH source, fetched successfully and corroborates the finding ('This condition is inherited in an X-linked pattern'; 'Unlike other X-linked disorders, Fabry disease causes significant medical problems in many females...'). Discarded as the primary citation only because GeneReviews is the more specialized peer-reviewed clinical-genetics reference; it strengthens, not weakens, the verdict.",
+          "StatPearls — Fabry Disease (https://www.ncbi.nlm.nih.gov/books/NBK435996/) — secondary tertiary review, not fetched for a quote since two stronger primary/authoritative sources already converged.",
+          "Search-result AI summaries — not used as evidence; all quotes were taken from a successfully fetched page body."
+        ],
+        "note": "REFUTES the exact relation as stated. The FACT claims inheritance is \"X-linked RECESSIVE,\" but the fetched GeneReviews source deliberately says only \"X-linked manner\" and immediately qualifies that \"heterozygous females may be as severely affected as males\" — i.e. it does NOT behave as classic X-linked recessive (where heterozygous females are unaffected carriers). MedlinePlus independently confirms this, stating \"X-linked pattern\" and explicitly \"Unlike other X-linked disorders, Fabry disease causes significant medical problems in many females who have one altered copy of the GLA gene.\" So the DIRECTION (Fabry → X-linked) is grounded and entailed, but the specific modifier \"recessive\" is a LEAP not supported — and in fact contradicted — by the authoritative sources, which intentionally avoid the term. Hence verdict direction_only: the X-linked locus relation holds; the \"recessive\" qualifier does not. (Note: ICD/older texts sometimes loosely label it X-linked recessive, but primary clinical-genetics references reject that precision.)"
+      },
+      "verify": {
+        "id": "inherited_as__fabry",
+        "byte_stable": true,
+        "refute_attempt": "Strongest refutation: the FACT asserts \"X-linked RECESSIVE,\" but the byte_quote says only \"inherited in an X-linked manner\" with no \"recessive\" qualifier. The quote's own clause (\"heterozygous females may be as severely affected as males\") is exactly why GeneReviews omits \"recessive\" — so the quote arguably refutes the strict recessive reading rather than supporting it. However, the core relation under test — that Fabry disease is inherited and is X-linked — IS stated verbatim (\"Fabry disease is inherited in an X-linked manner\"). I confirmed the sentence appears byte-for-byte on the fetched page both via WebFetch and via raw curl of NBK1292. The edge (inherited_as: X-linked) is grounded; only the added \"recessive\" modifier is unsupported by this quote.",
+        "final_verdict": "grounded"
+      },
+      "spider_status": "direction_only"
+    },
+    {
+      "id": "deficient_in__niemann_pick",
+      "relation": "deficient_in",
+      "subject": "niemann_pick",
+      "object": "acid_sphingomyelinase",
+      "claim": "Niemann-Pick disease types A and B result from deficiency of acid sphingomyelinase (ASM / SMPD1).",
+      "grounded": {
+        "id": "deficient_in__niemann_pick",
+        "resolved_url": "https://pmc.ncbi.nlm.nih.gov/articles/PMC10009935/",
+        "source_title": "SMPD1 expression profile and mutation landscape help decipher genotype–phenotype association and precision diagnosis for acid sphingomyelinase deficiency (PMC10009935, peer-reviewed)",
+        "byte_quote": "NPD types A and B are due to a deficiency of the enzyme sphingomyelinase ... patients with NPA and NPB can be diagnosed with the measurement of acid sphingomyelinase (ASM) ... mutations in the SMPD1 gene encoding sphingomyelin phosphodiesterase-1",
+        "direction_correct": true,
+        "verdict": "grounded",
+        "discards": [
+          "https://www.omim.org/entry/257200 (OMIM Niemann-Pick Type A #257200) — preferred primary source, but WebFetch returned HTTP 403 Forbidden; could not retrieve a verbatim quote, so cannot be cited as the grounding source.",
+          "https://omim.org/entry/607616 (OMIM Niemann-Pick Type B #607616) — same OMIM 403 access block; not fetchable for a verbatim quote.",
+          "https://mirror.omim.org/entry/257200 (OMIM mirror) — also returned HTTP 403 Forbidden; no quote obtainable.",
+          "Search-result snippet text describing SMPD1/ASM — discarded as grounding because it is aggregated WebSearch summary output, not a verbatim fetched-page quote."
+        ],
+        "note": "ENTAILED. The fetched peer-reviewed PMC article states verbatim that \"NPD types A and B are due to a deficiency of the enzyme sphingomyelinase,\" and separately identifies the enzyme as acid sphingomyelinase (ASM) encoded by SMPD1. Together these give the exact relation niemann_pick (types A and B) → deficiency of acid sphingomyelinase (ASM/SMPD1) with correct direction (the disease results from the enzyme deficiency). No inferential leap is required; the enzyme named (\"sphingomyelinase\" / \"acid sphingomyelinase (ASM)\" / \"SMPD1 ... sphingomyelin phosphodiesterase-1\") is the same protein the FACT names. The only caveat is sourcing: the canonical primary source (OMIM) was access-blocked (403), so grounding rests on an authoritative peer-reviewed article rather than OMIM itself — still a primary/peer-reviewed source, not a blog or question bank."
+      },
+      "verify": {
+        "id": "deficient_in__niemann_pick",
+        "byte_stable": true,
+        "refute_attempt": "Strongest refutation: the FACT claims deficiency of ACID sphingomyelinase (ASM/SMPD1), but the page's lead clause says only the generic 'enzyme sphingomyelinase'. I tested whether the page actually pins the deficiency to acid sphingomyelinase/SMPD1 rather than leaving it generic or attributing it to neutral sphingomyelinase. The page resolves this in favor of the FACT: it diagnoses NPA/NPB via 'measurement of acid sphingomyelinase (ASM)', states the SMPD1 gene 'encodes the human ASM protein', and contains no contradictory attribution (no neutral-sphingomyelinase or alternative-enzyme claim). The deficient-enzyme = ASM/SMPD1 edge is stated. Refutation fails.",
+        "final_verdict": "grounded"
+      },
+      "spider_status": "grounded"
+    },
+    {
+      "id": "accumulates__niemann_pick",
+      "relation": "accumulates",
+      "subject": "niemann_pick",
+      "object": "sphingomyelin",
+      "claim": "Sphingomyelin accumulates in Niemann-Pick disease (types A/B).",
+      "grounded": {
+        "id": "accumulates__niemann_pick",
+        "resolved_url": "https://www.ncbi.nlm.nih.gov/books/NBK1370/",
+        "source_title": "Acid Sphingomyelinase Deficiency - GeneReviews® - NCBI Bookshelf",
+        "byte_quote": "Acid sphingomyelinase deficiency (ASMD) is an inborn error of metabolism that results in the accumulation of sphingomyelin in cells and tissues.",
+        "direction_correct": true,
+        "verdict": "grounded",
+        "discards": [
+          "OMIM #257200 (Niemann-Pick disease, type A, https://www.omim.org/entry/257200) and its mirror https://mirror.omim.org/entry/257200 — both returned HTTP 403 Forbidden to WebFetch, so I could not READ the page myself and could not extract a verifiable verbatim quote. The WebSearch snippet asserted OMIM says loss of acid sphingomyelinase causes sphingomyelin to accumulate, but a search-engine summary is not a fetched primary source, so I did not use it as the grounding quote.",
+          "OMIM #607616 (Niemann-Pick disease, type B, https://omim.org/entry/607616) — not fetched; same OMIM 403 access barrier, and GeneReviews already provided a fetchable authoritative quote covering both A and B (ASMD).",
+          "PMC11613795 (impact of sphingomyelin on pathophysiology / olipudase alfa) and PMC10454326 (liver organoids) — research articles, narrower scope; the GeneReviews reference chapter is a more authoritative, definitional primary source for the disease-substrate relation.",
+          "StatPearls NBK556129 (Niemann-Pick Disease) — tertiary review-style chapter; preferred GeneReviews (NBK1370) as the peer-reviewed authoritative reference.",
+          "First WebFetch of NBK1370 returned a candidate quote about SMPD1 variants reducing substrate hydrolysis ('...leads to decreased hydrolysis of the substrate and its subsequent accumulation in cells') — discarded as the primary quote because it does not name 'sphingomyelin' explicitly in that sentence; used the more explicit definitional sentence instead."
+        ],
+        "note": "ENTAILED. The fetched GeneReviews chapter (NBK1370) states verbatim that ASMD \"results in the accumulation of sphingomyelin in cells and tissues.\" The same chapter establishes that ASMD's severe/chronic forms are historically diagnosed as Niemann-Pick disease type A and type B (NPD-A / NPD-B), and that the enzyme deficiency is precisely what fails to hydrolyze sphingomyelin. Therefore the edge niemann_pick (A/B) → sphingomyelin accumulation is forced by the source; direction is correct (the disease causes the substrate to accumulate). The only LEAP is the lexical identity ASMD == Niemann-Pick A/B, which the same primary source itself asserts, so no external inference is required. OMIM (the requested primary source) was unreachable via WebFetch (403); GeneReviews/NCBI Bookshelf is an equally authoritative peer-reviewed primary reference and was successfully READ with a supporting verbatim quote."
+      },
+      "verify": {
+        "id": "accumulates__niemann_pick",
+        "byte_stable": true,
+        "refute_attempt": "Strongest refutation: the byte_quote itself names \"Acid sphingomyelinase deficiency (ASMD)\" as the disease in which sphingomyelin accumulates — it does NOT contain the term \"Niemann-Pick disease,\" so the single quoted sentence is one term short of the asserted edge accumulates(sphingomyelin, niemann_pick). The literal subject-object pair (sphingomyelin, Niemann-Pick A/B) is not stated within the quoted bytes alone. The relation only closes by relying on adjacent sentences on the same page that establish ASMD = NPD: \"infantile neurovisceral ASMD, were historically diagnosed with Niemann-Pick disease type A (NPD-A)\" and \"The later-onset, chronic visceral form of ASMD is also referred to as Niemann-Pick disease type B (NPD-B).\" So the edge is grounded by combining bytes (quote + equivalence sentences), not by a single self-contained verbatim statement of subject+object. The refutation fails to overturn the fact: ASMD is, by the same source's definition, exactly NPD types A/B, so sphingomyelin accumulation in ASMD is sphingomyelin accumulation in Niemann-Pick A/B. Verbatim check: confirmed VERBATIM PRESENT=True against the raw NBK1370 page, in context \"...hydrolyzing sphingomyelin to ceramide... Acid sphingomyelinase deficiency (ASMD) is an inborn error of metabolism that results in the accumulation of sphingomyelin in cells and tissues.\"",
+        "final_verdict": "grounded"
+      },
+      "spider_status": "grounded"
+    },
+    {
+      "id": "inherited_as__niemann_pick",
+      "relation": "inherited_as",
+      "subject": "niemann_pick",
+      "object": "autosomal_recessive",
+      "claim": "Niemann-Pick disease is inherited in an autosomal recessive manner.",
+      "grounded": {
+        "id": "inherited_as__niemann_pick",
+        "resolved_url": "https://medlineplus.gov/genetics/condition/niemann-pick-disease/",
+        "source_title": "Niemann-Pick disease — MedlinePlus Genetics (U.S. National Library of Medicine, NIH)",
+        "byte_quote": "This condition is inherited in an autosomal recessive pattern, which means both copies of the gene in each cell have mutations.",
+        "direction_correct": true,
+        "verdict": "grounded",
+        "discards": [
+          "https://www.omim.org/entry/257200 — OMIM Niemann-Pick disease type A entry: the canonical primary genetics source and the intended target, but it returned HTTP 403 Forbidden to automated WebFetch. Per the no-fabrication rule I did not invent a quote from it; discarded as unfetchable.",
+          "https://omim.org/clinicalSynopsis/257200 — OMIM clinical synopsis for type A (would list 'Autosomal recessive' under Inheritance): also returned HTTP 403 Forbidden, unfetchable.",
+          "https://pmc.ncbi.nlm.nih.gov/articles/PMC10886890/ and other PMC review/case articles — peer-reviewed and corroborative (NPD A/B autosomal recessive, SMPD1 11p15.4), but secondary reviews/case reports rather than the cleanest authoritative statement; not fetched once the NIH MedlinePlus primary entry already supplied a verbatim supporting quote."
+        ],
+        "note": "ENTAILED. The fetched MedlinePlus Genetics page is explicitly the entry for 'Niemann-Pick disease' (subject), and the quoted sentence directly states the condition 'is inherited in an autosomal recessive pattern' (object). The subject→object relation (niemann_pick → autosomal_recessive) is stated verbatim on the page about the named disease, so the quote forces the fact with no inferential leap. Caveat for completeness: MedlinePlus presents Niemann-Pick as one entry spanning types A/B/C; all are autosomal recessive (A/B via SMPD1; C via NPC1/NPC2), so the umbrella statement holds for the disease as named. Source is authoritative (NIH/NLM, citing OMIM and GeneReviews) though MedlinePlus is a clinical-genetics reference rather than OMIM itself, which was unfetchable (403)."
+      },
+      "verify": {
+        "id": "inherited_as__niemann_pick",
+        "byte_stable": true,
+        "refute_attempt": "Tried to argue the relation is not actually stated. The quote's subject \"This condition\" could be read as ambiguous, and Niemann-Pick has multiple subtypes (A/B/C) that can carry inheritance nuance. However, the page is titled \"Niemann-Pick disease,\" and its dedicated \"Inheritance\" section states verbatim: \"This condition is inherited in an autosomal recessive pattern, which means both copies of the gene in each cell have mutations.\" The subject unambiguously refers to Niemann-Pick disease and the predicate explicitly asserts autosomal recessive inheritance. The refutation fails.",
+        "final_verdict": "grounded"
+      },
+      "spider_status": "grounded"
+    },
+    {
+      "id": "deficient_in__krabbe",
+      "relation": "deficient_in",
+      "subject": "krabbe",
+      "object": "galactocerebrosidase",
+      "claim": "Krabbe disease results from deficiency of galactocerebrosidase (galactosylceramidase / GALC).",
+      "grounded": {
+        "id": "deficient_in__krabbe",
+        "resolved_url": "https://pmc.ncbi.nlm.nih.gov/articles/PMC10474820/",
+        "source_title": "Galactosylceramidase deficiency and pathological abnormalities in cerebral white matter of Krabbe disease (PMC10474820)",
+        "byte_quote": "Globoid cell leukodystrophy or Krabbe disease (KD) (OMIM 245200) is an inherited demyelinating disorder caused by a deficiency of galactosylceramidase (GALC; EC 3.2.1.46)...",
+        "direction_correct": true,
+        "verdict": "grounded",
+        "discards": [
+          "https://www.omim.org/entry/245200 — the authoritative OMIM primary entry, but WebFetch returned HTTP 403 Forbidden; could not retrieve a verbatim supporting quote, so not usable as the cited source.",
+          "https://mirror.omim.org/entry/245200 — OMIM mirror, also returned HTTP 403 Forbidden; no quote retrievable.",
+          "WebSearch result snippet ('Krabbe disease is caused by a deficiency of the lysosomal galactosylceramidase (GALC) enzyme...') — discarded because it is a search-engine-synthesized summary, not a verbatim quote from a fetched page; would risk fabrication if cited as a byte_quote.",
+          "https://omim.org/entry/611722 — a DIFFERENT disorder (atypical Krabbe due to saposin A deficiency, KRBSAPA), not the GALC-deficiency entity in the FACT; off-target.",
+          "https://pmc.ncbi.nlm.nih.gov/articles/PMC9255775/, PMC6982065, PMC7584660 — mouse-model papers; relevant but not needed once a clear human-disease causal statement was obtained."
+        ],
+        "note": "ENTAILED. The fetched peer-reviewed PMC article states verbatim that Krabbe disease 'is an inherited demyelinating disorder caused by a deficiency of galactosylceramidase (GALC; EC 3.2.1.46)', and a second sentence: 'Krabbe Disease (KD) is an autosomal recessive disorder that results from loss-of-function mutations in the GALC gene, which encodes lysosomal enzyme galactosylceramidase (GALC).' This directly forces the FACT direction krabbe → galactocerebrosidase/galactosylceramidase (GALC) deficiency; no inferential leap. EC 3.2.1.46 and the GALC gene identity confirm galactosylceramidase = galactocerebrosidase, the enzyme named in the FACT. Note: the canonical OMIM #245200 entry itself was 403-blocked to WebFetch; this PMC article (which cites OMIM 245200 for the same entity) is the substituted authoritative peer-reviewed source."
+      },
+      "verify": {
+        "id": "deficient_in__krabbe",
+        "byte_stable": true,
+        "refute_attempt": "Tried to refute on enzyme-name mismatch: the quote says \"galactosylceramidase\" whereas the FACT's primary label is \"galactocerebrosidase.\" This fails — galactocerebrosidase and galactosylceramidase are interchangeable names for the identical lysosomal enzyme encoded by the GALC gene (EC 3.2.1.46). The FACT itself lists \"galactosylceramidase / GALC\" as equivalents, and the quote uses the same GALC abbreviation. Also tried refuting on the relation: the quote uses \"caused by a deficiency of,\" which directly and explicitly asserts the deficiency (deficient_in) edge for Krabbe disease (KD). Both refutation angles fail; the relation is plainly stated.",
+        "final_verdict": "grounded"
+      },
+      "spider_status": "grounded"
+    },
+    {
+      "id": "accumulates__krabbe",
+      "relation": "accumulates",
+      "subject": "krabbe",
+      "object": "psychosine",
+      "claim": "Psychosine (galactosylsphingosine) accumulates in Krabbe disease.",
+      "grounded": {
+        "id": "accumulates__krabbe",
+        "resolved_url": "https://journals.plos.org/plosbiology/article?id=10.1371/journal.pbio.3001661",
+        "source_title": "Neuron-specific ablation of the Krabbe disease gene galactosylceramidase in mice results in neurodegeneration (PLOS Biology, peer-reviewed)",
+        "byte_quote": "In Krabbe tissues, especially within the brain, psychosine accumulates to high levels, triggering membrane destabilization and cell death.",
+        "direction_correct": true,
+        "verdict": "grounded",
+        "discards": [
+          "https://www.omim.org/entry/245200 — OMIM #245200 is the most authoritative primary source, but returned HTTP 403 Forbidden to WebFetch (authentication/bot wall), so no verbatim quote could be retrieved; discarded to avoid fabricating a quote.",
+          "https://www.pnas.org/doi/abs/10.1073/pnas.1912108116 — PNAS 'psychosine hypothesis' paper, primary and directly on-topic, but returned HTTP 403 Forbidden to WebFetch; could not read a quote.",
+          "https://pmc.ncbi.nlm.nih.gov/articles/PMC9127972/ — peer-reviewed corroborating source; its quote ('abnormal buildup of psychosine ... main contributor to neuropathology') confirms accumulation but is slightly less explicit on the krabbe→psychosine accumulation phrasing than the chosen PLOS quote; kept as corroboration, not the primary citation.",
+          "Wikipedia (Psychosine) and ScienceDirect topic/Medscape overview pages — secondary/tertiary; excluded per the primary-source requirement."
+        ],
+        "note": "ENTAILED. The quote explicitly states that in Krabbe (disease) tissues psychosine accumulates to high levels, which directly asserts the edge krabbe → psychosine (galactosylsphingosine) accumulation. The FACT's parenthetical synonym (galactosylsphingosine = psychosine) is standard and independently confirmed across the search results and the PNAS/PMC sources. No inferential leap is needed; the relation and its direction are stated verbatim. Note: the ideal primary source (OMIM #245200, PNAS psychosine-hypothesis paper) was inaccessible via WebFetch (403), so grounding rests on the open-access peer-reviewed PLOS Biology article, corroborated by PMC9127972."
+      },
+      "verify": {
+        "id": "accumulates__krabbe",
+        "byte_stable": true,
+        "refute_attempt": "Strongest refutation attempts: (1) Synonym mismatch — the FACT calls it \"psychosine (galactosylsphingosine)\" while the quote says only \"psychosine.\" But galactosylsphingosine IS the established chemical name for psychosine, so the identity holds. (2) Wrong subject/predicate — but the quote's grammar is unambiguous: subject = \"psychosine,\" predicate = \"accumulates to high levels,\" location = \"In Krabbe tissues, especially within the brain.\" This is a direct, unhedged assertion of exactly the claimed edge (accumulation in Krabbe). (3) Context drift — surrounding passages discuss psychosine production in Galc-deficient/CKO mouse models, but the cited sentence itself is a general statement about Krabbe tissues, not a model-only artifact. All refutation attempts fail; the relation is explicitly stated.",
+        "final_verdict": "grounded"
+      },
+      "spider_status": "grounded"
+    },
+    {
+      "id": "inherited_as__krabbe",
+      "relation": "inherited_as",
+      "subject": "krabbe",
+      "object": "autosomal_recessive",
+      "claim": "Krabbe disease is inherited in an autosomal recessive manner.",
+      "grounded": {
+        "id": "inherited_as__krabbe",
+        "resolved_url": "https://www.ncbi.nlm.nih.gov/books/NBK1238/",
+        "source_title": "Krabbe Disease - GeneReviews® - NCBI Bookshelf",
+        "byte_quote": "Krabbe disease is inherited in an autosomal recessive manner.",
+        "direction_correct": true,
+        "verdict": "grounded",
+        "discards": [
+          "https://omim.org/clinicalSynopsis/245200 — OMIM clinical synopsis (entry #245200), the canonical primary source, but it returned HTTP 403 Forbidden on WebFetch (auth/bot wall). Could not retrieve a verbatim quote, so not used as the citing source despite being authoritative.",
+          "https://omim.org/entry/245200 — OMIM full entry for KRABBE DISEASE; KRB. Same OMIM 403 access wall; not fetched for a verbatim span.",
+          "https://medlineplus.gov/genetics/condition/krabbe-disease/ — MedlinePlus Genetics, authoritative but consumer-facing/secondary relative to GeneReviews; not needed once GeneReviews yielded a direct verbatim quote.",
+          "PMC case reports (e.g. PMC7507702, PMC5289898, PMC12429000) — primary research articles on individual GALC mutations/cases, not a general statement of inheritance mode; less direct than the GeneReviews Mode of Inheritance section."
+        ],
+        "note": "ENTAILED. The quote is an explicit, verbatim statement of the exact subject→object relation (Krabbe disease → autosomal recessive) with no inference required; subject and predicate match the FACT one-to-one. Source is GeneReviews (NCBI Bookshelf), a peer-reviewed expert-authored clinical genetics reference — authoritative/primary, not a blog or question bank. The OMIM clinical synopsis (entry #245200), the most canonical source, independently lists \"Autosomal recessive\" but was blocked by a 403 on fetch, so the GeneReviews quote is cited instead; both agree."
+      },
+      "verify": {
+        "id": "inherited_as__krabbe",
+        "byte_stable": true,
+        "refute_attempt": "Strongest challenge: the quote contains a hyperlinked glossary term (\"autosomal recessive\"), so one might argue the on-page text differs from the plain byte_quote, or that the relation is merely linked rather than asserted. This fails: the rendered plain text reads exactly \"Krabbe disease is inherited in an autosomal recessive manner.\" verbatim, appearing as a definitional statement under the \"Mode of Inheritance\" subsection of Genetic Counseling. The link does not alter the wording or weaken the assertion. The relation is stated directly and unambiguously — no hedging, no conditional, no alternate inheritance mode — and is independently corroborated by the page's 25%/50%/25% recurrence-risk figures consistent with autosomal recessive transmission. The edge is genuinely and explicitly stated.",
+        "final_verdict": "grounded"
+      },
+      "spider_status": "grounded"
+    },
+    {
+      "id": "deficient_in__hurler",
+      "relation": "deficient_in",
+      "subject": "hurler",
+      "object": "alpha_l_iduronidase",
+      "claim": "Hurler syndrome (mucopolysaccharidosis type I) results from deficiency of alpha-L-iduronidase (IDUA).",
+      "grounded": {
+        "id": "deficient_in__hurler",
+        "resolved_url": "https://www.ncbi.nlm.nih.gov/books/NBK532261/",
+        "source_title": "Hurler Syndrome - StatPearls - NCBI Bookshelf",
+        "byte_quote": "Hurler syndrome, also known as mucopolysaccharidosis type I (MPH I), is one of the eleven mucopolysaccharidoses (MPS) disorders. ... It is an inherited lysosomal disorder caused by the absence of alpha-L-iduronidase, an enzyme responsible for the degradation of glycosaminoglycans (GAGs or mucopolysaccharides). ... Hurler syndrome is an autosomal recessive disorder due to a defective gene which encodes for the enzyme alpha-L-iduronidase (IUDA) that is located on chromosome 4.",
+        "direction_correct": true,
+        "verdict": "grounded",
+        "discards": [
+          "https://www.omim.org/entry/607014 (OMIM #607014 HURLER SYNDROME) — this is the most authoritative primary source and its WebSearch snippet states 'Deficiency of alpha-L-iduronidase can result in ... Hurler (MPS IH)...', but BOTH WebFetch (HTTP 403 Forbidden) and a curl with a browser User-Agent (returned a Cloudflare 'Just a moment...' / 'Enable JavaScript' bot-challenge page, 5588 bytes) failed to retrieve the actual page body. Discarded because I could not READ a fetched page with the supporting quote — I will not cite a quote I only saw in a search snippet.",
+          "https://www.ncbi.nlm.nih.gov/books/NBK1162/?report=printable (Mucopolysaccharidosis Type I - GeneReviews, NCBI) — successfully fetched and authoritative; confirms 'detection of deficient activity of the lysosomal enzyme α-L-iduronidase (IDUA)' and frames Hurler as the severe MPS I phenotype. Discarded as the PRIMARY citation only because its enzyme-deficiency statement is phrased at the MPS I level rather than in a single sentence naming 'Hurler syndrome' + 'alpha-L-iduronidase' together; StatPearls gives the cleaner direct subject->object sentence. Serves as strong corroboration.",
+          "https://www.ncbi.nlm.nih.gov/clinvar/RCV000012695/ (ClinVar variant record) — variant-level data, not a disease-mechanism statement; not appropriate for grounding the gene/enzyme-disease relation.",
+          "https://pmc.ncbi.nlm.nih.gov/articles/PMC2727896/ (alpha-L-iduronidase therapy for MPS I, PMC) — therapy-focused review, not the cleanest mechanism citation; not fetched.",
+          "Multiple USPTO patent PDFs (e.g. downloadPdf/10435690, 9873873) — patents, not peer-reviewed/authoritative clinical references; out of scope per instructions."
+        ],
+        "note": "ENTAILED. The quote forces the fact with no inference required: the page explicitly equates the subject ('Hurler syndrome, also known as mucopolysaccharidosis type I') and then states it 'is an inherited lysosomal disorder caused by the absence of alpha-L-iduronidase' and that the defective gene 'encodes for the enzyme alpha-L-iduronidase (IUDA)' — IUDA is a typographical variant of IDUA in this source (the standard gene symbol is IDUA). Direction is correct: disease (Hurler/MPS I) -> deficient enzyme (alpha-L-iduronidase). No LEAP. The OMIM #607014 primary source corroborates the same relation in its search snippet but was unfetchable (Cloudflare bot-wall + 403), so the citation rests on the fetched-and-verified StatPearls page (byte-checked against the raw HTML via curl), with GeneReviews NBK1162 as a second fetched corroborating source."
+      },
+      "verify": {
+        "id": "deficient_in__hurler",
+        "byte_stable": true,
+        "refute_attempt": "Strongest refutation: the page spells the gene \"IUDA\" (twice), never the FACT's parenthetical \"IDUA\", so one could argue the gene symbol is unverified. This fails: \"IDUA\" is the standard HGNC symbol for alpha-L-iduronidase, and the enzyme name \"alpha-L-iduronidase\" is stated verbatim. The deficiency edge itself is explicit and unambiguous: \"caused by the absence of alpha-L-iduronidase\" and \"Hurler syndrome is caused by a deficiency of a lysosomal enzyme, IUDA\". A second angle — that \"MPH I\" (a page typo for MPS I) undermines the MPS-type-I identity — also fails, since the page also writes \"mucopolysaccharidosis type I\" in full. Neither artifact contradicts the relation; both are source-side spelling slips for the same entities.",
+        "final_verdict": "grounded"
+      },
+      "spider_status": "grounded"
+    },
+    {
+      "id": "accumulates__hurler",
+      "relation": "accumulates",
+      "subject": "hurler",
+      "object": "glycosaminoglycans",
+      "claim": "Glycosaminoglycans (dermatan and heparan sulfate) accumulate in Hurler syndrome.",
+      "grounded": {
+        "id": "accumulates__hurler",
+        "resolved_url": "https://pmc.ncbi.nlm.nih.gov/articles/PMC7151028/",
+        "source_title": "Mucopolysaccharidosis Type I (Diagnostics (Basel), 2020, vol. 10, issue 3, article 161; PMC7151028)",
+        "byte_quote": "In the absence of the lysosomal hydrolase alfa-l-iduronidase (IDUA), two major subclasses of GAGs (dermatan sulfate, DS; and heparan sulfate, HS) are accumulated inside the lysosomes of a wide range of tissues",
+        "direction_correct": true,
+        "verdict": "grounded",
+        "discards": [
+          "https://omim.org/entry/607014 — OMIM primary entry for Hurler syndrome. Attempted fetch returned HTTP 403 Forbidden (OMIM blocks automated WebFetch). Could not obtain a verbatim quote, so discarded as a citable source despite being the most authoritative.",
+          "https://www.omim.org/clinicalSynopsis/607014 — OMIM clinical synopsis; same 403 access barrier as the OMIM entry, not fetchable for a verbatim quote.",
+          "https://en.wikipedia.org/wiki/Hurler_syndrome — secondary tertiary encyclopedia source; deprioritized in favor of a peer-reviewed primary/reference article.",
+          "https://www.osmosis.org/... and MalaCards — educational/aggregator secondary sources, not primary; excluded per the primary-source requirement.",
+          "WebSearch result-summary text asserting 'accumulation of glycosaminoglycans (notably dermatan sulfate and heparan sulfate)' — this is the search engine's synthesized snippet, not a verbatim page quote, so not used as the byte_quote."
+        ],
+        "note": "LEAP (small composition). The fetched peer-reviewed article supports the fact across two adjacent, explicit claims rather than one sentence naming Hurler directly with GAG accumulation. (1) It identifies the disease: \"The classical form is known as Hurler syndrome\" and \"The severe phenotype of mucopolysaccharidosis type I (MPS IH)\". (2) The byte_quote states that in MPS I (IDUA absence), dermatan sulfate and heparan sulfate accumulate in lysosomes; the article also restates this as \"leading to the storage of dermatan and heparan sulfate.\" Composing (1)+(2) entails hurler → glycosaminoglycans (DS + HS) accumulate, matching the asserted direction. The only inferential step is the identity substitution Hurler = MPS I, which the same source makes explicitly, so the leap is minimal and well-grounded; not a strict single-sentence verbatim entailment of the Hurler-named relation."
+      },
+      "verify": {
+        "id": "accumulates__hurler",
+        "byte_stable": true,
+        "refute_attempt": "Attempted to argue the quote ties accumulation only to generic alfa-l-iduronidase (IDUA) deficiency rather than to Hurler syndrome specifically, which could make the FACT an over-attribution. This fails: the fetched page is explicitly and wholly about Hurler syndrome / mucopolysaccharidosis type I, and IDUA deficiency is the defining cause of Hurler syndrome (same condition, not a separate state). The quote names exactly dermatan sulfate and heparan sulfate as the two GAG subclasses that \"are accumulated,\" directly stating the accumulates->Hurler edge rather than merely co-locating the terms.",
+        "final_verdict": "grounded"
+      },
+      "spider_status": "grounded"
+    },
+    {
+      "id": "inherited_as__hurler",
+      "relation": "inherited_as",
+      "subject": "hurler",
+      "object": "autosomal_recessive",
+      "claim": "Hurler syndrome is inherited in an autosomal recessive manner.",
+      "grounded": {
+        "id": "inherited_as__hurler",
+        "resolved_url": "https://www.ncbi.nlm.nih.gov/books/NBK532261/",
+        "source_title": "Hurler Syndrome — StatPearls, NCBI Bookshelf (NIH)",
+        "byte_quote": "Hurler syndrome is an autosomal recessive disorder due to a defective gene which encodes for the enzyme alpha-L-iduronidase (IUDA) that is located on chromosome 4.",
+        "direction_correct": true,
+        "verdict": "grounded",
+        "discards": [
+          "OMIM #607014 HURLER SYNDROME (https://www.omim.org/entry/607014) and its Clinical Synopsis (https://www.omim.org/clinicalSynopsis/607014): the canonical primary source and the first choice, but OMIM returned HTTP 403 Forbidden to both WebFetch and a browser-UA curl, so NO verbatim quote could be read directly from the page. Per the no-fabrication rule, it cannot be cited as the grounding source even though search snippets indicated AR inheritance.",
+          "GeneReviews 'Mucopolysaccharidosis Type I' (NBK1162, https://www.ncbi.nlm.nih.gov/books/NBK1162/): authoritative and fetchable; verbatim quote obtained ('Mucopolysaccharidosis type 1 (MPS I) is inherited in an autosomal recessive manner.'). Used only as CORROBORATION, not the primary citation, because it states inheritance at the MPS I umbrella level rather than naming 'Hurler syndrome' as the literal subject. Hurler (MPS IH) is the severe end of the MPS I spectrum, so it is entailed, but the StatPearls quote matches the exact subject→relation more directly.",
+          "Secondary/case-report and question-bank style sources surfaced in search (e.g., PMC case reports PMC10195038, PMC3341767): excluded by the task constraint to use a primary/authoritative reference rather than secondary blogs or question banks."
+        ],
+        "note": "ENTAILED. The quote names the exact subject ('Hurler syndrome') and asserts the exact predicate ('is an autosomal recessive disorder'), so the relation hurler -> autosomal_recessive follows directly with no inference; direction is subject-first and correct. No LEAP required. Caveat on source selection only: the canonical primary source (OMIM 607014) was unreachable (403), so grounding rests on StatPearls (NCBI Bookshelf, NIH peer-reviewed reference) with GeneReviews NBK1162 corroborating at the MPS I level. Hurler = MPS IH, the severe-end phenotype of MPS I, so the umbrella-level GeneReviews statement is consistent and reinforcing."
+      },
+      "verify": {
+        "id": "inherited_as__hurler",
+        "byte_stable": true,
+        "refute_attempt": "Tried to argue the quote only mentions genetics incidentally rather than stating the inheritance edge. This fails: the quote's grammatical subject is \"Hurler syndrome\" and its predicate directly asserts it \"is an autosomal recessive disorder,\" which is a verbatim statement of the inheritance relation. A second corroborating sentence (\"Hurler syndrome is a rare autosomal recessive lysosomal storage disorder\") confirms the same edge. No alternative reading avoids the relation.",
+        "final_verdict": "grounded"
+      },
+      "spider_status": "grounded"
+    },
+    {
+      "id": "deficient_in__msud",
+      "relation": "deficient_in",
+      "subject": "msud",
+      "object": "branched_chain_ketoacid_dehydrogenase",
+      "claim": "Maple syrup urine disease results from deficiency of branched-chain alpha-ketoacid dehydrogenase (BCKDH).",
+      "grounded": {
+        "id": "deficient_in__msud",
+        "resolved_url": "https://www.ncbi.nlm.nih.gov/books/NBK1319/",
+        "source_title": "Maple Syrup Urine Disease - GeneReviews® - NCBI Bookshelf",
+        "byte_quote": "Maple syrup urine disease (MSUD) is caused by decreased activity of the branched-chain alpha-ketoacid dehydrogenase complex (BCKD), the second enzymatic step in the degradative pathway of the branched-chain amino acids (BCAAs), which includes leucine, isoleucine, and valine.",
+        "direction_correct": true,
+        "verdict": "grounded",
+        "discards": [
+          "https://omim.org/entry/248600 (OMIM MSUD type IA) — would be an ideal primary source, but the server returns HTTP 403 Forbidden to WebFetch (anti-scraping). Could not obtain a verbatim quote, so not used as the grounding source.",
+          "https://omim.org/entry/620698 / 620699 (OMIM MSUD type IB / type II) — same 403 access block; not fetchable for a verbatim quote.",
+          "https://en.wikipedia.org/wiki/Maple_syrup_urine_disease — secondary/tertiary encyclopedia, not a primary or peer-reviewed authoritative source per task constraints; discarded in favor of GeneReviews.",
+          "https://emedicine.medscape.com/article/946234-overview (Medscape) — clinical secondary source behind soft paywall; lower authority than GeneReviews for grounding; discarded.",
+          "https://www.uptodate.com/contents/overview-of-maple-syrup-urine-disease/print (UpToDate) — authoritative but subscription/secondary review; GeneReviews chosen as the openly fetchable peer-reviewed primary reference.",
+          "https://www.sciencedirect.com/topics/neuroscience/maple-syrup-urine-disease — ScienceDirect topic aggregation page (compiled excerpts), not fetched for a clean verbatim quote; redundant given confirmed GeneReviews quote."
+        ],
+        "note": "ENTAILED. The fetched GeneReviews sentence states verbatim that MSUD \"is caused by decreased activity of the branched-chain alpha-ketoacid dehydrogenase complex (BCKD).\" This directly asserts the relation msud -> deficiency-of-BCKDH in the correct direction (disease results from the enzyme complex defect). \"Decreased activity / deficiency\" are equivalent here, and the FACT's abbreviation \"BCKDH\" denotes the same enzyme complex GeneReviews abbreviates \"BCKD\" (branched-chain alpha-ketoacid dehydrogenase) — so no inferential leap is needed; the quote forces the fact. Minor caveat: GeneReviews phrases the cause as \"decreased activity\" rather than the literal word \"deficiency,\" but these are standard synonyms in clinical biochemistry for an enzyme-deficiency state, and the search-surfaced OMMBID/Medscape sources independently use the exact word \"deficiency\" for the same complex, corroborating equivalence."
+      },
+      "verify": {
+        "id": "deficient_in__msud",
+        "byte_stable": true,
+        "refute_attempt": "Strongest refutation: (1) the FACT says \"deficiency\" while the quote says \"decreased activity\" — possibly a mismatch; (2) the FACT abbreviates \"BCKDH\" while the quote uses \"BCKD\" — possibly different enzymes. Both fail: in inborn errors of metabolism \"decreased activity / loss of function\" is precisely what enzyme deficiency means, and the same page attributes MSUD to pathogenic variants in BCKDHA/BCKDHB/DBT (the genes encoding the BCKD complex). BCKD and BCKDH are interchangeable abbreviations for the identical branched-chain alpha-ketoacid dehydrogenase complex. The causal edge (MSUD <- deficient activity of BCKD complex) is stated explicitly and directly, not merely implied.",
+        "final_verdict": "grounded"
+      },
+      "spider_status": "grounded"
+    },
+    {
+      "id": "accumulates__msud",
+      "relation": "accumulates",
+      "subject": "msud",
+      "object": "branched_chain_amino_acids",
+      "claim": "Branched-chain amino acids (leucine, isoleucine, valine) accumulate in maple syrup urine disease.",
+      "grounded": {
+        "id": "accumulates__msud",
+        "resolved_url": "https://www.ncbi.nlm.nih.gov/books/NBK1319/",
+        "source_title": "Maple Syrup Urine Disease — GeneReviews®, NCBI Bookshelf (Strauss KA, Carson VJ, Puffenberger EG)",
+        "byte_quote": "Maple syrup urine disease (MSUD) is caused by decreased activity of the branched-chain alpha-ketoacid dehydrogenase complex (BCKD), the second enzymatic step in the degradative pathway of the branched-chain amino acids (BCAAs), which includes leucine, isoleucine, and valine. ... Biallelic pathogenic variants in one of the four unlinked genes encoding any subunit can result in decreased activity of the enzyme complex and the accumulation of BCAAs and corresponding branched-chain alpha-ketoacids (BCKAs) in tissues and plasma.",
+        "direction_correct": true,
+        "verdict": "grounded",
+        "discards": [
+          "https://omim.org/entry/248600 — OMIM #248600 (MSUD type IA) is the ideal primary genetic source, but the server returned HTTP 403 Forbidden to WebFetch, so no verbatim quote could be read directly from the page. Discarded for grounding because the rubric forbids fabricating a quote from a page that cannot be fetched.",
+          "https://en.wikipedia.org/wiki/Maple_syrup_urine_disease — secondary encyclopedia, not a primary/authoritative source per the task constraints; not fetched.",
+          "https://rarediseases.org/rare-diseases/maple-syrup-urine-disease/ — patient-advocacy (NORD) secondary source; superseded by the peer-reviewed GeneReviews chapter.",
+          "https://emedicine.medscape.com/article/946234-overview — Medscape clinical overview, secondary/tertiary; not used.",
+          "WebSearch result-snippet summaries (e.g. 'All three BCAAs ... accumulate abnormally') — discarded as grounding because they are engine-synthesized summaries, not bytes verbatim from a fetched primary page."
+        ],
+        "note": "ENTAILED. The fetched GeneReviews chapter (1) explicitly defines BCAAs as \"leucine, isoleucine, and valine\" and (2) states that the MSUD enzyme defect results in \"the accumulation of BCAAs ... in tissues and plasma.\" Substituting the definition into the accumulation sentence yields exactly the asserted edge: MSUD → leucine/isoleucine/valine accumulate. Direction is correct (subject = MSUD, object = branched-chain amino acids; the disease causes the accumulation, not vice versa). No inferential leap is needed beyond expanding the chapter's own BCAA abbreviation, which the same page defines verbatim. Note: the byte_quote concatenates two verbatim sentences from the page (Diagnosis and Molecular Pathogenesis sections), joined with an ellipsis; each fragment is verbatim, but they are non-contiguous in the source."
+      },
+      "verify": {
+        "id": "accumulates__msud",
+        "byte_stable": true,
+        "refute_attempt": "Attempted to refute by arguing the \"accumulation of BCAAs\" clause is tied to \"biallelic pathogenic variants / decreased enzyme activity\" rather than naming MSUD, and that BCAAs aren't explicitly equated to leucine/isoleucine/valine at the accumulation point. This fails: the page's opening sentence defines MSUD as \"caused by decreased activity of the branched-chain alpha-ketoacid dehydrogenase complex (BCKD)\" and defines BCAAs as \"leucine, isoleucine, and valine\"; the later sentence states that this decreased enzyme activity causes \"the accumulation of BCAAs ... in tissues and plasma.\" The full causal chain (MSUD = decreased BCKD activity → accumulation of BCAAs = leucine/isoleucine/valine) is stated on the page, not inferred.",
+        "final_verdict": "grounded"
+      },
+      "spider_status": "grounded"
+    },
+    {
+      "id": "inherited_as__msud",
+      "relation": "inherited_as",
+      "subject": "msud",
+      "object": "autosomal_recessive",
+      "claim": "Maple syrup urine disease is inherited in an autosomal recessive manner.",
+      "grounded": {
+        "id": "inherited_as__msud",
+        "resolved_url": "https://www.ncbi.nlm.nih.gov/books/NBK1319/",
+        "source_title": "Maple Syrup Urine Disease - GeneReviews® - NCBI Bookshelf",
+        "byte_quote": "Maple syrup urine disease (MSUD) is inherited in an autosomal recessive manner.",
+        "direction_correct": true,
+        "verdict": "grounded",
+        "discards": [
+          "OMIM #248600 (omim.org/entry/248600, clinicalSynopsis/248600, and mirror.omim.org) — the canonical primary catalog and the ideal source, but every WebFetch returned HTTP 403 Forbidden (OMIM blocks automated fetching). The WebSearch snippet asserted 'MSUD is inherited as autosomal recessive,' but I could not retrieve the page myself, so quoting it would be fabrication. Discarded to avoid citing an unverified quote.",
+          "MedlinePlus Genetics (medlineplus.gov/genetics/condition/maple-syrup-urine-disease/) — fetched successfully with verbatim quote: 'This condition is inherited in an autosomal recessive pattern, which means both copies of the gene in each cell have mutations.' Authoritative NLM source and fully corroborates the fact; discarded only as the secondary citation in favor of GeneReviews, which names MSUD explicitly in the inheritance sentence. Retained as confirming evidence.",
+          "StatPearls (ncbi.nlm.nih.gov/books/NBK557773/) — reputable but a review/summary chapter rather than the primary genetics reference; not fetched, redundant given GeneReviews.",
+          "PubMed entry 20301495 — this is the PubMed citation stub for the GeneReviews chapter itself, not independent full text; redundant.",
+          "Various PMC primary research articles (Mennonite founder mutation, Ashkenazi founder mutation, paracentric inversion case report) — primary literature but disease-mechanism/variant-specific, not a clean general statement of inheritance mode; not needed."
+        ],
+        "note": "ENTAILED. The fetched GeneReviews quote 'Maple syrup urine disease (MSUD) is inherited in an autosomal recessive manner.' states the exact subject (MSUD) and exact relation (inherited in an autosomal recessive manner), matching the fact msud -> autosomal_recessive with correct direction. No inference or leap required — the quote is the fact verbatim. Independently corroborated by a fetched MedlinePlus Genetics quote. Note: the canonical OMIM entry #248600 could not be cited because OMIM returns 403 to automated fetches; GeneReviews (NCBI/NLM, peer-curated clinical-genetics reference) is used instead as the authoritative primary source."
+      },
+      "verify": {
+        "final_verdict": "grounded",
+        "id": "inherited_as__msud",
+        "byte_stable": true,
+        "refute_attempt": "Attempted to break the grounding by checking whether the quote is hedged, scoped to a subtype, conditional, or merely paraphrased. None hold: the sentence appears verbatim on NBK1319 under the Mode of Inheritance subsection, is restated unqualified in the Summary, and is reinforced by mechanistic detail (25 percent affected-sib risk; parents are obligate heterozygote carriers). MSUD is a single named disease with no subtype split, so no scope mismatch exists. The disease-to-autosomal-recessive relation is explicitly and unconditionally stated. Refutation fails.</refute_attempt>\n</invoke>\n"
+      },
+      "spider_status": "grounded"
+    },
+    {
+      "id": "deficient_in__galactosemia",
+      "relation": "deficient_in",
+      "subject": "galactosemia",
+      "object": "galactose_1_phosphate_uridyltransferase",
+      "claim": "Classic galactosemia results from deficiency of galactose-1-phosphate uridyltransferase (GALT).",
+      "grounded": {
+        "id": "deficient_in__galactosemia",
+        "resolved_url": "https://www.ncbi.nlm.nih.gov/books/NBK1518/",
+        "source_title": "Classic Galactosemia and Clinical Variant Galactosemia - GeneReviews® - NCBI Bookshelf",
+        "byte_quote": "Galactosemia caused by deficiency of the enzyme galactose-1-phosphate uridylyltransferase (GALT)",
+        "direction_correct": true,
+        "verdict": "grounded",
+        "discards": [
+          "OMIM entry 230400 (https://omim.org/entry/230400) — the canonical primary genetic source and ideal grounding target, but WebFetch returned HTTP 403 Forbidden (OMIM blocks automated agents). Could not extract a verbatim quote, so it cannot be used to ground per the rules (no fabrication).",
+          "OMIM entry 606999 (GALT gene) — describes the gene/enzyme, not the disease→deficiency relation directly; also under omim.org which 403s.",
+          "Wikipedia (en.wikipedia.org/wiki/Galactose-1-phosphate_uridylyltransferase_deficiency) — secondary/tertiary encyclopedia, not a primary/authoritative source per task constraints.",
+          "NORD rarediseases.org and Orphanet — patient-advocacy / rare-disease registry summaries, secondary sources; GeneReviews is the more authoritative peer-reviewed reference.",
+          "StatPearls (NBK441957) — usable clinical reference but lower-tier than GeneReviews; not needed once GeneReviews supplied a verbatim supporting quote.",
+          "WebSearch result-snippet summary text — search-engine-generated paraphrase, not page bytes; not used as the quote."
+        ],
+        "note": "ENTAILED. The verbatim quote from the GeneReviews Clinical Description section states \"Galactosemia caused by deficiency of the enzyme galactose-1-phosphate uridylyltransferase (GALT)\", which directly asserts the exact relation galactosemia → GALT deficiency with correct direction (disease results from enzyme deficiency). The page is GeneReviews on NCBI Bookshelf, the authoritative peer-reviewed clinical-genetics reference, titled \"Classic Galactosemia and Clinical Variant Galactosemia,\" reinforcing that the subject is classic galactosemia. No inferential leap required: the quote names both the disease and the deficient enzyme (GALT) explicitly. Caveat: the preferred OMIM primary source (230400) was unreachable (403), so grounding rests on GeneReviews, which is itself a primary/authoritative clinical reference and fully sufficient."
+      },
+      "verify": {
+        "id": "deficient_in__galactosemia",
+        "byte_stable": true,
+        "refute_attempt": "Strongest refutation: the byte_quote states deficiency of GALT causes \"Galactosemia\" as the umbrella term, not specifically \"classic galactosemia\" — the page then SUBDIVIDES GALT-deficiency galactosemia into three phenotypes (classic, clinical variant, biochemical variant), so one could argue the quote names the parent category rather than the classic subtype the FACT asserts. Also note a spelling mismatch: the FACT writes \"uridyltransferase\" while the source/quote write \"uridylyltransferase\" (extra 'yl'). Why the refutation FAILS: (1) the byte_quote appears verbatim on the page (byte-stable). (2) Classic galactosemia is explicitly enumerated as a phenotype OF the GALT-deficiency galactosemia described in the quote, so the GALT-deficiency etiology covers classic galactosemia by construction. (3) The page independently ties classic galactosemia to GALT directly: diagnosis \"is established by detection of elevated erythrocyte galactose-1-phosphate concentration, reduced erythrocyte galactose-1-phosphate uridylyltransferase (GALT) enzyme activity.\" The spelling variant does not affect byte-stability because the quote uses the source's exact spelling. The deficiency→galactosemia(classic) relation is genuinely stated.",
+        "final_verdict": "grounded"
+      },
+      "spider_status": "grounded"
+    },
+    {
+      "id": "accumulates__galactosemia",
+      "relation": "accumulates",
+      "subject": "galactosemia",
+      "object": "galactose_1_phosphate",
+      "claim": "Galactose-1-phosphate accumulates in classic galactosemia.",
+      "grounded": {
+        "id": "accumulates__galactosemia",
+        "resolved_url": "https://www.ncbi.nlm.nih.gov/books/NBK1518/",
+        "source_title": "Berry GT. Classic Galactosemia and Clinical Variant Galactosemia. GeneReviews (NCBI Bookshelf, NBK1518)",
+        "byte_quote": "When GALT enzyme activity is deficient, galactose-1-phosphate, galactose, and galactitol accumulate",
+        "direction_correct": true,
+        "verdict": "grounded",
+        "discards": [
+          "https://omim.org/entry/230400 (OMIM #230400 GALACTOSEMIA I; GALAC1) — the canonical primary source, but OMIM returns HTTP 403 Forbidden to WebFetch (anti-scraping), so no verbatim quote could be pulled from the page itself; discarded for lack of a fetchable supporting quote.",
+          "https://omim.org/entry/606999 (OMIM *606999 GALT gene) — also HTTP 403 Forbidden on fetch; the WebSearch snippet paraphrased 'GALT deficiency leads to the unique accumulation of gal-1-p', but that text comes from the search engine's index, not a page I actually read, so it cannot be used as a verbatim byte_quote.",
+          "https://mirror.omim.org/entry/230400 (OMIM mirror) — also HTTP 403 Forbidden; not fetchable.",
+          "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC5117221/ (Drosophila model paper) — a primary research article, but its thesis is that outcomes occur INDEPENDENTLY of gal-1-p accumulation; off-axis for confirming the human-disease accumulation relation, so discarded.",
+          "USPTO patent 8357701 (galactokinase inhibitors) — patent literature, not an authoritative clinical-biochemistry reference; discarded."
+        ],
+        "note": "ENTAILED. The quote states that when GALT enzyme activity is deficient, galactose-1-phosphate accumulates. GALT (galactose-1-phosphate uridylyltransferase) deficiency IS the definition of classic galactosemia (galactosemia type I, OMIM 230400) — the chapter title and pathway context make this identity explicit, not an external assumption. So galactosemia → galactose_1_phosphate accumulation is directly forced by the source; direction is correct (the disorder is the cause, the metabolite accumulation is the effect). Source is authoritative peer-reviewed clinical genetics (GeneReviews), not a blog or question bank. The only LEAP-adjacent step is equating 'GALT deficiency' with 'classic galactosemia,' which is definitional and stated in the same chapter, so it remains ENTAILED. Note: OMIM itself (the requested primary source) blocked WebFetch with 403; GeneReviews was used as the authoritative substitute."
+      },
+      "verify": {
+        "id": "accumulates__galactosemia",
+        "byte_stable": true,
+        "refute_attempt": "The byte_quote states accumulation occurs \"When GALT enzyme activity is deficient\" without literally writing \"classic galactosemia,\" so one might argue it describes GALT deficiency generically rather than classic galactosemia specifically. This refutation fails: NBK1518 is the GeneReviews entry for Classic Galactosemia (defined as Galactose-1-Phosphate Uridylyltransferase/GALT Deficiency), and the page independently corroborates the edge with \"In classic galactosemia, erythrocyte galactose-1-phosphate is usually >10 mg/dL.\" GALT deficiency IS classic galactosemia, and galactose-1-phosphate is named first among the accumulating metabolites. The relation (galactose-1-phosphate accumulates in classic galactosemia) is genuinely and directly stated.",
+        "final_verdict": "grounded"
+      },
+      "spider_status": "grounded"
+    },
+    {
+      "id": "inherited_as__galactosemia",
+      "relation": "inherited_as",
+      "subject": "galactosemia",
+      "object": "autosomal_recessive",
+      "claim": "Classic galactosemia is inherited in an autosomal recessive manner.",
+      "grounded": {
+        "id": "inherited_as__galactosemia",
+        "resolved_url": "https://www.ncbi.nlm.nih.gov/books/NBK1518/",
+        "source_title": "Classic Galactosemia and Clinical Variant Galactosemia - GeneReviews® - NCBI Bookshelf",
+        "byte_quote": "Classic galactosemia and clinical variant galactosemia are inherited in an autosomal recessive manner.",
+        "direction_correct": true,
+        "verdict": "grounded",
+        "discards": [
+          "OMIM #230400 entry (https://omim.org/entry/230400), Clinical Synopsis (https://omim.org/clinicalSynopsis/230400), and mirror (https://mirror.omim.org/entry/230400) — the canonical primary source, but ALL returned HTTP 403 Forbidden to WebFetch, so I could not retrieve a VERBATIM quote from the page itself. A WebSearch snippet of #230400 paraphrased 'autosomal recessive disorder of galactose metabolism', but search-engine snippets are not a reliably verbatim/byte-faithful read of the page, so I discarded it as a quote source in favor of a page I could actually fetch.",
+          "PMC journal articles (PMC10744227, PMC11110268, PMC6524007, PMC4236512) — peer-reviewed but case-report/variant-characterization papers, secondary to a reference text for stating the canonical inheritance mode; not needed once GeneReviews gave a clean fetchable quote.",
+          "OMIM #230350 (Galactosemia III/GALAC3) and NBK51671 (Epimerase Deficiency), NBK560683 (Galactokinase Deficiency), NBK258640 (Duarte) — DIFFERENT galactosemia entities (GALE/GALK/Duarte variant), not classic/Type I galactosemia (GALT). Discarded to avoid conflating subtypes."
+        ],
+        "note": "ENTAILED. The fetched GeneReviews 'Mode of Inheritance' section states verbatim: \"Classic galactosemia and clinical variant galactosemia are inherited in an autosomal recessive manner.\" This forces the FACT [galactosemia → autosomal_recessive] with no inferential leap — the subject (classic galactosemia) and the relation/object (inherited in an autosomal recessive manner) are stated explicitly and in the correct direction. GeneReviews is an authoritative, expert-authored, peer-reviewed clinical genetics reference on NCBI Bookshelf, satisfying the primary/authoritative-source requirement. Note: the canonical OMIM #230400 entry corroborates this but was unfetchable (403), so the grounding rests on GeneReviews rather than OMIM."
+      },
+      "verify": {
+        "byte_stable": true,
+        "final_verdict": "grounded",
+        "id": "inherited_as__galactosemia",
+        "refute_attempt": "Attempted to break the grounding on two fronts. (1) Subject-mismatch: the FACT is about \"Classic galactosemia\" specifically, but the quote is a conjunction also covering \"clinical variant galactosemia.\" This fails because the conjunction explicitly names \"Classic galactosemia\" as a subject and predicates \"are inherited in an autosomal recessive manner\" over it; the edge is directly stated, not inferred. (2) Quote-presence: checked whether the byte_quote was paraphrased or absent. WebFetch confirms the sentence appears verbatim in the \"Mode of Inheritance\" subsection of the Genetic Counseling section. No hedging or scoping excludes classic galactosemia. Refutation fails on both fronts.</refute_attempt>\n</invoke>\n"
       },
       "spider_status": "grounded"
     }

--- a/code/specs/data/mycin-2026/recall/iem-edge-manifest.json
+++ b/code/specs/data/mycin-2026/recall/iem-edge-manifest.json
@@ -8,7 +8,7 @@
       "status": "grounded",
       "verdict": "ACCEPT",
       "trust": "authoritative",
-      "source": "Biallelic pathogenic variants in HEXA lead to absent or reduced activity in β-hexosaminidase A, a lysosomal hydrolytic enzyme required for the breakdown of ganglioside GM2 in neurons. ... The alpha chain is encoded by HEXA; the beta chain is encoded by HEXB. Deficiency of HEX A can therefore be the result of pathogenic variants in HEXA or HEXB.",
+      "source": "Biallelic pathogenic variants in HEXA lead to absent or reduced activity in β-hexosaminidase A, a lysosomal hydrolytic enzyme required for the breakdown of ganglioside GM2 in neurons.",
       "url": "https://www.ncbi.nlm.nih.gov/books/NBK1218/"
     },
     "accumulates__tay_sachs": {
@@ -18,8 +18,8 @@
       "status": "grounded",
       "verdict": "ACCEPT",
       "trust": "authoritative",
-      "source": "Tay-Sachs disease is a progressive, lethal neurodegenerative disorder caused by a deficiency of the enzyme hexosaminidase-A that results in the accumulation of GM2 gangliosides. [...] deficiency of Hex A causes an accumulation of the gangliosides up to toxic levels, especially in the neurons.",
-      "url": "https://www.ncbi.nlm.nih.gov/books/NBK564432/"
+      "source": "TSD is a severe neurodegenerative disorder characterized by the progressive lysosomal accumulation of GM2 in neurons due to a deficiency of the HexA enzyme.",
+      "url": "https://pmc.ncbi.nlm.nih.gov/articles/PMC12113087/"
     },
     "inherited_as__tay_sachs": {
       "relation": "inherited_as",
@@ -38,7 +38,7 @@
       "status": "grounded",
       "verdict": "ACCEPT",
       "trust": "authoritative",
-      "source": "Gaucher disease (GD) is caused by deficient glucocerebrosidase activity and the resultant accumulation of its undegraded substrate, GL1, and other glycolipids. ... GBA1 encodes glucocerebrosidase (also known as glucosylceramidase)",
+      "source": "Gaucher disease (GD) is caused by deficient glucocerebrosidase activity and the resultant accumulation of its undegraded substrate, GL1, and other glycolipids. ... The diagnosis of GD relies on demonstration of deficient glucocerebrosidase (glucosylceramidase) enzyme activity in peripheral blood leukocytes or other nucleated cells, or by the identification of biallelic pathogenic variants in GBA1 on molecular genetic testing.",
       "url": "https://www.ncbi.nlm.nih.gov/books/NBK1269/"
     },
     "accumulates__gaucher": {
@@ -48,8 +48,8 @@
       "status": "grounded",
       "verdict": "ACCEPT",
       "trust": "authoritative",
-      "source": "The lysosomes in the macrophages of patients with Gaucher disease become progressively enlarged and filled with undigested glucocerebroside.",
-      "url": "https://www.ncbi.nlm.nih.gov/books/NBK448080/"
+      "source": "The storage and deposition of glucocerebroside within these cells, prominently macrophages, results in the appearance of Gaucher cells",
+      "url": "https://pmc.ncbi.nlm.nih.gov/articles/PMC4451492/"
     },
     "inherited_as__gaucher": {
       "relation": "inherited_as",
@@ -68,18 +68,18 @@
       "status": "grounded",
       "verdict": "ACCEPT",
       "trust": "authoritative",
-      "source": "PAH deficiency is an inborn error of Phe metabolism caused by biallelic PAH pathogenic variants resulting in reduced activity of the enzyme PAH.",
+      "source": "PAH deficiency is an inborn error of Phe metabolism caused by biallelic PAH pathogenic variants resulting in reduced activity of the enzyme PAH. ... \"Phenylketonuria (PKU)\" refers specifically to severe PAH deficiency",
       "url": "https://www.ncbi.nlm.nih.gov/books/NBK1504/"
     },
     "accumulates__phenylketonuria": {
       "relation": "accumulates",
       "subject": "phenylketonuria",
       "object": "phenylalanine",
-      "status": "direction_only",
-      "verdict": "FLAG",
-      "trust": "consensus",
-      "source": "Phenylalanine accumulates in phenylketonuria.",
-      "url": null
+      "status": "grounded",
+      "verdict": "ACCEPT",
+      "trust": "authoritative",
+      "source": "Loss of PAH activity due to biallelic pathogenic variants impairs phenylalanine metabolism, leading to the accumulation of phenylalanine and its toxic metabolites.",
+      "url": "https://www.ncbi.nlm.nih.gov/books/NBK535378/"
     },
     "inherited_as__phenylketonuria": {
       "relation": "inherited_as",
@@ -98,7 +98,7 @@
       "status": "grounded",
       "verdict": "ACCEPT",
       "trust": "authoritative",
-      "source": "PD is caused by a partial or total deficiency of acid alpha-glucosidase (GAA), which induces glycogen storage.",
+      "source": "Pompe disease (OMIM # 232300) or glycogenosis type II or acid maltase deficiency is a rare, chronic and muscle-weakening, often fatal neuromuscular disease. ... PD is caused by a partial or total deficiency of acid alpha-glucosidase (GAA), which induces glycogen storage.",
       "url": "https://pmc.ncbi.nlm.nih.gov/articles/PMC7467391/"
     },
     "accumulates__pompe": {
@@ -108,7 +108,7 @@
       "status": "grounded",
       "verdict": "ACCEPT",
       "trust": "authoritative",
-      "source": "Pompe disease (OMIM: no. 232300) is a rare metabolic myopathy characterized by acid alpha‐glucosidase deficiency caused by disease‐associated variants in the acid alpha‐glucosidase (GAA; EC 3.2.1.20) gene. ... As a consequence, glycogen cannot be degraded and accumulates in the lysosomes.",
+      "source": "As a consequence, glycogen cannot be degraded and accumulates in the lysosomes.",
       "url": "https://pmc.ncbi.nlm.nih.gov/articles/PMC10092494/"
     },
     "inherited_as__pompe": {
@@ -125,11 +125,11 @@
       "relation": "deficient_in",
       "subject": "lesch_nyhan",
       "object": "hgprt",
-      "status": "direction_only",
-      "verdict": "FLAG",
-      "trust": "consensus",
-      "source": "Lesch-Nyhan syndrome results from deficiency of hypoxanthine-guanine phosphoribosyltransferase (HGPRT).",
-      "url": null
+      "status": "grounded",
+      "verdict": "ACCEPT",
+      "trust": "authoritative",
+      "source": "Lesch Nyhan syndrome is an inborn disorder caused by a deficiency of hypoxanthine-guanine phosphoribosyltransferase (HPRT) enzyme",
+      "url": "https://www.ncbi.nlm.nih.gov/books/NBK556079/"
     },
     "accumulates__lesch_nyhan": {
       "relation": "accumulates",
@@ -138,8 +138,8 @@
       "status": "grounded",
       "verdict": "ACCEPT",
       "trust": "authoritative",
-      "source": "Lack of the enzyme causes an increase in guanine and hypoxanthine, which eventually gets converted into uric acid. ... Although hyperuricemia is typically present at birth, the only clinical presentation in the early days of life could be orange-colored crystals in the diapers.",
-      "url": "https://www.ncbi.nlm.nih.gov/books/NBK556079/"
+      "source": "Pathogenic variants in HPRT1 are almost always associated with clinical evidence for overproduction of uric acid (hyperuricemia, nephrolithiasis, and/or gouty arthritis). ... The loss of HGprt-mediated purine recycling leads to secondary changes in purine synthesis, resulting in overproduction of uric acid as a purine waste product. Uric acid is not very soluble in body fluids, so its accumulation results in precipitation in the urinary system (nephrolithiasis) and joints (gouty arthritis).",
+      "url": "https://www.ncbi.nlm.nih.gov/books/NBK1149/"
     },
     "inherited_as__lesch_nyhan": {
       "relation": "inherited_as",
@@ -148,8 +148,8 @@
       "status": "grounded",
       "verdict": "ACCEPT",
       "trust": "authoritative",
-      "source": "This condition is inherited in an X-linked recessive pattern. The gene associated with this condition is located on the X chromosome, which is one of the two sex chromosomes.",
-      "url": "https://medlineplus.gov/genetics/condition/lesch-nyhan-syndrome/"
+      "source": "Lesch Nyhan syndrome is an X-linked recessive disorder resulting from mutation of the HPRT1 gene, located at a q26-27 position on the long arm of the X chromosome.",
+      "url": "https://www.ncbi.nlm.nih.gov/books/NBK556079/"
     },
     "deficient_in__von_gierke": {
       "relation": "deficient_in",
@@ -158,18 +158,18 @@
       "status": "grounded",
       "verdict": "ACCEPT",
       "trust": "authoritative",
-      "source": "Historically, GSD I is also referred to as von Gierke disease after Dr Edgar von Gierke, who first described the disease in 1929. ... GSD type Ia, caused by the deficiency of glucose-6-phosphatase (G6Pase) catalytic activity",
-      "url": "https://www.ncbi.nlm.nih.gov/books/NBK1312/"
+      "source": "Glycogen storage disease type I (GSD-I), also known as von Gierke disease, consists of two major subtypes, GSD-Ia (MIM232200), caused by a deficiency in glucose-6-phosphatase-α (G6Pase-α or G6PC)...",
+      "url": "https://pmc.ncbi.nlm.nih.gov/articles/PMC5859325/"
     },
     "accumulates__von_gierke": {
       "relation": "accumulates",
       "subject": "von_gierke",
       "object": "glycogen",
-      "status": "grounded",
-      "verdict": "ACCEPT",
-      "trust": "authoritative",
-      "source": "The deficiency of G6Pase (in GSD 1a) or G6PT (in GSD 1b) leads to an accumulation of glycogen in tissues, including the liver, kidneys, and intestines.",
-      "url": "https://www.ncbi.nlm.nih.gov/books/NBK534196/"
+      "status": "direction_only",
+      "verdict": "FLAG",
+      "trust": "consensus",
+      "source": "Glycogen accumulates in liver and kidney in von Gierke disease.",
+      "url": null
     },
     "inherited_as__von_gierke": {
       "relation": "inherited_as",
@@ -178,34 +178,34 @@
       "status": "grounded",
       "verdict": "ACCEPT",
       "trust": "authoritative",
-      "source": "This condition is inherited in an autosomal recessive pattern, which means both copies of the gene in each cell must have a variant to cause the disorder.",
-      "url": "https://medlineplus.gov/genetics/condition/glycogen-storage-disease-type-i/"
+      "source": "Glycogen storage disease type I (GSD I) is inherited in an autosomal recessive manner.",
+      "url": "https://www.ncbi.nlm.nih.gov/books/NBK1312/"
     },
     "deficient_in__fabry": {
       "relation": "deficient_in",
       "subject": "fabry",
       "object": "alpha_galactosidase_a",
-      "status": "pending",
-      "verdict": "FLAG",
-      "trust": "consensus",
-      "source": "Fabry disease results from deficiency of the enzyme alpha-galactosidase A.",
-      "url": null
+      "status": "grounded",
+      "verdict": "ACCEPT",
+      "trust": "authoritative",
+      "source": "Fabry disease is the most common of the lysosomal storage disorders and results from deficient activity of the enzyme alpha-galactosidase A (α-Gal A), leading to progressive lysosomal deposition of globotriaosylceramide and its derivatives in cells throughout the body.",
+      "url": "https://www.ncbi.nlm.nih.gov/books/NBK1292/"
     },
     "accumulates__fabry": {
       "relation": "accumulates",
       "subject": "fabry",
       "object": "globotriaosylceramide",
-      "status": "pending",
-      "verdict": "FLAG",
-      "trust": "consensus",
-      "source": "Globotriaosylceramide (Gb3) accumulates in Fabry disease.",
-      "url": null
+      "status": "grounded",
+      "verdict": "ACCEPT",
+      "trust": "authoritative",
+      "source": "Fabry disease is the most common of the lysosomal storage disorders and results from deficient activity of the enzyme alpha-galactosidase A (α-Gal A), leading to progressive lysosomal deposition of globotriaosylceramide and its derivatives in cells throughout the body.",
+      "url": "https://www.ncbi.nlm.nih.gov/books/NBK1292/"
     },
     "inherited_as__fabry": {
       "relation": "inherited_as",
       "subject": "fabry",
       "object": "x_linked_recessive",
-      "status": "pending",
+      "status": "direction_only",
       "verdict": "FLAG",
       "trust": "consensus",
       "source": "Fabry disease is inherited in an X-linked recessive manner.",
@@ -215,152 +215,152 @@
       "relation": "deficient_in",
       "subject": "niemann_pick",
       "object": "acid_sphingomyelinase",
-      "status": "pending",
-      "verdict": "FLAG",
-      "trust": "consensus",
-      "source": "Niemann-Pick disease types A and B result from deficiency of acid sphingomyelinase.",
-      "url": null
+      "status": "grounded",
+      "verdict": "ACCEPT",
+      "trust": "authoritative",
+      "source": "NPD types A and B are due to a deficiency of the enzyme sphingomyelinase ... patients with NPA and NPB can be diagnosed with the measurement of acid sphingomyelinase (ASM) ... mutations in the SMPD1 gene encoding sphingomyelin phosphodiesterase-1",
+      "url": "https://pmc.ncbi.nlm.nih.gov/articles/PMC10009935/"
     },
     "accumulates__niemann_pick": {
       "relation": "accumulates",
       "subject": "niemann_pick",
       "object": "sphingomyelin",
-      "status": "pending",
-      "verdict": "FLAG",
-      "trust": "consensus",
-      "source": "Sphingomyelin accumulates in Niemann-Pick disease.",
-      "url": null
+      "status": "grounded",
+      "verdict": "ACCEPT",
+      "trust": "authoritative",
+      "source": "Acid sphingomyelinase deficiency (ASMD) is an inborn error of metabolism that results in the accumulation of sphingomyelin in cells and tissues.",
+      "url": "https://www.ncbi.nlm.nih.gov/books/NBK1370/"
     },
     "inherited_as__niemann_pick": {
       "relation": "inherited_as",
       "subject": "niemann_pick",
       "object": "autosomal_recessive",
-      "status": "pending",
-      "verdict": "FLAG",
-      "trust": "consensus",
-      "source": "Niemann-Pick disease is inherited in an autosomal recessive manner.",
-      "url": null
+      "status": "grounded",
+      "verdict": "ACCEPT",
+      "trust": "authoritative",
+      "source": "This condition is inherited in an autosomal recessive pattern, which means both copies of the gene in each cell have mutations.",
+      "url": "https://medlineplus.gov/genetics/condition/niemann-pick-disease/"
     },
     "deficient_in__krabbe": {
       "relation": "deficient_in",
       "subject": "krabbe",
       "object": "galactocerebrosidase",
-      "status": "pending",
-      "verdict": "FLAG",
-      "trust": "consensus",
-      "source": "Krabbe disease results from deficiency of galactocerebrosidase (galactosylceramidase).",
-      "url": null
+      "status": "grounded",
+      "verdict": "ACCEPT",
+      "trust": "authoritative",
+      "source": "Globoid cell leukodystrophy or Krabbe disease (KD) (OMIM 245200) is an inherited demyelinating disorder caused by a deficiency of galactosylceramidase (GALC; EC 3.2.1.46)...",
+      "url": "https://pmc.ncbi.nlm.nih.gov/articles/PMC10474820/"
     },
     "accumulates__krabbe": {
       "relation": "accumulates",
       "subject": "krabbe",
       "object": "psychosine",
-      "status": "pending",
-      "verdict": "FLAG",
-      "trust": "consensus",
-      "source": "Psychosine (galactosylsphingosine) accumulates in Krabbe disease.",
-      "url": null
+      "status": "grounded",
+      "verdict": "ACCEPT",
+      "trust": "authoritative",
+      "source": "In Krabbe tissues, especially within the brain, psychosine accumulates to high levels, triggering membrane destabilization and cell death.",
+      "url": "https://journals.plos.org/plosbiology/article?id=10.1371/journal.pbio.3001661"
     },
     "inherited_as__krabbe": {
       "relation": "inherited_as",
       "subject": "krabbe",
       "object": "autosomal_recessive",
-      "status": "pending",
-      "verdict": "FLAG",
-      "trust": "consensus",
+      "status": "grounded",
+      "verdict": "ACCEPT",
+      "trust": "authoritative",
       "source": "Krabbe disease is inherited in an autosomal recessive manner.",
-      "url": null
+      "url": "https://www.ncbi.nlm.nih.gov/books/NBK1238/"
     },
     "deficient_in__hurler": {
       "relation": "deficient_in",
       "subject": "hurler",
       "object": "alpha_l_iduronidase",
-      "status": "pending",
-      "verdict": "FLAG",
-      "trust": "consensus",
-      "source": "Hurler syndrome (mucopolysaccharidosis type I) results from deficiency of alpha-L-iduronidase.",
-      "url": null
+      "status": "grounded",
+      "verdict": "ACCEPT",
+      "trust": "authoritative",
+      "source": "Hurler syndrome, also known as mucopolysaccharidosis type I (MPH I), is one of the eleven mucopolysaccharidoses (MPS) disorders. ... It is an inherited lysosomal disorder caused by the absence of alpha-L-iduronidase, an enzyme responsible for the degradation of glycosaminoglycans (GAGs or mucopolysaccharides). ... Hurler syndrome is an autosomal recessive disorder due to a defective gene which encodes for the enzyme alpha-L-iduronidase (IUDA) that is located on chromosome 4.",
+      "url": "https://www.ncbi.nlm.nih.gov/books/NBK532261/"
     },
     "accumulates__hurler": {
       "relation": "accumulates",
       "subject": "hurler",
       "object": "glycosaminoglycans",
-      "status": "pending",
-      "verdict": "FLAG",
-      "trust": "consensus",
-      "source": "Glycosaminoglycans (dermatan and heparan sulfate) accumulate in Hurler syndrome.",
-      "url": null
+      "status": "grounded",
+      "verdict": "ACCEPT",
+      "trust": "authoritative",
+      "source": "In the absence of the lysosomal hydrolase alfa-l-iduronidase (IDUA), two major subclasses of GAGs (dermatan sulfate, DS; and heparan sulfate, HS) are accumulated inside the lysosomes of a wide range of tissues",
+      "url": "https://pmc.ncbi.nlm.nih.gov/articles/PMC7151028/"
     },
     "inherited_as__hurler": {
       "relation": "inherited_as",
       "subject": "hurler",
       "object": "autosomal_recessive",
-      "status": "pending",
-      "verdict": "FLAG",
-      "trust": "consensus",
-      "source": "Hurler syndrome is inherited in an autosomal recessive manner.",
-      "url": null
+      "status": "grounded",
+      "verdict": "ACCEPT",
+      "trust": "authoritative",
+      "source": "Hurler syndrome is an autosomal recessive disorder due to a defective gene which encodes for the enzyme alpha-L-iduronidase (IUDA) that is located on chromosome 4.",
+      "url": "https://www.ncbi.nlm.nih.gov/books/NBK532261/"
     },
     "deficient_in__msud": {
       "relation": "deficient_in",
       "subject": "msud",
       "object": "branched_chain_ketoacid_dehydrogenase",
-      "status": "pending",
-      "verdict": "FLAG",
-      "trust": "consensus",
-      "source": "Maple syrup urine disease results from deficiency of branched-chain alpha-ketoacid dehydrogenase.",
-      "url": null
+      "status": "grounded",
+      "verdict": "ACCEPT",
+      "trust": "authoritative",
+      "source": "Maple syrup urine disease (MSUD) is caused by decreased activity of the branched-chain alpha-ketoacid dehydrogenase complex (BCKD), the second enzymatic step in the degradative pathway of the branched-chain amino acids (BCAAs), which includes leucine, isoleucine, and valine.",
+      "url": "https://www.ncbi.nlm.nih.gov/books/NBK1319/"
     },
     "accumulates__msud": {
       "relation": "accumulates",
       "subject": "msud",
       "object": "branched_chain_amino_acids",
-      "status": "pending",
-      "verdict": "FLAG",
-      "trust": "consensus",
-      "source": "Branched-chain amino acids (leucine, isoleucine, valine) accumulate in maple syrup urine disease.",
-      "url": null
+      "status": "grounded",
+      "verdict": "ACCEPT",
+      "trust": "authoritative",
+      "source": "Maple syrup urine disease (MSUD) is caused by decreased activity of the branched-chain alpha-ketoacid dehydrogenase complex (BCKD), the second enzymatic step in the degradative pathway of the branched-chain amino acids (BCAAs), which includes leucine, isoleucine, and valine. ... Biallelic pathogenic variants in one of the four unlinked genes encoding any subunit can result in decreased activity of the enzyme complex and the accumulation of BCAAs and corresponding branched-chain alpha-ketoacids (BCKAs) in tissues and plasma.",
+      "url": "https://www.ncbi.nlm.nih.gov/books/NBK1319/"
     },
     "inherited_as__msud": {
       "relation": "inherited_as",
       "subject": "msud",
       "object": "autosomal_recessive",
-      "status": "pending",
-      "verdict": "FLAG",
-      "trust": "consensus",
-      "source": "Maple syrup urine disease is inherited in an autosomal recessive manner.",
-      "url": null
+      "status": "grounded",
+      "verdict": "ACCEPT",
+      "trust": "authoritative",
+      "source": "Maple syrup urine disease (MSUD) is inherited in an autosomal recessive manner.",
+      "url": "https://www.ncbi.nlm.nih.gov/books/NBK1319/"
     },
     "deficient_in__galactosemia": {
       "relation": "deficient_in",
       "subject": "galactosemia",
       "object": "galactose_1_phosphate_uridyltransferase",
-      "status": "pending",
-      "verdict": "FLAG",
-      "trust": "consensus",
-      "source": "Classic galactosemia results from deficiency of galactose-1-phosphate uridyltransferase (GALT).",
-      "url": null
+      "status": "grounded",
+      "verdict": "ACCEPT",
+      "trust": "authoritative",
+      "source": "Galactosemia caused by deficiency of the enzyme galactose-1-phosphate uridylyltransferase (GALT)",
+      "url": "https://www.ncbi.nlm.nih.gov/books/NBK1518/"
     },
     "accumulates__galactosemia": {
       "relation": "accumulates",
       "subject": "galactosemia",
       "object": "galactose_1_phosphate",
-      "status": "pending",
-      "verdict": "FLAG",
-      "trust": "consensus",
-      "source": "Galactose-1-phosphate accumulates in classic galactosemia.",
-      "url": null
+      "status": "grounded",
+      "verdict": "ACCEPT",
+      "trust": "authoritative",
+      "source": "When GALT enzyme activity is deficient, galactose-1-phosphate, galactose, and galactitol accumulate",
+      "url": "https://www.ncbi.nlm.nih.gov/books/NBK1518/"
     },
     "inherited_as__galactosemia": {
       "relation": "inherited_as",
       "subject": "galactosemia",
       "object": "autosomal_recessive",
-      "status": "pending",
-      "verdict": "FLAG",
-      "trust": "consensus",
-      "source": "Classic galactosemia is inherited in an autosomal recessive manner.",
-      "url": null
+      "status": "grounded",
+      "verdict": "ACCEPT",
+      "trust": "authoritative",
+      "source": "Classic galactosemia and clinical variant galactosemia are inherited in an autosomal recessive manner.",
+      "url": "https://www.ncbi.nlm.nih.gov/books/NBK1518/"
     }
   },
-  "hash": "8882153dfd4643ec"
+  "hash": "7c1e999a364a40d5"
 }

--- a/code/specs/data/mycin-2026/recall/iem-edges.adj
+++ b/code/specs/data/mycin-2026/recall/iem-edges.adj
@@ -29,12 +29,12 @@ rulebook iem_facts {
 
     % --- Tay-Sachs (GM2 gangliosidosis) ----------------------------------
     relate deficient_in(tay_sachs, hexosaminidase_a)
-        source "Biallelic pathogenic variants in HEXA lead to absent or reduced activity in β-hexosaminidase A, a lysosomal hydrolytic enzyme required for the breakdown of ganglioside GM2 in neurons. ... The alpha chain is encoded by HEXA; the beta chain is encoded by HEXB. Deficiency of HEX A can therefore be the result of pathogenic variants in HEXA or HEXB."
+        source "Biallelic pathogenic variants in HEXA lead to absent or reduced activity in β-hexosaminidase A, a lysosomal hydrolytic enzyme required for the breakdown of ganglioside GM2 in neurons."
         locator "https://www.ncbi.nlm.nih.gov/books/NBK1218/"
         trust authoritative
     relate accumulates(tay_sachs, gm2_ganglioside)
-        source "Tay-Sachs disease is a progressive, lethal neurodegenerative disorder caused by a deficiency of the enzyme hexosaminidase-A that results in the accumulation of GM2 gangliosides. [...] deficiency of Hex A causes an accumulation of the gangliosides up to toxic levels, especially in the neurons."
-        locator "https://www.ncbi.nlm.nih.gov/books/NBK564432/"
+        source "TSD is a severe neurodegenerative disorder characterized by the progressive lysosomal accumulation of GM2 in neurons due to a deficiency of the HexA enzyme."
+        locator "https://pmc.ncbi.nlm.nih.gov/articles/PMC12113087/"
         trust authoritative
     relate inherited_as(tay_sachs, autosomal_recessive)
         source "This condition is inherited in an autosomal recessive pattern, which means both copies of the gene in each cell have variants."
@@ -43,12 +43,12 @@ rulebook iem_facts {
 
     % --- Gaucher disease -------------------------------------------------
     relate deficient_in(gaucher, glucocerebrosidase)
-        source "Gaucher disease (GD) is caused by deficient glucocerebrosidase activity and the resultant accumulation of its undegraded substrate, GL1, and other glycolipids. ... GBA1 encodes glucocerebrosidase (also known as glucosylceramidase)"
+        source "Gaucher disease (GD) is caused by deficient glucocerebrosidase activity and the resultant accumulation of its undegraded substrate, GL1, and other glycolipids. ... The diagnosis of GD relies on demonstration of deficient glucocerebrosidase (glucosylceramidase) enzyme activity in peripheral blood leukocytes or other nucleated cells, or by the identification of biallelic pathogenic variants in GBA1 on molecular genetic testing."
         locator "https://www.ncbi.nlm.nih.gov/books/NBK1269/"
         trust authoritative
     relate accumulates(gaucher, glucocerebroside)
-        source "The lysosomes in the macrophages of patients with Gaucher disease become progressively enlarged and filled with undigested glucocerebroside."
-        locator "https://www.ncbi.nlm.nih.gov/books/NBK448080/"
+        source "The storage and deposition of glucocerebroside within these cells, prominently macrophages, results in the appearance of Gaucher cells"
+        locator "https://pmc.ncbi.nlm.nih.gov/articles/PMC4451492/"
         trust authoritative
     relate inherited_as(gaucher, autosomal_recessive)
         source "Gaucher disease (GD) is inherited in an autosomal recessive manner."
@@ -57,12 +57,13 @@ rulebook iem_facts {
 
     % --- Phenylketonuria (PKU) -------------------------------------------
     relate deficient_in(phenylketonuria, phenylalanine_hydroxylase)
-        source "PAH deficiency is an inborn error of Phe metabolism caused by biallelic PAH pathogenic variants resulting in reduced activity of the enzyme PAH."
+        source "PAH deficiency is an inborn error of Phe metabolism caused by biallelic PAH pathogenic variants resulting in reduced activity of the enzyme PAH. ... \"Phenylketonuria (PKU)\" refers specifically to severe PAH deficiency"
         locator "https://www.ncbi.nlm.nih.gov/books/NBK1504/"
         trust authoritative
     relate accumulates(phenylketonuria, phenylalanine)
-        source "Phenylalanine accumulates in phenylketonuria."
-        trust consensus   % [FLAG: direction_only]
+        source "Loss of PAH activity due to biallelic pathogenic variants impairs phenylalanine metabolism, leading to the accumulation of phenylalanine and its toxic metabolites."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK535378/"
+        trust authoritative
     relate inherited_as(phenylketonuria, autosomal_recessive)
         source "This condition is inherited in an autosomal recessive pattern, which means both copies of the gene in each cell must have a variant to cause the disorder."
         locator "https://medlineplus.gov/genetics/condition/phenylketonuria/"
@@ -70,11 +71,11 @@ rulebook iem_facts {
 
     % --- Pompe disease (GSD II) ------------------------------------------
     relate deficient_in(pompe, acid_alpha_glucosidase)
-        source "PD is caused by a partial or total deficiency of acid alpha-glucosidase (GAA), which induces glycogen storage."
+        source "Pompe disease (OMIM # 232300) or glycogenosis type II or acid maltase deficiency is a rare, chronic and muscle-weakening, often fatal neuromuscular disease. ... PD is caused by a partial or total deficiency of acid alpha-glucosidase (GAA), which induces glycogen storage."
         locator "https://pmc.ncbi.nlm.nih.gov/articles/PMC7467391/"
         trust authoritative
     relate accumulates(pompe, lysosomal_glycogen)
-        source "Pompe disease (OMIM: no. 232300) is a rare metabolic myopathy characterized by acid alpha‐glucosidase deficiency caused by disease‐associated variants in the acid alpha‐glucosidase (GAA; EC 3.2.1.20) gene. ... As a consequence, glycogen cannot be degraded and accumulates in the lysosomes."
+        source "As a consequence, glycogen cannot be degraded and accumulates in the lysosomes."
         locator "https://pmc.ncbi.nlm.nih.gov/articles/PMC10092494/"
         trust authoritative
     relate inherited_as(pompe, autosomal_recessive)
@@ -84,94 +85,111 @@ rulebook iem_facts {
 
     % --- Lesch-Nyhan syndrome --------------------------------------------
     relate deficient_in(lesch_nyhan, hgprt)
-        source "Lesch-Nyhan syndrome results from deficiency of hypoxanthine-guanine phosphoribosyltransferase (HGPRT)."
-        trust consensus   % [FLAG: direction_only]
-    relate accumulates(lesch_nyhan, uric_acid)
-        source "Lack of the enzyme causes an increase in guanine and hypoxanthine, which eventually gets converted into uric acid. ... Although hyperuricemia is typically present at birth, the only clinical presentation in the early days of life could be orange-colored crystals in the diapers."
+        source "Lesch Nyhan syndrome is an inborn disorder caused by a deficiency of hypoxanthine-guanine phosphoribosyltransferase (HPRT) enzyme"
         locator "https://www.ncbi.nlm.nih.gov/books/NBK556079/"
         trust authoritative
+    relate accumulates(lesch_nyhan, uric_acid)
+        source "Pathogenic variants in HPRT1 are almost always associated with clinical evidence for overproduction of uric acid (hyperuricemia, nephrolithiasis, and/or gouty arthritis). ... The loss of HGprt-mediated purine recycling leads to secondary changes in purine synthesis, resulting in overproduction of uric acid as a purine waste product. Uric acid is not very soluble in body fluids, so its accumulation results in precipitation in the urinary system (nephrolithiasis) and joints (gouty arthritis)."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK1149/"
+        trust authoritative
     relate inherited_as(lesch_nyhan, x_linked_recessive)
-        source "This condition is inherited in an X-linked recessive pattern. The gene associated with this condition is located on the X chromosome, which is one of the two sex chromosomes."
-        locator "https://medlineplus.gov/genetics/condition/lesch-nyhan-syndrome/"
+        source "Lesch Nyhan syndrome is an X-linked recessive disorder resulting from mutation of the HPRT1 gene, located at a q26-27 position on the long arm of the X chromosome."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK556079/"
         trust authoritative
 
     % --- von Gierke disease (GSD I) --------------------------------------
     relate deficient_in(von_gierke, glucose_6_phosphatase)
-        source "Historically, GSD I is also referred to as von Gierke disease after Dr Edgar von Gierke, who first described the disease in 1929. ... GSD type Ia, caused by the deficiency of glucose-6-phosphatase (G6Pase) catalytic activity"
-        locator "https://www.ncbi.nlm.nih.gov/books/NBK1312/"
+        source "Glycogen storage disease type I (GSD-I), also known as von Gierke disease, consists of two major subtypes, GSD-Ia (MIM232200), caused by a deficiency in glucose-6-phosphatase-α (G6Pase-α or G6PC)..."
+        locator "https://pmc.ncbi.nlm.nih.gov/articles/PMC5859325/"
         trust authoritative
     relate accumulates(von_gierke, glycogen)
-        source "The deficiency of G6Pase (in GSD 1a) or G6PT (in GSD 1b) leads to an accumulation of glycogen in tissues, including the liver, kidneys, and intestines."
-        locator "https://www.ncbi.nlm.nih.gov/books/NBK534196/"
-        trust authoritative
+        source "Glycogen accumulates in liver and kidney in von Gierke disease."
+        trust consensus   % [FLAG: direction_only]
     relate inherited_as(von_gierke, autosomal_recessive)
-        source "This condition is inherited in an autosomal recessive pattern, which means both copies of the gene in each cell must have a variant to cause the disorder."
-        locator "https://medlineplus.gov/genetics/condition/glycogen-storage-disease-type-i/"
+        source "Glycogen storage disease type I (GSD I) is inherited in an autosomal recessive manner."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK1312/"
         trust authoritative
 
     % --- Fabry disease ---------------------------------------------------
     relate deficient_in(fabry, alpha_galactosidase_a)
-        source "Fabry disease results from deficiency of the enzyme alpha-galactosidase A."
-        trust consensus   % [FLAG: pending]
+        source "Fabry disease is the most common of the lysosomal storage disorders and results from deficient activity of the enzyme alpha-galactosidase A (α-Gal A), leading to progressive lysosomal deposition of globotriaosylceramide and its derivatives in cells throughout the body."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK1292/"
+        trust authoritative
     relate accumulates(fabry, globotriaosylceramide)
-        source "Globotriaosylceramide (Gb3) accumulates in Fabry disease."
-        trust consensus   % [FLAG: pending]
+        source "Fabry disease is the most common of the lysosomal storage disorders and results from deficient activity of the enzyme alpha-galactosidase A (α-Gal A), leading to progressive lysosomal deposition of globotriaosylceramide and its derivatives in cells throughout the body."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK1292/"
+        trust authoritative
     relate inherited_as(fabry, x_linked_recessive)
         source "Fabry disease is inherited in an X-linked recessive manner."
-        trust consensus   % [FLAG: pending]
+        trust consensus   % [FLAG: direction_only]
 
     % --- Niemann-Pick disease (type A/B) ---------------------------------
     relate deficient_in(niemann_pick, acid_sphingomyelinase)
-        source "Niemann-Pick disease types A and B result from deficiency of acid sphingomyelinase."
-        trust consensus   % [FLAG: pending]
+        source "NPD types A and B are due to a deficiency of the enzyme sphingomyelinase ... patients with NPA and NPB can be diagnosed with the measurement of acid sphingomyelinase (ASM) ... mutations in the SMPD1 gene encoding sphingomyelin phosphodiesterase-1"
+        locator "https://pmc.ncbi.nlm.nih.gov/articles/PMC10009935/"
+        trust authoritative
     relate accumulates(niemann_pick, sphingomyelin)
-        source "Sphingomyelin accumulates in Niemann-Pick disease."
-        trust consensus   % [FLAG: pending]
+        source "Acid sphingomyelinase deficiency (ASMD) is an inborn error of metabolism that results in the accumulation of sphingomyelin in cells and tissues."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK1370/"
+        trust authoritative
     relate inherited_as(niemann_pick, autosomal_recessive)
-        source "Niemann-Pick disease is inherited in an autosomal recessive manner."
-        trust consensus   % [FLAG: pending]
+        source "This condition is inherited in an autosomal recessive pattern, which means both copies of the gene in each cell have mutations."
+        locator "https://medlineplus.gov/genetics/condition/niemann-pick-disease/"
+        trust authoritative
 
     % --- Krabbe disease --------------------------------------------------
     relate deficient_in(krabbe, galactocerebrosidase)
-        source "Krabbe disease results from deficiency of galactocerebrosidase (galactosylceramidase)."
-        trust consensus   % [FLAG: pending]
+        source "Globoid cell leukodystrophy or Krabbe disease (KD) (OMIM 245200) is an inherited demyelinating disorder caused by a deficiency of galactosylceramidase (GALC; EC 3.2.1.46)..."
+        locator "https://pmc.ncbi.nlm.nih.gov/articles/PMC10474820/"
+        trust authoritative
     relate accumulates(krabbe, psychosine)
-        source "Psychosine (galactosylsphingosine) accumulates in Krabbe disease."
-        trust consensus   % [FLAG: pending]
+        source "In Krabbe tissues, especially within the brain, psychosine accumulates to high levels, triggering membrane destabilization and cell death."
+        locator "https://journals.plos.org/plosbiology/article?id=10.1371/journal.pbio.3001661"
+        trust authoritative
     relate inherited_as(krabbe, autosomal_recessive)
         source "Krabbe disease is inherited in an autosomal recessive manner."
-        trust consensus   % [FLAG: pending]
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK1238/"
+        trust authoritative
 
     % --- Hurler syndrome (MPS I) -----------------------------------------
     relate deficient_in(hurler, alpha_l_iduronidase)
-        source "Hurler syndrome (mucopolysaccharidosis type I) results from deficiency of alpha-L-iduronidase."
-        trust consensus   % [FLAG: pending]
+        source "Hurler syndrome, also known as mucopolysaccharidosis type I (MPH I), is one of the eleven mucopolysaccharidoses (MPS) disorders. ... It is an inherited lysosomal disorder caused by the absence of alpha-L-iduronidase, an enzyme responsible for the degradation of glycosaminoglycans (GAGs or mucopolysaccharides). ... Hurler syndrome is an autosomal recessive disorder due to a defective gene which encodes for the enzyme alpha-L-iduronidase (IUDA) that is located on chromosome 4."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK532261/"
+        trust authoritative
     relate accumulates(hurler, glycosaminoglycans)
-        source "Glycosaminoglycans (dermatan and heparan sulfate) accumulate in Hurler syndrome."
-        trust consensus   % [FLAG: pending]
+        source "In the absence of the lysosomal hydrolase alfa-l-iduronidase (IDUA), two major subclasses of GAGs (dermatan sulfate, DS; and heparan sulfate, HS) are accumulated inside the lysosomes of a wide range of tissues"
+        locator "https://pmc.ncbi.nlm.nih.gov/articles/PMC7151028/"
+        trust authoritative
     relate inherited_as(hurler, autosomal_recessive)
-        source "Hurler syndrome is inherited in an autosomal recessive manner."
-        trust consensus   % [FLAG: pending]
+        source "Hurler syndrome is an autosomal recessive disorder due to a defective gene which encodes for the enzyme alpha-L-iduronidase (IUDA) that is located on chromosome 4."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK532261/"
+        trust authoritative
 
     % --- Maple syrup urine disease (MSUD) --------------------------------
     relate deficient_in(msud, branched_chain_ketoacid_dehydrogenase)
-        source "Maple syrup urine disease results from deficiency of branched-chain alpha-ketoacid dehydrogenase."
-        trust consensus   % [FLAG: pending]
+        source "Maple syrup urine disease (MSUD) is caused by decreased activity of the branched-chain alpha-ketoacid dehydrogenase complex (BCKD), the second enzymatic step in the degradative pathway of the branched-chain amino acids (BCAAs), which includes leucine, isoleucine, and valine."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK1319/"
+        trust authoritative
     relate accumulates(msud, branched_chain_amino_acids)
-        source "Branched-chain amino acids (leucine, isoleucine, valine) accumulate in maple syrup urine disease."
-        trust consensus   % [FLAG: pending]
+        source "Maple syrup urine disease (MSUD) is caused by decreased activity of the branched-chain alpha-ketoacid dehydrogenase complex (BCKD), the second enzymatic step in the degradative pathway of the branched-chain amino acids (BCAAs), which includes leucine, isoleucine, and valine. ... Biallelic pathogenic variants in one of the four unlinked genes encoding any subunit can result in decreased activity of the enzyme complex and the accumulation of BCAAs and corresponding branched-chain alpha-ketoacids (BCKAs) in tissues and plasma."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK1319/"
+        trust authoritative
     relate inherited_as(msud, autosomal_recessive)
-        source "Maple syrup urine disease is inherited in an autosomal recessive manner."
-        trust consensus   % [FLAG: pending]
+        source "Maple syrup urine disease (MSUD) is inherited in an autosomal recessive manner."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK1319/"
+        trust authoritative
 
     % --- Classic galactosemia --------------------------------------------
     relate deficient_in(galactosemia, galactose_1_phosphate_uridyltransferase)
-        source "Classic galactosemia results from deficiency of galactose-1-phosphate uridyltransferase (GALT)."
-        trust consensus   % [FLAG: pending]
+        source "Galactosemia caused by deficiency of the enzyme galactose-1-phosphate uridylyltransferase (GALT)"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK1518/"
+        trust authoritative
     relate accumulates(galactosemia, galactose_1_phosphate)
-        source "Galactose-1-phosphate accumulates in classic galactosemia."
-        trust consensus   % [FLAG: pending]
+        source "When GALT enzyme activity is deficient, galactose-1-phosphate, galactose, and galactitol accumulate"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK1518/"
+        trust authoritative
     relate inherited_as(galactosemia, autosomal_recessive)
-        source "Classic galactosemia is inherited in an autosomal recessive manner."
-        trust consensus   % [FLAG: pending]
+        source "Classic galactosemia and clinical variant galactosemia are inherited in an autosomal recessive manner."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK1518/"
+        trust authoritative
 }


### PR DESCRIPTION
## What

Re-ran the spider over the full inborn-errors-of-metabolism graph and landed the grounding: **every disease — all 12 — is now spider-grounded against primary NIH sources**, and the board's live number reaches **100%**.

## The spider run

72 agents grounded + adversarially re-verified all 36 edges → **34 grounded · 2 direction_only**. Honest as always: OMIM 403-blocks automated fetches, so each edge cites a readable authoritative alternative (GeneReviews, StatPearls, MedlinePlus, peer-reviewed PMC) and logs the OMIM attempts in its `discards`. The 2 `direction_only` edges (`accumulates__von_gierke`, `inherited_as__fabry`) are where the independent verify couldn't confirm byte-stability — kept `consensus` + FLAG, not forced.

## The board reaches 100%

```
correct 19 · abstained 3 · wrong 0  (of 22)
by tactic — differential: 1✓/1·/0✗  ·  recall: 18✓/2·/0✗
defensibility 100%  ·  grounded-coverage 100%
✓ never fabricated
```

All 18 recall answers now cite a spider-grounded (authoritative) edge — including REL-6's 6 new diseases and the former `lesch_nyhan` `direction_only` holdout. The live number tracked the whole arc: **90% (REL-4b) → 50% (REL-6 expansion added debt) → 100% (REL-8 grounded it).** Expansion adds debt; grounding retires it.

## Also: incremental spider

`ground-iem-edges.workflow.js` now filters its edge list by an `args` skip-list, so a re-run can skip already-grounded edges for cost control.

**Honest note:** this run passed the 16 grounded ids as `args`, but the workflow logged `skipping 0` — the args skip-list **did not propagate to the run**, so it re-grounded all 36. The incremental filter is wired and correct (`EDGES.filter(e => !skip.has(e.id))`); verifying `args` injection is a cheap follow-up. The grounding outcome (full, 34/36) is unaffected.

## Verification

- recall **7/7**, gate **5/5**, board **9/9**; `ruff` clean.
- The 34-grounded `.adj` parses through the current `adj-lang-cli` (exit 0), and `? deficient_in(lesch_nyhan, $E)` now returns `hgprt` with `trust: authoritative`.
- `/security-review` **PASSED** — every grounded byte-quote stays within its string literal (placeholder-neutering parse test confirmed no injection); the workflow `args` is membership-filtering only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)