### PR TITLE
feat(spreadsheet facades): expose insert/delete rows & columns

### DIFF
--- a/code/packages/rust/spreadsheet-capi/CHANGELOG.md
+++ b/code/packages/rust/spreadsheet-capi/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.3.0
+
+**Insert/delete rows & columns over the C ABI.** New `void`-returning exports
+`sc_insert_rows` / `sc_delete_rows` / `sc_insert_cols` / `sc_delete_cols(s, at,
+count)` (1-based), declared in `include/spreadsheet.h`. They delegate to
+`SpreadsheetSession`'s new structural-edit methods; the host re-reads via
+`sc_get_window` / `sc_get_raw` afterwards. Null-session safe (no-op).
+
 ## 0.2.0
 
 Viewport C ABI for the virtualized infinite sheet, mirroring

--- a/code/packages/rust/spreadsheet-capi/Cargo.toml
+++ b/code/packages/rust/spreadsheet-capi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spreadsheet-capi"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 description = "Stable C ABI over the spreadsheet engine, for the native VisiCalc demos (Swift/Kotlin-JNI/Dart-FFI/.NET/C++)"
 license = "MIT"

--- a/code/packages/rust/spreadsheet-capi/include/spreadsheet.h
+++ b/code/packages/rust/spreadsheet-capi/include/spreadsheet.h
@@ -40,6 +40,15 @@ char *sc_get_value(ScSession *s, const char *a1);                 /* -> value JS
 char *sc_get_raw(ScSession *s, const char *a1);                   /* -> typed source */
 char *sc_get_values(ScSession *s);                                /* -> {a1: value} */
 
+/* Structural edits — insert/delete rows & columns. 1-based `at`, `count` lines.
+   The engine relocates cells and rewrites formula references (a reference to a
+   deleted line becomes #REF!); the formula echo stays in step. No return — the
+   host re-reads via sc_get_window / sc_get_raw afterwards. */
+void  sc_insert_rows(ScSession *s, uint32_t at, uint32_t count);
+void  sc_delete_rows(ScSession *s, uint32_t at, uint32_t count);
+void  sc_insert_cols(ScSession *s, uint32_t at, uint32_t count);
+void  sc_delete_cols(ScSession *s, uint32_t at, uint32_t count);
+
 /* Viewport primitive — read just the visible window of the unbounded sheet.
    Coordinates are 1-based and inclusive. Each char* result must be freed with
    sc_string_free(). */

--- a/code/packages/rust/spreadsheet-capi/src/lib.rs
+++ b/code/packages/rust/spreadsheet-capi/src/lib.rs
@@ -157,6 +157,59 @@ pub unsafe extern "C" fn sc_get_values(s: *mut ScSession) -> *mut c_char {
     into_cstr((*s).inner.get_values())
 }
 
+// ── Structural edits: insert / delete rows & columns ─────────────────
+// 1-based `at`, `count` lines. The engine relocates cells and rewrites every
+// formula's references; the facade keeps its raw echo map in step. No return —
+// the host re-reads via get_window / get_raw after the edit.
+
+/// `insert_rows(at, count)`. See [`SpreadsheetSession::insert_rows`].
+///
+/// # Safety
+/// `s` must be a valid session.
+#[no_mangle]
+pub unsafe extern "C" fn sc_insert_rows(s: *mut ScSession, at: u32, count: u32) {
+    if s.is_null() {
+        return;
+    }
+    (*s).inner.insert_rows(at, count);
+}
+
+/// `delete_rows(at, count)`. See [`SpreadsheetSession::delete_rows`].
+///
+/// # Safety
+/// `s` must be a valid session.
+#[no_mangle]
+pub unsafe extern "C" fn sc_delete_rows(s: *mut ScSession, at: u32, count: u32) {
+    if s.is_null() {
+        return;
+    }
+    (*s).inner.delete_rows(at, count);
+}
+
+/// `insert_cols(at, count)`. See [`SpreadsheetSession::insert_cols`].
+///
+/// # Safety
+/// `s` must be a valid session.
+#[no_mangle]
+pub unsafe extern "C" fn sc_insert_cols(s: *mut ScSession, at: u32, count: u32) {
+    if s.is_null() {
+        return;
+    }
+    (*s).inner.insert_cols(at, count);
+}
+
+/// `delete_cols(at, count)`. See [`SpreadsheetSession::delete_cols`].
+///
+/// # Safety
+/// `s` must be a valid session.
+#[no_mangle]
+pub unsafe extern "C" fn sc_delete_cols(s: *mut ScSession, at: u32, count: u32) {
+    if s.is_null() {
+        return;
+    }
+    (*s).inner.delete_cols(at, count);
+}
+
 // ── Viewport primitive (virtualized infinite sheet) ──────────────────
 // Integer coordinates (1-based, inclusive) so a native scrolling host can fetch
 // just the visible window of an unbounded sheet.

