### PR TITLE
feat(closurec): ADVANCED runs the optimization pipeline (no longer a no-op)

### DIFF
--- a/code/programs/rust/closurec/CHANGELOG.md
+++ b/code/programs/rust/closurec/CHANGELOG.md
@@ -2,6 +2,37 @@
 
 All notable changes to the `coding-adventures-closurec` binary will be documented in this file.
 
+## [0.144.0] - 2026-06-16
+
+### Changed (CLOC12.161 — ADVANCED now optimizes instead of being a no-op)
+
+`--compilation_level ADVANCED` was a **literal no-op**: it returned the source
+verbatim (`source.to_string()`), so ADVANCED users got no optimization at all.
+ADVANCED now runs the **same typed optimization pipeline as SIMPLE**
+(`constant-fold → fold-control-flow → dce → inline → remove-unused-vars →
+treeshake → rename`). ADVANCED is specified to be *at least* as aggressive as
+SIMPLE, so reusing the SIMPLE pipeline is a correct lower bound. Advanced-only
+passes (aggressive property/global renaming, cross-module tree-shaking) will
+layer on here as they are implemented.
+
+```js
+var dead = 1 + 2; function compute(longName) { return longName + 1; } report(compute(7));
+//  --compilation_level ADVANCED  ⇒  function compute(a){return a + 1};report(compute(7));
+```
+
+- The `Advanced` arm now shares the `Simple` match arm (the same
+  parse→bridge→pipeline→emit path, degrade-safe to whitespace_only).
+- `Bundle` / `TranspileOnly` remain identity (module bundling and language
+  down-levelling are orthogonal and land separately).
+- The `compilation_level` correlation-vector contribution for ADVANCED is now
+  `advanced_v1` (same shape as `simple_v2` — level, bridge_status, passes,
+  byte lengths) instead of the former `identity` tag.
+
+### Verified
+- New `tests/diff/advanced-optimizes/` fixture + `tests/diff_advanced_optimizes.rs`.
+- New unit tests `advanced_optimizes_like_simple` (ADVANCED is no longer
+  identity) and `advanced_matches_simple_output` (ADVANCED ≡ SIMPLE today).
+
 ## [0.143.0] - 2026-06-16
 
 ### Added (CLOC12.160 — SIMPLE pipeline gains `rename`)

--- a/code/programs/rust/closurec/Cargo.toml
+++ b/code/programs/rust/closurec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closurec"
-version = "0.143.0"
+version = "0.144.0"
 edition = "2021"
 description = "closurec — CLI driver for the Closure Compiler clone. Mirrors the upstream Java Closure Compiler's command-line flag surface (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility. Per CLOC08."
 

--- a/code/programs/rust/closurec/README.md
+++ b/code/programs/rust/closurec/README.md
@@ -125,7 +125,8 @@ body fills in.**
 |-------|--------------|
 | `WHITESPACE_ONLY` | Strips comments and inter-token whitespace only. Token-level; never parses to a typed AST. |
 | `SIMPLE` | Runs the typed-AST optimization pipeline — parse → bridge → passes → emit. Today the pipeline is `constant-fold → fold-control-flow → dce → inline → remove-unused-vars → treeshake → rename` (e.g. `1 + 2` ⇒ `3`; `if (2 > 3) {a} else {b}` ⇒ `{b}`; code after a `return` is dropped; unused top-level `var`s with pure initializers and unused top-level `function`s are deleted; leaf-function parameters are shortened to `a`, `b`, …); more passes land one PR at a time. Falls back to `WHITESPACE_ONLY` if the source uses a not-yet-supported construct, so it never errors on valid input. |
-| `ADVANCED` / `BUNDLE` / `TRANSPILE_ONLY` | Identity passthrough for now — the typed passes specific to these levels (tree-shaking, property renaming, etc.) land in follow-up work. |
+| `ADVANCED` | Runs the same typed optimization pipeline as `SIMPLE` (it is specified to be at least as aggressive). Advanced-only passes — aggressive property/global renaming, cross-module tree-shaking — layer on as they are implemented. |
+| `BUNDLE` / `TRANSPILE_ONLY` | Identity passthrough for now — module bundling and language down-levelling are orthogonal to the optimization pipeline and land separately. |
 
 The SIMPLE pipeline:
 

