### PR TITLE
Add SPICE AC LIN/OCT deck routing

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ### Added
 
+- **Deck AC LIN/OCT execution routing** —
+  `run_deck_analysis()` now executes selected `.ac LIN`, `.ac DEC`, and
+  `.ac OCT` plans with SPICE-style linear, points-per-decade, and
+  points-per-octave frequency grids, matching Rust and TypeScript.
+
 - **Deck analysis execution routing** —
   `run_deck_analysis()` now selects one deck `.op`, `.dc`, `.ac DEC`, or
   `.tran` plan, dispatches it into the matching solver, and returns the

--- a/code/packages/python/spice-engine/README.md
+++ b/code/packages/python/spice-engine/README.md
@@ -100,9 +100,9 @@ for malformed arguments, unsupported AC sweep modes, invalid sweep intervals,
 and unresolved scalar expressions. `select_deck_analysis_plan()` picks one
 explicit card by analysis alias, defaults decks without analysis cards to an
 implicit `.op`, and reports ambiguity before solver dispatch.
-`run_deck_analysis()` executes one selected `.op`, `.dc`, `.ac DEC`, or
-`.tran` plan against an existing `Circuit` and returns the plan, solver result,
-and deck-selected output table.
+`run_deck_analysis()` executes one selected `.op`, `.dc`, `.ac LIN`,
+`.ac DEC`, `.ac OCT`, or `.tran` plan against an existing `Circuit` and
+returns the plan, solver result, and deck-selected output table.
 `resolve_deck_outputs()` and `select_deck_output_probes()` extract `.save` and
 scoped or global `.probe` cards before `.end`, normalize and deduplicate output
 probes in deck order, and feed `format_deck_op_table()`,
@@ -183,7 +183,8 @@ diagnostics for malformed deck-level analysis controls.
 `select_deck_analysis_plan()` returns one selected or implicit plan for
 downstream deck execution helpers.
 `run_deck_analysis()` routes that selected plan into the matching solver and
-stable deck-selected table output.
+stable deck-selected table output, including `.ac LIN`, `.ac DEC`, and
+`.ac OCT` frequency grids.
 
 ## Controlled source examples
 

--- a/code/packages/python/spice-engine/src/spice_engine/engine.py
+++ b/code/packages/python/spice-engine/src/spice_engine/engine.py
@@ -2330,20 +2330,11 @@ def run_deck_analysis(
         )
     if plan.analysis == "ac":
         sweep_kind = _require_deck_plan_string(plan, "sweep_kind")
-        if sweep_kind != "dec":
-            raise ValueError(
-                f"run_deck_analysis: line {plan.line_number}: "
-                f".ac {sweep_kind.upper()} execution is not supported yet"
-            )
         point_count = _require_deck_plan_int(plan, "point_count")
         start_frequency = _require_deck_plan_number(plan, "start_frequency")
         stop_frequency = _require_deck_plan_number(plan, "stop_frequency")
