### PR TITLE
feat(web01a-2): ShardedWebServer — parallel WebApp dispatch across reactor shards

### DIFF
--- a/code/packages/rust/web-core/CHANGELOG.md
+++ b/code/packages/rust/web-core/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog — web-core
 
+## 0.2.0 (2026-06-16)
+
+### Added
+
+- **`ShardedWebServer` (WEB01a-2)** — a parallel counterpart to `WebServer`. It
+  runs `WebApp::handle` across `worker_count` reactor shards (via
+  `embeddable-http-server`'s `ShardedHttpServer`), so requests on different
+  connections are dispatched concurrently. The same `Arc<WebApp>` is shared
+  across all shards (immutable after construction — no locking; `handle` is
+  `&self` + `Send + Sync`). Platform constructors `bind_kqueue_sharded` /
+  `bind_epoll_sharded` / `bind_windows_sharded`, plus `serve` / `local_addr` /
+  `worker_count` / `stop_handle`; `on_server_start` / `on_server_stop` fire once,
+  exactly like `WebServer`.
+- This is **opt-in**: the single-reactor `WebServer` is unchanged and remains the
+  default. Hook/routing/`halt` semantics are identical (they run inside
+  `app.handle` on the owning shard); HTTP/1.1 per-connection response ordering is
+  preserved because each connection stays on one shard.
+- Tests: `sharded_web_server_handles_requests_concurrently` deterministically
+  proves cross-shard parallelism (observed max in-flight handlers ≥ 2 — serial
+  dispatch can never exceed 1), and an `#[ignore]`d CPU-bound benchmark
+  `sharded_web_server_cpu_bound_throughput_scales` demonstrates wall-clock
+  scaling (~5.3× on 14 cores for a busy-loop handler). See
+  `code/specs/WEB01-async-web-core.md`.
+
 ## 0.1.0 (2026-04-23)
 
 Initial release.

--- a/code/packages/rust/web-core/Cargo.toml
+++ b/code/packages/rust/web-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "web-core"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "Generic Rack/WSGI-like HTTP application layer built on embeddable-http-server"
 license = "MIT"

--- a/code/packages/rust/web-core/src/lib.rs
+++ b/code/packages/rust/web-core/src/lib.rs
@@ -55,6 +55,6 @@ pub use hooks::{HookRegistry, LogLevel};
 pub use request::WebRequest;
 pub use response::WebResponse;
 pub use router::{Handler, Route, Router, RouteLookupResult, RouteMatch};
-pub use server::WebServer;
+pub use server::{ShardedWebServer, WebServer};
 
 pub const VERSION: &str = "0.1.0";

--- a/code/packages/rust/web-core/src/server.rs
+++ b/code/packages/rust/web-core/src/server.rs
@@ -11,8 +11,8 @@
 use std::net::{SocketAddr, ToSocketAddrs};
 use std::sync::Arc;
 
-use embeddable_http_server::{HttpServerOptions, HttpServer};
-use tcp_runtime::PlatformError;
+use embeddable_http_server::{HttpServer, HttpServerOptions, ShardedHttpServer};
+use tcp_runtime::{PlatformError, ShardedStopHandle};
 
 use crate::app::WebApp;
 
@@ -125,6 +125,133 @@ impl WebServer<transport_platform::windows::WindowsTransportPlatform> {
             options,
             app,
         )
+    }
+}
+
+/// A **parallel** `WebApp` server (WEB01a-2): the sharded counterpart of
+/// [`WebServer`].
+///
+/// [`WebServer`] drives every connection on one reactor thread, so a slow or
+/// CPU-bound handler stalls every other connection. `ShardedWebServer` runs the
+/// dispatch (`app.handle`) across `worker_count` reactor shards (a
+/// [`ShardedHttpServer`]), so requests on different connections are handled
+/// **concurrently**. The same `Arc<WebApp>` is shared across all shards — it is
+/// immutable after construction, so no locking is needed; `WebApp::handle` is
+/// `&self` and `Send + Sync`.
+///
+/// This is **opt-in**: the existing [`WebServer`] (single reactor) is unchanged
+/// and remains the default. Callers choose parallelism explicitly by binding a
+/// `ShardedWebServer` with `worker_count > 1`. Handler semantics are identical
+/// (hooks, routing, `halt`, etc. all run inside `app.handle` on the owning
+/// shard); only the degree of concurrency changes. HTTP/1.1 response ordering on
+/// a single connection is preserved because each connection stays on one shard.
+pub struct ShardedWebServer<P> {
+    inner: ShardedHttpServer<P>,
+    app: Arc<WebApp>,
+}
+
+impl<P> ShardedWebServer<P> {
+    /// The local socket address the server is bound to.
+    pub fn local_addr(&self) -> SocketAddr {
+        self.inner.local_addr()
+    }
+
+    /// The number of reactor shards (the handler-parallelism degree).
+    pub fn worker_count(&self) -> usize {
+        self.inner.worker_count()
+    }
+
+    /// A handle that can stop every shard from another thread.
+    pub fn stop_handle(&self) -> ShardedStopHandle {
+        self.inner.stop_handle()
+    }
+}
+
+impl<P> ShardedWebServer<P>
+where
+    P: transport_platform::TransportPlatform + Send + 'static,
+{
+    /// Run all shard reactors until stopped. Blocks the calling thread; after it
+    /// returns, the `on_server_stop` hooks fire (once, like [`WebServer::serve`]).
+    pub fn serve(&mut self) -> Result<(), PlatformError> {
+        let result = self.inner.serve();
+        self.app.fire_server_stop();
+        result
+    }
+}
+
+#[cfg(any(
+    target_os = "macos",
+    target_os = "freebsd",
+    target_os = "openbsd",
+    target_os = "netbsd",
+    target_os = "dragonfly"
+))]
+impl ShardedWebServer<transport_platform::bsd::KqueueTransportPlatform> {
+    /// Bind a kqueue-backed sharded server (macOS / BSD) with `worker_count`
+    /// reactor shards. The `app`'s `on_server_start` hooks fire before returning.
+    pub fn bind_kqueue_sharded<A: ToSocketAddrs>(
+        addr: A,
+        options: HttpServerOptions,
+        worker_count: usize,
+        app: Arc<WebApp>,
+    ) -> Result<Self, PlatformError> {
+        let app_clone = Arc::clone(&app);
+        let inner = ShardedHttpServer::bind_kqueue_sharded(
+            addr,
+            options,
+            worker_count,
+            move |request| app_clone.handle(request),
+        )?;
+        let local_addr = inner.local_addr();
+        app.fire_server_start(local_addr);
+        Ok(Self { inner, app })
+    }
+}
+
+#[cfg(target_os = "linux")]
+impl ShardedWebServer<transport_platform::linux::EpollTransportPlatform> {
+    /// Bind an epoll-backed sharded server (Linux) with `worker_count` reactor
+    /// shards. The `app`'s `on_server_start` hooks fire before returning.
+    pub fn bind_epoll_sharded<A: ToSocketAddrs>(
+        addr: A,
+        options: HttpServerOptions,
+        worker_count: usize,
+        app: Arc<WebApp>,
+    ) -> Result<Self, PlatformError> {
+        let app_clone = Arc::clone(&app);
+        let inner = ShardedHttpServer::bind_epoll_sharded(
+            addr,
+            options,
+            worker_count,
+            move |request| app_clone.handle(request),
+        )?;
+        let local_addr = inner.local_addr();
+        app.fire_server_start(local_addr);
+        Ok(Self { inner, app })
+    }
+}
+
+#[cfg(target_os = "windows")]
+impl ShardedWebServer<transport_platform::windows::WindowsTransportPlatform> {
+    /// Bind a Windows IOCP-backed sharded server with `worker_count` reactor
+    /// shards. The `app`'s `on_server_start` hooks fire before returning.
+    pub fn bind_windows_sharded<A: ToSocketAddrs>(
+        addr: A,
+        options: HttpServerOptions,
+        worker_count: usize,
+        app: Arc<WebApp>,
+    ) -> Result<Self, PlatformError> {
+        let app_clone = Arc::clone(&app);
+        let inner = ShardedHttpServer::bind_windows_sharded(
+            addr,
+            options,
+            worker_count,
+            move |request| app_clone.handle(request),
+        )?;
+        let local_addr = inner.local_addr();
+        app.fire_server_start(local_addr);
+        Ok(Self { inner, app })
     }
 }
 

