### PR TITLE
feat(r-lang): R-14 — index sub-assignment (m[i,j] <- v, v[i] <- x)

### DIFF
--- a/code/packages/rust/r-runtime/CHANGELOG.md
+++ b/code/packages/rust/r-runtime/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.9.0] - 2026-06-16
+
+### Added (via the shared `s-runtime` lvalue machinery)
+
+- **R-14 — index sub-assignment**: `m[i, j] <- v`, `m[i, ] <- v`, `m[, j] <- v`,
+  `m[rows, cols] <- v`, and 1-D `v[i] <- val`, `v[-i] <- val`,
+  `v[logical] <- val`. The RHS recycles R-style; the matrix keeps its `dim`.
+  Sub-assignment is copy-on-modify (a prior `b <- a` copy is unaffected); an
+  out-of-range/`NA` index, an empty replacement, or an undefined base are clean
+  errors. This completes the R-13 deferral. See `s-runtime` 0.10.0.
+
 ## [0.8.0] - 2026-06-16
 
 ### Added (via the shared `s-runtime` + the `r.grammar` index_suffix change)

--- a/code/packages/rust/r-runtime/src/lib.rs
+++ b/code/packages/rust/r-runtime/src/lib.rs
@@ -589,10 +589,87 @@ mod tests {
         );
     }
 
+    // --- R-14: sub-assignment ------------------------------------------
+
     #[test]
-    fn matrix_sub_assignment_is_deferred() {
-        // `m[i, j] <- v` is not yet supported (R-14); it errors cleanly rather
-        // than panicking or silently doing nothing.
-        assert!(eval_r("m <- matrix(1:6, 2, 3)\nm[1, 1] <- 99\n").is_err());
+    fn vector_element_and_multi_assignment() {
+        assert_eq!(nums("v <- c(1, 2, 3)\nv[2] <- 9\nv\n"), vec![1.0, 9.0, 3.0]);
+        assert_eq!(
+            nums("v <- c(1, 2, 3)\nv[c(1, 3)] <- 0\nv\n"),
+            vec![0.0, 2.0, 0.0]
+        );
+        // The RHS recycles to fill the selected cells.
+        assert_eq!(
+            nums("v <- c(1, 2, 3, 4)\nv[c(1, 2, 3, 4)] <- c(10, 20)\nv\n"),
+            vec![10.0, 20.0, 10.0, 20.0]
+        );
+    }
+
+    #[test]
+    fn vector_negative_and_logical_assignment() {
+        assert_eq!(
+            nums("v <- c(1, 2, 3)\nv[-2] <- 7\nv\n"),
+            vec![7.0, 2.0, 7.0]
+        );
+        assert_eq!(
+            nums("v <- c(1, 2, 3)\nv[c(TRUE, FALSE, TRUE)] <- 5\nv\n"),
+            vec![5.0, 2.0, 5.0]
+        );
+    }
+
+    #[test]
+    fn matrix_element_row_and_column_assignment() {
+        // Element: m[1,2] <- 9 (column-major (1,2) is flat index 2).
+        assert_eq!(
+            nums("m <- matrix(1:6, 2, 3)\nm[1, 2] <- 9\nc(m)\n"),
+            vec![1.0, 2.0, 9.0, 4.0, 5.0, 6.0]
+        );
+        // Whole row: recycles the scalar across the row.
+        assert_eq!(
+            nums("m <- matrix(1:6, 2, 3)\nm[1, ] <- 0\nc(m)\n"),
+            vec![0.0, 2.0, 0.0, 4.0, 0.0, 6.0]
+        );
+        // Whole column: a length-2 RHS fills column 2.
+        assert_eq!(
+            nums("m <- matrix(1:6, 2, 3)\nm[, 2] <- c(7, 8)\nc(m)\n"),
+            vec![1.0, 2.0, 7.0, 8.0, 5.0, 6.0]
+        );
+        // The matrix keeps its shape after assignment.
+        assert_eq!(
+            nums("m <- matrix(1:6, 2, 3)\nm[1, 1] <- 99\ndim(m)\n"),
+            vec![2.0, 3.0]
+        );
+    }
+
+    #[test]
+    fn matrix_submatrix_assignment_recycles() {
+        // m[,] <- 1 fills every cell.
+        assert_eq!(
+            nums("m <- matrix(1:4, 2, 2)\nm[, ] <- 1\nc(m)\n"),
+            vec![1.0, 1.0, 1.0, 1.0]
+        );
+        // A 2x2 block written with 4 values, column-major fill order.
+        assert_eq!(
+            nums("m <- matrix(0, 2, 2)\nm[1:2, 1:2] <- c(1, 2, 3, 4)\nc(m)\n"),
+            vec![1.0, 2.0, 3.0, 4.0]
+        );
+    }
+
+    #[test]
+    fn out_of_range_or_undefined_assignment_is_an_error() {
+        assert!(eval_r("m <- matrix(1:6, 2, 3)\nm[5, 1] <- 9\n").is_err());
+        // Assigning into an undefined variable's index is an error.
+        assert!(eval_r("x[1] <- 9\n").is_err());
+        // An empty replacement is an error.
+        assert!(eval_r("v <- c(1, 2, 3)\nv[1] <- c()\n").is_err());
+    }
+
+    #[test]
+    fn assignment_returns_the_value_invisibly_and_does_not_alias() {
+        // The base is rebound to a fresh value; a prior copy is unchanged.
+        assert_eq!(
+            nums("a <- c(1, 2, 3)\nb <- a\na[1] <- 99\nb\n"),
+            vec![1.0, 2.0, 3.0]
+        );
     }
 }

