### PR TITLE
Accept .control quit markers

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ### Added
 
+- **Deck control quit marker routing** —
+  `analyze_deck_controls()` and `resolve_deck_sources()` now accept selected
+  `.control` block `quit` interpreter-exit markers as no-op control commands
+  instead of reporting unsupported-command diagnostics, matching Rust and
+  TypeScript.
+
 - **Deck control run marker routing** —
   `analyze_deck_controls()` and `resolve_deck_sources()` now accept selected
   `.control` block `run` execution markers as no-op control commands instead

--- a/code/packages/python/spice-engine/README.md
+++ b/code/packages/python/spice-engine/README.md
@@ -161,9 +161,9 @@ it returns active lines before `.end` and stable diagnostics for unsupported
 `.include`, `.lib`, and `.control` directives. Inside `.control` blocks,
 selected analysis/output commands (`op`, `dc`, `ac`, `tran`, `save`, `probe`,
 `measure`, `meas`, `four`, `fourier`, `print`, and `plot`) are normalized into
-dotted deck cards, and `run` is accepted as a no-op execution marker. Other
-unrecognized non-comment commands emit diagnostics until a broader executed
-control subset is in scope.
+dotted deck cards, while `run` and `quit` are accepted as no-op execution and
+interpreter-exit markers. Other unrecognized non-comment commands emit
+diagnostics until a broader executed control subset is in scope.
 `resolve_deck_sources()` is the first include/library resolution layer: callers
 provide a source-content map, `.include` directives are expanded in place, and
 `.lib path section` selects a named `.lib` / `.endl` section with stable

--- a/code/packages/python/spice-engine/src/spice_engine/compatibility.py
+++ b/code/packages/python/spice-engine/src/spice_engine/compatibility.py
@@ -515,7 +515,7 @@ _SUPPORTED_CONTROL_BLOCK_COMMANDS = frozenset(
         ".plot",
     }
 )
-_NOOP_CONTROL_BLOCK_COMMANDS = frozenset({"run", ".run"})
+_NOOP_CONTROL_BLOCK_COMMANDS = frozenset({"run", ".run", "quit", ".quit"})
 _SPICE_SUFFIX_FACTORS = {
     "t": 1.0e12,
     "g": 1.0e9,

--- a/code/packages/python/spice-engine/tests/test_compatibility.py
+++ b/code/packages/python/spice-engine/tests/test_compatibility.py
@@ -120,6 +120,7 @@ meas dc imax MAX I(V1)
 fourier 1k V(out)
 four 2k V(in)
 run
+quit
 .endc
 .end
 """
@@ -225,6 +226,7 @@ meas dc imax MAX I(V1)
 fourier 1k V(a)
 four 2k V(b)
 run
+.quit
 .endc
 .end
 """,

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Accept selected `.control` block `quit` interpreter-exit markers as no-op
+  control commands in `analyze_deck_controls` and `resolve_deck_sources`,
+  matching Python and TypeScript.
 - Accept selected `.control` block `run` execution markers as no-op control
   commands in `analyze_deck_controls` and `resolve_deck_sources`, matching
   Python and TypeScript.

--- a/code/packages/rust/spice-engine/README.md
+++ b/code/packages/rust/spice-engine/README.md
@@ -128,9 +128,9 @@ returns active lines before `.end` and stable diagnostics for unsupported
 `.include`, `.lib`, and `.control` directives. Inside `.control` blocks,
 selected analysis/output commands (`op`, `dc`, `ac`, `tran`, `save`, `probe`,
 `measure`, `meas`, `four`, `fourier`, `print`, and `plot`) are normalized into
-dotted deck cards, and `run` is accepted as a no-op execution marker. Other
-unrecognized non-comment commands emit diagnostics until a broader executed
-control subset is in scope.
+dotted deck cards, while `run` and `quit` are accepted as no-op execution and
+interpreter-exit markers. Other unrecognized non-comment commands emit
+diagnostics until a broader executed control subset is in scope.
 `resolve_deck_sources` is the first include/library resolution layer: callers
 provide a source-content map, `.include` directives are expanded in place, and
 `.lib path section` selects a named `.lib` / `.endl` section with stable

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -6907,7 +6907,7 @@ fn is_noop_control_block_command(line: &str) -> bool {
         line.split_whitespace()
             .next()
             .map(|command| command.to_ascii_lowercase()),
-        Some(command) if command == "run" || command == ".run"
+        Some(command) if command == "run" || command == ".run" || command == "quit" || command == ".quit"
     )
 }
 

--- a/code/packages/rust/spice-engine/tests/compatibility_tests.rs
+++ b/code/packages/rust/spice-engine/tests/compatibility_tests.rs
@@ -137,6 +137,7 @@ meas dc imax MAX I(V1)
 fourier 1k V(out)
 four 2k V(in)
 run
+quit
 .endc
 .end
 ",
@@ -317,6 +318,7 @@ meas dc imax MAX I(V1)
 fourier 1k V(a)
 four 2k V(b)
 run
+.quit
 .endc
 .end
 ",

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Accept selected `.control` block `quit` interpreter-exit markers as no-op
+  control commands in `analyzeDeckControls` and `resolveDeckSources`, matching
+  Python and Rust.
 - Accept selected `.control` block `run` execution markers as no-op control
   commands in `analyzeDeckControls` and `resolveDeckSources`, matching Python
   and Rust.

