### PR TITLE
Report control workdir policy diagnostics

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 ### Added
 
+- **Deck control working-directory policy diagnostics** —
+  `analyze_deck_controls()` and `resolve_deck_sources()` now emit explicit
+  policy diagnostics for selected `.control` block `cd` working-directory
+  mutation commands instead of generic unsupported-command diagnostics,
+  matching Rust and TypeScript. Working-directory mutation remains disabled by
+  the deck execution policy.
+
 - **Deck control script policy diagnostics** —
   `analyze_deck_controls()` and `resolve_deck_sources()` now emit explicit
   policy diagnostics for selected `.control` block `source` and `shell`

--- a/code/packages/python/spice-engine/README.md
+++ b/code/packages/python/spice-engine/README.md
@@ -171,8 +171,9 @@ control markers. Read-only control inspection commands (`display`, `listing`,
 `show`, `showmod`, `status`, `version`, `help`, `echo`, `rusage`, and `where`)
 are also accepted as no-op markers. External script and shell commands
 (`source` and `shell`) emit explicit policy diagnostics and are not executed.
-Other unrecognized non-comment commands emit diagnostics until a broader
-executed control subset is in scope.
+Working-directory mutation commands (`cd`) also emit explicit policy
+diagnostics and are not executed. Other unrecognized non-comment commands emit
+diagnostics until a broader executed control subset is in scope.
 `resolve_deck_sources()` is the first include/library resolution layer: callers
 provide a source-content map, `.include` directives are expanded in place, and
 `.lib path section` selects a named `.lib` / `.endl` section with stable

--- a/code/packages/python/spice-engine/src/spice_engine/compatibility.py
+++ b/code/packages/python/spice-engine/src/spice_engine/compatibility.py
@@ -551,6 +551,7 @@ _NOOP_CONTROL_BLOCK_SET_OPTIONS = frozenset(
     {"noaskquit", "filetype=ascii", "wr_vecnames", "wr_singlescale", "appendwrite"}
 )
 _SCRIPT_CONTROL_BLOCK_COMMANDS = frozenset({"source", ".source", "shell", ".shell"})
+_WORKDIR_CONTROL_BLOCK_COMMANDS = frozenset({"cd", ".cd"})
 _SPICE_SUFFIX_FACTORS = {
     "t": 1.0e12,
     "g": 1.0e9,
@@ -595,6 +596,17 @@ def analyze_deck_controls(netlist: str) -> DeckControlSummary:
                         directive=".control",
                         line_number=line_number,
                         message=_control_block_script_policy_message(stripped),
+                        severity="error",
+                    )
+                )
+                continue
+            if _is_workdir_control_block_command(stripped):
+                diagnostics.append(
+                    DeckControlDiagnostic(
+                        code="SPICE_DECK_CONTROL_WORKDIR_COMMAND",
+                        directive=".control",
+                        line_number=line_number,
+                        message=_control_block_workdir_policy_message(stripped),
                         severity="error",
                     )
                 )
@@ -3096,6 +3108,19 @@ def _resolve_deck_lines(
                     )
                 )
                 continue
