### PR TITLE
Report control variable policy diagnostics

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 ### Added
 
+- **Deck control variable policy diagnostics** —
+  `analyze_deck_controls()` and `resolve_deck_sources()` now emit explicit
+  policy diagnostics for selected `.control` block variable/state mutation
+  commands, including `let`, `alter`, `alterparam`, `set`, and `unset`,
+  instead of generic unsupported-command diagnostics, matching Rust and
+  TypeScript. Accepted no-op `set` options still route as no-op markers.
+
 - **Deck control-flow policy diagnostics** —
   `analyze_deck_controls()` and `resolve_deck_sources()` now emit explicit
   policy diagnostics for selected `.control` block control-flow commands,

--- a/code/packages/python/spice-engine/README.md
+++ b/code/packages/python/spice-engine/README.md
@@ -173,9 +173,11 @@ are also accepted as no-op markers. External script and shell commands
 (`source` and `shell`) emit explicit policy diagnostics and are not executed.
 Working-directory mutation commands (`cd`) also emit explicit policy
 diagnostics and are not executed. Control-flow commands (`if`, `while`,
-`foreach`, and `repeat`) emit explicit policy diagnostics as well. Other
-unrecognized non-comment commands emit diagnostics until a broader executed
-control subset is in scope.
+`foreach`, and `repeat`) emit explicit policy diagnostics as well.
+Variable/state mutation commands (`let`, `alter`, `alterparam`, `set`, and
+`unset`) emit explicit policy diagnostics unless they are one of the accepted
+no-op `set` options. Other unrecognized non-comment commands emit diagnostics
+until a broader executed control subset is in scope.
 `resolve_deck_sources()` is the first include/library resolution layer: callers
 provide a source-content map, `.include` directives are expanded in place, and
 `.lib path section` selects a named `.lib` / `.endl` section with stable

--- a/code/packages/python/spice-engine/src/spice_engine/compatibility.py
+++ b/code/packages/python/spice-engine/src/spice_engine/compatibility.py
@@ -574,6 +574,20 @@ _CONTROL_FLOW_CONTROL_BLOCK_COMMANDS = frozenset(
         ".continue",
     }
 )
+_VARIABLE_CONTROL_BLOCK_COMMANDS = frozenset(
+    {
+        "let",
+        ".let",
+        "alter",
+        ".alter",
+        "alterparam",
+        ".alterparam",
+        "set",
+        ".set",
+        "unset",
+        ".unset",
+    }
+)
 _SPICE_SUFFIX_FACTORS = {
     "t": 1.0e12,
     "g": 1.0e9,
@@ -640,6 +654,17 @@ def analyze_deck_controls(netlist: str) -> DeckControlSummary:
                         directive=".control",
                         line_number=line_number,
                         message=_control_block_flow_policy_message(stripped),
+                        severity="error",
+                    )
+                )
+                continue
+            if _is_variable_control_block_command(stripped):
+                diagnostics.append(
+                    DeckControlDiagnostic(
+                        code="SPICE_DECK_CONTROL_VARIABLE_COMMAND",
+                        directive=".control",
+                        line_number=line_number,
+                        message=_control_block_variable_policy_message(stripped),
                         severity="error",
                     )
                 )
@@ -3167,6 +3192,19 @@ def _resolve_deck_lines(
                     )
                 )
                 continue
