### PR TITLE
Add SPICE deck measurement artifacts

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ### Added
 
+- **Deck measurement artifact routing** —
+  `run_deck_analysis()` now returns selected `.measure` / `.meas` results and
+  a stable measurement table for selected `.dc`, `.ac`, and `.tran` executions,
+  matching Rust and TypeScript.
+
 - **Deck selected-output artifact metadata** —
   `run_deck_analysis()` now returns the normalized deck-selected output probes
   alongside each selected plan, solver result, and stable table, matching Rust

--- a/code/packages/python/spice-engine/README.md
+++ b/code/packages/python/spice-engine/README.md
@@ -103,7 +103,8 @@ implicit `.op`, and reports ambiguity before solver dispatch.
 `run_deck_analysis()` executes one selected `.op`, `.dc`, `.ac LIN`,
 `.ac DEC`, `.ac OCT`, or `.tran` plan against an existing `Circuit` and
 returns the plan, solver result, deck-selected output table, and normalized
-output probes that produced the table. Selected
+output probes that produced the table, plus selected `.measure` results and a
+stable measurement table for `.dc`, `.ac`, and `.tran` executions. Selected
 `.tran` plans route `START` output filtering, use `.tran TSTEP` as the output
 print grid, apply `MAXSTEP` as an internal fixed-step cap, and carry `UIC`
 initial-condition intent through that stable transient table surface.
@@ -188,8 +189,8 @@ diagnostics for malformed deck-level analysis controls.
 downstream deck execution helpers.
 `run_deck_analysis()` routes that selected plan into the matching solver and
 stable deck-selected table output with normalized output-probe artifacts,
-including `.ac LIN`, `.ac DEC`, `.ac OCT` frequency grids, and `.tran`
-`START` / print-step `TSTEP` / `MAXSTEP` / `UIC` controls.
+selected measurement artifacts, `.ac LIN`, `.ac DEC`, `.ac OCT` frequency
+grids, and `.tran` `START` / print-step `TSTEP` / `MAXSTEP` / `UIC` controls.
 
 ## Controlled source examples
 

--- a/code/packages/python/spice-engine/src/spice_engine/engine.py
+++ b/code/packages/python/spice-engine/src/spice_engine/engine.py
@@ -2301,6 +2301,26 @@ class DeckAnalysisExecution:
     result: DcResult | DcSweepResult | AcResult | TransientResult
     table: str
     output_probes: list[str]
