### PR TITLE
feat(spreadsheet facades): expose cell display formats

### DIFF
--- a/code/packages/rust/spreadsheet-capi/CHANGELOG.md
+++ b/code/packages/rust/spreadsheet-capi/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.4.0
+
+**Cell display formats over the C ABI.** New `sc_set_format(s, a1, code)` (void),
+`sc_get_format(s, a1)` (→ code | `""`), and `sc_get_display(s, a1)` (→ the value
+rendered through its format), declared in `include/spreadsheet.h`. Delegate to
+`SpreadsheetSession`'s format API; null-session safe.
+
 ## 0.3.0
 
 **Insert/delete rows & columns over the C ABI.** New `void`-returning exports

--- a/code/packages/rust/spreadsheet-capi/Cargo.toml
+++ b/code/packages/rust/spreadsheet-capi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spreadsheet-capi"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 description = "Stable C ABI over the spreadsheet engine, for the native VisiCalc demos (Swift/Kotlin-JNI/Dart-FFI/.NET/C++)"
 license = "MIT"

--- a/code/packages/rust/spreadsheet-capi/include/spreadsheet.h
+++ b/code/packages/rust/spreadsheet-capi/include/spreadsheet.h
@@ -40,6 +40,13 @@ char *sc_get_value(ScSession *s, const char *a1);                 /* -> value JS
 char *sc_get_raw(ScSession *s, const char *a1);                   /* -> typed source */
 char *sc_get_values(ScSession *s);                                /* -> {a1: value} */
 
