### PR TITLE
Add smart-home activation waiver tombstone tools

### DIFF
--- a/code/packages/rust/chief-of-staff-smart-home-tools/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/src/lib.rs
@@ -458,6 +458,10 @@ pub const SMART_HOME_LIST_INTEGRATION_ACTIVATION_WAIVER_DISPOSALS_TOOL_ID: &str 
     "smart_home.list_integration_activation_waiver_disposals";
 pub const SMART_HOME_GET_INTEGRATION_ACTIVATION_WAIVER_DISPOSAL_SUMMARY_TOOL_ID: &str =
     "smart_home.get_integration_activation_waiver_disposal_summary";
+pub const SMART_HOME_LIST_INTEGRATION_ACTIVATION_WAIVER_TOMBSTONES_TOOL_ID: &str =
+    "smart_home.list_integration_activation_waiver_tombstones";
+pub const SMART_HOME_GET_INTEGRATION_ACTIVATION_WAIVER_TOMBSTONE_SUMMARY_TOOL_ID: &str =
+    "smart_home.get_integration_activation_waiver_tombstone_summary";
 pub const SMART_HOME_LIST_INTEGRATION_ACTIVATION_RISK_TOOL_ID: &str =
     "smart_home.list_integration_activation_risk";
 pub const SMART_HOME_GET_INTEGRATION_ACTIVATION_RISK_SUMMARY_TOOL_ID: &str =
