### PR TITLE
feat(closurec): SIMPLE pipeline gains remove-unused-vars (+ inline)

### DIFF
--- a/code/programs/rust/closurec/CHANGELOG.md
+++ b/code/programs/rust/closurec/CHANGELOG.md
@@ -2,6 +2,65 @@
 
 All notable changes to the `coding-adventures-closurec` binary will be documented in this file.
 
+## [0.141.0] - 2026-06-16
+
+### Added (CLOC12.158 — SIMPLE pipeline gains `remove-unused-vars`)
+
+The `--compilation_level SIMPLE` pass pipeline is now
+`constant-fold → fold-control-flow → dce → inline → remove-unused-vars`. The
+final pass deletes top-level `var`/`let`/`const` bindings that nothing
+references, when their initializer is side-effect-free:
+
+| Source | SIMPLE output |
+|--------|---------------|
+| `var dead = 1 + 2; …` | *(removed — folds to `3`, then dropped)* |
+| `var live = 10; log(live);` | `var live=10;log(live);` *(referenced)* |
+| `var impure = run();` | `var impure=run();` *(kept — call may have a side effect)* |
+
+The `var dead = 1 + 2` case shows `constant-fold` and `remove-unused-vars`
+composing: the initializer must fold to a literal before the binding reads as a
+pure, removable declaration.
+
+- `inline` is now also registered. `remove-unused-vars` declares
+  `depends_on = ["dce", "inline"]`, so the scheduler will not run it unless
+  `inline` is in the pipeline. `inline` is an identity pass today; it holds the
+  canonical slot until real function inlining lands.
+- `SIMPLE_PASS_NAMES` is now
+  `["constant-fold", "fold-control-flow", "dce", "inline", "remove-unused-vars"]`;
+  the `passes` field in the `simple_v2` correlation-vector trace lists all five.
+
+This relies on `closure-pass-remove-unused-vars` 0.4.0, which made the pass
+actually remove bindings (it was previously a no-op on bridged programs).
+
+### Verified
+- New `tests/diff/simple-remove-unused-vars/` end-to-end fixture +
+  `tests/diff_simple_remove_unused_vars.rs`:
+  `var dead = 1 + 2; var live = 10; var impure = run(); log(live);` ⇒
+  `var live=10;var impure=run();log(live);`.
+- New unit tests `simple_remove_unused_drops_dead_top_level_var`,
+  `simple_remove_unused_composes_with_constant_fold`,
+  `simple_remove_unused_keeps_impure_initializer` (purity gate), and
+  `simple_remove_unused_whitespace_only_keeps_var`.
+- Existing `simple_v2` CV test updated to expect all five pass names.
+
+### Fixture / test churn (default level is SIMPLE)
+
+Adding `remove-unused-vars` to the default pipeline means an unreferenced
+top-level `var` is now deleted by default. Several existing tests used a bare
+`var x = 1;` as inert filler and broke when it vanished. Fixed two ways:
+- **Feature-orthogonal tests pinned to `WHITESPACE_ONLY`** (they test charset,
+  `--emit_use_strict`, IIFE/output-wrapper isolation, glob expansion,
+  output-file plumbing, source maps, externs, concatenation/newline handling —
+  none of which depend on the optimization level): the `charset-us-ascii`,
+  `charset-utf8`, `emit-use-strict`, `isolation-iife`, `js-glob`,
+  `js-output-file`, and `output-wrapper` diff fixtures, plus the corresponding
+  `run.rs` unit tests. This isolates them from future optimizer changes too.
+- **SIMPLE-level tests given referenced vars** so the binding survives and the
+  behavior under test stays observable: `simple_level_constant_folds_arithmetic`,
+  `simple_level_strips_whitespace_not_identity`,
+  `simple_level_bridge_status_n_a_without_cv`, and the `simple-constant-fold`
+  fixture now pass their values to a `report(...)`/`use(...)` call.
+
 ## [0.140.0] - 2026-06-16
 
 ### Added (CLOC12.157 — SIMPLE pipeline gains `dce`)

--- a/code/programs/rust/closurec/Cargo.toml
+++ b/code/programs/rust/closurec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closurec"
-version = "0.140.0"
+version = "0.141.0"
 edition = "2021"
 description = "closurec — CLI driver for the Closure Compiler clone. Mirrors the upstream Java Closure Compiler's command-line flag surface (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility. Per CLOC08."
 

