### PR TITLE
feat(r-lang): the matrix type — matrix/%*%/t/dim/apply (R-11)

### DIFF
--- a/code/packages/rust/r-runtime/CHANGELOG.md
+++ b/code/packages/rust/r-runtime/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.6.0] - 2026-06-16
+
+### Added (via the shared `s-runtime`)
+
+- **R-11 — the matrix type**: `matrix()`, `%*%`, `t()`, `dim`/`nrow`/`ncol`, and
+  `apply()`. See `s-runtime` 0.7.0.
+
 ## [0.5.0] - 2026-06-16
 
 ### Added (via the shared `s-runtime`)

--- a/code/packages/rust/r-runtime/src/lib.rs
+++ b/code/packages/rust/r-runtime/src/lib.rs
@@ -352,4 +352,62 @@ mod tests {
             vec![6.0]
         );
     }
+
+    // --- R-11: the matrix type ------------------------------------------
+
+    #[test]
+    fn matrix_construction_and_dims() {
+        assert_eq!(nums("dim(matrix(1:6, nrow = 2))\n"), vec![2.0, 3.0]);
+        assert_eq!(nums("nrow(matrix(1:6, 2, 3))\n"), vec![2.0]);
+        assert_eq!(nums("ncol(matrix(1:6, 2, 3))\n"), vec![3.0]);
+        // Column-major fill: flattening recovers the original order.
+        assert_eq!(
+            nums("c(matrix(1:6, 2, 3))\n"),
+            vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]
+        );
+        // byrow = TRUE fills row by row.
+        assert_eq!(
+            nums("c(matrix(1:6, nrow = 2, byrow = TRUE))\n"),
+            vec![1.0, 4.0, 2.0, 5.0, 3.0, 6.0]
+        );
+    }
+
+    #[test]
+    fn transpose_and_matrix_product() {
+        assert_eq!(
+            nums("c(t(matrix(1:6, 2, 3)))\n"),
+            vec![1.0, 3.0, 5.0, 2.0, 4.0, 6.0]
+        );
+        // [[1,3,5],[2,4,6]] %*% its transpose.
+        assert_eq!(
+            nums("c(matrix(1:6, 2, 3) %*% t(matrix(1:6, 2, 3)))\n"),
+            vec![35.0, 44.0, 44.0, 56.0]
+        );
+        // vector %*% vector is the dot product.
+        assert_eq!(nums("c(c(1, 2, 3) %*% c(4, 5, 6))\n"), vec![32.0]);
+        // M %*% I == M.
+        assert_eq!(
+            nums("c(matrix(1:4, 2, 2) %*% matrix(c(1, 0, 0, 1), 2, 2))\n"),
+            vec![1.0, 2.0, 3.0, 4.0]
+        );
+    }
+
+    #[test]
+    fn apply_over_rows_and_columns() {
+        assert_eq!(nums("apply(matrix(1:6, 2, 3), 1, sum)\n"), vec![9.0, 12.0]);
+        assert_eq!(
+            nums("apply(matrix(1:6, 2, 3), 2, sum)\n"),
+            vec![3.0, 7.0, 11.0]
+        );
+        // A non-scalar apply result (with an R-9 lambda) builds a matrix.
+        assert_eq!(
+            nums("dim(apply(matrix(1:6, 2, 3), 2, \\(col) col * 2))\n"),
+            vec![2.0, 3.0]
+        );
+    }
+
+    #[test]
+    fn non_conformable_product_is_an_error() {
+        assert!(eval_r("matrix(1:6, 2, 3) %*% matrix(1:6, 2, 3)\n").is_err());
+    }
 }

--- a/code/packages/rust/s-runtime/CHANGELOG.md
+++ b/code/packages/rust/s-runtime/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.7.0] - 2026-06-16
+
+### Added
+
+- **Matrix type (R-11)** — a new `SValue::Matrix { data, nrow, ncol }` (numeric,
+  column-major, implicit class `"matrix"`), the `%*%` matrix-multiply operator
+  (a new arm in the `%op%` infix dispatch — a bare vector is a row on the left,
+  a column on the right, so `v %*% w` is the dot product; NA propagates), and the
+  builtins `matrix(data, nrow =, ncol =, byrow =)`, `t()`, and
+  `apply(X, MARGIN, FUN, …)` (over rows/columns, simplifying to a vector or
+  matrix). `dim()`/`nrow()`/`ncol()` extended for matrices. Matrices coerce to
+  their flat vector and print with R's `[,j]`/`[i,]` console layout. The product
+  size and all loops are capped at `MAX_SEQ_LEN`.
+
 ## [0.6.0] - 2026-06-16
 
 ### Added

