### PR TITLE
feat(closurec): SIMPLE pipeline gains fold-control-flow pass

### DIFF
--- a/code/programs/rust/closurec/CHANGELOG.md
+++ b/code/programs/rust/closurec/CHANGELOG.md
@@ -2,6 +2,49 @@
 
 All notable changes to the `coding-adventures-closurec` binary will be documented in this file.
 
+## [0.139.0] - 2026-06-16
+
+### Added (CLOC12.156 — SIMPLE pipeline gains `fold-control-flow`)
+
+The `--compilation_level SIMPLE` pass pipeline is now
+`constant-fold → fold-control-flow` (was just `constant-fold`). With the
+control-flow folder, an `if` whose condition is statically decidable has its
+dead branch pruned:
+
+| Source | SIMPLE output |
+|--------|---------------|
+| `if (2 > 3) { keepElse(); } else { takeThis(); }` | `{takeThis()}` |
+| `if (true) { alsoKept(); } else { dropped(); }` | `{alsoKept()}` |
+| `if (4 > 5) { vanishes(); }` | `;` (empty statement) |
+
+The `if (2 > 3)` case is the load-bearing one: `constant-fold` first turns the
+comparison `2 > 3` into the literal `false`, and only then can
+`fold-control-flow` decide the branch — so the two passes must compose. The
+pass registers a `depends_on = ["constant-fold"]`, so the pipeline's
+dependency topo-sort guarantees that order regardless of registration order.
+
+- `SIMPLE_PASS_NAMES` is now `["constant-fold", "fold-control-flow"]`; the
+  `passes` field in the `simple_v2` correlation-vector trace lists both.
+- `run_simple_pipeline` registers `FoldControlFlowPass` alongside
+  `ConstantFoldPass`.
+
+### Verified
+- New `tests/diff/simple-fold-control-flow/` end-to-end fixture +
+  `tests/diff_simple_fold_control_flow.rs`: three decidable `if`s ⇒
+  `{takeThis()}{alsoKept()};`.
+- New unit tests `simple_fold_control_flow_prunes_dead_branch`
+  (`if (2 > 3) {a()} else {b()}` ⇒ `{b()}`) and
+  `simple_fold_control_flow_whitespace_only_keeps_if` (same input under
+  WHITESPACE_ONLY keeps the whole `if`).
+- Existing `simple_v2` CV test updated to expect both pass names in `passes`.
+- `tests/diff/define/` re-pinned to `--compilation_level WHITESPACE_ONLY`.
+  `--define` is level-independent, and the compilation level runs *before*
+  the define pass, so at SIMPLE the now-present fold-control-flow rewrites
+  `if (DEBUG) {…}` → `DEBUG && …` (while `DEBUG` is still a variable) before
+  the substitution — a correct but surprising interaction that would churn
+  this fixture on every SIMPLE PR. Pinning WHITESPACE_ONLY isolates the
+  define-substitution oracle; SIMPLE behavior lives in the `simple-*` fixtures.
+
 ## [0.138.0] - 2026-06-15
 
 ### Added (CLOC12.155 — SIMPLE runs the typed-AST optimization pipeline, v2)

--- a/code/programs/rust/closurec/Cargo.toml
+++ b/code/programs/rust/closurec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closurec"
-version = "0.138.0"
+version = "0.139.0"
 edition = "2021"
 description = "closurec — CLI driver for the Closure Compiler clone. Mirrors the upstream Java Closure Compiler's command-line flag surface (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility. Per CLOC08."
 

--- a/code/programs/rust/closurec/README.md
+++ b/code/programs/rust/closurec/README.md
@@ -124,7 +124,7 @@ body fills in.**
 | Level | What it does |
 |-------|--------------|
 | `WHITESPACE_ONLY` | Strips comments and inter-token whitespace only. Token-level; never parses to a typed AST. |
-| `SIMPLE` | Runs the typed-AST optimization pipeline — parse → bridge → passes → emit. Today the pipeline is `constant-fold` (e.g. `1 + 2` ⇒ `3`); more passes land one PR at a time. Falls back to `WHITESPACE_ONLY` if the source uses a not-yet-supported construct, so it never errors on valid input. |
+| `SIMPLE` | Runs the typed-AST optimization pipeline — parse → bridge → passes → emit. Today the pipeline is `constant-fold → fold-control-flow` (e.g. `1 + 2` ⇒ `3`; `if (2 > 3) {a} else {b}` ⇒ `{b}`); more passes land one PR at a time. Falls back to `WHITESPACE_ONLY` if the source uses a not-yet-supported construct, so it never errors on valid input. |
 | `ADVANCED` / `BUNDLE` / `TRANSPILE_ONLY` | Identity passthrough for now — the typed passes specific to these levels (tree-shaking, property renaming, etc.) land in follow-up work. |
 
 The SIMPLE pipeline:

