### PR TITLE
refactor(mycin): unify all drug exclusions into explicit engine constraints (ADJ-first)

### DIFF
--- a/code/specs/data/mycin-2026/CHART-AS-CONSTRAINTS.md
+++ b/code/specs/data/mycin-2026/CHART-AS-CONSTRAINTS.md
@@ -146,6 +146,13 @@ risks Y") — decision support, not a hidden choice.
 - **CC-2 — dose feasibility + renal/interaction caps as constraints.** Fold the dose-window
   solve into the COP (`floor ≤ dose ≤ ceiling(renal, interactions)`); UNSAT path returns the
   conflict. Ground the renal-adjustment + additive-nephrotoxicity rules (spider).
+- **REFACTOR (ADJ-first): every exclusion is now an EXPLICIT engine constraint.** Dose-infeasible
+  (CC-2), contraindicated (CC-3), and step-therapy (CC-6) drugs are unified into one
+  `forced_zero: {drug → reason}` and emitted as `constrain x_d <= 0   % excluded (reason)` in the
+  adj-lang program — not pre-removed from the candidate list in Python. So the emitted program is
+  self-documenting about *why* each drug is out, the infeasibility verdict is the engine's, and
+  the exclusion reasoning lives in ADJ, not the compiler. (Reasons are sanitized before reaching
+  the `%` comment.)
 - **CC-3 — contraindication / interaction grounding.** `contraindication-grounding.json` +
   `interaction-grounding.json` via the harness (pregnancy, QT, G6PD, allergy classes,
   drug–drug); gate → CAS; new "treatment constraints" ledger artifact.

--- a/code/specs/data/mycin-2026/treatment/antibiotics/chart_to_cop.py
+++ b/code/specs/data/mycin-2026/treatment/antibiotics/chart_to_cop.py
@@ -336,12 +336,15 @@ def derive(cli: Path, facts: list[ChartFact], disease: str = "meningitis") -> di
             "type": "dose_infeasible", "from": f"risks={sorted(cop.risks)}", "detail": d,
             "rule": f"no safe+effective dose: floor {w['floor_per_kg']} > ceiling "
                     f"{w['ceiling_per_kg']} mg/kg"})
-    # A drug leaves the cover if it has no safe dose (CC-2) OR is contraindicated (CC-3).
-    excluded_drugs = set(undosable) | cop.contraindicated
+    # Every exclusion is an EXPLICIT engine constraint (`x_d <= 0`), keyed by its reason, so
+    # the emitted program is self-documenting: a drug with no safe dose (CC-2) or one that is
+    # contraindicated (CC-3) is pinned out by the solver, not pre-removed in Python.
+    forced_zero = {d: "dose-infeasible" for d in undosable}
+    forced_zero.update({d: "contraindicated" for d in cop.contraindicated})
     # CC-4: solve under the chart's cost/side-effect objective blend (default tier-only).
     # `regimen` is the CLINICALLY optimal one — what the physician should give, ignoring
     # the payer. (CC-4 objective blend applies.)
-    res = nsc.solve(cli, cop.organisms, cop.exclusions, cop.defeated, excluded_drugs, cop.weights)
+    res = nsc.solve(cli, cop.organisms, cop.exclusions, cop.defeated, cop.weights, forced_zero=forced_zero)
     # CC-5: the empiric-now vs await-culture decision, from the chart's timing inputs.
     timing = decide_timing(disease, cop.culture_status, cop.clinical_status)
     # CC-6: when the chart carries payer step-therapy rules, ALSO solve the reimbursement-
@@ -351,12 +354,13 @@ def derive(cli: Path, facts: list[ChartFact], disease: str = "meningitis") -> di
     reimbursement = None
     if cop.step_therapy:
         blocked = reimbursement_blocked(cop.step_therapy, cop.tried)
