### PR TITLE
feat(adj-lang): context precedence surface — context: + context_order (ADJ73 PR-B surface)

### DIFF
--- a/code/grammars/adj_lang.grammar
+++ b/code/grammars/adj_lang.grammar
@@ -27,6 +27,7 @@ statement   = prior_decl
             | relate_decl
             | rule_decl
             | functional_decl
+            | context_order_decl
             | query_decl
             | let_decl
             | symbol_decl
@@ -101,9 +102,20 @@ relate_decl      = "relate" term { annotation } ;
 # every grounded clause carries. A body literal prefixed with `not` is
 # negation-as-failure.
 # ----------------------------------------------------------------
-rule_decl        = "rule" LBRACE "head" COLON term "when" COLON body_literal { COMMA body_literal } { annotation } [ "priority" COLON IDENT ] RBRACE ;
+rule_decl        = "rule" LBRACE "head" COLON term "when" COLON body_literal { COMMA body_literal } { annotation } [ "priority" COLON IDENT ] [ "context" COLON IDENT ] RBRACE ;
 
 body_literal     = [ "not" ] term ;
+
+# ----------------------------------------------------------------
+# `context_order { higher > lower , … }` — ADJ73 PR-B: a grounded CONTEXT
+# precedence order. Each edge `a > b` asserts "a rule grounded in context `a`
+# outranks a conflicting rule in context `b`" (federal > state, ninth_circuit >
+# district_court, idsa_2024 > idsa_2004). Lowers to
+# `KnowledgeBase::add_context_outranks`; the resolver consults it BEFORE the
+# priority tier (lex superior). `context_order`/`context` are IDENT-matched
+# literals — no lexer keywords; `>` is the existing GT operator.
+# ----------------------------------------------------------------
+context_order_decl = "context_order" LBRACE IDENT GT IDENT { COMMA IDENT GT IDENT } RBRACE ;
 
 # ----------------------------------------------------------------
 # `functional <pred>(<arg>, …)` — ADJ73 defeasible precedence (PR-C): declare a

--- a/code/packages/rust/adj-lang/CHANGELOG.md
+++ b/code/packages/rust/adj-lang/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Changelog
 
+## [0.16.0] - 2026-06-16 — context precedence surface (ADJ73 PR-B)
+
+### Added
+
+- **`rule { … context: <name> }`** — ground a rule in a CONTEXT (jurisdiction / guideline
+  edition / specialty). Lowers to `logic_engine::Rule::with_context`.
+- **`context_order { higher > lower, … }`** — a top-level statement declaring grounded context
+  precedence edges; each `a > b` lowers to `KnowledgeBase::add_context_outranks`. The resolver
+  consults this BEFORE the priority tier (lex superior): a rule in a greater context defeats a
+  conflicting one in a lesser context regardless of tier.
+- Grammar: `context_order_decl` added to `statement`; `rule_decl` gains a trailing
+  `[ "context" COLON IDENT ]` (after `[ "priority" … ]`). `context_order`/`context` are
+  IDENT-matched literals; `>` is the existing `GT` operator. `_parser_grammar.rs` /
+  `_lexer_grammar.rs` regenerated.
+- AST: `Statement::Rule` gains `context: Option<String>`; new `Statement::ContextOrder { edges }`.
+  Adapter: a shared `ident_after_keyword` helper extracts both `priority:` and `context:`;
+  `adapt_context_order` pairs the `IDENT > IDENT` edges (skipping the `>` Name token).
+
+### Notes
+
+Surface for logic-engine 0.19's grounded context precedence. A test compiles
+`context_order { ninth_circuit > district_court }` + `context:`-tagged rules and verifies via
+`enumerate_governing` that the higher-context rule governs **even with a lower priority tier**
+(lex superior), and that multi-edge orders lower transitively. The grounded `context-precedence`
+*rulebook* (byte-provenanced `outranks_context` edges + recency/appeal meta-rules) is the next
+slice.
+
 ## [0.15.0] - 2026-06-16 — precedence surface syntax (ADJ73 PR-C)
 
 ### Added

--- a/code/packages/rust/adj-lang/Cargo.toml
+++ b/code/packages/rust/adj-lang/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adj-lang"
-version = "0.15.0"
+version = "0.16.0"
 edition = "2021"
 description = "Surface-syntax frontend for the adjudication framework's probabilistic-logic rulebooks. Lexes, parses, and lowers a domain-expert-readable DSL into a `logic-engine` KnowledgeBase. Dissolves ADJ46 awkwardness items A10 (rulebook syntax) and A4 (joint contributions syntactically distinct)."
 

--- a/code/packages/rust/adj-lang/src/_parser_grammar.rs
+++ b/code/packages/rust/adj-lang/src/_parser_grammar.rs
@@ -29,6 +29,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::RuleReference { name: r#"relate_decl"#.to_string() },
                 GrammarElement::RuleReference { name: r#"rule_decl"#.to_string() },
                 GrammarElement::RuleReference { name: r#"functional_decl"#.to_string() },
+                GrammarElement::RuleReference { name: r#"context_order_decl"#.to_string() },
                 GrammarElement::RuleReference { name: r#"query_decl"#.to_string() },
                 GrammarElement::RuleReference { name: r#"let_decl"#.to_string() },
                 GrammarElement::RuleReference { name: r#"symbol_decl"#.to_string() },
@@ -53,7 +54,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::RuleReference { name: r#"term"#.to_string() },
                 GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"annotation"#.to_string() }) },
             ] },
-            line_number: 49,
+            line_number: 50,
         },
         GrammarRule {
             name: r#"contributes_decl"#.to_string(),
@@ -66,7 +67,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::RuleReference { name: r#"term"#.to_string() },
                 GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"annotation"#.to_string() }) },
             ] },
-            line_number: 51,
+            line_number: 52,
         },
         GrammarRule {
             name: r#"evidence"#.to_string(),
@@ -74,7 +75,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::RuleReference { name: r#"predicate"#.to_string() },
                 GrammarElement::RuleReference { name: r#"term"#.to_string() },
             ] },
-            line_number: 61,
+            line_number: 62,
         },
         GrammarRule {
             name: r#"predicate"#.to_string(),
@@ -89,7 +90,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::TokenReference { name: r#"NUMBER"#.to_string() },
             ] },
-            line_number: 63,
+            line_number: 64,
         },
         GrammarRule {
             name: r#"interacts_decl"#.to_string(),
@@ -108,7 +109,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::RuleReference { name: r#"term"#.to_string() },
                 GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"annotation"#.to_string() }) },
             ] },
-            line_number: 65,
+            line_number: 66,
         },
         GrammarRule {
             name: r#"uncertain_decl"#.to_string(),
@@ -125,7 +126,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::RuleReference { name: r#"term"#.to_string() },
                 GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"annotation"#.to_string() }) },
             ] },
-            line_number: 67,
+            line_number: 68,
         },
         GrammarRule {
             name: r#"observe_decl"#.to_string(),
@@ -133,7 +134,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"observe"#.to_string() },
                 GrammarElement::RuleReference { name: r#"term"#.to_string() },
             ] },
-            line_number: 69,
+            line_number: 70,
         },
         GrammarRule {
             name: r#"relate_decl"#.to_string(),
@@ -142,7 +143,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::RuleReference { name: r#"term"#.to_string() },
                 GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"annotation"#.to_string() }) },
             ] },
