### PR TITLE
feat(visicalc-swiftui): wire drag-fill into the infinite-sheet demo

### DIFF
--- a/demo/visicalc-swiftui/README.md
+++ b/demo/visicalc-swiftui/README.md
@@ -82,10 +82,17 @@ formatting. The sheet is u32 × u32 and sparse; a two-axis
 `ScrollView` sized from `used_range` drives the scrollbars, and only the visible
 window of cells is built into the view via `SpreadsheetSession.window(...)`.
 
+The **"Fill ↓ 10"** button next to the formula bar calls
+`WindowedSheetModel.fillDown(10)` (over the C ABI's `sc_fill`) to replicate the
+selected cell into the 10 rows below it — the engine shifts each copy's relative
+references (`=A1`→`=A2`, …), pins absolute (`$`) refs, and carries the format.
+
 Headless proof: `Tests/VisiCalcTests/WindowedModelTests.swift` asserts the
 window is engine-computed and dense, a formula 1000 rows down (`Z1000` = 39) is
-reachable, the gaps are empty (sparse), column letters run AA/BA/BB, and editing
-`A1` dirties the far dependent `Z1000` via `changedSince`. Run with `swift test`.
+reachable, the gaps are empty (sparse), column letters run AA/BA/BB, editing
+`A1` dirties the far dependent `Z1000` via `changedSince`, and `fillDown`
+replicates a relative formula down a column (`I1 = =H1*10` filled down ⇒ I2 = 30,
+I3 = 40, source I1 = 20 untouched). Run with `swift test`.
 
 ## Notes
 

--- a/demo/visicalc-swiftui/Sources/CSpreadsheetEngine/include/spreadsheet.h
+++ b/demo/visicalc-swiftui/Sources/CSpreadsheetEngine/include/spreadsheet.h
@@ -47,6 +47,13 @@ void  sc_set_format(ScSession *s, const char *a1, const char *code);
 char *sc_get_format(ScSession *s, const char *a1);                /* -> code | ""   */
 char *sc_get_display(ScSession *s, const char *a1);               /* -> display str */
 
+/* Fill / replicate (drag-fill): copy the `src` cell across the inclusive
+   rectangle `dst_start`..`dst_end`. Relative references shift per target,
+   absolute ($) refs pin, the source's format carries along, an empty source
+   clears each target; a malformed address is a no-op. No return — the host
+   re-reads via sc_get_window / sc_get_display_window / sc_get_raw afterwards. */
+void  sc_fill(ScSession *s, const char *src, const char *dst_start, const char *dst_end);
+
 /* Structural edits — insert/delete rows & columns. 1-based `at`, `count` lines.
    The engine relocates cells and rewrites formula references (a reference to a
    deleted line becomes #REF!); the formula echo stays in step. No return — the

--- a/demo/visicalc-swiftui/Sources/VisiCalc/Engine.swift
+++ b/demo/visicalc-swiftui/Sources/VisiCalc/Engine.swift
@@ -38,6 +38,16 @@ final class SpreadsheetSession {
     /// `window` reads through `sc_get_display_window`.
     func setFormat(_ a1: String, _ code: String) { sc_set_format(handle, a1, code) }
 
+    /// Drag-fill: replicate the `src` cell across the inclusive A1 rectangle
+    /// `dstStart`..`dstEnd`. Relative references shift per target (`=A1` filled
+    /// one row down becomes `=A2`), absolute (`$`) refs pin, off-grid refs become
+    /// `#REF!`, and the source's display format rides along; the engine recomputes
+    /// every dependent. Reaches `sc_fill` — the same path the web/Qt/Flutter/
+    /// Compose/XAML demos drive.
+    func fill(_ src: String, _ dstStart: String, _ dstEnd: String) {
+        sc_fill(handle, src, dstStart, dstEnd)
+    }
+
     /// The computed value of a cell as the string a spreadsheet should show.
     /// Parses the engine's JSON (`{"kind":...}`) — the same shape the TS and
     /// WASM engines emit.

--- a/demo/visicalc-swiftui/Sources/VisiCalc/InfiniteGrid.swift
+++ b/demo/visicalc-swiftui/Sources/VisiCalc/InfiniteGrid.swift
@@ -125,6 +125,22 @@ final class WindowedSheetModel: ObservableObject {
         revision += 1
     }
 
+    /// Drag-fill: replicate the selected cell into the `rows` rows below it. The
+    /// engine shifts each copy's relative references (`=A1`→`=A2`, …), pins
+    /// absolute (`$`) refs, carries the format, and recomputes every dependent;
+    /// then resize the extent and bump `revision` so the visible rows re-fetch.
+    /// The SwiftUI sibling of the Flutter/Compose/XAML `fillDown` and the Qt
+    /// "Fill ↓ 10" button. (Int is 64-bit here, so `selectedRow + rows` over the
+    /// u32-bounded extent cannot overflow.)
+    func fillDown(_ rows: Int) {
+        let src = address(selectedRow, selectedCol)
+        let first = address(selectedRow + 1, selectedCol)
+        let last = address(selectedRow + rows, selectedCol)
+        session.fill(src, first, last)
+        resize()
+        revision += 1
+    }
+
     /// Write `raw` into an explicit A1 cell and return the cells it dirtied.
     /// (Kept for the headless `WindowedModelTests`.)
     @discardableResult
@@ -184,6 +200,10 @@ struct InfiniteGridView: View {
                 .background(Color(hex: 0x121212))
                 .cornerRadius(3)
                 .onSubmit { model.commitFormula() }
+            // Drag-fill: replicate the selected cell into the 10 rows below it.
+            Button("Fill ↓ 10") { model.fillDown(10) }
+                .font(.system(size: 11, design: .monospaced))
+                .help("Replicate the selected cell into the 10 rows below it")
         }
         .padding(.bottom, 8)
     }

--- a/demo/visicalc-swiftui/Tests/VisiCalcTests/WindowedModelTests.swift
+++ b/demo/visicalc-swiftui/Tests/VisiCalcTests/WindowedModelTests.swift
@@ -58,4 +58,20 @@ final class WindowedModelTests: XCTestCase {
         // 115+8+12+4 = 139, formatted as a percent ("0.0%") → "13900.0%".
         XCTAssertEqual(m.window(rows: 1000...1000, cols: 26...26)[0][0], "13900.0%")
     }
+
+    /// Drag-fill replicates the selected cell, shifting relative refs per target.
+    func testFillDownShiftsRelativeReferences() {
+        let m = WindowedSheetModel()
+        // Seed a fresh column: H1=2, H2=3, H3=4 (col 8 = H); I1 = H1*10 (col 9 = I).
+        m.setCell("H1", "2")
+        m.setCell("H2", "3")
+        m.setCell("H3", "4")
+        m.setCell("I1", "=H1*10") // 20
+        // Select I1 and fill down 10 — each filled formula tracks its row.
+        m.select(row: 1, col: 9)
+        m.fillDown(10)
+        XCTAssertEqual(m.rowCells(2)[8], "30") // I2 = H2*10
+        XCTAssertEqual(m.rowCells(3)[8], "40") // I3 = H3*10
+        XCTAssertEqual(m.rowCells(1)[8], "20") // I1 source untouched
+    }
 }


### PR DESCRIPTION
Adds the **"Fill ↓ 10"** drag-fill action to the SwiftUI VisiCalc infinite-sheet demo, computing on the shared Rust `spreadsheet-core` engine through its C ABI (`sc_fill`) via Swift's C-interop. This is the **last of the six backends** — with it, **every VisiCalc backend drives `sc_fill` on the one shared engine**: web (WASM) + Qt + Flutter + Compose + XAML + SwiftUI. (engine #6048, facades #6057, web #6082, Qt #6086, Flutter #6089, Compose #6094, XAML #6097.)

## Changes
- **`spreadsheet.h`** (the demo's vendored C-interop header) — declare `sc_fill` with the canonical capi doc comment.
- **`Engine.swift`** — `SpreadsheetSession.fill(src, dstStart, dstEnd)` → `sc_fill` (Swift bridges `String` → `const char*` for the synchronous void call).
- **`InfiniteGrid.swift`** — `WindowedSheetModel.fillDown(rows)` (src = selected cell, dst = the `rows` cells below; `resize()` + bump `revision`) and a "Fill ↓ 10" SwiftUI `Button` next to the formula bar. The engine shifts each copy's relative references (`=A1`→`=A2`), pins absolute (`$`) refs, carries the format, and recomputes every dependent.
- **`WindowedModelTests.swift`** — headless `fillDown` proof: seed `H1`/`H2`/`H3` + `I1 = =H1*10`, select `I1`, fill down 10 ⇒ `I2 = H2*10 = 30`, `I3 = H3*10 = 40`, source `I1 = 20` untouched.
- **`README.md`** — documents the Fill button + the assertion.

## Verification
`swift test` (vendored `libspreadsheet_capi.a`) — **9/9 pass**, including the new `testFillDownShiftsRelativeReferences`. `/security-review` passed in 1 round (Swift↔C string bridging is synchronous-void-safe; 64-bit `Int` over the u32-bounded extent can't overflow; the engine re-validates ranges).

🤖 Generated with [Claude Code](https://claude.com/claude-code)