--- a/code/packages/rust/s-runtime/CHANGELOG.md
+++ b/code/packages/rust/s-runtime/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.10.0] - 2026-06-16
+
+### Added
+
+- **Index sub-assignment (R-14)** — the left side of an assignment may now be a
+  subscript expression, not just a bare name. `eval_indexed_assignment` descends
+  to the postfix `[ … ]`, requires a bare-name base, looks up its current value,
+  resolves the subscripts, writes the (recycled) RHS into the selected cells, and
+  rebinds the modified value to the base name. Supported: 1-D `v[i] <- val`,
+  `v[-i] <- val`, `v[logical] <- val` (full `resolve_picks` styles), and 2-D
+  `m[i, j] <- v`, `m[i, ] <- v`, `m[, j] <- v`, `m[rows, cols] <- v`. New free
+  functions `assign_index` / `assign_index2d` (with `assign_positions` /
+  `write_recycled` helpers) in `value.rs`.
+
+### Safety
+
+- Sub-assignment is **copy-on-modify**: the base value is cloned, mutated, and
+  re-`define`d, so a prior copy (`b <- a; a[1] <- 9`) is never aliased and the
+  rebind cannot corrupt any other binding. An out-of-range or `NA` index in an
+  assignment is a hard error (no silent auto-grow); an empty replacement
+  (`v[i] <- c()`) is an error; assigning into an undefined base is an error.
+  Write counts are bounded by the (`MAX_SEQ_LEN`-capped) selection length.
+
 ## [0.9.0] - 2026-06-16
 
 ### Added

--- a/code/packages/rust/s-runtime/README.md
+++ b/code/packages/rust/s-runtime/README.md
@@ -31,6 +31,9 @@ s-lexer → s-parser → GrammarASTNode → s-runtime (this crate) → s-repl
 - **v2** adds `%op%` infix operators, a broad builtin library, **S3 method
   dispatch** (a generic `print`), **factors**, and **data frames** (`$`,
   `[[ ]]`, 2-D indexing).
+- **Index sub-assignment** (R-14): the left side of `<-` may be a subscript,
+  e.g. `v[i] <- x`, `v[-i] <- x`, `m[i, j] <- x`, `m[, j] <- x` — copy-on-modify,
+  RHS recycled, so a prior `b <- a` copy is never aliased.
 - The **`d`/`p`/`q`/`r` distribution family** (R-8) over `statistics-core`:
   density/CDF/quantile/sampling for the normal, uniform, and exponential
   distributions, plus `set.seed` for a reproducible per-session RNG.