--- a/code/packages/rust/s-runtime/src/builtins.rs
+++ b/code/packages/rust/s-runtime/src/builtins.rs
@@ -165,6 +165,11 @@ pub fn install(env: &Env) {
     define(env, "colnames", builtin("colnames", b_names));
     define(env, "dim", builtin("dim", b_dim));
     define(env, "head", builtin("head", b_head));
+
+    // Matrices (R-11). `%*%` lives in the evaluator's infix dispatch.
+    define(env, "matrix", builtin("matrix", b_matrix));
+    define(env, "t", builtin("t", b_t));
+    define(env, "apply", builtin("apply", b_apply));
 }
 
 // ===========================================================================
@@ -216,6 +221,7 @@ fn b_nrow(_interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
         SValue::DataFrame { columns, .. } => Ok(SValue::scalar(
             columns.first().map(|c| c.length()).unwrap_or(0) as f64,
         )),
+        SValue::Matrix { nrow, .. } => Ok(SValue::scalar(*nrow as f64)),
         _ => Ok(SValue::Null),
     }
 }
@@ -224,6 +230,7 @@ fn b_nrow(_interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
 fn b_ncol(_interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
     match first_positional(args)? {
         SValue::DataFrame { columns, .. } => Ok(SValue::scalar(columns.len() as f64)),
+        SValue::Matrix { ncol, .. } => Ok(SValue::scalar(*ncol as f64)),
         _ => Ok(SValue::Null),
     }
 }
@@ -245,6 +252,7 @@ fn b_dim(_interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
             let nrow = columns.first().map(|c| c.length()).unwrap_or(0) as f64;
             Ok(SValue::doubles(vec![nrow, columns.len() as f64]))
         }
+        SValue::Matrix { nrow, ncol, .. } => Ok(SValue::doubles(vec![*nrow as f64, *ncol as f64])),
         _ => Ok(SValue::Null),
     }
 }
@@ -288,6 +296,187 @@ fn b_head(_interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
             let idx = SValue::doubles((1..=take).map(|k| k as f64).collect());
             index(other, &idx)
         }
