### PR TITLE
Add activation waiver erasure receipt tools

### DIFF
--- a/code/packages/rust/chief-of-staff-smart-home-tools/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/src/lib.rs
@@ -478,6 +478,10 @@ pub const SMART_HOME_LIST_INTEGRATION_ACTIVATION_WAIVER_ERASURES_TOOL_ID: &str =
     "smart_home.list_integration_activation_waiver_erasures";
 pub const SMART_HOME_GET_INTEGRATION_ACTIVATION_WAIVER_ERASURE_SUMMARY_TOOL_ID: &str =
     "smart_home.get_integration_activation_waiver_erasure_summary";
+pub const SMART_HOME_LIST_INTEGRATION_ACTIVATION_WAIVER_ERASURE_RECEIPTS_TOOL_ID: &str =
+    "smart_home.list_integration_activation_waiver_erasure_receipts";
+pub const SMART_HOME_GET_INTEGRATION_ACTIVATION_WAIVER_ERASURE_RECEIPT_SUMMARY_TOOL_ID: &str =
+    "smart_home.get_integration_activation_waiver_erasure_receipt_summary";
 pub const SMART_HOME_LIST_INTEGRATION_ACTIVATION_RISK_TOOL_ID: &str =
     "smart_home.list_integration_activation_risk";
 pub const SMART_HOME_GET_INTEGRATION_ACTIVATION_RISK_SUMMARY_TOOL_ID: &str =
