### PR TITLE
Add SPICE plot output routing

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ### Added
 
+- **Parsed plot output routing** —
+  `resolve_deck_outputs()`, `select_deck_output_probes()`, and
+  `format_deck_*_table()` now route scoped `.plot <analysis> ...` output
+  cards alongside `.save`, `.probe`, and `.print`, matching Rust and
+  TypeScript.
+
 - **Parsed print output routing** —
   `resolve_deck_outputs()`, `select_deck_output_probes()`, and
   `format_deck_*_table()` now route scoped `.print <analysis> ...` output

--- a/code/packages/python/spice-engine/README.md
+++ b/code/packages/python/spice-engine/README.md
@@ -64,7 +64,7 @@ print(result.diagnostics.solver)   # "dense_real" or "sparse_real"
 | `noise_ac` | `.NOISE` | Small-signal noise PSD (adjoint method) |
 | `fourier` | `.FOUR` | Harmonic magnitudes/phases and THD from transient output |
 | `format_dc_table`, `format_transient_table` | `.PRINT` / `.PLOT` output | Stable tabular node voltages and branch currents |
-| `resolve_deck_outputs`, `format_deck_*_table` | `.SAVE` / `.PROBE` output | Parsed deck-selected OP, DC sweep, AC, and transient tables |
+| `resolve_deck_outputs`, `format_deck_*_table` | `.SAVE` / `.PROBE` / `.PRINT` / `.PLOT` output | Parsed deck-selected OP, DC sweep, AC, and transient tables |
 | `format_deck_run_artifact_table` | Deck execution artifact | Stable selected-run row, output-probe, measurement, and Fourier counts |
 | `measure_transient_probe`, `measure_dc_sweep_probe`, `measure_ac_sweep_probe`, `format_measurement_table` | `.MEASURE` output | Stable scalar transient, DC sweep, and AC sweep probe measurements |
 
@@ -114,8 +114,9 @@ filtering, use `.tran TSTEP` as the output print grid, apply `MAXSTEP` as an
 internal fixed-step cap, and carry `UIC` initial-condition intent through that
 stable transient table surface.
 `resolve_deck_outputs()` and `select_deck_output_probes()` extract `.save`,
-scoped or global `.probe`, and scoped `.print <analysis> ...` cards before
-`.end`, normalize and deduplicate output probes in deck order, and feed
+scoped or global `.probe`, scoped `.print <analysis> ...`, and scoped
+`.plot <analysis> ...` cards before `.end`, normalize and deduplicate output
+probes in deck order, and feed
 `format_deck_op_table()`,
 `format_deck_dc_sweep_table()`, `format_deck_ac_table()`, and
 `format_deck_transient_table()` for stable deck-selected text output.
@@ -186,10 +187,10 @@ signatures, arguments, or empty expressions.
 `FIND ... AT=` sample points and `WHEN probe=target` crossings with optional
 `RISE`, `FALL`, or `CROSS` counters, and reports stable diagnostics for
 unsupported analyses, modes, options, expressions, and invalid windows.
-`resolve_deck_outputs()` extracts `.save`, `.probe`, and `.print` cards before
-`.end`, preserves non-output active lines, and reports stable diagnostics for
-missing probe lists, unsupported `.print` analyses, or malformed `V(node)` /
-`I(source)` probes.
+`resolve_deck_outputs()` extracts `.save`, `.probe`, `.print`, and `.plot`
+cards before `.end`, preserves non-output active lines, and reports stable
+diagnostics for missing probe lists, unsupported scoped output analyses, or
+malformed `V(node)` / `I(source)` probes.
 `resolve_deck_analyses()` extracts `.op`, `.dc`, `.ac`, and `.tran` cards
 before `.end`, preserves non-analysis active lines, and reports stable
 diagnostics for malformed deck-level analysis controls.

--- a/code/packages/python/spice-engine/src/spice_engine/compatibility.py
+++ b/code/packages/python/spice-engine/src/spice_engine/compatibility.py
@@ -268,7 +268,7 @@ class DeckFourierSummary:
 
 @dataclass(frozen=True, slots=True)
 class DeckOutputSelection:
