### PR TITLE
feat(visicalc-xaml): render the infinite grid via sc_get_display_window (formatting visible)

### DIFF
--- a/demo/visicalc-xaml/Engine.cs
+++ b/demo/visicalc-xaml/Engine.cs
@@ -53,6 +53,14 @@ internal static class ScNative
     // char* results, except sc_current_revision returns the u64 directly.
     [DllImport("spreadsheet_capi")]
     internal static extern IntPtr sc_get_window(IntPtr s, uint row0, uint col0, uint row1, uint col1);
+    // Format-aware sibling of sc_get_window: each cell is its display string.
+    [DllImport("spreadsheet_capi")]
+    internal static extern IntPtr sc_get_display_window(IntPtr s, uint row0, uint col0, uint row1, uint col1);
+    // sc_set_format(session, a1, code) → void (an empty code clears the format).
+    [DllImport("spreadsheet_capi")]
+    internal static extern void sc_set_format(IntPtr s,
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string a1,
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string code);
     [DllImport("spreadsheet_capi")] internal static extern IntPtr sc_used_range(IntPtr s);
     [DllImport("spreadsheet_capi")] internal static extern IntPtr sc_column_letters(IntPtr s, uint index);
     [DllImport("spreadsheet_capi")] internal static extern ulong sc_current_revision(IntPtr s);
@@ -105,6 +113,11 @@ public sealed class SpreadsheetSession : IDisposable
     public string SetCell(string a1, string raw) => Take(ScNative.sc_set_cell(_handle, a1, raw));
     public string GetValueJson(string a1) => Take(ScNative.sc_get_value(_handle, a1));
     public string GetRaw(string a1) => Take(ScNative.sc_get_raw(_handle, a1));
+
+    /// Set a cell's display format code (an Excel-style code like "#,##0.00" or
+    /// "0%"); an empty code clears it. Drives the engine's display path that
+    /// <see cref="Window"/> reads through sc_get_display_window.
+    public void SetFormat(string a1, string code) => ScNative.sc_set_format(_handle, a1, code);
 
     /// The display string for a cell — what a spreadsheet should show. Parses
     /// the engine's JSON (the fixed shape every backend's engine emits).
@@ -162,18 +175,23 @@ public sealed class SpreadsheetSession : IDisposable
 
     /// Dense display strings for the inclusive 1-based rectangle, row-major
     /// (empty cells become ""). Empty list on a bad/oversized request.
+    ///
+    /// Reads sc_get_display_window: each cell arrives already rendered through its
+    /// format code as a display string, so the host paints it directly and never
+    /// re-derives number formatting. The format-aware sibling of sc_get_window;
+    /// the JSON is {...,"cells":[["1,234.50",…],…]}.
     public IReadOnlyList<IReadOnlyList<string>> Window(uint row0, uint col0, uint row1, uint col1)
     {
-        string json = Take(ScNative.sc_get_window(_handle, row0, col0, row1, col1));
+        string json = Take(ScNative.sc_get_display_window(_handle, row0, col0, row1, col1));
         var rows = new List<IReadOnlyList<string>>();
         try
         {
             using var doc = JsonDocument.Parse(json);
-            if (!doc.RootElement.TryGetProperty("values", out var values)) return rows;
-            foreach (var rowEl in values.EnumerateArray())
+            if (!doc.RootElement.TryGetProperty("cells", out var cells)) return rows;
+            foreach (var rowEl in cells.EnumerateArray())
             {
                 var row = new List<string>();
-                foreach (var cell in rowEl.EnumerateArray()) row.Add(DisplayValue(cell));
+                foreach (var cell in rowEl.EnumerateArray()) row.Add(cell.GetString() ?? string.Empty);
                 rows.Add(row);
             }
         }
@@ -344,6 +362,20 @@ public sealed class InfiniteSheetModel : IDisposable
             ("BA50", "far cell"), ("BB50", "=Z1000*2"), // col 53/54, row 50: 78
         };
         foreach (var (a1, raw) in cells) _session.SetCell(a1, raw);
