### PR TITLE
feat(visicalc-compose): render the infinite grid via sc_get_display_window (formatting visible)

### DIFF
--- a/demo/visicalc-compose/README.md
+++ b/demo/visicalc-compose/README.md
@@ -70,9 +70,12 @@ grid to `InfiniteSheet` — a virtualized, effectively-infinite (u32 × u32,
 sparse) sheet rendered on the same engine. The body is a `LazyColumn`, which
 natively virtualizes: it composes a row item only while it's near the viewport
 and recycles it on scroll, so a 1000-row sheet costs the handful of rows you can
-see. Each composed row makes **one** engine `get_window` over its `1×totalCols`
-strip (`InfiniteSheetModel.rowCells`) — per-frame engine work is proportional to
-*visible* rows, never the sheet's height.
+see. Each composed row makes **one** engine `get_display_window` over its
+`1×totalCols` strip (`InfiniteSheetModel.rowCells`) — display strings, each
+already rendered through its Excel-style format code (the seed formats the
+cross-foot totals as `#,##0.00` and the far-flung `Z1000` total as a percent),
+so the Compose host paints them directly. Per-frame engine work is proportional
+to *visible* rows, never the sheet's height.
 
 Frozen chrome without a second scroller: the row-number gutter rides as each
 `LazyColumn` row's first child, *outside* the horizontal scroll, so it stays

--- a/demo/visicalc-compose/src/main/kotlin/Engine.kt
+++ b/demo/visicalc-compose/src/main/kotlin/Engine.kt
@@ -45,6 +45,9 @@ class SpreadsheetSession(libraryPath: String = resolveLibraryPath()) : AutoClose
     private val i32 = ValueLayout.JAVA_INT
     private val i64 = ValueLayout.JAVA_LONG
     private val scGetWindow = handle("sc_get_window", FunctionDescriptor.of(ptr, ptr, i32, i32, i32, i32))
+    private val scGetDisplayWindow = handle("sc_get_display_window", FunctionDescriptor.of(ptr, ptr, i32, i32, i32, i32))
+    // sc_set_format(session, a1, code) -> void (empty code clears the format).
+    private val scSetFormat = handle("sc_set_format", FunctionDescriptor.ofVoid(ptr, ptr, ptr))
     private val scUsedRange = handle("sc_used_range", FunctionDescriptor.of(ptr, ptr))
     private val scColumnLetters = handle("sc_column_letters", FunctionDescriptor.of(ptr, ptr, i32))
     private val scCurrentRevision = handle("sc_current_revision", FunctionDescriptor.of(i64, ptr))
@@ -104,14 +107,26 @@ class SpreadsheetSession(libraryPath: String = resolveLibraryPath()) : AutoClose
     // web/SwiftUI/Qt/Flutter infinite views. The window JSON is nested, so these
     // use the small JSON parser below rather than display()'s per-value regex.
 
+    /// Set a cell's display format code (an Excel-style code like "#,##0.00" or
+    /// "0%"); an empty code clears it. Drives the engine's display path that
+    /// [window] reads through sc_get_display_window.
+    fun setFormat(a1: String, code: String): Unit = Arena.ofConfined().use { a ->
+        scSetFormat.invoke(session, a.allocateUtf8String(a1), a.allocateUtf8String(code))
+    }
+
     /// Dense display strings for the inclusive 1-based rectangle, row-major
     /// (empty cells become ""). Empty list on a bad/oversized request.
