### PR TITLE
Accept control wrdata markers

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 ### Added
 
+- **Deck control WRDATA marker routing** —
+  `analyze_deck_controls()` and `resolve_deck_sources()` now accept selected
+  `.control` block `wrdata <file> <probes...>` ASCII data-write markers as
+  no-op control commands instead of reporting unsupported-command diagnostics,
+  matching Rust and TypeScript. Actual data-file serialization remains out of
+  scope for this marker.
+
 - **Deck control rawfile write marker routing** —
   `analyze_deck_controls()` and `resolve_deck_sources()` now accept selected
   `.control` block `write <rawfile> [probes...]` rawfile-write markers as

--- a/code/packages/python/spice-engine/README.md
+++ b/code/packages/python/spice-engine/README.md
@@ -165,8 +165,9 @@ dotted deck cards, while `run`, `reset`, `quit`, and the UI-only
 `set noaskquit` option plus the ASCII rawfile-format `set filetype=ascii`
 option, vector-name/single-scale rawfile output toggles (`set wr_vecnames`,
 `set wr_singlescale`), and the append-write rawfile option (`set appendwrite`)
-plus target-bearing rawfile-write markers (`write <rawfile> [probes...]`) are
-accepted as no-op control markers. Other
+plus target-bearing rawfile-write markers (`write <rawfile> [probes...]`) and
+ASCII data-write markers (`wrdata <file> <probes...>`) are accepted as no-op
+control markers. Other
 unrecognized non-comment commands emit diagnostics until a broader executed
 control subset is in scope.
 `resolve_deck_sources()` is the first include/library resolution layer: callers

--- a/code/packages/python/spice-engine/src/spice_engine/compatibility.py
+++ b/code/packages/python/spice-engine/src/spice_engine/compatibility.py
@@ -519,6 +519,7 @@ _NOOP_CONTROL_BLOCK_COMMANDS = frozenset(
     {"run", ".run", "reset", ".reset", "quit", ".quit"}
 )
 _NOOP_CONTROL_BLOCK_ARGUMENT_COMMANDS = frozenset({"write", ".write"})
+_NOOP_CONTROL_BLOCK_VECTOR_ARGUMENT_COMMANDS = frozenset({"wrdata", ".wrdata"})
 _NOOP_CONTROL_BLOCK_SET_OPTIONS = frozenset(
     {"noaskquit", "filetype=ascii", "wr_vecnames", "wr_singlescale", "appendwrite"}
 )
@@ -3354,6 +3355,8 @@ def _is_noop_control_block_command(line: str) -> bool:
         return True
     if command in _NOOP_CONTROL_BLOCK_ARGUMENT_COMMANDS:
         return len(parts) >= 2
+    if command in _NOOP_CONTROL_BLOCK_VECTOR_ARGUMENT_COMMANDS:
+        return len(parts) >= 3
     return (
         command in {"set", ".set"}
         and len(parts) == 2

--- a/code/packages/python/spice-engine/tests/test_compatibility.py
+++ b/code/packages/python/spice-engine/tests/test_compatibility.py
@@ -127,6 +127,8 @@ set wr_singlescale
 set appendwrite
 set filetype=binary
 write out.raw V(out)
+wrdata out.dat V(out)
+wrdata empty.dat
 run
 quit
 .endc
@@ -152,11 +154,13 @@ quit
         (".lib", 3, "error"),
         (".control", 4, "error"),
         (".control", 19, "error"),
+        (".control", 22, "error"),
     ]
     assert [diag.code for diag in summary.diagnostics] == [
         "SPICE_DECK_UNSUPPORTED_DIRECTIVE",
         "SPICE_DECK_UNSUPPORTED_DIRECTIVE",
         "SPICE_DECK_UNSUPPORTED_DIRECTIVE",
+        "SPICE_DECK_CONTROL_COMMAND",
         "SPICE_DECK_CONTROL_COMMAND",
     ]
     measurement_summary = resolve_deck_measurements("\n".join(summary.active_lines) + "\n.end")
@@ -242,6 +246,7 @@ four 2k V(b)
 .set wr_singlescale
 .set appendwrite
 .write out.raw V(a)
+.wrdata out.dat V(a)
 run
 .quit
 .endc

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Accept selected `.control` block `wrdata <file> <probes...>` ASCII
+  data-write markers as no-op control commands in `analyze_deck_controls` and
+  `resolve_deck_sources`, matching Python and TypeScript. Actual data-file
+  serialization remains out of scope for this marker.
 - Accept selected `.control` block `write <rawfile> [probes...]` rawfile-write
   markers as no-op control commands in `analyze_deck_controls` and
   `resolve_deck_sources`, matching Python and TypeScript. Rawfile

--- a/code/packages/rust/spice-engine/README.md
+++ b/code/packages/rust/spice-engine/README.md
@@ -132,8 +132,9 @@ dotted deck cards, while `run`, `reset`, `quit`, and the UI-only
 `set noaskquit` option plus the ASCII rawfile-format `set filetype=ascii`
 option, vector-name/single-scale rawfile output toggles (`set wr_vecnames`,
 `set wr_singlescale`), and the append-write rawfile option (`set appendwrite`)
