### PR TITLE
Accept control inspection markers

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 ### Added
 
+- **Deck control inspection marker routing** —
+  `analyze_deck_controls()` and `resolve_deck_sources()` now accept selected
+  `.control` block read-only `display` and `listing` inspection commands as
+  no-op control commands instead of reporting unsupported-command diagnostics,
+  matching Rust and TypeScript. Actual console/listing output remains out of
+  scope for these markers.
+
 - **Deck control WRDATA marker routing** —
   `analyze_deck_controls()` and `resolve_deck_sources()` now accept selected
   `.control` block `wrdata <file> <probes...>` ASCII data-write markers as

--- a/code/packages/python/spice-engine/README.md
+++ b/code/packages/python/spice-engine/README.md
@@ -167,7 +167,8 @@ option, vector-name/single-scale rawfile output toggles (`set wr_vecnames`,
 `set wr_singlescale`), and the append-write rawfile option (`set appendwrite`)
 plus target-bearing rawfile-write markers (`write <rawfile> [probes...]`) and
 ASCII data-write markers (`wrdata <file> <probes...>`) are accepted as no-op
-control markers. Other
+control markers. Read-only control inspection commands (`display` and
+`listing`) are also accepted as no-op markers. Other
 unrecognized non-comment commands emit diagnostics until a broader executed
 control subset is in scope.
 `resolve_deck_sources()` is the first include/library resolution layer: callers

--- a/code/packages/python/spice-engine/src/spice_engine/compatibility.py
+++ b/code/packages/python/spice-engine/src/spice_engine/compatibility.py
@@ -516,7 +516,18 @@ _SUPPORTED_CONTROL_BLOCK_COMMANDS = frozenset(
     }
 )
 _NOOP_CONTROL_BLOCK_COMMANDS = frozenset(
-    {"run", ".run", "reset", ".reset", "quit", ".quit"}
+    {
+        "display",
+        ".display",
+        "listing",
+        ".listing",
+        "run",
+        ".run",
+        "reset",
+        ".reset",
+        "quit",
+        ".quit",
+    }
 )
 _NOOP_CONTROL_BLOCK_ARGUMENT_COMMANDS = frozenset({"write", ".write"})
 _NOOP_CONTROL_BLOCK_VECTOR_ARGUMENT_COMMANDS = frozenset({"wrdata", ".wrdata"})

--- a/code/packages/python/spice-engine/tests/test_compatibility.py
+++ b/code/packages/python/spice-engine/tests/test_compatibility.py
@@ -129,6 +129,8 @@ set filetype=binary
 write out.raw V(out)
 wrdata out.dat V(out)
 wrdata empty.dat
+display all
+listing physical
 run
 quit
 .endc
@@ -247,6 +249,8 @@ four 2k V(b)
 .set appendwrite
 .write out.raw V(a)
 .wrdata out.dat V(a)
+.display all
+.listing deck
 run
 .quit
 .endc

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Accept selected `.control` block read-only `display` and `listing`
+  inspection commands as no-op control commands in `analyze_deck_controls` and
+  `resolve_deck_sources`, matching Python and TypeScript. Actual
+  console/listing output remains out of scope for these markers.
 - Accept selected `.control` block `wrdata <file> <probes...>` ASCII
   data-write markers as no-op control commands in `analyze_deck_controls` and
   `resolve_deck_sources`, matching Python and TypeScript. Actual data-file

--- a/code/packages/rust/spice-engine/README.md
+++ b/code/packages/rust/spice-engine/README.md
@@ -134,7 +134,8 @@ option, vector-name/single-scale rawfile output toggles (`set wr_vecnames`,
 `set wr_singlescale`), and the append-write rawfile option (`set appendwrite`)
 plus target-bearing rawfile-write markers (`write <rawfile> [probes...]`) and
 ASCII data-write markers (`wrdata <file> <probes...>`) are accepted as no-op
-control markers. Other
+control markers. Read-only control inspection commands (`display` and
+`listing`) are also accepted as no-op markers. Other
 unrecognized non-comment commands emit diagnostics until a broader executed
 control subset is in scope.
 `resolve_deck_sources` is the first include/library resolution layer: callers

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -6909,7 +6909,16 @@ fn is_noop_control_block_command(line: &str) -> bool {
     };
     if matches!(
         command.as_str(),
-        "run" | ".run" | "reset" | ".reset" | "quit" | ".quit"
+        "display"
+            | ".display"
+            | "listing"
+            | ".listing"
+            | "run"
+            | ".run"
+            | "reset"
+            | ".reset"
+            | "quit"
+            | ".quit"
     ) {
         return true;
     }

--- a/code/packages/rust/spice-engine/tests/compatibility_tests.rs
+++ b/code/packages/rust/spice-engine/tests/compatibility_tests.rs
@@ -146,6 +146,8 @@ set filetype=binary
 write out.raw V(out)
 wrdata out.dat V(out)
 wrdata empty.dat
+display all
+listing physical
 run
 quit
 .endc
@@ -339,6 +341,8 @@ four 2k V(b)
 .set appendwrite
 .write out.raw V(a)
 .wrdata out.dat V(a)
+.display all
+.listing deck
 run
 .quit
 .endc

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Accept selected `.control` block read-only `display` and `listing`
+  inspection commands as no-op control commands in `analyzeDeckControls` and
+  `resolveDeckSources`, matching Python and Rust. Actual console/listing
+  output remains out of scope for these markers.
 - Accept selected `.control` block `wrdata <file> <probes...>` ASCII
   data-write markers as no-op control commands in `analyzeDeckControls` and
   `resolveDeckSources`, matching Python and Rust. Actual data-file

