### PR TITLE
feat(logic-engine): grounded context precedence — lex superior (ADJ73 PR-B engine core)

### DIFF
--- a/code/packages/rust/adjudication-connector/src/lib.rs
+++ b/code/packages/rust/adjudication-connector/src/lib.rs
@@ -547,6 +547,7 @@ fn lower_rule_tracked(
                 probability: Probability::Value(p),
                 provenance: logic_engine::Provenance::unattributed(),
                 priority: logic_engine::Priority::Default,
+                context: None,
             })));
         }
         "constraint" => {
@@ -739,6 +740,7 @@ fn lower_rule(
                 probability: Probability::Value(p),
                 provenance: logic_engine::Provenance::unattributed(),
                 priority: logic_engine::Priority::Default,
+                context: None,
             });
         }
         "constraint" => {

--- a/code/packages/rust/logic-engine/CHANGELOG.md
+++ b/code/packages/rust/logic-engine/CHANGELOG.md
@@ -2,6 +2,35 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.19.0] - 2026-06-16 — grounded context precedence (lex superior) (ADJ73 PR-B engine core)
+
+### Added
+
+- **`Rule::context: Option<String>`** (builder `with_context`) — the context a rule is grounded
+  in (jurisdiction / guideline edition / specialty). `None` = context-free (today's behavior).
+- **`KnowledgeBase::add_context_outranks(higher, lower)`** — assert a grounded precedence edge
+  (federal > state, ninth_circuit > district_court, idsa_2024 > idsa_2004, specialist > general).
+- **`KnowledgeBase::context_outranks(a, b)`** — transitive reach over the edges (cycle-safe DFS);
+  **`context_order_has_cycle()`** — detect a cyclic order (the surface loader should reject).
+- **`govern::GovernedAnswer::context`** + a `defeats(a, b)` resolution: context precedence is
+  PRIMARY (lex superior — a higher-context answer defeats a lower-context one regardless of
+  tier); the [`Standing`] tier breaks ties the context order leaves open. An answer governs iff
+  no conflicting answer defeats it; multiple undefeated → `ConflictPeer`; a cyclic order crowns
+  nothing (safe degradation, never a wrong pick).
+
+### Unchanged (back-compat)
+
+- With NO `context_order` declared, `defeats` reduces to "higher tier wins" — resolution is
+  byte-identical to 0.18 (verified: the existing precedence + integration tests pass unchanged).
+  The two `adjudication-connector` `Rule{}` sites set `context: None`.
+
+### Scope
+
+PR-B engine core. The grounded `context-precedence` **rulebook** (each `outranks_context` edge
+citing its charter — the Supremacy Clause, etc.) + adj-lang **surface** (`context:` on a rule,
+`context_order { … }`) are the next slices (ADJ73 §7). Cycle *rejection* at load is the loader's
+job; the resolver itself stays safe regardless.
+
 ## [0.18.0] - 2026-06-16 — precedence priority is a named ENUM, not an integer (ADJ73 PR-A)
 
 ### Changed (breaking — nothing released; per user decision 1)

--- a/code/packages/rust/logic-engine/Cargo.toml
+++ b/code/packages/rust/logic-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "logic-engine"
-version = "0.18.0"
+version = "0.19.0"
 edition = "2021"
 description = "Probability-aware facts, rules, KB, SLD find-first/enumerate + WMC posterior + LP19e likelihood-ratio Bayesian aggregation."
 

--- a/code/packages/rust/logic-engine/README.md
+++ b/code/packages/rust/logic-engine/README.md
@@ -89,10 +89,27 @@ let res = enumerate_governing(&/* timing($D) */, &kb);
 Priority is a **named enum tier** (`Default < Specific < Authoritative < Mandatory`), not a raw
 integer; a ground fact (`Standing::Asserted`) outranks every rule tier. A predicate that is
 **not** declared functional never conflicts, so every answer governs and `enumerate_all`
-semantics are unchanged — precedence is opt-in per predicate. The richer, byte-provenanced
-mechanism — a grounded `context-precedence` rulebook (lex-superior / recency / appeal-status,
-for jurisdiction/specialist precedence) — and the adj-lang surface syntax are staged in
-`code/specs/ADJ73-defeasible-rule-precedence.md` (§2.3, §7).
+semantics are unchanged — precedence is opt-in per predicate.
+
+**Grounded context precedence (v0.19, lex superior).** A rule can be grounded in a *context*
+(`Rule::with_context("ninth_circuit")`), and a partial order over contexts
+(`kb.add_context_outranks("ninth_circuit", "district_court")`) makes the rule in the **greater**
+context defeat a conflicting one in a lesser context — *before* the tier is consulted (the tier
+breaks ties the context order leaves open):
+
+```rust
+kb.declare_functional("means", 2);
+kb.add_context_outranks("ninth_circuit", "district_court");  // grounded precedence edge
+kb.add_rule(Rule::certain(/* means(waters, broad) */).with_context("ninth_circuit"));
+kb.add_rule(Rule::certain(/* means(waters, narrow) */).with_context("district_court"));
+// → means(waters, broad) governs; the district reading is Defeated { by: … }.
+```
+
+`context_outranks` is cycle-safe; a cyclic order (`context_order_has_cycle`) crowns nothing
+rather than picking wrong. With no context order declared, resolution is pure-tier (back-compat).
+The grounded `context-precedence` *rulebook* (each edge citing its charter — the Supremacy
+Clause, etc.) + the adj-lang surface (`context:` / `context_order { … }`) are the next slices
+(`code/specs/ADJ73-defeasible-rule-precedence.md` §2.3, §7).
 
 ## Why Probability From Day One
 

--- a/code/packages/rust/logic-engine/src/govern.rs
+++ b/code/packages/rust/logic-engine/src/govern.rs
@@ -67,6 +67,11 @@ pub struct GovernedAnswer {
     /// The highest [`Standing`] over the proofs deriving this answer ([`Standing::Asserted`]
     /// if any derivation rests on a ground fact, else the max rule [`Priority`] tier).
     pub priority: Standing,
+    /// ADJ73 PR-B: the CONTEXT this answer is grounded in (the context of its highest-standing
+    /// deriving rule) — `None` for a context-free derivation. When two conflicting answers
+    /// carry contexts ordered by [`KnowledgeBase::add_context_outranks`], the one in the
+    /// greater context defeats the other *before* the [`Standing`] tier is consulted.
+    pub context: Option<String>,
     /// Indices into [`GovernedResult::dag`]`.proofs` that derive this answer.
     pub proof_indices: Vec<usize>,
     /// Whether this answer governs, was defeated, or is an unresolved conflict peer.
@@ -143,6 +148,34 @@ fn proof_priority(dag: &ProofDAG, proof_index: usize, kb: &KnowledgeBase) -> Sta
     }
 }
 
