### PR TITLE
fix(logic-engine): mutual precedence is an honest CONFLICT, not silent double-defeat (ADJ73 §4.3)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/context_metarules_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/context_metarules_e2e.rs
@@ -143,3 +143,30 @@ fn lex_specialis_metarule_picks_the_more_specific_statute() {
         "clean override, not a split: {s}"
     );
 }
+
+#[test]
+fn colliding_canons_abstain_with_an_honest_conflict() {
+    // ADJ73 §4.3: lex superior (federal > state) and lex specialis (state is more specific →
+    // state > federal) point OPPOSITE ways. The contradiction has no further grounded tiebreaker,
+    // so the engine ABSTAINS — both readings are conflict_peers and has_conflict is true — rather
+    // than silently crowning one canon (or silently double-defeating both). The "else CONFLICT".
+    let (ok, s) = run("worked-canon-conflict-example.adj");
+    assert!(ok, "cli should succeed: {s}");
+    assert!(
+        s.contains("\"has_conflict\":true"),
+        "the canon collision is flagged: {s}"
+    );
+    // Neither reading is silently 'defeated' or 'governing' — both are surfaced as peers.
+    assert!(
+        s.contains("\"status\":\"conflict_peer\""),
+        "the colliding readings are conflict peers: {s}"
+    );
+    assert!(
+        !s.contains("\"status\":\"governing\""),
+        "nothing governs under contradictory precedence: {s}"
+    );
+    assert!(
+        s.contains("\"context\":\"federal\"") && s.contains("\"context\":\"state\""),
+        "both contexts are present in the unresolved set: {s}"
+    );
+}

--- a/code/packages/rust/logic-engine/CHANGELOG.md
+++ b/code/packages/rust/logic-engine/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.22.0] - 2026-06-17 — mutual precedence is an honest CONFLICT, not silent double-defeat (ADJ73 §4.3)
+
+### Fixed
+
+- **Contradictory precedence between two competing answers now surfaces as `ConflictPeer`
+  (abstain), not a silent "both defeated, `has_conflict == false`".** When two canons point
+  opposite ways — e.g. lex superior derives `federal > state` while lex specialis derives
+  `state > federal` — each answer defeated the other, so the resolver marked BOTH `Defeated`,
+  crowned nothing, and reported no conflict (misleading). The defeat test in `enumerate_governing`
+  is now **strict domination**: `j` defeats `i` only if `j` defeats `i` AND `i` does not defeat
+  `j` back. A merely mutual defeat leaves both answers undefeated → the group resolves to
+  `ConflictPeer` / `has_conflict == true` — the honest "else CONFLICT (abstain)" the spec
+  (§4.3) promises. The caller is never silently handed an empty governing set with no conflict
+  signal.
+
+### Unchanged (no regression)
+
+- One-way precedence (the ordinary lex-superior / tier case) still cleanly governs: a strictly
+  dominating answer wins, the dominated one is `Defeated { by }`. Co-equal-tier and cyclic-order
+  cases already abstained and still do. The context order is a partial order + a total tier, so
+  only 2-cycles of mutual defeat arise (transitivity makes any longer cycle mutual everywhere) —
+  no strict Condorcet cycle can slip through. All prior `govern` tests pass unchanged.
+
 ## [0.21.0] - 2026-06-17 — context-precedence edges can be DERIVED by meta-rules (ADJ73 PR-B-4)
 
 ### Added

--- a/code/packages/rust/logic-engine/Cargo.toml
+++ b/code/packages/rust/logic-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "logic-engine"
-version = "0.21.0"
+version = "0.22.0"
 edition = "2021"
 description = "Probability-aware facts, rules, KB, SLD find-first/enumerate + WMC posterior + LP19e likelihood-ratio Bayesian aggregation."
 

