### PR TITLE
feat(logic-engine): grounded outranks_context facts as context-precedence edges (ADJ73 PR-B-2)

### DIFF
--- a/code/packages/rust/logic-engine/CHANGELOG.md
+++ b/code/packages/rust/logic-engine/CHANGELOG.md
@@ -2,6 +2,37 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.20.0] - 2026-06-17 — context-precedence edges as grounded facts (ADJ73 PR-B-2)
+
+### Added
+
+- **Grounded `outranks_context(higher, lower)` facts now ACT as context-precedence edges.** A
+  ground fact whose functor is `outranks_context` and whose two args are atoms participates in
+  the context order exactly like an explicit `add_context_outranks` edge — but, being an ordinary
+  [`Fact`], it carries `source`/`locator`/`trust` [`Provenance`], is queryable, and is one CAS
+  edit from correctable. This is the mechanism behind ADJ73's "context must be grounded": the
+  *reason* federal outranks state (the Supremacy Clause) rides on the edge itself rather than
+  being asserted bare in host code. A `relate outranks_context(federal, state) source "…" trust
+  authoritative` clause in adj-lang already lowers to such a fact — no surface change needed.
+- **`KnowledgeBase::context_edges()`** (private) — the EFFECTIVE edge set: the union of explicit
+  `add_context_outranks` edges and grounded-fact edges. `context_outranks`, `context_order_has_cycle`,
+  and the internal `reaches_self` walk this union, so a cycle formed *across* the two sources
+  (explicit `a > b` + grounded `outranks_context(b, a)`) is still detected.
+
+### Unchanged (back-compat)
+
+- A KB with no `outranks_context` facts and no `add_context_outranks` calls is byte-identical to
+  0.19 (every existing precedence + integration test passes unchanged). A non-atom
+  `outranks_context(_, X)` fact is NOT an edge — it stays an ordinary queryable fact.
+
+### Scope
+
+PR-B-2. The grounded `context-precedence` **rulebook** (a `.adj` library of `relate
+outranks_context(…)` edges, each byte-quoting its charter — the Supremacy Clause, circuit
+precedence, guideline editions) + a worked legal example end-to-end through the CLI `governing`
+section land in PR-B-3 (now unblocked by this engine change). The recursive conflict-resolution
+meta-rules (recency / appeal-status / lex specialis as themselves-grounded rules) follow.
+
 ## [0.19.0] - 2026-06-16 — grounded context precedence (lex superior) (ADJ73 PR-B engine core)
 
 ### Added

--- a/code/packages/rust/logic-engine/CHANGELOG.md
+++ b/code/packages/rust/logic-engine/CHANGELOG.md
@@ -14,10 +14,12 @@ All notable changes to this project will be documented in this file.
   *reason* federal outranks state (the Supremacy Clause) rides on the edge itself rather than
   being asserted bare in host code. A `relate outranks_context(federal, state) source "…" trust
   authoritative` clause in adj-lang already lowers to such a fact — no surface change needed.
-- **`KnowledgeBase::context_edges()`** (private) — the EFFECTIVE edge set: the union of explicit
-  `add_context_outranks` edges and grounded-fact edges. `context_outranks`, `context_order_has_cycle`,
-  and the internal `reaches_self` walk this union, so a cycle formed *across* the two sources
-  (explicit `a > b` + grounded `outranks_context(b, a)`) is still detected.
+- **`KnowledgeBase::context_adjacency()`** (private) — the EFFECTIVE order as a directed
+  adjacency map `higher → [lowers]`, unioning explicit `add_context_outranks` edges and
+  grounded-fact edges. `context_outranks` is a cycle-safe DFS over it (O(V+E)); `context_order_has_cycle`
+  is a single Kahn topological-sort pass (O(V+E)) — both detect a cycle formed *across* the two
+  sources (explicit `a > b` + grounded `outranks_context(b, a)`). The per-node adjacency lookup
+  replaces the prior full-edge-list rescan so the order scales to large rule corpora.
 
 ### Unchanged (back-compat)
 

--- a/code/packages/rust/logic-engine/Cargo.toml
+++ b/code/packages/rust/logic-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "logic-engine"
-version = "0.19.0"
+version = "0.20.0"
 edition = "2021"
 description = "Probability-aware facts, rules, KB, SLD find-first/enumerate + WMC posterior + LP19e likelihood-ratio Bayesian aggregation."
 

