### PR TITLE
feat(wolfram-8): local scoping — With, Module, Block

### DIFF
--- a/code/packages/rust/wolfram-runtime/CHANGELOG.md
+++ b/code/packages/rust/wolfram-runtime/CHANGELOG.md
@@ -4,6 +4,58 @@ All notable changes to `wolfram-runtime` are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/) and this project uses
 [Semantic Versioning](https://semver.org/).
 
+## [0.5.0] — 2026-06-17
+
+The **W-8** deliverable (MA04 §11): local scoping — the three Wolfram heads that
+bind named locals over a body. `With`, `Module`, and `Block` are lowered onto the
+*same* substrate as W-7's iteration index: held heads + the `vm.rs::substitute`
+primitive. No new evaluator, no opcode, no grammar change.
+
+### Added (local-scoping heads)
+
+- **`With[{x = e, …}, body]`** → `body` with each local bound to its **evaluated**
+  RHS, substituted in and re-evaluated. Lexical and immediate, parallel binding
+  (each RHS sees the surrounding scope, so a decl may reference an outer binding).
+  So `With[{x = 3}, x^2]` is `9` and `With[{a = 1, b = 2}, a + b]` is `3`.
+- **`Module[{x, y = e}, body]`** → lexically-scoped locals. An initialised decl
+  (`y = e`) binds like `With`; an **uninitialised** decl (`x`) is α-renamed to a
+  fresh gensym `x$nnn` (mirroring real Wolfram) so it stays undefined and cannot
+  resolve to — or be captured by — a same-named global. `Module[{a = 1, b = 2},
+  a + b]` is `3`.
+- **`Block[{x = e}, body]`** → temporarily binds `x` over `body`. For the
+  substitution-based subset a self-contained body is observably identical to
+  `With`; `Block[{x = 5}, x + 1]` is `6`. (See §11.3 for the dynamic-scope
+  simplification.)
+
+### Binding mechanism (MA04 §11.2–§11.3)
+
+- The three heads are **held** (added to the `WolframBackend` decorator's
+  `hold_heads` set, union with the inner held set and W-7's iteration heads) so
+  the declaration list and body arrive unevaluated.
+- Each decl's RHS is evaluated through `vm.eval`; the collected `name → value`
+  mapping is applied to a **copy** of the held body via the same `substitute`
+  used for user-function parameters and the W-7 index, then the result is
+  evaluated. Because the session environment is never mutated, **locals do not
+  leak** (`x` is still free after `With[{x = 3}, x]`) and never clobber a global.
+- Uninitialised `Module` locals are gensym-renamed (a monotonic `AtomicU64`
+  counter) — the documented capture-avoidance simplification in place of full
+  α-renaming of every local.
+
+### Robustness (MA04 §11.4)
+
+- Malformed forms are left **unevaluated**, never a panic: a non-`List` first
+  argument (`With[x, body]`), a `With`/`Block` local with no value
+  (`With[{x}, body]`), a non-symbol assignment target (`f[x] = 1`), or the wrong
+  arity. No new allocation source — the body is substituted once per scope entry,
+  bounded by the W-4 input/token caps; nested scopes recurse over strictly
+  smaller bodies.
+
+### Tests
+
+- W-8 acceptance values; no-leak and no-clobber guards; nested scoping; a decl
+  referring to an outer binding; the gensym shadow of a global by an
+  uninitialised `Module` local; and the malformed-form / wrong-arity guards.
+
 ## [0.4.0] — 2026-06-17
 
 The **W-7** deliverable (MA04 §10): iteration constructs — the first Wolfram-lane

--- a/code/packages/rust/wolfram-runtime/Cargo.toml
+++ b/code/packages/rust/wolfram-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-wolfram-runtime"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 description = "Wolfram Language runtime — lowers M-expressions to symbolic-ir and evaluates via symbolic-vm"
 license = "MIT"

--- a/code/packages/rust/wolfram-runtime/README.md
+++ b/code/packages/rust/wolfram-runtime/README.md
@@ -8,8 +8,8 @@ M-expression AST from
 Macsyma/Maxima drive rather than writing a bespoke evaluator.
 
 See the spec: [`code/specs/MA04-wolfram-language.md`](../../../specs/MA04-wolfram-language.md)
-§7 (W-4 runtime), §8 (W-5 built-ins), §9 (W-6 operator sugar), and §10 (W-7
-iteration constructs).
+§7 (W-4 runtime), §8 (W-5 built-ins), §9 (W-6 operator sugar), §10 (W-7
+iteration constructs), and §11 (W-8 local scoping).
 
 ## What it does
 
@@ -88,6 +88,12 @@ assert_eq!(eval("Sum[i, {i, 1, 10}]\n").unwrap(), "Out[1]= 55\n");
 assert_eq!(eval("Product[i, {i, 1, 4}]\n").unwrap(), "Out[1]= 24\n");
 assert_eq!(eval("Do[i, {i, 3}]\n").unwrap(), "Out[1]= Null\n");
 
+// W-8 local scoping — bind named locals over a body (locals never leak):
+assert_eq!(eval("With[{x = 3}, x^2]\n").unwrap(), "Out[1]= 9\n");
+assert_eq!(eval("With[{a = 1, b = 2}, a + b]\n").unwrap(), "Out[1]= 3\n");
+assert_eq!(eval("Module[{a = 1, b = 2}, a + b]\n").unwrap(), "Out[1]= 3\n");
+assert_eq!(eval("Block[{x = 5}, x + 1]\n").unwrap(), "Out[1]= 6\n");
+
 // Stateful (bindings and definitions persist):
 let mut s = WolframSession::new();
 s.feed("square[x_] := x^2;\n").unwrap();   // `;` suppresses display
@@ -159,6 +165,32 @@ hangs), and a malformed spec (`{i}` with no bound, a zero step, a non-integer
 bound) is left unevaluated rather than panicking. No grammar change — these are
 ordinary `Head[args]` forms.
 
+**W-8** adds the local-scoping heads — the generalisation of W-7's local index
+into named locals over a body, lowered onto the same held-head + substitution
+substrate:
+
+| Head | Example | Result |
+|------|---------|--------|
+| `With` | `With[{x = 3}, x^2]` | `9` |
+| `With` | `With[{a = 1, b = 2}, a + b]` | `3` |
+| `Module` | `Module[{a = 1, b = 2}, a + b]` | `3` |
+| `Block` | `Block[{x = 5}, x + 1]` | `6` |
+
+All three are `Head[{decls}, body]` forms (no grammar change — `{x = e, …}` is an
+ordinary list of `Set` nodes). They are **held** so the decl list and body arrive
+unevaluated; the handler evaluates each decl's RHS, then binds the locals into a
+*copy* of the body with the *same* `substitute` that binds W-7's index and
+user-function parameters. Because the session environment is never touched, a
+**local never leaks** (`x` is still free after `With[{x = 3}, x]`) and never
+clobbers a same-named global. `With`/`Block` require every local initialised
+(`name = value`); `Module` also accepts a bare `name`, which it α-renames to a
+fresh gensym `name$nnn` (as real Wolfram does) so an uninitialised local stays
+undefined and cannot capture a global. `Block`'s dynamic scope is approximated by
+lexical substitution — observably identical to `With` for the self-contained
+bodies this subset supports (see MA04 §11.3). A malformed form (a non-list decl
+argument, a `With`/`Block` local with no value, a non-symbol assignment target,
+the wrong arity) is left unevaluated rather than panicking.
+
 A `;` at the end of a line suppresses that result's display (the notebook
 convention) but the statement still runs and still advances the `Out[n]` counter.
 
