### PR TITLE
Add SPICE selected output probe artifacts

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ### Added
 
+- **Deck selected-output artifact metadata** —
+  `run_deck_analysis()` now returns the normalized deck-selected output probes
+  alongside each selected plan, solver result, and stable table, matching Rust
+  and TypeScript.
+
 - **Deck transient print-step output routing** —
   `run_deck_analysis()` now keeps `.tran TSTEP` as the stable deck output
   print grid while `MAXSTEP` caps internal solver stepping, matching Rust and

--- a/code/packages/python/spice-engine/README.md
+++ b/code/packages/python/spice-engine/README.md
@@ -102,7 +102,8 @@ explicit card by analysis alias, defaults decks without analysis cards to an
 implicit `.op`, and reports ambiguity before solver dispatch.
 `run_deck_analysis()` executes one selected `.op`, `.dc`, `.ac LIN`,
 `.ac DEC`, `.ac OCT`, or `.tran` plan against an existing `Circuit` and
-returns the plan, solver result, and deck-selected output table. Selected
+returns the plan, solver result, deck-selected output table, and normalized
+output probes that produced the table. Selected
 `.tran` plans route `START` output filtering, use `.tran TSTEP` as the output
 print grid, apply `MAXSTEP` as an internal fixed-step cap, and carry `UIC`
 initial-condition intent through that stable transient table surface.
@@ -186,9 +187,9 @@ diagnostics for malformed deck-level analysis controls.
 `select_deck_analysis_plan()` returns one selected or implicit plan for
 downstream deck execution helpers.
 `run_deck_analysis()` routes that selected plan into the matching solver and
-stable deck-selected table output, including `.ac LIN`, `.ac DEC`, `.ac OCT`
-frequency grids, and `.tran` `START` / print-step `TSTEP` / `MAXSTEP` / `UIC`
-controls.
+stable deck-selected table output with normalized output-probe artifacts,
+including `.ac LIN`, `.ac DEC`, `.ac OCT` frequency grids, and `.tran`
+`START` / print-step `TSTEP` / `MAXSTEP` / `UIC` controls.
 
 ## Controlled source examples
 

--- a/code/packages/python/spice-engine/src/spice_engine/engine.py
+++ b/code/packages/python/spice-engine/src/spice_engine/engine.py
@@ -2300,6 +2300,7 @@ class DeckAnalysisExecution:
     plan: DeckAnalysisPlan
     result: DcResult | DcSweepResult | AcResult | TransientResult
     table: str