+    ///
+    /// Reads sc_get_display_window: each cell arrives already rendered through its
+    /// format code as a display string, so the host paints it directly and never
+    /// re-derives number formatting. The format-aware sibling of sc_get_window;
+    /// the JSON is {...,"cells":[["1,234.50",…],…]}.
     fun window(row0: Int, col0: Int, row1: Int, col1: Int): List<List<String>> {
-        val json = take(scGetWindow.invoke(session, row0, col0, row1, col1) as MemorySegment)
+        val json = take(scGetDisplayWindow.invoke(session, row0, col0, row1, col1) as MemorySegment)
         val obj = parseJson(json) as? Map<*, *> ?: return emptyList()
-        val values = obj["values"] as? List<*> ?: return emptyList()
-        return values.map { row ->
-            (row as List<*>).map { valueToDisplay(it as Map<*, *>) }
+        val cells = obj["cells"] as? List<*> ?: return emptyList()
+        return cells.map { row ->
+            (row as List<*>).map { it as? String ?: "" }
         }
     }
 
@@ -273,6 +288,19 @@ class InfiniteSheetModel(
             "BA50" to "far cell", "BB50" to "=Z1000*2", // col 53/54, row 50: 78
         )
         for ((a1, raw) in cells) session.setCell(a1, raw)
+
+        // Attach Excel-style format codes so the engine's display path is visible
+        // in the windowed view (which renders via sc_get_display_window): the
+        // cross-foot totals read with thousands grouping + two decimals, and the
+        // far-flung Z1000 total as a percent. Values are unchanged — only how the
+        // display strings render. Identical to the web/Qt/Flutter demos' formats.
+        val formats = listOf(
+            "E1" to "#,##0.00", "E2" to "#,##0.00", "E3" to "#,##0.00",
+            "E4" to "#,##0.00", "E5" to "#,##0.00",
+            "A5" to "#,##0.00", "B5" to "#,##0.00", "C5" to "#,##0.00", "D5" to "#,##0.00",
+            "Z1000" to "0.0%", // 39 -> "3900.0%": proves the format applies far off-origin
+        )
+        for ((a1, code) in formats) session.setFormat(a1, code)
     }
 
     /// Re-derive the virtual grid size from the engine's data extent plus a
