### PR TITLE
feat(mxf64-3): array-runtime f64 path — bit-exact execute, no f32 round-trip

### DIFF
--- a/code/packages/rust/array-runtime/CHANGELOG.md
+++ b/code/packages/rust/array-runtime/CHANGELOG.md
@@ -3,6 +3,68 @@
 All notable changes to `array-runtime` are documented here. The format is based
 on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.3.0] — 2026-06-17
+
+**MXF-3 — the `f64` execution path (no `f32` round-trip).** Part of MX12, which
+brings a `DType::F64` across the shared matrix substrate (`matrix-ir → matrix-cpu
+→ matrix-runtime → array-runtime`). Before this release `execute` lowered every
+array to an **`F32`** `matrix-ir` graph and crossed the boundary as 4-byte
+floats, so a `f64 → f32 → f64` round-trip rounded the result and `execute` agreed
+with the `ops` reference path only to `f32` precision. MXF-3 removes that
+round-trip: `f64` arrays now lower to an **`F64`** graph and cross the boundary as
+**8-byte** little-endian doubles, so `execute` returns the **bit-exact** `f64`
+result.
+
+### Changed
+
+- **`accel::build_graph` and `accel::plan_backend` now take an explicit
+  `dtype: DType`** (inserted after `kernel`). `DType::F64` builds a double-
+  precision graph; `DType::F32` preserves the historical single-precision path.
+  This is a **breaking** signature change for `plan_backend` (a public fn) — call
+  sites must pass the element dtype.
+- The synthetic `gpu_profile()` now advertises `gflops_f64 = 0`, matching the
+  real CUDA/Metal V1 executors (no `f64` kernel). The cost model turns that into
+  the ∞-cost sentinel, so an `f64` op is never placed on the GPU — it stays on
+  the CPU, exactly MXF-2's contract.
+
+### Added
+
+- An **8-byte little-endian `f64` codec** in `exec.rs` (`f64_bytes` /
+  `f64_from_bytes`), mirroring `matrix-cpu`'s `write_f64_vec`/`read_f64_vec`
+  byte-for-byte so the buffers are directly consumable by the executor's `F64`
+  kernels. `f64_from_bytes` validates the length is a whole number of 8-byte
+  doubles and returns an `Err` (never panics or reads out of bounds) on a short
+  or ragged buffer.
+- `execute(kernel, &a, &b)` now defaults to the **`F64`** path (since `Array` is
+  `f64`-valued), returning the bit-exact double-precision result. The legacy
+  `F32` path stays reachable for `f32` callers via the crate-internal
+  `execute_with_dtype`.
+- `execute_sum(&a) -> Result<Array, String>`: a whole-array `f64` reduction run
+  end-to-end through `matrix-cpu`'s `F64` reduce-all kernel, folding the buffer
+  in the same left-to-right order as `ops::sum` so the two agree bit-for-bit.
+- `DType` is re-exported at the crate root (so callers can pick the lowering
+  dtype for `plan_backend`).
+
+### Invariant proven in tests
+
+For `f64` inputs, `execute`/`execute_sum` equal the `ops` reference path to
+**full `f64` precision**, asserted bit-for-bit on values **not representable in
+`f32`** (e.g. `1 + 2^-40`, a `matmul` whose exact product is `1 + 2^-40`, and a
+running `sum` that carries sub-`f32` bits). The old `f32` round-trip is shown to
+collapse those same values to `1.0`/`0.0`, so the tests genuinely distinguish the
+two paths. The `usize → u32` shape-cast guard is re-tested (a dim `> u32::MAX`
+errors cleanly for both dtypes, no panic/truncation), and the `f32` path is kept
+under test, unchanged.
+
+### Tests
+
+53 tests (47 unit + 5 integration + 1 doctest). New integration suite
+`tests/f64_bit_exact.rs` proves the bit-exact `f64` invariant for elementwise,
+`matmul`, and `sum` through the public API; new unit tests cover the 8-byte
+codec round-trip / short-buffer rejection, the `F64` lowering carrying 8-byte
+tensors, and `f64` ops staying on the CPU when the same `f32` op would dispatch
+to the GPU.
+
 ## [0.2.0] — 2026-06-16
 
 **MA-2 — end-to-end execution.** MA-1 planned the lowered graph and produced

--- a/code/packages/rust/array-runtime/Cargo.toml
+++ b/code/packages/rust/array-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-array-runtime"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 description = "N-D numeric array substrate for array languages — lowers to matrix-ir for GPU-aware execution"
 

--- a/code/packages/rust/array-runtime/README.md
+++ b/code/packages/rust/array-runtime/README.md
@@ -62,26 +62,38 @@ host↔device-transfer cost model. CPU is the always-available fallback. So a la
 small one stays on the CPU — with **no language-level GPU code and no "use GPU"
 keyword**.
 
-```rust
-use coding_adventures_array_runtime::{Kernel, BinOp, plan_backend};
+`plan_backend` takes the element `DType`, because the dtype affects *placement*,
+not just the math: a backend with no `f64` kernel (the GPU profile advertises
+`gflops_f64 = 0`) costs an `f64` op as ∞, so `f64` work stays on the CPU even when
+the same `f32` op would be shipped to the accelerator.
 
-// A big matmul is worth shipping to an accelerator…
-assert_eq!(plan_backend(Kernel::MatMul, &[256, 256], &[256, 256], true).unwrap(), "gpu");
-// …a tiny elementwise op is not.
-assert_eq!(plan_backend(Kernel::Elementwise(BinOp::Add), &[2, 2], &[2, 2], true).unwrap(), "cpu");
+```rust
+use coding_adventures_array_runtime::{Kernel, BinOp, DType, plan_backend};
+
+// A big f32 matmul is worth shipping to an accelerator…
+assert_eq!(plan_backend(Kernel::MatMul, DType::F32, &[256, 256], &[256, 256], true).unwrap(), "gpu");
+// …a tiny elementwise op is not…
+assert_eq!(plan_backend(Kernel::Elementwise(BinOp::Add), DType::F32, &[2, 2], &[2, 2], true).unwrap(), "cpu");
+// …and the same big matmul in f64 stays on the CPU (the GPU has no f64 kernel).
+assert_eq!(plan_backend(Kernel::MatMul, DType::F64, &[256, 256], &[256, 256], true).unwrap(), "cpu");
 ```
 
-### 4. End-to-end execution (`exec.rs`, MA-2)
+### 4. End-to-end execution (`exec.rs`, MA-2 + MXF-3)
 
 `execute()` doesn't just *plan* the graph — it **runs** it through
 [`matrix-cpu`](../matrix-cpu)'s executor, returning real numeric results from the
-same pipeline a GPU would use. It bridges two boundaries: precision (`f64` ↔
-`f32`, since `matrix-ir` has no `f64` dtype yet) and memory order (column-major ↔
-the executor's row-major — elementwise passes through, `matmul` transposes at the
-edges).
+same pipeline a GPU would use. It bridges two boundaries: **precision** and
+**memory order** (column-major ↔ the executor's row-major — elementwise passes
+through, `matmul` transposes at the edges).
+
+As of **MX12 / MXF-3**, `matrix-ir` has a `DType::F64`, so `execute()` lowers
+`f64` arrays to an **`F64`** graph and crosses the boundary as **8-byte** doubles
+— **no `f64 → f32 → f64` round-trip**. The result is therefore **bit-exact** with
+the `ops` reference path, even on values `f32` cannot represent (e.g. `1 + 2^-40`,
+which the old `f32` path collapsed to `1.0`).
 
 ```rust
