### PR TITLE
docs(mycin): ground β-lactam allergy cross-reactivity by R1 side chain — CC-3b evidence + design (⚠️ behavior change for review)

### DIFF
--- a/code/specs/data/mycin-2026/CHART-AS-CONSTRAINTS.md
+++ b/code/specs/data/mycin-2026/CHART-AS-CONSTRAINTS.md
@@ -177,6 +177,35 @@ risks Y") — decision support, not a hidden choice.
   grounded fact in the rulebook + (if a new context) one row in `_CONTEXT_FROM_FACT` — no
   drug-name logic in the compiler. Remaining CC-3 follow-ups (allergy drug-class exclusion,
   drug–drug interactions) move into the same rulebook next.
+- **CC-3b — β-lactam allergy is SIDE-CHAIN-scoped, not class-wide (grounded; ⚠️ CHANGES
+  BEHAVIOR — review).** The current `_ALLERGY_EXCLUSION` drops the *entire* β-lactam class on a
+  penicillin allergy. The literature (spider-grounded 2026-06-16, record
+  `ci_betalactam_sidechain_mechanism` in `treatment-constraints-grounding.json`) says that is
+  wrong: *"The similarity in structure of the R1-side-chains of penicillins and cephalosporins
+  determines the likelihood of cross-sensitivity between the drug classes — not the presence of
+  the beta-lactam ring."* Cross-reaction risk to cephalosporins in reported (untested)
+  penicillin allergy is **<1%** (~2% with a positive skin test); 3rd-gen cephalosporins
+  (ceftriaxone, cefepime), carbapenems, and aztreonam are given to penicillin-allergic patients
+  **without testing** under 2024 drug-allergy practice parameters.
+  - **Corrected model (the right thing from the literature):** a penicillin allergy excludes
+    penicillins **+ only the cephalosporins/agents that SHARE the culprit's R1 side chain** — NOT
+    structurally-dissimilar β-lactams. The cross-reactivity figures are **typed quantities**
+    (`percentage`, via the typed-value pipeline), grounded, and used directly (e.g. "<1%" is a
+    `percentage` literal in the ADJ program, not prose).
+  - **Implementation plan (separate PR, for clinical review BEFORE it lands):**
+    1. Add per-drug **R1 side-chain** data to the grounded formulary (e.g. `ampicillin`,
+       `amoxicillin` share an aminopenicillin side chain; `ceftriaxone`/`cefepime` are
+       dissimilar; `aztreonam` is a monobactam with a side chain shared with `ceftazidime`).
+    2. Extend the chart IR with the allergy **culprit** + **severity** (mild rash vs anaphylaxis).
+    3. Contraindication rulebook gains a grounded rule: `contraindicated($D, penicillin_allergy)
+       when: active_context(penicillin_allergy), shares_side_chain($D, $Culprit)` (+ a
+       conservative severe/anaphylaxis path that also excludes same-ring penicillins). The
+       blanket `betalactam_allergy_severe` token + the Python `_ALLERGY_EXCLUSION` map are
+       retired — the exclusion is engine-derived from the grounded side-chain facts.
+    4. Tests proving ceftriaxone/cefepime/meropenem/aztreonam remain available for a typical
+       penicillin allergy (low cross-reactivity), a same-side-chain agent is excluded, and the
+       severe path stays conservative. The behaviour change is surfaced loudly for the
+       physician-auditor (the system audits, the human signs off).
 - **CC-4 — cost + side-effect objective. ✅ DONE.** The set-cover objective is now the
   weighted blend `minimize Σ (w_cost·tier + w_tox·side_effects)·x_d`, emitted to the engine's
   integer optimizer (coefficients stay integer). A chart `objective_priority` fact selects the

--- a/code/specs/data/mycin-2026/grounding/treatment-constraints-grounding.json
+++ b/code/specs/data/mycin-2026/grounding/treatment-constraints-grounding.json
@@ -234,6 +234,33 @@
         "final_verdict": "grounded"
       },
       "spider_status": "grounded"