--- a/code/packages/rust/spreadsheet-core-wasm/CHANGELOG.md
+++ b/code/packages/rust/spreadsheet-core-wasm/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.3.0
+
+**Insert/delete rows & columns.** `insert_rows` / `delete_rows` / `insert_cols`
+/ `delete_cols(at, count)` (1-based) call through to the engine — which relocates
+cells and rewrites every formula's references (a reference to a deleted line →
+`#REF!`) — and keep this facade's `raw` echo map in step: each raw entry's
+address is relocated the same way, and a formula's *source* is rewritten via the
+shared `parse → FormulaAst::adjust → to_formula_string`, so the formula bar
+echoes the post-edit references. An insert that would push a non-empty cell off
+the u32 grid edge is rejected wholesale (mirrors the engine's guard). 3 new tests.
+
 ## 0.2.0
 
 Viewport primitive (for the virtualized infinite sheet), wrapping

--- a/code/packages/rust/spreadsheet-core-wasm/Cargo.toml
+++ b/code/packages/rust/spreadsheet-core-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spreadsheet-core-wasm"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 description = "Browser/WASM-facing string-in / JSON-out facade over spreadsheet-core"
 license = "MIT"

--- a/code/packages/rust/spreadsheet-core-wasm/src/lib.rs
+++ b/code/packages/rust/spreadsheet-core-wasm/src/lib.rs
@@ -52,8 +52,10 @@ use std::collections::HashMap;
 use std::panic::{catch_unwind, AssertUnwindSafe};
 
 use serde_json::{json, Value};
+use spreadsheet_core::parser::parse;
 use spreadsheet_core::{
-    column_index_to_letters, CellAddress, CellValue, ChangeSet, SheetId, SpreadsheetError, Workbook,
+    column_index_to_letters, CellAddress, CellValue, ChangeSet, SheetId, SpreadsheetError,
+    StructuralEdit, Workbook,
 };
 
 /// A single-sheet spreadsheet session with a JSON boundary.
@@ -128,6 +130,72 @@ impl SpreadsheetSession {
             self.wb.set_value(self.sheet, addr, coerce_literal(trimmed));
         }
         Ok(())
+    }
+
+    // ── Structural edits: insert / delete rows & columns ────────────
+    //
+    // These call through to the engine (which relocates cells and rewrites every
+    // formula's references) AND keep this facade's `raw` echo map in step: each
+    // raw entry's address is relocated the same way, and a formula's *source* is
+    // rewritten via the shared `parse → adjust → to_formula_string` so the
+    // formula bar echoes the post-edit references. Coordinates are 1-based.
+
+    /// Insert `count` blank rows before row `at`; rows at/after slide down.
+    pub fn insert_rows(&mut self, at: u32, count: u32) {
+        self.structural_edit(StructuralEdit::InsertRows { at, count });
+    }
+
+    /// Delete `count` rows starting at row `at`; rows after slide up. Cells on
+    /// deleted rows are removed; references to them become `#REF!`.
+    pub fn delete_rows(&mut self, at: u32, count: u32) {
+        self.structural_edit(StructuralEdit::DeleteRows { at, count });
+    }
+
+    /// Insert `count` blank columns before column `at`; columns at/after slide right.
+    pub fn insert_cols(&mut self, at: u32, count: u32) {
+        self.structural_edit(StructuralEdit::InsertCols { at, count });
+    }
+
+    /// Delete `count` columns starting at column `at`; columns after slide left.
+    pub fn delete_cols(&mut self, at: u32, count: u32) {
+        self.structural_edit(StructuralEdit::DeleteCols { at, count });
+    }
+
+    fn structural_edit(&mut self, edit: StructuralEdit) {
+        // Mirror the engine's guard: an insert that would push a non-empty cell
+        // off the u32 grid edge is rejected wholesale (the saturating shift would
+        // otherwise collide raw entries onto the same address). Both sides apply
+        // the same condition, so the facade and engine stay consistent.
+        let would_overflow = match edit {
+            StructuralEdit::InsertRows { at, count } => self
+                .raw
+                .keys()
+                .any(|a| a.row >= at && a.row.checked_add(count).is_none()),
+            StructuralEdit::InsertCols { at, count } => self
+                .raw
+                .keys()
+                .any(|a| a.col >= at && a.col.checked_add(count).is_none()),
+            StructuralEdit::DeleteRows { .. } | StructuralEdit::DeleteCols { .. } => false,
+        };
+        if would_overflow {
+            return;
+        }
+
+        match edit {
+            StructuralEdit::InsertRows { at, count } => self.wb.insert_rows(self.sheet, at, count),
+            StructuralEdit::DeleteRows { at, count } => self.wb.delete_rows(self.sheet, at, count),
+            StructuralEdit::InsertCols { at, count } => self.wb.insert_cols(self.sheet, at, count),
+            StructuralEdit::DeleteCols { at, count } => self.wb.delete_cols(self.sheet, at, count),
+        }
+
+        // Relocate the raw echo map to match: move each entry's address, drop
+        // entries on deleted lines, and rewrite formula sources.
+        let old = std::mem::take(&mut self.raw);
+        for (addr, raw) in old {
+            if let Some(new_addr) = addr.adjust(edit) {
+                self.raw.insert(new_addr, rewrite_raw_for_edit(&raw, edit));
+            }
+        }
     }
 
     /// Get a cell's *computed* value as a JSON object (see [`value_to_json`] for