@@ -339,19 +367,6 @@ class InfiniteSheetModel(
 // ASCII cell text and no \uXXXX escapes, so the minimal escape handling is
 // sufficient for this trusted input.
 // ─────────────────────────────────────────────────────────────────────
-
-/// Map one decoded value object (`{"kind":...}`) to the display string.
-private fun valueToDisplay(obj: Map<*, *>): String = when (obj["kind"]) {
-    "empty" -> ""
-    "number" -> {
-        val d = (obj["value"] as Number).toDouble()
-        if (d == Math.floor(d) && Math.abs(d) < 1e15) d.toLong().toString() else d.toString()
-    }
-    "text" -> obj["value"] as? String ?: ""
-    "boolean" -> if (obj["value"] == true) "TRUE" else "FALSE"
-    "error" -> obj["code"] as? String ?: "#ERR"
-    else -> ""
-}
 
 private fun parseJson(s: String): Any? = if (s.isEmpty()) null else JsonReader(s).readValue()
 

--- a/demo/visicalc-compose/src/main/kotlin/InfiniteSheet.kt
+++ b/demo/visicalc-compose/src/main/kotlin/InfiniteSheet.kt
@@ -1,16 +1,17 @@
 // InfiniteSheet.kt — a virtualized, effectively-infinite spreadsheet view for
 // the Compose Desktop demo, rendered on the shared Rust engine through the
-// viewport primitive (the same get_window / used_range / changed_since the
-// SwiftUI InfiniteGridView, the Qt InfiniteSheet.qml, and the Flutter
+// viewport primitive (the same get_display_window / used_range / changed_since
+// the SwiftUI InfiniteGridView, the Qt InfiniteSheet.qml, and the Flutter
 // InfiniteGrid drive).
 //
 // The sheet is u32 × u32 and sparse; only the cells in the VISIBLE rows are ever
 // composed. The body is a `LazyColumn`, which natively virtualizes — it composes
 // a row item only while it's near the viewport and recycles it as it scrolls
 // off. So a 1000-row-tall sheet costs the handful of rows you can see, and each
-// composed row makes ONE engine `get_window` over its 1×totalCols strip
-// (InfiniteSheetModel.rowCells). Per-frame engine work is proportional to
-// *visible* rows, never to the sheet's height.
+// composed row makes ONE engine `get_display_window` over its 1×totalCols strip
+// (InfiniteSheetModel.rowCells) — display strings, already rendered through each
+// cell's format code. Per-frame engine work is proportional to *visible* rows,
+// never to the sheet's height.
 //
 // Frozen chrome without a second scroller: the row-number gutter rides as each
 // LazyColumn row's first child, OUTSIDE the horizontal scroll, so it stays

--- a/demo/visicalc-compose/test/EngineSmoke.kt
+++ b/demo/visicalc-compose/test/EngineSmoke.kt
@@ -104,8 +104,8 @@ fun main() {
     // rowCells returns one row's display strings (columns 1..totalCols).
     val row1 = inf.rowCells(1)
     check("inf rowCells width", (row1.size == inf.totalCols).toString(), "true")
-    check("inf rowCells A1", row1[0], "15")
-    check("inf rowCells E1", row1[4], "38")  // SUM(A1:D1)
+    check("inf rowCells A1", row1[0], "15") // unformatted
+    check("inf rowCells E1", row1[4], "38.00")  // SUM(A1:D1), "#,##0.00" formatted
     check("inf rowCells J1 empty", row1[9], "") // sparse
     check("inf gap row blank", inf.rowCells(200).all { it.isEmpty() }.toString(), "true")
 
@@ -120,10 +120,10 @@ fun main() {
     // commitInf writes through and recomputes every dependent.
     inf.selectInf(2, 1)          // A2
     inf.commitInf("108")         // 8 -> 108
-    check("inf commit A2", inf.rowCells(2)[0], "108")
-    check("inf commit E2", inf.rowCells(2)[4], "151") // 108+14+7+22
-    check("inf commit A5", inf.rowCells(5)[0], "139") // 15+108+12+4
-    check("inf commit E5", inf.rowCells(5)[4], "269") // grand total
+    check("inf commit A2", inf.rowCells(2)[0], "108") // unformatted
+    check("inf commit E2", inf.rowCells(2)[4], "151.00") // 108+14+7+22, formatted
+    check("inf commit A5", inf.rowCells(5)[0], "139.00") // 15+108+12+4, formatted
+    check("inf commit E5", inf.rowCells(5)[4], "269.00") // grand total, formatted
     inf.close()
 
     println(if (failures == 0) "\nALL PASS" else "\n$failures FAILURE(S)")


### PR DESCRIPTION
## What

Switches the Compose Desktop demo's windowed reader from `sc_get_window` (typed value JSON, formatted client-side) to **`sc_get_display_window`** over the Java FFM API — the engine returns each visible cell already rendered through its format code as a display string, so the `LazyColumn` rows paint the strings directly and never re-derive number formatting. Fourth backend on the display path (after web #6019, Qt #6023, Flutter #6028).

## Changes

- **`Engine.kt`** — add FFM downcall handles for `sc_get_display_window` and `sc_set_format`; new `SpreadsheetSession.setFormat()`; `window()` parses the `"cells"` string array. The now-unused `valueToDisplay()` is removed (the 5×5 parity grid uses `display()`'s per-value regex, unchanged).
- **`InfiniteSheetModel.seed()`** attaches the same format codes as the web/Qt/Flutter demos: cross-foot totals (col E + row 5) → `"#,##0.00"`, far-flung `Z1000` → `"0.0%"`.
- **`EngineSmoke.kt`** — the `InfiniteSheetModel` checks assert the formatted strings (`38.00` / `151.00` / `139.00` / `269.00`); the standalone-session window checks seed no formats, so their `General`-rendered integers are unchanged.
- **README + `InfiniteSheet.kt`** comments updated to `get_display_window`.

## Verification

`scripts/verify.sh` (kotlinc + JDK 21 FFM, `--enable-preview --enable-native-access`) — **ALL PASS (40 checks)**, against the re-vendored `spreadsheet-capi` 0.5.0 dylib (`native/` is git-ignored).

`/security-review` — **PASSED** (FFM `Arena.ofConfined().use` bounds the input allocations; `sc_set_format` is `ofVoid` so there's no pointer to free; the window result is freed once via `take`/`sc_string_free`; coords bounded server-side).

## Next

Last two native backends: XAML (.NET P/Invoke) → SwiftUI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)