### PR TITLE
Route .control Fourier commands

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ### Added
 
+- **Deck control Fourier routing** —
+  `analyze_deck_controls()` and `resolve_deck_sources()` now normalize
+  selected `.control` block `four` and `fourier` harmonic output commands into
+  `.four` deck cards, matching Rust and TypeScript.
+
 - **Deck control measurement routing** —
   `analyze_deck_controls()` and `resolve_deck_sources()` now normalize
   selected `.control` block `measure` and `meas` measurement commands into

--- a/code/packages/python/spice-engine/README.md
+++ b/code/packages/python/spice-engine/README.md
@@ -160,9 +160,9 @@ provide stable tab-separated summaries for package checks.
 it returns active lines before `.end` and stable diagnostics for unsupported
 `.include`, `.lib`, and `.control` directives. Inside `.control` blocks,
 selected analysis/output commands (`op`, `dc`, `ac`, `tran`, `save`, `probe`,
-`measure`, `meas`, `print`, and `plot`) are normalized into dotted deck cards,
-while unrecognized non-comment commands emit diagnostics until a broader
-executed control subset is in scope.
+`measure`, `meas`, `four`, `fourier`, `print`, and `plot`) are normalized into
+dotted deck cards, while unrecognized non-comment commands emit diagnostics
+until a broader executed control subset is in scope.
 `resolve_deck_sources()` is the first include/library resolution layer: callers
 provide a source-content map, `.include` directives are expanded in place, and
 `.lib path section` selects a named `.lib` / `.endl` section with stable

--- a/code/packages/python/spice-engine/src/spice_engine/compatibility.py
+++ b/code/packages/python/spice-engine/src/spice_engine/compatibility.py
@@ -505,6 +505,10 @@ _SUPPORTED_CONTROL_BLOCK_COMMANDS = frozenset(
         ".measure",
         "meas",
         ".meas",
+        "four",
+        ".four",
+        "fourier",
+        ".fourier",
         "print",
         ".print",
         "plot",
@@ -3323,7 +3327,10 @@ def _control_block_command_as_deck_line(line: str) -> str | None:
     command = parts[0].lower()
     if command not in _SUPPORTED_CONTROL_BLOCK_COMMANDS:
         return None
-    directive = command if command.startswith(".") else f".{command}"
+    if command in {"four", ".four", "fourier", ".fourier"}:
+        directive = ".four"
+    else:
+        directive = command if command.startswith(".") else f".{command}"
     if len(parts) == 1:
         return directive
     return f"{directive} {parts[1]}"

--- a/code/packages/python/spice-engine/tests/test_compatibility.py
+++ b/code/packages/python/spice-engine/tests/test_compatibility.py
@@ -117,6 +117,8 @@ probe V(out)
 print op V(in)
 measure tran vmax MAX V(out)
 meas dc imax MAX I(V1)
+fourier 1k V(out)
+four 2k V(in)
 run
 .endc
 .end
@@ -133,12 +135,14 @@ run
         ".print op V(in)",
         ".measure tran vmax MAX V(out)",
         ".meas dc imax MAX I(V1)",
+        ".four 1k V(out)",
+        ".four 2k V(in)",
     )
     assert [(diag.directive, diag.line_number, diag.severity) for diag in summary.diagnostics] == [
         (".include", 2, "error"),
         (".lib", 3, "error"),
         (".control", 4, "error"),
-        (".control", 11, "error"),
+        (".control", 13, "error"),
     ]
     assert [diag.code for diag in summary.diagnostics] == [
         "SPICE_DECK_UNSUPPORTED_DIRECTIVE",
@@ -153,6 +157,14 @@ run
     ] == [
         (".measure", "tran", "vmax", "max", "V(out)"),
         (".meas", "dc", "imax", "max", "I(V1)"),
+    ]
+    fourier_summary = resolve_deck_fourier("\n".join(summary.active_lines) + "\n.end")
+    assert [
+        (card.directive, card.fundamental_frequency, card.probes)
+        for card in fourier_summary.fourier
+    ] == [
+        (".four", 1000.0, ("V(out)",)),
+        (".four", 2000.0, ("V(in)",)),
     ]
 
 