+            if _is_variable_control_block_command(stripped):
+                state.diagnostics.append(
+                    DeckResolutionDiagnostic(
+                        code="SPICE_DECK_CONTROL_VARIABLE_COMMAND",
+                        directive=".control",
+                        source=source,
+                        line_number=line_number,
+                        message=_control_block_variable_policy_message(stripped),
+                        severity="error",
+                        target=None,
+                    )
+                )
+                continue
             state.diagnostics.append(
                 DeckResolutionDiagnostic(
                     code="SPICE_DECK_CONTROL_COMMAND",
@@ -3502,6 +3540,11 @@ def _is_control_flow_control_block_command(line: str) -> bool:
     return bool(parts) and parts[0].lower() in _CONTROL_FLOW_CONTROL_BLOCK_COMMANDS
 
 
+def _is_variable_control_block_command(line: str) -> bool:
+    parts = line.split(maxsplit=1)
+    return bool(parts) and parts[0].lower() in _VARIABLE_CONTROL_BLOCK_COMMANDS
+
+
 def _control_block_script_policy_message(line: str) -> str:
     return (
         f"{line!r} inside .control is not executed because external script "
@@ -3520,4 +3563,11 @@ def _control_block_flow_policy_message(line: str) -> str:
     return (
         f"{line!r} inside .control is not executed because control-flow "
         "commands are disabled by the deck execution policy"
+    )
+
+
+def _control_block_variable_policy_message(line: str) -> str:
+    return (
+        f"{line!r} inside .control is not executed because control variables "
+        "and circuit mutation commands are disabled by the deck execution policy"
     )

--- a/code/packages/python/spice-engine/tests/test_compatibility.py
+++ b/code/packages/python/spice-engine/tests/test_compatibility.py
@@ -149,6 +149,12 @@ if $&run_monte
 .while $&again
 foreach dev M1 M2
 .repeat 2
+let gain = 2
+.let bias = v(out)
+alter R1=2k
+.alterparam gain=3
+set temp=27
+.unset temp
 run
 quit
 .endc
@@ -185,12 +191,18 @@ quit
         (".control", 40, "error"),
         (".control", 41, "error"),
         (".control", 42, "error"),
+        (".control", 43, "error"),
+        (".control", 44, "error"),
+        (".control", 45, "error"),
+        (".control", 46, "error"),
+        (".control", 47, "error"),
+        (".control", 48, "error"),
     ]
     assert [diag.code for diag in summary.diagnostics] == [
         "SPICE_DECK_UNSUPPORTED_DIRECTIVE",
         "SPICE_DECK_UNSUPPORTED_DIRECTIVE",
         "SPICE_DECK_UNSUPPORTED_DIRECTIVE",
-        "SPICE_DECK_CONTROL_COMMAND",
+        "SPICE_DECK_CONTROL_VARIABLE_COMMAND",
         "SPICE_DECK_CONTROL_COMMAND",
         "SPICE_DECK_CONTROL_SCRIPT_COMMAND",
         "SPICE_DECK_CONTROL_SCRIPT_COMMAND",
@@ -202,6 +214,12 @@ quit
         "SPICE_DECK_CONTROL_FLOW_COMMAND",
         "SPICE_DECK_CONTROL_FLOW_COMMAND",
         "SPICE_DECK_CONTROL_FLOW_COMMAND",
+        "SPICE_DECK_CONTROL_VARIABLE_COMMAND",
+        "SPICE_DECK_CONTROL_VARIABLE_COMMAND",
+        "SPICE_DECK_CONTROL_VARIABLE_COMMAND",
+        "SPICE_DECK_CONTROL_VARIABLE_COMMAND",
+        "SPICE_DECK_CONTROL_VARIABLE_COMMAND",
+        "SPICE_DECK_CONTROL_VARIABLE_COMMAND",
     ]
     measurement_summary = resolve_deck_measurements("\n".join(summary.active_lines) + "\n.end")
     assert [
@@ -307,6 +325,11 @@ cd /tmp
 while $&again
 .foreach dev M1 M2
 repeat 2
+.let gain = 2
+alter R1=2k
+.alterparam gain=3
+set temp=27
+.unset temp
 run
 .quit
 .endc
@@ -347,6 +370,11 @@ run
         "SPICE_DECK_CONTROL_FLOW_COMMAND",
         "SPICE_DECK_CONTROL_FLOW_COMMAND",
         "SPICE_DECK_CONTROL_FLOW_COMMAND",
+        "SPICE_DECK_CONTROL_VARIABLE_COMMAND",
+        "SPICE_DECK_CONTROL_VARIABLE_COMMAND",
+        "SPICE_DECK_CONTROL_VARIABLE_COMMAND",
+        "SPICE_DECK_CONTROL_VARIABLE_COMMAND",
+        "SPICE_DECK_CONTROL_VARIABLE_COMMAND",
     ]
     assert [(diag.directive, diag.line_number) for diag in summary.diagnostics[3:]] == [
         (".control", 5),
@@ -360,6 +388,11 @@ run
         (".control", 39),
         (".control", 40),
         (".control", 41),
+        (".control", 42),
+        (".control", 43),
+        (".control", 44),
+        (".control", 45),
+        (".control", 46),
     ]
     measurement_summary = resolve_deck_measurements("\n".join(summary.active_lines) + "\n.end")
     assert [

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- Emit explicit policy diagnostics for selected `.control` block
+  variable/state mutation commands, including `let`, `alter`, `alterparam`,
+  `set`, and `unset`, in `analyze_deck_controls` and `resolve_deck_sources`,
+  matching Python and TypeScript. Accepted no-op `set` options still route as
+  no-op markers.
 - Emit explicit policy diagnostics for selected `.control` block control-flow
   commands, including `if`, `while`, `foreach`, and `repeat`, in
   `analyze_deck_controls` and `resolve_deck_sources`, matching Python and

--- a/code/packages/rust/spice-engine/README.md
+++ b/code/packages/rust/spice-engine/README.md
@@ -140,9 +140,11 @@ are also accepted as no-op markers. External script and shell commands
 (`source` and `shell`) emit explicit policy diagnostics and are not executed.
 Working-directory mutation commands (`cd`) also emit explicit policy
 diagnostics and are not executed. Control-flow commands (`if`, `while`,
-`foreach`, and `repeat`) emit explicit policy diagnostics as well. Other
-unrecognized non-comment commands emit diagnostics until a broader executed
-control subset is in scope.
+`foreach`, and `repeat`) emit explicit policy diagnostics as well.
+Variable/state mutation commands (`let`, `alter`, `alterparam`, `set`, and
+`unset`) emit explicit policy diagnostics unless they are one of the accepted
+no-op `set` options. Other unrecognized non-comment commands emit diagnostics
+until a broader executed control subset is in scope.
 `resolve_deck_sources` is the first include/library resolution layer: callers
 provide a source-content map, `.include` directives are expanded in place, and
 `.lib path section` selects a named `.lib` / `.endl` section with stable

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -3601,6 +3601,16 @@ pub fn analyze_deck_controls(netlist: &str) -> DeckControlSummary {
                 });
                 continue;
             }
