### PR TITLE
feat(web01b-2): MailboxWebServer + conduit MailboxServer — per-request parallel serving facade

### DIFF
--- a/code/packages/rust/conduit/CHANGELOG.md
+++ b/code/packages/rust/conduit/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to this package will be documented in this file.
 
+## [0.3.0] - 2026-06-16
+
+### Added
+
+- **`MailboxServer` (WEB01b-2)** — an opt-in, per-request-parallel server, the
+  mailbox counterpart of `ShardedServer`. Where `ShardedServer` parallelises *by
+  connection* (N reactor shards), `MailboxServer::bind(host, port, worker_count,
+  app)` parallelises *by request*: a single reactor frames each request and
+  submits it to a `worker_count`-thread pool (via `web_core::MailboxWebServer`),
+  so a worker runs the Conduit dispatch off the reactor thread. Routing, hooks,
+  and `halt` behave exactly as with `Server`; the application is shared (`Arc`)
+  across pool threads unchanged. Surface: `bind` / `bind_with_options` /
+  `local_addr` / `is_running` / `stop` / `serve` (and `Clone`). Binding is a
+  single cross-platform call returning `std::io::Result` (the mailbox stack is
+  `io::Error`-based), unlike the per-platform `Server` / `ShardedServer` binds.
+  Correct and in order for one-request-and-close and *sequential* keep-alive;
+  pipelined-connection gating/reordering is WEB01b-1b. `Server` (single reactor)
+  remains the default. See `code/specs/WEB01b-mailbox-parallelism.md`.
+- Test `mailbox_server_dispatches_handlers_concurrently` deterministically proves
+  pool parallelism on a single reactor through the full facade (observed max
+  in-flight handlers >= 2 — inline dispatch never exceeds 1).
+
 ## [0.2.0] - 2026-06-16
 
 ### Added

--- a/code/packages/rust/conduit/Cargo.toml
+++ b/code/packages/rust/conduit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conduit"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 description = "Rust-native Conduit web framework facade over web-core"
 license = "MIT"

--- a/code/packages/rust/conduit/README.md
+++ b/code/packages/rust/conduit/README.md
@@ -38,10 +38,17 @@ server.serve()?;
 - `Application` — route registration, settings, before/after hooks, custom 404,
   custom 405, and panic recovery hooks
 - `Server` — platform-native single-reactor server binding over `web-core::WebServer`
-- `ShardedServer` — opt-in **parallel** server (WEB01) over `web-core::ShardedWebServer`:
+- `ShardedServer` — opt-in **parallel** server (WEB01a) over `web-core::ShardedWebServer`:
   `ShardedServer::bind(host, port, worker_count, app)` dispatches handlers across
   `worker_count` reactor shards so requests on different connections run
-  concurrently. Same surface and semantics as `Server`; `Server` stays the default.
+  concurrently (parallel *by connection*). Same surface and semantics as `Server`.
+- `MailboxServer` — opt-in **parallel** server (WEB01b-2) over `web-core::MailboxWebServer`:
+  `MailboxServer::bind(host, port, worker_count, app)` runs a single reactor that
+  submits each request to a `worker_count`-thread pool (parallel *by request*), so
+  even sequential keep-alive on one connection doesn't serialise behind the
+  dispatcher. Cross-platform single `bind`, returns `std::io::Result`. Correct and
+  in order for one-request-and-close and sequential keep-alive; pipelined gating is
+  WEB01b-1b. `Server` (single reactor) stays the default.
 - `RequestExt` — convenience accessors for route params, query params, and body text
 - response helpers — `text`, `html`, `json`, `redirect`, `halt`, and explicit-status
   variants

--- a/code/packages/rust/conduit/src/lib.rs
+++ b/code/packages/rust/conduit/src/lib.rs
@@ -466,6 +466,79 @@ impl ShardedServer {
     }
 }
 