+    output_probes: list[str]
 
 
 def run_deck_analysis(
@@ -2316,6 +2317,7 @@ def run_deck_analysis(
             plan=plan,
             result=result,
             table=format_deck_op_table(result, netlist),
+            output_probes=select_deck_output_probes(netlist, plan.analysis),
         )
     if plan.analysis == "dc":
         source_name = _require_deck_plan_string(plan, "source_name")
@@ -2327,6 +2329,7 @@ def run_deck_analysis(
             plan=plan,
             result=result,
             table=format_deck_dc_sweep_table(result, netlist),
+            output_probes=select_deck_output_probes(netlist, plan.analysis),
         )
     if plan.analysis == "ac":
         sweep_kind = _require_deck_plan_string(plan, "sweep_kind")
@@ -2340,6 +2343,7 @@ def run_deck_analysis(
             plan=plan,
             result=result,
             table=format_deck_ac_table(result, netlist),
+            output_probes=select_deck_output_probes(netlist, plan.analysis),
         )
     if plan.analysis == "tran":
         step_time = _require_deck_plan_number(plan, "step_time")
@@ -2357,6 +2361,7 @@ def run_deck_analysis(
             plan=plan,
             result=result,
             table=format_deck_transient_table(result, netlist),
+            output_probes=select_deck_output_probes(netlist, plan.analysis),
         )
     raise ValueError(f"run_deck_analysis: unsupported analysis {plan.analysis!r}")
 

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -6773,10 +6773,12 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
 
     op_execution = run_deck_analysis(circuit, netlist, "op")
     assert op_execution.plan.analysis == "op"
+    assert op_execution.output_probes == ["V(mid)"]
     assert op_execution.table == "Index\tV(mid)\n0\t5.000000e-01\n"
 
     dc_execution = run_deck_analysis(circuit, netlist, "dc")
     assert dc_execution.plan.source_name == "V1"
+    assert dc_execution.output_probes == ["V(mid)", "I(V1)"]
     assert isinstance(dc_execution.result, DcSweepResult)
     assert len(dc_execution.result.points) == 2
     assert dc_execution.table == (
@@ -6786,6 +6788,7 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
     )
 
     ac_execution = run_deck_analysis(circuit, netlist, "ac")
+    assert ac_execution.output_probes == ["V(mid)"]
     assert isinstance(ac_execution.result, AcResult)
     assert len(ac_execution.result.points) == 1
     assert ac_execution.table == (
@@ -6794,6 +6797,7 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
     )
 
     tran_execution = run_deck_analysis(circuit, netlist, "tran")
+    assert tran_execution.output_probes == ["V(mid)"]
     assert isinstance(tran_execution.result, TransientResult)
     assert tran_execution.table == (
         "Index\tTime\tV(mid)\n"
@@ -6808,6 +6812,7 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
     assert tran_window_execution.plan.start_time == pytest.approx(2.0e-3)
     assert tran_window_execution.plan.max_step == pytest.approx(1.0e-3)
     assert tran_window_execution.plan.use_initial_conditions is True
+    assert tran_window_execution.output_probes == ["V(mid)"]
     assert isinstance(tran_window_execution.result, TransientResult)
     assert [point.time for point in tran_window_execution.result.points] == pytest.approx(
         [2.0e-3, 4.0e-3, 6.0e-3],
@@ -6823,6 +6828,7 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
         run_deck_analysis(circuit, netlist)
 
     lin_execution = run_deck_analysis(circuit, ".save V(mid)\n.ac lin 3 1 3\n.end\n")
+    assert lin_execution.output_probes == ["V(mid)"]
     assert isinstance(lin_execution.result, AcResult)
     assert [point.freq for point in lin_execution.result.points] == [1.0, 2.0, 3.0]
     assert lin_execution.table == (
@@ -6833,6 +6839,7 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
     )
 
     oct_execution = run_deck_analysis(circuit, ".save V(mid)\n.ac oct 1 1 4\n.end\n")
+    assert oct_execution.output_probes == ["V(mid)"]
     assert isinstance(oct_execution.result, AcResult)
     assert [point.freq for point in oct_execution.result.points] == [1.0, 2.0, 4.0]
     assert oct_execution.table == (

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Add selected-output probe artifacts to `run_deck_analysis`; callers now
+  receive the normalized deck-selected output probes alongside each selected
+  plan, solver result, and stable table, matching Python and TypeScript.
 - Add `.tran` print-step output routing to `run_deck_analysis`; deck transient
   plans now keep `.tran TSTEP` as the stable output print grid while `MAXSTEP`
   caps internal solver stepping, matching Python and TypeScript.

--- a/code/packages/rust/spice-engine/README.md
+++ b/code/packages/rust/spice-engine/README.md
@@ -156,7 +156,8 @@ card by analysis alias, defaults decks without analysis cards to an implicit
 `.op`, and reports ambiguity before solver dispatch.
 `run_deck_analysis` executes one selected `.op`, `.dc`, `.ac LIN`, `.ac DEC`,
 `.ac OCT`, or `.tran` plan against an existing `Circuit` and returns the plan,
-solver result, and deck-selected output table. Selected `.tran` plans route
+solver result, deck-selected output table, and normalized output probes that
+produced the table. Selected `.tran` plans route
 `START` output filtering, use `.tran TSTEP` as the output print grid, apply
 `MAXSTEP` as an internal fixed-step cap, and carry `UIC` initial-condition
 intent through that stable transient table surface.
@@ -199,6 +200,6 @@ malformed deck-level analysis controls.
 `select_deck_analysis_plan` returns one selected or implicit plan for
 downstream deck execution helpers.
 `run_deck_analysis` routes that selected plan into the matching solver and
-stable deck-selected table output, including `.ac LIN`, `.ac DEC`, `.ac OCT`
-frequency grids, and `.tran` `START` / print-step `TSTEP` / `MAXSTEP` / `UIC`
-controls.
+stable deck-selected table output with normalized output-probe artifacts,
+including `.ac LIN`, `.ac DEC`, `.ac OCT` frequency grids, and `.tran`
+`START` / print-step `TSTEP` / `MAXSTEP` / `UIC` controls.

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -3403,6 +3403,7 @@ pub struct DeckAnalysisExecution {
     pub plan: DeckAnalysisPlan,
     pub result: DeckAnalysisExecutionResult,
     pub table: String,
+    pub output_probes: Vec<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -9426,6 +9427,7 @@ pub fn run_deck_analysis(
                 plan,
                 result: DeckAnalysisExecutionResult::Op(result),
                 table,
+                output_probes: select_deck_output_probes(netlist, "op")?,
             })
         }
         "dc" => {
@@ -9441,6 +9443,7 @@ pub fn run_deck_analysis(
                 plan,
                 result: DeckAnalysisExecutionResult::DcSweep(result),
                 table,
+                output_probes: select_deck_output_probes(netlist, "dc")?,
             })
         }
         "ac" => {
@@ -9457,6 +9460,7 @@ pub fn run_deck_analysis(
                 plan,
                 result: DeckAnalysisExecutionResult::Ac(result),
                 table,
+                output_probes: select_deck_output_probes(netlist, "ac")?,
             })
         }
         "tran" => {
@@ -9476,6 +9480,7 @@ pub fn run_deck_analysis(
                 plan,
                 result: DeckAnalysisExecutionResult::Tran(result),
                 table,
+                output_probes: select_deck_output_probes(netlist, "tran")?,
             })
         }
         _ => Err(SpiceError::InvalidElement {

--- a/code/packages/rust/spice-engine/tests/transient_tests.rs
+++ b/code/packages/rust/spice-engine/tests/transient_tests.rs
@@ -1871,10 +1871,15 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
 
     let op_execution = run_deck_analysis(&circuit, netlist, Some("op")).unwrap();
     assert_eq!(op_execution.plan.analysis, "op");
+    assert_eq!(op_execution.output_probes, vec!["V(mid)".to_string()]);
     assert_eq!(op_execution.table, "Index\tV(mid)\n0\t5.000000e-01\n");
 
     let dc_execution = run_deck_analysis(&circuit, netlist, Some("dc")).unwrap();
     assert_eq!(dc_execution.plan.source_name.as_deref(), Some("V1"));
+    assert_eq!(
+        dc_execution.output_probes,
+        vec!["V(mid)".to_string(), "I(V1)".to_string()]
+    );
     match dc_execution.result {
         DeckAnalysisExecutionResult::DcSweep(points) => assert_eq!(points.len(), 2),
         other => panic!("expected DC sweep result, got {other:?}"),
@@ -1885,6 +1890,7 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
     );
 
     let ac_execution = run_deck_analysis(&circuit, netlist, Some("ac")).unwrap();
+    assert_eq!(ac_execution.output_probes, vec!["V(mid)".to_string()]);
     match ac_execution.result {
         DeckAnalysisExecutionResult::Ac(points) => assert_eq!(points.len(), 1),
         other => panic!("expected AC result, got {other:?}"),
@@ -1895,6 +1901,7 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
     );
 
     let tran_execution = run_deck_analysis(&circuit, netlist, Some("tran")).unwrap();
+    assert_eq!(tran_execution.output_probes, vec!["V(mid)".to_string()]);
     match tran_execution.result {
         DeckAnalysisExecutionResult::Tran(points) => assert_eq!(points.len(), 1),
         other => panic!("expected transient result, got {other:?}"),
@@ -1913,6 +1920,10 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
     assert!((tran_window_execution.plan.start_time.unwrap() - 2.0e-3).abs() < 1.0e-12);
     assert!((tran_window_execution.plan.max_step.unwrap() - 1.0e-3).abs() < 1.0e-12);
     assert!(tran_window_execution.plan.use_initial_conditions);
+    assert_eq!(
+        tran_window_execution.output_probes,
+        vec!["V(mid)".to_string()]
+    );
     match &tran_window_execution.result {
         DeckAnalysisExecutionResult::Tran(points) => {
             let expected_times = [2.0e-3, 4.0e-3, 6.0e-3];
@@ -1933,6 +1944,7 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
 
     let lin_execution =
         run_deck_analysis(&circuit, ".save V(mid)\n.ac lin 3 1 3\n.end\n", None).unwrap();
+    assert_eq!(lin_execution.output_probes, vec!["V(mid)".to_string()]);
     match &lin_execution.result {
         DeckAnalysisExecutionResult::Ac(points) => assert_eq!(
             points
@@ -1950,6 +1962,7 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
 
     let oct_execution =
         run_deck_analysis(&circuit, ".save V(mid)\n.ac oct 1 1 4\n.end\n", None).unwrap();
+    assert_eq!(oct_execution.output_probes, vec!["V(mid)".to_string()]);
     match &oct_execution.result {
         DeckAnalysisExecutionResult::Ac(points) => assert_eq!(
             points

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Add selected-output probe artifacts to `runDeckAnalysis`; callers now receive
+  the normalized deck-selected output probes alongside each selected plan,
+  solver result, and stable table, matching Python and Rust.
 - Add `.tran` print-step output routing to `runDeckAnalysis`; deck transient
   plans now keep `.tran TSTEP` as the stable output print grid while `MAXSTEP`
   caps internal solver stepping, matching Python and Rust.

--- a/code/packages/typescript/spice-engine/README.md
+++ b/code/packages/typescript/spice-engine/README.md
@@ -90,7 +90,8 @@ by analysis alias, defaults decks without analysis cards to an implicit `.op`,
 and reports ambiguity before solver dispatch.
 `runDeckAnalysis` executes one selected `.op`, `.dc`, `.ac LIN`, `.ac DEC`,
 `.ac OCT`, or `.tran` plan against an existing `Circuit` and returns the plan,
-solver result, and deck-selected output table. Selected `.tran` plans route
+solver result, deck-selected output table, and normalized output probes that
+produced the table. Selected `.tran` plans route
 `START` output filtering, use `.tran TSTEP` as the output print grid, apply
 `MAXSTEP` as an internal fixed-step cap, and carry `UIC` initial-condition
 intent through that stable transient table surface.
@@ -162,6 +163,6 @@ malformed deck-level analysis controls.
 `selectDeckAnalysisPlan` returns one selected or implicit plan for downstream
 deck execution helpers.
 `runDeckAnalysis` routes that selected plan into the matching solver and stable
-deck-selected table output, including `.ac LIN`, `.ac DEC`, `.ac OCT`
-frequency grids, and `.tran` `START` / print-step `TSTEP` / `MAXSTEP` / `UIC`
-controls.
+deck-selected table output with normalized output-probe artifacts, including
+`.ac LIN`, `.ac DEC`, `.ac OCT` frequency grids, and `.tran` `START` /
+print-step `TSTEP` / `MAXSTEP` / `UIC` controls.

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -658,6 +658,7 @@ export interface DeckAnalysisExecution {
   readonly plan: DeckAnalysisPlan;
   readonly result: DeckAnalysisExecutionResult;
   readonly table: string;
+  readonly outputProbes: readonly string[];
 }
 
 export interface ReleaseReadinessIssue {
@@ -7258,7 +7259,12 @@ export function runDeckAnalysis(
   const plan = selectDeckAnalysisPlan(netlist, analysis);
   if (plan.analysis === "op") {
     const result = dcOp(circuit);
-    return { plan, result, table: formatDeckOpTable(result, netlist) };
+    return {
+      plan,
+      result,
+      table: formatDeckOpTable(result, netlist),
+      outputProbes: selectDeckOutputProbes(netlist, plan.analysis),
+    };
   }
   if (plan.analysis === "dc") {
     const sourceName = requireDeckPlanString(plan.sourceName, plan, "sourceName");
@@ -7266,7 +7272,12 @@ export function runDeckAnalysis(
     const stop = requireDeckPlanNumber(plan.stopValue, plan, "stopValue");
     const step = requireDeckPlanNumber(plan.stepValue, plan, "stepValue");
     const result = dcSweep(circuit, sourceName, start, stop, step);
-    return { plan, result, table: formatDeckDcSweepTable(sourceName, result, netlist) };
+    return {
+      plan,
+      result,
+      table: formatDeckDcSweepTable(sourceName, result, netlist),
+      outputProbes: selectDeckOutputProbes(netlist, plan.analysis),
+    };
   }
   if (plan.analysis === "ac") {
     const sweepKind = requireDeckPlanString(plan.sweepKind, plan, "sweepKind");
@@ -7285,7 +7296,12 @@ export function runDeckAnalysis(
       startFrequencyHz,
       stopFrequencyHz,
     );
-    return { plan, result, table: formatDeckAcTable(result, netlist) };
+    return {
+      plan,
+      result,
+      table: formatDeckAcTable(result, netlist),
+      outputProbes: selectDeckOutputProbes(netlist, plan.analysis),
+    };
   }
   if (plan.analysis === "tran") {
     const stepTime = requireDeckPlanNumber(plan.stepTime, plan, "stepTime");
@@ -7297,7 +7313,12 @@ export function runDeckAnalysis(
       plan.startTime,
       stopTime,
     );
-    return { plan, result, table: formatDeckTransientTable(result, netlist) };
+    return {
+      plan,
+      result,
+      table: formatDeckTransientTable(result, netlist),
+      outputProbes: selectDeckOutputProbes(netlist, plan.analysis),
+    };
   }
   throw invalidElement("runDeckAnalysis", `unsupported analysis ${JSON.stringify(plan.analysis)}`);
 }

--- a/code/packages/typescript/spice-engine/tests/transient.test.ts
+++ b/code/packages/typescript/spice-engine/tests/transient.test.ts
@@ -1451,10 +1451,12 @@ describe("transient", () => {
 
     const opExecution = runDeckAnalysis(circuit, netlist, "op");
     expect(opExecution.plan.analysis).toBe("op");
+    expect(opExecution.outputProbes).toEqual(["V(mid)"]);
     expect(opExecution.table).toBe("Index\tV(mid)\n0\t5.000000e-01\n");
 
     const dcExecution = runDeckAnalysis(circuit, netlist, "dc");
     expect(dcExecution.plan.sourceName).toBe("V1");
+    expect(dcExecution.outputProbes).toEqual(["V(mid)", "I(V1)"]);
     expect(Array.isArray(dcExecution.result)).toBe(true);
     expect(dcExecution.table).toBe(
       "Index\tSource\tValue\tV(mid)\tI(V1)\n" +
@@ -1463,6 +1465,7 @@ describe("transient", () => {
     );
 
     const acExecution = runDeckAnalysis(circuit, netlist, "ac");
+    expect(acExecution.outputProbes).toEqual(["V(mid)"]);
     expect(Array.isArray(acExecution.result)).toBe(true);
     expect(acExecution.table).toBe(
       "Index\tFrequency\tProbe\tReal\tImaginary\tMagnitude\tPhase\n" +
@@ -1470,6 +1473,7 @@ describe("transient", () => {
     );
 
     const tranExecution = runDeckAnalysis(circuit, netlist, "tran");
+    expect(tranExecution.outputProbes).toEqual(["V(mid)"]);
     expect(Array.isArray(tranExecution.result)).toBe(true);
     expect(tranExecution.table).toBe(
       "Index\tTime\tV(mid)\n" +
@@ -1483,6 +1487,7 @@ describe("transient", () => {
     expect(tranWindowExecution.plan.startTime).toBeCloseTo(2.0e-3, 12);
     expect(tranWindowExecution.plan.maxStep).toBeCloseTo(1.0e-3, 12);
     expect(tranWindowExecution.plan.useInitialConditions).toBe(true);
+    expect(tranWindowExecution.outputProbes).toEqual(["V(mid)"]);
     const tranWindowPoints = tranWindowExecution.result as { time: number }[];
     expect(tranWindowPoints).toHaveLength(3);
     [
@@ -1502,6 +1507,7 @@ describe("transient", () => {
     expect(() => runDeckAnalysis(circuit, netlist)).toThrow(/multiple analysis cards/);
 
     const linExecution = runDeckAnalysis(circuit, ".save V(mid)\n.ac lin 3 1 3\n.end\n");
+    expect(linExecution.outputProbes).toEqual(["V(mid)"]);
     const linPoints = linExecution.result as { frequencyHz: number }[];
     expect(linPoints.map((point) => point.frequencyHz)).toEqual([1.0, 2.0, 3.0]);
     expect(linExecution.table).toBe(
@@ -1512,6 +1518,7 @@ describe("transient", () => {
     );
 
     const octExecution = runDeckAnalysis(circuit, ".save V(mid)\n.ac oct 1 1 4\n.end\n");
+    expect(octExecution.outputProbes).toEqual(["V(mid)"]);
     const octPoints = octExecution.result as { frequencyHz: number }[];
     expect(octPoints.map((point) => point.frequencyHz)).toEqual([1.0, 2.0, 4.0]);
     expect(octExecution.table).toBe(

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -53,7 +53,8 @@ downstream tools to compare.
      `START` output filtering, `MAXSTEP` fixed-step caps, and `UIC`
      initial-condition intent; selected `.tran` execution now keeps `.tran
      TSTEP` as the deck output print grid while `MAXSTEP` caps internal solver
-     stepping.
+     stepping; deck executions now expose normalized selected output probes as
+     an inspectable artifact alongside the stable table.
    - Expand remaining deck-controlled analyses toward full SPICE compatibility
      while keeping unsupported control-flow diagnostics explicit.
 
@@ -429,12 +430,20 @@ downstream tools to compare.
     - This separates deck-visible transient output rows from internal solver
       stepping and preserves stable selected-plan transient tables.
 
+37. Deck selected-output artifact metadata.
+    - Status: completed in this output-probe artifact slice.
+    - Python, Rust, and TypeScript `run_deck_analysis` / `runDeckAnalysis`
+      results now include the normalized deck-selected output probes alongside
+      the selected plan, solver result, and stable table.
+    - This gives callers a structured deck-owned output artifact without
+      reparsing table text.
+
 ## Backlog
 
 1. Deck execution layer.
    - Expand selected-plan execution beyond fixed-step transient basics,
-     including richer deck-owned run artifacts and output-plan integration
-     beyond stable table routing.
+     including richer deck-owned run artifacts beyond selected output probes
+     and output-plan integration beyond stable table routing.
    - Expand deck-controlled output-plan integration beyond stable table
      routing toward full SPICE compatibility.
    - Define a deliberate `.control` subset; explicit unsupported-feature


### PR DESCRIPTION
## Summary
- add normalized selected output probe metadata to Python `run_deck_analysis`, Rust `run_deck_analysis`, and TypeScript `runDeckAnalysis` execution results
- assert the new artifact across op/dc/ac/tran selected-plan routing tests
- document the cross-language artifact surface in changelogs, READMEs, and the SPICE implementation plan

## Verification
- `PYTHONPATH="$(find code/packages/python -maxdepth 2 -type d -name src | paste -sd: -)" /Users/adhithya/.local/share/mise/installs/python/3.12.13/bin/python3 -m ruff check code/packages/python/spice-engine/src/spice_engine/engine.py code/packages/python/spice-engine/tests/test_engine.py`
- `PYTHONPATH="$(find code/packages/python -maxdepth 2 -type d -name src | paste -sd: -)" /Users/adhithya/.local/share/mise/installs/python/3.12.13/bin/python3 -m pytest code/packages/python/spice-engine/tests -q --no-cov`
- `npm --prefix code/packages/typescript/spice-engine ci`
- `npm --prefix code/packages/typescript/spice-engine run build`
- `npm --prefix code/packages/typescript/spice-engine test`
- `cargo fmt --manifest-path code/packages/rust/spice-engine/Cargo.toml --check`
- `cargo test --manifest-path code/packages/rust/spice-engine/Cargo.toml`
- `git diff --check`
- `git diff --cached --check`