### PR TITLE
feat(adj-lang-cli): grounded context-precedence rulebook + worked legal example (ADJ73 PR-B-3)

### DIFF
--- a/code/packages/rust/adj-lang-cli/CHANGELOG.md
+++ b/code/packages/rust/adj-lang-cli/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## [0.8.0] - 2026-06-17 — governing answers carry their grounded `context` (ADJ73 PR-B-3)
+
+### Added
+
+- Each `governing` answer now carries a **`"context"`** field — the grounded context its
+  highest-standing deriving rule is in (`ninth_circuit`, `district_court`, `federal`, `state`, …),
+  omitted for a context-free derivation. The audit reader sees *which context governed*, not just
+  which term beat another — the lex-superior story made legible in the output.
+
+### Worked example (committed, runnable)
+
+- `code/specs/data/context-precedence/` — a grounded context-precedence rulebook
+  (`context-precedence.adj`: `outranks_context` edges, each byte-quoting its charter — the
+  Supremacy Clause for `federal > state`, vertical stare decisis for `ninth_circuit >
+  district_court`) + a worked legal example (`worked-legal-example.adj`) that `import`s it and
+  proves *lex superior* end-to-end: the Ninth Circuit's broad reading **governs** a district
+  court's narrow reading **despite the latter's higher `mandatory` tier**. `SOURCES.md` is the
+  provenance ledger. New golden test `tests/context_precedence_e2e.rs` runs the committed
+  artifacts through the built CLI and asserts the override + that the edge is recallable WITH its
+  charter. 0 answer-time model calls.
+
 ## [0.7.0] - 2026-06-16 — `governing` section: defeasible precedence output (ADJ73 PR-3)
 
 ### Added

--- a/code/packages/rust/adj-lang-cli/Cargo.toml
+++ b/code/packages/rust/adj-lang-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adj-lang-cli"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
 description = "Command-line driver for the adj-lang adjudication DSL. Reads a .adj program (rulebook clauses + observe/query), compiles it through the adj-lang frontend, runs the logic-engine differential on the CPU, and emits the decision plus a byte-cited proof DAG as JSON. Argument parsing is declarative via cli-builder. Zero answer-time model calls — this is the CPU-bound reasoner that the MYCIN-2026 prototype shells out to."
 

--- a/code/packages/rust/adj-lang-cli/src/main.rs
+++ b/code/packages/rust/adj-lang-cli/src/main.rs
@@ -624,12 +624,21 @@ fn governing_json(query: &Term, kb: &KnowledgeBase) -> String {
                 Standing::Asserted => "asserted".to_string(),
                 Standing::Rule(p) => format!("{p:?}").to_lowercase(),
             };
+            // ADJ73 PR-B: surface the grounded CONTEXT this answer is decided in (the context of
+            // its highest-standing deriving rule), so the audit reader sees *which* context
+            // governed (federal vs state, ninth_circuit vs district_court) — not just that one
+            // term beat another. Omitted for a context-free derivation.
+            let context = match &a.context {
+                Some(c) => format!(",\"context\":\"{}\"", esc(c)),
+                None => String::new(),
+            };
             format!(
-                "{{\"term\":\"{}\",\"bindings\":{{{}}},\"status\":\"{}\",\"standing\":\"{}\"{}}}",
+                "{{\"term\":\"{}\",\"bindings\":{{{}}},\"status\":\"{}\",\"standing\":\"{}\"{}{}}}",
                 esc(&format!("{}", a.term)),
                 binds.join(","),
                 status,
                 standing,
+                context,
                 defeated_by
             )
         })