@@ -1143,6 +1147,18 @@ impl SmartHomeToolBridge {
                     let query = integration_activation_waiver_disposal_query(&arguments)?;
                     Ok(
                         get_integration_activation_waiver_disposal_summary_output_handler_output(
+                            query,
+                        ),
+                    )
+                }
+                SMART_HOME_LIST_INTEGRATION_ACTIVATION_WAIVER_TOMBSTONES_TOOL_ID => {
+                    let query = integration_activation_waiver_tombstone_query(&arguments)?;
+                    Ok(list_integration_activation_waiver_tombstones_output_handler_output(query))
+                }
+                SMART_HOME_GET_INTEGRATION_ACTIVATION_WAIVER_TOMBSTONE_SUMMARY_TOOL_ID => {
+                    let query = integration_activation_waiver_tombstone_query(&arguments)?;
+                    Ok(
+                        get_integration_activation_waiver_tombstone_summary_output_handler_output(
                             query,
                         ),
                     )
@@ -3668,6 +3684,40 @@ pub fn smart_home_tool_definitions() -> Vec<ToolDefinition> {
             "Get smart-home integration activation waiver disposal summary",
             "Return compact D23A activation waiver disposal counts by disposal status, disposal lane, source linkage, blocker, expiration readiness, and disposed posture.",
             integration_activation_waiver_disposal_query_schema(),
+            object_schema(
+                vec![SchemaProperty::new("summary", JsonSchema::Any)],
+                vec!["summary"],
+                false,
+            ),
+        ),
+        read_definition(
+            SMART_HOME_LIST_INTEGRATION_ACTIVATION_WAIVER_TOMBSTONES_TOOL_ID,
+            "List smart-home integration activation waiver tombstones",
+            "List Chief-facing D23A activation waiver tombstone rows derived from waiver disposal records with tombstone status, tombstone lane, source-lineage posture, and tombstone action.",
+            integration_activation_waiver_tombstone_query_schema(),
+            object_schema(
+                vec![
+                    SchemaProperty::new("activation_waiver_tombstones", JsonSchema::Array {
+                        items: Box::new(JsonSchema::Any),
+                    }),
+                    SchemaProperty::new("summary", JsonSchema::Any),
+                    SchemaProperty::new("count", JsonSchema::Integer),
+                    SchemaProperty::new("catalog_count", JsonSchema::Integer),
+                ],
+                vec![
+                    "activation_waiver_tombstones",
+                    "summary",
+                    "count",
+                    "catalog_count",
+                ],
+                false,
+            ),
+        ),
+        read_definition(
+            SMART_HOME_GET_INTEGRATION_ACTIVATION_WAIVER_TOMBSTONE_SUMMARY_TOOL_ID,
+            "Get smart-home integration activation waiver tombstone summary",
+            "Return compact D23A activation waiver tombstone counts by tombstone status, tombstone lane, source linkage, blocker, disposal readiness, and tombstoned posture.",
+            integration_activation_waiver_tombstone_query_schema(),
             object_schema(
                 vec![SchemaProperty::new("summary", JsonSchema::Any)],
                 vec!["summary"],
@@ -11732,6 +11782,324 @@ struct IntegrationActivationWaiverDisposalQuery {
     disposal_limit: Option<usize>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum IntegrationActivationWaiverTombstoneStatus {
+    Blocked,
+    EvidenceRequired,
+    ReadyForTombstone,
+    Tombstoned,
+}
+
+impl IntegrationActivationWaiverTombstoneStatus {
+    fn from_disposal_record(record: &IntegrationActivationWaiverDisposalRecord) -> Self {
+        if record.is_blocked() || record.disposal_status.is_blocked() {
+            Self::Blocked
+        } else if !record.has_source_lineage()
+            || !record.disposal_ready()
+            || !record.source.evidence_ready
+        {
+            Self::EvidenceRequired
+        } else if matches!(
+            record.disposal_status,
+            IntegrationActivationWaiverDisposalStatus::ReadyForDisposal
+        ) {
+            Self::ReadyForTombstone
+        } else {
+            Self::Tombstoned
+        }
+    }
+
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Blocked => "blocked",
+            Self::EvidenceRequired => "evidence_required",
+            Self::ReadyForTombstone => "ready_for_tombstone",
+            Self::Tombstoned => "tombstoned",
+        }
+    }
+
+    fn is_blocked(self) -> bool {
+        matches!(self, Self::Blocked)
+    }
+
+    fn requires_attention(self) -> bool {
+        matches!(self, Self::Blocked | Self::EvidenceRequired)
+    }
+
+    fn tombstone_ready(self) -> bool {
+        matches!(self, Self::ReadyForTombstone | Self::Tombstoned)
+    }
+
+    fn tombstoned(self) -> bool {
+        matches!(self, Self::Tombstoned)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct IntegrationActivationWaiverTombstoneRecord {
+    sequence: usize,
+    tombstone_id: String,
+    source_disposal_id: String,
+    tombstone_status: IntegrationActivationWaiverTombstoneStatus,
+    tombstone_lane: IntegrationActivationResponseOwnerLane,
+    tombstone_reason: String,
+    tombstone_action: String,
+    source: IntegrationActivationWaiverDisposalRecord,
+}
+
+impl IntegrationActivationWaiverTombstoneRecord {
+    fn from_disposal_record(
+        sequence: usize,
+        record: &IntegrationActivationWaiverDisposalRecord,
+    ) -> Self {
+        let tombstone_status =
+            IntegrationActivationWaiverTombstoneStatus::from_disposal_record(record);
+        Self {
+            sequence,
+            tombstone_id: format!("activation-waiver-tombstone-{sequence}"),
+            source_disposal_id: record.disposal_id.clone(),
+            tombstone_status,
+            tombstone_lane: activation_waiver_tombstone_lane(record, tombstone_status),
+            tombstone_reason: activation_waiver_tombstone_reason(record, tombstone_status)
+                .to_string(),
+            tombstone_action: activation_waiver_tombstone_action(tombstone_status).to_string(),
+            source: record.clone(),
+        }
+    }
+
+    fn has_source_lineage(&self) -> bool {
+        !self.source_disposal_id.is_empty() && self.source.has_source_lineage()
+    }
+
+    fn is_blocked(&self) -> bool {
+        self.tombstone_status.is_blocked()
+    }
+
+    fn requires_attention(&self) -> bool {
+        self.source.requires_attention() || self.tombstone_status.requires_attention()
+    }
+
+    fn tombstone_ready(&self) -> bool {
+        self.tombstone_status.tombstone_ready()
+    }
+
+    fn tombstoned(&self) -> bool {
+        self.tombstone_status.tombstoned()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct IntegrationActivationWaiverTombstoneSummary {
+    total_records: usize,
+    unique_integrations: usize,
+    records_requiring_attention: usize,
+    blocked_records: usize,
+    evidence_required_records: usize,
+    ready_for_tombstone_records: usize,
+    tombstoned_records: usize,
+    tombstone_ready_records: usize,
+    disposed_records: usize,
+    disposal_ready_records: usize,
+    expired_records: usize,
+    evidence_ready_records: usize,
+    source_linked_records: usize,
+    reviewer_required_records: usize,
+    exception_required_records: usize,
+    signoff_required_records: usize,
+    platform_tombstone_records: usize,
+    integration_tombstone_records: usize,
+    security_tombstone_records: usize,
+    reviewer_tombstone_records: usize,
+    verification_tombstone_records: usize,
+    audit_tombstone_records: usize,
+    first_attention_priority: Option<u8>,
+    first_blocked_priority: Option<u8>,
+    first_ready_priority: Option<u8>,
+    next_tombstone_status: Option<IntegrationActivationWaiverTombstoneStatus>,
+    next_tombstone_lane: Option<IntegrationActivationResponseOwnerLane>,
+    next_tombstone_action: Option<String>,
+    highest_policy_tier: PrivilegeTier,
+    overall_status: IntegrationActivationHealthStatus,
+}
+
+impl IntegrationActivationWaiverTombstoneSummary {
+    fn from_records<'a>(
+        records: impl IntoIterator<Item = &'a IntegrationActivationWaiverTombstoneRecord>,
+    ) -> Self {
+        let mut summary = Self {
+            total_records: 0,
+            unique_integrations: 0,
+            records_requiring_attention: 0,
+            blocked_records: 0,
+            evidence_required_records: 0,
+            ready_for_tombstone_records: 0,
+            tombstoned_records: 0,
+            tombstone_ready_records: 0,
+            disposed_records: 0,
+            disposal_ready_records: 0,
+            expired_records: 0,
+            evidence_ready_records: 0,
+            source_linked_records: 0,
+            reviewer_required_records: 0,
+            exception_required_records: 0,
+            signoff_required_records: 0,
+            platform_tombstone_records: 0,
+            integration_tombstone_records: 0,
+            security_tombstone_records: 0,
+            reviewer_tombstone_records: 0,
+            verification_tombstone_records: 0,
+            audit_tombstone_records: 0,
+            first_attention_priority: None,
+            first_blocked_priority: None,
+            first_ready_priority: None,
+            next_tombstone_status: None,
+            next_tombstone_lane: None,
+            next_tombstone_action: None,
+            highest_policy_tier: PrivilegeTier::ReadOnly,
+            overall_status: IntegrationActivationHealthStatus::Empty,
+        };
+        let mut integration_ids = BTreeSet::new();
+
+        for record in records {
+            summary.total_records += 1;
+            if summary.next_tombstone_status.is_none() {
+                summary.next_tombstone_status = Some(record.tombstone_status);
+                summary.next_tombstone_lane = Some(record.tombstone_lane);
+                summary.next_tombstone_action = Some(record.tombstone_action.clone());
+            }
+            for integration_id in &record.source.source.integration_ids {
+                integration_ids.insert(integration_id.clone());
+            }
+            if record.requires_attention() {
+                summary.records_requiring_attention += 1;
+                summary.first_attention_priority = min_optional_priority(
+                    summary.first_attention_priority,
+                    record.source.source.priority,
+                );
+            }
+            if record.is_blocked() {
+                summary.blocked_records += 1;
+                summary.first_blocked_priority = min_optional_priority(
+                    summary.first_blocked_priority,
+                    record.source.source.priority,
+                );
+            }
+            if record.tombstone_ready() {
+                summary.tombstone_ready_records += 1;
+                summary.first_ready_priority = min_optional_priority(
+                    summary.first_ready_priority,
+                    record.source.source.priority,
+                );
+            }
+            if record.source.disposed() {
+                summary.disposed_records += 1;
+            }
+            if record.source.disposal_ready() {
+                summary.disposal_ready_records += 1;
+            }
+            if record.source.source.expired {
+                summary.expired_records += 1;
+            }
+            if record.source.source.evidence_ready {
+                summary.evidence_ready_records += 1;
+            }
+            if record.has_source_lineage() {
+                summary.source_linked_records += 1;
+            }
+            if record.source.source.reviewer_required {
+                summary.reviewer_required_records += 1;
+            }
+            if record.source.source.exception_required {
+                summary.exception_required_records += 1;
+            }
+            if record.source.source.signoff_required {
+                summary.signoff_required_records += 1;
+            }
+            match record.tombstone_status {
+                IntegrationActivationWaiverTombstoneStatus::Blocked => {}
+                IntegrationActivationWaiverTombstoneStatus::EvidenceRequired => {
+                    summary.evidence_required_records += 1
+                }
+                IntegrationActivationWaiverTombstoneStatus::ReadyForTombstone => {
+                    summary.ready_for_tombstone_records += 1
+                }
+                IntegrationActivationWaiverTombstoneStatus::Tombstoned => {
+                    summary.tombstoned_records += 1
+                }
+            }
+            match record.tombstone_lane {
+                IntegrationActivationResponseOwnerLane::Platform => {
+                    summary.platform_tombstone_records += 1
+                }
+                IntegrationActivationResponseOwnerLane::Integration => {
+                    summary.integration_tombstone_records += 1
+                }
+                IntegrationActivationResponseOwnerLane::Security => {
+                    summary.security_tombstone_records += 1
+                }
+                IntegrationActivationResponseOwnerLane::Reviewer => {
+                    summary.reviewer_tombstone_records += 1
+                }
+                IntegrationActivationResponseOwnerLane::Verification => {
+                    summary.verification_tombstone_records += 1
+                }
+                IntegrationActivationResponseOwnerLane::Audit => {
+                    summary.audit_tombstone_records += 1
+                }
+            }
+            summary.highest_policy_tier = summary
+                .highest_policy_tier
+                .max(record.source.source.required_tier);
+        }
+
+        summary.unique_integrations = integration_ids.len();
+        summary.overall_status = if summary.total_records == 0 {
+            IntegrationActivationHealthStatus::Empty
+        } else if summary.blocked_records > 0 {
+            IntegrationActivationHealthStatus::Blocked
+        } else if summary.evidence_required_records > 0 {
+            IntegrationActivationHealthStatus::NeedsReview
+        } else {
+            IntegrationActivationHealthStatus::Ready
+        };
+        summary
+    }
+
+    fn has_blockers(&self) -> bool {
+        self.blocked_records > 0
+    }
+
+    fn requires_attention(&self) -> bool {
+        self.records_requiring_attention > 0 || self.evidence_required_records > 0
+    }
+}
+
+#[derive(Debug, Clone)]
+struct IntegrationActivationWaiverTombstoneQuery {
+    waiver_disposal: IntegrationActivationWaiverDisposalQuery,
+    tombstone_status: Option<IntegrationActivationWaiverTombstoneStatus>,
+    tombstone_lane: Option<IntegrationActivationResponseOwnerLane>,
+    disposal_lane: Option<IntegrationActivationResponseOwnerLane>,
+    expiration_lane: Option<IntegrationActivationResponseOwnerLane>,
+    retention_lane: Option<IntegrationActivationResponseOwnerLane>,
+    archive_lane: Option<IntegrationActivationResponseOwnerLane>,
+    closure_lane: Option<IntegrationActivationResponseOwnerLane>,
+    owner_lane: Option<IntegrationActivationResponseOwnerLane>,
+    approval_lane: Option<IntegrationActivationResponseOwnerLane>,
+    evidence_kind: Option<String>,
+    requires_attention: Option<bool>,
+    blocked: Option<bool>,
+    tombstone_ready: Option<bool>,
+    tombstoned: Option<bool>,
+    disposed: Option<bool>,
+    disposal_ready: Option<bool>,
+    expired: Option<bool>,
+    evidence_ready: Option<bool>,
+    reviewer_required: Option<bool>,
+    signoff_required: Option<bool>,
+    tombstone_limit: Option<usize>,
+}
+
 fn activation_exception_reason(focus: IntegrationActivationGuardrailKind) -> &'static str {
     match focus {
         IntegrationActivationGuardrailKind::Incident => "incident evidence closure required",
@@ -12158,6 +12526,61 @@ fn activation_waiver_disposal_action(
         }
         IntegrationActivationWaiverDisposalStatus::ReadyForDisposal => "dispose_waiver_expiration",
         IntegrationActivationWaiverDisposalStatus::Disposed => "monitor_waiver_disposal",
+    }
+}
+
+fn activation_waiver_tombstone_lane(
+    record: &IntegrationActivationWaiverDisposalRecord,
+    status: IntegrationActivationWaiverTombstoneStatus,
+) -> IntegrationActivationResponseOwnerLane {
+    match status {
+        IntegrationActivationWaiverTombstoneStatus::Blocked => record.disposal_lane,
+        IntegrationActivationWaiverTombstoneStatus::EvidenceRequired => record.disposal_lane,
+        IntegrationActivationWaiverTombstoneStatus::ReadyForTombstone => {
+            IntegrationActivationResponseOwnerLane::Audit
+        }
+        IntegrationActivationWaiverTombstoneStatus::Tombstoned => {
+            IntegrationActivationResponseOwnerLane::Audit
+        }
+    }
+}
+
+fn activation_waiver_tombstone_reason(
+    record: &IntegrationActivationWaiverDisposalRecord,
+    status: IntegrationActivationWaiverTombstoneStatus,
+) -> &'static str {
+    match status {
+        IntegrationActivationWaiverTombstoneStatus::Blocked => {
+            "blocking waiver disposal must clear before tombstone retention"
+        }
+        IntegrationActivationWaiverTombstoneStatus::EvidenceRequired => {
+            if !record.has_source_lineage() {
+                "waiver tombstone is missing disposal source lineage"
+            } else if !record.source.evidence_ready {
+                "waiver tombstone evidence is not ready"
+            } else {
+                "waiver disposal must be ready before tombstone retention"
+            }
+        }
+        IntegrationActivationWaiverTombstoneStatus::ReadyForTombstone => {
+            "waiver disposal record is ready for tombstone retention"
+        }
+        IntegrationActivationWaiverTombstoneStatus::Tombstoned => {
+            "waiver disposal has been reduced to audit tombstone posture"
+        }
+    }
+}
+
+fn activation_waiver_tombstone_action(
+    status: IntegrationActivationWaiverTombstoneStatus,
+) -> &'static str {
+    match status {
+        IntegrationActivationWaiverTombstoneStatus::Blocked => "clear_waiver_disposal_blocker",
+        IntegrationActivationWaiverTombstoneStatus::EvidenceRequired => {
+            "attach_waiver_tombstone_evidence"
+        }
+        IntegrationActivationWaiverTombstoneStatus::ReadyForTombstone => "retain_waiver_tombstone",
+        IntegrationActivationWaiverTombstoneStatus::Tombstoned => "monitor_waiver_tombstone",
     }
 }
 
@@ -13968,6 +14391,96 @@ fn integration_activation_waiver_disposal_query(
         signoff_required: optional_bool(arguments, "signoff_required")?,
         disposal_limit: optional_u64(arguments, "waiver_disposal_limit")?
             .or(optional_u64(arguments, "disposal_limit")?)
+            .or(optional_u64(arguments, "record_limit")?)
+            .map(|value| value as usize),
+    })
+}
+
+fn integration_activation_waiver_tombstone_query(
+    arguments: &JsonValue,
+) -> Result<IntegrationActivationWaiverTombstoneQuery, ToolCallError> {
+    let tombstone_status = optional_string(arguments, "waiver_tombstone_status")?
+        .or(optional_string(arguments, "tombstone_status")?)
+        .map(|label| parse_activation_waiver_tombstone_status(&label))
+        .transpose()?;
+    let tombstone_lane = optional_string(arguments, "waiver_tombstone_lane")?
+        .or(optional_string(arguments, "tombstone_lane")?)
+        .map(|label| parse_activation_response_owner_lane(&label))
+        .transpose()?;
+    let disposal_lane = optional_string(arguments, "waiver_tombstone_disposal_lane")?
+        .or(optional_string(arguments, "waiver_disposal_lane")?)
+        .or(optional_string(arguments, "disposal_lane")?)
+        .map(|label| parse_activation_response_owner_lane(&label))
+        .transpose()?;
+    let expiration_lane = optional_string(arguments, "waiver_tombstone_expiration_lane")?
+        .or(optional_string(arguments, "waiver_expiration_lane")?)
+        .or(optional_string(arguments, "expiration_lane")?)
+        .map(|label| parse_activation_response_owner_lane(&label))
+        .transpose()?;
+    let retention_lane = optional_string(arguments, "waiver_tombstone_retention_lane")?
+        .or(optional_string(arguments, "waiver_retention_lane")?)
+        .or(optional_string(arguments, "retention_lane")?)
+        .map(|label| parse_activation_response_owner_lane(&label))
+        .transpose()?;
+    let archive_lane = optional_string(arguments, "waiver_tombstone_archive_lane")?
+        .or(optional_string(arguments, "waiver_archive_lane")?)
+        .or(optional_string(arguments, "archive_lane")?)
+        .map(|label| parse_activation_response_owner_lane(&label))
+        .transpose()?;
+    let closure_lane = optional_string(arguments, "waiver_tombstone_closure_lane")?
+        .or(optional_string(arguments, "waiver_closure_lane")?)
+        .or(optional_string(arguments, "closure_lane")?)
+        .map(|label| parse_activation_response_owner_lane(&label))
+        .transpose()?;
+    let owner_lane = optional_string(arguments, "waiver_tombstone_owner_lane")?
+        .or(optional_string(arguments, "waiver_disposal_owner_lane")?)
+        .or(optional_string(arguments, "owner_lane")?)
+        .map(|label| parse_activation_response_owner_lane(&label))
+        .transpose()?;
+    let approval_lane = optional_string(arguments, "waiver_tombstone_approval_lane")?
+        .or(optional_string(arguments, "waiver_disposal_approval_lane")?)
+        .or(optional_string(arguments, "approval_lane")?)
+        .map(|label| parse_activation_response_owner_lane(&label))
+        .transpose()?;
+
+    Ok(IntegrationActivationWaiverTombstoneQuery {
+        waiver_disposal: integration_activation_waiver_disposal_query(arguments)?,
+        tombstone_status,
+        tombstone_lane,
+        disposal_lane,
+        expiration_lane,
+        retention_lane,
+        archive_lane,
+        closure_lane,
+        owner_lane,
+        approval_lane,
+        evidence_kind: optional_string(arguments, "waiver_tombstone_evidence_kind")?
+            .or(optional_string(arguments, "waiver_disposal_evidence_kind")?)
+            .or(optional_string(arguments, "evidence_kind")?),
+        requires_attention: optional_bool(arguments, "waiver_tombstone_requires_attention")?
+            .or(optional_bool(
+                arguments,
+                "waiver_disposal_requires_attention",
+            )?)
+            .or(optional_bool(arguments, "requires_attention")?),
+        blocked: optional_bool(arguments, "waiver_tombstone_blocked")?
+            .or(optional_bool(arguments, "waiver_disposal_blocked")?)
+            .or(optional_bool(arguments, "blocked")?),
+        tombstone_ready: optional_bool(arguments, "waiver_tombstone_ready")?
+            .or(optional_bool(arguments, "tombstone_ready")?),
+        tombstoned: optional_bool(arguments, "waiver_tombstoned")?
+            .or(optional_bool(arguments, "tombstoned")?),
+        disposed: optional_bool(arguments, "waiver_disposed")?
+            .or(optional_bool(arguments, "disposed")?),
+        disposal_ready: optional_bool(arguments, "waiver_disposal_ready")?
+            .or(optional_bool(arguments, "disposal_ready")?),
+        expired: optional_bool(arguments, "waiver_expired")?
+            .or(optional_bool(arguments, "expired")?),
+        evidence_ready: optional_bool(arguments, "evidence_ready")?,
+        reviewer_required: optional_bool(arguments, "reviewer_required")?,
+        signoff_required: optional_bool(arguments, "signoff_required")?,
+        tombstone_limit: optional_u64(arguments, "waiver_tombstone_limit")?
+            .or(optional_u64(arguments, "tombstone_limit")?)
             .or(optional_u64(arguments, "record_limit")?)
             .map(|value| value as usize),
     })
@@ -16234,6 +16747,86 @@ fn integration_activation_waiver_disposals_for_query(
         records.retain(|record| record.source.signoff_required == signoff_required);
     }
     if let Some(limit) = query.disposal_limit {
+        records.truncate(limit);
+    }
+
+    (records, catalog_count)
+}
+
+fn integration_activation_waiver_tombstones_for_query(
+    query: &IntegrationActivationWaiverTombstoneQuery,
+) -> (Vec<IntegrationActivationWaiverTombstoneRecord>, usize) {
+    let (disposal_records, catalog_count) =
+        integration_activation_waiver_disposals_for_query(&query.waiver_disposal);
+    let mut records: Vec<_> = disposal_records
+        .iter()
+        .enumerate()
+        .map(|(index, record)| {
+            IntegrationActivationWaiverTombstoneRecord::from_disposal_record(index + 1, record)
+        })
+        .collect();
+
+    if let Some(status) = query.tombstone_status {
+        records.retain(|record| record.tombstone_status == status);
+    }
+    if let Some(tombstone_lane) = query.tombstone_lane {
+        records.retain(|record| record.tombstone_lane == tombstone_lane);
+    }
+    if let Some(disposal_lane) = query.disposal_lane {
+        records.retain(|record| record.source.disposal_lane == disposal_lane);
+    }
+    if let Some(expiration_lane) = query.expiration_lane {
+        records.retain(|record| record.source.source.expiration_lane == expiration_lane);
+    }
+    if let Some(retention_lane) = query.retention_lane {
+        records.retain(|record| record.source.source.retention_lane == retention_lane);
+    }
+    if let Some(archive_lane) = query.archive_lane {
+        records.retain(|record| record.source.source.archive_lane == archive_lane);
+    }
+    if let Some(closure_lane) = query.closure_lane {
+        records.retain(|record| record.source.source.closure_lane == closure_lane);
+    }
+    if let Some(owner_lane) = query.owner_lane {
+        records.retain(|record| record.source.source.owner_lane == owner_lane);
+    }
+    if let Some(approval_lane) = query.approval_lane {
+        records.retain(|record| record.source.source.approval_lane == approval_lane);
+    }
+    if let Some(evidence_kind) = &query.evidence_kind {
+        records.retain(|record| record.source.source.evidence_kind == *evidence_kind);
+    }
+    if let Some(requires_attention) = query.requires_attention {
+        records.retain(|record| record.requires_attention() == requires_attention);
+    }
+    if let Some(blocked) = query.blocked {
+        records.retain(|record| record.is_blocked() == blocked);
+    }
+    if let Some(tombstone_ready) = query.tombstone_ready {
+        records.retain(|record| record.tombstone_ready() == tombstone_ready);
+    }
+    if let Some(tombstoned) = query.tombstoned {
+        records.retain(|record| record.tombstoned() == tombstoned);
+    }
+    if let Some(disposed) = query.disposed {
+        records.retain(|record| record.source.disposed() == disposed);
+    }
+    if let Some(disposal_ready) = query.disposal_ready {
+        records.retain(|record| record.source.disposal_ready() == disposal_ready);
+    }
+    if let Some(expired) = query.expired {
+        records.retain(|record| record.source.source.expired == expired);
+    }
+    if let Some(evidence_ready) = query.evidence_ready {
+        records.retain(|record| record.source.source.evidence_ready == evidence_ready);
+    }
+    if let Some(reviewer_required) = query.reviewer_required {
+        records.retain(|record| record.source.source.reviewer_required == reviewer_required);
+    }
+    if let Some(signoff_required) = query.signoff_required {
+        records.retain(|record| record.source.source.signoff_required == signoff_required);
+    }
+    if let Some(limit) = query.tombstone_limit {
         records.truncate(limit);
     }
 
@@ -20849,6 +21442,84 @@ fn get_integration_activation_waiver_disposal_summary_output_handler_output(
             (
                 "disposal_ready_records",
                 integer(summary.disposal_ready_records as i64),
+            ),
+            ("overall_status", string(summary.overall_status.as_str())),
+        ]),
+    )
+}
+
+fn list_integration_activation_waiver_tombstones_output_handler_output(
+    query: IntegrationActivationWaiverTombstoneQuery,
+) -> ToolHandlerOutput {
+    let (records, catalog_count) = integration_activation_waiver_tombstones_for_query(&query);
+    let summary = IntegrationActivationWaiverTombstoneSummary::from_records(records.iter());
+    let count = records.len();
+
+    ToolHandlerOutput::new(object([
+        (
+            "activation_waiver_tombstones",
+            JsonValue::Array(
+                records
+                    .iter()
+                    .map(activation_waiver_tombstone_record_json)
+                    .collect(),
+            ),
+        ),
+        (
+            "summary",
+            integration_activation_waiver_tombstone_summary_json(&summary),
+        ),
+        ("count", integer(count as i64)),
+        ("catalog_count", integer(catalog_count as i64)),
+    ]))
+    .with_event(
+        ToolEventKind::Progress,
+        object([
+            (
+                "operation",
+                string("list_integration_activation_waiver_tombstones"),
+            ),
+            ("records", integer(count as i64)),
+            (
+                "records_requiring_attention",
+                integer(summary.records_requiring_attention as i64),
+            ),
+            ("blocked_records", integer(summary.blocked_records as i64)),
+            (
+                "tombstone_ready_records",
+                integer(summary.tombstone_ready_records as i64),
+            ),
+            ("overall_status", string(summary.overall_status.as_str())),
+        ]),
+    )
+}
+
+fn get_integration_activation_waiver_tombstone_summary_output_handler_output(
+    query: IntegrationActivationWaiverTombstoneQuery,
+) -> ToolHandlerOutput {
+    let (records, _) = integration_activation_waiver_tombstones_for_query(&query);
+    let summary = IntegrationActivationWaiverTombstoneSummary::from_records(records.iter());
+
+    ToolHandlerOutput::new(object([(
+        "summary",
+        integration_activation_waiver_tombstone_summary_json(&summary),
+    )]))
+    .with_event(
+        ToolEventKind::Progress,
+        object([
+            (
+                "operation",
+                string("get_integration_activation_waiver_tombstone_summary"),
+            ),
+            ("total_records", integer(summary.total_records as i64)),
+            (
+                "records_requiring_attention",
+                integer(summary.records_requiring_attention as i64),
+            ),
+            ("blocked_records", integer(summary.blocked_records as i64)),
+            (
+                "tombstone_ready_records",
+                integer(summary.tombstone_ready_records as i64),
             ),
             ("overall_status", string(summary.overall_status.as_str())),
         ]),
@@ -35948,6 +36619,294 @@ fn integration_activation_waiver_disposal_summary_json(
     ])
 }
 
