### PR TITLE
feat(W-3): wolfram-parser — parse tree for the Wolfram M-expression subset

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -212,6 +212,7 @@ members = [
     "maxima-runtime",
     "maxima-repl",
     "wolfram-lexer",
+    "wolfram-parser",
     "logic-gates",
     "logic-core",
     "lookup-core",

--- a/code/packages/rust/wolfram-parser/BUILD
+++ b/code/packages/rust/wolfram-parser/BUILD
@@ -1,0 +1,1 @@
+cargo test -p coding-adventures-wolfram-parser -- --nocapture

--- a/code/packages/rust/wolfram-parser/BUILD_windows
+++ b/code/packages/rust/wolfram-parser/BUILD_windows
@@ -1,0 +1,1 @@
+cargo test -p coding-adventures-wolfram-parser -- --nocapture

--- a/code/packages/rust/wolfram-parser/CHANGELOG.md
+++ b/code/packages/rust/wolfram-parser/CHANGELOG.md
@@ -1,0 +1,22 @@
+# Changelog — coding-adventures-wolfram-parser
+
+All notable changes to this package are documented here. The format follows
+[Keep a Changelog](https://keepachangelog.com/), and this project adheres to
+Semantic Versioning.
+
+## [0.1.0] — 2026-06-16
+
+### Added
+
+- Initial release (W-3). A parser for the Wolfram Language M-expression subset,
+  a thin wrapper over the generic `GrammarParser` with the committed `_grammar.rs`
+  compiled from `code/grammars/wolfram.grammar`. Exposes `parse_wolfram` /
+  `try_parse_wolfram` / `create_wolfram_parser`, producing a `GrammarASTNode`
+  rooted at `program`.
+- The parse tree's rule names (`assignment`, `replaceall`, `rule`, `additive`,
+  `multiplicative`, `power`, `postfix`, `atom`, `list`, …) are the surface forms
+  the W-4 `wolfram-runtime` will lower into canonical `symbolic-ir` heads.
+
+### Notes
+
+- Sibling of `r-parser` / `macsyma-parser`. See `code/specs/MA04-wolfram-language.md`.

--- a/code/packages/rust/wolfram-parser/Cargo.toml
+++ b/code/packages/rust/wolfram-parser/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "coding-adventures-wolfram-parser"
+version = "0.1.0"
+edition = "2021"
+description = "Parser for the Wolfram Language (Mathematica) M-expression subset"
+license = "MIT"
+
+[dependencies]
+grammar-tools = { path = "../grammar-tools" }
+lexer = { path = "../lexer" }
+parser = { path = "../parser" }
+coding-adventures-wolfram-lexer = { path = "../wolfram-lexer" }

--- a/code/packages/rust/wolfram-parser/README.md
+++ b/code/packages/rust/wolfram-parser/README.md
@@ -1,0 +1,33 @@
+# coding-adventures-wolfram-parser
+
+The parser for the **Wolfram Language** (Mathematica) M-expression subset — W-3
+of the Wolfram frontend.
+
+A thin wrapper over the generic `GrammarParser` (a sibling of `r-parser` /
+`macsyma-parser`) with the committed `_grammar.rs` compiled from
+[`code/grammars/wolfram.grammar`](../../../grammars/wolfram.grammar). It tokenizes
+with `wolfram-lexer`, then parses into a `GrammarASTNode` rooted at `program`.
+
+```rust
+use coding_adventures_wolfram_parser::parse_wolfram;
+
+let ast = parse_wolfram("f[x_] := x^2\n");
+assert_eq!(ast.rule_name, "program");
+```
+
+Everything in Wolfram is `head[args]`; the tree's rule names (`replaceall`,
+`rule`, `additive`, `power`, `postfix`, `list`, …) are the surface forms the W-4
+`wolfram-runtime` lowers into canonical `symbolic-ir` heads. `try_parse_wolfram`
+returns a `Result` instead of panicking.
+
+## Where it fits
+
+```
+wolfram.grammar → wolfram-parser (this crate) → wolfram-runtime (W-4, → symbolic-ir)
+```
+
+## Testing
+
+```
+cargo test -p coding-adventures-wolfram-parser
+```

