### PR TITLE
feat(adj-lang-cli): governing output section — defeasible precedence (ADJ73 PR-3)

### DIFF
--- a/code/packages/rust/adj-lang-cli/CHANGELOG.md
+++ b/code/packages/rust/adj-lang-cli/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## [0.7.0] - 2026-06-16 — `governing` section: defeasible precedence output (ADJ73 PR-3)
+
+### Added
+
+- **`"governing"`** output section, emitted for each `$variable` binding query alongside
+  `"recall"`. Runs `logic_engine::enumerate_governing` and renders every distinct answer with
+  its precedence verdict: `status` ∈ `governing` | `defeated` (+ `defeated_by`) | `conflict_peer`,
+  plus its `standing` (`asserted` for a fact, else the rule's tier) and `bindings` + ground
+  `term`. A top-level `has_conflict` flags an unresolved tie. 0 answer-time model calls.
+- For a predicate **not** declared `functional`, every answer is `governing` (mirrors `recall`)
+  — the precedence-resolved view is back-compatible. For a functional predicate with
+  `priority:` tiers it shows the override chain (the Python runtime reads this to get the
+  governing decision — the enabler for the MYCIN `decide_timing` → ADJ refactor).
+
+### Tests
+
+- `tests/governing_e2e.rs`: the section tags every binding answer (non-functional baseline);
+  it is absent for a ground hypothesis query. The functional-override path is covered at the
+  engine (`logic-engine::govern`) + adj-lang lowering levels (the `functional`/`priority:`
+  surface lands in adj-lang PR-C).
+
 ## [0.6.0] - 2026-06-14 — relational recall: binding-query `"recall"` output (MYCIN-2026 REL-3)
 
 ### Added

--- a/code/packages/rust/adj-lang-cli/Cargo.toml
+++ b/code/packages/rust/adj-lang-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adj-lang-cli"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 description = "Command-line driver for the adj-lang adjudication DSL. Reads a .adj program (rulebook clauses + observe/query), compiles it through the adj-lang frontend, runs the logic-engine differential on the CPU, and emits the decision plus a byte-cited proof DAG as JSON. Argument parsing is declarative via cli-builder. Zero answer-time model calls — this is the CPU-bound reasoner that the MYCIN-2026 prototype shells out to."
 

--- a/code/packages/rust/adj-lang-cli/src/main.rs
+++ b/code/packages/rust/adj-lang-cli/src/main.rs
@@ -35,9 +35,10 @@ use adj_constraint_solver::{
 };
 use adj_lang::{compile_with_imports, decide, ImportLimits, ImportProvider};
 use logic_core::{atom, LogicVar, Term};
+use logic_engine::govern::Standing;
 use logic_engine::{
-    enumerate_all, DerivationOrigin, DifferentialDecision, Fact, KnowledgeBase, LRAggregateResult,
-    Provenance, TrustTier,
+    enumerate_all, enumerate_governing, DerivationOrigin, DifferentialDecision, Fact, GovernStatus,
+    KnowledgeBase, LRAggregateResult, Provenance, TrustTier,
 };
 
 const SPEC: &str = r#"{
@@ -465,6 +466,20 @@ fn main() -> ExitCode {
         format!(",\"recall\":[{}]", recall.join(","))
     };
 
+    // ADJ73 governance: the precedence-resolved view of each binding query — every answer
+    // tagged governing / defeated(by) / conflict_peer. For non-functional predicates this
+    // mirrors `recall` (all governing); for a functional predicate with `priority:` tiers it
+    // shows the override chain. 0 answer-time model calls.
+    let governing: Vec<String> = binding_queries
+        .iter()
+        .map(|q| governing_json(q, &lowered.kb))
+        .collect();
+    let governing_section = if governing.is_empty() {
+        String::new()
+    } else {
+        format!(",\"governing\":[{}]", governing.join(","))
+    };
+
     // Render the constraint sections from the outcomes computed above (the
     // solvers are not re-run). Absent a constraint system / `check` / objective,
     // the respective key is omitted entirely.
@@ -482,14 +497,15 @@ fn main() -> ExitCode {
     };
 
     println!(
-        "{{\"queries\":[{}],\"ranked\":[{}],\"decision\":{}{}{}{}{}}}",
+        "{{\"queries\":[{}],\"ranked\":[{}],\"decision\":{}{}{}{}{}{}}}",
         queries.join(","),
         ranked.join(","),
         decision,
         solve_section,
         check_section,
         optimize_section,
-        recall_section
+        recall_section,
+        governing_section
     );
     ExitCode::SUCCESS
 }
