### PR TITLE
feat(r-15): names() and named-vector access

### DIFF
--- a/code/packages/rust/r-runtime/CHANGELOG.md
+++ b/code/packages/rust/r-runtime/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.10.0] - 2026-06-17
+
+### Added (via the shared `s-runtime`)
+
+- **R-15 — `names()` and named-vector access**: `c(a = 1, b = 2)` attaches names
+  (nested named pieces combine R-style — `c(x = c(a = 1), 2)` → `"x.a"`, `""`);
+  `names(x)` gets them (`NULL` if unset); `names(x) <- value` sets them with R's
+  NA-padding recycling (`NULL` clears); `setNames(x, nm)` is the functional form;
+  `x["b"]` / `x[c("a","c")]` index by name (unmatched → `NA`). Positional /
+  negative / logical indexing still work and carry names along; sub-assignment
+  (`x[2] <- 9`, `x["a"] <- 5`) keeps names; arithmetic drops them, as in R. Named
+  vectors print names above values in aligned columns instead of the `[i]` prefix
+  — a user-visible change in the R REPL. See `s-runtime` 0.11.0.
+
 ## [0.9.0] - 2026-06-16
 
 ### Added (via the shared `s-runtime` lvalue machinery)

--- a/code/packages/rust/r-runtime/README.md
+++ b/code/packages/rust/r-runtime/README.md
@@ -19,10 +19,15 @@ R source ──▶ r_parser::try_parse_r ──▶ GrammarASTNode
                                          Outcome
 ```
 
-The value model, recycling, NA semantics, S3 dispatch, factors, data frames, and
-every built-in are exactly those of `s-runtime` — R gets them for free. The
-R-specific surface (the `=` / `->>` assignment operators and the typed-`NA`
-constants) is handled in the shared evaluator.
+The value model, recycling, NA semantics, S3 dispatch, factors, data frames,
+matrices, named vectors, and every built-in are exactly those of `s-runtime` — R
+gets them for free. The R-specific surface (the `=` / `->>` assignment operators
+and the typed-`NA` constants) is handled in the shared evaluator.
+
+Recent additions reach R unchanged through this reuse: **named vectors (R-15)** —
+`c(a = 1, b = 2)` attaches names, `names(x)` / `names(x) <- value` /
+`setNames(x, nm)` get and set them, `x["b"]` indexes by name, and a named vector
+prints names above values instead of the `[i]` prefix.
 
 ## Usage
 

--- a/code/packages/rust/r-runtime/src/lib.rs
+++ b/code/packages/rust/r-runtime/src/lib.rs
@@ -84,7 +84,9 @@ mod tests {
     }
 
     fn nums(src: &str) -> Vec<f64> {
-        match eval_r(src).unwrap() {
+        // See through a names attribute (R-15): a named numeric is still numeric.
+        let value = eval_r(src).unwrap();
+        match value.strip_names() {
             SValue::Double(d) => d.data().to_vec(),
             other => panic!("expected double, got {}", other.type_name()),
         }
@@ -670,6 +672,178 @@ mod tests {
         assert_eq!(
             nums("a <- c(1, 2, 3)\nb <- a\na[1] <- 99\nb\n"),
             vec![1.0, 2.0, 3.0]
+        );
+    }
+
+    // --- R-15: names() and named-vector access --------------------------
+
+    /// The names of a value as a vector of strings (an NA name → the literal
+    /// string "NA"), for assertions; panics if `x` has no names.
+    fn names_of(src: &str) -> Vec<String> {
+        match eval_r(src).unwrap() {
+            SValue::Character(v) => v
+                .into_iter()
+                .map(|o| o.unwrap_or_else(|| "NA".to_string()))
+                .collect(),
+            other => panic!("expected character names, got {}", other.type_name()),
+        }
+    }
+
+    #[test]
+    fn named_construction_attaches_argument_names() {
+        // c(a = 1, b = 2, c = 3) attaches the names; the values are unchanged.
+        assert_eq!(nums("c(a = 1, b = 2, c = 3)\n"), vec![1.0, 2.0, 3.0]);
+        assert_eq!(
+            names_of("names(c(a = 1, b = 2, c = 3))\n"),
+            vec!["a", "b", "c"]
+        );
+        // A vector with no names anywhere stays unnamed → names() is NULL.
+        assert_eq!(show("names(c(1, 2, 3))\n"), "NULL");
+    }
+
+    #[test]
+    fn named_construction_combines_nested_names_r_style() {
+        // c(x = c(a = 1), 2): the named element of a named piece is "x.a"; the
+        // bare second element is unnamed (empty string).
+        assert_eq!(names_of("names(c(x = c(a = 1), 2))\n"), vec!["x.a", ""]);
+        // A tagged multi-element argument with no inner names → tag + position.
+        assert_eq!(names_of("names(c(p = c(1, 2)))\n"), vec!["p1", "p2"]);
+        // An inner-named, untagged argument keeps the inner names verbatim.
+        assert_eq!(
+            names_of("names(c(c(a = 1, b = 2), 3))\n"),
+            vec!["a", "b", ""]
+        );
+    }
+
+    #[test]
+    fn names_get_and_set_and_clear() {
+        // names(x) <- value sets the names.
+        assert_eq!(
+            names_of("x <- c(1, 2, 3)\nnames(x) <- c(\"a\", \"b\", \"c\")\nnames(x)\n"),
+            vec!["a", "b", "c"]
+        );
+        // A too-short names vector NA-pads the tail.
+        assert_eq!(
+            names_of("x <- c(1, 2, 3)\nnames(x) <- c(\"a\")\nnames(x)\n"),
+            vec!["a", "NA", "NA"]
+        );
+        // names(x) <- NULL drops the names entirely.
+        assert_eq!(
+            show("x <- c(a = 1, b = 2)\nnames(x) <- NULL\nnames(x)\n"),
+            "NULL"
+        );
+        // The values survive a names round-trip.
+        assert_eq!(
+            nums("x <- c(1, 2, 3)\nnames(x) <- c(\"a\", \"b\", \"c\")\nx\n"),
+            vec![1.0, 2.0, 3.0]
+        );
+    }
+
+    #[test]
+    fn names_set_rejects_too_many_names() {
+        // A names vector longer than the value is an error (R's length rule).
+        assert!(eval_r("x <- c(1, 2)\nnames(x) <- c(\"a\", \"b\", \"c\")\n").is_err());
+    }
+
+    #[test]
+    fn set_names_functional_form() {
+        assert_eq!(
+            names_of("names(setNames(c(1, 2), c(\"a\", \"b\")))\n"),
+            vec!["a", "b"]
+        );
+        assert_eq!(
+            nums("setNames(c(10, 20), c(\"x\", \"y\"))\n"),
+            vec![10.0, 20.0]
+        );
+    }
+
+    #[test]
+    fn character_indexing_hits_and_misses() {
+        // x["b"] selects by name.
+        assert_eq!(nums("x <- c(a = 1, b = 2, c = 3)\nx[\"b\"]\n"), vec![2.0]);
+        // A vector of names selects several, in order.
+        assert_eq!(
+            nums("x <- c(a = 1, b = 2, c = 3)\nx[c(\"a\", \"c\")]\n"),
+            vec![1.0, 3.0]
+        );
+        // An unmatched name yields NA (value) and an NA name.
+        assert_eq!(show("x <- c(a = 1, b = 2)\nx[\"z\"]\n"), "<NA>\n  NA");
+        // The selected names come along.
+        assert_eq!(
+            names_of("x <- c(a = 1, b = 2, c = 3)\nnames(x[c(\"c\", \"a\")])\n"),
+            vec!["c", "a"]
+        );
+    }
+
+    #[test]
+    fn positional_negative_logical_indexing_still_work_on_named() {
+        let setup = "x <- c(a = 1, b = 2, c = 3)\n";
+        // Positional keeps names along.
+        assert_eq!(nums(&format!("{setup}x[c(1, 3)]\n")), vec![1.0, 3.0]);
+        assert_eq!(
+            names_of(&format!("{setup}names(x[c(1, 3)])\n")),
+            vec!["a", "c"]
+        );
+        // Negative excludes.
+        assert_eq!(nums(&format!("{setup}x[-2]\n")), vec![1.0, 3.0]);
+        // Logical masks.
+        assert_eq!(
+            nums(&format!("{setup}x[c(TRUE, FALSE, TRUE)]\n")),
+            vec![1.0, 3.0]
+        );
+    }
+
+    #[test]
+    fn unnamed_vector_indexing_unchanged() {
+        // Regression: the R-13/R-14 plain-vector behavior is untouched.
+        assert_eq!(nums("c(10, 20, 30)[-2]\n"), vec![10.0, 30.0]);
+        assert_eq!(
+            nums("c(10, 20, 30)[c(TRUE, FALSE, TRUE)]\n"),
+            vec![10.0, 30.0]
+        );
+        assert_eq!(nums("c(10, 20, 30)[2]\n"), vec![20.0]);
+    }
+
+    #[test]
+    fn named_vector_prints_names_above_values() {
+        // Two aligned rows: names, then values. Column widths fit the wider cell.
+        assert_eq!(show("c(a = 1, b = 2, c = 3)\n"), "a b c\n1 2 3");
+        // Wider value column widens the name column too.
+        assert_eq!(show("c(x = 100, y = 2)\n"), "  x y\n100 2");
+    }
+
+    #[test]
+    fn names_survive_index_assignment_and_drop_through_arithmetic() {
+        // Sub-assignment into a named vector keeps the names.
+        assert_eq!(
+            names_of("x <- c(a = 1, b = 2, c = 3)\nx[2] <- 9\nnames(x)\n"),
+            vec!["a", "b", "c"]
+        );
+        assert_eq!(
+            nums("x <- c(a = 1, b = 2, c = 3)\nx[2] <- 9\nx\n"),
+            vec![1.0, 9.0, 3.0]
+        );
+        // Character-index assignment writes the named element.
+        assert_eq!(
+            nums("x <- c(a = 1, b = 2)\nx[\"a\"] <- 5\nx\n"),
+            vec![5.0, 2.0]
+        );
+        // Arithmetic drops names (R semantics): names() of x + 1 is NULL.
+        assert_eq!(show("x <- c(a = 1, b = 2)\nnames(x + 1)\n"), "NULL");
+        // length() sees through the names wrapper.
+        assert_eq!(nums("length(c(a = 1, b = 2, c = 3))\n"), vec![3.0]);
+    }
+
+    #[test]
+    fn named_character_vector_round_trips() {
+        // Names work on a character vector too.
+        assert_eq!(
+            show("x <- c(first = \"hi\", second = \"yo\")\nx[\"second\"]\n"),
+            "second\n  \"yo\""
+        );
+        assert_eq!(
+            names_of("names(c(first = \"hi\", second = \"yo\"))\n"),
+            vec!["first", "second"]
         );
     }
 }

--- a/code/packages/rust/s-runtime/CHANGELOG.md
+++ b/code/packages/rust/s-runtime/CHANGELOG.md
@@ -2,6 +2,41 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.11.0] - 2026-06-17
+
+### Added
+
+- **Named vectors / the `names` attribute (R-15)** — a new transparent wrapper
+  `SValue::Named { names, values }` carries a parallel `Vec<Option<String>>` of
+  element names beside a boxed atomic value (`Double`/`Logical`/`Character`). Like
+  `SValue::Classed` it is *see-through*: `length`, `type_name`, `class_of`, the
+  coercions, `arithmetic`, `compare`, and `truthy` all delegate to the inner
+  value, so names drop exactly where R drops them and survive where R keeps them.
+  - `c(a = 1, b = 2)` attaches argument tags; nested named pieces combine R-style
+    (`c(x = c(a = 1), 2)` → names `"x.a"`, `""`; `c(p = c(1, 2))` → `"p1"`, `"p2"`).
+    `combine` builds names only when some argument is tagged or already named.
+  - `names(x)` returns the character names (or `NULL`); the `names<-` replacement
+    function sets them with R's NA-padding recycling (too-short pads with `NA`,
+    too-long is an error, `NULL` clears), and `setNames(x, nm)` is the functional
+    form. A general **replacement-function lvalue path** in the evaluator desugars
+    `f(x) <- v` to ``x <- `f<-`(x, v)`` (reusable for future `levels<-`/`dim<-`).
+  - **Character indexing** `x["b"]` / `x[c("a","c")]` selects by name (unmatched →
+    `NA`); a `resolve_picks_named` helper extends `resolve_picks` with the
+    by-name path. Positional / negative / logical indexing still work and now
+    **carry the selected names along**. `assign_index` keeps names through
+    `v[i] <- val` and resolves a character subscript by name.
+  - **Printing** lays a named vector out R-style — right-aligned names above
+    right-aligned values, each column the wider of the two — instead of the `[i]`
+    prefix; an unset name prints `<NA>`.
+
+### Safety
+
+- The names vector is always kept exactly as long as the values (every
+  constructor truncates / `NA`-pads via `with_names`), so a name lookup can never
+  index out of bounds; the by-name index path reuses the bounded `resolve_picks`.
+  No new unbounded allocation or integer-overflow surface — name lengths ride the
+  same vector-length channels already capped at `MAX_SEQ_LEN`.
+
 ## [0.10.0] - 2026-06-16
 
 ### Added

--- a/code/packages/rust/s-runtime/README.md
+++ b/code/packages/rust/s-runtime/README.md
@@ -34,6 +34,12 @@ s-lexer → s-parser → GrammarASTNode → s-runtime (this crate) → s-repl
 - **Index sub-assignment** (R-14): the left side of `<-` may be a subscript,
   e.g. `v[i] <- x`, `v[-i] <- x`, `m[i, j] <- x`, `m[, j] <- x` — copy-on-modify,
   RHS recycled, so a prior `b <- a` copy is never aliased.
+- **Named vectors / the `names` attribute** (R-15): `c(a = 1, b = 2)` attaches
+  names (nested named pieces combine R-style), `names(x)` gets them and
+  `names(x) <- value` / `setNames(x, nm)` set them (NA-pad short, `NULL` clears),
+  `x["b"]` indexes by name, and a named vector prints names above values. Names
+  are a transparent `SValue::Named` wrapper — they ride through indexing and drop
+  through arithmetic, exactly as in R.
 - The **`d`/`p`/`q`/`r` distribution family** (R-8) over `statistics-core`:
   density/CDF/quantile/sampling for the normal, uniform, and exponential
   distributions, plus `set.seed` for a reproducible per-session RNG.

--- a/code/packages/rust/s-runtime/src/builtins.rs
+++ b/code/packages/rust/s-runtime/src/builtins.rs
@@ -163,6 +163,9 @@ pub fn install(env: &Env) {
     define(env, "ncol", builtin("ncol", b_ncol));
     define(env, "names", builtin("names", b_names));
     define(env, "colnames", builtin("colnames", b_names));
+    // The `names(x) <- value` replacement function and its functional form.
+    define(env, "names<-", builtin("names<-", b_set_names_replace));
+    define(env, "setNames", builtin("setNames", b_set_names));
     define(env, "dim", builtin("dim", b_dim));
     define(env, "head", builtin("head", b_head));
 
@@ -246,14 +249,74 @@ fn b_ncol(_interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
     }
 }
 
-/// `names(df)` / `colnames(df)` — the column names.
+/// `names(x)` / `colnames(df)` — the names of `x`. For a data frame these are the
+/// column names; for a **named vector** (R-15) they are the element names (an
+/// unset name → `NA`). Anything without names is `NULL`.
 fn b_names(_interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
     match first_positional(args)? {
         SValue::DataFrame { names, .. } => {
             Ok(SValue::Character(names.iter().cloned().map(Some).collect()))
         }
+        SValue::Named { names, .. } => Ok(SValue::Character(names.clone())),
         _ => Ok(SValue::Null),
     }
+}
+
+/// `names<-`(x, value)` — the replacement form behind `names(x) <- value`
+/// (R-15). Coerces `value` to character and attaches it as `x`'s names, R-style:
+/// a too-short names vector pads the tail with `NA`, a too-long one is an error,
+/// and `value = NULL` drops the names entirely. Names attach only to atomic
+/// vectors; on any other value the names are silently ignored (R errors, but
+/// this subset keeps it lenient and returns the value unchanged).
+fn b_set_names_replace(_interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
+    // The replacement convention passes (x, value): x is positional[0], the new
+    // names are the `value =` named arg (or positional[1]).
+    let x = first_positional(args)?.clone();
+    let value = args
+        .iter()
+        .find(|a| a.name.as_deref() == Some("value"))
+        .map(|a| &a.value)
+        .or_else(|| nth_positional(args, 1));
+
+    match value {
+        // `names(x) <- NULL` clears the names.
+        None | Some(SValue::Null) => Ok(x.strip_names().clone()),
+        Some(v) => {
+            let new_names = v.as_character();
+            // Reject a names vector longer than the value (R's
+            // "'names' attribute must be the same length as the vector" — except
+            // R actually allows shorter with NA-pad; longer is the error).
+            if new_names.len() > x.length() {
+                return Err(SError::BadArgs(format!(
+                    "'names' attribute [{}] must be no longer than the vector [{}]",
+                    new_names.len(),
+                    x.length()
+                )));
+            }
+            Ok(SValue::with_names(x, new_names))
+        }
+    }
+}
+
+/// `setNames(x, nm)` — the functional form of `names(x) <- nm`: return `x` with
+/// its names set to `nm` (NA-padded / cleared by `NULL`, as `names<-`).
+fn b_set_names(interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
+    // Reuse the replacement engine, mapping the second positional to `value`.
+    let x = first_positional(args)?.clone();
+    let nm = nth_positional(args, 1).cloned().unwrap_or(SValue::Null);
+    b_set_names_replace(
+        interp,
+        &[
+            Arg {
+                name: None,
+                value: x,
+            },
+            Arg {
+                name: Some("value".to_string()),
+                value: nm,
+            },
+        ],
+    )
 }
 
 /// `dim(df)` — `c(nrow, ncol)`.