+fn activation_waiver_tombstone_record_json(
+    record: &IntegrationActivationWaiverTombstoneRecord,
+) -> JsonValue {
+    let disposal = &record.source;
+    let source = &disposal.source;
+    object([
+        ("sequence", integer(record.sequence as i64)),
+        ("tombstone_id", string(&record.tombstone_id)),
+        ("source_disposal_id", string(&record.source_disposal_id)),
+        (
+            "source_expiration_id",
+            string(&disposal.source_expiration_id),
+        ),
+        ("source_retention_id", string(&source.source_retention_id)),
+        ("source_archive_id", string(&source.source_archive_id)),
+        ("source_closure_id", string(&source.source_closure_id)),
+        (
+            "source_remediation_id",
+            string(&source.source_remediation_id),
+        ),
+        (
+            "source_disposition_id",
+            string(&source.source_disposition_id),
+        ),
+        ("source_review_id", string(&source.source_review_id)),
+        ("source_waiver_id", string(&source.source_waiver_id)),
+        ("source_exception_id", string(&source.source_exception_id)),
+        ("source_ledger_id", string(&source.source_ledger_id)),
+        (
+            "source_attestation_id",
+            string(&source.source_attestation_id),
+        ),
+        ("source_compliance_id", string(&source.source_compliance_id)),
+        ("source_governance_id", string(&source.source_governance_id)),
+        ("source_assurance_id", string(&source.source_assurance_id)),
+        ("source_guardrail_id", string(&source.source_guardrail_id)),
+        ("tombstone_status", string(record.tombstone_status.as_str())),
+        ("disposal_status", string(disposal.disposal_status.as_str())),
+        (
+            "expiration_status",
+            string(source.expiration_status.as_str()),
+        ),
+        ("retention_status", string(source.retention_status.as_str())),
+        ("archive_status", string(source.archive_status.as_str())),
+        ("closure_status", string(source.closure_status.as_str())),
+        (
+            "remediation_status",
+            string(source.remediation_status.as_str()),
+        ),
+        (
+            "disposition_status",
+            string(source.disposition_status.as_str()),
+        ),
+        ("review_status", string(source.review_status.as_str())),
+        ("waiver_status", string(source.waiver_status.as_str())),
+        ("exception_status", string(source.exception_status.as_str())),
+        ("tombstone_lane", string(record.tombstone_lane.as_str())),
+        ("disposal_lane", string(disposal.disposal_lane.as_str())),
+        ("expiration_lane", string(source.expiration_lane.as_str())),
+        ("retention_lane", string(source.retention_lane.as_str())),
+        ("archive_lane", string(source.archive_lane.as_str())),
+        ("closure_lane", string(source.closure_lane.as_str())),
+        ("owner_lane", string(source.owner_lane.as_str())),
+        ("approval_lane", string(source.approval_lane.as_str())),
+        ("tombstone_reason", string(&record.tombstone_reason)),
+        ("tombstone_action", string(&record.tombstone_action)),
+        ("disposal_reason", string(&disposal.disposal_reason)),
+        ("disposal_action", string(&disposal.disposal_action)),
+        ("expiration_reason", string(&source.expiration_reason)),
+        ("expiration_action", string(&source.expiration_action)),
+        ("retention_reason", string(&source.retention_reason)),
+        ("retention_action", string(&source.retention_action)),
+        ("archive_reason", string(&source.archive_reason)),
+        ("archive_action", string(&source.archive_action)),
+        ("closure_reason", string(&source.closure_reason)),
+        ("closure_action", string(&source.closure_action)),
+        ("remediation_kind", string(&source.remediation_kind)),
+        ("remediation_action", string(&source.remediation_action)),
+        ("disposition_reason", string(&source.disposition_reason)),
+        ("disposition_action", string(&source.disposition_action)),
+        ("waiver_scope", string(&source.waiver_scope)),
+        ("evidence_kind", string(&source.evidence_kind)),
+        ("focus", string(source.focus.as_str())),
+        ("recommended_view", string(source.recommended_view.as_str())),
+        ("title", string(&source.title)),
+        ("summary", string(&source.summary)),
+        ("priority", integer(source.priority as i64)),
+        (
+            "integration_ids",
+            JsonValue::Array(
+                source
+                    .integration_ids
+                    .iter()
+                    .map(|integration_id| string(integration_id.as_str()))
+                    .collect(),
+            ),
+        ),
+        (
+            "integration_count",
+            integer(source.integration_ids.len() as i64),
+        ),
+        (
+            "required_tier",
+            string(privilege_tier_label(source.required_tier)),
+        ),
+        (
+            "policy_surface",
+            source
+                .policy_surface
+                .map(|surface| string(surface.as_str()))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "reviewer_required",
+            JsonValue::Bool(source.reviewer_required),
+        ),
+        (
+            "exception_required",
+            JsonValue::Bool(source.exception_required),
+        ),
+        ("signoff_required", JsonValue::Bool(source.signoff_required)),
+        ("evidence_ready", JsonValue::Bool(source.evidence_ready)),
+        ("waiver_ready", JsonValue::Bool(source.waiver_ready)),
+        ("review_ready", JsonValue::Bool(source.review_ready)),
+        (
+            "disposition_ready",
+            JsonValue::Bool(source.disposition_ready),
+        ),
+        ("closure_ready", JsonValue::Bool(source.closure_ready)),
+        ("archive_ready", JsonValue::Bool(source.archive_ready)),
+        ("retention_ready", JsonValue::Bool(source.retention_ready)),
+        ("expiration_ready", JsonValue::Bool(source.expiration_ready)),
+        ("disposal_ready", JsonValue::Bool(disposal.disposal_ready())),
+        ("tombstone_ready", JsonValue::Bool(record.tombstone_ready())),
+        ("tombstoned", JsonValue::Bool(record.tombstoned())),
+        ("disposed", JsonValue::Bool(disposal.disposed())),
+        ("retained", JsonValue::Bool(source.retained)),
+        ("expired", JsonValue::Bool(source.expired)),
+        ("archived", JsonValue::Bool(source.archived)),
+        ("blocked", JsonValue::Bool(record.is_blocked())),
+        (
+            "requires_attention",
+            JsonValue::Bool(record.requires_attention()),
+        ),
+        (
+            "has_source_lineage",
+            JsonValue::Bool(record.has_source_lineage()),
+        ),
+    ])
+}
+
+fn integration_activation_waiver_tombstone_summary_json(
+    summary: &IntegrationActivationWaiverTombstoneSummary,
+) -> JsonValue {
+    object([
+        ("total_records", integer(summary.total_records as i64)),
+        (
+            "unique_integrations",
+            integer(summary.unique_integrations as i64),
+        ),
+        (
+            "records_requiring_attention",
+            integer(summary.records_requiring_attention as i64),
+        ),
+        ("blocked_records", integer(summary.blocked_records as i64)),
+        (
+            "evidence_required_records",
+            integer(summary.evidence_required_records as i64),
+        ),
+        (
+            "ready_for_tombstone_records",
+            integer(summary.ready_for_tombstone_records as i64),
+        ),
+        (
+            "tombstoned_records",
+            integer(summary.tombstoned_records as i64),
+        ),
+        (
+            "tombstone_ready_records",
+            integer(summary.tombstone_ready_records as i64),
+        ),
+        ("disposed_records", integer(summary.disposed_records as i64)),
+        (
+            "disposal_ready_records",
+            integer(summary.disposal_ready_records as i64),
+        ),
+        ("expired_records", integer(summary.expired_records as i64)),
+        (
+            "evidence_ready_records",
+            integer(summary.evidence_ready_records as i64),
+        ),
+        (
+            "source_linked_records",
+            integer(summary.source_linked_records as i64),
+        ),
+        (
+            "reviewer_required_records",
+            integer(summary.reviewer_required_records as i64),
+        ),
+        (
+            "exception_required_records",
+            integer(summary.exception_required_records as i64),
+        ),
+        (
+            "signoff_required_records",
+            integer(summary.signoff_required_records as i64),
+        ),
+        (
+            "platform_tombstone_records",
+            integer(summary.platform_tombstone_records as i64),
+        ),
+        (
+            "integration_tombstone_records",
+            integer(summary.integration_tombstone_records as i64),
+        ),
+        (
+            "security_tombstone_records",
+            integer(summary.security_tombstone_records as i64),
+        ),
+        (
+            "reviewer_tombstone_records",
+            integer(summary.reviewer_tombstone_records as i64),
+        ),
+        (
+            "verification_tombstone_records",
+            integer(summary.verification_tombstone_records as i64),
+        ),
+        (
+            "audit_tombstone_records",
+            integer(summary.audit_tombstone_records as i64),
+        ),
+        (
+            "first_attention_priority",
+            summary
+                .first_attention_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_blocked_priority",
+            summary
+                .first_blocked_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_ready_priority",
+            summary
+                .first_ready_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "next_tombstone_status",
+            summary
+                .next_tombstone_status
+                .map(|status| string(status.as_str()))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "next_tombstone_lane",
+            summary
+                .next_tombstone_lane
+                .map(|lane| string(lane.as_str()))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "next_tombstone_action",
+            summary
+                .next_tombstone_action
+                .as_ref()
+                .map(|action| string(action))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "highest_policy_tier",
+            string(privilege_tier_label(summary.highest_policy_tier)),
+        ),
+        ("overall_status", string(summary.overall_status.as_str())),
+        ("is_empty", JsonValue::Bool(summary.total_records == 0)),
+        ("has_blockers", JsonValue::Bool(summary.has_blockers())),
+        (
+            "requires_attention",
+            JsonValue::Bool(summary.requires_attention()),
+        ),
+    ])
+}
+
 fn activation_risk_json(risk: &IntegrationActivationRiskItem) -> JsonValue {
     object([
         ("risk_kind", string(risk.kind.as_str())),
@@ -39520,6 +40479,27 @@ fn parse_activation_waiver_disposal_status(
     }
 }
 
+fn parse_activation_waiver_tombstone_status(
+    label: &str,
+) -> Result<IntegrationActivationWaiverTombstoneStatus, ToolCallError> {
+    match label {
+        "blocked" | "blocker" | "hold" | "held" => {
+            Ok(IntegrationActivationWaiverTombstoneStatus::Blocked)
+        }
+        "evidence_required" | "needs_evidence" | "evidence" | "source_required"
+        | "source_linkage" => Ok(IntegrationActivationWaiverTombstoneStatus::EvidenceRequired),
+        "ready_for_tombstone" | "ready" | "tombstone_ready" | "ready_to_tombstone" => {
+            Ok(IntegrationActivationWaiverTombstoneStatus::ReadyForTombstone)
+        }
+        "tombstoned" | "tombstone" | "minimized" | "retained" | "complete" | "completed" => {
+            Ok(IntegrationActivationWaiverTombstoneStatus::Tombstoned)
+        }
+        _ => Err(validation_error(format!(
+            "unknown activation waiver tombstone status `{label}`"
+        ))),
+    }
+}
+
 fn parse_activation_risk_kind(label: &str) -> Result<IntegrationActivationRiskKind, ToolCallError> {
     match label {
         "policy_tier" | "tier" | "required_tier" => Ok(IntegrationActivationRiskKind::PolicyTier),
@@ -42365,6 +43345,92 @@ fn integration_activation_waiver_disposal_query_schema() -> JsonSchema {
     schema
 }
 
+fn integration_activation_waiver_tombstone_query_schema() -> JsonSchema {
+    let mut schema = integration_activation_waiver_disposal_query_schema();
+    if let JsonSchema::Object {
+        properties,
+        required: _,
+        allow_unknown_fields: _,
+    } = &mut schema
+    {
+        let mut push_if_absent = |property: SchemaProperty| {
+            if !properties
+                .iter()
+                .any(|existing| existing.name == property.name)
+            {
+                properties.push(property);
+            }
+        };
+        push_if_absent(SchemaProperty::new(
+            "waiver_tombstone_status",
+            JsonSchema::String,
+        ));
+        push_if_absent(SchemaProperty::new("tombstone_status", JsonSchema::String));
+        push_if_absent(SchemaProperty::new(
+            "waiver_tombstone_lane",
+            JsonSchema::String,
+        ));
+        push_if_absent(SchemaProperty::new("tombstone_lane", JsonSchema::String));
+        push_if_absent(SchemaProperty::new(
+            "waiver_tombstone_disposal_lane",
+            JsonSchema::String,
+        ));
+        push_if_absent(SchemaProperty::new(
+            "waiver_tombstone_expiration_lane",
+            JsonSchema::String,
+        ));
+        push_if_absent(SchemaProperty::new(
+            "waiver_tombstone_retention_lane",
+            JsonSchema::String,
+        ));
+        push_if_absent(SchemaProperty::new(
+            "waiver_tombstone_archive_lane",
+            JsonSchema::String,
+        ));
+        push_if_absent(SchemaProperty::new(
+            "waiver_tombstone_closure_lane",
+            JsonSchema::String,
+        ));
+        push_if_absent(SchemaProperty::new(
+            "waiver_tombstone_owner_lane",
+            JsonSchema::String,
+        ));
+        push_if_absent(SchemaProperty::new(
+            "waiver_tombstone_approval_lane",
+            JsonSchema::String,
+        ));
+        push_if_absent(SchemaProperty::new(
+            "waiver_tombstone_evidence_kind",
+            JsonSchema::String,
+        ));
+        push_if_absent(SchemaProperty::new(
+            "waiver_tombstone_requires_attention",
+            JsonSchema::Boolean,
+        ));
+        push_if_absent(SchemaProperty::new(
+            "waiver_tombstone_blocked",
+            JsonSchema::Boolean,
+        ));
+        push_if_absent(SchemaProperty::new(
+            "waiver_tombstone_ready",
+            JsonSchema::Boolean,
+        ));
+        push_if_absent(SchemaProperty::new("tombstone_ready", JsonSchema::Boolean));
+        push_if_absent(SchemaProperty::new(
+            "waiver_tombstoned",
+            JsonSchema::Boolean,
+        ));
+        push_if_absent(SchemaProperty::new("tombstoned", JsonSchema::Boolean));
+        push_if_absent(SchemaProperty::new(
+            "waiver_tombstone_limit",
+            JsonSchema::Integer,
+        ));
+        push_if_absent(SchemaProperty::new("tombstone_limit", JsonSchema::Integer));
+        push_if_absent(SchemaProperty::new("record_limit", JsonSchema::Integer));
+    }
+    schema
+}
+
 fn integration_activation_risk_query_schema() -> JsonSchema {
     let mut schema = integration_activation_candidate_query_schema(true);
     if let JsonSchema::Object {
@@ -42509,7 +43575,7 @@ mod tests {
         let definitions = smart_home_tool_definitions();
         let export = ToolCatalogExport::from_definitions(definitions.iter());
 
-        assert_eq!(definitions.len(), 171);
+        assert_eq!(definitions.len(), 173);
         assert!(
             export.ok(),
             "tool export validation failed: {:?}",
@@ -43000,9 +44066,15 @@ mod tests {
         assert!(export
             .tool_ids()
             .contains(&SMART_HOME_GET_INTEGRATION_ACTIVATION_WAIVER_DISPOSAL_SUMMARY_TOOL_ID));
+        assert!(export
+            .tool_ids()
+            .contains(&SMART_HOME_LIST_INTEGRATION_ACTIVATION_WAIVER_TOMBSTONES_TOOL_ID));
+        assert!(export
+            .tool_ids()
+            .contains(&SMART_HOME_GET_INTEGRATION_ACTIVATION_WAIVER_TOMBSTONE_SUMMARY_TOOL_ID));
         assert_eq!(
             export.summary.required_capability_count("smart_home:read"),
-            163
+            165
         );
         assert_eq!(
             export
@@ -43115,6 +44187,14 @@ mod tests {
         .is_some());
         assert!(smart_home_tool_definition(
             SMART_HOME_GET_INTEGRATION_ACTIVATION_WAIVER_DISPOSAL_SUMMARY_TOOL_ID
+        )
+        .is_some());
+        assert!(smart_home_tool_definition(
+            SMART_HOME_LIST_INTEGRATION_ACTIVATION_WAIVER_TOMBSTONES_TOOL_ID
+        )
+        .is_some());
+        assert!(smart_home_tool_definition(
+            SMART_HOME_GET_INTEGRATION_ACTIVATION_WAIVER_TOMBSTONE_SUMMARY_TOOL_ID
         )
         .is_some());
         assert!(smart_home_tool_definition(SMART_HOME_LIST_DISCOVERY_WORKERS_TOOL_ID).is_some());
@@ -43626,11 +44706,11 @@ mod tests {
         let tool_catalog_summary = field(tool_catalog_summary_output, "summary").unwrap();
         assert_eq!(
             field(tool_catalog_summary, "total_tools"),
-            Some(&integer(171))
+            Some(&integer(173))
         );
         assert_eq!(
             field(tool_catalog_summary, "read_tools"),
-            Some(&integer(163))
+            Some(&integer(165))
         );
         assert_eq!(
             field(tool_catalog_summary, "risky_tool_count"),
@@ -53997,6 +55077,191 @@ mod tests {
         traces.push((
             activation_waiver_disposal_summary_request,
             activation_waiver_disposal_summary_trace,
+        ));
+
+        traces
+    }
+
+    #[test]
+    fn activation_waiver_tombstone_tools_project_disposal_lineage_end_to_end() {
+        let runtime = Rc::new(RefCell::new(hue_lighting_runtime()));
+        let bridge = SmartHomeToolBridge::new(runtime, AgentId::trusted(AGENT_ID));
+        let mut tool_runtime = InMemoryToolRuntime::new();
+        bridge.register_all(&mut tool_runtime).unwrap();
+
+        let traces = exercise_activation_waiver_tombstone_tools(&tool_runtime);
+        let mut journal = ToolExecutionJournal::new();
+        for (request, trace) in traces {
+            journal.record_trace(request, trace);
+        }
+
+        let summary = journal.summary();
+        assert_eq!(summary.invocation_count, 2);
+        assert_eq!(summary.completed_count, 2);
+        assert_eq!(journal.audit_records().len(), 2);
+    }
+
+    fn exercise_activation_waiver_tombstone_tools(
+        tool_runtime: &InMemoryToolRuntime,
+    ) -> Vec<(ToolInvocationRequest, ToolExecutionTrace)> {
+        let mut traces = Vec::with_capacity(2);
+
+        let list_activation_waiver_tombstones_request = request(
+            "call-list-integration-activation-waiver-tombstones",
+            SMART_HOME_LIST_INTEGRATION_ACTIVATION_WAIVER_TOMBSTONES_TOOL_ID,
+            object([
+                ("priority_at_or_before", integer(2)),
+                (
+                    "available_primitives",
+                    JsonValue::Array(vec![
+                        string("normalized_model"),
+                        string("discovery_index"),
+                        string("command_mapping"),
+                        string("capability_policy"),
+                        string("supervision"),
+                    ]),
+                ),
+                (
+                    "allowed_capability_ids",
+                    JsonValue::Array(vec![string("smart_home.read")]),
+                ),
+                (
+                    "enabled_integrations",
+                    JsonValue::Array(vec![string("mqtt")]),
+                ),
+                ("waiver_tombstone_blocked", JsonValue::Bool(true)),
+                ("waiver_tombstone_requires_attention", JsonValue::Bool(true)),
+                ("waiver_tombstone_limit", integer(3)),
+            ]),
+            5_301,
+        );
+        let list_activation_waiver_tombstones_trace =
+            tool_runtime.invoke_with_events(&list_activation_waiver_tombstones_request);
+        assert!(list_activation_waiver_tombstones_trace.result.ok);
+        assert_eq!(
+            list_activation_waiver_tombstones_trace
+                .summary()
+                .progress_event_count,
+            1
+        );
+        let list_activation_waiver_tombstones_output = list_activation_waiver_tombstones_trace
+            .result
+            .output
+            .as_ref()
+            .unwrap();
+        let activation_waiver_tombstone_count =
+            integer_value(field(list_activation_waiver_tombstones_output, "count").unwrap())
+                .unwrap();
+        assert!((1..=3).contains(&activation_waiver_tombstone_count));
+        let activation_waiver_tombstone_summary =
+            field(list_activation_waiver_tombstones_output, "summary").unwrap();
+        assert_eq!(
+            field(activation_waiver_tombstone_summary, "total_records"),
+            Some(&integer(activation_waiver_tombstone_count))
+        );
+        assert!(
+            integer_value(field(activation_waiver_tombstone_summary, "blocked_records").unwrap())
+                .unwrap()
+                >= 1
+        );
+        assert_eq!(
+            field(activation_waiver_tombstone_summary, "has_blockers"),
+            Some(&JsonValue::Bool(true))
+        );
+        assert_eq!(
+            field(activation_waiver_tombstone_summary, "requires_attention"),
+            Some(&JsonValue::Bool(true))
+        );
+        let activation_waiver_tombstone = array_item(
+            field(
+                list_activation_waiver_tombstones_output,
+                "activation_waiver_tombstones",
+            )
+            .unwrap(),
+            0,
+        )
+        .unwrap();
+        assert!(field(activation_waiver_tombstone, "tombstone_id").is_some());
+        assert!(field(activation_waiver_tombstone, "source_disposal_id").is_some());
+        assert!(field(activation_waiver_tombstone, "source_expiration_id").is_some());
+        assert!(field(activation_waiver_tombstone, "source_retention_id").is_some());
+        assert!(field(activation_waiver_tombstone, "source_archive_id").is_some());
+        assert!(field(activation_waiver_tombstone, "source_waiver_id").is_some());
+        assert!(field(activation_waiver_tombstone, "source_exception_id").is_some());
+        assert!(field(activation_waiver_tombstone, "tombstone_lane").is_some());
+        assert!(field(activation_waiver_tombstone, "tombstone_action").is_some());
+        assert_eq!(
+            field(activation_waiver_tombstone, "blocked"),
+            Some(&JsonValue::Bool(true))
+        );
+        assert_eq!(
+            field(activation_waiver_tombstone, "requires_attention"),
+            Some(&JsonValue::Bool(true))
+        );
+        assert_eq!(
+            field(activation_waiver_tombstone, "has_source_lineage"),
+            Some(&JsonValue::Bool(true))
+        );
+        traces.push((
+            list_activation_waiver_tombstones_request,
+            list_activation_waiver_tombstones_trace,
+        ));
+
+        let activation_waiver_tombstone_summary_request = request(
+            "call-integration-activation-waiver-tombstone-summary",
+            SMART_HOME_GET_INTEGRATION_ACTIVATION_WAIVER_TOMBSTONE_SUMMARY_TOOL_ID,
+            object([
+                ("priority_at_or_before", integer(2)),
+                (
+                    "available_primitives",
+                    JsonValue::Array(vec![
+                        string("normalized_model"),
+                        string("discovery_index"),
+                        string("command_mapping"),
+                        string("capability_policy"),
+                        string("supervision"),
+                    ]),
+                ),
+                (
+                    "allowed_capability_ids",
+                    JsonValue::Array(vec![string("smart_home.read")]),
+                ),
+                (
+                    "enabled_integrations",
+                    JsonValue::Array(vec![string("mqtt")]),
+                ),
+                ("waiver_tombstone_blocked", JsonValue::Bool(true)),
+            ]),
+            5_302,
+        );
+        let activation_waiver_tombstone_summary_trace =
+            tool_runtime.invoke_with_events(&activation_waiver_tombstone_summary_request);
+        assert!(activation_waiver_tombstone_summary_trace.result.ok);
+        assert_eq!(
+            activation_waiver_tombstone_summary_trace
+                .summary()
+                .progress_event_count,
+            1
+        );
+        let activation_waiver_tombstone_summary_output = activation_waiver_tombstone_summary_trace
+            .result
+            .output
+            .as_ref()
+            .unwrap();
+        let activation_waiver_tombstone_rollup =
+            field(activation_waiver_tombstone_summary_output, "summary").unwrap();
+        assert!(
+            integer_value(field(activation_waiver_tombstone_rollup, "blocked_records").unwrap())
+                .unwrap()
+                >= 1
+        );
+        assert_eq!(
+            field(activation_waiver_tombstone_rollup, "has_blockers"),
+            Some(&JsonValue::Bool(true))
+        );
+        traces.push((
+            activation_waiver_tombstone_summary_request,
+            activation_waiver_tombstone_summary_trace,
         ));
 
         traces

--- a/code/packages/rust/smart-home-core/src/lib.rs
+++ b/code/packages/rust/smart-home-core/src/lib.rs
@@ -1569,6 +1569,8 @@ pub enum SmartHomeTool {
     GetIntegrationActivationWaiverExpirationSummary,
     ListIntegrationActivationWaiverDisposals,
     GetIntegrationActivationWaiverDisposalSummary,
+    ListIntegrationActivationWaiverTombstones,
+    GetIntegrationActivationWaiverTombstoneSummary,
     ListIntegrationActivationRisk,
     GetIntegrationActivationRiskSummary,
     ListIntegrationActivationDependencies,
@@ -1982,6 +1984,12 @@ impl SmartHomeTool {
             }
             Self::GetIntegrationActivationWaiverDisposalSummary => {
                 read_tool("smart_home.get_integration_activation_waiver_disposal_summary")
+            }
+            Self::ListIntegrationActivationWaiverTombstones => {
+                read_tool("smart_home.list_integration_activation_waiver_tombstones")
+            }
+            Self::GetIntegrationActivationWaiverTombstoneSummary => {
+                read_tool("smart_home.get_integration_activation_waiver_tombstone_summary")
             }
             Self::ListIntegrationActivationRisk => {
                 read_tool("smart_home.list_integration_activation_risk")
@@ -2734,6 +2742,8 @@ pub fn smart_home_tool_catalog() -> Vec<ToolDescriptor> {
         SmartHomeTool::GetIntegrationActivationWaiverExpirationSummary,
         SmartHomeTool::ListIntegrationActivationWaiverDisposals,
         SmartHomeTool::GetIntegrationActivationWaiverDisposalSummary,
+        SmartHomeTool::ListIntegrationActivationWaiverTombstones,
+        SmartHomeTool::GetIntegrationActivationWaiverTombstoneSummary,
         SmartHomeTool::ListIntegrationActivationRisk,
         SmartHomeTool::GetIntegrationActivationRiskSummary,
         SmartHomeTool::ListIntegrationActivationDependencies,
@@ -3576,7 +3586,7 @@ mod tests {
             .find(|tool| tool.tool_id == "smart_home.command")
             .unwrap();
 
-        assert_eq!(catalog.len(), 171);
+        assert_eq!(catalog.len(), 173);
         assert!(catalog
             .iter()
             .any(|tool| tool.tool_id == "smart_home.list_integrations"
@@ -4267,6 +4277,14 @@ mod tests {
             == "smart_home.get_integration_activation_waiver_disposal_summary"
             && tool.side_effects == ToolSideEffects::Read
             && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
+        assert!(catalog.iter().any(|tool| tool.tool_id
+            == "smart_home.list_integration_activation_waiver_tombstones"
+            && tool.side_effects == ToolSideEffects::Read
+            && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
+        assert!(catalog.iter().any(|tool| tool.tool_id
+            == "smart_home.get_integration_activation_waiver_tombstone_summary"
+            && tool.side_effects == ToolSideEffects::Read
+            && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
     }
 
     #[test]
@@ -4274,15 +4292,15 @@ mod tests {
         let summary = smart_home_tool_catalog_summary();
         let pair_bridge = SmartHomeTool::PairBridge.descriptor();
 
-        assert_eq!(summary.total_tools, 171);
-        assert_eq!(summary.read_tools, 163);
+        assert_eq!(summary.total_tools, 173);
+        assert_eq!(summary.read_tools, 165);
         assert_eq!(summary.write_tools, 2);
         assert_eq!(summary.external_tools, 6);
-        assert_eq!(summary.read_only_tier_tools, 163);
+        assert_eq!(summary.read_only_tier_tools, 165);
         assert_eq!(summary.low_risk_tier_tools, 6);
         assert_eq!(summary.high_risk_tier_tools, 0);
         assert_eq!(summary.human_approval_tier_tools, 2);
-        assert_eq!(summary.total_required_capabilities, 171);
+        assert_eq!(summary.total_required_capabilities, 173);
         assert_eq!(summary.risky_tool_count(), 8);
         assert_eq!(summary.approval_gated_tool_count(), 2);
         assert!(pair_bridge.requires_human_approval());


### PR DESCRIPTION
## Summary
- add reusable smart-home-core descriptors for activation waiver tombstone list and summary tools
- add Chief-facing D23A tombstone projection, filters, summaries, JSON output, and dispatch handlers over waiver disposal lineage
- cover the new tombstone tools with catalog assertions and an end-to-end invocation test that verifies source disposal/expiration/retention/archive lineage

## Validation
- cargo test -p smart-home-core
- cargo test -p smart-home-integration-catalog
- cargo test -p hue-core
- cargo test -p smart-home-runtime
- cargo test -p smart-home-testkit
- cargo test -p smart-home-local-http
- cargo test -p smart-home-discovery
- cargo test -p chief-of-staff-smart-home-tools
- cargo test -p smart-home-runtime discover_tool -- --nocapture
- sh BUILD in smart-home-core
- sh BUILD in smart-home-integration-catalog
- sh BUILD in hue-core
- sh BUILD in smart-home-runtime
- sh BUILD in smart-home-testkit
- sh BUILD in smart-home-local-http
- sh BUILD in smart-home-discovery
- sh BUILD in chief-of-staff-smart-home-tools
