### PR TITLE
feat(mycin): REL-13c — wire the grounded coagulation domain into the board scoreboard

### DIFF
--- a/code/specs/data/mycin-2026/board/README.md
+++ b/code/specs/data/mycin-2026/board/README.md
@@ -22,9 +22,9 @@ cite an `authoritative` (spider-grounded) edge vs a `consensus` (authored-debt)
 edge. That is the number every grounding/expansion PR moves:
 
 ```
-correct 48 · abstained 6 · wrong 0  (of 54)
-by tactic — differential: 1✓/1·/0✗  ·  management: 5✓/0·/0✗  ·  recall: 42✓/5·/0✗
-defensibility 100%  ·  accuracy-on-attempted 100%  ·  grounded-coverage 98%
+correct 59 · abstained 7 · wrong 0  (of 66)
+by tactic — differential: 1✓/1·/0✗  ·  management: 5✓/0·/0✗  ·  recall: 53✓/6·/0✗
+defensibility 100%  ·  accuracy-on-attempted 100%  ·  grounded-coverage 96%
 ✓ never fabricated — every answer is correct-with-proof or an honest abstention.
 ```
 
@@ -36,15 +36,17 @@ constraint program and SOLVES a regimen — or proves it INFEASIBLE with a named
 conflict). Constraints solved OR made unsatisfiable; both are defensible, neither
 fabricates.
 
-The bank spans **four recall domains** — 12 inborn-errors-of-metabolism diseases
+The bank spans **five recall domains** — 12 inborn-errors-of-metabolism diseases
 (`recall/iem-edges.adj`), 8 vitamin deficiencies (`recall/vitamin-edges.adj`), 8 anemia
-classifications (`recall/anemia-edges.adj`), and 8 endocrine hormones
-(`recall/endocrine-edges.adj`) — merged into one store, **all spider-grounded** (REL-8 /
-REL-10b / REL-11b / REL-12b). grounded-coverage is **98%**: 41 of 42 recall answers cite
-an `authoritative` edge; the lone holdout (`cortisol_def`) stays `consensus` + FLAG
-because the adversarial verify could not pin it verbatim — the framework declines to
-claim grounding it cannot defend, by design. Each new domain entered as authored-debt
-(dipping the number) and its spider run retired it — expansion adds debt, grounding
+classifications (`recall/anemia-edges.adj`), 8 endocrine hormones
+(`recall/endocrine-edges.adj`), and 5 coagulation / bleeding disorders queried three ways
+(`recall/coag-edges.adj`) — merged into one store, **all spider-grounded** (REL-8 /
+REL-10b / REL-11b / REL-12b / REL-13b). grounded-coverage is **96%**: 51 of 53 recall
+answers cite an `authoritative` edge; the two holdouts (`cortisol_def`,
+`factor7_def_factor`) stay `consensus` + FLAG because the adversarial verify could not pin
+them verbatim — the framework declines to claim grounding it cannot defend, by design.
+Each new domain entered as authored-debt (dipping the number) and its spider run retired
+it — expansion adds debt, grounding
 retires it, one watchable number. **A new domain = drop in its `*-edges.adj` file + its
 board items + the filename in `EDGE_FILES`; the harness merges and scores it unchanged.**
 