+            if is_variable_control_block_command(stripped) {
+                diagnostics.push(DeckControlDiagnostic {
+                    code: "SPICE_DECK_CONTROL_VARIABLE_COMMAND".to_string(),
+                    directive: ".control".to_string(),
+                    line_number,
+                    message: control_block_variable_policy_message(stripped),
+                    severity: "error".to_string(),
+                });
+                continue;
+            }
             diagnostics.push(DeckControlDiagnostic {
                 code: "SPICE_DECK_CONTROL_COMMAND".to_string(),
                 directive: ".control".to_string(),
@@ -4433,6 +4443,18 @@ fn resolve_deck_lines(
                     source: source.to_string(),
                     line_number,
                     message: control_block_flow_policy_message(stripped),
+                    severity: "error".to_string(),
+                    target: None,
+                });
+                continue;
+            }
+            if is_variable_control_block_command(stripped) {
+                state.diagnostics.push(DeckResolutionDiagnostic {
+                    code: "SPICE_DECK_CONTROL_VARIABLE_COMMAND".to_string(),
+                    directive: ".control".to_string(),
+                    source: source.to_string(),
+                    line_number,
+                    message: control_block_variable_policy_message(stripped),
                     severity: "error".to_string(),
                     target: None,
                 });
@@ -7069,6 +7091,29 @@ fn is_control_flow_control_block_command(line: &str) -> bool {
     )
 }
 
