### PR TITLE
feat(r-lang): r-parser (R-2) — r.grammar mirrors s.grammar for evaluator reuse

### DIFF
--- a/code/grammars/r.grammar
+++ b/code/grammars/r.grammar
@@ -1,0 +1,149 @@
+# @version 1
+
+# =============================================================================
+# r.grammar — Parser grammar for the R language
+# =============================================================================
+#
+# Drives the generic grammar-driven parser engine (parser::GrammarParser) over
+# the token stream from the r-lexer. See code/specs/R00-r-language.md.
+#
+# DESIGN RULE — RULE NAMES MIRROR s.grammar EXACTLY.
+# R is "an implementation of the S language" and shares S's semantics, so this
+# grammar deliberately uses the SAME rule names as code/grammars/s.grammar
+# (assignment, comparison, additive, …, postfix, call_suffix, primary, …). That
+# lets the shared s-runtime tree-walker — which dispatches on rule_name —
+# evaluate R programs unchanged. The only differences from s.grammar are the
+# handful of places R departs from S (assignment operators, typed NA atoms).
+#
+# Token names (UPPERCASE) come from the R lexer (code/grammars/r.tokens):
+#   NUMBER STRING NAME                literals and identifiers (NAME may contain _)
+#   ASSIGN (<-)  SUPER_ASSIGN (<<-)  RIGHT_ASSIGN (->)  RIGHT_SUPER_ASSIGN (->>)
+#   EQ (=)  — in R, `=` is ALSO assignment (and named-arg binding)
+#   EQEQ (==)  NE (!=)  LT (<)  GT (>)  LE (<=)  GE (>=)
+#   PLUS MINUS STAR SLASH CARET  COLON (:)  PERCENT_OP (%op%)
+#   LPAREN RPAREN  LBRACE RBRACE  LBRACKET RBRACKET  COMMA SEMICOLON  DOLLAR  NEWLINE
+# KEYWORD tokens (matched by exact value, case-sensitively):
+#   "if" "else" "for" "while" "repeat" "function" "break" "next" "in"
+#   "TRUE" "FALSE" "T" "F" "NULL" "NA" "NA_integer_" "NA_real_" "NA_character_"
+#   "Inf" "NaN"
+#
+# (There is NO UNDERSCORE token in R — `_` is part of NAME.)
+#
+# Precedence cascade (lowest binds loosest -> highest binds tightest)
+# -------------------------------------------------------------------
+#   assignment      <-  =  <<-  ->  ->>     (right-associative)
+#   comparison      == != < > <= >=
+#   additive        + -
+#   multiplicative  * /
+#   special         %op%
+#   range           :
+#   unary           - (prefix)
+#   power           ^                       (right-associative)
+#   postfix         f(...)  x[...]  x[[...]]  x$name
+#   primary         atoms, function, if/for/while, blocks, groups
+# =============================================================================
+
+program = { statement_line } ;
+
+statement_line = statement ( NEWLINE | SEMICOLON )
+               | statement
+               | NEWLINE
+               | SEMICOLON ;
+
+statement = expr ;
+
+expr = assignment ;
+
+# =============================================================================
+# assignment — loosest-binding, right-associative. R's assignment operators are
+# `<-`, `<<-`, `->`, `->>`, and `=` (the last also binds named call arguments;
+# the `arg` rule, which tries `NAME EQ expr` first, disambiguates inside calls).
+# `->` / `->>` assign right-to-left; the runtime reverses the direction.
+# =============================================================================
+
+assignment = comparison [ ( ASSIGN | SUPER_ASSIGN | RIGHT_ASSIGN | RIGHT_SUPER_ASSIGN | EQ ) assignment ] ;
+
+comparison = additive [ ( EQEQ | NE | LE | GE | LT | GT ) additive ] ;
+
+additive = multiplicative { ( PLUS | MINUS ) multiplicative } ;
+
+multiplicative = special { ( STAR | SLASH ) special } ;
+
+# `%op%` infix: tighter than `* /`, looser than `:`, matching R.
+special = range { PERCENT_OP range } ;
+
+# `:` binds tighter than arithmetic, so `1:3+1` is c(2,3,4).
+range = unary [ COLON unary ] ;
+
+unary = MINUS unary
+      | power ;
+
+# `^` right-associative; the right operand is `unary` so `2^-3` parses.
+power = postfix [ CARET unary ] ;
+
+# =============================================================================
+# postfix — calls, single/double indexing, and `$`, left-to-right and tightest.
+# `dindex_suffix` precedes `index_suffix` so `[[` matches as a double bracket.
+# =============================================================================
+
+postfix = primary { call_suffix | dindex_suffix | index_suffix | dollar_suffix } ;
+
+call_suffix   = LPAREN [ arg_list ] RPAREN ;
+dindex_suffix = LBRACKET LBRACKET expr RBRACKET RBRACKET ;
+index_suffix  = LBRACKET [ arg_list ] RBRACKET ;
+dollar_suffix = DOLLAR NAME ;
+
+arg_list = arg { COMMA arg } ;
+
+# Named argument (NAME = expr) tried before a positional expression. `==` is the
+# EQEQ token (distinct from EQ), so `f(x == 1)` is a positional comparison.
+arg = NAME EQ expr
+    | expr ;
+
+# =============================================================================
+# primary — atoms and bracketed/keyword-introduced forms. R adds the typed-NA
+# constants (`NA_integer_` etc.), which are KEYWORD tokens here.
+# =============================================================================
+
+primary = NUMBER
+        | STRING
+        | "TRUE"
+        | "FALSE"
+        | "T"
+        | "F"
+        | "NULL"
+        | "NA"
+        | "NA_integer_"
+        | "NA_real_"
+        | "NA_character_"
+        | "Inf"
+        | "NaN"
+        | func_def
+        | if_expr
+        | for_expr
+        | while_expr
+        | repeat_expr
+        | "break"
+        | "next"
+        | block
+        | group
+        | NAME ;
+
+group = LPAREN expr RPAREN ;
+
+block = LBRACE { statement_line } RBRACE ;
+
+func_def = "function" LPAREN [ param_list ] RPAREN expr ;
+
+param_list = param { COMMA param } ;
+
+param = NAME EQ expr
+      | NAME ;
+
+if_expr = "if" LPAREN expr RPAREN expr [ "else" expr ] ;
+
+for_expr = "for" LPAREN NAME "in" expr RPAREN expr ;
+
+while_expr = "while" LPAREN expr RPAREN expr ;
+
+repeat_expr = "repeat" expr ;