+            if _is_workdir_control_block_command(stripped):
+                state.diagnostics.append(
+                    DeckResolutionDiagnostic(
+                        code="SPICE_DECK_CONTROL_WORKDIR_COMMAND",
+                        directive=".control",
+                        source=source,
+                        line_number=line_number,
+                        message=_control_block_workdir_policy_message(stripped),
+                        severity="error",
+                        target=None,
+                    )
+                )
+                continue
             state.diagnostics.append(
                 DeckResolutionDiagnostic(
                     code="SPICE_DECK_CONTROL_COMMAND",
@@ -3421,8 +3446,20 @@ def _is_script_control_block_command(line: str) -> bool:
     return bool(parts) and parts[0].lower() in _SCRIPT_CONTROL_BLOCK_COMMANDS
 
 
+def _is_workdir_control_block_command(line: str) -> bool:
+    parts = line.split(maxsplit=1)
+    return bool(parts) and parts[0].lower() in _WORKDIR_CONTROL_BLOCK_COMMANDS
+
+
 def _control_block_script_policy_message(line: str) -> str:
     return (
         f"{line!r} inside .control is not executed because external script "
         "and shell commands are disabled by the deck execution policy"
+    )
+
+
+def _control_block_workdir_policy_message(line: str) -> str:
+    return (
+        f"{line!r} inside .control is not executed because working-directory "
+        "mutation is disabled by the deck execution policy"
     )

--- a/code/packages/python/spice-engine/tests/test_compatibility.py
+++ b/code/packages/python/spice-engine/tests/test_compatibility.py
@@ -143,6 +143,8 @@ source nested-control.cir
 .source dotted-control.cir
 shell echo nope
 .shell echo dotted
+cd models
+.cd /tmp
 run
 quit
 .endc
@@ -173,6 +175,8 @@ quit
         (".control", 34, "error"),
         (".control", 35, "error"),
         (".control", 36, "error"),
+        (".control", 37, "error"),
+        (".control", 38, "error"),
     ]
     assert [diag.code for diag in summary.diagnostics] == [
         "SPICE_DECK_UNSUPPORTED_DIRECTIVE",
@@ -184,6 +188,8 @@ quit
         "SPICE_DECK_CONTROL_SCRIPT_COMMAND",
         "SPICE_DECK_CONTROL_SCRIPT_COMMAND",
         "SPICE_DECK_CONTROL_SCRIPT_COMMAND",
+        "SPICE_DECK_CONTROL_WORKDIR_COMMAND",
+        "SPICE_DECK_CONTROL_WORKDIR_COMMAND",
     ]
     measurement_summary = resolve_deck_measurements("\n".join(summary.active_lines) + "\n.end")
     assert [
@@ -283,6 +289,8 @@ four 2k V(b)
 source plain-control.cir
 .shell echo nope
 shell echo plain
+.cd nested
+cd /tmp
 run
 .quit
 .endc
@@ -317,6 +325,8 @@ run
         "SPICE_DECK_CONTROL_SCRIPT_COMMAND",
         "SPICE_DECK_CONTROL_SCRIPT_COMMAND",
         "SPICE_DECK_CONTROL_SCRIPT_COMMAND",
+        "SPICE_DECK_CONTROL_WORKDIR_COMMAND",
+        "SPICE_DECK_CONTROL_WORKDIR_COMMAND",
     ]
     assert [(diag.directive, diag.line_number) for diag in summary.diagnostics[3:]] == [
         (".control", 5),
@@ -324,6 +334,8 @@ run
         (".control", 33),
         (".control", 34),
         (".control", 35),
+        (".control", 36),
+        (".control", 37),
     ]
     measurement_summary = resolve_deck_measurements("\n".join(summary.active_lines) + "\n.end")
     assert [

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Emit explicit policy diagnostics for selected `.control` block `cd`
+  working-directory mutation commands in `analyze_deck_controls` and
+  `resolve_deck_sources`, matching Python and TypeScript. Working-directory
+  mutation remains disabled by the deck execution policy.
 - Emit explicit policy diagnostics for selected `.control` block `source` and
   `shell` external script/shell commands in `analyze_deck_controls` and
   `resolve_deck_sources`, matching Python and TypeScript. External script

--- a/code/packages/rust/spice-engine/README.md
+++ b/code/packages/rust/spice-engine/README.md
@@ -138,8 +138,9 @@ control markers. Read-only control inspection commands (`display`, `listing`,
 `show`, `showmod`, `status`, `version`, `help`, `echo`, `rusage`, and `where`)
 are also accepted as no-op markers. External script and shell commands
 (`source` and `shell`) emit explicit policy diagnostics and are not executed.
-Other unrecognized non-comment commands emit diagnostics until a broader
-executed control subset is in scope.
+Working-directory mutation commands (`cd`) also emit explicit policy
+diagnostics and are not executed. Other unrecognized non-comment commands emit
+diagnostics until a broader executed control subset is in scope.
 `resolve_deck_sources` is the first include/library resolution layer: callers
 provide a source-content map, `.include` directives are expanded in place, and
 `.lib path section` selects a named `.lib` / `.endl` section with stable

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -3581,6 +3581,16 @@ pub fn analyze_deck_controls(netlist: &str) -> DeckControlSummary {
                 });
                 continue;
             }
