### PR TITLE
feat(logic-engine): ADJ73 precedence — named-enum priority (PR-A) + grounded-recursive design (spec v2)

### DIFF
--- a/code/packages/rust/adjudication-connector/src/lib.rs
+++ b/code/packages/rust/adjudication-connector/src/lib.rs
@@ -546,7 +546,7 @@ fn lower_rule_tracked(
                 body,
                 probability: Probability::Value(p),
                 provenance: logic_engine::Provenance::unattributed(),
-                priority: 0,
+                priority: logic_engine::Priority::Default,
             })));
         }
         "constraint" => {
@@ -738,7 +738,7 @@ fn lower_rule(
                 body,
                 probability: Probability::Value(p),
                 provenance: logic_engine::Provenance::unattributed(),
-                priority: 0,
+                priority: logic_engine::Priority::Default,
             });
         }
         "constraint" => {

--- a/code/packages/rust/logic-engine/CHANGELOG.md
+++ b/code/packages/rust/logic-engine/CHANGELOG.md
@@ -2,6 +2,33 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.18.0] - 2026-06-16 — precedence priority is a named ENUM, not an integer (ADJ73 PR-A)
+
+### Changed (breaking — nothing released; per user decision 1)
+
+- **`Rule::priority` is now `Priority`** (a named enum) instead of `i64`. Tiers, totally
+  ordered lowest→highest: `Default < Specific < Authoritative < Mandatory`. `Default` is the
+  implicit tier (existing rules unchanged). `Rule::with_priority` now takes a `Priority`.
+- **`GovernedAnswer::priority` is now `Standing`** (new enum): `Standing::Rule(Priority)` or
+  `Standing::Asserted` (a ground fact — outranks every rule tier, replacing the old `i64::MAX`
+  sentinel). `Standing` derives `Ord` (Asserted greatest), so the resolver compares tiers
+  without magic numbers.
+- The two `adjudication-connector` `Rule{}` literal sites set `priority: Priority::Default`.
+
+### Rationale
+
+Raw integers were magic-numbery; named tiers read correctly in grounded rulebooks and are the
+simplest *grounded precedence principle* ("a higher tier wins"). Richer, byte-provenanced
+precedence (a grounded `context-precedence` rulebook with lex-superior / recency / appeal-status
+meta-rules) is ADJ73 PR-B; the recursive grounded design is now spec'd in
+`code/specs/ADJ73-defeasible-rule-precedence.md` §2.3 + §7.
+
+### Unchanged
+
+- Resolution semantics, opt-in-per-predicate `declare_functional`, and back-compat of
+  `enumerate_all` are exactly as in 0.17.0. All 101 + 5 (govern) + 4 (precedence integration)
+  tests pass.
+
 ## [0.17.0] - 2026-06-16 — defeasible rule precedence (ADJ73 PR-1)
 
 ### Added

--- a/code/packages/rust/logic-engine/Cargo.toml
+++ b/code/packages/rust/logic-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "logic-engine"
-version = "0.17.0"
+version = "0.18.0"
 edition = "2021"
 description = "Probability-aware facts, rules, KB, SLD find-first/enumerate + WMC posterior + LP19e likelihood-ratio Bayesian aggregation."
 

--- a/code/packages/rust/logic-engine/README.md
+++ b/code/packages/rust/logic-engine/README.md
@@ -64,31 +64,35 @@ let answer = find_first(&query, &kb).expect("there is at least one answer");
 assert_eq!(answer.walk_var(&x), atom("bart"));  // first matching clause
 ```
 
-### Defeasible precedence (v0.17, ADJ73)
+### Defeasible precedence (v0.18, ADJ73)
 
 Most real rulebooks are **defaults with exceptions**: two rules derive conclusions that
 cannot both hold, and a priority decides which one *governs*. Declare the predicate
-**functional** (at most one value per key) and give the rules a `priority`; then
+**functional** (at most one value per key) and give the rules a `Priority` **tier**; then
 `enumerate_governing` resolves the conflict as a post-pass over `enumerate_all`:
 
 ```rust
-use logic_engine::{enumerate_governing, GovernStatus, KnowledgeBase, Rule};
+use logic_engine::{enumerate_governing, GovernStatus, KnowledgeBase, Priority, Rule};
 
 let mut kb = KnowledgeBase::new();
 kb.declare_functional("timing", 1);                       // one timing decision may hold
 kb.add_fact(/* stable_routine_pending */);
