### PR TITLE
Accept .control reset markers

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ### Added
 
+- **Deck control reset marker routing** —
+  `analyze_deck_controls()` and `resolve_deck_sources()` now accept selected
+  `.control` block `reset` session-reset markers as no-op control commands
+  instead of reporting unsupported-command diagnostics, matching Rust and
+  TypeScript.
+
 - **Deck control noaskquit option routing** —
   `analyze_deck_controls()` and `resolve_deck_sources()` now accept selected
   `.control` block `set noaskquit` UI options as no-op control commands instead

--- a/code/packages/python/spice-engine/README.md
+++ b/code/packages/python/spice-engine/README.md
@@ -161,9 +161,10 @@ it returns active lines before `.end` and stable diagnostics for unsupported
 `.include`, `.lib`, and `.control` directives. Inside `.control` blocks,
 selected analysis/output commands (`op`, `dc`, `ac`, `tran`, `save`, `probe`,
 `measure`, `meas`, `four`, `fourier`, `print`, and `plot`) are normalized into
-dotted deck cards, while `run`, `quit`, and the UI-only `set noaskquit` option
-are accepted as no-op control markers. Other unrecognized non-comment commands
-emit diagnostics until a broader executed control subset is in scope.
+dotted deck cards, while `run`, `reset`, `quit`, and the UI-only
+`set noaskquit` option are accepted as no-op control markers. Other
+unrecognized non-comment commands emit diagnostics until a broader executed
+control subset is in scope.
 `resolve_deck_sources()` is the first include/library resolution layer: callers
 provide a source-content map, `.include` directives are expanded in place, and
 `.lib path section` selects a named `.lib` / `.endl` section with stable

--- a/code/packages/python/spice-engine/src/spice_engine/compatibility.py
+++ b/code/packages/python/spice-engine/src/spice_engine/compatibility.py
@@ -515,7 +515,9 @@ _SUPPORTED_CONTROL_BLOCK_COMMANDS = frozenset(
         ".plot",
     }
 )
