### PR TITLE
Add SPICE print output routing

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ### Added
 
+- **Parsed print output routing** —
+  `resolve_deck_outputs()`, `select_deck_output_probes()`, and
+  `format_deck_*_table()` now route scoped `.print <analysis> ...` output
+  cards alongside `.save` and `.probe`, matching Rust and TypeScript.
+
 - **Deck run artifact metadata** —
   `run_deck_analysis()` now returns selected-run artifact summaries and a
   stable run-artifact table with result-row, output-probe, measurement, and

--- a/code/packages/python/spice-engine/README.md
+++ b/code/packages/python/spice-engine/README.md
@@ -113,9 +113,10 @@ output-probe, measurement, and Fourier counts. They route `START` output
 filtering, use `.tran TSTEP` as the output print grid, apply `MAXSTEP` as an
 internal fixed-step cap, and carry `UIC` initial-condition intent through that
 stable transient table surface.
-`resolve_deck_outputs()` and `select_deck_output_probes()` extract `.save` and
-scoped or global `.probe` cards before `.end`, normalize and deduplicate output
-probes in deck order, and feed `format_deck_op_table()`,
+`resolve_deck_outputs()` and `select_deck_output_probes()` extract `.save`,
+scoped or global `.probe`, and scoped `.print <analysis> ...` cards before
+`.end`, normalize and deduplicate output probes in deck order, and feed
+`format_deck_op_table()`,
 `format_deck_dc_sweep_table()`, `format_deck_ac_table()`, and
 `format_deck_transient_table()` for stable deck-selected text output.
 `resolve_deck_fourier()`, `fourier_transient_cards()`,
@@ -185,9 +186,10 @@ signatures, arguments, or empty expressions.
 `FIND ... AT=` sample points and `WHEN probe=target` crossings with optional
 `RISE`, `FALL`, or `CROSS` counters, and reports stable diagnostics for
 unsupported analyses, modes, options, expressions, and invalid windows.
-`resolve_deck_outputs()` extracts `.save` and `.probe` cards before `.end`,
-preserves non-output active lines, and reports stable diagnostics for missing
-probe lists or malformed `V(node)` / `I(source)` probes.
+`resolve_deck_outputs()` extracts `.save`, `.probe`, and `.print` cards before
+`.end`, preserves non-output active lines, and reports stable diagnostics for
+missing probe lists, unsupported `.print` analyses, or malformed `V(node)` /
+`I(source)` probes.
 `resolve_deck_analyses()` extracts `.op`, `.dc`, `.ac`, and `.tran` cards
 before `.end`, preserves non-analysis active lines, and reports stable
 diagnostics for malformed deck-level analysis controls.

--- a/code/packages/python/spice-engine/src/spice_engine/compatibility.py
+++ b/code/packages/python/spice-engine/src/spice_engine/compatibility.py
@@ -268,7 +268,7 @@ class DeckFourierSummary:
 
 @dataclass(frozen=True, slots=True)
 class DeckOutputSelection:
-    """A parsed ``.save`` or ``.probe`` output selection card."""
+    """A parsed ``.save``, ``.probe``, or ``.print`` output selection card."""
 
     directive: str
     analysis: str | None
@@ -290,7 +290,7 @@ class DeckOutputDiagnostic:
 
 @dataclass(frozen=True, slots=True)
 class DeckOutputSummary:
-    """Resolved active deck lines plus parsed ``.save`` / ``.probe`` cards."""
+    """Resolved active deck lines plus parsed deck output selection cards."""
 
     active_lines: tuple[str, ...]
     terminated: bool
@@ -723,7 +723,7 @@ def resolve_deck_fourier(netlist: str) -> DeckFourierSummary:
 
 
 def resolve_deck_outputs(netlist: str) -> DeckOutputSummary:
-    """Extract supported ``.save`` and ``.probe`` cards before ``.end``."""
+    """Extract supported ``.save``, ``.probe``, and ``.print`` cards."""
 
     state = _DeckOutputState()
     active_lines: list[str] = []
@@ -737,7 +737,7 @@ def resolve_deck_outputs(netlist: str) -> DeckOutputSummary:
         if directive == ".end":
             end_line_number = line_number
             break
-        if directive in {".save", ".probe"}:
+        if directive in {".save", ".probe", ".print"}:
             _resolve_output_line(stripped, line_number, directive, state)
             continue
         active_lines.append(stripped)
