### PR TITLE
Accept .control set noaskquit markers

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ### Added
 
+- **Deck control noaskquit option routing** —
+  `analyze_deck_controls()` and `resolve_deck_sources()` now accept selected
+  `.control` block `set noaskquit` UI options as no-op control commands instead
+  of reporting unsupported-command diagnostics, matching Rust and TypeScript.
+
 - **Deck control quit marker routing** —
   `analyze_deck_controls()` and `resolve_deck_sources()` now accept selected
   `.control` block `quit` interpreter-exit markers as no-op control commands

--- a/code/packages/python/spice-engine/README.md
+++ b/code/packages/python/spice-engine/README.md
@@ -161,9 +161,9 @@ it returns active lines before `.end` and stable diagnostics for unsupported
 `.include`, `.lib`, and `.control` directives. Inside `.control` blocks,
 selected analysis/output commands (`op`, `dc`, `ac`, `tran`, `save`, `probe`,
 `measure`, `meas`, `four`, `fourier`, `print`, and `plot`) are normalized into
-dotted deck cards, while `run` and `quit` are accepted as no-op execution and
-interpreter-exit markers. Other unrecognized non-comment commands emit
-diagnostics until a broader executed control subset is in scope.
+dotted deck cards, while `run`, `quit`, and the UI-only `set noaskquit` option
+are accepted as no-op control markers. Other unrecognized non-comment commands
+emit diagnostics until a broader executed control subset is in scope.
 `resolve_deck_sources()` is the first include/library resolution layer: callers
 provide a source-content map, `.include` directives are expanded in place, and
 `.lib path section` selects a named `.lib` / `.endl` section with stable

--- a/code/packages/python/spice-engine/src/spice_engine/compatibility.py
+++ b/code/packages/python/spice-engine/src/spice_engine/compatibility.py
@@ -516,6 +516,7 @@ _SUPPORTED_CONTROL_BLOCK_COMMANDS = frozenset(
     }
 )
 _NOOP_CONTROL_BLOCK_COMMANDS = frozenset({"run", ".run", "quit", ".quit"})
