### PR TITLE
feat(spreadsheet-core): clipboard — cut / copy / paste (0.8.0)

### DIFF
--- a/code/packages/rust/spreadsheet-core/CHANGELOG.md
+++ b/code/packages/rust/spreadsheet-core/CHANGELOG.md
@@ -1,5 +1,40 @@
 # Changelog
 
+## 0.8.0
+
+**Clipboard — cut / copy / paste.** A stateful clipboard on `Workbook`, layered
+over the same `FormulaAst::shift` reference arithmetic that powers fill. Where
+fill replicates one source cell across a range (each target shifts by its own
+offset), copy/paste captures a whole **rectangle** and shifts it as a unit on
+paste — the block's internal structure is preserved (`=A1` copied two columns
+right pastes as `=C1`).
+
+- `Workbook::copy(sheet, range)` / `cut(sheet, range)` (`workbook.rs`): snapshot
+  the non-blank cells of `range` (content **and** format) as offsets from the
+  range's top-left anchor. A copy survives any number of pastes; a cut is a
+  one-shot move (the buffer is consumed on the paste that places it). The source
+  is captured but not cleared until paste — a cut with no paste is a no-op
+  (spreadsheet "marching-ants" semantics). A `range` over `MAX_RANGE_CELLS` is
+  rejected (the same DoS guard fill/formula ranges use); an unknown sheet too.
+- `Workbook::paste(sheet, dst_anchor) -> bool`: place the block so its top-left
+  lands at `dst_anchor`. The whole block's references shift by
+  `dst_anchor − anchor` via `FormulaAst::shift` (relative refs track, absolute
+  `$` refs pin, off-grid → `#REF!`); content + format ride along. Every cell of
+  the destination rectangle is written, so blanks in the source **erase** their
+  targets. A cut then clears the source cells it didn't overwrite and consumes
+  the buffer. Returns `false` (a no-op) for an empty clipboard, unknown sheet, or
+  a destination rectangle that would run past the u32 grid edge — never silently
+  truncates or wraps. The block-shift delta is computed in `i64` then clamped
+  into `shift`'s `i32` contract, so a paste anchored at a high coordinate can't
+  overflow. `has_clipboard()` reports whether a block is held.
+- Known divergence (documented in code + spec): a **cut** shifts the moved
+  formulas' own references like a copy, rather than preserving them as Excel's
+  move does (Excel additionally rewrites outside references that pointed into the
+  moved range). This keeps cut a thin layer over the copy machinery.
+- 8 new tests: whole-block ref-shift, format-carry + absolute-pin, blank-cell
+  erase, cut-move-and-clear (+ one-shot), off-grid reject (buffer kept),
+  oversized-range reject, empty-clipboard no-op, unknown-sheet no-op.
+
 ## 0.7.0
 
 **Fill / replicate (drag-fill)** — `Workbook::fill` plus the `FormulaAst::shift`

--- a/code/packages/rust/spreadsheet-core/Cargo.toml
+++ b/code/packages/rust/spreadsheet-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spreadsheet-core"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
 description = "Headless spreadsheet engine — cell model, formula AST, dependency DAG, recalc, dispatch to Layer-1 cores. The engine VisiCalc Modern and any other Mosaic-rendered spreadsheet sits on top of."
 