+/// A **per-request-parallel** Conduit server (WEB01b-2): the mailbox counterpart
+/// of [`ShardedServer`].
+///
+/// [`ShardedServer`] parallelises *by connection* (N reactor shards). `MailboxServer`
+/// parallelises *by request*: a single reactor frames each request and submits it
+/// to a `worker_count`-thread pool (a `web_core::MailboxWebServer`); a worker runs
+/// the Conduit dispatch off the reactor thread. Routes, hooks, `halt`, etc. behave
+/// exactly as with [`Server`]; the application is shared (`Arc`) across pool
+/// threads unchanged.
+///
+/// Like [`ShardedServer`], this is **opt-in**. The platform (kqueue / epoll / IOCP)
+/// is chosen internally, so binding is a single cross-platform call and the error
+/// type is `std::io::Result` (the mailbox stack is `io::Error`-based) — unlike the
+/// per-platform [`Server`] / [`ShardedServer`] binds. Correct and in order for
+/// one-request-and-close and *sequential* keep-alive; pipelined-connection gating
+/// and reordering is WEB01b-1b. See `code/specs/WEB01b-mailbox-parallelism.md`.
+pub struct MailboxServer {
+    inner: web_core::MailboxWebServer,
+}
+
+impl MailboxServer {
+    /// Bind to `host:port` with a `worker_count`-thread handler pool and default options.
+    pub fn bind(
+        host: &str,
+        port: u16,
+        worker_count: usize,
+        app: Application,
+    ) -> std::io::Result<Self> {
+        Self::bind_with_options(host, port, worker_count, HttpServerOptions::default(), app)
+    }
+
+    /// Bind to `host:port` with a `worker_count`-thread handler pool and explicit options.
+    pub fn bind_with_options(
+        host: &str,
+        port: u16,
+        worker_count: usize,
+        options: HttpServerOptions,
+        app: Application,
+    ) -> std::io::Result<Self> {
+        let app = Arc::new(app.into_web_app());
+        let inner = web_core::MailboxWebServer::bind(host, port, options, worker_count, app)?;
+        Ok(Self { inner })
+    }
+
+    /// The local socket address the server bound to.
+    pub fn local_addr(&self) -> SocketAddr {
+        self.inner.local_addr()
+    }
+
+    /// Whether the server is currently serving.
+    pub fn is_running(&self) -> bool {
+        self.inner.is_running()
+    }
+
+    /// Signal the server to stop (from this or another thread).
+    pub fn stop(&self) {
+        self.inner.stop();
+    }
+
+    /// Serve requests until stopped. Blocks the calling thread.
+    pub fn serve(&self) -> std::io::Result<()> {
+        self.inner.serve()
+    }
+}
+
+impl Clone for MailboxServer {
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::io::{BufRead, BufReader, Read, Write};
@@ -735,5 +808,71 @@ mod tests {
         );
 
         stop.stop();
+    }
+
+    /// WEB01b-2: a `MailboxServer` dispatches Conduit handlers concurrently on a
+    /// SINGLE reactor by submitting them to its worker pool (parallel *by request*,
+    /// vs `ShardedServer`'s parallel *by connection*). Proven deterministically:
+    /// the handler bumps an in-flight gauge, holds briefly, and records the max
+    /// simultaneous handlers. A single reactor dispatching inline could never
+    /// exceed 1; observing >= 2 proves the pool runs Conduit dispatch in parallel
+    /// through the full facade (`Application` → `WebApp` → `MailboxWebServer` →
+    /// pool). Every concurrent request also gets a correct 200.
+    #[cfg(not(target_os = "windows"))]
+    #[test]
+    fn mailbox_server_dispatches_handlers_concurrently() {
+        let worker_count = 4;
+        let client_count = 8;
+
+        let in_flight = Arc::new(AtomicUsize::new(0));
+        let max_in_flight = Arc::new(AtomicUsize::new(0));
+        let h_in_flight = Arc::clone(&in_flight);
+        let h_max = Arc::clone(&max_in_flight);
+
+        let mut app = Application::new();
+        app.get("/work", move |_| {
+            let now = h_in_flight.fetch_add(1, Ordering::SeqCst) + 1;
+            h_max.fetch_max(now, Ordering::SeqCst);
+            // A sleeping handler does not hold a core, so overlap is observable
+            // regardless of the CI runner's core count.
+            thread::sleep(Duration::from_millis(60));
+            h_in_flight.fetch_sub(1, Ordering::SeqCst);
+            text("ok")
+        });
+
+        let server = MailboxServer::bind("127.0.0.1", 0, worker_count, app).expect("bind mailbox");
+        let port = server.local_addr().port();
+        // The server is `Clone`; serve a clone on a worker thread and stop via the
+        // original (serve takes `&self` — the mailbox stack owns its threads).
+        let serve = server.clone();
+        thread::spawn(move || {
+            let _ = serve.serve();
+        });
+        thread::sleep(Duration::from_millis(20));
+
+        let barrier = Arc::new(std::sync::Barrier::new(client_count));
+        let clients: Vec<_> = (0..client_count)
+            .map(|_| {
+                let barrier = Arc::clone(&barrier);
+                thread::spawn(move || {
+                    barrier.wait();
+                    request(port, "GET", "/work", "")
+                })
+            })
+            .collect();
+
+        for client in clients {
+            let (status, body) = client.join().expect("client thread");
+            assert_eq!(status, 200);
+            assert_eq!(body, "ok");
+        }
+
+        let observed_max = max_in_flight.load(Ordering::SeqCst);
+        server.stop();
+        assert!(
+            observed_max >= 2,
+            "expected concurrent handler dispatch via the pool on a single reactor; max \
+             in-flight was {observed_max} (inline dispatch never exceeds 1)",
+        );
     }
 }

