### PR TITLE
Accept .control appendwrite option

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ### Added
 
+- **Deck control appendwrite option routing** —
+  `analyze_deck_controls()` and `resolve_deck_sources()` now accept selected
+  `.control` block `set appendwrite` rawfile append-write options as no-op
+  control commands instead of reporting unsupported-command diagnostics,
+  matching Rust and TypeScript.
+
 - **Deck control rawfile output option routing** —
   `analyze_deck_controls()` and `resolve_deck_sources()` now accept selected
   `.control` block `set wr_vecnames` and `set wr_singlescale` rawfile output

--- a/code/packages/python/spice-engine/README.md
+++ b/code/packages/python/spice-engine/README.md
@@ -163,8 +163,9 @@ selected analysis/output commands (`op`, `dc`, `ac`, `tran`, `save`, `probe`,
 `measure`, `meas`, `four`, `fourier`, `print`, and `plot`) are normalized into
 dotted deck cards, while `run`, `reset`, `quit`, and the UI-only
 `set noaskquit` option plus the ASCII rawfile-format `set filetype=ascii`
-option and vector-name/single-scale rawfile output toggles (`set wr_vecnames`,
-`set wr_singlescale`) are accepted as no-op control markers. Other
+option, vector-name/single-scale rawfile output toggles (`set wr_vecnames`,
+`set wr_singlescale`), and the append-write rawfile option (`set appendwrite`)
+are accepted as no-op control markers. Other
 unrecognized non-comment commands emit diagnostics until a broader executed
 control subset is in scope.
 `resolve_deck_sources()` is the first include/library resolution layer: callers

--- a/code/packages/python/spice-engine/src/spice_engine/compatibility.py
+++ b/code/packages/python/spice-engine/src/spice_engine/compatibility.py
@@ -519,7 +519,7 @@ _NOOP_CONTROL_BLOCK_COMMANDS = frozenset(
     {"run", ".run", "reset", ".reset", "quit", ".quit"}
 )
 _NOOP_CONTROL_BLOCK_SET_OPTIONS = frozenset(
-    {"noaskquit", "filetype=ascii", "wr_vecnames", "wr_singlescale"}
+    {"noaskquit", "filetype=ascii", "wr_vecnames", "wr_singlescale", "appendwrite"}
 )
 _SPICE_SUFFIX_FACTORS = {
     "t": 1.0e12,

--- a/code/packages/python/spice-engine/tests/test_compatibility.py
+++ b/code/packages/python/spice-engine/tests/test_compatibility.py
@@ -124,7 +124,9 @@ set noaskquit
 set filetype=ascii
 set wr_vecnames
 set wr_singlescale
+set appendwrite
 set filetype=binary
+write out.raw
 run
 quit
 .endc
@@ -149,12 +151,14 @@ quit
         (".include", 2, "error"),
         (".lib", 3, "error"),
         (".control", 4, "error"),
-        (".control", 18, "error"),
+        (".control", 19, "error"),
+        (".control", 20, "error"),
     ]
     assert [diag.code for diag in summary.diagnostics] == [
         "SPICE_DECK_UNSUPPORTED_DIRECTIVE",
         "SPICE_DECK_UNSUPPORTED_DIRECTIVE",
         "SPICE_DECK_UNSUPPORTED_DIRECTIVE",
+        "SPICE_DECK_CONTROL_COMMAND",
         "SPICE_DECK_CONTROL_COMMAND",
     ]
     measurement_summary = resolve_deck_measurements("\n".join(summary.active_lines) + "\n.end")
@@ -238,6 +242,7 @@ four 2k V(b)
 .set filetype=ascii
 .set wr_vecnames
 .set wr_singlescale
+.set appendwrite
 run
 .quit
 .endc

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Accept selected `.control` block `set appendwrite` rawfile append-write
+  options as no-op control commands in `analyze_deck_controls` and
+  `resolve_deck_sources`, matching Python and TypeScript.
 - Accept selected `.control` block `set wr_vecnames` and `set wr_singlescale`
   rawfile output toggles as no-op control commands in `analyze_deck_controls`
   and `resolve_deck_sources`, matching Python and TypeScript.

--- a/code/packages/rust/spice-engine/README.md
+++ b/code/packages/rust/spice-engine/README.md
@@ -130,8 +130,9 @@ selected analysis/output commands (`op`, `dc`, `ac`, `tran`, `save`, `probe`,
 `measure`, `meas`, `four`, `fourier`, `print`, and `plot`) are normalized into
 dotted deck cards, while `run`, `reset`, `quit`, and the UI-only
 `set noaskquit` option plus the ASCII rawfile-format `set filetype=ascii`
