### PR TITLE
Add SPICE transient print-step deck routing

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ### Added
 
+- **Deck transient print-step output routing** —
+  `run_deck_analysis()` now keeps `.tran TSTEP` as the stable deck output
+  print grid while `MAXSTEP` caps internal solver stepping, matching Rust and
+  TypeScript.
+
 - **Deck transient START/MAXSTEP/UIC routing** —
   `run_deck_analysis()` now routes selected `.tran` `START` output filtering,
   `MAXSTEP` fixed-step caps, and `UIC` initial-condition intent through stable

--- a/code/packages/python/spice-engine/README.md
+++ b/code/packages/python/spice-engine/README.md
@@ -103,8 +103,9 @@ implicit `.op`, and reports ambiguity before solver dispatch.
 `run_deck_analysis()` executes one selected `.op`, `.dc`, `.ac LIN`,
 `.ac DEC`, `.ac OCT`, or `.tran` plan against an existing `Circuit` and
 returns the plan, solver result, and deck-selected output table. Selected
-`.tran` plans route `START` output filtering, `MAXSTEP` fixed-step caps, and
-`UIC` initial-condition intent through that stable transient table surface.
+`.tran` plans route `START` output filtering, use `.tran TSTEP` as the output
+print grid, apply `MAXSTEP` as an internal fixed-step cap, and carry `UIC`
+initial-condition intent through that stable transient table surface.
 `resolve_deck_outputs()` and `select_deck_output_probes()` extract `.save` and
 scoped or global `.probe` cards before `.end`, normalize and deduplicate output
 probes in deck order, and feed `format_deck_op_table()`,
@@ -186,7 +187,8 @@ diagnostics for malformed deck-level analysis controls.
 downstream deck execution helpers.
 `run_deck_analysis()` routes that selected plan into the matching solver and
 stable deck-selected table output, including `.ac LIN`, `.ac DEC`, `.ac OCT`
-frequency grids, and `.tran` `START` / `MAXSTEP` / `UIC` controls.
+frequency grids, and `.tran` `START` / print-step `TSTEP` / `MAXSTEP` / `UIC`
+controls.
 
 ## Controlled source examples
 

