### PR TITLE
feat(conduit-lua): standardize conduit-hello demo (BUILD, tests, README, CHANGELOG)

### DIFF
--- a/code/programs/lua/conduit-hello/BUILD
+++ b/code/programs/lua/conduit-hello/BUILD
@@ -1,0 +1,28 @@
+# build-tool: deps=lua/conduit
+set -e
+
+# BUILD — conduit-hello (Lua demo program)
+#
+# conduit-hello is a runnable program, not an installable package. It depends on
+# the Lua `conduit` package (which wraps the Rust `conduit_native` cdylib). We
+# build that native library into the conduit package directory first — exactly
+# as the conduit package's own BUILD does — so `require("conduit")` resolves the
+# `.so`, then run the demo's E2E tests against it.
+#
+# Each line runs in its own shell starting from this directory
+# (code/programs/lua/conduit-hello/), so each `cd` is transient.
+#
+#   ../../../packages/lua/conduit → code/packages/lua/conduit
+
+# Step 1: compile the Rust native extension for the conduit package.
+(cd ../../../packages/lua/conduit/ext/conduit_native && cargo build --release)
+
+# Step 2: copy the built cdylib next to the conduit Lua module so `require` finds it.
+(cd ../../../packages/lua/conduit && python3 -c "import glob,shutil,sys,os; libs=glob.glob('ext/conduit_native/target/release/libconduit_native.*'); src=next((l for l in libs if l.endswith(('.so','.dylib','.dll'))),None); sys.exit('no libconduit_native found') if not src else shutil.copy(src,'conduit/conduit_native.dll' if os.name=='nt' else 'conduit/conduit_native.so')")
+
+# Step 3: install luasocket so the E2E tests run (they self-skip if it's absent).
+luarocks install luasocket 2>/dev/null || true
+
+# Step 4: run the demo's E2E tests (busted), from the tests directory so the
+# relative package paths resolve.
+cd tests && busted . --verbose --pattern=test_

--- a/code/programs/lua/conduit-hello/BUILD_windows
+++ b/code/programs/lua/conduit-hello/BUILD_windows
@@ -1,0 +1,13 @@
+# build-tool: deps=lua/conduit
+set -e
+
+# BUILD_windows — conduit-hello (Lua demo program), Windows variant.
+# Mirrors BUILD but builds/copies the conduit_native.dll for Windows.
+
+(cd ..\..\..\packages\lua\conduit\ext\conduit_native && cargo build --release)
+
+(cd ..\..\..\packages\lua\conduit && python -c "import glob,shutil,sys,os; libs=glob.glob('ext/conduit_native/target/release/conduit_native.dll'); src=next((l for l in libs if l.endswith('.dll')),None); sys.exit('no conduit_native.dll found') if not src else shutil.copy(src,'conduit/conduit_native.dll')")
+
+luarocks install luasocket 2>NUL || echo luasocket install skipped
+
+cd tests && busted . --verbose --pattern=test_

--- a/code/programs/lua/conduit-hello/CHANGELOG.md
+++ b/code/programs/lua/conduit-hello/CHANGELOG.md
@@ -1,0 +1,27 @@
+# Changelog — conduit-hello (Lua)
+
+## 1.0.0 — 2026-06-15
+
+Standardise the Lua demo to match every other Conduit `conduit-hello` program
+(which all ship a BUILD, README, CHANGELOG, and a `tests/` suite). Previously the
+directory held only `hello.lua`, so the demo was absent from the build graph and
+untested.
+
+### Added
+- `BUILD` / `BUILD_windows` — declare `deps=lua/conduit`, compile the conduit
+  package's `conduit_native` cdylib, install `luasocket`, and run the demo's
+  E2E tests via busted.
+- `tests/test_hello.lua` — end-to-end tests that load the demo's `build_app()`,
+  serve it on an ephemeral port in the background, and drive all eight routes
+  (`/`, `/hello/:name`, `/echo`, `/redirect`, `/halt`, `/down`, `/error`,
+  unmatched → 404) over real HTTP. Self-skips when `luasocket` is unavailable,
+  mirroring the conduit library's server suite.
+- `README.md` — routes table, run instructions, structure, and test notes.
+
+### Changed
+- `hello.lua` — refactored so the application is built in a `build_app()`
+  factory (returns a configured `conduit.Application`, starts no server) with a
+  `serve()` helper. A bottom-of-file guard runs the foreground server only when
+  the file is invoked directly (`lua hello.lua`); when loaded as a module it just
+  returns the factory, so the tests can construct and drive the same app. Routes
+  and behaviour are unchanged.

