### PR TITLE
fix(sql-codegen): give unnamed Literal projections SQLite-compatible column names

### DIFF
--- a/code/packages/python/mini-sqlite/CHANGELOG.md
+++ b/code/packages/python/mini-sqlite/CHANGELOG.md
@@ -1,5 +1,36 @@
 # Changelog
 
+## [2.22.0] - 2026-06-16
+
+### Fixed
+
+- **`SELECT * FROM (SELECT 1, 2)` now returns `(1, 2)` instead of `(2,)`** —
+  when a derived-table subquery contains unnamed literal columns (e.g.
+  ``SELECT 1, 2``), the column names are now ``"1"`` and ``"2"`` (matching
+  SQLite's surface representation) instead of ``"?"`` for every column.
+
+  Root cause: ``_column_display_name()`` in sql-codegen returned ``None``
+  for ``Literal`` nodes, so every constant projection fell back to the
+  placeholder ``"?"``.  Two identical ``"?"`` keys in the same result set
+  caused ``dict(zip(cols, row))`` inside the VM's ``_do_run_subquery`` to
+  drop all columns but the last.  (sql-codegen v1.43.0)
+
+  The fix applies to all literal types:
+
+  | SQL expression | Column name before | Column name after |
+  |----------------|--------------------|-------------------|
+  | ``SELECT 1``   | ``"?"``            | ``"1"``           |
+  | ``SELECT 1, 2``| ``"?", "?"``       | ``"1", "2"``      |
+  | ``SELECT NULL``| ``"?"``            | ``"NULL"``        |
+  | ``SELECT 'hi'``| ``"?"``            | ``"'hi'"``        |
+
+- **21 new oracle tests** in ``test_tier3_subquery_literal_colnames.py``
+  cover column-name accuracy and row-value correctness for all literal
+  types, with byte-for-byte comparison against stdlib ``sqlite3``.
+- **10 new unit tests** in the sql-codegen test suite cover
+  ``_column_display_name`` directly, pushing sql-codegen coverage to
+  **80.48 %** (from the borderline pre-existing 79.61 %).
+
 ## [2.21.0] - 2026-06-16
 
 ### Fixed

--- a/code/packages/python/mini-sqlite/pyproject.toml
+++ b/code/packages/python/mini-sqlite/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-mini-sqlite"
-version = "2.21.0"
+version = "2.22.0"
 description = "PEP 249 DB-API 2.0 facade over the sql-lexer / parser / planner / optimizer / codegen / vm / backend stack."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/mini-sqlite/tests/test_tier3_subquery_literal_colnames.py
+++ b/code/packages/python/mini-sqlite/tests/test_tier3_subquery_literal_colnames.py
@@ -1,0 +1,142 @@
+"""Oracle tests for literal-column display names and SELECT * from derived tables.
+
+Root cause fixed: _column_display_name() in sql-codegen now returns the
+SQLite-compatible surface representation for Literal expressions (e.g. "1",
+"'hi'", "NULL").  Previously every unnamed literal got "?", so two integer
+columns in the same projection both had key "?" and dict(zip(cols, row)) lost
+all but the last value.
+
+Every test below is an oracle check — both sqlite3 and mini_sqlite run the
+same SQL and we assert the results are byte-for-byte identical.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+import pytest
+
+import mini_sqlite
+
+
+def _both(sql: str, setup: list[str] | None = None) -> tuple[list[tuple], list[tuple]]:
+    """Return (ref_rows, our_rows) for the given SQL."""
+    ref = sqlite3.connect(":memory:")
+    ours = mini_sqlite.connect(":memory:")
+    for s in setup or []:
+        ref.execute(s)
+        ours.execute(s)
+    return ref.execute(sql).fetchall(), ours.execute(sql).fetchall()
+
+
+def _cols(sql: str, setup: list[str] | None = None) -> tuple[list[str], list[str]]:
+    """Return (ref_col_names, our_col_names) for the given SQL."""
+    ref = sqlite3.connect(":memory:")
+    ours = mini_sqlite.connect(":memory:")
+    for s in setup or []:
+        ref.execute(s)
+        ours.execute(s)
+    rc = ref.cursor()
+    oc = ours.cursor()
+    rc.execute(sql)
+    oc.execute(sql)
+    return [d[0] for d in rc.description], [d[0] for d in oc.description]
+
+
+# ---------------------------------------------------------------------------
+# Column names for bare literal projections
+# ---------------------------------------------------------------------------
+
+
+class TestLiteralColumnNames:
+    """cursor.description column names for unnamed literal expressions."""
+
+    def test_integer_literal_column_name(self) -> None:
+        ref_cols, our_cols = _cols("SELECT 1")
+        assert our_cols == ref_cols  # SQLite: ["1"]
+
+    def test_two_integer_literals_have_distinct_names(self) -> None:
+        ref_cols, our_cols = _cols("SELECT 1, 2")
+        assert our_cols == ref_cols  # SQLite: ["1", "2"]
+
+    def test_three_integer_literals_distinct_names(self) -> None:
+        ref_cols, our_cols = _cols("SELECT 1, 2, 3")
+        assert our_cols == ref_cols
+
+    def test_null_literal_column_name(self) -> None:
+        ref_cols, our_cols = _cols("SELECT NULL")
+        assert our_cols == ref_cols  # SQLite: ["NULL"]
+
+    def test_string_literal_column_name(self) -> None:
+        ref_cols, our_cols = _cols("SELECT 'hello'")
+        assert our_cols == ref_cols  # SQLite: ["'hello'"]
+
+    def test_float_literal_column_name(self) -> None:
+        ref_cols, our_cols = _cols("SELECT 1.5")
+        assert our_cols == ref_cols  # SQLite: ["1.5"]
+
+    def test_alias_overrides_display_name(self) -> None:
+        ref_cols, our_cols = _cols("SELECT 1 AS one")
+        assert our_cols == ref_cols  # SQLite: ["one"]
+
+
+# ---------------------------------------------------------------------------
+# SELECT * FROM subquery with unnamed literal columns
+# ---------------------------------------------------------------------------
+
+
+class TestSubqueryLiteralColumns:
+    """SELECT * from derived tables containing unnamed literal expressions."""
+
+    def test_select_star_from_two_int_literals(self) -> None:
+        ref, ours = _both("SELECT * FROM (SELECT 1, 2)")
+        assert ours == ref  # was (2,) — now (1, 2)
+
+    def test_select_star_from_three_int_literals(self) -> None:
+        ref, ours = _both("SELECT * FROM (SELECT 1, 2, 3)")
+        assert ours == ref  # was (3,) — now (1, 2, 3)
+
+    def test_select_star_from_null_and_int(self) -> None:
+        ref, ours = _both("SELECT * FROM (SELECT NULL, 1)")
+        assert ours == ref
+
+    def test_select_star_from_string_literals(self) -> None:
+        ref, ours = _both("SELECT * FROM (SELECT 'a', 'b')")
+        assert ours == ref
+
+    def test_select_star_from_mixed_literal_and_alias(self) -> None:
+        ref, ours = _both("SELECT * FROM (SELECT 1 AS x, 2)")
+        assert ours == ref
+
+    def test_select_star_from_all_aliased(self) -> None:
+        ref, ours = _both("SELECT * FROM (SELECT 1 AS a, 2 AS b)")
+        assert ours == ref
+
+    def test_select_star_from_single_int_literal(self) -> None:
+        ref, ours = _both("SELECT * FROM (SELECT 1)")
+        assert ours == ref
+
+    def test_select_star_from_real_table_columns_unchanged(self) -> None:
+        setup = ["CREATE TABLE t(a INT, b INT)", "INSERT INTO t VALUES (10, 20)"]
+        ref, ours = _both("SELECT * FROM (SELECT a, b FROM t)", setup)
+        assert ours == ref
+
+    def test_subquery_value_correctness_first_col(self) -> None:
+        # Make sure we get the FIRST column's value, not the last
+        ref, ours = _both("SELECT * FROM (SELECT 42, 99)")
+        assert ours == [(42, 99)]
+        assert ours == ref
+
+    def test_subquery_value_correctness_ordering(self) -> None:
+        ref, ours = _both("SELECT * FROM (SELECT 10, 20, 30)")
+        assert ours == [(10, 20, 30)]
+        assert ours == ref
+
+
+class TestLiteralRoundTrips:
+    """Parametric round-trip checks for bare integer literals."""
+
+    @pytest.mark.parametrize("val", [0, -1, 100, 9999])
+    def test_integer_literal_round_trips(self, val: int) -> None:
+        ref, ours = _both(f"SELECT {val}")
+        assert ours == ref

--- a/code/packages/python/sql-codegen/CHANGELOG.md
+++ b/code/packages/python/sql-codegen/CHANGELOG.md
@@ -1,5 +1,36 @@
 # Changelog
 
+## [1.43.0] - 2026-06-16
+
+### Fixed
+
+- **Literal expressions now get SQLite-compatible column display names** —
+  `_column_display_name()` previously returned `None` for `Literal` nodes,
+  causing `_projection_name()` to fall back to `"?"` for every unnamed
+  constant expression.  When a single ``SELECT`` had two or more literal
+  columns (e.g. ``SELECT 1, 2``), both columns received the key ``"?"``,
+  and the VM's ``_do_run_subquery()`` converted rows to dicts via
+  ``dict(zip(cols, row))``, silently losing all but the last value.
+
+  Fix: ``_column_display_name`` now handles ``Literal`` by returning the
+  surface representation SQLite uses:
+
+  | Literal type | Display name example  |
+  |--------------|-----------------------|
+  | `int`        | `"1"`, `"42"`         |
+  | `float`      | `"1.5"`, `"3.14"`     |
+  | `str`        | `"'hello'"`           |
+  | `bytes`      | `"X'DEADBEEF'"`       |
+  | `None`       | `"NULL"`              |
+
+  This makes ``SELECT 1, 2`` produce column names ``("1", "2")`` instead
+  of ``("?", "?")``, fixing ``SELECT * FROM (SELECT 1, 2)`` which
+  previously returned ``(2,)`` instead of the correct ``(1, 2)``.
+
+- **RowIdRef now covered in ``_column_display_name``** — added unit tests
+  that exercise both the ``RowIdRef → "rowid"`` branch and the new
+  ``Literal`` branch, bringing overall package coverage to **80.48 %**.
+
 ## [1.42.0] - 2026-06-16
 
 ### Fixed

--- a/code/packages/python/sql-codegen/pyproject.toml
+++ b/code/packages/python/sql-codegen/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-sql-codegen"
-version = "1.42.0"
+version = "1.43.0"
 description = "Compiles LogicalPlan trees into flat IR bytecode for the sql-vm."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/sql-codegen/src/sql_codegen/compiler.py
+++ b/code/packages/python/sql-codegen/src/sql_codegen/compiler.py
@@ -477,6 +477,22 @@ def _column_display_name(expr: Expr) -> str | None:
         # display name.  This makes ``ORDER BY rowid`` find the column
         # emitted by ``SELECT rowid, ...`` via its alias.
         return "rowid"
+    if isinstance(expr, Literal):
+        # SQLite names unnamed literal columns by their surface representation:
+        #   SELECT 1      → column "1"
+        #   SELECT 'hi'   → column "'hi'"
+        #   SELECT NULL   → column "NULL"
+        # Without this, every Literal falls back to "?" and duplicate-column
+        # dicts in _do_run_subquery lose all but the last value — causing
+        # SELECT * FROM (SELECT 1, 2) to return (2,) instead of (1, 2).
+        v = expr.value
+        if v is None:
+            return "NULL"
+        if isinstance(v, str):
+            return f"'{v}'"
+        if isinstance(v, bytes):
+            return "X'" + v.hex().upper() + "'"
+        return str(v)  # int, float, bool
     return None
 
 

--- a/code/packages/python/sql-codegen/tests/test_select.py
+++ b/code/packages/python/sql-codegen/tests/test_select.py
@@ -12,7 +12,9 @@ from sql_planner import (
     Literal,
     Project,
     ProjectionItem,
+    RowIdRef,
     Scan,
+    SingleRow,
     Sort,
     Wildcard,
 )
@@ -266,3 +268,104 @@ class TestSchema:
         assert prog.result_schema == ("renamed", "y")
         schemas = [i for i in prog.instructions if isinstance(i, SetResultSchema)]
         assert schemas[0].columns == ("renamed", "y")
+
+    # ------------------------------------------------------------------
+    # Literal column display names
+    # ------------------------------------------------------------------
+    # SQLite names an unnamed literal column by its surface representation:
+    #   SELECT 1     → column "1"   (not "?")
+    #   SELECT 'hi'  → column "'hi'"
+    #   SELECT NULL  → column "NULL"
+    # Without this, two integer literals in the same SELECT both get "?"
+    # and dict(zip(cols, row)) in the VM loses all but the last value.
+    # ------------------------------------------------------------------
+
+    def test_integer_literal_schema_name(self) -> None:
+        plan = Project(
+            input=SingleRow(),
+            items=(ProjectionItem(expr=Literal(1), alias=None),),
+        )
+        prog = compile(plan)
+        assert prog.result_schema == ("1",)
+
+    def test_two_integer_literals_get_distinct_names(self) -> None:
+        plan = Project(
+            input=SingleRow(),
+            items=(
+                ProjectionItem(expr=Literal(1), alias=None),
+                ProjectionItem(expr=Literal(2), alias=None),
+            ),
+        )
+        prog = compile(plan)
+        assert prog.result_schema == ("1", "2")
+
+    def test_three_integer_literals_schema_names(self) -> None:
+        plan = Project(
+            input=SingleRow(),
+            items=(
+                ProjectionItem(expr=Literal(1), alias=None),
+                ProjectionItem(expr=Literal(2), alias=None),
+                ProjectionItem(expr=Literal(3), alias=None),
+            ),
+        )
+        prog = compile(plan)
+        assert prog.result_schema == ("1", "2", "3")
+
+    def test_null_literal_schema_name(self) -> None:
+        plan = Project(
+            input=SingleRow(),
+            items=(ProjectionItem(expr=Literal(None), alias=None),),
+        )
+        prog = compile(plan)
+        assert prog.result_schema == ("NULL",)
+
+    def test_string_literal_schema_name(self) -> None:
+        plan = Project(
+            input=SingleRow(),
+            items=(ProjectionItem(expr=Literal("hello"), alias=None),),
+        )
+        prog = compile(plan)
+        assert prog.result_schema == ("'hello'",)
+
+    def test_float_literal_schema_name(self) -> None:
+        plan = Project(
+            input=SingleRow(),
+            items=(ProjectionItem(expr=Literal(3.14), alias=None),),
+        )
+        prog = compile(plan)
+        assert prog.result_schema == ("3.14",)
+
+    def test_bytes_literal_schema_name(self) -> None:
+        plan = Project(
+            input=SingleRow(),
+            items=(ProjectionItem(expr=Literal(b"\xde\xad"), alias=None),),
+        )
+        prog = compile(plan)
+        assert prog.result_schema == ("X'DEAD'",)
+
+    def test_rowid_ref_schema_name(self) -> None:
+        plan = Project(
+            input=Scan(table="t", alias="t"),
+            items=(ProjectionItem(expr=RowIdRef(table="t"), alias=None),),
+        )
+        prog = compile(plan)
+        assert prog.result_schema == ("rowid",)
+
+    def test_alias_overrides_literal_name(self) -> None:
+        plan = Project(
+            input=SingleRow(),
+            items=(ProjectionItem(expr=Literal(42), alias="answer"),),
+        )
+        prog = compile(plan)
+        assert prog.result_schema == ("answer",)
+
+    def test_mixed_literal_and_column(self) -> None:
+        plan = Project(
+            input=Scan(table="t", alias="t"),
+            items=(
+                ProjectionItem(expr=Literal(99), alias=None),
+                ProjectionItem(expr=Column("t", "name"), alias=None),
+            ),
+        )
+        prog = compile(plan)
+        assert prog.result_schema == ("99", "name")


### PR DESCRIPTION
## Summary

- `SELECT 1, 2` previously gave both columns the name `"?"` — causing `SELECT * FROM (SELECT 1, 2)` to return `(2,)` instead of `(1, 2)` because `dict(zip(("?","?"), (1,2)))` drops the first key
- Fixed `_column_display_name()` in sql-codegen to return SQLite's surface representation for `Literal` nodes (`"1"`, `"'hello'"`, `"NULL"`, `"X'DEAD'"`)
- Pushed `sql-codegen` coverage from the borderline-failing 79.61% to **80.48%** with 10 new unit tests covering all Literal types + RowIdRef
- 21 new oracle tests in mini-sqlite verify byte-for-byte parity with `sqlite3`

**Packages bumped:** sql-codegen 1.42.0 → 1.43.0 · mini-sqlite 2.21.0 → 2.22.0

## Test plan

- [ ] `sql-codegen` tests: 92 passed, coverage 80.48% ✅
- [ ] `mini-sqlite` full suite: 2876 passed, coverage 91.15% ✅
- [ ] Oracle probe: `SELECT * FROM (SELECT 1, 2)` → `[(1, 2)]` matching `sqlite3` ✅
- [ ] All literal types tested: `int`, `float`, `str`, `bytes`, `None` ✅
- [ ] Pre-existing tests unchanged ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)