### PR TITLE
feat(adj-lang): precedence surface syntax — priority tiers + functional (ADJ73 PR-C)

### DIFF
--- a/code/grammars/adj_lang.grammar
+++ b/code/grammars/adj_lang.grammar
@@ -26,6 +26,7 @@ statement   = prior_decl
             | observe_decl
             | relate_decl
             | rule_decl
+            | functional_decl
             | query_decl
             | let_decl
             | symbol_decl
@@ -100,9 +101,20 @@ relate_decl      = "relate" term { annotation } ;
 # every grounded clause carries. A body literal prefixed with `not` is
 # negation-as-failure.
 # ----------------------------------------------------------------
-rule_decl        = "rule" LBRACE "head" COLON term "when" COLON body_literal { COMMA body_literal } { annotation } RBRACE ;
+rule_decl        = "rule" LBRACE "head" COLON term "when" COLON body_literal { COMMA body_literal } { annotation } [ "priority" COLON IDENT ] RBRACE ;
 
 body_literal     = [ "not" ] term ;
+
+# ----------------------------------------------------------------
+# `functional <pred>(<arg>, …)` — ADJ73 defeasible precedence (PR-C): declare a
+# predicate FUNCTIONAL on its last argument (at most one value per key = the
+# preceding args). The arg names are placeholders for readability; only the
+# functor + arity are used (→ `KnowledgeBase::declare_functional`). Two
+# derivations sharing the key but differing on the last arg then CONFLICT, and a
+# rule's `priority:` tier picks the governing one. `functional`/`priority` are
+# IDENT-matched literals — no lexer keywords.
+# ----------------------------------------------------------------
+functional_decl  = "functional" term ;
 
 query_decl       = QUESTION term ;
 

--- a/code/packages/rust/adj-lang/CHANGELOG.md
+++ b/code/packages/rust/adj-lang/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Changelog
 
+## [0.15.0] - 2026-06-16 — precedence surface syntax (ADJ73 PR-C)
+
+### Added
+
+- **`rule { … priority: <tier> }`** — optional named precedence tier on a derivation rule
+  (`default` | `specific` | `authoritative` | `mandatory`). Lowers to
+  `logic_engine::Rule::with_priority(Priority::…)`; absent ⇒ `Default`. An unknown tier is a
+  clean `LowerError::UnknownPriorityTier`, not a silent default.
+- **`functional <pred>(<arg>, …)`** — top-level declaration that a predicate is functional on
+  its last argument (arg names are placeholders; only functor + arity matter). Lowers to
+  `KnowledgeBase::declare_functional(functor, arity)`. Two derivations sharing the key but
+  differing on the last arg then *conflict*, and the `priority:` tier picks the governing one
+  (`logic_engine::govern::enumerate_governing`).
+- Grammar: `functional_decl` added to `statement`; `rule_decl` gains a trailing
+  `[ "priority" COLON IDENT ]`. `functional`/`priority` are IDENT-matched literals (no new lexer
+  tokens). `_parser_grammar.rs` / `_lexer_grammar.rs` regenerated.
+- AST: `Statement::Functional { functor, arity }`; `Statement::Rule` gains `priority: Option<String>`.
+
+### Notes
+
+This is the **surface** for the merged ADJ73 engine core (logic-engine 0.18 `Priority` /
+`declare_functional` / `enumerate_governing`). Tests compile the new syntax and verify the full
+path parse → lower → `enumerate_governing` (higher tier governs; equal tiers conflict;
+non-functional predicates unaffected — back-compat). `adj-lang-cli` *governing* rendering is the
+next slice (PR-3); the CLI's existing `decide`/recall paths are unchanged.
+
 ## [0.14.0] - 2026-06-16 — `rule { head: … when: … }` derivation rules (Datalog clauses)
 
 ### Added

--- a/code/packages/rust/adj-lang/Cargo.toml
+++ b/code/packages/rust/adj-lang/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adj-lang"
-version = "0.14.0"
+version = "0.15.0"
 edition = "2021"
 description = "Surface-syntax frontend for the adjudication framework's probabilistic-logic rulebooks. Lexes, parses, and lowers a domain-expert-readable DSL into a `logic-engine` KnowledgeBase. Dissolves ADJ46 awkwardness items A10 (rulebook syntax) and A4 (joint contributions syntactically distinct)."
 

--- a/code/packages/rust/adj-lang/src/_lexer_grammar.rs
+++ b/code/packages/rust/adj-lang/src/_lexer_grammar.rs
@@ -6,9 +6,7 @@
 // Call `token_grammar()` instead of reading and parsing the .tokens file.
 
 #[allow(unused_imports)]
-use grammar_tools::token_grammar::{
-    ModeTransition, PatternGroup, TokenDefinition, TokenGrammar, TransitionAction,
-};
+use grammar_tools::token_grammar::{ModeTransition, PatternGroup, TokenDefinition, TokenGrammar, TransitionAction};
 #[allow(unused_imports)]
 use std::collections::HashMap;
 
@@ -184,26 +182,7 @@ pub fn token_grammar() -> TokenGrammar {
                 alias: None,
             },
         ],