-option and vector-name/single-scale rawfile output toggles (`set wr_vecnames`,
-`set wr_singlescale`) are accepted as no-op control markers. Other
+option, vector-name/single-scale rawfile output toggles (`set wr_vecnames`,
+`set wr_singlescale`), and the append-write rawfile option (`set appendwrite`)
+are accepted as no-op control markers. Other
 unrecognized non-comment commands emit diagnostics until a broader executed
 control subset is in scope.
 `resolve_deck_sources` is the first include/library resolution layer: callers

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -6916,7 +6916,7 @@ fn is_noop_control_block_command(line: &str) -> bool {
     if !matches!(command.as_str(), "set" | ".set") {
         return false;
     }
-    matches!(parts.next().map(|option| option.to_ascii_lowercase()), Some(option) if matches!(option.as_str(), "noaskquit" | "filetype=ascii" | "wr_vecnames" | "wr_singlescale"))
+    matches!(parts.next().map(|option| option.to_ascii_lowercase()), Some(option) if matches!(option.as_str(), "noaskquit" | "filetype=ascii" | "wr_vecnames" | "wr_singlescale" | "appendwrite"))
         && parts.next().is_none()
 }
 

--- a/code/packages/rust/spice-engine/tests/compatibility_tests.rs
+++ b/code/packages/rust/spice-engine/tests/compatibility_tests.rs
@@ -141,7 +141,9 @@ set noaskquit
 set filetype=ascii
 set wr_vecnames
 set wr_singlescale
+set appendwrite
 set filetype=binary
+write out.raw
 run
 quit
 .endc
@@ -182,7 +184,8 @@ quit
             (".include", 2, "error"),
             (".lib", 3, "error"),
             (".control", 4, "error"),
-            (".control", 18, "error")
+            (".control", 19, "error"),
+            (".control", 20, "error")
         ]
     );
     assert_eq!(
@@ -195,6 +198,7 @@ quit
             "SPICE_DECK_UNSUPPORTED_DIRECTIVE",
             "SPICE_DECK_UNSUPPORTED_DIRECTIVE",
             "SPICE_DECK_UNSUPPORTED_DIRECTIVE",
+            "SPICE_DECK_CONTROL_COMMAND",
             "SPICE_DECK_CONTROL_COMMAND"
         ]
     );
@@ -330,6 +334,7 @@ four 2k V(b)
 .set filetype=ascii
 .set wr_vecnames
 .set wr_singlescale
+.set appendwrite
 run
 .quit
 .endc

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Accept selected `.control` block `set appendwrite` rawfile append-write
+  options as no-op control commands in `analyzeDeckControls` and
+  `resolveDeckSources`, matching Python and Rust.
 - Accept selected `.control` block `set wr_vecnames` and `set wr_singlescale`
   rawfile output toggles as no-op control commands in `analyzeDeckControls`
   and `resolveDeckSources`, matching Python and Rust.

--- a/code/packages/typescript/spice-engine/README.md
+++ b/code/packages/typescript/spice-engine/README.md
@@ -137,8 +137,9 @@ selected analysis/output commands (`op`, `dc`, `ac`, `tran`, `save`, `probe`,
 `measure`, `meas`, `four`, `fourier`, `print`, and `plot`) are normalized into
 dotted deck cards, while `run`, `reset`, `quit`, and the UI-only
 `set noaskquit` option plus the ASCII rawfile-format `set filetype=ascii`
