### PR TITLE
feat(visicalc-flutter): wire clipboard cut/copy/paste into the infinite-sheet demo

### DIFF
--- a/demo/visicalc-flutter/README.md
+++ b/demo/visicalc-flutter/README.md
@@ -121,7 +121,12 @@ follows the body's horizontal pan and the row-number gutter (its own virtualized
 button calls `InfiniteSheetModel.fillDown(10)` (over the C ABI's `sc_fill`) to
 replicate the selected cell into the 10 rows below it — the engine shifts each
 copy's relative references (`=A1`→`=A2`, …), pins absolute (`$`) refs, and
-carries the format. `InfiniteSheetModel`
+carries the format. The **Copy / Cut / Paste** buttons drive the engine's
+clipboard (`InfiniteSheetModel.copyCell`/`cutCell`/`pasteCell` over the C ABI's
+`sc_copy`/`sc_cut`/`sc_paste`): copy the selected cell, then paste it elsewhere
+with its relative references shifted by the destination's offset (absolute `$`
+refs pinned, format carried); a cut clears the source on paste, and `pasteCell`
+returns `false` (a no-op) for an empty clipboard. `InfiniteSheetModel`
 (in `lib/engine.dart`) seeds far-flung sparse cells (`Z1000`, `BA50`, `BB50`) so
 there's something to scroll to, and derives the extent from `usedRange()` + a
 margin.

