### PR TITLE
feat(web01a-3): ShardedServer — opt-in parallel serving in the conduit facade

### DIFF
--- a/code/packages/rust/conduit/CHANGELOG.md
+++ b/code/packages/rust/conduit/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to this package will be documented in this file.
 
+## [0.2.0] - 2026-06-16
+
+### Added
+
+- **`ShardedServer` (WEB01a-3)** — an opt-in parallel server. Where `Server`
+  runs every connection on a single reactor thread, `ShardedServer::bind(host,
+  port, worker_count, app)` dispatches handlers across `worker_count` reactor
+  shards (via `web_core::ShardedWebServer`), so requests on different connections
+  are handled concurrently and a slow/CPU-bound handler no longer stalls the
+  whole server. Mirrors `Server`'s surface (`bind` / `bind_with_options` /
+  `serve` / `local_addr` / `stop_handle`) plus `worker_count`. Routing, hooks,
+  `halt`, and HTTP/1.1 per-connection response ordering are unchanged — only the
+  degree of concurrency differs. `Server` (single reactor) remains the default;
+  parallelism is opt-in. See `code/specs/WEB01-async-web-core.md`.
+- Test `sharded_server_dispatches_handlers_concurrently` deterministically proves
+  cross-shard parallelism through the full facade (observed max in-flight
+  handlers >= 2 — a single reactor can never exceed 1).
+
 ## [0.1.0] - 2026-05-05
 
 ### Added

--- a/code/packages/rust/conduit/Cargo.toml
+++ b/code/packages/rust/conduit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conduit"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "Rust-native Conduit web framework facade over web-core"
 license = "MIT"

--- a/code/packages/rust/conduit/README.md
+++ b/code/packages/rust/conduit/README.md
@@ -37,7 +37,11 @@ server.serve()?;
 
 - `Application` — route registration, settings, before/after hooks, custom 404,
   custom 405, and panic recovery hooks
-- `Server` — platform-native server binding over `web-core::WebServer`
+- `Server` — platform-native single-reactor server binding over `web-core::WebServer`
+- `ShardedServer` — opt-in **parallel** server (WEB01) over `web-core::ShardedWebServer`:
+  `ShardedServer::bind(host, port, worker_count, app)` dispatches handlers across
+  `worker_count` reactor shards so requests on different connections run
+  concurrently. Same surface and semantics as `Server`; `Server` stays the default.
 - `RequestExt` — convenience accessors for route params, query params, and body text
 - response helpers — `text`, `html`, `json`, `redirect`, `halt`, and explicit-status
   variants

--- a/code/packages/rust/conduit/src/lib.rs
+++ b/code/packages/rust/conduit/src/lib.rs
@@ -23,7 +23,7 @@ use std::str::Utf8Error;
 use std::sync::Arc;
 
 use embeddable_http_server::{HttpRequest, HttpResponse, HttpServerOptions};
-use tcp_runtime::{PlatformError, StopHandle};
+use tcp_runtime::{PlatformError, ShardedStopHandle, StopHandle};
 use web_core::{LogLevel, WebApp, WebRequest, WebResponse};
 
 /// Request type exposed to Rust Conduit handlers.
@@ -370,6 +370,102 @@ impl Server {
     }
 }
 