--- a/code/packages/rust/s-runtime/src/eval.rs
+++ b/code/packages/rust/s-runtime/src/eval.rs
@@ -20,8 +20,8 @@ use crate::builtins;
 use crate::env::{define, lookup, Env, Scope};
 use crate::error::{SError, SResult};
 use crate::value::{
-    arithmetic, bounded_sequence, class_of, compare, format_value, index, index2d, membership,
-    negate, Arg, Param, SValue, MAX_SEQ_LEN,
+    arithmetic, assign_index, assign_index2d, bounded_sequence, class_of, compare, format_value,
+    index, index2d, membership, negate, Arg, Param, SValue, MAX_SEQ_LEN,
 };
 use coding_adventures_s_parser::try_parse_s;
 use parser::grammar_parser::{ASTNodeOrToken, GrammarASTNode};
@@ -263,10 +263,56 @@ impl Interpreter {
         } else {
             (nodes[0], nodes[1]) // target <- value
         };
-        let name = lvalue_name(target_node)?;
         let value = self.eval_node(value_node, env)?;
-        define(env, &name, value.clone());
-        self.as_invisible(value)
+        // A bare-name target is the simple case; otherwise try `x[...] <- v`
+        // sub-assignment (R-14) before giving up.
+        match lvalue_name(target_node) {
+            Ok(name) => {
+                define(env, &name, value.clone());
+                self.as_invisible(value)
+            }
+            Err(simple_err) => self.eval_indexed_assignment(target_node, value, env, simple_err),
+        }
+    }
+
+    /// Handle `x[i] <- v` / `m[i, j] <- v` — evaluate the base variable, resolve
+    /// the subscripts, write the recycled RHS into the selected cells of a
+    /// *clone*, and rebind the base name (so other bindings can't be corrupted).
+    fn eval_indexed_assignment(
+        &self,
+        target: &GrammarASTNode,
+        rhs: SValue,
+        env: &Env,
+        simple_err: SError,
+    ) -> SResult<SValue> {
+        // The target must reduce to a `postfix` of the form `NAME [ subscripts ]`.
+        let postfix = descend_to_postfix(target).ok_or(simple_err)?;
+        let parts = node_children(postfix);
+        // primary + exactly one index_suffix (no chained `$`/`[[`/`()` for now).
+        let (primary, suffix) = match parts.as_slice() {
+            [primary, suffix] if suffix.rule_name == "index_suffix" => (*primary, *suffix),
+            _ => {
+                return Err(SError::TypeError(
+                    "unsupported assignment target (only `x[...] <- v` is supported)".into(),
+                ))
+            }
+        };
+        let base_name = lvalue_name(primary)?;
+        let current =
+            lookup(env, &base_name).ok_or_else(|| SError::Undefined(base_name.clone()))?;
+
+        let subs = self.eval_subscripts(suffix, env)?;
+        let updated = match subs.len() {
+            1 => assign_index(&current, subs[0].as_ref(), &rhs)?,
+            2 => assign_index2d(&current, subs[0].as_ref(), subs[1].as_ref(), &rhs)?,
+            n => {
+                return Err(SError::Index(format!(
+                    "incorrect number of dimensions ({n}) in assignment"
+                )))
+            }
+        };
+        define(env, &base_name, updated);
+        self.as_invisible(rhs)
     }
 
     // -----------------------------------------------------------------------

--- a/code/packages/rust/s-runtime/src/value.rs
+++ b/code/packages/rust/s-runtime/src/value.rs
@@ -777,6 +777,117 @@ fn index_matrix_2d(
 }
 
 // ===========================================================================