+
+        // Attach Excel-style format codes so the engine's display path is visible
+        // in the windowed view (which renders via sc_get_display_window): the
+        // cross-foot totals read with thousands grouping + two decimals, and the
+        // far-flung Z1000 total as a percent. Values are unchanged — only how the
+        // display strings render. Identical to the web/Qt/Flutter/Compose demos.
+        (string a1, string code)[] formats =
+        {
+            ("E1", "#,##0.00"), ("E2", "#,##0.00"), ("E3", "#,##0.00"),
+            ("E4", "#,##0.00"), ("E5", "#,##0.00"),
+            ("A5", "#,##0.00"), ("B5", "#,##0.00"), ("C5", "#,##0.00"), ("D5", "#,##0.00"),
+            ("Z1000", "0.0%"), // 39 → "3900.0%": proves the format applies far off-origin
+        };
+        foreach (var (a1, code) in formats) _session.SetFormat(a1, code);
     }
 
     /// Re-derive the virtual grid size from the engine's data extent plus a

--- a/demo/visicalc-xaml/InfiniteSheet.xaml
+++ b/demo/visicalc-xaml/InfiniteSheet.xaml
@@ -1,6 +1,6 @@
 <!-- InfiniteSheet.xaml — a virtualized, effectively-infinite spreadsheet view for
      the WinUI 3 / XAML demo, rendered on the shared Rust engine through the
-     viewport primitive (the same get_window / used_range / changed_since the
+     viewport primitive (the same get_display_window / used_range / changed_since the
      SwiftUI InfiniteGridView, the Qt InfiniteSheet.qml, the Flutter InfiniteGrid,
      and the Compose InfiniteSheet drive).
 
@@ -8,7 +8,7 @@
      ever realized. The body is a ListView, which natively virtualizes (its
      ItemsStackPanel realizes a row container only while it's near the viewport
      and recycles it on scroll). Each realized row's cells are filled on demand in
-     the code-behind's ContainerContentChanging handler from one engine get_window
+     the code-behind's ContainerContentChanging handler from one engine get_display_window
      over its 1×TotalCols strip (InfiniteSheetModel.RowCells) — so per-frame engine
      work is proportional to *visible* rows, never the sheet's height.
 

--- a/demo/visicalc-xaml/InfiniteSheet.xaml.cs
+++ b/demo/visicalc-xaml/InfiniteSheet.xaml.cs
@@ -8,8 +8,9 @@
 // Virtualization: BodyList is a ListView whose ItemsSource is just the row
 // numbers (1..TotalRows) — a lightweight int list. The ListView's ItemsStackPanel
 // realizes a container only for on-screen rows; ContainerContentChanging fills
-// each realized row's cells from one engine get_window over its 1×TotalCols strip
-// (model.RowCells). So building the UI costs only the visible rows, never the
+// each realized row's cells from one engine get_display_window over its
+// 1×TotalCols strip (model.RowCells) — display strings, already rendered through
+// each cell's format code. So building the UI costs only the visible rows, never the
 // whole (possibly millions-tall) sheet. The gutter is a second virtualized
 // ListView over the same row numbers, and the header is a one-time StackPanel of
 // column letters; both are kept in sync with the body's scroll offsets.

--- a/demo/visicalc-xaml/README.md
+++ b/demo/visicalc-xaml/README.md
@@ -135,9 +135,12 @@ to `InfiniteSheet` — a virtualized, effectively-infinite (u32 × u32, sparse)
 view rendered on the same engine. The body is a `ListView` whose `ItemsSource`
 is just the row numbers (`1..TotalRows`); its `ItemsStackPanel` realizes a
 container only for on-screen rows, and `ContainerContentChanging` fills each
-realized row's cells from **one** engine `get_window` over its `1×TotalCols`
-strip (`InfiniteSheetModel.RowCells`) — so building the UI costs only the visible
-rows, never the whole (millions-tall) sheet. Frozen chrome by scroll-sync: the
+realized row's cells from **one** engine `get_display_window` over its
+`1×TotalCols` strip (`InfiniteSheetModel.RowCells`) — display strings, each
+already rendered through its Excel-style format code (the seed formats the
+cross-foot totals as `#,##0.00` and the far-flung `Z1000` total as a percent),
+so the host paints them directly. Building the UI costs only the visible rows,
+never the whole (millions-tall) sheet. Frozen chrome by scroll-sync: the
 row-number gutter is a second virtualized `ListView` slaved to the body's
 vertical scroll, and the column-letter header follows the body's horizontal pan.
 Tap a cell → `SelectInf` (clamps, loads the source into the formula bar); press

--- a/demo/visicalc-xaml/test/Program.cs
+++ b/demo/visicalc-xaml/test/Program.cs
@@ -102,8 +102,8 @@ using (var inf = new InfiniteSheetModel())
     // RowCells returns one row's display strings (columns 1..TotalCols).
     var row1 = inf.RowCells(1);
     Check("inf rowCells width", (row1.Count == inf.TotalCols).ToString(), "True");
-    Check("inf rowCells A1", row1[0], "15");
-    Check("inf rowCells E1", row1[4], "38");  // SUM(A1:D1)
+    Check("inf rowCells A1", row1[0], "15"); // unformatted
+    Check("inf rowCells E1", row1[4], "38.00");  // SUM(A1:D1), "#,##0.00" formatted
     Check("inf rowCells J1 empty", row1[9], ""); // sparse
     bool gapBlank = true;
     foreach (var c in inf.RowCells(200)) if (c.Length != 0) gapBlank = false;
@@ -120,10 +120,10 @@ using (var inf = new InfiniteSheetModel())
     // CommitInf writes through and recomputes every dependent.
     inf.SelectInf(2, 1);          // A2
     inf.CommitInf("108");         // 8 -> 108
-    Check("inf commit A2", inf.RowCells(2)[0], "108");
-    Check("inf commit E2", inf.RowCells(2)[4], "151"); // 108+14+7+22
-    Check("inf commit A5", inf.RowCells(5)[0], "139"); // 15+108+12+4
-    Check("inf commit E5", inf.RowCells(5)[4], "269"); // grand total
+    Check("inf commit A2", inf.RowCells(2)[0], "108"); // unformatted
+    Check("inf commit E2", inf.RowCells(2)[4], "151.00"); // 108+14+7+22, formatted
+    Check("inf commit A5", inf.RowCells(5)[0], "139.00"); // 15+108+12+4, formatted
+    Check("inf commit E5", inf.RowCells(5)[4], "269.00"); // grand total, formatted
 }
 
 Console.WriteLine(failures == 0 ? "\nALL PASS" : $"\n{failures} FAILURE(S)");