--- a/code/packages/rust/spreadsheet-core/src/workbook.rs
+++ b/code/packages/rust/spreadsheet-core/src/workbook.rs
@@ -39,6 +39,46 @@ pub struct Workbook {
     /// `changed_since(r)` with `r < dropped_revision` can't prove completeness
     /// and must answer `Stale`.
     dropped_revision: u64,
+    /// The clipboard buffer set by [`copy`]/[`cut`] and consumed by [`paste`].
+    /// `None` until something is copied. A copy survives any number of pastes; a
+    /// cut is one-shot (the buffer is taken on the paste that moves it).
+    ///
+    /// [`copy`]: Workbook::copy
+    /// [`cut`]: Workbook::cut
+    /// [`paste`]: Workbook::paste
+    clipboard: Option<Clipboard>,
+}
+
+/// A copied/cut rectangle, captured relative to the source range's top-left
+/// anchor so it can be pasted anywhere. Content + format ride along; on paste
+/// the whole block shifts its references by `dst_anchor − anchor`.
+struct Clipboard {
+    /// The sheet the snapshot came from.
+    sheet: SheetId,
+    /// The source range's top-left cell — paste shifts references by the
+    /// destination anchor's offset from here.
+    anchor: CellAddress,
+    /// The full source rectangle (kept so a `cut` paste can clear the origin).
+    source: CellRange,
+    /// Source rectangle size; paste clears this whole rectangle at the
+    /// destination, so blank source cells erase their targets (Excel-style).
+    rows: u32,
+    cols: u32,
+    /// The non-blank source cells, each as a `(d_row, d_col)` offset from
+    /// `anchor` plus its content and format. Sparse: blank cells are omitted and
+    /// reconstructed as "clear the target" from `rows`×`cols`.
+    cells: Vec<ClipCell>,
+    /// `true` for a cut — paste clears the source cells it didn't overwrite and
+    /// then consumes the buffer. `false` for a copy (repeatable paste).
+    is_cut: bool,
+}
+
+/// One snapshotted cell in a [`Clipboard`], at `(d_row, d_col)` from the anchor.
+struct ClipCell {
+    d_row: u32,
+    d_col: u32,
+    content: CellContent,
+    format: Option<String>,
 }
 
 struct Sheet {
@@ -64,6 +104,7 @@ impl Workbook {
             revision: 0,
             changes: VecDeque::new(),
             dropped_revision: 0,
+            clipboard: None,
         }
     }
 
@@ -611,6 +652,245 @@ impl Workbook {
                 self.log_change(sheet, CellAddress::new(row, col));
             }
         }