--- a/code/programs/rust/closurec/cli.spec.json
+++ b/code/programs/rust/closurec/cli.spec.json
@@ -2,7 +2,7 @@
   "cli_builder_spec_version": "1.0",
   "name": "closurec",
   "description": "closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.",
-  "version": "0.143.0",
+  "version": "0.144.0",
   "parsing_mode": "gnu",
   "flags": [
     { "id": "browser_featureset_year", "long": "browser_featureset_year", "type": "integer", "default": 0, "description": "Shortcut for defining goog.FEATURESET_YEAR=YYYY (minimum 2012)." },

--- a/code/programs/rust/closurec/src/run.rs
+++ b/code/programs/rust/closurec/src/run.rs
@@ -151,9 +151,9 @@ impl std::error::Error for CompilerError {}
 /// | Level             | Transform                                         |
 /// |-------------------|---------------------------------------------------|
 /// | `WhitespaceOnly`  | strip comments + collapse whitespace              |
-/// | `Simple`          | bridge-parse → whitespace_only (CLOC12.137 v1;    |
-/// |                   | typed passes land in follow-up PRs)               |
-/// | `Advanced`        | identity (future: typed passes)                   |
+/// | `Simple`          | bridge → typed optimization pipeline → emit       |
+/// | `Advanced`        | same typed pipeline as `Simple` (≥ SIMPLE;        |
+/// |                   | advanced-only passes land here as implemented)    |
 /// | `Bundle`          | identity                                          |
 /// | `TranspileOnly`   | identity                                          |
 ///
@@ -191,7 +191,8 @@ pub fn transform_source(
 /// |--------------------|--------------------|------------------|------------------------------------------|
 /// | WhitespaceOnly     | `compilation_level`| `whitespace_only`| `{input_byte_len, output_byte_len}`      |
 /// | Simple             | `compilation_level`| `simple_v2`      | `{level, bridge_status, passes, input_byte_len, output_byte_len}` |
-/// | Advanced / other   | `compilation_level`| `identity`       | `{level: "ADVANCED" \| "BUNDLE" \| ...}` |
+/// | Advanced           | `compilation_level`| `advanced_v1`    | same shape as `simple_v2` (shares the pipeline)  |
+/// | Bundle / Transpile | `compilation_level`| `identity`       | `{level: "BUNDLE" \| "TRANSPILE_ONLY"}` |
 /// | Defines            | `defines`          | `applied`        | `{input_byte_len, output_byte_len, defines_count}` |
 ///
 /// **`bridge_status`** (Simple only): `"ok"` if the full
@@ -356,9 +357,10 @@ pub fn transform_source_with_cv(
     // implement Copy, but we can reborrow at each call site.
     let mut cv_pair = cv;
 
-    // bridge_status is set only for CompilationLevel::Simple and
-    // threaded into the CV contribution below. Other levels leave
-    // it None, where the CV block substitutes "n/a".
+    // bridge_status is set for the typed-pipeline levels (Simple and
+    // Advanced, which share that pipeline) and threaded into the CV
+    // contribution below. Other levels leave it None, where the CV block
+    // substitutes "n/a".
     let mut simple_bridge_status: Option<String> = None;
 
     // Step 1 — compilation-level transform.
@@ -402,7 +404,14 @@ pub fn transform_source_with_cv(
         // correlation-vector trace can show whether the run was a true
         // optimized emit (`"ok"`) or a degrade (`"parse_error:…"`,
         // `"unsupported_syntax:…"`, `"pass_error:…"`, `"emit_error:…"`).
-        CompilationLevel::Simple => {
+        // ADVANCED currently runs the *same* typed optimization pipeline
+        // as SIMPLE. It is specified to be at least as aggressive as
+        // SIMPLE, so reusing the SIMPLE pipeline is a correct lower bound
+        // (and removes the former literal no-op, where ADVANCED returned
+        // the source verbatim). Advanced-only passes — aggressive
+        // property/global renaming, cross-module tree-shaking — layer on
+        // here as they are implemented.
+        CompilationLevel::Simple | CompilationLevel::Advanced => {
             // Attempt the typed optimization path. `Some(code)` means
             // the full parse→bridge→passes→emit chain succeeded;
             // `None` means we should degrade to whitespace_only.
@@ -442,10 +451,10 @@ pub fn transform_source_with_cv(
                 }
             }
         }
-        // Advanced / Bundle / TranspileOnly: identity until typed passes land.
-        CompilationLevel::Advanced
-        | CompilationLevel::Bundle
-        | CompilationLevel::TranspileOnly => source.to_string(),
+        // Bundle / TranspileOnly: identity for now (module bundling and
+        // language down-levelling are orthogonal to the optimization
+        // pipeline and land separately).
+        CompilationLevel::Bundle | CompilationLevel::TranspileOnly => source.to_string(),
     };
 
     if let Some((log, cv_id, _token_ids)) = cv_pair.as_mut() {
@@ -465,50 +474,51 @@ pub fn transform_source_with_cv(
                         ),
                     ],
                 ),
-                CompilationLevel::Simple => (
-                    "simple_v2",
-                    vec![
-                        ("level", serde_json::Value::String("SIMPLE".into())),
-                        (
-                            "bridge_status",
-                            serde_json::Value::String(
-                                simple_bridge_status
-                                    .as_deref()
-                                    .unwrap_or("n/a")
-                                    .into(),
+                // SIMPLE and ADVANCED share the typed optimization
+                // pipeline, so they share this contribution shape. The
+                // tag and `level` distinguish them; ADVANCED runs the same
+                // passes today (it is ≥ SIMPLE) and gains advanced-only
+                // passes here as they land.
+                CompilationLevel::Simple | CompilationLevel::Advanced => {
+                    let (tag, level) = match config.compilation.level {
+                        CompilationLevel::Advanced => ("advanced_v1", "ADVANCED"),
+                        _ => ("simple_v2", "SIMPLE"),
+                    };
+                    (
+                        tag,
+                        vec![
+                            ("level", serde_json::Value::String(level.into())),
+                            (
+                                "bridge_status",
+                                serde_json::Value::String(
+                                    simple_bridge_status.as_deref().unwrap_or("n/a").into(),
+                                ),
                             ),
-                        ),
-                        // The optimization passes that ran (in order).
-                        // A degrade (`bridge_status != "ok"`) still
-                        // lists them — they were the *intended* pipeline
-                        // even when the run fell back to whitespace_only.
-                        (
-                            "passes",
-                            serde_json::Value::Array(
-                                SIMPLE_PASS_NAMES
-                                    .iter()
-                                    .map(|p| serde_json::Value::String((*p).into()))
-                                    .collect(),
+                            // The optimization passes that ran (in order).
+                            // A degrade (`bridge_status != "ok"`) still
+                            // lists them — they were the *intended*
+                            // pipeline even when the run fell back to
+                            // whitespace_only.
+                            (
+                                "passes",
+                                serde_json::Value::Array(
+                                    SIMPLE_PASS_NAMES
+                                        .iter()
+                                        .map(|p| serde_json::Value::String((*p).into()))
+                                        .collect(),
+                                ),
                             ),
-                        ),
-                        (
-                            "input_byte_len",
-                            serde_json::Value::Number(
-                                (source.len() as u64).into(),
+                            (
+                                "input_byte_len",
+                                serde_json::Value::Number((source.len() as u64).into()),
                             ),
-                        ),
-                        (
-                            "output_byte_len",
-                            serde_json::Value::Number(
-                                (after_level.len() as u64).into(),
+                            (
+                                "output_byte_len",
+                                serde_json::Value::Number((after_level.len() as u64).into()),
                             ),
-                        ),
-                    ],
-                ),
-                CompilationLevel::Advanced => (
-                    "identity",
-                    vec![("level", serde_json::Value::String("ADVANCED".into()))],
-                ),
+                        ],
+                    )
+                }
                 CompilationLevel::Bundle => (
                     "identity",
                     vec![("level", serde_json::Value::String("BUNDLE".into()))],
@@ -5881,6 +5891,52 @@ mod tests {
         let out = transform_source("function f(longName) { return longName + 1; } f(5);", &cfg)
             .expect("ok");
         assert_eq!(out, "function f(longName){return longName+1};f(5);");
+    }
+
+    #[test]
+    fn advanced_optimizes_like_simple() {
+        // CLOC12.161: ADVANCED was a literal no-op (returned the source
+        // verbatim). It now runs the typed pipeline; this input is folded
+        // and renamed instead of passed through.
+        let src = "function f(longName) { return longName + 1; } f(5);";
+        let advanced = transform_source(
+            src,
+            &CompilerConfig {
+                compilation: crate::config::CompilationConfig {
+                    level: crate::config::CompilationLevel::Advanced,
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+        )
+        .expect("ok");
+        assert_eq!(advanced, "function f(a){return a + 1};f(5);");
+        assert_ne!(advanced, src, "ADVANCED must no longer be an identity no-op");
+    }
+
+    #[test]
+    fn advanced_matches_simple_output() {
+        // ADVANCED reuses the SIMPLE pipeline today, so the two levels
+        // produce identical output. (When advanced-only passes land, this
+        // test documents the point at which they diverge.)
+        let src = "var dead = 1 + 2; function g(value) { return value * 2; } use(g(4));";
+        let mk = |level| {
+            transform_source(
+                src,
+                &CompilerConfig {
+                    compilation: crate::config::CompilationConfig {
+                        level,
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                },
+            )
+            .expect("ok")
+        };
+        assert_eq!(
+            mk(crate::config::CompilationLevel::Advanced),
+            mk(crate::config::CompilationLevel::Simple),
+        );
     }
 
     #[test]

--- a/code/programs/rust/closurec/tests/diff/advanced-optimizes/README.md
+++ b/code/programs/rust/closurec/tests/diff/advanced-optimizes/README.md
@@ -1,0 +1,32 @@
+# Fixture: `advanced-optimizes`
+
+End-to-end oracle for `--compilation_level ADVANCED` running the optimization
+pipeline (CLOC12.161).
+
+| File | Role |
+|------|------|
+| `flags.txt` | `--compilation_level ADVANCED --js input/a.js` |
+| `input/a.js` | A program with a foldable expr, an unused var, and a renameable param |
+| `expected.stdout` | `function compute(a){return a + 1};report(compute(7));` |
+
+ADVANCED used to be a **literal no-op** — it returned the source verbatim. It
+now runs the **same typed optimization pipeline as SIMPLE** (it is specified to
+be at least as aggressive). So this input is:
+
+| Source | Fate |
+|--------|------|
+| `var dead = 1 + 2;` | `1 + 2` folds to `3`; the unused `dead` is then removed |
+| `function compute(longName) {…}` | kept (called); param `longName` → `a` |
+| `report(compute(7));` | kept |
+
+ADVANCED and SIMPLE produce identical output today; advanced-only passes
+(aggressive property/global renaming, cross-module tree-shaking) layer on as
+they are implemented.
+
+Regenerate the expected file after an intentional behavior change:
+
+```sh
+cargo run -- --compilation_level ADVANCED \
+    --js tests/diff/advanced-optimizes/input/a.js \
+    > tests/diff/advanced-optimizes/expected.stdout
+```

--- a/code/programs/rust/closurec/tests/diff/advanced-optimizes/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/advanced-optimizes/expected.stdout
@@ -1,0 +1,2 @@
+function compute(a){return a + 1};report(compute(7));
+

--- a/code/programs/rust/closurec/tests/diff/advanced-optimizes/flags.txt
+++ b/code/programs/rust/closurec/tests/diff/advanced-optimizes/flags.txt
@@ -1,0 +1,4 @@
+--compilation_level
+ADVANCED
+--js
+tests/diff/advanced-optimizes/input/a.js

--- a/code/programs/rust/closurec/tests/diff/advanced-optimizes/input/a.js
+++ b/code/programs/rust/closurec/tests/diff/advanced-optimizes/input/a.js
@@ -1,0 +1,18 @@
+// ADVANCED-level optimization (CLOC12.161).
+//
+// ADVANCED used to be a literal no-op (it returned the source verbatim).
+// It now runs the same typed optimization pipeline as SIMPLE — it is
+// specified to be at least as aggressive — so this input is folded,
+// dead-code-eliminated, and renamed exactly as SIMPLE would do it:
+//
+//   - `1 + 2` folds to `3`;
+//   - the unused `var dead` is removed;
+//   - `compute`'s parameter `longName` is shortened to `a`.
+//
+// Advanced-only passes (aggressive property/global renaming, cross-module
+// tree-shaking) layer on as they are implemented.
+var dead = 1 + 2;
+function compute(longName) {
+  return longName + 1;
+}
+report(compute(7));

--- a/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
@@ -2,7 +2,7 @@
 
 closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.
 
-Version: 0.143.0
+Version: 0.144.0
 
 ## Flags
 

--- a/code/programs/rust/closurec/tests/diff_advanced_optimizes.rs
+++ b/code/programs/rust/closurec/tests/diff_advanced_optimizes.rs
@@ -1,0 +1,51 @@
+//! Integration test for the `tests/diff/advanced-optimizes/` fixture.
+//!
+//! Exercises CLOC12.161 — `--compilation_level ADVANCED` now runs the
+//! typed optimization pipeline instead of being a literal no-op (it used
+//! to return the source verbatim). ADVANCED is specified to be at least
+//! as aggressive as SIMPLE, so it currently reuses the SIMPLE pipeline:
+//! constant-folding, dead-code elimination, unused-binding removal, and
+//! local renaming all apply. Advanced-only passes (aggressive
+//! property/global renaming, cross-module tree-shaking) layer on as they
+//! are implemented.
+//!
+//! The companion `advanced_matches_simple_*` unit test in `src/run.rs`
+//! pins that ADVANCED and SIMPLE produce identical output today.
+
+use std::process::Command;
+
+const BINARY: &str = env!("CARGO_BIN_EXE_closurec");
+
+fn read_flags() -> Vec<String> {
+    let raw = std::fs::read_to_string("tests/diff/advanced-optimizes/flags.txt")
+        .expect("read flags.txt");
+    raw.lines()
+        .filter(|l| !l.is_empty())
+        .map(|s| s.to_string())
+        .collect()
+}
+
+#[test]
+fn advanced_optimizes_fixture_matches_expected_stdout() {
+    let flags = read_flags();
+    let out = Command::new(BINARY)
+        .args(&flags)
+        .output()
+        .expect("run closurec");
+
+    assert!(
+        out.status.success(),
+        "exit: {:?}, stderr: {}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stderr),
+    );
+
+    let actual = String::from_utf8_lossy(&out.stdout);
+    let expected = std::fs::read_to_string("tests/diff/advanced-optimizes/expected.stdout")
+        .expect("read expected.stdout");
+    assert_eq!(
+        actual.trim_end_matches('\n'),
+        expected.trim_end_matches('\n'),
+        "mismatch.\nflags: {flags:?}\nactual:\n{actual}\nexpected:\n{expected}",
+    );
+}


### PR DESCRIPTION
## What

`--compilation_level ADVANCED` was a **literal no-op** — it returned the source verbatim. This wires it through the **same degrade-safe typed optimization pipeline as `SIMPLE`** (parse → bridge → `run_simple_pipeline` → emit, falling back to `whitespace_only` on any error).

ADVANCED is specified to be **at least as aggressive** as SIMPLE, so reusing the already-tested SIMPLE pipeline is a correct, zero-risk first step. Advanced-only passes (aggressive property/global renaming, cross-module tree-shaking) layer on as they are implemented.

## Changes

- `run.rs`: `CompilationLevel::Simple | CompilationLevel::Advanced` now share the typed pipeline arm; `Bundle | TranspileOnly` remain identity passthrough.
- Correlation-vector trace: ADVANCED reports `advanced_v1` (same shape as `simple_v2`) instead of `identity`.
- New fixture `tests/diff/advanced-optimizes/` + integration harness; unit tests `advanced_optimizes_like_simple` / `advanced_matches_simple_output` pin ADVANCED ≡ SIMPLE output today.
- Bump `0.143.0 → 0.144.0`; CHANGELOG, README, `cli.spec.json`, help-markdown fixture updated.

## Verification

- Full `cargo test` for closurec: **0 failures**.
- Empirically: `function f(longName){return longName+1} f(5);` under `--compilation_level ADVANCED` → `function f(a){return a + 1};f(5);` (previously returned verbatim).
- Security review (inline diff): **PASSED** — no new panic/overflow/error-handling/injection surface; the pipeline body is unchanged and already degrade-safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)