### PR TITLE
feat(R-13): 2-D matrix indexing — m[i,j] / m[i,] / m[,j] / m[rows,cols]

### DIFF
--- a/code/grammars/r.grammar
+++ b/code/grammars/r.grammar
@@ -95,7 +95,12 @@ postfix = primary { call_suffix | dindex_suffix | index_suffix | dollar_suffix }
 
 call_suffix   = LPAREN [ arg_list ] RPAREN ;
 dindex_suffix = LBRACKET LBRACKET expr RBRACKET RBRACKET ;
-index_suffix  = LBRACKET [ arg_list ] RBRACKET ;
+# Single `[ … ]` indexing. Each comma-separated position is OPTIONAL, so a whole
+# row / column can be selected with an empty subscript: `m[i, ]`, `m[, j]`,
+# `m[, ]`. The number of positions is (number of commas + 1); a position with no
+# `subscript` means "select everything along that dimension".
+index_suffix  = LBRACKET [ subscript ] { COMMA [ subscript ] } RBRACKET ;
+subscript     = expr ;
 dollar_suffix = DOLLAR NAME ;
 
 arg_list = arg { COMMA arg } ;

--- a/code/grammars/s.grammar
+++ b/code/grammars/s.grammar
@@ -133,7 +133,12 @@ postfix = primary { call_suffix | dindex_suffix | index_suffix | dollar_suffix }
 
 call_suffix   = LPAREN [ arg_list ] RPAREN ;
 dindex_suffix = LBRACKET LBRACKET expr RBRACKET RBRACKET ;
-index_suffix  = LBRACKET [ arg_list ] RBRACKET ;
+# Single `[ … ]` indexing. Each comma-separated position is OPTIONAL, so a whole
+# row / column can be selected with an empty subscript: `m[i, ]`, `m[, j]`,
+# `m[, ]`. The number of positions is (number of commas + 1); a position with no
+# `subscript` means "select everything along that dimension".
+index_suffix  = LBRACKET [ subscript ] { COMMA [ subscript ] } RBRACKET ;
+subscript     = expr ;
 dollar_suffix = DOLLAR NAME ;
 
 arg_list = arg { COMMA arg } ;