@@ -562,6 +578,67 @@ fn recall_json(query: &Term, kb: &KnowledgeBase) -> String {
         esc(&format!("{}", query)),
         answers.join(","),
         dag.proofs.is_empty()
+    )
+}
+
+/// Render the ADJ73 *governance* of a binding query (defeasible precedence): every distinct
+/// answer tagged `governing` / `defeated` (by which term) / `conflict_peer`, plus its precedence
+/// standing. For a predicate that is NOT declared `functional`, every answer is `governing`
+/// (no conflict) — so this section is the precedence-resolved view, alongside the raw `recall`.
+/// 0 answer-time model calls (pure SLD + a resolution post-pass over the grounded graph).
+fn governing_json(query: &Term, kb: &KnowledgeBase) -> String {
+    let res = enumerate_governing(query, kb);
+    let mut vars: Vec<LogicVar> = Vec::new();
+    collect_vars(query, &mut vars);
+    let answers: Vec<String> = res
+        .answers
+        .iter()
+        .map(|a| {
+            // Bindings come from one representative proof of this answer (all proofs of a
+            // distinct answer share the same variable bindings by construction).
+            let binds: Vec<String> = a
+                .proof_indices
+                .first()
+                .map(|&i| {
+                    let proof = &res.dag.proofs[i];
+                    vars.iter()
+                        .map(|v| {
+                            format!(
+                                "\"{}\":\"{}\"",
+                                esc(&v.display_name.clone().unwrap_or_default()),
+                                esc(&format!("{}", proof.bindings.walk_var(v)))
+                            )
+                        })
+                        .collect()
+                })
+                .unwrap_or_default();
+            let (status, defeated_by) = match &a.status {
+                GovernStatus::Governing => ("governing", String::new()),
+                GovernStatus::ConflictPeer => ("conflict_peer", String::new()),
+                GovernStatus::Defeated { by } => (
+                    "defeated",
+                    format!(",\"defeated_by\":\"{}\"", esc(&format!("{}", by))),
+                ),
+            };
+            let standing = match a.priority {
+                Standing::Asserted => "asserted".to_string(),
+                Standing::Rule(p) => format!("{p:?}").to_lowercase(),
+            };
+            format!(
+                "{{\"term\":\"{}\",\"bindings\":{{{}}},\"status\":\"{}\",\"standing\":\"{}\"{}}}",
+                esc(&format!("{}", a.term)),
+                binds.join(","),
+                status,
+                standing,
+                defeated_by
+            )
+        })
+        .collect();
+    format!(
+        "{{\"query\":\"{}\",\"answers\":[{}],\"has_conflict\":{}}}",
+        esc(&format!("{}", query)),
+        answers.join(","),
+        res.has_conflict()
     )
 }
 

--- a/code/packages/rust/adj-lang-cli/tests/governing_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/governing_e2e.rs
@@ -1,0 +1,63 @@
+//! End-to-end test for the ADJ73 `governing` section (defeasible precedence) through the
+//! built CLI binary. A binding query gets a precedence-resolved view alongside `recall`:
+//! every distinct answer tagged `governing` / `defeated` / `conflict_peer` + its standing.
+//!
+//! NOTE: the `functional` / `priority:` SURFACE syntax (adj-lang PR-C) is a separate PR; until
+//! it merges this binary can't parse those, so this test covers the engine-backed render for a
+//! non-functional predicate (every answer governs — the back-compat baseline). The functional
+//! override path is proven at the engine + adj-lang lowering level (logic-engine `govern` tests
+//! + adj-lang `functional_and_priority_tiers_resolve_a_conflict`).
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_gov_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &PathBuf) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+#[test]
+fn governing_section_tags_every_binding_answer() {
+    let dir = scratch("basic");
+    std::fs::write(
+        dir.join("case.adj"),
+        "relate deficient_in(tay_sachs, hexosaminidase_a) trust authoritative\n\
+         relate deficient_in(gaucher, glucocerebrosidase) trust authoritative\n\
+         ? deficient_in($Disease, $Enzyme)\n",
+    )
+    .unwrap();
+    let (ok, out) = run(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}");
+    // The governing section is present and parallels recall.
+    assert!(out.contains("\"governing\""), "has a governing section: {out}");
+    // A non-functional predicate ⇒ every answer governs, none defeated, no conflict.
+    assert!(out.contains("\"status\":\"governing\""), "answers are governing: {out}");
+    assert!(!out.contains("\"status\":\"defeated\""), "nothing defeated: {out}");
+    assert!(out.contains("\"has_conflict\":false"), "no conflict: {out}");
+    // Bindings + the ground answer term are carried.
+    assert!(out.contains("\"Enzyme\":\"hexosaminidase_a\""), "carries bindings: {out}");
+    assert!(
+        out.contains("deficient_in(tay_sachs, hexosaminidase_a)"),
+        "carries the ground answer term: {out}"
+    );
+}
+
+#[test]
+fn governing_section_absent_when_no_binding_query() {
+    let dir = scratch("none");
+    // A ground hypothesis query (no `$var`) is not a binding query → no governing section.
+    std::fs::write(dir.join("case.adj"), "prior 0.1 for acs\n? acs\n").unwrap();
+    let (ok, out) = run(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}");
+    assert!(!out.contains("\"governing\""), "no governing section for a ground query: {out}");
+}


### PR DESCRIPTION
The CLI now emits a **`"governing"`** section for each `$variable` binding query, alongside `"recall"`: it runs `logic_engine::enumerate_governing` and renders every distinct answer with its precedence verdict.

```json
"governing": [{"query":"timing(D)","answers":[
  {"term":"timing(await_culture)","bindings":{"D":"await_culture"},"status":"governing","standing":"specific"},
  {"term":"timing(treat_now)","bindings":{"D":"treat_now"},"status":"defeated","standing":"default","defeated_by":"timing(await_culture)"}
],"has_conflict":false}]
```

- `status` ∈ `governing` | `defeated` (+ `defeated_by`) | `conflict_peer`; `standing` = `asserted` (fact) or the rule's tier; `has_conflict` flags an unresolved tie. **0 answer-time model calls.**
- **This is what the Python runtime reads** to get the precedence-resolved decision — the enabler for the MYCIN `decide_timing` → ADJ refactor (PR-D).
- Non-functional predicate ⇒ every answer `governing` (mirrors `recall` — back-compat); functional + `priority:` ⇒ the override chain.

## Verification

`tests/governing_e2e.rs` (2): the section tags every binding answer (non-functional baseline) and is absent for a ground hypothesis query; 30+ existing CLI tests pass. The functional-override path is proven at the engine (`logic-engine::govern`) + adj-lang lowering levels; the `functional`/`priority:` **surface** lands in adj-lang [#6072](https://github.com/adhithyan15/coding-adventures/pull/6072) (PR-C). Security review passed. adj-lang-cli 0.7.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)