### PR TITLE
feat(r-lang): discrete distribution families — binomial & Poisson (R-8b)

### DIFF
--- a/code/packages/rust/r-runtime/CHANGELOG.md
+++ b/code/packages/rust/r-runtime/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.3.0] - 2026-06-16
+
+### Added (via the shared `s-runtime`)
+
+- **R-8b — discrete distribution families**: `dbinom`/`pbinom`/`qbinom`/`rbinom`
+  and `dpois`/`ppois`/`qpois`/`rpois`, with DoS-bounded count loops. R picks
+  these up unchanged from the shared evaluator. See `s-runtime` 0.4.0.
+
 ## [0.2.0] - 2026-06-16
 
 ### Added (via the shared `s-runtime`)

--- a/code/packages/rust/r-runtime/src/lib.rs
+++ b/code/packages/rust/r-runtime/src/lib.rs
@@ -253,4 +253,17 @@ mod tests {
         assert_eq!(a, b);
         assert_eq!(a.len(), 3);
     }
+
+    #[test]
+    fn discrete_distributions_work_through_r() {
+        // R-8b: the binomial/Poisson families reach R too.
+        assert!((nums("dbinom(2, 4, 0.5)\n")[0] - 0.375).abs() < 1e-9);
+        assert!((nums("dpois(0, 1)\n")[0] - (-1.0_f64).exp()).abs() < 1e-9);
+        // Sampling is reproducible and within range.
+        let draws = nums("set.seed(5)\nrbinom(10, size = 8, prob = 0.5)\n");
+        assert_eq!(draws.len(), 10);
+        assert!(draws.iter().all(|&k| (0.0..=8.0).contains(&k)));
+        // A pathological size is a clean error through R, not a hang.
+        assert!(eval_r("rbinom(1000000, 1000000, 0.5)\n").is_err());
+    }
 }

--- a/code/packages/rust/s-runtime/CHANGELOG.md
+++ b/code/packages/rust/s-runtime/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.4.0] - 2026-06-16
+
+### Added
+
+- **Discrete distribution family (R-8b)** — the `d`/`p`/`q`/`r` functions for the
+  discrete distributions, wired to `statistics-core`:
+  - **Binomial**: `dbinom`, `pbinom`, `qbinom`, `rbinom` (parameters `size`,
+    `prob`).
+  - **Poisson**: `dpois`, `ppois`, `qpois`, `rpois` (parameter `lambda`).
+
+  Same vectorized `d`/`p`/`q` (NA-propagating), named/positional parameters, and
+  reproducible per-session RNG as the continuous families (R-8).
+
+### Security
+
+- The discrete CDFs and inverse-CDF samplers loop over an integer count
+  (`pbinom` is O(`size`), `ppois` is O(`x`), `rbinom` is O(n·`size`)). Two guards
+  bound every loop: a per-element cap (`MAX_DISCRETE_SUPPORT` ≈ 1M on `size` and
+  the `ppois` quantile) and a total-iteration budget (`MAX_DISCRETE_WORK` ≈ 134M
+  over `len·driver` / `n·per-sample`). A crafted `rbinom(1e6, 1e6, …)` or
+  `ppois(1e18, …)` is a clean error, not an unbounded loop.
+
 ## [0.3.0] - 2026-06-16
 
 ### Added

--- a/code/packages/rust/s-runtime/src/builtins.rs
+++ b/code/packages/rust/s-runtime/src/builtins.rs
@@ -12,7 +12,10 @@ use crate::eval::{nth_element, Interpreter};
 use crate::value::{bounded_sequence, class_of, combine, index, Arg, SValue, MAX_SEQ_LEN};
 use r_vector::{is_na_real, na_real, Double};
 use statistics_core::distributions::{dnorm, pnorm, qnorm, rnorm};
-use statistics_core::distributions_more::{dexp, dunif, pexp, punif, qexp, qunif, rexp, runif};
+use statistics_core::distributions_more::{
+    dbinom, dexp, dpois, dunif, pbinom, pexp, ppois, punif, qbinom, qexp, qpois, qunif, rbinom,
+    rexp, rpois, runif,
+};
 use statistics_core::{descriptive, Number, StatsError};
 use std::collections::HashSet;
 