+    }
+
+    // ----------------------------------------------------------------
+    // Clipboard — cut / copy / paste
+    // ----------------------------------------------------------------
+
+    /// Copy `range` into the clipboard, capturing each cell's content **and**
+    /// format relative to the range's top-left anchor. The source is left
+    /// untouched and the buffer survives any number of [`paste`]s.
+    ///
+    /// This is `fill`'s sibling, generalised from one source cell to a whole
+    /// rectangle: where fill shifts each target's references by its own offset
+    /// from the source, a copy preserves the block's internal structure and
+    /// shifts it as a unit on paste (`=A1` copied two columns right pastes as
+    /// `=C1`). A `range` larger than [`MAX_RANGE_CELLS`] is rejected (the same
+    /// DoS guard fill and formula ranges use); an unknown `sheet` is a no-op.
+    ///
+    /// [`paste`]: Workbook::paste
+    pub fn copy(&mut self, sheet: SheetId, range: CellRange) {
+        self.snapshot(sheet, range, false);
+    }
+
+    /// Cut `range` into the clipboard. Identical to [`copy`] except the buffer is
+    /// marked as a move: the [`paste`] that places it clears the source cells it
+    /// did not overwrite and then consumes the buffer (a cut pastes once).
+    ///
+    /// The source is *not* cleared here — only on paste — so a cut with no
+    /// following paste leaves the sheet unchanged, matching a spreadsheet's
+    /// "marching ants" behaviour.
+    ///
+    /// [`copy`]: Workbook::copy
+    /// [`paste`]: Workbook::paste
+    pub fn cut(&mut self, sheet: SheetId, range: CellRange) {
+        self.snapshot(sheet, range, true);
+    }
+
+    /// Shared capture for [`copy`]/[`cut`]: snapshot the non-blank cells of
+    /// `range` (content + format) as offsets from its anchor.
+    fn snapshot(&mut self, sheet: SheetId, range: CellRange, is_cut: bool) {
+        if self.sheets.get(sheet.0 as usize).is_none() {
+            return;
+        }
+        // DoS guard: cap the rectangle a single copy/cut can capture.
+        if range.cell_count() > MAX_RANGE_CELLS {
+            return;
+        }
+
+        let anchor = range.start;
+        let rows = range.end.row - range.start.row + 1;
+        let cols = range.end.col - range.start.col + 1;
+
+        let s = &self.sheets[sheet.0 as usize];
+        let mut cells = Vec::new();
+        for row in range.start.row..=range.end.row {
+            for col in range.start.col..=range.end.col {
+                let addr = CellAddress::new(row, col);
+                let content = s.cells.get(&addr).map(|c| c.content.clone());
+                let format = s.formats.get(&addr).cloned();
+                // Skip cells that are blank in both content and format — they
+                // erase their targets, which `paste` already does for any
+                // offset not present in `cells`.
+                if content.is_none() && format.is_none() {
+                    continue;
+                }
+                cells.push(ClipCell {
+                    d_row: row - anchor.row,
+                    d_col: col - anchor.col,
+                    content: content.unwrap_or(CellContent::Empty),
+                    format,
+                });
+            }
+        }
+
+        self.clipboard = Some(Clipboard {
+            sheet,
+            anchor,
+            source: range,
+            rows,
+            cols,
+            cells,
+            is_cut,
+        });
+    }
+
+    /// Paste the clipboard so its top-left lands at `dst_anchor` on `sheet`.
+    ///
+    /// The whole block's references shift by `dst_anchor − anchor` via
+    /// [`FormulaAst::shift`] (relative refs track, absolute `$` refs pin, a ref
+    /// pushed off the grid becomes `#REF!`); content and format ride along. Every
+    /// cell of the destination rectangle is written, so blanks in the source
+    /// erase their targets. A **cut** then clears the source cells it didn't
+    /// overwrite and consumes the buffer; a **copy** leaves the buffer for reuse.
+    ///
+    /// No-op (returning `false`) if the clipboard is empty, `sheet` is unknown,
+    /// or the destination rectangle would run past the grid's last row/column —
+    /// the engine never silently truncates or wraps an off-grid paste. Returns
+    /// `true` when a paste was applied.
+    ///
+    /// > Note: for a cut, the moved formulas' own references are *shifted* like a
+    /// > copy, rather than preserved as Excel's move does (Excel also rewrites
+    /// > outside references that pointed into the moved range). This keeps cut a
+    /// > thin layer over the copy machinery; the divergence is documented here
+    /// > and in the spec.
+    pub fn paste(&mut self, sheet: SheetId, dst_anchor: CellAddress) -> bool {
+        // Take the buffer up front; restore it for a copy (repeatable), drop it
+        // for a cut (one-shot). Avoids borrowing `self.clipboard` across the
+        // mutations below.
+        let clip = match self.clipboard.take() {
+            Some(c) => c,
+            None => return false,
+        };
+        if self.sheets.get(sheet.0 as usize).is_none() {
+            self.clipboard = Some(clip); // sheet gone — leave the buffer intact
+            return false;
+        }
+
+        // Reject a paste whose rectangle would extend past the u32 grid edge,
+        // rather than wrap or clamp. `rows`/`cols` are ≥ 1, so subtract before
+        // adding to avoid overflow.
+        let last_row = dst_anchor.row as u64 + (clip.rows - 1) as u64;
+        let last_col = dst_anchor.col as u64 + (clip.cols - 1) as u64;
+        if last_row > u32::MAX as u64 || last_col > u32::MAX as u64 {
+            self.clipboard = Some(clip);
+            return false;
+        }
+
+        // The block shifts by the destination anchor's offset from the source
+        // anchor. i64 then clamped into shift's i32 contract — u32 coordinates
+        // up to ~4.3e9 would overflow an i32 subtraction (panic in debug, wrap in
+        // release); the clamp keeps it in range and any off-grid ref still
+        // collapses to #REF! inside `shift`.
+        let d_row =
+            (dst_anchor.row as i64 - clip.anchor.row as i64).clamp(i32::MIN as i64, i32::MAX as i64) as i32;
+        let d_col =
+            (dst_anchor.col as i64 - clip.anchor.col as i64).clamp(i32::MIN as i64, i32::MAX as i64) as i32;
+
+        // Index the snapshot by offset for O(1) lookup as we sweep the rectangle.
+        let mut by_offset: HashMap<(u32, u32), &ClipCell> = HashMap::new();
+        for c in &clip.cells {
+            by_offset.insert((c.d_row, c.d_col), c);
+        }
+
+        // Write every cell of the destination rectangle: snapshot cells get the
+        // shifted content + format, blanks clear their target.
+        for dr in 0..clip.rows {
+            for dc in 0..clip.cols {
+                let target = CellAddress::new(dst_anchor.row + dr, dst_anchor.col + dc);
+                let s = &mut self.sheets[sheet.0 as usize];
+                match by_offset.get(&(dr, dc)) {
+                    Some(cell) => {
+                        let new_content = match &cell.content {
+                            CellContent::Empty => CellContent::Empty,
+                            CellContent::Value(v) => CellContent::Value(v.clone()),
+                            CellContent::Formula { ast, .. } => {
+                                let shifted = ast.shift(d_row, d_col);
+                                CellContent::Formula {
+                                    text: shifted.to_formula_string(),
+                                    ast: shifted,
+                                    cached: None,
+                                }
+                            }
+                        };
+                        match new_content {
+                            CellContent::Empty => {
+                                s.cells.remove(&target);
+                            }
+                            content => {
+                                s.cells.insert(target, Cell { content });
+                            }
+                        }
+                        match &cell.format {
+                            Some(code) => {
+                                s.formats.insert(target, code.clone());
+                            }
+                            None => {
+                                s.formats.remove(&target);
+                            }
+                        }
+                    }
+                    None => {
+                        // Blank in the source → erase the target's content + format.
+                        s.cells.remove(&target);
+                        s.formats.remove(&target);
+                    }
+                }
+            }
+        }
+
+        // A cut moves: clear the source cells the paste didn't already overwrite
+        // (same sheet AND inside the destination rectangle = already rewritten).
+        if clip.is_cut {
+            let dst_end_row = dst_anchor.row + clip.rows - 1;
+            let dst_end_col = dst_anchor.col + clip.cols - 1;
+            for row in clip.source.start.row..=clip.source.end.row {
+                for col in clip.source.start.col..=clip.source.end.col {
+                    let covered = clip.sheet == sheet
+                        && row >= dst_anchor.row
+                        && row <= dst_end_row
+                        && col >= dst_anchor.col
+                        && col <= dst_end_col;
+                    if covered {
+                        continue;
+                    }
+                    let src_sheet = &mut self.sheets[clip.sheet.0 as usize];
+                    let addr = CellAddress::new(row, col);
+                    src_sheet.cells.remove(&addr);
+                    src_sheet.formats.remove(&addr);
+                }
+            }
+        }
+
+        // References changed en masse; rebuild edges, recalc once (one revision
+        // bump), then log every touched cell so a viewport `changed_since`
+        // snapshot taken before the paste sees the moves.
+        self.rebuild_dependency_graph();
+        self.recalc_all();
+        for dr in 0..clip.rows {
+            for dc in 0..clip.cols {
+                self.log_change(sheet, CellAddress::new(dst_anchor.row + dr, dst_anchor.col + dc));
+            }
+        }
+        if clip.is_cut {
+            for row in clip.source.start.row..=clip.source.end.row {
+                for col in clip.source.start.col..=clip.source.end.col {
+                    self.log_change(clip.sheet, CellAddress::new(row, col));
+                }
+            }
+        }
+
+        // A copy's buffer survives for further pastes; a cut's is consumed.
+        if !clip.is_cut {
+            self.clipboard = Some(clip);
+        }
+        true
+    }
+
+    /// Whether the clipboard currently holds a copied/cut block.
+    pub fn has_clipboard(&self) -> bool {
+        self.clipboard.is_some()
     }
 
     /// Rebuild the entire cross-sheet dependency graph from the current formula
