### PR TITLE
feat(mycin-train): model-free decompose-fidelity scorer

### DIFF
--- a/code/specs/data/mycin-2026/train/README.md
+++ b/code/specs/data/mycin-2026/train/README.md
@@ -75,6 +75,20 @@ engine's diagnosis vs gold — identical scoring to `../bench/bench_models.py`, 
 base-vs-specialist is apples-to-apples. The model never diagnoses; it only
 decomposes.
 
+### Decompose fidelity, scored directly (`decompose_score.py`)
+
+The diagnosis outcome above is a coarse, end-to-end proxy. `decompose_score.py` scores the
+decomposer's fidelity **directly and model-free** — a pure `score_decompose(predicted_ir,
+gold_ir, note)` over either IR shape (findings or chart-facts) returning: fact
+precision/recall/F1 (by identity key — for findings the key includes `polarity`, so a flipped
+negation does not match), **span_faithfulness** (every cited span must be a verbatim substring of
+the note — the byte-provenance discipline measured directly), discard precision/recall, and two
+integer counts that should be 0 — **near_miss_violations** (a fact coined from a span the gold
+says to discard — the over-extraction failure the `NEAR_MISS_DISTRACTORS` train against) and
+**false_positive_facts**. The model run that produces `predicted_ir` is the caller's step; the
+scoring is deterministic and fully unit-tested (`test_decompose_score.py`), so a fine-tune's
+faithfulness is measurable without re-running the model.
+
 ## Result
 
 Training the framework-authored data took the base model from **0/4 → 4/4** on the

--- a/code/specs/data/mycin-2026/train/decompose_score.py
+++ b/code/specs/data/mycin-2026/train/decompose_score.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""decompose_score.py — score a decomposer's FIDELITY against a gold typed IR (model-free).
+
+`eval_specialist.py` scores the *downstream diagnosis* (correct/wrong/abstained) a decomposed
+chart produces — a coarse, end-to-end proxy that needs an MLX-served model to run. This module
+scores the thing the framework actually cares about, **directly and offline**: did the model
+extract the right facts, cite VERBATIM spans, discard the right distractors, and — the headline —
+NOT coin a fact from something that should have been discarded (the near-miss over-extraction
+failure the training data, gen_*.py, is built to prevent)?
+
+It is a PURE function over `(predicted_ir, gold_ir, note)` — no model, no network — so it both
+(a) gives `eval_specialist` a sharp fidelity metric to print alongside the diagnosis outcome, and
+(b) is fully unit-testable on synthetic predictions (test_decompose_score.py). The model run that
+produces `predicted_ir` stays the caller's step; the scoring is deterministic here.
+
+Works for BOTH typed-IR shapes the decomposer emits:
+  - findings  (gen_data.py):       items under "findings",   identity key (functor, value, polarity)
+  - chart-facts (gen_chart_data.py): items under "chart_facts", identity key (kind, value)
+
+Metrics (all in [0, 1] except the integer violation counts):
+  - fact_precision / fact_recall / fact_f1 — set overlap of predicted vs gold facts by identity key.
+  - span_faithfulness — fraction of predicted facts whose (non-empty) `span` is a VERBATIM
+    (whitespace/case-normalized) substring of the note. A hallucinated/paraphrased span scores 0
+    here; this is the byte-provenance discipline measured directly.
+  - discard_recall / discard_precision — overlap of predicted vs gold `discard` spans (did the
+    model set aside the red herrings it should, without inventing discards?).
+  - near_miss_violations — COUNT of predicted facts whose span matches a GOLD DISCARD span: the
+    model coined a fact from a phrase the gold says to discard (a relative's illness, a hedge, a
+    pending test, …). The single most important faithfulness number — should be 0.
+  - false_positive_facts — COUNT of predicted facts with no matching gold fact (over-extraction).
+"""
+
+from __future__ import annotations
+
+FINDINGS = ("findings", ("functor", "value", "polarity"))
+CHART_FACTS = ("chart_facts", ("kind", "value"))
+
+
+def _norm(s: str) -> str:
+    """Lowercase + collapse whitespace — the framework's citation-matching normalization
+    (mirrors gen_data._norm), so a span counts as grounded under benign whitespace/case drift."""
+    return " ".join(str(s).lower().split())
+
+
+def _key(item: dict, fields: tuple[str, ...]) -> tuple:
+    """The identity tuple a fact is matched on (e.g. (functor, value, polarity))."""
+    return tuple(item.get(f) for f in fields)
+
+
+def _f1(precision: float, recall: float) -> float:
+    return 0.0 if precision + recall == 0 else 2 * precision * recall / (precision + recall)
+
+
+def score_decompose(predicted: dict, gold: dict, note: str,
+                    shape: tuple[str, tuple[str, ...]] = CHART_FACTS) -> dict:
+    """Score one predicted IR against the gold IR for `note`. `shape` is FINDINGS or CHART_FACTS
+    (the items field + the identity-key fields). Pure; returns the metrics dict documented above.
+
+    Conventions for empty sets (so an honest abstain scores perfectly, not 0/0 → NaN):
+      - no predicted facts AND no gold facts → precision = recall = f1 = 1.0 (correct abstention);
+      - no predicted facts but some gold → precision = 1.0 (no false positives), recall = 0.0;
+      - some predicted but no gold → precision = 0.0, recall = 1.0 (everything is a false positive).
+    """
+    items_field, key_fields = shape
+    pred_items = predicted.get(items_field, []) or []
+    gold_items = gold.get(items_field, []) or []
+    note_n = _norm(note)
+
+    pred_keys = [_key(i, key_fields) for i in pred_items]
+    gold_keys = {_key(i, key_fields) for i in gold_items}
+    matched = [k for k in pred_keys if k in gold_keys]
+
+    fact_precision = 1.0 if not pred_keys else len(matched) / len(pred_keys)
+    fact_recall = 1.0 if not gold_keys else len({k for k in matched}) / len(gold_keys)
+
+    # Span faithfulness: every cited span must be a verbatim substring of the note. Facts with an
+    # empty span (honest "inferred", no provenance) are excluded from the denominator — they make
+    # no provenance claim to verify.
+    cited = [i for i in pred_items if i.get("span")]
+    grounded = [i for i in cited if _norm(i["span"]) in note_n]
+    span_faithfulness = 1.0 if not cited else len(grounded) / len(cited)
+
+    # Discards: span-set overlap (normalized).
+    pred_disc = {_norm(d.get("span", "")) for d in (predicted.get("discard") or []) if d.get("span")}
+    gold_disc = {_norm(d.get("span", "")) for d in (gold.get("discard") or []) if d.get("span")}
+    matched_disc = pred_disc & gold_disc
+    discard_recall = 1.0 if not gold_disc else len(matched_disc) / len(gold_disc)
+    discard_precision = 1.0 if not pred_disc else len(matched_disc) / len(pred_disc)
+
+    # The over-extraction failure: a predicted FACT whose span is one the gold says to DISCARD.
+    near_miss_violations = sum(1 for i in pred_items
+                               if i.get("span") and _norm(i["span"]) in gold_disc)
+    false_positive_facts = sum(1 for k in pred_keys if k not in gold_keys)
+
+    return {
+        "fact_precision": fact_precision,
+        "fact_recall": fact_recall,
+        "fact_f1": _f1(fact_precision, fact_recall),
+        "span_faithfulness": span_faithfulness,
+        "discard_recall": discard_recall,
+        "discard_precision": discard_precision,
+        "near_miss_violations": near_miss_violations,
+        "false_positive_facts": false_positive_facts,
+    }
+
+
+def aggregate(scores: list[dict]) -> dict:
+    """Mean each ratio metric, SUM the violation counts, over a list of per-example score dicts.
+    Empty input → an empty dict (the caller reports 'no examples')."""
+    if not scores:
+        return {}
+    ratio = ("fact_precision", "fact_recall", "fact_f1", "span_faithfulness",
+             "discard_recall", "discard_precision")
+    counts = ("near_miss_violations", "false_positive_facts")
+    out = {m: sum(s[m] for s in scores) / len(scores) for m in ratio}
+    out.update({m: sum(s[m] for s in scores) for m in counts})
+    out["n"] = len(scores)
+    return out

--- a/code/specs/data/mycin-2026/train/test_decompose_score.py
+++ b/code/specs/data/mycin-2026/train/test_decompose_score.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""test_decompose_score.py — guard the model-free decompose-fidelity scorer.
+
+Pure unit tests (no model/network): feed synthetic predicted IRs against a fixed gold + note and
+assert each metric responds correctly — a perfect prediction scores 1.0 across the board; a miss,
+an over-extraction, a hallucinated span, a near-miss-coined-as-fact, and an honest abstain each
+move exactly the metric they should. Covers both IR shapes (chart-facts + findings).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(HERE))
+import decompose_score as ds  # noqa: E402
+
+NOTE = ("A 72-year-old man with an eGFR of 12; his father has chronic kidney disease. "
+        "He drove himself to the emergency department.")
+
+GOLD = {
+    "chart_facts": [
+        {"kind": "age_band", "value": "older_adult", "span": "A 72-year-old", "type": "stated"},
+        {"kind": "renal_status", "value": "renal_severe", "span": "an eGFR of 12", "type": "stated"},
+    ],
+    "discard": [
+        {"span": "his father has chronic kidney disease",
+         "reason": "family history (renal), NOT the patient's renal_status"},
+        {"span": "drove himself to the emergency department", "reason": "logistics"},
+    ],
+}
+
+
+def test_perfect_prediction_scores_one():
+    s = ds.score_decompose(GOLD, GOLD, NOTE, ds.CHART_FACTS)
+    assert s["fact_precision"] == 1.0 and s["fact_recall"] == 1.0 and s["fact_f1"] == 1.0
+    assert s["span_faithfulness"] == 1.0
+    assert s["discard_recall"] == 1.0 and s["discard_precision"] == 1.0
+    assert s["near_miss_violations"] == 0 and s["false_positive_facts"] == 0
+
+
+def test_missing_a_fact_drops_recall_only():
+    pred = {"chart_facts": GOLD["chart_facts"][:1], "discard": GOLD["discard"]}  # drop renal
+    s = ds.score_decompose(pred, GOLD, NOTE, ds.CHART_FACTS)
+    assert s["fact_precision"] == 1.0  # what it did emit is correct
+    assert s["fact_recall"] == 0.5  # 1 of 2 gold facts
+    assert s["false_positive_facts"] == 0
+
+
+def test_over_extraction_drops_precision():
+    pred = {"chart_facts": GOLD["chart_facts"] + [
+        {"kind": "pregnancy", "value": "present", "span": "", "type": "inferred"}], "discard": []}
+    s = ds.score_decompose(pred, GOLD, NOTE, ds.CHART_FACTS)
+    assert s["fact_recall"] == 1.0
+    assert s["fact_precision"] < 1.0  # 2 of 3 predicted match gold
+    assert s["false_positive_facts"] == 1
+
+
+def test_hallucinated_span_drops_faithfulness():
+    pred = {"chart_facts": [
+        {"kind": "age_band", "value": "older_adult", "span": "A 72-year-old", "type": "stated"},
+        {"kind": "renal_status", "value": "renal_severe",
+         "span": "dialysis three times a week", "type": "stated"}],  # span NOT in the note
+        "discard": GOLD["discard"]}
+    s = ds.score_decompose(pred, GOLD, NOTE, ds.CHART_FACTS)
+    assert s["fact_recall"] == 1.0 and s["fact_precision"] == 1.0  # identity keys still match
+    assert s["span_faithfulness"] == 0.5  # 1 of 2 cited spans is verbatim in the note
+
+
+def test_near_miss_coined_as_fact_is_flagged():
+    # The model wrongly coined a renal_status fact from the FATHER's CKD (a gold discard span).
+    pred = {"chart_facts": GOLD["chart_facts"] + [
+        {"kind": "renal_status", "value": "renal_moderate",
+         "span": "his father has chronic kidney disease", "type": "stated"}],
+        "discard": []}
+    s = ds.score_decompose(pred, GOLD, NOTE, ds.CHART_FACTS)
+    assert s["near_miss_violations"] == 1, s  # the headline faithfulness failure is caught
+    assert s["false_positive_facts"] == 1  # it's also a false positive (not in gold)
+
+
+def test_missing_a_discard_drops_discard_recall():
+    pred = {"chart_facts": GOLD["chart_facts"], "discard": GOLD["discard"][:1]}  # drop one discard
+    s = ds.score_decompose(pred, GOLD, NOTE, ds.CHART_FACTS)
+    assert s["discard_recall"] == 0.5 and s["discard_precision"] == 1.0
+
+
+def test_honest_abstain_scores_perfectly():
+    note = "A 50-year-old with a headache and nothing else of note."
+    empty_gold = {"chart_facts": [], "discard": []}
+    s = ds.score_decompose(empty_gold, empty_gold, note, ds.CHART_FACTS)
+    assert s["fact_precision"] == 1.0 and s["fact_recall"] == 1.0 and s["fact_f1"] == 1.0
+    assert s["near_miss_violations"] == 0 and s["false_positive_facts"] == 0
+
+
+def test_findings_shape_keys_on_polarity():
+    note = "The CSF Gram stain was negative; he has a fever."
+    gold = {"findings": [
+        {"functor": "csf_gram_stain", "value": "negative", "polarity": "denied",
+         "span": "Gram stain was negative", "type": "stated"},
+        {"functor": "fever", "value": "present", "polarity": "affirmed",
+         "span": "a fever", "type": "stated"}], "discard": []}
+    # A prediction that flips the gram-stain polarity to affirmed must NOT match (wrong polarity).
+    pred = {"findings": [
+        {"functor": "csf_gram_stain", "value": "negative", "polarity": "affirmed",
+         "span": "Gram stain was negative", "type": "stated"},
+        {"functor": "fever", "value": "present", "polarity": "affirmed",
+         "span": "a fever", "type": "stated"}], "discard": []}
+    s = ds.score_decompose(pred, gold, note, ds.FINDINGS)
+    assert s["fact_recall"] == 0.5, s  # only fever matches; flipped-polarity gram stain does not
+    assert s["false_positive_facts"] == 1
+
+
+def test_aggregate_means_ratios_and_sums_counts():
+    perfect = ds.score_decompose(GOLD, GOLD, NOTE, ds.CHART_FACTS)
+    bad = ds.score_decompose(
+        {"chart_facts": GOLD["chart_facts"] + [
+            {"kind": "renal_status", "value": "renal_moderate",
+             "span": "his father has chronic kidney disease", "type": "stated"}], "discard": []},
+        GOLD, NOTE, ds.CHART_FACTS)
+    agg = ds.aggregate([perfect, bad])
+    assert agg["n"] == 2
+    assert agg["near_miss_violations"] == 1  # summed (0 + 1)
+    assert 0.0 < agg["fact_precision"] < 1.0  # mean of 1.0 and <1.0
+    assert ds.aggregate([]) == {}
+
+
+def main() -> int:
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    failed = 0
+    for t in tests:
+        try:
+            t()
+            print(f"  PASS  {t.__name__}")
+        except AssertionError as exc:
+            failed += 1
+            print(f"  FAIL  {t.__name__}: {exc}")
+    print(f"\ntest_decompose_score: {len(tests) - failed}/{len(tests)} passed")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What

The training data hardened both decomposer IR shapes against over-extraction ([#6152](https://github.com/adhithyan15/coding-adventures/pull/6152) chart-facts, [#6155](https://github.com/adhithyan15/coding-adventures/pull/6155) findings). This adds the **measurement counterpart**: a scorer for decompose *fidelity*, so a fine-tune's faithfulness is quantified **directly** — not just inferred from the downstream diagnosis.

`eval_specialist.py` scores the diagnosis outcome (correct/wrong/abstained) an MLX-served model produces — a coarse, model-dependent proxy. New **`decompose_score.py`** scores the thing the framework cares about, directly and **offline**: a pure `score_decompose(predicted_ir, gold_ir, note, shape)` over either IR shape (`FINDINGS` keyed by `(functor,value,polarity)`; `CHART_FACTS` keyed by `(kind,value)`), returning:

- **fact precision / recall / f1** — identity-key overlap (a flipped negation `polarity` does *not* match).
- **span_faithfulness** — fraction of cited spans that are **verbatim** substrings of the note (the byte-provenance discipline measured directly; a hallucinated/paraphrased span scores 0).
- **discard precision / recall**.
- **near_miss_violations** (count) — a fact coined from a span the gold says to *discard* (the over-extraction failure the `NEAR_MISS_DISTRACTORS` train against). The headline number; want 0.
- **false_positive_facts** (count).

Plus `aggregate()` (mean ratios, **sum** counts) for a batch. Honest abstain (empty pred + empty gold) scores 1.0, not 0/0.

## Why pure / offline

It's a deterministic function — no model, no network — so the model run that produces `predicted_ir` stays the caller's local step, and the scoring is **fully unit-tested**. 9/9 tests cover perfect, missed-fact (recall↓), over-extraction (precision↓ + FP), hallucinated span (faithfulness↓), near-miss-coined-as-fact (violation flagged), missing-discard (discard recall↓), findings polarity discrimination, honest abstain, and aggregate. `ruff` clean; `/security-review` PASSED (pure dict/string/arithmetic, no sinks, div-by-zero guarded).

## Scope

No engine/package change, no version bump. Gives the Gemma fine-tune a sharp, reproducible faithfulness metric to optimize against — closing the loop with the training-data hardening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)