### PR TITLE
feat(spreadsheet-core): fill/replicate (drag-fill) + fix absolute-reference resolution

### DIFF
--- a/code/packages/rust/spreadsheet-core/CHANGELOG.md
+++ b/code/packages/rust/spreadsheet-core/CHANGELOG.md
@@ -1,5 +1,35 @@
 # Changelog
 
+## 0.7.0
+
+**Fill / replicate (drag-fill)** — `Workbook::fill` plus the `FormulaAst::shift`
+copy/paste reference arithmetic it rides on. Replicating a cell across a target
+range now shifts each copy's **relative** references by its offset while leaving
+**absolute** (`$`) references pinned — the classic spreadsheet fill.
+
+- `FormulaAst::shift(d_row, d_col) -> FormulaAst` (`ast.rs`): pure recursive
+  copy/paste rewrite of every `Ref`/`Range`, the sibling of `adjust`
+  (structural edits). The two differ on absolutes: `adjust` moves both relative
+  and absolute refs (a cell physically relocates); `shift` tracks relatives and
+  pins absolutes (`=A1`→`=A2` on fill-down, `$A$1` stays). A reference shifted
+  off the top/left edge collapses to `#REF!`. 6 new tests.
+- `Workbook::fill(sheet, src, dst)` (`workbook.rs`): replicate the `src` cell
+  across every cell of the `dst` range — formulas shifted per-target, literals
+  copied unchanged, an empty source clears each target, and the source's display
+  **format rides along**. One recalc transaction; unknown sheet is a no-op; a
+  `dst` over `MAX_RANGE_CELLS` is rejected wholesale (the same DoS guard formula
+  ranges use, so a hostile caller can't ask the engine to write billions of
+  cells). 7 new tests.
+- **Fix: absolute references now resolve.** A cell is keyed by *position* only,
+  but the evaluator (and `collect_refs`) used a reference's full address —
+  including its `$` flags — as the cell-store / dependency-graph key, so `=$A$1`
+  missed the relatively-stored `A1` cell and read as **0**, and editing `A1`
+  did not recompute a dependent that referenced it absolutely. New
+  `CellAddress::without_absolute()` normalises the address at those two
+  boundaries. (Pre-existing latent bug — no test had ever evaluated an absolute
+  reference; surfaced by the fill work, which depends on correct `$` handling.)
+  New regression test.
+
 ## 0.6.0
 
 **`get_display_window`** — a windowed read returning each cell's **formatted

--- a/code/packages/rust/spreadsheet-core/Cargo.toml
+++ b/code/packages/rust/spreadsheet-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spreadsheet-core"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 description = "Headless spreadsheet engine — cell model, formula AST, dependency DAG, recalc, dispatch to Layer-1 cores. The engine VisiCalc Modern and any other Mosaic-rendered spreadsheet sits on top of."
 

--- a/code/packages/rust/spreadsheet-core/src/address.rs
+++ b/code/packages/rust/spreadsheet-core/src/address.rs
@@ -51,6 +51,20 @@ impl CellAddress {
         }
     }
 
+    /// This address with its `$` absolute markers stripped (position only).
+    ///
+    /// A cell is *stored* and *tracked* by position alone — `A1`, `$A1`, `A$1`,
+    /// and `$A$1` in formulas must all resolve to the one cell at row 1, col 1.
+    /// The absolute markers only steer how a reference *shifts* on copy/fill (see
+    /// [`shift`](Self::shift)); they are not part of a cell's identity. So every
+    /// place that uses a reference's address as a key into the cell store or the
+    /// dependency graph normalises it through this first — otherwise a `$A$1`
+    /// lookup (flags set) would miss the relatively-keyed `A1` cell and read as
+    /// empty.
+    pub fn without_absolute(&self) -> CellAddress {
+        CellAddress::new(self.row, self.col)
+    }
+
     /// Shift by `(d_row, d_col)`, respecting absolute flags.
     /// Returns `Err(Ref)` if the shift would push the address to row
     /// or column 0 or below (i.e. would invalidate the reference).