+    }
+}
+
+// ===========================================================================
+// Matrices (R-11)
+// ===========================================================================
+
+/// Read a positive-integer `matrix`/`apply` dimension argument, by name or
+/// position.
+fn dim_arg(args: &[Arg], name: &str, pos: usize) -> Option<usize> {
+    args.iter()
+        .find(|a| a.name.as_deref() == Some(name))
+        .map(|a| &a.value)
+        .or_else(|| nth_positional(args, pos))
+        .and_then(|v| v.as_double().ok())
+        .and_then(|d| d.get_value(0))
+        .filter(|x| x.is_finite() && *x >= 1.0)
+        .map(|x| x as usize)
+}
+
+/// `matrix(data, nrow =, ncol =, byrow = FALSE)` — lay `data` (recycled) into a
+/// matrix. Column-major by default; `byrow = TRUE` fills row by row. With only
+/// one of `nrow`/`ncol`, the other is derived from the data length.
+fn b_matrix(_interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
+    let data = first_positional(args)?.as_double()?;
+    let n = data.len();
+    let nrow_a = dim_arg(args, "nrow", 1);
+    let ncol_a = dim_arg(args, "ncol", 2);
+    let byrow = args
+        .iter()
+        .find(|a| a.name.as_deref() == Some("byrow"))
+        .map(|a| a.value.truthy().unwrap_or(false))
+        .unwrap_or(false);
+
+    let ceil_div = |a: usize, b: usize| a.div_ceil(b.max(1));
+    let (nrow, ncol) = match (nrow_a, ncol_a) {
+        (Some(r), Some(c)) => (r, c),
+        (Some(r), None) => (r, ceil_div(n, r).max(1)),
+        (None, Some(c)) => (ceil_div(n, c).max(1), c),
+        (None, None) => (n.max(1), 1), // a bare column
+    };
+    let total = nrow
+        .checked_mul(ncol)
+        .filter(|&t| t <= MAX_SEQ_LEN)
+        .ok_or_else(|| SError::Index(format!("matrix too large (limit {MAX_SEQ_LEN} elements)")))?;
+
+    let src = data.data();
+    let at = |i: usize| if n == 0 { na_real() } else { src[i % n] };
+    let mut out = vec![0.0; total];
+    if byrow {
+        for r in 0..nrow {
+            for c in 0..ncol {
+                out[c * nrow + r] = at(r * ncol + c); // read row-major, store column-major
+            }
+        }
+    } else {
+        for (i, slot) in out.iter_mut().enumerate() {
+            *slot = at(i);
+        }
+    }
+    Ok(SValue::Matrix {
+        data: Double::from_values(out),
+        nrow,
+        ncol,
+    })
+}
+
+/// `t(x)` — the transpose of a matrix; a bare vector becomes a `1×n` row.
+fn b_t(_interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
+    match first_positional(args)? {
+        SValue::Matrix { data, nrow, ncol } => {
+            let (nr, nc) = (*nrow, *ncol);
+            let s = data.data();
+            let mut out = vec![0.0; nr * nc];
+            for r in 0..nr {
+                for c in 0..nc {
+                    out[r * nc + c] = s[c * nr + r]; // result (c, r) ← original (r, c)
+                }
+            }
+            Ok(SValue::Matrix {
+                data: Double::from_values(out),
+                nrow: nc,
+                ncol: nr,
+            })
+        }
+        other => {
+            let d = other.as_double()?;
+            let n = d.len();
+            Ok(SValue::Matrix {
+                data: d,
+                nrow: 1,
+                ncol: n,
+            })
+        }
+    }
+}
+
+/// `apply(X, MARGIN, FUN, …)` — apply `FUN` to each row (`MARGIN = 1`) or column
+/// (`MARGIN = 2`) of a matrix `X`. Simplifies to a vector when every result is a
+/// scalar, to a matrix (one column per margin) when they share a length, else a
+/// list. Trailing arguments are passed to `FUN`.
+fn b_apply(interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
+    let positional: Vec<&Arg> = args.iter().filter(|a| a.name.is_none()).collect();
+    let x = positional
+        .first()
+        .ok_or_else(|| SError::BadArgs("apply: missing X".into()))?
+        .value
+        .clone();
+    let margin = positional
+        .get(1)
+        .and_then(|a| a.value.as_double().ok())
+        .and_then(|d| d.get_value(0))
+        .map(|m| m as i64)
+        .filter(|&m| m == 1 || m == 2)
+        .ok_or_else(|| SError::BadArgs("apply: MARGIN must be 1 (rows) or 2 (columns)".into()))?;
+    let f = positional
+        .get(2)
+        .ok_or_else(|| SError::BadArgs("apply: missing FUN".into()))?
+        .value
+        .clone();
+    if !f.is_callable() {
+        return Err(SError::NotCallable(f.type_name().to_string()));
+    }
+    let extra: Vec<Arg> = positional
+        .iter()
+        .skip(3)
+        .map(|a| Arg {
+            name: None,
+            value: a.value.clone(),
+        })
+        .collect();
+
+    let (data, nrow, ncol) = match &x {
+        SValue::Matrix { data, nrow, ncol } => (data.clone(), *nrow, *ncol),
+        other => {
+            return Err(SError::BadArgs(format!(
+                "apply: X must be a matrix (got {})",
+                other.type_name()
+            )))
+        }
+    };
+    let s = data.data();
+    let count = if margin == 1 { nrow } else { ncol };
+    let mut results = Vec::with_capacity(count);
+    for k in 0..count {
+        let slice: Vec<f64> = if margin == 1 {
+            (0..ncol).map(|c| s[c * nrow + k]).collect() // row k
+        } else {
+            (0..nrow).map(|r| s[k * nrow + r]).collect() // column k
+        };
+        let mut call_args = Vec::with_capacity(1 + extra.len());
+        call_args.push(Arg {
+            name: None,
+            value: SValue::doubles(slice),
+        });
+        call_args.extend(extra.iter().cloned());
+        results.push(interp.call_value(f.clone(), &call_args)?);
+    }
+
+    if results.iter().all(|r| r.length() == 1) {
+        let wrapped: Vec<Arg> = results
+            .into_iter()
+            .map(|value| Arg { name: None, value })
+            .collect();
+        Ok(combine(&wrapped))
+    } else if !results.is_empty() && results.iter().all(|r| r.length() == results[0].length()) {
+        let rlen = results[0].length();
+        let mut out = Vec::with_capacity(rlen * count);
+        for r in &results {
+            out.extend_from_slice(r.as_double()?.data());
+        }
+        Ok(SValue::Matrix {
+            data: Double::from_values(out),
+            nrow: rlen,
+            ncol: count,
+        })
+    } else {
+        Ok(SValue::List {
+            names: vec![None; results.len()],
+            items: results,
+        })
     }
 }
 