--- a/code/packages/rust/r-parser/src/_grammar.rs
+++ b/code/packages/rust/r-parser/src/_grammar.rs
@@ -10,799 +10,378 @@ use grammar_tools::parser_grammar::{GrammarElement, GrammarRule, ParserGrammar};
 pub fn parser_grammar() -> ParserGrammar {
     ParserGrammar {
         rules: vec![
-            GrammarRule {
-                name: r#"program"#.to_string(),
-                body: GrammarElement::Repetition {
-                    element: Box::new(GrammarElement::RuleReference {
-                        name: r#"statement_line"#.to_string(),
-                    }),
-                },
-                line_number: 46,
-            },
-            GrammarRule {
-                name: r#"statement_line"#.to_string(),
-                body: GrammarElement::Alternation {
-                    choices: vec![
-                        GrammarElement::Sequence {
-                            elements: vec![
-                                GrammarElement::RuleReference {
-                                    name: r#"statement"#.to_string(),
-                                },
-                                GrammarElement::Group {
-                                    element: Box::new(GrammarElement::Alternation {
-                                        choices: vec![
-                                            GrammarElement::TokenReference {
-                                                name: r#"NEWLINE"#.to_string(),
-                                            },
-                                            GrammarElement::TokenReference {
-                                                name: r#"SEMICOLON"#.to_string(),
-                                            },
-                                        ],
-                                    }),
-                                },
-                            ],
-                        },
-                        GrammarElement::RuleReference {
-                            name: r#"statement"#.to_string(),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"NEWLINE"#.to_string(),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"SEMICOLON"#.to_string(),
-                        },
-                    ],
-                },
-                line_number: 48,
-            },
-            GrammarRule {
-                name: r#"statement"#.to_string(),
-                body: GrammarElement::RuleReference {
-                    name: r#"expr"#.to_string(),
-                },
-                line_number: 53,
-            },
-            GrammarRule {
-                name: r#"expr"#.to_string(),
-                body: GrammarElement::RuleReference {
-                    name: r#"assignment"#.to_string(),
-                },
-                line_number: 55,
-            },
-            GrammarRule {
-                name: r#"assignment"#.to_string(),
-                body: GrammarElement::Sequence {
-                    elements: vec![
-                        GrammarElement::RuleReference {
-                            name: r#"comparison"#.to_string(),
-                        },
-                        GrammarElement::Optional {
-                            element: Box::new(GrammarElement::Sequence {
-                                elements: vec![
-                                    GrammarElement::Group {
-                                        element: Box::new(GrammarElement::Alternation {
-                                            choices: vec![
-                                                GrammarElement::TokenReference {
-                                                    name: r#"ASSIGN"#.to_string(),
-                                                },
-                                                GrammarElement::TokenReference {
-                                                    name: r#"SUPER_ASSIGN"#.to_string(),
-                                                },
-                                                GrammarElement::TokenReference {
-                                                    name: r#"RIGHT_ASSIGN"#.to_string(),
-                                                },
-                                                GrammarElement::TokenReference {
-                                                    name: r#"RIGHT_SUPER_ASSIGN"#.to_string(),
-                                                },
-                                                GrammarElement::TokenReference {
-                                                    name: r#"EQ"#.to_string(),
-                                                },
-                                            ],
-                                        }),
-                                    },
-                                    GrammarElement::RuleReference {
-                                        name: r#"assignment"#.to_string(),
-                                    },
-                                ],
-                            }),
-                        },
-                    ],
-                },
-                line_number: 64,
-            },
-            GrammarRule {
-                name: r#"comparison"#.to_string(),
-                body: GrammarElement::Sequence {
-                    elements: vec![
-                        GrammarElement::RuleReference {
-                            name: r#"additive"#.to_string(),
-                        },
-                        GrammarElement::Optional {
-                            element: Box::new(GrammarElement::Sequence {
-                                elements: vec![
-                                    GrammarElement::Group {
-                                        element: Box::new(GrammarElement::Alternation {
-                                            choices: vec![
-                                                GrammarElement::TokenReference {
-                                                    name: r#"EQEQ"#.to_string(),
-                                                },
-                                                GrammarElement::TokenReference {
-                                                    name: r#"NE"#.to_string(),
-                                                },
-                                                GrammarElement::TokenReference {
-                                                    name: r#"LE"#.to_string(),
-                                                },
-                                                GrammarElement::TokenReference {
-                                                    name: r#"GE"#.to_string(),
-                                                },
-                                                GrammarElement::TokenReference {
-                                                    name: r#"LT"#.to_string(),
-                                                },
-                                                GrammarElement::TokenReference {
-                                                    name: r#"GT"#.to_string(),
-                                                },
-                                            ],
-                                        }),
-                                    },
-                                    GrammarElement::RuleReference {
-                                        name: r#"additive"#.to_string(),
-                                    },
-                                ],
-                            }),
-                        },
-                    ],
-                },
-                line_number: 66,
-            },
-            GrammarRule {
-                name: r#"additive"#.to_string(),
-                body: GrammarElement::Sequence {
-                    elements: vec![
-                        GrammarElement::RuleReference {
-                            name: r#"multiplicative"#.to_string(),
-                        },
-                        GrammarElement::Repetition {
-                            element: Box::new(GrammarElement::Sequence {
-                                elements: vec![
-                                    GrammarElement::Group {
-                                        element: Box::new(GrammarElement::Alternation {
-                                            choices: vec![
-                                                GrammarElement::TokenReference {
-                                                    name: r#"PLUS"#.to_string(),
-                                                },
-                                                GrammarElement::TokenReference {
-                                                    name: r#"MINUS"#.to_string(),
-                                                },
-                                            ],
-                                        }),
-                                    },
-                                    GrammarElement::RuleReference {
-                                        name: r#"multiplicative"#.to_string(),
-                                    },
-                                ],
-                            }),
-                        },
-                    ],
-                },
-                line_number: 68,
-            },
-            GrammarRule {
-                name: r#"multiplicative"#.to_string(),
-                body: GrammarElement::Sequence {
-                    elements: vec![
-                        GrammarElement::RuleReference {
-                            name: r#"special"#.to_string(),
-                        },
-                        GrammarElement::Repetition {
-                            element: Box::new(GrammarElement::Sequence {
-                                elements: vec![
-                                    GrammarElement::Group {
-                                        element: Box::new(GrammarElement::Alternation {
-                                            choices: vec![
-                                                GrammarElement::TokenReference {
-                                                    name: r#"STAR"#.to_string(),
-                                                },
-                                                GrammarElement::TokenReference {
-                                                    name: r#"SLASH"#.to_string(),
-                                                },
-                                            ],
-                                        }),
-                                    },
-                                    GrammarElement::RuleReference {
-                                        name: r#"special"#.to_string(),
-                                    },
-                                ],
-                            }),
-                        },
-                    ],
-                },
-                line_number: 70,
-            },
-            GrammarRule {
-                name: r#"special"#.to_string(),
-                body: GrammarElement::Sequence {
-                    elements: vec![
-                        GrammarElement::RuleReference {
-                            name: r#"pipe"#.to_string(),
-                        },
-                        GrammarElement::Repetition {
-                            element: Box::new(GrammarElement::Sequence {
-                                elements: vec![
-                                    GrammarElement::TokenReference {
-                                        name: r#"PERCENT_OP"#.to_string(),
-                                    },
-                                    GrammarElement::RuleReference {
-                                        name: r#"pipe"#.to_string(),
-                                    },
-                                ],
-                            }),
-                        },
-                    ],
-                },
-                line_number: 73,
-            },
-            GrammarRule {
-                name: r#"pipe"#.to_string(),
-                body: GrammarElement::Sequence {
-                    elements: vec![
-                        GrammarElement::RuleReference {
-                            name: r#"range"#.to_string(),
-                        },
-                        GrammarElement::Repetition {
-                            element: Box::new(GrammarElement::Sequence {
-                                elements: vec![
-                                    GrammarElement::TokenReference {
-                                        name: r#"PIPE_OP"#.to_string(),
-                                    },
-                                    GrammarElement::RuleReference {
-                                        name: r#"range"#.to_string(),
-                                    },
-                                ],
-                            }),
-                        },
-                    ],
-                },
-                line_number: 78,
-            },
-            GrammarRule {
-                name: r#"range"#.to_string(),
-                body: GrammarElement::Sequence {
-                    elements: vec![
-                        GrammarElement::RuleReference {
-                            name: r#"unary"#.to_string(),
-                        },
-                        GrammarElement::Optional {
-                            element: Box::new(GrammarElement::Sequence {
-                                elements: vec![
-                                    GrammarElement::TokenReference {
-                                        name: r#"COLON"#.to_string(),
-                                    },
-                                    GrammarElement::RuleReference {
-                                        name: r#"unary"#.to_string(),
-                                    },
-                                ],
-                            }),
-                        },
-                    ],
-                },
-                line_number: 81,
-            },
-            GrammarRule {
-                name: r#"unary"#.to_string(),
-                body: GrammarElement::Alternation {
-                    choices: vec![
-                        GrammarElement::Sequence {
-                            elements: vec![
-                                GrammarElement::TokenReference {
-                                    name: r#"MINUS"#.to_string(),
-                                },
-                                GrammarElement::RuleReference {
-                                    name: r#"unary"#.to_string(),
-                                },
-                            ],
-                        },
-                        GrammarElement::RuleReference {
-                            name: r#"power"#.to_string(),
-                        },
-                    ],
-                },
-                line_number: 83,
-            },
-            GrammarRule {
-                name: r#"power"#.to_string(),
-                body: GrammarElement::Sequence {
-                    elements: vec![
-                        GrammarElement::RuleReference {
-                            name: r#"postfix"#.to_string(),
-                        },
-                        GrammarElement::Optional {
-                            element: Box::new(GrammarElement::Sequence {
-                                elements: vec![
-                                    GrammarElement::TokenReference {
-                                        name: r#"CARET"#.to_string(),
-                                    },
-                                    GrammarElement::RuleReference {
-                                        name: r#"unary"#.to_string(),
-                                    },
-                                ],
-                            }),
-                        },
-                    ],
-                },
-                line_number: 87,
-            },
-            GrammarRule {
-                name: r#"postfix"#.to_string(),
-                body: GrammarElement::Sequence {
-                    elements: vec![
-                        GrammarElement::RuleReference {
-                            name: r#"primary"#.to_string(),
-                        },
-                        GrammarElement::Repetition {
-                            element: Box::new(GrammarElement::Alternation {
-                                choices: vec![
-                                    GrammarElement::RuleReference {
-                                        name: r#"call_suffix"#.to_string(),
-                                    },
-                                    GrammarElement::RuleReference {
-                                        name: r#"dindex_suffix"#.to_string(),
-                                    },
-                                    GrammarElement::RuleReference {
-                                        name: r#"index_suffix"#.to_string(),
-                                    },
-                                    GrammarElement::RuleReference {
-                                        name: r#"dollar_suffix"#.to_string(),
-                                    },
-                                ],
-                            }),
-                        },
-                    ],
-                },
-                line_number: 94,
-            },
-            GrammarRule {
-                name: r#"call_suffix"#.to_string(),
-                body: GrammarElement::Sequence {
-                    elements: vec![
-                        GrammarElement::TokenReference {
-                            name: r#"LPAREN"#.to_string(),
-                        },
-                        GrammarElement::Optional {
-                            element: Box::new(GrammarElement::RuleReference {
-                                name: r#"arg_list"#.to_string(),
-                            }),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"RPAREN"#.to_string(),
-                        },
-                    ],
-                },
-                line_number: 96,
-            },
-            GrammarRule {
-                name: r#"dindex_suffix"#.to_string(),
-                body: GrammarElement::Sequence {
-                    elements: vec![
-                        GrammarElement::TokenReference {
-                            name: r#"LBRACKET"#.to_string(),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"LBRACKET"#.to_string(),
-                        },
-                        GrammarElement::RuleReference {
-                            name: r#"expr"#.to_string(),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"RBRACKET"#.to_string(),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"RBRACKET"#.to_string(),
-                        },
-                    ],
-                },
-                line_number: 97,
-            },
-            GrammarRule {
-                name: r#"index_suffix"#.to_string(),
-                body: GrammarElement::Sequence {
-                    elements: vec![
-                        GrammarElement::TokenReference {
-                            name: r#"LBRACKET"#.to_string(),
-                        },
-                        GrammarElement::Optional {
-                            element: Box::new(GrammarElement::RuleReference {
-                                name: r#"arg_list"#.to_string(),
-                            }),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"RBRACKET"#.to_string(),
-                        },
-                    ],
-                },
-                line_number: 98,
-            },
-            GrammarRule {
-                name: r#"dollar_suffix"#.to_string(),
-                body: GrammarElement::Sequence {
-                    elements: vec![
-                        GrammarElement::TokenReference {
-                            name: r#"DOLLAR"#.to_string(),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"NAME"#.to_string(),
-                        },
-                    ],
-                },
-                line_number: 99,
-            },
-            GrammarRule {
-                name: r#"arg_list"#.to_string(),
-                body: GrammarElement::Sequence {
-                    elements: vec![
-                        GrammarElement::RuleReference {
-                            name: r#"arg"#.to_string(),
-                        },
-                        GrammarElement::Repetition {
-                            element: Box::new(GrammarElement::Sequence {
-                                elements: vec![
-                                    GrammarElement::TokenReference {
-                                        name: r#"COMMA"#.to_string(),
-                                    },
-                                    GrammarElement::RuleReference {
-                                        name: r#"arg"#.to_string(),
-                                    },
-                                ],
-                            }),
-                        },
-                    ],
-                },
-                line_number: 101,
-            },
-            GrammarRule {
-                name: r#"arg"#.to_string(),
-                body: GrammarElement::Alternation {
-                    choices: vec![
-                        GrammarElement::Sequence {
-                            elements: vec![
-                                GrammarElement::TokenReference {
-                                    name: r#"NAME"#.to_string(),
-                                },
-                                GrammarElement::TokenReference {
-                                    name: r#"EQ"#.to_string(),
-                                },
-                                GrammarElement::RuleReference {
-                                    name: r#"expr"#.to_string(),
-                                },
-                            ],
-                        },
-                        GrammarElement::RuleReference {
-                            name: r#"expr"#.to_string(),
-                        },
-                    ],
-                },
-                line_number: 105,
-            },
-            GrammarRule {
-                name: r#"primary"#.to_string(),
-                body: GrammarElement::Alternation {
-                    choices: vec![
-                        GrammarElement::TokenReference {
-                            name: r#"NUMBER"#.to_string(),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"HEX_LIT"#.to_string(),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"INT_LIT"#.to_string(),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"COMPLEX_LIT"#.to_string(),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"STRING"#.to_string(),
-                        },
-                        GrammarElement::Literal {
-                            value: r#"TRUE"#.to_string(),
-                        },
-                        GrammarElement::Literal {
-                            value: r#"FALSE"#.to_string(),
-                        },
-                        GrammarElement::Literal {
-                            value: r#"T"#.to_string(),
-                        },
-                        GrammarElement::Literal {
-                            value: r#"F"#.to_string(),
-                        },
-                        GrammarElement::Literal {
-                            value: r#"NULL"#.to_string(),
-                        },
-                        GrammarElement::Literal {
-                            value: r#"NA"#.to_string(),
-                        },
-                        GrammarElement::Literal {
-                            value: r#"NA_integer_"#.to_string(),
-                        },
-                        GrammarElement::Literal {
-                            value: r#"NA_real_"#.to_string(),
-                        },
-                        GrammarElement::Literal {
-                            value: r#"NA_character_"#.to_string(),
-                        },
-                        GrammarElement::Literal {
-                            value: r#"Inf"#.to_string(),
-                        },
-                        GrammarElement::Literal {
-                            value: r#"NaN"#.to_string(),
-                        },
-                        GrammarElement::RuleReference {
-                            name: r#"func_def"#.to_string(),
-                        },
-                        GrammarElement::RuleReference {
-                            name: r#"if_expr"#.to_string(),
-                        },
-                        GrammarElement::RuleReference {
-                            name: r#"for_expr"#.to_string(),
-                        },
-                        GrammarElement::RuleReference {
-                            name: r#"while_expr"#.to_string(),
-                        },
-                        GrammarElement::RuleReference {
-                            name: r#"repeat_expr"#.to_string(),
-                        },
-                        GrammarElement::Literal {
-                            value: r#"break"#.to_string(),
-                        },
-                        GrammarElement::Literal {
-                            value: r#"next"#.to_string(),
-                        },
-                        GrammarElement::RuleReference {
-                            name: r#"block"#.to_string(),
-                        },
-                        GrammarElement::RuleReference {
-                            name: r#"group"#.to_string(),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"NAME"#.to_string(),
-                        },
-                    ],
-                },
-                line_number: 113,
-            },
-            GrammarRule {
-                name: r#"group"#.to_string(),
-                body: GrammarElement::Sequence {
-                    elements: vec![
-                        GrammarElement::TokenReference {
-                            name: r#"LPAREN"#.to_string(),
-                        },
-                        GrammarElement::RuleReference {
-                            name: r#"expr"#.to_string(),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"RPAREN"#.to_string(),
-                        },
-                    ],
-                },
-                line_number: 140,
-            },
-            GrammarRule {
-                name: r#"block"#.to_string(),
-                body: GrammarElement::Sequence {
-                    elements: vec![
-                        GrammarElement::TokenReference {
-                            name: r#"LBRACE"#.to_string(),
-                        },
-                        GrammarElement::Repetition {
-                            element: Box::new(GrammarElement::RuleReference {
-                                name: r#"statement_line"#.to_string(),
-                            }),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"RBRACE"#.to_string(),
-                        },
-                    ],
-                },
-                line_number: 142,
-            },
-            GrammarRule {
-                name: r#"func_def"#.to_string(),
-                body: GrammarElement::Alternation {
-                    choices: vec![
-                        GrammarElement::Sequence {
-                            elements: vec![
-                                GrammarElement::Literal {
-                                    value: r#"function"#.to_string(),
-                                },
-                                GrammarElement::TokenReference {
-                                    name: r#"LPAREN"#.to_string(),
-                                },
-                                GrammarElement::Optional {
-                                    element: Box::new(GrammarElement::RuleReference {
-                                        name: r#"param_list"#.to_string(),
-                                    }),
-                                },
-                                GrammarElement::TokenReference {
-                                    name: r#"RPAREN"#.to_string(),
-                                },
-                                GrammarElement::RuleReference {
-                                    name: r#"expr"#.to_string(),
-                                },
-                            ],
-                        },
-                        GrammarElement::Sequence {
-                            elements: vec![
-                                GrammarElement::TokenReference {
-                                    name: r#"BACKSLASH"#.to_string(),
-                                },
-                                GrammarElement::TokenReference {
-                                    name: r#"LPAREN"#.to_string(),
-                                },
-                                GrammarElement::Optional {
-                                    element: Box::new(GrammarElement::RuleReference {
-                                        name: r#"param_list"#.to_string(),
-                                    }),
-                                },
-                                GrammarElement::TokenReference {
-                                    name: r#"RPAREN"#.to_string(),
-                                },
-                                GrammarElement::RuleReference {
-                                    name: r#"expr"#.to_string(),
-                                },
-                            ],
-                        },
-                    ],
-                },
-                line_number: 147,
-            },
-            GrammarRule {
-                name: r#"param_list"#.to_string(),
-                body: GrammarElement::Sequence {
-                    elements: vec![
-                        GrammarElement::RuleReference {
-                            name: r#"param"#.to_string(),
-                        },
-                        GrammarElement::Repetition {
-                            element: Box::new(GrammarElement::Sequence {
-                                elements: vec![
-                                    GrammarElement::TokenReference {
-                                        name: r#"COMMA"#.to_string(),
-                                    },
-                                    GrammarElement::RuleReference {
-                                        name: r#"param"#.to_string(),
-                                    },
-                                ],
-                            }),
-                        },
-                    ],
-                },
-                line_number: 150,
-            },
-            GrammarRule {
-                name: r#"param"#.to_string(),
-                body: GrammarElement::Alternation {
-                    choices: vec![
-                        GrammarElement::Sequence {
-                            elements: vec![
-                                GrammarElement::TokenReference {
-                                    name: r#"NAME"#.to_string(),
-                                },
-                                GrammarElement::TokenReference {
-                                    name: r#"EQ"#.to_string(),
-                                },
-                                GrammarElement::RuleReference {
-                                    name: r#"expr"#.to_string(),
-                                },
-                            ],
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"NAME"#.to_string(),
-                        },
-                    ],
-                },
-                line_number: 152,
-            },
-            GrammarRule {
-                name: r#"if_expr"#.to_string(),
-                body: GrammarElement::Sequence {
-                    elements: vec![
-                        GrammarElement::Literal {
-                            value: r#"if"#.to_string(),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"LPAREN"#.to_string(),
-                        },
-                        GrammarElement::RuleReference {
-                            name: r#"expr"#.to_string(),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"RPAREN"#.to_string(),
-                        },
-                        GrammarElement::RuleReference {
-                            name: r#"expr"#.to_string(),
-                        },
-                        GrammarElement::Optional {
-                            element: Box::new(GrammarElement::Sequence {
-                                elements: vec![
-                                    GrammarElement::Literal {
-                                        value: r#"else"#.to_string(),
-                                    },
-                                    GrammarElement::RuleReference {
-                                        name: r#"expr"#.to_string(),
-                                    },
-                                ],
-                            }),
-                        },
-                    ],
-                },
-                line_number: 155,
-            },
-            GrammarRule {
-                name: r#"for_expr"#.to_string(),
-                body: GrammarElement::Sequence {
-                    elements: vec![
-                        GrammarElement::Literal {
-                            value: r#"for"#.to_string(),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"LPAREN"#.to_string(),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"NAME"#.to_string(),
-                        },
-                        GrammarElement::Literal {
-                            value: r#"in"#.to_string(),
-                        },
-                        GrammarElement::RuleReference {
-                            name: r#"expr"#.to_string(),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"RPAREN"#.to_string(),
-                        },
-                        GrammarElement::RuleReference {
-                            name: r#"expr"#.to_string(),
-                        },
-                    ],
-                },
-                line_number: 157,
-            },
-            GrammarRule {
-                name: r#"while_expr"#.to_string(),
-                body: GrammarElement::Sequence {
-                    elements: vec![
-                        GrammarElement::Literal {
-                            value: r#"while"#.to_string(),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"LPAREN"#.to_string(),
-                        },
-                        GrammarElement::RuleReference {
-                            name: r#"expr"#.to_string(),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"RPAREN"#.to_string(),
-                        },
-                        GrammarElement::RuleReference {
-                            name: r#"expr"#.to_string(),
-                        },
-                    ],
-                },
-                line_number: 159,
-            },
-            GrammarRule {
-                name: r#"repeat_expr"#.to_string(),
-                body: GrammarElement::Sequence {
-                    elements: vec![
-                        GrammarElement::Literal {
-                            value: r#"repeat"#.to_string(),
-                        },
-                        GrammarElement::RuleReference {
-                            name: r#"expr"#.to_string(),
-                        },
-                    ],
-                },
-                line_number: 161,
-            },
-        ],
+        GrammarRule {
+            name: r#"program"#.to_string(),
+            body: GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"statement_line"#.to_string() }) },
+            line_number: 46,
+        },
+        GrammarRule {
+            name: r#"statement_line"#.to_string(),
+            body: GrammarElement::Alternation { choices: vec![
+                GrammarElement::Sequence { elements: vec![
+                    GrammarElement::RuleReference { name: r#"statement"#.to_string() },
+                    GrammarElement::Group { element: Box::new(GrammarElement::Alternation { choices: vec![
+                            GrammarElement::TokenReference { name: r#"NEWLINE"#.to_string() },
+                            GrammarElement::TokenReference { name: r#"SEMICOLON"#.to_string() },
+                        ] }) },
+                ] },
+                GrammarElement::RuleReference { name: r#"statement"#.to_string() },
+                GrammarElement::TokenReference { name: r#"NEWLINE"#.to_string() },
+                GrammarElement::TokenReference { name: r#"SEMICOLON"#.to_string() },
+            ] },
+            line_number: 48,
+        },
+        GrammarRule {
+            name: r#"statement"#.to_string(),
+            body: GrammarElement::RuleReference { name: r#"expr"#.to_string() },
+            line_number: 53,
+        },
+        GrammarRule {
+            name: r#"expr"#.to_string(),
+            body: GrammarElement::RuleReference { name: r#"assignment"#.to_string() },
+            line_number: 55,
+        },
+        GrammarRule {
+            name: r#"assignment"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::RuleReference { name: r#"comparison"#.to_string() },
+                GrammarElement::Optional { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::Group { element: Box::new(GrammarElement::Alternation { choices: vec![
+                                GrammarElement::TokenReference { name: r#"ASSIGN"#.to_string() },
+                                GrammarElement::TokenReference { name: r#"SUPER_ASSIGN"#.to_string() },
+                                GrammarElement::TokenReference { name: r#"RIGHT_ASSIGN"#.to_string() },
+                                GrammarElement::TokenReference { name: r#"RIGHT_SUPER_ASSIGN"#.to_string() },
+                                GrammarElement::TokenReference { name: r#"EQ"#.to_string() },
+                            ] }) },
+                        GrammarElement::RuleReference { name: r#"assignment"#.to_string() },
+                    ] }) },
+            ] },
+            line_number: 64,
+        },
+        GrammarRule {
+            name: r#"comparison"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::RuleReference { name: r#"additive"#.to_string() },
+                GrammarElement::Optional { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::Group { element: Box::new(GrammarElement::Alternation { choices: vec![
+                                GrammarElement::TokenReference { name: r#"EQEQ"#.to_string() },
+                                GrammarElement::TokenReference { name: r#"NE"#.to_string() },
+                                GrammarElement::TokenReference { name: r#"LE"#.to_string() },
+                                GrammarElement::TokenReference { name: r#"GE"#.to_string() },
+                                GrammarElement::TokenReference { name: r#"LT"#.to_string() },
+                                GrammarElement::TokenReference { name: r#"GT"#.to_string() },
+                            ] }) },
+                        GrammarElement::RuleReference { name: r#"additive"#.to_string() },
+                    ] }) },
+            ] },
+            line_number: 66,
+        },
+        GrammarRule {
+            name: r#"additive"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::RuleReference { name: r#"multiplicative"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::Group { element: Box::new(GrammarElement::Alternation { choices: vec![
+                                GrammarElement::TokenReference { name: r#"PLUS"#.to_string() },
+                                GrammarElement::TokenReference { name: r#"MINUS"#.to_string() },
+                            ] }) },
+                        GrammarElement::RuleReference { name: r#"multiplicative"#.to_string() },
+                    ] }) },
+            ] },
+            line_number: 68,
+        },
+        GrammarRule {
+            name: r#"multiplicative"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::RuleReference { name: r#"special"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::Group { element: Box::new(GrammarElement::Alternation { choices: vec![
+                                GrammarElement::TokenReference { name: r#"STAR"#.to_string() },
+                                GrammarElement::TokenReference { name: r#"SLASH"#.to_string() },
+                            ] }) },
+                        GrammarElement::RuleReference { name: r#"special"#.to_string() },
+                    ] }) },
+            ] },
+            line_number: 70,
+        },
+        GrammarRule {
+            name: r#"special"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::RuleReference { name: r#"pipe"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::TokenReference { name: r#"PERCENT_OP"#.to_string() },
+                        GrammarElement::RuleReference { name: r#"pipe"#.to_string() },
+                    ] }) },
+            ] },
+            line_number: 73,
+        },
+        GrammarRule {
+            name: r#"pipe"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::RuleReference { name: r#"range"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::TokenReference { name: r#"PIPE_OP"#.to_string() },
+                        GrammarElement::RuleReference { name: r#"range"#.to_string() },
+                    ] }) },
+            ] },
+            line_number: 78,
+        },
+        GrammarRule {
+            name: r#"range"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::RuleReference { name: r#"unary"#.to_string() },
+                GrammarElement::Optional { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::TokenReference { name: r#"COLON"#.to_string() },
+                        GrammarElement::RuleReference { name: r#"unary"#.to_string() },
+                    ] }) },
+            ] },
+            line_number: 81,
+        },
+        GrammarRule {
+            name: r#"unary"#.to_string(),
+            body: GrammarElement::Alternation { choices: vec![
+                GrammarElement::Sequence { elements: vec![
+                    GrammarElement::TokenReference { name: r#"MINUS"#.to_string() },
+                    GrammarElement::RuleReference { name: r#"unary"#.to_string() },
+                ] },
+                GrammarElement::RuleReference { name: r#"power"#.to_string() },
+            ] },
+            line_number: 83,
+        },
+        GrammarRule {
+            name: r#"power"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::RuleReference { name: r#"postfix"#.to_string() },
+                GrammarElement::Optional { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::TokenReference { name: r#"CARET"#.to_string() },
+                        GrammarElement::RuleReference { name: r#"unary"#.to_string() },
+                    ] }) },
+            ] },
+            line_number: 87,
+        },
+        GrammarRule {
+            name: r#"postfix"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::RuleReference { name: r#"primary"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::Alternation { choices: vec![
+                        GrammarElement::RuleReference { name: r#"call_suffix"#.to_string() },
+                        GrammarElement::RuleReference { name: r#"dindex_suffix"#.to_string() },
+                        GrammarElement::RuleReference { name: r#"index_suffix"#.to_string() },
+                        GrammarElement::RuleReference { name: r#"dollar_suffix"#.to_string() },
+                    ] }) },
+            ] },
+            line_number: 94,
+        },
+        GrammarRule {
+            name: r#"call_suffix"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::TokenReference { name: r#"LPAREN"#.to_string() },
+                GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"arg_list"#.to_string() }) },
+                GrammarElement::TokenReference { name: r#"RPAREN"#.to_string() },
+            ] },
+            line_number: 96,
+        },
+        GrammarRule {
+            name: r#"dindex_suffix"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::TokenReference { name: r#"LBRACKET"#.to_string() },
+                GrammarElement::TokenReference { name: r#"LBRACKET"#.to_string() },
+                GrammarElement::RuleReference { name: r#"expr"#.to_string() },
+                GrammarElement::TokenReference { name: r#"RBRACKET"#.to_string() },
+                GrammarElement::TokenReference { name: r#"RBRACKET"#.to_string() },
+            ] },
+            line_number: 97,
+        },
+        GrammarRule {
+            name: r#"index_suffix"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::TokenReference { name: r#"LBRACKET"#.to_string() },
+                GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"subscript"#.to_string() }) },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::TokenReference { name: r#"COMMA"#.to_string() },
+                        GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"subscript"#.to_string() }) },
+                    ] }) },
+                GrammarElement::TokenReference { name: r#"RBRACKET"#.to_string() },
+            ] },
+            line_number: 102,
+        },
+        GrammarRule {
+            name: r#"subscript"#.to_string(),
+            body: GrammarElement::RuleReference { name: r#"expr"#.to_string() },
+            line_number: 103,
+        },
+        GrammarRule {
+            name: r#"dollar_suffix"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::TokenReference { name: r#"DOLLAR"#.to_string() },
+                GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
+            ] },
+            line_number: 104,
+        },
+        GrammarRule {
+            name: r#"arg_list"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::RuleReference { name: r#"arg"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::TokenReference { name: r#"COMMA"#.to_string() },
+                        GrammarElement::RuleReference { name: r#"arg"#.to_string() },
+                    ] }) },
+            ] },
+            line_number: 106,
+        },
+        GrammarRule {
+            name: r#"arg"#.to_string(),
+            body: GrammarElement::Alternation { choices: vec![
+                GrammarElement::Sequence { elements: vec![
+                    GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
+                    GrammarElement::TokenReference { name: r#"EQ"#.to_string() },
+                    GrammarElement::RuleReference { name: r#"expr"#.to_string() },
+                ] },
+                GrammarElement::RuleReference { name: r#"expr"#.to_string() },
+            ] },
+            line_number: 110,
+        },
+        GrammarRule {
+            name: r#"primary"#.to_string(),
+            body: GrammarElement::Alternation { choices: vec![
+                GrammarElement::TokenReference { name: r#"NUMBER"#.to_string() },
+                GrammarElement::TokenReference { name: r#"HEX_LIT"#.to_string() },
+                GrammarElement::TokenReference { name: r#"INT_LIT"#.to_string() },
+                GrammarElement::TokenReference { name: r#"COMPLEX_LIT"#.to_string() },
+                GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
+                GrammarElement::Literal { value: r#"TRUE"#.to_string() },
+                GrammarElement::Literal { value: r#"FALSE"#.to_string() },
+                GrammarElement::Literal { value: r#"T"#.to_string() },
+                GrammarElement::Literal { value: r#"F"#.to_string() },
+                GrammarElement::Literal { value: r#"NULL"#.to_string() },
+                GrammarElement::Literal { value: r#"NA"#.to_string() },
+                GrammarElement::Literal { value: r#"NA_integer_"#.to_string() },
+                GrammarElement::Literal { value: r#"NA_real_"#.to_string() },
+                GrammarElement::Literal { value: r#"NA_character_"#.to_string() },
+                GrammarElement::Literal { value: r#"Inf"#.to_string() },
+                GrammarElement::Literal { value: r#"NaN"#.to_string() },
+                GrammarElement::RuleReference { name: r#"func_def"#.to_string() },
+                GrammarElement::RuleReference { name: r#"if_expr"#.to_string() },
+                GrammarElement::RuleReference { name: r#"for_expr"#.to_string() },
+                GrammarElement::RuleReference { name: r#"while_expr"#.to_string() },
+                GrammarElement::RuleReference { name: r#"repeat_expr"#.to_string() },
+                GrammarElement::Literal { value: r#"break"#.to_string() },
+                GrammarElement::Literal { value: r#"next"#.to_string() },
+                GrammarElement::RuleReference { name: r#"block"#.to_string() },
+                GrammarElement::RuleReference { name: r#"group"#.to_string() },
+                GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
+            ] },
+            line_number: 118,
+        },
+        GrammarRule {
+            name: r#"group"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::TokenReference { name: r#"LPAREN"#.to_string() },
+                GrammarElement::RuleReference { name: r#"expr"#.to_string() },
+                GrammarElement::TokenReference { name: r#"RPAREN"#.to_string() },
+            ] },
+            line_number: 145,
+        },
+        GrammarRule {
+            name: r#"block"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::TokenReference { name: r#"LBRACE"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"statement_line"#.to_string() }) },
+                GrammarElement::TokenReference { name: r#"RBRACE"#.to_string() },
+            ] },
+            line_number: 147,
+        },
+        GrammarRule {
+            name: r#"func_def"#.to_string(),
+            body: GrammarElement::Alternation { choices: vec![
+                GrammarElement::Sequence { elements: vec![
+                    GrammarElement::Literal { value: r#"function"#.to_string() },
+                    GrammarElement::TokenReference { name: r#"LPAREN"#.to_string() },
+                    GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"param_list"#.to_string() }) },
+                    GrammarElement::TokenReference { name: r#"RPAREN"#.to_string() },
+                    GrammarElement::RuleReference { name: r#"expr"#.to_string() },
+                ] },
+                GrammarElement::Sequence { elements: vec![
+                    GrammarElement::TokenReference { name: r#"BACKSLASH"#.to_string() },
+                    GrammarElement::TokenReference { name: r#"LPAREN"#.to_string() },
+                    GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"param_list"#.to_string() }) },
+                    GrammarElement::TokenReference { name: r#"RPAREN"#.to_string() },
+                    GrammarElement::RuleReference { name: r#"expr"#.to_string() },
+                ] },
+            ] },
+            line_number: 152,
+        },
+        GrammarRule {
+            name: r#"param_list"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::RuleReference { name: r#"param"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::TokenReference { name: r#"COMMA"#.to_string() },
+                        GrammarElement::RuleReference { name: r#"param"#.to_string() },
+                    ] }) },
+            ] },
+            line_number: 155,
+        },
+        GrammarRule {
+            name: r#"param"#.to_string(),
+            body: GrammarElement::Alternation { choices: vec![
+                GrammarElement::Sequence { elements: vec![
+                    GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
+                    GrammarElement::TokenReference { name: r#"EQ"#.to_string() },
+                    GrammarElement::RuleReference { name: r#"expr"#.to_string() },
+                ] },
+                GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
+            ] },
+            line_number: 157,
+        },
+        GrammarRule {
+            name: r#"if_expr"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Literal { value: r#"if"#.to_string() },
+                GrammarElement::TokenReference { name: r#"LPAREN"#.to_string() },
+                GrammarElement::RuleReference { name: r#"expr"#.to_string() },
+                GrammarElement::TokenReference { name: r#"RPAREN"#.to_string() },
+                GrammarElement::RuleReference { name: r#"expr"#.to_string() },
+                GrammarElement::Optional { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::Literal { value: r#"else"#.to_string() },
+                        GrammarElement::RuleReference { name: r#"expr"#.to_string() },
+                    ] }) },
+            ] },
+            line_number: 160,
+        },
+        GrammarRule {
+            name: r#"for_expr"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Literal { value: r#"for"#.to_string() },
+                GrammarElement::TokenReference { name: r#"LPAREN"#.to_string() },
+                GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
+                GrammarElement::Literal { value: r#"in"#.to_string() },
+                GrammarElement::RuleReference { name: r#"expr"#.to_string() },
+                GrammarElement::TokenReference { name: r#"RPAREN"#.to_string() },
+                GrammarElement::RuleReference { name: r#"expr"#.to_string() },
+            ] },
+            line_number: 162,
+        },
+        GrammarRule {
+            name: r#"while_expr"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Literal { value: r#"while"#.to_string() },
+                GrammarElement::TokenReference { name: r#"LPAREN"#.to_string() },
+                GrammarElement::RuleReference { name: r#"expr"#.to_string() },
+                GrammarElement::TokenReference { name: r#"RPAREN"#.to_string() },
+                GrammarElement::RuleReference { name: r#"expr"#.to_string() },
+            ] },
+            line_number: 164,
+        },
+        GrammarRule {
+            name: r#"repeat_expr"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Literal { value: r#"repeat"#.to_string() },
+                GrammarElement::RuleReference { name: r#"expr"#.to_string() },
+            ] },
+            line_number: 166,
+        },
+    ],
         version: 1,
     }
 }

--- a/code/packages/rust/r-runtime/CHANGELOG.md
+++ b/code/packages/rust/r-runtime/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.8.0] - 2026-06-16
+
+### Added (via the shared `s-runtime` + the `r.grammar` index_suffix change)
+
+- **R-13 — 2-D matrix indexing**: `m[i, j]`, `m[i, ]`, `m[, j]`, `m[rows, cols]`
+  (drop-to-vector on a single row/column), `m[i]` linear indexing, and full
+  positive / negative / logical subscript support (which also fixes 1-D vector
+  negative/logical indexing). Sub-assignment `m[i, j] <- v` is deferred to R-14.
+  See `s-runtime` 0.9.0.
+
 ## [0.7.0] - 2026-06-16
 
 ### Added (via the shared `s-runtime`)

--- a/code/packages/rust/r-runtime/src/lib.rs
+++ b/code/packages/rust/r-runtime/src/lib.rs
@@ -524,4 +524,75 @@ mod tests {
         // with a 2 x 2002 RHS exceeds the column cap.
         assert!(eval_r("solve(diag(2), matrix(1, 2, 2002))\n").is_err());
     }
+
+    // --- R-13: 2-D matrix indexing -------------------------------------
+
+    #[test]
+    fn matrix_element_row_and_column_indexing() {
+        // m is column-major [[1,3,5],[2,4,6]].
+        assert_eq!(nums("matrix(1:6, 2, 3)[1, 2]\n"), vec![3.0]); // (1,2)
+        assert_eq!(nums("matrix(1:6, 2, 3)[1, ]\n"), vec![1.0, 3.0, 5.0]); // whole row 1
+        assert_eq!(nums("matrix(1:6, 2, 3)[, 2]\n"), vec![3.0, 4.0]); // whole column 2
+                                                                      // m[3] indexes the flat column-major vector.
+        assert_eq!(nums("matrix(1:6, 2, 3)[3]\n"), vec![3.0]);
+    }
+
+    #[test]
+    fn matrix_submatrix_keeps_its_shape() {
+        // A multi-row, multi-column subset stays a matrix (no drop).
+        assert_eq!(nums("dim(matrix(1:6, 2, 3)[1:2, 2:3])\n"), vec![2.0, 2.0]);
+        assert_eq!(
+            nums("c(matrix(1:6, 2, 3)[1:2, 2:3])\n"),
+            vec![3.0, 4.0, 5.0, 6.0]
+        );
+    }
+
+    #[test]
+    fn matrix_negative_and_logical_subscripts() {
+        // Negative excludes; logical masks (recycled).
+        assert_eq!(nums("matrix(1:6, 2, 3)[-1, ]\n"), vec![2.0, 4.0, 6.0]);
+        assert_eq!(
+            nums("c(matrix(1:6, 2, 3)[, -1])\n"),
+            vec![3.0, 4.0, 5.0, 6.0]
+        );
+        assert_eq!(
+            nums("matrix(1:6, 2, 3)[c(TRUE, FALSE), ]\n"),
+            vec![1.0, 3.0, 5.0]
+        );
+    }
+
+    #[test]
+    fn vector_negative_and_logical_indexing_now_work() {
+        // R-13 extended 1-D indexing too: negatives exclude, logicals mask
+        // (the logical case previously coerced to numeric and was wrong).
+        assert_eq!(nums("c(10, 20, 30)[-2]\n"), vec![10.0, 30.0]);
+        assert_eq!(
+            nums("c(10, 20, 30)[c(TRUE, FALSE, TRUE)]\n"),
+            vec![10.0, 30.0]
+        );
+        // Mixing positive and negative is an error.
+        assert!(eval_r("c(10, 20, 30)[c(-1, 2)]\n").is_err());
+    }
+
+    #[test]
+    fn matrix_out_of_bounds_subscript_is_an_error() {
+        assert!(eval_r("matrix(1:6, 2, 3)[5, 1]\n").is_err());
+        assert!(eval_r("matrix(1:6, 2, 3)[1, 9]\n").is_err());
+    }
+
+    #[test]
+    fn empty_subscript_on_a_data_frame_selects_the_whole_dimension() {
+        // The grammar change (empty subscripts) benefits data frames too.
+        assert_eq!(
+            nums("data.frame(x = 1:2, y = c(9, 8))[, 1]\n"),
+            vec![1.0, 2.0]
+        );
+    }
+
+    #[test]
+    fn matrix_sub_assignment_is_deferred() {
+        // `m[i, j] <- v` is not yet supported (R-14); it errors cleanly rather
+        // than panicking or silently doing nothing.
+        assert!(eval_r("m <- matrix(1:6, 2, 3)\nm[1, 1] <- 99\n").is_err());
+    }
 }

--- a/code/packages/rust/s-parser/src/_grammar.rs
+++ b/code/packages/rust/s-parser/src/_grammar.rs
@@ -184,10 +184,19 @@ pub fn parser_grammar() -> ParserGrammar {
             name: r#"index_suffix"#.to_string(),
             body: GrammarElement::Sequence { elements: vec![
                 GrammarElement::TokenReference { name: r#"LBRACKET"#.to_string() },
-                GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"arg_list"#.to_string() }) },
+                GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"subscript"#.to_string() }) },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::TokenReference { name: r#"COMMA"#.to_string() },
+                        GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"subscript"#.to_string() }) },
+                    ] }) },
                 GrammarElement::TokenReference { name: r#"RBRACKET"#.to_string() },
             ] },
-            line_number: 136,
+            line_number: 140,
+        },
+        GrammarRule {
+            name: r#"subscript"#.to_string(),
+            body: GrammarElement::RuleReference { name: r#"expr"#.to_string() },
+            line_number: 141,
         },
         GrammarRule {
             name: r#"dollar_suffix"#.to_string(),
@@ -195,7 +204,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::TokenReference { name: r#"DOLLAR"#.to_string() },
                 GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
             ] },
-            line_number: 137,
+            line_number: 142,
         },
         GrammarRule {
             name: r#"arg_list"#.to_string(),
@@ -206,7 +215,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"arg"#.to_string() },
                     ] }) },
             ] },
-            line_number: 139,
+            line_number: 144,
         },
         GrammarRule {
             name: r#"arg"#.to_string(),
@@ -218,7 +227,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 ] },
                 GrammarElement::RuleReference { name: r#"expr"#.to_string() },
             ] },
-            line_number: 143,
+            line_number: 148,
         },
         GrammarRule {
             name: r#"primary"#.to_string(),
@@ -244,7 +253,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::RuleReference { name: r#"group"#.to_string() },
                 GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
             ] },
-            line_number: 154,
+            line_number: 159,
         },
         GrammarRule {
             name: r#"group"#.to_string(),
@@ -253,7 +262,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::RuleReference { name: r#"expr"#.to_string() },
                 GrammarElement::TokenReference { name: r#"RPAREN"#.to_string() },
             ] },
-            line_number: 175,
+            line_number: 180,
         },
         GrammarRule {
             name: r#"block"#.to_string(),
@@ -262,7 +271,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"statement_line"#.to_string() }) },
                 GrammarElement::TokenReference { name: r#"RBRACE"#.to_string() },
             ] },
-            line_number: 177,
+            line_number: 182,
         },
         GrammarRule {
             name: r#"func_def"#.to_string(),
@@ -273,7 +282,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::TokenReference { name: r#"RPAREN"#.to_string() },
                 GrammarElement::RuleReference { name: r#"expr"#.to_string() },
             ] },
-            line_number: 186,
+            line_number: 191,
         },
         GrammarRule {
             name: r#"param_list"#.to_string(),
@@ -284,7 +293,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"param"#.to_string() },
                     ] }) },
             ] },
-            line_number: 188,
+            line_number: 193,
         },
         GrammarRule {
             name: r#"param"#.to_string(),
@@ -296,7 +305,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 ] },
                 GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
             ] },
-            line_number: 190,
+            line_number: 195,
         },
         GrammarRule {
             name: r#"if_expr"#.to_string(),
@@ -311,7 +320,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"expr"#.to_string() },
                     ] }) },
             ] },
-            line_number: 193,
+            line_number: 198,
         },
         GrammarRule {
             name: r#"for_expr"#.to_string(),
@@ -324,7 +333,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::TokenReference { name: r#"RPAREN"#.to_string() },
                 GrammarElement::RuleReference { name: r#"expr"#.to_string() },
             ] },
-            line_number: 195,
+            line_number: 200,
         },
         GrammarRule {
             name: r#"while_expr"#.to_string(),
@@ -335,7 +344,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::TokenReference { name: r#"RPAREN"#.to_string() },
                 GrammarElement::RuleReference { name: r#"expr"#.to_string() },
             ] },
-            line_number: 197,
+            line_number: 202,
         },
         GrammarRule {
             name: r#"repeat_expr"#.to_string(),
@@ -343,7 +352,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"repeat"#.to_string() },
                 GrammarElement::RuleReference { name: r#"expr"#.to_string() },
             ] },
-            line_number: 199,
+            line_number: 204,
         },
     ],
         version: 1,

