### PR TITLE
spec(W-1): Wolfram/Mathematica — MA04 spec + M-expression grammar (Wave 3)

### DIFF
--- a/code/grammars/wolfram.grammar
+++ b/code/grammars/wolfram.grammar
@@ -1,0 +1,99 @@
+# @version 1
+
+# =============================================================================
+# wolfram.grammar — Parser grammar for the Wolfram Language (subset)
+# =============================================================================
+#
+# Drives the generic grammar-driven parser engine (parser::GrammarParser) over
+# the token stream from the wolfram-lexer. Everything in Wolfram is an expression
+# `head[args]`; this grammar parses the surface operators, and the W-4 runtime
+# desugars each rule into the canonical symbolic-ir head (Plus, Times, Power,
+# List, Rule, ReplaceAll, Set, …). See code/specs/MA04-wolfram-language.md.
+#
+# Token names (UPPERCASE) come from the Wolfram lexer (code/grammars/wolfram.tokens):
+#   NUMBER STRING NAME                literals and symbols
+#   SET (=)  SETDELAYED (:=)          assignment
+#   RULE (->)  RULEDELAYED (:>)  REPLACEALL (/.)
+#   AND (&&)  OR (||)  NOT (!)
+#   EQUAL (==)  UNEQUAL (!=)  LESS (<)  GREATER (>)  LE (<=)  GE (>=)
+#   PLUS MINUS TIMES SLASH POWER       arithmetic
+#   BLANK (_)                          pattern blank
+#   LBRACKET RBRACKET   (f[...] application)
+#   LBRACE RBRACE       ({...} list)
+#   LPAREN RPAREN       (grouping)
+#   COMMA SEMI NEWLINE
+#
+# Precedence cascade (loosest binds first -> tightest binds last)
+# ---------------------------------------------------------------
+#   assignment      =  :=                 (right-associative)
+#   replaceall      /.                    (left-associative)
+#   rule            ->  :>                (right-associative)
+#   logical_or      ||
+#   logical_and     &&
+#   logical_not     !  (prefix)
+#   comparison      == != < > <= >=
+#   additive        + -
+#   multiplicative  * /
+#   unary           - +  (prefix)
+#   power           ^                     (right-associative)
+#   application     f[...]                (postfix)
+#   atom            literals, symbols, patterns, {...}, ( ... )
+# =============================================================================
+
+program = { statement_line } ;
+
+# A line is one statement followed by a NEWLINE or `;` (which suppresses its
+# result's display), or a blank/terminator-only line.
+statement_line = statement ( NEWLINE | SEMI )
+               | statement
+               | NEWLINE
+               | SEMI ;
+
+statement = expr ;
+
+expr = assignment ;
+
+# Set / SetDelayed — right-associative, the loosest binding.
+assignment = replaceall [ ( SET | SETDELAYED ) assignment ] ;
+
+# ReplaceAll — left-associative: `e /. a /. b` is ReplaceAll[ReplaceAll[e,a],b].
+replaceall = rule { REPLACEALL rule } ;
+
+# Rule / RuleDelayed — right-associative: `a -> b -> c` is Rule[a, Rule[b, c]].
+rule = logical_or [ ( RULE | RULEDELAYED ) rule ] ;
+
+logical_or  = logical_and { OR logical_and } ;
+logical_and = logical_not { AND logical_not } ;
+logical_not = NOT logical_not | comparison ;
+
+# A single (non-chained) comparison for the subset.
+comparison = additive [ ( EQUAL | UNEQUAL | LESS | GREATER | LE | GE ) additive ] ;
+
+additive       = multiplicative { ( PLUS | MINUS ) multiplicative } ;
+multiplicative = unary { ( TIMES | SLASH ) unary } ;
+
+# Prefix minus/plus. Binds looser than Power, so `-x^2` is -(x^2).
+unary = ( MINUS | PLUS ) unary | power ;
+
+# Power — right-associative: `a^b^c` is Power[a, Power[b, c]].
+power = postfix [ POWER unary ] ;
+
+# Function application in square brackets, left-associative and chainable:
+# `f[x][y]` is `(f[x])[y]`. The arg list may be empty (`f[]`).
+postfix = atom { LBRACKET [ arglist ] RBRACKET } ;
+
+arglist = expr { COMMA expr } ;
+
+# Atoms, including the pattern blank forms:
+#   NAME                a symbol
+#   NAME BLANK [NAME]   x_  or  x_h   (Pattern[x, Blank[]] / Pattern[x, Blank[h]])
+#   BLANK [NAME]        _   or  _h    (Blank[] / Blank[h])
+atom = NUMBER
+     | STRING
+     | NAME [ BLANK [ NAME ] ]
+     | BLANK [ NAME ]
+     | list
+     | group ;
+
+list  = LBRACE [ arglist ] RBRACE ;
+group = LPAREN expr RPAREN ;

