### PR TITLE
feat(mycin-train): adversarial near-miss distractors for the chart-fact decomposer (F3 hardening)

### DIFF
--- a/code/specs/data/mycin-2026/train/README.md
+++ b/code/specs/data/mycin-2026/train/README.md
@@ -89,12 +89,23 @@ counterpart** — the messy-input front door to the constraint solver (the CC-7 
 
 Same backward-generation + byte-provenance discipline: sample a chart-fact set from the
 **closed** vocabulary (exactly what `compile_cop` maps), a teacher writes a chart note
-stating them (+ a non-charting distractor), and the gold IR is derived from the note with
-verbatim spans + a justified `discard` list. The headline guarantee
+stating them (+ distractors), and the gold IR is derived from the note with verbatim spans
++ a justified `discard` list. The headline guarantee
 (`test_gen_chart_data.py`) is the **F3→F2 consumability contract**: every `(kind, value)`
 the generator can sample is fed through `compile_cop` and asserted *not discarded* — so the
 decomposer's gold can never contain a chart fact the COP would silently drop (closed-vocab
 adherence proven against the actual downstream consumer, not just a schema).
+
+**Discard hardening — near-miss look-alikes.** Beyond generic non-charting noise, the
+generator injects `NEAR_MISS_DISTRACTORS`: phrases that *superficially resemble* a controlled
+kind but must be rejected — the wrong **subject** ("his father has CKD" ≠ the patient's
+`renal_status`), an **absence** ("no known drug allergies" / a negative β-hCG — never coin a
+fact from a negation), the wrong **relation** ("penicillin cleared her last UTI" is efficacy,
+not an `allergy`), or the wrong **quantity** ("weight loss of 10 kg" ≠ a dosing body weight).
+False-positive extraction on these is the #1 failure mode of a fine-tuned small decomposer, so
+each lands in the gold `discard` with a reason naming the trap. Tests pin that a near-miss is
+discarded, never coined, and that a real fact + its look-alike in one note yields exactly one
+fact (the discrimination boundary, not just "not a chart fact").
 
 ```sh
 python3 gen_chart_data.py --n 200 --teacher llama3.1:8b   # → data/chart_{train,valid}.jsonl

--- a/code/specs/data/mycin-2026/train/gen_chart_data.py
+++ b/code/specs/data/mycin-2026/train/gen_chart_data.py
@@ -14,7 +14,7 @@ teacher's fallible extraction):
 
   1. sample a chart-fact set from the CLOSED chart-fact vocabulary — this IS the gold IR;
   2. a teacher writes a natural chart note stating exactly those facts (+ a non-charting
-     distractor or two);
+     distractor or two, including HARD near-miss look-alikes — see NEAR_MISS_DISTRACTORS);
   3. the gold IR is derived from the note with BYTE PROVENANCE — each fact's supporting
      span located verbatim (reusing gen_data.find_span); a distractor that lands in the
      prose is recorded as a justified `discard`.
@@ -129,6 +129,43 @@ DISTRACTORS = [
     ("prefers to be seen by the morning team", "preference, not a chart fact"),
 ]
 
+# NEAR-MISS distractors — the HARD discards. Each phrase superficially resembles a controlled
+# chart-fact kind but must NOT become one: it is the wrong SUBJECT (a relative, not the patient),
+# the wrong RELATION (efficacy/diagnosis/recommendation, not the constraint), an ABSENCE (a
+# negated fact must never be coined as present), or the wrong QUANTITY (a non-dosing weight).
+# False-positive extraction on these look-alikes is the #1 failure mode of a fine-tuned small
+# decomposer, so the gold IR records each (when it lands in the note) as a justified `discard` —
+# teaching the discrimination boundary, not just "this isn't a chart fact". The `reason` names
+# the trap (and the look-alike kind) so the signal is explicit.
+NEAR_MISS_DISTRACTORS = [
+    # wrong SUBJECT — a family member's condition is not the patient's chart fact.
+    ("his father has chronic kidney disease",
+     "family history (renal), NOT the patient's renal_status — wrong subject"),
+    ("her sister is 12 weeks pregnant",
+     "family member's pregnancy, NOT the patient's pregnancy — wrong subject"),
+    ("a brother with a documented penicillin allergy",
+     "family history of allergy, NOT the patient's allergy — wrong subject"),
+    # ABSENCE — a negated/normal finding must never be coined as a positive fact.
+    ("no known drug allergies (NKDA)",
+     "explicit ABSENCE of an allergy — do not coin an allergy fact from a negative"),
+    ("renal function is normal with a creatinine of 0.9",
+     "NORMAL renal function — neither renal_severe nor renal_moderate; do not coin a renal_status"),
+    ("not currently pregnant per a negative beta-hCG",
+     "explicitly NOT pregnant — do not coin pregnancy=present from a negative"),
+    # wrong RELATION — efficacy / diagnosis / recommendation is not the constraint relation.
+    ("penicillin cleared her last urinary infection",
+     "drug EFFICACY history, NOT an allergy — wrong relation"),
+    ("the pharmacist recommended starting cefepime",
+     "a treatment RECOMMENDATION, not prior_failed/step_therapy — wrong relation"),
+    ("seasonal allergic rhinitis to pollen",
+     "an environmental allergy, NOT a drug allergy the COP excludes on — wrong relation"),
+    # wrong QUANTITY — a weight that is not the patient's current dosing body weight.
+    ("reports an unintentional weight loss of 10 kg",
+     "a weight CHANGE, NOT the current body weight used for mg/kg dosing — wrong quantity"),
+    ("the neonate weighed 3.2 kg at birth",
+     "birth weight of another person, NOT the patient's dosing weight — wrong subject/quantity"),
+]
+
 
 def sample_chart(rng: random.Random) -> list[dict]:
     """Sample a realistic chart-fact set: an age band, plus 1-4 other facts. Returns
@@ -219,7 +256,11 @@ def main() -> int:
     records = []
     for i in range(args.n):
         facts = sample_chart(rng)
-        distractors = rng.sample(DISTRACTORS, rng.choice([0, 0, 1, 1, 2]))
+        # A mix of generic non-charting noise AND the hard near-miss look-alikes, so the model
+        # learns both "this isn't a chart fact" and the sharper discrimination boundary (a
+        # near-miss must be discarded, never coined into the kind it resembles).
+        distractors = (rng.sample(DISTRACTORS, rng.choice([0, 0, 1, 1, 2]))
+                       + rng.sample(NEAR_MISS_DISTRACTORS, rng.choice([0, 1, 1, 2])))
         try:
             note = teacher_chart_note(args.teacher, facts, distractors)
         except Exception as e:  # noqa: BLE001

--- a/code/specs/data/mycin-2026/train/test_gen_chart_data.py
+++ b/code/specs/data/mycin-2026/train/test_gen_chart_data.py
@@ -91,9 +91,42 @@ def test_prompt_lists_the_closed_vocabulary() -> None:
 
 
 def test_distractor_pool_well_formed() -> None:
-    assert gcd.DISTRACTORS
-    for phrase, reason in gcd.DISTRACTORS:
+    assert gcd.DISTRACTORS and gcd.NEAR_MISS_DISTRACTORS
+    for phrase, reason in gcd.DISTRACTORS + gcd.NEAR_MISS_DISTRACTORS:
         assert isinstance(phrase, str) and len(phrase) >= 4 and isinstance(reason, str) and reason
+
+
+def test_near_miss_distractors_are_discarded_never_coined() -> None:
+    # A near-miss look-alike present in a note (with NO matching sampled fact) must be recorded
+    # as a justified discard and must NOT become a chart fact — only sampled facts coin facts, so
+    # the gold is correct by construction; this pins that contract over the whole near-miss pool.
+    for phrase, reason in gcd.NEAR_MISS_DISTRACTORS:
+        note = f"A 50-year-old patient with a headache; {phrase}."
+        facts = [{"kind": "age_band", "value": "adult", "surfaces": ["A 50-year-old"]}]
+        gold = gcd.build_gold_chart_ir(note, facts, [(phrase, reason)])
+        # exactly the one sampled fact (age_band) — the near-miss did NOT coin a look-alike fact.
+        assert [gf["kind"] for gf in gold["chart_facts"]] == ["age_band"], (phrase, gold)
+        # and the near-miss is set aside with its reason, span verbatim in the note.
+        assert len(gold["discard"]) == 1, gold
+        assert gold["discard"][0]["span"].lower() in note.lower()
+        assert gold["discard"][0]["reason"] == reason
+
+
+def test_near_miss_does_not_add_a_second_lookalike_fact() -> None:
+    # Discrimination: the SAME drug name ("penicillin") appears as a real allergy AND as an
+    # efficacy near-miss in one note. The allergy phrasing coins exactly one allergy fact; the
+    # efficacy phrasing is discarded — never a second, spurious allergy.
+    note = ("A 45-year-old man with anaphylaxis to penicillin; note that penicillin cleared "
+            "her last urinary infection.")
+    facts = [{"kind": "age_band", "value": "adult", "surfaces": ["A 45-year-old man"]},
+             {"kind": "allergy", "value": "penicillin", "surfaces": ["anaphylaxis to penicillin"]}]
+    near = ("penicillin cleared her last urinary infection",
+            "drug EFFICACY history, NOT an allergy — wrong relation")
+    gold = gcd.build_gold_chart_ir(note, facts, [near])
+    allergy_facts = [gf for gf in gold["chart_facts"] if gf["kind"] == "allergy"]
+    assert len(allergy_facts) == 1 and allergy_facts[0]["value"] == "penicillin", gold
+    assert allergy_facts[0]["span"] == "anaphylaxis to penicillin", gold
+    assert any("urinary infection" in d["span"] for d in gold["discard"]), gold
 
 
 def main() -> int:


### PR DESCRIPTION
## What

F3's chart-fact training data (L5) taught the decomposer the IR shape + generic discards, but the distractor pool was 5 generic non-charting phrases — so a fine-tuned small model never sees the **hard discrimination cases** and over-extracts on real charts. **False-positive extraction on look-alikes is the #1 failure mode of a small decomposer**; this hardens the discard discipline (directly serving the Gemma fine-tune quality).

## New `NEAR_MISS_DISTRACTORS` pool (`gen_chart_data.py`)

Phrases that *superficially resemble* a controlled chart-fact kind but must be **rejected**, across four trap families:

- **wrong SUBJECT** — *"his father has CKD"* / *"her sister is pregnant"* / a family allergy: a relative's condition is **not** the patient's chart fact.
- **ABSENCE** — *"no known drug allergies (NKDA)"* / *"creatinine 0.9, normal renal function"* / *"not pregnant per a negative beta-hCG"*: never coin a fact from a negation/normal.
- **wrong RELATION** — *"penicillin cleared her last UTI"* (efficacy, not `allergy`) / *"pharmacist recommended cefepime"* (recommendation, not `prior_failed`/`step_therapy`) / *"allergic to pollen"* (environmental, not a drug allergy).
- **wrong QUANTITY** — *"weight loss of 10 kg"* / *"neonate weighed 3.2 kg at birth"*: not the patient's current dosing body weight.

Each lands in the gold `discard` with a **reason naming the trap** (and the look-alike kind), so the signal teaches the *discrimination boundary*, not just "this isn't a chart fact". `main()` now samples a mix of generic + near-miss distractors per note.

## Tests

By construction the gold only coins facts from *sampled* facts, so a near-miss can only ever be a discard — two new tests pin the contract:
1. every near-miss, present in a note, is discarded with its reason and coins **no** look-alike fact;
2. a note with a real penicillin **allergy** *and* the penicillin-**efficacy** near-miss yields **exactly one** allergy fact, the efficacy phrase discarded (the discrimination boundary).

**8/8 `test_gen_chart_data` tests pass** (pure — no teacher/Ollama/MLX); `ruff` clean. README documents the four trap families. `/security-review` PASSED.

## Scope

Pure offline data-gen — **no engine/package change, no version bump**. This is the Gemma-track work: the training data that the typed-IR decomposer fine-tune learns from.

🤖 Generated with [Claude Code](https://claude.com/claude-code)