@@ -184,6 +216,9 @@ session-rebuild so a panic becomes a clean `Err` rather than a crash.
 - **W-7** (this crate) — the `Table`/`Do`/`Sum`/`Product` iteration constructs,
   iterator-bound evaluation over a local index (held heads + per-step
   substitution), DoS-capped like `Range`. No grammar change.
+- **W-8** (this crate) — the `With`/`Module`/`Block` local-scoping heads, named
+  locals bound into a held body via substitution (no session leak, no global
+  clobber; `Module` gensym-renames uninitialised locals). No grammar change.
 - **Future** — the full `cas-*` function surface under Wolfram names
   (`Simplify`, `Expand`, `Factor`, `Solve`, …).
 

--- a/code/packages/rust/wolfram-runtime/src/backend.rs
+++ b/code/packages/rust/wolfram-runtime/src/backend.rs
@@ -35,7 +35,7 @@ use symbolic_vm::SymbolicBackend;
 
 use symbolic_ir::{IRApply, IRNode};
 
-use crate::builtins::{build_wolfram_builtins, ITERATION_HEADS};
+use crate::builtins::{build_wolfram_builtins, ITERATION_HEADS, SCOPING_HEADS};
 
 /// The Wolfram evaluation backend: a [`SymbolicBackend`] plus the W-5 built-in
 /// handler table.
