### PR TITLE
feat(adj73): lex specialis as a grounded meta-rule (ADJ73 PR-B-5)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/context_metarules_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/context_metarules_e2e.rs
@@ -7,10 +7,12 @@
 //! the engine (logic-engine >= 0.21) reads as a context-order edge. These tests prove the derived
 //! edge drives `lex superior` end-to-end on the two worked examples, at 0 answer-time model calls:
 //!
-//!   * worked-appeal-example.adj — a Supreme Court reversal flips a (now-reversed) Ninth Circuit
-//!     reading that sits at the HIGHEST tier; the SCOTUS reading governs via the DERIVED edge.
+//!   * worked-appeal-example.adj — appeal status: a Supreme Court reversal flips a (now-reversed)
+//!     Ninth Circuit reading that sits at the HIGHEST tier; the SCOTUS reading governs.
 //!   * worked-supersession-example.adj — lex posterior: the 2024 guideline edition supersedes the
 //!     2004 one, so the current recommendation governs the legacy one.
+//!   * worked-lex-specialis-example.adj — lex specialis: the specific statute governs the general
+//!     one on the same matter, despite the general statute's higher tier.
 
 use std::path::PathBuf;
 use std::process::Command;
@@ -102,5 +104,42 @@ fn lex_posterior_metarule_picks_the_newer_edition() {
     assert!(
         s.contains("\"has_conflict\":false"),
         "clean supersession, not a split: {s}"
+    );
+}
+
+#[test]
+fn lex_specialis_metarule_picks_the_more_specific_statute() {
+    let (ok, s) = run("worked-lex-specialis-example.adj");
+    assert!(ok, "cli should succeed: {s}");
+    // The specific (wilderness-trail) statute's reading governs the general (traffic) statute's,
+    // via the lex-specialis meta-rule deriving the edge from a grounded `more_specific` fact —
+    // despite the general statute sitting at the higher `mandatory` tier.
+    assert!(
+        s.contains("rule_on(trail_access, prohibited)"),
+        "carries the specific-statute reading: {s}"
+    );
+    assert!(
+        s.contains("\"status\":\"governing\""),
+        "specific statute governs: {s}"
+    );
+    assert!(
+        s.contains("\"context\":\"trail_statute\""),
+        "governed in the specific (trail) statute context: {s}"
+    );
+    assert!(
+        s.contains("\"defeated_by\":\"rule_on(trail_access, prohibited)\""),
+        "the general statute reading is defeated by the specific one: {s}"
+    );
+    assert!(
+        s.contains("\"context\":\"traffic_statute\""),
+        "the defeated one is the general (traffic) statute: {s}"
+    );
+    assert!(
+        s.contains("\"standing\":\"mandatory\""),
+        "the defeated general reading was top-tier: {s}"
+    );
+    assert!(
+        s.contains("\"has_conflict\":false"),
+        "clean override, not a split: {s}"
     );
 }

--- a/code/specs/ADJ73-defeasible-rule-precedence.md
+++ b/code/specs/ADJ73-defeasible-rule-precedence.md
@@ -361,9 +361,15 @@ Each PR: spec-sync note, tests incl. a CONFLICT/abstain case, `/security-review`
     reversed Ninth Circuit reading (`worked-appeal-example.adj`), and `idsa_2024 > idsa_2004` is
     *derived* from a grounded `supersedes` fact (`worked-supersession-example.adj`). The recursion
     bottoms out at cited primitive facts — an edge that can be derived is derived, not duplicated.