+// Sub-assignment — `x[i] <- v`, `m[i, j] <- v` (R-14)
+// ===========================================================================
+
+/// Resolve a subscript into concrete write positions, rejecting `NA` /
+/// out-of-range (R forbids assigning *to* an `NA` or beyond-the-end position —
+/// the vector-extending case is deferred). `None` means the whole length.
+fn assign_positions(len: usize, slot: Option<&SValue>) -> SResult<Vec<usize>> {
+    match slot {
+        None => Ok((0..len).collect()),
+        Some(idx) => resolve_picks(len, idx)?
+            .into_iter()
+            .map(|p| {
+                p.ok_or_else(|| {
+                    SError::Index("NAs/out-of-range are not allowed in index assignment".into())
+                })
+            })
+            .collect(),
+    }
+}
+
+/// Write the recycled numeric `rhs` into `slots` of `out` (R recycles the
+/// replacement to fill the selected cells; an empty replacement is an error).
+fn write_recycled(out: &mut [f64], slots: &[usize], rhs: &Double) -> SResult<()> {
+    if rhs.is_empty() {
+        return Err(SError::BadArgs("replacement has length zero".into()));
+    }
+    let src = rhs.data();
+    for (k, &pos) in slots.iter().enumerate() {
+        out[pos] = src[k % src.len()];
+    }
+    Ok(())
+}
+
+/// `base[idx] <- rhs` — single-subscript assignment. Numeric only; a matrix
+/// keeps its shape (linear write over the flat column-major data). Returns the
+/// modified value (the caller rebinds it), so the original binding is never
+/// mutated in place — no aliasing.
+pub fn assign_index(base: &SValue, idx: Option<&SValue>, rhs: &SValue) -> SResult<SValue> {
+    let rhs_d = rhs.as_double()?;
+    match base {
+        SValue::Matrix { data, nrow, ncol } => {
+            let slots = assign_positions(data.len(), idx)?;
+            let mut out = data.data().to_vec();
+            write_recycled(&mut out, &slots, &rhs_d)?;
+            Ok(SValue::Matrix {
+                data: Double::from_values(out),
+                nrow: *nrow,
+                ncol: *ncol,
+            })
+        }
+        SValue::Double(d) => {
+            let slots = assign_positions(d.len(), idx)?;
+            let mut out = d.data().to_vec();
+            write_recycled(&mut out, &slots, &rhs_d)?;
+            Ok(SValue::Double(Double::from_values(out)))
+        }
+        SValue::Classed { inner, class } => Ok(SValue::Classed {
+            inner: Box::new(assign_index(inner, idx, rhs)?),
+            class: class.clone(),
+        }),
+        other => Err(SError::TypeError(format!(
+            "cannot index-assign into a value of type '{}'",
+            other.type_name()
+        ))),
+    }
+}
+
+/// `m[rows, cols] <- rhs` — two-subscript matrix assignment (column-major; the
+/// recycled `rhs` fills the selected cells in column order, matching R).
+pub fn assign_index2d(
+    base: &SValue,
+    rows: Option<&SValue>,
+    cols: Option<&SValue>,
+    rhs: &SValue,
+) -> SResult<SValue> {
+    match base {
+        SValue::Matrix { data, nrow, ncol } => {
+            let (nrow, ncol) = (*nrow, *ncol);
+            let rsel = resolve_dim(rows, nrow)?;
+            let csel = resolve_dim(cols, ncol)?;
+            let rhs_d = rhs.as_double()?;
+            if rhs_d.is_empty() {
+                return Err(SError::BadArgs("replacement has length zero".into()));
+            }
+            let src = rhs_d.data();
+            let mut out = data.data().to_vec();
+            let mut k = 0usize;
+            for &c in &csel {
+                for &r in &rsel {
+                    out[c * nrow + r] = src[k % src.len()];
+                    k += 1;
+                }
+            }
+            Ok(SValue::Matrix {
+                data: Double::from_values(out),
+                nrow,
+                ncol,
+            })
+        }
+        SValue::Classed { inner, class } => Ok(SValue::Classed {
+            inner: Box::new(assign_index2d(inner, rows, cols, rhs)?),
+            class: class.clone(),
+        }),
+        other => Err(SError::Index(format!(
+            "incorrect number of dimensions for {}",
+            other.type_name()
+        ))),
+    }
+}
+
+// ===========================================================================
 // Formatting — the printed representation, with the [i] index prefix
 // ===========================================================================
 

--- a/code/specs/R00-r-language.md
+++ b/code/specs/R00-r-language.md
@@ -175,9 +175,30 @@ unchanged.
     matrix subscripts are a hard error; the result size and the logical-recycle
     span are capped at `MAX_SEQ_LEN`. The empty-subscript grammar also enables
     `df[, j]` / `df[i, ]` on data frames.
