### PR TITLE
feat(mycin): REL-13 [F2] — management tactic (chart-as-constraints) in the board

### DIFF
--- a/code/specs/data/mycin-2026/board/README.md
+++ b/code/specs/data/mycin-2026/board/README.md
@@ -22,11 +22,19 @@ cite an `authoritative` (spider-grounded) edge vs a `consensus` (authored-debt)
 edge. That is the number every grounding/expansion PR moves:
 
 ```
-correct 43 · abstained 6 · wrong 0  (of 49)
-by tactic — differential: 1✓/1·/0✗  ·  recall: 42✓/5·/0✗
+correct 48 · abstained 6 · wrong 0  (of 54)
+by tactic — differential: 1✓/1·/0✗  ·  management: 5✓/0·/0✗  ·  recall: 42✓/5·/0✗
 defensibility 100%  ·  accuracy-on-attempted 100%  ·  grounded-coverage 98%
 ✓ never fabricated — every answer is correct-with-proof or an honest abstention.
 ```
+
+The board now scores **all three board question-types** over one engine + one
+defensibility metric: **recall** (binding queries over the grounded graph),
+**differential** (the LR engine ranks hypotheses; commit or abstain), and
+**management** (the chart-as-constraints engine compiles a patient context into a
+constraint program and SOLVES a regimen — or proves it INFEASIBLE with a named
+conflict). Constraints solved OR made unsatisfiable; both are defensible, neither
+fabricates.
 
 The bank spans **four recall domains** — 12 inborn-errors-of-metabolism diseases
 (`recall/iem-edges.adj`), 8 vitamin deficiencies (`recall/vitamin-edges.adj`), 8 anemia

