### PR TITLE
feat(visicalc-swiftui): wire clipboard cut/copy/paste into the infinite-sheet demo

### DIFF
--- a/demo/visicalc-swiftui/README.md
+++ b/demo/visicalc-swiftui/README.md
@@ -86,13 +86,21 @@ The **"Fill ↓ 10"** button next to the formula bar calls
 `WindowedSheetModel.fillDown(10)` (over the C ABI's `sc_fill`) to replicate the
 selected cell into the 10 rows below it — the engine shifts each copy's relative
 references (`=A1`→`=A2`, …), pins absolute (`$`) refs, and carries the format.
+The **Copy / Cut / Paste** buttons drive the engine's clipboard
+(`WindowedSheetModel.copyCell`/`cutCell`/`pasteCell` over the C ABI's
+`sc_copy`/`sc_cut`/`sc_paste`): copy the selected cell, then paste it elsewhere
+with its relative references shifted by the destination's offset (absolute `$`
+refs pinned, format carried); a cut clears the source on paste, and `pasteCell`
+returns `false` (a no-op) for an empty clipboard.
 
 Headless proof: `Tests/VisiCalcTests/WindowedModelTests.swift` asserts the
 window is engine-computed and dense, a formula 1000 rows down (`Z1000` = 39) is
 reachable, the gaps are empty (sparse), column letters run AA/BA/BB, editing
-`A1` dirties the far dependent `Z1000` via `changedSince`, and `fillDown`
+`A1` dirties the far dependent `Z1000` via `changedSince`, `fillDown`
 replicates a relative formula down a column (`I1 = =H1*10` filled down ⇒ I2 = 30,
-I3 = 40, source I1 = 20 untouched). Run with `swift test`.
+I3 = 40, source I1 = 20 untouched), and the clipboard (copy `I1 = =H1*2` → paste
+at I2 ⇒ I2 = H2*2 = 14; cut A1 → move to C1, A1 clears, a second paste is a
+no-op). Run with `swift test`.
 
 ## Notes
 

--- a/demo/visicalc-swiftui/Sources/CSpreadsheetEngine/include/spreadsheet.h
+++ b/demo/visicalc-swiftui/Sources/CSpreadsheetEngine/include/spreadsheet.h
@@ -54,6 +54,18 @@ char *sc_get_display(ScSession *s, const char *a1);               /* -> display 
    re-reads via sc_get_window / sc_get_display_window / sc_get_raw afterwards. */
 void  sc_fill(ScSession *s, const char *src, const char *dst_start, const char *dst_end);
 