-_NOOP_CONTROL_BLOCK_COMMANDS = frozenset({"run", ".run", "quit", ".quit"})
+_NOOP_CONTROL_BLOCK_COMMANDS = frozenset(
+    {"run", ".run", "reset", ".reset", "quit", ".quit"}
+)
 _NOOP_CONTROL_BLOCK_SET_OPTIONS = frozenset({"noaskquit"})
 _SPICE_SUFFIX_FACTORS = {
     "t": 1.0e12,

--- a/code/packages/python/spice-engine/tests/test_compatibility.py
+++ b/code/packages/python/spice-engine/tests/test_compatibility.py
@@ -119,6 +119,7 @@ measure tran vmax MAX V(out)
 meas dc imax MAX I(V1)
 fourier 1k V(out)
 four 2k V(in)
+reset
 set noaskquit
 set filetype=ascii
 run
@@ -145,7 +146,7 @@ quit
         (".include", 2, "error"),
         (".lib", 3, "error"),
         (".control", 4, "error"),
-        (".control", 14, "error"),
+        (".control", 15, "error"),
     ]
     assert [diag.code for diag in summary.diagnostics] == [
         "SPICE_DECK_UNSUPPORTED_DIRECTIVE",
@@ -229,6 +230,7 @@ measure tran vmax MAX V(a)
 meas dc imax MAX I(V1)
 fourier 1k V(a)
 four 2k V(b)
+.reset
 .set noaskquit
 run
 .quit

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Accept selected `.control` block `reset` session-reset markers as no-op
+  control commands in `analyze_deck_controls` and `resolve_deck_sources`,
+  matching Python and TypeScript.
 - Accept selected `.control` block `set noaskquit` UI options as no-op control
   commands in `analyze_deck_controls` and `resolve_deck_sources`, matching
   Python and TypeScript.

--- a/code/packages/rust/spice-engine/README.md
+++ b/code/packages/rust/spice-engine/README.md
@@ -128,9 +128,10 @@ returns active lines before `.end` and stable diagnostics for unsupported
 `.include`, `.lib`, and `.control` directives. Inside `.control` blocks,
 selected analysis/output commands (`op`, `dc`, `ac`, `tran`, `save`, `probe`,
 `measure`, `meas`, `four`, `fourier`, `print`, and `plot`) are normalized into
-dotted deck cards, while `run`, `quit`, and the UI-only `set noaskquit` option
-are accepted as no-op control markers. Other unrecognized non-comment commands
-emit diagnostics until a broader executed control subset is in scope.
+dotted deck cards, while `run`, `reset`, `quit`, and the UI-only
+`set noaskquit` option are accepted as no-op control markers. Other
+unrecognized non-comment commands emit diagnostics until a broader executed
+control subset is in scope.
 `resolve_deck_sources` is the first include/library resolution layer: callers
 provide a source-content map, `.include` directives are expanded in place, and
 `.lib path section` selects a named `.lib` / `.endl` section with stable

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -6907,7 +6907,10 @@ fn is_noop_control_block_command(line: &str) -> bool {
     let Some(command) = parts.next().map(|command| command.to_ascii_lowercase()) else {
         return false;
     };
-    if matches!(command.as_str(), "run" | ".run" | "quit" | ".quit") {
+    if matches!(
+        command.as_str(),
+        "run" | ".run" | "reset" | ".reset" | "quit" | ".quit"
+    ) {
         return true;
     }
     if !matches!(command.as_str(), "set" | ".set") {

--- a/code/packages/rust/spice-engine/tests/compatibility_tests.rs
+++ b/code/packages/rust/spice-engine/tests/compatibility_tests.rs
@@ -136,6 +136,7 @@ measure tran vmax MAX V(out)
 meas dc imax MAX I(V1)
 fourier 1k V(out)
 four 2k V(in)
+reset
 set noaskquit
 set filetype=ascii
 run
@@ -178,7 +179,7 @@ quit
             (".include", 2, "error"),
             (".lib", 3, "error"),
             (".control", 4, "error"),
-            (".control", 14, "error")
+            (".control", 15, "error")
         ]
     );
     assert_eq!(
@@ -321,6 +322,7 @@ measure tran vmax MAX V(a)
 meas dc imax MAX I(V1)
 fourier 1k V(a)
 four 2k V(b)
+.reset
 .set noaskquit
 run
 .quit

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Accept selected `.control` block `reset` session-reset markers as no-op
+  control commands in `analyzeDeckControls` and `resolveDeckSources`, matching
+  Python and Rust.
 - Accept selected `.control` block `set noaskquit` UI options as no-op control
   commands in `analyzeDeckControls` and `resolveDeckSources`, matching Python
   and Rust.

--- a/code/packages/typescript/spice-engine/README.md
+++ b/code/packages/typescript/spice-engine/README.md
@@ -135,9 +135,10 @@ returns active lines before `.end` and stable diagnostics for unsupported
 `.include`, `.lib`, and `.control` directives. Inside `.control` blocks,
 selected analysis/output commands (`op`, `dc`, `ac`, `tran`, `save`, `probe`,
 `measure`, `meas`, `four`, `fourier`, `print`, and `plot`) are normalized into
-dotted deck cards, while `run`, `quit`, and the UI-only `set noaskquit` option
-are accepted as no-op control markers. Other unrecognized non-comment commands
-emit diagnostics until a broader executed control subset is in scope.
+dotted deck cards, while `run`, `reset`, `quit`, and the UI-only
+`set noaskquit` option are accepted as no-op control markers. Other
+unrecognized non-comment commands emit diagnostics until a broader executed
+control subset is in scope.
 `resolveDeckSources` is the first include/library resolution layer: callers
 provide a source-content map, `.include` directives are expanded in place, and
 `.lib path section` selects a named `.lib` / `.endl` section with stable

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -2854,7 +2854,7 @@ const SUPPORTED_CONTROL_BLOCK_COMMANDS = new Set([
   "plot",
   ".plot",
 ]);
-const NOOP_CONTROL_BLOCK_COMMANDS = new Set(["run", ".run", "quit", ".quit"]);
+const NOOP_CONTROL_BLOCK_COMMANDS = new Set(["run", ".run", "reset", ".reset", "quit", ".quit"]);
 const NOOP_CONTROL_BLOCK_SET_OPTIONS = new Set(["noaskquit"]);
 
 export function compatibilityCorpus(): readonly CompatibilityDeck[] {

--- a/code/packages/typescript/spice-engine/tests/compatibility.test.ts
+++ b/code/packages/typescript/spice-engine/tests/compatibility.test.ts
@@ -123,6 +123,7 @@ measure tran vmax MAX V(out)
 meas dc imax MAX I(V1)
 fourier 1k V(out)
 four 2k V(in)
+reset
 set noaskquit
 set filetype=ascii
 run
@@ -152,7 +153,7 @@ quit
       [".include", 2, "error"],
       [".lib", 3, "error"],
       [".control", 4, "error"],
-      [".control", 14, "error"],
+      [".control", 15, "error"],
     ]);
     expect(summary.diagnostics.map((diagnostic) => diagnostic.code)).toStrictEqual([
       "SPICE_DECK_UNSUPPORTED_DIRECTIVE",
@@ -236,6 +237,7 @@ measure tran vmax MAX V(a)
 meas dc imax MAX I(V1)
 fourier 1k V(a)
 four 2k V(b)
+.reset
 .set noaskquit
 run
 .quit

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -36,10 +36,10 @@ downstream tools to compare.
      stable non-executed diagnostics, and selected `.control` block
      analysis/output commands (`op`, `dc`, `ac`, `tran`, `save`, `probe`,
      `measure`, `meas`, `four`, `fourier`, `print`, and `plot`) now normalize
-     into dotted deck cards while `run`, `quit`, and UI-only `set noaskquit`
-     options are accepted as no-op control markers; parsed `.measure dc` /
-     `.meas dc` cards now route DC sweep probe samples into the shared scalar
-     measurement table surface;
+     into dotted deck cards while `run`, `reset`, `quit`, and UI-only
+     `set noaskquit` options are accepted as no-op control markers; parsed
+     `.measure dc` / `.meas dc` cards now route DC sweep probe samples into
+     the shared scalar measurement table surface;
      parsed `.measure ac` / `.meas ac` cards now route AC probe magnitudes over
      optional frequency windows into the same measurement table surface; parsed
      transient `.measure ... FIND ... AT=` cards now route single-time probe
@@ -563,6 +563,15 @@ downstream tools to compare.
     - Other `set` variables and unrecognized non-comment commands inside
       `.control` blocks remain diagnostic-only so unsupported script state and
       control flow are still explicit.
+
+51. Selected `.control` reset marker routing.
+    - Status: completed in this selected control reset-marker routing slice.
+    - Python, Rust, and TypeScript now accept selected `.control` block `reset`
+      session-reset markers as no-op control commands after selected analysis
+      and output commands have normalized into deck cards.
+    - Other unrecognized non-comment commands inside `.control` blocks remain
+      diagnostic-only so unsupported stateful script execution is still
+      explicit.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- Accept selected `.control` / `.endc` `reset` and `.reset` session-reset markers as no-op control commands in Python, Rust, and TypeScript SPICE compatibility routing.
- Keep other unrecognized non-comment `.control` commands diagnostic-only so unsupported stateful script execution remains explicit.
- Update SPICE package docs/changelogs and mark the reset-marker slice complete in the full implementation plan.

## Verification
- `PYTHONPATH="$(find code/packages/python -maxdepth 2 -type d -name src | paste -sd: -)" /Users/adhithya/.local/share/mise/installs/python/3.12.13/bin/python3 -m ruff check code/packages/python/spice-engine/src/spice_engine/compatibility.py code/packages/python/spice-engine/tests/test_compatibility.py`
- `PYTHONPATH="$(find code/packages/python -maxdepth 2 -type d -name src | paste -sd: -)" /Users/adhithya/.local/share/mise/installs/python/3.12.13/bin/python3 -m pytest code/packages/python/spice-engine/tests -q`
- `cargo fmt --manifest-path code/packages/rust/spice-engine/Cargo.toml -- --check`
- `cargo test --manifest-path code/packages/rust/spice-engine/Cargo.toml`
- `npm --prefix code/packages/typescript/spice-engine ci`
- `npm --prefix code/packages/typescript/spice-engine run build`
- `npm --prefix code/packages/typescript/spice-engine test`
- `git diff --check`