### PR TITLE
feat(mycin-cc5b): ground the meningitis time-criticality threshold (retire authored-debt)

### DIFF
--- a/code/specs/data/mycin-2026/treatment/antibiotics/chart_to_cop.py
+++ b/code/specs/data/mycin-2026/treatment/antibiotics/chart_to_cop.py
@@ -123,18 +123,40 @@ _OBJECTIVE_WEIGHTS = {"cost": (1, 0), "balanced": (1, 1), "low_toxicity": (1, 3)
 # CC-5: the wait-vs-treat-now decision (§4). Empiric-now vs await-culture is a real
 # tradeoff: treating now buys broad coverage (more cost + side-effect burden) but
 # `delay_risk = 0`; awaiting the culture is cheaper/narrower but incurs delay_risk. The
-# disease's TIME-CRITICALITY decides which dominates. For bacterial meningitis the door-to-
-# antibiotic window is ~60 min — delay raises mortality — so empiric-now dominates regardless
-# of cost/toxicity. This threshold is AUTHORED-DEBT (the IDSA recommendation), flagged for
-# CC-5b spider grounding; `routine` acuity (a non-time-critical infection) leaves room to
-# await a culture when the patient is stable. The decision is reusable: it's a function of
-# (disease acuity, culture status, clinical stability), not meningitis-specific.
+# disease's TIME-CRITICALITY decides which dominates: for bacterial meningitis it is a
+# neurologic emergency and antibiotics must start AS SOON AS POSSIBLE — delay worsens outcome —
+# so empiric-now dominates regardless of cost/toxicity. `routine` acuity (a non-time-critical
+# infection) leaves room to await a culture when the patient is stable. The decision is
+# reusable: a function of (disease acuity, culture status, clinical stability), not
+# meningitis-specific.
+#
+# CC-5b — GROUNDED (was AUTHORED-DEBT). The time-criticality of bacterial meningitis is now
+# carried by VERBATIM guideline quotes, not a paraphrase. HONESTY CORRECTION: the IDSA
+# meningitis guideline (Tunkel 2004) says start antimicrobials "as soon as possible" and that
+# it is "a neurologic emergency" — it does NOT set a hard numeric door-to-antibiotic threshold
+# for meningitis. The earlier "≤60 min / ≤1 hour" figure was an unsupported overclaim (a
+# sepsis/quality-bundle number, not IDSA meningitis guidance), so we represent the urgency
+# QUALITATIVELY exactly as the source states (`treat_target: as_soon_as_possible`) rather than
+# asserting a threshold no cited source supports — grounding catching a mis-asserted pivot value
+# is the point. See `time-criticality.SOURCES.md` for the retrieval trail.
 _TIME_CRITICALITY = {
-    "meningitis": {"acuity": "time_critical", "treat_within_min": 60,
-                   "source": "Suspected bacterial meningitis is a medical emergency; "
-                             "empiric antibiotics should be started without delay (target "
-                             "≤1 hour), as delay increases mortality and morbidity (IDSA).",
-                   "trust": "consensus"},  # [FLAG: authored — ground in CC-5b]
+    "meningitis": {
+        "acuity": "time_critical",
+        # Qualitative target faithful to the source — NOT a numeric ≤60-min claim (see above).
+        "treat_target": "as_soon_as_possible",
+        "source": (
+            "Begin antimicrobial therapy as soon as possible: \"When a patient presents with "
+            "suspected acute bacterial meningitis, the physician should begin antimicrobial "
+            "therapy as soon as possible.\" Bacterial meningitis is a neurologic emergency: "
+            "\"Bacterial meningitis is a neurologic emergency; progression to more severe "
+            "disease reduces the patient's likelihood of a full recovery.\""
+        ),
+        "locator": (
+            "IDSA Practice Guidelines for the Management of Bacterial Meningitis (Tunkel et al., "
+            "Clin Infect Dis 2004;39:1267); AAFP summary (Am Fam Physician 2005;71(10):2003)"
+        ),
+        "trust": "authoritative",
+    },
 }
 
 
@@ -334,8 +356,9 @@ def decide_timing(cli: Path, disease: str, culture_status: str, clinical_status:
         "culture_status": culture_status or "unknown",
         "rationale": _TIMING_RATIONALE.get((decision, delay_risk), ""),
     }
-    # Carry the grounded (flagged) door-to-antibiotic threshold when one is recorded.
-    threshold = {k: tc[k] for k in ("treat_within_min", "source", "trust") if k in tc}
+    # Carry the grounded time-criticality basis (verbatim guideline quote + locator + trust +
+    # the qualitative treat target) when one is recorded for this disease.
+    threshold = {k: tc[k] for k in ("treat_target", "source", "locator", "trust") if k in tc}
     if threshold:
         out["threshold"] = threshold
     return out

--- a/code/specs/data/mycin-2026/treatment/antibiotics/test_chart_to_cop.py
+++ b/code/specs/data/mycin-2026/treatment/antibiotics/test_chart_to_cop.py
@@ -156,10 +156,15 @@ def test_decide_timing_decision_table():
     cli = decide_mod.find_cli()
     if cli is None:
         return
-    # Time-critical disease (meningitis) → empiric now, high delay_risk, with the threshold.
+    # Time-critical disease (meningitis) → empiric now, high delay_risk, with the GROUNDED
+    # time-criticality basis (CC-5b): a verbatim guideline quote + qualitative treat target,
+    # NOT the retired (unsupported) ≤60-min numeric threshold.
     t = cc.decide_timing(cli, "meningitis", "pending", "stable")
     assert t["decision"] == "treat_now_empiric" and t["delay_risk"] == "high", t
-    assert t["threshold"]["treat_within_min"] == 60 and t["threshold"]["trust"]
+    assert t["threshold"]["treat_target"] == "as_soon_as_possible", t
+    assert t["threshold"]["trust"] == "authoritative", t
+    assert "as soon as possible" in t["threshold"]["source"], t  # verbatim guideline quote rides on it
+    assert "treat_within_min" not in t["threshold"], "the unsupported ≤60-min overclaim is retired"
     assert t["standing"] == "authoritative"  # the time-critical rule governed
     # A critical patient forces empiric-now even for a routine-acuity disease.
     assert cc.decide_timing(cli, "cellulitis", "pending", "critical")["decision"] == "treat_now_empiric"

--- a/code/specs/data/mycin-2026/treatment/antibiotics/time-criticality.SOURCES.md
+++ b/code/specs/data/mycin-2026/treatment/antibiotics/time-criticality.SOURCES.md
@@ -1,0 +1,44 @@
+# Sources — disease time-criticality (CC-5b)
+
+The `_TIME_CRITICALITY` table in [`chart_to_cop.py`](chart_to_cop.py) classifies a disease's
+acuity (`time_critical` vs `routine`), which feeds the wait-vs-treat-now precedence ladder
+(`timing.adj`). This ledger grounds that classification — replacing the prior `[FLAG: authored]`
+paraphrase with verbatim guideline text.
+
+## meningitis → `time_critical`
+
+| Field | Value |
+|-------|-------|
+| Verbatim quote (start promptly) | "When a patient presents with suspected acute bacterial meningitis, the physician should begin antimicrobial therapy as soon as possible." |
+| Verbatim quote (emergency) | "Bacterial meningitis is a neurologic emergency; progression to more severe disease reduces the patient's likelihood of a full recovery." |
+| Charter | IDSA *Practice Guidelines for the Management of Bacterial Meningitis* (Tunkel et al., *Clin Infect Dis* 2004;39:1267) |
+| Locator | Tunkel 2004, CID 39:1267; AAFP summary (*Am Fam Physician* 2005;71(10):2003) |
+| Trust | authoritative |
+| Retrieved | 2026-06-17 |
+
+### Honesty correction (why no ≤60-min number)
+
+The earlier entry asserted a `treat_within_min: 60` ("target ≤1 hour") door-to-antibiotic
+threshold attributed to IDSA at `consensus` trust. **That was an overclaim.** The IDSA
+meningitis guideline does not set a hard numeric door-to-antibiotic threshold for meningitis —
+it says to start antimicrobials "as soon as possible" and that meningitis is "a neurologic
+emergency." A specific ≤60-minute figure is a **sepsis / quality-bundle** operationalization,
+not IDSA meningitis guidance. Grounding surfaced the mismatch, so the table now represents the
+urgency qualitatively (`treat_target: as_soon_as_possible`) — faithful to what the cited source
+actually states. Catching a mis-asserted pivot value is exactly what byte-provenance grounding
+is for.
+
+## Retrieval URLs
+
+- AAFP summary of the IDSA guidelines (verbatim quotes above):
+  <https://www.aafp.org/pubs/afp/issues/2005/0515/p2003.html>
+- IDSA guideline of record (Tunkel et al. 2004), *Clinical Infectious Diseases*:
+  <https://academic.oup.com/cid/article/39/9/1267/402080>
+- Supporting empirical evidence — time-to-antibiotic and outcome (Danish population cohort):
+  <https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4977612/>
+
+## Still routine (no time-critical edge)
+
+A disease absent from the table defaults to `routine` acuity — there is room to await a culture
+when the patient is stable. Adding a new `time_critical` disease must come with its own grounded
+quote here, same as meningitis.


### PR DESCRIPTION
## What

**CC-5b** — retire the last `[FLAG: authored]` debt in the wait-vs-treat-now ladder. The meningitis time-criticality entry in `chart_to_cop.py`'s `_TIME_CRITICALITY` table carried a *paraphrased* "≤60 min / ≤1 hour" door-to-antibiotic threshold attributed to IDSA at `consensus` trust. This grounds it from the literature.

## Honesty correction (the point of byte-provenance grounding)

The IDSA meningitis guideline (Tunkel 2004) says to start antimicrobials **"as soon as possible"** and that meningitis is **"a neurologic emergency"** — it sets **no hard numeric door-to-antibiotic threshold** for meningitis. The "≤60 min" figure was an **unsupported overclaim** (a sepsis/quality-bundle number, not IDSA meningitis guidance). So the entry now:

- carries **verbatim guideline quotes** (start ASAP; neurologic emergency; delay reduces likelihood of full recovery), sourced to Tunkel 2004 / the AAFP summary, at `authoritative` trust;
- represents the urgency **qualitatively** (`treat_target: as_soon_as_possible`) instead of the numeric ≤60-min claim no cited source supports;
- drops the `[FLAG: authored]` marker.

Grounding *catching a mis-asserted pivot value* is exactly what byte-provenance is for — the same failure mode the framework targets in the clinical/legal corpora.

`time-criticality.SOURCES.md` records the retrieval trail (Tunkel 2004, *CID* 39:1267; AAFP 2005 summary; supporting Danish time-to-antibiotic cohort) and documents why no ≤60-min number is asserted.

## No behavior change

The acuity classification (`time_critical`) is unchanged — well-supported by "neurologic emergency" / "as soon as possible" — so meningitis still forces empiric-now (`delay_risk` high). Only the threshold's **provenance** is corrected; the decision logic already lives in `timing.adj` (CC-5/PR-D). The `decide_timing` wrapper now surfaces `treat_target`/`locator`; the test asserts the grounded shape and that the ≤60-min overclaim is gone.

## Tests

`ruff` clean; full `test_chart_to_cop.py` suite green (engine-gated tests run against the built `adj-lang-cli`). `/security-review` PASSED.

Independent of the open ADJ73 precedence PRs (#6103/#6104) — different subsystem, off `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)