--- a/code/packages/rust/s-runtime/src/eval.rs
+++ b/code/packages/rust/s-runtime/src/eval.rs
@@ -285,18 +285,31 @@ impl Interpreter {
         env: &Env,
         simple_err: SError,
     ) -> SResult<SValue> {
-        // The target must reduce to a `postfix` of the form `NAME [ subscripts ]`.
+        // The target must reduce to a `postfix` of the form `NAME [ subscripts ]`
+        // (subscript assignment) or `fn ( x )` (a replacement-function call such
+        // as `names(x) <- value`).
         let postfix = descend_to_postfix(target).ok_or(simple_err)?;
         let parts = node_children(postfix);
-        // primary + exactly one index_suffix (no chained `$`/`[[`/`()` for now).
         let (primary, suffix) = match parts.as_slice() {
-            [primary, suffix] if suffix.rule_name == "index_suffix" => (*primary, *suffix),
-            _ => {
-                return Err(SError::TypeError(
-                    "unsupported assignment target (only `x[...] <- v` is supported)".into(),
-                ))
+            [primary, suffix]
+                if suffix.rule_name == "index_suffix" || suffix.rule_name == "call_suffix" =>
+            {
+                (*primary, *suffix)
             }
+            _ => return Err(SError::TypeError(
+                "unsupported assignment target (only `x[...] <- v` and `f(x) <- v` are supported)"
+                    .into(),
+            )),
         };
+
+        // `f(x) <- value` — a replacement-function call. R desugars this to
+        // `x <- \`f<-\`(x, value)`: the inner argument must be a bare-name
+        // variable, and the replacement function (`names<-`, …) is looked up,
+        // called with `(current_x, value)`, and its result rebound to `x`.
+        if suffix.rule_name == "call_suffix" {
+            return self.eval_replacement_assignment(primary, suffix, rhs, env);
+        }
+
         let base_name = lvalue_name(primary)?;
         let current =
             lookup(env, &base_name).ok_or_else(|| SError::Undefined(base_name.clone()))?;
@@ -312,6 +325,72 @@ impl Interpreter {
             }
         };
         define(env, &base_name, updated);
+        self.as_invisible(rhs)
+    }
+
+    /// Handle a **replacement-function** assignment `f(x) <- value` (R-15).
+    /// R defines this as sugar for `x <- \`f<-\`(x, value)`: the call's single
+    /// argument `x` must be a bare-name variable; we look up the replacement
+    /// function `\`f<-\``, call it with the *current* value of `x` and the RHS
+    /// `value` (passed as the named `value =` argument), and rebind the result to
+    /// `x`. Used for `names(x) <- …`; the same machinery serves any future
+    /// `levels<-` / `dim<-` once those replacement builtins are registered.
+    fn eval_replacement_assignment(
+        &self,
+        primary: &GrammarASTNode,
+        call_suffix: &GrammarASTNode,
+        rhs: SValue,
+        env: &Env,
+    ) -> SResult<SValue> {
+        // The replacement-function base name (e.g. `names`).
+        let fn_name = lvalue_name(primary)
+            .map_err(|_| SError::TypeError("invalid replacement-function target".into()))?;
+
+        // The call must have exactly one argument, and it must be a bare-name
+        // variable (the object being modified): `names(x) <- v`.
+        let arg_values = self.eval_args(call_suffix, env)?;
+        if arg_values.len() != 1 {
+            return Err(SError::BadArgs(format!(
+                "{fn_name}(...) <- value: the replacement target must take exactly one argument"
+            )));
+        }
+
+        // Recover the bare-name of that single argument from the parse tree (we
+        // need the *name* to rebind, not just its value).
+        let arg_node = call_suffix
+            .children
+            .iter()
+            .find_map(|c| match c {
+                ASTNodeOrToken::Node(n) if n.rule_name == "arg_list" => Some(n),
+                _ => None,
+            })
+            .and_then(first_node) // the first `arg`
+            .and_then(|arg| only_node(arg).ok())
+            .ok_or_else(|| SError::Parse("malformed replacement target".into()))?;
+        let target_name = lvalue_name(arg_node).map_err(|_| {
+            SError::TypeError(format!(
+                "target of {fn_name}(...) <- value must be a variable"
+            ))
+        })?;
+        let current =
+            lookup(env, &target_name).ok_or_else(|| SError::Undefined(target_name.clone()))?;
+
+        // Look up `\`f<-\`` and call it with (current, value = rhs).
+        let replacement_name = format!("{fn_name}<-");
+        let func = lookup(env, &replacement_name)
+            .ok_or_else(|| SError::Undefined(replacement_name.clone()))?;
+        let call_args = [
+            Arg {
+                name: None,
+                value: current,
+            },
+            Arg {
+                name: Some("value".to_string()),
+                value: rhs.clone(),
+            },
+        ];
+        let updated = self.call_value(func, &call_args)?;
+        define(env, &target_name, updated);
         self.as_invisible(rhs)
     }
 