--- a/code/packages/rust/s-runtime/CHANGELOG.md
+++ b/code/packages/rust/s-runtime/CHANGELOG.md
@@ -2,6 +2,34 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.9.0] - 2026-06-16
+
+### Added
+
+- **2-D matrix indexing (R-13)** — the `[` subscript operator extended to two
+  dimensions. An `index_suffix` grammar change makes each comma-separated
+  subscript optional, so `m[i, j]`, `m[i, ]` (whole row), `m[, j]` (whole
+  column), and `m[rows, cols]` (sub-matrix) all work on `SValue::Matrix`
+  (1-based, column-major). A 2-D result follows R's `drop = TRUE` (a single
+  row/column collapses to a vector). `m[i]` indexes the flat column-major
+  vector. The empty-subscript grammar also enables `df[, j]` / `df[i, ]`.
+
+### Changed
+
+- **Index resolution now supports all three R styles** (`resolve_picks`):
+  **positive** (1-based; `0` drops, out-of-range/`NA` → `NA`), **negative**
+  (`-k` excludes; cannot mix with positive), and **logical** (a mask recycled to
+  the dimension). This fixes 1-D vector indexing — `v[-2]` and
+  `v[c(TRUE, FALSE)]` now behave correctly (logical indices were previously
+  mis-coerced to numbers). `dataframe::index2d` now takes optional (`None` =
+  whole-dimension) subscripts.
+
+### Security
+
+- Out-of-range matrix subscripts are a hard error; the logical-recycle span and
+  the 2-D result size are capped at `MAX_SEQ_LEN`, so negative/logical index
+  expansion cannot be turned into unbounded allocation.
+
 ## [0.8.0] - 2026-06-16
 
 ### Added

