### PR TITLE
feat(mycin-train): adversarial near-miss distractors for the FINDINGS decomposer

### DIFF
--- a/code/specs/data/mycin-2026/train/README.md
+++ b/code/specs/data/mycin-2026/train/README.md
@@ -39,10 +39,16 @@ prompt asks for, derived **deterministically from the teacher's prose** by
 - **inference justification** — each finding gets an `ENTAILED` verdict when its
   span was found verbatim, or `LEAP` when it was not (which `ir_to_adj` then drops —
   the safe behavior: the model is taught to mark, not fabricate, unstated findings).
-- **discard** — a third of vignettes carry an injected non-diagnostic **distractor**
-  (a vital sign, social-history detail, symptomatic med). When it lands in the
-  prose, the gold records it as a `discard` `{span, reason}`, teaching the model to
-  set a red herring aside *with a justification* rather than coin a finding from it.
+- **discard** — vignettes carry injected **distractors** the gold must set aside with a
+  reason. Two pools: generic non-diagnostic details (a vital sign, social history, a
+  symptomatic med) AND hard **near-miss look-alikes** (`NEAR_MISS_DISTRACTORS`) that read
+  like a finding but map to none — the wrong **subject** ("his father had meningitis"), a
+  **hedge** ("concern for meningitis", "cannot exclude pleocytosis"), a **process not a
+  result** ("CSF sent for culture", "cultures pending"), or a **reference** ("guidelines note
+  CSF lactate aids diagnosis"). (A *negated* finding — "no fever" — is NOT a discard; it is a
+  real finding with `polarity:denied`.) When a distractor lands in the prose the gold records
+  it as a `discard` `{span, reason}` — teaching the model the discrimination boundary, the #1
+  over-extraction failure mode of a fine-tuned decomposer.
 
 So the model learns the discipline the framework demands of itself: extract only
 what the bytes support, cite the span, and justify both what it keeps and what it

--- a/code/specs/data/mycin-2026/train/gen_data.py
+++ b/code/specs/data/mycin-2026/train/gen_data.py
@@ -157,6 +157,41 @@ DISTRACTORS = [
     ("last ate breakfast around 8 a.m.", "incidental history, not a diagnostic finding"),
 ]
 
