### PR TITLE
feat(visicalc-xaml): wire clipboard cut/copy/paste into the infinite-sheet demo

### DIFF
--- a/demo/visicalc-xaml/Engine.cs
+++ b/demo/visicalc-xaml/Engine.cs
@@ -67,6 +67,19 @@ internal static class ScNative
         [MarshalAs(UnmanagedType.LPUTF8Str)] string src,
         [MarshalAs(UnmanagedType.LPUTF8Str)] string dstStart,
         [MarshalAs(UnmanagedType.LPUTF8Str)] string dstEnd);
+    // sc_copy / sc_cut(session, start, end) → void (clipboard capture; two A1 strings).
+    [DllImport("spreadsheet_capi")]
+    internal static extern void sc_copy(IntPtr s,
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string start,
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string end);
+    [DllImport("spreadsheet_capi")]
+    internal static extern void sc_cut(IntPtr s,
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string start,
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string end);
+    // sc_paste(session, dst_start) → int (1 applied, 0 no-op).
+    [DllImport("spreadsheet_capi")]
+    internal static extern int sc_paste(IntPtr s,
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string dstStart);
     [DllImport("spreadsheet_capi")] internal static extern IntPtr sc_used_range(IntPtr s);
     [DllImport("spreadsheet_capi")] internal static extern IntPtr sc_column_letters(IntPtr s, uint index);
     [DllImport("spreadsheet_capi")] internal static extern ulong sc_current_revision(IntPtr s);
@@ -132,6 +145,21 @@ public sealed class SpreadsheetSession : IDisposable
     /// every dependent. Reaches sc_fill — the same path every other backend drives.
     public void Fill(string src, string dstStart, string dstEnd) =>
         ScNative.sc_fill(_handle, src, dstStart, dstEnd);
+
+    /// Copy the inclusive rectangle `start`..`end` into the clipboard — a
+    /// whole-block copy that pastes as a unit. The source is untouched; the
+    /// buffer survives any number of pastes.
+    public void Copy(string start, string end) => ScNative.sc_copy(_handle, start, end);
+
+    /// Cut the inclusive rectangle `start`..`end`. Like <see cref="Copy"/> but a
+    /// one-shot move: the paste that places it clears the source it didn't overwrite.
+    public void Cut(string start, string end) => ScNative.sc_cut(_handle, start, end);
+
+    /// Paste the clipboard so its top-left lands at `dstStart`. Returns `true`
+    /// when applied, `false` (a no-op) for an empty clipboard, malformed address,
+    /// or off-grid destination. The block's references shift by the destination's
+    /// offset; content and format ride along.
+    public bool Paste(string dstStart) => ScNative.sc_paste(_handle, dstStart) != 0;
 
     /// The display string for a cell — what a spreadsheet should show. Parses
     /// the engine's JSON (the fixed shape every backend's engine emits).
@@ -464,6 +492,20 @@ public sealed class InfiniteSheetModel : IDisposable
         int last = Saturate((long)SelRow + rows, floor: 1);
         _session.Fill(InfAddress, $"{col}{first}", $"{col}{last}");
         ComputeExtent();
+    }
+
+    /// Clipboard: copy/cut the selected cell, then paste it at the selection. The
+    /// engine shifts the pasted formula's relative references by the destination's
+    /// offset, pins absolute (`$`) refs, carries the format; a cut clears the
+    /// source on paste. <see cref="PasteCell"/> returns false (a no-op) when the
+    /// clipboard is empty, and regrows the extent on success.
+    public void CopyCell() => _session.Copy(InfAddress, InfAddress);
+    public void CutCell() => _session.Cut(InfAddress, InfAddress);
+    public bool PasteCell()
+    {
+        bool ok = _session.Paste(InfAddress);
+        if (ok) ComputeExtent();
+        return ok;
     }
 
     public void Dispose() => _session.Dispose();

--- a/demo/visicalc-xaml/InfiniteSheet.xaml
+++ b/demo/visicalc-xaml/InfiniteSheet.xaml
@@ -33,7 +33,7 @@
         </Grid.RowDefinitions>
 
         <!-- Formula bar: the selected cell's address + an editable source line,
-             plus a "Fill ↓ 10" button that drag-fills the selection down. -->
+             plus "Fill ↓ 10" and Copy / Cut / Paste controls. -->
         <Grid Grid.Row="0" Margin="0,0,0,6">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="64"/>
@@ -47,13 +47,33 @@
                      Background="#2D2D30" Foreground="#CCCCCC" BorderBrush="#3F3F46"
                      FontSize="13" FontFamily="Consolas"
                      KeyDown="FormulaBox_KeyDown"/>