-            line_number: 82,
+            line_number: 83,
         },
         GrammarRule {
             name: r#"rule_decl"#.to_string(),
@@ -165,9 +166,14 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::TokenReference { name: r#"COLON"#.to_string() },
                         GrammarElement::TokenReference { name: r#"IDENT"#.to_string() },
                     ] }) },
+                GrammarElement::Optional { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::Literal { value: r#"context"#.to_string() },
+                        GrammarElement::TokenReference { name: r#"COLON"#.to_string() },
+                        GrammarElement::TokenReference { name: r#"IDENT"#.to_string() },
+                    ] }) },
                 GrammarElement::TokenReference { name: r#"RBRACE"#.to_string() },
             ] },
-            line_number: 104,
+            line_number: 105,
         },
         GrammarRule {
             name: r#"body_literal"#.to_string(),
@@ -175,7 +181,25 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Optional { element: Box::new(GrammarElement::Literal { value: r#"not"#.to_string() }) },
                 GrammarElement::RuleReference { name: r#"term"#.to_string() },
             ] },
-            line_number: 106,
+            line_number: 107,
+        },
+        GrammarRule {
+            name: r#"context_order_decl"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Literal { value: r#"context_order"#.to_string() },
+                GrammarElement::TokenReference { name: r#"LBRACE"#.to_string() },
+                GrammarElement::TokenReference { name: r#"IDENT"#.to_string() },
+                GrammarElement::TokenReference { name: r#"GT"#.to_string() },
+                GrammarElement::TokenReference { name: r#"IDENT"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::TokenReference { name: r#"COMMA"#.to_string() },
+                        GrammarElement::TokenReference { name: r#"IDENT"#.to_string() },
+                        GrammarElement::TokenReference { name: r#"GT"#.to_string() },
+                        GrammarElement::TokenReference { name: r#"IDENT"#.to_string() },
+                    ] }) },
+                GrammarElement::TokenReference { name: r#"RBRACE"#.to_string() },
+            ] },
+            line_number: 118,
         },
         GrammarRule {
             name: r#"functional_decl"#.to_string(),
@@ -183,7 +207,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"functional"#.to_string() },
                 GrammarElement::RuleReference { name: r#"term"#.to_string() },
             ] },
-            line_number: 117,
+            line_number: 129,
         },
         GrammarRule {
             name: r#"query_decl"#.to_string(),
@@ -191,7 +215,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::TokenReference { name: r#"QUESTION"#.to_string() },
                 GrammarElement::RuleReference { name: r#"term"#.to_string() },
             ] },
-            line_number: 119,
+            line_number: 131,
         },
         GrammarRule {
             name: r#"let_decl"#.to_string(),
@@ -201,7 +225,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::TokenReference { name: r#"EQUALS"#.to_string() },
                 GrammarElement::RuleReference { name: r#"expr"#.to_string() },
             ] },
-            line_number: 133,
+            line_number: 145,
         },
         GrammarRule {
             name: r#"expr"#.to_string(),
@@ -215,7 +239,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"term_expr"#.to_string() },
                     ] }) },
             ] },
-            line_number: 135,
+            line_number: 147,
         },
         GrammarRule {
             name: r#"term_expr"#.to_string(),
@@ -229,7 +253,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"factor"#.to_string() },
                     ] }) },
             ] },
-            line_number: 137,
+            line_number: 149,
         },
         GrammarRule {
             name: r#"factor"#.to_string(),
@@ -243,7 +267,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     GrammarElement::TokenReference { name: r#"RPAREN"#.to_string() },
                 ] },
             ] },
-            line_number: 139,
+            line_number: 151,
         },
         GrammarRule {
             name: r#"agg"#.to_string(),
@@ -259,7 +283,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::TokenReference { name: r#"IDENT"#.to_string() },
                 GrammarElement::TokenReference { name: r#"RPAREN"#.to_string() },
             ] },
-            line_number: 141,
+            line_number: 153,
         },
         GrammarRule {
             name: r#"symbol_decl"#.to_string(),
@@ -269,7 +293,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::TokenReference { name: r#"COLON"#.to_string() },
                 GrammarElement::RuleReference { name: r#"term"#.to_string() },
             ] },
-            line_number: 151,
+            line_number: 163,
         },
         GrammarRule {
             name: r#"constrain_decl"#.to_string(),
@@ -279,7 +303,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::RuleReference { name: r#"relop"#.to_string() },
                 GrammarElement::RuleReference { name: r#"expr"#.to_string() },
             ] },
-            line_number: 153,
+            line_number: 165,
         },
         GrammarRule {
             name: r#"relop"#.to_string(),
@@ -292,7 +316,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::TokenReference { name: r#"EQUALS"#.to_string() },
                 GrammarElement::TokenReference { name: r#"NE"#.to_string() },
             ] },
-            line_number: 155,
+            line_number: 167,
         },
         GrammarRule {
             name: r#"solve_decl"#.to_string(),
@@ -307,12 +331,12 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::TokenReference { name: r#"RBRACE"#.to_string() },
             ] },
-            line_number: 157,
+            line_number: 169,
         },
         GrammarRule {
             name: r#"check_decl"#.to_string(),
             body: GrammarElement::Literal { value: r#"check"#.to_string() },
-            line_number: 159,
+            line_number: 171,
         },
         GrammarRule {
             name: r#"optimize_decl"#.to_string(),
@@ -323,7 +347,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::RuleReference { name: r#"expr"#.to_string() },
             ] },
-            line_number: 166,
+            line_number: 178,
         },
         GrammarRule {
             name: r#"dictionary_decl"#.to_string(),
@@ -334,7 +358,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"define_decl"#.to_string() }) },
                 GrammarElement::TokenReference { name: r#"RBRACE"#.to_string() },
             ] },
-            line_number: 178,
+            line_number: 190,
         },
         GrammarRule {
             name: r#"define_decl"#.to_string(),
@@ -345,7 +369,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::RuleReference { name: r#"define_kind"#.to_string() },
                 GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"surface_clause"#.to_string() }) },
             ] },