@@ -45,9 +45,11 @@ pub struct WolframBackend {
     /// The W-5 list/functional/numeric handlers, consulted *before* `inner`.
     builtins: HashMap<String, Handler>,
     /// The set of heads whose args must NOT be pre-evaluated — the union of the
-    /// inner backend's held set (`If`, `Assign`, `Define`, …) and the W-7
-    /// iteration heads (`Table`, `Do`, `Sum`, `Product`), which must hold their
-    /// body + iterator spec so the local index can be bound per step.
+    /// inner backend's held set (`If`, `Assign`, `Define`, …), the W-7 iteration
+    /// heads (`Table`, `Do`, `Sum`, `Product`), which must hold their body +
+    /// iterator spec so the local index can be bound per step, and the W-8
+    /// local-scoping heads (`With`, `Module`, `Block`), which must hold their
+    /// declaration list + body so the locals can be bound into the body.
     ///
     /// `hold_heads` returns `&HashSet`, so the union must be *materialised and
     /// owned* here — we cannot synthesise it per-call. It is computed once at
@@ -64,6 +66,11 @@ impl WolframBackend {
         // one-time union is correct — no inner head is added after this point.
         let mut held: HashSet<String> = inner.hold_heads().iter().cloned().collect();
         for head in ITERATION_HEADS {
+            held.insert(head.to_string());
+        }
+        // W-8 local-scoping heads must also be held so their decl list + body
+        // arrive unevaluated and the locals can be bound into the body.
+        for head in SCOPING_HEADS {
             held.insert(head.to_string());
         }
         Self {
@@ -111,9 +118,9 @@ impl Backend for WolframBackend {
 
     fn hold_heads(&self) -> &HashSet<String> {
         // The W-5 heads are all non-held (eager args). W-7 adds the iteration
-        // heads (`Table`, `Do`, `Sum`, `Product`) to the inner backend's held
-        // set (`If`, `Assign`, `Define`, …); the union was materialised in
-        // `new()`.
+        // heads (`Table`, `Do`, `Sum`, `Product`) and W-8 adds the scoping heads
+        // (`With`, `Module`, `Block`) to the inner backend's held set (`If`,
+        // `Assign`, `Define`, …); the union was materialised in `new()`.
         &self.held
     }
 }
@@ -162,6 +169,38 @@ mod tests {
             assert!(held.contains(head), "{head} should be held");
         }
         assert!(held.contains("If"), "inner held set must be preserved");
+    }
+
+    #[test]
+    fn scoping_heads_are_held() {
+        // W-8: With/Module/Block must be held so the decl list + body arrive
+        // unevaluated and the locals can be bound into the body. The inner held
+        // set (If, …) and the W-7 iteration heads must survive the union.
+        let backend = WolframBackend::new();
+        let held = backend.hold_heads();
+        for head in ["With", "Module", "Block"] {
+            assert!(held.contains(head), "{head} should be held");
+        }
+        assert!(held.contains("If"), "inner held set must be preserved");
+        assert!(held.contains("Table"), "W-7 held set must be preserved");
+    }
+
+    #[test]
+    fn with_evaluates_end_to_end_through_the_vm() {
+        // With[{x = 3}, x^2] → 9: the decl RHS is evaluated, x is substituted
+        // into the held body, and the squaring re-eval goes through the real VM.
+        let mut vm = VM::new(Box::new(WolframBackend::new()));
+        let out = vm.eval(apply(
+            sym("With"),
+            vec![
+                apply(
+                    sym(LIST),
+                    vec![apply(sym("Assign"), vec![sym("x"), int(3)])],
+                ),
+                apply(sym("Pow"), vec![sym("x"), int(2)]),
+            ],
+        ));
+        assert_eq!(out, int(9));
     }
 
     #[test]

--- a/code/packages/rust/wolfram-runtime/src/builtins.rs
+++ b/code/packages/rust/wolfram-runtime/src/builtins.rs
@@ -43,7 +43,7 @@ use symbolic_vm::backend::{handler_fn, Handler};
 use symbolic_vm::vm::substitute;
 use symbolic_vm::VM;
 
-use symbolic_ir::{apply, flt, int, sym, IRApply, IRNode, ADD, LIST, MUL};
+use symbolic_ir::{apply, flt, int, sym, IRApply, IRNode, ADD, ASSIGN, LIST, MUL};
 
 use crate::lower::build_canonical_application;
 
@@ -83,6 +83,12 @@ pub fn build_wolfram_builtins() -> HashMap<String, Handler> {
     m.insert("Do".to_string(), handler_fn(do_handler));
     m.insert("Sum".to_string(), handler_fn(sum_handler));
     m.insert("Product".to_string(), handler_fn(product_handler));
+    // W-8 local-scoping constructs. These are *held* heads (see [`SCOPING_HEADS`]
+    // and the `WolframBackend` held set) — their declaration list and body arrive
+    // unevaluated so the locals can be bound into the body before it evaluates.
+    m.insert("With".to_string(), handler_fn(with_handler));
+    m.insert("Module".to_string(), handler_fn(module_handler));
+    m.insert("Block".to_string(), handler_fn(block_handler));
     m
 }
 
@@ -98,6 +104,20 @@ pub fn build_wolfram_builtins() -> HashMap<String, Handler> {
 /// (they may be expressions like `{i, n}`) while substituting `i` into the body
 /// per iteration.
 pub const ITERATION_HEADS: [&str; 4] = ["Table", "Do", "Sum", "Product"];
+
+/// The W-8 local-scoping heads, which must be **held** (args not pre-evaluated)
+/// so that the declaration list and body arrive unevaluated — the locals are
+/// bound *into* the body via `substitute` before the body is evaluated. The
+/// [`WolframBackend`](crate::backend::WolframBackend) folds these into its
+/// `hold_heads` set (union with the inner held set and [`ITERATION_HEADS`]).
+///
+/// Why held? `With[{x = 3}, x^2]` must *not* evaluate `x^2` up front — `x` is a
+/// local binder, and an eager eval would resolve it to a free symbol (or a
+/// stale global) with nothing left to substitute. Holding keeps both the decl
+/// list (`{x = 3}`, lowered to `List(Assign(x, 3))`) and the body (`x^2`)
+/// literal; the handler then evaluates each declaration's RHS itself and
+/// substitutes the locals into the body per scope entry.
+pub const SCOPING_HEADS: [&str; 3] = ["With", "Module", "Block"];
 
 // ---------------------------------------------------------------------------
 // List inspection — Length / First / Last / Part
@@ -465,6 +485,171 @@ fn fold_iteration(vm: &mut VM, expr: IRApply, op: &str, identity: IRNode) -> IRN
         acc = vm.eval(apply(sym(op), vec![acc, term]));
     }
     acc
+}
+
+// ---------------------------------------------------------------------------
+// Local scoping — With / Module / Block (W-8)
+// ---------------------------------------------------------------------------
+//
+// All three share one shape: a held declaration list `{x = e, …}` (lowered to
+// `List(Assign(x, e), …)`) and a held body. The handler parses the decls,
+// evaluates each RHS through the VM, builds an `index → value` mapping, and then
+// substitutes that mapping into the body before evaluating it — the **same**
+// `substitute` primitive W-7's iteration index and user-function parameters use.
+//
+// Substituting into a *copy* of the held body (rather than mutating the session
+// environment) is what makes the locals genuinely local: nothing is ever written
+// to the global env, so a local can neither leak past the body nor clobber a
+// same-named global. After `With[{x = 3}, x]`, a bare `x` is still the free
+// symbol `x`. (MA04 §11.2–§11.3.)
+//
+// The three heads differ only in how a declaration is allowed to look:
+//   * `With`  — every decl MUST be `name = value`; the value is evaluated.
+//   * `Module`— a decl may be `name = value` (evaluated) OR a bare `name`
+//               (uninitialised). An uninitialised local is **α-renamed** to a
+//               fresh gensym (`name$nnn`, mirroring real Wolfram) so it can never
+//               resolve to — and is never captured by — a same-named *global*.
+//   * `Block` — same decl grammar as `With` here. Its dynamic-vs-lexical scope
+//               difference is unobservable for the substitution-based subset
+//               (MA04 §11.3); a self-contained body behaves identically.
+//
+// Why gensym for uninitialised Module locals specifically? Mapping `u → u` (the
+// identity) would *not* shadow a global: `substitute` would leave the body's `u`
+// as the symbol `u`, which `vm.eval` then resolves against the session env to
+// any `u = 42` binding — a capture leak. Renaming `u → u$nnn` produces a symbol
+// the env has never bound, so it stays free (undefined) exactly as a fresh local
+// should. Initialised locals (`y = e`) don't need this: their `y` is replaced by
+// the *value* `eval(e)`, so no `y` symbol survives in the body to be captured.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+
+/// Monotonic counter for `Module`'s gensym renaming of uninitialised locals.
+///
+/// Each uninitialised `Module` local `x` is renamed to `x$<n>` for a unique `n`,
+/// so it cannot collide with a global, a sibling local, or an outer scope's
+/// local of the same name. `Relaxed` ordering is sufficient — we only need each
+/// fetched value to be distinct, not ordered relative to other memory.
+static MODULE_GENSYM_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+/// Allocate a fresh, never-before-used local name for `base` (e.g. `x` → `x$7`).
+fn fresh_local_name(base: &str) -> String {
+    let n = MODULE_GENSYM_COUNTER.fetch_add(1, Ordering::Relaxed);
+    format!("{base}${n}")
+}
+
+/// `With[{x = e, …}, body]` — bind each local to its evaluated RHS, substitute
+/// into the body, and evaluate. Lexical, immediate (the RHS is evaluated against
+/// the surrounding scope, so a decl may reference an outer binding). Every decl
+/// must be an initialised `name = value`; a bare-symbol decl (no value) or any
+/// other malformed decl/arity/non-list leaves the whole `With` unevaluated.
+fn with_handler(vm: &mut VM, expr: IRApply) -> IRNode {
+    scope_handler(vm, expr, /* allow_uninitialised = */ false)
+}
+
+/// `Block[{x = e}, body]` — temporarily binds `x` for the duration of `body`.
+/// In real Wolfram this is *dynamic* scope (it shadows a global `x`); for the
+/// substitution-based subset shipped here a self-contained body is observably
+/// identical to `With` (MA04 §11.3), so it shares the same decl grammar
+/// (every local must be initialised) and the same substitution mechanism.
+fn block_handler(vm: &mut VM, expr: IRApply) -> IRNode {
+    scope_handler(vm, expr, /* allow_uninitialised = */ false)
+}
+
+/// `Module[{x, y = e}, body]` — lexically-scoped locals. An initialised decl
+/// (`y = e`) is evaluated like `With`; an *uninitialised* decl (`x`) is α-renamed
+/// to a fresh gensym (`x$nnn`) so the body sees an undefined symbol that can
+/// never resolve to — or be captured by — a same-named global. This is the one
+/// head that accepts a bare-symbol declaration.
+fn module_handler(vm: &mut VM, expr: IRApply) -> IRNode {
+    scope_handler(vm, expr, /* allow_uninitialised = */ true)
+}
+
+/// Shared core of `With`/`Module`/`Block`: parse `{decls}`, evaluate each
+/// declaration's RHS, build the local mapping, substitute it into the body, and
+/// evaluate. `allow_uninitialised` controls whether a bare-symbol decl (no `=`)
+/// is permitted (`Module`) or rejected (`With`/`Block`).
+///
+/// Returns the form **unevaluated** (never a panic) on any malformed input:
+/// wrong arity, a non-`List` first argument, or a declaration that is neither a
+/// bare symbol nor a `name = value` assignment (or a bare symbol where a value
+/// is required). This mirrors the W-5/W-7 "I can't reduce this" convention.
+fn scope_handler(vm: &mut VM, expr: IRApply, allow_uninitialised: bool) -> IRNode {
+    // Head[{decls}, body] — exactly two arguments.
+    if expr.args.len() != 2 {
+        return unevaluated(expr);
+    }
+    // The first argument must be a literal `List` of declarations.
+    let Some(decls) = list_elements(&expr.args[0]) else {
+        return unevaluated(expr);
+    };
+
+    // Parse + evaluate every declaration into a (name, value) pair. A single
+    // malformed declaration aborts the whole form (left unevaluated) — we do not
+    // partially bind.
+    let mut mapping: StdHashMap<String, IRNode> = StdHashMap::new();
+    for decl in &decls {
+        let Some((name, value)) = eval_decl(vm, decl, allow_uninitialised) else {
+            return unevaluated(expr);
+        };
+        // A later decl with the same name shadows an earlier one (last wins),
+        // matching how a repeated local would behave; harmless for valid input.
+        mapping.insert(name, value);
+    }
+
+    // Bind the locals into a *copy* of the held body and evaluate. Because this
+    // never touches the session environment, the locals do not leak (MA04 §11.2).
+    let body = substitute(expr.args[1].clone(), &mapping);
+    vm.eval(body)
+}
+
+/// Parse one declaration node into `(name, replacement)` — the symbol the body
+/// binds and the IR node every free occurrence of it is replaced with.
+///
+/// Accepts two shapes:
+/// - `Assign(name, rhs)` (the lowering of `name = value`): `name` must be a bare
+///   symbol; `rhs` is **evaluated** through the VM (so `With[{x = 1 + 1}, …]`
+///   binds `x → 2`, and an RHS referring to an outer binding resolves). The
+///   replacement is the evaluated *value*.
+/// - a bare `Symbol(name)` — only when `allow_uninitialised` (i.e. `Module`): the
+///   local is α-renamed to a fresh gensym `name$nnn`. The replacement is that
+///   fresh symbol, so the body sees an undefined local that cannot resolve to a
+///   global (see the module-scoping note above).
+///
+/// Returns `None` (→ the caller leaves the whole scoping form unevaluated) for a
+/// non-symbol assignment target (`f[x] = 1`, `1 = 2`), a bare symbol where a
+/// value is required (`With`/`Block`), or any other node shape.
+fn eval_decl(
+    vm: &mut VM,
+    decl: &IRNode,
+    allow_uninitialised: bool,
+) -> Option<(String, IRNode)> {
+    match decl {
+        // `name = value` → Assign(name, value).
+        IRNode::Apply(app) if is_assign(&app.head) && app.args.len() == 2 => {
+            let name = match &app.args[0] {
+                IRNode::Symbol(s) => s.clone(),
+                // A non-symbol assignment target (`f[x] = 1`, `1 = 2`) is not a
+                // valid local declaration.
+                _ => return None,
+            };
+            let value = vm.eval(app.args[1].clone());
+            Some((name, value))
+        }
+        // A bare symbol `x` — an uninitialised local (Module only). It is renamed
+        // to a fresh gensym so the body sees an undefined local, never a global.
+        IRNode::Symbol(name) if allow_uninitialised => {
+            Some((name.clone(), sym(fresh_local_name(name))))
+        }
+        // Anything else (a bare symbol where a value is required, a literal, a
+        // non-Assign application) is malformed.
+        _ => None,
+    }
+}
+
+/// True if `head` is the `Assign` symbol (the IR head a surface `x = e`
+/// declaration lowers to).
+fn is_assign(head: &IRNode) -> bool {
+    matches!(head, IRNode::Symbol(s) if s == ASSIGN)
 }
 
 // ---------------------------------------------------------------------------
@@ -864,5 +1049,197 @@ mod tests {
         // Only the 2-arg (body, spec) form is valid.
         assert_eq!(run("Table", vec![sym("i")]), apply(sym("Table"), vec![sym("i")]));
         assert_eq!(run("Sum", vec![]), apply(sym("Sum"), vec![]));
+    }
+
+    // -----------------------------------------------------------------------
+    // W-8 local-scoping handlers (unit level — handlers run over a real VM so
+    // the decl-RHS eval, the substitute into the held body, and the body re-eval
+    // all exercise the shared SymbolicBackend handler table).
+    // -----------------------------------------------------------------------
+
+    /// `name = value` declaration helper (the lowering of an in-`{…}` `Set`).
+    fn decl(name: &str, value: IRNode) -> IRNode {
+        apply(sym(ASSIGN), vec![sym(name), value])
+    }
+
+    #[test]
+    fn with_binds_a_single_local_and_evaluates_the_body() {
+        // With[{x = 3}, x^2] → 9 (Pow is an inner-backend head).
+        assert_eq!(
+            run(
+                "With",
+                vec![
+                    list(vec![decl("x", int(3))]),
+                    apply(sym("Pow"), vec![sym("x"), int(2)])
+                ]
+            ),
+            int(9)
+        );
+    }
+
+    #[test]
+    fn with_binds_multiple_locals_in_parallel() {
+        // With[{a = 1, b = 2}, a + b] → 3.
+        assert_eq!(
+            run(
+                "With",
+                vec![
+                    list(vec![decl("a", int(1)), decl("b", int(2))]),
+                    apply(sym("Add"), vec![sym("a"), sym("b")])
+                ]
+            ),
+            int(3)
+        );
+    }
+
+    #[test]
+    fn with_evaluates_the_decl_rhs() {
+        // With[{x = 1 + 1}, x] → 2 — the RHS is evaluated before substitution.
+        assert_eq!(
+            run(
+                "With",
+                vec![
+                    list(vec![decl("x", apply(sym("Add"), vec![int(1), int(1)]))]),
+                    sym("x")
+                ]
+            ),
+            int(2)
+        );
+    }
+
+    #[test]
+    fn module_with_initialised_locals_behaves_like_with() {
+        // Module[{a = 1, b = 2}, a + b] → 3.
+        assert_eq!(
+            run(
+                "Module",
+                vec![
+                    list(vec![decl("a", int(1)), decl("b", int(2))]),
+                    apply(sym("Add"), vec![sym("a"), sym("b")])
+                ]
+            ),
+            int(3)
+        );
+    }
+
+    #[test]
+    fn module_uninitialised_local_stays_symbolic() {
+        // Module[{x}, x] → x$nnn — an uninitialised local is α-renamed to a fresh
+        // gensym, so the body sees an undefined symbol (never a global). We assert
+        // the *shape* (a free symbol whose name starts with the base) rather than
+        // the exact gensym number, which is non-deterministic across the suite.
+        match run("Module", vec![list(vec![sym("x")]), sym("x")]) {
+            IRNode::Symbol(s) => assert!(
+                s == "x" || s.starts_with("x$"),
+                "expected a fresh `x` local, got {s:?}"
+            ),
+            other => panic!("expected a symbol, got {other}"),
+        }
+        // A mix: Module[{x, y = 2}, y] → 2 (uninitialised x is harmless).
+        assert_eq!(
+            run(
+                "Module",
+                vec![list(vec![sym("x"), decl("y", int(2))]), sym("y")]
+            ),
+            int(2)
+        );
+    }
+
+    #[test]
+    fn module_uninitialised_local_does_not_resolve_to_a_global() {
+        // With a global `u = 42` bound in the backend, Module[{u}, u] must NOT
+        // return 42 — the gensym rename gives the local a name the env never
+        // bound, so it stays free. This is the capture-leak guard.
+        use symbolic_vm::backend::Backend;
+        let table = build_wolfram_builtins();
+        let handler = table.get("Module").expect("no Module builtin").clone();
+        let mut backend = SymbolicBackend::new();
+        backend.bind("u", int(42));
+        let mut vm = VM::new(Box::new(backend));
+        let out = handler(
+            &mut vm,
+            IRApply {
+                head: sym("Module"),
+                args: vec![list(vec![sym("u")]), sym("u")],
+            },
+        );
+        match out {
+            IRNode::Symbol(s) => assert!(
+                s.starts_with("u$"),
+                "uninitialised local must be a fresh gensym, got {s:?}"
+            ),
+            other => panic!("expected a fresh symbol, not the global 42: {other}"),
+        }
+    }
+
+    #[test]
+    fn block_binds_like_with_for_self_contained_bodies() {
+        // Block[{x = 5}, x + 1] → 6.
+        assert_eq!(
+            run(
+                "Block",
+                vec![
+                    list(vec![decl("x", int(5))]),
+                    apply(sym("Add"), vec![sym("x"), int(1)])
+                ]
+            ),
+            int(6)
+        );
+    }
+
+    #[test]
+    fn with_uninitialised_local_is_rejected() {
+        // With requires every local to be initialised; a bare `x` leaves the
+        // whole form unevaluated (Block too).
+        let form = vec![list(vec![sym("x")]), sym("x")];
+        assert_eq!(
+            run("With", form.clone()),
+            apply(sym("With"), form.clone())
+        );
+        assert_eq!(run("Block", form.clone()), apply(sym("Block"), form));
+    }
+
+    #[test]
+    fn scoping_with_malformed_decls_stays_unevaluated() {
+        // First argument not a list.
+        assert_eq!(
+            run("With", vec![sym("x"), sym("x")]),
+            apply(sym("With"), vec![sym("x"), sym("x")])
+        );
+        // A decl that is a literal, not a symbol or assignment.
+        let lit = vec![list(vec![int(7)]), int(1)];
+        assert_eq!(run("With", lit.clone()), apply(sym("With"), lit));
+        // A non-symbol assignment target: f[x] = 1.
+        let bad_target = vec![
+            list(vec![apply(
+                sym(ASSIGN),
+                vec![apply(sym("f"), vec![sym("x")]), int(1)],
+            )]),
+            int(1),
+        ];
+        assert_eq!(
+            run("With", bad_target.clone()),
+            apply(sym("With"), bad_target)
+        );
+    }
+
+    #[test]
+    fn scoping_wrong_arity_stays_unevaluated() {
+        // Only the 2-arg (decls, body) form is valid.
+        assert_eq!(
+            run("With", vec![list(vec![decl("x", int(1))])]),
+            apply(sym("With"), vec![list(vec![decl("x", int(1))])])
+        );
+        assert_eq!(run("Module", vec![]), apply(sym("Module"), vec![]));
+        assert_eq!(
+            run(
+                "Block",
+                vec![list(vec![decl("x", int(1))]), int(1), int(2)]
+            ),
+            apply(
+                sym("Block"),
+                vec![list(vec![decl("x", int(1))]), int(1), int(2)]
+            )
+        );
     }
 }