--- a/code/packages/rust/s-runtime/src/eval.rs
+++ b/code/packages/rust/s-runtime/src/eval.rs
@@ -363,6 +363,7 @@ impl Interpreter {
             "%/%" => arithmetic("%/%", lhs, rhs),
             "%in%" => Ok(membership(lhs, rhs)),
             "%o%" => self.outer_product(lhs, rhs),
+            "%*%" => self.matrix_multiply(lhs, rhs),
             _ => {
                 let func = lookup(env, op).ok_or_else(|| SError::Undefined(op.to_string()))?;
                 let args = [
@@ -407,6 +408,63 @@ impl Interpreter {
             }
         }
         Ok(SValue::doubles(out))
+    }
+
+    /// `a %*% b` — the matrix product (column-major). A bare vector on the left
+    /// is taken as a `1×n` row; on the right as an `n×1` column (so `v %*% w` is
+    /// the dot product), matching R's conformability rules. NA propagates.
+    fn matrix_multiply(&self, lhs: &SValue, rhs: &SValue) -> SResult<SValue> {
+        let (ad, am, ak) = match lhs {
+            SValue::Matrix { data, nrow, ncol } => (data.clone(), *nrow, *ncol),
+            other => {
+                let d = other.as_double()?;
+                let n = d.len();
+                (d, 1, n) // a left vector is a row
+            }
+        };
+        let (bd, bk, bn) = match rhs {
+            SValue::Matrix { data, nrow, ncol } => (data.clone(), *nrow, *ncol),
+            other => {
+                let d = other.as_double()?;
+                let n = d.len();
+                (d, n, 1) // a right vector is a column
+            }
+        };
+        if ak != bk {
+            return Err(SError::TypeError(format!(
+                "non-conformable arguments: {am}x{ak} %*% {bk}x{bn}"
+            )));
+        }
+        let total = am
+            .checked_mul(bn)
+            .filter(|&n| n <= MAX_SEQ_LEN)
+            .ok_or_else(|| {
+                SError::Index(format!(
+                    "matrix product result too large (limit {MAX_SEQ_LEN} elements)"
+                ))
+            })?;
+        let (a, b) = (ad.data(), bd.data());
+        let mut out = vec![0.0; total];
+        for c in 0..bn {
+            for r in 0..am {
+                let mut acc = 0.0;
+                let mut na = false;
+                for p in 0..ak {
+                    let (x, y) = (a[p * am + r], b[c * bk + p]); // column-major
+                    if is_na_real(x) || is_na_real(y) {
+                        na = true;
+                        break;
+                    }
+                    acc += x * y;
+                }
+                out[c * am + r] = if na { na_real() } else { acc };
+            }
+        }
+        Ok(SValue::Matrix {
+            data: Double::from_values(out),
+            nrow: am,
+            ncol: bn,
+        })
     }
 
     /// The native pipe `|>`. `x |> f(a)` desugars to `f(x, a)`: the left value

--- a/code/packages/rust/s-runtime/src/value.rs
+++ b/code/packages/rust/s-runtime/src/value.rs
@@ -90,6 +90,16 @@ pub enum SValue {
         names: Vec<Option<String>>,
         items: Vec<SValue>,
     },
+
+    /// A numeric matrix: an `nrow × ncol` rectangle of doubles stored
+    /// **column-major** (R/Fortran order — element `(r, c)` is at `c*nrow + r`).
+    /// Implicit class `"matrix"`; `length()` is `nrow*ncol`, `dim()` is
+    /// `c(nrow, ncol)`.
+    Matrix {
+        data: Double,
+        nrow: usize,
+        ncol: usize,
+    },
 }
 
 impl SValue {
@@ -113,6 +123,7 @@ pub fn class_of(value: &SValue) -> Vec<String> {
         SValue::Character(_) => vec!["character".to_string()],
         SValue::Null => vec!["NULL".to_string()],
         SValue::Closure { .. } | SValue::Builtin { .. } => vec!["function".to_string()],
+        SValue::Matrix { .. } => vec!["matrix".to_string(), "array".to_string()],
     }
 }
 
