### PR TITLE
Accept .control run markers

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ### Added
 
+- **Deck control run marker routing** —
+  `analyze_deck_controls()` and `resolve_deck_sources()` now accept selected
+  `.control` block `run` execution markers as no-op control commands instead
+  of reporting unsupported-command diagnostics, matching Rust and TypeScript.
+
 - **Deck control Fourier routing** —
   `analyze_deck_controls()` and `resolve_deck_sources()` now normalize
   selected `.control` block `four` and `fourier` harmonic output commands into

--- a/code/packages/python/spice-engine/README.md
+++ b/code/packages/python/spice-engine/README.md
@@ -161,8 +161,9 @@ it returns active lines before `.end` and stable diagnostics for unsupported
 `.include`, `.lib`, and `.control` directives. Inside `.control` blocks,
 selected analysis/output commands (`op`, `dc`, `ac`, `tran`, `save`, `probe`,
 `measure`, `meas`, `four`, `fourier`, `print`, and `plot`) are normalized into
-dotted deck cards, while unrecognized non-comment commands emit diagnostics
-until a broader executed control subset is in scope.
+dotted deck cards, and `run` is accepted as a no-op execution marker. Other
+unrecognized non-comment commands emit diagnostics until a broader executed
+control subset is in scope.
 `resolve_deck_sources()` is the first include/library resolution layer: callers
 provide a source-content map, `.include` directives are expanded in place, and
 `.lib path section` selects a named `.lib` / `.endl` section with stable

--- a/code/packages/python/spice-engine/src/spice_engine/compatibility.py
+++ b/code/packages/python/spice-engine/src/spice_engine/compatibility.py
@@ -515,6 +515,7 @@ _SUPPORTED_CONTROL_BLOCK_COMMANDS = frozenset(
         ".plot",
     }
 )