--- a/code/packages/rust/logic-engine/README.md
+++ b/code/packages/rust/logic-engine/README.md
@@ -125,7 +125,8 @@ kb.add_fact(
 // a federal rule now governs a conflicting state rule even at a lower tier; the edge is auditable.
 ```
 
-`context_edges()` unions the explicit and grounded edges, so cycle detection spans both sources.
+`context_adjacency()` unions the explicit and grounded edges into one directed graph, so the
+cycle check (a single Kahn pass) and `context_outranks` (a cycle-safe DFS) span both sources.
 The grounded `context-precedence` *rulebook* (a `.adj` library of such edges, each byte-quoting
 its charter) + a worked legal example through the CLI `governing` section land in PR-B-3
 (`code/specs/ADJ73-defeasible-rule-precedence.md` §2.3, §7).

--- a/code/packages/rust/logic-engine/README.md
+++ b/code/packages/rust/logic-engine/README.md
@@ -107,8 +107,27 @@ kb.add_rule(Rule::certain(/* means(waters, narrow) */).with_context("district_co
 
 `context_outranks` is cycle-safe; a cyclic order (`context_order_has_cycle`) crowns nothing
 rather than picking wrong. With no context order declared, resolution is pure-tier (back-compat).
-The grounded `context-precedence` *rulebook* (each edge citing its charter — the Supremacy
-Clause, etc.) + the adj-lang surface (`context:` / `context_order { … }`) are the next slices
+
+**Grounded precedence edges (v0.20).** `add_context_outranks` edges carry no provenance. The
+*grounded* way to declare precedence is a `relate outranks_context(higher, lower)` clause — an
+ordinary [`Fact`] carrying `source`/`locator`/`trust`, queryable and one CAS edit from
+correctable. Such a fact participates in the context order exactly like an explicit edge, so the
+*reason* one context outranks another rides on the edge itself:
+
+```rust
+// federal outranks state BECAUSE of the Supremacy Clause — the citation is on the edge.
+kb.add_fact(
+    Fact::certain(/* outranks_context(federal, state) */)
+        .with_provenance(Provenance::new(
+            "U.S. Const. art. VI, cl. 2 (Supremacy Clause)", Some("cl. 2".into()),
+            TrustTier::Authoritative)),
+);
+// a federal rule now governs a conflicting state rule even at a lower tier; the edge is auditable.
+```
+
+`context_edges()` unions the explicit and grounded edges, so cycle detection spans both sources.
+The grounded `context-precedence` *rulebook* (a `.adj` library of such edges, each byte-quoting
+its charter) + a worked legal example through the CLI `governing` section land in PR-B-3
 (`code/specs/ADJ73-defeasible-rule-precedence.md` §2.3, §7).
 
 ## Why Probability From Day One

--- a/code/packages/rust/logic-engine/src/govern.rs
+++ b/code/packages/rust/logic-engine/src/govern.rs
@@ -266,7 +266,7 @@ pub fn enumerate_governing(query: &Term, kb: &KnowledgeBase) -> GovernedResult {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{BodyLiteral, Fact, KnowledgeBase, Priority, Rule};
+    use crate::{BodyLiteral, Fact, KnowledgeBase, Priority, Provenance, Rule, TrustTier};
     use logic_core::Term;
 
     fn atom(s: &str) -> Term {
@@ -522,5 +522,60 @@ mod tests {
         let gov: Vec<&Term> = res.governing().map(|a| &a.term).collect();
         assert_eq!(gov, vec![&comp("timing", vec![atom("await")])]);
         assert!(!res.has_conflict());
+    }
+
+    /// ADJ73 PR-B-2 — END TO END: the precedence edge is a GROUNDED FACT, not a bare
+    /// `add_context_outranks` call. A `relate outranks_context(federal, state)` clause (here a
+    /// Fact carrying the Supremacy Clause as provenance) drives the same lex-superior resolution:
+    /// the federal reading governs the state reading even though state carries the higher tier,
+    /// AND the citation that justifies the precedence is retrievable for the audit trail.
+    #[test]
+    fn grounded_context_edge_fact_drives_lex_superior_with_provenance() {
+        let mut kb = KnowledgeBase::new();
+        kb.declare_functional("means", 2);
+
+        // The PRECEDENCE itself is grounded: federal outranks state *because of* the Supremacy
+        // Clause. The reason rides on the edge (one CAS edit away from correctable), not in code.
+        let edge_id = kb.add_fact(
+            Fact::certain(comp(
+                "outranks_context",
+                vec![atom("federal"), atom("state")],
+            ))
+            .with_provenance(Provenance::new(
+                "U.S. Const. art. VI, cl. 2 (Supremacy Clause)",
+                Some("cl. 2".to_string()),
+                TrustTier::Authoritative,
+            )),
+        );
+
+        // A federal reading at the LOWEST tier...
+        kb.add_rule(
+            Rule::certain(comp("means", vec![atom("waters"), atom("broad")]), vec![])
+                .with_context("federal"),
+        );
+        // ...vs a state reading at the HIGHEST tier — federal still governs (context is primary).
+        kb.add_rule(
+            Rule::certain(comp("means", vec![atom("waters"), atom("narrow")]), vec![])
+                .with_context("state")
+                .with_priority(Priority::Mandatory),
+        );
+
+        let res = enumerate_governing(&comp("means", vec![atom("waters"), var("R")]), &kb);
+        let gov: Vec<&Term> = res.governing().map(|a| &a.term).collect();
+        assert_eq!(
+            gov,
+            vec![&comp("means", vec![atom("waters"), atom("broad")])],
+            "the federal reading governs purely because of the grounded outranks_context edge"
+        );
+        assert!(!res.has_conflict());
+
+        // The precedence is auditable: the edge fact (and its citation) is recoverable.
+        let edge = kb
+            .fact(edge_id)
+            .expect("the grounded precedence edge is a queryable fact");
+        assert_eq!(
+            edge.provenance.source,
+            "U.S. Const. art. VI, cl. 2 (Supremacy Clause)"
+        );
     }
 }

--- a/code/packages/rust/logic-engine/src/lib.rs
+++ b/code/packages/rust/logic-engine/src/lib.rs
@@ -413,7 +413,7 @@ pub struct KnowledgeBase {
     /// specialist > general), declared via [`Self::add_context_outranks`] (the bare
     /// `context_order { a > b }` surface form). These edges carry NO provenance. The GROUNDED
     /// half — edges that DO carry a byte-quote (the Supremacy Clause, etc.) — lives as ordinary
-    /// `outranks_context(higher, lower)` facts in the fact store; [`Self::context_edges`] unions
+    /// `outranks_context(higher, lower)` facts in the fact store; [`Self::context_adjacency`] unions
     /// the two so both feed [`crate::govern::enumerate_governing`], which consults the order
     /// BEFORE the priority tier (lex superior). Transitive reach is computed cycle-safely.
     context_order: Vec<(String, String)>,
@@ -532,44 +532,49 @@ impl KnowledgeBase {
     ///     cited clause, riding on the edge itself rather than asserted bare in host code.
     ///
     /// Both args of the grounding fact must be atoms; a fact with a variable or nested compound arg
-    /// is not a ground edge and is ignored here (it stays a normal queryable fact). Borrows from
-    /// `&self`, so the returned `&str`s live as long as the borrow.
-    fn context_edges(&self) -> Vec<(&str, &str)> {
-        let mut edges: Vec<(&str, &str)> = self
-            .context_order
-            .iter()
-            .map(|(h, l)| (h.as_str(), l.as_str()))
-            .collect();
+    /// is not a ground edge and is ignored here (it stays a normal queryable fact). Returns the
+    /// edges as a directed ADJACENCY MAP `higher → [lowers]` so a graph walk does a single O(1)
+    /// neighbour lookup per node instead of re-scanning the whole edge list (the context order is
+    /// meant to scale to large rule corpora — e.g. a jurisdiction graph over the US Code — so the
+    /// walks below stay O(V+E), not O(V·E)). Borrows from `&self`, so the `&str`s live as long as
+    /// the borrow.
+    fn context_adjacency(&self) -> HashMap<&str, Vec<&str>> {
+        let mut adj: HashMap<&str, Vec<&str>> = HashMap::new();
+        // 1. Explicit edges (the bare `context_order { a > b }` surface form).
+        for (hi, lo) in &self.context_order {
+            adj.entry(hi.as_str()).or_default().push(lo.as_str());
+        }
+        // 2. Grounded edges — any ground `outranks_context(higher, lower)` fact (both args atoms).
         for fact in self.facts.values().flatten() {
             if let Term::Compound { functor, args } = &fact.term {
                 if functor == "outranks_context" && args.len() == 2 {
                     if let (Term::Atom(hi), Term::Atom(lo)) = (&args[0], &args[1]) {
-                        edges.push((hi.as_str(), lo.as_str()));
+                        adj.entry(hi.as_str()).or_default().push(lo.as_str());
                     }
                 }
             }
         }
-        edges
+        adj
     }
 
     /// ADJ73 PR-B: does context `a` outrank context `b` (directly or transitively)? Cycle-safe
-    /// DFS over the effective [`Self::context_edges`] (explicit + grounded-fact). `a == b` is
-    /// `false` (a context does not outrank itself). Returns `false` when there is no directed path
-    /// `a → … → b`.
+    /// DFS over the effective context adjacency (explicit + grounded-fact edges, see
+    /// [`Self::context_adjacency`]). `a == b` is `false` (a context does not outrank itself).
+    /// Returns `false` when there is no directed path `a → … → b`.
     pub fn context_outranks(&self, a: &str, b: &str) -> bool {
         if a == b {
             return false;
         }
-        let edges = self.context_edges();
+        let adj = self.context_adjacency();
         let mut stack = vec![a];
         let mut seen: HashSet<&str> = HashSet::new();
         while let Some(node) = stack.pop() {
             if !seen.insert(node) {
                 continue; // already visited — cycle-safe
             }
-            for (hi, lo) in &edges {
-                if *hi == node {
-                    if *lo == b {
+            if let Some(neighbours) = adj.get(node) {
+                for &lo in neighbours {
+                    if lo == b {
                         return true;
                     }
                     stack.push(lo);
@@ -580,40 +585,42 @@ impl KnowledgeBase {
     }
 
     /// ADJ73 PR-B: `true` iff the effective context order (explicit + grounded-fact edges, see
-    /// [`Self::context_edges`]) contains a cycle (e.g. `a > b`, `b > a`). The surface/loader should
-    /// reject such a rulebook; the resolver itself stays safe regardless. Detected as "some node can
-    /// reach itself". Catches a cycle formed *across* the two edge sources too (e.g. an explicit
-    /// `a > b` plus a grounded `outranks_context(b, a)` fact).
+    /// [`Self::context_adjacency`]) contains a cycle (e.g. `a > b`, `b > a`, or a self-loop). The
+    /// surface/loader should reject such a rulebook; the resolver itself stays safe regardless.
+    /// Catches a cycle formed *across* the two edge sources too (an explicit `a > b` plus a
+    /// grounded `outranks_context(b, a)` fact). Single Kahn topological-sort pass: a directed
+    /// acyclic graph fully drains to zero in-degree, so any node left unremoved lies on a cycle.
     pub fn context_order_has_cycle(&self) -> bool {
-        let edges = self.context_edges();
-        let nodes: HashSet<&str> = edges.iter().flat_map(|(h, l)| [*h, *l]).collect();
-        nodes.iter().any(|n| self.reaches_self(n, &edges))
-    }
-
-    /// Helper: can `start` reach itself via a directed path of length ≥ 1 over `edges`?
-    /// (`context_outranks` short-circuits `a == b` to false, so cycle detection needs this explicit
-    /// walk.) Takes the precomputed edge set so the caller builds the union once.
-    fn reaches_self(&self, start: &str, edges: &[(&str, &str)]) -> bool {
-        let mut stack: Vec<&str> = edges
+        let adj = self.context_adjacency();
+        // In-degree of every node that appears as a head or a tail.
+        let mut in_degree: HashMap<&str, usize> = HashMap::new();
+        for (&hi, lowers) in &adj {
+            in_degree.entry(hi).or_insert(0);
+            for &lo in lowers {
+                *in_degree.entry(lo).or_insert(0) += 1;
+            }
+        }
+        // Kahn: repeatedly retire a zero-in-degree node, decrementing its successors.
+        let mut ready: Vec<&str> = in_degree
             .iter()
-            .filter(|(h, _)| *h == start)
-            .map(|(_, l)| *l)
+            .filter(|&(_, &d)| d == 0)
+            .map(|(&n, _)| n)
             .collect();
-        let mut seen: HashSet<&str> = HashSet::new();
-        while let Some(node) = stack.pop() {
-            if node == start {
-                return true;
-            }
-            if !seen.insert(node) {
-                continue;
-            }
-            for (hi, lo) in edges {
-                if *hi == node {
-                    stack.push(lo);
+        let mut retired = 0usize;
+        while let Some(node) = ready.pop() {
+            retired += 1;
+            if let Some(neighbours) = adj.get(node) {
+                for &lo in neighbours {
+                    let d = in_degree.get_mut(lo).expect("successor was counted above");
+                    *d -= 1;
+                    if *d == 0 {
+                        ready.push(lo);
+                    }
                 }
             }
         }
-        false
+        // Anything not retired sits on (or downstream of) a cycle.
+        retired != in_degree.len()
     }
 
     /// Walk every Fact and every Rule once; return `true` iff every

--- a/code/packages/rust/logic-engine/src/lib.rs
+++ b/code/packages/rust/logic-engine/src/lib.rs
@@ -407,12 +407,15 @@ pub struct KnowledgeBase {
     /// highest-priority one. A predicate not listed here is monotonic (every derivation
     /// governs) — this is what makes precedence opt-in and `enumerate_all` unchanged.
     functional_predicates: HashSet<ClauseIndex>,
-    /// ADJ73 PR-B: the grounded CONTEXT precedence order — directed edges `(higher, lower)`
-    /// meaning "a rule in `higher` outranks a conflicting rule in `lower`" (federal > state,
-    /// ninth_circuit > district_court, idsa_2024 > idsa_2004, specialist > general). Each edge
-    /// is a grounded fact (its byte-quote — the Supremacy Clause, etc. — rides on the
-    /// surface/data layer). [`crate::govern::enumerate_governing`] consults this BEFORE the
-    /// priority tier (lex superior); the transitive reach is computed cycle-safely.
+    /// ADJ73 PR-B: the EXPLICIT half of the CONTEXT precedence order — directed edges
+    /// `(higher, lower)` meaning "a rule in `higher` outranks a conflicting rule in `lower`"
+    /// (federal > state, ninth_circuit > district_court, idsa_2024 > idsa_2004,
+    /// specialist > general), declared via [`Self::add_context_outranks`] (the bare
+    /// `context_order { a > b }` surface form). These edges carry NO provenance. The GROUNDED
+    /// half — edges that DO carry a byte-quote (the Supremacy Clause, etc.) — lives as ordinary
+    /// `outranks_context(higher, lower)` facts in the fact store; [`Self::context_edges`] unions
+    /// the two so both feed [`crate::govern::enumerate_governing`], which consults the order
+    /// BEFORE the priority tier (lex superior). Transitive reach is computed cycle-safely.
     context_order: Vec<(String, String)>,
     next_fact_id: u64,
     next_rule_id: u64,
@@ -516,22 +519,57 @@ impl KnowledgeBase {
         }
     }
 
+    /// ADJ73 PR-B: the EFFECTIVE context-precedence edges — the union of two sources, so an edge
+    /// may be declared either way and both participate in the same `lex superior` resolution:
+    ///
+    ///  1. **Explicit** edges from [`Self::add_context_outranks`] (the bare `context_order { a > b }`
+    ///     surface form) — convenient but unprovenanced.
+    ///  2. **Grounded** edges from any ground fact `outranks_context(higher, lower)` — the
+    ///     byte-provenanced form. A `relate outranks_context(federal, state) source "…Supremacy
+    ///     Clause…" trust authoritative` clause is an ordinary [`Fact`] (queryable, CAS-correctable,
+    ///     carrying [`Fact::provenance`]) that ALSO acts as a precedence edge. This is the whole
+    ///     point of ADJ73's "context must be grounded": the *reason* federal outranks state is the
+    ///     cited clause, riding on the edge itself rather than asserted bare in host code.
+    ///
+    /// Both args of the grounding fact must be atoms; a fact with a variable or nested compound arg
+    /// is not a ground edge and is ignored here (it stays a normal queryable fact). Borrows from
+    /// `&self`, so the returned `&str`s live as long as the borrow.
+    fn context_edges(&self) -> Vec<(&str, &str)> {
+        let mut edges: Vec<(&str, &str)> = self
+            .context_order
+            .iter()
+            .map(|(h, l)| (h.as_str(), l.as_str()))
+            .collect();
+        for fact in self.facts.values().flatten() {
+            if let Term::Compound { functor, args } = &fact.term {
+                if functor == "outranks_context" && args.len() == 2 {
+                    if let (Term::Atom(hi), Term::Atom(lo)) = (&args[0], &args[1]) {
+                        edges.push((hi.as_str(), lo.as_str()));
+                    }
+                }
+            }
+        }
+        edges
+    }
+
     /// ADJ73 PR-B: does context `a` outrank context `b` (directly or transitively)? Cycle-safe
-    /// DFS over the `(higher, lower)` edges. `a == b` is `false` (a context does not outrank
-    /// itself). Returns `false` when there is no directed path `a → … → b`.
+    /// DFS over the effective [`Self::context_edges`] (explicit + grounded-fact). `a == b` is
+    /// `false` (a context does not outrank itself). Returns `false` when there is no directed path
+    /// `a → … → b`.
     pub fn context_outranks(&self, a: &str, b: &str) -> bool {
         if a == b {
             return false;
         }
+        let edges = self.context_edges();
         let mut stack = vec![a];
         let mut seen: HashSet<&str> = HashSet::new();
         while let Some(node) = stack.pop() {
             if !seen.insert(node) {
                 continue; // already visited — cycle-safe
             }
-            for (hi, lo) in &self.context_order {
-                if hi == node {
-                    if lo == b {
+            for (hi, lo) in &edges {
+                if *hi == node {
+                    if *lo == b {
                         return true;
                     }
                     stack.push(lo);
@@ -541,26 +579,25 @@ impl KnowledgeBase {
         false
     }
 
-    /// ADJ73 PR-B: `true` iff the declared `context_order` contains a cycle (e.g. `a > b`,
-    /// `b > a`). The surface loader should reject such a rulebook; the resolver itself stays
-    /// safe regardless. Detected as "some node can reach itself".
+    /// ADJ73 PR-B: `true` iff the effective context order (explicit + grounded-fact edges, see
+    /// [`Self::context_edges`]) contains a cycle (e.g. `a > b`, `b > a`). The surface/loader should
+    /// reject such a rulebook; the resolver itself stays safe regardless. Detected as "some node can
+    /// reach itself". Catches a cycle formed *across* the two edge sources too (e.g. an explicit
+    /// `a > b` plus a grounded `outranks_context(b, a)` fact).
     pub fn context_order_has_cycle(&self) -> bool {
-        let nodes: HashSet<&str> = self
-            .context_order
-            .iter()
-            .flat_map(|(h, l)| [h.as_str(), l.as_str()])
-            .collect();
-        nodes.iter().any(|n| self.reaches_self(n))
+        let edges = self.context_edges();
+        let nodes: HashSet<&str> = edges.iter().flat_map(|(h, l)| [*h, *l]).collect();
+        nodes.iter().any(|n| self.reaches_self(n, &edges))
     }
 
-    /// Helper: can `start` reach itself via a directed path of length ≥ 1? (`context_outranks`
-    /// short-circuits `a == b` to false, so cycle detection needs this explicit walk.)
-    fn reaches_self(&self, start: &str) -> bool {
-        let mut stack: Vec<&str> = self
-            .context_order
+    /// Helper: can `start` reach itself via a directed path of length ≥ 1 over `edges`?
+    /// (`context_outranks` short-circuits `a == b` to false, so cycle detection needs this explicit
+    /// walk.) Takes the precomputed edge set so the caller builds the union once.
+    fn reaches_self(&self, start: &str, edges: &[(&str, &str)]) -> bool {
+        let mut stack: Vec<&str> = edges
             .iter()
-            .filter(|(h, _)| h == start)
-            .map(|(_, l)| l.as_str())
+            .filter(|(h, _)| *h == start)
+            .map(|(_, l)| *l)
             .collect();
         let mut seen: HashSet<&str> = HashSet::new();
         while let Some(node) = stack.pop() {
@@ -570,8 +607,8 @@ impl KnowledgeBase {
             if !seen.insert(node) {
                 continue;
             }
-            for (hi, lo) in &self.context_order {
-                if hi == node {
+            for (hi, lo) in edges {
+                if *hi == node {
                     stack.push(lo);
                 }
             }
@@ -1315,5 +1352,102 @@ mod tests {
         let s = find_first(&compound("p", vec![Term::Var(w.clone())]), &kb)
             .expect("p(W) should succeed via q(a, a)");
         assert_eq!(s.walk_var(&w), atom("a"));
+    }
+
+    // -----------------------------------------------------------------------
+    // ADJ73 PR-B-2 — GROUNDED context-precedence edges.
+    //
+    // A `relate outranks_context(higher, lower)` clause lowers to an ordinary
+    // ground Fact. These tests prove that such a fact PARTICIPATES in the
+    // context order exactly like an explicit `add_context_outranks` edge — so
+    // the *reason* one context outranks another (the Supremacy Clause, a
+    // circuit-precedence rule, a guideline year) can ride on the edge as
+    // byte-provenance instead of being asserted bare in host code.
+    // -----------------------------------------------------------------------
+
+    /// Helper: a ground `outranks_context(higher, lower)` edge fact.
+    fn outranks_context_fact(higher: &str, lower: &str) -> Fact {
+        Fact::certain(compound(
+            "outranks_context",
+            vec![atom(higher), atom(lower)],
+        ))
+    }
+
+    #[test]
+    fn grounded_outranks_context_fact_is_a_context_edge() {
+        // No explicit add_context_outranks — the ONLY edge is the grounded fact.
+        let mut kb = empty_kb();
+        kb.add_fact(outranks_context_fact("federal", "state"));
+        assert!(
+            kb.context_outranks("federal", "state"),
+            "a grounded outranks_context fact should drive the context order"
+        );
+        // Direction matters: the reverse does not hold.
+        assert!(!kb.context_outranks("state", "federal"));
+        // A context never outranks itself.
+        assert!(!kb.context_outranks("federal", "federal"));
+    }
+
+    #[test]
+    fn grounded_edges_compose_transitively_with_explicit_edges() {
+        // Mix the two sources: explicit federal > circuit, grounded circuit > district.
+        // The transitive reach federal → district must hold across both kinds of edge.
+        let mut kb = empty_kb();
+        kb.add_context_outranks("federal", "circuit");
+        kb.add_fact(outranks_context_fact("circuit", "district"));
+        assert!(kb.context_outranks("federal", "circuit"));
+        assert!(kb.context_outranks("circuit", "district"));
+        assert!(
+            kb.context_outranks("federal", "district"),
+            "transitive reach must span explicit + grounded edges"
+        );
+    }
+
+    #[test]
+    fn cycle_detection_spans_explicit_and_grounded_edges() {
+        // A cycle formed ACROSS the two sources (explicit a > b, grounded b > a)
+        // must still be caught — else the loader would accept a contradictory order.
+        let mut kb = empty_kb();
+        kb.add_context_outranks("a", "b");
+        kb.add_fact(outranks_context_fact("b", "a"));
+        assert!(kb.context_order_has_cycle());
+        // The resolver stays safe regardless: a mutual outrank is reported both ways
+        // (the caller's defeats() then yields a peer/conflict, never a wrong pick).
+        assert!(kb.context_outranks("a", "b") && kb.context_outranks("b", "a"));
+    }
+
+    #[test]
+    fn grounded_edge_carries_retrievable_provenance() {
+        // The whole point of "grounded context": the fact that establishes the edge
+        // is queryable and its citation is retrievable — the edge explains itself.
+        let mut kb = empty_kb();
+        let prov = Provenance::new(
+            "U.S. Const. art. VI, cl. 2 (Supremacy Clause)",
+            Some("cl. 2".to_string()),
+            TrustTier::Authoritative,
+        );
+        let id =
+            kb.add_fact(outranks_context_fact("federal", "state").with_provenance(prov.clone()));
+        // The edge is live...
+        assert!(kb.context_outranks("federal", "state"));
+        // ...AND its source is recoverable for the audit trail.
+        let f = kb
+            .fact(id)
+            .expect("the grounded edge fact is stored and queryable");
+        assert_eq!(f.provenance.source, prov.source);
+        assert_eq!(f.provenance.trust_tier, TrustTier::Authoritative);
+    }
+
+    #[test]
+    fn non_atom_outranks_context_fact_is_not_an_edge() {
+        // A variable/compound arg is not a ground edge — it stays an ordinary fact
+        // and does not silently inject a precedence relation.
+        let mut kb = empty_kb();
+        kb.add_fact(Fact::certain(compound(
+            "outranks_context",
+            vec![atom("federal"), Term::Var(var("X"))],
+        )));
+        assert!(!kb.context_outranks("federal", "state"));
+        assert!(!kb.context_order_has_cycle());
     }
 }

--- a/code/specs/ADJ73-defeasible-rule-precedence.md
+++ b/code/specs/ADJ73-defeasible-rule-precedence.md
@@ -334,10 +334,16 @@ Each PR: spec-sync note, tests incl. a CONFLICT/abstain case, `/security-review`
   - **PR-B engine core ✅ DONE (logic-engine 0.19).** `Rule::context` + `Knowledge­Base::{add_context_outranks,
     context_outranks (cycle-safe), context_order_has_cycle}` + a `defeats(a,b)` resolution that
     makes context precedence PRIMARY (lex superior) and the tier secondary — generalizing the
-    pure-tier rule (no context order ⇒ unchanged). A cyclic order crowns nothing (safe). Still
-    to come: the grounded `context-precedence.adj` **rulebook** with byte-provenanced edges + the
-    recency/appeal/lex-specialis **meta-rules**, and the adj-lang **surface** (`context:` on a
-    rule, `context_order { … }`).
+    pure-tier rule (no context order ⇒ unchanged). A cyclic order crowns nothing (safe).
+  - **PR-B surface ✅ DONE (adj-lang 0.16).** `context:` on a rule + `context_order { a > b }`.
+  - **PR-B-2 grounded edges ✅ DONE (logic-engine 0.20).** A ground `outranks_context(higher,
+    lower)` **fact** now participates in the context order exactly like an explicit edge, so the
+    precedence edge carries `source`/`locator`/`trust` provenance (the *reason* — Supremacy
+    Clause, circuit precedence, guideline year — rides on the edge, not host code). `context_edges()`
+    unions explicit + grounded edges; cycle detection spans both. This is the decision-§2.3
+    keystone: "context precedence is itself grounded, in its own rulebook, with provenance on WHY."
+    Still to come: the `context-precedence.adj` **rulebook** of byte-quoted edges + a worked legal
+    example through the CLI (PR-B-3 / PR-E), then the recency/appeal/lex-specialis **meta-rules**.
 - **PR-C — adj-lang surface** (`priority: <tier>`, `functional`/`decision`, the attribute
   annotations) + regen grammar.
 - **PR-D — MYCIN `decide_timing` → `timing.adj`** on the named-enum ladder (was PR-4).


### PR DESCRIPTION
## What

ADJ73 decision §2.3 requires context precedence to be **itself grounded** — its own rulebook, with byte-provenance on **why** one context outranks another. The PR-B engine core (0.19) stored the order as bare `add_context_outranks` edges with no provenance; the PR-B surface (`context_order { a > b }`) declares the same unprovenanced edges.

This makes a **grounded `outranks_context(higher, lower)` fact participate in the context order exactly like an explicit edge**. Such a fact is an ordinary `Fact` — queryable, CAS-correctable, carrying `source`/`locator`/`trust` `Provenance` — so the *reason* federal outranks state (the Supremacy Clause) **rides on the edge itself** rather than being asserted bare in host code.

A `relate outranks_context(federal, state) source "…" trust authoritative` clause in adj-lang already lowers to such a fact, so **no surface or grammar change is needed** — the engine simply now reads it.

## How

- New private `KnowledgeBase::context_adjacency()` returns the **effective** order as a directed adjacency map `higher → [lowers]`, unioning explicit `context_order` edges and grounded `outranks_context/2` facts (both args atoms; a non-atom arg stays a normal queryable fact, not an edge).
- `context_outranks` is a cycle-safe DFS over it (**O(V+E)**); `context_order_has_cycle` is a single **Kahn topological-sort pass** (**O(V+E)**) — detecting a cycle formed *across* the two sources (explicit `a > b` + grounded `outranks_context(b, a)`). The per-node adjacency lookup replaces the prior full-edge-list rescan so the order scales to large rule corpora (the stated US-Code-scale ambition).
- `govern::defeats` is **unchanged** — it already calls `kb.context_outranks(...)`, so the grounded edges thread through the whole lex-superior resolution for free, with the citing fact's provenance retrievable for the audit trail.

## Back-compat

A KB with no `outranks_context` facts is byte-identical to 0.19. All existing precedence + integration tests pass unchanged. `logic-engine` 0.19.0 → **0.20.0**.

## Tests

- 5 new unit tests: grounded fact is an edge; transitive across explicit+grounded; cross-source cycle detection; provenance retrievable; non-atom is not an edge.
- 1 end-to-end `govern` test: a grounded Supremacy-Clause edge drives lex-superior at a *lower* tier, citation recoverable.
- **112 unit tests green**; `cargo build --workspace` clean; `adj-lang` + `adjudication-connector` consumer tests pass.

## Review

`/security-review` run; one **LOW** algorithmic-complexity finding (per-node edge rescan) was **fixed** in this PR via the adjacency-map + Kahn refactor; re-review **PASSED**.

## Scope / next

Spec ADJ73 §7 marks **PR-B-2 DONE** and re-scopes **PR-B-3**: the grounded `context-precedence.adj` rulebook (a library of byte-quoted `outranks_context` edges) + a worked legal example through the CLI `governing` section — now unblocked by this engine change. The recursive conflict-resolution meta-rules (recency / appeal-status / lex specialis as themselves-grounded rules) follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)