--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -243,6 +243,7 @@ members = [
     "pipeline",
     "progress-bar",
     "r-lexer",
+    "r-parser",
     "r-vector",
     "riscv-simulator",
     "rom-bios",

--- a/code/packages/rust/r-parser/BUILD
+++ b/code/packages/rust/r-parser/BUILD
@@ -1,0 +1,1 @@
+cargo test -p coding-adventures-r-parser -- --nocapture

--- a/code/packages/rust/r-parser/CHANGELOG.md
+++ b/code/packages/rust/r-parser/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [0.1.0] - 2026-06-16
+
+### Added
+
+- Initial release of the R parser crate — item R-2 of the R frontend.
+- `parse_r()` / `try_parse_r()` and the `create_r_parser()` factory, producing a
+  `GrammarASTNode` rooted at the `program` rule.
+- Embedded `r.grammar` (`src/_grammar.rs`), generated ahead of time.
+- `r.grammar` mirrors `s.grammar`'s rule names exactly so the shared `s-runtime`
+  tree-walker can evaluate R programs unchanged. The grammar differences from S:
+  - `=` and `->>` are assignment operators (alongside `<-`, `<<-`, `->`);
+  - the typed-`NA` atoms `NA_integer_` / `NA_real_` / `NA_character_`.
+- 11 tests covering R's assignment operators, the `=` named-arg vs assignment
+  distinction, typed NAs, the shared precedence cascade, indexing/`[[`/`$`,
+  functions, control flow, multi-line input, and error reporting.

--- a/code/packages/rust/r-parser/Cargo.toml
+++ b/code/packages/rust/r-parser/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "coding-adventures-r-parser"
+version = "0.1.0"
+edition = "2021"
+description = "Parser for the R language (an implementation of the S language)"
+
+[dependencies]
+grammar-tools = { path = "../grammar-tools" }
+lexer = { path = "../lexer" }
+parser = { path = "../parser" }
+coding-adventures-r-lexer = { path = "../r-lexer" }

--- a/code/packages/rust/r-parser/README.md
+++ b/code/packages/rust/r-parser/README.md
@@ -1,0 +1,53 @@
+# R Parser
+
+A grammar-driven parser for the
+[R language](https://en.wikipedia.org/wiki/R_(programming_language)) — "an
+implementation of the S language" (Ihaka & Gentleman, 1993).
+
+## What it does
+
+Turns the token stream from `coding-adventures-r-lexer` into a parse tree
+(`GrammarASTNode`) using the generic `GrammarParser`, driven by the embedded
+`r.grammar` (`src/_grammar.rs`). It hand-writes no parsing logic.
+
+## Built to share the S evaluator
+
+R shares S's semantics, so `r.grammar` uses the **same rule names** as
+`s.grammar` (`assignment`, `comparison`, `additive`, …, `postfix`,
+`call_suffix`, `primary`, …). The `s-runtime` tree-walker dispatches on
+`rule_name`, so the same evaluator runs R programs once item R-3 wires it up.
+The only grammar differences from S are where R departs from S:
+
+| | S | R |
+|---|---|---|
+| Assignment ops | `<- <<- ->` (and `_`) | `<- <<- -> ->>` and **`=`** |
+| Typed `NA` | — | `NA_integer_`, `NA_real_`, `NA_character_` |
+
+Inside a call, `f(x = 1)` is still a *named argument*: the `arg` rule tries
+`NAME = expr` before the positional `expr`, so `=`-as-assignment at the top level
+and `=`-as-named-arg inside calls coexist.
+
+## Usage
+
+```rust
+use coding_adventures_r_parser::parse_r;
+
+let ast = parse_r("data_frame <- c(1, 2, 3)\nmean(data_frame)\n");
+assert_eq!(ast.rule_name, "program");
+```
+
+Use `try_parse_r` for a `Result` instead of a panic.
+
+## Regenerating the embedded grammar
+
+`src/_grammar.rs` is generated from `code/grammars/r.grammar` with
+`grammar-tools compile-grammar code/grammars/r.grammar -o src/_grammar.rs` —
+never hand-edit it.
+
+## Testing
+
+```sh
+cargo test -p coding-adventures-r-parser
+```
+
+See [`code/specs/R00-r-language.md`](../../../specs/R00-r-language.md).

--- a/code/packages/rust/r-parser/required_capabilities.json
+++ b/code/packages/rust/r-parser/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "rust/r-parser",
+  "capabilities": [],
+  "justification": "Pure computation. The R parser grammar is embedded as generated Rust code; parsing reads only the in-memory token stream."
+}

--- a/code/packages/rust/r-parser/src/_grammar.rs
+++ b/code/packages/rust/r-parser/src/_grammar.rs
@@ -1,0 +1,751 @@
+// AUTO-GENERATED FILE — DO NOT EDIT
+// Source: r.grammar
+// Regenerate with: grammar-tools compile-grammar r.grammar
+//
+// This file embeds a ParserGrammar as native Rust data structures.
+// Call `parser_grammar()` instead of reading and parsing the .grammar file.
+
+use grammar_tools::parser_grammar::{GrammarElement, GrammarRule, ParserGrammar};
+
+pub fn parser_grammar() -> ParserGrammar {
+    ParserGrammar {
+        rules: vec![
+            GrammarRule {
+                name: r#"program"#.to_string(),
+                body: GrammarElement::Repetition {
+                    element: Box::new(GrammarElement::RuleReference {
+                        name: r#"statement_line"#.to_string(),
+                    }),
+                },
+                line_number: 46,
+            },
+            GrammarRule {
+                name: r#"statement_line"#.to_string(),
+                body: GrammarElement::Alternation {
+                    choices: vec![
+                        GrammarElement::Sequence {
+                            elements: vec![
+                                GrammarElement::RuleReference {
+                                    name: r#"statement"#.to_string(),
+                                },
+                                GrammarElement::Group {
+                                    element: Box::new(GrammarElement::Alternation {
+                                        choices: vec![
+                                            GrammarElement::TokenReference {
+                                                name: r#"NEWLINE"#.to_string(),
+                                            },
+                                            GrammarElement::TokenReference {
+                                                name: r#"SEMICOLON"#.to_string(),
+                                            },
+                                        ],
+                                    }),
+                                },
+                            ],
+                        },
+                        GrammarElement::RuleReference {
+                            name: r#"statement"#.to_string(),
+                        },
+                        GrammarElement::TokenReference {
+                            name: r#"NEWLINE"#.to_string(),
+                        },
+                        GrammarElement::TokenReference {
+                            name: r#"SEMICOLON"#.to_string(),
+                        },
+                    ],
+                },
+                line_number: 48,
+            },
+            GrammarRule {
+                name: r#"statement"#.to_string(),
+                body: GrammarElement::RuleReference {
+                    name: r#"expr"#.to_string(),
+                },
+                line_number: 53,
+            },
+            GrammarRule {
+                name: r#"expr"#.to_string(),
+                body: GrammarElement::RuleReference {
+                    name: r#"assignment"#.to_string(),
+                },
+                line_number: 55,
+            },
+            GrammarRule {
+                name: r#"assignment"#.to_string(),
+                body: GrammarElement::Sequence {
+                    elements: vec![
+                        GrammarElement::RuleReference {
+                            name: r#"comparison"#.to_string(),
+                        },
+                        GrammarElement::Optional {
+                            element: Box::new(GrammarElement::Sequence {
+                                elements: vec![
+                                    GrammarElement::Group {
+                                        element: Box::new(GrammarElement::Alternation {
+                                            choices: vec![
+                                                GrammarElement::TokenReference {
+                                                    name: r#"ASSIGN"#.to_string(),
+                                                },
+                                                GrammarElement::TokenReference {
+                                                    name: r#"SUPER_ASSIGN"#.to_string(),
+                                                },
+                                                GrammarElement::TokenReference {
+                                                    name: r#"RIGHT_ASSIGN"#.to_string(),
+                                                },
+                                                GrammarElement::TokenReference {
+                                                    name: r#"RIGHT_SUPER_ASSIGN"#.to_string(),
+                                                },
+                                                GrammarElement::TokenReference {
+                                                    name: r#"EQ"#.to_string(),
+                                                },
+                                            ],
+                                        }),
+                                    },
+                                    GrammarElement::RuleReference {
+                                        name: r#"assignment"#.to_string(),
+                                    },
+                                ],
+                            }),
+                        },
+                    ],
+                },
+                line_number: 64,
+            },
+            GrammarRule {
+                name: r#"comparison"#.to_string(),
+                body: GrammarElement::Sequence {
+                    elements: vec![
+                        GrammarElement::RuleReference {
+                            name: r#"additive"#.to_string(),
+                        },
+                        GrammarElement::Optional {
+                            element: Box::new(GrammarElement::Sequence {
+                                elements: vec![
+                                    GrammarElement::Group {
+                                        element: Box::new(GrammarElement::Alternation {
+                                            choices: vec![
+                                                GrammarElement::TokenReference {
+                                                    name: r#"EQEQ"#.to_string(),
+                                                },
+                                                GrammarElement::TokenReference {
+                                                    name: r#"NE"#.to_string(),
+                                                },
+                                                GrammarElement::TokenReference {
+                                                    name: r#"LE"#.to_string(),
+                                                },
+                                                GrammarElement::TokenReference {
+                                                    name: r#"GE"#.to_string(),
+                                                },
+                                                GrammarElement::TokenReference {
+                                                    name: r#"LT"#.to_string(),
+                                                },
+                                                GrammarElement::TokenReference {
+                                                    name: r#"GT"#.to_string(),
+                                                },
+                                            ],
+                                        }),
+                                    },
+                                    GrammarElement::RuleReference {
+                                        name: r#"additive"#.to_string(),
+                                    },
+                                ],
+                            }),
+                        },
+                    ],
+                },
+                line_number: 66,
+            },
+            GrammarRule {
+                name: r#"additive"#.to_string(),
+                body: GrammarElement::Sequence {
+                    elements: vec![
+                        GrammarElement::RuleReference {
+                            name: r#"multiplicative"#.to_string(),
+                        },
+                        GrammarElement::Repetition {
+                            element: Box::new(GrammarElement::Sequence {
+                                elements: vec![
+                                    GrammarElement::Group {
+                                        element: Box::new(GrammarElement::Alternation {
+                                            choices: vec![
+                                                GrammarElement::TokenReference {
+                                                    name: r#"PLUS"#.to_string(),
+                                                },
+                                                GrammarElement::TokenReference {
+                                                    name: r#"MINUS"#.to_string(),
+                                                },
+                                            ],
+                                        }),
+                                    },
+                                    GrammarElement::RuleReference {
+                                        name: r#"multiplicative"#.to_string(),
+                                    },
+                                ],
+                            }),
+                        },
+                    ],
+                },
+                line_number: 68,
+            },
+            GrammarRule {
+                name: r#"multiplicative"#.to_string(),
+                body: GrammarElement::Sequence {
+                    elements: vec![
+                        GrammarElement::RuleReference {
+                            name: r#"special"#.to_string(),
+                        },
+                        GrammarElement::Repetition {
+                            element: Box::new(GrammarElement::Sequence {
+                                elements: vec![
+                                    GrammarElement::Group {
+                                        element: Box::new(GrammarElement::Alternation {
+                                            choices: vec![
+                                                GrammarElement::TokenReference {
+                                                    name: r#"STAR"#.to_string(),
+                                                },
+                                                GrammarElement::TokenReference {
+                                                    name: r#"SLASH"#.to_string(),
+                                                },
+                                            ],
+                                        }),
+                                    },
+                                    GrammarElement::RuleReference {
+                                        name: r#"special"#.to_string(),
+                                    },
+                                ],
+                            }),
+                        },
+                    ],
+                },
+                line_number: 70,
+            },
+            GrammarRule {
+                name: r#"special"#.to_string(),
+                body: GrammarElement::Sequence {
+                    elements: vec![
+                        GrammarElement::RuleReference {
+                            name: r#"range"#.to_string(),
+                        },
+                        GrammarElement::Repetition {
+                            element: Box::new(GrammarElement::Sequence {
+                                elements: vec![
+                                    GrammarElement::TokenReference {
+                                        name: r#"PERCENT_OP"#.to_string(),
+                                    },
+                                    GrammarElement::RuleReference {
+                                        name: r#"range"#.to_string(),
+                                    },
+                                ],
+                            }),
+                        },
+                    ],
+                },
+                line_number: 73,
+            },
+            GrammarRule {
+                name: r#"range"#.to_string(),
+                body: GrammarElement::Sequence {
+                    elements: vec![
+                        GrammarElement::RuleReference {
+                            name: r#"unary"#.to_string(),
+                        },
+                        GrammarElement::Optional {
+                            element: Box::new(GrammarElement::Sequence {
+                                elements: vec![
+                                    GrammarElement::TokenReference {
+                                        name: r#"COLON"#.to_string(),
+                                    },
+                                    GrammarElement::RuleReference {
+                                        name: r#"unary"#.to_string(),
+                                    },
+                                ],
+                            }),
+                        },
+                    ],
+                },
+                line_number: 76,
+            },
+            GrammarRule {
+                name: r#"unary"#.to_string(),
+                body: GrammarElement::Alternation {
+                    choices: vec![
+                        GrammarElement::Sequence {
+                            elements: vec![
+                                GrammarElement::TokenReference {
+                                    name: r#"MINUS"#.to_string(),
+                                },
+                                GrammarElement::RuleReference {
+                                    name: r#"unary"#.to_string(),
+                                },
+                            ],
+                        },
+                        GrammarElement::RuleReference {
+                            name: r#"power"#.to_string(),
+                        },
+                    ],
+                },
+                line_number: 78,
+            },
+            GrammarRule {
+                name: r#"power"#.to_string(),
+                body: GrammarElement::Sequence {
+                    elements: vec![
+                        GrammarElement::RuleReference {
+                            name: r#"postfix"#.to_string(),
+                        },
+                        GrammarElement::Optional {
+                            element: Box::new(GrammarElement::Sequence {
+                                elements: vec![
+                                    GrammarElement::TokenReference {
+                                        name: r#"CARET"#.to_string(),
+                                    },
+                                    GrammarElement::RuleReference {
+                                        name: r#"unary"#.to_string(),
+                                    },
+                                ],
+                            }),
+                        },
+                    ],
+                },
+                line_number: 82,
+            },
+            GrammarRule {
+                name: r#"postfix"#.to_string(),
+                body: GrammarElement::Sequence {
+                    elements: vec![
+                        GrammarElement::RuleReference {
+                            name: r#"primary"#.to_string(),
+                        },
+                        GrammarElement::Repetition {
+                            element: Box::new(GrammarElement::Alternation {
+                                choices: vec![
+                                    GrammarElement::RuleReference {
+                                        name: r#"call_suffix"#.to_string(),
+                                    },
+                                    GrammarElement::RuleReference {
+                                        name: r#"dindex_suffix"#.to_string(),
+                                    },
+                                    GrammarElement::RuleReference {
+                                        name: r#"index_suffix"#.to_string(),
+                                    },
+                                    GrammarElement::RuleReference {
+                                        name: r#"dollar_suffix"#.to_string(),
+                                    },
+                                ],
+                            }),
+                        },
+                    ],
+                },
+                line_number: 89,
+            },
+            GrammarRule {
+                name: r#"call_suffix"#.to_string(),
+                body: GrammarElement::Sequence {
+                    elements: vec![
+                        GrammarElement::TokenReference {
+                            name: r#"LPAREN"#.to_string(),
+                        },
+                        GrammarElement::Optional {
+                            element: Box::new(GrammarElement::RuleReference {
+                                name: r#"arg_list"#.to_string(),
+                            }),
+                        },
+                        GrammarElement::TokenReference {
+                            name: r#"RPAREN"#.to_string(),
+                        },
+                    ],
+                },
+                line_number: 91,
+            },
+            GrammarRule {
+                name: r#"dindex_suffix"#.to_string(),
+                body: GrammarElement::Sequence {
+                    elements: vec![
+                        GrammarElement::TokenReference {
+                            name: r#"LBRACKET"#.to_string(),
+                        },
+                        GrammarElement::TokenReference {
+                            name: r#"LBRACKET"#.to_string(),
+                        },
+                        GrammarElement::RuleReference {
+                            name: r#"expr"#.to_string(),
+                        },
+                        GrammarElement::TokenReference {
+                            name: r#"RBRACKET"#.to_string(),
+                        },
+                        GrammarElement::TokenReference {
+                            name: r#"RBRACKET"#.to_string(),
+                        },
+                    ],
+                },
+                line_number: 92,
+            },
+            GrammarRule {
+                name: r#"index_suffix"#.to_string(),
+                body: GrammarElement::Sequence {
+                    elements: vec![
+                        GrammarElement::TokenReference {
+                            name: r#"LBRACKET"#.to_string(),
+                        },
+                        GrammarElement::Optional {
+                            element: Box::new(GrammarElement::RuleReference {
+                                name: r#"arg_list"#.to_string(),
+                            }),
+                        },
+                        GrammarElement::TokenReference {
+                            name: r#"RBRACKET"#.to_string(),
+                        },
+                    ],
+                },
+                line_number: 93,
+            },
+            GrammarRule {
+                name: r#"dollar_suffix"#.to_string(),
+                body: GrammarElement::Sequence {
+                    elements: vec![
+                        GrammarElement::TokenReference {
+                            name: r#"DOLLAR"#.to_string(),
+                        },
+                        GrammarElement::TokenReference {
+                            name: r#"NAME"#.to_string(),
+                        },
+                    ],
+                },
+                line_number: 94,
+            },
+            GrammarRule {
+                name: r#"arg_list"#.to_string(),
+                body: GrammarElement::Sequence {
+                    elements: vec![
+                        GrammarElement::RuleReference {
+                            name: r#"arg"#.to_string(),
+                        },
+                        GrammarElement::Repetition {
+                            element: Box::new(GrammarElement::Sequence {
+                                elements: vec![
+                                    GrammarElement::TokenReference {
+                                        name: r#"COMMA"#.to_string(),
+                                    },
+                                    GrammarElement::RuleReference {
+                                        name: r#"arg"#.to_string(),
+                                    },
+                                ],
+                            }),
+                        },
+                    ],
+                },
+                line_number: 96,
+            },
+            GrammarRule {
+                name: r#"arg"#.to_string(),
+                body: GrammarElement::Alternation {
+                    choices: vec![
+                        GrammarElement::Sequence {
+                            elements: vec![
+                                GrammarElement::TokenReference {
+                                    name: r#"NAME"#.to_string(),
+                                },
+                                GrammarElement::TokenReference {
+                                    name: r#"EQ"#.to_string(),
+                                },
+                                GrammarElement::RuleReference {
+                                    name: r#"expr"#.to_string(),
+                                },
+                            ],
+                        },
+                        GrammarElement::RuleReference {
+                            name: r#"expr"#.to_string(),
+                        },
+                    ],
+                },
+                line_number: 100,
+            },
+            GrammarRule {
+                name: r#"primary"#.to_string(),
+                body: GrammarElement::Alternation {
+                    choices: vec![
+                        GrammarElement::TokenReference {
+                            name: r#"NUMBER"#.to_string(),
+                        },
+                        GrammarElement::TokenReference {
+                            name: r#"STRING"#.to_string(),
+                        },
+                        GrammarElement::Literal {
+                            value: r#"TRUE"#.to_string(),
+                        },
+                        GrammarElement::Literal {
+                            value: r#"FALSE"#.to_string(),
+                        },
+                        GrammarElement::Literal {
+                            value: r#"T"#.to_string(),
+                        },
+                        GrammarElement::Literal {
+                            value: r#"F"#.to_string(),
+                        },
+                        GrammarElement::Literal {
+                            value: r#"NULL"#.to_string(),
+                        },
+                        GrammarElement::Literal {
+                            value: r#"NA"#.to_string(),
+                        },
+                        GrammarElement::Literal {
+                            value: r#"NA_integer_"#.to_string(),
+                        },
+                        GrammarElement::Literal {
+                            value: r#"NA_real_"#.to_string(),
+                        },
+                        GrammarElement::Literal {
+                            value: r#"NA_character_"#.to_string(),
+                        },
+                        GrammarElement::Literal {
+                            value: r#"Inf"#.to_string(),
+                        },
+                        GrammarElement::Literal {
+                            value: r#"NaN"#.to_string(),
+                        },
+                        GrammarElement::RuleReference {
+                            name: r#"func_def"#.to_string(),
+                        },
+                        GrammarElement::RuleReference {
+                            name: r#"if_expr"#.to_string(),
+                        },
+                        GrammarElement::RuleReference {
+                            name: r#"for_expr"#.to_string(),
+                        },
+                        GrammarElement::RuleReference {
+                            name: r#"while_expr"#.to_string(),
+                        },
+                        GrammarElement::RuleReference {
+                            name: r#"repeat_expr"#.to_string(),
+                        },
+                        GrammarElement::Literal {
+                            value: r#"break"#.to_string(),
+                        },
+                        GrammarElement::Literal {
+                            value: r#"next"#.to_string(),
+                        },
+                        GrammarElement::RuleReference {
+                            name: r#"block"#.to_string(),
+                        },
+                        GrammarElement::RuleReference {
+                            name: r#"group"#.to_string(),
+                        },
+                        GrammarElement::TokenReference {
+                            name: r#"NAME"#.to_string(),
+                        },
+                    ],
+                },
+                line_number: 108,
+            },
+            GrammarRule {
+                name: r#"group"#.to_string(),
+                body: GrammarElement::Sequence {
+                    elements: vec![
+                        GrammarElement::TokenReference {
+                            name: r#"LPAREN"#.to_string(),
+                        },
+                        GrammarElement::RuleReference {
+                            name: r#"expr"#.to_string(),
+                        },
+                        GrammarElement::TokenReference {
+                            name: r#"RPAREN"#.to_string(),
+                        },
+                    ],
+                },
+                line_number: 132,
+            },
+            GrammarRule {
+                name: r#"block"#.to_string(),
+                body: GrammarElement::Sequence {
+                    elements: vec![
+                        GrammarElement::TokenReference {
+                            name: r#"LBRACE"#.to_string(),
+                        },
+                        GrammarElement::Repetition {
+                            element: Box::new(GrammarElement::RuleReference {
+                                name: r#"statement_line"#.to_string(),
+                            }),
+                        },
+                        GrammarElement::TokenReference {
+                            name: r#"RBRACE"#.to_string(),
+                        },
+                    ],
+                },
+                line_number: 134,
+            },
+            GrammarRule {
+                name: r#"func_def"#.to_string(),
+                body: GrammarElement::Sequence {
+                    elements: vec![
+                        GrammarElement::Literal {
+                            value: r#"function"#.to_string(),
+                        },
+                        GrammarElement::TokenReference {
+                            name: r#"LPAREN"#.to_string(),
+                        },
+                        GrammarElement::Optional {
+                            element: Box::new(GrammarElement::RuleReference {
+                                name: r#"param_list"#.to_string(),
+                            }),
+                        },
+                        GrammarElement::TokenReference {
+                            name: r#"RPAREN"#.to_string(),
+                        },
+                        GrammarElement::RuleReference {
+                            name: r#"expr"#.to_string(),
+                        },
+                    ],
+                },
+                line_number: 136,
+            },
+            GrammarRule {
+                name: r#"param_list"#.to_string(),
+                body: GrammarElement::Sequence {
+                    elements: vec![
+                        GrammarElement::RuleReference {
+                            name: r#"param"#.to_string(),
+                        },
+                        GrammarElement::Repetition {
+                            element: Box::new(GrammarElement::Sequence {
+                                elements: vec![
+                                    GrammarElement::TokenReference {
+                                        name: r#"COMMA"#.to_string(),
+                                    },
+                                    GrammarElement::RuleReference {
+                                        name: r#"param"#.to_string(),
+                                    },
+                                ],
+                            }),
+                        },
+                    ],
+                },
+                line_number: 138,
+            },
+            GrammarRule {
+                name: r#"param"#.to_string(),
+                body: GrammarElement::Alternation {
+                    choices: vec![
+                        GrammarElement::Sequence {
+                            elements: vec![
+                                GrammarElement::TokenReference {
+                                    name: r#"NAME"#.to_string(),
+                                },
+                                GrammarElement::TokenReference {
+                                    name: r#"EQ"#.to_string(),
+                                },
+                                GrammarElement::RuleReference {
+                                    name: r#"expr"#.to_string(),
+                                },
+                            ],
+                        },
+                        GrammarElement::TokenReference {
+                            name: r#"NAME"#.to_string(),
+                        },
+                    ],
+                },
+                line_number: 140,
+            },
+            GrammarRule {
+                name: r#"if_expr"#.to_string(),
+                body: GrammarElement::Sequence {
+                    elements: vec![
+                        GrammarElement::Literal {
+                            value: r#"if"#.to_string(),
+                        },
+                        GrammarElement::TokenReference {
+                            name: r#"LPAREN"#.to_string(),
+                        },
+                        GrammarElement::RuleReference {
+                            name: r#"expr"#.to_string(),
+                        },
+                        GrammarElement::TokenReference {
+                            name: r#"RPAREN"#.to_string(),
+                        },
+                        GrammarElement::RuleReference {
+                            name: r#"expr"#.to_string(),
+                        },
+                        GrammarElement::Optional {
+                            element: Box::new(GrammarElement::Sequence {
+                                elements: vec![
+                                    GrammarElement::Literal {
+                                        value: r#"else"#.to_string(),
+                                    },
+                                    GrammarElement::RuleReference {
+                                        name: r#"expr"#.to_string(),
+                                    },
+                                ],
+                            }),
+                        },
+                    ],
+                },
+                line_number: 143,
+            },
+            GrammarRule {
+                name: r#"for_expr"#.to_string(),
+                body: GrammarElement::Sequence {
+                    elements: vec![
+                        GrammarElement::Literal {
+                            value: r#"for"#.to_string(),
+                        },
+                        GrammarElement::TokenReference {
+                            name: r#"LPAREN"#.to_string(),
+                        },
+                        GrammarElement::TokenReference {
+                            name: r#"NAME"#.to_string(),
+                        },
+                        GrammarElement::Literal {
+                            value: r#"in"#.to_string(),
+                        },
+                        GrammarElement::RuleReference {
+                            name: r#"expr"#.to_string(),
+                        },
+                        GrammarElement::TokenReference {
+                            name: r#"RPAREN"#.to_string(),
+                        },
+                        GrammarElement::RuleReference {
+                            name: r#"expr"#.to_string(),
+                        },
+                    ],
+                },
+                line_number: 145,
+            },
+            GrammarRule {
+                name: r#"while_expr"#.to_string(),
+                body: GrammarElement::Sequence {
+                    elements: vec![
+                        GrammarElement::Literal {
+                            value: r#"while"#.to_string(),
+                        },
+                        GrammarElement::TokenReference {
+                            name: r#"LPAREN"#.to_string(),
+                        },
+                        GrammarElement::RuleReference {
+                            name: r#"expr"#.to_string(),
+                        },
+                        GrammarElement::TokenReference {
+                            name: r#"RPAREN"#.to_string(),
+                        },
+                        GrammarElement::RuleReference {
+                            name: r#"expr"#.to_string(),
+                        },
+                    ],
+                },
+                line_number: 147,
+            },
+            GrammarRule {
+                name: r#"repeat_expr"#.to_string(),
+                body: GrammarElement::Sequence {
+                    elements: vec![
+                        GrammarElement::Literal {
+                            value: r#"repeat"#.to_string(),
+                        },
+                        GrammarElement::RuleReference {
+                            name: r#"expr"#.to_string(),
+                        },
+                    ],
+                },
+                line_number: 149,
+            },
+        ],
+        version: 1,
+    }
+}

--- a/code/packages/rust/r-parser/src/lib.rs
+++ b/code/packages/rust/r-parser/src/lib.rs
@@ -1,0 +1,223 @@
+//! # R Parser — building a syntax tree for the R language.
+//!
+//! Turns the token stream from [`coding_adventures_r_lexer`] into a parse tree
+//! using the generic grammar-driven
+//! [`GrammarParser`](parser::grammar_parser::GrammarParser), driven by the
+//! embedded `r.grammar` (`src/_grammar.rs`). It hand-writes no parsing logic.
+//!
+//! ## Built to share the S evaluator
+//!
+//! R is "an implementation of the S language", so `r.grammar` deliberately uses
+//! the **same rule names** as `s.grammar` (`assignment`, `comparison`,
+//! `additive`, …, `postfix`, `call_suffix`, `primary`, …). The `s-runtime`
+//! tree-walker dispatches on `rule_name`, so the very same evaluator can run R
+//! programs once R-3 wires it up. The only grammar differences from S are the
+//! places R departs from S:
+//!
+//! - **`=` and `->>` are assignment operators** (S uses `_` and lacks `->>`).
+//! - **typed `NA`** atoms `NA_integer_` / `NA_real_` / `NA_character_`.
+//!
+//! ```text
+//! R source
+//!    |
+//!    v
+//! coding_adventures_r_lexer::tokenize_r   ->  Vec<Token>
+//!    |
+//!    v
+//! parser::GrammarParser  (driven by the embedded r.grammar)
+//!    |
+//!    v
+//! GrammarASTNode  <- the tree the (shared) s-runtime walks
+//! ```
+
+use coding_adventures_r_lexer::{tokenize_r, try_tokenize_r};
+use parser::grammar_parser::{GrammarASTNode, GrammarParser};
+mod _grammar;
+
+/// Create a [`GrammarParser`] wired to the R grammar and the tokens of `source`.
+///
+/// # Panics
+///
+/// Panics if tokenization fails. Use [`try_parse_r`] for a non-panicking path.
+pub fn create_r_parser(source: &str) -> GrammarParser {
+    let tokens = tokenize_r(source);
+    GrammarParser::new(tokens, _grammar::parser_grammar())
+}
+
+/// Parse R source text into a [`GrammarASTNode`] rooted at the `program` rule.
+///
+/// # Panics
+///
+/// Panics on a lexical or syntax error. Use [`try_parse_r`] to handle errors.
+///
+/// # Example
+///
+/// ```
+/// use coding_adventures_r_parser::parse_r;
+/// let ast = parse_r("data_frame <- c(1, 2, 3)\nmean(data_frame)\n");
+/// assert_eq!(ast.rule_name, "program");
+/// ```
+pub fn parse_r(source: &str) -> GrammarASTNode {
+    create_r_parser(source)
+        .parse()
+        .unwrap_or_else(|e| panic!("R parse failed: {e}"))
+}
+
+/// Parse R source text, returning a `Result` instead of panicking.
+pub fn try_parse_r(source: &str) -> Result<GrammarASTNode, String> {
+    let tokens = try_tokenize_r(source)?;
+    GrammarParser::new(tokens, _grammar::parser_grammar())
+        .parse()
+        .map_err(|e| e.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use parser::grammar_parser::ASTNodeOrToken;
+
+    fn contains_rule(node: &GrammarASTNode, name: &str) -> bool {
+        node.rule_name == name
+            || node.children.iter().any(|c| match c {
+                ASTNodeOrToken::Node(n) => contains_rule(n, name),
+                ASTNodeOrToken::Token(_) => false,
+            })
+    }
+
+    /// The value of the first operator/keyword token anywhere under `node`
+    /// belonging to a node whose rule is `rule` (used to check which operator a
+    /// construct matched).
+    fn first_token_of(node: &GrammarASTNode, rule: &str) -> Option<String> {
+        fn tok(n: &GrammarASTNode) -> Option<String> {
+            n.children.iter().find_map(|c| match c {
+                ASTNodeOrToken::Token(t) => Some(t.value.clone()),
+                _ => None,
+            })
+        }
+        fn search(n: &GrammarASTNode, rule: &str) -> Option<String> {
+            if n.rule_name == rule {
+                if let Some(t) = tok(n) {
+                    return Some(t);
+                }
+            }
+            n.children.iter().find_map(|c| match c {
+                ASTNodeOrToken::Node(child) => search(child, rule),
+                ASTNodeOrToken::Token(_) => None,
+            })
+        }
+        search(node, rule)
+    }
+
+    fn parses(src: &str) -> bool {
+        try_parse_r(src).is_ok()
+    }
+
+    #[test]
+    fn program_is_the_root() {
+        assert_eq!(parse_r("1\n").rule_name, "program");
+    }
+
+    #[test]
+    fn underscore_name_parses_as_one_identifier() {
+        // The R difference: `data_frame` is one name, used here as an lvalue.
+        assert!(parses("data_frame <- 1\n"));
+    }
+
+    #[test]
+    fn r_assignment_operators_parse() {
+        for src in [
+            "x <- 1\n",
+            "x = 1\n", // R: `=` is assignment
+            "x <<- 1\n",
+            "1 -> x\n",
+            "1 ->> x\n", // R: right super-assignment
+        ] {
+            assert!(parses(src), "should parse: {src:?}");
+            assert!(contains_rule(&parse_r(src), "assignment"), "{src:?}");
+        }
+    }
+
+    #[test]
+    fn equals_assignment_uses_the_eq_token() {
+        // `x = 1` should match the assignment rule with the `=` operator.
+        assert_eq!(
+            first_token_of(&parse_r("x = 1\n"), "assignment").as_deref(),
+            Some("=")
+        );
+    }
+
+    #[test]
+    fn named_argument_still_distinct_from_assignment() {
+        // Inside a call, `mean(x = 1)` is a named argument (tried before the
+        // positional `expr` alternative), not a nested assignment statement.
+        let ast = parse_r("mean(x = 1)\n");
+        assert!(contains_rule(&ast, "arg_list"));
+        assert!(parses("f(x == 1)\n")); // `==` stays a positional comparison
+    }
+
+    #[test]
+    fn typed_na_constants_parse() {
+        for src in ["NA_integer_\n", "NA_real_\n", "NA_character_\n"] {
+            assert!(parses(src), "should parse: {src:?}");
+        }
+    }
+
+    #[test]
+    fn shared_with_s_constructs_parse() {
+        // Arithmetic precedence cascade, sequence, infix, indexing, $, calls.
+        let ast = parse_r("y <- 1:3 + 2 * 3 ^ 2\n");
+        for rule in ["additive", "multiplicative", "power", "range"] {
+            assert!(contains_rule(&ast, rule), "missing {rule}");
+        }
+        assert!(contains_rule(&parse_r("x %in% c(1, 2)\n"), "special"));
+        assert!(contains_rule(&parse_r("x[1]\n"), "index_suffix"));
+        assert!(contains_rule(&parse_r("x[[1]]\n"), "dindex_suffix"));
+        assert!(contains_rule(&parse_r("df$col\n"), "dollar_suffix"));
+        assert!(contains_rule(&parse_r("c(1, 2, 3)\n"), "call_suffix"));
+    }
+
+    #[test]
+    fn functions_and_control_flow_parse() {
+        assert!(contains_rule(
+            &parse_r("sq <- function(v) v * v\n"),
+            "func_def"
+        ));
+        assert!(contains_rule(
+            &parse_r("f <- function(x, n = 1) x + n\n"),
+            "param_list"
+        ));
+        assert!(contains_rule(&parse_r("if (x > 0) 1 else -1\n"), "if_expr"));
+        assert!(contains_rule(
+            &parse_r("for (i in 1:3) print(i)\n"),
+            "for_expr"
+        ));
+        assert!(contains_rule(
+            &parse_r("while (x < 10) x <- x + 1\n"),
+            "while_expr"
+        ));
+        assert!(contains_rule(&parse_r("repeat break\n"), "repeat_expr"));
+        assert!(contains_rule(
+            &parse_r("{\n  a <- 1\n  a + 1\n}\n"),
+            "block"
+        ));
+    }
+
+    #[test]
+    fn multi_line_and_semicolons() {
+        assert!(parses("sum(1,\n    2,\n    3)\n"));
+        assert!(parses("x <- 1; y <- 2; x + y\n"));
+        assert!(parses("mean(x)")); // trailing newline optional
+    }
+
+    #[test]
+    fn syntax_error_is_reported() {
+        assert!(try_parse_r("1 +\n").is_err());
+    }
+
+    #[test]
+    fn the_canonical_r_session_parses() {
+        assert!(parses(
+            "data_frame <- c(1, 2, 3)\nmean(data_frame)\ndata_frame * 10 + c(1, 2)\n"
+        ));
+    }
+}

--- a/code/specs/R00-r-language.md
+++ b/code/specs/R00-r-language.md
@@ -42,13 +42,14 @@ unchanged.
 
 ## §3 Rollout (one item = one PR)
 
-- **R-1 — R00 spec + `r-lexer`** *(this PR)*. `code/grammars/r.tokens` (the S
+- **R-1 — R00 spec + `r-lexer`** ✅ *merged*. `code/grammars/r.tokens` (the S
   token grammar with `_` moved into `NAME`, no `UNDERSCORE`, plus `->>` and the
   `NA_*` constants) and the `r-lexer` crate (a sibling of `s-lexer`, reusing the
   identical bracket-interior newline hook).
-- **R-2 — `r-parser`**. `code/grammars/r.grammar`, mirroring `s.grammar`'s rule
-  names (so the S evaluator can consume the tree unchanged) and adding `=` as a
-  top-level assignment operator.
+- **R-2 — `r-parser`** *(this PR)*. `code/grammars/r.grammar`, mirroring
+  `s.grammar`'s rule names exactly (so the shared `s-runtime` evaluator can
+  consume the tree unchanged) and adding `=` and `->>` as assignment operators
+  plus the typed-`NA` atoms. The `r-parser` crate is a sibling of `s-parser`.
 - **R-3 — `r-runtime` + `r-repl` + the `R` binary**. A vertical slice to a
   working R REPL. The S runtime is refactored to expose evaluation of an
   externally-parsed tree; `r-runtime` parses with `r-parser` and evaluates with


### PR DESCRIPTION
## What

Item **R-2** of the R language frontend (continues [#5946](https://github.com/adhithyan15/coding-adventures/pull/5946), R-1). Adds `code/grammars/r.grammar` and the **`r-parser`** crate.

The design rule: **`r.grammar` uses the same rule names as `s.grammar`** (`assignment`, `comparison`, `additive`, …, `postfix`, `call_suffix`, `primary`, …). The `s-runtime` tree-walker dispatches on `rule_name`, so the *same evaluator* will run R programs unchanged once R-3 wires it up — no duplicated interpreter.

## R's grammar differences from S

| | S | R |
|---|---|---|
| Assignment ops | `<- <<- ->` (and `_`) | `<- <<- -> ->>` **and `=`** |
| Typed `NA` | — | `NA_integer_`, `NA_real_`, `NA_character_` |

Inside a call, `f(x = 1)` stays a *named argument*: the `arg` rule tries `NAME = expr` before the positional `expr`, so top-level `=`-assignment and in-call `=`-named-arg coexist cleanly.

## Verification

- `r.tokens` + `r.grammar` cross-validate (32 tokens, 29 rules); `_grammar.rs` is generated by the grammar-tools CLI.
- 11 unit tests + doctest, all green. `cargo clippy` clean; `cargo fmt` applied.
- `/security-review` on the diff → PASSED (pure computation, no unsafe/I/O; `parse_r`'s documented panic-on-error has the `try_parse_r` non-panicking path).

## Next in the loop

R-3: wire `r-runtime` + `r-repl` + the `R` binary to the shared `s-runtime` evaluator for a working R REPL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)