### PR TITLE
fix(mini-sqlite): reject INTERSECT ALL and EXCEPT ALL with OperationalError

### DIFF
--- a/code/grammars/sql.grammar
+++ b/code/grammars/sql.grammar
@@ -61,6 +61,10 @@ with_clause       = "WITH" [ "RECURSIVE" ] cte_def { "," cte_def } ;
 cte_def           = NAME [ "(" NAME { "," NAME } ")" ] "AS"
                     [ [ "NOT" ] "MATERIALIZED" ]
                     "(" query_stmt ")" ;
+# Grammar note: [ "ALL" ] is written for all three operators so the parser can
+# produce a useful token-stream and the adapter can emit the correct error.
+# Only UNION ALL is valid in SQLite; the adapter rejects INTERSECT ALL and
+# EXCEPT ALL with OperationalError: near "ALL": syntax error.
 set_op_clause     = ( "UNION" | "INTERSECT" | "EXCEPT" ) [ "ALL" ]
                     ( values_stmt | select_stmt ) ;
 

--- a/code/packages/python/mini-sqlite/CHANGELOG.md
+++ b/code/packages/python/mini-sqlite/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Changelog
 
+## [2.23.0] - 2026-06-16
+
+### Fixed
+
+- **`INTERSECT ALL` and `EXCEPT ALL` now raise `OperationalError: near "ALL": syntax error`** —
+  SQLite does not support bag semantics for `INTERSECT` or `EXCEPT`; only
+  `UNION ALL` is valid.  Previously mini-sqlite silently accepted these two
+  forms and returned results (treating them like plain `INTERSECT`/`EXCEPT`),
+  diverging from real SQLite behaviour.
+
+  Root cause: the SQL grammar accepts `[ "ALL" ]` for all three set operators
+  so the PEG parser can produce a meaningful token stream; the adapter
+  (`_set_op_clause`) is now the enforcement point.  When it detects
+  `INTERSECT ALL` or `EXCEPT ALL`, it raises `OperationalError` with the same
+  message byte-for-byte as the real engine.
+
+  | SQL form            | Before       | After                              |
+  |---------------------|--------------|------------------------------------|
+  | `UNION ALL`         | OK (correct) | OK (unchanged)                     |
+  | `INTERSECT ALL`     | returns rows | `OperationalError: near "ALL": …`  |
+  | `EXCEPT ALL`        | returns rows | `OperationalError: near "ALL": …`  |
+
+- **16 new oracle tests** in ``test_tier3_intersect_except_all_rejected.py``
+  verify that both operators raise the correct error type and message, that
+  plain `INTERSECT`/`EXCEPT` (without `ALL`) continue to work, and that
+  `UNION ALL` is unaffected.
+
 ## [2.22.0] - 2026-06-16
 
 ### Fixed

--- a/code/packages/python/mini-sqlite/pyproject.toml
+++ b/code/packages/python/mini-sqlite/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-mini-sqlite"
-version = "2.22.0"
+version = "2.23.0"
 description = "PEP 249 DB-API 2.0 facade over the sql-lexer / parser / planner / optimizer / codegen / vm / backend stack."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/mini-sqlite/src/mini_sqlite/adapter.py
+++ b/code/packages/python/mini-sqlite/src/mini_sqlite/adapter.py
@@ -429,6 +429,13 @@ def _set_op_clause(node: ASTNode) -> tuple[str, bool, ASTNode, str]:
     The body may be a ``select_stmt`` (the usual case) or a
     ``values_stmt`` (``UNION ALL VALUES (1)``).  The caller dispatches
     on ``body_rule`` to call the right translator.
