### PR TITLE
Report control flow policy diagnostics

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 ### Added
 
+- **Deck control-flow policy diagnostics** —
+  `analyze_deck_controls()` and `resolve_deck_sources()` now emit explicit
+  policy diagnostics for selected `.control` block control-flow commands,
+  including `if`, `while`, `foreach`, and `repeat`, instead of generic
+  unsupported-command diagnostics, matching Rust and TypeScript. Control-flow
+  execution remains disabled by the deck execution policy.
+
 - **Deck control working-directory policy diagnostics** —
   `analyze_deck_controls()` and `resolve_deck_sources()` now emit explicit
   policy diagnostics for selected `.control` block `cd` working-directory

--- a/code/packages/python/spice-engine/README.md
+++ b/code/packages/python/spice-engine/README.md
@@ -172,8 +172,10 @@ control markers. Read-only control inspection commands (`display`, `listing`,
 are also accepted as no-op markers. External script and shell commands
 (`source` and `shell`) emit explicit policy diagnostics and are not executed.
 Working-directory mutation commands (`cd`) also emit explicit policy
-diagnostics and are not executed. Other unrecognized non-comment commands emit
-diagnostics until a broader executed control subset is in scope.
+diagnostics and are not executed. Control-flow commands (`if`, `while`,
+`foreach`, and `repeat`) emit explicit policy diagnostics as well. Other
+unrecognized non-comment commands emit diagnostics until a broader executed
+control subset is in scope.
 `resolve_deck_sources()` is the first include/library resolution layer: callers
 provide a source-content map, `.include` directives are expanded in place, and
 `.lib path section` selects a named `.lib` / `.endl` section with stable

--- a/code/packages/python/spice-engine/src/spice_engine/compatibility.py
+++ b/code/packages/python/spice-engine/src/spice_engine/compatibility.py
@@ -552,6 +552,28 @@ _NOOP_CONTROL_BLOCK_SET_OPTIONS = frozenset(
 )
 _SCRIPT_CONTROL_BLOCK_COMMANDS = frozenset({"source", ".source", "shell", ".shell"})
 _WORKDIR_CONTROL_BLOCK_COMMANDS = frozenset({"cd", ".cd"})
+_CONTROL_FLOW_CONTROL_BLOCK_COMMANDS = frozenset(
+    {
+        "if",
+        ".if",
+        "else",
+        ".else",
+        "end",
+        ".end",
+        "while",
+        ".while",
+        "foreach",
+        ".foreach",
+        "repeat",
+        ".repeat",
+        "dowhile",
+        ".dowhile",
+        "break",
+        ".break",
+        "continue",
+        ".continue",
+    }
+)
 _SPICE_SUFFIX_FACTORS = {
     "t": 1.0e12,
     "g": 1.0e9,
@@ -607,6 +629,17 @@ def analyze_deck_controls(netlist: str) -> DeckControlSummary:
                         directive=".control",
                         line_number=line_number,
                         message=_control_block_workdir_policy_message(stripped),
+                        severity="error",
+                    )
+                )
+                continue
+            if _is_control_flow_control_block_command(stripped):
+                diagnostics.append(
+                    DeckControlDiagnostic(
+                        code="SPICE_DECK_CONTROL_FLOW_COMMAND",
+                        directive=".control",
+                        line_number=line_number,
+                        message=_control_block_flow_policy_message(stripped),
                         severity="error",
                     )
                 )
@@ -3121,6 +3154,19 @@ def _resolve_deck_lines(
                     )
                 )
                 continue