--- a/code/packages/rust/spreadsheet-core/src/ast.rs
+++ b/code/packages/rust/spreadsheet-core/src/ast.rs
@@ -2,6 +2,7 @@
 
 use crate::address::{CellAddress, CellRange};
 use crate::cell::CellValue;
+use crate::errors::SpreadsheetError;
 
 /// One node in a parsed formula.
 #[derive(Debug, Clone, PartialEq)]
@@ -155,6 +156,63 @@ impl FormulaAst {
             }
         }
     }
+
+    /// Rewrite every reference in this formula by `(d_row, d_col)` — the
+    /// **copy/paste (fill)** transform, the sibling of
+    /// [`adjust`](crate::edit) (structural edits).
+    ///
+    /// The two differ in how they treat absolute references:
+    ///
+    /// - `adjust` (insert/delete rows/cols) shifts **both** relative and
+    ///   absolute refs — a cell physically moves, so `$A$1` becomes `$A$2` when a
+    ///   row is inserted above it.
+    /// - `shift` (this) is what fill/drag-copy does: a **relative** ref tracks
+    ///   the offset (so `=A1` filled one row down becomes `=A2`), while an
+    ///   **absolute** ref is pinned (`$A$1` stays `$A$1`). The absolute-flag logic
+    ///   lives in [`CellAddress::shift`]; this just recurses it over the tree.
+    ///
+    /// A reference shifted off the top/left edge of the grid (row or column < 1)
+    /// collapses to the `#REF!` error literal — the same failure mode as `adjust`,
+    /// and it propagates through evaluation like any error. Pure: returns a new
+    /// tree, leaving `self` untouched.
+    pub fn shift(&self, d_row: i32, d_col: i32) -> FormulaAst {
+        match self {
+            FormulaAst::Literal(v) => FormulaAst::Literal(v.clone()),
+            FormulaAst::Ref(addr) => match addr.shift(d_row, d_col) {
+                Ok(a) => FormulaAst::Ref(a),
+                Err(_) => ref_error(),
+            },
+            // A range shifts both corners; if either falls off-grid the whole
+            // range is a dangling reference → `#REF!`.
+            FormulaAst::Range(range) => {
+                match (range.start.shift(d_row, d_col), range.end.shift(d_row, d_col)) {
+                    (Ok(start), Ok(end)) => FormulaAst::Range(CellRange::new(start, end)),
+                    _ => ref_error(),
+                }
+            }
+            FormulaAst::Unary { op, operand } => FormulaAst::Unary {
+                op: *op,
+                operand: Box::new(operand.shift(d_row, d_col)),
+            },
+            FormulaAst::Binary { op, lhs, rhs } => FormulaAst::Binary {
+                op: *op,
+                lhs: Box::new(lhs.shift(d_row, d_col)),
+                rhs: Box::new(rhs.shift(d_row, d_col)),
+            },
+            FormulaAst::Percent(inner) => FormulaAst::Percent(Box::new(inner.shift(d_row, d_col))),
+            FormulaAst::Call { name, args } => FormulaAst::Call {
+                name: name.clone(),
+                args: args.iter().map(|a| a.shift(d_row, d_col)).collect(),
+            },
+        }
+    }
+}
+
+/// The `#REF!` error as a formula literal — what a reference shifted off the grid
+/// collapses to. (Mirrors `edit::ref_error`; kept local so `shift` and `adjust`
+/// stay in their own modules.)
+fn ref_error() -> FormulaAst {
+    FormulaAst::Literal(CellValue::Error(SpreadsheetError::Ref))
 }
 
 /// Render a literal value back to its formula-source form: numbers bare