--- a/code/packages/rust/adj-lang-cli/tests/context_precedence_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/context_precedence_e2e.rs
@@ -1,0 +1,118 @@
+//! End-to-end golden test for the GROUNDED context-precedence rulebook + worked legal example
+//! (ADJ73 PR-B-3) through the built CLI binary.
+//!
+//! This proves the whole *lex superior* chain on real committed artifacts, at 0 answer-time
+//! model calls:
+//!
+//!   1. `context-precedence.adj` declares the precedence order as GROUNDED facts
+//!      (`relate outranks_context(ninth_circuit, district_court) source "<verbatim stare-decisis
+//!      quote>" trust authoritative`) — each edge carrying its charter.
+//!   2. `worked-legal-example.adj` `import`s that rulebook and sets the trap: two courts read a
+//!      statute term differently; the district court's (narrow) reading is asserted at the HIGHEST
+//!      (`mandatory`) tier, the circuit's (broad) reading at the lowest (`default`).
+//!   3. The engine reads the grounded edge as a context-order edge (logic-engine 0.20) and applies
+//!      context precedence BEFORE the tier: the circuit's broad reading GOVERNS, the district's
+//!      narrow reading is DEFEATED — despite its higher tier.
+//!
+//! It also proves the precedence is AUDITABLE: a binding query over `outranks_context` recalls the
+//! governing edge WITH its byte-quoted charter.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+/// The context-precedence data dir, relative to this crate's manifest:
+/// `code/packages/rust/adj-lang-cli` → `code/specs/data/context-precedence`.
+fn data(name: &str) -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/context-precedence")
+        .join(name)
+}
+
+/// Run the CLI on a committed `.adj` file; return (success, stdout).
+fn run(name: &str) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(data(name))
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+#[test]
+fn higher_context_reading_governs_despite_lower_tier() {
+    let (ok, s) = run("worked-legal-example.adj");
+    assert!(ok, "cli should succeed: {s}");
+
+    // The governing section exists (the query is a binding query).
+    assert!(s.contains("\"governing\""), "has a governing section: {s}");
+
+    // The Ninth Circuit's BROAD reading governs — and is decided in the ninth_circuit context.
+    assert!(
+        s.contains("means(navigable_waters, broad)"),
+        "carries the broad reading: {s}"
+    );
+    assert!(
+        s.contains("\"status\":\"governing\""),
+        "the broad reading governs: {s}"
+    );
+    assert!(
+        s.contains("\"context\":\"ninth_circuit\""),
+        "the governing answer is decided in the ninth_circuit context: {s}"
+    );
+
+    // The district court's NARROW reading is defeated by the broad reading — even though it sits
+    // at the higher `mandatory` tier (context is primary; lex superior beats the tier).
+    assert!(
+        s.contains("\"status\":\"defeated\""),
+        "the narrow reading is defeated: {s}"
+    );
+    assert!(
+        s.contains("\"context\":\"district_court\""),
+        "the defeated answer is the district_court reading: {s}"
+    );
+    assert!(
+        s.contains("\"defeated_by\":\"means(navigable_waters, broad)\""),
+        "defeated by the broad reading: {s}"
+    );
+    assert!(
+        s.contains("\"standing\":\"mandatory\""),
+        "the defeated reading carried the highest tier, yet still lost on context: {s}"
+    );
+
+    // It is a clean override, not an unresolved split.
+    assert!(s.contains("\"has_conflict\":false"), "no conflict: {s}");
+}
+
+#[test]
+fn the_precedence_edge_is_auditable_with_its_charter() {
+    // The precedence ORDER is itself queryable + cited: recall the grounded edge and confirm its
+    // verbatim charter rides on it (the whole point of "context precedence is grounded").
+    let dir = std::env::temp_dir().join(format!("adjcli_ctxaudit_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    // Copy the committed rulebook beside a tiny query case so the import resolves locally.
+    let rulebook = std::fs::read_to_string(data("context-precedence.adj")).unwrap();
+    std::fs::write(dir.join("context-precedence.adj"), rulebook).unwrap();
+    std::fs::write(
+        dir.join("audit.adj"),
+        "import \"context-precedence.adj\"\n? outranks_context(ninth_circuit, $lower)\n",
+    )
+    .unwrap();
+
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(dir.join("audit.adj"))
+        .output()
+        .expect("run adj-lang-cli");
+    let s = String::from_utf8(out.stdout).unwrap();
+    assert!(out.status.success(), "cli should succeed: {s}");
+
+    // The edge is recalled, bound to district_court...
+    assert!(
+        s.contains("outranks_context(ninth_circuit, district_court)"),
+        "recalls the grounded precedence edge: {s}"
+    );
+    // ...and its charter (the verbatim stare-decisis quote) is on the citation.
+    assert!(
+        s.contains("binding on all federal district courts within its circuit"),
+        "the edge carries its byte-quoted charter for the audit trail: {s}"
+    );
+}

--- a/code/specs/ADJ73-defeasible-rule-precedence.md
+++ b/code/specs/ADJ73-defeasible-rule-precedence.md
@@ -342,13 +342,23 @@ Each PR: spec-sync note, tests incl. a CONFLICT/abstain case, `/security-review`
     Clause, circuit precedence, guideline year — rides on the edge, not host code). `context_edges()`
     unions explicit + grounded edges; cycle detection spans both. This is the decision-§2.3
     keystone: "context precedence is itself grounded, in its own rulebook, with provenance on WHY."
-    Still to come: the `context-precedence.adj` **rulebook** of byte-quoted edges + a worked legal
-    example through the CLI (PR-B-3 / PR-E), then the recency/appeal/lex-specialis **meta-rules**.
+  - **PR-B-3 grounded rulebook + worked example ✅ DONE (adj-lang-cli 0.8).**
+    `code/specs/data/context-precedence/`: a grounded `context-precedence.adj` rulebook —
+    `outranks_context(federal, state)` byte-quoting the Supremacy Clause and
+    `outranks_context(ninth_circuit, district_court)` byte-quoting vertical stare decisis (verbatim
+    primary-source quotes + locator + `authoritative` tier; `SOURCES.md` ledger) — plus a worked
+    legal example that `import`s it and proves *lex superior* end-to-end through the CLI: the
+    circuit's broad reading **governs** a district court's narrow reading **despite its higher
+    `mandatory` tier**. Governing answers now carry their `context` in the JSON. Golden test
+    `adj-lang-cli/tests/context_precedence_e2e.rs`. Still to come: the recency / appeal-status /
+    lex-specialis **meta-rules** (PR-B-4) that *derive* precedence from grounded rule attributes
+    (e.g. `idsa_2024 > idsa_2004` as lex posterior) rather than asserting each edge bare.
 - **PR-C — adj-lang surface** (`priority: <tier>`, `functional`/`decision`, the attribute
   annotations) + regen grammar.
 - **PR-D — MYCIN `decide_timing` → `timing.adj`** on the named-enum ladder (was PR-4).
-- **PR-E — legal `context-precedence` worked example** (federal>state grounded to the Supremacy
-  Clause; a reversed-on-appeal defeat) proving the recursive grounded mechanism end-to-end.
+- **PR-E — legal `context-precedence` worked example** — the lex-superior half (federal>state /
+  ninth_circuit>district_court grounded to the Supremacy Clause + vertical stare decisis) is
+  ✅ DONE in **PR-B-3**; the reversed-on-appeal defeat folds into the appeal-status meta-rule (PR-B-4).
 
 Each PR: spec-sync note, tests incl. a CONFLICT/abstain case, `/security-review`, babysit.
 

--- a/code/specs/data/context-precedence/README.md
+++ b/code/specs/data/context-precedence/README.md
@@ -1,0 +1,44 @@
+# context-precedence — grounded lex-superior precedence (ADJ73 PR-B-3)
+
+A worked, byte-provenanced demonstration that **context precedence is itself grounded** — its
+own rulebook, with a citation on *why* one context outranks another (ADJ73 decision §2.3).
+
+## Files
+
+| File | What |
+|------|------|
+| [`context-precedence.adj`](context-precedence.adj) | The grounded precedence order: `outranks_context(higher, lower)` edges, each carrying a verbatim charter (`source`/`locator`/`trust`). The logic-engine (≥ 0.20) reads these facts as directed edges and applies *lex superior* before the priority tier. |
+| [`worked-legal-example.adj`](worked-legal-example.adj) | A case that `import`s the rulebook: two courts read "navigable waters" differently; the Ninth Circuit's reading **governs** the district court's *despite a lower tier*, because `ninth_circuit` outranks `district_court`. |
+| [`SOURCES.md`](SOURCES.md) | The provenance ledger — where each edge's verbatim quote came from. |
+
+## Run it
+
+```sh
+adj-lang-cli code/specs/data/context-precedence/worked-legal-example.adj
+```
+
+The `governing` section resolves the conflict (0 answer-time model calls):
+
+```json
+{ "term": "means(navigable_waters, broad)",  "status": "governing", "context": "ninth_circuit",   "standing": "default" }
+{ "term": "means(navigable_waters, narrow)", "status": "defeated",  "context": "district_court",
+  "standing": "mandatory", "defeated_by": "means(navigable_waters, broad)" }
+```
+
+The broad circuit reading wins on **context** (lex superior), not tier — the narrow reading sits
+at the higher `mandatory` tier and is still defeated. The precedence is auditable: a binding
+query `? outranks_context(ninth_circuit, $lower)` recalls the governing edge **with** its
+charter (the verbatim stare-decisis quote).
+
+## How it fits
+
+This is the data/worked-example layer of the ADJ73 precedence arc:
+
+- **engine** (logic-engine 0.19) — `context_outranks`, lex-superior `defeats`.
+- **grounded edges** (logic-engine 0.20, PR-B-2) — `outranks_context` facts participate as edges.
+- **surface** (adj-lang 0.16) — `context:` on a rule, `context_order { … }`.
+- **this** (PR-B-3) — the grounded rulebook + worked legal example end-to-end through the CLI.
+- **next** (PR-B-4) — the recursive conflict-resolution **meta-rules** (lex posterior / recency,
+  lex specialis, appeal status) that *derive* precedence from grounded rule attributes rather
+  than asserting it edge-by-edge. See [`SOURCES.md`](SOURCES.md) and the spec
+  `code/specs/ADJ73-defeasible-rule-precedence.md` §7.

--- a/code/specs/data/context-precedence/SOURCES.md
+++ b/code/specs/data/context-precedence/SOURCES.md
@@ -1,0 +1,33 @@
+# Sources — grounded context-precedence edges (ADJ73 PR-B-3)
+
+Every `outranks_context` edge in [`context-precedence.adj`](context-precedence.adj) is
+byte-provenanced: it carries a `source` (a verbatim quote of its charter), a `locator`, and a
+`trust` tier. This ledger records where each quote came from, so the edge is auditable and one
+CAS edit from correctable. Nothing here is human-authored doctrine — each edge is the literal
+text of a primary/authoritative source.
+
+| Edge | Charter | Verbatim quote (excerpt) | Locator | Trust | Retrieved |
+|------|---------|--------------------------|---------|-------|-----------|
+| `federal > state` | U.S. Constitution, Supremacy Clause | "This Constitution, and the laws of the United States which shall be made in pursuance thereof; … shall be the supreme law of the land; and the judges in every state shall be bound thereby, anything in the Constitution or laws of any State to the contrary notwithstanding." | U.S. Const. art. VI, cl. 2 | authoritative | 2026-06-17 |
+| `ninth_circuit > district_court` | Vertical stare decisis | "a federal circuit decision is binding on all federal district courts within its circuit, but not federal courts in other circuits" | WCL 1L Legal Research Primer — Binding v. Persuasive Authority | authoritative | 2026-06-17 |
+
+## Retrieval URLs
+
+- Supremacy Clause (verbatim): <https://www.law.cornell.edu/constitution/articlevi> (Legal Information Institute, Cornell Law School).
+- Vertical stare decisis (circuit binds district within circuit): <https://wcl.american.libguides.com/1Lresearch/authority> (American University, Washington College of Law — *Binding v. Persuasive Authority*, 1L Legal Research Primer). Corroborated by LII Wex, *stare decisis*: <https://www.law.cornell.edu/wex/stare_decisis>.
+
+## Deliberately NOT included here (deferred to PR-B-4 as grounded meta-rules)
+
+The other classical conflict-resolution canons are *derivable* from rule attributes and so must
+be grounded **meta-rules**, not bare edges duplicated per pair:
+
+- **lex posterior** (recency): a newer enactment/guideline supersedes an older one — e.g.
+  `idsa_2024 > idsa_2004`. This is a function of each rule's enactment/publication date, not a
+  standalone authority hierarchy; deriving it keeps the order honest (an edge that can be derived
+  should be derived).
+- **lex specialis**: the more specific rule controls the more general.
+- **appeal status**: a reversed/vacated holding loses precedential force.
+
+Each will itself be a byte-provenanced rule (citing the canon's authority) that *derives*
+`outranks_context` / defeats from typed, provenanced rule metadata — the recursive structure
+ADJ73 §7 calls for.

--- a/code/specs/data/context-precedence/context-precedence.adj
+++ b/code/specs/data/context-precedence/context-precedence.adj
@@ -1,0 +1,81 @@
+% =====================================================================
+% context-precedence.adj — a GROUNDED context-precedence rulebook
+% (ADJ73 PR-B-3, decision §2.3: "context precedence is itself grounded,
+%  in its own rulebook, with provenance on WHY").
+%
+% WHAT THIS IS
+% ------------
+% Defeasible precedence (ADJ73) resolves a conflict between two rules that
+% derive incompatible conclusions. The PRIMARY tiebreaker is *lex superior*:
+% a rule grounded in a higher-authority CONTEXT defeats a conflicting rule in
+% a lower context — BEFORE the priority tier is even consulted. This file is
+% the precedence order itself, and the whole point is that each edge is a
+% GROUNDED FACT carrying its charter:
+%
+%     relate outranks_context(higher, lower)  source "…"  locator "…"  trust …
+%
+% An `outranks_context(a, b)` fact means "context `a` outranks context `b`".
+% The logic-engine (>= 0.20) reads these facts as directed edges in the
+% context order (KnowledgeBase::context_adjacency), so `context_outranks`
+% walks them transitively and `enumerate_governing` applies lex superior.
+% Because the edge is an ordinary byte-provenanced Fact, it is queryable
+% (`? outranks_context(federal, $lower)`), auditable (its source rides on it),
+% and ONE CAS EDIT from correctable — exactly like every clinical/legal fact
+% in this framework. Nothing here is asserted bare in host code.
+%
+% WHY NOT JUST `context_order { federal > state }`?
+% -------------------------------------------------
+% That bare surface form (adj-lang 0.16) declares the same edges but carries
+% NO provenance — it cannot answer "says who?". A precedence order that the
+% system relies on to overturn one authority with another MUST itself be
+% defensible. So the durable, checked-in form is grounded facts, and the bare
+% `context_order` block is reserved for throwaway/inline examples.
+%
+% SCOPE (this file): the two *lex superior* (authority-hierarchy) edges, each
+% grounded to a primary source. The other classical conflict-resolution canons
+% — lex posterior (recency: a newer enactment/guideline supersedes an older
+% one, e.g. idsa_2024 > idsa_2004) and lex specialis (the more specific rule
+% controls) — are NOT hand-asserted as edges here. They are themselves grounded
+% META-RULES that DERIVE precedence from rule attributes (enactment date,
+% specificity, appeal status); they land in PR-B-4 so the recursive structure
+% the spec calls for (§7) stays honest: an edge that can be derived should be
+% derived, not duplicated as a bare fact.
+% =====================================================================
+
+% ---------------------------------------------------------------------
+% EDGE 1 — federal > state (the Supremacy Clause).
+%
+% Federal law is "the supreme Law of the Land", and state judges are bound by
+% it notwithstanding contrary state law. So a rule grounded in `federal`
+% context outranks a conflicting rule grounded in `state` context. This is the
+% canonical lex-superior instance and ADJ73's north-star (§5.3).
+%
+% Verbatim charter (locator art. VI, cl. 2):
+%   "This Constitution, and the laws of the United States which shall be made
+%    in pursuance thereof; … shall be the supreme law of the land; and the
+%    judges in every state shall be bound thereby, anything in the Constitution
+%    or laws of any State to the contrary notwithstanding."
+% ---------------------------------------------------------------------
+relate outranks_context(federal, state)
+  source "U.S. Const. art. VI, cl. 2 (Supremacy Clause): \"This Constitution, and the laws of the United States which shall be made in pursuance thereof; and all treaties made, or which shall be made, under the authority of the United States, shall be the supreme law of the land; and the judges in every state shall be bound thereby, anything in the Constitution or laws of any State to the contrary notwithstanding.\""
+  locator "U.S. Const. art. VI, cl. 2"
+  trust authoritative
+
+% ---------------------------------------------------------------------
+% EDGE 2 — ninth_circuit > district_court (vertical stare decisis).
+%
+% Within a circuit, a U.S. Court of Appeals decision binds every U.S. district
+% court in that circuit (vertical stare decisis). So a reading grounded in
+% `ninth_circuit` context outranks a conflicting reading a `district_court`
+% adopted on its own. (A decision of one circuit does NOT bind district courts
+% in another circuit — modelled by the ABSENCE of such an edge, so those
+% contexts are incomparable and fall back to the priority tier.)
+%
+% Verbatim charter:
+%   "a federal circuit decision is binding on all federal district courts
+%    within its circuit, but not federal courts in other circuits"
+% ---------------------------------------------------------------------
+relate outranks_context(ninth_circuit, district_court)
+  source "Binding v. Persuasive Authority (American University, Washington College of Law, 1L Legal Research Primer): \"a federal circuit decision is binding on all federal district courts within its circuit, but not federal courts in other circuits.\""
+  locator "WCL 1L Legal Research Primer — Binding v. Persuasive Authority"
+  trust authoritative

--- a/code/specs/data/context-precedence/worked-legal-example.adj
+++ b/code/specs/data/context-precedence/worked-legal-example.adj
@@ -1,0 +1,61 @@
+% =====================================================================
+% worked-legal-example.adj — lex superior, end-to-end (ADJ73 PR-B-3).
+%
+% THE CASE.  The term "navigable waters" is read two ways by two courts:
+%   • the Ninth Circuit reads it BROADLY;
+%   • a district court in that circuit reads it NARROWLY.
+% A statute's term has at most one governing meaning, so the two readings
+% CONFLICT. Which governs?
+%
+% The naive answer would look at the priority TIER — and here the trap is
+% deliberately set: the narrow district-court reading is asserted at the
+% `mandatory` tier (the highest), while the broad circuit reading sits at the
+% `default` tier. A pure-tier engine would pick the narrow reading.
+%
+% But context precedence is PRIMARY (lex superior). The grounded rulebook says
+% `ninth_circuit` outranks `district_court` (vertical stare decisis), so the
+% circuit's BROAD reading GOVERNS and the district's narrow reading is DEFEATED
+% — despite its higher tier. The tier only breaks ties the context order leaves
+% open. Run this through adj-lang-cli and read the `governing` section:
+%
+%   means(navigable_waters, broad)   status governing   context ninth_circuit
+%   means(navigable_waters, narrow)  status defeated     context district_court
+%                                    defeated_by means(navigable_waters, broad)
+%
+% 0 answer-time model calls — pure SLD + a precedence post-pass over the
+% grounded graph. The precedence is auditable: `? outranks_context(ninth_circuit,
+% $lower)` recalls the edge WITH its charter (the WCL stare-decisis quote).
+% =====================================================================
+
+% The grounded precedence order (federal>state, ninth_circuit>district_court),
+% each edge carrying its byte-quoted charter. Resolution relies on a DEFENSIBLE
+% order, so it is imported as a checked-in rulebook, not declared bare.
+import "context-precedence.adj"
+
+% A statute term has at most one governing reading → declare `means` functional
+% on its last argument, so the two readings conflict and precedence must pick.
+functional means(term, reading)
+
+% The Ninth Circuit's reading (broad), grounded in `ninth_circuit` context.
+% Left at the DEFAULT tier on purpose — it wins on context, not tier.
+rule {
+  head: means(navigable_waters, broad)
+  when: ninth_circuit_held
+  context: ninth_circuit
+}
+
+% The district court's reading (narrow), grounded in `district_court` context,
+% asserted at the MANDATORY tier — the highest. Context still overrides it.
+rule {
+  head: means(navigable_waters, narrow)
+  when: district_held
+  priority: mandatory
+  context: district_court
+}
+
+% Per-case facts: both courts have spoken.
+observe ninth_circuit_held
+observe district_held
+
+% Which reading governs?  (binding query → the `governing` section resolves it.)
+? means(navigable_waters, $reading)


### PR DESCRIPTION
## What

ADJ73 decision §2.3 requires context precedence to be **itself grounded** — its own rulebook, with provenance on *why* one context outranks another. PR-B-2 ([#6103](https://github.com/adhithyan15/coding-adventures/pull/6103)) made the engine read grounded `outranks_context` facts as edges; **this lands the actual grounded rulebook + a worked legal example** proving *lex superior* end-to-end through the CPU reasoner (0 answer-time model calls).

## New grounded data (`code/specs/data/context-precedence/`)

- **`context-precedence.adj`** — the precedence order as two byte-provenanced lex-superior edges, each carrying its **verbatim charter**:
  - `outranks_context(federal, state)` ← *U.S. Const. art. VI, cl. 2* (Supremacy Clause)
  - `outranks_context(ninth_circuit, district_court)` ← vertical stare decisis (a circuit decision binds all district courts within the circuit)
- **`worked-legal-example.adj`** — `import`s the rulebook and sets the trap: two courts read "navigable waters" differently; the district court's narrow reading is asserted at the **highest** (`mandatory`) tier, the circuit's broad reading at the lowest (`default`). Context precedence is primary, so the circuit's **broad reading governs** and the district's narrow reading is **defeated despite its higher tier**.
- **`SOURCES.md`** — provenance ledger (verbatim quotes + retrieval URLs: LII Cornell, American U. WCL).

## CLI (`adj-lang-cli` 0.7.0 → 0.8.0)

Each `governing` answer now carries a **`"context"`** field — the grounded context of its highest-standing deriving rule — so the audit reader sees *which context governed*, not just which term won. Additive; existing `governing_e2e` tests pass unchanged.

```json
{ "term": "means(navigable_waters, broad)",  "status": "governing", "context": "ninth_circuit",  "standing": "default" }
{ "term": "means(navigable_waters, narrow)", "status": "defeated",  "context": "district_court",
  "standing": "mandatory", "defeated_by": "means(navigable_waters, broad)" }
```

## Tests

New golden test `tests/context_precedence_e2e.rs` runs the **committed artifacts** through the built CLI: asserts the broad circuit reading governs (context `ninth_circuit`), the narrow district reading is `defeated_by` it at the `mandatory` tier, no conflict — **and** that the precedence is auditable (a binding query recalls `outranks_context` *with* its verbatim charter). Full `adj-lang-cli` suite green (30+ tests). `/security-review` PASSED.

## Honest scope

Only the two **lex-superior** (authority-hierarchy) edges are hand-asserted. The other canons — **lex posterior / recency** (e.g. `idsa_2024 > idsa_2004`), **lex specialis**, **appeal status** — are derivable from rule attributes and so become grounded **meta-rules** in **PR-B-4**, not bare edges duplicated per pair. An edge that can be derived should be derived (spec ADJ73 §7).

## Stacking

Stacked on **[#6103](https://github.com/adhithyan15/coding-adventures/pull/6103)** (PR-B-2 grounded-edge engine support) — the worked example only resolves via grounded edges once that merges. GitHub auto-retargets this PR to `main` when #6103 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)