### PR TITLE
feat(r-lang): regex built-ins (R-7) — grepl/grep/gsub/sub

### DIFF
--- a/code/packages/rust/r-runtime/src/lib.rs
+++ b/code/packages/rust/r-runtime/src/lib.rs
@@ -225,6 +225,16 @@ mod tests {
     }
 
     #[test]
+    fn regex_builtins_through_r_syntax() {
+        assert_eq!(
+            show("grepl(\"^a\", c(\"apple\", \"banana\"))\n"),
+            "[1]  TRUE FALSE"
+        );
+        assert_eq!(show("gsub(\"a\", \"X\", \"banana\")\n"), "[1] \"bXnXnX\"");
+        assert_eq!(show("sub(\"a\", \"X\", \"banana\")\n"), "[1] \"bXnana\"");
+    }
+
+    #[test]
     fn complex_literal_is_reported_unsupported() {
         // `1i` lexes and parses, but complex is not in this subset — the runtime
         // says so clearly rather than producing a wrong value.

--- a/code/packages/rust/s-runtime/Cargo.toml
+++ b/code/packages/rust/s-runtime/Cargo.toml
@@ -11,3 +11,4 @@ lexer = { path = "../lexer" }
 r-vector = { path = "../r-vector" }
 numeric-tower = { path = "../numeric-tower" }
 statistics-core = { path = "../statistics-core" }
+regex = "1"

--- a/code/packages/rust/s-runtime/src/builtins.rs
+++ b/code/packages/rust/s-runtime/src/builtins.rs
@@ -89,6 +89,12 @@ pub fn install(env: &Env) {
     define(env, "lapply", builtin("lapply", b_lapply));
     define(env, "strsplit", builtin("strsplit", b_strsplit));
 
+    // Regular expressions (R-7).
+    define(env, "grepl", builtin("grepl", b_grepl));
+    define(env, "grep", builtin("grep", b_grep));
+    define(env, "gsub", builtin("gsub", b_gsub));
+    define(env, "sub", builtin("sub", b_sub));
+
     // String manipulation (vectorized over a character vector).
     define(env, "nchar", builtin("nchar", b_nchar));
     define(env, "toupper", builtin("toupper", b_toupper));
@@ -636,6 +642,139 @@ fn paste_impl(args: &[Arg], default_sep: &str) -> SResult<SValue> {
         })
         .collect();
     Ok(SValue::Character(out))
+}
+
+// ===========================================================================
+// Regular expressions
+// ===========================================================================
+
+/// Read a boolean named argument (e.g. `fixed = TRUE`), defaulting to `false`.
+fn flag(args: &[Arg], name: &str) -> bool {
+    args.iter()
+        .find(|a| a.name.as_deref() == Some(name))
+        .and_then(|a| a.value.truthy().ok())
+        .unwrap_or(false)
+}
+
+/// Compile a pattern into a `regex::Regex`. With `fixed`, the pattern is matched
+/// literally (escaped). An invalid pattern returns a clean error, never a panic.
+fn compile(pattern: &str, fixed: bool) -> SResult<regex::Regex> {
+    let source = if fixed {
+        regex::escape(pattern)
+    } else {
+        pattern.to_string()
+    };
+    regex::Regex::new(&source)
+        .map_err(|e| SError::BadArgs(format!("invalid regular expression '{pattern}': {e}")))
+}
+
+/// Translate an R replacement string to the `regex` crate's syntax: R back-
+/// references `\1` become `${1}`, `\\` becomes a literal backslash, and a literal
+/// `$` is escaped to `$$` (the regex crate's literal-dollar). With `fixed`, the
+/// replacement is taken literally (only `$` needs escaping).
+fn translate_replacement(repl: &str, fixed: bool) -> String {
+    let mut out = String::with_capacity(repl.len());
+    let mut chars = repl.chars().peekable();
+    while let Some(c) = chars.next() {
+        match c {
+            '$' => out.push_str("$$"),
+            '\\' if !fixed => match chars.next() {
+                Some(d) if d.is_ascii_digit() => {
+                    out.push_str("${");
+                    out.push(d);
+                    out.push('}');
+                }
+                Some(other) => out.push(other), // `\\` -> `\`, `\x` -> `x`
+                None => {}
+            },
+            other => out.push(other),
+        }
+    }
+    out
+}
+
+/// The `(pattern, x, fixed)` of a `grepl`/`grep` call (pattern + first vector).
+fn regex_unary(args: &[Arg]) -> SResult<(regex::Regex, Vec<Option<String>>)> {
+    let pattern = nth_positional(args, 0)
+        .map(|v| v.as_character())
+        .and_then(|c| c.into_iter().next().flatten())
+        .ok_or_else(|| SError::BadArgs("missing 'pattern'".into()))?;
+    let x = nth_positional(args, 1)
+        .ok_or_else(|| SError::BadArgs("missing 'x'".into()))?
+        .as_character();
+    Ok((compile(&pattern, flag(args, "fixed"))?, x))
+}
+
+/// `grepl(pattern, x)` — a logical vector: does each element match? `NA` → `NA`.
+fn b_grepl(_interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
+    let (re, x) = regex_unary(args)?;
+    Ok(SValue::Logical(
+        x.iter()
+            .map(|o| o.as_ref().map(|s| re.is_match(s)))
+            .collect(),
+    ))
+}
+
+/// `grep(pattern, x, value = FALSE)` — the indices (1-based) of matching
+/// elements, or the matching strings themselves when `value = TRUE`.
+fn b_grep(_interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
+    let (re, x) = regex_unary(args)?;
+    let hits: Vec<(usize, &Option<String>)> = x
+        .iter()
+        .enumerate()
+        .filter(|(_, o)| o.as_ref().is_some_and(|s| re.is_match(s)))
+        .collect();
+    if flag(args, "value") {
+        Ok(SValue::Character(
+            hits.iter().map(|(_, o)| (*o).clone()).collect(),
+        ))
+    } else {
+        Ok(SValue::doubles(
+            hits.iter().map(|(i, _)| (i + 1) as f64).collect(),
+        ))
+    }
+}
+
+/// Shared `gsub`/`sub` body. `all` replaces every match; otherwise the first.
+fn replace_impl(args: &[Arg], all: bool) -> SResult<SValue> {
+    let fixed = flag(args, "fixed");
+    let pattern = nth_positional(args, 0)
+        .map(|v| v.as_character())
+        .and_then(|c| c.into_iter().next().flatten())
+        .ok_or_else(|| SError::BadArgs("missing 'pattern'".into()))?;
+    let replacement = nth_positional(args, 1)
+        .map(|v| v.as_character())
+        .and_then(|c| c.into_iter().next().flatten())
+        .ok_or_else(|| SError::BadArgs("missing 'replacement'".into()))?;
+    let x = nth_positional(args, 2)
+        .ok_or_else(|| SError::BadArgs("missing 'x'".into()))?
+        .as_character();
+
+    let re = compile(&pattern, fixed)?;
+    let rep = translate_replacement(&replacement, fixed);
+    let out = x
+        .into_iter()
+        .map(|o| {
+            o.map(|s| {
+                if all {
+                    re.replace_all(&s, rep.as_str()).into_owned()
+                } else {
+                    re.replace(&s, rep.as_str()).into_owned()
+                }
+            })
+        })
+        .collect();
+    Ok(SValue::Character(out))
+}
+
+/// `gsub(pattern, replacement, x)` — replace every match in each element.
+fn b_gsub(_interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
+    replace_impl(args, true)
+}
+
+/// `sub(pattern, replacement, x)` — replace only the first match in each element.
+fn b_sub(_interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
+    replace_impl(args, false)
 }
 
 // ===========================================================================

