### PR TITLE
feat(web01b-1b): per-connection reorder buffer — pipelined HTTP/1.1 response ordering

### DIFF
--- a/code/packages/rust/embeddable-http-server/CHANGELOG.md
+++ b/code/packages/rust/embeddable-http-server/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## Unreleased
 
+- **WEB01b-1b: pipelined-response ordering for `MailboxHttpServer`.** The server
+  now enables the mailbox's `ordered_responses`, so a single connection's replies
+  are written back in **request order** even when the worker pool finishes them
+  out of order — full HTTP/1.1 keep-alive pipelining is now correct (1a already
+  submitted every framed request; 1b makes the wire order right). The per-
+  connection reorder buffer is bounded by the pool's queue depth, so a connection
+  that pipelines past it is shed with a 503 rather than buffering unboundedly. New
+  test `mailbox_http_server_preserves_pipelined_response_order` pipelines 4
+  requests whose handlers finish in reverse order and asserts the bodies come back
+  `r0, r1, r2, r3` (it fails without the reorder buffer). See
+  `code/specs/WEB01b-mailbox-parallelism.md`.
+
 - **WEB01b-1a: `MailboxHttpServer`** — a deferred-response, *per-request*-parallel
   HTTP server. A single reactor frames each request and **submits it as a job** to
   an in-process `worker_count`-thread pool (`embeddable-tcp-server`'s

--- a/code/packages/rust/embeddable-http-server/src/lib.rs
+++ b/code/packages/rust/embeddable-http-server/src/lib.rs
@@ -541,19 +541,19 @@ impl ShardedHttpServer<transport_platform::windows::WindowsTransportPlatform> {
 /// serialized response back to the originating connection. Handler concurrency is
 /// thereby decoupled from the I/O thread — parallel *by request*.
 ///
-/// **WEB01b-1a scope.** Each framed request is submitted to the pool as it
-/// arrives, and the router writes responses back as workers finish. This serves
-/// one-request-and-close and *sequential* keep-alive correctly and in order
-/// (a sequential client has at most one request in flight at a time, so the
-/// unordered pool cannot reorder its responses). Gating a *pipelined* connection
-/// to one in-flight request — and reordering the pool's out-of-order responses
-/// into HTTP/1.1 wire order — needs a per-connection reorder buffer and is
-/// **WEB01b-1b**. (We intentionally do not use `stream-reactor`'s `defer_read`
-/// here: it replays the deferred chunk on resume, which would corrupt framing
-/// for bytes the handler already consumed — see the handler comment in `bind`.)
-/// Parallelism is across requests, bounded by `worker_count`. The platform
-/// (kqueue / epoll / IOCP) is selected internally by `EmbeddableTcpServer`, so
-/// this type is cross-platform with no per-OS binds.
+/// Each framed request is submitted to the pool as it arrives, so a single
+/// connection can have many requests in flight at once (full HTTP/1.1
+/// pipelining). **WEB01b-1b** keeps the wire correct: the server enables the
+/// mailbox's `ordered_responses`, so the response router writes each connection's
+/// replies in **submission order** (a per-connection reorder buffer) even though
+/// the worker pool finishes them out of order. The reorder buffer is bounded by
+/// the pool's queue depth — a connection that pipelines past it is shed with a
+/// 503 (backpressure), never unbounded buffering. (We intentionally do not use
+/// `stream-reactor`'s `defer_read` for gating: it replays the deferred chunk on
+/// resume, which would corrupt framing for bytes the handler already consumed —
+/// see the handler comment in `bind`.) Parallelism is across requests, bounded by
+/// `worker_count`. The platform (kqueue / epoll / IOCP) is selected internally by
+/// `EmbeddableTcpServer`, so this type is cross-platform with no per-OS binds.
 #[derive(Clone)]
 pub struct MailboxHttpServer {
     inner: EmbeddableTcpServer<HttpConnectionState>,
@@ -578,6 +578,13 @@ impl MailboxHttpServer {
                 host: host.to_string(),
                 port,
                 worker_processes: worker_count.max(1),
+                // WEB01b-1b: write each connection's responses back in submission
+                // order so a pipelined keep-alive connection's replies stay in
+                // HTTP/1.1 request order even when the pool finishes them out of
+                // order (the pool is unordered). The reorder buffer is bounded by
+                // the pool's queue depth — a connection that pipelines past it gets
+                // a 503 (backpressure), not unbounded buffering.
+                ordered_responses: true,
                 ..EmbeddableTcpServerOptions::default()
             },
             // init — one HTTP connection state (buffer + limits) per connection.
@@ -596,10 +603,10 @@ impl MailboxHttpServer {
             // for ANY connection's response), re-feeding a possibly TCP-fragmented
             // tail into the buffer — corrupting framing (a duplicate submit, or a
             // malformed-head 400 emitted before the real response). So we keep
-            // reading instead. This serves one-request-and-close and sequential
-            // keep-alive correctly and in order; gating a PIPELINED connection to
-            // one in-flight request (and reordering the unordered pool's responses)
-            // is WEB01b-1b's job — it needs a per-connection reorder buffer regardless.
+            // reading instead. Pipelined requests on one connection are all
+            // submitted; the mailbox's `ordered_responses` (enabled below) writes
+            // their replies back in submission order via a per-connection reorder
+            // buffer (WEB01b-1b), so the wire stays HTTP/1.1-correct.
             |info: TcpConnectionInfo, state: &mut HttpConnectionState, bytes: &[u8], submitter| {
                 state.buffer.extend_from_slice(bytes);
                 // Drain EVERY complete request the read delivered — a single TCP
@@ -1222,6 +1229,109 @@ mod tests {
             observed_max >= 2,
             "expected concurrent handler execution via the pool on a single reactor, but the \
              max observed in-flight handlers was {observed_max} (inline dispatch never exceeds 1)",
+        );
+    }
+
+    /// WEB01b-1b: a `MailboxHttpServer` writes a **pipelined** connection's
+    /// responses in REQUEST order, even though the (unordered) worker pool
+    /// finishes them out of order. Determinism: the handler for request `k` sleeps
+    /// `(n-1-k)*30ms`, so the LAST pipelined request finishes FIRST in the pool.
+    /// Without the per-connection reorder buffer the client would read the bodies
+    /// reversed; with it (WEB01b-1b's `ordered_responses`), they come back
+    /// `r0, r1, …, r{n-1}` — the request order.
+    #[cfg(not(target_os = "windows"))]
+    #[test]
+    fn mailbox_http_server_preserves_pipelined_response_order() {
+        // Split a raw byte stream of back-to-back HTTP/1 responses into the body
+        // of each, in wire order, using each response's Content-Length.
+        fn parse_http_bodies(raw: &[u8]) -> Vec<String> {
+            fn find(haystack: &[u8], needle: &[u8]) -> Option<usize> {
+                haystack.windows(needle.len()).position(|w| w == needle)
+            }
+            let mut bodies = Vec::new();
+            let mut pos = 0;
+            while pos < raw.len() {
+                let rest = &raw[pos..];
+                let Some(boundary) = find(rest, b"\r\n\r\n") else {
+                    break;
+                };
+                let head = String::from_utf8_lossy(&rest[..boundary]);
+                let content_length = head
+                    .lines()
+                    .find_map(|line| {
+                        line.trim()
+                            .to_ascii_lowercase()
+                            .strip_prefix("content-length:")
+                            .map(|value| value.trim().parse::<usize>().unwrap_or(0))
+                    })
+                    .unwrap_or(0);
+                let body_start = pos + boundary + 4;
+                let body_end = body_start + content_length;
+                if body_end > raw.len() {
+                    break;
+                }
+                bodies.push(String::from_utf8_lossy(&raw[body_start..body_end]).into_owned());
+                pos = body_end;
+            }
+            bodies
+        }
+
+        let worker_count = 4;
+        let n = 4usize;
+
+        let server = MailboxHttpServer::bind(
+            "127.0.0.1",
+            0,
+            HttpServerOptions::default(),
+            worker_count,
+            move |request| {
+                // "/rK" → sleep longer for smaller K, so completion order is reversed.
+                let k: usize = request
+                    .target()
+                    .trim_start_matches("/r")
+                    .parse()
+                    .unwrap_or(0);
+                thread::sleep(Duration::from_millis(((n - 1 - k) * 30) as u64));
+                HttpResponse::ok(format!("r{k}")).with_header("Content-Type", "text/plain")
+            },
+        )
+        .expect("bind mailbox HTTP server");
+
+        let addr = server.local_addr();
+        let serve_handle = {
+            let server = server.clone();
+            thread::spawn(move || server.serve())
+        };
+        thread::sleep(Duration::from_millis(50));
+
+        // One connection; all N requests pipelined in a single write (keep-alive,
+        // the last carrying `Connection: close` so the server closes after the
+        // final response and we can read to EOF).
+        let mut stream = TcpStream::connect(addr).expect("connect");
+        stream
+            .set_read_timeout(Some(Duration::from_secs(10)))
+            .unwrap();
+        let mut pipelined = String::new();
+        for k in 0..n {
+            let close = if k == n - 1 { "Connection: close\r\n" } else { "" };
+            pipelined.push_str(&format!("GET /r{k} HTTP/1.1\r\nHost: localhost\r\n{close}\r\n"));
+        }
+        stream
+            .write_all(pipelined.as_bytes())
+            .expect("write pipelined requests");
+
+        let mut raw = Vec::new();
+        stream.read_to_end(&mut raw).expect("read all responses");
+
+        let bodies = parse_http_bodies(&raw);
+        server.stop();
+        let _ = serve_handle.join();
+
+        let expected: Vec<String> = (0..n).map(|k| format!("r{k}")).collect();
+        assert_eq!(
+            bodies, expected,
+            "pipelined responses must be written in request order despite out-of-order \
+             completion (got {bodies:?})",
         );
     }
 }

--- a/code/packages/rust/embeddable-tcp-server/CHANGELOG.md
+++ b/code/packages/rust/embeddable-tcp-server/CHANGELOG.md
@@ -6,6 +6,18 @@ All notable changes to this package will be documented in this file.
 
 ### Added
 
+- **WEB01b-1b: `ordered_responses` option** for the in-process mailbox. When set,
+  the response router writes each connection's responses back in **submission
+  order** (not worker-completion order) via a per-connection reorder buffer: the
+  submitter records each connection's job-ids in submission order, and the router
+  buffers a finished response until every earlier one on the same connection has
+  been written. This is what a pipelined HTTP/1.1 keep-alive connection needs — the
+  pool is unordered (`supports_ordered_responses: false`), so without it a
+  connection's replies could be written out of request order. Default `false`
+  preserves the exact completion-order behaviour for all other consumers
+  (`MailboxHttpServer` is the only opt-in). New test
+  `inprocess_mailbox_orders_responses_by_submission_when_enabled` proves it
+  deterministically (workers finish `3,2,1,0`; the wire reads `0,1,2,3`).
 - Added `new_inprocess_mailbox` in `EmbeddableTcpServer` to run job execution in
   `generic-job-runtime`'s `RustThreadPool` while keeping the TCP callback and
   mailbox return path unchanged.

--- a/code/packages/rust/embeddable-tcp-server/src/lib.rs
+++ b/code/packages/rust/embeddable-tcp-server/src/lib.rs
@@ -15,7 +15,7 @@
 //! can submit jobs and return immediately. Worker responses are delivered later
 //! through the TCP mailbox owned by the Rust runtime.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, VecDeque};
 use std::fmt;
 use std::io::{self, BufRead, BufReader, Write};
 use std::marker::PhantomData;
@@ -103,6 +103,20 @@ pub struct EmbeddableTcpServerOptions {
     pub worker_job_timeout: Option<Duration>,
     pub worker_restart_policy: StdioWorkerRestartPolicy,
     pub worker: WorkerCommand,
+    /// WEB01b-1b: when `true`, the in-process mailbox response router writes each
+    /// connection's responses back in **submission order** (not worker-completion
+    /// order), via a per-connection reorder buffer. This is what a pipelined
+    /// HTTP/1.1 keep-alive connection needs: requests R1, R2, R3 submitted in that
+    /// order have their responses written R1, R2, R3 even when the (unordered)
+    /// worker pool finishes them out of order. Default `false` preserves the
+    /// completion-order behaviour exactly for every other consumer.
+    ///
+    /// Memory is bounded by the pool's queue depth (a connection that pipelines
+    /// past it is shed via a submit error), and per-connection buffers are
+    /// reclaimed as responses drain — the same lifecycle as the existing route
+    /// table. Like that table, this assumes `worker_fn` always returns a result:
+    /// a permanently-wedged `worker_fn` pins its job's buffer entries until exit.
+    pub ordered_responses: bool,
 }
 
 impl EmbeddableTcpServerOptions {
@@ -126,9 +140,18 @@ impl Default for EmbeddableTcpServerOptions {
             worker_job_timeout: None,
             worker_restart_policy: StdioWorkerRestartPolicy::default(),
             worker: WorkerCommand::new("worker", Vec::<String>::new()),
+            ordered_responses: false,
         }
     }
 }
+
+/// Per-connection submission-order queues of job-ids, used by the in-process
+/// mailbox router when `ordered_responses` is on. For each connection it holds
+/// the ids of its in-flight jobs in the order they were submitted; the router
+/// writes a connection's responses by draining the front of its queue, so a
+/// completed-but-out-of-order response waits until every earlier one on the same
+/// connection has been written. `None` everywhere when ordering is off.
+type ConnectionOrder = Arc<Mutex<BTreeMap<ConnectionId, VecDeque<String>>>>;
 
 /// Language-neutral stdio worker that speaks `generic-job-protocol` JSON lines.
 #[derive(Debug)]
@@ -219,6 +242,9 @@ pub struct RustThreadPoolJobSubmitter<Request, Response> {
     pool: RustThreadPool<Request, Response>,
     routes: Arc<Mutex<BTreeMap<String, ConnectionId>>>,
     next_job_id: Arc<AtomicU64>,
+    /// `Some` only when `ordered_responses` is on: records each connection's
+    /// submission order so the router can write responses back in that order.
+    order: Option<ConnectionOrder>,
     _types: PhantomData<fn() -> (Request, Response)>,
 }
 
@@ -228,6 +254,7 @@ impl<Request, Response> Clone for RustThreadPoolJobSubmitter<Request, Response> 
             pool: self.pool.clone(),
             routes: Arc::clone(&self.routes),
             next_job_id: Arc::clone(&self.next_job_id),
+            order: self.order.clone(),
             _types: PhantomData,
         }
     }
