### PR TITLE
feat(MA-3e): GNU Octave — octave-runtime + octave-repl + the `octave` binary

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -207,6 +207,8 @@ members = [
     "matlab-parser",
     "matlab-runtime",
     "matlab-repl",
+    "octave-runtime",
+    "octave-repl",
     "logic-gates",
     "logic-core",
     "lookup-core",

--- a/code/packages/rust/octave-repl/BUILD
+++ b/code/packages/rust/octave-repl/BUILD
@@ -1,0 +1,1 @@
+cargo test -p coding-adventures-octave-repl -- --nocapture

--- a/code/packages/rust/octave-repl/BUILD_windows
+++ b/code/packages/rust/octave-repl/BUILD_windows
@@ -1,0 +1,1 @@
+cargo test -p coding-adventures-octave-repl -- --nocapture

--- a/code/packages/rust/octave-repl/CHANGELOG.md
+++ b/code/packages/rust/octave-repl/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [0.1.0] - 2026-06-16
+
+### Added
+
+- Initial release — the interactive REPL and the **`octave` binary** (item
+  MA-3e), a sibling of `matlab-repl` over the `octave-runtime` interpreter.
+- `OctaveRepl` with a persistent workspace, `octave> `/`... ` prompts, and
+  `quit`/`exit`/EOF handling; `run()` drives a full stdio session.
+- Line continuation across open brackets and unterminated blocks, counting the
+  Octave `endX` terminators (and `until`) as block closers at bracket depth 0;
+  `#` and `%` line comments skipped.

--- a/code/packages/rust/octave-repl/Cargo.toml
+++ b/code/packages/rust/octave-repl/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "coding-adventures-octave-repl"
+version = "0.1.0"
+edition = "2021"
+description = "Interactive REPL and `octave` binary for GNU Octave"
+
+[dependencies]
+coding-adventures-octave-runtime = { path = "../octave-runtime" }
+
+[[bin]]
+name = "octave"
+path = "src/main.rs"

--- a/code/packages/rust/octave-repl/README.md
+++ b/code/packages/rust/octave-repl/README.md
@@ -1,0 +1,32 @@
+# Octave REPL
+
+The interactive REPL and the **`octave` binary** for GNU Octave. Wraps a
+persistent [`octave-runtime`](../octave-runtime) `Interpreter`. Item **MA-3e**;
+sibling of `matlab-repl`.
+
+## Usage
+
+```sh
+cargo run -p coding-adventures-octave-repl --bin octave
+```
+
+```octave
+octave> A = [1 2; 3 4];
+octave> for i = 1:3
+...   A = A + 1;
+... endfor
+octave> A(1,1) != 4
+ans = 0
+octave> quit
+```
+
+Lines continue across open brackets and unterminated blocks — recognising both
+`end` and Octave's `endif`/`endfor`/`endwhile`/`endfunction`/`endswitch`/
+`end_try_catch` terminators — with `#`/`%` comments skipped. `quit`/`exit`/Ctrl-D
+leaves; errors are shown, not fatal.
+
+## Testing
+
+```sh
+cargo test -p coding-adventures-octave-repl
+```

--- a/code/packages/rust/octave-repl/required_capabilities.json
+++ b/code/packages/rust/octave-repl/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "rust/octave-repl",
+  "capabilities": ["stdio"],
+  "justification": "An interactive console: the `octave` binary reads Octave source from stdin and writes results to stdout. No filesystem, network, or process access beyond standard streams."
+}

