### PR TITLE
feat(visicalc-qt): scrollable infinite-sheet GUI on the viewport primitive

### DIFF
--- a/demo/visicalc-qt/.gitignore
+++ b/demo/visicalc-qt/.gitignore
@@ -12,9 +12,11 @@ test/qmake-build/
 *.o
 moc_*.cpp
 moc_predefs.h
+*.moc
 *.app/
 .qmake.stash
 tst_model
+tst_window
 
 # Vendored engine — the C ABI static library + header, built by
 # scripts/build.sh from the spreadsheet-capi crate (like the SwiftUI demo).

--- a/demo/visicalc-qt/InfiniteSheet.qml
+++ b/demo/visicalc-qt/InfiniteSheet.qml
@@ -1,0 +1,245 @@
+// InfiniteSheet.qml — a virtualized, effectively-infinite spreadsheet view for
+// the Qt demo, rendered on the shared Rust engine through the viewport
+// primitive (the same get_window / used_range / changed_since the SwiftUI
+// InfiniteGridView and the web infinite.html drive).
+//
+// The sheet is u32 × u32 and sparse; only the cells in the VISIBLE rows are ever
+// built. The body is a QtQuick `ListView`, which natively virtualizes — it
+// instantiates a row delegate only while that row is on screen and recycles it
+// when it scrolls off. So a 1000-row-tall sheet costs the handful of rows you
+// can actually see, not 1000 delegates.
+//
+// Two-axis scroll + frozen chrome, all kept in sync by binding offsets:
+//
+//   ┌────────┬──────────────────────────────┐
+//   │ corner │  column-letter header  (A B…) │  ← frozen on top, scrolls →
+//   ├────────┼──────────────────────────────┤
+//   │  row   │                              │
+//   │ number │   body: ListView of rows     │
+//   │ gutter │   (each row = Repeater of    │  gutter frozen left, scrolls ↓
+//   │  1 2 … │    totalCols cells)          │
+//   └────────┴──────────────────────────────┘
+//
+//   • header.contentX  ← body horizontal Flickable.contentX   (header tracks ↔)
+//   • gutter.contentY  ← body ListView.contentY               (gutter tracks ↕)
+//
+// Each visible row delegate calls `doc.rowCells(rowNum)` ONCE — a single engine
+// `get_window` over that row's 1×totalCols strip — so the per-frame engine work
+// is proportional to visible rows, never to the sheet's height.
+
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+
+Item {
+    id: sheet
+
+    // The C++ SpreadsheetModel context property is named `model`, but `model`
+    // is ALSO the implicit name of a ListView/Repeater's data model inside a
+    // delegate — referencing `model` there would resolve to the wrong thing.
+    // Alias it once as `doc` and use that everywhere to dodge the shadowing.
+    readonly property var doc: model
+
+    // Cell geometry (pixels). The gutter and body share rowH so their two
+    // ListViews scroll in lockstep.
+    readonly property int rowH: 24
+    readonly property int colW: 90
+    readonly property int gutterW: 64
+    readonly property int headH: 26
+
+    ColumnLayout {
+        anchors.fill: parent
+        spacing: 0
+
+        // ── Formula bar ──────────────────────────────────────────────
+        // The selected cell's address (e.g. "Z1000") plus an editable source
+        // line. Enter commits through `doc.commitInf`, which writes to the
+        // engine, recomputes dependents, regrows the extent, and bumps
+        // `doc.revision` so the visible rows re-fetch.
+        RowLayout {
+            Layout.fillWidth: true
+            Layout.leftMargin: 8
+            Layout.rightMargin: 8
+            Layout.topMargin: 8
+            spacing: 8
+
+            Text {
+                text: doc ? doc.infAddress : ""
+                color: "#9D9D9D"
+                font.pixelSize: 12
+                font.family: "monospace"
+                Layout.preferredWidth: sheet.gutterW
+            }
+            Rectangle {
+                Layout.fillWidth: true
+                Layout.preferredHeight: 28
+                color: "#2D2D30"
+                border.color: "#3F3F46"
+                TextInput {
+                    id: formula
+                    anchors.fill: parent
+                    anchors.leftMargin: 6
+                    anchors.rightMargin: 6
+                    verticalAlignment: TextInput.AlignVCenter
+                    color: "#CCCCCC"
+                    font.pixelSize: 13
+                    font.family: "monospace"
+                    clip: true
+                    selectByMouse: true
+                    // Re-seed from the model on selection change; the user's
+                    // edits live here until they press Enter.
+                    text: doc ? doc.infFormula : ""
+                    onAccepted: if (doc) doc.commitInf(text)
+                }
+            }
+        }
+
+        // ── Column-letter header (frozen vertically, scrolls horizontally) ──
+        RowLayout {
+            Layout.fillWidth: true
+            Layout.leftMargin: 8
+            Layout.rightMargin: 8
+            Layout.topMargin: 6
+            spacing: 0
+
+            // Corner cell above the gutter.
+            Rectangle {
+                Layout.preferredWidth: sheet.gutterW
+                Layout.preferredHeight: sheet.headH
+                color: "#2D2D30"
+                border.color: "#3F3F46"
+            }
+            Flickable {
+                id: header
+                Layout.fillWidth: true
+                Layout.preferredHeight: sheet.headH
+                contentWidth: (doc ? doc.totalCols : 0) * sheet.colW
+                contentHeight: sheet.headH
+                interactive: false              // driven by the body's scroll
+                clip: true
+                contentX: bodyFlick.contentX     // track the body's HORIZONTAL pan
+                Row {
+                    Repeater {
+                        model: doc ? doc.totalCols : 0
+                        delegate: Rectangle {
+                            width: sheet.colW
+                            height: sheet.headH
+                            color: "#2D2D30"
+                            border.color: "#3F3F46"
+                            Text {
+                                anchors.centerIn: parent
+                                text: doc ? doc.columnLetters(index + 1) : ""
+                                color: "#9D9D9D"
+                                font.pixelSize: 12
+                                font.family: "monospace"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        // ── Body: row-number gutter + virtualized cell grid ─────────────
+        RowLayout {
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+            Layout.leftMargin: 8
+            Layout.rightMargin: 8
+            Layout.bottomMargin: 8
+            spacing: 0
+
+            // Row-number gutter — its own ListView so it virtualizes too,
+            // non-interactive and slaved to the body's vertical scroll.
+            ListView {
+                id: gutter
+                Layout.preferredWidth: sheet.gutterW
+                Layout.fillHeight: true
+                model: doc ? doc.totalRows : 0
+                interactive: false
+                clip: true
+                contentY: body.contentY
+                boundsBehavior: Flickable.StopAtBounds
+                delegate: Rectangle {
+                    width: sheet.gutterW
+                    height: sheet.rowH
+                    color: "#2D2D30"
+                    border.color: "#3F3F46"
+                    Text {
+                        anchors.centerIn: parent
+                        text: index + 1
+                        color: "#9D9D9D"
+                        font.pixelSize: 12
+                        font.family: "monospace"
+                    }
+                }
+            }
+
+            // The cells. A horizontal Flickable supplies left/right scroll; the
+            // vertical ListView inside it supplies up/down scroll + row
+            // virtualization. The ListView is as wide as the whole column span,
+            // so the Flickable's contentX pans it horizontally.
+            Flickable {
+                id: bodyFlick
+                Layout.fillWidth: true
+                Layout.fillHeight: true
+                contentWidth: (doc ? doc.totalCols : 0) * sheet.colW
+                contentHeight: height
+                flickableDirection: Flickable.HorizontalFlick
+                clip: true
+                boundsBehavior: Flickable.StopAtBounds
+
+                ListView {
+                    id: body
+                    width: bodyFlick.contentWidth
+                    height: bodyFlick.height
+                    model: doc ? doc.totalRows : 0
+                    clip: true
+                    boundsBehavior: Flickable.StopAtBounds
+                    cacheBuffer: sheet.rowH * 4
+
+                    delegate: Row {
+                        id: rowItem
+                        // ListView's `index` is 0-based; the engine is 1-based.
+                        readonly property int rowNum: index + 1
+                        // One engine read for the whole row. Touching
+                        // `doc.revision` makes this re-fetch after any commit.
+                        readonly property var cells: doc
+                            ? (doc.revision, doc.rowCells(rowNum))
+                            : []
+
+                        Repeater {
+                            model: doc ? doc.totalCols : 0
+                            delegate: Rectangle {
+                                id: cell
+                                readonly property int colNum: index + 1
+                                width: sheet.colW
+                                height: sheet.rowH
+                                color: (doc && doc.infRow === rowItem.rowNum
+                                        && doc.infCol === colNum)
+                                       ? "#094771" : "#1E1E1E"
+                                border.color: "#3F3F46"
+                                border.width: 1
+                                Text {
+                                    anchors.fill: parent
+                                    anchors.rightMargin: 4
+                                    horizontalAlignment: Text.AlignRight
+                                    verticalAlignment: Text.AlignVCenter
+                                    elide: Text.ElideRight
+                                    text: (colNum - 1) < rowItem.cells.length
+                                          ? rowItem.cells[colNum - 1] : ""
+                                    color: "#CCCCCC"
+                                    font.pixelSize: 12
+                                    font.family: "monospace"
+                                }
+                                MouseArea {
+                                    anchors.fill: parent
+                                    onClicked: if (doc) doc.selectInf(rowItem.rowNum, cell.colNum)
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/demo/visicalc-qt/README.md
+++ b/demo/visicalc-qt/README.md
@@ -80,10 +80,39 @@ are `Q_INVOKABLE`, so a windowed QML grid (rendering only the visible rectangle
 of an unbounded sheet, the Qt sibling of the web/SwiftUI infinite views) binds
 to them directly.
 
-Headless proof: `test/tst_window.cpp` (qmake) seeds far-flung sparse cells and
-asserts the window is engine-computed + dense, a formula 1000 rows down
-(`Z1000` = 39) is reachable, the gaps are empty (sparse), column letters run
-AA/BA, and editing `A1` dirties the far dependent `Z1000` via `changedSince`:
+### The scrollable infinite GUI (`InfiniteSheet.qml`)
+
+The **Infinite sheet** button in the running app toggles from the classic 5×5
+grid to `InfiniteSheet.qml` — a virtualized, effectively-infinite (u32 × u32,
+sparse) sheet rendered on the same engine. The body is a QtQuick `ListView`,
+which natively virtualizes: it instantiates a row delegate only while that row
+is on screen, so a 1000-row-tall sheet costs the handful of rows you can
+actually see. Each visible row calls `model.rowCells(row)` **once** — a single
+`get_window` over that row's `1×totalCols` strip — so per-frame engine work is
+proportional to *visible* rows, never to the sheet's height.
+
+Two-axis scroll with frozen chrome, kept in sync by binding offsets: the
+column-letter header tracks the body's horizontal pan (`header.contentX ←
+bodyFlick.contentX`) and the row-number gutter (its own non-interactive
+`ListView`) tracks the body's vertical scroll (`gutter.contentY ←
+body.contentY`). Tapping a cell calls `model.selectInf(row, col)` (pulling its
+source into the formula bar); pressing Enter calls `model.commitInf(text)`,
+which writes through to the engine, recomputes every dependent, regrows the
+extent, and bumps `model.revision` so the visible rows re-fetch.
+
+The model seeds far-flung sparse cells (`Z1000`, `BA50`, `BB50`) on top of the
+budget so there's something to scroll to; the extent (`totalRows`/`totalCols`)
+is derived from `usedRange()` plus a margin.
+
+### Headless proof
+
+`test/tst_window.cpp` (qmake) seeds far-flung sparse cells and asserts the
+window is engine-computed + dense, a formula 1000 rows down (`Z1000` = 39) is
+reachable, the gaps are empty (sparse), column letters run AA/BA, and editing
+`A1` dirties the far dependent `Z1000` via `changedSince`. A fourth case drives
+the infinite-view binding layer directly: `rowCells` returns one engine-read
+row, `selectInf` selects + clamps and loads the source, and `commitInf` edits
+`A2` 8 → 108 with every dependent recomputing (E2 → 151, A5 → 139, E5 → 269):
 
 ```bash
 cd test && qmake tst_window.pro && make && ./tst_window

--- a/demo/visicalc-qt/main.qml
+++ b/demo/visicalc-qt/main.qml
@@ -44,19 +44,38 @@ Window {
     // spreadsheet data lives in the engine, behind `model`.
     property string formulaText: model ? model.selectedRaw : ""
 
+    // Which view is showing: the classic 5×5 cross-foot budget (the auto-
+    // generated Grid), or the virtualized infinite sheet (InfiniteSheet.qml,
+    // a sibling component rendered on the same engine via the viewport
+    // primitive). The Layout ignores items whose `visible` is false, so only
+    // the active view participates in layout.
+    property bool infinite: false
+
     ColumnLayout {
         anchors.fill: parent
         spacing: 0
 
-        // Title bar.
-        Text {
+        // Title bar + view toggle.
+        RowLayout {
             Layout.fillWidth: true
             Layout.leftMargin: 16
+            Layout.rightMargin: 16
             Layout.topMargin: 16
-            text: "VISICALC · MOSAIC QT DEMO · RUST ENGINE"
-            color: "#9D9D9D"
-            font.pixelSize: 11
-            font.letterSpacing: 1.0
+            spacing: 8
+
+            Text {
+                Layout.fillWidth: true
+                text: root.infinite
+                      ? "VISICALC · INFINITE SHEET · RUST ENGINE"
+                      : "VISICALC · MOSAIC QT DEMO · RUST ENGINE"
+                color: "#9D9D9D"
+                font.pixelSize: 11
+                font.letterSpacing: 1.0
+            }
+            Button {
+                text: root.infinite ? "Classic grid" : "Infinite sheet"
+                onClicked: root.infinite = !root.infinite
+            }
         }
 
         // FormulaBar — the AUTO-GENERATED component. The host pushes the
@@ -64,6 +83,7 @@ Window {
         // edited text to the engine via `model.setSelected`, which recomputes.
         FormulaBar {
             id: formulaBar
+            visible: !root.infinite
             Layout.fillWidth: true
             Layout.topMargin: 8
             cellAddress: model ? model.cellAddress : ""
@@ -84,6 +104,7 @@ Window {
         // computed display matrix; selecting a cell (onNavigate) updates the
         // model's selection and pulls that cell's source into the formula bar.
         Grid {
+            visible: !root.infinite
             Layout.fillWidth: true
             Layout.fillHeight: true
             Layout.margins: 16
@@ -107,6 +128,16 @@ Window {
             onFormulaChange: (_value) => { /* in-cell live-edit deferred */ }
             onEditCommit:    () => { /* in-cell live-edit deferred */ }
             onEditCancel:    () => { /* in-cell live-edit deferred */ }
+        }
+
+        // InfiniteSheet — the virtualized, effectively-infinite view, rendered
+        // on the same engine through the viewport primitive. A sibling QML file
+        // in this directory (auto-importable). Only laid out when active.
+        InfiniteSheet {
+            visible: root.infinite
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+            Layout.margins: 8
         }
     }
 }

--- a/demo/visicalc-qt/src/SpreadsheetModel.cpp
+++ b/demo/visicalc-qt/src/SpreadsheetModel.cpp
@@ -66,6 +66,8 @@ SpreadsheetModel::SpreadsheetModel(QObject *parent)
     : QObject(parent), session_(sc_session_new()) {
     seed();
     recompute();
+    computeExtent();
+    selectInf(1, 1); // prime the infinite-view selection/formula bar at A1
 }
 
 SpreadsheetModel::~SpreadsheetModel() {
@@ -92,6 +94,10 @@ void SpreadsheetModel::seed() {
         {"A4", "4"},  {"B4", "11"}, {"C4", "3"},  {"D4", "17"}, {"E4", "=SUM(A4:D4)"},
         {"A5", "=SUM(A1:A4)"}, {"B5", "=SUM(B1:B4)"}, {"C5", "=SUM(C1:C4)"},
         {"D5", "=SUM(D1:D4)"}, {"E5", "=SUM(E1:E4)"},
+        // Far-flung, sparse cells so the infinite view has something to scroll to
+        // (the 5×5 parity grid only ever shows A1:E5, so these don't affect it).
+        {"Z1000", "=SUM(A1:A4)"},                    // row 1000, col 26: 39
+        {"BA50", "far cell"}, {"BB50", "=Z1000*2"},  // row 50, col 53/54: 78
     };
     for (const auto &cell : cells) {
         takeString(sc_set_cell(session_, cell.a1, cell.raw));
@@ -211,4 +217,66 @@ void SpreadsheetModel::setCell(const QString &a1, const QString &raw) {
     const QByteArray rawUtf8 = raw.toUtf8();
     takeString(sc_set_cell(session_, a1Utf8.constData(), rawUtf8.constData()));
     recompute();
+}
+
+// ── Infinite-sheet view (InfiniteSheet.qml) ──────────────────────────
+// The Qt sibling of the SwiftUI InfiniteGridView / web infinite.html. A
+// virtualized QML ListView renders only the visible rows; each visible delegate
+// asks `rowCells(row)` for that row's display strings (one engine `get_window`
+// over a 1×totalCols strip), so an unbounded sheet costs only what's on screen.
+
+QString SpreadsheetModel::rawAt(const QString &a1) const {
+    const QByteArray a1Utf8 = a1.toUtf8();
+    return takeString(sc_get_raw(session_, a1Utf8.constData()));
+}
+
+QString SpreadsheetModel::infAddress() const {
+    return columnLetters(infCol_) + QString::number(infRow_);
+}
+
+// One row of the infinite view: columns 1..totalCols_ as display strings. The
+// engine read is a single-row window; we return its first (only) row, or an
+// empty list if the request was rejected/oversized.
+QVariantList SpreadsheetModel::rowCells(int row) const {
+    if (row < 1) return QVariantList();
+    const QVariantList rows = window(row, 1, row, totalCols_);
+    if (rows.isEmpty()) return QVariantList();
+    return rows.first().toList();
+}
+
+// Re-derive the virtual grid size from the engine's data extent plus a margin so
+// you can scroll past the data into blank space. Mirrors WindowedSheetModel.resize().
+void SpreadsheetModel::computeExtent() {
+    const QVariantMap u = usedRange();
+    const int maxRow = u.value(QStringLiteral("maxRow"), 1).toInt();
+    const int maxCol = u.value(QStringLiteral("maxCol"), 1).toInt();
+    totalRows_ = std::max(maxRow + 200, 1000);
+    totalCols_ = std::max(maxCol + 30, 60);
+    emit extentChanged();
+}
+
+// Move the infinite-view selection (clamped to the virtual grid; col/row ≥ 1)
+// and pull the selected cell's raw source into the formula bar.
+void SpreadsheetModel::selectInf(int row, int col) {
+    infRow_ = std::max(1, std::min(totalRows_, row));
+    infCol_ = std::max(1, std::min(totalCols_, col));
+    infFormula_ = rawAt(infAddress());
+    emit infSelectionChanged();
+}
+
+// Commit the formula bar into the selected infinite-view cell: write through to
+// the engine (which recomputes every dependent), grow the extent if the edit
+// reached new ground, re-read the source, and bump `revision` so the visible
+// ListView delegates re-fetch their rows.
+void SpreadsheetModel::commitInf(const QString &raw) {
+    const QString a1 = infAddress();
+    const QByteArray a1Utf8 = a1.toUtf8();
+    const QByteArray rawUtf8 = raw.toUtf8();
+    takeString(sc_set_cell(session_, a1Utf8.constData(), rawUtf8.constData()));
+    recompute();        // keep the 5×5 parity grid in sync too
+    computeExtent();
+    infFormula_ = rawAt(a1);
+    revision_++;
+    emit infSelectionChanged();
+    emit revisionChanged();
 }

--- a/demo/visicalc-qt/src/SpreadsheetModel.h
+++ b/demo/visicalc-qt/src/SpreadsheetModel.h
@@ -88,11 +88,44 @@ public:
     // A1 addresses changed since `since` (empty if none / stale).
     Q_INVOKABLE QStringList changedSince(quint64 since) const;
 
+    // ── Infinite-sheet view state (InfiniteSheet.qml) ──
+    // The virtual grid size, the selection, the formula-bar text, and a revision
+    // counter the QML rebinds on to refresh the visible rows after an edit. All
+    // 1-based (row/col ≥ 1, col 1 = "A"). Separate from the 5×5 parity selection.
+    Q_PROPERTY(int totalRows READ totalRows NOTIFY extentChanged)
+    Q_PROPERTY(int totalCols READ totalCols NOTIFY extentChanged)
+    Q_PROPERTY(int infRow READ infRow NOTIFY infSelectionChanged)
+    Q_PROPERTY(int infCol READ infCol NOTIFY infSelectionChanged)
+    Q_PROPERTY(QString infAddress READ infAddress NOTIFY infSelectionChanged)
+    Q_PROPERTY(QString infFormula READ infFormula NOTIFY infSelectionChanged)
+    Q_PROPERTY(int revision READ revision NOTIFY revisionChanged)
+
+    int totalRows() const { return totalRows_; }
+    int totalCols() const { return totalCols_; }
+    int infRow() const { return infRow_; }
+    int infCol() const { return infCol_; }
+    QString infAddress() const;
+    QString infFormula() const { return infFormula_; }
+    int revision() const { return revision_; }
+
+    // One row's display strings (a QVariantList of QString, columns 1..totalCols)
+    // — what a windowed ListView delegate renders. One engine read per row.
+    Q_INVOKABLE QVariantList rowCells(int row) const;
+    // Select the infinite-view cell (clamped); pulls its source into infFormula.
+    Q_INVOKABLE void selectInf(int row, int col);
+    // Commit the formula bar into the selected infinite-view cell: write through,
+    // recompute, resize the extent, bump `revision` so the rows re-fetch.
+    Q_INVOKABLE void commitInf(const QString &raw);
+
 signals:
     // viewportRows changed (after a recompute) — QML rebinds the grid.
     void changed();
     // The selection moved — QML rebinds cellAddress / selectedRaw / highlight.
     void selectionChanged();
+    // Infinite-view signals.
+    void extentChanged();
+    void infSelectionChanged();
+    void revisionChanged();
 
 private:
     // A1 address for grid display row `r` (0-based) and column `c` (1..5).
@@ -104,10 +137,23 @@ private:
     // Rebuild viewportRows_ from the engine's computed values and emit changed().
     void recompute();
 
+    // Re-derive totalRows_/totalCols_ from the engine's used_range + a margin.
+    void computeExtent();
+    // The raw source of an A1 cell (the formula bar's text).
+    QString rawAt(const QString &a1) const;
+
     ScSession *session_;
     QVariantList viewportRows_;
     int selectedRow_ = 0; // 0..4
     int selectedCol_ = 1; // 1..5 (0 = gutter)
+
+    // Infinite-view state.
+    int totalRows_ = 1000;
+    int totalCols_ = 60;
+    int infRow_ = 1;     // 1-based
+    int infCol_ = 1;     // 1-based (1 = "A")
+    QString infFormula_;
+    int revision_ = 0;
 };
 
 #endif // VISICALC_QT_SPREADSHEET_MODEL_H

--- a/demo/visicalc-qt/test/tst_window.cpp
+++ b/demo/visicalc-qt/test/tst_window.cpp
@@ -21,6 +21,7 @@ private slots:
     void windowIsEngineComputedAndDense();
     void farWindowReachesZ1000AndGapsAreSparse();
     void extentColumnLettersAndChangedSince();
+    void infiniteViewSelectEditAndRowCells();
 };
 
 // Helper: the display string at window (1-based) cell (row, col), given the
@@ -61,10 +62,11 @@ void TstWindow::extentColumnLettersAndChangedSince() {
     SpreadsheetModel m;
     m.setCell("Z1000", "=SUM(A1:A4)");
 
-    // used_range extends to the far cell.
+    // used_range extends to the far cells. The default seed plants Z1000 (row
+    // 1000) and BB50 (col 54 = "BB"), so the extent spans both far islands.
     const QVariantMap u = m.usedRange();
     QCOMPARE(u.value("maxRow").toInt(), 1000);
-    QCOMPARE(u.value("maxCol").toInt(), 26);
+    QCOMPARE(u.value("maxCol").toInt(), 54);
 
     // Column letters past Z.
     QCOMPARE(m.columnLetters(27), QStringLiteral("AA"));
@@ -79,6 +81,56 @@ void TstWindow::extentColumnLettersAndChangedSince() {
              qPrintable("far dependent recomputed: " + changed.join(",")));
     // And the recomputed value shows through a fresh window read: 115+8+12+4.
     QCOMPARE(at(m.window(1000, 26, 1000, 26), 1000, 26, 1000, 26), QStringLiteral("139"));
+}
+
+// The infinite-view binding layer (InfiniteSheet.qml drives these): one engine
+// read per visible row via rowCells, tap-to-select via selectInf (which pulls
+// the cell's source into the formula bar), and write-through via commitInf
+// (which recomputes dependents, regrows the extent, and bumps `revision`).
+void TstWindow::infiniteViewSelectEditAndRowCells() {
+    SpreadsheetModel m;
+
+    // The constructor seeds the cross-foot budget PLUS far-flung cells
+    // (Z1000, BA50/BB50) and computes the extent: at least 1000×60, and grown
+    // to reach the far cells. Z1000 → totalRows ≥ 1000 + margin.
+    QVERIFY2(m.totalRows() >= 1000, "extent grows to reach the far seeded cells");
+    QVERIFY2(m.totalCols() >= 60, "extent has the default column margin");
+
+    // rowCells returns one row's display strings (columns 1..totalCols). Row 1
+    // is the budget's first row: A1..E1 = 15,3,12,8,38, then blanks.
+    const QVariantList row1 = m.rowCells(1);
+    QCOMPARE(row1.size(), m.totalCols());
+    QCOMPARE(row1.at(0).toString(), QStringLiteral("15")); // A1
+    QCOMPARE(row1.at(4).toString(), QStringLiteral("38")); // E1 = SUM(A1:D1)
+    QCOMPARE(row1.at(9).toString(), QString());            // J1 empty (sparse)
+    // A row in the gap between the data islands is entirely blank.
+    const QVariantList gapRow = m.rowCells(200);
+    for (const QVariant &cell : gapRow) QCOMPARE(cell.toString(), QString());
+
+    // selectInf moves the selection (1-based) and pulls the cell's SOURCE into
+    // the formula bar — A5 is a formula, so we see the formula, not its value.
+    m.selectInf(5, 1);
+    QCOMPARE(m.infRow(), 5);
+    QCOMPARE(m.infCol(), 1);
+    QCOMPARE(m.infAddress(), QStringLiteral("A5"));
+    QCOMPARE(m.infFormula(), QStringLiteral("=SUM(A1:A4)"));
+
+    // selectInf clamps to the virtual grid (never below 1, never past the extent).
+    m.selectInf(-3, 0);
+    QCOMPARE(m.infRow(), 1);
+    QCOMPARE(m.infCol(), 1);
+
+    // commitInf writes the formula bar through to the selected cell. Edit A2
+    // 8 → 108 and every dependent recomputes: E2 (row total) and A5/E5 (col /
+    // grand totals) all move, visible through a fresh rowCells read.
+    const int revBefore = m.revision();
+    m.selectInf(2, 1);                 // A2
+    m.commitInf(QStringLiteral("108"));
+    QVERIFY2(m.revision() > revBefore, "commit bumps the revision so rows re-fetch");
+    QCOMPARE(m.rowCells(2).at(0).toString(), QStringLiteral("108")); // A2
+    QCOMPARE(m.rowCells(2).at(4).toString(), QStringLiteral("151")); // E2 = 108+14+7+22
+    QCOMPARE(m.rowCells(5).at(0).toString(), QStringLiteral("139")); // A5 = 15+108+12+4
+    QCOMPARE(m.rowCells(5).at(4).toString(), QStringLiteral("269")); // E5 grand total
 }
 
 QTEST_MAIN(TstWindow)


### PR DESCRIPTION
## What

Adds **`InfiniteSheet.qml`** — a virtualized, effectively-infinite (u32×u32, sparse) spreadsheet view for the Qt demo, rendered on the same shared Rust engine through the viewport primitive (`sc_get_window` / `sc_used_range` / `sc_changed_since`). The Qt sibling of the SwiftUI `InfiniteGridView` and the web `infinite.html`. A toolbar toggle in `main.qml` switches between the classic 5×5 cross-foot budget and the infinite view.

This is **item 2 of the cross-backend infinite-GUI sequence** (SwiftUI done in #5868; Qt here → Flutter → Compose → XAML).

## How it virtualizes

- The body is a QtQuick `ListView` — it instantiates a row delegate only while that row is on screen, so a 1000-row sheet costs the handful of visible rows.
- Each visible row calls `model.rowCells(row)` **once** — a single `get_window` over its `1×totalCols` strip — so per-frame engine work is proportional to *visible* rows, not sheet height.
- Two-axis scroll with frozen chrome kept in sync by binding offsets: the column-letter header tracks the body's horizontal pan (`header.contentX ← bodyFlick.contentX`); the row-number gutter (its own non-interactive `ListView`) tracks vertical scroll (`gutter.contentY ← body.contentY`).
- Tap a cell → `model.selectInf(row, col)` (clamps, loads the source into the formula bar). Enter → `model.commitInf(text)` (writes through, recomputes dependents, regrows the extent, bumps `model.revision` so visible rows re-fetch).

`SpreadsheetModel` gains the infinite-view binding layer (`Q_INVOKABLE rowCells/selectInf/commitInf`, properties `totalRows/totalCols/infRow/infCol/infAddress/infFormula/revision`, `computeExtent` from `used_range` + margin) and seeds far-flung sparse cells (`Z1000`, `BA50`, `BB50`) so there's something to scroll to.

## Verified

**Live (computer-use, real GUI):** toggle to the infinite view → tap A2 → edit `8`→`108` in the formula bar → `E2` 151, `A5` 139, `E5` 269 recompute; vertical scroll re-windows with the gutter synced and the header frozen; horizontal scroll pans header + body together (caught + fixed a binding bug where the header was bound to the ListView's `contentX`, which never scrolls horizontally — it's the outer Flickable that pans).

**Headless:** `tst_window.cpp` gains `infiniteViewSelectEditAndRowCells` covering `rowCells` / `selectInf` (with clamping) / `commitInf` recompute. Both suites green — `tst_window` 6/6, `tst_model` 5/5. (The extent assertion now expects `maxCol` 54 since the default seed includes `BB50`.)

## Security

`/security-review` passed in 1 round, no findings — reviewer verified `takeString`/`sc_string_free` ownership (no double-free/leak/UAF), NULL-session guards, int→quint32 clamping can't bypass the engine's zero-origin / oversized-window guards, the engine-side 65,536-cell window cap bounds allocation, and no QML eval/injection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)