### PR TITLE
feat(visicalc-qt): render the infinite grid via sc_get_display_window (formatting visible)

### DIFF
--- a/demo/visicalc-qt/InfiniteSheet.qml
+++ b/demo/visicalc-qt/InfiniteSheet.qml
@@ -1,6 +1,6 @@
 // InfiniteSheet.qml — a virtualized, effectively-infinite spreadsheet view for
 // the Qt demo, rendered on the shared Rust engine through the viewport
-// primitive (the same get_window / used_range / changed_since the SwiftUI
+// primitive (the same get_display_window / used_range / changed_since the SwiftUI
 // InfiniteGridView and the web infinite.html drive).
 //
 // The sheet is u32 × u32 and sparse; only the cells in the VISIBLE rows are ever
@@ -24,8 +24,9 @@
 //   • gutter.contentY  ← body ListView.contentY               (gutter tracks ↕)
 //
 // Each visible row delegate calls `doc.rowCells(rowNum)` ONCE — a single engine
-// `get_window` over that row's 1×totalCols strip — so the per-frame engine work
-// is proportional to visible rows, never to the sheet's height.
+// `get_display_window` over that row's 1×totalCols strip (display strings,
+// already rendered through each cell's format code) — so the per-frame engine
+// work is proportional to visible rows, never to the sheet's height.
 
 import QtQuick 2.15
 import QtQuick.Controls 2.15

--- a/demo/visicalc-qt/README.md
+++ b/demo/visicalc-qt/README.md
@@ -75,7 +75,11 @@ with binary-op error propagation (`=1/0` → `#DIV/0!`, and `=A1+1` over it →
 `SpreadsheetModel` also exposes the engine's **viewport primitive** —
 `window(r0,c0,r1,c1)` (a dense `QVariantList` rectangle of display strings),
 `usedRange()`, `columnLetters()`, `currentRevision()`, and `changedSince()` —
-over the C ABI's `sc_get_window` / `sc_used_range` / `sc_changed_since`. These
+over the C ABI's `sc_get_display_window` / `sc_used_range` / `sc_changed_since`.
+`window()` reads `sc_get_display_window`, so each cell arrives already rendered
+through its Excel-style format code (the seed formats the cross-foot totals as
+`#,##0.00` and the far-flung `Z1000` total as a percent) — the Qt host paints
+the strings directly and never re-derives number formatting. These
 are `Q_INVOKABLE`, so a windowed QML grid (rendering only the visible rectangle
 of an unbounded sheet, the Qt sibling of the web/SwiftUI infinite views) binds
 to them directly.
@@ -88,8 +92,8 @@ sparse) sheet rendered on the same engine. The body is a QtQuick `ListView`,
 which natively virtualizes: it instantiates a row delegate only while that row
 is on screen, so a 1000-row-tall sheet costs the handful of rows you can
 actually see. Each visible row calls `model.rowCells(row)` **once** — a single
-`get_window` over that row's `1×totalCols` strip — so per-frame engine work is
-proportional to *visible* rows, never to the sheet's height.
+`get_display_window` over that row's `1×totalCols` strip — so per-frame engine
+work is proportional to *visible* rows, never to the sheet's height.
 
 Two-axis scroll with frozen chrome, kept in sync by binding offsets: the
 column-letter header tracks the body's horizontal pan (`header.contentX ←