--- a/code/programs/rust/closurec/README.md
+++ b/code/programs/rust/closurec/README.md
@@ -124,7 +124,7 @@ body fills in.**
 | Level | What it does |
 |-------|--------------|
 | `WHITESPACE_ONLY` | Strips comments and inter-token whitespace only. Token-level; never parses to a typed AST. |
-| `SIMPLE` | Runs the typed-AST optimization pipeline — parse → bridge → passes → emit. Today the pipeline is `constant-fold → fold-control-flow → dce` (e.g. `1 + 2` ⇒ `3`; `if (2 > 3) {a} else {b}` ⇒ `{b}`; code after a `return` is dropped); more passes land one PR at a time. Falls back to `WHITESPACE_ONLY` if the source uses a not-yet-supported construct, so it never errors on valid input. |
+| `SIMPLE` | Runs the typed-AST optimization pipeline — parse → bridge → passes → emit. Today the pipeline is `constant-fold → fold-control-flow → dce → inline → remove-unused-vars` (e.g. `1 + 2` ⇒ `3`; `if (2 > 3) {a} else {b}` ⇒ `{b}`; code after a `return` is dropped; unused top-level `var`s with pure initializers are deleted); more passes land one PR at a time. Falls back to `WHITESPACE_ONLY` if the source uses a not-yet-supported construct, so it never errors on valid input. |
 | `ADVANCED` / `BUNDLE` / `TRANSPILE_ONLY` | Identity passthrough for now — the typed passes specific to these levels (tree-shaking, property renaming, etc.) land in follow-up work. |
 
 The SIMPLE pipeline:

--- a/code/programs/rust/closurec/cli.spec.json
+++ b/code/programs/rust/closurec/cli.spec.json
@@ -2,7 +2,7 @@
   "cli_builder_spec_version": "1.0",
   "name": "closurec",
   "description": "closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.",
