### PR TITLE
feat(visicalc-flutter): wire drag-fill into the infinite-sheet demo

### DIFF
--- a/demo/visicalc-flutter/README.md
+++ b/demo/visicalc-flutter/README.md
@@ -117,7 +117,11 @@ Two-axis scroll with frozen chrome, kept in sync by one-way controller links
 follows the body's horizontal pan and the row-number gutter (its own virtualized
 `ListView`) follows the body's vertical scroll. Tap a cell → `selectInf(row,col)`
 (clamps, loads the source into the formula bar); press Enter → `commitInf(text)`
-(writes through, recomputes dependents, regrows the extent). `InfiniteSheetModel`
+(writes through, recomputes dependents, regrows the extent). The **"Fill ↓ 10"**
+button calls `InfiniteSheetModel.fillDown(10)` (over the C ABI's `sc_fill`) to
+replicate the selected cell into the 10 rows below it — the engine shifts each
+copy's relative references (`=A1`→`=A2`, …), pins absolute (`$`) refs, and
+carries the format. `InfiniteSheetModel`
 (in `lib/engine.dart`) seeds far-flung sparse cells (`Z1000`, `BA50`, `BB50`) so
 there's something to scroll to, and derives the extent from `usedRange()` + a
 margin.

--- a/demo/visicalc-flutter/lib/engine.dart
+++ b/demo/visicalc-flutter/lib/engine.dart
@@ -67,6 +67,12 @@ typedef _ChangedSinceD = Pointer<Uint8> Function(Pointer<Void>, int);
 typedef _SetFormatC = Void Function(Pointer<Void>, Pointer<Uint8>, Pointer<Uint8>);
 typedef _SetFormatD = void Function(Pointer<Void>, Pointer<Uint8>, Pointer<Uint8>);
 
+// sc_fill(session, src, dst_start, dst_end) → void (drag-fill; three A1 strings).
+typedef _FillC = Void Function(
+    Pointer<Void>, Pointer<Uint8>, Pointer<Uint8>, Pointer<Uint8>);
+typedef _FillD = void Function(
+    Pointer<Void>, Pointer<Uint8>, Pointer<Uint8>, Pointer<Uint8>);
+
 /// A single spreadsheet session, owning the opaque C handle.
 class SpreadsheetSession {
   final DynamicLibrary _lib;
@@ -77,9 +83,9 @@ class SpreadsheetSession {
   late final _GetD _getValue;
   late final _GetD _getRaw;
   late final _StringFreeD _stringFree;
-  late final _WindowD _getWindow;
   late final _WindowD _getDisplayWindow;
   late final _SetFormatD _setFormatFn;
+  late final _FillD _fillFn;
   late final _NoArgD _usedRangeFn;
   late final _ColLettersD _columnLettersFn;
   late final _CurrentRevD _currentRevisionFn;
@@ -97,9 +103,9 @@ class SpreadsheetSession {
     _getValue = _lib.lookupFunction<_GetC, _GetD>('sc_get_value');
     _getRaw = _lib.lookupFunction<_GetC, _GetD>('sc_get_raw');
     _stringFree = _lib.lookupFunction<_StringFreeC, _StringFreeD>('sc_string_free');
-    _getWindow = _lib.lookupFunction<_WindowC, _WindowD>('sc_get_window');
     _getDisplayWindow = _lib.lookupFunction<_WindowC, _WindowD>('sc_get_display_window');
     _setFormatFn = _lib.lookupFunction<_SetFormatC, _SetFormatD>('sc_set_format');
+    _fillFn = _lib.lookupFunction<_FillC, _FillD>('sc_fill');
     _usedRangeFn = _lib.lookupFunction<_NoArgC, _NoArgD>('sc_used_range');
     _columnLettersFn = _lib.lookupFunction<_ColLettersC, _ColLettersD>('sc_column_letters');
     _currentRevisionFn = _lib.lookupFunction<_CurrentRevC, _CurrentRevD>('sc_current_revision');
@@ -245,6 +251,23 @@ class SpreadsheetSession {
     } finally {
       _freeCString(a1Ptr);
       _freeCString(codePtr);
+    }
+  }
+
+  /// Drag-fill: replicate the `src` cell across the inclusive A1 rectangle
+  /// `dstStart`..`dstEnd`. Relative references shift per target (`=A1` filled
+  /// down → `=A2`), absolute (`$`) refs pin, the source's format carries along,
+  /// an empty source clears each target. A malformed address is a no-op.
+  void fill(String src, String dstStart, String dstEnd) {
+    final srcPtr = _toCString(src);
+    final startPtr = _toCString(dstStart);
+    final endPtr = _toCString(dstEnd);
+    try {
+      _fillFn(_handle, srcPtr, startPtr, endPtr);
+    } finally {
+      _freeCString(srcPtr);
+      _freeCString(startPtr);
+      _freeCString(endPtr);
     }
   }
 
@@ -468,5 +491,16 @@ class InfiniteSheetModel {
     _session.setCell(infAddress, raw);
     computeExtent();
     formula = _session.getRaw(infAddress);
+  }
+
+  /// Drag-fill: replicate the selected cell into the [rows] rows below it. The
+  /// engine shifts each copy's relative references, pins absolute (`$`) refs,
+  /// and carries the format. Regrows the extent if the fill reached new ground.
+  void fillDown(int rows) {
+    final col = columnLetters(selCol);
+    final first = '$col${selRow + 1}';
+    final last = '$col${selRow + rows}';
+    _session.fill(infAddress, first, last);
+    computeExtent();
   }
 }

--- a/demo/visicalc-flutter/lib/infinite_grid.dart
+++ b/demo/visicalc-flutter/lib/infinite_grid.dart
@@ -108,6 +108,12 @@ class _InfiniteGridState extends State<InfiniteGrid> {
     });
   }
 