--- a/code/packages/rust/web-core/CHANGELOG.md
+++ b/code/packages/rust/web-core/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog — web-core
 
+## 0.3.0 (2026-06-16)
+
+### Added
+
+- **`MailboxWebServer` (WEB01b-2)** — a per-request-parallel counterpart to
+  `WebServer`, wrapping `embeddable-http-server`'s `MailboxHttpServer`. Where
+  `ShardedWebServer` parallelises *by connection* (N reactors, inline dispatch),
+  `MailboxWebServer` parallelises *by request*: a single reactor frames each
+  request and submits it to a `worker_count`-thread pool; a worker runs
+  `WebApp::handle` off the reactor thread and the pool's response router writes
+  the reply back. The `Arc<WebApp>` is shared across pool threads unchanged
+  (`handle` is `&self` + `Send + Sync`). `on_server_start` / `on_server_stop`
+  fire once, like `WebServer`.
+- Single cross-platform `bind(host, port, options, worker_count, app)` (the
+  underlying `EmbeddableTcpServer` selects kqueue/epoll/IOCP internally — no
+  per-OS constructors), returning `std::io::Result` (the mailbox stack is
+  `io::Error`-based). Plus `local_addr` / `is_running` / `stop` / `serve`; the
+  type is `Clone` so a clone can serve on a worker thread while another stops it.
+- **Opt-in**, like `ShardedWebServer`: the default `WebServer` is untouched.
+  Correct and in order for one-request-and-close and *sequential* keep-alive;
+  pipelined-connection gating/reordering is WEB01b-1b. Exercised via conduit's
+  `mailbox_server_dispatches_handlers_concurrently` (deterministic ≥ 2 in-flight
+  proof). See `code/specs/WEB01b-mailbox-parallelism.md`.
+
 ## 0.2.0 (2026-06-16)
 
 ### Added

--- a/code/packages/rust/web-core/Cargo.toml
+++ b/code/packages/rust/web-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "web-core"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 description = "Generic Rack/WSGI-like HTTP application layer built on embeddable-http-server"
 license = "MIT"

--- a/code/packages/rust/web-core/README.md
+++ b/code/packages/rust/web-core/README.md
@@ -29,7 +29,9 @@ tcp-runtime + transport-platform (kqueue / epoll / IOCP)
 | Response building    | `WebResponse` — fluent builder, converts to `HttpResponse` |
 | Lifecycle hooks      | `HookRegistry` — 12 hook points, `Arc<dyn Fn>` closures |
 | Dispatch pipeline    | `WebApp::handle` — full lifecycle in one call |
-| Server binding       | `WebServer` — thin wrapper around `HttpServer` |
+| Server binding       | `WebServer` — thin wrapper around `HttpServer` (single reactor) |
+| Parallel by connection | `ShardedWebServer` (WEB01a-2) — N reactor shards, inline dispatch |
+| Parallel by request  | `MailboxWebServer` (WEB01b-2) — single reactor + worker pool |
 
 ## Quick start
 

--- a/code/packages/rust/web-core/src/lib.rs
+++ b/code/packages/rust/web-core/src/lib.rs
@@ -55,6 +55,6 @@ pub use hooks::{HookRegistry, LogLevel};
 pub use request::WebRequest;
 pub use response::WebResponse;
 pub use router::{Handler, Route, Router, RouteLookupResult, RouteMatch};