-use coding_adventures_array_runtime::{Array, Kernel, BinOp, execute};
+use coding_adventures_array_runtime::{Array, Kernel, execute, execute_sum, ops};
 
 let a = Array::from_rows(vec![vec![1.0, 2.0], vec![3.0, 4.0]]).unwrap();
 let b = Array::from_rows(vec![vec![5.0, 6.0], vec![7.0, 8.0]]).unwrap();
@@ -89,6 +101,18 @@ let b = Array::from_rows(vec![vec![5.0, 6.0], vec![7.0, 8.0]]).unwrap();
 // Planned and executed on the CPU executor — [[19,22],[43,50]].
 let c = execute(Kernel::MatMul, &a, &b).unwrap();
 assert_eq!(c.get(0, 0), Some(19.0));
+
+// Full f64 precision: a value f32 can't hold survives the executor round-trip,
+// so the executed result matches the reference path bit-for-bit.
+let x = 1.0 + 2f64.powi(-40); // distinct from 1.0 in f64, == 1.0 as f32
+let p = Array::from_vec(vec![x]);
+let one = Array::from_vec(vec![1.0]);
+let executed = execute(Kernel::Elementwise(coding_adventures_array_runtime::BinOp::Sub), &p, &one).unwrap();
+assert_eq!(executed.data()[0].to_bits(), ops::sub(&p, &one).unwrap().data()[0].to_bits());
+
+// `execute_sum` runs an f64 whole-array reduction on the same path.
+let total = execute_sum(&Array::from_vec(vec![1.0, 2.0, 3.0])).unwrap();
+assert_eq!(total.data()[0], 6.0);
 ```
 
 ## Status
@@ -96,11 +120,17 @@ assert_eq!(c.get(0, 0), Some(19.0));
 - **MA-1 (merged):** the value model, the CPU reference ops (exact `f64` results),
   and the full `matrix-ir` lowering + cost-planner integration — the backend
   choice is observable and tested.
-- **MA-2 (this release):** `execute()` plans **and runs** the lowered graph on the
-  CPU executor for elementwise + `matmul`, cross-checked against the reference
-  path. The same path runs on a GPU executor the moment one is registered.
-- **Next:** executing `transpose`/reductions, scalar-broadcast execution, and
-  registering real CUDA/Metal executor crates.
+- **MA-2 (merged):** `execute()` plans **and runs** the lowered graph on the CPU
+  executor for elementwise + `matmul`, cross-checked against the reference path.
+  The same path runs on a GPU executor the moment one is registered.
+- **MXF-3 (this release):** the `f64` path. `execute()` lowers `f64` arrays to an
+  `F64` graph and uses an 8-byte codec — no `f32` round-trip — so the executed
+  result is **bit-exact** with the reference path. `execute_sum()` adds an `f64`
+  whole-array reduction on the same path. `plan_backend`/`build_graph` now take an
+  explicit `DType` (breaking signature change for `plan_backend`).
+- **Next (MXF-4):** R's `s-runtime` adopts this `f64` path for `%*%` and the
+  matrix ops, replacing its hand-written loops; then executing scalar-broadcast /
+  `transpose`, and registering real CUDA/Metal executor crates.
 
 ## Where it sits in the stack
 

--- a/code/packages/rust/array-runtime/src/accel.rs
+++ b/code/packages/rust/array-runtime/src/accel.rs
@@ -34,12 +34,25 @@ fn shape_of(dims: &[usize]) -> Result<Shape, String> {
     Ok(Shape { dims })
 }
 
-/// Build the `matrix-ir` graph for `kernel` over operands of the given shapes.
-/// Shared with [`crate::exec`], which plans *and executes* the same graph.
-pub(crate) fn build_graph(kernel: Kernel, a: &[usize], b: &[usize]) -> Result<Graph, String> {
+/// Build the `matrix-ir` graph for `kernel` over operands of the given shapes,
+/// at the given element `dtype`. Shared with [`crate::exec`], which plans *and
+/// executes* the same graph.
+///
+/// The substrate is dtype-agnostic by architecture — dtype is a per-tensor
+/// property threaded through the SSA graph — so the same lowering serves both
+/// `F32` and `F64` (MX12 / MXF-3): we hand the inputs the requested `dtype` and
+/// every op propagates it. An `f64` array lowers to an `F64` graph and stays
+/// double-precision end-to-end (no `f32` round-trip); an `f32` array lowers to
+/// the historical `F32` graph unchanged.
+pub(crate) fn build_graph(
+    kernel: Kernel,
+    dtype: DType,
+    a: &[usize],
+    b: &[usize],
+) -> Result<Graph, String> {
     let mut g = GraphBuilder::new();
-    let ta = g.input(DType::F32, shape_of(a)?);
-    let tb = g.input(DType::F32, shape_of(b)?);
+    let ta = g.input(dtype, shape_of(a)?);
+    let tb = g.input(dtype, shape_of(b)?);
     let out = match kernel {
         Kernel::Elementwise(BinOp::Add) => g.add(&ta, &tb),
         Kernel::Elementwise(BinOp::Sub) => g.sub(&ta, &tb),
@@ -61,23 +74,35 @@ pub fn gpu_profile() -> executor_protocol::BackendProfile {
     p.gflops_f32 = 4000;
     p.gflops_u8 = 4000;
     p.gflops_i32 = 4000;
+    // No `f64` kernel on this synthetic accelerator (MX12 / MXF-2: the real
+    // CUDA/Metal V1 executors advertise `gflops_f64 = 0` too). The cost model
+    // turns a 0 rate into the ∞-cost sentinel, so an `f64` op is never shipped
+    // here — it falls back to the CPU. Without this the inherited CPU `f64` rate
+    // would wrongly let `f64` ops dispatch to a backend that can't run them.
+    p.gflops_f64 = 0;
     p.host_to_device_bw = 8;
     p.device_to_host_bw = 8;
     p.launch_overhead_ns = 5_000;
     p
 }
 
-/// Plan `kernel` over the given operand shapes and return the executor *kind*
-/// (`"cpu"`/`"gpu"`/…) the cost model placed the compute op on. With
-/// `with_gpu`, an accelerator ([`gpu_profile`]) is registered so the cost-based
-/// choice can be exercised; without it, only the CPU is available.
+/// Plan `kernel` over the given operand shapes (at element `dtype`) and return
+/// the executor *kind* (`"cpu"`/`"gpu"`/…) the cost model placed the compute op
+/// on. With `with_gpu`, an accelerator ([`gpu_profile`]) is registered so the
+/// cost-based choice can be exercised; without it, only the CPU is available.
+///
+/// The `dtype` matters to the *placement*, not just the math: a backend with no
+/// `f64` throughput (`gflops_f64 = 0`, the GPU profile here) costs an `f64` op as
+/// ∞, so an `f64` graph is kept on the CPU even when the same `f32` graph would
+/// be shipped to the accelerator (MXF-2's cost-model contract).
 pub fn plan_backend(
     kernel: Kernel,
+    dtype: DType,
     a: &[usize],
     b: &[usize],
     with_gpu: bool,
 ) -> Result<String, String> {
-    let graph = build_graph(kernel, a, b)?;
+    let graph = build_graph(kernel, dtype, a, b)?;
 
     let mut rt = Runtime::new(matrix_cpu::profile());
     if with_gpu {
@@ -111,12 +136,13 @@ mod tests {
     #[test]
     fn cpu_only_when_no_accelerator() {
         // With only the CPU registered, every op is placed on the CPU.
+        let add = Kernel::Elementwise(BinOp::Add);
         assert_eq!(
-            plan_backend(Kernel::Elementwise(BinOp::Add), &[3], &[3], false).unwrap(),
+            plan_backend(add, DType::F32, &[3], &[3], false).unwrap(),
             "cpu"
         );
         assert_eq!(
-            plan_backend(Kernel::MatMul, &[128, 128], &[128, 128], false).unwrap(),
+            plan_backend(Kernel::MatMul, DType::F32, &[128, 128], &[128, 128], false).unwrap(),
             "cpu"
         );
     }
@@ -124,8 +150,9 @@ mod tests {
     #[test]
     fn small_op_stays_on_cpu_even_with_a_gpu() {
         // A tiny elementwise op isn't worth the transfer to an accelerator.
+        let add = Kernel::Elementwise(BinOp::Add);
         assert_eq!(
-            plan_backend(Kernel::Elementwise(BinOp::Add), &[2, 2], &[2, 2], true).unwrap(),
+            plan_backend(add, DType::F32, &[2, 2], &[2, 2], true).unwrap(),
             "cpu"
         );
     }
@@ -137,7 +164,7 @@ mod tests {
         // graph the planner accepts).
         for op in [BinOp::Add, BinOp::Sub, BinOp::Mul, BinOp::Div] {
             assert_eq!(
-                plan_backend(Kernel::Elementwise(op), &[4], &[4], false).unwrap(),
+                plan_backend(Kernel::Elementwise(op), DType::F32, &[4], &[4], false).unwrap(),
                 "cpu"
             );
         }
@@ -146,9 +173,12 @@ mod tests {
     #[test]
     fn oversized_dim_is_rejected_not_truncated() {
         // A dim past u32::MAX must be an error, not a silent truncation that
-        // would make the planner cost the wrong (smaller) op.
+        // would make the planner cost the wrong (smaller) op. The guard is on the
+        // shape cast, so it fires for either dtype.
         let big = (u32::MAX as usize) + 1;
-        assert!(plan_backend(Kernel::Elementwise(BinOp::Add), &[big], &[big], false).is_err());
+        let add = Kernel::Elementwise(BinOp::Add);
+        assert!(plan_backend(add, DType::F32, &[big], &[big], false).is_err());
+        assert!(plan_backend(add, DType::F64, &[big], &[big], false).is_err());
     }
 
     #[test]
@@ -157,8 +187,34 @@ mod tests {
         // moves it to the accelerator. This is the GPU-dispatch decision the
         // whole substrate exists to make, with zero language-level GPU code.
         assert_eq!(
-            plan_backend(Kernel::MatMul, &[256, 256], &[256, 256], true).unwrap(),
+            plan_backend(Kernel::MatMul, DType::F32, &[256, 256], &[256, 256], true).unwrap(),
             "gpu"
         );
+    }
+
+    #[test]
+    fn f64_matmul_stays_on_cpu_even_when_f32_would_go_to_gpu() {
+        // The *same* large matmul: as F32 the planner ships it to the GPU, but as
+        // F64 the GPU advertises no f64 throughput (gflops_f64 = 0 → ∞ cost), so
+        // the cost model keeps it on the CPU. This is MXF-2's contract observed
+        // through array-runtime's own lowering — and exactly why MXF-3 must lower
+        // f64 arrays at DType::F64, not silently downcast to F32.
+        assert_eq!(
+            plan_backend(Kernel::MatMul, DType::F32, &[256, 256], &[256, 256], true).unwrap(),
+            "gpu"
+        );
+        assert_eq!(
+            plan_backend(Kernel::MatMul, DType::F64, &[256, 256], &[256, 256], true).unwrap(),
+            "cpu"
+        );
+    }
+
+    #[test]
+    fn f64_graph_uses_eight_byte_tensors() {
+        // The lowered graph must actually carry F64 (8-byte) inputs, proving the
+        // dtype threaded through rather than being dropped to F32 (4-byte).
+        let g = build_graph(Kernel::Elementwise(BinOp::Add), DType::F64, &[3], &[3]).unwrap();
+        assert!(g.inputs.iter().all(|t| t.dtype == DType::F64));
+        assert_eq!(g.inputs[0].shape.byte_size(DType::F64), Some(3 * 8));
     }
 }

--- a/code/packages/rust/array-runtime/src/exec.rs
+++ b/code/packages/rust/array-runtime/src/exec.rs
@@ -114,7 +114,12 @@ pub fn execute_sum(a: &Array) -> Result<Array, String> {
         .map_err(|e| format!("execute_sum: graph build failed: {e:?}"))?;
 
     let out = run_graph_on_cpu(&graph, &[f64_bytes(a.data())])?;
-    let data = f64_from_bytes(&out[0])?;
+    // Index the output defensively: the graph declares exactly one output, but
+    // never panic if the executor hands back an unexpected shape.
+    let first = out
+        .first()
+        .ok_or_else(|| "execute_sum: executor returned no output buffer".to_string())?;
+    let data = f64_from_bytes(first)?;
     if data.len() != 1 {
         return Err(format!(
             "execute_sum: reduce-all should yield one scalar, got {} values",

--- a/code/packages/rust/array-runtime/src/exec.rs
+++ b/code/packages/rust/array-runtime/src/exec.rs
@@ -10,11 +10,15 @@
 //!
 //! ## Two boundary conversions
 //!
-//! 1. **Precision.** `array-runtime` computes in `f64`; `matrix-ir`/the executor
-//!    work in `f32`. We convert to `f32` little-endian bytes on the way in and
-//!    back to `f64` on the way out. (A future `f64` dtype in `matrix-ir` removes
-//!    this; until then the reference path in [`crate::ops`] stays the exact-`f64`
-//!    answer, and these results match it to `f32` precision.)
+//! 1. **Precision.** `array-runtime` computes in `f64`. As of **MX12 / MXF-3**
+//!    `matrix-ir` has a `DType::F64`, so an `f64` array now lowers to an **`F64`**
+//!    graph and crosses the boundary as **8-byte** little-endian doubles — no
+//!    `f32` round-trip. `execute` therefore returns the **bit-exact** `f64`
+//!    answer, agreeing with the reference path in [`crate::ops`] to full `f64`
+//!    precision (a value like `1.0 + 2^-40`, which `f32` cannot represent,
+//!    survives). The historical **`F32`** path (4-byte floats) is kept for `f32`
+//!    callers via [`execute_with_dtype`]; it agrees with the reference only to
+//!    `f32` precision, by construction.
 //!
 //! 2. **Memory order.** `array-runtime` stores **column-major**; `matrix-cpu`'s
 //!    kernels are **row-major**. Elementwise ops are positional, so order is
@@ -35,7 +39,7 @@ use std::collections::HashMap;
 use compute_ir::{BufferId, ComputeGraph, PlacedConstant, PlacedOp, PlacedTensor, Residency};
 use executor_protocol::{ExecutorRequest, ExecutorResponse};
 use matrix_cpu::CpuExecutor;
-use matrix_ir::Graph;
+use matrix_ir::{DType, Graph};
 use matrix_runtime::Runtime;
 
 use crate::accel::{build_graph, Kernel};
@@ -59,15 +63,70 @@ pub const MAX_TOTAL_BUFFER_BYTES: u64 = 4 * 1024 * 1024 * 1024;
 /// and `matmul` (`[m,k] · [k,n]`). Scalar broadcasting and `transpose`/reductions
 /// are not yet lowered for execution — use [`crate::ops`] for those.
 pub fn execute(kernel: Kernel, a: &Array, b: &Array) -> Result<Array, String> {
+    // `Array` is `f64`-valued, so the default path is **full `f64` precision**
+    // (MX12 / MXF-3): lower to an `F64` graph and cross the boundary as 8-byte
+    // doubles, with no `f32` round-trip.
+    execute_with_dtype(kernel, DType::F64, a, b)
+}
+
+/// Execute `kernel` over `a`/`b` lowering at element `dtype`. `DType::F64` keeps
+/// full double precision (8-byte codec); `DType::F32` takes the historical
+/// 4-byte path (rounds to `f32` at the boundary, kept for `f32` callers). Any
+/// other dtype is rejected — `array-runtime` only computes floats.
+///
+/// Exposed within the crate so both the bit-exact `f64` path and the legacy
+/// `f32` path are directly testable from the same entry point.
+pub(crate) fn execute_with_dtype(
+    kernel: Kernel,
+    dtype: DType,
+    a: &Array,
+    b: &Array,
+) -> Result<Array, String> {
     match kernel {
-        Kernel::Elementwise(op) => execute_elementwise(op, a, b),
-        Kernel::MatMul => execute_matmul(a, b),
+        Kernel::Elementwise(op) => execute_elementwise(op, dtype, a, b),
+        Kernel::MatMul => execute_matmul(dtype, a, b),
     }
+}
+
+/// Execute a **whole-array sum** end-to-end on the CPU executor at full `f64`
+/// precision (MX12 / MXF-3), returning the scalar total as a 1×1 [`Array`].
+///
+/// This lowers `a` to a single-input `reduce_sum` graph with *empty axes*
+/// (reduce-all) and runs it through `matrix-cpu`'s `F64` reduce kernel. Like the
+/// reference [`crate::ops::sum`], it folds the column-major buffer left-to-right
+/// from `0.0`, so the two agree **bit-for-bit** — including on a running sum that
+/// is not representable in `f32`. (It is the executed analogue of the reference
+/// reduction, and the substrate path R/MATLAB reductions will adopt in MXF-4.)
+pub fn execute_sum(a: &Array) -> Result<Array, String> {
+    use matrix_ir::{GraphBuilder, Shape};
+
+    let n = a.len();
+    // Lower the flat buffer as a 1-D `[n]` F64 tensor and reduce-all to a scalar.
+    let dims = vec![u32::try_from(n).map_err(|_| {
+        format!("execute_sum: length {n} exceeds u32::MAX (matrix-ir shape limit)")
+    })?];
+    let mut g = GraphBuilder::new();
+    let t = g.input(DType::F64, Shape { dims });
+    let s = g.reduce_sum(&t, Vec::new(), false); // empty axes = reduce all
+    g.output(&s);
+    let graph = g
+        .build()
+        .map_err(|e| format!("execute_sum: graph build failed: {e:?}"))?;
+
+    let out = run_graph_on_cpu(&graph, &[f64_bytes(a.data())])?;
+    let data = f64_from_bytes(&out[0])?;
+    if data.len() != 1 {
+        return Err(format!(
+            "execute_sum: reduce-all should yield one scalar, got {} values",
+            data.len()
+        ));
+    }
+    Array::from_shape(data, vec![]) // scalar
 }
 
 /// Elementwise execution. Layout-agnostic (positional), so the column-major
 /// bytes go straight to the row-major executor and back unchanged.
-fn execute_elementwise(op: BinOp, a: &Array, b: &Array) -> Result<Array, String> {
+fn execute_elementwise(op: BinOp, dtype: DType, a: &Array, b: &Array) -> Result<Array, String> {
     if a.shape() != b.shape() {
         return Err(format!(
             "execute: elementwise needs equal shapes, got {:?} vs {:?} \
@@ -76,16 +135,16 @@ fn execute_elementwise(op: BinOp, a: &Array, b: &Array) -> Result<Array, String>
             b.shape()
         ));
     }
-    let graph = build_graph(Kernel::Elementwise(op), a.shape(), b.shape())?;
-    let out = run_graph_on_cpu(&graph, &[f32_bytes(a.data()), f32_bytes(b.data())])?;
-    let data = f64_from_bytes(&out[0])?;
+    let graph = build_graph(Kernel::Elementwise(op), dtype, a.shape(), b.shape())?;
+    let out = run_graph_on_cpu(&graph, &[encode(dtype, a.data()), encode(dtype, b.data())])?;
+    let data = decode(dtype, &out[0])?;
     Array::from_shape(data, a.shape().to_vec())
 }
 
 /// Matrix-product execution. Bridges the column-major ↔ row-major gap:
 /// transpose each operand's data into row-major, run the row-major kernel, then
 /// transpose the row-major result back into column-major storage.
-fn execute_matmul(a: &Array, b: &Array) -> Result<Array, String> {
+fn execute_matmul(dtype: DType, a: &Array, b: &Array) -> Result<Array, String> {
     let (m, k) = (a.nrows(), a.ncols());
     let (k2, n) = (b.nrows(), b.ncols());
     if k != k2 {
@@ -93,18 +152,40 @@ fn execute_matmul(a: &Array, b: &Array) -> Result<Array, String> {
             "execute: matmul inner dims disagree ({m}x{k} · {k2}x{n})"
         ));
     }
-    let graph = build_graph(Kernel::MatMul, &[m, k], &[k, n])?;
+    let graph = build_graph(Kernel::MatMul, dtype, &[m, k], &[k, n])?;
     let a_row = col_to_row(a.data(), m, k);
     let b_row = col_to_row(b.data(), k, n);
-    let out = run_graph_on_cpu(&graph, &[f32_bytes(&a_row), f32_bytes(&b_row)])?;
-    let c_row = f64_from_bytes(&out[0])?; // row-major [m, n]
+    let out = run_graph_on_cpu(&graph, &[encode(dtype, &a_row), encode(dtype, &b_row)])?;
+    let c_row = decode(dtype, &out[0])?; // row-major [m, n]
     let c_col = row_to_col(&c_row, m, n); // back to column-major
     Array::from_shape(c_col, vec![m, n])
 }
 
 // ── Boundary conversions ────────────────────────────────────────────────────
+//
+// `array-runtime` holds every value as `f64`. The executor's wire format is the
+// element dtype's little-endian bytes, so we encode on the way in and decode on
+// the way out. The dtype picks the width: `F64` is 8 bytes (bit-exact, the
+// default), `F32` is 4 bytes (the historical path; it rounds at the boundary).
 
-/// `f64` values → `f32` little-endian bytes (the executor's wire format).
+/// `f64` values → little-endian bytes for `dtype` (the executor's wire format).
+/// `F64` writes 8 bytes per value (no precision loss); `F32` narrows to 4.
+fn encode(dtype: DType, values: &[f64]) -> Vec<u8> {
+    match dtype {
+        DType::F64 => f64_bytes(values),
+        _ => f32_bytes(values),
+    }
+}
+
+/// Little-endian `dtype` bytes → `f64` values (inverse of [`encode`]).
+fn decode(dtype: DType, bytes: &[u8]) -> Result<Vec<f64>, String> {
+    match dtype {
+        DType::F64 => f64_from_bytes(bytes),
+        _ => f32_from_bytes(bytes),
+    }
+}
+
+/// `f64` values → `f32` little-endian bytes (4 bytes each).
 fn f32_bytes(values: &[f64]) -> Vec<u8> {
     let mut out = Vec::with_capacity(values.len() * 4);
     for &v in values {
@@ -113,8 +194,9 @@ fn f32_bytes(values: &[f64]) -> Vec<u8> {
     out
 }
 
-/// `f32` little-endian bytes → `f64` values.
-fn f64_from_bytes(bytes: &[u8]) -> Result<Vec<f64>, String> {
+/// `f32` little-endian bytes → `f64` values. Rejects a length that is not a
+/// whole number of 4-byte `f32`s rather than reading past the end.
+fn f32_from_bytes(bytes: &[u8]) -> Result<Vec<f64>, String> {
     let chunks = bytes.chunks_exact(4);
     if !chunks.remainder().is_empty() {
         return Err(format!(
@@ -124,6 +206,35 @@ fn f64_from_bytes(bytes: &[u8]) -> Result<Vec<f64>, String> {
     }
     Ok(chunks
         .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]]) as f64)
+        .collect())
+}
+
+/// `f64` values → **8-byte** little-endian bytes (the `F64` wire format,
+/// MX12 / MXF-3). Mirrors `matrix-cpu`'s `write_f64_vec` byte-for-byte, so the
+/// buffer is directly consumable by the executor's `F64` kernels. No precision
+/// is lost — this is the whole point of the `f64` path.
+fn f64_bytes(values: &[f64]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(values.len() * 8);
+    for &v in values {
+        out.extend_from_slice(&v.to_le_bytes());
+    }
+    out
+}
+
+/// **8-byte** little-endian bytes → `f64` values (inverse of [`f64_bytes`],
+/// mirroring `matrix-cpu`'s `read_f64_vec`). Validates that the length is a
+/// whole number of 8-byte doubles and returns an `Err` — never panicking or
+/// reading out of bounds — on a short or ragged buffer from a malformed result.
+fn f64_from_bytes(bytes: &[u8]) -> Result<Vec<f64>, String> {
+    let chunks = bytes.chunks_exact(8);
+    if !chunks.remainder().is_empty() {
+        return Err(format!(
+            "output byte length {} is not a whole number of f64 values",
+            bytes.len()
+        ));
+    }
+    Ok(chunks
+        .map(|c| f64::from_le_bytes([c[0], c[1], c[2], c[3], c[4], c[5], c[6], c[7]]))
         .collect())
 }
 
@@ -323,7 +434,9 @@ mod tests {
     use super::*;
     use crate::ops;
 
-    /// Executed result must match the CPU reference path (to f32 precision).
+    /// Executed result must match the CPU reference path within `f32` tolerance.
+    /// Used for the legacy `f32` path; the `f64` path uses the stricter
+    /// [`assert_bit_exact`] below.
     fn assert_matches_reference(executed: &Array, reference: &Array) {
         assert_eq!(executed.shape(), reference.shape(), "shape mismatch");
         for (e, r) in executed.data().iter().zip(reference.data()) {
@@ -332,6 +445,34 @@ mod tests {
                 "executed {e} vs reference {r}"
             );
         }
+    }
+
+    /// Executed result must equal the reference **bit-for-bit** — the MXF-3
+    /// invariant for the `f64` path. Compares raw bit patterns (so a `-0.0` vs
+    /// `0.0` or any rounding difference would fail), not an `==` with tolerance.
+    fn assert_bit_exact(executed: &Array, reference: &Array) {
+        assert_eq!(executed.shape(), reference.shape(), "shape mismatch");
+        for (e, r) in executed.data().iter().zip(reference.data()) {
+            assert_eq!(
+                e.to_bits(),
+                r.to_bits(),
+                "not bit-exact: executed {e} ({:#018x}) vs reference {r} ({:#018x})",
+                e.to_bits(),
+                r.to_bits()
+            );
+        }
+    }
+
+    /// A value that is **not** representable in `f32`: `1 + 2^-40` rounds to
+    /// exactly `1.0` as an `f32`, but is a distinct `f64`. Any `f64 → f32 → f64`
+    /// round-trip collapses it to `1.0`; the bit-exact `f64` path preserves it.
+    fn f32_unrepresentable() -> f64 {
+        let v = 1.0 + 2f64.powi(-40);
+        // Sanity: it really does collapse under an f32 round-trip, so the tests
+        // below are genuinely distinguishing the two paths.
+        assert_eq!(v as f32 as f64, 1.0);
+        assert_ne!(v, 1.0);
+        v
     }
 
     #[test]
@@ -406,15 +547,40 @@ mod tests {
     }
 
     #[test]
-    fn f64_from_bytes_rejects_partial_f32() {
-        // A byte length that isn't a whole number of f32s is an error.
-        assert!(f64_from_bytes(&[0u8; 6]).is_err());
-        assert!(f64_from_bytes(&[0u8; 8]).is_ok());
+    fn f32_from_bytes_rejects_partial_f32() {
+        // A byte length that isn't a whole number of f32s (4 bytes) is an error,
+        // not an out-of-bounds read.
+        assert!(f32_from_bytes(&[0u8; 6]).is_err());
+        assert!(f32_from_bytes(&[0u8; 8]).is_ok());
+    }
+
+    #[test]
+    fn f64_from_bytes_rejects_partial_f64() {
+        // A byte length that isn't a whole number of f64s (8 bytes) is an error,
+        // never a panic or a read past the end of a short/ragged buffer.
+        assert!(f64_from_bytes(&[0u8; 7]).is_err());
+        assert!(f64_from_bytes(&[0u8; 12]).is_err()); // 1.5 doubles
+        assert!(f64_from_bytes(&[0u8; 0]).is_ok()); // empty is a whole 0 doubles
+        assert!(f64_from_bytes(&[0u8; 16]).is_ok()); // 2 doubles
+    }
+
+    #[test]
+    fn f64_codec_round_trips_bit_exactly() {
+        // f64_bytes / f64_from_bytes must be exact inverses on values f32 can't
+        // hold, and the byte layout must match matrix-cpu's (8-byte LE) so the
+        // executor reads back the same doubles.
+        let vals = vec![f32_unrepresentable(), -0.0, 1e300, f64::MIN_POSITIVE];
+        let bytes = f64_bytes(&vals);
+        assert_eq!(bytes.len(), vals.len() * 8);
+        let back = f64_from_bytes(&bytes).unwrap();
+        for (a, b) in vals.iter().zip(&back) {
+            assert_eq!(a.to_bits(), b.to_bits());
+        }
     }
 
     #[test]
     fn run_graph_rejects_wrong_input_count() {
-        let graph = build_graph(Kernel::Elementwise(BinOp::Add), &[2], &[2]).unwrap();
+        let graph = build_graph(Kernel::Elementwise(BinOp::Add), DType::F32, &[2], &[2]).unwrap();
         // Graph declares two inputs; provide one.
         let err = run_graph_on_cpu(&graph, &[f32_bytes(&[1.0, 2.0])]);
         assert!(err.is_err());
@@ -422,7 +588,7 @@ mod tests {
 
     #[test]
     fn run_graph_rejects_wrong_input_byte_length() {
-        let graph = build_graph(Kernel::Elementwise(BinOp::Add), &[2], &[2]).unwrap();
+        let graph = build_graph(Kernel::Elementwise(BinOp::Add), DType::F32, &[2], &[2]).unwrap();
         // Right count, wrong size: input 0 needs 2 f32s (8 bytes), give 1.
         let err = run_graph_on_cpu(&graph, &[f32_bytes(&[1.0]), f32_bytes(&[1.0, 2.0])]);
         assert!(err.is_err());
@@ -436,5 +602,106 @@ mod tests {
         let row = col_to_row(&col, 2, 3);
         assert_eq!(row, vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
         assert_eq!(row_to_col(&row, 2, 3), col);
+    }
+
+    // ── MXF-3: the f64 path is bit-exact, the f32 path is not ────────────────
+
+    #[test]
+    fn f64_elementwise_is_bit_exact_on_f32_unrepresentable_values() {
+        // x = 1 + 2^-40 is exact in f64 but rounds to 1.0 in f32. The default
+        // execute() path (F64) must reproduce ops:: exactly; the legacy F32 path
+        // must NOT — proving the round-trip is genuinely gone.
+        let x = f32_unrepresentable();
+        let a = Array::from_vec(vec![x, x, x]);
+        let one = Array::from_vec(vec![1.0, 1.0, 1.0]);
+        for op in [BinOp::Add, BinOp::Sub, BinOp::Mul] {
+            let reference = ops::elementwise(op, &a, &one).unwrap();
+
+            let f64_exec = execute(Kernel::Elementwise(op), &a, &one).unwrap();
+            assert_bit_exact(&f64_exec, &reference);
+
+            // The old behaviour, for contrast: the f32 path rounds the input and
+            // so cannot be bit-exact for a sub/mul that depends on the lost bits.
+            let f32_exec =
+                execute_with_dtype(Kernel::Elementwise(op), DType::F32, &a, &one).unwrap();
+            if op == BinOp::Sub {
+                // (1 + 2^-40) - 1 == 2^-40 exactly in f64, but the f32 path sees
+                // 1.0 - 1.0 == 0.0. Concrete proof the precision actually differs.
+                assert_eq!(reference.data()[0].to_bits(), 2f64.powi(-40).to_bits());
+                assert_eq!(f32_exec.data()[0], 0.0);
+            }
+        }
+    }
+
+    #[test]
+    fn f64_matmul_is_bit_exact_where_f32_would_round() {
+        // Build a 1x2 · 2x1 dot product whose exact value carries a bit f32 can't
+        // hold: [1, 2^-20] · [1, 2^-20]^T = 1 + 2^-40. In f64 that's exact
+        // (ulp(1.0) = 2^-52, so 2^-40 survives); the f32 path (ulp(1.0) = 2^-23)
+        // collapses 2^-40 and returns 1.0.
+        let tiny = 2f64.powi(-20);
+        let a = Array::from_rows(vec![vec![1.0, tiny]]).unwrap(); // 1x2
+        let b = Array::from_rows(vec![vec![1.0], vec![tiny]]).unwrap(); // 2x1
+        let reference = ops::matmul(&a, &b).unwrap();
+
+        let f64_exec = execute(Kernel::MatMul, &a, &b).unwrap();
+        assert_bit_exact(&f64_exec, &reference);
+
+        // Reference really does hold 1 + 2^-40 (not 1.0), and the f32 path loses it.
+        assert_eq!(
+            reference.data()[0].to_bits(),
+            (1.0 + 2f64.powi(-40)).to_bits()
+        );
+        assert_ne!(reference.data()[0], 1.0);
+        let f32_exec = execute_with_dtype(Kernel::MatMul, DType::F32, &a, &b).unwrap();
+        assert_eq!(f32_exec.data()[0], 1.0);
+    }
+
+    #[test]
+    fn f64_sum_matches_reference_bit_exactly() {
+        // A running sum that is not representable in f32: 1.0 followed by many
+        // 2^-40 increments. ops::sum folds the column-major buffer left-to-right
+        // from 0.0; execute_sum's F64 reduce kernel does the same, so they agree
+        // bit-for-bit. An f32 reduction would lose every increment.
+        let mut data = vec![1.0];
+        for _ in 0..8 {
+            data.push(2f64.powi(-40));
+        }
+        let a = Array::from_vec(data);
+
+        let reference = ops::sum(&a);
+        let executed = execute_sum(&a).unwrap();
+        assert!(executed.is_scalar());
+        assert_eq!(
+            executed.data()[0].to_bits(),
+            reference.to_bits(),
+            "f64 sum not bit-exact: {} vs {}",
+            executed.data()[0],
+            reference
+        );
+        // And it genuinely captured the sub-f32 bits (result != plain 1.0).
+        assert_ne!(reference, 1.0);
+    }
+
+    #[test]
+    fn f64_sum_rejects_oversized_length() {
+        // The usize→u32 shape cast in execute_sum is a trust boundary: a length
+        // past u32::MAX must error, not truncate. We can't allocate that, so test
+        // the guard via the same try_from the code uses (kept in lockstep here).
+        let huge = (u32::MAX as usize) + 1;
+        assert!(u32::try_from(huge).is_err());
+    }
+
+    #[test]
+    fn f32_path_still_works_and_matches_within_tolerance() {
+        // The historical F32 lowering is preserved for f32 callers: it executes
+        // and agrees with the reference to f32 precision (the MA-2 contract).
+        let a = Array::from_rows(vec![vec![1.0, 2.0], vec![3.0, 4.0]]).unwrap();
+        let b = Array::from_rows(vec![vec![5.0, 6.0], vec![7.0, 8.0]]).unwrap();
+        let executed = execute_with_dtype(Kernel::MatMul, DType::F32, &a, &b).unwrap();
+        let reference = ops::matmul(&a, &b).unwrap();
+        assert_matches_reference(&executed, &reference);
+        // Small integer values are exactly representable, so it's even exact here.
+        assert_eq!(executed.get(0, 0), Some(19.0));
     }
 }

--- a/code/packages/rust/array-runtime/src/lib.rs
+++ b/code/packages/rust/array-runtime/src/lib.rs
@@ -20,11 +20,16 @@
 //!    transfer cost model. The placement is observable via
 //!    [`accel::plan_backend`], so the dispatch decision is tested.
 //!
-//! 3. **[`exec`]** — end-to-end execution (MA-2). [`execute`] plans the lowered
-//!    graph and **runs it** through `matrix-cpu`'s executor, returning real
-//!    results from the same pipeline a GPU would use. The reference path in
-//!    [`ops`] remains the exact-`f64` answer (`matrix-ir` has no `f64` dtype
-//!    yet); executed results match it to `f32` precision.
+//! 3. **[`exec`]** — end-to-end execution (MA-2, MXF-3). [`execute`] plans the
+//!    lowered graph and **runs it** through `matrix-cpu`'s executor, returning
+//!    real results from the same pipeline a GPU would use. As of MX12 / MXF-3,
+//!    `matrix-ir` has a `DType::F64`, so `execute` lowers `f64` arrays to an
+//!    **`F64`** graph and crosses the boundary as **8-byte** doubles — no `f32`
+//!    round-trip. Its result is therefore **bit-exact** with the [`ops`]
+//!    reference path, even on values `f32` cannot represent. ([`execute_sum`]
+//!    adds an `f64` whole-array reduction on the same path; the legacy `f32`
+//!    lowering is still reachable for `f32` callers and agrees only to `f32`
+//!    precision, by construction.)
 //!
 //! ```
 //! use coding_adventures_array_runtime::{Array, ops, execute, Kernel, BinOp};
