### PR TITLE
feat(logic-engine): context-precedence edges DERIVED by grounded meta-rules (ADJ73 PR-B-4)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/context_metarules_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/context_metarules_e2e.rs
@@ -1,0 +1,106 @@
+//! End-to-end golden test for the GROUNDED conflict-resolution META-RULES (ADJ73 PR-B-4) through
+//! the built CLI binary, on the committed artifacts.
+//!
+//! PR-B-3 asserted lex-superior edges as facts. PR-B-4 makes precedence DERIVED: a grounded
+//! meta-rule `rule { head: outranks_context($H, $L) when: reverses($H, $L) }` (citing the
+//! overruling doctrine) turns a primitive grounded `reverses` fact into a precedence edge, which
+//! the engine (logic-engine >= 0.21) reads as a context-order edge. These tests prove the derived
+//! edge drives `lex superior` end-to-end on the two worked examples, at 0 answer-time model calls:
+//!
+//!   * worked-appeal-example.adj — a Supreme Court reversal flips a (now-reversed) Ninth Circuit
+//!     reading that sits at the HIGHEST tier; the SCOTUS reading governs via the DERIVED edge.
+//!   * worked-supersession-example.adj — lex posterior: the 2024 guideline edition supersedes the
+//!     2004 one, so the current recommendation governs the legacy one.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+/// The context-precedence data dir, relative to this crate's manifest.
+fn data(name: &str) -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/context-precedence")
+        .join(name)
+}
+
+fn run(name: &str) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(data(name))
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+#[test]
+fn appeal_metarule_derives_the_edge_that_governs() {
+    let (ok, s) = run("worked-appeal-example.adj");
+    assert!(ok, "cli should succeed: {s}");
+    assert!(s.contains("\"governing\""), "has a governing section: {s}");
+
+    // The Supreme Court (narrow) reading governs, decided in the scotus_2023 context — purely
+    // because the appeal-status meta-rule DERIVED outranks_context(scotus_2023, ninth_circuit_2019)
+    // from the grounded `reverses` fact (no edge was asserted).
+    assert!(
+        s.contains("means(scope, narrow)"),
+        "carries the SCOTUS reading: {s}"
+    );
+    assert!(
+        s.contains("\"status\":\"governing\""),
+        "the SCOTUS reading governs: {s}"
+    );
+    assert!(
+        s.contains("\"context\":\"scotus_2023\""),
+        "governed in the scotus_2023 context: {s}"
+    );
+    // The reversed Ninth Circuit reading is defeated despite its `mandatory` tier.
+    assert!(
+        s.contains("\"status\":\"defeated\""),
+        "the reversed reading is defeated: {s}"
+    );
+    assert!(
+        s.contains("\"context\":\"ninth_circuit_2019\""),
+        "the defeated reading is the reversed Ninth Circuit one: {s}"
+    );
+    assert!(
+        s.contains("\"defeated_by\":\"means(scope, narrow)\""),
+        "defeated by the SCOTUS reading: {s}"
+    );
+    assert!(
+        s.contains("\"standing\":\"mandatory\""),
+        "the defeated reading carried the highest tier, yet lost on derived context: {s}"
+    );
+    assert!(
+        s.contains("\"has_conflict\":false"),
+        "clean override, not a split: {s}"
+    );
+}
+
+#[test]
+fn lex_posterior_metarule_picks_the_newer_edition() {
+    let (ok, s) = run("worked-supersession-example.adj");
+    assert!(ok, "cli should succeed: {s}");
+    // The 2024 (current) recommendation governs the 2004 (legacy) one via the derived edge.
+    assert!(
+        s.contains("recommendation(empiric_regimen, current)"),
+        "carries the current recommendation: {s}"
+    );
+    assert!(
+        s.contains("\"status\":\"governing\""),
+        "current recommendation governs: {s}"
+    );
+    assert!(
+        s.contains("\"context\":\"idsa_2024\""),
+        "governed in the idsa_2024 context: {s}"
+    );
+    assert!(
+        s.contains("\"defeated_by\":\"recommendation(empiric_regimen, current)\""),
+        "the legacy recommendation is defeated by the current one: {s}"
+    );
+    assert!(
+        s.contains("\"context\":\"idsa_2004\""),
+        "the defeated one is the 2004 edition: {s}"
+    );
+    assert!(
+        s.contains("\"has_conflict\":false"),
+        "clean supersession, not a split: {s}"
+    );
+}