+            if _is_control_flow_control_block_command(stripped):
+                state.diagnostics.append(
+                    DeckResolutionDiagnostic(
+                        code="SPICE_DECK_CONTROL_FLOW_COMMAND",
+                        directive=".control",
+                        source=source,
+                        line_number=line_number,
+                        message=_control_block_flow_policy_message(stripped),
+                        severity="error",
+                        target=None,
+                    )
+                )
+                continue
             state.diagnostics.append(
                 DeckResolutionDiagnostic(
                     code="SPICE_DECK_CONTROL_COMMAND",
@@ -3451,6 +3497,11 @@ def _is_workdir_control_block_command(line: str) -> bool:
     return bool(parts) and parts[0].lower() in _WORKDIR_CONTROL_BLOCK_COMMANDS
 
 
+def _is_control_flow_control_block_command(line: str) -> bool:
+    parts = line.split(maxsplit=1)
+    return bool(parts) and parts[0].lower() in _CONTROL_FLOW_CONTROL_BLOCK_COMMANDS
+
+
 def _control_block_script_policy_message(line: str) -> str:
     return (
         f"{line!r} inside .control is not executed because external script "
@@ -3462,4 +3513,11 @@ def _control_block_workdir_policy_message(line: str) -> str:
     return (
         f"{line!r} inside .control is not executed because working-directory "
         "mutation is disabled by the deck execution policy"
+    )
+
+
+def _control_block_flow_policy_message(line: str) -> str:
+    return (
+        f"{line!r} inside .control is not executed because control-flow "
+        "commands are disabled by the deck execution policy"
     )

--- a/code/packages/python/spice-engine/tests/test_compatibility.py
+++ b/code/packages/python/spice-engine/tests/test_compatibility.py
@@ -145,6 +145,10 @@ shell echo nope
 .shell echo dotted
 cd models
 .cd /tmp
+if $&run_monte
+.while $&again
+foreach dev M1 M2
+.repeat 2
 run
 quit
 .endc
@@ -177,6 +181,10 @@ quit
         (".control", 36, "error"),
         (".control", 37, "error"),
         (".control", 38, "error"),
+        (".control", 39, "error"),
+        (".control", 40, "error"),
+        (".control", 41, "error"),
+        (".control", 42, "error"),
     ]
     assert [diag.code for diag in summary.diagnostics] == [
         "SPICE_DECK_UNSUPPORTED_DIRECTIVE",
@@ -190,6 +198,10 @@ quit
         "SPICE_DECK_CONTROL_SCRIPT_COMMAND",
         "SPICE_DECK_CONTROL_WORKDIR_COMMAND",
         "SPICE_DECK_CONTROL_WORKDIR_COMMAND",
+        "SPICE_DECK_CONTROL_FLOW_COMMAND",
+        "SPICE_DECK_CONTROL_FLOW_COMMAND",
+        "SPICE_DECK_CONTROL_FLOW_COMMAND",
+        "SPICE_DECK_CONTROL_FLOW_COMMAND",
     ]
     measurement_summary = resolve_deck_measurements("\n".join(summary.active_lines) + "\n.end")
     assert [
@@ -291,6 +303,10 @@ source plain-control.cir
 shell echo plain
 .cd nested
 cd /tmp
+.if $&run_monte
+while $&again
+.foreach dev M1 M2
+repeat 2
 run
 .quit
 .endc
@@ -327,6 +343,10 @@ run
         "SPICE_DECK_CONTROL_SCRIPT_COMMAND",
         "SPICE_DECK_CONTROL_WORKDIR_COMMAND",
         "SPICE_DECK_CONTROL_WORKDIR_COMMAND",
+        "SPICE_DECK_CONTROL_FLOW_COMMAND",
+        "SPICE_DECK_CONTROL_FLOW_COMMAND",
+        "SPICE_DECK_CONTROL_FLOW_COMMAND",
+        "SPICE_DECK_CONTROL_FLOW_COMMAND",
     ]
     assert [(diag.directive, diag.line_number) for diag in summary.diagnostics[3:]] == [
         (".control", 5),
@@ -336,6 +356,10 @@ run
         (".control", 35),
         (".control", 36),
         (".control", 37),
+        (".control", 38),
+        (".control", 39),
+        (".control", 40),
+        (".control", 41),
     ]
     measurement_summary = resolve_deck_measurements("\n".join(summary.active_lines) + "\n.end")
     assert [

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- Emit explicit policy diagnostics for selected `.control` block control-flow
+  commands, including `if`, `while`, `foreach`, and `repeat`, in
+  `analyze_deck_controls` and `resolve_deck_sources`, matching Python and
+  TypeScript. Control-flow execution remains disabled by the deck execution
+  policy.
 - Emit explicit policy diagnostics for selected `.control` block `cd`
   working-directory mutation commands in `analyze_deck_controls` and
   `resolve_deck_sources`, matching Python and TypeScript. Working-directory

--- a/code/packages/rust/spice-engine/README.md
+++ b/code/packages/rust/spice-engine/README.md
@@ -139,8 +139,10 @@ control markers. Read-only control inspection commands (`display`, `listing`,
 are also accepted as no-op markers. External script and shell commands
 (`source` and `shell`) emit explicit policy diagnostics and are not executed.
 Working-directory mutation commands (`cd`) also emit explicit policy
-diagnostics and are not executed. Other unrecognized non-comment commands emit
-diagnostics until a broader executed control subset is in scope.
+diagnostics and are not executed. Control-flow commands (`if`, `while`,
+`foreach`, and `repeat`) emit explicit policy diagnostics as well. Other
+unrecognized non-comment commands emit diagnostics until a broader executed
+control subset is in scope.
 `resolve_deck_sources` is the first include/library resolution layer: callers
 provide a source-content map, `.include` directives are expanded in place, and
 `.lib path section` selects a named `.lib` / `.endl` section with stable

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -3591,6 +3591,16 @@ pub fn analyze_deck_controls(netlist: &str) -> DeckControlSummary {
                 });
                 continue;
             }
+            if is_control_flow_control_block_command(stripped) {
+                diagnostics.push(DeckControlDiagnostic {
+                    code: "SPICE_DECK_CONTROL_FLOW_COMMAND".to_string(),
+                    directive: ".control".to_string(),
+                    line_number,
+                    message: control_block_flow_policy_message(stripped),
+                    severity: "error".to_string(),
+                });
+                continue;
+            }
             diagnostics.push(DeckControlDiagnostic {
                 code: "SPICE_DECK_CONTROL_COMMAND".to_string(),
                 directive: ".control".to_string(),
@@ -4411,6 +4421,18 @@ fn resolve_deck_lines(
                     source: source.to_string(),
                     line_number,
                     message: control_block_workdir_policy_message(stripped),
+                    severity: "error".to_string(),
+                    target: None,
+                });
+                continue;
+            }
+            if is_control_flow_control_block_command(stripped) {
+                state.diagnostics.push(DeckResolutionDiagnostic {
+                    code: "SPICE_DECK_CONTROL_FLOW_COMMAND".to_string(),
+                    directive: ".control".to_string(),
+                    source: source.to_string(),
+                    line_number,
+                    message: control_block_flow_policy_message(stripped),
                     severity: "error".to_string(),
                     target: None,
                 });
@@ -7017,6 +7039,36 @@ fn is_workdir_control_block_command(line: &str) -> bool {
     matches!(command.as_str(), "cd" | ".cd")
 }
 
+fn is_control_flow_control_block_command(line: &str) -> bool {
+    let Some(command) = line
+        .split_whitespace()
+        .next()
+        .map(|command| command.to_ascii_lowercase())
+    else {
+        return false;
+    };
+    matches!(
+        command.as_str(),
+        "if" | ".if"
+            | "else"
+            | ".else"
+            | "end"
+            | ".end"
+            | "while"
+            | ".while"
+            | "foreach"
+            | ".foreach"
+            | "repeat"
+            | ".repeat"
+            | "dowhile"
+            | ".dowhile"
+            | "break"
+            | ".break"
+            | "continue"
+            | ".continue"
+    )
+}
+
 fn control_block_script_policy_message(line: &str) -> String {
     format!(
         "{line:?} inside .control is not executed because external script and shell commands are disabled by the deck execution policy"
@@ -7026,6 +7078,12 @@ fn control_block_script_policy_message(line: &str) -> String {
 fn control_block_workdir_policy_message(line: &str) -> String {
     format!(
         "{line:?} inside .control is not executed because working-directory mutation is disabled by the deck execution policy"
+    )
+}
+
+fn control_block_flow_policy_message(line: &str) -> String {
+    format!(
+        "{line:?} inside .control is not executed because control-flow commands are disabled by the deck execution policy"
     )
 }
 

--- a/code/packages/rust/spice-engine/tests/compatibility_tests.rs
+++ b/code/packages/rust/spice-engine/tests/compatibility_tests.rs
@@ -162,6 +162,10 @@ shell echo nope
 .shell echo dotted
 cd models
 .cd /tmp
+if $&run_monte
+.while $&again
+foreach dev M1 M2
+.repeat 2
 run
 quit
 .endc
@@ -209,7 +213,11 @@ quit
             (".control", 35, "error"),
             (".control", 36, "error"),
             (".control", 37, "error"),
-            (".control", 38, "error")
+            (".control", 38, "error"),
+            (".control", 39, "error"),
+            (".control", 40, "error"),
+            (".control", 41, "error"),
+            (".control", 42, "error")
         ]
     );
     assert_eq!(
@@ -229,7 +237,11 @@ quit
             "SPICE_DECK_CONTROL_SCRIPT_COMMAND",
             "SPICE_DECK_CONTROL_SCRIPT_COMMAND",
             "SPICE_DECK_CONTROL_WORKDIR_COMMAND",
-            "SPICE_DECK_CONTROL_WORKDIR_COMMAND"
+            "SPICE_DECK_CONTROL_WORKDIR_COMMAND",
+            "SPICE_DECK_CONTROL_FLOW_COMMAND",
+            "SPICE_DECK_CONTROL_FLOW_COMMAND",
+            "SPICE_DECK_CONTROL_FLOW_COMMAND",
+            "SPICE_DECK_CONTROL_FLOW_COMMAND"
         ]
     );
     let measurement_deck = format!("{}\n.end", summary.active_lines.join("\n"));
@@ -383,6 +395,10 @@ source plain-control.cir
 shell echo plain
 .cd nested
 cd /tmp
+.if $&run_monte
+while $&again
+.foreach dev M1 M2
+repeat 2
 run
 .quit
 .endc
@@ -423,7 +439,11 @@ run
             "SPICE_DECK_CONTROL_SCRIPT_COMMAND",
             "SPICE_DECK_CONTROL_SCRIPT_COMMAND",
             "SPICE_DECK_CONTROL_WORKDIR_COMMAND",
-            "SPICE_DECK_CONTROL_WORKDIR_COMMAND"
+            "SPICE_DECK_CONTROL_WORKDIR_COMMAND",
+            "SPICE_DECK_CONTROL_FLOW_COMMAND",
+            "SPICE_DECK_CONTROL_FLOW_COMMAND",
+            "SPICE_DECK_CONTROL_FLOW_COMMAND",
+            "SPICE_DECK_CONTROL_FLOW_COMMAND"
         ]
     );
     assert_eq!(
@@ -440,7 +460,11 @@ run
             (".control", 34),
             (".control", 35),
             (".control", 36),
-            (".control", 37)
+            (".control", 37),
+            (".control", 38),
+            (".control", 39),
+            (".control", 40),
+            (".control", 41)
         ]
     );
     let measurement_deck = format!("{}\n.end", summary.active_lines.join("\n"));

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Emit explicit policy diagnostics for selected `.control` block control-flow
+  commands, including `if`, `while`, `foreach`, and `repeat`, in
+  `analyzeDeckControls` and `resolveDeckSources`, matching Python and Rust.
+  Control-flow execution remains disabled by the deck execution policy.
 - Emit explicit policy diagnostics for selected `.control` block `cd`
   working-directory mutation commands in `analyzeDeckControls` and
   `resolveDeckSources`, matching Python and Rust. Working-directory mutation