@@ -261,11 +288,35 @@ where
             .expect("thread pool worker route table mutex poisoned")
             .insert(id.clone(), connection_id);
 
+        // Register submission order BEFORE handing the job to the pool, so the
+        // job-id is in the connection's queue before any worker can finish it (the
+        // router only writes ids it finds at the front of that queue).
+        if let Some(order) = &self.order {
+            order
+                .lock()
+                .expect("thread pool worker order table mutex poisoned")
+                .entry(connection_id)
+                .or_default()
+                .push_back(id.clone());
+        }
+
         if let Err(error) = self.pool.submit(request) {
             self.routes
                 .lock()
                 .expect("thread pool worker route table mutex poisoned")
                 .remove(&id);
+            if let Some(order) = &self.order {
+                // Roll back the order entry for the failed submit (it never ran).
+                let mut guard = order
+                    .lock()
+                    .expect("thread pool worker order table mutex poisoned");
+                if let Some(queue) = guard.get_mut(&connection_id) {
+                    queue.retain(|queued| queued != &id);
+                    if queue.is_empty() {
+                        guard.remove(&connection_id);
+                    }
+                }
+            }
             return Err(error.into());
         }
 
@@ -711,10 +762,18 @@ where
             worker_fn,
         );
         let routes = Arc::new(Mutex::new(BTreeMap::new()));