--- a/code/packages/rust/wolfram-parser/required_capabilities.json
+++ b/code/packages/rust/wolfram-parser/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "rust/wolfram-parser",
+  "capabilities": [],
+  "justification": "Pure computation. The Wolfram grammar is embedded as generated Rust code; tokenizing and parsing need no filesystem, network, or process access."
+}

--- a/code/packages/rust/wolfram-parser/src/_grammar.rs
+++ b/code/packages/rust/wolfram-parser/src/_grammar.rs
@@ -1,0 +1,530 @@
+// AUTO-GENERATED FILE — DO NOT EDIT
+// Source: wolfram.grammar
+// Regenerate with: grammar-tools compile-grammar wolfram.grammar
+//
+// This file embeds a ParserGrammar as native Rust data structures.
+// Call `parser_grammar()` instead of reading and parsing the .grammar file.
+
+use grammar_tools::parser_grammar::{GrammarElement, GrammarRule, ParserGrammar};
+
+pub fn parser_grammar() -> ParserGrammar {
+    ParserGrammar {
+        rules: vec![
+            GrammarRule {
+                name: r#"program"#.to_string(),
+                body: GrammarElement::Repetition {
+                    element: Box::new(GrammarElement::RuleReference {
+                        name: r#"statement_line"#.to_string(),
+                    }),
+                },
+                line_number: 43,
+            },
+            GrammarRule {
+                name: r#"statement_line"#.to_string(),
+                body: GrammarElement::Alternation {
+                    choices: vec![
+                        GrammarElement::Sequence {
+                            elements: vec![
+                                GrammarElement::RuleReference {
+                                    name: r#"statement"#.to_string(),
+                                },
+                                GrammarElement::Group {
+                                    element: Box::new(GrammarElement::Alternation {
+                                        choices: vec![
+                                            GrammarElement::TokenReference {
+                                                name: r#"NEWLINE"#.to_string(),
+                                            },
+                                            GrammarElement::TokenReference {
+                                                name: r#"SEMI"#.to_string(),
+                                            },
+                                        ],
+                                    }),
+                                },
+                            ],
+                        },
+                        GrammarElement::RuleReference {
+                            name: r#"statement"#.to_string(),
+                        },
+                        GrammarElement::TokenReference {
+                            name: r#"NEWLINE"#.to_string(),
+                        },
+                        GrammarElement::TokenReference {
+                            name: r#"SEMI"#.to_string(),
+                        },
+                    ],
+                },
+                line_number: 47,
+            },
+            GrammarRule {
+                name: r#"statement"#.to_string(),
+                body: GrammarElement::RuleReference {
+                    name: r#"expr"#.to_string(),
+                },
+                line_number: 52,
+            },
+            GrammarRule {
+                name: r#"expr"#.to_string(),
+                body: GrammarElement::RuleReference {
+                    name: r#"assignment"#.to_string(),
+                },
+                line_number: 54,
+            },
+            GrammarRule {
+                name: r#"assignment"#.to_string(),
+                body: GrammarElement::Sequence {
+                    elements: vec![
+                        GrammarElement::RuleReference {
+                            name: r#"replaceall"#.to_string(),
+                        },
+                        GrammarElement::Optional {
+                            element: Box::new(GrammarElement::Sequence {
+                                elements: vec![
+                                    GrammarElement::Group {
+                                        element: Box::new(GrammarElement::Alternation {
+                                            choices: vec![
+                                                GrammarElement::TokenReference {
+                                                    name: r#"SET"#.to_string(),
+                                                },
+                                                GrammarElement::TokenReference {
+                                                    name: r#"SETDELAYED"#.to_string(),
+                                                },
+                                            ],
+                                        }),
+                                    },
+                                    GrammarElement::RuleReference {
+                                        name: r#"assignment"#.to_string(),
+                                    },
+                                ],
+                            }),
+                        },
+                    ],
+                },
+                line_number: 57,
+            },
+            GrammarRule {
+                name: r#"replaceall"#.to_string(),
+                body: GrammarElement::Sequence {
+                    elements: vec![
+                        GrammarElement::RuleReference {
+                            name: r#"rule"#.to_string(),
+                        },
+                        GrammarElement::Repetition {
+                            element: Box::new(GrammarElement::Sequence {
+                                elements: vec![
+                                    GrammarElement::TokenReference {
+                                        name: r#"REPLACEALL"#.to_string(),
+                                    },
+                                    GrammarElement::RuleReference {
+                                        name: r#"rule"#.to_string(),
+                                    },
+                                ],
+                            }),
+                        },
+                    ],
+                },
+                line_number: 60,
+            },
+            GrammarRule {
+                name: r#"rule"#.to_string(),
+                body: GrammarElement::Sequence {
+                    elements: vec![
+                        GrammarElement::RuleReference {
+                            name: r#"logical_or"#.to_string(),
+                        },
+                        GrammarElement::Optional {
+                            element: Box::new(GrammarElement::Sequence {
+                                elements: vec![
+                                    GrammarElement::Group {
+                                        element: Box::new(GrammarElement::Alternation {
+                                            choices: vec![
+                                                GrammarElement::TokenReference {
+                                                    name: r#"RULE"#.to_string(),
+                                                },
+                                                GrammarElement::TokenReference {
+                                                    name: r#"RULEDELAYED"#.to_string(),
+                                                },
+                                            ],
+                                        }),
+                                    },
+                                    GrammarElement::RuleReference {
+                                        name: r#"rule"#.to_string(),
+                                    },
+                                ],
+                            }),
+                        },
+                    ],
+                },
+                line_number: 63,
+            },
+            GrammarRule {
+                name: r#"logical_or"#.to_string(),
+                body: GrammarElement::Sequence {
+                    elements: vec![
+                        GrammarElement::RuleReference {
+                            name: r#"logical_and"#.to_string(),
+                        },
+                        GrammarElement::Repetition {
+                            element: Box::new(GrammarElement::Sequence {
+                                elements: vec![
+                                    GrammarElement::TokenReference {
+                                        name: r#"OR"#.to_string(),
+                                    },
+                                    GrammarElement::RuleReference {
+                                        name: r#"logical_and"#.to_string(),
+                                    },
+                                ],
+                            }),
+                        },
+                    ],
+                },
+                line_number: 65,
+            },
+            GrammarRule {
+                name: r#"logical_and"#.to_string(),
+                body: GrammarElement::Sequence {
+                    elements: vec![
+                        GrammarElement::RuleReference {
+                            name: r#"logical_not"#.to_string(),
+                        },
+                        GrammarElement::Repetition {
+                            element: Box::new(GrammarElement::Sequence {
+                                elements: vec![
+                                    GrammarElement::TokenReference {
+                                        name: r#"AND"#.to_string(),
+                                    },
+                                    GrammarElement::RuleReference {
+                                        name: r#"logical_not"#.to_string(),
+                                    },
+                                ],
+                            }),
+                        },
+                    ],
+                },
+                line_number: 66,
+            },
+            GrammarRule {
+                name: r#"logical_not"#.to_string(),
+                body: GrammarElement::Alternation {
+                    choices: vec![
+                        GrammarElement::Sequence {
+                            elements: vec![
+                                GrammarElement::TokenReference {
+                                    name: r#"NOT"#.to_string(),
+                                },
+                                GrammarElement::RuleReference {
+                                    name: r#"logical_not"#.to_string(),
+                                },
+                            ],
+                        },
+                        GrammarElement::RuleReference {
+                            name: r#"comparison"#.to_string(),
+                        },
+                    ],
+                },
+                line_number: 67,
+            },
+            GrammarRule {
+                name: r#"comparison"#.to_string(),
+                body: GrammarElement::Sequence {
+                    elements: vec![
+                        GrammarElement::RuleReference {
+                            name: r#"additive"#.to_string(),
+                        },
+                        GrammarElement::Optional {
+                            element: Box::new(GrammarElement::Sequence {
+                                elements: vec![
+                                    GrammarElement::Group {
+                                        element: Box::new(GrammarElement::Alternation {
+                                            choices: vec![
+                                                GrammarElement::TokenReference {
+                                                    name: r#"EQUAL"#.to_string(),
+                                                },
+                                                GrammarElement::TokenReference {
+                                                    name: r#"UNEQUAL"#.to_string(),
+                                                },
+                                                GrammarElement::TokenReference {
+                                                    name: r#"LESS"#.to_string(),
+                                                },
+                                                GrammarElement::TokenReference {
+                                                    name: r#"GREATER"#.to_string(),
+                                                },
+                                                GrammarElement::TokenReference {
+                                                    name: r#"LE"#.to_string(),
+                                                },
+                                                GrammarElement::TokenReference {
+                                                    name: r#"GE"#.to_string(),
+                                                },
+                                            ],
+                                        }),
+                                    },
+                                    GrammarElement::RuleReference {
+                                        name: r#"additive"#.to_string(),
+                                    },
+                                ],
+                            }),
+                        },
+                    ],
+                },
+                line_number: 70,
+            },
+            GrammarRule {
+                name: r#"additive"#.to_string(),
+                body: GrammarElement::Sequence {
+                    elements: vec![
+                        GrammarElement::RuleReference {
+                            name: r#"multiplicative"#.to_string(),
+                        },
+                        GrammarElement::Repetition {
+                            element: Box::new(GrammarElement::Sequence {
+                                elements: vec![
+                                    GrammarElement::Group {
+                                        element: Box::new(GrammarElement::Alternation {
+                                            choices: vec![
+                                                GrammarElement::TokenReference {
+                                                    name: r#"PLUS"#.to_string(),
+                                                },
+                                                GrammarElement::TokenReference {
+                                                    name: r#"MINUS"#.to_string(),
+                                                },
+                                            ],
+                                        }),
+                                    },
+                                    GrammarElement::RuleReference {
+                                        name: r#"multiplicative"#.to_string(),
+                                    },
+                                ],
+                            }),
+                        },
+                    ],
+                },
+                line_number: 72,
+            },
+            GrammarRule {
+                name: r#"multiplicative"#.to_string(),
+                body: GrammarElement::Sequence {
+                    elements: vec![
+                        GrammarElement::RuleReference {
+                            name: r#"unary"#.to_string(),
+                        },
+                        GrammarElement::Repetition {
+                            element: Box::new(GrammarElement::Sequence {
+                                elements: vec![
+                                    GrammarElement::Group {
+                                        element: Box::new(GrammarElement::Alternation {
+                                            choices: vec![
+                                                GrammarElement::TokenReference {
+                                                    name: r#"TIMES"#.to_string(),
+                                                },
+                                                GrammarElement::TokenReference {
+                                                    name: r#"SLASH"#.to_string(),
+                                                },
+                                            ],
+                                        }),
+                                    },
+                                    GrammarElement::RuleReference {
+                                        name: r#"unary"#.to_string(),
+                                    },
+                                ],
+                            }),
+                        },
+                    ],
+                },
+                line_number: 73,
+            },
+            GrammarRule {
+                name: r#"unary"#.to_string(),
+                body: GrammarElement::Alternation {
+                    choices: vec![
+                        GrammarElement::Sequence {
+                            elements: vec![
+                                GrammarElement::Group {
+                                    element: Box::new(GrammarElement::Alternation {
+                                        choices: vec![
+                                            GrammarElement::TokenReference {
+                                                name: r#"MINUS"#.to_string(),
+                                            },
+                                            GrammarElement::TokenReference {
+                                                name: r#"PLUS"#.to_string(),
+                                            },
+                                        ],
+                                    }),
+                                },
+                                GrammarElement::RuleReference {
+                                    name: r#"unary"#.to_string(),
+                                },
+                            ],
+                        },
+                        GrammarElement::RuleReference {
+                            name: r#"power"#.to_string(),
+                        },
+                    ],
+                },
+                line_number: 76,
+            },
+            GrammarRule {
+                name: r#"power"#.to_string(),
+                body: GrammarElement::Sequence {
+                    elements: vec![
+                        GrammarElement::RuleReference {
+                            name: r#"postfix"#.to_string(),
+                        },
+                        GrammarElement::Optional {
+                            element: Box::new(GrammarElement::Sequence {
+                                elements: vec![
+                                    GrammarElement::TokenReference {
+                                        name: r#"POWER"#.to_string(),
+                                    },
+                                    GrammarElement::RuleReference {
+                                        name: r#"unary"#.to_string(),
+                                    },
+                                ],
+                            }),
+                        },
+                    ],
+                },
+                line_number: 79,
+            },
+            GrammarRule {
+                name: r#"postfix"#.to_string(),
+                body: GrammarElement::Sequence {
+                    elements: vec![
+                        GrammarElement::RuleReference {
+                            name: r#"atom"#.to_string(),
+                        },
+                        GrammarElement::Repetition {
+                            element: Box::new(GrammarElement::Sequence {
+                                elements: vec![
+                                    GrammarElement::TokenReference {
+                                        name: r#"LBRACKET"#.to_string(),
+                                    },
+                                    GrammarElement::Optional {
+                                        element: Box::new(GrammarElement::RuleReference {
+                                            name: r#"arglist"#.to_string(),
+                                        }),
+                                    },
+                                    GrammarElement::TokenReference {
+                                        name: r#"RBRACKET"#.to_string(),
+                                    },
+                                ],
+                            }),
+                        },
+                    ],
+                },
+                line_number: 83,
+            },
+            GrammarRule {
+                name: r#"arglist"#.to_string(),
+                body: GrammarElement::Sequence {
+                    elements: vec![
+                        GrammarElement::RuleReference {
+                            name: r#"expr"#.to_string(),
+                        },
+                        GrammarElement::Repetition {
+                            element: Box::new(GrammarElement::Sequence {
+                                elements: vec![
+                                    GrammarElement::TokenReference {
+                                        name: r#"COMMA"#.to_string(),
+                                    },
+                                    GrammarElement::RuleReference {
+                                        name: r#"expr"#.to_string(),
+                                    },
+                                ],
+                            }),
+                        },
+                    ],
+                },
+                line_number: 85,
+            },
+            GrammarRule {
+                name: r#"atom"#.to_string(),
+                body: GrammarElement::Alternation {
+                    choices: vec![
+                        GrammarElement::TokenReference {
+                            name: r#"NUMBER"#.to_string(),
+                        },
+                        GrammarElement::TokenReference {
+                            name: r#"STRING"#.to_string(),
+                        },
+                        GrammarElement::Sequence {
+                            elements: vec![
+                                GrammarElement::TokenReference {
+                                    name: r#"NAME"#.to_string(),
+                                },
+                                GrammarElement::Optional {
+                                    element: Box::new(GrammarElement::Sequence {
+                                        elements: vec![
+                                            GrammarElement::TokenReference {
+                                                name: r#"BLANK"#.to_string(),
+                                            },
+                                            GrammarElement::Optional {
+                                                element: Box::new(GrammarElement::TokenReference {
+                                                    name: r#"NAME"#.to_string(),
+                                                }),
+                                            },
+                                        ],
+                                    }),
+                                },
+                            ],
+                        },
+                        GrammarElement::Sequence {
+                            elements: vec![
+                                GrammarElement::TokenReference {
+                                    name: r#"BLANK"#.to_string(),
+                                },
+                                GrammarElement::Optional {
+                                    element: Box::new(GrammarElement::TokenReference {
+                                        name: r#"NAME"#.to_string(),
+                                    }),
+                                },
+                            ],
+                        },
+                        GrammarElement::RuleReference {
+                            name: r#"list"#.to_string(),
+                        },
+                        GrammarElement::RuleReference {
+                            name: r#"group"#.to_string(),
+                        },
+                    ],
+                },
+                line_number: 91,
+            },
+            GrammarRule {
+                name: r#"list"#.to_string(),
+                body: GrammarElement::Sequence {
+                    elements: vec![
+                        GrammarElement::TokenReference {
+                            name: r#"LBRACE"#.to_string(),
+                        },
+                        GrammarElement::Optional {
+                            element: Box::new(GrammarElement::RuleReference {
+                                name: r#"arglist"#.to_string(),
+                            }),
+                        },
+                        GrammarElement::TokenReference {
+                            name: r#"RBRACE"#.to_string(),
+                        },
+                    ],
+                },
+                line_number: 98,
+            },
+            GrammarRule {
+                name: r#"group"#.to_string(),
+                body: GrammarElement::Sequence {
+                    elements: vec![
+                        GrammarElement::TokenReference {
+                            name: r#"LPAREN"#.to_string(),
+                        },
+                        GrammarElement::RuleReference {
+                            name: r#"expr"#.to_string(),
+                        },
+                        GrammarElement::TokenReference {
+                            name: r#"RPAREN"#.to_string(),
+                        },
+                    ],
+                },
+                line_number: 99,
+            },
+        ],
+        version: 1,
+    }
+}

