### PR TITLE
refactor(mycin): CC-6 step-therapy as an ENGINE constraint (not a Python re-filter)

### DIFF
--- a/code/specs/data/mycin-2026/CHART-AS-CONSTRAINTS.md
+++ b/code/specs/data/mycin-2026/CHART-AS-CONSTRAINTS.md
@@ -172,8 +172,10 @@ risks Y") — decision support, not a hidden choice.
   **CC-5b** spider grounding.
 - **CC-6 — insurance / step-therapy (§5). ✅ DONE.** A payer step-therapy rule ("won't
   approve Y until X tried") enters as a `step_therapy` chart fact (`restricted:prerequisite`)
-  + `prior_failed` facts (drugs already tried); the precedence `x_Y ≤ tried_X` is realized as
-  a reimbursement-only exclusion (`reimbursement_blocked`). `derive()` solves TWICE: `regimen`
+  + `prior_failed` facts (drugs already tried); the precedence `x_Y ≤ tried_X` is emitted as an
+  EXPLICIT engine constraint `constrain x_Y <= 0` in the reimbursement program (the known-untried
+  `tried_X = 0` folded in) — enforced by the constraint solver and auditable in the program, NOT
+  pre-filtered in Python. `derive()` solves TWICE: `regimen`
   is the clinically optimal one; `reimbursement` carries the payer-covered regimen, the
   `blocked` drugs, whether it `differs_from_clinical`, and a note. Reimbursement infeasibility
   (a rule blocking a clinically-forced drug → covered = INFEASIBLE) is surfaced **distinctly**

--- a/code/specs/data/mycin-2026/treatment/antibiotics/chart_to_cop.py
+++ b/code/specs/data/mycin-2026/treatment/antibiotics/chart_to_cop.py
@@ -351,8 +351,12 @@ def derive(cli: Path, facts: list[ChartFact], disease: str = "meningitis") -> di
     reimbursement = None
     if cop.step_therapy:
         blocked = reimbursement_blocked(cop.step_therapy, cop.tried)
+        # The precedence is enforced BY THE ENGINE: blocked drugs are pinned to 0 via an
+        # explicit `constrain x_Y <= 0` clause in the reimbursement program (step_blocked),
+        # not removed from candidates in Python — so the payer constraint is auditable in
+        # the emitted program and the covered-infeasibility verdict is the solver's.
         cov = nsc.solve(cli, cop.organisms, cop.exclusions, cop.defeated,
-                        excluded_drugs | blocked, cop.weights)
+                        excluded_drugs, cop.weights, step_blocked=blocked)
         differs = cov["regimen"] != res["regimen"]
         if cov["regimen"] is None:
             note = ("reimbursement-INFEASIBLE under step therapy: the only regimens covering "

--- a/code/specs/data/mycin-2026/treatment/antibiotics/native_setcover.py
+++ b/code/specs/data/mycin-2026/treatment/antibiotics/native_setcover.py
@@ -56,7 +56,8 @@ def _sym(prefix: str, *parts: str) -> str:
 def emit_program(organisms: list[str], exclusions: set[str],
                  defeated: set[tuple[str, str]] = frozenset(),
                  dose_excluded: set[str] = frozenset(),
-                 weights: tuple[int, int] = reg.DEFAULT_WEIGHTS) -> tuple[str, dict, bool]:
+                 weights: tuple[int, int] = reg.DEFAULT_WEIGHTS,
+                 step_blocked: set[str] = frozenset()) -> tuple[str, dict, bool]:
     """Emit the adj-lang integer program for this cover. Returns (program text,
     {x_var → drug}, feasible?) — feasible is False if some organism has no coverer
     (the program is then trivially infeasible and the engine will say so).
@@ -73,7 +74,15 @@ def emit_program(organisms: list[str], exclusions: set[str],
     renal/interaction risks shrink it (dose_window UNSAT). Such a drug is dropped from the
     candidate set before the cover is built, so the optimizer re-derives around it (or
     abstains if it was load-bearing) — dose feasibility folded INTO the cover, not a
-    post-hoc warning."""
+    post-hoc warning.
+
+    `step_blocked` (CC-6) is the set of drugs a payer step-therapy rule blocks because
+    their prerequisite hasn't been tried. Unlike dose_excluded (which removes a drug from
+    the cover entirely on clinical grounds), a step-blocked drug stays a first-class
+    variable but is pinned to 0 by an EXPLICIT precedence constraint `x_Y <= 0` — the
+    `x_Y ≤ tried_X` precedence with the known-untried `tried_X = 0` folded in. The
+    reimbursement constraint is thus enforced BY THE ENGINE and visible in the program
+    (auditable / appealable), not pre-filtered away in Python."""
     cands = [d for d in reg.candidates(exclusions) if d not in dose_excluded]
     lines: list[str] = []
     xvar = {d: _sym("x", d) for d in cands}
@@ -115,6 +124,14 @@ def emit_program(organisms: list[str], exclusions: set[str],
             feasible = False  # no drug or combination covers this organism
             lines.append(f"constrain 0 >= 1   % UNCOVERABLE: {org}")
 
+    # CC-6 step-therapy precedence: `x_Y ≤ tried_Y`. The prerequisite is known-untried at
+    # compile time (tried_Y = 0), so the precedence folds to `x_Y <= 0` — an explicit,
+    # engine-enforced constraint that pins the payer-blocked drug out of the reimbursement
+    # solve. (Clinical solve passes step_blocked=∅, so it is unconstrained there.)
+    for d in cands:
+        if d in step_blocked:
+            lines.append(f"constrain {xvar[d]} <= 0   % step-therapy: reimbursement requires prerequisite tried")
+
     # CC-4 objective: minimize Σ (w_cost·tier + w_tox·side_effects)·x_d. The coefficient
     # is a non-negative integer (validated below), so this stays in the engine's INTEGER
     # optimizer. weights=(1,0) reproduces the historical tier-only objective exactly.
@@ -138,12 +155,15 @@ def emit_program(organisms: list[str], exclusions: set[str],
 def solve(cli: Path, organisms: list[str], exclusions: set[str],
           defeated: set[tuple[str, str]] = frozenset(),
           dose_excluded: set[str] = frozenset(),
-          weights: tuple[int, int] = reg.DEFAULT_WEIGHTS) -> dict:
+          weights: tuple[int, int] = reg.DEFAULT_WEIGHTS,
+          step_blocked: set[str] = frozenset()) -> dict:
     """Run the emitted program through the engine; return the engine's regimen.
     `defeated` carries culture-sensitivity results (resistant drug→organism edges);
     `dose_excluded` carries drugs with no safe-and-effective dose for this patient (CC-2);