-            <!-- Drag-fill: replicate the selected cell into the 10 rows below it. -->
-            <Button x:Name="FillButton" Grid.Column="2" Margin="8,0,0,0" Height="28"
-                    Background="#2D2D30" Foreground="#CCCCCC" BorderBrush="#3F3F46"
-                    BorderThickness="1" FontSize="12" FontFamily="Consolas"
-                    Content="Fill ↓ 10"
-                    ToolTipService.ToolTip="Replicate the selected cell into the 10 rows below it"
-                    Click="FillButton_Click"/>
+            <!-- Drag-fill + clipboard controls. -->
+            <StackPanel Grid.Column="2" Orientation="Horizontal">
+                <Button x:Name="FillButton" Margin="8,0,0,0" Height="28"
+                        Background="#2D2D30" Foreground="#CCCCCC" BorderBrush="#3F3F46"
+                        BorderThickness="1" FontSize="12" FontFamily="Consolas"
+                        Content="Fill ↓ 10"
+                        ToolTipService.ToolTip="Replicate the selected cell into the 10 rows below it"
+                        Click="FillButton_Click"/>
+                <Button x:Name="CopyButton" Margin="8,0,0,0" Height="28"
+                        Background="#2D2D30" Foreground="#CCCCCC" BorderBrush="#3F3F46"
+                        BorderThickness="1" FontSize="12" FontFamily="Consolas"
+                        Content="Copy"
+                        ToolTipService.ToolTip="Copy the selected cell to the clipboard"
+                        Click="CopyButton_Click"/>
+                <Button x:Name="CutButton" Margin="8,0,0,0" Height="28"
+                        Background="#2D2D30" Foreground="#CCCCCC" BorderBrush="#3F3F46"
+                        BorderThickness="1" FontSize="12" FontFamily="Consolas"
+                        Content="Cut"
+                        ToolTipService.ToolTip="Cut the selected cell (cleared when you paste)"
+                        Click="CutButton_Click"/>
+                <Button x:Name="PasteButton" Margin="8,0,0,0" Height="28"
+                        Background="#2D2D30" Foreground="#CCCCCC" BorderBrush="#3F3F46"
+                        BorderThickness="1" FontSize="12" FontFamily="Consolas"
+                        Content="Paste"
+                        ToolTipService.ToolTip="Paste the clipboard at the selected cell, shifting relative references"
+                        Click="PasteButton_Click"/>
+            </StackPanel>
         </Grid>
 
         <!-- Column-letter header (frozen vertically, follows horizontal pan). -->

--- a/demo/visicalc-xaml/InfiniteSheet.xaml.cs
+++ b/demo/visicalc-xaml/InfiniteSheet.xaml.cs
@@ -182,6 +182,17 @@ public sealed partial class InfiniteSheet : UserControl
         RepaintRealizedRows();
     }
 
