### PR TITLE
feat(rename): implement real renaming — leaf-function parameters to short names

### DIFF
--- a/code/packages/rust/closure-pass-rename/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-rename/CHANGELOG.md
@@ -2,6 +2,44 @@
 
 All notable changes to the `coding-adventures-closure-pass-rename` crate will be documented in this file.
 
+## [0.3.0] - 2026-06-16
+
+### Added — real renaming (leaf-function parameters)
+
+`RenamePass::run` is no longer identity. It now renames the **parameters of
+leaf functions** (function declarations whose body declares no nested function)
+to short names (`a`, `b`, …), rewriting the declaration and every use site:
+
+```js
+function f(longName) { return longName + 1; }   ⇒   function f(a){return a + 1}
+```
+
+It is a self-contained scope-aware α-rename over the Phase-1 AST. It
+conservatively never renames:
+
+- module/global top-level names (potentially externally visible);
+- free globals (`console`, `window`, …);
+- property names — the `.x` of a non-computed member access, a non-computed
+  object-literal key;
+- a parameter also declared `var`/`let`/`const` in the body (re-declared or
+  block-shadowed) — skipped rather than mis-renamed;
+- single-character parameters (already minimal).
+
+Fresh names avoid every identifier that appears anywhere in the function, so a
+rename can neither collide with another local nor capture a free global. Within
+this subset the transform is provably sound; anything outside it is left
+untouched (`changed` stays `false`).
+
+This is the v1 slice. Broader renaming — non-leaf scopes, locals, module-private
+top-level names — is future work on the same walker, and will consume
+`closure-scope-analyzer` for cross-scope resolution (v1 does not yet use it).
+
+- **11 new behavior tests** driving the real `source → bridge → rename → emit`
+  roundtrip (added `javascript-parser` + `closure-emitter` dev-deps): renaming,
+  property-name preservation, global avoidance, redeclared/non-leaf/single-char
+  skips, computed-member rewriting, nested-block uses.
+- De-staled the module/struct/test docs (they claimed "v1 is identity").
+
 ## [0.2.0] - 2026-06-01
 
 ### Added (CLOC13.A — consume `closure-scope-analyzer`)

--- a/code/packages/rust/closure-pass-rename/Cargo.toml
+++ b/code/packages/rust/closure-pass-rename/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-rename"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 description = "Variable renaming pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Replaces non-exported binding names with shorter identifiers to reduce output size while preserving externally-visible names and semantics."
 
@@ -14,3 +14,7 @@ serde_json = "1"
 
 [dev-dependencies]
 coding-adventures-javascript-tokens = { path = "../javascript-tokens" }
+# Test the real source -> bridge -> rename -> emit roundtrip against the
+# actual AST shape the parser produces (not hand-built ASTs).
+coding-adventures-javascript-parser = { path = "../javascript-parser" }
+coding-adventures-closure-emitter = { path = "../closure-emitter" }

--- a/code/packages/rust/closure-pass-rename/README.md
+++ b/code/packages/rust/closure-pass-rename/README.md
@@ -50,11 +50,21 @@ attribute and AST export markers to build the do-not-rename set.
     itself.
   - `cost = 3` — two-pass walk (collect bindings, then
     substitute) plus the name allocator.
-- `Pass::run` is **identity** in v1: `javascript-ast` ships only
-  `Program` / `SourceType` today, so there are no `Identifier` /
-  `VariableDeclarator` / `FunctionDeclaration` nodes to rename.
-  The real two-pass walk slots into `Pass::run` once the AST
-  grows variants.
+- `Pass::run` renames the **parameters of leaf functions** (function
+  declarations with no nested function in their body) to short names:
+
+  ```js
+  function f(longName) { return longName + 1; }
+  // ⇒ function f(a) { return a + 1 }
+  ```
+
+  It is a self-contained, scope-aware α-rename. It conservatively never
+  touches module/global top-level names, free globals (`console`),
+  property names (`obj.x`, `{ x: … }`), parameters re-declared as a
+  local, or single-character params. Fresh names avoid every identifier
+  in the function, so a rename can't collide or capture a global.
+  Broader renaming (locals, non-leaf scopes, module-private top-level
+  names) is future work on the same walker.
 
 ## Where this pass sits
 

--- a/code/packages/rust/closure-pass-rename/src/lib.rs
+++ b/code/packages/rust/closure-pass-rename/src/lib.rs
@@ -52,34 +52,49 @@
 //! binding has been renamed; running again would just be a no-op.
 //! `OneShot` tells the scheduler exactly that.
 //!
-//! # Scope (v1)
+//! # Scope (current slice)
 //!
-//! `javascript-ast` ships only `Program` / `SourceType` today
-//! (CLOC02 Phase 1). With no `Identifier` / `VariableDeclarator` /
-//! `FunctionDeclaration` nodes there is nothing to rename;
-//! [`RenamePass::run`] is identity in v1. Per CLOC03 §"When a pass
-//! keeps a node unchanged" no contributions are emitted.
+//! `RenamePass::run` is a real transform. v1 renames the
+//! **parameters of leaf functions** — `function` declarations whose
+//! body declares no nested function — to short names (`a`, `b`, …),
+//! at the declaration and every use site. It conservatively never
+//! touches:
 //!
-//! What this PR locks down:
+//! - module/global top-level names (they may be externally visible);
+//! - free globals (`console`, `window`, …);
+//! - property names (the `.x` of a non-computed member, a non-computed
+//!   object-literal key);
+//! - a parameter that is also declared `var`/`let`/`const` in the body
+//!   (re-declared / block-shadowed — skipped rather than mis-renamed).
 //!