--- a/code/packages/rust/web-core/tests/web_core_test.rs
+++ b/code/packages/rust/web-core/tests/web_core_test.rs
@@ -506,3 +506,201 @@ fn e2e_on_server_stop_fires_after_serve_exits() {
     thread::sleep(Duration::from_millis(100));
     assert_eq!(stopped.load(Ordering::SeqCst), 1, "on_server_stop should have fired once");
 }
+
+// ---------------------------------------------------------------------------
+// WEB01a-2 — ShardedWebServer: parallel request handling across reactor shards
+// ---------------------------------------------------------------------------
+
+/// Bind and start a `ShardedWebServer` on port 0 with `worker_count` shards,
+/// returning the port and a stop handle. Mirrors `start_server` but parallel.
+fn start_sharded_server(
+    app: WebApp,
+    worker_count: usize,
+) -> (u16, usize, tcp_runtime::ShardedStopHandle) {
+    use web_core::ShardedWebServer;
+    let app = Arc::new(app);
+
+    #[cfg(any(
+        target_os = "macos",
+        target_os = "freebsd",
+        target_os = "openbsd",
+        target_os = "netbsd",
+        target_os = "dragonfly"
+    ))]
+    let mut server = ShardedWebServer::bind_kqueue_sharded(
+        "127.0.0.1:0",
+        HttpServerOptions::default(),
+        worker_count,
+        Arc::clone(&app),
+    )
+    .expect("bind kqueue sharded");
+
+    #[cfg(target_os = "linux")]
+    let mut server = ShardedWebServer::bind_epoll_sharded(
+        "127.0.0.1:0",
+        HttpServerOptions::default(),
+        worker_count,
+        Arc::clone(&app),
+    )
+    .expect("bind epoll sharded");
+
+    #[cfg(target_os = "windows")]
+    let mut server = ShardedWebServer::bind_windows_sharded(
+        "127.0.0.1:0",
+        HttpServerOptions::default(),
+        worker_count,
+        Arc::clone(&app),
+    )
+    .expect("bind windows sharded");
+
+    let port = server.local_addr().port();
+    let shards = server.worker_count();
+    let stop = server.stop_handle();
+    thread::spawn(move || {
+        let _ = server.serve();
+    });
+    thread::sleep(Duration::from_millis(20));
+    (port, shards, stop)
+}
+
+/// A `ShardedWebServer` actually handles requests **concurrently** across its
+/// shards — proven deterministically (not by wall-clock thresholds, which flake
+/// under CI load). The handler bumps an in-flight gauge, holds it briefly, and
+/// records the maximum number of handlers running at once. If dispatch were
+/// serial (single reactor) the gauge would never exceed 1; observing ≥ 2
+/// concurrent handlers proves real cross-shard parallelism. Every client also
+/// gets a correct 200, so parallelism does not corrupt the request/response
+/// contract.
+#[cfg(not(target_os = "windows"))]
+#[test]
+fn sharded_web_server_handles_requests_concurrently() {
+    let worker_count = 4;
+    let client_count = 8;
+
+    let in_flight = Arc::new(AtomicUsize::new(0));
+    let max_in_flight = Arc::new(AtomicUsize::new(0));
+    let handler_in_flight = Arc::clone(&in_flight);
+    let handler_max = Arc::clone(&max_in_flight);
+
+    let mut app = WebApp::new();
+    app.get("/work", move |_| {
+        // Enter: bump the in-flight count and raise the observed maximum.
+        let now = handler_in_flight.fetch_add(1, Ordering::SeqCst) + 1;
+        handler_max.fetch_max(now, Ordering::SeqCst);
+        // Hold the handler open long enough for sibling requests on other shards
+        // to overlap (loopback round-trips are sub-millisecond).
+        thread::sleep(Duration::from_millis(40));
+        handler_in_flight.fetch_sub(1, Ordering::SeqCst);
+        WebResponse::text("ok")
+    });
+
+    let (port, shards, stop) = start_sharded_server(app, worker_count);
+    assert_eq!(shards, worker_count, "all requested shards spawned");
+
+    // Release all clients together so they spread across shards and overlap.
+    let barrier = Arc::new(std::sync::Barrier::new(client_count));
+    let clients: Vec<_> = (0..client_count)
+        .map(|_| {
+            let barrier = Arc::clone(&barrier);
+            thread::spawn(move || {
+                barrier.wait();
+                http_get(port, "/work")
+            })
+        })
+        .collect();
+
+    for client in clients {
+        let (status, body) = client.join().expect("client thread");
+        assert_eq!(status, 200, "every concurrent request gets a 200");
+        assert_eq!(body, "ok");
+    }
+
+    let observed_max = max_in_flight.load(Ordering::SeqCst);
+    assert!(
+        observed_max >= 2,
+        "expected concurrent handler execution across shards, but the max observed \
+         in-flight handlers was {observed_max} (serial dispatch would never exceed 1)",
+    );
+
+    stop.stop();
+}
+
+/// CPU-bound throughput benchmark for `ShardedWebServer` (WEB01a-2).
+///
+/// `#[ignore]`d — like the embeddable-http-server stress test — because
+/// wall-clock scaling is sensitive to the host's core count and load, so it is a
+/// runnable *measurement*, not a CI pass/fail gate (the deterministic
+/// `sharded_web_server_handles_requests_concurrently` test is the CI proof of
+/// parallelism). Run manually on a multi-core machine:
+///
+/// ```sh
+/// cargo test -p web-core --test web_core_test -- --ignored --nocapture \
+///     sharded_web_server_cpu_bound_throughput_scales
+/// ```
+///
+/// Each request burns a fixed CPU budget (a busy hash loop — NOT an echo, which
+/// is latency-bound and would not scale). It serves the same concurrent load on
+/// a 1-shard and an N-shard server and prints both wall-clock times; with real
+/// cores the N-shard run finishes meaningfully faster.
+#[cfg(not(target_os = "windows"))]
+#[test]
+#[ignore]
+fn sharded_web_server_cpu_bound_throughput_scales() {
+    use std::time::Instant;
+
+    // A deterministic, optimiser-resistant CPU burn (~a few ms per request).
+    fn cpu_burn() -> u64 {
+        let mut acc: u64 = 0xcbf2_9ce4_8422_2325; // FNV offset basis
+        for i in 0..2_000_000u64 {
+            acc = (acc ^ i).wrapping_mul(0x0000_0100_0000_01b3); // FNV prime
+        }
+        acc
+    }
+
+    fn run_load(worker_count: usize, client_count: usize) -> std::time::Duration {
+        let mut app = WebApp::new();
+        app.get("/compute", move |_| WebResponse::text(format!("{}", cpu_burn())));
+        let (port, _shards, stop) = start_sharded_server(app, worker_count);
+
+        let barrier = Arc::new(std::sync::Barrier::new(client_count));
+        let start = Instant::now();
+        let clients: Vec<_> = (0..client_count)
+            .map(|_| {
+                let barrier = Arc::clone(&barrier);
+                thread::spawn(move || {
+                    barrier.wait();
+                    let (status, _) = http_get(port, "/compute");
+                    assert_eq!(status, 200);
+                })
+            })
+            .collect();
+        for c in clients {
+            c.join().expect("compute client");
+        }
+        let elapsed = start.elapsed();
+        stop.stop();
+        thread::sleep(Duration::from_millis(50));
+        elapsed
+    }
+
+    let cores = std::thread::available_parallelism().map(|n| n.get()).unwrap_or(1);
+    let client_count = 16;
+
+    let serial = run_load(1, client_count);
+    let parallel = run_load(cores.max(2), client_count);
+
+    println!(
+        "CPU-bound throughput: {client_count} requests — 1 shard: {serial:?}, \
+         {} shards: {parallel:?} (speedup {:.2}x, {cores} cores)",
+        cores.max(2),
+        serial.as_secs_f64() / parallel.as_secs_f64(),
+    );
+
+    if cores >= 2 {
+        assert!(
+            parallel < serial,
+            "expected the sharded server to finish CPU-bound load faster than a \
+             single reactor on {cores} cores (1 shard: {serial:?}, parallel: {parallel:?})",
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Second step of **WEB01** (per the spec + sign-off: **Path A sharded reactors, opt-in**). [WEB01a-1 (#5949)](https://github.com/adhithyan15/coding-adventures/pull/5949) added the sharded HTTP primitive; this wires it into `web-core` so a `WebApp` can serve **in parallel**.

`web-core` 0.2.0 gains **`ShardedWebServer<P>`**: it dispatches `WebApp::handle` across `worker_count` reactor shards (via `ShardedHttpServer`), so requests on different connections run concurrently. The same `Arc<WebApp>` is shared across all shards — it's immutable after construction (no interior mutability in the routing/hook/settings dispatch path — verified in review), so no locking is needed.

- Platform binds `bind_kqueue_sharded` / `bind_epoll_sharded` / `bind_windows_sharded`, plus `serve` / `local_addr` / `worker_count` / `stop_handle`. `on_server_start`/`on_server_stop` fire once, exactly like `WebServer`.
- **Opt-in**: existing `WebServer` unchanged and still the default; hook/routing/`halt` semantics identical; HTTP/1.1 per-connection response ordering preserved (a connection stays on one shard).

## Test plan

- [x] `sharded_web_server_handles_requests_concurrently` — **deterministic** parallelism proof (in-flight gauge ≥ 2 is impossible under serial dispatch; not a flaky wall-clock threshold) + every concurrent request gets a correct 200. **Runs in CI.**
- [x] `sharded_web_server_cpu_bound_throughput_scales` (`#[ignore]`d, manual) — CPU-bound busy-loop handler (not echo). Measured locally: **16 requests, 1 shard 203ms vs 14 shards 38ms = 5.28× on 14 cores.**
- [x] Downstream `conduit` (Rust facade) builds + tests green; web-core's 29 tests pass
- [x] Added code clippy-clean; `/security-review` passed
- [ ] CI green

> Next: **WEB01a-3** (optional) exposes `worker_count` through the language facades that want it; default stays single-reactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)