### PR TITLE
Add SPICE control block routing

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ### Added
 
+- **Deck control-block exclusion diagnostics** —
+  `analyze_deck_controls()` and `resolve_deck_sources()` now exclude
+  unsupported `.control` / `.endc` blocks from active deck lines while
+  reporting stable command diagnostics for non-comment lines inside the block,
+  matching Rust and TypeScript.
+
 - **Parsed plot output routing** —
   `resolve_deck_outputs()`, `select_deck_output_probes()`, and
   `format_deck_*_table()` now route scoped `.plot <analysis> ...` output

--- a/code/packages/python/spice-engine/README.md
+++ b/code/packages/python/spice-engine/README.md
@@ -158,13 +158,16 @@ notes. `release_readiness_gates()` validates the corpus metadata, while
 provide stable tab-separated summaries for package checks.
 `analyze_deck_controls()` provides the shared deck-control boundary foothold:
 it returns active lines before `.end` and stable diagnostics for unsupported
-`.include`, `.lib`, and `.control` directives before future include/library
-resolution and control-block execution are in scope.
+`.include`, `.lib`, and `.control` directives. Unsupported `.control` blocks
+are excluded from active deck lines, and non-comment commands inside the block
+emit command diagnostics until a deliberate executed control subset is in
+scope.
 `resolve_deck_sources()` is the first include/library resolution layer: callers
 provide a source-content map, `.include` directives are expanded in place, and
 `.lib path section` selects a named `.lib` / `.endl` section with stable
 diagnostics for missing files, missing sections, unterminated sections, cycles,
-and still-unsupported `.control` blocks.
+and still-unsupported `.control` blocks whose body commands are not forwarded
+as active solver input.
 `resolve_deck_parameters()` evaluates scalar whitespace-tokenized `.param`
 assignments, collects scalar `.func` definitions before `.end`, preserves
 parameter order, rewrites braced and quoted active-line expressions, and emits

--- a/code/packages/python/spice-engine/src/spice_engine/compatibility.py
+++ b/code/packages/python/spice-engine/src/spice_engine/compatibility.py
@@ -507,12 +507,30 @@ def analyze_deck_controls(netlist: str) -> DeckControlSummary:
     active_lines: list[str] = []
     diagnostics: list[DeckControlDiagnostic] = []
     end_line_number: int | None = None
+    in_control_block = False
 
     for line_number, raw_line in enumerate(netlist.splitlines(), start=1):
         stripped = raw_line.strip()
         if not stripped or stripped.startswith(("*", ";")):
             continue
         directive = _deck_directive(stripped)
+        if in_control_block:
+            if directive == ".endc":
+                in_control_block = False
+                continue
+            diagnostics.append(
+                DeckControlDiagnostic(
+                    code="SPICE_DECK_CONTROL_COMMAND",
+                    directive=".control",
+                    line_number=line_number,
+                    message=(
+                        f"{stripped!r} inside .control is not executed by "
+                        "the deck execution foothold yet"
+                    ),
+                    severity="error",
+                )
+            )
+            continue
         if directive == ".end":
             end_line_number = line_number
             break
@@ -529,6 +547,9 @@ def analyze_deck_controls(netlist: str) -> DeckControlSummary:
                     severity="error",
                 )
             )
+            if directive == ".control":
+                in_control_block = True
+                continue
         active_lines.append(stripped)
 
     return DeckControlSummary(
@@ -2964,12 +2985,31 @@ def _resolve_deck_lines(
 ) -> tuple[list[str], bool, int | None]:
     active_lines: list[str] = []
     end_line_number: int | None = None
+    in_control_block = False
 
     for line_number, raw_line in enumerate(netlist.splitlines(), start=1):
         stripped = raw_line.strip()
         if not stripped or stripped.startswith(("*", ";")):
             continue
         directive = _deck_directive(stripped)
+        if in_control_block:
+            if directive == ".endc":
+                in_control_block = False
+                continue
+            state.diagnostics.append(
+                DeckResolutionDiagnostic(
+                    code="SPICE_DECK_CONTROL_COMMAND",
+                    directive=".control",
+                    source=source,
+                    line_number=line_number,
+                    message=(
+                        f"{stripped!r} inside .control is not executed by "
+                        "the deck source resolver yet"
+                    ),
+                    severity="error",
+                )
+            )
+            continue
         if directive == ".end":
             end_line_number = line_number
             break
@@ -3011,6 +3051,9 @@ def _resolve_deck_lines(
                     severity="error",
                 )
             )