+    },
+    {
+      "id": "ci_betalactam_sidechain_mechanism",
+      "kind": "mechanism",
+      "claim": "Is penicillin-cephalosporin cross-reactivity driven by R1 side-chain similarity rather than the shared beta-lactam ring, and what does that imply for excluding cephalosporins in a penicillin-allergic patient?",
+      "grounded": {
+        "id": "ci_betalactam_sidechain_mechanism",
+        "resolved_url": "https://www.ebmconsult.com/articles/penicillin-allergy-cross-reactivity-cephalosporin-antibiotics",
+        "source_title": "Penicillin and Cephalosporin Cross-Reactivity and Risk for Allergic Reaction - EBM Consult",
+        "byte_quote": "The similarity in structure of the R1-side-chains of penicillins and cephalosporins determines the likelihood of cross-sensitivity between the drug classes - not the presence of the beta-lactam ring.",
+        "value_found": "Cross-reactivity is R1-SIDE-CHAIN-driven, NOT beta-lactam-ring-driven. The risk of a cross-reaction to cephalosporins in patients with reported (untested) penicillin allergy is <1%, ~2% with a confirmed positive penicillin skin test. Structurally-dissimilar cephalosporins (incl. 3rd-gen ceftriaxone/cefepime) therefore carry low cross-reactivity. CLINICAL IMPLICATION: a penicillin allergy should exclude penicillins + only those cephalosporins SHARING the culprit's R1 side chain - NOT the entire beta-lactam class.",
+        "direction_correct": true,
+        "verdict": "grounded",
+        "discards": [
+          "UNC inpatient penicillin-allergy guideline PDF (med.unc.edu) - relevant (cross-reactivity table + side-chain guidance) but the fetched PDF was non-extractable binary, so not usable as the cited byte-quote source.",
+          "about.ebsco.com health-notes blog ('myths debunked') - secondary blog; excluded per the standing instruction to cite a primary/clinical source."
+        ],
+        "note": "Spider run 2026-06-16 (WebSearch + WebFetch, ebmconsult HTML). Corroborated by the already-grounded ci_penicillin_cephalosporin (CDC STI 2021: 3rd-gen <1%, 1st/2nd 1-8%) and 2024 drug-allergy practice-parameter guidance that structurally-dissimilar cephalosporins may be given to IgE-mediated penicillin-allergic patients WITHOUT testing. Pairs with ci_aztreonam_safe_penicillin (monobactam <1%)."
+      },
+      "verify": {
+        "id": "ci_betalactam_sidechain_mechanism",
+        "byte_stable": true,
+        "reextracted_value": "Re-fetch confirmed the R1-side-chain mechanism quote and the <1% (reported, untested) / ~2% (positive skin test) cross-reaction figures.",
+        "refute_attempt": "Adversarial check: sought evidence the beta-lactam RING (class-wide) drives cross-reactivity. Found none current; the historical ~10% figure is attributed to first-generation cephalosporins contaminated with penicillin and to shared side chains, not the ring. Side-chain mechanism is current consensus.",
+        "final_verdict": "grounded"
+      },
+      "spider_status": "grounded"
     }
   ]
 }


### PR DESCRIPTION
Acts on your **decision 5**: *"B-lactam exclusion should be fixed up. Use the same grounding mechanism we have for others. Figure out what the right thing from literature is and use it. Everything like 1% should be properly grounded and typed into the ADJ program and used correctly."*

## What the literature says (spider-grounded)

The current `_ALLERGY_EXCLUSION` drops the **entire β-lactam class** on a penicillin allergy. The literature says that's wrong. New grounded record `ci_betalactam_sidechain_mechanism` (WebSearch + WebFetch, verbatim byte-quote + adversarial verify, same shape as the other treatment-constraints records):

> "The similarity in structure of the **R1-side-chains** of penicillins and cephalosporins determines the likelihood of cross-sensitivity between the drug classes — **not the presence of the beta-lactam ring**." — EBM Consult (corroborated by CDC STI 2021 + 2024 drug-allergy practice parameters)

- Cross-reaction risk to cephalosporins in reported (untested) penicillin allergy: **<1%** (~2% with a positive skin test).
- 3rd-gen cephalosporins (ceftriaxone, cefepime), carbapenems, and aztreonam are given to penicillin-allergic patients **without testing**.

## This PR (grounding + design only — no code)

- **Grounded record** added to `treatment-constraints-grounding.json` (the same mechanism as every other grounded fact).
- **`CHART-AS-CONSTRAINTS.md` CC-3b** records the corrected **side-chain-scoped** model: a penicillin allergy excludes penicillins **+ only same-R1-side-chain agents**, not the whole class; the cross-reactivity figures are **typed `percentage` quantities** used directly in the ADJ program; plus the staged implementation plan (per-drug R1 side-chain data → chart culprit+severity → engine-derived `contraindicated($D, penicillin_allergy) when: shares_side_chain($D, $Culprit)`, retiring the blanket token + the Python map).

## ⚠️ Why this is grounding+design, not the code flip

The implementation **changes clinical behaviour** — allergic patients become eligible for structurally-dissimilar β-lactams. That is the literature-correct change, but it's the one safety-critical place where the system's *human-as-auditor* thesis matters most: I've grounded the evidence and designed the fix; **you (the physician-auditor) review the grounded evidence before it lands in code.** The code PR follows on your nod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)