--- a/code/packages/rust/logic-engine/src/govern.rs
+++ b/code/packages/rust/logic-engine/src/govern.rs
@@ -218,11 +218,19 @@ pub fn enumerate_governing(query: &Term, kb: &KnowledgeBase) -> GovernedResult {
     let keys: Vec<Option<(String, Vec<Term>)>> =
         answers.iter().map(|a| conflict_key(&a.term, kb)).collect();
 
-    let undefeated = |idx: usize, group: &[usize]| -> bool {
-        !group
-            .iter()
-            .any(|&j| j != idx && defeats(&answers[j], &answers[idx], kb))
+    // STRICT domination (ADJ73 §4.3): `j` defeats `i` AND `i` does not defeat `j` back. A merely
+    // *mutual* defeat — each context outranks the other, e.g. lex superior says federal > state
+    // while lex specialis says state > federal — is NOT a clean defeat of either: it is a genuine
+    // collision of canons. Resolving it as "both defeated" would silently crown nothing while
+    // reporting no conflict; instead a mutually-defeated answer stays UNDEFEATED here, so the group
+    // surfaces as `ConflictPeer` (abstain) — the honest "else CONFLICT" the spec promises. (The
+    // context order is a partial order + a total tier, so only 2-cycles of mutual defeat arise, not
+    // strict Condorcet cycles — transitivity makes any longer cycle mutual everywhere.)
+    let dominates = |j: usize, i: usize| -> bool {
+        j != i && defeats(&answers[j], &answers[i], kb) && !defeats(&answers[i], &answers[j], kb)
     };
+    let undefeated =
+        |idx: usize, group: &[usize]| -> bool { !group.iter().any(|&j| dominates(j, idx)) };
 
     let mut verdicts: Vec<GovernStatus> = vec![GovernStatus::Governing; answers.len()];
     for (i, key_i) in keys.iter().enumerate() {
@@ -238,10 +246,11 @@ pub fn enumerate_governing(query: &Term, kb: &KnowledgeBase) -> GovernedResult {
             continue; // singleton → no contest
         }
         verdicts[i] = if !undefeated(i, &group) {
-            // Defeated — cite a defeating witness (one of the answers that defeats i).
+            // Defeated — cite a witness that STRICTLY dominates i (defeats it and isn't defeated
+            // back). A merely mutual defeat does not land here; it leaves i undefeated → conflict.
             let by = group
                 .iter()
-                .find(|&&j| j != i && defeats(&answers[j], &answers[i], kb))
+                .find(|&&j| dominates(j, i))
                 .map(|&j| answers[j].term.clone())
                 .unwrap();
             GovernStatus::Defeated { by }
@@ -577,5 +586,60 @@ mod tests {
             edge.provenance.source,
             "U.S. Const. art. VI, cl. 2 (Supremacy Clause)"
         );
+    }
+
+    /// ADJ73 §4.3 — when two canons point OPPOSITE ways (each context outranks the other: lex
+    /// superior says federal > state, lex specialis says state > federal), the defeat is MUTUAL.
+    /// Neither answer is strictly dominated, so the group is an unresolved CONFLICT (abstain) —
+    /// NOT a silent "both defeated, nothing flagged". This is the honest "else CONFLICT" branch.
+    #[test]
+    fn mutually_outranking_contexts_yield_conflict_not_silent_double_defeat() {
+        let mut kb = KnowledgeBase::new();
+        kb.declare_functional("rule_on", 1);
+        // Contradictory context order: federal outranks state AND state outranks federal.
+        kb.add_context_outranks("federal", "state");
+        kb.add_context_outranks("state", "federal");
+        kb.add_rule(
+            Rule::certain(comp("rule_on", vec![atom("permitted")]), vec![]).with_context("federal"),
+        );
+        kb.add_rule(
+            Rule::certain(comp("rule_on", vec![atom("prohibited")]), vec![]).with_context("state"),
+        );
+        let res = enumerate_governing(&comp("rule_on", vec![var("X")]), &kb);
+        assert!(
+            res.has_conflict(),
+            "mutual outranking is an honest CONFLICT, not a silent pick"
+        );
+        assert_eq!(
+            res.governing().count(),
+            0,
+            "nothing governs under contradictory precedence — the caller must abstain"
+        );
+        // Both are surfaced as peers (neither silently 'defeated').
+        assert!(res
+            .answers
+            .iter()
+            .all(|a| a.status == GovernStatus::ConflictPeer));
+    }
+
+    /// Guard the common path is unchanged: a ONE-WAY context edge still cleanly defeats (the
+    /// strict-domination refinement must not regress the ordinary lex-superior case).
+    #[test]
+    fn one_way_context_edge_still_cleanly_governs() {
+        let mut kb = KnowledgeBase::new();
+        kb.declare_functional("rule_on", 1);
+        kb.add_context_outranks("federal", "state"); // one direction only
+        kb.add_rule(
+            Rule::certain(comp("rule_on", vec![atom("permitted")]), vec![]).with_context("federal"),
+        );
+        kb.add_rule(
+            Rule::certain(comp("rule_on", vec![atom("forbidden")]), vec![])
+                .with_context("state")
+                .with_priority(Priority::Mandatory),
+        );
+        let res = enumerate_governing(&comp("rule_on", vec![var("X")]), &kb);
+        let gov: Vec<&Term> = res.governing().map(|a| &a.term).collect();
+        assert_eq!(gov, vec![&comp("rule_on", vec![atom("permitted")])]);
+        assert!(!res.has_conflict());
     }
 }

--- a/code/specs/ADJ73-defeasible-rule-precedence.md
+++ b/code/specs/ADJ73-defeasible-rule-precedence.md
@@ -367,9 +367,16 @@ Each PR: spec-sync note, tests incl. a CONFLICT/abstain case, `/security-review`
     specialis derogat legi generali*) to `context-precedence-meta.adj` + `worked-lex-specialis-example.adj`
     (a specific wilderness-trail statute governs a general traffic statute despite the general's
     `mandatory` tier). Completes the three classical canons (lex superior / lex posterior / lex
-    specialis). Still to come: the lex-specialis-vs-lex-superior **tiebreaker** (§4.3) — when a
-    specific lower-authority rule and a general higher-authority rule point opposite ways the two
-    derived orders conflict; a further grounded meta-rule must decide, else `CONFLICT` (abstain).
+    specialis).
+  - **PR-B-6 §4.3 honest CONFLICT ✅ DONE (logic-engine 0.22).** When two canons point opposite
+    ways (lex superior `federal > state` vs lex specialis `state > federal`) the defeat is MUTUAL;
+    the resolver now uses **strict domination** (`j` defeats `i` only if `i` does not defeat back),
+    so neither is silently `Defeated` — the group abstains as `ConflictPeer` / `has_conflict`. This
+    closes the "else CONFLICT (abstain)" guarantee (previously the engine produced a misleading
+    "both defeated, no conflict flag"). `worked-canon-conflict-example.adj` +
+    `colliding_canons_abstain_with_an_honest_conflict`. Still to come (the RESOLVING tiebreaker):
+    a grounded meta-rule that turns a *chosen* collision into a cited decision — needs each derived
+    edge tagged with its canon + a grounded canon-ordering, so the engine picks with provenance.
 - **PR-C — adj-lang surface** (`priority: <tier>`, `functional`/`decision`, the attribute
   annotations) + regen grammar.
 - **PR-D — MYCIN `decide_timing` → `timing.adj`** on the named-enum ladder (was PR-4).