@@ -112,6 +115,16 @@ pub fn install(env: &Env) {
     define(env, "pexp", builtin("pexp", b_pexp));
     define(env, "qexp", builtin("qexp", b_qexp));
     define(env, "rexp", builtin("rexp", b_rexp));
+
+    // Discrete distribution family (R-8b): binomial and Poisson.
+    define(env, "dbinom", builtin("dbinom", b_dbinom));
+    define(env, "pbinom", builtin("pbinom", b_pbinom));
+    define(env, "qbinom", builtin("qbinom", b_qbinom));
+    define(env, "rbinom", builtin("rbinom", b_rbinom));
+    define(env, "dpois", builtin("dpois", b_dpois));
+    define(env, "ppois", builtin("ppois", b_ppois));
+    define(env, "qpois", builtin("qpois", b_qpois));
+    define(env, "rpois", builtin("rpois", b_rpois));
 
     // String manipulation (vectorized over a character vector).
     define(env, "nchar", builtin("nchar", b_nchar));
@@ -1473,6 +1486,180 @@ fn b_rexp(interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
     let rate = dist_param(args, 1, "rate", 1.0)?;
     Ok(SValue::doubles(
         interp.sample_with(|rng| rexp(n, rate, rng)),
+    ))
+}
+
+// ===========================================================================
+// Discrete distribution family (R-8b) — binomial and Poisson
+// ===========================================================================
+//
+// Unlike the continuous families (R-8), the discrete CDFs and samplers loop
+// over an integer *count*: `pbinom`/`qbinom` sum/scan O(size) terms,
+// `ppois` sums O(x) terms (Poisson has unbounded support), and the samplers
+// draw via inverse-CDF, so `rbinom` is O(n·size). Left unbounded, a crafted
+// `pbinom(0, size = 1e18)` or `rbinom(1e6, size = 1e9)` would hang the process.
+//
+// Two guards bound every loop:
+//   * MAX_DISCRETE_SUPPORT caps the per-element driver — `size` (binomial) and
+//     the `x` quantile fed to `ppois` — so no single term-sum runs away.
+//   * MAX_DISCRETE_WORK caps the *total* iterations of a call: `len · driver`
+//     for the vectorized `d`/`p`/`q` functions and `n · per_sample` for the
+//     samplers. Anything larger is a clean error, never an unbounded loop.
+// statistics-core's own `qpois`/Poisson sampler already cap their internal
+// scan at ~10_000, which we reuse as the Poisson per-element/per-sample driver.
+
+/// Largest per-element loop driver (`size`, or the `ppois` quantile) we accept.
+const MAX_DISCRETE_SUPPORT: u64 = 1 << 20; // ~1.05M
+/// Largest total inner-loop iteration count a single discrete call may incur.
+const MAX_DISCRETE_WORK: u128 = 1 << 27; // ~134M (sub-second)
+/// statistics-core caps the Poisson quantile/sampler scan at this many terms.
+const POISSON_SCAN_CAP: u128 = 10_000;
+
+/// Reject a discrete call whose estimated total iteration count exceeds the
+/// budget, before it runs.
+fn check_discrete_work(count: u128, driver: u128, what: &str) -> SResult<()> {
+    if count.saturating_mul(driver) > MAX_DISCRETE_WORK {
+        return Err(SError::BadArgs(format!(
+            "{what}: requested work exceeds the safety limit \
+             (count {count} × {driver} > {MAX_DISCRETE_WORK})"
+        )));
+    }
+    Ok(())
+}
+
+/// Read a **required** distribution parameter (by name or position) as a finite
+/// scalar — `dbinom`/`dpois` have no defaults for `size`/`prob`/`lambda`.
+fn required_param(args: &[Arg], pos: usize, name: &str) -> SResult<f64> {
+    let v = args
+        .iter()
+        .find(|a| a.name.as_deref() == Some(name))
+        .map(|a| &a.value)
+        .or_else(|| nth_positional(args, pos))
+        .ok_or_else(|| {
+            SError::BadArgs(format!("argument \"{name}\" is missing, with no default"))
+        })?;
+    v.as_double()?
+        .get_value(0)
+        .filter(|x| x.is_finite())
+        .ok_or_else(|| SError::BadArgs(format!("invalid \"{name}\" (must be a finite number)")))
+}
+
+/// Read and validate the binomial parameters `(size, prob)`. `size` is a
+/// non-negative count capped at [`MAX_DISCRETE_SUPPORT`]; `prob` is in `[0, 1]`.
+fn binom_params(args: &[Arg]) -> SResult<(u64, f64)> {
+    let size_f = required_param(args, 1, "size")?;
+    if size_f < 0.0 || size_f > MAX_DISCRETE_SUPPORT as f64 {
+        return Err(SError::BadArgs(format!(
+            "size must be in 0..={MAX_DISCRETE_SUPPORT} (got {size_f})"
+        )));
+    }
+    let prob = required_param(args, 2, "prob")?;
+    if !(0.0..=1.0).contains(&prob) {
+        return Err(SError::BadArgs(format!(
+            "prob must be in [0, 1] (got {prob})"
+        )));
+    }
+    Ok((size_f.trunc() as u64, prob))
+}
+
+/// Read and validate the Poisson `lambda` (a non-negative rate).
+fn pois_lambda(args: &[Arg]) -> SResult<f64> {
+    let lambda = required_param(args, 1, "lambda")?;
+    if lambda < 0.0 {
+        return Err(SError::BadArgs(format!(
+            "lambda must be ≥ 0 (got {lambda})"
+        )));
+    }
+    Ok(lambda)
+}
+
+/// Map an integer-valued density/CDF/quantile over the first positional vector,
+/// truncating each element toward zero and propagating `NA`.
+fn map_discrete(args: &[Arg], f: impl Fn(f64) -> f64) -> SResult<SValue> {
+    let x = first_positional(args)?.as_double()?;
+    Ok(SValue::doubles(
+        x.iter()
+            .map(|v| if is_na_real(v) { na_real() } else { f(v) })
+            .collect(),
+    ))
+}
+
+// --- binomial ------------------------------------------------------------
+
+fn b_dbinom(_i: &Interpreter, args: &[Arg]) -> SResult<SValue> {
+    let (size, prob) = binom_params(args)?; // pmf is O(1) per element
+    map_discrete(args, move |x| dbinom(x.trunc() as i64, size, prob))
+}
+fn b_pbinom(_i: &Interpreter, args: &[Arg]) -> SResult<SValue> {
+    let (size, prob) = binom_params(args)?;
+    let x = first_positional(args)?.as_double()?;
+    check_discrete_work(x.len() as u128, size as u128, "pbinom")?;
+    map_discrete(args, move |q| pbinom(q.trunc() as i64, size, prob))
+}
+fn b_qbinom(_i: &Interpreter, args: &[Arg]) -> SResult<SValue> {
+    let (size, prob) = binom_params(args)?;
+    let p = first_positional(args)?.as_double()?;
+    check_discrete_work(p.len() as u128, size as u128, "qbinom")?;
+    map_discrete(args, move |p| qbinom(p, size, prob) as f64)
+}
+fn b_rbinom(interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
+    let n = sample_count(args)?;
+    let (size, prob) = binom_params(args)?;
+    check_discrete_work(n as u128, size as u128, "rbinom")?; // each draw is O(size)
+    Ok(SValue::doubles(
+        interp
+            .sample_with(|rng| rbinom(n, size, prob, rng))
+            .iter()
+            .map(|&k| k as f64)
+            .collect(),
+    ))
+}
+
+// --- Poisson -------------------------------------------------------------
+
+fn b_dpois(_i: &Interpreter, args: &[Arg]) -> SResult<SValue> {
+    let lambda = pois_lambda(args)?; // pmf is O(1) per element
+    map_discrete(args, move |x| dpois(x.trunc() as i64, lambda))
+}
+fn b_ppois(_i: &Interpreter, args: &[Arg]) -> SResult<SValue> {
+    let lambda = pois_lambda(args)?;
+    let x = first_positional(args)?.as_double()?;
+    // ppois sums O(x) terms (unbounded support) — bound the largest x and the
+    // total work before evaluating.
+    let max_x = x
+        .iter()
+        .filter(|v| v.is_finite() && *v >= 0.0)
+        .map(|v| v.trunc() as i128)
+        .max()
+        .unwrap_or(0);
+    if max_x > MAX_DISCRETE_SUPPORT as i128 {
+        return Err(SError::BadArgs(format!(
+            "ppois: x = {max_x} exceeds the safety limit of {MAX_DISCRETE_SUPPORT}"
+        )));
+    }
+    check_discrete_work(x.len() as u128, max_x.max(1) as u128, "ppois")?;
+    map_discrete(args, move |q| ppois(q.trunc() as i64, lambda))
+}
+fn b_qpois(_i: &Interpreter, args: &[Arg]) -> SResult<SValue> {
+    let lambda = pois_lambda(args)?;
+    let p = first_positional(args)?.as_double()?;
+    // statistics-core caps the quantile scan at ~10_000 terms per element.
+    check_discrete_work(p.len() as u128, POISSON_SCAN_CAP, "qpois")?;
+    map_discrete(args, move |p| qpois(p, lambda) as f64)
+}
+fn b_rpois(interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
+    let n = sample_count(args)?;
+    let lambda = pois_lambda(args)?;
+    // Knuth sampling is ~O(lambda) for small lambda; the large-lambda path uses
+    // the ~10_000-capped quantile. Bound the per-sample cost accordingly.
+    let per_sample = if lambda < 30.0 { 64 } else { POISSON_SCAN_CAP };
+    check_discrete_work(n as u128, per_sample, "rpois")?;
+    Ok(SValue::doubles(
+        interp
+            .sample_with(|rng| rpois(n, lambda, rng))
+            .iter()
+            .map(|&k| k as f64)
+            .collect(),
     ))
 }
 

--- a/code/packages/rust/s-runtime/src/lib.rs
+++ b/code/packages/rust/s-runtime/src/lib.rs
@@ -845,4 +845,68 @@ mod tests {
         let outcome = Interpreter::new().eval_str("set.seed(1)\n").unwrap();
         assert!(!outcome.visible);
     }
+
+    // --- Discrete distribution family (R-8b) ----------------------------
+
+    #[test]
+    fn binomial_density_cdf_quantile() {
+        // dbinom(2, 4, 0.5) = C(4,2)·0.5^4 = 6/16 = 0.375.
+        approx("dbinom(2, 4, 0.5)\n", 0.375);
+        // pbinom(2, 4, 0.5) = (1+4+6)/16 = 11/16 = 0.6875.
+        approx("pbinom(2, 4, 0.5)\n", 0.6875);
+        // qbinom(0.5, 4, 0.5): smallest k with cdf ≥ 0.5 → 2.
+        approx("qbinom(0.5, 4, 0.5)\n", 2.0);
+        // Parameters by name agree with positional.
+        approx("dbinom(2, size = 4, prob = 0.5)\n", 0.375);
+    }
+
+    #[test]
+    fn poisson_density_cdf_quantile() {
+        // dpois(0, 2) = e^-2 ≈ 0.1353353.
+        approx("dpois(0, 2)\n", (-2.0_f64).exp());
+        approx("ppois(0, 2)\n", (-2.0_f64).exp());
+        // The Poisson median for lambda = 4 is 4.
+        approx("qpois(0.5, 4)\n", 4.0);
+        approx("dpois(0, lambda = 2)\n", (-2.0_f64).exp());
+    }
+
+    #[test]
+    fn discrete_is_vectorized_with_na() {
+        // d* maps over the whole vector and propagates NA.
+        let b = nums("dbinom(c(0, 4), 4, 0.5)\n");
+        assert!((b[0] - 0.0625).abs() < 1e-9 && (b[1] - 0.0625).abs() < 1e-9);
+        let p = nums("dpois(c(0, NA), 1)\n");
+        assert!((p[0] - (-1.0_f64).exp()).abs() < 1e-9);
+        assert!(p[1].is_nan()); // NA propagates
+    }
+
+    #[test]
+    fn discrete_sampling_is_reseedable_and_in_range() {
+        // rbinom draws lie in 0..=size; rpois draws are non-negative.
+        let b = nums("set.seed(1)\nrbinom(50, 10, 0.3)\n");
+        assert_eq!(b.len(), 50);
+        assert!(b
+            .iter()
+            .all(|&k| (0.0..=10.0).contains(&k) && k.fract() == 0.0));
+        // Reproducible across fresh sessions.
+        assert_eq!(
+            nums("set.seed(7)\nrpois(20, 3)\n"),
+            nums("set.seed(7)\nrpois(20, 3)\n")
+        );
+        assert!(nums("set.seed(7)\nrpois(20, 3)\n")
+            .iter()
+            .all(|&k| k >= 0.0));
+    }
+
+    #[test]
+    fn discrete_dos_guards() {
+        // size / x / sampling counts that would drive an unbounded inner loop
+        // are clean errors, not hangs.
+        assert!(eval_s("rbinom(1000000, 1000000, 0.5)\n").is_err()); // n·size huge
+        assert!(eval_s("pbinom(0, 1e18, 0.5)\n").is_err()); // size beyond support
+        assert!(eval_s("ppois(1e18, 2)\n").is_err()); // x beyond support
+                                                      // Required parameters can't be omitted.
+        assert!(eval_s("dbinom(1)\n").is_err());
+        assert!(eval_s("dpois(1)\n").is_err());
+    }
 }