@@ -212,6 +224,8 @@ probe V(b)
 print op V(a)
 measure tran vmax MAX V(a)
 meas dc imax MAX I(V1)
+fourier 1k V(a)
+four 2k V(b)
 run
 .endc
 .end
@@ -233,6 +247,8 @@ run
         ".print op V(a)",
         ".measure tran vmax MAX V(a)",
         ".meas dc imax MAX I(V1)",
+        ".four 1k V(a)",
+        ".four 2k V(b)",
     )
     assert [diag.code for diag in summary.diagnostics] == [
         "SPICE_DECK_INCLUDE_NOT_FOUND",
@@ -243,7 +259,7 @@ run
     ]
     assert [(diag.directive, diag.line_number) for diag in summary.diagnostics[3:]] == [
         (".control", 5),
-        (".control", 12),
+        (".control", 14),
     ]
     measurement_summary = resolve_deck_measurements("\n".join(summary.active_lines) + "\n.end")
     assert [
@@ -252,6 +268,14 @@ run
     ] == [
         (".measure", "tran", "vmax", "max", "V(a)"),
         (".meas", "dc", "imax", "max", "I(V1)"),
+    ]
+    fourier_summary = resolve_deck_fourier("\n".join(summary.active_lines) + "\n.end")
+    assert [
+        (card.directive, card.fundamental_frequency, card.probes)
+        for card in fourier_summary.fourier
+    ] == [
+        (".four", 1000.0, ("V(a)",)),
+        (".four", 2000.0, ("V(b)",)),
     ]
     assert [(diag.source, diag.line_number, diag.target) for diag in summary.diagnostics[:3]] == [
         ("<deck>", 2, "missing.inc"),

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Add selected `.control` block `four` and `fourier` command routing to
+  `analyze_deck_controls` and `resolve_deck_sources`; the commands are
+  normalized into `.four` deck cards, matching Python and TypeScript.
 - Add selected `.control` block `measure` and `meas` command routing to
   `analyze_deck_controls` and `resolve_deck_sources`; the commands are
   normalized into `.measure` and `.meas` deck cards, matching Python and

--- a/code/packages/rust/spice-engine/README.md
+++ b/code/packages/rust/spice-engine/README.md
@@ -127,9 +127,9 @@ provide stable tab-separated summaries for package checks.
 returns active lines before `.end` and stable diagnostics for unsupported
 `.include`, `.lib`, and `.control` directives. Inside `.control` blocks,
 selected analysis/output commands (`op`, `dc`, `ac`, `tran`, `save`, `probe`,
-`measure`, `meas`, `print`, and `plot`) are normalized into dotted deck cards,
-while unrecognized non-comment commands emit diagnostics until a broader
-executed control subset is in scope.
+`measure`, `meas`, `four`, `fourier`, `print`, and `plot`) are normalized into
+dotted deck cards, while unrecognized non-comment commands emit diagnostics
+until a broader executed control subset is in scope.
 `resolve_deck_sources` is the first include/library resolution layer: callers
 provide a source-content map, `.include` directives are expanded in place, and
 `.lib path section` selects a named `.lib` / `.endl` section with stable

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -6883,6 +6883,7 @@ fn control_block_command_as_deck_line(line: &str) -> Option<String> {
         "probe" | ".probe" => ".probe",
         "measure" | ".measure" => ".measure",
         "meas" | ".meas" => ".meas",
+        "four" | ".four" | "fourier" | ".fourier" => ".four",
         "print" | ".print" => ".print",
         "plot" | ".plot" => ".plot",
         _ => return None,

--- a/code/packages/rust/spice-engine/tests/compatibility_tests.rs
+++ b/code/packages/rust/spice-engine/tests/compatibility_tests.rs
@@ -134,6 +134,8 @@ probe V(out)
 print op V(in)
 measure tran vmax MAX V(out)
 meas dc imax MAX I(V1)
+fourier 1k V(out)
+four 2k V(in)
 run
 .endc
 .end
@@ -152,6 +154,8 @@ run
             ".print op V(in)".to_string(),
             ".measure tran vmax MAX V(out)".to_string(),
             ".meas dc imax MAX I(V1)".to_string(),
+            ".four 1k V(out)".to_string(),
+            ".four 2k V(in)".to_string(),
         ]
     );
     let diagnostics = summary