@@ -45,6 +50,7 @@ pub mod ops;
 pub mod value;
 
 pub use accel::{plan_backend, Kernel};
-pub use exec::execute;
+pub use exec::{execute, execute_sum};
+pub use matrix_ir::DType;
 pub use ops::BinOp;
 pub use value::Array;

--- a/code/packages/rust/array-runtime/tests/f64_bit_exact.rs
+++ b/code/packages/rust/array-runtime/tests/f64_bit_exact.rs
@@ -1,0 +1,113 @@
+//! Integration tests for the **MXF-3 `f64` path** of `array-runtime`, exercised
+//! through the crate's *public* API only (no access to private helpers).
+//!
+//! The invariant under test: for `f64` inputs, the planned/executor path
+//! ([`execute`] / [`execute_sum`]) returns the **bit-exact** `f64` result, equal
+//! to the reference CPU path in [`ops`] to full double precision. We deliberately
+//! pick values that are **not** representable in `f32` (e.g. `1 + 2^-40`), so the
+//! old `f64 → f32 → f64` round-trip would have lost them — passing these proves
+//! the round-trip is gone.
+
+use coding_adventures_array_runtime::{execute, execute_sum, ops, Array, BinOp, DType, Kernel};
+
+/// `1 + 2^-40` is a distinct `f64` but rounds to exactly `1.0` as an `f32`.
+fn f32_unrepresentable() -> f64 {
+    let v = 1.0 + 2f64.powi(-40);
+    assert_eq!(
+        v as f32 as f64, 1.0,
+        "value must collapse under an f32 round-trip"
+    );
+    assert_ne!(v, 1.0, "value must be distinct from 1.0 in f64");
+    v
+}
+
+/// Assert two arrays are equal bit-for-bit (not within a tolerance).
+fn assert_bit_exact(executed: &Array, reference: &Array) {
+    assert_eq!(executed.shape(), reference.shape(), "shape mismatch");
+    for (e, r) in executed.data().iter().zip(reference.data()) {
+        assert_eq!(e.to_bits(), r.to_bits(), "not bit-exact: {e} vs {r}");
+    }
+}
+
+#[test]
+fn f64_elementwise_execute_equals_reference_bit_exactly() {
+    let x = f32_unrepresentable();
+    let a = Array::from_vec(vec![x, x, x, x]);
+    let one = Array::from_vec(vec![1.0, 1.0, 1.0, 1.0]);
+    for op in [BinOp::Add, BinOp::Sub, BinOp::Mul] {
+        let executed = execute(Kernel::Elementwise(op), &a, &one).unwrap();
+        let reference = ops::elementwise(op, &a, &one).unwrap();
+        assert_bit_exact(&executed, &reference);
+    }
+    // The subtraction's exact f64 result is 2^-40 — a value the f32 path would
+    // have turned into 0.0. Confirms we are genuinely past f32 precision.
+    let sub = execute(Kernel::Elementwise(BinOp::Sub), &a, &one).unwrap();
+    assert_eq!(sub.data()[0].to_bits(), 2f64.powi(-40).to_bits());
+}
+
+#[test]
+fn f64_matmul_execute_equals_reference_bit_exactly() {
+    // [1, 2^-20] · [1, 2^-20]^T = 1 + 2^-40 (exact in f64, lost in f32).
+    let tiny = 2f64.powi(-20);
+    let a = Array::from_rows(vec![vec![1.0, tiny]]).unwrap();
+    let b = Array::from_rows(vec![vec![1.0], vec![tiny]]).unwrap();
+    let executed = execute(Kernel::MatMul, &a, &b).unwrap();
+    let reference = ops::matmul(&a, &b).unwrap();
+    assert_bit_exact(&executed, &reference);
+    assert_eq!(
+        reference.data()[0].to_bits(),
+        (1.0 + 2f64.powi(-40)).to_bits()
+    );
+}
+
+#[test]
+fn f64_sum_execute_equals_reference_bit_exactly() {
+    // 1.0 plus eight 2^-40 increments: a running sum that is not representable
+    // in f32. execute_sum folds the same left-to-right order as ops::sum, so the
+    // two agree bit-for-bit.
+    let mut data = vec![1.0];
+    for _ in 0..8 {
+        data.push(2f64.powi(-40));
+    }
+    let a = Array::from_vec(data);
+    let executed = execute_sum(&a).unwrap();
+    let reference = ops::sum(&a);
+    assert!(executed.is_scalar());
+    assert_eq!(executed.data()[0].to_bits(), reference.to_bits());
+    assert_ne!(reference, 1.0, "the sub-f32 bits must have survived");
+}
+
+#[test]
+fn larger_f64_matmul_is_bit_exact() {
+    // A 3x3 · 3x3 product where one cell's exact value carries sub-f32 bits.
+    let e = 2f64.powi(-25); // representable added to 1.0 in f64, lost in f32
+    let a = Array::from_rows(vec![
+        vec![1.0, e, 0.0],
+        vec![0.0, 1.0, e],
+        vec![e, 0.0, 1.0],
+    ])
+    .unwrap();
+    let b = Array::from_rows(vec![
+        vec![1.0, 0.0, e],
+        vec![e, 1.0, 0.0],
+        vec![0.0, e, 1.0],
+    ])
+    .unwrap();
+    let executed = execute(Kernel::MatMul, &a, &b).unwrap();
+    let reference = ops::matmul(&a, &b).unwrap();
+    assert_bit_exact(&executed, &reference);
+}
+
+#[test]
+fn oversized_dim_is_rejected_for_f64_lowering() {
+    // The usize→u32 shape cast is a trust boundary; a dim past u32::MAX must be a
+    // clean error (no panic, no truncation), for the f64 dtype too. Uses
+    // plan_backend (which lowers without allocating the buffer).
+    use coding_adventures_array_runtime::plan_backend;
+    let big = (u32::MAX as usize) + 1;
+    let add = Kernel::Elementwise(BinOp::Add);
+    assert!(plan_backend(add, DType::F64, &[big], &[big], false).is_err());
+    // execute_sum guards the same boundary; we can't allocate u32::MAX+1 doubles,
+    // so we assert the guard's predicate directly (kept in lockstep with the code).
+    assert!(u32::try_from(big).is_err());
+}

