### PR TITLE
feat(r-lang): the d/p/q/r distribution family (R-8)

### DIFF
--- a/code/packages/rust/r-runtime/CHANGELOG.md
+++ b/code/packages/rust/r-runtime/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.2.0] - 2026-06-16
+
+### Added (via the shared `s-runtime`)
+
+- **R-8 — the `d`/`p`/`q`/`r` distribution family**: `dnorm`/`pnorm`/`qnorm`/
+  `rnorm`, `dunif`/`punif`/`qunif`/`runif`, `dexp`/`pexp`/`qexp`/`rexp`, and
+  `set.seed`. R picks these up unchanged from the shared evaluator. See
+  `s-runtime` 0.3.0 for the full notes.
+
 ## [0.1.0] - 2026-06-16
 
 ### Added

--- a/code/packages/rust/r-runtime/src/lib.rs
+++ b/code/packages/rust/r-runtime/src/lib.rs
@@ -240,4 +240,17 @@ mod tests {
         // says so clearly rather than producing a wrong value.
         assert!(matches!(eval_r("1i\n"), Err(RError::TypeError(_))));
     }
+
+    #[test]
+    fn distribution_family_works_through_r() {
+        // R-8: d/p/q/r reach R unchanged via the shared evaluator, including the
+        // dotted name `set.seed` and the `mean =` named parameter.
+        assert_eq!(show("pnorm(0)\n"), "[1] 0.5");
+        assert_eq!(show("qunif(0.5)\n"), "[1] 0.5");
+        // set.seed makes rnorm reproducible across two fresh R sessions.
+        let a = nums("set.seed(123)\nrnorm(3, mean = 10)\n");
+        let b = nums("set.seed(123)\nrnorm(3, mean = 10)\n");
+        assert_eq!(a, b);
+        assert_eq!(a.len(), 3);
+    }
 }

--- a/code/packages/rust/s-runtime/CHANGELOG.md
+++ b/code/packages/rust/s-runtime/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.3.0] - 2026-06-16
+
+### Added
+
+- **Distribution family (R-8)** — the `d`/`p`/`q`/`r` probability functions
+  wired to `statistics-core`, for the closed-form continuous distributions:
+  - **Normal**: `dnorm`, `pnorm`, `qnorm`, `rnorm` (defaults `mean = 0`,
+    `sd = 1`).
+  - **Uniform**: `dunif`, `punif`, `qunif`, `runif` (`min = 0`, `max = 1`).
+  - **Exponential**: `dexp`, `pexp`, `qexp`, `rexp` (`rate = 1`).
+  - `set.seed(n)` to make the `r*` sampling stream reproducible.
+
+  `d*`/`p*`/`q*` vectorize over their first argument with NA-propagation;
+  distribution parameters are read by name (`sd =`) or position. `r*` draws from
+  a per-session R-compatible MT19937 generator; the sample count is capped at
+  `MAX_SEQ_LEN`, so `rnorm(1e18)` is a clean error rather than an OOM abort.
+
+### Changed
+
+- The `Interpreter` now carries a `RefCell<RngState>` (the session RNG) that
+  `set.seed` reseeds and the `r*` builtins draw from. `set.seed` returns
+  invisibly, alongside `print`/`cat`.
+
 ## [0.2.0] - 2026-06-15
 
 ### Added

--- a/code/packages/rust/s-runtime/README.md
+++ b/code/packages/rust/s-runtime/README.md
@@ -31,6 +31,9 @@ s-lexer → s-parser → GrammarASTNode → s-runtime (this crate) → s-repl
 - **v2** adds `%op%` infix operators, a broad builtin library, **S3 method
   dispatch** (a generic `print`), **factors**, and **data frames** (`$`,
   `[[ ]]`, 2-D indexing).
+- The **`d`/`p`/`q`/`r` distribution family** (R-8) over `statistics-core`:
+  density/CDF/quantile/sampling for the normal, uniform, and exponential
+  distributions, plus `set.seed` for a reproducible per-session RNG.
 
 ## Quick start
 

--- a/code/packages/rust/s-runtime/src/builtins.rs
+++ b/code/packages/rust/s-runtime/src/builtins.rs
@@ -11,6 +11,8 @@ use crate::error::{SError, SResult};
 use crate::eval::{nth_element, Interpreter};
 use crate::value::{bounded_sequence, class_of, combine, index, Arg, SValue, MAX_SEQ_LEN};
 use r_vector::{is_na_real, na_real, Double};