@@ -1457,5 +1737,129 @@ mod tests {
         wb.fill(SheetId(9), cell(1, 1), CellRange::new(cell(1, 1), cell(2, 2)));
         // No panic, nothing created.
         assert_eq!(wb.sheet_count(), 0);
+    }
+
+    // ── Clipboard: cut / copy / paste ────────────────────────────────
+
+    #[test]
+    fn copy_paste_shifts_a_block_as_a_unit() {
+        // A 1×2 block B1:C1 where C1 = B1*2. Copy it and paste at B2 → the block
+        // moves down one row: B2 keeps its literal, C2 = B2*2 (the relative ref
+        // tracked the whole-block shift).
+        let mut wb = Workbook::new();
+        let s = wb.add_sheet("S");
+        wb.set_value(s, cell(1, 2), CellValue::Number(5.0)); // B1 = 5
+        wb.set_formula(s, cell(1, 3), "=B1*2").unwrap(); // C1 = 10
+        wb.copy(s, CellRange::new(cell(1, 2), cell(1, 3))); // copy B1:C1
+        assert!(wb.has_clipboard());
+        assert!(wb.paste(s, cell(2, 2))); // paste at B2
+
+        assert_eq!(wb.get_value(s, cell(2, 2)), Some(CellValue::Number(5.0))); // B2
+        assert_eq!(wb.get_value(s, cell(2, 3)), Some(CellValue::Number(10.0))); // C2 = B2*2
+        // Source is untouched and a copy's buffer survives for another paste.
+        assert_eq!(wb.get_value(s, cell(1, 2)), Some(CellValue::Number(5.0)));
+        assert!(wb.has_clipboard());
+        assert!(wb.paste(s, cell(3, 2))); // paste again at B3
+        assert_eq!(wb.get_value(s, cell(3, 3)), Some(CellValue::Number(10.0))); // C3 = B3*2
+    }
+
+    #[test]
+    fn copy_carries_format_and_pins_absolute_refs() {
+        // A1 = 1234.5 formatted; B1 = =$A$1 (absolute). Copy A1:B1 and paste two
+        // rows down at A3: the format rides along, and the absolute ref stays
+        // pinned to $A$1 (does NOT shift), so B3 still reads A1's value.
+        let mut wb = Workbook::new();
+        let s = wb.add_sheet("S");
+        wb.set_value(s, cell(1, 1), CellValue::Number(1234.5));
+        wb.set_format(s, cell(1, 1), "#,##0.00");
+        wb.set_formula(s, cell(1, 2), "=$A$1").unwrap(); // B1 → 1234.5
+        wb.copy(s, CellRange::new(cell(1, 1), cell(1, 2)));
+        assert!(wb.paste(s, cell(3, 1))); // paste at A3
+
+        assert_eq!(wb.get_display(s, cell(3, 1)), "1,234.50"); // format carried
+        // Absolute ref pinned: B3 still points at $A$1 (1234.5), not A3.
+        assert_eq!(wb.get_value(s, cell(3, 2)), Some(CellValue::Number(1234.5)));
+    }
+
+    #[test]
+    fn paste_clears_blank_cells_of_the_source_rectangle() {
+        // Copy a 1×2 block whose second cell is blank over a destination whose
+        // matching cell is occupied — the blank must erase the target (a paste
+        // overwrites the whole rectangle, not just the non-blank cells).
+        let mut wb = Workbook::new();
+        let s = wb.add_sheet("S");
+        wb.set_value(s, cell(1, 1), CellValue::Number(7.0)); // A1 = 7, B1 blank
+        wb.set_value(s, cell(3, 2), CellValue::Number(99.0)); // B3 occupied (target)
+        wb.copy(s, CellRange::new(cell(1, 1), cell(1, 2))); // copy A1:B1
+        assert!(wb.paste(s, cell(3, 1))); // paste at A3:B3
+
+        assert_eq!(wb.get_value(s, cell(3, 1)), Some(CellValue::Number(7.0))); // A3 = 7
+        assert_eq!(wb.get_value(s, cell(3, 2)), None); // B3 erased by the blank
+    }
+
+    #[test]
+    fn cut_paste_moves_and_clears_the_source() {
+        // Cut A1 (=5) and paste at C1. The value moves; A1 is cleared; the buffer
+        // is consumed (a cut pastes once).
+        let mut wb = Workbook::new();
+        let s = wb.add_sheet("S");
+        wb.set_value(s, cell(1, 1), CellValue::Number(5.0));
+        wb.set_format(s, cell(1, 1), "#,##0.00");
+        wb.cut(s, CellRange::new(cell(1, 1), cell(1, 1)));
+        assert!(wb.paste(s, cell(1, 3))); // paste at C1
+
+        assert_eq!(wb.get_value(s, cell(1, 3)), Some(CellValue::Number(5.0))); // moved
+        assert_eq!(wb.get_format(s, cell(1, 3)), Some("#,##0.00")); // format moved too
+        assert_eq!(wb.get_value(s, cell(1, 1)), None); // source cleared
+        assert_eq!(wb.get_format(s, cell(1, 1)), None);
+        // Buffer consumed: a second paste does nothing.
+        assert!(!wb.has_clipboard());
+        assert!(!wb.paste(s, cell(1, 5)));
+        assert_eq!(wb.get_value(s, cell(1, 5)), None);
+    }
+
+    #[test]
+    fn paste_off_grid_is_rejected_and_keeps_the_buffer() {
+        // A 1×2 copy whose destination's second column would run past the last
+        // column (u32::MAX) is rejected wholesale — nothing is written and the
+        // buffer is preserved.
+        let mut wb = Workbook::new();
+        let s = wb.add_sheet("S");
+        wb.set_value(s, cell(1, 1), CellValue::Number(1.0));
+        wb.set_value(s, cell(1, 2), CellValue::Number(2.0));
+        wb.copy(s, CellRange::new(cell(1, 1), cell(1, 2))); // 1×2 block
+        // Anchor at the last column: the second cell would be at col u32::MAX+1.
+        assert!(!wb.paste(s, cell(1, u32::MAX)));
+        assert!(wb.has_clipboard()); // buffer kept for a valid paste
+        assert_eq!(wb.get_value(s, cell(1, u32::MAX)), None); // nothing written
+    }
+
+    #[test]
+    fn copy_oversized_range_captures_nothing() {
+        // A copy spanning more than MAX_RANGE_CELLS is rejected (DoS guard), so
+        // the clipboard stays empty and a following paste is a no-op.
+        let mut wb = Workbook::new();
+        let s = wb.add_sheet("S");
+        wb.set_value(s, cell(1, 1), CellValue::Number(1.0));
+        let huge = CellRange::new(cell(1, 1), cell((1 << 20) + 1, 1));
+        assert!(huge.cell_count() > MAX_RANGE_CELLS);
+        wb.copy(s, huge);
+        assert!(!wb.has_clipboard());
+        assert!(!wb.paste(s, cell(10, 10)));
+    }
+
+    #[test]
+    fn paste_with_empty_clipboard_is_noop() {
+        let mut wb = Workbook::new();
+        let s = wb.add_sheet("S");
+        assert!(!wb.has_clipboard());
+        assert!(!wb.paste(s, cell(1, 1)));
+    }
+
+    #[test]
+    fn copy_unknown_sheet_is_noop() {
+        let mut wb = Workbook::new();
+        wb.copy(SheetId(9), CellRange::new(cell(1, 1), cell(2, 2)));
+        assert!(!wb.has_clipboard());
     }
 }