+fn is_variable_control_block_command(line: &str) -> bool {
+    let Some(command) = line
+        .split_whitespace()
+        .next()
+        .map(|command| command.to_ascii_lowercase())
+    else {
+        return false;
+    };
+    matches!(
+        command.as_str(),
+        "let"
+            | ".let"
+            | "alter"
+            | ".alter"
+            | "alterparam"
+            | ".alterparam"
+            | "set"
+            | ".set"
+            | "unset"
+            | ".unset"
+    )
+}
+
 fn control_block_script_policy_message(line: &str) -> String {
     format!(
         "{line:?} inside .control is not executed because external script and shell commands are disabled by the deck execution policy"
@@ -7084,6 +7129,12 @@ fn control_block_workdir_policy_message(line: &str) -> String {
 fn control_block_flow_policy_message(line: &str) -> String {
     format!(
         "{line:?} inside .control is not executed because control-flow commands are disabled by the deck execution policy"
+    )
+}
+
+fn control_block_variable_policy_message(line: &str) -> String {
+    format!(
+        "{line:?} inside .control is not executed because control variables and circuit mutation commands are disabled by the deck execution policy"
     )
 }
 

--- a/code/packages/rust/spice-engine/tests/compatibility_tests.rs
+++ b/code/packages/rust/spice-engine/tests/compatibility_tests.rs
@@ -166,6 +166,12 @@ if $&run_monte
 .while $&again
 foreach dev M1 M2
 .repeat 2
+let gain = 2
+.let bias = v(out)
+alter R1=2k
+.alterparam gain=3
+set temp=27
+.unset temp
 run
 quit
 .endc
@@ -217,7 +223,13 @@ quit
             (".control", 39, "error"),
             (".control", 40, "error"),
             (".control", 41, "error"),
-            (".control", 42, "error")
+            (".control", 42, "error"),
+            (".control", 43, "error"),
+            (".control", 44, "error"),
+            (".control", 45, "error"),
+            (".control", 46, "error"),
+            (".control", 47, "error"),
+            (".control", 48, "error")
         ]
     );
     assert_eq!(
@@ -230,7 +242,7 @@ quit
             "SPICE_DECK_UNSUPPORTED_DIRECTIVE",
             "SPICE_DECK_UNSUPPORTED_DIRECTIVE",
             "SPICE_DECK_UNSUPPORTED_DIRECTIVE",
-            "SPICE_DECK_CONTROL_COMMAND",
+            "SPICE_DECK_CONTROL_VARIABLE_COMMAND",
             "SPICE_DECK_CONTROL_COMMAND",
             "SPICE_DECK_CONTROL_SCRIPT_COMMAND",
             "SPICE_DECK_CONTROL_SCRIPT_COMMAND",
@@ -241,7 +253,13 @@ quit
             "SPICE_DECK_CONTROL_FLOW_COMMAND",
             "SPICE_DECK_CONTROL_FLOW_COMMAND",
             "SPICE_DECK_CONTROL_FLOW_COMMAND",
-            "SPICE_DECK_CONTROL_FLOW_COMMAND"
+            "SPICE_DECK_CONTROL_FLOW_COMMAND",
+            "SPICE_DECK_CONTROL_VARIABLE_COMMAND",
+            "SPICE_DECK_CONTROL_VARIABLE_COMMAND",
+            "SPICE_DECK_CONTROL_VARIABLE_COMMAND",
+            "SPICE_DECK_CONTROL_VARIABLE_COMMAND",
+            "SPICE_DECK_CONTROL_VARIABLE_COMMAND",
+            "SPICE_DECK_CONTROL_VARIABLE_COMMAND"
         ]
     );
     let measurement_deck = format!("{}\n.end", summary.active_lines.join("\n"));
@@ -399,6 +417,11 @@ cd /tmp
 while $&again
 .foreach dev M1 M2
 repeat 2
+.let gain = 2
+alter R1=2k
+.alterparam gain=3
+set temp=27
+.unset temp
 run
 .quit
 .endc
@@ -443,7 +466,12 @@ run
             "SPICE_DECK_CONTROL_FLOW_COMMAND",
             "SPICE_DECK_CONTROL_FLOW_COMMAND",
             "SPICE_DECK_CONTROL_FLOW_COMMAND",