-        keywords: vec![
-            r#"prior"#.to_string(),
-            r#"for"#.to_string(),
-            r#"contributes"#.to_string(),
-            r#"from"#.to_string(),
-            r#"to"#.to_string(),
-            r#"interacts"#.to_string(),
-            r#"when"#.to_string(),
-            r#"and"#.to_string(),
-            r#"observe"#.to_string(),
-            r#"uncertain"#.to_string(),
-            r#"source"#.to_string(),
-            r#"trust"#.to_string(),
-            r#"locator"#.to_string(),
-            r#"consensus"#.to_string(),
-            r#"authoritative"#.to_string(),
-            r#"empirical"#.to_string(),
-            r#"inferred"#.to_string(),
-            r#"unattributed"#.to_string(),
-        ],
+        keywords: vec![r#"prior"#.to_string(), r#"for"#.to_string(), r#"contributes"#.to_string(), r#"from"#.to_string(), r#"to"#.to_string(), r#"interacts"#.to_string(), r#"when"#.to_string(), r#"and"#.to_string(), r#"observe"#.to_string(), r#"uncertain"#.to_string(), r#"source"#.to_string(), r#"trust"#.to_string(), r#"locator"#.to_string(), r#"consensus"#.to_string(), r#"authoritative"#.to_string(), r#"empirical"#.to_string(), r#"inferred"#.to_string(), r#"unattributed"#.to_string()],
         mode: None,
         skip_definitions: vec![
             TokenDefinition {

--- a/code/packages/rust/adj-lang/src/_parser_grammar.rs
+++ b/code/packages/rust/adj-lang/src/_parser_grammar.rs
@@ -10,1031 +10,479 @@ use grammar_tools::parser_grammar::{GrammarElement, GrammarRule, ParserGrammar};
 pub fn parser_grammar() -> ParserGrammar {
     ParserGrammar {
         rules: vec![
-            GrammarRule {
-                name: r#"program"#.to_string(),
-                body: GrammarElement::Sequence {
-                    elements: vec![
-                        GrammarElement::Repetition {
-                            element: Box::new(GrammarElement::RuleReference {
-                                name: r#"statement"#.to_string(),
-                            }),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"EOF"#.to_string(),
-                        },
-                    ],
-                },
-                line_number: 20,
-            },
-            GrammarRule {
-                name: r#"statement"#.to_string(),
-                body: GrammarElement::Alternation {
-                    choices: vec![
-                        GrammarElement::RuleReference {
-                            name: r#"prior_decl"#.to_string(),
-                        },
-                        GrammarElement::RuleReference {
-                            name: r#"contributes_decl"#.to_string(),
-                        },
-                        GrammarElement::RuleReference {
-                            name: r#"interacts_decl"#.to_string(),
-                        },
-                        GrammarElement::RuleReference {
-                            name: r#"uncertain_decl"#.to_string(),
-                        },
-                        GrammarElement::RuleReference {
-                            name: r#"observe_decl"#.to_string(),
-                        },
-                        GrammarElement::RuleReference {
-                            name: r#"relate_decl"#.to_string(),
-                        },
-                        GrammarElement::RuleReference {
-                            name: r#"rule_decl"#.to_string(),
-                        },
-                        GrammarElement::RuleReference {
-                            name: r#"query_decl"#.to_string(),
-                        },
-                        GrammarElement::RuleReference {
-                            name: r#"let_decl"#.to_string(),
-                        },
-                        GrammarElement::RuleReference {
-                            name: r#"symbol_decl"#.to_string(),
-                        },
-                        GrammarElement::RuleReference {
-                            name: r#"constrain_decl"#.to_string(),
-                        },
-                        GrammarElement::RuleReference {
-                            name: r#"solve_decl"#.to_string(),
-                        },
-                        GrammarElement::RuleReference {
-                            name: r#"check_decl"#.to_string(),
-                        },
-                        GrammarElement::RuleReference {
-                            name: r#"optimize_decl"#.to_string(),
-                        },
-                        GrammarElement::RuleReference {
-                            name: r#"dictionary_decl"#.to_string(),
-                        },
-                        GrammarElement::RuleReference {
-                            name: r#"define_decl"#.to_string(),
-                        },
-                        GrammarElement::RuleReference {
-                            name: r#"rulebook_decl"#.to_string(),
-                        },
-                        GrammarElement::RuleReference {
-                            name: r#"use_decl"#.to_string(),
-                        },
-                        GrammarElement::RuleReference {
-                            name: r#"import_decl"#.to_string(),
-                        },
-                    ],
-                },
-                line_number: 22,
-            },
-            GrammarRule {
-                name: r#"prior_decl"#.to_string(),
-                body: GrammarElement::Sequence {
-                    elements: vec![
-                        GrammarElement::Literal {
-                            value: r#"prior"#.to_string(),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"NUMBER"#.to_string(),
-                        },
-                        GrammarElement::Literal {
-                            value: r#"for"#.to_string(),
-                        },
-                        GrammarElement::RuleReference {
-                            name: r#"term"#.to_string(),
-                        },
-                        GrammarElement::Repetition {
-                            element: Box::new(GrammarElement::RuleReference {
-                                name: r#"annotation"#.to_string(),
-                            }),
-                        },
-                    ],
-                },
-                line_number: 48,
-            },
-            GrammarRule {
-                name: r#"contributes_decl"#.to_string(),
-                body: GrammarElement::Sequence {
-                    elements: vec![
-                        GrammarElement::Literal {
-                            value: r#"contributes"#.to_string(),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"NUMBER"#.to_string(),
-                        },
-                        GrammarElement::Literal {
-                            value: r#"from"#.to_string(),
-                        },
-                        GrammarElement::RuleReference {
-                            name: r#"evidence"#.to_string(),
-                        },
-                        GrammarElement::Literal {
-                            value: r#"to"#.to_string(),
-                        },
-                        GrammarElement::RuleReference {
-                            name: r#"term"#.to_string(),
-                        },
-                        GrammarElement::Repetition {
-                            element: Box::new(GrammarElement::RuleReference {
-                                name: r#"annotation"#.to_string(),
-                            }),
-                        },
-                    ],
-                },
-                line_number: 50,
-            },
-            GrammarRule {
-                name: r#"evidence"#.to_string(),
-                body: GrammarElement::Alternation {
-                    choices: vec![
-                        GrammarElement::RuleReference {
-                            name: r#"predicate"#.to_string(),
-                        },
-                        GrammarElement::RuleReference {
-                            name: r#"term"#.to_string(),
-                        },
-                    ],
-                },
-                line_number: 60,
-            },
-            GrammarRule {
-                name: r#"predicate"#.to_string(),
-                body: GrammarElement::Sequence {
-                    elements: vec![
-                        GrammarElement::TokenReference {
-                            name: r#"IDENT"#.to_string(),
-                        },
-                        GrammarElement::Group {
-                            element: Box::new(GrammarElement::Alternation {
-                                choices: vec![
-                                    GrammarElement::TokenReference {
-                                        name: r#"GE"#.to_string(),
-                                    },
-                                    GrammarElement::TokenReference {
-                                        name: r#"LE"#.to_string(),
-                                    },
-                                    GrammarElement::TokenReference {
-                                        name: r#"GT"#.to_string(),
-                                    },
-                                    GrammarElement::TokenReference {
-                                        name: r#"LT"#.to_string(),
-                                    },
-                                    GrammarElement::TokenReference {
-                                        name: r#"EQEQ"#.to_string(),
-                                    },
-                                ],
-                            }),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"NUMBER"#.to_string(),
-                        },
-                    ],
-                },
-                line_number: 62,
-            },
-            GrammarRule {
-                name: r#"interacts_decl"#.to_string(),
-                body: GrammarElement::Sequence {
-                    elements: vec![
-                        GrammarElement::Literal {
-                            value: r#"interacts"#.to_string(),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"NUMBER"#.to_string(),
-                        },
-                        GrammarElement::Literal {
-                            value: r#"when"#.to_string(),
-                        },
-                        GrammarElement::RuleReference {
-                            name: r#"term"#.to_string(),
-                        },
-                        GrammarElement::Literal {
-                            value: r#"and"#.to_string(),
-                        },
-                        GrammarElement::RuleReference {
-                            name: r#"term"#.to_string(),
-                        },
-                        GrammarElement::Repetition {
-                            element: Box::new(GrammarElement::Sequence {
-                                elements: vec![
-                                    GrammarElement::Literal {
-                                        value: r#"and"#.to_string(),
-                                    },
-                                    GrammarElement::RuleReference {
-                                        name: r#"term"#.to_string(),
-                                    },
-                                ],
-                            }),
-                        },
-                        GrammarElement::Literal {
-                            value: r#"for"#.to_string(),
-                        },
-                        GrammarElement::RuleReference {
-                            name: r#"term"#.to_string(),
-                        },
-                        GrammarElement::Repetition {
-                            element: Box::new(GrammarElement::RuleReference {
-                                name: r#"annotation"#.to_string(),
-                            }),
-                        },
-                    ],
-                },
-                line_number: 64,
-            },
-            GrammarRule {
-                name: r#"uncertain_decl"#.to_string(),
-                body: GrammarElement::Sequence {
-                    elements: vec![
-                        GrammarElement::Literal {
-                            value: r#"uncertain"#.to_string(),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"LBRACE"#.to_string(),
-                        },
-                        GrammarElement::RuleReference {
-                            name: r#"term"#.to_string(),
-                        },
-                        GrammarElement::Repetition {
-                            element: Box::new(GrammarElement::Sequence {
-                                elements: vec![
-                                    GrammarElement::TokenReference {
-                                        name: r#"COMMA"#.to_string(),
-                                    },
-                                    GrammarElement::RuleReference {
-                                        name: r#"term"#.to_string(),
-                                    },
-                                ],
-                            }),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"RBRACE"#.to_string(),
-                        },
-                        GrammarElement::Literal {
-                            value: r#"for"#.to_string(),
-                        },
-                        GrammarElement::RuleReference {
-                            name: r#"term"#.to_string(),
-                        },
-                        GrammarElement::Repetition {
-                            element: Box::new(GrammarElement::RuleReference {
-                                name: r#"annotation"#.to_string(),
-                            }),
-                        },
-                    ],
-                },
-                line_number: 66,
-            },
-            GrammarRule {
-                name: r#"observe_decl"#.to_string(),
-                body: GrammarElement::Sequence {
-                    elements: vec![
-                        GrammarElement::Literal {
-                            value: r#"observe"#.to_string(),
-                        },
-                        GrammarElement::RuleReference {
-                            name: r#"term"#.to_string(),
-                        },
-                    ],
-                },
-                line_number: 68,
-            },
-            GrammarRule {
-                name: r#"relate_decl"#.to_string(),
-                body: GrammarElement::Sequence {
-                    elements: vec![
-                        GrammarElement::Literal {
-                            value: r#"relate"#.to_string(),
-                        },
-                        GrammarElement::RuleReference {
-                            name: r#"term"#.to_string(),
-                        },
-                        GrammarElement::Repetition {
-                            element: Box::new(GrammarElement::RuleReference {
-                                name: r#"annotation"#.to_string(),
-                            }),
-                        },
-                    ],
-                },
-                line_number: 81,
-            },
-            GrammarRule {
-                name: r#"rule_decl"#.to_string(),
-                body: GrammarElement::Sequence {
-                    elements: vec![
-                        GrammarElement::Literal {
-                            value: r#"rule"#.to_string(),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"LBRACE"#.to_string(),
-                        },
-                        GrammarElement::Literal {
-                            value: r#"head"#.to_string(),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"COLON"#.to_string(),
-                        },
-                        GrammarElement::RuleReference {
-                            name: r#"term"#.to_string(),
-                        },
-                        GrammarElement::Literal {
-                            value: r#"when"#.to_string(),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"COLON"#.to_string(),
-                        },
-                        GrammarElement::RuleReference {
-                            name: r#"body_literal"#.to_string(),
-                        },
-                        GrammarElement::Repetition {
-                            element: Box::new(GrammarElement::Sequence {
-                                elements: vec![
-                                    GrammarElement::TokenReference {
-                                        name: r#"COMMA"#.to_string(),
-                                    },
-                                    GrammarElement::RuleReference {
-                                        name: r#"body_literal"#.to_string(),
-                                    },
-                                ],
-                            }),
-                        },
-                        GrammarElement::Repetition {
-                            element: Box::new(GrammarElement::RuleReference {
-                                name: r#"annotation"#.to_string(),
-                            }),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"RBRACE"#.to_string(),
-                        },
-                    ],
-                },
-                line_number: 103,
-            },
-            GrammarRule {
-                name: r#"body_literal"#.to_string(),
-                body: GrammarElement::Sequence {
-                    elements: vec![
-                        GrammarElement::Optional {
-                            element: Box::new(GrammarElement::Literal {
-                                value: r#"not"#.to_string(),
-                            }),
-                        },
-                        GrammarElement::RuleReference {
-                            name: r#"term"#.to_string(),
-                        },
-                    ],
-                },
-                line_number: 105,
-            },
-            GrammarRule {
-                name: r#"query_decl"#.to_string(),
-                body: GrammarElement::Sequence {
-                    elements: vec![
-                        GrammarElement::TokenReference {
-                            name: r#"QUESTION"#.to_string(),
-                        },
-                        GrammarElement::RuleReference {
-                            name: r#"term"#.to_string(),
-                        },
-                    ],
-                },
-                line_number: 107,
-            },
-            GrammarRule {
-                name: r#"let_decl"#.to_string(),
-                body: GrammarElement::Sequence {
-                    elements: vec![
-                        GrammarElement::Literal {
-                            value: r#"let"#.to_string(),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"IDENT"#.to_string(),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"EQUALS"#.to_string(),
-                        },
-                        GrammarElement::RuleReference {
-                            name: r#"expr"#.to_string(),
-                        },
-                    ],
-                },
-                line_number: 121,
-            },
-            GrammarRule {
-                name: r#"expr"#.to_string(),
-                body: GrammarElement::Sequence {
-                    elements: vec![
-                        GrammarElement::RuleReference {
-                            name: r#"term_expr"#.to_string(),
-                        },
-                        GrammarElement::Repetition {
-                            element: Box::new(GrammarElement::Sequence {
-                                elements: vec![
-                                    GrammarElement::Group {
-                                        element: Box::new(GrammarElement::Alternation {
-                                            choices: vec![
-                                                GrammarElement::TokenReference {
-                                                    name: r#"PLUS"#.to_string(),
-                                                },
-                                                GrammarElement::TokenReference {
-                                                    name: r#"MINUS"#.to_string(),
-                                                },
-                                            ],
-                                        }),
-                                    },
-                                    GrammarElement::RuleReference {
-                                        name: r#"term_expr"#.to_string(),
-                                    },
-                                ],
-                            }),
-                        },
-                    ],
-                },
-                line_number: 123,
-            },
-            GrammarRule {
-                name: r#"term_expr"#.to_string(),
-                body: GrammarElement::Sequence {
-                    elements: vec![
-                        GrammarElement::RuleReference {
-                            name: r#"factor"#.to_string(),
-                        },
-                        GrammarElement::Repetition {
-                            element: Box::new(GrammarElement::Sequence {
-                                elements: vec![
-                                    GrammarElement::Group {
-                                        element: Box::new(GrammarElement::Alternation {
-                                            choices: vec![
-                                                GrammarElement::TokenReference {
-                                                    name: r#"STAR"#.to_string(),
-                                                },
-                                                GrammarElement::TokenReference {
-                                                    name: r#"SLASH"#.to_string(),
-                                                },
-                                            ],
-                                        }),
-                                    },
-                                    GrammarElement::RuleReference {
-                                        name: r#"factor"#.to_string(),
-                                    },
-                                ],
-                            }),
-                        },
-                    ],
-                },
-                line_number: 125,
-            },
-            GrammarRule {
-                name: r#"factor"#.to_string(),
-                body: GrammarElement::Alternation {
-                    choices: vec![
-                        GrammarElement::RuleReference {
-                            name: r#"agg"#.to_string(),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"NUMBER"#.to_string(),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"IDENT"#.to_string(),
-                        },
-                        GrammarElement::Sequence {
-                            elements: vec![
-                                GrammarElement::TokenReference {
-                                    name: r#"LPAREN"#.to_string(),
-                                },
-                                GrammarElement::RuleReference {
-                                    name: r#"expr"#.to_string(),
-                                },
-                                GrammarElement::TokenReference {
-                                    name: r#"RPAREN"#.to_string(),
-                                },
-                            ],
-                        },
-                    ],
-                },
-                line_number: 127,
-            },
-            GrammarRule {
-                name: r#"agg"#.to_string(),
-                body: GrammarElement::Sequence {
-                    elements: vec![
-                        GrammarElement::Group {
-                            element: Box::new(GrammarElement::Alternation {
-                                choices: vec![
-                                    GrammarElement::Literal {
-                                        value: r#"sum"#.to_string(),
-                                    },
-                                    GrammarElement::Literal {
-                                        value: r#"count"#.to_string(),
-                                    },
-                                    GrammarElement::Literal {
-                                        value: r#"min"#.to_string(),
-                                    },
-                                    GrammarElement::Literal {
-                                        value: r#"max"#.to_string(),
-                                    },
-                                    GrammarElement::Literal {
-                                        value: r#"avg"#.to_string(),
-                                    },
-                                ],
-                            }),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"LPAREN"#.to_string(),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"IDENT"#.to_string(),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"RPAREN"#.to_string(),
-                        },
-                    ],
-                },
-                line_number: 129,
-            },
-            GrammarRule {
-                name: r#"symbol_decl"#.to_string(),
-                body: GrammarElement::Sequence {
-                    elements: vec![
-                        GrammarElement::Literal {
-                            value: r#"symbol"#.to_string(),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"IDENT"#.to_string(),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"COLON"#.to_string(),
-                        },
-                        GrammarElement::RuleReference {
-                            name: r#"term"#.to_string(),
-                        },
-                    ],
-                },
-                line_number: 139,
-            },
-            GrammarRule {
-                name: r#"constrain_decl"#.to_string(),
-                body: GrammarElement::Sequence {
-                    elements: vec![
-                        GrammarElement::Literal {
-                            value: r#"constrain"#.to_string(),
-                        },
-                        GrammarElement::RuleReference {
-                            name: r#"expr"#.to_string(),
-                        },
-                        GrammarElement::RuleReference {
-                            name: r#"relop"#.to_string(),
-                        },
-                        GrammarElement::RuleReference {
-                            name: r#"expr"#.to_string(),
-                        },
-                    ],
-                },
-                line_number: 141,
-            },
-            GrammarRule {
-                name: r#"relop"#.to_string(),
-                body: GrammarElement::Alternation {
-                    choices: vec![
-                        GrammarElement::TokenReference {
-                            name: r#"GE"#.to_string(),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"LE"#.to_string(),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"GT"#.to_string(),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"LT"#.to_string(),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"EQEQ"#.to_string(),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"EQUALS"#.to_string(),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"NE"#.to_string(),
-                        },
-                    ],
-                },
-                line_number: 143,
-            },
-            GrammarRule {
-                name: r#"solve_decl"#.to_string(),
-                body: GrammarElement::Sequence {
-                    elements: vec![
-                        GrammarElement::Literal {
-                            value: r#"solve"#.to_string(),
-                        },
-                        GrammarElement::Literal {
-                            value: r#"for"#.to_string(),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"LBRACE"#.to_string(),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"IDENT"#.to_string(),
-                        },
-                        GrammarElement::Repetition {
-                            element: Box::new(GrammarElement::Sequence {
-                                elements: vec![
-                                    GrammarElement::TokenReference {
-                                        name: r#"COMMA"#.to_string(),
-                                    },
-                                    GrammarElement::TokenReference {
-                                        name: r#"IDENT"#.to_string(),
-                                    },
-                                ],
-                            }),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"RBRACE"#.to_string(),
-                        },
-                    ],
-                },
-                line_number: 145,
-            },
-            GrammarRule {
-                name: r#"check_decl"#.to_string(),
-                body: GrammarElement::Literal {
-                    value: r#"check"#.to_string(),
-                },
-                line_number: 147,
-            },
-            GrammarRule {
-                name: r#"optimize_decl"#.to_string(),
-                body: GrammarElement::Sequence {
-                    elements: vec![
-                        GrammarElement::Group {
-                            element: Box::new(GrammarElement::Alternation {
-                                choices: vec![
-                                    GrammarElement::Literal {
-                                        value: r#"minimize"#.to_string(),
-                                    },
-                                    GrammarElement::Literal {
-                                        value: r#"maximize"#.to_string(),
-                                    },
-                                ],
-                            }),
-                        },
-                        GrammarElement::RuleReference {
-                            name: r#"expr"#.to_string(),
-                        },
-                    ],
-                },
-                line_number: 154,
-            },
-            GrammarRule {
-                name: r#"dictionary_decl"#.to_string(),
-                body: GrammarElement::Sequence {
-                    elements: vec![
-                        GrammarElement::Literal {
-                            value: r#"dictionary"#.to_string(),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"IDENT"#.to_string(),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"LBRACE"#.to_string(),
-                        },
-                        GrammarElement::Repetition {
-                            element: Box::new(GrammarElement::RuleReference {
-                                name: r#"define_decl"#.to_string(),
-                            }),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"RBRACE"#.to_string(),
-                        },
-                    ],
-                },
-                line_number: 166,
-            },
-            GrammarRule {
-                name: r#"define_decl"#.to_string(),
-                body: GrammarElement::Sequence {
-                    elements: vec![
-                        GrammarElement::Literal {
-                            value: r#"define"#.to_string(),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"IDENT"#.to_string(),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"COLON"#.to_string(),
-                        },
-                        GrammarElement::RuleReference {
-                            name: r#"define_kind"#.to_string(),
-                        },
-                        GrammarElement::Repetition {
-                            element: Box::new(GrammarElement::RuleReference {
-                                name: r#"surface_clause"#.to_string(),
-                            }),
-                        },
-                    ],
-                },
-                line_number: 168,
-            },
-            GrammarRule {
-                name: r#"define_kind"#.to_string(),
-                body: GrammarElement::Alternation {
-                    choices: vec![
-                        GrammarElement::Literal {
-                            value: r#"hypothesis"#.to_string(),
-                        },
-                        GrammarElement::Sequence {
-                            elements: vec![
-                                GrammarElement::Literal {
-                                    value: r#"finding"#.to_string(),
-                                },
-                                GrammarElement::Optional {
-                                    element: Box::new(GrammarElement::Sequence {
-                                        elements: vec![
-                                            GrammarElement::Literal {
-                                                value: r#"values"#.to_string(),
-                                            },
-                                            GrammarElement::TokenReference {
-                                                name: r#"LBRACK"#.to_string(),
-                                            },
-                                            GrammarElement::TokenReference {
-                                                name: r#"IDENT"#.to_string(),
-                                            },
-                                            GrammarElement::Repetition {
-                                                element: Box::new(GrammarElement::Sequence {
-                                                    elements: vec![
-                                                        GrammarElement::TokenReference {
-                                                            name: r#"COMMA"#.to_string(),
-                                                        },
-                                                        GrammarElement::TokenReference {
-                                                            name: r#"IDENT"#.to_string(),
-                                                        },
-                                                    ],
-                                                }),
-                                            },
-                                            GrammarElement::TokenReference {
-                                                name: r#"RBRACK"#.to_string(),
-                                            },
-                                        ],
-                                    }),
-                                },
-                            ],
-                        },
-                        GrammarElement::Literal {
-                            value: r#"entity"#.to_string(),
-                        },
-                        GrammarElement::Sequence {
-                            elements: vec![
-                                GrammarElement::Literal {
-                                    value: r#"relation"#.to_string(),
-                                },
-                                GrammarElement::Literal {
-                                    value: r#"from"#.to_string(),
-                                },
-                                GrammarElement::TokenReference {
-                                    name: r#"IDENT"#.to_string(),
-                                },
-                                GrammarElement::Literal {
-                                    value: r#"to"#.to_string(),
-                                },
-                                GrammarElement::TokenReference {
-                                    name: r#"IDENT"#.to_string(),
-                                },
-                            ],
-                        },
-                    ],
-                },
-                line_number: 170,
-            },
-            GrammarRule {
-                name: r#"surface_clause"#.to_string(),
-                body: GrammarElement::Sequence {
-                    elements: vec![
-                        GrammarElement::Literal {
-                            value: r#"surface"#.to_string(),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"STRING"#.to_string(),
-                        },
-                        GrammarElement::Repetition {
-                            element: Box::new(GrammarElement::Sequence {
-                                elements: vec![
-                                    GrammarElement::TokenReference {
-                                        name: r#"COMMA"#.to_string(),
-                                    },
-                                    GrammarElement::TokenReference {
-                                        name: r#"STRING"#.to_string(),
-                                    },
-                                ],
-                            }),
-                        },
-                    ],
-                },
-                line_number: 176,
-            },
-            GrammarRule {
-                name: r#"rulebook_decl"#.to_string(),
-                body: GrammarElement::Sequence {
-                    elements: vec![
-                        GrammarElement::Literal {
-                            value: r#"rulebook"#.to_string(),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"IDENT"#.to_string(),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"LBRACE"#.to_string(),
-                        },
-                        GrammarElement::Repetition {
-                            element: Box::new(GrammarElement::RuleReference {
-                                name: r#"statement"#.to_string(),
-                            }),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"RBRACE"#.to_string(),
-                        },
-                    ],
-                },
-                line_number: 193,
-            },
-            GrammarRule {
-                name: r#"use_decl"#.to_string(),
-                body: GrammarElement::Sequence {
-                    elements: vec![
-                        GrammarElement::Literal {
-                            value: r#"use"#.to_string(),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"IDENT"#.to_string(),
-                        },
-                    ],
-                },
-                line_number: 195,
-            },
-            GrammarRule {
-                name: r#"import_decl"#.to_string(),
-                body: GrammarElement::Sequence {
-                    elements: vec![
-                        GrammarElement::Literal {
-                            value: r#"import"#.to_string(),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"STRING"#.to_string(),
-                        },
-                    ],
-                },
-                line_number: 211,
-            },
-            GrammarRule {
-                name: r#"annotation"#.to_string(),
-                body: GrammarElement::Alternation {
-                    choices: vec![
-                        GrammarElement::RuleReference {
-                            name: r#"source_annotation"#.to_string(),
-                        },
-                        GrammarElement::RuleReference {
-                            name: r#"locator_annotation"#.to_string(),
-                        },
-                        GrammarElement::RuleReference {
-                            name: r#"trust_annotation"#.to_string(),
-                        },
-                    ],
-                },
-                line_number: 219,
-            },
-            GrammarRule {
-                name: r#"source_annotation"#.to_string(),
-                body: GrammarElement::Sequence {
-                    elements: vec![
-                        GrammarElement::Literal {
-                            value: r#"source"#.to_string(),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"STRING"#.to_string(),
-                        },
-                    ],
-                },
-                line_number: 224,
-            },
-            GrammarRule {
-                name: r#"locator_annotation"#.to_string(),
-                body: GrammarElement::Sequence {
-                    elements: vec![
-                        GrammarElement::Literal {
-                            value: r#"locator"#.to_string(),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"STRING"#.to_string(),
-                        },
-                    ],
-                },
-                line_number: 225,
-            },
-            GrammarRule {
-                name: r#"trust_annotation"#.to_string(),
-                body: GrammarElement::Sequence {
-                    elements: vec![
-                        GrammarElement::Literal {
-                            value: r#"trust"#.to_string(),
-                        },
-                        GrammarElement::RuleReference {
-                            name: r#"trust_tier"#.to_string(),
-                        },
-                    ],
-                },
-                line_number: 226,
-            },
-            GrammarRule {
-                name: r#"trust_tier"#.to_string(),
-                body: GrammarElement::Alternation {
-                    choices: vec![
-                        GrammarElement::Literal {
-                            value: r#"consensus"#.to_string(),
-                        },
-                        GrammarElement::Literal {
-                            value: r#"authoritative"#.to_string(),
-                        },
-                        GrammarElement::Literal {
-                            value: r#"empirical"#.to_string(),
-                        },
-                        GrammarElement::Literal {
-                            value: r#"inferred"#.to_string(),
-                        },
-                        GrammarElement::Literal {
-                            value: r#"unattributed"#.to_string(),
-                        },
-                    ],
-                },
-                line_number: 228,
-            },
-            GrammarRule {
-                name: r#"term"#.to_string(),
-                body: GrammarElement::Sequence {
-                    elements: vec![
-                        GrammarElement::TokenReference {
-                            name: r#"IDENT"#.to_string(),
-                        },
-                        GrammarElement::Optional {
-                            element: Box::new(GrammarElement::Sequence {
-                                elements: vec![
-                                    GrammarElement::TokenReference {
-                                        name: r#"LPAREN"#.to_string(),
-                                    },
-                                    GrammarElement::Group {
-                                        element: Box::new(GrammarElement::Alternation {
-                                            choices: vec![
-                                                GrammarElement::RuleReference {
-                                                    name: r#"term"#.to_string(),
-                                                },
-                                                GrammarElement::TokenReference {
-                                                    name: r#"NUMBER"#.to_string(),
-                                                },
-                                                GrammarElement::TokenReference {
-                                                    name: r#"VAR"#.to_string(),
-                                                },
-                                            ],
-                                        }),
-                                    },
-                                    GrammarElement::Repetition {
-                                        element: Box::new(GrammarElement::Sequence {
-                                            elements: vec![
-                                                GrammarElement::TokenReference {
-                                                    name: r#"COMMA"#.to_string(),
-                                                },
-                                                GrammarElement::Group {
-                                                    element: Box::new(
-                                                        GrammarElement::Alternation {
-                                                            choices: vec![
-                                                                GrammarElement::RuleReference {
-                                                                    name: r#"term"#.to_string(),
-                                                                },
-                                                                GrammarElement::TokenReference {
-                                                                    name: r#"NUMBER"#.to_string(),
-                                                                },
-                                                                GrammarElement::TokenReference {
-                                                                    name: r#"VAR"#.to_string(),
-                                                                },
-                                                            ],
-                                                        },
-                                                    ),
-                                                },
-                                            ],
-                                        }),
-                                    },
-                                    GrammarElement::TokenReference {
-                                        name: r#"RPAREN"#.to_string(),
-                                    },
-                                ],
-                            }),
-                        },
-                    ],
-                },
-                line_number: 250,
-            },
-        ],
+        GrammarRule {
+            name: r#"program"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"statement"#.to_string() }) },
+                GrammarElement::TokenReference { name: r#"EOF"#.to_string() },
+            ] },
+            line_number: 20,
+        },
+        GrammarRule {
+            name: r#"statement"#.to_string(),
+            body: GrammarElement::Alternation { choices: vec![
+                GrammarElement::RuleReference { name: r#"prior_decl"#.to_string() },
+                GrammarElement::RuleReference { name: r#"contributes_decl"#.to_string() },
+                GrammarElement::RuleReference { name: r#"interacts_decl"#.to_string() },
+                GrammarElement::RuleReference { name: r#"uncertain_decl"#.to_string() },
+                GrammarElement::RuleReference { name: r#"observe_decl"#.to_string() },
+                GrammarElement::RuleReference { name: r#"relate_decl"#.to_string() },
+                GrammarElement::RuleReference { name: r#"rule_decl"#.to_string() },
+                GrammarElement::RuleReference { name: r#"functional_decl"#.to_string() },
+                GrammarElement::RuleReference { name: r#"query_decl"#.to_string() },
+                GrammarElement::RuleReference { name: r#"let_decl"#.to_string() },
+                GrammarElement::RuleReference { name: r#"symbol_decl"#.to_string() },
+                GrammarElement::RuleReference { name: r#"constrain_decl"#.to_string() },
+                GrammarElement::RuleReference { name: r#"solve_decl"#.to_string() },
+                GrammarElement::RuleReference { name: r#"check_decl"#.to_string() },
+                GrammarElement::RuleReference { name: r#"optimize_decl"#.to_string() },
+                GrammarElement::RuleReference { name: r#"dictionary_decl"#.to_string() },
+                GrammarElement::RuleReference { name: r#"define_decl"#.to_string() },
+                GrammarElement::RuleReference { name: r#"rulebook_decl"#.to_string() },
+                GrammarElement::RuleReference { name: r#"use_decl"#.to_string() },
+                GrammarElement::RuleReference { name: r#"import_decl"#.to_string() },
+            ] },
+            line_number: 22,
+        },
+        GrammarRule {
+            name: r#"prior_decl"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Literal { value: r#"prior"#.to_string() },
+                GrammarElement::TokenReference { name: r#"NUMBER"#.to_string() },
+                GrammarElement::Literal { value: r#"for"#.to_string() },
+                GrammarElement::RuleReference { name: r#"term"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"annotation"#.to_string() }) },
+            ] },
+            line_number: 49,
+        },
+        GrammarRule {
+            name: r#"contributes_decl"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Literal { value: r#"contributes"#.to_string() },
+                GrammarElement::TokenReference { name: r#"NUMBER"#.to_string() },
+                GrammarElement::Literal { value: r#"from"#.to_string() },
+                GrammarElement::RuleReference { name: r#"evidence"#.to_string() },
+                GrammarElement::Literal { value: r#"to"#.to_string() },
+                GrammarElement::RuleReference { name: r#"term"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"annotation"#.to_string() }) },
+            ] },
+            line_number: 51,
+        },
+        GrammarRule {
+            name: r#"evidence"#.to_string(),
+            body: GrammarElement::Alternation { choices: vec![
+                GrammarElement::RuleReference { name: r#"predicate"#.to_string() },
+                GrammarElement::RuleReference { name: r#"term"#.to_string() },
+            ] },
+            line_number: 61,
+        },
+        GrammarRule {
+            name: r#"predicate"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::TokenReference { name: r#"IDENT"#.to_string() },
+                GrammarElement::Group { element: Box::new(GrammarElement::Alternation { choices: vec![
+                        GrammarElement::TokenReference { name: r#"GE"#.to_string() },
+                        GrammarElement::TokenReference { name: r#"LE"#.to_string() },
+                        GrammarElement::TokenReference { name: r#"GT"#.to_string() },
+                        GrammarElement::TokenReference { name: r#"LT"#.to_string() },
+                        GrammarElement::TokenReference { name: r#"EQEQ"#.to_string() },
+                    ] }) },
+                GrammarElement::TokenReference { name: r#"NUMBER"#.to_string() },
+            ] },
+            line_number: 63,
+        },
+        GrammarRule {
+            name: r#"interacts_decl"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Literal { value: r#"interacts"#.to_string() },
+                GrammarElement::TokenReference { name: r#"NUMBER"#.to_string() },
+                GrammarElement::Literal { value: r#"when"#.to_string() },
+                GrammarElement::RuleReference { name: r#"term"#.to_string() },
+                GrammarElement::Literal { value: r#"and"#.to_string() },
+                GrammarElement::RuleReference { name: r#"term"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::Literal { value: r#"and"#.to_string() },
+                        GrammarElement::RuleReference { name: r#"term"#.to_string() },
+                    ] }) },
+                GrammarElement::Literal { value: r#"for"#.to_string() },
+                GrammarElement::RuleReference { name: r#"term"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"annotation"#.to_string() }) },
+            ] },
+            line_number: 65,
+        },
+        GrammarRule {
+            name: r#"uncertain_decl"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Literal { value: r#"uncertain"#.to_string() },
+                GrammarElement::TokenReference { name: r#"LBRACE"#.to_string() },
+                GrammarElement::RuleReference { name: r#"term"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::TokenReference { name: r#"COMMA"#.to_string() },
+                        GrammarElement::RuleReference { name: r#"term"#.to_string() },
+                    ] }) },
+                GrammarElement::TokenReference { name: r#"RBRACE"#.to_string() },
+                GrammarElement::Literal { value: r#"for"#.to_string() },
+                GrammarElement::RuleReference { name: r#"term"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"annotation"#.to_string() }) },
+            ] },
+            line_number: 67,
+        },
+        GrammarRule {
+            name: r#"observe_decl"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Literal { value: r#"observe"#.to_string() },
+                GrammarElement::RuleReference { name: r#"term"#.to_string() },
+            ] },
+            line_number: 69,
+        },
+        GrammarRule {
+            name: r#"relate_decl"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Literal { value: r#"relate"#.to_string() },
+                GrammarElement::RuleReference { name: r#"term"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"annotation"#.to_string() }) },
+            ] },
+            line_number: 82,
+        },
+        GrammarRule {
+            name: r#"rule_decl"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Literal { value: r#"rule"#.to_string() },
+                GrammarElement::TokenReference { name: r#"LBRACE"#.to_string() },
+                GrammarElement::Literal { value: r#"head"#.to_string() },
+                GrammarElement::TokenReference { name: r#"COLON"#.to_string() },
+                GrammarElement::RuleReference { name: r#"term"#.to_string() },
+                GrammarElement::Literal { value: r#"when"#.to_string() },
+                GrammarElement::TokenReference { name: r#"COLON"#.to_string() },
+                GrammarElement::RuleReference { name: r#"body_literal"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::TokenReference { name: r#"COMMA"#.to_string() },
+                        GrammarElement::RuleReference { name: r#"body_literal"#.to_string() },
+                    ] }) },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"annotation"#.to_string() }) },
+                GrammarElement::Optional { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::Literal { value: r#"priority"#.to_string() },
+                        GrammarElement::TokenReference { name: r#"COLON"#.to_string() },
+                        GrammarElement::TokenReference { name: r#"IDENT"#.to_string() },
+                    ] }) },
+                GrammarElement::TokenReference { name: r#"RBRACE"#.to_string() },
+            ] },
+            line_number: 104,
+        },
+        GrammarRule {
+            name: r#"body_literal"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Optional { element: Box::new(GrammarElement::Literal { value: r#"not"#.to_string() }) },
+                GrammarElement::RuleReference { name: r#"term"#.to_string() },
+            ] },
+            line_number: 106,
+        },
+        GrammarRule {
+            name: r#"functional_decl"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Literal { value: r#"functional"#.to_string() },
+                GrammarElement::RuleReference { name: r#"term"#.to_string() },
+            ] },
+            line_number: 117,
+        },
+        GrammarRule {
+            name: r#"query_decl"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::TokenReference { name: r#"QUESTION"#.to_string() },
+                GrammarElement::RuleReference { name: r#"term"#.to_string() },
+            ] },
+            line_number: 119,
+        },
+        GrammarRule {
+            name: r#"let_decl"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Literal { value: r#"let"#.to_string() },
+                GrammarElement::TokenReference { name: r#"IDENT"#.to_string() },
+                GrammarElement::TokenReference { name: r#"EQUALS"#.to_string() },
+                GrammarElement::RuleReference { name: r#"expr"#.to_string() },
+            ] },
+            line_number: 133,
+        },
+        GrammarRule {
+            name: r#"expr"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::RuleReference { name: r#"term_expr"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::Group { element: Box::new(GrammarElement::Alternation { choices: vec![
+                                GrammarElement::TokenReference { name: r#"PLUS"#.to_string() },
+                                GrammarElement::TokenReference { name: r#"MINUS"#.to_string() },
+                            ] }) },
+                        GrammarElement::RuleReference { name: r#"term_expr"#.to_string() },
+                    ] }) },
+            ] },
+            line_number: 135,
+        },
+        GrammarRule {
+            name: r#"term_expr"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::RuleReference { name: r#"factor"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::Group { element: Box::new(GrammarElement::Alternation { choices: vec![
+                                GrammarElement::TokenReference { name: r#"STAR"#.to_string() },
+                                GrammarElement::TokenReference { name: r#"SLASH"#.to_string() },
+                            ] }) },
+                        GrammarElement::RuleReference { name: r#"factor"#.to_string() },
+                    ] }) },
+            ] },
+            line_number: 137,
+        },
+        GrammarRule {
+            name: r#"factor"#.to_string(),
+            body: GrammarElement::Alternation { choices: vec![
+                GrammarElement::RuleReference { name: r#"agg"#.to_string() },
+                GrammarElement::TokenReference { name: r#"NUMBER"#.to_string() },
+                GrammarElement::TokenReference { name: r#"IDENT"#.to_string() },
+                GrammarElement::Sequence { elements: vec![
+                    GrammarElement::TokenReference { name: r#"LPAREN"#.to_string() },
+                    GrammarElement::RuleReference { name: r#"expr"#.to_string() },
+                    GrammarElement::TokenReference { name: r#"RPAREN"#.to_string() },
+                ] },
+            ] },
+            line_number: 139,
+        },
+        GrammarRule {
+            name: r#"agg"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Group { element: Box::new(GrammarElement::Alternation { choices: vec![
+                        GrammarElement::Literal { value: r#"sum"#.to_string() },
+                        GrammarElement::Literal { value: r#"count"#.to_string() },
+                        GrammarElement::Literal { value: r#"min"#.to_string() },
+                        GrammarElement::Literal { value: r#"max"#.to_string() },
+                        GrammarElement::Literal { value: r#"avg"#.to_string() },
+                    ] }) },
+                GrammarElement::TokenReference { name: r#"LPAREN"#.to_string() },
+                GrammarElement::TokenReference { name: r#"IDENT"#.to_string() },
+                GrammarElement::TokenReference { name: r#"RPAREN"#.to_string() },
+            ] },
+            line_number: 141,
+        },
+        GrammarRule {
+            name: r#"symbol_decl"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Literal { value: r#"symbol"#.to_string() },
+                GrammarElement::TokenReference { name: r#"IDENT"#.to_string() },
+                GrammarElement::TokenReference { name: r#"COLON"#.to_string() },
+                GrammarElement::RuleReference { name: r#"term"#.to_string() },
+            ] },
+            line_number: 151,
+        },
+        GrammarRule {
+            name: r#"constrain_decl"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Literal { value: r#"constrain"#.to_string() },
+                GrammarElement::RuleReference { name: r#"expr"#.to_string() },
+                GrammarElement::RuleReference { name: r#"relop"#.to_string() },
+                GrammarElement::RuleReference { name: r#"expr"#.to_string() },
+            ] },
+            line_number: 153,
+        },
+        GrammarRule {
+            name: r#"relop"#.to_string(),
+            body: GrammarElement::Alternation { choices: vec![
+                GrammarElement::TokenReference { name: r#"GE"#.to_string() },
+                GrammarElement::TokenReference { name: r#"LE"#.to_string() },
+                GrammarElement::TokenReference { name: r#"GT"#.to_string() },
+                GrammarElement::TokenReference { name: r#"LT"#.to_string() },
+                GrammarElement::TokenReference { name: r#"EQEQ"#.to_string() },
+                GrammarElement::TokenReference { name: r#"EQUALS"#.to_string() },
+                GrammarElement::TokenReference { name: r#"NE"#.to_string() },
+            ] },
+            line_number: 155,
+        },
+        GrammarRule {
+            name: r#"solve_decl"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Literal { value: r#"solve"#.to_string() },
+                GrammarElement::Literal { value: r#"for"#.to_string() },
+                GrammarElement::TokenReference { name: r#"LBRACE"#.to_string() },
+                GrammarElement::TokenReference { name: r#"IDENT"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::TokenReference { name: r#"COMMA"#.to_string() },
+                        GrammarElement::TokenReference { name: r#"IDENT"#.to_string() },
+                    ] }) },
+                GrammarElement::TokenReference { name: r#"RBRACE"#.to_string() },
+            ] },
+            line_number: 157,
+        },
+        GrammarRule {
+            name: r#"check_decl"#.to_string(),
+            body: GrammarElement::Literal { value: r#"check"#.to_string() },
+            line_number: 159,
+        },
+        GrammarRule {
+            name: r#"optimize_decl"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Group { element: Box::new(GrammarElement::Alternation { choices: vec![
+                        GrammarElement::Literal { value: r#"minimize"#.to_string() },
+                        GrammarElement::Literal { value: r#"maximize"#.to_string() },
+                    ] }) },
+                GrammarElement::RuleReference { name: r#"expr"#.to_string() },
+            ] },
+            line_number: 166,
+        },
+        GrammarRule {
+            name: r#"dictionary_decl"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Literal { value: r#"dictionary"#.to_string() },
+                GrammarElement::TokenReference { name: r#"IDENT"#.to_string() },
+                GrammarElement::TokenReference { name: r#"LBRACE"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"define_decl"#.to_string() }) },
+                GrammarElement::TokenReference { name: r#"RBRACE"#.to_string() },
+            ] },
+            line_number: 178,
+        },
+        GrammarRule {
+            name: r#"define_decl"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Literal { value: r#"define"#.to_string() },
+                GrammarElement::TokenReference { name: r#"IDENT"#.to_string() },
+                GrammarElement::TokenReference { name: r#"COLON"#.to_string() },
+                GrammarElement::RuleReference { name: r#"define_kind"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"surface_clause"#.to_string() }) },
+            ] },
+            line_number: 180,
+        },
+        GrammarRule {
+            name: r#"define_kind"#.to_string(),
+            body: GrammarElement::Alternation { choices: vec![
+                GrammarElement::Literal { value: r#"hypothesis"#.to_string() },
+                GrammarElement::Sequence { elements: vec![
+                    GrammarElement::Literal { value: r#"finding"#.to_string() },
+                    GrammarElement::Optional { element: Box::new(GrammarElement::Sequence { elements: vec![
+                            GrammarElement::Literal { value: r#"values"#.to_string() },
+                            GrammarElement::TokenReference { name: r#"LBRACK"#.to_string() },
+                            GrammarElement::TokenReference { name: r#"IDENT"#.to_string() },
+                            GrammarElement::Repetition { element: Box::new(GrammarElement::Sequence { elements: vec![
+                                    GrammarElement::TokenReference { name: r#"COMMA"#.to_string() },
+                                    GrammarElement::TokenReference { name: r#"IDENT"#.to_string() },
+                                ] }) },
+                            GrammarElement::TokenReference { name: r#"RBRACK"#.to_string() },
+                        ] }) },
+                ] },
+                GrammarElement::Literal { value: r#"entity"#.to_string() },
+                GrammarElement::Sequence { elements: vec![
+                    GrammarElement::Literal { value: r#"relation"#.to_string() },
+                    GrammarElement::Literal { value: r#"from"#.to_string() },
+                    GrammarElement::TokenReference { name: r#"IDENT"#.to_string() },
+                    GrammarElement::Literal { value: r#"to"#.to_string() },
+                    GrammarElement::TokenReference { name: r#"IDENT"#.to_string() },
+                ] },
+            ] },
+            line_number: 182,
+        },
+        GrammarRule {
+            name: r#"surface_clause"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Literal { value: r#"surface"#.to_string() },
+                GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::TokenReference { name: r#"COMMA"#.to_string() },
+                        GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
+                    ] }) },
+            ] },
+            line_number: 188,
+        },
+        GrammarRule {
+            name: r#"rulebook_decl"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Literal { value: r#"rulebook"#.to_string() },
+                GrammarElement::TokenReference { name: r#"IDENT"#.to_string() },
+                GrammarElement::TokenReference { name: r#"LBRACE"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"statement"#.to_string() }) },
+                GrammarElement::TokenReference { name: r#"RBRACE"#.to_string() },
+            ] },
+            line_number: 205,
+        },
+        GrammarRule {
+            name: r#"use_decl"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Literal { value: r#"use"#.to_string() },
+                GrammarElement::TokenReference { name: r#"IDENT"#.to_string() },
+            ] },
+            line_number: 207,
+        },
+        GrammarRule {
+            name: r#"import_decl"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Literal { value: r#"import"#.to_string() },
+                GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
+            ] },
+            line_number: 223,
+        },
+        GrammarRule {
+            name: r#"annotation"#.to_string(),
+            body: GrammarElement::Alternation { choices: vec![
+                GrammarElement::RuleReference { name: r#"source_annotation"#.to_string() },
+                GrammarElement::RuleReference { name: r#"locator_annotation"#.to_string() },
+                GrammarElement::RuleReference { name: r#"trust_annotation"#.to_string() },
+            ] },
+            line_number: 231,
+        },
+        GrammarRule {
+            name: r#"source_annotation"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Literal { value: r#"source"#.to_string() },
+                GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
+            ] },
+            line_number: 236,
+        },
+        GrammarRule {
+            name: r#"locator_annotation"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Literal { value: r#"locator"#.to_string() },
+                GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
+            ] },
+            line_number: 237,
+        },
+        GrammarRule {
+            name: r#"trust_annotation"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Literal { value: r#"trust"#.to_string() },
+                GrammarElement::RuleReference { name: r#"trust_tier"#.to_string() },
+            ] },
+            line_number: 238,
+        },
+        GrammarRule {
+            name: r#"trust_tier"#.to_string(),
+            body: GrammarElement::Alternation { choices: vec![
+                GrammarElement::Literal { value: r#"consensus"#.to_string() },
+                GrammarElement::Literal { value: r#"authoritative"#.to_string() },
+                GrammarElement::Literal { value: r#"empirical"#.to_string() },
+                GrammarElement::Literal { value: r#"inferred"#.to_string() },
+                GrammarElement::Literal { value: r#"unattributed"#.to_string() },
+            ] },
+            line_number: 240,
+        },
+        GrammarRule {
+            name: r#"term"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::TokenReference { name: r#"IDENT"#.to_string() },
+                GrammarElement::Optional { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::TokenReference { name: r#"LPAREN"#.to_string() },
+                        GrammarElement::Group { element: Box::new(GrammarElement::Alternation { choices: vec![
+                                GrammarElement::RuleReference { name: r#"term"#.to_string() },
+                                GrammarElement::TokenReference { name: r#"NUMBER"#.to_string() },
+                                GrammarElement::TokenReference { name: r#"VAR"#.to_string() },
+                            ] }) },
+                        GrammarElement::Repetition { element: Box::new(GrammarElement::Sequence { elements: vec![
+                                GrammarElement::TokenReference { name: r#"COMMA"#.to_string() },
+                                GrammarElement::Group { element: Box::new(GrammarElement::Alternation { choices: vec![
+                                        GrammarElement::RuleReference { name: r#"term"#.to_string() },
+                                        GrammarElement::TokenReference { name: r#"NUMBER"#.to_string() },
+                                        GrammarElement::TokenReference { name: r#"VAR"#.to_string() },
+                                    ] }) },
+                            ] }) },
+                        GrammarElement::TokenReference { name: r#"RPAREN"#.to_string() },
+                    ] }) },
+            ] },
+            line_number: 262,
+        },
+    ],
         version: 1,
     }
 }

--- a/code/packages/rust/adj-lang/src/adapter.rs
+++ b/code/packages/rust/adj-lang/src/adapter.rs
@@ -110,6 +110,7 @@ fn adapt_statement(node: &GrammarASTNode) -> Result<Statement, AdapterError> {
         "observe_decl" => adapt_observe(child),
         "relate_decl" => adapt_relate(child),
         "rule_decl" => adapt_rule(child),
+        "functional_decl" => adapt_functional(child),
         "query_decl" => adapt_query(child),
         "let_decl" => adapt_let(child),
         "symbol_decl" => adapt_symbol(child),
@@ -324,11 +325,43 @@ fn adapt_rule(node: &GrammarASTNode) -> Result<Statement, AdapterError> {
         });
     }
     let annotations = collect_annotations(node)?;
+    // ADJ73 PR-C: optional trailing `priority: <tier>`. The tier is the first Name token after
+    // the `priority` literal token (the COLON between them is a separate token).
+    let mut priority = None;
+    let mut seen_priority_kw = false;
+    for child in &node.children {
+        if let ASTNodeOrToken::Token(t) = child {
+            if t.type_ == TokenType::Name && t.value == "priority" {
+                seen_priority_kw = true;
+            } else if seen_priority_kw && t.type_ == TokenType::Name {
+                priority = Some(t.value.clone());
+                break;
+            }
+        }
+    }
     Ok(Statement::Rule {
         head,
         body,
         annotations,
+        priority,
     })
+}
+
+fn adapt_functional(node: &GrammarASTNode) -> Result<Statement, AdapterError> {
+    // functional_decl = "functional" term — declare a predicate functional on its last
+    // argument. Only the functor + arity of the term matter (arg names are placeholders).
+    let term = expect_term_child(node, "functional_decl")?;
+    let (functor, arity) = match &term {
+        Term::Compound { functor, args } => (functor.clone(), args.len()),
+        Term::Atom(name) => (name.clone(), 0),
+        _ => {
+            return Err(AdapterError::MissingChild {
+                rule: "functional_decl".into(),
+                position: "predicate term (compound or atom)",
+            })
+        }
+    };
+    Ok(Statement::Functional { functor, arity })
 }
 
 fn adapt_query(node: &GrammarASTNode) -> Result<Statement, AdapterError> {

--- a/code/packages/rust/adj-lang/src/ast.rs
+++ b/code/packages/rust/adj-lang/src/ast.rs
@@ -149,7 +149,18 @@ pub enum Statement {
         head: Term,
         body: Vec<RuleLiteral>,
         annotations: Vec<Annotation>,
+        /// ADJ73 defeasible precedence (PR-C): the optional `priority: <tier>` annotation
+        /// (`default` | `specific` | `authoritative` | `mandatory`). `None` lowers to
+        /// `Priority::Default`. Among *conflicting* derivations of a functional predicate, a
+        /// higher tier defeats a lower one (`logic_engine::govern::enumerate_governing`).
+        priority: Option<String>,
     },
+    /// `functional <pred>(<arg>, …)` — declare a predicate FUNCTIONAL on its last argument
+    /// (ADJ73 PR-C): at most one value may hold per key (the preceding args). The argument
+    /// names are placeholders for readability; only the functor + arity are used. Lowers to
+    /// `KnowledgeBase::declare_functional(functor, arity)`. Two derivations sharing the key but
+    /// differing on the last arg then *conflict*, and precedence picks the governing one.
+    Functional { functor: String, arity: usize },
     /// `? <conclusion>` — query the engine. With a ground hypothesis term this
     /// returns the posterior; with a relational goal containing a `$variable`
     /// (`? deficient_in(tay_sachs, $E)`) it returns the binding(s) — fact recall

--- a/code/packages/rust/adj-lang/src/lower.rs
+++ b/code/packages/rust/adj-lang/src/lower.rs
@@ -25,7 +25,7 @@ use logic_core::{
 use logic_engine::{
     compute, BodyLiteral, CmpOp as EngineCmpOp, ComputeExpr, ComputeOp, ContributionClause, Fact,
     JointContributionClause, KbError, KnowledgeBase, PredicateContributionClause, PriorClause,
-    Provenance, Rule, TrustTier, UncertaintyMarker,
+    Priority, Provenance, Rule, TrustTier, UncertaintyMarker,
 };
 
 use std::collections::HashMap;
@@ -102,6 +102,12 @@ pub enum LowerError {
     /// rather than panicking in `from_lr`.
     InvalidLikelihoodRatio {
         value: f64,
+    },
+    /// A `rule { … priority: <tier> }` whose tier is not one of the named
+    /// [`Priority`] levels (`default` | `specific` | `authoritative` | `mandatory`).
+    /// Caught at lowering so a typo produces a clean diagnostic, not a silent default.
+    UnknownPriorityTier {
+        tier: String,
     },
     /// A `let <name> = <expr>` whose formula could not be evaluated (an
     /// unknown slot, division by zero, an empty aggregation, …). Carries
@@ -258,10 +264,16 @@ pub fn lower(program: &Program) -> Result<LoweredProgram, LowerError> {
                 let prov = annotations_to_provenance(annotations)?;
                 kb.add_fact(Fact::certain(lower_term(edge)).with_provenance(prov));
             }
+            Statement::Functional { functor, arity } => {
+                // ADJ73 PR-C: declare the predicate functional on its last argument, so
+                // conflicting derivations are resolved by precedence (enumerate_governing).
+                kb.declare_functional(functor, *arity);
+            }
             Statement::Rule {
                 head,
                 body,
                 annotations,
+                priority,
             } => {
                 // A derivation rule → `logic_engine::Rule { head, body }`. Head and body
                 // share ONE variable scope so a `$Var` in the head unifies with the same
@@ -282,7 +294,21 @@ pub fn lower(program: &Program) -> Result<LoweredProgram, LowerError> {
                     })
                     .collect();
                 let prov = annotations_to_provenance(annotations)?;
-                kb.add_rule(Rule::certain(head_term, body_lits).with_provenance(prov));
+                // ADJ73 PR-C: map the optional named tier → Priority (absent ⇒ Default).
+                let tier = match priority.as_deref() {
+                    None | Some("default") => Priority::Default,
+                    Some("specific") => Priority::Specific,
+                    Some("authoritative") => Priority::Authoritative,
+                    Some("mandatory") => Priority::Mandatory,
+                    Some(other) => {
+                        return Err(LowerError::UnknownPriorityTier { tier: other.into() })
+                    }
+                };
+                kb.add_rule(
+                    Rule::certain(head_term, body_lits)
+                        .with_provenance(prov)
+                        .with_priority(tier),
+                );
             }
             Statement::Query { conclusion } => {
                 // Lower with a per-query variable scope so repeated `$Var`s in one
@@ -1628,5 +1654,89 @@ mod tests {
     fn a_pure_rulebook_has_an_empty_constraint_system() {
         let lowered = compile("prior 0.10 for acs\n? acs").unwrap();
         assert!(lowered.constraints.is_empty());
+    }
+
+    // ---- ADJ73 PR-C: precedence surface syntax (functional + priority tiers) ----
+
+    /// `functional` + `priority:` lower into the engine so a higher-tier rule GOVERNS a
+    /// conflicting lower-tier one (the whole point — surface syntax over the merged engine).
+    #[test]
+    fn functional_and_priority_tiers_resolve_a_conflict() {
+        use logic_engine::{enumerate_governing, GovernStatus};
+        let src = "\
+functional timing(decision)
+relate stable_routine_pending(yes)
+rule { head: timing(await_culture) when: stable_routine_pending(yes) priority: specific }
+rule { head: timing(treat_now) when: stable_routine_pending(yes) priority: default }
+? timing($D)";
+        let lowered = compile(src).unwrap();
+        let res = enumerate_governing(&lowered.queries[0], &lowered.kb);
+        let governing: Vec<&CoreTerm> = res.governing().map(|a| &a.term).collect();
+        assert_eq!(
+            governing.len(),
+            1,
+            "exactly one answer should govern: {res:?}"
+        );
+        // the `specific` tier governs; the `default` is defeated but retained.
+        assert!(matches!(
+            governing[0],
+            CoreTerm::Compound { functor, args }
+                if functor == "timing" && args == &[CoreTerm::Atom("await_culture".into())]
+        ));
+        assert!(!res.has_conflict());
+        let defeated = res
+            .answers
+            .iter()
+            .find(|a| {
+                matches!(&a.term, CoreTerm::Compound { args, .. }
+                if args == &[CoreTerm::Atom("treat_now".into())])
+            })
+            .unwrap();
+        assert!(matches!(defeated.status, GovernStatus::Defeated { .. }));
+    }
+
+    /// Two equal tiers on a functional predicate → an unresolved CONFLICT (no governor).
+    #[test]
+    fn equal_tiers_on_a_functional_predicate_conflict() {
+        use logic_engine::enumerate_governing;
+        let prog = "\
+functional pick(x)
+relate gate(t)
+rule { head: pick(a) when: gate(t) priority: authoritative }
+rule { head: pick(b) when: gate(t) priority: authoritative }
+? pick($X)";
+        let lowered = compile(prog).unwrap();
+        let res = enumerate_governing(&lowered.queries[0], &lowered.kb);
+        assert!(
+            res.has_conflict(),
+            "equal tiers must conflict, not silently pick: {res:?}"
+        );
+        assert_eq!(res.governing().count(), 0);
+    }
+
+    /// A non-functional predicate is unaffected — every derivation governs (back-compat).
+    #[test]
+    fn priority_without_functional_leaves_every_answer_governing() {
+        use logic_engine::enumerate_governing;
+        let prog = "\
+relate gate(t)
+rule { head: note(a) when: gate(t) priority: specific }
+rule { head: note(b) when: gate(t) priority: default }
+? note($X)";
+        let lowered = compile(prog).unwrap();
+        let res = enumerate_governing(&lowered.queries[0], &lowered.kb);
+        assert_eq!(res.governing().count(), 2, "non-functional → both govern");
+        assert!(!res.has_conflict());
+    }
+
+    /// An unknown priority tier is a clean lowering error, not a silent default.
+    #[test]
+    fn unknown_priority_tier_is_rejected() {
+        let err =
+            compile("relate g(t)\nrule { head: h(a) when: g(t) priority: urgent }").unwrap_err();
+        assert!(
+            format!("{err:?}").contains("UnknownPriorityTier"),
+            "expected UnknownPriorityTier, got {err:?}"
+        );
     }
 }


### PR DESCRIPTION
The author-facing **surface syntax** for the merged ADJ73 engine core (logic-engine 0.18). Rulebooks can now declare defeasible precedence directly instead of only via the Rust API:

```
functional timing(decision)
rule { head: timing(await_culture) when: stable_routine_pending(yes) priority: specific }
rule { head: timing(treat_now)     when: stable_routine_pending(yes) priority: default  }
? timing($D)        % → timing(await_culture) governs; the default is defeated but retained
```

- **Grammar:** `functional_decl = "functional" term` added to `statement`; `rule_decl` gains `[ "priority" COLON IDENT ]`. `functional`/`priority` are IDENT-matched literals (no new lexer tokens); `_parser_grammar.rs`/`_lexer_grammar.rs` regenerated.
- **AST:** `Statement::Functional { functor, arity }`; `Statement::Rule` gains `priority: Option<String>`.
- **Lower:** `functional` → `declare_functional`; tier → `Priority::{Default,Specific,Authoritative,Mandatory}` via `with_priority`; unknown tier → `LowerError::UnknownPriorityTier` (clean diagnostic, never a silent default).

## Verification

71 adj-lang tests pass incl. **4 new PR-C tests** that compile the surface and run the full path **parse → lower → `enumerate_governing`**: higher tier governs; equal tiers conflict (no governor); a non-functional predicate is unaffected (back-compat); unknown tier rejected. `adj-lang-cli` + `adjudication-connector` build; security review passed.

Unblocks **PR-D** (`decide_timing` → ADJ on this engine). Next slice is **PR-3** (adj-lang-cli `governing` render); the CLI's existing `decide`/recall paths are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)