### PR TITLE
feat(closurec): SIMPLE runs the typed-AST optimization pipeline (v2 — constant-fold)

### DIFF
--- a/code/programs/rust/closurec/CHANGELOG.md
+++ b/code/programs/rust/closurec/CHANGELOG.md
@@ -2,6 +2,61 @@
 
 All notable changes to the `coding-adventures-closurec` binary will be documented in this file.
 
+## [0.138.0] - 2026-06-15
+
+### Added (CLOC12.155 — SIMPLE runs the typed-AST optimization pipeline, v2)
+
+`--compilation_level SIMPLE` no longer degrades to whitespace-only output.
+It now runs the real typed-AST optimization pipeline:
+
+```text
+source ──parse──▶ grammar AST ──bridge──▶ typed Program
+       ──passes──▶ optimized Program ──emit──▶ JS text
+```
+
+In this first slice (PR-1) the pass pipeline holds a single pass —
+`constant-fold` — so constant expressions are evaluated at compile time
+(`1 + 2` ⇒ `3`, `3 * 4` ⇒ `12`, `2 + 3 * 4` ⇒ `14`). Follow-up PRs append
+the remaining SIMPLE-appropriate passes (fold-control-flow, dce,
+remove-unused-vars, local inline/rename), one pass per PR.
+
+- **New `run_simple_pipeline` helper** in `run.rs`: takes the bridged
+  `Program`, runs a `closure-pass-pipeline::PassPipeline` holding
+  `ConstantFoldPass`, then serialises the optimized tree back to JS with
+  `closure-emitter::emit` (minified, no source map). All four
+  previously-wired-but-unused crates (`closure-pass-pipeline`,
+  `closure-pass-constant-fold`, `closure-emitter`, `type-sidecar`) are now
+  actually invoked.
+- **`SIMPLE_PASS_NAMES` constant** — the ordered pass list the SIMPLE level
+  runs (`["constant-fold"]` today). Each follow-up PR appends one entry.
+- **Degrade-safe**: the typed path is best-effort. A grammar-parse
+  rejection, a Phase-2+ bridge `UnsupportedSyntax`, a pass error, or an
+  emitter error all fall back to `whitespace_only` so the compiler never
+  errors on valid-but-not-yet-supported input. Only
+  `BridgeError::InternalError` (a broken invariant) still propagates as
+  `CompilerError::Bridge`.
+- **Correlation-vector trace**: the `compilation_level` contribution tag
+  moves from `simple_v1` to `simple_v2` and gains a `passes` field listing
+  the pipeline. `bridge_status` now distinguishes `"ok"` (true optimized
+  emit) from the degrade reasons `"parse_error:…"`,
+  `"unsupported_syntax:…"`, `"pass_error:…"`, and `"emit_error:…"`.
+
+### Verified
+- New `tests/diff/simple-constant-fold/` end-to-end fixture +
+  `tests/diff_simple.rs`: `var sum = 1 + 2; …` ⇒
+  `var sum=3;var product=12;var nested=14;`.
+- New unit tests `simple_level_constant_folds_arithmetic` (SIMPLE folds
+  `1 + 2` ⇒ `3`) and `simple_level_whitespace_only_leaves_arithmetic_unfolded`
+  (the same input under WHITESPACE_ONLY keeps `1+2`, proving the fold is the
+  pipeline's doing).
+- Existing SIMPLE unit tests updated for the `simple_v2` tag and `passes`
+  field; degrade-on-unsupported-syntax behavior unchanged.
+- `tests/diff/define/expected.stdout` regenerated: it runs at the default
+  level (now SIMPLE), so its output is the emitter's form — the `if` keeps
+  its block braces (`if(false){…}`) where the older whitespace-only path
+  stripped them. The `--define` substitution meaning (`DEBUG` → `false`) is
+  unchanged and identical across levels (define is a token-level pre-pass).
+
 ## [0.137.0] - 2026-06-15
 
 ### Fixed

--- a/code/programs/rust/closurec/Cargo.toml
+++ b/code/programs/rust/closurec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closurec"
-version = "0.137.0"
+version = "0.138.0"
 edition = "2021"
 description = "closurec — CLI driver for the Closure Compiler clone. Mirrors the upstream Java Closure Compiler's command-line flag surface (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility. Per CLOC08."
 

--- a/code/programs/rust/closurec/README.md
+++ b/code/programs/rust/closurec/README.md
@@ -117,6 +117,29 @@ surface now means scripts and CI configs that invoke the Java
 tool today can target `closurec` with no flag changes when the
 body fills in.**
 
+## Compilation levels
+
+`--compilation_level` (`-O`) selects how hard the compiler works:
+
+| Level | What it does |
+|-------|--------------|
+| `WHITESPACE_ONLY` | Strips comments and inter-token whitespace only. Token-level; never parses to a typed AST. |
+| `SIMPLE` | Runs the typed-AST optimization pipeline — parse → bridge → passes → emit. Today the pipeline is `constant-fold` (e.g. `1 + 2` ⇒ `3`); more passes land one PR at a time. Falls back to `WHITESPACE_ONLY` if the source uses a not-yet-supported construct, so it never errors on valid input. |
+| `ADVANCED` / `BUNDLE` / `TRANSPILE_ONLY` | Identity passthrough for now — the typed passes specific to these levels (tree-shaking, property renaming, etc.) land in follow-up work. |
+
+The SIMPLE pipeline:
+
+```text
+source ──parse──▶ grammar AST ──bridge──▶ typed Program
+       ──passes──▶ optimized Program ──emit──▶ JS text
+```
+
+```sh
+# SIMPLE evaluates constant expressions at compile time:
+closurec --compilation_level SIMPLE --js in.js
+#   var x = 1 + 2;   ⇒   var x=3;
+```
+
 ## Architecture
 
 ```text

--- a/code/programs/rust/closurec/cli.spec.json
+++ b/code/programs/rust/closurec/cli.spec.json
@@ -2,7 +2,7 @@
   "cli_builder_spec_version": "1.0",
   "name": "closurec",
   "description": "closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.",
-  "version": "0.137.0",
+  "version": "0.138.0",
   "parsing_mode": "gnu",
   "flags": [
     { "id": "browser_featureset_year", "long": "browser_featureset_year", "type": "integer", "default": 0, "description": "Shortcut for defining goog.FEATURESET_YEAR=YYYY (minimum 2012)." },

--- a/code/programs/rust/closurec/src/run.rs
+++ b/code/programs/rust/closurec/src/run.rs
@@ -190,20 +190,97 @@ pub fn transform_source(
 /// | Stage              | `source`           | `tag`            | `meta`                                   |
 /// |--------------------|--------------------|------------------|------------------------------------------|
 /// | WhitespaceOnly     | `compilation_level`| `whitespace_only`| `{input_byte_len, output_byte_len}`      |
-/// | Simple             | `compilation_level`| `simple_v1`      | `{level, bridge_status, input_byte_len, output_byte_len}` |
+/// | Simple             | `compilation_level`| `simple_v2`      | `{level, bridge_status, passes, input_byte_len, output_byte_len}` |
 /// | Advanced / other   | `compilation_level`| `identity`       | `{level: "ADVANCED" \| "BUNDLE" \| ...}` |
 /// | Defines            | `defines`          | `applied`        | `{input_byte_len, output_byte_len, defines_count}` |
 ///
-/// **`bridge_status`** (Simple only): `"ok"` if the bridge parsed
-/// successfully, `"unsupported_syntax:<rule>@<loc>"` if the source
-/// contains Phase 2+ constructs (the output still degrades to
-/// whitespace_only), or `"n/a"` if the bridge was not called.
+/// **`bridge_status`** (Simple only): `"ok"` if the full
+/// parse→bridge→passes→emit chain succeeded, otherwise the degrade
+/// reason — `"parse_error:<e>"`, `"unsupported_syntax:<rule>@<loc>"`
+/// (Phase 2+ constructs), `"pass_error:<e>"`, or `"emit_error:<e>"` —
+/// in all of which cases the output falls back to whitespace_only.
+/// `"n/a"` when the level is not Simple.
 ///
 /// The `defines.applied` contribution lands for every input even
 /// when `--define` is empty (`defines_count: 0`), because the
 /// stage *ran* — it just didn't do any substitutions. That keeps
 /// the trace symmetric across files and visualization tools
 /// don't have to special-case zero-defines runs.
+/// The ordered list of optimization passes the SIMPLE level runs.
+///
+/// v2 holds a single pass. Each follow-up PR appends one more
+/// SIMPLE-appropriate pass here (and to the pipeline below) so the
+/// growth is auditable one pass at a time. The names are the passes'
+/// own canonical `Pass::name()` values; they also become the `passes`
+/// field in the correlation-vector trace.
+const SIMPLE_PASS_NAMES: &[&str] = &["constant-fold"];
+
+/// Run the SIMPLE optimization pipeline over a bridged `Program` and
+/// emit the result as JavaScript text.
+///
+/// This is the "happy path" half of the SIMPLE level. The caller has
+/// already turned source text into a typed [`Program`] via the
+/// grammar parser and the bridge; this function runs the pass
+/// pipeline ([`SIMPLE_PASS_NAMES`]) over it and serialises the
+/// optimized tree back to JS with [`closure_emitter::emit`].
+///
+/// Returns `Some(code)` on success and `None` if a pass or the
+/// emitter fails — in which case the caller degrades to
+/// `whitespace_only`. Either way it records the outcome in
+/// `*status` (`"ok"`, `"pass_error:<e>"`, or `"emit_error:<e>"`) so
+/// the correlation-vector trace can distinguish a true optimized emit
+/// from a degrade.
+///
+/// The pass pipeline and emitter both want a type [`Sidecar`] and a
+/// [`CVLog`]. SIMPLE v2 has no type-inference stage yet, so we pass an
+/// empty sidecar; the pass-internal CV log is created disabled because
+/// the per-byte SIMPLE trace is emitted by the caller's stage block,
+/// not by the individual passes.
+fn run_simple_pipeline(
+    program: coding_adventures_javascript_ast::Program,
+    status: &mut Option<String>,
+) -> Option<String> {
+    use coding_adventures_closure_emitter::{emit, EmitOptions};
+    use coding_adventures_closure_pass_constant_fold::ConstantFoldPass;
+    use coding_adventures_closure_pass_pipeline::PassPipeline;
+    use coding_adventures_correlation_vector::CVLog;
+    use coding_adventures_type_sidecar::Sidecar;
+
+    let sidecar = Sidecar::new();
+    // The passes and emitter take a CV log, but SIMPLE's per-stage CV
+    // record is produced by the caller, not by the passes. A disabled
+    // log accepts contributions and drops them — zero overhead.
+    let mut pass_cv = CVLog::new(false);
+
+    let mut pipeline = PassPipeline::new();
+    pipeline.add(Box::new(ConstantFoldPass::new()));
+
+    let optimized = match pipeline.run(program, &sidecar, &mut pass_cv) {
+        Ok(out) => out.program,
+        Err(e) => {
+            *status = Some(format!("pass_error:{e}"));
+            return None;
+        }
+    };
+
+    // Emit minified JS (pretty=false). No source map at this layer —
+    // SIMPLE source maps land with the dedicated source-map work.
+    let opts = EmitOptions {
+        source_map: false,
+        ..Default::default()
+    };
+    match emit(&optimized, &sidecar, &mut pass_cv, &opts) {
+        Ok(out) => {
+            *status = Some("ok".to_string());
+            Some(out.code)
+        }
+        Err(e) => {
+            *status = Some(format!("emit_error:{e}"));
+            None
+        }
+    }
+}
+
 pub fn transform_source_with_cv(
     source: &str,
     config: &CompilerConfig,
@@ -246,55 +323,70 @@ pub fn transform_source_with_cv(
             whitespace_only::whitespace_only_minify(source, es_version, wo_cv)
                 .map_err(CompilerError::Minify)?
         }
-        // CLOC12.137: SIMPLE routes through the typed-AST bridge (v1).
+        // CLOC12.155: SIMPLE runs the typed-AST optimization pipeline (v2).
         //
-        // The bridge validates source structure and yields a typed
-        // `javascript_ast::Program`. In v1, the output is produced by
-        // whitespace_only — typed optimization passes (variable
-        // renaming, dead code elimination, etc.) land in follow-up PRs.
+        // The pipeline is:
         //
-        // Degrade policy:
-        // - BridgeError::UnsupportedSyntax  → record status and still
-        //   emit whitespace_only output (Phase 2+ constructs are common
-        //   in real codebases; we must not error on them).
-        // - BridgeError::InternalError      → propagate as
-        //   CompilerError::Bridge (indicates a bridge invariant violation,
-        //   NOT something the caller should silently degrade past).
+        //     source ──parse──▶ grammar AST ──bridge──▶ typed Program
+        //            ──passes──▶ optimized Program ──emit──▶ JS text
+        //
+        // In v2 the pass pipeline holds a single pass — `constant-fold`
+        // (e.g. `1 + 2` ⇒ `3`). Follow-up PRs append the remaining
+        // SIMPLE-appropriate passes (fold-control-flow, dce,
+        // remove-unused-vars, local inline/rename), one pass per PR.
+        //
+        // Degrade policy — the typed path is best-effort. If ANY stage
+        // fails (the grammar parser rejects the source, the bridge hits
+        // a Phase-2+ construct, a pass errors, or the emitter cannot
+        // serialise a node), we fall back to `whitespace_only` so the
+        // compiler never errors on valid-but-not-yet-supported input.
+        // The one exception is `BridgeError::InternalError`, which
+        // signals a broken bridge invariant rather than an unsupported
+        // construct — that propagates as `CompilerError::Bridge`.
+        //
+        // `simple_bridge_status` records which branch we took so the
+        // correlation-vector trace can show whether the run was a true
+        // optimized emit (`"ok"`) or a degrade (`"parse_error:…"`,
+        // `"unsupported_syntax:…"`, `"pass_error:…"`, `"emit_error:…"`).
         CompilationLevel::Simple => {
-            // Two-phase bridge call: grammar-parse first, then
-            // bridge-convert. We split the phases so we can match
-            // directly on BridgeError variants rather than on the
-            // stringified error returned by parse_javascript_program().
-            simple_bridge_status = Some(
-                match parse_javascript_typed(source, es_version) {
-                    Err(parse_err) => {
-                        // Malformed JS — grammar parser rejected it.
-                        // Degrade gracefully; whitespace_only will
-                        // surface the real lex error if needed.
-                        format!("parse_error:{parse_err}")
+            // Attempt the typed optimization path. `Some(code)` means
+            // the full parse→bridge→passes→emit chain succeeded;
+            // `None` means we should degrade to whitespace_only.
+            let optimized: Option<String> = match parse_javascript_typed(source, es_version) {
+                Err(parse_err) => {
+                    // Malformed JS — grammar parser rejected it.
+                    // Degrade; whitespace_only surfaces the real error.
+                    simple_bridge_status = Some(format!("parse_error:{parse_err}"));
+                    None
+                }
+                Ok(node) => match bridge::grammar_to_program(&node, es_version) {
+                    Ok(program) => run_simple_pipeline(program, &mut simple_bridge_status),
+                    Err(BridgeError::UnsupportedSyntax { rule, location }) => {
+                        simple_bridge_status =
+                            Some(format!("unsupported_syntax:{rule}@{location}"));
+                        None
                     }
-                    Ok(node) => match bridge::grammar_to_program(&node, es_version) {
-                        Ok(_program) => "ok".to_string(),
-                        Err(BridgeError::UnsupportedSyntax { rule, location }) => {
-                            format!("unsupported_syntax:{rule}@{location}")
-                        }
-                        Err(BridgeError::InternalError { msg, rule }) => {
-                            return Err(CompilerError::Bridge(format!("{rule}: {msg}")));
-                        }
-                    },
+                    Err(BridgeError::InternalError { msg, rule }) => {
+                        return Err(CompilerError::Bridge(format!("{rule}: {msg}")));
+                    }
                 },
-            );
-            // v1: emit via whitespace_only; future passes will use
-            // `_program` to produce fully-optimised SIMPLE output.
-            let wo_cv = cv_pair.as_mut().map(|(log, id, ids)| {
-                (
-                    *log as &mut coding_adventures_correlation_vector::CVLog,
-                    *id,
-                    *ids,
-                )
-            });
-            whitespace_only::whitespace_only_minify(source, es_version, wo_cv)
-                .map_err(CompilerError::Minify)?
+            };
+
+            match optimized {
+                Some(code) => code,
+                None => {
+                    // Degrade path: emit via whitespace_only.
+                    let wo_cv = cv_pair.as_mut().map(|(log, id, ids)| {
+                        (
+                            *log as &mut coding_adventures_correlation_vector::CVLog,
+                            *id,
+                            *ids,
+                        )
+                    });
+                    whitespace_only::whitespace_only_minify(source, es_version, wo_cv)
+                        .map_err(CompilerError::Minify)?
+                }
+            }
         }
         // Advanced / Bundle / TranspileOnly: identity until typed passes land.
         CompilationLevel::Advanced
@@ -320,7 +412,7 @@ pub fn transform_source_with_cv(
                     ],
                 ),
                 CompilationLevel::Simple => (
-                    "simple_v1",
+                    "simple_v2",
                     vec![
                         ("level", serde_json::Value::String("SIMPLE".into())),
                         (
@@ -330,6 +422,19 @@ pub fn transform_source_with_cv(
                                     .as_deref()
                                     .unwrap_or("n/a")
                                     .into(),
+                            ),
+                        ),
+                        // The optimization passes that ran (in order).
+                        // A degrade (`bridge_status != "ok"`) still
+                        // lists them — they were the *intended* pipeline
+                        // even when the run fell back to whitespace_only.
+                        (
+                            "passes",
+                            serde_json::Value::Array(
+                                SIMPLE_PASS_NAMES
+                                    .iter()
+                                    .map(|p| serde_json::Value::String((*p).into()))
+                                    .collect(),
                             ),
                         ),
                         (
@@ -3259,8 +3364,8 @@ mod tests {
         };
         let _ = run_compiler(&cfg).expect("ok");
         let body = fs::read_to_string(&sidecar_path).expect("read sidecar");
-        // CLOC12.137: SIMPLE now records "simple_v1" (not "identity").
-        assert!(body.contains("\"tag\":\"simple_v1\""), "got: {body}");
+        // CLOC12.155: SIMPLE now records "simple_v2" (constant-fold pipeline).
+        assert!(body.contains("\"tag\":\"simple_v2\""), "got: {body}");
         assert!(body.contains("\"level\":\"SIMPLE\""), "got: {body}");
         assert!(body.contains("\"bridge_status\":\"ok\""), "got: {body}");
         let _ = fs::remove_dir_all(&dir);
@@ -5332,10 +5437,9 @@ mod tests {
 
     #[test]
     fn simple_level_strips_whitespace_not_identity() {
-        // v1: SIMPLE output must be whitespace-stripped (not the raw
-        // source). This confirms that transform_source now calls the
-        // bridge and whitespace_only for SIMPLE rather than returning
-        // the source verbatim.
+        // SIMPLE output must be whitespace-stripped (not the raw
+        // source). With no foldable expression the typed pipeline
+        // emits the same compact form whitespace_only would.
         let cfg = CompilerConfig {
             compilation: crate::config::CompilationConfig {
                 level: crate::config::CompilationLevel::Simple,
@@ -5345,10 +5449,43 @@ mod tests {
         };
         let source = "var  x   =   1 ;";
         let out = transform_source(source, &cfg).expect("ok");
-        // whitespace_only collapses extra spaces and removes the
-        // space before `=` that the raw string contains.
+        // The typed emitter produces the compact `var x=1;`.
         assert_ne!(out, source, "SIMPLE must not return the raw source");
         assert_eq!(out, "var x=1;");
+    }
+
+    #[test]
+    fn simple_level_constant_folds_arithmetic() {
+        // CLOC12.155: the SIMPLE pipeline runs constant-fold, so a
+        // literal arithmetic expression is evaluated at compile time.
+        // This is the load-bearing difference from whitespace_only —
+        // `1 + 2` becomes `3`, not `1+2`. If the bridge/pipeline/emit
+        // chain ever silently degraded, this would regress to `1+2`.
+        let cfg = CompilerConfig {
+            compilation: crate::config::CompilationConfig {
+                level: crate::config::CompilationLevel::Simple,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let out = transform_source("var x = 1 + 2;", &cfg).expect("ok");
+        assert_eq!(out, "var x=3;", "constant-fold must evaluate 1 + 2");
+    }
+
+    #[test]
+    fn simple_level_whitespace_only_leaves_arithmetic_unfolded() {
+        // Companion to the test above — the SAME input under
+        // WHITESPACE_ONLY keeps `1+2` literally, proving the fold is
+        // the SIMPLE pipeline's doing and not the lexer/emitter.
+        let cfg = CompilerConfig {
+            compilation: crate::config::CompilationConfig {
+                level: crate::config::CompilationLevel::WhitespaceOnly,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let out = transform_source("var x = 1 + 2;", &cfg).expect("ok");
+        assert_eq!(out, "var x=1+2;", "whitespace_only must NOT fold");
     }
 
     #[test]
@@ -5380,12 +5517,17 @@ mod tests {
         let _ = run_compiler(&cfg).expect("ok");
         let body = fs::read_to_string(&sidecar_path).expect("read sidecar");
         assert!(
-            body.contains("\"tag\":\"simple_v1\""),
-            "expected simple_v1 tag in CV sidecar: {body}"
+            body.contains("\"tag\":\"simple_v2\""),
+            "expected simple_v2 tag in CV sidecar: {body}"
         );
         assert!(
             body.contains("\"bridge_status\":\"ok\""),
             "expected bridge_status=ok in CV sidecar: {body}"
+        );
+        // The pass pipeline must be recorded in the trace.
+        assert!(
+            body.contains("\"passes\":[\"constant-fold\"]"),
+            "expected passes list in CV sidecar: {body}"
         );
         let _ = fs::remove_dir_all(&dir);
     }
@@ -5429,9 +5571,11 @@ mod tests {
             "expected output file written"
         );
         let body = fs::read_to_string(&sidecar_path).expect("read sidecar");
+        // Even on a degrade the stage is still tagged simple_v2 — the
+        // tag names the level's pipeline version, not the outcome.
         assert!(
-            body.contains("\"tag\":\"simple_v1\""),
-            "expected simple_v1 tag: {body}"
+            body.contains("\"tag\":\"simple_v2\""),
+            "expected simple_v2 tag: {body}"
         );
         assert!(
             body.contains("\"bridge_status\":\"unsupported_syntax:"),

--- a/code/programs/rust/closurec/tests/diff/define/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/define/expected.stdout
@@ -1,1 +1,2 @@
-var DEBUG_FLAG=false;if(false)console.log("dev mode");
+var DEBUG_FLAG=false;if(false){console.log("dev mode")}
+

--- a/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
@@ -2,7 +2,7 @@
 
 closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.
 
-Version: 0.137.0
+Version: 0.138.0
 
 ## Flags
 

--- a/code/programs/rust/closurec/tests/diff/simple-constant-fold/README.md
+++ b/code/programs/rust/closurec/tests/diff/simple-constant-fold/README.md
@@ -1,0 +1,24 @@
+# Fixture: `simple-constant-fold`
+
+End-to-end oracle for `--compilation_level SIMPLE` (CLOC12.155, PR-1).
+
+| File | Role |
+|------|------|
+| `flags.txt` | CLI args: `--compilation_level SIMPLE --js input/a.js` |
+| `input/a.js` | Three `var` declarations with constant arithmetic initializers |
+| `expected.stdout` | The folded output: `var sum=3;var product=12;var nested=14;` |
+
+The SIMPLE level runs the typed-AST optimization pipeline (currently
+just the `constant-fold` pass), so `1 + 2` ⇒ `3`, `3 * 4` ⇒ `12`, and
+`2 + 3 * 4` ⇒ `14` (operator precedence respected). The same input
+under `WHITESPACE_ONLY` keeps `1+2` etc. — see the
+`simple_level_whitespace_only_leaves_arithmetic_unfolded` unit test in
+`src/run.rs`.
+
+Regenerate the expected file after an intentional behavior change:
+
+```sh
+cargo run -- --compilation_level SIMPLE \
+    --js tests/diff/simple-constant-fold/input/a.js \
+    > tests/diff/simple-constant-fold/expected.stdout
+```

--- a/code/programs/rust/closurec/tests/diff/simple-constant-fold/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/simple-constant-fold/expected.stdout
@@ -1,0 +1,2 @@
+var sum=3;var product=12;var nested=14;
+

--- a/code/programs/rust/closurec/tests/diff/simple-constant-fold/flags.txt
+++ b/code/programs/rust/closurec/tests/diff/simple-constant-fold/flags.txt
@@ -1,0 +1,4 @@
+--compilation_level
+SIMPLE
+--js
+tests/diff/simple-constant-fold/input/a.js

--- a/code/programs/rust/closurec/tests/diff/simple-constant-fold/input/a.js
+++ b/code/programs/rust/closurec/tests/diff/simple-constant-fold/input/a.js
@@ -1,0 +1,9 @@
+// SIMPLE-level constant folding (CLOC12.155).
+//
+// Each declaration's initializer is a constant expression that the
+// `constant-fold` pass evaluates at compile time. Under WHITESPACE_ONLY
+// these would survive as `1+2`, `3*4`, etc.; under SIMPLE they fold to
+// their value. This fixture is the end-to-end oracle for PR-1.
+var sum = 1 + 2;
+var product = 3 * 4;
+var nested = 2 + 3 * 4;

--- a/code/programs/rust/closurec/tests/diff_define.rs
+++ b/code/programs/rust/closurec/tests/diff_define.rs
@@ -5,15 +5,18 @@
 //! `--define DEBUG=false` against a small input that references
 //! `DEBUG` in two places (initializer + `if` condition).
 //!
-//! Note this test does NOT pass `--compilation_level
-//! WHITESPACE_ONLY` explicitly. Because the define-substitution
-//! path re-tokenizes and re-emits with the same conservative
-//! spacing rule, the output is naturally minified. CC's behavior
-//! is similar — `--define` runs alongside whatever
-//! compilation-level passes are active. Per CLOC11 §3 this is
-//! "behavioral equality" not byte-equal to CC; the expected
-//! file is checked in from our own output and the diff target
-//! is the *meaning* of the substitution.
+//! Note this test does NOT pass `--compilation_level` explicitly,
+//! so it runs at the default level (SIMPLE). As of closurec 0.138.0
+//! SIMPLE routes through the typed-AST pipeline (bridge → passes →
+//! emit), so the output is the emitter's form — e.g. the `if`
+//! keeps its block braces (`if(false){…}`) where the older
+//! whitespace-only path stripped them. `--define` runs as a
+//! token-level pre-pass *before* the compilation level, so the
+//! substitution's meaning (`DEBUG` → `false` in both the
+//! initializer and the `if` condition) is identical across levels.
+//! Per CLOC11 §3 this is "behavioral equality" not byte-equal to
+//! CC; the expected file is checked in from our own output and the
+//! diff target is the *meaning* of the substitution.
 
 use std::process::Command;
 

--- a/code/programs/rust/closurec/tests/diff_simple.rs
+++ b/code/programs/rust/closurec/tests/diff_simple.rs
@@ -1,0 +1,61 @@
+//! Integration test for the `tests/diff/simple-constant-fold/` fixture.
+//!
+//! Exercises the CLOC12.155 `--compilation_level SIMPLE` path
+//! end-to-end. Unlike WHITESPACE_ONLY (which only strips
+//! inter-token whitespace), SIMPLE routes the source through the
+//! typed-AST pipeline:
+//!
+//! ```text
+//! source ──parse──▶ grammar AST ──bridge──▶ typed Program
+//!        ──passes──▶ optimized Program ──emit──▶ JS text
+//! ```
+//!
+//! In this PR the pass pipeline holds a single pass —
+//! `constant-fold` — so the fixture's constant initializers
+//! (`1 + 2`, `3 * 4`, `2 + 3 * 4`) are evaluated at compile time and
+//! emitted as their values (`3`, `12`, `14`). The companion
+//! `simple_level_whitespace_only_leaves_arithmetic_unfolded` unit
+//! test pins that the SAME input under WHITESPACE_ONLY keeps `1+2`,
+//! proving the fold is the SIMPLE pipeline's doing.
+//!
+//! This is the behavioral oracle for the SIMPLE level: when we
+//! later diff against the real `closure-compiler.jar`, this expected
+//! file is the diff target.
+
+use std::process::Command;
+
+const BINARY: &str = env!("CARGO_BIN_EXE_closurec");
+
+fn read_flags() -> Vec<String> {
+    let raw = std::fs::read_to_string("tests/diff/simple-constant-fold/flags.txt")
+        .expect("read flags.txt");
+    raw.lines()
+        .filter(|l| !l.is_empty())
+        .map(|s| s.to_string())
+        .collect()
+}
+
+#[test]
+fn simple_constant_fold_fixture_matches_expected_stdout() {
+    let flags = read_flags();
+    let out = Command::new(BINARY)
+        .args(&flags)
+        .output()
+        .expect("run closurec");
+
+    assert!(
+        out.status.success(),
+        "exit: {:?}, stderr: {}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stderr),
+    );
+
+    let actual = String::from_utf8_lossy(&out.stdout);
+    let expected = std::fs::read_to_string("tests/diff/simple-constant-fold/expected.stdout")
+        .expect("read expected.stdout");
+    assert_eq!(
+        actual.trim_end_matches('\n'),
+        expected.trim_end_matches('\n'),
+        "mismatch.\nflags: {flags:?}\nactual:\n{actual}\nexpected:\n{expected}",
+    );
+}


### PR DESCRIPTION
## Summary

`--compilation_level SIMPLE` (also the **default** level) no longer degrades to whitespace-only output. It now runs the real typed-AST optimization pipeline:

```text
source ──parse──▶ grammar AST ──bridge──▶ typed Program
       ──passes──▶ optimized Program ──emit──▶ JS text
```

In this first slice the pass pipeline holds a single pass — **`constant-fold`** — so constant expressions are evaluated at compile time:

```sh
closurec --compilation_level SIMPLE --js in.js
#   var x = 1 + 2;   ⇒   var x=3;
```

Follow-up PRs append the remaining SIMPLE-appropriate passes (fold-control-flow, dce, remove-unused-vars, local inline/rename), one pass per PR.

## What changed

- **`run_simple_pipeline` helper** runs `closure-pass-pipeline::PassPipeline` holding `ConstantFoldPass`, then serialises via `closure-emitter::emit` (minified, no source map). The four previously-wired-but-unused dependency crates (`closure-pass-pipeline`, `closure-pass-constant-fold`, `closure-emitter`, `type-sidecar`) are now actually invoked.
- **`SIMPLE_PASS_NAMES`** constant — the ordered pass list; each follow-up PR appends one entry.
- **Degrade-safe**: a parse rejection, a Phase-2+ bridge `UnsupportedSyntax`, a pass error, or an emit error all fall back to `whitespace_only`, so the compiler never errors on valid-but-not-yet-supported input. Only `BridgeError::InternalError` (a broken invariant) propagates as `CompilerError::Bridge`.
- **Correlation-vector trace**: tag `simple_v1` → `simple_v2` with a `passes` field; `bridge_status` now distinguishes `"ok"` from `parse_error` / `unsupported_syntax` / `pass_error` / `emit_error`.

## Dependency

Builds on [#5924](https://github.com/adhithyan15/coding-adventures/pull/5924) (`javascript-parser` 0.8.0 — member-expression suffix-chain fix), already merged. The typed emitter needs it to round-trip `a.b.c` / `console.log(...)` correctly.

## Test plan

- [x] New `tests/diff/simple-constant-fold/` fixture + `tests/diff_simple.rs`: `var sum = 1 + 2; var product = 3 * 4; var nested = 2 + 3 * 4;` ⇒ `var sum=3;var product=12;var nested=14;`
- [x] New unit tests: `simple_level_constant_folds_arithmetic` (SIMPLE folds `1+2`⇒`3`) and `simple_level_whitespace_only_leaves_arithmetic_unfolded` (same input under WHITESPACE_ONLY keeps `1+2`, proving the fold is the pipeline's doing)
- [x] `tests/diff/define/expected.stdout` regenerated — it runs at the default level (now SIMPLE), so the `if` keeps its block braces (emitter form); the `--define` substitution meaning (`DEBUG`→`false`) is unchanged
- [x] 655 unit tests + all diff fixtures pass; clippy clean for new code
- [x] Security review passed (degrade-safe control flow, no panic paths, f64 fold arithmetic non-panicking)
- closurec 0.137.0 → 0.138.0 (Cargo.toml + cli.spec.json + help-markdown fixture)

🤖 Generated with [Claude Code](https://claude.com/claude-code)