### PR TITLE
feat(visicalc-compose): scrollable infinite-sheet GUI on the viewport primitive

### DIFF
--- a/demo/visicalc-compose/README.md
+++ b/demo/visicalc-compose/README.md
@@ -63,11 +63,42 @@ rectangle of an unbounded sheet (the Compose sibling of the web/SwiftUI/Qt/
 Flutter infinite views). The window JSON is nested, so it's parsed by a tiny
 in-file JSON reader rather than `display()`'s per-value regex.
 
+### The scrollable infinite GUI (`InfiniteSheet.kt`)
+
+The **Infinite sheet** button in the running app toggles from the classic 5×5
+grid to `InfiniteSheet` — a virtualized, effectively-infinite (u32 × u32,
+sparse) sheet rendered on the same engine. The body is a `LazyColumn`, which
+natively virtualizes: it composes a row item only while it's near the viewport
+and recycles it on scroll, so a 1000-row sheet costs the handful of rows you can
+see. Each composed row makes **one** engine `get_window` over its `1×totalCols`
+strip (`InfiniteSheetModel.rowCells`) — per-frame engine work is proportional to
+*visible* rows, never the sheet's height.
+
+Frozen chrome without a second scroller: the row-number gutter rides as each
+`LazyColumn` row's first child, *outside* the horizontal scroll, so it stays
+pinned left and scrolls vertically with the body for free; every row and the
+column-letter header share one horizontal `ScrollState`, so dragging any row
+pans them all in lockstep (the header is gesture-disabled — it only follows).
+Tap a cell → `selectInf(row,col)` (clamps, loads the source into the formula
+bar); press Enter → `commitInf(text)` (writes through, recomputes dependents,
+regrows the extent). `InfiniteSheetModel` (in `Engine.kt`) seeds far-flung
+sparse cells (`Z1000`, `BA50`, `BB50`) and derives the extent from `usedRange()`
++ a margin.
+
+### Verification
+
 Headless proof: `scripts/verify.sh` (kotlinc + FFM) seeds far-flung sparse cells
 and asserts the window is engine-computed + dense (A1=15, E1=38, E5=169), a
 formula 1000 rows down (`Z1000` = 39) is reachable, the gaps are empty (sparse),
 column letters run AA/BA, and editing `A1` dirties the far dependent `Z1000` via
-`changedSince`.
+`changedSince`. It also drives `InfiniteSheetModel` directly: `rowCells`
+one-read rows, `selectInf` clamping + source load, and `commitInf` recompute
+(A2 `8`→`108` ⇒ E2 151, A5 139, E5 269).
+
+The Compose UI itself (`InfiniteSheet.kt` + the `Main.kt` toggle) is verified to
+compile against the real Compose Desktop APIs via `gradle compileKotlin`; the
+engine-backed logic it drives is the headlessly-proven model above. (A live GUI
+needs a Compose Desktop window — `gradle run`.)
 
 ## Why "Compose for Desktop" rather than Jetpack Compose for Android?
 
@@ -96,7 +127,8 @@ demo/visicalc-compose/
 ├── test/
 │   └── EngineSmoke.kt            ← asserts the grid is engine-computed + recomputes
 └── src/main/kotlin/