+use statistics_core::distributions::{dnorm, pnorm, qnorm, rnorm};
+use statistics_core::distributions_more::{dexp, dunif, pexp, punif, qexp, qunif, rexp, runif};
 use statistics_core::{descriptive, Number, StatsError};
 use std::collections::HashSet;
 
@@ -94,6 +96,22 @@ pub fn install(env: &Env) {
     define(env, "grep", builtin("grep", b_grep));
     define(env, "gsub", builtin("gsub", b_gsub));
     define(env, "sub", builtin("sub", b_sub));
+
+    // Distribution family (R-8): density (d*), distribution/CDF (p*),
+    // quantile (q*), and random sampling (r*), wired to statistics-core.
+    define(env, "set.seed", builtin("set.seed", b_set_seed));
+    define(env, "dnorm", builtin("dnorm", b_dnorm));
+    define(env, "pnorm", builtin("pnorm", b_pnorm));
+    define(env, "qnorm", builtin("qnorm", b_qnorm));
+    define(env, "rnorm", builtin("rnorm", b_rnorm));
+    define(env, "dunif", builtin("dunif", b_dunif));
+    define(env, "punif", builtin("punif", b_punif));
+    define(env, "qunif", builtin("qunif", b_qunif));
+    define(env, "runif", builtin("runif", b_runif));
+    define(env, "dexp", builtin("dexp", b_dexp));
+    define(env, "pexp", builtin("pexp", b_pexp));
+    define(env, "qexp", builtin("qexp", b_qexp));
+    define(env, "rexp", builtin("rexp", b_rexp));
 
     // String manipulation (vectorized over a character vector).
     define(env, "nchar", builtin("nchar", b_nchar));
@@ -1283,6 +1301,179 @@ fn apply_reducer(name: &str, f: Reducer, data: &Double, na_rm: bool) -> SResult<
         Ok(num) => Ok(SValue::scalar(num.to_f64_lossy())),
         Err(err) => Err(SError::Domain(format!("{name}: {}", describe(err)))),
     }
