### PR TITLE
feat(adj73): resolving canon tiebreaker — grounded canon-ordering, in-language (ADJ73 §4.3)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/context_metarules_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/context_metarules_e2e.rs
@@ -170,3 +170,33 @@ fn colliding_canons_abstain_with_an_honest_conflict() {
         "both contexts are present in the unresolved set: {s}"
     );
 }
+
+#[test]
+fn a_grounded_canon_ordering_resolves_the_collision() {
+    // ADJ73 §4.3 (resolving tiebreaker): the SAME federal-vs-state collision as the abstention
+    // example, but the jurisdiction supplies one more grounded fact —
+    // `canon_outranks(lex_specialis, lex_superior)` — and a NAF resolution rule keeps the
+    // lex-specialis edge (state > federal) while canon-defeating the lex-superior edge. So the
+    // SPECIFIC state reading GOVERNS — a cited decision, not an abstention. No engine change: the
+    // tiebreaker is expressed entirely in the language (canon-tagged edges + negation-as-failure).
+    let (ok, s) = run("worked-canon-tiebreaker-example.adj");
+    assert!(ok, "cli should succeed: {s}");
+    // Resolved, not abstained.
+    assert!(
+        s.contains("\"has_conflict\":false"),
+        "the grounded canon-ordering resolves the collision: {s}"
+    );
+    // The specific state reading governs; the general federal one is defeated.
+    assert!(
+        s.contains("rule_on(matter, prohibited)") && s.contains("\"status\":\"governing\""),
+        "the specific (state) reading governs by the canon-ordering: {s}"
+    );
+    assert!(
+        s.contains("\"context\":\"state\""),
+        "governed in the specific (state) context: {s}"
+    );
+    assert!(
+        s.contains("\"defeated_by\":\"rule_on(matter, prohibited)\""),
+        "the general federal reading is canon-defeated by the specific one: {s}"
+    );
+}

--- a/code/specs/ADJ73-defeasible-rule-precedence.md
+++ b/code/specs/ADJ73-defeasible-rule-precedence.md
@@ -374,9 +374,20 @@ Each PR: spec-sync note, tests incl. a CONFLICT/abstain case, `/security-review`
     so neither is silently `Defeated` — the group abstains as `ConflictPeer` / `has_conflict`. This
     closes the "else CONFLICT (abstain)" guarantee (previously the engine produced a misleading
     "both defeated, no conflict flag"). `worked-canon-conflict-example.adj` +
-    `colliding_canons_abstain_with_an_honest_conflict`. Still to come (the RESOLVING tiebreaker):
-    a grounded meta-rule that turns a *chosen* collision into a cited decision — needs each derived
-    edge tagged with its canon + a grounded canon-ordering, so the engine picks with provenance.
+    `colliding_canons_abstain_with_an_honest_conflict`.
+  - **PR-B-7 resolving tiebreaker ✅ DONE (no engine change — pure in-language pattern).** A
+    chosen collision RESOLVES to a cited decision via: (a) canon-TAGGED edges
+    `outranks_context_by(Higher, Lower, Canon)`, (b) a grounded `canon_outranks(C2, C1)` ordering,
+    and (c) a negation-as-failure resolution rule — `outranks_context(H,L) :-
+    outranks_context_by(H,L,C), not canon_defeated(H,L,C)` with `canon_defeated(H,L,C) :-
+    outranks_context_by(L,H,C2), canon_outranks(C2,C)`. The engine's existing NAF + derived-edge
+    machinery (PR-B-4) does the rest — `context_adjacency` reads the resolved `outranks_context/2`.
+    `worked-canon-tiebreaker-example.adj` (lex specialis prevails over lex superior here → the
+    specific state reading governs) + `a_grounded_canon_ordering_resolves_the_collision`. The
+    canon-ordering is itself a grounded fact, so the recursion stays grounded; remove it and the
+    rulebook falls back to §4.3 abstention. Still to come: migrate the SHARED
+    `context-precedence(-meta).adj` rulebook to the tagged `outranks_context_by/3` form (proven
+    self-contained first), so a jurisdiction's `canon_outranks` applies uniformly.
 - **PR-C — adj-lang surface** (`priority: <tier>`, `functional`/`decision`, the attribute
   annotations) + regen grammar.
 - **PR-D — MYCIN `decide_timing` → `timing.adj`** on the named-enum ladder (was PR-4).

