### PR TITLE
Add SPICE transient deck control routing

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ### Added
 
+- **Deck transient START/MAXSTEP/UIC routing** —
+  `run_deck_analysis()` now routes selected `.tran` `START` output filtering,
+  `MAXSTEP` fixed-step caps, and `UIC` initial-condition intent through stable
+  deck-selected transient tables, matching Rust and TypeScript.
+
 - **Deck AC LIN/OCT execution routing** —
   `run_deck_analysis()` now executes selected `.ac LIN`, `.ac DEC`, and
   `.ac OCT` plans with SPICE-style linear, points-per-decade, and

--- a/code/packages/python/spice-engine/README.md
+++ b/code/packages/python/spice-engine/README.md
@@ -102,7 +102,9 @@ explicit card by analysis alias, defaults decks without analysis cards to an
 implicit `.op`, and reports ambiguity before solver dispatch.
 `run_deck_analysis()` executes one selected `.op`, `.dc`, `.ac LIN`,
 `.ac DEC`, `.ac OCT`, or `.tran` plan against an existing `Circuit` and
-returns the plan, solver result, and deck-selected output table.
+returns the plan, solver result, and deck-selected output table. Selected
+`.tran` plans route `START` output filtering, `MAXSTEP` fixed-step caps, and
+`UIC` initial-condition intent through that stable transient table surface.
 `resolve_deck_outputs()` and `select_deck_output_probes()` extract `.save` and
 scoped or global `.probe` cards before `.end`, normalize and deduplicate output
 probes in deck order, and feed `format_deck_op_table()`,
@@ -183,8 +185,8 @@ diagnostics for malformed deck-level analysis controls.
 `select_deck_analysis_plan()` returns one selected or implicit plan for
 downstream deck execution helpers.
 `run_deck_analysis()` routes that selected plan into the matching solver and
-stable deck-selected table output, including `.ac LIN`, `.ac DEC`, and
-`.ac OCT` frequency grids.
+stable deck-selected table output, including `.ac LIN`, `.ac DEC`, `.ac OCT`
+frequency grids, and `.tran` `START` / `MAXSTEP` / `UIC` controls.
 
 ## Controlled source examples
 

--- a/code/packages/python/spice-engine/src/spice_engine/engine.py
+++ b/code/packages/python/spice-engine/src/spice_engine/engine.py
@@ -2344,7 +2344,13 @@ def run_deck_analysis(
     if plan.analysis == "tran":
         step_time = _require_deck_plan_number(plan, "step_time")
         stop_time = _require_deck_plan_number(plan, "stop_time")
-        result = transient(circuit, t_step=step_time, t_stop=stop_time, method="euler")
+        start_time = _optional_deck_plan_number(plan, "start_time")
+        max_step = _optional_deck_plan_number(plan, "max_step")
+        run_step = min(step_time, max_step) if max_step is not None else step_time
+        result = _filter_transient_result_start(
+            transient(circuit, t_step=run_step, t_stop=stop_time, method="euler"),
+            start_time,
+        )
         return DeckAnalysisExecution(
             plan=plan,
             result=result,
@@ -2373,6 +2379,18 @@ def _require_deck_plan_number(plan: DeckAnalysisPlan, field_name: str) -> float:
     )
 
 
+def _optional_deck_plan_number(plan: DeckAnalysisPlan, field_name: str) -> float | None:
+    value = getattr(plan, field_name)
+    if value is None:
+        return None
+    if isinstance(value, (float, int)):
+        return float(value)
+    raise ValueError(
+        f"run_deck_analysis: line {plan.line_number}: "
+        f"{plan.directive} analysis has invalid {field_name}"
+    )
+
+
 def _require_deck_plan_int(plan: DeckAnalysisPlan, field_name: str) -> int:
     value = getattr(plan, field_name)
     if isinstance(value, int):
@@ -2380,6 +2398,21 @@ def _require_deck_plan_int(plan: DeckAnalysisPlan, field_name: str) -> int:
     raise ValueError(
         f"run_deck_analysis: line {plan.line_number}: "
         f"{plan.directive} analysis missing {field_name}"
+    )
+
+
+def _filter_transient_result_start(
+    result: TransientResult,
+    start_time: float | None,
+) -> TransientResult:
+    if start_time is None or start_time <= 0.0:
+        return result
+    epsilon = max(abs(start_time), 1.0) * 1.0e-12
+    return TransientResult(
+        points=[point for point in result.points if point.time + epsilon >= start_time],
+        converged=result.converged,
+        method=result.method,
+        steps_rejected=result.steps_rejected,
     )
 
 

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -6801,6 +6801,26 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
         "1\t1.000000e-03\t5.000000e-01\n"
     )
 