@@ -216,5 +274,63 @@ mod tests {
         assert_eq!(parse("=3.5").unwrap().to_formula_string(), "3.5");
         assert_eq!(parse("=\"hi\"").unwrap().to_formula_string(), "\"hi\"");
         assert_eq!(parse("=SUM(A1:A2)").unwrap().to_formula_string(), "SUM(A1:A2)");
+    }
+
+    // ── shift (copy/paste / fill) ────────────────────────────────────
+
+    /// Shift `src`'s formula by `(d_row, d_col)` and render it back, for compact
+    /// assertions.
+    fn shifted(src: &str, d_row: i32, d_col: i32) -> String {
+        parse(src).unwrap().shift(d_row, d_col).to_formula_string()
+    }
+
+    #[test]
+    fn shift_tracks_relative_refs_and_pins_absolute() {
+        // Filling =A1 one row down → =A2 (relative ref tracks the offset).
+        assert_eq!(shifted("=A1", 1, 0), "A2");
+        // …and one column right → =B1.
+        assert_eq!(shifted("=A1", 0, 1), "B1");
+        // A fully-absolute ref is pinned: $A$1 stays $A$1.
+        assert_eq!(shifted("=$A$1", 5, 5), "$A$1");
+        // Mixed: $A1 (abs col, rel row) shifted down+right → only the row moves.
+        assert_eq!(shifted("=$A1", 2, 3), "$A3");
+        // A$1 (rel col, abs row) shifted → only the column moves.
+        assert_eq!(shifted("=A$1", 2, 3), "D$1");
+    }
+
+    #[test]
+    fn shift_recurses_ranges_ops_and_calls() {
+        // A range shifts both corners.
+        assert_eq!(shifted("=SUM(A1:A4)", 0, 1), "SUM(B1:B4)");
+        // Recurses through nested binary ops (fully parenthesised) and percent.
+        assert_eq!(shifted("=A1+B1*2", 1, 0), "(A2+(B2*2))");
+        assert_eq!(shifted("=A1%", 0, 1), "B1%");
+    }
+
+    #[test]
+    fn shift_binary_and_call_structure() {
+        // Binary ops are fully parenthesised by the serializer; each ref tracked.
+        assert_eq!(shifted("=A1+B1", 1, 0), "(A2+B2)");
+        assert_eq!(shifted("=IF(A1>0,A1,$Z$9)", 0, 1), "IF((B1>0),B1,$Z$9)");
+    }
+
+    #[test]
+    fn shift_off_grid_becomes_ref_error() {
+        // Shifting A1 up (row would be 0) → the ref collapses to #REF!.
+        assert_eq!(shifted("=A1", -1, 0), "#REF!");
+        // Left off column 1 → #REF!.
+        assert_eq!(shifted("=A1", 0, -1), "#REF!");
+        // A range with a corner off-grid is a dangling reference → the range
+        // collapses to #REF! (here inside the SUM call → `SUM(#REF!)`).
+        assert_eq!(shifted("=SUM(A1:B2)", -5, 0), "SUM(#REF!)");
+        // But an absolute ref can't go off-grid by shifting — it's pinned.
+        assert_eq!(shifted("=$A$1", -10, -10), "$A$1");
+    }
+
+    #[test]
+    fn shift_by_zero_is_identity() {
+        for src in ["=A1", "=$A$1", "=SUM(A1:A4)", "=A1+B2*C3"] {
+            assert_eq!(parse(src).unwrap().shift(0, 0), parse(src).unwrap());
+        }
     }
 }