-  "version": "0.140.0",
+  "version": "0.141.0",
   "parsing_mode": "gnu",
   "flags": [
     { "id": "browser_featureset_year", "long": "browser_featureset_year", "type": "integer", "default": 0, "description": "Shortcut for defining goog.FEATURESET_YEAR=YYYY (minimum 2012)." },

--- a/code/programs/rust/closurec/src/run.rs
+++ b/code/programs/rust/closurec/src/run.rs
@@ -216,19 +216,27 @@ pub fn transform_source(
 /// The list is in execution order. Ordering is enforced two ways: every
 /// pass that needs a predecessor declares it via `Pass::depends_on`, and
 /// where two passes are mutually independent the pipeline falls back to
-/// *registration order* as the tie-breaker. Both `fold-control-flow` and
-/// `dce` declare `depends_on = ["constant-fold"]` (so constant-fold always
-/// runs first), but neither depends on the other — so we register, and
-/// thus run, `fold-control-flow` before `dce` on purpose:
+/// *registration order* as the tie-breaker.
 ///
 /// - constant-fold turns `2 > 3` into the literal `false`;
 /// - fold-control-flow then prunes `if (false) {A}` to an empty `;`;
 /// - dce then sweeps that empty statement (and any code after a `return`)
-///   away.
-///
-/// Running dce last means it cleans up the `;` debris the control-flow
-/// folder leaves behind.
-const SIMPLE_PASS_NAMES: &[&str] = &["constant-fold", "fold-control-flow", "dce"];
+///   away;
+/// - inline is in the chain because `remove-unused-vars` declares
+///   `depends_on = ["dce", "inline"]` — the scheduler will not run
+///   remove-unused-vars unless `inline` is registered. (inline is
+///   currently an identity pass; it earns its slot once function
+///   inlining lands, and registering it now pins the canonical order.)
+/// - remove-unused-vars runs last and deletes top-level `var/let/const`
+///   bindings that nothing references, when their initializer is
+///   side-effect-free.
+const SIMPLE_PASS_NAMES: &[&str] = &[
+    "constant-fold",
+    "fold-control-flow",
+    "dce",
+    "inline",
+    "remove-unused-vars",
+];
 
 /// Run the SIMPLE optimization pipeline over a bridged `Program` and
 /// emit the result as JavaScript text.
@@ -259,7 +267,9 @@ fn run_simple_pipeline(
     use coding_adventures_closure_pass_constant_fold::ConstantFoldPass;
     use coding_adventures_closure_pass_dce::DcePass;
     use coding_adventures_closure_pass_fold_control_flow::FoldControlFlowPass;
+    use coding_adventures_closure_pass_inline::InlinePass;
     use coding_adventures_closure_pass_pipeline::PassPipeline;
+    use coding_adventures_closure_pass_remove_unused_vars::RemoveUnusedVarsPass;
     use coding_adventures_correlation_vector::CVLog;
     use coding_adventures_type_sidecar::Sidecar;
 
@@ -271,14 +281,16 @@ fn run_simple_pipeline(
 
     // The pipeline topo-sorts on each pass's `depends_on`, with
     // registration order as the tie-breaker between independent passes.
-    // `fold-control-flow` and `dce` both depend on `constant-fold` (so it
-    // runs first) but not on each other, so registration order is what
-    // puts `fold-control-flow` before `dce` — letting dce sweep the empty
-    // `;` statements the control-flow folder leaves behind.
+    // `remove-unused-vars` declares `depends_on = ["dce", "inline"]`, so
+    // `inline` MUST be registered or the scheduler refuses to run
+    // remove-unused-vars. `inline` is an identity pass today; it holds
+    // the canonical slot until real function inlining lands.
     let mut pipeline = PassPipeline::new();
     pipeline.add(Box::new(ConstantFoldPass::new()));
     pipeline.add(Box::new(FoldControlFlowPass::new()));
     pipeline.add(Box::new(DcePass::new()));
+    pipeline.add(Box::new(InlinePass::new()));
+    pipeline.add(Box::new(RemoveUnusedVarsPass::new()));
 
     let optimized = match pipeline.run(program, &sidecar, &mut pass_cv) {
         Ok(out) => out.program,
@@ -2202,6 +2214,13 @@ mod tests {
                 ],
                 ..Default::default()
             },
+            // Pinned to WHITESPACE_ONLY: this test is about input
+            // concatenation order, not optimization (at SIMPLE the
+            // unreferenced `var a`/`var b` would be removed).
+            compilation: crate::config::CompilationConfig {
+                level: crate::config::CompilationLevel::WhitespaceOnly,
+                ..Default::default()
+            },
             ..Default::default()
         };
         let out = run_compiler(&cfg).expect("ok");
@@ -2247,6 +2266,13 @@ mod tests {
         let cfg = CompilerConfig {
             io: IoConfig {
                 js_patterns: vec![in_path.to_string_lossy().to_string()],
+                ..Default::default()
+            },
+            // Pinned to WHITESPACE_ONLY: this test is about newline
+            // handling, not optimization. At the default level (SIMPLE)
+            // remove-unused-vars would delete the unreferenced `var x`.
+            compilation: crate::config::CompilationConfig {
+                level: crate::config::CompilationLevel::WhitespaceOnly,
                 ..Default::default()
             },
             ..Default::default()
@@ -2351,12 +2377,18 @@ mod tests {
                 js_output_file: Some(out_path.clone()),
                 ..Default::default()
             },
+            // Pinned to WHITESPACE_ONLY: this test is about parent-dir
+            // auto-creation, not optimization (at SIMPLE the unreferenced
+            // `var x` would be removed).
+            compilation: crate::config::CompilationConfig {
+                level: crate::config::CompilationLevel::WhitespaceOnly,
+                ..Default::default()
+            },
             ..Default::default()
         };
         let out = run_compiler(&cfg).expect("ok");
         assert_eq!(out.wrote_files, vec![out_path.clone()]);
         let written = fs::read_to_string(&out_path).expect("read out");
-        // SIMPLE v1 produces whitespace_only output (no extra spaces).
         assert_eq!(written, "var x=1;\n");
         let _ = fs::remove_dir_all(&base);
     }
@@ -2375,6 +2407,13 @@ mod tests {
             io: IoConfig {
                 js_patterns: vec![in_path.to_string_lossy().to_string()],
                 js_output_file: None,
+                ..Default::default()
+            },
+            // Pinned to WHITESPACE_ONLY: this test is about the stdout
+            // fallback plumbing, not optimization (at SIMPLE the
+            // unreferenced `var x` would be removed).
+            compilation: crate::config::CompilationConfig {
+                level: crate::config::CompilationLevel::WhitespaceOnly,
                 ..Default::default()
             },
             ..Default::default()
@@ -2400,6 +2439,13 @@ mod tests {
             },
             language: crate::config::LanguageConfig {
                 emit_use_strict: true,
+                ..Default::default()
+            },
+            // Pinned to WHITESPACE_ONLY: this test is about the
+            // use-strict directive, not optimization (at SIMPLE the
+            // unreferenced `var x` would be removed).
+            compilation: crate::config::CompilationConfig {
+                level: crate::config::CompilationLevel::WhitespaceOnly,
                 ..Default::default()
             },
             ..Default::default()
@@ -2453,6 +2499,12 @@ mod tests {
                 isolation_mode: crate::config::IsolationMode::Iife,
                 ..Default::default()
             },
+            // Pinned to WHITESPACE_ONLY: tests directive placement
+            // inside the IIFE, not optimization.
+            compilation: crate::config::CompilationConfig {
+                level: crate::config::CompilationLevel::WhitespaceOnly,
+                ..Default::default()
+            },
             ..Default::default()
         };
         let out = run_compiler(&cfg).expect("ok");
@@ -2485,6 +2537,12 @@ mod tests {
             },
             formatting: crate::config::FormattingConfig {
                 output_wrapper: "PRE %output% POST".to_string(),
+                ..Default::default()
+            },
+            // Pinned to WHITESPACE_ONLY: tests directive placement
+            // inside the output wrapper, not optimization.
+            compilation: crate::config::CompilationConfig {
+                level: crate::config::CompilationLevel::WhitespaceOnly,
                 ..Default::default()
             },
             ..Default::default()
@@ -2918,6 +2976,13 @@ mod tests {
                 externs: vec![ext_path.to_string_lossy().to_string()],
                 ..Default::default()
             },
+            // Pinned to WHITESPACE_ONLY: this test is about externs
+            // resolution, not optimization (at SIMPLE the unreferenced
+            // `var x` would be removed).
+            compilation: crate::config::CompilationConfig {
+                level: crate::config::CompilationLevel::WhitespaceOnly,
+                ..Default::default()
+            },
             ..Default::default()
         };
         let out = run_compiler(&cfg).expect("ok");
@@ -3000,6 +3065,13 @@ mod tests {
             },
             source_map: crate::config::SourceMapConfig {
                 path_template: map_path.to_string_lossy().to_string(),
+                ..Default::default()
+            },
+            // Pinned to WHITESPACE_ONLY: this test is about source-map
+            // emission, not optimization (at SIMPLE the unreferenced
+            // `var x` would be removed).
+            compilation: crate::config::CompilationConfig {
+                level: crate::config::CompilationLevel::WhitespaceOnly,
                 ..Default::default()
             },
             ..Default::default()
@@ -5472,11 +5544,13 @@ mod tests {
             },
             ..Default::default()
         };
-        let source = "var  x   =   1 ;";
+        // `x` is referenced so remove-unused-vars keeps it; the point
+        // here is the whitespace normalisation, not removal.
+        let source = "var  x   =   1 ; use(x);";
         let out = transform_source(source, &cfg).expect("ok");
-        // The typed emitter produces the compact `var x=1;`.
+        // The typed emitter produces the compact `var x=1;use(x);`.
         assert_ne!(out, source, "SIMPLE must not return the raw source");
-        assert_eq!(out, "var x=1;");
+        assert_eq!(out, "var x=1;use(x);");
     }
 
     #[test]