--- a/code/packages/rust/logic-engine/CHANGELOG.md
+++ b/code/packages/rust/logic-engine/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.21.0] - 2026-06-17 — context-precedence edges can be DERIVED by meta-rules (ADJ73 PR-B-4)
+
+### Added
+
+- **`outranks_context` edges may now be RULE-DERIVED, not just asserted.** When the KB contains
+  rules whose head is `outranks_context/2` (the grounded conflict-resolution **meta-rules** — lex
+  posterior / appeal status / lex specialis), `KnowledgeBase::context_adjacency` enumerates every
+  provable `outranks_context($A, $B)` (via `enumerate_all`, which subsumes the ground facts as
+  one-step proofs) and feeds those edges into the same `lex superior` resolution. So a meta-rule
+  `outranks_context($H, $L) :- reverses($H, $L)` (itself citing the overruling doctrine) turns a
+  primitive grounded `reverses(a, b)` fact into a precedence edge — the recursive structure ADJ73
+  §7 calls for: an edge that can be derived is derived (and cited), not duplicated as a bare fact.
+- New private `KnowledgeBase::derived_context_edges` — enumerates the provable `outranks_context`
+  ground edges. Pure read; not re-entrant with `enumerate_governing` (queries a different predicate
+  and never consults the context order itself).
+
+### Unchanged (back-compat / performance)
+
+- With **no** `outranks_context` rules (the common case), `context_adjacency` keeps the cheap
+  ground-fact + explicit-edge scan — no SLD enumeration cost. All PR-B / PR-B-2 behavior is
+  byte-identical; `context_outranks` / `context_order_has_cycle` now key on owned `String`s
+  (derived answer terms are built during enumeration), but the DFS / Kahn-cycle semantics are
+  unchanged. Cycle detection spans derived edges too (a contradictory `reverses` pair is caught).
+
 ## [0.20.0] - 2026-06-17 — context-precedence edges as grounded facts (ADJ73 PR-B-2)
 
 ### Added

--- a/code/packages/rust/logic-engine/Cargo.toml
+++ b/code/packages/rust/logic-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "logic-engine"
-version = "0.20.0"
+version = "0.21.0"
 edition = "2021"
 description = "Probability-aware facts, rules, KB, SLD find-first/enumerate + WMC posterior + LP19e likelihood-ratio Bayesian aggregation."
 