-//! 1. Pass metadata (`name`, `iteration_policy`, `cost`,
-//!    `depends_on`) — what the scheduler keys on and what the
-//!    future `closurec` CLI surfaces as `--disable=rename`.
-//! 2. Establishes the pass as a registerable unit in the pipeline
-//!    so subsequent PRs can wire in real renaming logic without
-//!    touching the public surface.
+//! Within that subset the rename is a provably-sound α-conversion (see
+//! the `rename_leaf_params` safety argument). Broader renaming — locals,
+//! nested non-leaf scopes, module-private top-level names once an
+//! `external` marker exists — is future work built on the same walker.
+//!
+//! The implementation is self-contained (its own scope-aware walk over
+//! the Phase-1 AST); it does not yet consume `closure-scope-analyzer`,
+//! which the broader renamer will use for cross-scope resolution.
+
+use std::collections::{HashMap, HashSet};
 
 use coding_adventures_closure_pass_pipeline::{
     IterationPolicy, Pass, PassContext, PassError, PassOutput, PassStats,
 };
-use coding_adventures_closure_scope_analyzer::{analyze, BindingId};
+use coding_adventures_javascript_ast::statement::TaggedStatement;
+use coding_adventures_javascript_ast::{
+    AssignmentTarget, BindingTarget, BlockStatement, Declaration, Expression, ForInit,
+    FunctionDeclaration, FunctionParam, Program, ProgramItem, PropertyKey, Statement,
+    VariableDeclaration,
+};
 
 /// `Pass::depends_on` value. Empty in v1 — see crate-level docs
 /// for why. Kept as a `const` so future tests/crates can refer to
 /// it by reference rather than retyping.
 const DEPS: &[&str] = &[];
 
-/// Variable renaming pass. v1 is identity — see crate-level docs.
+/// Variable renaming pass — renames leaf-function parameters to short
+/// names. See crate-level docs for the exact (conservative) scope.
 ///
 /// Zero-sized type: no per-instance state. Pass-internal state
 /// (the binding → short-name map, the next-id counter, the