--- a/code/programs/lua/conduit-hello/README.md
+++ b/code/programs/lua/conduit-hello/README.md
@@ -1,0 +1,62 @@
+# conduit-hello (Lua)
+
+A runnable demo of the [Conduit](../../../packages/lua/conduit) web framework for
+Lua. It exercises every feature of the Conduit Lua DSL on the shared Rust
+`web-core` engine: routing with path params, JSON bodies, before/after filters,
+`halt`, `redirect`, and custom not-found / error handlers.
+
+## Routes
+
+| Method | Path           | Behaviour                                    |
+|--------|----------------|----------------------------------------------|
+| GET    | `/`            | HTML greeting                                |
+| GET    | `/hello/:name` | JSON `{ message = "Hello <name>" }`           |
+| POST   | `/echo`        | Echoes the JSON request body                 |
+| GET    | `/redirect`    | `301` redirect to `/`                         |
+| GET    | `/halt`        | `403` via `halt()`                            |
+| GET    | `/down`        | `503` via a `before` filter (route unreached) |
+| GET    | `/error`       | `500` via a custom `error_handler`            |
+| *any*  | (unmatched)    | `404` via a custom `not_found` handler        |
+
+## Run it
+
+```sh
+lua hello.lua
+```
+
+Then, in another terminal:
+
+```sh
+curl http://127.0.0.1:3000/
+curl http://127.0.0.1:3000/hello/Adhithya
+curl -X POST http://127.0.0.1:3000/echo \
+     -H 'Content-Type: application/json' -d '{"ping":"pong"}'
+curl -i http://127.0.0.1:3000/redirect
+curl http://127.0.0.1:3000/halt
+curl http://127.0.0.1:3000/down
+curl http://127.0.0.1:3000/error
+curl http://127.0.0.1:3000/missing
+```
+
+## How it's structured
+
+`hello.lua` exposes a `build_app()` factory that returns a configured
+`conduit.Application` without starting a server, plus a `serve()` helper. When
+run directly (`lua hello.lua`) it serves in the foreground on port 3000; when
+loaded as a module (by the tests) it only returns the factory. This is what lets
+the test suite construct the same app and drive it over a background server.
+
+## Tests
+
+`tests/test_hello.lua` is an end-to-end suite (busted): it loads `build_app()`,
+serves it on an ephemeral port in the background, and hits every route over real
+HTTP via `luasocket`, asserting status codes and bodies. If `luasocket` is not
+installed the E2E tests are skipped (pending), mirroring the conduit library's
+own server tests.
+
+```sh
+cd tests && busted . --pattern=test_
+```
+
+The `BUILD` file compiles the conduit package's native extension first, then runs
+these tests.

--- a/code/programs/lua/conduit-hello/hello.lua
+++ b/code/programs/lua/conduit-hello/hello.lua
@@ -23,6 +23,16 @@
 --   curl http://127.0.0.1:3000/down
 --   curl http://127.0.0.1:3000/error
 --   curl http://127.0.0.1:3000/missing
+--
+-- STRUCTURE
+-- ---------
+-- The application is built in `build_app()` (returns a configured
+-- `conduit.Application`) so the test suite can construct it and drive it over a
+-- background server WITHOUT this file's top-level code starting a blocking
+-- foreground server.  When run directly (`lua hello.lua`) the guard at the
+-- bottom builds the app and serves it in the foreground; when this file is
+-- loaded as a module (`dofile`/`require` from the tests) it only returns the
+-- module table.
 
 -- Adjust the package path so this program can be run from its own directory
 -- or from the repo root. The conduit package directory is three levels up.
@@ -39,86 +49,108 @@ local html     = conduit.html
 local json     = conduit.json
 local halt     = conduit.halt
 
-local app = conduit.Application.new()
+-- ── Application factory ───────────────────────────────────────────────────────
+-- Build and return the demo application.  Pure construction — no server is
+-- started here, so this is safe to call from tests.
+local function build_app()
+    local app = conduit.Application.new()
 
-app:set("app_name", "Conduit Hello")
+    app:set("app_name", "Conduit Hello")
 
--- ── Before filter: block /down for maintenance ──────────────────────────────
+    -- Before filter: block /down for maintenance.
+    app:before(function(ctx)
+        if ctx:path() == "/down" then
+            halt(503, "Under maintenance")
+        end
+    end)
 
