### PR TITLE
feat(visicalc-flutter): render the infinite grid via sc_get_display_window (formatting visible)

### DIFF
--- a/demo/visicalc-flutter/README.md
+++ b/demo/visicalc-flutter/README.md
@@ -105,9 +105,12 @@ grid to `InfiniteGrid` — a virtualized, effectively-infinite (u32 × u32, spar
 sheet rendered on the same engine. The body is a `ListView.builder`, which
 natively virtualizes: it calls its `itemBuilder` only for rows near the viewport
 and recycles them as they scroll off, so a 1000-row sheet costs the handful of
-rows you can see. Each built row makes **one** engine `get_window` over its
-`1×totalCols` strip (`InfiniteSheetModel.rowCells`) — per-frame engine work is
-proportional to *visible* rows, never the sheet's height.
+rows you can see. Each built row makes **one** engine `get_display_window` over
+its `1×totalCols` strip (`InfiniteSheetModel.rowCells`) — display strings, each
+already rendered through its Excel-style format code (the seed formats the
+cross-foot totals as `#,##0.00` and the far-flung `Z1000` total as a percent),
+so the Flutter host paints them directly. Per-frame engine work is proportional
+to *visible* rows, never the sheet's height.
 
 Two-axis scroll with frozen chrome, kept in sync by one-way controller links
 (the chrome is non-interactive and slaved to the body): the column-letter header

--- a/demo/visicalc-flutter/lib/engine.dart
+++ b/demo/visicalc-flutter/lib/engine.dart
@@ -63,6 +63,10 @@ typedef _CurrentRevD = int Function(Pointer<Void>);
 typedef _ChangedSinceC = Pointer<Uint8> Function(Pointer<Void>, Uint64);
 typedef _ChangedSinceD = Pointer<Uint8> Function(Pointer<Void>, int);
 
+// sc_set_format(session, a1, code) → void. An empty code clears the format.
+typedef _SetFormatC = Void Function(Pointer<Void>, Pointer<Uint8>, Pointer<Uint8>);
+typedef _SetFormatD = void Function(Pointer<Void>, Pointer<Uint8>, Pointer<Uint8>);
+
 /// A single spreadsheet session, owning the opaque C handle.
 class SpreadsheetSession {
   final DynamicLibrary _lib;
@@ -74,6 +78,8 @@ class SpreadsheetSession {
   late final _GetD _getRaw;
   late final _StringFreeD _stringFree;
   late final _WindowD _getWindow;
+  late final _WindowD _getDisplayWindow;
+  late final _SetFormatD _setFormatFn;
   late final _NoArgD _usedRangeFn;
   late final _ColLettersD _columnLettersFn;
   late final _CurrentRevD _currentRevisionFn;
@@ -92,6 +98,8 @@ class SpreadsheetSession {
     _getRaw = _lib.lookupFunction<_GetC, _GetD>('sc_get_raw');
     _stringFree = _lib.lookupFunction<_StringFreeC, _StringFreeD>('sc_string_free');
     _getWindow = _lib.lookupFunction<_WindowC, _WindowD>('sc_get_window');
+    _getDisplayWindow = _lib.lookupFunction<_WindowC, _WindowD>('sc_get_display_window');
+    _setFormatFn = _lib.lookupFunction<_SetFormatC, _SetFormatD>('sc_set_format');
     _usedRangeFn = _lib.lookupFunction<_NoArgC, _NoArgD>('sc_used_range');
     _columnLettersFn = _lib.lookupFunction<_ColLettersC, _ColLettersD>('sc_column_letters');
     _currentRevisionFn = _lib.lookupFunction<_CurrentRevC, _CurrentRevD>('sc_current_revision');
@@ -226,16 +234,34 @@ class SpreadsheetSession {
   // C ABI's sc_get_window etc.), 1-based inclusive coords, so a windowed Flutter
   // grid can render only the visible rectangle of an unbounded sheet.
 
+  /// Set a cell's display format code (an Excel-style code like `"#,##0.00"` or
+  /// `"0%"`); an empty code clears it. Drives the engine's display path that
+  /// [window] reads through `sc_get_display_window`.
+  void setFormat(String a1, String code) {
+    final a1Ptr = _toCString(a1);
+    final codePtr = _toCString(code);
+    try {
+      _setFormatFn(_handle, a1Ptr, codePtr);
+    } finally {
+      _freeCString(a1Ptr);
+      _freeCString(codePtr);
+    }
+  }
+
   /// Dense display strings for the inclusive 1-based rectangle, row-major
   /// (empty cells become ''). Empty list on a bad/oversized request.
+  ///
+  /// Reads `sc_get_display_window`: each cell arrives already rendered through
+  /// its format code as a display string, so the host paints it directly and
+  /// never re-derives number formatting. The format-aware sibling of
+  /// `sc_get_window`; the JSON is `{...,"cells":[["1,234.50",...],...]}`.
   List<List<String>> window(int row0, int col0, int row1, int col1) {
-    final json = _takeString(_getWindow(_handle, row0, col0, row1, col1));
+    final json = _takeString(_getDisplayWindow(_handle, row0, col0, row1, col1));
     final Object? obj = jsonDecode(json);
-    if (obj is! Map || obj['values'] is! List) return const [];
-    return (obj['values'] as List)
-        .map<List<String>>((row) => (row as List)
-            .map<String>((c) => (c is Map) ? _displayValue(c) : '')
-            .toList())
+    if (obj is! Map || obj['cells'] is! List) return const [];
+    return (obj['cells'] as List)
+        .map<List<String>>((row) =>
+            (row as List).map<String>((c) => (c as String?) ?? '').toList())
         .toList();
   }
 
@@ -386,6 +412,21 @@ class InfiniteSheetModel {
     ];
     for (final cell in cells) {
       _session.setCell(cell[0], cell[1]);
+    }
+
+    // Attach Excel-style format codes so the engine's display path is visible in
+    // the windowed view (which renders via sc_get_display_window): the cross-foot
+    // totals read with thousands grouping + two decimals, and the far-flung Z1000
+    // total as a percent. Values are unchanged — only how the display strings
+    // render. Identical to the web/Qt demos' seeded formats.
+    const formats = <List<String>>[
+      ['E1', '#,##0.00'], ['E2', '#,##0.00'], ['E3', '#,##0.00'],
+      ['E4', '#,##0.00'], ['E5', '#,##0.00'],
+      ['A5', '#,##0.00'], ['B5', '#,##0.00'], ['C5', '#,##0.00'], ['D5', '#,##0.00'],
+      ['Z1000', '0.0%'], // 39 → "3900.0%": proves the format applies far off-origin
+    ];
+    for (final f in formats) {
+      _session.setFormat(f[0], f[1]);
     }
   }
 

--- a/demo/visicalc-flutter/lib/infinite_grid.dart
+++ b/demo/visicalc-flutter/lib/infinite_grid.dart
@@ -1,15 +1,16 @@
 // infinite_grid.dart — a virtualized, effectively-infinite spreadsheet view for
 // the Flutter demo, rendered on the shared Rust engine through the viewport
-// primitive (the same get_window / used_range / changed_since the SwiftUI
-// InfiniteGridView, the Qt InfiniteSheet.qml, and the web infinite.html drive).
+// primitive (the same get_display_window / used_range / changed_since the
+// SwiftUI InfiniteGridView, the Qt InfiniteSheet.qml, and web infinite.html drive).
 //
 // The sheet is u32 × u32 and sparse; only the cells in the VISIBLE rows are ever
 // built. The body is a `ListView.builder`, which natively virtualizes — it calls
 // its `itemBuilder` only for rows near the viewport and recycles them as they
 // scroll off. So a 1000-row-tall sheet costs the handful of rows you can see,
-// and each built row makes ONE engine `get_window` over its 1×totalCols strip
-// (InfiniteSheetModel.rowCells). Per-frame engine work is proportional to
-// *visible* rows, never to the sheet's height.
+// and each built row makes ONE engine `get_display_window` over its 1×totalCols
+// strip (InfiniteSheetModel.rowCells) — display strings, already rendered through
+// each cell's format code. Per-frame engine work is proportional to *visible*
+// rows, never to the sheet's height.
 //
 // Two-axis scroll with frozen chrome, all kept in sync by one-way controller
 // links (the chrome is non-interactive and slaved to the body's scroll):

--- a/demo/visicalc-flutter/test/window_test.dart
+++ b/demo/visicalc-flutter/test/window_test.dart
@@ -87,8 +87,10 @@ void main() {
       addTearDown(m.dispose);
       final row1 = m.rowCells(1);
       expect(row1.length, m.totalCols);
-      expect(row1[0], '15'); // A1
-      expect(row1[4], '38'); // E1 = SUM(A1:D1)
+      expect(row1[0], '15'); // A1 (unformatted)
+      // E1 carries the "#,##0.00" seed format → engine renders the formatted
+      // display string (rowCells now reads sc_get_display_window).
+      expect(row1[4], '38.00'); // E1 = SUM(A1:D1), formatted
       expect(row1[9], ''); // J1 empty (sparse)
       // A row in the gap between the data islands is entirely blank.
       expect(m.rowCells(200).every((c) => c.isEmpty), isTrue);
@@ -110,10 +112,10 @@ void main() {
       addTearDown(m.dispose);
       m.selectInf(2, 1); // A2
       m.commitInf('108'); // 8 -> 108
-      expect(m.rowCells(2)[0], '108'); // A2
-      expect(m.rowCells(2)[4], '151'); // E2 = 108+14+7+22
-      expect(m.rowCells(5)[0], '139'); // A5 = 15+108+12+4
-      expect(m.rowCells(5)[4], '269'); // E5 grand total
+      expect(m.rowCells(2)[0], '108'); // A2 (unformatted)
+      expect(m.rowCells(2)[4], '151.00'); // E2 = 108+14+7+22, formatted
+      expect(m.rowCells(5)[0], '139.00'); // A5 = 15+108+12+4, formatted
+      expect(m.rowCells(5)[4], '269.00'); // E5 grand total, formatted
     });
   });
 }


### PR DESCRIPTION
## What

Switches the Flutter demo's windowed reader from `sc_get_window` (typed value JSON, formatted client-side) to **`sc_get_display_window`** over `dart:ffi` — the engine returns each visible cell already rendered through its format code as a display string, so the `ListView.builder` rows paint the strings directly and never re-derive number formatting. Third backend on the display path (after web #6019 and Qt #6023).

## Changes

- **`lib/engine.dart`** — add `dart:ffi` bindings for `sc_get_display_window` and `sc_set_format`; new `SpreadsheetSession.setFormat()`; `window()` parses the `"cells"` string array. The 5×5 parity-grid path (`display()` → `sc_get_value`) is unchanged; `_displayValue()` stays for it.
- **`InfiniteSheetModel._seed()`** attaches the same format codes as the web/Qt demos: cross-foot totals (col E + row 5) → `"#,##0.00"`, far-flung `Z1000` → `"0.0%"` (`39` → `"3900.0%"`).
- **`test/window_test.dart`** — the `InfiniteSheetModel` group asserts the formatted strings (`38.00` / `151.00` / `139.00` / `269.00`). The first group seeds no formats, so its `General`-rendered integers are unchanged.
- **README + `infinite_grid.dart`** comments updated to `get_display_window`.

## Verification

`flutter test test/window_test.dart` — **7/7 PASS**, against the re-vendored `spreadsheet-capi` 0.5.0 dylib (`native/` is git-ignored; `nm` confirms the `sc_get_display_window` symbol is present).

`/security-review` — **PASSED** (FFI free-once via `_takeString`/`sc_string_free`; `setFormat` frees both malloc'd inputs in a `finally`; window coords bounded server-side by the `MAX_WINDOW_CELLS` cap).

## Next

Continue rolling the switch through the remaining native backends: Compose → XAML → SwiftUI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)