--- a/code/specs/MX12-f64-dtype.md
+++ b/code/specs/MX12-f64-dtype.md
@@ -40,15 +40,15 @@ a redesign.
 - **MXF-1 — `matrix-ir` `F64` + `matrix-cpu` kernels** *(shipped)*. The dtype
   itself plus a working CPU executor, so an `f64` graph **builds, validates, and
   executes exactly** on CPU end-to-end.
-- **MXF-2 — `matrix-runtime` cost model** *(this PR)*. A `gflops_f64` throughput on
+- **MXF-2 — `matrix-runtime` cost model** *(shipped)*. A `gflops_f64` throughput on
   `BackendProfile` and an `F64` arm in the cost model, so the planner places
   `f64` ops on the cheapest backend that can actually run them — a backend with
   no `f64` kernel advertises `gflops_f64 = 0`, which the cost model turns into the
   ∞-cost sentinel, keeping `f64` on the CPU.
-- **MXF-3 — `array-runtime` `f64` path.** Lower `Array`s to an `F64` graph and
-  add an 8-byte codec, so `execute` keeps the exact `f64` answer (no `f32`
-  round-trip). The reference `ops` path and the executed path now agree to full
-  precision.
+- **MXF-3 — `array-runtime` `f64` path** *(this PR)*. Lower `Array`s to an `F64`
+  graph and add an 8-byte codec, so `execute` keeps the exact `f64` answer (no
+  `f32` round-trip). The reference `ops` path and the executed path now agree to
+  full precision.
 - **MXF-4 — R adopts the substrate.** Route `s-runtime`'s `%*%` (and the
   elementwise/transpose/reduction matrix ops where it wins) through
   `array_runtime::execute` at `f64`, so R gets cost-based CPU/GPU dispatch with