-app:before(function(ctx)
-    if ctx:path() == "/down" then
-        halt(503, "Under maintenance")
-    end
-end)
+    -- After filter: log every request to stdout.
+    app:after(function(ctx)
+        io.write("[after] " .. ctx:method() .. " " .. ctx:path() .. "\n")
+        io.flush()
+    end)
 
--- ── After filter: log every request to stdout ───────────────────────────────
+    -- Routes.
+    app:get("/", function(ctx)
+        return html("<h1>Hello from Conduit!</h1><p>Try /hello/Adhithya</p>")
+    end)
 
-app:after(function(ctx)
-    io.write("[after] " .. ctx:method() .. " " .. ctx:path() .. "\n")
+    app:get("/hello/:name", function(ctx)
+        local name = ctx:params()["name"]
+        return json({ message = "Hello " .. name, app = app:get("app_name") })
+    end)
+
+    app:post("/echo", function(ctx)
+        local data = ctx:json_body()
+        return json(data)
+    end)
+
+    app:get("/redirect", function(ctx)
+        return conduit.redirect("/", 301)
+    end)
+
+    app:get("/halt", function(ctx)
+        halt(403, "Forbidden — this route always halts")
+    end)
+
+    app:get("/down", function(ctx)
+        -- Unreachable: the before filter halts 503 on /down
+        return html("This should never be reached")
+    end)
+
+    app:get("/error", function(ctx)
+        error("Intentional error for demo")
+    end)
+
+    -- Custom not-found handler.
+    app:not_found(function(ctx)
+        return html("<h1>404 Not Found</h1>", 404)
+    end)
+
+    -- Custom error handler.  Never include raw error details in the response:
+    -- they may expose file paths, line numbers, or other internal implementation
+    -- details to external clients.
+    app:error_handler(function(ctx, err)
+        return json({ error = "Internal Server Error" }, 500)
+    end)
+
+    return app
+end
+
+-- ── Foreground server (run directly) ─────────────────────────────────────────
+local function serve(host, port)
+    host = host or "127.0.0.1"
+    port = port or 3000
+    local app = build_app()
+    local server = conduit.Server.new(app, { host = host, port = port })
+
+    io.write(app:get("app_name") .. " listening on http://" .. host .. ":" .. port .. "\n")
+    io.write("Routes:\n")
+    io.write("  GET  /                 → HTML greeting\n")
+    io.write("  GET  /hello/:name      → JSON response\n")
+    io.write("  POST /echo             → echo JSON body\n")
+    io.write("  GET  /redirect         → 301 to /\n")
+    io.write("  GET  /halt             → 403 Forbidden\n")
+    io.write("  GET  /down             → 503 (before filter)\n")
+    io.write("  GET  /error            → 500 via custom error handler\n")
+    io.write("  GET  /missing          → 404 via custom not_found handler\n")
+    io.write("Press Ctrl-C to stop.\n")
     io.flush()
-end)
 
--- ── Routes ───────────────────────────────────────────────────────────────────
+    server:serve()
+end
 
-app:get("/", function(ctx)
-    return html("<h1>Hello from Conduit!</h1><p>Try /hello/Adhithya</p>")
-end)
+-- Run the server only when executed directly (`lua hello.lua`), NOT when this
+-- file is loaded as a module by the test suite (`dofile`).  `arg[0]` is the
+-- entry script's path; under the test runner it is the runner, not `hello.lua`.
+local invoked_directly = arg and arg[0]
+    and arg[0]:gsub("\\", "/"):match("hello%.lua$") ~= nil
 
-app:get("/hello/:name", function(ctx)
-    local name = ctx:params()["name"]
-    return json({ message = "Hello " .. name, app = app:get("app_name") })
-end)
+if invoked_directly then
+    serve()
+end
 
