### PR TITLE
feat(visicalc-compose): wire drag-fill into the infinite-sheet demo

### DIFF
--- a/demo/visicalc-compose/README.md
+++ b/demo/visicalc-compose/README.md
@@ -84,7 +84,11 @@ column-letter header share one horizontal `ScrollState`, so dragging any row
 pans them all in lockstep (the header is gesture-disabled — it only follows).
 Tap a cell → `selectInf(row,col)` (clamps, loads the source into the formula
 bar); press Enter → `commitInf(text)` (writes through, recomputes dependents,
-regrows the extent). `InfiniteSheetModel` (in `Engine.kt`) seeds far-flung
+regrows the extent). The **"Fill ↓ 10"** button next to the formula bar calls
+`InfiniteSheetModel.fillDown(10)` (over the C ABI's `sc_fill`) to replicate the
+selected cell into the 10 rows below it — the engine shifts each copy's relative
+references (`=A1`→`=A2`, …), pins absolute (`$`) refs, and carries the format.
+`InfiniteSheetModel` (in `Engine.kt`) seeds far-flung
 sparse cells (`Z1000`, `BA50`, `BB50`) and derives the extent from `usedRange()`
 + a margin.
 
@@ -95,8 +99,9 @@ and asserts the window is engine-computed + dense (A1=15, E1=38, E5=169), a
 formula 1000 rows down (`Z1000` = 39) is reachable, the gaps are empty (sparse),
 column letters run AA/BA, and editing `A1` dirties the far dependent `Z1000` via
 `changedSince`. It also drives `InfiniteSheetModel` directly: `rowCells`
-one-read rows, `selectInf` clamping + source load, and `commitInf` recompute
-(A2 `8`→`108` ⇒ E2 151, A5 139, E5 269).
+one-read rows, `selectInf` clamping + source load, `commitInf` recompute
+(A2 `8`→`108` ⇒ E2 151, A5 139, E5 269), and `fillDown` (`I1 = =H1*10` filled
+down 10 rows ⇒ I2 = H2*10 = 30, I3 = H3*10 = 40, source I1 = 20 untouched).
 
 The Compose UI itself (`InfiniteSheet.kt` + the `Main.kt` toggle) is verified to
 compile against the real Compose Desktop APIs via `gradle compileKotlin`; the

--- a/demo/visicalc-compose/src/main/kotlin/Engine.kt
+++ b/demo/visicalc-compose/src/main/kotlin/Engine.kt
@@ -48,6 +48,8 @@ class SpreadsheetSession(libraryPath: String = resolveLibraryPath()) : AutoClose
     private val scGetDisplayWindow = handle("sc_get_display_window", FunctionDescriptor.of(ptr, ptr, i32, i32, i32, i32))
     // sc_set_format(session, a1, code) -> void (empty code clears the format).
     private val scSetFormat = handle("sc_set_format", FunctionDescriptor.ofVoid(ptr, ptr, ptr))
+    // sc_fill(session, src, dst_start, dst_end) -> void (drag-fill; three A1 strings).
+    private val scFill = handle("sc_fill", FunctionDescriptor.ofVoid(ptr, ptr, ptr, ptr))
     private val scUsedRange = handle("sc_used_range", FunctionDescriptor.of(ptr, ptr))
     private val scColumnLetters = handle("sc_column_letters", FunctionDescriptor.of(ptr, ptr, i32))
     private val scCurrentRevision = handle("sc_current_revision", FunctionDescriptor.of(i64, ptr))
@@ -112,6 +114,21 @@ class SpreadsheetSession(libraryPath: String = resolveLibraryPath()) : AutoClose
     /// [window] reads through sc_get_display_window.
     fun setFormat(a1: String, code: String): Unit = Arena.ofConfined().use { a ->
         scSetFormat.invoke(session, a.allocateUtf8String(a1), a.allocateUtf8String(code))
+    }
+
+    /// Drag-fill: replicate the `src` cell across the inclusive A1 rectangle
+    /// `dstStart`..`dstEnd`. Relative references shift per target (`=A1` filled
+    /// one row down becomes `=A2`), absolute (`$`) refs pin, off-grid refs become
+    /// `#REF!`; the source's display format rides along. The engine recomputes
+    /// every dependent. Reaches sc_fill — the same path the web/SwiftUI/Qt/Flutter
+    /// demos drive.
+    fun fill(src: String, dstStart: String, dstEnd: String): Unit = Arena.ofConfined().use { a ->
+        scFill.invoke(
+            session,
+            a.allocateUtf8String(src),
+            a.allocateUtf8String(dstStart),
+            a.allocateUtf8String(dstEnd),
+        )
     }
 
     /// Dense display strings for the inclusive 1-based rectangle, row-major
@@ -354,6 +371,19 @@ class InfiniteSheetModel(
         session.setCell(infAddress(), raw)
         computeExtent()
         formula = session.getRaw(infAddress())
+    }
+
+    /// Drag-fill: replicate the selected cell into the [rows] rows below it. The
+    /// engine shifts each copy's relative references (`=A1`→`=A2`, …), pins
+    /// absolute (`$`) refs, carries the format, and recomputes every dependent.
+    /// Regrows the extent if the fill reached new ground. The Kotlin sibling of
+    /// the Flutter `InfiniteSheetModel.fillDown` and the Qt "Fill ↓ 10" button.
+    fun fillDown(rows: Int) {
+        val col = session.columnLetters(selCol)
+        val first = "$col${selRow + 1}"
+        val last = "$col${selRow + rows}"
+        session.fill(infAddress(), first, last)
+        computeExtent()
     }
 
     override fun close() = session.close()

--- a/demo/visicalc-compose/src/main/kotlin/InfiniteSheet.kt
+++ b/demo/visicalc-compose/src/main/kotlin/InfiniteSheet.kt
@@ -101,13 +101,20 @@ fun InfiniteSheet() {
         rev++
     }
 
+    // Drag-fill: replicate the selected cell into the 10 rows below it. The engine
+    // shifts each copy's relative refs, pins absolute ($) refs, carries the format.
+    fun fillDown() {
+        model.fillDown(10)
+        rev++
+    }
+
     Column(modifier = Modifier.fillMaxSize().padding(8.dp)) {
         // ── Formula bar: the selected cell's address + an editable source ──
         Row(verticalAlignment = Alignment.CenterVertically) {
             Text(model.infAddress(), DIM, GUTTER_W)
             Box(
                 modifier = Modifier
-                    .fillMaxWidth()
+                    .weight(1f)
                     .height(28.dp)
                     .background(CHROME)
                     .border(1.dp, BORDER)
@@ -123,6 +130,22 @@ fun InfiniteSheet() {
                     keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
                     keyboardActions = KeyboardActions(onDone = { commit() }),
                     modifier = Modifier.fillMaxWidth(),
+                )
+            }
+            Spacer(Modifier.width(8.dp))
+            // Drag-fill: replicate the selected cell into the 10 rows below it.
+            androidx.compose.material.OutlinedButton(
+                onClick = { fillDown() },
+                colors = androidx.compose.material.ButtonDefaults.outlinedButtonColors(
+                    backgroundColor = CHROME,
+                    contentColor = INK,
+                ),
+                border = androidx.compose.foundation.BorderStroke(1.dp, BORDER),
+            ) {
+                androidx.compose.material.Text(
+                    "Fill ↓ 10",
+                    fontSize = 12.sp,
+                    fontFamily = MONO,
                 )
             }
         }

--- a/demo/visicalc-compose/test/EngineSmoke.kt
+++ b/demo/visicalc-compose/test/EngineSmoke.kt
@@ -124,6 +124,20 @@ fun main() {
     check("inf commit E2", inf.rowCells(2)[4], "151.00") // 108+14+7+22, formatted
     check("inf commit A5", inf.rowCells(5)[0], "139.00") // 15+108+12+4, formatted
     check("inf commit E5", inf.rowCells(5)[4], "269.00") // grand total, formatted
+
+    // fillDown replicates the selected cell, shifting relative refs per target.
+    // Seed a fresh column via select+commit: H1=2, H2=3, H3=4 (col 8 = H);
+    // I1 = H1*10 (col 9 = I). Select I1 and fill down 10 — each filled formula
+    // tracks its row (I2 = H2*10 = 30, I3 = H3*10 = 40), and I1 stays untouched.
+    inf.selectInf(1, 8); inf.commitInf("2")        // H1
+    inf.selectInf(2, 8); inf.commitInf("3")        // H2
+    inf.selectInf(3, 8); inf.commitInf("4")        // H3
+    inf.selectInf(1, 9); inf.commitInf("=H1*10")   // I1 = 20
+    inf.selectInf(1, 9)
+    inf.fillDown(10)
+    check("inf fillDown I2", inf.rowCells(2)[8], "30") // I2 = H2*10
+    check("inf fillDown I3", inf.rowCells(3)[8], "40") // I3 = H3*10
+    check("inf fillDown I1 source", inf.rowCells(1)[8], "20") // I1 untouched
     inf.close()
 
     println(if (failures == 0) "\nALL PASS" else "\n$failures FAILURE(S)")


### PR DESCRIPTION
Adds the **"Fill ↓ 10"** drag-fill action to the Compose Desktop VisiCalc infinite-sheet demo, computing on the shared Rust `spreadsheet-core` engine through its C ABI (`sc_fill`) over the Java FFM API — the Kotlin sibling of the SwiftUI/Qt/Flutter "Fill ↓ 10" buttons and the web demo's fill. Continues the cross-backend drag-fill rollout (engine #6048, facades #6057, web #6082, Qt #6086, Flutter #6089).

## Changes
- **`Engine.kt`** — `sc_fill` FFM downcall handle (void; `src`/`dst_start`/`dst_end` A1 strings), `SpreadsheetSession.fill(src, dstStart, dstEnd)` marshalling all three through a confined `Arena`, and `InfiniteSheetModel.fillDown(rows)` (src = selected cell, dst = the `rows` cells below; regrows the extent). The engine shifts each copy's relative references (`=A1`→`=A2`), pins absolute (`$`) refs, carries the display format, and recomputes every dependent.
- **`InfiniteSheet.kt`** — a "Fill ↓ 10" `OutlinedButton` next to the formula bar (the formula box switches to `weight(1f)` so the button gets room); bumps the recompose revision so visible rows re-read.
- **`EngineSmoke.kt`** — headless `fillDown` proof: seed `H1`/`H2`/`H3` + `I1 = =H1*10`, fill `I1` down 10 rows ⇒ `I2 = H2*10 = 30`, `I3 = H3*10 = 40`, source `I1 = 20` untouched.
- **`README.md`** — documents the Fill button + the headless assertion.

## Verification
`scripts/verify.sh` (kotlinc + FFM, vendored dylib) — **ALL PASS**, including the three new `fillDown` checks (I2=30, I3=40, I1=20). `/security-review` passed in 1 round (FFM arena lifetime, range validation at the engine trust boundary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)