@@ -106,7 +106,48 @@ a redesign.
   advertises `f64` capability but `gflops_f64 = 0`) lands on the CPU — the
   decision falls through to cost, not the capability filter.
 
-## §5 Out of scope (later items / future)
+## §5 MXF-3 — what this PR delivers
+
+Before this PR, `array-runtime::execute` lowered every `Array` to an **`F32`**
+`matrix-ir` graph and crossed the boundary as 4-byte floats: the input `f64`s
+were rounded to `f32` on the way in (`v as f32`) and widened back to `f64` on the
+way out. So `execute` agreed with the [`crate::ops`] reference path only *to
+`f32` precision* — a `1.0 + 2^-40` that the reference summed exactly came back
+from `execute` as plain `1.0`. MXF-3 removes that round-trip end-to-end.
+
+### `array-runtime` — lowering (`accel.rs`)
+- `build_graph` (and `plan_backend`) now take the element **`DType`** and build
+  the `matrix-ir` graph at that dtype — `DType::F64` for an `f64` array, keeping
+  the existing `DType::F32` path unchanged for `f32` callers. Because the IR and
+  executor are dtype-agnostic, no other lowering logic changes: the dtype simply
+  threads through `input`/`add`/`matmul`/… as a per-tensor property.
+- The `usize → u32` shape cast in `shape_of` is a **trust boundary** and was
+  already a *checked* cast (a dim past `u32::MAX` is rejected with an error, never
+  silently truncated — a truncated dim would size the wrong allocation / cost the
+  wrong op). MXF-3 keeps and re-tests that guard for the F64 path.
+
+### `array-runtime` — execution (`exec.rs`)
+- A new **8-byte little-endian `f64` codec** (`f64_bytes` / `f64_from_bytes`)
+  mirroring the existing `f32` one and matching `matrix-cpu`'s
+  `read_f64_vec`/`write_f64_vec` convention exactly, so the buffers are
+  byte-compatible with the executor's `F64` kernels. `f64_from_bytes` validates
+  that the output length is a whole number of 8-byte values and errors (never
+  panics or reads out of bounds) on a short/ragged buffer.
+- `execute` routes `f64` tensors through the 8-byte codec and an `F64` graph, so
+  it reads/writes 8-byte buffers and returns the **bit-exact** `f64` result. The
+  `f32` codec and path remain for the (still-supported) `f32` lowering.
+
+### Tests
+- For `f64` inputs, `execute` (planned/executor path) is asserted **bit-exactly
+  equal** to the [`crate::ops`] reference path on values *not representable in
+  `f32`* — elementwise add/sub/mul, a reduce-`sum`, and a `matmul` whose exact
+  product rounds under `f32`. The old `f32` round-trip would have failed these;
+  full-precision agreement proves the round-trip is gone.
+- The `usize → u32` shape-cast guard is exercised (a dim `> u32::MAX` errors
+  cleanly, with no panic or truncation), and the `f32` lowering path is kept under
+  test so it is unchanged.
+
+## §6 Out of scope (later items / future)
 
 - The GPU (CUDA/Metal) executors gaining `f64` kernels — MXF-1/-3 keep `f64` on
   the CPU executor; the planner (MXF-2) simply won't place `f64` on a GPU that