-    """A parsed ``.save``, ``.probe``, or ``.print`` output selection card."""
+    """A parsed ``.save``, ``.probe``, ``.print``, or ``.plot`` output card."""
 
     directive: str
     analysis: str | None
@@ -723,7 +723,7 @@ def resolve_deck_fourier(netlist: str) -> DeckFourierSummary:
 
 
 def resolve_deck_outputs(netlist: str) -> DeckOutputSummary:
-    """Extract supported ``.save``, ``.probe``, and ``.print`` cards."""
+    """Extract supported ``.save``, ``.probe``, ``.print``, and ``.plot`` cards."""
 
     state = _DeckOutputState()
     active_lines: list[str] = []
@@ -737,7 +737,7 @@ def resolve_deck_outputs(netlist: str) -> DeckOutputSummary:
         if directive == ".end":
             end_line_number = line_number
             break
-        if directive in {".save", ".probe", ".print"}:
+        if directive in {".save", ".probe", ".print", ".plot"}:
             _resolve_output_line(stripped, line_number, directive, state)
             continue
         active_lines.append(stripped)
@@ -2174,8 +2174,8 @@ def _resolve_output_line(
     tokens = _directive_tokens(line)
     if len(tokens) < 2:
         message = (
-            ".print requires an analysis token and at least one probe token"
-            if directive == ".print"
+            f"{directive} requires an analysis token and at least one probe token"
+            if directive in {".print", ".plot"}
             else f"{directive} requires at least one probe token"
         )
         _add_output_diagnostic(
@@ -2189,14 +2189,14 @@ def _resolve_output_line(
 
     analysis: str | None = None
     probe_tokens = tokens[1:]
-    if directive == ".print":
+    if directive in {".print", ".plot"}:
         if len(tokens) < 3:
             _add_output_diagnostic(
                 state,
                 code="SPICE_DECK_OUTPUT_ARGUMENT",
                 directive=directive,
                 line_number=line_number,
-                message=".print requires an analysis token and at least one probe token",
+                message=f"{directive} requires an analysis token and at least one probe token",
             )
             return
         analysis = _normalize_deck_output_analysis(tokens[1])
@@ -2206,7 +2206,7 @@ def _resolve_output_line(
                 code="SPICE_DECK_OUTPUT_ANALYSIS",
                 directive=directive,
                 line_number=line_number,
-                message=f".print analysis must be op, dc, ac, or tran, got {tokens[1]!r}",
+                message=f"{directive} analysis must be op, dc, ac, or tran, got {tokens[1]!r}",
                 token=tokens[1],
             )
             return

--- a/code/packages/python/spice-engine/tests/test_compatibility.py
+++ b/code/packages/python/spice-engine/tests/test_compatibility.py
@@ -533,7 +533,7 @@ def test_resolve_deck_fourier_reports_unsupported_subset() -> None:
     }
 
 
-def test_resolve_deck_outputs_extracts_save_probe_and_print_cards() -> None:
+def test_resolve_deck_outputs_extracts_save_probe_print_and_plot_cards() -> None:
     summary = resolve_deck_outputs(
         """
 V1 in 0 DC 1
@@ -541,6 +541,7 @@ V1 in 0 DC 1
 .probe tran V(clk)
 .probe AC V(out)
 .print dc V(load) I(V2)
+.plot ac I(V3)
 .end
 .save V(ignored)
 """
@@ -548,7 +549,7 @@ V1 in 0 DC 1
 
     assert summary.active_lines == ("V1 in 0 DC 1",)
     assert summary.terminated is True
-    assert summary.end_line_number == 7
+    assert summary.end_line_number == 8
     assert summary.diagnostics == ()
     assert [
         (selection.directive, selection.analysis, selection.probes)
@@ -558,6 +559,7 @@ V1 in 0 DC 1
         (".probe", "tran", ("V(clk)",)),
         (".probe", "ac", ("V(out)",)),
         (".print", "dc", ("V(load)", "I(V2)")),
+        (".plot", "ac", ("I(V3)",)),
     ]
 
     assert select_deck_output_probes(
@@ -565,11 +567,12 @@ V1 in 0 DC 1
 .save V(out) I(V1)
 .probe tran V(out) V(clk)
 .print tran I(V2)
+.plot tran V(extra)
 .probe ac V(freq)
 .end
 """,
         "transient",
-    ) == ["V(out)", "I(V1)", "V(clk)", "I(V2)"]
+    ) == ["V(out)", "I(V1)", "V(clk)", "I(V2)", "V(extra)"]
 
 
 def test_resolve_deck_analyses_extracts_supported_cards() -> None:
@@ -712,18 +715,24 @@ def test_resolve_deck_outputs_reports_invalid_cards() -> None:
 .probe tran
 .print tran
 .print foo V(out)
+.plot tran
+.plot foo V(out)
 .save P(out)
 .probe dc V(out) bad-token
 .print dc bad-token
+.plot dc bad-token
 .end
 """
     )
 
     assert sorted(diagnostic.code for diagnostic in summary.diagnostics) == [
         "SPICE_DECK_OUTPUT_ANALYSIS",
+        "SPICE_DECK_OUTPUT_ANALYSIS",
         "SPICE_DECK_OUTPUT_ARGUMENT",
         "SPICE_DECK_OUTPUT_ARGUMENT",
         "SPICE_DECK_OUTPUT_ARGUMENT",
+        "SPICE_DECK_OUTPUT_ARGUMENT",
+        "SPICE_DECK_OUTPUT_PROBE",
         "SPICE_DECK_OUTPUT_PROBE",
         "SPICE_DECK_OUTPUT_PROBE",
         "SPICE_DECK_OUTPUT_PROBE",

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -6695,12 +6695,13 @@ def test_text_output_tables_are_stable_for_dc_and_transient_results() -> None:
     )
 
 
-def test_deck_output_tables_route_save_probe_print_cards() -> None:
+def test_deck_output_tables_route_save_probe_print_plot_cards() -> None:
     netlist = """
 .save V(out)
 .probe dc I(V1)
 .probe tran V(clk)
 .print tran V(ignored)
+.plot tran I(V1)
 .probe ac I(V1)
 .end
 """
@@ -6749,9 +6750,9 @@ def test_deck_output_tables_route_save_probe_print_cards() -> None:
         "1\tV1\t1.000000e+00\t5.000000e-01\t-5.000000e-04\n"
     )
     assert format_deck_transient_table(transient_points, netlist) == (
-        "Index\tTime\tV(out)\tV(clk)\tV(ignored)\n"
-        "0\t0.000000e+00\t0.000000e+00\t0.000000e+00\t1.000000e+00\n"
-        "1\t1.000000e-03\t5.000000e-01\t1.000000e+00\t2.000000e+00\n"
+        "Index\tTime\tV(out)\tV(clk)\tV(ignored)\tI(V1)\n"
+        "0\t0.000000e+00\t0.000000e+00\t0.000000e+00\t1.000000e+00\t0.000000e+00\n"
+        "1\t1.000000e-03\t5.000000e-01\t1.000000e+00\t2.000000e+00\t-5.000000e-04\n"
     )
     assert format_deck_ac_table(ac_result, netlist) == (
         "Index\tFrequency\tProbe\tReal\tImaginary\tMagnitude\tPhase\n"

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Add parsed `.plot <analysis> ...` output routing to `resolve_deck_outputs`,
+  `select_deck_output_probes`, and deck table formatters, matching Python and
+  TypeScript.
 - Add parsed `.print <analysis> ...` output routing to `resolve_deck_outputs`,
   `select_deck_output_probes`, and deck table formatters, matching Python and
   TypeScript.

--- a/code/packages/rust/spice-engine/README.md
+++ b/code/packages/rust/spice-engine/README.md
@@ -192,11 +192,12 @@ signatures, arguments, or empty expressions.
 `FIND ... AT=` sample points and `WHEN probe=target` crossings with optional
 `RISE`, `FALL`, or `CROSS` counters, and reports stable diagnostics for
 unsupported analyses, modes, options, expressions, and invalid windows.
-`resolve_deck_outputs` extracts `.save`, scoped or global `.probe`, and scoped
-`.print <analysis> ...` cards before `.end`, keeps non-output active lines,
-and reports stable diagnostics for missing probe lists, unsupported `.print`
-analyses, or malformed output probes. `select_deck_output_probes` deduplicates
-the selected probes for a requested analysis, while `format_deck_op_table`,
+`resolve_deck_outputs` extracts `.save`, scoped or global `.probe`, scoped
+`.print <analysis> ...`, and scoped `.plot <analysis> ...` cards before
+`.end`, keeps non-output active lines, and reports stable diagnostics for
+missing probe lists, unsupported scoped output analyses, or malformed output
+probes. `select_deck_output_probes` deduplicates the selected probes for a
+requested analysis, while `format_deck_op_table`,
 `format_deck_dc_sweep_table`, `format_deck_ac_table`, and
 `format_deck_transient_table` feed those deck-card selections into the stable
 text table formatters.

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -3811,7 +3811,10 @@ pub fn resolve_deck_outputs(netlist: &str) -> DeckOutputSummary {
             end_line_number = Some(line_number);
             break;
         }
-        if matches!(directive.as_deref(), Some(".save" | ".probe" | ".print")) {
+        if matches!(
+            directive.as_deref(),
+            Some(".save" | ".probe" | ".print" | ".plot")
+        ) {
             resolve_output_line(
                 stripped,
                 line_number,
@@ -5854,8 +5857,8 @@ fn resolve_output_line(
 ) {
     let tokens = directive_tokens(line);
     if tokens.len() < 2 {
-        let message = if directive == ".print" {
-            ".print requires an analysis token and at least one probe token".to_string()
+        let message = if matches!(directive, ".print" | ".plot") {
+            format!("{directive} requires an analysis token and at least one probe token")
         } else {
             format!("{directive} requires at least one probe token")
         };
@@ -5870,14 +5873,14 @@ fn resolve_output_line(
         return;
     }
 
-    let (analysis, probe_tokens) = if directive == ".print" {
+    let (analysis, probe_tokens) = if matches!(directive, ".print" | ".plot") {
         if tokens.len() < 3 {
             add_output_diagnostic(
                 state,
                 "SPICE_DECK_OUTPUT_ARGUMENT",
                 directive,
                 line_number,
-                ".print requires an analysis token and at least one probe token",
+                &format!("{directive} requires an analysis token and at least one probe token"),
                 None,
             );
             return;
@@ -5889,8 +5892,8 @@ fn resolve_output_line(
                 directive,
                 line_number,
                 &format!(
-                    ".print analysis must be op, dc, ac, or tran, got {:?}",
-                    tokens[1]
+                    "{directive} analysis must be op, dc, ac, or tran, got {:?}",
+                    tokens[1],
                 ),
                 Some(tokens[1].to_string()),
             );

--- a/code/packages/rust/spice-engine/tests/compatibility_tests.rs
+++ b/code/packages/rust/spice-engine/tests/compatibility_tests.rs
@@ -766,7 +766,7 @@ fn resolve_deck_fourier_reports_unsupported_subset() {
 }
 
 #[test]
-fn resolve_deck_outputs_extracts_save_probe_and_print_cards() {
+fn resolve_deck_outputs_extracts_save_probe_print_and_plot_cards() {
     let summary = resolve_deck_outputs(
         "
 V1 in 0 DC 1
@@ -774,6 +774,7 @@ V1 in 0 DC 1
 .probe tran V(clk)
 .probe AC V(out)
 .print dc V(load) I(V2)
+.plot ac I(V3)
 .end
 .save V(ignored)
 ",
@@ -781,7 +782,7 @@ V1 in 0 DC 1
 
     assert_eq!(summary.active_lines, vec!["V1 in 0 DC 1"]);
     assert!(summary.terminated);
-    assert_eq!(summary.end_line_number, Some(7));
+    assert_eq!(summary.end_line_number, Some(8));
     assert!(summary.diagnostics.is_empty());
     assert_eq!(
         summary
@@ -806,6 +807,7 @@ V1 in 0 DC 1
                 Some("dc"),
                 &["V(load)".to_string(), "I(V2)".to_string()][..]
             ),
+            (".plot", Some("ac"), &["I(V3)".to_string()][..]),
         ]
     );
 
@@ -815,13 +817,14 @@ V1 in 0 DC 1
 .save V(out) I(V1)
 .probe tran V(out) V(clk)
 .print tran I(V2)
+.plot tran V(extra)
 .probe ac V(freq)
 .end
 ",
             "transient",
         )
         .unwrap(),
-        vec!["V(out)", "I(V1)", "V(clk)", "I(V2)"]
+        vec!["V(out)", "I(V1)", "V(clk)", "I(V2)", "V(extra)"]
     );
 }
 
@@ -997,9 +1000,12 @@ fn resolve_deck_outputs_reports_invalid_cards() {
 .probe tran
 .print tran
 .print foo V(out)
+.plot tran
+.plot foo V(out)
 .save P(out)
 .probe dc V(out) bad-token
 .print dc bad-token
+.plot dc bad-token
 .end
 ",
     );
@@ -1014,9 +1020,12 @@ fn resolve_deck_outputs_reports_invalid_cards() {
         codes,
         vec![
             "SPICE_DECK_OUTPUT_ANALYSIS",
+            "SPICE_DECK_OUTPUT_ANALYSIS",
             "SPICE_DECK_OUTPUT_ARGUMENT",
             "SPICE_DECK_OUTPUT_ARGUMENT",
             "SPICE_DECK_OUTPUT_ARGUMENT",
+            "SPICE_DECK_OUTPUT_ARGUMENT",
+            "SPICE_DECK_OUTPUT_PROBE",
             "SPICE_DECK_OUTPUT_PROBE",
             "SPICE_DECK_OUTPUT_PROBE",
             "SPICE_DECK_OUTPUT_PROBE",

--- a/code/packages/rust/spice-engine/tests/transient_tests.rs
+++ b/code/packages/rust/spice-engine/tests/transient_tests.rs
@@ -1838,6 +1838,7 @@ fn transient_deck_output_cards_select_table_probes() {
 .save V(out) I(V1)
 .probe tran V(clk) V(out)
 .print tran V(ignored)
+.plot tran I(V1)
 .probe ac V(ignored)
 .end
 ",

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Add parsed `.plot <analysis> ...` output routing to `resolveDeckOutputs`,
+  `selectDeckOutputProbes`, and deck table formatters, matching Python and
+  Rust.
 - Add parsed `.print <analysis> ...` output routing to `resolveDeckOutputs`,
   `selectDeckOutputProbes`, and deck table formatters, matching Python and
   Rust.

--- a/code/packages/typescript/spice-engine/README.md
+++ b/code/packages/typescript/spice-engine/README.md
@@ -20,8 +20,9 @@ to thresholded transient probe outputs with stable schedule tables and VCD
 correlation output,
 stable text tables for selected node voltages, branch currents, AC phasors,
 Fourier harmonics, transfer-function results, pole-zero entries, and
-distortion harmonics, parsed `.save` / `.probe` / `.print` deck-selected
-output tables, and backward-Euler reactive-element companion models.
+distortion harmonics, parsed `.save` / `.probe` / `.print` / `.plot`
+deck-selected output tables, and backward-Euler reactive-element companion
+models.
 
 ```ts
 import {
@@ -100,8 +101,9 @@ results and a stable Fourier table. Executions also include selected-run
 artifact summaries plus `formatDeckRunArtifactTable` output for stable
 result-row, output-probe, measurement, and Fourier counts.
 `resolveDeckOutputs` and `selectDeckOutputProbes` extract `.save`, scoped or
-global `.probe`, and scoped `.print <analysis> ...` cards before `.end`,
-normalize and deduplicate output probes in deck order, and feed
+global `.probe`, scoped `.print <analysis> ...`, and scoped
+`.plot <analysis> ...` cards before `.end`, normalize and deduplicate output
+probes in deck order, and feed
 `formatDeckOpTable`,
 `formatDeckDcSweepTable`, `formatDeckAcTable`, and
 `formatDeckTransientTable` for stable deck-selected text output.
@@ -159,10 +161,10 @@ cards before `.end`, keeps non-measure active lines, evaluates optional
 `FIND ... AT=` sample points and `WHEN probe=target` crossings with optional
 `RISE`, `FALL`, or `CROSS` counters, and reports stable diagnostics for
 unsupported analyses, modes, options, expressions, and invalid windows.
-`resolveDeckOutputs` extracts `.save`, `.probe`, and `.print` cards before
-`.end`, preserves non-output active lines, and reports stable diagnostics for
-missing probe lists, unsupported `.print` analyses, or malformed `V(node)` /
-`I(source)` probes.
+`resolveDeckOutputs` extracts `.save`, `.probe`, `.print`, and `.plot` cards
+before `.end`, preserves non-output active lines, and reports stable
+diagnostics for missing probe lists, unsupported scoped output analyses, or
+malformed `V(node)` / `I(source)` probes.
 `resolveDeckAnalyses` extracts `.op`, `.dc`, `.ac`, and `.tran` cards before
 `.end`, preserves non-analysis active lines, and reports stable diagnostics for
 malformed deck-level analysis controls.

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -589,7 +589,7 @@ export interface DeckFourierSummary {
 }
 
 export interface DeckOutputSelection {
-  readonly directive: ".save" | ".probe" | ".print";
+  readonly directive: ".save" | ".probe" | ".print" | ".plot";
   readonly analysis?: "op" | "dc" | "ac" | "tran";
   readonly probes: readonly string[];
   readonly lineNumber: number;
@@ -597,7 +597,7 @@ export interface DeckOutputSelection {
 
 export interface DeckOutputDiagnostic {
   readonly code: string;
-  readonly directive: ".save" | ".probe" | ".print";
+  readonly directive: ".save" | ".probe" | ".print" | ".plot";
   readonly lineNumber: number;
   readonly message: string;
   readonly severity: "error" | "warning";
@@ -3088,7 +3088,7 @@ export function resolveDeckOutputs(netlist: string): DeckOutputSummary {
       endLineNumber = lineNumber;
       break;
     }
-    if (directive === ".save" || directive === ".probe" || directive === ".print") {
+    if (directive === ".save" || directive === ".probe" || directive === ".print" || directive === ".plot") {
       resolveOutputLine(stripped, lineNumber, directive, state);
       continue;
     }
@@ -4235,13 +4235,13 @@ function resolveFourierLine(
 function resolveOutputLine(
   line: string,
   lineNumber: number,
-  directive: ".save" | ".probe" | ".print",
+  directive: ".save" | ".probe" | ".print" | ".plot",
   state: DeckOutputState,
 ): void {
   const tokens = directiveTokens(line);
   if (tokens.length < 2) {
-    const message = directive === ".print"
-      ? ".print requires an analysis token and at least one probe token"
+    const message = directive === ".print" || directive === ".plot"
+      ? `${directive} requires an analysis token and at least one probe token`
       : `${directive} requires at least one probe token`;
     addOutputDiagnostic(state, {
       code: "SPICE_DECK_OUTPUT_ARGUMENT",
@@ -4254,13 +4254,13 @@ function resolveOutputLine(
 
   let analysis: DeckOutputSelection["analysis"];
   let probeTokens = tokens.slice(1);
-  if (directive === ".print") {
+  if (directive === ".print" || directive === ".plot") {
     if (tokens.length < 3) {
       addOutputDiagnostic(state, {
         code: "SPICE_DECK_OUTPUT_ARGUMENT",
         directive,
         lineNumber,
-        message: ".print requires an analysis token and at least one probe token",
+        message: `${directive} requires an analysis token and at least one probe token`,
       });
       return;
     }
@@ -4270,7 +4270,7 @@ function resolveOutputLine(
         code: "SPICE_DECK_OUTPUT_ANALYSIS",
         directive,
         lineNumber,
-        message: `.print analysis must be op, dc, ac, or tran, got ${JSON.stringify(tokens[1])}`,
+        message: `${directive} analysis must be op, dc, ac, or tran, got ${JSON.stringify(tokens[1])}`,
         token: tokens[1],
       });
       return;

--- a/code/packages/typescript/spice-engine/tests/compatibility.test.ts
+++ b/code/packages/typescript/spice-engine/tests/compatibility.test.ts
@@ -554,20 +554,21 @@ V1 in 0 SIN(0 1 1k)
     ]);
   });
 
-  it("extracts .save, .probe, and .print output cards", () => {
+  it("extracts .save, .probe, .print, and .plot output cards", () => {
     const summary = resolveDeckOutputs(`
 V1 in 0 DC 1
 .save V(out) i(V1)
 .probe tran V(clk)
 .probe AC V(out)
 .print dc V(load) I(V2)
+.plot ac I(V3)
 .end
 .save V(ignored)
 `);
 
     expect(summary.activeLines).toStrictEqual(["V1 in 0 DC 1"]);
     expect(summary.terminated).toBe(true);
-    expect(summary.endLineNumber).toBe(7);
+    expect(summary.endLineNumber).toBe(8);
     expect(summary.diagnostics).toStrictEqual([]);
     expect(
       summary.selections.map((selection) => [
@@ -580,6 +581,7 @@ V1 in 0 DC 1
       [".probe", "tran", ["V(clk)"]],
       [".probe", "ac", ["V(out)"]],
       [".print", "dc", ["V(load)", "I(V2)"]],
+      [".plot", "ac", ["I(V3)"]],
     ]);
 
     expect(
@@ -588,31 +590,38 @@ V1 in 0 DC 1
 .save V(out) I(V1)
 .probe tran V(out) V(clk)
 .print tran I(V2)
+.plot tran V(extra)
 .probe ac V(freq)
 .end
 `,
         "transient",
       ),
-    ).toStrictEqual(["V(out)", "I(V1)", "V(clk)", "I(V2)"]);
+    ).toStrictEqual(["V(out)", "I(V1)", "V(clk)", "I(V2)", "V(extra)"]);
   });
 
-  it("reports invalid .save, .probe, and .print output cards", () => {
+  it("reports invalid .save, .probe, .print, and .plot output cards", () => {
     const summary = resolveDeckOutputs(`
 .save
 .probe tran
 .print tran
 .print foo V(out)
+.plot tran
+.plot foo V(out)
 .save P(out)
 .probe dc V(out) bad-token
 .print dc bad-token
+.plot dc bad-token
 .end
 `);
 
     expect(summary.diagnostics.map((diagnostic) => diagnostic.code).sort()).toStrictEqual([
       "SPICE_DECK_OUTPUT_ANALYSIS",
+      "SPICE_DECK_OUTPUT_ANALYSIS",
       "SPICE_DECK_OUTPUT_ARGUMENT",
       "SPICE_DECK_OUTPUT_ARGUMENT",
       "SPICE_DECK_OUTPUT_ARGUMENT",
+      "SPICE_DECK_OUTPUT_ARGUMENT",
+      "SPICE_DECK_OUTPUT_PROBE",
       "SPICE_DECK_OUTPUT_PROBE",
       "SPICE_DECK_OUTPUT_PROBE",
       "SPICE_DECK_OUTPUT_PROBE",

--- a/code/packages/typescript/spice-engine/tests/transient.test.ts
+++ b/code/packages/typescript/spice-engine/tests/transient.test.ts
@@ -1430,7 +1430,7 @@ describe("transient", () => {
     expect(
       formatDeckTransientTable(
         points,
-        ".save V(mid)\n.probe tran V(vin)\n.print tran I(V1)\n.end\n",
+        ".save V(mid)\n.probe tran V(vin)\n.print tran I(V1)\n.plot tran V(vin)\n.end\n",
       ),
     ).toBe(
       "Index\tTime\tV(mid)\tV(vin)\tI(V1)\n" +

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -28,9 +28,10 @@ downstream tools to compare.
      diagnostic and solver footholds; transient scalar `.measure`-style output
      helpers now cover shared peak-to-peak and final-value measurement output,
      and parsed transient `.measure` / `.meas` cards can now feed those
-     measurement helpers from deck text; parsed `.save`, `.probe`, and
-     `.print <analysis> ...` cards now drive stable table output for
-     operating-point, DC sweep, AC sweep, and transient results; parsed
+     measurement helpers from deck text; parsed `.save`, `.probe`,
+     `.print <analysis> ...`, and `.plot <analysis> ...` cards now drive
+     stable table output for operating-point, DC sweep, AC sweep, and transient
+     results; parsed
      `.measure dc` / `.meas dc` cards now route DC
      sweep probe samples into the shared scalar measurement table surface;
      parsed `.measure ac` / `.meas ac` cards now route AC probe magnitudes over
@@ -481,6 +482,15 @@ downstream tools to compare.
       diagnostics distinguish missing `.print` probes, unsupported `.print`
       analyses, and malformed output probes.
 
+42. Parsed `.plot` output routing.
+    - Status: completed in this parsed plot output-routing slice.
+    - Python, Rust, and TypeScript now treat scoped
+      `.plot <analysis> V(node) I(source)` cards as deck output selections
+      alongside `.save`, `.probe`, and `.print`.
+    - Selected probes are normalized and deduplicated in deck order, while
+      diagnostics distinguish missing `.plot` probes, unsupported `.plot`
+      analyses, and malformed output probes.
+
 ## Backlog
 
 1. Deck execution layer.
@@ -489,7 +499,8 @@ downstream tools to compare.
      selected measurement artifacts, selected Fourier artifacts, and selected
      run summaries, plus output-plan integration beyond stable table routing.
    - Expand deck-controlled output-plan integration beyond stable table
-     routing and scoped `.print` selection toward full SPICE compatibility.
+     routing and scoped `.print` / `.plot` selection toward full SPICE
+     compatibility.
    - Define a deliberate `.control` subset; explicit unsupported-feature
      diagnostics are now present for the current non-executed state.
 


### PR DESCRIPTION
## Summary
- parse scoped `.plot <analysis> ...` cards as deck output selections across Python, Rust, and TypeScript
- route `.plot` probes through the existing normalized/deduplicated deck table output helpers alongside `.save`, `.probe`, and `.print`
- add diagnostics/tests/docs/changelog entries and mark the slice complete in the SPICE implementation plan

## Verification
- `PYTHONPATH="$(find code/packages/python -maxdepth 2 -type d -name src | paste -sd: -)" /Users/adhithya/.local/share/mise/installs/python/3.12.13/bin/python3 -m ruff check code/packages/python/spice-engine/src/spice_engine/__init__.py code/packages/python/spice-engine/src/spice_engine/compatibility.py code/packages/python/spice-engine/src/spice_engine/engine.py code/packages/python/spice-engine/tests/test_compatibility.py code/packages/python/spice-engine/tests/test_engine.py`
- `PYTHONPATH="$(find code/packages/python -maxdepth 2 -type d -name src | paste -sd: -)" /Users/adhithya/.local/share/mise/installs/python/3.12.13/bin/python3 -m pytest code/packages/python/spice-engine/tests -q --no-cov`
- `npm --prefix code/packages/typescript/spice-engine ci`
- `npm --prefix code/packages/typescript/spice-engine run build`
- `npm --prefix code/packages/typescript/spice-engine test`
- `cargo fmt --manifest-path code/packages/rust/spice-engine/Cargo.toml --check`
- `cargo test --manifest-path code/packages/rust/spice-engine/Cargo.toml`
- `git diff --check`
- `git diff --cached --check`