@@ -171,7 +175,7 @@ run
             (".include", 2, "error"),
             (".lib", 3, "error"),
             (".control", 4, "error"),
-            (".control", 11, "error")
+            (".control", 13, "error")
         ]
     );
     assert_eq!(
@@ -204,6 +208,26 @@ run
         vec![
             (".measure", "tran", "vmax", "max", "V(out)"),
             (".meas", "dc", "imax", "max", "I(V1)")
+        ]
+    );
+    let fourier_deck = format!("{}\n.end", summary.active_lines.join("\n"));
+    let fourier_summary = resolve_deck_fourier(&fourier_deck);
+    assert_eq!(
+        fourier_summary
+            .fourier
+            .iter()
+            .map(|card| (
+                card.directive.as_str(),
+                card.fundamental_frequency_hz,
+                card.probes
+                    .iter()
+                    .map(|probe| probe.as_str())
+                    .collect::<Vec<_>>()
+            ))
+            .collect::<Vec<_>>(),
+        vec![
+            (".four", 1000.0, vec!["V(out)"]),
+            (".four", 2000.0, vec!["V(in)"])
         ]
     );
 }
@@ -292,6 +316,8 @@ probe V(b)
 print op V(a)
 measure tran vmax MAX V(a)
 meas dc imax MAX I(V1)
+fourier 1k V(a)
+four 2k V(b)
 run
 .endc
 .end
@@ -310,7 +336,9 @@ run
             ".probe V(b)",
             ".print op V(a)",
             ".measure tran vmax MAX V(a)",
-            ".meas dc imax MAX I(V1)"
+            ".meas dc imax MAX I(V1)",
+            ".four 1k V(a)",
+            ".four 2k V(b)"
         ]
     );
     assert_eq!(
@@ -334,7 +362,7 @@ run
             .skip(3)
             .map(|diagnostic| (diagnostic.directive.as_str(), diagnostic.line_number))
             .collect::<Vec<_>>(),
-        vec![(".control", 5), (".control", 12)]
+        vec![(".control", 5), (".control", 14)]
     );
     let measurement_deck = format!("{}\n.end", summary.active_lines.join("\n"));
     let measurement_summary = resolve_deck_measurements(&measurement_deck);