-kb.add_rule(Rule::certain(/* timing(await) when stable_routine_pending */).with_priority(10));
-kb.add_rule(Rule::certain(/* timing(treat_now) — default */));            // priority 0
+kb.add_rule(Rule::certain(/* timing(await) when stable_routine_pending */)
+    .with_priority(Priority::Specific));                  // beats the default
+kb.add_rule(Rule::certain(/* timing(treat_now) — default */));            // Priority::Default
 
 let res = enumerate_governing(&/* timing($D) */, &kb);
 // timing(await) governs; timing(treat_now) is Defeated { by: timing(await) }.
-// A tie at the top priority yields ConflictPeer (never silently resolved) — abstain/ask.
+// A tie at the top tier yields ConflictPeer (never silently resolved) — abstain/ask.
 ```
 
-A predicate that is **not** declared functional never conflicts, so every answer governs and
-`enumerate_all` semantics are unchanged — precedence is opt-in per predicate. The general
-partial-order form (`context_order`, for jurisdiction/specialist precedence) and the adj-lang
-surface syntax are staged in `code/specs/ADJ73-defeasible-rule-precedence.md`.
+Priority is a **named enum tier** (`Default < Specific < Authoritative < Mandatory`), not a raw
+integer; a ground fact (`Standing::Asserted`) outranks every rule tier. A predicate that is
+**not** declared functional never conflicts, so every answer governs and `enumerate_all`
+semantics are unchanged — precedence is opt-in per predicate. The richer, byte-provenanced
+mechanism — a grounded `context-precedence` rulebook (lex-superior / recency / appeal-status,
+for jurisdiction/specialist precedence) — and the adj-lang surface syntax are staged in
+`code/specs/ADJ73-defeasible-rule-precedence.md` (§2.3, §7).
 
 ## Why Probability From Day One
 

--- a/code/packages/rust/logic-engine/src/govern.rs
+++ b/code/packages/rust/logic-engine/src/govern.rs
@@ -16,12 +16,13 @@
 //!    hypothetical `means(term, reading, ctx)` declared functional, two answers conflict only
 //!    when they share `(term, ctx)` but differ on `reading`. A predicate that is NOT declared
 //!    functional never conflicts → every answer governs (back-compat).
-//! 2. **Priority** — which competitor wins? Each answer's priority is the **maximum**
-//!    [`Rule::priority`](crate::Rule) over the proofs that derive it (a fact-derived answer is
-//!    [`i64::MAX`] — an asserted truth is never defeated by a rule). Among a conflict group,
-//!    the unique maximum **governs**; the rest are **defeated**. A tie at the maximum is a
-//!    genuine **conflict** — both are surfaced as [`GovernStatus::ConflictPeer`], never
-//!    silently resolved (mirrors the engine's `INDETERMINATE/CONFLICT` stance).
+//! 2. **Priority** — which competitor wins? Each answer's [`Standing`] is the **maximum** over
+//!    the proofs that derive it: the rule [`Priority`] tier, or [`Standing::Asserted`] for a
+//!    fact-derived answer (asserted truth outranks any rule tier). Among a conflict group, the
+//!    unique maximum **governs**; the rest are **defeated**. A tie at the maximum is a genuine
+//!    **conflict** — both are surfaced as [`GovernStatus::ConflictPeer`], never silently
+//!    resolved (mirrors the engine's `INDETERMINATE/CONFLICT` stance). Named tiers, not raw
+//!    integers (ADJ73 decision 1); richer grounded precedence is PR-B.
 //!
 //! Defeated/peer answers are *kept and tagged*, not discarded — the audit trail shows exactly
 //! what was overridden and by what (`feedback_nothing_human_authored` / provenance-first).
@@ -30,7 +31,20 @@ use logic_core::{Substitution, Term};
 
 use crate::enumerate::enumerate_all;
 use crate::proof_dag::{DerivationOrigin, ProofDAG};
-use crate::KnowledgeBase;
+use crate::{KnowledgeBase, Priority};
+
+/// The precedence STANDING of a derived answer (ADJ73 decision 1: named tiers, not integers).
+/// Either the priority tier of the rule that derived it, or [`Standing::Asserted`] when it
+/// rests on a ground fact — an asserted truth that outranks every rule tier. Totally ordered
+/// by `derive(Ord)`: `Rule` is declared first so `Asserted` is the greatest, and `Rule(p)`
+/// compares by its [`Priority`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum Standing {
+    /// Derived by a rule carrying this priority tier.
+    Rule(Priority),
+    /// Derived from a ground fact — outranks every rule tier (asserted truth).
+    Asserted,
+}
 
 /// The governance verdict for one distinct answer term.
 #[derive(Debug, Clone, PartialEq)]
@@ -50,9 +64,9 @@ pub enum GovernStatus {
 pub struct GovernedAnswer {
     /// The ground answer term (the query with this proof's bindings applied).
     pub term: Term,
-    /// Max [`Rule::priority`](crate::Rule) over the proofs deriving this answer
-    /// (`i64::MAX` if any derivation is a bare fact).
-    pub priority: i64,
+    /// The highest [`Standing`] over the proofs deriving this answer ([`Standing::Asserted`]
+    /// if any derivation rests on a ground fact, else the max rule [`Priority`] tier).
+    pub priority: Standing,
     /// Indices into [`GovernedResult::dag`]`.proofs` that derive this answer.
     pub proof_indices: Vec<usize>,
     /// Whether this answer governs, was defeated, or is an unresolved conflict peer.
@@ -113,16 +127,19 @@ fn conflict_key(term: &Term, kb: &KnowledgeBase) -> Option<(String, Vec<Term>)> 
     }
 }
 
-/// The priority a single proof confers on its answer: the priority of the rule that derived the
-/// query head (the proof's first step). A fact-derived head is `i64::MAX` — an asserted truth
-/// outranks any rule. An empty/odd proof falls back to `0` (the default rule priority).
-fn proof_priority(dag: &ProofDAG, proof_index: usize, kb: &KnowledgeBase) -> i64 {
+/// The [`Standing`] a single proof confers on its answer: the priority tier of the rule that
+/// derived the query head (the proof's first step), or [`Standing::Asserted`] when the head is
+/// a ground fact (asserted truth outranks any rule). An empty/odd proof falls back to the
+/// `Default` tier.
+fn proof_priority(dag: &ProofDAG, proof_index: usize, kb: &KnowledgeBase) -> Standing {
     match dag.proofs[proof_index].steps.first().map(|s| &s.origin) {
-        Some(DerivationOrigin::FromRule(id)) => {
-            kb.find_rule_by_id(*id).map(|r| r.priority).unwrap_or(0)
-        }
-        Some(DerivationOrigin::FromFact(_)) => i64::MAX,
-        _ => 0,
+        Some(DerivationOrigin::FromRule(id)) => Standing::Rule(
+            kb.find_rule_by_id(*id)
+                .map(|r| r.priority)
+                .unwrap_or(Priority::Default),
+        ),
+        Some(DerivationOrigin::FromFact(_)) => Standing::Asserted,
+        _ => Standing::Rule(Priority::Default),
     }
 }
 
@@ -198,7 +215,7 @@ pub fn enumerate_governing(query: &Term, kb: &KnowledgeBase) -> GovernedResult {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{BodyLiteral, Fact, KnowledgeBase, Rule};
+    use crate::{BodyLiteral, Fact, KnowledgeBase, Priority, Rule};
     use logic_core::Term;
 
     fn atom(s: &str) -> Term {
@@ -227,7 +244,7 @@ mod tests {
                 comp("timing", vec![atom("await")]),
                 vec![BodyLiteral::Pos(atom("stable_routine_pending"))],
             )
-            .with_priority(10),
+            .with_priority(Priority::Specific),
         );
         // default: timing(treat_now) unconditionally — priority 0
         kb.add_rule(Rule::certain(
@@ -258,9 +275,13 @@ mod tests {
     fn equal_priority_conflict_yields_peers_not_a_silent_pick() {
         let mut kb = KnowledgeBase::new();
         kb.declare_functional("timing", 1);
-        kb.add_rule(Rule::certain(comp("timing", vec![atom("await")]), vec![]).with_priority(5));
         kb.add_rule(
-            Rule::certain(comp("timing", vec![atom("treat_now")]), vec![]).with_priority(5),
+            Rule::certain(comp("timing", vec![atom("await")]), vec![])
+                .with_priority(Priority::Specific),
+        );
+        kb.add_rule(
+            Rule::certain(comp("timing", vec![atom("treat_now")]), vec![])
+                .with_priority(Priority::Specific),
         );
 
         let res = enumerate_governing(&comp("timing", vec![var("D")]), &kb);
@@ -279,10 +300,11 @@ mod tests {
         // contraindicated/2 is NOT declared functional — many may hold.
         kb.add_rule(
             Rule::certain(comp("contra", vec![atom("moxi"), atom("preg")]), vec![])
-                .with_priority(1),
+                .with_priority(Priority::Specific),
         );
         kb.add_rule(
-            Rule::certain(comp("contra", vec![atom("tmp"), atom("preg")]), vec![]).with_priority(9),
+            Rule::certain(comp("contra", vec![atom("tmp"), atom("preg")]), vec![])
+                .with_priority(Priority::Authoritative),
         );
 
         let res = enumerate_governing(&comp("contra", vec![var("D"), var("C")]), &kb);
@@ -297,7 +319,8 @@ mod tests {
         kb.declare_functional("timing", 1);
         kb.add_fact(Fact::certain(comp("timing", vec![atom("targeted")])));
         kb.add_rule(
-            Rule::certain(comp("timing", vec![atom("treat_now")]), vec![]).with_priority(50),
+            Rule::certain(comp("timing", vec![atom("treat_now")]), vec![])
+                .with_priority(Priority::Authoritative),
         );
 
         let res = enumerate_governing(&comp("timing", vec![var("D")]), &kb);
@@ -313,16 +336,16 @@ mod tests {
         kb.declare_functional("means", 2); // means(term, reading) functional on reading per term
         kb.add_rule(
             Rule::certain(comp("means", vec![atom("waters"), atom("broad")]), vec![])
-                .with_priority(2),
+                .with_priority(Priority::Authoritative),
         );
         kb.add_rule(
             Rule::certain(comp("means", vec![atom("waters"), atom("narrow")]), vec![])
-                .with_priority(1),
+                .with_priority(Priority::Specific),
         );
         // a different key (term=person) — independent, should govern on its own.
         kb.add_rule(
             Rule::certain(comp("means", vec![atom("person"), atom("natural")]), vec![])
-                .with_priority(1),
+                .with_priority(Priority::Specific),
         );
 
         let res = enumerate_governing(&comp("means", vec![var("T"), var("R")]), &kb);

--- a/code/packages/rust/logic-engine/src/lib.rs
+++ b/code/packages/rust/logic-engine/src/lib.rs
@@ -234,14 +234,41 @@ pub struct Rule {
     /// no citation. Mirrors [`Fact::provenance`], so a derived consequence can (in
     /// future) cite the rule that produced it alongside the facts it fired on.
     pub provenance: Provenance,
-    /// ADJ73 defeasible precedence: the rule's priority among *conflicting*
-    /// derivations. Higher defeats lower when two rules derive heads that cannot
-    /// both hold (a predicate declared functional via
-    /// [`KnowledgeBase::declare_functional`]). Defaults to `0`; a plain rulebook
-    /// with no priorities and no functional predicates behaves exactly as before
-    /// (every conclusion governs). Only [`crate::govern::enumerate_governing`] reads
-    /// this field — `enumerate_all` ignores it, so monotonic queries are unchanged.
-    pub priority: i64,
+    /// ADJ73 defeasible precedence: the rule's priority TIER among *conflicting*
+    /// derivations. A higher tier defeats a lower one when two rules derive heads that
+    /// cannot both hold (a predicate declared functional via
+    /// [`KnowledgeBase::declare_functional`]). Defaults to [`Priority::Default`]; a plain
+    /// rulebook with no priorities and no functional predicates behaves exactly as before
+    /// (every conclusion governs). Only [`crate::govern::enumerate_governing`] reads this
+    /// field — `enumerate_all` ignores it, so monotonic queries are unchanged.
+    ///
+    /// Named TIERS, not raw integers (ADJ73 decision 1): the explicit tier is the simplest
+    /// grounded precedence principle ("a higher tier wins"), used for local default-vs-
+    /// exception ladders. Richer, byte-provenanced precedence (lex-superior / recency /
+    /// appeal-status over a grounded `context-precedence` rulebook) is ADJ73 PR-B.
+    pub priority: Priority,
+}
+
+/// ADJ73 defeasible-precedence TIER (decision 1: named enum, not raw integers). Totally
+/// ordered lowest→highest by declaration order, so `derive(Ord)` gives `Default < Specific
+/// < Authoritative < Mandatory`. A ground **fact** sits above every tier (asserted truth);
+/// that "above all" standing is represented by [`crate::govern::Standing`], not here.
+///
+/// - `Default` — the implicit fallback rule (what a rule has when no tier is written).
+/// - `Specific` — a more specific rule than the general default.
+/// - `Authoritative` — a rule from a governing/authoritative source.
+/// - `Mandatory` — a hard override (the highest rule tier).
+///
+/// These are domain-neutral: a clinical "specialist guideline over general" and a legal
+/// "controlling authority over persuasive" both map onto the same ladder. The names are
+/// open to revision (ADJ73 §2.2).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Default)]
+pub enum Priority {
+    #[default]
+    Default,
+    Specific,
+    Authoritative,
+    Mandatory,
 }
 
 impl Rule {
@@ -252,7 +279,7 @@ impl Rule {
             body,
             probability: Probability::Certain,
             provenance: Provenance::unattributed(),
-            priority: 0,
+            priority: Priority::Default,
         }
     }
 