--- a/code/specs/data/mycin-2026/board/board-scorecard.json
+++ b/code/specs/data/mycin-2026/board/board-scorecard.json
@@ -1,13 +1,18 @@
 {
   "summary": {
-    "total": 49,
-    "correct": 43,
+    "total": 54,
+    "correct": 48,
     "abstained": 6,
     "wrong": 0,
     "by_tactic": {
       "differential": {
         "correct": 1,
         "abstained": 1,
+        "wrong": 0
+      },
+      "management": {
+        "correct": 5,
+        "abstained": 0,
         "wrong": 0
       },
       "recall": {
@@ -412,6 +417,46 @@
       "gold": "ABSTAIN",
       "answer": null,
       "outcome": "abstained",
+      "trust": null
+    },
+    {
+      "id": "mgmt_adult_community",
+      "tactic": "management",
+      "gold": "ceftriaxone+vancomycin",
+      "answer": "ceftriaxone+vancomycin",
+      "outcome": "correct",
+      "trust": null
+    },
+    {
+      "id": "mgmt_older_adult",
+      "tactic": "management",
+      "gold": "ampicillin+ceftriaxone+vancomycin",
+      "answer": "ampicillin+ceftriaxone+vancomycin",
+      "outcome": "correct",
+      "trust": null
+    },
+    {
+      "id": "mgmt_neurosurgical",
+      "tactic": "management",
+      "gold": "cefepime+vancomycin",
+      "answer": "cefepime+vancomycin",
+      "outcome": "correct",
+      "trust": null
+    },
+    {
+      "id": "mgmt_pregnant_adult",
+      "tactic": "management",
+      "gold": "ceftriaxone+vancomycin",
+      "answer": "ceftriaxone+vancomycin",
+      "outcome": "correct",
+      "trust": null
+    },
+    {
+      "id": "mgmt_betalactam_allergic",
+      "tactic": "management",
+      "gold": "INFEASIBLE",
+      "answer": "INFEASIBLE",
+      "outcome": "correct",
       "trust": null
     }
   ]

--- a/code/specs/data/mycin-2026/board/board_eval.py
+++ b/code/specs/data/mycin-2026/board/board_eval.py
@@ -107,6 +107,48 @@ def score_differential(decision: dict | None, gold: str) -> tuple[str, str | Non
     return "abstained", None
 
 
+# The MANAGEMENT tactic — "best next step / empiric regimen" — runs the real
+# chart-as-constraints engine: a patient context (likely organisms + allergies /
+# comorbidity / pregnancy / renal) compiles into a constraint program that the
+# adj-constraint-solver SOLVES into a min-cost regimen, OR proves INFEASIBLE with a
+# named conflict. Constraints solved OR made unsatisfiable — both are defensible.
+_TREATMENT = HERE.parent / "treatment" / "antibiotics"
+
+
+def run_management(chart: list[list[str]]) -> dict | None:
+    """Compile the chart-fact IR → COP, solve it via the native engine, and return the
+    result dict (regimen / outcome / conflict). None if the CLI binary is unavailable."""
+    if not cli_available():
+        return None
+    if str(_TREATMENT) not in sys.path:
+        sys.path.insert(0, str(_TREATMENT))
+    import chart_to_cop as ctc  # noqa: E402  (reuse the merged chart→constraints engine)
+
+    facts = [ctc.ChartFact(*(f + [""])[:3]) for f in chart]  # [kind, value, span?]
+    return ctc.derive(_CLI, facts)
+
+
+def score_management(result: dict | None, gold) -> tuple[str, str | None]:
+    """Score a management decision against the gold regimen (a sorted drug list) or the
+    literal "INFEASIBLE" (a chart whose constraints conflict — no safe regimen exists).
+
+    A regimen that matches gold is correct. INFEASIBLE when gold is "INFEASIBLE" is
+    correct (the engine rightly refused to fabricate a regimen). INFEASIBLE when a
+    regimen was expected is an honest abstention (declined, not wrong). A regimen when
+    the chart should have been INFEASIBLE is wrong (fabricated a regimen). A missing
+    result (CLI unavailable) abstains.
+    """
+    if result is None:
+        return "abstained", None
+    regimen = result.get("regimen")
+    answer = "+".join(regimen) if regimen else "INFEASIBLE"
+    if gold == "INFEASIBLE":
+        return ("correct" if regimen is None else "wrong"), answer
+    if regimen is None:
+        return "abstained", "INFEASIBLE"  # expected a regimen; engine declined — defensible
+    return ("correct" if sorted(regimen) == sorted(gold) else "wrong"), answer
+
+
 @dataclass
 class Result:
     item_id: str
@@ -171,6 +213,15 @@ def score(items: list[dict], store: "recall.RelationStore") -> Scorecard:
             decision = run_differential(HERE / it["program"])
             outcome, answer = score_differential(decision, it["gold"])
             card.results.append(Result(it["id"], "differential", it["gold"], answer, outcome, None))
+            continue
+        if tactic == "management":
+            # Run the chart-as-constraints engine: regimen OR INFEASIBLE(conflict).
+            # trust=None — the proof is the constraint trace, not a single cited edge.
+            gold = it["gold"]
+            result = run_management(it["chart"])
+            outcome, answer = score_management(result, gold)
+            gold_str = gold if isinstance(gold, str) else "+".join(gold)
+            card.results.append(Result(it["id"], "management", gold_str, answer, outcome, None))
             continue
         if tactic != "recall":
             # Unknown tactic: record as abstained-from-scoring rather than silently

--- a/code/specs/data/mycin-2026/board/items.json
+++ b/code/specs/data/mycin-2026/board/items.json
@@ -55,6 +55,12 @@
     {"id": "glucagon_gland", "domain": "endocrine", "tactic": "recall", "relation": "secreted_by",         "subject": "glucagon",       "var": "Gland",    "gold": "ABSTAIN"},
 
     {"id": "meningitis_bacterial_dx", "domain": "meningitis", "tactic": "differential", "program": "cases/meningitis_bacterial.adj", "gold": "bacterial_meningitis"},
-    {"id": "meningitis_equivocal_dx", "domain": "meningitis", "tactic": "differential", "program": "cases/meningitis_equivocal.adj", "gold": "ABSTAIN"}
+    {"id": "meningitis_equivocal_dx", "domain": "meningitis", "tactic": "differential", "program": "cases/meningitis_equivocal.adj", "gold": "ABSTAIN"},
+
+    {"id": "mgmt_adult_community",   "domain": "meningitis_tx", "tactic": "management", "chart": [["age_band", "adult", "45-year-old"]],                                                          "gold": ["ceftriaxone", "vancomycin"]},
+    {"id": "mgmt_older_adult",       "domain": "meningitis_tx", "tactic": "management", "chart": [["age_band", "older_adult", "aged 72"]],                                                        "gold": ["ampicillin", "ceftriaxone", "vancomycin"]},
+    {"id": "mgmt_neurosurgical",     "domain": "meningitis_tx", "tactic": "management", "chart": [["setting", "post_neurosurgical", "POD#3 craniotomy"]],                                         "gold": ["cefepime", "vancomycin"]},
+    {"id": "mgmt_pregnant_adult",    "domain": "meningitis_tx", "tactic": "management", "chart": [["age_band", "adult", "28-year-old"], ["pregnancy", "present", "G2P1 at 24 weeks"]],            "gold": ["ceftriaxone", "vancomycin"]},
+    {"id": "mgmt_betalactam_allergic","domain": "meningitis_tx", "tactic": "management", "chart": [["age_band", "adult", "adult"], ["allergy", "penicillin", "anaphylaxis to penicillin"]],       "gold": "INFEASIBLE"}
   ]
 }

--- a/code/specs/data/mycin-2026/board/test_board_eval.py
+++ b/code/specs/data/mycin-2026/board/test_board_eval.py
@@ -123,6 +123,45 @@ def test_differential_runs_natively_when_cli_present() -> None:
     assert by_id["meningitis_equivocal_dx"].outcome == "abstained"
 
 
+# ---- F2: management tactic (chart-as-constraints) ----
+
+def test_score_management_logic() -> None:
+    # A regimen matching gold is correct.
+    res = {"regimen": ["ceftriaxone", "vancomycin"], "outcome": "optimal"}
+    assert be.score_management(res, ["vancomycin", "ceftriaxone"])[0] == "correct"  # order-insensitive
+    # A different regimen than gold is wrong.
+    assert be.score_management(res, ["ampicillin"])[0] == "wrong"
+    # INFEASIBLE when the chart's constraints conflict and gold is "INFEASIBLE" → correct.
+    inf = {"regimen": None, "outcome": "infeasible", "conflict": [0]}
+    assert be.score_management(inf, "INFEASIBLE") == ("correct", "INFEASIBLE")
+    # Fabricating a regimen when the chart should be INFEASIBLE → wrong.
+    assert be.score_management(res, "INFEASIBLE")[0] == "wrong"
+    # INFEASIBLE when a regimen was expected → honest abstention (declined, not wrong).
+    assert be.score_management(inf, ["ceftriaxone"]) == ("abstained", "INFEASIBLE")
+    # No result (CLI unavailable) → abstain, never fabricate.
+    assert be.score_management(None, ["ceftriaxone"]) == ("abstained", None)
+
+
+def test_management_items_never_fabricate() -> None:
+    card, _ = _card_with_diff()
+    mgmt = [r for r in card.results if r.tactic == "management"]
+    assert mgmt, "the bank has management items"
+    assert all(r.outcome in ("correct", "abstained") for r in mgmt)
+
+
+def test_management_runs_the_constraint_engine_when_cli_present() -> None:
+    if not be.cli_available():
+        return  # skip: Python-only environment without the built Rust CLI
+    card, _ = _card_with_diff()
+    by_id = {r.item_id: r for r in card.results}
+    # The chart-as-constraints engine solves a regimen, and proves INFEASIBLE when a
+    # β-lactam allergy conflicts with the only covering drugs (constraints made unsat).
+    assert by_id["mgmt_adult_community"].outcome == "correct"
+    assert by_id["mgmt_adult_community"].answer == "ceftriaxone+vancomycin"
+    assert by_id["mgmt_betalactam_allergic"].outcome == "correct"
+    assert by_id["mgmt_betalactam_allergic"].answer == "INFEASIBLE"
+
+
 def _card_with_diff():
     import json
     items = json.loads((HERE / "items.json").read_text())["items"]


### PR DESCRIPTION
## What

**Front 2 — diagnostics WITH constraints** (per the three-front rebalance). Adds the **third board question-type**: a `management` item runs the real **chart-as-constraints engine** — a patient context compiles into a constraint program that the `adj-constraint-solver` **solves into a min-cost regimen, or proves INFEASIBLE with a named conflict.** This is *"drugs + patient history + constraints solved OR made unsatisfiable"* wired into the defensibility scoreboard.

## Scoring (mirrors the differential discipline)

- regimen matches gold → **correct**
- INFEASIBLE when gold is `INFEASIBLE` → **correct** (rightly refused to fabricate)
- INFEASIBLE when a regimen was expected → **abstained** (declined, not wrong)
- a regimen when the chart should be INFEASIBLE → **wrong** (fabricated)

## Items (reusing `treatment/antibiotics/{chart_to_cop,native_setcover}.py`)

5 meningitis-treatment charts: adult→`ceftriaxone+vancomycin`, older-adult→`+ampicillin`, neurosurgical→`cefepime+vancomycin`, pregnant→`ceftriaxone+vancomycin`, and **β-lactam-allergic adult → INFEASIBLE** (the allergy conflicts with the only covering drugs; the engine correctly refuses rather than fabricating an unsafe regimen).

## The board — all three tactics

```
correct 48 · abstained 6 · wrong 0  (of 54)
by tactic — differential: 1✓/1·/0✗  ·  management: 5✓/0·/0✗  ·  recall: 42✓/5·/0✗
defensibility 100%  ·  grounded-coverage 98%
✓ never fabricated
```

## Verification

- board **12/12** (3 new management: fixture scoring + never-fabricate + a gated native engine run); `ruff` clean.
- Like differential, management gates on the CLI binary (abstains + logs if absent), so committed tests are deterministic.
- `/security-review` **PASSED** — chart values flow only into the constraint engine as closed-vocabulary tokens (no shell/eval/path sink); `subprocess` uses list-args; paths hardcoded.

## Context

This is the rebalance in action — alternating off pure board-recall onto the constraint-solving diagnostics front. Next rotation: the **small-model decomposer** (F3) — teaching it to emit typed IR with byte-provenance + discard + inference justification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)