+/// ADJ73 PR-B: the CONTEXT a single proof confers — the `context` of the rule that derived the
+/// query head (the proof's first step). Fact-derived heads have no context.
+fn proof_context(dag: &ProofDAG, proof_index: usize, kb: &KnowledgeBase) -> Option<String> {
+    match dag.proofs[proof_index].steps.first().map(|s| &s.origin) {
+        Some(DerivationOrigin::FromRule(id)) => {
+            kb.find_rule_by_id(*id).and_then(|r| r.context.clone())
+        }
+        _ => None,
+    }
+}
+
+/// ADJ73 PR-B: does answer `a` DEFEAT answer `b` in a conflict group? Context precedence is
+/// primary (lex superior): if `a`'s context outranks `b`'s, `a` defeats `b` regardless of tier;
+/// if `b`'s outranks `a`'s, it does not. When the contexts are equal / incomparable / absent,
+/// the [`Standing`] tier decides. This generalizes the pure-tier rule (with no contexts it
+/// reduces to "higher tier defeats lower"), so a rulebook with no `context_order` is unchanged.
+fn defeats(a: &GovernedAnswer, b: &GovernedAnswer, kb: &KnowledgeBase) -> bool {
+    if let (Some(ca), Some(cb)) = (&a.context, &b.context) {
+        if kb.context_outranks(ca, cb) {
+            return true;
+        }
+        if kb.context_outranks(cb, ca) {
+            return false;
+        }
+    }
+    a.priority > b.priority
+}
+
 /// Enumerate all proofs of `query`, then resolve conflicting answers by defeasible precedence
 /// (ADJ73). Returns every distinct answer tagged [`GovernStatus`]. For a query over predicates
 /// none of which are declared functional, every answer is [`GovernStatus::Governing`] and the
