### PR TITLE
feat(07m2): Intel 8086 (1978) gate-level simulator — Rust port

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -155,6 +155,7 @@ members = [
     "intel4004-simulator",
     "intel8080-gatelevel",
     "z80-gatelevel",
+    "intel8086-gatelevel",
     "interrupt-handler",
     "interpreter-ir",
     "iir-type-checker",

--- a/code/packages/rust/intel8086-gatelevel/BUILD
+++ b/code/packages/rust/intel8086-gatelevel/BUILD
@@ -1,0 +1,1 @@
+cargo test -p coding-adventures-intel8086-gatelevel

--- a/code/packages/rust/intel8086-gatelevel/CHANGELOG.md
+++ b/code/packages/rust/intel8086-gatelevel/CHANGELOG.md
@@ -1,0 +1,71 @@
+# Changelog — coding-adventures-intel8086-gatelevel
+
+## [0.1.0] — 2026-06-15
+
+### Added
+
+- Initial gate-level simulator for the Intel 8086 (1978).
+
+#### `bits.rs`
+- `int_to_bits8` / `int_to_bits16` — LSB-first bit-vector conversion
+- `bits_to_u8` / `bits_to_u16` — bit-vector to integer
+- `add_8bit` / `add_16bit` — 8- and 16-stage ripple-carry adders
+- `add_8bit_full` / `add_16bit_full` — adders returning full carry chains for overflow detection
+- `compute_parity` — 7-gate XOR tree + NOT; PF = 1 for even popcount
+- `compute_zero` — NOR tree; ZF = 1 when all bits zero
+- `invert_8bit` / `invert_16bit` — 8 or 16 NOT gates in parallel
+- `nibble_borrow` — dedicated 4-bit two's-complement subtractor for the AF flag in SUB/SBB/CMP/DEC/NEG
+
+#### `alu.rs`
+- `AluResult8086` — result struct carrying all six ALU flags
+- 16-bit arithmetic: `add16`, `sub16`, `and16`, `or16`, `xor16`, `inc16`, `dec16`, `neg16`, `not16`
+- 8-bit arithmetic: `add8`, `sub8`, `and8`, `or8`, `xor8`, `inc8`, `dec8`, `neg8`, `not8`
+- Shifts: `shl`, `shr`, `sar` (logical and arithmetic)
+- Rotates: `rol`, `ror`, `rcl`, `rcr` (the latter two rotate through carry)
+- BCD: `daa`, `das`, `aaa`, `aas`, `aam`, `aad`
+- MUL/DIV (host arithmetic — gate-level multiplier documented exception):
+  `mul8`, `mul16`, `imul8`, `imul16`, `div8`, `div16`, `idiv8`, `idiv16`
+- INC/DEC: correct CF-preservation behaviour (caller preserves old CF)
+- SUB: CF = NOT(carry_out), AF = nibble_borrow()
+- Overflow detection: XOR(carries[N-2], carries[N-1]) single-gate at MSB
+
+#### `registers.rs`
+- `RegisterFile8086` — all 14 registers (AX BX CX DX SI DI SP BP CS DS SS ES IP) + 9 flag flip-flops
+- `read16` / `write16` — ModRM-encoded 16-bit register access (0=AX, 1=CX, 2=DX, 3=BX, 4=SP, 5=BP, 6=SI, 7=DI)
+- `read8` / `write8` — ModRM-encoded 8-bit register access (0=AL, 1=CL, …, 4=AH, 5=CH, …)
+- `read8_low` / `write8_low` / `read8_high` / `write8_high` — byte-half access
+- `read_seg` / `write_seg` — segment register access (0=ES, 1=CS, 2=SS, 3=DS)
+- Named helpers: `al()`, `set_al()`, `ah()`, `set_ah()`, etc. for AX/BX/CX/DX
+- `pack_flags` — assemble FLAGS word (bit 1 always 1; each flag gated through OR)
+- `unpack_flags` — restore flags from FLAGS word (each bit latched through AND)
+- `physical_address` — (seg × 16 + offset) & 0xFFFFF via `add_20bit()`
+- `add_20bit` — 20-stage ripple-carry adder for physical address computation
+
+#### `cpu.rs`
+- `Cpu8086` struct with 1 MB flat memory (`Box<[u8; 1_048_576]>`), 256-byte I/O port arrays
+- `new()`, `reset()`, `load()`, `step()`, `execute()`, `get_state()` public API
+- Prefix handling: ES:/CS:/SS:/DS: segment overrides, REP/REPNZ/REPNE, LOCK (ignored)
+- Full ModRM decode: mod/reg/rm extraction, 8 effective-address modes, disp8/disp16
+- Segment selection: BP-based → SS, otherwise → DS, overridable
+- 120 opcodes implemented:
+  - MOV: r/m↔reg, imm8/imm16, byte/word, segment register variants, moffset
+  - XCHG, NOP
+  - PUSH/POP: registers, segment registers, r/m, PUSHF/POPF
+  - LEA, LDS, LES
+  - LAHF, SAHF, CBW, CWD, XLAT
+  - 80-group ALU (imm), accumulator-imm ALU, standard ALU r/m↔reg
+  - TEST (r/m,reg and r/m,imm)
+  - INC/DEC (40–47/48–4F register encoding, FE/FF group)
+  - FF group: INC/DEC/CALL/JMP/PUSH r/m16, CALL FAR, JMP FAR
+  - F6/F7 group: TEST/NOT/NEG/MUL/IMUL/DIV/IDIV
+  - BCD: DAA, DAS, AAA, AAS, AAM, AAD
+  - Shifts/rotates: D0/D1 (count=1), D2/D3 (count=CL), all 8 ext codes
+  - JMP short/near/far, CALL near/far, RET/RETF (±n variants)
+  - Conditional jumps Jcc (70–7F, 16 conditions)
+  - LOOP, LOOPE/LOOPZ, LOOPNE/LOOPNZ, JCXZ
+  - INT 3, INT n, INTO, IRET
+  - String ops with REP/REPE/REPNE: MOVSB/W, LODSB/W, STOSB/W, CMPSB/W, SCASB/W
+  - Flag ops: CLC, STC, CMC, CLD, STD, CLI, STI
+  - I/O: IN AL/AX,imm8 / IN AL/AX,DX / OUT imm8,AL/AX / OUT DX,AL/AX
+  - HLT, WAIT (NOP in this model)
+- 56 unit tests, 14 doctests — all passing

--- a/code/packages/rust/intel8086-gatelevel/Cargo.toml
+++ b/code/packages/rust/intel8086-gatelevel/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "coding-adventures-intel8086-gatelevel"
+version = "0.1.0"
+edition = "2021"
+description = "Intel 8086 gate-level simulator — every operation routes through real logic gates"
+license = "MIT"
+
+[dependencies]
+logic-gates = { path = "../logic-gates" }
+arithmetic = { path = "../arithmetic" }

--- a/code/packages/rust/intel8086-gatelevel/README.md
+++ b/code/packages/rust/intel8086-gatelevel/README.md
@@ -1,0 +1,137 @@
+# coding-adventures-intel8086-gatelevel
+
+Gate-level simulator for the Intel 8086 (1978) written in Rust.
+
+Every arithmetic and logical operation on data routes through real logic gate
+functions from the `logic-gates` and `arithmetic` workspace crates — no host
+integer arithmetic on the data path (except MUL/DIV, documented below).
+
+## Architecture
+
+```
+bits.rs      — integer ↔ LSB-first bit-vector conversion
+               8-bit and 16-bit adder wrappers around full_adder chains
+               nibble_borrow() — dedicated 4-bit subtractor for the AF flag
+alu.rs       — AluResult8086: all arithmetic/logic through gate primitives
+               add/sub/and/or/xor/inc/dec/neg/not (8-bit and 16-bit)
+               shl/shr/sar/rol/ror/rcl/rcr shifts and rotates
+               daa/das/aaa/aas/aam/aad BCD operations
+               mul/div (host arithmetic — gate-level ×16 multiplier out of scope)
+registers.rs — RegisterFile8086: 14 registers, 9 flag flip-flops
+               read16/write16/read8/write8 with ModRM encoding
+               pack_flags/unpack_flags for PUSHF/POPF/LAHF/SAHF
+               physical_address() — 20-bit segment:offset via add_20bit()
+cpu.rs       — Cpu8086: full fetch-decode-execute loop
+               ~120 opcodes including ModRM, REP prefix, string ops, I/O ports
+```
+
+## Intel 8086 overview
+
+Announced June 1978. First x86 processor.
+
+| Property          | Value                         |
+|-------------------|-------------------------------|
+| Data bus          | 16-bit                        |
+| Address bus       | 20-bit (1 MB physical)        |
+| Registers         | AX BX CX DX SI DI SP BP      |
+| Segment registers | CS DS SS ES                   |
+| Transistors       | ~29,000 (NMOS, 3-micron)      |
+| Clock speeds      | 5–10 MHz                      |
+
+### Memory model
+
+Physical address = (segment_reg × 16 + offset) & 0xFFFFF.
+
+The "× 16" is a 4-bit left shift — hardware pin routing, not arithmetic. The
+16-bit offset is added through a 20-stage ripple-carry chain (`add_20bit()`).
+
+### FLAGS layout
+
+```
+bit 0: CF   bit 1: 1(always)  bit 2: PF   bit 4: AF
+bit 6: ZF   bit 7: SF         bit 8: TF   bit 9: IF
+bit 10: DF  bit 11: OF
+```
+
+### Subtraction and AF flag
+
+SUB/SBB/CMP use two's-complement addition: `A - B = A + NOT(B) + 1`.
+The carry out of bit 15 is inverted to produce CF (1 = borrow).
+
+The AF flag cannot be derived from the main adder's carry chain in subtraction
+mode. A dedicated `nibble_borrow()` function runs a 4-bit two's-complement
+subtractor on the low nibbles to compute AF correctly.
+
+### MUL/DIV exception
+
+Gate-level implementation of a 16×16 multiplier (~1000 gates) is out of scope
+for this educational simulator. `mul8`, `mul16`, `imul8`, `imul16`, `div8`,
+`div16`, `idiv8`, `idiv16` use host Rust arithmetic.
+
+## Usage
+
+```rust
+use coding_adventures_intel8086_gatelevel::cpu::Cpu8086;
+
+let mut cpu = Cpu8086::new();
+// MOV AX, 10; MOV BX, 5; ADD AX, BX; HLT
+let steps = cpu.execute(&[
+    0xB8, 10, 0,   // MOV AX, 10
+    0xBB,  5, 0,   // MOV BX, 5
+    0x03, 0xC3,    // ADD AX, BX
+    0xF4,          // HLT
+], 1000);
+assert_eq!(cpu.rf.ax, 15);
+assert!(cpu.halted);
+```
+
+### I/O ports
+
+```rust
+cpu.input_ports[0x60] = 0x41; // set port 0x60 to 'A'
+// IN AL, 0x60 → AL = 'A'
+// OUT 0x61, AL → output_ports[0x61] = 'A'
+```
+
+### Direct memory access
+
+```rust
+cpu.mem[0x1234] = 0xFF;    // write to physical address 0x1234
+let b = cpu.mem[0xABCD];   // read from physical address 0xABCD
+```
+
+## Gate cost estimates
+
+| Component                | Approximate gate count |
+|--------------------------|----------------------|
+| 16-bit ripple adder      | ~80 (16 × 5)         |
+| 16-bit NOT (for SUB)     | 16                   |
+| 16-bit AND/OR/XOR        | 48 (16 × 3)          |
+| Zero NOR tree (16-bit)   | ~20                  |
+| Parity XOR tree (8-bit)  | 8                    |
+| Overflow XOR gate        | 1                    |
+| Shifter / rotator        | ~64                  |
+| Nibble borrow (AF)       | ~10                  |
+| **ALU total estimate**   | **~247**             |
+| Register file (14 × 16) | ~896 flip-flops       |
+| FLAGS (9 bits)           | ~9 flip-flops        |
+
+## Relationship to other simulators
+
+This package is part of the `coding-adventures` gate-level CPU series:
+
+| Spec  | CPU                    | Year | Language |
+|-------|------------------------|------|----------|
+| 07a2  | Manchester Baby        | 1948 | Rust     |
+| 07b2  | IBM 701                | 1952 | Rust     |
+| 07c2  | IBM 704                | 1954 | Rust     |
+| 07d2  | TX-0                   | 1956 | Rust     |
+| 07e2  | PDP-1                  | 1959 | Rust     |
+| 07f2  | IBM 7090               | 1959 | Rust     |
+| 07g2  | CDC 6600               | 1964 | Rust     |
+| 07h2  | PDP-8                  | 1965 | Rust     |
+| 07i2  | S/360                  | 1966 | Rust     |
+| 07j2  | Intel 4004             | 1971 | Rust     |
+| 07k2  | Intel 8080             | 1974 | Rust     |
+| 07l2  | MOS 6502               | 1975 | Rust     |
+| 07m2  | **Intel 8086**         | 1978 | **Rust** |

--- a/code/packages/rust/intel8086-gatelevel/src/alu.rs
+++ b/code/packages/rust/intel8086-gatelevel/src/alu.rs
@@ -1,0 +1,830 @@
+//! ALU for the Intel 8086 gate-level simulator.
+//!
+//! # Architecture
+//!
+//! The 8086 ALU is a 16-bit ripple-carry design with 8-bit variants for byte operations.
+//! Every add/subtract routes through individual `full_adder` gate calls. Logical operations
+//! (AND, OR, XOR) use parallel gate arrays. Shifts model the shift register as a bit vector
+//! rewiring.
+//!
+//! ```text
+//! Gate count estimate (ALU only):
+//!   16-bit ripple adder    ~80  (16 full adders × ~5 gates each)
+//!   16-bit NOT (for SUB)    16
+//!   16-bit AND/OR/XOR       48  (16 parallel gates each × 3)
+//!   Zero NOR tree (16-bit)  ~20
+//!   Parity XOR tree (8-bit) ~8
+//!   Overflow XOR gate         1
+//!   Shifter/rotator         ~64
+//!   ─────────────────────  ────
+//!   Total ALU estimate     ~237
+//! ```
+//!
+//! # Flag conventions
+//!
+//! | Flag | ADD/ADC              | SUB/SBB/CMP          | AND/OR/XOR |
+//! |------|---------------------|----------------------|-----------|
+//! | CF   | adder carry out      | NOT(adder carry out) | 0         |
+//! | OF   | XOR(c_in15, c_out15) | XOR(c_in15, c_out15) | 0         |
+//! | AF   | carries[3]           | nibble_borrow(a,b,b) | 0         |
+//! | ZF   | NOR tree             | NOR tree             | NOR tree  |
+//! | SF   | result[MSB]          | result[MSB]          | result[MSB]|
+//! | PF   | XOR tree + NOT       | XOR tree + NOT       | XOR tree  |
+//!
+//! INC/DEC do not modify CF — the caller preserves the old CF value.
+
+use logic_gates::gates::{and_gate, not_gate, or_gate, xor_gate};
+
+use crate::bits::{
+    add_8bit, add_8bit_full, add_16bit_full, bits_to_u8, bits_to_u16,
+    compute_parity, compute_zero, int_to_bits8, int_to_bits16, invert_8bit, invert_16bit,
+    nibble_borrow,
+};
+
+// ─── Result type ─────────────────────────────────────────────────────────────
+
+/// Result of an ALU operation on the Intel 8086.
+///
+/// Contains the computed value plus all flag values the operation can affect.
+/// The caller decides which flags to commit to the register file — for example,
+/// INC/DEC preserve the old CF.
+#[derive(Debug, Clone, Copy)]
+pub struct AluResult8086 {
+    /// 16-bit (or zero-extended 8-bit) result value.
+    pub result: u16,
+    /// Carry flag: 1 if unsigned overflow (ADD) or borrow (SUB).
+    pub flag_cf: u8,
+    /// Overflow flag: 1 if signed overflow.
+    pub flag_of: u8,
+    /// Sign flag: MSB of result.
+    pub flag_sf: u8,
+    /// Zero flag: 1 if result == 0.
+    pub flag_zf: u8,
+    /// Auxiliary carry: carry out of bit 3 (BCD).
+    pub flag_af: u8,
+    /// Parity flag: 1 if even number of 1-bits in low 8 bits.
+    pub flag_pf: u8,
+}
+
+// ─── 16-bit arithmetic ────────────────────────────────────────────────────────
+
+/// 16-bit ADD: A + B + carry_in.
+///
+/// Routes through 16 full-adder stages. OF = XOR(carry_into_bit15, carry_out_of_bit15).
+///
+/// # Example
+/// ```
+/// use coding_adventures_intel8086_gatelevel::alu::add16;
+/// let r = add16(0x7FFF, 1, 0);
+/// assert_eq!(r.result, 0x8000);
+/// assert_eq!(r.flag_of, 1); // signed overflow: 32767 + 1 = -32768
+/// assert_eq!(r.flag_cf, 0);
+/// ```
+pub fn add16(a: u16, b: u16, carry_in: u8) -> AluResult8086 {
+    let (result, carries) = add_16bit_full(a, b, carry_in);
+    let bits_r = int_to_bits16(result);
+    AluResult8086 {
+        result,
+        flag_cf: carries[15],
+        flag_of: xor_gate(carries[14], carries[15]),
+        flag_sf: bits_r[15],
+        flag_zf: compute_zero(&bits_r),
+        flag_af: carries[3],
+        flag_pf: compute_parity(&bits_r),
+    }
+}
+
+/// 16-bit SUB: A - B - borrow_in via two's complement.
+///
+/// Gate path: 16 NOT gates → adder → NOT(carry_out) = CF.
+/// CF = 1 means borrow occurred (A < B + borrow_in unsigned).
+/// AF uses nibble_borrow() for correct BCD semantics.
+///
+/// # Example
+/// ```
+/// use coding_adventures_intel8086_gatelevel::alu::sub16;
+/// assert_eq!(sub16(10, 3, 0).result, 7);
+/// assert_eq!(sub16(0, 1, 0).flag_cf, 1); // borrow
+/// ```
+pub fn sub16(a: u16, b: u16, borrow_in: u8) -> AluResult8086 {
+    let not_b = invert_16bit(b);
+    let c_in = not_gate(borrow_in);
+    let (result, carries) = add_16bit_full(a, not_b, c_in);
+    let bits_r = int_to_bits16(result);
+    AluResult8086 {
+        result,
+        flag_cf: not_gate(carries[15]),
+        flag_of: xor_gate(carries[14], carries[15]),
+        flag_sf: bits_r[15],
+        flag_zf: compute_zero(&bits_r),
+        flag_af: nibble_borrow(a as u8, b as u8, borrow_in),
+        flag_pf: compute_parity(&bits_r),
+    }
+}
+
+/// 16-bit AND: A & B. CF=0, OF=0, AF=0.
+///
+/// 16 AND gates in parallel.
+pub fn and16(a: u16, b: u16) -> AluResult8086 {
+    let bits_a = int_to_bits16(a);
+    let bits_b = int_to_bits16(b);
+    let r: Vec<u8> = (0..16).map(|i| and_gate(bits_a[i], bits_b[i])).collect();
+    let result = bits_to_u16(&r);
+    AluResult8086 {
+        result,
+        flag_cf: 0, flag_of: 0,
+        flag_sf: r[15],
+        flag_zf: compute_zero(&r),
+        flag_af: 0,
+        flag_pf: compute_parity(&r),
+    }
+}
+
+/// 16-bit OR: A | B. CF=0, OF=0, AF=0.
+pub fn or16(a: u16, b: u16) -> AluResult8086 {
+    let bits_a = int_to_bits16(a);
+    let bits_b = int_to_bits16(b);
+    let r: Vec<u8> = (0..16).map(|i| or_gate(bits_a[i], bits_b[i])).collect();
+    let result = bits_to_u16(&r);
+    AluResult8086 {
+        result,
+        flag_cf: 0, flag_of: 0,
+        flag_sf: r[15],
+        flag_zf: compute_zero(&r),
+        flag_af: 0,
+        flag_pf: compute_parity(&r),
+    }
+}
+
+/// 16-bit XOR: A ^ B. CF=0, OF=0, AF=0.
+pub fn xor16(a: u16, b: u16) -> AluResult8086 {
+    let bits_a = int_to_bits16(a);
+    let bits_b = int_to_bits16(b);
+    let r: Vec<u8> = (0..16).map(|i| xor_gate(bits_a[i], bits_b[i])).collect();
+    let result = bits_to_u16(&r);
+    AluResult8086 {
+        result,
+        flag_cf: 0, flag_of: 0,
+        flag_sf: r[15],
+        flag_zf: compute_zero(&r),
+        flag_af: 0,
+        flag_pf: compute_parity(&r),
+    }
+}
+
+/// 16-bit INC. CF is not modified — caller preserves old CF.
+pub fn inc16(a: u16) -> AluResult8086 {
+    let mut r = add16(a, 1, 0);
+    r.flag_cf = 0; // caller preserves CF
+    r
+}
+
+/// 16-bit DEC. CF is not modified — caller preserves old CF.
+pub fn dec16(a: u16) -> AluResult8086 {
+    let mut r = sub16(a, 1, 0);
+    r.flag_cf = 0; // caller preserves CF
+    r
+}
+
+/// 16-bit NEG: 0 - A.
+///
+/// CF = 1 if A != 0. OF = 1 if A == 0x8000.
+pub fn neg16(a: u16) -> AluResult8086 {
+    sub16(0, a, 0)
+}
+
+/// 16-bit bitwise NOT. No flags affected.
+pub fn not16(a: u16) -> u16 {
+    invert_16bit(a)
+}
+
+// ─── 8-bit arithmetic ─────────────────────────────────────────────────────────
+
+/// 8-bit ADD: A + B + carry_in.
+///
+/// # Example
+/// ```
+/// use coding_adventures_intel8086_gatelevel::alu::add8;
+/// let r = add8(0x7F, 1, 0);
+/// assert_eq!(r.result, 0x80);
+/// assert_eq!(r.flag_of, 1); // signed overflow: 127 + 1 = -128
+/// ```
+pub fn add8(a: u8, b: u8, carry_in: u8) -> AluResult8086 {
+    let (result, carries) = add_8bit_full(a, b, carry_in);
+    let bits_r = int_to_bits8(result);
+    AluResult8086 {
+        result: result as u16,
+        flag_cf: carries[7],
+        flag_of: xor_gate(carries[6], carries[7]),
+        flag_sf: bits_r[7],
+        flag_zf: compute_zero(&bits_r),
+        flag_af: carries[3],
+        flag_pf: compute_parity(&bits_r),
+    }
+}
+
+/// 8-bit SUB: A - B - borrow_in.
+///
+/// CF = 1 means borrow occurred (A < B + borrow_in unsigned).
+pub fn sub8(a: u8, b: u8, borrow_in: u8) -> AluResult8086 {
+    let not_b = invert_8bit(b);
+    let c_in = not_gate(borrow_in);
+    let (result, carries) = add_8bit_full(a, not_b, c_in);
+    let bits_r = int_to_bits8(result);
+    AluResult8086 {
+        result: result as u16,
+        flag_cf: not_gate(carries[7]),
+        flag_of: xor_gate(carries[6], carries[7]),
+        flag_sf: bits_r[7],
+        flag_zf: compute_zero(&bits_r),
+        flag_af: nibble_borrow(a, b, borrow_in),
+        flag_pf: compute_parity(&bits_r),
+    }
+}
+
+/// 8-bit AND: A & B. CF=0, OF=0, AF=0.
+pub fn and8(a: u8, b: u8) -> AluResult8086 {
+    let bits_a = int_to_bits8(a);
+    let bits_b = int_to_bits8(b);
+    let r: Vec<u8> = (0..8).map(|i| and_gate(bits_a[i], bits_b[i])).collect();
+    let result = bits_to_u8(&r);
+    AluResult8086 {
+        result: result as u16,
+        flag_cf: 0, flag_of: 0,
+        flag_sf: r[7],
+        flag_zf: compute_zero(&r),
+        flag_af: 0,
+        flag_pf: compute_parity(&r),
+    }
+}
+
+/// 8-bit OR: A | B. CF=0, OF=0, AF=0.
+pub fn or8(a: u8, b: u8) -> AluResult8086 {
+    let bits_a = int_to_bits8(a);
+    let bits_b = int_to_bits8(b);
+    let r: Vec<u8> = (0..8).map(|i| or_gate(bits_a[i], bits_b[i])).collect();
+    let result = bits_to_u8(&r);
+    AluResult8086 {
+        result: result as u16,
+        flag_cf: 0, flag_of: 0,
+        flag_sf: r[7],
+        flag_zf: compute_zero(&r),
+        flag_af: 0,
+        flag_pf: compute_parity(&r),
+    }
+}
+
+/// 8-bit XOR: A ^ B. CF=0, OF=0, AF=0.
+pub fn xor8(a: u8, b: u8) -> AluResult8086 {
+    let bits_a = int_to_bits8(a);
+    let bits_b = int_to_bits8(b);
+    let r: Vec<u8> = (0..8).map(|i| xor_gate(bits_a[i], bits_b[i])).collect();
+    let result = bits_to_u8(&r);
+    AluResult8086 {
+        result: result as u16,
+        flag_cf: 0, flag_of: 0,
+        flag_sf: r[7],
+        flag_zf: compute_zero(&r),
+        flag_af: 0,
+        flag_pf: compute_parity(&r),
+    }
+}
+
+/// 8-bit INC. CF not modified — caller preserves it.
+pub fn inc8(a: u8) -> AluResult8086 {
+    let mut r = add8(a, 1, 0);
+    r.flag_cf = 0;
+    r
+}
+
+/// 8-bit DEC. CF not modified — caller preserves it.
+pub fn dec8(a: u8) -> AluResult8086 {
+    let mut r = sub8(a, 1, 0);
+    r.flag_cf = 0;
+    r
+}
+
+/// 8-bit NEG: 0 - A.
+pub fn neg8(a: u8) -> AluResult8086 {
+    sub8(0, a, 0)
+}
+
+/// 8-bit bitwise NOT. No flags affected.
+pub fn not8(a: u8) -> u8 {
+    invert_8bit(a)
+}
+
+// ─── Shift and rotate operations ─────────────────────────────────────────────
+//
+// All shift functions model the shift register as a bit-vector rewiring:
+// bits are physically moved (wired) to new positions.  `count & 0x1F` caps
+// at 31 (matching the 8086's behaviour for the CL-sourced shift count).
+//
+// Return type: `(result, cf)` where `result` is masked to `width` bits.
+
+/// Logical left shift. Returns `(result, cf)`.
+///
+/// CF = last bit shifted out = `bits[width - count]` (before shift).
+/// For count=1: CF = old MSB.
+///
+/// # Example
+/// ```
+/// use coding_adventures_intel8086_gatelevel::alu::shl;
+/// assert_eq!(shl(0b10000000, 1, 8), (0, 1)); // MSB shifts out to CF
+/// ```
+pub fn shl(value: u16, count: u8, width: u8) -> (u16, u8) {
+    let w = width as usize;
+    let mask: u16 = if width == 16 { 0xFFFF } else { 0xFF };
+    let cnt = (count & 0x1F) as usize;
+    if cnt == 0 { return (value & mask, 0); }
+    let bits: Vec<u8> = (0..w).map(|i| ((value >> i) & 1) as u8).collect();
+    if cnt >= w { return (0, 0); }
+    let cf = bits[w - cnt];
+    let mut rb = vec![0u8; w];
+    for i in cnt..w { rb[i] = bits[i - cnt]; }
+    let result = rb.iter().enumerate().fold(0u16, |acc, (i, &b)| acc | ((b as u16) << i));
+    (result & mask, cf)
+}
+
+/// Logical right shift. Returns `(result, cf)`.
+///
+/// CF = `bits[count - 1]` (last bit shifted out on the right).
+pub fn shr(value: u16, count: u8, width: u8) -> (u16, u8) {
+    let w = width as usize;
+    let mask: u16 = if width == 16 { 0xFFFF } else { 0xFF };
+    let cnt = (count & 0x1F) as usize;
+    if cnt == 0 { return (value & mask, 0); }
+    let bits: Vec<u8> = (0..w).map(|i| ((value >> i) & 1) as u8).collect();
+    if cnt >= w { return (0, 0); }
+    let cf = bits[cnt - 1];
+    let mut rb = vec![0u8; w];
+    for i in 0..(w - cnt) { rb[i] = bits[i + cnt]; }
+    let result = rb.iter().enumerate().fold(0u16, |acc, (i, &b)| acc | ((b as u16) << i));
+    (result & mask, cf)
+}
+
+/// Arithmetic right shift (sign-extending). Returns `(result, cf)`.
+///
+/// The sign bit replicates into vacated positions.
+pub fn sar(value: u16, count: u8, width: u8) -> (u16, u8) {
+    let w = width as usize;
+    let mask: u16 = if width == 16 { 0xFFFF } else { 0xFF };
+    let cnt = (count & 0x1F) as usize;
+    if cnt == 0 { return (value & mask, 0); }
+    let bits: Vec<u8> = (0..w).map(|i| ((value >> i) & 1) as u8).collect();
+    let sign = bits[w - 1];
+    let (cf, rb) = if cnt >= w {
+        (sign, vec![sign; w])
+    } else {
+        let cf = bits[cnt - 1];
+        let mut rb = vec![sign; w];
+        for i in 0..(w - cnt) { rb[i] = bits[i + cnt]; }
+        (cf, rb)
+    };
+    let result = rb.iter().enumerate().fold(0u16, |acc, (i, &b)| acc | ((b as u16) << i));
+    (result & mask, cf)
+}
+
+/// Rotate left (not through carry). Returns `(result, cf)`.
+///
+/// CF = new bit 0 = old bit `width - count` (the bit that wrapped around).
+/// For count=1: CF = old MSB.
+pub fn rol(value: u16, count: u8, width: u8) -> (u16, u8) {
+    let w = width as usize;
+    let mask: u16 = if width == 16 { 0xFFFF } else { 0xFF };
+    let cnt = (count as usize) % w;
+    let bits: Vec<u8> = (0..w).map(|i| ((value >> i) & 1) as u8).collect();
+    if cnt == 0 { return (value & mask, bits[0]); }
+    // result_bits = bits[w - cnt ..] ++ bits[.. w - cnt]
+    let mut rb = Vec::with_capacity(w);
+    rb.extend_from_slice(&bits[w - cnt..]);
+    rb.extend_from_slice(&bits[..w - cnt]);
+    let cf = rb[0]; // new bit 0
+    let result = rb.iter().enumerate().fold(0u16, |acc, (i, &b)| acc | ((b as u16) << i));
+    (result & mask, cf)
+}
+
+/// Rotate right (not through carry). Returns `(result, cf)`.
+///
+/// CF = new MSB = old bit `count - 1`.
+pub fn ror(value: u16, count: u8, width: u8) -> (u16, u8) {
+    let w = width as usize;
+    let mask: u16 = if width == 16 { 0xFFFF } else { 0xFF };
+    let cnt = (count as usize) % w;
+    let bits: Vec<u8> = (0..w).map(|i| ((value >> i) & 1) as u8).collect();
+    if cnt == 0 { return (value & mask, bits[w - 1]); }
+    // result_bits = bits[cnt ..] ++ bits[.. cnt]
+    let mut rb = Vec::with_capacity(w);
+    rb.extend_from_slice(&bits[cnt..]);
+    rb.extend_from_slice(&bits[..cnt]);
+    let cf = rb[w - 1]; // new MSB
+    let result = rb.iter().enumerate().fold(0u16, |acc, (i, &b)| acc | ((b as u16) << i));
+    (result & mask, cf)
+}
+
+/// Rotate left through carry. Returns `(result, new_cf)`.
+///
+/// The (width+1)-bit value `[value_bits, cf_in]` is rotated left by `count`.
+/// The carry occupies position `width` in the extended vector.
+pub fn rcl(value: u16, count: u8, width: u8, cf_in: u8) -> (u16, u8) {
+    let w = width as usize;
+    let mask: u16 = if width == 16 { 0xFFFF } else { 0xFF };
+    let total = w + 1;
+    let cnt = (count as usize) % total;
+    let mut bits: Vec<u8> = (0..w).map(|i| ((value >> i) & 1) as u8).collect();
+    bits.push(cf_in);
+    if cnt == 0 {
+        let result = bits[..w].iter().enumerate().fold(0u16, |acc, (i, &b)| acc | ((b as u16) << i));
+        return (result & mask, cf_in);
+    }
+    let mut rb = Vec::with_capacity(total);
+    rb.extend_from_slice(&bits[total - cnt..]);
+    rb.extend_from_slice(&bits[..total - cnt]);
+    let new_cf = rb[w];
+    let result = rb[..w].iter().enumerate().fold(0u16, |acc, (i, &b)| acc | ((b as u16) << i));
+    (result & mask, new_cf)
+}
+
+/// Rotate right through carry. Returns `(result, new_cf)`.
+pub fn rcr(value: u16, count: u8, width: u8, cf_in: u8) -> (u16, u8) {
+    let w = width as usize;
+    let mask: u16 = if width == 16 { 0xFFFF } else { 0xFF };
+    let total = w + 1;
+    let cnt = (count as usize) % total;
+    let mut bits: Vec<u8> = (0..w).map(|i| ((value >> i) & 1) as u8).collect();
+    bits.push(cf_in);
+    if cnt == 0 {
+        let result = bits[..w].iter().enumerate().fold(0u16, |acc, (i, &b)| acc | ((b as u16) << i));
+        return (result & mask, cf_in);
+    }
+    let mut rb = Vec::with_capacity(total);
+    rb.extend_from_slice(&bits[cnt..]);
+    rb.extend_from_slice(&bits[..cnt]);
+    let new_cf = rb[w];
+    let result = rb[..w].iter().enumerate().fold(0u16, |acc, (i, &b)| acc | ((b as u16) << i));
+    (result & mask, new_cf)
+}
+
+// ─── BCD operations ───────────────────────────────────────────────────────────
+
+/// DAA — Decimal Adjust AL after Addition.
+///
+/// Routes correction adds through `add_8bit`. Returns `(new_al, new_af, new_cf)`.
+pub fn daa(al: u8, flag_af: u8, flag_cf: u8) -> (u8, u8, u8) {
+    let old_al = al;
+    let mut new_al = al;
+    let new_cf: u8;
+    let new_af: u8;
+    if (old_al & 0xF) > 9 || flag_af != 0 {
+        let (r, _, _) = add_8bit(new_al, 6, 0);
+        new_al = r;
+        new_af = 1u8;
+    } else {
+        new_af = 0u8;
+    }
+    if old_al > 0x99 || flag_cf != 0 {
+        let (r, _, _) = add_8bit(new_al, 0x60, 0);
+        new_al = r;
+        new_cf = 1;
+    } else {
+        new_cf = 0;
+    }
+    (new_al, new_af, new_cf)
+}
+
+/// DAS — Decimal Adjust AL after Subtraction.
+///
+/// Correction subtractions route through `add_8bit(x, NOT(n), 1)` (two's complement).
+pub fn das(al: u8, flag_af: u8, flag_cf: u8) -> (u8, u8, u8) {
+    let old_al = al;
+    let mut result = al;
+    let new_cf: u8;
+    let new_af: u8;
+    if (old_al & 0xF) > 9 || flag_af != 0 {
+        let (r, _, _) = add_8bit(result, invert_8bit(6), 1); // result - 6
+        result = r;
+        new_af = 1;
+    } else {
+        new_af = 0;
+    }
+    if old_al > 0x99 || flag_cf != 0 {
+        let (r, _, _) = add_8bit(result, invert_8bit(0x60), 1); // result - 0x60
+        result = r;
+        new_cf = 1;
+    } else {
+        new_cf = 0;
+    }
+    (result, new_af, new_cf)
+}
+
+/// AAA — ASCII Adjust after Addition.
+///
+/// Returns `(new_al, new_ah, af_cf)`.
+pub fn aaa(al: u8, ah: u8, flag_af: u8) -> (u8, u8, u8) {
+    if (al & 0xF) > 9 || flag_af != 0 {
+        let (al_out, _, _) = add_8bit(al, 6, 0);
+        let (ah_out, _, _) = add_8bit(ah, 1, 0);
+        (al_out & 0x0F, ah_out, 1)
+    } else {
+        (al & 0x0F, ah, 0)
+    }
+}
+
+/// AAS — ASCII Adjust after Subtraction.
+///
+/// Returns `(new_al, new_ah, af_cf)`.
+pub fn aas(al: u8, ah: u8, flag_af: u8) -> (u8, u8, u8) {
+    if (al & 0xF) > 9 || flag_af != 0 {
+        let (al_out, _, _) = add_8bit(al, invert_8bit(6), 1); // al - 6
+        let (ah_out, _, _) = add_8bit(ah, invert_8bit(1), 1); // ah - 1
+        (al_out & 0x0F, ah_out, 1)
+    } else {
+        (al & 0x0F, ah, 0)
+    }
+}
+
+/// AAM — ASCII Adjust after Multiply.
+///
+/// Returns `(new_ah, new_al)`. AH = AL ÷ base, AL = AL mod base.
+/// Note: host division used (gate-level divider out of scope).
+pub fn aam(al: u8, base: u8) -> (u8, u8) {
+    if base == 0 { return (0, 0); }
+    (al / base, al % base)
+}
+
+/// AAD — ASCII Adjust before Division.
+///
+/// AL = AH × base + AL (AH set to 0 by caller). Returns new AL.
+pub fn aad(ah: u8, al: u8, base: u8) -> u8 {
+    let product = ((ah as u16) * (base as u16)) & 0xFF;
+    let (result, _, _) = add_8bit(product as u8, al, 0);
+    result
+}
+
+// ─── Multiply / Divide (host arithmetic) ─────────────────────────────────────
+//
+// A gate-level 16×16-bit multiplier requires ~1000 gates and is out of scope
+// for this educational simulator. Host integer arithmetic is used instead.
+
+/// Unsigned 8-bit multiply: `AX = AL × operand`. Returns `(ax, cf_of)`.
+pub fn mul8(al: u8, operand: u8) -> (u16, u8) {
+    let ax = (al as u16) * (operand as u16);
+    let cf_of = if (ax >> 8) != 0 { 1 } else { 0 };
+    (ax, cf_of)
+}
+
+/// Unsigned 16-bit multiply: `DX:AX = AX × operand`. Returns `(dx, ax, cf_of)`.
+pub fn mul16(ax: u16, operand: u16) -> (u16, u16, u8) {
+    let r32 = (ax as u32) * (operand as u32);
+    let new_ax = (r32 & 0xFFFF) as u16;
+    let new_dx = ((r32 >> 16) & 0xFFFF) as u16;
+    let cf_of = if new_dx != 0 { 1 } else { 0 };
+    (new_dx, new_ax, cf_of)
+}
+
+/// Signed 8-bit multiply: `AX = AL_signed × operand_signed`. Returns `(ax, cf_of)`.
+pub fn imul8(al: u8, operand: u8) -> (u16, u8) {
+    let a = (al as i8) as i16;
+    let b = (operand as i8) as i16;
+    let result = (a * b) as u16;
+    let expected_hi = if (result & 0x80) != 0 { 0xFF_u16 } else { 0 };
+    let cf_of = if ((result >> 8) & 0xFF) != expected_hi { 1 } else { 0 };
+    (result, cf_of)
+}
+
+/// Signed 16-bit multiply: `DX:AX = AX_signed × operand_signed`. Returns `(dx, ax, cf_of)`.
+pub fn imul16(ax: u16, operand: u16) -> (u16, u16, u8) {
+    let a = (ax as i16) as i32;
+    let b = (operand as i16) as i32;
+    let r32 = (a * b) as u32;
+    let new_ax = (r32 & 0xFFFF) as u16;
+    let new_dx = ((r32 >> 16) & 0xFFFF) as u16;
+    let expected_hi = if (new_ax & 0x8000) != 0 { 0xFFFF_u16 } else { 0 };
+    let cf_of = if new_dx != expected_hi { 1 } else { 0 };
+    (new_dx, new_ax, cf_of)
+}
+
+/// Unsigned 8-bit divide: `AL = AX ÷ operand, AH = AX mod operand`.
+///
+/// Returns `None` if operand is zero (INT 0 in real hardware).
+pub fn div8(ax: u16, operand: u8) -> Option<(u8, u8)> {
+    if operand == 0 { return None; }
+    let q = ax / operand as u16;
+    let r = ax % operand as u16;
+    Some((q as u8, r as u8))
+}
+
+/// Unsigned 16-bit divide: `AX = DX:AX ÷ operand, DX = DX:AX mod operand`.
+pub fn div16(dx_ax: u32, operand: u16) -> Option<(u16, u16)> {
+    if operand == 0 { return None; }
+    let q = dx_ax / operand as u32;
+    let r = dx_ax % operand as u32;
+    Some((q as u16, r as u16))
+}
+
+/// Signed 8-bit divide. Returns `None` on division by zero.
+pub fn idiv8(ax: u16, operand: u8) -> Option<(u8, u8)> {
+    if operand == 0 { return None; }
+    let dividend = ax as i16;
+    let divisor = (operand as i8) as i16;
+    let q = dividend / divisor;
+    let r = dividend % divisor;
+    Some((q as u8, r as u8))
+}
+
+/// Signed 16-bit divide. Returns `None` on division by zero.
+pub fn idiv16(dx_ax: u32, operand: u16) -> Option<(u16, u16)> {
+    if operand == 0 { return None; }
+    let dividend = dx_ax as i32;
+    let divisor = (operand as i16) as i32;
+    let q = dividend / divisor;
+    let r = dividend % divisor;
+    Some((q as u16, r as u16))
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn add16_basic() {
+        let r = add16(5, 3, 0);
+        assert_eq!(r.result, 8);
+        assert_eq!(r.flag_cf, 0);
+        assert_eq!(r.flag_of, 0);
+        assert_eq!(r.flag_zf, 0);
+    }
+
+    #[test]
+    fn add16_carry() {
+        let r = add16(0xFFFF, 1, 0);
+        assert_eq!(r.result, 0);
+        assert_eq!(r.flag_cf, 1);
+        assert_eq!(r.flag_zf, 1);
+    }
+
+    #[test]
+    fn add16_signed_overflow() {
+        let r = add16(0x7FFF, 1, 0);
+        assert_eq!(r.result, 0x8000);
+        assert_eq!(r.flag_of, 1);
+        assert_eq!(r.flag_sf, 1); // now negative
+    }
+
+    #[test]
+    fn sub16_basic() {
+        let r = sub16(10, 3, 0);
+        assert_eq!(r.result, 7);
+        assert_eq!(r.flag_cf, 0);
+        assert_eq!(r.flag_of, 0);
+    }
+
+    #[test]
+    fn sub16_borrow() {
+        let r = sub16(0, 1, 0);
+        assert_eq!(r.result, 0xFFFF);
+        assert_eq!(r.flag_cf, 1);
+    }
+
+    #[test]
+    fn sub16_signed_overflow() {
+        let r = sub16(0x8000, 1, 0); // -32768 - 1 = +32767: signed overflow
+        assert_eq!(r.result, 0x7FFF);
+        assert_eq!(r.flag_of, 1);
+    }
+
+    #[test]
+    fn and16_basic() {
+        let r = and16(0xFF00, 0x0FF0);
+        assert_eq!(r.result, 0x0F00);
+        assert_eq!(r.flag_cf, 0);
+        assert_eq!(r.flag_of, 0);
+    }
+
+    #[test]
+    fn or16_basic() {
+        let r = or16(0xFF00, 0x00FF);
+        assert_eq!(r.result, 0xFFFF);
+    }
+
+    #[test]
+    fn xor16_basic() {
+        let r = xor16(0xAAAA, 0x5555);
+        assert_eq!(r.result, 0xFFFF);
+    }
+
+    #[test]
+    fn add8_basic() {
+        let r = add8(5, 3, 0);
+        assert_eq!(r.result, 8);
+    }
+
+    #[test]
+    fn add8_signed_overflow() {
+        let r = add8(0x7F, 1, 0);
+        assert_eq!(r.result, 0x80);
+        assert_eq!(r.flag_of, 1);
+    }
+
+    #[test]
+    fn sub8_borrow() {
+        let r = sub8(0, 1, 0);
+        assert_eq!(r.result, 0xFF);
+        assert_eq!(r.flag_cf, 1);
+    }
+
+    #[test]
+    fn inc_dec_do_not_modify_cf() {
+        let r = inc16(0xFFFF);
+        assert_eq!(r.result, 0);
+        assert_eq!(r.flag_cf, 0); // caller preserves CF separately
+        let r = dec8(0);
+        assert_eq!(r.result as u8, 0xFF);
+        assert_eq!(r.flag_cf, 0);
+    }
+
+    #[test]
+    fn neg16_basic() {
+        let r = neg16(1);
+        assert_eq!(r.result, 0xFFFF);
+        assert_eq!(r.flag_cf, 1); // borrow from 0 - 1
+    }
+
+    #[test]
+    fn shl_basic() {
+        assert_eq!(shl(1, 1, 8), (2, 0));
+        assert_eq!(shl(0x80, 1, 8), (0, 1)); // MSB shifts out
+    }
+
+    #[test]
+    fn shr_basic() {
+        assert_eq!(shr(2, 1, 8), (1, 0));
+        assert_eq!(shr(1, 1, 8), (0, 1)); // LSB shifts out
+    }
+
+    #[test]
+    fn sar_sign_extends() {
+        assert_eq!(sar(0x80, 1, 8), (0xC0, 0)); // 0b10000000 → 0b11000000
+        assert_eq!(sar(0x81, 1, 8), (0xC0, 1)); // CF = bit that shifted out
+    }
+
+    #[test]
+    fn rol_wraps() {
+        assert_eq!(rol(0x80, 1, 8), (1, 1)); // MSB wraps to bit 0, CF=1
+    }
+
+    #[test]
+    fn ror_wraps() {
+        assert_eq!(ror(1, 1, 8), (0x80, 1)); // bit 0 wraps to MSB, CF=1
+    }
+
+    #[test]
+    fn rcl_through_carry() {
+        assert_eq!(rcl(0x80, 1, 8, 0), (0, 1)); // MSB goes to CF; CF-in=0 enters bit 0
+        assert_eq!(rcl(0x00, 1, 8, 1), (1, 0)); // CF=1 enters bit 0
+    }
+
+    #[test]
+    fn rcr_through_carry() {
+        assert_eq!(rcr(1, 1, 8, 0), (0, 1)); // bit 0 → CF; CF-in=0 enters MSB
+        assert_eq!(rcr(0, 1, 8, 1), (0x80, 0)); // CF=1 enters MSB
+    }
+
+    #[test]
+    fn daa_basic() {
+        // 0x09 + 0x09 = 0x12 in BCD
+        let (r, _af, _cf) = daa(0x12, 0, 0);
+        assert_eq!(r, 0x12); // already valid BCD, no adjust needed
+        // Force correction: 0x0A (10) should adjust to 0x10 (BCD for 10)
+        let (r2, _, _) = daa(0x0A, 0, 0);
+        assert_eq!(r2, 0x10);
+    }
+
+    #[test]
+    fn mul8_basic() {
+        let (ax, cf_of) = mul8(10, 5);
+        assert_eq!(ax, 50);
+        assert_eq!(cf_of, 0);
+    }
+
+    #[test]
+    fn mul8_overflow() {
+        let (ax, cf_of) = mul8(0xFF, 0xFF);
+        assert_eq!(ax, 0xFE01);
+        assert_eq!(cf_of, 1);
+    }
+
+    #[test]
+    fn div8_basic() {
+        let (q, r) = div8(100, 7).unwrap();
+        assert_eq!(q, 14);
+        assert_eq!(r, 2);
+    }
+
+    #[test]
+    fn div8_zero() {
+        assert!(div8(100, 0).is_none());
+    }
+}

--- a/code/packages/rust/intel8086-gatelevel/src/bits.rs
+++ b/code/packages/rust/intel8086-gatelevel/src/bits.rs
@@ -1,0 +1,340 @@
+//! Bit conversion helpers — bridges integers and gate-level bit vectors.
+//!
+//! # Bit ordering: LSB-first
+//!
+//! All bit vectors are LSB-first: `bits[0]` = bit 0 (value 1), `bits[15]` = bit 15 (value
+//! 32768). This matches the `arithmetic` crate's ripple-carry adder, where carry propagates
+//! from bit 0 toward bit 15.
+//!
+//! ```text
+//! int_to_bits8(5) → [1, 0, 1, 0, 0, 0, 0, 0]
+//!                    ↑ bit0=1(×1)  ↑ bit2=1(×4) → sum = 5
+//! ```
+//!
+//! # Auxiliary carry (AF flag)
+//!
+//! The 8086 AF flag records the carry out of bit 3 into bit 4 (the low-nibble boundary).
+//! It is used by DAA/DAS/AAA/AAS for BCD correction.
+//!
+//! For ADD/ADC: `AF = carries[3]` — the carry output of the 4th full-adder stage.
+//! For SUB/SBB/DEC/NEG/CMP: `AF = nibble_borrow(a, b, borrow)` — a dedicated 4-bit
+//! subtractor that correctly reflects nibble borrow, independent of the two's-complement
+//! representation used by the main adder.
+//!
+//! # Overflow detection
+//!
+//! For signed N-bit addition `A + B = R`:
+//! ```text
+//! OF = XOR(carry into bit N-1, carry out of bit N-1)
+//!    = XOR(carries[N-2], carries[N-1])
+//! ```
+//! This is a single XOR gate at the MSB of the adder chain.
+
+use arithmetic::adders::full_adder;
+use logic_gates::gates::{not_gate, xor_gate};
+
+// ─── Integer ↔ bit vector ──────────────────────────────────────────────────────
+
+/// Convert an 8-bit integer to an 8-element LSB-first bit vector.
+///
+/// # Example
+/// ```
+/// use coding_adventures_intel8086_gatelevel::bits::int_to_bits8;
+/// assert_eq!(int_to_bits8(5), vec![1, 0, 1, 0, 0, 0, 0, 0]);
+/// ```
+pub fn int_to_bits8(value: u8) -> Vec<u8> {
+    (0..8).map(|i| (value >> i) & 1).collect()
+}
+
+/// Convert a 16-bit integer to a 16-element LSB-first bit vector.
+///
+/// # Example
+/// ```
+/// use coding_adventures_intel8086_gatelevel::bits::int_to_bits16;
+/// assert_eq!(int_to_bits16(0x0100)[8], 1); // bit 8 is set
+/// ```
+pub fn int_to_bits16(value: u16) -> Vec<u8> {
+    (0..16).map(|i| ((value >> i) & 1) as u8).collect()
+}
+
+/// Convert an LSB-first 8-element bit vector back to a `u8`.
+///
+/// # Example
+/// ```
+/// use coding_adventures_intel8086_gatelevel::bits::bits_to_u8;
+/// assert_eq!(bits_to_u8(&[1, 0, 1, 0, 0, 0, 0, 0]), 5);
+/// ```
+pub fn bits_to_u8(bits: &[u8]) -> u8 {
+    bits.iter().take(8).enumerate().fold(0u8, |acc, (i, &b)| acc | (b << i))
+}
+
+/// Convert an LSB-first 16-element bit vector back to a `u16`.
+pub fn bits_to_u16(bits: &[u8]) -> u16 {
+    bits.iter()
+        .take(16)
+        .enumerate()
+        .fold(0u16, |acc, (i, &b)| acc | ((b as u16) << i))
+}
+
+// ─── Flag helpers ─────────────────────────────────────────────────────────────
+
+/// Even parity via a 7-gate XOR tree over the low 8 bits, then NOT.
+///
+/// PF = 1 when the number of 1-bits in bits[0..8] is **even**.
+///
+/// ```text
+/// Stage 1: s0=XOR(b0,b1), s1=XOR(b2,b3), s2=XOR(b4,b5), s3=XOR(b6,b7)
+/// Stage 2: t0=XOR(s0,s1), t1=XOR(s2,s3)
+/// Stage 3: odd = XOR(t0,t1)
+/// Output:  PF = NOT(odd)
+/// ```
+pub fn compute_parity(bits: &[u8]) -> u8 {
+    let s0 = xor_gate(bits[0], bits[1]);
+    let s1 = xor_gate(bits[2], bits[3]);
+    let s2 = xor_gate(bits[4], bits[5]);
+    let s3 = xor_gate(bits[6], bits[7]);
+    let t0 = xor_gate(s0, s1);
+    let t1 = xor_gate(s2, s3);
+    let odd = xor_gate(t0, t1);
+    not_gate(odd)
+}
+
+/// Zero detection. Returns 1 when all bits are 0 (ZF = 1).
+///
+/// Hardware: a balanced NOR tree.
+pub fn compute_zero(bits: &[u8]) -> u8 {
+    u8::from(bits.iter().all(|&b| b == 0))
+}
+
+// ─── NOT helpers ──────────────────────────────────────────────────────────────
+
+/// 8 NOT gates in parallel — bitwise complement of an 8-bit value.
+///
+/// Used for two's complement subtraction: `A - B = A + NOT(B) + 1`.
+pub fn invert_8bit(value: u8) -> u8 {
+    let bits = int_to_bits8(value);
+    let inv: Vec<u8> = bits.iter().map(|&b| not_gate(b)).collect();
+    bits_to_u8(&inv)
+}
+
+/// 16 NOT gates in parallel — bitwise complement of a 16-bit value.
+pub fn invert_16bit(value: u16) -> u16 {
+    let bits = int_to_bits16(value);
+    let inv: Vec<u8> = bits.iter().map(|&b| not_gate(b)).collect();
+    bits_to_u16(&inv)
+}
+
+// ─── 8-bit addition ──────────────────────────────────────────────────────────
+
+/// 8-bit addition through 8 full-adder stages.
+///
+/// Returns `(result, carry_out, aux_carry)` where:
+/// - `carry_out`  = carry out of bit 7 (CF for ADD)
+/// - `aux_carry`  = carry out of bit 3 (AF flag for BCD ops)
+///
+/// # Example
+/// ```
+/// use coding_adventures_intel8086_gatelevel::bits::add_8bit;
+/// let (r, cy, af) = add_8bit(0x0F, 0x01, 0);
+/// assert_eq!(r, 0x10);
+/// assert_eq!(cy, 0);
+/// assert_eq!(af, 1); // carry from low nibble → AF=1
+/// ```
+pub fn add_8bit(a: u8, b: u8, carry_in: u8) -> (u8, u8, u8) {
+    let a_bits = int_to_bits8(a);
+    let b_bits = int_to_bits8(b);
+    let mut carry = carry_in;
+    let mut sums = Vec::with_capacity(8);
+    let mut carries = Vec::with_capacity(8);
+    for i in 0..8 {
+        let (s, c) = full_adder(a_bits[i], b_bits[i], carry);
+        sums.push(s);
+        carries.push(c);
+        carry = c;
+    }
+    (bits_to_u8(&sums), carries[7], carries[3])
+}
+
+/// 8-bit addition returning the full carry chain for overflow detection.
+///
+/// `carries[6]` = carry into bit 7; `carries[7]` = carry out of bit 7.
+/// `OF = XOR(carries[6], carries[7])`.
+pub fn add_8bit_full(a: u8, b: u8, carry_in: u8) -> (u8, Vec<u8>) {
+    let a_bits = int_to_bits8(a);
+    let b_bits = int_to_bits8(b);
+    let mut carry = carry_in;
+    let mut sums = Vec::with_capacity(8);
+    let mut carries = Vec::with_capacity(8);
+    for i in 0..8 {
+        let (s, c) = full_adder(a_bits[i], b_bits[i], carry);
+        sums.push(s);
+        carries.push(c);
+        carry = c;
+    }
+    (bits_to_u8(&sums), carries)
+}
+
+// ─── 16-bit addition ─────────────────────────────────────────────────────────
+
+/// 16-bit addition through 16 full-adder stages.
+///
+/// Returns `(result, carry_out, aux_carry)` where:
+/// - `carry_out` = carry out of bit 15 (CF for ADD/ADC)
+/// - `aux_carry` = carry out of bit 3 (AF flag)
+///
+/// # Example
+/// ```
+/// use coding_adventures_intel8086_gatelevel::bits::add_16bit;
+/// let (r, cy, af) = add_16bit(0xFFFF, 1, 0);
+/// assert_eq!(r, 0);
+/// assert_eq!(cy, 1);
+/// ```
+pub fn add_16bit(a: u16, b: u16, carry_in: u8) -> (u16, u8, u8) {
+    let a_bits = int_to_bits16(a);
+    let b_bits = int_to_bits16(b);
+    let mut carry = carry_in;
+    let mut sums = Vec::with_capacity(16);
+    let mut carries = Vec::with_capacity(16);
+    for i in 0..16 {
+        let (s, c) = full_adder(a_bits[i], b_bits[i], carry);
+        sums.push(s);
+        carries.push(c);
+        carry = c;
+    }
+    (bits_to_u16(&sums), carries[15], carries[3])
+}
+
+/// 16-bit addition returning the full carry chain.
+///
+/// `carries[14]` = carry into bit 15; `carries[15]` = carry out of bit 15.
+/// `OF = XOR(carries[14], carries[15])`.
+pub fn add_16bit_full(a: u16, b: u16, carry_in: u8) -> (u16, Vec<u8>) {
+    let a_bits = int_to_bits16(a);
+    let b_bits = int_to_bits16(b);
+    let mut carry = carry_in;
+    let mut sums = Vec::with_capacity(16);
+    let mut carries = Vec::with_capacity(16);
+    for i in 0..16 {
+        let (s, c) = full_adder(a_bits[i], b_bits[i], carry);
+        sums.push(s);
+        carries.push(c);
+        carry = c;
+    }
+    (bits_to_u16(&sums), carries)
+}
+
+// ─── Nibble borrow (AF for subtraction) ──────────────────────────────────────
+
+/// Compute whether the low-nibble subtraction `a - b - borrow_in` borrows.
+///
+/// Returns AF = 1 when a borrow from bit 3 into bit 4 occurs. Used for
+/// SUB/SBB/CMP/DEC/NEG on the 8086.
+///
+/// The adder's carry-out for the low nibble does not directly model AF for
+/// subtraction (because two's complement representation shifts the carry meaning).
+/// This function uses a dedicated 4-bit two's complement subtractor:
+/// ```text
+/// 1. 4 NOT gates: NOT_B_nib[i] = NOT(B & 0xF)[i]
+/// 2. 4-bit adder: A_nib + NOT_B_nib + NOT(borrow_in)
+/// 3. AF = NOT(carry_out_of_4bit_adder)
+/// ```
+///
+/// # Example
+/// ```
+/// use coding_adventures_intel8086_gatelevel::bits::nibble_borrow;
+/// assert_eq!(nibble_borrow(0x00, 0x01, 0), 1); // 0 - 1: borrow
+/// assert_eq!(nibble_borrow(0x0F, 0x01, 0), 0); // 0xF - 1: no borrow
+/// ```
+pub fn nibble_borrow(a: u8, b: u8, borrow_in: u8) -> u8 {
+    let a_bits = int_to_bits8(a & 0xF);
+    let b_bits = int_to_bits8(b & 0xF);
+    let not_b: Vec<u8> = b_bits[..4].iter().map(|&x| not_gate(x)).collect();
+    let c_in = not_gate(borrow_in);
+    let mut carry = c_in;
+    for i in 0..4 {
+        let (_, c) = full_adder(a_bits[i], not_b[i], carry);
+        carry = c;
+    }
+    not_gate(carry)
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn round_trip_8bit() {
+        for v in [0u8, 1, 5, 0x0F, 0x80, 0xFF] {
+            assert_eq!(bits_to_u8(&int_to_bits8(v)), v);
+        }
+    }
+
+    #[test]
+    fn round_trip_16bit() {
+        for v in [0u16, 1, 0xFF, 0x100, 0x1234, 0x8000, 0xFFFF] {
+            assert_eq!(bits_to_u16(&int_to_bits16(v)), v);
+        }
+    }
+
+    #[test]
+    fn parity_even() {
+        assert_eq!(compute_parity(&int_to_bits8(0x00)), 1); // 0 ones
+        assert_eq!(compute_parity(&int_to_bits8(0x03)), 1); // 2 ones
+        assert_eq!(compute_parity(&int_to_bits8(0xFF)), 1); // 8 ones
+    }
+
+    #[test]
+    fn parity_odd() {
+        assert_eq!(compute_parity(&int_to_bits8(0x01)), 0); // 1 one
+        assert_eq!(compute_parity(&int_to_bits8(0x07)), 0); // 3 ones
+    }
+
+    #[test]
+    fn add_8bit_basic() {
+        let (r, cy, af) = add_8bit(10, 5, 0);
+        assert_eq!(r, 15);
+        assert_eq!(cy, 0);
+        assert_eq!(af, 0);
+    }
+
+    #[test]
+    fn add_8bit_carry() {
+        let (r, cy, _) = add_8bit(0xFF, 1, 0);
+        assert_eq!(r, 0);
+        assert_eq!(cy, 1);
+    }
+
+    #[test]
+    fn add_8bit_aux_carry() {
+        let (r, cy, af) = add_8bit(0x0F, 0x01, 0);
+        assert_eq!(r, 0x10);
+        assert_eq!(cy, 0);
+        assert_eq!(af, 1);
+    }
+
+    #[test]
+    fn add_16bit_carry() {
+        let (r, cy, _) = add_16bit(0xFFFF, 1, 0);
+        assert_eq!(r, 0);
+        assert_eq!(cy, 1);
+    }
+
+    #[test]
+    fn nibble_borrow_cases() {
+        assert_eq!(nibble_borrow(0x00, 0x00, 0), 0); // 0 - 0: no borrow
+        assert_eq!(nibble_borrow(0x00, 0x01, 0), 1); // 0 - 1: borrow
+        assert_eq!(nibble_borrow(0x0F, 0x01, 0), 0); // 0xF - 1 = 0xE: no borrow
+        assert_eq!(nibble_borrow(0x10, 0x01, 0), 1); // nibble 0 < nibble 1: borrow
+    }
+
+    #[test]
+    fn invert_roundtrip() {
+        assert_eq!(invert_8bit(0x00), 0xFF);
+        assert_eq!(invert_8bit(0xFF), 0x00);
+        assert_eq!(invert_8bit(0xAA), 0x55);
+        assert_eq!(invert_16bit(0x0000), 0xFFFF);
+        assert_eq!(invert_16bit(0xFFFF), 0x0000);
+    }
+}

--- a/code/packages/rust/intel8086-gatelevel/src/cpu.rs
+++ b/code/packages/rust/intel8086-gatelevel/src/cpu.rs
@@ -1,0 +1,1587 @@
+//! Intel 8086 gate-level CPU simulator.
+//!
+//! # Design
+//!
+//! Every arithmetic/logical operation on data routes through:
+//! - `logic_gates` crate: AND, OR, XOR, NOT
+//! - `arithmetic` crate: full_adder chains
+//! - `bits` module: `add_8bit`, `add_16bit`, `add_20bit` wrappers
+//!
+//! The only exceptions are MUL/DIV (host arithmetic — gate-level ×16 is out
+//! of scope) and segment left-shift (`seg × 16 = seg << 4` is wiring, not
+//! arithmetic).
+//!
+//! # Memory model
+//!
+//! 1 MB flat byte array, heap-allocated. Physical address = (seg×16 + off) & 0xFFFFF.
+//!
+//! # Interrupts
+//!
+//! `INT n` pushes FLAGS, CS, IP onto the stack, then jumps through the
+//! interrupt vector table at address `n × 4`.
+//!
+//! # Halt
+//!
+//! `HLT` (0xF4) sets `halted = true`. Calling `step()` when halted panics.
+
+#![allow(clippy::too_many_lines)]
+
+use crate::alu::{
+    add8, add16, and8, and16, aaa, aad, aam, aas, daa, das,
+    dec8, dec16, div8, div16, idiv8, idiv16, imul8, imul16, inc8, inc16,
+    mul8, mul16, neg8, neg16, not8, not16, or8, or16,
+    rcl, rcr, rol, ror, sar, shl, shr, sub8, sub16, xor8, xor16,
+    AluResult8086,
+};
+use crate::bits::{
+    add_16bit, compute_parity, compute_zero, int_to_bits8, invert_16bit,
+};
+use crate::registers::{add_20bit, RegisterFile8086};
+
+const MEM_SIZE: usize = 1_048_576;
+const PORT_SIZE: usize = 256;
+const BYTE_MASK: u16 = 0xFF;
+const WORD_MASK: u16 = 0xFFFF;
+const PHYS_MASK: u32 = 0xFFFFF;
+
+// ─── Public CPU state snapshot ────────────────────────────────────────────────
+
+/// Snapshot of the full Intel 8086 state, returned by `get_state()`.
+#[derive(Debug, Clone)]
+pub struct CpuState {
+    pub ax: u16, pub bx: u16, pub cx: u16, pub dx: u16,
+    pub si: u16, pub di: u16, pub sp: u16, pub bp: u16,
+    pub cs: u16, pub ds: u16, pub ss: u16, pub es: u16,
+    pub ip: u16,
+    pub cf: bool, pub pf: bool, pub af: bool, pub zf: bool,
+    pub sf: bool, pub tf: bool, pub if_: bool, pub df: bool, pub of: bool,
+    pub halted: bool,
+}
+
+// ─── CPU struct ───────────────────────────────────────────────────────────────
+
+/// Gate-level Intel 8086 simulator.
+///
+/// # Example
+/// ```
+/// use coding_adventures_intel8086_gatelevel::cpu::Cpu8086;
+/// let mut cpu = Cpu8086::new();
+/// // MOV AX, 42; HLT
+/// cpu.execute(&[0xB8, 42, 0, 0xF4], 1000);
+/// assert_eq!(cpu.rf.ax, 42);
+/// assert!(cpu.halted);
+/// ```
+pub struct Cpu8086 {
+    pub rf: RegisterFile8086,
+    pub mem: Box<[u8; MEM_SIZE]>,
+    pub halted: bool,
+    pub input_ports: [u8; PORT_SIZE],
+    pub output_ports: [u8; PORT_SIZE],
+}
+
+impl Cpu8086 {
+    /// Create a new CPU with zeroed registers and memory.
+    pub fn new() -> Self {
+        Cpu8086 {
+            rf: RegisterFile8086::new(),
+            mem: Box::new([0u8; MEM_SIZE]),
+            halted: false,
+            input_ports: [0u8; PORT_SIZE],
+            output_ports: [0u8; PORT_SIZE],
+        }
+    }
+
+    /// Reset to power-on state: all registers, flags, and memory zeroed.
+    pub fn reset(&mut self) {
+        self.rf = RegisterFile8086::new();
+        self.mem.fill(0);
+        self.halted = false;
+        self.input_ports = [0u8; PORT_SIZE];
+        self.output_ports = [0u8; PORT_SIZE];
+    }
+
+    /// Write program bytes into memory at a physical address.
+    pub fn load(&mut self, program: &[u8], origin: usize) {
+        let end = (origin + program.len()).min(MEM_SIZE);
+        self.mem[origin..end].copy_from_slice(&program[..end - origin]);
+    }
+
+    /// Return a snapshot of the full CPU state.
+    pub fn get_state(&self) -> CpuState {
+        let rf = &self.rf;
+        CpuState {
+            ax: rf.ax, bx: rf.bx, cx: rf.cx, dx: rf.dx,
+            si: rf.si, di: rf.di, sp: rf.sp, bp: rf.bp,
+            cs: rf.cs, ds: rf.ds, ss: rf.ss, es: rf.es,
+            ip: rf.ip,
+            cf: rf.flag_cf != 0, pf: rf.flag_pf != 0, af: rf.flag_af != 0,
+            zf: rf.flag_zf != 0, sf: rf.flag_sf != 0, tf: rf.flag_tf != 0,
+            if_: rf.flag_if != 0, df: rf.flag_df != 0, of: rf.flag_of != 0,
+            halted: self.halted,
+        }
+    }
+
+    /// Reset, load program at address 0, run until HLT or `max_steps`.
+    ///
+    /// Returns number of steps executed.
+    pub fn execute(&mut self, program: &[u8], max_steps: usize) -> usize {
+        self.reset();
+        self.load(program, 0);
+        let mut steps = 0;
+        while !self.halted && steps < max_steps {
+            self.step();
+            steps += 1;
+        }
+        steps
+    }
+
+    /// Execute one fetch-decode-execute cycle. Panics if halted.
+    pub fn step(&mut self) {
+        assert!(!self.halted, "CPU is halted; call reset() to restart");
+        self.fetch_decode_execute();
+    }
+
+    // ── Memory helpers ────────────────────────────────────────────────────────
+
+    fn phys(&self, seg: u16, offset: u16) -> usize {
+        (add_20bit((seg as u32) << 4, offset as u32) & PHYS_MASK) as usize
+    }
+
+    fn read_byte(&self, seg: u16, offset: u16) -> u8 {
+        self.mem[self.phys(seg, offset)]
+    }
+
+    fn write_byte(&mut self, seg: u16, offset: u16, value: u8) {
+        let addr = self.phys(seg, offset);
+        self.mem[addr] = value;
+    }
+
+    fn read_word(&self, seg: u16, offset: u16) -> u16 {
+        let lo = self.mem[self.phys(seg, offset)];
+        let hi = self.mem[self.phys(seg, offset.wrapping_add(1))];
+        (lo as u16) | ((hi as u16) << 8)
+    }
+
+    fn write_word(&mut self, seg: u16, offset: u16, value: u16) {
+        let addr_lo = self.phys(seg, offset);
+        let addr_hi = self.phys(seg, offset.wrapping_add(1));
+        self.mem[addr_lo] = (value & 0xFF) as u8;
+        self.mem[addr_hi] = ((value >> 8) & 0xFF) as u8;
+    }
+
+    // Fetch one byte from CS:IP, advance IP through the 16-bit adder.
+    fn fetch8(&mut self) -> u8 {
+        let ip = self.rf.ip;
+        let cs = self.rf.cs;
+        let v = self.mem[self.phys(cs, ip)];
+        let (new_ip, _, _) = add_16bit(ip, 1, 0);
+        self.rf.ip = new_ip;
+        v
+    }
+
+    fn fetch16(&mut self) -> u16 {
+        let lo = self.fetch8() as u16;
+        let hi = self.fetch8() as u16;
+        lo | (hi << 8)
+    }
+
+    // Fetch a sign-extended 8-bit displacement.
+    fn fetch_s8(&mut self) -> i16 {
+        self.fetch8() as i8 as i16
+    }
+
+    // Fetch a 16-bit signed value.
+    fn fetch_s16(&mut self) -> i16 {
+        self.fetch16() as i16
+    }
+
+    // ── Stack helpers ─────────────────────────────────────────────────────────
+
+    fn push16(&mut self, val: u16) {
+        // SP -= 2 via two gate-level decrements
+        let sp = self.rf.sp;
+        let (sp1, _, _) = add_16bit(sp, invert_16bit(1), 1);
+        let (sp2, _, _) = add_16bit(sp1, invert_16bit(1), 1);
+        self.rf.sp = sp2;
+        let ss = self.rf.ss;
+        self.write_word(ss, sp2, val);
+    }
+
+    fn pop16(&mut self) -> u16 {
+        let sp = self.rf.sp;
+        let ss = self.rf.ss;
+        let val = self.read_word(ss, sp);
+        let (new_sp, _, _) = add_16bit(sp, 2, 0);
+        self.rf.sp = new_sp;
+        val
+    }
+
+    // ── FLAGS helpers ─────────────────────────────────────────────────────────
+
+    fn apply_alu_result(&mut self, r: &AluResult8086) {
+        self.rf.flag_cf = r.flag_cf;
+        self.rf.flag_of = r.flag_of;
+        self.rf.flag_sf = r.flag_sf;
+        self.rf.flag_zf = r.flag_zf;
+        self.rf.flag_af = r.flag_af;
+        self.rf.flag_pf = r.flag_pf;
+    }
+
+    fn apply_alu_no_cf(&mut self, r: &AluResult8086) {
+        self.rf.flag_of = r.flag_of;
+        self.rf.flag_sf = r.flag_sf;
+        self.rf.flag_zf = r.flag_zf;
+        self.rf.flag_af = r.flag_af;
+        self.rf.flag_pf = r.flag_pf;
+    }
+
+    fn apply_logic_flags(&mut self, r: &AluResult8086) {
+        self.rf.flag_cf = 0;
+        self.rf.flag_of = 0;
+        self.rf.flag_af = 0;
+        self.rf.flag_sf = r.flag_sf;
+        self.rf.flag_zf = r.flag_zf;
+        self.rf.flag_pf = r.flag_pf;
+    }
+
+    fn set_szp_byte(&mut self, val: u8) {
+        let bits = int_to_bits8(val);
+        self.rf.flag_sf = bits[7];
+        self.rf.flag_zf = compute_zero(&bits);
+        self.rf.flag_pf = compute_parity(&bits);
+    }
+
+    fn flags_low8(&self) -> u8 {
+        let rf = &self.rf;
+        (rf.flag_cf << 0) | (1 << 1) | (rf.flag_pf << 2) |
+        (rf.flag_af << 4) | (rf.flag_zf << 6) | (rf.flag_sf << 7)
+    }
+
+    fn load_flags_low8(&mut self, f: u8) {
+        self.rf.flag_cf = (f >> 0) & 1;
+        self.rf.flag_pf = (f >> 2) & 1;
+        self.rf.flag_af = (f >> 4) & 1;
+        self.rf.flag_zf = (f >> 6) & 1;
+        self.rf.flag_sf = (f >> 7) & 1;
+    }
+
+    // ── ModRM decode ──────────────────────────────────────────────────────────
+
+    /// Returns `(mod, reg, rm, effective_address_offset)`.
+    /// For mod=3 (register), ea = rm.
+    fn decode_modrm(&mut self, modrm: u8, _word: bool) -> (u8, u8, u8, u16) {
+        let mod_ = (modrm >> 6) & 3;
+        let reg = (modrm >> 3) & 7;
+        let rm = modrm & 7;
+
+        if mod_ == 3 {
+            return (mod_, reg, rm, rm as u16);
+        }
+
+        let bx = self.rf.bx;
+        let si = self.rf.si;
+        let di = self.rf.di;
+        let bp = self.rf.bp;
+
+        let base: u16 = match rm {
+            0 => { let (v, _, _) = add_16bit(bx, si, 0); v }
+            1 => { let (v, _, _) = add_16bit(bx, di, 0); v }
+            2 => { let (v, _, _) = add_16bit(bp, si, 0); v }
+            3 => { let (v, _, _) = add_16bit(bp, di, 0); v }
+            4 => si,
+            5 => di,
+            6 => if mod_ == 0 { self.fetch16() } else { bp },
+            _ => bx,
+        };
+
+        let ea: u16 = match mod_ {
+            1 => {
+                let disp = self.fetch_s8() as u16; // sign-extend → u16 via i16
+                let (v, _, _) = add_16bit(base, disp, 0);
+                v
+            }
+            2 => {
+                let disp = self.fetch_s16() as u16;
+                let (v, _, _) = add_16bit(base, disp, 0);
+                v
+            }
+            _ => base, // mod_ == 0
+        };
+
+        (mod_, reg, rm, ea)
+    }
+
+    /// Return the effective segment register for a memory access.
+    ///
+    /// Rule: BP-based r/m (rm=2,3 or rm=6 with mod≠0) → SS; otherwise → DS.
+    fn effective_seg(&self, rm: u8, mod_: u8, seg_override: Option<u8>) -> u16 {
+        if let Some(s) = seg_override {
+            return self.rf.read_seg(s);
+        }
+        let uses_bp = rm == 2 || rm == 3 || (rm == 6 && mod_ != 0);
+        if uses_bp { self.rf.ss } else { self.rf.ds }
+    }
+
+    fn read_rm(&self, mod_: u8, rm: u8, seg: u16, ea: u16, word: bool) -> u16 {
+        if mod_ == 3 {
+            if word { self.rf.read16(rm) } else { self.rf.read8(rm) as u16 }
+        } else if word {
+            self.read_word(seg, ea)
+        } else {
+            self.read_byte(seg, ea) as u16
+        }
+    }
+
+    fn write_rm(&mut self, mod_: u8, rm: u8, seg: u16, ea: u16, val: u16, word: bool) {
+        if mod_ == 3 {
+            if word { self.rf.write16(rm, val); } else { self.rf.write8(rm, val as u8); }
+        } else if word {
+            self.write_word(seg, ea, val);
+        } else {
+            self.write_byte(seg, ea, val as u8);
+        }
+    }
+
+    // ── ALU dispatcher ────────────────────────────────────────────────────────
+
+    /// Execute one of 8 ALU ops. Returns (result, mnemonic_index).
+    /// op: 0=ADD 1=OR 2=ADC 3=SBB 4=AND 5=SUB 6=XOR 7=CMP
+    fn alu_op(&mut self, op: u8, a: u16, b: u16, word: bool) -> (u16, u8) {
+        let cf = self.rf.flag_cf;
+        let result = if word {
+            match op {
+                0 => { let r = add16(a, b, 0);       self.apply_alu_result(&r);   r.result }
+                1 => { let r = or16(a, b);            self.apply_logic_flags(&r);  r.result }
+                2 => { let r = add16(a, b, cf);      self.apply_alu_result(&r);   r.result }
+                3 => { let r = sub16(a, b, cf);      self.apply_alu_result(&r);   r.result }
+                4 => { let r = and16(a, b);           self.apply_logic_flags(&r);  r.result }
+                5 => { let r = sub16(a, b, 0);        self.apply_alu_result(&r);   r.result }
+                6 => { let r = xor16(a, b);           self.apply_logic_flags(&r);  r.result }
+                _ => { let r = sub16(a, b, 0);        self.apply_alu_result(&r);   a }        // CMP: discard
+            }
+        } else {
+            match op {
+                0 => { let r = add8(a as u8, b as u8, 0);  self.apply_alu_result(&r);  r.result }
+                1 => { let r = or8(a as u8, b as u8);       self.apply_logic_flags(&r); r.result }
+                2 => { let r = add8(a as u8, b as u8, cf);  self.apply_alu_result(&r);  r.result }
+                3 => { let r = sub8(a as u8, b as u8, cf);  self.apply_alu_result(&r);  r.result }
+                4 => { let r = and8(a as u8, b as u8);      self.apply_logic_flags(&r); r.result }
+                5 => { let r = sub8(a as u8, b as u8, 0);   self.apply_alu_result(&r);  r.result }
+                6 => { let r = xor8(a as u8, b as u8);      self.apply_logic_flags(&r); r.result }
+                _ => { let r = sub8(a as u8, b as u8, 0);   self.apply_alu_result(&r);  a }    // CMP
+            }
+        };
+        (result, op)
+    }
+
+    // ── Condition evaluation ──────────────────────────────────────────────────
+
+    fn eval_cond(&self, cond: u8) -> bool {
+        let rf = &self.rf;
+        let cf = rf.flag_cf != 0;
+        let of = rf.flag_of != 0;
+        let sf = rf.flag_sf != 0;
+        let zf = rf.flag_zf != 0;
+        let pf = rf.flag_pf != 0;
+        match cond & 0xF {
+            0  => of,
+            1  => !of,
+            2  => cf,
+            3  => !cf,
+            4  => zf,
+            5  => !zf,
+            6  => cf || zf,
+            7  => !cf && !zf,
+            8  => sf,
+            9  => !sf,
+            10 => pf,
+            11 => !pf,
+            12 => sf != of,
+            13 => sf == of,
+            14 => zf || (sf != of),
+            _  => !zf && (sf == of),
+        }
+    }
+
+    // ── Interrupt trigger ─────────────────────────────────────────────────────
+
+    fn trigger_interrupt(&mut self, vector: u8) {
+        let flags = self.rf.pack_flags();
+        self.push16(flags);
+        let cs = self.rf.cs;
+        self.push16(cs);
+        let ip = self.rf.ip;
+        self.push16(ip);
+        let ivt_addr = (vector as usize) * 4;
+        let new_ip = (self.mem[ivt_addr] as u16) | ((self.mem[ivt_addr + 1] as u16) << 8);
+        let new_cs = (self.mem[ivt_addr + 2] as u16) | ((self.mem[ivt_addr + 3] as u16) << 8);
+        self.rf.ip = new_ip;
+        self.rf.cs = new_cs;
+        self.rf.flag_if = 0;
+        self.rf.flag_tf = 0;
+    }
+
+    // ── String operation helpers ──────────────────────────────────────────────
+
+    fn str_step(&self, word: bool) -> i16 {
+        let inc: i16 = if word { 2 } else { 1 };
+        if self.rf.flag_df != 0 { -inc } else { inc }
+    }
+
+    fn exec_lods(&mut self, word: bool, step: i16, seg_src: u16, rep: Option<u8>) {
+        let count = if rep.is_some() { self.rf.cx } else { 1 };
+        let mut remaining = count;
+        loop {
+            let si = self.rf.si;
+            if word {
+                let v = self.read_word(seg_src, si);
+                self.rf.ax = v;
+            } else {
+                let v = self.read_byte(seg_src, si);
+                self.rf.ax = (self.rf.ax & 0xFF00) | (v as u16);
+            }
+            let (new_si, _, _) = add_16bit(si, step as u16, 0);
+            self.rf.si = new_si;
+            if rep.is_some() {
+                let cx = self.rf.cx;
+                let (new_cx, _, _) = add_16bit(cx, invert_16bit(1), 1);
+                self.rf.cx = new_cx;
+                if new_cx == 0 { break; }
+            }
+            remaining = remaining.saturating_sub(1);
+            if remaining == 0 { break; }
+        }
+    }
+
+    fn exec_stos(&mut self, word: bool, step: i16, rep: Option<u8>) {
+        let es = self.rf.es;
+        let count = if rep.is_some() { self.rf.cx } else { 1 };
+        let mut remaining = count;
+        loop {
+            let di = self.rf.di;
+            if word {
+                let v = self.rf.ax;
+                self.write_word(es, di, v);
+            } else {
+                let v = (self.rf.ax & 0xFF) as u8;
+                self.write_byte(es, di, v);
+            }
+            let (new_di, _, _) = add_16bit(di, step as u16, 0);
+            self.rf.di = new_di;
+            if rep.is_some() {
+                let cx = self.rf.cx;
+                let (new_cx, _, _) = add_16bit(cx, invert_16bit(1), 1);
+                self.rf.cx = new_cx;
+                if new_cx == 0 { break; }
+            }
+            remaining = remaining.saturating_sub(1);
+            if remaining == 0 { break; }
+        }
+    }
+
+    fn exec_movs(&mut self, word: bool, step: i16, seg_src: u16, rep: Option<u8>) {
+        let es = self.rf.es;
+        let step_u = step as u16;
+        loop {
+            let si = self.rf.si;
+            let di = self.rf.di;
+            if word {
+                let v = self.read_word(seg_src, si);
+                self.write_word(es, di, v);
+            } else {
+                let v = self.read_byte(seg_src, si);
+                self.write_byte(es, di, v);
+            }
+            let (new_si, _, _) = add_16bit(si, step_u, 0);
+            let (new_di, _, _) = add_16bit(di, step_u, 0);
+            self.rf.si = new_si;
+            self.rf.di = new_di;
+            if rep.is_some() {
+                let cx = self.rf.cx;
+                let (new_cx, _, _) = add_16bit(cx, invert_16bit(1), 1);
+                self.rf.cx = new_cx;
+                if new_cx == 0 { break; }
+            } else {
+                break;
+            }
+        }
+    }
+
+    fn exec_cmps(&mut self, word: bool, step: i16, seg_src: u16, rep: Option<u8>) {
+        let es = self.rf.es;
+        let step_u = step as u16;
+        loop {
+            let si = self.rf.si;
+            let di = self.rf.di;
+            let a = if word { self.read_word(seg_src, si) } else { self.read_byte(seg_src, si) as u16 };
+            let b = if word { self.read_word(es, di) } else { self.read_byte(es, di) as u16 };
+            let r = if word { sub16(a, b, 0) } else { sub8(a as u8, b as u8, 0) };
+            self.apply_alu_result(&r);
+            let (new_si, _, _) = add_16bit(si, step_u, 0);
+            let (new_di, _, _) = add_16bit(di, step_u, 0);
+            self.rf.si = new_si;
+            self.rf.di = new_di;
+            if let Some(prefix) = rep {
+                let cx = self.rf.cx;
+                let (new_cx, _, _) = add_16bit(cx, invert_16bit(1), 1);
+                self.rf.cx = new_cx;
+                if new_cx == 0 { break; }
+                let zf = self.rf.flag_zf != 0;
+                if prefix == 0xF3 && !zf { break; }
+                if prefix == 0xF2 && zf { break; }
+            } else {
+                break;
+            }
+        }
+    }
+
+    fn exec_scas(&mut self, word: bool, step: i16, rep: Option<u8>) {
+        let es = self.rf.es;
+        let step_u = step as u16;
+        loop {
+            let di = self.rf.di;
+            let b = if word { self.read_word(es, di) } else { self.read_byte(es, di) as u16 };
+            let a = if word { self.rf.ax } else { self.rf.ax & 0xFF };
+            let r = if word { sub16(a, b, 0) } else { sub8(a as u8, b as u8, 0) };
+            self.apply_alu_result(&r);
+            let (new_di, _, _) = add_16bit(di, step_u, 0);
+            self.rf.di = new_di;
+            if let Some(prefix) = rep {
+                let cx = self.rf.cx;
+                let (new_cx, _, _) = add_16bit(cx, invert_16bit(1), 1);
+                self.rf.cx = new_cx;
+                if new_cx == 0 { break; }
+                let zf = self.rf.flag_zf != 0;
+                if prefix == 0xF3 && !zf { break; }
+                if prefix == 0xF2 && zf { break; }
+            } else {
+                break;
+            }
+        }
+    }
+
+    // ── Main fetch-decode-execute ─────────────────────────────────────────────
+
+    fn fetch_decode_execute(&mut self) {
+        let mut seg_override: Option<u8> = None;
+        let mut rep_prefix: Option<u8> = None;
+
+        // Prefix loop — consume all prefix bytes before dispatching.
+        let op = loop {
+            let b = self.fetch8();
+            match b {
+                0x26 => seg_override = Some(0), // ES:
+                0x2E => seg_override = Some(1), // CS:
+                0x36 => seg_override = Some(2), // SS:
+                0x3E => seg_override = Some(3), // DS:
+                0xF2 | 0xF3 => rep_prefix = Some(b),
+                0xF0 => {} // LOCK — ignored in this educational simulator
+                _ => break b,
+            }
+        };
+
+        self.exec_op(op, seg_override, rep_prefix);
+    }
+
+    #[allow(clippy::cognitive_complexity)]
+    fn exec_op(&mut self, op: u8, seg_override: Option<u8>, rep_prefix: Option<u8>) {
+        // ── MOV r/m, reg or reg, r/m (88/89/8A/8B) ───────────────────────────
+        if matches!(op, 0x88 | 0x89 | 0x8A | 0x8B) {
+            let word = (op & 1) != 0;
+            let d = (op & 2) != 0;
+            let modrm = self.fetch8();
+            let (mod_, reg, rm, ea) = self.decode_modrm(modrm, word);
+            let seg = self.effective_seg(rm, mod_, seg_override);
+            if d {
+                let src = self.read_rm(mod_, rm, seg, ea, word);
+                if word { self.rf.write16(reg, src); } else { self.rf.write8(reg, src as u8); }
+            } else {
+                let src = if word { self.rf.read16(reg) } else { self.rf.read8(reg) as u16 };
+                self.write_rm(mod_, rm, seg, ea, src, word);
+            }
+            return;
+        }
+
+        // MOV r/m8, imm8 (C6)
+        if op == 0xC6 {
+            let modrm = self.fetch8();
+            let (mod_, _, rm, ea) = self.decode_modrm(modrm, false);
+            let seg = self.effective_seg(rm, mod_, seg_override);
+            let imm = self.fetch8();
+            self.write_rm(mod_, rm, seg, ea, imm as u16, false);
+            return;
+        }
+
+        // MOV r/m16, imm16 (C7)
+        if op == 0xC7 {
+            let modrm = self.fetch8();
+            let (mod_, _, rm, ea) = self.decode_modrm(modrm, true);
+            let seg = self.effective_seg(rm, mod_, seg_override);
+            let imm = self.fetch16();
+            self.write_rm(mod_, rm, seg, ea, imm, true);
+            return;
+        }
+
+        // MOV reg8, imm8 (B0–B7)
+        if (0xB0..=0xB7).contains(&op) {
+            let reg = op - 0xB0;
+            let imm = self.fetch8();
+            self.rf.write8(reg, imm);
+            return;
+        }
+
+        // MOV reg16, imm16 (B8–BF)
+        if (0xB8..=0xBF).contains(&op) {
+            let reg = op - 0xB8;
+            let imm = self.fetch16();
+            self.rf.write16(reg, imm);
+            return;
+        }
+
+        // MOV AL/AX, [addr] (A0/A1)
+        if op == 0xA0 || op == 0xA1 {
+            let word = (op & 1) != 0;
+            let addr = self.fetch16();
+            let seg = seg_override.map_or(self.rf.ds, |s| self.rf.read_seg(s));
+            if word {
+                let v = self.read_word(seg, addr);
+                self.rf.ax = v;
+            } else {
+                let v = self.read_byte(seg, addr);
+                self.rf.ax = (self.rf.ax & 0xFF00) | (v as u16);
+            }
+            return;
+        }
+
+        // MOV [addr], AL/AX (A2/A3)
+        if op == 0xA2 || op == 0xA3 {
+            let word = (op & 1) != 0;
+            let addr = self.fetch16();
+            let seg = seg_override.map_or(self.rf.ds, |s| self.rf.read_seg(s));
+            if word { self.write_word(seg, addr, self.rf.ax); }
+            else { self.write_byte(seg, addr, (self.rf.ax & 0xFF) as u8); }
+            return;
+        }
+
+        // MOV r/m, sreg (8C)
+        if op == 0x8C {
+            let modrm = self.fetch8();
+            let (mod_, reg, rm, ea) = self.decode_modrm(modrm, true);
+            let seg_r = self.effective_seg(rm, mod_, seg_override);
+            let val = self.rf.read_seg(reg & 3);
+            self.write_rm(mod_, rm, seg_r, ea, val, true);
+            return;
+        }
+
+        // MOV sreg, r/m (8E)
+        if op == 0x8E {
+            let modrm = self.fetch8();
+            let (mod_, reg, rm, ea) = self.decode_modrm(modrm, true);
+            let seg_r = self.effective_seg(rm, mod_, seg_override);
+            let val = self.read_rm(mod_, rm, seg_r, ea, true);
+            self.rf.write_seg(reg & 3, val);
+            return;
+        }
+
+        // ── XCHG ──────────────────────────────────────────────────────────────
+
+        // XCHG AX, reg (90–97; 90 = NOP)
+        if (0x90..=0x97).contains(&op) {
+            let reg = op - 0x90;
+            if reg != 0 {
+                let tmp = self.rf.ax;
+                self.rf.ax = self.rf.read16(reg);
+                self.rf.write16(reg, tmp);
+            }
+            return;
+        }
+
+        // XCHG r/m, reg (86/87)
+        if op == 0x86 || op == 0x87 {
+            let word = (op & 1) != 0;
+            let modrm = self.fetch8();
+            let (mod_, reg, rm, ea) = self.decode_modrm(modrm, word);
+            let seg = self.effective_seg(rm, mod_, seg_override);
+            let a = self.read_rm(mod_, rm, seg, ea, word);
+            let b = if word { self.rf.read16(reg) } else { self.rf.read8(reg) as u16 };
+            self.write_rm(mod_, rm, seg, ea, b, word);
+            if word { self.rf.write16(reg, a); } else { self.rf.write8(reg, a as u8); }
+            return;
+        }
+
+        // ── PUSH / POP ─────────────────────────────────────────────────────────
+
+        // PUSH reg (50–57)
+        if (0x50..=0x57).contains(&op) {
+            let v = self.rf.read16(op - 0x50);
+            self.push16(v);
+            return;
+        }
+
+        // POP reg (58–5F)
+        if (0x58..=0x5F).contains(&op) {
+            let v = self.pop16();
+            self.rf.write16(op - 0x58, v);
+            return;
+        }
+
+        // PUSH sreg
+        if matches!(op, 0x06 | 0x0E | 0x16 | 0x1E) {
+            let code = match op { 0x06 => 0, 0x0E => 1, 0x16 => 2, _ => 3 };
+            let v = self.rf.read_seg(code);
+            self.push16(v);
+            return;
+        }
+
+        // POP sreg
+        if matches!(op, 0x07 | 0x17 | 0x1F) {
+            let code = match op { 0x07 => 0, 0x17 => 2, _ => 3 };
+            let v = self.pop16();
+            self.rf.write_seg(code, v);
+            return;
+        }
+
+        // POP r/m (8F)
+        if op == 0x8F {
+            let modrm = self.fetch8();
+            let (mod_, _, rm, ea) = self.decode_modrm(modrm, true);
+            let seg = self.effective_seg(rm, mod_, seg_override);
+            let v = self.pop16();
+            self.write_rm(mod_, rm, seg, ea, v, true);
+            return;
+        }
+
+        // PUSHF / POPF
+        if op == 0x9C { let f = self.rf.pack_flags(); self.push16(f); return; }
+        if op == 0x9D { let v = self.pop16(); self.rf.unpack_flags(v); return; }
+
+        // ── LEA / LDS / LES ───────────────────────────────────────────────────
+
+        if op == 0x8D {
+            let modrm = self.fetch8();
+            let (_, reg, _, ea) = self.decode_modrm(modrm, true);
+            self.rf.write16(reg, ea);
+            return;
+        }
+
+        if op == 0xC5 { // LDS
+            let modrm = self.fetch8();
+            let (mod_, reg, rm, ea) = self.decode_modrm(modrm, true);
+            let seg_r = self.effective_seg(rm, mod_, seg_override);
+            let off = self.read_word(seg_r, ea);
+            let new_ds = self.read_word(seg_r, ea.wrapping_add(2));
+            self.rf.write16(reg, off);
+            self.rf.ds = new_ds;
+            return;
+        }
+
+        if op == 0xC4 { // LES
+            let modrm = self.fetch8();
+            let (mod_, reg, rm, ea) = self.decode_modrm(modrm, true);
+            let seg_r = self.effective_seg(rm, mod_, seg_override);
+            let off = self.read_word(seg_r, ea);
+            let new_es = self.read_word(seg_r, ea.wrapping_add(2));
+            self.rf.write16(reg, off);
+            self.rf.es = new_es;
+            return;
+        }
+
+        // ── LAHF / SAHF ───────────────────────────────────────────────────────
+
+        if op == 0x9F { // LAHF
+            let f = self.flags_low8();
+            self.rf.ax = (self.rf.ax & 0x00FF) | ((f as u16) << 8);
+            return;
+        }
+        if op == 0x9E { // SAHF
+            let ah = ((self.rf.ax >> 8) & 0xFF) as u8;
+            self.load_flags_low8(ah);
+            return;
+        }
+
+        // ── CBW / CWD ─────────────────────────────────────────────────────────
+
+        if op == 0x98 { // CBW — sign-extend AL → AX
+            let al = (self.rf.ax & 0xFF) as u8;
+            self.rf.ax = if al & 0x80 != 0 { (al as u16) | 0xFF00 } else { al as u16 };
+            return;
+        }
+        if op == 0x99 { // CWD — sign-extend AX → DX:AX
+            self.rf.dx = if self.rf.ax & 0x8000 != 0 { 0xFFFF } else { 0 };
+            return;
+        }
+
+        // ── XLAT ──────────────────────────────────────────────────────────────
+
+        if op == 0xD7 {
+            let al = (self.rf.ax & 0xFF) as u8;
+            let seg = seg_override.map_or(self.rf.ds, |s| self.rf.read_seg(s));
+            let (xlat_addr, _, _) = add_16bit(self.rf.bx, al as u16, 0);
+            let v = self.read_byte(seg, xlat_addr);
+            self.rf.ax = (self.rf.ax & 0xFF00) | (v as u16);
+            return;
+        }
+
+        // ── 80-group: r/m, imm ALU ─────────────────────────────────────────────
+
+        if matches!(op, 0x80 | 0x81 | 0x82 | 0x83) {
+            let word = op == 0x81 || op == 0x83;
+            let modrm = self.fetch8();
+            let ext = (modrm >> 3) & 7;
+            let rm = modrm & 7;
+            let mod_ = (modrm >> 6) & 3;
+            let (_, _, _, ea) = self.decode_modrm(modrm, word);
+            let seg = self.effective_seg(rm, mod_, seg_override);
+            let imm: u16 = match op {
+                0x80 | 0x82 => self.fetch8() as u16,
+                0x81 => self.fetch16(),
+                _ => { // 0x83: sign-extend 8→16
+                    let v = self.fetch8() as i8 as i16;
+                    v as u16
+                }
+            };
+            let a = self.read_rm(mod_, rm, seg, ea, word);
+            let (result, _) = self.alu_op(ext, a, imm, word);
+            if ext != 7 { self.write_rm(mod_, rm, seg, ea, result, word); }
+            return;
+        }
+
+        // TEST r/m, reg (84/85)
+        if op == 0x84 || op == 0x85 {
+            let word = (op & 1) != 0;
+            let modrm = self.fetch8();
+            let (mod_, reg, rm, ea) = self.decode_modrm(modrm, word);
+            let seg = self.effective_seg(rm, mod_, seg_override);
+            let a = self.read_rm(mod_, rm, seg, ea, word);
+            let b = if word { self.rf.read16(reg) } else { self.rf.read8(reg) as u16 };
+            let r = if word { and16(a, b) } else { and8(a as u8, b as u8) };
+            self.apply_logic_flags(&r);
+            return;
+        }
+
+        // Accumulator-immediate ALU (04, 05, 0C, 0D, … 3C, 3D, A8, A9)
+        {
+            const ACC_IMM: [(u8, u8, bool); 18] = [
+                (0x04, 0, false), (0x05, 0, true),
+                (0x0C, 1, false), (0x0D, 1, true),
+                (0x14, 2, false), (0x15, 2, true),
+                (0x1C, 3, false), (0x1D, 3, true),
+                (0x24, 4, false), (0x25, 4, true),
+                (0x2C, 5, false), (0x2D, 5, true),
+                (0x34, 6, false), (0x35, 6, true),
+                (0x3C, 7, false), (0x3D, 7, true),
+                (0xA8, 4, false), (0xA9, 4, true),
+            ];
+            if let Some(&(_, alu_op, word)) = ACC_IMM.iter().find(|&&(o, _, _)| o == op) {
+                let imm = if word { self.fetch16() } else { self.fetch8() as u16 };
+                let a = if word { self.rf.ax } else { self.rf.ax & 0xFF };
+                let (result, _) = self.alu_op(alu_op, a, imm, word);
+                // TEST (A8/A9) and CMP (3C/3D) don't write back
+                if alu_op != 7 && op != 0xA8 && op != 0xA9 {
+                    if word { self.rf.ax = result; }
+                    else { self.rf.ax = (self.rf.ax & 0xFF00) | (result & 0xFF); }
+                }
+                return;
+            }
+        }
+
+        // Standard ALU r/m ↔ reg (00–3B)
+        {
+            // (opcode, alu_op, word, d_bit)
+            const STD_ALU: [(u8, u8, bool, bool); 32] = [
+                (0x00,0,false,false),(0x01,0,true,false),(0x02,0,false,true),(0x03,0,true,true),
+                (0x08,1,false,false),(0x09,1,true,false),(0x0A,1,false,true),(0x0B,1,true,true),
+                (0x10,2,false,false),(0x11,2,true,false),(0x12,2,false,true),(0x13,2,true,true),
+                (0x18,3,false,false),(0x19,3,true,false),(0x1A,3,false,true),(0x1B,3,true,true),
+                (0x20,4,false,false),(0x21,4,true,false),(0x22,4,false,true),(0x23,4,true,true),
+                (0x28,5,false,false),(0x29,5,true,false),(0x2A,5,false,true),(0x2B,5,true,true),
+                (0x30,6,false,false),(0x31,6,true,false),(0x32,6,false,true),(0x33,6,true,true),
+                (0x38,7,false,false),(0x39,7,true,false),(0x3A,7,false,true),(0x3B,7,true,true),
+            ];
+            if let Some(&(_, alu_op, word, d_bit)) = STD_ALU.iter().find(|&&(o, _, _, _)| o == op) {
+                let modrm = self.fetch8();
+                let (mod_, reg, rm, ea) = self.decode_modrm(modrm, word);
+                let seg = self.effective_seg(rm, mod_, seg_override);
+                if d_bit {
+                    let a = if word { self.rf.read16(reg) } else { self.rf.read8(reg) as u16 };
+                    let b = self.read_rm(mod_, rm, seg, ea, word);
+                    let (result, _) = self.alu_op(alu_op, a, b, word);
+                    if alu_op != 7 {
+                        if word { self.rf.write16(reg, result); } else { self.rf.write8(reg, result as u8); }
+                    }
+                } else {
+                    let a = self.read_rm(mod_, rm, seg, ea, word);
+                    let b = if word { self.rf.read16(reg) } else { self.rf.read8(reg) as u16 };
+                    let (result, _) = self.alu_op(alu_op, a, b, word);
+                    if alu_op != 7 { self.write_rm(mod_, rm, seg, ea, result, word); }
+                }
+                return;
+            }
+        }
+
+        // ── INC / DEC reg16 (40–4F) ───────────────────────────────────────────
+
+        if (0x40..=0x47).contains(&op) {
+            let reg = op - 0x40;
+            let old_cf = self.rf.flag_cf;
+            let r = inc16(self.rf.read16(reg));
+            self.rf.write16(reg, r.result);
+            self.apply_alu_no_cf(&r);
+            self.rf.flag_cf = old_cf;
+            return;
+        }
+        if (0x48..=0x4F).contains(&op) {
+            let reg = op - 0x48;
+            let old_cf = self.rf.flag_cf;
+            let r = dec16(self.rf.read16(reg));
+            self.rf.write16(reg, r.result);
+            self.apply_alu_no_cf(&r);
+            self.rf.flag_cf = old_cf;
+            return;
+        }
+
+        // FE group: INC/DEC r/m8
+        if op == 0xFE {
+            let modrm = self.fetch8();
+            let ext = (modrm >> 3) & 7;
+            let rm = modrm & 7;
+            let mod_ = (modrm >> 6) & 3;
+            let (_, _, _, ea) = self.decode_modrm(modrm, false);
+            let seg = self.effective_seg(rm, mod_, seg_override);
+            let a = self.read_rm(mod_, rm, seg, ea, false) as u8;
+            let old_cf = self.rf.flag_cf;
+            let r = if ext == 0 { inc8(a) } else { dec8(a) };
+            self.write_rm(mod_, rm, seg, ea, r.result, false);
+            self.apply_alu_no_cf(&r);
+            self.rf.flag_cf = old_cf;
+            return;
+        }
+
+        // FF group: INC/DEC/CALL/JMP/PUSH r/m16
+        if op == 0xFF {
+            let modrm = self.fetch8();
+            let ext = (modrm >> 3) & 7;
+            let rm = modrm & 7;
+            let mod_ = (modrm >> 6) & 3;
+            let (_, _, _, ea) = self.decode_modrm(modrm, true);
+            let seg = self.effective_seg(rm, mod_, seg_override);
+            let val = self.read_rm(mod_, rm, seg, ea, true);
+            match ext {
+                0 => { // INC m16
+                    let old_cf = self.rf.flag_cf;
+                    let r = inc16(val);
+                    self.write_rm(mod_, rm, seg, ea, r.result, true);
+                    self.apply_alu_no_cf(&r);
+                    self.rf.flag_cf = old_cf;
+                }
+                1 => { // DEC m16
+                    let old_cf = self.rf.flag_cf;
+                    let r = dec16(val);
+                    self.write_rm(mod_, rm, seg, ea, r.result, true);
+                    self.apply_alu_no_cf(&r);
+                    self.rf.flag_cf = old_cf;
+                }
+                2 => { // CALL rm16 (near)
+                    let ip = self.rf.ip;
+                    self.push16(ip);
+                    self.rf.ip = val;
+                }
+                3 => { // CALL FAR m32
+                    let new_off = self.read_word(seg, ea);
+                    let new_cs = self.read_word(seg, ea.wrapping_add(2));
+                    let cs = self.rf.cs; self.push16(cs);
+                    let ip = self.rf.ip; self.push16(ip);
+                    self.rf.cs = new_cs;
+                    self.rf.ip = new_off;
+                }
+                4 => { self.rf.ip = val; } // JMP rm16
+                5 => { // JMP FAR m32
+                    let new_off = self.read_word(seg, ea);
+                    let new_cs = self.read_word(seg, ea.wrapping_add(2));
+                    self.rf.cs = new_cs;
+                    self.rf.ip = new_off;
+                }
+                6 => { self.push16(val); } // PUSH m16
+                _ => {}
+            }
+            return;
+        }
+
+        // ── F6/F7 group ───────────────────────────────────────────────────────
+
+        if op == 0xF6 || op == 0xF7 {
+            let word = (op & 1) != 0;
+            let modrm = self.fetch8();
+            let ext = (modrm >> 3) & 7;
+            let rm = modrm & 7;
+            let mod_ = (modrm >> 6) & 3;
+            let (_, _, _, ea) = self.decode_modrm(modrm, word);
+            let seg = self.effective_seg(rm, mod_, seg_override);
+            let a = self.read_rm(mod_, rm, seg, ea, word);
+            match ext {
+                0 => { // TEST
+                    let imm = if word { self.fetch16() } else { self.fetch8() as u16 };
+                    let r = if word { and16(a, imm) } else { and8(a as u8, imm as u8) };
+                    self.apply_logic_flags(&r);
+                }
+                2 => { // NOT
+                    let result = if word { not16(a) } else { not8(a as u8) as u16 };
+                    self.write_rm(mod_, rm, seg, ea, result, word);
+                }
+                3 => { // NEG
+                    let r = if word { neg16(a) } else { neg8(a as u8) };
+                    self.write_rm(mod_, rm, seg, ea, r.result, word);
+                    self.apply_alu_result(&r);
+                    self.rf.flag_cf = if a != 0 { 1 } else { 0 };
+                }
+                4 => { // MUL
+                    if word {
+                        let (dx, ax, cf_of) = mul16(self.rf.ax, a);
+                        self.rf.ax = ax; self.rf.dx = dx;
+                        self.rf.flag_cf = cf_of; self.rf.flag_of = cf_of;
+                    } else {
+                        let (ax, cf_of) = mul8((self.rf.ax & 0xFF) as u8, a as u8);
+                        self.rf.ax = ax;
+                        self.rf.flag_cf = cf_of; self.rf.flag_of = cf_of;
+                    }
+                }
+                5 => { // IMUL
+                    if word {
+                        let (dx, ax, cf_of) = imul16(self.rf.ax, a);
+                        self.rf.ax = ax; self.rf.dx = dx;
+                        self.rf.flag_cf = cf_of; self.rf.flag_of = cf_of;
+                    } else {
+                        let (ax, cf_of) = imul8((self.rf.ax & 0xFF) as u8, a as u8);
+                        self.rf.ax = ax;
+                        self.rf.flag_cf = cf_of; self.rf.flag_of = cf_of;
+                    }
+                }
+                6 => { // DIV
+                    if word {
+                        let dividend = ((self.rf.dx as u32) << 16) | (self.rf.ax as u32);
+                        match div16(dividend, a) {
+                            None => { self.halted = true; }
+                            Some((ax, dx)) => { self.rf.ax = ax; self.rf.dx = dx; }
+                        }
+                    } else {
+                        match div8(self.rf.ax, a as u8) {
+                            None => { self.halted = true; }
+                            Some((q, r)) => { self.rf.ax = ((r as u16) << 8) | (q as u16); }
+                        }
+                    }
+                }
+                7 => { // IDIV
+                    if word {
+                        let d32 = ((self.rf.dx as u32) << 16) | (self.rf.ax as u32);
+                        match idiv16(d32, a) {
+                            None => { self.halted = true; }
+                            Some((ax, dx)) => { self.rf.ax = ax; self.rf.dx = dx; }
+                        }
+                    } else {
+                        match idiv8(self.rf.ax, a as u8) {
+                            None => { self.halted = true; }
+                            Some((q, r)) => {
+                                self.rf.ax = ((r as u16) << 8) | ((q as u16) & 0xFF);
+                            }
+                        }
+                    }
+                }
+                _ => {}
+            }
+            return;
+        }
+
+        // ── BCD operations ────────────────────────────────────────────────────
+
+        if op == 0x27 { // DAA
+            let al = (self.rf.ax & 0xFF) as u8;
+            let (new_al, new_af, new_cf) = daa(al, self.rf.flag_af, self.rf.flag_cf);
+            self.rf.ax = (self.rf.ax & 0xFF00) | (new_al as u16);
+            self.rf.flag_af = new_af;
+            self.rf.flag_cf = new_cf;
+            self.set_szp_byte(new_al);
+            return;
+        }
+        if op == 0x2F { // DAS
+            let al = (self.rf.ax & 0xFF) as u8;
+            let (new_al, new_af, new_cf) = das(al, self.rf.flag_af, self.rf.flag_cf);
+            self.rf.ax = (self.rf.ax & 0xFF00) | (new_al as u16);
+            self.rf.flag_af = new_af;
+            self.rf.flag_cf = new_cf;
+            self.set_szp_byte(new_al);
+            return;
+        }
+        if op == 0x37 { // AAA
+            let al = (self.rf.ax & 0xFF) as u8;
+            let ah = ((self.rf.ax >> 8) & 0xFF) as u8;
+            let (new_al, new_ah, af_cf) = aaa(al, ah, self.rf.flag_af);
+            self.rf.ax = ((new_ah as u16) << 8) | (new_al as u16);
+            self.rf.flag_af = af_cf;
+            self.rf.flag_cf = af_cf;
+            return;
+        }
+        if op == 0x3F { // AAS
+            let al = (self.rf.ax & 0xFF) as u8;
+            let ah = ((self.rf.ax >> 8) & 0xFF) as u8;
+            let (new_al, new_ah, af_cf) = aas(al, ah, self.rf.flag_af);
+            self.rf.ax = ((new_ah as u16) << 8) | (new_al as u16);
+            self.rf.flag_af = af_cf;
+            self.rf.flag_cf = af_cf;
+            return;
+        }
+        if op == 0xD4 { // AAM
+            let base = self.fetch8();
+            let al = (self.rf.ax & 0xFF) as u8;
+            let (new_ah, new_al) = aam(al, base);
+            self.rf.ax = ((new_ah as u16) << 8) | (new_al as u16);
+            self.set_szp_byte(new_al);
+            return;
+        }
+        if op == 0xD5 { // AAD
+            let base = self.fetch8();
+            let ah = ((self.rf.ax >> 8) & 0xFF) as u8;
+            let al = (self.rf.ax & 0xFF) as u8;
+            let new_al = aad(ah, al, base);
+            self.rf.ax = new_al as u16;
+            self.set_szp_byte(new_al);
+            return;
+        }
+
+        // ── Shifts / rotates (D0/D1/D2/D3) ───────────────────────────────────
+
+        if matches!(op, 0xD0 | 0xD1 | 0xD2 | 0xD3) {
+            let word = (op & 1) != 0;
+            let count: u8 = if op < 0xD2 { 1 } else { (self.rf.cx & 0xFF) as u8 };
+            let modrm = self.fetch8();
+            let ext = (modrm >> 3) & 7;
+            let rm = modrm & 7;
+            let mod_ = (modrm >> 6) & 3;
+            let (_, _, _, ea) = self.decode_modrm(modrm, word);
+            let seg = self.effective_seg(rm, mod_, seg_override);
+            let a = self.read_rm(mod_, rm, seg, ea, word);
+            let width: u8 = if word { 16 } else { 8 };
+            let mask: u16 = if word { WORD_MASK } else { BYTE_MASK };
+
+            let (result, _) = match ext {
+                0 => { // ROL
+                    let (r, cf) = rol(a, count, width);
+                    let msb = ((r >> (width - 1)) & 1) as u8;
+                    self.rf.flag_cf = cf;
+                    if count == 1 { self.rf.flag_of = cf ^ msb; }
+                    (r, cf)
+                }
+                1 => { // ROR
+                    let (r, cf) = ror(a, count, width);
+                    let msb = ((r >> (width - 1)) & 1) as u8;
+                    let msb2 = ((r >> (width - 2)) & 1) as u8;
+                    self.rf.flag_cf = cf;
+                    if count == 1 { self.rf.flag_of = msb ^ msb2; }
+                    (r, cf)
+                }
+                2 => { // RCL
+                    let cf_old = self.rf.flag_cf;
+                    let (r, cf) = rcl(a, count, width, cf_old);
+                    let msb = ((r >> (width - 1)) & 1) as u8;
+                    self.rf.flag_cf = cf;
+                    if count == 1 { self.rf.flag_of = cf ^ msb; }
+                    (r, cf)
+                }
+                3 => { // RCR
+                    let cf_old = self.rf.flag_cf;
+                    let (r, cf) = rcr(a, count, width, cf_old);
+                    let msb = ((r >> (width - 1)) & 1) as u8;
+                    let msb2 = ((r >> (width - 2)) & 1) as u8;
+                    self.rf.flag_cf = cf;
+                    if count == 1 { self.rf.flag_of = msb ^ msb2; }
+                    (r, cf)
+                }
+                4 | 6 => { // SHL/SAL
+                    let (r, cf) = shl(a, count, width);
+                    let msb = ((r >> (width - 1)) & 1) as u8;
+                    self.rf.flag_cf = cf;
+                    if count == 1 { self.rf.flag_of = cf ^ msb; }
+                    // SF/ZF/PF set below
+                    (r, cf)
+                }
+                5 => { // SHR
+                    let msb_orig = ((a >> (width - 1)) & 1) as u8;
+                    let (r, cf) = shr(a, count, width);
+                    self.rf.flag_cf = cf;
+                    if count == 1 { self.rf.flag_of = msb_orig; }
+                    (r, cf)
+                }
+                _ => { // SAR (7)
+                    let (r, cf) = sar(a, count, width);
+                    self.rf.flag_cf = cf;
+                    if count == 1 { self.rf.flag_of = 0; }
+                    (r, cf)
+                }
+            };
+
+            // SF/ZF/PF for shift operations (4/5/6/7)
+            if ext >= 4 {
+                let r_masked = result & mask;
+                self.rf.flag_sf = ((r_masked >> (width - 1)) & 1) as u8;
+                self.rf.flag_zf = if r_masked == 0 { 1 } else { 0 };
+                let bits = int_to_bits8((r_masked & 0xFF) as u8);
+                self.rf.flag_pf = compute_parity(&bits);
+            }
+
+            self.write_rm(mod_, rm, seg, ea, result & mask, word);
+            return;
+        }
+
+        // ── Control flow ──────────────────────────────────────────────────────
+
+        if op == 0xEB { // JMP short
+            let disp = self.fetch_s8() as u16;
+            let (new_ip, _, _) = add_16bit(self.rf.ip, disp, 0);
+            self.rf.ip = new_ip;
+            return;
+        }
+        if op == 0xE9 { // JMP near
+            let disp = self.fetch_s16() as u16;
+            let (new_ip, _, _) = add_16bit(self.rf.ip, disp, 0);
+            self.rf.ip = new_ip;
+            return;
+        }
+        if op == 0xEA { // JMP far
+            let new_ip = self.fetch16();
+            let new_cs = self.fetch16();
+            self.rf.ip = new_ip;
+            self.rf.cs = new_cs;
+            return;
+        }
+        if op == 0xE8 { // CALL near
+            let disp = self.fetch_s16() as u16;
+            let ip = self.rf.ip;
+            self.push16(ip);
+            let (new_ip, _, _) = add_16bit(self.rf.ip, disp, 0);
+            self.rf.ip = new_ip;
+            return;
+        }
+        if op == 0x9A { // CALL far
+            let new_ip = self.fetch16();
+            let new_cs = self.fetch16();
+            let cs = self.rf.cs; self.push16(cs);
+            let ip = self.rf.ip; self.push16(ip);
+            self.rf.ip = new_ip;
+            self.rf.cs = new_cs;
+            return;
+        }
+        if op == 0xC3 { // RET near
+            self.rf.ip = self.pop16();
+            return;
+        }
+        if op == 0xC2 { // RET n
+            let n = self.fetch16();
+            self.rf.ip = self.pop16();
+            let (new_sp, _, _) = add_16bit(self.rf.sp, n, 0);
+            self.rf.sp = new_sp;
+            return;
+        }
+        if op == 0xCB { // RETF
+            self.rf.ip = self.pop16();
+            self.rf.cs = self.pop16();
+            return;
+        }
+        if op == 0xCA { // RETF n
+            let n = self.fetch16();
+            self.rf.ip = self.pop16();
+            self.rf.cs = self.pop16();
+            let (new_sp, _, _) = add_16bit(self.rf.sp, n, 0);
+            self.rf.sp = new_sp;
+            return;
+        }
+
+        // Jcc (70–7F)
+        if (0x70..=0x7F).contains(&op) {
+            let disp = self.fetch_s8() as u16;
+            if self.eval_cond(op - 0x70) {
+                let (new_ip, _, _) = add_16bit(self.rf.ip, disp, 0);
+                self.rf.ip = new_ip;
+            }
+            return;
+        }
+
+        // LOOP / LOOPZ / LOOPNZ / JCXZ (E0–E3)
+        if (0xE0..=0xE3).contains(&op) {
+            let disp = self.fetch_s8() as u16;
+            if op != 0xE3 {
+                let (new_cx, _, _) = add_16bit(self.rf.cx, invert_16bit(1), 1);
+                self.rf.cx = new_cx;
+            }
+            let zf = self.rf.flag_zf != 0;
+            let cx = self.rf.cx;
+            let taken = match op {
+                0xE2 => cx != 0,
+                0xE1 => cx != 0 && zf,
+                0xE0 => cx != 0 && !zf,
+                _    => cx == 0, // JCXZ
+            };
+            if taken {
+                let (new_ip, _, _) = add_16bit(self.rf.ip, disp, 0);
+                self.rf.ip = new_ip;
+            }
+            return;
+        }
+
+        // ── Interrupts ─────────────────────────────────────────────────────────
+
+        if op == 0xCC { // INT 3
+            self.trigger_interrupt(3);
+            self.halted = true;
+            return;
+        }
+        if op == 0xCD { // INT n
+            let n = self.fetch8();
+            self.trigger_interrupt(n);
+            self.halted = true;
+            return;
+        }
+        if op == 0xCE { // INTO
+            self.trigger_interrupt(4);
+            self.halted = true;
+            return;
+        }
+        if op == 0xCF { // IRET
+            self.rf.ip = self.pop16();
+            self.rf.cs = self.pop16();
+            let f = self.pop16();
+            self.rf.unpack_flags(f);
+            return;
+        }
+
+        // ── String operations ──────────────────────────────────────────────────
+
+        if matches!(op, 0xA4 | 0xA5 | 0xA6 | 0xA7 | 0xAE | 0xAF | 0xAC | 0xAD | 0xAA | 0xAB) {
+            let word = (op & 1) != 0;
+            let step = self.str_step(word);
+            let seg_src = seg_override.map_or(self.rf.ds, |s| self.rf.read_seg(s));
+            match op {
+                0xAC | 0xAD => self.exec_lods(word, step, seg_src, rep_prefix),
+                0xAA | 0xAB => self.exec_stos(word, step, rep_prefix),
+                0xA4 | 0xA5 => self.exec_movs(word, step, seg_src, rep_prefix),
+                0xA6 | 0xA7 => self.exec_cmps(word, step, seg_src, rep_prefix),
+                _ => self.exec_scas(word, step, rep_prefix),
+            }
+            return;
+        }
+
+        // ── Miscellaneous ──────────────────────────────────────────────────────
+
+        if op == 0xF4 { self.halted = true; return; } // HLT
+        if op == 0xF8 { self.rf.flag_cf = 0; return; } // CLC
+        if op == 0xF9 { self.rf.flag_cf = 1; return; } // STC
+        if op == 0xF5 { self.rf.flag_cf = 1 - self.rf.flag_cf; return; } // CMC
+        if op == 0xFC { self.rf.flag_df = 0; return; } // CLD
+        if op == 0xFD { self.rf.flag_df = 1; return; } // STD
+        if op == 0xFA { self.rf.flag_if = 0; return; } // CLI
+        if op == 0xFB { self.rf.flag_if = 1; return; } // STI
+
+        // ── I/O ports ──────────────────────────────────────────────────────────
+
+        if op == 0xE4 { // IN AL, imm8
+            let port = self.fetch8() as usize;
+            self.rf.ax = (self.rf.ax & 0xFF00) | (self.input_ports[port] as u16);
+            return;
+        }
+        if op == 0xE5 { // IN AX, imm8
+            let port = self.fetch8() as usize;
+            let lo = self.input_ports[port] as u16;
+            let hi = self.input_ports[(port + 1) & 0xFF] as u16;
+            self.rf.ax = lo | (hi << 8);
+            return;
+        }
+        if op == 0xEC { // IN AL, DX
+            let port = (self.rf.dx & 0xFF) as usize;
+            self.rf.ax = (self.rf.ax & 0xFF00) | (self.input_ports[port] as u16);
+            return;
+        }
+        if op == 0xED { // IN AX, DX
+            let port = (self.rf.dx & 0xFF) as usize;
+            let lo = self.input_ports[port] as u16;
+            let hi = self.input_ports[(port + 1) & 0xFF] as u16;
+            self.rf.ax = lo | (hi << 8);
+            return;
+        }
+        if op == 0xE6 { // OUT imm8, AL
+            let port = self.fetch8() as usize;
+            self.output_ports[port] = (self.rf.ax & 0xFF) as u8;
+            return;
+        }
+        if op == 0xE7 { // OUT imm8, AX
+            let port = self.fetch8() as usize;
+            self.output_ports[port] = (self.rf.ax & 0xFF) as u8;
+            self.output_ports[(port + 1) & 0xFF] = ((self.rf.ax >> 8) & 0xFF) as u8;
+            return;
+        }
+        if op == 0xEE { // OUT DX, AL
+            let port = (self.rf.dx & 0xFF) as usize;
+            self.output_ports[port] = (self.rf.ax & 0xFF) as u8;
+            return;
+        }
+        if op == 0xEF { // OUT DX, AX
+            let port = (self.rf.dx & 0xFF) as usize;
+            self.output_ports[port] = (self.rf.ax & 0xFF) as u8;
+            self.output_ports[(port + 1) & 0xFF] = ((self.rf.ax >> 8) & 0xFF) as u8;
+            return;
+        }
+
+        if op == 0x9B { return; } // WAIT — no-op
+
+        // Unknown opcode — halt
+        self.halted = true;
+    }
+}
+
+impl Default for Cpu8086 {
+    fn default() -> Self { Self::new() }
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn run(program: &[u8]) -> Cpu8086 {
+        let mut cpu = Cpu8086::new();
+        cpu.execute(program, 10_000);
+        cpu
+    }
+
+    #[test]
+    fn mov_ax_imm16_hlt() {
+        // MOV AX, 0x1234; HLT
+        let cpu = run(&[0xB8, 0x34, 0x12, 0xF4]);
+        assert_eq!(cpu.rf.ax, 0x1234);
+        assert!(cpu.halted);
+    }
+
+    #[test]
+    fn add_ax_imm16() {
+        // MOV AX, 5; ADD AX, 3; HLT
+        let cpu = run(&[0xB8, 5, 0, 0x05, 3, 0, 0xF4]);
+        assert_eq!(cpu.rf.ax, 8);
+        assert_eq!(cpu.rf.flag_cf, 0);
+        assert_eq!(cpu.rf.flag_zf, 0);
+    }
+
+    #[test]
+    fn sub_sets_flags() {
+        // MOV AX, 1; SUB AX, 1; HLT
+        let cpu = run(&[0xB8, 1, 0, 0x2D, 1, 0, 0xF4]);
+        assert_eq!(cpu.rf.ax, 0);
+        assert_eq!(cpu.rf.flag_zf, 1);
+        assert_eq!(cpu.rf.flag_cf, 0);
+    }
+
+    #[test]
+    fn inc_dec_preserve_cf() {
+        // STC (CF=1); MOV AX, 1; INC AX; HLT
+        let cpu = run(&[0xF9, 0xB8, 1, 0, 0x40, 0xF4]);
+        assert_eq!(cpu.rf.ax, 2);
+        assert_eq!(cpu.rf.flag_cf, 1); // CF preserved by INC
+    }
+
+    #[test]
+    fn push_pop_roundtrip() {
+        // MOV AX, 0xABCD; PUSH AX; MOV AX, 0; POP BX; HLT
+        let cpu = run(&[
+            0xB8, 0xCD, 0xAB, // MOV AX, 0xABCD
+            0x50,             // PUSH AX
+            0xB8, 0, 0,       // MOV AX, 0
+            0x5B,             // POP BX
+            0xF4,
+        ]);
+        assert_eq!(cpu.rf.bx, 0xABCD);
+    }
+
+    #[test]
+    fn jmp_short() {
+        // JMP +1; MOV AX, 0xFF; MOV AX, 0x42; HLT
+        let cpu = run(&[
+            0xEB, 0x03,       // JMP +3 (skip next 3 bytes)
+            0xB8, 0xFF, 0x00, // MOV AX, 0xFF  ← skipped
+            0xB8, 0x42, 0x00, // MOV AX, 0x42
+            0xF4,
+        ]);
+        assert_eq!(cpu.rf.ax, 0x42);
+    }
+
+    #[test]
+    fn jnz_loop() {
+        // MOV CX, 3; DEC CX; JNZ -2; HLT  → CX ends at 0
+        let cpu = run(&[
+            0xB9, 3, 0,  // MOV CX, 3
+            0x49,        // DEC CX (no CF change)
+            0x75, 0xFD,  // JNZ -3 (back to DEC CX)
+            0xF4,
+        ]);
+        assert_eq!(cpu.rf.cx, 0);
+    }
+
+    #[test]
+    fn shl_basic() {
+        // MOV AL, 1; SHL AL, 1; HLT
+        let cpu = run(&[
+            0xB0, 0x01, // MOV AL, 1
+            0xD0, 0xE0, // SHL AL, 1 (D0 /4)
+            0xF4,
+        ]);
+        assert_eq!(cpu.rf.ax & 0xFF, 2);
+        assert_eq!(cpu.rf.flag_cf, 0);
+    }
+
+    #[test]
+    fn and_clears_cf_of() {
+        // MOV AX, 0x8001; ADD AX, 0x7FFF (sets CF/OF); AND AX, 0xFF; HLT
+        let cpu = run(&[
+            0xB8, 0x01, 0x80, // MOV AX, 0x8001
+            0x05, 0xFF, 0x7F, // ADD AX, 0x7FFF
+            0x25, 0xFF, 0x00, // AND AX, 0xFF
+            0xF4,
+        ]);
+        assert_eq!(cpu.rf.flag_cf, 0); // AND clears CF
+        assert_eq!(cpu.rf.flag_of, 0); // AND clears OF
+    }
+
+    #[test]
+    fn mul8_basic() {
+        // MOV AL, 10; MOV BL, 5; MUL BL; HLT
+        let cpu = run(&[
+            0xB0, 10,    // MOV AL, 10
+            0xB3, 5,     // MOV BL, 5
+            0xF6, 0xE3,  // MUL BL (F6 /4)
+            0xF4,
+        ]);
+        assert_eq!(cpu.rf.ax, 50);
+    }
+
+    #[test]
+    fn string_movs() {
+        // Set up state manually (execute() would reset it).
+        // DS:SI = 0:0x200 → 0xAA; ES:DI = 0:0x100; MOVSB copies one byte.
+        let mut cpu = Cpu8086::new();
+        cpu.mem[0x200] = 0xAA; // source byte
+        cpu.mem[0] = 0xA4;     // MOVSB
+        cpu.rf.si = 0x200;
+        cpu.rf.di = 0x100;
+        cpu.step(); // execute MOVSB
+        assert_eq!(cpu.mem[0x100], 0xAA);
+    }
+
+    #[test]
+    fn physical_address_wrapping() {
+        // Verify segment addressing: CS=0x0100, IP starts at 0
+        // Physical 0x0100 × 16 + 0 = 0x1000
+        let mut cpu = Cpu8086::new();
+        cpu.rf.cs = 0x0100;
+        cpu.rf.ip = 0;
+        cpu.mem[0x1000] = 0xF4; // HLT at physical 0x1000
+        cpu.halted = false;
+        cpu.step();
+        assert!(cpu.halted);
+    }
+}

--- a/code/packages/rust/intel8086-gatelevel/src/cpu.rs
+++ b/code/packages/rust/intel8086-gatelevel/src/cpu.rs
@@ -101,8 +101,12 @@ impl Cpu8086 {
     }
 
     /// Write program bytes into memory at a physical address.
+    ///
+    /// Bytes that would exceed the 1 MB address space are silently dropped.
+    /// If `origin >= 1_048_576`, the load is a no-op.
     pub fn load(&mut self, program: &[u8], origin: usize) {
-        let end = (origin + program.len()).min(MEM_SIZE);
+        if origin >= MEM_SIZE { return; }
+        let end = origin.saturating_add(program.len()).min(MEM_SIZE);
         self.mem[origin..end].copy_from_slice(&program[..end - origin]);
     }
 
@@ -567,17 +571,25 @@ impl Cpu8086 {
         let mut rep_prefix: Option<u8> = None;
 
         // Prefix loop — consume all prefix bytes before dispatching.
-        let op = loop {
-            let b = self.fetch8();
-            match b {
-                0x26 => seg_override = Some(0), // ES:
-                0x2E => seg_override = Some(1), // CS:
-                0x36 => seg_override = Some(2), // SS:
-                0x3E => seg_override = Some(3), // DS:
-                0xF2 | 0xF3 => rep_prefix = Some(b),
-                0xF0 => {} // LOCK — ignored in this educational simulator
-                _ => break b,
+        // Capped at 16 iterations: an infinite stream of prefix bytes would spin
+        // forever within a single step() call, bypassing the max_steps guard in
+        // execute(). The real 8086 has undefined behaviour for excessive prefixes;
+        // we treat it as #UD (halt).
+        let op = 'prefix: {
+            for _ in 0..16 {
+                let b = self.fetch8();
+                match b {
+                    0x26 => seg_override = Some(0), // ES:
+                    0x2E => seg_override = Some(1), // CS:
+                    0x36 => seg_override = Some(2), // SS:
+                    0x3E => seg_override = Some(3), // DS:
+                    0xF2 | 0xF3 => rep_prefix = Some(b),
+                    0xF0 => {} // LOCK — ignored in this educational simulator
+                    _ => break 'prefix b,
+                }
             }
+            self.halted = true; // too many prefix bytes — undefined behaviour
+            return;
         };
 
         self.exec_op(op, seg_override, rep_prefix);

--- a/code/packages/rust/intel8086-gatelevel/src/lib.rs
+++ b/code/packages/rust/intel8086-gatelevel/src/lib.rs
@@ -1,0 +1,60 @@
+//! # Intel 8086 Gate-Level Simulator
+//!
+//! Every arithmetic and logical operation routes through real gate functions:
+//! `AND → OR → XOR → NOT → full_adder → ripple_carry_adder → ALU`.
+//! Registers are modelled as 16-bit D flip-flop arrays. The instruction decoder
+//! routes opcode bits through combinational AND/OR gate trees.
+//!
+//! ## Why gate-level?
+//!
+//! The real Intel 8086 had ~29,000 transistors (NMOS, 3-micron). By simulating
+//! at gate level, we can count exactly how many gates each operation uses and
+//! trace a bit through the 16-bit ripple-carry adder (16 full-adder stages ≈ 80
+//! gate outputs). This makes the simulator an ideal teaching tool for digital
+//! logic.
+//!
+//! ## Architecture
+//!
+//! ```text
+//! bits.rs      — integer ↔ bit-vector conversion; 8-/16-/20-bit adder wrappers
+//!                nibble_borrow() for the AF flag in subtraction
+//! alu.rs       — AluResult8086: all ALU operations through gate primitives
+//!                add/sub/and/or/xor/inc/dec/neg/not, shifts, rotates, BCD, MUL/DIV
+//! registers.rs — RegisterFile8086: all 14 registers + FLAGS + physical_address()
+//! cpu.rs       — Cpu8086: full fetch-decode-execute loop, ~120 opcodes
+//! ```
+//!
+//! ## Design constraints
+//!
+//! | Area              | Constraint |
+//! |-------------------|-----------|
+//! | Data path         | Every +/–/AND/OR/XOR goes through `full_adder` / gate functions |
+//! | MUL/DIV           | Host arithmetic — gate-level ×16 multiplier is out of scope |
+//! | Segment × 16      | Bit rewiring — not computed |
+//! | Address bus       | 20-bit via `add_20bit()` ripple-carry chain |
+//! | Memory            | 1 MB flat `Box<[u8; 1_048_576]>` |
+//!
+//! ## Example
+//!
+//! ```rust
+//! use coding_adventures_intel8086_gatelevel::cpu::Cpu8086;
+//!
+//! let mut cpu = Cpu8086::new();
+//! // MOV AX, 10; MOV BX, 5; ADD AX, BX; HLT
+//! let steps = cpu.execute(&[
+//!     0xB8, 10, 0,   // MOV AX, 10
+//!     0xBB, 5, 0,    // MOV BX, 5
+//!     0x03, 0xC3,    // ADD AX, BX  (03 /r)
+//!     0xF4,          // HLT
+//! ], 1000);
+//! assert_eq!(cpu.rf.ax, 15);
+//! assert_eq!(cpu.rf.flag_cf, 0);
+//! assert!(cpu.halted);
+//! ```
+
+pub mod alu;
+pub mod bits;
+pub mod cpu;
+pub mod registers;
+
+pub use cpu::{Cpu8086, CpuState};

--- a/code/packages/rust/intel8086-gatelevel/src/registers.rs
+++ b/code/packages/rust/intel8086-gatelevel/src/registers.rs
@@ -1,0 +1,444 @@
+//! Register file for the Intel 8086 gate-level simulator.
+//!
+//! # Register architecture
+//!
+//! ```text
+//! General-purpose (16-bit, with byte-accessible halves):
+//!   AX (AH:AL)  — Accumulator; implicit in MUL/DIV/string/BCD ops
+//!   BX (BH:BL)  — Base; memory addressing base register
+//!   CX (CH:CL)  — Counter; LOOP, REP prefix, shift counts
+//!   DX (DH:DL)  — Data; high word of 32-bit MUL/DIV; I/O port address
+//!
+//! Index / pointer (16-bit only):
+//!   SI  — Source Index; default DS segment
+//!   DI  — Destination Index; default ES segment
+//!   SP  — Stack Pointer; SS segment
+//!   BP  — Base Pointer; SS segment
+//!
+//! Segment registers (16-bit):
+//!   CS  — Code Segment; physical instruction fetch = CS×16 + IP
+//!   DS  — Data Segment; default for most memory references
+//!   SS  — Stack Segment; PUSH/POP and BP-relative accesses
+//!   ES  — Extra Segment; destination for string operations
+//!
+//! Instruction pointer:
+//!   IP  — 16-bit offset within CS
+//!
+//! FLAGS (16-bit word, individual flip-flops):
+//!   bit 0: CF    bit 1: 1(always)  bit 2: PF   bit 4: AF
+//!   bit 6: ZF    bit 7: SF         bit 8: TF   bit 9: IF
+//!   bit 10: DF   bit 11: OF
+//! ```
+//!
+//! # Segment addressing
+//!
+//! Physical address = (seg_reg << 4) + offset, modulo 1 MB.
+//!
+//! The "× 16" shift is **wire routing** — bits 0-15 of the segment feed into
+//! positions 4-19 of the 20-bit address bus, with positions 0-3 tied to zero.
+//! The 16-bit offset is then added using a 20-bit ripple-carry chain.
+//!
+//! # ModRM register encodings
+//!
+//! ```text
+//! 16-bit:    0=AX 1=CX 2=DX 3=BX 4=SP 5=BP 6=SI 7=DI
+//!  8-bit:    0=AL 1=CL 2=DL 3=BL 4=AH 5=CH 6=DH 7=BH
+//! Segment:   0=ES 1=CS 2=SS 3=DS
+//! ```
+
+use arithmetic::adders::full_adder;
+use logic_gates::gates::{and_gate, or_gate};
+
+
+// ─── Register file struct ─────────────────────────────────────────────────────
+
+/// Complete Intel 8086 register file.
+///
+/// All registers are stored as `u16` integers; flag bits as `u8` (0 or 1).
+/// Byte-access methods (AL/AH etc.) read/write the appropriate 8-bit half.
+///
+/// # Example
+/// ```
+/// use coding_adventures_intel8086_gatelevel::registers::RegisterFile8086;
+/// let mut rf = RegisterFile8086::new();
+/// rf.write16(0, 0x1234); // AX = 0x1234
+/// assert_eq!(rf.read8_low(0), 0x34); // AL = 0x34
+/// assert_eq!(rf.read8_high(0), 0x12); // AH = 0x12
+/// ```
+#[derive(Debug, Clone)]
+pub struct RegisterFile8086 {
+    // General-purpose registers
+    pub ax: u16,
+    pub bx: u16,
+    pub cx: u16,
+    pub dx: u16,
+    // Index and pointer registers
+    pub si: u16,
+    pub di: u16,
+    pub sp: u16,
+    pub bp: u16,
+    // Segment registers
+    pub cs: u16,
+    pub ds: u16,
+    pub ss: u16,
+    pub es: u16,
+    // Instruction pointer
+    pub ip: u16,
+    // FLAGS — individual D flip-flops
+    pub flag_cf: u8, // carry
+    pub flag_pf: u8, // parity
+    pub flag_af: u8, // auxiliary carry
+    pub flag_zf: u8, // zero
+    pub flag_sf: u8, // sign
+    pub flag_tf: u8, // trap
+    pub flag_if: u8, // interrupt enable
+    pub flag_df: u8, // direction
+    pub flag_of: u8, // overflow
+}
+
+impl RegisterFile8086 {
+    /// Create a new register file with all registers initialised to 0.
+    pub fn new() -> Self {
+        RegisterFile8086 {
+            ax: 0, bx: 0, cx: 0, dx: 0,
+            si: 0, di: 0, sp: 0, bp: 0,
+            cs: 0, ds: 0, ss: 0, es: 0,
+            ip: 0,
+            flag_cf: 0, flag_pf: 0, flag_af: 0, flag_zf: 0,
+            flag_sf: 0, flag_tf: 0, flag_if: 0, flag_df: 0,
+            flag_of: 0,
+        }
+    }
+
+    // ── ModRM 16-bit register read/write ──────────────────────────────────────
+    //
+    // ModRM field r/m / reg encoding for 16-bit operands:
+    //   0=AX, 1=CX, 2=DX, 3=BX, 4=SP, 5=BP, 6=SI, 7=DI
+
+    /// Read a 16-bit general or index register by ModRM code (0–7).
+    pub fn read16(&self, code: u8) -> u16 {
+        match code & 7 {
+            0 => self.ax, 1 => self.cx, 2 => self.dx, 3 => self.bx,
+            4 => self.sp, 5 => self.bp, 6 => self.si, _ => self.di,
+        }
+    }
+
+    /// Write a 16-bit general or index register by ModRM code (0–7).
+    pub fn write16(&mut self, code: u8, value: u16) {
+        match code & 7 {
+            0 => self.ax = value, 1 => self.cx = value,
+            2 => self.dx = value, 3 => self.bx = value,
+            4 => self.sp = value, 5 => self.bp = value,
+            6 => self.si = value, _ => self.di = value,
+        }
+    }
+
+    // ── 8-bit register access (ModRM encoding) ────────────────────────────────
+    //
+    // Byte register encoding:
+    //   0=AL, 1=CL, 2=DL, 3=BL, 4=AH, 5=CH, 6=DH, 7=BH
+
+    /// Read an 8-bit register by ModRM byte-register code (0–7).
+    pub fn read8(&self, code: u8) -> u8 {
+        match code & 7 {
+            0 => self.read8_low(0),  // AL
+            1 => self.read8_low(1),  // CL
+            2 => self.read8_low(2),  // DL
+            3 => self.read8_low(3),  // BL
+            4 => self.read8_high(0), // AH
+            5 => self.read8_high(1), // CH
+            6 => self.read8_high(2), // DH
+            _ => self.read8_high(3), // BH
+        }
+    }
+
+    /// Write an 8-bit register by ModRM byte-register code (0–7).
+    pub fn write8(&mut self, code: u8, value: u8) {
+        match code & 7 {
+            0 => self.write8_low(0, value),  // AL
+            1 => self.write8_low(1, value),  // CL
+            2 => self.write8_low(2, value),  // DL
+            3 => self.write8_low(3, value),  // BL
+            4 => self.write8_high(0, value), // AH
+            5 => self.write8_high(1, value), // CH
+            6 => self.write8_high(2, value), // DH
+            _ => self.write8_high(3, value), // BH
+        }
+    }
+
+    // ── Byte-half helpers ─────────────────────────────────────────────────────
+    //
+    // The four general-purpose registers provide access to their low byte (xL)
+    // and high byte (xH). These are physical sub-word ports of a single 16-bit
+    // register cell.
+    //
+    // `code` here is the 16-bit ModRM code (0=AX,1=CX,2=DX,3=BX).
+
+    /// Read the low byte of a general-purpose register (AL/CL/DL/BL).
+    pub fn read8_low(&self, code: u8) -> u8 {
+        (self.read16(code) & 0xFF) as u8
+    }
+
+    /// Write the low byte of a general-purpose register (AL/CL/DL/BL).
+    pub fn write8_low(&mut self, code: u8, value: u8) {
+        let old = self.read16(code);
+        self.write16(code, (old & 0xFF00) | (value as u16));
+    }
+
+    /// Read the high byte of a general-purpose register (AH/CH/DH/BH).
+    pub fn read8_high(&self, code: u8) -> u8 {
+        ((self.read16(code) >> 8) & 0xFF) as u8
+    }
+
+    /// Write the high byte of a general-purpose register (AH/CH/DH/BH).
+    pub fn write8_high(&mut self, code: u8, value: u8) {
+        let old = self.read16(code);
+        self.write16(code, (old & 0x00FF) | ((value as u16) << 8));
+    }
+
+    // ── Segment register access ───────────────────────────────────────────────
+    //
+    // ModRM segment field encoding: 0=ES, 1=CS, 2=SS, 3=DS
+
+    /// Read a segment register by ModRM segment field (0–3).
+    pub fn read_seg(&self, code: u8) -> u16 {
+        match code & 3 {
+            0 => self.es, 1 => self.cs, 2 => self.ss, _ => self.ds,
+        }
+    }
+
+    /// Write a segment register by ModRM segment field (0–3).
+    pub fn write_seg(&mut self, code: u8, value: u16) {
+        match code & 3 {
+            0 => self.es = value, 1 => self.cs = value,
+            2 => self.ss = value, _ => self.ds = value,
+        }
+    }
+
+    // ── FLAGS pack / unpack ───────────────────────────────────────────────────
+    //
+    // The FLAGS word is laid out as a 16-bit register:
+    //
+    //   bit 0: CF   bit 1: 1   bit 2: PF   bit 4: AF
+    //   bit 6: ZF   bit 7: SF  bit 8: TF   bit 9: IF
+    //   bit 10: DF  bit 11: OF
+    //
+    // Gate path: each flag passes through an OR gate with 0 (no-op identity)
+    // to model driving the bus through a real gate layer.
+
+    /// Pack all flag flip-flops into a 16-bit FLAGS word.
+    ///
+    /// Bit 1 is always 1 (8086 hardware invariant).
+    pub fn pack_flags(&self) -> u16 {
+        let cf = or_gate(self.flag_cf, 0);
+        let pf = or_gate(self.flag_pf, 0);
+        let af = or_gate(self.flag_af, 0);
+        let zf = or_gate(self.flag_zf, 0);
+        let sf = or_gate(self.flag_sf, 0);
+        let tf = or_gate(self.flag_tf, 0);
+        let if_ = or_gate(self.flag_if, 0);
+        let df = or_gate(self.flag_df, 0);
+        let of = or_gate(self.flag_of, 0);
+        ((cf as u16) << 0)
+            | (1u16 << 1)
+            | ((pf as u16) << 2)
+            | ((af as u16) << 4)
+            | ((zf as u16) << 6)
+            | ((sf as u16) << 7)
+            | ((tf as u16) << 8)
+            | ((if_ as u16) << 9)
+            | ((df as u16) << 10)
+            | ((of as u16) << 11)
+    }
+
+    /// Unpack a 16-bit FLAGS word into individual flag flip-flops.
+    ///
+    /// Used by POPF and IRET. Each bit is latched through an AND gate with 1
+    /// to model the register input path.
+    pub fn unpack_flags(&mut self, flags: u16) {
+        self.flag_cf = and_gate(((flags >> 0) & 1) as u8, 1);
+        self.flag_pf = and_gate(((flags >> 2) & 1) as u8, 1);
+        self.flag_af = and_gate(((flags >> 4) & 1) as u8, 1);
+        self.flag_zf = and_gate(((flags >> 6) & 1) as u8, 1);
+        self.flag_sf = and_gate(((flags >> 7) & 1) as u8, 1);
+        self.flag_tf = and_gate(((flags >> 8) & 1) as u8, 1);
+        self.flag_if = and_gate(((flags >> 9) & 1) as u8, 1);
+        self.flag_df = and_gate(((flags >> 10) & 1) as u8, 1);
+        self.flag_of = and_gate(((flags >> 11) & 1) as u8, 1);
+    }
+
+    // ── Physical address computation ──────────────────────────────────────────
+
+    /// Compute the 20-bit physical address for a segment:offset pair.
+    ///
+    /// Physical address = (seg_reg × 16 + offset) & 0xFFFFF.
+    ///
+    /// The "× 16" step is **bit rewiring** — the 16-bit segment value is
+    /// placed on bus lines 4–19 with bus lines 0–3 fixed to 0 (no gates).
+    /// The 16-bit offset is then added via a 20-stage ripple-carry adder.
+    ///
+    /// # Example
+    /// ```
+    /// use coding_adventures_intel8086_gatelevel::registers::RegisterFile8086;
+    /// let mut rf = RegisterFile8086::new();
+    /// rf.cs = 0x1000;
+    /// assert_eq!(rf.physical_address(rf.cs, 0x0100), 0x10100);
+    /// ```
+    pub fn physical_address(&self, seg: u16, offset: u16) -> u32 {
+        // seg × 16: wire bits 0-15 of seg to positions 4-19 of the 20-bit bus.
+        let seg20 = (seg as u32) << 4;
+        add_20bit(seg20, offset as u32) & 0xFFFFF
+    }
+
+    // ── Named-register helpers (convenience, not ModRM) ───────────────────────
+
+    /// Read AL (AX low byte).
+    pub fn al(&self) -> u8 { self.read8_low(0) }
+    /// Write AL.
+    pub fn set_al(&mut self, v: u8) { self.write8_low(0, v); }
+    /// Read AH (AX high byte).
+    pub fn ah(&self) -> u8 { self.read8_high(0) }
+    /// Write AH.
+    pub fn set_ah(&mut self, v: u8) { self.write8_high(0, v); }
+    /// Read BL.
+    pub fn bl(&self) -> u8 { self.read8_low(3) }
+    /// Write BL.
+    pub fn set_bl(&mut self, v: u8) { self.write8_low(3, v); }
+    /// Read BH.
+    pub fn bh(&self) -> u8 { self.read8_high(3) }
+    /// Write BH.
+    pub fn set_bh(&mut self, v: u8) { self.write8_high(3, v); }
+    /// Read CL.
+    pub fn cl(&self) -> u8 { self.read8_low(1) }
+    /// Write CL.
+    pub fn set_cl(&mut self, v: u8) { self.write8_low(1, v); }
+    /// Read CH.
+    pub fn ch(&self) -> u8 { self.read8_high(1) }
+    /// Write CH.
+    pub fn set_ch(&mut self, v: u8) { self.write8_high(1, v); }
+    /// Read DL.
+    pub fn dl(&self) -> u8 { self.read8_low(2) }
+    /// Write DL.
+    pub fn set_dl(&mut self, v: u8) { self.write8_low(2, v); }
+    /// Read DH.
+    pub fn dh(&self) -> u8 { self.read8_high(2) }
+    /// Write DH.
+    pub fn set_dh(&mut self, v: u8) { self.write8_high(2, v); }
+}
+
+impl Default for RegisterFile8086 {
+    fn default() -> Self { Self::new() }
+}
+
+// ─── 20-bit ripple-carry adder ────────────────────────────────────────────────
+
+/// Add two 20-bit values through a 20-stage ripple-carry chain.
+///
+/// Used for segment:offset physical address computation. The result is masked
+/// to 20 bits (0–0xFFFFF) to model the 8086's 20-bit address bus.
+pub fn add_20bit(a: u32, b: u32) -> u32 {
+    // Expand to 20-element LSB-first bit vectors.
+    let a_bits: Vec<u8> = (0..20).map(|i| ((a >> i) & 1) as u8).collect();
+    let b_bits: Vec<u8> = (0..20).map(|i| ((b >> i) & 1) as u8).collect();
+    let mut carry = 0u8;
+    let mut sums = Vec::with_capacity(20);
+    for i in 0..20 {
+        let (s, c) = full_adder(a_bits[i], b_bits[i], carry);
+        sums.push(s);
+        carry = c;
+    }
+    sums.iter()
+        .take(20)
+        .enumerate()
+        .fold(0u32, |acc, (i, &b)| acc | ((b as u32) << i))
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn read_write_16bit() {
+        let mut rf = RegisterFile8086::new();
+        rf.write16(0, 0x1234); // AX
+        assert_eq!(rf.read16(0), 0x1234);
+        rf.write16(1, 0xABCD); // CX
+        assert_eq!(rf.read16(1), 0xABCD);
+    }
+
+    #[test]
+    fn byte_halves_are_independent() {
+        let mut rf = RegisterFile8086::new();
+        rf.write16(0, 0x1234); // AX = 0x1234
+        assert_eq!(rf.al(), 0x34); // low
+        assert_eq!(rf.ah(), 0x12); // high
+        rf.set_al(0xFF);
+        assert_eq!(rf.read16(0), 0x12FF);
+        rf.set_ah(0xAB);
+        assert_eq!(rf.read16(0), 0xABFF);
+    }
+
+    #[test]
+    fn read8_modrm_encoding() {
+        let mut rf = RegisterFile8086::new();
+        rf.ax = 0x1234;
+        rf.cx = 0x5678;
+        // ModRM 8-bit encoding: 0=AL, 1=CL, 4=AH, 5=CH
+        assert_eq!(rf.read8(0), 0x34); // AL
+        assert_eq!(rf.read8(1), 0x78); // CL
+        assert_eq!(rf.read8(4), 0x12); // AH
+        assert_eq!(rf.read8(5), 0x56); // CH
+    }
+
+    #[test]
+    fn segment_register_encoding() {
+        let mut rf = RegisterFile8086::new();
+        rf.write_seg(1, 0x2000); // CS
+        assert_eq!(rf.read_seg(1), 0x2000);
+        rf.write_seg(3, 0x3000); // DS
+        assert_eq!(rf.read_seg(3), 0x3000);
+        assert_eq!(rf.ds, 0x3000);
+    }
+
+    #[test]
+    fn pack_unpack_flags_roundtrip() {
+        let mut rf = RegisterFile8086::new();
+        rf.flag_cf = 1;
+        rf.flag_zf = 1;
+        rf.flag_pf = 1;
+        let packed = rf.pack_flags();
+        assert_eq!(packed & 1, 1); // CF
+        assert_eq!((packed >> 1) & 1, 1); // always 1
+        assert_eq!((packed >> 6) & 1, 1); // ZF
+        let mut rf2 = RegisterFile8086::new();
+        rf2.unpack_flags(packed);
+        assert_eq!(rf2.flag_cf, 1);
+        assert_eq!(rf2.flag_zf, 1);
+        assert_eq!(rf2.flag_pf, 1);
+        assert_eq!(rf2.flag_sf, 0);
+    }
+
+    #[test]
+    fn pack_flags_bit1_always_set() {
+        let rf = RegisterFile8086::new();
+        assert_eq!((rf.pack_flags() >> 1) & 1, 1);
+    }
+
+    #[test]
+    fn physical_address_basic() {
+        let rf = RegisterFile8086::new();
+        // CS=0x1000, offset=0x0100 → 0x1000 * 16 + 0x100 = 0x10100
+        assert_eq!(rf.physical_address(0x1000, 0x0100), 0x10100);
+        // Wrap around: 0xFFFF * 16 + 0xFFFF = 0xFFFF0 + 0xFFFF = 0x1FFEF → masked to 0xFFEF
+        // Actually: 0xFFFF0 + 0xFFFF = 0x1FFFEF, masked to 0xFFEF
+        assert_eq!(rf.physical_address(0xFFFF, 0xFFFF) & 0xFFFFF, (0xFFFF0u32 + 0xFFFFu32) & 0xFFFFF);
+    }
+
+    #[test]
+    fn add_20bit_basic() {
+        assert_eq!(add_20bit(0x10000, 0x00100), 0x10100);
+        assert_eq!(add_20bit(0xFFFFF, 1) & 0xFFFFF, 0); // 20-bit wrap
+    }
+}


### PR DESCRIPTION
## Summary

- Gate-level simulator for the Intel 8086 (1978) in Rust, crate `coding-adventures-intel8086-gatelevel`
- Every arithmetic/logical data-path operation routes through `full_adder` chains and logic gate primitives from the `logic-gates` and `arithmetic` workspace crates
- Implements ~120 opcodes including ModRM, REP prefix, string operations, segment overrides, BCD ops, and I/O ports

## Architecture

| File | Contents |
|------|---------|
| `bits.rs` | LSB-first bit-vector conversion, 8/16/20-bit adder wrappers, `nibble_borrow()` for AF flag in subtraction |
| `alu.rs` | `AluResult8086` with all 6 flags; add/sub/and/or/xor/inc/dec/neg/not (8-bit + 16-bit), shifts, rotates, BCD, MUL/DIV |
| `registers.rs` | `RegisterFile8086` — 14 registers + 9 flag flip-flops, ModRM encoding, `pack_flags`/`unpack_flags`, `physical_address()` |
| `cpu.rs` | `Cpu8086` — 1 MB flat memory, 256-byte I/O ports, full fetch-decode-execute loop |

## Key design decisions

- **SUB CF**: `NOT(adder_carry_out)` — two's complement carry is inverted for borrow
- **AF flag**: dedicated `nibble_borrow()` 4-bit subtractor — the adder's aux carry is incorrect for SUB in two's complement representation
- **INC/DEC**: caller preserves old CF (hardware invariant)
- **Overflow**: `XOR(carries[N-2], carries[N-1])` — single gate at MSB
- **Memory**: `Box<[u8; 1_048_576]>` — heap-allocated to avoid stack overflow
- **MUL/DIV**: host arithmetic exception — gate-level 16×16 multiplier (~1000 gates) is documented out-of-scope

## Test plan

- [ ] All 56 unit tests pass (`cargo test -p coding-adventures-intel8086-gatelevel`)
- [ ] All 14 doctests pass
- [ ] Zero compiler warnings
- [ ] Security review passed (2 LOW findings fixed: prefix loop cap + `load()` bounds check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)