-    Golden test `adj-lang-cli/tests/context_metarules_e2e.rs`. Still to come: **lex specialis**
-    (needs a comparable specificity attribute on rules) + the lex-specialis-vs-lex-superior
-    tiebreaker meta-rule (§4.3).
+    Golden test `adj-lang-cli/tests/context_metarules_e2e.rs`.
+  - **PR-B-5 lex specialis ✅ DONE (no engine change — pure grounded meta-rule on the PR-B-4
+    machinery).** Added canon 3 `outranks_context($S,$G) :- more_specific($S,$G)` (citing *lex
+    specialis derogat legi generali*) to `context-precedence-meta.adj` + `worked-lex-specialis-example.adj`
+    (a specific wilderness-trail statute governs a general traffic statute despite the general's
+    `mandatory` tier). Completes the three classical canons (lex superior / lex posterior / lex
+    specialis). Still to come: the lex-specialis-vs-lex-superior **tiebreaker** (§4.3) — when a
+    specific lower-authority rule and a general higher-authority rule point opposite ways the two
+    derived orders conflict; a further grounded meta-rule must decide, else `CONFLICT` (abstain).
 - **PR-C — adj-lang surface** (`priority: <tier>`, `functional`/`decision`, the attribute
   annotations) + regen grammar.
 - **PR-D — MYCIN `decide_timing` → `timing.adj`** on the named-enum ladder (was PR-4).