@@ -156,23 +189,40 @@ pub fn enumerate_governing(query: &Term, kb: &KnowledgeBase) -> GovernedResult {
     for (i, proof) in dag.proofs.iter().enumerate() {
         let term = resolve_deep(query, &proof.bindings);
         let pri = proof_priority(&dag, i, kb);
+        let ctx = proof_context(&dag, i, kb);
         if let Some(a) = answers.iter_mut().find(|a| a.term == term) {
             a.proof_indices.push(i);
-            a.priority = a.priority.max(pri);
+            // Track the standing AND the context of the highest-standing derivation, so a
+            // context-precedence comparison uses the context of the rule that gave the answer
+            // its strongest footing.
+            if pri > a.priority {
+                a.priority = pri;
+                a.context = ctx;
+            }
         } else {
             answers.push(GovernedAnswer {
                 term,
                 priority: pri,
+                context: ctx,
                 proof_indices: vec![i],
                 status: GovernStatus::Governing, // provisional; resolved below
             });
         }
     }
 
-    // 2. Resolve each functional conflict group. We compute verdicts first (immutable borrow),
-    //    then apply them, to keep the borrow checker happy and the logic readable.
+    // 2. Resolve each functional conflict group via the `defeats` relation (context precedence
+    //    primary, tier secondary). An answer GOVERNS iff no other answer in its group defeats
+    //    it; a sole undefeated answer governs, multiple undefeated answers are conflict peers
+    //    (a genuine split), and a defeated answer cites a defeating witness. We compute verdicts
+    //    first (immutable borrow), then apply them.
     let keys: Vec<Option<(String, Vec<Term>)>> =
         answers.iter().map(|a| conflict_key(&a.term, kb)).collect();
+
+    let undefeated = |idx: usize, group: &[usize]| -> bool {
+        !group
+            .iter()
+            .any(|&j| j != idx && defeats(&answers[j], &answers[idx], kb))
+    };
 
     let mut verdicts: Vec<GovernStatus> = vec![GovernStatus::Governing; answers.len()];
     for (i, key_i) in keys.iter().enumerate() {
@@ -187,22 +237,23 @@ pub fn enumerate_governing(query: &Term, kb: &KnowledgeBase) -> GovernedResult {
         if group.len() < 2 {
             continue; // singleton → no contest
         }
-        let max_pri = group.iter().map(|&j| answers[j].priority).max().unwrap();
-        let winners: Vec<usize> = group
-            .iter()
-            .copied()
-            .filter(|&j| answers[j].priority == max_pri)
-            .collect();
-        verdicts[i] = if answers[i].priority < max_pri {
-            // Defeated — cite a governing winner. With a unique winner that is THE governor;
-            // with a tie, any peer is a valid "defeated by" witness.
-            GovernStatus::Defeated {
-                by: answers[winners[0]].term.clone(),
-            }
-        } else if winners.len() == 1 {
-            GovernStatus::Governing
+        verdicts[i] = if !undefeated(i, &group) {
+            // Defeated — cite a defeating witness (one of the answers that defeats i).
+            let by = group
+                .iter()
+                .find(|&&j| j != i && defeats(&answers[j], &answers[i], kb))
+                .map(|&j| answers[j].term.clone())
+                .unwrap();
+            GovernStatus::Defeated { by }
         } else {
-            GovernStatus::ConflictPeer // tied at the top with another answer
+            // i is undefeated. The unique undefeated answer governs; if several are undefeated
+            // (incomparable at the top — a true split of authority) they are conflict peers.
+            let undefeated_count = group.iter().filter(|&&j| undefeated(j, &group)).count();
+            if undefeated_count == 1 {
+                GovernStatus::Governing
+            } else {
+                GovernStatus::ConflictPeer
+            }
         };
     }
     for (a, v) in answers.iter_mut().zip(verdicts) {
@@ -358,6 +409,118 @@ mod tests {
                 comp("means", vec![atom("waters"), atom("broad")]),
             ]
         );
+        assert!(!res.has_conflict());
+    }
+
+    // ---- ADJ73 PR-B: grounded context precedence (lex superior) ----
+
+    /// A rule grounded in a higher context governs a conflicting one in a lower context — the
+    /// north-star case. ninth_circuit > district_court, so the broad reading governs.
+    #[test]
+    fn higher_context_governs_the_lower_context() {
+        let mut kb = KnowledgeBase::new();
+        kb.declare_functional("means", 2);
+        kb.add_context_outranks("ninth_circuit", "district_court");
+        kb.add_rule(
+            Rule::certain(comp("means", vec![atom("waters"), atom("broad")]), vec![])
+                .with_context("ninth_circuit"),
+        );
+        kb.add_rule(
+            Rule::certain(comp("means", vec![atom("waters"), atom("narrow")]), vec![])
+                .with_context("district_court"),
+        );
+        let res = enumerate_governing(&comp("means", vec![atom("waters"), var("R")]), &kb);
+        let gov: Vec<&Term> = res.governing().map(|a| &a.term).collect();
+        assert_eq!(
+            gov,
+            vec![&comp("means", vec![atom("waters"), atom("broad")])]
+        );
+        assert!(!res.has_conflict());
+    }
+
+    /// Context precedence is PRIMARY: a higher-context rule with a LOWER tier still defeats a
+    /// lower-context rule carrying a higher tier (lex superior beats the explicit tier).
+    #[test]
+    fn context_precedence_outranks_the_tier() {
+        let mut kb = KnowledgeBase::new();
+        kb.declare_functional("rule_on", 1);
+        kb.add_context_outranks("federal", "state");
+        // federal rule at the LOWEST tier...
+        kb.add_rule(
+            Rule::certain(comp("rule_on", vec![atom("permitted")]), vec![]).with_context("federal"),
+        );
+        // ...vs a state rule at the HIGHEST tier — federal still governs.
+        kb.add_rule(
+            Rule::certain(comp("rule_on", vec![atom("forbidden")]), vec![])
+                .with_context("state")
+                .with_priority(Priority::Mandatory),
+        );
+        let res = enumerate_governing(&comp("rule_on", vec![var("X")]), &kb);
+        let gov: Vec<&Term> = res.governing().map(|a| &a.term).collect();
+        assert_eq!(gov, vec![&comp("rule_on", vec![atom("permitted")])]);
+    }
+
+    /// Incomparable contexts (no order between them) fall back to the priority tier.
+    #[test]
+    fn incomparable_contexts_fall_back_to_tier() {
+        let mut kb = KnowledgeBase::new();
+        kb.declare_functional("rule_on", 1);
+        // two unrelated contexts — no edge between them.
+        kb.add_rule(
+            Rule::certain(comp("rule_on", vec![atom("a")]), vec![])
+                .with_context("oregon")
+                .with_priority(Priority::Authoritative),
+        );
+        kb.add_rule(
+            Rule::certain(comp("rule_on", vec![atom("b")]), vec![])
+                .with_context("nevada")
+                .with_priority(Priority::Specific),
+        );
+        let res = enumerate_governing(&comp("rule_on", vec![var("X")]), &kb);
+        let gov: Vec<&Term> = res.governing().map(|a| &a.term).collect();
+        assert_eq!(gov, vec![&comp("rule_on", vec![atom("a")])]); // higher tier wins the tie
+    }
+
+    /// A cyclic context order (a > b, b > a) is detectable and never silently picks a winner.
+    #[test]
+    fn cyclic_context_order_is_detected_and_governs_nothing() {
+        let mut kb = KnowledgeBase::new();
+        kb.declare_functional("means", 2);
+        kb.add_context_outranks("a", "b");
+        kb.add_context_outranks("b", "a");
+        assert!(kb.context_order_has_cycle());
+        assert!(kb.context_outranks("a", "b") && kb.context_outranks("b", "a"));
+        kb.add_rule(
+            Rule::certain(comp("means", vec![atom("t"), atom("x")]), vec![]).with_context("a"),
+        );
+        kb.add_rule(
+            Rule::certain(comp("means", vec![atom("t"), atom("y")]), vec![]).with_context("b"),
+        );
+        let res = enumerate_governing(&comp("means", vec![atom("t"), var("R")]), &kb);
+        assert_eq!(
+            res.governing().count(),
+            0,
+            "a cycle must not crown a winner"
+        );
+    }
+
+    /// Back-compat: with NO context order declared, context-free rules resolve purely by tier
+    /// exactly as before PR-B.
+    #[test]
+    fn no_context_order_is_pure_tier_resolution() {
+        let mut kb = KnowledgeBase::new();
+        kb.declare_functional("timing", 1);
+        kb.add_rule(
+            Rule::certain(comp("timing", vec![atom("await")]), vec![])
+                .with_priority(Priority::Specific),
+        );
+        kb.add_rule(Rule::certain(
+            comp("timing", vec![atom("treat_now")]),
+            vec![],
+        ));
+        let res = enumerate_governing(&comp("timing", vec![var("D")]), &kb);
+        let gov: Vec<&Term> = res.governing().map(|a| &a.term).collect();
+        assert_eq!(gov, vec![&comp("timing", vec![atom("await")])]);
         assert!(!res.has_conflict());
     }
 }

--- a/code/packages/rust/logic-engine/src/lib.rs
+++ b/code/packages/rust/logic-engine/src/lib.rs
@@ -247,6 +247,15 @@ pub struct Rule {
     /// exception ladders. Richer, byte-provenanced precedence (lex-superior / recency /
     /// appeal-status over a grounded `context-precedence` rulebook) is ADJ73 PR-B.
     pub priority: Priority,
+    /// ADJ73 PR-B (grounded context precedence): the CONTEXT this rule is grounded in — a
+    /// jurisdiction (`ninth_circuit`), guideline edition (`idsa_2024`), specialty
+    /// (`specialist`), etc. `None` for a context-free rule (today's behavior). When two
+    /// conflicting rules carry contexts ordered by [`KnowledgeBase::add_context_outranks`]
+    /// (e.g. `ninth_circuit` outranks `district_court`), the rule in the GREATER context
+    /// defeats the other — the McCarthy lex-superior relation — *before* the priority tier is
+    /// consulted (the tier breaks ties the context order leaves open). Only
+    /// [`crate::govern::enumerate_governing`] reads it.
+    pub context: Option<String>,
 }
 
 /// ADJ73 defeasible-precedence TIER (decision 1: named enum, not raw integers). Totally
@@ -280,6 +289,7 @@ impl Rule {
             probability: Probability::Certain,
             provenance: Provenance::unattributed(),
             priority: Priority::Default,
+            context: None,
         }
     }
 