--- a/code/packages/rust/octave-repl/src/lib.rs
+++ b/code/packages/rust/octave-repl/src/lib.rs
@@ -1,0 +1,217 @@
+//! # Octave REPL — an interactive Read-Eval-Print loop for GNU Octave.
+//!
+//! [`OctaveRepl`] wraps a persistent [`Interpreter`] (which normalizes Octave
+//! syntax to MATLAB and delegates to `matlab-runtime`) and adds the console
+//! behaviours: line continuation across open brackets and unterminated blocks —
+//! recognising both `end` and Octave's `endif`/`endfor`/`endwhile`/`endfunction`/
+//! `endswitch`/`end_try_catch` terminators — plus `#`/`%` comments and `"`/`'`
+//! strings. Sibling of `matlab-repl`.
+
+use coding_adventures_octave_runtime::Interpreter;
+use std::io::{BufRead, Write};
+
+/// What the REPL should do after being fed one physical line.
+#[derive(Debug, PartialEq, Eq)]
+pub enum ReplResponse {
+    Output(String),
+    NeedMore,
+    Quit,
+}
+
+/// A persistent interactive Octave session.
+pub struct OctaveRepl {
+    interp: Interpreter,
+    buffer: String,
+}
+
+impl Default for OctaveRepl {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl OctaveRepl {
+    pub fn new() -> Self {
+        OctaveRepl {
+            interp: Interpreter::new(),
+            buffer: String::new(),
+        }
+    }
+
+    pub fn prompt(&self) -> &'static str {
+        if self.buffer.is_empty() {
+            "octave> "
+        } else {
+            "... "
+        }
+    }
+
+    /// Feed one physical input line (without its trailing newline).
+    pub fn feed(&mut self, line: &str) -> ReplResponse {
+        if self.buffer.is_empty() {
+            match line.trim() {
+                "quit" | "exit" | "quit()" | "exit()" => return ReplResponse::Quit,
+                _ => {}
+            }
+        }
+        self.buffer.push_str(line);
+        self.buffer.push('\n');
+
+        if is_incomplete(&self.buffer) {
+            return ReplResponse::NeedMore;
+        }
+
+        let src = std::mem::take(&mut self.buffer);
+        if src.trim().is_empty() {
+            return ReplResponse::Output(String::new());
+        }
+        match self.interp.feed(&src) {
+            Ok(text) => ReplResponse::Output(text),
+            Err(e) => ReplResponse::Output(format!("Error: {e}\n")),
+        }
+    }
+
+    pub fn is_continuing(&self) -> bool {
+        !self.buffer.is_empty()
+    }
+}
+
+/// Is the accumulated source incomplete — an open bracket, an unterminated
+/// `"`-string, or a block keyword without its `end`/`endX`? `#` and `%` line
+/// comments are skipped; `'` is treated as transpose (char arrays are
+/// single-line).
+fn is_incomplete(src: &str) -> bool {
+    let mut bracket: i32 = 0;
+    let mut blocks: i32 = 0;
+    let mut in_string = false;
+
+    for raw_line in src.lines() {
+        let mut word = String::new();
+        let flush = |w: &mut String, blocks: &mut i32, bracket: i32| {
+            if !w.is_empty() {
+                match w.as_str() {
+                    "if" | "for" | "while" | "switch" | "try" | "function" | "parfor" | "do" => {
+                        *blocks += 1
+                    }
+                    // Any of these closes a block — but only at bracket depth 0,
+                    // since a bare `end` inside `( )` is the index sentinel.
+                    "end" | "endif" | "endfor" | "endwhile" | "endfunction" | "endswitch"
+                    | "endparfor" | "end_try_catch" | "until"
+                        if bracket == 0 =>
+                    {
+                        *blocks -= 1
+                    }
+                    _ => {}
+                }
+                w.clear();
+            }
+        };
+        for ch in raw_line.chars() {
+            if in_string {
+                if ch == '"' {
+                    in_string = false;
+                }
+                continue;
+            }
+            match ch {
+                '%' | '#' => break, // line comment
+                '"' => {
+                    flush(&mut word, &mut blocks, bracket);
+                    in_string = true;
+                }
+                '(' | '[' | '{' => {
+                    flush(&mut word, &mut blocks, bracket);
+                    bracket += 1;
+                }
+                ')' | ']' | '}' => {
+                    flush(&mut word, &mut blocks, bracket);
+                    bracket -= 1;
+                }
+                c if c.is_alphanumeric() || c == '_' => word.push(c),
+                _ => flush(&mut word, &mut blocks, bracket),
+            }
+        }
+        flush(&mut word, &mut blocks, bracket);
+    }
+    bracket > 0 || blocks > 0 || in_string
+}
+
+/// Drive a full interactive Octave session over the given reader and writer.
+pub fn run<R: BufRead, W: Write>(mut reader: R, mut writer: W) -> std::io::Result<()> {
+    let mut repl = OctaveRepl::new();
+    writeln!(
+        writer,
+        "GNU Octave (on the MATLAB stack) — type quit to exit."
+    )?;
+
+    loop {
+        write!(writer, "{}", repl.prompt())?;
+        writer.flush()?;
+
+        let mut line = String::new();
+        if reader.read_line(&mut line)? == 0 {
+            writeln!(writer)?;
+            break;
+        }
+        let line = line.strip_suffix('\n').unwrap_or(&line);
+        let line = line.strip_suffix('\r').unwrap_or(line);
+
+        match repl.feed(line) {
+            ReplResponse::Output(text) => {
+                write!(writer, "{text}")?;
+                writer.flush()?;
+            }
+            ReplResponse::NeedMore => {}
+            ReplResponse::Quit => break,
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn continues_across_an_endfor_block() {
+        let mut r = OctaveRepl::new();
+        assert_eq!(r.feed("s = 0;"), ReplResponse::Output(String::new()));
+        assert_eq!(r.feed("for i = 1:3"), ReplResponse::NeedMore);
+        assert_eq!(r.feed("  s = s + i;"), ReplResponse::NeedMore);
+        assert!(matches!(r.feed("endfor"), ReplResponse::Output(_))); // endfor closes it
+        assert!(matches!(r.feed("s"), ReplResponse::Output(t) if t.contains("6")));
+    }
+
+    #[test]
+    fn if_endif_with_bang_not() {
+        let mut r = OctaveRepl::new();
+        assert_eq!(r.feed("x = 0;"), ReplResponse::Output(String::new()));
+        assert_eq!(r.feed("if !x"), ReplResponse::NeedMore);
+        assert_eq!(r.feed("  y = 7;"), ReplResponse::NeedMore);
+        assert!(matches!(r.feed("endif"), ReplResponse::Output(_)));
+        assert!(matches!(r.feed("y"), ReplResponse::Output(t) if t.contains("7")));
+    }
+
+    #[test]
+    fn hash_comment_and_brackets() {
+        let mut r = OctaveRepl::new();
+        assert_eq!(r.feed("A = [1 2  # a row"), ReplResponse::NeedMore); // open bracket
+        assert!(matches!(r.feed("3 4];"), ReplResponse::Output(_)));
+    }
+
+    #[test]
+    fn quit_and_errors() {
+        assert_eq!(OctaveRepl::new().feed("quit"), ReplResponse::Quit);
+        let mut r = OctaveRepl::new();
+        assert!(matches!(r.feed("nope"), ReplResponse::Output(t) if t.contains("Error")));
+        assert!(matches!(r.feed("1 + 1"), ReplResponse::Output(t) if t.contains("2")));
+    }
+
+    #[test]
+    fn run_drives_a_session() {
+        let input = b"x = 3;\nx != 2\nquit\n" as &[u8];
+        let mut output = Vec::new();
+        run(input, &mut output).unwrap();
+        assert!(String::from_utf8(output).unwrap().contains('1')); // 3 != 2 is true
+    }
+}

--- a/code/packages/rust/octave-repl/src/main.rs
+++ b/code/packages/rust/octave-repl/src/main.rs
@@ -1,0 +1,18 @@
+//! The `octave` binary — an interactive prompt for GNU Octave.
+//!
+//! Reads one line at a time (continuing across open brackets and unterminated
+//! `if`/`for`/`while`/… blocks, closed by `end` or `endif`/`endfor`/…),
+//! normalizes Octave syntax to MATLAB, and evaluates over `array-runtime`. Type
+//! `quit`/`exit` (or Ctrl-D) to leave. All logic lives in
+//! [`coding_adventures_octave_repl::run`].
+
+use std::io;
+
+fn main() {
+    let stdin = io::stdin();
+    let stdout = io::stdout();
+    if let Err(e) = coding_adventures_octave_repl::run(stdin.lock(), stdout.lock()) {
+        eprintln!("octave: I/O error: {e}");
+        std::process::exit(1);
+    }
+}

--- a/code/packages/rust/octave-runtime/BUILD
+++ b/code/packages/rust/octave-runtime/BUILD
@@ -1,0 +1,1 @@
+cargo test -p coding-adventures-octave-runtime -- --nocapture

--- a/code/packages/rust/octave-runtime/BUILD_windows
+++ b/code/packages/rust/octave-runtime/BUILD_windows
@@ -1,0 +1,1 @@
+cargo test -p coding-adventures-octave-runtime -- --nocapture

--- a/code/packages/rust/octave-runtime/CHANGELOG.md
+++ b/code/packages/rust/octave-runtime/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [0.1.0] - 2026-06-16
+
+### Added
+
+- Initial release — **MA-3e**, GNU Octave as a source-compatibility shim over
+  `matlab-runtime` (spec [`MA01`](../../../specs/MA01-matlab-language.md) §5).
+- `octavify(source)`: rewrites `#` comments → `%`, the `endX` block terminators
+  (`endif`/`endfor`/`endwhile`/`endfunction`/`endswitch`/`endparfor`/
+  `end_try_catch`) → `end`, and `!`/`!=` → `~`/`~=`, leaving string and comment
+  contents untouched (transpose-vs-quote aware).
+- `Interpreter` + `eval` that `octavify` then delegate to `matlab-runtime`, so
+  the matrix engine (incl. `*` lowering to `array-runtime::execute`), indexing,
+  builtins, and control flow are inherited unchanged.
+- Deferred: `++`/`--`, `do…until`.

--- a/code/packages/rust/octave-runtime/Cargo.toml
+++ b/code/packages/rust/octave-runtime/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "coding-adventures-octave-runtime"
+version = "0.1.0"
+edition = "2021"
+description = "GNU Octave frontend — a source-compatibility shim over matlab-runtime"
+
+[dependencies]
+coding-adventures-matlab-runtime = { path = "../matlab-runtime" }

--- a/code/packages/rust/octave-runtime/README.md
+++ b/code/packages/rust/octave-runtime/README.md
@@ -1,0 +1,44 @@
+# Octave Runtime
+
+GNU Octave on the MATLAB stack. **Octave is to MATLAB what R is to S** — a
+compatible reimplementation with a few syntactic additions. Item **MA-3e** of
+the historical math-languages roadmap; see
+[`MA01`](../../../specs/MA01-matlab-language.md) §5.
+
+## How it works
+
+Where R needed its own lexer/parser (its `_`/`->>` differences are pervasive),
+Octave's departures from MATLAB are a small, *local* set of surface forms — so
+this crate reuses the **entire** MATLAB frontend
+([`matlab-runtime`](../matlab-runtime), and through it the MATLAB lexer/parser and
+[`array-runtime`](../array-runtime)) behind a thin **source-compatibility shim**,
+`octavify`, that normalizes Octave syntax to MATLAB before evaluation. The matrix
+engine, the **GPU-lowering of `*`**, 1-based indexing, and control flow are all
+inherited unchanged.
+
+| Octave | becomes (MATLAB) |
+|--------|------------------|
+| `# comment` | `% comment` |
+| `endif`/`endfor`/`endwhile`/`endfunction`/`endswitch`/`end_try_catch` | `end` |
+| `!=` | `~=` |
+| `!` | `~` |
+
+The shim is **string- and comment-aware** (and handles MATLAB's transpose-vs-quote
+ambiguity), so `'#tag'`, `"a != b"`, and `A'` are never rewritten.
+
+```rust
+use coding_adventures_octave_runtime::eval;
+let out = eval("if !0\n  x = 6;\nendif\nx * x\n").unwrap();
+assert!(out.contains("36"));
+```
+
+### Deferred
+
+Octave's `++`/`--` and `do…until` (no MATLAB equivalent) are left as-is and
+currently error; documented deferrals, plus everything `matlab-runtime` defers.
+
+## Testing
+
+```sh
+cargo test -p coding-adventures-octave-runtime
+```

--- a/code/packages/rust/octave-runtime/required_capabilities.json
+++ b/code/packages/rust/octave-runtime/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "rust/octave-runtime",
+  "capabilities": [],
+  "justification": "Pure computation: a source-to-source shim that normalizes Octave syntax to MATLAB, then delegates to matlab-runtime. No filesystem, network, or process access."
+}

--- a/code/packages/rust/octave-runtime/src/lib.rs
+++ b/code/packages/rust/octave-runtime/src/lib.rs
@@ -1,0 +1,274 @@
+//! # Octave Runtime — GNU Octave on the MATLAB stack.
+//!
+//! GNU Octave is to MATLAB what R is to S: a compatible reimplementation with a
+//! few syntactic additions. Where R needed its own lexer/parser (its `_`/`->>`
+//! differences are pervasive), Octave's departures from MATLAB are a small,
+//! local set of surface forms — so this crate reuses the **entire** MATLAB
+//! frontend ([`matlab_runtime`], and through it the MATLAB lexer/parser and
+//! `array-runtime`) behind a thin **source-compatibility shim**, [`octavify`],
+//! that normalizes Octave syntax to MATLAB before evaluation. The matrix engine,
+//! the GPU-lowering of `*`, indexing, and control flow are all inherited
+//! unchanged.
+//!
+//! ## What the shim normalizes
+//!
+//! | Octave                              | becomes (MATLAB) |
+//! |-------------------------------------|------------------|
+//! | `# comment`                         | `% comment`      |
+//! | `endif`/`endfor`/`endwhile`/`endfunction`/`endswitch`/`end_try_catch` | `end` |
+//! | `!=`                                | `~=`             |
+//! | `!` (logical not)                   | `~`              |
+//!
+//! All four are rewritten *only outside* string literals and comments — the shim
+//! is string/comment-aware (and handles MATLAB's transpose-vs-quote ambiguity)
+//! so `'#tag'`, `"a != b"`, and `A'` are never touched. Octave's `++`/`--` and
+//! `do…until` (which have no MATLAB equivalent) are left as-is and currently
+//! error; they are documented deferrals.
+
+use coding_adventures_matlab_runtime::Interpreter as MatlabInterpreter;
+
+pub use coding_adventures_matlab_runtime::MatValue;
+
+/// A persistent Octave session — a thin wrapper that `octavify`s each input and
+/// delegates to a [`matlab_runtime::Interpreter`]. Variables persist across
+/// calls.
+pub struct Interpreter {
+    inner: MatlabInterpreter,
+}
+
+impl Default for Interpreter {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Interpreter {
+    pub fn new() -> Self {
+        Interpreter {
+            inner: MatlabInterpreter::new(),
+        }
+    }
+
+    /// Normalize Octave source to MATLAB and evaluate it.
+    pub fn feed(&mut self, source: &str) -> Result<String, String> {
+        self.inner.feed(&octavify(source))
+    }
+}
+
+/// Evaluate Octave source in a fresh session and return its display output.
+pub fn eval(source: &str) -> Result<String, String> {
+    Interpreter::new().feed(source)
+}
+
+/// The Octave→MATLAB source shim. Rewrites `#` comments, the `endX` block
+/// terminators, and `!`/`!=`, leaving string and comment contents untouched.
+pub fn octavify(source: &str) -> String {
+    let chars: Vec<char> = source.chars().collect();
+    let mut out = String::with_capacity(chars.len());
+    let mut i = 0;
+    let n = chars.len();
+    // Whether the immediately-preceding character was a value-terminator — used,
+    // exactly as in the MATLAB lexer, to tell a transpose `A'` from a string `'…'`.
+    let mut prev_value = false;
+
+    while i < n {
+        let c = chars[i];
+        match c {
+            // A `%` comment is already MATLAB-style: copy verbatim to end of line.
+            '%' => {
+                while i < n && chars[i] != '\n' {
+                    out.push(chars[i]);
+                    i += 1;
+                }
+            }
+            // An Octave `#` comment becomes a `%` comment.
+            '#' => {
+                out.push('%');
+                i += 1;
+                while i < n && chars[i] != '\n' {
+                    out.push(chars[i]);
+                    i += 1;
+                }
+            }
+            // Double-quoted string: copy whole (honour the `""` escape).
+            '"' => {
+                out.push('"');
+                i += 1;
+                while i < n {
+                    if chars[i] == '"' {
+                        if i + 1 < n && chars[i + 1] == '"' {
+                            out.push_str("\"\"");
+                            i += 2;
+                        } else {
+                            out.push('"');
+                            i += 1;
+                            break;
+                        }
+                    } else {
+                        out.push(chars[i]);
+                        i += 1;
+                    }
+                }
+                prev_value = true;
+            }
+            // A `'` after a value is transpose; otherwise it opens a char array.
+            '\'' if prev_value => {
+                out.push('\'');
+                i += 1;
+                prev_value = true;
+            }
+            '\'' => {
+                out.push('\'');
+                i += 1;
+                while i < n {
+                    if chars[i] == '\'' {
+                        if i + 1 < n && chars[i + 1] == '\'' {
+                            out.push_str("''");
+                            i += 2;
+                        } else {
+                            out.push('\'');
+                            i += 1;
+                            break;
+                        }
+                    } else {
+                        out.push(chars[i]);
+                        i += 1;
+                    }
+                }
+                prev_value = true;
+            }
+            // `!=` → `~=`, `!` → `~`.
+            '!' => {
+                if i + 1 < n && chars[i + 1] == '=' {
+                    out.push_str("~=");
+                    i += 2;
+                } else {
+                    out.push('~');
+                    i += 1;
+                }
+                prev_value = false;
+            }
+            // A word: an `endX` block terminator is rewritten to `end`.
+            c if c.is_alphanumeric() || c == '_' => {
+                let start = i;
+                while i < n && (chars[i].is_alphanumeric() || chars[i] == '_') {
+                    i += 1;
+                }
+                let word: String = chars[start..i].iter().collect();
+                let mapped = match word.as_str() {
+                    "endif" | "endfor" | "endwhile" | "endfunction" | "endswitch" | "endparfor"
+                    | "end_try_catch" => "end",
+                    other => other,
+                };
+                out.push_str(mapped);
+                prev_value = true; // an identifier/number is a value-terminator
+            }
+            ')' | ']' | '}' => {
+                out.push(c);
+                i += 1;
+                prev_value = true;
+            }
+            '.' => {
+                out.push('.');
+                i += 1;
+                prev_value = true;
+            }
+            ' ' | '\t' | '\n' | '\r' => {
+                out.push(c);
+                i += 1;
+                prev_value = false;
+            }
+            _ => {
+                out.push(c);
+                i += 1;
+                prev_value = false;
+            }
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn scalar(src: &str) -> f64 {
+        let out = eval(src).unwrap_or_else(|e| panic!("eval failed for {src:?}: {e}"));
+        out.rsplit('=')
+            .next()
+            .unwrap()
+            .trim()
+            .parse::<f64>()
+            .unwrap_or_else(|_| panic!("not a scalar echo: {out:?}"))
+    }
+
+    // --- the shim itself ------------------------------------------------
+
+    #[test]
+    fn octavify_rewrites_octave_forms() {
+        assert_eq!(octavify("x != 3"), "x ~= 3");
+        assert_eq!(octavify("!done"), "~done");
+        assert_eq!(octavify("# a comment\n"), "% a comment\n");
+        assert_eq!(octavify("if x\n  y = 1;\nendif\n"), "if x\n  y = 1;\nend\n");
+        assert_eq!(octavify("for i=1:3\nendfor\n"), "for i=1:3\nend\n");
+    }
+
+    #[test]
+    fn shim_leaves_strings_and_comments_alone() {
+        // `!`, `#`, and `endif` inside a char array / string / comment are kept.
+        assert_eq!(octavify("s = '!= endif #'"), "s = '!= endif #'");
+        assert_eq!(octavify("t = \"a != b\""), "t = \"a != b\"");
+        assert_eq!(octavify("% keep != and endif\n"), "% keep != and endif\n");
+        // A transpose is not mistaken for a string opener.
+        assert_eq!(octavify("y = A'"), "y = A'");
+    }
+
+    // --- evaluation through the MATLAB engine ---------------------------
+
+    #[test]
+    fn octave_blocks_and_operators_evaluate() {
+        // `endfor` / `endif` and `!=` work end-to-end.
+        let mut m = Interpreter::new();
+        m.feed("s = 0;\nfor i = 1:5\n  s = s + i;\nendfor\n")
+            .unwrap();
+        assert_eq!(scalar("s = 15"), 15.0); // sanity on the helper
+        assert_eq!(
+            m.feed("s\n").unwrap().rsplit('=').next().unwrap().trim(),
+            "15"
+        );
+    }
+
+    #[test]
+    fn octave_not_equal_and_hash_comment() {
+        assert_eq!(scalar("x = 5;  # set x\nx ~= 4\n"), 1.0); // 5 != 4 is true (1)
+        assert_eq!(scalar("3 != 3\n"), 0.0);
+    }
+
+    #[test]
+    fn the_matrix_engine_is_inherited() {
+        // The headline MATLAB capability — matmul through array-runtime — works
+        // unchanged from Octave syntax.
+        let mut m = Interpreter::new();
+        m.feed("A = [1 2; 3 4];\n").unwrap();
+        m.feed("B = A * A;\n").unwrap();
+        assert_eq!(
+            m.feed("B(1,1)\n")
+                .unwrap()
+                .rsplit('=')
+                .next()
+                .unwrap()
+                .trim(),
+            "7"
+        );
+    }
+
+    #[test]
+    fn if_endif_with_not() {
+        let mut m = Interpreter::new();
+        m.feed("x = 0;\nif !x\n  y = 42;\nendif\n").unwrap();
+        assert_eq!(
+            m.feed("y\n").unwrap().rsplit('=').next().unwrap().trim(),
+            "42"
+        );
+    }
+}

--- a/code/specs/MA01-matlab-language.md
+++ b/code/specs/MA01-matlab-language.md
@@ -143,13 +143,19 @@ Other lexer specifics (MA-3b):
   `array-runtime::{ops, execute}`. The value model is shared, not reinvented.
 - **REPL & binary:** `matlab-repl` + a `matlab` binary, mirroring `s-repl`/`R`.
 
-## §5 Octave
+## §5 Octave *(MA-3e — done)*
 
 GNU Octave is to MATLAB roughly what R is to S — a compatible reimplementation
-with small additions (`#` comments, `++`/`--`, `endif`/`endfor`, `!=`). Once the
-MATLAB frontend exists, Octave is a thin sibling: the same `array-runtime`
-runtime with an `octave.tokens`/`octave.grammar` that adds those forms (the S→R
-playbook). Tracked for after MA-3.
+with small additions (`#` comments, `endif`/`endfor`/… terminators, `!`/`!=` for
+`~`/`~=`). Because those departures are a small, *local* set of surface forms
+(unlike R's pervasive `_`/`->>`, which forced a separate lexer/parser), Octave
+reuses the **entire** MATLAB frontend behind a thin **source-compatibility
+shim** rather than a new grammar: `octave-runtime`'s `octavify` rewrites the
+Octave-only forms to MATLAB (string/comment-aware, so literals are untouched)
+and delegates to `matlab-runtime`. The matrix engine, the `*`→`execute` GPU
+lowering, indexing, and control flow are inherited unchanged. The `octave-repl`
+crate adds the `octave` binary (continuation recognises the `endX` terminators).
+*Deferred:* `++`/`--` and `do…until` (no MATLAB equivalent).
 
 ## §6 Crate layout
 
@@ -182,8 +188,10 @@ is registered in `code/packages/rust/Cargo.toml` members.
   `if`/`for`/`while`, the `ans =`/`x =` echo, and the core built-ins. *Deferred:*
   user `function` definitions, anonymous `@(x)`, cells, `switch`/`try` execution,
   matrix solve/power, indexed and multi-assignment.
-- **MA-3e+ — Octave** (§5), then the wider built-in library, then APL/Maxima/
-  Wolfram per [`HML00`](HML00-historical-math-languages-roadmap.md).
+- **MA-3e — Octave** *(done, §5)* — `octave-runtime` (the `octavify` shim) +
+  `octave-repl` (the `octave` binary), reusing the whole MATLAB frontend.
+- **Next:** the wider built-in library, then APL/Maxima/Wolfram per
+  [`HML00`](HML00-historical-math-languages-roadmap.md).
 
 ## §8 References
 


### PR DESCRIPTION
## What & why

**MA-3e** — GNU Octave, **completing the MATLAB/Octave family**. Octave is to MATLAB what R is to S: a compatible reimplementation. But where R needed its own lexer/parser (its `_`/`->>` differences are pervasive), Octave's departures from MATLAB are a small, *local* set of surface forms — so this lands as a thin **source-compatibility shim** reusing the **entire** MATLAB frontend ([matlab-runtime](code/packages/rust/matlab-runtime), and through it the MATLAB lexer/parser and [array-runtime](code/packages/rust/array-runtime)), **not** a new grammar. Implements [MA01](code/specs/MA01-matlab-language.md) §5.

## How

`octave-runtime`'s **`octavify(source)`** rewrites the Octave-only forms to MATLAB:

| Octave | → MATLAB |
|--------|----------|
| `# comment` | `% comment` |
| `endif`/`endfor`/`endwhile`/`endfunction`/`endswitch`/`endparfor`/`end_try_catch` | `end` |
| `!=` | `~=` |
| `!` | `~` |

It's **string- and comment-aware** (and handles the transpose-vs-quote ambiguity with the same prev-value rule as the MATLAB lexer), so `'#tag'`, `"a != b"`, and `A'` are never rewritten. `Interpreter`/`eval` `octavify` then delegate to `matlab-runtime` — so the **matrix engine (incl. `*` lowering to `array_runtime::execute(MatMul)`), 1-based indexing, builtins, and control flow are inherited unchanged**, with **zero changes to the matlab-\* crates**.

`octave-repl` adds the **`octave` binary** (sibling of `matlab`/`R`), with continuation that recognises both `end` and the Octave `endX` terminators (and `until`) as block closers at bracket depth 0.

```octave
octave> A = [1 2; 3 4];
octave> for i = 1:3
...   A = A + 1;
... endfor
octave> A(1,1) != 4
ans = 0
```

## Quality

5 octave-runtime + 6 octave-repl tests (the shim's rewrites; leaving strings/comments/transpose untouched; `endfor`/`endif` blocks; `!`/`!=`; `#` comments; and the inherited matmul-through-`execute`); `cargo fmt` + `cargo clippy` clean. **`/security-review` → PASSED**: `octavify` always advances (no hang), all peeks bounds-guarded, the transform can't change bracket counts (so it can't defeat matlab-runtime's `check_nesting`), output length-bounded, REPL heuristic can't wedge or panic.

Deferred (documented): `++`/`--` and `do…until` (no MATLAB equivalent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)