### PR TITLE
Report control script policy diagnostics

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 ### Added
 
+- **Deck control script policy diagnostics** —
+  `analyze_deck_controls()` and `resolve_deck_sources()` now emit explicit
+  policy diagnostics for selected `.control` block `source` and `shell`
+  external script/shell commands instead of generic unsupported-command
+  diagnostics, matching Rust and TypeScript. External script execution and
+  shelling out remain disabled by the deck execution policy.
+
 - **Deck control console marker routing** —
   `analyze_deck_controls()` and `resolve_deck_sources()` now accept selected
   `.control` block read-only `echo`, `rusage`, and `where` console/debug

--- a/code/packages/python/spice-engine/README.md
+++ b/code/packages/python/spice-engine/README.md
@@ -169,9 +169,10 @@ plus target-bearing rawfile-write markers (`write <rawfile> [probes...]`) and
 ASCII data-write markers (`wrdata <file> <probes...>`) are accepted as no-op
 control markers. Read-only control inspection commands (`display`, `listing`,
 `show`, `showmod`, `status`, `version`, `help`, `echo`, `rusage`, and `where`)
-are also accepted as no-op markers. Other
-unrecognized non-comment commands emit diagnostics until a broader executed
-control subset is in scope.
+are also accepted as no-op markers. External script and shell commands
+(`source` and `shell`) emit explicit policy diagnostics and are not executed.
+Other unrecognized non-comment commands emit diagnostics until a broader
+executed control subset is in scope.
 `resolve_deck_sources()` is the first include/library resolution layer: callers
 provide a source-content map, `.include` directives are expanded in place, and
 `.lib path section` selects a named `.lib` / `.endl` section with stable

--- a/code/packages/python/spice-engine/src/spice_engine/compatibility.py
+++ b/code/packages/python/spice-engine/src/spice_engine/compatibility.py
@@ -550,6 +550,7 @@ _NOOP_CONTROL_BLOCK_VECTOR_ARGUMENT_COMMANDS = frozenset({"wrdata", ".wrdata"})
 _NOOP_CONTROL_BLOCK_SET_OPTIONS = frozenset(
     {"noaskquit", "filetype=ascii", "wr_vecnames", "wr_singlescale", "appendwrite"}
 )