-        # The precedence is enforced BY THE ENGINE: blocked drugs are pinned to 0 via an
-        # explicit `constrain x_Y <= 0` clause in the reimbursement program (step_blocked),
-        # not removed from candidates in Python — so the payer constraint is auditable in
-        # the emitted program and the covered-infeasibility verdict is the solver's.
+        # The precedence is enforced BY THE ENGINE: payer-blocked drugs join forced_zero
+        # (reason "step-therapy") → an explicit `constrain x_Y <= 0` clause in the
+        # reimbursement program. Clinical exclusions (dose/contraindication) carry over, so
+        # the covered solve layers the payer constraint on top of the clinical one.
+        cov_forced = {**forced_zero, **{d: "step-therapy" for d in blocked}}
         cov = nsc.solve(cli, cop.organisms, cop.exclusions, cop.defeated,
-                        excluded_drugs, cop.weights, step_blocked=blocked)
+                        cop.weights, forced_zero=cov_forced)
         differs = cov["regimen"] != res["regimen"]
         if cov["regimen"] is None:
             note = ("reimbursement-INFEASIBLE under step therapy: the only regimens covering "

--- a/code/specs/data/mycin-2026/treatment/antibiotics/native_setcover.py
+++ b/code/specs/data/mycin-2026/treatment/antibiotics/native_setcover.py
@@ -53,11 +53,17 @@ def _sym(prefix: str, *parts: str) -> str:
     return name
 
 
+def _safe_reason(reason: str) -> str:
+    """Sanitize an exclusion reason before it goes into a `%` line-comment in the emitted
+    program — keep only an alnum/space/_-: subset (no newline can escape the comment),
+    bounded length. Never interpolate a reason string into the program unvalidated."""
+    return re.sub(r"[^A-Za-z0-9 _:-]", "", reason)[:80]
+
+
 def emit_program(organisms: list[str], exclusions: set[str],
                  defeated: set[tuple[str, str]] = frozenset(),
-                 dose_excluded: set[str] = frozenset(),
                  weights: tuple[int, int] = reg.DEFAULT_WEIGHTS,
-                 step_blocked: set[str] = frozenset()) -> tuple[str, dict, bool]:
+                 forced_zero: dict[str, str] | None = None) -> tuple[str, dict, bool]:
     """Emit the adj-lang integer program for this cover. Returns (program text,
     {x_var → drug}, feasible?) — feasible is False if some organism has no coverer
     (the program is then trivially infeasible and the engine will say so).
@@ -69,21 +75,20 @@ def emit_program(organisms: list[str], exclusions: set[str],
     A combination is defeated for an organism if any of its members is resistant to
     that organism (the synergy rationale is undercut).
 
-    `dose_excluded` (CC-2) is the set of drugs that have NO safe-and-effective dose for
-    this patient — their efficacy floor exceeds their toxicity ceiling once the chart's
-    renal/interaction risks shrink it (dose_window UNSAT). Such a drug is dropped from the
-    candidate set before the cover is built, so the optimizer re-derives around it (or
-    abstains if it was load-bearing) — dose feasibility folded INTO the cover, not a
-    post-hoc warning.
-
-    `step_blocked` (CC-6) is the set of drugs a payer step-therapy rule blocks because
-    their prerequisite hasn't been tried. Unlike dose_excluded (which removes a drug from
-    the cover entirely on clinical grounds), a step-blocked drug stays a first-class
-    variable but is pinned to 0 by an EXPLICIT precedence constraint `x_Y <= 0` — the
-    `x_Y ≤ tried_X` precedence with the known-untried `tried_X = 0` folded in. The
-    reimbursement constraint is thus enforced BY THE ENGINE and visible in the program
-    (auditable / appealable), not pre-filtered away in Python."""
-    cands = [d for d in reg.candidates(exclusions) if d not in dose_excluded]
+    `forced_zero` maps a drug → the REASON it is unavailable for this patient, and every
+    such drug is pinned out by an EXPLICIT engine constraint `x_d <= 0   % excluded (reason)`
+    — NOT silently dropped from the candidate set in Python. This unifies every exclusion
+    family as auditable constraints visible in the emitted program:
+      - dose-infeasible (CC-2): no safe-and-effective dose under the chart's renal/interaction
+        risks (the efficacy floor exceeds the toxicity ceiling);
+      - contraindicated (CC-3): e.g. a drug contraindicated in pregnancy;
+      - step-therapy (CC-6): a payer won't reimburse the drug until a prerequisite is tried
+        (the `x_Y ≤ tried_X` precedence with the known-untried `tried_X = 0` folded in).
+    A forced-zero drug keeps its selector variable (so the reason is on the record and any
+    covering combination it belongs to is correctly disabled via `y <= x_d`); the constraint,
+    not its absence, removes it — so the engine, not Python, owns the exclusion + infeasibility."""
+    forced_zero = forced_zero or {}
+    cands = list(reg.candidates(exclusions))
     lines: list[str] = []
     xvar = {d: _sym("x", d) for d in cands}
     var_to_drug = {v: d for d, v in xvar.items()}
@@ -124,13 +129,13 @@ def emit_program(organisms: list[str], exclusions: set[str],
             feasible = False  # no drug or combination covers this organism
             lines.append(f"constrain 0 >= 1   % UNCOVERABLE: {org}")
 
-    # CC-6 step-therapy precedence: `x_Y ≤ tried_Y`. The prerequisite is known-untried at
-    # compile time (tried_Y = 0), so the precedence folds to `x_Y <= 0` — an explicit,
-    # engine-enforced constraint that pins the payer-blocked drug out of the reimbursement
-    # solve. (Clinical solve passes step_blocked=∅, so it is unconstrained there.)
+    # Exclusions as EXPLICIT constraints: every forced-zero drug is pinned out by
+    # `constrain x_d <= 0`, with its reason in the comment — so dose-infeasibility (CC-2),
+    # contraindication (CC-3), and step-therapy (CC-6) are all auditable in the program and
+    # the resulting infeasibility is the engine's verdict, not a Python pre-filter.
     for d in cands:
-        if d in step_blocked:
-            lines.append(f"constrain {xvar[d]} <= 0   % step-therapy: reimbursement requires prerequisite tried")
+        if d in forced_zero:
+            lines.append(f"constrain {xvar[d]} <= 0   % excluded ({_safe_reason(forced_zero[d])})")
 
     # CC-4 objective: minimize Σ (w_cost·tier + w_tox·side_effects)·x_d. The coefficient
     # is a non-negative integer (validated below), so this stays in the engine's INTEGER
@@ -154,16 +159,14 @@ def emit_program(organisms: list[str], exclusions: set[str],
 
 def solve(cli: Path, organisms: list[str], exclusions: set[str],
           defeated: set[tuple[str, str]] = frozenset(),
-          dose_excluded: set[str] = frozenset(),
           weights: tuple[int, int] = reg.DEFAULT_WEIGHTS,
-          step_blocked: set[str] = frozenset()) -> dict:
+          forced_zero: dict[str, str] | None = None) -> dict:
     """Run the emitted program through the engine; return the engine's regimen.
     `defeated` carries culture-sensitivity results (resistant drug→organism edges);