+/* Cell display formats — an Excel-style code per cell (e.g. "#,##0.00",
+   "yyyy-mm-dd") decides how its value reads. set with an empty code to clear.
+   char* results must be freed with sc_string_free(). */
+void  sc_set_format(ScSession *s, const char *a1, const char *code);
+char *sc_get_format(ScSession *s, const char *a1);                /* -> code | ""   */
+char *sc_get_display(ScSession *s, const char *a1);               /* -> display str */
+
 /* Structural edits — insert/delete rows & columns. 1-based `at`, `count` lines.
    The engine relocates cells and rewrites formula references (a reference to a
    deleted line becomes #REF!); the formula echo stays in step. No return — the

--- a/code/packages/rust/spreadsheet-capi/src/lib.rs
+++ b/code/packages/rust/spreadsheet-capi/src/lib.rs
@@ -157,6 +157,50 @@ pub unsafe extern "C" fn sc_get_values(s: *mut ScSession) -> *mut c_char {
     into_cstr((*s).inner.get_values())
 }
 
+// ── Cell display formats ─────────────────────────────────────────────
+// An Excel-style format code per cell decides how its value reads.
+
+/// `set_format(a1, code)` — set a cell's display format (empty `code` clears it).
+/// See [`SpreadsheetSession::set_format`].
+///
+/// # Safety
+/// `s` must be a valid session; `a1`/`code` must be null or valid C strings.
+#[no_mangle]
+pub unsafe extern "C" fn sc_set_format(s: *mut ScSession, a1: *const c_char, code: *const c_char) {
+    if s.is_null() {
+        return;
+    }
+    let a1 = read_cstr(a1);
+    let code = read_cstr(code);
+    (*s).inner.set_format(&a1, &code);
+}
+
+/// `get_format(a1)` → the cell's format code, or `""`. See
+/// [`SpreadsheetSession::get_format`].
+///
+/// # Safety
+/// `s` must be a valid session; `a1` must be null or a valid C string.
+#[no_mangle]
+pub unsafe extern "C" fn sc_get_format(s: *mut ScSession, a1: *const c_char) -> *mut c_char {
+    if s.is_null() {
+        return ptr::null_mut();
+    }
+    into_cstr((*s).inner.get_format(&read_cstr(a1)))
+}
+
+/// `get_display(a1)` → the cell's value rendered through its format (the display
+/// string). See [`SpreadsheetSession::get_display`].
+///
+/// # Safety
+/// `s` must be a valid session; `a1` must be null or a valid C string.
+#[no_mangle]
+pub unsafe extern "C" fn sc_get_display(s: *mut ScSession, a1: *const c_char) -> *mut c_char {
+    if s.is_null() {
+        return ptr::null_mut();
+    }
+    into_cstr((*s).inner.get_display(&read_cstr(a1)))
+}
+
 // ── Structural edits: insert / delete rows & columns ─────────────────
 // 1-based `at`, `count` lines. The engine relocates cells and rewrites every
 // formula's references; the facade keeps its raw echo map in step. No return —

--- a/code/packages/rust/spreadsheet-core-wasm/CHANGELOG.md
+++ b/code/packages/rust/spreadsheet-core-wasm/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.4.0
+
+**Cell display formats.** `set_format(a1, code)` / `get_format(a1)` /
+`get_display(a1)` expose the engine's cell-format API: set an Excel-style code
+(empty clears it), read it back, and get the value rendered through it (e.g.
+`1234.5` with `"#,##0.00"` → `"1,234.50"`). `get_display` is the display string a
+cell paints — distinct from `get_value` (typed JSON) and `get_raw` (source). 1
+new test.
+
 ## 0.3.0
 
 **Insert/delete rows & columns.** `insert_rows` / `delete_rows` / `insert_cols`

--- a/code/packages/rust/spreadsheet-core-wasm/Cargo.toml
+++ b/code/packages/rust/spreadsheet-core-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spreadsheet-core-wasm"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 description = "Browser/WASM-facing string-in / JSON-out facade over spreadsheet-core"
 license = "MIT"

--- a/code/packages/rust/spreadsheet-core-wasm/src/lib.rs
+++ b/code/packages/rust/spreadsheet-core-wasm/src/lib.rs
@@ -221,6 +221,41 @@ impl SpreadsheetSession {
             .unwrap_or_default()
     }
 
+    // ── Cell display formats ────────────────────────────────────────
+    //
+    // A format is an Excel-style code (`"#,##0.00"`, `"0%"`, `"yyyy-mm-dd"`) that
+    // decides how a cell's computed value reads. The engine stores the code and
+    // applies it (via number-format-core); these thin wrappers expose that to a
+    // JS / native host.
+
+    /// Set a cell's display format code. An empty code clears it (the cell falls
+    /// back to `General`). A malformed address is a no-op.
+    pub fn set_format(&mut self, a1: &str, code: &str) {
+        if let Ok(addr) = CellAddress::parse(a1) {
+            self.wb.set_format(self.sheet, addr, code);
+        }
+    }
+
+    /// A cell's display format code, or `""` if it uses the default (`General`).
+    pub fn get_format(&self, a1: &str) -> String {
+        CellAddress::parse(a1)
+            .ok()
+            .and_then(|addr| self.wb.get_format(self.sheet, addr))
+            .map(str::to_string)
+            .unwrap_or_default()
+    }
+
+    /// A cell's computed value rendered through its format — the **display
+    /// string** to show (e.g. `1234.5` with `"#,##0.00"` → `"1,234.50"`). What a
+    /// cell paints, as opposed to [`get_value`](Self::get_value) (typed JSON) or
+    /// [`get_raw`](Self::get_raw) (the source). Empty string for a bad address.
+    pub fn get_display(&self, a1: &str) -> String {
+        match CellAddress::parse(a1) {
+            Ok(addr) => self.wb.get_display(self.sheet, addr),
+            Err(_) => String::new(),
+        }
+    }
+
     /// Get every set cell's computed value as a JSON object keyed by A1
     /// address, e.g. `{"B1":{"kind":"number","value":15.0},...}`. Only cells
     /// that were explicitly set appear; everything else is implicitly empty.
@@ -462,6 +497,25 @@ mod tests {
         assert_eq!(s.get_value("A1"), r#"{"kind":"number","value":20.0}"#); // was A2
         assert_eq!(s.get_value("A2"), r#"{"kind":"number","value":40.0}"#); // =A1*2
         assert_eq!(s.get_raw("A2"), "=(A1*2)");
+    }
+
+    #[test]
+    fn set_get_and_apply_display_format() {
+        let mut s = SpreadsheetSession::new();
+        s.set_cell("A1", "1234.5");
+        // No format → General display.
+        assert_eq!(s.get_display("A1"), "1234.5");
+        assert_eq!(s.get_format("A1"), "");
+        // Set a format → get_display applies it; get_format echoes the code.
+        s.set_format("A1", "#,##0.00");
+        assert_eq!(s.get_format("A1"), "#,##0.00");
+        assert_eq!(s.get_display("A1"), "1,234.50");
+        // get_value (typed) is unaffected by the format.
+        assert_eq!(s.get_value("A1"), r#"{"kind":"number","value":1234.5}"#);
+        // Clearing the format reverts to General.
+        s.set_format("A1", "");
+        assert_eq!(s.get_format("A1"), "");
+        assert_eq!(s.get_display("A1"), "1234.5");
     }
 
     #[test]

--- a/code/packages/rust/spreadsheet-wasm/CHANGELOG.md
+++ b/code/packages/rust/spreadsheet-wasm/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.4.0
+
+**Cell display formats over the WASM ABI.** New `set_format(a1, code)` (void),
+`get_format(a1)`, and `get_display(a1)` exports (pointer/length string
+marshalling via `read_input`/`pack`), delegating to the thread-local
+`SpreadsheetSession`. `get_display` returns the value rendered through its format
+code. 1 new ABI round-trip test.
+
 ## 0.3.0
 
 **Insert/delete rows & columns over the WASM ABI.** New `void`-returning exports

--- a/code/packages/rust/spreadsheet-wasm/Cargo.toml
+++ b/code/packages/rust/spreadsheet-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spreadsheet-wasm"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 description = "extern \"C\" + linear-memory WASM ABI over the spreadsheet-core-wasm JSON facade"
 license = "MIT"

--- a/code/packages/rust/spreadsheet-wasm/src/lib.rs
+++ b/code/packages/rust/spreadsheet-wasm/src/lib.rs
@@ -195,6 +195,48 @@ pub extern "C" fn get_values() -> *mut u8 {
     pack(SESSION.with(|s| s.borrow().get_values()))
 }
 
+// ── Cell display formats ─────────────────────────────────────────────
+// An Excel-style format code per cell decides how its value reads.
+
+/// `set_format(a1, code)` — set a cell's display format (empty `code` clears).
+/// See [`SpreadsheetSession::set_format`].
+///
+/// # Safety
+/// The `(ptr, len)` pairs must describe readable byte ranges (see [`read_input`]).
+#[no_mangle]
+pub unsafe extern "C" fn set_format(
+    a1_ptr: *const u8,
+    a1_len: usize,
+    code_ptr: *const u8,
+    code_len: usize,
+) {
+    let a1 = read_input(a1_ptr, a1_len);
+    let code = read_input(code_ptr, code_len);
+    SESSION.with(|s| s.borrow_mut().set_format(&a1, &code));
+}
+
+/// `get_format(a1)` → the cell's format code, or `""`. See
+/// [`SpreadsheetSession::get_format`].
+///
+/// # Safety
+/// `(ptr, len)` must describe a readable byte range.
+#[no_mangle]
+pub unsafe extern "C" fn get_format(a1_ptr: *const u8, a1_len: usize) -> *mut u8 {
+    let a1 = read_input(a1_ptr, a1_len);
+    pack(SESSION.with(|s| s.borrow().get_format(&a1)))
+}
+
+/// `get_display(a1)` → the cell's value rendered through its format (the display
+/// string). See [`SpreadsheetSession::get_display`].
+///
+/// # Safety
+/// `(ptr, len)` must describe a readable byte range.
+#[no_mangle]
+pub unsafe extern "C" fn get_display(a1_ptr: *const u8, a1_len: usize) -> *mut u8 {
+    let a1 = read_input(a1_ptr, a1_len);
+    pack(SESSION.with(|s| s.borrow().get_display(&a1)))
+}
+
 // ── Structural edits: insert / delete rows & columns ─────────────────
 // 1-based `at`, `count` lines. The engine relocates cells and rewrites formula
 // references; the formula echo stays in step. No return — the JS host re-reads
@@ -320,6 +362,43 @@ mod tests {
         let out = unsafe { get_raw(ap, al) };
         unsafe { dealloc(ap, al) };
         take(out)
+    }
+
+    fn set_fmt(a1: &str, code: &str) {
+        let (ap, al) = put(a1);
+        let (cp, cl) = put(code);
+        unsafe { set_format(ap, al, cp, cl) };
+        unsafe {
+            dealloc(ap, al);
+            dealloc(cp, cl);
+        }
+    }
+
+    fn display(a1: &str) -> String {
+        let (ap, al) = put(a1);
+        let out = unsafe { get_display(ap, al) };
+        unsafe { dealloc(ap, al) };
+        take(out)
+    }
+
+    fn format(a1: &str) -> String {
+        let (ap, al) = put(a1);
+        let out = unsafe { get_format(ap, al) };
+        unsafe { dealloc(ap, al) };
+        take(out)
+    }
+
+    #[test]
+    fn abi_cell_format_round_trip() {
+        reset();
+        set("A1", "1234.5");
+        assert_eq!(display("A1"), "1234.5"); // General before any format
+        set_fmt("A1", "#,##0.00");
+        assert_eq!(format("A1"), "#,##0.00");
+        assert_eq!(display("A1"), "1,234.50");
+        set_fmt("A1", ""); // clear → back to General
+        assert_eq!(format("A1"), "");
+        assert_eq!(display("A1"), "1234.5");
     }
 
     #[test]


### PR DESCRIPTION
## What

Wires the merged `spreadsheet-core` cell-format API ([#5991](https://github.com/adhithyan15/coding-adventures/pull/5991)) out through **all three facades**, so every backend can set a cell's format and read its formatted display.

- **`spreadsheet-core-wasm`** (JSON facade): `set_format(a1, code)` / `get_format(a1)` / `get_display(a1)`. `get_display` returns the value rendered through its format (`1234.5` + `"#,##0.00"` → `"1,234.50"`) — distinct from `get_value` (typed JSON) and `get_raw` (source).
- **`spreadsheet-capi`** (C ABI): `sc_set_format` / `sc_get_format` / `sc_get_display`, declared in `include/spreadsheet.h`. Null-session safe.
- **`spreadsheet-wasm`** (browser ABI): `set_format` / `get_format` / `get_display` over the thread-local session (`read_input`/`pack` marshalling).

## Verification

- **core-wasm 21 tests** (1 new: set/get/apply + clear-reverts-to-General), **capi 4**, **wasm 7** (1 new ABI format round-trip). Clippy clean across all three. Each `0.3.0 → 0.4.0` (additive).
- **`/security-review` passed** (1 round, no findings) — null-session guards match the sibling `sc_*` pattern, the pre-existing `read_cstr`/`read_input`/`pack` helpers are reused unchanged (null/zero-len safe, no double-free/leak), every `CellAddress::parse` is handled so a malformed address is a no-op/`""` (never a panic), and `get_display` delegates to the already-reviewed panic-safe `number-format-core`.

## Next

Surface formatting in the backend UIs (e.g. a format picker that calls `sc_set_format` and renders `sc_get_display`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)