--- a/code/packages/typescript/spice-engine/README.md
+++ b/code/packages/typescript/spice-engine/README.md
@@ -141,7 +141,8 @@ option, vector-name/single-scale rawfile output toggles (`set wr_vecnames`,
 `set wr_singlescale`), and the append-write rawfile option (`set appendwrite`)
 plus target-bearing rawfile-write markers (`write <rawfile> [probes...]`) and
 ASCII data-write markers (`wrdata <file> <probes...>`) are accepted as no-op
-control markers. Other
+control markers. Read-only control inspection commands (`display` and
+`listing`) are also accepted as no-op markers. Other
 unrecognized non-comment commands emit diagnostics until a broader executed
 control subset is in scope.
 `resolveDeckSources` is the first include/library resolution layer: callers

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -2854,7 +2854,18 @@ const SUPPORTED_CONTROL_BLOCK_COMMANDS = new Set([
   "plot",
   ".plot",
 ]);
-const NOOP_CONTROL_BLOCK_COMMANDS = new Set(["run", ".run", "reset", ".reset", "quit", ".quit"]);
+const NOOP_CONTROL_BLOCK_COMMANDS = new Set([
+  "display",
+  ".display",
+  "listing",
+  ".listing",
+  "run",
+  ".run",
+  "reset",
+  ".reset",
+  "quit",
+  ".quit",
+]);
 const NOOP_CONTROL_BLOCK_ARGUMENT_COMMANDS = new Set(["write", ".write"]);
 const NOOP_CONTROL_BLOCK_VECTOR_ARGUMENT_COMMANDS = new Set(["wrdata", ".wrdata"]);
 const NOOP_CONTROL_BLOCK_SET_OPTIONS = new Set([

--- a/code/packages/typescript/spice-engine/tests/compatibility.test.ts
+++ b/code/packages/typescript/spice-engine/tests/compatibility.test.ts
@@ -133,6 +133,8 @@ set filetype=binary
 write out.raw V(out)
 wrdata out.dat V(out)
 wrdata empty.dat
+display all
+listing physical
 run
 quit
 .endc
@@ -254,6 +256,8 @@ four 2k V(b)
 .set appendwrite
 .write out.raw V(a)
 .wrdata out.dat V(a)
+.display all
+.listing deck
 run
 .quit
 .endc

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -42,7 +42,8 @@ downstream tools to compare.
      `set wr_singlescale`), and rawfile append-write `set appendwrite` options
      plus target-bearing rawfile `write <rawfile> [probes...]` markers and
      ASCII data-write `wrdata <file> <probes...>` markers are accepted as
-     no-op control markers; parsed
+     no-op control markers, and read-only `display` / `listing` inspection
+     commands are accepted as no-op control markers; parsed
      `.measure dc` / `.meas dc` cards now route DC sweep probe samples into
      the shared scalar measurement table surface;
      parsed `.measure ac` / `.meas ac` cards now route AC probe magnitudes over
@@ -628,6 +629,17 @@ downstream tools to compare.
       rawfile formats, other file-writing commands, other `set` variables, and
       unrecognized non-comment commands inside `.control` blocks remain
       diagnostic-only so unsupported file I/O and script state are explicit.
+
+57. Selected `.control` inspection marker routing.
+    - Status: completed in this selected control inspection-marker routing
+      slice.
+    - Python, Rust, and TypeScript now accept selected `.control` block
+      read-only `display` and `listing` inspection commands as no-op control
+      commands.
+    - Actual console/listing output, mutating control-flow commands, other
+      `set` variables, and unrecognized non-comment commands inside `.control`
+      blocks remain diagnostic-only so unsupported UI output and script state
+      are explicit.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- Accept selected `.control` block read-only `display` and `listing` commands as no-op inspection markers across Python, Rust, and TypeScript.
- Cover plain and dotted forms in deck-control/source-resolution compatibility tests while preserving diagnostics for unsupported commands.
- Update package docs/changelogs and mark SPICE plan slice 57 complete; actual console/listing output remains out of scope.

## Tests
- `/Users/adhithya/.local/share/mise/installs/python/3.12.13/bin/ruff check code/packages/python/spice-engine/src/spice_engine/compatibility.py code/packages/python/spice-engine/tests/test_compatibility.py`
- `PYTEST_ADDOPTS=--no-cov PYTHONPATH=code/packages/python/device-physics/src:code/packages/python/mosfet-models/src:code/packages/python/spice-engine/src /Users/adhithya/.local/share/mise/installs/python/3.12.13/bin/python3.12 -m pytest code/packages/python/spice-engine/tests/test_compatibility.py -q`
- `PYTHONPATH=code/packages/python/device-physics/src:code/packages/python/mosfet-models/src:code/packages/python/spice-engine/src /Users/adhithya/.local/share/mise/installs/python/3.12.13/bin/python3.12 -m pytest code/packages/python/spice-engine/tests -q`
- `cargo fmt --manifest-path code/packages/rust/spice-engine/Cargo.toml -- --check`
- `cargo test --manifest-path code/packages/rust/spice-engine/Cargo.toml --test compatibility_tests`
- `cargo test --manifest-path code/packages/rust/spice-engine/Cargo.toml`
- `PATH=/Users/adhithya/.local/share/mise/installs/node/22.22.3/bin:$PATH npm --prefix code/packages/typescript/spice-engine ci`
- `PATH=/Users/adhithya/.local/share/mise/installs/node/22.22.3/bin:$PATH npm --prefix code/packages/typescript/spice-engine run build`
- `PATH=/Users/adhithya/.local/share/mise/installs/node/22.22.3/bin:$PATH npm --prefix code/packages/typescript/spice-engine test -- compatibility`
- `PATH=/Users/adhithya/.local/share/mise/installs/node/22.22.3/bin:$PATH npm --prefix code/packages/typescript/spice-engine test`
- `git diff --check`