+  // Drag-fill: replicate the selected cell into the 10 rows below it. The engine
+  // shifts each copy's relative refs, pins absolute ($) refs, carries the format.
+  void _fillDown() {
+    setState(() => _model.fillDown(10));
+  }
+
   @override
   Widget build(BuildContext context) {
     return Column(
@@ -149,6 +155,20 @@ class _InfiniteGridState extends State<InfiniteGrid> {
                   border: InputBorder.none,
                 ),
               ),
+            ),
+          ),
+          const SizedBox(width: 8),
+          // Drag-fill: replicate the selected cell into the 10 rows below it.
+          Tooltip(
+            message: 'Replicate the selected cell into the 10 rows below it',
+            child: OutlinedButton(
+              onPressed: _fillDown,
+              style: OutlinedButton.styleFrom(
+                foregroundColor: _ink,
+                side: const BorderSide(color: _border),
+                padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+              ),
+              child: const Text('Fill ↓ 10', style: TextStyle(fontFamily: _mono, fontSize: 12)),
             ),
           ),
         ],

--- a/demo/visicalc-flutter/test/window_test.dart
+++ b/demo/visicalc-flutter/test/window_test.dart
@@ -117,5 +117,22 @@ void main() {
       expect(m.rowCells(5)[0], '139.00'); // A5 = 15+108+12+4, formatted
       expect(m.rowCells(5)[4], '269.00'); // E5 grand total, formatted
     });
+
+    test('fillDown replicates the selected cell, shifting relative refs', () {
+      final m = InfiniteSheetModel();
+      addTearDown(m.dispose);
+      // Seed a fresh column via select+commit: H1=2, H2=3, H3=4 (col 8 = H);
+      // I1 = H1*10 (col 9 = I). Select I1 and fill down 10 — each filled formula
+      // tracks its row (I2 = H2*10 = 30, …).
+      m.selectInf(1, 8); m.commitInf('2'); // H1
+      m.selectInf(2, 8); m.commitInf('3'); // H2
+      m.selectInf(3, 8); m.commitInf('4'); // H3
+      m.selectInf(1, 9); m.commitInf('=H1*10'); // I1 = 20
+      m.selectInf(1, 9);
+      m.fillDown(10);
+      expect(m.rowCells(2)[8], '30'); // I2 = H2*10
+      expect(m.rowCells(3)[8], '40'); // I3 = H3*10
+      expect(m.rowCells(1)[8], '20'); // I1 source untouched
+    });
   });
 }


### PR DESCRIPTION
## What

Adds a **"Fill ↓ 10"** affordance to the Flutter infinite-sheet view — the second **native** consumer of the `fill` ABI (after Qt #6086; engine #6048, facades #6057, web #6082). The button replicates the selected cell into the 10 rows below it; the engine shifts each copy's relative references (`=A1`→`=A2`, …), pins absolute (`$`) refs, and carries the format.

## Changes

- **`lib/engine.dart`** — add the `sc_fill` FFI typedef/lookup + `SpreadsheetSession.fill(src, dstStart, dstEnd)` (three A1 strings; all malloc'd inputs freed in a `finally`, mirroring `setFormat`); `InfiniteSheetModel.fillDown(rows)` fills the selected cell down `rows` rows and regrows the extent. Also **removes the now-dead `_getWindow` FFI field + lookup** (`window()` switched to `sc_get_display_window` in #6028; the `_WindowD` typedef is retained, reused by `_getDisplayWindow`) — clears a `flutter analyze` warning.
- **`lib/infinite_grid.dart`** — "Fill ↓ 10" `OutlinedButton` + `_fillDown` handler.
- **`test/window_test.dart`** — `fillDown` test (I1=H1*10 filled down → I2=30, I3=40; source untouched).
- README updated.

## Verification

- `flutter test test/window_test.dart` — **8/8 PASS**, against the re-vendored `spreadsheet-capi` 0.6.0 dylib (`native/` git-ignored; `nm` confirms the `sc_fill` symbol).
- `flutter analyze` — **No issues found** (the dead-field removal cleared the pre-existing warning).

`/security-review` — **PASSED** (FFI free-once via `_toCString`/`_freeCString`; `fill` A1 args are engine-derived/clamped; fill range is the constant 10 and the engine caps at `MAX_RANGE_CELLS`; dead-field removal doesn't break the retained typedef).

## Next

Compose → XAML → SwiftUI, one PR each.

🤖 Generated with [Claude Code](https://claude.com/claude-code)