--- a/code/specs/data/context-precedence/README.md
+++ b/code/specs/data/context-precedence/README.md
@@ -13,6 +13,7 @@ own rulebook, with a citation on *why* one context outranks another (ADJ73 decis
 | [`worked-appeal-example.adj`](worked-appeal-example.adj) | A Supreme Court reversal flips a (now-reversed) Ninth Circuit reading at the **highest** tier — the precedence edge is **derived** by the appeal-status meta-rule from a grounded `reverses` fact, not asserted. |
 | [`worked-supersession-example.adj`](worked-supersession-example.adj) | Lex posterior (bridges to MYCIN): the 2024 guideline edition supersedes the 2004 one, so the current recommendation governs the legacy one — `idsa_2024 > idsa_2004` derived from a grounded `supersedes` fact. |
 | [`worked-lex-specialis-example.adj`](worked-lex-specialis-example.adj) | Lex specialis: a specific wilderness-trail statute governs a general traffic statute on the same matter — `trail_statute > traffic_statute` derived from a grounded `more_specific` fact, despite the general statute's higher tier. |
+| [`worked-canon-conflict-example.adj`](worked-canon-conflict-example.adj) | **§4.3 honest CONFLICT** — lex superior (`federal > state`) and lex specialis (`state > federal`) point opposite ways with no tiebreaker → the engine **abstains** (both `conflict_peer`, `has_conflict: true`), never silently crowning a canon. |
 | [`SOURCES.md`](SOURCES.md) | The provenance ledger — where each edge's verbatim quote came from. |
 
 ## Run it
@@ -47,7 +48,11 @@ This is the data/worked-example layer of the ADJ73 precedence arc:
   precedence from primitive grounded facts (`reverses`, `supersedes`, `more_specific`). The engine
   reads rule-derived `outranks_context` edges, so the recursion bottoms out at cited primitives —
   an edge that can be derived is derived.
-- **next** — the lex-specialis-vs-lex-superior **tiebreaker** (§4.3): when a specific rule from a
-  lower authority and a general rule from a higher authority point opposite ways, the two derived
-  orders conflict; a further grounded meta-rule must decide, else `CONFLICT` (abstain). See
-  [`SOURCES.md`](SOURCES.md) and the spec `code/specs/ADJ73-defeasible-rule-precedence.md` §4.3, §7.
+- **conflict handling** (logic-engine 0.22, §4.3) — when canons point opposite ways and no
+  tiebreaker exists, the engine **abstains** (`ConflictPeer` / `has_conflict`), never silently
+  crowning one or double-defeating both (`worked-canon-conflict-example.adj`). The "else CONFLICT".
+- **next** — a *grounded tiebreaker* meta-rule that RESOLVES a specific collision (e.g. "in this
+  jurisdiction lex specialis prevails over lex superior for statutory interpretation"), turning a
+  chosen abstention into a cited decision. Needs each derived edge tagged with the canon that
+  produced it + a grounded canon-ordering. See the spec
+  `code/specs/ADJ73-defeasible-rule-precedence.md` §4.3, §7.

--- a/code/specs/data/context-precedence/worked-canon-conflict-example.adj
+++ b/code/specs/data/context-precedence/worked-canon-conflict-example.adj
@@ -1,0 +1,52 @@
+% =====================================================================
+% worked-canon-conflict-example.adj — when canons COLLIDE (ADJ73 §4.3).
+%
+% THE CASE.  A matter is governed two ways:
+%   • a GENERAL federal provision says "permitted" (context: federal);
+%   • a SPECIFIC state provision says "prohibited" (context: state).
+% Which governs?  Two grounded canons point OPPOSITE ways:
+%   • LEX SUPERIOR (context-precedence.adj): federal outranks state (Supremacy Clause)
+%       ⇒ the federal "permitted" reading should win.
+%   • LEX SPECIALIS (context-precedence-meta.adj): the more-specific provision controls,
+%     and here the state statute is the specific one (`more_specific(state, federal)`)
+%       ⇒ the state "prohibited" reading should win.
+%
+% The two derived/asserted edges form a CONTRADICTION: federal > state AND state > federal.
+% There is no further grounded meta-rule yet to break this particular tie, so the honest
+% outcome is **CONFLICT** — the engine ABSTAINS rather than silently pick one canon:
+%
+%   rule_on(matter, permitted)   status conflict_peer   context federal
+%   rule_on(matter, prohibited)  status conflict_peer   context state
+%   has_conflict: true
+%
+% This is ADJ73 §4.3: "when lex specialis and lex superior point opposite ways, a further
+% grounded meta-rule decides — else CONFLICT (abstain)." Neither reading is silently
+% defeated; both are surfaced as peers so a human (or a future grounded tiebreaker
+% meta-rule, e.g. "in this jurisdiction lex specialis prevails over lex superior for
+% statutory interpretation") resolves it. 0 answer-time model calls. The right behavior
+% for a genuine split of authority is to say so, not to guess.
+% =====================================================================
+
+import "context-precedence.adj"        % grounded lex-superior edges (federal > state, …)
+import "context-precedence-meta.adj"   % the conflict-resolution canons (incl. lex specialis)
+
+functional rule_on(topic, ruling)
+
+% The STATE provision is the more specific one on this matter → lex specialis derives
+% outranks_context(state, federal), which contradicts the grounded federal > state edge.
+relate more_specific(state, federal)
+  source "The state statute addresses this specific situation; the federal provision is general."
+  locator "statutory subject-matter comparison"
+  trust authoritative
+
+% The general federal reading (permitted), grounded in the federal context.
+rule { head: rule_on(matter, permitted)  when: federal_general  context: federal }
+
+% The specific state reading (prohibited), grounded in the state context.
+rule { head: rule_on(matter, prohibited) when: state_specific   context: state }
+
+observe federal_general
+observe state_specific
+
+% Which governs?  → CONFLICT: the two canons contradict and nothing breaks the tie → abstain.
+? rule_on(matter, $ruling)


### PR DESCRIPTION
## What

Closes the ADJ73 **§4.3 "else CONFLICT (abstain)"** guarantee. When two grounded canons point opposite ways — lex superior derives `federal > state` while lex specialis derives `state > federal` — each answer defeated the other, so the resolver marked **both `Defeated`**, crowned nothing, and reported **`has_conflict == false`**. The caller was silently handed an empty governing set with no conflict signal — a misleading non-answer, exactly the dishonest outcome ADJ73 forbids.

Found while building the §4.3 worked example off the now-merged three-canon stack: the engine produced "both defeated, no conflict flag" instead of an honest CONFLICT.

## Fix (logic-engine 0.21 → 0.22)

The defeat test in `enumerate_governing` is now **strict domination**: `j` defeats `i` only if `j` defeats `i` **and** `i` does not defeat `j` back. A merely mutual defeat leaves both answers undefeated → the group resolves to **`ConflictPeer` / `has_conflict == true`** (abstain). The context order is a partial order + a total tier, so only 2-cycles of mutual defeat arise (transitivity makes any longer cycle mutual everywhere) — no strict Condorcet cycle can slip through.

**No regression:** one-way precedence (ordinary lex-superior / tier) still cleanly governs — a strictly dominating answer wins, the dominated one is `Defeated { by }`. All prior govern tests pass (co-equal tie, cyclic order, lex-superior override).

## Tests

- 2 new logic-engine unit tests: `mutually_outranking_contexts_yield_conflict_not_silent_double_defeat`, `one_way_context_edge_still_cleanly_governs`.
- `worked-canon-conflict-example.adj` (federal-general vs state-specific collision) + the CLI golden `colliding_canons_abstain_with_an_honest_conflict` (asserts `has_conflict: true`, both `conflict_peer`, nothing governs).
- **118 logic-engine + 4 meta-rule CLI tests green; clippy clean. `/security-review` PASSED** (no panic — the Defeated-witness finder uses the same `dominates` predicate as `undefeated`; strictly more conservative; bounded).

## Scope / next

Spec ADJ73 §7 synced (this is the §4.3 honest-abstention slice). The **resolving** tiebreaker — a grounded meta-rule that turns a *chosen* collision into a cited decision (e.g. "lex specialis prevails over lex superior for statutory interpretation here"), needing each derived edge tagged with its canon + a grounded canon-ordering — is a noted independent follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)