### PR TITLE
Add SPICE control command routing

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -4,10 +4,16 @@
 
 ### Added
 
+- **Deck control-command routing** —
+  `analyze_deck_controls()` and `resolve_deck_sources()` now normalize
+  selected `.control` block analysis/output commands (`op`, `dc`, `ac`,
+  `tran`, `print`, and `plot`) into dotted deck cards, matching Rust and
+  TypeScript.
+
 - **Deck control-block exclusion diagnostics** —
   `analyze_deck_controls()` and `resolve_deck_sources()` now exclude
-  unsupported `.control` / `.endc` blocks from active deck lines while
-  reporting stable command diagnostics for non-comment lines inside the block,
+  unsupported `.control` / `.endc` block markers and unrecognized body
+  commands from active deck lines while reporting stable command diagnostics,
   matching Rust and TypeScript.
 
 - **Parsed plot output routing** —

--- a/code/packages/python/spice-engine/README.md
+++ b/code/packages/python/spice-engine/README.md
@@ -158,16 +158,16 @@ notes. `release_readiness_gates()` validates the corpus metadata, while
 provide stable tab-separated summaries for package checks.
 `analyze_deck_controls()` provides the shared deck-control boundary foothold:
 it returns active lines before `.end` and stable diagnostics for unsupported
-`.include`, `.lib`, and `.control` directives. Unsupported `.control` blocks
-are excluded from active deck lines, and non-comment commands inside the block
-emit command diagnostics until a deliberate executed control subset is in
-scope.
+`.include`, `.lib`, and `.control` directives. Inside `.control` blocks,
+selected analysis/output commands (`op`, `dc`, `ac`, `tran`, `print`, and
+`plot`) are normalized into dotted deck cards, while unrecognized non-comment
+commands emit diagnostics until a broader executed control subset is in scope.
 `resolve_deck_sources()` is the first include/library resolution layer: callers
 provide a source-content map, `.include` directives are expanded in place, and
 `.lib path section` selects a named `.lib` / `.endl` section with stable
 diagnostics for missing files, missing sections, unterminated sections, cycles,
-and still-unsupported `.control` blocks whose body commands are not forwarded
-as active solver input.
+and still-unsupported `.control` block commands that are not part of the
+selected analysis/output subset.
 `resolve_deck_parameters()` evaluates scalar whitespace-tokenized `.param`
 assignments, collects scalar `.func` definitions before `.end`, preserves
 parameter order, rewrites braced and quoted active-line expressions, and emits

--- a/code/packages/python/spice-engine/src/spice_engine/compatibility.py
+++ b/code/packages/python/spice-engine/src/spice_engine/compatibility.py
@@ -487,6 +487,9 @@ _REQUIRED_ANALYSES = frozenset({"op", "dc", "ac", "tran"})
 _UNSUPPORTED_DECK_CONTROL_DIRECTIVES = frozenset({".include", ".lib", ".control"})
 _UNSUPPORTED_RESOLVED_DIRECTIVES = frozenset({".control"})
 _UNSUPPORTED_PARAMETER_DIRECTIVES = frozenset()