--- a/demo/visicalc-flutter/lib/engine.dart
+++ b/demo/visicalc-flutter/lib/engine.dart
@@ -73,6 +73,13 @@ typedef _FillC = Void Function(
 typedef _FillD = void Function(
     Pointer<Void>, Pointer<Uint8>, Pointer<Uint8>, Pointer<Uint8>);
 
+// sc_copy / sc_cut(session, start, end) → void (clipboard capture; two A1 strings).
+typedef _ClipC = Void Function(Pointer<Void>, Pointer<Uint8>, Pointer<Uint8>);
+typedef _ClipD = void Function(Pointer<Void>, Pointer<Uint8>, Pointer<Uint8>);
+// sc_paste(session, dst_start) → int (1 applied, 0 no-op).
+typedef _PasteC = Int32 Function(Pointer<Void>, Pointer<Uint8>);
+typedef _PasteD = int Function(Pointer<Void>, Pointer<Uint8>);
+
 /// A single spreadsheet session, owning the opaque C handle.
 class SpreadsheetSession {
   final DynamicLibrary _lib;
@@ -86,6 +93,9 @@ class SpreadsheetSession {
   late final _WindowD _getDisplayWindow;
   late final _SetFormatD _setFormatFn;
   late final _FillD _fillFn;
+  late final _ClipD _copyFn;
+  late final _ClipD _cutFn;
+  late final _PasteD _pasteFn;
   late final _NoArgD _usedRangeFn;
   late final _ColLettersD _columnLettersFn;
   late final _CurrentRevD _currentRevisionFn;
@@ -106,6 +116,9 @@ class SpreadsheetSession {
     _getDisplayWindow = _lib.lookupFunction<_WindowC, _WindowD>('sc_get_display_window');
     _setFormatFn = _lib.lookupFunction<_SetFormatC, _SetFormatD>('sc_set_format');
     _fillFn = _lib.lookupFunction<_FillC, _FillD>('sc_fill');
+    _copyFn = _lib.lookupFunction<_ClipC, _ClipD>('sc_copy');
+    _cutFn = _lib.lookupFunction<_ClipC, _ClipD>('sc_cut');
+    _pasteFn = _lib.lookupFunction<_PasteC, _PasteD>('sc_paste');
     _usedRangeFn = _lib.lookupFunction<_NoArgC, _NoArgD>('sc_used_range');
     _columnLettersFn = _lib.lookupFunction<_ColLettersC, _ColLettersD>('sc_column_letters');
     _currentRevisionFn = _lib.lookupFunction<_CurrentRevC, _CurrentRevD>('sc_current_revision');
@@ -268,6 +281,46 @@ class SpreadsheetSession {
       _freeCString(srcPtr);
       _freeCString(startPtr);
       _freeCString(endPtr);
+    }
+  }
+
+  /// Copy the inclusive rectangle [start]..[end] into the clipboard — a
+  /// whole-block copy that pastes as a unit. The source is untouched; the buffer
+  /// survives any number of pastes.
+  void copy(String start, String end) {
+    final startPtr = _toCString(start);
+    final endPtr = _toCString(end);
+    try {
+      _copyFn(_handle, startPtr, endPtr);
+    } finally {
+      _freeCString(startPtr);
+      _freeCString(endPtr);
+    }
+  }
+
+  /// Cut the inclusive rectangle [start]..[end]. Like [copy] but a one-shot
+  /// move: the [paste] that places it clears the source it didn't overwrite.
+  void cut(String start, String end) {
+    final startPtr = _toCString(start);
+    final endPtr = _toCString(end);
+    try {
+      _cutFn(_handle, startPtr, endPtr);
+    } finally {
+      _freeCString(startPtr);
+      _freeCString(endPtr);
+    }
+  }
+
+  /// Paste the clipboard so its top-left lands at [dstStart]. Returns `true`
+  /// when applied, `false` (a no-op) for an empty clipboard, malformed address,
+  /// or off-grid destination. The block's references shift by the destination's
+  /// offset; content and format ride along.
+  bool paste(String dstStart) {
+    final dstPtr = _toCString(dstStart);
+    try {
+      return _pasteFn(_handle, dstPtr) != 0;
+    } finally {
+      _freeCString(dstPtr);
     }
   }
 
@@ -502,5 +555,18 @@ class InfiniteSheetModel {
     final last = '$col${selRow + rows}';
     _session.fill(infAddress, first, last);
     computeExtent();
+  }
+
+  /// Clipboard: copy/cut the selected cell, then paste it at the selection. The
+  /// engine shifts the pasted formula's relative references by the destination's
+  /// offset, pins absolute (`$`) refs, carries the format; a cut clears the
+  /// source on paste. [pasteCell] returns false (a no-op) when the clipboard is
+  /// empty, and regrows the extent on success.
+  void copyCell() => _session.copy(infAddress, infAddress);
+  void cutCell() => _session.cut(infAddress, infAddress);
+  bool pasteCell() {
+    final ok = _session.paste(infAddress);
+    if (ok) computeExtent();
+    return ok;
   }
 }

--- a/demo/visicalc-flutter/lib/infinite_grid.dart
+++ b/demo/visicalc-flutter/lib/infinite_grid.dart
@@ -114,6 +114,29 @@ class _InfiniteGridState extends State<InfiniteGrid> {
     setState(() => _model.fillDown(10));
   }
 
+  // Clipboard: copy/cut the selected cell, then paste at the selection. The
+  // engine shifts the pasted formula's relative refs by the destination's
+  // offset, pins absolute ($) refs, carries the format; a cut clears on paste.
+  void _copy() => _model.copyCell();
+  void _cut() => _model.cutCell();
+  void _paste() => setState(() => _model.pasteCell());
+
+  // A compact outlined button for the clipboard controls, matching "Fill ↓ 10".
+  Widget _clipButton(String label, String tip, VoidCallback onPressed) {
+    return Tooltip(
+      message: tip,
+      child: OutlinedButton(
+        onPressed: onPressed,
+        style: OutlinedButton.styleFrom(
+          foregroundColor: _ink,
+          side: const BorderSide(color: _border),
+          padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+        ),
+        child: Text(label, style: const TextStyle(fontFamily: _mono, fontSize: 12)),
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     return Column(
@@ -171,6 +194,13 @@ class _InfiniteGridState extends State<InfiniteGrid> {
               child: const Text('Fill ↓ 10', style: TextStyle(fontFamily: _mono, fontSize: 12)),
             ),
           ),
+          const SizedBox(width: 8),
+          // Clipboard: copy/cut the selected cell, paste at the selection.
+          _clipButton('Copy', 'Copy the selected cell to the clipboard', _copy),
+          const SizedBox(width: 8),
+          _clipButton('Cut', 'Cut the selected cell (cleared when you paste)', _cut),
+          const SizedBox(width: 8),
+          _clipButton('Paste', 'Paste the clipboard at the selected cell, shifting relative references', _paste),
         ],
       ),
     );

--- a/demo/visicalc-flutter/test/window_test.dart
+++ b/demo/visicalc-flutter/test/window_test.dart
@@ -134,5 +134,25 @@ void main() {
       expect(m.rowCells(3)[8], '40'); // I3 = H3*10
       expect(m.rowCells(1)[8], '20'); // I1 source untouched
     });
+
+    test('clipboard copyCell/cutCell/pasteCell shifts a formula and moves a cut', () {
+      final m = InfiniteSheetModel();
+      addTearDown(m.dispose);
+      // Seed H1=5, H2=7; I1 = H1*2 (col 8 = H, col 9 = I). Copy I1, then paste at
+      // I2 — the relative ref shifts by the destination's offset, so I2 = H2*2.
+      m.selectInf(1, 8); m.commitInf('5'); // H1
+      m.selectInf(2, 8); m.commitInf('7'); // H2
+      m.selectInf(1, 9); m.commitInf('=H1*2'); // I1 = 10
+      m.selectInf(1, 9); m.copyCell(); // copy I1
+      m.selectInf(2, 9); expect(m.pasteCell(), isTrue); // paste at I2
+      expect(m.rowCells(2)[8], '14'); // I2 = H2*2 = 14
+      // Cut A1, move it to C1: source clears, a second paste is a no-op.
+      m.selectInf(1, 1); m.commitInf('99'); // A1
+      m.selectInf(1, 1); m.cutCell();
+      m.selectInf(1, 3); expect(m.pasteCell(), isTrue); // paste at C1
+      expect(m.rowCells(1)[2], '99'); // C1 moved
+      expect(m.rowCells(1)[0], ''); // A1 cleared
+      m.selectInf(1, 5); expect(m.pasteCell(), isFalse); // buffer consumed
+    });
   });
 }


