### PR TITLE
feat(closurec): SIMPLE pipeline gains treeshake (drops unused functions)

### DIFF
--- a/code/packages/rust/closure-pass-treeshake/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-treeshake/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to the `coding-adventures-closure-pass-treeshake` crate will be documented in this file.
 
+## [0.3.2] - 2026-06-16
+
+### Docs
+
+De-staled the module header, struct doc, `run` body comment, and test-module
+doc. They still claimed "v1 is identity" / "sweep deferred to CLOC13.C.1" /
+"`changed` is hard-pinned to false" / "analyzer returns empty bindings" — none
+of which has been true since the apply step and the scope-analyzer body landed.
+`TreeshakePass::run` already deletes unreferenced top-level `function`/`class`
+declarations (`changed = removed_count > 0`), as the existing
+`apply_step_drops_unreferenced_function` test asserts. No code change — this
+crate is now wired into closurec's SIMPLE pipeline, so its docs needed to stop
+describing it as a no-op.
+
 ## [0.3.1] - 2026-06-02
 
 ### Added — retention test (paired with CLOC13.0.2 activation)

--- a/code/packages/rust/closure-pass-treeshake/Cargo.toml
+++ b/code/packages/rust/closure-pass-treeshake/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-treeshake"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2021"
 description = "Tree-shaking pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Removes module exports and imports that aren't reachable from the program's entry points, eliminating whole-module dead weight that intra-module DCE can't see."
 

--- a/code/packages/rust/closure-pass-treeshake/src/lib.rs
+++ b/code/packages/rust/closure-pass-treeshake/src/lib.rs
@@ -49,23 +49,33 @@
 //! which can in turn make *more* modules' exports unreferenced.
 //! Bounded by module count in practice; we don't pre-cap it.
 //!
-//! # Scope (v1)
+//! # Scope
 //!
-//! `javascript-ast` ships only `Program` / `SourceType` today
-//! (CLOC02 Phase 1). With no `ImportDeclaration` /
-//! `ExportDeclaration` / `Identifier` nodes there is nothing to
-//! shake; [`TreeshakePass::run`] is identity in v1. Per CLOC03
-//! §"When a pass keeps a node unchanged" no contributions are
-//! emitted.
+//! `TreeshakePass::run` is a real transform: it uses
+//! `closure-scope-analyzer` to find top-level (`ScopeId::GLOBAL`)
+//! `function`/`class` bindings that no [`Reference`] resolves to, and
+//! deletes their declarations. This is the function/class-shaped
+//! complement to `remove-unused-vars` (which handles `var`/`let`/`const`
+//! and skips functions). Removing an unused function/class declaration is
+//! unconditionally safe — declaring one has no side effect — so unlike
+//! `remove-unused-vars` there is no initializer-purity gate.
 //!
-//! What this PR locks down:
+//! Current slice: top-level bindings only, removed by name against the
+//! `Declaration::FunctionDeclaration` items in `program.body`. The full
+//! cross-module import/export reachability walk lands once
+//! `javascript-ast` grows `ImportDeclaration` / `ExportDeclaration`
+//! variants and a host root-set; until then a function is "reachable" iff
+//! some in-module reference resolves to it.
+//!
+//! What this pass locks down:
 //!
 //! 1. Pass metadata (`name`, `iteration_policy`, `cost`,
 //!    `depends_on`) — what the scheduler keys on and what the
-//!    future `closurec` CLI surfaces as `--disable=treeshake`.
+//!    `closurec` CLI surfaces as `--disable=treeshake`.
 //! 2. The `depends_on("dce")` edge so the scheduler forces