@@ -129,94 +144,761 @@ impl Pass for RenamePass {
     }
 
     fn run(&self, ctx: PassContext<'_>) -> Result<PassOutput, PassError> {
-        // CLOC13.A wiring: consume the shared `ScopeAnalysis` from
-        // `closure-scope-analyzer` to identify *rename candidates*
-        // — every binding the analyzer surfaces. Rename's job is
-        // global (every non-external binding gets a shorter name),
-        // so the candidate set is *all* bindings minus the
-        // externally-visible ones. v0.2.0 collects the full set
-        // without filtering — the externals filter waits for the
-        // type-sidecar to grow an `external` attribute (CLOC04 left
-        // it open).
-        //
-        // The algorithm (collect phase; substitute deferred):
-        //
-        //   1. Walk `analysis.bindings`. Every binding is a
-        //      candidate. (`#[non_exhaustive]` BindingKind: future
-        //      variants are admitted by default — they all need
-        //      renaming. This is the *opposite* default from
-        //      treeshake/collapse, which conservatively *skip*
-        //      unknown kinds. Rename is conservative-toward-
-        //      compression rather than conservative-toward-skip.)
-        //   2. Track candidates in a Vec<BindingId> for the
-        //      observability path.
-        //   3. Substitute — deferred to CLOC13.A.1 because cleanly
-        //      rewriting Identifier nodes needs the AST to grow
-        //      Identifier / VariableDeclarator variants AND the
-        //      analyzer to surface a binding → uses backreference.
-        //
-        // **Critical (lesson from CLOC13.E security review):**
-        // `changed` is hard-pinned to `false` until step 3 lands.
-        // Even though this pass's `iteration_policy` is OneShot
-        // (so the FixedPoint infinite-loop concern doesn't apply),
-        // the discipline of "don't lie to the scheduler about
-        // mutation" is the same. Pipeline consumers may key off
-        // `changed` for cache invalidation or to skip downstream
-        // serialization; reporting `true` without mutation would
-        // force unnecessary work. Documented in both the source
-        // and the CHANGELOG.
-        //
-        // **Why this is safe with the v0.1.0 analyzer body.** The
-        // current `analyze` returns empty bindings + references,
-        // so the candidate scan finds zero names, the candidates
-        // vec is empty, `nodes_touched` is small, and the program
-        // passes through unchanged. The wiring becomes *effective*
-        // (real candidate-finding) the moment CLOC13.0 lands the
-        // analyzer body — no churn here.
-
-        let analysis = analyze(ctx.program);
-
-        // Steps 1 + 2: every binding is a rename candidate.
-        let mut rename_candidates: Vec<BindingId> = Vec::new();
-        for (idx, _binding) in analysis.bindings.iter().enumerate() {
-            rename_candidates.push(BindingId(idx as u32));
-        }
-
-        // Step 3 deferred — keep `changed = false`.
-        let _rename_candidates = rename_candidates;
+        // v1 scope: rename the parameters of *leaf functions* (function
+        // declarations whose body contains no nested function
+        // declarations) to short names, conservatively. See
+        // [`rename_program`] and the crate-level docs for the full
+        // safety argument. Top-level / module-scope names are never
+        // touched (they may be externally visible).
+        let mut program = ctx.program.clone();
+        let mut nodes_touched: u32 = 1; // the program root
+        let changed = rename_program(&mut program, &mut nodes_touched);
 
         Ok(PassOutput {
-            program: ctx.program.clone(),
+            program,
             contributions: Vec::new(),
-            changed: false,
+            changed,
             diagnostics: Vec::new(),
-            stats: PassStats {
-                // Visited the program root + every binding +
-                // every reference. Real cost numbers for the
-                // scheduler.
-                nodes_touched: (1
-                    + analysis.bindings.len()
-                    + analysis.references.len()) as u32,
-            },
+            stats: PassStats { nodes_touched },
         })
+    }
+}
+
+// =========================================================================
+// Local-rename implementation (v1: leaf-function parameters)
+// =========================================================================
+//
+// # What gets renamed, and why it is safe
+//
+// We rename the *parameters* of a **leaf function** — a
+// `FunctionDeclaration` whose body declares no nested function — to short
+// names (`a`, `b`, `c`, …). We never touch:
+//
+//   - module/global top-level names (they may be referenced by other
+//     scripts / be the program's public surface);
+//   - free globals (`console`, `window`, …);
+//   - the `.name` side of a non-computed member access or the key of a
+//     non-computed object literal (those are property names, not
+//     bindings).
+//
+// **The safety argument** for a leaf function `f`:
+//   1. `f` has no nested functions, so nothing inside `f` can capture or
+//      re-scope `f`'s parameters under a different name.
+//   2. We rename a parameter `p` only when `p` is NOT also declared as a
+//      `var`/`let`/`const` anywhere in the body. With that excluded,
+//      `p`'s *only* binding in the function is the parameter, so EVERY
+//      identifier use of `p` in the body (other than property names)
+//      resolves to that parameter. Rewriting all of them plus the
+//      parameter declaration is therefore a sound α-rename.
+//   3. The fresh name we pick avoids *every* identifier that appears
+//      anywhere in the function, so it can neither collide with another
+//      local nor accidentally capture a free global.
+//
+// Anything outside this provably-safe subset (non-leaf functions,
+// shadowed/redeclared parameters, module-scope bindings) is left
+// untouched — `changed` stays `false` for it. Broader renaming (locals,
+// nested scopes) is future work built on the same walker.
+
+/// Reserved words we must never emit as a fresh short name. Single
+/// letters are all safe; only some two-letter combinations collide.
+const RESERVED: &[&str] = &[
+    "do", "if", "in", "of", "as", "is", "or", // 2-letter keywords/contextual
+];
+
+/// Walk the whole program and rename leaf-function parameters in place.
+/// Returns whether anything changed. `nodes_touched` is bumped per
+/// statement visited for the scheduler's cost accounting.
+fn rename_program(program: &mut Program, nodes_touched: &mut u32) -> bool {
+    let mut changed = false;
+    for item in &mut program.body {
+        if let ProgramItem::Declaration(Declaration::FunctionDeclaration(fd)) = item {
+            changed |= process_function(fd, nodes_touched);
+        } else if let ProgramItem::Statement(stmt) = item {
+            changed |= process_stmt(stmt, nodes_touched);
+        }
+    }
+    changed
+}
+
+/// Process one statement: recurse to find function declarations (which
+/// may be nested in blocks / `if` / loops / `switch`), and rename the
+/// parameters of any leaf function found.
+fn process_stmt(stmt: &mut Statement, nodes_touched: &mut u32) -> bool {
+    *nodes_touched += 1;
+    match stmt {
+        Statement::Declaration(Declaration::FunctionDeclaration(fd)) => {
+            process_function(fd, nodes_touched)
+        }
+        Statement::Declaration(Declaration::VariableDeclaration(_)) => false,
+        Statement::Tagged(t) => process_tagged(t, nodes_touched),
+    }
+}
+
+/// Recurse into a tagged statement's child statements to find nested
+/// function declarations. (No renaming happens here directly — that is
+/// driven from [`process_function`].)
+fn process_tagged(t: &mut TaggedStatement, nodes_touched: &mut u32) -> bool {
+    let mut changed = false;
+    match t {
+        TaggedStatement::BlockStatement(b) => {
+            for s in &mut b.body {
+                changed |= process_stmt(s, nodes_touched);
+            }
+        }
+        TaggedStatement::IfStatement(is) => {
+            changed |= process_stmt(&mut is.consequent, nodes_touched);
+            if let Some(alt) = &mut is.alternate {
+                changed |= process_stmt(alt, nodes_touched);
+            }
+        }
+        TaggedStatement::WhileStatement(ws) => {
+            changed |= process_stmt(&mut ws.body, nodes_touched);
+        }
+        TaggedStatement::ForStatement(fs) => {
+            changed |= process_stmt(&mut fs.body, nodes_touched);
+        }
+        TaggedStatement::LabeledStatement(ls) => {
+            changed |= process_stmt(&mut ls.body, nodes_touched);
+        }
+        TaggedStatement::SwitchStatement(ss) => {
+            for case in &mut ss.cases {
+                for s in &mut case.consequent {
+                    changed |= process_stmt(s, nodes_touched);
+                }
+            }
+        }
+        // No nested statements that could hold a function declaration.
+        TaggedStatement::ExpressionStatement(_)
+        | TaggedStatement::ReturnStatement(_)
+        | TaggedStatement::ThrowStatement(_)
+        | TaggedStatement::BreakStatement(_)
+        | TaggedStatement::ContinueStatement(_)
+        | TaggedStatement::EmptyStatement(_) => {}
+    }
+    changed
+}
+
+/// Recurse into a function's nested functions, then — if it is a leaf —
+/// rename its renameable parameters.
+fn process_function(fd: &mut FunctionDeclaration, nodes_touched: &mut u32) -> bool {
+    // First handle any nested functions inside the body.
+    let mut changed = false;
+    for s in &mut fd.body.body {
+        changed |= process_stmt(s, nodes_touched);
+    }
+    // A leaf function (no nested function declarations) is eligible for
+    // parameter renaming.
+    if !block_has_function(&fd.body) {
+        changed |= rename_leaf_params(fd);
+    }
+    changed
+}
+
+/// True if `block` contains a function declaration anywhere (recursively).
+fn block_has_function(block: &BlockStatement) -> bool {
+    block.body.iter().any(stmt_has_function)
+}
+
+fn stmt_has_function(stmt: &Statement) -> bool {
+    match stmt {
+        Statement::Declaration(Declaration::FunctionDeclaration(_)) => true,
+        Statement::Declaration(Declaration::VariableDeclaration(_)) => false,
+        Statement::Tagged(t) => match t {
+            TaggedStatement::BlockStatement(b) => b.body.iter().any(stmt_has_function),
+            TaggedStatement::IfStatement(is) => {
+                stmt_has_function(&is.consequent)
+                    || is.alternate.as_deref().is_some_and(stmt_has_function)
+            }
+            TaggedStatement::WhileStatement(ws) => stmt_has_function(&ws.body),
+            TaggedStatement::ForStatement(fs) => stmt_has_function(&fs.body),
+            TaggedStatement::LabeledStatement(ls) => stmt_has_function(&ls.body),
+            TaggedStatement::SwitchStatement(ss) => ss
+                .cases
+                .iter()
+                .any(|c| c.consequent.iter().any(stmt_has_function)),
+            // Statements that cannot (in the Phase-1 AST) contain a
+            // function declaration. Listed EXHAUSTIVELY on purpose: when
+            // the AST grows a new scope-introducing construct (a class
+            // declaration, a `try`/`catch`, a function/arrow expression),
+            // this match will fail to compile, forcing a maintainer to
+            // decide whether it can hold a function — rather than this
+            // silently classifying a non-leaf function as a leaf and
+            // performing an unsound rename.
+            TaggedStatement::ExpressionStatement(_)
+            | TaggedStatement::ReturnStatement(_)
+            | TaggedStatement::ThrowStatement(_)
+            | TaggedStatement::BreakStatement(_)
+            | TaggedStatement::ContinueStatement(_)
+            | TaggedStatement::EmptyStatement(_) => false,
+        },
+    }
+}
+
+/// Rename the parameters of a leaf function. Returns whether anything
+/// changed.
+fn rename_leaf_params(fd: &mut FunctionDeclaration) -> bool {
+    if fd.params.is_empty() {
+        return false;
+    }
+
+    // Names declared as var/let/const anywhere in the body. A parameter
+    // sharing such a name is either the same binding (`var p`) or
+    // block-shadowed (`let p`); either way we conservatively skip it.
+    let mut decl_names: HashSet<String> = HashSet::new();
+    collect_decl_names(&fd.body, &mut decl_names);
+
+    // Every identifier that appears anywhere in the function (params +
+    // body, including property names). A fresh name avoiding all of
+    // these cannot collide with a local or capture a free global.
+    let mut avoid: HashSet<String> = HashSet::new();
+    for p in &fd.params {
+        let FunctionParam::Identifier(id) = p;
+        avoid.insert(id.name.clone());
+    }
+    collect_all_idents_block(&fd.body, &mut avoid);
+
+    // Decide the renames.
+    let mut map: HashMap<String, String> = HashMap::new();
+    let mut gen = FreshNames::new();
+    for p in &fd.params {
+        let FunctionParam::Identifier(id) = p;
+        if decl_names.contains(&id.name) {
+            continue; // redeclared / shadowed — skip
+        }
+        if id.name.len() <= 1 {
+            continue; // already minimal; renaming can't help
+        }
+        let fresh = gen.next(&avoid);
+        avoid.insert(fresh.clone());
+        map.insert(id.name.clone(), fresh);
+    }
+
+    if map.is_empty() {
+        return false;
+    }
+
+    // Apply: rewrite the parameter declarations …
+    for p in &mut fd.params {
+        let FunctionParam::Identifier(id) = p;
+        if let Some(new) = map.get(&id.name) {
+            id.name = new.clone();
+        }
+    }
+    // … and every use inside the body.
+    rewrite_uses_block(&mut fd.body, &map);
+    true
+}
+
+/// Generates `a`, `b`, …, `z`, `aa`, `ab`, … skipping reserved words and
+/// (via the caller's `avoid` set) any name already in use.
+struct FreshNames {
+    counter: usize,
+}
+
+impl FreshNames {
+    fn new() -> Self {
+        FreshNames { counter: 0 }
+    }
+
+    fn next(&mut self, avoid: &HashSet<String>) -> String {
+        loop {
+            let name = encode(self.counter);
+            self.counter += 1;
+            if !RESERVED.contains(&name.as_str()) && !avoid.contains(&name) {
+                return name;
+            }
+        }
+    }
+}
+
+/// Bijective base-26 encoding into lowercase identifiers: 0→a, 25→z,
+/// 26→aa, 27→ab, …
+fn encode(mut n: usize) -> String {
+    let mut s = Vec::new();
+    loop {
+        s.push(b'a' + (n % 26) as u8);
+        if n < 26 {
+            break;
+        }
+        n = n / 26 - 1;
+    }
+    s.reverse();
+    String::from_utf8(s).expect("ascii")
+}
+
+// ---- name collection -----------------------------------------------------
+
+/// Collect `var`/`let`/`const` and nested function-declaration names
+/// declared anywhere in `block` (recursing through nested blocks/control
+/// flow but NOT into nested function bodies — those are separate scopes).
+fn collect_decl_names(block: &BlockStatement, out: &mut HashSet<String>) {
+    for s in &block.body {
+        collect_decl_names_stmt(s, out);
+    }
+}
+
+fn collect_decl_names_stmt(stmt: &Statement, out: &mut HashSet<String>) {
+    match stmt {
+        Statement::Declaration(Declaration::VariableDeclaration(vd)) => {
+            insert_var_names(vd, out);
+        }
+        Statement::Declaration(Declaration::FunctionDeclaration(fd)) => {
+            out.insert(fd.id.name.clone());
+            // Do NOT recurse into fd.body — separate scope.
+        }
+        Statement::Tagged(t) => match t {
+            TaggedStatement::BlockStatement(b) => collect_decl_names(b, out),
+            TaggedStatement::IfStatement(is) => {
+                collect_decl_names_stmt(&is.consequent, out);
+                if let Some(alt) = &is.alternate {
+                    collect_decl_names_stmt(alt, out);
+                }
+            }
+            TaggedStatement::WhileStatement(ws) => collect_decl_names_stmt(&ws.body, out),
+            TaggedStatement::ForStatement(fs) => {
+                if let Some(ForInit::VariableDeclaration(vd)) = &fs.init {
+                    insert_var_names(vd, out);
+                }
+                collect_decl_names_stmt(&fs.body, out);
+            }
+            TaggedStatement::LabeledStatement(ls) => collect_decl_names_stmt(&ls.body, out),
+            TaggedStatement::SwitchStatement(ss) => {
+                for c in &ss.cases {
+                    for s in &c.consequent {
+                        collect_decl_names_stmt(s, out);
+                    }
+                }
+            }
+            // Statements that introduce no binding in the Phase-1 AST.
+            // Exhaustive on purpose: a future binding-introducing
+            // statement (a `try`/`catch`, a `class` declaration) must be
+            // handled here, otherwise its name could shadow a parameter
+            // without our noticing and we'd rename the parameter
+            // unsoundly. The compiler will flag the omission.
+            TaggedStatement::ExpressionStatement(_)
+            | TaggedStatement::ReturnStatement(_)
+            | TaggedStatement::ThrowStatement(_)
+            | TaggedStatement::BreakStatement(_)
+            | TaggedStatement::ContinueStatement(_)
+            | TaggedStatement::EmptyStatement(_) => {}
+        },
+    }
+}
+
+fn insert_var_names(vd: &VariableDeclaration, out: &mut HashSet<String>) {
+    for d in &vd.declarations {
+        let BindingTarget::Identifier(id) = &d.id;
+        out.insert(id.name.clone());
+    }
+}
+
+/// Collect EVERY identifier name appearing anywhere in `block`
+/// (declarations, uses, and property names) — used to pick collision-free
+/// fresh names. Over-inclusive on purpose: avoiding a name that only
+/// appears as a property key is harmless, and never missing a real use is
+/// what keeps the rename sound.
+fn collect_all_idents_block(block: &BlockStatement, out: &mut HashSet<String>) {
+    for s in &block.body {
+        collect_all_idents_stmt(s, out);
+    }
+}
+
+fn collect_all_idents_stmt(stmt: &Statement, out: &mut HashSet<String>) {
+    match stmt {
+        Statement::Declaration(Declaration::VariableDeclaration(vd)) => {
+            for d in &vd.declarations {
+                let BindingTarget::Identifier(id) = &d.id;
+                out.insert(id.name.clone());
+                if let Some(init) = &d.init {
+                    collect_all_idents_expr(init, out);
+                }
+            }
+        }
+        Statement::Declaration(Declaration::FunctionDeclaration(fd)) => {
+            out.insert(fd.id.name.clone());
+            for p in &fd.params {
+                let FunctionParam::Identifier(id) = p;
+                out.insert(id.name.clone());
+            }
+            collect_all_idents_block(&fd.body, out);
+        }
+        Statement::Tagged(t) => match t {
+            TaggedStatement::ExpressionStatement(es) => {
+                collect_all_idents_expr(&es.expression, out)
+            }
+            TaggedStatement::BlockStatement(b) => collect_all_idents_block(b, out),
+            TaggedStatement::IfStatement(is) => {
+                collect_all_idents_expr(&is.test, out);
+                collect_all_idents_stmt(&is.consequent, out);
+                if let Some(alt) = &is.alternate {
+                    collect_all_idents_stmt(alt, out);
+                }
+            }
+            TaggedStatement::WhileStatement(ws) => {
+                collect_all_idents_expr(&ws.test, out);
+                collect_all_idents_stmt(&ws.body, out);
+            }
+            TaggedStatement::ForStatement(fs) => {
+                if let Some(init) = &fs.init {
+                    match init {
+                        ForInit::VariableDeclaration(vd) => {
+                            for d in &vd.declarations {
+                                let BindingTarget::Identifier(id) = &d.id;
+                                out.insert(id.name.clone());
+                                if let Some(i) = &d.init {
+                                    collect_all_idents_expr(i, out);
+                                }
+                            }
+                        }
+                        ForInit::Expression(e) => collect_all_idents_expr(e, out),
+                    }
+                }
+                if let Some(test) = &fs.test {
+                    collect_all_idents_expr(test, out);
+                }
+                if let Some(update) = &fs.update {
+                    collect_all_idents_expr(update, out);
+                }
+                collect_all_idents_stmt(&fs.body, out);
+            }
+            TaggedStatement::ReturnStatement(rs) => {
+                if let Some(a) = &rs.argument {
+                    collect_all_idents_expr(a, out);
+                }
+            }
+            TaggedStatement::ThrowStatement(ts) => collect_all_idents_expr(&ts.argument, out),
+            TaggedStatement::LabeledStatement(ls) => {
+                out.insert(ls.label.name.clone());
+                collect_all_idents_stmt(&ls.body, out);
+            }
+            TaggedStatement::SwitchStatement(ss) => {
+                collect_all_idents_expr(&ss.discriminant, out);
+                for c in &ss.cases {
+                    if let Some(test) = &c.test {
+                        collect_all_idents_expr(test, out);
+                    }
+                    for s in &c.consequent {
+                        collect_all_idents_stmt(s, out);
+                    }
+                }
+            }
+            TaggedStatement::BreakStatement(b) => {
+                if let Some(l) = &b.label {
+                    out.insert(l.name.clone());
+                }
+            }
+            TaggedStatement::ContinueStatement(c) => {
+                if let Some(l) = &c.label {
+                    out.insert(l.name.clone());
+                }
+            }
+            TaggedStatement::EmptyStatement(_) => {}
+        },
+    }
+}
+
+fn collect_all_idents_expr(expr: &Expression, out: &mut HashSet<String>) {
+    match expr {
+        Expression::Identifier(id) => {
+            out.insert(id.name.clone());
+        }
+        Expression::NumericLiteral(_)
+        | Expression::StringLiteral(_)
+        | Expression::BooleanLiteral(_)
+        | Expression::NullLiteral(_)
+        | Expression::BigIntLiteral(_)
+        | Expression::UndefinedLiteral(_) => {}
+        Expression::BinaryExpression(be) => {
+            collect_all_idents_expr(&be.left, out);
+            collect_all_idents_expr(&be.right, out);
+        }
+        Expression::LogicalExpression(le) => {
+            collect_all_idents_expr(&le.left, out);
+            collect_all_idents_expr(&le.right, out);
+        }
+        Expression::UnaryExpression(ue) => collect_all_idents_expr(&ue.argument, out),
+        Expression::AssignmentExpression(ae) => {
+            match &ae.left {
+                AssignmentTarget::Identifier(id) => {
+                    out.insert(id.name.clone());
+                }
+                AssignmentTarget::MemberExpression(m) => {
+                    collect_all_idents_member(&m.object, &m.property, m.computed, out)
+                }
+            }
+            collect_all_idents_expr(&ae.right, out);
+        }
+        Expression::ConditionalExpression(ce) => {
+            collect_all_idents_expr(&ce.test, out);
+            collect_all_idents_expr(&ce.consequent, out);
+            collect_all_idents_expr(&ce.alternate, out);
+        }
+        Expression::CallExpression(ce) => {
+            collect_all_idents_expr(&ce.callee, out);
+            for a in &ce.arguments {
+                collect_all_idents_expr(a, out);
+            }
+        }
+        Expression::MemberExpression(m) => {
+            collect_all_idents_member(&m.object, &m.property, m.computed, out)
+        }
+        Expression::ArrayExpression(ae) => {
+            for el in ae.elements.iter().flatten() {
+                collect_all_idents_expr(el, out);
+            }
+        }
+        Expression::ObjectExpression(oe) => {
+            for prop in &oe.properties {
+                match &prop.key {
+                    PropertyKey::Identifier(id) => {
+                        out.insert(id.name.clone());
+                    }
+                    PropertyKey::Expression(e) => collect_all_idents_expr(e, out),
+                    _ => {}
+                }
+                collect_all_idents_expr(&prop.value, out);
+            }
+        }
+    }
+}
+
+fn collect_all_idents_member(
+    object: &Expression,
+    property: &Expression,
+    computed: bool,
+    out: &mut HashSet<String>,
+) {
+    collect_all_idents_expr(object, out);
+    if computed {
+        collect_all_idents_expr(property, out);
+    } else if let Expression::Identifier(id) = property {
+        // Property name — record it for fresh-name avoidance, but it is
+        // not a binding use (rewrite_uses skips it).
+        out.insert(id.name.clone());
+    }
+}
+
+// ---- use rewriting -------------------------------------------------------
+
+fn rewrite_uses_block(block: &mut BlockStatement, map: &HashMap<String, String>) {
+    for s in &mut block.body {
+        rewrite_uses_stmt(s, map);
+    }
+}
+
+fn rewrite_uses_stmt(stmt: &mut Statement, map: &HashMap<String, String>) {
+    match stmt {
+        Statement::Declaration(Declaration::VariableDeclaration(vd)) => {
+            for d in &mut vd.declarations {
+                // A declarator id with a name in `map` cannot happen here:
+                // we only map parameter names that are NOT redeclared as
+                // var/let/const (see rename_leaf_params). So we rewrite
+                // only the initializer (a use position).
+                if let Some(init) = &mut d.init {
+                    rewrite_uses_expr(init, map);
+                }
+            }
+        }
+        // A leaf function has no nested function declarations, so this arm
+        // is unreachable in practice; leave nested functions untouched.
+        Statement::Declaration(Declaration::FunctionDeclaration(_)) => {}
+        Statement::Tagged(t) => rewrite_uses_tagged(t, map),
+    }
+}
+
+fn rewrite_uses_tagged(t: &mut TaggedStatement, map: &HashMap<String, String>) {
+    match t {
+        TaggedStatement::ExpressionStatement(es) => rewrite_uses_expr(&mut es.expression, map),
+        TaggedStatement::BlockStatement(b) => rewrite_uses_block(b, map),
+        TaggedStatement::IfStatement(is) => {
+            rewrite_uses_expr(&mut is.test, map);
+            rewrite_uses_stmt(&mut is.consequent, map);
+            if let Some(alt) = &mut is.alternate {
+                rewrite_uses_stmt(alt, map);
+            }
+        }
+        TaggedStatement::WhileStatement(ws) => {
+            rewrite_uses_expr(&mut ws.test, map);
+            rewrite_uses_stmt(&mut ws.body, map);
+        }
+        TaggedStatement::ForStatement(fs) => {
+            if let Some(init) = &mut fs.init {
+                match init {
+                    ForInit::VariableDeclaration(vd) => {
+                        for d in &mut vd.declarations {
+                            if let Some(i) = &mut d.init {
+                                rewrite_uses_expr(i, map);
+                            }
+                        }
+                    }
+                    ForInit::Expression(e) => rewrite_uses_expr(e, map),
+                }
+            }
+            if let Some(test) = &mut fs.test {
+                rewrite_uses_expr(test, map);
+            }
+            if let Some(update) = &mut fs.update {
+                rewrite_uses_expr(update, map);
+            }
+            rewrite_uses_stmt(&mut fs.body, map);
+        }
+        TaggedStatement::ReturnStatement(rs) => {
+            if let Some(a) = &mut rs.argument {
+                rewrite_uses_expr(a, map);
+            }
+        }
+        TaggedStatement::ThrowStatement(ts) => rewrite_uses_expr(&mut ts.argument, map),
+        TaggedStatement::LabeledStatement(ls) => rewrite_uses_stmt(&mut ls.body, map),
+        TaggedStatement::SwitchStatement(ss) => {
+            rewrite_uses_expr(&mut ss.discriminant, map);
+            for c in &mut ss.cases {
+                if let Some(test) = &mut c.test {
+                    rewrite_uses_expr(test, map);
+                }
+                for s in &mut c.consequent {
+                    rewrite_uses_stmt(s, map);
+                }
+            }
+        }
+        // Labels (break/continue) live in a separate label namespace, not
+        // the variable namespace — never rewritten.
+        TaggedStatement::BreakStatement(_)
+        | TaggedStatement::ContinueStatement(_)
+        | TaggedStatement::EmptyStatement(_) => {}
+    }
+}
+
+fn rewrite_uses_expr(expr: &mut Expression, map: &HashMap<String, String>) {
+    match expr {
+        Expression::Identifier(id) => {
+            if let Some(new) = map.get(&id.name) {
+                id.name = new.clone();
+            }
+        }
+        Expression::NumericLiteral(_)
+        | Expression::StringLiteral(_)
+        | Expression::BooleanLiteral(_)
+        | Expression::NullLiteral(_)
+        | Expression::BigIntLiteral(_)
+        | Expression::UndefinedLiteral(_) => {}
+        Expression::BinaryExpression(be) => {
+            rewrite_uses_expr(&mut be.left, map);
+            rewrite_uses_expr(&mut be.right, map);
+        }
+        Expression::LogicalExpression(le) => {
+            rewrite_uses_expr(&mut le.left, map);
+            rewrite_uses_expr(&mut le.right, map);
+        }
+        Expression::UnaryExpression(ue) => rewrite_uses_expr(&mut ue.argument, map),
+        Expression::AssignmentExpression(ae) => {
+            match &mut ae.left {
+                AssignmentTarget::Identifier(id) => {
+                    if let Some(new) = map.get(&id.name) {
+                        id.name = new.clone();
+                    }
+                }
+                AssignmentTarget::MemberExpression(m) => {
+                    rewrite_uses_member(&mut m.object, &mut m.property, m.computed, map)
+                }
+            }
+            rewrite_uses_expr(&mut ae.right, map);
+        }
+        Expression::ConditionalExpression(ce) => {
+            rewrite_uses_expr(&mut ce.test, map);
+            rewrite_uses_expr(&mut ce.consequent, map);
+            rewrite_uses_expr(&mut ce.alternate, map);
+        }
+        Expression::CallExpression(ce) => {
+            rewrite_uses_expr(&mut ce.callee, map);
+            for a in &mut ce.arguments {
+                rewrite_uses_expr(a, map);
+            }
+        }
+        Expression::MemberExpression(m) => {
+            rewrite_uses_member(&mut m.object, &mut m.property, m.computed, map)
+        }
+        Expression::ArrayExpression(ae) => {
+            for el in ae.elements.iter_mut().flatten() {
+                rewrite_uses_expr(el, map);
+            }
+        }
+        Expression::ObjectExpression(oe) => {
+            for prop in &mut oe.properties {
+                // Only a *computed* key `[expr]` is a use position; a
+                // plain identifier / string / number key is a property
+                // name, never rewritten.
+                if prop.computed {
+                    if let PropertyKey::Expression(e) = &mut prop.key {
+                        rewrite_uses_expr(e, map);
+                    }
+                }
+                rewrite_uses_expr(&mut prop.value, map);
+            }
+        }
+    }
+}
+
+fn rewrite_uses_member(
+    object: &mut Expression,
+    property: &mut Expression,
+    computed: bool,
+    map: &HashMap<String, String>,
+) {
+    rewrite_uses_expr(object, map);
+    // The `.name` of a non-computed member access is a property name, NOT
+    // a binding — only rewrite the property when it is computed (`o[x]`).
+    if computed {
+        rewrite_uses_expr(property, map);
     }
 }
 
 #[cfg(test)]
 mod tests {
     //! These tests pin the public contract (name, policy, cost,
-    //! deps) and lock the integration with `PassPipeline`. Even
-    //! though v1's `run` is identity, the metadata is what the
-    //! scheduler keys on, and it'll outlive the v1 body.
+    //! deps), the `PassPipeline` integration, and the renaming
+    //! behavior itself — driven end-to-end through the real
+    //! source → bridge → rename → emit roundtrip so the tests
+    //! exercise the exact AST shape the parser produces.
     use super::*;
-    use coding_adventures_closure_pass_pipeline::{PassPipeline, PipelineOutput};
+    use coding_adventures_closure_emitter::{emit, EmitOptions};
+    use coding_adventures_closure_pass_pipeline::{PassContext, PassPipeline, PipelineOutput};
     use coding_adventures_correlation_vector::CVLog;
     use coding_adventures_javascript_ast::{Program, SourceType};
+    use coding_adventures_javascript_parser::{bridge, parse_javascript_typed};
     use coding_adventures_javascript_tokens::EsVersion;
     use coding_adventures_type_sidecar::Sidecar;
 
     fn program() -> Program {
         Program::new("prog.1".to_string(), EsVersion::Es2025, SourceType::Module)
+    }
+
+    /// Parse `src`, bridge it to a typed `Program`, run `RenamePass`,
+    /// and emit the result as minified JS — the same chain closurec's
+    /// SIMPLE level uses. Returns the emitted string.
+    fn rename_source(src: &str) -> String {
+        let es = EsVersion::Es2025;
+        let node = parse_javascript_typed(src, es).expect("parse");
+        let prog = bridge::grammar_to_program(&node, es).expect("bridge");
+
+        let pass = RenamePass::new();
+        let sidecar = Sidecar::new();
+        let mut cv = CVLog::new(false);
+        let out = pass
+            .run(PassContext {
+                program: &prog,
+                sidecar: &sidecar,
+                cv: &mut cv,
+            })
+            .expect("rename");
+
+        let mut cv2 = CVLog::new(false);
+        let opts = EmitOptions {
+            source_map: false,
+            ..Default::default()
+        };
+        emit(&out.program, &sidecar, &mut cv2, &opts)
+            .expect("emit")
+            .code
     }
 
     #[test]
@@ -319,5 +1001,133 @@ mod tests {
         let _b: RenamePass = RenamePass::new();
         let _c = _b;
         let _d = _c.clone();
+    }
+
+    // =====================================================================
+    // Renaming behavior (source → bridge → rename → emit)
+    // =====================================================================
+
+    // NOTE on whitespace: these assert against the raw
+    // `closure-emitter` output (binary operators get spaces, function
+    // declarations get a trailing `;`). closurec's pipeline emits the
+    // same; the WHITESPACE_ONLY-style tightening is a separate concern.
+    // What matters here is WHICH identifiers were renamed.
+
+    #[test]
+    fn renames_leaf_function_param() {
+        // The signature case: a leaf function's parameter is renamed to
+        // a short name, at both the declaration and every use site.
+        assert_eq!(
+            rename_source("function f(longName) { return longName + 1; }"),
+            "function f(a){return a + 1};"
+        );
+    }
+
+    #[test]
+    fn renames_multiple_params_distinctly() {
+        assert_eq!(
+            rename_source("function f(first, second) { return first * second; }"),
+            "function f(a,b){return a * b};"
+        );
+    }
+
+    #[test]
+    fn does_not_rename_property_access() {
+        // `obj.longName` — `longName` here is a property name, NOT a use
+        // of the parameter, so it must NOT be renamed. The parameter
+        // `obj` IS renamed; the `.longName` member stays.
+        assert_eq!(
+            rename_source("function f(obj) { return obj.longName; }"),
+            "function f(a){return a.longName};"
+        );
+    }
+
+    #[test]
+    fn does_not_rename_object_literal_key() {
+        // A non-computed object key is a property name, never renamed.
+        // The param `val` is renamed; the key `keyName` stays.
+        assert_eq!(
+            rename_source("function f(val) { return { keyName: val }; }"),
+            "function f(a){return {keyName:a}};"
+        );
+    }
+
+    #[test]
+    fn renames_computed_member_and_key() {
+        // A computed member `obj[idx]` IS a use position — the param
+        // `idx` must be renamed there too.
+        assert_eq!(
+            rename_source("function f(obj, idx) { return obj[idx]; }"),
+            "function f(a,b){return a[b]};"
+        );
+    }
+
+    #[test]
+    fn skips_param_redeclared_as_local() {
+        // `p` is also declared `var p` — same function-scope binding.
+        // We conservatively skip renaming it (would need to rewrite the
+        // declaration too).
+        assert_eq!(
+            rename_source("function f(p) { var p = 2; return p; }"),
+            "function f(p){var p=2;return p};"
+        );
+    }
+
+    #[test]
+    fn does_not_rename_non_leaf_function_params() {
+        // `outer` has a nested function `inner`, so it is NOT a leaf —
+        // its parameter `param` is left alone (renaming non-leaf
+        // functions is future work). `inner` IS a leaf, so ITS param
+        // `q` is renamed.
+        assert_eq!(
+            rename_source(
+                "function outer(param) { function inner(innerArg) { return innerArg; } return inner(param); }"
+            ),
+            "function outer(param){function inner(a){return a};return inner(param)};"
+        );
+    }
+
+    #[test]
+    fn does_not_rename_top_level_or_globals() {
+        // Top-level function name `f` and free global `console` are
+        // never renamed; only the parameter `message` is.
+        assert_eq!(
+            rename_source("function f(message) { console.log(message); }"),
+            "function f(a){console.log(a)};"
+        );
+    }
+
+    #[test]
+    fn fresh_name_avoids_referenced_global() {
+        // The body references a free global `a`. The parameter must NOT
+        // be renamed to `a` (that would capture the global); it gets the
+        // next free name `b`.
+        assert_eq!(
+            rename_source("function f(longName) { return a + longName; }"),
+            "function f(b){return a + b};"
+        );
+    }
+
+    #[test]
+    fn renames_param_used_in_nested_block() {
+        // Uses inside a nested `if` block are rewritten. (Bare
+        // assignment statements like `x = …;` are not in the Phase-1
+        // grammar, so this exercises nested-block uses via `return`.)
+        assert_eq!(
+            rename_source(
+                "function f(counter) { if (counter > 0) { return counter; } return 0; }"
+            ),
+            "function f(a){if(a > 0){return a}return 0};"
+        );
+    }
+
+    #[test]
+    fn single_char_param_left_alone() {
+        // A one-character parameter is already minimal; renaming can't
+        // shrink it, so nothing changes.
+        assert_eq!(
+            rename_source("function f(x) { return x + 1; }"),
+            "function f(x){return x + 1};"
+        );
     }
 }