@@ -294,6 +304,7 @@ impl Rule {
             probability: Probability::Value(p),
             provenance: Provenance::unattributed(),
             priority: Priority::Default,
+            context: None,
         }
     }
 
@@ -308,6 +319,14 @@ impl Rule {
     /// among conflicting derivations). Builder-style, mirrors [`Self::with_provenance`].
     pub fn with_priority(mut self, priority: Priority) -> Self {
         self.priority = priority;
+        self
+    }
+
+    /// ADJ73 PR-B: ground the rule in a CONTEXT (a jurisdiction / guideline edition /
+    /// specialty). Combined with [`KnowledgeBase::add_context_outranks`], the rule in the
+    /// greater context defeats a conflicting one in a lesser context (lex superior).
+    pub fn with_context(mut self, context: impl Into<String>) -> Self {
+        self.context = Some(context.into());
         self
     }
 }
@@ -388,6 +407,13 @@ pub struct KnowledgeBase {
     /// highest-priority one. A predicate not listed here is monotonic (every derivation
     /// governs) — this is what makes precedence opt-in and `enumerate_all` unchanged.
     functional_predicates: HashSet<ClauseIndex>,
+    /// ADJ73 PR-B: the grounded CONTEXT precedence order — directed edges `(higher, lower)`
+    /// meaning "a rule in `higher` outranks a conflicting rule in `lower`" (federal > state,
+    /// ninth_circuit > district_court, idsa_2024 > idsa_2004, specialist > general). Each edge
+    /// is a grounded fact (its byte-quote — the Supremacy Clause, etc. — rides on the
+    /// surface/data layer). [`crate::govern::enumerate_governing`] consults this BEFORE the
+    /// priority tier (lex superior); the transitive reach is computed cycle-safely.
+    context_order: Vec<(String, String)>,
     next_fact_id: u64,
     next_rule_id: u64,
     next_prior_id: u64,
@@ -476,6 +502,81 @@ impl KnowledgeBase {
         ClauseIndex::from_term(term)
             .map(|idx| self.functional_predicates.contains(&idx))
             .unwrap_or(false)
+    }
+
+    /// ADJ73 PR-B: assert that context `higher` OUTRANKS context `lower` (a grounded
+    /// precedence edge — federal > state, ninth_circuit > district_court). Idempotent; the
+    /// transitive closure is computed on query. Adding a back-edge that creates a cycle is
+    /// *allowed* here (the loader may reject it), but [`Self::context_outranks`] is cycle-safe
+    /// and a mutual outrank degrades to an unresolved conflict rather than a wrong pick.
+    pub fn add_context_outranks(&mut self, higher: impl Into<String>, lower: impl Into<String>) {
+        let edge = (higher.into(), lower.into());
+        if !self.context_order.contains(&edge) {
+            self.context_order.push(edge);
+        }
+    }
+
+    /// ADJ73 PR-B: does context `a` outrank context `b` (directly or transitively)? Cycle-safe
+    /// DFS over the `(higher, lower)` edges. `a == b` is `false` (a context does not outrank
+    /// itself). Returns `false` when there is no directed path `a → … → b`.
+    pub fn context_outranks(&self, a: &str, b: &str) -> bool {
+        if a == b {
+            return false;
+        }
+        let mut stack = vec![a];
+        let mut seen: HashSet<&str> = HashSet::new();
+        while let Some(node) = stack.pop() {
+            if !seen.insert(node) {
+                continue; // already visited — cycle-safe
+            }
+            for (hi, lo) in &self.context_order {
+                if hi == node {
+                    if lo == b {
+                        return true;
+                    }
+                    stack.push(lo);
+                }
+            }
+        }
+        false
+    }
+
+    /// ADJ73 PR-B: `true` iff the declared `context_order` contains a cycle (e.g. `a > b`,
+    /// `b > a`). The surface loader should reject such a rulebook; the resolver itself stays
+    /// safe regardless. Detected as "some node can reach itself".
+    pub fn context_order_has_cycle(&self) -> bool {
+        let nodes: HashSet<&str> = self
+            .context_order
+            .iter()
+            .flat_map(|(h, l)| [h.as_str(), l.as_str()])
+            .collect();
+        nodes.iter().any(|n| self.reaches_self(n))
+    }
+
+    /// Helper: can `start` reach itself via a directed path of length ≥ 1? (`context_outranks`
+    /// short-circuits `a == b` to false, so cycle detection needs this explicit walk.)
+    fn reaches_self(&self, start: &str) -> bool {
+        let mut stack: Vec<&str> = self
+            .context_order
+            .iter()
+            .filter(|(h, _)| h == start)
+            .map(|(_, l)| l.as_str())
+            .collect();
+        let mut seen: HashSet<&str> = HashSet::new();
+        while let Some(node) = stack.pop() {
+            if node == start {
+                return true;
+            }
+            if !seen.insert(node) {
+                continue;
+            }
+            for (hi, lo) in &self.context_order {
+                if hi == node {
+                    stack.push(lo);
+                }
+            }
+        }
+        false
     }
 
     /// Walk every Fact and every Rule once; return `true` iff every

--- a/code/specs/ADJ73-defeasible-rule-precedence.md
+++ b/code/specs/ADJ73-defeasible-rule-precedence.md
@@ -331,6 +331,13 @@ Each PR: spec-sync note, tests incl. a CONFLICT/abstain case, `/security-review`
   appeal-status / lex-specialis). Engine resolution queries `outranks` instead of comparing enum
   tiers when rule attributes are present; cycle/contradiction → CONFLICT. Rule attributes
   (authority/date/appeal/specificity) added as typed, provenanced metadata.