+_NOOP_CONTROL_BLOCK_SET_OPTIONS = frozenset({"noaskquit"})
 _SPICE_SUFFIX_FACTORS = {
     "t": 1.0e12,
     "g": 1.0e9,
@@ -3342,5 +3343,12 @@ def _control_block_command_as_deck_line(line: str) -> str | None:
 
 
 def _is_noop_control_block_command(line: str) -> bool:
-    command = line.split(maxsplit=1)[0].lower()
-    return command in _NOOP_CONTROL_BLOCK_COMMANDS
+    parts = line.split()
+    command = parts[0].lower()
+    if command in _NOOP_CONTROL_BLOCK_COMMANDS:
+        return True
+    return (
+        command in {"set", ".set"}
+        and len(parts) == 2
+        and parts[1].lower() in _NOOP_CONTROL_BLOCK_SET_OPTIONS
+    )

--- a/code/packages/python/spice-engine/tests/test_compatibility.py
+++ b/code/packages/python/spice-engine/tests/test_compatibility.py
@@ -119,6 +119,8 @@ measure tran vmax MAX V(out)
 meas dc imax MAX I(V1)
 fourier 1k V(out)
 four 2k V(in)
+set noaskquit
+set filetype=ascii
 run
 quit
 .endc
@@ -143,11 +145,13 @@ quit
         (".include", 2, "error"),
         (".lib", 3, "error"),
         (".control", 4, "error"),
+        (".control", 14, "error"),
     ]
     assert [diag.code for diag in summary.diagnostics] == [
         "SPICE_DECK_UNSUPPORTED_DIRECTIVE",
         "SPICE_DECK_UNSUPPORTED_DIRECTIVE",
         "SPICE_DECK_UNSUPPORTED_DIRECTIVE",
+        "SPICE_DECK_CONTROL_COMMAND",
     ]
     measurement_summary = resolve_deck_measurements("\n".join(summary.active_lines) + "\n.end")
     assert [
@@ -225,6 +229,7 @@ measure tran vmax MAX V(a)
 meas dc imax MAX I(V1)
 fourier 1k V(a)
 four 2k V(b)
+.set noaskquit
 run
 .quit
 .endc

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Accept selected `.control` block `set noaskquit` UI options as no-op control
+  commands in `analyze_deck_controls` and `resolve_deck_sources`, matching
+  Python and TypeScript.
 - Accept selected `.control` block `quit` interpreter-exit markers as no-op
   control commands in `analyze_deck_controls` and `resolve_deck_sources`,
   matching Python and TypeScript.

--- a/code/packages/rust/spice-engine/README.md
+++ b/code/packages/rust/spice-engine/README.md
@@ -128,9 +128,9 @@ returns active lines before `.end` and stable diagnostics for unsupported
 `.include`, `.lib`, and `.control` directives. Inside `.control` blocks,
 selected analysis/output commands (`op`, `dc`, `ac`, `tran`, `save`, `probe`,
 `measure`, `meas`, `four`, `fourier`, `print`, and `plot`) are normalized into
-dotted deck cards, while `run` and `quit` are accepted as no-op execution and
-interpreter-exit markers. Other unrecognized non-comment commands emit
-diagnostics until a broader executed control subset is in scope.
+dotted deck cards, while `run`, `quit`, and the UI-only `set noaskquit` option
+are accepted as no-op control markers. Other unrecognized non-comment commands
+emit diagnostics until a broader executed control subset is in scope.
 `resolve_deck_sources` is the first include/library resolution layer: callers
 provide a source-content map, `.include` directives are expanded in place, and
 `.lib path section` selects a named `.lib` / `.endl` section with stable

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -6903,12 +6903,18 @@ fn control_block_command_as_deck_line(line: &str) -> Option<String> {
 }
 
 fn is_noop_control_block_command(line: &str) -> bool {
-    matches!(
-        line.split_whitespace()
-            .next()
-            .map(|command| command.to_ascii_lowercase()),
-        Some(command) if command == "run" || command == ".run" || command == "quit" || command == ".quit"
-    )
+    let mut parts = line.split_whitespace();
+    let Some(command) = parts.next().map(|command| command.to_ascii_lowercase()) else {
+        return false;
+    };
+    if matches!(command.as_str(), "run" | ".run" | "quit" | ".quit") {
+        return true;
+    }
+    if !matches!(command.as_str(), "set" | ".set") {
+        return false;
+    }
+    matches!(parts.next().map(|option| option.to_ascii_lowercase()), Some(option) if option == "noaskquit")
+        && parts.next().is_none()
 }
 
 fn is_unsupported_deck_control_directive(directive: &str) -> bool {

--- a/code/packages/rust/spice-engine/tests/compatibility_tests.rs
+++ b/code/packages/rust/spice-engine/tests/compatibility_tests.rs
@@ -136,6 +136,8 @@ measure tran vmax MAX V(out)
 meas dc imax MAX I(V1)
 fourier 1k V(out)
 four 2k V(in)
+set noaskquit
+set filetype=ascii
 run
 quit
 .endc
@@ -175,7 +177,8 @@ quit
         vec![
             (".include", 2, "error"),
             (".lib", 3, "error"),
-            (".control", 4, "error")
+            (".control", 4, "error"),
+            (".control", 14, "error")
         ]
     );
     assert_eq!(
@@ -187,7 +190,8 @@ quit
         vec![
             "SPICE_DECK_UNSUPPORTED_DIRECTIVE",
             "SPICE_DECK_UNSUPPORTED_DIRECTIVE",
-            "SPICE_DECK_UNSUPPORTED_DIRECTIVE"
+            "SPICE_DECK_UNSUPPORTED_DIRECTIVE",
+            "SPICE_DECK_CONTROL_COMMAND"
         ]
     );
     let measurement_deck = format!("{}\n.end", summary.active_lines.join("\n"));
@@ -317,6 +321,7 @@ measure tran vmax MAX V(a)
 meas dc imax MAX I(V1)
 fourier 1k V(a)
 four 2k V(b)
+.set noaskquit
 run
 .quit
 .endc

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Accept selected `.control` block `set noaskquit` UI options as no-op control
+  commands in `analyzeDeckControls` and `resolveDeckSources`, matching Python
+  and Rust.
 - Accept selected `.control` block `quit` interpreter-exit markers as no-op
   control commands in `analyzeDeckControls` and `resolveDeckSources`, matching
   Python and Rust.

--- a/code/packages/typescript/spice-engine/README.md
+++ b/code/packages/typescript/spice-engine/README.md
@@ -135,9 +135,9 @@ returns active lines before `.end` and stable diagnostics for unsupported
 `.include`, `.lib`, and `.control` directives. Inside `.control` blocks,
 selected analysis/output commands (`op`, `dc`, `ac`, `tran`, `save`, `probe`,
 `measure`, `meas`, `four`, `fourier`, `print`, and `plot`) are normalized into
-dotted deck cards, while `run` and `quit` are accepted as no-op execution and
-interpreter-exit markers. Other unrecognized non-comment commands emit
-diagnostics until a broader executed control subset is in scope.
+dotted deck cards, while `run`, `quit`, and the UI-only `set noaskquit` option
+are accepted as no-op control markers. Other unrecognized non-comment commands
+emit diagnostics until a broader executed control subset is in scope.
 `resolveDeckSources` is the first include/library resolution layer: callers
 provide a source-content map, `.include` directives are expanded in place, and
 `.lib path section` selects a named `.lib` / `.endl` section with stable

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -2855,6 +2855,7 @@ const SUPPORTED_CONTROL_BLOCK_COMMANDS = new Set([
   ".plot",
 ]);
 const NOOP_CONTROL_BLOCK_COMMANDS = new Set(["run", ".run", "quit", ".quit"]);
+const NOOP_CONTROL_BLOCK_SET_OPTIONS = new Set(["noaskquit"]);
 
 export function compatibilityCorpus(): readonly CompatibilityDeck[] {
   return COMPATIBILITY_CORPUS;
@@ -5712,8 +5713,19 @@ function controlBlockCommandAsDeckLine(line: string): string | undefined {
 }
 
 function isNoopControlBlockCommand(line: string): boolean {
-  const command = line.split(/\s+/, 1)[0]?.toLowerCase();
-  return command !== undefined && NOOP_CONTROL_BLOCK_COMMANDS.has(command);
+  const parts = line.split(/\s+/);
+  const command = parts[0]?.toLowerCase();
+  if (command === undefined) {
+    return false;
+  }
+  if (NOOP_CONTROL_BLOCK_COMMANDS.has(command)) {
+    return true;
+  }
+  return (
+    (command === "set" || command === ".set") &&
+    parts.length === 2 &&
+    NOOP_CONTROL_BLOCK_SET_OPTIONS.has(parts[1]?.toLowerCase() ?? "")
+  );
 }
 
 export function subcircuitDefinition(

--- a/code/packages/typescript/spice-engine/tests/compatibility.test.ts
+++ b/code/packages/typescript/spice-engine/tests/compatibility.test.ts
@@ -123,6 +123,8 @@ measure tran vmax MAX V(out)
 meas dc imax MAX I(V1)
 fourier 1k V(out)
 four 2k V(in)
+set noaskquit
+set filetype=ascii
 run
 quit
 .endc
@@ -150,11 +152,13 @@ quit
       [".include", 2, "error"],
       [".lib", 3, "error"],
       [".control", 4, "error"],
+      [".control", 14, "error"],
     ]);
     expect(summary.diagnostics.map((diagnostic) => diagnostic.code)).toStrictEqual([
       "SPICE_DECK_UNSUPPORTED_DIRECTIVE",
       "SPICE_DECK_UNSUPPORTED_DIRECTIVE",
       "SPICE_DECK_UNSUPPORTED_DIRECTIVE",
+      "SPICE_DECK_CONTROL_COMMAND",
     ]);
     const measurementSummary = resolveDeckMeasurements(`${summary.activeLines.join("\n")}\n.end`);
     expect(measurementSummary.measurements.map((card) => [
@@ -232,6 +236,7 @@ measure tran vmax MAX V(a)
 meas dc imax MAX I(V1)
 fourier 1k V(a)
 four 2k V(b)
+.set noaskquit
 run
 .quit
 .endc

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -36,10 +36,10 @@ downstream tools to compare.
      stable non-executed diagnostics, and selected `.control` block
      analysis/output commands (`op`, `dc`, `ac`, `tran`, `save`, `probe`,
      `measure`, `meas`, `four`, `fourier`, `print`, and `plot`) now normalize
-     into dotted deck cards while `run` and `quit` are accepted as no-op
-     execution / interpreter-exit markers; parsed `.measure dc` / `.meas dc`
-     cards now route DC sweep probe samples into the shared scalar measurement
-     table surface;
+     into dotted deck cards while `run`, `quit`, and UI-only `set noaskquit`
+     options are accepted as no-op control markers; parsed `.measure dc` /
+     `.meas dc` cards now route DC sweep probe samples into the shared scalar
+     measurement table surface;
      parsed `.measure ac` / `.meas ac` cards now route AC probe magnitudes over
      optional frequency windows into the same measurement table surface; parsed
      transient `.measure ... FIND ... AT=` cards now route single-time probe
@@ -555,6 +555,14 @@ downstream tools to compare.
       analysis and output commands have normalized into deck cards.
     - Other unrecognized non-comment commands inside `.control` blocks remain
       diagnostic-only so unsupported control flow is still explicit.
+
+50. Selected `.control` noaskquit option routing.
+    - Status: completed in this selected control noaskquit-option routing slice.
+    - Python, Rust, and TypeScript now accept exact selected `.control` block
+      `set noaskquit` UI options as no-op control commands.
+    - Other `set` variables and unrecognized non-comment commands inside
+      `.control` blocks remain diagnostic-only so unsupported script state and
+      control flow are still explicit.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- Accept exact `.control` / `.endc` `set noaskquit` and `.set noaskquit` commands as UI-only no-op control markers in Python, Rust, and TypeScript SPICE compatibility routing.
- Keep other `set` variables diagnostic-only so unsupported control-block state remains explicit.
- Update SPICE package docs/changelogs and mark the slice complete in the full implementation plan.

## Verification
- `PYTHONPATH="$(find code/packages/python -maxdepth 2 -type d -name src | paste -sd: -)" /Users/adhithya/.local/share/mise/installs/python/3.12.13/bin/python3 -m ruff check code/packages/python/spice-engine/src/spice_engine/compatibility.py code/packages/python/spice-engine/tests/test_compatibility.py`
- `PYTHONPATH="$(find code/packages/python -maxdepth 2 -type d -name src | paste -sd: -)" /Users/adhithya/.local/share/mise/installs/python/3.12.13/bin/python3 -m pytest code/packages/python/spice-engine/tests -q`
- `cargo fmt --manifest-path code/packages/rust/spice-engine/Cargo.toml -- --check`
- `cargo test --manifest-path code/packages/rust/spice-engine/Cargo.toml`
- `npm --prefix code/packages/typescript/spice-engine ci`
- `npm --prefix code/packages/typescript/spice-engine run build`
- `npm --prefix code/packages/typescript/spice-engine test`
- `git diff --check`