--- a/code/packages/rust/wolfram-runtime/tests/integration.rs
+++ b/code/packages/rust/wolfram-runtime/tests/integration.rs
@@ -449,3 +449,133 @@ fn w7_negative_and_descending_ranges() {
     assert_eq!(eval("Table[i, {i, -2, 2}]\n").unwrap(), "Out[1]= {-2, -1, 0, 1, 2}\n");
     assert_eq!(eval("Table[i, {i, 5, 1, -2}]\n").unwrap(), "Out[1]= {5, 3, 1}\n");
 }
+
+// ---------------------------------------------------------------------------
+// W-8 — local scoping (With, Module, Block)
+// ---------------------------------------------------------------------------
+
+/// `With[{x = e}, body]` substitutes the evaluated value of `x` into `body`.
+/// The canonical acceptance values from the W-8 brief.
+#[test]
+fn w8_with_single_and_multiple_locals() {
+    // With[{x = 3}, x^2] → 9.
+    assert_eq!(eval("With[{x = 3}, x^2]\n").unwrap(), "Out[1]= 9\n");
+    // With[{a = 1, b = 2}, a + b] → 3 (parallel binding).
+    assert_eq!(eval("With[{a = 1, b = 2}, a + b]\n").unwrap(), "Out[1]= 3\n");
+}
+
+/// `Module[{x, y = e}, body]` — initialised locals bind like `With`; the
+/// acceptance value `Module[{a = 1, b = 2}, a + b]` → `3`.
+#[test]
+fn w8_module_initialised_locals() {
+    assert_eq!(eval("Module[{a = 1, b = 2}, a + b]\n").unwrap(), "Out[1]= 3\n");
+}
+
+/// `Block[{x = e}, body]` — for a self-contained body it binds like `With`;
+/// `Block[{x = 5}, x + 1]` → `6`.
+#[test]
+fn w8_block_binds_local() {
+    assert_eq!(eval("Block[{x = 5}, x + 1]\n").unwrap(), "Out[1]= 6\n");
+}
+
+/// **Locals do not leak to the session.** After `With[{x = 3}, x]`, a bare `x`
+/// is still the free symbol `x` (the session env was never written). Same for
+/// `Module` and `Block`.
+#[test]
+fn w8_locals_do_not_leak() {
+    let mut s = WolframSession::new();
+    assert_eq!(s.feed("With[{x = 3}, x]\n").unwrap(), "Out[1]= 3\n");
+    // `x` is still unbound (free), not 3 — no env leak.
+    assert_eq!(s.feed("x\n").unwrap(), "Out[2]= x\n");
+
+    let mut s = WolframSession::new();
+    assert_eq!(s.feed("Module[{y = 7}, y]\n").unwrap(), "Out[1]= 7\n");
+    assert_eq!(s.feed("y\n").unwrap(), "Out[2]= y\n");
+
+    let mut s = WolframSession::new();
+    assert_eq!(s.feed("Block[{z = 9}, z]\n").unwrap(), "Out[1]= 9\n");
+    assert_eq!(s.feed("z\n").unwrap(), "Out[2]= z\n");
+}
+
+/// A local must not *clobber* a same-named global: a global `x` set before the
+/// scope is unchanged by a `With`/`Module`/`Block` that binds its own `x`.
+#[test]
+fn w8_local_does_not_clobber_a_global() {
+    let mut s = WolframSession::new();
+    s.feed("x = 100\n").unwrap();
+    // Inside the scope, the local `x` shadows the global.
+    assert_eq!(s.feed("With[{x = 1}, x]\n").unwrap(), "Out[2]= 1\n");
+    // The global `x` is untouched afterwards.
+    assert_eq!(s.feed("x\n").unwrap(), "Out[3]= 100\n");
+}
+
+/// Nested scoping: each level binds its own local cleanly, and an inner body
+/// sees both the inner and the (already-substituted) outer local.
+#[test]
+fn w8_nested_scopes() {
+    // With[{x = 1}, With[{y = 2}, x + y]] → 3.
+    assert_eq!(
+        eval("With[{x = 1}, With[{y = 2}, x + y]]\n").unwrap(),
+        "Out[1]= 3\n"
+    );
+    // Module nested inside With composes too.
+    assert_eq!(
+        eval("With[{a = 10}, Module[{b = 5}, a + b]]\n").unwrap(),
+        "Out[1]= 15\n"
+    );
+}
+
+/// A declaration may **refer to an outer binding** — the RHS is evaluated
+/// against the surrounding scope before substitution.
+#[test]
+fn w8_decl_refers_to_outer_binding() {
+    // The inner decl `y = x + 1` reads the outer local `x = 1` → y = 2.
+    assert_eq!(
+        eval("With[{x = 1}, With[{y = x + 1}, y]]\n").unwrap(),
+        "Out[1]= 2\n"
+    );
+    // A decl reading a session binding.
+    let mut s = WolframSession::new();
+    s.feed("n = 4\n").unwrap();
+    assert_eq!(s.feed("With[{m = n + 1}, m]\n").unwrap(), "Out[2]= 5\n");
+}
+
+/// `Module` allows an *uninitialised* local, which stays symbolic in the body
+/// (it is α-renamed to a fresh gensym, so it does not resolve to any global of
+/// the same name).
+#[test]
+fn w8_module_uninitialised_local_is_symbolic() {
+    // Module[{u}, u + 1] → 1 + u$nnn (u stays a free symbol; `+` keeps it
+    // symbolic). The base name survives in the gensym, so the output mentions u.
+    let out = eval("Module[{u}, u + 1]\n").unwrap();
+    assert!(out.contains('u'), "uninitialised local should stay symbolic: {out:?}");
+    // Even with a global `u = 42` set, the uninitialised Module local shadows it:
+    // the result is a fresh `u$nnn` symbol, NOT the global value 42.
+    let mut s = WolframSession::new();
+    s.feed("u = 42\n").unwrap();
+    let out = s.feed("Module[{u}, u]\n").unwrap();
+    assert!(
+        out.contains("u$") && !out.contains("42"),
+        "uninitialised local must shadow the global, got {out:?}"
+    );
+}
+
+/// Malformed scoping forms are left unevaluated (never a panic): a non-list
+/// declaration argument, a `With`/`Block` local with no value, wrong arity.
+#[test]
+fn w8_malformed_forms_stay_unevaluated() {
+    // First argument not a list.
+    assert_eq!(eval("With[x, x]\n").unwrap(), "Out[1]= With[x, x]\n");
+    // With requires an initialised local; a bare `x` is rejected.
+    assert_eq!(eval("With[{x}, x]\n").unwrap(), "Out[1]= With[{x}, x]\n");
+    assert_eq!(eval("Block[{x}, x]\n").unwrap(), "Out[1]= Block[{x}, x]\n");
+}
+
+/// W-4..W-7 behaviour is unchanged by the W-8 handlers (regression guard).
+#[test]
+fn w8_does_not_disturb_existing_forms() {
+    assert_eq!(eval("1 + 2*3\n").unwrap(), "Out[1]= 7\n");
+    assert_eq!(eval("Table[i^2, {i, 3}]\n").unwrap(), "Out[1]= {1, 4, 9}\n");
+    assert_eq!(eval("Sum[i, {i, 1, 10}]\n").unwrap(), "Out[1]= 55\n");
+    assert_eq!(eval("Map[f, {1, 2}]\n").unwrap(), "Out[1]= {f[1], f[2]}\n");
+}