### PR DESCRIPTION
## What

Switches the WinUI 3 / .NET demo's windowed reader from `sc_get_window` (typed value JSON, formatted client-side) to **`sc_get_display_window`** over P/Invoke — the engine returns each visible cell already rendered through its format code as a display string, so the virtualized `ListView` rows paint the strings directly and never re-derive number formatting. Fifth backend on the display path (after web #6019, Qt #6023, Flutter #6028, Compose #6031).

## Changes

- **`Engine.cs`** — add `[DllImport]` declarations for `sc_get_display_window` and `sc_set_format` (the latter `[MarshalAs(LPUTF8Str)]` like `sc_set_cell`); new `SpreadsheetSession.SetFormat()`; `Window()` parses the `"cells"` string array. The 5×5 parity-grid path (`Display()` → `sc_get_value`) is unchanged; `DisplayValue()` stays for it.
- **`InfiniteSheetModel.Seed()`** attaches the same format codes as the other demos: cross-foot totals (col E + row 5) → `"#,##0.00"`, far-flung `Z1000` → `"0.0%"`.
- **`test/Program.cs`** — the `InfiniteSheetModel` checks assert the formatted strings (`38.00` / `151.00` / `139.00` / `269.00`); the standalone-session window checks seed no formats, so their `General`-rendered integers are unchanged.
- **README + `InfiniteSheet.xaml`(.cs)** comments updated to `get_display_window`.

## Verification

`scripts/verify.sh` (.NET 9, `dotnet run` the P/Invoke console harness with `CAPI_LIB` set) — **ALL PASS (40 checks)**, against the re-vendored `spreadsheet-capi` 0.5.0 dylib (`native/` is git-ignored).

`/security-review` — **PASSED** (`LPUTF8Str` inputs are auto-marshalled and freed by the CLR; `sc_set_format` is `void` so there's no pointer to free; the window result is freed once via `Take`/`sc_string_free`; coords bounded server-side).

## Next

Last backend: **SwiftUI** — then the engine's `get_display_window` is rendered on every VisiCalc surface (web + 5 native).

🤖 Generated with [Claude Code](https://claude.com/claude-code)