--- a/code/packages/rust/spreadsheet-core/src/recalc.rs
+++ b/code/packages/rust/spreadsheet-core/src/recalc.rs
@@ -303,7 +303,11 @@ where
 pub fn collect_refs(ast: &FormulaAst, current_sheet: SheetId, out: &mut Vec<(SheetId, CellAddress)>) {
     match ast {
         FormulaAst::Literal(_) => {}
-        FormulaAst::Ref(a) => out.push((current_sheet, *a)),
+        // Normalise away `$` markers: the dependency graph (like the cell store)
+        // is keyed by position, so a `$A$1` precedent points at the same node as
+        // `A1` — otherwise the edge would never match and `set_value` wouldn't
+        // recompute a dependent that referenced it absolutely.
+        FormulaAst::Ref(a) => out.push((current_sheet, a.without_absolute())),
         FormulaAst::Range(r) => {
             // Skip expansion of an oversized range: registering one
             // dependency per cell for `=SUM(A1:XFD1048576)` would
@@ -312,7 +316,7 @@ pub fn collect_refs(ast: &FormulaAst, current_sheet: SheetId, out: &mut Vec<(She
             // so it has no meaningful precedents to track.
             if !r.is_oversized() {
                 for addr in r.iter() {
-                    out.push((current_sheet, addr));
+                    out.push((current_sheet, addr.without_absolute()));
                 }
             }
         }

--- a/code/packages/rust/spreadsheet-core/src/workbook.rs
+++ b/code/packages/rust/spreadsheet-core/src/workbook.rs
@@ -7,7 +7,7 @@
 
 use std::collections::{HashMap, HashSet, VecDeque};
 
-use crate::address::{CellAddress, SheetId};
+use crate::address::{CellAddress, CellRange, SheetId, MAX_RANGE_CELLS};
 use crate::cell::{Cell, CellContent, CellValue};
 use crate::dag::DependencyGraph;
 use crate::edit::StructuralEdit;
@@ -511,6 +511,108 @@ impl Workbook {
         }
     }
 
+    // ----------------------------------------------------------------
+    // Fill / replicate (drag-fill)
+    // ----------------------------------------------------------------
+
+    /// Replicate the cell at `src` across every cell of `dst` — the engine side
+    /// of drag-fill / copy-paste.
+    ///
+    /// Each target gets a **copy** of the source, with its formula's references
+    /// shifted by the target's offset from `src` (so `=A1` filled down the column
+    /// becomes `=A2`, `=A3`, …), via [`FormulaAst::shift`] — relative refs track,
+    /// absolute (`$`) refs stay pinned, and a ref shifted off the grid edge
+    /// becomes `#REF!`. A literal source is copied unchanged; an **empty** source
+    /// clears each target (filling "nothing" erases). The source's display
+    /// **format** rides along to every target, the way a spreadsheet's fill does.
+    /// `src` itself is overwritten with an identical copy when it falls inside
+    /// `dst` (a zero offset — a no-op in effect).
+    ///
+    /// One recalc transaction (`recalc_all` bumps the revision once). Unknown
+    /// `sheet` is a no-op. A `dst` larger than [`MAX_RANGE_CELLS`] is rejected
+    /// wholesale (the same DoS guard formula ranges use) — a hostile or buggy
+    /// caller can't ask the engine to materialise billions of cells.
+    pub fn fill(&mut self, sheet: SheetId, src: CellAddress, dst: CellRange) {
+        if self.sheets.get(sheet.0 as usize).is_none() {
+            return;
+        }
+        // DoS guard: cap the number of cells a single fill can write. Computed in
+        // u64 (cell_count already is), so it can't overflow on a full-grid range.
+        if dst.cell_count() > MAX_RANGE_CELLS {
+            return;
+        }
+
+        // Snapshot the source content + format up front: the loop overwrites
+        // cells (possibly `src` itself), so we must not read it mid-fill.
+        let s = &self.sheets[sheet.0 as usize];
+        let src_content = s.cells.get(&src).map(|c| c.content.clone());
+        let src_format = s.formats.get(&src).cloned();
+
+        // Write every target's content + format directly (one transaction; the
+        // single recalc_all below evaluates them all and bumps the revision once).
+        for row in dst.start.row..=dst.end.row {
+            for col in dst.start.col..=dst.end.col {
+                let target = CellAddress::new(row, col);
+                // Offsets in i64 then clamped into shift's i32 contract: row/col
+                // are u32 (up to ~4.3e9), so `row as i32 - src.row as i32` would
+                // overflow — a panic in debug/test builds, a silent wrap in
+                // release — for a fill anchored at a high coordinate (which clears
+                // the cell_count guard). i64 makes the subtraction exact for all
+                // u32 operands; the clamp keeps it in range, and any resulting
+                // off-grid reference still collapses to #REF! inside `shift`.
+                let d_row =
+                    (row as i64 - src.row as i64).clamp(i32::MIN as i64, i32::MAX as i64) as i32;
+                let d_col =
+                    (col as i64 - src.col as i64).clamp(i32::MIN as i64, i32::MAX as i64) as i32;
+
+                let new_content = match &src_content {
+                    // Source never set / explicitly empty → clear the target.
+                    None | Some(CellContent::Empty) => CellContent::Empty,
+                    Some(CellContent::Value(v)) => CellContent::Value(v.clone()),
+                    Some(CellContent::Formula { ast, .. }) => {
+                        let shifted = ast.shift(d_row, d_col);
+                        CellContent::Formula {
+                            text: shifted.to_formula_string(),
+                            ast: shifted,
+                            cached: None, // recomputed by recalc_all
+                        }
+                    }
+                };
+
+                let s = &mut self.sheets[sheet.0 as usize];
+                match new_content {
+                    CellContent::Empty => {
+                        s.cells.remove(&target);
+                    }
+                    content => {
+                        s.cells.insert(target, Cell { content });
+                    }
+                }
+                // The format rides with the cell: copy it, or clear the target's
+                // format when the source had none.
+                match &src_format {
+                    Some(code) => {
+                        s.formats.insert(target, code.clone());
+                    }
+                    None => {
+                        s.formats.remove(&target);
+                    }
+                }
+            }
+        }
+
+        // Targets' references changed en masse; rebuild edges, then recalc the
+        // whole workbook (one revision bump). Log every target so a viewport
+        // `changed_since` snapshot taken before the fill sees them.
+        self.rebuild_dependency_graph();
+        self.recalc_all();
+        for row in dst.start.row..=dst.end.row {
+            for col in dst.start.col..=dst.end.col {
+                self.log_change(sheet, CellAddress::new(row, col));
+            }
+        }
+    }
+
     /// Rebuild the entire cross-sheet dependency graph from the current formula
     /// ASTs. Used after a structural edit relocates addresses en masse, which
     /// invalidates every existing edge.
@@ -578,9 +680,11 @@ impl Workbook {
         let result = {
             let sheets = &self.sheets;
             let lookup = |sid: SheetId, a: CellAddress| {
+                // Normalise away `$` markers: a `$A$1` reference must resolve to
+                // the same cell as `A1` (cells are keyed by position only).
                 sheets
                     .get(sid.0 as usize)
-                    .and_then(|s| s.cells.get(&a))
+                    .and_then(|s| s.cells.get(&a.without_absolute()))
                     .map(|c| c.current_value())
                     .unwrap_or(CellValue::Empty)
             };
@@ -1212,5 +1316,146 @@ mod tests {
             wb.changed_since(s, recent),
             ChangeSet::Delta { .. }
         ));
+    }
+
+    // ── Absolute-reference resolution (regression) ───────────────────
+
+    #[test]
+    fn absolute_references_resolve_to_the_same_cell_as_relative() {
+        // A cell is keyed by position only, so $A$1 / $A1 / A$1 / A1 in a formula
+        // must all read the value at A1. (Regression: the evaluator once keyed the
+        // cell lookup by the reference's full address incl. its `$` flags, so an
+        // absolute reference missed the relatively-stored cell and read 0.)
+        let mut wb = Workbook::new();
+        let s = wb.add_sheet("S");
+        wb.set_value(s, cell(1, 1), CellValue::Number(7.0)); // A1
+        wb.set_formula(s, cell(1, 2), "=$A$1+$A1+A$1+A1").unwrap(); // B1 = 7*4
+        assert_eq!(wb.get_value(s, cell(1, 2)), Some(CellValue::Number(28.0)));
+        // And the absolute precedent is tracked: editing A1 recomputes B1.
+        wb.set_value(s, cell(1, 1), CellValue::Number(10.0));
+        assert_eq!(wb.get_value(s, cell(1, 2)), Some(CellValue::Number(40.0)));
+        // An absolute range corner resolves too: SUM($A$1:$A$2).
+        wb.set_value(s, cell(2, 1), CellValue::Number(5.0)); // A2
+        wb.set_formula(s, cell(1, 3), "=SUM($A$1:$A$2)").unwrap(); // C1 = 15
+        assert_eq!(wb.get_value(s, cell(1, 3)), Some(CellValue::Number(15.0)));
+    }
+
+    // ── Fill / replicate ─────────────────────────────────────────────
+
+    #[test]
+    fn fill_shifts_relative_formula_references_down_a_column() {
+        // Classic cross-foot: B1=A1*2, then fill B1 down B2:B4 over a column of
+        // inputs. Each filled formula tracks its row: B2 = A2*2, etc.
+        let mut wb = Workbook::new();
+        let s = wb.add_sheet("S");
+        for (r, v) in [(1, 10.0), (2, 20.0), (3, 30.0), (4, 40.0)] {
+            wb.set_value(s, cell(r, 1), CellValue::Number(v)); // A1..A4
+        }
+        wb.set_formula(s, cell(1, 2), "=A1*2").unwrap(); // B1 = 20
+        wb.fill(s, cell(1, 2), CellRange::new(cell(2, 2), cell(4, 2))); // fill B2:B4
+
+        assert_eq!(wb.get_value(s, cell(2, 2)), Some(CellValue::Number(40.0))); // A2*2
+        assert_eq!(wb.get_value(s, cell(3, 2)), Some(CellValue::Number(60.0))); // A3*2
+        assert_eq!(wb.get_value(s, cell(4, 2)), Some(CellValue::Number(80.0))); // A4*2
+    }
+
+    #[test]
+    fn fill_pins_absolute_references() {
+        // B1 = A1 * $A$1 ; filled down, the relative A1 tracks but $A$1 stays.
+        let mut wb = Workbook::new();
+        let s = wb.add_sheet("S");
+        wb.set_value(s, cell(1, 1), CellValue::Number(3.0)); // A1
+        wb.set_value(s, cell(2, 1), CellValue::Number(5.0)); // A2
+        wb.set_formula(s, cell(1, 2), "=A1*$A$1").unwrap(); // B1 = 9
+        wb.fill(s, cell(1, 2), CellRange::new(cell(2, 2), cell(2, 2))); // fill B2
+
+        // B2 = A2 * $A$1 = 5 * 3 = 15 (the absolute corner stayed at A1).
+        assert_eq!(wb.get_value(s, cell(2, 2)), Some(CellValue::Number(15.0)));
+    }
+
+    #[test]
+    fn fill_copies_literals_and_formats() {
+        // A literal source replicates unchanged, and its display format rides along.
+        let mut wb = Workbook::new();
+        let s = wb.add_sheet("S");
+        wb.set_value(s, cell(1, 1), CellValue::Number(1234.5));
+        wb.set_format(s, cell(1, 1), "#,##0.00");
+        wb.fill(s, cell(1, 1), CellRange::new(cell(1, 2), cell(1, 3))); // fill right B1:C1
+
+        assert_eq!(wb.get_value(s, cell(1, 2)), Some(CellValue::Number(1234.5)));
+        assert_eq!(wb.get_format(s, cell(1, 3)), Some("#,##0.00"));
+        assert_eq!(wb.get_display(s, cell(1, 2)), "1,234.50"); // format applied
+    }
+
+    #[test]
+    fn fill_off_grid_reference_becomes_ref_error() {
+        // B2 = A1 (one row up-left of B2). Fill it up into B1, where the relative
+        // ref would point at row 0 → #REF!.
+        let mut wb = Workbook::new();
+        let s = wb.add_sheet("S");
+        wb.set_value(s, cell(1, 1), CellValue::Number(7.0)); // A1
+        wb.set_formula(s, cell(2, 2), "=A1").unwrap(); // B2 = 7
+        wb.fill(s, cell(2, 2), CellRange::new(cell(1, 2), cell(1, 2))); // fill up into B1
+
+        assert_eq!(
+            wb.get_value(s, cell(1, 2)),
+            Some(CellValue::Error(SpreadsheetError::Ref))
+        );
+    }
+
+    #[test]
+    fn fill_from_empty_source_clears_targets() {
+        let mut wb = Workbook::new();
+        let s = wb.add_sheet("S");
+        wb.set_value(s, cell(2, 1), CellValue::Number(9.0)); // A2 set
+        // A1 was never set (empty). Filling it over A2 clears A2.
+        wb.fill(s, cell(1, 1), CellRange::new(cell(2, 1), cell(2, 1)));
+        assert_eq!(wb.get_value(s, cell(2, 1)), None);
+    }
+
+    #[test]
+    fn fill_oversized_range_is_rejected_wholesale() {
+        // A fill spanning more than MAX_RANGE_CELLS is a no-op (DoS guard), so a
+        // pre-existing cell in that range is left untouched rather than overwritten.
+        let mut wb = Workbook::new();
+        let s = wb.add_sheet("S");
+        wb.set_value(s, cell(5, 5), CellValue::Number(42.0));
+        wb.set_value(s, cell(1, 1), CellValue::Number(1.0));
+        // 1 .. 2^20 rows in one column is exactly the cap; add a row to exceed it.
+        let huge = CellRange::new(cell(1, 1), cell((1 << 20) + 1, 1));
+        assert!(huge.cell_count() > MAX_RANGE_CELLS);
+        wb.fill(s, cell(1, 1), huge);
+        assert_eq!(wb.get_value(s, cell(5, 5)), Some(CellValue::Number(42.0))); // untouched
+    }
+
+    #[test]
+    fn fill_at_high_coordinate_does_not_overflow() {
+        // A single-cell fill anchored near u32::MAX passes the cell_count guard
+        // (count = 1) but its offset arithmetic must not overflow i32 (would
+        // panic in debug/test, wrap in release). Filling a literal far down the
+        // sheet just copies it; a formula's huge negative shift collapses to #REF!.
+        let mut wb = Workbook::new();
+        let s = wb.add_sheet("S");
+        let hi = 2_147_483_648; // > i32::MAX
+        wb.set_value(s, cell(hi, 1), CellValue::Number(5.0));
+        // Fill that literal one row further down — no panic, value copied.
+        wb.fill(s, cell(hi, 1), CellRange::new(cell(hi + 1, 1), cell(hi + 1, 1)));
+        assert_eq!(wb.get_value(s, cell(hi + 1, 1)), Some(CellValue::Number(5.0)));
+        // A formula at the high anchor filled back to row 1 shifts by a huge
+        // negative delta → its reference goes off-grid → #REF! (no overflow).
+        wb.set_formula(s, cell(hi, 2), "=A1").unwrap();
+        wb.fill(s, cell(hi, 2), CellRange::new(cell(1, 2), cell(1, 2)));
+        assert_eq!(
+            wb.get_value(s, cell(1, 2)),
+            Some(CellValue::Error(SpreadsheetError::Ref))
+        );
+    }
+
+    #[test]
+    fn fill_unknown_sheet_is_noop() {
+        let mut wb = Workbook::new();
+        wb.fill(SheetId(9), cell(1, 1), CellRange::new(cell(1, 1), cell(2, 2)));
+        // No panic, nothing created.
+        assert_eq!(wb.sheet_count(), 0);
     }
 }

--- a/lessons.md
+++ b/lessons.md
@@ -769,3 +769,25 @@ Net: N6 is a multi-part item (proof-mechanism design + Nib type-lookup fix + JVM
 backend fixes), NOT a one-line frontend wiring. The native-AOT E2 leg (PR #5887,
 merged) IS real — its `aarch64-backend` proof installs and *calls* the generated
 code and reads the raw u64 (44), so it is not exit-code-confounded.
+
+## Identity must be a SUBSET of fields when a rich struct is a map/graph key (spreadsheet-core fill PR)
+
+`CellAddress` carries `{row, col, absolute_row, absolute_col}` and derives
+`Eq`/`Hash` over **all four** fields. But a cell's *identity* is its position
+(`row, col`) only — the `$` markers just steer copy/fill shifting. The engine
+stored cells (and dependency-graph nodes) keyed by the bare `CellAddress`, yet
+the evaluator looked them up with the address taken **straight from the formula's
+`Ref`**, flags and all. So `=$A$1` built a lookup key `{1,1,true,true}` that never
+matched the relatively-stored `{1,1,false,false}` cell → it read as empty (**0**),
+and editing `A1` never recomputed a dependent that referenced it absolutely.
+
+Nobody had ever written a test that *evaluated* an absolute reference, so the bug
+sat latent until the fill feature (whose whole point is "`$A$1` stays pinned")
+surfaced it. Fix: a `without_absolute()` normaliser applied at the two key
+boundaries (the evaluator's `lookup` closure and `collect_refs`).
+
+Lesson: when a struct with "decorative" fields is used as a `HashMap` key or graph
+node, either (a) don't derive `Hash`/`Eq` over the decorative fields, or (b)
+normalise to the identity subset at **every** key boundary — and add a test that
+exercises the decorated form through the real lookup path, not just the AST. A
+derive that silently widens identity is a landmine.


### PR DESCRIPTION
## What

Adds **drag-fill** to the shared spreadsheet engine — the next cross-cutting engine feature (task #47) — plus a companion fix for a pre-existing latent bug the feature surfaced.

### Fill
- **`FormulaAst::shift(d_row, d_col)`** (`ast.rs`) — a pure copy/paste reference rewrite, the sibling of `adjust` (structural edits). Relative refs track the offset (`=A1` filled down → `=A2`); **absolute (`$`) refs stay pinned**; a ref shifted off the top/left edge → `#REF!`.
- **`Workbook::fill(sheet, src, dst)`** (`workbook.rs`) — replicate the `src` cell across the `dst` range: formulas shifted per-target, literals copied unchanged, an empty source clears each target, and the source's display **format rides along**. One recalc transaction; unknown sheet is a no-op; a `dst` over `MAX_RANGE_CELLS` is rejected wholesale (DoS guard).

### Fix — absolute references now resolve
A cell is keyed by **position** only, but the evaluator's `lookup` and `collect_refs` used a reference's *full* address — including its `$` flags — as the cell-store / dependency-graph key. So `=$A$1` missed the relatively-stored `A1` cell and **read as 0**, and editing `A1` didn't recompute a dependent that referenced it absolutely. New `CellAddress::without_absolute()` normalises the address at those two boundaries. No test had ever *evaluated* an absolute reference, so the bug sat latent until fill (whose whole point is "`$A$1` stays pinned") surfaced it. (Recorded in `lessons.md`.)

## Security review

Caught and fixed a **HIGH**: the per-target offset `row as i32 - src.row as i32` overflows for a fill anchored at a high (near-`u32::MAX`) coordinate that clears the `cell_count` guard — a panic in debug/test, a silent wrap in release. Now computed in `i64` and clamped into `shift`'s `i32` contract (off-grid results still collapse to `#REF!`), with a high-coordinate regression test. Re-review clear; `without_absolute` normalization confirmed correct (only strips flags, never redirects to a different cell).

## Verification

- `cargo test -p spreadsheet-core` — **148 lib tests pass** (fill, absolute-ref regression, shift, high-coordinate overflow).
- Downstream consumers re-tested (the `lookup`/`collect_refs` change is shared): `spreadsheet-core-wasm` / `spreadsheet-capi` / `spreadsheet-wasm` — all green.
- Library clippy clean. (The `--all-targets` `approx_constant` errors are pre-existing `3.14…` test literals in `cell.rs`/`dispatch.rs`/`parser.rs`, untouched here.)

`spreadsheet-core` 0.6.0 → 0.7.0.

## Next

Expose `fill` through the 3 facades, then wire drag-fill into the demos — the same engine→facades→demos arc as the formatting rollout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)