--- a/code/specs/MA04-wolfram-language.md
+++ b/code/specs/MA04-wolfram-language.md
@@ -437,6 +437,133 @@ the W-1 grammar. W-7 touches only `wolfram-runtime` (the builtin handler table
 and the decorator's held set); the lexer, grammar, and `_grammar.rs` are
 untouched.
 
+## §11 W-8 local scoping `With`, `Module`, `Block` (implemented)
+
+W-7 (§10) introduced the first *scoped local binder* — the iteration index `i`,
+bound per step via `substitute`. W-8 generalises that idea into Wolfram's three
+**local-scoping heads**, which bind one or more named locals over a body and
+evaluate the body in that augmented scope. Like W-7 they are lowered onto the
+*same* substrate — held heads + the `vm.rs::substitute` primitive — with no new
+evaluator, no opcode, and no grammar change.
+
+### §11.1 What W-8 adds
+
+All three are `Head[{decls}, body]` forms: a literal `List` of declarations and a
+body. They differ only in how a local is *initialised* and how its scope relates
+to the surrounding session.
+
+| Form | Result | Notes |
+| --- | --- | --- |
+| `With[{x = e}, body]` | `body` with `x → eval(e)` | lexical constant; the value is substituted *immediately*. Multiple decls: `With[{x = e1, y = e2}, body]` |
+| `Module[{x, y = e}, body]` | `body` with locals bound; an *uninitialised* local (`x`) stays undefined | lexically-scoped locals; an initialised local (`y = e`) gets `eval(e)`, an uninitialised one (`x`) is α-renamed to a fresh `x$nnn` so it is undefined and cannot capture a global |
+| `Block[{x = e}, body]` | `body` evaluated with `x` temporarily set to `eval(e)` | dynamically-scoped: shadows a global `x` for the duration of `body`, then restores it |
+
+Worked examples (the W-8 acceptance tests):
+`With[{x = 3}, x^2]` → `9`; `With[{a = 1, b = 2}, a + b]` → `3`;
+`Module[{a = 1, b = 2}, a + b]` → `3`; `Block[{x = 5}, x + 1]` → `6`;
+nested `With[{x = 1}, With[{y = 2}, x + y]]` → `3`; a decl referring to an
+outer binding `With[{x = 1}, With[{y = x + 1}, y]]` → `2`.
+
+### §11.2 Binding the locals — held heads + `substitute`
+
+The three scoping heads are **held** (added to the backend's `hold_heads` set
+via the `WolframBackend` decorator — it now returns the union of the inner held
+set and `{Table, Do, Sum, Product, With, Module, Block}`). Holding is essential
+for the same reason as W-7: the `body` must *not* be evaluated before the locals
+are bound (otherwise a local symbol evaluates to its free/global meaning and the
+per-binding substitution has nothing to replace), and the declaration list
+`{x = e, …}` must stay a literal `List` of literal assignments (`x = e` parses as
+a `Set`/`Assign` node) so the binder names and their RHS expressions are readable
+rather than evaluated against the session.
+
+Inside the handler, each declaration's **RHS is evaluated** through `vm.eval`
+(`x = e` → `x → eval(e)`), then the collected mapping is applied to the body with
+the **same `substitute`** the VM uses for user-function parameters and W-7's
+iteration index. `substitute(body, {x → v, …})` produces a fresh body with the
+locals replaced; the result is evaluated through `vm.eval`. Using `substitute`
+rather than mutating the session environment is what keeps the locals **local**:
+
+- **`With`** evaluates every RHS *first* (against the surrounding scope, so a
+  decl may reference an outer binding) and substitutes all values simultaneously.
+  Multiple decls bind in parallel like Wolfram's `With` (each RHS sees the outer
+  scope, not its sibling decls).
+- **`Module`** treats an initialised decl `y = e` exactly like `With`; an
+  *uninitialised* decl `x` is **α-renamed to a fresh gensym `x$nnn`** (mirroring
+  real Wolfram) and `x → x$nnn` is substituted into the body. The renamed symbol
+  is one the session env has never bound, so the body sees an undefined local
+  that cannot resolve to — or be captured by — a same-named global `x`. (Mapping
+  `x → x` would *not* shadow a global, since the surviving symbol `x` would still
+  be resolved against the env at eval time; the gensym is what makes the local
+  genuinely fresh.)
+- **`Block`** evaluates each RHS and substitutes into the body identically. The
+  *semantic* difference from `With`/`Module` (dynamic vs lexical scope) is only
+  observable when the body calls a *separately-defined* function that reads the
+  shadowed global; for the substitution-based subset shipped here, a `Block` over
+  a self-contained body behaves like `With` over the same body, which is correct
+  for every tested case. See §11.3 for the simplification this entails.
+
+Because the binding is by substitution into a held body, **no local leaks into
+the session**: after `With[{x = 3}, x]`, a bare `x` is still the free symbol `x`
+(the session environment was never touched). Nested scopes each substitute over a
+body whose outer locals were already replaced, so `With[{x = 1}, With[{y = 2},
+x + y]]` correctly yields `3`.
+
+### §11.3 Substitution-based scoping — the documented simplification
+
+Real Wolfram renames `Module` locals (`x` → `x$nnn`) to guarantee no variable
+*capture*: if the substituted value itself mentions the local name, or the body
+contains a nested binder of the same name, a naïve textual substitution could
+capture the wrong occurrence. W-8 uses a **capture-avoiding-by-construction**
+substitution instead of renaming:
+
+- **No global mutation, so no leak and no clobber.** `substitute` rewrites a
+  *copy* of the body; the session environment is never written, so a local can
+  neither escape the body nor overwrite a same-named global. This is the property
+  the leak tests pin (`x` is still free after `With[{x = 3}, x]`).
+- **Inner binders shadow correctly under `substitute`.** `substitute` only
+  replaces *free* symbol occurrences in the body; an inner `With[{x = …}, …]`
+  re-binds `x` for its own (already-substituted) sub-body, so the outer
+  substitution and the inner binding compose without capture in the nested cases
+  tested. (A fully general implementation would still need α-renaming for the
+  adversarial case where a substituted *value* contains a name that a deeper body
+  binder shadows; W-8 documents this boundary rather than implementing renaming,
+  matching the brief's "substitution-based binding is acceptable IF documented
+  and capture-guarded in the tested cases".)
+- **`Block`'s dynamic scope is approximated by lexical substitution.** Because
+  the subset has no separately-stored closures that close over a *dynamic* `x`,
+  substituting `x`'s temporary value directly into the body is observationally
+  identical to dynamic shadowing for self-contained bodies. The divergence
+  (a `Block` body calling an out-of-line function that reads the global `x`) is
+  documented and out of scope for the tested forms.
+
+### §11.4 Robustness — malformed declarations stay unevaluated
+
+The handlers follow the same fail-soft convention as every W-5/W-7 head: a
+malformed form is **left unevaluated** (echoed back), never a panic.
+
+- Wrong arity (`With[{x = 1}]`, `With[{x = 1}, b, c]`) → unevaluated.
+- A first argument that is **not a `List`** (`With[x, body]`) → unevaluated.
+- A declaration that is neither a bare symbol nor a `name = value` assignment
+  (`With[{1 + 1}, body]`, `With[{f[x] = 1}, body]`) → the whole form unevaluated.
+- For `With`/`Block`, a bare-symbol decl with **no value** (`With[{x}, body]`) is
+  rejected (a value is required); for `Module` it is the valid "uninitialised
+  local" case. This asymmetry matches Wolfram (`With` requires every local to be
+  initialised; `Module` does not).
+
+There is no new allocation source: the body is substituted once per scope entry
+and the declaration count is bounded by the (token/-input-capped) source size, so
+W-8 adds no DoS surface beyond what W-4 already bounds. Deeply nested scopes are
+bounded by the evaluator's existing recursion handling (each nested head is an
+ordinary `vm.eval` call over a strictly smaller body).
+
+### §11.5 No grammar change
+
+`With[…]`, `Module[…]`, `Block[…]` are ordinary `Head[args]` applications, the
+declaration list `{x = e, …}` is an ordinary list literal, and `x = e` inside it
+is the ordinary `Set` infix already parsed since W-1. W-8 touches only
+`wolfram-runtime` (the builtin handler table and the decorator's held set); the
+lexer, grammar, and `_grammar.rs` are untouched.
+
 ## §6 References
 
 Internal: [`HML00`](HML00-historical-math-languages-roadmap.md),


### PR DESCRIPTION
## W-8 — Wolfram local scoping (`With`, `Module`, `Block`)

Adds Wolfram's three local-scoping heads, lowered onto the **same substrate** as W-7's iteration index: held heads + the `vm.rs::substitute` primitive. No new evaluator, no opcode, **no grammar change** — `With[{decls}, body]` already parses, and `x = e` inside `{…}` lowers to `Assign(x, e)`.

### Scope

| Form | Result |
| --- | --- |
| `With[{x = e, …}, body]` | `body` with each local bound to its **evaluated** RHS, substituted in, re-evaluated. Lexical, immediate, parallel binding. |
| `Module[{x, y = e}, body]` | lexically-scoped locals; `y = e` binds like `With`, an uninitialised `x` is α-renamed to a fresh `x$nnn` gensym (left undefined). |
| `Block[{x = e}, body]` | temporarily binds `x` over `body`; for the substitution-based subset a self-contained body is observably identical to `With`. |

Acceptance values: `With[{x=3}, x^2]`→9, `With[{a=1,b=2}, a+b]`→3, `Module[{a=1,b=2}, a+b]`→3, `Block[{x=5}, x+1]`→6, nested `With[{x=1}, With[{y=2}, x+y]]`→3, decl referring to an outer binding `With[{x=1}, With[{y=x+1}, y]]`→2.

### Binding approach

The three heads are added to the `WolframBackend` decorator's `hold_heads` set (union with the inner held set and W-7's `ITERATION_HEADS`), so the decl list and body arrive unevaluated. The shared `scope_handler` evaluates each decl's RHS through `vm.eval`, builds a `name → value` mapping, applies it to a **copy** of the held body via the same `substitute` used for user-function parameters and W-7's index, and evaluates the result.