+        // WEB01b-1b: the per-connection submission-order table — present only when
+        // the caller opts into ordered responses, so default callers are unchanged.
+        let order: Option<ConnectionOrder> = if options.ordered_responses {
+            Some(Arc::new(Mutex::new(BTreeMap::new())))
+        } else {
+            None
+        };
         let submitter = RustThreadPoolJobSubmitter {
             pool: pool.clone(),
             routes: Arc::clone(&routes),
             next_job_id: Arc::new(AtomicU64::new(1)),
+            order: order.clone(),
             _types: PhantomData,
         };
         let runtime = build_runtime_mailbox(&options, submitter, init, handler, on_close)
@@ -729,6 +788,7 @@ where
             mailbox,
             Arc::new(map_response),
             Arc::clone(&response_stop),
+            order,
         );
 
         Ok(Self {
@@ -826,52 +886,147 @@ where
     })
 }
 
+/// What the router will write to a connection for one finished job. Computing it
+/// up front (running `map_response`) lets the ordered router buffer it until all
+/// earlier responses on the same connection have been written.
+enum ReadyOutcome {
+    Write { bytes: Vec<u8>, close: bool },
+    Close,
+}
+
+/// Run `map_response` on a job result and reduce it to a `ReadyOutcome`. A failed
+/// map or any non-`Ok` job result (error/cancelled/timed-out) closes the
+/// connection, matching the original completion-order behaviour.
+fn ready_outcome<Response, MapResponse>(
+    result: JobResult<Response>,
+    map_response: &MapResponse,
+) -> ReadyOutcome
+where
+    MapResponse: Fn(Response) -> Result<TcpMailboxFrame, WorkerError>,
+{
+    match result {
+        JobResult::Ok { payload } => match map_response(payload) {
+            Ok(frame) => {
+                let close = frame.close;
+                ReadyOutcome::Write {
+                    bytes: frame.flatten_writes(),
+                    close,
+                }
+            }
+            Err(_) => ReadyOutcome::Close,
+        },
+        JobResult::Error { .. } | JobResult::Cancelled { .. } | JobResult::TimedOut { .. } => {
+            ReadyOutcome::Close
+        }
+    }
+}
+
+/// Write one finished outcome to its connection.
+fn write_outcome(mailbox: &TcpMailbox, connection_id: ConnectionId, outcome: ReadyOutcome) {
+    match outcome {
+        ReadyOutcome::Write { bytes, close } => {
+            if close {
+                mailbox.send_and_close(connection_id, bytes);
+            } else if !bytes.is_empty() {
+                mailbox.send(connection_id, bytes);
+            }
+        }
+        ReadyOutcome::Close => mailbox.close(connection_id),
+    }
+}
+
 fn spawn_rust_thread_pool_response_router<Request, Response, MapResponse>(
     pool: RustThreadPool<Request, Response>,
     routes: Arc<Mutex<BTreeMap<String, ConnectionId>>>,
     mailbox: TcpMailbox,
     map_response: Arc<MapResponse>,
     stop: Arc<AtomicBool>,
+    order: Option<ConnectionOrder>,
 ) -> thread::JoinHandle<()>
 where
     Request: Send + 'static,
     Response: Send + 'static,
     MapResponse: Fn(Response) -> Result<TcpMailboxFrame, WorkerError> + Send + Sync + 'static,
 {
-    thread::spawn(move || loop {
-        if stop.load(Ordering::SeqCst) {
-            break;
-        }
-        let Some(response) = pool
-            .recv_response_timeout(Duration::from_millis(10))
-            .unwrap_or(None)
-        else {
-            continue;
-        };
-        mailbox.resume_all_reads();
-        let Some(connection_id) = routes
-            .lock()
-            .expect("thread pool worker route table mutex poisoned")
-            .remove(&response.id)
-        else {
-            continue;
-        };
+    thread::spawn(move || {
+        // Ordered mode keeps a small per-router buffer of finished-but-not-yet-
+        // written responses, keyed by job-id, until each becomes the front of its
+        // connection's submission queue. Unused (and never populated) when off.
+        let mut ready: BTreeMap<String, (ConnectionId, ReadyOutcome)> = BTreeMap::new();
 
-        match response.result {
-            JobResult::Ok { payload } => match map_response(payload) {
-                Ok(frame) => {
-                    let close = frame.close;
-                    let bytes = frame.flatten_writes();
-                    if close {
-                        mailbox.send_and_close(connection_id, bytes);
-                    } else if !bytes.is_empty() {
-                        mailbox.send(connection_id, bytes);
+        loop {
+            if stop.load(Ordering::SeqCst) {
+                break;
+            }
+            let Some(response) = pool
+                .recv_response_timeout(Duration::from_millis(10))
+                .unwrap_or(None)
+            else {
+                continue;
+            };
+            mailbox.resume_all_reads();
+
+            match &order {
+                // ── Completion order (default): write each response as it lands ──
+                None => {
+                    let Some(connection_id) = routes
+                        .lock()
+                        .expect("thread pool worker route table mutex poisoned")
+                        .remove(&response.id)
+                    else {
+                        continue;
+                    };
+                    let outcome = ready_outcome(response.result, map_response.as_ref());
+                    write_outcome(&mailbox, connection_id, outcome);
+                }
+
+                // ── Submission order (WEB01b-1b): buffer, then drain in order ──
+                Some(order) => {
+                    let connection_id = {
+                        // Peek (do NOT remove yet — removal happens when we write).
+                        let routes = routes
+                            .lock()
+                            .expect("thread pool worker route table mutex poisoned");
+                        match routes.get(&response.id) {
+                            Some(id) => *id,
+                            None => continue, // connection already gone; drop it.
+                        }
+                    };
+                    let outcome = ready_outcome(response.result, map_response.as_ref());
+                    ready.insert(response.id.clone(), (connection_id, outcome));
+
+                    // Pull every now-writable job off the front of this
+                    // connection's queue (holds only the order lock).
+                    let mut writable: Vec<String> = Vec::new();
+                    {
+                        let mut guard = order
+                            .lock()
+                            .expect("thread pool worker order table mutex poisoned");
+                        if let Some(queue) = guard.get_mut(&connection_id) {
+                            while let Some(front) = queue.front() {
+                                if ready.contains_key(front) {
+                                    writable.push(queue.pop_front().expect("front exists"));
+                                } else {
+                                    break; // an earlier response hasn't finished yet.
+                                }
+                            }
+                            if queue.is_empty() {
+                                guard.remove(&connection_id);
+                            }
+                        }
+                    }
+
+                    // Write them out in submission order (no locks held across I/O
+                    // except the brief routes removal).
+                    for job_id in writable {
+                        let (conn, outcome) = ready.remove(&job_id).expect("buffered outcome");
+                        routes
+                            .lock()
+                            .expect("thread pool worker route table mutex poisoned")
+                            .remove(&job_id);
+                        write_outcome(&mailbox, conn, outcome);
                     }
                 }
-                Err(_) => mailbox.close(connection_id),
-            },
-            JobResult::Error { .. } | JobResult::Cancelled { .. } | JobResult::TimedOut { .. } => {
-                mailbox.close(connection_id)
             }
         }
     })
@@ -1534,6 +1689,7 @@ print(json.dumps({"version":1,"kind":"response","body":{"id":body["id"],"result"
                 worker_job_timeout: None,
                 worker_restart_policy: StdioWorkerRestartPolicy::default(),
                 worker,
+                ordered_responses: false,
             },
             |_| (),
             handle_tcp_bytes,
@@ -1802,6 +1958,7 @@ print(json.dumps({"version":1,"kind":"response","body":{"id":body["id"],"result"
                 worker_job_timeout: None,
                 worker_restart_policy: StdioWorkerRestartPolicy::default(),
                 worker,
+                ordered_responses: false,
             },
             |_| (),
             handle_tcp_bytes_mailbox,
@@ -1837,6 +1994,7 @@ print(json.dumps({"version":1,"kind":"response","body":{"id":body["id"],"result"
                 worker_job_timeout: None,
                 worker_restart_policy: StdioWorkerRestartPolicy::default(),
                 worker: WorkerCommand::new("worker", Vec::<String>::new()),
+                ordered_responses: false,
             },
             |_| (),
             handle_tcp_bytes_mailbox_with_submitter::<
@@ -2269,6 +2427,7 @@ emit(second, "second")
                 worker_job_timeout: None,
                 worker_restart_policy: StdioWorkerRestartPolicy::default(),
                 worker: WorkerCommand::new("worker", Vec::<String>::new()),
+                ordered_responses: false,
             },
             |_| (),
             handle_tcp_bytes_mailbox_with_submitter::<
@@ -2301,5 +2460,66 @@ emit(second, "second")
         }
 
         stop_server(server, handle);
+    }
+
+    /// WEB01b-1b: with `ordered_responses` on, the in-process mailbox router
+    /// writes a connection's responses in **submission order** even when the
+    /// (unordered) worker pool finishes them out of order. Each input byte `b`
+    /// becomes one job whose worker sleeps `(N-1-b)*20ms`, so byte 0 finishes LAST
+    /// and byte N-1 finishes FIRST. Submitting bytes `0,1,2,3` and reading back
+    /// `0,1,2,3` proves the reorder buffer restored submission order (the
+    /// completion order was `3,2,1,0`).
+    #[cfg(not(target_os = "windows"))]
+    #[test]
+    fn inprocess_mailbox_orders_responses_by_submission_when_enabled() {
+        let n: u8 = 4;
+        let server = EmbeddableTcpServer::new_inprocess_mailbox(
+            EmbeddableTcpServerOptions {
+                host: "127.0.0.1".to_string(),
+                port: 0,
+                worker_processes: 4,
+                ordered_responses: true,
+                ..EmbeddableTcpServerOptions::default()
+            },
+            |_info| (),
+            |info: TcpConnectionInfo,
+             _state: &mut (),
+             data: &[u8],
+             submitter: &RustThreadPoolJobSubmitter<u8, u8>| {
+                for &byte in data {
+                    let _ = submitter.submit(info.id, byte);
+                }
+                TcpHandlerResult::default()
+            },
+            |_info, _state| {},
+            |response: u8| Ok(TcpMailboxFrame::write(vec![response])),
+            move |job: JobRequest<u8>| {
+                let byte = job.payload;
+                thread::sleep(Duration::from_millis(u64::from(n - 1 - byte) * 20));
+                JobResult::Ok { payload: byte }
+            },
+        )
+        .expect("bind ordered in-process mailbox");
+
+        let addr = server.local_addr();
+        let background = server.clone();
+        let handle = thread::spawn(move || background.serve());
+        thread::sleep(Duration::from_millis(50));
+
+        let mut stream = TcpStream::connect(addr).expect("connect");
+        stream
+            .set_read_timeout(Some(Duration::from_secs(10)))
+            .unwrap();
+        stream.write_all(&[0u8, 1, 2, 3]).expect("write bytes");
+        let mut out = vec![0u8; 4];
+        stream.read_exact(&mut out).expect("read responses");
+
+        server.stop();
+        let _ = handle.join();
+        assert_eq!(
+            out,
+            vec![0u8, 1, 2, 3],
+            "ordered mailbox must write responses in submission order (completion was 3,2,1,0)",
+        );
     }
 }

--- a/code/specs/WEB01b-mailbox-parallelism.md
+++ b/code/specs/WEB01b-mailbox-parallelism.md
@@ -163,10 +163,19 @@ connection" un-gates. Read the mailbox write-back path / connection bookkeeping 
    `std::io::Result` (the mailbox stack is `io::Error`-based), `Clone`; mirrors the
    `ShardedWebServer`/`ShardedServer` surface. web-core 0.2.0→0.3.0, conduit
    0.2.0→0.3.0.
-4. **WEB01b-1b — per-connection reorder buffer** for the *pipelined* path: gate a
-   connection to one in-flight request and reassemble the unordered pool's
-   responses into HTTP/1.1 wire order (the pool is `supports_ordered_responses =
-   false`). Still open.
+4. **WEB01b-1b — per-connection reorder buffer** for the *pipelined* path:
+   reassemble the unordered pool's responses into HTTP/1.1 wire order (the pool is
+   `supports_ordered_responses = false`). ✅ done. Implemented as an opt-in
+   `ordered_responses` flag on `EmbeddableTcpServerOptions` (default off → existing
+   consumers byte-identical; `MailboxHttpServer` is the only opt-in): the submitter
+   records each connection's job-ids in submission order and the router buffers a
+   finished response until every earlier one on that connection has been written.
+   No separate in-flight *gate* was needed — the reorder buffer is already bounded
+   by the pool's queue depth (a connection that pipelines past it is shed with a
+   503). Deterministic tests at both layers:
+   `inprocess_mailbox_orders_responses_by_submission_when_enabled`
+   (embeddable-tcp-server) and `mailbox_http_server_preserves_pipelined_response_order`
+   (embeddable-http-server) — both fail without the buffer.
 5. **WEB01b-3 — comparative benchmark** (`#[ignore]`): single-reactor vs sharded
    (WEB01a) vs mailbox (WEB01b) on a CPU-bound load; document when to pick which.
    ✅ done — `web_serving_modes_cpu_bound_comparison` in

--- a/lessons.md
+++ b/lessons.md
@@ -831,3 +831,29 @@ as a *mechanism* ("replay") — read the reactor's drain path before reusing it,
 and never trust a same-host test to expose a TCP-segmentation-dependent bug
 (loopback coalescing hides it; the Linux runner under parallel load splits the
 read and surfaces it).
+
+## `mv file.bak file` restores OLD mtime → cargo skips the rebuild (false "race")
+
+While building WEB01b-1b I did a "does this test actually prove anything" check:
+`sed -i.bak 's/ordered_responses: true/false/' lib.rs` (build+run → correctly
+FAILED), then `mv lib.rs.bak lib.rs` to restore. The restored file had
+`ordered_responses: true` again — but every subsequent `cargo test` kept FAILING
+as if it were still `false`. Adding ANY `eprintln!` "fixed" it, which screamed
+"timing race." It was not a race.
+
+`mv` preserves the SOURCE file's mtime. The `.bak` was created at the moment of
+the `sed` (before the false-build), so restoring it stamped `lib.rs` with an
+mtime OLDER than the compiled artifact from the false build. Cargo's
+mtime-based staleness check then judged `lib.rs` "older than the build" and
+skipped recompiling — so the tests ran against the stale `ordered_responses:
+false` binary. Adding an `eprintln` edited the file (fresh mtime) and forced a
+real rebuild, which is why it "passed."
+
+Lessons:
+- To revert a quick experiment, restore from git (`git checkout -- file`) or
+  `touch file` after a `cp`/`mv` — never trust `mv file.bak file` to trigger a
+  rebuild; it can move the mtime backwards.
+- A Heisenbug that disappears the instant you add a print, where the print is
+  AFTER the observed effect, is almost never a real race — suspect a stale build
+  artifact (or caching) first. Confirm by `touch`-ing the source and re-running
+  clean BEFORE hunting for a concurrency bug.


### PR DESCRIPTION
## Summary

The final piece of the WEB01b mailbox arc. **WEB01b-1a** already submits every framed request to the worker pool (full pipelining), but the pool is unordered (`supports_ordered_responses=false`), so a single connection's replies could be written **out of request order** — an HTTP/1.1 keep-alive violation. **1b makes the wire order correct.**

### `embeddable-tcp-server` — opt-in `ordered_responses`
A new flag on `EmbeddableTcpServerOptions`, **default `false`** so every existing consumer is byte-identical (`MailboxHttpServer` is the only opt-in). When on:
- the **submitter** records each connection's job-ids in submission order — pushed *before* `pool.submit`, so the id is queued before any worker can finish it (rolled back on submit failure);
- the in-process **response router** buffers each finished response (keyed by job-id) and drains the **front** of the connection's queue, writing a response only once every earlier one on that connection has been written.

Lock discipline: `routes` and `order` are **never held nested** in either direction (no deadlock). Memory is bounded by the pool's queue depth and per-connection buffers are reclaimed as they drain — the same lifecycle as the existing route table. The write path is refactored into `ReadyOutcome` + `ready_outcome` + `write_outcome` helpers shared by both the completion-order and submission-order paths.

### `embeddable-http-server`
`MailboxHttpServer` enables `ordered_responses`, so **pipelined keep-alive is now correct end-to-end**. Over-pipelining past the queue depth is shed with a 503 (no unbounded buffering).

## Test plan
Deterministic tests at **both layers**, each of which **fails without the buffer**:
- [x] `inprocess_mailbox_orders_responses_by_submission_when_enabled` (tcp-server) — workers finish `3,2,1,0`; the wire reads `0,1,2,3`
- [x] `mailbox_http_server_preserves_pipelined_response_order` (http-server) — 4 pipelined requests whose handlers finish in reverse → bodies `r0,r1,r2,r3` (verified it fails with the flag off)
- [x] All affected crates green: embeddable-tcp-server (17), embeddable-http-server (8), web-core (29), conduit; downstream **conduit-capi / conduit-jni** build+test clean
- [x] My code clippy-clean (remaining warnings are pre-existing in other crates); default path byte-identical
- [x] `/security-review` **passed** — no deadlock, bounded memory, no cross-connection misrouting, sound Send/Sync
- [ ] CI green

This closes WEB01b (1a engine, 2 facades, 3 benchmark, 1b ordering all merged/queued). Spec roadmap + CHANGELOGs updated; `lessons.md` records the `mv`-restores-old-mtime stale-build gotcha hit en route.

🤖 Generated with [Claude Code](https://claude.com/claude-code)