--- a/code/specs/data/context-precedence/README.md
+++ b/code/specs/data/context-precedence/README.md
@@ -9,9 +9,10 @@ own rulebook, with a citation on *why* one context outranks another (ADJ73 decis
 |------|------|
 | [`context-precedence.adj`](context-precedence.adj) | The grounded precedence order: `outranks_context(higher, lower)` edges, each carrying a verbatim charter (`source`/`locator`/`trust`). The logic-engine (≥ 0.20) reads these facts as directed edges and applies *lex superior* before the priority tier. |
 | [`worked-legal-example.adj`](worked-legal-example.adj) | A case that `import`s the rulebook: two courts read "navigable waters" differently; the Ninth Circuit's reading **governs** the district court's *despite a lower tier*, because `ninth_circuit` outranks `district_court`. |
-| [`context-precedence-meta.adj`](context-precedence-meta.adj) | **PR-B-4** — the recursive conflict-resolution **canons** as grounded meta-rules: `outranks_context($H,$L) :- reverses($H,$L)` (appeal status) and `… :- supersedes($New,$Old)` (lex posterior / recency), each citing its doctrine. The engine (≥ 0.21) reads rule-*derived* edges, so a primitive grounded fact (`reverses`/`supersedes`) becomes precedence. |
+| [`context-precedence-meta.adj`](context-precedence-meta.adj) | **PR-B-4/5** — the recursive conflict-resolution **canons** as grounded meta-rules: `outranks_context($H,$L) :- reverses($H,$L)` (appeal status), `… :- supersedes($New,$Old)` (lex posterior / recency), and `… :- more_specific($S,$G)` (lex specialis), each citing its doctrine. The engine (≥ 0.21) reads rule-*derived* edges, so a primitive grounded fact (`reverses`/`supersedes`/`more_specific`) becomes precedence. |
 | [`worked-appeal-example.adj`](worked-appeal-example.adj) | A Supreme Court reversal flips a (now-reversed) Ninth Circuit reading at the **highest** tier — the precedence edge is **derived** by the appeal-status meta-rule from a grounded `reverses` fact, not asserted. |
 | [`worked-supersession-example.adj`](worked-supersession-example.adj) | Lex posterior (bridges to MYCIN): the 2024 guideline edition supersedes the 2004 one, so the current recommendation governs the legacy one — `idsa_2024 > idsa_2004` derived from a grounded `supersedes` fact. |
+| [`worked-lex-specialis-example.adj`](worked-lex-specialis-example.adj) | Lex specialis: a specific wilderness-trail statute governs a general traffic statute on the same matter — `trail_statute > traffic_statute` derived from a grounded `more_specific` fact, despite the general statute's higher tier. |
 | [`SOURCES.md`](SOURCES.md) | The provenance ledger — where each edge's verbatim quote came from. |
 
 ## Run it
@@ -41,10 +42,12 @@ This is the data/worked-example layer of the ADJ73 precedence arc:
 - **grounded edges** (logic-engine 0.20, PR-B-2) — `outranks_context` facts participate as edges.
 - **surface** (adj-lang 0.16) — `context:` on a rule, `context_order { … }`.
 - **edges** (logic-engine 0.20, PR-B-3) — the grounded lex-superior rulebook + worked legal example.
-- **meta-rules** (logic-engine 0.21, PR-B-4) — the recursive conflict-resolution **canons** (appeal
-  status, lex posterior / recency) as grounded meta-rules that *derive* precedence from primitive
-  grounded facts (`reverses`, `supersedes`). The engine reads rule-derived `outranks_context` edges,
-  so the recursion bottoms out at cited primitives — an edge that can be derived is derived.
-- **next** — lex specialis (the more specific rule controls), once rules carry a comparable
-  specificity attribute. See [`SOURCES.md`](SOURCES.md) and the spec
-  `code/specs/ADJ73-defeasible-rule-precedence.md` §7.
+- **meta-rules** (logic-engine 0.21, PR-B-4/5) — the recursive conflict-resolution **canons**
+  (appeal status, lex posterior / recency, **lex specialis**) as grounded meta-rules that *derive*
+  precedence from primitive grounded facts (`reverses`, `supersedes`, `more_specific`). The engine
+  reads rule-derived `outranks_context` edges, so the recursion bottoms out at cited primitives —
+  an edge that can be derived is derived.
+- **next** — the lex-specialis-vs-lex-superior **tiebreaker** (§4.3): when a specific rule from a
+  lower authority and a general rule from a higher authority point opposite ways, the two derived
+  orders conflict; a further grounded meta-rule must decide, else `CONFLICT` (abstain). See
+  [`SOURCES.md`](SOURCES.md) and the spec `code/specs/ADJ73-defeasible-rule-precedence.md` §4.3, §7.

--- a/code/specs/data/context-precedence/context-precedence-meta.adj
+++ b/code/specs/data/context-precedence/context-precedence-meta.adj
@@ -66,3 +66,32 @@ rule {
   locator "Wikipedia, \"Implied repeal\" — leges posteriores priores contrarias abrogant"
   trust authoritative
 }
+
+% ---------------------------------------------------------------------
+% CANON 3 — LEX SPECIALIS (the specific governs the general). When two rules
+% both apply to the same situation, the one governing the more specific subject
+% matter controls the one governing only general matters. So
+% `more_specific(S, G)` ⇒ context S outranks context G. The case supplies the
+% primitive `relate more_specific(specific_statute, general_statute) source
+% "<why S is the more specific provision>"`, and this rule derives the edge.
+%
+% Verbatim charter (lex specialis derogat legi generali):
+%   "The lex specialis doctrine, also referred to as generalia specialibus non
+%    derogant (\"the general does not [derogate] from the specific\"), states
+%    that if two laws govern the same factual situation, a law governing a
+%    specific subject matter (lex specialis) overrides a law governing only
+%    general matters (lex generalis)."
+%
+% NOTE (§4.3): lex specialis and lex superior can point OPPOSITE ways (a general
+% rule from a higher authority vs a specific rule from a lower one). This rule
+% only contributes the lex-specialis edge; when the two orders conflict, the
+% engine's cycle/ambiguity handling surfaces it (no silent pick) until a further
+% grounded tiebreaker meta-rule is added. That tiebreaker is the next slice.
+% ---------------------------------------------------------------------
+rule {
+  head: outranks_context($Specific, $General)
+  when: more_specific($Specific, $General)
+  source "Lex specialis derogat legi generali — Lex specialis (Wikipedia): \"The lex specialis doctrine, also referred to as generalia specialibus non derogant (\\\"the general does not [derogate] from the specific\\\"), states that if two laws govern the same factual situation, a law governing a specific subject matter (lex specialis) overrides a law governing only general matters (lex generalis).\""
+  locator "Wikipedia, \"Lex specialis\" — generalia specialibus non derogant"
+  trust authoritative
+}

--- a/code/specs/data/context-precedence/worked-lex-specialis-example.adj
+++ b/code/specs/data/context-precedence/worked-lex-specialis-example.adj
@@ -1,0 +1,59 @@
+% =====================================================================
+% worked-lex-specialis-example.adj — lex specialis, DERIVED (ADJ73 PR-B-4/5).
+%
+% THE CASE.  Two statutes both speak to whether a particular vehicle may use a
+% trail. A GENERAL traffic statute reads "motor vehicles permitted"; a SPECIFIC
+% wilderness-trail statute reads "motor vehicles prohibited". Both apply to the
+% same situation, so the readings CONFLICT. Which governs?
+%
+% The case supplies one primitive grounded fact — `more_specific(trail_statute,
+% traffic_statute)` (the wilderness-trail statute governs the narrower subject
+% matter) — and the LEX-SPECIALIS meta-rule (context-precedence-meta.adj, canon
+% 3) DERIVES the precedence edge `trail_statute > traffic_statute`. The specific
+% statute's reading governs:
+%
+%   rule_on(trail_access, prohibited)  status governing   context trail_statute
+%   rule_on(trail_access, permitted)   status defeated     context traffic_statute
+%
+% The trap (as throughout the arc): the GENERAL statute's "permitted" reading is
+% asserted at the highest `mandatory` tier, and the specific statute's reading at
+% the default tier — derived lex-specialis precedence still controls. 0
+% answer-time model calls; the edge is derived from a cited primitive by a cited
+% canon.
+%
+% (When lex specialis and lex superior point opposite ways — a general rule from
+% a higher authority vs a specific rule from a lower one — the orders conflict
+% and the engine surfaces it rather than guessing; the grounded tiebreaker for
+% that case is the next slice, see context-precedence-meta.adj canon-3 note.)
+% =====================================================================
+
+import "context-precedence-meta.adj"
+
+functional rule_on(topic, ruling)
+
+% PRIMITIVE grounded fact: the wilderness-trail statute is the more specific
+% provision on trail access (the traffic statute is the general one).
+relate more_specific(trail_statute, traffic_statute)
+  source "The wilderness-trail statute governs the specific subject matter (use of this trail); the traffic statute governs motor vehicles in general."
+  locator "statutory subject-matter comparison"
+  trust authoritative
+
+% The GENERAL statute's reading (permitted), at the highest tier — yet general.
+rule {
+  head: rule_on(trail_access, permitted)
+  when: traffic_statute_applies
+  priority: mandatory
+  context: traffic_statute
+}
+
+% The SPECIFIC statute's reading (prohibited), default tier — governs on lex specialis.
+rule {
+  head: rule_on(trail_access, prohibited)
+  when: trail_statute_applies
+  context: trail_statute
+}
+
+observe traffic_statute_applies
+observe trail_statute_applies
+
+? rule_on(trail_access, $ruling)


### PR DESCRIPTION
## What

Completes the **three classical conflict-resolution canons** (lex superior ✓, lex posterior ✓, **lex specialis**). Thanks to **[#6121](https://github.com/adhithyan15/coding-adventures/pull/6121)** (PR-B-4: the engine derives context-precedence edges from any `outranks_context/2` meta-rule), lex specialis needs **no engine change** — it's purely another grounded meta-rule + a worked example.

## Changes (data + test + docs only — no src, no version bump)

- **`context-precedence-meta.adj` canon 3**: `outranks_context($Specific, $General) :- more_specific($Specific, $General)`, citing the verbatim *lex specialis derogat legi generali* doctrine ("a law governing a specific subject matter overrides a law governing only general matters"). The case supplies the primitive `relate more_specific(S, G)`; the rule derives the edge.
- **`worked-lex-specialis-example.adj`**: a specific wilderness-trail statute (*prohibited*) governs a general traffic statute (*permitted*) on the same matter — `trail_statute > traffic_statute` derived from a grounded `more_specific` fact, despite the general statute's `mandatory` tier. Proven end-to-end through the CLI (0 answer-time model calls).
- Golden test `lex_specialis_metarule_picks_the_more_specific_statute`; all 3 meta-rule tests green.

## Honest scope (spec §4.3)

Lex specialis and lex superior can point **opposite** ways (a specific lower-authority rule vs a general higher-authority one). This rule only contributes the lex-specialis edge; when the derived orders conflict, the engine **surfaces it** (cycle/ambiguity, no silent pick) rather than guessing. The grounded **tiebreaker** meta-rule for that case is the next slice.

`/security-review` PASSED. Spec ADJ73 §7 synced (PR-B-5 DONE).

## Stacking

Stacked on **[#6121](https://github.com/adhithyan15/coding-adventures/pull/6121)** (PR-B-4 derived-edge engine) — the meta-rule only resolves once that engine change is on `main`. Auto-retargets to `main` when #6121 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)