@@ -1122,6 +1201,7 @@ pub(crate) fn nth_element(value: &SValue, i: usize) -> SValue {
             levels: levels.clone(),
         },
         SValue::Classed { inner, .. } => nth_element(inner, i),
+        SValue::Named { values, .. } => nth_element(values, i),
         SValue::List { items, .. } => items.get(i).cloned().unwrap_or(SValue::Null),
         _ => SValue::Null,
     }

--- a/code/packages/rust/s-runtime/src/lib.rs
+++ b/code/packages/rust/s-runtime/src/lib.rs
@@ -49,9 +49,11 @@ mod tests {
         format_value(&value).join("\n")
     }
 
-    /// Evaluate and return the numeric data of a `Double` result.
+    /// Evaluate and return the numeric data of a `Double` result (seeing through
+    /// a names attribute — a named numeric is still numeric).
     fn nums(src: &str) -> Vec<f64> {
-        match eval_s(src).unwrap() {
+        let value = eval_s(src).unwrap();
+        match value.strip_names() {
             SValue::Double(d) => d.data().to_vec(),
             other => panic!("expected double, got {}", other.type_name()),
         }
@@ -908,5 +910,61 @@ mod tests {
                                                       // Required parameters can't be omitted.
         assert!(eval_s("dbinom(1)\n").is_err());
         assert!(eval_s("dpois(1)\n").is_err());
+    }
+
+    // --- R-15: named vectors through the S pipeline ----------------------
+
+    /// The names of `src`'s result as strings (NA → "NA"); panics if unnamed.
+    fn names_of(src: &str) -> Vec<String> {
+        match eval_s(src).unwrap() {
+            SValue::Character(v) => v
+                .into_iter()
+                .map(|o| o.unwrap_or_else(|| "NA".to_string()))
+                .collect(),
+            other => panic!("expected character, got {}", other.type_name()),
+        }
+    }
+
+    #[test]
+    fn named_vectors_through_s_syntax() {
+        // c(name = value) attaches names (S uses `=` for argument names).
+        assert_eq!(
+            names_of("names(c(a = 1, b = 2, c = 3))\n"),
+            vec!["a", "b", "c"]
+        );
+        assert_eq!(nums("c(a = 1, b = 2)\n"), vec![1.0, 2.0]);
+        // names(x) <- value (S `<-` assignment, replacement function path).
+        assert_eq!(
+            names_of("x <- c(1, 2, 3)\nnames(x) <- c(\"p\", \"q\", \"r\")\nnames(x)\n"),
+            vec!["p", "q", "r"]
+        );
+        // NA-pad on a short names vector.
+        assert_eq!(
+            names_of("x <- c(1, 2, 3)\nnames(x) <- c(\"p\")\nnames(x)\n"),
+            vec!["p", "NA", "NA"]
+        );
+        // Clearing names with NULL.
+        assert_eq!(show("x <- c(a = 1)\nnames(x) <- NULL\nnames(x)\n"), "NULL");
+        // Character indexing by name.
+        assert_eq!(nums("x <- c(a = 1, b = 2, c = 3)\nx[\"b\"]\n"), vec![2.0]);
+        assert_eq!(
+            nums("x <- c(a = 1, b = 2, c = 3)\nx[c(\"a\", \"c\")]\n"),
+            vec![1.0, 3.0]
+        );
+        // setNames functional form (no underscore, so it is writable in S).
+        assert_eq!(
+            names_of("names(setNames(c(1, 2), c(\"x\", \"y\")))\n"),
+            vec!["x", "y"]
+        );
+        // Printing: names above values.
+        assert_eq!(show("c(a = 1, b = 2, c = 3)\n"), "a b c\n1 2 3");
+    }
+
+    #[test]
+    fn named_vector_replacement_errors_are_clean() {
+        // Too many names is an error.
+        assert!(eval_s("x <- c(1, 2)\nnames(x) <- c(\"a\", \"b\", \"c\")\n").is_err());
+        // A replacement target that isn't a registered `f<-` is undefined.
+        assert!(eval_s("x <- c(1, 2)\nnope(x) <- 5\n").is_err());
     }
 }

--- a/code/packages/rust/s-runtime/src/value.rs
+++ b/code/packages/rust/s-runtime/src/value.rs
@@ -100,6 +100,24 @@ pub enum SValue {
         nrow: usize,
         ncol: usize,
     },
+
+    /// An atomic vector carrying a **names attribute** (R's `names(x)`). The
+    /// `names` vector runs in lockstep with the elements of `values` — one
+    /// `Option<String>` per element, `None` for an unset name — and is *always*
+    /// kept exactly as long as `values` (every constructor truncates or
+    /// `NA`-pads it), so a name lookup can never index out of bounds.
+    ///
+    /// Like [`SValue::Classed`], this is a **transparent wrapper**: `length`,
+    /// `type_name`, the coercions, arithmetic, comparison, and `class_of` all
+    /// see straight through to `values`. Only the operations where R actually
+    /// observes names — `names()`, character indexing, positional indexing that
+    /// carries names along, and printing — look at the `names` field. `values`
+    /// is itself never another `Named` (constructors flatten), and is always one
+    /// of the atomic variants (`Double`/`Logical`/`Character`).
+    Named {
+        names: Vec<Option<String>>,
+        values: Box<SValue>,
+    },
 }
 
 impl SValue {
@@ -107,6 +125,53 @@ impl SValue {
     pub fn list(pairs: Vec<(Option<String>, SValue)>) -> SValue {
         let (names, items) = pairs.into_iter().unzip();
         SValue::List { names, items }
+    }
+
+    /// Wrap an atomic `values` vector with a names attribute, normalizing the
+    /// names to exactly the element count (truncating a too-long names vector,
+    /// `NA`-padding a too-short one). If `values` is *already* `Named`, its old
+    /// names are replaced (R's `names<-` semantics). A `values` that is not an
+    /// atomic vector (a list, matrix, data frame, …) is returned unchanged
+    /// rather than wrapped — names on those structures are out of scope here.
+    pub fn with_names(values: SValue, mut names: Vec<Option<String>>) -> SValue {
+        // Unwrap an existing names attribute so we never nest `Named`.
+        let inner = match values {
+            SValue::Named { values, .. } => *values,
+            other => other,
+        };
+        if !matches!(
+            inner,
+            SValue::Double(_) | SValue::Logical(_) | SValue::Character(_)
+        ) {
+            return inner;
+        }
+        let n = inner.length();
+        // Normalize to exactly `n` slots: pad short with NA, truncate long.
+        if names.len() < n {
+            names.resize(n, None);
+        } else {
+            names.truncate(n);
+        }
+        SValue::Named {
+            names,
+            values: Box::new(inner),
+        }
+    }
+
+    /// The names attribute of a value, if it carries one (`None` otherwise).
+    pub fn names_attr(&self) -> Option<&[Option<String>]> {
+        match self {
+            SValue::Named { names, .. } => Some(names),
+            _ => None,
+        }
+    }
+
+    /// The atomic value underneath a names wrapper (or the value itself).
+    pub fn strip_names(&self) -> &SValue {
+        match self {
+            SValue::Named { values, .. } => values,
+            other => other,
+        }
     }
 }
 
@@ -124,6 +189,9 @@ pub fn class_of(value: &SValue) -> Vec<String> {
         SValue::Null => vec!["NULL".to_string()],
         SValue::Closure { .. } | SValue::Builtin { .. } => vec!["function".to_string()],
         SValue::Matrix { .. } => vec!["matrix".to_string(), "array".to_string()],
+        // A names attribute is transparent to `class()` — see through to the
+        // underlying value's class (a named numeric is still `"numeric"`).
+        SValue::Named { values, .. } => class_of(values),
     }
 }
 