-option and vector-name/single-scale rawfile output toggles (`set wr_vecnames`,
-`set wr_singlescale`) are accepted as no-op control markers. Other
+option, vector-name/single-scale rawfile output toggles (`set wr_vecnames`,
+`set wr_singlescale`), and the append-write rawfile option (`set appendwrite`)
+are accepted as no-op control markers. Other
 unrecognized non-comment commands emit diagnostics until a broader executed
 control subset is in scope.
 `resolveDeckSources` is the first include/library resolution layer: callers

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -2860,6 +2860,7 @@ const NOOP_CONTROL_BLOCK_SET_OPTIONS = new Set([
   "filetype=ascii",
   "wr_vecnames",
   "wr_singlescale",
+  "appendwrite",
 ]);
 
 export function compatibilityCorpus(): readonly CompatibilityDeck[] {

--- a/code/packages/typescript/spice-engine/tests/compatibility.test.ts
+++ b/code/packages/typescript/spice-engine/tests/compatibility.test.ts
@@ -128,7 +128,9 @@ set noaskquit
 set filetype=ascii
 set wr_vecnames
 set wr_singlescale
+set appendwrite
 set filetype=binary
+write out.raw
 run
 quit
 .endc
@@ -156,12 +158,14 @@ quit
       [".include", 2, "error"],
       [".lib", 3, "error"],
       [".control", 4, "error"],
-      [".control", 18, "error"],
+      [".control", 19, "error"],
+      [".control", 20, "error"],
     ]);
     expect(summary.diagnostics.map((diagnostic) => diagnostic.code)).toStrictEqual([
       "SPICE_DECK_UNSUPPORTED_DIRECTIVE",
       "SPICE_DECK_UNSUPPORTED_DIRECTIVE",
       "SPICE_DECK_UNSUPPORTED_DIRECTIVE",
+      "SPICE_DECK_CONTROL_COMMAND",
       "SPICE_DECK_CONTROL_COMMAND",
     ]);
     const measurementSummary = resolveDeckMeasurements(`${summary.activeLines.join("\n")}\n.end`);
@@ -245,6 +249,7 @@ four 2k V(b)
 .set filetype=ascii
 .set wr_vecnames
 .set wr_singlescale
+.set appendwrite
 run
 .quit
 .endc

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -38,8 +38,9 @@ downstream tools to compare.
      `measure`, `meas`, `four`, `fourier`, `print`, and `plot`) now normalize
      into dotted deck cards while `run`, `reset`, `quit`, and UI-only
      `set noaskquit` options plus ASCII rawfile-format `set filetype=ascii`
-     options and rawfile vector-name/single-scale toggles (`set wr_vecnames`,
-     `set wr_singlescale`) are accepted as no-op control markers; parsed
+     options, rawfile vector-name/single-scale toggles (`set wr_vecnames`,
+     `set wr_singlescale`), and rawfile append-write `set appendwrite` options
+     are accepted as no-op control markers; parsed
      `.measure dc` / `.meas dc` cards now route DC sweep probe samples into
      the shared scalar measurement table surface;
      parsed `.measure ac` / `.meas ac` cards now route AC probe magnitudes over
@@ -593,6 +594,16 @@ downstream tools to compare.
     - Other `set` variables, rawfile file-writing commands, and unrecognized
       non-comment commands inside `.control` blocks remain diagnostic-only so
       unsupported file I/O and script state are explicit.
+
+54. Selected `.control` appendwrite option routing.
+    - Status: completed in this selected control appendwrite-option routing
+      slice.
+    - Python, Rust, and TypeScript now accept exact selected `.control` block
+      `set appendwrite` rawfile append-write options as no-op control commands.
+    - Binary rawfile formats, actual rawfile file-writing commands, other `set`
+      variables, and unrecognized non-comment commands inside `.control` blocks
+      remain diagnostic-only so unsupported file I/O and script state are
+      explicit.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- accept exact `.control` `set appendwrite` as a no-op rawfile append-write compatibility marker across Python, Rust, and TypeScript
- keep binary rawfile formats and actual rawfile write commands diagnostic-only in parity tests
- update SPICE docs, changelogs, and the full implementation plan with completed slice #54

## Verification
- `ruff check code/packages/python/spice-engine/src/spice_engine/compatibility.py code/packages/python/spice-engine/tests/test_compatibility.py`
- `PYTEST_ADDOPTS=--no-cov PYTHONPATH=code/packages/python/device-physics/src:code/packages/python/mosfet-models/src:code/packages/python/spice-engine/src pytest code/packages/python/spice-engine/tests/test_compatibility.py -q`
- `PYTHONPATH=code/packages/python/device-physics/src:code/packages/python/mosfet-models/src:code/packages/python/spice-engine/src pytest code/packages/python/spice-engine/tests -q`
- `cargo fmt --manifest-path code/packages/rust/spice-engine/Cargo.toml -- --check`
- `cargo test --manifest-path code/packages/rust/spice-engine/Cargo.toml compatibility_tests`
- `cargo test --manifest-path code/packages/rust/spice-engine/Cargo.toml`
- `npm --prefix code/packages/typescript/spice-engine ci`
- `npm --prefix code/packages/typescript/spice-engine run build`
- `npm --prefix code/packages/typescript/spice-engine test -- compatibility`
- `npm --prefix code/packages/typescript/spice-engine test`
- `git diff --check`