### PR DESCRIPTION
## Summary

`closure-pass-rename`'s `run()` was a genuine identity stub (`program.clone()`, "Step 3 deferred"). It now performs a real, conservative **α-rename**: the **parameters of leaf functions** (function declarations whose body declares no nested function) are renamed to short names, at the declaration and every use site:

```js
function f(longName) { return longName + 1; }   ⇒   function f(a){return a + 1}
```

## What it renames — and deliberately doesn't

A self-contained scope-aware walk over the Phase-1 AST. It conservatively **never** renames:

- module/global top-level names (potentially externally visible);
- free globals (`console`, `window`, …);
- **property names** — the `.x` of a non-computed member, a non-computed object-literal key (`obj.x` keeps `.x`; `obj[x]` *does* get `x` renamed, since that's a real reference);
- a parameter also declared `var`/`let`/`const` in the body (re-declared or block-shadowed);
- single-character params (already minimal).

Fresh names avoid *every* identifier appearing anywhere in the function, so a rename can neither collide with a local nor capture a free global. Within this subset the transform is provably sound; anything outside it is left untouched (`changed` stays `false`). Broader renaming (locals, non-leaf scopes, module-private top-level names) is future work on the same walker.

## Safety hardening (from the security review)

The reviewer flagged that "leaf = no nested *FunctionDeclaration*" must cover *every* nested-scope/binding introducer. The Phase-1 AST has none of the risky ones (no arrow/function expressions, no `try`/`catch`, no classes, no destructuring — verified), so it's correct today. To prevent a future landmine, the `stmt_has_function` (leaf detection) and `collect_decl_names` (shadow detection) matches over `TaggedStatement` are now **exhaustive (no `_` wildcard)** — when the AST grows a new construct, the compiler forces a maintainer to handle it rather than silently performing an unsound rename.

## Test plan

- [x] **11 new behavior tests** driving the real `source → bridge → rename → emit` roundtrip (added `javascript-parser` + `closure-emitter` dev-deps): renaming, property-name preservation, global avoidance, redeclared/non-leaf/single-char skips, computed-member rewriting, nested-block uses
- [x] 19 crate tests pass; downstream `closurec` tests pass; clippy-clean; security review passed
- De-staled module/struct/test docs (claimed "v1 is identity")
- `closure-pass-rename` 0.2.0 → 0.3.0

This is a **pass-crate-only** change; wiring `rename` into closurec's SIMPLE pipeline is a follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)