--- a/code/programs/rust/closurec/cli.spec.json
+++ b/code/programs/rust/closurec/cli.spec.json
@@ -2,7 +2,7 @@
   "cli_builder_spec_version": "1.0",
   "name": "closurec",
   "description": "closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.",
-  "version": "0.138.0",
+  "version": "0.139.0",
   "parsing_mode": "gnu",
   "flags": [
     { "id": "browser_featureset_year", "long": "browser_featureset_year", "type": "integer", "default": 0, "description": "Shortcut for defining goog.FEATURESET_YEAR=YYYY (minimum 2012)." },

--- a/code/programs/rust/closurec/src/run.rs
+++ b/code/programs/rust/closurec/src/run.rs
@@ -208,12 +208,18 @@ pub fn transform_source(
 /// don't have to special-case zero-defines runs.
 /// The ordered list of optimization passes the SIMPLE level runs.
 ///
-/// v2 holds a single pass. Each follow-up PR appends one more
-/// SIMPLE-appropriate pass here (and to the pipeline below) so the
-/// growth is auditable one pass at a time. The names are the passes'
-/// own canonical `Pass::name()` values; they also become the `passes`
-/// field in the correlation-vector trace.
-const SIMPLE_PASS_NAMES: &[&str] = &["constant-fold"];
+/// Each PR appends one more SIMPLE-appropriate pass here (and to the
+/// pipeline below) so the growth is auditable one pass at a time. The
+/// names are the passes' own canonical `Pass::name()` values; they also
+/// become the `passes` field in the correlation-vector trace.
+///
+/// The list is in execution order, but ordering is ultimately enforced
+/// by the pipeline's dependency graph: `fold-control-flow` declares
+/// `depends_on = ["constant-fold"]`, so the topo-sort runs constant-fold
+/// first regardless. That ordering matters — constant-fold turns a
+/// comparison like `2 > 3` into the literal `false`, which is what lets
+/// fold-control-flow then prune `if (2 > 3) {A} else {B}` down to `B`.
+const SIMPLE_PASS_NAMES: &[&str] = &["constant-fold", "fold-control-flow"];
 
 /// Run the SIMPLE optimization pipeline over a bridged `Program` and
 /// emit the result as JavaScript text.
@@ -242,6 +248,7 @@ fn run_simple_pipeline(
 ) -> Option<String> {
     use coding_adventures_closure_emitter::{emit, EmitOptions};
     use coding_adventures_closure_pass_constant_fold::ConstantFoldPass;
+    use coding_adventures_closure_pass_fold_control_flow::FoldControlFlowPass;
     use coding_adventures_closure_pass_pipeline::PassPipeline;
     use coding_adventures_correlation_vector::CVLog;
     use coding_adventures_type_sidecar::Sidecar;
@@ -252,8 +259,12 @@ fn run_simple_pipeline(
     // log accepts contributions and drops them — zero overhead.
     let mut pass_cv = CVLog::new(false);
 
+    // Registration order is not significant — the pipeline topo-sorts
+    // on each pass's `depends_on`, so `fold-control-flow` (which depends
+    // on `constant-fold`) always runs after it.
     let mut pipeline = PassPipeline::new();
     pipeline.add(Box::new(ConstantFoldPass::new()));
+    pipeline.add(Box::new(FoldControlFlowPass::new()));
 
     let optimized = match pipeline.run(program, &sidecar, &mut pass_cv) {
         Ok(out) => out.program,
@@ -5489,6 +5500,44 @@ mod tests {
     }
 
     #[test]
+    fn simple_fold_control_flow_prunes_dead_branch() {
+        // CLOC12.156: the SIMPLE pipeline now runs fold-control-flow
+        // after constant-fold, so an `if` with a statically-false
+        // condition keeps only its `else` branch. The `2 > 3` form is
+        // the load-bearing case: constant-fold turns `2 > 3` into
+        // `false`, and only then can fold-control-flow decide the
+        // branch — so this exercises the two passes composing.
+        let cfg = CompilerConfig {
+            compilation: crate::config::CompilationConfig {
+                level: crate::config::CompilationLevel::Simple,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let out = transform_source("if (2 > 3) { a(); } else { b(); }", &cfg).expect("ok");
+        assert_eq!(out, "{b()}", "fold-control-flow must keep only the else branch");
+    }
+
+    #[test]
+    fn simple_fold_control_flow_whitespace_only_keeps_if() {
+        // Companion — the SAME input under WHITESPACE_ONLY keeps the
+        // whole `if`/`else`, proving the pruning is the SIMPLE
+        // pipeline's doing and not the lexer/emitter.
+        let cfg = CompilerConfig {
+            compilation: crate::config::CompilationConfig {
+                level: crate::config::CompilationLevel::WhitespaceOnly,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let out = transform_source("if (2 > 3) { a(); } else { b(); }", &cfg).expect("ok");
+        assert_eq!(
+            out, "if(2>3)a();else b();",
+            "whitespace_only must NOT prune the branch"
+        );
+    }
+
+    #[test]
     fn simple_level_bridge_ok_status_in_cv() {
         // When the source parses cleanly, the CV contribution for the
         // `compilation_level` stage must carry bridge_status = "ok".
@@ -5524,9 +5573,9 @@ mod tests {
             body.contains("\"bridge_status\":\"ok\""),
             "expected bridge_status=ok in CV sidecar: {body}"
         );
-        // The pass pipeline must be recorded in the trace.
+        // The pass pipeline must be recorded in the trace, in order.
         assert!(
-            body.contains("\"passes\":[\"constant-fold\"]"),
+            body.contains("\"passes\":[\"constant-fold\",\"fold-control-flow\"]"),
             "expected passes list in CV sidecar: {body}"
         );
         let _ = fs::remove_dir_all(&dir);

--- a/code/programs/rust/closurec/tests/diff/define/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/define/expected.stdout
@@ -1,2 +1,2 @@
-var DEBUG_FLAG=false;if(false){console.log("dev mode")}
+var DEBUG_FLAG=false;if(false)console.log("dev mode");
 

--- a/code/programs/rust/closurec/tests/diff/define/flags.txt
+++ b/code/programs/rust/closurec/tests/diff/define/flags.txt
@@ -1,4 +1,6 @@
 --define
 DEBUG=false
+--compilation_level
+WHITESPACE_ONLY
 --js
 tests/diff/define/input/app.js

--- a/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
@@ -2,7 +2,7 @@
 
 closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.
 
-Version: 0.138.0
+Version: 0.139.0
 
 ## Flags
 

--- a/code/programs/rust/closurec/tests/diff/simple-fold-control-flow/README.md
+++ b/code/programs/rust/closurec/tests/diff/simple-fold-control-flow/README.md
@@ -1,0 +1,32 @@
+# Fixture: `simple-fold-control-flow`
+
+End-to-end oracle for the `fold-control-flow` pass in `--compilation_level
+SIMPLE` (CLOC12.156, PR-2).
+
+| File | Role |
+|------|------|
+| `flags.txt` | `--compilation_level SIMPLE --js input/a.js` |
+| `input/a.js` | Three `if` statements with statically-decidable conditions |
+| `expected.stdout` | `{takeThis()}{alsoKept()};` |
+
+The SIMPLE pipeline is now `constant-fold → fold-control-flow`. Each `if`'s
+condition is decided at compile time and the dead branch is pruned:
+
+| Source | Result |
+|--------|--------|
+| `if (2 > 3) { keepElse(); } else { takeThis(); }` | `{takeThis()}` |
+| `if (true) { alsoKept(); } else { dropped(); }` | `{alsoKept()}` |
+| `if (4 > 5) { vanishes(); }` | `;` (empty statement) |
+
+The `if (2 > 3)` row is the key one: `constant-fold` turns `2 > 3` into
+`false`, and only *then* can `fold-control-flow` keep the `else` branch —
+proving the two passes compose. The same input under `WHITESPACE_ONLY` keeps
+every `if` verbatim.
+
+Regenerate the expected file after an intentional behavior change:
+
+```sh
+cargo run -- --compilation_level SIMPLE \
+    --js tests/diff/simple-fold-control-flow/input/a.js \
+    > tests/diff/simple-fold-control-flow/expected.stdout
+```

--- a/code/programs/rust/closurec/tests/diff/simple-fold-control-flow/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/simple-fold-control-flow/expected.stdout
@@ -1,0 +1,2 @@
+{takeThis()}{alsoKept()};
+

--- a/code/programs/rust/closurec/tests/diff/simple-fold-control-flow/flags.txt
+++ b/code/programs/rust/closurec/tests/diff/simple-fold-control-flow/flags.txt
@@ -1,0 +1,4 @@
+--compilation_level
+SIMPLE
+--js
+tests/diff/simple-fold-control-flow/input/a.js

--- a/code/programs/rust/closurec/tests/diff/simple-fold-control-flow/input/a.js
+++ b/code/programs/rust/closurec/tests/diff/simple-fold-control-flow/input/a.js
@@ -1,0 +1,17 @@
+// SIMPLE-level control-flow folding (CLOC12.156).
+//
+// The SIMPLE pipeline now runs `fold-control-flow` after `constant-fold`.
+// Each `if` below has a statically-decidable condition, so the dead branch
+// is pruned:
+//
+//   - `if (2 > 3)`  — constant-fold first turns `2 > 3` into `false`, THEN
+//     fold-control-flow keeps the `else` branch. This proves the two passes
+//     compose (the comparison must be folded before the branch can be).
+//   - `if (true)`   — keeps the consequent.
+//   - `if (4 > 5)`  — folds to `false` with no `else`, so the whole `if`
+//     becomes an empty statement.
+//
+// Under WHITESPACE_ONLY none of this happens — every `if` survives verbatim.
+if (2 > 3) { keepElse(); } else { takeThis(); }
+if (true) { alsoKept(); } else { dropped(); }
+if (4 > 5) { vanishes(); }

--- a/code/programs/rust/closurec/tests/diff_define.rs
+++ b/code/programs/rust/closurec/tests/diff_define.rs
@@ -5,18 +5,25 @@
 //! `--define DEBUG=false` against a small input that references
 //! `DEBUG` in two places (initializer + `if` condition).
 //!
-//! Note this test does NOT pass `--compilation_level` explicitly,
-//! so it runs at the default level (SIMPLE). As of closurec 0.138.0
-//! SIMPLE routes through the typed-AST pipeline (bridge → passes →
-//! emit), so the output is the emitter's form — e.g. the `if`
-//! keeps its block braces (`if(false){…}`) where the older
-//! whitespace-only path stripped them. `--define` runs as a
-//! token-level pre-pass *before* the compilation level, so the
-//! substitution's meaning (`DEBUG` → `false` in both the
-//! initializer and the `if` condition) is identical across levels.
-//! Per CLOC11 §3 this is "behavioral equality" not byte-equal to
-//! CC; the expected file is checked in from our own output and the
-//! diff target is the *meaning* of the substitution.
+//! This test pins `--compilation_level WHITESPACE_ONLY` on purpose.
+//! `--define` is level-independent (a token-level pass), so running it
+//! at WHITESPACE_ONLY isolates the substitution from the SIMPLE
+//! optimizer — which now keeps growing passes (constant-fold,
+//! fold-control-flow, …) that would otherwise churn this expected file
+//! on every SIMPLE PR. The SIMPLE level's own behavior is covered by
+//! the dedicated `simple-*` fixtures.
+//!
+//! A subtlety worth recording: the compilation level runs *before* the
+//! `--define` substitution (pass order: lex → compilation_level →
+//! defines). Under SIMPLE that means `if (DEBUG) {…}` would be rewritten
+//! to `DEBUG && …` while `DEBUG` is still a variable, and only then
+//! substituted — a correct but surprising interaction. WHITESPACE_ONLY
+//! does no such rewrite, so the fixture stays a clean substitution oracle.
+//!
+//! Per CLOC11 §3 this is "behavioral equality" not byte-equal to CC; the
+//! expected file is checked in from our own output and the diff target
+//! is the *meaning* of the substitution (`DEBUG` → `false` in both the
+//! initializer and the `if` condition).
 
 use std::process::Command;
 

--- a/code/programs/rust/closurec/tests/diff_simple_fold_control_flow.rs
+++ b/code/programs/rust/closurec/tests/diff_simple_fold_control_flow.rs
@@ -1,0 +1,61 @@
+//! Integration test for the `tests/diff/simple-fold-control-flow/` fixture.
+//!
+//! Exercises the CLOC12.156 addition of the `fold-control-flow` pass to
+//! the `--compilation_level SIMPLE` pipeline. The pipeline is now
+//! `constant-fold → fold-control-flow`, so an `if` with a
+//! statically-decidable condition has its dead branch pruned:
+//!
+//! ```text
+//! if (2 > 3) { keepElse(); } else { takeThis(); }   ⇒  { takeThis(); }
+//! if (true)  { alsoKept(); } else { dropped();  }   ⇒  { alsoKept(); }
+//! if (4 > 5) { vanishes();  }                       ⇒  ;   (empty)
+//! ```
+//!
+//! The `if (2 > 3)` case is the load-bearing one: it proves the two
+//! passes compose — `constant-fold` must first turn `2 > 3` into the
+//! literal `false` before `fold-control-flow` can decide the branch.
+//! The same input under WHITESPACE_ONLY keeps every `if` verbatim (see
+//! the `simple_fold_control_flow_*` unit tests in `src/run.rs`).
+//!
+//! This is the behavioral oracle for the SIMPLE level's control-flow
+//! folding: when we later diff against the real `closure-compiler.jar`,
+//! this expected file is the diff target.
+
+use std::process::Command;
+
+const BINARY: &str = env!("CARGO_BIN_EXE_closurec");
+
+fn read_flags() -> Vec<String> {
+    let raw = std::fs::read_to_string("tests/diff/simple-fold-control-flow/flags.txt")
+        .expect("read flags.txt");
+    raw.lines()
+        .filter(|l| !l.is_empty())
+        .map(|s| s.to_string())
+        .collect()
+}
+
+#[test]
+fn simple_fold_control_flow_fixture_matches_expected_stdout() {
+    let flags = read_flags();
+    let out = Command::new(BINARY)
+        .args(&flags)
+        .output()
+        .expect("run closurec");
+
+    assert!(
+        out.status.success(),
+        "exit: {:?}, stderr: {}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stderr),
+    );
+
+    let actual = String::from_utf8_lossy(&out.stdout);
+    let expected =
+        std::fs::read_to_string("tests/diff/simple-fold-control-flow/expected.stdout")
+            .expect("read expected.stdout");
+    assert_eq!(
+        actual.trim_end_matches('\n'),
+        expected.trim_end_matches('\n'),
+        "mismatch.\nflags: {flags:?}\nactual:\n{actual}\nexpected:\n{expected}",
+    );
+}


### PR DESCRIPTION
## Summary

The `--compilation_level SIMPLE` pass pipeline is now **`constant-fold → fold-control-flow`** (was just `constant-fold`). With the control-flow folder, an `if` whose condition is statically decidable has its dead branch pruned:

| Source | SIMPLE output |
|--------|---------------|
| `if (2 > 3) { keepElse(); } else { takeThis(); }` | `{takeThis()}` |
| `if (true) { alsoKept(); } else { dropped(); }` | `{alsoKept()}` |
| `if (4 > 5) { vanishes(); }` | `;` (empty statement) |

The `if (2 > 3)` case is load-bearing: `constant-fold` first turns the comparison `2 > 3` into the literal `false`, and only then can `fold-control-flow` decide the branch — so the two passes **compose**. `FoldControlFlowPass` declares `depends_on = ["constant-fold"]`, so the pipeline's dependency topo-sort guarantees that order regardless of registration order.

## Also: re-pinned the `define` fixture

`tests/diff/define/` is now pinned to `--compilation_level WHITESPACE_ONLY`. `--define` is level-independent, and the compilation level runs **before** the define pass, so under SIMPLE the now-present `fold-control-flow` rewrites `if (DEBUG) {…}` → `DEBUG && …` (while `DEBUG` is still a variable) *before* the substitution — a correct but surprising interaction that would churn this fixture on every SIMPLE PR. Pinning WHITESPACE_ONLY keeps it a clean substitution oracle; SIMPLE-level behavior is covered by the dedicated `simple-*` fixtures.

## Dependency

Builds on [#5943](https://github.com/adhithyan15/coding-adventures/pull/5943) (SIMPLE constant-fold pipeline), already merged.

## Test plan

- [x] New `tests/diff/simple-fold-control-flow/` fixture + `tests/diff_simple_fold_control_flow.rs`: three decidable `if`s ⇒ `{takeThis()}{alsoKept()};`
- [x] New unit tests: `simple_fold_control_flow_prunes_dead_branch` (`if (2 > 3) {a} else {b}` ⇒ `{b()}`) and `simple_fold_control_flow_whitespace_only_keeps_if` (same input under WHITESPACE_ONLY keeps the whole `if`)
- [x] `simple_v2` CV trace test updated to expect both pass names in `passes`
- [x] 657 unit tests + all diff fixtures pass; security review passed
- closurec 0.138.0 → 0.139.0 (Cargo.toml + cli.spec.json + help-markdown fixture)

🤖 Generated with [Claude Code](https://claude.com/claude-code)