--- a/code/specs/spreadsheet-core.md
+++ b/code/specs/spreadsheet-core.md
@@ -236,6 +236,40 @@ pub enum RecalcMode {
 The workbook is the unit of recalc. Multi-sheet dependencies live in
 the same graph.
 
+### Range operations — fill, cut/copy/paste
+
+Two operations replicate cells across the grid, both built on
+`FormulaAst::shift(d_row, d_col)` — a pure copy/paste reference rewrite that
+tracks **relative** refs and pins **absolute** (`$`) refs (the sibling of
+`adjust`, which moves both for structural edits). A reference shifted off the
+top/left edge collapses to `#REF!`.
+
+- **Fill** (`Workbook::fill(sheet, src, dst)`) replicates one `src` cell across
+  every cell of the `dst` range; each target shifts the formula by *its own*
+  offset from `src` (so `=A1` filled down a column becomes `=A2`, `=A3`, …). A
+  literal copies unchanged, an empty source clears each target, and the source's
+  display format rides along.
+
+- **Clipboard** (`copy`/`cut`/`paste`) captures a whole **rectangle** and shifts
+  it as a *unit*: every cell's formula shifts by the same block delta
+  `dst_anchor − src_anchor`, so the block's internal structure is preserved
+  (`=A1` copied two columns right pastes as `=C1`). `copy` leaves a reusable
+  buffer; `cut` is a one-shot move whose `paste` clears the source cells it
+  didn't overwrite. A paste overwrites the whole destination rectangle, so blank
+  source cells erase their targets; content and format both ride along.
+
+Both cap the affected range at `MAX_RANGE_CELLS` (DoS guard), treat an unknown
+sheet as a no-op, and compute their shift delta in `i64` clamped into `shift`'s
+`i32` contract so a high-coordinate operation can't overflow. `paste` returns
+`false` (writing nothing) when the clipboard is empty or the destination would
+run past the u32 grid edge.
+
+> Divergence from Excel: a **cut** shifts the moved formulas' own references
+> like a copy, rather than preserving them as a true move does. Excel's move
+> additionally rewrites *outside* references that pointed into the moved range;
+> the engine keeps cut a thin layer over the copy machinery and does not (yet)
+> track those inbound references.
+
 ---
 
 ## §5 The Dependency Graph


### PR DESCRIPTION
The **engine layer** of the cut/copy/paste campaign — the next cross-cutting feature within task #47, after [fill #6048](https://github.com/adhithyan15/coding-adventures/pull/6048). Built on the same `FormulaAst::shift` reference arithmetic. Where fill replicates one source cell across a range (each target shifts by its own offset), copy/paste captures a whole **rectangle** and shifts it as a unit, so the block's internal structure is preserved (`=A1` copied two columns right pastes as `=C1`).

This is the first of the campaign's PRs; the 3 facades and 6 demos follow the established fill rollout pattern.

## API (`Workbook`)
- **`copy(sheet, range)` / `cut(sheet, range)`** — snapshot the non-blank cells of `range` (content **and** format) as offsets from its top-left anchor. A copy survives any number of pastes; a cut is a one-shot move (buffer consumed on the paste that places it). The source is captured but **not cleared until paste** — a cut with no paste is a no-op (marching-ants semantics).
- **`paste(sheet, dst_anchor) -> bool`** — place the block at `dst_anchor`; the whole block's references shift by `dst_anchor − anchor` via `FormulaAst::shift` (relative track, absolute `$` pin, off-grid → `#REF!`); content + format ride along. The full destination rectangle is written, so source blanks **erase** their targets. A cut then clears the source cells it didn't overwrite and consumes the buffer. Returns `false` (no-op) for an empty clipboard, unknown sheet, or a destination past the u32 grid edge — never silently truncates or wraps.
- **`has_clipboard()`** — whether a block is held.

## Safety
- copy/cut cap capture at `MAX_RANGE_CELLS` (the fill/formula DoS guard), computed **before** the `rows`/`cols` spans so the `+1` can't overflow.
- paste's off-grid `u64` guard proves the later `u32` target additions can't overflow; the block-shift delta is `i64`-clamped into `shift`'s `i32` contract (the same pattern fill uses).
- Buffer lifecycle: `take()` up front, restored on every reject path, restored for a copy, dropped for a cut. No double-apply.

## Known divergence (documented in code + spec)
A **cut** shifts the moved formulas' own references like a copy, rather than preserving them as Excel's move does (Excel additionally rewrites *outside* references that pointed into the moved range). This keeps cut a thin layer over the copy machinery.

## Verification
`cargo test -p spreadsheet-core` — **156/156** (8 new clipboard tests: whole-block shift, format-carry + absolute-pin, blank-erase, cut-move-and-clear + one-shot, off-grid reject, oversized reject, empty/unknown no-ops). Workspace builds; the 3 downstream facades' tests still pass. Spec §4 gains a "Range operations" subsection covering fill + clipboard. `/security-review` passed in 1 round — every overflow / DoS / buffer-lifecycle path checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)