--- a/code/packages/rust/s-runtime/src/lib.rs
+++ b/code/packages/rust/s-runtime/src/lib.rs
@@ -660,6 +660,48 @@ mod tests {
         assert!(outcome.printed.contains("[[2]]"), "{:?}", outcome.printed);
     }
 
+    // --- Regular expressions (R-7) --------------------------------------
+
+    #[test]
+    fn grepl_and_grep() {
+        assert_eq!(
+            show("grepl(\"^a\", c(\"apple\", \"banana\", \"avocado\"))\n"),
+            "[1]  TRUE FALSE  TRUE"
+        );
+        assert_eq!(nums("grep(\"an\", c(\"apple\", \"banana\"))\n"), vec![2.0]);
+        assert_eq!(
+            show("grep(\"an\", c(\"apple\", \"banana\"), value = TRUE)\n"),
+            "[1] \"banana\""
+        );
+        // A regex metacharacter is honored by default but literal with fixed=TRUE.
+        assert_eq!(show("grepl(\".\", \"abc\")\n"), "[1] TRUE");
+        assert_eq!(show("grepl(\".\", \"abc\", fixed = TRUE)\n"), "[1] FALSE");
+    }
+
+    #[test]
+    fn gsub_and_sub() {
+        assert_eq!(show("gsub(\"a\", \"X\", \"banana\")\n"), "[1] \"bXnXnX\"");
+        assert_eq!(show("sub(\"a\", \"X\", \"banana\")\n"), "[1] \"bXnana\"");
+        // Back-reference: R's \\1 -> the regex crate's ${1}.
+        assert_eq!(
+            show("gsub(\"(a)(b)\", \"\\\\2\\\\1\", \"ababab\")\n"),
+            "[1] \"bababa\""
+        );
+        // fixed = TRUE makes the pattern literal.
+        assert_eq!(
+            show("gsub(\".\", \"_\", \"a.b\", fixed = TRUE)\n"),
+            "[1] \"a_b\""
+        );
+    }
+
+    #[test]
+    fn invalid_regex_is_a_clean_error() {
+        assert!(matches!(
+            eval_s("grepl(\"(\", \"x\")\n"),
+            Err(SError::BadArgs(_))
+        ));
+    }
+
     #[test]
     fn print_returns_its_argument_invisibly() {
         let outcome = Interpreter::new().eval_str("print(42)\n").unwrap();

--- a/code/specs/R00-r-language.md
+++ b/code/specs/R00-r-language.md
@@ -73,9 +73,15 @@ unchanged.
   and R-style `$name`/`[[i]]` block printing. Built-ins `list(...)`,
   `lapply(x, f)` (returns a list), and `strsplit(x, split)` (fixed-string split
   → a list of character vectors). `nth_element` now iterates list elements, so
-  `sapply`/`lapply` work over lists. *Deferred:* `table`, regex (`gsub`/`grepl`).
-- **R-7+** — regex helpers, then the `d/p/q/r` distribution family wired to
-  `statistics-core`.
+  `sapply`/`lapply` work over lists.
+- **R-7 — regular expressions** *(this PR)*. `grepl(pattern, x)` → logical,
+  `grep(pattern, x, value=)` → indices or matches, `gsub`/`sub(pattern, repl, x)`
+  → replace all / first. Built on the `regex` crate (linear-time, no
+  catastrophic backtracking), with a `fixed = TRUE` literal-match option and R
+  back-reference translation (`\\1` → the crate's `${1}`). Invalid patterns
+  return a clean error. *Deferred:* `regmatches`/`gregexpr`, `table`.
+- **R-8+** — the `d/p/q/r` distribution family (`rnorm`/`dnorm`/`pnorm`/`qnorm`,
+  `runif`, …) wired to `statistics-core`.
 
 ## §4 Reuse strategy
 


### PR DESCRIPTION
## What

Item **R-7**: regular-expression string helpers in the shared `s-runtime`, built on the **`regex` crate**. Continues R-1…R-6.

| Function | Behavior |
|---|---|
| `grepl(pattern, x)` | logical vector — does each element match? (NA → NA) |
| `grep(pattern, x, value=)` | 1-based indices of matches, or the matching strings with `value = TRUE` |
| `gsub(pattern, repl, x)` | replace **all** matches in each element |
| `sub(pattern, repl, x)` | replace the **first** match |

- **`fixed = TRUE`** matches the pattern literally (via `regex::escape`).
- **Back-references**: R's `\\1` is translated to the `regex` crate's `${1}` (and a literal `$` is escaped to `$$`).
- **Invalid patterns** return a clean `SError::BadArgs` — never a panic.

```r
> grepl("^a", c("apple", "banana", "avocado"))   # TRUE FALSE TRUE
> gsub("a", "X", "banana")                        # "bXnXnX"
> gsub("(a)(b)", "\\2\\1", "ababab")              # "bababa"
```

## Why `regex` is safe here

The crate uses finite-automaton matching — **linear-time, no catastrophic backtracking** — so a malicious pattern from untrusted source can't cause ReDoS the way PCRE can. Oversized patterns hit the crate's compile-size limit and return a handled error.

## Verification

- s-runtime now 105 tests, r-runtime 17 (grepl/grep/gsub/sub, `fixed=`, back-references, invalid-pattern error). All green; clippy clean; fmt applied. Inert for S's grammar.
- `/security-review` → PASSED: no ReDoS (finite automata), compile errors handled (no panic), no unwrap/index panic paths, replacement `$`-escaping degrades to wrong-output-at-worst not a crash. Local-REPL allocation posture consistent with existing caps.

## Next in the loop

R-8: the **`d/p/q/r` distribution family** (`rnorm`/`dnorm`/`pnorm`/`qnorm`, `runif`, …) wired to `statistics-core` — where R really starts to feel like R.

🤖 Generated with [Claude Code](https://claude.com/claude-code)