@@ -149,6 +217,9 @@ impl std::fmt::Debug for SValue {
             SValue::Classed { inner, class } => write!(f, "Classed({class:?}, {inner:?})"),
             SValue::List { items, .. } => write!(f, "List({} items)", items.len()),
             SValue::Matrix { nrow, ncol, .. } => write!(f, "Matrix({nrow}x{ncol})"),
+            SValue::Named { names, values } => {
+                write!(f, "Named({:?}, {values:?})", names)
+            }
         }
     }
 }
@@ -159,6 +230,8 @@ fn type_rank(value: &SValue) -> u8 {
         SValue::Logical(_) => 0,
         SValue::Double(_) => 1,
         SValue::Character(_) => 2,
+        // A names attribute is transparent: rank by the underlying value.
+        SValue::Named { values, .. } => type_rank(values),
         _ => 3, // NULL / functions — not part of the atomic lattice
     }
 }
@@ -187,6 +260,7 @@ impl SValue {
             SValue::Classed { inner, .. } => inner.type_name(),
             SValue::List { .. } => "list",
             SValue::Matrix { .. } => "double",
+            SValue::Named { values, .. } => values.type_name(),
         }
     }
 
@@ -204,6 +278,7 @@ impl SValue {
             SValue::Classed { inner, .. } => inner.length(),
             SValue::List { items, .. } => items.len(),
             SValue::Matrix { data, .. } => data.len(),
+            SValue::Named { values, .. } => values.length(),
         }
     }
 