@@ -267,6 +335,23 @@ fn coerce_literal(s: &str) -> CellValue {
     CellValue::Text(s.to_string())
 }
 
+/// Rewrite a raw cell source for a [`StructuralEdit`], so the formula bar echoes
+/// the post-edit references. A literal is unchanged (it has no references); a
+/// formula is re-parsed, its references adjusted via the shared `edit` arithmetic,
+/// and re-serialized. An unparseable formula is kept verbatim — there's nothing
+/// to rewrite, and the source must survive for the user to fix.
+fn rewrite_raw_for_edit(raw: &str, edit: StructuralEdit) -> String {
+    let trimmed = raw.trim();
+    if trimmed.starts_with('=') {
+        match parse(trimmed) {
+            Ok(ast) => format!("={}", ast.adjust(edit).to_formula_string()),
+            Err(_) => raw.to_string(),
+        }
+    } else {
+        raw.to_string()
+    }
+}
+
 /// Encode a [`CellValue`] as the JSON the JS host expects. The shape matches
 /// the TypeScript engine's `CellValue` discriminated union exactly, so the
 /// demo glue is identical whichever engine backs it:
@@ -330,6 +415,53 @@ mod tests {
         // Change a precedent → the total recomputes.
         s.set_cell("B1", "115");
         assert_eq!(s.get_value("B6"), r#"{"kind":"number","value":146.0}"#);
+    }
+
+    // ── Structural edits: insert / delete rows & columns ────────────
+
+    #[test]
+    fn insert_rows_shifts_values_raw_and_formula_refs() {
+        let mut s = SpreadsheetSession::new();
+        s.set_cell("A1", "10");
+        s.set_cell("A2", "20");
+        s.set_cell("A3", "=SUM(A1:A2)");
+        assert_eq!(s.get_value("A3"), r#"{"kind":"number","value":30.0}"#);
+
+        s.insert_rows(1, 1); // a blank row at the top; everything slides down
+
+        assert_eq!(s.get_value("A1"), r#"{"kind":"empty"}"#); // now blank
+        assert_eq!(s.get_value("A2"), r#"{"kind":"number","value":10.0}"#); // was A1
+        assert_eq!(s.get_value("A4"), r#"{"kind":"number","value":30.0}"#); // SUM moved
+        // Echo: the SUM moved to A4 and its range rewrote A1:A2 → A2:A3.
+        assert_eq!(s.get_raw("A4"), "=SUM(A2:A3)");
+        assert_eq!(s.get_raw("A1"), ""); // nothing there now
+    }
+
+    #[test]
+    fn delete_cols_makes_dangling_reference_ref_error() {
+        let mut s = SpreadsheetSession::new();
+        s.set_cell("A1", "10");
+        s.set_cell("B1", "=A1+1");
+        s.delete_cols(1, 1); // delete column A
+
+        // B1 → A1, and its reference A1 (now deleted) → #REF!.
+        assert_eq!(s.get_value("A1"), r##"{"code":"#REF!","kind":"error"}"##);
+        // The echoed source shows the dangling reference (binary ops are fully
+        // parenthesised by the serializer).
+        assert_eq!(s.get_raw("A1"), "=(#REF!+1)");
+    }
+
+    #[test]
+    fn delete_rows_shifts_survivors_up() {
+        let mut s = SpreadsheetSession::new();
+        s.set_cell("A1", "10");
+        s.set_cell("A2", "20");
+        s.set_cell("A3", "=A2*2");
+        s.delete_rows(1, 1); // delete row 1
+
+        assert_eq!(s.get_value("A1"), r#"{"kind":"number","value":20.0}"#); // was A2
+        assert_eq!(s.get_value("A2"), r#"{"kind":"number","value":40.0}"#); // =A1*2
+        assert_eq!(s.get_raw("A2"), "=(A1*2)");
     }
 
     #[test]

--- a/code/packages/rust/spreadsheet-wasm/CHANGELOG.md
+++ b/code/packages/rust/spreadsheet-wasm/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.3.0
+
+**Insert/delete rows & columns over the WASM ABI.** New `void`-returning exports
+`insert_rows` / `delete_rows` / `insert_cols` / `delete_cols(at, count)` (1-based,
+plain integer args — no pointer marshalling), each delegating to the thread-local
+`SpreadsheetSession`. The JS host re-reads via `get_window` / `get_raw`
+afterwards. 1 new ABI round-trip test (insert then delete restores the sheet).
+
 ## 0.2.0
 
 Viewport entry points for the virtualized infinite sheet, mirroring

--- a/code/packages/rust/spreadsheet-wasm/Cargo.toml
+++ b/code/packages/rust/spreadsheet-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spreadsheet-wasm"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 description = "extern \"C\" + linear-memory WASM ABI over the spreadsheet-core-wasm JSON facade"
 license = "MIT"

--- a/code/packages/rust/spreadsheet-wasm/src/lib.rs
+++ b/code/packages/rust/spreadsheet-wasm/src/lib.rs
@@ -195,6 +195,35 @@ pub extern "C" fn get_values() -> *mut u8 {
     pack(SESSION.with(|s| s.borrow().get_values()))
 }
 
+// ── Structural edits: insert / delete rows & columns ─────────────────
+// 1-based `at`, `count` lines. The engine relocates cells and rewrites formula
+// references; the formula echo stays in step. No return — the JS host re-reads
+// via get_window / get_raw afterwards.
+
+/// `insert_rows(at, count)`. See [`SpreadsheetSession::insert_rows`].
+#[no_mangle]
+pub extern "C" fn insert_rows(at: u32, count: u32) {
+    SESSION.with(|s| s.borrow_mut().insert_rows(at, count));
+}
+
+/// `delete_rows(at, count)`. See [`SpreadsheetSession::delete_rows`].
+#[no_mangle]
+pub extern "C" fn delete_rows(at: u32, count: u32) {
+    SESSION.with(|s| s.borrow_mut().delete_rows(at, count));
+}
+
+/// `insert_cols(at, count)`. See [`SpreadsheetSession::insert_cols`].
+#[no_mangle]
+pub extern "C" fn insert_cols(at: u32, count: u32) {
+    SESSION.with(|s| s.borrow_mut().insert_cols(at, count));
+}
+
+/// `delete_cols(at, count)`. See [`SpreadsheetSession::delete_cols`].
+#[no_mangle]
+pub extern "C" fn delete_cols(at: u32, count: u32) {
+    SESSION.with(|s| s.borrow_mut().delete_cols(at, count));
+}
+
 // ── Viewport primitive (virtualized infinite sheet) ──────────────────
 // These take integer coordinates directly (no pointer marshalling), so a
 // scrolling JS host can fetch just the visible window of an unbounded sheet.
@@ -307,6 +336,24 @@ mod tests {
         // Recalc on dependency change.
         set("B1", "115");
         assert_eq!(value("B6"), r#"{"kind":"number","value":146.0}"#);
+    }
+
+    #[test]
+    fn abi_insert_and_delete_rows() {
+        reset();
+        set("A1", "10");
+        set("A2", "20");
+        set("A3", "=SUM(A1:A2)");
+
+        insert_rows(1, 1); // a blank row at the top — everything slides down
+        assert_eq!(value("A2"), r#"{"kind":"number","value":10.0}"#); // was A1
+        assert_eq!(value("A4"), r#"{"kind":"number","value":30.0}"#); // SUM moved
+        assert_eq!(raw("A4"), "=SUM(A2:A3)"); // range rewritten
+
+        delete_rows(1, 1); // remove the blank top row again
+        assert_eq!(value("A1"), r#"{"kind":"number","value":10.0}"#);
+        assert_eq!(value("A3"), r#"{"kind":"number","value":30.0}"#);
+        assert_eq!(raw("A3"), "=SUM(A1:A2)");
     }
 
     #[test]


### PR DESCRIPTION
## What

Wires the merged `Workbook::insert_rows/delete_rows/insert_cols/delete_cols` ([#5960](https://github.com/adhithyan15/coding-adventures/pull/5960)) out through **all three facades**, so every backend (web WASM + native C ABI) can drive structural edits. This is the follow-up unblocked by #5960's merge.

- **`spreadsheet-core-wasm`** (JSON facade): `insert_rows/delete_rows/insert_cols/delete_cols(at, count)`. Calls the engine **and** keeps the facade's own `raw` echo map in step — relocates each entry's address via `CellAddress::adjust`, drops entries on deleted lines, and rewrites formula sources via the shared `parse → FormulaAst::adjust → to_formula_string`, so the formula bar echoes post-edit references. Mirrors the engine's off-grid-overflow guard (reject the whole edit) so the two stay consistent.
- **`spreadsheet-capi`** (C ABI): `sc_insert_rows/sc_delete_rows/sc_insert_cols/sc_delete_cols(s, at, count)`, declared in `include/spreadsheet.h`. Null-session safe.
- **`spreadsheet-wasm`** (browser WASM ABI): `insert_rows/delete_rows/insert_cols/delete_cols(at, count)` over the thread-local session.

All are `void` — the host re-reads via `get_window` / `get_raw` after the edit.

## Verification

- **core-wasm 20 tests** (3 new: insert shifts values + raw + formula refs; delete-column dangling reference → `#REF!`; delete-row survivor shift), **capi 4**, **wasm 6** (1 new ABI insert→delete round-trip). Clippy clean across all three. Each `0.2.0 → 0.3.0` (additive).
- **`/security-review` passed** (1 round, no findings) — verified the facade's overflow guard is byte-identical to the engine's over the same key set (no-op together), `CellAddress::adjust` is injective over surviving raw keys post-guard (no silent raw-map data loss — the engine's historical bug not reintroduced), `parse` is depth-bounded so `rewrite_raw_for_edit` can't stack-overflow (unparseable formulas kept verbatim), the C ABI null-guards match the sibling `sc_*` pattern, and the WASM thread-local calls can't double-borrow.

## Next

Surface insert/delete in the backend UIs; wire `number-format-core` into `spreadsheet-core`'s display path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)