### PR TITLE
feat(mycin): F3 — chart-fact decomposer training data (second typed IR shape)

### DIFF
--- a/code/specs/data/mycin-2026/train/README.md
+++ b/code/specs/data/mycin-2026/train/README.md
@@ -77,11 +77,35 @@ expert decomposer by data the framework wrote itself, with no human labels. See
 `../bench/BENCH_FINDINGS.md` for how small the *base* models can go with a tolerant
 framework (down to ~1 GB), and `../LOCAL-MODEL-FINDINGS.md` for the privacy thesis.
 
+## Second IR shape: the chart-fact decomposer (`gen_chart_data.py`)
+
+The decomposer's job is to turn *any* messy clinical input into a typed IR. `gen_data.py`
+teaches the **findings** shape (CSF labs / organism-id → diagnosis). `gen_chart_data.py`
+teaches the **chart-fact** shape: a free-text patient chart note → the typed
+`ChartFact{kind, value, span}` list the **chart-as-constraints COP** consumes
+(`../treatment/antibiotics/chart_to_cop.py`). The structured path already exists
+(`../fhir/fhir_to_chartfacts.py` maps a FHIR bundle → ChartFacts); this is its **prose
+counterpart** — the messy-input front door to the constraint solver (the CC-7 enabler).
+
+Same backward-generation + byte-provenance discipline: sample a chart-fact set from the
+**closed** vocabulary (exactly what `compile_cop` maps), a teacher writes a chart note
+stating them (+ a non-charting distractor), and the gold IR is derived from the note with
+verbatim spans + a justified `discard` list. The headline guarantee
+(`test_gen_chart_data.py`) is the **F3→F2 consumability contract**: every `(kind, value)`
+the generator can sample is fed through `compile_cop` and asserted *not discarded* — so the
+decomposer's gold can never contain a chart fact the COP would silently drop (closed-vocab
+adherence proven against the actual downstream consumer, not just a schema).
+
+```sh
+python3 gen_chart_data.py --n 200 --teacher llama3.1:8b   # → data/chart_{train,valid}.jsonl
+python3 test_gen_chart_data.py                            # 6 pure tests (no Ollama/MLX)
+```
+
 ## What is and isn't committed
 
-Source only: `gen_data.py`, `eval_specialist.py`, this README. The `.gitignore`
-excludes `.venv/`, `data/` (generated pairs), `adapters/` (trained weights), and
-`*.log` — those are reproducible from the scripts + a base model, and the weights
+Source only: `gen_data.py`, `gen_chart_data.py`, `eval_specialist.py`, this README. The
+`.gitignore` excludes `.venv/`, `data/` (generated pairs), `adapters/` (trained weights),
+and `*.log` — those are reproducible from the scripts + a base model, and the weights
 are large/environment-specific. Regenerate with the workflow above.
 
 ## Honest limits

