### PR TITLE
feat(closurec): SIMPLE pipeline gains dce (dead-code elimination)

### DIFF
--- a/code/programs/rust/closurec/CHANGELOG.md
+++ b/code/programs/rust/closurec/CHANGELOG.md
@@ -2,6 +2,39 @@
 
 All notable changes to the `coding-adventures-closurec` binary will be documented in this file.
 
+## [0.140.0] - 2026-06-16
+
+### Added (CLOC12.157 — SIMPLE pipeline gains `dce`)
+
+The `--compilation_level SIMPLE` pass pipeline is now
+`constant-fold → fold-control-flow → dce` (was `constant-fold → fold-control-flow`).
+The dead-code-elimination pass does two things, both scoped to block bodies:
+
+1. **Dead-after-terminator** — drops every statement after a `return` in a
+   block (`function f(){g();return 1;dead()}` ⇒ `function f(){g();return 1}`).
+2. **Empty-statement removal** — sweeps `;` no-ops out of a block. This is what
+   cleans up the empty statement `fold-control-flow` leaves behind when it folds
+   away an `if (false) {…}` with no `else`.
+
+dce runs **last**: both it and `fold-control-flow` declare
+`depends_on = ["constant-fold"]` (so constant-fold runs first), but neither
+depends on the other, so registration order is the tie-breaker — and we register
+dce after fold-control-flow so it can sweep that pass's `;` debris.
+
+- `SIMPLE_PASS_NAMES` is now `["constant-fold", "fold-control-flow", "dce"]`;
+  the `passes` field in the `simple_v2` correlation-vector trace lists all three.
+- `run_simple_pipeline` registers `DcePass` after `FoldControlFlowPass`.
+
+### Verified
+- New `tests/diff/simple-dce/` end-to-end fixture +
+  `tests/diff_simple_dce.rs`: a function body exercising all three passes ⇒
+  `function f(){keep();return 1};` (the dead `if (4 > 5) {…}` folds and is swept,
+  the post-`return` `alsoDead()` is dropped).
+- New unit tests `simple_dce_drops_dead_after_return`,
+  `simple_dce_sweeps_folded_if_empty_statement` (all three passes composing), and
+  `simple_dce_whitespace_only_keeps_dead_code`.
+- Existing `simple_v2` CV test updated to expect all three pass names in `passes`.
+
 ## [0.139.0] - 2026-06-16
 
 ### Added (CLOC12.156 — SIMPLE pipeline gains `fold-control-flow`)

--- a/code/programs/rust/closurec/Cargo.toml
+++ b/code/programs/rust/closurec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closurec"
-version = "0.139.0"
+version = "0.140.0"
 edition = "2021"
 description = "closurec — CLI driver for the Closure Compiler clone. Mirrors the upstream Java Closure Compiler's command-line flag surface (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility. Per CLOC08."
 

--- a/code/programs/rust/closurec/README.md
+++ b/code/programs/rust/closurec/README.md
@@ -124,7 +124,7 @@ body fills in.**
 | Level | What it does |
 |-------|--------------|
 | `WHITESPACE_ONLY` | Strips comments and inter-token whitespace only. Token-level; never parses to a typed AST. |
-| `SIMPLE` | Runs the typed-AST optimization pipeline — parse → bridge → passes → emit. Today the pipeline is `constant-fold → fold-control-flow` (e.g. `1 + 2` ⇒ `3`; `if (2 > 3) {a} else {b}` ⇒ `{b}`); more passes land one PR at a time. Falls back to `WHITESPACE_ONLY` if the source uses a not-yet-supported construct, so it never errors on valid input. |
+| `SIMPLE` | Runs the typed-AST optimization pipeline — parse → bridge → passes → emit. Today the pipeline is `constant-fold → fold-control-flow → dce` (e.g. `1 + 2` ⇒ `3`; `if (2 > 3) {a} else {b}` ⇒ `{b}`; code after a `return` is dropped); more passes land one PR at a time. Falls back to `WHITESPACE_ONLY` if the source uses a not-yet-supported construct, so it never errors on valid input. |
 | `ADVANCED` / `BUNDLE` / `TRANSPILE_ONLY` | Identity passthrough for now — the typed passes specific to these levels (tree-shaking, property renaming, etc.) land in follow-up work. |
 
 The SIMPLE pipeline:

--- a/code/programs/rust/closurec/cli.spec.json
+++ b/code/programs/rust/closurec/cli.spec.json
@@ -2,7 +2,7 @@
   "cli_builder_spec_version": "1.0",
   "name": "closurec",
   "description": "closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.",
-  "version": "0.139.0",
+  "version": "0.140.0",
   "parsing_mode": "gnu",
   "flags": [
     { "id": "browser_featureset_year", "long": "browser_featureset_year", "type": "integer", "default": 0, "description": "Shortcut for defining goog.FEATURESET_YEAR=YYYY (minimum 2012)." },

--- a/code/programs/rust/closurec/src/run.rs
+++ b/code/programs/rust/closurec/src/run.rs
@@ -213,13 +213,22 @@ pub fn transform_source(
 /// names are the passes' own canonical `Pass::name()` values; they also
 /// become the `passes` field in the correlation-vector trace.
 ///
-/// The list is in execution order, but ordering is ultimately enforced
-/// by the pipeline's dependency graph: `fold-control-flow` declares
-/// `depends_on = ["constant-fold"]`, so the topo-sort runs constant-fold
-/// first regardless. That ordering matters — constant-fold turns a
-/// comparison like `2 > 3` into the literal `false`, which is what lets
-/// fold-control-flow then prune `if (2 > 3) {A} else {B}` down to `B`.
-const SIMPLE_PASS_NAMES: &[&str] = &["constant-fold", "fold-control-flow"];
+/// The list is in execution order. Ordering is enforced two ways: every
+/// pass that needs a predecessor declares it via `Pass::depends_on`, and
+/// where two passes are mutually independent the pipeline falls back to
+/// *registration order* as the tie-breaker. Both `fold-control-flow` and
+/// `dce` declare `depends_on = ["constant-fold"]` (so constant-fold always
+/// runs first), but neither depends on the other — so we register, and
+/// thus run, `fold-control-flow` before `dce` on purpose:
+///
+/// - constant-fold turns `2 > 3` into the literal `false`;
+/// - fold-control-flow then prunes `if (false) {A}` to an empty `;`;
+/// - dce then sweeps that empty statement (and any code after a `return`)
+///   away.
+///
+/// Running dce last means it cleans up the `;` debris the control-flow
+/// folder leaves behind.
+const SIMPLE_PASS_NAMES: &[&str] = &["constant-fold", "fold-control-flow", "dce"];
 
 /// Run the SIMPLE optimization pipeline over a bridged `Program` and
 /// emit the result as JavaScript text.
@@ -248,6 +257,7 @@ fn run_simple_pipeline(
 ) -> Option<String> {
     use coding_adventures_closure_emitter::{emit, EmitOptions};
     use coding_adventures_closure_pass_constant_fold::ConstantFoldPass;
+    use coding_adventures_closure_pass_dce::DcePass;
     use coding_adventures_closure_pass_fold_control_flow::FoldControlFlowPass;
     use coding_adventures_closure_pass_pipeline::PassPipeline;
     use coding_adventures_correlation_vector::CVLog;
@@ -259,12 +269,16 @@ fn run_simple_pipeline(
     // log accepts contributions and drops them — zero overhead.
     let mut pass_cv = CVLog::new(false);
 
-    // Registration order is not significant — the pipeline topo-sorts
-    // on each pass's `depends_on`, so `fold-control-flow` (which depends
-    // on `constant-fold`) always runs after it.
+    // The pipeline topo-sorts on each pass's `depends_on`, with
+    // registration order as the tie-breaker between independent passes.
+    // `fold-control-flow` and `dce` both depend on `constant-fold` (so it
+    // runs first) but not on each other, so registration order is what
+    // puts `fold-control-flow` before `dce` — letting dce sweep the empty
+    // `;` statements the control-flow folder leaves behind.
     let mut pipeline = PassPipeline::new();
     pipeline.add(Box::new(ConstantFoldPass::new()));
     pipeline.add(Box::new(FoldControlFlowPass::new()));
+    pipeline.add(Box::new(DcePass::new()));
 
     let optimized = match pipeline.run(program, &sidecar, &mut pass_cv) {
         Ok(out) => out.program,
@@ -5538,6 +5552,68 @@ mod tests {
     }
 
     #[test]
+    fn simple_dce_drops_dead_after_return() {
+        // CLOC12.157: the SIMPLE pipeline now runs dce after
+        // fold-control-flow. Code after a `return` in a block is
+        // unreachable, so dce removes it.
+        let cfg = CompilerConfig {
+            compilation: crate::config::CompilationConfig {
+                level: crate::config::CompilationLevel::Simple,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let out = transform_source("function f() { g(); return 1; dead(); }", &cfg)
+            .expect("ok");
+        assert_eq!(
+            out, "function f(){g();return 1};",
+            "dce must drop the statement after the return"
+        );
+    }
+
+    #[test]
+    fn simple_dce_sweeps_folded_if_empty_statement() {
+        // All three passes compose: constant-fold turns `4 > 5` into
+        // `false`, fold-control-flow turns `if (false) {…}` into an
+        // empty `;`, and dce sweeps that empty statement out of the
+        // block — leaving just the `return`.
+        let cfg = CompilerConfig {
+            compilation: crate::config::CompilationConfig {
+                level: crate::config::CompilationLevel::Simple,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let out =
+            transform_source("function f() { if (4 > 5) { x(); } return 2; }", &cfg)
+                .expect("ok");
+        assert_eq!(
+            out, "function f(){return 2};",
+            "dce must sweep the empty statement left by fold-control-flow"
+        );
+    }
+
+    #[test]
+    fn simple_dce_whitespace_only_keeps_dead_code() {
+        // Companion — the SAME input under WHITESPACE_ONLY keeps the
+        // dead statement, proving the elimination is the SIMPLE
+        // pipeline's doing.
+        let cfg = CompilerConfig {
+            compilation: crate::config::CompilationConfig {
+                level: crate::config::CompilationLevel::WhitespaceOnly,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let out = transform_source("function f() { g(); return 1; dead(); }", &cfg)
+            .expect("ok");
+        assert_eq!(
+            out, "function f(){g();return 1;dead()};",
+            "whitespace_only must NOT drop dead code"
+        );
+    }
+
+    #[test]
     fn simple_level_bridge_ok_status_in_cv() {
         // When the source parses cleanly, the CV contribution for the
         // `compilation_level` stage must carry bridge_status = "ok".
@@ -5575,7 +5651,7 @@ mod tests {
         );
         // The pass pipeline must be recorded in the trace, in order.
         assert!(
-            body.contains("\"passes\":[\"constant-fold\",\"fold-control-flow\"]"),
+            body.contains("\"passes\":[\"constant-fold\",\"fold-control-flow\",\"dce\"]"),
             "expected passes list in CV sidecar: {body}"
         );
         let _ = fs::remove_dir_all(&dir);

--- a/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
@@ -2,7 +2,7 @@
 
 closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.
 
-Version: 0.139.0
+Version: 0.140.0
 
 ## Flags
 

--- a/code/programs/rust/closurec/tests/diff/simple-dce/README.md
+++ b/code/programs/rust/closurec/tests/diff/simple-dce/README.md
@@ -1,0 +1,32 @@
+# Fixture: `simple-dce`
+
+End-to-end oracle for the `dce` (dead-code elimination) pass in
+`--compilation_level SIMPLE` (CLOC12.157, PR-3).
+
+| File | Role |
+|------|------|
+| `flags.txt` | `--compilation_level SIMPLE --js input/a.js` |
+| `input/a.js` | A function whose body has dead branches and post-`return` code |
+| `expected.stdout` | `function f(){keep();return 1};` |
+
+The SIMPLE pipeline is now `constant-fold → fold-control-flow → dce`. This
+fixture shows all three composing inside one function body:
+
+| Source line | Fate |
+|-------------|------|
+| `keep();` | live, before the `return` — retained |
+| `if (4 > 5) { neverRuns(); }` | `4>5`⇒`false` ⇒ `if(false){…}`⇒`;` ⇒ dce sweeps the empty statement |
+| `return 1;` | block terminator — retained |
+| `alsoDead();` | after the `return` — dce drops it (dead-after-terminator) |
+
+dce runs **last** so it cleans up the empty `;` debris the control-flow
+folder leaves behind, and removes unreachable code after a `return`. The same
+input under `WHITESPACE_ONLY` keeps every statement verbatim.
+
+Regenerate the expected file after an intentional behavior change:
+
+```sh
+cargo run -- --compilation_level SIMPLE \
+    --js tests/diff/simple-dce/input/a.js \
+    > tests/diff/simple-dce/expected.stdout
+```

--- a/code/programs/rust/closurec/tests/diff/simple-dce/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/simple-dce/expected.stdout
@@ -1,0 +1,2 @@
+function f(){keep();return 1};
+

--- a/code/programs/rust/closurec/tests/diff/simple-dce/flags.txt
+++ b/code/programs/rust/closurec/tests/diff/simple-dce/flags.txt
@@ -1,0 +1,4 @@
+--compilation_level
+SIMPLE
+--js
+tests/diff/simple-dce/input/a.js

--- a/code/programs/rust/closurec/tests/diff/simple-dce/input/a.js
+++ b/code/programs/rust/closurec/tests/diff/simple-dce/input/a.js
@@ -1,0 +1,22 @@
+// SIMPLE-level dead-code elimination (CLOC12.157).
+//
+// The SIMPLE pipeline now runs `dce` after `constant-fold` and
+// `fold-control-flow`. This function exercises both of dce's jobs at
+// once, and shows all three passes composing inside one block:
+//
+//   - `keep();`                  — live, before the return: retained.
+//   - `if (4 > 5) { neverRuns(); }`
+//        constant-fold turns `4 > 5` into `false`;
+//        fold-control-flow turns `if (false) {…}` into an empty `;`;
+//        dce then sweeps that empty statement out of the block.
+//   - `return 1;`                — the block terminator: retained.
+//   - `alsoDead();`              — after the return: dce drops it
+//        (dead-after-terminator).
+//
+// Under WHITESPACE_ONLY none of this happens — every statement survives.
+function f() {
+  keep();
+  if (4 > 5) { neverRuns(); }
+  return 1;
+  alsoDead();
+}

--- a/code/programs/rust/closurec/tests/diff_simple_dce.rs
+++ b/code/programs/rust/closurec/tests/diff_simple_dce.rs
@@ -1,0 +1,62 @@
+//! Integration test for the `tests/diff/simple-dce/` fixture.
+//!
+//! Exercises the CLOC12.157 addition of the `dce` (dead-code
+//! elimination) pass to the `--compilation_level SIMPLE` pipeline. The
+//! pipeline is now `constant-fold → fold-control-flow → dce`, and this
+//! fixture's function body exercises both of dce's jobs while showing
+//! all three passes composing inside one block:
+//!
+//! ```text
+//! function f() {
+//!   keep();                      // live, retained
+//!   if (4 > 5) { neverRuns(); }  // 4>5⇒false ⇒ if(false){…}⇒; ⇒ dce sweeps it
+//!   return 1;                    // terminator, retained
+//!   alsoDead();                  // dead-after-return ⇒ dce drops it
+//! }
+//! ⇒ function f(){keep();return 1};
+//! ```
+//!
+//! The same input under WHITESPACE_ONLY keeps every statement (see the
+//! `simple_dce_*` unit tests in `src/run.rs`).
+//!
+//! This is the behavioral oracle for the SIMPLE level's dead-code
+//! elimination: when we later diff against the real
+//! `closure-compiler.jar`, this expected file is the diff target.
+
+use std::process::Command;
+
+const BINARY: &str = env!("CARGO_BIN_EXE_closurec");
+
+fn read_flags() -> Vec<String> {
+    let raw = std::fs::read_to_string("tests/diff/simple-dce/flags.txt")
+        .expect("read flags.txt");
+    raw.lines()
+        .filter(|l| !l.is_empty())
+        .map(|s| s.to_string())
+        .collect()
+}
+
+#[test]
+fn simple_dce_fixture_matches_expected_stdout() {
+    let flags = read_flags();
+    let out = Command::new(BINARY)
+        .args(&flags)
+        .output()
+        .expect("run closurec");
+
+    assert!(
+        out.status.success(),
+        "exit: {:?}, stderr: {}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stderr),
+    );
+
+    let actual = String::from_utf8_lossy(&out.stdout);
+    let expected = std::fs::read_to_string("tests/diff/simple-dce/expected.stdout")
+        .expect("read expected.stdout");
+    assert_eq!(
+        actual.trim_end_matches('\n'),
+        expected.trim_end_matches('\n'),
+        "mismatch.\nflags: {flags:?}\nactual:\n{actual}\nexpected:\n{expected}",
+    );
+}


### PR DESCRIPTION
## Summary

The `--compilation_level SIMPLE` pass pipeline is now **`constant-fold → fold-control-flow → dce`** (was `constant-fold → fold-control-flow`). The dead-code-elimination pass does two things, both scoped to block bodies:

1. **Dead-after-terminator** — drops every statement after a `return` in a block: `function f(){g();return 1;dead()}` ⇒ `function f(){g();return 1}`.
2. **Empty-statement removal** — sweeps `;` no-ops out of a block, including the empty statement `fold-control-flow` leaves behind when it folds away an `if (false) {…}` with no `else`.

dce runs **last**: both it and `fold-control-flow` declare `depends_on = ["constant-fold"]` (so constant-fold runs first), but neither depends on the other, so registration order is the tie-breaker — dce is registered after fold-control-flow so it can sweep that pass's `;` debris.

### All three passes composing

The fixture's function body shows the whole pipeline cooperate:

```js
function f() {
  keep();                      // live — retained
  if (4 > 5) { neverRuns(); }  // 4>5⇒false ⇒ if(false){…}⇒; ⇒ dce sweeps it
  return 1;                    // terminator — retained
  alsoDead();                  // dead-after-return ⇒ dce drops it
}
```
⇒ `function f(){keep();return 1};`

## Dependency

Builds on [#5950](https://github.com/adhithyan15/coding-adventures/pull/5950) (SIMPLE fold-control-flow pipeline), already merged.

## Test plan

- [x] New `tests/diff/simple-dce/` fixture + `tests/diff_simple_dce.rs`: ⇒ `function f(){keep();return 1};`
- [x] New unit tests: `simple_dce_drops_dead_after_return`, `simple_dce_sweeps_folded_if_empty_statement` (all three passes composing), `simple_dce_whitespace_only_keeps_dead_code`
- [x] `simple_v2` CV trace test updated to expect all three pass names in `passes`
- [x] 657 unit tests + all diff fixtures pass; security review passed
- closurec 0.139.0 → 0.140.0 (Cargo.toml + cli.spec.json + help-markdown fixture)

🤖 Generated with [Claude Code](https://claude.com/claude-code)