-app:post("/echo", function(ctx)
-    local data = ctx:json_body()
-    return json(data)
-end)
-
-app:get("/redirect", function(ctx)
-    return conduit.redirect("/", 301)
-end)
-
-app:get("/halt", function(ctx)
-    halt(403, "Forbidden — this route always halts")
-end)
-
-app:get("/down", function(ctx)
-    -- Unreachable: the before filter halts 503 on /down
-    return html("This should never be reached")
-end)
-
-app:get("/error", function(ctx)
-    error("Intentional error for demo")
-end)
-
--- ── Custom not-found handler ─────────────────────────────────────────────────
-
-app:not_found(function(ctx)
-    return html("<h1>404 Not Found</h1>", 404)
-end)
-
--- ── Custom error handler ──────────────────────────────────────────────────────
--- Never include raw error details in the response: they may expose file paths,
--- line numbers, or other internal implementation details to external clients.
-app:error_handler(function(ctx, err)
-    return json({ error = "Internal Server Error" }, 500)
-end)
-
--- ── Start server ─────────────────────────────────────────────────────────────
-
-local server = conduit.Server.new(app, { host = "127.0.0.1", port = 3000 })
-
-io.write(app:get("app_name") .. " listening on http://127.0.0.1:3000\n")
-io.write("Routes:\n")
-io.write("  GET  /                 → HTML greeting\n")
-io.write("  GET  /hello/:name      → JSON response\n")
-io.write("  POST /echo             → echo JSON body\n")
-io.write("  GET  /redirect         → 301 to /\n")
-io.write("  GET  /halt             → 403 Forbidden\n")
-io.write("  GET  /down             → 503 (before filter)\n")
-io.write("  GET  /error            → 500 via custom error handler\n")
-io.write("  GET  /missing          → 404 via custom not_found handler\n")
-io.write("Press Ctrl-C to stop.\n")
-io.flush()
-
-server:serve()
+return {
+    build_app = build_app,
+    serve     = serve,
+}

