### PR TITLE
Accept .control rawfile output toggles

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ### Added
 
+- **Deck control rawfile output option routing** —
+  `analyze_deck_controls()` and `resolve_deck_sources()` now accept selected
+  `.control` block `set wr_vecnames` and `set wr_singlescale` rawfile output
+  toggles as no-op control commands instead of reporting unsupported-command
+  diagnostics, matching Rust and TypeScript.
+
 - **Deck control ASCII filetype option routing** —
   `analyze_deck_controls()` and `resolve_deck_sources()` now accept selected
   `.control` block `set filetype=ascii` output-format options as no-op control

--- a/code/packages/python/spice-engine/README.md
+++ b/code/packages/python/spice-engine/README.md
@@ -163,8 +163,10 @@ selected analysis/output commands (`op`, `dc`, `ac`, `tran`, `save`, `probe`,
 `measure`, `meas`, `four`, `fourier`, `print`, and `plot`) are normalized into
 dotted deck cards, while `run`, `reset`, `quit`, and the UI-only
 `set noaskquit` option plus the ASCII rawfile-format `set filetype=ascii`
-option are accepted as no-op control markers. Other unrecognized non-comment
-commands emit diagnostics until a broader executed control subset is in scope.
+option and vector-name/single-scale rawfile output toggles (`set wr_vecnames`,
+`set wr_singlescale`) are accepted as no-op control markers. Other
+unrecognized non-comment commands emit diagnostics until a broader executed
+control subset is in scope.
 `resolve_deck_sources()` is the first include/library resolution layer: callers
 provide a source-content map, `.include` directives are expanded in place, and
 `.lib path section` selects a named `.lib` / `.endl` section with stable