-plus target-bearing rawfile-write markers (`write <rawfile> [probes...]`) are
-accepted as no-op control markers. Other
+plus target-bearing rawfile-write markers (`write <rawfile> [probes...]`) and
+ASCII data-write markers (`wrdata <file> <probes...>`) are accepted as no-op
+control markers. Other
 unrecognized non-comment commands emit diagnostics until a broader executed
 control subset is in scope.
 `resolve_deck_sources` is the first include/library resolution layer: callers

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -6916,6 +6916,9 @@ fn is_noop_control_block_command(line: &str) -> bool {
     if matches!(command.as_str(), "write" | ".write") {
         return parts.next().is_some();
     }
+    if matches!(command.as_str(), "wrdata" | ".wrdata") {
+        return parts.nth(1).is_some();
+    }
     if !matches!(command.as_str(), "set" | ".set") {
         return false;
     }

--- a/code/packages/rust/spice-engine/tests/compatibility_tests.rs
+++ b/code/packages/rust/spice-engine/tests/compatibility_tests.rs
@@ -144,6 +144,8 @@ set wr_singlescale
 set appendwrite
 set filetype=binary
 write out.raw V(out)
+wrdata out.dat V(out)
+wrdata empty.dat
 run
 quit
 .endc
@@ -184,7 +186,8 @@ quit
             (".include", 2, "error"),
             (".lib", 3, "error"),
             (".control", 4, "error"),
-            (".control", 19, "error")
+            (".control", 19, "error"),
+            (".control", 22, "error")
         ]
     );
     assert_eq!(
@@ -197,6 +200,7 @@ quit
             "SPICE_DECK_UNSUPPORTED_DIRECTIVE",
             "SPICE_DECK_UNSUPPORTED_DIRECTIVE",
             "SPICE_DECK_UNSUPPORTED_DIRECTIVE",
+            "SPICE_DECK_CONTROL_COMMAND",
             "SPICE_DECK_CONTROL_COMMAND"
         ]
     );
@@ -334,6 +338,7 @@ four 2k V(b)
 .set wr_singlescale
 .set appendwrite
 .write out.raw V(a)
+.wrdata out.dat V(a)
 run
 .quit
 .endc

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Accept selected `.control` block `wrdata <file> <probes...>` ASCII
+  data-write markers as no-op control commands in `analyzeDeckControls` and
+  `resolveDeckSources`, matching Python and Rust. Actual data-file
+  serialization remains out of scope for this marker.
 - Accept selected `.control` block `write <rawfile> [probes...]` rawfile-write
   markers as no-op control commands in `analyzeDeckControls` and
   `resolveDeckSources`, matching Python and Rust. Rawfile serialization remains

--- a/code/packages/typescript/spice-engine/README.md
+++ b/code/packages/typescript/spice-engine/README.md
@@ -139,8 +139,9 @@ dotted deck cards, while `run`, `reset`, `quit`, and the UI-only
 `set noaskquit` option plus the ASCII rawfile-format `set filetype=ascii`
 option, vector-name/single-scale rawfile output toggles (`set wr_vecnames`,
 `set wr_singlescale`), and the append-write rawfile option (`set appendwrite`)
-plus target-bearing rawfile-write markers (`write <rawfile> [probes...]`) are
-accepted as no-op control markers. Other
+plus target-bearing rawfile-write markers (`write <rawfile> [probes...]`) and
+ASCII data-write markers (`wrdata <file> <probes...>`) are accepted as no-op
+control markers. Other
 unrecognized non-comment commands emit diagnostics until a broader executed
 control subset is in scope.
 `resolveDeckSources` is the first include/library resolution layer: callers

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -2856,6 +2856,7 @@ const SUPPORTED_CONTROL_BLOCK_COMMANDS = new Set([
 ]);
 const NOOP_CONTROL_BLOCK_COMMANDS = new Set(["run", ".run", "reset", ".reset", "quit", ".quit"]);
 const NOOP_CONTROL_BLOCK_ARGUMENT_COMMANDS = new Set(["write", ".write"]);