--- a/code/programs/lua/conduit-hello/tests/test_hello.lua
+++ b/code/programs/lua/conduit-hello/tests/test_hello.lua
@@ -1,0 +1,153 @@
+-- test_hello.lua — End-to-end tests for the conduit-hello Lua demo.
+--
+-- Loads the demo's `build_app()` (without starting its foreground server),
+-- serves it on an ephemeral port in the background, and drives every route over
+-- real HTTP via luasocket — mirroring the conduit library's own `test_server`.
+--
+-- If luasocket is not installed the E2E tests are pending (skipped), exactly
+-- like the library suite, so the demo still builds where the optional socket
+-- library is unavailable.
+--
+-- Run (from this directory): `busted . --pattern=test_`
+
+-- Find the conduit package: from this `tests/` dir it is four levels up under
+-- `code/packages/lua/conduit`.  The demo's own `hello.lua` also extends the
+-- path, but we set it here too so this test file can be loaded standalone.
+package.path  = "../../../../packages/lua/conduit/?.lua;"
+             .. "../../../../packages/lua/conduit/?/init.lua;"
+             .. package.path
+package.cpath = "../../../../packages/lua/conduit/?.so;"
+             .. "../../../../packages/lua/conduit/?.dll;"
+             .. package.cpath
+
+-- Try to load luasocket; skip E2E if unavailable.
+local socket_http_ok, socket_http = pcall(require, "socket.http")
+local ltn12_ok,       ltn12       = pcall(require, "ltn12")
+local socket_ok,      socket      = pcall(require, "socket")
+
+if not (socket_http_ok and ltn12_ok and socket_ok) then
+    pending("luasocket is not installed — skipping E2E demo tests")
+    return
+end
+
+local conduit = require("conduit")
+
+-- ---------------------------------------------------------------------------
+-- HTTP helpers (same shape as the library's test_server.lua)
+-- ---------------------------------------------------------------------------
+
+local function request(method, port, path, req_headers, req_body)
+    local url = "http://127.0.0.1:" .. port .. path
+    local body_sink = {}
+    local opts = {
+        url     = url,
+        method  = method,
+        sink    = ltn12.sink.table(body_sink),
+        headers = req_headers or {},
+        redirect = false, -- assert the 3xx ourselves; do not follow
+    }
+    if req_body then
+        opts.source  = ltn12.source.string(req_body)
+        opts.headers = opts.headers or {}
+        opts.headers["content-length"] = tostring(#req_body)
+    end
+    local _, status, resp_headers = socket_http.request(opts)
+    return {
+        status  = status,
+        headers = resp_headers or {},
+        body    = table.concat(body_sink),
+    }
+end
+
+local function get(port, path)
+    return request("GET", port, path)
+end
+
+local function post(port, path, content_type, body)
+    return request("POST", port, path, { ["content-type"] = content_type }, body)
+end
+
+local function wait_for_server(port, timeout)
+    local deadline = socket.gettime() + (timeout or 2)
+    while socket.gettime() < deadline do
+        local c = socket.connect("127.0.0.1", port)
+        if c then c:close(); return true end
+        socket.sleep(0.05)
+    end
+    return false
+end
+
+-- ---------------------------------------------------------------------------
+-- Server setup — load the DEMO's app factory and serve it in the background.
+-- ---------------------------------------------------------------------------
+
+local server_instance
+local server_port
+
+describe("conduit-hello demo (Lua)", function()
+    setup(function()
+        -- `dofile` the demo: its bottom-of-file guard only serves when invoked
+        -- as `lua hello.lua` (arg[0] ends in hello.lua), so under busted it just
+        -- returns the module table without starting a foreground server.
+        local demo = dofile("../hello.lua")
+        local app = demo.build_app()
+        server_instance = conduit.Server.new(app, { host = "127.0.0.1", port = 0 })
+        server_instance:serve_background()
+        server_port = server_instance:local_port()
+        assert.is_true(wait_for_server(server_port, 5), "demo server did not start in time")
+    end)
+
+    teardown(function()
+        if server_instance then
+            server_instance:stop()
+            socket.sleep(0.1)
+        end
+    end)
+
+    it("GET / returns the HTML greeting", function()
+        local res = get(server_port, "/")
+        assert.are.equal(200, res.status)
+        assert.is_truthy(res.body:find("Hello from Conduit!", 1, true))
+    end)
+
+    it("GET /hello/:name returns JSON with the name", function()
+        local res = get(server_port, "/hello/Adhithya")
+        assert.are.equal(200, res.status)
+        assert.is_truthy(res.body:find("Hello Adhithya", 1, true))
+    end)
+
+    it("POST /echo echoes the JSON body", function()
+        local res = post(server_port, "/echo", "application/json", '{"ping":"pong"}')
+        assert.are.equal(200, res.status)
+        assert.is_truthy(res.body:find("pong", 1, true))
+    end)
+
+    it("GET /redirect returns 301 with Location: /", function()
+        local res = get(server_port, "/redirect")
+        assert.are.equal(301, res.status)
+        local loc = res.headers["location"] or res.headers["Location"]
+        assert.are.equal("/", loc)
+    end)
+
+    it("GET /halt returns 403", function()
+        local res = get(server_port, "/halt")
+        assert.are.equal(403, res.status)
+    end)
+
+    it("GET /down returns 503 from the before filter", function()
+        local res = get(server_port, "/down")
+        assert.are.equal(503, res.status)
+    end)
+
+    it("GET /error returns 500 from the custom error handler", function()
+        local res = get(server_port, "/error")
+        assert.are.equal(500, res.status)
+        assert.is_truthy(res.body:find("Internal Server Error", 1, true))
+    end)
+
+    it("GET /missing returns the custom 404 page", function()
+        local res = get(server_port, "/missing")
+        assert.are.equal(404, res.status)
+        assert.is_truthy(res.body:find("404 Not Found", 1, true))
+    end)
+end)


### PR DESCRIPTION
## Summary

A Conduit completeness audit found the **Lua `conduit-hello` demo was the one outlier** in the 16-language port matrix: its directory held only `hello.lua` — no BUILD, README, CHANGELOG, or tests. That means it was **absent from the build graph and untested**, unlike every other language's demo (python, ruby, typescript, … all ship those + a `tests/` suite).

This brings the Lua demo to parity:

- **`BUILD` / `BUILD_windows`** — declare `deps=lua/conduit`, compile the conduit package's `conduit_native` cdylib, install `luasocket`, and run the demo's E2E tests via `busted`.
- **`tests/test_hello.lua`** — end-to-end suite that loads the demo's `build_app()`, serves it on an ephemeral port in the background, and drives all 8 routes (`/`, `/hello/:name`, `/echo`, `/redirect`, `/halt`, `/down`, `/error`, unmatched→404) over real HTTP. Self-skips when `luasocket` is absent, mirroring the conduit library's own server suite.
- **`README.md`** (routes table, run + structure + test notes) and **`CHANGELOG.md`**.
- **`hello.lua` refactor** — app construction moved into a `build_app()` factory (starts no server) + a `serve()` helper; a bottom-of-file guard runs the foreground server only when invoked directly (`lua hello.lua`), so the tests can construct and drive the same app. **Routes/behaviour unchanged.**

## Test plan

- [x] Local: `bash BUILD` → builds the native cdylib + runs busted → **8 successes / 0 failures**
- [x] `/security-review` passed (shell injection, Lua `dofile`/XSS/info-disclosure, secrets) — no findings
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)