+    /// Clipboard: copy/cut the selected cell, then paste it at the selection. The
+    /// engine shifts the pasted formula's relative refs by the destination's
+    /// offset, pins absolute ($) refs, carries the format; a cut clears the source
+    /// on paste. Paste repaints the realized rows when it actually applied.
+    private void CopyButton_Click(object sender, RoutedEventArgs e) => _model.CopyCell();
+    private void CutButton_Click(object sender, RoutedEventArgs e) => _model.CutCell();
+    private void PasteButton_Click(object sender, RoutedEventArgs e)
+    {
+        if (_model.PasteCell()) RepaintRealizedRows();
+    }
+
     private void RefreshFormulaBar()
     {
         AddressText.Text = _model.InfAddress;

--- a/demo/visicalc-xaml/README.md
+++ b/demo/visicalc-xaml/README.md
@@ -149,6 +149,12 @@ The **"Fill ↓ 10"** button next to the formula bar calls
 `InfiniteSheetModel.FillDown(10)` (over the C ABI's `sc_fill`) to replicate the
 selected cell into the 10 rows below it — the engine shifts each copy's relative
 references (`=A1`→`=A2`, …), pins absolute (`$`) refs, and carries the format.
+The **Copy / Cut / Paste** buttons drive the engine's clipboard
+(`InfiniteSheetModel.CopyCell`/`CutCell`/`PasteCell` over the C ABI's
+`sc_copy`/`sc_cut`/`sc_paste`): copy the selected cell, then paste it elsewhere
+with its relative references shifted by the destination's offset (absolute `$`
+refs pinned, format carried); a cut clears the source on paste, and `PasteCell`
+returns `false` (a no-op) for an empty clipboard.
 
 `InfiniteSheetModel` (in `Engine.cs`, WinUI-free) seeds far-flung sparse cells
 (`Z1000`, `BA50`, `BB50`) and derives the extent from `UsedRange()` + a margin

--- a/demo/visicalc-xaml/test/Program.cs
+++ b/demo/visicalc-xaml/test/Program.cs
@@ -138,6 +138,20 @@ using (var inf = new InfiniteSheetModel())
     Check("inf fillDown I2", inf.RowCells(2)[8], "30"); // I2 = H2*10
     Check("inf fillDown I3", inf.RowCells(3)[8], "40"); // I3 = H3*10
     Check("inf fillDown I1 source", inf.RowCells(1)[8], "20"); // I1 untouched
+
+    // Clipboard: copy I1 (= H1*10) and paste at I4 — the relative ref shifts by
+    // the destination's offset, so I4 = H4*10. (Seed H4 first.)
+    inf.SelectInf(4, 8); inf.CommitInf("6");        // H4 = 6
+    inf.SelectInf(1, 9); inf.CopyCell();            // copy I1
+    inf.SelectInf(4, 9); Check("inf pasteCell applied", inf.PasteCell().ToString(), "True");
+    Check("inf paste I4 = H4*10", inf.RowCells(4)[8], "60"); // I4 = H4*10 = 60
+    // Cut A1 and move it to C1: source clears, a second paste is a no-op.
+    inf.SelectInf(1, 1); inf.CommitInf("99");       // A1
+    inf.SelectInf(1, 1); inf.CutCell();
+    inf.SelectInf(1, 3); Check("inf cut paste applied", inf.PasteCell().ToString(), "True");
+    Check("inf cut moved C1", inf.RowCells(1)[2], "99"); // C1 (col 3, index 2)
+    Check("inf cut cleared A1", inf.RowCells(1)[0], ""); // A1 cleared
+    inf.SelectInf(1, 5); Check("inf cut buffer consumed", inf.PasteCell().ToString(), "False");
 }
 
 Console.WriteLine(failures == 0 ? "\nALL PASS" : $"\n{failures} FAILURE(S)");


### PR DESCRIPTION
**Demo 5 of 6** in the cut/copy/paste rollout (engine [#6120](https://github.com/adhithyan15/coding-adventures/pull/6120), facades [#6126](https://github.com/adhithyan15/coding-adventures/pull/6126), web [#6130](https://github.com/adhithyan15/coding-adventures/pull/6130), Qt [#6134](https://github.com/adhithyan15/coding-adventures/pull/6134), Flutter [#6137](https://github.com/adhithyan15/coding-adventures/pull/6137), Compose [#6140](https://github.com/adhithyan15/coding-adventures/pull/6140)). Adds Copy / Cut / Paste to the WinUI 3 / XAML demo over the C ABI's `sc_copy`/`sc_cut`/`sc_paste` via P/Invoke.

## Changes
- **`Engine.cs`** — `sc_copy`/`sc_cut` `[DllImport]` (void; two `LPUTF8Str` args) + `sc_paste` (`extern int`); `SpreadsheetSession.Copy/Cut/Paste` — `Paste` reads the int as `!= 0` → `bool`. `InfiniteSheetModel.CopyCell/CutCell/PasteCell` act on the selected cell (`PasteCell` regrows the extent on success). No host-side arithmetic (a single `InfAddress` passes through), so no overflow guard needed here.
- **`InfiniteSheet.xaml`** — Fill + Copy / Cut / Paste buttons grouped in a horizontal `StackPanel`; Click handlers in `InfiniteSheet.xaml.cs` (Paste repaints the realized rows only when it applied).
- **`test/Program.cs`** — clipboard assertions: copy `I1` (`==H1*10`) → paste at `I4` (`I4 = H4*10 = 60`); cut `A1` → move to `C1` (source clears, second paste `False`).

## Verification
Re-vendored `native/libspreadsheet_capi.dylib` from the merged facades (gitignored). `scripts/verify.sh` (.NET P/Invoke console harness) — **ALL PASS** incl. the clipboard checks. The WinUI view is Windows-only, so the headless harness is the canonical proof here. `/security-review` passed in 1 round (P/Invoke marshalling, int return, no injection).

**SwiftUI is the last demo** — after it merges, cut/copy/paste is complete across all 6 backends.

🤖 Generated with [Claude Code](https://claude.com/claude-code)