### PR TITLE
feat(visicalc-xaml): wire drag-fill into the infinite-sheet demo

### DIFF
--- a/demo/visicalc-xaml/Engine.cs
+++ b/demo/visicalc-xaml/Engine.cs
@@ -61,6 +61,12 @@ internal static class ScNative
     internal static extern void sc_set_format(IntPtr s,
         [MarshalAs(UnmanagedType.LPUTF8Str)] string a1,
         [MarshalAs(UnmanagedType.LPUTF8Str)] string code);
+    // sc_fill(session, src, dst_start, dst_end) → void (drag-fill; three A1 strings).
+    [DllImport("spreadsheet_capi")]
+    internal static extern void sc_fill(IntPtr s,
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string src,
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string dstStart,
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string dstEnd);
     [DllImport("spreadsheet_capi")] internal static extern IntPtr sc_used_range(IntPtr s);
     [DllImport("spreadsheet_capi")] internal static extern IntPtr sc_column_letters(IntPtr s, uint index);
     [DllImport("spreadsheet_capi")] internal static extern ulong sc_current_revision(IntPtr s);
@@ -118,6 +124,14 @@ public sealed class SpreadsheetSession : IDisposable
     /// "0%"); an empty code clears it. Drives the engine's display path that
     /// <see cref="Window"/> reads through sc_get_display_window.
     public void SetFormat(string a1, string code) => ScNative.sc_set_format(_handle, a1, code);
+
+    /// Drag-fill: replicate the `src` cell across the inclusive A1 rectangle
+    /// `dstStart`..`dstEnd`. Relative references shift per target (`=A1` filled
+    /// one row down becomes `=A2`), absolute (`$`) refs pin, off-grid refs become
+    /// `#REF!`; the source's display format rides along. The engine recomputes
+    /// every dependent. Reaches sc_fill — the same path every other backend drives.
+    public void Fill(string src, string dstStart, string dstEnd) =>
+        ScNative.sc_fill(_handle, src, dstStart, dstEnd);
 
     /// The display string for a cell — what a spreadsheet should show. Parses
     /// the engine's JSON (the fixed shape every backend's engine emits).
@@ -429,6 +443,27 @@ public sealed class InfiniteSheetModel : IDisposable
         _session.SetCell(InfAddress, raw);
         ComputeExtent();
         Formula = _session.GetRaw(InfAddress);
+    }
+
+    /// Drag-fill: replicate the selected cell into the `rows` rows below it. The
+    /// engine shifts each copy's relative references (`=A1`→`=A2`, …), pins
+    /// absolute (`$`) refs, carries the format, and recomputes every dependent.
+    /// Regrows the extent if the fill reached new ground. The .NET sibling of the
+    /// Flutter/Compose `FillDown` and the Qt "Fill ↓ 10" button.
+    public void FillDown(int rows)
+    {
+        string col = _session.ColumnLetters((uint)SelCol);
+        // Widen the row arithmetic to `long` and saturate back into a valid row
+        // before building the A1 strings. SelRow is clamped to [1, TotalRows] but
+        // TotalRows can be up to int.MaxValue, so `SelRow + rows` would otherwise
+        // overflow to a negative row (the same u32-overflow-defeats-cap hazard the
+        // Saturate helper guards) and emit a malformed address. Saturate clamps to
+        // [1, int.MaxValue]; the engine treats any off-grid target as #REF! and
+        // ComputeExtent() below regrows the virtual grid to cover the fill.
+        int first = Saturate((long)SelRow + 1, floor: 1);
+        int last = Saturate((long)SelRow + rows, floor: 1);
+        _session.Fill(InfAddress, $"{col}{first}", $"{col}{last}");
+        ComputeExtent();
     }
 
     public void Dispose() => _session.Dispose();

--- a/demo/visicalc-xaml/InfiniteSheet.xaml
+++ b/demo/visicalc-xaml/InfiniteSheet.xaml
@@ -32,11 +32,13 @@
             <RowDefinition Height="*"/>
         </Grid.RowDefinitions>
 
-        <!-- Formula bar: the selected cell's address + an editable source line. -->
+        <!-- Formula bar: the selected cell's address + an editable source line,
+             plus a "Fill ↓ 10" button that drag-fills the selection down. -->
         <Grid Grid.Row="0" Margin="0,0,0,6">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="64"/>
                 <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="Auto"/>
             </Grid.ColumnDefinitions>
             <TextBlock x:Name="AddressText" Grid.Column="0"
                        VerticalAlignment="Center"
@@ -45,6 +47,13 @@
                      Background="#2D2D30" Foreground="#CCCCCC" BorderBrush="#3F3F46"
                      FontSize="13" FontFamily="Consolas"
                      KeyDown="FormulaBox_KeyDown"/>
+            <!-- Drag-fill: replicate the selected cell into the 10 rows below it. -->
+            <Button x:Name="FillButton" Grid.Column="2" Margin="8,0,0,0" Height="28"
+                    Background="#2D2D30" Foreground="#CCCCCC" BorderBrush="#3F3F46"
+                    BorderThickness="1" FontSize="12" FontFamily="Consolas"
+                    Content="Fill ↓ 10"
+                    ToolTipService.ToolTip="Replicate the selected cell into the 10 rows below it"
+                    Click="FillButton_Click"/>
         </Grid>
 
         <!-- Column-letter header (frozen vertically, follows horizontal pan). -->

--- a/demo/visicalc-xaml/InfiniteSheet.xaml.cs
+++ b/demo/visicalc-xaml/InfiniteSheet.xaml.cs
@@ -173,6 +173,15 @@ public sealed partial class InfiniteSheet : UserControl
         e.Handled = true;
     }
 