--- a/code/grammars/wolfram.tokens
+++ b/code/grammars/wolfram.tokens
@@ -1,0 +1,97 @@
+# Wolfram Language Token Grammar
+# ============================================================================
+#
+# Tokenizes a subset of the Wolfram Language (Mathematica). Wolfram's surface
+# syntax differs from Macsyma's — function application uses SQUARE brackets
+# (`f[x]`), lists use BRACES (`{a, b}`), and the language is built around the
+# replacement operators `/.`, `->`, `:>` and the pattern blanks `_`/`x_`. So,
+# unlike Maxima (which reuses the Macsyma frontend), Wolfram gets its own lexer
+# and parser; only the symbolic engine underneath is shared. See
+# code/specs/MA04-wolfram-language.md.
+#
+# Wolfram is CASE-SENSITIVE (`Sin` is the builtin, `sin` is an ordinary symbol),
+# so case_sensitive is left at its default (true).
+#
+# @version 1
+
+# Strings keep their backslash escapes as raw text; the runtime decodes them.
+escapes: none
+
+# ============================================================================
+# SECTION 1: Multi-character operators
+#
+# Longest-match-first: every multi-character operator is listed before the
+# shorter operator(s) it begins with, so `:=`/`:>` win over a bare `:`, `->`
+# over `-`, `==` over `=`, `/.` over `/`, and `&&`/`||` are the only `&`/`|`
+# forms in this subset.
+# ============================================================================
+
+SETDELAYED  = ":="
+RULEDELAYED = ":>"
+RULE        = "->"
+REPLACEALL  = "/."
+
+EQUAL       = "=="
+UNEQUAL     = "!="
+LE          = "<="
+GE          = ">="
+
+AND         = "&&"
+OR          = "||"
+
+# ============================================================================
+# SECTION 2: Single-character operators and delimiters
+# ============================================================================
+
+PLUS      = "+"
+MINUS     = "-"
+TIMES     = "*"
+SLASH     = "/"
+POWER     = "^"
+SET       = "="
+LESS      = "<"
+GREATER   = ">"
+NOT       = "!"
+
+# `_` is the pattern Blank — it is NOT a symbol/name character in Wolfram
+# (unlike R). `x_` therefore lexes as NAME `x` followed by BLANK.
+BLANK     = "_"
+
+LBRACKET  = "["
+RBRACKET  = "]"
+LBRACE    = "{"
+RBRACE    = "}"
+LPAREN    = "("
+RPAREN    = ")"
+
+COMMA     = ","
+SEMI      = ";"
+
+# ============================================================================
+# SECTION 3: Literal value tokens
+#
+# NUMBER requires a leading digit, so `.5` is not a number and `/.` is never
+# mistaken for the start of a float. NAME is a case-sensitive identifier; builtin
+# heads (Sin, Plus, If, True) are ordinary capitalized NAMEs resolved by the
+# runtime, so there is no `keywords:` block.
+# ============================================================================
+
+NUMBER = /[0-9]+\.?[0-9]*([eE][+-]?[0-9]+)?/
+NAME   = /[a-zA-Z][a-zA-Z0-9]*/
+STRING = /"([^"\\]|\\.)*"/
+
+# ============================================================================
+# SECTION 4: Significant newlines + skip patterns
+#
+# A newline terminates a top-level statement (Wolfram has no required statement
+# terminator), so NEWLINE is a real token — but the W-2 lexer drops newlines that
+# fall inside `[ ]`/`{ }`/`( )` so a call or list may span lines. Spaces/tabs and
+# `(* … *)` comments are consumed silently. (The comment regex is non-nesting for
+# simplicity; true Wolfram comments nest.)
+# ============================================================================
+
+NEWLINE = /\r?\n/
+
+skip:
+  WHITESPACE = /[ \t]+/
+  COMMENT    = /\(\*([^*]|\*[^)])*\*\)/