-            "SPICE_DECK_CONTROL_FLOW_COMMAND"
+            "SPICE_DECK_CONTROL_FLOW_COMMAND",
+            "SPICE_DECK_CONTROL_VARIABLE_COMMAND",
+            "SPICE_DECK_CONTROL_VARIABLE_COMMAND",
+            "SPICE_DECK_CONTROL_VARIABLE_COMMAND",
+            "SPICE_DECK_CONTROL_VARIABLE_COMMAND",
+            "SPICE_DECK_CONTROL_VARIABLE_COMMAND"
         ]
     );
     assert_eq!(
@@ -464,7 +492,12 @@ run
             (".control", 38),
             (".control", 39),
             (".control", 40),
-            (".control", 41)
+            (".control", 41),
+            (".control", 42),
+            (".control", 43),
+            (".control", 44),
+            (".control", 45),
+            (".control", 46)
         ]
     );
     let measurement_deck = format!("{}\n.end", summary.active_lines.join("\n"));

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- Emit explicit policy diagnostics for selected `.control` block
+  variable/state mutation commands, including `let`, `alter`, `alterparam`,
+  `set`, and `unset`, in `analyzeDeckControls` and `resolveDeckSources`,
+  matching Python and Rust. Accepted no-op `set` options still route as no-op
+  markers.
 - Emit explicit policy diagnostics for selected `.control` block control-flow
   commands, including `if`, `while`, `foreach`, and `repeat`, in
   `analyzeDeckControls` and `resolveDeckSources`, matching Python and Rust.

--- a/code/packages/typescript/spice-engine/README.md
+++ b/code/packages/typescript/spice-engine/README.md
@@ -147,9 +147,11 @@ are also accepted as no-op markers. External script and shell commands
 (`source` and `shell`) emit explicit policy diagnostics and are not executed.
 Working-directory mutation commands (`cd`) also emit explicit policy
 diagnostics and are not executed. Control-flow commands (`if`, `while`,
-`foreach`, and `repeat`) emit explicit policy diagnostics as well. Other
-unrecognized non-comment commands emit diagnostics until a broader executed
-control subset is in scope.
+`foreach`, and `repeat`) emit explicit policy diagnostics as well.
+Variable/state mutation commands (`let`, `alter`, `alterparam`, `set`, and
+`unset`) emit explicit policy diagnostics unless they are one of the accepted
+no-op `set` options. Other unrecognized non-comment commands emit diagnostics
+until a broader executed control subset is in scope.
 `resolveDeckSources` is the first include/library resolution layer: callers
 provide a source-content map, `.include` directives are expanded in place, and
 `.lib path section` selects a named `.lib` / `.endl` section with stable

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -2913,6 +2913,18 @@ const CONTROL_FLOW_CONTROL_BLOCK_COMMANDS = new Set([
   "continue",
   ".continue",
 ]);
