### PR TITLE
feat(MA-1): array-runtime — shared N-D array substrate with GPU dispatch by lowering

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -17,6 +17,7 @@ members = [
     "audio-device-sink",
     "actor",
     "arithmetic",
+    "array-runtime",
     "arm-simulator",
     "array-core",
     "assembler",

--- a/code/packages/rust/array-runtime/BUILD
+++ b/code/packages/rust/array-runtime/BUILD
@@ -1,0 +1,1 @@
+cargo test -p coding-adventures-array-runtime -- --nocapture

--- a/code/packages/rust/array-runtime/BUILD_windows
+++ b/code/packages/rust/array-runtime/BUILD_windows
@@ -1,0 +1,1 @@
+cargo test -p coding-adventures-array-runtime -- --nocapture

--- a/code/packages/rust/array-runtime/CHANGELOG.md
+++ b/code/packages/rust/array-runtime/CHANGELOG.md
@@ -56,9 +56,27 @@ executors. `matrix-runtime` currently plans placement but does not yet
 orchestrate execution end-to-end; when it does, compute switches from the CPU
 reference path to the planned graph with no public API change.
 
+### Hardened (pre-merge security review)
+
+Defensive overflow handling so crafted dimensions can't wrap to an
+under-sized buffer or a mis-costed dispatch decision:
+
+- `Array::from_shape` computes the element count with checked multiplication
+  and rejects shapes whose product overflows `usize` (previously an unchecked
+  `product()` could wrap to a small count that passed the length check).
+- `Array::filled` (and `zeros`/`ones`/`eye` through it) and `Array::from_rows`
+  size their backing buffer with `checked_mul` — a deterministic error/panic on
+  overflow instead of a release-mode wrap that would under-allocate.
+- `ops::matmul` checks the `m * n` output size; `ops::transpose` allocates from
+  the input's element count (which already fit in memory).
+- `accel::shape_of` converts `usize` dims to `matrix-ir`'s `u32` with a
+  *checked* cast, rejecting dims past `u32::MAX` rather than silently truncating
+  (which would make the planner cost the wrong op and return a wrong backend).
+
 ### Tests
 
-24 tests (23 unit + 1 doctest): the value model (shapes, column-major storage,
-constructors, bounds, `Display`), every reference op (including broadcasting,
-NaN/Inf, dimension-mismatch errors, transpose involution), and the dispatch
-decision (CPU-only fallback, small op stays on CPU, large matmul moves to GPU).
+28 tests (27 unit + 1 doctest): the value model (shapes, column-major storage,
+constructors, bounds, `Display`, overflow rejection), every reference op
+(including broadcasting, NaN/Inf, dimension-mismatch errors, transpose
+involution), and the dispatch decision (CPU-only fallback, small op stays on
+CPU, large matmul moves to GPU, oversized dim rejected).

--- a/code/packages/rust/array-runtime/CHANGELOG.md
+++ b/code/packages/rust/array-runtime/CHANGELOG.md
@@ -1,0 +1,64 @@
+# Changelog
+
+All notable changes to `array-runtime` are documented here. The format is based
+on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+## [0.1.0] — 2026-06-16
+
+Initial release — **MA-1**, Wave 0 of the historical math-languages roadmap
+([`HML00`](../../../specs/HML00-historical-math-languages-roadmap.md), spec
+[`MA00`](../../../specs/MA00-array-runtime.md)). The shared N-D numeric-array
+substrate that the array/matrix-language frontends (MATLAB first) sit on.
+
+### Added — the `Array` value model (`value.rs`)
+
+A dense, rectangular, **column-major** `f64` array (`data: Vec<f64>`,
+`shape: Vec<usize>`). Element `(r, c)` of an `[nrows, ncols]` matrix lives at
+flat index `c * nrows + r` — Fortran/MATLAB order, chosen so a future MATLAB
+frontend maps directly (`reshape`, linear indexing, `[a; b]` literals).
+
+- Constructors: `scalar`, `from_vec` (1-D), `from_rows` (transposes row-major
+  input into column-major store), `from_shape` (validated), `zeros`, `ones`,
+  `filled`, `eye`.
+- Accessors: `shape`, `data`, `ndims`, `len`, `is_empty`, `is_scalar`, `nrows`,
+  `ncols`, `get(r, c)`.
+- `Display`: MATLAB-style right-aligned rows; integer-valued doubles print
+  without a trailing `.0`.
+
+### Added — CPU reference operations (`ops.rs`)
+
+Correct, dependency-free implementations that produce values today:
+
+- Elementwise `add`/`sub`/`mul`/`div` with scalar broadcasting (either operand
+  may be scalar; otherwise shapes must match). NaN/Inf propagate naturally.
+- Linear algebra: `matmul` (`[m,k]·[k,n] → [m,n]`, column-major) and `transpose`.
+- Reductions: `sum`, `mean`, `max`, `min`.
+
+### Added — GPU dispatch by lowering (`accel.rs`)
+
+The cost-based backend decision. An op lowers to a `matrix-ir::Graph` via
+`GraphBuilder` and is planned by `matrix-runtime::Runtime`, which places each op
+on the cheapest available backend (CPU/CUDA/Metal) from a FLOP + transfer cost
+model.
+
+- `Kernel` (`Elementwise(BinOp)` / `MatMul`) and `plan_backend(kernel, a, b,
+  with_gpu) -> String` returns the executor *kind* the planner chose
+  (`"cpu"`/`"gpu"`), so the dispatch decision is observable and tested.
+- `gpu_profile()` registers a synthetic accelerator (≈100× CPU throughput, real
+  host↔device transfer cost) to exercise the cost model. `matrix-ir` works in
+  `f32`/`u32`-dim `Shape`; `array-runtime` works in `f64` and converts at the
+  lowering boundary.
+
+### Deferred to MA-2
+
+Routing actual *execution* of the planned `ComputeGraph` through registered
+executors. `matrix-runtime` currently plans placement but does not yet
+orchestrate execution end-to-end; when it does, compute switches from the CPU
+reference path to the planned graph with no public API change.
+
+### Tests
+
+24 tests (23 unit + 1 doctest): the value model (shapes, column-major storage,
+constructors, bounds, `Display`), every reference op (including broadcasting,
+NaN/Inf, dimension-mismatch errors, transpose involution), and the dispatch
+decision (CPU-only fallback, small op stays on CPU, large matmul moves to GPU).

--- a/code/packages/rust/array-runtime/Cargo.toml
+++ b/code/packages/rust/array-runtime/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "coding-adventures-array-runtime"
+version = "0.1.0"
+edition = "2021"
+description = "N-D numeric array substrate for array languages — lowers to matrix-ir for GPU-aware execution"
+
+[dependencies]
+matrix-ir = { path = "../matrix-ir" }
+matrix-runtime = { path = "../matrix-runtime" }
+compute-ir = { path = "../compute-ir" }
+executor-protocol = { path = "../executor-protocol" }
+matrix-cpu = { path = "../matrix-cpu" }

--- a/code/packages/rust/array-runtime/README.md
+++ b/code/packages/rust/array-runtime/README.md
@@ -1,0 +1,100 @@
+# array-runtime
+
+The shared **N-dimensional numeric-array substrate** for the historical
+array/matrix languages — MATLAB first, then Octave, Scilab, APL, J, IDL. It is
+**Wave 0** of the historical math-languages roadmap
+([`HML00`](../../../specs/HML00-historical-math-languages-roadmap.md); full spec:
+[`MA00`](../../../specs/MA00-array-runtime.md)).
+
+The array languages differ mostly in *syntax*; underneath they share one value
+model — dense, rectangular, column-major numeric arrays with broadcasting,
+reshaping, linear algebra, and reductions. `array-runtime` builds that model
+once so each language frontend is a thin lexer/parser/runtime on top — exactly
+as R became a thin frontend over the shared S evaluator.
+
+## What it provides
+
+### 1. The `Array` value model (`value.rs`)
+
+A dense, **column-major** (Fortran/MATLAB order) `f64` array. Element `(r, c)` of
+an `[nrows, ncols]` matrix lives at flat index `c * nrows + r`. Column-major is
+deliberate: MATLAB's `reshape`, linear indexing, and `[a; b]` literal semantics
+all assume it.
+
+```rust
+use coding_adventures_array_runtime::Array;
+
+let a = Array::from_rows(vec![vec![1.0, 2.0], vec![3.0, 4.0]]).unwrap(); // 2x2
+let i = Array::eye(2);                                                   // identity
+let z = Array::zeros(3, 3);
+println!("{a}"); // MATLAB-style aligned rows
+```
+
+Constructors: `scalar`, `from_vec`, `from_rows`, `from_shape`, `zeros`, `ones`,
+`filled`, `eye`. Accessors: `shape`, `ndims`, `nrows`, `ncols`, `len`, `get`,
+`data`, plus a MATLAB-ish `Display`.
+
+### 2. CPU reference operations (`ops.rs`)
+
+Correct, dependency-free implementations that produce values **today**:
+
+- **Elementwise** `add`/`sub`/`mul`/`div` with scalar broadcasting (NaN/Inf
+  propagate naturally).
+- **Linear algebra** `matmul` (`[m,k]·[k,n] → [m,n]`) and `transpose`.
+- **Reductions** `sum`, `mean`, `max`, `min`.
+
+```rust
+use coding_adventures_array_runtime::{Array, ops};
+
+let a = Array::from_rows(vec![vec![1.0, 2.0], vec![3.0, 4.0]]).unwrap();
+let c = ops::matmul(&a, &Array::eye(2)).unwrap(); // a · I == a
+assert_eq!(c.data(), a.data());
+```
+
+### 3. GPU dispatch by lowering (`accel.rs`)
+
+The hardware story is **dispatch by lowering, not by syntax**. An op lowers to a
+[`matrix-ir`](../matrix-ir) tensor-algebra graph and is handed to
+[`matrix-runtime`](../matrix-runtime)'s cost-based planner, which places each op
+on the cheapest available backend — **CPU, CUDA, or Metal** — from a FLOP +
+host↔device-transfer cost model. CPU is the always-available fallback. So a large
+`matmul` runs on the GPU exactly when its FLOPs beat the transfer overhead, and a
+small one stays on the CPU — with **no language-level GPU code and no "use GPU"
+keyword**.
+
+```rust
+use coding_adventures_array_runtime::{Kernel, BinOp, plan_backend};
+
+// A big matmul is worth shipping to an accelerator…
+assert_eq!(plan_backend(Kernel::MatMul, &[256, 256], &[256, 256], true).unwrap(), "gpu");
+// …a tiny elementwise op is not.
+assert_eq!(plan_backend(Kernel::Elementwise(BinOp::Add), &[2, 2], &[2, 2], true).unwrap(), "cpu");
+```
+
+## Status — what MA-1 delivers vs. defers
+
+- **Delivered now:** the value model, the CPU reference ops (exact results
+  today), and the full `matrix-ir` lowering + cost-planner integration — the
+  backend choice is observable and tested.
+- **Deferred (MA-2):** routing actual *execution* of the planned `ComputeGraph`
+  through the registered executors. `matrix-runtime` currently *plans* placement
+  but does not yet orchestrate execution end-to-end. When that lands,
+  `array-runtime` switches its compute from the reference path to the planned
+  graph with **no public API change** — the lowering and dispatch decision are
+  already wired here.
+
+## Where it sits in the stack
+
+```
+matlab-runtime / octave-runtime / apl-runtime  (future frontends)
+                     │
+                array-runtime          ← this crate (shared value model + ops + dispatch)
+                     │
+        matrix-ir → matrix-runtime → executors (cpu / cuda / metal)
+```
+
+## Testing
+
+```sh
+cargo test -p coding-adventures-array-runtime
+```

--- a/code/packages/rust/array-runtime/required_capabilities.json
+++ b/code/packages/rust/array-runtime/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "rust/array-runtime",
+  "capabilities": [],
+  "justification": "Pure compute: an in-memory N-D array value model, CPU reference ops, and matrix-ir lowering + cost-based backend planning. No filesystem, network, process, or environment access."
+}

