### PR TITLE
feat(visicalc-qt): wire drag-fill into the infinite-sheet demo

### DIFF
--- a/demo/visicalc-qt/InfiniteSheet.qml
+++ b/demo/visicalc-qt/InfiniteSheet.qml
@@ -93,6 +93,19 @@ Item {
                     onAccepted: if (doc) doc.commitInf(text)
                 }
             }
+            // Drag-fill: replicate the selected cell into the 10 rows below it.
+            // The engine shifts each copy's relative refs, pins absolute ($) refs,
+            // and carries the format — one doc.fill call.
+            Button {
+                text: "Fill ↓ 10"
+                ToolTip.visible: hovered
+                ToolTip.text: "Replicate the selected cell into the 10 rows below it"
+                onClicked: if (doc) {
+                    var first = doc.columnLetters(doc.infCol) + (doc.infRow + 1);
+                    var last = doc.columnLetters(doc.infCol) + (doc.infRow + 10);
+                    doc.fill(doc.infAddress, first, last);
+                }
+            }
         }
 
         // ── Column-letter header (frozen vertically, scrolls horizontally) ──

--- a/demo/visicalc-qt/README.md
+++ b/demo/visicalc-qt/README.md
@@ -102,7 +102,11 @@ bodyFlick.contentX`) and the row-number gutter (its own non-interactive
 body.contentY`). Tapping a cell calls `model.selectInf(row, col)` (pulling its
 source into the formula bar); pressing Enter calls `model.commitInf(text)`,
 which writes through to the engine, recomputes every dependent, regrows the
-extent, and bumps `model.revision` so the visible rows re-fetch.
+extent, and bumps `model.revision` so the visible rows re-fetch. The **"Fill ↓
+10"** button next to the formula bar calls `model.fill(src, dstStart, dstEnd)`
+(over the C ABI's `sc_fill`) to replicate the selected cell into the 10 rows
+below it — the engine shifts each copy's relative references (`=A1`→`=A2`, …),
+pins absolute (`$`) refs, and carries the format.
 
 The model seeds far-flung sparse cells (`Z1000`, `BA50`, `BB50`) on top of the
 budget so there's something to scroll to; the extent (`totalRows`/`totalCols`)

--- a/demo/visicalc-qt/src/SpreadsheetModel.cpp
+++ b/demo/visicalc-qt/src/SpreadsheetModel.cpp
@@ -303,3 +303,20 @@ void SpreadsheetModel::commitInf(const QString &raw) {
     emit infSelectionChanged();
     emit revisionChanged();
 }
+
+// Drag-fill: the engine replicates the `src` cell across the inclusive A1
+// rectangle (relative refs shift per target, absolute ($) refs pin, the format
+// carries). sc_fill returns void; we then recompute the parity grid, regrow the
+// extent if the fill reached new ground, and bump `revision` so the visible rows
+// re-fetch. A malformed address is a no-op inside the engine.
+void SpreadsheetModel::fill(const QString &src, const QString &dstStart, const QString &dstEnd) {
+    const QByteArray s = src.toUtf8();
+    const QByteArray ds = dstStart.toUtf8();
+    const QByteArray de = dstEnd.toUtf8();
+    sc_fill(session_, s.constData(), ds.constData(), de.constData());
+    recompute();
+    computeExtent();
+    revision_++;
+    emit changed();
+    emit revisionChanged();
+}

--- a/demo/visicalc-qt/src/SpreadsheetModel.h
+++ b/demo/visicalc-qt/src/SpreadsheetModel.h
@@ -116,6 +116,10 @@ public:
     // Commit the formula bar into the selected infinite-view cell: write through,
     // recompute, resize the extent, bump `revision` so the rows re-fetch.
     Q_INVOKABLE void commitInf(const QString &raw);
+    // Drag-fill: replicate the `src` cell across the inclusive A1 rectangle
+    // `dstStart`..`dstEnd` (relative refs shift, absolute pin, format carried);
+    // resizes the extent and bumps `revision` so the visible rows re-fetch.
+    Q_INVOKABLE void fill(const QString &src, const QString &dstStart, const QString &dstEnd);
 
 signals:
     // viewportRows changed (after a recompute) — QML rebinds the grid.

--- a/demo/visicalc-qt/test/tst_window.cpp
+++ b/demo/visicalc-qt/test/tst_window.cpp
@@ -22,6 +22,7 @@ private slots:
     void farWindowReachesZ1000AndGapsAreSparse();
     void extentColumnLettersAndChangedSince();
     void infiniteViewSelectEditAndRowCells();
+    void fillReplicatesShiftingReferences();
 };
 
 // Helper: the display string at window (1-based) cell (row, col), given the