+#[cfg(target_os = "linux")]
+type NativeShardedServer = web_core::ShardedWebServer<transport_platform::linux::EpollTransportPlatform>;
+
+#[cfg(any(
+    target_os = "macos",
+    target_os = "freebsd",
+    target_os = "openbsd",
+    target_os = "netbsd",
+    target_os = "dragonfly"
+))]
+type NativeShardedServer = web_core::ShardedWebServer<transport_platform::bsd::KqueueTransportPlatform>;
+
+#[cfg(target_os = "windows")]
+type NativeShardedServer = web_core::ShardedWebServer<transport_platform::windows::WindowsTransportPlatform>;
+
+/// A **parallel** Conduit server (WEB01a-3): the opt-in counterpart of [`Server`].
+///
+/// [`Server`] runs every connection on a single reactor thread. `ShardedServer`
+/// dispatches across `worker_count` reactor shards (a `web_core::ShardedWebServer`),
+/// so requests on different connections are handled **concurrently** — a slow or
+/// CPU-bound handler no longer stalls the whole server. The application is shared
+/// (`Arc`) across shards unchanged; routes, hooks, `halt`, etc. behave exactly as
+/// with [`Server`], and HTTP/1.1 per-connection response ordering is preserved
+/// (each connection stays on one shard).
+///
+/// Parallelism is **opt-in**: keep using [`Server`] for the default single-reactor
+/// behaviour; reach for `ShardedServer` with `worker_count > 1` to scale across
+/// cores. See `code/specs/WEB01-async-web-core.md`.
+pub struct ShardedServer {
+    inner: NativeShardedServer,
+}
+
+impl ShardedServer {
+    /// Bind to `host:port` with `worker_count` reactor shards and default options.
+    pub fn bind(
+        host: &str,
+        port: u16,
+        worker_count: usize,
+        app: Application,
+    ) -> Result<Self, PlatformError> {
+        Self::bind_with_options(host, port, worker_count, HttpServerOptions::default(), app)
+    }
+
+    /// Bind to `host:port` with `worker_count` reactor shards and explicit options.
+    pub fn bind_with_options(
+        host: &str,
+        port: u16,
+        worker_count: usize,
+        options: HttpServerOptions,
+        app: Application,
+    ) -> Result<Self, PlatformError> {
+        let addr = format!("{host}:{port}");
+        let app = Arc::new(app.into_web_app());
+
+        #[cfg(target_os = "linux")]
+        let inner =
+            web_core::ShardedWebServer::bind_epoll_sharded(addr, options, worker_count, app)?;
+
+        #[cfg(any(
+            target_os = "macos",
+            target_os = "freebsd",
+            target_os = "openbsd",
+            target_os = "netbsd",
+            target_os = "dragonfly"
+        ))]
+        let inner =
+            web_core::ShardedWebServer::bind_kqueue_sharded(addr, options, worker_count, app)?;
+
+        #[cfg(target_os = "windows")]
+        let inner =
+            web_core::ShardedWebServer::bind_windows_sharded(addr, options, worker_count, app)?;
+
+        Ok(Self { inner })
+    }
+
+    /// The local socket address the server bound to.
+    pub fn local_addr(&self) -> SocketAddr {
+        self.inner.local_addr()
+    }
+
+    /// The number of reactor shards (the handler-parallelism degree).
+    pub fn worker_count(&self) -> usize {
+        self.inner.worker_count()
+    }
+
+    /// Handle that can stop every shard from another thread.
+    pub fn stop_handle(&self) -> ShardedStopHandle {
+        self.inner.stop_handle()
+    }
+
+    /// Serve requests until stopped.
+    pub fn serve(&mut self) -> Result<(), PlatformError> {
+        self.inner.serve()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::io::{BufRead, BufReader, Read, Write};
@@ -573,5 +669,71 @@ mod tests {
     #[test]
     fn json_string_escaping_handles_control_characters() {
         assert_eq!(escape_json_string("a\"b\\c\n"), "a\\\"b\\\\c\\n");
+    }
+
+    /// WEB01a-3: a `ShardedServer` dispatches Conduit handlers concurrently across
+    /// its shards. Proven deterministically (not by wall-clock, which flakes under
+    /// CI load): the handler bumps an in-flight gauge, holds briefly, and records
+    /// the max simultaneous handlers. A single-reactor server could never exceed 1;
+    /// observing >= 2 proves real cross-shard parallelism. Every concurrent request
+    /// also gets a correct 200, so parallelism preserves the request/response
+    /// contract through the full facade (`Application` → `WebApp` → shards).
+    #[cfg(not(target_os = "windows"))]
+    #[test]
+    fn sharded_server_dispatches_handlers_concurrently() {
+        let worker_count = 4;
+        let client_count = 8;
+
+        let in_flight = Arc::new(AtomicUsize::new(0));
+        let max_in_flight = Arc::new(AtomicUsize::new(0));
+        let h_in_flight = Arc::clone(&in_flight);
+        let h_max = Arc::clone(&max_in_flight);
+
+        let mut app = Application::new();
+        app.get("/work", move |_| {
+            let now = h_in_flight.fetch_add(1, Ordering::SeqCst) + 1;
+            h_max.fetch_max(now, Ordering::SeqCst);
+            // A sleeping handler does not hold a core, so overlap is observable
+            // regardless of the CI runner's core count.
+            thread::sleep(Duration::from_millis(60));
+            h_in_flight.fetch_sub(1, Ordering::SeqCst);
+            text("ok")
+        });
+
+        let mut server =
+            ShardedServer::bind("127.0.0.1", 0, worker_count, app).expect("bind sharded");
+        assert_eq!(server.worker_count(), worker_count, "all requested shards spawned");
+        let port = server.local_addr().port();
+        let stop = server.stop_handle();
+        thread::spawn(move || {
+            let _ = server.serve();
+        });
+        thread::sleep(Duration::from_millis(20));
+
+        let barrier = Arc::new(std::sync::Barrier::new(client_count));
+        let clients: Vec<_> = (0..client_count)
+            .map(|_| {
+                let barrier = Arc::clone(&barrier);
+                thread::spawn(move || {
+                    barrier.wait();
+                    request(port, "GET", "/work", "")
+                })
+            })
+            .collect();
+
+        for client in clients {
+            let (status, body) = client.join().expect("client thread");
+            assert_eq!(status, 200);
+            assert_eq!(body, "ok");
+        }
+
+        let observed_max = max_in_flight.load(Ordering::SeqCst);
+        assert!(
+            observed_max >= 2,
+            "expected concurrent handler dispatch across shards; max in-flight was \
+             {observed_max} (a single reactor would never exceed 1)",
+        );
+
+        stop.stop();
     }
 }


### PR DESCRIPTION
## Summary

Final step of the **WEB01 Path-A** arc. [WEB01a-1 (#5949)](https://github.com/adhithyan15/coding-adventures/pull/5949) added the sharded HTTP primitive; [WEB01a-2 (#5968)](https://github.com/adhithyan15/coding-adventures/pull/5968) wired it into `web-core` (`ShardedWebServer`); this exposes it through the Rust `conduit` facade so applications can **opt into parallel serving**.

`conduit` 0.2.0 gains **`ShardedServer`**: `ShardedServer::bind(host, port, worker_count, app)` dispatches handlers across `worker_count` reactor shards, so requests on different connections run concurrently and a slow/CPU-bound handler no longer stalls the whole server. It mirrors `Server`'s surface (`bind` / `bind_with_options` / `serve` / `local_addr` / `stop_handle`) plus `worker_count`. Routing, hooks, `halt`, and HTTP/1.1 per-connection response ordering are unchanged — only the degree of concurrency differs.

**Opt-in:** `Server` (single reactor) is untouched and stays the default; callers reach for `ShardedServer` with `worker_count > 1`. (The Rust facade is the reference opt-in; per-language native bridges can surface the same `worker_count` knob in follow-ups.)

## Test plan

- [x] `sharded_server_dispatches_handlers_concurrently` — **deterministic** proof through the *full* facade (`Application` → `WebApp` → shards): in-flight gauge ≥ 2 is impossible under serial dispatch; every concurrent request gets a correct 200. Not a flaky wall-clock threshold.
- [x] conduit's 7 tests pass; clippy-clean; README + CHANGELOG updated
- [x] `/security-review` passed (faithful mirror of the trusted `Server`; no new unsafe or shared state)
- [ ] CI green

> This completes **WEB01a** (Path A — sharded reactors). **WEB01b** (the in-process mailbox / deferred-response path) remains deferred per the spec — to be taken on only if benchmarks justify its added ordering/backpressure complexity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)