--- a/code/packages/rust/logic-engine/README.md
+++ b/code/packages/rust/logic-engine/README.md
@@ -127,8 +127,23 @@ kb.add_fact(
 
 `context_adjacency()` unions the explicit and grounded edges into one directed graph, so the
 cycle check (a single Kahn pass) and `context_outranks` (a cycle-safe DFS) span both sources.
-The grounded `context-precedence` *rulebook* (a `.adj` library of such edges, each byte-quoting
-its charter) + a worked legal example through the CLI `governing` section land in PR-B-3
+
+**Derived precedence — meta-rules (v0.21).** Most precedence is not a standing hierarchy but is
+*derived* from a primitive fact about the two authorities (which came later, which reversed which).
+So `context_adjacency` also reads **rule-derived** `outranks_context` edges: when the KB has any
+`outranks_context/2` rule, it enumerates every provable edge (subsuming the ground facts). A
+grounded meta-rule then turns a primitive into precedence — `outranks_context($H, $L) :-
+reverses($H, $L)` (citing the overruling doctrine) makes a `reverses(a, b)` fact an edge `a > b`:
+
+```rust
+kb.add_rule(/* outranks_context(H, L) :- reverses(H, L) */);   // the appeal-status canon
+kb.add_fact(/* reverses(scotus_2023, ninth_circuit_2019) */);   // a primitive grounded fact
+assert!(kb.context_outranks("scotus_2023", "ninth_circuit_2019")); // edge DERIVED, not asserted
+```
+
+The recursion bottoms out at the primitive grounded facts, each byte-provenanced — an edge that can
+be derived is derived (and cited), not duplicated. The grounded `context-precedence` rulebook + its
+meta-rules + worked legal/medical examples live in `code/specs/data/context-precedence/`
 (`code/specs/ADJ73-defeasible-rule-precedence.md` §2.3, §7).
 
 ## Why Probability From Day One

--- a/code/packages/rust/logic-engine/src/lib.rs
+++ b/code/packages/rust/logic-engine/src/lib.rs
@@ -536,20 +536,42 @@ impl KnowledgeBase {
     /// edges as a directed ADJACENCY MAP `higher → [lowers]` so a graph walk does a single O(1)
     /// neighbour lookup per node instead of re-scanning the whole edge list (the context order is
     /// meant to scale to large rule corpora — e.g. a jurisdiction graph over the US Code — so the
-    /// walks below stay O(V+E), not O(V·E)). Borrows from `&self`, so the `&str`s live as long as
-    /// the borrow.
-    fn context_adjacency(&self) -> HashMap<&str, Vec<&str>> {
-        let mut adj: HashMap<&str, Vec<&str>> = HashMap::new();
+    /// walks below stay O(V+E), not O(V·E)).
+    ///
+    /// ADJ73 PR-B-4 — DERIVED edges. When the KB contains RULES whose head is `outranks_context/2`
+    /// (the grounded conflict-resolution META-RULES: lex posterior / lex specialis / appeal status),
+    /// the precedence order is no longer just hand-asserted facts — it is *derived* from more
+    /// primitive grounded facts (`supersedes`, `reverses`, …) via those rules. In that case we
+    /// enumerate every provable `outranks_context($A, $B)` (which subsumes the ground facts, since a
+    /// fact is a one-step derivation) so a meta-rule edge participates in `lex superior` exactly like
+    /// an asserted one. With no such rules (the common case) we keep the cheap ground-fact scan.
+    /// Returns OWNED strings because a derived answer term is built during enumeration, not borrowed
+    /// from `self`.
+    fn context_adjacency(&self) -> HashMap<String, Vec<String>> {
+        let mut adj: HashMap<String, Vec<String>> = HashMap::new();
         // 1. Explicit edges (the bare `context_order { a > b }` surface form).
         for (hi, lo) in &self.context_order {
-            adj.entry(hi.as_str()).or_default().push(lo.as_str());
+            adj.entry(hi.clone()).or_default().push(lo.clone());
         }
-        // 2. Grounded edges — any ground `outranks_context(higher, lower)` fact (both args atoms).
-        for fact in self.facts.values().flatten() {
-            if let Term::Compound { functor, args } = &fact.term {
-                if functor == "outranks_context" && args.len() == 2 {
-                    if let (Term::Atom(hi), Term::Atom(lo)) = (&args[0], &args[1]) {
-                        adj.entry(hi.as_str()).or_default().push(lo.as_str());
+        // 2. Grounded + DERIVED edges from the `outranks_context/2` relation.
+        let outranks_idx = ClauseIndex {
+            functor: "outranks_context".to_string(),
+            arity: 2,
+        };
+        if self.rules.contains_key(&outranks_idx) {
+            // Meta-rules can DERIVE precedence → enumerate every provable edge (this already
+            // includes the ground facts, each a one-step proof).
+            for (hi, lo) in self.derived_context_edges() {
+                adj.entry(hi).or_default().push(lo);
+            }
+        } else {
+            // No meta-rules → the cheap path: ground `outranks_context(hi, lo)` facts (both atoms).
+            for fact in self.facts.values().flatten() {
+                if let Term::Compound { functor, args } = &fact.term {
+                    if functor == "outranks_context" && args.len() == 2 {
+                        if let (Term::Atom(hi), Term::Atom(lo)) = (&args[0], &args[1]) {
+                            adj.entry(hi.clone()).or_default().push(lo.clone());
+                        }
                     }
                 }
             }
@@ -557,8 +579,34 @@ impl KnowledgeBase {
         adj
     }
 
+    /// ADJ73 PR-B-4: enumerate every provable `outranks_context($A, $B)` answer whose two arguments
+    /// resolve to atoms, returning the `(higher, lower)` ground edges. This is what lets a grounded
+    /// META-RULE (`rule { head: outranks_context($H, $L) when: reverses($H, $L) }`, itself citing the
+    /// canon) contribute precedence edges derived from primitive grounded facts. Pure read over the
+    /// KB (no mutation); not re-entrant with `enumerate_governing` because it queries a *different*
+    /// predicate and never consults the context order itself.
+    fn derived_context_edges(&self) -> Vec<(String, String)> {
+        let a = LogicVar::fresh(Some("A"));
+        let b = LogicVar::fresh(Some("B"));
+        let query = Term::Compound {
+            functor: "outranks_context".to_string(),
+            args: vec![Term::Var(a.clone()), Term::Var(b.clone())],
+        };
+        let dag = enumerate::enumerate_all(&query, self);
+        let mut edges = Vec::new();
+        for proof in &dag.proofs {
+            if let (Term::Atom(hi), Term::Atom(lo)) = (
+                proof.bindings.walk(&Term::Var(a.clone())),
+                proof.bindings.walk(&Term::Var(b.clone())),
+            ) {
+                edges.push((hi, lo));
+            }
+        }
+        edges
+    }
+
     /// ADJ73 PR-B: does context `a` outrank context `b` (directly or transitively)? Cycle-safe
-    /// DFS over the effective context adjacency (explicit + grounded-fact edges, see
+    /// DFS over the effective context adjacency (explicit + grounded/derived edges, see
     /// [`Self::context_adjacency`]). `a == b` is `false` (a context does not outrank itself).
     /// Returns `false` when there is no directed path `a → … → b`.
     pub fn context_outranks(&self, a: &str, b: &str) -> bool {
@@ -566,38 +614,38 @@ impl KnowledgeBase {
             return false;
         }
         let adj = self.context_adjacency();
-        let mut stack = vec![a];
+        let mut stack: Vec<&str> = vec![a];
         let mut seen: HashSet<&str> = HashSet::new();
         while let Some(node) = stack.pop() {
             if !seen.insert(node) {
                 continue; // already visited — cycle-safe
             }
             if let Some(neighbours) = adj.get(node) {
-                for &lo in neighbours {
+                for lo in neighbours {
                     if lo == b {
                         return true;
                     }
-                    stack.push(lo);
+                    stack.push(lo.as_str());
                 }
             }
         }
         false
     }
 
-    /// ADJ73 PR-B: `true` iff the effective context order (explicit + grounded-fact edges, see
+    /// ADJ73 PR-B: `true` iff the effective context order (explicit + grounded/derived edges, see
     /// [`Self::context_adjacency`]) contains a cycle (e.g. `a > b`, `b > a`, or a self-loop). The
     /// surface/loader should reject such a rulebook; the resolver itself stays safe regardless.
-    /// Catches a cycle formed *across* the two edge sources too (an explicit `a > b` plus a
-    /// grounded `outranks_context(b, a)` fact). Single Kahn topological-sort pass: a directed
+    /// Catches a cycle formed *across* the edge sources too (an explicit `a > b` plus a grounded or
+    /// meta-rule-derived `outranks_context(b, a)`). Single Kahn topological-sort pass: a directed
     /// acyclic graph fully drains to zero in-degree, so any node left unremoved lies on a cycle.
     pub fn context_order_has_cycle(&self) -> bool {
         let adj = self.context_adjacency();
         // In-degree of every node that appears as a head or a tail.
         let mut in_degree: HashMap<&str, usize> = HashMap::new();
-        for (&hi, lowers) in &adj {
-            in_degree.entry(hi).or_insert(0);
-            for &lo in lowers {
-                *in_degree.entry(lo).or_insert(0) += 1;
+        for (hi, lowers) in &adj {
+            in_degree.entry(hi.as_str()).or_insert(0);
+            for lo in lowers {
+                *in_degree.entry(lo.as_str()).or_insert(0) += 1;
             }
         }
         // Kahn: repeatedly retire a zero-in-degree node, decrementing its successors.
@@ -610,11 +658,13 @@ impl KnowledgeBase {
         while let Some(node) = ready.pop() {
             retired += 1;
             if let Some(neighbours) = adj.get(node) {
-                for &lo in neighbours {
-                    let d = in_degree.get_mut(lo).expect("successor was counted above");
+                for lo in neighbours {
+                    let d = in_degree
+                        .get_mut(lo.as_str())
+                        .expect("successor was counted above");
                     *d -= 1;
                     if *d == 0 {
-                        ready.push(lo);
+                        ready.push(lo.as_str());
                     }
                 }
             }
@@ -1456,5 +1506,95 @@ mod tests {
         )));
         assert!(!kb.context_outranks("federal", "state"));
         assert!(!kb.context_order_has_cycle());
+    }
+
+    // -----------------------------------------------------------------------
+    // ADJ73 PR-B-4 — DERIVED context-precedence edges (grounded meta-rules).
+    //
+    // The precedence ORDER itself can be derived: a meta-rule
+    //   outranks_context(H, L) :- reverses(H, L).
+    // (the appeal-status canon) turns a primitive grounded fact `reverses(a, b)`
+    // into a precedence edge a > b. These tests prove a rule-derived edge drives
+    // `context_outranks` exactly like an asserted one — the recursive structure
+    // ADJ73 §7 calls for (an edge that can be derived is derived, not duplicated).
+    // -----------------------------------------------------------------------
+
+    /// Helper: the appeal-status meta-rule `outranks_context(H, L) :- reverses(H, L)`.
+    fn reverses_metarule() -> Rule {
+        let h = var("H");
+        let l = var("L");
+        Rule::certain(
+            compound(
+                "outranks_context",
+                vec![Term::Var(h.clone()), Term::Var(l.clone())],
+            ),
+            vec![BodyLiteral::Pos(compound(
+                "reverses",
+                vec![Term::Var(h), Term::Var(l)],
+            ))],
+        )
+    }
+
+    #[test]
+    fn metarule_derived_edge_drives_context_outranks() {
+        // No asserted outranks_context edge — only a primitive `reverses` fact + the meta-rule.
+        let mut kb = empty_kb();
+        kb.add_rule(reverses_metarule());
+        kb.add_fact(Fact::certain(compound(
+            "reverses",
+            vec![atom("scotus_2023"), atom("ninth_circuit_2019")],
+        )));
+        assert!(
+            kb.context_outranks("scotus_2023", "ninth_circuit_2019"),
+            "the meta-rule should DERIVE the precedence edge from the reverses fact"
+        );
+        assert!(!kb.context_outranks("ninth_circuit_2019", "scotus_2023"));
+        assert!(!kb.context_order_has_cycle());
+    }
+
+    #[test]
+    fn derived_and_explicit_edges_compose_transitively() {
+        // explicit federal > scotus_2023; derived scotus_2023 > ninth_circuit_2019 (via reverses).
+        // Transitive reach federal → ninth_circuit_2019 must hold across both kinds.
+        let mut kb = empty_kb();
+        kb.add_context_outranks("federal", "scotus_2023");
+        kb.add_rule(reverses_metarule());
+        kb.add_fact(Fact::certain(compound(
+            "reverses",
+            vec![atom("scotus_2023"), atom("ninth_circuit_2019")],
+        )));
+        assert!(kb.context_outranks("federal", "ninth_circuit_2019"));
+    }
+
+    #[test]
+    fn derived_edges_are_cycle_checked() {
+        // Two reverses facts forming a cycle (a reverses b, b reverses a) → detectable, never a
+        // wrong silent pick. (Degenerate, but the resolver must stay safe on contradictory input.)
+        let mut kb = empty_kb();
+        kb.add_rule(reverses_metarule());
+        kb.add_fact(Fact::certain(compound(
+            "reverses",
+            vec![atom("ruling_a"), atom("ruling_b")],
+        )));
+        kb.add_fact(Fact::certain(compound(
+            "reverses",
+            vec![atom("ruling_b"), atom("ruling_a")],
+        )));
+        assert!(kb.context_order_has_cycle());
+    }
+
+    #[test]
+    fn no_metarule_keeps_the_ground_fact_fast_path() {
+        // With no outranks_context RULES, only ground facts are edges (back-compat / cheap path).
+        // A `reverses` fact alone (no meta-rule) injects NO precedence.
+        let mut kb = empty_kb();
+        kb.add_fact(Fact::certain(compound(
+            "reverses",
+            vec![atom("a"), atom("b")],
+        )));
+        assert!(!kb.context_outranks("a", "b"));
+        // A ground outranks_context fact still works without any rule.
+        kb.add_fact(outranks_context_fact("a", "b"));
+        assert!(kb.context_outranks("a", "b"));
     }
 }

--- a/code/specs/ADJ73-defeasible-rule-precedence.md
+++ b/code/specs/ADJ73-defeasible-rule-precedence.md
@@ -350,9 +350,20 @@ Each PR: spec-sync note, tests incl. a CONFLICT/abstain case, `/security-review`
     legal example that `import`s it and proves *lex superior* end-to-end through the CLI: the
     circuit's broad reading **governs** a district court's narrow reading **despite its higher
     `mandatory` tier**. Governing answers now carry their `context` in the JSON. Golden test
-    `adj-lang-cli/tests/context_precedence_e2e.rs`. Still to come: the recency / appeal-status /
-    lex-specialis **meta-rules** (PR-B-4) that *derive* precedence from grounded rule attributes
-    (e.g. `idsa_2024 > idsa_2004` as lex posterior) rather than asserting each edge bare.
+    `adj-lang-cli/tests/context_precedence_e2e.rs`.
+  - **PR-B-4 grounded meta-rules ✅ DONE (logic-engine 0.21).** `context_adjacency` now reads
+    **rule-derived** `outranks_context` edges (enumerated via `enumerate_all` when any
+    `outranks_context/2` rule exists; the cheap ground-fact scan is kept otherwise). So the
+    conflict-resolution canons are themselves grounded meta-rules in `context-precedence-meta.adj`:
+    `outranks_context($H,$L) :- reverses($H,$L)` (appeal status, citing the overruling doctrine)
+    and `… :- supersedes($New,$Old)` (lex posterior / recency, citing implied-repeal). Two worked
+    examples prove it end-to-end through the CLI — a Supreme Court reversal flips a `mandatory`-tier
+    reversed Ninth Circuit reading (`worked-appeal-example.adj`), and `idsa_2024 > idsa_2004` is
+    *derived* from a grounded `supersedes` fact (`worked-supersession-example.adj`). The recursion
+    bottoms out at cited primitive facts — an edge that can be derived is derived, not duplicated.
+    Golden test `adj-lang-cli/tests/context_metarules_e2e.rs`. Still to come: **lex specialis**
+    (needs a comparable specificity attribute on rules) + the lex-specialis-vs-lex-superior
+    tiebreaker meta-rule (§4.3).
 - **PR-C — adj-lang surface** (`priority: <tier>`, `functional`/`decision`, the attribute
   annotations) + regen grammar.
 - **PR-D — MYCIN `decide_timing` → `timing.adj`** on the named-enum ladder (was PR-4).

--- a/code/specs/data/context-precedence/README.md
+++ b/code/specs/data/context-precedence/README.md
@@ -9,6 +9,9 @@ own rulebook, with a citation on *why* one context outranks another (ADJ73 decis
 |------|------|
 | [`context-precedence.adj`](context-precedence.adj) | The grounded precedence order: `outranks_context(higher, lower)` edges, each carrying a verbatim charter (`source`/`locator`/`trust`). The logic-engine (≥ 0.20) reads these facts as directed edges and applies *lex superior* before the priority tier. |
 | [`worked-legal-example.adj`](worked-legal-example.adj) | A case that `import`s the rulebook: two courts read "navigable waters" differently; the Ninth Circuit's reading **governs** the district court's *despite a lower tier*, because `ninth_circuit` outranks `district_court`. |
+| [`context-precedence-meta.adj`](context-precedence-meta.adj) | **PR-B-4** — the recursive conflict-resolution **canons** as grounded meta-rules: `outranks_context($H,$L) :- reverses($H,$L)` (appeal status) and `… :- supersedes($New,$Old)` (lex posterior / recency), each citing its doctrine. The engine (≥ 0.21) reads rule-*derived* edges, so a primitive grounded fact (`reverses`/`supersedes`) becomes precedence. |
+| [`worked-appeal-example.adj`](worked-appeal-example.adj) | A Supreme Court reversal flips a (now-reversed) Ninth Circuit reading at the **highest** tier — the precedence edge is **derived** by the appeal-status meta-rule from a grounded `reverses` fact, not asserted. |
+| [`worked-supersession-example.adj`](worked-supersession-example.adj) | Lex posterior (bridges to MYCIN): the 2024 guideline edition supersedes the 2004 one, so the current recommendation governs the legacy one — `idsa_2024 > idsa_2004` derived from a grounded `supersedes` fact. |
 | [`SOURCES.md`](SOURCES.md) | The provenance ledger — where each edge's verbatim quote came from. |
 
 ## Run it
@@ -37,8 +40,11 @@ This is the data/worked-example layer of the ADJ73 precedence arc:
 - **engine** (logic-engine 0.19) — `context_outranks`, lex-superior `defeats`.
 - **grounded edges** (logic-engine 0.20, PR-B-2) — `outranks_context` facts participate as edges.
 - **surface** (adj-lang 0.16) — `context:` on a rule, `context_order { … }`.
-- **this** (PR-B-3) — the grounded rulebook + worked legal example end-to-end through the CLI.
-- **next** (PR-B-4) — the recursive conflict-resolution **meta-rules** (lex posterior / recency,
-  lex specialis, appeal status) that *derive* precedence from grounded rule attributes rather
-  than asserting it edge-by-edge. See [`SOURCES.md`](SOURCES.md) and the spec
+- **edges** (logic-engine 0.20, PR-B-3) — the grounded lex-superior rulebook + worked legal example.
+- **meta-rules** (logic-engine 0.21, PR-B-4) — the recursive conflict-resolution **canons** (appeal
+  status, lex posterior / recency) as grounded meta-rules that *derive* precedence from primitive
+  grounded facts (`reverses`, `supersedes`). The engine reads rule-derived `outranks_context` edges,
+  so the recursion bottoms out at cited primitives — an edge that can be derived is derived.
+- **next** — lex specialis (the more specific rule controls), once rules carry a comparable
+  specificity attribute. See [`SOURCES.md`](SOURCES.md) and the spec
   `code/specs/ADJ73-defeasible-rule-precedence.md` §7.

--- a/code/specs/data/context-precedence/context-precedence-meta.adj
+++ b/code/specs/data/context-precedence/context-precedence-meta.adj
@@ -1,0 +1,68 @@
+% =====================================================================
+% context-precedence-meta.adj — the RECURSIVE conflict-resolution canons
+% (ADJ73 PR-B-4, decision §2.3 / §7: "everything in this work is recursive;
+%  each [canon] has its own byte provenance").
+%
+% PR-B-3 grounded the LEX-SUPERIOR edges (federal>state, ninth_circuit>
+% district_court) by ASSERTING them as `relate outranks_context(...)` facts.
+% But most precedence is not a standing hierarchy — it is DERIVED from a more
+% primitive fact about the two authorities: which came later, which reversed
+% which, which is more specific. Hard-asserting an `outranks_context` edge for
+% every such pair would (a) duplicate a derivable fact and (b) hide the WHY.
+%
+% So the other classical canons are themselves GROUNDED META-RULES: a
+% `rule { head: outranks_context($H, $L) when: <primitive>($H, $L) }` whose
+% `source` cites the canon's authority. The engine (logic-engine >= 0.21) reads
+% DERIVED `outranks_context` answers as context-order edges exactly like
+% asserted ones (KnowledgeBase::context_adjacency enumerates them), so a
+% meta-rule edge drives `lex superior` end-to-end. The recursion bottoms out at
+% the primitive grounded facts a case supplies (`reverses(...)`, `supersedes(...)`),
+% which carry their own byte-provenance — turtles all the way down, every layer
+% cited and CAS-correctable.
+%
+% USE: a case file `import`s this rulebook, asserts the primitive facts for its
+% authorities (`relate reverses(scotus_2023, ninth_circuit_2019) source "<the
+% appellate record>" ...`), and the canons derive the precedence. See
+% worked-appeal-example.adj and worked-supersession-example.adj.
+% =====================================================================
+
+% ---------------------------------------------------------------------
+% CANON 1 — APPEAL STATUS (lex posterior's cousin in case law). A holding that
+% a higher court has reversed/overruled is no longer binding; the reversing
+% court's holding controls. So `reverses(H, L)` ⇒ context H outranks context L.
+%
+% Verbatim charter (the doctrine of overruling):
+%   "overruled, if the same or higher courts on appeal or determination of
+%    subsequent cases found the principles underpinning the previous decision
+%    erroneous in law or overtaken by new legislation or developments"
+% ---------------------------------------------------------------------
+rule {
+  head: outranks_context($Higher, $Lower)
+  when: reverses($Higher, $Lower)
+  source "Overruling/reversal strips precedential force — Precedent (Wikipedia), on a holding being \"overruled, if the same or higher courts on appeal or determination of subsequent cases found the principles underpinning the previous decision erroneous in law or overtaken by new legislation or developments.\" The reversing court's holding controls; the reversed one is no longer binding."
+  locator "Wikipedia, \"Precedent\" — Overruling"
+  trust authoritative
+}
+
+% ---------------------------------------------------------------------
+% CANON 2 — LEX POSTERIOR (recency / implied repeal). A later enactment or
+% edition prevails over an earlier conflicting one. So `supersedes(New, Old)`
+% ⇒ context New outranks context Old. This is the canon behind a newer clinical
+% guideline edition outranking the prior one (idsa_2024 > idsa_2004): the case
+% supplies `relate supersedes(idsa_2024, idsa_2004) source "<the 2024 guideline's
+% statement that it replaces the 2004 edition>"`, and this rule derives the edge.
+%
+% Verbatim charter (doctrine of implied repeal / lex posterior derogat priori):
+%   "The doctrine of implied repeal is a concept in constitutional theory which
+%    states that where an act of Parliament or an act of Congress (or of some
+%    other legislature) conflicts with an earlier one, the later Act takes
+%    precedence and the conflicting parts of the earlier Act become legally
+%    inoperable."
+% ---------------------------------------------------------------------
+rule {
+  head: outranks_context($New, $Old)
+  when: supersedes($New, $Old)
+  source "Lex posterior derogat priori (implied repeal) — Implied repeal (Wikipedia): \"The doctrine of implied repeal is a concept in constitutional theory which states that where an act of Parliament or an act of Congress (or of some other legislature) conflicts with an earlier one, the later Act takes precedence and the conflicting parts of the earlier Act become legally inoperable.\" A later edition/enactment outranks the earlier conflicting one."
+  locator "Wikipedia, \"Implied repeal\" — leges posteriores priores contrarias abrogant"
+  trust authoritative
+}

--- a/code/specs/data/context-precedence/worked-appeal-example.adj
+++ b/code/specs/data/context-precedence/worked-appeal-example.adj
@@ -1,0 +1,59 @@
+% =====================================================================
+% worked-appeal-example.adj — precedence DERIVED by a meta-rule (ADJ73 PR-B-4).
+%
+% THE CASE.  A statutory term "scope" was read BROADLY by a Ninth Circuit panel
+% in 2019. In 2023 the Supreme Court reversed that panel and read it NARROWLY.
+% Both readings are in the record, so they CONFLICT. Which governs?
+%
+% There is NO hand-asserted `outranks_context(scotus_2023, ninth_circuit_2019)`
+% edge. Instead the case supplies one primitive grounded fact —
+% `reverses(scotus_2023, ninth_circuit_2019)` — and the APPEAL-STATUS meta-rule
+% (context-precedence-meta.adj, canon 1) DERIVES the precedence edge from it.
+% The derived edge drives lex superior:
+%
+%   means(scope, narrow)  status governing   context scotus_2023
+%   means(scope, broad)   status defeated     context ninth_circuit_2019
+%                         defeated_by means(scope, narrow)
+%
+% The trap is set as in PR-B-3: the (now-reversed) Ninth Circuit reading is
+% asserted at the HIGHEST `mandatory` tier, the Supreme Court reading at the
+% default tier — and context precedence (derived from `reverses`) still flips it.
+% 0 answer-time model calls. The precedence is auditable AND recursive: the edge
+% comes from the meta-rule (which cites the overruling doctrine) applied to the
+% `reverses` fact (which cites the appellate record).
+% =====================================================================
+
+% The recursive canons (appeal status, lex posterior), each citing its doctrine.
+import "context-precedence-meta.adj"
+
+% A statutory term has at most one governing reading.
+functional means(term, reading)
+
+% The PRIMITIVE grounded fact for this case: the 2023 Supreme Court decision
+% reversed the 2019 Ninth Circuit panel. (In a real pipeline this is decomposed
+% from the appellate record; here it carries that record as its source.)
+relate reverses(scotus_2023, ninth_circuit_2019)
+  source "Supreme Court (2023) reversed the Ninth Circuit panel (2019) on the meaning of the statutory term."
+  locator "appellate record — judgment reversed"
+  trust authoritative
+
+% The reversed Ninth Circuit reading (broad), at the HIGHEST tier — yet reversed.
+rule {
+  head: means(scope, broad)
+  when: ninth_circuit_held
+  priority: mandatory
+  context: ninth_circuit_2019
+}
+
+% The Supreme Court reading (narrow), at the default tier — governs on derived context.
+rule {
+  head: means(scope, narrow)
+  when: scotus_held
+  context: scotus_2023
+}
+
+observe ninth_circuit_held
+observe scotus_held
+
+% Which reading governs?  (the meta-rule-derived edge resolves it)
+? means(scope, $reading)

--- a/code/specs/data/context-precedence/worked-supersession-example.adj
+++ b/code/specs/data/context-precedence/worked-supersession-example.adj
@@ -1,0 +1,52 @@
+% =====================================================================
+% worked-supersession-example.adj — lex posterior, DERIVED (ADJ73 PR-B-4).
+%
+% THE CASE (medical, bridges to MYCIN).  A treatment recommendation for a
+% condition reads one way in the 2004 guideline edition and another in the 2024
+% edition. They CONFLICT. Which governs?
+%
+% The case supplies one primitive grounded fact — `supersedes(idsa_2024,
+% idsa_2004)` (the 2024 edition states it replaces the 2004 one) — and the
+% LEX-POSTERIOR meta-rule (context-precedence-meta.adj, canon 2) DERIVES the
+% precedence edge `idsa_2024 > idsa_2004`. The newer edition's recommendation
+% governs:
+%
+%   recommendation(empiric_regimen, current)   status governing   context idsa_2024
+%   recommendation(empiric_regimen, legacy)    status defeated     context idsa_2004
+%
+% This is the guideline-edition precedence ADJ73 §2.3 named explicitly. It is
+% NOT hand-asserted as an edge — it is derived from the (grounded) supersession
+% fact by the (grounded) recency canon. Replacing 2024 with a yet-newer edition
+% is one `relate supersedes(...)` fact, no engine or rulebook change.
+% 0 answer-time model calls.
+% =====================================================================
+
+import "context-precedence-meta.adj"
+
+functional recommendation(topic, choice)
+
+% PRIMITIVE grounded fact: the 2024 edition supersedes the 2004 edition.
+relate supersedes(idsa_2024, idsa_2004)
+  source "The 2024 guideline edition states that it replaces and supersedes the 2004 edition for this recommendation."
+  locator "guideline front-matter — supersession statement"
+  trust authoritative
+
+% Legacy (2004) recommendation — asserted at the highest tier, yet superseded.
+rule {
+  head: recommendation(empiric_regimen, legacy)
+  when: legacy_text
+  priority: mandatory
+  context: idsa_2004
+}
+
+% Current (2024) recommendation — default tier, governs on derived recency.
+rule {
+  head: recommendation(empiric_regimen, current)
+  when: current_text
+  context: idsa_2024
+}
+
+observe legacy_text
+observe current_text
+
+? recommendation(empiric_regimen, $choice)


### PR DESCRIPTION
## What

ADJ73 §2.3/§7: *"everything in this work is recursive; each [conflict-resolution canon] has its own byte provenance."* PR-B-3 grounded the lex-superior edges by **asserting** them as facts. But most precedence is not a standing hierarchy — it is **derived** from a primitive fact about the two authorities (which came later, which reversed which). This makes the canons themselves **grounded meta-rules**.

## Engine (logic-engine 0.20 → 0.21)

- `KnowledgeBase::context_adjacency` now reads **rule-derived** `outranks_context` edges: when the KB has any `outranks_context/2` rule, it enumerates every provable `outranks_context($A,$B)` via `enumerate_all` (which subsumes ground facts, each a one-step proof) and feeds those into the same lex-superior resolution. **No meta-rules → unchanged cheap ground-fact scan** (byte-identical to 0.20, no SLD cost).
- New private `derived_context_edges`; pure read, not re-entrant with `enumerate_governing`. The DFS / Kahn-cycle walks now key on owned `String`s; semantics unchanged, and **cycle detection spans derived edges** (a contradictory `reverses` pair is caught).

## Grounded meta-rulebook (`code/specs/data/context-precedence/context-precedence-meta.adj`)

- **Appeal status**: `outranks_context($H,$L) :- reverses($H,$L)` — cites the overruling doctrine (a reversed holding is no longer binding; the reversing court controls).
- **Lex posterior / recency**: `outranks_context($New,$Old) :- supersedes($New,$Old)` — cites the implied-repeal doctrine (a later enactment/edition prevails).

Each meta-rule carries its canon's **verbatim source/locator/trust**. The recursion bottoms out at the primitive grounded facts a case supplies (`reverses`, `supersedes`), each itself byte-provenanced — an edge that can be derived is derived (and cited), not duplicated bare.

## Worked examples (end-to-end through the CLI, 0 answer-time model calls)

- **`worked-appeal-example.adj`** — a 2023 Supreme Court reversal flips a (now-reversed) 2019 Ninth Circuit reading asserted at the **highest** `mandatory` tier; the SCOTUS reading governs purely via the meta-rule-**derived** edge.
- **`worked-supersession-example.adj`** — lex posterior, bridging to MYCIN: `idsa_2024 > idsa_2004` derived from a grounded `supersedes` fact; the current guideline recommendation governs the legacy one (the guideline-edition precedence ADJ73 §2.3 named explicitly).

## Tests

4 new logic-engine unit tests (derived edge drives `context_outranks`; derived+explicit compose transitively; derived-edge cycle detection; no-meta-rule fast path) + `adj-lang-cli/tests/context_metarules_e2e.rs` (both worked examples). **120 logic-engine + 32 adj-lang-cli tests green**; affected packages (`adj-lang`, `adjudication-connector`) build/test clean. `/security-review` PASSED.

## Scope / next

Spec ADJ73 §7 synced (PR-B-4 DONE). **Lex specialis** (the more specific rule controls) is next — it needs a comparable specificity attribute on rules. Non-blocking follow-up (perf, noted in the commit): cache the derived adjacency once per `enumerate_governing` rather than recomputing per `context_outranks` call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)