### PR TITLE
feat(MA-4): Maxima — a macsyma-runtime reuse (Wave 1 of the historical-math roadmap)

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -209,6 +209,8 @@ members = [
     "matlab-repl",
     "octave-runtime",
     "octave-repl",
+    "maxima-runtime",
+    "maxima-repl",
     "logic-gates",
     "logic-core",
     "lookup-core",

--- a/code/packages/rust/maxima-repl/BUILD
+++ b/code/packages/rust/maxima-repl/BUILD
@@ -1,0 +1,1 @@
+cargo test -p coding-adventures-maxima-repl -- --nocapture

--- a/code/packages/rust/maxima-repl/BUILD_windows
+++ b/code/packages/rust/maxima-repl/BUILD_windows
@@ -1,0 +1,1 @@
+cargo test -p coding-adventures-maxima-repl -- --nocapture

--- a/code/packages/rust/maxima-repl/CHANGELOG.md
+++ b/code/packages/rust/maxima-repl/CHANGELOG.md
@@ -1,0 +1,23 @@
+# Changelog — coding-adventures-maxima-repl
+
+All notable changes to this package are documented here. The format follows
+[Keep a Changelog](https://keepachangelog.com/), and this project adheres to
+Semantic Versioning.
+
+## [0.1.0] — 2026-06-16
+
+### Added
+
+- Initial release. The interactive `maxima` binary and the
+  `coding_adventures_maxima_repl::run` driver.
+- `MaximaRepl` over a persistent `MaximaSession`: `(%i«n») ` / `... ` prompts,
+  line continuation until a `;`/`$` statement terminator (tracked outside `"`
+  strings, with `\"` escapes, and only at bracket depth 0 so a `;` inside a
+  string or a paren group does not terminate early), `quit;`/`quit()`/`exit`/EOF
+  handling, and non-fatal error reporting (a surface error prints and the session
+  continues).
+
+### Notes
+
+- The symbolic sibling of `octave-repl`. The only Maxima-specific logic is the
+  `;`/`$`-terminator continuation rule. See `code/specs/MA03-maxima-language.md`.

--- a/code/packages/rust/maxima-repl/CHANGELOG.md
+++ b/code/packages/rust/maxima-repl/CHANGELOG.md
@@ -12,10 +12,15 @@ Semantic Versioning.
   `coding_adventures_maxima_repl::run` driver.
 - `MaximaRepl` over a persistent `MaximaSession`: `(%i«n») ` / `... ` prompts,
   line continuation until a `;`/`$` statement terminator (tracked outside `"`
-  strings, with `\"` escapes, and only at bracket depth 0 so a `;` inside a
-  string or a paren group does not terminate early), `quit;`/`quit()`/`exit`/EOF
-  handling, and non-fatal error reporting (a surface error prints and the session
-  continues).
+  strings — with `\"` escapes — and outside `/* */` comments, and only at bracket
+  depth 0, so a `;` inside a string, comment, or paren group does not terminate
+  early, and a stray `"` in a comment does not wedge the prompt),
+  `quit;`/`quit()`/`exit`/EOF handling, and non-fatal error reporting (a surface
+  error prints and the session continues).
+- The accumulation buffer is size-capped (at the runtime's `MAX_INPUT_LEN`): an
+  input that never satisfies the continuation rule is submitted once it exceeds
+  the cap (yielding a clean "too large" error) instead of buffering unbounded
+  memory.
 
 ### Notes
 

--- a/code/packages/rust/maxima-repl/Cargo.toml
+++ b/code/packages/rust/maxima-repl/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "coding-adventures-maxima-repl"
+version = "0.1.0"
+edition = "2021"
+description = "Interactive REPL and `maxima` binary for the Maxima CAS"
+license = "MIT"
+
+[dependencies]
+coding-adventures-maxima-runtime = { path = "../maxima-runtime" }
+
+[[bin]]
+name = "maxima"
+path = "src/main.rs"

--- a/code/packages/rust/maxima-repl/README.md
+++ b/code/packages/rust/maxima-repl/README.md
@@ -1,0 +1,53 @@
+# coding-adventures-maxima-repl
+
+The interactive **`maxima`** binary — a Read-Eval-Print loop for the Maxima CAS.
+
+`maxima-repl` wraps a persistent
+[`MaximaSession`](../maxima-runtime/README.md) (which reuses the whole Macsyma
+symbolic stack) and adds the console behaviours:
+
+- **`(%i«n») ` / `... ` prompts** — the input prompt shows the next input index;
+  the continuation prompt appears while a statement spans multiple lines.
+- **Line continuation** — Maxima statements end with a terminator: `;` displays
+  the result, `$` suppresses it. The REPL keeps reading physical lines until it
+  sees a terminator *outside a string* with all brackets balanced.
+- **Quit / EOF** — `quit;`, `quit()`, `exit`, or Ctrl-D end the session.
+- **Non-fatal errors** — a surface error prints and the session continues.
+
+It is the symbolic sibling of `octave-repl`; the only Maxima-specific part is the
+`;`/`$`-terminator continuation rule (vs Octave's `end`/`endX` block rule),
+because Maxima is statement-terminated at the REPL surface.
+
+## Running
+
+```
+cargo run -p coding-adventures-maxima-repl --bin maxima
+```
+
+```text
+Maxima (on the Macsyma symbolic stack) — end statements with ; or $, type quit; to exit.
+(%i1) diff(x^3, x);
+(%o1) 3*x^2
+(%i2) x : 5$
+(%i3) x + 1;
+(%o3) 6
+(%i4) quit;
+```
+
+## Where it fits in the stack
+
+```
+maxima-repl  ← you are here   (the `maxima` binary + continuation logic)
+    │
+    ▼
+maxima-runtime  (MaximaSession facade)
+    │
+    ▼
+macsyma-runtime · symbolic-vm · cas-* crates
+```
+
+## Testing
+
+```
+cargo test -p coding-adventures-maxima-repl
+```

--- a/code/packages/rust/maxima-repl/required_capabilities.json
+++ b/code/packages/rust/maxima-repl/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "rust/maxima-repl",
+  "capabilities": ["stdio"],
+  "justification": "An interactive console: the `maxima` binary reads Maxima source from stdin and writes results to stdout. No filesystem, network, or process access beyond standard streams."
+}

--- a/code/packages/rust/maxima-repl/src/lib.rs
+++ b/code/packages/rust/maxima-repl/src/lib.rs
@@ -1,0 +1,254 @@
+//! # Maxima REPL — an interactive Read-Eval-Print loop for the Maxima CAS.
+//!
+//! [`MaximaRepl`] wraps a persistent [`MaximaSession`] (which reuses the entire
+//! Macsyma symbolic stack) and adds the console behaviours Maxima users expect:
+//!
+//! * **`(%i«n») ` / `... ` prompts** — the input prompt shows the next input
+//!   index; the continuation prompt is shown while a statement spans lines.
+//! * **Line continuation** — Maxima statements end with a terminator: `;` to
+//!   display the result or `$` to suppress it. The REPL keeps reading physical
+//!   lines until it sees a terminator *outside a string* with all brackets
+//!   balanced, then evaluates the whole buffer at once.
+//! * **Quit / EOF** — `quit;`, `quit()`, `exit`, or Ctrl-D end the session.
+//! * **Non-fatal errors** — a surface error prints and the session continues.
+//!
+//! This mirrors `octave-repl`'s single-threaded driver; the only Maxima-specific
+//! part is the `;`/`$`-terminator continuation rule (vs Octave's `end`/`endX`
+//! block rule), because Maxima is statement-terminated, not block-structured at
+//! the REPL surface.
+
+use coding_adventures_maxima_runtime::MaximaSession;
+use std::io::{BufRead, Write};
+
+/// What the REPL should do after being fed one physical line.
+#[derive(Debug, PartialEq, Eq)]
+pub enum ReplResponse {
+    /// A complete statement (or batch) was evaluated; here is its echo.
+    Output(String),
+    /// The buffer is not yet a complete statement — read another line.
+    NeedMore,
+    /// The user asked to leave.
+    Quit,
+}
+
+/// A persistent interactive Maxima session.
+pub struct MaximaRepl {
+    session: MaximaSession,
+    buffer: String,
+    /// The 1-based input index shown in the `(%i«n»)` prompt. It advances once
+    /// per *submitted* statement batch, mirroring Maxima's `%i` counter.
+    input_index: usize,
+}
+
+impl Default for MaximaRepl {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl MaximaRepl {
+    pub fn new() -> Self {
+        MaximaRepl {
+            session: MaximaSession::new(),
+            buffer: String::new(),
+            input_index: 1,
+        }
+    }
+
+    /// The prompt to print before reading the next physical line: the input
+    /// prompt when starting a fresh statement, the continuation prompt while a
+    /// statement is still open.
+    pub fn prompt(&self) -> String {
+        if self.buffer.is_empty() {
+            format!("(%i{}) ", self.input_index)
+        } else {
+            "... ".to_string()
+        }
+    }
+
+    /// Feed one physical input line (without its trailing newline).
+    pub fn feed(&mut self, line: &str) -> ReplResponse {
+        // Quit words are only recognised at the start of a fresh statement, so
+        // an identifier like `exit` mid-expression is never hijacked. (Maxima
+        // spells these as functions; we also accept the bare words.)
+        if self.buffer.is_empty() {
+            match line.trim() {
+                "quit" | "quit;" | "quit()" | "quit();" | "exit" | "exit;" | "exit()"
+                | "exit();" => return ReplResponse::Quit,
+                _ => {}
+            }
+        }
+        self.buffer.push_str(line);
+        self.buffer.push('\n');
+
+        if is_incomplete(&self.buffer) {
+            return ReplResponse::NeedMore;
+        }
+
+        let src = std::mem::take(&mut self.buffer);
+        if src.trim().is_empty() {
+            return ReplResponse::Output(String::new());
+        }
+        self.input_index += 1;
+        match self.session.feed(&src) {
+            Ok(text) => ReplResponse::Output(text),
+            Err(e) => ReplResponse::Output(format!("Error: {e}\n")),
+        }
+    }
+
+    /// Is a statement currently spanning multiple lines?
+    pub fn is_continuing(&self) -> bool {
+        !self.buffer.is_empty()
+    }
+}
+
+/// Is the accumulated source *incomplete* — i.e. should the REPL keep reading?
+///
+/// A Maxima statement is complete once a terminator (`;` or `$`) has appeared
+/// **outside a string** with bracket/paren/brace depth back to zero. So this
+/// returns `true` while either:
+///
+/// * brackets are still open (`depth > 0`), or
+/// * a `"`-string is unterminated, or
+/// * no `;`/`$` terminator has yet been seen outside a string.
+///
+/// `"`-delimited strings are tracked (with `\"` escapes) so a `;` *inside* a
+/// string — `s : "a;b";` — is not mistaken for a terminator.
+fn is_incomplete(src: &str) -> bool {
+    let mut depth: i32 = 0;
+    let mut in_string = false;
+    let mut escaped = false;
+    let mut saw_terminator = false;
+
+    for ch in src.chars() {
+        if in_string {
+            if escaped {
+                escaped = false;
+            } else if ch == '\\' {
+                escaped = true;
+            } else if ch == '"' {
+                in_string = false;
+            }
+            continue;
+        }
+        match ch {
+            '"' => in_string = true,
+            '(' | '[' | '{' => depth += 1,
+            ')' | ']' | '}' => depth -= 1,
+            ';' | '$' if depth <= 0 => saw_terminator = true,
+            _ => {}
+        }
+    }
+
+    in_string || depth > 0 || !saw_terminator
+}
+
+/// Drive a full interactive Maxima session over the given reader and writer.
+pub fn run<R: BufRead, W: Write>(mut reader: R, mut writer: W) -> std::io::Result<()> {
+    let mut repl = MaximaRepl::new();
+    writeln!(
+        writer,
+        "Maxima (on the Macsyma symbolic stack) — end statements with ; or $, type quit; to exit."
+    )?;
+
+    loop {
+        write!(writer, "{}", repl.prompt())?;
+        writer.flush()?;
+
+        let mut line = String::new();
+        if reader.read_line(&mut line)? == 0 {
+            writeln!(writer)?;
+            break;
+        }
+        let line = line.strip_suffix('\n').unwrap_or(&line);
+        let line = line.strip_suffix('\r').unwrap_or(line);
+
+        match repl.feed(line) {
+            ReplResponse::Output(text) => {
+                write!(writer, "{text}")?;
+                writer.flush()?;
+            }
+            ReplResponse::NeedMore => {}
+            ReplResponse::Quit => break,
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn continues_until_a_semicolon_terminator() {
+        let mut r = MaximaRepl::new();
+        assert_eq!(r.feed("diff(x^3,"), ReplResponse::NeedMore); // open paren
+        assert_eq!(r.feed("  x)"), ReplResponse::NeedMore); // balanced, but no ;/$
+        assert!(matches!(r.feed(";"), ReplResponse::Output(t) if t.contains('3')));
+    }
+
+    #[test]
+    fn dollar_is_also_a_terminator_and_suppresses() {
+        let mut r = MaximaRepl::new();
+        // `x : 5$` is complete (ends in $) and prints nothing.
+        assert_eq!(r.feed("x : 5$"), ReplResponse::Output(String::new()));
+        // The binding persists across statements.
+        assert!(matches!(r.feed("x + 1;"), ReplResponse::Output(t) if t.contains('6')));
+    }
+
+    #[test]
+    fn a_semicolon_inside_a_string_is_not_a_terminator() {
+        let mut r = MaximaRepl::new();
+        // The ; is inside the string, so the statement is still open until the
+        // closing quote and the real terminator.
+        assert_eq!(r.feed("s : \"a;b\""), ReplResponse::NeedMore);
+        assert!(matches!(r.feed(";"), ReplResponse::Output(_)));
+    }
+
+    #[test]
+    fn prompts_switch_between_input_and_continuation() {
+        let mut r = MaximaRepl::new();
+        assert_eq!(r.prompt(), "(%i1) ");
+        assert_eq!(r.feed("factor("), ReplResponse::NeedMore);
+        assert_eq!(r.prompt(), "... ", "continuation prompt while open");
+        assert!(matches!(r.feed("x^2 - 1);"), ReplResponse::Output(_)));
+        assert_eq!(r.prompt(), "(%i2) ", "input index advanced");
+    }
+
+    #[test]
+    fn quit_words_leave_the_session() {
+        assert_eq!(MaximaRepl::new().feed("quit;"), ReplResponse::Quit);
+        assert_eq!(MaximaRepl::new().feed("quit()"), ReplResponse::Quit);
+        assert_eq!(MaximaRepl::new().feed("exit"), ReplResponse::Quit);
+    }
+
+    #[test]
+    fn an_error_is_printed_and_the_session_survives() {
+        let mut r = MaximaRepl::new();
+        assert!(matches!(r.feed("@#$;"), ReplResponse::Output(t) if t.contains("Error")));
+        // still usable afterwards
+        assert!(matches!(r.feed("1 + 1;"), ReplResponse::Output(t) if t.contains('2')));
+    }
+
+    #[test]
+    fn run_drives_a_session_to_eof() {
+        let input = b"1 + 2*3;\nquit;\n" as &[u8];
+        let mut output = Vec::new();
+        run(input, &mut output).unwrap();
+        let text = String::from_utf8(output).unwrap();
+        assert!(text.contains('7'), "expected 7 in session: {text:?}");
+        assert!(
+            text.contains("(%i1)"),
+            "expected the input prompt: {text:?}"
+        );
+    }
+
+    #[test]
+    fn run_handles_bare_eof_without_quit() {
+        // No quit; just EOF — the loop should end cleanly.
+        let input = b"2 + 2;\n" as &[u8];
+        let mut output = Vec::new();
+        run(input, &mut output).unwrap();
+        assert!(String::from_utf8(output).unwrap().contains('4'));
+    }
+}

--- a/code/packages/rust/maxima-repl/src/lib.rs
+++ b/code/packages/rust/maxima-repl/src/lib.rs
@@ -7,8 +7,10 @@
 //!   index; the continuation prompt is shown while a statement spans lines.
 //! * **Line continuation** — Maxima statements end with a terminator: `;` to
 //!   display the result or `$` to suppress it. The REPL keeps reading physical
-//!   lines until it sees a terminator *outside a string* with all brackets
-//!   balanced, then evaluates the whole buffer at once.
+//!   lines until it sees a terminator *outside a string or `/* */` comment* with
+//!   all brackets balanced, then evaluates the whole buffer at once. The
+//!   accumulation buffer is size-capped so an input that never terminates cannot
+//!   grow memory without bound.
 //! * **Quit / EOF** — `quit;`, `quit()`, `exit`, or Ctrl-D end the session.
 //! * **Non-fatal errors** — a surface error prints and the session continues.
 //!
@@ -17,7 +19,7 @@
 //! block rule), because Maxima is statement-terminated, not block-structured at
 //! the REPL surface.
 
-use coding_adventures_maxima_runtime::MaximaSession;
+use coding_adventures_maxima_runtime::{MaximaSession, MAX_INPUT_LEN};
 use std::io::{BufRead, Write};
 
 /// What the REPL should do after being fed one physical line.
@@ -81,7 +83,13 @@ impl MaximaRepl {
         self.buffer.push_str(line);
         self.buffer.push('\n');
 
-        if is_incomplete(&self.buffer) {
+        // Bound the accumulation buffer: a stream that never satisfies the
+        // continuation rule (an unterminated string/comment, or endless open
+        // brackets) must not grow memory without limit. Once we are over the
+        // size the session itself would reject anyway, stop waiting and submit
+        // it so `feed` returns the clean "input too large" error and the buffer
+        // is reset — rather than buffering unbounded input.
+        if self.buffer.len() <= MAX_INPUT_LEN && is_incomplete(&self.buffer) {
             return ReplResponse::NeedMore;
         }
 
@@ -109,18 +117,35 @@ impl MaximaRepl {
 /// returns `true` while either:
 ///
 /// * brackets are still open (`depth > 0`), or
-/// * a `"`-string is unterminated, or
-/// * no `;`/`$` terminator has yet been seen outside a string.
+/// * a `"`-string or a `/* */` comment is unterminated, or
+/// * no `;`/`$` terminator has yet been seen outside a string/comment.
 ///
-/// `"`-delimited strings are tracked (with `\"` escapes) so a `;` *inside* a
-/// string — `s : "a;b";` — is not mistaken for a terminator.
+/// Strings (`"…"`, with `\"` escapes) and C-style `/* … */` comments are tracked
+/// exactly as the macsyma lexer treats them — non-nesting comments, and a `"`
+/// only opens a string outside a comment — so a `;` *inside* either (`s :
+/// "a;b";`, or `/* end; */ x;`) is not mistaken for a terminator, and a stray
+/// `"` inside a comment does not wedge the prompt into a phantom string. This is
+/// only a continuation heuristic: whatever is finally submitted still passes
+/// through `MaximaSession::feed`, which re-lexes with the real lexer and applies
+/// the size/complexity guards, so a mismatch here can never crash — at worst it
+/// submits early or asks for one more line.
 fn is_incomplete(src: &str) -> bool {
     let mut depth: i32 = 0;
     let mut in_string = false;
+    let mut in_comment = false;
     let mut escaped = false;
     let mut saw_terminator = false;
 
-    for ch in src.chars() {
+    let mut chars = src.chars().peekable();
+    while let Some(ch) = chars.next() {
+        if in_comment {
+            // A non-nesting `/* … */` comment closes at the first `*/`.
+            if ch == '*' && chars.peek() == Some(&'/') {
+                chars.next();
+                in_comment = false;
+            }
+            continue;
+        }
         if in_string {
             if escaped {
                 escaped = false;
@@ -132,6 +157,11 @@ fn is_incomplete(src: &str) -> bool {
             continue;
         }
         match ch {
+            // `/*` opens a comment (only outside a string — handled above).
+            '/' if chars.peek() == Some(&'*') => {
+                chars.next();
+                in_comment = true;
+            }
             '"' => in_string = true,
             '(' | '[' | '{' => depth += 1,
             ')' | ']' | '}' => depth -= 1,
@@ -140,7 +170,7 @@ fn is_incomplete(src: &str) -> bool {
         }
     }
 
-    in_string || depth > 0 || !saw_terminator
+    in_string || in_comment || depth > 0 || !saw_terminator
 }
 
 /// Drive a full interactive Maxima session over the given reader and writer.
@@ -203,6 +233,40 @@ mod tests {
         // closing quote and the real terminator.
         assert_eq!(r.feed("s : \"a;b\""), ReplResponse::NeedMore);
         assert!(matches!(r.feed(";"), ReplResponse::Output(_)));
+    }
+
+    #[test]
+    fn a_terminator_inside_a_comment_is_not_a_terminator() {
+        // `/* … ; … */` — the `;` is inside a block comment, so the statement is
+        // still open until the real terminator after the comment closes.
+        let mut r = MaximaRepl::new();
+        assert_eq!(r.feed("x : 1 /* end; here */"), ReplResponse::NeedMore);
+        assert!(matches!(r.feed("+ 2;"), ReplResponse::Output(t) if t.contains('3')));
+    }
+
+    #[test]
+    fn a_quote_inside_a_comment_does_not_wedge_the_prompt() {
+        // A lone `"` inside a comment must not flip the continuation logic into a
+        // never-ending "string" — the statement completes at its real `;`.
+        let mut r = MaximaRepl::new();
+        assert!(
+            matches!(r.feed("/* a \" quote */ 2 + 2;"), ReplResponse::Output(t) if t.contains('4'))
+        );
+    }
+
+    #[test]
+    fn an_unterminated_buffer_is_submitted_once_it_passes_the_size_cap() {
+        // A never-closing bracket run must not buffer unbounded memory: once the
+        // accumulation exceeds the size cap it is submitted and the session
+        // returns the clean "too large" error instead of asking for more forever.
+        let mut r = MaximaRepl::new();
+        let big = "(".repeat(MAX_INPUT_LEN + 16);
+        match r.feed(&big) {
+            ReplResponse::Output(t) => assert!(t.contains("too large"), "got {t:?}"),
+            other => panic!("expected an over-size submission, got {other:?}"),
+        }
+        // The buffer was reset, so the prompt is back to a fresh input prompt.
+        assert_eq!(r.prompt(), "(%i2) ");
     }
 
     #[test]

--- a/code/packages/rust/maxima-repl/src/main.rs
+++ b/code/packages/rust/maxima-repl/src/main.rs
@@ -1,0 +1,18 @@
+//! The `maxima` binary — an interactive prompt for the Maxima CAS.
+//!
+//! Reads one line at a time (continuing across open brackets and unterminated
+//! statements until a `;` or `$` terminator), evaluates over the reused Macsyma
+//! symbolic stack, and echoes each displayed result as `(%o«n») «value»`. Type
+//! `quit;`/`exit` (or Ctrl-D) to leave. All logic lives in
+//! [`coding_adventures_maxima_repl::run`].
+
+use std::io;
+
+fn main() {
+    let stdin = io::stdin();
+    let stdout = io::stdout();
+    if let Err(e) = coding_adventures_maxima_repl::run(stdin.lock(), stdout.lock()) {
+        eprintln!("maxima: I/O error: {e}");
+        std::process::exit(1);
+    }
+}

--- a/code/packages/rust/maxima-runtime/BUILD
+++ b/code/packages/rust/maxima-runtime/BUILD
@@ -1,0 +1,1 @@
+cargo test -p coding-adventures-maxima-runtime -- --nocapture

--- a/code/packages/rust/maxima-runtime/BUILD_windows
+++ b/code/packages/rust/maxima-runtime/BUILD_windows
@@ -1,0 +1,1 @@
+cargo test -p coding-adventures-maxima-runtime -- --nocapture

--- a/code/packages/rust/maxima-runtime/CHANGELOG.md
+++ b/code/packages/rust/maxima-runtime/CHANGELOG.md
@@ -1,0 +1,29 @@
+# Changelog — coding-adventures-maxima-runtime
+
+All notable changes to this package are documented here. The format follows
+[Keep a Changelog](https://keepachangelog.com/), and this project adheres to
+Semantic Versioning.
+
+## [0.1.0] — 2026-06-16
+
+### Added
+
+- Initial release. `MaximaSession` — a presentation façade that wraps a
+  `macsyma_runtime::MacsymaSession` and exposes Maxima's string-in/string-out
+  console contract. `feed(src)` evaluates a chunk of Maxima source and returns
+  one `(%o«n») «text»` echo line per **displayed** result (`;` displays, `$`
+  suppresses but still advances the `%o` history counter). A surface/parse error
+  is returned as `Err(String)` via the macsyma evaluator's `Display`.
+- One-shot `eval(src)` convenience on a fresh session.
+- **Panic-safety at the trust boundary:** `feed` runs evaluation inside
+  `catch_unwind`, converting the underlying `macsyma-lexer`'s panic-on-bad-input
+  into a clean `Err` so a single stray character cannot abort an interactive
+  session. Documented as a defensive shim pending an upstream lexer fix.
+
+### Notes
+
+- Maxima is the GPL descendant of DOE Macsyma with an identical algebraic surface
+  for the supported subset, so this crate adds **no evaluation logic of its own**
+  — it reuses the entire macsyma frontend/VM/`cas-*` stack unchanged (the
+  symbolic-CAS analogue of Octave-over-MATLAB). It therefore inherits exactly
+  macsyma-runtime's evaluation power. See `code/specs/MA03-maxima-language.md`.

--- a/code/packages/rust/maxima-runtime/CHANGELOG.md
+++ b/code/packages/rust/maxima-runtime/CHANGELOG.md
@@ -15,10 +15,19 @@ Semantic Versioning.
   suppresses but still advances the `%o` history counter). A surface/parse error
   is returned as `Err(String)` via the macsyma evaluator's `Display`.
 - One-shot `eval(src)` convenience on a fresh session.
-- **Panic-safety at the trust boundary:** `feed` runs evaluation inside
-  `catch_unwind`, converting the underlying `macsyma-lexer`'s panic-on-bad-input
-  into a clean `Err` so a single stray character cannot abort an interactive
-  session. Documented as a defensive shim pending an upstream lexer fix.
+- **Robustness at the trust boundary** (`feed` takes arbitrary user text):
+  - *Unwinding panics* — evaluation runs inside `catch_unwind`, converting the
+    underlying `macsyma-lexer`'s panic-on-bad-input into a clean `Err` so a stray
+    character cannot abort the session.
+  - *Stack-overflow from unbounded parser/VM recursion* — deeply nested input
+    (nested `(`, prefix `-` runs, long `1+1+…` chains) would overflow the stack
+    and **abort the process uncatchably**. Guarded by a total-size cap
+    (`MAX_INPUT_LEN`), a per-statement token cap (`MAX_STATEMENT_TOKENS`) counted
+    from the **real macsyma lexer** (so comment/string skip rules can't be used
+    to bypass it), and a large-stack worker thread that also builds the echo, so
+    bounded trees are created and dropped clear of the caller's stack.
+  - *Mutex poisoning* — after any caught panic the wrapped session is rebuilt, so
+    a panic inside a lock-holding macsyma handler can't permanently brick it.
 
 ### Notes
 

--- a/code/packages/rust/maxima-runtime/Cargo.toml
+++ b/code/packages/rust/maxima-runtime/Cargo.toml
@@ -10,3 +10,9 @@ license = "MIT"
 # `macsyma_runtime` while the published package keeps its `coding-adventures-`
 # prefix (the same pattern matlab-runtime uses for array-runtime).
 macsyma_runtime = { package = "coding-adventures-macsyma-runtime", path = "../macsyma-runtime" }
+# The same lexer the macsyma parser consumes. We tokenize once up front (the
+# lexer is iterative, so unlike the parser it cannot stack-overflow) to measure
+# per-statement token counts from the *real* token stream — comments and
+# whitespace already skipped, strings already coalesced — rather than re-deriving
+# the lexical model in the façade (which is bypassable, as a review found).
+macsyma_lexer = { package = "coding-adventures-macsyma-lexer", path = "../macsyma-lexer" }

--- a/code/packages/rust/maxima-runtime/Cargo.toml
+++ b/code/packages/rust/maxima-runtime/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "coding-adventures-maxima-runtime"
+version = "0.1.0"
+edition = "2021"
+description = "Maxima runtime — a thin session facade reusing the Macsyma symbolic stack"
+license = "MIT"
+
+[dependencies]
+# Renamed so the source can refer to the dependency by its short crate name
+# `macsyma_runtime` while the published package keeps its `coding-adventures-`
+# prefix (the same pattern matlab-runtime uses for array-runtime).
+macsyma_runtime = { package = "coding-adventures-macsyma-runtime", path = "../macsyma-runtime" }

--- a/code/packages/rust/maxima-runtime/README.md
+++ b/code/packages/rust/maxima-runtime/README.md
@@ -1,0 +1,72 @@
+# coding-adventures-maxima-runtime
+
+A **Maxima** runtime session, built as a thin reuse of the Macsyma stack.
+
+[Maxima](https://maxima.sourceforge.io/) is the GPL-licensed descendant of DOE
+Macsyma. For the subset we support the two languages share an identical algebraic
+surface, so this crate adds **no interpreter of its own**: a `MaximaSession` owns
+a [`macsyma_runtime::MacsymaSession`] and presents Maxima's string-in/string-out
+console contract over it. The entire pipeline beneath — the `macsyma-lexer` →
+`macsyma-parser` → `macsyma-compiler` frontend, the `symbolic-vm`, and the twenty
+`cas-*` crates — is reused unchanged.
+
+This is the symbolic-CAS analogue of how GNU Octave was delivered as a thin reuse
+of `matlab-runtime`: a second historical language for the cost of a façade plus a
+REPL, because the syntax already matched.
+
+## Where it fits in the stack
+
+```
+maxima-repl  (the `maxima` binary)
+    │
+    ▼
+maxima-runtime  ← you are here   (presentation façade)
+    │
+    ▼
+macsyma-runtime  (MacsymaSession: eval_source → EvalResult)
+    │
+    ▼
+macsyma-lexer / -parser / -compiler · symbolic-vm · cas-* crates
+```
+
+## Usage
+
+```rust
+use coding_adventures_maxima_runtime::{MaximaSession, eval};
+
+// One-shot:
+let echo = eval("diff(x^3, x);").unwrap();
+assert!(echo.contains("3")); // (%o1) 3*x^2
+
+// Persistent session — bindings and %o history carry across calls:
+let mut s = MaximaSession::new();
+assert_eq!(s.feed("x : 5$").unwrap(), "");      // $ suppresses output
+assert!(s.feed("x + 1;").unwrap().contains("6")); // ; displays → (%o2) 6
+```
+
+`feed` returns the console echo: one `(%o«n») «text»` line per **displayed**
+result (a statement terminated by `;`; a `$`-terminated statement runs and
+advances the `%o` counter but prints nothing). A surface/parse error comes back
+as `Err(String)`.
+
+### Panic-safety
+
+The underlying `macsyma-lexer` *panics* on characters it cannot tokenize. Because
+`feed` is a trust boundary over arbitrary user text, it runs the evaluation inside
+`catch_unwind` and converts any panic into a clean `Err` — a stray `@` returns an
+error instead of aborting the session. (The proper upstream fix is for the lexer
+to return a `Result`; this façade is defensive in the meantime.)
+
+## What evaluates
+
+Maxima inherits `macsyma-runtime`'s evaluation power exactly. Today that means
+exact arithmetic, `diff`, `integrate`, `factor`, and `subst` genuinely reduce;
+`expand`/`ratsimp`/`solve`/`limit`/`trig*` parse and echo symbolically until the
+macsyma evaluator grows to reduce them — at which point Maxima inherits it for
+free. See [`MA03-maxima-language.md`](../../../specs/MA03-maxima-language.md).
+
+## Testing
+
+```
+cargo test -p coding-adventures-maxima-runtime
+```

--- a/code/packages/rust/maxima-runtime/README.md
+++ b/code/packages/rust/maxima-runtime/README.md
@@ -49,13 +49,24 @@ result (a statement terminated by `;`; a `$`-terminated statement runs and
 advances the `%o` counter but prints nothing). A surface/parse error comes back
 as `Err(String)`.
 
-### Panic-safety
+### Robustness at the trust boundary
 
-The underlying `macsyma-lexer` *panics* on characters it cannot tokenize. Because
-`feed` is a trust boundary over arbitrary user text, it runs the evaluation inside
-`catch_unwind` and converts any panic into a clean `Err` — a stray `@` returns an
-error instead of aborting the session. (The proper upstream fix is for the lexer
-to return a `Result`; this façade is defensive in the meantime.)
+`feed` takes arbitrary user text, so it defends against three failure modes of
+the reused Macsyma stack:
+
+- **Unwinding panics** — the `macsyma-lexer` *panics* on a character it cannot
+  tokenize, so `feed` runs evaluation inside `catch_unwind` and returns a clean
+  `Err` (a stray `@` errors instead of aborting).
+- **Stack overflow** — the parser/VM recurse on nesting with no depth limit, so
+  deeply nested input would overflow the stack and *abort the process
+  uncatchably*. `feed` caps total size (`MAX_INPUT_LEN`) and per-statement token
+  count (`MAX_STATEMENT_TOKENS`, counted from the **real** lexer so comment/string
+  skip rules can't bypass it), and evaluates on a large-stack worker thread.
+- **Mutex poisoning** — after any caught panic the wrapped session is rebuilt, so
+  a panic in a lock-holding handler can't permanently brick it.
+
+The proper upstream fixes are a `Result`-returning lexer and a parser/VM
+recursion-depth limit; these are defensive shims in the façade meanwhile.
 
 ## What evaluates
 

--- a/code/packages/rust/maxima-runtime/required_capabilities.json
+++ b/code/packages/rust/maxima-runtime/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "rust/maxima-runtime",
+  "capabilities": [],
+  "justification": "Pure computation: a presentation facade that forwards source strings to macsyma-runtime and formats the (%o) echo. No filesystem, network, or process access."
+}

--- a/code/packages/rust/maxima-runtime/src/lib.rs
+++ b/code/packages/rust/maxima-runtime/src/lib.rs
@@ -244,12 +244,17 @@ fn check_statement_token_counts(src: &str) -> Result<(), String> {
 
     let mut count: usize = 0;
     for token in &tokens {
-        // `;` and `$` are the statement terminators; the next statement starts
-        // its own budget. (Matched on the lexeme, which is robust regardless of
-        // how the token is classified.)
-        if token.value == ";" || token.value == "$" {
-            count = 0;
-            continue;
+        // Reset on a statement terminator. Match on the token *type* (`SEMI` /
+        // `DOLLAR`), never on its lexeme: a STRING literal like `";"` or `"$"`
+        // has its quotes stripped, so its `value` is `;`/`$` while its type is
+        // `STRING` — keying on `value` would let such a literal masquerade as a
+        // terminator and reset the counter mid-expression, bypassing the cap.
+        match token.effective_type_name() {
+            "SEMI" | "DOLLAR" => {
+                count = 0;
+                continue;
+            }
+            _ => {}
         }
         count += 1;
         if count > MAX_STATEMENT_TOKENS {
@@ -460,6 +465,29 @@ mod tests {
         assert!(
             err.contains("too complex"),
             "quote-in-comment bypass not closed: {err:?}"
+        );
+    }
+
+    #[test]
+    fn a_string_literal_terminator_does_not_reset_the_cap() {
+        // A STRING literal `";"` / `"$"` has its quotes stripped, so its lexeme
+        // is `;`/`$` — but its token TYPE is STRING, not a terminator. Splicing
+        // such literals into one deep expression must NOT reset the per-statement
+        // counter (which would bypass the cap). Build a deep `1+1+…` chain with a
+        // `";"+` spliced in every 50 terms and confirm it is still rejected.
+        let mut src = String::new();
+        for i in 0..6_000 {
+            src.push_str("1+");
+            if i % 50 == 0 {
+                src.push_str("\";\"+"); // a string literal whose content is ';'
+            }
+        }
+        src.push_str("1;");
+        assert!(src.len() <= MAX_INPUT_LEN);
+        let err = eval(&src).unwrap_err(); // must NOT abort
+        assert!(
+            err.contains("too complex"),
+            "string-literal terminator must not reset the cap: {err:?}"
         );
     }
 

--- a/code/packages/rust/maxima-runtime/src/lib.rs
+++ b/code/packages/rust/maxima-runtime/src/lib.rs
@@ -1,0 +1,234 @@
+//! # Maxima runtime — a Macsyma reuse.
+//!
+//! [Maxima](https://maxima.sourceforge.io/) is the GPL-licensed descendant of
+//! DOE Macsyma. When MIT's Project MAC handed Macsyma to the Department of
+//! Energy, William Schelter maintained a copy and in 1998 released it under the
+//! GPL as *Maxima*. The two share the same algebraic surface: `:` assignment,
+//! `;` to display / `$` to suppress, the `%i«n»`/`%o«n»` history convention,
+//! and the whole `diff`/`integrate`/`expand`/`factor`/`solve` function family.
+//! A program written for one runs on the other.
+//!
+//! Because of that, this crate is **not** a new interpreter. It is a thin
+//! facade — a [`MaximaSession`] that owns a [`macsyma_runtime::MacsymaSession`]
+//! and presents Maxima's string-in / string-out console contract over it. The
+//! entire pipeline beneath (the `macsyma-lexer` → `macsyma-parser` →
+//! `macsyma-compiler` frontend, the `symbolic-vm`, and the twenty `cas-*`
+//! crates that implement simplification, calculus, trig, solving, substitution,
+//! and pretty-printing) is reused **unchanged**.
+//!
+//! This is the symbolic-CAS analogue of how GNU Octave was delivered as a thin
+//! reuse of `matlab-runtime`: a second historical language for the cost of a
+//! façade plus a REPL, because the syntax already matched.
+//!
+//! ## What `feed` does
+//!
+//! ```text
+//! (%i1) diff(x^3, x);
+//! (%o1) 3*x^2
+//! ```
+//!
+//! [`MaximaSession::feed`] hands the source straight to
+//! [`MacsymaSession::eval_source`](macsyma_runtime::MacsymaSession::eval_source),
+//! which parses and evaluates it, then builds the output echo. For each evaluated
+//! statement **whose `display` flag is set** (i.e. terminated by `;`, not `$`)
+//! it appends one line:
+//!
+//! ```text
+//! (%o«output_index») «output_text»
+//! ```
+//!
+//! A `$`-suppressed statement still runs and still advances the shared `%o`
+//! history counter, but contributes no output line — exactly as in Maxima. A
+//! surface/parse error arrives as the macsyma `CompileError`; we forward its
+//! `Display` text as `Err(String)` so a REPL can show it without leaking a Rust
+//! backtrace.
+//!
+//! ## Panic-safety at the trust boundary
+//!
+//! The underlying `macsyma-lexer` **panics** (rather than returning an error)
+//! when it meets a character it cannot tokenize — e.g. a stray `@`. Since
+//! `feed` is a trust boundary that takes arbitrary user text, a single bad
+//! keystroke must not abort an interactive session. So `feed` runs the
+//! evaluation inside [`std::panic::catch_unwind`] and turns any unwinding panic
+//! into a clean `Err(String)`. The tokenizer panics *before* it mutates session
+//! state, so the wrapped [`MacsymaSession`] stays consistent and usable
+//! afterwards; the [`AssertUnwindSafe`](std::panic::AssertUnwindSafe) wrapper is
+//! sound here because all the code involved is panic-safe ordinary Rust (no
+//! `unsafe`, no half-updated invariants that could be observed). This is a
+//! defensive shim in the façade; the proper upstream fix is for the lexer to
+//! return a `Result` instead of panicking.
+
+use macsyma_runtime::MacsymaSession;
+use std::panic::{catch_unwind, AssertUnwindSafe};
+
+/// A persistent Maxima session.
+///
+/// Holds the wrapped [`MacsymaSession`], so `%i`/`%o` history, variable bindings
+/// (`x : 5$`), and `load("orthopoly")` gates all persist across calls to
+/// [`feed`](MaximaSession::feed) just as they would in an interactive Maxima.
+pub struct MaximaSession {
+    inner: MacsymaSession,
+}
+
+impl Default for MaximaSession {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl MaximaSession {
+    /// Create a fresh session with empty history and bindings.
+    pub fn new() -> Self {
+        MaximaSession {
+            inner: MacsymaSession::new(),
+        }
+    }
+
+    /// Evaluate a chunk of Maxima source and return the console echo.
+    ///
+    /// The source may contain several statements (each terminated by `;` or
+    /// `$`). Every displayed result becomes one `(%o«n») «text»` line; the lines
+    /// are concatenated in evaluation order, each ending in a newline. If nothing
+    /// is displayed (e.g. a single `$`-suppressed statement) the result is the
+    /// empty string. A parse/surface error is returned as `Err` with the
+    /// evaluator's own message.
+    pub fn feed(&mut self, src: &str) -> Result<String, String> {
+        // The macsyma tokenizer panics on characters it cannot lex, so guard
+        // the whole evaluation against an unwinding panic and surface it as an
+        // ordinary error (see the module-level "Panic-safety" note). On the
+        // happy path this is a no-op; on a bad-input panic the session is left
+        // untouched (the panic fires before any mutation) and remains usable.
+        let inner = &mut self.inner;
+        let evaluated = catch_unwind(AssertUnwindSafe(|| inner.eval_source(src)));
+        let results = match evaluated {
+            Ok(Ok(results)) => results,
+            Ok(Err(e)) => return Err(format!("{e}")),
+            Err(payload) => return Err(panic_message(payload)),
+        };
+        let mut out = String::new();
+        for r in results {
+            if r.display {
+                // Maxima echoes a displayed result as `(%o«n») «value»`. The
+                // output_index is Macsyma's 1-based %o counter, carried through
+                // verbatim; output_text is whatever the macsyma pretty-printer
+                // selected (single-line, or a 2-D box when display2d is on).
+                out.push_str(&format!("(%o{}) {}\n", r.output_index, r.output_text));
+            }
+        }
+        Ok(out)
+    }
+}
+
+/// Evaluate `src` once on a fresh [`MaximaSession`] and return its echo.
+///
+/// Convenience for callers that do not need persistent history.
+pub fn eval(src: &str) -> Result<String, String> {
+    MaximaSession::new().feed(src)
+}
+
+/// Recover a human-readable message from a caught panic payload.
+///
+/// `panic!("…")` stores either a `&'static str` or a `String`; we try both and
+/// fall back to a generic message so the caller always gets *something* to show
+/// the user rather than a debug-formatted `Box<dyn Any>`.
+fn panic_message(payload: Box<dyn std::any::Any + Send>) -> String {
+    if let Some(s) = payload.downcast_ref::<String>() {
+        s.clone()
+    } else if let Some(s) = payload.downcast_ref::<&str>() {
+        s.to_string()
+    } else {
+        "Maxima could not evaluate that input".to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // The exact `output_text` formatting is whatever the macsyma pretty-printer
+    // produces; these tests assert on robust substrings (and the `(%oN)` echo
+    // shape) rather than brittle whole-string matches, so they stay green if the
+    // printer's spacing changes.
+
+    #[test]
+    fn arithmetic_folds_to_an_integer() {
+        // 1 + 2*3 = 7, displayed as (%o1) 7
+        let out = eval("1 + 2*3;").unwrap();
+        assert!(out.starts_with("(%o1) "), "echo shape: {out:?}");
+        assert!(out.contains('7'), "expected 7 in {out:?}");
+    }
+
+    #[test]
+    fn differentiation_of_a_cube() {
+        // diff(x^3, x) = 3*x^2
+        let out = eval("diff(x^3, x);").unwrap();
+        assert!(out.contains('3') && out.contains('x'), "got {out:?}");
+        // the derivative is quadratic in x — a 2 (the exponent) appears
+        assert!(out.contains('2'), "expected the exponent 2 in {out:?}");
+    }
+
+    #[test]
+    fn integration_of_a_power() {
+        // integrate(x^2, x) = x^3/3 — genuinely reduced by the macsyma evaluator
+        // (chosen over `expand`, which the current evaluator echoes symbolically).
+        let out = eval("integrate(x^2, x);").unwrap();
+        assert!(out.contains('x'), "got {out:?}");
+        assert!(
+            out.contains('3'),
+            "expected the x^3/3 antiderivative in {out:?}"
+        );
+    }
+
+    #[test]
+    fn suppressed_assignment_then_use() {
+        // `x : 5$` binds and displays nothing; `x + 1;` then shows 6.
+        let mut s = MaximaSession::new();
+        let nothing = s.feed("x : 5$").unwrap();
+        assert_eq!(nothing, "", "a $-suppressed statement prints nothing");
+        let out = s.feed("x + 1;").unwrap();
+        assert!(out.contains('6'), "binding should persist: {out:?}");
+    }
+
+    #[test]
+    fn factoring_a_difference_of_squares() {
+        // factor(x^2 - 1) = (x - 1)*(x + 1)
+        let out = eval("factor(x^2 - 1);").unwrap();
+        assert!(out.contains('x'), "got {out:?}");
+        // both linear factors mention 1
+        assert!(out.contains('1'), "expected (x-1)(x+1) form in {out:?}");
+    }
+
+    #[test]
+    fn history_counter_advances_across_statements() {
+        // Two displayed statements in one feed get %o1 then %o2.
+        let out = eval("2; 3;").unwrap();
+        assert!(out.contains("(%o1) "), "first echo: {out:?}");
+        assert!(out.contains("(%o2) "), "second echo: {out:?}");
+    }
+
+    #[test]
+    fn suppression_still_advances_the_output_index() {
+        // A `$` statement consumes an %o slot even though it prints nothing,
+        // so the *next* displayed result is %o2, not %o1.
+        let mut s = MaximaSession::new();
+        assert_eq!(s.feed("10$").unwrap(), "");
+        let out = s.feed("20;").unwrap();
+        assert!(out.contains("(%o2) "), "index should skip to 2: {out:?}");
+    }
+
+    #[test]
+    fn a_surface_error_is_returned_not_panicked() {
+        // An unparseable fragment yields Err with the evaluator's message,
+        // never a panic.
+        let err = eval("@#$%^;");
+        assert!(err.is_err(), "expected a clean Err, got {err:?}");
+    }
+
+    #[test]
+    fn the_one_shot_eval_helper_matches_a_session() {
+        let one = eval("1 + 1;").unwrap();
+        let mut s = MaximaSession::new();
+        let two = s.feed("1 + 1;").unwrap();
+        assert_eq!(one, two);
+    }
+}

--- a/code/packages/rust/maxima-runtime/src/lib.rs
+++ b/code/packages/rust/maxima-runtime/src/lib.rs
@@ -63,13 +63,17 @@
 //!    overflow is **not** a catchable panic; it aborts the whole process, and
 //!    `catch_unwind` cannot stop it. Three layered guards close this:
 //!    `feed` rejects input longer than [`MAX_INPUT_LEN`]; it rejects any single
-//!    statement whose structural-symbol count exceeds [`MAX_STATEMENT_SYMBOLS`]
-//!    (an upper bound on the resulting tree depth, since a tree of *n* internal
-//!    operator/bracket nodes is at most *n* deep), so a pathologically deep tree
-//!    is never built in the first place; and it runs evaluation on a dedicated
-//!    worker thread with a large, bounded stack ([`EVAL_STACK_SIZE`]) and builds
-//!    the echo string there, so even the bounded trees are created *and dropped*
-//!    on the big stack rather than the caller's.
+//!    statement that lexes to more than [`MAX_STATEMENT_TOKENS`] tokens (an upper
+//!    bound on the resulting tree depth, since every node of the parse tree
+//!    consumes at least one token), so a pathologically deep tree is never built
+//!    in the first place; and it runs evaluation on a dedicated worker thread
+//!    with a large, bounded stack ([`EVAL_STACK_SIZE`]) and builds the echo
+//!    string there, so even the bounded trees are created *and dropped* on the
+//!    big stack rather than the caller's. Crucially the token count comes from
+//!    the **real macsyma lexer** (which is iterative and so cannot itself
+//!    overflow), not a re-implemented surface scan — a façade scan that doesn't
+//!    perfectly mirror the lexer's comment/string skip rules is bypassable, so
+//!    we reuse the genuine tokenizer the parser will consume.
 //!
 //! 3. **A poisoned session after a caught panic.** Some Macsyma handlers hold an
 //!    internal `Mutex` while running; a panic there would poison it and make
@@ -86,6 +90,7 @@
 //! fixes are for the lexer to return a `Result` and for the parser/VM to carry a
 //! recursion-depth limit.
 
+use macsyma_lexer::tokenize_macsyma;
 use macsyma_runtime::MacsymaSession;
 use std::panic::{catch_unwind, AssertUnwindSafe};
 
@@ -95,17 +100,18 @@ use std::panic::{catch_unwind, AssertUnwindSafe};
 /// beyond any realistic interactive submission.
 pub const MAX_INPUT_LEN: usize = 64 * 1024;
 
-/// Maximum number of structural (operator/bracket/punctuation) symbols allowed
-/// in any single top-level statement.
+/// Maximum number of lexer tokens allowed in any single top-level statement.
 ///
-/// The depth of the IRNode tree a statement parses to is bounded above by the
-/// number of operator/bracket *tokens* it contains, which is in turn bounded by
-/// the count of non-identifier symbol characters. Capping that per statement
-/// therefore caps the tree depth, so the parser/VM (and the later `Drop` of the
-/// tree) cannot be driven into a stack-overflowing recursion. 2000 operators in
-/// one statement is already absurd for human-written Maxima, so the cap never
-/// bites legitimate input.
-pub const MAX_STATEMENT_SYMBOLS: usize = 2000;
+/// The depth of the parse tree a statement produces is bounded above by the
+/// number of tokens it contains, because every node of the tree consumes at
+/// least one token. Capping the per-statement token count therefore caps the
+/// tree depth, so the parser/VM (and the later `Drop` of the tree) cannot be
+/// driven into a stack-overflowing recursion. The count is taken from the real
+/// macsyma lexer (see [`MaximaSession::feed`]), so comments and whitespace are
+/// already skipped and strings are single tokens — there is no surface-scan
+/// model to diverge from and bypass. 2000 tokens in one statement is already
+/// absurd for human-written Maxima, so the cap never bites legitimate input.
+pub const MAX_STATEMENT_TOKENS: usize = 2000;
 
 /// Stack size of the worker thread that runs evaluation.
 ///
@@ -156,7 +162,7 @@ impl MaximaSession {
         }
         // Guard 2: reject any over-complex statement so no stack-overflowing tree
         // is ever built (see the module "Robustness" note and the const docs).
-        check_statement_complexity(src)?;
+        check_statement_token_counts(src)?;
 
         // Guard 3: run evaluation — and the echo formatting that walks the result
         // trees — on a worker thread with a large, bounded stack, so the bounded
@@ -212,48 +218,44 @@ impl MaximaSession {
     }
 }
 
-/// Reject input whose per-statement structural complexity could drive the
-/// parser/VM — or the later `Drop` of the resulting tree — into a deep,
-/// stack-overflowing recursion.
+/// Reject input where any single statement lexes to too many tokens, which
+/// would let the parser/VM — or the later `Drop` of the resulting tree — recurse
+/// deeply enough to overflow the stack.
 ///
-/// A statement's IRNode tree is at most as deep as the number of operator /
-/// bracket tokens it contains, which is bounded by the count of non-identifier
-/// "structural" symbol characters. We count those per top-level statement
-/// (resetting at each `;`/`$` that lies outside a `"`-string) and refuse the
-/// whole chunk if any statement exceeds [`MAX_STATEMENT_SYMBOLS`]. The scan is a
-/// single linear pass and treats string contents as opaque so an operator-heavy
-/// string literal is not mistaken for deep structure.
-fn check_statement_complexity(src: &str) -> Result<(), String> {
-    let mut symbols: usize = 0;
-    let mut in_string = false;
-    let mut escaped = false;
-    for ch in src.chars() {
-        if in_string {
-            if escaped {
-                escaped = false;
-            } else if ch == '\\' {
-                escaped = true;
-            } else if ch == '"' {
-                in_string = false;
-            }
+/// The count is taken from the **real** macsyma lexer, the very one the parser
+/// consumes, so there is no separately-maintained lexical model to diverge from:
+/// comments and whitespace are skip patterns (absent from the token stream),
+/// strings are single tokens, and an unterminated comment or quote is lexed
+/// exactly as the parser would see it. A statement's parse-tree depth is at most
+/// its token count (every node consumes ≥1 token), so capping tokens per
+/// statement caps the depth.
+///
+/// The lexer is iterative and so cannot itself overflow on deep nesting. It does,
+/// however, *panic* on a character it cannot tokenize; we catch that and return
+/// `Ok(())` so the bad input flows on to the worker-thread evaluation, where it
+/// is reported uniformly (and the session is rebuilt) — we never reject solely
+/// because the *checker* could not lex something.
+fn check_statement_token_counts(src: &str) -> Result<(), String> {
+    let src_owned = src.to_string();
+    let tokens = match catch_unwind(AssertUnwindSafe(|| tokenize_macsyma(&src_owned))) {
+        Ok(tokens) => tokens,
+        Err(_) => return Ok(()), // unlexable — let the evaluator surface it
+    };
+
+    let mut count: usize = 0;
+    for token in &tokens {
+        // `;` and `$` are the statement terminators; the next statement starts
+        // its own budget. (Matched on the lexeme, which is robust regardless of
+        // how the token is classified.)
+        if token.value == ";" || token.value == "$" {
+            count = 0;
             continue;
         }
-        match ch {
-            '"' => in_string = true,
-            // End of a statement — the next statement starts fresh.
-            ';' | '$' => symbols = 0,
-            // Identifiers, numbers, and whitespace are leaves / separators: they
-            // do not deepen the tree.
-            c if c.is_alphanumeric() || c == '_' || c.is_whitespace() => {}
-            // Anything else is a structural symbol (operator, bracket, comma, …).
-            _ => {
-                symbols += 1;
-                if symbols > MAX_STATEMENT_SYMBOLS {
-                    return Err(format!(
-                        "statement too complex: more than {MAX_STATEMENT_SYMBOLS} operators/brackets in one statement"
-                    ));
-                }
-            }
+        count += 1;
+        if count > MAX_STATEMENT_TOKENS {
+            return Err(format!(
+                "statement too complex: more than {MAX_STATEMENT_TOKENS} tokens in one statement"
+            ));
         }
     }
     Ok(())
@@ -426,6 +428,56 @@ mod tests {
         let src = format!("{}1 + 2{};", "(".repeat(depth), ")".repeat(depth));
         let out = eval(&src).unwrap();
         assert!(out.contains('3'), "((…1 + 2…)) should fold to 3: {out:?}");
+    }
+
+    #[test]
+    fn comment_hidden_terminator_does_not_bypass_the_cap() {
+        // A `;` inside a `/* */` comment is skipped by the real lexer (it stays
+        // ONE statement), but a naive surface scan would treat it as a statement
+        // boundary and reset its counter, letting deep nesting through. Because
+        // we count REAL lexer tokens — where comments are already skipped — the
+        // hidden terminator changes nothing and the deep nest is still rejected.
+        let depth = 20_000;
+        let src = format!("/*;*/{}1{};", "(".repeat(depth), ")".repeat(depth));
+        assert!(src.len() <= MAX_INPUT_LEN);
+        let err = eval(&src).unwrap_err(); // must NOT abort
+        assert!(
+            err.contains("too complex"),
+            "comment bypass not closed: {err:?}"
+        );
+    }
+
+    #[test]
+    fn comment_hidden_quote_does_not_bypass_the_cap() {
+        // A `"` inside a comment would flip a surface scanner into a phantom
+        // "string" mode and make it count zero structural symbols thereafter.
+        // The real lexer skips the comment, so the following nest is fully
+        // tokenized and rejected.
+        let depth = 20_000;
+        let src = format!("/*\"*/{}1{};", "(".repeat(depth), ")".repeat(depth));
+        assert!(src.len() <= MAX_INPUT_LEN);
+        let err = eval(&src).unwrap_err(); // must NOT abort
+        assert!(
+            err.contains("too complex"),
+            "quote-in-comment bypass not closed: {err:?}"
+        );
+    }
+
+    #[test]
+    fn an_operator_heavy_string_literal_is_not_deep_structure() {
+        // The flip side: a string full of `(`/`+` is a SINGLE token, so it must
+        // not trip the cap — the token count reflects structure, not characters.
+        let s = format!("\"{}\";", "(".repeat(5_000));
+        assert!(s.len() <= MAX_INPUT_LEN);
+        // One STRING token + terminator — well under the cap, so this evaluates
+        // (or returns a surface error) but is never rejected as "too complex".
+        let result = eval(&s);
+        if let Err(e) = &result {
+            assert!(
+                !e.contains("too complex"),
+                "a string literal is not deep: {e:?}"
+            );
+        }
     }
 
     #[test]

--- a/code/packages/rust/maxima-runtime/src/lib.rs
+++ b/code/packages/rust/maxima-runtime/src/lib.rs
@@ -43,23 +43,76 @@
 //! `Display` text as `Err(String)` so a REPL can show it without leaking a Rust
 //! backtrace.
 //!
-//! ## Panic-safety at the trust boundary
+//! ## Robustness at the trust boundary
 //!
-//! The underlying `macsyma-lexer` **panics** (rather than returning an error)
-//! when it meets a character it cannot tokenize — e.g. a stray `@`. Since
-//! `feed` is a trust boundary that takes arbitrary user text, a single bad
-//! keystroke must not abort an interactive session. So `feed` runs the
-//! evaluation inside [`std::panic::catch_unwind`] and turns any unwinding panic
-//! into a clean `Err(String)`. The tokenizer panics *before* it mutates session
-//! state, so the wrapped [`MacsymaSession`] stays consistent and usable
-//! afterwards; the [`AssertUnwindSafe`](std::panic::AssertUnwindSafe) wrapper is
-//! sound here because all the code involved is panic-safe ordinary Rust (no
-//! `unsafe`, no half-updated invariants that could be observed). This is a
-//! defensive shim in the façade; the proper upstream fix is for the lexer to
-//! return a `Result` instead of panicking.
+//! `feed` takes arbitrary user text, so it is the trust boundary for the whole
+//! reused Macsyma stack. Three failure modes of that stack are contained here so
+//! a single bad input can never crash or wedge an interactive session:
+//!
+//! 1. **Unwinding panics.** The `macsyma-lexer` *panics* (rather than returning
+//!    an error) on a character it cannot tokenize — e.g. a stray `@`. `feed`
+//!    runs evaluation inside [`std::panic::catch_unwind`] and converts any
+//!    unwinding panic into a clean `Err(String)`.
+//!
+//! 2. **Stack overflow from unbounded recursion.** The Macsyma parser and the
+//!    `symbolic-vm` recurse on expression nesting with no depth limit, so deeply
+//!    nested input — thousands of `(`, a long run of prefix `-`, or a long
+//!    `1+1+1+…` chain — builds a correspondingly deep tree. That overflows the
+//!    stack while *parsing/evaluating* it, and again later when the tree is
+//!    *dropped* (the wrapped session retains it in its `%o` history). A stack
+//!    overflow is **not** a catchable panic; it aborts the whole process, and
+//!    `catch_unwind` cannot stop it. Three layered guards close this:
+//!    `feed` rejects input longer than [`MAX_INPUT_LEN`]; it rejects any single
+//!    statement whose structural-symbol count exceeds [`MAX_STATEMENT_SYMBOLS`]
+//!    (an upper bound on the resulting tree depth, since a tree of *n* internal
+//!    operator/bracket nodes is at most *n* deep), so a pathologically deep tree
+//!    is never built in the first place; and it runs evaluation on a dedicated
+//!    worker thread with a large, bounded stack ([`EVAL_STACK_SIZE`]) and builds
+//!    the echo string there, so even the bounded trees are created *and dropped*
+//!    on the big stack rather than the caller's.
+//!
+//! 3. **A poisoned session after a caught panic.** Some Macsyma handlers hold an
+//!    internal `Mutex` while running; a panic there would poison it and make
+//!    *every* later call fail. So whenever `feed` catches a panic it **rebuilds
+//!    the wrapped session from scratch**, trading the lost `%o` history and
+//!    bindings for a guaranteed-usable session on the next call. (On the common
+//!    lexer-panic path nothing was mutated, so this is cheap and lossless in
+//!    practice.)
+//!
+//! The [`AssertUnwindSafe`](std::panic::AssertUnwindSafe) wrapper is sound here
+//! because the code involved is ordinary safe Rust (no `unsafe`, no observable
+//! half-updated invariant — and any logical inconsistency is erased by the
+//! rebuild in (3)). These are defensive shims in the façade; the proper upstream
+//! fixes are for the lexer to return a `Result` and for the parser/VM to carry a
+//! recursion-depth limit.
 
 use macsyma_runtime::MacsymaSession;
 use std::panic::{catch_unwind, AssertUnwindSafe};
+
+/// Maximum length, in bytes, of a single source chunk handed to [`feed`].
+///
+/// A cheap first gate that bounds total memory/time per call. 64 KiB is far
+/// beyond any realistic interactive submission.
+pub const MAX_INPUT_LEN: usize = 64 * 1024;
+
+/// Maximum number of structural (operator/bracket/punctuation) symbols allowed
+/// in any single top-level statement.
+///
+/// The depth of the IRNode tree a statement parses to is bounded above by the
+/// number of operator/bracket *tokens* it contains, which is in turn bounded by
+/// the count of non-identifier symbol characters. Capping that per statement
+/// therefore caps the tree depth, so the parser/VM (and the later `Drop` of the
+/// tree) cannot be driven into a stack-overflowing recursion. 2000 operators in
+/// one statement is already absurd for human-written Maxima, so the cap never
+/// bites legitimate input.
+pub const MAX_STATEMENT_SYMBOLS: usize = 2000;
+
+/// Stack size of the worker thread that runs evaluation.
+///
+/// With the per-statement complexity cap bounding tree depth, this is generous
+/// headroom: it lets the bounded-but-still-deep trees be built and dropped well
+/// clear of any overflow, regardless of the caller's own (possibly small) stack.
+const EVAL_STACK_SIZE: usize = 512 * 1024 * 1024;
 
 /// A persistent Maxima session.
 ///
@@ -93,30 +146,117 @@ impl MaximaSession {
     /// empty string. A parse/surface error is returned as `Err` with the
     /// evaluator's own message.
     pub fn feed(&mut self, src: &str) -> Result<String, String> {
-        // The macsyma tokenizer panics on characters it cannot lex, so guard
-        // the whole evaluation against an unwinding panic and surface it as an
-        // ordinary error (see the module-level "Panic-safety" note). On the
-        // happy path this is a no-op; on a bad-input panic the session is left
-        // untouched (the panic fires before any mutation) and remains usable.
+        // Guard 1: bound total input size (cheap memory/time gate).
+        if src.len() > MAX_INPUT_LEN {
+            return Err(format!(
+                "input too large: {} bytes exceeds the {}-byte limit",
+                src.len(),
+                MAX_INPUT_LEN
+            ));
+        }
+        // Guard 2: reject any over-complex statement so no stack-overflowing tree
+        // is ever built (see the module "Robustness" note and the const docs).
+        check_statement_complexity(src)?;
+
+        // Guard 3: run evaluation — and the echo formatting that walks the result
+        // trees — on a worker thread with a large, bounded stack, so the bounded
+        // trees are built and dropped clear of the caller's (possibly small)
+        // stack; and Guard 4 (unwinding panics): catch the macsyma lexer's
+        // panic-on-bad-input and turn it into an ordinary error. Only the small
+        // `String` echo (or an error message) crosses back to the caller.
         let inner = &mut self.inner;
-        let evaluated = catch_unwind(AssertUnwindSafe(|| inner.eval_source(src)));
-        let results = match evaluated {
-            Ok(Ok(results)) => results,
-            Ok(Err(e)) => return Err(format!("{e}")),
-            Err(payload) => return Err(panic_message(payload)),
-        };
-        let mut out = String::new();
-        for r in results {
-            if r.display {
-                // Maxima echoes a displayed result as `(%o«n») «value»`. The
-                // output_index is Macsyma's 1-based %o counter, carried through
-                // verbatim; output_text is whatever the macsyma pretty-printer
-                // selected (single-line, or a 2-D box when display2d is on).
-                out.push_str(&format!("(%o{}) {}\n", r.output_index, r.output_text));
+        let outcome = std::thread::scope(|scope| {
+            std::thread::Builder::new()
+                .stack_size(EVAL_STACK_SIZE)
+                .spawn_scoped(scope, || {
+                    catch_unwind(AssertUnwindSafe(|| match inner.eval_source(src) {
+                        Ok(results) => {
+                            let mut out = String::new();
+                            for r in results {
+                                if r.display {
+                                    // Maxima echoes a displayed result as
+                                    // `(%o«n») «value»`: output_index is the
+                                    // 1-based %o counter, output_text is whatever
+                                    // the macsyma pretty-printer selected.
+                                    out.push_str(&format!(
+                                        "(%o{}) {}\n",
+                                        r.output_index, r.output_text
+                                    ));
+                                }
+                            }
+                            // The (possibly deep) result trees drop here, on the
+                            // big worker stack.
+                            Ok(out)
+                        }
+                        Err(e) => Err(format!("{e}")),
+                    }))
+                })
+                .expect("failed to spawn maxima evaluation thread")
+                .join()
+        });
+
+        match outcome {
+            // Normal path: the worker produced the echo (or a surface error).
+            Ok(Ok(Ok(out))) => Ok(out),
+            Ok(Ok(Err(message))) => Err(message),
+            // A panic the worker caught (e.g. the lexer's bad-input panic), or a
+            // panic that escaped the catch and unwound the join. Either way the
+            // session may be inconsistent / mutex-poisoned, so rebuild it before
+            // returning, so the *next* call is guaranteed usable rather than
+            // failing forever on a poisoned lock.
+            Ok(Err(payload)) | Err(payload) => {
+                self.inner = MacsymaSession::new();
+                Err(panic_message(payload))
             }
         }
-        Ok(out)
     }
+}
+
+/// Reject input whose per-statement structural complexity could drive the
+/// parser/VM — or the later `Drop` of the resulting tree — into a deep,
+/// stack-overflowing recursion.
+///
+/// A statement's IRNode tree is at most as deep as the number of operator /
+/// bracket tokens it contains, which is bounded by the count of non-identifier
+/// "structural" symbol characters. We count those per top-level statement
+/// (resetting at each `;`/`$` that lies outside a `"`-string) and refuse the
+/// whole chunk if any statement exceeds [`MAX_STATEMENT_SYMBOLS`]. The scan is a
+/// single linear pass and treats string contents as opaque so an operator-heavy
+/// string literal is not mistaken for deep structure.
+fn check_statement_complexity(src: &str) -> Result<(), String> {
+    let mut symbols: usize = 0;
+    let mut in_string = false;
+    let mut escaped = false;
+    for ch in src.chars() {
+        if in_string {
+            if escaped {
+                escaped = false;
+            } else if ch == '\\' {
+                escaped = true;
+            } else if ch == '"' {
+                in_string = false;
+            }
+            continue;
+        }
+        match ch {
+            '"' => in_string = true,
+            // End of a statement — the next statement starts fresh.
+            ';' | '$' => symbols = 0,
+            // Identifiers, numbers, and whitespace are leaves / separators: they
+            // do not deepen the tree.
+            c if c.is_alphanumeric() || c == '_' || c.is_whitespace() => {}
+            // Anything else is a structural symbol (operator, bracket, comma, …).
+            _ => {
+                symbols += 1;
+                if symbols > MAX_STATEMENT_SYMBOLS {
+                    return Err(format!(
+                        "statement too complex: more than {MAX_STATEMENT_SYMBOLS} operators/brackets in one statement"
+                    ));
+                }
+            }
+        }
+    }
+    Ok(())
 }
 
 /// Evaluate `src` once on a fresh [`MaximaSession`] and return its echo.
@@ -230,5 +370,71 @@ mod tests {
         let mut s = MaximaSession::new();
         let two = s.feed("1 + 1;").unwrap();
         assert_eq!(one, two);
+    }
+
+    #[test]
+    fn oversized_input_is_rejected_before_evaluation() {
+        // A chunk past the length cap is refused outright (Guard 1), bounding the
+        // worst-case recursion the parser/VM can be driven to.
+        let huge = format!("{}1;", "1+".repeat(MAX_INPUT_LEN));
+        assert!(huge.len() > MAX_INPUT_LEN);
+        let err = eval(&huge).unwrap_err();
+        assert!(
+            err.contains("too large"),
+            "expected a size error, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn deeply_nested_brackets_are_rejected_not_aborted() {
+        // Thousands of nested parens used to abort the process via stack
+        // overflow (on creation and again on drop). The complexity cap now
+        // rejects them with a clean error before any deep tree is built.
+        let depth = 20_000;
+        let src = format!("{}1{};", "(".repeat(depth), ")".repeat(depth));
+        assert!(src.len() <= MAX_INPUT_LEN, "stays under the length cap");
+        let err = eval(&src).unwrap_err(); // must not abort the process
+        assert!(
+            err.contains("too complex"),
+            "expected a complexity error: {err:?}"
+        );
+    }
+
+    #[test]
+    fn long_chain_of_prefix_operators_is_rejected() {
+        // The non-bracketed recursion vector: a long run of unary minus, also a
+        // former abort. Rejected by the complexity cap, never parsed.
+        let src = format!("{}x;", "-".repeat(5_000));
+        assert!(src.len() <= MAX_INPUT_LEN);
+        assert!(eval(&src).unwrap_err().contains("too complex"));
+    }
+
+    #[test]
+    fn long_binary_chain_is_rejected() {
+        // `1+1+1+…` builds a left-deep tree as deep as the number of `+`; the
+        // cap rejects it before that tree (or its drop) can overflow.
+        let src = format!("{}1;", "1+".repeat(5_000));
+        assert!(src.len() <= MAX_INPUT_LEN);
+        assert!(eval(&src).unwrap_err().contains("too complex"));
+    }
+
+    #[test]
+    fn moderate_nesting_still_evaluates() {
+        // The cap is far above realistic input: a modestly nested expression
+        // well under the limit still evaluates normally.
+        let depth = 40;
+        let src = format!("{}1 + 2{};", "(".repeat(depth), ")".repeat(depth));
+        let out = eval(&src).unwrap();
+        assert!(out.contains('3'), "((…1 + 2…)) should fold to 3: {out:?}");
+    }
+
+    #[test]
+    fn the_session_survives_and_recovers_after_a_panic() {
+        // A bad-input panic is caught and the session is rebuilt, so the very
+        // next statement works (rather than failing forever on a poisoned lock).
+        let mut s = MaximaSession::new();
+        assert!(s.feed("@@@;").is_err());
+        let out = s.feed("3 + 4;").unwrap();
+        assert!(out.contains('7'), "session should recover: {out:?}");
     }
 }

--- a/code/packages/rust/maxima-runtime/tests/integration.rs
+++ b/code/packages/rust/maxima-runtime/tests/integration.rs
@@ -1,0 +1,44 @@
+//! End-to-end tests of the public Maxima façade, exercised exactly as an
+//! external caller (e.g. `maxima-repl`) would: through `MaximaSession::feed`
+//! and the one-shot `eval`. These complement the in-module unit tests by
+//! pinning the crate's *public* contract.
+
+use coding_adventures_maxima_runtime::{eval, MaximaSession};
+
+#[test]
+fn a_multi_statement_feed_echoes_each_displayed_result() {
+    // Two displayed statements in a single feed → two echo lines, %o1 then %o2.
+    let out = eval("1 + 1; diff(x^2, x);").unwrap();
+    assert!(out.contains("(%o1) "), "first echo missing: {out:?}");
+    assert!(out.contains("(%o2) "), "second echo missing: {out:?}");
+    assert!(out.contains('2'), "diff(x^2,x)=2*x should appear: {out:?}");
+}
+
+#[test]
+fn bindings_persist_across_feeds() {
+    let mut s = MaximaSession::new();
+    assert_eq!(s.feed("a : 10$").unwrap(), "");
+    assert_eq!(s.feed("b : 20$").unwrap(), "");
+    let out = s.feed("a + b;").unwrap();
+    assert!(
+        out.contains("30"),
+        "expected 30 from persisted a+b: {out:?}"
+    );
+}
+
+#[test]
+fn integration_genuinely_reduces() {
+    // A real symbolic reduction round-trips through the façade unchanged.
+    let out = eval("integrate(x^2, x);").unwrap();
+    assert!(out.contains('x') && out.contains('3'), "got {out:?}");
+}
+
+#[test]
+fn bad_input_is_an_error_not_a_crash() {
+    // The macsyma lexer panics on `@`; the façade must turn that into an Err.
+    assert!(eval("@@@;").is_err());
+    // And a session survives a bad feed and keeps working.
+    let mut s = MaximaSession::new();
+    let _ = s.feed("@@@;");
+    assert!(s.feed("2 + 2;").unwrap().contains('4'));
+}

--- a/code/specs/HML00-historical-math-languages-roadmap.md
+++ b/code/specs/HML00-historical-math-languages-roadmap.md
@@ -178,7 +178,11 @@ sequence of one-PR items run through the autonomous loop (§8).
 ### Item breakdown for the first three waves (illustrative)
 
 - **Maxima:** M-1 spec + grammar diff from Macsyma; M-2 lexer/parser; M-3 runtime
-  alias over `macsyma-runtime`; M-4 GPL-era builtins.
+  alias over `macsyma-runtime`; M-4 GPL-era builtins. *(Delivered: see
+  [MA03](MA03-maxima-language.md). The grammar diff is empty for the supported
+  subset — Maxima parses identically to Macsyma — so M-1/M-2 collapsed and Maxima
+  shipped as just the runtime alias + REPL, the symbolic-CAS analogue of
+  Octave-over-MATLAB. No `maxima.tokens`/`maxima.grammar`.)*
 - **MATLAB/Octave:** ML-1 spec + `array-runtime` (Wave 0); ML-2 `matlab.tokens/grammar`
   + lexer; ML-3 parser; ML-4 `matlab-runtime` (matrix literals, `\`/`'`/`end`,
   ranges, broadcasting → `matrix-ir`); ML-5 `matlab-repl` + binary; ML-6 Octave

--- a/code/specs/MA03-maxima-language.md
+++ b/code/specs/MA03-maxima-language.md
@@ -40,15 +40,26 @@ second historical language for the cost of a façade plus a REPL.
 
 ## §2 What is supported
 
-Everything `macsyma-runtime` supports, presented under the Maxima name. That
-includes (non-exhaustively): arithmetic over exact rationals and floats; symbolic
-algebra (`expand`, `factor`, `ratsimp`); calculus (`diff`, `integrate`, `limit`,
-`taylor`); trigonometric simplification (`trigsimp`, `trigexpand`, `trigreduce`);
-equation solving (`solve`, linear systems); substitution (`subst`, `ev`); lists
-and their operations; the `orthopoly` package (Legendre, Chebyshev, Hermite,
-Bessel) behind the same allow-listed `load("orthopoly")` gate; and the
-`%i«n»`/`%o«n»` history convention. Display follows Macsyma's flags: `;`
-displays, `$` suppresses.
+**Exactly what `macsyma-runtime` evaluates — no more, no less.** Maxima inherits
+the wrapped evaluator's power verbatim, so this section is honest about where
+that evaluator currently stops (convention 9). The whole Macsyma function
+*surface* parses and is accepted; what actually *reduces* today is:
+
+- **Arithmetic** over exact rationals and floats (`2/4` → `1/2`, `1 + 2*3` → `7`).
+- **Differentiation** — `diff(x^3, x)` → `3*x^2`, `diff(sin(x), x)` → `cos(x)`.
+- **Integration** — `integrate(x^2, x)` → `x^3/3`.
+- **Factoring** — `factor(x^2 - 1)` → `(x - 1)*(x + 1)`.
+- **Substitution** — `subst(3, x, x^2 + 1)`.
+- **Bindings & history** — `x : 5$` then `x + 1;` → `6`; the `%i«n»`/`%o«n»`
+  counters; `;` displays and `$` suppresses.
+
+Other CAS verbs — `expand`, `ratsimp`, `solve`, `limit`, `taylor`, the `trig*`
+family, list operations, and the allow-listed `load("orthopoly")` package — are
+**parsed and accepted** but, in the current `macsyma-runtime`, echo back
+symbolically rather than reducing. They are not errors; they simply pass through
+unevaluated. As `macsyma-runtime`'s evaluator grows to reduce them, **Maxima
+inherits that for free**, because this crate adds no evaluation logic of its own —
+it is a pure presentation façade.
 
 ## §3 The `feed` contract
 

--- a/code/specs/MA03-maxima-language.md
+++ b/code/specs/MA03-maxima-language.md
@@ -1,0 +1,104 @@
+# MA03 — Maxima (a Macsyma reuse)
+
+## Status
+
+Active. Delivers **Maxima** — the GPL-licensed descendant of DOE Macsyma — as a
+thin reuse of the existing `macsyma-runtime` stack, exactly as
+[GNU Octave](MA01-matlab-language.md) was delivered as a thin reuse of
+`matlab-runtime`. No new lexer, parser, compiler, or symbolic engine: Maxima's
+surface syntax is, for the subset we support, *identical* to Macsyma's, so the
+entire frontend-to-evaluator pipeline is shared verbatim.
+
+This realizes **Wave 1 (Maxima)** of the historical-math roadmap
+([HML00 §7](HML00-historical-math-languages-roadmap.md)): "≈ Macsyma + GPL-era
+surface… reuses the Macsyma frontend/runtime almost wholesale."
+
+## §1 Why Maxima is (almost) free
+
+Maxima *is* Macsyma. When MIT's Project MAC handed DOE Macsyma to the Department
+of Energy, William Schelter maintained a copy ("Maxima") and in 1998 released it
+under the GPL. The two share the same algebraic surface: `:` for assignment, `;`
+to display and `$` to suppress, `%i`/`%o` input/output history, `diff`/`integrate`/
+`expand`/`factor`/`solve`, the `%pi`/`%e` constants, list/matrix syntax, and so on.
+A program written for one runs on the other.
+
+The repo already has a complete Macsyma vertical slice: `macsyma-lexer`,
+`macsyma-parser`, `macsyma-compiler`, and `macsyma-runtime` (a session facade over
+the Rust `symbolic-vm` and the twenty `cas-*` crates — simplification, calculus,
+trig, solve, substitution, pretty-printing). Because the syntax matches, **Maxima
+reuses all of it unchanged**. The only new code is:
+
+1. `maxima-runtime` — a `MaximaSession` that wraps a `MacsymaSession` and exposes
+   a string-in/string-out `feed`, formatting each displayed result as Maxima's
+   `(%o«n») «text»` echo line.
+2. `maxima-repl` — the interactive `maxima` binary: prompts (`(%i«n») ` / `... `),
+   line-continuation until a statement terminator (`;` or `$`) with balanced
+   brackets, and the standard quit/EOF handling. A sibling of `octave-repl`.
+
+This is the symbolic-CAS analogue of the numeric Octave-over-MATLAB shim: a
+second historical language for the cost of a façade plus a REPL.
+
+## §2 What is supported
+
+Everything `macsyma-runtime` supports, presented under the Maxima name. That
+includes (non-exhaustively): arithmetic over exact rationals and floats; symbolic
+algebra (`expand`, `factor`, `ratsimp`); calculus (`diff`, `integrate`, `limit`,
+`taylor`); trigonometric simplification (`trigsimp`, `trigexpand`, `trigreduce`);
+equation solving (`solve`, linear systems); substitution (`subst`, `ev`); lists
+and their operations; the `orthopoly` package (Legendre, Chebyshev, Hermite,
+Bessel) behind the same allow-listed `load("orthopoly")` gate; and the
+`%i«n»`/`%o«n»` history convention. Display follows Macsyma's flags: `;`
+displays, `$` suppresses.
+
+## §3 The `feed` contract
+
+`MaximaSession::feed(src)` parses and evaluates `src` through the wrapped
+`MacsymaSession::eval_source`, then concatenates an echo line **only for results
+whose `display` flag is set** (i.e. statements terminated by `;`, not `$`):
+
+```
+(%o«output_index») «output_text»
+```
+
+`output_index` is Macsyma's 1-based `%o` counter, carried straight through; it is
+shared session state, so a suppressed (`$`) statement still advances history but
+prints nothing. A `CompileError` from the evaluator (a parse or surface error) is
+surfaced verbatim via its `Display` impl as an `Err(String)`, so the REPL can show
+it without a Rust backtrace. There is also a one-shot `maxima_runtime::eval(src)`
+convenience on a fresh session.
+
+## §4 The REPL
+
+`maxima-repl` mirrors `octave-repl`'s single-threaded driver. A statement is
+*incomplete* (the REPL asks for more, switching the prompt to `... `) when, over
+the accumulated buffer with `"`-strings and `/* */`-free surface handled, **no
+terminating `;` or `$` has appeared yet outside a string, or bracket/paren/brace
+depth is still positive.** `quit;`, `quit()`, `exit`, and EOF (Ctrl-D) end the
+session. Errors are printed and the session continues. Statement terminators are
+detected only outside string literals so that `s : "a;b"; ` is one statement.
+
+## §5 Out of scope (for now)
+
+The same subset boundary as `macsyma-runtime`: no plotting, no `batch`/file I/O,
+no arbitrary package `load` beyond the allow-list, no Lisp escape, no `tex`/GUI.
+These are Macsyma-stack concerns; when that stack grows them, Maxima inherits them
+for free.
+
+## §6 Divergence from the HML00 sketch
+
+HML00 §7 sketched Maxima as four items (M-1 grammar diff, M-2 lexer/parser, M-3
+runtime alias, M-4 builtins). In practice the *grammar diff is empty* for the
+supported subset — Maxima and Macsyma parse identically — so M-1/M-2 collapse
+away and there is no `maxima.tokens`/`maxima.grammar`. The work is exactly M-3
+(the runtime alias) plus the REPL, with M-4's "GPL-era builtins" already present
+in the shared `cas-*` surface. This is a strict simplification, noted here so the
+roadmap and the code agree (per repo convention 9).
+
+## §7 References
+
+Internal: [`HML00`](HML00-historical-math-languages-roadmap.md),
+[`MA01`](MA01-matlab-language.md) (the Octave-over-MATLAB precedent),
+`macsyma-runtime`, `symbolic-vm`, the `cas-*` crates.
+
+External: Joel Moses & William Martin, *MACSYMA* (Project MAC, MIT); William
+Schelter, *Maxima* (GPL release, 1998); the Maxima Manual.


### PR DESCRIPTION
## What

Delivers **Maxima** — the GPL-licensed descendant of DOE Macsyma — as the symbolic-CAS analogue of how GNU Octave shipped over MATLAB: a thin runtime façade + REPL over the **existing macsyma stack**, with **no new lexer/parser/grammar**. For the supported subset, Maxima and Macsyma parse identically, so the entire frontend → `symbolic-vm` → 20 `cas-*` crates pipeline is reused verbatim.

This is **Wave 1** of [HML00](code/specs/HML00-historical-math-languages-roadmap.md).

```
(%i1) diff(x^3, x);
(%o1) 3*x^2
(%i2) factor(x^2 - 1);
(%o2) (1 + x)*(x - 1)
(%i3) x : 5$
(%i4) x + 1;
(%o4) 6
```

## Crates

- **`maxima-runtime`** — `MaximaSession { inner: MacsymaSession }`. `feed(src)` forwards to `eval_source` and emits one `(%o«n») «text»` line per **displayed** (`;`-terminated) result; `$` suppresses but still advances the `%o` counter. One-shot `eval(src)` too.
- **`maxima-repl`** — the interactive `maxima` binary, sibling of `octave-repl`: `(%i«n»)`/`...` prompts, `;`/`$` continuation, `quit;`/`exit`/EOF.

## Spec honesty (convention 9)

[MA03](code/specs/MA03-maxima-language.md) is explicit that Maxima inherits *exactly* macsyma-runtime's evaluation power: arithmetic, `diff`, `integrate`, `factor`, `subst` genuinely reduce; `expand`/`solve`/`ratsimp`/`limit`/`trig*` currently parse-and-echo. As macsyma's evaluator grows, Maxima inherits it for free (the façade adds no evaluation logic). The HML00 M-1/M-2 grammar items collapsed (empty diff vs Macsyma) — noted in the roadmap.

## Security

`feed` is a trust boundary over arbitrary text; `/security-review` ran **4 rounds** and found + fixed **3 real vulnerabilities**, final round **PASSED**:

1. **Uncatchable stack-overflow abort** (HIGH) — the reused parser/VM recurse on nesting with no depth limit, so deeply nested input (nested `(`, prefix `-` runs, long `1+1+…` chains) overflowed the stack on creation *and* on `Drop` (trees are retained in `%o` history), aborting the process — `catch_unwind` can't stop a stack overflow. Fixed with a per-statement token cap counted from the **real macsyma lexer**, a total-size cap, and a large-stack worker thread that also builds the echo.
2. **Comment-desync cap bypass** (HIGH) — an initial byte-scan cap didn't model `/* */` comments; a `;`/`"` hidden in a comment let deep nesting through. Fixed by counting the real lexer's tokens (comments are skip patterns).
3. **String-literal-lexeme bypass** (HIGH) — the cap reset on token *lexeme* `;`, but a STRING literal `";"` has value `;`; splicing them reset the counter mid-expression. Fixed by resetting only on token *type* `SEMI`/`DOLLAR`.

Also: session is **rebuilt after any caught panic** (a panic in a lock-holding macsyma handler can't permanently poison/brick it); the REPL `is_incomplete` models comments/strings like the lexer and its accumulation buffer is size-capped (closes an OOM vector).

## Tests

34 tests across both crates (incl. regression tests for all three bypass vectors and the panic-recovery path). `cargo fmt` + `clippy` clean. Standard BUILD/BUILD_windows/README/CHANGELOG/required_capabilities.json for both crates; registered in the workspace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)