+/* Clipboard — cut / copy / paste. copy/cut capture the inclusive rectangle
+   `start`..`end` (content + format + the typed source) as a whole-block copy
+   that pastes as a unit. A copy's buffer survives any number of pastes; a cut is
+   a one-shot move whose paste clears the source it didn't overwrite. paste
+   places the block so its top-left lands at `dst_start`, shifting the block's
+   references by the destination's offset; it returns 1 when applied, 0 for a
+   no-op (empty clipboard / malformed address / off-grid). The host re-reads via
+   sc_get_window / sc_get_display_window / sc_get_raw afterwards. */
+void  sc_copy(ScSession *s, const char *start, const char *end);
+void  sc_cut(ScSession *s, const char *start, const char *end);
+int   sc_paste(ScSession *s, const char *dst_start);
+
 /* Structural edits — insert/delete rows & columns. 1-based `at`, `count` lines.
    The engine relocates cells and rewrites formula references (a reference to a
    deleted line becomes #REF!); the formula echo stays in step. No return — the

--- a/demo/visicalc-swiftui/Sources/VisiCalc/Engine.swift
+++ b/demo/visicalc-swiftui/Sources/VisiCalc/Engine.swift
@@ -48,6 +48,27 @@ final class SpreadsheetSession {
         sc_fill(handle, src, dstStart, dstEnd)
     }
 
+    /// Copy the inclusive rectangle `start`..`end` into the clipboard — a
+    /// whole-block copy that pastes as a unit. The source is untouched; the
+    /// buffer survives any number of pastes. Reaches `sc_copy`.
+    func copy(_ start: String, _ end: String) {
+        sc_copy(handle, start, end)
+    }
+
+    /// Cut the inclusive rectangle `start`..`end`. Like `copy` but a one-shot
+    /// move: the `paste` that places it clears the source it didn't overwrite.
+    func cut(_ start: String, _ end: String) {
+        sc_cut(handle, start, end)
+    }
+
+    /// Paste the clipboard so its top-left lands at `dstStart`. Returns `true`
+    /// when applied, `false` (a no-op) for an empty clipboard, malformed address,
+    /// or off-grid destination. The block's references shift by the destination's
+    /// offset; content and format ride along.
+    func paste(_ dstStart: String) -> Bool {
+        sc_paste(handle, dstStart) != 0
+    }
+
     /// The computed value of a cell as the string a spreadsheet should show.
     /// Parses the engine's JSON (`{"kind":...}`) — the same shape the TS and
     /// WASM engines emit.

--- a/demo/visicalc-swiftui/Sources/VisiCalc/InfiniteGrid.swift
+++ b/demo/visicalc-swiftui/Sources/VisiCalc/InfiniteGrid.swift
@@ -141,6 +141,29 @@ final class WindowedSheetModel: ObservableObject {
         revision += 1
     }
 
+    /// Clipboard: copy/cut the selected cell, then paste it at the selection. The
+    /// engine shifts the pasted formula's relative references by the
+    /// destination's offset, pins absolute (`$`) refs, carries the format; a cut
+    /// clears the source on paste. `pasteCell` returns `false` (a no-op) for an
+    /// empty clipboard, and resizes the extent + bumps `revision` on success.
+    func copyCell() {
+        let a = address(selectedRow, selectedCol)
+        session.copy(a, a)
+    }
+    func cutCell() {
+        let a = address(selectedRow, selectedCol)
+        session.cut(a, a)
+    }
+    @discardableResult
+    func pasteCell() -> Bool {
+        let ok = session.paste(address(selectedRow, selectedCol))
+        if ok {
+            resize()
+            revision += 1
+        }
+        return ok
+    }
+
     /// Write `raw` into an explicit A1 cell and return the cells it dirtied.
     /// (Kept for the headless `WindowedModelTests`.)
     @discardableResult
@@ -204,6 +227,17 @@ struct InfiniteGridView: View {
             Button("Fill ↓ 10") { model.fillDown(10) }
                 .font(.system(size: 11, design: .monospaced))
                 .help("Replicate the selected cell into the 10 rows below it")
+            // Clipboard: copy/cut the selected cell, paste at the selection. The
+            // engine shifts the pasted formula's relative refs by the offset.
+            Button("Copy") { model.copyCell() }
+                .font(.system(size: 11, design: .monospaced))
+                .help("Copy the selected cell to the clipboard")
+            Button("Cut") { model.cutCell() }
+                .font(.system(size: 11, design: .monospaced))
+                .help("Cut the selected cell (cleared when you paste)")
+            Button("Paste") { model.pasteCell() }
+                .font(.system(size: 11, design: .monospaced))
+                .help("Paste the clipboard at the selected cell, shifting relative references")
         }
         .padding(.bottom, 8)
     }

--- a/demo/visicalc-swiftui/Tests/VisiCalcTests/WindowedModelTests.swift
+++ b/demo/visicalc-swiftui/Tests/VisiCalcTests/WindowedModelTests.swift
@@ -74,4 +74,27 @@ final class WindowedModelTests: XCTestCase {
         XCTAssertEqual(m.rowCells(3)[8], "40") // I3 = H3*10
         XCTAssertEqual(m.rowCells(1)[8], "20") // I1 source untouched
     }
+
+    /// Clipboard copy/cut/paste shifts a formula and moves a cut.
+    func testClipboardCopyCutPaste() {
+        let m = WindowedSheetModel()
+        // Seed H1=5, H2=7; I1 = H1*2 (col 8 = H, col 9 = I). Copy I1, paste at I2 —
+        // the relative ref shifts by the destination's offset, so I2 = H2*2.
+        m.setCell("H1", "5")
+        m.setCell("H2", "7")
+        m.setCell("I1", "=H1*2") // 10
+        m.select(row: 1, col: 9); m.copyCell() // copy I1
+        m.select(row: 2, col: 9)
+        XCTAssertTrue(m.pasteCell())           // paste at I2
+        XCTAssertEqual(m.rowCells(2)[8], "14") // I2 = H2*2 = 14
+        // Cut A1, move it to C1: source clears, a second paste is a no-op.
+        m.setCell("A1", "99")
+        m.select(row: 1, col: 1); m.cutCell()
+        m.select(row: 1, col: 3)
+        XCTAssertTrue(m.pasteCell())           // paste at C1
+        XCTAssertEqual(m.rowCells(1)[2], "99") // C1 moved
+        XCTAssertEqual(m.rowCells(1)[0], "")   // A1 cleared
+        m.select(row: 1, col: 5)
+        XCTAssertFalse(m.pasteCell())          // buffer consumed
+    }
 }


### PR DESCRIPTION
**The last of the 6 demo PRs** in the cut/copy/paste rollout (engine [#6120](https://github.com/adhithyan15/coding-adventures/pull/6120), facades [#6126](https://github.com/adhithyan15/coding-adventures/pull/6126); demos web [#6130](https://github.com/adhithyan15/coding-adventures/pull/6130), Qt [#6134](https://github.com/adhithyan15/coding-adventures/pull/6134), Flutter [#6137](https://github.com/adhithyan15/coding-adventures/pull/6137), Compose [#6140](https://github.com/adhithyan15/coding-adventures/pull/6140), XAML [#6143](https://github.com/adhithyan15/coding-adventures/pull/6143)). Adds Copy / Cut / Paste to the SwiftUI demo over the C ABI's `sc_copy`/`sc_cut`/`sc_paste` via Swift's C-interop. **With this, every VisiCalc backend drives the clipboard on the one shared Rust engine.**

## Changes
- **`spreadsheet.h`** (vendored C-interop header) — declare `sc_copy`/`sc_cut` (void) + `sc_paste` (int).
- **`Engine.swift`** — `SpreadsheetSession.copy/cut/paste` — `paste` reads the `Int32` return as `!= 0` → `Bool` (Swift bridges `String` → `const char*` for the synchronous call).
- **`InfiniteGrid.swift`** — `WindowedSheetModel.copyCell/cutCell/pasteCell` on the selected cell (`pasteCell` resizes + bumps `revision` only on success) + Copy / Cut / Paste SwiftUI `Button`s next to "Fill ↓ 10".
- **`WindowedModelTests.swift`** — `testClipboardCopyCutPaste`: copy `I1` (`==H1*2`) → paste at `I2` (`= H2*2 = 14`); cut `A1` → move to `C1` (source clears, second paste `false`).

## Verification
Re-vendored `Vendor/macos/libspreadsheet_capi.a` from the merged facades (gitignored). `swift test` — **10/10 pass** (incl. `testClipboardCopyCutPaste`). `/security-review` passed in 1 round (Swift↔C bridging lifetime, Int32 return, no injection/overflow).

After this merges, **cut/copy/paste is complete across all 6 VisiCalc backends** — web (WASM) + Qt + Flutter + Compose + XAML + SwiftUI, all on the one shared Rust engine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)