+_NOOP_CONTROL_BLOCK_COMMANDS = frozenset({"run", ".run"})
 _SPICE_SUFFIX_FACTORS = {
     "t": 1.0e12,
     "g": 1.0e9,
@@ -549,6 +550,8 @@ def analyze_deck_controls(netlist: str) -> DeckControlSummary:
             control_line = _control_block_command_as_deck_line(stripped)
             if control_line is not None:
                 active_lines.append(control_line)
+                continue
+            if _is_noop_control_block_command(stripped):
                 continue
             diagnostics.append(
                 DeckControlDiagnostic(
@@ -3032,6 +3035,8 @@ def _resolve_deck_lines(
             if control_line is not None:
                 active_lines.append(control_line)
                 continue
+            if _is_noop_control_block_command(stripped):
+                continue
             state.diagnostics.append(
                 DeckResolutionDiagnostic(
                     code="SPICE_DECK_CONTROL_COMMAND",
@@ -3334,3 +3339,8 @@ def _control_block_command_as_deck_line(line: str) -> str | None:
     if len(parts) == 1:
         return directive
     return f"{directive} {parts[1]}"
+
+
+def _is_noop_control_block_command(line: str) -> bool:
+    command = line.split(maxsplit=1)[0].lower()
+    return command in _NOOP_CONTROL_BLOCK_COMMANDS

--- a/code/packages/python/spice-engine/tests/test_compatibility.py
+++ b/code/packages/python/spice-engine/tests/test_compatibility.py
@@ -142,13 +142,11 @@ run
         (".include", 2, "error"),
         (".lib", 3, "error"),
         (".control", 4, "error"),
-        (".control", 13, "error"),
     ]
     assert [diag.code for diag in summary.diagnostics] == [
         "SPICE_DECK_UNSUPPORTED_DIRECTIVE",
         "SPICE_DECK_UNSUPPORTED_DIRECTIVE",
         "SPICE_DECK_UNSUPPORTED_DIRECTIVE",
-        "SPICE_DECK_CONTROL_COMMAND",
     ]
     measurement_summary = resolve_deck_measurements("\n".join(summary.active_lines) + "\n.end")
     assert [
@@ -255,11 +253,9 @@ run
         "SPICE_DECK_INCLUDE_CYCLE",
         "SPICE_DECK_LIB_SECTION_NOT_FOUND",
         "SPICE_DECK_UNSUPPORTED_DIRECTIVE",
-        "SPICE_DECK_CONTROL_COMMAND",
     ]
     assert [(diag.directive, diag.line_number) for diag in summary.diagnostics[3:]] == [
         (".control", 5),
-        (".control", 14),
     ]
     measurement_summary = resolve_deck_measurements("\n".join(summary.active_lines) + "\n.end")
     assert [

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Accept selected `.control` block `run` execution markers as no-op control
+  commands in `analyze_deck_controls` and `resolve_deck_sources`, matching
+  Python and TypeScript.
 - Add selected `.control` block `four` and `fourier` command routing to
   `analyze_deck_controls` and `resolve_deck_sources`; the commands are
   normalized into `.four` deck cards, matching Python and TypeScript.

--- a/code/packages/rust/spice-engine/README.md
+++ b/code/packages/rust/spice-engine/README.md
@@ -128,8 +128,9 @@ returns active lines before `.end` and stable diagnostics for unsupported
 `.include`, `.lib`, and `.control` directives. Inside `.control` blocks,
 selected analysis/output commands (`op`, `dc`, `ac`, `tran`, `save`, `probe`,
 `measure`, `meas`, `four`, `fourier`, `print`, and `plot`) are normalized into
-dotted deck cards, while unrecognized non-comment commands emit diagnostics
-until a broader executed control subset is in scope.
+dotted deck cards, and `run` is accepted as a no-op execution marker. Other
+unrecognized non-comment commands emit diagnostics until a broader executed
+control subset is in scope.
 `resolve_deck_sources` is the first include/library resolution layer: callers
 provide a source-content map, `.include` directives are expanded in place, and
 `.lib path section` selects a named `.lib` / `.endl` section with stable

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -3568,6 +3568,9 @@ pub fn analyze_deck_controls(netlist: &str) -> DeckControlSummary {
                 active_lines.push(control_line);
                 continue;
             }
+            if is_noop_control_block_command(stripped) {
+                continue;
+            }
             diagnostics.push(DeckControlDiagnostic {
                 code: "SPICE_DECK_CONTROL_COMMAND".to_string(),
                 directive: ".control".to_string(),
@@ -4364,6 +4367,9 @@ fn resolve_deck_lines(
             }
             if let Some(control_line) = control_block_command_as_deck_line(stripped) {
                 active_lines.push(control_line);
+                continue;
+            }
+            if is_noop_control_block_command(stripped) {
                 continue;
             }
             state.diagnostics.push(DeckResolutionDiagnostic {
@@ -6894,6 +6900,15 @@ fn control_block_command_as_deck_line(line: &str) -> Option<String> {
     } else {
         Some(format!("{directive} {rest}"))
     }
+}
+
+fn is_noop_control_block_command(line: &str) -> bool {
+    matches!(
+        line.split_whitespace()
+            .next()
+            .map(|command| command.to_ascii_lowercase()),
+        Some(command) if command == "run" || command == ".run"
+    )
 }
 
 fn is_unsupported_deck_control_directive(directive: &str) -> bool {

--- a/code/packages/rust/spice-engine/tests/compatibility_tests.rs
+++ b/code/packages/rust/spice-engine/tests/compatibility_tests.rs
@@ -174,8 +174,7 @@ run
         vec![
             (".include", 2, "error"),
             (".lib", 3, "error"),
-            (".control", 4, "error"),
-            (".control", 13, "error")
+            (".control", 4, "error")
         ]
     );
     assert_eq!(
@@ -187,8 +186,7 @@ run
         vec![
             "SPICE_DECK_UNSUPPORTED_DIRECTIVE",
             "SPICE_DECK_UNSUPPORTED_DIRECTIVE",
-            "SPICE_DECK_UNSUPPORTED_DIRECTIVE",
-            "SPICE_DECK_CONTROL_COMMAND"
+            "SPICE_DECK_UNSUPPORTED_DIRECTIVE"
         ]
     );
     let measurement_deck = format!("{}\n.end", summary.active_lines.join("\n"));
@@ -351,8 +349,7 @@ run
             "SPICE_DECK_INCLUDE_NOT_FOUND",
             "SPICE_DECK_INCLUDE_CYCLE",
             "SPICE_DECK_LIB_SECTION_NOT_FOUND",
-            "SPICE_DECK_UNSUPPORTED_DIRECTIVE",
-            "SPICE_DECK_CONTROL_COMMAND"
+            "SPICE_DECK_UNSUPPORTED_DIRECTIVE"
         ]
     );
     assert_eq!(
@@ -362,7 +359,7 @@ run
             .skip(3)
             .map(|diagnostic| (diagnostic.directive.as_str(), diagnostic.line_number))
             .collect::<Vec<_>>(),
-        vec![(".control", 5), (".control", 14)]
+        vec![(".control", 5)]
     );
     let measurement_deck = format!("{}\n.end", summary.active_lines.join("\n"));
     let measurement_summary = resolve_deck_measurements(&measurement_deck);

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Accept selected `.control` block `run` execution markers as no-op control
+  commands in `analyzeDeckControls` and `resolveDeckSources`, matching Python
+  and Rust.
 - Add selected `.control` block `four` and `fourier` command routing to
   `analyzeDeckControls` and `resolveDeckSources`; the commands are normalized
   into `.four` deck cards, matching Python and Rust.

--- a/code/packages/typescript/spice-engine/README.md
+++ b/code/packages/typescript/spice-engine/README.md
@@ -135,8 +135,9 @@ returns active lines before `.end` and stable diagnostics for unsupported
 `.include`, `.lib`, and `.control` directives. Inside `.control` blocks,
 selected analysis/output commands (`op`, `dc`, `ac`, `tran`, `save`, `probe`,
 `measure`, `meas`, `four`, `fourier`, `print`, and `plot`) are normalized into
-dotted deck cards, while unrecognized non-comment commands emit diagnostics
-until a broader executed control subset is in scope.
+dotted deck cards, and `run` is accepted as a no-op execution marker. Other
+unrecognized non-comment commands emit diagnostics until a broader executed
+control subset is in scope.
 `resolveDeckSources` is the first include/library resolution layer: callers
 provide a source-content map, `.include` directives are expanded in place, and
 `.lib path section` selects a named `.lib` / `.endl` section with stable

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -2854,6 +2854,7 @@ const SUPPORTED_CONTROL_BLOCK_COMMANDS = new Set([
   "plot",
   ".plot",
 ]);
+const NOOP_CONTROL_BLOCK_COMMANDS = new Set(["run", ".run"]);
 
 export function compatibilityCorpus(): readonly CompatibilityDeck[] {
   return COMPATIBILITY_CORPUS;
@@ -2881,6 +2882,9 @@ export function analyzeDeckControls(netlist: string): DeckControlSummary {
       const controlLine = controlBlockCommandAsDeckLine(stripped);
       if (controlLine !== undefined) {
         activeLines.push(controlLine);
+        continue;
+      }
+      if (isNoopControlBlockCommand(stripped)) {
         continue;
       }
       diagnostics.push({
@@ -3441,6 +3445,9 @@ function resolveDeckLines(
       const controlLine = controlBlockCommandAsDeckLine(stripped);
       if (controlLine !== undefined) {
         activeLines.push(controlLine);
+        continue;
+      }
+      if (isNoopControlBlockCommand(stripped)) {
         continue;
       }
       state.diagnostics.push({
@@ -5702,6 +5709,11 @@ function controlBlockCommandAsDeckLine(line: string): string | undefined {
         : `.${command}`;
   const rest = line.slice(parts[0].length).trimStart();
   return rest.length === 0 ? directive : `${directive} ${rest}`;
+}
+
+function isNoopControlBlockCommand(line: string): boolean {
+  const command = line.split(/\s+/, 1)[0]?.toLowerCase();
+  return command !== undefined && NOOP_CONTROL_BLOCK_COMMANDS.has(command);
 }
 
 export function subcircuitDefinition(

--- a/code/packages/typescript/spice-engine/tests/compatibility.test.ts
+++ b/code/packages/typescript/spice-engine/tests/compatibility.test.ts
@@ -149,13 +149,11 @@ run
       [".include", 2, "error"],
       [".lib", 3, "error"],
       [".control", 4, "error"],
-      [".control", 13, "error"],
     ]);
     expect(summary.diagnostics.map((diagnostic) => diagnostic.code)).toStrictEqual([
       "SPICE_DECK_UNSUPPORTED_DIRECTIVE",
       "SPICE_DECK_UNSUPPORTED_DIRECTIVE",
       "SPICE_DECK_UNSUPPORTED_DIRECTIVE",
-      "SPICE_DECK_CONTROL_COMMAND",
     ]);
     const measurementSummary = resolveDeckMeasurements(`${summary.activeLines.join("\n")}\n.end`);
     expect(measurementSummary.measurements.map((card) => [
@@ -260,14 +258,12 @@ run
       "SPICE_DECK_INCLUDE_CYCLE",
       "SPICE_DECK_LIB_SECTION_NOT_FOUND",
       "SPICE_DECK_UNSUPPORTED_DIRECTIVE",
-      "SPICE_DECK_CONTROL_COMMAND",
     ]);
     expect(summary.diagnostics.slice(3).map(({ directive, lineNumber }) => [
       directive,
       lineNumber,
     ])).toStrictEqual([
       [".control", 5],
-      [".control", 14],
     ]);
     const measurementSummary = resolveDeckMeasurements(`${summary.activeLines.join("\n")}\n.end`);
     expect(measurementSummary.measurements.map((card) => [

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -36,8 +36,9 @@ downstream tools to compare.
      stable non-executed diagnostics, and selected `.control` block
      analysis/output commands (`op`, `dc`, `ac`, `tran`, `save`, `probe`,
      `measure`, `meas`, `four`, `fourier`, `print`, and `plot`) now normalize
-     into dotted deck cards; parsed `.measure dc` / `.meas dc` cards now route DC
-     sweep probe samples into the shared scalar measurement table surface;
+     into dotted deck cards while `run` is accepted as a no-op execution
+     marker; parsed `.measure dc` / `.meas dc` cards now route DC sweep probe
+     samples into the shared scalar measurement table surface;
      parsed `.measure ac` / `.meas ac` cards now route AC probe magnitudes over
      optional frequency windows into the same measurement table surface; parsed
      transient `.measure ... FIND ... AT=` cards now route single-time probe
@@ -536,6 +537,14 @@ downstream tools to compare.
       harmonic output commands (`four` and `fourier`) into the same `.four`
       deck cards consumed by existing Fourier resolvers.
     - Unrecognized non-comment commands inside `.control` blocks remain
+      diagnostic-only so unsupported control flow is still explicit.
+
+48. Selected `.control` run marker routing.
+    - Status: completed in this selected control run-marker routing slice.
+    - Python, Rust, and TypeScript now accept selected `.control` block `run`
+      execution markers as no-op control commands after selected analysis and
+      output commands have normalized into deck cards.
+    - Other unrecognized non-comment commands inside `.control` blocks remain
       diagnostic-only so unsupported control flow is still explicit.
 
 ## Backlog


### PR DESCRIPTION
## Summary
- accept selected `.control` block `run` / `.run` execution markers as no-op control commands
- keep unknown `.control` commands diagnostic-only while preserving normalized analysis/output command routing
- update Python, Rust, and TypeScript docs/tests plus the SPICE implementation plan

## Verification
- `PYTHONPATH="$(find code/packages/python -maxdepth 2 -type d -name src | paste -sd: -)" /Users/adhithya/.local/share/mise/installs/python/3.12.13/bin/python3 -m ruff check code/packages/python/spice-engine/src/spice_engine/compatibility.py code/packages/python/spice-engine/tests/test_compatibility.py`
- `PYTHONPATH="$(find code/packages/python -maxdepth 2 -type d -name src | paste -sd: -)" /Users/adhithya/.local/share/mise/installs/python/3.12.13/bin/python3 -m pytest code/packages/python/spice-engine/tests -q`
- `cargo fmt --manifest-path code/packages/rust/spice-engine/Cargo.toml -- --check`
- `cargo test --manifest-path code/packages/rust/spice-engine/Cargo.toml`
- `npm --prefix code/packages/typescript/spice-engine run build`
- `npm --prefix code/packages/typescript/spice-engine test`
- `git diff --check`