-pub use server::{ShardedWebServer, WebServer};
+pub use server::{MailboxWebServer, ShardedWebServer, WebServer};
 
 pub const VERSION: &str = "0.1.0";

--- a/code/packages/rust/web-core/src/server.rs
+++ b/code/packages/rust/web-core/src/server.rs
@@ -11,7 +11,7 @@
 use std::net::{SocketAddr, ToSocketAddrs};
 use std::sync::Arc;
 
-use embeddable_http_server::{HttpServer, HttpServerOptions, ShardedHttpServer};
+use embeddable_http_server::{HttpServer, HttpServerOptions, MailboxHttpServer, ShardedHttpServer};
 use tcp_runtime::{PlatformError, ShardedStopHandle};
 
 use crate::app::WebApp;
@@ -252,6 +252,91 @@ impl ShardedWebServer<transport_platform::windows::WindowsTransportPlatform> {
         let local_addr = inner.local_addr();
         app.fire_server_start(local_addr);
         Ok(Self { inner, app })
+    }
+}
+
+/// A **per-request-parallel** `WebApp` server (WEB01b-2): the mailbox counterpart
+/// of [`WebServer`].
+///
+/// Where [`ShardedWebServer`] parallelises *by connection* (N reactors, each
+/// running `app.handle` inline), `MailboxWebServer` parallelises *by request*: a
+/// single reactor frames each request and submits it to a `worker_count`-thread
+/// pool (a [`MailboxHttpServer`]); a worker runs `app.handle` off the reactor
+/// thread and the pool's response router writes the reply back. This decouples
+/// handler concurrency from the I/O thread, so even requests arriving on the
+/// *same* connection (sequential keep-alive) do not serialise behind one another
+/// in the dispatcher. The `Arc<WebApp>` is shared across all pool threads
+/// unchanged (`WebApp::handle` is `&self` and `Send + Sync`).
+///
+/// This is **opt-in**, like [`ShardedWebServer`]: the default [`WebServer`] is
+/// untouched. The platform (kqueue / epoll / IOCP) is selected internally by the
+/// underlying `EmbeddableTcpServer`, so — unlike the per-platform sharded binds —
+/// there is a single cross-platform [`bind`](MailboxWebServer::bind) and the
+/// error type is `std::io::Result` (the mailbox stack is `io::Error`-based).
+///
+/// **Scope (WEB01b-2 / -1a):** correct and in order for one-request-and-close and
+/// *sequential* keep-alive; gating and reordering a *pipelined* connection is
+/// WEB01b-1b. See `code/specs/WEB01b-mailbox-parallelism.md`.
+#[derive(Clone)]
+pub struct MailboxWebServer {
+    inner: MailboxHttpServer,
+    app: Arc<WebApp>,
+    /// Fires the `on_server_stop` hooks **exactly once**, even though this type is
+    /// `Clone` and `serve` takes `&self`: two clones could each call `serve` and
+    /// both return, so we gate the stop hooks behind a shared `Once` to keep them
+    /// from double-firing (matching `WebServer`/`ShardedWebServer`, whose
+    /// `&mut self` serve cannot be called twice).
+    stop_hooks_fired: Arc<std::sync::Once>,
+}
+
+impl MailboxWebServer {
+    /// Bind `host:port` with a `worker_count`-thread handler pool.
+    ///
+    /// The `app`'s `on_server_start` hooks fire before this method returns.
+    pub fn bind(
+        host: &str,
+        port: u16,
+        options: HttpServerOptions,
+        worker_count: usize,
+        app: Arc<WebApp>,
+    ) -> std::io::Result<Self> {
+        let app_clone = Arc::clone(&app);
+        let inner = MailboxHttpServer::bind(host, port, options, worker_count, move |request| {
+            app_clone.handle(request)
+        })?;
+        let local_addr = inner.local_addr();
+        app.fire_server_start(local_addr);
+        Ok(Self {
+            inner,
+            app,
+            stop_hooks_fired: Arc::new(std::sync::Once::new()),
+        })
+    }
+
+    /// The local socket address the server is bound to.
+    pub fn local_addr(&self) -> SocketAddr {
+        self.inner.local_addr()
+    }
+
+    /// Whether the server is currently serving.
+    pub fn is_running(&self) -> bool {
+        self.inner.is_running()
+    }
+
+    /// Signal the server to stop (from this or another thread; the type is
+    /// `Clone`, so a clone can serve on a worker thread while another stops it).
+    pub fn stop(&self) {
+        self.inner.stop();
+    }
+
+    /// Run the event loop until stopped. Blocks the calling thread; after it
+    /// returns, the `on_server_stop` hooks fire (exactly once across all clones —
+    /// see `stop_hooks_fired`).
+    pub fn serve(&self) -> std::io::Result<()> {
+        let result = self.inner.serve();
+        let app = &self.app;
+        self.stop_hooks_fired.call_once(|| app.fire_server_stop());
+        result
     }
 }
 

