### PR TITLE
feat(MA-3d): matlab-runtime + matlab-repl + the `matlab` binary

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -205,6 +205,8 @@ members = [
     "macsyma-wasm",
     "matlab-lexer",
     "matlab-parser",
+    "matlab-runtime",
+    "matlab-repl",
     "logic-gates",
     "logic-core",
     "lookup-core",

--- a/code/packages/rust/matlab-repl/BUILD
+++ b/code/packages/rust/matlab-repl/BUILD
@@ -1,0 +1,1 @@
+cargo test -p coding-adventures-matlab-repl -- --nocapture

--- a/code/packages/rust/matlab-repl/BUILD_windows
+++ b/code/packages/rust/matlab-repl/BUILD_windows
@@ -1,0 +1,1 @@
+cargo test -p coding-adventures-matlab-repl -- --nocapture

--- a/code/packages/rust/matlab-repl/CHANGELOG.md
+++ b/code/packages/rust/matlab-repl/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [0.1.0] - 2026-06-16
+
+### Added
+
+- Initial release — the interactive REPL and the **`matlab` binary** (item
+  MA-3d), a sibling of `s-repl`/`r-repl` over the `matlab-runtime` interpreter.
+- `MatlabRepl` with a persistent workspace, `>> `/`... ` prompts, and `quit`/
+  `exit`/EOF handling; `run()` drives a full stdio session.
+- **Line continuation** across open brackets *and* unterminated block keywords
+  (`if`/`for`/`while`/`switch`/`try`/`function`), counting `end` as a block
+  closer only at bracket depth 0 (so `A(end)` does not open a block). `%` line
+  comments and `"`-strings are skipped.
+- Errors are surfaced (`Error: …`) without ending the session.

--- a/code/packages/rust/matlab-repl/Cargo.toml
+++ b/code/packages/rust/matlab-repl/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "coding-adventures-matlab-repl"
+version = "0.1.0"
+edition = "2021"
+description = "Interactive REPL and `matlab` binary for the MATLAB language"
+
+[dependencies]
+coding-adventures-matlab-runtime = { path = "../matlab-runtime" }
+
+[[bin]]
+name = "matlab"
+path = "src/main.rs"

--- a/code/packages/rust/matlab-repl/README.md
+++ b/code/packages/rust/matlab-repl/README.md
@@ -1,0 +1,35 @@
+# MATLAB REPL
+
+The interactive REPL and the **`matlab` binary** for the MATLAB language. Wraps a
+persistent [`matlab-runtime`](../matlab-runtime) `Interpreter` and adds console
+behaviours. Item **MA-3d**; sibling of `s-repl`/`r-repl`.
+
+## Usage
+
+```sh
+cargo run -p coding-adventures-matlab-repl --bin matlab
+```
+
+```matlab
+>> A = [1 2; 3 4];
+>> A * A          % matrix product, executed through the array-runtime planner
+ans =
+
+ 7  10
+15  22
+
+>> sum(A(:, 1))
+ans = 4
+>> quit
+```
+
+Lines **continue** across open brackets and unterminated
+`if`/`for`/`while`/`switch`/`try`/`function` blocks (the `... ` prompt); `quit`
+or `exit` (or Ctrl-D) leaves. Errors are shown, not fatal — the session
+continues.
+
+## Testing
+
+```sh
+cargo test -p coding-adventures-matlab-repl
+```

--- a/code/packages/rust/matlab-repl/required_capabilities.json
+++ b/code/packages/rust/matlab-repl/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "rust/matlab-repl",
+  "capabilities": ["stdio"],
+  "justification": "An interactive console: the `matlab` binary reads MATLAB source from stdin and writes results to stdout. No filesystem, network, or process access beyond standard streams."
+}