@@ -2173,18 +2173,45 @@ def _resolve_output_line(
 ) -> None:
     tokens = _directive_tokens(line)
     if len(tokens) < 2:
+        message = (
+            ".print requires an analysis token and at least one probe token"
+            if directive == ".print"
+            else f"{directive} requires at least one probe token"
+        )
         _add_output_diagnostic(
             state,
             code="SPICE_DECK_OUTPUT_ARGUMENT",
             directive=directive,
             line_number=line_number,
-            message=f"{directive} requires at least one probe token",
+            message=message,
         )
         return
 
     analysis: str | None = None
     probe_tokens = tokens[1:]
-    if directive == ".probe" and _normalize_deck_output_analysis(tokens[1]) is not None:
+    if directive == ".print":
+        if len(tokens) < 3:
+            _add_output_diagnostic(
+                state,
+                code="SPICE_DECK_OUTPUT_ARGUMENT",
+                directive=directive,
+                line_number=line_number,
+                message=".print requires an analysis token and at least one probe token",
+            )
+            return
+        analysis = _normalize_deck_output_analysis(tokens[1])
+        if analysis is None:
+            _add_output_diagnostic(
+                state,
+                code="SPICE_DECK_OUTPUT_ANALYSIS",
+                directive=directive,
+                line_number=line_number,
+                message=f".print analysis must be op, dc, ac, or tran, got {tokens[1]!r}",
+                token=tokens[1],
+            )
+            return
+        probe_tokens = tokens[2:]
+    elif directive == ".probe" and _normalize_deck_output_analysis(tokens[1]) is not None:
         analysis = _normalize_deck_output_analysis(tokens[1])
         probe_tokens = tokens[2:]
     if not probe_tokens:

--- a/code/packages/python/spice-engine/src/spice_engine/engine.py
+++ b/code/packages/python/spice-engine/src/spice_engine/engine.py
@@ -2264,19 +2264,19 @@ def format_ac_table(result: AcResult | list[AcPoint], probes: list[str] | None =
 
 
 def format_deck_op_table(result: DcResult, netlist: str) -> str:
-    """Format a DC operating point using parsed ``.save`` / ``.probe`` cards."""
+    """Format a DC operating point using parsed deck output cards."""
 
     return format_dc_table(result, select_deck_output_probes(netlist, "op"))
 
 
 def format_deck_dc_sweep_table(result: DcSweepResult, netlist: str) -> str:
-    """Format a DC sweep using parsed ``.save`` / ``.probe`` cards."""
+    """Format a DC sweep using parsed deck output cards."""
 
     return format_dc_sweep_table(result, select_deck_output_probes(netlist, "dc"))
 
 
 def format_deck_ac_table(result: AcResult | list[AcPoint], netlist: str) -> str:
-    """Format AC phasors using parsed ``.save`` / ``.probe`` cards."""
+    """Format AC phasors using parsed deck output cards."""
 
     return format_ac_table(result, select_deck_output_probes(netlist, "ac"))
 
@@ -2285,7 +2285,7 @@ def format_deck_transient_table(
     transient_result: TransientResult | list[TransientPoint],
     netlist: str,
 ) -> str:
-    """Format transient samples using parsed ``.save`` / ``.probe`` cards."""
+    """Format transient samples using parsed deck output cards."""
 
     return format_transient_table(
         transient_result,

--- a/code/packages/python/spice-engine/tests/test_compatibility.py
+++ b/code/packages/python/spice-engine/tests/test_compatibility.py
@@ -533,13 +533,14 @@ def test_resolve_deck_fourier_reports_unsupported_subset() -> None:
     }
 
 
-def test_resolve_deck_outputs_extracts_save_and_probe_cards() -> None:
+def test_resolve_deck_outputs_extracts_save_probe_and_print_cards() -> None:
     summary = resolve_deck_outputs(
         """
 V1 in 0 DC 1
 .save V(out) i(V1)
 .probe tran V(clk)
 .probe AC V(out)
+.print dc V(load) I(V2)
 .end
 .save V(ignored)
 """
@@ -547,7 +548,7 @@ V1 in 0 DC 1
 
     assert summary.active_lines == ("V1 in 0 DC 1",)
     assert summary.terminated is True
-    assert summary.end_line_number == 6
+    assert summary.end_line_number == 7
     assert summary.diagnostics == ()
     assert [
         (selection.directive, selection.analysis, selection.probes)
@@ -556,17 +557,19 @@ V1 in 0 DC 1
         (".save", None, ("V(out)", "I(V1)")),
         (".probe", "tran", ("V(clk)",)),
         (".probe", "ac", ("V(out)",)),
+        (".print", "dc", ("V(load)", "I(V2)")),
     ]
 
     assert select_deck_output_probes(
         """
 .save V(out) I(V1)
 .probe tran V(out) V(clk)
+.print tran I(V2)
 .probe ac V(freq)
 .end
 """,
         "transient",
-    ) == ["V(out)", "I(V1)", "V(clk)"]
+    ) == ["V(out)", "I(V1)", "V(clk)", "I(V2)"]
 
 
 def test_resolve_deck_analyses_extracts_supported_cards() -> None:
@@ -707,15 +710,21 @@ def test_resolve_deck_outputs_reports_invalid_cards() -> None:
         """
 .save
 .probe tran
+.print tran
+.print foo V(out)
 .save P(out)
 .probe dc V(out) bad-token
+.print dc bad-token
 .end
 """
     )
 
     assert sorted(diagnostic.code for diagnostic in summary.diagnostics) == [
+        "SPICE_DECK_OUTPUT_ANALYSIS",
         "SPICE_DECK_OUTPUT_ARGUMENT",
         "SPICE_DECK_OUTPUT_ARGUMENT",
+        "SPICE_DECK_OUTPUT_ARGUMENT",
+        "SPICE_DECK_OUTPUT_PROBE",
         "SPICE_DECK_OUTPUT_PROBE",
         "SPICE_DECK_OUTPUT_PROBE",
     ]

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -6695,11 +6695,12 @@ def test_text_output_tables_are_stable_for_dc_and_transient_results() -> None:
     )
 
 