--- a/code/packages/python/spice-engine/src/spice_engine/engine.py
+++ b/code/packages/python/spice-engine/src/spice_engine/engine.py
@@ -2347,9 +2347,11 @@ def run_deck_analysis(
         start_time = _optional_deck_plan_number(plan, "start_time")
         max_step = _optional_deck_plan_number(plan, "max_step")
         run_step = min(step_time, max_step) if max_step is not None else step_time
-        result = _filter_transient_result_start(
+        result = _sample_transient_result_print_step(
             transient(circuit, t_step=run_step, t_stop=stop_time, method="euler"),
-            start_time,
+            step_time,
+            start_time=start_time,
+            stop_time=stop_time,
         )
         return DeckAnalysisExecution(
             plan=plan,
@@ -2401,19 +2403,85 @@ def _require_deck_plan_int(plan: DeckAnalysisPlan, field_name: str) -> int:
     )
 
 
-def _filter_transient_result_start(
+def _sample_transient_result_print_step(
     result: TransientResult,
+    print_step: float,
+    *,
     start_time: float | None,
+    stop_time: float,
 ) -> TransientResult:
-    if start_time is None or start_time <= 0.0:
+    if not result.points:
         return result
-    epsilon = max(abs(start_time), 1.0) * 1.0e-12
+    epsilon = max(abs(stop_time), abs(print_step), 1.0) * 1.0e-12
+    if start_time is not None and start_time > 0.0:
+        report_start = start_time
+    elif abs(result.points[0].time) <= epsilon:
+        report_start = 0.0
+    else:
+        report_start = print_step
+
+    sampled_points: list[TransientPoint] = []
+    index = 0
+    while True:
+        sample_time = report_start + index * print_step
+        if sample_time > stop_time + epsilon:
+            break
+        sampled_points.append(_interpolate_transient_point(result.points, sample_time))
+        index += 1
+
     return TransientResult(
-        points=[point for point in result.points if point.time + epsilon >= start_time],
+        points=sampled_points,
         converged=result.converged,
         method=result.method,
         steps_rejected=result.steps_rejected,
     )
+
+
+def _interpolate_transient_point(
+    points: list[TransientPoint],
+    time: float,
+) -> TransientPoint:
+    epsilon = max(abs(time), 1.0) * 1.0e-12
+    for point in points:
+        if abs(point.time - time) <= epsilon:
+            return TransientPoint(
+                time=time,
+                node_voltages=dict(point.node_voltages),
+                branch_currents=dict(point.branch_currents),
+            )
+    for left, right in zip(points, points[1:], strict=False):
+        if left.time - epsilon <= time <= right.time + epsilon:
+            span = right.time - left.time
+            if span <= 0.0:
+                return TransientPoint(
+                    time=time,
+                    node_voltages=dict(left.node_voltages),
+                    branch_currents=dict(left.branch_currents),
+                )
+            alpha = (time - left.time) / span
+            return TransientPoint(
+                time=time,
+                node_voltages=_interpolate_value_map(
+                    left.node_voltages, right.node_voltages, alpha
+                ),
+                branch_currents=_interpolate_value_map(
+                    left.branch_currents, right.branch_currents, alpha
+                ),
+            )
+    raise ValueError("run_deck_analysis: transient print point is outside output")
+
+
+def _interpolate_value_map(
+    left: dict[str, float],
+    right: dict[str, float],
+    alpha: float,
+) -> dict[str, float]:
+    values: dict[str, float] = {}
+    for key in set(left) | set(right):
+        left_value = left.get(key, right.get(key, 0.0))
+        right_value = right.get(key, left_value)
+        values[key] = (1.0 - alpha) * left_value + alpha * right_value
+    return values
 
 
 def _run_deck_ac_sweep(

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -6810,15 +6810,13 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
     assert tran_window_execution.plan.use_initial_conditions is True
     assert isinstance(tran_window_execution.result, TransientResult)
     assert [point.time for point in tran_window_execution.result.points] == pytest.approx(
-        [2.0e-3, 3.0e-3, 4.0e-3, 5.0e-3, 6.0e-3],
+        [2.0e-3, 4.0e-3, 6.0e-3],
     )
     assert tran_window_execution.table == (
         "Index\tTime\tV(mid)\n"
         "0\t2.000000e-03\t5.000000e-01\n"
-        "1\t3.000000e-03\t5.000000e-01\n"
-        "2\t4.000000e-03\t5.000000e-01\n"
-        "3\t5.000000e-03\t5.000000e-01\n"
-        "4\t6.000000e-03\t5.000000e-01\n"
+        "1\t4.000000e-03\t5.000000e-01\n"
+        "2\t6.000000e-03\t5.000000e-01\n"
     )
 
     with pytest.raises(ValueError, match="multiple analysis cards"):

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Add `.tran` print-step output routing to `run_deck_analysis`; deck transient
+  plans now keep `.tran TSTEP` as the stable output print grid while `MAXSTEP`
+  caps internal solver stepping, matching Python and TypeScript.
 - Add `.tran START/MAXSTEP/UIC` selected-plan execution routing to
   `run_deck_analysis`; deck transient plans now apply `START` output filtering,
   `MAXSTEP` fixed-step caps, and `UIC` initial-condition intent through stable

--- a/code/packages/rust/spice-engine/README.md
+++ b/code/packages/rust/spice-engine/README.md
@@ -157,8 +157,9 @@ card by analysis alias, defaults decks without analysis cards to an implicit
 `run_deck_analysis` executes one selected `.op`, `.dc`, `.ac LIN`, `.ac DEC`,
 `.ac OCT`, or `.tran` plan against an existing `Circuit` and returns the plan,
 solver result, and deck-selected output table. Selected `.tran` plans route
-`START` output filtering, `MAXSTEP` fixed-step caps, and `UIC`
-initial-condition intent through that stable transient table surface.
+`START` output filtering, use `.tran TSTEP` as the output print grid, apply
+`MAXSTEP` as an internal fixed-step cap, and carry `UIC` initial-condition
+intent through that stable transient table surface.
 `resolve_deck_fourier`, `fourier_transient_cards`, and
 `fourier_transient_deck` extract parsed `.four` / `.FOUR` cards before `.end`
 and route transient samples into the existing SPICE-style Fourier result shape
@@ -199,4 +200,5 @@ malformed deck-level analysis controls.
 downstream deck execution helpers.
 `run_deck_analysis` routes that selected plan into the matching solver and
 stable deck-selected table output, including `.ac LIN`, `.ac DEC`, `.ac OCT`
-frequency grids, and `.tran` `START` / `MAXSTEP` / `UIC` controls.
+frequency grids, and `.tran` `START` / print-step `TSTEP` / `MAXSTEP` / `UIC`
+controls.

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -9465,10 +9465,12 @@ pub fn run_deck_analysis(
             let run_step = plan
                 .max_step
                 .map_or(step_time, |max_step| step_time.min(max_step));
-            let result = filter_transient_points_start(
+            let result = sample_transient_points_print_step(
                 transient(circuit, run_step, stop_time)?,
+                step_time,
                 plan.start_time,
-            );
+                stop_time,
+            )?;
             let table = format_deck_transient_table(&result, netlist)?;
             Ok(DeckAnalysisExecution {
                 plan,
@@ -9526,21 +9528,105 @@ fn require_deck_plan_usize(
     })
 }
 
-fn filter_transient_points_start(
+fn sample_transient_points_print_step(
     points: Vec<TransientPoint>,
+    print_step: f64,
     start_time: Option<f64>,
-) -> Vec<TransientPoint> {
-    let Some(start_time) = start_time else {
-        return points;
-    };
-    if start_time <= 0.0 {
-        return points;
+    stop_time: f64,
+) -> Result<Vec<TransientPoint>, SpiceError> {
+    if points.is_empty() {
+        return Ok(points);
     }
-    let epsilon = start_time.abs().max(1.0) * 1.0e-12;
-    points
-        .into_iter()
-        .filter(|point| point.time + epsilon >= start_time)
-        .collect()
+    let epsilon = stop_time.abs().max(print_step.abs()).max(1.0) * 1.0e-12;
+    let report_start = if let Some(start_time) = start_time.filter(|value| *value > 0.0) {
+        start_time
+    } else if points[0].time.abs() <= epsilon {
+        0.0
+    } else {
+        print_step
+    };
+    let mut sampled = Vec::new();
+    let mut index = 0usize;
+    loop {
+        let sample_time = report_start + index as f64 * print_step;
+        if sample_time > stop_time + epsilon {
+            break;
+        }
+        sampled.push(interpolate_transient_point(&points, sample_time)?);
+        index += 1;
+    }
+    Ok(sampled)
+}
+
+fn interpolate_transient_point(
+    points: &[TransientPoint],
+    time: f64,
+) -> Result<TransientPoint, SpiceError> {
+    let epsilon = time.abs().max(1.0) * 1.0e-12;
+    for point in points {
+        if (point.time - time).abs() <= epsilon {
+            return Ok(TransientPoint {
+                time,
+                node_voltages: point.node_voltages.clone(),
+                branch_currents: point.branch_currents.clone(),
+            });
+        }
+    }
+    for pair in points.windows(2) {
+        let left = &pair[0];
+        let right = &pair[1];
+        if left.time - epsilon <= time && time <= right.time + epsilon {
+            let span = right.time - left.time;
+            if span <= 0.0 {
+                return Ok(TransientPoint {
+                    time,
+                    node_voltages: left.node_voltages.clone(),
+                    branch_currents: left.branch_currents.clone(),
+                });
+            }
+            let alpha = (time - left.time) / span;
+            return Ok(TransientPoint {
+                time,
+                node_voltages: interpolate_value_map(
+                    &left.node_voltages,
+                    &right.node_voltages,
+                    alpha,
+                ),
+                branch_currents: interpolate_value_map(
+                    &left.branch_currents,
+                    &right.branch_currents,
+                    alpha,
+                ),
+            });
+        }
+    }
+    Err(SpiceError::InvalidElement {
+        name: "run_deck_analysis".to_string(),
+        reason: "transient print point is outside output".to_string(),
+    })
+}
+
+fn interpolate_value_map(
+    left: &BTreeMap<String, f64>,
+    right: &BTreeMap<String, f64>,
+    alpha: f64,
+) -> BTreeMap<String, f64> {
+    let mut values = BTreeMap::new();
+    for key in left
+        .keys()
+        .chain(right.keys())
+        .cloned()
+        .collect::<BTreeSet<_>>()
+    {
+        let left_value = left
+            .get(&key)
+            .copied()
+            .or_else(|| right.get(&key).copied())
+            .unwrap_or(0.0);
+        let right_value = right.get(&key).copied().unwrap_or(left_value);
+        values.insert(key, (1.0 - alpha) * left_value + alpha * right_value);
+    }
+    values
 }
 
 fn deck_plan_error(plan: &DeckAnalysisPlan, reason: String) -> SpiceError {

--- a/code/packages/rust/spice-engine/tests/transient_tests.rs
+++ b/code/packages/rust/spice-engine/tests/transient_tests.rs
@@ -1915,7 +1915,7 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
     assert!(tran_window_execution.plan.use_initial_conditions);
     match &tran_window_execution.result {
         DeckAnalysisExecutionResult::Tran(points) => {
-            let expected_times = [2.0e-3, 3.0e-3, 4.0e-3, 5.0e-3, 6.0e-3];
+            let expected_times = [2.0e-3, 4.0e-3, 6.0e-3];
             assert_eq!(points.len(), expected_times.len());
             for (point, expected_time) in points.iter().zip(expected_times) {
                 assert!((point.time - expected_time).abs() < 1.0e-12);
@@ -1925,7 +1925,7 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
     }
     assert_eq!(
         tran_window_execution.table,
-        "Index\tTime\tV(mid)\n0\t2.000000e-03\t5.000000e-01\n1\t3.000000e-03\t5.000000e-01\n2\t4.000000e-03\t5.000000e-01\n3\t5.000000e-03\t5.000000e-01\n4\t6.000000e-03\t5.000000e-01\n"
+        "Index\tTime\tV(mid)\n0\t2.000000e-03\t5.000000e-01\n1\t4.000000e-03\t5.000000e-01\n2\t6.000000e-03\t5.000000e-01\n"
     );
 
     let error = run_deck_analysis(&circuit, netlist, None).unwrap_err();

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Add `.tran` print-step output routing to `runDeckAnalysis`; deck transient
+  plans now keep `.tran TSTEP` as the stable output print grid while `MAXSTEP`
+  caps internal solver stepping, matching Python and Rust.
 - Add `.tran START/MAXSTEP/UIC` selected-plan execution routing to
   `runDeckAnalysis`; deck transient plans now apply `START` output filtering,
   `MAXSTEP` fixed-step caps, and `UIC` initial-condition intent through stable

--- a/code/packages/typescript/spice-engine/README.md
+++ b/code/packages/typescript/spice-engine/README.md
@@ -91,8 +91,9 @@ and reports ambiguity before solver dispatch.
 `runDeckAnalysis` executes one selected `.op`, `.dc`, `.ac LIN`, `.ac DEC`,
 `.ac OCT`, or `.tran` plan against an existing `Circuit` and returns the plan,
 solver result, and deck-selected output table. Selected `.tran` plans route
-`START` output filtering, `MAXSTEP` fixed-step caps, and `UIC`
-initial-condition intent through that stable transient table surface.
+`START` output filtering, use `.tran TSTEP` as the output print grid, apply
+`MAXSTEP` as an internal fixed-step cap, and carry `UIC` initial-condition
+intent through that stable transient table surface.
 `resolveDeckOutputs` and `selectDeckOutputProbes` extract `.save` and scoped
 or global `.probe` cards before `.end`, normalize and deduplicate output
 probes in deck order, and feed `formatDeckOpTable`,
@@ -162,4 +163,5 @@ malformed deck-level analysis controls.
 deck execution helpers.
 `runDeckAnalysis` routes that selected plan into the matching solver and stable
 deck-selected table output, including `.ac LIN`, `.ac DEC`, `.ac OCT`
-frequency grids, and `.tran` `START` / `MAXSTEP` / `UIC` controls.
+frequency grids, and `.tran` `START` / print-step `TSTEP` / `MAXSTEP` / `UIC`
+controls.

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -7291,9 +7291,11 @@ export function runDeckAnalysis(
     const stepTime = requireDeckPlanNumber(plan.stepTime, plan, "stepTime");
     const stopTime = requireDeckPlanNumber(plan.stopTime, plan, "stopTime");
     const runStep = plan.maxStep !== undefined ? Math.min(stepTime, plan.maxStep) : stepTime;
-    const result = filterTransientPointsStart(
+    const result = sampleTransientPointsPrintStep(
       transient(circuit, runStep, stopTime),
+      stepTime,
       plan.startTime,
+      stopTime,
     );
     return { plan, result, table: formatDeckTransientTable(result, netlist) };
   }
@@ -7342,15 +7344,77 @@ function requireDeckPlanInteger(
   );
 }
 
-function filterTransientPointsStart(
+function sampleTransientPointsPrintStep(
   points: readonly TransientPoint[],
+  printStep: number,
   startTime: number | undefined,
+  stopTime: number,
 ): TransientPoint[] {
-  if (startTime === undefined || startTime <= 0.0) {
+  if (points.length === 0) {
     return [...points];
   }
-  const epsilon = Math.max(Math.abs(startTime), 1.0) * 1.0e-12;
-  return points.filter((point) => point.time + epsilon >= startTime);
+  const epsilon = Math.max(Math.abs(stopTime), Math.abs(printStep), 1.0) * 1.0e-12;
+  const reportStart = startTime !== undefined && startTime > 0.0
+    ? startTime
+    : Math.abs(points[0]?.time ?? 0.0) <= epsilon
+      ? 0.0
+      : printStep;
+  const sampled: TransientPoint[] = [];
+  for (let index = 0; ; index += 1) {
+    const sampleTime = reportStart + index * printStep;
+    if (sampleTime > stopTime + epsilon) {
+      break;
+    }
+    sampled.push(interpolateTransientPoint(points, sampleTime));
+  }
+  return sampled;
+}
+
+function interpolateTransientPoint(
+  points: readonly TransientPoint[],
+  time: number,
+): TransientPoint {
+  const epsilon = Math.max(Math.abs(time), 1.0) * 1.0e-12;
+  for (const point of points) {
+    if (Math.abs(point.time - time) <= epsilon) {
+      return makeTransientPoint(time, new Map(point.nodeVoltages), new Map(point.branchCurrents));
+    }
+  }
+  for (let index = 0; index + 1 < points.length; index += 1) {
+    const left = points[index]!;
+    const right = points[index + 1]!;
+    if (left.time - epsilon <= time && time <= right.time + epsilon) {
+      const span = right.time - left.time;
+      if (span <= 0.0) {
+        return makeTransientPoint(time, new Map(left.nodeVoltages), new Map(left.branchCurrents));
+      }
+      const alpha = (time - left.time) / span;
+      return makeTransientPoint(
+        time,
+        interpolateValueMap(left.nodeVoltages, right.nodeVoltages, alpha),
+        interpolateValueMap(left.branchCurrents, right.branchCurrents, alpha),
+      );
+    }
+  }
+  throw invalidElement("runDeckAnalysis", "transient print point is outside output");
+}
+
+function interpolateValueMap(
+  left: ReadonlyMap<string, number>,
+  right: ReadonlyMap<string, number>,
+  alpha: number,
+): Map<string, number> {
+  const values = new Map<string, number>();
+  for (const [key, leftValue] of left) {
+    const rightValue = right.get(key) ?? leftValue;
+    values.set(key, (1.0 - alpha) * leftValue + alpha * rightValue);
+  }
+  for (const [key, rightValue] of right) {
+    if (!values.has(key)) {
+      values.set(key, rightValue);
+    }
+  }
+  return values;
 }
 
 function runDeckAcSweep(

--- a/code/packages/typescript/spice-engine/tests/transient.test.ts
+++ b/code/packages/typescript/spice-engine/tests/transient.test.ts
@@ -1484,11 +1484,10 @@ describe("transient", () => {
     expect(tranWindowExecution.plan.maxStep).toBeCloseTo(1.0e-3, 12);
     expect(tranWindowExecution.plan.useInitialConditions).toBe(true);
     const tranWindowPoints = tranWindowExecution.result as { time: number }[];
+    expect(tranWindowPoints).toHaveLength(3);
     [
       2.0e-3,
-      3.0e-3,
       4.0e-3,
-      5.0e-3,
       6.0e-3,
     ].forEach((expectedTime, index) => {
       expect(tranWindowPoints[index]?.time).toBeCloseTo(expectedTime, 12);
@@ -1496,10 +1495,8 @@ describe("transient", () => {
     expect(tranWindowExecution.table).toBe(
       "Index\tTime\tV(mid)\n" +
         "0\t2.000000e-03\t5.000000e-01\n" +
-        "1\t3.000000e-03\t5.000000e-01\n" +
-        "2\t4.000000e-03\t5.000000e-01\n" +
-        "3\t5.000000e-03\t5.000000e-01\n" +
-        "4\t6.000000e-03\t5.000000e-01\n",
+        "1\t4.000000e-03\t5.000000e-01\n" +
+        "2\t6.000000e-03\t5.000000e-01\n",
     );
 
     expect(() => runDeckAnalysis(circuit, netlist)).toThrow(/multiple analysis cards/);

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -51,7 +51,9 @@ downstream tools to compare.
      route `.op`, `.dc`, `.ac LIN`, `.ac DEC`, `.ac OCT`, or `.tran` into the
      matching solver plus deck-selected table output, including `.tran`
      `START` output filtering, `MAXSTEP` fixed-step caps, and `UIC`
-     initial-condition intent.
+     initial-condition intent; selected `.tran` execution now keeps `.tran
+     TSTEP` as the deck output print grid while `MAXSTEP` caps internal solver
+     stepping.
    - Expand remaining deck-controlled analyses toward full SPICE compatibility
      while keeping unsupported control-flow diagnostics explicit.
 
@@ -419,12 +421,20 @@ downstream tools to compare.
       while leaving richer run artifacts and output-plan integration in
       backlog.
 
+36. Deck transient print-step output routing.
+    - Status: completed in this transient print-step routing slice.
+    - Python, Rust, and TypeScript now keep `.tran TSTEP` as the stable deck
+      output print grid while using `MAXSTEP` only as an internal fixed-step
+      cap.
+    - This separates deck-visible transient output rows from internal solver
+      stepping and preserves stable selected-plan transient tables.
+
 ## Backlog
 
 1. Deck execution layer.
    - Expand selected-plan execution beyond fixed-step transient basics,
-     including richer deck-owned run artifacts, print-step vs internal-step
-     separation, and output-plan integration beyond stable table routing.
+     including richer deck-owned run artifacts and output-plan integration
+     beyond stable table routing.
    - Expand deck-controlled output-plan integration beyond stable table
      routing toward full SPICE compatibility.
    - Define a deliberate `.control` subset; explicit unsupported-feature


### PR DESCRIPTION
## Summary
- keep selected deck `.tran TSTEP` as the stable output print grid while `MAXSTEP` only caps internal fixed-step solver execution
- add cross-language transient-point sampling/interpolation for deck-selected tables
- update Python, Rust, and TypeScript regression coverage plus SPICE docs/changelogs and the full implementation plan

## Verification
- `PYTHONPATH="$(find code/packages/python -maxdepth 2 -type d -name src | paste -sd: -)" /Users/adhithya/.local/share/mise/installs/python/3.12.13/bin/python3 -m ruff check code/packages/python/spice-engine/src/spice_engine/engine.py code/packages/python/spice-engine/tests/test_engine.py`
- `PYTHONPATH="$(find code/packages/python -maxdepth 2 -type d -name src | paste -sd: -)" /Users/adhithya/.local/share/mise/installs/python/3.12.13/bin/python3 -m pytest code/packages/python/spice-engine/tests -q --no-cov`
- `cargo fmt --manifest-path code/packages/rust/spice-engine/Cargo.toml --check`
- `cargo test --manifest-path code/packages/rust/spice-engine/Cargo.toml`
- `npm --prefix code/packages/typescript/spice-engine run build`
- `npm --prefix code/packages/typescript/spice-engine test`
- `git diff --check`
- `git diff --cached --check`