-  - *Deferred (R-14):* **sub-assignment** `m[i, j] <- v` — it needs new
-    lvalue-target machinery (the evaluator currently only assigns to bare names),
-    a separable feature; today it is a clean error, not a silent no-op.
+  - *Done in R-14:* **sub-assignment** `m[i, j] <- v` (below).
+- **R-14 — index sub-assignment** *(this PR)*. `m[i, j] <- v` and the 1-D
+  `v[i] <- val`, in the shared `s-runtime`. The evaluator previously only
+  assigned to **bare names**; R-14 adds the lvalue-target machinery so the left
+  side of `<-` (or `=` / `->`) may be a **subscript expression**:
+  - When the assignment target is not a bare name, the evaluator descends to the
+    postfix `[ … ]`, requires a bare-name base, **looks up the current value of
+    that base**, resolves the subscripts (reusing R-13's `resolve_picks` for the
+    1-D case and the 2-D dimension resolver for `m[rows, cols]`), writes the RHS
+    into the selected cells, and **rebinds the modified value to the base name**.
+  - The write is **copy-then-rebind**: the base value is cloned, the clone is
+    mutated, and `define` replaces the binding. Because `SValue` bindings are
+    by-value, an earlier copy (`b <- a; a[1] <- 9`) is *not* aliased — `b` keeps
+    its old contents, matching R's copy-on-modify semantics.
+  - The RHS is **recycled** R-style to fill the selected cells (a length-1 RHS
+    broadcasts; a length-*k* RHS repeats). 1-D selection accepts the full
+    positive / negative / logical index styles; 2-D accepts `m[i, ]`, `m[, j]`,
+    and `m[rows, cols]`. The matrix keeps its `dim` after assignment.
+  - **Safety:** the selected positions are bounds-checked against the target
+    length (an out-of-range or `NA` index in an *assignment* is a hard error, not
+    a silent grow — vector auto-extension is deferred); an **empty replacement**
+    (`v[i] <- c()`) is an error; assigning into an **undefined base** is an error.
+    No write can touch another binding, so the rebind cannot corrupt unrelated
+    variables. The number of writes is bounded by the (capped) selection length.
 
 ## §4 Reuse strategy
 


### PR DESCRIPTION
## R-14 — index sub-assignment

Completes the R-13 deferral. The left side of an assignment (`<-`, `=`, `->`)
may now be a **subscript expression**, not just a bare name.

### What works
- 1-D: `v[i] <- x`, `v[c(1,3)] <- 0`, `v[-2] <- 7`, `v[c(TRUE,FALSE,TRUE)] <- 5`
- 2-D: `m[i, j] <- v`, `m[i, ] <- v` (row), `m[, j] <- v` (column),
  `m[rows, cols] <- v` (sub-matrix)
- RHS is recycled R-style; the matrix keeps its `dim`.

### How
A new `eval_indexed_assignment` (in the shared `s-runtime`) descends to the
postfix `[ … ]`, requires a bare-name base, looks up its current value, resolves
the subscripts (reusing R-13's `resolve_picks` for 1-D and the 2-D dimension
resolver), writes the recycled RHS into the selected cells of a **clone**, and
rebinds the base name. New free functions `assign_index` / `assign_index2d`
(with `assign_positions` / `write_recycled` helpers) in `value.rs`.

### Safety
- **Copy-on-modify**: the base is cloned, mutated, and re-`define`d — a prior
  `b <- a` copy is never aliased, and the rebind cannot corrupt any other
  binding.
- An out-of-range / `NA` index in an assignment is a **hard error** (no silent
  auto-grow; vector extension is deferred); an **empty replacement**
  (`v[i] <- c()`, incl. `<- NULL`) is an error; an **undefined base** is an error.
- Writes go into a fixed-size clone (no growth) and are bounded by the
  `MAX_SEQ_LEN`-capped selection length. `% 0` recycling is guarded by the
  empty-replacement check.

### Tests / verification
- 6 new r-runtime tests (replacing the R-13 deferred-marker test); the R-13 test
  that asserted `m[1,1]<-99` errors is updated to assert it now succeeds.
- `cargo test` green (119 r-runtime, 55 s-runtime), `cargo fmt` + `cargo clippy`
  clean for both crates.
- `/security-review`: **PASSED** (one round, no findings) — write bounds, the
  `% 0` / `NULL`-RHS guard, `c*nrow+r` overflow, DoS, and no-aliasing all
  independently verified.
- Spec (`code/specs/R00-r-language.md`) and CHANGELOGs (s-runtime 0.10.0,
  r-runtime 0.9.0) updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)