### PR TITLE
feat(r-16): general attributes — attr(), attributes(), structure()

### DIFF
--- a/code/packages/rust/r-runtime/CHANGELOG.md
+++ b/code/packages/rust/r-runtime/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.11.0] - 2026-06-17
+
+### Added (via the shared `s-runtime`)
+
+- **R-16 — general attributes**: `attr(x, which)` gets a named attribute (`NULL`
+  if absent); `attr(x, which) <- value` sets/replaces it (`NULL` removes);
+  `attributes(x)` gets all attributes as a named list (`NULL` if none);
+  `attributes(x) <- list(...)` replaces them (`NULL` clears); `structure(x, ...)`
+  returns `x` with the `...` named args attached as attributes. The special
+  attributes stay consistent with their dedicated wrappers — `attr(x, "names")`
+  == `names(x)` (R-15), `attr(x, "class")` == `class(x)` (S3), `attr(x, "dim")`
+  == `dim(x)` (R-11) — even after layering a class on a matrix, and setting `dim`
+  via `attr<-` reshapes a vector into a matrix. `attr<-`/`attributes<-` slot into
+  R-15's replacement-function lvalue path (now generalized to thread the `which`
+  argument through). See `s-runtime` 0.12.0.
+
 ## [0.10.0] - 2026-06-17
 
 ### Added (via the shared `s-runtime`)

--- a/code/packages/rust/r-runtime/README.md
+++ b/code/packages/rust/r-runtime/README.md
@@ -27,7 +27,11 @@ and the typed-`NA` constants) is handled in the shared evaluator.
 Recent additions reach R unchanged through this reuse: **named vectors (R-15)** —
 `c(a = 1, b = 2)` attaches names, `names(x)` / `names(x) <- value` /
 `setNames(x, nm)` get and set them, `x["b"]` indexes by name, and a named vector
-prints names above values instead of the `[i]` prefix.
+prints names above values instead of the `[i]` prefix. **General attributes
+(R-16)** — `attr(x, which)` / `attr(x, which) <- value` (`NULL` removes),
+`attributes(x)` / `attributes(x) <- list(...)`, and `structure(x, ...)` — also
+reach R unchanged; the special attributes stay consistent (`attr(x, "names")` ==
+`names(x)`, `attr(x, "class")` == `class(x)`, `attr(x, "dim")` == `dim(x)`).
 
 ## Usage
 

--- a/code/packages/rust/r-runtime/src/lib.rs
+++ b/code/packages/rust/r-runtime/src/lib.rs
@@ -846,4 +846,250 @@ mod tests {
             vec!["first", "second"]
         );
     }
+
+    // --- R-16: general attributes ---------------------------------------
+
+    #[test]
+    fn attr_get_absent_is_null() {
+        assert_eq!(show("x <- 1:3\nattr(x, \"foo\")\n"), "NULL");
+        assert_eq!(show("attr(c(1, 2, 3), \"bar\")\n"), "NULL");
+    }
+
+    #[test]
+    fn attr_set_get_and_replace_general() {
+        // Set then read back a general attribute.
+        assert_eq!(
+            show("x <- 1:3\nattr(x, \"foo\") <- \"bar\"\nattr(x, \"foo\")\n"),
+            "[1] \"bar\""
+        );
+        // Replacing an existing attribute overwrites it.
+        assert_eq!(
+            show("x <- 1:3\nattr(x, \"foo\") <- \"a\"\nattr(x, \"foo\") <- \"b\"\nattr(x, \"foo\")\n"),
+            "[1] \"b\""
+        );
+        // The underlying value is untouched and still usable.
+        assert_eq!(
+            nums("x <- c(10, 20, 30)\nattr(x, \"src\") <- \"sensor\"\nx + 1\n"),
+            vec![11.0, 21.0, 31.0]
+        );
+    }
+
+    #[test]
+    fn attr_assign_null_removes() {
+        assert_eq!(
+            show(
+                "x <- structure(1:3, foo = \"bar\")\nattr(x, \"foo\") <- NULL\nattr(x, \"foo\")\n"
+            ),
+            "NULL"
+        );
+        // Removing the last general attribute leaves the bare value (attributes → NULL).
+        assert_eq!(
+            show("x <- structure(1:3, foo = \"bar\")\nattr(x, \"foo\") <- NULL\nattributes(x)\n"),
+            "NULL"
+        );
+    }
+
+    #[test]
+    fn structure_attaches_multiple_attributes() {
+        // The value prints transparently; class and general attrs attach.
+        assert_eq!(
+            show("structure(1:3, class = \"myc\", foo = \"bar\")\n"),
+            "[1] 1 2 3"
+        );
+        assert_eq!(
+            show("x <- structure(1:3, class = \"myc\", foo = \"bar\")\nclass(x)\n"),
+            "[1] \"myc\""
+        );
+        assert_eq!(
+            show("x <- structure(1:3, class = \"myc\", foo = \"bar\")\nattr(x, \"foo\")\n"),
+            "[1] \"bar\""
+        );
+    }
+
+    // --- consistency of the three special attributes --------------------
+
+    #[test]
+    fn attr_names_agrees_with_names() {
+        // attr(x, "names") returns exactly what names(x) does (R-15).
+        assert_eq!(
+            names_of("attr(c(a = 1, b = 2), \"names\")\n"),
+            vec!["a", "b"]
+        );
+        // Setting names *via* attr<- is observable through names().
+        assert_eq!(
+            names_of("x <- 1:2\nattr(x, \"names\") <- c(\"p\", \"q\")\nnames(x)\n"),
+            vec!["p", "q"]
+        );
+        // ...and conversely, names set by c() are visible via attr().
+        assert_eq!(
+            names_of("x <- c(a = 1, b = 2, c = 3)\nattr(x, \"names\")\n"),
+            vec!["a", "b", "c"]
+        );
+        // Removing names via attr<- NULL clears them.
+        assert_eq!(
+            show("x <- c(a = 1, b = 2)\nattr(x, \"names\") <- NULL\nnames(x)\n"),
+            "NULL"
+        );
+    }
+
+    #[test]
+    fn attr_class_agrees_with_class() {
+        // attr(x, "class") matches class(x) for an explicitly classed value.
+        assert_eq!(
+            show("x <- structure(1, class = \"k\")\nattr(x, \"class\")\n"),
+            "[1] \"k\""
+        );
+        assert_eq!(
+            show("x <- structure(1, class = \"k\")\nclass(x)\n"),
+            "[1] \"k\""
+        );
+        // A bare vector has no explicit class attribute (implicit class is NOT one).
+        assert_eq!(show("attr(1, \"class\")\n"), "NULL");
+        // Setting class via attr<- is observable through class()/inherits().
+        assert_eq!(
+            show("x <- 1:3\nattr(x, \"class\") <- \"k\"\ninherits(x, \"k\")\n"),
+            "[1] TRUE"
+        );
+        // Removing it via NULL restores the implicit class.
+        assert_eq!(
+            show("x <- structure(1, class = \"k\")\nattr(x, \"class\") <- NULL\nclass(x)\n"),
+            "[1] \"numeric\""
+        );
+    }
+
+    #[test]
+    fn attr_dim_agrees_with_matrix_dim() {
+        // attr(m, "dim") matches dim(m) for a matrix (R-11).
+        assert_eq!(
+            nums("m <- matrix(1:6, nrow = 2)\nattr(m, \"dim\")\n"),
+            vec![2.0, 3.0]
+        );
+        // Setting dim via attr<- reshapes a vector into a matrix; dim() agrees.
+        assert_eq!(
+            nums("x <- 1:6\nattr(x, \"dim\") <- c(2, 3)\ndim(x)\n"),
+            vec![2.0, 3.0]
+        );
+        // The reshaped value indexes as a matrix (column-major).
+        assert_eq!(
+            nums("x <- 1:6\nattr(x, \"dim\") <- c(2, 3)\nx[2, 1]\n"),
+            vec![2.0]
+        );
+        // Clearing dim collapses back to a flat vector.
+        assert_eq!(
+            show("m <- matrix(1:6, nrow = 2)\nattr(m, \"dim\") <- NULL\ndim(m)\n"),
+            "NULL"
+        );
+    }
+
+    #[test]
+    fn attr_dim_rejects_nonconforming_length() {
+        // A dim whose product != element count is an error (no panic).
+        assert!(eval_r("x <- 1:5\nattr(x, \"dim\") <- c(2, 3)\nx\n").is_err());
+    }
+
+    // --- attributes() get/set -------------------------------------------
+
+    #[test]
+    fn attributes_get_returns_named_list_or_null() {
+        // No attributes → NULL.
+        assert_eq!(show("attributes(1:3)\n"), "NULL");
+        // A classed + general-attributed value lists both (class last).
+        let out = show("x <- structure(1:3, foo = \"bar\", class = \"k\")\nattributes(x)\n");
+        assert!(out.contains("$foo"), "got: {out}");
+        assert!(out.contains("$class"), "got: {out}");
+        assert!(out.contains("\"bar\""), "got: {out}");
+        // names appears first when present.
+        let out = show("x <- c(a = 1, b = 2)\nattributes(x)\n");
+        assert!(out.contains("$names"), "got: {out}");
+    }
+
+    #[test]
+    fn attributes_set_replaces_whole_set() {
+        // attributes(x) <- list(...) applies each named element.
+        assert_eq!(
+            show("x <- 1:3\nattributes(x) <- list(foo = \"z\")\nattr(x, \"foo\")\n"),
+            "[1] \"z\""
+        );
+        assert_eq!(
+            show("x <- 1:3\nattributes(x) <- list(class = \"k\")\nclass(x)\n"),
+            "[1] \"k\""
+        );
+        // A names element routes to the names wrapper.
+        assert_eq!(
+            names_of("x <- 1:2\nattributes(x) <- list(names = c(\"p\", \"q\"))\nnames(x)\n"),
+            vec!["p", "q"]
+        );
+        // Assigning NULL clears everything.
+        assert_eq!(
+            show("x <- structure(1:3, foo = \"b\", class = \"k\")\nattributes(x) <- NULL\nattributes(x)\n"),
+            "NULL"
+        );
+    }
+
+    #[test]
+    fn attributes_set_rejects_malformed_input() {
+        // An unnamed list element is an error.
+        assert!(eval_r("x <- 1:3\nattributes(x) <- list(\"unnamed\")\n").is_err());
+        // A non-list, non-NULL value is an error.
+        assert!(eval_r("x <- 1:3\nattributes(x) <- 5\n").is_err());
+    }
+
+    // --- regressions: R-15 / S3 / factors / data frames still work ------
+
+    #[test]
+    fn r15_named_vectors_unaffected() {
+        // Named construction, names(), character indexing all still work.
+        assert_eq!(
+            names_of("names(c(a = 1, b = 2, c = 3))\n"),
+            vec!["a", "b", "c"]
+        );
+        assert_eq!(nums("x <- c(a = 1, b = 2)\nx[\"b\"]\n"), vec![2.0]);
+        assert_eq!(
+            nums("x <- 1:3\nnames(x) <- c(\"a\", \"b\", \"c\")\nx[\"c\"]\n"),
+            vec![3.0]
+        );
+    }
+
+    #[test]
+    fn s3_class_and_factors_and_data_frames_unaffected() {
+        // S3 class via structure + inherits.
+        assert_eq!(
+            show("x <- structure(1, class = \"k\")\ninherits(x, \"k\")\n"),
+            "[1] TRUE"
+        );
+        // Factors: class is still "factor", levels intact.
+        assert_eq!(
+            show("class(factor(c(\"a\", \"b\", \"a\")))\n"),
+            "[1] \"factor\""
+        );
+        assert_eq!(
+            names_of("levels(factor(c(\"b\", \"a\", \"b\")))\n"),
+            vec!["a", "b"]
+        );
+        // Data frames: class, names, $ access.
+        assert_eq!(
+            show("class(data.frame(x = 1:2, y = c(10, 20)))\n"),
+            "[1] \"data.frame\""
+        );
+        assert_eq!(
+            nums("d <- data.frame(x = 1:2, y = c(10, 20))\nd$y\n"),
+            vec![10.0, 20.0]
+        );
+        assert_eq!(
+            names_of("names(data.frame(aa = 1:2, bb = 3:4))\n"),
+            vec!["aa", "bb"]
+        );
+    }
+
+    #[test]
+    fn attr_combines_class_names_and_general_together() {
+        // A value can carry all three layers at once and stay consistent.
+        let prog = "x <- 1:6\n\
+                    attr(x, \"dim\") <- c(2, 3)\n\
+                    attr(x, \"class\") <- \"grid\"\n\
+                    attr(x, \"label\") <- \"demo\"\n";
+        assert_eq!(nums(&format!("{prog}dim(x)\n")), vec![2.0, 3.0]);
+        assert_eq!(show(&format!("{prog}class(x)\n")), "[1] \"grid\"");
+        assert_eq!(show(&format!("{prog}attr(x, \"label\")\n")), "[1] \"demo\"");
+    }
 }