--- a/code/specs/data/mycin-2026/train/gen_chart_data.py
+++ b/code/specs/data/mycin-2026/train/gen_chart_data.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+"""gen_chart_data.py — training data for the CHART-FACT decomposer (F3, new IR shape).
+
+REL-14 taught the decomposer the *findings* IR shape (CSF labs / organism-id, with
+byte-provenance + discard + inference). This adds the SECOND typed IR shape the system
+needs: the **chart-fact IR** — turning a messy free-text patient chart note into the
+typed `ChartFact{kind, value, span}` list that the chart-as-constraints COP consumes
+(`treatment/antibiotics/chart_to_cop.py`). The structured path already exists
+(`fhir/fhir_to_chartfacts.py` maps a FHIR bundle → ChartFacts); this is its PROSE
+counterpart, the messy-input front door to the constraint solver (the CC-7 enabler).
+
+Same BACKWARD-GENERATION discipline as gen_data.py (so the label is exact, never a
+teacher's fallible extraction):
+
+  1. sample a chart-fact set from the CLOSED chart-fact vocabulary — this IS the gold IR;
+  2. a teacher writes a natural chart note stating exactly those facts (+ a non-charting
+     distractor or two);
+  3. the gold IR is derived from the note with BYTE PROVENANCE — each fact's supporting
+     span located verbatim (reusing gen_data.find_span); a distractor that lands in the
+     prose is recorded as a justified `discard`.
+
+The closed vocabulary is exactly what `chart_to_cop.compile_cop` maps — so every gold
+fact is guaranteed CONSUMABLE by the COP (no unmapped kinds). test_gen_chart_data pins
+that F3→F2 contract: feed each sampled (kind, value) through compile_cop and assert it
+is NOT discarded.
+
+Output: data/chart_train.jsonl + data/chart_valid.jsonl in MLX chat format.
+
+Usage:  python3 gen_chart_data.py [--n 200] [--teacher llama3.1:8b] [--seed 0]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import random
+import sys
+import urllib.request
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(HERE))
+import gen_data  # noqa: E402  (reuse find_span / _norm — one byte-provenance matcher)
+
+OUT = HERE / "data"
+OLLAMA = "http://127.0.0.1:11434/api/generate"
+
+# The CLOSED chart-fact vocabulary — kind → list of (value, [surface phrases]). EVERY
+# (kind, value) here is mapped by chart_to_cop.compile_cop (verified in the tests), so the
+# decomposer can never emit a chart fact the COP would silently drop. Surfaces are the
+# natural phrasings a chart note might use; the teacher is steered to one of them.
+CHART_PROFILES: dict[str, list[tuple[str, list[str]]]] = {
+    "age_band": [
+        ("older_adult", ["a 72-year-old", "an elderly patient aged 80", "76-year-old woman"]),
+        ("adult", ["a 45-year-old man", "a 38-year-old", "adult patient"]),
+    ],
+    "immune_status": [
+        ("immunocompromised", ["on chemotherapy", "post-transplant on immunosuppression",
+                               "HIV with a low CD4 count", "on chronic high-dose steroids"]),
+    ],
+    "setting": [
+        ("post_neurosurgical", ["post-operative day 3 from a craniotomy",
+                                "recent neurosurgery", "status post posterior fossa resection"]),
+        ("csf_shunt", ["has a ventriculoperitoneal shunt", "a CSF shunt is in place"]),
+    ],
+    "allergy": [
+        ("penicillin", ["anaphylaxis to penicillin", "a severe penicillin allergy"]),
+        ("cephalosporin", ["a documented cephalosporin allergy", "hives with cephalosporins"]),
+    ],
+    "renal_status": [
+        ("renal_severe", ["an eGFR of 12", "on hemodialysis", "a creatinine of 5.2"]),
+        ("renal_moderate", ["an eGFR of 45", "moderate chronic kidney disease"]),
+    ],
+    "interaction": [
+        ("nephrotoxin_interaction", ["also receiving tacrolimus", "concurrent amphotericin B",
+                                     "on another nephrotoxic agent"]),
+    ],
+    "pregnancy": [
+        ("present", ["28 weeks pregnant", "G2P1 at 30 weeks gestation", "currently pregnant"]),
+    ],
+    "weight": [
+        ("80", ["weighs 80 kg"]), ("65", ["body weight 65 kg"]), ("90", ["90 kg"]),
+    ],
+    "culture_resistance": [
+        ("ceftriaxone:n_meningitidis", ["CSF isolate resistant to ceftriaxone",
+                                        "the meningococcus is ceftriaxone-resistant on sensitivities"]),
+    ],
+}
+
+# Non-charting DISTRACTORS — details a note may carry that map to NO chart-fact kind.
+# Recorded in the gold `discard` so the decomposer learns to set them aside with a reason
+# rather than coin a spurious ChartFact.
+DISTRACTORS = [
+    ("drove himself to the emergency department", "logistics, not a chart fact the COP consumes"),
+    ("lives at home with his wife", "social history, not a controlled chart-fact kind"),
+    ("blood pressure was 132/84 mmHg", "vital sign, no constraint rule maps it"),
+    ("has no known sick contacts", "exposure history, not a controlled chart-fact kind"),
+    ("prefers to be seen by the morning team", "preference, not a chart fact"),
+]
+
+
+def sample_chart(rng: random.Random) -> list[dict]:
+    """Sample a realistic chart-fact set: an age band, plus 1-4 other facts. Returns
+    dicts {kind, value, surfaces}. Abstain case (empty) lets the model learn to emit no
+    chart facts from a note that states none."""
+    if rng.random() < 0.12:
+        return []
+    facts: list[dict] = []
+    # Almost every chart states an age band.
+    k = "age_band"
+    val, surf = rng.choice(CHART_PROFILES[k])
+    facts.append({"kind": k, "value": val, "surfaces": surf})
+    others = [kk for kk in CHART_PROFILES if kk != "age_band"]
+    for kk in rng.sample(others, rng.randint(1, 4)):
+        val, surf = rng.choice(CHART_PROFILES[kk])
+        facts.append({"kind": kk, "value": val, "surfaces": surf})
+    return facts
+
+
+def prompt_for_chart(note: str) -> str:
+    """The decompose prompt the model is trained on — turn a chart note into the typed
+    chart-fact IR over the CLOSED vocabulary, with a span for each fact + a discard list."""
+    kinds = ", ".join(sorted(CHART_PROFILES))
+    return (
+        "You are a clinical chart decomposer. Read the patient chart note and emit ONLY a "
+        "JSON object with typed chart facts drawn from this CLOSED vocabulary of kinds: "
+        f"{kinds}. For each fact give {{\"kind\", \"value\", \"span\"}} where `span` is the "
+        "VERBATIM substring of the note supporting it. Put any detail that does NOT map to a "
+        "kind in `discard` as {\"span\", \"reason\"}. Do not invent facts.\n\n"
+        f"CHART NOTE:\n{note}\n\nJSON:"
+    )
+
+
+def teacher_chart_note(teacher: str, facts: list[dict], distractors: list[tuple[str, str]]) -> str:
+    lines = []
+    for f in facts:
+        phrase = random.choice(f["surfaces"])
+        lines.append(f'- {f["kind"]} = {f["value"]}  (phrase like: "{phrase}")')
+    distractor_ask = ""
+    if distractors:
+        ds = "; ".join(f'"{p}"' for p, _ in distractors)
+        distractor_ask = f" Also include, verbatim or nearly so, this non-clinical aside: {ds}."
+    if not facts:
+        ask = ("Write a realistic 1-2 sentence patient chart note that states NO age, allergy, "
+               "renal, pregnancy, immune, setting, weight, or culture-resistance detail (e.g. only "
+               "a chief complaint)." + distractor_ask)
+    else:
+        ask = ("Write a realistic 2-4 sentence patient chart note (ED/admission style) that states "
+               "EXACTLY these facts and no other controlled facts. Vary the wording naturally. Do "
+               "NOT name a diagnosis or a drug." + distractor_ask + "\n\nFACTS:\n" + "\n".join(lines))
+    body = json.dumps({"model": teacher, "prompt": ask, "stream": False,
+                       "options": {"temperature": 0.7, "num_predict": 220}}).encode()
+    req = urllib.request.Request(OLLAMA, data=body, headers={"Content-Type": "application/json"})
+    with urllib.request.urlopen(req, timeout=120) as r:  # noqa: S310 (fixed localhost)
+        return json.loads(r.read())["response"].strip()
+
+
+def build_gold_chart_ir(note: str, facts: list[dict],
+                        distractors: list[tuple[str, str]]) -> dict:
+    """Construct the gold chart-fact IR with BYTE PROVENANCE + DISCARD. Each sampled fact's
+    supporting span is located verbatim in the note (reusing gen_data.find_span): a verbatim
+    span → type:"stated"; none (teacher paraphrased past recognition) → type:"inferred" with
+    an empty span. Each distractor appearing in the note becomes a discard {span, reason}.
+    Keeps kind/value (what compile_cop consumes) + adds span/type (the provenance)."""
+    gold_facts = []
+    for f in facts:
+        phrases = list(f.get("surfaces", [])) + [f["value"].replace("_", " ").replace(":", " ")]
+        span = gen_data.find_span(note, phrases)
+        gold_facts.append({"kind": f["kind"], "value": f["value"],
+                           "span": span, "type": "stated" if span else "inferred"})
+    discard = []
+    for phrase, reason in distractors:
+        dspan = gen_data.find_span(note, [phrase])
+        if dspan:
+            discard.append({"span": dspan, "reason": reason})
+    return {"chart_facts": gold_facts, "discard": discard}
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--n", type=int, default=200)
+    ap.add_argument("--teacher", default="llama3.1:8b")
+    ap.add_argument("--seed", type=int, default=0)
+    args = ap.parse_args()
+    rng = random.Random(args.seed)
+
+    OUT.mkdir(exist_ok=True)
+    records = []
+    for i in range(args.n):
+        facts = sample_chart(rng)
+        distractors = rng.sample(DISTRACTORS, rng.choice([0, 0, 1, 1, 2]))
+        try:
+            note = teacher_chart_note(args.teacher, facts, distractors)
+        except Exception as e:  # noqa: BLE001
+            print(f"  [{i}] teacher error: {e}", file=sys.stderr)
+            continue
+        if not note or len(note) < 20:
+            continue
+        gold = build_gold_chart_ir(note, facts, distractors)
+        records.append({"messages": [{"role": "user", "content": prompt_for_chart(note)},
+                                     {"role": "assistant", "content": json.dumps(gold)}]})
+        if (i + 1) % 25 == 0:
+            print(f"  generated {i + 1}/{args.n}", flush=True)
+
+    rng.shuffle(records)
+    n_valid = max(1, len(records) // 10)
+    valid, trainset = records[:n_valid], records[n_valid:]
+    (OUT / "chart_train.jsonl").write_text("".join(json.dumps(r) + "\n" for r in trainset))
+    (OUT / "chart_valid.jsonl").write_text("".join(json.dumps(r) + "\n" for r in valid))
+    n_abstain = sum(1 for r in records
+                    if json.loads(r["messages"][1]["content"])["chart_facts"] == [])
+    print(f"\ngen_chart_data: {len(trainset)} train + {len(valid)} valid chart-decompose "
+          f"examples ({n_abstain} abstain) -> {OUT}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/code/specs/data/mycin-2026/train/test_gen_chart_data.py
+++ b/code/specs/data/mycin-2026/train/test_gen_chart_data.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""test_gen_chart_data.py — guard the chart-fact decomposer data generator (F3).
+
+Pure checks (no teacher / Ollama / MLX). The headline is the F3→F2 CONSUMABILITY
+contract: every (kind, value) the generator can sample is mapped by the chart-as-
+constraints compiler (`chart_to_cop.compile_cop`) — i.e. the decomposer's gold IR can
+never contain a chart fact the COP would silently discard. Plus: the gold carries
+verbatim byte-provenance spans, an unstated fact degrades to type:inferred, distractors
+become justified discards, and the abstain case yields no chart facts.
+"""
+
+from __future__ import annotations
+
+import random
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+MYCIN = HERE.parent
+sys.path.insert(0, str(HERE))
+sys.path.insert(0, str(MYCIN / "warm"))
+sys.path.insert(0, str(MYCIN / "treatment" / "antibiotics"))
+import chart_to_cop as cc  # noqa: E402  (the F2 consumer — closed-vocab gate)
+import gen_chart_data as gcd  # noqa: E402
+
+
+def test_every_sampled_chart_fact_is_consumable_by_the_cop() -> None:
+    # The F3→F2 contract: each (kind, value) the decomposer may emit must compile into a
+    # COP input, never land in compile_cop's discards (which would mean an unmapped fact).
+    for kind, options in gcd.CHART_PROFILES.items():
+        for value, surfaces in options:
+            cop = cc.compile_cop([cc.ChartFact(kind, value, surfaces[0])])
+            unmapped = [d for d in cop.discards if d["fact"].startswith(f"{kind}=")]
+            assert not unmapped, f"{kind}={value} is discarded by compile_cop: {unmapped}"
+
+
+def test_sampled_charts_stay_in_vocab_and_include_an_age_band() -> None:
+    for seed in range(40):
+        facts = gcd.sample_chart(random.Random(seed))
+        if not facts:
+            continue  # abstain case
+        assert facts[0]["kind"] == "age_band", facts
+        for f in facts:
+            assert f["kind"] in gcd.CHART_PROFILES
+            vals = {v for v, _ in gcd.CHART_PROFILES[f["kind"]]}
+            assert f["value"] in vals, f
+
+
+def test_build_gold_grounds_stated_facts_with_spans() -> None:
+    note = ("A 72-year-old man, post-operative day 3 from a craniotomy, with an eGFR of 12; "
+            "he drove himself to the emergency department.")
+    facts = [{"kind": "age_band", "value": "older_adult", "surfaces": ["a 72-year-old"]},
+             {"kind": "setting", "value": "post_neurosurgical",
+              "surfaces": ["post-operative day 3 from a craniotomy"]},
+             {"kind": "renal_status", "value": "renal_severe", "surfaces": ["an eGFR of 12"]}]
+    distractors = [("drove himself to the emergency department", "logistics, not a chart fact")]
+    gold = gcd.build_gold_chart_ir(note, facts, distractors)
+    assert len(gold["chart_facts"]) == 3
+    for gf in gold["chart_facts"]:
+        for k in ("kind", "value", "span", "type"):
+            assert k in gf, gf
+        assert gf["span"] and gf["span"].lower() in note.lower(), gf
+        assert gf["type"] == "stated"
+    # the distractor that appears in the note is recorded as a justified discard
+    assert len(gold["discard"]) == 1 and gold["discard"][0]["span"].lower() in note.lower()
+    assert gold["discard"][0]["reason"]
+    # and the gold facts are consumable by the COP (end-to-end F3→F2 on a real note)
+    cop = cc.compile_cop([cc.ChartFact(gf["kind"], gf["value"], gf["span"])
+                          for gf in gold["chart_facts"]])
+    assert "post_neurosurgical" in cop.organisms or cop.organisms  # scenario selected
+    assert not any(d["fact"].split("=")[0] in {"age_band", "setting", "renal_status"}
+                   for d in cop.discards)
+
+
+def test_unstated_fact_degrades_to_inferred_empty_span() -> None:
+    # The note does NOT mention pregnancy → the fact can only be a non-verbatim inference.
+    note = "A 45-year-old man with a headache."
+    facts = [{"kind": "age_band", "value": "adult", "surfaces": ["a 45-year-old man"]},
+             {"kind": "pregnancy", "value": "present", "surfaces": ["28 weeks pregnant"]}]
+    gold = gcd.build_gold_chart_ir(note, facts, [])
+    by_kind = {gf["kind"]: gf for gf in gold["chart_facts"]}
+    assert by_kind["age_band"]["span"] and by_kind["age_band"]["type"] == "stated"
+    assert by_kind["pregnancy"]["span"] == "" and by_kind["pregnancy"]["type"] == "inferred"
+
+
+def test_prompt_lists_the_closed_vocabulary() -> None:
+    p = gcd.prompt_for_chart("A 50-year-old with fever.")
+    for kind in ("age_band", "allergy", "renal_status", "culture_resistance"):
+        assert kind in p, kind
+    assert "discard" in p and "span" in p
+
+
+def test_distractor_pool_well_formed() -> None:
+    assert gcd.DISTRACTORS
+    for phrase, reason in gcd.DISTRACTORS:
+        assert isinstance(phrase, str) and len(phrase) >= 4 and isinstance(reason, str) and reason
+
+
+def main() -> int:
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    failed = 0
+    for t in tests:
+        try:
+            t()
+            print(f"  PASS  {t.__name__}")
+        except AssertionError as exc:
+            failed += 1
+            print(f"  FAIL  {t.__name__}: {exc}")
+    print(f"\ntest_gen_chart_data: {len(tests) - failed}/{len(tests)} passed")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## F3 — the decomposer learns the chart-fact IR shape (prose chart → typed ChartFact)