--- a/code/specs/WEB01b-mailbox-parallelism.md
+++ b/code/specs/WEB01b-mailbox-parallelism.md
@@ -150,14 +150,26 @@ connection" un-gates. Read the mailbox write-back path / connection bookkeeping 
 
 ## Phased PR plan
 
-1. **WEB01b spec** (this file).
-2. **WEB01b-1 — `embeddable-http-server` mailbox serve** + ordering + backpressure;
-   the deterministic ordering and parallelism tests. The riskiest PR.
+1. **WEB01b spec** (this file). ✅ merged.
+2. **WEB01b-1a — `embeddable-http-server` `MailboxHttpServer`** (the approved
+   bounded slice): per-request submit-to-pool + backpressure (503) + the
+   deterministic in-flight-gauge parallelism test. ✅ merged (PR #6047). Scope is
+   one-request-and-close + *sequential* keep-alive; the original `defer_read`
+   read-gating was removed (it *replays* the consumed chunk — see the CI-fix note
+   in that PR and `lessons.md`). Pipelined gating/ordering is deferred to 1b.
 3. **WEB01b-2 — `web-core` `MailboxWebServer`** (`worker_fn = app.handle`) +
    `conduit` `MailboxServer` (opt-in), with the in-flight-gauge parallelism test
-   through the facade.
-4. **WEB01b-3 — comparative benchmark** (`#[ignore]`): single-reactor vs sharded
+   through the facade. ✅ done (this PR). Single cross-platform `bind`,
+   `std::io::Result` (the mailbox stack is `io::Error`-based), `Clone`; mirrors the
+   `ShardedWebServer`/`ShardedServer` surface. web-core 0.2.0→0.3.0, conduit
+   0.2.0→0.3.0.
+4. **WEB01b-1b — per-connection reorder buffer** for the *pipelined* path: gate a
+   connection to one in-flight request and reassemble the unordered pool's
+   responses into HTTP/1.1 wire order (the pool is `supports_ordered_responses =
+   false`). Still open.
+5. **WEB01b-3 — comparative benchmark** (`#[ignore]`): single-reactor vs sharded
    (WEB01a) vs mailbox (WEB01b) on a CPU-bound load; document when to pick which.
+   Still open.
 
 ## Open questions (for sign-off before WEB01b-1)
 

--- a/lessons.md
+++ b/lessons.md
@@ -791,3 +791,43 @@ node, either (a) don't derive `Hash`/`Eq` over the decorative fields, or (b)
 normalise to the identity subset at **every** key boundary — and add a test that
 exercises the decorated form through the real lookup path, not just the AST. A
 derive that silently widens identity is a landmine.
+
+## stream-reactor `defer_read` REPLAYS the chunk — it is not "pause output" (WEB01b-1a, PR #6047)
+
+`MailboxHttpServer` (the new mailbox/deferred-response HTTP server) framed a
+request, submitted it to the worker pool, and returned
+`TcpHandlerResult::defer_read()` intending "pause this connection's reads until
+the response is written." The test passed locally on macOS but failed on the
+Linux CI runner: the client received a spurious `400 Bad Request` written
+*before* the real `200 OK` on the same connection.
+
+Root cause: in `code/packages/rust/stream-reactor`, `defer_read` does **not**
+mean "pause output." It means **"I did NOT consume these bytes — buffer this
+chunk and *replay* it (re-invoke the handler with the same bytes) when reads
+resume."** The mailbox response-router calls `resume_all_reads()` for *every*
+connection's response, so a deferred chunk gets replayed (`progress_reads_with_state`
+→ `apply_read_chunk`, stream-reactor/src/lib.rs:651-668,720-724). Because the
+handler had already *consumed* the bytes (drained its buffer + submitted the
+job), the replay re-fed the chunk. On macOS the whole request arrived in one TCP
+segment, so the replay merely double-submitted (the leading `200` still satisfied
+the assertion). On Linux under load the request was TCP-segmented, so the
+replayed **trailing fragment** (`ection: close\r\n\r\n`) parsed as a malformed
+head → `pop_request` returned `Err` → a `400` was queued before the real `200`.
+
+Fixes:
+1. After a successful consume+submit, return `TcpHandlerResult::default()`
+   (keep reading) — **never** `defer_read()`. Only return `defer_read` when you
+   genuinely did NOT consume the bytes and want them replayed (e.g. the
+   QueueFull backpressure case in embeddable-tcp-server). There is currently no
+   "pause-without-replay" primitive; a per-connection in-flight gate needs a
+   reorder buffer (deferred to WEB01b-1b).
+2. Drain **every** complete request a read delivered by looping `pop_request`
+   until `Ok(None)` — one TCP read can carry multiple coalesced/pipelined
+   requests; popping once strands the extras in the buffer and hangs a client
+   that sent them together and then waited. (Caught by the security review.)
+
+Lesson: a handler-result flag named for an *intent* ("defer") may be implemented
+as a *mechanism* ("replay") — read the reactor's drain path before reusing it,
+and never trust a same-host test to expose a TCP-segmentation-dependent bug
+(loopback coalescing hides it; the Linux runner under parallel load splits the
+read and surfaces it).