--- a/code/packages/rust/s-runtime/CHANGELOG.md
+++ b/code/packages/rust/s-runtime/CHANGELOG.md
@@ -2,6 +2,47 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.12.0] - 2026-06-17
+
+### Added
+
+- **General attributes — `attr()`, `attributes()`, `structure()` (R-16)** — R's
+  open key→value metadata map. A new transparent wrapper
+  `SValue::Attributed { attrs, inner }` stores the *general* (non-special)
+  attributes as an insertion-ordered association list beside a boxed inner value.
+  Like `Named`/`Classed` it is *see-through*: `length`, `type_name`, `class_of`,
+  the coercions, `arithmetic`, `compare`, `truthy`, `index`, `assign_index`, and
+  printing all delegate to `inner`; only the attribute builtins observe the map.
+  - The three **special** attributes keep their dedicated representations and are
+    *never* duplicated into the general map: `names` → `SValue::Named` (R-15),
+    `class` → `SValue::Classed` (S v2), `dim` → `SValue::Matrix` (R-11). This
+    makes the consistency invariant structural — `attr(x, "names")` reads the same
+    field as `names(x)`, `attr(x, "class")` agrees with `class(x)`/`class_of`, and
+    `attr(x, "dim")` agrees with the matrix `dim`.
+  - `attr(x, which)` gets one attribute (or `NULL`); `attr(x, which) <- value`
+    sets/replaces it (`NULL` removes), wired through R-15's replacement-function
+    lvalue path, now **generalized** to thread extra call arguments through
+    (`attr(x, "foo") <- v` desugars to ``x <- `attr<-`(x, "foo", value = v)``).
+  - `attributes(x)` returns all attributes as a named list (special ones first in
+    R's canonical `names`/`dim`/general order, `class` last) or `NULL`;
+    `attributes(x) <- list(...)` replaces the whole set; `NULL` clears it.
+  - `structure(x, ...)` (previously `class`-only) now routes *every* named
+    argument through the same per-name logic, so `dim`, `names`, and arbitrary
+    attributes all attach in one call. `.Names`/`.Dim` aliases are honoured.
+  - `dim`/`nrow`/`ncol`/`levels` peel the new transparent wrappers (and `names`
+    peels class/general but stops at the names wrapper) so a classed or
+    generally-attributed matrix/factor still reports its shape/levels.
+
+### Safety
+
+- The general attribute map is bounded by `MAX_ATTRIBUTES` (4096) — `attr<-`,
+  `attributes<-`, and `structure` refuse runaway growth from crafted input. A
+  `"dim"` set validates the reshape with checked multiplication against
+  `MAX_SEQ_LEN` before allocating. No `unwrap`/panic is reachable from malformed
+  `attributes(x) <- …` input: a non-list `value`, an unnamed element, a too-long
+  `names`, a non-integer `dim` component, or a non-conforming `dim` product all
+  return a clean `SError`.
+
 ## [0.11.0] - 2026-06-17
 
 ### Added

--- a/code/packages/rust/s-runtime/README.md
+++ b/code/packages/rust/s-runtime/README.md
@@ -40,6 +40,14 @@ s-lexer → s-parser → GrammarASTNode → s-runtime (this crate) → s-repl
   `x["b"]` indexes by name, and a named vector prints names above values. Names
   are a transparent `SValue::Named` wrapper — they ride through indexing and drop
   through arithmetic, exactly as in R.
+- **General attributes** (R-16): `attr(x, which)` / `attr(x, which) <- value`
+  (assigning `NULL` removes), `attributes(x)` / `attributes(x) <- list(...)`, and
+  `structure(x, class = "myc", foo = "bar")`. General (non-special) attributes
+  live in a transparent `SValue::Attributed` wrapper; the *special* attributes
+  route to their dedicated representations, so `attr(x, "names")` agrees with
+  `names(x)`, `attr(x, "class")` with `class(x)`, and `attr(x, "dim")` with the
+  matrix `dim` by construction. The general map is bounded and malformed input
+  fails closed.
 - The **`d`/`p`/`q`/`r` distribution family** (R-8) over `statistics-core`:
   density/CDF/quantile/sampling for the normal, uniform, and exponential
   distributions, plus `set.seed` for a reproducible per-session RNG.

--- a/code/packages/rust/s-runtime/src/builtins.rs
+++ b/code/packages/rust/s-runtime/src/builtins.rs
@@ -9,7 +9,9 @@
 use crate::env::{define, Env};
 use crate::error::{SError, SResult};
 use crate::eval::{nth_element, Interpreter};
-use crate::value::{bounded_sequence, class_of, combine, index, Arg, SValue, MAX_SEQ_LEN};
+use crate::value::{
+    bounded_sequence, class_of, combine, index, Arg, SValue, MAX_ATTRIBUTES, MAX_SEQ_LEN,
+};
 use r_vector::{is_na_real, na_real, Double};
 use statistics_core::distributions::{dnorm, pnorm, qnorm, rnorm};
 use statistics_core::distributions_more::{
@@ -149,6 +151,13 @@ pub fn install(env: &Env) {
     define(env, "structure", builtin("structure", b_structure));
     define(env, "inherits", builtin("inherits", b_inherits));
     define(env, "unclass", builtin("unclass", b_unclass));
+
+    // R-16 — general attributes. `attr<-` / `attributes<-` slot into the
+    // replacement-function lvalue path R-15 added (`f(x) <- v` ≡ `x <- \`f<-\`(x, v)`).
+    define(env, "attr", builtin("attr", b_attr));
+    define(env, "attr<-", builtin("attr<-", b_attr_replace));
+    define(env, "attributes", builtin("attributes", b_attributes));
+    define(env, "attributes<-", builtin("attributes<-", b_attributes_replace));
 
     // v2 — factors.
     define(env, "factor", builtin("factor", b_factor));
@@ -1147,20 +1156,26 @@ fn b_class(_interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
     Ok(SValue::Character(classes.into_iter().map(Some).collect()))
 }
 
-/// `structure(x, class = …)` — attach an explicit S3 class to a value. v2
-/// supports the `class` attribute; other attributes are accepted but ignored.
+/// `structure(x, ...)` — return `x` with each named `...` argument attached as an
+/// attribute (R-16). `structure(1:3, class = "myc", foo = "bar")` attaches both
+/// the special `class` and the general `foo`. Each named argument is routed
+/// through the same per-name logic as `attr<-` (special names — `names`/`.Names`,
+/// `class`, `dim`/`.Dim` — go to their dedicated wrappers; the rest into the
+/// general attribute map), so a single call can set `dim`, `names`, and arbitrary
+/// attributes consistently. The first positional argument is `x`; any further
+/// positional arguments are ignored (R has no positional `...` attributes here).
 fn b_structure(_interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
-    let inner = first_positional(args)?.clone();
-    match args.iter().find(|a| a.name.as_deref() == Some("class")) {
-        Some(arg) => {
-            let class: Vec<String> = arg.value.as_character().into_iter().flatten().collect();
-            Ok(SValue::Classed {
-                inner: Box::new(inner),
-                class,
-            })
+    let mut value = first_positional(args)?.clone();
+    for a in args {
+        if let Some(name) = &a.name {
+            // `.Data` is R's positional alias for the object itself; skip it.
+            if name == ".Data" {
+                continue;
+            }
+            value = set_attr(value, name, &a.value)?;
         }
-        None => Ok(inner),
     }
+    Ok(value)
 }
 
 /// `inherits(x, what)` — whether any class of `x` matches `what`.
@@ -1190,6 +1205,359 @@ fn b_unclass(_interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
     match first_positional(args)? {
         SValue::Classed { inner, .. } => Ok((**inner).clone()),
         other => Ok(other.clone()),
+    }
+}
+
+// ===========================================================================
+// R-16 — general attributes (attr / attributes / structure)
+// ===========================================================================
+//
+// R's attribute system is an open key→value metadata map on every object. Three
+// attributes are *special* — `names`, `class`, `dim` — and we keep them in their
+// dedicated representations so they can never disagree with the wrappers built
+// for them:
+//
+//   | attribute | where it actually lives           | get reads                | set routes to        |
+//   |-----------|-----------------------------------|--------------------------|----------------------|
+//   | "names"   | `SValue::Named.names` (R-15)      | `names(x)`               | `with_names`         |
+//   | "class"   | `SValue::Classed.class` (S v2)    | `class_of` (explicit)    | `Classed` / `unclass`|
+//   | "dim"     | `SValue::Matrix{nrow,ncol}` (R-11)| `c(nrow, ncol)`          | reshape into Matrix  |
+//
+// Every *other* attribute is stored generally in `SValue::Attributed.attrs`.
+// Because the special ones are never duplicated into that map, `attr(x,"names")`
+// *is* `names(x)` — both read the same field — and likewise for class/dim. R
+// also accepts `.Names`/`.Dim` as aliases for `names`/`dim`, which we honour.
+
+/// `attr(x, which)` — the named attribute, or `NULL` if absent. Special names are
+/// synthesized from the dedicated wrappers; everything else is looked up in the
+/// general attribute map.
+fn get_attr(x: &SValue, which: &str) -> SValue {
+    match which {
+        "names" | ".Names" => match x {
+            SValue::Named { names, .. } => SValue::Character(names.clone()),
+            SValue::DataFrame { names, .. } => {
+                SValue::Character(names.iter().cloned().map(Some).collect())
+            }
+            // Names live *inside* the class/general wrappers — see through them.
+            SValue::Attributed { inner, .. } => get_attr(inner, "names"),
+            SValue::Classed { inner, .. } => get_attr(inner, "names"),
+            _ => SValue::Null,
+        },
+        "class" => match x {
+            // Only an *explicitly* set class is an attribute; the implicit class
+            // of a bare vector is not (matching R's `attr(1, "class")` → NULL).
+            SValue::Classed { class, .. } => {
+                SValue::Character(class.iter().cloned().map(|c| Some(c)).collect())
+            }
+            // See through a general-attribute wrapper to find an inner class.
+            SValue::Attributed { inner, .. } => get_attr(inner, "class"),
+            SValue::Named { values, .. } => get_attr(values, "class"),
+            _ => SValue::Null,
+        },
+        "dim" | ".Dim" => match x {
+            SValue::Matrix { nrow, ncol, .. } => SValue::doubles(vec![*nrow as f64, *ncol as f64]),
+            SValue::Attributed { inner, .. } => get_attr(inner, "dim"),
+            SValue::Classed { inner, .. } => get_attr(inner, "dim"),
+            SValue::Named { values, .. } => get_attr(values, "dim"),
+            _ => SValue::Null,
+        },
+        // A general attribute: look it up in the map (seeing through Named/Classed
+        // so `attr(setNames(structure(...)), "foo")` still finds `foo`).
+        _ => match x {
+            SValue::Attributed { attrs, .. } => attrs
+                .iter()
+                .find(|(k, _)| k == which)
+                .map(|(_, v)| v.clone())
+                .unwrap_or(SValue::Null),
+            SValue::Named { values, .. } => get_attr(values, which),
+            SValue::Classed { inner, .. } => get_attr(inner, which),
+            _ => SValue::Null,
+        },
+    }
+}
+
+/// `attr(x, which) <- value` — set/replace/remove a single attribute, returning
+/// the modified value. Assigning `NULL` *removes* the attribute. Special names
+/// route to their dedicated wrappers; the rest go into the general map (bounded
+/// by [`MAX_ATTRIBUTES`]). Never panics on malformed input — a bad `dim` or
+/// over-long `names` returns a clean `SError`.
+fn set_attr(x: SValue, which: &str, value: &SValue) -> SResult<SValue> {
+    let removing = matches!(value, SValue::Null);
+    match which {
+        "names" | ".Names" => set_names_attr(x, value),
+        "class" => Ok(set_class_attr(x, value)),
+        "dim" | ".Dim" => set_dim_attr(x, value),
+        _ => set_general_attr(x, which, value, removing),
+    }
+}
+
+/// Route a `names`/`class`/`dim` set into the existing wrapper machinery, leaving
+/// the general-attribute layer (if any) intact around the result.
+///
+/// Set the `names` attribute, reusing R-15's `with_names` (NA-pad / truncate /
+/// `NULL`-clear), preserving any general attributes around it.
+fn set_names_attr(x: SValue, value: &SValue) -> SResult<SValue> {
+    // Peel a general-attribute wrapper so names attach to the bare value, then
+    // re-wrap. (`names<-` semantics are unchanged from R-15.)
+    let (attrs, bare) = split_general(x);
+    let renamed = match value {
+        SValue::Null => bare.strip_names().clone(),
+        v => {
+            let new_names = v.as_character();
+            if new_names.len() > bare.length() {
+                return Err(SError::BadArgs(format!(
+                    "'names' attribute [{}] must be no longer than the vector [{}]",
+                    new_names.len(),
+                    bare.length()
+                )));
+            }
+            SValue::with_names(bare, new_names)
+        }
+    };
+    Ok(SValue::with_general_attrs(renamed, attrs))
+}
+
+/// Set (or, with `NULL`, clear) the explicit S3 `class`, preserving general attrs.
+fn set_class_attr(x: SValue, value: &SValue) -> SValue {
+    let (attrs, bare) = split_general(x);
+    // `unclass` first so re-setting replaces rather than nests.
+    let unclassed = match bare {
+        SValue::Classed { inner, .. } => *inner,
+        other => other,
+    };
+    let classed = match value {
+        SValue::Null => unclassed,
+        v => {
+            let class: Vec<String> = v.as_character().into_iter().flatten().collect();
+            if class.is_empty() {
+                unclassed
+            } else {
+                SValue::Classed {
+                    inner: Box::new(unclassed),
+                    class,
+                }
+            }
+        }
+    };
+    SValue::with_general_attrs(classed, attrs)
+}
+
+/// Set (or, with `NULL`, clear) the `dim` attribute. Setting `dim <- c(nr, nc)`
+/// reshapes a length-`nr*nc` numeric vector into a column-major matrix; the
+/// product must equal the element count (as in R). Clearing turns a matrix back
+/// into its flat vector. General attributes are preserved around the result.
+fn set_dim_attr(x: SValue, value: &SValue) -> SResult<SValue> {
+    let (attrs, bare) = split_general(x);
+    let reshaped = match value {
+        // Clearing dim: a matrix collapses to its flat column-major vector.
+        SValue::Null => match bare {
+            SValue::Matrix { data, .. } => SValue::Double(data),
+            other => other,
+        },
+        v => {
+            let dims = v.as_double()?;
+            if dims.len() != 2 {
+                return Err(SError::BadArgs(
+                    "dim<-: only 2-D dims (c(nrow, ncol)) are supported".into(),
+                ));
+            }
+            let nr = dim_component(dims.get_value(0))?;
+            let nc = dim_component(dims.get_value(1))?;
+            // Checked product, bounded — never allocate an oversize matrix.
+            let total = nr
+                .checked_mul(nc)
+                .filter(|&t| t <= MAX_SEQ_LEN)
+                .ok_or_else(|| {
+                    SError::BadArgs(format!("dim<-: dimensions too large (limit {MAX_SEQ_LEN})"))
+                })?;
+            let data = bare.as_double()?;
+            if data.len() != total {
+                return Err(SError::BadArgs(format!(
+                    "dim<-: dims [product {total}] do not match the length of object [{}]",
+                    data.len()
+                )));
+            }
+            SValue::Matrix {
+                data,
+                nrow: nr,
+                ncol: nc,
+            }
+        }
+    };
+    Ok(SValue::with_general_attrs(reshaped, attrs))
+}
+
+/// Validate one `dim` component: a finite non-negative integer.
+fn dim_component(x: Option<f64>) -> SResult<usize> {
+    match x {
+        Some(v) if v.is_finite() && v >= 0.0 && v.fract() == 0.0 => Ok(v as usize),
+        _ => Err(SError::BadArgs("dim<-: each dimension must be a non-negative integer".into())),
+    }
+}
+
+/// Set/replace/remove a *general* (non-special) attribute in the `Attributed`
+/// map, bounded by [`MAX_ATTRIBUTES`].
+fn set_general_attr(x: SValue, which: &str, value: &SValue, removing: bool) -> SResult<SValue> {
+    // Pull the current general attrs off (if any), keeping the special wrappers.
+    let (mut attrs, bare) = split_general(x);
+    if let Some(pos) = attrs.iter().position(|(k, _)| k == which) {
+        if removing {
+            attrs.remove(pos);
+        } else {
+            attrs[pos].1 = value.clone();
+        }
+    } else if !removing {
+        if attrs.len() >= MAX_ATTRIBUTES {
+            return Err(SError::BadArgs(format!(
+                "too many attributes (limit {MAX_ATTRIBUTES})"
+            )));
+        }
+        attrs.push((which.to_string(), value.clone()));
+    }
+    Ok(SValue::with_general_attrs(bare, attrs))
+}
+
+/// Split a value into its general-attribute list (empty if none) and the bare
+/// value underneath the `Attributed` wrapper. Special wrappers (`Named`,
+/// `Classed`, `Matrix`) stay intact inside `bare`.
+fn split_general(x: SValue) -> (Vec<(String, SValue)>, SValue) {
+    match x {
+        SValue::Attributed { attrs, inner } => (attrs, *inner),
+        other => (Vec::new(), other),
+    }
+}
+
+/// `attr(x, which)` — get a single attribute (or `NULL`). `which` is the second
+/// positional (or `which =`) argument, coerced to its first character element.
+fn b_attr(_interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
+    let x = first_positional(args)?;
+    let which = attr_which(args)?;
+    Ok(get_attr(x, &which))
+}
+
+/// `attr<-`(x, which, value)` — the replacement form behind `attr(x, which) <- v`.
+/// The replacement convention passes `(x, which, value = v)`.
+fn b_attr_replace(_interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
+    let x = first_positional(args)?.clone();
+    let which = attr_which(args)?;
+    let value = args
+        .iter()
+        .find(|a| a.name.as_deref() == Some("value"))
+        .map(|a| &a.value)
+        .or_else(|| nth_positional(args, 2))
+        .cloned()
+        .unwrap_or(SValue::Null);
+    set_attr(x, &which, &value)
+}
+
+/// Read the `which` argument of `attr` / `attr<-`: the `which =` named arg, or
+/// the second positional. Must be a non-`NA` character scalar.
+fn attr_which(args: &[Arg]) -> SResult<String> {
+    let v = args
+        .iter()
+        .find(|a| a.name.as_deref() == Some("which"))
+        .map(|a| &a.value)
+        .or_else(|| nth_positional(args, 1))
+        .ok_or_else(|| SError::BadArgs("attr: 'which' is missing".into()))?;
+    v.as_character()
+        .into_iter()
+        .next()
+        .flatten()
+        .ok_or_else(|| SError::BadArgs("attr: 'which' must be a non-NA character string".into()))
+}
+
+/// `attributes(x)` — *all* attributes as a named list (or `NULL` if none). The
+/// special attributes come first in R's canonical order (`names`, then `dim`,
+/// then the general ones in insertion order), with `class` last.
+fn b_attributes(_interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
+    let x = first_positional(args)?;
+    let mut pairs: Vec<(Option<String>, SValue)> = Vec::new();
+
+    // names, then dim (special, canonical order).
+    let names = get_attr(x, "names");
+    if !matches!(names, SValue::Null) {
+        pairs.push((Some("names".to_string()), names));
+    }
+    let dim = get_attr(x, "dim");
+    if !matches!(dim, SValue::Null) {
+        pairs.push((Some("dim".to_string()), dim));
+    }
+    // General attributes, in insertion order. The general-attribute wrapper is
+    // always the *outermost* layer (every `set_attr`/`structure` re-wraps it
+    // outside the special `Named`/`Classed`/`Matrix` wrappers), so a single
+    // `general_attrs()` on `x` sees them all.
+    if let Some(attrs) = x.general_attrs() {
+        for (k, v) in attrs {
+            pairs.push((Some(k.clone()), v.clone()));
+        }
+    }
+    // class last.
+    let class = get_attr(x, "class");
+    if !matches!(class, SValue::Null) {
+        pairs.push((Some("class".to_string()), class));
+    }
+
+    if pairs.is_empty() {
+        Ok(SValue::Null)
+    } else {
+        Ok(SValue::list(pairs))
+    }
+}
+
+/// `attributes<-`(x, value)` — replace the *whole* attribute set. `value` is a
+/// named list (each element applied as the matching attribute) or `NULL` (clear
+/// every attribute). An unnamed element, or a non-list / non-NULL `value`, is an
+/// error. Bounded by [`MAX_ATTRIBUTES`] via the per-attribute `set_attr` path.
+fn b_attributes_replace(_interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
+    let x = first_positional(args)?.clone();
+    let value = args
+        .iter()
+        .find(|a| a.name.as_deref() == Some("value"))
+        .map(|a| &a.value)
+        .or_else(|| nth_positional(args, 1))
+        .cloned()
+        .unwrap_or(SValue::Null);
+
+    // Start from a fully bare value: clearing every attribute is the baseline.
+    let bare = strip_all_attrs(x);
+    match value {
+        SValue::Null => Ok(bare),
+        SValue::List { names, items } => {
+            if items.len() > MAX_ATTRIBUTES {
+                return Err(SError::BadArgs(format!(
+                    "attributes<-: too many attributes (limit {MAX_ATTRIBUTES})"
+                )));
+            }
+            let mut out = bare;
+            for (name, item) in names.iter().zip(items.iter()) {
+                let key = name
+                    .as_deref()
+                    .filter(|s| !s.is_empty())
+                    .ok_or_else(|| {
+                        SError::BadArgs(
+                            "attributes<-: all attributes in the list must be named".into(),
+                        )
+                    })?;
+                out = set_attr(out, key, item)?;
+            }
+            Ok(out)
+        }
+        other => Err(SError::TypeError(format!(
+            "attributes<-: value must be a named list or NULL (got {})",
+            other.type_name()
+        ))),
+    }
+}
+
+/// Strip *every* attribute (special and general) from a value, returning the bare
+/// underlying vector — the baseline for `attributes(x) <- list(...)`.
+fn strip_all_attrs(x: SValue) -> SValue {
+    match x {
+        SValue::Attributed { inner, .. } => strip_all_attrs(*inner),
+        SValue::Named { values, .. } => strip_all_attrs(*values),
+        SValue::Classed { inner, .. } => strip_all_attrs(*inner),
+        SValue::Matrix { data, .. } => SValue::Double(data),
+        other => other,
     }
 }
 

--- a/code/packages/rust/s-runtime/src/builtins.rs
+++ b/code/packages/rust/s-runtime/src/builtins.rs
@@ -157,7 +157,11 @@ pub fn install(env: &Env) {
     define(env, "attr", builtin("attr", b_attr));
     define(env, "attr<-", builtin("attr<-", b_attr_replace));
     define(env, "attributes", builtin("attributes", b_attributes));
-    define(env, "attributes<-", builtin("attributes<-", b_attributes_replace));
+    define(
+        env,
+        "attributes<-",
+        builtin("attributes<-", b_attributes_replace),
+    );
 
     // v2 — factors.
     define(env, "factor", builtin("factor", b_factor));
@@ -240,7 +244,7 @@ fn b_data_frame(_interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
 
 /// `nrow(df)` — the row count (the common column length).
 fn b_nrow(_interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
-    match first_positional(args)? {
+    match peel_structural(first_positional(args)?) {
         SValue::DataFrame { columns, .. } => Ok(SValue::scalar(
             columns.first().map(|c| c.length()).unwrap_or(0) as f64,
         )),
@@ -251,7 +255,7 @@ fn b_nrow(_interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
 
 /// `ncol(df)` — the column count.
 fn b_ncol(_interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
-    match first_positional(args)? {
+    match peel_structural(first_positional(args)?) {
         SValue::DataFrame { columns, .. } => Ok(SValue::scalar(columns.len() as f64)),
         SValue::Matrix { ncol, .. } => Ok(SValue::scalar(*ncol as f64)),
         _ => Ok(SValue::Null),
@@ -262,7 +266,9 @@ fn b_ncol(_interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
 /// column names; for a **named vector** (R-15) they are the element names (an
 /// unset name → `NA`). Anything without names is `NULL`.
 fn b_names(_interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
-    match first_positional(args)? {
+    // Peel class/general wrappers (but not the names wrapper itself) so a classed
+    // or generally-attributed named vector still reports its names.
+    match peel_to_named(first_positional(args)?) {
         SValue::DataFrame { names, .. } => {
             Ok(SValue::Character(names.iter().cloned().map(Some).collect()))
         }
@@ -330,7 +336,7 @@ fn b_set_names(interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
 
 /// `dim(df)` — `c(nrow, ncol)`.
 fn b_dim(_interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
-    match first_positional(args)? {
+    match peel_structural(first_positional(args)?) {
         SValue::DataFrame { columns, .. } => {
             let nrow = columns.first().map(|c| c.length()).unwrap_or(0) as f64;
             Ok(SValue::doubles(vec![nrow, columns.len() as f64]))
@@ -1104,7 +1110,7 @@ fn b_factor(_interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
 
 /// `levels(f)` — the level labels of a factor (`NULL` otherwise).
 fn b_levels(_interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
-    match first_positional(args)? {
+    match peel_structural(first_positional(args)?) {
         SValue::Factor { levels, .. } => Ok(SValue::Character(
             levels.iter().cloned().map(Some).collect(),
         )),
@@ -1228,6 +1234,31 @@ fn b_unclass(_interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
 // *is* `names(x)` — both read the same field — and likewise for class/dim. R
 // also accepts `.Names`/`.Dim` as aliases for `names`/`dim`, which we honour.
 
+/// Peel the transparent wrappers — `Attributed` (general attrs, R-16), `Classed`
+/// (S v2 class), and `Named` (names, R-15) — to reach the *structural* value
+/// underneath (a `Matrix`/`DataFrame`/`Factor`/atomic). Used by the
+/// structural-query builtins (`dim`/`nrow`/`ncol`) so a value that has had a
+/// class or general attribute layered on top still reports its shape — keeping
+/// `attr(x,"dim")` and `dim(x)` in agreement even after `attr(x,"class") <- …`.
+fn peel_structural(x: &SValue) -> &SValue {
+    match x {
+        SValue::Attributed { inner, .. } => peel_structural(inner),
+        SValue::Classed { inner, .. } => peel_structural(inner),
+        SValue::Named { values, .. } => peel_structural(values),
+        other => other,
+    }
+}
+
+/// Peel only the non-`Named` transparent wrappers (`Attributed`, `Classed`),
+/// stopping at a `Named` so a names lookup still finds it.
+fn peel_to_named(x: &SValue) -> &SValue {
+    match x {
+        SValue::Attributed { inner, .. } => peel_to_named(inner),
+        SValue::Classed { inner, .. } => peel_to_named(inner),
+        other => other,
+    }
+}
+
 /// `attr(x, which)` — the named attribute, or `NULL` if absent. Special names are
 /// synthesized from the dedicated wrappers; everything else is looked up in the
 /// general attribute map.
@@ -1247,7 +1278,7 @@ fn get_attr(x: &SValue, which: &str) -> SValue {
             // Only an *explicitly* set class is an attribute; the implicit class
             // of a bare vector is not (matching R's `attr(1, "class")` → NULL).
             SValue::Classed { class, .. } => {
-                SValue::Character(class.iter().cloned().map(|c| Some(c)).collect())
+                SValue::Character(class.iter().cloned().map(Some).collect())
             }
             // See through a general-attribute wrapper to find an inner class.
             SValue::Attributed { inner, .. } => get_attr(inner, "class"),
@@ -1391,7 +1422,9 @@ fn set_dim_attr(x: SValue, value: &SValue) -> SResult<SValue> {
 fn dim_component(x: Option<f64>) -> SResult<usize> {
     match x {
         Some(v) if v.is_finite() && v >= 0.0 && v.fract() == 0.0 => Ok(v as usize),
-        _ => Err(SError::BadArgs("dim<-: each dimension must be a non-negative integer".into())),
+        _ => Err(SError::BadArgs(
+            "dim<-: each dimension must be a non-negative integer".into(),
+        )),
     }
 }
 
@@ -1530,14 +1563,9 @@ fn b_attributes_replace(_interp: &Interpreter, args: &[Arg]) -> SResult<SValue> 
             }
             let mut out = bare;
             for (name, item) in names.iter().zip(items.iter()) {
-                let key = name
-                    .as_deref()
-                    .filter(|s| !s.is_empty())
-                    .ok_or_else(|| {
-                        SError::BadArgs(
-                            "attributes<-: all attributes in the list must be named".into(),
-                        )
-                    })?;
+                let key = name.as_deref().filter(|s| !s.is_empty()).ok_or_else(|| {
+                    SError::BadArgs("attributes<-: all attributes in the list must be named".into())
+                })?;
                 out = set_attr(out, key, item)?;
             }
             Ok(out)

--- a/code/packages/rust/s-runtime/src/dataframe.rs
+++ b/code/packages/rust/s-runtime/src/dataframe.rs
@@ -26,6 +26,7 @@ pub fn column_by_name(value: &SValue, name: &str) -> SResult<SValue> {
             .map(|i| items[i].clone())
             .unwrap_or(SValue::Null)),
         SValue::Classed { inner, .. } => column_by_name(inner, name),
+        SValue::Attributed { inner, .. } => column_by_name(inner, name),
         other => Err(SError::TypeError(format!(
             "$ operator is invalid for {}",
             other.type_name()
@@ -75,6 +76,7 @@ pub fn extract(value: &SValue, key: &SValue) -> SResult<SValue> {
             }
         },
         SValue::Classed { inner, .. } => extract(inner, key),
+        SValue::Attributed { inner, .. } => extract(inner, key),
         other => {
             // `x[[i]]` on a plain vector is single-element extraction.
             let pos = scalar_index(key)?;

--- a/code/packages/rust/s-runtime/src/eval.rs
+++ b/code/packages/rust/s-runtime/src/eval.rs
@@ -346,16 +346,19 @@ impl Interpreter {
         let fn_name = lvalue_name(primary)
             .map_err(|_| SError::TypeError("invalid replacement-function target".into()))?;
 
-        // The call must have exactly one argument, and it must be a bare-name
-        // variable (the object being modified): `names(x) <- v`.
+        // The call must have at least one argument; the *first* is the bare-name
+        // variable being modified (`names(x) <- v`, `attr(x, "foo") <- v`). Any
+        // further arguments (`attr`'s `which`, etc.) are passed through to the
+        // replacement function ahead of `value`, matching R's desugaring
+        // `x <- \`f<-\`(x, <extra args>, value = v)`.
         let arg_values = self.eval_args(call_suffix, env)?;
-        if arg_values.len() != 1 {
+        if arg_values.is_empty() {
             return Err(SError::BadArgs(format!(
-                "{fn_name}(...) <- value: the replacement target must take exactly one argument"
+                "{fn_name}(...) <- value: the replacement target must take at least one argument"
             )));
         }
 
-        // Recover the bare-name of that single argument from the parse tree (we
+        // Recover the bare-name of the *first* argument from the parse tree (we
         // need the *name* to rebind, not just its value).
         let arg_node = call_suffix
             .children
@@ -375,20 +378,23 @@ impl Interpreter {
         let current =
             lookup(env, &target_name).ok_or_else(|| SError::Undefined(target_name.clone()))?;
 
-        // Look up `\`f<-\`` and call it with (current, value = rhs).
+        // Look up `\`f<-\`` and call it with (current, <extra args…>, value = rhs):
+        // the first call arg is replaced by the variable's current value, the
+        // remaining call args (e.g. `which`) pass through unchanged, and the RHS
+        // is appended as the named `value` argument.
         let replacement_name = format!("{fn_name}<-");
         let func = lookup(env, &replacement_name)
             .ok_or_else(|| SError::Undefined(replacement_name.clone()))?;
-        let call_args = [
-            Arg {
-                name: None,
-                value: current,
-            },
-            Arg {
-                name: Some("value".to_string()),
-                value: rhs.clone(),
-            },
-        ];
+        let mut call_args: Vec<Arg> = Vec::with_capacity(arg_values.len() + 1);
+        call_args.push(Arg {
+            name: None,
+            value: current,
+        });
+        call_args.extend(arg_values.into_iter().skip(1));
+        call_args.push(Arg {
+            name: Some("value".to_string()),
+            value: rhs.clone(),
+        });
         let updated = self.call_value(func, &call_args)?;
         define(env, &target_name, updated);
         self.as_invisible(rhs)
@@ -1202,6 +1208,7 @@ pub(crate) fn nth_element(value: &SValue, i: usize) -> SValue {
         },
         SValue::Classed { inner, .. } => nth_element(inner, i),
         SValue::Named { values, .. } => nth_element(values, i),
+        SValue::Attributed { inner, .. } => nth_element(inner, i),
         SValue::List { items, .. } => items.get(i).cloned().unwrap_or(SValue::Null),
         _ => SValue::Null,
     }

--- a/code/packages/rust/s-runtime/src/value.rs
+++ b/code/packages/rust/s-runtime/src/value.rs
@@ -1028,6 +1028,8 @@ pub fn index2d(value: &SValue, rows: Option<&SValue>, cols: Option<&SValue>) -> 
         SValue::Matrix { data, nrow, ncol } => index_matrix_2d(data, *nrow, *ncol, rows, cols),
         SValue::DataFrame { .. } => crate::dataframe::index2d(value, rows, cols),
         SValue::Classed { inner, .. } => index2d(inner, rows, cols),
+        SValue::Attributed { inner, .. } => index2d(inner, rows, cols),
+        SValue::Named { values, .. } => index2d(values, rows, cols),
         other => Err(SError::Index(format!(
             "incorrect number of dimensions for {}",
             other.type_name()
@@ -2108,5 +2110,87 @@ mod tests {
         // A wider value widens the name column too; an unset name prints <NA>.
         let v = SValue::with_names(SValue::doubles(vec![100.0, 2.0]), vec![name("x"), None]);
         assert_eq!(format_value(&v), vec!["  x <NA>", "100    2"]);
+    }
+
+    // --- R-16: general-attribute wrapper mechanics ----------------------
+
+    fn attributed(attrs: Vec<(&str, SValue)>, inner: SValue) -> SValue {
+        SValue::with_general_attrs(
+            inner,
+            attrs.into_iter().map(|(k, v)| (k.to_string(), v)).collect(),
+        )
+    }
+
+    #[test]
+    fn with_general_attrs_drops_empty_and_never_nests() {
+        // An empty attr list returns the bare value (no wrapper).
+        let bare = SValue::with_general_attrs(SValue::scalar(1.0), vec![]);
+        assert!(matches!(bare, SValue::Double(_)));
+        assert!(bare.general_attrs().is_none());
+        // A non-empty list wraps.
+        let v = attributed(vec![("foo", SValue::scalar(9.0))], SValue::scalar(1.0));
+        assert_eq!(v.general_attrs().map(|a| a.len()), Some(1));
+        // Re-wrapping replaces (never nests an Attributed in an Attributed).
+        let v2 = attributed(vec![("bar", SValue::scalar(2.0))], v);
+        if let SValue::Attributed { attrs, inner } = &v2 {
+            assert_eq!(attrs.len(), 1);
+            assert_eq!(attrs[0].0, "bar");
+            assert!(!matches!(**inner, SValue::Attributed { .. }));
+        } else {
+            panic!("expected Attributed");
+        }
+    }
+
+    #[test]
+    fn attributed_is_transparent_to_core_ops() {
+        let v = attributed(
+            vec![("foo", SValue::Character(vec![name("bar")]))],
+            SValue::doubles(vec![1.0, 2.0, 3.0]),
+        );
+        // length / type / class / coercions / truthy all see through.
+        assert_eq!(v.length(), 3);
+        assert_eq!(v.type_name(), "double");
+        assert_eq!(class_of(&v), vec!["numeric"]);
+        assert_eq!(v.as_double().unwrap().data(), &[1.0, 2.0, 3.0]);
+        assert_eq!(
+            v.strip_attrs().as_double().unwrap().data(),
+            &[1.0, 2.0, 3.0]
+        );
+        // Arithmetic sees through and drops the attribute.
+        let r = arithmetic("+", &v, &SValue::scalar(1.0)).unwrap();
+        assert_eq!(dbl(&r), vec![2.0, 3.0, 4.0]);
+        assert!(r.general_attrs().is_none());
+    }
+
+    #[test]
+    fn attributed_index_drops_attrs_but_assign_keeps_them() {
+        let v = attributed(
+            vec![("foo", SValue::scalar(7.0))],
+            SValue::doubles(vec![10.0, 20.0, 30.0]),
+        );
+        // `[` drops general attributes (as in R).
+        let got = index(&v, &SValue::scalar(2.0)).unwrap();
+        assert_eq!(dbl(&got), vec![20.0]);
+        assert!(got.general_attrs().is_none());
+        // `x[i] <- v` keeps them.
+        let assigned = assign_index(&v, Some(&SValue::scalar(1.0)), &SValue::scalar(99.0)).unwrap();
+        assert_eq!(
+            assigned.strip_attrs().as_double().unwrap().data(),
+            &[99.0, 20.0, 30.0]
+        );
+        assert_eq!(assigned.general_attrs().map(|a| a.len()), Some(1));
+    }
+
+    #[test]
+    fn attributed_format_and_compare_see_through() {
+        let v = attributed(
+            vec![("foo", SValue::scalar(1.0))],
+            SValue::Character(vec![name("a"), name("b")]),
+        );
+        // Printing shows the inner value, not the attribute.
+        assert_eq!(format_value(&v), vec!["[1] \"a\" \"b\""]);
+        // String comparison still works through the wrapper.
+        let r = compare("==", &v, &SValue::Character(vec![name("a")])).unwrap();
+        assert!(matches!(&r, SValue::Logical(l) if l[0] == Some(true)));
     }
 }

--- a/code/packages/rust/s-runtime/src/value.rs
+++ b/code/packages/rust/s-runtime/src/value.rs
@@ -118,7 +118,33 @@ pub enum SValue {
         names: Vec<Option<String>>,
         values: Box<SValue>,
     },
+
+    /// A value carrying **general attributes** — R's open key→value metadata map
+    /// (R-16). `attrs` is an insertion-ordered association list of
+    /// `(attribute name, attribute value)` pairs. The *special* attributes
+    /// `names`, `class`, and `dim` are **never** stored here — they keep their
+    /// dedicated representations ([`SValue::Named`], [`SValue::Classed`], and the
+    /// matrix `dim`), so `attr(x, "names")` and `names(x)` can never disagree.
+    ///
+    /// Like [`SValue::Named`] and [`SValue::Classed`], this is a **transparent
+    /// wrapper**: `length`, `type_name`, the coercions, arithmetic, comparison,
+    /// `class_of`, indexing, and printing all see straight through to `inner`.
+    /// Only the attribute builtins (`attr`/`attributes`/`structure`) observe the
+    /// map. The map is bounded by [`MAX_ATTRIBUTES`]; an empty map is never
+    /// constructed (the wrapper is dropped when its last entry is removed).
+    Attributed {
+        attrs: Vec<(String, SValue)>,
+        inner: Box<SValue>,
+    },
 }
+
+/// The largest number of *general* attributes a single value may carry. This
+/// caps memory against a crafted `attributes(x) <- list(...)` (or a tight
+/// `attr<-` loop) that would otherwise grow an unbounded association list. The
+/// special attributes (`names`/`class`/`dim`) are not counted — they live in
+/// their own wrappers — so this bounds only the open metadata map. 4096 is far
+/// beyond any realistic object.
+pub const MAX_ATTRIBUTES: usize = 4096;
 
 impl SValue {
     /// Build a list from `(optional name, value)` pairs.
@@ -173,6 +199,44 @@ impl SValue {
             other => other,
         }
     }
+
+    /// The value underneath a general-attributes wrapper (or the value itself).
+    /// Only peels one [`SValue::Attributed`] layer (constructors never nest one).
+    pub fn strip_attrs(&self) -> &SValue {
+        match self {
+            SValue::Attributed { inner, .. } => inner,
+            other => other,
+        }
+    }
+
+    /// The general (non-special) attributes carried by this value, if any.
+    pub fn general_attrs(&self) -> Option<&[(String, SValue)]> {
+        match self {
+            SValue::Attributed { attrs, .. } => Some(attrs),
+            _ => None,
+        }
+    }
+
+    /// Wrap `inner` with the general-attribute association list `attrs`, dropping
+    /// the wrapper entirely when `attrs` is empty (an empty `Attributed` is never
+    /// constructed). If `inner` is *already* an `Attributed`, the new `attrs`
+    /// replace the old ones (the wrapper never nests). The caller is responsible
+    /// for keeping `attrs` free of the special names (`names`/`class`/`dim`) and
+    /// within [`MAX_ATTRIBUTES`].
+    pub fn with_general_attrs(inner: SValue, attrs: Vec<(String, SValue)>) -> SValue {
+        let inner = match inner {
+            SValue::Attributed { inner, .. } => *inner,
+            other => other,
+        };
+        if attrs.is_empty() {
+            inner
+        } else {
+            SValue::Attributed {
+                attrs,
+                inner: Box::new(inner),
+            }
+        }
+    }
 }
 
 /// The S3 class vector of a value: the explicit class if one was set, otherwise
@@ -192,6 +256,9 @@ pub fn class_of(value: &SValue) -> Vec<String> {
         // A names attribute is transparent to `class()` — see through to the
         // underlying value's class (a named numeric is still `"numeric"`).
         SValue::Named { values, .. } => class_of(values),
+        // General attributes are transparent to `class()` too — the class lives
+        // in `Classed`, not the general map (R-16).
+        SValue::Attributed { inner, .. } => class_of(inner),
     }
 }
 
@@ -220,6 +287,10 @@ impl std::fmt::Debug for SValue {
             SValue::Named { names, values } => {
                 write!(f, "Named({:?}, {values:?})", names)
             }
+            SValue::Attributed { attrs, inner } => {
+                let keys: Vec<&str> = attrs.iter().map(|(k, _)| k.as_str()).collect();
+                write!(f, "Attributed({keys:?}, {inner:?})")
+            }
         }
     }
 }
@@ -232,6 +303,8 @@ fn type_rank(value: &SValue) -> u8 {
         SValue::Character(_) => 2,
         // A names attribute is transparent: rank by the underlying value.
         SValue::Named { values, .. } => type_rank(values),
+        // General attributes are transparent: rank by the underlying value.
+        SValue::Attributed { inner, .. } => type_rank(inner),
         _ => 3, // NULL / functions — not part of the atomic lattice
     }
 }
@@ -261,6 +334,7 @@ impl SValue {
             SValue::List { .. } => "list",
             SValue::Matrix { .. } => "double",
             SValue::Named { values, .. } => values.type_name(),
+            SValue::Attributed { inner, .. } => inner.type_name(),
         }
     }
 
@@ -279,6 +353,7 @@ impl SValue {
             SValue::List { items, .. } => items.len(),
             SValue::Matrix { data, .. } => data.len(),
             SValue::Named { values, .. } => values.length(),
+            SValue::Attributed { inner, .. } => inner.length(),
         }
     }
 
@@ -303,6 +378,7 @@ impl SValue {
             SValue::Null => Ok(Double::from_values(vec![])),
             SValue::Classed { inner, .. } => inner.as_double(),
             SValue::Named { values, .. } => values.as_double(),
+            SValue::Attributed { inner, .. } => inner.as_double(),
             SValue::Matrix { data, .. } => Ok(data.clone()),
             other => Err(SError::TypeError(format!(
                 "non-numeric argument (got {})",
@@ -323,6 +399,7 @@ impl SValue {
             SValue::Null => Ok(vec![]),
             SValue::Classed { inner, .. } => inner.as_logical(),
             SValue::Named { values, .. } => values.as_logical(),
+            SValue::Attributed { inner, .. } => inner.as_logical(),
             SValue::Matrix { data, .. } => Ok(data
                 .iter()
                 .map(|x| if is_na_real(x) { None } else { Some(x != 0.0) })
@@ -365,6 +442,7 @@ impl SValue {
             SValue::Factor { codes, levels } => SValue::factor_labels(codes, levels),
             SValue::Classed { inner, .. } => inner.as_character(),
             SValue::Named { values, .. } => values.as_character(),
+            SValue::Attributed { inner, .. } => inner.as_character(),
             SValue::Matrix { data, .. } => data
                 .iter()
                 .map(|x| {
@@ -399,6 +477,7 @@ impl SValue {
             },
             SValue::Classed { inner, .. } => inner.truthy(),
             SValue::Named { values, .. } => values.truthy(),
+            SValue::Attributed { inner, .. } => inner.truthy(),
             SValue::Matrix { data, .. } => SValue::Double(data.clone()).truthy(),
             other => Err(SError::TypeError(format!(
                 "argument is not interpretable as logical (got {})",
@@ -473,10 +552,11 @@ pub fn combine(args: &[Arg]) -> SValue {
             SValue::Character(out)
         }
         0 => {
-            // all logical: concatenate logical payloads (seeing through names).
+            // all logical: concatenate logical payloads (seeing through any
+            // names or general-attribute wrapper).
             let mut out = Vec::new();
             for (_, v) in &present {
-                if let SValue::Logical(l) = v.strip_names() {
+                if let SValue::Logical(l) = v.strip_names().strip_attrs() {
                     out.extend(l.iter().cloned());
                 }
             }
@@ -635,8 +715,12 @@ pub fn membership(lhs: &SValue, rhs: &SValue) -> SValue {
 /// compare numerically; if either side is character, both are compared as
 /// strings (S's coercion for relational operators).
 pub fn compare(op: &str, lhs: &SValue, rhs: &SValue) -> SResult<SValue> {
-    // See through any names attribute before deciding numeric vs string compare.
-    let (lhs, rhs) = (lhs.strip_names(), rhs.strip_names());
+    // See through any names / general-attribute wrapper before deciding numeric
+    // vs string compare.
+    let (lhs, rhs) = (
+        lhs.strip_names().strip_attrs(),
+        rhs.strip_names().strip_attrs(),
+    );
     let either_char = matches!(lhs, SValue::Character(_)) || matches!(rhs, SValue::Character(_));
 
     if either_char {
@@ -862,6 +946,13 @@ pub fn index(base: &SValue, idx: &SValue) -> SResult<SValue> {
         return index(&SValue::Double(data.clone()), idx);
     }
 
+    // A value carrying **general attributes**: `[` drops them in R, so index the
+    // underlying value directly (names/dim, living in their own wrappers, are
+    // handled by the arms above/below).
+    if let SValue::Attributed { inner, .. } = base {
+        return index(inner, idx);
+    }
+
     // A **named** vector: index the underlying value, then carry the selected
     // names along (R keeps names through `[`). Character indices resolve by name.
     if let SValue::Named { names, values } = base {
@@ -1058,6 +1149,12 @@ pub fn assign_index(base: &SValue, idx: Option<&SValue>, rhs: &SValue) -> SResul
             inner: Box::new(assign_index(inner, idx, rhs)?),
             class: class.clone(),
         }),
+        // A value with general attributes: write through to the inner value and
+        // keep the attributes (R preserves them across `x[i] <- v`).
+        SValue::Attributed { attrs, inner } => Ok(SValue::Attributed {
+            attrs: attrs.clone(),
+            inner: Box::new(assign_index(inner, idx, rhs)?),
+        }),
         // A named vector: write into the underlying value (resolving a character
         // subscript by name) and keep the names attribute. The selection length
         // is bounded, so this is the same write count as the unnamed path.
@@ -1221,6 +1318,8 @@ pub fn format_value(value: &SValue) -> Vec<String> {
         SValue::List { names, items } => return format_list(names, items),
         SValue::Matrix { data, nrow, ncol } => return format_matrix(data, *nrow, *ncol),
         SValue::Named { names, values } => return format_named(names, values),
+        // General attributes are transparent to printing — show the inner value.
+        SValue::Attributed { inner, .. } => return format_value(inner),
     };
 
     format_vector(&elems)
@@ -1387,6 +1486,7 @@ pub fn element_string(value: &SValue, i: usize) -> String {
             .unwrap_or_else(|| "NA".into()),
         SValue::Classed { inner, .. } => element_string(inner, i),
         SValue::Named { values, .. } => element_string(values, i),
+        SValue::Attributed { inner, .. } => element_string(inner, i),
         _ => "NA".into(),
     }
 }

--- a/code/specs/R00-r-language.md
+++ b/code/specs/R00-r-language.md
@@ -237,6 +237,61 @@ unchanged.
     character-index path reuses the bounds-checked `resolve_picks`. No new
     unbounded allocation or integer-overflow surface is introduced.
 
+- **R-16 — general attributes** *(this PR)*. R's *general attribute system* — the
+  open key→value metadata map every object carries — in the shared `s-runtime`.
+  R-15 modelled the one special attribute it needed (`names`) as a transparent
+  `SValue::Named` wrapper; R-16 generalizes that to **arbitrary** attributes while
+  keeping the three *special* attributes — `names`, `class`, `dim` — routed to
+  their existing dedicated representations so they can never disagree with the
+  wrappers built for them in R-11/R-15/S v2.
+  - **Representation.** A new transparent wrapper
+    `SValue::Attributed { attrs: Vec<(String, SValue)>, inner }` stores the
+    *general* (non-special) attributes as an insertion-ordered association list
+    beside a boxed inner value — the same "see-through" pattern as `Named` and
+    `Classed` (`length`, `type_name`, the coercions, arithmetic, comparison,
+    `class`, indexing, and printing all delegate to `inner`; only the attribute
+    builtins observe the map). The three special attributes are **never** stored
+    in this map: `names` lives in `SValue::Named`, `class` in `SValue::Classed`,
+    and `dim` is the `nrow`/`ncol` of `SValue::Matrix` (and the implicit
+    `c(nrow, ncol)` of a data frame). This makes the consistency invariant
+    structural rather than a runtime check — `attr(x, "names")` *is*
+    `names(x)` because both read the very same `Named.names` field, and likewise
+    for `class`/`dim`.
+  - **`attr(x, which)`** returns the named attribute or `NULL` if absent. The
+    special names are synthesized from the wrappers (`"names"` → the names vector,
+    `"class"` → the explicit class if one was set, `"dim"` → `c(nrow, ncol)`);
+    everything else is looked up in the general map. **`attr(x, which) <- value`**
+    is the replacement form, wired through R-15's general replacement-function
+    lvalue path (`attr(x, "foo") <- v` desugars to
+    `x <- \`attr<-\`(x, "foo", v)`). Assigning `NULL` **removes** the attribute
+    (clears the `Named`/`Classed`/`Matrix`-derived wrapper for a special name, or
+    drops the entry — and the whole `Attributed` wrapper when its last entry goes
+    — for a general one). Setting `"names"`/`"class"` routes to the same
+    `with_names`/`Classed` machinery `names<-`/`structure` use; setting `"dim"`
+    reshapes a length-`nrow*ncol` vector into a matrix (the product must equal the
+    element count, as in R).
+  - **`attributes(x)`** returns *all* attributes as a named `list` (special ones
+    first, in R's canonical `names`, `dim`, then-general order, with `class`
+    last), or `NULL` when the value has none. **`attributes(x) <- list(...)`**
+    replaces the whole set: each named element is applied as the corresponding
+    attribute (special names routed, the rest stored generally); `NULL` clears
+    every attribute. An unnamed element, or a `value` that is not a list (other
+    than `NULL`), is an error.
+  - **`structure(x, ...)`** returns `x` with each `...` named argument attached as
+    an attribute (`structure(1:3, class = "myc", foo = "bar")`). R-16 extends the
+    v2 `structure` (which handled only `class`) to route every named argument
+    through the same per-name logic as `attr<-`, so `dim`, `names`, and arbitrary
+    attributes all attach correctly in one call. The `.Names`/`.Dim` aliases R
+    accepts for `names`/`dim` inside `structure` are honoured.
+  - **Safety.** The general attribute map is bounded: a per-object cap
+    (`MAX_ATTRIBUTES`) refuses runaway `attr<-`/`attributes<-`/`structure` growth
+    (a crafted `attributes(x) <- list` with millions of entries), and a `"dim"`
+    set validates the reshape length with checked multiplication against
+    `MAX_SEQ_LEN` before allocating, reusing the existing matrix bound. No
+    `unwrap`/panic is reachable from malformed `attributes(x) <- …` input — a
+    non-list `value`, an unnamed element, a too-long `names`, or a non-conforming
+    `dim` all return a clean `SError`.
+
 ## §4 Reuse strategy
 
 - **Lexer/parser:** the grammar-tools framework, exactly as S uses it. `r.tokens`

--- a/code/specs/S00-s-language.md
+++ b/code/specs/S00-s-language.md
@@ -316,6 +316,31 @@ NA-padding recycling (too-short pads with `NA`, `NULL` clears) via a general
 name (unmatched → `NA`). A named vector prints names above values in aligned
 columns instead of the `[i]` prefix.
 
+### V2.8 General attributes (`attr`, `attributes`, `structure`)
+
+V2.7's `names` is *one* attribute; V2.8 adds the **general attribute system** —
+the open key→value metadata map R attaches to any object. The *special*
+attributes `names`, `class`, and `dim` keep their dedicated representations
+(`SValue::Named`, `SValue::Classed`, `SValue::Matrix`); a new transparent wrapper
+`SValue::Attributed { attrs: Vec<(String, SValue)>, inner }` stores every *other*
+attribute as an insertion-ordered association list. Like `Named`/`Classed` it is
+**see-through** (`length`, `type_name`, coercions, arithmetic, comparison,
+`class`, indexing, printing all delegate to `inner`); only the attribute builtins
+read the map.
+
+Because the three special attributes are *never* duplicated into the general map,
+the consistency invariant is structural: `attr(x, "names")` reads the same field
+`names(x)` does, `attr(x, "class")` agrees with `class(x)`/`class_of`, and
+`attr(x, "dim")` agrees with the matrix `dim` (R-11). `attr(x, which)` gets one
+attribute (or `NULL`); `attr(x, which) <- value` sets/replaces it (`NULL`
+removes) through the V2.7 replacement-function lvalue path (`\`attr<-\``).
+`attributes(x)` returns all attributes as a named list (or `NULL`);
+`attributes(x) <- list(...)` replaces them. `structure(x, ...)` attaches each
+named `...` argument as an attribute, routing special names appropriately. The
+general map is bounded (`MAX_ATTRIBUTES`) and a `"dim"` reshape is length-checked
+against `MAX_SEQ_LEN`, so attacker-controlled attribute input cannot exhaust
+memory or panic.
+
 ## §9 Divergences from ST00 (spec-sync)
 
 1. **S before R.** ST00 specs R first; we implement historical S first. The two


### PR DESCRIPTION
## R-16 — general attributes

Implements R's general attribute system in the shared `s-runtime` (with `r-runtime` reaching it unchanged through the existing reuse), per `R00`/`S00`:

- `attr(x, which)` — get a named attribute (`NULL` if absent).
- `attr(x, which) <- value` — set/replace/remove (assigning `NULL` removes).
- `attributes(x)` — all attributes as a named list (`NULL` if none); `attributes(x) <- list(...)` replaces them (`NULL` clears).
- `structure(x, ...)` — return `x` with the `...` named args attached as attributes (extends the v2 `class`-only `structure`).

### Design choice (special-attribute consistency)

The three **special** attributes keep their existing dedicated representations and are **never** duplicated into a general map:

| attribute | lives in | get reads | set routes to |
|-----------|----------|-----------|---------------|
| `names` | `SValue::Named` (R-15) | `names(x)` | `with_names` |
| `class` | `SValue::Classed` (S v2) | `class_of` (explicit) | `Classed` / `unclass` |
| `dim` | `SValue::Matrix{nrow,ncol}` (R-11) | `c(nrow, ncol)` | length-checked reshape into a `Matrix` |

All **other** attributes live in a new transparent wrapper `SValue::Attributed { attrs, inner }` (an insertion-ordered association list), mirroring the see-through pattern of `Named`/`Classed`. Because the special ones are routed rather than copied, the consistency invariant is **structural**: `attr(x, "names")` reads the same field as `names(x)`, `attr(x, "class")` agrees with `class(x)`/`class_of`, and `attr(x, "dim")` agrees with the matrix `dim` — even after layering a class on a matrix. `dim`/`nrow`/`ncol`/`levels` were taught to peel the new wrappers so a classed/attributed matrix/factor still reports its shape.

`attr<-`/`attributes<-` slot into R-15's replacement-function lvalue path, which was **generalized** to thread extra call arguments through (`attr(x, "foo") <- v` ≡ `` x <- `attr<-`(x, "foo", value = v) ``).

### Tests

- `s-runtime` unit tests for the `Attributed` wrapper: empty-drop / never-nest, transparency to length/type/class/coercions/arithmetic, `[` drops attrs while `x[i] <-` keeps them, format/compare see-through.
- `r-runtime` R-syntax integration tests: `attr` get/set/remove, `structure`, `attributes` get/set, the consistency of `names`/`class`/`dim` as attributes (incl. after layering class on a matrix), malformed-input errors, and regressions that R-15 named vectors, S3 class, factors, and data frames still work.
- `cargo test -p coding-adventures-s-runtime -p coding-adventures-r-runtime`: **132 + 80 + 2 doctests, all green**. `cargo clippy` clean for both crates; `git diff` is functional-only (rustfmt 1.9.0 clean on changed regions).

### Security review

No `Agent` tool was available in this environment, so the review was performed inline (per the task fallback). Focus areas and outcome:

- **Unbounded attribute-map growth (DoS):** mitigated — `set_general_attr` caps new pushes at `MAX_ATTRIBUTES` (4096); `attributes<-` checks `list` length upfront; `structure` iterates parse-bounded args.
- **Panics/unwrap on malformed `attributes(x) <- …`:** none — no `unwrap`/`expect`/`panic` in new non-test code; a non-list value, an unnamed element, a too-long `names`, a non-integer/NA/negative `dim` component, and a non-conforming `dim` product all return a clean `SError` (verified with an adversarial smoke test).
- **Integer/length issues for `dim`/`names`:** `dim_component` validates finite/non-negative/integer before the `as usize` cast (which saturates rather than UB), then `checked_mul` against `MAX_SEQ_LEN` before allocating; `names`/`dim` lengths are validated against the element count.
- **Recursion depth:** wrappers are flattened by their constructors (never nest same-kind), so the peel/get/strip recursion is constant-bounded; no attacker-controllable deep nesting.

**Result: SECURITY REVIEW PASSED — no vulnerabilities found (design is bounded and fails closed).**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