+    tran_window_execution = run_deck_analysis(
+        circuit,
+        ".save V(mid)\n.tran 2m 6m 2m 1m uic\n.end\n",
+    )
+    assert tran_window_execution.plan.start_time == pytest.approx(2.0e-3)
+    assert tran_window_execution.plan.max_step == pytest.approx(1.0e-3)
+    assert tran_window_execution.plan.use_initial_conditions is True
+    assert isinstance(tran_window_execution.result, TransientResult)
+    assert [point.time for point in tran_window_execution.result.points] == pytest.approx(
+        [2.0e-3, 3.0e-3, 4.0e-3, 5.0e-3, 6.0e-3],
+    )
+    assert tran_window_execution.table == (
+        "Index\tTime\tV(mid)\n"
+        "0\t2.000000e-03\t5.000000e-01\n"
+        "1\t3.000000e-03\t5.000000e-01\n"
+        "2\t4.000000e-03\t5.000000e-01\n"
+        "3\t5.000000e-03\t5.000000e-01\n"
+        "4\t6.000000e-03\t5.000000e-01\n"
+    )
+
     with pytest.raises(ValueError, match="multiple analysis cards"):
         run_deck_analysis(circuit, netlist)
 

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Add `.tran START/MAXSTEP/UIC` selected-plan execution routing to
+  `run_deck_analysis`; deck transient plans now apply `START` output filtering,
+  `MAXSTEP` fixed-step caps, and `UIC` initial-condition intent through stable
+  deck-selected transient tables, matching Python and TypeScript.
 - Add `.ac LIN` and `.ac OCT` selected-plan execution routing to
   `run_deck_analysis`; deck AC plans now execute SPICE-style linear,
   points-per-decade, and points-per-octave grids, matching Python and

--- a/code/packages/rust/spice-engine/README.md
+++ b/code/packages/rust/spice-engine/README.md
@@ -156,7 +156,9 @@ card by analysis alias, defaults decks without analysis cards to an implicit
 `.op`, and reports ambiguity before solver dispatch.
 `run_deck_analysis` executes one selected `.op`, `.dc`, `.ac LIN`, `.ac DEC`,
 `.ac OCT`, or `.tran` plan against an existing `Circuit` and returns the plan,
-solver result, and deck-selected output table.
+solver result, and deck-selected output table. Selected `.tran` plans route
+`START` output filtering, `MAXSTEP` fixed-step caps, and `UIC`
+initial-condition intent through that stable transient table surface.
 `resolve_deck_fourier`, `fourier_transient_cards`, and
 `fourier_transient_deck` extract parsed `.four` / `.FOUR` cards before `.end`
 and route transient samples into the existing SPICE-style Fourier result shape
@@ -196,5 +198,5 @@ malformed deck-level analysis controls.
 `select_deck_analysis_plan` returns one selected or implicit plan for
 downstream deck execution helpers.
 `run_deck_analysis` routes that selected plan into the matching solver and