+}
+
+// ===========================================================================
+// Distribution family (R-8) — d/p/q/r over statistics-core
+// ===========================================================================
+//
+// R names probability functions with a one-letter prefix on the distribution:
+//
+//   prefix   meaning                  example         maps to
+//   ------   ----------------------   -------------   ----------------------
+//   d*       density / mass           dnorm(x)        statistics_core::…::dnorm
+//   p*       cumulative probability   pnorm(q)        …::pnorm  (CDF, P[X ≤ q])
+//   q*       quantile (inverse CDF)   qnorm(p)        …::qnorm  (the x with that p)
+//   r*       random sample of size n  rnorm(n)        …::rnorm  (draws from the RNG)
+//
+// `d*`/`p*`/`q*` are pure and **vectorized over their first argument** (the
+// quantile/probability vector); the distribution parameters (`mean`, `sd`,
+// `min`, `max`, `rate`) are read as scalars, by name or position, with R's
+// defaults. `r*` draws from the session generator on the `Interpreter`, so a
+// run of `set.seed(s); rnorm(3)` is reproducible. NA in the input propagates to
+// NA in the output, exactly as in R.
+//
+// Scope: the closed-form continuous families (normal, uniform, exponential).
+// Their density/CDF/quantile are O(1) and sampling is O(n), so there are no
+// input-driven unbounded loops — the only resource knob is `n`, which
+// [`sample_count`] caps at `MAX_SEQ_LEN`. Discrete families (binomial, Poisson),
+// whose CDF/sampling loop over a user-supplied count, are a separate follow-up.
+
+/// `set.seed(n)` — reseed the session RNG so subsequent `r*` draws are
+/// reproducible. Returns invisibly (`NULL`), like R.
+fn b_set_seed(interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
+    let seed = first_positional(args)?
+        .as_double()?
+        .get_value(0)
+        .filter(|v| v.is_finite())
+        .ok_or_else(|| SError::BadArgs("set.seed: seed must be a finite number".into()))?;
+    // R coerces the seed to a 32-bit integer; mirror that so `set.seed(1)`
+    // behaves the same here as there.
+    interp.reseed(seed.trunc() as i64 as u32 as u64);
+    Ok(SValue::Null)
+}
+
+/// Read distribution parameter `name` (or positional index `pos`) as a scalar,
+/// falling back to `default` when absent. Position 0 is the quantile/probability
+/// vector, so parameters start at position 1.
+fn dist_param(args: &[Arg], pos: usize, name: &str, default: f64) -> SResult<f64> {
+    let v = args
+        .iter()
+        .find(|a| a.name.as_deref() == Some(name))
+        .map(|a| &a.value)
+        .or_else(|| nth_positional(args, pos));
+    match v {
+        Some(sv) => Ok(sv.as_double()?.get_value(0).unwrap_or(default)),
+        None => Ok(default),
+    }
+}
+
+/// Interpret the first positional argument as a sample count for an `r*`
+/// function. Following R, a vector of length > 1 means "draw `length(n)`
+/// samples". The result is capped at [`MAX_SEQ_LEN`] and rejects non-finite or
+/// negative counts, so `rnorm(1e18)` is a clean error rather than an
+/// out-of-memory abort.
+fn sample_count(args: &[Arg]) -> SResult<usize> {
+    let nv = first_positional(args)?.as_double()?;
+    let n = if nv.len() > 1 {
+        nv.len()
+    } else {
+        let v = nv
+            .get_value(0)
+            .ok_or_else(|| SError::BadArgs("invalid arguments (n is missing)".into()))?;
+        if !v.is_finite() || v < 0.0 {
+            return Err(SError::BadArgs(
+                "invalid arguments (n must be a non-negative count)".into(),
+            ));
+        }
+        v.trunc() as usize // saturates for huge v; the cap below rejects it
+    };
+    if n > MAX_SEQ_LEN {
+        return Err(SError::BadArgs(format!(
+            "cannot allocate a sample of length {n} (limit {MAX_SEQ_LEN})"
+        )));
+    }
+    Ok(n)
+}
+
+// --- normal --------------------------------------------------------------
+
+fn b_dnorm(_i: &Interpreter, args: &[Arg]) -> SResult<SValue> {
+    let (mean, sd) = (
+        dist_param(args, 1, "mean", 0.0)?,
+        dist_param(args, 2, "sd", 1.0)?,
+    );
+    unary_math(args, move |x| dnorm(x, mean, sd))
+}
+fn b_pnorm(_i: &Interpreter, args: &[Arg]) -> SResult<SValue> {
+    let (mean, sd) = (
+        dist_param(args, 1, "mean", 0.0)?,
+        dist_param(args, 2, "sd", 1.0)?,
+    );
+    unary_math(args, move |x| pnorm(x, mean, sd))
+}
+fn b_qnorm(_i: &Interpreter, args: &[Arg]) -> SResult<SValue> {
+    let (mean, sd) = (
+        dist_param(args, 1, "mean", 0.0)?,
+        dist_param(args, 2, "sd", 1.0)?,
+    );
+    unary_math(args, move |p| qnorm(p, mean, sd))
+}
+fn b_rnorm(interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
+    let n = sample_count(args)?;
+    let (mean, sd) = (
+        dist_param(args, 1, "mean", 0.0)?,
+        dist_param(args, 2, "sd", 1.0)?,
+    );
+    Ok(SValue::doubles(
+        interp.sample_with(|rng| rnorm(n, mean, sd, rng)),
+    ))
+}
+
+// --- uniform -------------------------------------------------------------
+
+fn b_dunif(_i: &Interpreter, args: &[Arg]) -> SResult<SValue> {
+    let (min, max) = (
+        dist_param(args, 1, "min", 0.0)?,
+        dist_param(args, 2, "max", 1.0)?,
+    );
+    unary_math(args, move |x| dunif(x, min, max))
+}
+fn b_punif(_i: &Interpreter, args: &[Arg]) -> SResult<SValue> {
+    let (min, max) = (
+        dist_param(args, 1, "min", 0.0)?,
+        dist_param(args, 2, "max", 1.0)?,
+    );
+    unary_math(args, move |x| punif(x, min, max))
+}
+fn b_qunif(_i: &Interpreter, args: &[Arg]) -> SResult<SValue> {
+    let (min, max) = (
+        dist_param(args, 1, "min", 0.0)?,
+        dist_param(args, 2, "max", 1.0)?,
+    );
+    unary_math(args, move |p| qunif(p, min, max))
+}
+fn b_runif(interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
+    let n = sample_count(args)?;
+    let (min, max) = (
+        dist_param(args, 1, "min", 0.0)?,
+        dist_param(args, 2, "max", 1.0)?,
+    );
+    Ok(SValue::doubles(
+        interp.sample_with(|rng| runif(n, min, max, rng)),
+    ))
+}
+
+// --- exponential ---------------------------------------------------------
+
+fn b_dexp(_i: &Interpreter, args: &[Arg]) -> SResult<SValue> {
+    let rate = dist_param(args, 1, "rate", 1.0)?;
+    unary_math(args, move |x| dexp(x, rate))
+}
+fn b_pexp(_i: &Interpreter, args: &[Arg]) -> SResult<SValue> {
+    let rate = dist_param(args, 1, "rate", 1.0)?;
+    unary_math(args, move |x| pexp(x, rate))
+}
+fn b_qexp(_i: &Interpreter, args: &[Arg]) -> SResult<SValue> {
+    let rate = dist_param(args, 1, "rate", 1.0)?;
+    unary_math(args, move |p| qexp(p, rate))
+}
+fn b_rexp(interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
+    let n = sample_count(args)?;
+    let rate = dist_param(args, 1, "rate", 1.0)?;
+    Ok(SValue::doubles(
+        interp.sample_with(|rng| rexp(n, rate, rng)),
+    ))
 }
 
 // ===========================================================================

