### PR TITLE
refactor(mycin): re-land step-therapy ADJ rule (dropped by #6008 squash-merge)

### DIFF
--- a/code/specs/data/mycin-2026/CHART-AS-CONSTRAINTS.md
+++ b/code/specs/data/mycin-2026/CHART-AS-CONSTRAINTS.md
@@ -247,6 +247,18 @@ risks Y") — decision support, not a hidden choice.
   (a rule blocking a clinically-forced drug → covered = INFEASIBLE) is surfaced **distinctly**
   from clinical infeasibility → physician override / appeal on medical necessity. Grounding a
   real published payer policy is the **CC-6b** follow-up.
+- **CC-6 REFACTOR (ADJ-native): the step-therapy precedence is now an ENGINE RULE, not a
+  Python set-difference. ✅ DONE.** The blocked-drug derivation left `chart_to_cop.py`
+  (`reimbursement_blocked()` is deleted) and became `step_therapy.adj` — a durable,
+  domain-neutral **negation-as-failure** rule: `reimbursement_blocked($Y) when:
+  requires_prerequisite($Y,$X), not already_tried($X)`. The per-case payer facts
+  (`requires_prerequisite` / `already_tried`) are asserted from the chart at query time;
+  `derive()` calls `step_therapy.derive_blocked(cli, …)` which runs the engine
+  (`? reimbursement_blocked($Y)`, 0 model calls) and folds the blocked drugs into the
+  reimbursement program's `forced_zero`. NAF is the natural encoding of "blocked unless the
+  step is satisfied"; the precedence reasoning lives in the language. The same `requires… ∧
+  not done…` shape is reusable across any rule corpus (a filing gated on a precondition, a
+  benefit gated on a prior step).
 - **CC-7 — full chart drive-through:** wire CH (chart→IR + de-identification) into the COP so
   a whole de-identified FHIR chart produces a regimen with the full audit trail.
 

--- a/code/specs/data/mycin-2026/treatment/antibiotics/chart_to_cop.py
+++ b/code/specs/data/mycin-2026/treatment/antibiotics/chart_to_cop.py
@@ -45,6 +45,7 @@ import contraindications as ci  # noqa: E402  (ADJ-native: derive_contraindicati
 import decide as decide_mod  # noqa: E402  (find_cli)
 import derive_regimen as reg  # noqa: E402  (grounded formulary: SCENARIOS, DRUGS, candidates)
 import native_setcover as nsc  # noqa: E402  (the COP emitter/solver)
+import step_therapy as st  # noqa: E402  (ADJ-native: derive_blocked via the engine, NAF)
 
 
 # --------------------------------------------------------------------------
@@ -341,13 +342,6 @@ def dose_infeasible(cli: Path, drugs: list[str], risks: set[str], weight: float)
     return out
 
 
-def reimbursement_blocked(step_therapy: set[tuple[str, str]], tried: set[str]) -> set[str]:
-    """CC-6: the drugs a payer won't reimburse because their step-therapy prerequisite
-    hasn't been tried — the precedence `x_Y ≤ tried_X` realized as a reimbursement-only
-    exclusion. A restricted drug Y is blocked iff its prerequisite X is not in `tried`."""
-    return {restricted for restricted, prereq in step_therapy if prereq not in tried}
-
-
 def derive(cli: Path, facts: list[ChartFact], disease: str = "meningitis") -> dict:
     """Compile the chart → COP, solve it, and return the regimen with provenance.
     Dose feasibility (CC-2) is folded into the cover: a drug with no safe-and-effective
@@ -392,7 +386,10 @@ def derive(cli: Path, facts: list[ChartFact], disease: str = "meningitis") -> di
     # explicit. Reimbursement infeasibility is distinct from clinical infeasibility.
     reimbursement = None
     if cop.step_therapy:
-        blocked = reimbursement_blocked(cop.step_therapy, cop.tried)
+        # CC-6: the ENGINE derives which drugs the payer blocks, via the step-therapy
+        # precedence rule (negation-as-failure over the per-case requires/tried facts) —
+        # not a Python set-difference. The precedence reasoning lives in the language.
+        blocked = st.derive_blocked(cli, cop.step_therapy, cop.tried)
         # The precedence is enforced BY THE ENGINE: payer-blocked drugs join forced_zero
         # (reason "step-therapy") → an explicit `constrain x_Y <= 0` clause in the
         # reimbursement program. Clinical exclusions (dose/contraindication) carry over, so

--- a/code/specs/data/mycin-2026/treatment/antibiotics/step_therapy.adj
+++ b/code/specs/data/mycin-2026/treatment/antibiotics/step_therapy.adj
@@ -1,0 +1,48 @@
+% ============================================================================
+% step-therapy — payer reimbursement precedence as an ADJ derivation rule (ADJ-native).
+% ============================================================================
+% MYCIN-2026 (therapy layer, insurance).  "Step therapy" is a payer policy: a
+% restricted drug Y will not be reimbursed until a cheaper prerequisite X has been
+% tried (and failed).  That is a PRECEDENCE rule — exactly what a Horn clause with
+% negation-as-failure expresses:
+%
+%     a drug is reimbursement-blocked  IF  it requires a prerequisite
+%                                      AND  that prerequisite has NOT been tried.
+%
+% This replaces the Python set-difference `reimbursement_blocked()` in chart_to_cop:
+% the precedence reasoning now lives in the language, and the engine derives the
+% blocked drugs (`? reimbursement_blocked($Y)`, 0 model calls).  The per-case facts
+% (which drug requires which prerequisite, what has been tried) are asserted from the
+% chart at query time; the RULE here is durable and domain-neutral.
+%
+% NOT a clinical claim — step therapy is a definitional payer MECHANISM, so this
+% rulebook is structural (no spider grounding needed), like the generic derivation
+% rules in contraindications.adj.  The same `requires_… ∧ not done_…` precedence shape
+% recurs across rule corpora (a legal filing blocked until a precondition is met, a
+% benefit gated on a prior step), which is the point: a domain-neutral substrate
+% (project_adj_universal_rule_substrate).
+% ============================================================================
+
+dictionary step_therapy_vocab {
+    define drug : entity   surface "drug", "agent", "antibiotic"
+
+    % payer precedence: Y is reimbursable only after prerequisite X has been tried.
+    define requires_prerequisite : relation from drug to drug
+    % a drug already tried (and failed) for this patient — satisfies a prerequisite.
+    define already_tried         : relation from drug to drug
+    % DERIVED: Y is not reimbursable because its prerequisite is unmet (the query target).
+    define reimbursement_blocked : relation from drug to drug
+}
+
+rulebook step_therapy {
+    use step_therapy_vocab
+
+    % --- the GENERIC precedence rule (negation-as-failure) -------------------
+    % Y is reimbursement-blocked if it requires a prerequisite X that has NOT been
+    % tried.  `not already_tried($X)` is negation-as-failure: absence of a tried-fact
+    % means the step has not been satisfied, so the payer blocks Y.
+    rule {
+        head: reimbursement_blocked($Y)
+        when: requires_prerequisite($Y, $X), not already_tried($X)
+    }
+}

--- a/code/specs/data/mycin-2026/treatment/antibiotics/step_therapy.py
+++ b/code/specs/data/mycin-2026/treatment/antibiotics/step_therapy.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""step_therapy.py — DERIVE the reimbursement-blocked drugs by running the ADJ rule.
+
+The runtime half of the step-therapy ADJ-native refactor.  `step_therapy.adj` holds the
+durable, domain-neutral precedence rule (negation-as-failure); this module RUNS it under a
+patient's per-case payer facts and returns which drugs the payer will not reimburse.
+
+    derive_blocked(cli,
+                   step_therapy={("cefepime", "meropenem")},   # (restricted Y, prerequisite X)
+                   tried={"vancomycin"})                        # drugs already tried/failed
+        → {"cefepime"}        # cefepime needs meropenem tried first; it has not been → blocked
+
+This replaces chart_to_cop's Python `reimbursement_blocked()` set-difference: the precedence
+`x_Y ≤ tried_X` is now derived by the ENGINE via the rule
+`reimbursement_blocked($Y) when: requires_prerequisite($Y,$X), not already_tried($X)` — 0
+model calls, pure SLD + negation-as-failure over the per-case facts.
+
+SECURITY (trust boundary).  Drug tokens can originate from a model-decomposed chart, so they
+are semi-untrusted and are interpolated into an `.adj` program we then execute.  Every token
+is checked against `^[a-z][a-z0-9_]*$` BEFORE it reaches the program text (closes off `.adj`
+clause injection).  The temp program is written beside the rulebook and removed in a
+`finally`.  (Mirrors contraindications.py / warm/decide.py.)
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+import tempfile
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+RULEBOOK = HERE / "step_therapy.adj"
+
+# A drug token is a closed-vocabulary symbol — anything else is refused before it can reach
+# the generated program (injection guard).
+DRUG_RE = re.compile(r"\A[a-z][a-z0-9_]*\Z")
+
+
+def _safe_drug(d: str) -> str:
+    if not DRUG_RE.match(d):
+        raise ValueError(f"unsafe drug token {d!r} (must match {DRUG_RE.pattern})")
+    return d
+
+
+def derive_blocked(cli: Path, step_therapy, tried) -> set[str]:
+    """Return the set of drugs the payer will not reimburse because a step-therapy
+    prerequisite is unmet, DERIVED by the engine from `step_therapy` (an iterable of
+    (restricted, prerequisite) pairs) and `tried` (drugs already tried).  An empty
+    `step_therapy` short-circuits to the empty set without invoking the engine."""
+    pairs = sorted({(_safe_drug(y), _safe_drug(x)) for y, x in step_therapy})
+    if not pairs:
+        return set()
+    done = sorted({_safe_drug(d) for d in tried})
+
+    program = RULEBOOK.read_text() + "\n"
+    program += "".join(f"relate requires_prerequisite({y}, {x})\n" for y, x in pairs)
+    program += "".join(f"relate already_tried({d})\n" for d in done)
+    program += "? reimbursement_blocked($Y)\n"
+
+    tmp = tempfile.NamedTemporaryFile("w", suffix=".adj", dir=HERE, delete=False)
+    try:
+        tmp.write(program)
+        tmp.close()
+        r = subprocess.run([str(cli), tmp.name], capture_output=True, text=True)
+        if r.returncode != 0:
+            raise RuntimeError(f"adj-lang-cli exited {r.returncode}: {r.stderr}")
+        out = json.loads(r.stdout)
+    finally:
+        Path(tmp.name).unlink(missing_ok=True)
+
+    blocked: set[str] = set()
+    for rec in out.get("recall", []):
+        if not rec.get("query", "").startswith("reimbursement_blocked("):
+            continue
+        for ans in rec.get("answers", []):
+            y = ans.get("bindings", {}).get("Y")
+            if y:
+                blocked.add(y)
+    return blocked
+
+
+if __name__ == "__main__":  # tiny demo
+    import sys
+    sys.path.insert(0, str(HERE.parent.parent / "warm"))
+    import decide as decide_mod  # noqa: E402
+
+    cli = decide_mod.find_cli()
+    if cli is None:
+        print("step_therapy: adj-lang-cli not built", file=sys.stderr)
+        raise SystemExit(3)
+    print(sorted(derive_blocked(cli, {("cefepime", "meropenem"), ("linezolid", "vancomycin")},
+                                {"vancomycin"})))

--- a/code/specs/data/mycin-2026/treatment/antibiotics/test_chart_to_cop.py
+++ b/code/specs/data/mycin-2026/treatment/antibiotics/test_chart_to_cop.py
@@ -195,9 +195,8 @@ def test_step_therapy_facts_compile_and_reimbursement_blocked_logic():
     assert any(c["type"] == "prior_treatment" for c in cop.constraints)
     bad = cc.compile_cop([cc.ChartFact("step_therapy", "no_colon_here")])
     assert not bad.step_therapy and any("step_therapy" in d["fact"] for d in bad.discards)
-    # The precedence x_Y ≤ tried_X: Y blocked iff its prerequisite X is not in `tried`.
-    assert cc.reimbursement_blocked({("cefepime", "meropenem")}, set()) == {"cefepime"}
-    assert cc.reimbursement_blocked({("cefepime", "meropenem")}, {"meropenem"}) == set()
+    # The precedence x_Y ≤ tried_X is now DERIVED BY THE ENGINE (step_therapy.adj, NAF) —
+    # covered by test_step_therapy.py and the engine-gated test_dual_* path below.
 
 
 def test_dual_clinical_vs_reimbursement_regimen():

--- a/code/specs/data/mycin-2026/treatment/antibiotics/test_step_therapy.py
+++ b/code/specs/data/mycin-2026/treatment/antibiotics/test_step_therapy.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""test_step_therapy.py — guard the ADJ-native step-therapy precedence rule + runtime.
+
+Pure checks (no engine): the rulebook is present and carries the negation-as-failure rule;
+the runtime's injection guard refuses unsafe drug tokens and short-circuits an empty policy.
+Engine-gated checks (if adj-lang-cli is built): the engine derives exactly the blocked drugs
+via `reimbursement_blocked($Y) when: requires_prerequisite($Y,$X), not already_tried($X)` —
+a restricted drug whose prerequisite is untried is blocked; once the prerequisite is tried it
+is not; an unrestricted drug is never blocked. The precedence reasoning is the engine's.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(HERE))
+sys.path.insert(0, str(HERE.parent.parent / "warm"))
+import decide as decide_mod  # noqa: E402
+import step_therapy as st  # noqa: E402
+
+
+# --------------------------------------------------------------------------
+# Rulebook + injection guard (pure).
+# --------------------------------------------------------------------------
+def test_rulebook_carries_the_naf_precedence_rule():
+    text = st.RULEBOOK.read_text()
+    assert "reimbursement_blocked($Y)" in text
+    assert "requires_prerequisite($Y, $X)" in text and "not already_tried($X)" in text
+
+
+@pytest.mark.parametrize("bad", ["cefepime)\n? evil(", "Cefepime", "a b", "x;y", "", "1drug"])
+def test_unsafe_drug_tokens_are_rejected(bad):
+    with pytest.raises(ValueError):
+        st.derive_blocked(_DUMMY_CLI, {(bad, "meropenem")}, set())
+    with pytest.raises(ValueError):
+        st.derive_blocked(_DUMMY_CLI, {("cefepime", "meropenem")}, {bad})
+
+
+def test_empty_policy_short_circuits_without_the_engine():
+    assert st.derive_blocked(_DUMMY_CLI, set(), {"vancomycin"}) == set()
+
+
+class _DummyCli:
+    def __fspath__(self):  # pragma: no cover - never reached when the guard fires
+        raise AssertionError("the engine must not be invoked for a rejected/empty policy")
+
+
+_DUMMY_CLI = _DummyCli()
+
+
+# --------------------------------------------------------------------------
+# Engine-gated — the ENGINE derives the blocked set (negation-as-failure).
+# --------------------------------------------------------------------------
+def _cli_or_skip():
+    cli = decide_mod.find_cli()
+    if cli is None:
+        pytest.skip("adj-lang-cli not built")
+    return cli
+
+
+def test_engine_blocks_a_drug_whose_prerequisite_is_untried():
+    cli = _cli_or_skip()
+    assert st.derive_blocked(cli, {("cefepime", "meropenem")}, set()) == {"cefepime"}
+
+
+def test_engine_unblocks_once_the_prerequisite_is_tried():
+    cli = _cli_or_skip()
+    assert st.derive_blocked(cli, {("cefepime", "meropenem")}, {"meropenem"}) == set()
+
+
+def test_engine_handles_multiple_policies_independently():
+    cli = _cli_or_skip()
+    # cefepime's prereq (meropenem) untried → blocked; linezolid's (vancomycin) tried → not.
+    out = st.derive_blocked(cli, {("cefepime", "meropenem"), ("linezolid", "vancomycin")},
+                            {"vancomycin"})
+    assert out == {"cefepime"}
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-q"]))


### PR DESCRIPTION
## Why

PR #6008 squash-merged **only its first commit** (contraindications). The second commit — step-therapy as an ADJ negation-as-failure rule (`b95169821`) — was dropped by the squash (the merge raced a second push). So `reimbursement_blocked` is still Python on `main`. This re-lands the missing work verbatim (cherry-pick of `b95169821` onto current main).

## What

- **NEW `step_therapy.adj`** — durable, domain-neutral rulebook with one NAF rule: `reimbursement_blocked($Y) when: requires_prerequisite($Y,$X), not already_tried($X)`.
- **NEW `step_therapy.py`** — `derive_blocked(cli, pairs, tried)`: asserts per-case payer facts + `? reimbursement_blocked($Y)`, runs the engine (0 model calls), reads bindings. Closed-vocab `\A[a-z][a-z0-9_]*\Z` injection guard.
- **`chart_to_cop.py`** — `reimbursement_blocked()` deleted; `derive()` calls `st.derive_blocked`. Dual clinical-vs-reimbursement regimen + distinct reimbursement-INFEASIBLE preserved.

## Verification

Cherry-pick applied cleanly onto current main. `test_step_therapy.py` (11) + the engine-gated dual/step/reproduces chart_to_cop tests (4) pass; `ruff` clean. Diff is identical to the previously-security-reviewed `b95169821`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)