-            line_number: 180,
+            line_number: 192,
         },
         GrammarRule {
             name: r#"define_kind"#.to_string(),
@@ -373,7 +397,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     GrammarElement::TokenReference { name: r#"IDENT"#.to_string() },
                 ] },
             ] },
-            line_number: 182,
+            line_number: 194,
         },
         GrammarRule {
             name: r#"surface_clause"#.to_string(),
@@ -385,7 +409,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
                     ] }) },
             ] },
-            line_number: 188,
+            line_number: 200,
         },
         GrammarRule {
             name: r#"rulebook_decl"#.to_string(),
@@ -396,7 +420,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"statement"#.to_string() }) },
                 GrammarElement::TokenReference { name: r#"RBRACE"#.to_string() },
             ] },
-            line_number: 205,
+            line_number: 217,
         },
         GrammarRule {
             name: r#"use_decl"#.to_string(),
@@ -404,7 +428,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"use"#.to_string() },
                 GrammarElement::TokenReference { name: r#"IDENT"#.to_string() },
             ] },
-            line_number: 207,
+            line_number: 219,
         },
         GrammarRule {
             name: r#"import_decl"#.to_string(),
@@ -412,7 +436,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"import"#.to_string() },
                 GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
             ] },
-            line_number: 223,
+            line_number: 235,
         },
         GrammarRule {
             name: r#"annotation"#.to_string(),
@@ -421,7 +445,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::RuleReference { name: r#"locator_annotation"#.to_string() },
                 GrammarElement::RuleReference { name: r#"trust_annotation"#.to_string() },
             ] },
-            line_number: 231,
+            line_number: 243,
         },
         GrammarRule {
             name: r#"source_annotation"#.to_string(),
@@ -429,7 +453,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"source"#.to_string() },
                 GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
             ] },
-            line_number: 236,
+            line_number: 248,
         },
         GrammarRule {
             name: r#"locator_annotation"#.to_string(),
@@ -437,7 +461,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"locator"#.to_string() },
                 GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
             ] },
-            line_number: 237,
+            line_number: 249,
         },
         GrammarRule {
             name: r#"trust_annotation"#.to_string(),
@@ -445,7 +469,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"trust"#.to_string() },
                 GrammarElement::RuleReference { name: r#"trust_tier"#.to_string() },
             ] },
-            line_number: 238,
+            line_number: 250,
         },
         GrammarRule {
             name: r#"trust_tier"#.to_string(),
@@ -456,7 +480,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"inferred"#.to_string() },
                 GrammarElement::Literal { value: r#"unattributed"#.to_string() },
             ] },
-            line_number: 240,
+            line_number: 252,
         },
         GrammarRule {
             name: r#"term"#.to_string(),
@@ -480,7 +504,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::TokenReference { name: r#"RPAREN"#.to_string() },
                     ] }) },
             ] },
-            line_number: 262,
+            line_number: 274,
         },
     ],
         version: 1,

--- a/code/packages/rust/adj-lang/src/adapter.rs
+++ b/code/packages/rust/adj-lang/src/adapter.rs
@@ -111,6 +111,7 @@ fn adapt_statement(node: &GrammarASTNode) -> Result<Statement, AdapterError> {
         "relate_decl" => adapt_relate(child),
         "rule_decl" => adapt_rule(child),
         "functional_decl" => adapt_functional(child),
+        "context_order_decl" => adapt_context_order(child),
         "query_decl" => adapt_query(child),
         "let_decl" => adapt_let(child),
         "symbol_decl" => adapt_symbol(child),
@@ -325,26 +326,66 @@ fn adapt_rule(node: &GrammarASTNode) -> Result<Statement, AdapterError> {
         });
     }
     let annotations = collect_annotations(node)?;
-    // ADJ73 PR-C: optional trailing `priority: <tier>`. The tier is the first Name token after
-    // the `priority` literal token (the COLON between them is a separate token).
-    let mut priority = None;
-    let mut seen_priority_kw = false;
-    for child in &node.children {
-        if let ASTNodeOrToken::Token(t) = child {
-            if t.type_ == TokenType::Name && t.value == "priority" {
-                seen_priority_kw = true;
-            } else if seen_priority_kw && t.type_ == TokenType::Name {
-                priority = Some(t.value.clone());
-                break;
-            }
-        }
-    }
+    // ADJ73: optional trailing `priority: <tier>` (PR-C) and `context: <name>` (PR-B). Each
+    // value is the first Name token AFTER its keyword literal (the COLON is a separate token).
+    // Only structural Name tokens appear at the rule_decl level (head/when/priority/context +
+    // the two values); body/head TERMS are Nodes, so they cannot be mistaken for a value.
+    let priority = ident_after_keyword(node, "priority");
+    let context = ident_after_keyword(node, "context");
     Ok(Statement::Rule {
         head,
         body,
         annotations,
         priority,
+        context,
     })
