### PR TITLE
fix(mycin): REL-9 — spider args propagation (incremental skip-list now works)

### DIFF
--- a/code/specs/data/mycin-2026/recall/ground-iem-edges.workflow.js
+++ b/code/specs/data/mycin-2026/recall/ground-iem-edges.workflow.js
@@ -135,12 +135,23 @@ const VERIFY_SCHEMA = {
   },
 }
 
-// INCREMENTAL grounding (REL-8): the caller passes `args` = an array of edge ids
-// already grounded (the Workflow sandbox has no filesystem, so the skip-list is
-// injected, not read from iem-edge-grounding.json). Those edges are skipped so a
-// re-run only grounds the new / not-yet-grounded edges — no wasted re-fetching of
-// the 16 already-authoritative ones. With no args, every edge is grounded.
-const skip = new Set(Array.isArray(args) ? args : [])
+// INCREMENTAL grounding (REL-8, fixed REL-9): the caller passes `args` = an array
+// of edge ids already grounded (the Workflow sandbox has no filesystem, so the
+// skip-list is injected, not read from iem-edge-grounding.json). Those edges are
+// skipped so a re-run only grounds the new / not-yet-grounded edges — no wasted
+// re-fetching of already-authoritative ones. With no args, every edge is grounded.
+//
+// The runtime may deliver `args` either as a parsed array OR as a JSON-ENCODED
+// STRING (REL-8 saw the string form, so `Array.isArray` was false and nothing was
+// skipped). Normalise: parse a string, accept an array, else empty.
+function _skipList(a) {
+  if (Array.isArray(a)) return a
+  if (typeof a === 'string') {
+    try { const p = JSON.parse(a); return Array.isArray(p) ? p : [] } catch { return [] }
+  }
+  return []
+}
+const skip = new Set(_skipList(args))
 const todo = EDGES.filter((e) => !skip.has(e.id))
 log(`grounding ${todo.length} edge(s); skipping ${skip.size} already grounded`)
 


### PR DESCRIPTION
## What

Fixes the incremental-spider `args` bug REL-8 flagged honestly ("skipping 0").

## Root cause (found with a zero-cost probe)

A tiny no-agent probe workflow revealed the Workflow runtime delivers `args` as a **JSON-encoded string**, not a parsed array — so `Array.isArray(args)` was `false` and the skip-set stayed empty:

```
probe → {"received_args":"[\"alpha\",\"beta\",\"gamma\"]","is_array":false,"arg_count":0}
```

## Fix

A `_skipList(a)` normaliser in `ground-iem-edges.workflow.js`: parse a string arg (try/catch), accept an array, else `[]`.

Verified with a second zero-cost probe (no agents, no web) — `args=["a","c"]` over edges `a/b/c/d`:
```
probe → {"raw_typeof":"string","skip_size":2,"todo_ids":["b","d"]}
```
The skip-list now works: a re-run skips already-grounded edges and grounds only the new/changed ones, so future re-grounds cost only what changed instead of the full set.

## Verification

- Two zero-cost probe workflows (0 agents, 0 tokens) confirm the bug and the fix.
- `/security-review` **PASSED** — `JSON.parse` (not a code-execution sink) in try/catch, result used only for `Set.has` membership; no injection/prototype-pollution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)