### PR TITLE
feat(visicalc-swiftui): render the infinite grid via sc_get_display_window (formatting visible)

### DIFF
--- a/demo/visicalc-swiftui/README.md
+++ b/demo/visicalc-swiftui/README.md
@@ -73,8 +73,12 @@ variant.)
 A **"Infinite sheet ›"** toggle (top-right) switches the demo to a virtualized,
 effectively-infinite grid (`InfiniteGridView` + `WindowedSheetModel`), rendered
 on the same engine through its **viewport primitive** — the C ABI's
-`sc_get_window` / `sc_used_range` / `sc_changed_since` (the native sibling of the
-web demo's `infinite.html`). The sheet is u32 × u32 and sparse; a two-axis
+`sc_get_display_window` / `sc_used_range` / `sc_changed_since` (the native
+sibling of the web demo's `infinite.html`). `sc_get_display_window` returns each
+cell already rendered through its Excel-style format code (the seed formats the
+cross-foot totals as `#,##0.00` and the far-flung `Z1000` total as a percent),
+so the host paints the display strings directly and never re-derives number
+formatting. The sheet is u32 × u32 and sparse; a two-axis
 `ScrollView` sized from `used_range` drives the scrollbars, and only the visible
 window of cells is built into the view via `SpreadsheetSession.window(...)`.
 

--- a/demo/visicalc-swiftui/Sources/CSpreadsheetEngine/include/spreadsheet.h
+++ b/demo/visicalc-swiftui/Sources/CSpreadsheetEngine/include/spreadsheet.h
@@ -40,12 +40,33 @@ char *sc_get_value(ScSession *s, const char *a1);                 /* -> value JS
 char *sc_get_raw(ScSession *s, const char *a1);                   /* -> typed source */
 char *sc_get_values(ScSession *s);                                /* -> {a1: value} */
 
+/* Cell display formats — an Excel-style code per cell (e.g. "#,##0.00",
+   "yyyy-mm-dd") decides how its value reads. set with an empty code to clear.
+   char* results must be freed with sc_string_free(). */
+void  sc_set_format(ScSession *s, const char *a1, const char *code);
+char *sc_get_format(ScSession *s, const char *a1);                /* -> code | ""   */
+char *sc_get_display(ScSession *s, const char *a1);               /* -> display str */
+
+/* Structural edits — insert/delete rows & columns. 1-based `at`, `count` lines.
+   The engine relocates cells and rewrites formula references (a reference to a
+   deleted line becomes #REF!); the formula echo stays in step. No return — the
+   host re-reads via sc_get_window / sc_get_raw afterwards. */
+void  sc_insert_rows(ScSession *s, uint32_t at, uint32_t count);
+void  sc_delete_rows(ScSession *s, uint32_t at, uint32_t count);
+void  sc_insert_cols(ScSession *s, uint32_t at, uint32_t count);
+void  sc_delete_cols(ScSession *s, uint32_t at, uint32_t count);
+
 /* Viewport primitive — read just the visible window of the unbounded sheet.
    Coordinates are 1-based and inclusive. Each char* result must be freed with
    sc_string_free(). */
 /* -> {"row0":..,"col0":..,"rows":R,"cols":C,"values":[[value,..],..]} | {"error":".."} */
 char *sc_get_window(ScSession *s, uint32_t row0, uint32_t col0,
                     uint32_t row1, uint32_t col1);
+/* Like sc_get_window, but each cell is its display string (value rendered through
+   its format code); empty cells are "". The one read a virtualized grid needs. */
+/* -> {"row0":..,"col0":..,"rows":R,"cols":C,"cells":[["1,234.50",..],..]} | {"error":".."} */
+char *sc_get_display_window(ScSession *s, uint32_t row0, uint32_t col0,
+                            uint32_t row1, uint32_t col1);
 char *sc_used_range(ScSession *s);              /* -> {"minRow":..,..} | null            */
 char *sc_column_letters(ScSession *s, uint32_t index); /* 1-based index -> "A"/"AA"/...   */
 uint64_t sc_current_revision(ScSession *s);     /* per-edit revision clock (0 if s==NULL) */

--- a/demo/visicalc-swiftui/Sources/VisiCalc/Engine.swift
+++ b/demo/visicalc-swiftui/Sources/VisiCalc/Engine.swift
@@ -33,6 +33,11 @@ final class SpreadsheetSession {
     func getValueJSON(_ a1: String) -> String { take(sc_get_value(handle, a1)) }
     func getRaw(_ a1: String) -> String { take(sc_get_raw(handle, a1)) }
 
+    /// Set a cell's display format code (an Excel-style code like `"#,##0.00"` or
+    /// `"0%"`); an empty code clears it. Drives the engine's display path that
+    /// `window` reads through `sc_get_display_window`.
+    func setFormat(_ a1: String, _ code: String) { sc_set_format(handle, a1, code) }
+
     /// The computed value of a cell as the string a spreadsheet should show.
     /// Parses the engine's JSON (`{"kind":...}`) — the same shape the TS and
     /// WASM engines emit.
@@ -72,14 +77,19 @@ final class SpreadsheetSession {
 
     /// Dense display strings for the inclusive 1-based rectangle, row-major
     /// (empty cells become ""). Empty array on a bad/oversized request.
+    ///
+    /// Reads `sc_get_display_window`: each cell arrives already rendered through
+    /// its format code as a display string, so the host paints it directly and
+    /// never re-derives number formatting. The format-aware sibling of
+    /// `sc_get_window`; the JSON is `{...,"cells":[["1,234.50",…],…]}`.
     func window(_ row0: UInt32, _ col0: UInt32, _ row1: UInt32, _ col1: UInt32) -> [[String]] {
-        let json = take(sc_get_window(handle, row0, col0, row1, col1))
+        let json = take(sc_get_display_window(handle, row0, col0, row1, col1))
         guard
             let data = json.data(using: .utf8),
             let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-            let rows = obj["values"] as? [[[String: Any]]]
+            let rows = obj["cells"] as? [[String]]
         else { return [] }
-        return rows.map { row in row.map { Self.displayValue($0) } }
+        return rows
     }
 
     /// The data extent (1-based inclusive), or nil if the sheet is empty.

--- a/demo/visicalc-swiftui/Sources/VisiCalc/InfiniteGrid.swift
+++ b/demo/visicalc-swiftui/Sources/VisiCalc/InfiniteGrid.swift
@@ -1,6 +1,6 @@
 // InfiniteGrid.swift — a virtualized, effectively-infinite, EDITABLE sheet for
 // the SwiftUI demo, rendered on the shared Rust engine through the viewport
-// primitive (the same `get_window` / `used_range` / `changed_since` the web
+// primitive (the same `get_display_window` / `used_range` / `changed_since` the web
 // demo's infinite.html uses through WASM).
 //
 // The sheet is u32 × u32 and sparse. Virtualization is delegated to SwiftUI's
@@ -57,6 +57,19 @@ final class WindowedSheetModel: ObservableObject {
             ("BA50", "far cell"), ("BB50", "=Z1000*2"), // col 53/54, row 50: 78
         ]
         for (a, v) in cells { session.setCell(a, v) }
+
+        // Attach Excel-style format codes so the engine's display path is visible
+        // in the windowed view (which renders via sc_get_display_window): the
+        // cross-foot totals read with thousands grouping + two decimals, and the
+        // far-flung Z1000 total as a percent. Values are unchanged — only how the
+        // display strings render. Identical to the web/Qt/Flutter/Compose/XAML demos.
+        let formats: [(String, String)] = [
+            ("E1", "#,##0.00"), ("E2", "#,##0.00"), ("E3", "#,##0.00"),
+            ("E4", "#,##0.00"), ("E5", "#,##0.00"),
+            ("A5", "#,##0.00"), ("B5", "#,##0.00"), ("C5", "#,##0.00"), ("D5", "#,##0.00"),
+            ("Z1000", "0.0%"), // 39 → "3900.0%": proves the format applies far off-origin
+        ]
+        for (a, code) in formats { session.setFormat(a, code) }
     }
 
     /// Size the virtual grid to the data extent plus a comfortable margin, and
@@ -77,7 +90,8 @@ final class WindowedSheetModel: ObservableObject {
     }
 
     /// The display strings for one full row (all columns) — what a visible row
-    /// renders. One engine `get_window` call per on-screen row.
+    /// renders (display strings, already rendered through each cell.s format code).
+    /// One engine `get_display_window` call per on-screen row.
     func rowCells(_ row: Int) -> [String] {
         let w = session.window(UInt32(row), 1, UInt32(row), totalCols)
         return w.first ?? Array(repeating: "", count: Int(totalCols))

--- a/demo/visicalc-swiftui/Tests/VisiCalcTests/WindowedModelTests.swift
+++ b/demo/visicalc-swiftui/Tests/VisiCalcTests/WindowedModelTests.swift
@@ -21,16 +21,20 @@ final class WindowedModelTests: XCTestCase {
         // A small visible window over A1:E5 — the values are engine-computed.
         let w = m.window(rows: 1...5, cols: 1...5)
         XCTAssertEqual(w.count, 5)
-        XCTAssertEqual(w[0][0], "15")   // A1
-        XCTAssertEqual(w[0][4], "38")   // E1 = SUM(A1:D1)
-        XCTAssertEqual(w[4][4], "169")  // E5 grand total
+        XCTAssertEqual(w[0][0], "15")       // A1 (unformatted)
+        // E1/E5 carry the "#,##0.00" seed format → the engine renders the
+        // formatted display string (window() now reads sc_get_display_window).
+        XCTAssertEqual(w[0][4], "38.00")    // E1 = SUM(A1:D1)
+        XCTAssertEqual(w[4][4], "169.00")   // E5 grand total
     }
 
     func testFarWindowReachesZ1000AndGapsAreSparse() {
         let m = WindowedSheetModel()
         // A window 1000 rows down, around column Z (26): the far formula shows.
         let far = m.window(rows: 998...1002, cols: 24...28)
-        XCTAssertEqual(far[2][2], "39") // Z1000 = SUM(A1:A4), at row 1000 / col 26
+        // Z1000 = SUM(A1:A4) = 39 at row 1000 / col 26, with the "0.0%" seed
+        // format → 39 × 100 = "3900.0%": the format applies 1000 rows off-origin.
+        XCTAssertEqual(far[2][2], "3900.0%")
         // The gap between the two data islands is empty (the sheet is sparse).
         let gap = m.window(rows: 100...110, cols: 1...10)
         for row in gap { for cell in row { XCTAssertEqual(cell, "") } }
@@ -50,7 +54,8 @@ final class WindowedModelTests: XCTestCase {
         XCTAssertFalse(stale)
         XCTAssertTrue(changed.contains("A1"))
         XCTAssertTrue(changed.contains("Z1000"), "far dependent recomputed: \(changed)")
-        // And the recomputed value is visible through a fresh window read.
-        XCTAssertEqual(m.window(rows: 1000...1000, cols: 26...26)[0][0], "139") // 115+8+12+4
+        // And the recomputed value is visible through a fresh window read:
+        // 115+8+12+4 = 139, formatted as a percent ("0.0%") → "13900.0%".
+        XCTAssertEqual(m.window(rows: 1000...1000, cols: 26...26)[0][0], "13900.0%")
     }
 }


### PR DESCRIPTION
## What

Switches the SwiftUI demo's windowed reader from `sc_get_window` (typed value JSON, formatted client-side) to **`sc_get_display_window`** over Swift C interop — the engine returns each visible cell already rendered through its format code as a display string, so the `LazyVStack` rows paint the strings directly and never re-derive number formatting.

**The sixth and final backend on the display path** (after web #6019, Qt #6023, Flutter #6028, Compose #6031, XAML #6034).

## Changes

- **`Engine.swift`** — new `SpreadsheetSession.setFormat()`; `window()` reads `sc_get_display_window` and decodes the `"cells"` string array. The 5×5 parity-grid path (`display()` → `sc_get_value`) is unchanged; `displayValue()` stays for it.
- **`InfiniteGrid.swift`** `WindowedSheetModel.seed()` attaches the same format codes as every other demo: cross-foot totals (col E + row 5) → `"#,##0.00"`, far-flung `Z1000` → `"0.0%"`.
- **`WindowedModelTests.swift`** asserts the formatted strings (`38.00` / `169.00` / `3900.0%` / `13900.0%`).
- **Re-vendored** `Sources/CSpreadsheetEngine/include/spreadsheet.h` from the merged `spreadsheet-capi` 0.5.0 (the committed C-interop header; now declares `sc_get_display_window` + the format/structural-edit ABI). README + comments updated.

## Verification

`swift test` — **8/8 PASS**, against the re-vendored `spreadsheet-capi` 0.5.0 static lib (`Vendor/` is git-ignored).

`/security-review` — **PASSED** (`take`/`sc_string_free` single-free; `sc_set_format` is `void` so there's no pointer to free; the `String`→`char*` bridge is bounded to the call; coords bounded server-side by the `MAX_WINDOW_CELLS` cap).

## Rollout complete 🎉

With this, the engine's `get_display_window` renders on **every VisiCalc surface**: web (WASM) + 5 native runtimes (Qt / C ABI, Flutter / dart:ffi, Compose / Java FFM, XAML / .NET P/Invoke, SwiftUI / C interop). Cell formatting computed once in the shared Rust engine, painted identically everywhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)