### PR TITLE
Accept control rawfile write markers

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 ### Added
 
+- **Deck control rawfile write marker routing** —
+  `analyze_deck_controls()` and `resolve_deck_sources()` now accept selected
+  `.control` block `write <rawfile> [probes...]` rawfile-write markers as
+  no-op control commands instead of reporting unsupported-command diagnostics,
+  matching Rust and TypeScript. Rawfile serialization remains out of scope for
+  this marker.
+
 - **Deck control appendwrite option routing** —
   `analyze_deck_controls()` and `resolve_deck_sources()` now accept selected
   `.control` block `set appendwrite` rawfile append-write options as no-op

--- a/code/packages/python/spice-engine/README.md
+++ b/code/packages/python/spice-engine/README.md
@@ -165,7 +165,8 @@ dotted deck cards, while `run`, `reset`, `quit`, and the UI-only
 `set noaskquit` option plus the ASCII rawfile-format `set filetype=ascii`
 option, vector-name/single-scale rawfile output toggles (`set wr_vecnames`,
 `set wr_singlescale`), and the append-write rawfile option (`set appendwrite`)
-are accepted as no-op control markers. Other
+plus target-bearing rawfile-write markers (`write <rawfile> [probes...]`) are
+accepted as no-op control markers. Other
 unrecognized non-comment commands emit diagnostics until a broader executed
 control subset is in scope.
 `resolve_deck_sources()` is the first include/library resolution layer: callers

--- a/code/packages/python/spice-engine/src/spice_engine/compatibility.py
+++ b/code/packages/python/spice-engine/src/spice_engine/compatibility.py
@@ -518,6 +518,7 @@ _SUPPORTED_CONTROL_BLOCK_COMMANDS = frozenset(
 _NOOP_CONTROL_BLOCK_COMMANDS = frozenset(
     {"run", ".run", "reset", ".reset", "quit", ".quit"}
 )
+_NOOP_CONTROL_BLOCK_ARGUMENT_COMMANDS = frozenset({"write", ".write"})
 _NOOP_CONTROL_BLOCK_SET_OPTIONS = frozenset(
     {"noaskquit", "filetype=ascii", "wr_vecnames", "wr_singlescale", "appendwrite"}
 )
@@ -3351,6 +3352,8 @@ def _is_noop_control_block_command(line: str) -> bool:
     command = parts[0].lower()
     if command in _NOOP_CONTROL_BLOCK_COMMANDS:
         return True
+    if command in _NOOP_CONTROL_BLOCK_ARGUMENT_COMMANDS:
+        return len(parts) >= 2
     return (
         command in {"set", ".set"}
         and len(parts) == 2

--- a/code/packages/python/spice-engine/tests/test_compatibility.py
+++ b/code/packages/python/spice-engine/tests/test_compatibility.py
@@ -126,7 +126,7 @@ set wr_vecnames
 set wr_singlescale
 set appendwrite
 set filetype=binary
-write out.raw
+write out.raw V(out)
 run
 quit
 .endc
@@ -152,13 +152,11 @@ quit
         (".lib", 3, "error"),
         (".control", 4, "error"),
         (".control", 19, "error"),
-        (".control", 20, "error"),
     ]
     assert [diag.code for diag in summary.diagnostics] == [
         "SPICE_DECK_UNSUPPORTED_DIRECTIVE",
         "SPICE_DECK_UNSUPPORTED_DIRECTIVE",
         "SPICE_DECK_UNSUPPORTED_DIRECTIVE",
-        "SPICE_DECK_CONTROL_COMMAND",
         "SPICE_DECK_CONTROL_COMMAND",
     ]
     measurement_summary = resolve_deck_measurements("\n".join(summary.active_lines) + "\n.end")
@@ -243,6 +241,7 @@ four 2k V(b)
 .set wr_vecnames
 .set wr_singlescale
 .set appendwrite
+.write out.raw V(a)
 run
 .quit
 .endc

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Accept selected `.control` block `write <rawfile> [probes...]` rawfile-write
+  markers as no-op control commands in `analyze_deck_controls` and
+  `resolve_deck_sources`, matching Python and TypeScript. Rawfile
+  serialization remains out of scope for this marker.
 - Accept selected `.control` block `set appendwrite` rawfile append-write
   options as no-op control commands in `analyze_deck_controls` and
   `resolve_deck_sources`, matching Python and TypeScript.

--- a/code/packages/rust/spice-engine/README.md
+++ b/code/packages/rust/spice-engine/README.md
@@ -132,7 +132,8 @@ dotted deck cards, while `run`, `reset`, `quit`, and the UI-only
 `set noaskquit` option plus the ASCII rawfile-format `set filetype=ascii`
 option, vector-name/single-scale rawfile output toggles (`set wr_vecnames`,
 `set wr_singlescale`), and the append-write rawfile option (`set appendwrite`)
-are accepted as no-op control markers. Other
+plus target-bearing rawfile-write markers (`write <rawfile> [probes...]`) are
+accepted as no-op control markers. Other
 unrecognized non-comment commands emit diagnostics until a broader executed
 control subset is in scope.
 `resolve_deck_sources` is the first include/library resolution layer: callers

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -6913,6 +6913,9 @@ fn is_noop_control_block_command(line: &str) -> bool {
     ) {
         return true;
     }
+    if matches!(command.as_str(), "write" | ".write") {
+        return parts.next().is_some();
+    }
     if !matches!(command.as_str(), "set" | ".set") {
         return false;
     }

--- a/code/packages/rust/spice-engine/tests/compatibility_tests.rs
+++ b/code/packages/rust/spice-engine/tests/compatibility_tests.rs
@@ -143,7 +143,7 @@ set wr_vecnames
 set wr_singlescale
 set appendwrite
 set filetype=binary
-write out.raw
+write out.raw V(out)
 run
 quit
 .endc
@@ -184,8 +184,7 @@ quit
             (".include", 2, "error"),
             (".lib", 3, "error"),
             (".control", 4, "error"),
-            (".control", 19, "error"),
-            (".control", 20, "error")
+            (".control", 19, "error")
         ]
     );
     assert_eq!(
@@ -198,7 +197,6 @@ quit
             "SPICE_DECK_UNSUPPORTED_DIRECTIVE",
             "SPICE_DECK_UNSUPPORTED_DIRECTIVE",
             "SPICE_DECK_UNSUPPORTED_DIRECTIVE",
-            "SPICE_DECK_CONTROL_COMMAND",
             "SPICE_DECK_CONTROL_COMMAND"
         ]
     );
