### PR TITLE
feat(visicalc-compose): wire clipboard cut/copy/paste into the infinite-sheet demo

### DIFF
--- a/demo/visicalc-compose/README.md
+++ b/demo/visicalc-compose/README.md
@@ -88,6 +88,12 @@ regrows the extent). The **"Fill ↓ 10"** button next to the formula bar calls
 `InfiniteSheetModel.fillDown(10)` (over the C ABI's `sc_fill`) to replicate the
 selected cell into the 10 rows below it — the engine shifts each copy's relative
 references (`=A1`→`=A2`, …), pins absolute (`$`) refs, and carries the format.
+The **Copy / Cut / Paste** buttons drive the engine's clipboard
+(`InfiniteSheetModel.copyCell`/`cutCell`/`pasteCell` over the C ABI's
+`sc_copy`/`sc_cut`/`sc_paste`): copy the selected cell, then paste it elsewhere
+with its relative references shifted by the destination's offset (absolute `$`
+refs pinned, format carried); a cut clears the source on paste, and `pasteCell`
+returns `false` (a no-op) for an empty clipboard.
 `InfiniteSheetModel` (in `Engine.kt`) seeds far-flung
 sparse cells (`Z1000`, `BA50`, `BB50`) and derives the extent from `usedRange()`
 + a margin.
@@ -100,8 +106,10 @@ formula 1000 rows down (`Z1000` = 39) is reachable, the gaps are empty (sparse),
 column letters run AA/BA, and editing `A1` dirties the far dependent `Z1000` via
 `changedSince`. It also drives `InfiniteSheetModel` directly: `rowCells`
 one-read rows, `selectInf` clamping + source load, `commitInf` recompute
-(A2 `8`→`108` ⇒ E2 151, A5 139, E5 269), and `fillDown` (`I1 = =H1*10` filled
-down 10 rows ⇒ I2 = H2*10 = 30, I3 = H3*10 = 40, source I1 = 20 untouched).
+(A2 `8`→`108` ⇒ E2 151, A5 139, E5 269), `fillDown` (`I1 = =H1*10` filled
+down 10 rows ⇒ I2 = H2*10 = 30, I3 = H3*10 = 40, source I1 = 20 untouched), and
+the clipboard (`copyCell` I1 → `pasteCell` at I4 ⇒ I4 = H4*10 = 60; `cutCell` A1
+→ paste at C1 moves it, A1 clears, a second paste returns false).
 
 The Compose UI itself (`InfiniteSheet.kt` + the `Main.kt` toggle) is verified to
 compile against the real Compose Desktop APIs via `gradle compileKotlin`; the

--- a/demo/visicalc-compose/src/main/kotlin/Engine.kt
+++ b/demo/visicalc-compose/src/main/kotlin/Engine.kt
@@ -50,6 +50,11 @@ class SpreadsheetSession(libraryPath: String = resolveLibraryPath()) : AutoClose
     private val scSetFormat = handle("sc_set_format", FunctionDescriptor.ofVoid(ptr, ptr, ptr))
     // sc_fill(session, src, dst_start, dst_end) -> void (drag-fill; three A1 strings).
     private val scFill = handle("sc_fill", FunctionDescriptor.ofVoid(ptr, ptr, ptr, ptr))
+    // sc_copy / sc_cut(session, start, end) -> void (clipboard capture; two A1 strings).
+    private val scCopy = handle("sc_copy", FunctionDescriptor.ofVoid(ptr, ptr, ptr))
+    private val scCut = handle("sc_cut", FunctionDescriptor.ofVoid(ptr, ptr, ptr))
+    // sc_paste(session, dst_start) -> int (1 applied, 0 no-op).
+    private val scPaste = handle("sc_paste", FunctionDescriptor.of(i32, ptr, ptr))
     private val scUsedRange = handle("sc_used_range", FunctionDescriptor.of(ptr, ptr))
     private val scColumnLetters = handle("sc_column_letters", FunctionDescriptor.of(ptr, ptr, i32))
     private val scCurrentRevision = handle("sc_current_revision", FunctionDescriptor.of(i64, ptr))
@@ -129,6 +134,27 @@ class SpreadsheetSession(libraryPath: String = resolveLibraryPath()) : AutoClose
             a.allocateUtf8String(dstStart),
             a.allocateUtf8String(dstEnd),
         )