+const NOOP_CONTROL_BLOCK_VECTOR_ARGUMENT_COMMANDS = new Set(["wrdata", ".wrdata"]);
 const NOOP_CONTROL_BLOCK_SET_OPTIONS = new Set([
   "noaskquit",
   "filetype=ascii",
@@ -5730,6 +5731,9 @@ function isNoopControlBlockCommand(line: string): boolean {
   }
   if (NOOP_CONTROL_BLOCK_ARGUMENT_COMMANDS.has(command)) {
     return parts.length >= 2;
+  }
+  if (NOOP_CONTROL_BLOCK_VECTOR_ARGUMENT_COMMANDS.has(command)) {
+    return parts.length >= 3;
   }
   return (
     (command === "set" || command === ".set") &&

--- a/code/packages/typescript/spice-engine/tests/compatibility.test.ts
+++ b/code/packages/typescript/spice-engine/tests/compatibility.test.ts
@@ -131,6 +131,8 @@ set wr_singlescale
 set appendwrite
 set filetype=binary
 write out.raw V(out)
+wrdata out.dat V(out)
+wrdata empty.dat
 run
 quit
 .endc
@@ -159,11 +161,13 @@ quit
       [".lib", 3, "error"],
       [".control", 4, "error"],
       [".control", 19, "error"],
+      [".control", 22, "error"],
     ]);
     expect(summary.diagnostics.map((diagnostic) => diagnostic.code)).toStrictEqual([
       "SPICE_DECK_UNSUPPORTED_DIRECTIVE",
       "SPICE_DECK_UNSUPPORTED_DIRECTIVE",
       "SPICE_DECK_UNSUPPORTED_DIRECTIVE",
+      "SPICE_DECK_CONTROL_COMMAND",
       "SPICE_DECK_CONTROL_COMMAND",
     ]);
     const measurementSummary = resolveDeckMeasurements(`${summary.activeLines.join("\n")}\n.end`);
@@ -249,6 +253,7 @@ four 2k V(b)
 .set wr_singlescale
 .set appendwrite
 .write out.raw V(a)
+.wrdata out.dat V(a)
 run
 .quit
 .endc

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -40,8 +40,9 @@ downstream tools to compare.
      `set noaskquit` options plus ASCII rawfile-format `set filetype=ascii`
      options, rawfile vector-name/single-scale toggles (`set wr_vecnames`,
      `set wr_singlescale`), and rawfile append-write `set appendwrite` options
-     plus target-bearing rawfile `write <rawfile> [probes...]` markers are
-     accepted as no-op control markers; parsed
+     plus target-bearing rawfile `write <rawfile> [probes...]` markers and
+     ASCII data-write `wrdata <file> <probes...>` markers are accepted as
+     no-op control markers; parsed
      `.measure dc` / `.meas dc` cards now route DC sweep probe samples into
      the shared scalar measurement table surface;
      parsed `.measure ac` / `.meas ac` cards now route AC probe magnitudes over
@@ -616,6 +617,17 @@ downstream tools to compare.
       commands, other `set` variables, and unrecognized non-comment commands
       inside `.control` blocks remain diagnostic-only so unsupported file I/O
       and script state are explicit.
+
+56. Selected `.control` WRDATA marker routing.
+    - Status: completed in this selected control WRDATA marker routing slice.
+    - Python, Rust, and TypeScript now accept selected `.control` block
+      `wrdata <file> <probes...>` ASCII data-write markers as no-op control
+      commands when both a target path token and at least one vector/probe token
+      are present.
+    - Actual ASCII data-file serialization, rawfile serialization, binary
+      rawfile formats, other file-writing commands, other `set` variables, and
+      unrecognized non-comment commands inside `.control` blocks remain
+      diagnostic-only so unsupported file I/O and script state are explicit.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- Accept selected `.control` block `wrdata <file> <probes...>` commands as no-op ASCII data-write markers across Python, Rust, and TypeScript.
- Keep empty `wrdata <file>` commands diagnostic-only by requiring at least one vector/probe token.
- Update package docs/changelogs and mark SPICE plan slice 56 complete while keeping actual file serialization out of scope.

## Tests
- `/Users/adhithya/.local/share/mise/installs/python/3.12.13/bin/ruff check code/packages/python/spice-engine/src/spice_engine/compatibility.py code/packages/python/spice-engine/tests/test_compatibility.py`
- `PYTEST_ADDOPTS=--no-cov PYTHONPATH=code/packages/python/device-physics/src:code/packages/python/mosfet-models/src:code/packages/python/spice-engine/src /Users/adhithya/.local/share/mise/installs/python/3.12.13/bin/python3.12 -m pytest code/packages/python/spice-engine/tests/test_compatibility.py -q`
- `PYTHONPATH=code/packages/python/device-physics/src:code/packages/python/mosfet-models/src:code/packages/python/spice-engine/src /Users/adhithya/.local/share/mise/installs/python/3.12.13/bin/python3.12 -m pytest code/packages/python/spice-engine/tests -q`
- `cargo fmt --manifest-path code/packages/rust/spice-engine/Cargo.toml -- --check`
- `cargo test --manifest-path code/packages/rust/spice-engine/Cargo.toml --test compatibility_tests`
- `cargo test --manifest-path code/packages/rust/spice-engine/Cargo.toml`
- `PATH=/Users/adhithya/.local/share/mise/installs/node/22.22.3/bin:$PATH npm --prefix code/packages/typescript/spice-engine ci`
- `PATH=/Users/adhithya/.local/share/mise/installs/node/22.22.3/bin:$PATH npm --prefix code/packages/typescript/spice-engine run build`
- `PATH=/Users/adhithya/.local/share/mise/installs/node/22.22.3/bin:$PATH npm --prefix code/packages/typescript/spice-engine test -- compatibility`
- `PATH=/Users/adhithya/.local/share/mise/installs/node/22.22.3/bin:$PATH npm --prefix code/packages/typescript/spice-engine test`
- `git diff --check`