@@ -137,6 +148,7 @@ impl std::fmt::Debug for SValue {
             }
             SValue::Classed { inner, class } => write!(f, "Classed({class:?}, {inner:?})"),
             SValue::List { items, .. } => write!(f, "List({} items)", items.len()),
+            SValue::Matrix { nrow, ncol, .. } => write!(f, "Matrix({nrow}x{ncol})"),
         }
     }
 }
@@ -174,6 +186,7 @@ impl SValue {
             SValue::DataFrame { .. } => "data.frame",
             SValue::Classed { inner, .. } => inner.type_name(),
             SValue::List { .. } => "list",
+            SValue::Matrix { .. } => "double",
         }
     }
 
@@ -190,6 +203,7 @@ impl SValue {
             SValue::DataFrame { columns, .. } => columns.len(),
             SValue::Classed { inner, .. } => inner.length(),
             SValue::List { items, .. } => items.len(),
+            SValue::Matrix { data, .. } => data.len(),
         }
     }
 
@@ -213,6 +227,7 @@ impl SValue {
             )),
             SValue::Null => Ok(Double::from_values(vec![])),
             SValue::Classed { inner, .. } => inner.as_double(),
+            SValue::Matrix { data, .. } => Ok(data.clone()),
             other => Err(SError::TypeError(format!(
                 "non-numeric argument (got {})",
                 other.type_name()
@@ -231,6 +246,10 @@ impl SValue {
                 .collect()),
             SValue::Null => Ok(vec![]),
             SValue::Classed { inner, .. } => inner.as_logical(),
+            SValue::Matrix { data, .. } => Ok(data
+                .iter()
+                .map(|x| if is_na_real(x) { None } else { Some(x != 0.0) })
+                .collect()),
             other => Err(SError::TypeError(format!(
                 "argument is not logical (got {})",
                 other.type_name()
@@ -268,6 +287,16 @@ impl SValue {
             SValue::Null => vec![],
             SValue::Factor { codes, levels } => SValue::factor_labels(codes, levels),
             SValue::Classed { inner, .. } => inner.as_character(),
+            SValue::Matrix { data, .. } => data
+                .iter()
+                .map(|x| {
+                    if is_na_real(x) {
+                        None
+                    } else {
+                        Some(format_number(x))
+                    }
+                })
+                .collect(),
             other => vec![Some(other.type_name().to_string())],
         }
     }
@@ -291,6 +320,7 @@ impl SValue {
                 None => Err(SError::Missing("argument is of length zero".into())),
             },
             SValue::Classed { inner, .. } => inner.truthy(),
+            SValue::Matrix { data, .. } => SValue::Double(data.clone()).truthy(),
             other => Err(SError::TypeError(format!(
                 "argument is not interpretable as logical (got {})",
                 other.type_name()
@@ -697,9 +727,53 @@ pub fn format_value(value: &SValue) -> Vec<String> {
         SValue::DataFrame { names, columns } => return format_data_frame(names, columns),
         SValue::Classed { inner, .. } => return format_value(inner),
         SValue::List { names, items } => return format_list(names, items),
+        SValue::Matrix { data, nrow, ncol } => return format_matrix(data, *nrow, *ncol),
     };
 
     format_vector(&elems)
+}
+
+/// Render a matrix the way R's console does: a `[,j]` column-header row, then
+/// `[i,]`-labelled data rows, every cell right-aligned to a common width.
+fn format_matrix(data: &Double, nrow: usize, ncol: usize) -> Vec<String> {
+    if nrow == 0 || ncol == 0 {
+        return vec![format!("<{nrow} x {ncol} matrix>")];
+    }
+    // Column-major access: element (r, c) is at c*nrow + r.
+    let cell = |r: usize, c: usize| {
+        data.get_value(c * nrow + r)
+            .map(format_number)
+            .unwrap_or_else(|| "NA".to_string())
+    };
+    let row_label_w = format!("[{nrow},]").len();
+    // Each column is as wide as the widest of its header and its cells.
+    let col_w: Vec<usize> = (0..ncol)
+        .map(|c| {
+            let header = format!("[,{}]", c + 1).len();
+            (0..nrow)
+                .map(|r| cell(r, c).len())
+                .max()
+                .unwrap_or(1)
+                .max(header)
+        })
+        .collect();
+
+    let mut lines = Vec::with_capacity(nrow + 1);
+    let mut header = format!("{:>row_label_w$}", "");
+    for (c, &w) in col_w.iter().enumerate() {
+        header.push(' ');
+        header.push_str(&format!("{:>w$}", format!("[,{}]", c + 1)));
+    }
+    lines.push(header);
+    for r in 0..nrow {
+        let mut line = format!("{:>row_label_w$}", format!("[{},]", r + 1));
+        for (c, &w) in col_w.iter().enumerate() {
+            line.push(' ');
+            line.push_str(&format!("{:>w$}", cell(r, c)));
+        }
+        lines.push(line);
+    }
+    lines
 }
 
 /// Free-function form of [`SValue::factor_labels`] for use inside formatting.

--- a/code/specs/R00-r-language.md
+++ b/code/specs/R00-r-language.md
@@ -122,6 +122,18 @@ unchanged.
   The function is taken by name (`f =`/`FUN =`) or as the first callable
   positional, and the data are the other positionals — so they compose with the
   pipe: `1:5 |> Filter(f = \(x) x %% 2 == 0) |> Reduce(f = \(a, b) a + b)`.
+- **R-11 — the matrix type** *(this PR)*. A new `SValue::Matrix { data, nrow,
+  ncol }` (numeric, **column-major** — R/Fortran order, `length` is `nrow*ncol`,
+  implicit class `"matrix"`). `matrix(data, nrow =, ncol =, byrow = FALSE)`
+  builds one (recycling, deriving the missing dimension); `t()` transposes;
+  `dim()`/`nrow()`/`ncol()` report the shape; `%*%` is the matrix product (a new
+  arm in the evaluator's `%op%` infix dispatch — a bare vector becomes a row on
+  the left, a column on the right, so `v %*% w` is the dot product); and
+  `apply(X, MARGIN, FUN, …)` maps `FUN` over rows (`MARGIN = 1`) or columns
+  (`MARGIN = 2`), simplifying to a vector or matrix. NA propagates through the
+  product; the result-size and all loops are capped at `MAX_SEQ_LEN`. Matrices
+  coerce to their flat vector (`c(m)`, `sum(m)`) and print with R's `[,j]`/`[i,]`
+  console layout.
 
 ## §4 Reuse strategy
 


### PR DESCRIPTION
## What & why

**R-11** — R's **matrix type**, added to the shared `s-runtime`. Continues the autonomous R loop ([R00](code/specs/R00-r-language.md) §3).

```r
m <- matrix(1:6, nrow = 2)     # column-major 2x3
m %*% t(m)                     # [[35,44],[44,56]]
apply(m, 1, sum)               # 9 12  (row sums)
c(1,2,3) %*% c(4,5,6)          # 32    (dot product)
dim(m)                         # 2 3
```

## What it adds

- **`SValue::Matrix { data, nrow, ncol }`** — numeric, **column-major** (R/Fortran order), implicit class `"matrix"`. Extended every exhaustive `SValue` match and added `format_matrix` (R's `[,j]` column-header / `[i,]` row-label console layout). Matrices coerce to their flat vector, so `c(m)`/`sum(m)`/`mean(m)` just work.
- **`%*%`** — matrix multiply, a new arm in the evaluator's `%op%` infix dispatch (beside `%%`/`%/%`/`%in%`/`%o%`). Column-major, with R's vector conformability (a bare vector is a `1×n` row on the left, an `n×1` column on the right — so `v %*% w` is the dot product). NA propagates.
- **`matrix(data, nrow =, ncol =, byrow = FALSE)`**, **`t()`**, **`dim()`/`nrow()`/`ncol()`** (extended for matrices), and **`apply(X, MARGIN, FUN, …)`** over rows (`MARGIN = 1`) / columns (`MARGIN = 2`), invoking `FUN` via `call_value` and simplifying to a vector or matrix.

## Quality

- 119 `s-runtime` + 33 `r-runtime` tests (construction + column-major/byrow fill, transpose, the matrix product incl. dot-product and `M %*% I`, `apply` over rows and columns incl. an R-9 lambda producing a matrix, and the non-conformable error). `cargo fmt` + `cargo clippy` clean.
- **`/security-review` → PASSED**: the `data.len() == nrow*ncol` invariant holds at all constructors (fields immutable, no desync), all allocations `checked_mul`-capped at `MAX_SEQ_LEN`, no div-by-zero, no reachable panics; `apply`'s `FUN` calls are bounded by a matrix dimension and depth-guarded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)