### PR TITLE
feat(mycin): REL-14 — decomposer gold IR gains byte-provenance, discard, inference justification

### DIFF
--- a/code/specs/data/mycin-2026/train/README.md
+++ b/code/specs/data/mycin-2026/train/README.md
@@ -26,6 +26,29 @@ language, never the ground truth. The mix deliberately includes bacterial / vira
 / mixed profiles, negations, and **ABSTAIN** cases (prose with no dictionary
 findings → empty IR) so the model learns to decline rather than hallucinate.
 
+### The gold IR carries byte-provenance, discard, and inference justification
+
+The label is not a bare finding list — it is the full typed IR the warm pipeline's
+prompt asks for, derived **deterministically from the teacher's prose** by
+`build_gold_ir()` (pure, no model — so it is unit-tested without Ollama):
+
+- **byte-provenance** — each finding records the verbatim `span` of prose that
+  supports it (located by matching the finding's dictionary surface forms against
+  the vignette). A finding stated verbatim → `type: stated`; one the teacher
+  paraphrased past recognition → `type: inferred` with an empty span.
+- **inference justification** — each finding gets an `ENTAILED` verdict when its
+  span was found verbatim, or `LEAP` when it was not (which `ir_to_adj` then drops —
+  the safe behavior: the model is taught to mark, not fabricate, unstated findings).
+- **discard** — a third of vignettes carry an injected non-diagnostic **distractor**
+  (a vital sign, social-history detail, symptomatic med). When it lands in the
+  prose, the gold records it as a `discard` `{span, reason}`, teaching the model to
+  set a red herring aside *with a justification* rather than coin a finding from it.
+
+So the model learns the discipline the framework demands of itself: extract only
+what the bytes support, cite the span, and justify both what it keeps and what it
+discards. The gold finding still keeps `functor`/`value`/`polarity` (what the
+rulebook consumes), so the addition is non-breaking downstream.
+
 ## Workflow
 
 ```sh

--- a/code/specs/data/mycin-2026/train/gen_data.py
+++ b/code/specs/data/mycin-2026/train/gen_data.py
@@ -71,11 +71,20 @@ ORGANISM_ID = [
 ]
 
 
-def teacher_vignette(teacher: str, findings: list[dict], surfaces: dict) -> str:
+def teacher_vignette(teacher: str, findings: list[dict], surfaces: dict,
+                     distractors: list[tuple[str, str]] | None = None) -> str:
+    distractors = distractors or []
+    distractor_ask = ""
+    if distractors:
+        # Ask the teacher to weave in the incidental detail(s) verbatim-ish, so the
+        # gold `discard` span can be located in the prose (teaches set-aside w/ reason).
+        ds = "; ".join(f'"{p}"' for p, _ in distractors)
+        distractor_ask = (f" Also include, verbatim or nearly so, this incidental "
+                          f"non-diagnostic detail: {ds}.")
     if not findings:
         ask = ("Write a realistic 1-2 sentence clinical vignette of a patient being "
                "evaluated for headache/meningitis that states NO specific CSF lab "
-               "findings (e.g. only chief complaint / demographics, labs pending).")
+               "findings (e.g. only chief complaint / demographics, labs pending)." + distractor_ask)
     else:
         lines = []
         for f in findings:
@@ -88,7 +97,8 @@ def teacher_vignette(teacher: str, findings: list[dict], surfaces: dict) -> str:
         ask = ("Write a realistic 2-4 sentence clinical vignette for a meningitis workup "
                "that states EXACTLY these findings and no other CSF lab findings. Vary the "
                "wording naturally; you may add ONE non-diagnostic sentence (age, chief "
-               "complaint). Do NOT name a diagnosis.\n\nFINDINGS:\n" + "\n".join(lines))
+               "complaint). Do NOT name a diagnosis." + distractor_ask
+               + "\n\nFINDINGS:\n" + "\n".join(lines))
     body = json.dumps({"model": teacher, "prompt": ask, "stream": False,
                        "options": {"temperature": 0.7, "num_predict": 220}}).encode()
     req = urllib.request.Request(OLLAMA, data=body, headers={"Content-Type": "application/json"})
@@ -134,6 +144,91 @@ def sample_findings(rng: random.Random) -> list[dict]:
     return findings
 
 
+# Non-diagnostic DISTRACTORS — incidental details a vignette may carry that look
+# informative but map to NO controlled-vocabulary finding. We ask the teacher to
+# include one, then record it in the gold `discard` (span + reason) so the model learns
+# to set it aside with a justification rather than hallucinate a finding from it.
+DISTRACTORS = [
+    ("blood pressure 128/82 mmHg", "vital sign, not a meningitis CSF/host finding"),
+    ("works as a high-school teacher", "social history, not a controlled-vocabulary finding"),
+    ("took acetaminophen for the headache", "symptomatic medication, not a diagnostic finding"),
+    ("no known drug allergies", "negative allergy history, not a meningitis finding"),
+    ("drove himself to the emergency department", "logistical detail, not a clinical finding"),
+    ("last ate breakfast around 8 a.m.", "incidental history, not a diagnostic finding"),
+]
+
+
+def _norm(s: str) -> str:
+    """Lowercase + collapse whitespace — for substring matching prose against a phrase
+    (mirrors the framework's verify_citation normalization)."""
+    return " ".join(s.lower().split())
+
+
+def find_span(vignette: str, phrases: list[str]) -> str:
+    """Return the VERBATIM substring of `vignette` (original case) that supports a
+    finding — the first of `phrases` (surface forms / hint / its `/`-split or word
+    fragments) that appears in the vignette, normalized. "" if none does. This is the
+    byte-provenance: a finding's span must be an actual slice of the source prose."""
+    nv = _norm(vignette)
+    cands: list[str] = []
+    for p in phrases:
+        if not p:
+            continue
+        cands.append(p)
+        cands.extend(part.strip() for part in p.split("/"))           # "a / b" alternatives
+    vl = vignette.lower()
+    # longest first — prefer the most specific phrase that still matches.
+    for cand in sorted({c for c in cands if len(c) >= 4}, key=len, reverse=True):
+        nc = _norm(cand)
+        if nc not in nv:
+            continue
+        # Map the normalized hit back to a TIGHT original-case slice: anchor on the
+        # first word, then extend to the end of the last word (handles whitespace that
+        # normalization collapsed, without swallowing trailing punctuation/text).
+        words = nc.split()
+        lo = vl.find(words[0])
+        if lo == -1:
+            continue
+        end = vl.find(words[-1], lo) + len(words[-1])
+        if end <= lo:
+            continue
+        return vignette[lo:end]
+    return ""
+
+
+def build_gold_ir(vignette: str, findings: list[dict], distractors: list[tuple[str, str]],
+                  surfaces: dict) -> dict:
+    """Construct the gold IR with BYTE PROVENANCE + DISCARD + INFERENCE justification.
+
+    For each sampled finding, locate its supporting span in the prose: a verbatim span
+    → `type:"stated"` + an ENTAILED inference justification; no verbatim span (teacher
+    paraphrased past recognition) → `type:"inferred"` + a LEAP justification (which
+    ir_to_adj then drops — the safe behavior). Each distractor that appears in the prose
+    becomes a `discard` {span, reason}. The gold finding keeps functor/value/polarity
+    (what the rulebook consumes) AND adds term/span/type (the provenance the prompt asks
+    for) — additive, so downstream ir_to_adj is unaffected."""
+    gold_findings, inferences = [], []
+    for f in findings:
+        functor, value = f["functor"], f["value"]
+        phrases = [f.get("hint")] + list(surfaces.get(functor, [])) + [value.replace("_", " ")]
+        span = find_span(vignette, phrases)
+        denied = f.get("polarity") == "denied"
+        ftype = "stated" if span else "inferred"
+        term = f"{functor}({value})"
+        gold_findings.append({"functor": functor, "value": value, "term": term,
+                              "span": span, "type": ftype,
+                              "polarity": "denied" if denied else "affirmed"})
+        inferences.append({"term": term, "basis_span": span,
+                           "verdict": "ENTAILED" if span else "LEAP"})
+    discard = []
+    for phrase, reason in distractors:
+        dspan = find_span(vignette, [phrase])
+        if dspan:
+            discard.append({"span": dspan, "reason": reason})
+    return {"findings": gold_findings, "discard": discard,
+            "inference_justifications": inferences}
+
+
 def main() -> int:
     ap = argparse.ArgumentParser()
     ap.add_argument("--n", type=int, default=300)
@@ -148,19 +243,22 @@ def main() -> int:
     records = []
     for i in range(args.n):
         findings = sample_findings(rng)
+        # Inject 0-2 non-diagnostic distractors so a third of vignettes carry a red
+        # herring the gold must DISCARD (with a reason) rather than turn into a finding.
+        distractors = rng.sample(DISTRACTORS, rng.choice([0, 0, 1, 1, 2]))
         try:
-            vignette = teacher_vignette(args.teacher, findings, surfaces)
+            vignette = teacher_vignette(args.teacher, findings, surfaces, distractors)
         except Exception as e:  # noqa: BLE001
             print(f"  [{i}] teacher error: {e}", file=sys.stderr)
             continue
         if not vignette or len(vignette) < 20:
             continue
         user = decompose_mod.prompt_for(vignette, d)
-        # The gold IR carries only the typed fields — the generation-time `hint` (used to
-        # steer the teacher's phrasing) must NOT leak into the label the model learns.
-        gold_findings = [{"functor": f["functor"], "value": f["value"], "polarity": f["polarity"]}
-                         for f in findings]
-        gold = {"findings": gold_findings, "discard": [], "inference_justifications": []}
+        # The gold IR is derived from the prose with BYTE PROVENANCE: build_gold_ir locates
+        # each finding's supporting span (ENTAILED) or marks it inferred/LEAP, and records
+        # any distractor that landed in the prose as a justified discard. The generation-time
+        # `hint` steers the teacher's phrasing but never leaks into the label.
+        gold = build_gold_ir(vignette, findings, distractors, surfaces)
         records.append({"messages": [{"role": "user", "content": user},
                                      {"role": "assistant", "content": json.dumps(gold)}]})
         if (i + 1) % 25 == 0:

--- a/code/specs/data/mycin-2026/train/test_gen_data.py
+++ b/code/specs/data/mycin-2026/train/test_gen_data.py
@@ -61,11 +61,87 @@ def test_sampled_findings_stay_in_vocab_and_hints_do_not_leak():
     assert saw_organism_id, "organism-id findings never sampled across 60 seeds"
 
 
+# ---- F3: byte-provenance + discard + inference justification in the gold IR ----
+
+def test_find_span_returns_a_verbatim_slice_or_empty():
+    v = "A 19-year-old presents with neutrophil-predominant pleocytosis and a low CSF glucose."
+    # A surface form that appears (case-insensitively) → a real substring of the prose.
+    span = gd.find_span(v, ["neutrophil-predominant pleocytosis"])
+    assert span and span.lower() in v.lower(), span
+    # A `/`-alternative phrase: either side may match.
+    assert gd.find_span(v, ["PMN predominance / neutrophil-predominant pleocytosis"])
+    # Nothing matches → empty string (no fabricated span).
+    assert gd.find_span(v, ["enteroviral pcr positive"]) == ""
+    assert gd.find_span(v, [None, ""]) == ""
+
+
+def test_build_gold_ir_grounds_stated_findings_with_an_entailed_span():
+    surfaces = {"csf_glucose": ["low CSF glucose", "hypoglycorrhachia"],
+                "csf_neutrophilic_pleocytosis": ["neutrophil-predominant pleocytosis"]}
+    vignette = ("A 19-year-old with neutrophil-predominant pleocytosis and a low CSF "
+                "glucose; he works as a high-school teacher.")
+    findings = [{"functor": "csf_neutrophilic_pleocytosis", "value": "high", "polarity": "stated"},
+                {"functor": "csf_glucose", "value": "low", "polarity": "stated"}]
+    distractors = [("works as a high-school teacher", "social history, not a finding")]
+    gold = gd.build_gold_ir(vignette, findings, distractors, surfaces)
+    # Every finding keeps functor/value/polarity AND gains term/span/type (additive).
+    for f in gold["findings"]:
+        for k in ("functor", "value", "polarity", "term", "span", "type"):
+            assert k in f, f"missing {k} in {f}"
+    # Both findings are stated verbatim → spans are real substrings, type stated, ENTAILED.
+    assert all(f["span"] and f["span"].lower() in vignette.lower() for f in gold["findings"])
+    assert all(f["type"] == "stated" for f in gold["findings"])
+    assert {f["functor"]: f["polarity"] for f in gold["findings"]} == {
+        "csf_neutrophilic_pleocytosis": "affirmed", "csf_glucose": "affirmed"}
+    verdicts = {ij["term"]: ij["verdict"] for ij in gold["inference_justifications"]}
+    assert all(v == "ENTAILED" for v in verdicts.values()), verdicts
+    assert all(ij["basis_span"] for ij in gold["inference_justifications"])
+    # The distractor that appears in the prose is recorded as a justified discard.
+    assert len(gold["discard"]) == 1
+    assert gold["discard"][0]["span"].lower() in vignette.lower()
+    assert gold["discard"][0]["reason"]
+
+
+def test_build_gold_ir_marks_unstated_findings_inferred_and_leap():
+    # The teacher's prose does NOT mention the gram stain → the finding can only be a LEAP.
+    surfaces = {"csf_gram_stain": ["positive Gram stain"], "fever": ["fever"]}
+    vignette = "The patient has a fever and headache; labs are otherwise pending."
+    findings = [{"functor": "fever", "value": "present", "polarity": "stated"},
+                {"functor": "csf_gram_stain", "value": "positive", "polarity": "stated"}]
+    gold = gd.build_gold_ir(vignette, findings, [], surfaces)
+    by_f = {f["functor"]: f for f in gold["findings"]}
+    assert by_f["fever"]["span"] and by_f["fever"]["type"] == "stated"
+    assert by_f["csf_gram_stain"]["span"] == "" and by_f["csf_gram_stain"]["type"] == "inferred"
+    verdicts = {ij["term"]: ij["verdict"] for ij in gold["inference_justifications"]}
+    assert verdicts["fever(present)"] == "ENTAILED"
+    assert verdicts["csf_gram_stain(positive)"] == "LEAP"  # ir_to_adj will drop this — safe
+
+
+def test_build_gold_ir_records_negation_polarity():
+    surfaces = {"csf_gram_stain": ["Gram stain was negative"]}
+    vignette = "The CSF Gram stain was negative."
+    findings = [{"functor": "csf_gram_stain", "value": "negative", "polarity": "denied"}]
+    gold = gd.build_gold_ir(vignette, findings, [], surfaces)
+    assert gold["findings"][0]["polarity"] == "denied"
+
+
+def test_distractors_pool_is_well_formed():
+    assert gd.DISTRACTORS, "need a distractor pool to teach justified discard"
+    for phrase, reason in gd.DISTRACTORS:
+        assert isinstance(phrase, str) and len(phrase) >= 4
+        assert isinstance(reason, str) and reason
+
+
 def main() -> int:
     test_every_profile_value_is_in_the_dictionary()
     test_sampled_findings_stay_in_vocab_and_hints_do_not_leak()
-    print("test_gen_data: PASS (every profile value in the closed vocabulary; sampled "
-          "findings stay in-vocab incl. the organism-id findings; hints don't leak to gold)")
+    test_find_span_returns_a_verbatim_slice_or_empty()
+    test_build_gold_ir_grounds_stated_findings_with_an_entailed_span()
+    test_build_gold_ir_marks_unstated_findings_inferred_and_leap()
+    test_build_gold_ir_records_negation_polarity()
+    test_distractors_pool_is_well_formed()
+    print("test_gen_data: PASS (closed-vocab adherence; hints don't leak; gold IR carries "
+          "byte-provenance spans, ENTAILED/LEAP inference verdicts, and justified discards)")
     return 0
 
 


### PR DESCRIPTION
## Front 3 — the small-model decomposer learns the framework's own discipline

The decomposer training-data generator (`train/gen_data.py`) was producing gold IR
that was a **bare finding list** with `discard` and `inference_justifications` **always
empty** — it taught extraction but not the byte-provenance discipline the framework
demands of itself. This closes that gap: the gold now carries the full typed IR the
warm pipeline's prompt asks for, derived **deterministically from the teacher's prose**
by a pure, unit-tested `build_gold_ir()` (no model — testable without Ollama/MLX).

### What the gold IR now carries
- **byte-provenance** — each finding records the verbatim `span` of prose that supports
  it (located via the dictionary surface forms). Stated verbatim → `type: stated`;
  paraphrased past recognition → `type: inferred` with an empty span.
- **inference justification** — `ENTAILED` when the span was found verbatim, `LEAP` when
  not (which `ir_to_adj` then drops — the safe behavior: the model is taught to *mark*,
  not fabricate, unstated findings).
- **discard** — a third of vignettes inject a non-diagnostic **distractor** (vital sign,
  social history, symptomatic med). When it lands in the prose the gold records it as a
  `discard` `{span, reason}`, teaching justified set-aside over coining a finding.

### Non-breaking
`build_gold_ir` is additive: the gold finding keeps `functor`/`value`/`polarity` (what
the rulebook consumes via `ir_to_adj.normalize_finding`), so downstream is unaffected —
verified by round-tripping the enriched gold through `normalize_finding`. `find_span`
returns a **tight** verbatim slice (anchored on first/last matched words) or `""` — never
a fabricated span. `eval_specialist.py` is unchanged (it scores the diagnostic leader
through ir_to_adj→decide, never the gold IR shape).

### Tests (pure, no Ollama)
`find_span` verbatim-or-empty; `build_gold_ir` grounds stated findings with an ENTAILED
span, marks unstated findings inferred/LEAP, records negation polarity and justified
discards; distractor pool well-formed. All green; ruff clean.

The MLX LoRA **training run** remains a separate opt-in step (this PR is data + tests + docs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)