--- a/code/specs/HML00-historical-math-languages-roadmap.md
+++ b/code/specs/HML00-historical-math-languages-roadmap.md
@@ -190,6 +190,10 @@ sequence of one-PR items run through the autonomous loop (§8).
 - **Wolfram:** W-1 spec + `wolfram.tokens/grammar` (M-expressions); W-2 lexer;
   W-3 parser; W-4 `wolfram-runtime` (rewrite rules + `/.`/`:>` over `symbolic-vm`);
   W-5 repl + binary; W-6 the `cas-*` function surface under Wolfram names.
+  *(W-1 delivered: see [MA04](MA04-wolfram-language.md). Unlike Maxima, the
+  syntax genuinely differs from Macsyma — `f[x]`/`{a,b}`/`/.`/`->`/`x_` — so this
+  is a real new frontend over the shared `symbolic-vm`/`cas-*` engine, not a
+  reuse of the Macsyma grammar.)*
 
 ## §8 Plugging into the autonomous loop
 

--- a/code/specs/MA04-wolfram-language.md
+++ b/code/specs/MA04-wolfram-language.md
@@ -1,0 +1,144 @@
+# MA04 — Wolfram / Mathematica (a subset)
+
+## Status
+
+Active spec / roadmap for a **Wolfram Language** (Mathematica) frontend — Wave 3
+of the historical-math roadmap
+([HML00 §7](HML00-historical-math-languages-roadmap.md)), "the flagship
+symbolic." Unlike [Maxima](MA03-maxima-language.md), which is byte-for-byte
+Macsyma and so reused that frontend wholesale, **Wolfram's surface syntax is
+genuinely different** — `f[x]` function application in *square* brackets,
+`{a, b}` list braces, `_`/`x_` patterns, and the `/.`, `->`, `:>` replacement
+operators. So Wolfram needs a *real new frontend* (lexer + parser). What it
+reuses is the **engine underneath**: every M-expression lowers to the shared
+[`symbolic-ir`](../packages/rust/symbolic-ir) term representation and is
+evaluated by [`symbolic-vm`](../packages/rust/symbolic-vm) term rewriting, with
+[`cas-pattern-matching`](../packages/rust/cas-pattern-matching) backing `/.` and
+[`cas-simplify`](../packages/rust/cas-simplify) backing simplification — the same
+substrate Macsyma drives.
+
+This is the symbolic-CAS analogue of how the MATLAB *numeric* frontend was a new
+grammar over the shared `array-runtime`: a new surface, a shared engine.
+
+## §1 Why Wolfram is "everything is an expression"
+
+Wolfram's defining idea is that *every* program fragment is a single expression
+tree `head[arg, …]` — `2 + 3` is `Plus[2, 3]`, `{1, 2, 3}` is `List[1, 2, 3]`,
+`x = 5` is `Set[x, 5]`, even `f[x]` is just `f` applied to `x`. The infix
+operators are syntactic sugar for those heads. This maps **directly** onto
+`symbolic-ir`'s [`IRNode::Apply { head, args }`](../packages/rust/symbolic-ir):
+parsing a Wolfram program is, essentially, desugaring its surface operators into
+the canonical heads (`Plus`/`Times`/`Power`/`List`/`Rule`/`ReplaceAll`/…) that
+`symbolic-vm` already knows how to rewrite. The pattern/rewrite core (`_`, `x_`,
+`->`, `:>`, `/.`) is a *direct fit* for `cas-pattern-matching`'s
+`Blank`/`Pattern`/`match_pattern`/`rewrite`.
+
+## §2 The pieces (one item = one PR)
+
+Following [HML00 §6](HML00-historical-math-languages-roadmap.md)'s breakdown:
+
+- **W-1 — this spec + the grammar** *(this PR)*. `code/grammars/wolfram.tokens`
+  and `code/grammars/wolfram.grammar`, authored in the grammar-tools format and
+  validated with `grammar-tools validate`. No crate yet — the grammar is the
+  contract the next items implement against.
+- **W-2 — `wolfram-lexer`.** A sibling of the other grammar-driven lexers, with
+  the committed `_grammar.rs` compiled from `wolfram.tokens`, plus a
+  bracket-interior-newline hook (a `NEWLINE` inside `[ ]`, `{ }`, or `( )` is
+  not a statement terminator) — the same shape as the R/S lexer's hook.
+- **W-3 — `wolfram-parser`.** The committed `_grammar.rs` compiled from
+  `wolfram.grammar`, over the generic `parser::GrammarParser`.
+- **W-4 — `wolfram-runtime`.** A `WolframSession` that lowers the parsed
+  `GrammarASTNode` into `symbolic-ir`, evaluates with `symbolic-vm` (a Wolfram
+  `Backend` over the shared handler table), and applies `cas-pattern-matching`
+  for `/.` and `cas-simplify` for `Simplify`. String-in / string-out, like the
+  Maxima/Octave facades.
+- **W-5 — `wolfram-repl` + the `wolfram` (alias `math`) binary.** The
+  interactive prompt (`In[n]:= ` / `Out[n]= `), line-continuation across open
+  brackets, mirroring the other REPLs.
+- **W-6 — the `cas-*` function surface under Wolfram names** (`Sin`, `Expand`,
+  `Factor`, `Solve`, `D`, `Integrate`, …) wired to the existing `cas-*` crates.
+
+## §3 The supported surface (the grammar)
+
+The W-1 grammar captures this subset of Wolfram syntax. Everything is desugared
+to a `head[args]` form (shown in the right column) in W-4.
+
+| Surface | Meaning | Lowers to |
+|---------|---------|-----------|
+| `123`, `1.5` | integer / real literal | `Integer` / `Float` |
+| `"text"` | string literal | `Str` |
+| `Sin`, `x`, `foo` | symbol (case-sensitive; built-ins are Capitalized) | `Symbol` |
+| `f[a, b]` | function application (square brackets) | `f[a, b]` |
+| `{a, b, c}` | list | `List[a, b, c]` |
+| `a + b`, `a - b` | additive | `Plus` / `Subtract` |
+| `a b`* / `a * b` | multiply *(explicit `*` required — see below)* | `Times` |
+| `a / b` | divide | `Times[a, Power[b, -1]]` (W-4) |
+| `a ^ b` | power (right-assoc) | `Power` |
+| `-a` | negation | `Times[-1, a]` |
+| `a == b`, `!=`, `<`, `>`, `<=`, `>=` | comparison | `Equal`/`Unequal`/`Less`/… |
+| `a && b`, `a \|\| b`, `!a` | logic | `And` / `Or` / `Not` |
+| `_`, `x_`, `_h`, `x_h` | pattern blanks | `Blank[]` / `Pattern[x, Blank[]]` / `Blank[h]` / `Pattern[x, Blank[h]]` |
+| `a -> b` | Rule (right-assoc) | `Rule[a, b]` |
+| `a :> b` | RuleDelayed | `RuleDelayed[a, b]` |
+| `expr /. rules` | ReplaceAll (left-assoc) | `ReplaceAll[expr, rules]` |
+| `x = e`, `x := e` | Set / SetDelayed (right-assoc) | `Set` / `SetDelayed` |
+| `( … )` | grouping | — |
+| `e1 ; e2` | statement separator (`;` suppresses output) | *(see below)* |
+
+**Precedence**, loosest → tightest (each binds tighter than the line above):
+`Set`/`SetDelayed` → `ReplaceAll` → `Rule`/`RuleDelayed` → `Or` → `And` → `Not`
+→ comparison → additive → multiplicative → unary minus → `Power` → application
+`f[…]` → atoms. This matches Wolfram's operator precedences for the subset (e.g.
+`x /. a -> b` is `ReplaceAll[x, Rule[a, b]]`; `a && b -> c` is
+`Rule[And[a, b], c]`; `-x^2` is `Times[-1, Power[x, 2]]`).
+
+Comments are `(* … *)`. Newlines terminate a top-level statement; a `;`
+separates statements on one line and suppresses the preceding result's display
+(the REPL convention). Inside `[ ]`/`{ }`/`( )` a newline is whitespace (the W-2
+lexer hook), so a call or list may span lines.
+
+## §4 Honest scope — what is *out* (for now)
+
+This is a clearly-scoped subset (per convention 9 and as S00/R00/MA03 do). The
+W-1 grammar deliberately omits, to be added later if warranted:
+
+- **Implicit multiplication by juxtaposition.** Real Wolfram reads `2 x` as
+  `2*x`; that is genuinely hard in a context-free grammar, so this subset
+  **requires an explicit `*`**. (`2 x` will not parse; write `2*x`.)
+- **`[[ … ]]` `Part`, `;;` `Span`**, `@`/`@@`/`/@` (prefix/apply/map), `&`
+  pure functions and `#`/`#1` slots, `~f~` infix, `|` `Alternatives`,
+  `..`/`...` repeated patterns, `/;` `Condition`, `:` `Optional`/`Pattern`
+  binding, `'` `Derivative`, `%` `Out`, contexts/backtick symbols.
+- **`CompoundExpression` inside an expression** — `;` is supported only as a
+  top-level statement separator, not as `(a; b)`. (Deferred to a later item.)
+- Big-integer / arbitrary-precision and complex literals; `&&`/`||` short
+  circuit is a runtime concern (W-4), not lexical.
+
+These are surface-syntax gaps only; the *engine* (rewrite + pattern matching +
+simplify) already supports the corresponding heads, so each is a grammar/lexer
+addition, not an engine change.
+
+## §5 Reuse strategy
+
+- **Frontend:** the grammar-tools framework, exactly as Macsyma/MATLAB/R use it.
+  `wolfram.tokens`/`wolfram.grammar` compile to committed `_grammar.rs` in
+  `wolfram-lexer`/`wolfram-parser` (W-2/W-3).
+- **Lowering + engine (W-4):** the parsed tree is lowered to
+  [`symbolic_ir::IRNode`](../packages/rust/symbolic-ir) (surface operators →
+  canonical heads), then evaluated by
+  [`symbolic_vm::VM`](../packages/rust/symbolic-vm) with a Wolfram `Backend`
+  over `build_handler_table`. `/.`/`->`/`:>` use
+  [`cas_pattern_matching`](../packages/rust/cas-pattern-matching)
+  (`match_pattern`/`rewrite`/`rule`/`rule_delayed`); `Simplify`/`Expand`/… use
+  the `cas-*` crates (W-6).
+- **REPL (W-5):** a single-threaded driver mirroring `s-repl`/`maxima-repl`.
+
+## §6 References
+
+Internal: [`HML00`](HML00-historical-math-languages-roadmap.md),
+[`MA03`](MA03-maxima-language.md) (the Maxima reuse precedent),
+`symbolic-ir`, `symbolic-vm`, `cas-pattern-matching`, `cas-simplify`,
+`grammar-tools`.
+
+External: Stephen Wolfram, *The Mathematica Book* / *An Elementary Introduction
+to the Wolfram Language*; the Wolfram Language operator-precedence tables.