--- a/code/packages/rust/matlab-repl/src/lib.rs
+++ b/code/packages/rust/matlab-repl/src/lib.rs
@@ -1,0 +1,231 @@
+//! # MATLAB REPL — an interactive Read-Eval-Print loop for MATLAB.
+//!
+//! [`MatlabRepl`] wraps a persistent [`Interpreter`] and adds the interactive
+//! behaviours a console needs: line continuation across open brackets and
+//! unterminated `if`/`for`/`while`/`switch`/`try`/`function` blocks, and echoing
+//! of unsuppressed results. It is the sibling of `s-repl`/`r-repl`; only the
+//! interpreter differs. See `code/specs/MA01-matlab-language.md`.
+//!
+//! Hand-rolled rather than built on the generic `repl` crate because the
+//! interpreter is single-threaded; a console session is sequential anyway.
+
+use coding_adventures_matlab_runtime::Interpreter;
+use std::io::{BufRead, Write};
+
+/// What the REPL should do after being fed one physical line.
+#[derive(Debug, PartialEq, Eq)]
+pub enum ReplResponse {
+    /// Text to display (may be empty).
+    Output(String),
+    /// The current statement is incomplete; read another line (`... ` prompt).
+    NeedMore,
+    /// End the session.
+    Quit,
+}
+
+/// A persistent interactive MATLAB session.
+pub struct MatlabRepl {
+    interp: Interpreter,
+    buffer: String,
+}
+
+impl Default for MatlabRepl {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl MatlabRepl {
+    pub fn new() -> Self {
+        MatlabRepl {
+            interp: Interpreter::new(),
+            buffer: String::new(),
+        }
+    }
+
+    /// `>> ` for a fresh statement, `... ` while continuing an incomplete one.
+    pub fn prompt(&self) -> &'static str {
+        if self.buffer.is_empty() {
+            ">> "
+        } else {
+            "... "
+        }
+    }
+
+    /// Feed one physical input line (without its trailing newline).
+    pub fn feed(&mut self, line: &str) -> ReplResponse {
+        if self.buffer.is_empty() {
+            match line.trim() {
+                "quit" | "exit" | "quit()" | "exit()" => return ReplResponse::Quit,
+                _ => {}
+            }
+        }
+
+        self.buffer.push_str(line);
+        self.buffer.push('\n');
+
+        if is_incomplete(&self.buffer) {
+            return ReplResponse::NeedMore;
+        }
+
+        let src = std::mem::take(&mut self.buffer);
+        if src.trim().is_empty() {
+            return ReplResponse::Output(String::new());
+        }
+        match self.interp.feed(&src) {
+            Ok(text) => ReplResponse::Output(text),
+            Err(e) => ReplResponse::Output(format!("Error: {e}\n")),
+        }
+    }
+
+    pub fn is_continuing(&self) -> bool {
+        !self.buffer.is_empty()
+    }
+}
+
+/// Is the accumulated source an incomplete statement? It is incomplete while a
+/// bracket is open, a `"`-string is unterminated, or a block keyword
+/// (`if`/`for`/`while`/`switch`/`try`/`function`) has no matching `end`. `%` line
+/// comments and `"` strings are skipped; `'` is treated as transpose (char
+/// arrays are single-line, so they never extend a statement).
+fn is_incomplete(src: &str) -> bool {
+    let mut bracket: i32 = 0;
+    let mut blocks: i32 = 0;
+    let mut in_string = false;
+
+    for raw_line in src.lines() {
+        let mut word = String::new();
+        let flush = |w: &mut String, blocks: &mut i32, bracket: i32| {
+            if !w.is_empty() {
+                match w.as_str() {
+                    "if" | "for" | "while" | "switch" | "try" | "function" | "parfor" => {
+                        *blocks += 1
+                    }
+                    // `end` closes a block only at bracket depth 0; inside
+                    // brackets it is the index sentinel.
+                    "end" if bracket == 0 => *blocks -= 1,
+                    _ => {}
+                }
+                w.clear();
+            }
+        };
+        for ch in raw_line.chars() {
+            if in_string {
+                if ch == '"' {
+                    in_string = false;
+                }
+                continue;
+            }
+            match ch {
+                '%' => break, // line comment: ignore the rest of the line
+                '"' => {
+                    flush(&mut word, &mut blocks, bracket);
+                    in_string = true;
+                }
+                '(' | '[' | '{' => {
+                    flush(&mut word, &mut blocks, bracket);
+                    bracket += 1;
+                }
+                ')' | ']' | '}' => {
+                    flush(&mut word, &mut blocks, bracket);
+                    bracket -= 1;
+                }
+                c if c.is_alphanumeric() || c == '_' => word.push(c),
+                _ => flush(&mut word, &mut blocks, bracket),
+            }
+        }
+        flush(&mut word, &mut blocks, bracket);
+    }
+    bracket > 0 || blocks > 0 || in_string
+}
+
+/// Drive a full interactive MATLAB session over the given reader and writer.
+pub fn run<R: BufRead, W: Write>(mut reader: R, mut writer: W) -> std::io::Result<()> {
+    let mut repl = MatlabRepl::new();
+    writeln!(writer, "MATLAB (on array-runtime) — type quit to exit.")?;
+
+    loop {
+        write!(writer, "{}", repl.prompt())?;
+        writer.flush()?;
+
+        let mut line = String::new();
+        if reader.read_line(&mut line)? == 0 {
+            writeln!(writer)?;
+            break;
+        }
+        let line = line.strip_suffix('\n').unwrap_or(&line);
+        let line = line.strip_suffix('\r').unwrap_or(line);
+
+        match repl.feed(line) {
+            ReplResponse::Output(text) => {
+                write!(writer, "{text}")?;
+                writer.flush()?;
+            }
+            ReplResponse::NeedMore => {}
+            ReplResponse::Quit => break,
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn echoes_a_result_and_suppresses_with_semicolon() {
+        let mut r = MatlabRepl::new();
+        assert!(matches!(r.feed("2 + 2"), ReplResponse::Output(t) if t.contains("4")));
+        assert_eq!(r.feed("x = 5;"), ReplResponse::Output(String::new()));
+    }
+
+    #[test]
+    fn continues_across_open_brackets() {
+        let mut r = MatlabRepl::new();
+        assert_eq!(r.feed("A = [1 2"), ReplResponse::NeedMore);
+        assert!(r.is_continuing());
+        assert!(matches!(r.feed("3 4];"), ReplResponse::Output(_)));
+        assert!(!r.is_continuing());
+    }
+
+    #[test]
+    fn continues_across_an_unterminated_block() {
+        let mut r = MatlabRepl::new();
+        assert_eq!(r.feed("s = 0;"), ReplResponse::Output(String::new()));
+        assert_eq!(r.feed("for i = 1:3"), ReplResponse::NeedMore);
+        assert_eq!(r.feed("  s = s + i;"), ReplResponse::NeedMore);
+        assert!(matches!(r.feed("end"), ReplResponse::Output(_)));
+        assert!(matches!(r.feed("s"), ReplResponse::Output(t) if t.contains("6")));
+    }
+
+    #[test]
+    fn end_inside_an_index_does_not_open_a_block() {
+        // `A(end)` must not be read as opening a block via the word `end`.
+        let mut r = MatlabRepl::new();
+        r.feed("A = [10 20 30];");
+        assert!(matches!(r.feed("A(end)"), ReplResponse::Output(t) if t.contains("30")));
+    }
+
+    #[test]
+    fn quit_commands() {
+        assert_eq!(MatlabRepl::new().feed("quit"), ReplResponse::Quit);
+        assert_eq!(MatlabRepl::new().feed("exit"), ReplResponse::Quit);
+    }
+
+    #[test]
+    fn errors_are_shown_not_fatal() {
+        let mut r = MatlabRepl::new();
+        assert!(matches!(r.feed("undefined_var"), ReplResponse::Output(t) if t.contains("Error")));
+        // The session keeps going.
+        assert!(matches!(r.feed("1 + 1"), ReplResponse::Output(t) if t.contains("2")));
+    }
+
+    #[test]
+    fn run_drives_a_session_to_eof() {
+        let input = b"x = 3;\nx * 2\nquit\n" as &[u8];
+        let mut output = Vec::new();
+        run(input, &mut output).unwrap();
+        let text = String::from_utf8(output).unwrap();
+        assert!(text.contains("6"));
+    }
+}

--- a/code/packages/rust/matlab-repl/src/main.rs
+++ b/code/packages/rust/matlab-repl/src/main.rs
@@ -1,0 +1,17 @@
+//! The `matlab` binary — an interactive prompt for the MATLAB language.
+//!
+//! Reads one line at a time (continuing across open brackets and unterminated
+//! `if`/`for`/`while`/`function` blocks), evaluates over `array-runtime`, and
+//! prints the result. Type `quit` / `exit` (or send EOF with Ctrl-D) to leave.
+//! All logic lives in [`coding_adventures_matlab_repl::run`].
+
+use std::io;
+
+fn main() {
+    let stdin = io::stdin();
+    let stdout = io::stdout();
+    if let Err(e) = coding_adventures_matlab_repl::run(stdin.lock(), stdout.lock()) {
+        eprintln!("matlab: I/O error: {e}");
+        std::process::exit(1);
+    }
+}

--- a/code/packages/rust/matlab-runtime/BUILD
+++ b/code/packages/rust/matlab-runtime/BUILD
@@ -1,0 +1,1 @@
+cargo test -p coding-adventures-matlab-runtime -- --nocapture

--- a/code/packages/rust/matlab-runtime/BUILD_windows
+++ b/code/packages/rust/matlab-runtime/BUILD_windows
@@ -1,0 +1,1 @@
+cargo test -p coding-adventures-matlab-runtime -- --nocapture

--- a/code/packages/rust/matlab-runtime/CHANGELOG.md
+++ b/code/packages/rust/matlab-runtime/CHANGELOG.md
@@ -1,0 +1,23 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [0.1.0] - 2026-06-16
+
+### Added
+
+- Initial release — **MA-3d** of the MATLAB frontend: a tree-walking evaluator
+  over `array-runtime` (spec [`MA01`](../../../specs/MA01-matlab-language.md)).
+- `Interpreter` (persistent workspace) + `feed`/`eval` entry points producing the
+  MATLAB prompt echo (`x =` / `ans =`, `;` suppresses).
+- **Matrix products lower to `array_runtime::execute(MatMul, …)`** — the planner
+  picks the backend (CPU now, GPU when registered), so `A * B` is accelerated by
+  cost with no language-level GPU code. Element-wise operators use the
+  `array_runtime::ops` reference path (exact `f64`, scalar broadcasting).
+- Matrix/range literals, `+ - .* ./ .^ * ' ~`, comparisons and logicals,
+  variables/assignment, 1-based indexing (`A(i)`, `A(i,j)`, `A(:,k)`, `A(end)`),
+  `if`/`for`/`while`, and the core builtins (`zeros`/`ones`/`eye`/`size`/`length`/
+  `numel`/`sum`/`mean`/`max`/`min`/`abs`/`sqrt`/`transpose`/`disp`).
+- DoS bounds: range length and constructor dimensions are capped (`1<<26`), and
+  `while` has an iteration limit, so `1:1e18`, `zeros(1e18)`, and runaway loops
+  are clean errors.

--- a/code/packages/rust/matlab-runtime/Cargo.toml
+++ b/code/packages/rust/matlab-runtime/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "coding-adventures-matlab-runtime"
+version = "0.1.0"
+edition = "2021"
+description = "Tree-walking evaluator for the MATLAB language over array-runtime"
+
+[dependencies]
+coding-adventures-matlab-parser = { path = "../matlab-parser" }
+array-runtime = { package = "coding-adventures-array-runtime", path = "../array-runtime" }
+parser = { path = "../parser" }

--- a/code/packages/rust/matlab-runtime/README.md
+++ b/code/packages/rust/matlab-runtime/README.md
@@ -1,0 +1,52 @@
+# MATLAB Runtime
+
+A tree-walking evaluator for the [MATLAB](https://en.wikipedia.org/wiki/MATLAB)
+language, over [`array-runtime`](../array-runtime). Item **MA-3d** of the MATLAB
+frontend (spec [`MA01`](../../../specs/MA01-matlab-language.md)): the piece that
+makes the MATLAB lexer/parser executable.
+
+## The payoff
+
+A matrix product `A * B` lowers to `array_runtime::execute(MatMul, …)`, which
+**plans the operation and runs it on the cheapest available backend** — CPU
+today, a GPU executor the moment one is registered. So matrix acceleration is
+automatic and *by cost*, with no `gpuArray` and no language-level GPU code: the
+whole MA-1 → MA-2 substrate lights up through real MATLAB syntax.
+
+```rust
+use coding_adventures_matlab_runtime::eval;
+// A * A is executed through the array-runtime planner → [[7 10], [15 22]].
+let out = eval("A = [1 2; 3 4]; A * A\n").unwrap();
+assert!(out.contains('7') && out.contains("22"));
+```
+
+Unlike R (which reuses the shared S evaluator), MATLAB has its **own** evaluator,
+because its value model is the `array-runtime` `Array` and its semantics are
+MATLAB's: 1-based, column-major, matrix-first.
+
+## What it evaluates
+
+- Scalars, **matrix literals** `[1 2; 3 4]`, **ranges** `a:b`/`a:b:c`.
+- Operators: `+ - .* ./ .^` (element-wise, broadcasting, via `array_runtime::ops`),
+  `*` (matrix product, via `execute`; scalar `*` is element-wise), unary `- ~`,
+  transpose `'`/`.'`, comparisons (`== ~= < > <= >=` → `0`/`1`), `& | && ||`.
+- **Variables and assignment**, with `;`-suppressed display and the `x =` / `ans =`
+  echo.
+- **1-based indexing**: `A(i)` (linear, column-major), `A(i,j)`, `A(:,k)`,
+  `A(i,:)`, `A(:)`, and the `A(end)` sentinel.
+- **Control flow**: `if/elseif/else`, `for`, `while`.
+- **Builtins**: `zeros`, `ones`, `eye`, `size`, `length`, `numel`, `sum`, `mean`,
+  `max`, `min`, `abs`, `sqrt`, `transpose`, `disp`.
+
+### Deferred (documented)
+
+User `function` definitions, anonymous `@(x)`, cell arrays, `switch`/`try`
+execution, matrix solve `\`/`/`, matrix power `^`, indexed assignment
+(`A(i)=…`), and multi-assign `[a,b]=…`. Execution is `f32`-precision for `*`
+(the `array-runtime` executor's dtype); element-wise ops stay exact `f64`.
+
+## Testing
+
+```sh
+cargo test -p coding-adventures-matlab-runtime
+```

--- a/code/packages/rust/matlab-runtime/required_capabilities.json
+++ b/code/packages/rust/matlab-runtime/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "rust/matlab-runtime",
+  "capabilities": [],
+  "justification": "Pure computation: a tree-walking evaluator over the in-memory array-runtime value model. No filesystem, network, or process access (the REPL crate owns stdio)."
+}

--- a/code/packages/rust/matlab-runtime/src/builtins.rs
+++ b/code/packages/rust/matlab-runtime/src/builtins.rs
@@ -1,0 +1,122 @@
+//! The core MATLAB built-in functions, over `array-runtime`.
+//!
+//! This is the starter set a textbook session needs: array constructors
+//! (`zeros`/`ones`/`eye`), shape queries (`size`/`length`/`numel`), the
+//! whole-array reductions (`sum`/`mean`/`max`/`min`), element-wise math
+//! (`abs`/`sqrt`), `transpose`, and `disp`. More of the library follows; this is
+//! the seam each addition slots into.
+
+use crate::value::MatValue;
+use array_runtime::{ops, Array};
+
+/// Dispatch a builtin by name. Returns `Err` for an unknown name (which the
+/// evaluator reports as an undefined function/variable).
+pub fn call(name: &str, args: &[MatValue]) -> Result<MatValue, String> {
+    match name {
+        "zeros" => constructor(name, args, 0.0),
+        "ones" => constructor(name, args, 1.0),
+        "eye" => eye(args),
+        "size" => size(args),
+        "length" => length(args),
+        "numel" => numel(args),
+        "sum" => reduce(name, args, ops::sum),
+        "mean" => reduce(name, args, ops::mean),
+        "max" => reduce(name, args, ops::max),
+        "min" => reduce(name, args, ops::min),
+        "abs" => unary(name, args, f64::abs),
+        "sqrt" => unary(name, args, f64::sqrt),
+        "transpose" => {
+            let a = arg_num(name, args, 0)?;
+            Ok(MatValue::Num(ops::transpose(a)))
+        }
+        "disp" => {
+            let _ = one_arg(name, args)?;
+            Ok(MatValue::Num(
+                Array::from_shape(vec![], vec![0, 0]).unwrap(),
+            )) // invisible
+        }
+        other => Err(format!("matlab-runtime: '{other}' is not a known function")),
+    }
+}
+
+/// `zeros(n)` → `n×n`; `zeros(r, c)` → `r×c`.
+fn constructor(name: &str, args: &[MatValue], fill: f64) -> Result<MatValue, String> {
+    let (r, c) = dims(name, args)?;
+    Ok(MatValue::Num(Array::filled(r, c, fill)))
+}
+
+/// `eye(n)` → the `n×n` identity.
+fn eye(args: &[MatValue]) -> Result<MatValue, String> {
+    let n = count(arg_num("eye", args, 0)?, "eye")?;
+    Ok(MatValue::Num(Array::eye(n)))
+}
+
+/// `size(A)` → the `1×2` row vector `[rows cols]`.
+fn size(args: &[MatValue]) -> Result<MatValue, String> {
+    let a = arg_num("size", args, 0)?;
+    Array::from_shape(vec![a.nrows() as f64, a.ncols() as f64], vec![1, 2]).map(MatValue::Num)
+}
+
+/// `length(A)` → the largest dimension (0 for an empty array).
+fn length(args: &[MatValue]) -> Result<MatValue, String> {
+    let a = arg_num("length", args, 0)?;
+    let len = if a.is_empty() {
+        0
+    } else {
+        a.nrows().max(a.ncols())
+    };
+    Ok(MatValue::scalar(len as f64))
+}
+
+/// `numel(A)` → the element count.
+fn numel(args: &[MatValue]) -> Result<MatValue, String> {
+    Ok(MatValue::scalar(arg_num("numel", args, 0)?.len() as f64))
+}
+
+/// A whole-array reduction to a scalar.
+fn reduce(name: &str, args: &[MatValue], f: fn(&Array) -> f64) -> Result<MatValue, String> {
+    Ok(MatValue::scalar(f(arg_num(name, args, 0)?)))
+}
+
+/// An element-wise unary math function.
+fn unary(name: &str, args: &[MatValue], f: fn(f64) -> f64) -> Result<MatValue, String> {
+    let a = arg_num(name, args, 0)?;
+    Array::from_shape(a.data().iter().map(|&x| f(x)).collect(), a.shape().to_vec())
+        .map(MatValue::Num)
+}
+
+// --- argument helpers ----------------------------------------------------
+
+/// Interpret a constructor's arguments: `f(n)` → `(n, n)`, `f(r, c)` → `(r, c)`.
+fn dims(name: &str, args: &[MatValue]) -> Result<(usize, usize), String> {
+    match args {
+        [n] => {
+            let n = count(n.as_num(name)?, name)?;
+            Ok((n, n))
+        }
+        [r, c] => Ok((count(r.as_num(name)?, name)?, count(c.as_num(name)?, name)?)),
+        _ => Err(format!("{name}: expected 1 or 2 size arguments")),
+    }
+}
+
+/// Read a non-negative dimension count from a scalar array, capped so a crafted
+/// `zeros(1e18)` is a clean error rather than an allocation abort.
+fn count(a: &Array, name: &str) -> Result<usize, String> {
+    const MAX_DIM: f64 = (1u64 << 26) as f64;
+    let x = a.data().first().copied().unwrap_or(0.0);
+    if !(0.0..=MAX_DIM).contains(&x) {
+        return Err(format!("{name}: size must be in 0..={}", MAX_DIM as u64));
+    }
+    Ok(x.round() as usize)
+}
+
+fn one_arg<'a>(name: &str, args: &'a [MatValue]) -> Result<&'a MatValue, String> {
+    args.first()
+        .ok_or_else(|| format!("{name}: expected an argument"))
+}
+
+fn arg_num<'a>(name: &str, args: &'a [MatValue], i: usize) -> Result<&'a Array, String> {
+    args.get(i)
+        .ok_or_else(|| format!("{name}: expected at least {} argument(s)", i + 1))?
+        .as_num(name)
+}

--- a/code/packages/rust/matlab-runtime/src/eval.rs
+++ b/code/packages/rust/matlab-runtime/src/eval.rs
@@ -1,0 +1,726 @@
+//! The tree-walking evaluator.
+//!
+//! [`Interpreter`] walks the [`GrammarASTNode`] tree from `matlab-parser` and
+//! computes [`MatValue`]s over `array-runtime`. The headline: a matrix product
+//! `A * B` lowers to [`array_runtime::execute`]`(MatMul, …)`, which plans the op
+//! and runs it on the cheapest available backend (CPU today, a GPU executor the
+//! moment one is registered) — so `gpuArray`-style acceleration is automatic and
+//! by cost, with no language-level GPU code. Element-wise operators use the
+//! `array_runtime::ops` reference path (exact `f64`, with scalar broadcasting).
+
+use crate::builtins;
+use crate::value::{echo, MatValue};
+use array_runtime::{execute, ops, Array, Kernel};
+use parser::grammar_parser::{ASTNodeOrToken, GrammarASTNode};
+use std::cell::Cell;
+use std::collections::HashMap;
+
+/// A persistent MATLAB session: a variable workspace plus the value of `end`
+/// currently in scope (set while evaluating an index expression).
+pub struct Interpreter {
+    vars: HashMap<String, MatValue>,
+    end_value: Cell<Option<f64>>,
+}
+
+/// One index argument: a value, or a bare colon meaning "the whole dimension".
+enum Index {
+    Colon,
+    At(MatValue),
+}
+
+impl Default for Interpreter {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Interpreter {
+    pub fn new() -> Self {
+        Interpreter {
+            vars: HashMap::new(),
+            end_value: Cell::new(None),
+        }
+    }
+
+    /// Evaluate a whole program (the `program` node), returning the prompt echo
+    /// for every statement whose result is *not* suppressed by a trailing `;`.
+    pub fn run(&mut self, program: &GrammarASTNode) -> Result<String, String> {
+        let mut out = String::new();
+        for line in node_children(program) {
+            if line.rule_name != "statement_line" {
+                continue;
+            }
+            if let Some(text) = self.eval_statement_line(line)? {
+                out.push_str(&text);
+                out.push('\n');
+            }
+        }
+        Ok(out)
+    }
+
+    /// Evaluate one statement line. Returns `Some(echo)` for a visible result,
+    /// `None` when suppressed (`;`) or when the line is just a separator.
+    fn eval_statement_line(&mut self, line: &GrammarASTNode) -> Result<Option<String>, String> {
+        let stmt = match first_node(line) {
+            Some(n) if n.rule_name == "statement" => n,
+            _ => return Ok(None), // a bare terminator / blank line
+        };
+        // A trailing `;` suppresses display; a newline or comma shows it. The
+        // terminator is a `stmt_term` child node holding the punctuation token.
+        let suppressed = line.children.iter().any(|c| match c {
+            ASTNodeOrToken::Node(n) if n.rule_name == "stmt_term" => n
+                .children
+                .iter()
+                .any(|t| matches!(t, ASTNodeOrToken::Token(t) if t.value == ";")),
+            ASTNodeOrToken::Token(t) => t.value == ";",
+            _ => false,
+        });
+
+        let inner = only_node(stmt)?;
+        match inner.rule_name.as_str() {
+            "if_stmt" => {
+                self.eval_if(inner)?;
+                Ok(None)
+            }
+            "for_stmt" => {
+                self.eval_for(inner)?;
+                Ok(None)
+            }
+            "while_stmt" => {
+                self.eval_while(inner)?;
+                Ok(None)
+            }
+            // An expression statement: either an assignment (`x = …`) or a bare
+            // expression (echoed as `ans`).
+            "expr" => {
+                let (name, value) = self.eval_expr_or_assign(inner)?;
+                if suppressed {
+                    Ok(None)
+                } else {
+                    Ok(Some(echo(&name, &value)))
+                }
+            }
+            other => Err(format!("matlab-runtime: unsupported statement '{other}'")),
+        }
+    }
+
+    /// Evaluate an `expr`. If it is a top-level assignment `lhs = rhs`, bind the
+    /// variable and report its name; otherwise evaluate it and report `ans`
+    /// (also binding `ans`, as MATLAB does).
+    fn eval_expr_or_assign(&mut self, expr: &GrammarASTNode) -> Result<(String, MatValue), String> {
+        let assignment = only_node(expr)?; // expr = assignment
+                                           // assignment = logical_or [ EQ assignment ]
+        let kids = node_children(assignment);
+        let has_eq = assignment
+            .children
+            .iter()
+            .any(|c| matches!(c, ASTNodeOrToken::Token(t) if t.value == "="));
+        if has_eq && kids.len() == 2 {
+            // The LHS must be a plain variable name (indexed-assignment is a
+            // documented deferral).
+            let name = lhs_name(kids[0]).ok_or_else(|| {
+                "matlab-runtime: assignment target must be a variable".to_string()
+            })?;
+            let value = self.eval_node(kids[1])?;
+            self.vars.insert(name.clone(), value.clone());
+            Ok((name, value))
+        } else {
+            let value = self.eval_node(assignment)?;
+            self.vars.insert("ans".to_string(), value.clone());
+            Ok(("ans".to_string(), value))
+        }
+    }
+
+    /// Evaluate any expression node, dispatching by rule name.
+    fn eval_node(&self, node: &GrammarASTNode) -> Result<MatValue, String> {
+        match node.rule_name.as_str() {
+            "expr" | "assignment" | "statement" => self.eval_node(only_node(node)?),
+            "logical_or" | "logical_and" | "bit_or" | "bit_and" | "comparison" | "additive"
+            | "multiplicative" => self.eval_binary_chain(node),
+            "colon_expr" => self.eval_colon(node),
+            "unary" => self.eval_unary(node),
+            "power" => self.eval_power(node),
+            "postfix" => self.eval_postfix(node),
+            "primary" => self.eval_primary(node),
+            "group" => self.eval_node(only_node(node)?),
+            "matrix_literal" => self.eval_matrix(node),
+            other => Err(format!("matlab-runtime: cannot evaluate '{other}'")),
+        }
+    }
+
+    /// Left-associative fold of a binary-operator chain (`a op b op c …`). The
+    /// operator token between operands selects the operation.
+    fn eval_binary_chain(&self, node: &GrammarASTNode) -> Result<MatValue, String> {
+        let mut acc: Option<MatValue> = None;
+        let mut op: Option<String> = None;
+        for child in &node.children {
+            match child {
+                ASTNodeOrToken::Node(n) => {
+                    let v = self.eval_node(n)?;
+                    acc = Some(match (acc.take(), op.take()) {
+                        (None, _) => v,
+                        (Some(a), Some(o)) => apply_binop(&o, &a, &v)?,
+                        (Some(a), None) => a,
+                    });
+                }
+                ASTNodeOrToken::Token(t) => op = Some(t.value.clone()),
+            }
+        }
+        acc.ok_or_else(|| "matlab-runtime: empty expression".to_string())
+    }
+
+    /// The colon: `a:b` or `a:b:c`. Builds an inclusive numeric row vector.
+    fn eval_colon(&self, node: &GrammarASTNode) -> Result<MatValue, String> {
+        let parts = node_children(node);
+        if parts.len() == 1 {
+            return self.eval_node(parts[0]);
+        }
+        let scalar = |v: &MatValue| -> Result<f64, String> {
+            let a = v.as_num("range")?;
+            a.data()
+                .first()
+                .copied()
+                .ok_or_else(|| "range bound is empty".to_string())
+        };
+        let (from, step, to) = match parts.as_slice() {
+            [a, b] => (
+                scalar(&self.eval_node(a)?)?,
+                1.0,
+                scalar(&self.eval_node(b)?)?,
+            ),
+            [a, s, b] => (
+                scalar(&self.eval_node(a)?)?,
+                scalar(&self.eval_node(s)?)?,
+                scalar(&self.eval_node(b)?)?,
+            ),
+            _ => return Err("range: too many colons".to_string()),
+        };
+        if step == 0.0 {
+            return Err("range: step cannot be zero".to_string());
+        }
+        let mut data = Vec::new();
+        let mut x = from;
+        // Bound the length so a crafted `1:1e18` can't exhaust memory.
+        const MAX_RANGE: usize = 1 << 26;
+        while (step > 0.0 && x <= to + 1e-9) || (step < 0.0 && x >= to - 1e-9) {
+            data.push(x);
+            if data.len() > MAX_RANGE {
+                return Err(format!("range produces more than {MAX_RANGE} elements"));
+            }
+            x += step;
+        }
+        // A range is a 1×n row vector.
+        let n = data.len();
+        Array::from_shape(data, if n == 0 { vec![1, 0] } else { vec![1, n] }).map(MatValue::Num)
+    }
+
+    fn eval_unary(&self, node: &GrammarASTNode) -> Result<MatValue, String> {
+        // `(+|-|~) unary` or a pass-through to `power`.
+        let op = node.children.first().and_then(|c| match c {
+            ASTNodeOrToken::Token(t) => Some(t.value.clone()),
+            _ => None,
+        });
+        let operand = only_node(node)?;
+        let v = self.eval_node(operand)?;
+        match op.as_deref() {
+            Some("-") => unary_map(&v, |x| -x),
+            Some("+") => Ok(v),
+            Some("~") => unary_map(&v, |x| if x == 0.0 { 1.0 } else { 0.0 }),
+            _ => Ok(v),
+        }
+    }
+
+    fn eval_power(&self, node: &GrammarASTNode) -> Result<MatValue, String> {
+        // `postfix [ (^|.^) unary ]`.
+        let kids = node_children(node);
+        if kids.len() == 1 {
+            return self.eval_node(kids[0]);
+        }
+        let base = self.eval_node(kids[0])?;
+        let exp = self.eval_node(kids[1])?;
+        // `^` and `.^` coincide for scalars (the common case); matrix power is a
+        // documented deferral.
+        let (b, e) = (base.as_num("^")?, exp.as_num("^")?);
+        broadcast(b, e, |x, y| x.powf(y)).map(MatValue::Num)
+    }
+
+    fn eval_postfix(&self, node: &GrammarASTNode) -> Result<MatValue, String> {
+        let mut children = node.children.iter();
+        let primary = match children.next() {
+            Some(ASTNodeOrToken::Node(n)) => n,
+            _ => return Err("matlab-runtime: malformed postfix".to_string()),
+        };
+        let suffixes: Vec<&GrammarASTNode> = children
+            .filter_map(|c| match c {
+                ASTNodeOrToken::Node(n) => Some(n),
+                ASTNodeOrToken::Token(_) => None,
+            })
+            .collect();
+
+        // Resolve the head: a bare NAME with a `(…)` suffix is either indexing a
+        // variable or calling a builtin; everything else evaluates as a value.
+        let (mut value, rest): (MatValue, &[&GrammarASTNode]) =
+            if let Some(name) = bare_name(primary) {
+                if name == "end" {
+                    // The index sentinel, bound while evaluating index arguments.
+                    let e = self
+                        .end_value
+                        .get()
+                        .ok_or_else(|| "matlab-runtime: 'end' used outside an index".to_string())?;
+                    (MatValue::scalar(e), &suffixes)
+                } else if let Some(v) = self.vars.get(&name) {
+                    (v.clone(), &suffixes)
+                } else if suffixes.first().map(|s| s.rule_name.as_str()) == Some("call_suffix") {
+                    // A builtin call: arguments are values (a bare colon is not
+                    // valid here).
+                    let args = self
+                        .eval_index_args(suffixes[0], None)?
+                        .into_iter()
+                        .map(|a| match a {
+                            Index::At(v) => Ok(v),
+                            Index::Colon => {
+                                Err("matlab-runtime: ':' is not a valid call argument".to_string())
+                            }
+                        })
+                        .collect::<Result<Vec<_>, String>>()?;
+                    let v = builtins::call(&name, &args)?;
+                    (v, &suffixes[1..])
+                } else {
+                    return Err(format!("matlab-runtime: undefined variable '{name}'"));
+                }
+            } else {
+                (self.eval_node(primary)?, &suffixes[..])
+            };
+
+        for suffix in rest {
+            value = match suffix.rule_name.as_str() {
+                "transpose_suffix" => MatValue::Num(ops::transpose(value.as_num("transpose")?)),
+                "call_suffix" => self.index_value(&value, suffix)?,
+                other => return Err(format!("matlab-runtime: '{other}' is not yet supported")),
+            };
+        }
+        Ok(value)
+    }
+
+    /// Index into an already-evaluated array value: `A(i)`, `A(i,j)`, `A(:,j)`,
+    /// `A(i,:)`, `A(:)`, `A(end)`. All subscripts are 1-based.
+    fn index_value(&self, value: &MatValue, call: &GrammarASTNode) -> Result<MatValue, String> {
+        let a = value.as_num("indexing")?;
+        let args = self.eval_index_args(call, Some(a))?;
+        match args.as_slice() {
+            // Linear indexing `A(k)` (column-major) or `A(:)` (linearize).
+            [Index::Colon] => Ok(MatValue::Num(
+                Array::from_shape(a.data().to_vec(), vec![a.len(), 1])
+                    .unwrap_or_else(|_| a.clone()),
+            )),
+            [Index::At(k)] => {
+                let idx = scalar_index(k, a.len(), "index")?;
+                Ok(MatValue::scalar(a.data()[idx]))
+            }
+            // 2-D indexing `A(i, j)` with optional colons for whole rows/columns.
+            [ri, ci] => {
+                let rows = dim_indices(ri, a.nrows(), "row")?;
+                let cols = dim_indices(ci, a.ncols(), "column")?;
+                let mut out = Vec::with_capacity(rows.len() * cols.len());
+                // Column-major output: iterate columns, then rows.
+                for &c in &cols {
+                    for &r in &rows {
+                        out.push(
+                            a.get(r, c)
+                                .ok_or_else(|| "index out of bounds".to_string())?,
+                        );
+                    }
+                }
+                Array::from_shape(out, vec![rows.len(), cols.len()]).map(MatValue::Num)
+            }
+            _ => Err("matlab-runtime: only 1-D and 2-D indexing is supported".to_string()),
+        }
+    }
+
+    /// Evaluate a call/index argument list into [`Index`] values. When `host` is
+    /// `Some`, `end` resolves to that array's relevant dimension size.
+    fn eval_index_args(
+        &self,
+        call: &GrammarASTNode,
+        host: Option<&Array>,
+    ) -> Result<Vec<Index>, String> {
+        let arg_list = match call.children.iter().find_map(|c| match c {
+            ASTNodeOrToken::Node(n) if n.rule_name == "arg_list" => Some(n),
+            _ => None,
+        }) {
+            Some(a) => a,
+            None => return Ok(Vec::new()), // `f()` / `A()`
+        };
+        let args: Vec<&GrammarASTNode> = node_children(arg_list)
+            .into_iter()
+            .filter(|n| n.rule_name == "arg")
+            .collect();
+        let n_args = args.len();
+        let mut out = Vec::with_capacity(n_args);
+        for (i, arg) in args.iter().enumerate() {
+            // A bare colon argument.
+            if node_children(arg).is_empty() {
+                out.push(Index::Colon);
+                continue;
+            }
+            // Bind `end` to the size of the dimension this argument indexes.
+            let end = host.map(|h| match (n_args, i) {
+                (1, _) => h.len() as f64,   // linear: numel
+                (_, 0) => h.nrows() as f64, // first subscript: rows
+                _ => h.ncols() as f64,      // second subscript: cols
+            });
+            self.end_value.set(end);
+            let v = self.eval_node(only_node(arg)?);
+            self.end_value.set(None);
+            out.push(Index::At(v?));
+        }
+        Ok(out)
+    }
+
+    fn eval_primary(&self, node: &GrammarASTNode) -> Result<MatValue, String> {
+        // A primary is a single token (NUMBER/STRING/NAME) or a sub-rule node.
+        if let Some(inner) = first_node(node) {
+            return self.eval_node(inner);
+        }
+        let tok = match node.children.first() {
+            Some(ASTNodeOrToken::Token(t)) => t,
+            _ => return Err("matlab-runtime: empty primary".to_string()),
+        };
+        match tok.effective_type_name() {
+            "NUMBER" => tok
+                .value
+                .parse::<f64>()
+                .map(MatValue::scalar)
+                .map_err(|_| format!("invalid number '{}'", tok.value)),
+            "STRING" => Ok(MatValue::Char(tok.value.clone())),
+            "NAME" => {
+                if tok.value == "end" {
+                    if let Some(e) = self.end_value.get() {
+                        return Ok(MatValue::scalar(e));
+                    }
+                }
+                self.vars
+                    .get(&tok.value)
+                    .cloned()
+                    .ok_or_else(|| format!("matlab-runtime: undefined variable '{}'", tok.value))
+            }
+            other => Err(format!("matlab-runtime: unexpected token {other}")),
+        }
+    }
+
+    /// A matrix literal `[ rows ]`: columns are juxtaposed/comma-separated
+    /// elements, rows are `;`/newline-separated. Each row is concatenated
+    /// horizontally, then the rows are stacked vertically.
+    fn eval_matrix(&self, node: &GrammarASTNode) -> Result<MatValue, String> {
+        let rows_node = match first_node(node) {
+            Some(n) if n.rule_name == "matrix_rows" => n,
+            _ => {
+                return Ok(MatValue::Num(
+                    Array::from_shape(vec![], vec![0, 0]).unwrap(),
+                ))
+            } // []
+        };
+        let mut row_arrays = Vec::new();
+        for row in node_children(rows_node) {
+            if row.rule_name != "matrix_row" {
+                continue;
+            }
+            let mut cells = Vec::new();
+            for el in node_children(row) {
+                cells.push(self.eval_node(el)?.as_num("matrix element")?.clone());
+            }
+            row_arrays.push(hcat(&cells)?);
+        }
+        vcat(&row_arrays).map(MatValue::Num)
+    }
+
+    // --- control flow ----------------------------------------------------
+
+    fn eval_if(&mut self, node: &GrammarASTNode) -> Result<(), String> {
+        // if_stmt = "if" expr block_body { elseif_clause } [ else_clause ] "end"
+        let kids = node_children(node);
+        // Leading `if expr block_body`.
+        if self.eval_node(kids[0])?.is_true() {
+            return self.eval_block(kids[1]);
+        }
+        let mut i = 2;
+        while i < kids.len() {
+            match kids[i].rule_name.as_str() {
+                "elseif_clause" => {
+                    let c = node_children(kids[i]);
+                    if self.eval_node(c[0])?.is_true() {
+                        return self.eval_block(c[1]);
+                    }
+                    i += 1;
+                }
+                "else_clause" => {
+                    return self.eval_block(first_node(kids[i]).unwrap());
+                }
+                _ => i += 1,
+            }
+        }
+        Ok(())
+    }
+
+    fn eval_for(&mut self, node: &GrammarASTNode) -> Result<(), String> {
+        // for_stmt = "for" NAME EQ expr block_body "end"
+        let name = node
+            .children
+            .iter()
+            .find_map(|c| match c {
+                ASTNodeOrToken::Token(t) if t.effective_type_name() == "NAME" => {
+                    Some(t.value.clone())
+                }
+                _ => None,
+            })
+            .ok_or_else(|| "for: missing loop variable".to_string())?;
+        let kids = node_children(node);
+        // kids: [expr (the range), block_body]
+        let range = self.eval_node(kids[0])?;
+        let cols = range.as_num("for")?.clone();
+        // MATLAB iterates over the COLUMNS of the range/matrix; for a row vector
+        // that is each element in turn.
+        let (nr, nc) = (cols.nrows(), cols.ncols());
+        for c in 0..nc {
+            let col: Vec<f64> = (0..nr).map(|r| cols.get(r, c).unwrap()).collect();
+            let v = if col.len() == 1 {
+                MatValue::scalar(col[0])
+            } else {
+                MatValue::Num(Array::from_shape(col, vec![nr, 1]).unwrap())
+            };
+            self.vars.insert(name.clone(), v);
+            self.eval_block(kids[1])?;
+        }
+        Ok(())
+    }
+
+    fn eval_while(&mut self, node: &GrammarASTNode) -> Result<(), String> {
+        // while_stmt = "while" expr block_body "end"
+        let kids = node_children(node);
+        const MAX_ITERS: usize = 10_000_000;
+        let mut iters = 0;
+        while self.eval_node(kids[0])?.is_true() {
+            self.eval_block(kids[1])?;
+            iters += 1;
+            if iters > MAX_ITERS {
+                return Err("while: exceeded the iteration limit".to_string());
+            }
+        }
+        Ok(())
+    }
+
+    /// Run a `block_body` (a run of statement lines) for its side effects.
+    fn eval_block(&mut self, body: &GrammarASTNode) -> Result<(), String> {
+        for line in node_children(body) {
+            if line.rule_name == "statement_line" {
+                self.eval_statement_line(line)?;
+            }
+        }
+        Ok(())
+    }
+}
+
+// ── operators ────────────────────────────────────────────────────────────────
+
+/// Apply a binary operator (selected by its source token) to two values.
+fn apply_binop(op: &str, lhs: &MatValue, rhs: &MatValue) -> Result<MatValue, String> {
+    let (a, b) = (lhs.as_num(op)?, rhs.as_num(op)?);
+    let num = |a: Array| Ok(MatValue::Num(a));
+    match op {
+        "+" => ops::add(a, b).and_then(num),
+        "-" => ops::sub(a, b).and_then(num),
+        ".*" => ops::mul(a, b).and_then(num),
+        "./" => ops::div(a, b).and_then(num),
+        ".\\" => broadcast(a, b, |x, y| y / x).and_then(num),
+        ".^" => broadcast(a, b, |x, y| x.powf(y)).and_then(num),
+        // `*`: scalar on either side is an element-wise scale; otherwise it is a
+        // true matrix product — lowered to the array-runtime planner + executor.
+        "*" => {
+            if a.is_scalar() || b.is_scalar() {
+                ops::mul(a, b).and_then(num)
+            } else {
+                execute(Kernel::MatMul, a, b).and_then(num)
+            }
+        }
+        "/" if b.is_scalar() => ops::div(a, b).and_then(num),
+        "==" => broadcast(a, b, |x, y| (x == y) as i32 as f64).and_then(num),
+        "~=" => broadcast(a, b, |x, y| (x != y) as i32 as f64).and_then(num),
+        "<" => broadcast(a, b, |x, y| (x < y) as i32 as f64).and_then(num),
+        "<=" => broadcast(a, b, |x, y| (x <= y) as i32 as f64).and_then(num),
+        ">" => broadcast(a, b, |x, y| (x > y) as i32 as f64).and_then(num),
+        ">=" => broadcast(a, b, |x, y| (x >= y) as i32 as f64).and_then(num),
+        "&" | "&&" => {
+            broadcast(a, b, |x, y| ((x != 0.0) && (y != 0.0)) as i32 as f64).and_then(num)
+        }
+        "|" | "||" => {
+            broadcast(a, b, |x, y| ((x != 0.0) || (y != 0.0)) as i32 as f64).and_then(num)
+        }
+        other => Err(format!(
+            "matlab-runtime: operator '{other}' is not yet supported"
+        )),
+    }
+}
+
+/// Element-wise binary map with MATLAB scalar broadcasting (either operand may
+/// be `1×1`); otherwise the shapes must agree.
+fn broadcast(a: &Array, b: &Array, f: impl Fn(f64, f64) -> f64) -> Result<Array, String> {
+    let (ad, bd) = (a.data(), b.data());
+    let data: Vec<f64> = if a.is_scalar() {
+        bd.iter().map(|&y| f(ad[0], y)).collect()
+    } else if b.is_scalar() {
+        ad.iter().map(|&x| f(x, bd[0])).collect()
+    } else {
+        if a.shape() != b.shape() {
+            return Err(format!(
+                "matrix dimensions must agree: {:?} vs {:?}",
+                a.shape(),
+                b.shape()
+            ));
+        }
+        ad.iter().zip(bd).map(|(&x, &y)| f(x, y)).collect()
+    };
+    let shape = if a.is_scalar() { b.shape() } else { a.shape() };
+    Array::from_shape(data, shape.to_vec())
+}
+
+fn unary_map(v: &MatValue, f: impl Fn(f64) -> f64) -> Result<MatValue, String> {
+    let a = v.as_num("unary")?;
+    Array::from_shape(a.data().iter().map(|&x| f(x)).collect(), a.shape().to_vec())
+        .map(MatValue::Num)
+}
+
+/// Concatenate arrays horizontally (a matrix row): all must share their row
+/// count; columns are appended. (`[1 2 3]`, `[A B]`.)
+fn hcat(cells: &[Array]) -> Result<Array, String> {
+    let cells: Vec<&Array> = cells.iter().filter(|a| !a.is_empty()).collect();
+    let Some(first) = cells.first() else {
+        return Array::from_shape(vec![], vec![1, 0]);
+    };
+    let nrows = first.nrows();
+    let mut cols: Vec<Vec<f64>> = Vec::new();
+    for a in &cells {
+        if a.nrows() != nrows {
+            return Err("horizontal concatenation: row counts must match".to_string());
+        }
+        for c in 0..a.ncols() {
+            cols.push((0..nrows).map(|r| a.get(r, c).unwrap()).collect());
+        }
+    }
+    // Assemble column-major.
+    let ncols = cols.len();
+    let mut data = vec![0.0; nrows * ncols];
+    for (c, col) in cols.iter().enumerate() {
+        for (r, &v) in col.iter().enumerate() {
+            data[c * nrows + r] = v;
+        }
+    }
+    Array::from_shape(data, vec![nrows, ncols])
+}
+
+/// Stack row-arrays vertically (`[a; b]`): all must share their column count.
+fn vcat(rows: &[Array]) -> Result<Array, String> {
+    let rows: Vec<&Array> = rows.iter().filter(|a| !a.is_empty()).collect();
+    let Some(first) = rows.first() else {
+        return Array::from_shape(vec![], vec![0, 0]);
+    };
+    let ncols = first.ncols();
+    let total_rows: usize = rows.iter().map(|a| a.nrows()).sum();
+    let mut data = vec![0.0; total_rows * ncols];
+    let mut row_off = 0;
+    for a in &rows {
+        if a.ncols() != ncols {
+            return Err("vertical concatenation: column counts must match".to_string());
+        }
+        for c in 0..ncols {
+            for r in 0..a.nrows() {
+                data[c * total_rows + (row_off + r)] = a.get(r, c).unwrap();
+            }
+        }
+        row_off += a.nrows();
+    }
+    Array::from_shape(data, vec![total_rows, ncols])
+}
+
+/// Resolve a scalar 1-based subscript to a 0-based offset, bounds-checked.
+fn scalar_index(v: &MatValue, len: usize, what: &str) -> Result<usize, String> {
+    let a = v.as_num(what)?;
+    let one = a.data().first().copied().unwrap_or(0.0);
+    let idx = one.round() as i64;
+    if idx < 1 || idx as usize > len {
+        return Err(format!("{what} {idx} is out of bounds 1..={len}"));
+    }
+    Ok((idx - 1) as usize)
+}
+
+/// Resolve one subscript of a 2-D index into 0-based offsets along a dimension
+/// of size `dim`. A colon means the whole dimension; a vector means several.
+fn dim_indices(idx: &Index, dim: usize, what: &str) -> Result<Vec<usize>, String> {
+    match idx {
+        Index::Colon => Ok((0..dim).collect()),
+        Index::At(v) => {
+            let a = v.as_num(what)?;
+            a.data()
+                .iter()
+                .map(|&x| {
+                    let i = x.round() as i64;
+                    if i < 1 || i as usize > dim {
+                        Err(format!("{what} index {i} is out of bounds 1..={dim}"))
+                    } else {
+                        Ok((i - 1) as usize)
+                    }
+                })
+                .collect()
+        }
+    }
+}
+
+// ── AST helpers ──────────────────────────────────────────────────────────────
+
+fn node_children(node: &GrammarASTNode) -> Vec<&GrammarASTNode> {
+    node.children
+        .iter()
+        .filter_map(|c| match c {
+            ASTNodeOrToken::Node(n) => Some(n),
+            ASTNodeOrToken::Token(_) => None,
+        })
+        .collect()
+}
+
+fn first_node(node: &GrammarASTNode) -> Option<&GrammarASTNode> {
+    node.children.iter().find_map(|c| match c {
+        ASTNodeOrToken::Node(n) => Some(n),
+        ASTNodeOrToken::Token(_) => None,
+    })
+}
+
+fn only_node(node: &GrammarASTNode) -> Result<&GrammarASTNode, String> {
+    first_node(node).ok_or_else(|| format!("matlab-runtime: malformed '{}' node", node.rule_name))
+}
+
+/// If `node` is a `primary` that is a bare `NAME`, return that name.
+fn bare_name(primary: &GrammarASTNode) -> Option<String> {
+    if primary.rule_name != "primary" || first_node(primary).is_some() {
+        return None;
+    }
+    match primary.children.first() {
+        Some(ASTNodeOrToken::Token(t)) if t.effective_type_name() == "NAME" => {
+            Some(t.value.clone())
+        }
+        _ => None,
+    }
+}
+
+/// The variable name of an assignment LHS, if it is a simple `postfix → … →
+/// primary → NAME` with no suffixes.
+fn lhs_name(node: &GrammarASTNode) -> Option<String> {
+    let mut cur = node;
+    loop {
+        if cur.rule_name == "primary" {
+            return bare_name(cur);
+        }
+        match node_children(cur).as_slice() {
+            [only] => cur = only,
+            _ => return None,
+        }
+    }
+}

--- a/code/packages/rust/matlab-runtime/src/eval.rs
+++ b/code/packages/rust/matlab-runtime/src/eval.rs
@@ -14,12 +14,30 @@ use array_runtime::{execute, ops, Array, Kernel};
 use parser::grammar_parser::{ASTNodeOrToken, GrammarASTNode};
 use std::cell::Cell;
 use std::collections::HashMap;
+use std::rc::Rc;
 
-/// A persistent MATLAB session: a variable workspace plus the value of `end`
-/// currently in scope (set while evaluating an index expression).
+/// Maximum expression/block nesting depth. Crafted input like `((((…))))` or
+/// `if…if…end…end` recurses one frame per level; this bound turns a stack
+/// overflow (which would abort the whole process) into a clean error.
+const MAX_DEPTH: usize = 512;
+
+/// A persistent MATLAB session: a variable workspace, the value of `end`
+/// currently in scope (set while evaluating an index expression), and the
+/// current evaluation depth.
 pub struct Interpreter {
     vars: HashMap<String, MatValue>,
     end_value: Cell<Option<f64>>,
+    depth: Rc<Cell<usize>>,
+}
+
+/// RAII guard that decrements the depth counter on every exit path (including
+/// `?` early returns).
+struct DepthGuard(Rc<Cell<usize>>);
+
+impl Drop for DepthGuard {
+    fn drop(&mut self) {
+        self.0.set(self.0.get().saturating_sub(1));
+    }
 }
 
 /// One index argument: a value, or a bare colon meaning "the whole dimension".
@@ -39,7 +57,19 @@ impl Interpreter {
         Interpreter {
             vars: HashMap::new(),
             end_value: Cell::new(None),
+            depth: Rc::new(Cell::new(0)),
         }
+    }
+
+    /// Enter one level of recursion, erroring if the nesting limit is exceeded.
+    /// The returned guard decrements the counter when it drops.
+    fn enter(&self) -> Result<DepthGuard, String> {
+        self.depth.set(self.depth.get() + 1);
+        let guard = DepthGuard(Rc::clone(&self.depth));
+        if self.depth.get() > MAX_DEPTH {
+            return Err("matlab-runtime: expression or block nesting too deep".to_string());
+        }
+        Ok(guard)
     }
 
     /// Evaluate a whole program (the `program` node), returning the prompt echo
@@ -133,6 +163,7 @@ impl Interpreter {
 
     /// Evaluate any expression node, dispatching by rule name.
     fn eval_node(&self, node: &GrammarASTNode) -> Result<MatValue, String> {
+        let _guard = self.enter()?;
         match node.rule_name.as_str() {
             "expr" | "assignment" | "statement" => self.eval_node(only_node(node)?),
             "logical_or" | "logical_and" | "bit_or" | "bit_and" | "comparison" | "additive"
@@ -511,6 +542,7 @@ impl Interpreter {
 
     /// Run a `block_body` (a run of statement lines) for its side effects.
     fn eval_block(&mut self, body: &GrammarASTNode) -> Result<(), String> {
+        let _guard = self.enter()?;
         for line in node_children(body) {
             if line.rule_name == "statement_line" {
                 self.eval_statement_line(line)?;

--- a/code/packages/rust/matlab-runtime/src/lib.rs
+++ b/code/packages/rust/matlab-runtime/src/lib.rs
@@ -1,0 +1,204 @@
+//! # MATLAB Runtime — a tree-walking evaluator over `array-runtime`.
+//!
+//! This is item **MA-3d** of the MATLAB frontend (spec
+//! `code/specs/MA01-matlab-language.md`): the runtime that makes the MATLAB
+//! lexer/parser executable. It parses with [`coding_adventures_matlab_parser`]
+//! and walks the resulting tree with a recursive [`Interpreter`], computing
+//! [`MatValue`]s over [`array_runtime`]. Unlike R (which reuses the shared S
+//! evaluator), MATLAB has its *own* evaluator because its value model is the
+//! `array-runtime` `Array` and its semantics are MATLAB's (1-based,
+//! column-major, matrix-first).
+//!
+//! ## The payoff
+//!
+//! A matrix product `A * B` lowers to [`array_runtime::execute`]`(MatMul, …)`,
+//! which plans the operation and runs it on the cheapest available backend — CPU
+//! today, a GPU executor the moment one is registered. So matrix acceleration is
+//! automatic and by cost, with no `gpuArray` and no language-level GPU code:
+//! the whole MA-1 → MA-2 substrate lights up through real MATLAB syntax.
+//!
+//! ```
+//! use coding_adventures_matlab_runtime::eval;
+//!
+//! // A matrix product, executed through the array-runtime planner.
+//! let out = eval("A = [1 2; 3 4]; A * eye(2)\n").unwrap();
+//! assert!(out.contains("ans ="));
+//! ```
+//!
+//! For a persistent session (the REPL), construct an [`Interpreter`] and call
+//! [`Interpreter::feed`] repeatedly — variables persist between calls.
+
+mod builtins;
+mod eval;
+mod value;
+
+pub use eval::Interpreter;
+pub use value::MatValue;
+
+use coding_adventures_matlab_parser::try_parse_matlab;
+
+impl Interpreter {
+    /// Parse and evaluate a chunk of MATLAB source, returning the concatenated
+    /// prompt echo of every unsuppressed result. Variables persist across calls.
+    pub fn feed(&mut self, source: &str) -> Result<String, String> {
+        let tree = try_parse_matlab(source)?;
+        self.run(&tree)
+    }
+}
+
+/// Evaluate MATLAB source in a fresh session and return its display output.
+pub fn eval(source: &str) -> Result<String, String> {
+    Interpreter::new().feed(source)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Evaluate and return the trimmed display output.
+    fn run(src: &str) -> String {
+        eval(src).unwrap_or_else(|e| panic!("eval failed for {src:?}: {e}"))
+    }
+
+    /// Evaluate `expr` (suppressed) and read back the bound variable's data via a
+    /// follow-up `disp`-free echo — here we just parse the echoed scalar.
+    fn scalar(src: &str) -> f64 {
+        let out = run(src);
+        // The echo looks like `ans = 6` or `x = 6`.
+        out.rsplit('=')
+            .next()
+            .unwrap()
+            .trim()
+            .parse::<f64>()
+            .unwrap_or_else(|_| panic!("not a scalar echo: {out:?}"))
+    }
+
+    // --- arithmetic and display -----------------------------------------
+
+    #[test]
+    fn scalar_arithmetic_echoes_ans() {
+        assert_eq!(scalar("2 + 3 * 4\n"), 14.0);
+        assert_eq!(scalar("2 ^ 10\n"), 1024.0);
+        assert_eq!(scalar("-2 ^ 2\n"), -4.0); // unary looser than power
+    }
+
+    #[test]
+    fn semicolon_suppresses_display() {
+        assert_eq!(run("x = 5;\n"), ""); // suppressed
+        assert!(run("x = 5\n").contains("x = 5")); // shown
+    }
+
+    #[test]
+    fn assignment_persists_in_a_session() {
+        let mut m = Interpreter::new();
+        m.feed("a = 10;\n").unwrap();
+        m.feed("b = 20;\n").unwrap();
+        assert!(m.feed("a + b\n").unwrap().contains("30"));
+    }
+
+    // --- matrices, ranges, indexing -------------------------------------
+
+    #[test]
+    fn matrix_literal_and_indexing() {
+        let mut m = Interpreter::new();
+        m.feed("A = [1 2; 3 4];\n").unwrap();
+        assert_eq!(scalar_in(&mut m, "A(2, 1)\n"), 3.0); // 1-based, row 2 col 1
+        assert_eq!(scalar_in(&mut m, "A(3)\n"), 2.0); // linear, column-major
+        assert_eq!(scalar_in(&mut m, "A(end)\n"), 4.0); // end = last
+    }
+
+    #[test]
+    fn ranges_and_for_loop() {
+        let mut m = Interpreter::new();
+        // sum 1..5 via a for loop over a range.
+        m.feed("s = 0;\nfor i = 1:5\n  s = s + i;\nend\n").unwrap();
+        assert_eq!(scalar_in(&mut m, "s\n"), 15.0);
+        // a stepped range
+        assert!(m.feed("0:2:6\n").unwrap().contains("ans"));
+    }
+
+    #[test]
+    fn whole_column_and_row_indexing() {
+        let mut m = Interpreter::new();
+        m.feed("A = [1 2; 3 4];\n").unwrap();
+        // A(:, 1) is the first column [1; 3]; its sum is 4.
+        assert_eq!(scalar_in(&mut m, "sum(A(:, 1))\n"), 4.0);
+        assert_eq!(scalar_in(&mut m, "sum(A(2, :))\n"), 7.0); // row 2: 3 + 4
+    }
+
+    // --- the headline: matmul through array-runtime ---------------------
+
+    #[test]
+    fn matrix_product_lowers_to_execute() {
+        let mut m = Interpreter::new();
+        m.feed("A = [1 2; 3 4];\n").unwrap();
+        m.feed("B = [5 6; 7 8];\n").unwrap();
+        m.feed("C = A * B;\n").unwrap();
+        // [[1,2],[3,4]] * [[5,6],[7,8]] = [[19,22],[43,50]].
+        assert_eq!(scalar_in(&mut m, "C(1, 1)\n"), 19.0);
+        assert_eq!(scalar_in(&mut m, "C(2, 2)\n"), 50.0);
+        // A * I == A (the layout round-trips through the executor).
+        m.feed("D = A * eye(2);\n").unwrap();
+        assert_eq!(scalar_in(&mut m, "D(2, 1)\n"), 3.0);
+    }
+
+    #[test]
+    fn elementwise_vs_matrix_multiply() {
+        let mut m = Interpreter::new();
+        m.feed("A = [1 2; 3 4];\n").unwrap();
+        // .* is element-wise; A .* A squares each entry → A(2,2) entry is 16.
+        assert_eq!(scalar_in(&mut m, "B = A .* A;\nB(2, 2)\n"), 16.0);
+        // scalar * matrix is element-wise scaling.
+        assert_eq!(scalar_in(&mut m, "C = 2 * A;\nC(2, 2)\n"), 8.0);
+    }
+
+    #[test]
+    fn transpose_and_builtins() {
+        let mut m = Interpreter::new();
+        m.feed("A = [1 2; 3 4];\n").unwrap();
+        assert_eq!(scalar_in(&mut m, "T = A';\nT(1, 2)\n"), 3.0); // transpose
+        assert_eq!(scalar_in(&mut m, "sum(sum(eye(3)))\n"), 3.0);
+        assert_eq!(scalar_in(&mut m, "numel(zeros(2, 3))\n"), 6.0);
+        assert_eq!(scalar_in(&mut m, "length([1 2 3 4])\n"), 4.0);
+    }
+
+    #[test]
+    fn comparison_and_if() {
+        let mut m = Interpreter::new();
+        m.feed("x = 5;\nif x > 3\n  y = 1;\nelse\n  y = 0;\nend\n")
+            .unwrap();
+        assert_eq!(scalar_in(&mut m, "y\n"), 1.0);
+    }
+
+    #[test]
+    fn while_loop() {
+        let mut m = Interpreter::new();
+        m.feed("n = 0;\nwhile n < 10\n  n = n + 1;\nend\n").unwrap();
+        assert_eq!(scalar_in(&mut m, "n\n"), 10.0);
+    }
+
+    // --- safety / errors ------------------------------------------------
+
+    #[test]
+    fn dimension_mismatch_and_oob_are_errors() {
+        assert!(eval("[1 2] * [3 4]\n").is_err()); // inner dims disagree
+        let mut m = Interpreter::new();
+        m.feed("A = [1 2 3];\n").unwrap();
+        assert!(m.feed("A(9)\n").is_err()); // out of bounds
+        assert!(eval("zeros(1e18)\n").is_err()); // capped, not OOM
+        assert!(eval("undefined_thing\n").is_err());
+    }
+
+    /// Helper: evaluate in an existing session and read the scalar echo.
+    fn scalar_in(m: &mut Interpreter, src: &str) -> f64 {
+        let out = m
+            .feed(src)
+            .unwrap_or_else(|e| panic!("eval failed for {src:?}: {e}"));
+        out.rsplit('=')
+            .next()
+            .unwrap()
+            .trim()
+            .parse::<f64>()
+            .unwrap_or_else(|_| panic!("not a scalar echo: {out:?}"))
+    }
+}

--- a/code/packages/rust/matlab-runtime/src/lib.rs
+++ b/code/packages/rust/matlab-runtime/src/lib.rs
@@ -37,13 +37,42 @@ pub use value::MatValue;
 
 use coding_adventures_matlab_parser::try_parse_matlab;
 
+/// Maximum bracket nesting depth accepted by [`Interpreter::feed`]. The
+/// recursive-descent parser uses one stack frame per nesting level, so this
+/// bound rejects pathologically nested input (`((((…))))`) *before* parsing,
+/// turning a would-be stack overflow into a clean error. Real code nests a
+/// handful of levels deep; 200 is generous.
+const MAX_NESTING: usize = 200;
+
 impl Interpreter {
     /// Parse and evaluate a chunk of MATLAB source, returning the concatenated
     /// prompt echo of every unsuppressed result. Variables persist across calls.
     pub fn feed(&mut self, source: &str) -> Result<String, String> {
+        check_nesting(source)?;
         let tree = try_parse_matlab(source)?;
         self.run(&tree)
     }
+}
+
+/// Reject source whose `(`/`[`/`{` nesting exceeds [`MAX_NESTING`], so the parser
+/// is never handed input deep enough to exhaust the stack. A linear pre-scan.
+fn check_nesting(source: &str) -> Result<(), String> {
+    let mut depth: usize = 0;
+    for ch in source.chars() {
+        match ch {
+            '(' | '[' | '{' => {
+                depth += 1;
+                if depth > MAX_NESTING {
+                    return Err(format!(
+                        "matlab-runtime: input nests deeper than the limit of {MAX_NESTING}"
+                    ));
+                }
+            }
+            ')' | ']' | '}' => depth = depth.saturating_sub(1),
+            _ => {}
+        }
+    }
+    Ok(())
 }
 
 /// Evaluate MATLAB source in a fresh session and return its display output.
@@ -187,6 +216,14 @@ mod tests {
         assert!(m.feed("A(9)\n").is_err()); // out of bounds
         assert!(eval("zeros(1e18)\n").is_err()); // capped, not OOM
         assert!(eval("undefined_thing\n").is_err());
+    }
+
+    #[test]
+    fn deeply_nested_input_errors_instead_of_crashing() {
+        // Pathologically nested parentheses must be a clean error, not a stack
+        // overflow that aborts the process.
+        let src = format!("{}1{}\n", "(".repeat(2000), ")".repeat(2000));
+        assert!(eval(&src).is_err());
     }
 
     /// Helper: evaluate in an existing session and read the scalar echo.

--- a/code/packages/rust/matlab-runtime/src/value.rs
+++ b/code/packages/rust/matlab-runtime/src/value.rs
@@ -1,0 +1,65 @@
+//! The MATLAB value model.
+//!
+//! MATLAB's universe is the array, so the workhorse value is an
+//! [`array_runtime::Array`] (a dense, column-major `f64` matrix — a scalar is
+//! `1×1`, a row vector `1×n`). Char arrays (`'abc'` / `"abc"`) are a thin string
+//! layer on top. Logicals are ordinary `0.0`/`1.0` numeric arrays, exactly as in
+//! MATLAB where `true`/`false` are `1`/`0`.
+
+use array_runtime::Array;
+use std::fmt;
+
+/// A MATLAB value.
+#[derive(Clone, Debug)]
+pub enum MatValue {
+    /// A numeric (or logical) array — the common case.
+    Num(Array),
+    /// A char array / string.
+    Char(String),
+}
+
+impl MatValue {
+    /// A `1×1` numeric scalar.
+    pub fn scalar(x: f64) -> MatValue {
+        MatValue::Num(Array::scalar(x))
+    }
+
+    /// Borrow the underlying numeric array, or error with `ctx` if this is a
+    /// non-numeric value (a char array). Most operators are numeric-only.
+    pub fn as_num(&self, ctx: &str) -> Result<&Array, String> {
+        match self {
+            MatValue::Num(a) => Ok(a),
+            MatValue::Char(_) => Err(format!("{ctx}: operation is not defined for char arrays")),
+        }
+    }
+
+    /// MATLAB truthiness for `if`/`while`: a numeric array is true iff it is
+    /// non-empty and *every* element is non-zero. A char array is true iff
+    /// non-empty.
+    pub fn is_true(&self) -> bool {
+        match self {
+            MatValue::Num(a) => !a.is_empty() && a.data().iter().all(|&x| x != 0.0),
+            MatValue::Char(s) => !s.is_empty(),
+        }
+    }
+}
+
+impl fmt::Display for MatValue {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            MatValue::Num(a) => write!(f, "{a}"),
+            MatValue::Char(s) => write!(f, "{s}"),
+        }
+    }
+}
+
+/// Render a value the way the MATLAB prompt echoes an unsuppressed result:
+/// `name = <value>`. A scalar prints on the same line; a matrix on the lines
+/// below. `ans` is the name for an unassigned expression result.
+pub fn echo(name: &str, value: &MatValue) -> String {
+    match value {
+        MatValue::Num(a) if a.is_scalar() => format!("{name} = {a}"),
+        MatValue::Char(s) => format!("{name} = {s}"),
+        MatValue::Num(a) => format!("{name} =\n\n{a}\n"),
+    }
+}

--- a/code/specs/MA01-matlab-language.md
+++ b/code/specs/MA01-matlab-language.md
@@ -175,10 +175,13 @@ is registered in `code/packages/rust/Cargo.toml` members.
   ranges (`a:b:c`), the operator-precedence cascade (element-wise vs matrix,
   transpose postfix, unary), indexing `A(i,j)`/`A(:,k)`/`A(end)`, and control
   flow.
-- **MA-3d — `matlab-runtime` + `matlab-repl` + the `matlab` binary.** A working
-  REPL: evaluate matrix expressions over `array-runtime`, with `*`→`execute`
-  (MatMul) and element-wise ops lowering to the substrate, 1-based indexing,
-  `ans =`/`x =` echo, and the core built-ins.
+- **MA-3d — `matlab-runtime` + `matlab-repl` + the `matlab` binary** *(done)*. A
+  working REPL: a tree-walking evaluator over `array-runtime` with `*`→`execute`
+  (MatMul) and element-wise ops on the `ops` reference path, 1-based column-major
+  indexing (`A(i)`, `A(i,j)`, `A(:,k)`, `A(end)`), matrix/range literals,
+  `if`/`for`/`while`, the `ans =`/`x =` echo, and the core built-ins. *Deferred:*
+  user `function` definitions, anonymous `@(x)`, cells, `switch`/`try` execution,
+  matrix solve/power, indexed and multi-assignment.
 - **MA-3e+ — Octave** (§5), then the wider built-in library, then APL/Maxima/
   Wolfram per [`HML00`](HML00-historical-math-languages-roadmap.md).
 


### PR DESCRIPTION
## What & why

**MA-3d** — the runtime that makes the MATLAB frontend **executable**, completing the lexer → parser → runtime trio (MA-3b/c are merged). A fresh tree-walking evaluator over [array-runtime](code/packages/rust/array-runtime), plus the **`matlab` REPL binary**. Implements [MA01](code/specs/MA01-matlab-language.md) §7.

## The payoff — the whole stack lights up

A matrix product `A * B` lowers to **`array_runtime::execute(MatMul, …)`**, which plans the op and runs it on the cheapest available backend — **CPU today, a GPU executor the moment one is registered**. So matrix acceleration is automatic and *by cost*, with no `gpuArray` and no language-level GPU code. The MA-1 → MA-2 substrate now executes through real MATLAB syntax:

```matlab
>> A = [1 2; 3 4];
>> A * A          % planned + executed via array-runtime
ans =

 7  10
15  22
```

(Unlike R, which reuses the shared S evaluator, MATLAB gets its **own** evaluator — its value model is the `Array`, its semantics are 1-based, column-major, matrix-first.)

## What it does

- The precedence cascade; `+ - .* ./ .^` (element-wise via `ops`, broadcasting), `*` (matmul via `execute`), unary `- ~`, transpose `'`/`.'`, comparisons + logicals; colon ranges `a:b`/`a:b:c`.
- Variables + assignment, `;`-suppressed display, `x =`/`ans =` echo.
- **1-based column-major indexing**: `A(i)`, `A(i,j)`, `A(:,k)`, `A(i,:)`, `A(:)`, `A(end)`.
- `if/elseif/else`, `for`, `while`; builtins `zeros`/`ones`/`eye`/`size`/`length`/`numel`/`sum`/`mean`/`max`/`min`/`abs`/`sqrt`/`transpose`/`disp`.
- **`matlab-repl`**: the `matlab` binary (sibling of `R`/`s`), with line continuation across open brackets *and* unterminated `if/for/while/…end` blocks, `quit`/`exit`/EOF, non-fatal error display.

## Safety

DoS bounds throughout: range length & constructor dims capped (`1<<26`), `while` iteration cap, **input bracket-nesting pre-check (200) + evaluator depth guard (512)** so deeply-nested input is a clean error, never a stack overflow. `/security-review` → **PASSED** (2 rounds; the round-1 MEDIUM recursion finding fixed). A pre-existing shared-`GrammarParser` depth gap surfaced during review is tracked as a separate follow-up.

## Quality

12 matlab-runtime + 7 matlab-repl tests + 1 doctest (incl. the matmul-through-`execute` headline, indexing with `end`, loops, the deep-nesting regression); `cargo fmt` + `cargo clippy` clean. Documented deferrals: user `function`s, anonymous `@(x)`, cells, `switch`/`try`, matrix solve/power, indexed/multi-assignment.

The MATLAB frontend is now **complete end-to-end** (spec → lexer → parser → runtime+binary). Next: **MA-3e** Octave (the S→R playbook).

🤖 Generated with [Claude Code](https://claude.com/claude-code)