+}
+
+/// The IDENT token that immediately follows the keyword literal `keyword` among a node's direct
+/// token children (e.g. the tier after `priority`, the context after `context`). `None` if the
+/// keyword is absent.
+fn ident_after_keyword(node: &GrammarASTNode, keyword: &str) -> Option<String> {
+    let mut seen = false;
+    for child in &node.children {
+        if let ASTNodeOrToken::Token(t) = child {
+            if t.type_ == TokenType::Name && t.value == keyword {
+                seen = true;
+            } else if seen && t.type_ == TokenType::Name {
+                return Some(t.value.clone());
+            }
+        }
+    }
+    None
+}
+
+fn adapt_context_order(node: &GrammarASTNode) -> Result<Statement, AdapterError> {
+    // context_order_decl = "context_order" "{" IDENT ">" IDENT { "," IDENT ">" IDENT } "}"
+    // The IDENT tokens come in (higher, lower) pairs. Collect the Name tokens in order and pair
+    // them up, skipping the `context_order` keyword and the `>` operator (the lexer surfaces GT
+    // as a Name token whose value is ">"). Commas/braces are non-Name tokens, already excluded.
+    let idents: Vec<String> = node
+        .children
+        .iter()
+        .filter_map(|c| match c {
+            ASTNodeOrToken::Token(t)
+                if t.type_ == TokenType::Name && t.value != "context_order" && t.value != ">" =>
+            {
+                Some(t.value.clone())
+            }
+            _ => None,
+        })
+        .collect();
+    if idents.is_empty() || idents.len() % 2 != 0 {
+        return Err(AdapterError::MissingChild {
+            rule: "context_order_decl".into(),
+            position: "higher > lower context pairs",
+        });
+    }
+    let edges = idents
+        .chunks_exact(2)
+        .map(|p| (p[0].clone(), p[1].clone()))
+        .collect();
+    Ok(Statement::ContextOrder { edges })
 }
 
 fn adapt_functional(node: &GrammarASTNode) -> Result<Statement, AdapterError> {

--- a/code/packages/rust/adj-lang/src/ast.rs
+++ b/code/packages/rust/adj-lang/src/ast.rs
@@ -154,6 +154,11 @@ pub enum Statement {
         /// `Priority::Default`. Among *conflicting* derivations of a functional predicate, a
         /// higher tier defeats a lower one (`logic_engine::govern::enumerate_governing`).
         priority: Option<String>,
+        /// ADJ73 PR-B: the optional `context: <name>` annotation — the CONTEXT this rule is
+        /// grounded in (jurisdiction / guideline edition / specialty). `None` = context-free.
+        /// Lowers to `logic_engine::Rule::with_context`; a rule in a context that outranks
+        /// another's (per [`Statement::ContextOrder`]) defeats it before the tier is consulted.
+        context: Option<String>,
     },
     /// `functional <pred>(<arg>, …)` — declare a predicate FUNCTIONAL on its last argument
     /// (ADJ73 PR-C): at most one value may hold per key (the preceding args). The argument
@@ -161,6 +166,10 @@ pub enum Statement {
     /// `KnowledgeBase::declare_functional(functor, arity)`. Two derivations sharing the key but
     /// differing on the last arg then *conflict*, and precedence picks the governing one.
     Functional { functor: String, arity: usize },
+    /// `context_order { higher > lower, … }` — ADJ73 PR-B: grounded CONTEXT precedence edges.
+    /// Each `(higher, lower)` lowers to `KnowledgeBase::add_context_outranks`, so a rule in
+    /// `higher` defeats a conflicting one in `lower` (lex superior).
+    ContextOrder { edges: Vec<(String, String)> },
     /// `? <conclusion>` — query the engine. With a ground hypothesis term this
     /// returns the posterior; with a relational goal containing a `$variable`
     /// (`? deficient_in(tay_sachs, $E)`) it returns the binding(s) — fact recall

--- a/code/packages/rust/adj-lang/src/lower.rs
+++ b/code/packages/rust/adj-lang/src/lower.rs
@@ -269,11 +269,19 @@ pub fn lower(program: &Program) -> Result<LoweredProgram, LowerError> {
                 // conflicting derivations are resolved by precedence (enumerate_governing).
                 kb.declare_functional(functor, *arity);
             }
+            Statement::ContextOrder { edges } => {
+                // ADJ73 PR-B: each `a > b` edge asserts that context `a` outranks context `b`
+                // (lex superior) — consulted before the priority tier in resolution.
+                for (higher, lower) in edges {
+                    kb.add_context_outranks(higher.clone(), lower.clone());
+                }
+            }
             Statement::Rule {
                 head,
                 body,
                 annotations,
                 priority,
+                context,
             } => {
                 // A derivation rule → `logic_engine::Rule { head, body }`. Head and body
                 // share ONE variable scope so a `$Var` in the head unifies with the same
@@ -304,11 +312,14 @@ pub fn lower(program: &Program) -> Result<LoweredProgram, LowerError> {
                         return Err(LowerError::UnknownPriorityTier { tier: other.into() })
                     }
                 };
-                kb.add_rule(
-                    Rule::certain(head_term, body_lits)
-                        .with_provenance(prov)
-                        .with_priority(tier),
-                );
+                // ADJ73 PR-B: the optional `context: <name>` grounds the rule in a context.
+                let mut rule = Rule::certain(head_term, body_lits)
+                    .with_provenance(prov)
+                    .with_priority(tier);
+                if let Some(ctx) = context {
+                    rule = rule.with_context(ctx.clone());
+                }
+                kb.add_rule(rule);
             }
             Statement::Query { conclusion } => {
                 // Lower with a per-query variable scope so repeated `$Var`s in one
@@ -1738,5 +1749,43 @@ rule { head: note(b) when: gate(t) priority: default }
             format!("{err:?}").contains("UnknownPriorityTier"),
             "expected UnknownPriorityTier, got {err:?}"
         );
+    }
+
+    // ---- ADJ73 PR-B: context precedence surface (`context:` + `context_order`) ----
+
+    /// `context_order { higher > lower }` + `context:` on rules → the higher-context rule
+    /// governs the lower-context one, and context precedence BEATS the priority tier (lex
+    /// superior): the broad reading governs despite carrying the lower `default` tier.
+    #[test]
+    fn context_order_and_context_resolve_lex_superior() {
+        use logic_engine::enumerate_governing;
+        let prog = "\
+functional means(term, reading)
+context_order { ninth_circuit > district_court }
+relate gate(t)
+rule { head: means(waters, broad) when: gate(t) priority: default context: ninth_circuit }
+rule { head: means(waters, narrow) when: gate(t) priority: authoritative context: district_court }
+? means(waters, $R)";
+        let lowered = compile(prog).unwrap();
+        let res = enumerate_governing(&lowered.queries[0], &lowered.kb);
+        let gov: Vec<&CoreTerm> = res.governing().map(|a| &a.term).collect();
+        assert_eq!(gov.len(), 1, "exactly one governs: {res:?}");
+        assert!(matches!(gov[0], CoreTerm::Compound { args, .. }
+            if args == &[CoreTerm::Atom("waters".into()), CoreTerm::Atom("broad".into())]));
+        assert!(!res.has_conflict());
+    }
+
+    /// A multi-edge `context_order` lowers every edge (transitive: federal > circuit > state).
+    #[test]
+    fn context_order_lowers_multiple_edges_transitively() {
+        let prog = "\
+context_order { federal > circuit, circuit > state }
+relate x(t)
+rule { head: r(a) when: x(t) }";
+        let lowered = compile(prog).unwrap();
+        // federal transitively outranks state via circuit.
+        assert!(lowered.kb.context_outranks("federal", "state"));
+        assert!(lowered.kb.context_outranks("federal", "circuit"));
+        assert!(!lowered.kb.context_outranks("state", "federal"));
     }
 }