+const VARIABLE_CONTROL_BLOCK_COMMANDS = new Set([
+  "let",
+  ".let",
+  "alter",
+  ".alter",
+  "alterparam",
+  ".alterparam",
+  "set",
+  ".set",
+  "unset",
+  ".unset",
+]);
 
 export function compatibilityCorpus(): readonly CompatibilityDeck[] {
   return COMPATIBILITY_CORPUS;
@@ -2971,6 +2983,16 @@ export function analyzeDeckControls(netlist: string): DeckControlSummary {
           directive: ".control",
           lineNumber,
           message: controlBlockFlowPolicyMessage(stripped),
+          severity: "error",
+        });
+        continue;
+      }
+      if (isVariableControlBlockCommand(stripped)) {
+        diagnostics.push({
+          code: "SPICE_DECK_CONTROL_VARIABLE_COMMAND",
+          directive: ".control",
+          lineNumber,
+          message: controlBlockVariablePolicyMessage(stripped),
           severity: "error",
         });
         continue;
@@ -3567,6 +3589,17 @@ function resolveDeckLines(
           source,
           lineNumber,
           message: controlBlockFlowPolicyMessage(stripped),
+          severity: "error",
+        });
+        continue;
+      }
+      if (isVariableControlBlockCommand(stripped)) {
+        state.diagnostics.push({
+          code: "SPICE_DECK_CONTROL_VARIABLE_COMMAND",
+          directive: ".control",
+          source,
+          lineNumber,
+          message: controlBlockVariablePolicyMessage(stripped),
           severity: "error",
         });
         continue;
@@ -5869,6 +5902,11 @@ function isControlFlowControlBlockCommand(line: string): boolean {
   return command !== undefined && CONTROL_FLOW_CONTROL_BLOCK_COMMANDS.has(command);
 }
 
+function isVariableControlBlockCommand(line: string): boolean {
+  const command = line.split(/\s+/, 1)[0]?.toLowerCase();
+  return command !== undefined && VARIABLE_CONTROL_BLOCK_COMMANDS.has(command);
+}
+
 function controlBlockScriptPolicyMessage(line: string): string {
   return `${JSON.stringify(line)} inside .control is not executed because external script and shell commands are disabled by the deck execution policy`;
 }
@@ -5879,6 +5917,10 @@ function controlBlockWorkdirPolicyMessage(line: string): string {
 
 function controlBlockFlowPolicyMessage(line: string): string {
   return `${JSON.stringify(line)} inside .control is not executed because control-flow commands are disabled by the deck execution policy`;
+}
+
+function controlBlockVariablePolicyMessage(line: string): string {
+  return `${JSON.stringify(line)} inside .control is not executed because control variables and circuit mutation commands are disabled by the deck execution policy`;
 }
 
 export function subcircuitDefinition(

--- a/code/packages/typescript/spice-engine/tests/compatibility.test.ts
+++ b/code/packages/typescript/spice-engine/tests/compatibility.test.ts
@@ -153,6 +153,12 @@ if $&run_monte
 .while $&again
 foreach dev M1 M2
 .repeat 2
+let gain = 2
+.let bias = v(out)
+alter R1=2k
+.alterparam gain=3
+set temp=27
+.unset temp
 run
 quit
 .endc
@@ -192,12 +198,18 @@ quit
       [".control", 40, "error"],
       [".control", 41, "error"],
       [".control", 42, "error"],
+      [".control", 43, "error"],
+      [".control", 44, "error"],
+      [".control", 45, "error"],
+      [".control", 46, "error"],
+      [".control", 47, "error"],
+      [".control", 48, "error"],
     ]);
     expect(summary.diagnostics.map((diagnostic) => diagnostic.code)).toStrictEqual([
       "SPICE_DECK_UNSUPPORTED_DIRECTIVE",
       "SPICE_DECK_UNSUPPORTED_DIRECTIVE",
       "SPICE_DECK_UNSUPPORTED_DIRECTIVE",
-      "SPICE_DECK_CONTROL_COMMAND",
+      "SPICE_DECK_CONTROL_VARIABLE_COMMAND",
       "SPICE_DECK_CONTROL_COMMAND",
       "SPICE_DECK_CONTROL_SCRIPT_COMMAND",
       "SPICE_DECK_CONTROL_SCRIPT_COMMAND",
@@ -209,6 +221,12 @@ quit
       "SPICE_DECK_CONTROL_FLOW_COMMAND",
       "SPICE_DECK_CONTROL_FLOW_COMMAND",
       "SPICE_DECK_CONTROL_FLOW_COMMAND",
+      "SPICE_DECK_CONTROL_VARIABLE_COMMAND",
+      "SPICE_DECK_CONTROL_VARIABLE_COMMAND",
+      "SPICE_DECK_CONTROL_VARIABLE_COMMAND",
+      "SPICE_DECK_CONTROL_VARIABLE_COMMAND",
+      "SPICE_DECK_CONTROL_VARIABLE_COMMAND",
+      "SPICE_DECK_CONTROL_VARIABLE_COMMAND",
     ]);
     const measurementSummary = resolveDeckMeasurements(`${summary.activeLines.join("\n")}\n.end`);
     expect(measurementSummary.measurements.map((card) => [
@@ -314,6 +332,11 @@ cd /tmp
 while $&again
 .foreach dev M1 M2
 repeat 2
+.let gain = 2
+alter R1=2k
+.alterparam gain=3
+set temp=27
+.unset temp
 run
 .quit
 .endc
@@ -352,6 +375,11 @@ run
       "SPICE_DECK_CONTROL_FLOW_COMMAND",
       "SPICE_DECK_CONTROL_FLOW_COMMAND",
       "SPICE_DECK_CONTROL_FLOW_COMMAND",
+      "SPICE_DECK_CONTROL_VARIABLE_COMMAND",
+      "SPICE_DECK_CONTROL_VARIABLE_COMMAND",
+      "SPICE_DECK_CONTROL_VARIABLE_COMMAND",
+      "SPICE_DECK_CONTROL_VARIABLE_COMMAND",
+      "SPICE_DECK_CONTROL_VARIABLE_COMMAND",
     ]);
     expect(summary.diagnostics.slice(3).map(({ directive, lineNumber }) => [
       directive,
@@ -368,6 +396,11 @@ run
       [".control", 39],
       [".control", 40],
       [".control", 41],
+      [".control", 42],
+      [".control", 43],
+      [".control", 44],
+      [".control", 45],
+      [".control", 46],
     ]);
     const measurementSummary = resolveDeckMeasurements(`${summary.activeLines.join("\n")}\n.end`);
     expect(measurementSummary.measurements.map((card) => [

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -52,7 +52,10 @@ downstream tools to compare.
      instead of generic unsupported-command diagnostics, and selected
      control-flow commands (`if`, `while`, `foreach`, and `repeat`) now emit
      explicit policy diagnostics instead of generic unsupported-command
-     diagnostics; parsed
+     diagnostics, and selected variable/state mutation commands (`let`,
+     `alter`, `alterparam`, `set`, and `unset`) now emit explicit policy
+     diagnostics instead of generic unsupported-command diagnostics while
+     accepted no-op `set` options continue to route as no-op markers; parsed
      `.measure dc` / `.meas dc` cards now route DC sweep probe samples into
      the shared scalar measurement table surface;
      parsed `.measure ac` / `.meas ac` cards now route AC probe magnitudes over
@@ -715,6 +718,18 @@ downstream tools to compare.
       script execution, shelling out, and unrecognized non-comment commands
       inside `.control` blocks remain diagnostic-only so unsupported execution
       policy is explicit.
+
+64. Selected `.control` variable policy diagnostics.
+    - Status: completed in this selected variable policy diagnostics slice.
+    - Python, Rust, and TypeScript now emit explicit diagnostics for selected
+      `.control` block variable/state mutation commands, including `let`,
+      `alter`, `alterparam`, `set`, and `unset`, instead of generic
+      unsupported-command diagnostics.
+    - Accepted no-op `set` options still route as no-op markers; variable
+      mutation, circuit mutation, control-flow execution, working-directory
+      mutation, external script execution, shelling out, and unrecognized
+      non-comment commands inside `.control` blocks remain diagnostic-only so
+      unsupported execution policy is explicit.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- Emit explicit `.control` policy diagnostics for selected variable/state mutation commands across the Python, Rust, and TypeScript SPICE compatibility APIs.
- Cover plain and dotted `let`, `alter`, `alterparam`, `set`, and `unset` forms in deck-control and source-resolution tests while preserving accepted no-op `set` option routing.
- Update package docs/changelogs and mark SPICE plan slice 64 complete; variable and circuit mutation remain disabled by deck execution policy.

## Verification
- `/Users/adhithya/.local/share/mise/installs/python/3.12.13/bin/ruff check code/packages/python/spice-engine`
- `PYTEST_ADDOPTS=--no-cov PYTHONPATH=code/packages/python/device-physics/src:code/packages/python/mosfet-models/src:code/packages/python/spice-engine/src /Users/adhithya/.local/share/mise/installs/python/3.12.13/bin/python3.12 -m pytest code/packages/python/spice-engine/tests -q`
- `cargo fmt --manifest-path code/packages/rust/spice-engine/Cargo.toml -- --check`
- `cargo test --manifest-path code/packages/rust/spice-engine/Cargo.toml`
- `PATH=/Users/adhithya/.local/share/mise/installs/node/22.22.3/bin:$PATH npm --prefix code/packages/typescript/spice-engine run build`
- `PATH=/Users/adhithya/.local/share/mise/installs/node/22.22.3/bin:$PATH npm --prefix code/packages/typescript/spice-engine test`
- `git diff --check HEAD~1..HEAD`