-//!    intra-module DCE before cross-module shaking.
-//! 3. The two-pass integration test that proves the ordering.
+//!    intra-module DCE before shaking.
+//! 3. Removal of dead top-level function declarations, plus the
+//!    DCE-ordering integration test.
 
 use coding_adventures_closure_pass_pipeline::{
     IterationPolicy, Pass, PassContext, PassError, PassOutput, PassStats,
@@ -80,13 +90,12 @@ use coding_adventures_javascript_ast::{Declaration, ProgramItem};
 /// crates can reference the dependency name without retyping.
 const DEPS: &[&str] = &["dce"];
 
-/// Tree-shaking pass. v1 is identity — see crate-level docs.
+/// Tree-shaking pass — deletes top-level `function`/`class`
+/// declarations nothing references. See crate-level docs.
 ///
-/// Zero-sized type: no per-instance state. Pass-internal state
-/// (cross-module import graph, root-set seeded from entry points
-/// and `export` markers that the host declared reachable, the
-/// per-module set of reached identifiers) lives in pass-local
-/// maps constructed inside [`Pass::run`] per CLOC06
+/// Zero-sized type: no per-instance state. Pass-internal state (the
+/// binding → reference-count map and the dead-name set) lives in
+/// pass-local maps constructed inside [`Pass::run`] per CLOC06
 /// §"Pass-internal state."
 #[derive(Debug, Default, Clone, Copy)]
 pub struct TreeshakePass;
@@ -135,49 +144,28 @@ impl Pass for TreeshakePass {
     }
 
     fn run(&self, ctx: PassContext<'_>) -> Result<PassOutput, PassError> {
-        // CLOC13.C wiring: consume the shared `ScopeAnalysis` from
-        // `closure-scope-analyzer` to identify *module-shape
-        // candidates* — bindings whose kind (`Function` / `Class`)
-        // is the shape that becomes a module export once
-        // `javascript-ast` grows `ImportDeclaration` /
-        // `ExportDeclaration` variants.
+        // Consume the shared `ScopeAnalysis` from
+        // `closure-scope-analyzer` and delete top-level `Function`/
+        // `Class` declarations that nothing references. The algorithm:
         //
-        // The algorithm (mark phase; sweep deferred):
+        //   1. Use-count per binding (scan `analysis.references`).
+        //   2. Dead-shape scan: a binding is removable when its
+        //      use-count is 0, its scope is `ScopeId::GLOBAL`, and its
+        //      kind is `Function` or `Class`. (`Var`/`Let`/`Const` are
+        //      remove-unused-vars' / collapse-properties' job — the
+        //      split is kind-based.)
+        //   3. Apply: walk `program.body` and drop the matching
+        //      `Declaration::FunctionDeclaration`s.
         //
-        //   1. Walk `analysis.bindings`. A binding is a
-        //      *module-shape candidate* when:
-        //        a. kind == Function OR kind == Class  (these are
-        //           the only binding shapes ESM allows to be
-        //           exported as a named export from the top
-        //           level. `Var`/`Let`/`Const` *can* be exported
-        //           but cross over to remove-unused-vars and
-        //           collapse-properties; the cleanest split is
-        //           kind-based.)
-        //   2. Track candidates in a Vec<BindingId> for the
-        //      observability path.
-        //   3. Sweep — deferred to CLOC13.C.1 because *removing* a
-        //      function/class binding cleanly requires the AST to
-        //      have ImportDeclaration / ExportDeclaration nodes
-        //      (otherwise treeshake can't tell an exported
-        //      function from an internal one).
+        // `changed` is `true` iff at least one declaration was dropped.
+        // Under `IterationPolicy::FixedPoint` this is sound because each
+        // iteration strictly shrinks the binding set (a removed function
+        // mints no new bindings), so it converges — see the apply-step
+        // comment below.
         //
-        // **Critical (lesson from CLOC13.E security review):**
-        // `changed` is hard-pinned to `false` until step 3 lands.
-        // Reporting `changed = true` while returning an unchanged
-        // program would cause the scheduler under
-        // `IterationPolicy::FixedPoint` to re-run forever — each
-        // iteration would find the same candidates, claim a
-        // change, return the same program, repeat. Documented in
-        // both the code and the CHANGELOG so the next contributor
-        // doesn't reintroduce the bug.
-        //
-        // **Why this is safe with the v0.1.0 analyzer body.** The
-        // current `analyze` returns empty bindings + references,
-        // so the candidate scan finds zero shapes, the candidates
-        // vec is empty, `nodes_touched` is small, and the program
-        // passes through unchanged. The wiring becomes *effective*
-        // (real shape-finding) the moment CLOC13.0 lands the
-        // analyzer body — no churn here.
+        // Note: a `Function`/`Class` declaration has no evaluation side
+        // effect, so removing an unreferenced one is unconditionally
+        // safe — no initializer-purity gate (unlike remove-unused-vars).
 
         let analysis = analyze(ctx.program);
 
@@ -292,10 +280,11 @@ impl Pass for TreeshakePass {
 
 #[cfg(test)]
 mod tests {
-    //! Tests pin the public contract and lock the DCE ordering
-    //! integration with `PassPipeline`. v1's `run` is identity,
-    //! but the metadata drives the scheduler and outlives the
-    //! v1 body.
+    //! Tests pin the public contract: pass metadata, the DCE-ordering
+    //! integration with `PassPipeline`, and the removal behavior itself
+    //! — actual deletion of unreferenced top-level function
+    //! declarations, with referenced functions and `var`/statements
+    //! passed through.
     use super::*;
     use coding_adventures_closure_pass_dce::DcePass;
     use coding_adventures_closure_pass_pipeline::{PassPipeline, PipelineOutput};

--- a/code/programs/rust/closurec/CHANGELOG.md
+++ b/code/programs/rust/closurec/CHANGELOG.md
@@ -2,6 +2,50 @@
 
 All notable changes to the `coding-adventures-closurec` binary will be documented in this file.
 
+## [0.142.0] - 2026-06-16
+
+### Added (CLOC12.159 — SIMPLE pipeline gains `treeshake`)
+
+The `--compilation_level SIMPLE` pass pipeline is now
+`constant-fold → fold-control-flow → dce → inline → remove-unused-vars →
+treeshake`. The final pass deletes top-level `function`/`class` declarations
+that nothing references — the function-shaped complement to
+`remove-unused-vars` (which deliberately skips functions):
+
+| Source | SIMPLE output |
+|--------|---------------|
+| `function dead() { return 1; }` | *(removed — never called)* |
+| `function live() { return 2; } log(live());` | `function live(){return 2};log(live());` |
+
+Removing an unused function declaration is unconditionally safe — declaring a
+function has no side effect, so (unlike a `var` initializer) `treeshake` needs
+no purity gate. It runs after `remove-unused-vars` so a function that only a
+now-removed `var` referenced is itself swept in the same pipeline.
+
+`treeshake`'s apply step was already implemented (it drops dead
+`ProgramItem::Declaration(FunctionDeclaration)`s); functions bridge as bare
+declarations, so — unlike `remove-unused-vars` — it had no Statement-wrapping
+bug and works end-to-end as-is. Verified empirically before wiring.
+
+- `SIMPLE_PASS_NAMES` is now
+  `[constant-fold, fold-control-flow, dce, inline, remove-unused-vars, treeshake]`;
+  the `simple_v2` correlation-vector trace lists all six.
+
+### Verified
+- New `tests/diff/simple-treeshake/` end-to-end fixture +
+  `tests/diff_simple_treeshake.rs`:
+  `function dead(){…} function live(){…} log(live());` ⇒
+  `function live(){return 2};log(live());`.
+- New unit tests `simple_treeshake_drops_unused_function`,
+  `simple_treeshake_keeps_called_function`,
+  `simple_treeshake_whitespace_only_keeps_function`.
+- `simple_v2` CV test updated to expect all six pass names.
+
+### Fixture/test churn
+- The two `simple_dce_*` unit tests used an uncalled top-level `function f` as
+  the carrier for the dce behavior under test; `treeshake` now removes it, so
+  they call `f()` to keep it alive (the dce-inside-the-body effect is unchanged).
+
 ## [0.141.0] - 2026-06-16
 
 ### Added (CLOC12.158 — SIMPLE pipeline gains `remove-unused-vars`)

--- a/code/programs/rust/closurec/Cargo.toml
+++ b/code/programs/rust/closurec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closurec"
-version = "0.141.0"
+version = "0.142.0"
 edition = "2021"
 description = "closurec — CLI driver for the Closure Compiler clone. Mirrors the upstream Java Closure Compiler's command-line flag surface (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility. Per CLOC08."
 

--- a/code/programs/rust/closurec/README.md
+++ b/code/programs/rust/closurec/README.md
@@ -124,7 +124,7 @@ body fills in.**
 | Level | What it does |
 |-------|--------------|
 | `WHITESPACE_ONLY` | Strips comments and inter-token whitespace only. Token-level; never parses to a typed AST. |
-| `SIMPLE` | Runs the typed-AST optimization pipeline — parse → bridge → passes → emit. Today the pipeline is `constant-fold → fold-control-flow → dce → inline → remove-unused-vars` (e.g. `1 + 2` ⇒ `3`; `if (2 > 3) {a} else {b}` ⇒ `{b}`; code after a `return` is dropped; unused top-level `var`s with pure initializers are deleted); more passes land one PR at a time. Falls back to `WHITESPACE_ONLY` if the source uses a not-yet-supported construct, so it never errors on valid input. |
+| `SIMPLE` | Runs the typed-AST optimization pipeline — parse → bridge → passes → emit. Today the pipeline is `constant-fold → fold-control-flow → dce → inline → remove-unused-vars → treeshake` (e.g. `1 + 2` ⇒ `3`; `if (2 > 3) {a} else {b}` ⇒ `{b}`; code after a `return` is dropped; unused top-level `var`s with pure initializers and unused top-level `function`s are deleted); more passes land one PR at a time. Falls back to `WHITESPACE_ONLY` if the source uses a not-yet-supported construct, so it never errors on valid input. |
 | `ADVANCED` / `BUNDLE` / `TRANSPILE_ONLY` | Identity passthrough for now — the typed passes specific to these levels (tree-shaking, property renaming, etc.) land in follow-up work. |
 
 The SIMPLE pipeline:

--- a/code/programs/rust/closurec/cli.spec.json
+++ b/code/programs/rust/closurec/cli.spec.json
@@ -2,7 +2,7 @@
   "cli_builder_spec_version": "1.0",
   "name": "closurec",
   "description": "closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.",
-  "version": "0.141.0",
+  "version": "0.142.0",
   "parsing_mode": "gnu",
   "flags": [
     { "id": "browser_featureset_year", "long": "browser_featureset_year", "type": "integer", "default": 0, "description": "Shortcut for defining goog.FEATURESET_YEAR=YYYY (minimum 2012)." },

--- a/code/programs/rust/closurec/src/run.rs
+++ b/code/programs/rust/closurec/src/run.rs
@@ -227,15 +227,23 @@ pub fn transform_source(
 ///   remove-unused-vars unless `inline` is registered. (inline is
 ///   currently an identity pass; it earns its slot once function
 ///   inlining lands, and registering it now pins the canonical order.)
-/// - remove-unused-vars runs last and deletes top-level `var/let/const`
-///   bindings that nothing references, when their initializer is
-///   side-effect-free.
+/// - remove-unused-vars deletes top-level `var/let/const` bindings that
+///   nothing references, when their initializer is side-effect-free;
+/// - treeshake runs last and deletes top-level `function`/`class`
+///   declarations that nothing references. It is the function-shaped
+///   complement to remove-unused-vars (which deliberately skips
+///   functions). Running it after remove-unused-vars means a function
+///   that only a now-removed var referenced is itself swept this pass.
+///   Removing an unused function declaration is unconditionally safe —
+///   declaring a function has no side effect, so no purity gate is
+///   needed (unlike a `var` initializer).
 const SIMPLE_PASS_NAMES: &[&str] = &[
     "constant-fold",
     "fold-control-flow",
     "dce",
     "inline",
     "remove-unused-vars",
+    "treeshake",
 ];
 
 /// Run the SIMPLE optimization pipeline over a bridged `Program` and
@@ -270,6 +278,7 @@ fn run_simple_pipeline(
     use coding_adventures_closure_pass_inline::InlinePass;
     use coding_adventures_closure_pass_pipeline::PassPipeline;
     use coding_adventures_closure_pass_remove_unused_vars::RemoveUnusedVarsPass;
+    use coding_adventures_closure_pass_treeshake::TreeshakePass;
     use coding_adventures_correlation_vector::CVLog;
     use coding_adventures_type_sidecar::Sidecar;
 
@@ -291,6 +300,7 @@ fn run_simple_pipeline(
     pipeline.add(Box::new(DcePass::new()));
     pipeline.add(Box::new(InlinePass::new()));
     pipeline.add(Box::new(RemoveUnusedVarsPass::new()));
+    pipeline.add(Box::new(TreeshakePass::new()));
 
     let optimized = match pipeline.run(program, &sidecar, &mut pass_cv) {
         Ok(out) => out.program,
@@ -5641,10 +5651,14 @@ mod tests {
             },
             ..Default::default()
         };
-        let out = transform_source("function f() { g(); return 1; dead(); }", &cfg)
+        // `f` is called so treeshake (now last in the SIMPLE pipeline)
+        // keeps the declaration; otherwise the unused function would be
+        // removed wholesale and the dce-inside-the-body effect wouldn't
+        // be observable.
+        let out = transform_source("function f() { g(); return 1; dead(); } f();", &cfg)
             .expect("ok");
         assert_eq!(
-            out, "function f(){g();return 1};",
+            out, "function f(){g();return 1};f();",
             "dce must drop the statement after the return"
         );
     }
@@ -5662,11 +5676,13 @@ mod tests {
             },
             ..Default::default()
         };
+        // `f` is called so treeshake keeps the declaration (see the
+        // companion dead-after-return test).
         let out =
-            transform_source("function f() { if (4 > 5) { x(); } return 2; }", &cfg)
+            transform_source("function f() { if (4 > 5) { x(); } return 2; } f();", &cfg)
                 .expect("ok");
         assert_eq!(
-            out, "function f(){return 2};",
+            out, "function f(){return 2};f();",
             "dce must sweep the empty statement left by fold-control-flow"
         );
     }
@@ -5758,6 +5774,59 @@ mod tests {
     }
 
     #[test]
+    fn simple_treeshake_drops_unused_function() {
+        // CLOC12.159: the SIMPLE pipeline now ends with treeshake, which
+        // deletes a top-level function declaration nothing references.
+        let cfg = CompilerConfig {
+            compilation: crate::config::CompilationConfig {
+                level: crate::config::CompilationLevel::Simple,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let out =
+            transform_source("function dead() { return 1; } used();", &cfg).expect("ok");
+        assert_eq!(out, "used();", "the unused function must be removed");
+    }
+
+    #[test]
+    fn simple_treeshake_keeps_called_function() {
+        // A function that IS referenced (called) survives.
+        let cfg = CompilerConfig {
+            compilation: crate::config::CompilationConfig {
+                level: crate::config::CompilationLevel::Simple,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let out = transform_source("function f() { return 2; } log(f());", &cfg)
+            .expect("ok");
+        assert_eq!(
+            out, "function f(){return 2};log(f());",
+            "a called function must be kept"
+        );
+    }
+
+    #[test]
+    fn simple_treeshake_whitespace_only_keeps_function() {
+        // Companion — the SAME unused function under WHITESPACE_ONLY
+        // survives, proving the removal is the SIMPLE pipeline's doing.
+        let cfg = CompilerConfig {
+            compilation: crate::config::CompilationConfig {
+                level: crate::config::CompilationLevel::WhitespaceOnly,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let out =
+            transform_source("function dead() { return 1; } used();", &cfg).expect("ok");
+        assert_eq!(
+            out, "function dead(){return 1};used();",
+            "whitespace_only must NOT remove the function"
+        );
+    }
+
+    #[test]
     fn simple_level_bridge_ok_status_in_cv() {
         // When the source parses cleanly, the CV contribution for the
         // `compilation_level` stage must carry bridge_status = "ok".
@@ -5796,7 +5865,7 @@ mod tests {
         // The pass pipeline must be recorded in the trace, in order.
         assert!(
             body.contains(
-                "\"passes\":[\"constant-fold\",\"fold-control-flow\",\"dce\",\"inline\",\"remove-unused-vars\"]"
+                "\"passes\":[\"constant-fold\",\"fold-control-flow\",\"dce\",\"inline\",\"remove-unused-vars\",\"treeshake\"]"
             ),
             "expected passes list in CV sidecar: {body}"
         );

--- a/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
@@ -2,7 +2,7 @@
 
 closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.
 
-Version: 0.141.0
+Version: 0.142.0
 
 ## Flags
 

--- a/code/programs/rust/closurec/tests/diff/simple-dce/README.md
+++ b/code/programs/rust/closurec/tests/diff/simple-dce/README.md
@@ -7,7 +7,7 @@ End-to-end oracle for the `dce` (dead-code elimination) pass in
 |------|------|
 | `flags.txt` | `--compilation_level SIMPLE --js input/a.js` |
 | `input/a.js` | A function whose body has dead branches and post-`return` code |
-| `expected.stdout` | `function f(){keep();return 1};` |
+| `expected.stdout` | `function f(){keep();return 1};f();` |
 
 The SIMPLE pipeline is now `constant-fold → fold-control-flow → dce`. This
 fixture shows all three composing inside one function body:

--- a/code/programs/rust/closurec/tests/diff/simple-dce/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/simple-dce/expected.stdout
@@ -1,2 +1,2 @@
-function f(){keep();return 1};
+function f(){keep();return 1};f();
 

--- a/code/programs/rust/closurec/tests/diff/simple-dce/input/a.js
+++ b/code/programs/rust/closurec/tests/diff/simple-dce/input/a.js
@@ -1,22 +1,27 @@
 // SIMPLE-level dead-code elimination (CLOC12.157).
 //
-// The SIMPLE pipeline now runs `dce` after `constant-fold` and
+// The SIMPLE pipeline runs `dce` after `constant-fold` and
 // `fold-control-flow`. This function exercises both of dce's jobs at
-// once, and shows all three passes composing inside one block:
+// once, and shows the passes composing inside one block:
 //
-//   - `keep();`                  — live, before the return: retained.
+//   - `keep();`                  -- live, before the return: retained.
 //   - `if (4 > 5) { neverRuns(); }`
 //        constant-fold turns `4 > 5` into `false`;
-//        fold-control-flow turns `if (false) {…}` into an empty `;`;
+//        fold-control-flow turns `if (false) {...}` into an empty `;`;
 //        dce then sweeps that empty statement out of the block.
-//   - `return 1;`                — the block terminator: retained.
-//   - `alsoDead();`              — after the return: dce drops it
+//   - `return 1;`                -- the block terminator: retained.
+//   - `alsoDead();`              -- after the return: dce drops it
 //        (dead-after-terminator).
 //
-// Under WHITESPACE_ONLY none of this happens — every statement survives.
+// `f()` is called so treeshake (the last SIMPLE pass) keeps the
+// function; otherwise the whole unused declaration would be removed and
+// the dce-inside-the-body effect wouldn't be observable.
+//
+// Under WHITESPACE_ONLY none of this happens -- every statement survives.
 function f() {
   keep();
   if (4 > 5) { neverRuns(); }
   return 1;
   alsoDead();
 }
+f();

--- a/code/programs/rust/closurec/tests/diff/simple-treeshake/README.md
+++ b/code/programs/rust/closurec/tests/diff/simple-treeshake/README.md
@@ -1,0 +1,34 @@
+# Fixture: `simple-treeshake`
+
+End-to-end oracle for the `treeshake` pass in `--compilation_level SIMPLE`
+(CLOC12.159, PR-C).
+
+| File | Role |
+|------|------|
+| `flags.txt` | `--compilation_level SIMPLE --js input/a.js` |
+| `input/a.js` | One unused top-level function, one used one |
+| `expected.stdout` | `function live(){return 2};log(live());` |
+
+The SIMPLE pipeline is now
+`constant-fold → fold-control-flow → dce → inline → remove-unused-vars →
+treeshake`. The final pass deletes top-level `function`/`class`
+declarations that nothing references:
+
+| Source | Fate |
+|--------|------|
+| `function dead() { return 1; }` | removed — never called |
+| `function live() { return 2; }` | kept — called by `log(live())` |
+
+`treeshake` is the function-shaped complement to `remove-unused-vars`
+(which deliberately skips functions). Removing an unused function
+declaration is always safe — declaring a function has no side effect, so
+no purity gate is needed. The same input under `WHITESPACE_ONLY` keeps
+both functions.
+
+Regenerate the expected file after an intentional behavior change:
+
+```sh
+cargo run -- --compilation_level SIMPLE \
+    --js tests/diff/simple-treeshake/input/a.js \
+    > tests/diff/simple-treeshake/expected.stdout
+```

--- a/code/programs/rust/closurec/tests/diff/simple-treeshake/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/simple-treeshake/expected.stdout
@@ -1,0 +1,2 @@
+function live(){return 2};log(live());
+

--- a/code/programs/rust/closurec/tests/diff/simple-treeshake/flags.txt
+++ b/code/programs/rust/closurec/tests/diff/simple-treeshake/flags.txt
@@ -1,0 +1,4 @@
+--compilation_level
+SIMPLE
+--js
+tests/diff/simple-treeshake/input/a.js

--- a/code/programs/rust/closurec/tests/diff/simple-treeshake/input/a.js
+++ b/code/programs/rust/closurec/tests/diff/simple-treeshake/input/a.js
@@ -1,0 +1,15 @@
+// SIMPLE-level tree-shaking of unused functions (CLOC12.159).
+//
+// The SIMPLE pipeline now ends with `treeshake`, which deletes top-level
+// `function`/`class` declarations that nothing references. It is the
+// function-shaped complement to remove-unused-vars (which skips
+// functions). Removing an unused function declaration is always safe --
+// declaring a function has no side effect.
+//
+//   - `function dead()`  -- never called, so treeshake removes it.
+//   - `function live()`  -- called by `log(live())`, so it survives.
+//
+// Under WHITESPACE_ONLY both functions survive verbatim.
+function dead() { return 1; }
+function live() { return 2; }
+log(live());

--- a/code/programs/rust/closurec/tests/diff_simple_treeshake.rs
+++ b/code/programs/rust/closurec/tests/diff_simple_treeshake.rs
@@ -1,0 +1,58 @@
+//! Integration test for the `tests/diff/simple-treeshake/` fixture.
+//!
+//! Exercises the CLOC12.159 addition of the `treeshake` pass to the
+//! `--compilation_level SIMPLE` pipeline, which is now
+//! `constant-fold → fold-control-flow → dce → inline → remove-unused-vars
+//! → treeshake`. `treeshake` deletes top-level `function`/`class`
+//! declarations that nothing references — the function-shaped complement
+//! to `remove-unused-vars` (which skips functions):
+//!
+//! ```text
+//! function dead() { return 1; }   ⇒  (removed — never called)
+//! function live() { return 2; }   ⇒  function live(){return 2}   (called below)
+//! log(live());                    ⇒  log(live());
+//! ```
+//!
+//! Removing an unused function declaration is unconditionally safe —
+//! declaring a function has no side effect, so (unlike a `var`
+//! initializer) no purity gate is needed. The same input under
+//! WHITESPACE_ONLY keeps both functions (see the `simple_treeshake_*`
+//! unit tests in `src/run.rs`).
+
+use std::process::Command;
+
+const BINARY: &str = env!("CARGO_BIN_EXE_closurec");
+
+fn read_flags() -> Vec<String> {
+    let raw = std::fs::read_to_string("tests/diff/simple-treeshake/flags.txt")
+        .expect("read flags.txt");
+    raw.lines()
+        .filter(|l| !l.is_empty())
+        .map(|s| s.to_string())
+        .collect()
+}
+
+#[test]
+fn simple_treeshake_fixture_matches_expected_stdout() {
+    let flags = read_flags();
+    let out = Command::new(BINARY)
+        .args(&flags)
+        .output()
+        .expect("run closurec");
+
+    assert!(
+        out.status.success(),
+        "exit: {:?}, stderr: {}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stderr),
+    );
+
+    let actual = String::from_utf8_lossy(&out.stdout);
+    let expected = std::fs::read_to_string("tests/diff/simple-treeshake/expected.stdout")
+        .expect("read expected.stdout");
+    assert_eq!(
+        actual.trim_end_matches('\n'),
+        expected.trim_end_matches('\n'),
+        "mismatch.\nflags: {flags:?}\nactual:\n{actual}\nexpected:\n{expected}",
+    );
+}


### PR DESCRIPTION
## Summary

The `--compilation_level SIMPLE` pass pipeline is now **`constant-fold → fold-control-flow → dce → inline → remove-unused-vars → treeshake`**. The final pass deletes top-level `function`/`class` declarations that nothing references — the function-shaped complement to `remove-unused-vars` (which deliberately skips functions):

| Source | SIMPLE output |
|--------|---------------|
| `function dead() { return 1; }` | *(removed — never called)* |
| `function live() { return 2; } log(live());` | `function live(){return 2};log(live());` |

Removing an unused function declaration is **unconditionally safe** — declaring a function has no side effect — so unlike `remove-unused-vars`, treeshake needs no purity gate. It runs after `remove-unused-vars` so a function that only a now-removed `var` referenced is itself swept in the same pipeline.

## Why this one "just worked"

`treeshake`'s apply step was **already implemented** (drops dead `ProgramItem::Declaration(FunctionDeclaration)`s) and already had crate-level removal tests. Functions bridge as **bare declarations**, so — unlike `remove-unused-vars`, which had a Statement-wrapping bug — treeshake works end-to-end as-is. I verified this empirically (wired it in, probed `function unused(){…} used();` → `used();`) before committing.

`closure-pass-treeshake` 0.3.2 de-stales its docs (the module/struct/run/test comments still claimed "v1 is identity" / "sweep deferred" / "`changed` hard-pinned to false" — none true since the apply landed). No code change in the pass.

## Fixture/test churn

`treeshake` removes uncalled top-level functions, so the two `simple_dce_*` unit tests and the `simple-dce` diff fixture (which used an uncalled `function f` as the carrier for the dce behavior under test) now call `f()` to keep it alive. The dce-inside-the-body effect is unchanged.

## Test plan

- [x] New `tests/diff/simple-treeshake/` fixture + harness: `function dead(){…} function live(){…} log(live());` ⇒ `function live(){return 2};log(live());`
- [x] New unit tests: `simple_treeshake_drops_unused_function`, `simple_treeshake_keeps_called_function`, `simple_treeshake_whitespace_only_keeps_function`
- [x] `simple_v2` CV trace test updated to expect all six pass names
- [x] 667 closurec unit tests + all diff fixtures pass; `closure-pass-treeshake` 16 tests pass; security review passed
- closurec 0.141.0 → 0.142.0; closure-pass-treeshake 0.3.1 → 0.3.2 (doc-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)