**How local-leak / clobber is prevented:** substitution rewrites a *copy* of the body and **never mutates the session environment**, so a local can neither escape `body` nor overwrite a same-named global. After `With[{x=3}, x]` a bare `x` is still the free symbol `x`; a global `x=100` survives a `With` that binds its own `x`.

**Module simplification (documented):** an uninitialised `Module` local is α-renamed to a fresh gensym `x$nnn` (monotonic `AtomicU64`), mirroring real Wolfram. Mapping `x → x` (identity) would *not* shadow a global — the surviving `x` symbol would resolve against the env at eval time — so the gensym is what makes the local genuinely fresh and capture-proof. The `$` char is not a legal source identifier, so the gensym namespace is disjoint from user symbols. `Block`'s dynamic scope is approximated by lexical substitution; the only divergence (a `Block` body calling a separately-defined function that reads the shadowed global) is documented in spec §11.3 and out of scope for the tested forms. Full α-renaming of *every* local's substituted value is likewise documented as the boundary rather than implemented.

### Leak tests

`w8_locals_do_not_leak` (`With`/`Module`/`Block` — bare local still free afterward), `w8_local_does_not_clobber_a_global`, `w8_module_uninitialised_local_is_symbolic` (+ a backend-level `module_uninitialised_local_does_not_resolve_to_a_global` guarding the gensym shadow of a global), `w8_nested_scopes`, `w8_decl_refers_to_outer_binding`, and `w8_malformed_forms_stay_unevaluated`.