+
+    SQLite compatibility note: only ``UNION ALL`` is valid.  SQLite parses
+    ``INTERSECT ALL`` and ``EXCEPT ALL`` as syntax errors because neither the
+    SQL-92 nor the SQLite dialect defines bag semantics for those two operators.
+    We enforce the same restriction here so callers get the same
+    ``OperationalError: near "ALL": syntax error`` they would from the real
+    SQLite engine.
     """
     op: str | None = None
     all_flag = False
@@ -446,6 +453,11 @@ def _set_op_clause(node: ASTNode) -> tuple[str, bool, ASTNode, str]:
             body_rule = c.rule_name
     if op is None or body_node is None or body_rule is None:
         raise ProgrammingError("malformed set_op_clause")
+    # SQLite only supports UNION ALL.  INTERSECT ALL and EXCEPT ALL are not
+    # part of the SQLite dialect (the grammar accepts them so the parser can
+    # report a clean error rather than a confusing token-mismatch).
+    if op in ("INTERSECT", "EXCEPT") and all_flag:
+        raise OperationalError('near "ALL": syntax error')
     return op, all_flag, body_node, body_rule
 
 

--- a/code/packages/python/mini-sqlite/tests/test_tier3_intersect_except_all_rejected.py
+++ b/code/packages/python/mini-sqlite/tests/test_tier3_intersect_except_all_rejected.py
@@ -1,0 +1,139 @@
+"""Oracle tests: INTERSECT ALL and EXCEPT ALL raise OperationalError.
+
+SQLite does not support bag semantics for INTERSECT or EXCEPT.  Both
+``SELECT … INTERSECT ALL SELECT …`` and ``SELECT … EXCEPT ALL SELECT …``
+produce ``OperationalError: near "ALL": syntax error`` in the real engine.
+Mini-sqlite must match this behaviour byte-for-byte.
+
+The grammar parses ``[ "ALL" ]`` for all three set operators so the adapter
+can surface a clean, SQLite-compatible error rather than a confusing
+token-mismatch from the PEG engine.  The adapter's ``_set_op_clause``
+function detects the illegal combination and raises ``OperationalError``.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+import pytest
+
+import mini_sqlite
+
+
+def _ref_raises(sql: str) -> str:
+    """Assert sqlite3 raises OperationalError and return the message."""
+    with pytest.raises(sqlite3.OperationalError) as exc_info:
+        sqlite3.connect(":memory:").execute(sql)
+    return str(exc_info.value)
+
+
+class TestIntersectAllRejected:
+    """INTERSECT ALL is rejected with the same error as real SQLite."""
+
+    def test_intersect_all_raises_operational_error(self) -> None:
+        sql = "SELECT 1 INTERSECT ALL SELECT 1"
+        ref_msg = _ref_raises(sql)
+        with pytest.raises(mini_sqlite.OperationalError) as exc_info:
+            mini_sqlite.connect(":memory:").execute(sql)
+        assert str(exc_info.value) == ref_msg
+
+    def test_intersect_all_message_contains_near_all(self) -> None:
+        sql = "SELECT 1 INTERSECT ALL SELECT 1"
+        with pytest.raises(mini_sqlite.OperationalError) as exc_info:
+            mini_sqlite.connect(":memory:").execute(sql)
+        assert 'near "ALL": syntax error' in str(exc_info.value)
+
+    def test_intersect_all_with_strings(self) -> None:
+        sql = "SELECT 'a' INTERSECT ALL SELECT 'a'"
+        with pytest.raises(mini_sqlite.OperationalError):
+            mini_sqlite.connect(":memory:").execute(sql)
+
+    def test_intersect_all_with_table(self) -> None:
+        con = mini_sqlite.connect(":memory:")
+        con.execute("CREATE TABLE t(x INT)")
+        con.execute("INSERT INTO t VALUES (1)")
+        with pytest.raises(mini_sqlite.OperationalError) as exc_info:
+            con.execute("SELECT x FROM t INTERSECT ALL SELECT x FROM t")
+        assert 'near "ALL": syntax error' in str(exc_info.value)
+
+    def test_intersect_without_all_still_works(self) -> None:
+        """Plain INTERSECT (no ALL) must continue to work."""
+        ref = sqlite3.connect(":memory:").execute("SELECT 1 INTERSECT SELECT 1").fetchall()
+        our = mini_sqlite.connect(":memory:").execute("SELECT 1 INTERSECT SELECT 1").fetchall()
+        assert our == ref
+
+    def test_intersect_deduplicates(self) -> None:
+        """INTERSECT without ALL gives set (deduplicated) semantics."""
+        sql = "SELECT 1 UNION ALL SELECT 1 UNION ALL SELECT 2 INTERSECT SELECT 1"
+        ref = sqlite3.connect(":memory:").execute(sql).fetchall()
+        our = mini_sqlite.connect(":memory:").execute(sql).fetchall()
+        assert our == ref
+
+
+class TestExceptAllRejected:
+    """EXCEPT ALL is rejected with the same error as real SQLite."""
+
+    def test_except_all_raises_operational_error(self) -> None:
+        sql = "SELECT 1 EXCEPT ALL SELECT 2"
+        ref_msg = _ref_raises(sql)
+        with pytest.raises(mini_sqlite.OperationalError) as exc_info:
+            mini_sqlite.connect(":memory:").execute(sql)
+        assert str(exc_info.value) == ref_msg
+
+    def test_except_all_message_contains_near_all(self) -> None:
+        sql = "SELECT 1 EXCEPT ALL SELECT 2"
+        with pytest.raises(mini_sqlite.OperationalError) as exc_info:
+            mini_sqlite.connect(":memory:").execute(sql)
+        assert 'near "ALL": syntax error' in str(exc_info.value)
+
+    def test_except_all_with_strings(self) -> None:
+        sql = "SELECT 'x' EXCEPT ALL SELECT 'y'"
+        with pytest.raises(mini_sqlite.OperationalError):
+            mini_sqlite.connect(":memory:").execute(sql)
+
+    def test_except_all_with_table(self) -> None:
+        con = mini_sqlite.connect(":memory:")
+        con.execute("CREATE TABLE t(x INT)")
+        con.execute("INSERT INTO t VALUES (1), (2)")
+        with pytest.raises(mini_sqlite.OperationalError) as exc_info:
+            con.execute("SELECT x FROM t EXCEPT ALL SELECT 1")
+        assert 'near "ALL": syntax error' in str(exc_info.value)
+
+    def test_except_without_all_still_works(self) -> None:
+        """Plain EXCEPT (no ALL) must continue to work."""
+        ref = sqlite3.connect(":memory:").execute("SELECT 1 EXCEPT SELECT 2").fetchall()
+        our = mini_sqlite.connect(":memory:").execute("SELECT 1 EXCEPT SELECT 2").fetchall()
+        assert our == ref
+
+    def test_except_removes_intersection(self) -> None:
+        """EXCEPT without ALL gives set-difference semantics."""
+        sql = "SELECT 1 UNION ALL SELECT 2 EXCEPT SELECT 2"
+        ref = sqlite3.connect(":memory:").execute(sql).fetchall()
+        our = mini_sqlite.connect(":memory:").execute(sql).fetchall()
+        assert our == ref
+
+
+class TestUnionAllStillWorks:
+    """UNION ALL must be unaffected by the INTERSECT/EXCEPT guard."""
+
+    def test_union_all_basic(self) -> None:
+        ref = sqlite3.connect(":memory:").execute("SELECT 1 UNION ALL SELECT 1").fetchall()
+        our = mini_sqlite.connect(":memory:").execute("SELECT 1 UNION ALL SELECT 1").fetchall()
+        assert our == ref  # [(1,), (1,)] — duplicates preserved
+
+    def test_union_all_with_strings(self) -> None:
+        ref = sqlite3.connect(":memory:").execute("SELECT 'a' UNION ALL SELECT 'a'").fetchall()
+        our = mini_sqlite.connect(":memory:").execute("SELECT 'a' UNION ALL SELECT 'a'").fetchall()
+        assert our == ref
+
+    def test_union_all_three_way(self) -> None:
+        sql = "SELECT 1 UNION ALL SELECT 2 UNION ALL SELECT 3"
+        ref = sqlite3.connect(":memory:").execute(sql).fetchall()
+        our = mini_sqlite.connect(":memory:").execute(sql).fetchall()
+        assert our == ref
+
+    def test_union_without_all_deduplicates(self) -> None:
+        sql = "SELECT 1 UNION SELECT 1"
+        ref = sqlite3.connect(":memory:").execute(sql).fetchall()
+        our = mini_sqlite.connect(":memory:").execute(sql).fetchall()
+        assert our == ref  # [(1,)] — deduplicated