+_SCRIPT_CONTROL_BLOCK_COMMANDS = frozenset({"source", ".source", "shell", ".shell"})
 _SPICE_SUFFIX_FACTORS = {
     "t": 1.0e12,
     "g": 1.0e9,
@@ -586,6 +587,17 @@ def analyze_deck_controls(netlist: str) -> DeckControlSummary:
                 active_lines.append(control_line)
                 continue
             if _is_noop_control_block_command(stripped):
+                continue
+            if _is_script_control_block_command(stripped):
+                diagnostics.append(
+                    DeckControlDiagnostic(
+                        code="SPICE_DECK_CONTROL_SCRIPT_COMMAND",
+                        directive=".control",
+                        line_number=line_number,
+                        message=_control_block_script_policy_message(stripped),
+                        severity="error",
+                    )
+                )
                 continue
             diagnostics.append(
                 DeckControlDiagnostic(
@@ -3071,6 +3083,19 @@ def _resolve_deck_lines(
                 continue
             if _is_noop_control_block_command(stripped):
                 continue
+            if _is_script_control_block_command(stripped):
+                state.diagnostics.append(
+                    DeckResolutionDiagnostic(
+                        code="SPICE_DECK_CONTROL_SCRIPT_COMMAND",
+                        directive=".control",
+                        source=source,
+                        line_number=line_number,
+                        message=_control_block_script_policy_message(stripped),
+                        severity="error",
+                        target=None,
+                    )
+                )
+                continue
             state.diagnostics.append(
                 DeckResolutionDiagnostic(
                     code="SPICE_DECK_CONTROL_COMMAND",
@@ -3388,4 +3413,16 @@ def _is_noop_control_block_command(line: str) -> bool:
         command in {"set", ".set"}
         and len(parts) == 2
         and parts[1].lower() in _NOOP_CONTROL_BLOCK_SET_OPTIONS
+    )
+
+
+def _is_script_control_block_command(line: str) -> bool:
+    parts = line.split(maxsplit=1)
+    return bool(parts) and parts[0].lower() in _SCRIPT_CONTROL_BLOCK_COMMANDS
+
+
+def _control_block_script_policy_message(line: str) -> str:
+    return (
+        f"{line!r} inside .control is not executed because external script "
+        "and shell commands are disabled by the deck execution policy"
     )

--- a/code/packages/python/spice-engine/tests/test_compatibility.py
+++ b/code/packages/python/spice-engine/tests/test_compatibility.py
@@ -139,6 +139,10 @@ help tran
 echo running selected deck
 rusage all
 where
+source nested-control.cir
+.source dotted-control.cir
+shell echo nope
+.shell echo dotted
 run
 quit
 .endc
@@ -165,6 +169,10 @@ quit
         (".control", 4, "error"),
         (".control", 19, "error"),
         (".control", 22, "error"),
+        (".control", 33, "error"),
+        (".control", 34, "error"),
+        (".control", 35, "error"),
+        (".control", 36, "error"),
     ]
     assert [diag.code for diag in summary.diagnostics] == [
         "SPICE_DECK_UNSUPPORTED_DIRECTIVE",
@@ -172,6 +180,10 @@ quit
         "SPICE_DECK_UNSUPPORTED_DIRECTIVE",
         "SPICE_DECK_CONTROL_COMMAND",
         "SPICE_DECK_CONTROL_COMMAND",
+        "SPICE_DECK_CONTROL_SCRIPT_COMMAND",
+        "SPICE_DECK_CONTROL_SCRIPT_COMMAND",
+        "SPICE_DECK_CONTROL_SCRIPT_COMMAND",
+        "SPICE_DECK_CONTROL_SCRIPT_COMMAND",
     ]
     measurement_summary = resolve_deck_measurements("\n".join(summary.active_lines) + "\n.end")
     assert [
@@ -267,6 +279,10 @@ four 2k V(b)
 .echo running selected deck
 .rusage all
 .where
+.source nested-control.cir
+source plain-control.cir
+.shell echo nope
+shell echo plain
 run
 .quit
 .endc
@@ -297,9 +313,17 @@ run
         "SPICE_DECK_INCLUDE_CYCLE",
         "SPICE_DECK_LIB_SECTION_NOT_FOUND",
         "SPICE_DECK_UNSUPPORTED_DIRECTIVE",
+        "SPICE_DECK_CONTROL_SCRIPT_COMMAND",
+        "SPICE_DECK_CONTROL_SCRIPT_COMMAND",
+        "SPICE_DECK_CONTROL_SCRIPT_COMMAND",
+        "SPICE_DECK_CONTROL_SCRIPT_COMMAND",
     ]
     assert [(diag.directive, diag.line_number) for diag in summary.diagnostics[3:]] == [
         (".control", 5),
+        (".control", 32),
+        (".control", 33),
+        (".control", 34),
+        (".control", 35),
     ]
     measurement_summary = resolve_deck_measurements("\n".join(summary.active_lines) + "\n.end")
     assert [

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Emit explicit policy diagnostics for selected `.control` block `source` and
+  `shell` external script/shell commands in `analyze_deck_controls` and
+  `resolve_deck_sources`, matching Python and TypeScript. External script
+  execution and shelling out remain disabled by the deck execution policy.
 - Accept selected `.control` block read-only `echo`, `rusage`, and `where`
   console/debug commands as no-op control commands in `analyze_deck_controls`
   and `resolve_deck_sources`, matching Python and TypeScript. Actual

--- a/code/packages/rust/spice-engine/README.md
+++ b/code/packages/rust/spice-engine/README.md
@@ -136,9 +136,10 @@ plus target-bearing rawfile-write markers (`write <rawfile> [probes...]`) and
 ASCII data-write markers (`wrdata <file> <probes...>`) are accepted as no-op
 control markers. Read-only control inspection commands (`display`, `listing`,
 `show`, `showmod`, `status`, `version`, `help`, `echo`, `rusage`, and `where`)
-are also accepted as no-op markers. Other
-unrecognized non-comment commands emit diagnostics until a broader executed
-control subset is in scope.
+are also accepted as no-op markers. External script and shell commands
+(`source` and `shell`) emit explicit policy diagnostics and are not executed.
+Other unrecognized non-comment commands emit diagnostics until a broader
+executed control subset is in scope.
 `resolve_deck_sources` is the first include/library resolution layer: callers
 provide a source-content map, `.include` directives are expanded in place, and
 `.lib path section` selects a named `.lib` / `.endl` section with stable

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -3571,6 +3571,16 @@ pub fn analyze_deck_controls(netlist: &str) -> DeckControlSummary {
             if is_noop_control_block_command(stripped) {
                 continue;
             }
+            if is_script_control_block_command(stripped) {
+                diagnostics.push(DeckControlDiagnostic {
+                    code: "SPICE_DECK_CONTROL_SCRIPT_COMMAND".to_string(),
+                    directive: ".control".to_string(),
+                    line_number,
+                    message: control_block_script_policy_message(stripped),
+                    severity: "error".to_string(),
+                });
+                continue;
+            }
             diagnostics.push(DeckControlDiagnostic {
                 code: "SPICE_DECK_CONTROL_COMMAND".to_string(),
                 directive: ".control".to_string(),
@@ -4370,6 +4380,18 @@ fn resolve_deck_lines(
                 continue;
             }
             if is_noop_control_block_command(stripped) {
+                continue;
+            }
+            if is_script_control_block_command(stripped) {
+                state.diagnostics.push(DeckResolutionDiagnostic {
+                    code: "SPICE_DECK_CONTROL_SCRIPT_COMMAND".to_string(),
+                    directive: ".control".to_string(),
+                    source: source.to_string(),
+                    line_number,
+                    message: control_block_script_policy_message(stripped),
+                    severity: "error".to_string(),
+                    target: None,
+                });
                 continue;
             }
             state.diagnostics.push(DeckResolutionDiagnostic {
@@ -6949,6 +6971,23 @@ fn is_noop_control_block_command(line: &str) -> bool {
     }
     matches!(parts.next().map(|option| option.to_ascii_lowercase()), Some(option) if matches!(option.as_str(), "noaskquit" | "filetype=ascii" | "wr_vecnames" | "wr_singlescale" | "appendwrite"))
         && parts.next().is_none()
+}
+
+fn is_script_control_block_command(line: &str) -> bool {
+    let Some(command) = line
+        .split_whitespace()
+        .next()
+        .map(|command| command.to_ascii_lowercase())
+    else {
+        return false;
+    };
+    matches!(command.as_str(), "source" | ".source" | "shell" | ".shell")
+}
+
+fn control_block_script_policy_message(line: &str) -> String {
+    format!(
+        "{line:?} inside .control is not executed because external script and shell commands are disabled by the deck execution policy"
+    )
 }
 
 fn is_unsupported_deck_control_directive(directive: &str) -> bool {

--- a/code/packages/rust/spice-engine/tests/compatibility_tests.rs
+++ b/code/packages/rust/spice-engine/tests/compatibility_tests.rs
@@ -156,6 +156,10 @@ help tran
 echo running selected deck
 rusage all
 where
+source nested-control.cir
+.source dotted-control.cir
+shell echo nope
+.shell echo dotted
 run
 quit
 .endc
@@ -197,7 +201,11 @@ quit
             (".lib", 3, "error"),
             (".control", 4, "error"),
             (".control", 19, "error"),
-            (".control", 22, "error")
+            (".control", 22, "error"),
+            (".control", 33, "error"),
+            (".control", 34, "error"),
+            (".control", 35, "error"),
+            (".control", 36, "error")
         ]
     );
     assert_eq!(
@@ -211,7 +219,11 @@ quit
             "SPICE_DECK_UNSUPPORTED_DIRECTIVE",
             "SPICE_DECK_UNSUPPORTED_DIRECTIVE",
             "SPICE_DECK_CONTROL_COMMAND",
-            "SPICE_DECK_CONTROL_COMMAND"
+            "SPICE_DECK_CONTROL_COMMAND",
+            "SPICE_DECK_CONTROL_SCRIPT_COMMAND",
+            "SPICE_DECK_CONTROL_SCRIPT_COMMAND",
+            "SPICE_DECK_CONTROL_SCRIPT_COMMAND",
+            "SPICE_DECK_CONTROL_SCRIPT_COMMAND"
         ]
     );
     let measurement_deck = format!("{}\n.end", summary.active_lines.join("\n"));
@@ -359,6 +371,10 @@ four 2k V(b)
 .echo running selected deck
 .rusage all
 .where
+.source nested-control.cir
+source plain-control.cir
+.shell echo nope
+shell echo plain
 run
 .quit
 .endc
@@ -393,7 +409,11 @@ run
             "SPICE_DECK_INCLUDE_NOT_FOUND",
             "SPICE_DECK_INCLUDE_CYCLE",
             "SPICE_DECK_LIB_SECTION_NOT_FOUND",
-            "SPICE_DECK_UNSUPPORTED_DIRECTIVE"
+            "SPICE_DECK_UNSUPPORTED_DIRECTIVE",
+            "SPICE_DECK_CONTROL_SCRIPT_COMMAND",
+            "SPICE_DECK_CONTROL_SCRIPT_COMMAND",
+            "SPICE_DECK_CONTROL_SCRIPT_COMMAND",
+            "SPICE_DECK_CONTROL_SCRIPT_COMMAND"
         ]
     );
     assert_eq!(
@@ -403,7 +423,13 @@ run
             .skip(3)
             .map(|diagnostic| (diagnostic.directive.as_str(), diagnostic.line_number))
             .collect::<Vec<_>>(),
-        vec![(".control", 5)]
+        vec![
+            (".control", 5),
+            (".control", 32),
+            (".control", 33),
+            (".control", 34),
+            (".control", 35)
+        ]
     );
     let measurement_deck = format!("{}\n.end", summary.active_lines.join("\n"));
     let measurement_summary = resolve_deck_measurements(&measurement_deck);

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Emit explicit policy diagnostics for selected `.control` block `source` and
+  `shell` external script/shell commands in `analyzeDeckControls` and
+  `resolveDeckSources`, matching Python and Rust. External script execution
+  and shelling out remain disabled by the deck execution policy.
 - Accept selected `.control` block read-only `echo`, `rusage`, and `where`
   console/debug commands as no-op control commands in `analyzeDeckControls`
   and `resolveDeckSources`, matching Python and Rust. Actual console/debug

--- a/code/packages/typescript/spice-engine/README.md
+++ b/code/packages/typescript/spice-engine/README.md
@@ -143,9 +143,10 @@ plus target-bearing rawfile-write markers (`write <rawfile> [probes...]`) and
 ASCII data-write markers (`wrdata <file> <probes...>`) are accepted as no-op
 control markers. Read-only control inspection commands (`display`, `listing`,
 `show`, `showmod`, `status`, `version`, `help`, `echo`, `rusage`, and `where`)
-are also accepted as no-op markers. Other
-unrecognized non-comment commands emit diagnostics until a broader executed
-control subset is in scope.
+are also accepted as no-op markers. External script and shell commands
+(`source` and `shell`) emit explicit policy diagnostics and are not executed.
+Other unrecognized non-comment commands emit diagnostics until a broader
+executed control subset is in scope.
 `resolveDeckSources` is the first include/library resolution layer: callers
 provide a source-content map, `.include` directives are expanded in place, and
 `.lib path section` selects a named `.lib` / `.endl` section with stable

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -2891,6 +2891,7 @@ const NOOP_CONTROL_BLOCK_SET_OPTIONS = new Set([
   "wr_singlescale",
   "appendwrite",
 ]);
+const SCRIPT_CONTROL_BLOCK_COMMANDS = new Set(["source", ".source", "shell", ".shell"]);
 
 export function compatibilityCorpus(): readonly CompatibilityDeck[] {
   return COMPATIBILITY_CORPUS;
@@ -2921,6 +2922,16 @@ export function analyzeDeckControls(netlist: string): DeckControlSummary {
         continue;
       }
       if (isNoopControlBlockCommand(stripped)) {
+        continue;
+      }
+      if (isScriptControlBlockCommand(stripped)) {
+        diagnostics.push({
+          code: "SPICE_DECK_CONTROL_SCRIPT_COMMAND",
+          directive: ".control",
+          lineNumber,
+          message: controlBlockScriptPolicyMessage(stripped),
+          severity: "error",
+        });
         continue;
       }
       diagnostics.push({
@@ -3484,6 +3495,17 @@ function resolveDeckLines(
         continue;
       }
       if (isNoopControlBlockCommand(stripped)) {
+        continue;
+      }
+      if (isScriptControlBlockCommand(stripped)) {
+        state.diagnostics.push({
+          code: "SPICE_DECK_CONTROL_SCRIPT_COMMAND",
+          directive: ".control",
+          source,
+          lineNumber,
+          message: controlBlockScriptPolicyMessage(stripped),
+          severity: "error",
+        });
         continue;
       }
       state.diagnostics.push({
@@ -5767,6 +5789,15 @@ function isNoopControlBlockCommand(line: string): boolean {
     parts.length === 2 &&
     NOOP_CONTROL_BLOCK_SET_OPTIONS.has(parts[1]?.toLowerCase() ?? "")
   );
+}
+
+function isScriptControlBlockCommand(line: string): boolean {
+  const command = line.split(/\s+/, 1)[0]?.toLowerCase();
+  return command !== undefined && SCRIPT_CONTROL_BLOCK_COMMANDS.has(command);
+}
+
+function controlBlockScriptPolicyMessage(line: string): string {
+  return `${JSON.stringify(line)} inside .control is not executed because external script and shell commands are disabled by the deck execution policy`;
 }
 
 export function subcircuitDefinition(

--- a/code/packages/typescript/spice-engine/tests/compatibility.test.ts
+++ b/code/packages/typescript/spice-engine/tests/compatibility.test.ts
@@ -143,6 +143,10 @@ help tran
 echo running selected deck
 rusage all
 where
+source nested-control.cir
+.source dotted-control.cir
+shell echo nope
+.shell echo dotted
 run
 quit
 .endc
@@ -172,6 +176,10 @@ quit
       [".control", 4, "error"],
       [".control", 19, "error"],
       [".control", 22, "error"],
+      [".control", 33, "error"],
+      [".control", 34, "error"],
+      [".control", 35, "error"],
+      [".control", 36, "error"],
     ]);
     expect(summary.diagnostics.map((diagnostic) => diagnostic.code)).toStrictEqual([
       "SPICE_DECK_UNSUPPORTED_DIRECTIVE",
@@ -179,6 +187,10 @@ quit
       "SPICE_DECK_UNSUPPORTED_DIRECTIVE",
       "SPICE_DECK_CONTROL_COMMAND",
       "SPICE_DECK_CONTROL_COMMAND",
+      "SPICE_DECK_CONTROL_SCRIPT_COMMAND",
+      "SPICE_DECK_CONTROL_SCRIPT_COMMAND",
+      "SPICE_DECK_CONTROL_SCRIPT_COMMAND",
+      "SPICE_DECK_CONTROL_SCRIPT_COMMAND",
     ]);
     const measurementSummary = resolveDeckMeasurements(`${summary.activeLines.join("\n")}\n.end`);
     expect(measurementSummary.measurements.map((card) => [
@@ -274,6 +286,10 @@ four 2k V(b)
 .echo running selected deck
 .rusage all
 .where
+.source nested-control.cir
+source plain-control.cir
+.shell echo nope
+shell echo plain
 run
 .quit
 .endc
@@ -302,12 +318,20 @@ run
       "SPICE_DECK_INCLUDE_CYCLE",
       "SPICE_DECK_LIB_SECTION_NOT_FOUND",
       "SPICE_DECK_UNSUPPORTED_DIRECTIVE",
+      "SPICE_DECK_CONTROL_SCRIPT_COMMAND",
+      "SPICE_DECK_CONTROL_SCRIPT_COMMAND",
+      "SPICE_DECK_CONTROL_SCRIPT_COMMAND",
+      "SPICE_DECK_CONTROL_SCRIPT_COMMAND",
     ]);
     expect(summary.diagnostics.slice(3).map(({ directive, lineNumber }) => [
       directive,
       lineNumber,
     ])).toStrictEqual([
       [".control", 5],
+      [".control", 32],
+      [".control", 33],
+      [".control", 34],
+      [".control", 35],
     ]);
     const measurementSummary = resolveDeckMeasurements(`${summary.activeLines.join("\n")}\n.end`);
     expect(measurementSummary.measurements.map((card) => [

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -45,7 +45,9 @@ downstream tools to compare.
      no-op control markers, and read-only `display` / `listing` / `show` /
      `showmod` / `status` / `version` / `help` / `echo` / `rusage` / `where`
      inspection, introspection, and console/debug commands are accepted as
-     no-op control markers; parsed
+     no-op control markers, while selected `source` and `shell` external
+     script/shell commands now emit explicit policy diagnostics instead of
+     generic unsupported-command diagnostics; parsed
      `.measure dc` / `.meas dc` cards now route DC sweep probe samples into
      the shared scalar measurement table surface;
      parsed `.measure ac` / `.meas ac` cards now route AC probe magnitudes over
@@ -674,6 +676,17 @@ downstream tools to compare.
       script execution, other `set` variables, and unrecognized non-comment
       commands inside `.control` blocks remain diagnostic-only so unsupported
       UI output and script state are explicit.
+
+61. Selected `.control` script execution policy diagnostics.
+    - Status: completed in this selected control script-policy diagnostics
+      slice.
+    - Python, Rust, and TypeScript now emit explicit diagnostics for selected
+      `.control` block `source` and `shell` external script/shell commands
+      instead of generic unsupported-command diagnostics.
+    - External script execution, shelling out, working-directory mutation,
+      control flow, variables, and unrecognized non-comment commands inside
+      `.control` blocks remain diagnostic-only so unsupported script execution
+      policy is explicit.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- Emit explicit .control policy diagnostics for source/shell external execution commands across Python, Rust, and TypeScript.
- Cover plain and dotted source/shell forms in deck-control and source-resolution compatibility tests while preserving existing unsupported diagnostics.
- Update package docs/changelogs and mark SPICE plan slice 61 complete; external script/shell execution remains disabled.

## Verification
- /Users/adhithya/.local/share/mise/installs/python/3.12.13/bin/ruff check code/packages/python/spice-engine
- PYTEST_ADDOPTS=--no-cov PYTHONPATH=code/packages/python/device-physics/src:code/packages/python/mosfet-models/src:code/packages/python/spice-engine/src /Users/adhithya/.local/share/mise/installs/python/3.12.13/bin/python3.12 -m pytest code/packages/python/spice-engine/tests -q
- cargo fmt --manifest-path code/packages/rust/spice-engine/Cargo.toml -- --check
- cargo test --manifest-path code/packages/rust/spice-engine/Cargo.toml
- PATH=/Users/adhithya/.local/share/mise/installs/node/22.22.3/bin:$PATH npm --prefix code/packages/typescript/spice-engine run build
- PATH=/Users/adhithya/.local/share/mise/installs/node/22.22.3/bin:$PATH npm --prefix code/packages/typescript/spice-engine test
- git diff --check