+# NEAR-MISS distractors — the HARD discards. Each phrase superficially reads like a controlled
+# FINDING but maps to none: it is the wrong SUBJECT (a relative's illness), a HEDGE (a clinician's
+# suspicion/query, not an affirmed result), a PROCESS not a RESULT (a test ordered/sent/pending,
+# with no value), or a REFERENCE (a teaching statement, not THIS patient's datum). Coining a
+# finding from these is the #1 over-extraction failure of a fine-tuned decomposer, so the gold
+# records each (when it lands in the prose) as a justified `discard`. NOTE: a NEGATED finding
+# ("no fever", "afebrile") is NOT here — that is a real finding with polarity:denied (the sampler
+# handles it), never a discard. These are phrases that map to NO finding in either polarity.
+NEAR_MISS_DISTRACTORS = [
+    # wrong SUBJECT — someone else's finding is not the patient's.
+    ("his father had bacterial meningitis as a child",
+     "family history, NOT the patient's finding — wrong subject"),
+    ("a sibling with a history of recurrent seizures",
+     "family history of seizures, NOT this patient's seizure finding — wrong subject"),
+    # HEDGE / suspicion — a query or concern is not an affirmed result.
+    ("there is clinical concern for possible meningitis",
+     "a clinician's suspicion/hedge, not an affirmed finding — do not coin a result"),
+    ("cannot exclude early CSF pleocytosis on these numbers",
+     "an explicit uncertainty (cannot exclude), not a confirmed pleocytosis finding"),
+    ("query a CNS infection, to be confirmed",
+     "a differential question, not a confirmed finding"),
+    # PROCESS not RESULT — an order/pending test carries no value to extract.
+    ("CSF was sent for Gram stain and culture",
+     "a test ORDERED, not a result — no value to coin a finding from"),
+    ("blood cultures were drawn and are pending",
+     "a pending test, not a resulted finding"),
+    ("a lumbar puncture is planned for this afternoon",
+     "a planned procedure, not a finding"),
+    # REFERENCE / teaching — a general statement is not this patient's datum.
+    ("guidelines note that CSF lactate can aid the diagnosis",
+     "a reference/teaching statement, not a measured value for this patient"),
+    ("textbooks list neck stiffness as a classic meningismus sign",
+     "a general teaching point, not an observation of this patient"),
+]
+
 
 def _norm(s: str) -> str:
     """Lowercase + collapse whitespace — for substring matching prose against a phrase
@@ -243,9 +278,12 @@ def main() -> int:
     records = []
     for i in range(args.n):
         findings = sample_findings(rng)
-        # Inject 0-2 non-diagnostic distractors so a third of vignettes carry a red
-        # herring the gold must DISCARD (with a reason) rather than turn into a finding.
-        distractors = rng.sample(DISTRACTORS, rng.choice([0, 0, 1, 1, 2]))
+        # Inject 0-2 generic distractors AND 0-2 HARD near-miss look-alikes, so a vignette
+        # carries red herrings the gold must DISCARD (with a reason) rather than turn into a
+        # finding — teaching both "not a finding" and the sharper boundary (a suspicion / a
+        # relative's illness / an ordered test / a teaching point is not THIS patient's result).
+        distractors = (rng.sample(DISTRACTORS, rng.choice([0, 0, 1, 1, 2]))
+                       + rng.sample(NEAR_MISS_DISTRACTORS, rng.choice([0, 1, 1, 2])))
         try:
             vignette = teacher_vignette(args.teacher, findings, surfaces, distractors)
         except Exception as e:  # noqa: BLE001

--- a/code/specs/data/mycin-2026/train/test_gen_data.py
+++ b/code/specs/data/mycin-2026/train/test_gen_data.py
@@ -126,10 +126,43 @@ def test_build_gold_ir_records_negation_polarity():
 
 
 def test_distractors_pool_is_well_formed():
-    assert gd.DISTRACTORS, "need a distractor pool to teach justified discard"
-    for phrase, reason in gd.DISTRACTORS:
+    assert gd.DISTRACTORS and gd.NEAR_MISS_DISTRACTORS, "need pools to teach justified discard"
+    for phrase, reason in gd.DISTRACTORS + gd.NEAR_MISS_DISTRACTORS:
         assert isinstance(phrase, str) and len(phrase) >= 4
         assert isinstance(reason, str) and reason
+
+
+def test_near_miss_distractors_are_discarded_never_coined():
+    # A near-miss look-alike in the prose (with NO matching sampled finding) must be recorded
+    # as a justified discard and coin NO finding — only sampled findings become findings, so the
+    # gold is correct by construction; this pins that contract over the whole near-miss pool.
+    surfaces = {"fever": ["fever"]}
+    for phrase, reason in gd.NEAR_MISS_DISTRACTORS:
+        vignette = f"The patient has a fever. {phrase}."
+        findings = [{"functor": "fever", "value": "present", "polarity": "stated"}]
+        gold = gd.build_gold_ir(vignette, findings, [(phrase, reason)], surfaces)
+        # exactly the one sampled finding (fever) — the near-miss coined no spurious finding.
+        assert [f["functor"] for f in gold["findings"]] == ["fever"], (phrase, gold)
+        # and the near-miss is set aside with its reason, span verbatim in the prose.
+        assert len(gold["discard"]) == 1, gold
+        assert gold["discard"][0]["span"].lower() in vignette.lower()
+        assert gold["discard"][0]["reason"] == reason
+
+
+def test_near_miss_does_not_coin_a_family_history_finding():
+    # Discrimination: the SAME concept (seizure / meningitis) appears as a real patient finding
+    # AND as a relative's history in one vignette. Only the patient's finding is coined; the
+    # family-history phrase is discarded — never a second finding from the wrong subject.
+    surfaces = {"seizure": ["had a seizure"]}
+    vignette = ("The patient had a seizure on arrival; a sibling with a history of recurrent "
+                "seizures is noted in the family history.")
+    findings = [{"functor": "seizure", "value": "present", "polarity": "stated"}]
+    near = ("a sibling with a history of recurrent seizures",
+            "family history of seizures, NOT this patient's seizure finding — wrong subject")
+    gold = gd.build_gold_ir(vignette, findings, [near], surfaces)
+    seizure_findings = [f for f in gold["findings"] if f["functor"] == "seizure"]
+    assert len(seizure_findings) == 1 and seizure_findings[0]["span"] == "had a seizure", gold
+    assert any("sibling" in d["span"] for d in gold["discard"]), gold
 
 
 def main() -> int:
@@ -140,8 +173,11 @@ def main() -> int:
     test_build_gold_ir_marks_unstated_findings_inferred_and_leap()
     test_build_gold_ir_records_negation_polarity()
     test_distractors_pool_is_well_formed()
+    test_near_miss_distractors_are_discarded_never_coined()
+    test_near_miss_does_not_coin_a_family_history_finding()
     print("test_gen_data: PASS (closed-vocab adherence; hints don't leak; gold IR carries "
-          "byte-provenance spans, ENTAILED/LEAP inference verdicts, and justified discards)")
+          "byte-provenance spans, ENTAILED/LEAP inference verdicts, justified discards, and "
+          "near-miss discrimination)")
     return 0
 
 


### PR DESCRIPTION
## What

Mirrors the chart-fact decomposer hardening ([#6152](https://github.com/adhithyan15/coding-adventures/pull/6152)) onto the **findings** decomposer (`gen_data.py`) — the symmetric gap. The distractor pool was 6 generic non-diagnostic phrases, so the fine-tuned model never saw the hard look-alikes and **over-extracts findings from non-results** (its #1 failure mode).

## New `NEAR_MISS_DISTRACTORS` pool

Phrases that read like a controlled **finding** but map to none, across four trap families:
- **wrong SUBJECT** — *"his father had bacterial meningitis"* / *"a sibling with recurrent seizures"*: a relative's illness ≠ the patient's finding.
- **HEDGE / suspicion** — *"clinical concern for possible meningitis"* / *"cannot exclude early CSF pleocytosis"* / *"query a CNS infection"*: a suspicion/uncertainty ≠ an affirmed result.
- **PROCESS not RESULT** — *"CSF was sent for Gram stain"* / *"blood cultures pending"* / *"LP planned"*: an ordered/pending test has no value to coin a finding from.
- **REFERENCE / teaching** — *"guidelines note CSF lactate can aid diagnosis"* / *"textbooks list neck stiffness as meningismus"*: a general statement, not this patient's datum.

Each lands in the gold `discard` with a reason naming the trap. **Important:** a *negated* finding (*"no fever"*, *"afebrile"*) is deliberately **not** here — that's a real finding with `polarity:denied` (the sampler handles it), never a discard.

## Tests

By construction the gold only coins findings from *sampled* findings, so a near-miss can only ever be a discard — two new tests pin it: (1) every near-miss, present in a vignette, is discarded with its reason and coins no finding; (2) a vignette with a real patient seizure **and** a sibling's seizure history yields exactly one seizure finding, the family-history phrase discarded.

`test_gen_data` passes (incl. near-miss discrimination); `ruff` clean. `/security-review` PASSED.

## Scope

Pure offline data-gen — **no engine/package change, no version bump**. Companion to #6152; together they harden both decomposer IR shapes (findings + chart-facts) against over-extraction, improving the Gemma fine-tune's faithfulness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)