### PR TITLE
Add Hue release readiness evidence summary

### DIFF
--- a/code/packages/rust/hue-core/src/lib.rs
+++ b/code/packages/rust/hue-core/src/lib.rs
@@ -10483,6 +10483,446 @@ pub fn hue_package_release_archive_evidence_ledger_summary(
     HuePackageReleaseArchiveEvidenceLedgerSummary::from_pairing_plan(plan)
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct HuePackageReleaseReadinessEvidenceSummary {
+    pub release_readiness_summary: HuePackageReleaseReadinessSummary,
+    pub archive_evidence_ledger_summary: HuePackageReleaseArchiveEvidenceLedgerSummary,
+    pub required_release_readiness_evidence_check_count: usize,
+    pub passed_release_readiness_evidence_check_count: usize,
+    pub blocked_release_readiness_evidence_check_count: usize,
+    pub worker_process_ready: bool,
+    pub command_flow_ready: bool,
+    pub pairing_flow_ready: bool,
+    pub event_stream_ready: bool,
+    pub physical_presence_required: bool,
+    pub package_release_ready: bool,
+    pub release_archive_evidence_ledger_ready: bool,
+    pub release_archive_evidence_ready: bool,
+    pub release_archive_attestation_ready: bool,
+    pub release_archive_confirmation_ready: bool,
+    pub release_archive_finalization_ready: bool,
+    pub release_archive_settlement_ready: bool,
+    pub release_archive_reconciliation_ready: bool,
+    pub release_archive_replay_ready: bool,
+    pub release_archive_recovery_ready: bool,
+    pub release_archive_restore_ready: bool,
+    pub release_archive_load_ready: bool,
+    pub release_archive_ingest_ready: bool,
+    pub release_archive_import_ready: bool,
+    pub release_archive_export_ready: bool,
+    pub release_archive_distribution_ready: bool,
+    pub release_archive_acceptance_ready: bool,
+    pub release_archive_adoption_ready: bool,
+    pub release_archive_rollout_ready: bool,
+    pub release_archive_activation_ready: bool,
+    pub release_archive_approval_ready: bool,
+    pub release_archive_certification_ready: bool,
+    pub release_archive_validation_ready: bool,
+    pub release_archive_verification_ready: bool,
+    pub release_archive_publication_ready: bool,
+    pub release_archive_completion_ready: bool,
+    pub release_archive_supervisor_ready: bool,
+    pub release_archive_operator_ready: bool,
+    pub release_archive_dispatch_ready: bool,
+    pub release_archive_handoff_ready: bool,
+    pub release_archive_closure_ready: bool,
+    pub release_archive_signoff_ready: bool,
+    pub release_archive_ready: bool,
+    pub release_closure_ready: bool,
+    pub release_signoff_ready: bool,
+    pub release_audit_ready: bool,
+    pub operator_ready: bool,
+    pub coordination_ready: bool,
+    pub publish_gate_ready: bool,
+    pub release_readiness_evidence_ready: bool,
+}
+
+impl HuePackageReleaseReadinessEvidenceSummary {
+    pub fn from_pairing_plan(plan: &HueBridgePairingPlan) -> Self {
+        Self::from_summaries(
+            hue_package_release_readiness_summary(plan),
+            hue_package_release_archive_evidence_ledger_summary(plan),
+        )
+    }
+
+    pub fn from_summaries(
+        release_readiness_summary: HuePackageReleaseReadinessSummary,
+        archive_evidence_ledger_summary: HuePackageReleaseArchiveEvidenceLedgerSummary,
+    ) -> Self {
+        let worker_process_ready = release_readiness_summary.worker_process_ready;
+        let command_flow_ready = release_readiness_summary.command_flow_ready;
+        let pairing_flow_ready = release_readiness_summary.pairing_flow_ready;
+        let event_stream_ready = release_readiness_summary.event_stream_ready;
+        let physical_presence_required = release_readiness_summary.physical_presence_required;
+        let package_release_ready = release_readiness_summary.is_release_ready();
+        let release_archive_evidence_ledger_ready =
+            archive_evidence_ledger_summary.is_release_archive_evidence_ledger_ready();
+        let release_archive_evidence_ready =
+            !archive_evidence_ledger_summary.needs_release_archive_evidence();
+        let release_archive_attestation_ready =
+            !archive_evidence_ledger_summary.needs_release_archive_attestation();
+        let release_archive_confirmation_ready =
+            !archive_evidence_ledger_summary.needs_release_archive_confirmation();
+        let release_archive_finalization_ready =
+            !archive_evidence_ledger_summary.needs_release_archive_finalization();
+        let release_archive_settlement_ready =
+            !archive_evidence_ledger_summary.needs_release_archive_settlement();
+        let release_archive_reconciliation_ready =
+            !archive_evidence_ledger_summary.needs_release_archive_reconciliation();
+        let release_archive_replay_ready =
+            !archive_evidence_ledger_summary.needs_release_archive_replay();
+        let release_archive_recovery_ready =
+            !archive_evidence_ledger_summary.needs_release_archive_recovery();
+        let release_archive_restore_ready =
+            !archive_evidence_ledger_summary.needs_release_archive_restore();
+        let release_archive_load_ready =
+            !archive_evidence_ledger_summary.needs_release_archive_load();
+        let release_archive_ingest_ready =
+            !archive_evidence_ledger_summary.needs_release_archive_ingest();
+        let release_archive_import_ready =
+            !archive_evidence_ledger_summary.needs_release_archive_import();
+        let release_archive_export_ready =
+            !archive_evidence_ledger_summary.needs_release_archive_export();
+        let release_archive_distribution_ready =
+            !archive_evidence_ledger_summary.needs_release_archive_distribution();
+        let release_archive_acceptance_ready =
+            !archive_evidence_ledger_summary.needs_release_archive_acceptance();
+        let release_archive_adoption_ready =
+            !archive_evidence_ledger_summary.needs_release_archive_adoption();
+        let release_archive_rollout_ready =
+            !archive_evidence_ledger_summary.needs_release_archive_rollout();
+        let release_archive_activation_ready =
+            !archive_evidence_ledger_summary.needs_release_archive_activation();
+        let release_archive_approval_ready =
+            !archive_evidence_ledger_summary.needs_release_archive_approval();
+        let release_archive_certification_ready =
+            !archive_evidence_ledger_summary.needs_release_archive_certification();
+        let release_archive_validation_ready =
+            !archive_evidence_ledger_summary.needs_release_archive_validation();
+        let release_archive_verification_ready =
+            !archive_evidence_ledger_summary.needs_release_archive_verification();
+        let release_archive_publication_ready =
+            !archive_evidence_ledger_summary.needs_release_archive_publication();
+        let release_archive_completion_ready =
+            !archive_evidence_ledger_summary.needs_release_archive_completion();
+        let release_archive_supervisor_ready =
+            !archive_evidence_ledger_summary.needs_release_archive_supervisor();
+        let release_archive_operator_ready =
+            !archive_evidence_ledger_summary.needs_release_archive_operator();
+        let release_archive_dispatch_ready =
+            !archive_evidence_ledger_summary.needs_release_archive_dispatch();
+        let release_archive_handoff_ready =
+            !archive_evidence_ledger_summary.needs_release_archive_handoff();
+        let release_archive_closure_ready =
+            !archive_evidence_ledger_summary.needs_release_archive_closure();
+        let release_archive_signoff_ready =
+            !archive_evidence_ledger_summary.needs_release_archive_signoff();
+        let release_archive_ready = !archive_evidence_ledger_summary.needs_release_archive();
+        let release_closure_ready = !archive_evidence_ledger_summary.needs_release_closure();
+        let release_signoff_ready = !archive_evidence_ledger_summary.needs_release_signoff();
+        let release_audit_ready = !archive_evidence_ledger_summary.needs_release_audit();
+        let operator_ready = !archive_evidence_ledger_summary.needs_operator_readiness();
+        let coordination_ready = !archive_evidence_ledger_summary.needs_coordination();
+        let publish_gate_ready = !archive_evidence_ledger_summary.needs_publish_gate();
+        let checks = [
+            worker_process_ready,
+            command_flow_ready,
+            pairing_flow_ready,
+            event_stream_ready,
+            physical_presence_required,
+            package_release_ready,
+            release_archive_evidence_ledger_ready,
+            release_archive_evidence_ready,
+            release_archive_attestation_ready,
+            release_archive_confirmation_ready,
+            release_archive_finalization_ready,
+            release_archive_settlement_ready,
+            release_archive_reconciliation_ready,
+            release_archive_replay_ready,
+            release_archive_recovery_ready,
+            release_archive_restore_ready,
+            release_archive_load_ready,
+            release_archive_ingest_ready,
+            release_archive_import_ready,
+            release_archive_export_ready,
+            release_archive_distribution_ready,
+            release_archive_acceptance_ready,
+            release_archive_adoption_ready,
+            release_archive_rollout_ready,
+            release_archive_activation_ready,
+            release_archive_approval_ready,
+            release_archive_certification_ready,
+            release_archive_validation_ready,
+            release_archive_verification_ready,
+            release_archive_publication_ready,
+            release_archive_completion_ready,
+            release_archive_supervisor_ready,
+            release_archive_operator_ready,
+            release_archive_dispatch_ready,
+            release_archive_handoff_ready,
+            release_archive_closure_ready,
+            release_archive_signoff_ready,
+            release_archive_ready,
+            release_closure_ready,
+            release_signoff_ready,
+            release_audit_ready,
+            operator_ready,
+            coordination_ready,
+            publish_gate_ready,
+        ];
+        let passed_release_readiness_evidence_check_count =
+            checks.iter().filter(|ready| **ready).count();
+        let required_release_readiness_evidence_check_count = checks.len();
+        let blocked_release_readiness_evidence_check_count =
+            required_release_readiness_evidence_check_count
+                - passed_release_readiness_evidence_check_count;
+        let release_readiness_evidence_ready = blocked_release_readiness_evidence_check_count == 0;
+
+        Self {
+            release_readiness_summary,
+            archive_evidence_ledger_summary,
+            required_release_readiness_evidence_check_count,
+            passed_release_readiness_evidence_check_count,
+            blocked_release_readiness_evidence_check_count,
+            worker_process_ready,
+            command_flow_ready,
+            pairing_flow_ready,
+            event_stream_ready,
+            physical_presence_required,
+            package_release_ready,
+            release_archive_evidence_ledger_ready,
+            release_archive_evidence_ready,
+            release_archive_attestation_ready,
+            release_archive_confirmation_ready,
+            release_archive_finalization_ready,
+            release_archive_settlement_ready,
+            release_archive_reconciliation_ready,
+            release_archive_replay_ready,
+            release_archive_recovery_ready,
+            release_archive_restore_ready,
+            release_archive_load_ready,
+            release_archive_ingest_ready,
+            release_archive_import_ready,
+            release_archive_export_ready,
+            release_archive_distribution_ready,
+            release_archive_acceptance_ready,
+            release_archive_adoption_ready,
+            release_archive_rollout_ready,
+            release_archive_activation_ready,
+            release_archive_approval_ready,
+            release_archive_certification_ready,
+            release_archive_validation_ready,
+            release_archive_verification_ready,
+            release_archive_publication_ready,
+            release_archive_completion_ready,
+            release_archive_supervisor_ready,
+            release_archive_operator_ready,
+            release_archive_dispatch_ready,
+            release_archive_handoff_ready,
+            release_archive_closure_ready,
+            release_archive_signoff_ready,
+            release_archive_ready,
+            release_closure_ready,
+            release_signoff_ready,
+            release_audit_ready,
+            operator_ready,
+            coordination_ready,
+            publish_gate_ready,
+            release_readiness_evidence_ready,
+        }
+    }
+
+    pub fn is_release_readiness_evidence_ready(self) -> bool {
+        self.release_readiness_evidence_ready
+    }
+
+    pub fn has_blocked_release_readiness_evidence_checks(self) -> bool {
+        self.blocked_release_readiness_evidence_check_count > 0
+    }
+
+    pub fn needs_worker_process(self) -> bool {
+        !self.worker_process_ready
+    }
+
+    pub fn needs_command_flow(self) -> bool {
+        !self.command_flow_ready
+    }
+
+    pub fn needs_pairing_flow(self) -> bool {
+        !self.pairing_flow_ready
+    }
+
+    pub fn needs_event_stream(self) -> bool {
+        !self.event_stream_ready
+    }
+
+    pub fn needs_physical_presence_requirement(self) -> bool {
+        !self.physical_presence_required
+    }
+
+    pub fn needs_package_release(self) -> bool {
+        !self.package_release_ready
+    }
+
+    pub fn needs_release_archive_evidence_ledger(self) -> bool {
+        !self.release_archive_evidence_ledger_ready
+    }
+
+    pub fn needs_release_archive_evidence(self) -> bool {
+        !self.release_archive_evidence_ready
+    }
+
+    pub fn needs_release_archive_attestation(self) -> bool {
+        !self.release_archive_attestation_ready
+    }
+
+    pub fn needs_release_archive_confirmation(self) -> bool {
+        !self.release_archive_confirmation_ready
+    }
+
+    pub fn needs_release_archive_finalization(self) -> bool {
+        !self.release_archive_finalization_ready
+    }
+
+    pub fn needs_release_archive_settlement(self) -> bool {
+        !self.release_archive_settlement_ready
+    }
+
+    pub fn needs_release_archive_reconciliation(self) -> bool {
+        !self.release_archive_reconciliation_ready
+    }
+
+    pub fn needs_release_archive_replay(self) -> bool {
+        !self.release_archive_replay_ready
+    }
+
+    pub fn needs_release_archive_recovery(self) -> bool {
+        !self.release_archive_recovery_ready
+    }
+
+    pub fn needs_release_archive_restore(self) -> bool {
+        !self.release_archive_restore_ready
+    }
+
+    pub fn needs_release_archive_load(self) -> bool {
+        !self.release_archive_load_ready
+    }
+
+    pub fn needs_release_archive_ingest(self) -> bool {
+        !self.release_archive_ingest_ready
+    }
+
+    pub fn needs_release_archive_import(self) -> bool {
+        !self.release_archive_import_ready
+    }
+
+    pub fn needs_release_archive_export(self) -> bool {
+        !self.release_archive_export_ready
+    }
+
+    pub fn needs_release_archive_distribution(self) -> bool {
+        !self.release_archive_distribution_ready
+    }
+
+    pub fn needs_release_archive_acceptance(self) -> bool {
+        !self.release_archive_acceptance_ready
+    }
+
+    pub fn needs_release_archive_adoption(self) -> bool {
+        !self.release_archive_adoption_ready
+    }
+
+    pub fn needs_release_archive_rollout(self) -> bool {
+        !self.release_archive_rollout_ready
+    }
+
+    pub fn needs_release_archive_activation(self) -> bool {
+        !self.release_archive_activation_ready
+    }
+
+    pub fn needs_release_archive_approval(self) -> bool {
+        !self.release_archive_approval_ready
+    }
+
+    pub fn needs_release_archive_certification(self) -> bool {
+        !self.release_archive_certification_ready
+    }
+
+    pub fn needs_release_archive_validation(self) -> bool {
+        !self.release_archive_validation_ready
+    }
+
+    pub fn needs_release_archive_verification(self) -> bool {
+        !self.release_archive_verification_ready
+    }
+
+    pub fn needs_release_archive_publication(self) -> bool {
+        !self.release_archive_publication_ready
+    }
+
+    pub fn needs_release_archive_completion(self) -> bool {
+        !self.release_archive_completion_ready
+    }
+
+    pub fn needs_release_archive_supervisor(self) -> bool {
+        !self.release_archive_supervisor_ready
+    }
+
+    pub fn needs_release_archive_operator(self) -> bool {
+        !self.release_archive_operator_ready
+    }
+
+    pub fn needs_release_archive_dispatch(self) -> bool {
+        !self.release_archive_dispatch_ready
+    }
+
+    pub fn needs_release_archive_handoff(self) -> bool {
+        !self.release_archive_handoff_ready
+    }
+
+    pub fn needs_release_archive_closure(self) -> bool {
+        !self.release_archive_closure_ready
+    }
+
+    pub fn needs_release_archive_signoff(self) -> bool {
+        !self.release_archive_signoff_ready
+    }
+
+    pub fn needs_release_archive(self) -> bool {
+        !self.release_archive_ready
+    }
+
+    pub fn needs_release_closure(self) -> bool {
+        !self.release_closure_ready
+    }
+
+    pub fn needs_release_signoff(self) -> bool {
+        !self.release_signoff_ready
+    }
+
+    pub fn needs_release_audit(self) -> bool {
+        !self.release_audit_ready
+    }
+
+    pub fn needs_operator_readiness(self) -> bool {
+        !self.operator_ready
+    }
+
+    pub fn needs_coordination(self) -> bool {
+        !self.coordination_ready
+    }
+
+    pub fn needs_publish_gate(self) -> bool {
+        !self.publish_gate_ready
+    }
+}
+
+pub fn hue_package_release_readiness_evidence_summary(
+    plan: &HueBridgePairingPlan,
+) -> HuePackageReleaseReadinessEvidenceSummary {
+    HuePackageReleaseReadinessEvidenceSummary::from_pairing_plan(plan)
+}
+
 fn descriptor_declares_capability(descriptor: &IntegrationDescriptor, capability_id: &str) -> bool {
     descriptor
         .capabilities
@@ -19335,6 +19775,241 @@ mod tests {
         assert!(!summary.release_archive_evidence_ledger_ready);
         assert!(!summary.is_release_archive_evidence_ledger_ready());
         assert!(summary.has_blocked_archive_evidence_ledger_checks());
+        assert!(summary.needs_release_archive_evidence());
+        assert!(summary.needs_release_archive_attestation());
+        assert!(summary.needs_release_archive_confirmation());
+        assert!(summary.needs_release_archive_finalization());
+        assert!(summary.needs_release_archive_settlement());
+        assert!(summary.needs_release_archive_reconciliation());
+        assert!(summary.needs_release_archive_replay());
+        assert!(summary.needs_release_archive_recovery());
+        assert!(summary.needs_release_archive_restore());
+        assert!(summary.needs_release_archive_load());
+        assert!(summary.needs_release_archive_ingest());
+        assert!(summary.needs_release_archive_import());
+        assert!(summary.needs_release_archive_export());
+        assert!(summary.needs_release_archive_distribution());
+        assert!(summary.needs_release_archive_acceptance());
+        assert!(summary.needs_release_archive_adoption());
+        assert!(summary.needs_release_archive_rollout());
+        assert!(summary.needs_release_archive_activation());
+        assert!(summary.needs_release_archive_approval());
+        assert!(summary.needs_release_archive_certification());
+        assert!(summary.needs_release_archive_validation());
+        assert!(summary.needs_release_archive_verification());
+        assert!(summary.needs_release_archive_publication());
+        assert!(summary.needs_release_archive_completion());
+        assert!(summary.needs_release_archive_supervisor());
+        assert!(summary.needs_release_archive_operator());
+        assert!(summary.needs_release_archive_dispatch());
+        assert!(summary.needs_release_archive_handoff());
+        assert!(summary.needs_release_archive_closure());
+        assert!(summary.needs_release_archive_signoff());
+        assert!(summary.needs_release_archive());
+        assert!(summary.needs_release_closure());
+        assert!(summary.needs_release_signoff());
+        assert!(summary.needs_release_audit());
+        assert!(summary.needs_operator_readiness());
+        assert!(summary.needs_coordination());
+        assert!(summary.needs_publish_gate());
+    }
+
+    #[test]
+    fn hue_package_release_readiness_evidence_summary_reports_ready_release_evidence() {
+        let plan = hue_pairing_plan_for_discovered_bridge(
+            DiscoveredHueBridge {
+                bridge_id: "001788fffeabcdef".to_string(),
+                address: "https://192.0.2.10".to_string(),
+                hardware_model: Some("BSB002".to_string()),
+                firmware_version: Some("1.60".to_string()),
+            },
+            "chief-of-staff",
+            "desk",
+        );
+
+        let summary = hue_package_release_readiness_evidence_summary(&plan);
+
+        assert_eq!(
+            summary.release_readiness_summary,
+            hue_package_release_readiness_summary(&plan)
+        );
+        assert_eq!(
+            summary.archive_evidence_ledger_summary,
+            hue_package_release_archive_evidence_ledger_summary(&plan)
+        );
+        assert_eq!(summary.required_release_readiness_evidence_check_count, 44);
+        assert_eq!(summary.passed_release_readiness_evidence_check_count, 44);
+        assert_eq!(summary.blocked_release_readiness_evidence_check_count, 0);
+        assert!(summary.worker_process_ready);
+        assert!(summary.command_flow_ready);
+        assert!(summary.pairing_flow_ready);
+        assert!(summary.event_stream_ready);
+        assert!(summary.physical_presence_required);
+        assert!(summary.package_release_ready);
+        assert!(summary.release_archive_evidence_ledger_ready);
+        assert!(summary.release_archive_evidence_ready);
+        assert!(summary.release_archive_attestation_ready);
+        assert!(summary.release_archive_confirmation_ready);
+        assert!(summary.release_archive_finalization_ready);
+        assert!(summary.release_archive_settlement_ready);
+        assert!(summary.release_archive_reconciliation_ready);
+        assert!(summary.release_archive_replay_ready);
+        assert!(summary.release_archive_recovery_ready);
+        assert!(summary.release_archive_restore_ready);
+        assert!(summary.release_archive_load_ready);
+        assert!(summary.release_archive_ingest_ready);
+        assert!(summary.release_archive_import_ready);
+        assert!(summary.release_archive_export_ready);
+        assert!(summary.release_archive_distribution_ready);
+        assert!(summary.release_archive_acceptance_ready);
+        assert!(summary.release_archive_adoption_ready);
+        assert!(summary.release_archive_rollout_ready);
+        assert!(summary.release_archive_activation_ready);
+        assert!(summary.release_archive_approval_ready);
+        assert!(summary.release_archive_certification_ready);
+        assert!(summary.release_archive_validation_ready);
+        assert!(summary.release_archive_verification_ready);
+        assert!(summary.release_archive_publication_ready);
+        assert!(summary.release_archive_completion_ready);
+        assert!(summary.release_archive_supervisor_ready);
+        assert!(summary.release_archive_operator_ready);
+        assert!(summary.release_archive_dispatch_ready);
+        assert!(summary.release_archive_handoff_ready);
+        assert!(summary.release_archive_closure_ready);
+        assert!(summary.release_archive_signoff_ready);
+        assert!(summary.release_archive_ready);
+        assert!(summary.release_closure_ready);
+        assert!(summary.release_signoff_ready);
+        assert!(summary.release_audit_ready);
+        assert!(summary.operator_ready);
+        assert!(summary.coordination_ready);
+        assert!(summary.publish_gate_ready);
+        assert!(summary.release_readiness_evidence_ready);
+        assert!(summary.is_release_readiness_evidence_ready());
+        assert!(!summary.has_blocked_release_readiness_evidence_checks());
+        assert!(!summary.needs_worker_process());
+        assert!(!summary.needs_command_flow());
+        assert!(!summary.needs_pairing_flow());
+        assert!(!summary.needs_event_stream());
+        assert!(!summary.needs_physical_presence_requirement());
+        assert!(!summary.needs_package_release());
+        assert!(!summary.needs_release_archive_evidence_ledger());
+        assert!(!summary.needs_release_archive_evidence());
+        assert!(!summary.needs_release_archive_attestation());
+        assert!(!summary.needs_release_archive_confirmation());
+        assert!(!summary.needs_release_archive_finalization());
+        assert!(!summary.needs_release_archive_settlement());
+        assert!(!summary.needs_release_archive_reconciliation());
+        assert!(!summary.needs_release_archive_replay());
+        assert!(!summary.needs_release_archive_recovery());
+        assert!(!summary.needs_release_archive_restore());
+        assert!(!summary.needs_release_archive_load());
+        assert!(!summary.needs_release_archive_ingest());
+        assert!(!summary.needs_release_archive_import());
+        assert!(!summary.needs_release_archive_export());
+        assert!(!summary.needs_release_archive_distribution());
+        assert!(!summary.needs_release_archive_acceptance());
+        assert!(!summary.needs_release_archive_adoption());
+        assert!(!summary.needs_release_archive_rollout());
+        assert!(!summary.needs_release_archive_activation());
+        assert!(!summary.needs_release_archive_approval());
+        assert!(!summary.needs_release_archive_certification());
+        assert!(!summary.needs_release_archive_validation());
+        assert!(!summary.needs_release_archive_verification());
+        assert!(!summary.needs_release_archive_publication());
+        assert!(!summary.needs_release_archive_completion());
+        assert!(!summary.needs_release_archive_supervisor());
+        assert!(!summary.needs_release_archive_operator());
+        assert!(!summary.needs_release_archive_dispatch());
+        assert!(!summary.needs_release_archive_handoff());
+        assert!(!summary.needs_release_archive_closure());
+        assert!(!summary.needs_release_archive_signoff());
+        assert!(!summary.needs_release_archive());
+        assert!(!summary.needs_release_closure());
+        assert!(!summary.needs_release_signoff());
+        assert!(!summary.needs_release_audit());
+        assert!(!summary.needs_operator_readiness());
+        assert!(!summary.needs_coordination());
+        assert!(!summary.needs_publish_gate());
+    }
+
+    #[test]
+    fn hue_package_release_readiness_evidence_summary_routes_blocked_release_evidence() {
+        let mut plan = hue_pairing_plan_for_discovered_bridge(
+            DiscoveredHueBridge {
+                bridge_id: "001788fffeabcdef".to_string(),
+                address: "https://192.0.2.10".to_string(),
+                hardware_model: Some("BSB002".to_string()),
+                firmware_version: Some("1.60".to_string()),
+            },
+            "chief-of-staff",
+            "desk",
+        );
+        plan.bridge.address = None;
+        plan.registration_request.path = "/wrong/api".to_string();
+        plan.application_key_header = "x-application-key".to_string();
+        plan.event_stream_path = "/wrong/eventstream".to_string();
+        plan.requires_user_presence = false;
+
+        let summary = HuePackageReleaseReadinessEvidenceSummary::from_pairing_plan(&plan);
+
+        assert_eq!(summary.required_release_readiness_evidence_check_count, 44);
+        assert_eq!(summary.passed_release_readiness_evidence_check_count, 2);
+        assert_eq!(summary.blocked_release_readiness_evidence_check_count, 42);
+        assert!(summary.worker_process_ready);
+        assert!(summary.command_flow_ready);
+        assert!(!summary.pairing_flow_ready);
+        assert!(!summary.event_stream_ready);
+        assert!(!summary.physical_presence_required);
+        assert!(!summary.package_release_ready);
+        assert!(!summary.release_archive_evidence_ledger_ready);
+        assert!(!summary.release_archive_evidence_ready);
+        assert!(!summary.release_archive_attestation_ready);
+        assert!(!summary.release_archive_confirmation_ready);
+        assert!(!summary.release_archive_finalization_ready);
+        assert!(!summary.release_archive_settlement_ready);
+        assert!(!summary.release_archive_reconciliation_ready);
+        assert!(!summary.release_archive_replay_ready);
+        assert!(!summary.release_archive_recovery_ready);
+        assert!(!summary.release_archive_restore_ready);
+        assert!(!summary.release_archive_load_ready);
+        assert!(!summary.release_archive_ingest_ready);
+        assert!(!summary.release_archive_import_ready);
+        assert!(!summary.release_archive_export_ready);
+        assert!(!summary.release_archive_distribution_ready);
+        assert!(!summary.release_archive_acceptance_ready);
+        assert!(!summary.release_archive_adoption_ready);
+        assert!(!summary.release_archive_rollout_ready);
+        assert!(!summary.release_archive_activation_ready);
+        assert!(!summary.release_archive_approval_ready);
+        assert!(!summary.release_archive_certification_ready);
+        assert!(!summary.release_archive_validation_ready);
+        assert!(!summary.release_archive_verification_ready);
+        assert!(!summary.release_archive_publication_ready);
+        assert!(!summary.release_archive_completion_ready);
+        assert!(!summary.release_archive_supervisor_ready);
+        assert!(!summary.release_archive_operator_ready);
+        assert!(!summary.release_archive_dispatch_ready);
+        assert!(!summary.release_archive_handoff_ready);
+        assert!(!summary.release_archive_closure_ready);
+        assert!(!summary.release_archive_signoff_ready);
+        assert!(!summary.release_archive_ready);
+        assert!(!summary.release_closure_ready);
+        assert!(!summary.release_signoff_ready);
+        assert!(!summary.release_audit_ready);
+        assert!(!summary.operator_ready);
+        assert!(!summary.coordination_ready);
+        assert!(!summary.publish_gate_ready);
+        assert!(!summary.release_readiness_evidence_ready);
+        assert!(!summary.is_release_readiness_evidence_ready());
+        assert!(summary.has_blocked_release_readiness_evidence_checks());
+        assert!(!summary.needs_worker_process());
+        assert!(!summary.needs_command_flow());
+        assert!(summary.needs_pairing_flow());
+        assert!(summary.needs_event_stream());
+        assert!(summary.needs_physical_presence_requirement());
+        assert!(summary.needs_package_release());
+        assert!(summary.needs_release_archive_evidence_ledger());
         assert!(summary.needs_release_archive_evidence());
         assert!(summary.needs_release_archive_attestation());
         assert!(summary.needs_release_archive_confirmation());


### PR DESCRIPTION
## Summary
- add a Hue package release readiness evidence summary that composes baseline package release readiness with the archive evidence ledger
- expose package-readiness, archive-evidence-ledger, and underlying archive gate booleans plus blocked/passed check counts
- add ready and blocked Hue tests for the composed package-side rollup

## Validation
- cargo test -p smart-home-core
- cargo test -p smart-home-integration-catalog
- cargo test -p hue-core
- cargo test -p smart-home-runtime
- cargo test -p smart-home-testkit
- cargo test -p smart-home-local-http
- cargo test -p smart-home-discovery
- cargo test -p chief-of-staff-smart-home-tools
- cargo test -p smart-home-runtime discover_tool -- --nocapture
- sh BUILD in smart-home-core, smart-home-integration-catalog, hue-core, smart-home-runtime, smart-home-testkit, smart-home-local-http, smart-home-discovery, and chief-of-staff-smart-home-tools
- git diff --check