@@ -266,7 +293,7 @@ impl Rule {
             body,
             probability: Probability::Value(p),
             provenance: Provenance::unattributed(),
-            priority: 0,
+            priority: Priority::Default,
         }
     }
 
@@ -279,7 +306,7 @@ impl Rule {
 
     /// ADJ73: set the rule's defeasible-precedence priority (higher defeats lower
     /// among conflicting derivations). Builder-style, mirrors [`Self::with_provenance`].
-    pub fn with_priority(mut self, priority: i64) -> Self {
+    pub fn with_priority(mut self, priority: Priority) -> Self {
         self.priority = priority;
         self
     }

--- a/code/packages/rust/logic-engine/tests/test_governing_precedence.rs
+++ b/code/packages/rust/logic-engine/tests/test_governing_precedence.rs
@@ -8,7 +8,9 @@
 //! legal "higher court overrides lower" precedence, resolved by the identical machinery.
 
 use logic_core::{LogicVar, Term};
-use logic_engine::{enumerate_governing, BodyLiteral, Fact, GovernStatus, KnowledgeBase, Rule};
+use logic_engine::{
+    enumerate_governing, BodyLiteral, Fact, GovernStatus, KnowledgeBase, Priority, Rule,
+};
 
 fn atom(s: &str) -> Term {
     Term::Atom(s.to_string())
@@ -47,7 +49,7 @@ fn medical_timing_ladder_picks_the_exception_over_the_default() {
                 BodyLiteral::Pos(atom("culture_pending")),
             ],
         )
-        .with_priority(10),
+        .with_priority(Priority::Specific),
     );
     // conservative default: treat now (priority 0).
     kb.add_rule(Rule::certain(
@@ -88,7 +90,7 @@ fn medical_timing_falls_back_to_the_default_when_the_exception_does_not_fire() {
                 BodyLiteral::Pos(atom("culture_pending")),
             ],
         )
-        .with_priority(10),
+        .with_priority(Priority::Specific),
     );
     kb.add_rule(Rule::certain(
         comp("timing", vec![atom("treat_now_empiric")]),
@@ -118,7 +120,7 @@ fn legal_higher_court_reading_governs_the_lower_court() {
             comp("means", vec![atom("navigable_waters"), atom("broad")]),
             vec![],
         )
-        .with_priority(20),
+        .with_priority(Priority::Authoritative),
     );
     // a district court reads it narrowly (lower court → priority 10).
     kb.add_rule(
@@ -126,7 +128,7 @@ fn legal_higher_court_reading_governs_the_lower_court() {
             comp("means", vec![atom("navigable_waters"), atom("narrow")]),
             vec![],
         )
-        .with_priority(10),
+        .with_priority(Priority::Specific),
     );
 
     let res = enumerate_governing(
@@ -165,11 +167,11 @@ fn co_equal_authorities_yield_an_unresolved_conflict() {
     kb.declare_functional("means", 2);
     kb.add_rule(
         Rule::certain(comp("means", vec![atom("term"), atom("reading_a")]), vec![])
-            .with_priority(15),
+            .with_priority(Priority::Authoritative),
     );
     kb.add_rule(
         Rule::certain(comp("means", vec![atom("term"), atom("reading_b")]), vec![])
-            .with_priority(15),
+            .with_priority(Priority::Authoritative),
     );
 
     let res = enumerate_governing(&comp("means", vec![atom("term"), var("R")]), &kb);

--- a/code/specs/ADJ73-defeasible-rule-precedence.md
+++ b/code/specs/ADJ73-defeasible-rule-precedence.md
@@ -82,33 +82,92 @@ backwards-compatibility guarantee: precedence is opt-in per predicate.**
 
 ### 2.2 Priority — which competitor wins?
 
-Attach an ordering to rules. Two layers, used together:
+> **Design decisions (2026-06-16, user).** (1) Explicit priority uses **named enum tiers**, not
+> raw integers. (2) Context precedence is **itself grounded** — its own rulebook, each edge
+> byte-provenanced (§2.3). (3) The principle that *resolves a precedence conflict* (lex-specialis
+> vs lex-superior vs recency vs appeal-status) is **also a grounded rule** — precedence is
+> recursive, and every layer carries byte-provenance. (4) Cycles are rejected at load.
 
-- **Explicit rule priority** — a non-negative integer (or named tier) on a rule; higher
-  defeats lower among *conflicting* heads:
+Attach an ordering to rules. Three layers, weakest-to-strongest in generality:
+
+- **Explicit rule priority — a NAMED ENUM tier** (not a magic integer) on a rule; a higher tier
+  defeats a lower one among *conflicting* heads. The tiers are domain-neutral and totally
+  ordered:
   ```
-  rule { head: timing(targeted)        when: culture_status(resulted)            priority: 30 }
-  rule { head: timing(treat_now)       when: disease_acuity(time_critical)       priority: 20 }
-  rule { head: timing(await_culture)   when: stable, routine, culture_pending     priority: 10 }
-  rule { head: timing(treat_now)       when: true                                priority: 0  }  % default
+  rule { head: timing(targeted)        when: culture_status(resulted)         priority: mandatory  }
+  rule { head: timing(treat_now)       when: disease_acuity(time_critical)    priority: authoritative }
+  rule { head: timing(await_culture)   when: stable, routine, culture_pending priority: specific }
+  rule { head: timing(treat_now)       when: any_case                         priority: default }  % fallback
   ```
+  Proposed tier ladder (lowest→highest), open to your edit:
+  `default < specific < authoritative < mandatory`. `default` is the implicit tier when none is
+  written (so existing rules are unchanged). A bare ground **fact** sits above all tiers
+  (asserted truth). Integers are *not* exposed in the surface; internally the enum has a total
+  order so the resolver can compare.
 - **Context specificity (the generic precedence)** — when rules fire under different
-  *contexts* (the `active_context` convention from the contraindication rulebook), a partial
-  order over contexts induces rule priority *without* hand-numbering. Declared once:
-  ```
-  context_order { federal > state }            % law
-  context_order { specialist > general }       % medicine
-  context_order { idsa_2024 > idsa_2004 }      % newer guideline > older
-  ```
-  A conclusion grounded in a context that is **greater** in the order defeats a conflicting
-  conclusion grounded in a lesser context. Numeric `priority` is the degenerate
-  total-order case; `context_order` is the general partial order and is what the legal vision
-  needs. The two combine: explicit `priority` breaks ties the context order leaves unordered.
+  *contexts* (the `active_context` convention from the contraindication rulebook), an order
+  over contexts induces rule priority *without* hand-numbering. But — **decision (2)** — that
+  order is **not config**. It is a grounded relation in its own rulebook (§2.3).
 
-**Why both:** numeric priority is ergonomic for a small local ladder (timing); context order
-is the scalable, *declared-once* mechanism for thousands of cross-referencing rules where
-hand-numbering is infeasible (the US Code). Numeric priority lowers to a trivial total
-`context_order` internally, so the engine has one mechanism.
+- **Grounded conflict-resolution principles (the recursive layer, §2.3)** — when an explicit
+  tier and a context order *disagree* (a `specific` lower-court rule vs an `authoritative`
+  higher-court rule), which wins is itself decided by **grounded meta-rules**, not a hardcoded
+  precedence-of-precedence. Recency, appeal status, court level, and lex-specialis are each a
+  byte-provenanced rule (§2.3).
+
+### 2.3 Precedence is grounded and recursive (decisions 2 + 3)
+
+> The headline architectural commitment. "Everything in this work is recursive and each has its
+> own byte provenance." Precedence is not a hardcoded `max(priority)`; it is **derived** by a
+> grounded **precedence rulebook**, the same way every clinical/legal fact is derived.
+
+1. **Context order edges are grounded facts.** `federal > state` is not config — it is
+   `outranks_context(federal, state)` **with a source**: the Supremacy Clause (US Const. Art.
+   VI, cl. 2), a byte-quote, a locator, a trust tier. It enters the CAS through the *same*
+   spider → provenance → adversarial-gate pipeline as any other fact
+   (`feedback_nothing_human_authored`). Its own rulebook: `context-precedence.adj`.
+
+2. **Rules carry typed attributes, not a baked-in rank.** A rule (esp. a grounded legal/clinical
+   one) records *why it might out- or under-rank another*: its **authority level** (court /
+   guideline-body), **decision/effective date**, **appeal status** (good-law / reversed /
+   vacated / superseded), and **specificity**. These are typed (dates via datetime-core, etc.)
+   and themselves provenanced.
+
+3. **The conflict-resolution PRINCIPLES are grounded meta-rules.** "Which rule governs" is a
+   derived relation `outranks($R1, $R2)`, produced by rules like — each byte-provenanced:
+   - *lex superior*: a higher authority outranks a lower (`outranks_context` grounded in the
+     hierarchy's charter).
+   - *stare decisis / recency*: a later **controlling** opinion supersedes an earlier one (cite
+     the doctrine).
+   - *good-law gate*: a rule **reversed/vacated on appeal** is defeated outright (cite the
+     reversing decision — recursive: the defeater is itself a grounded rule).
+   - *lex specialis*: the more specific provision governs the general — **and when lex specialis
+     and lex superior point opposite ways, a further grounded meta-rule decides** (e.g. "a
+     specific statute controls over a general one unless the general is constitutional"), cited
+     to the governing canon. There is no built-in tiebreaker the engine invents; if no grounded
+     meta-rule resolves it, the result is `CONFLICT` (abstain), surfaced honestly.
+
+   So the resolver does not compare integers — it **queries the precedence rulebook**:
+   `? outranks($winner, $loser)` over the conflicting rules' attributes. The named-enum tier
+   (§2.2) is just the simplest grounded meta-rule ("a higher explicit tier outranks a lower"),
+   used for local ladders where no richer principle applies.
+
+4. **Cycles are rejected at load (decision 4).** `outranks_context` (and any derived `outranks`
+   that is asserted as ground) must be acyclic; the loader runs a cycle check and refuses a
+   rulebook that asserts `a > b, b > a`. Derived `outranks` from meta-rules is checked for
+   contradiction (both `outranks(A,B)` and `outranks(B,A)` derivable ⇒ `CONFLICT`, not a pick).
+
+**Why this is the right shape:** it makes the legal-corpus vision tractable *and honest* — the
+reason one authority beats another is auditable down to the clause, the system never invents a
+hierarchy, and "the law changed / was overruled" is a CAS edit to a grounded rule that
+re-propagates. It is the McCarthy context-lifting relation, but *every lift is justified by
+cited bytes*. Medicine uses the identical machinery (specialist guideline > general; a
+retracted study defeats its claims; a newer IDSA edition supersedes an older).
+
+**Why explicit tiers still exist:** a named-enum tier is ergonomic for a small local ladder
+(timing) where authoring a full grounded meta-rule would be overkill; it is the degenerate
+grounded principle "higher tier wins". The scalable mechanism for thousands of cross-referencing
+rules (the US Code) is the grounded `outranks` rulebook.
 
 ---
 
@@ -243,22 +302,42 @@ Each PR: spec-sync note, tests incl. a CONFLICT/abstain case, `/security-review`
 
 ---
 
-## 7. Open design questions (for review before PR-1)
+## 7. Resolved design decisions (2026-06-16, user)
 
-1. **Priority scope.** Per-rule integer vs named tiers (`priority: authoritative` mapped to a
-   number)? Named tiers read better in grounded rulebooks and align with the `trust` ladder —
-   lean named, with integers as the escape hatch.
-2. **Context order source.** Should `context_order` be *grounded* (a precedence itself has a
-   source — e.g. the Supremacy Clause for federal > state) rather than authored? Likely yes,
-   long-term: precedence edges are facts in the CAS with provenance, same as any other.
-3. **Transitivity / cycles.** `context_order` is a strict partial order; the loader must
-   reject cycles (`a > b, b > a`) at compile time. Lex-specialis vs lex-superior can conflict
-   (a specific *lower* rule vs a general *higher* one) — do we need rule-level priority to
-   adjudicate *between ordering principles*? Defer to PR-5 once real cases exist; PR-1 ships
-   single-dimension orders.
-4. **Defeat vs probability discount.** Hard defeat (loser contributes nothing) vs soft
-   (loser's probability is discounted)? Start hard (matches statutes/clinical contraindication);
-   soft defeat is a later `ADJ` extension if a domain needs graded override.
+1. **Priority = named enum tiers**, not raw integers (§2.2). Proposed ladder
+   `default < specific < authoritative < mandatory` (open to edit); `default` implicit; a ground
+   fact sits above all tiers. Integers are not exposed in the surface.
+2. **Context precedence is grounded, in its own rulebook, with provenance on WHY** (§2.3). Each
+   `outranks_context` edge cites its charter (Supremacy Clause for federal > state, etc.) and
+   enters via the standard spider → gate → CAS pipeline. New artifact: `context-precedence.adj`.
+3. **Conflict-resolution principles are themselves grounded, recursive meta-rules** (§2.3) —
+   lex-superior, recency/stare-decisis, appeal-status (reversed ⇒ defeated), lex-specialis, and
+   the meta-meta-rule for when specialis and superior disagree. The resolver *queries* the
+   precedence rulebook (`? outranks($w,$l)`); it never invents a hierarchy. Unresolved ⇒
+   `CONFLICT` (abstain). Rules carry typed, provenanced attributes (authority level, decision
+   date, appeal status, specificity) that the meta-rules read.
+4. **Cycles rejected at load**; contradictory derived `outranks` ⇒ `CONFLICT`, not a silent pick.
+5. **Defeat is hard** for now (a defeated rule contributes nothing). Soft probability-discount is
+   deferred unless a domain needs graded override. *(This was the one question with no strong
+   user signal; hard defeat is the conservative default and matches statutes/contraindications.)*
+
+### Revised PR staging (supersedes §6's PR-1b/PR-2/PR-5 framing)
+
+- **PR-A — named-enum priority (engine).** Replace `Rule.priority: i64` with `Priority` enum
+  (`Default < Specific < Authoritative < Mandatory`, `Ord`; fact = above all). Update
+  `with_priority`, `enumerate_governing` comparison, the 2 adjudication-connector sites, tests.
+- **PR-B — grounded `context-precedence` rulebook + `outranks` resolver.** A grounded rulebook
+  of `outranks_context` edges (each byte-provenanced) + the meta-rules (lex-superior / recency /
+  appeal-status / lex-specialis). Engine resolution queries `outranks` instead of comparing enum
+  tiers when rule attributes are present; cycle/contradiction → CONFLICT. Rule attributes
+  (authority/date/appeal/specificity) added as typed, provenanced metadata.
+- **PR-C — adj-lang surface** (`priority: <tier>`, `functional`/`decision`, the attribute
+  annotations) + regen grammar.
+- **PR-D — MYCIN `decide_timing` → `timing.adj`** on the named-enum ladder (was PR-4).
+- **PR-E — legal `context-precedence` worked example** (federal>state grounded to the Supremacy
+  Clause; a reversed-on-appeal defeat) proving the recursive grounded mechanism end-to-end.
+
+Each PR: spec-sync note, tests incl. a CONFLICT/abstain case, `/security-review`, babysit.
 
 ---
 


### PR DESCRIPTION
Acts on your design decisions for defeasible precedence (the ADJ73 §7 questions).

## 1. Priority is a named enum, not an integer (decision 1)

- `Rule.priority: i64` → **`Priority { Default < Specific < Authoritative < Mandatory }`** (derive `Ord`; `Default` implicit, so existing rules unchanged). `with_priority` takes a `Priority`.
- `GovernedAnswer.priority: i64` → **`Standing { Rule(Priority), Asserted }`** — a ground fact is `Asserted` (outranks every rule tier), replacing the old `i64::MAX` sentinel.
- The resolver compares tiers; no magic numbers. The 2 `adjudication-connector` `Rule{}` sites use `Priority::Default`.

## 2. Spec v2 — precedence is grounded and recursive (decisions 2 + 3, the headline)

Per your direction, the spec now commits to: **precedence is not a hardcoded `max()` — it is *derived* from a grounded `context-precedence` rulebook, recursively, with byte-provenance at every layer.**

- Each `outranks_context` edge **cites its charter** (e.g. `federal > state` ← Supremacy Clause) and enters via the standard spider → gate → CAS pipeline — not config.
- The **conflict-resolution *principles* are themselves grounded meta-rules**: lex-superior, recency / stare decisis, **appeal-status (reversed ⇒ defeated)**, lex-specialis, and the meta-rule for when specialis and superior disagree. The resolver *queries* `? outranks($w,$l)` over rules' typed, provenanced attributes (authority / decision-date / appeal-status / specificity); it never invents a hierarchy. An unresolved clash is `CONFLICT` (abstain).
- **Cycles rejected at load** (decision 4); **hard defeat** for now (decision 5). The named-enum tier is the simplest grounded principle ("higher tier wins") for local ladders.
- Revised PR staging **A–E** in §7 (A = this; B = grounded `context-precedence` rulebook + `outranks` resolver; C = adj-lang surface; D = MYCIN `decide_timing`; E = legal worked example).

## Verification

Behaviour identical to the merged PR-1 core — pure type substitution; every remapped priority preserves its ordering (security review verified this explicitly). **101** logic-engine + **5** govern + **4** precedence-integration tests pass; downstream builds; fmt churn reverted; security review passed. CHANGELOG 0.18.0 + README updated.

The b-lactam allergy grounding (decision 5 / your "figure out the right thing from literature") is the next unit — a separate MYCIN-grounding PR, since it runs the spider + types the cross-reactivity %.

🤖 Generated with [Claude Code](https://claude.com/claude-code)