--- a/code/packages/rust/adjudication-connector/src/lib.rs
+++ b/code/packages/rust/adjudication-connector/src/lib.rs
@@ -547,6 +547,7 @@ fn lower_rule_tracked(
                 probability: Probability::Value(p),
                 provenance: logic_engine::Provenance::unattributed(),
                 priority: logic_engine::Priority::Default,
+                context: None,
             })));
         }
         "constraint" => {
@@ -739,6 +740,7 @@ fn lower_rule(
                 probability: Probability::Value(p),
                 provenance: logic_engine::Provenance::unattributed(),
                 priority: logic_engine::Priority::Default,
+                context: None,
             });
         }
         "constraint" => {

--- a/code/packages/rust/logic-engine/CHANGELOG.md
+++ b/code/packages/rust/logic-engine/CHANGELOG.md
@@ -2,6 +2,35 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.19.0] - 2026-06-16 — grounded context precedence (lex superior) (ADJ73 PR-B engine core)
+
+### Added
+
+- **`Rule::context: Option<String>`** (builder `with_context`) — the context a rule is grounded
+  in (jurisdiction / guideline edition / specialty). `None` = context-free (today's behavior).
+- **`KnowledgeBase::add_context_outranks(higher, lower)`** — assert a grounded precedence edge
+  (federal > state, ninth_circuit > district_court, idsa_2024 > idsa_2004, specialist > general).
+- **`KnowledgeBase::context_outranks(a, b)`** — transitive reach over the edges (cycle-safe DFS);
+  **`context_order_has_cycle()`** — detect a cyclic order (the surface loader should reject).
+- **`govern::GovernedAnswer::context`** + a `defeats(a, b)` resolution: context precedence is
+  PRIMARY (lex superior — a higher-context answer defeats a lower-context one regardless of
+  tier); the [`Standing`] tier breaks ties the context order leaves open. An answer governs iff
+  no conflicting answer defeats it; multiple undefeated → `ConflictPeer`; a cyclic order crowns
+  nothing (safe degradation, never a wrong pick).
+
+### Unchanged (back-compat)
+
+- With NO `context_order` declared, `defeats` reduces to "higher tier wins" — resolution is
+  byte-identical to 0.18 (verified: the existing precedence + integration tests pass unchanged).
+  The two `adjudication-connector` `Rule{}` sites set `context: None`.
+
+### Scope
+
+PR-B engine core. The grounded `context-precedence` **rulebook** (each `outranks_context` edge
+citing its charter — the Supremacy Clause, etc.) + adj-lang **surface** (`context:` on a rule,
+`context_order { … }`) are the next slices (ADJ73 §7). Cycle *rejection* at load is the loader's
+job; the resolver itself stays safe regardless.
+
 ## [0.18.0] - 2026-06-16 — precedence priority is a named ENUM, not an integer (ADJ73 PR-A)
 
 ### Changed (breaking — nothing released; per user decision 1)

--- a/code/packages/rust/logic-engine/Cargo.toml
+++ b/code/packages/rust/logic-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "logic-engine"
-version = "0.18.0"
+version = "0.19.0"
 edition = "2021"
 description = "Probability-aware facts, rules, KB, SLD find-first/enumerate + WMC posterior + LP19e likelihood-ratio Bayesian aggregation."
 

--- a/code/packages/rust/logic-engine/README.md
+++ b/code/packages/rust/logic-engine/README.md
@@ -89,10 +89,27 @@ let res = enumerate_governing(&/* timing($D) */, &kb);
 Priority is a **named enum tier** (`Default < Specific < Authoritative < Mandatory`), not a raw
 integer; a ground fact (`Standing::Asserted`) outranks every rule tier. A predicate that is
 **not** declared functional never conflicts, so every answer governs and `enumerate_all`
-semantics are unchanged — precedence is opt-in per predicate. The richer, byte-provenanced
-mechanism — a grounded `context-precedence` rulebook (lex-superior / recency / appeal-status,
-for jurisdiction/specialist precedence) — and the adj-lang surface syntax are staged in
-`code/specs/ADJ73-defeasible-rule-precedence.md` (§2.3, §7).
+semantics are unchanged — precedence is opt-in per predicate.
+
+**Grounded context precedence (v0.19, lex superior).** A rule can be grounded in a *context*
+(`Rule::with_context("ninth_circuit")`), and a partial order over contexts
+(`kb.add_context_outranks("ninth_circuit", "district_court")`) makes the rule in the **greater**
+context defeat a conflicting one in a lesser context — *before* the tier is consulted (the tier
+breaks ties the context order leaves open):
+
+```rust
+kb.declare_functional("means", 2);
+kb.add_context_outranks("ninth_circuit", "district_court");  // grounded precedence edge
+kb.add_rule(Rule::certain(/* means(waters, broad) */).with_context("ninth_circuit"));
+kb.add_rule(Rule::certain(/* means(waters, narrow) */).with_context("district_court"));
+// → means(waters, broad) governs; the district reading is Defeated { by: … }.
+```
+
+`context_outranks` is cycle-safe; a cyclic order (`context_order_has_cycle`) crowns nothing
+rather than picking wrong. With no context order declared, resolution is pure-tier (back-compat).
+The grounded `context-precedence` *rulebook* (each edge citing its charter — the Supremacy
+Clause, etc.) + the adj-lang surface (`context:` / `context_order { … }`) are the next slices
+(`code/specs/ADJ73-defeasible-rule-precedence.md` §2.3, §7).
 
 ## Why Probability From Day One
 

--- a/code/packages/rust/logic-engine/src/govern.rs
+++ b/code/packages/rust/logic-engine/src/govern.rs
@@ -67,6 +67,11 @@ pub struct GovernedAnswer {
     /// The highest [`Standing`] over the proofs deriving this answer ([`Standing::Asserted`]
     /// if any derivation rests on a ground fact, else the max rule [`Priority`] tier).
     pub priority: Standing,
+    /// ADJ73 PR-B: the CONTEXT this answer is grounded in (the context of its highest-standing
+    /// deriving rule) — `None` for a context-free derivation. When two conflicting answers
+    /// carry contexts ordered by [`KnowledgeBase::add_context_outranks`], the one in the
+    /// greater context defeats the other *before* the [`Standing`] tier is consulted.
+    pub context: Option<String>,
     /// Indices into [`GovernedResult::dag`]`.proofs` that derive this answer.
     pub proof_indices: Vec<usize>,
     /// Whether this answer governs, was defeated, or is an unresolved conflict peer.
@@ -143,6 +148,34 @@ fn proof_priority(dag: &ProofDAG, proof_index: usize, kb: &KnowledgeBase) -> Sta
     }
 }
 