@@ -227,6 +302,7 @@ impl SValue {
             )),
             SValue::Null => Ok(Double::from_values(vec![])),
             SValue::Classed { inner, .. } => inner.as_double(),
+            SValue::Named { values, .. } => values.as_double(),
             SValue::Matrix { data, .. } => Ok(data.clone()),
             other => Err(SError::TypeError(format!(
                 "non-numeric argument (got {})",
@@ -246,6 +322,7 @@ impl SValue {
                 .collect()),
             SValue::Null => Ok(vec![]),
             SValue::Classed { inner, .. } => inner.as_logical(),
+            SValue::Named { values, .. } => values.as_logical(),
             SValue::Matrix { data, .. } => Ok(data
                 .iter()
                 .map(|x| if is_na_real(x) { None } else { Some(x != 0.0) })
@@ -287,6 +364,7 @@ impl SValue {
             SValue::Null => vec![],
             SValue::Factor { codes, levels } => SValue::factor_labels(codes, levels),
             SValue::Classed { inner, .. } => inner.as_character(),
+            SValue::Named { values, .. } => values.as_character(),
             SValue::Matrix { data, .. } => data
                 .iter()
                 .map(|x| {
@@ -320,6 +398,7 @@ impl SValue {
                 None => Err(SError::Missing("argument is of length zero".into())),
             },
             SValue::Classed { inner, .. } => inner.truthy(),
+            SValue::Named { values, .. } => values.truthy(),
             SValue::Matrix { data, .. } => SValue::Double(data.clone()).truthy(),
             other => Err(SError::TypeError(format!(
                 "argument is not interpretable as logical (got {})",
@@ -335,33 +414,69 @@ impl SValue {
 
 /// Combine values into a single vector, coercing to the highest type present.
 /// `NULL` contributes nothing (`c(1, NULL, 2)` is `c(1, 2)`).
+///
+/// **Names (R-15).** `c()` builds a names attribute iff any contributing
+/// argument is *tagged* (`c(a = 1)`) or already *carries* names
+/// (`c(x = c(a = 1))`). The R combination rule for each contributing element is:
+///
+/// | argument tag | element name in piece | resulting name |
+/// |--------------|-----------------------|----------------|
+/// | `tag`        | `inner`               | `tag.inner`    |
+/// | `tag`        | (none)                | `tag` (length 1) / `tag1`, `tag2`, … (longer) |
+/// | (none)       | `inner`               | `inner`        |
+/// | (none)       | (none)                | `""` (empty)   |
+///
+/// If no name appears anywhere, the result is a plain unnamed vector.
 pub fn combine(args: &[Arg]) -> SValue {
-    let present: Vec<&SValue> = args
+    // Drop NULL arguments; carry each surviving argument's tag alongside its
+    // value so we can build names in lockstep with the concatenation.
+    let present: Vec<(&Option<String>, &SValue)> = args
         .iter()
-        .map(|a| &a.value)
-        .filter(|v| !matches!(v, SValue::Null))
+        .filter(|a| !matches!(a.value, SValue::Null))
+        .map(|a| (&a.name, &a.value))
         .collect();
 
     if present.is_empty() {
         return SValue::Null;
     }
 
-    let rank = present.iter().map(|v| type_rank(v)).max().unwrap_or(0);
+    let any_named = present
+        .iter()
+        .any(|(tag, v)| tag.is_some() || v.names_attr().is_some());
 
-    match rank {
+    // Build the names vector (only used if `any_named`), one entry per output
+    // element, in the same order as the value concatenation below.
+    let names: Vec<Option<String>> = if any_named {
+        let mut names = Vec::new();
+        for (tag, v) in &present {
+            let inner_names = v.names_attr();
+            let count = v.length();
+            for i in 0..count {
+                let inner = inner_names.and_then(|ns| ns.get(i).and_then(|o| o.clone()));
+                names.push(combined_name(tag.as_deref(), inner.as_deref(), count, i));
+            }
+        }
+        names
+    } else {
+        Vec::new()
+    };
+
+    let rank = present.iter().map(|(_, v)| type_rank(v)).max().unwrap_or(0);
+
+    let combined = match rank {
         2 => {
             // character wins: stringify everything.
             let mut out = Vec::new();
-            for v in present {
+            for (_, v) in &present {
                 out.extend(v.as_character());
             }
             SValue::Character(out)
         }
         0 => {
-            // all logical: concatenate logical payloads.
+            // all logical: concatenate logical payloads (seeing through names).
             let mut out = Vec::new();
-            for v in present {
-                if let SValue::Logical(l) = v {
+            for (_, v) in &present {
+                if let SValue::Logical(l) = v.strip_names() {
                     out.extend(l.iter().cloned());
                 }
             }
@@ -370,7 +485,7 @@ pub fn combine(args: &[Arg]) -> SValue {
         _ => {
             // double (with any logicals coerced to 0/1).
             let mut out = Vec::new();
-            for v in present {
+            for (_, v) in &present {
                 // as_double cannot fail here: only logical/double remain.
                 if let Ok(d) = v.as_double() {
                     out.extend(d.iter());
@@ -378,7 +493,36 @@ pub fn combine(args: &[Arg]) -> SValue {
             }
             SValue::Double(Double::from_values(out))
         }
+    };
+
+    if any_named {
+        SValue::with_names(combined, names)
+    } else {
+        combined
     }
+}
+
+/// Compute the R-combination name for one output element. `tag` is the
+/// argument's name at the call site (`c(tag = …)`); `inner` is the element's own
+/// name (if the argument was itself a named vector); `count` is the argument's
+/// length and `i` the 0-based position within it. An empty string (not `NA`)
+/// marks a positionally-unnamed slot, matching R.
+fn combined_name(tag: Option<&str>, inner: Option<&str>, count: usize, i: usize) -> Option<String> {
+    let name = match (tag, inner) {
+        (Some(t), Some(inner)) => format!("{t}.{inner}"),
+        (Some(t), None) => {
+            // A scalar tagged argument takes the tag verbatim; a longer one
+            // suffixes the 1-based position (`c(p = c(1, 2))` → `p1`, `p2`).
+            if count == 1 {
+                t.to_string()
+            } else {
+                format!("{t}{}", i + 1)
+            }
+        }
+        (None, Some(inner)) => inner.to_string(),
+        (None, None) => String::new(),
+    };
+    Some(name)
 }
 
 // ===========================================================================
@@ -491,6 +635,8 @@ pub fn membership(lhs: &SValue, rhs: &SValue) -> SValue {
 /// compare numerically; if either side is character, both are compared as
 /// strings (S's coercion for relational operators).
 pub fn compare(op: &str, lhs: &SValue, rhs: &SValue) -> SResult<SValue> {
+    // See through any names attribute before deciding numeric vs string compare.
+    let (lhs, rhs) = (lhs.strip_names(), rhs.strip_names());
     let either_char = matches!(lhs, SValue::Character(_)) || matches!(rhs, SValue::Character(_));
 
     if either_char {
@@ -574,8 +720,37 @@ fn compare_ord(op: &str, ord: std::cmp::Ordering) -> bool {
 /// * **positive** — 1-based selection; `0` selects nothing, out-of-range/`NA`
 ///   yield an `NA` slot.
 fn resolve_picks(len: usize, idx: &SValue) -> SResult<Vec<Option<usize>>> {
+    resolve_picks_named(len, None, idx)
+}
+
+/// As [`resolve_picks`], but also handling **character** index vectors by name
+/// (R-15): `x["b"]` / `x[c("a","c")]`. `names` is the base's names attribute (if
+/// any); each lookup matches the *first* occurrence of the name, and an
+/// unmatched (or `NA`) name yields a `None` slot (→ an `NA` element). A
+/// character index against a base with no names selects all-`NA`, as in R.
+fn resolve_picks_named(
+    len: usize,
+    names: Option<&[Option<String>]>,
+    idx: &SValue,
+) -> SResult<Vec<Option<usize>>> {
+    // Character index → match by name.
+    if let SValue::Character(keys) = idx.strip_names() {
+        let mut picks = Vec::with_capacity(keys.len());
+        for key in keys {
+            match (key, names) {
+                (Some(k), Some(ns)) => {
+                    // First matching name; miss → NA slot.
+                    picks.push(ns.iter().position(|n| n.as_deref() == Some(k.as_str())));
+                }
+                // No names on the base, or an NA key → no match.
+                _ => picks.push(None),
+            }
+        }
+        return Ok(picks);
+    }
+
     // Logical mask (recycled to the longer of len / mask length).
-    if let SValue::Logical(mask) = idx {
+    if let SValue::Logical(mask) = idx.strip_names() {
         if mask.is_empty() {
             return Ok(Vec::new());
         }
@@ -645,6 +820,39 @@ fn resolve_picks(len: usize, idx: &SValue) -> SResult<Vec<Option<usize>>> {
     Ok(picks)
 }
 
+/// Apply already-resolved `picks` to an atomic `base` value, materializing the
+/// selected elements (a `None` pick → an `NA`/`NULL` slot). Used by the names
+/// wrapper in [`index`] to subset the underlying value without recomputing the
+/// picks. `base` must be one of the atomic variants; other types are an error.
+fn pick_into(base: &SValue, picks: &[Option<usize>]) -> SResult<SValue> {
+    Ok(match base {
+        SValue::Double(d) => SValue::Double(Double::from_values(
+            picks
+                .iter()
+                .map(|p| p.and_then(|i| d.get_value(i)).unwrap_or_else(na_real))
+                .collect(),
+        )),
+        SValue::Logical(v) => SValue::Logical(
+            picks
+                .iter()
+                .map(|p| p.and_then(|i| v.get(i).copied().flatten()))
+                .collect(),
+        ),
+        SValue::Character(v) => SValue::Character(
+            picks
+                .iter()
+                .map(|p| p.and_then(|i| v.get(i).cloned().flatten()))
+                .collect(),
+        ),
+        other => {
+            return Err(SError::Index(format!(
+                "object of type '{}' is not subsettable",
+                other.type_name()
+            )))
+        }
+    })
+}
+
 /// Index `base` with the index vector `idx` (1-based; positive, negative, or
 /// logical — see [`resolve_picks`]). A `Matrix` is indexed *linearly* over its
 /// flat column-major data (dropping its matrix structure, as R does for `m[i]`).
@@ -652,6 +860,19 @@ pub fn index(base: &SValue, idx: &SValue) -> SResult<SValue> {
     // `m[i]` — single-subscript indexing of a matrix is over the flat vector.
     if let SValue::Matrix { data, .. } = base {
         return index(&SValue::Double(data.clone()), idx);
+    }
+
+    // A **named** vector: index the underlying value, then carry the selected
+    // names along (R keeps names through `[`). Character indices resolve by name.
+    if let SValue::Named { names, values } = base {
+        let len = values.length();
+        let picks = resolve_picks_named(len, Some(names), idx)?;
+        let selected_values = pick_into(values, &picks)?;
+        let selected_names: Vec<Option<String>> = picks
+            .iter()
+            .map(|p| p.and_then(|i| names.get(i).and_then(|o| o.clone())))
+            .collect();
+        return Ok(SValue::with_names(selected_values, selected_names));
     }
 
     let len = base.length();
@@ -837,6 +1058,30 @@ pub fn assign_index(base: &SValue, idx: Option<&SValue>, rhs: &SValue) -> SResul
             inner: Box::new(assign_index(inner, idx, rhs)?),
             class: class.clone(),
         }),
+        // A named vector: write into the underlying value (resolving a character
+        // subscript by name) and keep the names attribute. The selection length
+        // is bounded, so this is the same write count as the unnamed path.
+        SValue::Named { names, values } => {
+            let slots = match idx {
+                None => (0..values.length()).collect(),
+                Some(i) => resolve_picks_named(values.length(), Some(names), i)?
+                    .into_iter()
+                    .map(|p| {
+                        p.ok_or_else(|| {
+                            SError::Index(
+                                "NAs/out-of-range are not allowed in index assignment".into(),
+                            )
+                        })
+                    })
+                    .collect::<SResult<Vec<usize>>>()?,
+            };
+            let mut out = values.as_double()?.data().to_vec();
+            write_recycled(&mut out, &slots, &rhs_d)?;
+            Ok(SValue::Named {
+                names: names.clone(),
+                values: Box::new(SValue::Double(Double::from_values(out))),
+            })
+        }
         other => Err(SError::TypeError(format!(
             "cannot index-assign into a value of type '{}'",
             other.type_name()
@@ -975,9 +1220,99 @@ pub fn format_value(value: &SValue) -> Vec<String> {
         SValue::Classed { inner, .. } => return format_value(inner),
         SValue::List { names, items } => return format_list(names, items),
         SValue::Matrix { data, nrow, ncol } => return format_matrix(data, *nrow, *ncol),
+        SValue::Named { names, values } => return format_named(names, values),
     };
 
     format_vector(&elems)
+}
+
+/// Render a **named** vector R-style: a row of right-aligned names above a row
+/// of right-aligned values, each column as wide as the wider of its name and its
+/// value. An unset name prints as `<NA>` (matching R). An empty named vector
+/// falls back to the underlying empty-vector form. Long vectors wrap at ~80
+/// columns, repeating the name header for each wrapped block.
+fn format_named(names: &[Option<String>], values: &SValue) -> Vec<String> {
+    // The displayed value cells (same convention as `format_vector`: strings are
+    // quoted, doubles use `format_number`, NA logical → "NA", etc.).
+    let value_cells: Vec<String> = match value_strings(values) {
+        Some(cells) => cells,
+        // Empty or non-atomic underlying value: defer to its own formatting.
+        None => return format_value(values),
+    };
+    if value_cells.is_empty() {
+        return format_value(values);
+    }
+    let name_cells: Vec<String> = (0..value_cells.len())
+        .map(|i| match names.get(i).and_then(|o| o.as_deref()) {
+            Some(s) => s.to_string(),
+            None => "<NA>".to_string(),
+        })
+        .collect();
+
+    // Per-column width = max(name width, value width).
+    let widths: Vec<usize> = value_cells
+        .iter()
+        .zip(&name_cells)
+        .map(|(v, n)| v.len().max(n.len()))
+        .collect();
+
+    // Wrap so each block's total width stays within ~80 columns.
+    let n = value_cells.len();
+    let mut lines = Vec::new();
+    let mut i = 0;
+    while i < n {
+        let mut used = 0usize;
+        let mut j = i;
+        while j < n {
+            let add = widths[j] + if j > i { 1 } else { 0 };
+            if j > i && used + add > 80 {
+                break;
+            }
+            used += add;
+            j += 1;
+        }
+        let mut name_line = String::new();
+        let mut value_line = String::new();
+        for k in i..j {
+            if k > i {
+                name_line.push(' ');
+                value_line.push(' ');
+            }
+            let w = widths[k];
+            name_line.push_str(&format!("{:>w$}", name_cells[k]));
+            value_line.push_str(&format!("{:>w$}", value_cells[k]));
+        }
+        lines.push(name_line);
+        lines.push(value_line);
+        i = j;
+    }
+    lines
+}
+
+/// The display strings for an atomic value's elements (quoted for character),
+/// or `None` if the value is empty or not an atomic vector.
+fn value_strings(values: &SValue) -> Option<Vec<String>> {
+    match values {
+        SValue::Double(d) if !d.is_empty() => Some(d.iter().map(format_number).collect()),
+        SValue::Logical(v) if !v.is_empty() => Some(
+            v.iter()
+                .map(|o| match o {
+                    Some(true) => "TRUE".to_string(),
+                    Some(false) => "FALSE".to_string(),
+                    None => "NA".to_string(),
+                })
+                .collect(),
+        ),
+        SValue::Character(v) if !v.is_empty() => Some(
+            v.iter()
+                .map(|o| match o {
+                    Some(s) => format!("\"{s}\""),
+                    None => "NA".to_string(),
+                })
+                .collect(),
+        ),
+        _ => None,
+    }
 }
 
 /// Render a matrix the way R's console does: a `[,j]` column-header row, then
@@ -1051,6 +1386,7 @@ pub fn element_string(value: &SValue, i: usize) -> String {
             .and_then(|k| levels.get((k as usize).wrapping_sub(1)).cloned())
             .unwrap_or_else(|| "NA".into()),
         SValue::Classed { inner, .. } => element_string(inner, i),
+        SValue::Named { values, .. } => element_string(values, i),
         _ => "NA".into(),
     }
 }
@@ -1517,5 +1853,160 @@ mod tests {
         );
         let d = SValue::doubles(vec![1.0, 2.5]);
         assert_eq!(element_string(&d, 1), "2.5");
+    }
+
+    // --- R-15: named vectors --------------------------------------------
+
+    fn name(s: &str) -> Option<String> {
+        Some(s.to_string())
+    }
+
+    /// Build an Arg with an optional tag (call-site name).
+    fn tagged(tag: Option<&str>, value: SValue) -> Arg {
+        Arg {
+            name: tag.map(|s| s.to_string()),
+            value,
+        }
+    }
+
+    #[test]
+    fn with_names_normalizes_length() {
+        // Exactly-right names attach verbatim.
+        let v = SValue::with_names(SValue::doubles(vec![1.0, 2.0]), vec![name("a"), name("b")]);
+        assert_eq!(v.names_attr(), Some(&[name("a"), name("b")][..]));
+        // Too-short pads with NA (None).
+        let v = SValue::with_names(SValue::doubles(vec![1.0, 2.0, 3.0]), vec![name("a")]);
+        assert_eq!(v.names_attr(), Some(&[name("a"), None, None][..]));
+        // Too-long truncates.
+        let v = SValue::with_names(
+            SValue::doubles(vec![1.0]),
+            vec![name("a"), name("b"), name("c")],
+        );
+        assert_eq!(v.names_attr(), Some(&[name("a")][..]));
+        // Re-wrapping a Named replaces its old names (never nests).
+        let v = SValue::with_names(v, vec![name("z")]);
+        assert!(
+            matches!(&v, SValue::Named { values, .. } if !matches!(**values, SValue::Named { .. }))
+        );
+        assert_eq!(v.names_attr(), Some(&[name("z")][..]));
+        // A non-atomic value is returned unwrapped.
+        let lst = SValue::list(vec![(None, SValue::scalar(1.0))]);
+        assert!(SValue::with_names(lst, vec![name("a")])
+            .names_attr()
+            .is_none());
+    }
+
+    #[test]
+    fn combine_attaches_and_combines_names() {
+        // c(a = 1, b = 2) attaches the tags.
+        let v = combine(&[
+            tagged(Some("a"), SValue::scalar(1.0)),
+            tagged(Some("b"), SValue::scalar(2.0)),
+        ]);
+        assert_eq!(v.names_attr(), Some(&[name("a"), name("b")][..]));
+        // Nested: c(x = c(a = 1), 2) → "x.a", "".
+        let inner = combine(&[tagged(Some("a"), SValue::scalar(1.0))]);
+        let v = combine(&[tagged(Some("x"), inner), tagged(None, SValue::scalar(2.0))]);
+        assert_eq!(v.names_attr(), Some(&[name("x.a"), name("")][..]));
+        // A tagged multi-element argument suffixes its position.
+        let v = combine(&[tagged(Some("p"), SValue::doubles(vec![1.0, 2.0]))]);
+        assert_eq!(v.names_attr(), Some(&[name("p1"), name("p2")][..]));
+        // No names anywhere → a plain unnamed vector.
+        let v = combine(&[
+            tagged(None, SValue::scalar(1.0)),
+            tagged(None, SValue::scalar(2.0)),
+        ]);
+        assert!(v.names_attr().is_none());
+        assert!(matches!(v, SValue::Double(_)));
+    }
+
+    #[test]
+    fn character_index_resolves_by_name() {
+        let names = [name("a"), name("b"), name("c")];
+        // Hit → the matching 0-based position; miss → None (NA slot).
+        let picks = resolve_picks_named(
+            3,
+            Some(&names),
+            &SValue::Character(vec![name("b"), name("z"), name("a")]),
+        )
+        .unwrap();
+        assert_eq!(picks, vec![Some(1), None, Some(0)]);
+        // No names on the base → all-None.
+        let picks = resolve_picks_named(3, None, &SValue::Character(vec![name("a")])).unwrap();
+        assert_eq!(picks, vec![None]);
+    }
+
+    #[test]
+    fn index_on_named_carries_names_and_resolves_characters() {
+        let v = SValue::with_names(
+            SValue::doubles(vec![1.0, 2.0, 3.0]),
+            vec![name("a"), name("b"), name("c")],
+        );
+        // x["b"] → value 2, name "b".
+        let r = index(&v, &SValue::Character(vec![name("b")])).unwrap();
+        assert_eq!(r.strip_names().as_double().unwrap().data(), &[2.0]);
+        assert_eq!(r.names_attr(), Some(&[name("b")][..]));
+        // x[c(1, 3)] keeps names a, c.
+        let r = index(&v, &SValue::doubles(vec![1.0, 3.0])).unwrap();
+        assert_eq!(r.names_attr(), Some(&[name("a"), name("c")][..]));
+        // A miss → NA value and NA name.
+        let r = index(&v, &SValue::Character(vec![name("z")])).unwrap();
+        assert!(is_na_real(r.strip_names().as_double().unwrap().data()[0]));
+        assert_eq!(r.names_attr(), Some(&[None][..]));
+    }
+
+    #[test]
+    fn assign_index_keeps_names_and_resolves_character_subscript() {
+        let v = SValue::with_names(
+            SValue::doubles(vec![1.0, 2.0, 3.0]),
+            vec![name("a"), name("b"), name("c")],
+        );
+        // Positional assignment keeps names.
+        let r = assign_index(&v, Some(&SValue::scalar(2.0)), &SValue::scalar(9.0)).unwrap();
+        assert_eq!(
+            r.strip_names().as_double().unwrap().data(),
+            &[1.0, 9.0, 3.0]
+        );
+        assert_eq!(r.names_attr(), Some(&[name("a"), name("b"), name("c")][..]));
+        // Character subscript assignment writes the named element.
+        let r = assign_index(
+            &v,
+            Some(&SValue::Character(vec![name("a")])),
+            &SValue::scalar(5.0),
+        )
+        .unwrap();
+        assert_eq!(
+            r.strip_names().as_double().unwrap().data(),
+            &[5.0, 2.0, 3.0]
+        );
+    }
+
+    #[test]
+    fn named_value_is_transparent_to_core_ops() {
+        let v = SValue::with_names(SValue::doubles(vec![1.0, 2.0]), vec![name("a"), name("b")]);
+        assert_eq!(v.length(), 2);
+        assert_eq!(v.type_name(), "double");
+        assert_eq!(class_of(&v), vec!["numeric"]);
+        assert_eq!(v.as_double().unwrap().data(), &[1.0, 2.0]);
+        // Arithmetic sees through (and the result has no names).
+        let r = arithmetic("+", &v, &SValue::scalar(1.0)).unwrap();
+        assert_eq!(dbl(&r), vec![2.0, 3.0]);
+        assert!(r.names_attr().is_none());
+        // Comparison on a named character vector still compares as strings.
+        let cv = SValue::with_names(SValue::Character(vec![name("x")]), vec![name("k")]);
+        let r = compare("==", &cv, &SValue::Character(vec![name("x")])).unwrap();
+        assert!(matches!(&r, SValue::Logical(v) if v[0] == Some(true)));
+    }
+
+    #[test]
+    fn format_named_lays_out_two_aligned_rows() {
+        let v = SValue::with_names(
+            SValue::doubles(vec![1.0, 2.0, 3.0]),
+            vec![name("a"), name("b"), name("c")],
+        );
+        assert_eq!(format_value(&v), vec!["a b c", "1 2 3"]);
+        // A wider value widens the name column too; an unset name prints <NA>.
+        let v = SValue::with_names(SValue::doubles(vec![100.0, 2.0]), vec![name("x"), None]);
+        assert_eq!(format_value(&v), vec!["  x <NA>", "100    2"]);
     }
 }

--- a/code/specs/R00-r-language.md
+++ b/code/specs/R00-r-language.md
@@ -199,6 +199,43 @@ unchanged.
     (`v[i] <- c()`) is an error; assigning into an **undefined base** is an error.
     No write can touch another binding, so the rebind cannot corrupt unrelated
     variables. The number of writes is bounded by the (capped) selection length.
+- **R-15 — `names()` and named-vector access** *(this PR)*. R's *names attribute*
+  on atomic vectors, in the shared `s-runtime`. A new transparent wrapper
+  `SValue::Named { names, values }` carries a parallel `Vec<Option<String>>` of
+  element names beside a boxed atomic value (`Double`/`Logical`/`Character`), the
+  same "see-through" wrapper pattern as `SValue::Classed` (`length`, `type_name`,
+  coercions, arithmetic, comparison, and `class` all delegate to the inner value;
+  most operations therefore ignore names, and where R *drops* names — arithmetic,
+  comparison, `c()` of partly-unnamed pieces — so do we).
+  - **Construction.** `c(a = 1, b = 2, c = 3)` attaches the argument names. `c()`
+    builds a names vector iff any contributing argument is named *or* already
+    carries names; nested named vectors combine R-style — `c(x = c(a = 1), 2)`
+    yields names `c("x.a", "")` (a named element of a named piece is `outer.inner`;
+    an unnamed slot is the empty string). A `c()` with no names anywhere stays a
+    plain unnamed vector.
+  - **`names(x)`** returns the character vector of names (an unset name → `NA`),
+    or `NULL` when `x` has none. **`names(x) <- value`** is the replacement form:
+    it coerces `value` to character and, R-style, **recycles by NA-padding** — a
+    too-short names vector pads the tail with `NA`, a too-long one is an error;
+    `names(x) <- NULL` drops the wrapper entirely. The evaluator gains a general
+    **replacement-function** lvalue path so `f(x) <- v` desugars to
+    `x <- \`f<-\`(x, v)` for the registered replacements (`names<-`; the
+    machinery is reusable for future `levels<-`, `dim<-`, …). `setNames(x, nm)`
+    is the functional form.
+  - **Character indexing.** `x["b"]` and `x[c("a", "c")]` select by name; an
+    unmatched name yields an `NA` element (and an `NA` name). Positional,
+    negative, and logical indexing are unchanged, and a named vector indexed
+    positionally **carries the selected names along** (`v[c(1, 3)]` keeps those
+    two names), matching R.
+  - **Printing.** A named vector prints R-style — a row of right-aligned names
+    above the row of values, each column as wide as the wider of the two — instead
+    of the `[i]` index prefix. Unnamed slots print as `<NA>`.
+  - **Safety.** Names are attacker-controllable in length only through the same
+    vector-length channels already capped at `MAX_SEQ_LEN`; the names vector is
+    always kept exactly as long as the values (truncated/`NA`-padded on every
+    constructor), so no name lookup can index out of bounds, and the
+    character-index path reuses the bounds-checked `resolve_picks`. No new
+    unbounded allocation or integer-overflow surface is introduced.
 
 ## §4 Reuse strategy
 

--- a/code/specs/S00-s-language.md
+++ b/code/specs/S00-s-language.md
@@ -296,6 +296,26 @@ an aligned table. (Empty-subscript forms `df[, c]` / `df[r, ]` are deferred —
 they need an empty grammar argument, which v2 does not yet add; pass an explicit
 row/column vector instead.)
 
+### V2.7 Named vectors (the `names` attribute)
+
+Atomic vectors may carry a *names* attribute — the R feature that the deferred
+`table` (V2.5) was waiting on. A new transparent wrapper
+`SValue::Named { names, values }` holds a `Vec<Option<String>>` (one slot per
+element, `None` = an unset/`NA` name) beside a boxed atomic value. Like
+`SValue::Classed` it is **see-through**: `length`, `type_name`, the coercions,
+arithmetic, comparison, and `class` all delegate to the inner value, so names are
+silently dropped exactly where R drops them (binary arithmetic, comparison, `c()`
+of unnamed pieces) and preserved where R keeps them (positional/character
+indexing, `rev` via index, the value as returned). Construction:
+`c(a = 1, b = 2)` attaches argument names, and nested named pieces combine
+R-style (`c(x = c(a = 1), 2)` → names `"x.a"`, `""`). `names(x)` returns the
+character names vector (or `NULL`); `names(x) <- value` sets them with R's
+NA-padding recycling (too-short pads with `NA`, `NULL` clears) via a general
+**replacement-function** lvalue path (`f(x) <- v` ≡ ``x <- `f<-`(x, v)``);
+`setNames(x, nm)` is the functional form. `x["b"]` / `x[c("a","c")]` select by
+name (unmatched → `NA`). A named vector prints names above values in aligned
+columns instead of the `[i]` prefix.
+
 ## §9 Divergences from ST00 (spec-sync)
 
 1. **S before R.** ST00 specs R first; we implement historical S first. The two


### PR DESCRIPTION
## R-15 — `names()` and named-vector access

Implements R's *names attribute* on atomic vectors, in the shared `s-runtime` (so R gets it for free via reuse), plus R-syntax integration tests in `r-runtime`. Spec committed first (R00 R-15 + S00 V2.7).

### Scope shipped
- **Value model:** new transparent `SValue::Named { names, values }` wrapper carrying a parallel `Vec<Option<String>>` beside a boxed atomic value, see-through like `Classed` — `length` / `type_name` / `class_of` / the coercions / `arithmetic` / `compare` / `truthy` all delegate to the inner value, so names drop where R drops them and survive where R keeps them.
- **Construction:** `c(a = 1, b = 2)` attaches argument tags; nested named pieces combine R-style (`c(x = c(a = 1), 2)` → `"x.a"`, `""`; `c(p = c(1, 2))` → `"p1"`, `"p2"`). `combine` builds names only when something is tagged or already named.
- **`names(x)`** get (or `NULL`); **`names(x) <- value`** replacement with R NA-padding recycling (too-short pads with `NA`, too-long errors, `NULL` clears); **`setNames(x, nm)`** functional form. A general replacement-function lvalue path desugars `f(x) <- v` to ``x <- `f<-`(x, v)`` (reusable for future `levels<-`/`dim<-`).
- **Character indexing:** `x["b"]` / `x[c("a","c")]` select by name (unmatched → `NA`); positional/negative/logical indexing still work and carry the selected names along; `assign_index` keeps names and resolves a character subscript by name.
- **Printing:** named vectors print names above values in aligned columns instead of the `[i]` prefix (`<NA>` for unset names) — user-visible in the R/S REPL.

### Tests
- `s-runtime`: value-level units (`with_names` normalization, `combine` name-combination, character `resolve_picks_named`, named index/assign, core-op transparency, `format_named`) + S-syntax integration in `lib.rs`. **128 passed.**
- `r-runtime`: R-syntax integration — named construction, `names()` get, `names<-` set/clear/NA-pad, character indexing (hit / miss→NA / vector of names), `setNames`, printing layout, and regression checks that positional/negative/logical indexing + sub-assignment still pass and arithmetic drops names. **66 passed.**
- `cargo build --workspace` compiles (only the pre-existing unrelated `uefi` `panic_impl` error remains); `cargo clippy` clean for both touched crates; rustfmt applied only to edited regions, no unrelated churn.

### Security
Self-reviewed as a senior Rust security engineer (no sub-agent Agent tool available in this environment). Checked: panics/unwrap on malformed input (none — all element access is bounds-checked `.get()`/`get_value()`, all eval steps use `?`); unbounded allocation/DoS from attacker-controlled names (none — the names vector is always normalized to exactly the value length, which rides the existing `MAX_SEQ_LEN` caps; `names<-` rejects over-long names; `format_named`'s wrapping loop has guaranteed forward progress); integer overflow in index/recycle math (none — only `i + 1` on length-bounded loop indices); out-of-bounds in the new name-lookup/indexing paths (none — character lookups use `.position()`, all reads use `.get(i)`, and the len(names)==len(values) invariant holds). Result: **PASSED** — no CRITICAL/HIGH/MEDIUM findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