+            if is_workdir_control_block_command(stripped) {
+                diagnostics.push(DeckControlDiagnostic {
+                    code: "SPICE_DECK_CONTROL_WORKDIR_COMMAND".to_string(),
+                    directive: ".control".to_string(),
+                    line_number,
+                    message: control_block_workdir_policy_message(stripped),
+                    severity: "error".to_string(),
+                });
+                continue;
+            }
             diagnostics.push(DeckControlDiagnostic {
                 code: "SPICE_DECK_CONTROL_COMMAND".to_string(),
                 directive: ".control".to_string(),
@@ -4389,6 +4399,18 @@ fn resolve_deck_lines(
                     source: source.to_string(),
                     line_number,
                     message: control_block_script_policy_message(stripped),
+                    severity: "error".to_string(),
+                    target: None,
+                });
+                continue;
+            }
+            if is_workdir_control_block_command(stripped) {
+                state.diagnostics.push(DeckResolutionDiagnostic {
+                    code: "SPICE_DECK_CONTROL_WORKDIR_COMMAND".to_string(),
+                    directive: ".control".to_string(),
+                    source: source.to_string(),
+                    line_number,
+                    message: control_block_workdir_policy_message(stripped),
                     severity: "error".to_string(),
                     target: None,
                 });
@@ -6984,9 +7006,26 @@ fn is_script_control_block_command(line: &str) -> bool {
     matches!(command.as_str(), "source" | ".source" | "shell" | ".shell")
 }
 
+fn is_workdir_control_block_command(line: &str) -> bool {
+    let Some(command) = line
+        .split_whitespace()
+        .next()
+        .map(|command| command.to_ascii_lowercase())
+    else {
+        return false;
+    };
+    matches!(command.as_str(), "cd" | ".cd")
+}
+
 fn control_block_script_policy_message(line: &str) -> String {
     format!(
         "{line:?} inside .control is not executed because external script and shell commands are disabled by the deck execution policy"
+    )
+}
+
+fn control_block_workdir_policy_message(line: &str) -> String {
+    format!(
+        "{line:?} inside .control is not executed because working-directory mutation is disabled by the deck execution policy"
     )
 }
 

--- a/code/packages/rust/spice-engine/tests/compatibility_tests.rs
+++ b/code/packages/rust/spice-engine/tests/compatibility_tests.rs
@@ -160,6 +160,8 @@ source nested-control.cir
 .source dotted-control.cir
 shell echo nope
 .shell echo dotted
+cd models
+.cd /tmp
 run
 quit
 .endc
@@ -205,7 +207,9 @@ quit
             (".control", 33, "error"),
             (".control", 34, "error"),
             (".control", 35, "error"),
-            (".control", 36, "error")
+            (".control", 36, "error"),
+            (".control", 37, "error"),
+            (".control", 38, "error")
         ]
     );
     assert_eq!(
@@ -223,7 +227,9 @@ quit
             "SPICE_DECK_CONTROL_SCRIPT_COMMAND",
             "SPICE_DECK_CONTROL_SCRIPT_COMMAND",
             "SPICE_DECK_CONTROL_SCRIPT_COMMAND",
-            "SPICE_DECK_CONTROL_SCRIPT_COMMAND"
+            "SPICE_DECK_CONTROL_SCRIPT_COMMAND",
+            "SPICE_DECK_CONTROL_WORKDIR_COMMAND",
+            "SPICE_DECK_CONTROL_WORKDIR_COMMAND"
         ]
     );
     let measurement_deck = format!("{}\n.end", summary.active_lines.join("\n"));
@@ -375,6 +381,8 @@ four 2k V(b)
 source plain-control.cir
 .shell echo nope
 shell echo plain
+.cd nested
+cd /tmp
 run
 .quit
 .endc
@@ -413,7 +421,9 @@ run
             "SPICE_DECK_CONTROL_SCRIPT_COMMAND",
             "SPICE_DECK_CONTROL_SCRIPT_COMMAND",
             "SPICE_DECK_CONTROL_SCRIPT_COMMAND",
-            "SPICE_DECK_CONTROL_SCRIPT_COMMAND"
+            "SPICE_DECK_CONTROL_SCRIPT_COMMAND",
+            "SPICE_DECK_CONTROL_WORKDIR_COMMAND",
+            "SPICE_DECK_CONTROL_WORKDIR_COMMAND"
         ]
     );
     assert_eq!(
@@ -428,7 +438,9 @@ run
             (".control", 32),
             (".control", 33),
             (".control", 34),
-            (".control", 35)
+            (".control", 35),
+            (".control", 36),
+            (".control", 37)
         ]
     );
     let measurement_deck = format!("{}\n.end", summary.active_lines.join("\n"));

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Emit explicit policy diagnostics for selected `.control` block `cd`
+  working-directory mutation commands in `analyzeDeckControls` and
+  `resolveDeckSources`, matching Python and Rust. Working-directory mutation
+  remains disabled by the deck execution policy.
 - Emit explicit policy diagnostics for selected `.control` block `source` and
   `shell` external script/shell commands in `analyzeDeckControls` and
   `resolveDeckSources`, matching Python and Rust. External script execution