+/// ADJ73 PR-B: the CONTEXT a single proof confers — the `context` of the rule that derived the
+/// query head (the proof's first step). Fact-derived heads have no context.
+fn proof_context(dag: &ProofDAG, proof_index: usize, kb: &KnowledgeBase) -> Option<String> {
+    match dag.proofs[proof_index].steps.first().map(|s| &s.origin) {
+        Some(DerivationOrigin::FromRule(id)) => {
+            kb.find_rule_by_id(*id).and_then(|r| r.context.clone())
+        }
+        _ => None,
+    }
+}
+
+/// ADJ73 PR-B: does answer `a` DEFEAT answer `b` in a conflict group? Context precedence is
+/// primary (lex superior): if `a`'s context outranks `b`'s, `a` defeats `b` regardless of tier;
+/// if `b`'s outranks `a`'s, it does not. When the contexts are equal / incomparable / absent,
+/// the [`Standing`] tier decides. This generalizes the pure-tier rule (with no contexts it
+/// reduces to "higher tier defeats lower"), so a rulebook with no `context_order` is unchanged.
+fn defeats(a: &GovernedAnswer, b: &GovernedAnswer, kb: &KnowledgeBase) -> bool {
+    if let (Some(ca), Some(cb)) = (&a.context, &b.context) {
+        if kb.context_outranks(ca, cb) {
+            return true;
+        }
+        if kb.context_outranks(cb, ca) {
+            return false;
+        }
+    }
+    a.priority > b.priority
+}
+
 /// Enumerate all proofs of `query`, then resolve conflicting answers by defeasible precedence
 /// (ADJ73). Returns every distinct answer tagged [`GovernStatus`]. For a query over predicates
 /// none of which are declared functional, every answer is [`GovernStatus::Governing`] and the
@@ -156,23 +189,40 @@ pub fn enumerate_governing(query: &Term, kb: &KnowledgeBase) -> GovernedResult {
     for (i, proof) in dag.proofs.iter().enumerate() {
         let term = resolve_deep(query, &proof.bindings);
         let pri = proof_priority(&dag, i, kb);
+        let ctx = proof_context(&dag, i, kb);
         if let Some(a) = answers.iter_mut().find(|a| a.term == term) {
             a.proof_indices.push(i);
-            a.priority = a.priority.max(pri);
+            // Track the standing AND the context of the highest-standing derivation, so a
+            // context-precedence comparison uses the context of the rule that gave the answer
+            // its strongest footing.
+            if pri > a.priority {
+                a.priority = pri;
+                a.context = ctx;
+            }
         } else {
             answers.push(GovernedAnswer {
                 term,
                 priority: pri,
+                context: ctx,
                 proof_indices: vec![i],
                 status: GovernStatus::Governing, // provisional; resolved below
             });
         }
     }
 
-    // 2. Resolve each functional conflict group. We compute verdicts first (immutable borrow),
-    //    then apply them, to keep the borrow checker happy and the logic readable.
+    // 2. Resolve each functional conflict group via the `defeats` relation (context precedence
+    //    primary, tier secondary). An answer GOVERNS iff no other answer in its group defeats
+    //    it; a sole undefeated answer governs, multiple undefeated answers are conflict peers
+    //    (a genuine split), and a defeated answer cites a defeating witness. We compute verdicts
+    //    first (immutable borrow), then apply them.
     let keys: Vec<Option<(String, Vec<Term>)>> =
         answers.iter().map(|a| conflict_key(&a.term, kb)).collect();
+
+    let undefeated = |idx: usize, group: &[usize]| -> bool {
+        !group
+            .iter()
+            .any(|&j| j != idx && defeats(&answers[j], &answers[idx], kb))
+    };
 
     let mut verdicts: Vec<GovernStatus> = vec![GovernStatus::Governing; answers.len()];
     for (i, key_i) in keys.iter().enumerate() {
@@ -187,22 +237,23 @@ pub fn enumerate_governing(query: &Term, kb: &KnowledgeBase) -> GovernedResult {
         if group.len() < 2 {
             continue; // singleton → no contest
         }
-        let max_pri = group.iter().map(|&j| answers[j].priority).max().unwrap();
-        let winners: Vec<usize> = group
-            .iter()
-            .copied()
-            .filter(|&j| answers[j].priority == max_pri)
-            .collect();
-        verdicts[i] = if answers[i].priority < max_pri {
-            // Defeated — cite a governing winner. With a unique winner that is THE governor;
-            // with a tie, any peer is a valid "defeated by" witness.
-            GovernStatus::Defeated {
-                by: answers[winners[0]].term.clone(),
-            }
-        } else if winners.len() == 1 {
-            GovernStatus::Governing
+        verdicts[i] = if !undefeated(i, &group) {
+            // Defeated — cite a defeating witness (one of the answers that defeats i).
+            let by = group
+                .iter()
+                .find(|&&j| j != i && defeats(&answers[j], &answers[i], kb))
+                .map(|&j| answers[j].term.clone())
+                .unwrap();
+            GovernStatus::Defeated { by }
         } else {
-            GovernStatus::ConflictPeer // tied at the top with another answer
+            // i is undefeated. The unique undefeated answer governs; if several are undefeated
+            // (incomparable at the top — a true split of authority) they are conflict peers.
+            let undefeated_count = group.iter().filter(|&&j| undefeated(j, &group)).count();
+            if undefeated_count == 1 {
+                GovernStatus::Governing
+            } else {
+                GovernStatus::ConflictPeer
+            }
         };
     }
     for (a, v) in answers.iter_mut().zip(verdicts) {
@@ -358,6 +409,118 @@ mod tests {
                 comp("means", vec![atom("waters"), atom("broad")]),
             ]
         );
+        assert!(!res.has_conflict());
+    }
+
+    // ---- ADJ73 PR-B: grounded context precedence (lex superior) ----
+
+    /// A rule grounded in a higher context governs a conflicting one in a lower context — the
+    /// north-star case. ninth_circuit > district_court, so the broad reading governs.
+    #[test]
+    fn higher_context_governs_the_lower_context() {
+        let mut kb = KnowledgeBase::new();
+        kb.declare_functional("means", 2);
+        kb.add_context_outranks("ninth_circuit", "district_court");
+        kb.add_rule(
+            Rule::certain(comp("means", vec![atom("waters"), atom("broad")]), vec![])
+                .with_context("ninth_circuit"),
+        );
+        kb.add_rule(
+            Rule::certain(comp("means", vec![atom("waters"), atom("narrow")]), vec![])
+                .with_context("district_court"),
+        );
+        let res = enumerate_governing(&comp("means", vec![atom("waters"), var("R")]), &kb);
+        let gov: Vec<&Term> = res.governing().map(|a| &a.term).collect();
+        assert_eq!(
+            gov,
+            vec![&comp("means", vec![atom("waters"), atom("broad")])]
+        );
+        assert!(!res.has_conflict());
+    }
+
+    /// Context precedence is PRIMARY: a higher-context rule with a LOWER tier still defeats a
+    /// lower-context rule carrying a higher tier (lex superior beats the explicit tier).
+    #[test]
+    fn context_precedence_outranks_the_tier() {
+        let mut kb = KnowledgeBase::new();
+        kb.declare_functional("rule_on", 1);
+        kb.add_context_outranks("federal", "state");
+        // federal rule at the LOWEST tier...
+        kb.add_rule(
+            Rule::certain(comp("rule_on", vec![atom("permitted")]), vec![]).with_context("federal"),
+        );
+        // ...vs a state rule at the HIGHEST tier — federal still governs.
+        kb.add_rule(
+            Rule::certain(comp("rule_on", vec![atom("forbidden")]), vec![])
+                .with_context("state")
+                .with_priority(Priority::Mandatory),
+        );
+        let res = enumerate_governing(&comp("rule_on", vec![var("X")]), &kb);
+        let gov: Vec<&Term> = res.governing().map(|a| &a.term).collect();
+        assert_eq!(gov, vec![&comp("rule_on", vec![atom("permitted")])]);
+    }
+
+    /// Incomparable contexts (no order between them) fall back to the priority tier.
+    #[test]
+    fn incomparable_contexts_fall_back_to_tier() {
+        let mut kb = KnowledgeBase::new();
+        kb.declare_functional("rule_on", 1);
+        // two unrelated contexts — no edge between them.
+        kb.add_rule(
+            Rule::certain(comp("rule_on", vec![atom("a")]), vec![])
+                .with_context("oregon")
+                .with_priority(Priority::Authoritative),
+        );
+        kb.add_rule(
+            Rule::certain(comp("rule_on", vec![atom("b")]), vec![])
+                .with_context("nevada")
+                .with_priority(Priority::Specific),
+        );
+        let res = enumerate_governing(&comp("rule_on", vec![var("X")]), &kb);
+        let gov: Vec<&Term> = res.governing().map(|a| &a.term).collect();
+        assert_eq!(gov, vec![&comp("rule_on", vec![atom("a")])]); // higher tier wins the tie
+    }
+
+    /// A cyclic context order (a > b, b > a) is detectable and never silently picks a winner.
+    #[test]
+    fn cyclic_context_order_is_detected_and_governs_nothing() {
+        let mut kb = KnowledgeBase::new();
+        kb.declare_functional("means", 2);
+        kb.add_context_outranks("a", "b");
+        kb.add_context_outranks("b", "a");
+        assert!(kb.context_order_has_cycle());
+        assert!(kb.context_outranks("a", "b") && kb.context_outranks("b", "a"));
+        kb.add_rule(
+            Rule::certain(comp("means", vec![atom("t"), atom("x")]), vec![]).with_context("a"),
+        );
+        kb.add_rule(
+            Rule::certain(comp("means", vec![atom("t"), atom("y")]), vec![]).with_context("b"),
+        );
+        let res = enumerate_governing(&comp("means", vec![atom("t"), var("R")]), &kb);
+        assert_eq!(
+            res.governing().count(),
+            0,
+            "a cycle must not crown a winner"
+        );
+    }
+
+    /// Back-compat: with NO context order declared, context-free rules resolve purely by tier
+    /// exactly as before PR-B.
+    #[test]
+    fn no_context_order_is_pure_tier_resolution() {
+        let mut kb = KnowledgeBase::new();
+        kb.declare_functional("timing", 1);
+        kb.add_rule(
+            Rule::certain(comp("timing", vec![atom("await")]), vec![])
+                .with_priority(Priority::Specific),
+        );
+        kb.add_rule(Rule::certain(
+            comp("timing", vec![atom("treat_now")]),
+            vec![],
+        ));
+        let res = enumerate_governing(&comp("timing", vec![var("D")]), &kb);
+        let gov: Vec<&Term> = res.governing().map(|a| &a.term).collect();
+        assert_eq!(gov, vec![&comp("timing", vec![atom("await")])]);
         assert!(!res.has_conflict());
     }
 }

--- a/code/packages/rust/logic-engine/src/lib.rs
+++ b/code/packages/rust/logic-engine/src/lib.rs
@@ -247,6 +247,15 @@ pub struct Rule {
     /// exception ladders. Richer, byte-provenanced precedence (lex-superior / recency /
     /// appeal-status over a grounded `context-precedence` rulebook) is ADJ73 PR-B.
     pub priority: Priority,
+    /// ADJ73 PR-B (grounded context precedence): the CONTEXT this rule is grounded in — a
+    /// jurisdiction (`ninth_circuit`), guideline edition (`idsa_2024`), specialty
+    /// (`specialist`), etc. `None` for a context-free rule (today's behavior). When two
+    /// conflicting rules carry contexts ordered by [`KnowledgeBase::add_context_outranks`]
+    /// (e.g. `ninth_circuit` outranks `district_court`), the rule in the GREATER context
+    /// defeats the other — the McCarthy lex-superior relation — *before* the priority tier is
+    /// consulted (the tier breaks ties the context order leaves open). Only
+    /// [`crate::govern::enumerate_governing`] reads it.
+    pub context: Option<String>,
 }
 
 /// ADJ73 defeasible-precedence TIER (decision 1: named enum, not raw integers). Totally
@@ -280,6 +289,7 @@ impl Rule {
             probability: Probability::Certain,
             provenance: Provenance::unattributed(),
             priority: Priority::Default,
+            context: None,
         }
     }
 