### PR DESCRIPTION
**Demo 3 of 6** in the cut/copy/paste rollout (engine [#6120](https://github.com/adhithyan15/coding-adventures/pull/6120), facades [#6126](https://github.com/adhithyan15/coding-adventures/pull/6126), web [#6130](https://github.com/adhithyan15/coding-adventures/pull/6130), Qt [#6134](https://github.com/adhithyan15/coding-adventures/pull/6134)). Adds Copy / Cut / Paste to the Flutter (dart:ffi) infinite-sheet demo over the C ABI's `sc_copy`/`sc_cut`/`sc_paste`.

## Changes
- **`lib/engine.dart`** — `_ClipC`/`_ClipD` (void; sc_copy/sc_cut) + `_PasteC`/`_PasteD` (int; sc_paste) typedefs, field lookups, and `SpreadsheetSession.copy/cut/paste`. `paste` returns `bool` from the int; each marshals A1 strings via `_toCString` and frees every pointer in a `finally` (mirrors `fill`). `InfiniteSheetModel.copyCell/cutCell/pasteCell` act on the selected cell (`pasteCell` regrows the extent).
- **`lib/infinite_grid.dart`** — Copy / Cut / Paste `OutlinedButton`s next to "Fill ↓ 10" via a shared `_clipButton` helper.
- **`test/window_test.dart`** — clipboard test: copy `I1` (`==H1*2`) → paste at `I2` (`= H2*2 = 14`); cut `A1` → move to `C1` (source clears, second paste returns `false`).

## Verification
Re-vendored `native/libspreadsheet_capi.dylib` from the merged facades (gitignored). `flutter test test/window_test.dart` — **9/9 pass** (incl. the clipboard test); `flutter analyze lib test` clean for the changed files (the 2 warnings are pre-existing, in `lib/generated/grid.dart`). `/security-review` passed in 1 round (ffi alloc/free symmetry, signatures, no UAF).

3 demos remain (Compose, XAML, SwiftUI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)