--- a/code/packages/typescript/spice-engine/README.md
+++ b/code/packages/typescript/spice-engine/README.md
@@ -145,8 +145,9 @@ control markers. Read-only control inspection commands (`display`, `listing`,
 `show`, `showmod`, `status`, `version`, `help`, `echo`, `rusage`, and `where`)
 are also accepted as no-op markers. External script and shell commands
 (`source` and `shell`) emit explicit policy diagnostics and are not executed.
-Other unrecognized non-comment commands emit diagnostics until a broader
-executed control subset is in scope.
+Working-directory mutation commands (`cd`) also emit explicit policy
+diagnostics and are not executed. Other unrecognized non-comment commands emit
+diagnostics until a broader executed control subset is in scope.
 `resolveDeckSources` is the first include/library resolution layer: callers
 provide a source-content map, `.include` directives are expanded in place, and
 `.lib path section` selects a named `.lib` / `.endl` section with stable

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -2892,6 +2892,7 @@ const NOOP_CONTROL_BLOCK_SET_OPTIONS = new Set([
   "appendwrite",
 ]);
 const SCRIPT_CONTROL_BLOCK_COMMANDS = new Set(["source", ".source", "shell", ".shell"]);
+const WORKDIR_CONTROL_BLOCK_COMMANDS = new Set(["cd", ".cd"]);
 
 export function compatibilityCorpus(): readonly CompatibilityDeck[] {
   return COMPATIBILITY_CORPUS;
@@ -2930,6 +2931,16 @@ export function analyzeDeckControls(netlist: string): DeckControlSummary {
           directive: ".control",
           lineNumber,
           message: controlBlockScriptPolicyMessage(stripped),
+          severity: "error",
+        });
+        continue;
+      }
+      if (isWorkdirControlBlockCommand(stripped)) {
+        diagnostics.push({
+          code: "SPICE_DECK_CONTROL_WORKDIR_COMMAND",
+          directive: ".control",
+          lineNumber,
+          message: controlBlockWorkdirPolicyMessage(stripped),
           severity: "error",
         });
         continue;
@@ -3504,6 +3515,17 @@ function resolveDeckLines(
           source,
           lineNumber,
           message: controlBlockScriptPolicyMessage(stripped),
+          severity: "error",
+        });
+        continue;
+      }
+      if (isWorkdirControlBlockCommand(stripped)) {
+        state.diagnostics.push({
+          code: "SPICE_DECK_CONTROL_WORKDIR_COMMAND",
+          directive: ".control",
+          source,
+          lineNumber,
+          message: controlBlockWorkdirPolicyMessage(stripped),
           severity: "error",
         });
         continue;
@@ -5796,8 +5818,17 @@ function isScriptControlBlockCommand(line: string): boolean {
   return command !== undefined && SCRIPT_CONTROL_BLOCK_COMMANDS.has(command);
 }
 
+function isWorkdirControlBlockCommand(line: string): boolean {
+  const command = line.split(/\s+/, 1)[0]?.toLowerCase();
+  return command !== undefined && WORKDIR_CONTROL_BLOCK_COMMANDS.has(command);
+}
+
 function controlBlockScriptPolicyMessage(line: string): string {
   return `${JSON.stringify(line)} inside .control is not executed because external script and shell commands are disabled by the deck execution policy`;
+}
+
+function controlBlockWorkdirPolicyMessage(line: string): string {
+  return `${JSON.stringify(line)} inside .control is not executed because working-directory mutation is disabled by the deck execution policy`;
 }
 
 export function subcircuitDefinition(

--- a/code/packages/typescript/spice-engine/tests/compatibility.test.ts
+++ b/code/packages/typescript/spice-engine/tests/compatibility.test.ts
@@ -147,6 +147,8 @@ source nested-control.cir
 .source dotted-control.cir
 shell echo nope
 .shell echo dotted
+cd models
+.cd /tmp
 run
 quit
 .endc
@@ -180,6 +182,8 @@ quit
       [".control", 34, "error"],
       [".control", 35, "error"],
       [".control", 36, "error"],
+      [".control", 37, "error"],
+      [".control", 38, "error"],
     ]);
     expect(summary.diagnostics.map((diagnostic) => diagnostic.code)).toStrictEqual([
       "SPICE_DECK_UNSUPPORTED_DIRECTIVE",
@@ -191,6 +195,8 @@ quit
       "SPICE_DECK_CONTROL_SCRIPT_COMMAND",
       "SPICE_DECK_CONTROL_SCRIPT_COMMAND",
       "SPICE_DECK_CONTROL_SCRIPT_COMMAND",
+      "SPICE_DECK_CONTROL_WORKDIR_COMMAND",
+      "SPICE_DECK_CONTROL_WORKDIR_COMMAND",
     ]);
     const measurementSummary = resolveDeckMeasurements(`${summary.activeLines.join("\n")}\n.end`);
     expect(measurementSummary.measurements.map((card) => [
@@ -290,6 +296,8 @@ four 2k V(b)
 source plain-control.cir
 .shell echo nope
 shell echo plain
+.cd nested
+cd /tmp
 run
 .quit
 .endc
@@ -322,6 +330,8 @@ run
       "SPICE_DECK_CONTROL_SCRIPT_COMMAND",
       "SPICE_DECK_CONTROL_SCRIPT_COMMAND",
       "SPICE_DECK_CONTROL_SCRIPT_COMMAND",
+      "SPICE_DECK_CONTROL_WORKDIR_COMMAND",
+      "SPICE_DECK_CONTROL_WORKDIR_COMMAND",
     ]);
     expect(summary.diagnostics.slice(3).map(({ directive, lineNumber }) => [
       directive,
@@ -332,6 +342,8 @@ run
       [".control", 33],
       [".control", 34],
       [".control", 35],
+      [".control", 36],
+      [".control", 37],
     ]);
     const measurementSummary = resolveDeckMeasurements(`${summary.activeLines.join("\n")}\n.end`);
     expect(measurementSummary.measurements.map((card) => [

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -47,7 +47,9 @@ downstream tools to compare.
      inspection, introspection, and console/debug commands are accepted as
      no-op control markers, while selected `source` and `shell` external
      script/shell commands now emit explicit policy diagnostics instead of
-     generic unsupported-command diagnostics; parsed
+     generic unsupported-command diagnostics, and selected `cd`
+     working-directory mutation commands now emit explicit policy diagnostics
+     instead of generic unsupported-command diagnostics; parsed
      `.measure dc` / `.meas dc` cards now route DC sweep probe samples into
      the shared scalar measurement table surface;
      parsed `.measure ac` / `.meas ac` cards now route AC probe magnitudes over
@@ -687,6 +689,17 @@ downstream tools to compare.
       control flow, variables, and unrecognized non-comment commands inside
       `.control` blocks remain diagnostic-only so unsupported script execution
       policy is explicit.
+
+62. Selected `.control` working-directory policy diagnostics.
+    - Status: completed in this selected control working-directory policy
+      diagnostics slice.
+    - Python, Rust, and TypeScript now emit explicit diagnostics for selected
+      `.control` block `cd` working-directory mutation commands instead of
+      generic unsupported-command diagnostics.
+    - Working-directory mutation, external script execution, shelling out,
+      control flow, variables, and unrecognized non-comment commands inside
+      `.control` blocks remain diagnostic-only so unsupported execution policy
+      is explicit.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- Emit explicit .control policy diagnostics for cd working-directory mutation commands across Python, Rust, and TypeScript.
- Cover plain and dotted cd forms in deck-control and source-resolution compatibility tests while preserving existing script-policy and unsupported-command diagnostics.
- Update package docs/changelogs and mark SPICE plan slice 62 complete; working-directory mutation remains disabled.

## Verification
- /Users/adhithya/.local/share/mise/installs/python/3.12.13/bin/ruff check code/packages/python/spice-engine
- PYTEST_ADDOPTS=--no-cov PYTHONPATH=code/packages/python/device-physics/src:code/packages/python/mosfet-models/src:code/packages/python/spice-engine/src /Users/adhithya/.local/share/mise/installs/python/3.12.13/bin/python3.12 -m pytest code/packages/python/spice-engine/tests -q
- cargo fmt --manifest-path code/packages/rust/spice-engine/Cargo.toml -- --check
- cargo test --manifest-path code/packages/rust/spice-engine/Cargo.toml
- PATH=/Users/adhithya/.local/share/mise/installs/node/22.22.3/bin:$PATH npm --prefix code/packages/typescript/spice-engine run build
- PATH=/Users/adhithya/.local/share/mise/installs/node/22.22.3/bin:$PATH npm --prefix code/packages/typescript/spice-engine test
- git diff --check