@@ -294,6 +304,7 @@ impl Rule {
             probability: Probability::Value(p),
             provenance: Provenance::unattributed(),
             priority: Priority::Default,
+            context: None,
         }
     }
 
@@ -308,6 +319,14 @@ impl Rule {
     /// among conflicting derivations). Builder-style, mirrors [`Self::with_provenance`].
     pub fn with_priority(mut self, priority: Priority) -> Self {
         self.priority = priority;
+        self
+    }
+
+    /// ADJ73 PR-B: ground the rule in a CONTEXT (a jurisdiction / guideline edition /
+    /// specialty). Combined with [`KnowledgeBase::add_context_outranks`], the rule in the
+    /// greater context defeats a conflicting one in a lesser context (lex superior).
+    pub fn with_context(mut self, context: impl Into<String>) -> Self {
+        self.context = Some(context.into());
         self
     }
 }
@@ -388,6 +407,13 @@ pub struct KnowledgeBase {
     /// highest-priority one. A predicate not listed here is monotonic (every derivation
     /// governs) — this is what makes precedence opt-in and `enumerate_all` unchanged.
     functional_predicates: HashSet<ClauseIndex>,
+    /// ADJ73 PR-B: the grounded CONTEXT precedence order — directed edges `(higher, lower)`
+    /// meaning "a rule in `higher` outranks a conflicting rule in `lower`" (federal > state,
+    /// ninth_circuit > district_court, idsa_2024 > idsa_2004, specialist > general). Each edge
+    /// is a grounded fact (its byte-quote — the Supremacy Clause, etc. — rides on the
+    /// surface/data layer). [`crate::govern::enumerate_governing`] consults this BEFORE the
+    /// priority tier (lex superior); the transitive reach is computed cycle-safely.
+    context_order: Vec<(String, String)>,
     next_fact_id: u64,
     next_rule_id: u64,
     next_prior_id: u64,
@@ -476,6 +502,81 @@ impl KnowledgeBase {
         ClauseIndex::from_term(term)
             .map(|idx| self.functional_predicates.contains(&idx))
             .unwrap_or(false)
+    }
+
+    /// ADJ73 PR-B: assert that context `higher` OUTRANKS context `lower` (a grounded
+    /// precedence edge — federal > state, ninth_circuit > district_court). Idempotent; the
+    /// transitive closure is computed on query. Adding a back-edge that creates a cycle is
+    /// *allowed* here (the loader may reject it), but [`Self::context_outranks`] is cycle-safe
+    /// and a mutual outrank degrades to an unresolved conflict rather than a wrong pick.
+    pub fn add_context_outranks(&mut self, higher: impl Into<String>, lower: impl Into<String>) {
+        let edge = (higher.into(), lower.into());
+        if !self.context_order.contains(&edge) {
+            self.context_order.push(edge);
+        }
+    }
+
+    /// ADJ73 PR-B: does context `a` outrank context `b` (directly or transitively)? Cycle-safe
+    /// DFS over the `(higher, lower)` edges. `a == b` is `false` (a context does not outrank
+    /// itself). Returns `false` when there is no directed path `a → … → b`.
+    pub fn context_outranks(&self, a: &str, b: &str) -> bool {
+        if a == b {
+            return false;
+        }
+        let mut stack = vec![a];
+        let mut seen: HashSet<&str> = HashSet::new();
+        while let Some(node) = stack.pop() {
+            if !seen.insert(node) {
+                continue; // already visited — cycle-safe
+            }
+            for (hi, lo) in &self.context_order {
+                if hi == node {
+                    if lo == b {
+                        return true;
+                    }
+                    stack.push(lo);
+                }
+            }
+        }
+        false
+    }
+
+    /// ADJ73 PR-B: `true` iff the declared `context_order` contains a cycle (e.g. `a > b`,
+    /// `b > a`). The surface loader should reject such a rulebook; the resolver itself stays
+    /// safe regardless. Detected as "some node can reach itself".
+    pub fn context_order_has_cycle(&self) -> bool {
+        let nodes: HashSet<&str> = self
+            .context_order
+            .iter()
+            .flat_map(|(h, l)| [h.as_str(), l.as_str()])
+            .collect();
+        nodes.iter().any(|n| self.reaches_self(n))
+    }
+
+    /// Helper: can `start` reach itself via a directed path of length ≥ 1? (`context_outranks`
+    /// short-circuits `a == b` to false, so cycle detection needs this explicit walk.)
+    fn reaches_self(&self, start: &str) -> bool {
+        let mut stack: Vec<&str> = self
+            .context_order
+            .iter()
+            .filter(|(h, _)| h == start)
+            .map(|(_, l)| l.as_str())
+            .collect();
+        let mut seen: HashSet<&str> = HashSet::new();
+        while let Some(node) = stack.pop() {
+            if node == start {
+                return true;
+            }
+            if !seen.insert(node) {
+                continue;
+            }
+            for (hi, lo) in &self.context_order {
+                if hi == node {
+                    stack.push(lo);
+                }
+            }
+        }
+        false
     }
 
     /// Walk every Fact and every Rule once; return `true` iff every

--- a/code/specs/ADJ73-defeasible-rule-precedence.md
+++ b/code/specs/ADJ73-defeasible-rule-precedence.md
@@ -331,6 +331,13 @@ Each PR: spec-sync note, tests incl. a CONFLICT/abstain case, `/security-review`
   appeal-status / lex-specialis). Engine resolution queries `outranks` instead of comparing enum
   tiers when rule attributes are present; cycle/contradiction → CONFLICT. Rule attributes
   (authority/date/appeal/specificity) added as typed, provenanced metadata.