@@ -335,6 +333,7 @@ four 2k V(b)
 .set wr_vecnames
 .set wr_singlescale
 .set appendwrite
+.write out.raw V(a)
 run
 .quit
 .endc

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Accept selected `.control` block `write <rawfile> [probes...]` rawfile-write
+  markers as no-op control commands in `analyzeDeckControls` and
+  `resolveDeckSources`, matching Python and Rust. Rawfile serialization remains
+  out of scope for this marker.
 - Accept selected `.control` block `set appendwrite` rawfile append-write
   options as no-op control commands in `analyzeDeckControls` and
   `resolveDeckSources`, matching Python and Rust.

--- a/code/packages/typescript/spice-engine/README.md
+++ b/code/packages/typescript/spice-engine/README.md
@@ -139,7 +139,8 @@ dotted deck cards, while `run`, `reset`, `quit`, and the UI-only
 `set noaskquit` option plus the ASCII rawfile-format `set filetype=ascii`
 option, vector-name/single-scale rawfile output toggles (`set wr_vecnames`,
 `set wr_singlescale`), and the append-write rawfile option (`set appendwrite`)
-are accepted as no-op control markers. Other
+plus target-bearing rawfile-write markers (`write <rawfile> [probes...]`) are
+accepted as no-op control markers. Other
 unrecognized non-comment commands emit diagnostics until a broader executed
 control subset is in scope.
 `resolveDeckSources` is the first include/library resolution layer: callers

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -2855,6 +2855,7 @@ const SUPPORTED_CONTROL_BLOCK_COMMANDS = new Set([
   ".plot",
 ]);
 const NOOP_CONTROL_BLOCK_COMMANDS = new Set(["run", ".run", "reset", ".reset", "quit", ".quit"]);