+  - **PR-B engine core ✅ DONE (logic-engine 0.19).** `Rule::context` + `Knowledge­Base::{add_context_outranks,
+    context_outranks (cycle-safe), context_order_has_cycle}` + a `defeats(a,b)` resolution that
+    makes context precedence PRIMARY (lex superior) and the tier secondary — generalizing the
+    pure-tier rule (no context order ⇒ unchanged). A cyclic order crowns nothing (safe). Still
+    to come: the grounded `context-precedence.adj` **rulebook** with byte-provenanced edges + the
+    recency/appeal/lex-specialis **meta-rules**, and the adj-lang **surface** (`context:` on a
+    rule, `context_order { … }`).
 - **PR-C — adj-lang surface** (`priority: <tier>`, `functional`/`decision`, the attribute
   annotations) + regen grammar.
 - **PR-D — MYCIN `decide_timing` → `timing.adj`** on the named-enum ladder (was PR-4).


### PR DESCRIPTION
The **legal north-star** mechanism: a rule grounded in a higher **context** defeats a conflicting one in a lower context (federal > state, ninth_circuit > district_court, idsa_2024 > idsa_2004, specialist > general) — McCarthy's **lex superior** — *before* the priority tier is consulted.

```rust
kb.declare_functional("means", 2);
kb.add_context_outranks("ninth_circuit", "district_court");   // grounded precedence edge
kb.add_rule(Rule::certain(/* means(waters, broad) */).with_context("ninth_circuit"));
kb.add_rule(Rule::certain(/* means(waters, narrow) */).with_context("district_court"));
// → means(waters, broad) governs; the district reading is Defeated { by: … }.
```