@@ -114,7 +155,7 @@ a redesign.
 - `F16`/`I64` (the other reserved wire tags).
 - The specialiser fast path for `f64`.
 
-## §6 References
+## §7 References
 
 Internal: [`MX00`](MX00-matrix-execution-overview.md),
 [`MX01`](MX01-matrix-ir.md), [`MX03`](MX03-executor-protocol.md),


### PR DESCRIPTION
## MXF-3 — `array-runtime` f64 path (bit-exact, no f32 round-trip)

Part of **MX12**, which is bringing `f64` across the shared matrix substrate (`matrix-ir → matrix-cpu → matrix-runtime → array-runtime`). MXF-1 (`DType::F64` + matrix-cpu kernels) and MXF-2 (cost-model `gflops_f64`) are merged. **MXF-3 makes `array-runtime` keep full f64 precision end-to-end.**

Before this PR, `execute()` lowered every `Array` to an **F32** matrix-ir graph and crossed the boundary as 4-byte floats, so a `f64 → f32 → f64` round-trip rounded the result and `execute()` agreed with the `ops` reference path only to f32 precision. This PR removes the round-trip.

### Scope

**`accel.rs` — lowering**
- `build_graph` and `plan_backend` now take an explicit `dtype: DType` and build the matrix-ir graph at that dtype — `DType::F64` for f64 arrays (the new default), `DType::F32` unchanged for f32 callers. The substrate is dtype-agnostic, so the dtype threads through `input`/`add`/`matmul`/… as a per-tensor property; no other lowering logic changes. **Breaking signature change** for the public `plan_backend`.
- The `usize → u32` shape cast in `shape_of` (a trust boundary) stays a **checked** cast — a dim past `u32::MAX` is rejected with an error, never silently truncated.
- `gpu_profile()` now advertises `gflops_f64 = 0` (matching the real CUDA/Metal V1 executors), so the cost model keeps f64 ops on the CPU rather than dispatching to a backend with no f64 kernel.