--- a/demo/visicalc-qt/src/SpreadsheetModel.cpp
+++ b/demo/visicalc-qt/src/SpreadsheetModel.cpp
@@ -102,6 +102,24 @@ void SpreadsheetModel::seed() {
     for (const auto &cell : cells) {
         takeString(sc_set_cell(session_, cell.a1, cell.raw));
     }
+
+    // Attach Excel-style format codes so the engine's display path is visible in
+    // the infinite view (which now renders via sc_get_display_window): the
+    // cross-foot totals read with thousands grouping + two decimals, and the
+    // far-flung Z1000 total as a percent. Values are unchanged — only how the
+    // display strings render. Identical to the web demo's seeded formats.
+    static const struct {
+        const char *a1;
+        const char *code;
+    } formats[] = {
+        {"E1", "#,##0.00"}, {"E2", "#,##0.00"}, {"E3", "#,##0.00"},
+        {"E4", "#,##0.00"}, {"E5", "#,##0.00"},
+        {"A5", "#,##0.00"}, {"B5", "#,##0.00"}, {"C5", "#,##0.00"}, {"D5", "#,##0.00"},
+        {"Z1000", "0.0%"}, // 39 → "3900.0%": proves the format applies far off-origin
+    };
+    for (const auto &f : formats) {
+        sc_set_format(session_, f.a1, f.code);
+    }
 }
 
 QString SpreadsheetModel::display(const QString &a1) const {
@@ -158,17 +176,22 @@ void SpreadsheetModel::select(int row, int col) {
 // — the Qt sibling of the SwiftUI/web infinite views. 1-based inclusive coords.
 
 QVariantList SpreadsheetModel::window(int row0, int col0, int row1, int col1) const {
-    const QString json = takeString(sc_get_window(
+    // sc_get_display_window returns each cell already rendered through its format
+    // code as a display STRING (the format-aware sibling of sc_get_window), so the
+    // QML grid paints the strings directly and never re-derives number formatting.
+    // The JSON is {"row0":..,"cols":..,"cells":[["1,234.50",..],..]} (empty cells
+    // ""), or {"error":".."} on a bad/oversized request.
+    const QString json = takeString(sc_get_display_window(
         session_, static_cast<quint32>(row0), static_cast<quint32>(col0),
         static_cast<quint32>(row1), static_cast<quint32>(col1)));
     QVariantList rows;
     const QJsonDocument doc = QJsonDocument::fromJson(json.toUtf8());
     if (!doc.isObject()) return rows; // bad/oversized request → empty
-    const QJsonArray values = doc.object().value(QStringLiteral("values")).toArray();
-    for (const QJsonValue &rowVal : values) {
+    const QJsonArray cells = doc.object().value(QStringLiteral("cells")).toArray();
+    for (const QJsonValue &rowVal : cells) {
         QVariantList row;
         for (const QJsonValue &cell : rowVal.toArray()) {
-            row.append(displayValue(cell.toObject()));
+            row.append(cell.toString());
         }
         rows.append(QVariant(row));
     }

--- a/demo/visicalc-qt/test/tst_window.cpp
+++ b/demo/visicalc-qt/test/tst_window.cpp
@@ -37,9 +37,11 @@ void TstWindow::windowIsEngineComputedAndDense() {
     // engine-computed and dense.
     const QVariantList w = m.window(1, 1, 5, 5);
     QCOMPARE(w.size(), 5);
-    QCOMPARE(at(w, 1, 1, 1, 1), QStringLiteral("15"));  // A1
-    QCOMPARE(at(w, 1, 1, 1, 5), QStringLiteral("38"));  // E1 = SUM(A1:D1)
-    QCOMPARE(at(w, 1, 1, 5, 5), QStringLiteral("169")); // E5 grand total
+    QCOMPARE(at(w, 1, 1, 1, 1), QStringLiteral("15"));      // A1 (unformatted)
+    // E1/E5 carry the "#,##0.00" seed format → the engine renders the formatted
+    // display string (window() now reads sc_get_display_window).
+    QCOMPARE(at(w, 1, 1, 1, 5), QStringLiteral("38.00"));   // E1 = SUM(A1:D1)
+    QCOMPARE(at(w, 1, 1, 5, 5), QStringLiteral("169.00"));  // E5 grand total
 }
 
 void TstWindow::farWindowReachesZ1000AndGapsAreSparse() {
@@ -47,8 +49,9 @@ void TstWindow::farWindowReachesZ1000AndGapsAreSparse() {
     // Plant a far-flung formula 1000 rows down (Z = col 26).
     m.setCell("Z1000", "=SUM(A1:A4)"); // 15+8+12+4 = 39
     // A window around it returns the computed value — reachable without
-    // materialising the millions of cells in between.
-    QCOMPARE(at(m.window(998, 24, 1002, 28), 998, 24, 1000, 26), QStringLiteral("39"));
+    // materialising the millions of cells in between. Z1000 carries the "0.0%"
+    // seed format, so 39 renders as "3900.0%": the format applies 1000 rows down.
+    QCOMPARE(at(m.window(998, 24, 1002, 28), 998, 24, 1000, 26), QStringLiteral("3900.0%"));
     // The gap between the two data islands is empty (the sheet is sparse).
     const QVariantList gap = m.window(100, 1, 110, 10);
     for (const QVariant &rowVar : gap) {
@@ -79,8 +82,9 @@ void TstWindow::extentColumnLettersAndChangedSince() {
     QVERIFY2(changed.contains("A1"), "A1 changed");
     QVERIFY2(changed.contains("Z1000"),
              qPrintable("far dependent recomputed: " + changed.join(",")));
-    // And the recomputed value shows through a fresh window read: 115+8+12+4.
-    QCOMPARE(at(m.window(1000, 26, 1000, 26), 1000, 26, 1000, 26), QStringLiteral("139"));
+    // And the recomputed value shows through a fresh window read: 115+8+12+4 =
+    // 139, formatted as a percent ("0.0%") → "13900.0%".
+    QCOMPARE(at(m.window(1000, 26, 1000, 26), 1000, 26, 1000, 26), QStringLiteral("13900.0%"));
 }
 
 // The infinite-view binding layer (InfiniteSheet.qml drives these): one engine
@@ -100,9 +104,9 @@ void TstWindow::infiniteViewSelectEditAndRowCells() {
     // is the budget's first row: A1..E1 = 15,3,12,8,38, then blanks.
     const QVariantList row1 = m.rowCells(1);
     QCOMPARE(row1.size(), m.totalCols());
-    QCOMPARE(row1.at(0).toString(), QStringLiteral("15")); // A1
-    QCOMPARE(row1.at(4).toString(), QStringLiteral("38")); // E1 = SUM(A1:D1)
-    QCOMPARE(row1.at(9).toString(), QString());            // J1 empty (sparse)
+    QCOMPARE(row1.at(0).toString(), QStringLiteral("15"));    // A1 (unformatted)
+    QCOMPARE(row1.at(4).toString(), QStringLiteral("38.00")); // E1 = SUM(A1:D1), formatted
+    QCOMPARE(row1.at(9).toString(), QString());               // J1 empty (sparse)
     // A row in the gap between the data islands is entirely blank.
     const QVariantList gapRow = m.rowCells(200);
     for (const QVariant &cell : gapRow) QCOMPARE(cell.toString(), QString());
@@ -127,10 +131,10 @@ void TstWindow::infiniteViewSelectEditAndRowCells() {
     m.selectInf(2, 1);                 // A2
     m.commitInf(QStringLiteral("108"));
     QVERIFY2(m.revision() > revBefore, "commit bumps the revision so rows re-fetch");
-    QCOMPARE(m.rowCells(2).at(0).toString(), QStringLiteral("108")); // A2
-    QCOMPARE(m.rowCells(2).at(4).toString(), QStringLiteral("151")); // E2 = 108+14+7+22
-    QCOMPARE(m.rowCells(5).at(0).toString(), QStringLiteral("139")); // A5 = 15+108+12+4
-    QCOMPARE(m.rowCells(5).at(4).toString(), QStringLiteral("269")); // E5 grand total
+    QCOMPARE(m.rowCells(2).at(0).toString(), QStringLiteral("108"));    // A2 (unformatted)
+    QCOMPARE(m.rowCells(2).at(4).toString(), QStringLiteral("151.00")); // E2 = 108+14+7+22, formatted
+    QCOMPARE(m.rowCells(5).at(0).toString(), QStringLiteral("139.00")); // A5 = 15+108+12+4, formatted
+    QCOMPARE(m.rowCells(5).at(4).toString(), QStringLiteral("269.00")); // E5 grand total, formatted
 }
 
 QTEST_MAIN(TstWindow)


### PR DESCRIPTION
## What

Switches the Qt demo's windowed reader from `sc_get_window` (typed value JSON, formatted client-side) to **`sc_get_display_window`** — the engine returns each visible cell already rendered through its format code as a display string, so the QML `ListView` paints the strings directly and never re-derives number formatting. The Qt sibling of the web demo's #6019 switch; second native backend after the web HTML demo.

## Changes

- **`src/SpreadsheetModel.cpp`** — `window()` reads `sc_get_display_window` and parses the `"cells"` string array. The 5×5 parity-grid path (`display()` → `sc_get_value`) is untouched; `displayValue()` stays for it. `seed()` attaches the same format codes as the web demo: cross-foot totals (col E + row 5) → `"#,##0.00"`, far-flung `Z1000` → `"0.0%"` (`39` → `"3900.0%"`, proving the format applies 1000 rows off-origin).
- **`test/tst_window.cpp`** — asserts the formatted display strings (`38.00` / `169.00` / `3900.0%` / `13900.0%` / `151.00` / `269.00`).
- **README + `InfiniteSheet.qml`** comments updated to `get_display_window`.

## Verification

Built and ran locally with **Qt 6.11 (qmake)** against the re-vendored `spreadsheet-capi` 0.5.0 static lib (`Vendor/` is git-ignored):
- `tst_window` — **6/6 PASS** (the windowing/infinite-view suite, now asserting formatted strings)
- `tst_model` — **5/5 PASS** (the 5×5 parity grid, unaffected)

`/security-review` — **PASSED** (FFI free-once via `takeString`, JSON parse guarded, coord casts rejected server-side by the `MAX_WINDOW_CELLS` cap).

## Next

Continue rolling the same switch through the remaining native infinite grids: Flutter → Compose → XAML → SwiftUI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)