@@ -1199,6 +1203,22 @@ impl SmartHomeToolBridge {
                     let query = integration_activation_waiver_erasure_query(&arguments)?;
                     Ok(
                         get_integration_activation_waiver_erasure_summary_output_handler_output(
+                            query,
+                        ),
+                    )
+                }
+                SMART_HOME_LIST_INTEGRATION_ACTIVATION_WAIVER_ERASURE_RECEIPTS_TOOL_ID => {
+                    let query = integration_activation_waiver_erasure_receipt_query(&arguments)?;
+                    Ok(
+                        list_integration_activation_waiver_erasure_receipts_output_handler_output(
+                            query,
+                        ),
+                    )
+                }
+                SMART_HOME_GET_INTEGRATION_ACTIVATION_WAIVER_ERASURE_RECEIPT_SUMMARY_TOOL_ID => {
+                    let query = integration_activation_waiver_erasure_receipt_query(&arguments)?;
+                    Ok(
+                        get_integration_activation_waiver_erasure_receipt_summary_output_handler_output(
                             query,
                         ),
                     )
@@ -3826,6 +3846,40 @@ pub fn smart_home_tool_definitions() -> Vec<ToolDefinition> {
             "Get smart-home integration activation waiver erasure summary",
             "Return compact D23A activation waiver erasure evidence counts by erasure status, erasure lane, source linkage, blocker, purge readiness, and receipt posture.",
             integration_activation_waiver_erasure_query_schema(),
+            object_schema(
+                vec![SchemaProperty::new("summary", JsonSchema::Any)],
+                vec!["summary"],
+                false,
+            ),
+        ),
+        read_definition(
+            SMART_HOME_LIST_INTEGRATION_ACTIVATION_WAIVER_ERASURE_RECEIPTS_TOOL_ID,
+            "List smart-home integration activation waiver erasure receipts",
+            "List Chief-facing D23A activation waiver erasure receipt rows derived from erasure evidence with receipt status, receipt lane, source-lineage posture, and audit action.",
+            integration_activation_waiver_erasure_receipt_query_schema(),
+            object_schema(
+                vec![
+                    SchemaProperty::new("activation_waiver_erasure_receipts", JsonSchema::Array {
+                        items: Box::new(JsonSchema::Any),
+                    }),
+                    SchemaProperty::new("summary", JsonSchema::Any),
+                    SchemaProperty::new("count", JsonSchema::Integer),
+                    SchemaProperty::new("catalog_count", JsonSchema::Integer),
+                ],
+                vec![
+                    "activation_waiver_erasure_receipts",
+                    "summary",
+                    "count",
+                    "catalog_count",
+                ],
+                false,
+            ),
+        ),
+        read_definition(
+            SMART_HOME_GET_INTEGRATION_ACTIVATION_WAIVER_ERASURE_RECEIPT_SUMMARY_TOOL_ID,
+            "Get smart-home integration activation waiver erasure receipt summary",
+            "Return compact D23A activation waiver erasure receipt counts by receipt status, receipt lane, source linkage, blocker, erasure readiness, and erased posture.",
+            integration_activation_waiver_erasure_receipt_query_schema(),
             object_schema(
                 vec![SchemaProperty::new("summary", JsonSchema::Any)],
                 vec!["summary"],
@@ -12846,6 +12900,462 @@ struct IntegrationActivationWaiverErasureQuery {
     erasure_limit: Option<usize>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum IntegrationActivationWaiverErasureReceiptStatus {
+    Blocked,
+    EvidenceRequired,
+    ReadyForReceipt,
+    Receipted,
+}
+
+impl IntegrationActivationWaiverErasureReceiptStatus {
+    fn from_erasure_record(record: &IntegrationActivationWaiverErasureRecord) -> Self {
+        if record.is_blocked() || record.erasure_status.is_blocked() {
+            Self::Blocked
+        } else if !record.has_source_lineage()
+            || !record.erasure_ready()
+            || !record.source.purge_ready()
+        {
+            Self::EvidenceRequired
+        } else if matches!(
+            record.erasure_status,
+            IntegrationActivationWaiverErasureStatus::ReadyForErasure
+        ) {
+            Self::ReadyForReceipt
+        } else {
+            Self::Receipted
+        }
+    }
+
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Blocked => "blocked",
+            Self::EvidenceRequired => "evidence_required",
+            Self::ReadyForReceipt => "ready_for_receipt",
+            Self::Receipted => "receipted",
+        }
+    }
+
+    fn is_blocked(self) -> bool {
+        matches!(self, Self::Blocked)
+    }
+
+    fn requires_attention(self) -> bool {
+        matches!(self, Self::Blocked | Self::EvidenceRequired)
+    }
+
+    fn receipt_ready(self) -> bool {
+        matches!(self, Self::ReadyForReceipt | Self::Receipted)
+    }
+
+    fn receipted(self) -> bool {
+        matches!(self, Self::Receipted)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct IntegrationActivationWaiverErasureReceiptSource {
+    source_purge_id: String,
+    source_tombstone_id: String,
+    source_disposal_id: String,
+    source_expiration_id: String,
+    source_retention_id: String,
+    source_archive_id: String,
+    source_closure_id: String,
+    source_remediation_id: String,
+    source_disposition_id: String,
+    source_review_id: String,
+    source_waiver_id: String,
+    source_exception_id: String,
+    source_ledger_id: String,
+    source_attestation_id: String,
+    source_compliance_id: String,
+    source_governance_id: String,
+    source_assurance_id: String,
+    source_guardrail_id: String,
+    erasure_status: IntegrationActivationWaiverErasureStatus,
+    purge_status: IntegrationActivationWaiverPurgeStatus,
+    tombstone_status: IntegrationActivationWaiverTombstoneStatus,
+    disposal_status: IntegrationActivationWaiverDisposalStatus,
+    expiration_status: IntegrationActivationWaiverExpirationStatus,
+    retention_status: IntegrationActivationWaiverRetentionStatus,
+    archive_status: IntegrationActivationWaiverArchiveStatus,
+    waiver_status: IntegrationActivationWaiverStatus,
+    exception_status: IntegrationActivationExceptionLedgerStatus,
+    erasure_lane: IntegrationActivationResponseOwnerLane,
+    purge_lane: IntegrationActivationResponseOwnerLane,
+    tombstone_lane: IntegrationActivationResponseOwnerLane,
+    disposal_lane: IntegrationActivationResponseOwnerLane,
+    expiration_lane: IntegrationActivationResponseOwnerLane,
+    retention_lane: IntegrationActivationResponseOwnerLane,
+    archive_lane: IntegrationActivationResponseOwnerLane,
+    closure_lane: IntegrationActivationResponseOwnerLane,
+    owner_lane: IntegrationActivationResponseOwnerLane,
+    approval_lane: IntegrationActivationResponseOwnerLane,
+    erasure_action: String,
+    purge_action: String,
+    tombstone_action: String,
+    disposal_action: String,
+    expiration_action: String,
+    evidence_kind: String,
+    priority: u8,
+    integration_ids: Vec<IntegrationId>,
+    required_tier: PrivilegeTier,
+    reviewer_required: bool,
+    exception_required: bool,
+    signoff_required: bool,
+    evidence_ready: bool,
+    waiver_ready: bool,
+    archive_ready: bool,
+    retention_ready: bool,
+    expiration_ready: bool,
+    retained: bool,
+    expired: bool,
+    archived: bool,
+    disposal_ready: bool,
+    disposed: bool,
+    tombstone_ready: bool,
+    tombstoned: bool,
+    purge_ready: bool,
+    purged: bool,
+    erasure_ready: bool,
+    erased: bool,
+    erasure_requires_attention: bool,
+    has_source_lineage: bool,
+}
+
+impl IntegrationActivationWaiverErasureReceiptSource {
+    fn from_erasure_record(record: &IntegrationActivationWaiverErasureRecord) -> Self {
+        let purge = &record.source;
+        let tombstone = &purge.source;
+        let disposal = &tombstone.source;
+        let source = &disposal.source;
+        Self {
+            source_purge_id: record.source_purge_id.clone(),
+            source_tombstone_id: purge.source_tombstone_id.clone(),
+            source_disposal_id: tombstone.source_disposal_id.clone(),
+            source_expiration_id: disposal.source_expiration_id.clone(),
+            source_retention_id: source.source_retention_id.clone(),
+            source_archive_id: source.source_archive_id.clone(),
+            source_closure_id: source.source_closure_id.clone(),
+            source_remediation_id: source.source_remediation_id.clone(),
+            source_disposition_id: source.source_disposition_id.clone(),
+            source_review_id: source.source_review_id.clone(),
+            source_waiver_id: source.source_waiver_id.clone(),
+            source_exception_id: source.source_exception_id.clone(),
+            source_ledger_id: source.source_ledger_id.clone(),
+            source_attestation_id: source.source_attestation_id.clone(),
+            source_compliance_id: source.source_compliance_id.clone(),
+            source_governance_id: source.source_governance_id.clone(),
+            source_assurance_id: source.source_assurance_id.clone(),
+            source_guardrail_id: source.source_guardrail_id.clone(),
+            erasure_status: record.erasure_status,
+            purge_status: purge.purge_status,
+            tombstone_status: tombstone.tombstone_status,
+            disposal_status: disposal.disposal_status,
+            expiration_status: source.expiration_status,
+            retention_status: source.retention_status,
+            archive_status: source.archive_status,
+            waiver_status: source.waiver_status,
+            exception_status: source.exception_status,
+            erasure_lane: record.erasure_lane,
+            purge_lane: purge.purge_lane,
+            tombstone_lane: tombstone.tombstone_lane,
+            disposal_lane: disposal.disposal_lane,
+            expiration_lane: source.expiration_lane,
+            retention_lane: source.retention_lane,
+            archive_lane: source.archive_lane,
+            closure_lane: source.closure_lane,
+            owner_lane: source.owner_lane,
+            approval_lane: source.approval_lane,
+            erasure_action: record.erasure_action.clone(),
+            purge_action: purge.purge_action.clone(),
+            tombstone_action: tombstone.tombstone_action.clone(),
+            disposal_action: disposal.disposal_action.clone(),
+            expiration_action: source.expiration_action.clone(),
+            evidence_kind: source.evidence_kind.clone(),
+            priority: source.priority,
+            integration_ids: source.integration_ids.clone(),
+            required_tier: source.required_tier,
+            reviewer_required: source.reviewer_required,
+            exception_required: source.exception_required,
+            signoff_required: source.signoff_required,
+            evidence_ready: source.evidence_ready,
+            waiver_ready: source.waiver_ready,
+            archive_ready: source.archive_ready,
+            retention_ready: source.retention_ready,
+            expiration_ready: source.expiration_ready,
+            retained: source.retained,
+            expired: source.expired,
+            archived: source.archived,
+            disposal_ready: disposal.disposal_ready(),
+            disposed: disposal.disposed(),
+            tombstone_ready: tombstone.tombstone_ready(),
+            tombstoned: tombstone.tombstoned(),
+            purge_ready: purge.purge_ready(),
+            purged: purge.purged(),
+            erasure_ready: record.erasure_ready(),
+            erased: record.erased(),
+            erasure_requires_attention: record.requires_attention(),
+            has_source_lineage: record.has_source_lineage(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct IntegrationActivationWaiverErasureReceiptRecord {
+    sequence: usize,
+    receipt_id: String,
+    source_erasure_id: String,
+    receipt_status: IntegrationActivationWaiverErasureReceiptStatus,
+    receipt_lane: IntegrationActivationResponseOwnerLane,
+    receipt_reason: String,
+    receipt_action: String,
+    source: IntegrationActivationWaiverErasureReceiptSource,
+}
+
+impl IntegrationActivationWaiverErasureReceiptRecord {
+    fn from_erasure_record(
+        sequence: usize,
+        record: &IntegrationActivationWaiverErasureRecord,
+    ) -> Self {
+        let receipt_status =
+            IntegrationActivationWaiverErasureReceiptStatus::from_erasure_record(record);
+        Self {
+            sequence,
+            receipt_id: format!("activation-waiver-erasure-receipt-{sequence}"),
+            source_erasure_id: record.erasure_id.clone(),
+            receipt_status,
+            receipt_lane: activation_waiver_erasure_receipt_lane(record, receipt_status),
+            receipt_reason: activation_waiver_erasure_receipt_reason(record, receipt_status)
+                .to_string(),
+            receipt_action: activation_waiver_erasure_receipt_action(receipt_status).to_string(),
+            source: IntegrationActivationWaiverErasureReceiptSource::from_erasure_record(record),
+        }
+    }
+
+    fn has_source_lineage(&self) -> bool {
+        !self.source_erasure_id.is_empty() && self.source.has_source_lineage
+    }
+
+    fn is_blocked(&self) -> bool {
+        self.receipt_status.is_blocked()
+    }
+
+    fn requires_attention(&self) -> bool {
+        self.source.erasure_requires_attention || self.receipt_status.requires_attention()
+    }
+
+    fn receipt_ready(&self) -> bool {
+        self.receipt_status.receipt_ready()
+    }
+
+    fn receipted(&self) -> bool {
+        self.receipt_status.receipted()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct IntegrationActivationWaiverErasureReceiptSummary {
+    total_records: usize,
+    unique_integrations: usize,
+    records_requiring_attention: usize,
+    blocked_records: usize,
+    evidence_required_records: usize,
+    ready_for_receipt_records: usize,
+    receipted_records: usize,
+    receipt_ready_records: usize,
+    erased_records: usize,
+    erasure_ready_records: usize,
+    purged_records: usize,
+    source_linked_records: usize,
+    reviewer_required_records: usize,
+    exception_required_records: usize,
+    signoff_required_records: usize,
+    platform_receipt_records: usize,
+    integration_receipt_records: usize,
+    security_receipt_records: usize,
+    reviewer_receipt_records: usize,
+    verification_receipt_records: usize,
+    audit_receipt_records: usize,
+    first_attention_priority: Option<u8>,
+    first_blocked_priority: Option<u8>,
+    first_ready_priority: Option<u8>,
+    next_receipt_status: Option<IntegrationActivationWaiverErasureReceiptStatus>,
+    next_receipt_lane: Option<IntegrationActivationResponseOwnerLane>,
+    next_receipt_action: Option<String>,
+    highest_policy_tier: PrivilegeTier,
+    overall_status: IntegrationActivationHealthStatus,
+}
+
+impl IntegrationActivationWaiverErasureReceiptSummary {
+    fn from_records<'a>(
+        records: impl IntoIterator<Item = &'a IntegrationActivationWaiverErasureReceiptRecord>,
+    ) -> Self {
+        let mut summary = Self {
+            total_records: 0,
+            unique_integrations: 0,
+            records_requiring_attention: 0,
+            blocked_records: 0,
+            evidence_required_records: 0,
+            ready_for_receipt_records: 0,
+            receipted_records: 0,
+            receipt_ready_records: 0,
+            erased_records: 0,
+            erasure_ready_records: 0,
+            purged_records: 0,
+            source_linked_records: 0,
+            reviewer_required_records: 0,
+            exception_required_records: 0,
+            signoff_required_records: 0,
+            platform_receipt_records: 0,
+            integration_receipt_records: 0,
+            security_receipt_records: 0,
+            reviewer_receipt_records: 0,
+            verification_receipt_records: 0,
+            audit_receipt_records: 0,
+            first_attention_priority: None,
+            first_blocked_priority: None,
+            first_ready_priority: None,
+            next_receipt_status: None,
+            next_receipt_lane: None,
+            next_receipt_action: None,
+            highest_policy_tier: PrivilegeTier::ReadOnly,
+            overall_status: IntegrationActivationHealthStatus::Empty,
+        };
+        let mut integration_ids = BTreeSet::new();
+
+        for record in records {
+            summary.total_records += 1;
+            if summary.next_receipt_status.is_none() {
+                summary.next_receipt_status = Some(record.receipt_status);
+                summary.next_receipt_lane = Some(record.receipt_lane);
+                summary.next_receipt_action = Some(record.receipt_action.clone());
+            }
+            let source = &record.source;
+            for integration_id in &source.integration_ids {
+                integration_ids.insert(integration_id.clone());
+            }
+            if record.requires_attention() {
+                summary.records_requiring_attention += 1;
+                summary.first_attention_priority =
+                    min_optional_priority(summary.first_attention_priority, source.priority);
+            }
+            if record.is_blocked() {
+                summary.blocked_records += 1;
+                summary.first_blocked_priority =
+                    min_optional_priority(summary.first_blocked_priority, source.priority);
+            }
+            if record.receipt_ready() {
+                summary.receipt_ready_records += 1;
+                summary.first_ready_priority =
+                    min_optional_priority(summary.first_ready_priority, source.priority);
+            }
+            if source.erased {
+                summary.erased_records += 1;
+            }
+            if source.erasure_ready {
+                summary.erasure_ready_records += 1;
+            }
+            if source.purged {
+                summary.purged_records += 1;
+            }
+            if record.has_source_lineage() {
+                summary.source_linked_records += 1;
+            }
+            if source.reviewer_required {
+                summary.reviewer_required_records += 1;
+            }
+            if source.exception_required {
+                summary.exception_required_records += 1;
+            }
+            if source.signoff_required {
+                summary.signoff_required_records += 1;
+            }
+            match record.receipt_status {
+                IntegrationActivationWaiverErasureReceiptStatus::Blocked => {}
+                IntegrationActivationWaiverErasureReceiptStatus::EvidenceRequired => {
+                    summary.evidence_required_records += 1
+                }
+                IntegrationActivationWaiverErasureReceiptStatus::ReadyForReceipt => {
+                    summary.ready_for_receipt_records += 1
+                }
+                IntegrationActivationWaiverErasureReceiptStatus::Receipted => {
+                    summary.receipted_records += 1
+                }
+            }
+            match record.receipt_lane {
+                IntegrationActivationResponseOwnerLane::Platform => {
+                    summary.platform_receipt_records += 1
+                }
+                IntegrationActivationResponseOwnerLane::Integration => {
+                    summary.integration_receipt_records += 1
+                }
+                IntegrationActivationResponseOwnerLane::Security => {
+                    summary.security_receipt_records += 1
+                }
+                IntegrationActivationResponseOwnerLane::Reviewer => {
+                    summary.reviewer_receipt_records += 1
+                }
+                IntegrationActivationResponseOwnerLane::Verification => {
+                    summary.verification_receipt_records += 1
+                }
+                IntegrationActivationResponseOwnerLane::Audit => summary.audit_receipt_records += 1,
+            }
+            summary.highest_policy_tier = summary.highest_policy_tier.max(source.required_tier);
+        }
+
+        summary.unique_integrations = integration_ids.len();
+        summary.overall_status = if summary.total_records == 0 {
+            IntegrationActivationHealthStatus::Empty
+        } else if summary.blocked_records > 0 {
+            IntegrationActivationHealthStatus::Blocked
+        } else if summary.evidence_required_records > 0 {
+            IntegrationActivationHealthStatus::NeedsReview
+        } else {
+            IntegrationActivationHealthStatus::Ready
+        };
+        summary
+    }
+
+    fn has_blockers(&self) -> bool {
+        self.blocked_records > 0
+    }
+
+    fn requires_attention(&self) -> bool {
+        self.records_requiring_attention > 0 || self.evidence_required_records > 0
+    }
+}
+
+#[derive(Debug, Clone)]
+struct IntegrationActivationWaiverErasureReceiptQuery {
+    waiver_erasure: Box<IntegrationActivationWaiverErasureQuery>,
+    receipt_status: Option<IntegrationActivationWaiverErasureReceiptStatus>,
+    receipt_lane: Option<IntegrationActivationResponseOwnerLane>,
+    erasure_lane: Option<IntegrationActivationResponseOwnerLane>,
+    purge_lane: Option<IntegrationActivationResponseOwnerLane>,
+    tombstone_lane: Option<IntegrationActivationResponseOwnerLane>,
+    disposal_lane: Option<IntegrationActivationResponseOwnerLane>,
+    expiration_lane: Option<IntegrationActivationResponseOwnerLane>,
+    retention_lane: Option<IntegrationActivationResponseOwnerLane>,
+    archive_lane: Option<IntegrationActivationResponseOwnerLane>,
+    closure_lane: Option<IntegrationActivationResponseOwnerLane>,
+    owner_lane: Option<IntegrationActivationResponseOwnerLane>,
+    approval_lane: Option<IntegrationActivationResponseOwnerLane>,
+    evidence_kind: Option<String>,
+    requires_attention: Option<bool>,
+    blocked: Option<bool>,
+    receipt_ready: Option<bool>,
+    receipted: Option<bool>,
+    erasure_ready: Option<bool>,
+    erased: Option<bool>,
+    purged: Option<bool>,
+    evidence_ready: Option<bool>,
+    reviewer_required: Option<bool>,
+    signoff_required: Option<bool>,
+    receipt_limit: Option<usize>,
+}
+
 fn activation_exception_reason(focus: IntegrationActivationGuardrailKind) -> &'static str {
     match focus {
         IntegrationActivationGuardrailKind::Incident => "incident evidence closure required",
@@ -13435,6 +13945,65 @@ fn activation_waiver_erasure_action(
             "record_waiver_erasure_receipt"
         }
         IntegrationActivationWaiverErasureStatus::Erased => "monitor_waiver_erasure_receipt",
+    }
+}
+
+fn activation_waiver_erasure_receipt_lane(
+    record: &IntegrationActivationWaiverErasureRecord,
+    status: IntegrationActivationWaiverErasureReceiptStatus,
+) -> IntegrationActivationResponseOwnerLane {
+    match status {
+        IntegrationActivationWaiverErasureReceiptStatus::Blocked => record.erasure_lane,
+        IntegrationActivationWaiverErasureReceiptStatus::EvidenceRequired => record.erasure_lane,
+        IntegrationActivationWaiverErasureReceiptStatus::ReadyForReceipt => {
+            IntegrationActivationResponseOwnerLane::Audit
+        }
+        IntegrationActivationWaiverErasureReceiptStatus::Receipted => {
+            IntegrationActivationResponseOwnerLane::Audit
+        }
+    }
+}
+
+fn activation_waiver_erasure_receipt_reason(
+    record: &IntegrationActivationWaiverErasureRecord,
+    status: IntegrationActivationWaiverErasureReceiptStatus,
+) -> &'static str {
+    match status {
+        IntegrationActivationWaiverErasureReceiptStatus::Blocked => {
+            "blocking waiver erasure must clear before receipt finalization"
+        }
+        IntegrationActivationWaiverErasureReceiptStatus::EvidenceRequired => {
+            if !record.has_source_lineage() {
+                "waiver erasure receipt is missing erasure source lineage"
+            } else if !record.erasure_ready() {
+                "waiver erasure evidence must be ready before receipt finalization"
+            } else {
+                "waiver purge source must be ready before receipt finalization"
+            }
+        }
+        IntegrationActivationWaiverErasureReceiptStatus::ReadyForReceipt => {
+            "waiver erasure is ready for receipt finalization"
+        }
+        IntegrationActivationWaiverErasureReceiptStatus::Receipted => {
+            "waiver erasure receipt has reached audit posture"
+        }
+    }
+}
+
+fn activation_waiver_erasure_receipt_action(
+    status: IntegrationActivationWaiverErasureReceiptStatus,
+) -> &'static str {
+    match status {
+        IntegrationActivationWaiverErasureReceiptStatus::Blocked => "clear_waiver_erasure_blocker",
+        IntegrationActivationWaiverErasureReceiptStatus::EvidenceRequired => {
+            "attach_waiver_erasure_receipt_evidence"
+        }
+        IntegrationActivationWaiverErasureReceiptStatus::ReadyForReceipt => {
+            "finalize_waiver_erasure_receipt"
+        }
+        IntegrationActivationWaiverErasureReceiptStatus::Receipted => {
+            "monitor_waiver_erasure_receipt"
+        }
     }
 }
 
@@ -15541,6 +16110,110 @@ fn integration_activation_waiver_erasure_query(
         signoff_required: optional_bool(arguments, "signoff_required")?,
         erasure_limit: optional_u64(arguments, "waiver_erasure_limit")?
             .or(optional_u64(arguments, "erasure_limit")?)
+            .or(optional_u64(arguments, "record_limit")?)
+            .map(|value| value as usize),
+    })
+}
+
+fn integration_activation_waiver_erasure_receipt_query(
+    arguments: &JsonValue,
+) -> Result<IntegrationActivationWaiverErasureReceiptQuery, ToolCallError> {
+    let receipt_status = optional_string(arguments, "waiver_erasure_receipt_status")?
+        .or(optional_string(arguments, "receipt_status")?)
+        .map(|label| parse_activation_waiver_erasure_receipt_status(&label))
+        .transpose()?;
+    let receipt_lane = optional_string(arguments, "waiver_erasure_receipt_lane")?
+        .or(optional_string(arguments, "receipt_lane")?)
+        .map(|label| parse_activation_response_owner_lane(&label))
+        .transpose()?;
+    let erasure_lane = optional_string(arguments, "waiver_erasure_receipt_erasure_lane")?
+        .or(optional_string(arguments, "waiver_erasure_lane")?)
+        .or(optional_string(arguments, "erasure_lane")?)
+        .map(|label| parse_activation_response_owner_lane(&label))
+        .transpose()?;
+    let purge_lane = optional_string(arguments, "waiver_erasure_receipt_purge_lane")?
+        .or(optional_string(arguments, "waiver_purge_lane")?)
+        .or(optional_string(arguments, "purge_lane")?)
+        .map(|label| parse_activation_response_owner_lane(&label))
+        .transpose()?;
+    let tombstone_lane = optional_string(arguments, "waiver_erasure_receipt_tombstone_lane")?
+        .or(optional_string(arguments, "waiver_tombstone_lane")?)
+        .or(optional_string(arguments, "tombstone_lane")?)
+        .map(|label| parse_activation_response_owner_lane(&label))
+        .transpose()?;
+    let disposal_lane = optional_string(arguments, "waiver_erasure_receipt_disposal_lane")?
+        .or(optional_string(arguments, "waiver_disposal_lane")?)
+        .or(optional_string(arguments, "disposal_lane")?)
+        .map(|label| parse_activation_response_owner_lane(&label))
+        .transpose()?;
+    let expiration_lane = optional_string(arguments, "waiver_erasure_receipt_expiration_lane")?
+        .or(optional_string(arguments, "waiver_expiration_lane")?)
+        .or(optional_string(arguments, "expiration_lane")?)
+        .map(|label| parse_activation_response_owner_lane(&label))
+        .transpose()?;
+    let retention_lane = optional_string(arguments, "waiver_erasure_receipt_retention_lane")?
+        .or(optional_string(arguments, "waiver_retention_lane")?)
+        .or(optional_string(arguments, "retention_lane")?)
+        .map(|label| parse_activation_response_owner_lane(&label))
+        .transpose()?;
+    let archive_lane = optional_string(arguments, "waiver_erasure_receipt_archive_lane")?
+        .or(optional_string(arguments, "waiver_archive_lane")?)
+        .or(optional_string(arguments, "archive_lane")?)
+        .map(|label| parse_activation_response_owner_lane(&label))
+        .transpose()?;
+    let closure_lane = optional_string(arguments, "waiver_erasure_receipt_closure_lane")?
+        .or(optional_string(arguments, "waiver_closure_lane")?)
+        .or(optional_string(arguments, "closure_lane")?)
+        .map(|label| parse_activation_response_owner_lane(&label))
+        .transpose()?;
+    let owner_lane = optional_string(arguments, "waiver_erasure_receipt_owner_lane")?
+        .or(optional_string(arguments, "owner_lane")?)
+        .map(|label| parse_activation_response_owner_lane(&label))
+        .transpose()?;
+    let approval_lane = optional_string(arguments, "waiver_erasure_receipt_approval_lane")?
+        .or(optional_string(arguments, "approval_lane")?)
+        .map(|label| parse_activation_response_owner_lane(&label))
+        .transpose()?;
+
+    Ok(IntegrationActivationWaiverErasureReceiptQuery {
+        waiver_erasure: Box::new(integration_activation_waiver_erasure_query(arguments)?),
+        receipt_status,
+        receipt_lane,
+        erasure_lane,
+        purge_lane,
+        tombstone_lane,
+        disposal_lane,
+        expiration_lane,
+        retention_lane,
+        archive_lane,
+        closure_lane,
+        owner_lane,
+        approval_lane,
+        evidence_kind: optional_string(arguments, "waiver_erasure_receipt_evidence_kind")?
+            .or(optional_string(arguments, "waiver_erasure_evidence_kind")?)
+            .or(optional_string(arguments, "evidence_kind")?),
+        requires_attention: optional_bool(arguments, "waiver_erasure_receipt_requires_attention")?
+            .or(optional_bool(
+                arguments,
+                "waiver_erasure_requires_attention",
+            )?)
+            .or(optional_bool(arguments, "requires_attention")?),
+        blocked: optional_bool(arguments, "waiver_erasure_receipt_blocked")?
+            .or(optional_bool(arguments, "waiver_erasure_blocked")?)
+            .or(optional_bool(arguments, "blocked")?),
+        receipt_ready: optional_bool(arguments, "waiver_erasure_receipt_ready")?
+            .or(optional_bool(arguments, "receipt_ready")?),
+        receipted: optional_bool(arguments, "waiver_erasure_receipted")?
+            .or(optional_bool(arguments, "receipted")?),
+        erasure_ready: optional_bool(arguments, "waiver_erasure_ready")?
+            .or(optional_bool(arguments, "erasure_ready")?),
+        erased: optional_bool(arguments, "waiver_erased")?.or(optional_bool(arguments, "erased")?),
+        purged: optional_bool(arguments, "waiver_purged")?.or(optional_bool(arguments, "purged")?),
+        evidence_ready: optional_bool(arguments, "evidence_ready")?,
+        reviewer_required: optional_bool(arguments, "reviewer_required")?,
+        signoff_required: optional_bool(arguments, "signoff_required")?,
+        receipt_limit: optional_u64(arguments, "waiver_erasure_receipt_limit")?
+            .or(optional_u64(arguments, "receipt_limit")?)
             .or(optional_u64(arguments, "record_limit")?)
             .map(|value| value as usize),
     })
@@ -18075,6 +18748,95 @@ fn integration_activation_waiver_erasures_for_query(
         });
     }
     if let Some(limit) = query.erasure_limit {
+        records.truncate(limit);
+    }
+
+    (records, catalog_count)
+}
+
+fn integration_activation_waiver_erasure_receipts_for_query(
+    query: &IntegrationActivationWaiverErasureReceiptQuery,
+) -> (Vec<IntegrationActivationWaiverErasureReceiptRecord>, usize) {
+    let (erasure_records, catalog_count) =
+        integration_activation_waiver_erasures_for_query(&query.waiver_erasure);
+    let mut records: Vec<_> = erasure_records
+        .iter()
+        .enumerate()
+        .map(|(index, record)| {
+            IntegrationActivationWaiverErasureReceiptRecord::from_erasure_record(index + 1, record)
+        })
+        .collect();
+
+    if let Some(status) = query.receipt_status {
+        records.retain(|record| record.receipt_status == status);
+    }
+    if let Some(receipt_lane) = query.receipt_lane {
+        records.retain(|record| record.receipt_lane == receipt_lane);
+    }
+    if let Some(erasure_lane) = query.erasure_lane {
+        records.retain(|record| record.source.erasure_lane == erasure_lane);
+    }
+    if let Some(purge_lane) = query.purge_lane {
+        records.retain(|record| record.source.purge_lane == purge_lane);
+    }
+    if let Some(tombstone_lane) = query.tombstone_lane {
+        records.retain(|record| record.source.tombstone_lane == tombstone_lane);
+    }
+    if let Some(disposal_lane) = query.disposal_lane {
+        records.retain(|record| record.source.disposal_lane == disposal_lane);
+    }
+    if let Some(expiration_lane) = query.expiration_lane {
+        records.retain(|record| record.source.expiration_lane == expiration_lane);
+    }
+    if let Some(retention_lane) = query.retention_lane {
+        records.retain(|record| record.source.retention_lane == retention_lane);
+    }
+    if let Some(archive_lane) = query.archive_lane {
+        records.retain(|record| record.source.archive_lane == archive_lane);
+    }
+    if let Some(closure_lane) = query.closure_lane {
+        records.retain(|record| record.source.closure_lane == closure_lane);
+    }
+    if let Some(owner_lane) = query.owner_lane {
+        records.retain(|record| record.source.owner_lane == owner_lane);
+    }
+    if let Some(approval_lane) = query.approval_lane {
+        records.retain(|record| record.source.approval_lane == approval_lane);
+    }
+    if let Some(evidence_kind) = &query.evidence_kind {
+        records.retain(|record| record.source.evidence_kind == *evidence_kind);
+    }
+    if let Some(requires_attention) = query.requires_attention {
+        records.retain(|record| record.requires_attention() == requires_attention);
+    }
+    if let Some(blocked) = query.blocked {
+        records.retain(|record| record.is_blocked() == blocked);
+    }
+    if let Some(receipt_ready) = query.receipt_ready {
+        records.retain(|record| record.receipt_ready() == receipt_ready);
+    }
+    if let Some(receipted) = query.receipted {
+        records.retain(|record| record.receipted() == receipted);
+    }
+    if let Some(erasure_ready) = query.erasure_ready {
+        records.retain(|record| record.source.erasure_ready == erasure_ready);
+    }
+    if let Some(erased) = query.erased {
+        records.retain(|record| record.source.erased == erased);
+    }
+    if let Some(purged) = query.purged {
+        records.retain(|record| record.source.purged == purged);
+    }
+    if let Some(evidence_ready) = query.evidence_ready {
+        records.retain(|record| record.source.evidence_ready == evidence_ready);
+    }
+    if let Some(reviewer_required) = query.reviewer_required {
+        records.retain(|record| record.source.reviewer_required == reviewer_required);
+    }
+    if let Some(signoff_required) = query.signoff_required {
+        records.retain(|record| record.source.signoff_required == signoff_required);
+    }
+    if let Some(limit) = query.receipt_limit {
         records.truncate(limit);
     }
 
@@ -22924,6 +23686,84 @@ fn get_integration_activation_waiver_erasure_summary_output_handler_output(
             (
                 "erasure_ready_records",
                 integer(summary.erasure_ready_records as i64),
+            ),
+            ("overall_status", string(summary.overall_status.as_str())),
+        ]),
+    )
+}
+
+fn list_integration_activation_waiver_erasure_receipts_output_handler_output(
+    query: IntegrationActivationWaiverErasureReceiptQuery,
+) -> ToolHandlerOutput {
+    let (records, catalog_count) = integration_activation_waiver_erasure_receipts_for_query(&query);
+    let summary = IntegrationActivationWaiverErasureReceiptSummary::from_records(records.iter());
+    let count = records.len();
+
+    ToolHandlerOutput::new(object([
+        (
+            "activation_waiver_erasure_receipts",
+            JsonValue::Array(
+                records
+                    .iter()
+                    .map(activation_waiver_erasure_receipt_record_json)
+                    .collect(),
+            ),
+        ),
+        (
+            "summary",
+            integration_activation_waiver_erasure_receipt_summary_json(&summary),
+        ),
+        ("count", integer(count as i64)),
+        ("catalog_count", integer(catalog_count as i64)),
+    ]))
+    .with_event(
+        ToolEventKind::Progress,
+        object([
+            (
+                "operation",
+                string("list_integration_activation_waiver_erasure_receipts"),
+            ),
+            ("records", integer(count as i64)),
+            (
+                "records_requiring_attention",
+                integer(summary.records_requiring_attention as i64),
+            ),
+            ("blocked_records", integer(summary.blocked_records as i64)),
+            (
+                "receipt_ready_records",
+                integer(summary.receipt_ready_records as i64),
+            ),
+            ("overall_status", string(summary.overall_status.as_str())),
+        ]),
+    )
+}
+
+fn get_integration_activation_waiver_erasure_receipt_summary_output_handler_output(
+    query: IntegrationActivationWaiverErasureReceiptQuery,
+) -> ToolHandlerOutput {
+    let (records, _) = integration_activation_waiver_erasure_receipts_for_query(&query);
+    let summary = IntegrationActivationWaiverErasureReceiptSummary::from_records(records.iter());
+
+    ToolHandlerOutput::new(object([(
+        "summary",
+        integration_activation_waiver_erasure_receipt_summary_json(&summary),
+    )]))
+    .with_event(
+        ToolEventKind::Progress,
+        object([
+            (
+                "operation",
+                string("get_integration_activation_waiver_erasure_receipt_summary"),
+            ),
+            ("total_records", integer(summary.total_records as i64)),
+            (
+                "records_requiring_attention",
+                integer(summary.records_requiring_attention as i64),
+            ),
+            ("blocked_records", integer(summary.blocked_records as i64)),
+            (
+                "receipt_ready_records",
+                integer(summary.receipt_ready_records as i64),
             ),
             ("overall_status", string(summary.overall_status.as_str())),
         ]),
@@ -37787,16 +38627,6 @@ fn activation_waiver_disposal_record_json(
         ),
         ("retention_status", string(source.retention_status.as_str())),
         ("archive_status", string(source.archive_status.as_str())),
-        ("closure_status", string(source.closure_status.as_str())),
-        (
-            "remediation_status",
-            string(source.remediation_status.as_str()),
-        ),
-        (
-            "disposition_status",
-            string(source.disposition_status.as_str()),
-        ),
-        ("review_status", string(source.review_status.as_str())),
         ("waiver_status", string(source.waiver_status.as_str())),
         ("exception_status", string(source.exception_status.as_str())),
         ("disposal_lane", string(record.disposal_lane.as_str())),
@@ -38067,16 +38897,6 @@ fn activation_waiver_tombstone_record_json(
         ),
         ("retention_status", string(source.retention_status.as_str())),
         ("archive_status", string(source.archive_status.as_str())),
-        ("closure_status", string(source.closure_status.as_str())),
-        (
-            "remediation_status",
-            string(source.remediation_status.as_str()),
-        ),
-        (
-            "disposition_status",
-            string(source.disposition_status.as_str()),
-        ),
-        ("review_status", string(source.review_status.as_str())),
         ("waiver_status", string(source.waiver_status.as_str())),
         ("exception_status", string(source.exception_status.as_str())),
         ("tombstone_lane", string(record.tombstone_lane.as_str())),
@@ -38361,16 +39181,6 @@ fn activation_waiver_purge_record_json(
         ),
         ("retention_status", string(source.retention_status.as_str())),
         ("archive_status", string(source.archive_status.as_str())),
-        ("closure_status", string(source.closure_status.as_str())),
-        (
-            "remediation_status",
-            string(source.remediation_status.as_str()),
-        ),
-        (
-            "disposition_status",
-            string(source.disposition_status.as_str()),
-        ),
-        ("review_status", string(source.review_status.as_str())),
         ("waiver_status", string(source.waiver_status.as_str())),
         ("exception_status", string(source.exception_status.as_str())),
         ("purge_lane", string(record.purge_lane.as_str())),
@@ -38671,16 +39481,6 @@ fn activation_waiver_erasure_record_json(
         ),
         ("retention_status", string(source.retention_status.as_str())),
         ("archive_status", string(source.archive_status.as_str())),
-        ("closure_status", string(source.closure_status.as_str())),
-        (
-            "remediation_status",
-            string(source.remediation_status.as_str()),
-        ),
-        (
-            "disposition_status",
-            string(source.disposition_status.as_str()),
-        ),
-        ("review_status", string(source.review_status.as_str())),
         ("waiver_status", string(source.waiver_status.as_str())),
         ("exception_status", string(source.exception_status.as_str())),
         ("erasure_lane", string(record.erasure_lane.as_str())),
@@ -38910,6 +39710,264 @@ fn integration_activation_waiver_erasure_summary_json(
             "next_erasure_action",
             summary
                 .next_erasure_action
+                .as_ref()
+                .map(|action| string(action))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "highest_policy_tier",
+            string(privilege_tier_label(summary.highest_policy_tier)),
+        ),
+        ("overall_status", string(summary.overall_status.as_str())),
+        ("is_empty", JsonValue::Bool(summary.total_records == 0)),
+        ("has_blockers", JsonValue::Bool(summary.has_blockers())),
+        (
+            "requires_attention",
+            JsonValue::Bool(summary.requires_attention()),
+        ),
+    ]
+}
+
+fn activation_waiver_erasure_receipt_record_json(
+    record: &IntegrationActivationWaiverErasureReceiptRecord,
+) -> JsonValue {
+    let source = &record.source;
+    heap_object![
+        ("sequence", integer(record.sequence as i64)),
+        ("receipt_id", string(&record.receipt_id)),
+        ("source_erasure_id", string(&record.source_erasure_id)),
+        ("source_purge_id", string(&source.source_purge_id)),
+        ("source_tombstone_id", string(&source.source_tombstone_id)),
+        ("source_disposal_id", string(&source.source_disposal_id)),
+        ("source_expiration_id", string(&source.source_expiration_id)),
+        ("source_retention_id", string(&source.source_retention_id)),
+        ("source_archive_id", string(&source.source_archive_id)),
+        ("source_closure_id", string(&source.source_closure_id)),
+        (
+            "source_remediation_id",
+            string(&source.source_remediation_id),
+        ),
+        (
+            "source_disposition_id",
+            string(&source.source_disposition_id),
+        ),
+        ("source_review_id", string(&source.source_review_id)),
+        ("source_waiver_id", string(&source.source_waiver_id)),
+        ("source_exception_id", string(&source.source_exception_id)),
+        ("source_ledger_id", string(&source.source_ledger_id)),
+        (
+            "source_attestation_id",
+            string(&source.source_attestation_id),
+        ),
+        ("source_compliance_id", string(&source.source_compliance_id)),
+        ("source_governance_id", string(&source.source_governance_id)),
+        ("source_assurance_id", string(&source.source_assurance_id)),
+        ("source_guardrail_id", string(&source.source_guardrail_id)),
+        ("receipt_status", string(record.receipt_status.as_str())),
+        ("erasure_status", string(source.erasure_status.as_str())),
+        ("purge_status", string(source.purge_status.as_str())),
+        ("tombstone_status", string(source.tombstone_status.as_str()),),
+        ("disposal_status", string(source.disposal_status.as_str())),
+        (
+            "expiration_status",
+            string(source.expiration_status.as_str()),
+        ),
+        ("retention_status", string(source.retention_status.as_str())),
+        ("archive_status", string(source.archive_status.as_str())),
+        ("waiver_status", string(source.waiver_status.as_str())),
+        ("exception_status", string(source.exception_status.as_str())),
+        ("receipt_lane", string(record.receipt_lane.as_str())),
+        ("erasure_lane", string(source.erasure_lane.as_str())),
+        ("purge_lane", string(source.purge_lane.as_str())),
+        ("tombstone_lane", string(source.tombstone_lane.as_str())),
+        ("disposal_lane", string(source.disposal_lane.as_str())),
+        ("expiration_lane", string(source.expiration_lane.as_str())),
+        ("retention_lane", string(source.retention_lane.as_str())),
+        ("archive_lane", string(source.archive_lane.as_str())),
+        ("closure_lane", string(source.closure_lane.as_str())),
+        ("owner_lane", string(source.owner_lane.as_str())),
+        ("approval_lane", string(source.approval_lane.as_str())),
+        ("receipt_reason", string(&record.receipt_reason)),
+        ("receipt_action", string(&record.receipt_action)),
+        ("erasure_action", string(&source.erasure_action)),
+        ("purge_action", string(&source.purge_action)),
+        ("tombstone_action", string(&source.tombstone_action)),
+        ("disposal_action", string(&source.disposal_action)),
+        ("expiration_action", string(&source.expiration_action)),
+        ("evidence_kind", string(&source.evidence_kind)),
+        ("priority", integer(source.priority as i64)),
+        (
+            "integration_ids",
+            JsonValue::Array(
+                source
+                    .integration_ids
+                    .iter()
+                    .map(|integration_id| string(integration_id.as_str()))
+                    .collect(),
+            ),
+        ),
+        (
+            "integration_count",
+            integer(source.integration_ids.len() as i64),
+        ),
+        (
+            "required_tier",
+            string(privilege_tier_label(source.required_tier)),
+        ),
+        (
+            "reviewer_required",
+            JsonValue::Bool(source.reviewer_required),
+        ),
+        (
+            "exception_required",
+            JsonValue::Bool(source.exception_required),
+        ),
+        ("signoff_required", JsonValue::Bool(source.signoff_required)),
+        ("evidence_ready", JsonValue::Bool(source.evidence_ready)),
+        ("waiver_ready", JsonValue::Bool(source.waiver_ready)),
+        ("archive_ready", JsonValue::Bool(source.archive_ready)),
+        ("retention_ready", JsonValue::Bool(source.retention_ready)),
+        ("expiration_ready", JsonValue::Bool(source.expiration_ready)),
+        ("disposal_ready", JsonValue::Bool(source.disposal_ready)),
+        ("tombstone_ready", JsonValue::Bool(source.tombstone_ready)),
+        ("purge_ready", JsonValue::Bool(source.purge_ready)),
+        ("erasure_ready", JsonValue::Bool(source.erasure_ready)),
+        ("receipt_ready", JsonValue::Bool(record.receipt_ready())),
+        ("receipted", JsonValue::Bool(record.receipted())),
+        ("erased", JsonValue::Bool(source.erased)),
+        ("purged", JsonValue::Bool(source.purged)),
+        ("tombstoned", JsonValue::Bool(source.tombstoned)),
+        ("disposed", JsonValue::Bool(source.disposed)),
+        ("retained", JsonValue::Bool(source.retained)),
+        ("expired", JsonValue::Bool(source.expired)),
+        ("archived", JsonValue::Bool(source.archived)),
+        ("blocked", JsonValue::Bool(record.is_blocked())),
+        (
+            "requires_attention",
+            JsonValue::Bool(record.requires_attention()),
+        ),
+        (
+            "has_source_lineage",
+            JsonValue::Bool(record.has_source_lineage()),
+        ),
+    ]
+}
+
+fn integration_activation_waiver_erasure_receipt_summary_json(
+    summary: &IntegrationActivationWaiverErasureReceiptSummary,
+) -> JsonValue {
+    heap_object![
+        ("total_records", integer(summary.total_records as i64)),
+        (
+            "unique_integrations",
+            integer(summary.unique_integrations as i64),
+        ),
+        (
+            "records_requiring_attention",
+            integer(summary.records_requiring_attention as i64),
+        ),
+        ("blocked_records", integer(summary.blocked_records as i64)),
+        (
+            "evidence_required_records",
+            integer(summary.evidence_required_records as i64),
+        ),
+        (
+            "ready_for_receipt_records",
+            integer(summary.ready_for_receipt_records as i64),
+        ),
+        (
+            "receipted_records",
+            integer(summary.receipted_records as i64)
+        ),
+        (
+            "receipt_ready_records",
+            integer(summary.receipt_ready_records as i64),
+        ),
+        ("erased_records", integer(summary.erased_records as i64)),
+        (
+            "erasure_ready_records",
+            integer(summary.erasure_ready_records as i64),
+        ),
+        ("purged_records", integer(summary.purged_records as i64)),
+        (
+            "source_linked_records",
+            integer(summary.source_linked_records as i64),
+        ),
+        (
+            "reviewer_required_records",
+            integer(summary.reviewer_required_records as i64),
+        ),
+        (
+            "exception_required_records",
+            integer(summary.exception_required_records as i64),
+        ),
+        (
+            "signoff_required_records",
+            integer(summary.signoff_required_records as i64),
+        ),
+        (
+            "platform_receipt_records",
+            integer(summary.platform_receipt_records as i64),
+        ),
+        (
+            "integration_receipt_records",
+            integer(summary.integration_receipt_records as i64),
+        ),
+        (
+            "security_receipt_records",
+            integer(summary.security_receipt_records as i64),
+        ),
+        (
+            "reviewer_receipt_records",
+            integer(summary.reviewer_receipt_records as i64),
+        ),
+        (
+            "verification_receipt_records",
+            integer(summary.verification_receipt_records as i64),
+        ),
+        (
+            "audit_receipt_records",
+            integer(summary.audit_receipt_records as i64),
+        ),
+        (
+            "first_attention_priority",
+            summary
+                .first_attention_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_blocked_priority",
+            summary
+                .first_blocked_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_ready_priority",
+            summary
+                .first_ready_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "next_receipt_status",
+            summary
+                .next_receipt_status
+                .map(|status| string(status.as_str()))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "next_receipt_lane",
+            summary
+                .next_receipt_lane
+                .map(|lane| string(lane.as_str()))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "next_receipt_action",
+            summary
+                .next_receipt_action
                 .as_ref()
                 .map(|action| string(action))
                 .unwrap_or(JsonValue::Null),
@@ -42563,6 +43621,27 @@ fn parse_activation_waiver_erasure_status(
     }
 }
 
+fn parse_activation_waiver_erasure_receipt_status(
+    label: &str,
+) -> Result<IntegrationActivationWaiverErasureReceiptStatus, ToolCallError> {
+    match label {
+        "blocked" | "blocker" | "hold" | "held" => {
+            Ok(IntegrationActivationWaiverErasureReceiptStatus::Blocked)
+        }
+        "evidence_required" | "needs_evidence" | "evidence" | "source_required"
+        | "source_linkage" => Ok(IntegrationActivationWaiverErasureReceiptStatus::EvidenceRequired),
+        "ready_for_receipt" | "ready" | "receipt_ready" | "ready_to_receipt" => {
+            Ok(IntegrationActivationWaiverErasureReceiptStatus::ReadyForReceipt)
+        }
+        "receipted" | "receipt" | "finalized" | "finalised" | "complete" | "completed" => {
+            Ok(IntegrationActivationWaiverErasureReceiptStatus::Receipted)
+        }
+        _ => Err(validation_error(format!(
+            "unknown activation waiver erasure receipt status `{label}`"
+        ))),
+    }
+}
+
 fn parse_activation_risk_kind(label: &str) -> Result<IntegrationActivationRiskKind, ToolCallError> {
     match label {
         "policy_tier" | "tier" | "required_tier" => Ok(IntegrationActivationRiskKind::PolicyTier),
@@ -45678,6 +46757,104 @@ fn integration_activation_waiver_erasure_query_schema() -> JsonSchema {
     schema
 }
 
+fn integration_activation_waiver_erasure_receipt_query_schema() -> JsonSchema {
+    let mut schema = integration_activation_waiver_erasure_query_schema();
+    if let JsonSchema::Object {
+        properties,
+        required: _,
+        allow_unknown_fields: _,
+    } = &mut schema
+    {
+        let mut push_if_absent = |property: SchemaProperty| {
+            if !properties
+                .iter()
+                .any(|existing| existing.name == property.name)
+            {
+                properties.push(property);
+            }
+        };
+        push_if_absent(SchemaProperty::new(
+            "waiver_erasure_receipt_status",
+            JsonSchema::String,
+        ));
+        push_if_absent(SchemaProperty::new("receipt_status", JsonSchema::String));
+        push_if_absent(SchemaProperty::new(
+            "waiver_erasure_receipt_lane",
+            JsonSchema::String,
+        ));
+        push_if_absent(SchemaProperty::new("receipt_lane", JsonSchema::String));
+        push_if_absent(SchemaProperty::new(
+            "waiver_erasure_receipt_erasure_lane",
+            JsonSchema::String,
+        ));
+        push_if_absent(SchemaProperty::new(
+            "waiver_erasure_receipt_purge_lane",
+            JsonSchema::String,
+        ));
+        push_if_absent(SchemaProperty::new(
+            "waiver_erasure_receipt_tombstone_lane",
+            JsonSchema::String,
+        ));
+        push_if_absent(SchemaProperty::new(
+            "waiver_erasure_receipt_disposal_lane",
+            JsonSchema::String,
+        ));
+        push_if_absent(SchemaProperty::new(
+            "waiver_erasure_receipt_expiration_lane",
+            JsonSchema::String,
+        ));
+        push_if_absent(SchemaProperty::new(
+            "waiver_erasure_receipt_retention_lane",
+            JsonSchema::String,
+        ));
+        push_if_absent(SchemaProperty::new(
+            "waiver_erasure_receipt_archive_lane",
+            JsonSchema::String,
+        ));
+        push_if_absent(SchemaProperty::new(
+            "waiver_erasure_receipt_closure_lane",
+            JsonSchema::String,
+        ));
+        push_if_absent(SchemaProperty::new(
+            "waiver_erasure_receipt_owner_lane",
+            JsonSchema::String,
+        ));
+        push_if_absent(SchemaProperty::new(
+            "waiver_erasure_receipt_approval_lane",
+            JsonSchema::String,
+        ));
+        push_if_absent(SchemaProperty::new(
+            "waiver_erasure_receipt_evidence_kind",
+            JsonSchema::String,
+        ));
+        push_if_absent(SchemaProperty::new(
+            "waiver_erasure_receipt_requires_attention",
+            JsonSchema::Boolean,
+        ));
+        push_if_absent(SchemaProperty::new(
+            "waiver_erasure_receipt_blocked",
+            JsonSchema::Boolean,
+        ));
+        push_if_absent(SchemaProperty::new(
+            "waiver_erasure_receipt_ready",
+            JsonSchema::Boolean,
+        ));
+        push_if_absent(SchemaProperty::new("receipt_ready", JsonSchema::Boolean));
+        push_if_absent(SchemaProperty::new(
+            "waiver_erasure_receipted",
+            JsonSchema::Boolean,
+        ));
+        push_if_absent(SchemaProperty::new("receipted", JsonSchema::Boolean));
+        push_if_absent(SchemaProperty::new(
+            "waiver_erasure_receipt_limit",
+            JsonSchema::Integer,
+        ));
+        push_if_absent(SchemaProperty::new("receipt_limit", JsonSchema::Integer));
+        push_if_absent(SchemaProperty::new("record_limit", JsonSchema::Integer));
+    }
+    schema
+}
+
 fn integration_activation_risk_query_schema() -> JsonSchema {
     let mut schema = integration_activation_candidate_query_schema(true);
     if let JsonSchema::Object {
@@ -45822,7 +46999,7 @@ mod tests {
         let definitions = smart_home_tool_definitions();
         let export = ToolCatalogExport::from_definitions(definitions.iter());
 
-        assert_eq!(definitions.len(), 177);
+        assert_eq!(definitions.len(), 179);
         assert!(
             export.ok(),
             "tool export validation failed: {:?}",
@@ -46331,9 +47508,15 @@ mod tests {
         assert!(export
             .tool_ids()
             .contains(&SMART_HOME_GET_INTEGRATION_ACTIVATION_WAIVER_ERASURE_SUMMARY_TOOL_ID));
+        assert!(export
+            .tool_ids()
+            .contains(&SMART_HOME_LIST_INTEGRATION_ACTIVATION_WAIVER_ERASURE_RECEIPTS_TOOL_ID));
+        assert!(export.tool_ids().contains(
+            &SMART_HOME_GET_INTEGRATION_ACTIVATION_WAIVER_ERASURE_RECEIPT_SUMMARY_TOOL_ID
+        ));
         assert_eq!(
             export.summary.required_capability_count("smart_home:read"),
-            169
+            171
         );
         assert_eq!(
             export
@@ -46973,11 +48156,11 @@ mod tests {
         let tool_catalog_summary = field(tool_catalog_summary_output, "summary").unwrap();
         assert_eq!(
             field(tool_catalog_summary, "total_tools"),
-            Some(&integer(177))
+            Some(&integer(179))
         );
         assert_eq!(
             field(tool_catalog_summary, "read_tools"),
-            Some(&integer(169))
+            Some(&integer(171))
         );
         assert_eq!(
             field(tool_catalog_summary, "risky_tool_count"),
@@ -57900,6 +59083,216 @@ mod tests {
         traces.push((
             activation_waiver_erasure_summary_request,
             activation_waiver_erasure_summary_trace,
+        ));
+
+        traces
+    }
+
+    #[test]
+    fn activation_waiver_erasure_receipt_tools_project_erasure_lineage_end_to_end() {
+        std::thread::Builder::new()
+            .name("activation-waiver-erasure-receipt-e2e".to_string())
+            .stack_size(16 * 1024 * 1024)
+            .spawn(activation_waiver_erasure_receipt_tools_project_erasure_lineage_end_to_end_inner)
+            .unwrap()
+            .join()
+            .unwrap();
+    }
+
+    fn activation_waiver_erasure_receipt_tools_project_erasure_lineage_end_to_end_inner() {
+        let runtime = Rc::new(RefCell::new(hue_lighting_runtime()));
+        let bridge = SmartHomeToolBridge::new(runtime, AgentId::trusted(AGENT_ID));
+        let mut tool_runtime = InMemoryToolRuntime::new();
+        bridge.register_all(&mut tool_runtime).unwrap();
+
+        let traces = exercise_activation_waiver_erasure_receipt_tools(&tool_runtime);
+        let mut journal = ToolExecutionJournal::new();
+        for (request, trace) in traces {
+            journal.record_trace(request, trace);
+        }
+
+        let summary = journal.summary();
+        assert_eq!(summary.invocation_count, 2);
+        assert_eq!(summary.completed_count, 2);
+        assert_eq!(journal.audit_records().len(), 2);
+    }
+
+    fn exercise_activation_waiver_erasure_receipt_tools(
+        tool_runtime: &InMemoryToolRuntime,
+    ) -> Vec<(ToolInvocationRequest, ToolExecutionTrace)> {
+        let mut traces = Vec::with_capacity(2);
+
+        let list_activation_waiver_erasure_receipts_request = request(
+            "call-list-integration-activation-waiver-erasure-receipts",
+            SMART_HOME_LIST_INTEGRATION_ACTIVATION_WAIVER_ERASURE_RECEIPTS_TOOL_ID,
+            object([
+                ("priority_at_or_before", integer(2)),
+                (
+                    "available_primitives",
+                    JsonValue::Array(vec![
+                        string("normalized_model"),
+                        string("discovery_index"),
+                        string("command_mapping"),
+                        string("capability_policy"),
+                        string("supervision"),
+                    ]),
+                ),
+                (
+                    "allowed_capability_ids",
+                    JsonValue::Array(vec![string("smart_home.read")]),
+                ),
+                (
+                    "enabled_integrations",
+                    JsonValue::Array(vec![string("mqtt")]),
+                ),
+                ("waiver_erasure_receipt_blocked", JsonValue::Bool(true)),
+                (
+                    "waiver_erasure_receipt_requires_attention",
+                    JsonValue::Bool(true),
+                ),
+                ("waiver_erasure_receipt_limit", integer(3)),
+            ]),
+            5_405,
+        );
+        let list_activation_waiver_erasure_receipts_trace =
+            tool_runtime.invoke_with_events(&list_activation_waiver_erasure_receipts_request);
+        assert!(list_activation_waiver_erasure_receipts_trace.result.ok);
+        assert_eq!(
+            list_activation_waiver_erasure_receipts_trace
+                .summary()
+                .progress_event_count,
+            1
+        );
+        let list_activation_waiver_erasure_receipts_output =
+            list_activation_waiver_erasure_receipts_trace
+                .result
+                .output
+                .as_ref()
+                .unwrap();
+        let activation_waiver_erasure_receipt_count =
+            integer_value(field(list_activation_waiver_erasure_receipts_output, "count").unwrap())
+                .unwrap();
+        assert!((1..=3).contains(&activation_waiver_erasure_receipt_count));
+        let activation_waiver_erasure_receipt_summary =
+            field(list_activation_waiver_erasure_receipts_output, "summary").unwrap();
+        assert_eq!(
+            field(activation_waiver_erasure_receipt_summary, "total_records"),
+            Some(&integer(activation_waiver_erasure_receipt_count))
+        );
+        assert!(
+            integer_value(
+                field(activation_waiver_erasure_receipt_summary, "blocked_records",).unwrap(),
+            )
+            .unwrap()
+                >= 1
+        );
+        assert_eq!(
+            field(activation_waiver_erasure_receipt_summary, "has_blockers"),
+            Some(&JsonValue::Bool(true))
+        );
+        assert_eq!(
+            field(
+                activation_waiver_erasure_receipt_summary,
+                "requires_attention",
+            ),
+            Some(&JsonValue::Bool(true))
+        );
+        let activation_waiver_erasure_receipt = array_item(
+            field(
+                list_activation_waiver_erasure_receipts_output,
+                "activation_waiver_erasure_receipts",
+            )
+            .unwrap(),
+            0,
+        )
+        .unwrap();
+        assert!(field(activation_waiver_erasure_receipt, "receipt_id").is_some());
+        assert!(field(activation_waiver_erasure_receipt, "source_erasure_id").is_some());
+        assert!(field(activation_waiver_erasure_receipt, "source_purge_id").is_some());
+        assert!(field(activation_waiver_erasure_receipt, "source_tombstone_id").is_some());
+        assert!(field(activation_waiver_erasure_receipt, "source_disposal_id").is_some());
+        assert!(field(activation_waiver_erasure_receipt, "source_expiration_id").is_some());
+        assert!(field(activation_waiver_erasure_receipt, "source_retention_id").is_some());
+        assert!(field(activation_waiver_erasure_receipt, "source_archive_id").is_some());
+        assert!(field(activation_waiver_erasure_receipt, "source_waiver_id").is_some());
+        assert!(field(activation_waiver_erasure_receipt, "source_exception_id").is_some());
+        assert!(field(activation_waiver_erasure_receipt, "receipt_lane").is_some());
+        assert!(field(activation_waiver_erasure_receipt, "receipt_action").is_some());
+        assert_eq!(
+            field(activation_waiver_erasure_receipt, "blocked"),
+            Some(&JsonValue::Bool(true))
+        );
+        assert_eq!(
+            field(activation_waiver_erasure_receipt, "requires_attention"),
+            Some(&JsonValue::Bool(true))
+        );
+        assert_eq!(
+            field(activation_waiver_erasure_receipt, "has_source_lineage"),
+            Some(&JsonValue::Bool(true))
+        );
+        traces.push((
+            list_activation_waiver_erasure_receipts_request,
+            list_activation_waiver_erasure_receipts_trace,
+        ));
+
+        let activation_waiver_erasure_receipt_summary_request = request(
+            "call-integration-activation-waiver-erasure-receipt-summary",
+            SMART_HOME_GET_INTEGRATION_ACTIVATION_WAIVER_ERASURE_RECEIPT_SUMMARY_TOOL_ID,
+            object([
+                ("priority_at_or_before", integer(2)),
+                (
+                    "available_primitives",
+                    JsonValue::Array(vec![
+                        string("normalized_model"),
+                        string("discovery_index"),
+                        string("command_mapping"),
+                        string("capability_policy"),
+                        string("supervision"),
+                    ]),
+                ),
+                (
+                    "allowed_capability_ids",
+                    JsonValue::Array(vec![string("smart_home.read")]),
+                ),
+                (
+                    "enabled_integrations",
+                    JsonValue::Array(vec![string("mqtt")]),
+                ),
+                ("waiver_erasure_receipt_blocked", JsonValue::Bool(true)),
+            ]),
+            5_406,
+        );
+        let activation_waiver_erasure_receipt_summary_trace =
+            tool_runtime.invoke_with_events(&activation_waiver_erasure_receipt_summary_request);
+        assert!(activation_waiver_erasure_receipt_summary_trace.result.ok);
+        assert_eq!(
+            activation_waiver_erasure_receipt_summary_trace
+                .summary()
+                .progress_event_count,
+            1
+        );
+        let activation_waiver_erasure_receipt_summary_output =
+            activation_waiver_erasure_receipt_summary_trace
+                .result
+                .output
+                .as_ref()
+                .unwrap();
+        let activation_waiver_erasure_receipt_rollup =
+            field(activation_waiver_erasure_receipt_summary_output, "summary").unwrap();
+        assert!(
+            integer_value(
+                field(activation_waiver_erasure_receipt_rollup, "blocked_records",).unwrap(),
+            )
+            .unwrap()
+                >= 1
+        );
+        assert_eq!(
+            field(activation_waiver_erasure_receipt_rollup, "has_blockers"),
+            Some(&JsonValue::Bool(true))
+        );
+        traces.push((
+            activation_waiver_erasure_receipt_summary_request,
+            activation_waiver_erasure_receipt_summary_trace,
         ));
 
         traces

--- a/code/packages/rust/smart-home-core/src/lib.rs
+++ b/code/packages/rust/smart-home-core/src/lib.rs
@@ -1575,6 +1575,8 @@ pub enum SmartHomeTool {
     GetIntegrationActivationWaiverPurgeSummary,
     ListIntegrationActivationWaiverErasures,
     GetIntegrationActivationWaiverErasureSummary,
+    ListIntegrationActivationWaiverErasureReceipts,
+    GetIntegrationActivationWaiverErasureReceiptSummary,
     ListIntegrationActivationRisk,
     GetIntegrationActivationRiskSummary,
     ListIntegrationActivationDependencies,
@@ -2006,6 +2008,12 @@ impl SmartHomeTool {
             }
             Self::GetIntegrationActivationWaiverErasureSummary => {
                 read_tool("smart_home.get_integration_activation_waiver_erasure_summary")
+            }
+            Self::ListIntegrationActivationWaiverErasureReceipts => {
+                read_tool("smart_home.list_integration_activation_waiver_erasure_receipts")
+            }
+            Self::GetIntegrationActivationWaiverErasureReceiptSummary => {
+                read_tool("smart_home.get_integration_activation_waiver_erasure_receipt_summary")
             }
             Self::ListIntegrationActivationRisk => {
                 read_tool("smart_home.list_integration_activation_risk")
@@ -2764,6 +2772,8 @@ pub fn smart_home_tool_catalog() -> Vec<ToolDescriptor> {
         SmartHomeTool::GetIntegrationActivationWaiverPurgeSummary,
         SmartHomeTool::ListIntegrationActivationWaiverErasures,
         SmartHomeTool::GetIntegrationActivationWaiverErasureSummary,
+        SmartHomeTool::ListIntegrationActivationWaiverErasureReceipts,
+        SmartHomeTool::GetIntegrationActivationWaiverErasureReceiptSummary,
         SmartHomeTool::ListIntegrationActivationRisk,
         SmartHomeTool::GetIntegrationActivationRiskSummary,
         SmartHomeTool::ListIntegrationActivationDependencies,
@@ -3606,7 +3616,7 @@ mod tests {
             .find(|tool| tool.tool_id == "smart_home.command")
             .unwrap();
 
-        assert_eq!(catalog.len(), 177);
+        assert_eq!(catalog.len(), 179);
         assert!(catalog
             .iter()
             .any(|tool| tool.tool_id == "smart_home.list_integrations"
@@ -4321,6 +4331,14 @@ mod tests {
             == "smart_home.get_integration_activation_waiver_erasure_summary"
             && tool.side_effects == ToolSideEffects::Read
             && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
+        assert!(catalog.iter().any(|tool| tool.tool_id
+            == "smart_home.list_integration_activation_waiver_erasure_receipts"
+            && tool.side_effects == ToolSideEffects::Read
+            && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
+        assert!(catalog.iter().any(|tool| tool.tool_id
+            == "smart_home.get_integration_activation_waiver_erasure_receipt_summary"
+            && tool.side_effects == ToolSideEffects::Read
+            && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
     }
 
     #[test]
@@ -4328,15 +4346,15 @@ mod tests {
         let summary = smart_home_tool_catalog_summary();
         let pair_bridge = SmartHomeTool::PairBridge.descriptor();
 
-        assert_eq!(summary.total_tools, 177);
-        assert_eq!(summary.read_tools, 169);
+        assert_eq!(summary.total_tools, 179);
+        assert_eq!(summary.read_tools, 171);
         assert_eq!(summary.write_tools, 2);
         assert_eq!(summary.external_tools, 6);
-        assert_eq!(summary.read_only_tier_tools, 169);
+        assert_eq!(summary.read_only_tier_tools, 171);
         assert_eq!(summary.low_risk_tier_tools, 6);
         assert_eq!(summary.high_risk_tier_tools, 0);
         assert_eq!(summary.human_approval_tier_tools, 2);
-        assert_eq!(summary.total_required_capabilities, 177);
+        assert_eq!(summary.total_required_capabilities, 179);
         assert_eq!(summary.risky_tool_count(), 8);
         assert_eq!(summary.approval_gated_tool_count(), 2);
         assert!(pair_bridge.requires_human_approval());


### PR DESCRIPTION
## Summary
- add read-only smart-home catalog descriptors for activation waiver erasure receipt list and summary tools
- add Chief bridge handlers, query parsing, receipt rollups, and compact receipt row projection derived from erasure lineage
- cover the receipt tools with an end-to-end Chief tool invocation test and catalog export assertions

## Validation
- cargo test -p smart-home-core
- cargo test -p smart-home-integration-catalog
- cargo test -p hue-core
- cargo test -p smart-home-runtime
- cargo test -p smart-home-testkit
- cargo test -p smart-home-local-http
- cargo test -p smart-home-discovery
- cargo test -p chief-of-staff-smart-home-tools
- cargo test -p smart-home-runtime discover_tool -- --nocapture
- sh BUILD in smart-home-core, smart-home-integration-catalog, hue-core, smart-home-runtime, smart-home-testkit, smart-home-local-http, smart-home-discovery, and chief-of-staff-smart-home-tools