--- a/code/packages/typescript/spice-engine/README.md
+++ b/code/packages/typescript/spice-engine/README.md
@@ -135,9 +135,9 @@ returns active lines before `.end` and stable diagnostics for unsupported
 `.include`, `.lib`, and `.control` directives. Inside `.control` blocks,
 selected analysis/output commands (`op`, `dc`, `ac`, `tran`, `save`, `probe`,
 `measure`, `meas`, `four`, `fourier`, `print`, and `plot`) are normalized into
-dotted deck cards, and `run` is accepted as a no-op execution marker. Other
-unrecognized non-comment commands emit diagnostics until a broader executed
-control subset is in scope.
+dotted deck cards, while `run` and `quit` are accepted as no-op execution and
+interpreter-exit markers. Other unrecognized non-comment commands emit
+diagnostics until a broader executed control subset is in scope.
 `resolveDeckSources` is the first include/library resolution layer: callers
 provide a source-content map, `.include` directives are expanded in place, and
 `.lib path section` selects a named `.lib` / `.endl` section with stable

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -2854,7 +2854,7 @@ const SUPPORTED_CONTROL_BLOCK_COMMANDS = new Set([
   "plot",
   ".plot",
 ]);
-const NOOP_CONTROL_BLOCK_COMMANDS = new Set(["run", ".run"]);
+const NOOP_CONTROL_BLOCK_COMMANDS = new Set(["run", ".run", "quit", ".quit"]);
 
 export function compatibilityCorpus(): readonly CompatibilityDeck[] {
   return COMPATIBILITY_CORPUS;

--- a/code/packages/typescript/spice-engine/tests/compatibility.test.ts
+++ b/code/packages/typescript/spice-engine/tests/compatibility.test.ts
@@ -124,6 +124,7 @@ meas dc imax MAX I(V1)
 fourier 1k V(out)
 four 2k V(in)
 run
+quit
 .endc
 .end
 `);
@@ -232,6 +233,7 @@ meas dc imax MAX I(V1)
 fourier 1k V(a)
 four 2k V(b)
 run
+.quit
 .endc
 .end
 `, {

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -36,9 +36,10 @@ downstream tools to compare.
      stable non-executed diagnostics, and selected `.control` block
      analysis/output commands (`op`, `dc`, `ac`, `tran`, `save`, `probe`,
      `measure`, `meas`, `four`, `fourier`, `print`, and `plot`) now normalize
-     into dotted deck cards while `run` is accepted as a no-op execution
-     marker; parsed `.measure dc` / `.meas dc` cards now route DC sweep probe
-     samples into the shared scalar measurement table surface;
+     into dotted deck cards while `run` and `quit` are accepted as no-op
+     execution / interpreter-exit markers; parsed `.measure dc` / `.meas dc`
+     cards now route DC sweep probe samples into the shared scalar measurement
+     table surface;
      parsed `.measure ac` / `.meas ac` cards now route AC probe magnitudes over
      optional frequency windows into the same measurement table surface; parsed
      transient `.measure ... FIND ... AT=` cards now route single-time probe
@@ -544,6 +545,14 @@ downstream tools to compare.
     - Python, Rust, and TypeScript now accept selected `.control` block `run`
       execution markers as no-op control commands after selected analysis and
       output commands have normalized into deck cards.
+    - Other unrecognized non-comment commands inside `.control` blocks remain
+      diagnostic-only so unsupported control flow is still explicit.
+
+49. Selected `.control` quit marker routing.
+    - Status: completed in this selected control quit-marker routing slice.
+    - Python, Rust, and TypeScript now accept selected `.control` block `quit`
+      interpreter-exit markers as no-op control commands after selected
+      analysis and output commands have normalized into deck cards.
     - Other unrecognized non-comment commands inside `.control` blocks remain
       diagnostic-only so unsupported control flow is still explicit.
 


### PR DESCRIPTION
## Summary
- accept selected `.control` block `quit` / `.quit` interpreter-exit markers as no-op control commands
- preserve diagnostics for other unsupported `.control` commands
- update Python, Rust, and TypeScript docs/tests plus the SPICE implementation plan

## Verification
- `PYTHONPATH="$(find code/packages/python -maxdepth 2 -type d -name src | paste -sd: -)" /Users/adhithya/.local/share/mise/installs/python/3.12.13/bin/python3 -m ruff check code/packages/python/spice-engine/src/spice_engine/compatibility.py code/packages/python/spice-engine/tests/test_compatibility.py`
- `PYTHONPATH="$(find code/packages/python -maxdepth 2 -type d -name src | paste -sd: -)" /Users/adhithya/.local/share/mise/installs/python/3.12.13/bin/python3 -m pytest code/packages/python/spice-engine/tests -q`
- `cargo fmt --manifest-path code/packages/rust/spice-engine/Cargo.toml -- --check`
- `cargo test --manifest-path code/packages/rust/spice-engine/Cargo.toml`
- `npm --prefix code/packages/typescript/spice-engine ci`
- `npm --prefix code/packages/typescript/spice-engine run build`
- `npm --prefix code/packages/typescript/spice-engine test`
- `git diff --check`