@@ -135,6 +136,25 @@ void TstWindow::infiniteViewSelectEditAndRowCells() {
     QCOMPARE(m.rowCells(2).at(4).toString(), QStringLiteral("151.00")); // E2 = 108+14+7+22, formatted
     QCOMPARE(m.rowCells(5).at(0).toString(), QStringLiteral("139.00")); // A5 = 15+108+12+4, formatted
     QCOMPARE(m.rowCells(5).at(4).toString(), QStringLiteral("269.00")); // E5 grand total, formatted
+}
+
+// Drag-fill (the "Fill down" control drives model.fill): replicate a formula
+// down a column, each copy's relative reference tracking its row.
+void TstWindow::fillReplicatesShiftingReferences() {
+    SpreadsheetModel m;
+    // Seed a fresh column away from the default budget: H1=2, H2=3, H3=4;
+    // I1 = H1*10. Fill I1 down into I2:I3 — each tracks its row.
+    m.setCell("H1", "2");
+    m.setCell("H2", "3");
+    m.setCell("H3", "4");
+    m.setCell("I1", "=H1*10"); // 20
+    m.fill("I1", "I2", "I3");
+    // I2 = H2*10 = 30, I3 = H3*10 = 40 (each filled formula's relative ref tracked
+    // its row). Read through a window over col 9 (= I); the values prove the shift.
+    QCOMPARE(m.window(2, 9, 2, 9).at(0).toList().at(0).toString(), QStringLiteral("30"));
+    QCOMPARE(m.window(3, 9, 3, 9).at(0).toList().at(0).toString(), QStringLiteral("40"));
+    // The source cell is untouched by its own fill.
+    QCOMPARE(m.window(1, 9, 1, 9).at(0).toList().at(0).toString(), QStringLiteral("20"));
 }
 
 QTEST_MAIN(TstWindow)


### PR DESCRIPTION
## What

Adds a **"Fill ↓ 10"** affordance to the Qt infinite-sheet view — the first **native** consumer of the `fill` ABI (engine #6048, facades #6057, web demo #6082). The button replicates the selected cell into the 10 rows below it; the engine shifts each copy's relative references (`=A1`→`=A2`, …), pins absolute (`$`) refs, and carries the format.

## Changes

- **`SpreadsheetModel.{h,cpp}`** — `Q_INVOKABLE fill(src, dstStart, dstEnd)` wrapping the C ABI's `sc_fill`. Each `toUtf8()` is bound to a **named `const QByteArray` local** so the buffer outlives the synchronous FFI call (no dangling-temporary use-after-free), then `recompute()` / `computeExtent()` / bump `revision` / emit.
- **`InfiniteSheet.qml`** — "Fill ↓ 10" `Button` computing the target rectangle from the infinite-view selection (`doc.columnLetters(infCol) + infRow±N`).
- **`tst_window.cpp`** — new `fillReplicatesShiftingReferences` test (I1=H1*10 filled down → I2=30, I3=40; source untouched).
- README updated.

## Verification

Built and ran with **Qt 6.11 (qmake)** against the re-vendored `spreadsheet-capi` 0.6.0 static lib + header (`Vendor/` git-ignored):
- `tst_window` — **7/7 PASS** (incl. the new fill test).
- `qmllint InfiniteSheet.qml` — no errors.

`/security-review` — **PASSED** (named-`QByteArray`-local pattern avoids the dangling-temporary trap; `sc_fill` is `void`/null-safe; fixed 10-row range, engine caps at `MAX_RANGE_CELLS`).

## Next

Roll the same drag-fill affordance through Flutter → Compose → XAML → SwiftUI, one PR each.

🤖 Generated with [Claude Code](https://claude.com/claude-code)