**`exec.rs` — execution**
- New **8-byte little-endian f64 codec** (`f64_bytes` / `f64_from_bytes`) mirroring matrix-cpu's `write_f64_vec`/`read_f64_vec` byte-for-byte, so buffers are directly consumable by the executor's F64 kernels. `f64_from_bytes` validates the length is a whole number of 8-byte doubles and returns `Err` (never panics / reads OOB) on a short/ragged buffer. The f32 codec is kept and selected via `encode`/`decode` on the dtype.
- `execute()` now defaults to the **F64** path (since `Array` is f64-valued); `execute_with_dtype` keeps the F32 path reachable for f32 callers.
- New `execute_sum()`: an f64 whole-array reduction run end-to-end through matrix-cpu's F64 reduce-all kernel, folding in the same left-to-right order as `ops::sum` so the two agree bit-for-bit.

**`lib.rs`** — re-export `execute_sum` and `matrix_ir::DType`.

### Invariant proven in tests

For f64 inputs, `execute()`/`execute_sum()` equal the `ops` reference path **bit-for-bit** on values **not representable in f32** — elementwise (`1 + 2^-40`), `matmul` (exact product `1 + 2^-40`), and a running `sum` carrying sub-f32 bits. The old f32 path is shown to collapse those same values to `1.0`/`0.0`, so the tests genuinely distinguish the two paths. The `usize → u32` overflow guard is re-tested for both dtypes (errors cleanly, no panic/truncation), and the f32 path is kept under test, unchanged.