- **`Rule::context: Option<String>`** (builder `with_context`).
- **`KnowledgeBase::add_context_outranks` / `context_outranks` (cycle-safe DFS) / `context_order_has_cycle`**.
- **`govern`**: `GovernedAnswer.context` + a `defeats(a,b)` resolution — context precedence **primary**, `Standing` tier **secondary**. Governs iff undefeated; several undefeated → `ConflictPeer`; a **cyclic order crowns nothing** (safe, never a wrong pick).

## Back-compat

With **no** context order declared, `defeats` reduces to "higher tier wins" — byte-identical to 0.18 (the existing precedence + integration tests pass unchanged). The 2 `adjudication-connector` `Rule{}` sites set `context: None`.

## Verification

**106** logic-engine tests pass incl. **5 new** context-precedence tests (higher-context governs; context beats tier; incomparable → tier fallback; cyclic order governs nothing; no-context = pure tier). Downstream builds; fmt churn reverted; **security review passed** (both graph walks cycle-safe; the Defeated-branch `unwrap` provably `Some`; all proof indices in-bounds). CHANGELOG 0.19.0 + README + ADJ73 §7 spec sync.

This is PR-B's **engine core**. The grounded `context-precedence` **rulebook** (byte-provenanced `outranks_context` edges + recency/appeal/lex-specialis meta-rules) and the adj-lang **surface** (`context:` / `context_order {}`) are the next slices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)