--- a/code/packages/rust/array-runtime/src/accel.rs
+++ b/code/packages/rust/array-runtime/src/accel.rs
@@ -20,17 +20,25 @@ pub enum Kernel {
     MatMul,
 }
 
-fn shape_of(dims: &[usize]) -> Shape {
-    Shape {
-        dims: dims.iter().map(|&d| d as u32).collect(),
-    }
+/// `matrix-ir` shapes use `u32` dims. Convert with a *checked* cast: a dim that
+/// doesn't fit `u32` is rejected rather than silently truncated, because a
+/// truncated dim would make the planner cost a different (smaller) op than the
+/// caller asked for and hand back a wrong backend placement.
+fn shape_of(dims: &[usize]) -> Result<Shape, String> {
+    let dims = dims
+        .iter()
+        .map(|&d| {
+            u32::try_from(d).map_err(|_| format!("dim {d} exceeds u32::MAX (matrix-ir limit)"))
+        })
+        .collect::<Result<Vec<u32>, String>>()?;
+    Ok(Shape { dims })
 }
 
 /// Build the `matrix-ir` graph for `kernel` over operands of the given shapes.
 fn build_graph(kernel: Kernel, a: &[usize], b: &[usize]) -> Result<Graph, String> {
     let mut g = GraphBuilder::new();
-    let ta = g.input(DType::F32, shape_of(a));
-    let tb = g.input(DType::F32, shape_of(b));
+    let ta = g.input(DType::F32, shape_of(a)?);
+    let tb = g.input(DType::F32, shape_of(b)?);
     let out = match kernel {
         Kernel::Elementwise(BinOp::Add) => g.add(&ta, &tb),
         Kernel::Elementwise(BinOp::Sub) => g.sub(&ta, &tb),
@@ -132,6 +140,14 @@ mod tests {
                 "cpu"
             );
         }
+    }
+
+    #[test]
+    fn oversized_dim_is_rejected_not_truncated() {
+        // A dim past u32::MAX must be an error, not a silent truncation that
+        // would make the planner cost the wrong (smaller) op.
+        let big = (u32::MAX as usize) + 1;
+        assert!(plan_backend(Kernel::Elementwise(BinOp::Add), &[big], &[big], false).is_err());
     }
 
     #[test]

--- a/code/packages/rust/array-runtime/src/accel.rs
+++ b/code/packages/rust/array-runtime/src/accel.rs
@@ -1,0 +1,147 @@
+//! Lowering to `matrix-ir` + the cost-based backend decision.
+//!
+//! This is the GPU-dispatch brain: an array op is lowered to a `matrix-ir`
+//! graph and handed to `matrix-runtime`'s planner, which places each op on the
+//! cheapest available backend (CPU/CUDA/Metal) from a FLOP + transfer cost
+//! model. CPU is the always-available fallback. The placement is observable via
+//! [`plan_backend`], so the dispatch decision is testable today — even though
+//! *executing* the placed graph on a real GPU is a later MA item (the reference
+//! ops in [`crate::ops`] produce values until then).
+
+use crate::ops::BinOp;
+use compute_ir::PlacedOp;
+use matrix_ir::{DType, Graph, GraphBuilder, Shape};
+use matrix_runtime::Runtime;
+
+/// Which kernel to lower for a dispatch decision.
+#[derive(Clone, Copy, Debug)]
+pub enum Kernel {
+    Elementwise(BinOp),
+    MatMul,
+}
+
+fn shape_of(dims: &[usize]) -> Shape {
+    Shape {
+        dims: dims.iter().map(|&d| d as u32).collect(),
+    }
+}
+
+/// Build the `matrix-ir` graph for `kernel` over operands of the given shapes.
+fn build_graph(kernel: Kernel, a: &[usize], b: &[usize]) -> Result<Graph, String> {
+    let mut g = GraphBuilder::new();
+    let ta = g.input(DType::F32, shape_of(a));
+    let tb = g.input(DType::F32, shape_of(b));
+    let out = match kernel {
+        Kernel::Elementwise(BinOp::Add) => g.add(&ta, &tb),
+        Kernel::Elementwise(BinOp::Sub) => g.sub(&ta, &tb),
+        Kernel::Elementwise(BinOp::Mul) => g.mul(&ta, &tb),
+        Kernel::Elementwise(BinOp::Div) => g.div(&ta, &tb),
+        Kernel::MatMul => g.matmul(&ta, &tb),
+    };
+    g.output(&out);
+    g.build().map_err(|e| format!("graph build failed: {e:?}"))
+}
+
+/// A synthetic accelerator profile: ~100× the CPU's throughput, but with a real
+/// host↔device transfer cost and per-dispatch overhead — so the planner keeps
+/// small ops on the CPU and moves large ones to the GPU. This is exactly the
+/// trade-off the cost model exists to make.
+pub fn gpu_profile() -> executor_protocol::BackendProfile {
+    let mut p = matrix_cpu::profile();
+    p.kind = "gpu".to_string();
+    p.gflops_f32 = 4000;
+    p.gflops_u8 = 4000;
+    p.gflops_i32 = 4000;
+    p.host_to_device_bw = 8;
+    p.device_to_host_bw = 8;
+    p.launch_overhead_ns = 5_000;
+    p
+}
+
+/// Plan `kernel` over the given operand shapes and return the executor *kind*
+/// (`"cpu"`/`"gpu"`/…) the cost model placed the compute op on. With
+/// `with_gpu`, an accelerator ([`gpu_profile`]) is registered so the cost-based
+/// choice can be exercised; without it, only the CPU is available.
+pub fn plan_backend(
+    kernel: Kernel,
+    a: &[usize],
+    b: &[usize],
+    with_gpu: bool,
+) -> Result<String, String> {
+    let graph = build_graph(kernel, a, b)?;
+
+    let mut rt = Runtime::new(matrix_cpu::profile());
+    if with_gpu {
+        rt.register("gpu", gpu_profile());
+    }
+
+    let placed = rt
+        .plan(&graph)
+        .map_err(|e| format!("planning failed: {e:?}"))?;
+    let exec_id = placed
+        .ops
+        .iter()
+        .find_map(|op| match op {
+            PlacedOp::Compute { executor, .. } => Some(executor.0),
+            _ => None,
+        })
+        .ok_or_else(|| "planned graph has no compute op".to_string())?;
+
+    Ok(rt
+        .executors()
+        .iter()
+        .find(|e| e.id.0 == exec_id)
+        .map(|e| e.kind.clone())
+        .unwrap_or_else(|| "unknown".to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cpu_only_when_no_accelerator() {
+        // With only the CPU registered, every op is placed on the CPU.
+        assert_eq!(
+            plan_backend(Kernel::Elementwise(BinOp::Add), &[3], &[3], false).unwrap(),
+            "cpu"
+        );
+        assert_eq!(
+            plan_backend(Kernel::MatMul, &[128, 128], &[128, 128], false).unwrap(),
+            "cpu"
+        );
+    }
+
+    #[test]
+    fn small_op_stays_on_cpu_even_with_a_gpu() {
+        // A tiny elementwise op isn't worth the transfer to an accelerator.
+        assert_eq!(
+            plan_backend(Kernel::Elementwise(BinOp::Add), &[2, 2], &[2, 2], true).unwrap(),
+            "cpu"
+        );
+    }
+
+    #[test]
+    fn every_elementwise_kernel_lowers_and_plans() {
+        // Each arithmetic op has a distinct matrix-ir lowering; plan them all so
+        // the whole lowering surface is exercised (and proven to build a valid
+        // graph the planner accepts).
+        for op in [BinOp::Add, BinOp::Sub, BinOp::Mul, BinOp::Div] {
+            assert_eq!(
+                plan_backend(Kernel::Elementwise(op), &[4], &[4], false).unwrap(),
+                "cpu"
+            );
+        }
+    }
+
+    #[test]
+    fn large_matmul_dispatches_to_the_gpu() {
+        // A big matmul has enough FLOPs to beat the transfer cost — the planner
+        // moves it to the accelerator. This is the GPU-dispatch decision the
+        // whole substrate exists to make, with zero language-level GPU code.
+        assert_eq!(
+            plan_backend(Kernel::MatMul, &[256, 256], &[256, 256], true).unwrap(),
+            "gpu"
+        );
+    }
+}

--- a/code/packages/rust/array-runtime/src/lib.rs
+++ b/code/packages/rust/array-runtime/src/lib.rs
@@ -1,0 +1,43 @@
+//! # array-runtime — the shared N-D numeric-array substrate
+//!
+//! `array-runtime` is **Wave 0** of the historical math-languages roadmap
+//! (`code/specs/HML00`). It is the dense, rectangular, column-major numeric-array
+//! value model that every numerical/array-language frontend — MATLAB first, then
+//! Octave/Scilab/APL/J — sits on, the array-family analogue of what the shared
+//! S evaluator is to R. Build the value model and its operations once; each
+//! language becomes a thin lexer/parser/runtime on top.
+//!
+//! ## The two halves
+//!
+//! 1. **[`Array`] + [`ops`]** — a correct, dependency-free CPU **reference**
+//!    implementation of the core operations (elementwise arithmetic with scalar
+//!    broadcasting, `matmul`, `transpose`, reductions). This is what produces
+//!    values *today*.
+//!
+//! 2. **[`accel`]** — the GPU-dispatch brain. Each op lowers to a `matrix-ir`
+//!    graph and is handed to `matrix-runtime`'s cost-based planner, which places
+//!    each op on the cheapest available backend (CPU/CUDA/Metal) from a FLOP +
+//!    transfer cost model. The placement is observable via
+//!    [`accel::plan_backend`], so the dispatch decision is tested today — even
+//!    though *executing* the placed graph through a real GPU executor is a later
+//!    MA item. Until then the reference path guarantees correct results and the
+//!    planner integration guarantees the dispatch decision is right. When the
+//!    execution layer lands, compute switches from the reference path to the
+//!    planned graph with **no public API change**.
+//!
+//! ```
+//! use coding_adventures_array_runtime::{Array, ops};
+//!
+//! let a = Array::from_rows(vec![vec![1.0, 2.0], vec![3.0, 4.0]]).unwrap();
+//! let b = Array::eye(2);
+//! let c = ops::matmul(&a, &b).unwrap(); // a · I == a
+//! assert_eq!(c.data(), a.data());
+//! ```
+
+pub mod accel;
+pub mod ops;
+pub mod value;
+
+pub use accel::{plan_backend, Kernel};
+pub use ops::BinOp;
+pub use value::Array;

--- a/code/packages/rust/array-runtime/src/ops.rs
+++ b/code/packages/rust/array-runtime/src/ops.rs
@@ -75,7 +75,12 @@ pub fn matmul(a: &Array, b: &Array) -> Result<Array, String> {
         ));
     }
     let (ad, bd) = (a.data(), b.data());
-    let mut out = vec![0.0; m * n];
+    // The output `[m, n]` can be far larger than either operand (e.g. an outer
+    // product), so size it with checked arithmetic rather than risking a wrap.
+    let out_len = m
+        .checked_mul(n)
+        .ok_or_else(|| format!("matmul: output {m}x{n} overflows usize"))?;
+    let mut out = vec![0.0; out_len];
     for j in 0..n {
         for i in 0..m {
             let mut acc = 0.0;
@@ -92,7 +97,10 @@ pub fn matmul(a: &Array, b: &Array) -> Result<Array, String> {
 pub fn transpose(a: &Array) -> Array {
     let (m, n) = (a.nrows(), a.ncols());
     let ad = a.data();
-    let mut out = vec![0.0; m * n];
+    // The transpose has exactly as many elements as the input, so allocate from
+    // `ad.len()` — that count already fit in memory, so it can't overflow even
+    // if a malformed `Array` had `m * n != ad.len()`.
+    let mut out = vec![0.0; ad.len()];
     for j in 0..n {
         for i in 0..m {
             out[i * n + j] = ad[j * m + i];

--- a/code/packages/rust/array-runtime/src/ops.rs
+++ b/code/packages/rust/array-runtime/src/ops.rs
@@ -1,0 +1,228 @@
+//! CPU **reference** implementations of the core array operations.
+//!
+//! These compute exact results today. In a later MA item the same ops will run
+//! through the planned `ComputeGraph` on the chosen backend (CPU/GPU) — the
+//! lowering and dispatch decision already live in [`crate::accel`]. Keeping a
+//! correct reference path here means every PR is usable while the execution
+//! layer is built out.
+
+use crate::value::Array;
+
+/// A binary elementwise operator (`+ - * /`, etc.).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum BinOp {
+    Add,
+    Sub,
+    Mul,
+    Div,
+}
+
+impl BinOp {
+    fn apply(self, a: f64, b: f64) -> f64 {
+        match self {
+            BinOp::Add => a + b,
+            BinOp::Sub => a - b,
+            BinOp::Mul => a * b,
+            BinOp::Div => a / b,
+        }
+    }
+}
+
+/// Elementwise binary op with scalar broadcasting. Either operand may be a
+/// scalar; otherwise the shapes must match exactly. (Full NumPy/MATLAB
+/// broadcasting follows in a later item.)
+pub fn elementwise(op: BinOp, a: &Array, b: &Array) -> Result<Array, String> {
+    let (ad, bd) = (a.data(), b.data());
+    let data: Vec<f64> = match (a.is_scalar(), b.is_scalar()) {
+        (true, _) => bd.iter().map(|&y| op.apply(ad[0], y)).collect(),
+        (_, true) => ad.iter().map(|&x| op.apply(x, bd[0])).collect(),
+        _ => {
+            if a.shape() != b.shape() {
+                return Err(format!(
+                    "non-conformable arrays: {:?} vs {:?}",
+                    a.shape(),
+                    b.shape()
+                ));
+            }
+            ad.iter().zip(bd).map(|(&x, &y)| op.apply(x, y)).collect()
+        }
+    };
+    // Result takes the non-scalar operand's shape (or the scalar's if both are).
+    let shape = if a.is_scalar() { b.shape() } else { a.shape() };
+    Array::from_shape(data, shape.to_vec())
+}
+
+pub fn add(a: &Array, b: &Array) -> Result<Array, String> {
+    elementwise(BinOp::Add, a, b)
+}
+pub fn sub(a: &Array, b: &Array) -> Result<Array, String> {
+    elementwise(BinOp::Sub, a, b)
+}
+pub fn mul(a: &Array, b: &Array) -> Result<Array, String> {
+    elementwise(BinOp::Mul, a, b)
+}
+pub fn div(a: &Array, b: &Array) -> Result<Array, String> {
+    elementwise(BinOp::Div, a, b)
+}
+
+/// Matrix product `[m, k] · [k, n] → [m, n]` (column-major throughout).
+pub fn matmul(a: &Array, b: &Array) -> Result<Array, String> {
+    let (m, ka) = (a.nrows(), a.ncols());
+    let (kb, n) = (b.nrows(), b.ncols());
+    if ka != kb {
+        return Err(format!(
+            "matmul: inner dimensions disagree ({m}x{ka} · {kb}x{n})"
+        ));
+    }
+    let (ad, bd) = (a.data(), b.data());
+    let mut out = vec![0.0; m * n];
+    for j in 0..n {
+        for i in 0..m {
+            let mut acc = 0.0;
+            for p in 0..ka {
+                acc += ad[p * m + i] * bd[j * kb + p]; // column-major indexing
+            }
+            out[j * m + i] = acc;
+        }
+    }
+    Array::from_shape(out, vec![m, n])
+}
+
+/// Matrix transpose.
+pub fn transpose(a: &Array) -> Array {
+    let (m, n) = (a.nrows(), a.ncols());
+    let ad = a.data();
+    let mut out = vec![0.0; m * n];
+    for j in 0..n {
+        for i in 0..m {
+            out[i * n + j] = ad[j * m + i];
+        }
+    }
+    Array::from_shape(out, vec![n, m]).expect("transpose preserves element count")
+}
+
+/// Whole-array reductions.
+pub fn sum(a: &Array) -> f64 {
+    a.data().iter().sum()
+}
+pub fn mean(a: &Array) -> f64 {
+    if a.is_empty() {
+        f64::NAN
+    } else {
+        sum(a) / a.len() as f64
+    }
+}
+pub fn max(a: &Array) -> f64 {
+    a.data().iter().copied().fold(f64::NEG_INFINITY, f64::max)
+}
+pub fn min(a: &Array) -> f64 {
+    a.data().iter().copied().fold(f64::INFINITY, f64::min)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::value::Array;
+
+    #[test]
+    fn elementwise_equal_shapes() {
+        let a = Array::from_vec(vec![1.0, 2.0, 3.0]);
+        let b = Array::from_vec(vec![10.0, 20.0, 30.0]);
+        assert_eq!(add(&a, &b).unwrap().data(), &[11.0, 22.0, 33.0]);
+        assert_eq!(sub(&b, &a).unwrap().data(), &[9.0, 18.0, 27.0]);
+        assert_eq!(mul(&a, &b).unwrap().data(), &[10.0, 40.0, 90.0]);
+        assert_eq!(div(&b, &a).unwrap().data(), &[10.0, 10.0, 10.0]);
+    }
+
+    #[test]
+    fn scalar_broadcasts_either_side() {
+        let v = Array::from_vec(vec![1.0, 2.0, 3.0]);
+        let s = Array::scalar(2.0);
+        assert_eq!(mul(&s, &v).unwrap().data(), &[2.0, 4.0, 6.0]); // scalar lhs
+        assert_eq!(add(&v, &s).unwrap().data(), &[3.0, 4.0, 5.0]); // scalar rhs
+                                                                   // The result keeps the array operand's shape, not the scalar's.
+        assert_eq!(add(&v, &s).unwrap().shape(), &[3]);
+    }
+
+    #[test]
+    fn two_scalars_stay_scalar() {
+        let r = add(&Array::scalar(2.0), &Array::scalar(40.0)).unwrap();
+        assert!(r.is_scalar());
+        assert_eq!(r.data(), &[42.0]);
+    }
+
+    #[test]
+    fn nonconformable_is_an_error() {
+        let a = Array::from_vec(vec![1.0, 2.0]);
+        let b = Array::from_vec(vec![1.0, 2.0, 3.0]);
+        assert!(add(&a, &b).is_err());
+    }
+
+    #[test]
+    fn nan_and_inf_propagate() {
+        let a = Array::from_vec(vec![1.0, 0.0]);
+        let b = Array::from_vec(vec![0.0, 0.0]);
+        let q = div(&a, &b).unwrap();
+        assert!(q.data()[0].is_infinite());
+        assert!(q.data()[1].is_nan());
+    }
+
+    #[test]
+    fn matmul_identity_and_product() {
+        // [[1,2],[3,4]] · I == itself.
+        let a = Array::from_rows(vec![vec![1.0, 2.0], vec![3.0, 4.0]]).unwrap();
+        assert_eq!(matmul(&a, &Array::eye(2)).unwrap().data(), a.data());
+
+        // [[1,2],[3,4]] · [[5,6],[7,8]] = [[19,22],[43,50]].
+        let b = Array::from_rows(vec![vec![5.0, 6.0], vec![7.0, 8.0]]).unwrap();
+        let c = matmul(&a, &b).unwrap();
+        assert_eq!(c.shape(), &[2, 2]);
+        assert_eq!(c.get(0, 0), Some(19.0));
+        assert_eq!(c.get(0, 1), Some(22.0));
+        assert_eq!(c.get(1, 0), Some(43.0));
+        assert_eq!(c.get(1, 1), Some(50.0));
+    }
+
+    #[test]
+    fn matmul_nonsquare() {
+        // [2x3] · [3x1] -> [2x1].
+        let a = Array::from_rows(vec![vec![1.0, 2.0, 3.0], vec![4.0, 5.0, 6.0]]).unwrap();
+        let x = Array::from_rows(vec![vec![1.0], vec![0.0], vec![-1.0]]).unwrap();
+        let y = matmul(&a, &x).unwrap();
+        assert_eq!(y.shape(), &[2, 1]);
+        assert_eq!(y.data(), &[-2.0, -2.0]);
+    }
+
+    #[test]
+    fn matmul_dimension_mismatch_errors() {
+        let a = Array::from_rows(vec![vec![1.0, 2.0]]).unwrap(); // 1x2
+        let b = Array::from_rows(vec![vec![1.0, 2.0]]).unwrap(); // 1x2
+        assert!(matmul(&a, &b).is_err());
+    }
+
+    #[test]
+    fn transpose_swaps_axes() {
+        let a = Array::from_rows(vec![vec![1.0, 2.0, 3.0], vec![4.0, 5.0, 6.0]]).unwrap();
+        let t = transpose(&a);
+        assert_eq!(t.shape(), &[3, 2]);
+        assert_eq!(t.get(0, 0), Some(1.0));
+        assert_eq!(t.get(2, 1), Some(6.0));
+        // Transpose is an involution.
+        assert_eq!(transpose(&t).data(), a.data());
+    }
+
+    #[test]
+    fn reductions() {
+        let a = Array::from_vec(vec![2.0, 4.0, 6.0, 8.0]);
+        assert_eq!(sum(&a), 20.0);
+        assert_eq!(mean(&a), 5.0);
+        assert_eq!(max(&a), 8.0);
+        assert_eq!(min(&a), 2.0);
+    }
+
+    #[test]
+    fn mean_of_empty_is_nan() {
+        let empty = Array::from_shape(vec![], vec![0, 0]).unwrap();
+        assert!(mean(&empty).is_nan());
+    }
+}

--- a/code/packages/rust/array-runtime/src/value.rs
+++ b/code/packages/rust/array-runtime/src/value.rs
@@ -1,0 +1,270 @@
+//! The N-D array value model — dense, rectangular, **column-major** `f64`.
+//!
+//! Column-major (Fortran/MATLAB) storage is deliberate: the first numeric-array
+//! frontend on this substrate is MATLAB, whose `reshape`, linear indexing, and
+//! `[a; b]` literal semantics all assume column-major order. Element `(r, c)` of
+//! an `[nrows, ncols]` matrix lives at flat index `c * nrows + r`.
+
+use std::fmt;
+
+/// A dense N-dimensional `f64` array. `shape == []` is a scalar, `[n]` a vector,
+/// `[r, c]` a matrix; higher ranks are stored but only rank ≤ 2 ops are defined
+/// in MA-1.
+#[derive(Clone, Debug, PartialEq)]
+pub struct Array {
+    data: Vec<f64>,
+    shape: Vec<usize>,
+}
+
+impl Array {
+    /// A length-1 (scalar) array.
+    pub fn scalar(value: f64) -> Array {
+        Array {
+            data: vec![value],
+            shape: vec![],
+        }
+    }
+
+    /// A 1-D array (a column vector's worth of values, shape `[n]`).
+    pub fn from_vec(data: Vec<f64>) -> Array {
+        let n = data.len();
+        Array {
+            data,
+            shape: vec![n],
+        }
+    }
+
+    /// Build a matrix from rows. All rows must be the same length; the data is
+    /// transposed into column-major order on the way in.
+    pub fn from_rows(rows: Vec<Vec<f64>>) -> Result<Array, String> {
+        let nrows = rows.len();
+        if nrows == 0 {
+            return Ok(Array {
+                data: vec![],
+                shape: vec![0, 0],
+            });
+        }
+        let ncols = rows[0].len();
+        if rows.iter().any(|r| r.len() != ncols) {
+            return Err("from_rows: ragged rows".into());
+        }
+        let mut data = vec![0.0; nrows * ncols];
+        for (r, row) in rows.iter().enumerate() {
+            for (c, &v) in row.iter().enumerate() {
+                data[c * nrows + r] = v; // column-major store
+            }
+        }
+        Ok(Array {
+            data,
+            shape: vec![nrows, ncols],
+        })
+    }
+
+    /// Wrap raw column-major data with an explicit shape (the product of the
+    /// dims must equal the data length).
+    pub fn from_shape(data: Vec<f64>, shape: Vec<usize>) -> Result<Array, String> {
+        let n: usize = shape
+            .iter()
+            .product::<usize>()
+            .max(if shape.is_empty() { 1 } else { 0 });
+        if n != data.len() {
+            return Err(format!(
+                "from_shape: shape {shape:?} implies {n} elements, got {}",
+                data.len()
+            ));
+        }
+        Ok(Array { data, shape })
+    }
+
+    /// An `[rows, cols]` array of zeros / ones / a constant.
+    pub fn filled(rows: usize, cols: usize, value: f64) -> Array {
+        Array {
+            data: vec![value; rows * cols],
+            shape: vec![rows, cols],
+        }
+    }
+    pub fn zeros(rows: usize, cols: usize) -> Array {
+        Array::filled(rows, cols, 0.0)
+    }
+    pub fn ones(rows: usize, cols: usize) -> Array {
+        Array::filled(rows, cols, 1.0)
+    }
+
+    /// The `n × n` identity matrix.
+    pub fn eye(n: usize) -> Array {
+        let mut a = Array::zeros(n, n);
+        for i in 0..n {
+            a.data[i * n + i] = 1.0;
+        }
+        a
+    }
+
+    // --- accessors ------------------------------------------------------
+
+    pub fn shape(&self) -> &[usize] {
+        &self.shape
+    }
+    pub fn data(&self) -> &[f64] {
+        &self.data
+    }
+    pub fn ndims(&self) -> usize {
+        self.shape.len()
+    }
+    pub fn len(&self) -> usize {
+        self.data.len()
+    }
+    pub fn is_empty(&self) -> bool {
+        self.data.is_empty()
+    }
+    pub fn is_scalar(&self) -> bool {
+        self.data.len() == 1
+    }
+
+    /// Rows / columns, treating a scalar as 1×1 and a vector `[n]` as `n×1`.
+    pub fn nrows(&self) -> usize {
+        match self.shape.as_slice() {
+            [] => 1,
+            [n] => *n,
+            [r, _, ..] => *r,
+        }
+    }
+    pub fn ncols(&self) -> usize {
+        match self.shape.as_slice() {
+            [] => 1,
+            [_] => 1,
+            [_, c, ..] => *c,
+        }
+    }
+
+    /// Element `(r, c)` (column-major), or `None` if out of bounds.
+    pub fn get(&self, r: usize, c: usize) -> Option<f64> {
+        if r < self.nrows() && c < self.ncols() {
+            self.data.get(c * self.nrows() + r).copied()
+        } else {
+            None
+        }
+    }
+}
+
+impl fmt::Display for Array {
+    /// MATLAB-ish display: a scalar prints bare; a matrix prints right-aligned
+    /// rows.
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if self.is_scalar() {
+            return write!(f, "{}", fmt_num(self.data[0]));
+        }
+        let (rows, cols) = (self.nrows(), self.ncols());
+        let cells: Vec<String> = self.data.iter().map(|&x| fmt_num(x)).collect();
+        let width = cells.iter().map(|s| s.len()).max().unwrap_or(1);
+        for r in 0..rows {
+            for c in 0..cols {
+                let cell = &cells[c * rows + r];
+                write!(f, "{}{cell:>width$}", if c == 0 { "" } else { "  " })?;
+            }
+            if r + 1 < rows {
+                writeln!(f)?;
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Integer-valued doubles print without a decimal point (`3`, not `3.0`).
+fn fmt_num(x: f64) -> String {
+    if x.is_finite() && x.fract() == 0.0 && x.abs() < 1e15 {
+        format!("{}", x as i64)
+    } else {
+        format!("{x}")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn scalar_is_rank0_length1() {
+        let s = Array::scalar(42.0);
+        assert!(s.is_scalar());
+        assert_eq!(s.ndims(), 0);
+        assert_eq!(s.shape(), &[] as &[usize]);
+        assert_eq!(s.nrows(), 1);
+        assert_eq!(s.ncols(), 1);
+        assert_eq!(s.get(0, 0), Some(42.0));
+    }
+
+    #[test]
+    fn vector_shape_and_dims() {
+        let v = Array::from_vec(vec![1.0, 2.0, 3.0]);
+        assert_eq!(v.shape(), &[3]);
+        assert_eq!(v.ndims(), 1);
+        assert_eq!(v.nrows(), 3);
+        assert_eq!(v.ncols(), 1); // a vector is a column
+        assert!(!v.is_scalar());
+        assert!(!v.is_empty());
+    }
+
+    #[test]
+    fn from_rows_stores_column_major() {
+        // Row-major rows [[1,2,3],[4,5,6]] become column-major [1,4,2,5,3,6].
+        let a = Array::from_rows(vec![vec![1.0, 2.0, 3.0], vec![4.0, 5.0, 6.0]]).unwrap();
+        assert_eq!(a.shape(), &[2, 3]);
+        assert_eq!(a.data(), &[1.0, 4.0, 2.0, 5.0, 3.0, 6.0]);
+        assert_eq!(a.get(0, 0), Some(1.0));
+        assert_eq!(a.get(1, 2), Some(6.0));
+        assert_eq!(a.get(0, 2), Some(3.0));
+    }
+
+    #[test]
+    fn from_rows_empty_and_ragged() {
+        let empty = Array::from_rows(vec![]).unwrap();
+        assert_eq!(empty.shape(), &[0, 0]);
+        assert!(empty.is_empty());
+        assert!(Array::from_rows(vec![vec![1.0, 2.0], vec![3.0]]).is_err());
+    }
+
+    #[test]
+    fn from_shape_validates_element_count() {
+        assert!(Array::from_shape(vec![1.0, 2.0, 3.0, 4.0], vec![2, 2]).is_ok());
+        assert!(Array::from_shape(vec![1.0, 2.0, 3.0], vec![2, 2]).is_err());
+        // A scalar shape [] implies exactly one element.
+        assert!(Array::from_shape(vec![7.0], vec![]).is_ok());
+        assert!(Array::from_shape(vec![7.0, 8.0], vec![]).is_err());
+    }
+
+    #[test]
+    fn constructors_zeros_ones_filled_eye() {
+        assert_eq!(Array::zeros(2, 2).data(), &[0.0; 4]);
+        assert_eq!(Array::ones(1, 3).data(), &[1.0; 3]);
+        assert_eq!(Array::filled(2, 1, 9.0).data(), &[9.0, 9.0]);
+        let i = Array::eye(3);
+        assert_eq!(i.shape(), &[3, 3]);
+        // Identity has 1s on the diagonal, 0 elsewhere.
+        for r in 0..3 {
+            for c in 0..3 {
+                assert_eq!(i.get(r, c), Some(if r == c { 1.0 } else { 0.0 }));
+            }
+        }
+    }
+
+    #[test]
+    fn get_out_of_bounds_is_none() {
+        let a = Array::from_rows(vec![vec![1.0, 2.0]]).unwrap(); // 1x2
+        assert_eq!(a.get(0, 1), Some(2.0));
+        assert_eq!(a.get(1, 0), None); // row OOB
+        assert_eq!(a.get(0, 2), None); // col OOB
+    }
+
+    #[test]
+    fn display_scalar_and_integer_valued() {
+        assert_eq!(format!("{}", Array::scalar(3.0)), "3"); // no trailing .0
+        assert_eq!(format!("{}", Array::scalar(2.5)), "2.5");
+    }
+
+    #[test]
+    fn display_matrix_is_row_aligned() {
+        let a = Array::from_rows(vec![vec![1.0, 20.0], vec![300.0, 4.0]]).unwrap();
+        // Right-aligned to the widest cell ("300"), rows separated by newlines.
+        assert_eq!(format!("{a}"), "  1   20\n300    4");
+    }
+}

--- a/code/packages/rust/array-runtime/src/value.rs
+++ b/code/packages/rust/array-runtime/src/value.rs
@@ -48,7 +48,10 @@ impl Array {
         if rows.iter().any(|r| r.len() != ncols) {
             return Err("from_rows: ragged rows".into());
         }
-        let mut data = vec![0.0; nrows * ncols];
+        let n = nrows
+            .checked_mul(ncols)
+            .ok_or_else(|| "from_rows: nrows * ncols overflows usize".to_string())?;
+        let mut data = vec![0.0; n];
         for (r, row) in rows.iter().enumerate() {
             for (c, &v) in row.iter().enumerate() {
                 data[c * nrows + r] = v; // column-major store
@@ -63,10 +66,23 @@ impl Array {
     /// Wrap raw column-major data with an explicit shape (the product of the
     /// dims must equal the data length).
     pub fn from_shape(data: Vec<f64>, shape: Vec<usize>) -> Result<Array, String> {
-        let n: usize = shape
-            .iter()
-            .product::<usize>()
-            .max(if shape.is_empty() { 1 } else { 0 });
+        // Element count = product of the dims (an empty shape `[]` is a scalar →
+        // exactly one element). Use *checked* multiplication: a crafted shape
+        // whose product overflows `usize` must not wrap to a small count that
+        // spuriously passes the length check below and leaves `shape`
+        // disagreeing with `data.len()` — an invariant the indexing and
+        // `Display` code rely on (they compute offsets from `nrows()/ncols()`,
+        // not from `data.len()`).
+        let n: usize = if shape.is_empty() {
+            1
+        } else {
+            shape
+                .iter()
+                .try_fold(1usize, |acc, &d| acc.checked_mul(d))
+                .ok_or_else(|| {
+                    format!("from_shape: shape {shape:?} element count overflows usize")
+                })?
+        };
         if n != data.len() {
             return Err(format!(
                 "from_shape: shape {shape:?} implies {n} elements, got {}",
@@ -78,8 +94,14 @@ impl Array {
 
     /// An `[rows, cols]` array of zeros / ones / a constant.
     pub fn filled(rows: usize, cols: usize, value: f64) -> Array {
+        // `checked_mul` turns an absurd `rows * cols` into a clean panic rather
+        // than a release-mode wrap that would under-allocate `data` and let
+        // `eye` (and later index math) write out of bounds.
+        let n = rows
+            .checked_mul(cols)
+            .expect("Array::filled: rows * cols overflows usize");
         Array {
-            data: vec![value; rows * cols],
+            data: vec![value; n],
             shape: vec![rows, cols],
         }
     }
@@ -230,6 +252,23 @@ mod tests {
         // A scalar shape [] implies exactly one element.
         assert!(Array::from_shape(vec![7.0], vec![]).is_ok());
         assert!(Array::from_shape(vec![7.0, 8.0], vec![]).is_err());
+    }
+
+    #[test]
+    fn from_shape_rejects_overflowing_product() {
+        // A shape whose element count overflows usize must be an error, not a
+        // wrapped-small count that spuriously matches a short data vector.
+        let huge = vec![1.0]; // pretend a 1-element buffer
+        let shape = vec![usize::MAX, 2]; // product wraps
+        assert!(Array::from_shape(huge, shape).is_err());
+    }
+
+    #[test]
+    #[should_panic(expected = "overflows usize")]
+    fn filled_panics_on_overflowing_dims() {
+        // Deterministic panic (not a silent release-mode wrap that would
+        // under-allocate and corrupt later index math).
+        let _ = Array::filled(usize::MAX, 2, 0.0);
     }
 
     #[test]

--- a/code/specs/MA00-array-runtime.md
+++ b/code/specs/MA00-array-runtime.md
@@ -1,0 +1,134 @@
+# MA00 — array-runtime: the shared N-D array substrate for numeric languages
+
+## Status
+
+Active spec. `array-runtime` is **Wave 0** of the historical math-languages
+roadmap ([`HML00`](HML00-historical-math-languages-roadmap.md)): the N-dimensional
+numeric-array value model that every numerical/array-language frontend (MATLAB,
+Octave, Scilab, APL, J, IDL) sits on — the array-family analogue of what
+`r-vector`/`s-runtime` are to the statistical-language family. It is built once
+and reused by all of them.
+
+## §1 Why a shared array substrate
+
+The array languages differ mostly in *syntax*; underneath they share one value
+model — dense, rectangular, column-major numeric arrays with broadcasting,
+reshaping, linear algebra, and reductions. Building that once means each
+frontend (MATLAB first) is a thin lexer/parser/runtime over `array-runtime`,
+exactly as R was a thin frontend over the shared S evaluator.
+
+## §2 Modern hardware: GPU dispatch by lowering, not by syntax
+
+Per [`HML00`](HML00-historical-math-languages-roadmap.md) §4, array operations
+do **not** hand-roll GPU code. They lower to **`matrix-ir`** (a tensor-algebra
+DAG) and submit the graph to **`matrix-runtime`**, whose cost-based planner
+assigns each op to the cheapest available backend — **CPU, CUDA, or Metal** —
+from a FLOP + dtype + host↔device-transfer cost model, with CPU as the
+always-available fallback. So `A * B` runs on the GPU exactly when the matrices
+are large enough to beat transfer overhead, and on the CPU otherwise, with no
+language-level GPU code and no "use GPU" keyword.
+
+### What this PR (MA-1) delivers vs. defers
+
+- **Delivered now:** the `Array` value model + a correct CPU **reference**
+  implementation of the core ops (so results are exact today), **and** the
+  `matrix-ir` lowering + `matrix-runtime` cost-planner integration — i.e. each
+  op can be lowered to a `matrix-ir` graph and *planned*, and the planner's
+  backend choice is observable and tested (a large `matmul` with a GPU profile
+  registered plans onto the GPU; a small one stays on the CPU).
+- **Deferred (next MA item):** routing actual *execution* of the planned
+  `ComputeGraph` through the registered executors. `matrix-runtime`'s public API
+  currently *plans* (cost-based placement) but does not yet orchestrate
+  execution end-to-end, and the GPU executor crates are not yet registered. Once
+  that execution path lands, `array-runtime` switches its compute from the CPU
+  reference path to the planned executors with **no API change** — the lowering
+  and dispatch decision are already wired here. Until then the reference path
+  guarantees correct results and the planner integration guarantees the dispatch
+  decision is right.
+
+This staging keeps every PR correct and mergeable while building the GPU path
+incrementally.
+
+## §3 The value model
+
+```rust
+pub struct Array {
+    data: Vec<f64>,       // column-major (Fortran/MATLAB order)
+    shape: Vec<usize>,    // dims; [] = scalar, [n] = vector, [r, c] = matrix
+}
+```
+
+- **Column-major** storage, matching MATLAB/Fortran (so a future MATLAB frontend
+  is a direct map and `reshape`/linear-indexing match).
+- Constructors: `scalar`, `from_vec` (1-D), `from_rows`/`from_cols` (2-D),
+  `zeros`, `ones`, `eye`, `filled`.
+- Accessors: `shape`, `ndims`, `nrows`, `ncols`, `len`, `get(idx)`, `data()`.
+- `Display`: MATLAB-style aligned rows.
+
+## §4 Operations (CPU reference; GPU-dispatch-ready)
+
+- **Elementwise** `add/sub/mul/div` with **broadcasting** (scalar↔array, and
+  equal-shape), NaN/Inf propagating naturally.
+- **Linear algebra**: `matmul` (2-D `[m,k] · [k,n] → [m,n]`), `transpose`.
+- **Reductions**: `sum`, `mean`, `max`, `min` (whole-array; axis reductions
+  follow).
+- **Shape**: `reshape`.
+
+Each op has a CPU reference body **and** a `matrix-ir` lowering (§5). The
+reference body is what produces values today; the lowering is what the planner
+uses to decide hardware placement.
+
+## §5 Lowering + planning (the GPU brain)
+
+`accel` lowers an op to a `matrix-ir::Graph` via `matrix_ir::GraphBuilder` and
+plans it with `matrix_runtime::Runtime`:
+
+```text
+Array op  ──▶  matrix_ir::GraphBuilder (add/mul/matmul/…)  ──▶  Graph
+                                                                  │
+                                  matrix_runtime::Runtime::plan(&graph)
+                                                                  │
+                                                                  ▼
+                                              compute_ir::ComputeGraph
+                                              (each op placed on cpu/cuda/metal
+                                               by the cost model)
+```
+
+`plan_backend(op, shapes) -> &'static str` returns the executor *kind* the
+planner chose ("cpu"/"gpu"), so the dispatch decision is testable. The runtime
+is constructed with `matrix_cpu::profile()` (CPU always present); a GPU profile
+can be registered to exercise the cost model. (`matrix-ir` uses `f32`/`Shape`
+with `u32` dims; `array-runtime` works in `f64` and converts at the lowering
+boundary.)
+
+## §6 Crate layout & dependencies
+
+```
+array-runtime/
+  src/{lib.rs, value.rs, ops.rs, accel.rs}
+```
+
+```toml
+[dependencies]
+matrix-ir = { path = "../matrix-ir" }
+matrix-runtime = { path = "../matrix-runtime" }
+compute-ir = { path = "../compute-ir" }
+executor-protocol = { path = "../executor-protocol" }
+matrix-cpu = { path = "../matrix-cpu" }
+```
+
+## §7 Roadmap fit
+
+- **MA-1** *(this PR)*: value model + CPU reference ops + matrix-ir lowering /
+  cost-planner integration (this spec).
+- **MA-2**: execution through the registered executors (CPU first), replacing the
+  reference compute with the planned `ComputeGraph` run — same API.
+- **MA-3+**: the MATLAB frontend (`matlab-lexer`/`matlab-parser`/`matlab-runtime`
+  + the `matlab`/`octave` binaries) on top of `array-runtime`; then APL, etc.,
+  per [`HML00`](HML00-historical-math-languages-roadmap.md).
+
+## §8 References
+
+Internal: [`HML00`](HML00-historical-math-languages-roadmap.md),
+[`MX00`](MX00-matrix-execution-overview.md), [`MX01`](MX01-matrix-ir.md),
+`matrix-runtime`, `executor-protocol`, `matrix-cpu`.


### PR DESCRIPTION
## What & why

**MA-1**, Wave 0 of the historical math-languages roadmap ([HML00](code/specs/HML00-historical-math-languages-roadmap.md)). `array-runtime` is the shared **N-dimensional numeric-array substrate** that every array/matrix-language frontend — MATLAB first, then Octave/Scilab/APL/J — will sit on. It is the array-family analogue of the shared S evaluator that R reuses: build the value model + ops once, and each language becomes a thin lexer/parser/runtime on top.

Spec: [MA00-array-runtime.md](code/specs/MA00-array-runtime.md).

## The three parts

- **`value.rs` — the `Array` value model.** Dense, rectangular, **column-major** `f64` (Fortran/MATLAB order: element `(r,c)` at `c*nrows+r`), chosen so a future MATLAB frontend maps directly (`reshape`, linear indexing, `[a;b]`). Constructors `scalar`/`from_vec`/`from_rows`/`from_shape`/`zeros`/`ones`/`filled`/`eye`; `get`/`shape`/`nrows`/`ncols`/… accessors; MATLAB-ish aligned `Display`.
- **`ops.rs` — CPU reference ops** that produce values **today**: elementwise `add`/`sub`/`mul`/`div` with scalar broadcasting, `matmul`, `transpose`, `sum`/`mean`/`max`/`min`.
- **`accel.rs` — GPU dispatch by lowering.** Each op lowers to a `matrix-ir` graph and is handed to `matrix-runtime`'s cost-based planner, which places it on the cheapest backend (CPU/CUDA/Metal) from a FLOP + transfer cost model. `plan_backend(kernel, shapes, with_gpu)` returns the chosen executor kind, so the decision is **observable and tested**: a large `matmul` with a GPU profile registered plans onto the GPU; small ops stay on the CPU. **No language-level GPU code, no "use GPU" keyword.**

## Delivered vs. deferred

- **Now:** value model + correct CPU reference ops + the full `matrix-ir` lowering and cost-planner integration (dispatch decision observable & tested).
- **MA-2:** routing actual *execution* of the planned `ComputeGraph` through the registered executors. `matrix-runtime` currently *plans* placement but does not yet orchestrate execution end-to-end; the switch will need **no public API change**.

## Tests / quality

- 28 tests (27 unit + 1 doctest), **100% line coverage** (value 85/85, ops 60/60, accel 44/44).
- `cargo fmt` + `cargo clippy` clean.
- Two rounds of `/security-review` → **PASSED**. Round 1 flagged latent overflow/truncation footguns (foundational substrate); hardened with checked arithmetic in `from_shape`/`filled`/`from_rows`/`matmul` and a checked `usize→u32` cast in `accel::shape_of`, with regression tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)