+    }
+
+    /// Copy the inclusive rectangle [start]..[end] into the clipboard — a
+    /// whole-block copy that pastes as a unit. The source is untouched; the
+    /// buffer survives any number of pastes.
+    fun copy(start: String, end: String): Unit = Arena.ofConfined().use { a ->
+        scCopy.invoke(session, a.allocateUtf8String(start), a.allocateUtf8String(end))
+    }
+
+    /// Cut the inclusive rectangle [start]..[end]. Like [copy] but a one-shot
+    /// move: the [paste] that places it clears the source it didn't overwrite.
+    fun cut(start: String, end: String): Unit = Arena.ofConfined().use { a ->
+        scCut.invoke(session, a.allocateUtf8String(start), a.allocateUtf8String(end))
+    }
+
+    /// Paste the clipboard so its top-left lands at [dstStart]. Returns `true`
+    /// when applied, `false` (a no-op) for an empty clipboard, malformed address,
+    /// or off-grid destination. The block's references shift by the destination's
+    /// offset; content and format ride along.
+    fun paste(dstStart: String): Boolean = Arena.ofConfined().use { a ->
+        (scPaste.invoke(session, a.allocateUtf8String(dstStart)) as Int) != 0
     }
 
     /// Dense display strings for the inclusive 1-based rectangle, row-major
@@ -384,6 +410,19 @@ class InfiniteSheetModel(
         val last = "$col${selRow + rows}"
         session.fill(infAddress(), first, last)
         computeExtent()
+    }
+
+    /// Clipboard: copy/cut the selected cell, then paste it at the selection. The
+    /// engine shifts the pasted formula's relative references by the
+    /// destination's offset, pins absolute (`$`) refs, carries the format; a cut
+    /// clears the source on paste. [pasteCell] returns false (a no-op) when the
+    /// clipboard is empty, and regrows the extent on success.
+    fun copyCell() = session.copy(infAddress(), infAddress())
+    fun cutCell() = session.cut(infAddress(), infAddress())
+    fun pasteCell(): Boolean {
+        val ok = session.paste(infAddress())
+        if (ok) computeExtent()
+        return ok
     }
 
     override fun close() = session.close()

--- a/demo/visicalc-compose/src/main/kotlin/InfiniteSheet.kt
+++ b/demo/visicalc-compose/src/main/kotlin/InfiniteSheet.kt
@@ -108,6 +108,16 @@ fun InfiniteSheet() {
         rev++
     }
 
+    // Clipboard: copy/cut the selected cell, then paste at the selection. The
+    // engine shifts the pasted formula's relative refs by the destination's
+    // offset, pins absolute ($) refs, carries the format; a cut clears on paste.
+    fun copyCell() = model.copyCell()
+    fun cutCell() = model.cutCell()
+    fun pasteCell() {
+        model.pasteCell()
+        rev++
+    }
+
     Column(modifier = Modifier.fillMaxSize().padding(8.dp)) {
         // ── Formula bar: the selected cell's address + an editable source ──
         Row(verticalAlignment = Alignment.CenterVertically) {
@@ -148,6 +158,13 @@ fun InfiniteSheet() {
                     fontFamily = MONO,
                 )
             }
+            // Clipboard: copy/cut the selected cell, paste at the selection.
+            Spacer(Modifier.width(8.dp))
+            clipButton("Copy") { copyCell() }
+            Spacer(Modifier.width(8.dp))
+            clipButton("Cut") { cutCell() }
+            Spacer(Modifier.width(8.dp))
+            clipButton("Paste") { pasteCell() }
         }
 
         Spacer(Modifier.height(6.dp))
