### PR TITLE
feat(closurec): SIMPLE pipeline gains rename (shortens leaf-function params)

### DIFF
--- a/code/programs/rust/closurec/CHANGELOG.md
+++ b/code/programs/rust/closurec/CHANGELOG.md
@@ -2,6 +2,40 @@
 
 All notable changes to the `coding-adventures-closurec` binary will be documented in this file.
 
+## [0.143.0] - 2026-06-16
+
+### Added (CLOC12.160 — SIMPLE pipeline gains `rename`)
+
+The `--compilation_level SIMPLE` pass pipeline is now
+`constant-fold → fold-control-flow → dce → inline → remove-unused-vars →
+treeshake → rename`. The final pass shortens the parameters of **leaf
+functions** (functions with no nested function) to short names, while keeping
+the potentially-externally-visible function name:
+
+```js
+function distance(horizontal, vertical) { return horizontal*horizontal + vertical*vertical; }
+distance(3, 4);
+//  ⇒  function distance(a,b){return a * a + b * b};distance(3,4);
+```
+
+`rename` runs last (it has no dependencies; registration order places it at the
+end) so it shortens names after every structural pass has finished. It relies
+on `closure-pass-rename` 0.3.0's conservative α-rename — property names, free
+globals, redeclared parameters, and non-leaf functions are all left untouched.
+
+- `SIMPLE_PASS_NAMES` is now
+  `[constant-fold, fold-control-flow, dce, inline, remove-unused-vars, treeshake, rename]`;
+  the `simple_v2` correlation-vector trace lists all seven.
+
+### Verified
+- New `tests/diff/simple-rename/` fixture + `tests/diff_simple_rename.rs`:
+  `function distance(horizontal, vertical) {…} distance(3, 4);` ⇒
+  `function distance(a,b){return a * a + b * b};distance(3,4);`.
+- New unit tests `simple_rename_shortens_leaf_function_params`,
+  `simple_rename_keeps_property_names` (property names preserved),
+  `simple_rename_whitespace_only_keeps_param_names`.
+- `simple_v2` CV test updated to expect all seven pass names.
+
 ## [0.142.0] - 2026-06-16
 
 ### Added (CLOC12.159 — SIMPLE pipeline gains `treeshake`)

--- a/code/programs/rust/closurec/Cargo.toml
+++ b/code/programs/rust/closurec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closurec"
-version = "0.142.0"
+version = "0.143.0"
 edition = "2021"
 description = "closurec — CLI driver for the Closure Compiler clone. Mirrors the upstream Java Closure Compiler's command-line flag surface (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility. Per CLOC08."
 

--- a/code/programs/rust/closurec/README.md
+++ b/code/programs/rust/closurec/README.md
@@ -124,7 +124,7 @@ body fills in.**
 | Level | What it does |
 |-------|--------------|
 | `WHITESPACE_ONLY` | Strips comments and inter-token whitespace only. Token-level; never parses to a typed AST. |
-| `SIMPLE` | Runs the typed-AST optimization pipeline — parse → bridge → passes → emit. Today the pipeline is `constant-fold → fold-control-flow → dce → inline → remove-unused-vars → treeshake` (e.g. `1 + 2` ⇒ `3`; `if (2 > 3) {a} else {b}` ⇒ `{b}`; code after a `return` is dropped; unused top-level `var`s with pure initializers and unused top-level `function`s are deleted); more passes land one PR at a time. Falls back to `WHITESPACE_ONLY` if the source uses a not-yet-supported construct, so it never errors on valid input. |
+| `SIMPLE` | Runs the typed-AST optimization pipeline — parse → bridge → passes → emit. Today the pipeline is `constant-fold → fold-control-flow → dce → inline → remove-unused-vars → treeshake → rename` (e.g. `1 + 2` ⇒ `3`; `if (2 > 3) {a} else {b}` ⇒ `{b}`; code after a `return` is dropped; unused top-level `var`s with pure initializers and unused top-level `function`s are deleted; leaf-function parameters are shortened to `a`, `b`, …); more passes land one PR at a time. Falls back to `WHITESPACE_ONLY` if the source uses a not-yet-supported construct, so it never errors on valid input. |
 | `ADVANCED` / `BUNDLE` / `TRANSPILE_ONLY` | Identity passthrough for now — the typed passes specific to these levels (tree-shaking, property renaming, etc.) land in follow-up work. |
 
 The SIMPLE pipeline:

--- a/code/programs/rust/closurec/cli.spec.json
+++ b/code/programs/rust/closurec/cli.spec.json
@@ -2,7 +2,7 @@
   "cli_builder_spec_version": "1.0",
   "name": "closurec",
   "description": "closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.",
-  "version": "0.142.0",
+  "version": "0.143.0",
   "parsing_mode": "gnu",
   "flags": [
     { "id": "browser_featureset_year", "long": "browser_featureset_year", "type": "integer", "default": 0, "description": "Shortcut for defining goog.FEATURESET_YEAR=YYYY (minimum 2012)." },

--- a/code/programs/rust/closurec/src/run.rs
+++ b/code/programs/rust/closurec/src/run.rs
@@ -244,6 +244,7 @@ const SIMPLE_PASS_NAMES: &[&str] = &[
     "inline",
     "remove-unused-vars",
     "treeshake",
+    "rename",
 ];
 
 /// Run the SIMPLE optimization pipeline over a bridged `Program` and
@@ -278,6 +279,7 @@ fn run_simple_pipeline(
     use coding_adventures_closure_pass_inline::InlinePass;
     use coding_adventures_closure_pass_pipeline::PassPipeline;
     use coding_adventures_closure_pass_remove_unused_vars::RemoveUnusedVarsPass;
+    use coding_adventures_closure_pass_rename::RenamePass;
     use coding_adventures_closure_pass_treeshake::TreeshakePass;
     use coding_adventures_correlation_vector::CVLog;
     use coding_adventures_type_sidecar::Sidecar;
@@ -301,6 +303,11 @@ fn run_simple_pipeline(
     pipeline.add(Box::new(InlinePass::new()));
     pipeline.add(Box::new(RemoveUnusedVarsPass::new()));
     pipeline.add(Box::new(TreeshakePass::new()));
+    // rename runs last: it shortens leaf-function parameter names after
+    // every structural pass has finished removing/rewriting code. It has
+    // no dependencies (correct standalone), so registration order places
+    // it at the end.
+    pipeline.add(Box::new(RenamePass::new()));
 
     let optimized = match pipeline.run(program, &sidecar, &mut pass_cv) {
         Ok(out) => out.program,
@@ -5827,6 +5834,56 @@ mod tests {
     }
 
     #[test]
+    fn simple_rename_shortens_leaf_function_params() {
+        // CLOC12.160: the SIMPLE pipeline now ends with rename, which
+        // shortens a leaf function's parameter names. The function is
+        // called so treeshake keeps it; the top-level name `f` is kept,
+        // its parameter `longName` becomes `a`.
+        let cfg = CompilerConfig {
+            compilation: crate::config::CompilationConfig {
+                level: crate::config::CompilationLevel::Simple,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let out = transform_source("function f(longName) { return longName + 1; } f(5);", &cfg)
+            .expect("ok");
+        assert_eq!(out, "function f(a){return a + 1};f(5);");
+    }
+
+    #[test]
+    fn simple_rename_keeps_property_names() {
+        // Rename must not touch property names: `obj.longName` keeps its
+        // `.longName`; only the parameter `obj` is shortened.
+        let cfg = CompilerConfig {
+            compilation: crate::config::CompilationConfig {
+                level: crate::config::CompilationLevel::Simple,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let out =
+            transform_source("function f(obj) { return obj.longName; } f(x);", &cfg).expect("ok");
+        assert_eq!(out, "function f(a){return a.longName};f(x);");
+    }
+
+    #[test]
+    fn simple_rename_whitespace_only_keeps_param_names() {
+        // Companion — the SAME input under WHITESPACE_ONLY keeps the full
+        // parameter name, proving the renaming is the SIMPLE pipeline's.
+        let cfg = CompilerConfig {
+            compilation: crate::config::CompilationConfig {
+                level: crate::config::CompilationLevel::WhitespaceOnly,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let out = transform_source("function f(longName) { return longName + 1; } f(5);", &cfg)
+            .expect("ok");
+        assert_eq!(out, "function f(longName){return longName+1};f(5);");
+    }
+
+    #[test]
     fn simple_level_bridge_ok_status_in_cv() {
         // When the source parses cleanly, the CV contribution for the
         // `compilation_level` stage must carry bridge_status = "ok".
@@ -5865,7 +5922,7 @@ mod tests {
         // The pass pipeline must be recorded in the trace, in order.
         assert!(
             body.contains(
-                "\"passes\":[\"constant-fold\",\"fold-control-flow\",\"dce\",\"inline\",\"remove-unused-vars\",\"treeshake\"]"
+                "\"passes\":[\"constant-fold\",\"fold-control-flow\",\"dce\",\"inline\",\"remove-unused-vars\",\"treeshake\",\"rename\"]"
             ),
             "expected passes list in CV sidecar: {body}"
         );

--- a/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
@@ -2,7 +2,7 @@
 
 closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.
 
-Version: 0.142.0
+Version: 0.143.0
 
 ## Flags
 

--- a/code/programs/rust/closurec/tests/diff/simple-rename/README.md
+++ b/code/programs/rust/closurec/tests/diff/simple-rename/README.md
@@ -1,0 +1,35 @@
+# Fixture: `simple-rename`
+
+End-to-end oracle for the `rename` pass in `--compilation_level SIMPLE`
+(CLOC12.160).
+
+| File | Role |
+|------|------|
+| `flags.txt` | `--compilation_level SIMPLE --js input/a.js` |
+| `input/a.js` | A called leaf function with descriptive parameter names |
+| `expected.stdout` | `function distance(a,b){return a * a + b * b};distance(3,4);` |
+
+The SIMPLE pipeline is now
+`constant-fold → fold-control-flow → dce → inline → remove-unused-vars →
+treeshake → rename`. The final pass shortens the parameters of leaf
+functions:
+
+| Source | Fate |
+|--------|------|
+| function name `distance` | kept — top-level, potentially externally visible |
+| param `horizontal` | renamed to `a` |
+| param `vertical` | renamed to `b` |
+
+`distance(3, 4)` keeps the function past `treeshake`. The same input under
+`WHITESPACE_ONLY` keeps the full parameter names. See the
+`closure-pass-rename` crate for the full (conservative) rename rules —
+property names, free globals, redeclared params, and non-leaf functions are
+all left untouched.
+
+Regenerate the expected file after an intentional behavior change:
+
+```sh
+cargo run -- --compilation_level SIMPLE \
+    --js tests/diff/simple-rename/input/a.js \
+    > tests/diff/simple-rename/expected.stdout
+```

--- a/code/programs/rust/closurec/tests/diff/simple-rename/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/simple-rename/expected.stdout
@@ -1,0 +1,2 @@
+function distance(a,b){return a * a + b * b};distance(3,4);
+

--- a/code/programs/rust/closurec/tests/diff/simple-rename/flags.txt
+++ b/code/programs/rust/closurec/tests/diff/simple-rename/flags.txt
@@ -1,0 +1,4 @@
+--compilation_level
+SIMPLE
+--js
+tests/diff/simple-rename/input/a.js

--- a/code/programs/rust/closurec/tests/diff/simple-rename/input/a.js
+++ b/code/programs/rust/closurec/tests/diff/simple-rename/input/a.js
@@ -1,0 +1,16 @@
+// SIMPLE-level local renaming (CLOC12.160).
+//
+// The SIMPLE pipeline now ends with `rename`, which shortens the
+// parameters of leaf functions (functions with no nested function) to
+// short names. The function NAME `distance` is top-level and may be
+// referenced externally, so it is kept; only its parameters
+// `horizontal` and `vertical` are renamed (to `a` and `b`).
+//
+// `distance(3, 4)` calls it, so treeshake keeps the declaration; an
+// uncalled function would be removed before rename ever saw it.
+//
+// Under WHITESPACE_ONLY nothing is renamed.
+function distance(horizontal, vertical) {
+  return horizontal * horizontal + vertical * vertical;
+}
+distance(3, 4);

--- a/code/programs/rust/closurec/tests/diff_simple_rename.rs
+++ b/code/programs/rust/closurec/tests/diff_simple_rename.rs
@@ -1,0 +1,59 @@
+//! Integration test for the `tests/diff/simple-rename/` fixture.
+//!
+//! Exercises the CLOC12.160 addition of the `rename` pass to the
+//! `--compilation_level SIMPLE` pipeline, which is now
+//! `constant-fold → fold-control-flow → dce → inline → remove-unused-vars
+//! → treeshake → rename`. `rename` shortens the parameters of leaf
+//! functions (functions with no nested function) to short names, while
+//! leaving the (potentially externally-visible) function name alone:
+//!
+//! ```text
+//! function distance(horizontal, vertical) {
+//!   return horizontal * horizontal + vertical * vertical;
+//! }
+//! distance(3, 4);
+//! ⇒ function distance(a,b){return a * a + b * b};distance(3,4);
+//! ```
+//!
+//! `distance(3, 4)` keeps the function alive past `treeshake`; an uncalled
+//! function would be removed before `rename` ran. The same input under
+//! WHITESPACE_ONLY keeps the full parameter names (see the
+//! `simple_rename_*` unit tests in `src/run.rs`).
+
+use std::process::Command;
+
+const BINARY: &str = env!("CARGO_BIN_EXE_closurec");
+
+fn read_flags() -> Vec<String> {
+    let raw = std::fs::read_to_string("tests/diff/simple-rename/flags.txt")
+        .expect("read flags.txt");
+    raw.lines()
+        .filter(|l| !l.is_empty())
+        .map(|s| s.to_string())
+        .collect()
+}
+
+#[test]
+fn simple_rename_fixture_matches_expected_stdout() {
+    let flags = read_flags();
+    let out = Command::new(BINARY)
+        .args(&flags)
+        .output()
+        .expect("run closurec");
+
+    assert!(
+        out.status.success(),
+        "exit: {:?}, stderr: {}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stderr),
+    );
+
+    let actual = String::from_utf8_lossy(&out.stdout);
+    let expected = std::fs::read_to_string("tests/diff/simple-rename/expected.stdout")
+        .expect("read expected.stdout");
+    assert_eq!(
+        actual.trim_end_matches('\n'),
+        expected.trim_end_matches('\n'),
+        "mismatch.\nflags: {flags:?}\nactual:\n{actual}\nexpected:\n{expected}",
+    );
+}


### PR DESCRIPTION
## Summary

The `--compilation_level SIMPLE` pass pipeline is now **`constant-fold → fold-control-flow → dce → inline → remove-unused-vars → treeshake → rename`** (seven passes). The final pass shortens the parameters of **leaf functions** (functions with no nested function) to short names, keeping the potentially-externally-visible function name:

```js
function distance(horizontal, vertical) { return horizontal*horizontal + vertical*vertical; }
distance(3, 4);
//  ⇒  function distance(a,b){return a * a + b * b};distance(3,4);
```

`rename` runs last (no dependencies; registration order places it at the end) so it shortens names after every structural pass has finished. It relies on [`closure-pass-rename` 0.3.0](https://github.com/adhithyan15/coding-adventures/pull/6050)'s conservative α-rename — property names, free globals, redeclared parameters, and non-leaf functions are all left untouched.

## Test plan

- [x] New `tests/diff/simple-rename/` fixture + `tests/diff_simple_rename.rs`: `function distance(horizontal, vertical) {…} distance(3, 4);` ⇒ `function distance(a,b){return a * a + b * b};distance(3,4);`
- [x] New unit tests: `simple_rename_shortens_leaf_function_params`, `simple_rename_keeps_property_names` (property names preserved), `simple_rename_whitespace_only_keeps_param_names`
- [x] `simple_v2` CV trace test updated to expect all seven pass names
- [x] Full `cargo test` green (0 failures; no fixture churn — existing functions either have no renameable params or are removed by treeshake); security review passed
- closurec 0.142.0 → 0.143.0 (Cargo.toml + cli.spec.json + help-markdown fixture)

Builds on [#6050](https://github.com/adhithyan15/coding-adventures/pull/6050) (`closure-pass-rename` 0.3.0), merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)