### PR TITLE
feat(mycin-cc7): full chart drive-through — FHIR chart → regimen + audit (0 model calls)

### DIFF
--- a/code/specs/data/mycin-2026/CHART-AS-CONSTRAINTS.md
+++ b/code/specs/data/mycin-2026/CHART-AS-CONSTRAINTS.md
@@ -272,8 +272,15 @@ risks Y") — decision support, not a hidden choice.
   step is satisfied"; the precedence reasoning lives in the language. The same `requires… ∧
   not done…` shape is reusable across any rule corpus (a filing gated on a precondition, a
   benefit gated on a prior step).
-- **CC-7 — full chart drive-through:** wire CH (chart→IR + de-identification) into the COP so
-  a whole de-identified FHIR chart produces a regimen with the full audit trail.
+- **CC-7 — full chart drive-through. ✅ DONE.** `fhir/run_chart_to_regimen.py` joins the three
+  stages into one call — `chart_to_regimen(cli, bundle, disease, as_of_year)` runs
+  *deidentify → to_chartfacts → chart_to_cop.derive* and returns the treatment decision PLUS the
+  full audit trail (Safe-Harbor de-id report, mapped ChartFacts, per-resource discards, grounded
+  constraints, wait-vs-treat + reimbursement). `answer_time_model_calls == 0` — a whole
+  de-identified FHIR chart → a regimen (or honest INFEASIBLE + conflict) entirely on the CPU.
+  Two committed fixtures + `fhir/test_run_chart_to_regimen.py`: a straightforward adult →
+  vancomycin + ceftriaxone, and the complex PHI chart → de-identified → abstention. This closes
+  CC-2..7; the chart-as-constraints arc is end-to-end.
 
 Each CC-n: spec note → grounded rules (no authoring) → deterministic compiler/solver wiring
 → tests (incl. an infeasibility/abstention test) → security review → PR → babysit.

--- a/code/specs/data/mycin-2026/fhir/README.md
+++ b/code/specs/data/mycin-2026/fhir/README.md
@@ -84,12 +84,23 @@ chart-as-constraints vision needs (`../CHART-AS-CONSTRAINTS.md`, CC-7):
   provenance-bearing ChartFact; an unrecognized clinically-relevant one is a **discard with
   a reason** (no silent drops).
 
-Worked end-to-end (`samples/chart_with_phi_bundle.json`, 0 model calls): a PHI-laden chart
-of a complex patient (penicillin allergy + ESRD + tacrolimus) → **de-identify** (no name /
-MRN / SSN / phone / address / exact date survives) → **ChartFacts** → the **constraint
-optimizer**, which **abstains** (β-lactams excluded by the allergy *and* vancomycin
-undosable under renal failure + nephrotoxin) with the conflict named — escalate to a
-specialist, never a fabricated or unsafe regimen. Privacy-first, decision-support only.
+- **`run_chart_to_regimen.py`** — **CC-7, the full chart drive-through**: the single
+  end-to-end on-ramp that joins the three stages — `chart_to_regimen(cli, bundle, disease,
+  as_of_year)` runs *de-identify → to_chartfacts → chart_to_cop.derive* and returns the
+  treatment decision **plus the full audit trail** (the Safe-Harbor report of what PHI was
+  removed, the mapped ChartFacts, the per-resource discards, every grounded constraint, and the
+  wait-vs-treat / reimbursement decisions). `answer_time_model_calls == 0`. Run it:
+  `python3 run_chart_to_regimen.py samples/chart_feasible_adult_bundle.json`.
+
+Worked end-to-end (0 model calls), both proven by `test_run_chart_to_regimen.py`:
+- `samples/chart_feasible_adult_bundle.json` — a straightforward young adult (no allergy,
+  normal renal) → **de-identify** → **ChartFacts** (`age_band=adult`, weight) → the optimizer
+  returns the standard community regimen (**vancomycin + ceftriaxone**).
+- `samples/chart_with_phi_bundle.json` — a complex patient (penicillin allergy + ESRD +
+  tacrolimus) → **de-identify** (no name / MRN / SSN / phone / address / exact date survives) →
+  **ChartFacts** → the optimizer **abstains** (β-lactams excluded by the allergy *and*
+  vancomycin undosable under renal failure + nephrotoxin) with the conflict named — escalate to
+  a specialist, never a fabricated or unsafe regimen. Privacy-first, decision-support only.
 
 **De-identification scope (audited):** dates are generalized to the year *by value shape*
 (Period / `value[x]` / extension / timing dates can't slip a key allow-list); the

--- a/code/specs/data/mycin-2026/fhir/run_chart_to_regimen.py
+++ b/code/specs/data/mycin-2026/fhir/run_chart_to_regimen.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""run_chart_to_regimen.py — a raw FHIR chart → an antibiotic regimen + full audit trail.
+
+MYCIN-2026 CC-7 (the "full chart drive-through", CHART-AS-CONSTRAINTS §7). This is the
+TREATMENT counterpart to run_fhir.py (which drives a chart → *diagnosis*). It wires the three
+already-built, already-tested stages into one end-to-end call:
+
+    raw FHIR Bundle ──► deidentify ──► to_chartfacts ──► chart_to_cop.derive ──► regimen + audit
+       (PHI in)         (HIPAA          (LOINC/SNOMED      (constraint program,
+                         Safe Harbor)    → ChartFacts)       solved on the CPU)
+
+The headline, end to end: a whole de-identified FHIR chart produces a treatment decision —
+the regimen, OR an honest INFEASIBLE with the conflict set — at **0 answer-time model calls**
+(every stage is deterministic: Safe-Harbor de-id, coded-fact mapping, and the constraint
+solver). Nothing leaves the machine, and the result carries a *full audit trail*: what PHI was
+removed, which chart facts mapped vs were discarded, every constraint with its grounded
+provenance, and the wait-vs-treat / reimbursement decisions. Decision SUPPORT — the physician
+reviews and overrides any grounded constraint.
+
+The pieces already compose (no type translation): `deidentify` returns a clean Bundle dict,
+`to_chartfacts` consumes it and returns `ChartFact`s, `derive` consumes those and returns the
+decision. CC-7 is the orchestrator that joins them and assembles the audit trail, plus the
+end-to-end drive-through tests.
+
+Usage:  python3 run_chart_to_regimen.py samples/chart_with_phi_bundle.json
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+MYCIN = HERE.parent
+sys.path.insert(0, str(HERE))
+sys.path.insert(0, str(MYCIN / "treatment" / "antibiotics"))
+sys.path.insert(0, str(MYCIN / "warm"))
+import chart_to_cop as cc  # noqa: E402  (derive: ChartFacts → regimen + provenance)
+import decide as decide_mod  # noqa: E402  (find_cli)
+import deidentify  # noqa: E402  (HIPAA Safe-Harbor de-identification)
+import fhir_to_chartfacts as f2c  # noqa: E402  (de-identified Bundle → ChartFacts)
+
+
+def chart_to_regimen(cli: Path, fhir_bundle: dict, disease: str = "meningitis",
+                     as_of_year: int | None = None) -> dict:
+    """End-to-end CC-7: a raw FHIR Bundle → a regimen decision + a full audit trail.
+
+    Stages (all deterministic; 0 answer-time model calls):
+      1. de-identify the bundle (HIPAA Safe Harbor) — strips PHI, keeps clinical codes/values;
+      2. map the de-identified bundle → ChartFacts (LOINC/SNOMED lookups), recording discards;
+      3. compile the ChartFacts → constraint program and solve → regimen OR INFEASIBLE(conflict).
+
+    The returned dict is `chart_to_cop.derive`'s decision PLUS the upstream audit layers:
+      - `deidentification`: the Safe-Harbor report (what classes of PHI were removed, dates
+        generalized, ages capped, free-text labels kept);
+      - `chart_discards`: chart resources that mapped to no constraint, each with a reason
+        (the "no unaccounted bytes" discipline applied to the chart);
+      - `answer_time_model_calls`: 0 (the whole drive-through is CPU-bound).
+    `derive` itself supplies `regimen`/`outcome`/`conflict`/`timing`/`reimbursement` plus the
+    per-constraint provenance trail."""
+    clean_bundle, deident_report = deidentify.deidentify(fhir_bundle, as_of_year)
+    facts, chart_discards = f2c.to_chartfacts(clean_bundle, as_of_year)
+    decision = cc.derive(cli, facts, disease)
+    # Assemble the full audit trail: the upstream de-id + mapping layers wrap the COP decision.
+    decision["deidentification"] = deident_report
+    decision["chart_discards"] = chart_discards
+    decision["chart_facts"] = [{"kind": f.kind, "value": f.value, "span": f.span} for f in facts]
+    decision["answer_time_model_calls"] = 0
+    return decision
+
+
+def _print_drivethrough(name: str, disease: str, res: dict) -> None:
+    """Human-readable drive-through (presentation only; the data is `res`)."""
+    bar = "=" * 78
+    print(bar)
+    print(f"FHIR CHART → REGIMEN: {name}   (disease={disease})")
+    print(bar)
+    dr = res["deidentification"]
+    removed = ", ".join(f"{k}×{v}" for k, v in sorted(dr.get("removed", {}).items())) or "(none)"
+    print("\n[1] DE-IDENTIFICATION (HIPAA Safe Harbor, one-way, 0 model calls):")
+    print(f"    PHI removed: {removed}")
+    print(f"    dates→year: {dr.get('dates_generalized', 0)}   age-capped: {dr.get('age_capped', 0)}"
+          f"   free-text labels kept (audited): {dr.get('free_text_kept', 0)}")
+    print("\n[2] CHART FACTS (deterministic LOINC/SNOMED mapping, 0 model calls):")
+    for f in res["chart_facts"]:
+        print(f"    {f['kind']:16s} = {f['value']:24s}  ⟵ {f['span']}")
+    for d in res["chart_discards"]:
+        print(f"    DISCARD: {d['fact']}  ({d['reason']})")
+    print("\n[3] TREATMENT DECISION (constraint solver on the CPU, 0 model calls):")
+    if res["regimen"]:
+        print(f"    REGIMEN: {', '.join(res['regimen'])}   (cost {res.get('cost')})")
+    else:
+        print(f"    INFEASIBLE — honest abstention. conflict core: {res.get('conflict')}")
+        print(f"    (dose-infeasible: {res.get('dose_infeasible')}; "
+              f"contraindicated: {res.get('contraindicated')}; exclusions: {res.get('exclusions')})")
+    t = res.get("timing") or {}
+    print(f"    timing: {t.get('decision')} (delay_risk {t.get('delay_risk')})")
+    if res.get("reimbursement"):
+        rb = res["reimbursement"]
+        print(f"    reimbursement: covered={rb.get('covered_regimen')} — {rb.get('note')}")
+    print("\n" + bar)
+    print("PHYSICIAN REVIEW — grounded + overridable; you make the call.")
+    print(f"answer-time model calls: {res['answer_time_model_calls']}   |   "
+          "chart data left the machine: none")
+
+
+def run(bundle_path: str, disease: str = "meningitis", as_of_year: int = 2026) -> int:
+    cli = decide_mod.find_cli()
+    if cli is None:
+        print("run_chart_to_regimen: adj-lang-cli not built", file=sys.stderr)
+        return 3
+    bundle = json.loads(Path(bundle_path).read_text())
+    res = chart_to_regimen(cli, bundle, disease=disease, as_of_year=as_of_year)
+    _print_drivethrough(Path(bundle_path).name, disease, res)
+    return 0
+
+
+def main(argv: list[str]) -> int:
+    if not argv:
+        print("usage: run_chart_to_regimen.py <bundle.json> [disease] [as_of_year]", file=sys.stderr)
+        return 2
+    disease = argv[1] if len(argv) > 1 else "meningitis"
+    as_of = int(argv[2]) if len(argv) > 2 else 2026
+    return run(argv[0], disease, as_of)
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/code/specs/data/mycin-2026/fhir/samples/chart_feasible_adult_bundle.json
+++ b/code/specs/data/mycin-2026/fhir/samples/chart_feasible_adult_bundle.json
@@ -1,0 +1,55 @@
+{
+  "resourceType": "Bundle",
+  "type": "collection",
+  "_doc": "SYNTHETIC FHIR Bundle (no real patient) — a STRAIGHTFORWARD chart for the CC-7 full-chart drive-through: a healthy young adult with suspected meningitis, NO drug allergy, NORMAL renal function, on no interacting medications. Carries deliberate PHI (name, MRN, phone, address, narrative, exact dates) so deidentify.py has something to strip. Maps to age_band=adult + a body weight → the community empiric regimen is feasible (the optimizer returns vancomycin + ceftriaxone, the standard cover). The companion chart_with_phi_bundle.json is the INFEASIBLE counterpart (renal + nephrotoxin + penicillin allergy → abstain).",
+  "entry": [
+    {
+      "resource": {
+        "resourceType": "Patient",
+        "id": "p1",
+        "identifier": [{"system": "urn:mrn", "value": "MRN-7720145"}],
+        "name": [{"family": "Okafor", "given": ["Daniel"]}],
+        "telecom": [{"system": "phone", "value": "+1-312-555-0148"}],
+        "address": [{"line": ["19 Maple Court"], "city": "Chicago", "state": "IL",
+                     "postalCode": "60614"}],
+        "gender": "male",
+        "birthDate": "1992-09-30",
+        "text": {"status": "generated",
+                 "div": "<div>Daniel Okafor, 33yo M, MRN-7720145, ED visit 2026-06-15 for fever + neck stiffness</div>"}
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "Condition",
+        "id": "c1",
+        "recordedDate": "2026-06-15",
+        "clinicalStatus": {"coding": [{"code": "active"}]},
+        "code": {"text": "Suspected bacterial meningitis",
+                 "coding": [{"system": "http://snomed.info/sct", "code": "58170007",
+                             "display": "Bacterial meningitis"}]}
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "Observation",
+        "id": "o1",
+        "status": "final",
+        "effectiveDateTime": "2026-06-15T21:10:00Z",
+        "code": {"coding": [{"system": "http://loinc.org", "code": "33914-3",
+                             "display": "Estimated GFR"}]},
+        "valueQuantity": {"value": 102, "unit": "mL/min/1.73m2"}
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "Observation",
+        "id": "o2",
+        "status": "final",
+        "effectiveDateTime": "2026-06-15T21:10:00Z",
+        "code": {"coding": [{"system": "http://loinc.org", "code": "29463-7",
+                             "display": "Body weight"}]},
+        "valueQuantity": {"value": 78, "unit": "kg"}
+      }
+    }
+  ]
+}

--- a/code/specs/data/mycin-2026/fhir/test_run_chart_to_regimen.py
+++ b/code/specs/data/mycin-2026/fhir/test_run_chart_to_regimen.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""test_run_chart_to_regimen.py — the CC-7 full-chart drive-through, end to end.
+
+Drives RAW FHIR Bundles (PHI in) through deidentify → to_chartfacts → chart_to_cop.derive in a
+single `chart_to_regimen` call and asserts: (a) PHI is stripped and the de-identification report
+is part of the audit trail; (b) the constraint solver returns the right decision — a regimen for
+a straightforward chart, an honest INFEASIBLE+conflict for a complex one; (c) every stage is
+deterministic (answer_time_model_calls == 0). Engine-gated on `find_cli()` (pure-mapping
+assertions still run without the CLI); mirrors test_deidentify.py's two-tier pattern.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(HERE))
+sys.path.insert(0, str(HERE.parent / "treatment" / "antibiotics"))
+sys.path.insert(0, str(HERE.parent / "warm"))
+import decide as decide_mod  # noqa: E402
+import deidentify  # noqa: E402
+import fhir_to_chartfacts as f2c  # noqa: E402
+import run_chart_to_regimen as rc  # noqa: E402
+
+FEASIBLE = HERE / "samples" / "chart_feasible_adult_bundle.json"
+INFEASIBLE = HERE / "samples" / "chart_with_phi_bundle.json"
+
+
+def _bundle(p: Path) -> dict:
+    return json.loads(p.read_text())
+
+
+def test_deidentification_strips_phi_before_anything_downstream():
+    # Pure (no CLI): the raw bundle carries PHI; de-id removes it and the mapping never sees it.
+    raw = _bundle(FEASIBLE)
+    clean, report = deidentify.deidentify(raw, as_of_year=2026)
+    blob = json.dumps(clean)
+    for phi in ("Okafor", "Daniel", "MRN-7720145", "312-555-0148", "Maple Court"):
+        assert phi not in blob, f"PHI {phi!r} survived de-identification: leak"
+    assert report["removed"], "the de-identification report records what was removed"
+    # The clinical signal the COP needs DOES survive (codes/values).
+    facts, _ = f2c.to_chartfacts(clean, as_of_year=2026)
+    kinds = {f.kind for f in facts}
+    assert "age_band" in kinds and "weight" in kinds, kinds
+
+
+def test_feasible_chart_drives_through_to_a_regimen():
+    cli = decide_mod.find_cli()
+    if cli is None:
+        print("test_run_chart_to_regimen: PASS (de-id+mapping); engine SKIPPED (no cli)")
+        return
+    res = rc.chart_to_regimen(cli, _bundle(FEASIBLE), as_of_year=2026)
+    # A straightforward adult → the standard community empiric regimen is feasible. The min-cost
+    # set-cover reports a solved cover as `optimal` (vs `infeasible` for the abstention case).
+    assert res["outcome"] == "optimal" and res["regimen"], res
+    assert {"vancomycin", "ceftriaxone"} <= set(res["regimen"]), res["regimen"]
+    # The full audit trail is assembled on the decision.
+    assert res["deidentification"]["removed"], "de-id report present"
+    assert any(f["kind"] == "age_band" for f in res["chart_facts"]), res["chart_facts"]
+    assert res["answer_time_model_calls"] == 0
+    # Time-critical disease → treat-now (CC-5 grounded acuity).
+    assert res["timing"]["decision"] == "treat_now_empiric", res["timing"]
+
+
+def test_complex_chart_drives_through_to_honest_abstention():
+    cli = decide_mod.find_cli()
+    if cli is None:
+        return
+    # Penicillin allergy + ESRD + a nephrotoxin: vancomycin is undosable and ampicillin is
+    # contraindicated → no regimen covers the organisms safely → INFEASIBLE with a conflict core.
+    res = rc.chart_to_regimen(cli, _bundle(INFEASIBLE), as_of_year=2026)
+    assert res["outcome"] == "infeasible" and res["regimen"] is None, res
+    assert res["conflict"], "an INFEASIBLE drive-through surfaces the minimal conflict set"
+    assert "vancomycin" in res["dose_infeasible"], res["dose_infeasible"]
+    assert "ampicillin" in res["contraindicated"], res["contraindicated"]
+    # Still fully audited + CPU-bound even when it abstains.
+    assert res["deidentification"]["removed"]
+    assert res["answer_time_model_calls"] == 0
+
+
+def test_chart_facts_and_discards_are_carried_for_audit():
+    cli = decide_mod.find_cli()
+    if cli is None:
+        return
+    # The drive-through carries the mapped facts AND any unmapped resources (with a reason) —
+    # the "no unaccounted bytes" discipline applied to the chart.
+    res = rc.chart_to_regimen(cli, _bundle(INFEASIBLE), as_of_year=2026)
+    assert isinstance(res["chart_facts"], list) and res["chart_facts"]
+    assert isinstance(res["chart_discards"], list)  # may be empty, but always present
+
+
+if __name__ == "__main__":
+    test_deidentification_strips_phi_before_anything_downstream()
+    test_feasible_chart_drives_through_to_a_regimen()
+    test_complex_chart_drives_through_to_honest_abstention()
+    test_chart_facts_and_discards_are_carried_for_audit()
+    print("all CC-7 drive-through tests passed")


### PR DESCRIPTION
## What

**CC-7** (CHART-AS-CONSTRAINTS §7) — the **full chart drive-through**, treatment counterpart to `run_fhir.py`'s diagnosis driver. **Closes CC-2..7**: the chart-as-constraints arc is now end-to-end.

The three stages already existed and compose cleanly; CC-7 is the orchestrator + the drive-through proof.

## New `fhir/run_chart_to_regimen.py`

```
chart_to_regimen(cli, bundle, disease, as_of_year) =
   deidentify (HIPAA Safe Harbor) → to_chartfacts (LOINC/SNOMED) → chart_to_cop.derive