--- a/code/specs/R00-r-language.md
+++ b/code/specs/R00-r-language.md
@@ -93,6 +93,16 @@ unchanged.
   `MAX_SEQ_LEN` so `rnorm(1e18)` errors instead of aborting. *Deferred (R-8b):*
   the discrete families (`dbinom`/`dpois`/…), whose CDF/sampling loop over a
   user-supplied count and need their own bounds.
+- **R-8b — the discrete distribution families** *(this PR)*. **Binomial**
+  (`dbinom`/`pbinom`/`qbinom`/`rbinom`, parameters `size`, `prob`) and **Poisson**
+  (`dpois`/`ppois`/`qpois`/`rpois`, parameter `lambda`), same `d`/`p`/`q`/`r`
+  shape and reproducible RNG as R-8. The discrete CDFs and inverse-CDF samplers
+  loop over an integer count (`pbinom` sums O(`size`) terms, `ppois` sums O(`x`)
+  terms, `rbinom` is O(n·`size`)), so two guards bound every loop: a per-element
+  cap (`size` and the `ppois` quantile ≤ `MAX_DISCRETE_SUPPORT` ≈ 1M) and a
+  total-iteration budget (`MAX_DISCRETE_WORK` ≈ 134M) over `len·driver` /
+  `n·per-sample`. `rbinom(1e6, 1e6, …)` and `ppois(1e18, …)` are clean errors,
+  never hangs.
 
 ## §4 Reuse strategy
 