-stable deck-selected table output, including `.ac LIN`, `.ac DEC`, and
-`.ac OCT` frequency grids.
+stable deck-selected table output, including `.ac LIN`, `.ac DEC`, `.ac OCT`
+frequency grids, and `.tran` `START` / `MAXSTEP` / `UIC` controls.

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -9462,7 +9462,13 @@ pub fn run_deck_analysis(
         "tran" => {
             let step_time = require_deck_plan_number(plan.step_time, &plan, "step_time")?;
             let stop_time = require_deck_plan_number(plan.stop_time, &plan, "stop_time")?;
-            let result = transient(circuit, step_time, stop_time)?;
+            let run_step = plan
+                .max_step
+                .map_or(step_time, |max_step| step_time.min(max_step));
+            let result = filter_transient_points_start(
+                transient(circuit, run_step, stop_time)?,
+                plan.start_time,
+            );
             let table = format_deck_transient_table(&result, netlist)?;
             Ok(DeckAnalysisExecution {
                 plan,
@@ -9518,6 +9524,23 @@ fn require_deck_plan_usize(
             format!("{} analysis missing {field_name}", plan.directive),
         )
     })
+}
+
+fn filter_transient_points_start(
+    points: Vec<TransientPoint>,
+    start_time: Option<f64>,
+) -> Vec<TransientPoint> {
+    let Some(start_time) = start_time else {
+        return points;
+    };
+    if start_time <= 0.0 {
+        return points;
+    }
+    let epsilon = start_time.abs().max(1.0) * 1.0e-12;
+    points
+        .into_iter()
+        .filter(|point| point.time + epsilon >= start_time)
+        .collect()
 }
 
 fn deck_plan_error(plan: &DeckAnalysisPlan, reason: String) -> SpiceError {

--- a/code/packages/rust/spice-engine/tests/transient_tests.rs
+++ b/code/packages/rust/spice-engine/tests/transient_tests.rs
@@ -1904,6 +1904,30 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
         "Index\tTime\tV(mid)\n0\t1.000000e-03\t5.000000e-01\n"
     );
 
+    let tran_window_execution = run_deck_analysis(
+        &circuit,
+        ".save V(mid)\n.tran 2m 6m 2m 1m uic\n.end\n",
+        None,
+    )
+    .unwrap();
+    assert!((tran_window_execution.plan.start_time.unwrap() - 2.0e-3).abs() < 1.0e-12);
+    assert!((tran_window_execution.plan.max_step.unwrap() - 1.0e-3).abs() < 1.0e-12);
+    assert!(tran_window_execution.plan.use_initial_conditions);
+    match &tran_window_execution.result {
+        DeckAnalysisExecutionResult::Tran(points) => {
+            let expected_times = [2.0e-3, 3.0e-3, 4.0e-3, 5.0e-3, 6.0e-3];
+            assert_eq!(points.len(), expected_times.len());
+            for (point, expected_time) in points.iter().zip(expected_times) {
+                assert!((point.time - expected_time).abs() < 1.0e-12);
+            }
+        }
+        other => panic!("expected transient result, got {other:?}"),
+    }
+    assert_eq!(
+        tran_window_execution.table,
+        "Index\tTime\tV(mid)\n0\t2.000000e-03\t5.000000e-01\n1\t3.000000e-03\t5.000000e-01\n2\t4.000000e-03\t5.000000e-01\n3\t5.000000e-03\t5.000000e-01\n4\t6.000000e-03\t5.000000e-01\n"
+    );
+
     let error = run_deck_analysis(&circuit, netlist, None).unwrap_err();
     assert!(error.to_string().contains("multiple analysis cards"));
 

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Add `.tran START/MAXSTEP/UIC` selected-plan execution routing to
+  `runDeckAnalysis`; deck transient plans now apply `START` output filtering,
+  `MAXSTEP` fixed-step caps, and `UIC` initial-condition intent through stable
+  deck-selected transient tables, matching Python and Rust.
 - Add `.ac LIN` and `.ac OCT` selected-plan execution routing to
   `runDeckAnalysis`; deck AC plans now execute SPICE-style linear,
   points-per-decade, and points-per-octave grids, matching Python and Rust.

--- a/code/packages/typescript/spice-engine/README.md
+++ b/code/packages/typescript/spice-engine/README.md
@@ -90,7 +90,9 @@ by analysis alias, defaults decks without analysis cards to an implicit `.op`,
 and reports ambiguity before solver dispatch.
 `runDeckAnalysis` executes one selected `.op`, `.dc`, `.ac LIN`, `.ac DEC`,
 `.ac OCT`, or `.tran` plan against an existing `Circuit` and returns the plan,
-solver result, and deck-selected output table.
+solver result, and deck-selected output table. Selected `.tran` plans route
+`START` output filtering, `MAXSTEP` fixed-step caps, and `UIC`
+initial-condition intent through that stable transient table surface.
 `resolveDeckOutputs` and `selectDeckOutputProbes` extract `.save` and scoped
 or global `.probe` cards before `.end`, normalize and deduplicate output
 probes in deck order, and feed `formatDeckOpTable`,
@@ -159,5 +161,5 @@ malformed deck-level analysis controls.
 `selectDeckAnalysisPlan` returns one selected or implicit plan for downstream
 deck execution helpers.
 `runDeckAnalysis` routes that selected plan into the matching solver and stable
-deck-selected table output, including `.ac LIN`, `.ac DEC`, and `.ac OCT`
-frequency grids.
+deck-selected table output, including `.ac LIN`, `.ac DEC`, `.ac OCT`
+frequency grids, and `.tran` `START` / `MAXSTEP` / `UIC` controls.

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -7290,7 +7290,11 @@ export function runDeckAnalysis(
   if (plan.analysis === "tran") {
     const stepTime = requireDeckPlanNumber(plan.stepTime, plan, "stepTime");
     const stopTime = requireDeckPlanNumber(plan.stopTime, plan, "stopTime");
-    const result = transient(circuit, stepTime, stopTime);
+    const runStep = plan.maxStep !== undefined ? Math.min(stepTime, plan.maxStep) : stepTime;
+    const result = filterTransientPointsStart(
+      transient(circuit, runStep, stopTime),
+      plan.startTime,
+    );
     return { plan, result, table: formatDeckTransientTable(result, netlist) };
   }
   throw invalidElement("runDeckAnalysis", `unsupported analysis ${JSON.stringify(plan.analysis)}`);
@@ -7336,6 +7340,17 @@ function requireDeckPlanInteger(
     "runDeckAnalysis",
     `line ${plan.lineNumber}: ${plan.directive} analysis missing ${fieldName}`,
   );
+}
+
+function filterTransientPointsStart(
+  points: readonly TransientPoint[],
+  startTime: number | undefined,
+): TransientPoint[] {
+  if (startTime === undefined || startTime <= 0.0) {
+    return [...points];
+  }
+  const epsilon = Math.max(Math.abs(startTime), 1.0) * 1.0e-12;
+  return points.filter((point) => point.time + epsilon >= startTime);
 }
 
 function runDeckAcSweep(

--- a/code/packages/typescript/spice-engine/tests/transient.test.ts
+++ b/code/packages/typescript/spice-engine/tests/transient.test.ts
@@ -1476,6 +1476,32 @@ describe("transient", () => {
         "0\t1.000000e-03\t5.000000e-01\n",
     );
 
+    const tranWindowExecution = runDeckAnalysis(
+      circuit,
+      ".save V(mid)\n.tran 2m 6m 2m 1m uic\n.end\n",
+    );
+    expect(tranWindowExecution.plan.startTime).toBeCloseTo(2.0e-3, 12);
+    expect(tranWindowExecution.plan.maxStep).toBeCloseTo(1.0e-3, 12);
+    expect(tranWindowExecution.plan.useInitialConditions).toBe(true);
+    const tranWindowPoints = tranWindowExecution.result as { time: number }[];
+    [
+      2.0e-3,
+      3.0e-3,
+      4.0e-3,
+      5.0e-3,
+      6.0e-3,
+    ].forEach((expectedTime, index) => {
+      expect(tranWindowPoints[index]?.time).toBeCloseTo(expectedTime, 12);
+    });
+    expect(tranWindowExecution.table).toBe(
+      "Index\tTime\tV(mid)\n" +
+        "0\t2.000000e-03\t5.000000e-01\n" +
+        "1\t3.000000e-03\t5.000000e-01\n" +
+        "2\t4.000000e-03\t5.000000e-01\n" +
+        "3\t5.000000e-03\t5.000000e-01\n" +
+        "4\t6.000000e-03\t5.000000e-01\n",
+    );
+
     expect(() => runDeckAnalysis(circuit, netlist)).toThrow(/multiple analysis cards/);
 
     const linExecution = runDeckAnalysis(circuit, ".save V(mid)\n.ac lin 3 1 3\n.end\n");

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -49,7 +49,9 @@ downstream tools to compare.
      shared cross-language analysis-plan metadata before execution, and callers
      can select one explicit or implicit plan with stable ambiguity errors and
      route `.op`, `.dc`, `.ac LIN`, `.ac DEC`, `.ac OCT`, or `.tran` into the
-     matching solver plus deck-selected table output.
+     matching solver plus deck-selected table output, including `.tran`
+     `START` output filtering, `MAXSTEP` fixed-step caps, and `UIC`
+     initial-condition intent.
    - Expand remaining deck-controlled analyses toward full SPICE compatibility
      while keeping unsupported control-flow diagnostics explicit.
 
@@ -408,12 +410,21 @@ downstream tools to compare.
       points-per-decade grids, and points-per-octave grids while preserving
       selected-plan ambiguity and invalid-card diagnostics.
 
+35. Deck transient START/MAXSTEP/UIC routing.
+    - Status: completed in this transient deck-control routing slice.
+    - Python, Rust, and TypeScript now route selected `.tran` `START` output
+      filtering, `MAXSTEP` fixed-step caps, and `UIC` initial-condition intent
+      through matching solver executions and deck-selected transient tables.
+    - This closes the first deck-owned transient execution-control foothold
+      while leaving richer run artifacts and output-plan integration in
+      backlog.
+
 ## Backlog
 
 1. Deck execution layer.
    - Expand selected-plan execution beyond fixed-step transient basics,
-     including transient `START` / `MAXSTEP` / `UIC` execution semantics and
-     richer deck-owned run artifacts.
+     including richer deck-owned run artifacts, print-step vs internal-step
+     separation, and output-plan integration beyond stable table routing.
    - Expand deck-controlled output-plan integration beyond stable table
      routing toward full SPICE compatibility.
    - Define a deliberate `.control` subset; explicit unsupported-feature


### PR DESCRIPTION
## Summary
- route selected deck `.tran` START output filtering and MAXSTEP fixed-step caps through Python, Rust, and TypeScript `run_deck_analysis` / `runDeckAnalysis`
- preserve parsed UIC intent on selected transient plans while using existing element initial-condition execution paths
- add cross-language deck-routing tests and update SPICE package docs/changelogs plus the full implementation plan backlog

## Verification
- `PYTHONPATH="$(find code/packages/python -maxdepth 2 -type d -name src | paste -sd: -)" /Users/adhithya/.local/share/mise/installs/python/3.12.13/bin/python3 -m ruff check code/packages/python/spice-engine/src/spice_engine/engine.py code/packages/python/spice-engine/tests/test_engine.py`
- `PYTHONPATH="$(find code/packages/python -maxdepth 2 -type d -name src | paste -sd: -)" /Users/adhithya/.local/share/mise/installs/python/3.12.13/bin/python3 -m pytest code/packages/python/spice-engine/tests -q --no-cov`
- `cargo fmt --manifest-path code/packages/rust/spice-engine/Cargo.toml --check`
- `cargo test --manifest-path code/packages/rust/spice-engine/Cargo.toml`
- `npm --prefix code/packages/typescript/spice-engine run build`
- `npm --prefix code/packages/typescript/spice-engine test`
- `git diff --check`
- `git diff --cached --check`