-    `dose_excluded` carries drugs with no safe-and-effective dose for this patient (CC-2);
     `weights`=(w_cost, w_tox) is the CC-4 cost+side-effect objective blend (default (1,0));
-    `step_blocked` (CC-6) pins payer-blocked drugs to 0 via an explicit precedence constraint."""
-    program, var_to_drug, _ = emit_program(organisms, exclusions, defeated, dose_excluded,
-                                            weights, step_blocked)
+    `forced_zero` maps drug→reason for every drug pinned out by an explicit `x_d <= 0`
+    constraint (dose-infeasible / contraindicated / step-therapy)."""
+    program, var_to_drug, _ = emit_program(organisms, exclusions, defeated, weights, forced_zero)
     fd, name = tempfile.mkstemp(suffix=".adj", prefix="_tmp_native_", dir=HERE)
     p = Path(name)
     try:

--- a/code/specs/data/mycin-2026/treatment/antibiotics/test_native_setcover.py
+++ b/code/specs/data/mycin-2026/treatment/antibiotics/test_native_setcover.py
@@ -52,23 +52,33 @@ def test_side_effect_weights_loaded() -> None:
         assert isinstance(se, int) and not isinstance(se, bool) and se >= 0, (d, se)
 
 
-def test_step_therapy_emits_a_native_precedence_constraint() -> None:
-    """CC-6: a step-blocked drug is pinned out by an EXPLICIT `constrain x_Y <= 0` clause
-    in the emitted program (engine-enforced precedence) — not removed in Python. The drug
-    still gets its selector variable; only the constraint forces it to 0."""
+def test_forced_zero_exclusions_emit_explicit_constraints() -> None:
+    """Every exclusion (dose-infeasible / contraindicated / step-therapy) is pinned out by
+    an EXPLICIT `constrain x_d <= 0` clause carrying its reason — not removed in Python. The
+    drug keeps its selector variable; only the constraint forces it to 0."""
     prog, _, _ = ns.emit_program(
-        reg.SCENARIOS["post_neurosurgical_or_shunt"], set(), step_blocked={"cefepime"})
-    assert "symbol x_cefepime : bool" in prog           # still a first-class variable
-    assert "constrain x_cefepime <= 0" in prog, prog     # ...pinned out by a real constraint
+        reg.SCENARIOS["post_neurosurgical_or_shunt"], set(),
+        forced_zero={"cefepime": "step-therapy", "meropenem": "contraindicated"})
+    assert "symbol x_cefepime : bool" in prog                       # still a first-class variable
+    assert "constrain x_cefepime <= 0   % excluded (step-therapy)" in prog, prog
+    assert "constrain x_meropenem <= 0   % excluded (contraindicated)" in prog, prog
     plain, _, _ = ns.emit_program(reg.SCENARIOS["post_neurosurgical_or_shunt"], set())