### PR DESCRIPTION
## What

Opens **Wave 3 — Wolfram/Mathematica (subset)**, the flagship symbolic CAS. This first item (W-1) is the **spec + grammar contract**; the lexer/parser/runtime/repl follow as W-2…W-6, one PR each.

Unlike Maxima (which *is* Macsyma and reused that frontend wholesale), **Wolfram's surface syntax genuinely differs** — square-bracket application `f[x]`, brace lists `{a, b}`, the replacement operators `/.` `->` `:>`, and the pattern blanks `_`/`x_`. So Wolfram needs a **real new frontend**. What it reuses is the *engine*: every M-expression lowers to the shared `symbolic-ir` and is evaluated by `symbolic-vm` term rewriting, with `cas-pattern-matching` backing `/.` and `cas-simplify` backing simplification — the same substrate Macsyma drives. (The symbolic analogue of how MATLAB was a new grammar over the shared `array-runtime`.)

## Deliverables

- **`code/specs/MA04-wolfram-language.md`** — the language spec: the "everything is `head[args]`" model and how it maps onto `IRNode::Apply`; the supported surface (literals, `f[x]`, `{…}`, arithmetic, comparison, logic, patterns, `->`/`:>`/`/.`, `=`/`:=`); the full precedence table; the W-1…W-6 rollout; and an honest out-of-scope list (no juxtaposition multiplication — explicit `*` required; no `[[Part]]`/`Map`/pure-functions/`CompoundExpression`-in-expr yet).
- **`code/grammars/wolfram.tokens`** — square brackets/braces/blank/replacement operators, case-sensitive `NAME`s (builtins are ordinary capitalized symbols — no keywords block), significant `NEWLINE`, `(* *)` comments.
- **`code/grammars/wolfram.grammar`** — the precedence cascade `Set`/`:=` › `/.` › `->`/`:>` › `||` › `&&` › `!` › comparison › `+ -` › `* /` › unary `-` › `^` › application `f[…]` › atoms, with the `_`/`x_`/`_h`/`x_h` pattern-blank atom forms.

## Verification

`grammar-tools validate` passes (**32 tokens, 20 rules, cross-validation OK**), and both files **code-generate** cleanly (the W-2/W-3 `_grammar.rs` step, dry-run). `/security-review` **passed**: this PR is purely declarative, and all six token regexes are disjoint-alternation / flat-quantifier patterns — **ReDoS-safe**, confirmed analytically and by linear-scaling stress tests on adversarial inputs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)