### PR DESCRIPTION
## What & why

**R-8b** — completes the R distribution work begun in [R-8](https://github.com/adhithyan15/coding-adventures/pull/6017) (continuous) by adding the **discrete** families to the shared `s-runtime`, wired to `statistics-core`. R picks them up unchanged via the shared evaluator.

- **Binomial**: `dbinom`/`pbinom`/`qbinom`/`rbinom` (`size`, `prob`)
- **Poisson**: `dpois`/`ppois`/`qpois`/`rpois` (`lambda`)

Same vectorized `d`/`p`/`q` (NA-propagating), named/positional parameters, and reproducible per-session RNG as R-8. Spec: [R00 §3](code/specs/R00-r-language.md).

## The DoS bounds (why R-8 deferred these)

Unlike the closed-form continuous families, the discrete CDFs and inverse-CDF samplers **loop over an integer count**: `pbinom`/`qbinom` scan O(`size`), `ppois` sums O(`x`) (Poisson has unbounded support), and the samplers draw via inverse-CDF so `rbinom` is O(n·`size`). Left unbounded, `rbinom(1e6, 1e6, 0.5)` or `ppois(1e18, 2)` would hang the process.

Two guards bound **every** loop before it runs:
- **`MAX_DISCRETE_SUPPORT`** (~1M) caps the per-element driver — `size`, and the `ppois` quantile.
- **`check_discrete_work` / `MAX_DISCRETE_WORK`** (~134M) caps total iterations: `len·driver` for vectorized `d`/`p`/`q`, `n·per-sample` for the samplers.

So the pathological calls are clean `BadArgs` errors, never hangs. (`statistics-core`'s own ~10k-term Poisson quantile/sampler cap is reused as the Poisson driver.)

## Quality

- 119 `s-runtime` + 19 `r-runtime` tests: d/p/q correctness vs known values (`dbinom(2,4,.5)=0.375`, `pbinom=0.6875`, `dpois(0,2)=e⁻²`, the Poisson median…), NA propagation, sampling range + cross-seed reproducibility, **every DoS guard**, and missing-required-param errors; plus an R-side integration test. `cargo fmt` + `cargo clippy` clean.
- **`/security-review` → PASSED** (no CRITICAL/HIGH/MEDIUM/LOW): all eight builtins' loops verified bounded, work math overflow-safe (saturating u128), no reachable panics. Two INFO advisories noted (a non-exploitable theoretical Knuth loop in statistics-core; `size==0`/`lambda==0` return sentinel values — a minor wrong-value edge, flagged for follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)