### PR TITLE
[codex] Add Hue archive restore summary

### DIFF
--- a/code/packages/rust/hue-core/CHANGELOG.md
+++ b/code/packages/rust/hue-core/CHANGELOG.md
@@ -95,6 +95,8 @@ All notable changes to this package will be documented in this file.
   readiness into final archive ingest checks.
 - Hue package release archive load summaries that turn archive ingest readiness
   into final archive load checks.
+- Hue package release archive restore summaries that turn archive load readiness
+  into final archive restore checks.
 - Hue discovery worker-run projection from generic `MdnsScanResult` envelopes,
   preserving scan parse failures as per-source D23 worker failures.
 - Hue discovery worker-run projection from aggregate `MdnsWorkerScanReport`

--- a/code/packages/rust/hue-core/README.md
+++ b/code/packages/rust/hue-core/README.md
@@ -135,6 +135,8 @@ packages a typed surface for:
   readiness into final archive ingest checks
 - Hue package release archive load summaries that turn archive ingest
   readiness into final archive load checks
+- Hue package release archive restore summaries that turn archive load
+  readiness into final archive restore checks
 
 ## Dependencies
 

--- a/code/packages/rust/hue-core/src/lib.rs
+++ b/code/packages/rust/hue-core/src/lib.rs
@@ -7165,6 +7165,288 @@ pub fn hue_package_release_archive_load_summary(
     HuePackageReleaseArchiveLoadSummary::from_pairing_plan(plan)
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct HuePackageReleaseArchiveRestoreSummary {
+    pub archive_load_summary: HuePackageReleaseArchiveLoadSummary,
+    pub required_archive_restore_check_count: usize,
+    pub passed_archive_restore_check_count: usize,
+    pub blocked_archive_restore_check_count: usize,
+    pub release_archive_load_ready: bool,
+    pub release_archive_ingest_ready: bool,
+    pub release_archive_import_ready: bool,
+    pub release_archive_export_ready: bool,
+    pub release_archive_distribution_ready: bool,
+    pub release_archive_acceptance_ready: bool,
+    pub release_archive_adoption_ready: bool,
+    pub release_archive_rollout_ready: bool,
+    pub release_archive_activation_ready: bool,
+    pub release_archive_approval_ready: bool,
+    pub release_archive_certification_ready: bool,
+    pub release_archive_validation_ready: bool,
+    pub release_archive_verification_ready: bool,
+    pub release_archive_publication_ready: bool,
+    pub release_archive_completion_ready: bool,
+    pub release_archive_supervisor_ready: bool,
+    pub release_archive_operator_ready: bool,
+    pub release_archive_dispatch_ready: bool,
+    pub release_archive_handoff_ready: bool,
+    pub release_archive_closure_ready: bool,
+    pub release_archive_signoff_ready: bool,
+    pub release_archive_ready: bool,
+    pub release_closure_ready: bool,
+    pub release_signoff_ready: bool,
+    pub release_audit_ready: bool,
+    pub operator_ready: bool,
+    pub coordination_ready: bool,
+    pub publish_gate_ready: bool,
+    pub release_archive_restore_ready: bool,
+}
+
+impl HuePackageReleaseArchiveRestoreSummary {
+    pub fn from_pairing_plan(plan: &HueBridgePairingPlan) -> Self {
+        Self::from_archive_load_summary(hue_package_release_archive_load_summary(plan))
+    }
+
+    pub fn from_archive_load_summary(
+        archive_load_summary: HuePackageReleaseArchiveLoadSummary,
+    ) -> Self {
+        let release_archive_load_ready = archive_load_summary.is_release_archive_load_ready();
+        let release_archive_ingest_ready = !archive_load_summary.needs_release_archive_ingest();
+        let release_archive_import_ready = !archive_load_summary.needs_release_archive_import();
+        let release_archive_export_ready = !archive_load_summary.needs_release_archive_export();
+        let release_archive_distribution_ready =
+            !archive_load_summary.needs_release_archive_distribution();
+        let release_archive_acceptance_ready =
+            !archive_load_summary.needs_release_archive_acceptance();
+        let release_archive_adoption_ready = !archive_load_summary.needs_release_archive_adoption();
+        let release_archive_rollout_ready = !archive_load_summary.needs_release_archive_rollout();
+        let release_archive_activation_ready =
+            !archive_load_summary.needs_release_archive_activation();
+        let release_archive_approval_ready = !archive_load_summary.needs_release_archive_approval();
+        let release_archive_certification_ready =
+            !archive_load_summary.needs_release_archive_certification();
+        let release_archive_validation_ready =
+            !archive_load_summary.needs_release_archive_validation();
+        let release_archive_verification_ready =
+            !archive_load_summary.needs_release_archive_verification();
+        let release_archive_publication_ready =
+            !archive_load_summary.needs_release_archive_publication();
+        let release_archive_completion_ready =
+            !archive_load_summary.needs_release_archive_completion();
+        let release_archive_supervisor_ready =
+            !archive_load_summary.needs_release_archive_supervisor();
+        let release_archive_operator_ready = !archive_load_summary.needs_release_archive_operator();
+        let release_archive_dispatch_ready = !archive_load_summary.needs_release_archive_dispatch();
+        let release_archive_handoff_ready = !archive_load_summary.needs_release_archive_handoff();
+        let release_archive_closure_ready = !archive_load_summary.needs_release_archive_closure();
+        let release_archive_signoff_ready = !archive_load_summary.needs_release_archive_signoff();
+        let release_archive_ready = !archive_load_summary.needs_release_archive();
+        let release_closure_ready = !archive_load_summary.needs_release_closure();
+        let release_signoff_ready = !archive_load_summary.needs_release_signoff();
+        let release_audit_ready = !archive_load_summary.needs_release_audit();
+        let operator_ready = !archive_load_summary.needs_operator_readiness();
+        let coordination_ready = !archive_load_summary.needs_coordination();
+        let publish_gate_ready = !archive_load_summary.needs_publish_gate();
+        let checks = [
+            release_archive_load_ready,
+            release_archive_ingest_ready,
+            release_archive_import_ready,
+            release_archive_export_ready,
+            release_archive_distribution_ready,
+            release_archive_acceptance_ready,
+            release_archive_adoption_ready,
+            release_archive_rollout_ready,
+            release_archive_activation_ready,
+            release_archive_approval_ready,
+            release_archive_certification_ready,
+            release_archive_validation_ready,
+            release_archive_verification_ready,
+            release_archive_publication_ready,
+            release_archive_completion_ready,
+            release_archive_supervisor_ready,
+            release_archive_operator_ready,
+            release_archive_dispatch_ready,
+            release_archive_handoff_ready,
+            release_archive_closure_ready,
+            release_archive_signoff_ready,
+            release_archive_ready,
+            release_closure_ready,
+            release_signoff_ready,
+            release_audit_ready,
+            operator_ready,
+            coordination_ready,
+            publish_gate_ready,
+        ];
+        let passed_archive_restore_check_count = checks.iter().filter(|ready| **ready).count();
+        let required_archive_restore_check_count = checks.len();
+        let blocked_archive_restore_check_count =
+            required_archive_restore_check_count - passed_archive_restore_check_count;
+        let release_archive_restore_ready = blocked_archive_restore_check_count == 0;
+
+        Self {
+            archive_load_summary,
+            required_archive_restore_check_count,
+            passed_archive_restore_check_count,
+            blocked_archive_restore_check_count,
+            release_archive_load_ready,
+            release_archive_ingest_ready,
+            release_archive_import_ready,
+            release_archive_export_ready,
+            release_archive_distribution_ready,
+            release_archive_acceptance_ready,
+            release_archive_adoption_ready,
+            release_archive_rollout_ready,
+            release_archive_activation_ready,
+            release_archive_approval_ready,
+            release_archive_certification_ready,
+            release_archive_validation_ready,
+            release_archive_verification_ready,
+            release_archive_publication_ready,
+            release_archive_completion_ready,
+            release_archive_supervisor_ready,
+            release_archive_operator_ready,
+            release_archive_dispatch_ready,
+            release_archive_handoff_ready,
+            release_archive_closure_ready,
+            release_archive_signoff_ready,
+            release_archive_ready,
+            release_closure_ready,
+            release_signoff_ready,
+            release_audit_ready,
+            operator_ready,
+            coordination_ready,
+            publish_gate_ready,
+            release_archive_restore_ready,
+        }
+    }
+
+    pub fn is_release_archive_restore_ready(self) -> bool {
+        self.release_archive_restore_ready
+    }
+
+    pub fn has_blocked_archive_restore_checks(self) -> bool {
+        self.blocked_archive_restore_check_count > 0
+    }
+
+    pub fn needs_release_archive_load(self) -> bool {
+        !self.release_archive_load_ready
+    }
+
+    pub fn needs_release_archive_ingest(self) -> bool {
+        !self.release_archive_ingest_ready
+    }
+
+    pub fn needs_release_archive_import(self) -> bool {
+        !self.release_archive_import_ready
+    }
+
+    pub fn needs_release_archive_export(self) -> bool {
+        !self.release_archive_export_ready
+    }
+
+    pub fn needs_release_archive_distribution(self) -> bool {
+        !self.release_archive_distribution_ready
+    }
+
+    pub fn needs_release_archive_acceptance(self) -> bool {
+        !self.release_archive_acceptance_ready
+    }
+
+    pub fn needs_release_archive_adoption(self) -> bool {
+        !self.release_archive_adoption_ready
+    }
+
+    pub fn needs_release_archive_rollout(self) -> bool {
+        !self.release_archive_rollout_ready
+    }
+
+    pub fn needs_release_archive_activation(self) -> bool {
+        !self.release_archive_activation_ready
+    }
+
+    pub fn needs_release_archive_approval(self) -> bool {
+        !self.release_archive_approval_ready
+    }
+
+    pub fn needs_release_archive_certification(self) -> bool {
+        !self.release_archive_certification_ready
+    }
+
+    pub fn needs_release_archive_validation(self) -> bool {
+        !self.release_archive_validation_ready
+    }
+
+    pub fn needs_release_archive_verification(self) -> bool {
+        !self.release_archive_verification_ready
+    }
+
+    pub fn needs_release_archive_publication(self) -> bool {
+        !self.release_archive_publication_ready
+    }
+
+    pub fn needs_release_archive_completion(self) -> bool {
+        !self.release_archive_completion_ready
+    }
+
+    pub fn needs_release_archive_supervisor(self) -> bool {
+        !self.release_archive_supervisor_ready
+    }
+
+    pub fn needs_release_archive_operator(self) -> bool {
+        !self.release_archive_operator_ready
+    }
+
+    pub fn needs_release_archive_dispatch(self) -> bool {
+        !self.release_archive_dispatch_ready
+    }
+
+    pub fn needs_release_archive_handoff(self) -> bool {
+        !self.release_archive_handoff_ready
+    }
+
+    pub fn needs_release_archive_closure(self) -> bool {
+        !self.release_archive_closure_ready
+    }
+
+    pub fn needs_release_archive_signoff(self) -> bool {
+        !self.release_archive_signoff_ready
+    }
+
+    pub fn needs_release_archive(self) -> bool {
+        !self.release_archive_ready
+    }
+
+    pub fn needs_release_closure(self) -> bool {
+        !self.release_closure_ready
+    }
+
+    pub fn needs_release_signoff(self) -> bool {
+        !self.release_signoff_ready
+    }
+
+    pub fn needs_release_audit(self) -> bool {
+        !self.release_audit_ready
+    }
+
+    pub fn needs_operator_readiness(self) -> bool {
+        !self.operator_ready
+    }
+
+    pub fn needs_coordination(self) -> bool {
+        !self.coordination_ready
+    }
+
+    pub fn needs_publish_gate(self) -> bool {
+        !self.publish_gate_ready
+    }
+}
+
+pub fn hue_package_release_archive_restore_summary(
+    plan: &HueBridgePairingPlan,
+) -> HuePackageReleaseArchiveRestoreSummary {
+    HuePackageReleaseArchiveRestoreSummary::from_pairing_plan(plan)
+}
+
 fn descriptor_declares_capability(descriptor: &IntegrationDescriptor, capability_id: &str) -> bool {
     descriptor
         .capabilities
@@ -14176,6 +14458,173 @@ mod tests {
         assert!(!summary.release_archive_load_ready);
         assert!(!summary.is_release_archive_load_ready());
         assert!(summary.has_blocked_archive_load_checks());
+        assert!(summary.needs_release_archive_ingest());
+        assert!(summary.needs_release_archive_import());
+        assert!(summary.needs_release_archive_export());
+        assert!(summary.needs_release_archive_distribution());
+        assert!(summary.needs_release_archive_acceptance());
+        assert!(summary.needs_release_archive_adoption());
+        assert!(summary.needs_release_archive_rollout());
+        assert!(summary.needs_release_archive_activation());
+        assert!(summary.needs_release_archive_approval());
+        assert!(summary.needs_release_archive_certification());
+        assert!(summary.needs_release_archive_validation());
+        assert!(summary.needs_release_archive_verification());
+        assert!(summary.needs_release_archive_publication());
+        assert!(summary.needs_release_archive_completion());
+        assert!(summary.needs_release_archive_supervisor());
+        assert!(summary.needs_release_archive_operator());
+        assert!(summary.needs_release_archive_dispatch());
+        assert!(summary.needs_release_archive_handoff());
+        assert!(summary.needs_release_archive_closure());
+        assert!(summary.needs_release_archive_signoff());
+        assert!(summary.needs_release_archive());
+        assert!(summary.needs_release_closure());
+        assert!(summary.needs_release_signoff());
+        assert!(summary.needs_release_audit());
+        assert!(summary.needs_operator_readiness());
+        assert!(summary.needs_coordination());
+        assert!(summary.needs_publish_gate());
+    }
+
+    #[test]
+    fn hue_package_release_archive_restore_summary_reports_ready_archive_restore() {
+        let plan = hue_pairing_plan_for_discovered_bridge(
+            DiscoveredHueBridge {
+                bridge_id: "001788fffeabcdef".to_string(),
+                address: "https://192.0.2.10".to_string(),
+                hardware_model: Some("BSB002".to_string()),
+                firmware_version: Some("1.60".to_string()),
+            },
+            "chief-of-staff",
+            "desk",
+        );
+
+        let summary = hue_package_release_archive_restore_summary(&plan);
+
+        assert_eq!(
+            summary.archive_load_summary,
+            hue_package_release_archive_load_summary(&plan)
+        );
+        assert_eq!(summary.required_archive_restore_check_count, 28);
+        assert_eq!(summary.passed_archive_restore_check_count, 28);
+        assert_eq!(summary.blocked_archive_restore_check_count, 0);
+        assert!(summary.release_archive_load_ready);
+        assert!(summary.release_archive_ingest_ready);
+        assert!(summary.release_archive_import_ready);
+        assert!(summary.release_archive_export_ready);
+        assert!(summary.release_archive_distribution_ready);
+        assert!(summary.release_archive_acceptance_ready);
+        assert!(summary.release_archive_adoption_ready);
+        assert!(summary.release_archive_rollout_ready);
+        assert!(summary.release_archive_activation_ready);
+        assert!(summary.release_archive_approval_ready);
+        assert!(summary.release_archive_certification_ready);
+        assert!(summary.release_archive_validation_ready);
+        assert!(summary.release_archive_verification_ready);
+        assert!(summary.release_archive_publication_ready);
+        assert!(summary.release_archive_completion_ready);
+        assert!(summary.release_archive_supervisor_ready);
+        assert!(summary.release_archive_operator_ready);
+        assert!(summary.release_archive_dispatch_ready);
+        assert!(summary.release_archive_handoff_ready);
+        assert!(summary.release_archive_closure_ready);
+        assert!(summary.release_archive_signoff_ready);
+        assert!(summary.release_archive_ready);
+        assert!(summary.release_closure_ready);
+        assert!(summary.release_signoff_ready);
+        assert!(summary.release_audit_ready);
+        assert!(summary.operator_ready);
+        assert!(summary.coordination_ready);
+        assert!(summary.publish_gate_ready);
+        assert!(summary.release_archive_restore_ready);
+        assert!(summary.is_release_archive_restore_ready());
+        assert!(!summary.has_blocked_archive_restore_checks());
+        assert!(!summary.needs_release_archive_load());
+        assert!(!summary.needs_release_archive_ingest());
+        assert!(!summary.needs_release_archive_import());
+        assert!(!summary.needs_release_archive_export());
+        assert!(!summary.needs_release_archive_distribution());
+        assert!(!summary.needs_release_archive_acceptance());
+        assert!(!summary.needs_release_archive_adoption());
+        assert!(!summary.needs_release_archive_rollout());
+        assert!(!summary.needs_release_archive_activation());
+        assert!(!summary.needs_release_archive_approval());
+        assert!(!summary.needs_release_archive_certification());
+        assert!(!summary.needs_release_archive_validation());
+        assert!(!summary.needs_release_archive_verification());
+        assert!(!summary.needs_release_archive_publication());
+        assert!(!summary.needs_release_archive_completion());
+        assert!(!summary.needs_release_archive_supervisor());
+        assert!(!summary.needs_release_archive_operator());
+        assert!(!summary.needs_release_archive_dispatch());
+        assert!(!summary.needs_release_archive_handoff());
+        assert!(!summary.needs_release_archive_closure());
+        assert!(!summary.needs_release_archive_signoff());
+        assert!(!summary.needs_release_archive());
+        assert!(!summary.needs_release_closure());
+        assert!(!summary.needs_release_signoff());
+        assert!(!summary.needs_release_audit());
+        assert!(!summary.needs_operator_readiness());
+        assert!(!summary.needs_coordination());
+        assert!(!summary.needs_publish_gate());
+    }
+
+    #[test]
+    fn hue_package_release_archive_restore_summary_routes_blocked_archive_restore() {
+        let mut plan = hue_pairing_plan_for_discovered_bridge(
+            DiscoveredHueBridge {
+                bridge_id: "001788fffeabcdef".to_string(),
+                address: "https://192.0.2.10".to_string(),
+                hardware_model: Some("BSB002".to_string()),
+                firmware_version: Some("1.60".to_string()),
+            },
+            "chief-of-staff",
+            "desk",
+        );
+        plan.bridge.address = None;
+        plan.registration_request.path = "/wrong/api".to_string();
+        plan.application_key_header = "x-application-key".to_string();
+        plan.event_stream_path = "/wrong/eventstream".to_string();
+        plan.requires_user_presence = false;
+
+        let summary = HuePackageReleaseArchiveRestoreSummary::from_pairing_plan(&plan);
+
+        assert_eq!(summary.required_archive_restore_check_count, 28);
+        assert_eq!(summary.passed_archive_restore_check_count, 0);
+        assert_eq!(summary.blocked_archive_restore_check_count, 28);
+        assert!(!summary.release_archive_load_ready);
+        assert!(!summary.release_archive_ingest_ready);
+        assert!(!summary.release_archive_import_ready);
+        assert!(!summary.release_archive_export_ready);
+        assert!(!summary.release_archive_distribution_ready);
+        assert!(!summary.release_archive_acceptance_ready);
+        assert!(!summary.release_archive_adoption_ready);
+        assert!(!summary.release_archive_rollout_ready);
+        assert!(!summary.release_archive_activation_ready);
+        assert!(!summary.release_archive_approval_ready);
+        assert!(!summary.release_archive_certification_ready);
+        assert!(!summary.release_archive_validation_ready);
+        assert!(!summary.release_archive_verification_ready);
+        assert!(!summary.release_archive_publication_ready);
+        assert!(!summary.release_archive_completion_ready);
+        assert!(!summary.release_archive_supervisor_ready);
+        assert!(!summary.release_archive_operator_ready);
+        assert!(!summary.release_archive_dispatch_ready);
+        assert!(!summary.release_archive_handoff_ready);
+        assert!(!summary.release_archive_closure_ready);
+        assert!(!summary.release_archive_signoff_ready);
+        assert!(!summary.release_archive_ready);
+        assert!(!summary.release_closure_ready);
+        assert!(!summary.release_signoff_ready);
+        assert!(!summary.release_audit_ready);
+        assert!(!summary.operator_ready);
+        assert!(!summary.coordination_ready);
+        assert!(!summary.publish_gate_ready);
+        assert!(!summary.release_archive_restore_ready);
+        assert!(!summary.is_release_archive_restore_ready());
+        assert!(summary.has_blocked_archive_restore_checks());
+        assert!(summary.needs_release_archive_load());
         assert!(summary.needs_release_archive_ingest());
         assert!(summary.needs_release_archive_import());
         assert!(summary.needs_release_archive_export());


### PR DESCRIPTION
## Summary
- add Hue package release archive restore summaries after archive load readiness
- expose restore readiness, blocked counts, and inherited archive/release gate helpers
- document the new Hue archive restore summary step

## Validation
- cargo fmt --manifest-path code\packages\rust\hue-core\Cargo.toml
- git diff --check
- cargo test --manifest-path code\packages\rust\hue-core\Cargo.toml hue_package_release_archive_restore_summary
- cargo test --manifest-path code\packages\rust\hue-core\Cargo.toml