--- a/code/packages/rust/wolfram-parser/src/lib.rs
+++ b/code/packages/rust/wolfram-parser/src/lib.rs
@@ -1,0 +1,215 @@
+//! # Wolfram Parser — building a syntax tree for the Wolfram Language.
+//!
+//! Turns the token stream from [`coding_adventures_wolfram_lexer`] into a parse
+//! tree using the generic
+//! [`GrammarParser`](parser::grammar_parser::GrammarParser), driven by the
+//! embedded `wolfram.grammar` (`src/_grammar.rs`). It hand-writes no parsing
+//! logic. A sibling of `r-parser` / `macsyma-parser`. See
+//! `code/specs/MA04-wolfram-language.md`.
+//!
+//! ## What the tree captures
+//!
+//! Everything in Wolfram is `head[args]`; this parser produces the surface tree
+//! whose rule names (`assignment`, `replaceall`, `rule`, `additive`,
+//! `multiplicative`, `power`, `postfix`, `atom`, `list`, …) the W-4
+//! `wolfram-runtime` will lower into the canonical `symbolic-ir` heads
+//! (`Plus`/`Times`/`Power`/`List`/`Rule`/`ReplaceAll`/`Set`/…).
+//!
+//! ```text
+//! Wolfram source
+//!    |
+//!    v
+//! coding_adventures_wolfram_lexer::tokenize_wolfram  ->  Vec<Token>
+//!    |
+//!    v
+//! parser::GrammarParser  (driven by the embedded wolfram.grammar)
+//!    |
+//!    v
+//! GrammarASTNode  <- the tree W-4 lowers to symbolic-ir
+//! ```
+
+use coding_adventures_wolfram_lexer::{tokenize_wolfram, try_tokenize_wolfram};
+use parser::grammar_parser::{GrammarASTNode, GrammarParser};
+mod _grammar;
+
+/// Create a [`GrammarParser`] wired to the Wolfram grammar and the tokens of
+/// `source`.
+///
+/// # Panics
+///
+/// Panics if tokenization fails. Use [`try_parse_wolfram`] for a non-panicking
+/// path.
+pub fn create_wolfram_parser(source: &str) -> GrammarParser {
+    let tokens = tokenize_wolfram(source);
+    GrammarParser::new(tokens, _grammar::parser_grammar())
+}
+
+/// Parse Wolfram source text into a [`GrammarASTNode`] rooted at `program`.
+///
+/// # Panics
+///
+/// Panics on a lexical or syntax error. Use [`try_parse_wolfram`] to handle
+/// errors.
+///
+/// # Example
+///
+/// ```
+/// use coding_adventures_wolfram_parser::parse_wolfram;
+/// let ast = parse_wolfram("Sin[x] + 1\n");
+/// assert_eq!(ast.rule_name, "program");
+/// ```
+pub fn parse_wolfram(source: &str) -> GrammarASTNode {
+    create_wolfram_parser(source)
+        .parse()
+        .unwrap_or_else(|e| panic!("Wolfram parse failed: {e}"))
+}
+
+/// Parse Wolfram source text, returning a `Result` instead of panicking.
+pub fn try_parse_wolfram(source: &str) -> Result<GrammarASTNode, String> {
+    let tokens = try_tokenize_wolfram(source)?;
+    GrammarParser::new(tokens, _grammar::parser_grammar())
+        .parse()
+        .map_err(|e| e.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use parser::grammar_parser::ASTNodeOrToken;
+
+    fn contains_rule(node: &GrammarASTNode, name: &str) -> bool {
+        node.rule_name == name
+            || node.children.iter().any(|c| match c {
+                ASTNodeOrToken::Node(n) => contains_rule(n, name),
+                ASTNodeOrToken::Token(_) => false,
+            })
+    }
+
+    /// The value of the first token directly under the first node whose rule is
+    /// `rule` — used to check which operator a construct matched.
+    fn first_token_of(node: &GrammarASTNode, rule: &str) -> Option<String> {
+        fn tok(n: &GrammarASTNode) -> Option<String> {
+            n.children.iter().find_map(|c| match c {
+                ASTNodeOrToken::Token(t) => Some(t.value.clone()),
+                _ => None,
+            })
+        }
+        if node.rule_name == rule {
+            if let Some(t) = tok(node) {
+                return Some(t);
+            }
+        }
+        node.children.iter().find_map(|c| match c {
+            ASTNodeOrToken::Node(child) => first_token_of(child, rule),
+            ASTNodeOrToken::Token(_) => None,
+        })
+    }
+
+    fn parses(src: &str) -> bool {
+        try_parse_wolfram(src).is_ok()
+    }
+
+    #[test]
+    fn program_is_the_root() {
+        assert_eq!(parse_wolfram("1\n").rule_name, "program");
+    }
+
+    #[test]
+    fn square_bracket_application_parses() {
+        // `Sin[x]` is application (postfix), not a list.
+        let ast = parse_wolfram("Sin[x]\n");
+        assert!(contains_rule(&ast, "postfix"));
+    }
+
+    #[test]
+    fn nested_application_parses() {
+        assert!(parses("f[g[x]]\n"));
+        assert!(parses("f[x, y, z]\n"));
+        assert!(parses("f[]\n")); // empty arg list
+    }
+
+    #[test]
+    fn brace_list_parses() {
+        assert!(contains_rule(&parse_wolfram("{a, b, c}\n"), "list"));
+        assert!(parses("{}\n")); // empty list
+        assert!(parses("{1, {2, 3}, 4}\n")); // nested list
+    }
+
+    #[test]
+    fn arithmetic_precedence_cascade() {
+        // x + 2*y^3 exercises additive > multiplicative > power.
+        let ast = parse_wolfram("x + 2*y^3\n");
+        for rule in ["additive", "multiplicative", "power"] {
+            assert!(contains_rule(&ast, rule), "missing {rule}");
+        }
+    }
+
+    #[test]
+    fn replacement_operators_parse() {
+        assert!(contains_rule(&parse_wolfram("x /. a -> b\n"), "replaceall"));
+        assert_eq!(
+            first_token_of(&parse_wolfram("a -> b\n"), "rule").as_deref(),
+            Some("->")
+        );
+        assert!(parses("x /. a :> b\n")); // RuleDelayed
+                                          // `x /. a -> b` is ReplaceAll[x, Rule[a, b]] — rule binds tighter than /.
+        let ast = parse_wolfram("x /. a -> b\n");
+        assert!(contains_rule(&ast, "replaceall") && contains_rule(&ast, "rule"));
+    }
+
+    #[test]
+    fn assignment_set_and_setdelayed() {
+        assert_eq!(
+            first_token_of(&parse_wolfram("x = 5\n"), "assignment").as_deref(),
+            Some("=")
+        );
+        assert_eq!(
+            first_token_of(&parse_wolfram("f[x_] := x^2\n"), "assignment").as_deref(),
+            Some(":=")
+        );
+    }
+
+    #[test]
+    fn pattern_blanks_parse() {
+        assert!(parses("x_\n")); // Pattern[x, Blank[]]
+        assert!(parses("_\n")); // Blank[]
+        assert!(parses("_Integer\n")); // Blank[Integer]
+        assert!(parses("x_Integer\n")); // Pattern[x, Blank[Integer]]
+        assert!(parses("f[x_] := x\n")); // a pattern in a function definition
+    }
+
+    #[test]
+    fn comparison_logic_and_grouping() {
+        assert!(contains_rule(&parse_wolfram("a == b\n"), "comparison"));
+        assert!(contains_rule(&parse_wolfram("a && b || c\n"), "logical_or"));
+        assert!(parses("!x\n"));
+        assert!(parses("(a + b) * c\n")); // grouping
+    }
+
+    #[test]
+    fn newlines_inside_brackets_let_a_form_span_lines() {
+        // The lexer drops interior newlines; the parser sees one statement.
+        assert!(parses("f[\n  a,\n  b\n]\n"));
+        assert!(parses("{\n  1,\n  2\n}\n"));
+    }
+
+    #[test]
+    fn statement_separators_and_trailing_newline() {
+        assert!(parses("a; b; c\n"));
+        assert!(parses("x = 1;\n")); // a `;` suppresses, still parses
+        assert!(parses("1 + 1")); // trailing newline optional
+    }
+
+    #[test]
+    fn syntax_error_is_reported() {
+        assert!(try_parse_wolfram("1 +\n").is_err());
+        assert!(try_parse_wolfram("f[x\n").is_err()); // unclosed bracket
+    }
+
+    #[test]
+    fn a_small_wolfram_program_parses() {
+        assert!(parses(
+            "f[x_] := x^2\nf[3] + Sin[0]\n{1, 2, 3} /. a_ -> a + 1\n"
+        ));
+    }
+}


### PR DESCRIPTION
## What

W-3 of the Wolfram frontend (Wave 3): the **parser**. A thin wrapper over the generic `GrammarParser` (sibling of `r-parser` / `macsyma-parser`), with the committed `_grammar.rs` compiled from the W-1 `code/grammars/wolfram.grammar`. Exposes `parse_wolfram` / `try_parse_wolfram` / `create_wolfram_parser`, producing a `GrammarASTNode` rooted at `program`.

```rust
parse_wolfram("f[x_] := x^2\n")   // → program → … → assignment(":=") → postfix(f[x_]) → power(x^2)
```

The tree's rule names (`assignment`, `replaceall`, `rule`, `additive`, `multiplicative`, `power`, `postfix`, `atom`, `list`, …) are the surface forms the **W-4 `wolfram-runtime`** will lower into canonical `symbolic-ir` heads.

## Tests (13)

`f[x]` square-bracket application (`postfix`), `{a,b}` brace list, nested `f[g[x]]`, empty `f[]` / `{}`, the `additive` › `multiplicative` › `power` precedence cascade, the replacement operators `->` `/.` `:>` with **`/.` looser than `->`** (`x /. a -> b` is `ReplaceAll[x, Rule[a,b]]`), `Set`/`SetDelayed` (`=` / `:=`), the `_`/`x_`/`_h`/`x_h` pattern blanks, comparison/logic/grouping, bracket-spanning newlines, `;` separators, and syntax errors (incomplete expr, unclosed bracket). `fmt` + `clippy` clean; standard BUILD/README/CHANGELOG/caps; registered in the workspace.

## Security

`/security-review` **PASSED**: the wrapper adds no parsing logic of its own (constructs a `GrammarParser` and calls `.parse()`), no `unsafe`/indexing/`unwrap`, and `try_parse_wolfram` is panic-free end to end. The only `panic!` is the documented `parse_wolfram` variant (matching the sibling-crate convention); recursion-depth is a pre-existing property of the shared `GrammarParser` (identical for every language), not introduced here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)