REL-14 (#5933) taught the decomposer the **findings** IR shape (CSF labs / organism-id → diagnosis, with byte-provenance + discard + inference). This adds the **second** shape the system needs: the **chart-fact IR** — turning a free-text patient chart note into the typed `ChartFact{kind, value, span}` list the **chart-as-constraints COP** consumes (`treatment/antibiotics/chart_to_cop.py`).

The structured path already exists (`fhir/fhir_to_chartfacts.py`: FHIR bundle → ChartFacts); this is its **prose counterpart** — the messy-input front door to the constraint solver. It **connects F3 (decomposer) → F2 (diagnostics-with-constraints)** and is the CC-7 enabler.

### Same discipline, reused matcher
Backward-generation + byte-provenance (reuses `gen_data.find_span` — one matcher): sample a chart-fact set from the **closed** vocabulary, a teacher writes a chart note stating exactly those facts (+ a non-charting distractor), and the gold IR is derived from the note with verbatim spans (`stated`) or empty span (`inferred`) + a justified `discard` list. Vocabulary = exactly what `compile_cop` maps (age_band, immune_status, setting, allergy, renal_status, interaction, pregnancy, weight, culture_resistance).

### Headline — the F3→F2 consumability contract
`test_gen_chart_data.py` feeds **every** `(kind, value)` the generator can sample through `chart_to_cop.compile_cop` and asserts it is **not discarded** — so the decomposer's gold can never contain a chart fact the COP would silently drop. Closed-vocab adherence proven against the *actual downstream consumer*, not just a schema. Also tested: verbatim spans for stated facts, `type:inferred`+empty-span for an unstated fact, distractor→discard, abstain→no facts, prompt lists the closed vocab. 6/6 pure tests (no Ollama/MLX); ruff clean.

The MLX LoRA training run is a separate opt-in step; this PR is the generator + pure tests. `gen_data.py` untouched (only imports `find_span`); its test still green. Security review passed (fixed-localhost Ollama POST, no shell/eval, no path traversal, json-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)