-        result = ac_sweep(
-            circuit,
-            f_start=start_frequency,
-            f_stop=stop_frequency,
-            n_points=point_count,
-            sweep="log",
+        result = _run_deck_ac_sweep(
+            circuit, plan, sweep_kind, point_count, start_frequency, stop_frequency
         )
         return DeckAnalysisExecution(
             plan=plan,
@@ -2389,6 +2380,64 @@ def _require_deck_plan_int(plan: DeckAnalysisPlan, field_name: str) -> int:
     raise ValueError(
         f"run_deck_analysis: line {plan.line_number}: "
         f"{plan.directive} analysis missing {field_name}"
+    )
+
+
+def _run_deck_ac_sweep(
+    circuit: Circuit,
+    plan: DeckAnalysisPlan,
+    sweep_kind: str,
+    point_count: int,
+    start_frequency: float,
+    stop_frequency: float,
+) -> AcResult:
+    frequencies = _deck_ac_frequencies(
+        plan, sweep_kind, point_count, start_frequency, stop_frequency
+    )
+    points: list[AcPoint] = []
+    for frequency in frequencies:
+        points.extend(
+            ac_sweep(
+                circuit,
+                f_start=frequency,
+                f_stop=frequency,
+                n_points=1,
+                sweep="lin",
+            ).points
+        )
+    return AcResult(points=points)
+
+
+def _deck_ac_frequencies(
+    plan: DeckAnalysisPlan,
+    sweep_kind: str,
+    point_count: int,
+    start_frequency: float,
+    stop_frequency: float,
+) -> list[float]:
+    if point_count <= 0:
+        raise ValueError(
+            f"run_deck_analysis: line {plan.line_number}: "
+            ".ac point_count must be positive"
+        )
+    if sweep_kind == "lin":
+        if point_count == 1:
+            return [start_frequency]
+        step = (stop_frequency - start_frequency) / (point_count - 1)
+        return [start_frequency + index * step for index in range(point_count)]
+    if sweep_kind in {"dec", "oct"}:
+        base = 10.0 if sweep_kind == "dec" else 2.0
+        ratio = base ** (1.0 / point_count)
+        epsilon = stop_frequency * 1.0e-12
+        frequencies: list[float] = []
+        frequency = start_frequency
+        while frequency <= stop_frequency + epsilon:
+            frequencies.append(frequency)
+            frequency *= ratio
+        return frequencies
+    raise ValueError(
+        f"run_deck_analysis: line {plan.line_number}: "
+        f".ac {sweep_kind.upper()} execution is not supported yet"
     )
 
 

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -6803,8 +6803,26 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
 
     with pytest.raises(ValueError, match="multiple analysis cards"):
         run_deck_analysis(circuit, netlist)
-    with pytest.raises(ValueError, match="LIN execution is not supported yet"):
-        run_deck_analysis(circuit, ".ac lin 2 1 10\n.end\n")
+
+    lin_execution = run_deck_analysis(circuit, ".save V(mid)\n.ac lin 3 1 3\n.end\n")
+    assert isinstance(lin_execution.result, AcResult)
+    assert [point.freq for point in lin_execution.result.points] == [1.0, 2.0, 3.0]
+    assert lin_execution.table == (
+        "Index\tFrequency\tProbe\tReal\tImaginary\tMagnitude\tPhase\n"
+        "0\t1.000000e+00\tV(mid)\t5.000000e-01\t0.000000e+00\t5.000000e-01\t0.000000e+00\n"
+        "1\t2.000000e+00\tV(mid)\t5.000000e-01\t0.000000e+00\t5.000000e-01\t0.000000e+00\n"
+        "2\t3.000000e+00\tV(mid)\t5.000000e-01\t0.000000e+00\t5.000000e-01\t0.000000e+00\n"
+    )
+
+    oct_execution = run_deck_analysis(circuit, ".save V(mid)\n.ac oct 1 1 4\n.end\n")
+    assert isinstance(oct_execution.result, AcResult)
+    assert [point.freq for point in oct_execution.result.points] == [1.0, 2.0, 4.0]
+    assert oct_execution.table == (
+        "Index\tFrequency\tProbe\tReal\tImaginary\tMagnitude\tPhase\n"
+        "0\t1.000000e+00\tV(mid)\t5.000000e-01\t0.000000e+00\t5.000000e-01\t0.000000e+00\n"
+        "1\t2.000000e+00\tV(mid)\t5.000000e-01\t0.000000e+00\t5.000000e-01\t0.000000e+00\n"
+        "2\t4.000000e+00\tV(mid)\t5.000000e-01\t0.000000e+00\t5.000000e-01\t0.000000e+00\n"
+    )
 
 
 def test_transient_probe_measurements_are_stable() -> None:

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Add `.ac LIN` and `.ac OCT` selected-plan execution routing to
+  `run_deck_analysis`; deck AC plans now execute SPICE-style linear,
+  points-per-decade, and points-per-octave grids, matching Python and
+  TypeScript.
 - Add `run_deck_analysis` so callers can select one deck `.op`, `.dc`,
   `.ac DEC`, or `.tran` plan, execute the matching solver, and receive the
   selected plan, solver result, and deck-selected output table, matching Python

--- a/code/packages/rust/spice-engine/README.md
+++ b/code/packages/rust/spice-engine/README.md
@@ -154,9 +154,9 @@ malformed arguments, unsupported AC sweep modes, invalid sweep intervals, and
 unresolved scalar expressions. `select_deck_analysis_plan` picks one explicit
 card by analysis alias, defaults decks without analysis cards to an implicit
 `.op`, and reports ambiguity before solver dispatch.
-`run_deck_analysis` executes one selected `.op`, `.dc`, `.ac DEC`, or `.tran`
-plan against an existing `Circuit` and returns the plan, solver result, and
-deck-selected output table.
+`run_deck_analysis` executes one selected `.op`, `.dc`, `.ac LIN`, `.ac DEC`,
+`.ac OCT`, or `.tran` plan against an existing `Circuit` and returns the plan,
+solver result, and deck-selected output table.
 `resolve_deck_fourier`, `fourier_transient_cards`, and
 `fourier_transient_deck` extract parsed `.four` / `.FOUR` cards before `.end`
 and route transient samples into the existing SPICE-style Fourier result shape
@@ -196,4 +196,5 @@ malformed deck-level analysis controls.
 `select_deck_analysis_plan` returns one selected or implicit plan for
 downstream deck execution helpers.
 `run_deck_analysis` routes that selected plan into the matching solver and
-stable deck-selected table output.
+stable deck-selected table output, including `.ac LIN`, `.ac DEC`, and
+`.ac OCT` frequency grids.

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -9446,21 +9446,12 @@ pub fn run_deck_analysis(
         "ac" => {
             let sweep_kind =
                 require_deck_plan_string(plan.sweep_kind.as_deref(), &plan, "sweep_kind")?;
-            if sweep_kind != "dec" {
-                return Err(deck_plan_error(
-                    &plan,
-                    format!(
-                        ".ac {} execution is not supported yet",
-                        sweep_kind.to_ascii_uppercase()
-                    ),
-                ));
-            }
             let point_count = require_deck_plan_usize(plan.point_count, &plan, "point_count")?;
             let start =
                 require_deck_plan_number(plan.start_frequency_hz, &plan, "start_frequency_hz")?;
             let stop =
                 require_deck_plan_number(plan.stop_frequency_hz, &plan, "stop_frequency_hz")?;
-            let result = ac_sweep(circuit, start, stop, point_count)?;
+            let result = run_deck_ac_sweep(circuit, &plan, sweep_kind, point_count, start, stop)?;
             let table = format_deck_ac_table(&result, netlist)?;
             Ok(DeckAnalysisExecution {
                 plan,
@@ -9533,6 +9524,74 @@ fn deck_plan_error(plan: &DeckAnalysisPlan, reason: String) -> SpiceError {
     SpiceError::InvalidElement {
         name: "run_deck_analysis".to_string(),
         reason: format!("line {}: {reason}", plan.line_number),
+    }
+}
+
+fn run_deck_ac_sweep(
+    circuit: &Circuit,
+    plan: &DeckAnalysisPlan,
+    sweep_kind: &str,
+    point_count: usize,
+    start_hz: f64,
+    stop_hz: f64,
+) -> Result<Vec<AcPoint>, SpiceError> {
+    let mut points = Vec::new();
+    for frequency_hz in deck_ac_frequencies(plan, sweep_kind, point_count, start_hz, stop_hz)? {
+        let point = ac_sweep(circuit, frequency_hz, frequency_hz, 1)?
+            .into_iter()
+            .next()
+            .ok_or(SpiceError::SingularMatrix)?;
+        points.push(point);
+    }
+    Ok(points)
+}
+
+fn deck_ac_frequencies(
+    plan: &DeckAnalysisPlan,
+    sweep_kind: &str,
+    point_count: usize,
+    start_hz: f64,
+    stop_hz: f64,
+) -> Result<Vec<f64>, SpiceError> {
+    if point_count == 0 {
+        return Err(deck_plan_error(
+            plan,
+            ".ac point_count must be positive".to_string(),
+        ));
+    }
+    match sweep_kind {
+        "lin" => {
+            if point_count == 1 {
+                return Ok(vec![start_hz]);
+            }
+            let step = (stop_hz - start_hz) / (point_count - 1) as f64;
+            Ok((0..point_count)
+                .map(|index| start_hz + index as f64 * step)
+                .collect())
+        }
+        "dec" | "oct" => {
+            let base = if sweep_kind == "dec" {
+                10.0_f64
+            } else {
+                2.0_f64
+            };
+            let ratio = base.powf(1.0 / point_count as f64);
+            let epsilon = stop_hz * 1.0e-12;
+            let mut frequencies = Vec::new();
+            let mut frequency_hz = start_hz;
+            while frequency_hz <= stop_hz + epsilon {
+                frequencies.push(frequency_hz);
+                frequency_hz *= ratio;
+            }
+            Ok(frequencies)
+        }
+        _ => Err(deck_plan_error(
+            plan,
+            format!(
+                ".ac {} execution is not supported yet",
+                sweep_kind.to_ascii_uppercase()
+            ),
+        )),
     }
 }
 

--- a/code/packages/rust/spice-engine/tests/transient_tests.rs
+++ b/code/packages/rust/spice-engine/tests/transient_tests.rs
@@ -1906,10 +1906,40 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
 
     let error = run_deck_analysis(&circuit, netlist, None).unwrap_err();
     assert!(error.to_string().contains("multiple analysis cards"));
-    let error = run_deck_analysis(&circuit, ".ac lin 2 1 10\n.end\n", None).unwrap_err();
-    assert!(error
-        .to_string()
-        .contains("LIN execution is not supported yet"));
+
+    let lin_execution =
+        run_deck_analysis(&circuit, ".save V(mid)\n.ac lin 3 1 3\n.end\n", None).unwrap();
+    match &lin_execution.result {
+        DeckAnalysisExecutionResult::Ac(points) => assert_eq!(
+            points
+                .iter()
+                .map(|point| point.frequency_hz)
+                .collect::<Vec<_>>(),
+            vec![1.0, 2.0, 3.0]
+        ),
+        other => panic!("expected AC result, got {other:?}"),
+    }
+    assert_eq!(
+        lin_execution.table,
+        "Index\tFrequency\tProbe\tReal\tImaginary\tMagnitude\tPhase\n0\t1.000000e+00\tV(mid)\t5.000000e-01\t0.000000e+00\t5.000000e-01\t0.000000e+00\n1\t2.000000e+00\tV(mid)\t5.000000e-01\t0.000000e+00\t5.000000e-01\t0.000000e+00\n2\t3.000000e+00\tV(mid)\t5.000000e-01\t0.000000e+00\t5.000000e-01\t0.000000e+00\n"
+    );
+
+    let oct_execution =
+        run_deck_analysis(&circuit, ".save V(mid)\n.ac oct 1 1 4\n.end\n", None).unwrap();
+    match &oct_execution.result {
+        DeckAnalysisExecutionResult::Ac(points) => assert_eq!(
+            points
+                .iter()
+                .map(|point| point.frequency_hz)
+                .collect::<Vec<_>>(),
+            vec![1.0, 2.0, 4.0]
+        ),
+        other => panic!("expected AC result, got {other:?}"),
+    }
+    assert_eq!(
+        oct_execution.table,
+        "Index\tFrequency\tProbe\tReal\tImaginary\tMagnitude\tPhase\n0\t1.000000e+00\tV(mid)\t5.000000e-01\t0.000000e+00\t5.000000e-01\t0.000000e+00\n1\t2.000000e+00\tV(mid)\t5.000000e-01\t0.000000e+00\t5.000000e-01\t0.000000e+00\n2\t4.000000e+00\tV(mid)\t5.000000e-01\t0.000000e+00\t5.000000e-01\t0.000000e+00\n"
+    );
 }
 
 #[test]

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Add `.ac LIN` and `.ac OCT` selected-plan execution routing to
+  `runDeckAnalysis`; deck AC plans now execute SPICE-style linear,
+  points-per-decade, and points-per-octave grids, matching Python and Rust.
 - Add `runDeckAnalysis` so callers can select one deck `.op`, `.dc`,
   `.ac DEC`, or `.tran` plan, execute the matching solver, and receive the
   selected plan, solver result, and deck-selected output table, matching

--- a/code/packages/typescript/spice-engine/README.md
+++ b/code/packages/typescript/spice-engine/README.md
@@ -88,9 +88,9 @@ malformed arguments, unsupported AC sweep modes, invalid sweep intervals, and
 unresolved scalar expressions. `selectDeckAnalysisPlan` picks one explicit card
 by analysis alias, defaults decks without analysis cards to an implicit `.op`,
 and reports ambiguity before solver dispatch.
-`runDeckAnalysis` executes one selected `.op`, `.dc`, `.ac DEC`, or `.tran`
-plan against an existing `Circuit` and returns the plan, solver result, and
-deck-selected output table.
+`runDeckAnalysis` executes one selected `.op`, `.dc`, `.ac LIN`, `.ac DEC`,
+`.ac OCT`, or `.tran` plan against an existing `Circuit` and returns the plan,
+solver result, and deck-selected output table.
 `resolveDeckOutputs` and `selectDeckOutputProbes` extract `.save` and scoped
 or global `.probe` cards before `.end`, normalize and deduplicate output
 probes in deck order, and feed `formatDeckOpTable`,
@@ -159,4 +159,5 @@ malformed deck-level analysis controls.
 `selectDeckAnalysisPlan` returns one selected or implicit plan for downstream
 deck execution helpers.
 `runDeckAnalysis` routes that selected plan into the matching solver and stable
-deck-selected table output.
+deck-selected table output, including `.ac LIN`, `.ac DEC`, and `.ac OCT`
+frequency grids.

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -7270,12 +7270,6 @@ export function runDeckAnalysis(
   }
   if (plan.analysis === "ac") {
     const sweepKind = requireDeckPlanString(plan.sweepKind, plan, "sweepKind");
-    if (sweepKind !== "dec") {
-      throw invalidElement(
-        "runDeckAnalysis",
-        `line ${plan.lineNumber}: .ac ${sweepKind.toUpperCase()} execution is not supported yet`,
-      );
-    }
     const pointCount = requireDeckPlanInteger(plan.pointCount, plan, "pointCount");
     const startFrequencyHz = requireDeckPlanNumber(
       plan.startFrequencyHz,
@@ -7283,7 +7277,14 @@ export function runDeckAnalysis(
       "startFrequencyHz",
     );
     const stopFrequencyHz = requireDeckPlanNumber(plan.stopFrequencyHz, plan, "stopFrequencyHz");
-    const result = acSweep(circuit, startFrequencyHz, stopFrequencyHz, pointCount);
+    const result = runDeckAcSweep(
+      circuit,
+      plan,
+      sweepKind,
+      pointCount,
+      startFrequencyHz,
+      stopFrequencyHz,
+    );
     return { plan, result, table: formatDeckAcTable(result, netlist) };
   }
   if (plan.analysis === "tran") {
@@ -7334,6 +7335,68 @@ function requireDeckPlanInteger(
   throw invalidElement(
     "runDeckAnalysis",
     `line ${plan.lineNumber}: ${plan.directive} analysis missing ${fieldName}`,
+  );
+}
+
+function runDeckAcSweep(
+  circuit: Circuit,
+  plan: DeckAnalysisPlan,
+  sweepKind: string,
+  pointCount: number,
+  startFrequencyHz: number,
+  stopFrequencyHz: number,
+): AcPoint[] {
+  return deckAcFrequencies(plan, sweepKind, pointCount, startFrequencyHz, stopFrequencyHz).map(
+    (frequencyHz) => {
+      const point = acSweep(circuit, frequencyHz, frequencyHz, 1)[0];
+      if (point === undefined) {
+        throw invalidElement(
+          "runDeckAnalysis",
+          `line ${plan.lineNumber}: .ac ${sweepKind.toUpperCase()} produced no samples`,
+        );
+      }
+      return point;
+    },
+  );
+}
+
+function deckAcFrequencies(
+  plan: DeckAnalysisPlan,
+  sweepKind: string,
+  pointCount: number,
+  startFrequencyHz: number,
+  stopFrequencyHz: number,
+): number[] {
+  if (pointCount <= 0) {
+    throw invalidElement(
+      "runDeckAnalysis",
+      `line ${plan.lineNumber}: .ac pointCount must be positive`,
+    );
+  }
+  if (sweepKind === "lin") {
+    if (pointCount === 1) {
+      return [startFrequencyHz];
+    }
+    const step = (stopFrequencyHz - startFrequencyHz) / (pointCount - 1);
+    return Array.from({ length: pointCount }, (_value, index) => startFrequencyHz + index * step);
+  }
+  if (sweepKind === "dec" || sweepKind === "oct") {
+    const base = sweepKind === "dec" ? 10.0 : 2.0;
+    const ratio = base ** (1.0 / pointCount);
+    const epsilon = stopFrequencyHz * 1.0e-12;
+    const frequencies: number[] = [];
+    for (
+      let frequencyHz = startFrequencyHz;
+      frequencyHz <= stopFrequencyHz + epsilon;
+      frequencyHz *= ratio
+    ) {
+      frequencies.push(frequencyHz);
+    }
+    return frequencies;
+  }
+  throw invalidElement(
+    "runDeckAnalysis",
+    `line ${plan.lineNumber}: .ac ${sweepKind.toUpperCase()} execution is not supported yet`,
   );
 }
 

--- a/code/packages/typescript/spice-engine/tests/transient.test.ts
+++ b/code/packages/typescript/spice-engine/tests/transient.test.ts
@@ -1477,8 +1477,25 @@ describe("transient", () => {
     );
 
     expect(() => runDeckAnalysis(circuit, netlist)).toThrow(/multiple analysis cards/);
-    expect(() => runDeckAnalysis(circuit, ".ac lin 2 1 10\n.end\n")).toThrow(
-      /LIN execution is not supported yet/,
+
+    const linExecution = runDeckAnalysis(circuit, ".save V(mid)\n.ac lin 3 1 3\n.end\n");
+    const linPoints = linExecution.result as { frequencyHz: number }[];
+    expect(linPoints.map((point) => point.frequencyHz)).toEqual([1.0, 2.0, 3.0]);
+    expect(linExecution.table).toBe(
+      "Index\tFrequency\tProbe\tReal\tImaginary\tMagnitude\tPhase\n" +
+        "0\t1.000000e+00\tV(mid)\t5.000000e-01\t0.000000e+00\t5.000000e-01\t0.000000e+00\n" +
+        "1\t2.000000e+00\tV(mid)\t5.000000e-01\t0.000000e+00\t5.000000e-01\t0.000000e+00\n" +
+        "2\t3.000000e+00\tV(mid)\t5.000000e-01\t0.000000e+00\t5.000000e-01\t0.000000e+00\n",
+    );
+
+    const octExecution = runDeckAnalysis(circuit, ".save V(mid)\n.ac oct 1 1 4\n.end\n");
+    const octPoints = octExecution.result as { frequencyHz: number }[];
+    expect(octPoints.map((point) => point.frequencyHz)).toEqual([1.0, 2.0, 4.0]);
+    expect(octExecution.table).toBe(
+      "Index\tFrequency\tProbe\tReal\tImaginary\tMagnitude\tPhase\n" +
+        "0\t1.000000e+00\tV(mid)\t5.000000e-01\t0.000000e+00\t5.000000e-01\t0.000000e+00\n" +
+        "1\t2.000000e+00\tV(mid)\t5.000000e-01\t0.000000e+00\t5.000000e-01\t0.000000e+00\n" +
+        "2\t4.000000e+00\tV(mid)\t5.000000e-01\t0.000000e+00\t5.000000e-01\t0.000000e+00\n",
     );
   });
 

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -48,8 +48,8 @@ downstream tools to compare.
      controls; parsed `.op`, `.dc`, `.ac`, and `.tran` cards now resolve into
      shared cross-language analysis-plan metadata before execution, and callers
      can select one explicit or implicit plan with stable ambiguity errors and
-     route `.op`, `.dc`, `.ac DEC`, or `.tran` into the matching solver plus
-     deck-selected table output.
+     route `.op`, `.dc`, `.ac LIN`, `.ac DEC`, `.ac OCT`, or `.tran` into the
+     matching solver plus deck-selected table output.
    - Expand remaining deck-controlled analyses toward full SPICE compatibility
      while keeping unsupported control-flow diagnostics explicit.
 
@@ -399,12 +399,21 @@ downstream tools to compare.
       explicitly reports unsupported `.ac LIN` / `.ac OCT` execution modes for
       future solver-grid expansion.
 
+34. Deck AC LIN/OCT execution routing.
+    - Status: completed in this deck AC grid routing slice.
+    - Python, Rust, and TypeScript now route selected `.ac LIN`, `.ac DEC`, and
+      `.ac OCT` plans through matching solver executions and deck-selected AC
+      table output.
+    - The execution bridge uses SPICE-style linear total-point grids,
+      points-per-decade grids, and points-per-octave grids while preserving
+      selected-plan ambiguity and invalid-card diagnostics.
+
 ## Backlog
 
 1. Deck execution layer.
-   - Expand selected-plan execution beyond `.ac DEC` and fixed-step transient
-     basics, including `.ac LIN` / `.ac OCT`, transient `START` / `MAXSTEP` /
-     `UIC` execution semantics, and richer deck-owned run artifacts.
+   - Expand selected-plan execution beyond fixed-step transient basics,
+     including transient `START` / `MAXSTEP` / `UIC` execution semantics and
+     richer deck-owned run artifacts.
    - Expand deck-controlled output-plan integration beyond stable table
      routing toward full SPICE compatibility.
    - Define a deliberate `.control` subset; explicit unsupported-feature


### PR DESCRIPTION
## Summary
- route selected `.ac LIN`, `.ac DEC`, and `.ac OCT` deck plans through matching solver executions in Python, Rust, and TypeScript
- add shared deck AC frequency-grid semantics for linear total-point, points-per-decade, and points-per-octave sweeps
- document the completed slice and leave transient START/MAXSTEP/UIC execution semantics in backlog

## Verification
- `PYTHONPATH="$(find code/packages/python -maxdepth 2 -type d -name src | paste -sd: -)" /Users/adhithya/.local/share/mise/installs/python/3.12.13/bin/python3 -m ruff check code/packages/python/spice-engine/src/spice_engine/engine.py code/packages/python/spice-engine/tests/test_engine.py`
- `PYTHONPATH="$(find code/packages/python -maxdepth 2 -type d -name src | paste -sd: -)" /Users/adhithya/.local/share/mise/installs/python/3.12.13/bin/python3 -m pytest code/packages/python/spice-engine/tests -q --no-cov`
- `npm --prefix code/packages/typescript/spice-engine ci`
- `npm --prefix code/packages/typescript/spice-engine run build`
- `npm --prefix code/packages/typescript/spice-engine test`
- `cargo fmt --manifest-path code/packages/rust/spice-engine/Cargo.toml --check`
- `cargo test --manifest-path code/packages/rust/spice-engine/Cargo.toml`
- `git diff --check`
- `git diff --cached --check`