-    ├── Main.kt                   ← `application { Window { ... } }`, binds the engine model
-    ├── Engine.kt                 ← Java FFM bindings + SpreadsheetModel
+    ├── Main.kt                   ← `application { Window { ... } }`; classic grid + infinite toggle
+    ├── InfiniteSheet.kt          ← virtualized infinite-sheet composable (LazyColumn over the viewport)
+    ├── Engine.kt                 ← Java FFM bindings + SpreadsheetModel + InfiniteSheetModel
     └── generated/                ← FormulaBar.kt + Grid.kt (mosaic-compile output)
 ```

--- a/demo/visicalc-compose/src/main/kotlin/Engine.kt
+++ b/demo/visicalc-compose/src/main/kotlin/Engine.kt
@@ -223,6 +223,114 @@ class SpreadsheetModel(
     }
 }
 
+/// Engine-backed model for the VIRTUALIZED infinite sheet — the Kotlin sibling
+/// of the SwiftUI `WindowedSheetModel`, the Qt `SpreadsheetModel` infinite-view
+/// state, and the Flutter `InfiniteSheetModel`. It seeds a deliberately
+/// far-flung, sparse dataset and exposes one-row windowed reads plus the data
+/// extent, so a `LazyColumn`-virtualized Compose grid can render only the
+/// visible rectangle of an effectively-unbounded (u32 × u32) sheet.
+///
+/// Plain Kotlin (no Compose types): the host `@Composable` mutates it and bumps
+/// a `revision` state to recompose, exactly as `Main.kt` drives [SpreadsheetModel].
+/// All coordinates here are 1-based (row/col ≥ 1, col 1 = "A"), matching the engine.
+class InfiniteSheetModel(
+    private val session: SpreadsheetSession = SpreadsheetSession(),
+) : AutoCloseable {
+
+    /// The virtual grid size, derived from the data extent plus a margin so you
+    /// can scroll past the data into blank space.
+    var totalRows: Int = 1000
+        private set
+    var totalCols: Int = 60
+        private set
+
+    /// The selected cell (1-based) and the formula-bar text (its raw source).
+    var selRow: Int = 1
+        private set
+    var selCol: Int = 1
+        private set
+    var formula: String = ""
+        private set
+
+    init {
+        seed()
+        computeExtent()
+        selectInf(1, 1) // prime the selection + formula bar at A1
+    }
+
+    /// The classic cross-footing budget PLUS far-flung cells (a formula at
+    /// `Z1000`, a couple near `BA50`/`BB50`) to prove the sheet is sparse and
+    /// unbounded — identical seed to the SwiftUI/Qt/Flutter infinite views.
+    private fun seed() {
+        val cells = listOf(
+            "A1" to "15", "B1" to "3", "C1" to "12", "D1" to "8", "E1" to "=SUM(A1:D1)",
+            "A2" to "8", "B2" to "14", "C2" to "7", "D2" to "22", "E2" to "=SUM(A2:D2)",
+            "A3" to "12", "B3" to "9", "C3" to "18", "D3" to "6", "E3" to "=SUM(A3:D3)",
+            "A4" to "4", "B4" to "11", "C4" to "3", "D4" to "17", "E4" to "=SUM(A4:D4)",
+            "A5" to "=SUM(A1:A4)", "B5" to "=SUM(B1:B4)", "C5" to "=SUM(C1:C4)",
+            "D5" to "=SUM(D1:D4)", "E5" to "=SUM(E1:E4)",
+            "Z1000" to "=SUM(A1:A4)", // 1000 rows down: 39
+            "BA50" to "far cell", "BB50" to "=Z1000*2", // col 53/54, row 50: 78
+        )
+        for ((a1, raw) in cells) session.setCell(a1, raw)
+    }
+
+    /// Re-derive the virtual grid size from the engine's data extent plus a
+    /// comfortable margin. Mirrors `WindowedSheetModel.resize()`.
+    ///
+    /// The `+ margin` is done in `Long` and saturated back into `Int` before use:
+    /// the engine is u32-backed, so a `maxRow`/`maxCol` near `Int.MAX_VALUE`
+    /// would otherwise overflow the 32-bit add to a negative size — which would
+    /// feed `LazyColumn(items(...))` a negative count and invert the `coerceIn`
+    /// range. Not reachable in this demo (the only far cell is the fixed Z1000),
+    /// but the saturation makes the model safe against any sheet, per the
+    /// recorded "u32-overflow-defeats-cap" lesson.
+    fun computeExtent() {
+        val u = session.usedRange()
+        totalRows = saturate((u?.get("maxRow") ?: 1).toLong() + 200, floor = 1000)
+        totalCols = saturate((u?.get("maxCol") ?: 1).toLong() + 30, floor = 60)
+    }
+
+    /// Clamp a widened (`Long`) extent into a sane positive `Int`: at least
+    /// [floor], at most [Int.MAX_VALUE].
+    private fun saturate(value: Long, floor: Int): Int =
+        value.coerceIn(floor.toLong(), Int.MAX_VALUE.toLong()).toInt()
+
+    /// Column letters for a 1-based index (1 -> "A", 27 -> "AA").
+    fun columnLetters(index: Int): String = session.columnLetters(index)
+
+    /// The A1 address of the selected cell (e.g. "Z1000").
+    fun infAddress(): String = "${session.columnLetters(selCol)}$selRow"
+
+    /// One row's display strings (columns 1..totalCols) — what a virtualized
+    /// `LazyColumn` item renders. A single engine `get_window` over a 1×N strip;
+    /// returns an empty list if the request was rejected/oversized.
+    fun rowCells(row: Int): List<String> {
+        if (row < 1) return emptyList()
+        val w = session.window(row, 1, row, totalCols)
+        return if (w.isEmpty()) emptyList() else w[0]
+    }
+
+    /// Move the selection (clamped to the virtual grid; row/col ≥ 1) and pull the
+    /// selected cell's raw source into the formula bar.
+    fun selectInf(row: Int, col: Int) {
+        selRow = row.coerceIn(1, totalRows)
+        selCol = col.coerceIn(1, totalCols)
+        formula = session.getRaw(infAddress())
+    }
+
+    /// Commit the formula bar into the selected cell: write through to the engine
+    /// (which recomputes every dependent), grow the extent if the edit reached new
+    /// ground, and re-read the canonicalised source back into the bar.
+    fun commitInf(raw: String) {
+        session.setCell(infAddress(), raw)
+        computeExtent()
+        formula = session.getRaw(infAddress())
+    }
+
+    override fun close() = session.close()
+}
+
 // ─────────────────────────────────────────────────────────────────────
 // A small JSON reader, just enough for the engine's output (objects,
 // arrays, strings, numbers, true/false/null). The window read is nested

--- a/demo/visicalc-compose/src/main/kotlin/InfiniteSheet.kt
+++ b/demo/visicalc-compose/src/main/kotlin/InfiniteSheet.kt
@@ -1,0 +1,206 @@
+// InfiniteSheet.kt — a virtualized, effectively-infinite spreadsheet view for
+// the Compose Desktop demo, rendered on the shared Rust engine through the
+// viewport primitive (the same get_window / used_range / changed_since the
+// SwiftUI InfiniteGridView, the Qt InfiniteSheet.qml, and the Flutter
+// InfiniteGrid drive).
+//
+// The sheet is u32 × u32 and sparse; only the cells in the VISIBLE rows are ever
+// composed. The body is a `LazyColumn`, which natively virtualizes — it composes
+// a row item only while it's near the viewport and recycles it as it scrolls
+// off. So a 1000-row-tall sheet costs the handful of rows you can see, and each
+// composed row makes ONE engine `get_window` over its 1×totalCols strip
+// (InfiniteSheetModel.rowCells). Per-frame engine work is proportional to
+// *visible* rows, never to the sheet's height.
+//
+// Frozen chrome without a second scroller: the row-number gutter rides as each
+// LazyColumn row's first child, OUTSIDE the horizontal scroll, so it stays
+// pinned on the left and scrolls vertically with the body for free. Every row
+// and the column-letter header share ONE horizontal `ScrollState`, so dragging
+// any row pans them all in lockstep (the header is gesture-disabled — it only
+// follows). Vertical drags fall through the per-row horizontalScroll to the
+// LazyColumn.
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+// Cell geometry + palette, matching the sibling infinite views.
+private val ROW_H = 24.dp
+private val COL_W = 90.dp
+private val GUTTER_W = 64.dp
+private val HEAD_H = 26.dp
+
+private val BG = Color(0xFF1E1E1E)
+private val CHROME = Color(0xFF2D2D30)
+private val BORDER = Color(0xFF3F3F46)
+private val INK = Color(0xFFCCCCCC)
+private val DIM = Color(0xFF9D9D9D)
+private val SEL = Color(0xFF094771)
+private val MONO = FontFamily.Monospace
+
+/// The virtualized infinite-sheet view. Owns its [InfiniteSheetModel] and the
+/// single horizontal scroll state shared by the header and every body row.
+@Composable
+fun InfiniteSheet() {
+    val model = remember { InfiniteSheetModel() }
+    DisposableEffect(Unit) { onDispose { model.close() } }
+
+    // The body scrolls horizontally; the header follows the same state.
+    val hScroll = rememberScrollState()
+
+    // Compose state that mirrors the model, so edits/selections recompose.
+    // `rev` is bumped on commit to force visible rows to re-read rowCells.
+    var selRow by remember { mutableStateOf(model.selRow) }
+    var selCol by remember { mutableStateOf(model.selCol) }
+    var formula by remember { mutableStateOf(model.formula) }
+    var rev by remember { mutableStateOf(0) }
+
+    fun select(row: Int, col: Int) {
+        model.selectInf(row, col)
+        selRow = model.selRow
+        selCol = model.selCol
+        formula = model.formula
+    }
+
+    fun commit() {
+        model.commitInf(formula)
+        formula = model.formula
+        rev++
+    }
+
+    Column(modifier = Modifier.fillMaxSize().padding(8.dp)) {
+        // ── Formula bar: the selected cell's address + an editable source ──
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Text(model.infAddress(), DIM, GUTTER_W)
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(28.dp)
+                    .background(CHROME)
+                    .border(1.dp, BORDER)
+                    .padding(horizontal = 6.dp),
+                contentAlignment = Alignment.CenterStart,
+            ) {
+                BasicTextField(
+                    value = formula,
+                    onValueChange = { formula = it },
+                    singleLine = true,
+                    textStyle = TextStyle(color = INK, fontSize = 13.sp, fontFamily = MONO),
+                    cursorBrush = androidx.compose.ui.graphics.SolidColor(INK),
+                    keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
+                    keyboardActions = KeyboardActions(onDone = { commit() }),
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            }
+        }
+
+        Spacer(Modifier.height(6.dp))
+
+        // ── Column-letter header (frozen vertically, follows horizontal pan) ──
+        Row {
+            chromeCell(GUTTER_W, HEAD_H, "") // corner
+            Box(modifier = Modifier.horizontalScroll(hScroll, enabled = false)) {
+                Row {
+                    for (c in 1..model.totalCols) {
+                        chromeCell(COL_W, HEAD_H, model.columnLetters(c))
+                    }
+                }
+            }
+        }
+
+        // ── Body: virtualized rows, each with a frozen gutter + scrolling cells ──
+        LazyColumn(modifier = Modifier.fillMaxSize()) {
+            items(model.totalRows) { idx ->
+                val rowNum = idx + 1
+                // One engine read for the whole row; re-read when `rev` changes.
+                val cells = remember(rowNum, rev) { model.rowCells(rowNum) }
+                Row {
+                    chromeCell(GUTTER_W, ROW_H, "$rowNum") // gutter — frozen left
+                    Box(modifier = Modifier.horizontalScroll(hScroll)) {
+                        Row {
+                            for (c in 1..model.totalCols) {
+                                val text = if (c - 1 < cells.size) cells[c - 1] else ""
+                                val selected = selRow == rowNum && selCol == c
+                                dataCell(text, selected) { select(rowNum, c) }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// A right-aligned, tappable data cell.
+@Composable
+private fun dataCell(text: String, selected: Boolean, onTap: () -> Unit) {
+    Box(
+        modifier = Modifier
+            .size(COL_W, ROW_H)
+            .background(if (selected) SEL else BG)
+            .border(0.5.dp, BORDER)
+            .clickable(onClick = onTap)
+            .padding(end = 4.dp),
+        contentAlignment = Alignment.CenterEnd,
+    ) {
+        androidx.compose.material.Text(
+            text = text,
+            color = INK,
+            fontSize = 12.sp,
+            fontFamily = MONO,
+            maxLines = 1,
+            textAlign = TextAlign.End,
+        )
+    }
+}
+
+/// A frozen header/gutter cell (column letter, row number, or the corner).
+@Composable
+private fun chromeCell(w: androidx.compose.ui.unit.Dp, h: androidx.compose.ui.unit.Dp, text: String) {
+    Box(
+        modifier = Modifier.size(w, h).background(CHROME).border(0.5.dp, BORDER),
+        contentAlignment = Alignment.Center,
+    ) {
+        androidx.compose.material.Text(text, color = DIM, fontSize = 12.sp, fontFamily = MONO)
+    }
+}
+
+/// The formula-bar address label (fixed width).
+@Composable
+private fun Text(text: String, color: Color, width: androidx.compose.ui.unit.Dp) {
+    Box(modifier = Modifier.width(width)) {
+        androidx.compose.material.Text(text, color = color, fontSize = 12.sp, fontFamily = MONO)
+    }
+}

--- a/demo/visicalc-compose/src/main/kotlin/Main.kt
+++ b/demo/visicalc-compose/src/main/kotlin/Main.kt
@@ -28,10 +28,13 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.Row
+import androidx.compose.material.Button
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Surface
 import androidx.compose.material.Text
 import androidx.compose.material.darkColors
+import androidx.compose.ui.Alignment
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -98,15 +101,36 @@ private fun VisiCalcApp() {
     // Start showing the selected cell's source (A1 → "15") in the bar.
     var formulaText by remember { mutableStateOf(model.rawAt(0, 1)) }
 
+    // Which view is showing: the classic 5×5 cross-foot budget (the generated
+    // Grid), or the virtualized infinite sheet (InfiniteSheet, rendered on the
+    // same engine via the viewport primitive).
+    var infinite by remember { mutableStateOf(false) }
+
     Column(modifier = Modifier.fillMaxSize().padding(16.dp)) {
-        // Title row — kebab-cased label up top, matching the
-        // sibling demos' "VISICALC · MOSAIC <BACKEND> DEMO" style.
-        Text(
-            text = "VISICALC · MOSAIC COMPOSE DEMO",
-            color = Color(0xFF9D9D9D),
-            fontSize = 11.sp,
-            fontFamily = FontFamily.Monospace,
-        )
+        // Title row + view toggle — kebab-cased label, matching the sibling
+        // demos' "VISICALC · MOSAIC <BACKEND> DEMO" style.
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Text(
+                text = if (infinite)
+                    "VISICALC · INFINITE SHEET · RUST ENGINE"
+                else
+                    "VISICALC · MOSAIC COMPOSE DEMO",
+                color = Color(0xFF9D9D9D),
+                fontSize = 11.sp,
+                fontFamily = FontFamily.Monospace,
+                modifier = Modifier.weight(1f),
+            )
+            Button(onClick = { infinite = !infinite }) {
+                Text(if (infinite) "Classic grid" else "Infinite sheet")
+            }
+        }
+
+        // The infinite view owns its own model + chrome, so it replaces the
+        // whole classic stack (formula bar + grid) when toggled on.
+        if (infinite) {
+            InfiniteSheet()
+            return@Column
+        }
 
         Box(modifier = Modifier.padding(top = 8.dp)) {
             FormulaBar(

--- a/demo/visicalc-compose/test/EngineSmoke.kt
+++ b/demo/visicalc-compose/test/EngineSmoke.kt
@@ -91,6 +91,41 @@ fun main() {
     check("window Z1000 after edit", s.window(1000, 26, 1000, 26)[0][0], "139")
     s.close()
 
+    // ── Infinite-view binding layer (InfiniteSheetModel) ─────────────
+    // The model InfiniteSheet.kt drives: one engine read per visible row via
+    // rowCells, tap-to-select via selectInf (loading the cell's source into the
+    // formula bar), and write-through via commitInf (recompute + regrow extent).
+    val inf = InfiniteSheetModel()
+    // The constructor seeds the budget PLUS far-flung cells (Z1000, BA50/BB50)
+    // and computes the extent: at least 1000×60, grown to reach the far cells.
+    check("inf totalRows >= 1000", (inf.totalRows >= 1000).toString(), "true")
+    check("inf totalCols >= 60", (inf.totalCols >= 60).toString(), "true")
+
+    // rowCells returns one row's display strings (columns 1..totalCols).
+    val row1 = inf.rowCells(1)
+    check("inf rowCells width", (row1.size == inf.totalCols).toString(), "true")
+    check("inf rowCells A1", row1[0], "15")
+    check("inf rowCells E1", row1[4], "38")  // SUM(A1:D1)
+    check("inf rowCells J1 empty", row1[9], "") // sparse
+    check("inf gap row blank", inf.rowCells(200).all { it.isEmpty() }.toString(), "true")
+
+    // selectInf loads the cell SOURCE (A5 is a formula) and clamps to the grid.
+    inf.selectInf(5, 1)
+    check("inf select A5 addr", inf.infAddress(), "A5")
+    check("inf select A5 formula", inf.formula, "=SUM(A1:A4)")
+    inf.selectInf(-3, 0) // clamps to (1,1)
+    check("inf clamp row", inf.selRow.toString(), "1")
+    check("inf clamp col", inf.selCol.toString(), "1")
+
+    // commitInf writes through and recomputes every dependent.
+    inf.selectInf(2, 1)          // A2
+    inf.commitInf("108")         // 8 -> 108
+    check("inf commit A2", inf.rowCells(2)[0], "108")
+    check("inf commit E2", inf.rowCells(2)[4], "151") // 108+14+7+22
+    check("inf commit A5", inf.rowCells(5)[0], "139") // 15+108+12+4
+    check("inf commit E5", inf.rowCells(5)[4], "269") // grand total
+    inf.close()
+
     println(if (failures == 0) "\nALL PASS" else "\n$failures FAILURE(S)")
     kotlin.system.exitProcess(if (failures == 0) 0 else 1)
 }


### PR DESCRIPTION
## What

Adds **`InfiniteSheet`** (`src/main/kotlin/InfiniteSheet.kt`) — a virtualized, effectively-infinite (u32×u32, sparse) spreadsheet view for the Compose Desktop demo, rendered on the same shared Rust engine through the viewport primitive (`sc_get_window` / `sc_used_range` / `sc_changed_since` over Java FFM). The Compose sibling of the SwiftUI `InfiniteGridView`, the Qt `InfiniteSheet.qml`, and the Flutter `InfiniteGrid`. A toolbar toggle in `Main.kt` switches between the classic 5×5 cross-foot budget and the infinite view.

**Item 4 of the cross-backend infinite-GUI sequence** (SwiftUI #5868 → Qt #5911 → Flutter #5920 → Compose here → XAML).

## How it virtualizes

- The body is a `LazyColumn` — composes a row item only while near the viewport, recycled on scroll, so a 1000-row sheet costs the handful of visible rows.
- Each composed row makes **one** engine `get_window` over its `1×totalCols` strip (`InfiniteSheetModel.rowCells`) — per-frame engine work is proportional to *visible* rows, not sheet height.
- Frozen chrome **without a second scroller**: the row-number gutter rides as each `LazyColumn` row's first child, *outside* the horizontal scroll (pinned left, scrolls vertically with the body for free); every row + the column-letter header share one horizontal `ScrollState`, so dragging any row pans them all in lockstep (the header is gesture-disabled — it only follows).
- Tap a cell → `selectInf(row,col)` (clamps, loads source into the formula bar). Enter → `commitInf(text)` (writes through, recomputes dependents, regrows the extent).

`InfiniteSheetModel` (in `Engine.kt`, plain Kotlin — mutated by the `@Composable` which bumps a `revision` state to recompose) seeds far-flung sparse cells (`Z1000`, `BA50`, `BB50`) and derives the extent from `usedRange()` + a margin (saturated in `Long` then clamped to `Int`, guarding the documented u32-overflow case).

## Verified

- **Headless** (`scripts/verify.sh`, kotlinc + FFM, no Compose): `EngineSmoke.kt` gains an `InfiniteSheetModel` block — extent growth, `rowCells` one-read dense-then-sparse rows, `selectInf` source-load + clamping, `commitInf` recompute (A2 `8`→`108` ⇒ E2 151, A5 139, E5 269). **ALL PASS** through the real Kotlin→FFM→Rust path.
- The Compose UI itself (`InfiniteSheet.kt` + `Main.kt` toggle) **compiles against the real Compose Desktop APIs** (`gradle compileKotlin --offline`: BUILD SUCCESSFUL; the compile caught a wrong `RowScope.weight` import along the way). A live GUI needs a Compose Desktop window (`gradle run`), which launches here, but a bare `gradle`-spawned JVM has no app bundle for computer-use to drive.

## Security

`/security-review` passed — verified FFM string ownership (confined-Arena allocations auto-freed, `sc_string_free` once, NULL handled), `selectInf`'s `coerceIn(1, total)` + `rowCells` guard can't bypass the engine's zero-origin / `MAX_WINDOW_CELLS` guards, real `LazyColumn` virtualization (no unbounded composition), and no injection (raw formula text is the engine's to parse). The one INFO note (theoretical `Int` overflow in `computeExtent`) was hardened with `Long` saturation in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)