### PR TITLE
feat(visicalc-qt): wire clipboard cut/copy/paste into the infinite-sheet demo

### DIFF
--- a/demo/visicalc-qt/InfiniteSheet.qml
+++ b/demo/visicalc-qt/InfiniteSheet.qml
@@ -106,6 +106,27 @@ Item {
                     doc.fill(doc.infAddress, first, last);
                 }
             }
+            // Clipboard: copy/cut the selected cell, paste at the selection. The
+            // engine shifts the pasted formula's relative refs by the offset,
+            // pins absolute ($) refs, carries the format; a cut clears on paste.
+            Button {
+                text: "Copy"
+                ToolTip.visible: hovered
+                ToolTip.text: "Copy the selected cell to the clipboard"
+                onClicked: if (doc) doc.copy(doc.infAddress, doc.infAddress)
+            }
+            Button {
+                text: "Cut"
+                ToolTip.visible: hovered
+                ToolTip.text: "Cut the selected cell (cleared when you paste)"
+                onClicked: if (doc) doc.cut(doc.infAddress, doc.infAddress)
+            }
+            Button {
+                text: "Paste"
+                ToolTip.visible: hovered
+                ToolTip.text: "Paste the clipboard at the selected cell, shifting relative references"
+                onClicked: if (doc) doc.paste(doc.infAddress)
+            }
         }
 
         // ── Column-letter header (frozen vertically, scrolls horizontally) ──

--- a/demo/visicalc-qt/README.md
+++ b/demo/visicalc-qt/README.md
@@ -106,7 +106,12 @@ extent, and bumps `model.revision` so the visible rows re-fetch. The **"Fill ↓
 10"** button next to the formula bar calls `model.fill(src, dstStart, dstEnd)`
 (over the C ABI's `sc_fill`) to replicate the selected cell into the 10 rows
 below it — the engine shifts each copy's relative references (`=A1`→`=A2`, …),
-pins absolute (`$`) refs, and carries the format.
+pins absolute (`$`) refs, and carries the format. The **Copy / Cut / Paste**
+buttons drive the engine's clipboard (`model.copy`/`cut`/`paste` over the C ABI's
+`sc_copy`/`sc_cut`/`sc_paste`): copy the selected cell, then paste it elsewhere
+with its relative references shifted by the destination's offset (absolute `$`
+refs pinned, format carried); a cut clears the source on paste. `paste` returns a
+`bool` — false (a no-op) for an empty clipboard, malformed address, or off-grid.
 
 The model seeds far-flung sparse cells (`Z1000`, `BA50`, `BB50`) on top of the
 budget so there's something to scroll to; the extent (`totalRows`/`totalCols`)

--- a/demo/visicalc-qt/src/SpreadsheetModel.cpp
+++ b/demo/visicalc-qt/src/SpreadsheetModel.cpp
@@ -320,3 +320,35 @@ void SpreadsheetModel::fill(const QString &src, const QString &dstStart, const Q
     emit changed();
     emit revisionChanged();
 }
+
+// Clipboard: copy/cut capture the inclusive rectangle into the engine's
+// clipboard; paste places it (the whole block's references shift by the
+// destination's offset). The QByteArray locals are NAMED so the UTF-8 buffers
+// outlive the C call — a `start.toUtf8().constData()` temporary would dangle.
+void SpreadsheetModel::copy(const QString &start, const QString &end) {
+    const QByteArray s = start.toUtf8();
+    const QByteArray e = end.toUtf8();
+    sc_copy(session_, s.constData(), e.constData());
+}
+
+void SpreadsheetModel::cut(const QString &start, const QString &end) {
+    const QByteArray s = start.toUtf8();
+    const QByteArray e = end.toUtf8();
+    sc_cut(session_, s.constData(), e.constData());
+}
+
+// Returns true when a paste was applied; false (no-op) for an empty clipboard,
+// a malformed address, or an off-grid destination. On success, recompute the
+// grid, regrow the extent, and bump `revision` so the visible rows re-fetch.
+bool SpreadsheetModel::paste(const QString &dstStart) {
+    const QByteArray d = dstStart.toUtf8();
+    const bool applied = sc_paste(session_, d.constData()) != 0;
+    if (applied) {
+        recompute();
+        computeExtent();
+        revision_++;
+        emit changed();
+        emit revisionChanged();
+    }
+    return applied;
+}

--- a/demo/visicalc-qt/src/SpreadsheetModel.h
+++ b/demo/visicalc-qt/src/SpreadsheetModel.h
@@ -120,6 +120,15 @@ public:
     // `dstStart`..`dstEnd` (relative refs shift, absolute pin, format carried);
     // resizes the extent and bumps `revision` so the visible rows re-fetch.
     Q_INVOKABLE void fill(const QString &src, const QString &dstStart, const QString &dstEnd);