-    assert "constrain x_cefepime <= 0" not in plain      # absent without a step block
+    assert "<= 0   % excluded" not in plain                          # absent without exclusions
+    # the reason is sanitized — a newline can't escape the `%` comment into a fake clause:
+    # the injected text collapses onto the single comment line, and the only `minimize` line
+    # remains the real objective (no rogue `minimize 999` clause on its own line).
+    nasty, _, _ = ns.emit_program(["n_meningitidis"], set(),
+                                  forced_zero={"ceftriaxone": "evil\nminimize 999"})
+    minimize_lines = [ln for ln in nasty.splitlines() if ln.startswith("minimize")]
+    assert len(minimize_lines) == 1 and "999" not in minimize_lines[0]  # no rogue objective
+    assert "evilminimize 999" in nasty                              # collapsed into the comment
 
 
 def main() -> int:
     test_emit_is_well_formed()
     test_default_weights_reproduce_tier_only_objective()
     test_side_effect_weights_loaded()
-    test_step_therapy_emits_a_native_precedence_constraint()
+    test_forced_zero_exclusions_emit_explicit_constraints()
     cli = decide_mod.find_cli()
     if cli is None:
         print("test_native_setcover: PASS (emit + CC-4 weight checks); "


### PR DESCRIPTION
## Move exclusion reasoning out of Python and into the adj-lang program

Second unit of the ADJ-first refactor (after #5974). Previously the COP removed excluded drugs from the candidate list **in Python** — dose-infeasible + contraindicated via `dose_excluded`, step-therapy via `step_blocked`. Now **all exclusion families are unified** into one `forced_zero: {drug → reason}` and emitted as explicit engine constraints:

```
constrain x_<drug> <= 0   % excluded (dose-infeasible | contraindicated | step-therapy)
```

- `native_setcover.emit_program`/`solve`: dropped `dose_excluded` + `step_blocked`, added `forced_zero`. Candidates are **no longer pre-filtered** — every csf-penetrant drug gets its selector variable, and the **constraint** (not its absence) pins an excluded drug to 0. The emitted program is now self-documenting about *why* each drug is out, any covering combination it belongs to is correctly disabled via the existing `y ≤ x_d`, and the infeasibility verdict is the **engine's**, not Python's.
- Reasons are sanitized (`_safe_reason`: `[A-Za-z0-9 _:-]`, ≤80 chars) before reaching the `%` comment — no newline can escape into a fake clause (tested).
- `chart_to_cop.derive` builds `forced_zero = {dose-infeasible} ∪ {contraindicated}`; the reimbursement solve layers `{step-therapy}` on top. `reimbursement_blocked` stays as the chart→constraint **mapping** (the compiler's job); the **constraint** is engine-native.

### Break-compat (nothing released)
The `emit_program`/`solve` signatures changed (removed two params, added `forced_zero`). All in-tree consumers updated — `chart_to_cop` + tests; `mycin_consult`/`test_mycin_consult` use only `defeated=`/positional and are unaffected. Behavior unchanged: all treatment tests + downstream **board 12/12** + **mycin_consult** green, ruff clean. Security review passed.

Part of the response to "why isn't ADJ primary?": exclusion *reasoning* now lives in the emitted ADJ program the engine evaluates, not in Python candidate-removal. Next: `decide_timing` (CC-5) → engine clauses; `board_eval`'s Python `RelationStore` → the native recall path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)