@@ -353,6 +381,26 @@ run
         vec![
             (".measure", "tran", "vmax", "max", "V(a)"),
             (".meas", "dc", "imax", "max", "I(V1)")
+        ]
+    );
+    let fourier_deck = format!("{}\n.end", summary.active_lines.join("\n"));
+    let fourier_summary = resolve_deck_fourier(&fourier_deck);
+    assert_eq!(
+        fourier_summary
+            .fourier
+            .iter()
+            .map(|card| (
+                card.directive.as_str(),
+                card.fundamental_frequency_hz,
+                card.probes
+                    .iter()
+                    .map(|probe| probe.as_str())
+                    .collect::<Vec<_>>()
+            ))
+            .collect::<Vec<_>>(),
+        vec![
+            (".four", 1000.0, vec!["V(a)"]),
+            (".four", 2000.0, vec!["V(b)"])
         ]
     );
     assert_eq!(

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Add selected `.control` block `four` and `fourier` command routing to
+  `analyzeDeckControls` and `resolveDeckSources`; the commands are normalized
+  into `.four` deck cards, matching Python and Rust.
 - Add selected `.control` block `measure` and `meas` command routing to
   `analyzeDeckControls` and `resolveDeckSources`; the commands are normalized
   into `.measure` and `.meas` deck cards, matching Python and Rust.

--- a/code/packages/typescript/spice-engine/README.md
+++ b/code/packages/typescript/spice-engine/README.md
@@ -134,9 +134,9 @@ stable tab-separated summaries for package checks.
 returns active lines before `.end` and stable diagnostics for unsupported
 `.include`, `.lib`, and `.control` directives. Inside `.control` blocks,
 selected analysis/output commands (`op`, `dc`, `ac`, `tran`, `save`, `probe`,
-`measure`, `meas`, `print`, and `plot`) are normalized into dotted deck cards,
-while unrecognized non-comment commands emit diagnostics until a broader
-executed control subset is in scope.
+`measure`, `meas`, `four`, `fourier`, `print`, and `plot`) are normalized into
+dotted deck cards, while unrecognized non-comment commands emit diagnostics
+until a broader executed control subset is in scope.
 `resolveDeckSources` is the first include/library resolution layer: callers
 provide a source-content map, `.include` directives are expanded in place, and
 `.lib path section` selects a named `.lib` / `.endl` section with stable

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -2845,6 +2845,10 @@ const SUPPORTED_CONTROL_BLOCK_COMMANDS = new Set([
   ".measure",
   "meas",
   ".meas",
+  "four",
+  ".four",
+  "fourier",
+  ".fourier",
   "print",
   ".print",
   "plot",
@@ -5690,7 +5694,12 @@ function controlBlockCommandAsDeckLine(line: string): string | undefined {
   if (command === undefined || !SUPPORTED_CONTROL_BLOCK_COMMANDS.has(command)) {
     return undefined;
   }
-  const directive = command.startsWith(".") ? command : `.${command}`;
+  const directive =
+    command === "four" || command === ".four" || command === "fourier" || command === ".fourier"
+      ? ".four"
+      : command.startsWith(".")
+        ? command
+        : `.${command}`;
   const rest = line.slice(parts[0].length).trimStart();
   return rest.length === 0 ? directive : `${directive} ${rest}`;
 }

--- a/code/packages/typescript/spice-engine/tests/compatibility.test.ts
+++ b/code/packages/typescript/spice-engine/tests/compatibility.test.ts
@@ -121,6 +121,8 @@ probe V(out)
 print op V(in)
 measure tran vmax MAX V(out)
 meas dc imax MAX I(V1)
+fourier 1k V(out)
+four 2k V(in)
 run
 .endc
 .end
@@ -136,6 +138,8 @@ run
       ".print op V(in)",
       ".measure tran vmax MAX V(out)",
       ".meas dc imax MAX I(V1)",
+      ".four 1k V(out)",
+      ".four 2k V(in)",
     ]);
     expect(summary.diagnostics.map(({ directive, lineNumber, severity }) => [
       directive,
@@ -145,7 +149,7 @@ run
       [".include", 2, "error"],
       [".lib", 3, "error"],
       [".control", 4, "error"],
-      [".control", 11, "error"],
+      [".control", 13, "error"],
     ]);
     expect(summary.diagnostics.map((diagnostic) => diagnostic.code)).toStrictEqual([
       "SPICE_DECK_UNSUPPORTED_DIRECTIVE",
@@ -163,6 +167,15 @@ run
     ])).toStrictEqual([
       [".measure", "tran", "vmax", "max", "V(out)"],
       [".meas", "dc", "imax", "max", "I(V1)"],
+    ]);
+    const fourierSummary = resolveDeckFourier(`${summary.activeLines.join("\n")}\n.end`);
+    expect(fourierSummary.fourier.map((card) => [
+      card.directive,
+      card.fundamentalFrequencyHz,
+      card.probes,
+    ])).toStrictEqual([
+      [".four", 1000, ["V(out)"]],
+      [".four", 2000, ["V(in)"]],
     ]);
   });
 
@@ -218,6 +231,8 @@ probe V(b)
 print op V(a)
 measure tran vmax MAX V(a)
 meas dc imax MAX I(V1)
+fourier 1k V(a)
+four 2k V(b)
 run
 .endc
 .end
@@ -237,6 +252,8 @@ run
       ".print op V(a)",
       ".measure tran vmax MAX V(a)",
       ".meas dc imax MAX I(V1)",