--- a/code/packages/python/spice-engine/src/spice_engine/compatibility.py
+++ b/code/packages/python/spice-engine/src/spice_engine/compatibility.py
@@ -518,7 +518,9 @@ _SUPPORTED_CONTROL_BLOCK_COMMANDS = frozenset(
 _NOOP_CONTROL_BLOCK_COMMANDS = frozenset(
     {"run", ".run", "reset", ".reset", "quit", ".quit"}
 )
-_NOOP_CONTROL_BLOCK_SET_OPTIONS = frozenset({"noaskquit", "filetype=ascii"})
+_NOOP_CONTROL_BLOCK_SET_OPTIONS = frozenset(
+    {"noaskquit", "filetype=ascii", "wr_vecnames", "wr_singlescale"}
+)
 _SPICE_SUFFIX_FACTORS = {
     "t": 1.0e12,
     "g": 1.0e9,

--- a/code/packages/python/spice-engine/tests/test_compatibility.py
+++ b/code/packages/python/spice-engine/tests/test_compatibility.py
@@ -122,6 +122,8 @@ four 2k V(in)
 reset
 set noaskquit
 set filetype=ascii
+set wr_vecnames
+set wr_singlescale
 set filetype=binary
 run
 quit
@@ -147,7 +149,7 @@ quit
         (".include", 2, "error"),
         (".lib", 3, "error"),
         (".control", 4, "error"),
-        (".control", 16, "error"),
+        (".control", 18, "error"),
     ]
     assert [diag.code for diag in summary.diagnostics] == [
         "SPICE_DECK_UNSUPPORTED_DIRECTIVE",
@@ -234,6 +236,8 @@ four 2k V(b)
 .reset
 .set noaskquit
 .set filetype=ascii
+.set wr_vecnames
+.set wr_singlescale
 run
 .quit
 .endc

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Accept selected `.control` block `set wr_vecnames` and `set wr_singlescale`
+  rawfile output toggles as no-op control commands in `analyze_deck_controls`
+  and `resolve_deck_sources`, matching Python and TypeScript.
 - Accept selected `.control` block `set filetype=ascii` output-format options
   as no-op control commands in `analyze_deck_controls` and
   `resolve_deck_sources`, matching Python and TypeScript.

--- a/code/packages/rust/spice-engine/README.md
+++ b/code/packages/rust/spice-engine/README.md
@@ -130,8 +130,10 @@ selected analysis/output commands (`op`, `dc`, `ac`, `tran`, `save`, `probe`,
 `measure`, `meas`, `four`, `fourier`, `print`, and `plot`) are normalized into
 dotted deck cards, while `run`, `reset`, `quit`, and the UI-only
 `set noaskquit` option plus the ASCII rawfile-format `set filetype=ascii`
-option are accepted as no-op control markers. Other unrecognized non-comment
-commands emit diagnostics until a broader executed control subset is in scope.
+option and vector-name/single-scale rawfile output toggles (`set wr_vecnames`,
+`set wr_singlescale`) are accepted as no-op control markers. Other
+unrecognized non-comment commands emit diagnostics until a broader executed
+control subset is in scope.
 `resolve_deck_sources` is the first include/library resolution layer: callers
 provide a source-content map, `.include` directives are expanded in place, and
 `.lib path section` selects a named `.lib` / `.endl` section with stable

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -6916,7 +6916,7 @@ fn is_noop_control_block_command(line: &str) -> bool {
     if !matches!(command.as_str(), "set" | ".set") {
         return false;
     }
-    matches!(parts.next().map(|option| option.to_ascii_lowercase()), Some(option) if option == "noaskquit" || option == "filetype=ascii")
+    matches!(parts.next().map(|option| option.to_ascii_lowercase()), Some(option) if matches!(option.as_str(), "noaskquit" | "filetype=ascii" | "wr_vecnames" | "wr_singlescale"))
         && parts.next().is_none()
 }
 

--- a/code/packages/rust/spice-engine/tests/compatibility_tests.rs
+++ b/code/packages/rust/spice-engine/tests/compatibility_tests.rs
@@ -139,6 +139,8 @@ four 2k V(in)
 reset
 set noaskquit
 set filetype=ascii
+set wr_vecnames
+set wr_singlescale
 set filetype=binary
 run
 quit
@@ -180,7 +182,7 @@ quit
             (".include", 2, "error"),
             (".lib", 3, "error"),
             (".control", 4, "error"),
-            (".control", 16, "error")
+            (".control", 18, "error")
         ]
     );
     assert_eq!(
@@ -326,6 +328,8 @@ four 2k V(b)
 .reset
 .set noaskquit
 .set filetype=ascii
+.set wr_vecnames
+.set wr_singlescale
 run
 .quit
 .endc

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Accept selected `.control` block `set wr_vecnames` and `set wr_singlescale`
+  rawfile output toggles as no-op control commands in `analyzeDeckControls`
+  and `resolveDeckSources`, matching Python and Rust.
 - Accept selected `.control` block `set filetype=ascii` output-format options
   as no-op control commands in `analyzeDeckControls` and `resolveDeckSources`,
   matching Python and Rust.

--- a/code/packages/typescript/spice-engine/README.md
+++ b/code/packages/typescript/spice-engine/README.md
@@ -137,8 +137,10 @@ selected analysis/output commands (`op`, `dc`, `ac`, `tran`, `save`, `probe`,
 `measure`, `meas`, `four`, `fourier`, `print`, and `plot`) are normalized into
 dotted deck cards, while `run`, `reset`, `quit`, and the UI-only
 `set noaskquit` option plus the ASCII rawfile-format `set filetype=ascii`
-option are accepted as no-op control markers. Other unrecognized non-comment
-commands emit diagnostics until a broader executed control subset is in scope.
+option and vector-name/single-scale rawfile output toggles (`set wr_vecnames`,
+`set wr_singlescale`) are accepted as no-op control markers. Other
+unrecognized non-comment commands emit diagnostics until a broader executed
+control subset is in scope.
 `resolveDeckSources` is the first include/library resolution layer: callers
 provide a source-content map, `.include` directives are expanded in place, and
 `.lib path section` selects a named `.lib` / `.endl` section with stable

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -2855,7 +2855,12 @@ const SUPPORTED_CONTROL_BLOCK_COMMANDS = new Set([
   ".plot",
 ]);
 const NOOP_CONTROL_BLOCK_COMMANDS = new Set(["run", ".run", "reset", ".reset", "quit", ".quit"]);
-const NOOP_CONTROL_BLOCK_SET_OPTIONS = new Set(["noaskquit", "filetype=ascii"]);
+const NOOP_CONTROL_BLOCK_SET_OPTIONS = new Set([
+  "noaskquit",
+  "filetype=ascii",
+  "wr_vecnames",
+  "wr_singlescale",
+]);
 
 export function compatibilityCorpus(): readonly CompatibilityDeck[] {
   return COMPATIBILITY_CORPUS;

--- a/code/packages/typescript/spice-engine/tests/compatibility.test.ts
+++ b/code/packages/typescript/spice-engine/tests/compatibility.test.ts
@@ -126,6 +126,8 @@ four 2k V(in)
 reset
 set noaskquit
 set filetype=ascii
+set wr_vecnames
+set wr_singlescale
 set filetype=binary
 run
 quit
@@ -154,7 +156,7 @@ quit
       [".include", 2, "error"],
       [".lib", 3, "error"],
       [".control", 4, "error"],
-      [".control", 16, "error"],
+      [".control", 18, "error"],
     ]);
     expect(summary.diagnostics.map((diagnostic) => diagnostic.code)).toStrictEqual([
       "SPICE_DECK_UNSUPPORTED_DIRECTIVE",
@@ -241,6 +243,8 @@ four 2k V(b)
 .reset
 .set noaskquit
 .set filetype=ascii
+.set wr_vecnames
+.set wr_singlescale
 run
 .quit
 .endc

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -38,7 +38,8 @@ downstream tools to compare.
      `measure`, `meas`, `four`, `fourier`, `print`, and `plot`) now normalize
      into dotted deck cards while `run`, `reset`, `quit`, and UI-only
      `set noaskquit` options plus ASCII rawfile-format `set filetype=ascii`
-     options are accepted as no-op control markers; parsed
+     options and rawfile vector-name/single-scale toggles (`set wr_vecnames`,
+     `set wr_singlescale`) are accepted as no-op control markers; parsed
      `.measure dc` / `.meas dc` cards now route DC sweep probe samples into
      the shared scalar measurement table surface;
      parsed `.measure ac` / `.meas ac` cards now route AC probe magnitudes over
@@ -582,6 +583,16 @@ downstream tools to compare.
     - Other `set` variables, binary rawfile options, file-writing commands, and
       unrecognized non-comment commands inside `.control` blocks remain
       diagnostic-only so unsupported file I/O and script state are explicit.
+
+53. Selected `.control` rawfile output option routing.
+    - Status: completed in this selected control rawfile-output option routing
+      slice.
+    - Python, Rust, and TypeScript now accept exact selected `.control` block
+      `set wr_vecnames` and `set wr_singlescale` rawfile output toggles as
+      no-op control commands.
+    - Other `set` variables, rawfile file-writing commands, and unrecognized
+      non-comment commands inside `.control` blocks remain diagnostic-only so
+      unsupported file I/O and script state are explicit.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- Accept exact `.control` block `set wr_vecnames` and `set wr_singlescale` commands as no-op rawfile output-format markers across Python, Rust, and TypeScript.
- Keep other `set` variables, `set filetype=binary`, rawfile file-writing commands, and unrecognized `.control` body commands diagnostic-only.
- Update SPICE package READMEs/changelogs and the full implementation plan with the completed slice and remaining explicit backlog.

## Verification
- `PYTHONPATH="$(printf '%s:' /Users/adhithya/Downloads/Codex/worktrees/coding-adventures-spice-control-output-format-routing/code/packages/python/*/src)" /Users/adhithya/.local/share/mise/installs/python/3.12.13/bin/python3 -m ruff check code/packages/python/spice-engine/src/spice_engine/compatibility.py code/packages/python/spice-engine/tests/test_compatibility.py`
- `PYTHONPATH="$(printf '%s:' /Users/adhithya/Downloads/Codex/worktrees/coding-adventures-spice-control-output-format-routing/code/packages/python/*/src)" /Users/adhithya/.local/share/mise/installs/python/3.12.13/bin/python3 -m pytest code/packages/python/spice-engine/tests -q`
- `cargo fmt --manifest-path code/packages/rust/spice-engine/Cargo.toml -- --check`
- `cargo test --manifest-path code/packages/rust/spice-engine/Cargo.toml`
- `npm --prefix code/packages/typescript/spice-engine ci`
- `npm --prefix code/packages/typescript/spice-engine run build`
- `npm --prefix code/packages/typescript/spice-engine test`
- `git diff --check`

## Freshness
- Verified PR #6062 was merged at `2026-06-16T18:09:15Z` with completed checks.
- Fetched `origin/main` before commit; branch was `0 0` against `origin/main` before publishing.