--- a/code/packages/typescript/spice-engine/README.md
+++ b/code/packages/typescript/spice-engine/README.md
@@ -146,8 +146,10 @@ control markers. Read-only control inspection commands (`display`, `listing`,
 are also accepted as no-op markers. External script and shell commands
 (`source` and `shell`) emit explicit policy diagnostics and are not executed.
 Working-directory mutation commands (`cd`) also emit explicit policy
-diagnostics and are not executed. Other unrecognized non-comment commands emit
-diagnostics until a broader executed control subset is in scope.
+diagnostics and are not executed. Control-flow commands (`if`, `while`,
+`foreach`, and `repeat`) emit explicit policy diagnostics as well. Other
+unrecognized non-comment commands emit diagnostics until a broader executed
+control subset is in scope.
 `resolveDeckSources` is the first include/library resolution layer: callers
 provide a source-content map, `.include` directives are expanded in place, and
 `.lib path section` selects a named `.lib` / `.endl` section with stable

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -2893,6 +2893,26 @@ const NOOP_CONTROL_BLOCK_SET_OPTIONS = new Set([
 ]);
 const SCRIPT_CONTROL_BLOCK_COMMANDS = new Set(["source", ".source", "shell", ".shell"]);
 const WORKDIR_CONTROL_BLOCK_COMMANDS = new Set(["cd", ".cd"]);
+const CONTROL_FLOW_CONTROL_BLOCK_COMMANDS = new Set([
+  "if",
+  ".if",
+  "else",
+  ".else",
+  "end",
+  ".end",
+  "while",
+  ".while",
+  "foreach",
+  ".foreach",
+  "repeat",
+  ".repeat",
+  "dowhile",
+  ".dowhile",
+  "break",
+  ".break",
+  "continue",
+  ".continue",
+]);
 
 export function compatibilityCorpus(): readonly CompatibilityDeck[] {
   return COMPATIBILITY_CORPUS;
@@ -2941,6 +2961,16 @@ export function analyzeDeckControls(netlist: string): DeckControlSummary {
           directive: ".control",
           lineNumber,
           message: controlBlockWorkdirPolicyMessage(stripped),
+          severity: "error",
+        });
+        continue;
+      }
+      if (isControlFlowControlBlockCommand(stripped)) {
+        diagnostics.push({
+          code: "SPICE_DECK_CONTROL_FLOW_COMMAND",
+          directive: ".control",
+          lineNumber,
+          message: controlBlockFlowPolicyMessage(stripped),
           severity: "error",
         });
         continue;
@@ -3526,6 +3556,17 @@ function resolveDeckLines(
           source,
           lineNumber,
           message: controlBlockWorkdirPolicyMessage(stripped),
+          severity: "error",
+        });
+        continue;
+      }
+      if (isControlFlowControlBlockCommand(stripped)) {
+        state.diagnostics.push({
+          code: "SPICE_DECK_CONTROL_FLOW_COMMAND",
+          directive: ".control",
+          source,
+          lineNumber,
+          message: controlBlockFlowPolicyMessage(stripped),
           severity: "error",
         });
         continue;
@@ -5823,12 +5864,21 @@ function isWorkdirControlBlockCommand(line: string): boolean {
   return command !== undefined && WORKDIR_CONTROL_BLOCK_COMMANDS.has(command);
 }
 
+function isControlFlowControlBlockCommand(line: string): boolean {
+  const command = line.split(/\s+/, 1)[0]?.toLowerCase();
+  return command !== undefined && CONTROL_FLOW_CONTROL_BLOCK_COMMANDS.has(command);
+}
+
 function controlBlockScriptPolicyMessage(line: string): string {
   return `${JSON.stringify(line)} inside .control is not executed because external script and shell commands are disabled by the deck execution policy`;
 }
 
 function controlBlockWorkdirPolicyMessage(line: string): string {
   return `${JSON.stringify(line)} inside .control is not executed because working-directory mutation is disabled by the deck execution policy`;
+}
+
+function controlBlockFlowPolicyMessage(line: string): string {
+  return `${JSON.stringify(line)} inside .control is not executed because control-flow commands are disabled by the deck execution policy`;
 }
 
 export function subcircuitDefinition(

--- a/code/packages/typescript/spice-engine/tests/compatibility.test.ts
+++ b/code/packages/typescript/spice-engine/tests/compatibility.test.ts
@@ -149,6 +149,10 @@ shell echo nope
 .shell echo dotted
 cd models
 .cd /tmp
+if $&run_monte
+.while $&again
+foreach dev M1 M2
+.repeat 2
 run
 quit
 .endc
@@ -184,6 +188,10 @@ quit
       [".control", 36, "error"],
       [".control", 37, "error"],
       [".control", 38, "error"],
+      [".control", 39, "error"],
+      [".control", 40, "error"],
+      [".control", 41, "error"],
+      [".control", 42, "error"],
     ]);
     expect(summary.diagnostics.map((diagnostic) => diagnostic.code)).toStrictEqual([
       "SPICE_DECK_UNSUPPORTED_DIRECTIVE",
@@ -197,6 +205,10 @@ quit
       "SPICE_DECK_CONTROL_SCRIPT_COMMAND",
       "SPICE_DECK_CONTROL_WORKDIR_COMMAND",
       "SPICE_DECK_CONTROL_WORKDIR_COMMAND",
+      "SPICE_DECK_CONTROL_FLOW_COMMAND",
+      "SPICE_DECK_CONTROL_FLOW_COMMAND",
+      "SPICE_DECK_CONTROL_FLOW_COMMAND",
+      "SPICE_DECK_CONTROL_FLOW_COMMAND",
     ]);
     const measurementSummary = resolveDeckMeasurements(`${summary.activeLines.join("\n")}\n.end`);
     expect(measurementSummary.measurements.map((card) => [
@@ -298,6 +310,10 @@ source plain-control.cir
 shell echo plain
 .cd nested
 cd /tmp
+.if $&run_monte
+while $&again
+.foreach dev M1 M2
+repeat 2
 run
 .quit
 .endc
@@ -332,6 +348,10 @@ run
       "SPICE_DECK_CONTROL_SCRIPT_COMMAND",
       "SPICE_DECK_CONTROL_WORKDIR_COMMAND",
       "SPICE_DECK_CONTROL_WORKDIR_COMMAND",
+      "SPICE_DECK_CONTROL_FLOW_COMMAND",
+      "SPICE_DECK_CONTROL_FLOW_COMMAND",
+      "SPICE_DECK_CONTROL_FLOW_COMMAND",
+      "SPICE_DECK_CONTROL_FLOW_COMMAND",
     ]);
     expect(summary.diagnostics.slice(3).map(({ directive, lineNumber }) => [
       directive,
@@ -344,6 +364,10 @@ run
       [".control", 35],
       [".control", 36],
       [".control", 37],
+      [".control", 38],
+      [".control", 39],
+      [".control", 40],
+      [".control", 41],
     ]);
     const measurementSummary = resolveDeckMeasurements(`${summary.activeLines.join("\n")}\n.end`);
     expect(measurementSummary.measurements.map((card) => [

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -49,7 +49,10 @@ downstream tools to compare.
      script/shell commands now emit explicit policy diagnostics instead of
      generic unsupported-command diagnostics, and selected `cd`
      working-directory mutation commands now emit explicit policy diagnostics
-     instead of generic unsupported-command diagnostics; parsed
+     instead of generic unsupported-command diagnostics, and selected
+     control-flow commands (`if`, `while`, `foreach`, and `repeat`) now emit
+     explicit policy diagnostics instead of generic unsupported-command
+     diagnostics; parsed
      `.measure dc` / `.meas dc` cards now route DC sweep probe samples into
      the shared scalar measurement table surface;
      parsed `.measure ac` / `.meas ac` cards now route AC probe magnitudes over
@@ -700,6 +703,18 @@ downstream tools to compare.
       control flow, variables, and unrecognized non-comment commands inside
       `.control` blocks remain diagnostic-only so unsupported execution policy
       is explicit.
+
+63. Selected `.control` control-flow policy diagnostics.
+    - Status: completed in this selected control-flow policy diagnostics
+      slice.
+    - Python, Rust, and TypeScript now emit explicit diagnostics for selected
+      `.control` block control-flow commands, including `if`, `while`,
+      `foreach`, and `repeat`, instead of generic unsupported-command
+      diagnostics.
+    - Control-flow execution, variables, working-directory mutation, external
+      script execution, shelling out, and unrecognized non-comment commands
+      inside `.control` blocks remain diagnostic-only so unsupported execution
+      policy is explicit.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- Emit explicit `.control` policy diagnostics for selected control-flow commands across the Python, Rust, and TypeScript SPICE compatibility APIs.
- Cover plain and dotted flow-control forms in deck-control and source-resolution tests while preserving the script, workdir, and generic unsupported-command diagnostics.
- Update package docs/changelogs and mark SPICE plan slice 63 complete; control-flow execution remains disabled by policy.

## Verification
- `/Users/adhithya/.local/share/mise/installs/python/3.12.13/bin/ruff check code/packages/python/spice-engine`
- `PYTEST_ADDOPTS=--no-cov PYTHONPATH=code/packages/python/device-physics/src:code/packages/python/mosfet-models/src:code/packages/python/spice-engine/src /Users/adhithya/.local/share/mise/installs/python/3.12.13/bin/python3.12 -m pytest code/packages/python/spice-engine/tests -q`
- `cargo fmt --manifest-path code/packages/rust/spice-engine/Cargo.toml -- --check`
- `cargo test --manifest-path code/packages/rust/spice-engine/Cargo.toml`
- `PATH=/Users/adhithya/.local/share/mise/installs/node/22.22.3/bin:$PATH npm --prefix code/packages/typescript/spice-engine run build`
- `PATH=/Users/adhithya/.local/share/mise/installs/node/22.22.3/bin:$PATH npm --prefix code/packages/typescript/spice-engine test`
- `git diff --check`