+    measurements: list[ProbeMeasurement]
+    measurement_table: str
+
+
+def _select_deck_measurement_cards_for_analysis(
+    netlist: str,
+    analysis: str,
+) -> list[DeckMeasurementCard]:
+    summary = resolve_deck_measurements(netlist)
+    if summary.diagnostics:
+        diagnostic = summary.diagnostics[0]
+        raise ValueError(
+            f"run_deck_analysis: line {diagnostic.line_number}: {diagnostic.message}"
+        )
+    return [
+        measurement
+        for measurement in summary.measurements
+        if measurement.analysis == analysis
+        or (analysis == "tran" and measurement.analysis == "transient")
+    ]
 
 
 def run_deck_analysis(
@@ -2313,11 +2333,15 @@ def run_deck_analysis(
     plan = select_deck_analysis_plan(netlist, analysis)
     if plan.analysis == "op":
         result = dc_op(circuit)
+        _select_deck_measurement_cards_for_analysis(netlist, plan.analysis)
+        measurements: list[ProbeMeasurement] = []
         return DeckAnalysisExecution(
             plan=plan,
             result=result,
             table=format_deck_op_table(result, netlist),
             output_probes=select_deck_output_probes(netlist, plan.analysis),
+            measurements=measurements,
+            measurement_table=format_measurement_table(measurements),
         )
     if plan.analysis == "dc":
         source_name = _require_deck_plan_string(plan, "source_name")
@@ -2325,11 +2349,17 @@ def run_deck_analysis(
         stop = _require_deck_plan_number(plan, "stop_value")
         step = _require_deck_plan_number(plan, "step_value")
         result = dc_sweep(circuit, source_name, start, stop, step)
+        measurements = measure_dc_sweep_cards(
+            result,
+            _select_deck_measurement_cards_for_analysis(netlist, plan.analysis),
+        )
         return DeckAnalysisExecution(
             plan=plan,
             result=result,
             table=format_deck_dc_sweep_table(result, netlist),
             output_probes=select_deck_output_probes(netlist, plan.analysis),
+            measurements=measurements,
+            measurement_table=format_measurement_table(measurements),
         )
     if plan.analysis == "ac":
         sweep_kind = _require_deck_plan_string(plan, "sweep_kind")
@@ -2339,11 +2369,17 @@ def run_deck_analysis(
         result = _run_deck_ac_sweep(
             circuit, plan, sweep_kind, point_count, start_frequency, stop_frequency
         )
+        measurements = measure_ac_sweep_cards(
+            result,
+            _select_deck_measurement_cards_for_analysis(netlist, plan.analysis),
+        )
         return DeckAnalysisExecution(
             plan=plan,
             result=result,
             table=format_deck_ac_table(result, netlist),
             output_probes=select_deck_output_probes(netlist, plan.analysis),
+            measurements=measurements,
+            measurement_table=format_measurement_table(measurements),
         )
     if plan.analysis == "tran":
         step_time = _require_deck_plan_number(plan, "step_time")
@@ -2357,11 +2393,17 @@ def run_deck_analysis(
             start_time=start_time,
             stop_time=stop_time,
         )
+        measurements = measure_transient_cards(
+            result,
+            _select_deck_measurement_cards_for_analysis(netlist, plan.analysis),
+        )
         return DeckAnalysisExecution(
             plan=plan,
             result=result,
             table=format_deck_transient_table(result, netlist),
             output_probes=select_deck_output_probes(netlist, plan.analysis),
+            measurements=measurements,
+            measurement_table=format_measurement_table(measurements),
         )
     raise ValueError(f"run_deck_analysis: unsupported analysis {plan.analysis!r}")
 

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -6768,17 +6768,27 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
 .dc V1 0 1 1
 .ac dec 1 1k 1k
 .tran 1m 1m
+.measure dc mid_avg avg V(mid)
+.measure ac mid_peak max V(mid)
+.measure tran mid_final final V(mid)
 .end
 """
 
     op_execution = run_deck_analysis(circuit, netlist, "op")
     assert op_execution.plan.analysis == "op"
     assert op_execution.output_probes == ["V(mid)"]
+    assert op_execution.measurements == []
+    assert op_execution.measurement_table == "Name\tAnalysis\tProbe\tMode\tFrom\tTo\tValue\n"
     assert op_execution.table == "Index\tV(mid)\n0\t5.000000e-01\n"
 
     dc_execution = run_deck_analysis(circuit, netlist, "dc")
     assert dc_execution.plan.source_name == "V1"
     assert dc_execution.output_probes == ["V(mid)", "I(V1)"]
+    assert [measurement.name for measurement in dc_execution.measurements] == ["mid_avg"]
+    assert dc_execution.measurement_table == (
+        "Name\tAnalysis\tProbe\tMode\tFrom\tTo\tValue\n"
+        "mid_avg\tdc\tV(mid)\tavg\t\t\t2.500000e-01\n"
+    )
     assert isinstance(dc_execution.result, DcSweepResult)
     assert len(dc_execution.result.points) == 2
     assert dc_execution.table == (
@@ -6789,6 +6799,11 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
 
     ac_execution = run_deck_analysis(circuit, netlist, "ac")
     assert ac_execution.output_probes == ["V(mid)"]
+    assert [measurement.name for measurement in ac_execution.measurements] == ["mid_peak"]
+    assert ac_execution.measurement_table == (
+        "Name\tAnalysis\tProbe\tMode\tFrom\tTo\tValue\n"
+        "mid_peak\tac\tV(mid)\tmax\t\t\t5.000000e-01\n"
+    )
     assert isinstance(ac_execution.result, AcResult)
     assert len(ac_execution.result.points) == 1
     assert ac_execution.table == (
@@ -6798,6 +6813,13 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
 
     tran_execution = run_deck_analysis(circuit, netlist, "tran")
     assert tran_execution.output_probes == ["V(mid)"]
+    assert [measurement.name for measurement in tran_execution.measurements] == [
+        "mid_final"
+    ]
+    assert tran_execution.measurement_table == (
+        "Name\tAnalysis\tProbe\tMode\tFrom\tTo\tValue\n"
+        "mid_final\ttran\tV(mid)\tlast\t\t\t5.000000e-01\n"
+    )
     assert isinstance(tran_execution.result, TransientResult)
     assert tran_execution.table == (
         "Index\tTime\tV(mid)\n"

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Add selected measurement artifacts to `run_deck_analysis`; selected `.dc`,
+  `.ac`, and `.tran` executions now return parsed `.measure` / `.meas` results
+  and a stable measurement table alongside the selected plan, solver result,
+  output probes, and output table, matching Python and TypeScript.
 - Add selected-output probe artifacts to `run_deck_analysis`; callers now
   receive the normalized deck-selected output probes alongside each selected
   plan, solver result, and stable table, matching Python and TypeScript.

--- a/code/packages/rust/spice-engine/README.md
+++ b/code/packages/rust/spice-engine/README.md
@@ -157,7 +157,8 @@ card by analysis alias, defaults decks without analysis cards to an implicit
 `run_deck_analysis` executes one selected `.op`, `.dc`, `.ac LIN`, `.ac DEC`,
 `.ac OCT`, or `.tran` plan against an existing `Circuit` and returns the plan,
 solver result, deck-selected output table, and normalized output probes that
-produced the table. Selected `.tran` plans route
+produced the table, plus selected `.measure` results and a stable measurement
+table for `.dc`, `.ac`, and `.tran` executions. Selected `.tran` plans route
 `START` output filtering, use `.tran TSTEP` as the output print grid, apply
 `MAXSTEP` as an internal fixed-step cap, and carry `UIC` initial-condition
 intent through that stable transient table surface.
@@ -201,5 +202,5 @@ malformed deck-level analysis controls.
 downstream deck execution helpers.
 `run_deck_analysis` routes that selected plan into the matching solver and
 stable deck-selected table output with normalized output-probe artifacts,
-including `.ac LIN`, `.ac DEC`, `.ac OCT` frequency grids, and `.tran`
-`START` / print-step `TSTEP` / `MAXSTEP` / `UIC` controls.
+selected measurement artifacts, `.ac LIN`, `.ac DEC`, `.ac OCT` frequency
+grids, and `.tran` `START` / print-step `TSTEP` / `MAXSTEP` / `UIC` controls.

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -3404,6 +3404,8 @@ pub struct DeckAnalysisExecution {
     pub result: DeckAnalysisExecutionResult,
     pub table: String,
     pub output_probes: Vec<String>,
+    pub measurements: Vec<ProbeMeasurement>,
+    pub measurement_table: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -9413,6 +9415,27 @@ pub fn format_deck_transient_table(
     format_transient_table(points, &probe_refs)
 }
 
+fn select_deck_measurement_cards_for_analysis(
+    netlist: &str,
+    analysis: &str,
+) -> Result<Vec<DeckMeasurementCard>, SpiceError> {
+    let summary = resolve_deck_measurements(netlist);
+    if let Some(diagnostic) = summary.diagnostics.first() {
+        return Err(table_error(
+            "run_deck_analysis",
+            &format!("line {}: {}", diagnostic.line_number, diagnostic.message),
+        ));
+    }
+    Ok(summary
+        .measurements
+        .into_iter()
+        .filter(|measurement| {
+            measurement.analysis == analysis
+                || (analysis == "tran" && measurement.analysis == "transient")
+        })
+        .collect())
+}
+
 pub fn run_deck_analysis(
     circuit: &Circuit,
     netlist: &str,
@@ -9423,11 +9446,16 @@ pub fn run_deck_analysis(
         "op" => {
             let result = dc_op(circuit)?;
             let table = format_deck_op_table(&result, netlist)?;
+            select_deck_measurement_cards_for_analysis(netlist, "op")?;
+            let measurements = Vec::new();
+            let measurement_table = format_measurement_table(&measurements);
             Ok(DeckAnalysisExecution {
                 plan,
                 result: DeckAnalysisExecutionResult::Op(result),
                 table,
                 output_probes: select_deck_output_probes(netlist, "op")?,
+                measurements,
+                measurement_table,
             })
         }
         "dc" => {
@@ -9439,11 +9467,16 @@ pub fn run_deck_analysis(
             let step = require_deck_plan_number(plan.step_value, &plan, "step_value")?;
             let result = dc_sweep(circuit, &source_name, start, stop, step)?;
             let table = format_deck_dc_sweep_table(&source_name, &result, netlist)?;
+            let measurement_cards = select_deck_measurement_cards_for_analysis(netlist, "dc")?;
+            let measurements = measure_dc_sweep_cards(&result, &measurement_cards)?;
+            let measurement_table = format_measurement_table(&measurements);
             Ok(DeckAnalysisExecution {
                 plan,
                 result: DeckAnalysisExecutionResult::DcSweep(result),
                 table,
                 output_probes: select_deck_output_probes(netlist, "dc")?,
+                measurements,
+                measurement_table,
             })
         }
         "ac" => {
@@ -9456,11 +9489,16 @@ pub fn run_deck_analysis(
                 require_deck_plan_number(plan.stop_frequency_hz, &plan, "stop_frequency_hz")?;
             let result = run_deck_ac_sweep(circuit, &plan, sweep_kind, point_count, start, stop)?;
             let table = format_deck_ac_table(&result, netlist)?;
+            let measurement_cards = select_deck_measurement_cards_for_analysis(netlist, "ac")?;
+            let measurements = measure_ac_sweep_cards(&result, &measurement_cards)?;
+            let measurement_table = format_measurement_table(&measurements);
             Ok(DeckAnalysisExecution {
                 plan,
                 result: DeckAnalysisExecutionResult::Ac(result),
                 table,
                 output_probes: select_deck_output_probes(netlist, "ac")?,
+                measurements,
+                measurement_table,
             })
         }
         "tran" => {
@@ -9476,11 +9514,16 @@ pub fn run_deck_analysis(
                 stop_time,
             )?;
             let table = format_deck_transient_table(&result, netlist)?;
+            let measurement_cards = select_deck_measurement_cards_for_analysis(netlist, "tran")?;
+            let measurements = measure_transient_cards(&result, &measurement_cards)?;
+            let measurement_table = format_measurement_table(&measurements);
             Ok(DeckAnalysisExecution {
                 plan,
                 result: DeckAnalysisExecutionResult::Tran(result),
                 table,
                 output_probes: select_deck_output_probes(netlist, "tran")?,
+                measurements,
+                measurement_table,
             })
         }
         _ => Err(SpiceError::InvalidElement {

--- a/code/packages/rust/spice-engine/tests/transient_tests.rs
+++ b/code/packages/rust/spice-engine/tests/transient_tests.rs
@@ -1866,12 +1866,20 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
 .dc V1 0 1 1
 .ac dec 1 1k 1k
 .tran 1m 1m
+.measure dc mid_avg avg V(mid)
+.measure ac mid_peak max V(mid)
+.measure tran mid_final final V(mid)
 .end
 ";
 
     let op_execution = run_deck_analysis(&circuit, netlist, Some("op")).unwrap();
     assert_eq!(op_execution.plan.analysis, "op");
     assert_eq!(op_execution.output_probes, vec!["V(mid)".to_string()]);
+    assert!(op_execution.measurements.is_empty());
+    assert_eq!(
+        op_execution.measurement_table,
+        "Name\tAnalysis\tProbe\tMode\tFrom\tTo\tValue\n"
+    );
     assert_eq!(op_execution.table, "Index\tV(mid)\n0\t5.000000e-01\n");
 
     let dc_execution = run_deck_analysis(&circuit, netlist, Some("dc")).unwrap();
@@ -1879,6 +1887,11 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
     assert_eq!(
         dc_execution.output_probes,
         vec!["V(mid)".to_string(), "I(V1)".to_string()]
+    );
+    assert_eq!(dc_execution.measurements[0].name, "mid_avg");
+    assert_eq!(
+        dc_execution.measurement_table,
+        "Name\tAnalysis\tProbe\tMode\tFrom\tTo\tValue\nmid_avg\tdc\tV(mid)\tavg\t\t\t2.500000e-01\n"
     );
     match dc_execution.result {
         DeckAnalysisExecutionResult::DcSweep(points) => assert_eq!(points.len(), 2),
@@ -1891,6 +1904,11 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
 
     let ac_execution = run_deck_analysis(&circuit, netlist, Some("ac")).unwrap();
     assert_eq!(ac_execution.output_probes, vec!["V(mid)".to_string()]);
+    assert_eq!(ac_execution.measurements[0].name, "mid_peak");
+    assert_eq!(
+        ac_execution.measurement_table,
+        "Name\tAnalysis\tProbe\tMode\tFrom\tTo\tValue\nmid_peak\tac\tV(mid)\tmax\t\t\t5.000000e-01\n"
+    );
     match ac_execution.result {
         DeckAnalysisExecutionResult::Ac(points) => assert_eq!(points.len(), 1),
         other => panic!("expected AC result, got {other:?}"),
@@ -1902,6 +1920,11 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
 
     let tran_execution = run_deck_analysis(&circuit, netlist, Some("tran")).unwrap();
     assert_eq!(tran_execution.output_probes, vec!["V(mid)".to_string()]);
+    assert_eq!(tran_execution.measurements[0].name, "mid_final");
+    assert_eq!(
+        tran_execution.measurement_table,
+        "Name\tAnalysis\tProbe\tMode\tFrom\tTo\tValue\nmid_final\ttran\tV(mid)\tlast\t\t\t5.000000e-01\n"
+    );
     match tran_execution.result {
         DeckAnalysisExecutionResult::Tran(points) => assert_eq!(points.len(), 1),
         other => panic!("expected transient result, got {other:?}"),

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Add selected measurement artifacts to `runDeckAnalysis`; selected `.dc`,
+  `.ac`, and `.tran` executions now return parsed `.measure` / `.meas` results
+  and a stable measurement table alongside the selected plan, solver result,
+  output probes, and output table, matching Python and Rust.
 - Add selected-output probe artifacts to `runDeckAnalysis`; callers now receive
   the normalized deck-selected output probes alongside each selected plan,
   solver result, and stable table, matching Python and Rust.

--- a/code/packages/typescript/spice-engine/README.md
+++ b/code/packages/typescript/spice-engine/README.md
@@ -91,7 +91,8 @@ and reports ambiguity before solver dispatch.
 `runDeckAnalysis` executes one selected `.op`, `.dc`, `.ac LIN`, `.ac DEC`,
 `.ac OCT`, or `.tran` plan against an existing `Circuit` and returns the plan,
 solver result, deck-selected output table, and normalized output probes that
-produced the table. Selected `.tran` plans route
+produced the table, plus selected `.measure` results and a stable measurement
+table for `.dc`, `.ac`, and `.tran` executions. Selected `.tran` plans route
 `START` output filtering, use `.tran TSTEP` as the output print grid, apply
 `MAXSTEP` as an internal fixed-step cap, and carry `UIC` initial-condition
 intent through that stable transient table surface.
@@ -163,6 +164,6 @@ malformed deck-level analysis controls.
 `selectDeckAnalysisPlan` returns one selected or implicit plan for downstream
 deck execution helpers.
 `runDeckAnalysis` routes that selected plan into the matching solver and stable
-deck-selected table output with normalized output-probe artifacts, including
-`.ac LIN`, `.ac DEC`, `.ac OCT` frequency grids, and `.tran` `START` /
-print-step `TSTEP` / `MAXSTEP` / `UIC` controls.
+deck-selected table output with normalized output-probe artifacts, selected
+measurement artifacts, `.ac LIN`, `.ac DEC`, `.ac OCT` frequency grids, and
+`.tran` `START` / print-step `TSTEP` / `MAXSTEP` / `UIC` controls.

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -659,6 +659,8 @@ export interface DeckAnalysisExecution {
   readonly result: DeckAnalysisExecutionResult;
   readonly table: string;
   readonly outputProbes: readonly string[];
+  readonly measurements: readonly ProbeMeasurement[];
+  readonly measurementTable: string;
 }
 
 export interface ReleaseReadinessIssue {
@@ -7251,6 +7253,24 @@ export function formatDeckTransientTable(
   return probes.length === 0 ? formatTransientTable(points) : formatTransientTable(points, probes);
 }
 
+function selectDeckMeasurementCardsForAnalysis(
+  netlist: string,
+  analysis: DeckAnalysisPlan["analysis"],
+): DeckMeasurementCard[] {
+  const summary = resolveDeckMeasurements(netlist);
+  if (summary.diagnostics.length > 0) {
+    const diagnostic = summary.diagnostics[0]!;
+    throw invalidElement(
+      "runDeckAnalysis",
+      `line ${diagnostic.lineNumber}: ${diagnostic.message}`,
+    );
+  }
+  return summary.measurements.filter((measurement) =>
+    measurement.analysis === analysis ||
+    (analysis === "tran" && measurement.analysis === "transient")
+  );
+}
+
 export function runDeckAnalysis(
   circuit: Circuit,
   netlist: string,
@@ -7259,11 +7279,15 @@ export function runDeckAnalysis(
   const plan = selectDeckAnalysisPlan(netlist, analysis);
   if (plan.analysis === "op") {
     const result = dcOp(circuit);
+    selectDeckMeasurementCardsForAnalysis(netlist, plan.analysis);
+    const measurements: ProbeMeasurement[] = [];
     return {
       plan,
       result,
       table: formatDeckOpTable(result, netlist),
       outputProbes: selectDeckOutputProbes(netlist, plan.analysis),
+      measurements,
+      measurementTable: formatMeasurementTable(measurements),
     };
   }
   if (plan.analysis === "dc") {
@@ -7272,11 +7296,17 @@ export function runDeckAnalysis(
     const stop = requireDeckPlanNumber(plan.stopValue, plan, "stopValue");
     const step = requireDeckPlanNumber(plan.stepValue, plan, "stepValue");
     const result = dcSweep(circuit, sourceName, start, stop, step);
+    const measurements = measureDcSweepCards(
+      result,
+      selectDeckMeasurementCardsForAnalysis(netlist, plan.analysis),
+    );
     return {
       plan,
       result,
       table: formatDeckDcSweepTable(sourceName, result, netlist),
       outputProbes: selectDeckOutputProbes(netlist, plan.analysis),
+      measurements,
+      measurementTable: formatMeasurementTable(measurements),
     };
   }
   if (plan.analysis === "ac") {
@@ -7296,11 +7326,17 @@ export function runDeckAnalysis(
       startFrequencyHz,
       stopFrequencyHz,
     );
+    const measurements = measureAcSweepCards(
+      result,
+      selectDeckMeasurementCardsForAnalysis(netlist, plan.analysis),
+    );
     return {
       plan,
       result,
       table: formatDeckAcTable(result, netlist),
       outputProbes: selectDeckOutputProbes(netlist, plan.analysis),
+      measurements,
+      measurementTable: formatMeasurementTable(measurements),
     };
   }
   if (plan.analysis === "tran") {
@@ -7313,11 +7349,17 @@ export function runDeckAnalysis(
       plan.startTime,
       stopTime,
     );
+    const measurements = measureTransientCards(
+      result,
+      selectDeckMeasurementCardsForAnalysis(netlist, plan.analysis),
+    );
     return {
       plan,
       result,
       table: formatDeckTransientTable(result, netlist),
       outputProbes: selectDeckOutputProbes(netlist, plan.analysis),
+      measurements,
+      measurementTable: formatMeasurementTable(measurements),
     };
   }
   throw invalidElement("runDeckAnalysis", `unsupported analysis ${JSON.stringify(plan.analysis)}`);

--- a/code/packages/typescript/spice-engine/tests/transient.test.ts
+++ b/code/packages/typescript/spice-engine/tests/transient.test.ts
@@ -1446,17 +1446,27 @@ describe("transient", () => {
 .dc V1 0 1 1
 .ac dec 1 1k 1k
 .tran 1m 1m
+.measure dc mid_avg avg V(mid)
+.measure ac mid_peak max V(mid)
+.measure tran mid_final final V(mid)
 .end
 `;
 
     const opExecution = runDeckAnalysis(circuit, netlist, "op");
     expect(opExecution.plan.analysis).toBe("op");
     expect(opExecution.outputProbes).toEqual(["V(mid)"]);
+    expect(opExecution.measurements).toEqual([]);
+    expect(opExecution.measurementTable).toBe("Name\tAnalysis\tProbe\tMode\tFrom\tTo\tValue\n");
     expect(opExecution.table).toBe("Index\tV(mid)\n0\t5.000000e-01\n");
 
     const dcExecution = runDeckAnalysis(circuit, netlist, "dc");
     expect(dcExecution.plan.sourceName).toBe("V1");
     expect(dcExecution.outputProbes).toEqual(["V(mid)", "I(V1)"]);
+    expect(dcExecution.measurements.map((measurement) => measurement.name)).toEqual(["mid_avg"]);
+    expect(dcExecution.measurementTable).toBe(
+      "Name\tAnalysis\tProbe\tMode\tFrom\tTo\tValue\n" +
+        "mid_avg\tdc\tV(mid)\tavg\t\t\t2.500000e-01\n",
+    );
     expect(Array.isArray(dcExecution.result)).toBe(true);
     expect(dcExecution.table).toBe(
       "Index\tSource\tValue\tV(mid)\tI(V1)\n" +
@@ -1466,6 +1476,11 @@ describe("transient", () => {
 
     const acExecution = runDeckAnalysis(circuit, netlist, "ac");
     expect(acExecution.outputProbes).toEqual(["V(mid)"]);
+    expect(acExecution.measurements.map((measurement) => measurement.name)).toEqual(["mid_peak"]);
+    expect(acExecution.measurementTable).toBe(
+      "Name\tAnalysis\tProbe\tMode\tFrom\tTo\tValue\n" +
+        "mid_peak\tac\tV(mid)\tmax\t\t\t5.000000e-01\n",
+    );
     expect(Array.isArray(acExecution.result)).toBe(true);
     expect(acExecution.table).toBe(
       "Index\tFrequency\tProbe\tReal\tImaginary\tMagnitude\tPhase\n" +
@@ -1474,6 +1489,11 @@ describe("transient", () => {
 
     const tranExecution = runDeckAnalysis(circuit, netlist, "tran");
     expect(tranExecution.outputProbes).toEqual(["V(mid)"]);
+    expect(tranExecution.measurements.map((measurement) => measurement.name)).toEqual(["mid_final"]);
+    expect(tranExecution.measurementTable).toBe(
+      "Name\tAnalysis\tProbe\tMode\tFrom\tTo\tValue\n" +
+        "mid_final\ttran\tV(mid)\tlast\t\t\t5.000000e-01\n",
+    );
     expect(Array.isArray(tranExecution.result)).toBe(true);
     expect(tranExecution.table).toBe(
       "Index\tTime\tV(mid)\n" +

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -54,7 +54,9 @@ downstream tools to compare.
      initial-condition intent; selected `.tran` execution now keeps `.tran
      TSTEP` as the deck output print grid while `MAXSTEP` caps internal solver
      stepping; deck executions now expose normalized selected output probes as
-     an inspectable artifact alongside the stable table.
+     an inspectable artifact alongside the stable table; selected `.measure`
+     outputs now travel with deck execution results as structured measurements
+     plus stable measurement tables.
    - Expand remaining deck-controlled analyses toward full SPICE compatibility
      while keeping unsupported control-flow diagnostics explicit.
 
@@ -438,12 +440,22 @@ downstream tools to compare.
     - This gives callers a structured deck-owned output artifact without
       reparsing table text.
 
+38. Deck selected measurement artifact routing.
+    - Status: completed in this deck measurement artifact slice.
+    - Python, Rust, and TypeScript `run_deck_analysis` / `runDeckAnalysis`
+      results now include selected `.measure` / `.meas` outputs and a stable
+      measurement table for `.dc`, `.ac`, and `.tran` executions.
+    - Measurement cards are selected by the executed analysis, so mixed-analysis
+      decks can expose the chosen analysis artifact without reparsing output
+      tables.
+
 ## Backlog
 
 1. Deck execution layer.
    - Expand selected-plan execution beyond fixed-step transient basics,
      including richer deck-owned run artifacts beyond selected output probes
-     and output-plan integration beyond stable table routing.
+     and selected measurement artifacts, plus output-plan integration beyond
+     stable table routing.
    - Expand deck-controlled output-plan integration beyond stable table
      routing toward full SPICE compatibility.
    - Define a deliberate `.control` subset; explicit unsupported-feature


### PR DESCRIPTION
## Summary
- add selected `.measure` / `.meas` artifacts to Python `run_deck_analysis`, Rust `run_deck_analysis`, and TypeScript `runDeckAnalysis` results
- expose both structured measurements and stable measurement-table text alongside selected plans, solver results, output probes, and output tables
- cover mixed-analysis decks so explicit `.dc`, `.ac`, and `.tran` executions select their own measurement artifacts without reparsing table text

## Verification
- `PYTHONPATH="$(find code/packages/python -maxdepth 2 -type d -name src | paste -sd: -)" /Users/adhithya/.local/share/mise/installs/python/3.12.13/bin/python3 -m ruff check code/packages/python/spice-engine/src/spice_engine/engine.py code/packages/python/spice-engine/tests/test_engine.py`
- `PYTHONPATH="$(find code/packages/python -maxdepth 2 -type d -name src | paste -sd: -)" /Users/adhithya/.local/share/mise/installs/python/3.12.13/bin/python3 -m pytest code/packages/python/spice-engine/tests -q --no-cov`
- `npm --prefix code/packages/typescript/spice-engine ci`
- `npm --prefix code/packages/typescript/spice-engine run build`
- `npm --prefix code/packages/typescript/spice-engine test`
- `cargo fmt --manifest-path code/packages/rust/spice-engine/Cargo.toml --check`
- `cargo test --manifest-path code/packages/rust/spice-engine/Cargo.toml`
- `git diff --check`
- `git diff --cached --check`