-def test_deck_output_tables_route_save_probe_cards() -> None:
+def test_deck_output_tables_route_save_probe_print_cards() -> None:
     netlist = """
 .save V(out)
 .probe dc I(V1)
 .probe tran V(clk)
+.print tran V(ignored)
 .probe ac I(V1)
 .end
 """
@@ -6717,8 +6718,16 @@ def test_deck_output_tables_route_save_probe_cards() -> None:
         source_name="V1",
     )
     transient_points = [
-        TransientPoint(0.0, {"clk": 0.0, "out": 0.0}, {"I(V1)": 0.0}),
-        TransientPoint(1.0e-3, {"clk": 1.0, "out": 0.5}, {"I(V1)": -5.0e-4}),
+        TransientPoint(
+            0.0,
+            {"clk": 0.0, "out": 0.0, "ignored": 1.0},
+            {"I(V1)": 0.0},
+        ),
+        TransientPoint(
+            1.0e-3,
+            {"clk": 1.0, "out": 0.5, "ignored": 2.0},
+            {"I(V1)": -5.0e-4},
+        ),
     ]
     ac_result = AcResult(
         points=[
@@ -6740,9 +6749,9 @@ def test_deck_output_tables_route_save_probe_cards() -> None:
         "1\tV1\t1.000000e+00\t5.000000e-01\t-5.000000e-04\n"
     )
     assert format_deck_transient_table(transient_points, netlist) == (
-        "Index\tTime\tV(out)\tV(clk)\n"
-        "0\t0.000000e+00\t0.000000e+00\t0.000000e+00\n"
-        "1\t1.000000e-03\t5.000000e-01\t1.000000e+00\n"
+        "Index\tTime\tV(out)\tV(clk)\tV(ignored)\n"
+        "0\t0.000000e+00\t0.000000e+00\t0.000000e+00\t1.000000e+00\n"
+        "1\t1.000000e-03\t5.000000e-01\t1.000000e+00\t2.000000e+00\n"
     )
     assert format_deck_ac_table(ac_result, netlist) == (
         "Index\tFrequency\tProbe\tReal\tImaginary\tMagnitude\tPhase\n"

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Add parsed `.print <analysis> ...` output routing to `resolve_deck_outputs`,
+  `select_deck_output_probes`, and deck table formatters, matching Python and
+  TypeScript.
 - Add selected-run artifact summaries to `run_deck_analysis`; executions now
   return stable result-row, output-probe, measurement, and Fourier counts plus
   a run-artifact table, matching Python and TypeScript.

--- a/code/packages/rust/spice-engine/README.md
+++ b/code/packages/rust/spice-engine/README.md
@@ -192,10 +192,11 @@ signatures, arguments, or empty expressions.
 `FIND ... AT=` sample points and `WHEN probe=target` crossings with optional
 `RISE`, `FALL`, or `CROSS` counters, and reports stable diagnostics for
 unsupported analyses, modes, options, expressions, and invalid windows.
-`resolve_deck_outputs` extracts `.save` and scoped or global `.probe` cards
-before `.end`, keeps non-output active lines, and reports stable diagnostics for
-malformed output probes. `select_deck_output_probes` deduplicates the selected
-probes for a requested analysis, while `format_deck_op_table`,
+`resolve_deck_outputs` extracts `.save`, scoped or global `.probe`, and scoped
+`.print <analysis> ...` cards before `.end`, keeps non-output active lines,
+and reports stable diagnostics for missing probe lists, unsupported `.print`
+analyses, or malformed output probes. `select_deck_output_probes` deduplicates
+the selected probes for a requested analysis, while `format_deck_op_table`,
 `format_deck_dc_sweep_table`, `format_deck_ac_table`, and
 `format_deck_transient_table` feed those deck-card selections into the stable
 text table formatters.

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -3811,7 +3811,7 @@ pub fn resolve_deck_outputs(netlist: &str) -> DeckOutputSummary {
             end_line_number = Some(line_number);
             break;
         }
-        if matches!(directive.as_deref(), Some(".save" | ".probe")) {
+        if matches!(directive.as_deref(), Some(".save" | ".probe" | ".print")) {
             resolve_output_line(
                 stripped,
                 line_number,
@@ -5854,18 +5854,50 @@ fn resolve_output_line(
 ) {
     let tokens = directive_tokens(line);
     if tokens.len() < 2 {
+        let message = if directive == ".print" {
+            ".print requires an analysis token and at least one probe token".to_string()
+        } else {
+            format!("{directive} requires at least one probe token")
+        };
         add_output_diagnostic(
             state,
             "SPICE_DECK_OUTPUT_ARGUMENT",
             directive,
             line_number,
-            &format!("{directive} requires at least one probe token"),
+            &message,
             None,
         );
         return;
     }
 
-    let (analysis, probe_tokens) = if directive == ".probe"
+    let (analysis, probe_tokens) = if directive == ".print" {
+        if tokens.len() < 3 {
+            add_output_diagnostic(
+                state,
+                "SPICE_DECK_OUTPUT_ARGUMENT",
+                directive,
+                line_number,
+                ".print requires an analysis token and at least one probe token",
+                None,
+            );
+            return;
+        }
+        let Some(analysis) = normalize_deck_output_analysis(tokens[1]) else {
+            add_output_diagnostic(
+                state,
+                "SPICE_DECK_OUTPUT_ANALYSIS",
+                directive,
+                line_number,
+                &format!(
+                    ".print analysis must be op, dc, ac, or tran, got {:?}",
+                    tokens[1]
+                ),
+                Some(tokens[1].to_string()),
+            );
+            return;
+        };
+        (Some(analysis.to_string()), &tokens[2..])
+    } else if directive == ".probe"
         && tokens
             .get(1)
             .and_then(|token| normalize_deck_output_analysis(token))

--- a/code/packages/rust/spice-engine/tests/compatibility_tests.rs
+++ b/code/packages/rust/spice-engine/tests/compatibility_tests.rs
@@ -766,13 +766,14 @@ fn resolve_deck_fourier_reports_unsupported_subset() {
 }
 
 #[test]
-fn resolve_deck_outputs_extracts_save_and_probe_cards() {
+fn resolve_deck_outputs_extracts_save_probe_and_print_cards() {
     let summary = resolve_deck_outputs(
         "
 V1 in 0 DC 1
 .save V(out) i(V1)
 .probe tran V(clk)
 .probe AC V(out)
+.print dc V(load) I(V2)
 .end
 .save V(ignored)
 ",
@@ -780,7 +781,7 @@ V1 in 0 DC 1
 
     assert_eq!(summary.active_lines, vec!["V1 in 0 DC 1"]);
     assert!(summary.terminated);
-    assert_eq!(summary.end_line_number, Some(6));
+    assert_eq!(summary.end_line_number, Some(7));
     assert!(summary.diagnostics.is_empty());
     assert_eq!(
         summary
@@ -800,6 +801,11 @@ V1 in 0 DC 1
             ),
             (".probe", Some("tran"), &["V(clk)".to_string()][..]),
             (".probe", Some("ac"), &["V(out)".to_string()][..]),
+            (
+                ".print",
+                Some("dc"),
+                &["V(load)".to_string(), "I(V2)".to_string()][..]
+            ),
         ]
     );
 
@@ -808,13 +814,14 @@ V1 in 0 DC 1
             "
 .save V(out) I(V1)
 .probe tran V(out) V(clk)
+.print tran I(V2)
 .probe ac V(freq)
 .end
 ",
             "transient",
         )
         .unwrap(),
-        vec!["V(out)", "I(V1)", "V(clk)"]
+        vec!["V(out)", "I(V1)", "V(clk)", "I(V2)"]
     );
 }
 
@@ -988,8 +995,11 @@ fn resolve_deck_outputs_reports_invalid_cards() {
         "
 .save
 .probe tran
+.print tran
+.print foo V(out)
 .save P(out)
 .probe dc V(out) bad-token
+.print dc bad-token
 .end
 ",
     );
@@ -1003,8 +1013,11 @@ fn resolve_deck_outputs_reports_invalid_cards() {
     assert_eq!(
         codes,
         vec![
+            "SPICE_DECK_OUTPUT_ANALYSIS",
             "SPICE_DECK_OUTPUT_ARGUMENT",
             "SPICE_DECK_OUTPUT_ARGUMENT",
+            "SPICE_DECK_OUTPUT_ARGUMENT",
+            "SPICE_DECK_OUTPUT_PROBE",
             "SPICE_DECK_OUTPUT_PROBE",
             "SPICE_DECK_OUTPUT_PROBE",
         ]

--- a/code/packages/rust/spice-engine/tests/transient_tests.rs
+++ b/code/packages/rust/spice-engine/tests/transient_tests.rs
@@ -1837,6 +1837,7 @@ fn transient_deck_output_cards_select_table_probes() {
         "
 .save V(out) I(V1)
 .probe tran V(clk) V(out)
+.print tran V(ignored)
 .probe ac V(ignored)
 .end
 ",
@@ -1845,7 +1846,7 @@ fn transient_deck_output_cards_select_table_probes() {
 
     assert_eq!(
         table,
-        "Index\tTime\tV(out)\tI(V1)\tV(clk)\n0\t0.000000e+00\t0.000000e+00\t-1.000000e-03\t0.000000e+00\n1\t1.000000e-03\t1.000000e+00\t-2.000000e-03\t5.000000e+00\n"
+        "Index\tTime\tV(out)\tI(V1)\tV(clk)\tV(ignored)\n0\t0.000000e+00\t0.000000e+00\t-1.000000e-03\t0.000000e+00\t1.000000e+00\n1\t1.000000e-03\t1.000000e+00\t-2.000000e-03\t5.000000e+00\t2.000000e+00\n"
     );
 }
 

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Add parsed `.print <analysis> ...` output routing to `resolveDeckOutputs`,
+  `selectDeckOutputProbes`, and deck table formatters, matching Python and
+  Rust.
 - Add selected-run artifact summaries to `runDeckAnalysis`; executions now
   return stable result-row, output-probe, measurement, and Fourier counts plus
   a run-artifact table, matching Python and Rust.

--- a/code/packages/typescript/spice-engine/README.md
+++ b/code/packages/typescript/spice-engine/README.md
@@ -20,8 +20,8 @@ to thresholded transient probe outputs with stable schedule tables and VCD
 correlation output,
 stable text tables for selected node voltages, branch currents, AC phasors,
 Fourier harmonics, transfer-function results, pole-zero entries, and
-distortion harmonics, parsed `.save` / `.probe` deck-selected output tables,
-and backward-Euler reactive-element companion models.
+distortion harmonics, parsed `.save` / `.probe` / `.print` deck-selected
+output tables, and backward-Euler reactive-element companion models.
 
 ```ts
 import {
@@ -99,9 +99,10 @@ stable transient table surface. They also return selected `.four` harmonic
 results and a stable Fourier table. Executions also include selected-run
 artifact summaries plus `formatDeckRunArtifactTable` output for stable
 result-row, output-probe, measurement, and Fourier counts.
-`resolveDeckOutputs` and `selectDeckOutputProbes` extract `.save` and scoped
-or global `.probe` cards before `.end`, normalize and deduplicate output
-probes in deck order, and feed `formatDeckOpTable`,
+`resolveDeckOutputs` and `selectDeckOutputProbes` extract `.save`, scoped or
+global `.probe`, and scoped `.print <analysis> ...` cards before `.end`,
+normalize and deduplicate output probes in deck order, and feed
+`formatDeckOpTable`,
 `formatDeckDcSweepTable`, `formatDeckAcTable`, and
 `formatDeckTransientTable` for stable deck-selected text output.
 `resolveDeckFourier`, `fourierTransientCards`, `fourierTransientDeck`, and
@@ -158,9 +159,10 @@ cards before `.end`, keeps non-measure active lines, evaluates optional
 `FIND ... AT=` sample points and `WHEN probe=target` crossings with optional
 `RISE`, `FALL`, or `CROSS` counters, and reports stable diagnostics for
 unsupported analyses, modes, options, expressions, and invalid windows.
-`resolveDeckOutputs` extracts `.save` and `.probe` cards before `.end`,
-preserves non-output active lines, and reports stable diagnostics for missing
-probe lists or malformed `V(node)` / `I(source)` probes.
+`resolveDeckOutputs` extracts `.save`, `.probe`, and `.print` cards before
+`.end`, preserves non-output active lines, and reports stable diagnostics for
+missing probe lists, unsupported `.print` analyses, or malformed `V(node)` /
+`I(source)` probes.
 `resolveDeckAnalyses` extracts `.op`, `.dc`, `.ac`, and `.tran` cards before
 `.end`, preserves non-analysis active lines, and reports stable diagnostics for
 malformed deck-level analysis controls.

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -589,7 +589,7 @@ export interface DeckFourierSummary {
 }
 
 export interface DeckOutputSelection {
-  readonly directive: ".save" | ".probe";
+  readonly directive: ".save" | ".probe" | ".print";
   readonly analysis?: "op" | "dc" | "ac" | "tran";
   readonly probes: readonly string[];
   readonly lineNumber: number;
@@ -597,7 +597,7 @@ export interface DeckOutputSelection {
 
 export interface DeckOutputDiagnostic {
   readonly code: string;
-  readonly directive: ".save" | ".probe";
+  readonly directive: ".save" | ".probe" | ".print";
   readonly lineNumber: number;
   readonly message: string;
   readonly severity: "error" | "warning";
@@ -3088,7 +3088,7 @@ export function resolveDeckOutputs(netlist: string): DeckOutputSummary {
       endLineNumber = lineNumber;
       break;
     }
-    if (directive === ".save" || directive === ".probe") {
+    if (directive === ".save" || directive === ".probe" || directive === ".print") {
       resolveOutputLine(stripped, lineNumber, directive, state);
       continue;
     }
@@ -4235,23 +4235,49 @@ function resolveFourierLine(
 function resolveOutputLine(
   line: string,
   lineNumber: number,
-  directive: ".save" | ".probe",
+  directive: ".save" | ".probe" | ".print",
   state: DeckOutputState,
 ): void {
   const tokens = directiveTokens(line);
   if (tokens.length < 2) {
+    const message = directive === ".print"
+      ? ".print requires an analysis token and at least one probe token"
+      : `${directive} requires at least one probe token`;
     addOutputDiagnostic(state, {
       code: "SPICE_DECK_OUTPUT_ARGUMENT",
       directive,
       lineNumber,
-      message: `${directive} requires at least one probe token`,
+      message,
     });
     return;
   }
 
   let analysis: DeckOutputSelection["analysis"];
   let probeTokens = tokens.slice(1);
-  if (directive === ".probe") {
+  if (directive === ".print") {
+    if (tokens.length < 3) {
+      addOutputDiagnostic(state, {
+        code: "SPICE_DECK_OUTPUT_ARGUMENT",
+        directive,
+        lineNumber,
+        message: ".print requires an analysis token and at least one probe token",
+      });
+      return;
+    }
+    const normalizedAnalysis = normalizeDeckOutputAnalysis(tokens[1]);
+    if (normalizedAnalysis === undefined) {
+      addOutputDiagnostic(state, {
+        code: "SPICE_DECK_OUTPUT_ANALYSIS",
+        directive,
+        lineNumber,
+        message: `.print analysis must be op, dc, ac, or tran, got ${JSON.stringify(tokens[1])}`,
+        token: tokens[1],
+      });
+      return;
+    }
+    analysis = normalizedAnalysis;
+    probeTokens = tokens.slice(2);
+  } else if (directive === ".probe") {
     const normalizedAnalysis = normalizeDeckOutputAnalysis(tokens[1]);
     if (normalizedAnalysis !== undefined) {
       analysis = normalizedAnalysis;

--- a/code/packages/typescript/spice-engine/tests/compatibility.test.ts
+++ b/code/packages/typescript/spice-engine/tests/compatibility.test.ts
@@ -554,19 +554,20 @@ V1 in 0 SIN(0 1 1k)
     ]);
   });
 
-  it("extracts .save and .probe output cards", () => {
+  it("extracts .save, .probe, and .print output cards", () => {
     const summary = resolveDeckOutputs(`
 V1 in 0 DC 1
 .save V(out) i(V1)
 .probe tran V(clk)
 .probe AC V(out)
+.print dc V(load) I(V2)
 .end
 .save V(ignored)
 `);
 
     expect(summary.activeLines).toStrictEqual(["V1 in 0 DC 1"]);
     expect(summary.terminated).toBe(true);
-    expect(summary.endLineNumber).toBe(6);
+    expect(summary.endLineNumber).toBe(7);
     expect(summary.diagnostics).toStrictEqual([]);
     expect(
       summary.selections.map((selection) => [
@@ -578,6 +579,7 @@ V1 in 0 DC 1
       [".save", undefined, ["V(out)", "I(V1)"]],
       [".probe", "tran", ["V(clk)"]],
       [".probe", "ac", ["V(out)"]],
+      [".print", "dc", ["V(load)", "I(V2)"]],
     ]);
 
     expect(
@@ -585,26 +587,33 @@ V1 in 0 DC 1
         `
 .save V(out) I(V1)
 .probe tran V(out) V(clk)
+.print tran I(V2)
 .probe ac V(freq)
 .end
 `,
         "transient",
       ),
-    ).toStrictEqual(["V(out)", "I(V1)", "V(clk)"]);
+    ).toStrictEqual(["V(out)", "I(V1)", "V(clk)", "I(V2)"]);
   });
 
-  it("reports invalid .save and .probe output cards", () => {
+  it("reports invalid .save, .probe, and .print output cards", () => {
     const summary = resolveDeckOutputs(`
 .save
 .probe tran
+.print tran
+.print foo V(out)
 .save P(out)
 .probe dc V(out) bad-token
+.print dc bad-token
 .end
 `);
 
     expect(summary.diagnostics.map((diagnostic) => diagnostic.code).sort()).toStrictEqual([
+      "SPICE_DECK_OUTPUT_ANALYSIS",
       "SPICE_DECK_OUTPUT_ARGUMENT",
       "SPICE_DECK_OUTPUT_ARGUMENT",
+      "SPICE_DECK_OUTPUT_ARGUMENT",
+      "SPICE_DECK_OUTPUT_PROBE",
       "SPICE_DECK_OUTPUT_PROBE",
       "SPICE_DECK_OUTPUT_PROBE",
     ]);

--- a/code/packages/typescript/spice-engine/tests/transient.test.ts
+++ b/code/packages/typescript/spice-engine/tests/transient.test.ts
@@ -1427,10 +1427,15 @@ describe("transient", () => {
         "0\t1.000000e-03\t1.000000e+01\t5.000000e+00\t-5.000000e-03\n" +
         "1\t2.000000e-03\t1.000000e+01\t5.000000e+00\t-5.000000e-03\n",
     );
-    expect(formatDeckTransientTable(points, ".save V(mid)\n.probe tran V(vin)\n.end\n")).toBe(
-      "Index\tTime\tV(mid)\tV(vin)\n" +
-        "0\t1.000000e-03\t5.000000e+00\t1.000000e+01\n" +
-        "1\t2.000000e-03\t5.000000e+00\t1.000000e+01\n",
+    expect(
+      formatDeckTransientTable(
+        points,
+        ".save V(mid)\n.probe tran V(vin)\n.print tran I(V1)\n.end\n",
+      ),
+    ).toBe(
+      "Index\tTime\tV(mid)\tV(vin)\tI(V1)\n" +
+        "0\t1.000000e-03\t5.000000e+00\t1.000000e+01\t-5.000000e-03\n" +
+        "1\t2.000000e-03\t5.000000e+00\t1.000000e+01\t-5.000000e-03\n",
     );
   });
 

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -28,9 +28,10 @@ downstream tools to compare.
      diagnostic and solver footholds; transient scalar `.measure`-style output
      helpers now cover shared peak-to-peak and final-value measurement output,
      and parsed transient `.measure` / `.meas` cards can now feed those
-     measurement helpers from deck text; parsed `.save` and `.probe` cards now
-     drive stable Rust table output for operating-point, DC sweep, AC sweep, and
-     transient results; parsed `.measure dc` / `.meas dc` cards now route DC
+     measurement helpers from deck text; parsed `.save`, `.probe`, and
+     `.print <analysis> ...` cards now drive stable table output for
+     operating-point, DC sweep, AC sweep, and transient results; parsed
+     `.measure dc` / `.meas dc` cards now route DC
      sweep probe samples into the shared scalar measurement table surface;
      parsed `.measure ac` / `.meas ac` cards now route AC probe magnitudes over
      optional frequency windows into the same measurement table surface; parsed
@@ -471,6 +472,15 @@ downstream tools to compare.
     - The summary is list-shaped so future nested sweeps can append more
       deck-owned run artifacts without changing the public field shape.
 
+41. Parsed `.print` output routing.
+    - Status: completed in this parsed print output-routing slice.
+    - Python, Rust, and TypeScript now treat scoped
+      `.print <analysis> V(node) I(source)` cards as deck output selections
+      alongside `.save` and `.probe`.
+    - Selected probes are normalized and deduplicated in deck order, while
+      diagnostics distinguish missing `.print` probes, unsupported `.print`
+      analyses, and malformed output probes.
+
 ## Backlog
 
 1. Deck execution layer.
@@ -479,7 +489,7 @@ downstream tools to compare.
      selected measurement artifacts, selected Fourier artifacts, and selected
      run summaries, plus output-plan integration beyond stable table routing.
    - Expand deck-controlled output-plan integration beyond stable table
-     routing toward full SPICE compatibility.
+     routing and scoped `.print` selection toward full SPICE compatibility.
    - Define a deliberate `.control` subset; explicit unsupported-feature
      diagnostics are now present for the current non-executed state.
 


### PR DESCRIPTION
## Summary
- parse scoped `.print <analysis> ...` cards as deck output selections across Python, Rust, and TypeScript
- route `.print` probes through the existing selected deck table output helpers with normalized/deduplicated probes
- add diagnostics for missing `.print` probes, unsupported `.print` analyses, and malformed output probes; update docs/changelogs/plan

## Verification
- `PYTHONPATH="$(find code/packages/python -maxdepth 2 -type d -name src | paste -sd: -)" /Users/adhithya/.local/share/mise/installs/python/3.12.13/bin/python3 -m ruff check code/packages/python/spice-engine/src/spice_engine/__init__.py code/packages/python/spice-engine/src/spice_engine/compatibility.py code/packages/python/spice-engine/src/spice_engine/engine.py code/packages/python/spice-engine/tests/test_compatibility.py code/packages/python/spice-engine/tests/test_engine.py`
- `PYTHONPATH="$(find code/packages/python -maxdepth 2 -type d -name src | paste -sd: -)" /Users/adhithya/.local/share/mise/installs/python/3.12.13/bin/python3 -m pytest code/packages/python/spice-engine/tests -q --no-cov`
- `npm --prefix code/packages/typescript/spice-engine ci`
- `npm --prefix code/packages/typescript/spice-engine run build`
- `npm --prefix code/packages/typescript/spice-engine test`
- `cargo fmt --manifest-path code/packages/rust/spice-engine/Cargo.toml --check`
- `cargo test --manifest-path code/packages/rust/spice-engine/Cargo.toml`
- `git diff --check`
- `git diff --cached --check`