### PR TITLE
feat(mxf64-2): matrix-runtime cost model for f64 (gflops_f64)

### DIFF
--- a/code/packages/rust/executor-protocol/CHANGELOG.md
+++ b/code/packages/rust/executor-protocol/CHANGELOG.md
@@ -7,6 +7,13 @@ format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- `BackendProfile.gflops_f64` (MX12 / MXF-2): an `f64` (double-precision)
+  compute-throughput field, sitting beside `gflops_f32`. A backend with no
+  `f64` kernel advertises `0` here; the `matrix-runtime` cost model reads that
+  as infinite cost and keeps `f64` work on a backend that can run it. The field
+  is encoded/decoded as one extra `u32` in `encode_profile`/`decode_profile`,
+  inserted symmetrically right after `gflops_f32` (this changes the
+  `BackendProfile` wire layout — both ends must be built from this version).
 - `ProtocolSurfaceSummary` plus `protocol_surface_summary()` for
   payload-free host/tool/catalog introspection of protocol version,
   frame version, message counts, kernel-source counts, and specialised

--- a/code/packages/rust/executor-protocol/src/local.rs
+++ b/code/packages/rust/executor-protocol/src/local.rs
@@ -121,6 +121,7 @@ mod tests {
             supported_ops: 0,
             supported_dtypes: 0,
             gflops_f32: 0,
+            gflops_f64: 0,
             gflops_u8: 0,
             gflops_i32: 0,
             host_to_device_bw: 0,

--- a/code/packages/rust/executor-protocol/src/messages.rs
+++ b/code/packages/rust/executor-protocol/src/messages.rs
@@ -76,6 +76,13 @@ pub struct BackendProfile {
     pub supported_dtypes: u8,
     /// Compute throughput, peak, in floating-point GFLOPS scaled.
     pub gflops_f32: u32,
+    /// Throughput for f64 (double-precision) ops.  A backend with no
+    /// f64 kernel advertises 0 here, which the cost model reads as
+    /// infinite cost — keeping f64 work on a backend (the CPU) that can
+    /// run it.  CPUs typically set this to their f32 rate (or roughly
+    /// half, since double-precision SIMD lanes are wider); the synthetic
+    /// GPU profile leaves it 0.
+    pub gflops_f64: u32,
     /// Throughput for u8 element ops.
     pub gflops_u8: u32,
     /// Throughput for i32 element ops.
@@ -555,6 +562,7 @@ mod tests {
             supported_ops: 0,
             supported_dtypes: 0,
             gflops_f32: 0,
+            gflops_f64: 0,
             gflops_u8: 0,
             gflops_i32: 0,
             host_to_device_bw: 0,

--- a/code/packages/rust/executor-protocol/src/wire.rs
+++ b/code/packages/rust/executor-protocol/src/wire.rs
@@ -183,6 +183,7 @@ fn encode_profile(p: &BackendProfile, w: &mut Writer<'_>) {
     w.u32(p.supported_ops);
     w.u8(p.supported_dtypes);
     w.u32(p.gflops_f32);
+    w.u32(p.gflops_f64);
     w.u32(p.gflops_u8);
     w.u32(p.gflops_i32);
     w.u32(p.host_to_device_bw);
@@ -201,6 +202,7 @@ fn decode_profile(r: &mut Reader<'_>) -> Result<BackendProfile, WireError> {
         supported_ops: r.u32()?,
         supported_dtypes: r.u8()?,
         gflops_f32: r.u32()?,
+        gflops_f64: r.u32()?,
         gflops_u8: r.u32()?,
         gflops_i32: r.u32()?,
         host_to_device_bw: r.u32()?,

--- a/code/packages/rust/executor-protocol/tests/integration.rs
+++ b/code/packages/rust/executor-protocol/tests/integration.rs
@@ -25,6 +25,7 @@ fn stub_profile() -> BackendProfile {
         supported_ops: 0xFFFF_FFFF,
         supported_dtypes: 0x07,
         gflops_f32: 100,
+        gflops_f64: 88,
         gflops_u8: 50,
         gflops_i32: 75,
         host_to_device_bw: 12,

--- a/code/packages/rust/matrix-cpu/src/lib.rs
+++ b/code/packages/rust/matrix-cpu/src/lib.rs
@@ -68,6 +68,7 @@ pub fn profile() -> BackendProfile {
         // Supports F32 (bit 0), U8 (bit 1), I32 (bit 2).
         supported_dtypes: 0b0000_0111,
         gflops_f32: 40,
+        gflops_f64: 40, // MXF-1 gave the CPU f64 kernels; it runs them at ≈ its f32 rate
         gflops_u8: 60,
         gflops_i32: 50,
         host_to_device_bw: 100,    // host = device for CPU; effectively no transfer cost

--- a/code/packages/rust/matrix-cuda/src/lib.rs
+++ b/code/packages/rust/matrix-cuda/src/lib.rs
@@ -149,6 +149,7 @@ pub fn profile() -> BackendProfile {
         // (5_000 vs ~10 measured) — the planner uses this as a
         // floor, not a ceiling.
         gflops_f32: 10_000,
+        gflops_f64: 0, // no CUDA f64 kernel in V1 → planner keeps f64 on CPU
         gflops_u8: 0,
         gflops_i32: 0,
 

--- a/code/packages/rust/matrix-metal/src/lib.rs
+++ b/code/packages/rust/matrix-metal/src/lib.rs
@@ -137,6 +137,9 @@ pub fn profile() -> BackendProfile {
         // a conservative 5000 (5 TFLOPS) so the planner's threshold
         // err on the side of GPU when in doubt.
         gflops_f32: 5_000,
+        // No Metal f64 kernel (Apple GPUs lack native f64); 0 makes the
+        // cost model treat f64 as infinite here, so it stays on the CPU.
+        gflops_f64: 0,
         // Integer GFLOPS unused since we don't support integer dtypes
         // yet; planner uses these only for ops it routes to us.
         gflops_u8: 0,

--- a/code/packages/rust/matrix-runtime/CHANGELOG.md
+++ b/code/packages/rust/matrix-runtime/CHANGELOG.md
@@ -5,10 +5,25 @@ format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [unreleased] — MX12 f64 dtype
 
-### Changed — cost model accepts `DType::F64` (MX12)
+### Changed — cost model uses a dedicated `gflops_f64` rate (MXF-2)
 
-`compute_cost` handles `F64` (using the `f32` GFLOPS rate as a placeholder; MXF-2
-adds a dedicated `gflops_f64`), so graphs with `f64` tensors plan without panic.
+`compute_cost`'s `DType::F64` arm now reads `profile.gflops_f64` instead of the
+MXF-1 `gflops_f32` placeholder. A backend with no `f64` kernel advertises
+`gflops_f64 = 0`, which the existing `gflops == 0 → u64::MAX / 2` branch turns
+into the ∞-cost sentinel — so the planner keeps `f64` work on a backend (the CPU)
+that can actually run it, and never ships it to a GPU lacking an `f64` kernel. CPU
+profiles mirror their `f32` rate; the synthetic GPU profiles set `gflops_f64 = 0`.
+
+New tests: a giant `f64` matmul costs the ∞ sentinel on the GPU but a finite
+amount on the CPU; halving only `gflops_f64` doubles the `f64` cost (proving the
+arm reads its own field); and an `f64` matmul planned against a CPU + a faster
+GPU (which advertises `f64` capability but `gflops_f64 = 0`) lands on the CPU.
+
+### Changed — cost model accepts `DType::F64` (MXF-1)
+
+`compute_cost` handles `F64` (originally using the `f32` GFLOPS rate as a
+placeholder, replaced by `gflops_f64` in MXF-2 above), so graphs with `f64`
+tensors plan without panic.
 
 ## [0.10.0] — 2026-05-13
 

--- a/code/packages/rust/matrix-runtime/README.md
+++ b/code/packages/rust/matrix-runtime/README.md
@@ -39,7 +39,7 @@ use matrix_runtime::{Runtime, BackendProfile};
 let cpu = BackendProfile {
     kind: "cpu".to_string(),
     supported_ops: 0xFFFF_FFFF, supported_dtypes: 0x07,
-    gflops_f32: 40, gflops_u8: 40, gflops_i32: 40,
+    gflops_f32: 40, gflops_f64: 40, gflops_u8: 40, gflops_i32: 40,
     host_to_device_bw: 100, device_to_host_bw: 100, device_internal_bw: 100,
     launch_overhead_ns: 0, transport_latency_ns: 0,
     on_device_mib: 8 * 1024, max_tensor_rank: 16, max_dim: u32::MAX,
@@ -49,6 +49,7 @@ let mut rt = Runtime::new(cpu);
 let gpu = BackendProfile {
     kind: "gpu".to_string(),
     gflops_f32: 5_000, /* …125× faster… */
+    gflops_f64: 0, /* …no GPU f64 kernel → cost model keeps f64 on the CPU… */
     host_to_device_bw: 10, /* …slow PCIe… */
     ..rt.executors()[0].profile.clone()
 };

--- a/code/packages/rust/matrix-runtime/src/cost.rs
+++ b/code/packages/rust/matrix-runtime/src/cost.rs
@@ -135,12 +135,12 @@ pub enum TransferDirection {
 pub fn compute_cost(flops: u64, dtype: DType, profile: &BackendProfile) -> u64 {
     let gflops = match dtype {
         DType::F32 => profile.gflops_f32,
-        // MXF-1: f64 runs only on the CPU executor (no GPU f64 kernel yet), and
-        // the CPU's f64 throughput is ~its f32 throughput, so the f32 rate is a
-        // fair placeholder. MXF-2 adds a dedicated `gflops_f64` to the profile
-        // (CPU set, GPU left at 0 until a GPU f64 kernel exists) so the planner
-        // keeps f64 off GPUs that can't run it.
-        DType::F64 => profile.gflops_f32,
+        // MXF-2: f64 has its own throughput field.  A CPU sets it (≈ its f32
+        // rate); a backend with no f64 kernel — e.g. the synthetic GPU profile —
+        // leaves it 0, which the `gflops == 0` branch below turns into the
+        // ~infinite-cost sentinel, keeping f64 work on a backend that can
+        // actually run it.  This replaces the MXF-1 f32-rate placeholder.
+        DType::F64 => profile.gflops_f64,
         DType::U8 => profile.gflops_u8,
         DType::I32 => profile.gflops_i32,
     };
@@ -169,6 +169,7 @@ mod tests {
             supported_ops: 0xFFFF_FFFF,
             supported_dtypes: 0x07,
             gflops_f32: 40, // 40 GFLOPS
+            gflops_f64: 40, // CPU runs f64 at ≈ its f32 rate
             gflops_u8: 40,
             gflops_i32: 40,
             host_to_device_bw: 100, // bytes/ns; effectively no transfer cost
@@ -188,6 +189,7 @@ mod tests {
             supported_ops: 0xFFFF_FFFF,
             supported_dtypes: 0x07,
             gflops_f32: 5_000,
+            gflops_f64: 0, // no GPU f64 kernel → cost model treats f64 as ∞
             gflops_u8: 2_500,
             gflops_i32: 2_500,
             host_to_device_bw: 10, // bytes/ns = 10 GB/s
@@ -227,6 +229,39 @@ mod tests {
             + 2 * transfer_cost_ns(bytes, &gpu_profile(), TransferDirection::HostToDevice);
         // GPU should win even with 2 transfers.
         assert!(gpu_ns < cpu_ns, "GPU {} should beat CPU {}", gpu_ns, cpu_ns);
+    }
+
+    #[test]
+    fn f64_matmul_stays_on_cpu_even_when_large() {
+        // A 4096³ f64 matmul is enormous (137 G flops), yet it must stay on
+        // the CPU: the synthetic GPU advertises `gflops_f64 = 0`, so the cost
+        // model hands back the ∞ sentinel for the GPU and a finite cost for the
+        // CPU — CPU wins no matter how big the workload is.
+        let a = Tensor::new(TensorId(0), DType::F64, Shape::from(&[4096, 4096]));
+        let b = Tensor::new(TensorId(1), DType::F64, Shape::from(&[4096, 4096]));
+        let flops = estimate_matmul_flops(&a, &b);
+        let cpu_ns = compute_cost(flops, DType::F64, &cpu_profile());
+        let gpu_ns = compute_cost(flops, DType::F64, &gpu_profile());
+        let sentinel = u64::MAX / 2;
+        assert_eq!(gpu_ns, sentinel, "GPU f64 cost should be the ∞ sentinel");
+        assert!(
+            cpu_ns < sentinel,
+            "CPU f64 cost should be finite, not the sentinel: {cpu_ns}"
+        );
+        assert!(cpu_ns < gpu_ns, "CPU {cpu_ns} should beat GPU {gpu_ns} for f64");
+    }
+
+    #[test]
+    fn f64_uses_its_own_throughput_not_f32() {
+        // Halving only `gflops_f64` (leaving `gflops_f32` alone) must double the
+        // f64 cost — proving the F64 arm reads its own field, not the f32 rate.
+        let half_f64 = BackendProfile {
+            gflops_f64: 20,
+            ..cpu_profile()
+        };
+        let f32_ns = compute_cost(40_000, DType::F32, &cpu_profile());
+        let f64_ns = compute_cost(40_000, DType::F64, &half_f64);
+        assert_eq!(f64_ns, 2 * f32_ns, "f64 at half rate should cost double");
     }
 
     #[test]

--- a/code/packages/rust/matrix-runtime/src/planner.rs
+++ b/code/packages/rust/matrix-runtime/src/planner.rs
@@ -558,6 +558,7 @@ mod tests {
             supported_ops: 0xFFFF_FFFF,
             supported_dtypes: 0x07,
             gflops_f32: 40,
+            gflops_f64: 40,
             gflops_u8: 40,
             gflops_i32: 40,
             host_to_device_bw: 100,
@@ -618,6 +619,7 @@ mod tests {
             supported_ops: 0xFFFF_FFFF,
             supported_dtypes: 0x07,
             gflops_f32: 40,
+            gflops_f64: 40,
             gflops_u8: 40,
             gflops_i32: 40,
             host_to_device_bw: 100,
@@ -641,6 +643,7 @@ mod tests {
             // F32 only — matches matrix-metal V1.
             supported_dtypes: 0b001,
             gflops_f32: 5_000,
+            gflops_f64: 0,
             gflops_u8: 0,
             gflops_i32: 0,
             host_to_device_bw: 50,

--- a/code/packages/rust/matrix-runtime/src/registry.rs
+++ b/code/packages/rust/matrix-runtime/src/registry.rs
@@ -130,6 +130,7 @@ mod tests {
             supported_ops: ops,
             supported_dtypes: dtypes,
             gflops_f32: 100,
+            gflops_f64: 100,
             gflops_u8: 100,
             gflops_i32: 100,
             host_to_device_bw: 10,

--- a/code/packages/rust/matrix-runtime/src/runtime.rs
+++ b/code/packages/rust/matrix-runtime/src/runtime.rs
@@ -103,6 +103,7 @@ mod tests {
             supported_ops: 0xFFFF_FFFF,
             supported_dtypes: 0x07,
             gflops_f32: 40,
+            gflops_f64: 40,
             gflops_u8: 40,
             gflops_i32: 40,
             host_to_device_bw: 100,

--- a/code/packages/rust/matrix-runtime/tests/integration.rs
+++ b/code/packages/rust/matrix-runtime/tests/integration.rs
@@ -24,6 +24,7 @@ fn cpu_default() -> BackendProfile {
         supported_ops: 0xFFFF_FFFF,
         supported_dtypes: 0x07,
         gflops_f32: 40,
+        gflops_f64: 40,
         gflops_u8: 40,
         gflops_i32: 40,
         host_to_device_bw: 100,
@@ -43,6 +44,7 @@ fn fast_gpu() -> BackendProfile {
         supported_ops: 0xFFFF_FFFF,
         supported_dtypes: 0x07,
         gflops_f32: 5_000, // 125× faster than CPU
+        gflops_f64: 0,     // no GPU f64 kernel
         gflops_u8: 2_500,
         gflops_i32: 2_500,
         host_to_device_bw: 10, // Slow PCIe
@@ -325,4 +327,55 @@ fn plan_function_works_with_registry() {
 
     let placed = plan(&g, &r).expect("plan");
     placed.validate().expect("validates");
+}
+
+// ─────────────────── f64 cost-model routing (MXF-2) ───────────────────
+
+/// An f64 matmul must land on the CPU even when a much faster GPU is
+/// registered: the GPU advertises f64 *capability* but `gflops_f64 = 0`,
+/// so the cost model assigns it the ∞-cost sentinel and the planner keeps
+/// the work on the CPU — the only backend with a real f64 kernel.
+#[test]
+fn f64_matmul_plans_onto_cpu_not_gpu() {
+    // Both profiles must *claim* f64 support (bit 5, since `DType::F64`'s wire
+    // tag is `0x05`) so the capability filter passes and the decision falls to
+    // cost.  Without this, f64 would reach the CPU via the fallback path and
+    // never exercise the cost model at all.
+    const F64_BIT: u8 = 1 << 5;
+    let mut cpu = cpu_default();
+    cpu.supported_dtypes |= F64_BIT; // CPU has the f64 kernel + throughput
+    let mut gpu = fast_gpu();
+    gpu.supported_dtypes |= F64_BIT; // GPU claims f64 but `gflops_f64 == 0`
+
+    let mut rt = Runtime::new(cpu);
+    let gpu_id = rt.register("gpu", gpu);
+
+    let mut g = GraphBuilder::new();
+    let a = g.input(DType::F64, Shape::from(&[4096, 4096]));
+    let b = g.input(DType::F64, Shape::from(&[4096, 4096]));
+    let c = g.matmul(&a, &b);
+    g.output(&c);
+    let g = g.build().unwrap();
+
+    let placed = rt.plan(&g).expect("plan");
+    placed.validate().expect("validates");
+
+    let mm_executor = placed.ops.iter().find_map(|o| match o {
+        PlacedOp::Compute {
+            op: Op::MatMul { .. },
+            executor,
+            ..
+        } => Some(*executor),
+        _ => None,
+    });
+    assert_eq!(
+        mm_executor,
+        Some(CPU_EXECUTOR),
+        "f64 matmul must stay on CPU even with a faster GPU present"
+    );
+    assert_ne!(
+        mm_executor,
+        Some(gpu_id),
+        "f64 must not ship to the f64-less GPU"
+    );
 }

--- a/code/specs/MX12-f64-dtype.md
+++ b/code/specs/MX12-f64-dtype.md
@@ -37,12 +37,14 @@ a redesign.
 
 ## §2 The rollout (one item = one PR)
 
-- **MXF-1 — `matrix-ir` `F64` + `matrix-cpu` kernels** *(this PR)*. The dtype
+- **MXF-1 — `matrix-ir` `F64` + `matrix-cpu` kernels** *(shipped)*. The dtype
   itself plus a working CPU executor, so an `f64` graph **builds, validates, and
   executes exactly** on CPU end-to-end.
-- **MXF-2 — `matrix-runtime` cost model.** A `gflops_f64` throughput on
+- **MXF-2 — `matrix-runtime` cost model** *(this PR)*. A `gflops_f64` throughput on
   `BackendProfile` and an `F64` arm in the cost model, so the planner places
-  `f64` ops on the cheapest backend (typically ~½ the `f32` GPU throughput).
+  `f64` ops on the cheapest backend that can actually run them — a backend with
+  no `f64` kernel advertises `gflops_f64 = 0`, which the cost model turns into the
+  ∞-cost sentinel, keeping `f64` on the CPU.
 - **MXF-3 — `array-runtime` `f64` path.** Lower `Array`s to an `F64` graph and
   add an 8-byte codec, so `execute` keeps the exact `f64` answer (no `f32`
   round-trip). The reference `ops` path and the executed path now agree to full
@@ -80,7 +82,31 @@ a redesign.
   would round (e.g. a sum that is not representable in `f32`), proving the new
   path is genuinely double-precision.
 
-## §4 Out of scope (later items / future)
+## §4 MXF-2 — what this PR delivers
+
+### `executor-protocol`
+- A `gflops_f64: u32` field on `BackendProfile`, sitting next to `gflops_f32`,
+  with matching `encode_profile`/`decode_profile` wire I/O (one extra `u32`,
+  inserted symmetrically so the round-trip stays balanced). Every constructor of
+  the profile — the CPU/CUDA/Metal executor defaults, the runtime/registry/test
+  stubs — sets it: CPUs to their `f32` rate, GPUs (no `f64` kernel in V1) to `0`.
+
+### `matrix-runtime`
+- `compute_cost`'s per-dtype rate selection now reads `profile.gflops_f64` for
+  `DType::F64`, replacing the MXF-1 placeholder that reused `gflops_f32`. The
+  existing `gflops == 0 → u64::MAX / 2` branch then makes an `f64` op on a
+  backend with no `f64` throughput cost *infinity*, so the planner never ships
+  `f64` to a GPU that can't run it.
+
+### Tests
+- Unit: a 4096³ `f64` matmul costs the ∞ sentinel on the GPU profile but a
+  finite amount on the CPU; halving only `gflops_f64` doubles the `f64` cost,
+  proving the F64 arm reads its own field rather than the `f32` rate.
+- Integration: an `f64` matmul planned against a CPU + a *faster* GPU (that
+  advertises `f64` capability but `gflops_f64 = 0`) lands on the CPU — the
+  decision falls through to cost, not the capability filter.
+
+## §5 Out of scope (later items / future)
 
 - The GPU (CUDA/Metal) executors gaining `f64` kernels — MXF-1/-3 keep `f64` on
   the CPU executor; the planner (MXF-2) simply won't place `f64` on a GPU that
@@ -88,7 +114,7 @@ a redesign.
 - `F16`/`I64` (the other reserved wire tags).
 - The specialiser fast path for `f64`.
 
-## §5 References
+## §6 References
 
 Internal: [`MX00`](MX00-matrix-execution-overview.md),
 [`MX01`](MX01-matrix-ir.md), [`MX03`](MX03-executor-protocol.md),


### PR DESCRIPTION
## MXF-2 — `matrix-runtime` cost model for `f64`

Second item in the **MX12** rollout (f64 across the matrix substrate). MXF-1 added `DType::F64` + working `matrix-cpu` kernels; this PR teaches the **planner's cost model** about f64 so it routes f64 work to a backend that can actually run it.

### What changed

**`executor-protocol`**
- New `gflops_f64: u32` field on `BackendProfile`, beside `gflops_f32`.
- `encode_profile`/`decode_profile` gain one symmetric extra `u32` right after `gflops_f32` (the `BackendProfile` wire layout changes — both ends must build from this version).
- Every constructor sets it: CPU executors mirror their f32 rate; the CUDA/Metal GPU profiles (no f64 kernel in V1) and the no-op stubs set `0`.

**`matrix-runtime`**
- `compute_cost`'s `DType::F64` arm now reads `profile.gflops_f64` instead of the MXF-1 `gflops_f32` placeholder. A backend advertising `gflops_f64 = 0` hits the existing `gflops == 0 → u64::MAX / 2` branch, so its f64 cost is the ∞ sentinel — the planner keeps f64 on the CPU and never ships it to a GPU lacking an f64 kernel.

### Tests
- **Unit:** a 4096³ f64 matmul costs the ∞ sentinel on the GPU profile but a finite amount on the CPU; halving only `gflops_f64` doubles the f64 cost (proving the arm reads its own field, not the f32 rate).
- **Integration:** an f64 matmul planned against a CPU + a *faster* GPU that advertises f64 capability but `gflops_f64 = 0` lands on the CPU — the decision falls through to **cost**, not the capability filter.

### Notes
- Spec `MX12-f64-dtype.md` updated (MXF-1 marked shipped, MXF-2 = this PR, new §4 delivers section).
- CHANGELOGs (executor-protocol, matrix-runtime) + matrix-runtime README updated.
- `/security-review` passed (Rust): wire decode is bounds-checked (`need(4)` before read); cost model's `gflops == 0` guard precedes the division — no OOB read, no divide-by-zero.
- Diff is functional-only — no rustfmt churn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)