### PR DESCRIPTION
## Summary

- **Root cause**: `INTERSECT ALL` and `EXCEPT ALL` are not valid in SQLite's dialect, but mini-sqlite was silently accepting them and returning results, diverging from real SQLite behaviour.
- **Fix**: `_set_op_clause()` in the adapter now raises `OperationalError: near "ALL": syntax error` when it detects `INTERSECT ALL` or `EXCEPT ALL`, matching the real engine byte-for-byte.
- **Grammar note**: The grammar retains `[ "ALL" ]` for all three set operators so the PEG parser produces a valid token stream; enforcement is at the adapter level because `GrammarParseError` maps to `ProgrammingError` while SQLite uses `OperationalError` for this case.

| SQL form | Before | After |
|----------|--------|-------|
| `UNION ALL` | OK (correct) | OK (unchanged) |
| `INTERSECT ALL` | returns rows silently | `OperationalError: near "ALL": syntax error` |
| `EXCEPT ALL` | returns rows silently | `OperationalError: near "ALL": syntax error` |

## Test plan

- [ ] 16 new oracle tests in `test_tier3_intersect_except_all_rejected.py` verify:
  - `INTERSECT ALL` raises `OperationalError` with the exact SQLite message
  - `EXCEPT ALL` raises `OperationalError` with the exact SQLite message
  - Plain `INTERSECT` (no ALL) continues to work correctly
  - Plain `EXCEPT` (no ALL) continues to work correctly
  - `UNION ALL` is unaffected
- [ ] Full test suite: 2464 passed, 2 skipped, 91.16% coverage (exceeds 80% threshold)
- [ ] `ruff check` passes on all changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)