--- a/code/packages/rust/s-runtime/src/dataframe.rs
+++ b/code/packages/rust/s-runtime/src/dataframe.rs
@@ -83,15 +83,23 @@ pub fn extract(value: &SValue, key: &SValue) -> SResult<SValue> {
     }
 }
 
-/// `df[rows, cols]` — a 2-D subset. Returns the lone column (as a vector) when a
-/// single column is selected, otherwise a narrower data frame.
-pub fn index2d(value: &SValue, rows: &SValue, cols: &SValue) -> SResult<SValue> {
+/// `df[rows, cols]` — a 2-D subset. Either subscript may be `None` (an empty
+/// subscript selecting the whole dimension). Returns the lone column (as a
+/// vector) when a single column is selected, otherwise a narrower data frame.
+pub fn index2d(value: &SValue, rows: Option<&SValue>, cols: Option<&SValue>) -> SResult<SValue> {
     match value {
         SValue::DataFrame { names, columns } => {
-            let picks = resolve_columns(names, columns.len(), cols)?;
+            // `None` columns → all columns, in order.
+            let picks = match cols {
+                None => (0..columns.len()).collect::<Vec<_>>(),
+                Some(c) => resolve_columns(names, columns.len(), c)?,
+            };
             let selected: Vec<SValue> = picks
                 .iter()
-                .map(|&ci| index(&columns[ci], rows))
+                .map(|&ci| match rows {
+                    None => Ok(columns[ci].clone()), // whole column
+                    Some(r) => index(&columns[ci], r),
+                })
                 .collect::<SResult<_>>()?;
             if selected.len() == 1 {
                 Ok(selected.into_iter().next().unwrap())

--- a/code/packages/rust/s-runtime/src/eval.rs
+++ b/code/packages/rust/s-runtime/src/eval.rs
@@ -20,8 +20,8 @@ use crate::builtins;
 use crate::env::{define, lookup, Env, Scope};
 use crate::error::{SError, SResult};
 use crate::value::{
-    arithmetic, bounded_sequence, class_of, compare, format_value, index, membership, negate, Arg,
-    Param, SValue, MAX_SEQ_LEN,
+    arithmetic, bounded_sequence, class_of, compare, format_value, index, index2d, membership,
+    negate, Arg, Param, SValue, MAX_SEQ_LEN,
 };
 use coding_adventures_s_parser::try_parse_s;
 use parser::grammar_parser::{ASTNodeOrToken, GrammarASTNode};
@@ -555,12 +555,24 @@ impl Interpreter {
                     value = self.apply(value, &args, env)?;
                 }
                 "index_suffix" => {
-                    let args = self.eval_args(suffix, env)?;
-                    value = match args.len() {
-                        1 => index(&value, &args[0].value)?,
-                        // `df[rows, cols]` — 2-D subsetting (data frames).
-                        2 => crate::dataframe::index2d(&value, &args[0].value, &args[1].value)?,
-                        _ => return Err(SError::Index("too many subscripts".into())),
+                    // Each comma-separated position is optional (`m[i, ]`,
+                    // `m[, j]`); `None` means "all of that dimension".
+                    let subs = self.eval_subscripts(suffix, env)?;
+                    value = match subs.len() {
+                        // `x[i]` (or `x[]` → the whole object unchanged).
+                        1 => match &subs[0] {
+                            Some(i) => index(&value, i)?,
+                            None => value,
+                        },
+                        // `m[rows, cols]` / `df[rows, cols]` — 2-D subsetting,
+                        // with empty subscripts selecting a whole dimension.
+                        2 => index2d(&value, subs[0].as_ref(), subs[1].as_ref())?,
+                        _ => {
+                            return Err(SError::Index(format!(
+                                "incorrect number of dimensions ({})",
+                                subs.len()
+                            )))
+                        }
                     };
                     self.visible.set(true);
                 }
@@ -608,6 +620,29 @@ impl Interpreter {
             }
         }
         Ok(args)
+    }
+
+    /// Evaluate the comma-separated subscripts of an `index_suffix` into one
+    /// slot per position. A position with no `subscript` node (an empty
+    /// subscript like the row part of `m[, j]`) yields `None`, meaning "select
+    /// the whole dimension". The number of positions is (number of commas + 1).
+    fn eval_subscripts(&self, suffix: &GrammarASTNode, env: &Env) -> SResult<Vec<Option<SValue>>> {
+        let mut slots: Vec<Option<SValue>> = Vec::new();
+        let mut current: Option<SValue> = None;
+        for child in &suffix.children {
+            match child {
+                ASTNodeOrToken::Node(n) if n.rule_name == "subscript" => {
+                    current = Some(self.eval_node(only_node(n)?, env)?);
+                }
+                ASTNodeOrToken::Token(t) if t.value == "," => {
+                    slots.push(current.take());
+                }
+                // Skip the surrounding `[` / `]` tokens.
+                _ => {}
+            }
+        }
+        slots.push(current.take());
+        Ok(slots)
     }
 
     fn eval_arg(&self, arg: &GrammarASTNode, env: &Env) -> SResult<Arg> {

--- a/code/packages/rust/s-runtime/src/value.rs
+++ b/code/packages/rust/s-runtime/src/value.rs
@@ -562,25 +562,75 @@ fn compare_ord(op: &str, ord: std::cmp::Ordering) -> bool {
 // Indexing — x[i] with a positive-integer index vector (v1)
 // ===========================================================================
 
-/// Index `base` with the numeric index vector `idx` (1-based). Index `0` is
-/// dropped (as in S); an out-of-range or `NA` index yields `NA`. Negative and
-/// logical indices are not supported in v1.
-pub fn index(base: &SValue, idx: &SValue) -> SResult<SValue> {
-    let positions = idx.as_double()?;
-    let len = base.length();
+/// Resolve an index vector against a dimension of length `len` into a list of
+/// selected 0-based positions (`Some(i)`), where `None` marks a slot that
+/// should become `NA` (an out-of-range or `NA` index). Supports R's three index
+/// styles:
+///
+/// * **logical** — a mask recycled to `len`; `TRUE` selects, `FALSE` skips, a
+///   `TRUE` past the end (a longer mask) and an `NA` both yield an `NA` slot;
+/// * **negative** — `-k` *excludes* position `k` (cannot be mixed with positive
+///   subscripts, and `NA` is not allowed);
+/// * **positive** — 1-based selection; `0` selects nothing, out-of-range/`NA`
+///   yield an `NA` slot.
+fn resolve_picks(len: usize, idx: &SValue) -> SResult<Vec<Option<usize>>> {
+    // Logical mask (recycled to the longer of len / mask length).
+    if let SValue::Logical(mask) = idx {
+        if mask.is_empty() {
+            return Ok(Vec::new());
+        }
+        let span = len.max(mask.len());
+        if span > MAX_SEQ_LEN {
+            return Err(SError::Index(format!(
+                "logical index too long (limit {MAX_SEQ_LEN})"
+            )));
+        }
+        let mut picks = Vec::new();
+        for i in 0..span {
+            match mask[i % mask.len()] {
+                Some(true) => picks.push(if i < len { Some(i) } else { None }),
+                Some(false) => {}
+                None => picks.push(None),
+            }
+        }
+        return Ok(picks);
+    }
 
-    // Resolve each requested 1-based position into either Some(0-based) or None
-    // (meaning NA / drop). 0 is dropped entirely.
+    let positions = idx.as_double()?;
+    let any_neg = positions.iter().any(|p| !is_na_real(p) && p < 0.0);
+    let any_pos = positions.iter().any(|p| !is_na_real(p) && p >= 1.0);
+    if any_neg && any_pos {
+        return Err(SError::Index(
+            "can't mix positive and negative subscripts".into(),
+        ));
+    }
+
+    if any_neg {
+        // Negative subscripts EXCLUDE; NA is not allowed, out-of-range is ignored.
+        if positions.iter().any(is_na_real) {
+            return Err(SError::Index(
+                "NAs are not allowed in negative subscripts".into(),
+            ));
+        }
+        let mut excluded = vec![false; len];
+        for p in positions.iter() {
+            if p == 0.0 {
+                continue;
+            }
+            let drop = (-p) as usize; // 1-based magnitude
+            if drop >= 1 && drop <= len {
+                excluded[drop - 1] = true;
+            }
+        }
+        return Ok((0..len).filter(|i| !excluded[*i]).map(Some).collect());
+    }
+
+    // Positive (the common case): 1-based, 0 drops, out-of-range/NA → NA slot.
     let mut picks: Vec<Option<usize>> = Vec::new();
     for p in positions.iter() {
         if is_na_real(p) {
             picks.push(None);
             continue;
-        }
-        if p < 0.0 {
-            return Err(SError::Index(
-                "negative subscripts are not supported in v1".into(),
-            ));
         }
         let one_based = p as usize; // truncates toward zero, like S
         if one_based == 0 {
@@ -592,6 +642,20 @@ pub fn index(base: &SValue, idx: &SValue) -> SResult<SValue> {
             picks.push(Some(one_based - 1));
         }
     }
+    Ok(picks)
+}
+
+/// Index `base` with the index vector `idx` (1-based; positive, negative, or
+/// logical — see [`resolve_picks`]). A `Matrix` is indexed *linearly* over its
+/// flat column-major data (dropping its matrix structure, as R does for `m[i]`).
+pub fn index(base: &SValue, idx: &SValue) -> SResult<SValue> {
+    // `m[i]` — single-subscript indexing of a matrix is over the flat vector.
+    if let SValue::Matrix { data, .. } = base {
+        return index(&SValue::Double(data.clone()), idx);
+    }
+
+    let len = base.length();
+    let picks = resolve_picks(len, idx)?;
 
     Ok(match base {
         SValue::Double(d) => SValue::Double(Double::from_values(
@@ -638,6 +702,78 @@ pub fn index(base: &SValue, idx: &SValue) -> SResult<SValue> {
             )))
         }
     })
+}
+
+// ===========================================================================
+// 2-D indexing — `x[rows, cols]` (R-13)
+// ===========================================================================
+
+/// `x[rows, cols]` — two-subscript indexing, where each subscript is `None`
+/// (an empty subscript: select the whole dimension) or `Some(idx)`. Dispatches
+/// to matrix or data-frame 2-D subsetting.
+pub fn index2d(value: &SValue, rows: Option<&SValue>, cols: Option<&SValue>) -> SResult<SValue> {
+    match value {
+        SValue::Matrix { data, nrow, ncol } => index_matrix_2d(data, *nrow, *ncol, rows, cols),
+        SValue::DataFrame { .. } => crate::dataframe::index2d(value, rows, cols),
+        SValue::Classed { inner, .. } => index2d(inner, rows, cols),
+        other => Err(SError::Index(format!(
+            "incorrect number of dimensions for {}",
+            other.type_name()
+        ))),
+    }
+}
+
+/// Resolve one matrix subscript into concrete 0-based positions along a
+/// dimension of length `dim`. An empty subscript (`None`) is the whole
+/// dimension; otherwise NA / out-of-range positions are a hard error (R rejects
+/// them for matrix subscripts rather than producing NA rows).
+fn resolve_dim(slot: Option<&SValue>, dim: usize) -> SResult<Vec<usize>> {
+    match slot {
+        None => Ok((0..dim).collect()),
+        Some(idx) => resolve_picks(dim, idx)?
+            .into_iter()
+            .map(|p| p.ok_or_else(|| SError::Index("subscript out of bounds".into())))
+            .collect(),
+    }
+}
+
+/// `m[rows, cols]` over a column-major matrix. The result is the `rows × cols`
+/// sub-rectangle; following R's default `drop = TRUE`, a single-row or
+/// single-column result collapses to a plain vector.
+fn index_matrix_2d(
+    data: &Double,
+    nrow: usize,
+    ncol: usize,
+    rows: Option<&SValue>,
+    cols: Option<&SValue>,
+) -> SResult<SValue> {
+    let rsel = resolve_dim(rows, nrow)?;
+    let csel = resolve_dim(cols, ncol)?;
+    let (out_nrow, out_ncol) = (rsel.len(), csel.len());
+    let total = out_nrow
+        .checked_mul(out_ncol)
+        .filter(|&t| t <= MAX_SEQ_LEN)
+        .ok_or_else(|| SError::Index(format!("matrix subset too large (limit {MAX_SEQ_LEN})")))?;
+
+    let src = data.data();
+    let mut out = vec![0.0; total];
+    for (oc, &c) in csel.iter().enumerate() {
+        for (or, &r) in rsel.iter().enumerate() {
+            // Both are column-major: (r, c) at c*nrow + r.
+            out[oc * out_nrow + or] = src[c * nrow + r];
+        }
+    }
+
+    // drop = TRUE: a single row or column becomes a vector.
+    if out_nrow == 1 || out_ncol == 1 {
+        Ok(SValue::Double(Double::from_values(out)))
+    } else {
+        Ok(SValue::Matrix {
+            data: Double::from_values(out),
+            nrow: out_nrow,
+            ncol: out_ncol,
+        })
+    }
 }
 
 // ===========================================================================
@@ -1097,8 +1233,22 @@ mod tests {
         );
         let oob = index(&base, &SValue::scalar(9.0)).unwrap();
         assert!(is_na_real(dbl(&oob)[0]));
-        // negative subscript is rejected in v1
-        assert!(index(&base, &SValue::scalar(-1.0)).is_err());
+        // negative subscript EXCLUDES that position (R-13)
+        assert_eq!(
+            dbl(&index(&base, &SValue::scalar(-1.0)).unwrap()),
+            vec![20.0, 30.0]
+        );
+        // mixing positive and negative is an error
+        assert!(index(&base, &SValue::doubles(vec![-1.0, 2.0])).is_err());
+        // a logical mask selects by position (recycled)
+        assert_eq!(
+            dbl(&index(
+                &base,
+                &SValue::Logical(vec![Some(true), Some(false), Some(true)])
+            )
+            .unwrap()),
+            vec![10.0, 30.0]
+        );
         // logical and character vectors are subsettable too
         let lg = index(
             &SValue::Logical(vec![Some(true), Some(false)]),

--- a/code/specs/R00-r-language.md
+++ b/code/specs/R00-r-language.md
@@ -154,6 +154,30 @@ unchanged.
     and `solve` an error, and the dimension is capped (`MAX_SOLVE_DIM`) so the
     `O(n³)` work cannot be turned into a denial-of-service. All construction is
     bounded by `MAX_SEQ_LEN`.
+- **R-13 — 2-D matrix indexing** *(this PR)*. The `[` subscript operator extended
+  to two dimensions and to R's full index styles, in the shared `s-runtime`:
+  - A **grammar change** makes each comma-separated subscript *optional*, so an
+    empty subscript selects a whole dimension: `m[i, j]` (one element),
+    `m[i, ]` (a whole row), `m[, j]` (a whole column), `m[rows, cols]`
+    (a sub-matrix). `index_suffix` becomes
+    `LBRACKET [ subscript ] { COMMA [ subscript ] } RBRACKET` in both `s.grammar`
+    and `r.grammar` (regenerated); the evaluator reads one slot per
+    comma-separated position, `None` meaning "all of that dimension".
+  - Each subscript resolves through a shared `resolve_picks` that now supports
+    all three R index styles: **positive** (1-based; `0` drops, out-of-range/`NA`
+    → `NA`), **negative** (`-k` *excludes* position `k`; cannot be mixed with
+    positive), and **logical** (a mask recycled to the dimension; `TRUE` selects).
+    This also fixes 1-D vector indexing — `v[-2]` and `v[c(TRUE, FALSE)]` now
+    behave correctly (logical indices were previously mis-coerced to numbers).
+  - `m[i]` indexes the **flat column-major** vector (dropping matrix structure,
+    as R does). A 2-D result follows R's default `drop = TRUE`: a single row or
+    column collapses to a vector, otherwise the result is a matrix. Out-of-range
+    matrix subscripts are a hard error; the result size and the logical-recycle
+    span are capped at `MAX_SEQ_LEN`. The empty-subscript grammar also enables
+    `df[, j]` / `df[i, ]` on data frames.
+  - *Deferred (R-14):* **sub-assignment** `m[i, j] <- v` — it needs new
+    lvalue-target machinery (the evaluator currently only assigns to bare names),
+    a separable feature; today it is a clean error, not a silent no-op.
 
 ## §4 Reuse strategy
 


### PR DESCRIPTION
## What

Extends the `[` subscript operator to **two dimensions** and to R's **full index styles**, on the R-11 `SValue::Matrix`. All in the shared `s-runtime`.

```r
m <- matrix(1:6, 2, 3)   # column-major [[1,3,5],[2,4,6]]
m[1, 2]      # 3        (one element)
m[1, ]       # 1 3 5    (whole row — drops to a vector)
m[, 2]       # 3 4      (whole column)
m[1:2, 2:3]  # a 2x2 sub-matrix (no drop)
m[3]         # 3        (linear, flat column-major)
m[-1, ]      # 2 4 6    (negative excludes)
m[c(TRUE,FALSE), ]      # logical row mask
```

## How

- **Grammar change** (`s.grammar` + `r.grammar`, regenerated `_grammar.rs`): `index_suffix` becomes `LBRACKET [ subscript ] { COMMA [ subscript ] } RBRACKET`, so each comma-separated position is **optional** — an empty subscript selects a whole dimension. The evaluator's new `eval_subscripts` reads one `Option<SValue>` slot per position (`None` = all of that dimension).
- **`resolve_picks`** — one shared resolver for all three R index styles: **positive** (1-based; `0` drops, out-of-range/`NA` → `NA`), **negative** (`-k` excludes; can't mix with positive), **logical** (mask recycled to the dimension). This also **fixes 1-D vector indexing**: `v[-2]` and `v[c(TRUE, FALSE)]` previously mis-coerced logicals to numbers and gave wrong results.
- **`index_matrix_2d`** builds the `rows × cols` sub-rectangle column-major, following R's default **`drop = TRUE`** (single row/column → vector). `index()` gained a `Matrix` arm for linear `m[i]`. `dataframe::index2d` now takes optional subscripts, so `df[, j]` / `df[i, ]` work too.

## Scope

This PR is **read indexing**. **Sub-assignment `m[i, j] <- v` is deferred to R-14** — it needs new lvalue-target machinery (the evaluator only assigns to bare names today), a cleanly separable feature. Today it errors cleanly rather than panicking or silently doing nothing (tested).

## Security

`/security-review` **PASSED** (focus: index bounds + negative/logical expansion DoS). Every slice index in `resolve_picks`/`index`/`resolve_dim`/`index_matrix_2d` is **provably in-bounds** for all reachable inputs (degenerate 0×n shapes, empty masks, NaN/Inf/NA/huge/negative subscripts); the modulo-by-zero in the logical-recycle is guarded by an early empty-mask return; the recycle span and 2-D result size are capped at `MAX_SEQ_LEN` **before** allocation; and float→int saturation + exact-bit-pattern `is_na_real` neutralize pathological subscripts. Out-of-range matrix subscripts are a hard error.

## Tests

7 new r-runtime tests + an updated `indexing_variants` (negative/logical now work) — **50 r-runtime + 119 s-runtime** pass; `fmt` + `clippy` clean; existing S/R behavior preserved (the grammar change regenerated both parsers with no regression). R00 spec R-13 entry; s-runtime 0.9.0 / r-runtime 0.8.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)