--- a/code/specs/data/context-precedence/README.md
+++ b/code/specs/data/context-precedence/README.md
@@ -14,6 +14,7 @@ own rulebook, with a citation on *why* one context outranks another (ADJ73 decis
 | [`worked-supersession-example.adj`](worked-supersession-example.adj) | Lex posterior (bridges to MYCIN): the 2024 guideline edition supersedes the 2004 one, so the current recommendation governs the legacy one — `idsa_2024 > idsa_2004` derived from a grounded `supersedes` fact. |
 | [`worked-lex-specialis-example.adj`](worked-lex-specialis-example.adj) | Lex specialis: a specific wilderness-trail statute governs a general traffic statute on the same matter — `trail_statute > traffic_statute` derived from a grounded `more_specific` fact, despite the general statute's higher tier. |
 | [`worked-canon-conflict-example.adj`](worked-canon-conflict-example.adj) | **§4.3 honest CONFLICT** — lex superior (`federal > state`) and lex specialis (`state > federal`) point opposite ways with no tiebreaker → the engine **abstains** (both `conflict_peer`, `has_conflict: true`), never silently crowning a canon. |
+| [`worked-canon-tiebreaker-example.adj`](worked-canon-tiebreaker-example.adj) | **§4.3 RESOLVING tiebreaker** — the same collision, but a grounded `canon_outranks(lex_specialis, lex_superior)` fact + a negation-as-failure resolution rule (over canon-tagged `outranks_context_by/3` edges) **resolves** it to a cited decision: the specific state reading governs. No engine change — the tiebreaker is in the language; remove the canon-ordering fact and it falls back to abstention. |
 | [`SOURCES.md`](SOURCES.md) | The provenance ledger — where each edge's verbatim quote came from. |
 
 ## Run it
@@ -51,8 +52,12 @@ This is the data/worked-example layer of the ADJ73 precedence arc:
 - **conflict handling** (logic-engine 0.22, §4.3) — when canons point opposite ways and no
   tiebreaker exists, the engine **abstains** (`ConflictPeer` / `has_conflict`), never silently
   crowning one or double-defeating both (`worked-canon-conflict-example.adj`). The "else CONFLICT".
-- **next** — a *grounded tiebreaker* meta-rule that RESOLVES a specific collision (e.g. "in this
-  jurisdiction lex specialis prevails over lex superior for statutory interpretation"), turning a
-  chosen abstention into a cited decision. Needs each derived edge tagged with the canon that
-  produced it + a grounded canon-ordering. See the spec
+- **resolving tiebreaker** (§4.3, in-language — no engine change) — a grounded `canon_outranks`
+  ordering + a negation-as-failure resolution rule over canon-tagged `outranks_context_by/3` edges
+  RESOLVES a chosen collision into a **cited decision** (`worked-canon-tiebreaker-example.adj`):
+  the canon-ordering is itself a grounded fact, so the recursion stays grounded all the way up.
+  Remove it → fall back to abstention.
+- **next** — migrate the shared `context-precedence(-meta).adj` rulebook to the canon-tagged
+  `outranks_context_by/3` + resolution form (the tiebreaker pattern is proven self-contained
+  first), so any jurisdiction's `canon_outranks` ordering applies uniformly. See the spec
   `code/specs/ADJ73-defeasible-rule-precedence.md` §4.3, §7.

--- a/code/specs/data/context-precedence/worked-canon-tiebreaker-example.adj
+++ b/code/specs/data/context-precedence/worked-canon-tiebreaker-example.adj
@@ -1,0 +1,84 @@
+% =====================================================================
+% worked-canon-tiebreaker-example.adj — RESOLVING a canon collision with a
+% grounded canon-ordering (ADJ73 §4.3, the resolving tiebreaker).
+%
+% worked-canon-conflict-example.adj showed the HONEST DEFAULT: when lex superior
+% (federal > state) and lex specialis (state > federal) point opposite ways and
+% nothing breaks the tie, the engine ABSTAINS (CONFLICT). This file shows the
+% RESOLUTION: a jurisdiction that has decided how to rank the canons supplies one
+% more grounded fact — `canon_outranks(lex_specialis, lex_superior)` — and the
+% collision resolves to a CITED decision instead of an abstention.
+%
+% THE KEY MOVE — entirely in the language, no engine change. Each canon derives a
+% context edge TAGGED with the canon that produced it:
+%       outranks_context_by(Higher, Lower, Canon)
+% and a single resolution rule (negation-as-failure) keeps an edge unless the
+% REVERSE edge comes from a higher-ranked canon:
+%       outranks_context(H, L) :- outranks_context_by(H, L, C), not canon_defeated(H, L, C).
+%       canon_defeated(H, L, C) :- outranks_context_by(L, H, C2), canon_outranks(C2, C).
+% The engine (logic-engine ≥ 0.21) reads the resolved `outranks_context/2` as the
+% context order, so the survivor drives `lex superior` exactly as before. The
+% recursion bottoms out at grounded facts at every layer — the primitive
+% (`more_specific`), the canon edge, AND the canon-ordering — each byte-cited.
+%
+% THE CASE (same collision as worked-canon-conflict-example.adj):
+%   • lex superior: federal > state (Supremacy Clause)
+%   • lex specialis: state > federal (the state statute is the specific one)
+%   • this jurisdiction's interpretive rule: lex specialis prevails over lex superior.
+% Resolution: the federal>state edge is canon-defeated (its reverse comes from the
+% higher-ranked lex specialis), so only state>federal survives → the SPECIFIC state
+% reading GOVERNS:
+%
+%   rule_on(matter, prohibited)  status governing   context state
+%   rule_on(matter, permitted)   status defeated     context federal
+%   has_conflict: false
+%
+% REMOVE the `canon_outranks` fact and this same rulebook ABSTAINS (the §4.3
+% default) — the tiebreaker is opt-in and itself grounded. 0 answer-time model calls.
+% =====================================================================
+
+functional rule_on(topic, ruling)
+
+% --- the two canons, each emitting a CANON-TAGGED edge ---
+
+% LEX SUPERIOR (federal > state) — grounded, tagged with its canon.
+relate outranks_context_by(federal, state, lex_superior)
+  source "U.S. Const. art. VI, cl. 2 (Supremacy Clause): federal law is the supreme law of the land."
+  locator "U.S. Const. art. VI, cl. 2"
+  trust authoritative
+
+% LEX SPECIALIS — the state statute is the more specific provision on this matter; the canon
+% derives state > federal, tagged.
+relate more_specific(state, federal)
+  source "The state statute addresses this specific situation; the federal provision is general."
+  locator "statutory subject-matter comparison"
+  trust authoritative
+rule {
+  head: outranks_context_by($Specific, $General, lex_specialis)
+  when: more_specific($Specific, $General)
+  source "Lex specialis derogat legi generali: the specific provision governs the general."
+  trust authoritative
+}
+
+% --- the GROUNDED canon-ordering (the tiebreaker itself, byte-provenanced) ---
+% This jurisdiction resolves a specific-vs-general collision in favor of the specific provision.
+% Remove this fact and the collision falls back to the honest CONFLICT (§4.3 abstention).
+relate canon_outranks(lex_specialis, lex_superior)
+  source "Where a specific statutory provision conflicts with a general one on the same matter, the specific provision controls (lex specialis), even over a higher-authority general rule, for statutory interpretation in this jurisdiction."
+  locator "jurisdiction interpretive canon-ordering"
+  trust authoritative
+
+% --- the resolution (in-language, negation-as-failure) ---
+% An edge holds unless its reverse comes from a higher-ranked canon.
+rule { head: outranks_context($H, $L)  when: outranks_context_by($H, $L, $C), not canon_defeated($H, $L, $C) }
+rule { head: canon_defeated($H, $L, $C)  when: outranks_context_by($L, $H, $C2), canon_outranks($C2, $C) }
+
+% --- the case: a general federal reading vs a specific state reading ---
+rule { head: rule_on(matter, permitted)  when: federal_general  context: federal }
+rule { head: rule_on(matter, prohibited) when: state_specific   context: state }
+
+observe federal_general
+observe state_specific
+
+% Which governs?  → the specific state reading, by the grounded canon-ordering (no abstention).
+? rule_on(matter, $ruling)


### PR DESCRIPTION
## What

The companion to **[#6131](https://github.com/adhithyan15/coding-adventures/pull/6131)** (§4.3 honest CONFLICT). When two canons collide, the engine abstains by default; this shows how a jurisdiction **resolves** the collision into a **cited decision** — with **no engine change**, entirely in the language.

## The pattern (proven self-contained in `worked-canon-tiebreaker-example.adj`)

- each canon emits a canon-**tagged** edge `outranks_context_by(Higher, Lower, Canon)`;
- a grounded `canon_outranks(C2, C1)` fact records the jurisdiction's interpretive ordering (e.g. *"lex specialis prevails over lex superior for statutory interpretation here"*), itself byte-cited;
- a **negation-as-failure** resolution rule keeps an edge unless its reverse comes from a higher-ranked canon:

```
outranks_context(H,L)  :- outranks_context_by(H,L,C), not canon_defeated(H,L,C).
canon_defeated(H,L,C)  :- outranks_context_by(L,H,C2), canon_outranks(C2,C).
```

The engine's existing NAF + derived-edge machinery (PR-B-4) reads the resolved `outranks_context/2`, so the survivor drives lex superior exactly as before. **The recursion stays grounded all the way up** — primitive, canon edge, *and* canon-ordering each cited. Remove the `canon_outranks` fact and the same rulebook falls back to §4.3 abstention (the tiebreaker is opt-in and grounded).

## Worked example + test

Same federal-vs-state collision as `worked-canon-conflict-example.adj`, but `canon_outranks(lex_specialis, lex_superior)` **resolves** it → the **specific state reading governs** (federal canon-defeated), `has_conflict: false`. 0 answer-time model calls. CLI golden test `a_grounded_canon_ordering_resolves_the_collision`; **5 meta-rule tests green**. `/security-review` PASSED.

## Scope

**No engine/package src change → no version bump** (data + test + docs only). Spec ADJ73 §7 synced (this is the resolving-tiebreaker slice). **Next:** migrate the *shared* `context-precedence(-meta).adj` rulebook to the tagged `outranks_context_by/3` form (the pattern is proven self-contained here first), so a jurisdiction's `canon_outranks` ordering applies uniformly across all canons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)