@@ -5486,6 +5560,10 @@ mod tests {
         // This is the load-bearing difference from whitespace_only —
         // `1 + 2` becomes `3`, not `1+2`. If the bridge/pipeline/emit
         // chain ever silently degraded, this would regress to `1+2`.
+        //
+        // `x` is referenced (`use(x)`) so remove-unused-vars — now last
+        // in the SIMPLE pipeline — keeps the declaration; otherwise the
+        // whole `var x` would be removed and the fold wouldn't be visible.
         let cfg = CompilerConfig {
             compilation: crate::config::CompilationConfig {
                 level: crate::config::CompilationLevel::Simple,
@@ -5493,8 +5571,8 @@ mod tests {
             },
             ..Default::default()
         };
-        let out = transform_source("var x = 1 + 2;", &cfg).expect("ok");
-        assert_eq!(out, "var x=3;", "constant-fold must evaluate 1 + 2");
+        let out = transform_source("var x = 1 + 2; use(x);", &cfg).expect("ok");
+        assert_eq!(out, "var x=3;use(x);", "constant-fold must evaluate 1 + 2");
     }
 
     #[test]
@@ -5614,6 +5692,72 @@ mod tests {
     }
 
     #[test]
+    fn simple_remove_unused_drops_dead_top_level_var() {
+        // CLOC12.158: the SIMPLE pipeline now ends with
+        // remove-unused-vars. An unreferenced top-level `var` with a
+        // pure (literal) initializer is deleted entirely.
+        let cfg = CompilerConfig {
+            compilation: crate::config::CompilationConfig {
+                level: crate::config::CompilationLevel::Simple,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let out = transform_source("var unused = 1; used();", &cfg).expect("ok");
+        assert_eq!(out, "used();", "the unused var must be removed");
+    }
+
+    #[test]
+    fn simple_remove_unused_composes_with_constant_fold() {
+        // `var x = 1 + 2; sideEffect();` — constant-fold turns the
+        // initializer into the literal `3`, and only then does
+        // remove-unused-vars see a pure init it can drop. Proves the
+        // two passes compose end to end.
+        let cfg = CompilerConfig {
+            compilation: crate::config::CompilationConfig {
+                level: crate::config::CompilationLevel::Simple,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let out = transform_source("var x = 1 + 2; sideEffect();", &cfg).expect("ok");
+        assert_eq!(out, "sideEffect();", "folded-then-dead var must be removed");
+    }
+
+    #[test]
+    fn simple_remove_unused_keeps_impure_initializer() {
+        // `var impure = run();` — unreferenced, but the call initializer
+        // may have a side effect, so the purity gate keeps it.
+        let cfg = CompilerConfig {
+            compilation: crate::config::CompilationConfig {
+                level: crate::config::CompilationLevel::Simple,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let out = transform_source("var impure = run();", &cfg).expect("ok");
+        assert_eq!(
+            out, "var impure=run();",
+            "a dead var with a side-effecting initializer must be kept"
+        );
+    }
+
+    #[test]
+    fn simple_remove_unused_whitespace_only_keeps_var() {
+        // Companion — the SAME unused var under WHITESPACE_ONLY survives,
+        // proving the removal is the SIMPLE pipeline's doing.
+        let cfg = CompilerConfig {
+            compilation: crate::config::CompilationConfig {
+                level: crate::config::CompilationLevel::WhitespaceOnly,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let out = transform_source("var unused = 1; used();", &cfg).expect("ok");
+        assert_eq!(out, "var unused=1;used();", "whitespace_only must NOT remove");
+    }
+
+    #[test]
     fn simple_level_bridge_ok_status_in_cv() {
         // When the source parses cleanly, the CV contribution for the
         // `compilation_level` stage must carry bridge_status = "ok".
@@ -5651,7 +5795,9 @@ mod tests {
         );
         // The pass pipeline must be recorded in the trace, in order.
         assert!(
-            body.contains("\"passes\":[\"constant-fold\",\"fold-control-flow\",\"dce\"]"),
+            body.contains(
+                "\"passes\":[\"constant-fold\",\"fold-control-flow\",\"dce\",\"inline\",\"remove-unused-vars\"]"
+            ),
             "expected passes list in CV sidecar: {body}"
         );
         let _ = fs::remove_dir_all(&dir);
@@ -5720,7 +5866,8 @@ mod tests {
             },
             ..Default::default()
         };
-        let out = transform_source("var x = 1;", &cfg).expect("ok");
-        assert_eq!(out, "var x=1;");
+        // `x` is referenced so remove-unused-vars keeps it.
+        let out = transform_source("var x = 1; use(x);", &cfg).expect("ok");
+        assert_eq!(out, "var x=1;use(x);");
     }
 }

--- a/code/programs/rust/closurec/tests/diff/charset-us-ascii/flags.txt
+++ b/code/programs/rust/closurec/tests/diff/charset-us-ascii/flags.txt
@@ -1,2 +1,4 @@
 --js
 tests/diff/charset-us-ascii/input/a.js
+--compilation_level
+WHITESPACE_ONLY

--- a/code/programs/rust/closurec/tests/diff/charset-utf8/flags.txt
+++ b/code/programs/rust/closurec/tests/diff/charset-utf8/flags.txt
@@ -2,3 +2,5 @@
 tests/diff/charset-utf8/input/a.js
 --charset
 UTF-8
+--compilation_level
+WHITESPACE_ONLY

--- a/code/programs/rust/closurec/tests/diff/emit-use-strict/flags.txt
+++ b/code/programs/rust/closurec/tests/diff/emit-use-strict/flags.txt
@@ -1,3 +1,5 @@
 --emit_use_strict
 --js
 tests/diff/emit-use-strict/input/a.js
+--compilation_level
+WHITESPACE_ONLY

--- a/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
@@ -2,7 +2,7 @@
 
 closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.
 
-Version: 0.140.0
+Version: 0.141.0
 
 ## Flags
 

--- a/code/programs/rust/closurec/tests/diff/isolation-iife/flags.txt
+++ b/code/programs/rust/closurec/tests/diff/isolation-iife/flags.txt
@@ -2,3 +2,5 @@
 IIFE
 --js
 tests/diff/isolation-iife/input/a.js
+--compilation_level
+WHITESPACE_ONLY

--- a/code/programs/rust/closurec/tests/diff/js-glob/flags.txt
+++ b/code/programs/rust/closurec/tests/diff/js-glob/flags.txt
@@ -2,3 +2,5 @@
 tests/diff/js-glob/input/**/*.js
 --js
 !tests/diff/js-glob/input/excluded/**
+--compilation_level
+WHITESPACE_ONLY

--- a/code/programs/rust/closurec/tests/diff/js-output-file/flags.txt
+++ b/code/programs/rust/closurec/tests/diff/js-output-file/flags.txt
@@ -2,3 +2,5 @@
 tests/diff/js-output-file/input/a.js
 --js
 tests/diff/js-output-file/input/b.js
+--compilation_level
+WHITESPACE_ONLY

--- a/code/programs/rust/closurec/tests/diff/output-wrapper/flags.txt
+++ b/code/programs/rust/closurec/tests/diff/output-wrapper/flags.txt
@@ -2,3 +2,5 @@
 (function(){%output%})();
 --js
 tests/diff/output-wrapper/input/a.js
+--compilation_level
+WHITESPACE_ONLY

--- a/code/programs/rust/closurec/tests/diff/simple-constant-fold/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/simple-constant-fold/expected.stdout
@@ -1,2 +1,1 @@
-var sum=3;var product=12;var nested=14;
-
+var sum=3;var product=12;var nested=14;report(sum,product,nested);

--- a/code/programs/rust/closurec/tests/diff/simple-constant-fold/input/a.js
+++ b/code/programs/rust/closurec/tests/diff/simple-constant-fold/input/a.js
@@ -4,6 +4,11 @@
 // `constant-fold` pass evaluates at compile time. Under WHITESPACE_ONLY
 // these would survive as `1+2`, `3*4`, etc.; under SIMPLE they fold to
 // their value. This fixture is the end-to-end oracle for PR-1.
+//
+// The values are passed to `report(...)` so they stay referenced —
+// otherwise remove-unused-vars (now the last SIMPLE pass) would delete
+// the whole declarations and the fold would not be observable.
 var sum = 1 + 2;
 var product = 3 * 4;
 var nested = 2 + 3 * 4;
+report(sum, product, nested);

--- a/code/programs/rust/closurec/tests/diff/simple-remove-unused-vars/README.md
+++ b/code/programs/rust/closurec/tests/diff/simple-remove-unused-vars/README.md
@@ -1,0 +1,36 @@
+# Fixture: `simple-remove-unused-vars`
+
+End-to-end oracle for the `remove-unused-vars` pass in
+`--compilation_level SIMPLE` (CLOC12.158, PR-B).
+
+| File | Role |
+|------|------|
+| `flags.txt` | `--compilation_level SIMPLE --js input/a.js` |
+| `input/a.js` | Three top-level `var`s — one dead, one live, one impure |
+| `expected.stdout` | `var live=10;var impure=run();log(live);` |
+
+The SIMPLE pipeline is now
+`constant-fold → fold-control-flow → dce → inline → remove-unused-vars`.
+The final pass deletes top-level bindings nothing references, when their
+initializer is side-effect-free:
+
+| Source | Fate |
+|--------|------|
+| `var dead = 1 + 2;` | removed — `constant-fold` folds it to the literal `3`, then `remove-unused-vars` drops the dead, pure-init declaration |
+| `var live = 10;` | kept — referenced by `log(live)` |
+| `var impure = run();` | kept — unreferenced, but the call initializer may have a side effect (purity gate) |
+
+The `var dead` row proves `constant-fold` and `remove-unused-vars`
+compose: the comparison must be folded to a literal before the binding
+reads as a pure, removable declaration. `inline` (an identity pass today)
+is in the pipeline only because `remove-unused-vars` declares
+`depends_on = ["dce", "inline"]`. The same input under `WHITESPACE_ONLY`
+keeps every declaration verbatim.
+
+Regenerate the expected file after an intentional behavior change:
+
+```sh
+cargo run -- --compilation_level SIMPLE \
+    --js tests/diff/simple-remove-unused-vars/input/a.js \
+    > tests/diff/simple-remove-unused-vars/expected.stdout
+```

--- a/code/programs/rust/closurec/tests/diff/simple-remove-unused-vars/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/simple-remove-unused-vars/expected.stdout
@@ -1,0 +1,2 @@
+var live=10;var impure=run();log(live);
+

--- a/code/programs/rust/closurec/tests/diff/simple-remove-unused-vars/flags.txt
+++ b/code/programs/rust/closurec/tests/diff/simple-remove-unused-vars/flags.txt
@@ -1,0 +1,4 @@
+--compilation_level
+SIMPLE
+--js
+tests/diff/simple-remove-unused-vars/input/a.js

--- a/code/programs/rust/closurec/tests/diff/simple-remove-unused-vars/input/a.js
+++ b/code/programs/rust/closurec/tests/diff/simple-remove-unused-vars/input/a.js
@@ -1,0 +1,21 @@
+// SIMPLE-level unused-variable removal (CLOC12.158).
+//
+// The SIMPLE pipeline now ends with `remove-unused-vars` (after
+// constant-fold -> fold-control-flow -> dce -> inline). It deletes
+// top-level bindings nothing references, when their initializer is
+// side-effect-free. This fixture shows all three outcomes at once:
+//
+//   - `var dead = 1 + 2;`  -- unreferenced. constant-fold first turns
+//        `1 + 2` into the literal `3`, then remove-unused-vars drops the
+//        whole declaration (literal init => pure => safe to delete). This
+//        proves the two passes compose.
+//   - `var live = 10;`     -- referenced by `log(live)` below, so it
+//        survives.
+//   - `var impure = run();` -- unreferenced, BUT its initializer is a
+//        call, which may have a side effect. The purity gate keeps it.
+//
+// Under WHITESPACE_ONLY every declaration survives verbatim.
+var dead = 1 + 2;
+var live = 10;
+var impure = run();
+log(live);

--- a/code/programs/rust/closurec/tests/diff_simple_remove_unused_vars.rs
+++ b/code/programs/rust/closurec/tests/diff_simple_remove_unused_vars.rs
@@ -1,0 +1,65 @@
+//! Integration test for the `tests/diff/simple-remove-unused-vars/`
+//! fixture.
+//!
+//! Exercises the CLOC12.158 addition of the `remove-unused-vars` pass to
+//! the `--compilation_level SIMPLE` pipeline, which is now
+//! `constant-fold → fold-control-flow → dce → inline → remove-unused-vars`.
+//! The pass deletes top-level bindings nothing references when their
+//! initializer is side-effect-free:
+//!
+//! ```text
+//! var dead = 1 + 2;     ⇒  (removed — folds to a literal, then dropped)
+//! var live = 10;        ⇒  var live=10;   (referenced by log(live))
+//! var impure = run();   ⇒  var impure=run();   (kept — call may have a side effect)
+//! log(live);            ⇒  log(live);
+//! ```
+//!
+//! The `var dead = 1 + 2` row is the load-bearing one: `constant-fold`
+//! turns `1 + 2` into the literal `3`, and only then does
+//! `remove-unused-vars` see a pure (literal) initializer it can drop —
+//! proving the two passes compose. The same input under WHITESPACE_ONLY
+//! keeps every declaration (see the `simple_remove_unused_*` unit tests
+//! in `src/run.rs`).
+//!
+//! `remove-unused-vars` needs `inline` registered (it declares
+//! `depends_on = ["dce", "inline"]`); `inline` is an identity pass today
+//! and is wired in alongside to satisfy the scheduler.
+
+use std::process::Command;
+
+const BINARY: &str = env!("CARGO_BIN_EXE_closurec");
+
+fn read_flags() -> Vec<String> {
+    let raw = std::fs::read_to_string("tests/diff/simple-remove-unused-vars/flags.txt")
+        .expect("read flags.txt");
+    raw.lines()
+        .filter(|l| !l.is_empty())
+        .map(|s| s.to_string())
+        .collect()
+}
+
+#[test]
+fn simple_remove_unused_vars_fixture_matches_expected_stdout() {
+    let flags = read_flags();
+    let out = Command::new(BINARY)
+        .args(&flags)
+        .output()
+        .expect("run closurec");
+
+    assert!(
+        out.status.success(),
+        "exit: {:?}, stderr: {}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stderr),
+    );
+
+    let actual = String::from_utf8_lossy(&out.stdout);
+    let expected =
+        std::fs::read_to_string("tests/diff/simple-remove-unused-vars/expected.stdout")
+            .expect("read expected.stdout");
+    assert_eq!(
+        actual.trim_end_matches('\n'),
+        expected.trim_end_matches('\n'),
+        "mismatch.\nflags: {flags:?}\nactual:\n{actual}\nexpected:\n{expected}",
+    );
+}


### PR DESCRIPTION
## Summary

The `--compilation_level SIMPLE` pass pipeline is now **`constant-fold → fold-control-flow → dce → inline → remove-unused-vars`**. The final pass deletes top-level `var`/`let`/`const` bindings nothing references, when their initializer is side-effect-free:

| Source | SIMPLE output |
|--------|---------------|
| `var dead = 1 + 2; …` | *(removed — folds to `3`, then dropped)* |
| `var live = 10; log(live);` | `var live=10;log(live);` *(referenced)* |
| `var impure = run();` | `var impure=run();` *(kept — call may have a side effect)* |

The `var dead = 1 + 2` case shows `constant-fold` and `remove-unused-vars` **compose**: the initializer must fold to a literal before the binding reads as a pure, removable declaration.

- **`inline` is registered too.** `remove-unused-vars` declares `depends_on = ["dce", "inline"]`, so the scheduler refuses to run it unless `inline` is present. `inline` is an identity pass today; it holds the canonical slot until real function inlining lands.
- Relies on `closure-pass-remove-unused-vars` 0.4.0 ([#5972](https://github.com/adhithyan15/coding-adventures/pull/5972), merged), which made the pass actually remove bindings.

## Fixture/test churn (default level is SIMPLE)

Adding `remove-unused-vars` to the default pipeline means an unreferenced top-level `var` is now deleted by default. Several existing tests used a bare `var x = 1;` as inert filler and broke when it vanished. Fixed two ways:
- **Feature-orthogonal tests pinned to `WHITESPACE_ONLY`** (charset, `--emit_use_strict`, IIFE/output-wrapper isolation, glob, output-file, source maps, externs, concat/newline — all level-independent): the `charset-us-ascii`, `charset-utf8`, `emit-use-strict`, `isolation-iife`, `js-glob`, `js-output-file`, `output-wrapper` fixtures + matching unit tests. Isolates them from future optimizer changes too.
- **SIMPLE-level tests given referenced vars** so the behavior stays observable: `simple_level_constant_folds_arithmetic` & co., plus the `simple-constant-fold` fixture, now pass values to a `report(...)`/`use(...)` call.

## Test plan

- [x] New `tests/diff/simple-remove-unused-vars/` fixture + harness: `var dead = 1 + 2; var live = 10; var impure = run(); log(live);` ⇒ `var live=10;var impure=run();log(live);`
- [x] New unit tests: `simple_remove_unused_drops_dead_top_level_var`, `simple_remove_unused_composes_with_constant_fold`, `simple_remove_unused_keeps_impure_initializer` (purity gate), `simple_remove_unused_whitespace_only_keeps_var`
- [x] `simple_v2` CV trace test updated to expect all five pass names
- [x] Full `cargo test` green (0 failures); security review passed
- closurec 0.140.0 → 0.141.0 (Cargo.toml + cli.spec.json + help-markdown fixture)

🤖 Generated with [Claude Code](https://claude.com/claude-code)