@@ -226,5 +243,20 @@ private fun chromeCell(w: androidx.compose.ui.unit.Dp, h: androidx.compose.ui.un
 private fun Text(text: String, color: Color, width: androidx.compose.ui.unit.Dp) {
     Box(modifier = Modifier.width(width)) {
         androidx.compose.material.Text(text, color = color, fontSize = 12.sp, fontFamily = MONO)
+    }
+}
+
+/// A compact outlined button for the clipboard controls, matching "Fill ↓ 10".
+@Composable
+private fun clipButton(label: String, onClick: () -> Unit) {
+    androidx.compose.material.OutlinedButton(
+        onClick = onClick,
+        colors = androidx.compose.material.ButtonDefaults.outlinedButtonColors(
+            backgroundColor = CHROME,
+            contentColor = INK,
+        ),
+        border = androidx.compose.foundation.BorderStroke(1.dp, BORDER),
+    ) {
+        androidx.compose.material.Text(label, fontSize = 12.sp, fontFamily = MONO)
     }
 }

--- a/demo/visicalc-compose/test/EngineSmoke.kt
+++ b/demo/visicalc-compose/test/EngineSmoke.kt
@@ -138,6 +138,20 @@ fun main() {
     check("inf fillDown I2", inf.rowCells(2)[8], "30") // I2 = H2*10
     check("inf fillDown I3", inf.rowCells(3)[8], "40") // I3 = H3*10
     check("inf fillDown I1 source", inf.rowCells(1)[8], "20") // I1 untouched
+
+    // Clipboard: copy I1 (= H1*10) and paste at I4 — the relative ref shifts by
+    // the destination's offset, so I4 = H4*10. (H4 unset → 0, so seed it.)
+    inf.selectInf(4, 8); inf.commitInf("6")        // H4 = 6
+    inf.selectInf(1, 9); inf.copyCell()            // copy I1
+    inf.selectInf(4, 9); check("inf pasteCell applied", inf.pasteCell().toString(), "true")
+    check("inf paste I4 = H4*10", inf.rowCells(4)[8], "60") // I4 = H4*10 = 60
+    // Cut A1 and move it to C1: source clears, a second paste is a no-op.
+    inf.selectInf(1, 1); inf.commitInf("99")       // A1
+    inf.selectInf(1, 1); inf.cutCell()
+    inf.selectInf(1, 3); check("inf cut paste applied", inf.pasteCell().toString(), "true")
+    check("inf cut moved C1", inf.rowCells(1)[2], "99") // C1 (col 3, index 2)
+    check("inf cut cleared A1", inf.rowCells(1)[0], "") // A1 cleared
+    inf.selectInf(1, 5); check("inf cut buffer consumed", inf.pasteCell().toString(), "false")
     inf.close()
 
     println(if (failures == 0) "\nALL PASS" else "\n$failures FAILURE(S)")


### PR DESCRIPTION
**Demo 4 of 6** in the cut/copy/paste rollout (engine [#6120](https://github.com/adhithyan15/coding-adventures/pull/6120), facades [#6126](https://github.com/adhithyan15/coding-adventures/pull/6126), web [#6130](https://github.com/adhithyan15/coding-adventures/pull/6130), Qt [#6134](https://github.com/adhithyan15/coding-adventures/pull/6134), Flutter [#6137](https://github.com/adhithyan15/coding-adventures/pull/6137)). Adds Copy / Cut / Paste to the Compose Desktop demo over the C ABI's `sc_copy`/`sc_cut`/`sc_paste` via the Java FFM API.

## Changes
- **`Engine.kt`** — `scCopy`/`scCut` FFM handles (`ofVoid(ptr,ptr,ptr)`) + `scPaste` (`of(i32,ptr,ptr)`, returns `JAVA_INT`); `SpreadsheetSession.copy/cut/paste` — `paste` casts the int return to `Boolean`; each marshals A1 strings on a confined `Arena` whose `.use{}` encloses the downcall (mirrors `fill`). `InfiniteSheetModel.copyCell/cutCell/pasteCell` act on the selected cell (`pasteCell` regrows the extent).
- **`InfiniteSheet.kt`** — Copy / Cut / Paste `OutlinedButton`s next to "Fill ↓ 10" via a shared private `@Composable clipButton` helper.
- **`test/EngineSmoke.kt`** — clipboard checks: copy `I1` (`==H1*10`) → paste at `I4` (`I4 = H4*10 = 60`); cut `A1` → move to `C1` (source clears, second paste `false`).

## Verification
Re-vendored `native/libspreadsheet_capi.dylib` from the merged facades (gitignored). `scripts/verify.sh` (kotlinc + FFM) — **ALL PASS** incl. the clipboard checks. `/security-review` passed in 1 round (FFM arena lifetime, signatures, int return).

2 demos remain (XAML, SwiftUI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)