-    `weights`=(w_cost, w_tox) is the CC-4 cost+side-effect objective blend (default (1,0))."""
-    program, var_to_drug, _ = emit_program(organisms, exclusions, defeated, dose_excluded, weights)
+    `weights`=(w_cost, w_tox) is the CC-4 cost+side-effect objective blend (default (1,0));
+    `step_blocked` (CC-6) pins payer-blocked drugs to 0 via an explicit precedence constraint."""
+    program, var_to_drug, _ = emit_program(organisms, exclusions, defeated, dose_excluded,
+                                            weights, step_blocked)
     fd, name = tempfile.mkstemp(suffix=".adj", prefix="_tmp_native_", dir=HERE)
     p = Path(name)
     try:

--- a/code/specs/data/mycin-2026/treatment/antibiotics/test_native_setcover.py
+++ b/code/specs/data/mycin-2026/treatment/antibiotics/test_native_setcover.py
@@ -52,10 +52,23 @@ def test_side_effect_weights_loaded() -> None:
         assert isinstance(se, int) and not isinstance(se, bool) and se >= 0, (d, se)
 
 
+def test_step_therapy_emits_a_native_precedence_constraint() -> None:
+    """CC-6: a step-blocked drug is pinned out by an EXPLICIT `constrain x_Y <= 0` clause
+    in the emitted program (engine-enforced precedence) — not removed in Python. The drug
+    still gets its selector variable; only the constraint forces it to 0."""
+    prog, _, _ = ns.emit_program(
+        reg.SCENARIOS["post_neurosurgical_or_shunt"], set(), step_blocked={"cefepime"})
+    assert "symbol x_cefepime : bool" in prog           # still a first-class variable
+    assert "constrain x_cefepime <= 0" in prog, prog     # ...pinned out by a real constraint
+    plain, _, _ = ns.emit_program(reg.SCENARIOS["post_neurosurgical_or_shunt"], set())
+    assert "constrain x_cefepime <= 0" not in plain      # absent without a step block
+
+
 def main() -> int:
     test_emit_is_well_formed()
     test_default_weights_reproduce_tier_only_objective()
     test_side_effect_weights_loaded()
+    test_step_therapy_emits_a_native_precedence_constraint()
     cli = decide_mod.find_cli()
     if cli is None:
         print("test_native_setcover: PASS (emit + CC-4 weight checks); "


### PR DESCRIPTION
## Make insurance a real constraint — first unit of the ADJ-first refactor

Follow-up to CC-6 (#5966, merged), addressing the review: *insurance should be modeled as constraints, and reasoning shouldn't live in Python.*

CC-6 originally realized the step-therapy precedence `x_Y ≤ tried_X` as a **Python set-difference** (`reimbursement_blocked` removed the drug from the candidate list before a second solve). This reworks it so the precedence is an **explicit adj-lang constraint the engine enforces**:

- `native_setcover.emit_program` gains `step_blocked` → for each blocked drug (which keeps its first-class selector variable) it emits `constrain x_<drug> <= 0   % step-therapy: reimbursement requires prerequisite tried`. The known-untried `tried_X = 0` is folded into the precedence.
- `chart_to_cop.derive` passes `step_blocked=blocked` to the reimbursement solve (instead of unioning it into the candidate-removing `dose_excluded`).
- `reimbursement_blocked` stays as the chart→constraint **mapping** (which drug, because which prerequisite — the compiler's job); the **constraint itself** is now engine-native, auditable in the emitted program, and the covered-infeasibility verdict is the constraint solver's.

Behavior is unchanged (same dual clinical-vs-reimbursement regimens) — the payer rule is now a real constraint, not a Python pre-filter. New test asserts `emit_program(step_blocked={cefepime})` emits both `symbol x_cefepime` and `constrain x_cefepime <= 0` (absent without a block). All treatment tests + downstream `test_board_eval` 12/12 green, ruff clean. Security review passed.

**This is the first step of the refactor-first push** to move MYCIN's reasoning out of Python and into ADJ (decisions/constraints belong in the emitted program the engine evaluates). Next units: `decide_timing` (CC-5) and the contraindication/exclusion logic → engine constraints/clauses; the `compile_cop` fact→constraint mapping → ADJ; `board_eval`'s Python `RelationStore` → the native recall path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)