+  - **PR-B engine core ✅ DONE (logic-engine 0.19).** `Rule::context` + `Knowledge­Base::{add_context_outranks,
+    context_outranks (cycle-safe), context_order_has_cycle}` + a `defeats(a,b)` resolution that
+    makes context precedence PRIMARY (lex superior) and the tier secondary — generalizing the
+    pure-tier rule (no context order ⇒ unchanged). A cyclic order crowns nothing (safe). Still
+    to come: the grounded `context-precedence.adj` **rulebook** with byte-provenanced edges + the
+    recency/appeal/lex-specialis **meta-rules**, and the adj-lang **surface** (`context:` on a
+    rule, `context_order { … }`).
 - **PR-C — adj-lang surface** (`priority: <tier>`, `functional`/`decision`, the attribute
   annotations) + regen grammar.
 - **PR-D — MYCIN `decide_timing` → `timing.adj`** on the named-enum ladder (was PR-4).


### PR DESCRIPTION
The author-facing **surface** for logic-engine 0.19's grounded context precedence (lex superior). A rulebook can declare context-scoped rules + a context order directly:

```
functional means(term, reading)
context_order { ninth_circuit > district_court }
rule { head: means(waters, broad)  when: case(x) priority: default       context: ninth_circuit }
rule { head: means(waters, narrow) when: case(x) priority: authoritative  context: district_court }
? means(waters, $R)        // → means(waters, broad) governs (context beats the higher tier)
```

- **Grammar:** `context_order { IDENT > IDENT … }` added to `statement`; `rule_decl` gains `[ "context" COLON IDENT ]`. `context_order`/`context` are IDENT-matched literals; `>` is the existing GT operator; grammar regenerated.
- **AST / adapter / lower:** `Statement::Rule.context` + `Statement::ContextOrder`; a shared `ident_after_keyword` extracts both `priority:` and `context:`; `context_order` edges → `add_context_outranks`; `context:` → `Rule::with_context`.

## Verification

73 adj-lang tests pass incl. **2 new** — one compiles `context_order { ninth_circuit > district_court }` + context-tagged rules and asserts via `enumerate_governing` that the higher-context rule **governs despite the lower tier** (lex superior); one checks multi-edge orders lower transitively (federal > circuit > state ⇒ federal outranks state). Builds clean; **security review passed**. adj-lang 0.16.0.

> ⚠️ **Stacked on [#6087](https://github.com/adhithyan15/coding-adventures/pull/6087)** (logic-engine PR-B engine core) — base is `adj-context-precedence`; it retargets to `main` automatically when #6087 merges.

Next: the grounded `context-precedence` **rulebook** (byte-provenanced `outranks_context` edges + a worked legal example) using this surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)