+    /// Drag-fill: replicate the selected cell into the 10 rows below it. The
+    /// engine shifts each copy's relative refs, pins absolute ($) refs, carries
+    /// the format, and recomputes every dependent; then repaint the visible rows.
+    private void FillButton_Click(object sender, RoutedEventArgs e)
+    {
+        _model.FillDown(10);
+        RepaintRealizedRows();
+    }
+
     private void RefreshFormulaBar()
     {
         AddressText.Text = _model.InfAddress;

--- a/demo/visicalc-xaml/README.md
+++ b/demo/visicalc-xaml/README.md
@@ -145,6 +145,10 @@ row-number gutter is a second virtualized `ListView` slaved to the body's
 vertical scroll, and the column-letter header follows the body's horizontal pan.
 Tap a cell → `SelectInf` (clamps, loads the source into the formula bar); press
 Enter → `CommitInf` (writes through, recomputes dependents, regrows the extent).
+The **"Fill ↓ 10"** button next to the formula bar calls
+`InfiniteSheetModel.FillDown(10)` (over the C ABI's `sc_fill`) to replicate the
+selected cell into the 10 rows below it — the engine shifts each copy's relative
+references (`=A1`→`=A2`, …), pins absolute (`$`) refs, and carries the format.
 
 `InfiniteSheetModel` (in `Engine.cs`, WinUI-free) seeds far-flung sparse cells
 (`Z1000`, `BA50`, `BB50`) and derives the extent from `UsedRange()` + a margin

--- a/demo/visicalc-xaml/test/Program.cs
+++ b/demo/visicalc-xaml/test/Program.cs
@@ -124,6 +124,20 @@ using (var inf = new InfiniteSheetModel())
     Check("inf commit E2", inf.RowCells(2)[4], "151.00"); // 108+14+7+22, formatted
     Check("inf commit A5", inf.RowCells(5)[0], "139.00"); // 15+108+12+4, formatted
     Check("inf commit E5", inf.RowCells(5)[4], "269.00"); // grand total, formatted
+
+    // FillDown replicates the selected cell, shifting relative refs per target.
+    // Seed a fresh column via select+commit: H1=2, H2=3, H3=4 (col 8 = H);
+    // I1 = H1*10 (col 9 = I). Select I1 and fill down 10 — each filled formula
+    // tracks its row (I2 = H2*10 = 30, I3 = H3*10 = 40), and I1 stays untouched.
+    inf.SelectInf(1, 8); inf.CommitInf("2");        // H1
+    inf.SelectInf(2, 8); inf.CommitInf("3");        // H2
+    inf.SelectInf(3, 8); inf.CommitInf("4");        // H3
+    inf.SelectInf(1, 9); inf.CommitInf("=H1*10");   // I1 = 20
+    inf.SelectInf(1, 9);
+    inf.FillDown(10);
+    Check("inf fillDown I2", inf.RowCells(2)[8], "30"); // I2 = H2*10
+    Check("inf fillDown I3", inf.RowCells(3)[8], "40"); // I3 = H3*10
+    Check("inf fillDown I1 source", inf.RowCells(1)[8], "20"); // I1 untouched
 }
 
 Console.WriteLine(failures == 0 ? "\nALL PASS" : $"\n{failures} FAILURE(S)");


### PR DESCRIPTION
Adds the **"Fill ↓ 10"** drag-fill action to the WinUI 3 / XAML VisiCalc infinite-sheet demo, computing on the shared Rust `spreadsheet-core` engine through its C ABI (`sc_fill`) via P/Invoke — the .NET sibling of the SwiftUI/Qt/Flutter/Compose buttons and the web demo's fill. Completes the **5th of 6** backends in the cross-backend drag-fill rollout (engine #6048, facades #6057, web #6082, Qt #6086, Flutter #6089, Compose #6094); SwiftUI is the last.

## Changes
- **`Engine.cs`** — `sc_fill` P/Invoke (void; `src`/`dst_start`/`dst_end` `LPUTF8Str` A1 strings), `SpreadsheetSession.Fill`, and `InfiniteSheetModel.FillDown(rows)` (src = selected cell, dst = the `rows` cells below; regrows the extent). The engine shifts each copy's relative references (`=A1`→`=A2`), pins absolute (`$`) refs, carries the display format, and recomputes every dependent. The row arithmetic is widened to `long` and saturated via the existing `Saturate` helper so `SelRow + rows` can't overflow to a negative row (the u32-overflow-defeats-cap hazard).
- **`InfiniteSheet.xaml` / `.xaml.cs`** — a "Fill ↓ 10" `Button` in the formula-bar grid (third `Auto` column); its `Click` handler calls `FillDown(10)` and repaints the realized rows.
- **`test/Program.cs`** — headless `fillDown` proof: seed `H1`/`H2`/`H3` + `I1 = =H1*10`, fill `I1` down 10 rows ⇒ `I2 = H2*10 = 30`, `I3 = H3*10 = 40`, source `I1 = 20` untouched.
- **`README.md`** — documents the Fill button.

## Verification
`scripts/verify.sh` (.NET P/Invoke console harness, vendored dylib) — **ALL PASS**, including the three new `fillDown` checks (I2=30, I3=40, I1=20). The WinUI view itself is Windows-only, so the headless harness is the canonical proof here (matching the demo's existing boundary). `/security-review` passed in 2 rounds — round 1 flagged a LOW integer-overflow in `FillDown` (`SelRow + rows`), fixed with the `long`-widened `Saturate` clamp; round 2 clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)