+      ".four 1k V(a)",
+      ".four 2k V(b)",
     ]);
     expect(summary.diagnostics.map((diagnostic) => diagnostic.code)).toStrictEqual([
       "SPICE_DECK_INCLUDE_NOT_FOUND",
@@ -250,7 +267,7 @@ run
       lineNumber,
     ])).toStrictEqual([
       [".control", 5],
-      [".control", 12],
+      [".control", 14],
     ]);
     const measurementSummary = resolveDeckMeasurements(`${summary.activeLines.join("\n")}\n.end`);
     expect(measurementSummary.measurements.map((card) => [
@@ -262,6 +279,15 @@ run
     ])).toStrictEqual([
       [".measure", "tran", "vmax", "max", "V(a)"],
       [".meas", "dc", "imax", "max", "I(V1)"],
+    ]);
+    const fourierSummary = resolveDeckFourier(`${summary.activeLines.join("\n")}\n.end`);
+    expect(fourierSummary.fourier.map((card) => [
+      card.directive,
+      card.fundamentalFrequencyHz,
+      card.probes,
+    ])).toStrictEqual([
+      [".four", 1000, ["V(a)"]],
+      [".four", 2000, ["V(b)"]],
     ]);
     expect(summary.diagnostics.slice(0, 3).map(({ source, lineNumber, target }) => [
       source,

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -35,8 +35,8 @@ downstream tools to compare.
      active deck and source-resolved solver input while body commands emit
      stable non-executed diagnostics, and selected `.control` block
      analysis/output commands (`op`, `dc`, `ac`, `tran`, `save`, `probe`,
-     `measure`, `meas`, `print`, and `plot`) now normalize into dotted deck
-     cards; parsed `.measure dc` / `.meas dc` cards now route DC
+     `measure`, `meas`, `four`, `fourier`, `print`, and `plot`) now normalize
+     into dotted deck cards; parsed `.measure dc` / `.meas dc` cards now route DC
      sweep probe samples into the shared scalar measurement table surface;
      parsed `.measure ac` / `.meas ac` cards now route AC probe magnitudes over
      optional frequency windows into the same measurement table surface; parsed
@@ -530,6 +530,14 @@ downstream tools to compare.
     - Unrecognized non-comment commands inside `.control` blocks remain
       diagnostic-only so unsupported control flow is still explicit.
 
+47. Selected `.control` Fourier routing.
+    - Status: completed in this selected control Fourier-routing slice.
+    - Python, Rust, and TypeScript now normalize selected `.control` block
+      harmonic output commands (`four` and `fourier`) into the same `.four`
+      deck cards consumed by existing Fourier resolvers.
+    - Unrecognized non-comment commands inside `.control` blocks remain
+      diagnostic-only so unsupported control flow is still explicit.
+
 ## Backlog
 
 1. Deck execution layer.
@@ -538,8 +546,8 @@ downstream tools to compare.
      selected measurement artifacts, selected Fourier artifacts, and selected
      run summaries, plus output-plan integration beyond stable table routing.
    - Expand deck-controlled output-plan integration beyond stable table
-     routing and scoped `.save`, `.probe`, `.print`, and `.plot` selection
-     toward full SPICE compatibility.
+     routing and scoped `.save`, `.probe`, `.print`, `.plot`, and `.four`
+     selection toward full SPICE compatibility.
    - Expand the deliberate `.control` subset beyond simple analysis/output
      command routing, including control flow, variables, and script execution
      policy.


### PR DESCRIPTION
Summary
- Normalize selected .control four/fourier commands into .four deck cards across Python, Rust, and TypeScript.
- Cover analyze/resolve source control-block paths by parsing normalized active lines through existing Fourier resolvers.
- Update SPICE package docs, changelogs, and the full implementation plan slice log.

Tests
- PYTHONPATH="$(find code/packages/python -maxdepth 2 -type d -name src | paste -sd: -)" /Users/adhithya/.local/share/mise/installs/python/3.12.13/bin/python3 -m ruff check code/packages/python/spice-engine/src/spice_engine/compatibility.py code/packages/python/spice-engine/tests/test_compatibility.py
- PYTHONPATH="$(find code/packages/python -maxdepth 2 -type d -name src | paste -sd: -)" /Users/adhithya/.local/share/mise/installs/python/3.12.13/bin/python3 -m pytest code/packages/python/spice-engine/tests -q
- cargo fmt --manifest-path code/packages/rust/spice-engine/Cargo.toml -- --check
- cargo test --manifest-path code/packages/rust/spice-engine/Cargo.toml
- npm --prefix code/packages/typescript/spice-engine ci
- npm --prefix code/packages/typescript/spice-engine run build
- npm --prefix code/packages/typescript/spice-engine test
- git diff --check