### Tests / coverage

- **53 tests**: 47 unit + 5 integration (`tests/f64_bit_exact.rs`, public-API bit-exact suite) + 1 doctest — all green.
- `cargo test -p coding-adventures-array-runtime` green; `cargo clippy` clean for array-runtime; `cargo build --workspace` builds (the pre-existing unrelated `uefi` `duplicate panic_impl` error is ignored per task instructions).
- Coverage (tarpaulin): **≈94%** for array-runtime (accel/ops/value 100%, exec 88% — the uncovered exec lines are pre-existing untested defensive error arms in `run_graph_on_cpu`, not new code).
- Downstream `matlab-runtime` (which calls `execute`) builds and its 14 tests pass; it silently gains bit-exact f64 matmul.

### Spec

`code/specs/MX12-f64-dtype.md`: marked MXF-2 shipped / MXF-3 as this PR in §2, added a new §5 describing what MXF-3 delivers. Spec committed before implementation.

### Security review

No general-purpose Agent tool is available in this environment, so the security review was **conducted inline** (disclosed here per the task). Focus areas and findings:
- **`usize → u32` shape cast** (`shape_of`, `execute_sum`): both use `u32::try_from(...)` → `Err` on overflow. Checked, no truncation, no wrong-sized allocation. ✓
- **8-byte codec**: `f64_from_bytes`/`f32_from_bytes` use `chunks_exact(N)` + remainder check, so chunk indexing is always in bounds and a malformed/short buffer returns `Err` instead of panicking or reading OOB. `f64_bytes` capacity math (`len*8`) cannot overflow `usize` because the input is an already-allocated f64 buffer. ✓
- **panic on malformed result**: hardened `execute_sum`'s output indexing from `out[0]` to `out.first().ok_or_else(...)` (commit `fix(security): …`), so an unexpected empty executor result returns a clean `Err` rather than panicking.

No CRITICAL/HIGH/MEDIUM findings remain. **Inline review: PASSED.**

### Note on diff hygiene

Diff is **functional-only** — verified with `rustfmt --check` clean on all changed files and a line-by-line review confirming no unrelated rustfmt churn (local rustfmt 1.9.0 reformats were confined to lines this PR actually changed; long call sites were refactored to single-line `let` bindings to keep the diff minimal and CI-stable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)