--- a/code/packages/rust/s-runtime/src/eval.rs
+++ b/code/packages/rust/s-runtime/src/eval.rs
@@ -26,6 +26,7 @@ use crate::value::{
 use coding_adventures_s_parser::try_parse_s;
 use parser::grammar_parser::{ASTNodeOrToken, GrammarASTNode};
 use r_vector::{is_na_real, na_real, Double};
+use statistics_core::rng::RngState;
 use std::cell::{Cell, RefCell};
 use std::rc::Rc;
 
@@ -50,7 +51,18 @@ pub struct Interpreter {
     /// runaway recursive S function) returns a clean error instead of
     /// overflowing the native stack and aborting the process.
     depth: Cell<usize>,
+    /// The session's random-number generator, shared across `r*` sampling calls
+    /// (`rnorm`, `runif`, …) and reseeded by `set.seed()`. Held behind a
+    /// `RefCell` because builtins receive `&Interpreter` but the generator must
+    /// advance its state on every draw.
+    rng: RefCell<RngState>,
 }
+
+/// The fixed seed a fresh session starts from. Real R seeds from the clock and
+/// process state; we use a constant so a brand-new interpreter is reproducible
+/// until the program calls `set.seed()`. (Macsyma-style determinism beats
+/// surprise here — anyone wanting a fresh stream calls `set.seed`.)
+const DEFAULT_SEED: u64 = 4357;
 
 /// Maximum `eval_node` recursion depth. The precedence cascade adds roughly a
 /// dozen frames per source nesting level, so this allows comfortably deep
@@ -84,12 +96,25 @@ impl Interpreter {
             out: RefCell::new(String::new()),
             visible: Cell::new(false),
             depth: Cell::new(0),
+            rng: RefCell::new(RngState::new(DEFAULT_SEED)),
         }
     }
 
     /// The global environment (for tests and the REPL).
     pub fn global(&self) -> &Env {
         &self.global
+    }
+
+    /// Reseed the session generator — the engine behind `set.seed(n)`.
+    pub(crate) fn reseed(&self, seed: u64) {
+        self.rng.borrow_mut().seed(seed);
+    }
+
+    /// Draw from the session generator. The closure gets exclusive access to the
+    /// `RngState` for the duration of one sampling builtin, so a single `rnorm`
+    /// call advances the stream exactly as far as the values it produced.
+    pub(crate) fn sample_with<T>(&self, f: impl FnOnce(&mut RngState) -> T) -> T {
+        f(&mut self.rng.borrow_mut())
     }
 
     /// Append a block of output, one newline-terminated line each.