+            if directive == ".control":
+                in_control_block = True
+                continue
         active_lines.append(stripped)
 
     return active_lines, end_line_number is not None, end_line_number

--- a/code/packages/python/spice-engine/tests/test_compatibility.py
+++ b/code/packages/python/spice-engine/tests/test_compatibility.py
@@ -118,17 +118,22 @@ run
     )
 
     assert summary.terminated is True
-    assert summary.active_lines[:3] == (
+    assert summary.active_lines == (
         ".include models.inc",
         ".LIB vendor.lib TT",
-        ".control",
     )
     assert [(diag.directive, diag.line_number, diag.severity) for diag in summary.diagnostics] == [
         (".include", 2, "error"),
         (".lib", 3, "error"),
         (".control", 4, "error"),
+        (".control", 5, "error"),
     ]
-    assert all(diag.code == "SPICE_DECK_UNSUPPORTED_DIRECTIVE" for diag in summary.diagnostics)
+    assert [diag.code for diag in summary.diagnostics] == [
+        "SPICE_DECK_UNSUPPORTED_DIRECTIVE",
+        "SPICE_DECK_UNSUPPORTED_DIRECTIVE",
+        "SPICE_DECK_UNSUPPORTED_DIRECTIVE",
+        "SPICE_DECK_CONTROL_COMMAND",
+    ]
 
 
 def test_resolve_deck_sources_expands_include_and_library_section() -> None:
@@ -181,6 +186,8 @@ def test_resolve_deck_sources_reports_missing_sources_and_cycles() -> None:
 .include a.inc
 .lib vendor.lib SS
 .control
+run
+.endc
 .end
 """,
         {
@@ -190,12 +197,14 @@ def test_resolve_deck_sources_reports_missing_sources_and_cycles() -> None:
         },
     )
 
-    assert summary.active_lines == ("R2 b 0 2", "R1 a b 1", ".control")
+    assert summary.terminated is True
+    assert summary.active_lines == ("R2 b 0 2", "R1 a b 1")
     assert [diag.code for diag in summary.diagnostics] == [
         "SPICE_DECK_INCLUDE_NOT_FOUND",
         "SPICE_DECK_INCLUDE_CYCLE",
         "SPICE_DECK_LIB_SECTION_NOT_FOUND",
         "SPICE_DECK_UNSUPPORTED_DIRECTIVE",
+        "SPICE_DECK_CONTROL_COMMAND",
     ]
     assert [(diag.source, diag.line_number, diag.target) for diag in summary.diagnostics[:3]] == [
         ("<deck>", 2, "missing.inc"),

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Add control-block exclusion diagnostics to `analyze_deck_controls` and
+  `resolve_deck_sources`; unsupported `.control` / `.endc` blocks are no
+  longer forwarded as active deck lines, and non-comment commands inside the
+  block emit stable diagnostics, matching Python and TypeScript.
 - Add parsed `.plot <analysis> ...` output routing to `resolve_deck_outputs`,
   `select_deck_output_probes`, and deck table formatters, matching Python and
   TypeScript.

--- a/code/packages/rust/spice-engine/README.md
+++ b/code/packages/rust/spice-engine/README.md
@@ -125,13 +125,16 @@ notes. `release_readiness_gates` validates the corpus metadata, while
 provide stable tab-separated summaries for package checks.
 `analyze_deck_controls` provides the shared deck-control boundary foothold: it
 returns active lines before `.end` and stable diagnostics for unsupported
-`.include`, `.lib`, and `.control` directives before future include/library
-resolution and control-block execution are in scope.
+`.include`, `.lib`, and `.control` directives. Unsupported `.control` blocks
+are excluded from active deck lines, and non-comment commands inside the block
+emit command diagnostics until a deliberate executed control subset is in
+scope.
 `resolve_deck_sources` is the first include/library resolution layer: callers
 provide a source-content map, `.include` directives are expanded in place, and
 `.lib path section` selects a named `.lib` / `.endl` section with stable
 diagnostics for missing files, missing sections, unterminated sections, cycles,
-and still-unsupported `.control` blocks.
+and still-unsupported `.control` blocks whose body commands are not forwarded
+as active solver input.
 `measure_transient_probe`, `measure_transient_deck`,
 `measure_dc_sweep_probe`, `measure_dc_sweep_deck`,
 `measure_ac_sweep_probe`, `measure_ac_sweep_deck`, and

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -3550,6 +3550,7 @@ pub fn analyze_deck_controls(netlist: &str) -> DeckControlSummary {
     let mut active_lines = Vec::new();
     let mut diagnostics = Vec::new();
     let mut end_line_number = None;
+    let mut in_control_block = false;
 
     for (index, raw_line) in netlist.lines().enumerate() {
         let line_number = index + 1;
@@ -3558,6 +3559,22 @@ pub fn analyze_deck_controls(netlist: &str) -> DeckControlSummary {
             continue;
         }
         let directive = deck_directive(stripped);
+        if in_control_block {
+            if directive.as_deref() == Some(".endc") {
+                in_control_block = false;
+                continue;
+            }
+            diagnostics.push(DeckControlDiagnostic {
+                code: "SPICE_DECK_CONTROL_COMMAND".to_string(),
+                directive: ".control".to_string(),
+                line_number,
+                message: format!(
+                    "{stripped:?} inside .control is not executed by the deck execution foothold yet"
+                ),
+                severity: "error".to_string(),
+            });
+            continue;
+        }
         if directive.as_deref() == Some(".end") {
             end_line_number = Some(line_number);
             break;
@@ -3573,6 +3590,10 @@ pub fn analyze_deck_controls(netlist: &str) -> DeckControlSummary {
                     ),
                     severity: "error".to_string(),
                 });
+                if directive == ".control" {
+                    in_control_block = true;
+                    continue;
+                }
             }
         }
         active_lines.push(stripped.to_string());
@@ -4323,6 +4344,7 @@ fn resolve_deck_lines(
 ) -> (Vec<String>, bool, Option<usize>) {
     let mut active_lines = Vec::new();
     let mut end_line_number = None;
+    let mut in_control_block = false;
 
     for (index, raw_line) in netlist.lines().enumerate() {
         let line_number = index + 1;
@@ -4331,6 +4353,24 @@ fn resolve_deck_lines(
             continue;
         }
         let directive = deck_directive(stripped);
+        if in_control_block {
+            if directive.as_deref() == Some(".endc") {
+                in_control_block = false;
+                continue;
+            }
+            state.diagnostics.push(DeckResolutionDiagnostic {
+                code: "SPICE_DECK_CONTROL_COMMAND".to_string(),
+                directive: ".control".to_string(),
+                source: source.to_string(),
+                line_number,
+                message: format!(
+                    "{stripped:?} inside .control is not executed by the deck source resolver yet"
+                ),
+                severity: "error".to_string(),
+                target: None,
+            });
+            continue;
+        }
         if directive.as_deref() == Some(".end") {
             end_line_number = Some(line_number);
             break;
@@ -4367,6 +4407,8 @@ fn resolve_deck_lines(
                 severity: "error".to_string(),
                 target: None,
             });
+            in_control_block = true;
+            continue;
         }
         active_lines.push(stripped.to_string());
     }

--- a/code/packages/rust/spice-engine/tests/compatibility_tests.rs
+++ b/code/packages/rust/spice-engine/tests/compatibility_tests.rs
@@ -136,11 +136,10 @@ run
 
     assert!(summary.terminated);
     assert_eq!(
-        &summary.active_lines[..3],
+        summary.active_lines,
         &[
             ".include models.inc".to_string(),
             ".LIB vendor.lib TT".to_string(),
-            ".control".to_string()
         ]
     );
     let diagnostics = summary
@@ -159,13 +158,23 @@ run
         vec![
             (".include", 2, "error"),
             (".lib", 3, "error"),
-            (".control", 4, "error")
+            (".control", 4, "error"),
+            (".control", 5, "error")
         ]
     );
-    assert!(summary
-        .diagnostics
-        .iter()
-        .all(|diagnostic| diagnostic.code == "SPICE_DECK_UNSUPPORTED_DIRECTIVE"));
+    assert_eq!(
+        summary
+            .diagnostics
+            .iter()
+            .map(|diagnostic| diagnostic.code.as_str())
+            .collect::<Vec<_>>(),
+        vec![
+            "SPICE_DECK_UNSUPPORTED_DIRECTIVE",
+            "SPICE_DECK_UNSUPPORTED_DIRECTIVE",
+            "SPICE_DECK_UNSUPPORTED_DIRECTIVE",
+            "SPICE_DECK_CONTROL_COMMAND"
+        ]
+    );
 }
 
 #[test]
@@ -246,15 +255,15 @@ fn resolve_deck_sources_reports_missing_sources_and_cycles() {
 .include a.inc
 .lib vendor.lib SS
 .control
+run
+.endc
 .end
 ",
         &sources,
     );
 
-    assert_eq!(
-        summary.active_lines,
-        vec!["R2 b 0 2", "R1 a b 1", ".control"]
-    );
+    assert!(summary.terminated);
+    assert_eq!(summary.active_lines, vec!["R2 b 0 2", "R1 a b 1"]);
     assert_eq!(
         summary
             .diagnostics
@@ -265,7 +274,8 @@ fn resolve_deck_sources_reports_missing_sources_and_cycles() {
             "SPICE_DECK_INCLUDE_NOT_FOUND",
             "SPICE_DECK_INCLUDE_CYCLE",
             "SPICE_DECK_LIB_SECTION_NOT_FOUND",
-            "SPICE_DECK_UNSUPPORTED_DIRECTIVE"
+            "SPICE_DECK_UNSUPPORTED_DIRECTIVE",
+            "SPICE_DECK_CONTROL_COMMAND"
         ]
     );
     assert_eq!(

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Add control-block exclusion diagnostics to `analyzeDeckControls` and
+  `resolveDeckSources`; unsupported `.control` / `.endc` blocks are no longer
+  forwarded as active deck lines, and non-comment commands inside the block
+  emit stable diagnostics, matching Python and Rust.
 - Add parsed `.plot <analysis> ...` output routing to `resolveDeckOutputs`,
   `selectDeckOutputProbes`, and deck table formatters, matching Python and
   Rust.

--- a/code/packages/typescript/spice-engine/README.md
+++ b/code/packages/typescript/spice-engine/README.md
@@ -132,13 +132,16 @@ notes. `releaseReadinessGates` validates the corpus metadata, while
 stable tab-separated summaries for package checks.
 `analyzeDeckControls` provides the shared deck-control boundary foothold: it
 returns active lines before `.end` and stable diagnostics for unsupported
-`.include`, `.lib`, and `.control` directives before future include/library
-resolution and control-block execution are in scope.
+`.include`, `.lib`, and `.control` directives. Unsupported `.control` blocks
+are excluded from active deck lines, and non-comment commands inside the block
+emit command diagnostics until a deliberate executed control subset is in
+scope.
 `resolveDeckSources` is the first include/library resolution layer: callers
 provide a source-content map, `.include` directives are expanded in place, and
 `.lib path section` selects a named `.lib` / `.endl` section with stable
 diagnostics for missing files, missing sections, unterminated sections, cycles,
-and still-unsupported `.control` blocks.
+and still-unsupported `.control` blocks whose body commands are not forwarded
+as active solver input.
 `resolveDeckParameters` evaluates scalar whitespace-tokenized `.param`
 assignments, collects scalar `.func` definitions before `.end`, preserves
 parameter order, rewrites braced and quoted active-line expressions, and emits

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -2837,6 +2837,7 @@ export function analyzeDeckControls(netlist: string): DeckControlSummary {
   const activeLines: string[] = [];
   const diagnostics: DeckControlDiagnostic[] = [];
   let endLineNumber: number | undefined;
+  let inControlBlock = false;
 
   const lines = netlist.split(/\r?\n/);
   for (let index = 0; index < lines.length; index++) {
@@ -2846,6 +2847,20 @@ export function analyzeDeckControls(netlist: string): DeckControlSummary {
       continue;
     }
     const directive = deckDirective(stripped);
+    if (inControlBlock) {
+      if (directive === ".endc") {
+        inControlBlock = false;
+        continue;
+      }
+      diagnostics.push({
+        code: "SPICE_DECK_CONTROL_COMMAND",
+        directive: ".control",
+        lineNumber,
+        message: `${JSON.stringify(stripped)} inside .control is not executed by the deck execution foothold yet`,
+        severity: "error",
+      });
+      continue;
+    }
     if (directive === ".end") {
       endLineNumber = lineNumber;
       break;
@@ -2858,6 +2873,10 @@ export function analyzeDeckControls(netlist: string): DeckControlSummary {
         message: `${directive} is not supported by the deck execution foothold yet`,
         severity: "error",
       });
+      if (directive === ".control") {
+        inControlBlock = true;
+        continue;
+      }
     }
     activeLines.push(stripped);
   }
@@ -3373,6 +3392,7 @@ function resolveDeckLines(
 ): ResolvedDeckLines {
   const activeLines: string[] = [];
   let endLineNumber: number | undefined;
+  let inControlBlock = false;
 
   const lines = netlist.split(/\r?\n/);
   for (let index = 0; index < lines.length; index++) {
@@ -3382,6 +3402,21 @@ function resolveDeckLines(
       continue;
     }
     const directive = deckDirective(stripped);
+    if (inControlBlock) {
+      if (directive === ".endc") {
+        inControlBlock = false;
+        continue;
+      }
+      state.diagnostics.push({
+        code: "SPICE_DECK_CONTROL_COMMAND",
+        directive: ".control",
+        source,
+        lineNumber,
+        message: `${JSON.stringify(stripped)} inside .control is not executed by the deck source resolver yet`,
+        severity: "error",
+      });
+      continue;
+    }
     if (directive === ".end") {
       endLineNumber = lineNumber;
       break;
@@ -3407,6 +3442,10 @@ function resolveDeckLines(
         message: `${directive} is not supported by the deck source resolver yet`,
         severity: "error",
       });
+      if (directive === ".control") {
+        inControlBlock = true;
+        continue;
+      }
     }
     activeLines.push(stripped);
   }

--- a/code/packages/typescript/spice-engine/tests/compatibility.test.ts
+++ b/code/packages/typescript/spice-engine/tests/compatibility.test.ts
@@ -121,10 +121,9 @@ run
 `);
 
     expect(summary.terminated).toBe(true);
-    expect(summary.activeLines.slice(0, 3)).toStrictEqual([
+    expect(summary.activeLines).toStrictEqual([
       ".include models.inc",
       ".LIB vendor.lib TT",
-      ".control",
     ]);
     expect(summary.diagnostics.map(({ directive, lineNumber, severity }) => [
       directive,
@@ -134,10 +133,14 @@ run
       [".include", 2, "error"],
       [".lib", 3, "error"],
       [".control", 4, "error"],
+      [".control", 5, "error"],
     ]);
-    expect(summary.diagnostics.every((diagnostic) =>
-      diagnostic.code === "SPICE_DECK_UNSUPPORTED_DIRECTIVE"
-    )).toBe(true);
+    expect(summary.diagnostics.map((diagnostic) => diagnostic.code)).toStrictEqual([
+      "SPICE_DECK_UNSUPPORTED_DIRECTIVE",
+      "SPICE_DECK_UNSUPPORTED_DIRECTIVE",
+      "SPICE_DECK_UNSUPPORTED_DIRECTIVE",
+      "SPICE_DECK_CONTROL_COMMAND",
+    ]);
   });
 
   it("expands include files and selected library sections", () => {
@@ -186,6 +189,8 @@ Ctyp out 0 1u
 .include a.inc
 .lib vendor.lib SS
 .control
+run
+.endc
 .end
 `, {
       "a.inc": ".include b.inc\nR1 a b 1\n",
@@ -193,12 +198,14 @@ Ctyp out 0 1u
       "vendor.lib": ".lib TT\nRtyp out 0 20\n.endl TT\n",
     });
 
-    expect(summary.activeLines).toStrictEqual(["R2 b 0 2", "R1 a b 1", ".control"]);
+    expect(summary.terminated).toBe(true);
+    expect(summary.activeLines).toStrictEqual(["R2 b 0 2", "R1 a b 1"]);
     expect(summary.diagnostics.map((diagnostic) => diagnostic.code)).toStrictEqual([
       "SPICE_DECK_INCLUDE_NOT_FOUND",
       "SPICE_DECK_INCLUDE_CYCLE",
       "SPICE_DECK_LIB_SECTION_NOT_FOUND",
       "SPICE_DECK_UNSUPPORTED_DIRECTIVE",
+      "SPICE_DECK_CONTROL_COMMAND",
     ]);
     expect(summary.diagnostics.slice(0, 3).map(({ source, lineNumber, target }) => [
       source,

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -31,7 +31,9 @@ downstream tools to compare.
      measurement helpers from deck text; parsed `.save`, `.probe`,
      `.print <analysis> ...`, and `.plot <analysis> ...` cards now drive
      stable table output for operating-point, DC sweep, AC sweep, and transient
-     results; parsed
+     results; unsupported `.control` / `.endc` blocks are now excluded from
+     active deck and source-resolved solver input while body commands emit
+     stable non-executed diagnostics; parsed
      `.measure dc` / `.meas dc` cards now route DC
      sweep probe samples into the shared scalar measurement table surface;
      parsed `.measure ac` / `.meas ac` cards now route AC probe magnitudes over
@@ -194,10 +196,11 @@ downstream tools to compare.
       active deck lines before `.end`.
     - The helpers emit stable unsupported-feature diagnostics for `.include`,
       `.lib`, and `.control` directives that appear before `.end`, while
-      ignoring lines after the deck boundary.
+      ignoring lines after the deck boundary. Unsupported `.control` blocks
+      are also excluded from active lines, with per-command diagnostics for
+      non-comment lines inside the block.
     - Package README, changelog, and tests document and lock this shared
-      parser/planner foothold before include/library resolution and control
-      block execution are implemented.
+      parser/planner foothold before control block execution is implemented.
 
 15. Include/library source resolution.
     - Status: completed in this include/library resolution slice.
@@ -208,7 +211,8 @@ downstream tools to compare.
       named `.lib` / `.endl` library sections.
     - Stable diagnostics cover missing include files, missing library files,
       absent or unterminated sections, include/library cycles, and
-      still-unsupported `.control` directives.
+      still-unsupported `.control` directives whose body commands are excluded
+      from active source-resolved solver input.
 
 16. Parameter/expression resolution foothold.
     - Status: completed in this parameter/expression resolution slice.
@@ -491,6 +495,14 @@ downstream tools to compare.
       diagnostics distinguish missing `.plot` probes, unsupported `.plot`
       analyses, and malformed output probes.
 
+43. Deck `.control` block exclusion.
+    - Status: completed in this control-block exclusion slice.
+    - Python, Rust, and TypeScript now exclude unsupported `.control` / `.endc`
+      blocks from active deck-control lines and source-resolved solver input.
+    - The existing unsupported `.control` directive diagnostic is preserved,
+      while non-comment commands inside the block emit stable
+      `SPICE_DECK_CONTROL_COMMAND` diagnostics.
+
 ## Backlog
 
 1. Deck execution layer.
@@ -501,8 +513,8 @@ downstream tools to compare.
    - Expand deck-controlled output-plan integration beyond stable table
      routing and scoped `.print` / `.plot` selection toward full SPICE
      compatibility.
-   - Define a deliberate `.control` subset; explicit unsupported-feature
-     diagnostics are now present for the current non-executed state.
+   - Expand a deliberate `.control` subset beyond the current excluded,
+     non-executed block diagnostics.
 
 2. Production solver core.
    - Finish sparse real and complex matrix paths.


### PR DESCRIPTION
## Summary
- Exclude unsupported .control/.endc blocks from active deck-control lines and source-resolved solver input across Python, Rust, and TypeScript.
- Preserve the existing unsupported .control diagnostic and add stable SPICE_DECK_CONTROL_COMMAND diagnostics for non-comment commands inside the block.
- Update compatibility tests, README/changelog entries, and the SPICE implementation plan with completed slice 43.

## Verification
- PYTHONPATH="code/packages/python/spice-engine/src:code/packages/python/device-physics/src:code/packages/python/mosfet-models/src" /Users/adhithya/.local/share/mise/installs/python/3.12.13/bin/python3 -m ruff check code/packages/python/spice-engine/src/spice_engine/compatibility.py code/packages/python/spice-engine/tests/test_compatibility.py
- PYTHONPATH="code/packages/python/spice-engine/src:code/packages/python/device-physics/src:code/packages/python/mosfet-models/src" /Users/adhithya/.local/share/mise/installs/python/3.12.13/bin/python3 -m pytest code/packages/python/spice-engine/tests -q
- npm --prefix code/packages/typescript/spice-engine run build
- npm --prefix code/packages/typescript/spice-engine test
- cargo fmt --manifest-path code/packages/rust/spice-engine/Cargo.toml -- --check
- cargo test --manifest-path code/packages/rust/spice-engine/Cargo.toml
- git diff --check