### PR TITLE
feat(mycin): CC-6 — insurance / step-therapy, dual clinical-vs-reimbursement regimen

### DIFF
--- a/code/specs/data/mycin-2026/CHART-AS-CONSTRAINTS.md
+++ b/code/specs/data/mycin-2026/CHART-AS-CONSTRAINTS.md
@@ -170,8 +170,15 @@ risks Y") — decision support, not a hidden choice.
   `derive()` surfaces the decision + delay_risk + rationale + threshold. The decision is reusable
   (not meningitis-specific). The ≤60-min meningitis threshold is authored-debt (IDSA), flagged for
   **CC-5b** spider grounding.
-- **CC-6 — insurance / step-therapy (§5):** precedence constraints + the dual
-  clinical-vs-reimbursement regimen output; ground a sample payer step-therapy policy.
+- **CC-6 — insurance / step-therapy (§5). ✅ DONE.** A payer step-therapy rule ("won't
+  approve Y until X tried") enters as a `step_therapy` chart fact (`restricted:prerequisite`)
+  + `prior_failed` facts (drugs already tried); the precedence `x_Y ≤ tried_X` is realized as
+  a reimbursement-only exclusion (`reimbursement_blocked`). `derive()` solves TWICE: `regimen`
+  is the clinically optimal one; `reimbursement` carries the payer-covered regimen, the
+  `blocked` drugs, whether it `differs_from_clinical`, and a note. Reimbursement infeasibility
+  (a rule blocking a clinically-forced drug → covered = INFEASIBLE) is surfaced **distinctly**
+  from clinical infeasibility → physician override / appeal on medical necessity. Grounding a
+  real published payer policy is the **CC-6b** follow-up.
 - **CC-7 — full chart drive-through:** wire CH (chart→IR + de-identification) into the COP so
   a whole de-identified FHIR chart produces a regimen with the full audit trail.
 

--- a/code/specs/data/mycin-2026/treatment/antibiotics/chart_to_cop.py
+++ b/code/specs/data/mycin-2026/treatment/antibiotics/chart_to_cop.py
@@ -73,6 +73,8 @@ class Cop:
     weights: tuple[int, int] = reg.DEFAULT_WEIGHTS            # CC-4 objective blend (w_cost, w_tox)
     culture_status: str = ""                                 # CC-5 pending | resulted (timing decision)
     clinical_status: str = ""                                # CC-5 critical | unstable | stable
+    step_therapy: set[tuple[str, str]] = field(default_factory=set)  # CC-6 (restricted, prerequisite)
+    tried: set[str] = field(default_factory=set)             # CC-6 drugs already tried/failed
     constraints: list[dict] = field(default_factory=list)   # provenance per constraint
     discards: list[dict] = field(default_factory=list)       # facts not mapped + reason
 
@@ -215,6 +217,25 @@ def compile_cop(facts: list[ChartFact]) -> Cop:
             else:
                 cop.discards.append({"fact": f"clinical_status={f.value}",
                                      "reason": "unrecognized clinical status (want critical/unstable/stable)"})
+        elif f.kind == "step_therapy":
+            # CC-6: a payer step-therapy rule "won't approve Y until X tried", value
+            # "restricted:prerequisite" (e.g. "cefepime:meropenem" — wait, no: the
+            # restricted drug is the one needing a prior trial). Format "Y:X" = Y requires X.
+            restricted, _, prereq = f.value.partition(":")
+            if restricted and prereq:
+                cop.step_therapy.add((restricted, prereq))
+                cop.constraints.append({"type": "step_therapy", "from": f"step_therapy={f.value}",
+                                        "rule": f"payer won't reimburse {restricted} until {prereq} is tried",
+                                        "detail": [restricted, prereq], "span": f.span})
+            else:
+                cop.discards.append({"fact": f"step_therapy={f.value}",
+                                     "reason": "malformed step_therapy value (want restricted:prerequisite)"})
+        elif f.kind == "prior_failed":
+            # CC-6: a drug already tried (and failed) — satisfies a step-therapy prerequisite.
+            cop.tried.add(f.value)
+            cop.constraints.append({"type": "prior_treatment", "from": f"prior_failed={f.value}",
+                                    "rule": f"{f.value} already tried/failed → satisfies its step-therapy prerequisite",
+                                    "span": f.span})
         elif f.kind == "objective_priority":
             # CC-4: the chart's treatment priority selects the cost/side-effect objective
             # blend. "cost" (default) = cheapest acceptable regimen; "low_toxicity" weights
@@ -293,6 +314,13 @@ def dose_infeasible(cli: Path, drugs: list[str], risks: set[str], weight: float)
     return out
 
 
+def reimbursement_blocked(step_therapy: set[tuple[str, str]], tried: set[str]) -> set[str]:
+    """CC-6: the drugs a payer won't reimburse because their step-therapy prerequisite
+    hasn't been tried — the precedence `x_Y ≤ tried_X` realized as a reimbursement-only
+    exclusion. A restricted drug Y is blocked iff its prerequisite X is not in `tried`."""
+    return {restricted for restricted, prereq in step_therapy if prereq not in tried}
+
+
 def derive(cli: Path, facts: list[ChartFact], disease: str = "meningitis") -> dict:
     """Compile the chart → COP, solve it, and return the regimen with provenance.
     Dose feasibility (CC-2) is folded into the cover: a drug with no safe-and-effective
@@ -311,13 +339,42 @@ def derive(cli: Path, facts: list[ChartFact], disease: str = "meningitis") -> di
     # A drug leaves the cover if it has no safe dose (CC-2) OR is contraindicated (CC-3).
     excluded_drugs = set(undosable) | cop.contraindicated
     # CC-4: solve under the chart's cost/side-effect objective blend (default tier-only).
+    # `regimen` is the CLINICALLY optimal one — what the physician should give, ignoring
+    # the payer. (CC-4 objective blend applies.)
     res = nsc.solve(cli, cop.organisms, cop.exclusions, cop.defeated, excluded_drugs, cop.weights)
     # CC-5: the empiric-now vs await-culture decision, from the chart's timing inputs.
     timing = decide_timing(disease, cop.culture_status, cop.clinical_status)
+    # CC-6: when the chart carries payer step-therapy rules, ALSO solve the reimbursement-
+    # feasible regimen (the clinically-best drugs whose step-therapy prerequisite is unmet
+    # are excluded) and surface BOTH so the tradeoff — and any medical-necessity appeal — is
+    # explicit. Reimbursement infeasibility is distinct from clinical infeasibility.
+    reimbursement = None
+    if cop.step_therapy:
+        blocked = reimbursement_blocked(cop.step_therapy, cop.tried)
+        cov = nsc.solve(cli, cop.organisms, cop.exclusions, cop.defeated,
+                        excluded_drugs | blocked, cop.weights)
+        differs = cov["regimen"] != res["regimen"]
+        if cov["regimen"] is None:
+            note = ("reimbursement-INFEASIBLE under step therapy: the only regimens covering "
+                    "these organisms need a drug the payer blocks until its prerequisite is "
+                    "tried → physician override / appeal on medical necessity")
+        elif differs:
+            note = ("the payer-covered regimen differs from the clinical optimum because step "
+                    "therapy blocks a clinically-preferred drug — give the clinical one on "
+                    "medical necessity, or step through the prerequisite")
+        else:
+            note = "step therapy does not change the regimen (prerequisites already satisfied)"
+        reimbursement = {
+            "step_therapy": sorted(map(list, cop.step_therapy)), "tried": sorted(cop.tried),
+            "blocked": sorted(blocked), "covered_regimen": cov["regimen"],
+            "covered_outcome": cov["outcome"], "covered_conflict": cov.get("iis"),
+            "differs_from_clinical": differs, "note": note,
+        }
     return {
         "regimen": res["regimen"], "outcome": res["outcome"],
         "cost": res.get("cost"), "conflict": res.get("iis"),
         "objective": res.get("objective"), "timing": timing,
+        "reimbursement": reimbursement,
         "organisms": cop.organisms, "exclusions": sorted(cop.exclusions),
         "defeated": sorted(map(list, cop.defeated)),
         "risks": sorted(cop.risks), "dose_infeasible": sorted(undosable),

--- a/code/specs/data/mycin-2026/treatment/antibiotics/test_chart_to_cop.py
+++ b/code/specs/data/mycin-2026/treatment/antibiotics/test_chart_to_cop.py
@@ -170,6 +170,60 @@ def test_timing_facts_compile_and_surface_in_derive():
     assert r["timing"]["decision"] == "treat_now_empiric" and r["timing"]["delay_risk"] == "high"
 
 
+def test_step_therapy_facts_compile_and_reimbursement_blocked_logic():
+    # CC-6: a step_therapy rule "restricted:prerequisite" + a prior_failed drug compile
+    # into the payer-policy COP inputs with provenance.
+    cop = cc.compile_cop([cc.ChartFact("step_therapy", "cefepime:meropenem", "payer policy"),
+                          cc.ChartFact("prior_failed", "ampicillin", "failed amp last week")])
+    assert ("cefepime", "meropenem") in cop.step_therapy
+    assert "ampicillin" in cop.tried
+    assert any(c["type"] == "step_therapy" for c in cop.constraints)
+    assert any(c["type"] == "prior_treatment" for c in cop.constraints)
+    bad = cc.compile_cop([cc.ChartFact("step_therapy", "no_colon_here")])
+    assert not bad.step_therapy and any("step_therapy" in d["fact"] for d in bad.discards)
+    # The precedence x_Y ≤ tried_X: Y blocked iff its prerequisite X is not in `tried`.
+    assert cc.reimbursement_blocked({("cefepime", "meropenem")}, set()) == {"cefepime"}
+    assert cc.reimbursement_blocked({("cefepime", "meropenem")}, {"meropenem"}) == set()
+
+
+def test_dual_clinical_vs_reimbursement_regimen():
+    cli = decide_mod.find_cli()
+    if cli is None:
+        return
+    # post-neurosurgical: clinical optimum uses cefepime. A payer step-therapy rule
+    # "cefepime needs meropenem tried first" (meropenem NOT tried) → the reimbursement-
+    # covered regimen drops cefepime and differs; the clinical regimen is unchanged.
+    r = cc.derive(cli, [cc.ChartFact("setting", "post_neurosurgical"),
+                        cc.ChartFact("step_therapy", "cefepime:meropenem", "payer policy")])
+    assert "cefepime" in r["regimen"]                       # clinical optimum keeps cefepime
+    rb = r["reimbursement"]
+    assert rb is not None and rb["blocked"] == ["cefepime"] and rb["differs_from_clinical"]
+    assert "cefepime" not in (rb["covered_regimen"] or [])  # payer-covered regimen drops it
+    assert rb["covered_regimen"] is not None and rb["note"]
+    # Once meropenem has been tried/failed, the prerequisite is satisfied → no divergence.
+    r2 = cc.derive(cli, [cc.ChartFact("setting", "post_neurosurgical"),
+                         cc.ChartFact("step_therapy", "cefepime:meropenem"),
+                         cc.ChartFact("prior_failed", "meropenem")])
+    assert not r2["reimbursement"]["differs_from_clinical"]
+    # No payer rules → no reimbursement block at all (additive, opt-in).
+    assert cc.derive(cli, [cc.ChartFact("age_band", "adult")])["reimbursement"] is None
+
+
+def test_step_therapy_can_be_reimbursement_infeasible_distinct_from_clinical():
+    cli = decide_mod.find_cli()
+    if cli is None:
+        return
+    # A step-therapy rule that blocks a CLINICALLY-FORCED drug (vancomycin is the only
+    # resistant-pneumococcus coverer) → a clinically valid regimen exists, but it is
+    # reimbursement-INFEASIBLE → surfaced distinctly for physician override / appeal.
+    r = cc.derive(cli, [cc.ChartFact("age_band", "adult"),
+                        cc.ChartFact("step_therapy", "vancomycin:meropenem")])
+    assert r["regimen"] is not None                          # clinically feasible
+    rb = r["reimbursement"]
+    assert rb["covered_regimen"] is None and rb["covered_outcome"] == "infeasible"
+    assert rb["differs_from_clinical"] and "appeal" in rb["note"]
+
+
 def test_unmapped_fact_is_discarded_not_ignored():
     # No silent drops: a fact with no rule lands in discards WITH a reason.
     cop = cc.compile_cop([cc.ChartFact("age_band", "adult"),
@@ -210,6 +264,9 @@ def main() -> int:
     test_objective_breakdown_surfaced_with_chart_weights()
     test_decide_timing_decision_table()
     test_timing_facts_compile_and_surface_in_derive()
+    test_step_therapy_facts_compile_and_reimbursement_blocked_logic()
+    test_dual_clinical_vs_reimbursement_regimen()
+    test_step_therapy_can_be_reimbursement_infeasible_distinct_from_clinical()
     test_dose_infeasibility_folds_into_the_cover()
     test_pregnancy_contraindicates_drugs()
     test_pregnancy_engine_behaviour()


### PR DESCRIPTION
## CC-6 — payer step-therapy as constraints, with a dual clinical-vs-reimbursement regimen (§5)

Adds insurance step-therapy to the chart-as-constraints COP. A payer rule ("won't approve **Y** until **X** tried/failed") enters as a `step_therapy` chart fact (`restricted:prerequisite`, e.g. `cefepime:meropenem`) + `prior_failed` facts (drugs already tried). The precedence `x_Y ≤ tried_X` is realized as a **reimbursement-only exclusion** (`reimbursement_blocked`): Y is blocked iff its prerequisite isn't in `tried`.

### Dual output
`derive()` now solves **twice**:
- **`regimen`** — the *clinically optimal* regimen (what the physician should give), ignoring the payer.
- **`reimbursement`** — `{covered_regimen, blocked, differs_from_clinical, covered_outcome, covered_conflict, note}`: the *payer-feasible* regimen with step-blocked drugs removed.

Worked example (post-neurosurgical, rule "cefepime needs meropenem first"):
```
clinical      → {cefepime, vancomycin}
reimbursement → blocked {cefepime}, covered {ceftriaxone, meropenem, vancomycin}, differs ✓
```

### Reimbursement infeasibility is distinct from clinical
A rule blocking a clinically-**forced** drug (vancomycin — the only resistant-pneumococcus coverer) yields a valid clinical regimen but `covered = INFEASIBLE` → the note flags **physician override / appeal on medical necessity**. When the prerequisite has been tried (`prior_failed`), the block lifts and the regimens converge.

### Additive / opt-in
`reimbursement` is `null` when the chart has no payer rules — the four canonical regimens + board management tactic are unchanged (verified: all treatment tests + downstream `test_board_eval` **12/12** green, ruff clean). Tests: compile + provenance + malformed-discard, the `reimbursement_blocked` precedence, dual divergence + convergence-when-tried, and reimbursement-infeasible-distinct-from-clinical. Security review passed (arbitrary fact strings only filter real formulary drugs — never reach the emitted program). Spec `CHART-AS-CONSTRAINTS.md` CC-6 marked done; CC-6b (ground a real payer policy) teed up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)