@@ -509,9 +534,10 @@ impl Interpreter {
         match callee {
             SValue::Builtin { name, func } => {
                 let result = func(self, args)?;
-                // `print` and `cat` produce their own output and return
-                // invisibly; every other built-in yields a visible value.
-                if name == "print" || name == "cat" {
+                // `print`/`cat` produce their own output, and `set.seed` mutates
+                // RNG state — all three return invisibly (R's `invisible(NULL)`);
+                // every other built-in yields a visible value.
+                if name == "print" || name == "cat" || name == "set.seed" {
                     self.as_invisible(result)
                 } else {
                     self.as_visible(result)

--- a/code/packages/rust/s-runtime/src/lib.rs
+++ b/code/packages/rust/s-runtime/src/lib.rs
@@ -757,4 +757,92 @@ mod tests {
             vec!["[1] 10".to_string()]
         );
     }
+
+    // --- Distribution family (R-8) --------------------------------------
+
+    /// Assert the first element of a `Double` result is approximately `expected`.
+    fn approx(src: &str, expected: f64) {
+        let got = nums(src)[0];
+        assert!(
+            (got - expected).abs() < 1e-6,
+            "{src:?}: got {got}, expected {expected}"
+        );
+    }
+
+    #[test]
+    fn normal_density_cdf_quantile() {
+        approx("dnorm(0)\n", 1.0 / (2.0 * std::f64::consts::PI).sqrt()); // ≈ 0.3989423
+        approx("pnorm(0)\n", 0.5);
+        approx("qnorm(0.5)\n", 0.0);
+        approx("pnorm(1.96)\n", 0.9750021); // the classic 97.5% point
+                                            // q is the inverse of p: qnorm(pnorm(x)) == x.
+        approx("qnorm(pnorm(1.2345))\n", 1.2345);
+    }
+
+    #[test]
+    fn normal_parameters_by_name_and_position() {
+        // Standardising: pnorm(x, mean, sd) == pnorm((x-mean)/sd).
+        approx("pnorm(110, mean = 100, sd = 10)\n", 0.8413447);
+        approx("pnorm(110, 100, 10)\n", 0.8413447); // positional form agrees
+        approx(
+            "dnorm(0, sd = 2)\n",
+            1.0 / (2.0 * (2.0 * std::f64::consts::PI).sqrt()),
+        );
+    }
+
+    #[test]
+    fn normal_is_vectorized_over_x_with_na() {
+        // d* maps over the whole quantile vector; NA propagates.
+        assert_eq!(show("pnorm(c(0, NA))\n"), "[1] 0.5  NA");
+    }
+
+    #[test]
+    fn uniform_family() {
+        approx("dunif(0.5)\n", 1.0);
+        approx("dunif(2)\n", 0.0); // outside [0,1] has zero density
+        approx("punif(0.25)\n", 0.25);
+        approx("qunif(0.75)\n", 0.75);
+        approx("punif(5, min = 0, max = 10)\n", 0.5);
+    }
+
+    #[test]
+    fn exponential_family() {
+        approx("dexp(0)\n", 1.0); // rate 1: density at 0 is the rate
+        approx("pexp(0.6931471805599453)\n", 0.5); // CDF at ln 2 is 1/2
+        approx("qexp(0.5)\n", std::f64::consts::LN_2);
+        approx("pexp(1, rate = 2)\n", 1.0 - (-2.0_f64).exp());
+    }
+
+    #[test]
+    fn sampling_respects_n_and_is_reseedable() {
+        // rnorm(n) returns n draws…
+        assert_eq!(nums("set.seed(1)\nrnorm(5)\n").len(), 5);
+        // …and set.seed makes the stream reproducible.
+        let a = nums("set.seed(42)\nrnorm(4)\n");
+        let b = nums("set.seed(42)\nrnorm(4)\n");
+        assert_eq!(a, b);
+        // A different seed gives a different stream.
+        let c = nums("set.seed(99)\nrnorm(4)\n");
+        assert_ne!(a, c);
+    }
+
+    #[test]
+    fn runif_draws_lie_in_range() {
+        let xs = nums("set.seed(7)\nrunif(100, min = -1, max = 1)\n");
+        assert_eq!(xs.len(), 100);
+        assert!(xs.iter().all(|&x| (-1.0..1.0).contains(&x)));
+    }
+
+    #[test]
+    fn sample_count_is_capped_not_oom() {
+        // A pathological n is a clean error, not an allocation abort.
+        assert!(eval_s("rnorm(1e18)\n").is_err());
+        assert!(eval_s("runif(-3)\n").is_err());
+    }
+
+    #[test]
+    fn set_seed_returns_invisibly() {
+        let outcome = Interpreter::new().eval_str("set.seed(1)\n").unwrap();
+        assert!(!outcome.visible);
+    }
 }

--- a/code/specs/R00-r-language.md
+++ b/code/specs/R00-r-language.md
@@ -80,8 +80,19 @@ unchanged.
   catastrophic backtracking), with a `fixed = TRUE` literal-match option and R
   back-reference translation (`\\1` → the crate's `${1}`). Invalid patterns
   return a clean error. *Deferred:* `regmatches`/`gregexpr`, `table`.
-- **R-8+** — the `d/p/q/r` distribution family (`rnorm`/`dnorm`/`pnorm`/`qnorm`,
-  `runif`, …) wired to `statistics-core`.
+- **R-8 — the `d/p/q/r` distribution family** *(this PR)*. The four-prefix
+  probability functions wired to `statistics-core`: density `d*`, cumulative
+  `p*` (CDF), quantile `q*` (inverse CDF), and random sampling `r*`, for the
+  closed-form continuous families **normal** (`dnorm`/`pnorm`/`qnorm`/`rnorm`,
+  defaults `mean = 0`, `sd = 1`), **uniform** (`dunif`/…/`runif`, `min = 0`,
+  `max = 1`), and **exponential** (`dexp`/…/`rexp`, `rate = 1`), plus
+  `set.seed(n)`. `d*`/`p*`/`q*` are vectorized over their first argument with
+  NA-propagation; parameters are read by name or position. `r*` draws from a
+  per-session RNG (R-compatible MT19937) held on the `Interpreter`, so
+  `set.seed(s); rnorm(n)` is reproducible; the sample count is capped at
+  `MAX_SEQ_LEN` so `rnorm(1e18)` errors instead of aborting. *Deferred (R-8b):*
+  the discrete families (`dbinom`/`dpois`/…), whose CDF/sampling loop over a
+  user-supplied count and need their own bounds.
 
 ## §4 Reuse strategy
 


### PR DESCRIPTION
## What & why

**R-8** of the [R frontend](code/specs/R00-r-language.md), continuing the autonomous R loop (R-1…R-7 merged). Adds R's four-prefix probability functions to the shared `s-runtime` evaluator, wired to `statistics-core`. R picks them up unchanged because `r.grammar` mirrors `s.grammar` — same reuse strategy as every prior R item.

## The family

| prefix | meaning | example |
|--------|---------|---------|
| `d*` | density | `dnorm(0)` → 0.3989 |
| `p*` | cumulative (CDF) | `pnorm(1.96)` → 0.975 |
| `q*` | quantile (inverse CDF) | `qnorm(0.5)` → 0 |
| `r*` | random sample of size `n` | `rnorm(5)` |

For the closed-form continuous distributions:
- **normal** `dnorm`/`pnorm`/`qnorm`/`rnorm` (defaults `mean = 0`, `sd = 1`)
- **uniform** `dunif`/`punif`/`qunif`/`runif` (`min = 0`, `max = 1`)
- **exponential** `dexp`/`pexp`/`qexp`/`rexp` (`rate = 1`)
- plus **`set.seed(n)`**

`d*`/`p*`/`q*` vectorize over their first argument (the quantile/probability vector) with NA-propagation, reusing the existing `unary_math` mapper; parameters are read by name (`sd =`) or position. `r*` draws from a per-session **R-compatible MT19937** generator now held on the `Interpreter` (`RefCell<RngState>`) and reseeded by `set.seed`, so `set.seed(s); rnorm(n)` is reproducible. `set.seed` returns invisibly, alongside `print`/`cat`.

## Safety

The `r*` sample count goes through a shared `sample_count` helper that rejects non-finite/negative `n` and **caps at `MAX_SEQ_LEN`** — so `rnorm(1e18)` is a clean error, not an allocation abort (`f64 as usize` saturates, so a huge `n` can't wrap past the cap). The continuous families are closed-form (O(1) density/CDF/quantile, O(n) sampling) — no input-driven unbounded loops. The discrete families (binomial/Poisson), whose CDF/sampling loop over a user count, are deferred to **R-8b** with their own bounds.

## Tests

- `s-runtime`: per-family d/p/q correctness vs known values (`pnorm(0)=0.5`, `qexp(0.5)=ln2`, the `q∘p` inverse identity, the 97.5% normal point…), params by name and position, NA propagation, reproducibility + stream divergence across seeds, `runif` range, the `n`-cap error, and `set.seed` invisibility.
- `r-runtime`: an R-side integration test (dotted `set.seed` + `mean =` through the R parser).
- 114 `s-runtime` + 18 `r-runtime` tests pass; `cargo fmt` + `cargo clippy` clean.
- `/security-review` → **PASSED** (first round): cap enforced, saturating casts, no reachable panics, no RefCell re-entrancy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)