### PR TITLE
refactor(mycin): decide_timing → ADJ defeasible-precedence ladder (CC-5, ADJ73 PR-D)

### DIFF
--- a/code/specs/data/mycin-2026/CHART-AS-CONSTRAINTS.md
+++ b/code/specs/data/mycin-2026/CHART-AS-CONSTRAINTS.md
@@ -236,6 +236,19 @@ risks Y") — decision support, not a hidden choice.
   `derive()` surfaces the decision + delay_risk + rationale + threshold. The decision is reusable
   (not meningitis-specific). The ≤60-min meningitis threshold is authored-debt (IDSA), flagged for
   **CC-5b** spider grounding.
+- **CC-5 REFACTOR (ADJ-native): the timing DECISION is now a defeasible-precedence ladder the
+  engine resolves, not a Python if/elif. ✅ DONE.** The wait-vs-treat logic moved out of
+  `decide_timing` into `timing.adj` — a `functional timing(_)` predicate + four `priority:`-tiered
+  rules (ADJ73): resulted-culture → targeted (`mandatory`); time-critical/unstable → treat-now
+  (`authoritative`); stable+routine+pending → await (`specific`); else → treat-now (`default`).
+  `timing.derive_timing(cli, culture, clinical, acuity)` asserts the per-case facts, runs the
+  engine, and reads the **governing** answer (adj-lang-cli's `governing` section); `delay_risk`
+  is read off the governing **tier** (treat-now@authoritative = high vs @default = moderate). The
+  Python if/elif is retired — the reasoning lives in the language; the engine derives it (0 model
+  calls) and the proof shows which rule governed + what it defeated. `decide_timing` is now a thin
+  wrapper supplying the disease's acuity (from the flagged `_TIME_CRITICALITY` input table) + the
+  threshold/rationale presentation. (The disease→acuity table remains authored-debt — input data,
+  not decision logic.)
 - **CC-6 — insurance / step-therapy (§5). ✅ DONE.** A payer step-therapy rule ("won't
   approve Y until X tried") enters as a `step_therapy` chart fact (`restricted:prerequisite`)
   + `prior_failed` facts (drugs already tried); the precedence `x_Y ≤ tried_X` is emitted as an

--- a/code/specs/data/mycin-2026/treatment/antibiotics/chart_to_cop.py
+++ b/code/specs/data/mycin-2026/treatment/antibiotics/chart_to_cop.py
@@ -46,6 +46,7 @@ import decide as decide_mod  # noqa: E402  (find_cli)
 import derive_regimen as reg  # noqa: E402  (grounded formulary: SCENARIOS, DRUGS, candidates)
 import native_setcover as nsc  # noqa: E402  (the COP emitter/solver)
 import step_therapy as st  # noqa: E402  (ADJ-native: derive_blocked via the engine, NAF)
+import timing as timing_mod  # noqa: E402  (ADJ-native: derive_timing via the precedence engine)
 
 
 # --------------------------------------------------------------------------
@@ -295,39 +296,49 @@ def compile_cop(facts: list[ChartFact]) -> Cop:
     return cop
 
 
-def decide_timing(disease: str, culture_status: str, clinical_status: str) -> dict:
-    """CC-5 (§4): model the empiric-now vs await-culture decision as a costed binary, with
-    the grounded time-criticality threshold as the deciding factor. Returns the decision +
-    its delay_risk + the rationale/threshold provenance — a reusable function of (disease
-    acuity, culture status, clinical stability), not meningitis-specific.
+# A decision → its human-readable rationale. The DECISION is engine-derived (timing.adj
+# precedence ladder); this is presentation only, keyed by what governed. treat_now's rationale
+# depends on the governing tier (authoritative time-critical/unstable vs the conservative
+# default), so it is keyed by (decision, delay_risk).
+_TIMING_RATIONALE = {
+    ("targeted_culture_directed", "none"): "culture resulted → narrow to the isolate's susceptibilities",
+    ("treat_now_empiric", "high"): ("time-critical (or unstable): start empiric antibiotics now; "
+                                    "awaiting culture would save cost/side-effects but the delay "
+                                    "raises mortality above the grounded threshold"),
+    ("await_culture", "low"): ("stable + non-time-critical + culture pending: await the result "
+                               "and give narrow targeted therapy — cheaper, fewer side effects"),
+    ("treat_now_empiric", "moderate"): "insufficient evidence the delay is safe → treat empirically (conservative)",
+}
 
-      culture resulted        → targeted (culture-directed): the wait question is moot.
-      time-critical disease   → treat_now_empiric (delay_risk high): the grounded threshold
-        OR critical/unstable     says delay raises mortality; empiric coverage now dominates
-                                 any cost/side-effect saving from waiting.
-      stable + routine acuity → await_culture (delay_risk low): narrow, cheaper, fewer side
-        + culture pending        effects — defensible only when delay is safe.
-      otherwise               → treat_now_empiric (delay_risk moderate): the conservative
-                                 default (don't gamble on a benign course)."""
+
+def decide_timing(cli: Path, disease: str, culture_status: str, clinical_status: str) -> dict:
+    """CC-5 (§4) — ADJ-NATIVE: the empiric-now vs await-culture DECISION is now derived by the
+    engine from the `timing.adj` precedence ladder (`timing.derive_timing`), not a Python
+    if/elif. This wrapper supplies the disease's acuity (from the flagged `_TIME_CRITICALITY`
+    input table) and dresses the engine verdict with the threshold provenance + a
+    human-readable rationale (presentation). The reasoning lives in the language.
+
+      culture resulted        → targeted (mandatory tier; the wait question is moot)
+      time-critical / unstable→ treat_now_empiric (authoritative tier; delay_risk high)
+      stable+routine+pending  → await_culture (specific tier; delay_risk low)
+      otherwise               → treat_now_empiric (default tier; delay_risk moderate)"""
     tc = _TIME_CRITICALITY.get(disease, {"acuity": "routine"})
     acuity = tc.get("acuity", "routine")
-    if culture_status == "resulted":
-        return {"decision": "targeted_culture_directed", "delay_risk": "none",
-                "rationale": "culture resulted → narrow to the isolate's susceptibilities",
-                "disease_acuity": acuity}
-    base = {"disease_acuity": acuity, "culture_status": culture_status or "unknown",
-            "threshold": {k: tc[k] for k in ("treat_within_min", "source", "trust") if k in tc}}
-    if acuity == "time_critical" or clinical_status in ("critical", "unstable"):
-        return {**base, "decision": "treat_now_empiric", "delay_risk": "high",
-                "rationale": ("time-critical (or unstable): start empiric antibiotics now; "
-                              "awaiting culture would save cost/side-effects but the delay "
-                              "raises mortality above the grounded threshold")}
-    if clinical_status == "stable" and acuity == "routine" and culture_status == "pending":
-        return {**base, "decision": "await_culture", "delay_risk": "low",
-                "rationale": ("stable + non-time-critical + culture pending: await the result "
-                              "and give narrow targeted therapy — cheaper, fewer side effects")}
-    return {**base, "decision": "treat_now_empiric", "delay_risk": "moderate",
-            "rationale": "insufficient evidence the delay is safe → treat empirically (conservative)"}
+    res = timing_mod.derive_timing(cli, culture_status, clinical_status, acuity)
+    decision, delay_risk = res["decision"], res["delay_risk"]
+    out = {
+        "decision": decision,
+        "delay_risk": delay_risk,
+        "standing": res.get("standing"),
+        "disease_acuity": acuity,
+        "culture_status": culture_status or "unknown",
+        "rationale": _TIMING_RATIONALE.get((decision, delay_risk), ""),
+    }
+    # Carry the grounded (flagged) door-to-antibiotic threshold when one is recorded.
+    threshold = {k: tc[k] for k in ("treat_within_min", "source", "trust") if k in tc}
+    if threshold:
+        out["threshold"] = threshold
+    return out
 
 
 def dose_infeasible(cli: Path, drugs: list[str], risks: set[str], weight: float) -> dict:
@@ -378,8 +389,9 @@ def derive(cli: Path, facts: list[ChartFact], disease: str = "meningitis") -> di
     # `regimen` is the CLINICALLY optimal one — what the physician should give, ignoring
     # the payer. (CC-4 objective blend applies.)
     res = nsc.solve(cli, cop.organisms, cop.exclusions, cop.defeated, cop.weights, forced_zero=forced_zero)
-    # CC-5: the empiric-now vs await-culture decision, from the chart's timing inputs.
-    timing = decide_timing(disease, cop.culture_status, cop.clinical_status)
+    # CC-5: the empiric-now vs await-culture decision — DERIVED BY THE ENGINE from the timing
+    # precedence ladder (timing.adj), keyed by the chart's culture/clinical status + acuity.
+    timing = decide_timing(cli, disease, cop.culture_status, cop.clinical_status)
     # CC-6: when the chart carries payer step-therapy rules, ALSO solve the reimbursement-
     # feasible regimen (the clinically-best drugs whose step-therapy prerequisite is unmet
     # are excluded) and surface BOTH so the tradeoff — and any medical-necessity appeal — is

--- a/code/specs/data/mycin-2026/treatment/antibiotics/test_chart_to_cop.py
+++ b/code/specs/data/mycin-2026/treatment/antibiotics/test_chart_to_cop.py
@@ -150,21 +150,27 @@ def test_objective_breakdown_surfaced_with_chart_weights():
 
 
 def test_decide_timing_decision_table():
-    # CC-5 (§4): the wait-vs-treat-now decision is a function of (disease acuity, culture
-    # status, clinical stability). Pure — no engine needed.
+    # CC-5 (§4) ADJ-NATIVE: the wait-vs-treat-now DECISION is now derived by the engine from
+    # the timing.adj precedence ladder (decide_timing wraps timing.derive_timing). Same
+    # outcomes as the retired Python if/elif, keyed by (disease acuity, culture, clinical).
+    cli = decide_mod.find_cli()
+    if cli is None:
+        return
     # Time-critical disease (meningitis) → empiric now, high delay_risk, with the threshold.
-    t = cc.decide_timing("meningitis", "pending", "stable")
-    assert t["decision"] == "treat_now_empiric" and t["delay_risk"] == "high"
+    t = cc.decide_timing(cli, "meningitis", "pending", "stable")
+    assert t["decision"] == "treat_now_empiric" and t["delay_risk"] == "high", t
     assert t["threshold"]["treat_within_min"] == 60 and t["threshold"]["trust"]
+    assert t["standing"] == "authoritative"  # the time-critical rule governed
     # A critical patient forces empiric-now even for a routine-acuity disease.
-    assert cc.decide_timing("cellulitis", "pending", "critical")["decision"] == "treat_now_empiric"
+    assert cc.decide_timing(cli, "cellulitis", "pending", "critical")["decision"] == "treat_now_empiric"
     # Stable + non-time-critical + culture pending → awaiting the culture is defensible.
-    aw = cc.decide_timing("cellulitis", "pending", "stable")
-    assert aw["decision"] == "await_culture" and aw["delay_risk"] == "low"
+    aw = cc.decide_timing(cli, "cellulitis", "pending", "stable")
+    assert aw["decision"] == "await_culture" and aw["delay_risk"] == "low", aw
     # Culture already back → targeted, the wait question is moot.
-    assert cc.decide_timing("meningitis", "resulted", "stable")["decision"] == "targeted_culture_directed"
-    # No timing info on a routine disease → conservative treat-now (don't gamble).
-    assert cc.decide_timing("cellulitis", "", "")["decision"] == "treat_now_empiric"
+    assert cc.decide_timing(cli, "meningitis", "resulted", "stable")["decision"] == "targeted_culture_directed"
+    # No timing info on a routine disease → conservative treat-now (don't gamble), moderate risk.
+    none = cc.decide_timing(cli, "cellulitis", "", "")
+    assert none["decision"] == "treat_now_empiric" and none["delay_risk"] == "moderate", none
 
 
 def test_timing_facts_compile_and_surface_in_derive():

--- a/code/specs/data/mycin-2026/treatment/antibiotics/test_timing.py
+++ b/code/specs/data/mycin-2026/treatment/antibiotics/test_timing.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""test_timing.py — guard the ADJ-native wait-vs-treat precedence ladder + runtime (CC-5).
+
+Pure checks: the rulebook carries the functional decl + the priority-tiered rules; the runtime
+rejects unsafe/unknown inputs. Engine-gated checks (if adj-lang-cli is built): the four ladder
+outcomes resolve by precedence — resulted→targeted (mandatory), time-critical/unstable→treat-now
+(authoritative, high risk), stable+routine+pending→await (specific, low), else→treat-now
+(default, moderate). The decision is the engine's; delay_risk reads off the governing tier.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(HERE))
+sys.path.insert(0, str(HERE.parent.parent / "warm"))
+import decide as decide_mod  # noqa: E402
+import timing as timing_mod  # noqa: E402
+
+
+def test_rulebook_has_functional_decl_and_priority_tiers():
+    text = timing_mod.RULEBOOK.read_text()
+    assert "functional timing(decision)" in text
+    assert "priority: mandatory" in text and "priority: authoritative" in text
+    assert "priority: specific" in text and "priority: default" in text
+
+
+@pytest.mark.parametrize("bad", ["resultd", "Pending", "x;y", "pending)\n? evil("])
+def test_unknown_inputs_are_rejected(bad):
+    # (An empty string is NOT rejected — it is coerced to the conservative "unknown" default.)
+    with pytest.raises(ValueError):
+        timing_mod.derive_timing(_DUMMY_CLI, bad, "stable", "routine")
+
+
+class _DummyCli:
+    def __fspath__(self):  # pragma: no cover - never reached when the guard fires
+        raise AssertionError("the engine must not be invoked for a rejected input")
+
+
+_DUMMY_CLI = _DummyCli()
+
+
+def _cli_or_skip():
+    cli = decide_mod.find_cli()
+    if cli is None:
+        pytest.skip("adj-lang-cli not built")
+    return cli
+
+
+def test_resulted_culture_is_targeted_mandatory():
+    cli = _cli_or_skip()
+    r = timing_mod.derive_timing(cli, "resulted", "stable", "routine")
+    assert r["decision"] == "targeted_culture_directed" and r["delay_risk"] == "none"
+    assert r["standing"] == "mandatory" and r["governing"]
+
+
+def test_time_critical_is_treat_now_authoritative_high():
+    cli = _cli_or_skip()
+    r = timing_mod.derive_timing(cli, "pending", "stable", "time_critical")
+    assert r["decision"] == "treat_now_empiric" and r["delay_risk"] == "high"
+    assert r["standing"] == "authoritative"
+
+
+def test_unstable_patient_forces_treat_now():
+    cli = _cli_or_skip()
+    r = timing_mod.derive_timing(cli, "pending", "unstable", "routine")
+    assert r["decision"] == "treat_now_empiric" and r["delay_risk"] == "high"
+
+
+def test_stable_routine_pending_awaits_culture():
+    cli = _cli_or_skip()
+    r = timing_mod.derive_timing(cli, "pending", "stable", "routine")
+    assert r["decision"] == "await_culture" and r["delay_risk"] == "low"
+    assert r["standing"] == "specific"
+
+
+def test_default_fallback_is_treat_now_moderate():
+    cli = _cli_or_skip()
+    # unknown culture + stable + routine: nothing specific fires → conservative default.
+    r = timing_mod.derive_timing(cli, "unknown", "stable", "routine")
+    assert r["decision"] == "treat_now_empiric" and r["delay_risk"] == "moderate"
+    assert r["standing"] == "default"
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-q"]))

--- a/code/specs/data/mycin-2026/treatment/antibiotics/timing.adj
+++ b/code/specs/data/mycin-2026/treatment/antibiotics/timing.adj
@@ -1,0 +1,63 @@
+% ============================================================================
+% timing — the wait-vs-treat-now decision as a DEFEASIBLE PRECEDENCE ladder (ADJ-native).
+% ============================================================================
+% MYCIN-2026 (therapy layer, CC-5).  Empiric-now vs await-culture is a priority
+% ladder: a resulted culture moots the question; a time-critical disease or an
+% unstable patient forces treat-now; a stable + routine + culture-pending patient
+% may safely await; otherwise treat now (conservative default).  This is exactly a
+% "defaults with exceptions" rulebook — `functional timing(_)` makes the four
+% decisions mutually exclusive, and the `priority:` tier picks the governing one
+% (ADJ73).  The Python if/elif ladder (`decide_timing`) is RETIRED; the reasoning
+% lives in the language, the engine derives the decision (`? timing($D)`, 0 model
+% calls), and the audit trail shows which rule governed and what it defeated.
+%
+% The per-case inputs (culture_status / clinical_status / disease_acuity) are
+% asserted by the runtime (timing.py) from the chart + the disease's acuity.  The
+% ≤60-min door-to-antibiotic threshold behind `time_critical` is AUTHORED-DEBT
+% (IDSA), flagged for spider grounding (CC-5b) — same status as before; only the
+% DECISION LOGIC moves here, not the threshold's provenance.
+% ============================================================================
+
+dictionary timing_vocab {
+    define decision        : entity   surface "wait-vs-treat decision"
+    define clinical_state  : entity   surface "clinical status"
+    define culture_state   : entity   surface "culture status"
+    define acuity_level    : entity   surface "disease acuity"
+    define marker          : entity   surface "per-case marker"
+
+    % per-case inputs (asserted by the runtime).
+    define culture_status  : relation from culture_state to culture_state
+    define clinical_status : relation from clinical_state to clinical_state
+    define disease_acuity  : relation from acuity_level to acuity_level
+    define case_active     : relation from marker to marker
+    % DERIVED, functional: the single governing timing decision.
+    define timing          : relation from decision to decision
+}
+
+% `timing` admits at most one governing value — the four rules below conflict, and
+% precedence (not order) resolves them.
+functional timing(decision)
+
+rulebook timing_decision {
+    use timing_vocab
+
+    % resulted culture → targeted (culture-directed): the wait question is moot. Highest.
+    rule { head: timing(targeted_culture_directed)
+           when: culture_status(resulted)                              priority: mandatory }
+
+    % time-critical disease OR an unstable/critical patient → treat empirically NOW
+    % (delay raises mortality above the grounded threshold). Beats the await rule.
+    rule { head: timing(treat_now_empiric) when: disease_acuity(time_critical) priority: authoritative }
+    rule { head: timing(treat_now_empiric) when: clinical_status(critical)     priority: authoritative }
+    rule { head: timing(treat_now_empiric) when: clinical_status(unstable)     priority: authoritative }
+
+    % stable + routine acuity + culture pending → safe to AWAIT (narrow, cheaper,
+    % fewer side effects). Defensible only when delay is safe.
+    rule { head: timing(await_culture)
+           when: clinical_status(stable), disease_acuity(routine), culture_status(pending)
+                                                                       priority: specific }
+
+    % conservative default: treat now (don't gamble on a benign course). Gated on the
+    % always-asserted per-case marker so it fires whenever nothing higher does.
+    rule { head: timing(treat_now_empiric) when: case_active(yes)      priority: default }
+}

--- a/code/specs/data/mycin-2026/treatment/antibiotics/timing.py
+++ b/code/specs/data/mycin-2026/treatment/antibiotics/timing.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""timing.py — DERIVE the wait-vs-treat-now decision by running the ADJ precedence ladder.
+
+The runtime half of the CC-5 ADJ-native refactor. `timing.adj` holds the wait-vs-treat
+decision as a defeasible-precedence ladder (`functional timing(_)` + `priority:` tiers); this
+module RUNS it under a case's culture/clinical status + the disease's acuity and reads the
+engine's *governing* answer — replacing the Python if/elif `decide_timing`.
+
+    derive_timing(cli, culture_status="pending", clinical_status="stable",
+                  disease_acuity="time_critical")
+        → {"decision": "treat_now_empiric", "delay_risk": "high", "standing": "authoritative",
+           "governing": True, ...}
+
+The DECISION is the engine's (`? timing($D)`, 0 model calls); `delay_risk` is read off the
+*governing tier* — treat-now via the authoritative (time-critical/unstable) rule is high risk,
+treat-now via the default fallback is only moderate, await is low, targeted is none. The
+reasoning lives in the language; Python only asserts the inputs and maps the verdict to its
+human-readable risk label.
+
+SECURITY: the three inputs can originate from a model-decomposed chart, so they are
+semi-untrusted and interpolated into an `.adj` program. Each is checked against a closed
+vocabulary (`^[a-z][a-z0-9_]*$` + an allow-list) BEFORE it reaches the program text. The temp
+program is written beside the rulebook and removed in a `finally` (mirrors contraindications.py
+/ step_therapy.py).
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+import tempfile
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+RULEBOOK = HERE / "timing.adj"
+
+_TOKEN_RE = re.compile(r"\A[a-z][a-z0-9_]*\Z")
+# Closed vocabularies for the three inputs (defence in depth on top of the regex).
+_CULTURE = {"pending", "resulted", "unknown"}
+_CLINICAL = {"critical", "unstable", "stable", "unknown"}
+_ACUITY = {"time_critical", "routine"}
+
+# delay_risk is a property of the governing (decision, tier): treat-now forced by the
+# authoritative time-critical/unstable rule is HIGH; the conservative default fallback is only
+# MODERATE; awaiting is LOW; a resulted culture moots the wait (NONE).
+_DELAY_RISK = {
+    ("targeted_culture_directed", None): "none",
+    ("await_culture", None): "low",
+    ("treat_now_empiric", "authoritative"): "high",
+    ("treat_now_empiric", "default"): "moderate",
+}
+
+
+def _safe(token: str, allowed: set[str], kind: str) -> str:
+    if not _TOKEN_RE.match(token) or token not in allowed:
+        raise ValueError(f"unsafe/unknown {kind} {token!r} (allowed: {sorted(allowed)})")
+    return token
+
+
+def derive_timing(cli: Path, culture_status: str, clinical_status: str,
+                  disease_acuity: str) -> dict:
+    """Run the timing precedence ladder and return the engine-derived decision + delay_risk.
+    Inputs default to the conservative unknowns when a chart did not specify them."""
+    culture = _safe(culture_status or "unknown", _CULTURE, "culture_status")
+    clinical = _safe(clinical_status or "unknown", _CLINICAL, "clinical_status")
+    acuity = _safe(disease_acuity or "routine", _ACUITY, "disease_acuity")
+
+    program = RULEBOOK.read_text() + "\n"
+    program += f"relate culture_status({culture})\n"
+    program += f"relate clinical_status({clinical})\n"
+    program += f"relate disease_acuity({acuity})\n"
+    program += "relate case_active(yes)\n"  # always-present marker the default rule gates on
+    program += "? timing($D)\n"
+
+    tmp = tempfile.NamedTemporaryFile("w", suffix=".adj", dir=HERE, delete=False)
+    try:
+        tmp.write(program)
+        tmp.close()
+        r = subprocess.run([str(cli), tmp.name], capture_output=True, text=True)
+        if r.returncode != 0:
+            raise RuntimeError(f"adj-lang-cli exited {r.returncode}: {r.stderr}")
+        out = json.loads(r.stdout)
+    finally:
+        Path(tmp.name).unlink(missing_ok=True)
+
+    # Read the governing answer for the `timing(...)` query.
+    decision, standing, has_conflict = None, None, False
+    for rec in out.get("governing", []):
+        if not rec.get("query", "").startswith("timing("):
+            continue
+        has_conflict = rec.get("has_conflict", False)
+        for ans in rec.get("answers", []):
+            if ans.get("status") == "governing":
+                decision = ans.get("bindings", {}).get("D")
+                standing = ans.get("standing")
+    # delay_risk keyed by (decision, tier) — None tier-key for decisions whose risk is fixed.
+    risk_key = (decision, standing) if (decision, standing) in _DELAY_RISK else (decision, None)
+    delay_risk = _DELAY_RISK.get(risk_key, "moderate")
+    return {
+        "decision": decision,
+        "delay_risk": delay_risk,
+        "standing": standing,
+        "governing": decision is not None and not has_conflict,
+        "culture_status": culture,
+        "clinical_status": clinical,
+        "disease_acuity": acuity,
+    }
+
+
+if __name__ == "__main__":  # tiny demo
+    import sys
+    sys.path.insert(0, str(HERE.parent.parent / "warm"))
+    import decide as decide_mod  # noqa: E402
+
+    cli = decide_mod.find_cli()
+    if cli is None:
+        print("timing: adj-lang-cli not built", file=sys.stderr)
+        raise SystemExit(3)
+    for c, cl, a in [("resulted", "stable", "routine"), ("pending", "stable", "time_critical"),
+                     ("pending", "stable", "routine"), ("unknown", "stable", "routine")]:
+        print(c, cl, a, "->", derive_timing(cli, c, cl, a))


### PR DESCRIPTION
The wait-vs-treat-now **decision** leaves Python and becomes a precedence rulebook the engine resolves — the first MYCIN consumer of the merged ADJ73 stack (priority tiers #6072 + CLI `governing` render #6073).

- **`timing.adj`** — `functional timing(decision)` + four `priority:`-tiered rules:

  | input | decision | tier | delay_risk |
  |---|---|---|---|
  | culture resulted | targeted | mandatory | none |
  | time-critical / unstable | treat-now | authoritative | high |
  | stable + routine + pending | await | specific | low |
  | else | treat-now | default | moderate |

  The Python if/elif is gone — `functional` makes the decisions mutually exclusive; the tier picks the governing one.
- **`timing.py`** — `derive_timing(cli, …)` asserts per-case facts + `? timing($D)`, runs adj-lang-cli, reads the `governing` section; `delay_risk` is read off the governing **tier**. Closed-vocab input guard.
- **`chart_to_cop.py`** — `decide_timing` is now a thin wrapper (disease→acuity lookup + threshold/rationale presentation); the **decision** is engine-derived (0 model calls), with the proof showing what governed + what it defeated.

## Verification

`test_timing.py` (10) + full `test_chart_to_cop.py` (16, incl. the engine-gated timing table + `derive()` integration) pass; `ruff` clean; **security review passed** (every interpolated input guarded by regex + closed vocabulary; list-form subprocess; guaranteed temp cleanup). Spec CC-5 updated. The disease→acuity table remains authored-debt (input data, not decision logic — CC-5b grounding).

🤖 Generated with [Claude Code](https://claude.com/claude-code)