--- a/code/specs/data/mycin-2026/board/board-scorecard.json
+++ b/code/specs/data/mycin-2026/board/board-scorecard.json
@@ -1,8 +1,8 @@
 {
   "summary": {
-    "total": 54,
-    "correct": 48,
-    "abstained": 6,
+    "total": 66,
+    "correct": 59,
+    "abstained": 7,
     "wrong": 0,
     "by_tactic": {
       "differential": {
@@ -16,15 +16,15 @@
         "wrong": 0
       },
       "recall": {
-        "correct": 42,
-        "abstained": 5,
+        "correct": 53,
+        "abstained": 6,
         "wrong": 0
       }
     },
     "defensibility": 1.0,
     "accuracy_on_attempted": 1.0,
-    "grounded_coverage": 0.9762,
-    "grounded_correct": 41
+    "grounded_coverage": 0.9623,
+    "grounded_correct": 51
   },
   "results": [
     {
@@ -397,6 +397,102 @@
     },
     {
       "id": "glucagon_gland",
+      "tactic": "recall",
+      "gold": "ABSTAIN",
+      "answer": null,
+      "outcome": "abstained",
+      "trust": null
+    },
+    {
+      "id": "hemophilia_a_factor",
+      "tactic": "recall",
+      "gold": "factor_viii",
+      "answer": "factor_viii",
+      "outcome": "correct",
+      "trust": "authoritative"
+    },
+    {
+      "id": "hemophilia_b_factor",
+      "tactic": "recall",
+      "gold": "factor_ix",
+      "answer": "factor_ix",
+      "outcome": "correct",
+      "trust": "authoritative"
+    },
+    {
+      "id": "vwd_factor",
+      "tactic": "recall",
+      "gold": "von_willebrand_factor",
+      "answer": "von_willebrand_factor",
+      "outcome": "correct",
+      "trust": "authoritative"
+    },
+    {
+      "id": "hemophilia_c_factor",
+      "tactic": "recall",
+      "gold": "factor_xi",
+      "answer": "factor_xi",
+      "outcome": "correct",
+      "trust": "authoritative"
+    },
+    {
+      "id": "factor7_def_factor",
+      "tactic": "recall",
+      "gold": "factor_vii",
+      "answer": "factor_vii",
+      "outcome": "correct",
+      "trust": "consensus"
+    },
+    {
+      "id": "hemophilia_a_inherit",
+      "tactic": "recall",
+      "gold": "x_linked_recessive",
+      "answer": "x_linked_recessive",
+      "outcome": "correct",
+      "trust": "authoritative"
+    },
+    {
+      "id": "vwd_inherit",
+      "tactic": "recall",
+      "gold": "autosomal_dominant",
+      "answer": "autosomal_dominant",
+      "outcome": "correct",
+      "trust": "authoritative"
+    },
+    {
+      "id": "factor7_def_inherit",
+      "tactic": "recall",
+      "gold": "autosomal_recessive",
+      "answer": "autosomal_recessive",
+      "outcome": "correct",
+      "trust": "authoritative"
+    },
+    {
+      "id": "hemophilia_a_test",
+      "tactic": "recall",
+      "gold": "aptt",
+      "answer": "aptt",
+      "outcome": "correct",
+      "trust": "authoritative"
+    },
+    {
+      "id": "factor7_def_test",
+      "tactic": "recall",
+      "gold": "pt",
+      "answer": "pt",
+      "outcome": "correct",
+      "trust": "authoritative"
+    },
+    {
+      "id": "vwd_test",
+      "tactic": "recall",
+      "gold": "bleeding_time",
+      "answer": "bleeding_time",
+      "outcome": "correct",
+      "trust": "authoritative"
+    },
+    {
+      "id": "bernard_soulier_factor",
       "tactic": "recall",
       "gold": "ABSTAIN",
       "answer": null,

--- a/code/specs/data/mycin-2026/board/board_eval.py
+++ b/code/specs/data/mycin-2026/board/board_eval.py
@@ -48,7 +48,8 @@ import recall  # noqa: E402  (the REL-1 RelationStore + parse_edges)
 # vitamin deficiencies, …). They share the relational substrate, so the board
 # merges them into one store — a recall item resolves against whichever domain
 # holds its relation. Adding a domain = drop in its edge file + its board items.
-EDGE_FILES = ["iem-edges.adj", "vitamin-edges.adj", "anemia-edges.adj", "endocrine-edges.adj"]
+EDGE_FILES = ["iem-edges.adj", "vitamin-edges.adj", "anemia-edges.adj", "endocrine-edges.adj",
+              "coag-edges.adj"]
 
 
 def load_store() -> "recall.RelationStore":

--- a/code/specs/data/mycin-2026/board/items.json
+++ b/code/specs/data/mycin-2026/board/items.json
@@ -54,6 +54,19 @@
     {"id": "adh_def",        "domain": "endocrine", "tactic": "recall", "relation": "deficiency_syndrome", "subject": "adh",            "var": "Syndrome", "gold": "central_diabetes_insipidus"},
     {"id": "glucagon_gland", "domain": "endocrine", "tactic": "recall", "relation": "secreted_by",         "subject": "glucagon",       "var": "Gland",    "gold": "ABSTAIN"},
 
+    {"id": "hemophilia_a_factor", "domain": "coag", "tactic": "recall", "relation": "factor_deficiency", "subject": "hemophilia_a",            "var": "Factor",  "gold": "factor_viii"},
+    {"id": "hemophilia_b_factor", "domain": "coag", "tactic": "recall", "relation": "factor_deficiency", "subject": "hemophilia_b",            "var": "Factor",  "gold": "factor_ix"},
+    {"id": "vwd_factor",          "domain": "coag", "tactic": "recall", "relation": "factor_deficiency", "subject": "von_willebrand_disease",  "var": "Factor",  "gold": "von_willebrand_factor"},
+    {"id": "hemophilia_c_factor", "domain": "coag", "tactic": "recall", "relation": "factor_deficiency", "subject": "hemophilia_c",            "var": "Factor",  "gold": "factor_xi"},
+    {"id": "factor7_def_factor",  "domain": "coag", "tactic": "recall", "relation": "factor_deficiency", "subject": "factor_vii_deficiency",   "var": "Factor",  "gold": "factor_vii"},
+    {"id": "hemophilia_a_inherit","domain": "coag", "tactic": "recall", "relation": "coag_inheritance",  "subject": "hemophilia_a",            "var": "Pattern", "gold": "x_linked_recessive"},
+    {"id": "vwd_inherit",         "domain": "coag", "tactic": "recall", "relation": "coag_inheritance",  "subject": "von_willebrand_disease",  "var": "Pattern", "gold": "autosomal_dominant"},
+    {"id": "factor7_def_inherit", "domain": "coag", "tactic": "recall", "relation": "coag_inheritance",  "subject": "factor_vii_deficiency",   "var": "Pattern", "gold": "autosomal_recessive"},
+    {"id": "hemophilia_a_test",   "domain": "coag", "tactic": "recall", "relation": "prolonged_test",    "subject": "hemophilia_a",            "var": "Test",    "gold": "aptt"},
+    {"id": "factor7_def_test",    "domain": "coag", "tactic": "recall", "relation": "prolonged_test",    "subject": "factor_vii_deficiency",   "var": "Test",    "gold": "pt"},
+    {"id": "vwd_test",            "domain": "coag", "tactic": "recall", "relation": "prolonged_test",    "subject": "von_willebrand_disease",  "var": "Test",    "gold": "bleeding_time"},
+    {"id": "bernard_soulier_factor", "domain": "coag", "tactic": "recall", "relation": "factor_deficiency", "subject": "bernard_soulier",     "var": "Factor",  "gold": "ABSTAIN"},
+
     {"id": "meningitis_bacterial_dx", "domain": "meningitis", "tactic": "differential", "program": "cases/meningitis_bacterial.adj", "gold": "bacterial_meningitis"},
     {"id": "meningitis_equivocal_dx", "domain": "meningitis", "tactic": "differential", "program": "cases/meningitis_equivocal.adj", "gold": "ABSTAIN"},
 

--- a/code/specs/data/mycin-2026/board/test_board_eval.py
+++ b/code/specs/data/mycin-2026/board/test_board_eval.py
@@ -38,15 +38,17 @@ def test_covered_items_answer_correctly_with_a_proof() -> None:
     assert by_id["tay_sachs_enzyme"].answer == "hexosaminidase_a"
     # A correct recall answer carries the citing edge's trust tier (its proof).
     assert by_id["tay_sachs_enzyme"].trust is not None
-    # The bank spans FOUR recall domains: 18 IEM + 8 vitamin + 8 anemia + 8 endocrine
-    # (REL-12) = 42 covered recall items, all over one merged store.
+    # The bank spans FIVE recall domains: 18 IEM + 8 vitamin + 8 anemia + 8 endocrine
+    # + 11 coagulation (REL-13) = 53 covered recall items, all over one merged store.
     recall_correct = [r for r in card.results if r.outcome == "correct" and r.tactic == "recall"]
-    assert len(recall_correct) == 42
+    assert len(recall_correct) == 53
     assert by_id["fabry_enzyme"].outcome == "correct"               # IEM
     assert by_id["thiamine_disease"].answer == "beriberi"           # vitamin
     assert by_id["ida_mcv"].answer == "microcytic"                  # anemia
     assert by_id["cortisol_gland"].answer == "adrenal_cortex"       # endocrine (REL-12)
     assert by_id["adh_def"].answer == "central_diabetes_insipidus"
+    assert by_id["hemophilia_a_factor"].answer == "factor_viii"     # coagulation (REL-13)
+    assert by_id["vwd_test"].answer == "bleeding_time"              # coag — prolonged_test relation
 
 
 def test_uncovered_items_abstain_not_fabricate() -> None:
@@ -56,6 +58,8 @@ def test_uncovered_items_abstain_not_fabricate() -> None:
     assert by_id["wilson_disease_enzyme"].outcome == "abstained"
     assert by_id["wilson_disease_enzyme"].answer is None
     assert by_id["menkes_enzyme"].outcome == "abstained"
+    # A platelet disorder isn't in the coagulation-FACTOR graph → abstain, never fabricate.
+    assert by_id["bernard_soulier_factor"].outcome == "abstained"
 
 
 def test_defensibility_is_full() -> None:
@@ -68,18 +72,21 @@ def test_defensibility_is_full() -> None:
 def test_grounded_coverage_is_the_live_grounding_number() -> None:
     card, _ = _card()
     s = card.summary()
-    # REL-12b spider-grounded the endocrine domain (11/12 edges). 41 of the 42 recall
-    # answers across all four domains now cite an authoritative edge: grounded-coverage
-    # 98%. The lone holdout is cortisol_def (deficiency_syndrome__cortisol) — the
-    # adversarial verify could not pin it verbatim, so it stays consensus + FLAG: the
-    # framework declines to claim grounding it cannot defend, by design.
-    assert s["grounded_coverage"] == round(41 / 42, 4)   # 0.9762
-    assert s["grounded_correct"] == 41
+    # REL-13b spider-grounded the coagulation domain (14/15 edges). 51 of the 53 recall
+    # answers across all FIVE domains now cite an authoritative edge: grounded-coverage
+    # 96%. Two holdouts stay consensus + FLAG (direction_only) — the adversarial verify
+    # could not pin them verbatim, so the framework declines to claim grounding it cannot
+    # defend, by design: cortisol_def (endocrine) and factor7_def_factor (coagulation,
+    # factor_deficiency__factor_vii_deficiency).
+    assert s["grounded_coverage"] == round(51 / 53, 4)   # 0.9623
+    assert s["grounded_correct"] == 51
     by_id = {r.item_id: r for r in card.results}
     assert by_id["tay_sachs_enzyme"].trust == "authoritative"      # IEM
     assert by_id["ida_mcv"].trust == "authoritative"               # anemia
     assert by_id["cortisol_gland"].trust == "authoritative"        # endocrine, grounded (REL-12b)
-    assert by_id["cortisol_def"].trust == "consensus"              # direction_only holdout
+    assert by_id["hemophilia_a_factor"].trust == "authoritative"   # coagulation, grounded (REL-13b)
+    assert by_id["cortisol_def"].trust == "consensus"              # endocrine direction_only holdout
+    assert by_id["factor7_def_factor"].trust == "consensus"        # coagulation direction_only holdout
 
 
 def test_gate_exit_code_zero_when_no_fabrication() -> None:


### PR DESCRIPTION
## Completes the F1 coagulation loop — the grounded domain is now scored

Follow-up to REL-13 (#5935, coag recall graph) + REL-13b (#5936, spider-grounding). Adds `coag-edges.adj` to `board_eval`'s `EDGE_FILES` and 12 board items (11 covered recall + 1 ABSTAIN), so the spider-grounded coagulation graph is **scored on the board** over the same merged `RelationStore` + defensibility metric. The bank now spans **five recall domains**.

### New scoreboard (CLI present)
```
correct 59 · abstained 7 · wrong 0  (of 66)
by tactic — differential: 1✓/1·  ·  management: 5✓/0·  ·  recall: 53✓/6·
defensibility 100%  ·  accuracy-on-attempted 100%  ·  grounded-coverage 96%
```
- recall_correct **42 → 53** (+11 coag: hemophilia A/B/C, vWD, factor VII deficiency — queried across `factor_deficiency` / `coag_inheritance` / `prolonged_test`)
- grounded_correct **41 → 51** (the spider grounded 14/15 coag edges)
- grounded-coverage **97.6% → 96.2%** = 51/53

### Holdouts surfaced honestly
Two `consensus` + FLAG (`direction_only`) edges are represented in the bank, not hidden: `cortisol_def` (endocrine) and `factor7_def_factor` (coagulation, `factor_deficiency__factor_vii_deficiency`). Both drive to zero on a later re-ground.

### Never fabricates
`bernard_soulier` (a platelet disorder absent from the factor graph) **ABSTAINS** — the discriminator the metric exists to reward.

`board-scorecard.json` regenerated with the built `adj-lang-cli` (differential + management score natively). `test_board_eval` pins the new counts; all 12 tests green, ruff clean, security review passed. Pure board wiring — no engine/grammar change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)