+_SUPPORTED_CONTROL_BLOCK_COMMANDS = frozenset(
+    {"op", ".op", "dc", ".dc", "ac", ".ac", "tran", ".tran", "print", ".print", "plot", ".plot"}
+)
 _SPICE_SUFFIX_FACTORS = {
     "t": 1.0e12,
     "g": 1.0e9,
@@ -517,6 +520,10 @@ def analyze_deck_controls(netlist: str) -> DeckControlSummary:
         if in_control_block:
             if directive == ".endc":
                 in_control_block = False
+                continue
+            control_line = _control_block_command_as_deck_line(stripped)
+            if control_line is not None:
+                active_lines.append(control_line)
                 continue
             diagnostics.append(
                 DeckControlDiagnostic(
@@ -2996,6 +3003,10 @@ def _resolve_deck_lines(
             if directive == ".endc":
                 in_control_block = False
                 continue
+            control_line = _control_block_command_as_deck_line(stripped)
+            if control_line is not None:
+                active_lines.append(control_line)
+                continue
             state.diagnostics.append(
                 DeckResolutionDiagnostic(
                     code="SPICE_DECK_CONTROL_COMMAND",
@@ -3282,3 +3293,16 @@ def _deck_directive(line: str) -> str | None:
     if not line.startswith("."):
         return None
     return line.split(None, 1)[0].lower()
+
+
+def _control_block_command_as_deck_line(line: str) -> str | None:
+    parts = line.split(maxsplit=1)
+    if not parts:
+        return None
+    command = parts[0].lower()
+    if command not in _SUPPORTED_CONTROL_BLOCK_COMMANDS:
+        return None
+    directive = command if command.startswith(".") else f".{command}"
+    if len(parts) == 1:
+        return directive
+    return f"{directive} {parts[1]}"

--- a/code/packages/python/spice-engine/tests/test_compatibility.py
+++ b/code/packages/python/spice-engine/tests/test_compatibility.py
@@ -111,6 +111,8 @@ def test_analyze_deck_controls_reports_unsupported_directives() -> None:
 .include models.inc
 .LIB vendor.lib TT
 .control
+op
+print op V(in)
 run
 .endc
 .end
@@ -121,12 +123,14 @@ run
     assert summary.active_lines == (
         ".include models.inc",
         ".LIB vendor.lib TT",
+        ".op",
+        ".print op V(in)",
     )
     assert [(diag.directive, diag.line_number, diag.severity) for diag in summary.diagnostics] == [
         (".include", 2, "error"),
         (".lib", 3, "error"),
         (".control", 4, "error"),
-        (".control", 5, "error"),
+        (".control", 7, "error"),
     ]
     assert [diag.code for diag in summary.diagnostics] == [
         "SPICE_DECK_UNSUPPORTED_DIRECTIVE",
@@ -186,6 +190,8 @@ def test_resolve_deck_sources_reports_missing_sources_and_cycles() -> None:
 .include a.inc
 .lib vendor.lib SS
 .control
+op
+print op V(a)
 run
 .endc
 .end
@@ -198,13 +204,17 @@ run
     )
 
     assert summary.terminated is True
-    assert summary.active_lines == ("R2 b 0 2", "R1 a b 1")
+    assert summary.active_lines == ("R2 b 0 2", "R1 a b 1", ".op", ".print op V(a)")
     assert [diag.code for diag in summary.diagnostics] == [
         "SPICE_DECK_INCLUDE_NOT_FOUND",
         "SPICE_DECK_INCLUDE_CYCLE",
         "SPICE_DECK_LIB_SECTION_NOT_FOUND",
         "SPICE_DECK_UNSUPPORTED_DIRECTIVE",
         "SPICE_DECK_CONTROL_COMMAND",
+    ]
+    assert [(diag.directive, diag.line_number) for diag in summary.diagnostics[3:]] == [
+        (".control", 5),
+        (".control", 8),
     ]
     assert [(diag.source, diag.line_number, diag.target) for diag in summary.diagnostics[:3]] == [
         ("<deck>", 2, "missing.inc"),

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -2,10 +2,14 @@
 
 ## Unreleased
 
+- Add selected `.control` block command routing to `analyze_deck_controls` and
+  `resolve_deck_sources`; analysis/output commands (`op`, `dc`, `ac`, `tran`,
+  `print`, and `plot`) are normalized into dotted deck cards, matching Python
+  and TypeScript.
 - Add control-block exclusion diagnostics to `analyze_deck_controls` and
-  `resolve_deck_sources`; unsupported `.control` / `.endc` blocks are no
-  longer forwarded as active deck lines, and non-comment commands inside the
-  block emit stable diagnostics, matching Python and TypeScript.
+  `resolve_deck_sources`; unsupported `.control` / `.endc` block markers and
+  unrecognized body commands are no longer forwarded as active deck lines and
+  emit stable diagnostics, matching Python and TypeScript.
 - Add parsed `.plot <analysis> ...` output routing to `resolve_deck_outputs`,
   `select_deck_output_probes`, and deck table formatters, matching Python and
   TypeScript.

--- a/code/packages/rust/spice-engine/README.md
+++ b/code/packages/rust/spice-engine/README.md
@@ -125,16 +125,16 @@ notes. `release_readiness_gates` validates the corpus metadata, while
 provide stable tab-separated summaries for package checks.
 `analyze_deck_controls` provides the shared deck-control boundary foothold: it
 returns active lines before `.end` and stable diagnostics for unsupported
-`.include`, `.lib`, and `.control` directives. Unsupported `.control` blocks
-are excluded from active deck lines, and non-comment commands inside the block
-emit command diagnostics until a deliberate executed control subset is in
-scope.
+`.include`, `.lib`, and `.control` directives. Inside `.control` blocks,
+selected analysis/output commands (`op`, `dc`, `ac`, `tran`, `print`, and
+`plot`) are normalized into dotted deck cards, while unrecognized non-comment
+commands emit diagnostics until a broader executed control subset is in scope.
 `resolve_deck_sources` is the first include/library resolution layer: callers
 provide a source-content map, `.include` directives are expanded in place, and
 `.lib path section` selects a named `.lib` / `.endl` section with stable
 diagnostics for missing files, missing sections, unterminated sections, cycles,
-and still-unsupported `.control` blocks whose body commands are not forwarded
-as active solver input.
+and still-unsupported `.control` block commands that are not part of the
+selected analysis/output subset.
 `measure_transient_probe`, `measure_transient_deck`,
 `measure_dc_sweep_probe`, `measure_dc_sweep_deck`,
 `measure_ac_sweep_probe`, `measure_ac_sweep_deck`, and

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -3564,6 +3564,10 @@ pub fn analyze_deck_controls(netlist: &str) -> DeckControlSummary {
                 in_control_block = false;
                 continue;
             }
+            if let Some(control_line) = control_block_command_as_deck_line(stripped) {
+                active_lines.push(control_line);
+                continue;
+            }
             diagnostics.push(DeckControlDiagnostic {
                 code: "SPICE_DECK_CONTROL_COMMAND".to_string(),
                 directive: ".control".to_string(),
@@ -4356,6 +4360,10 @@ fn resolve_deck_lines(
         if in_control_block {
             if directive.as_deref() == Some(".endc") {
                 in_control_block = false;
+                continue;
+            }
+            if let Some(control_line) = control_block_command_as_deck_line(stripped) {
+                active_lines.push(control_line);
                 continue;
             }
             state.diagnostics.push(DeckResolutionDiagnostic {
@@ -6861,6 +6869,26 @@ fn deck_directive(line: &str) -> Option<String> {
             .unwrap_or(line)
             .to_ascii_lowercase(),
     )
+}
+
+fn control_block_command_as_deck_line(line: &str) -> Option<String> {
+    let command_token = line.split_whitespace().next()?;
+    let command = command_token.to_ascii_lowercase();
+    let directive = match command.as_str() {
+        "op" | ".op" => ".op",
+        "dc" | ".dc" => ".dc",
+        "ac" | ".ac" => ".ac",
+        "tran" | ".tran" => ".tran",
+        "print" | ".print" => ".print",
+        "plot" | ".plot" => ".plot",
+        _ => return None,
+    };
+    let rest = line[command_token.len()..].trim_start();
+    if rest.is_empty() {
+        Some(directive.to_string())
+    } else {
+        Some(format!("{directive} {rest}"))
+    }
 }
 
 fn is_unsupported_deck_control_directive(directive: &str) -> bool {

--- a/code/packages/rust/spice-engine/tests/compatibility_tests.rs
+++ b/code/packages/rust/spice-engine/tests/compatibility_tests.rs
@@ -128,6 +128,8 @@ fn analyze_deck_controls_reports_unsupported_directives() {
 .include models.inc
 .LIB vendor.lib TT
 .control
+op
+print op V(in)
 run
 .endc
 .end
@@ -140,6 +142,8 @@ run
         &[
             ".include models.inc".to_string(),
             ".LIB vendor.lib TT".to_string(),
+            ".op".to_string(),
+            ".print op V(in)".to_string(),
         ]
     );
     let diagnostics = summary
@@ -159,7 +163,7 @@ run
             (".include", 2, "error"),
             (".lib", 3, "error"),
             (".control", 4, "error"),
-            (".control", 5, "error")
+            (".control", 7, "error")
         ]
     );
     assert_eq!(
@@ -255,6 +259,8 @@ fn resolve_deck_sources_reports_missing_sources_and_cycles() {
 .include a.inc
 .lib vendor.lib SS
 .control
+op
+print op V(a)
 run
 .endc
 .end
@@ -263,7 +269,10 @@ run
     );
 
     assert!(summary.terminated);
-    assert_eq!(summary.active_lines, vec!["R2 b 0 2", "R1 a b 1"]);
+    assert_eq!(
+        summary.active_lines,
+        vec!["R2 b 0 2", "R1 a b 1", ".op", ".print op V(a)"]
+    );
     assert_eq!(
         summary
             .diagnostics
@@ -277,6 +286,15 @@ run
             "SPICE_DECK_UNSUPPORTED_DIRECTIVE",
             "SPICE_DECK_CONTROL_COMMAND"
         ]
+    );
+    assert_eq!(
+        summary
+            .diagnostics
+            .iter()
+            .skip(3)
+            .map(|diagnostic| (diagnostic.directive.as_str(), diagnostic.line_number))
+            .collect::<Vec<_>>(),
+        vec![(".control", 5), (".control", 8)]
     );
     assert_eq!(
         summary

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -2,9 +2,13 @@
 
 ## Unreleased
 
+- Add selected `.control` block command routing to `analyzeDeckControls` and
+  `resolveDeckSources`; analysis/output commands (`op`, `dc`, `ac`, `tran`,
+  `print`, and `plot`) are normalized into dotted deck cards, matching Python
+  and Rust.
 - Add control-block exclusion diagnostics to `analyzeDeckControls` and
-  `resolveDeckSources`; unsupported `.control` / `.endc` blocks are no longer
-  forwarded as active deck lines, and non-comment commands inside the block
+  `resolveDeckSources`; unsupported `.control` / `.endc` block markers and
+  unrecognized body commands are no longer forwarded as active deck lines and
   emit stable diagnostics, matching Python and Rust.
 - Add parsed `.plot <analysis> ...` output routing to `resolveDeckOutputs`,
   `selectDeckOutputProbes`, and deck table formatters, matching Python and

--- a/code/packages/typescript/spice-engine/README.md
+++ b/code/packages/typescript/spice-engine/README.md
@@ -132,16 +132,16 @@ notes. `releaseReadinessGates` validates the corpus metadata, while
 stable tab-separated summaries for package checks.
 `analyzeDeckControls` provides the shared deck-control boundary foothold: it
 returns active lines before `.end` and stable diagnostics for unsupported
-`.include`, `.lib`, and `.control` directives. Unsupported `.control` blocks
-are excluded from active deck lines, and non-comment commands inside the block
-emit command diagnostics until a deliberate executed control subset is in
-scope.
+`.include`, `.lib`, and `.control` directives. Inside `.control` blocks,
+selected analysis/output commands (`op`, `dc`, `ac`, `tran`, `print`, and
+`plot`) are normalized into dotted deck cards, while unrecognized non-comment
+commands emit diagnostics until a broader executed control subset is in scope.
 `resolveDeckSources` is the first include/library resolution layer: callers
 provide a source-content map, `.include` directives are expanded in place, and
 `.lib path section` selects a named `.lib` / `.endl` section with stable
 diagnostics for missing files, missing sections, unterminated sections, cycles,
-and still-unsupported `.control` blocks whose body commands are not forwarded
-as active solver input.
+and still-unsupported `.control` block commands that are not part of the
+selected analysis/output subset.
 `resolveDeckParameters` evaluates scalar whitespace-tokenized `.param`
 assignments, collects scalar `.func` definitions before `.end`, preserves
 parameter order, rewrites braced and quoted active-line expressions, and emits

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -2828,6 +2828,20 @@ const REQUIRED_COMPATIBILITY_ANALYSES = ["op", "dc", "ac", "tran"];
 const UNSUPPORTED_DECK_CONTROL_DIRECTIVES = new Set([".include", ".lib", ".control"]);
 const UNSUPPORTED_RESOLVED_DIRECTIVES = new Set([".control"]);
 const UNSUPPORTED_PARAMETER_DIRECTIVES = new Set<string>();
+const SUPPORTED_CONTROL_BLOCK_COMMANDS = new Set([
+  "op",
+  ".op",
+  "dc",
+  ".dc",
+  "ac",
+  ".ac",
+  "tran",
+  ".tran",
+  "print",
+  ".print",
+  "plot",
+  ".plot",
+]);
 
 export function compatibilityCorpus(): readonly CompatibilityDeck[] {
   return COMPATIBILITY_CORPUS;
@@ -2850,6 +2864,11 @@ export function analyzeDeckControls(netlist: string): DeckControlSummary {
     if (inControlBlock) {
       if (directive === ".endc") {
         inControlBlock = false;
+        continue;
+      }
+      const controlLine = controlBlockCommandAsDeckLine(stripped);
+      if (controlLine !== undefined) {
+        activeLines.push(controlLine);
         continue;
       }
       diagnostics.push({
@@ -3405,6 +3424,11 @@ function resolveDeckLines(
     if (inControlBlock) {
       if (directive === ".endc") {
         inControlBlock = false;
+        continue;
+      }
+      const controlLine = controlBlockCommandAsDeckLine(stripped);
+      if (controlLine !== undefined) {
+        activeLines.push(controlLine);
         continue;
       }
       state.diagnostics.push({
@@ -5650,6 +5674,17 @@ function deckDirective(line: string): string | undefined {
     return undefined;
   }
   return line.split(/\s+/, 1)[0].toLowerCase();
+}
+
+function controlBlockCommandAsDeckLine(line: string): string | undefined {
+  const parts = line.split(/\s+/, 1);
+  const command = parts[0]?.toLowerCase();
+  if (command === undefined || !SUPPORTED_CONTROL_BLOCK_COMMANDS.has(command)) {
+    return undefined;
+  }
+  const directive = command.startsWith(".") ? command : `.${command}`;
+  const rest = line.slice(parts[0].length).trimStart();
+  return rest.length === 0 ? directive : `${directive} ${rest}`;
 }
 
 export function subcircuitDefinition(

--- a/code/packages/typescript/spice-engine/tests/compatibility.test.ts
+++ b/code/packages/typescript/spice-engine/tests/compatibility.test.ts
@@ -115,6 +115,8 @@ V1 in 0 DC 1
 .include models.inc
 .LIB vendor.lib TT
 .control
+op
+print op V(in)
 run
 .endc
 .end
@@ -124,6 +126,8 @@ run
     expect(summary.activeLines).toStrictEqual([
       ".include models.inc",
       ".LIB vendor.lib TT",
+      ".op",
+      ".print op V(in)",
     ]);
     expect(summary.diagnostics.map(({ directive, lineNumber, severity }) => [
       directive,
@@ -133,7 +137,7 @@ run
       [".include", 2, "error"],
       [".lib", 3, "error"],
       [".control", 4, "error"],
-      [".control", 5, "error"],
+      [".control", 7, "error"],
     ]);
     expect(summary.diagnostics.map((diagnostic) => diagnostic.code)).toStrictEqual([
       "SPICE_DECK_UNSUPPORTED_DIRECTIVE",
@@ -189,6 +193,8 @@ Ctyp out 0 1u
 .include a.inc
 .lib vendor.lib SS
 .control
+op
+print op V(a)
 run
 .endc
 .end
@@ -199,13 +205,20 @@ run
     });
 
     expect(summary.terminated).toBe(true);
-    expect(summary.activeLines).toStrictEqual(["R2 b 0 2", "R1 a b 1"]);
+    expect(summary.activeLines).toStrictEqual(["R2 b 0 2", "R1 a b 1", ".op", ".print op V(a)"]);
     expect(summary.diagnostics.map((diagnostic) => diagnostic.code)).toStrictEqual([
       "SPICE_DECK_INCLUDE_NOT_FOUND",
       "SPICE_DECK_INCLUDE_CYCLE",
       "SPICE_DECK_LIB_SECTION_NOT_FOUND",
       "SPICE_DECK_UNSUPPORTED_DIRECTIVE",
       "SPICE_DECK_CONTROL_COMMAND",
+    ]);
+    expect(summary.diagnostics.slice(3).map(({ directive, lineNumber }) => [
+      directive,
+      lineNumber,
+    ])).toStrictEqual([
+      [".control", 5],
+      [".control", 8],
     ]);
     expect(summary.diagnostics.slice(0, 3).map(({ source, lineNumber, target }) => [
       source,

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -33,7 +33,9 @@ downstream tools to compare.
      stable table output for operating-point, DC sweep, AC sweep, and transient
      results; unsupported `.control` / `.endc` blocks are now excluded from
      active deck and source-resolved solver input while body commands emit
-     stable non-executed diagnostics; parsed
+     stable non-executed diagnostics, and selected `.control` block
+     analysis/output commands (`op`, `dc`, `ac`, `tran`, `print`, and `plot`)
+     now normalize into dotted deck cards; parsed
      `.measure dc` / `.meas dc` cards now route DC
      sweep probe samples into the shared scalar measurement table surface;
      parsed `.measure ac` / `.meas ac` cards now route AC probe magnitudes over
@@ -500,8 +502,17 @@ downstream tools to compare.
     - Python, Rust, and TypeScript now exclude unsupported `.control` / `.endc`
       blocks from active deck-control lines and source-resolved solver input.
     - The existing unsupported `.control` directive diagnostic is preserved,
-      while non-comment commands inside the block emit stable
+      while unrecognized non-comment commands inside the block emit stable
       `SPICE_DECK_CONTROL_COMMAND` diagnostics.
+
+44. Selected `.control` command routing.
+    - Status: completed in this selected control-command routing slice.
+    - Python, Rust, and TypeScript now normalize selected `.control` block
+      analysis/output commands (`op`, `dc`, `ac`, `tran`, `print`, and `plot`)
+      into the same dotted deck cards consumed by the existing analysis and
+      output resolvers.
+    - Unrecognized non-comment commands inside `.control` blocks remain
+      diagnostic-only so unsupported control flow is still explicit.
 
 ## Backlog
 
@@ -513,8 +524,9 @@ downstream tools to compare.
    - Expand deck-controlled output-plan integration beyond stable table
      routing and scoped `.print` / `.plot` selection toward full SPICE
      compatibility.
-   - Expand a deliberate `.control` subset beyond the current excluded,
-     non-executed block diagnostics.
+   - Expand the deliberate `.control` subset beyond simple analysis/output
+     command routing, including control flow, variables, and script execution
+     policy.
 
 2. Production solver core.
    - Finish sparse real and complex matrix paths.


### PR DESCRIPTION
## Summary
- Normalize selected .control block analysis/output commands (op, dc, ac, tran, print, plot) into dotted deck cards across Python, Rust, and TypeScript.
- Keep unrecognized .control body commands diagnostic-only with the existing SPICE_DECK_CONTROL_COMMAND behavior.
- Update compatibility tests, README/changelog docs, and the SPICE implementation plan with completed slice 44.

## Verification
- PYTHONPATH="code/packages/python/spice-engine/src:code/packages/python/device-physics/src:code/packages/python/mosfet-models/src" /Users/adhithya/.local/share/mise/installs/python/3.12.13/bin/python3 -m ruff check code/packages/python/spice-engine/src/spice_engine/compatibility.py code/packages/python/spice-engine/tests/test_compatibility.py
- PYTHONPATH="code/packages/python/spice-engine/src:code/packages/python/device-physics/src:code/packages/python/mosfet-models/src" /Users/adhithya/.local/share/mise/installs/python/3.12.13/bin/python3 -m pytest code/packages/python/spice-engine/tests -q
- npm --prefix code/packages/typescript/spice-engine run build
- npm --prefix code/packages/typescript/spice-engine test
- cargo fmt --manifest-path code/packages/rust/spice-engine/Cargo.toml -- --check
- cargo test --manifest-path code/packages/rust/spice-engine/Cargo.toml
- git diff --check