### PR TITLE
feat(adj73): migrate the shared precedence rulebook to the uniform canon-tagged substrate (PR-B-8)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/context_precedence_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/context_precedence_e2e.rs
@@ -89,12 +89,16 @@ fn the_precedence_edge_is_auditable_with_its_charter() {
     let dir = std::env::temp_dir().join(format!("adjcli_ctxaudit_{}", std::process::id()));
     let _ = std::fs::remove_dir_all(&dir);
     std::fs::create_dir_all(&dir).unwrap();
-    // Copy the committed rulebook beside a tiny query case so the import resolves locally.
-    let rulebook = std::fs::read_to_string(data("context-precedence.adj")).unwrap();
-    std::fs::write(dir.join("context-precedence.adj"), rulebook).unwrap();
+    // Copy the committed rulebook + its shared resolve module beside a tiny query case so the
+    // import chain resolves locally. The grounded charter now rides on the canon-TAGGED edge
+    // fact `outranks_context_by(…, lex_superior)` (the bare `outranks_context/2` is the resolved
+    // order, derived); audit by recalling the tagged edge.
+    for f in ["context-precedence.adj", "context-precedence-resolve.adj"] {
+        std::fs::write(dir.join(f), std::fs::read_to_string(data(f)).unwrap()).unwrap();
+    }
     std::fs::write(
         dir.join("audit.adj"),
-        "import \"context-precedence.adj\"\n? outranks_context(ninth_circuit, $lower)\n",
+        "import \"context-precedence.adj\"\n? outranks_context_by(ninth_circuit, district_court, $canon)\n",
     )
     .unwrap();
 
@@ -105,10 +109,10 @@ fn the_precedence_edge_is_auditable_with_its_charter() {
     let s = String::from_utf8(out.stdout).unwrap();
     assert!(out.status.success(), "cli should succeed: {s}");
 
-    // The edge is recalled, bound to district_court...
+    // The tagged edge is recalled, bound to district_court + the lex_superior canon...
     assert!(
-        s.contains("outranks_context(ninth_circuit, district_court)"),
-        "recalls the grounded precedence edge: {s}"
+        s.contains("outranks_context_by(ninth_circuit, district_court, lex_superior)"),
+        "recalls the grounded canon-tagged precedence edge: {s}"
     );
     // ...and its charter (the verbatim stare-decisis quote) is on the citation.
     assert!(

--- a/code/specs/ADJ73-defeasible-rule-precedence.md
+++ b/code/specs/ADJ73-defeasible-rule-precedence.md
@@ -385,9 +385,18 @@ Each PR: spec-sync note, tests incl. a CONFLICT/abstain case, `/security-review`
     `worked-canon-tiebreaker-example.adj` (lex specialis prevails over lex superior here → the
     specific state reading governs) + `a_grounded_canon_ordering_resolves_the_collision`. The
     canon-ordering is itself a grounded fact, so the recursion stays grounded; remove it and the
-    rulebook falls back to §4.3 abstention. Still to come: migrate the SHARED
-    `context-precedence(-meta).adj` rulebook to the tagged `outranks_context_by/3` form (proven
-    self-contained first), so a jurisdiction's `canon_outranks` applies uniformly.
+    rulebook falls back to §4.3 abstention.
+  - **PR-B-8 shared-rulebook migration ✅ DONE (data only — no engine change).** The proven
+    pattern is now the SUBSTRATE: every grounded source emits a canon-TAGGED edge
+    `outranks_context_by(Higher, Lower, Canon)` — the lex-superior edges in `context-precedence.adj`
+    (canon `lex_superior`) and the three canon meta-rules in `context-precedence-meta.adj`
+    (`appeal_status` / `lex_posterior` / `lex_specialis`). A shared `context-precedence-resolve.adj`
+    module (imported idempotently by both) holds the NAF resolution. So ANY jurisdiction's grounded
+    `canon_outranks` ordering now applies uniformly across all canons; absent one, a collision
+    abstains (§4.3). All worked examples + golden tests pass unchanged (the audit query now recalls
+    the tagged `outranks_context_by` fact, which carries the charter). This completes the ADJ73
+    defeasible-precedence arc: lex superior → posterior → specialis → honest CONFLICT → resolving
+    tiebreaker → uniform grounded substrate.
 - **PR-C — adj-lang surface** (`priority: <tier>`, `functional`/`decision`, the attribute
   annotations) + regen grammar.
 - **PR-D — MYCIN `decide_timing` → `timing.adj`** on the named-enum ladder (was PR-4).

--- a/code/specs/data/context-precedence/README.md
+++ b/code/specs/data/context-precedence/README.md
@@ -33,8 +33,8 @@ The `governing` section resolves the conflict (0 answer-time model calls):
 
 The broad circuit reading wins on **context** (lex superior), not tier — the narrow reading sits
 at the higher `mandatory` tier and is still defeated. The precedence is auditable: a binding
-query `? outranks_context(ninth_circuit, $lower)` recalls the governing edge **with** its
-charter (the verbatim stare-decisis quote).
+query `? outranks_context_by(ninth_circuit, $lower, $canon)` recalls the grounded canon-tagged
+edge **with** its charter (the verbatim stare-decisis quote) and the canon that asserts it.
 
 ## How it fits
 
@@ -57,7 +57,11 @@ This is the data/worked-example layer of the ADJ73 precedence arc:
   RESOLVES a chosen collision into a **cited decision** (`worked-canon-tiebreaker-example.adj`):
   the canon-ordering is itself a grounded fact, so the recursion stays grounded all the way up.
   Remove it → fall back to abstention.
-- **next** — migrate the shared `context-precedence(-meta).adj` rulebook to the canon-tagged
-  `outranks_context_by/3` + resolution form (the tiebreaker pattern is proven self-contained
-  first), so any jurisdiction's `canon_outranks` ordering applies uniformly. See the spec
+- **uniform substrate** (the shared rulebook migrated) — `context-precedence.adj` (lex-superior
+  edges) and `context-precedence-meta.adj` (the three canons) now all emit canon-tagged
+  `outranks_context_by/3`, and the shared `context-precedence-resolve.adj` module (imported by
+  both, idempotently) holds the NAF resolution. So a jurisdiction's grounded `canon_outranks`
+  ordering applies **uniformly** across every canon; absent one, a collision abstains (§4.3). The
+  audit query is now `? outranks_context_by(H, $lower, $canon)` (the tagged fact carries the
+  charter). This completes the precedence arc as a uniform grounded substrate. See the spec
   `code/specs/ADJ73-defeasible-rule-precedence.md` §4.3, §7.

--- a/code/specs/data/context-precedence/context-precedence-meta.adj
+++ b/code/specs/data/context-precedence/context-precedence-meta.adj
@@ -37,7 +37,7 @@
 %    erroneous in law or overtaken by new legislation or developments"
 % ---------------------------------------------------------------------
 rule {
-  head: outranks_context($Higher, $Lower)
+  head: outranks_context_by($Higher, $Lower, appeal_status)
   when: reverses($Higher, $Lower)
   source "Overruling/reversal strips precedential force — Precedent (Wikipedia), on a holding being \"overruled, if the same or higher courts on appeal or determination of subsequent cases found the principles underpinning the previous decision erroneous in law or overtaken by new legislation or developments.\" The reversing court's holding controls; the reversed one is no longer binding."
   locator "Wikipedia, \"Precedent\" — Overruling"
@@ -60,7 +60,7 @@ rule {
 %    inoperable."
 % ---------------------------------------------------------------------
 rule {
-  head: outranks_context($New, $Old)
+  head: outranks_context_by($New, $Old, lex_posterior)
   when: supersedes($New, $Old)
   source "Lex posterior derogat priori (implied repeal) — Implied repeal (Wikipedia): \"The doctrine of implied repeal is a concept in constitutional theory which states that where an act of Parliament or an act of Congress (or of some other legislature) conflicts with an earlier one, the later Act takes precedence and the conflicting parts of the earlier Act become legally inoperable.\" A later edition/enactment outranks the earlier conflicting one."
   locator "Wikipedia, \"Implied repeal\" — leges posteriores priores contrarias abrogant"
@@ -89,9 +89,14 @@ rule {
 % grounded tiebreaker meta-rule is added. That tiebreaker is the next slice.
 % ---------------------------------------------------------------------
 rule {
-  head: outranks_context($Specific, $General)
+  head: outranks_context_by($Specific, $General, lex_specialis)
   when: more_specific($Specific, $General)
   source "Lex specialis derogat legi generali — Lex specialis (Wikipedia): \"The lex specialis doctrine, also referred to as generalia specialibus non derogant (\\\"the general does not [derogate] from the specific\\\"), states that if two laws govern the same factual situation, a law governing a specific subject matter (lex specialis) overrides a law governing only general matters (lex generalis).\""
   locator "Wikipedia, \"Lex specialis\" — generalia specialibus non derogant"
   trust authoritative
 }
+
+% Turn the canon-tagged edges above into the engine's effective `outranks_context/2`
+% order, applying any grounded `canon_outranks` tiebreak (else abstaining on a collision).
+% Imported idempotently — safe to also import context-precedence.adj alongside this file.
+import "context-precedence-resolve.adj"

--- a/code/specs/data/context-precedence/context-precedence-resolve.adj
+++ b/code/specs/data/context-precedence/context-precedence-resolve.adj
@@ -1,0 +1,40 @@
+% =====================================================================
+% context-precedence-resolve.adj — the shared CANON-RESOLUTION layer (ADJ73 §4.3).
+%
+% Every grounded precedence source — the lex-superior edges (context-precedence.adj)
+% and the conflict-resolution canons (context-precedence-meta.adj) — emits a
+% canon-TAGGED edge:
+%
+%     outranks_context_by(Higher, Lower, Canon)
+%
+% This module turns those tagged edges into the engine's effective context order
+% (`outranks_context/2`, which logic-engine ≥ 0.21 reads as the precedence graph),
+% applying the jurisdiction's grounded canon-ordering when two canons collide:
+%
+%   • an edge HOLDS unless its REVERSE comes from a HIGHER-RANKED canon;
+%   • "higher-ranked" is a grounded `canon_outranks(Winner, Loser)` fact (e.g.
+%     `canon_outranks(lex_specialis, lex_superior)` for a jurisdiction that lets
+%     the specific provision beat a higher-authority general one) — itself
+%     byte-provenanced, so the tiebreak is auditable and correctable.
+%
+% When NO canon-ordering covers a collision, BOTH reverse edges survive → the
+% engine's mutual-defeat handling (logic-engine 0.22) abstains as CONFLICT (the
+% honest §4.3 default). So precedence resolution is grounded all the way up:
+% primitive fact → canon-tagged edge → canon-ordering → effective order.
+%
+% Import this module from any rulebook that emits `outranks_context_by/3`
+% (idempotent by path, so importing it transitively from several files is safe).
+% =====================================================================
+
+% An edge holds iff it is NOT canon-defeated (negation-as-failure over the ordering).
+rule {
+  head: outranks_context($Higher, $Lower)
+  when: outranks_context_by($Higher, $Lower, $Canon), not canon_defeated($Higher, $Lower, $Canon)
+}
+
+% An edge `Higher > Lower` (from canon C) is canon-defeated iff the REVERSE edge
+% `Lower > Higher` is asserted by some canon C2 that the jurisdiction ranks above C.
+rule {
+  head: canon_defeated($Higher, $Lower, $Canon)
+  when: outranks_context_by($Lower, $Higher, $Other), canon_outranks($Other, $Canon)
+}

--- a/code/specs/data/context-precedence/context-precedence.adj
+++ b/code/specs/data/context-precedence/context-precedence.adj
@@ -10,18 +10,21 @@
 % a rule grounded in a higher-authority CONTEXT defeats a conflicting rule in
 % a lower context — BEFORE the priority tier is even consulted. This file is
 % the precedence order itself, and the whole point is that each edge is a
-% GROUNDED FACT carrying its charter:
+% GROUNDED FACT carrying its charter, TAGGED with the canon that asserts it
+% (here `lex_superior` — the authority hierarchy):
 %
-%     relate outranks_context(higher, lower)  source "…"  locator "…"  trust …
+%     relate outranks_context_by(higher, lower, lex_superior)  source "…" locator "…" trust …
 %
-% An `outranks_context(a, b)` fact means "context `a` outranks context `b`".
-% The logic-engine (>= 0.20) reads these facts as directed edges in the
-% context order (KnowledgeBase::context_adjacency), so `context_outranks`
-% walks them transitively and `enumerate_governing` applies lex superior.
-% Because the edge is an ordinary byte-provenanced Fact, it is queryable
-% (`? outranks_context(federal, $lower)`), auditable (its source rides on it),
-% and ONE CAS EDIT from correctable — exactly like every clinical/legal fact
-% in this framework. Nothing here is asserted bare in host code.
+% An `outranks_context_by(a, b, canon)` fact means "canon `canon` says context
+% `a` outranks context `b`". The shared resolution layer (context-precedence-resolve.adj,
+% imported below) turns these tagged edges into the engine's effective
+% `outranks_context/2` order — applying a jurisdiction's grounded `canon_outranks`
+% tiebreak when canons collide, else abstaining (ADJ73 §4.3). The logic-engine
+% (>= 0.21) reads the resolved `outranks_context/2` as the precedence graph, so
+% `enumerate_governing` applies lex superior. Because each edge is an ordinary
+% byte-provenanced Fact, it is queryable (`? outranks_context_by(federal, $lower, $canon)`),
+% auditable (its source rides on it), and ONE CAS EDIT from correctable — exactly
+% like every clinical/legal fact in this framework. Nothing is asserted bare in host code.
 %
 % WHY NOT JUST `context_order { federal > state }`?
 % -------------------------------------------------
@@ -56,7 +59,7 @@
 %    judges in every state shall be bound thereby, anything in the Constitution
 %    or laws of any State to the contrary notwithstanding."
 % ---------------------------------------------------------------------
-relate outranks_context(federal, state)
+relate outranks_context_by(federal, state, lex_superior)
   source "U.S. Const. art. VI, cl. 2 (Supremacy Clause): \"This Constitution, and the laws of the United States which shall be made in pursuance thereof; and all treaties made, or which shall be made, under the authority of the United States, shall be the supreme law of the land; and the judges in every state shall be bound thereby, anything in the Constitution or laws of any State to the contrary notwithstanding.\""
   locator "U.S. Const. art. VI, cl. 2"
   trust authoritative
@@ -75,7 +78,12 @@ relate outranks_context(federal, state)
 %   "a federal circuit decision is binding on all federal district courts
 %    within its circuit, but not federal courts in other circuits"
 % ---------------------------------------------------------------------
-relate outranks_context(ninth_circuit, district_court)
+relate outranks_context_by(ninth_circuit, district_court, lex_superior)
   source "Binding v. Persuasive Authority (American University, Washington College of Law, 1L Legal Research Primer): \"a federal circuit decision is binding on all federal district courts within its circuit, but not federal courts in other circuits.\""
   locator "WCL 1L Legal Research Primer — Binding v. Persuasive Authority"
   trust authoritative
+
+% The shared canon-resolution layer turns these tagged edges into the engine's
+% effective `outranks_context/2` order (applying any grounded `canon_outranks`
+% tiebreak, else abstaining on a collision). Imported idempotently.
+import "context-precedence-resolve.adj"

--- a/code/specs/data/context-precedence/worked-legal-example.adj
+++ b/code/specs/data/context-precedence/worked-legal-example.adj
@@ -23,8 +23,8 @@
 %                                    defeated_by means(navigable_waters, broad)
 %
 % 0 answer-time model calls — pure SLD + a precedence post-pass over the
-% grounded graph. The precedence is auditable: `? outranks_context(ninth_circuit,
-% $lower)` recalls the edge WITH its charter (the WCL stare-decisis quote).
+% grounded graph. The precedence is auditable: `? outranks_context_by(ninth_circuit,
+% $lower, $canon)` recalls the tagged edge WITH its charter (the WCL stare-decisis quote).
 % =====================================================================
 
 % The grounded precedence order (federal>state, ninth_circuit>district_court),


### PR DESCRIPTION
## What

Makes the proven canon-resolution pattern ([#6138](https://github.com/adhithyan15/coding-adventures/pull/6138), PR-B-7) the actual **substrate** — not a self-contained demo. Every grounded precedence source now emits a canon-**tagged** edge `outranks_context_by(Higher, Lower, Canon)`:

- `context-precedence.adj` — the two lex-superior edges, canon `lex_superior`;
- `context-precedence-meta.adj` — the three canons, tagged `appeal_status` / `lex_posterior` / `lex_specialis`.

A new shared **`context-precedence-resolve.adj`** module holds the negation-as-failure resolution and is imported (idempotently by path) by both rulebooks:

```
outranks_context(H,L)  :- outranks_context_by(H,L,C), not canon_defeated(H,L,C).
canon_defeated(H,L,C)  :- outranks_context_by(L,H,C2), canon_outranks(C2,C).
```

## Why

Before, the resolving tiebreaker only worked in a self-contained example. Now **any jurisdiction's grounded `canon_outranks` ordering applies uniformly across every canon** (lex superior vs specialis vs posterior vs appeal). Absent a canon-ordering, a collision abstains (§4.3). The precedence order is grounded all the way up: primitive fact → canon-tagged edge → canon-ordering → resolved order — every layer byte-cited and CAS-correctable.

## No engine change

Data only — the logic-engine 0.21 derived-edge machinery + 0.22 mutual-defeat handling already do everything. **No version bump.** The resolution rulebook is stratified NAF (no negative cycle).

## Behavior preserved

All worked examples + golden tests pass unchanged: the lex-superior legal example governs; appeal/supersession/lex-specialis govern; canon-conflict abstains; the tiebreaker resolves. The audit query is updated to `? outranks_context_by(ninth_circuit, district_court, $canon)` — the charter now rides on the tagged edge fact (the bare `outranks_context/2` is the derived order); the e2e test copies the resolve module alongside so the import chain resolves. **7 precedence golden tests green; `/security-review` PASSED** (stratified NAF, safe temp-file handling).

## Scope

Completes the **ADJ73 defeasible-precedence arc** as a uniform grounded substrate: lex superior → posterior → specialis → honest CONFLICT → resolving tiebreaker → uniform substrate. Spec §7 marks PR-B-8 DONE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)