+const NOOP_CONTROL_BLOCK_ARGUMENT_COMMANDS = new Set(["write", ".write"]);
 const NOOP_CONTROL_BLOCK_SET_OPTIONS = new Set([
   "noaskquit",
   "filetype=ascii",
@@ -5726,6 +5727,9 @@ function isNoopControlBlockCommand(line: string): boolean {
   }
   if (NOOP_CONTROL_BLOCK_COMMANDS.has(command)) {
     return true;
+  }
+  if (NOOP_CONTROL_BLOCK_ARGUMENT_COMMANDS.has(command)) {
+    return parts.length >= 2;
   }
   return (
     (command === "set" || command === ".set") &&

--- a/code/packages/typescript/spice-engine/tests/compatibility.test.ts
+++ b/code/packages/typescript/spice-engine/tests/compatibility.test.ts
@@ -130,7 +130,7 @@ set wr_vecnames
 set wr_singlescale
 set appendwrite
 set filetype=binary
-write out.raw
+write out.raw V(out)
 run
 quit
 .endc
@@ -159,13 +159,11 @@ quit
       [".lib", 3, "error"],
       [".control", 4, "error"],
       [".control", 19, "error"],
-      [".control", 20, "error"],
     ]);
     expect(summary.diagnostics.map((diagnostic) => diagnostic.code)).toStrictEqual([
       "SPICE_DECK_UNSUPPORTED_DIRECTIVE",
       "SPICE_DECK_UNSUPPORTED_DIRECTIVE",
       "SPICE_DECK_UNSUPPORTED_DIRECTIVE",
-      "SPICE_DECK_CONTROL_COMMAND",
       "SPICE_DECK_CONTROL_COMMAND",
     ]);
     const measurementSummary = resolveDeckMeasurements(`${summary.activeLines.join("\n")}\n.end`);
@@ -250,6 +248,7 @@ four 2k V(b)
 .set wr_vecnames
 .set wr_singlescale
 .set appendwrite
+.write out.raw V(a)
 run
 .quit
 .endc

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -40,7 +40,8 @@ downstream tools to compare.
      `set noaskquit` options plus ASCII rawfile-format `set filetype=ascii`
      options, rawfile vector-name/single-scale toggles (`set wr_vecnames`,
      `set wr_singlescale`), and rawfile append-write `set appendwrite` options
-     are accepted as no-op control markers; parsed
+     plus target-bearing rawfile `write <rawfile> [probes...]` markers are
+     accepted as no-op control markers; parsed
      `.measure dc` / `.meas dc` cards now route DC sweep probe samples into
      the shared scalar measurement table surface;
      parsed `.measure ac` / `.meas ac` cards now route AC probe magnitudes over
@@ -600,10 +601,21 @@ downstream tools to compare.
       slice.
     - Python, Rust, and TypeScript now accept exact selected `.control` block
       `set appendwrite` rawfile append-write options as no-op control commands.
-    - Binary rawfile formats, actual rawfile file-writing commands, other `set`
+    - Binary rawfile formats, actual rawfile serialization, other `set`
       variables, and unrecognized non-comment commands inside `.control` blocks
       remain diagnostic-only so unsupported file I/O and script state are
       explicit.
+
+55. Selected `.control` rawfile write marker routing.
+    - Status: completed in this selected control rawfile-write marker routing
+      slice.
+    - Python, Rust, and TypeScript now accept selected `.control` block
+      `write <rawfile> [probes...]` rawfile-write markers as no-op control
+      commands when a target path token is present.
+    - Actual rawfile serialization, binary rawfile formats, other file-writing
+      commands, other `set` variables, and unrecognized non-comment commands
+      inside `.control` blocks remain diagnostic-only so unsupported file I/O
+      and script state are explicit.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary

- accept selected `.control` block `write <rawfile> [probes...]` commands as no-op rawfile-write markers across Python, Rust, and TypeScript
- keep binary rawfile formats and actual rawfile serialization diagnostic-only while removing unsupported-command diagnostics for target-bearing write markers
- update SPICE package READMEs, changelogs, and the full implementation plan with completed slice #55

## Verification

- `/Users/adhithya/.local/share/mise/installs/python/3.12.13/bin/ruff check code/packages/python/spice-engine/src/spice_engine/compatibility.py code/packages/python/spice-engine/tests/test_compatibility.py`
- `PYTEST_ADDOPTS=--no-cov PYTHONPATH=code/packages/python/device-physics/src:code/packages/python/mosfet-models/src:code/packages/python/spice-engine/src /Users/adhithya/.local/share/mise/installs/python/3.12.13/bin/python3.12 -m pytest code/packages/python/spice-engine/tests/test_compatibility.py -q`
- `PYTHONPATH=code/packages/python/device-physics/src:code/packages/python/mosfet-models/src:code/packages/python/spice-engine/src /Users/adhithya/.local/share/mise/installs/python/3.12.13/bin/python3.12 -m pytest code/packages/python/spice-engine/tests -q`
- `cargo fmt --manifest-path code/packages/rust/spice-engine/Cargo.toml -- --check`
- `cargo test --manifest-path code/packages/rust/spice-engine/Cargo.toml --test compatibility_tests`
- `cargo test --manifest-path code/packages/rust/spice-engine/Cargo.toml`
- `PATH=/Users/adhithya/.local/share/mise/installs/node/22.22.3/bin:$PATH npm --prefix code/packages/typescript/spice-engine ci`
- `PATH=/Users/adhithya/.local/share/mise/installs/node/22.22.3/bin:$PATH npm --prefix code/packages/typescript/spice-engine run build`
- `PATH=/Users/adhithya/.local/share/mise/installs/node/22.22.3/bin:$PATH npm --prefix code/packages/typescript/spice-engine test -- compatibility`
- `PATH=/Users/adhithya/.local/share/mise/installs/node/22.22.3/bin:$PATH npm --prefix code/packages/typescript/spice-engine test`
- `git diff --check`