### Robustness

Malformed forms are left **unevaluated**, never a panic: non-`List` first argument (`With[x, body]`), a `With`/`Block` local with no value (`With[{x}, body]`), a non-symbol assignment target (`f[x] = 1`), wrong arity. No new allocation source (body substituted once per scope entry, decl count bounded by the W-4 token cap); nested scopes recurse over strictly smaller bodies under the existing parse-depth cap.

### Tests

`cargo test -p coding-adventures-wolfram-runtime -p coding-adventures-wolfram-repl` — all green (113 runtime unit, 50 integration incl. the W-8 cases, 14 repl, doctests). `cargo clippy` clean for both touched crates.

### Security review

No Agent/Task tool is available in this environment, so the review was performed **inline** as a senior Rust security engineer over `git diff origin/main...HEAD`, focused on variable-capture/leak correctness, recursion/DoS via nested scopes, panics on malformed decls, and integer/alloc safety. **Result: PASSED — no vulnerabilities found.** No `unsafe`, no unchecked indexing/`unwrap` on user input (every access is arity-guarded), no env mutation (so no leak/clobber), gensym namespace disjoint from source identifiers, nesting bounded by the existing token/parse-depth cap. The one documented simplification (non-α-renamed substituted values under adversarial deep nesting) never mutates session state and is not a security defect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