### PR DESCRIPTION
## Summary

Wires the merged **WEB01b-1a** engine ([`MailboxHttpServer`](code/packages/rust/embeddable-http-server/src/lib.rs), [#6047](https://github.com/adhithyan15/coding-adventures/pull/6047)) up through the **web-core** and **conduit** facades, mirroring the `ShardedWebServer`/`ShardedServer` pattern from WEB01a-2/3.

- **web-core `MailboxWebServer`** wraps `MailboxHttpServer`. Where `ShardedWebServer` is parallel *by connection* (N reactors, inline `app.handle`), `MailboxWebServer` is parallel *by request*: one reactor frames each request and submits it to a `worker_count`-thread pool; a worker runs `app.handle` off the reactor thread. Single cross-platform `bind` (the underlying `EmbeddableTcpServer` selects kqueue/epoll/IOCP), `std::io::Result`, `Clone`. `on_server_start`/`on_server_stop` fire **once** — stop is gated behind a shared `Once` because the type is `Clone` and `serve` takes `&self`.
- **conduit `MailboxServer`** mirrors `ShardedServer`'s surface (`bind` / `bind_with_options` / `local_addr` / `is_running` / `stop` / `serve`, + `Clone`) over `MailboxWebServer`. Routing, hooks, `halt` unchanged; **opt-in** (`Server` stays the default).
- **Scope (1a/2):** correct and in order for one-request-and-close and *sequential* keep-alive; pipelined-connection gating/reordering is WEB01b-1b.

## Test plan
- [x] `mailbox_server_dispatches_handlers_concurrently` — deterministic pool-parallelism proof through the full facade (`Application` → `WebApp` → `MailboxWebServer` → pool); in-flight gauge ≥ 2 (inline dispatch never exceeds 1). **6/6 stable.**
- [x] `web-core` + `conduit` full test suites pass; clippy-clean (own crates)
- [x] Downstream `conduit-capi` / `conduit-jni` build clean
- [x] `/security-review` ran — no CRITICAL/HIGH/MEDIUM; the one LOW (stop-hook double-fire on `Clone`) is fixed via the shared `Once`
- [ ] CI green

Versions: web-core 0.2.0→0.3.0, conduit 0.2.0→0.3.0. Spec roadmap, CHANGELOGs, READMEs updated. `lessons.md` records the `defer_read`-replays substrate gotcha from the 1a CI fix.

> Remaining WEB01b: **1b** (per-connection reorder buffer for pipelining) and **3** (comparative benchmark).

🤖 Generated with [Claude Code](https://claude.com/claude-code)