```

Returns the treatment decision **plus the full audit trail**: the Safe-Harbor report (what PHI was removed), the mapped ChartFacts, per-resource discards (*no unaccounted bytes*), every grounded constraint, and the wait-vs-treat / reimbursement decisions. **`answer_time_model_calls == 0`** — a whole de-identified FHIR chart → a regimen (or honest `INFEASIBLE` + conflict) entirely on the CPU. PHI is stripped **before** anything downstream sees the chart; nothing leaves the machine.

## Fixtures + tests (`fhir/test_run_chart_to_regimen.py`, 4 cases)

- **`chart_feasible_adult_bundle.json`** (new) — a straightforward young adult (no allergy, normal renal) → de-identify → `ChartFacts(age_band=adult, weight)` → standard regimen **vancomycin + ceftriaxone**.
- **`chart_with_phi_bundle.json`** (existing) — penicillin allergy + ESRD + tacrolimus → de-identify (no name/MRN/SSN/phone/address/exact-date survives) → vancomycin undosable + ampicillin contraindicated → **honest `INFEASIBLE`** with the conflict core named.
- A pure (no-CLI) test asserts named PHI tokens do **not** survive de-identification while the clinical signal (age_band, weight) does; engine-gated tests run when `adj-lang-cli` is built.

`ruff` clean; all 4 tests pass; **`/security-review` PASSED** (PHI de-identified before mapping/print; CLI invoked via list-form argv — no shell injection; synthetic fixture; the `span` audit field inherits the de-identifier's *already-documented* CodeableConcept.text/display limitation — no new leak).

Spec CHART-AS-CONSTRAINTS.md §7 synced (CC-7 DONE). Independent of the ADJ73 precedence PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)