+    // Clipboard: copy/cut capture the inclusive rectangle `start`..`end` (a
+    // whole-block copy that pastes as a unit); paste places the block so its
+    // top-left lands at `dstStart`, shifting the block's references by the
+    // destination's offset (a cut clears the source it didn't overwrite). paste
+    // returns true when applied, false for a no-op (empty clipboard / malformed
+    // address / off-grid). paste resizes the extent and bumps `revision`.
+    Q_INVOKABLE void copy(const QString &start, const QString &end);
+    Q_INVOKABLE void cut(const QString &start, const QString &end);
+    Q_INVOKABLE bool paste(const QString &dstStart);
 
 signals:
     // viewportRows changed (after a recompute) — QML rebinds the grid.

--- a/demo/visicalc-qt/test/tst_window.cpp
+++ b/demo/visicalc-qt/test/tst_window.cpp
@@ -23,6 +23,7 @@ private slots:
     void extentColumnLettersAndChangedSince();
     void infiniteViewSelectEditAndRowCells();
     void fillReplicatesShiftingReferences();
+    void clipboardCopyCutPaste();
 };
 
 // Helper: the display string at window (1-based) cell (row, col), given the
@@ -155,6 +156,25 @@ void TstWindow::fillReplicatesShiftingReferences() {
     QCOMPARE(m.window(3, 9, 3, 9).at(0).toList().at(0).toString(), QStringLiteral("40"));
     // The source cell is untouched by its own fill.
     QCOMPARE(m.window(1, 9, 1, 9).at(0).toList().at(0).toString(), QStringLiteral("20"));
+}
+
+// Clipboard (the Copy/Cut/Paste controls drive model.copy/cut/paste): copy a
+// 1×2 block and paste it as a unit; cut a cell and move it.
+void TstWindow::clipboardCopyCutPaste() {
+    SpreadsheetModel m;
+    m.setCell("H1", "5");
+    m.setCell("I1", "=H1*2"); // 10 (col 8 = H, col 9 = I)
+    // Copy the block H1:I1 and paste at H2 — the block shifts down one row.
+    m.copy("H1", "I1");
+    QVERIFY(m.paste("H2")); // applied
+    QCOMPARE(m.window(2, 9, 2, 9).at(0).toList().at(0).toString(), QStringLiteral("10")); // I2 = H2*2
+    // Cut a cell, move it, confirm the source clears and a second paste is a no-op.
+    m.setCell("A1", "99");
+    m.cut("A1", "A1");
+    QVERIFY(m.paste("K1")); // col 11 = K
+    QCOMPARE(m.window(1, 11, 1, 11).at(0).toList().at(0).toString(), QStringLiteral("99"));
+    QCOMPARE(m.window(1, 1, 1, 1).at(0).toList().at(0).toString(), QString()); // A1 cleared
+    QVERIFY(!m.paste("M1")); // buffer consumed
 }
 
 QTEST_MAIN(TstWindow)


### PR DESCRIPTION
**Demo 2 of 6** in the cut/copy/paste rollout (engine [#6120](https://github.com/adhithyan15/coding-adventures/pull/6120), facades [#6126](https://github.com/adhithyan15/coding-adventures/pull/6126), web [#6130](https://github.com/adhithyan15/coding-adventures/pull/6130)). Adds Copy / Cut / Paste to the Qt/QML infinite-sheet demo over the C ABI's `sc_copy`/`sc_cut`/`sc_paste`.

## Changes
- **`SpreadsheetModel.{h,cpp}`** — `Q_INVOKABLE copy(start, end)` / `cut(start, end)` (void) + `paste(dstStart) -> bool`. Each binds its `toUtf8()` result to a **named `const QByteArray` local** so the buffer outlives the C call (a `.toUtf8().constData()` temporary would dangle — the bug the fill PR fixed). `paste` returns `sc_paste`'s int as a `bool` and only `recompute()` / `computeExtent()` / bumps revision on success.
- **`InfiniteSheet.qml`** — Copy / Cut / Paste buttons next to "Fill ↓ 10" driving `model.copy/cut/paste` on the selected cell.
- **`test/tst_window.cpp`** — `clipboardCopyCutPaste`: copy block `H1:I1` → paste at `H2` (`I2 = H2*2 = 10`); cut `A1` → move to `K1` (source clears, second paste `false`).

## Verification
Re-vendored `Vendor/libspreadsheet_capi.a` + `Vendor/spreadsheet.h` from the merged facades (gitignored). `tst_window` — **8/8 PASS** (incl. `clipboardCopyCutPaste`) via qmake. `/security-review` passed in 1 round (QByteArray lifetime / no dangle / null-safety).

4 demos remain (Flutter, Compose, XAML, SwiftUI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)