### PR TITLE
feat(closure-pass-inline-variables): const-literal propagation (CLOC13.H)

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -553,6 +553,7 @@ members = [
     "closure-pass-dce",
     "closure-pass-fold-control-flow",
     "closure-pass-inline",
+    "closure-pass-inline-variables",
     "closure-pass-pipeline",
     "closure-pass-remove-unused-vars",
     "closure-pass-rename",

--- a/code/packages/rust/closure-pass-inline-variables/BUILD
+++ b/code/packages/rust/closure-pass-inline-variables/BUILD
@@ -1,0 +1,1 @@
+cargo test -p coding-adventures-closure-pass-inline-variables -- --nocapture

--- a/code/packages/rust/closure-pass-inline-variables/BUILD_windows
+++ b/code/packages/rust/closure-pass-inline-variables/BUILD_windows
@@ -1,0 +1,1 @@
+cargo test -p coding-adventures-closure-pass-inline-variables -- --nocapture

--- a/code/packages/rust/closure-pass-inline-variables/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-inline-variables/CHANGELOG.md
@@ -1,0 +1,53 @@
+# Changelog
+
+All notable changes to the `coding-adventures-closure-pass-inline-variables` crate will be documented in this file.
+
+## [0.1.0] - 2026-06-17
+
+### Added (CLOC13.H — constant propagation)
+
+New crate per CLOC06's canonical pass set — Closure Compiler's `InlineVariables`
+in miniature. `InlineVariablesPass::run` propagates a **top-level `const` bound
+to a literal** to all of its use sites:
+
+```js
+const RATE = 2;
+total = base * RATE;
+// =>  const RATE = 2;   (now unreferenced — removed by remove-unused-vars)
+//     total = base * 2;
+```
+
+- `InlinePass`-style metadata: `name = "inline-variables"`,
+  `depends_on = ["constant-fold"]` (so a folded initializer `const X = 1 + 2`
+  → `const X = 3` is a literal by the time we look), `iteration_policy =
+  FixedPoint`, `cost = 3`.
+- **Soundness** rests on three restrictions, plus the inline pass's
+  self-contained shadow guard (the name must be declared exactly once in the
+  whole program):
+  - **`const` only** — a `let`/`var` can be reassigned between its declaration
+    and a use, so its initializer is not a safe substitute. `const` cannot.
+  - **literal values only** — a literal is immutable. `const X = y;` (an
+    identifier whose value could later change) and `const X = o.p;` (a member
+    read that could trigger a getter) are NOT propagated.
+  - **temporal-dead-zone guard** — a `const` read before its declaration line
+    runs throws `ReferenceError` (even from a function called early). We only
+    propagate when every top-level item *before* the declaration is inert (a
+    function declaration, or a variable declaration with only literal
+    initializers), so nothing executes — and nothing can read the binding in
+    its TDZ — before it initializes. Only single-declarator `const`s are taken.
+- **Single-use** → always propagated (the whole `const` declaration becomes
+  pure overhead once its one use is gone). **Multi-use** → propagated only when
+  the literal's emitted form is short (`<= MAX_MULTIUSE_LITERAL_LEN`, 8 bytes),
+  so duplicating it across the uses is outweighed by deleting the declaration.
+- The pass only **propagates**; it leaves the emptied `const` declaration for
+  `remove-unused-vars` to delete (mirrors how the inline pass leaves dead
+  functions for treeshake). Property names (non-computed `.x` / object keys)
+  and assignment targets are never substituted; computed `o[X]` is.
+- Self-contained name-based analysis over the Phase-1 AST (same philosophy as
+  the `inline` and `rename` passes); does not depend on `closure-scope-analyzer`.
+
+### Tests
+- 19 tests: metadata/pipeline-ordering contract + source → bridge →
+  inline-variables → emit roundtrips covering single/multi-use propagation, the
+  multi-use literal-size budget, and every rejection (let/var, non-literal
+  value, shadowed name, property name, computed member).

--- a/code/packages/rust/closure-pass-inline-variables/Cargo.toml
+++ b/code/packages/rust/closure-pass-inline-variables/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "coding-adventures-closure-pass-inline-variables"
+version = "0.1.0"
+edition = "2021"
+description = "Constant-propagation pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Replaces references to a top-level `const` bound to a literal with the literal itself, so the binding becomes unused and remove-unused-vars deletes it."
+
+[dependencies]
+coding-adventures-closure-pass-pipeline = { path = "../closure-pass-pipeline" }
+coding-adventures-javascript-ast = { path = "../javascript-ast" }
+
+[dev-dependencies]
+coding-adventures-javascript-tokens = { path = "../javascript-tokens" }
+coding-adventures-closure-pass-constant-fold = { path = "../closure-pass-constant-fold" }
+# Test the real source -> bridge -> inline-variables -> emit roundtrip
+# against the actual AST shape the parser produces (not hand-built ASTs).
+coding-adventures-javascript-parser = { path = "../javascript-parser" }
+coding-adventures-closure-emitter = { path = "../closure-emitter" }
+coding-adventures-type-sidecar = { path = "../type-sidecar" }
+coding_adventures_correlation_vector = { path = "../correlation-vector" }

--- a/code/packages/rust/closure-pass-inline-variables/README.md
+++ b/code/packages/rust/closure-pass-inline-variables/README.md
@@ -1,0 +1,79 @@
+# coding-adventures-closure-pass-inline-variables
+
+Constant-propagation pass for the Closure Compiler clone — Closure
+Compiler's `InlineVariables` in miniature. Replaces references to a
+top-level `const` bound to a literal with the literal itself, so the
+binding can be deleted and downstream folding sees a concrete value.
+Per [CLOC06](../../../specs/CLOC06-pass-interface-contract.md)'s
+canonical pass set.
+
+## What it does
+
+```js
+// before
+const RATE = 2;
+total = base * RATE;
+
+// after inline-variables (the const is now unreferenced; remove-unused-vars
+// deletes it, after which constant-fold can fold base*2 if base is known)
+total = base * 2;
+```
+
+## Why only `const`, only literals
+
+Propagating `X`'s value to a use site is sound only when that value is
+the same at every use as at the declaration:
+
+1. **`const`, never `let`/`var`.** A `const` can't be reassigned; a
+   `let`/`var` could be written between declaration and use, so its
+   initializer isn't a safe substitute.
+2. **A literal, never an expression.** A literal is immutable.
+   `const X = y;` isn't propagated (`y` could change); `const X = o.p;`
+   isn't either (`o.p` may be a getter).
+
+Plus the self-contained **shadow guard** the inline pass uses — the name
+must be declared exactly once in the whole program — so every occurrence
+of the identifier provably refers to this one `const`.
+
+## The temporal dead zone
+
+Scope resolution isn't enough: a `const` read *before* its declaration
+line runs throws `ReferenceError` (even from a function called early), so
+replacing that read with the inert literal would erase the throw. We
+guard conservatively — a `const` is a candidate only when every top-level
+item before it is **inert** (a function declaration, which only hoists,
+or a variable declaration with literal initializers, which runs nothing),
+and only single-declarator `const`s are taken. A block of constants at the
+top of the file is fully covered; a `const` after any executable
+statement is left alone.
+
+## Single-use vs. multi-use
+
+- **One use** → always propagate (the whole `const` declaration is
+  overhead once its single use is gone).
+- **N > 1 uses** → propagate only when the literal is short
+  (`<= MAX_MULTIUSE_LITERAL_LEN`), so duplicating it doesn't outweigh
+  deleting the declaration. A long string constant used in twenty places
+  stays a `const`.
+
+The pass only propagates; it leaves the emptied `const` for
+`remove-unused-vars` to delete (mirroring how `inline` leaves dead
+functions for `treeshake`).
+
+## Where it sits
+
+`depends_on = ["constant-fold"]` so a folded initializer
+(`const X = 1 + 2` → `const X = 3`) is a literal when this pass looks.
+It runs before `remove-unused-vars` (which clears the emptied
+declaration) and feeds `constant-fold` on the next fixed-point sweep.
+
+## Dependency whitelist
+
+- `coding-adventures-closure-pass-pipeline` — `Pass` trait + types.
+- `coding-adventures-javascript-ast` — `Program` and the typed AST.
+
+Dev-deps: `coding-adventures-javascript-tokens`,
+`coding-adventures-javascript-parser`, `coding-adventures-closure-emitter`
+(source → bridge → pass → emit roundtrip tests),
+`coding-adventures-closure-pass-constant-fold` (pipeline-ordering test),
+`coding-adventures-type-sidecar`, `coding_adventures_correlation_vector`.

--- a/code/packages/rust/closure-pass-inline-variables/required_capabilities.json
+++ b/code/packages/rust/closure-pass-inline-variables/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "rust/closure-pass-inline-variables",
+  "capabilities": [],
+  "justification": "Pure data transformation over an AST. No filesystem, network, process, or environment access needed."
+}

--- a/code/packages/rust/closure-pass-inline-variables/src/lib.rs
+++ b/code/packages/rust/closure-pass-inline-variables/src/lib.rs
@@ -1,0 +1,1120 @@
+//! Constant-propagation pass for the Closure Compiler clone.
+//!
+//! Per [CLOC06](../../../specs/CLOC06-pass-interface-contract.md)'s
+//! canonical pass set. Replaces references to a top-level `const`
+//! binding whose value is a literal with the literal itself:
+//!
+//! ```js
+//! // before
+//! const RATE = 2;
+//! total = base * RATE;
+//!
+//! // after inline-variables
+//! const RATE = 2;          // now unreferenced …
+//! total = base * 2;        // … and removed by remove-unused-vars,
+//!                          //     after which constant-fold can fold
+//!                          //     `base * 2` further if `base` is known
+//! ```
+//!
+//! This is Closure Compiler's `InlineVariables` in miniature: pull a
+//! constant's value to its use sites so the binding can be deleted and
+//! downstream folding sees a concrete literal instead of a name.
+//!
+//! # Why this is safe — and why only `const`, only literals
+//!
+//! Propagating `X`'s value to a use site is sound only when that value
+//! is the SAME at every use as it was at the declaration. Two things
+//! guarantee that here:
+//!
+//! 1. **`const`, never `let`/`var`.** A `const` binding cannot be
+//!    reassigned, so its value never changes after initialization. A
+//!    `let`/`var` could be written between the declaration and a use
+//!    (`let x = 1; … x = 2; … use(x)`), so propagating its initializer
+//!    would be wrong. We touch only `const`.
+//! 2. **A literal value, never an expression.** A literal
+//!    (`5`, `"s"`, `true`, `null`, …) is immutable and has no
+//!    sub-terms that could change. `const X = y;` is NOT propagated:
+//!    `y` is a *variable* whose value at a later use could differ from
+//!    its value when `X` was bound (copy propagation needs
+//!    reaching-definitions analysis we don't do yet). `const X = o.p;`
+//!    is not propagated either — reading `o.p` may trigger a getter.
+//!
+//! Add the same self-contained **shadow guard** the inline pass uses —
+//! the name must be declared *exactly once in the whole program* — and
+//! every occurrence of the identifier `X` provably refers to this one
+//! `const`, so substituting the literal at each is a sound rewrite.
+//!
+//! # The temporal dead zone (why a use can throw)
+//!
+//! Scope resolution is not the whole story. A `const` has a *temporal
+//! dead zone*: reading `X` before its declaration line executes throws
+//! `ReferenceError`, even from a function whose body textually follows
+//! the declaration but is *called* earlier. Replacing such a read with
+//! the inert literal would erase a throw the original program performs —
+//! unsound. Example:
+//!
+//! ```js
+//! function read() { return X; }
+//! const r = read();   // runs while X is in its TDZ → ReferenceError
+//! const X = 5;
+//! ```
+//!
+//! We guard against this conservatively: a `const X` is a candidate only
+//! when **every top-level item before its declaration is inert** — a
+//! function declaration (hoists, runs nothing) or a variable declaration
+//! with only literal initializers (binds a constant, runs nothing). Then
+//! no code executes before `X` initializes, so nothing can read it in
+//! its TDZ. The common shape — a block of constants at the top of the
+//! file, used by code and functions below — is fully covered; a `const`
+//! sitting after any executable statement is left alone. (We also take
+//! only single-declarator `const`s, so an earlier sibling in the same
+//! declaration can't sneak a call in before `X`.)
+//!
+//! # Single-use vs. multi-use (the "is it worth it?" knob)
+//!
+//! Soundness aside, propagating a literal is a size win when the
+//! literal isn't much larger than the name it replaces, *plus* the
+//! whole `const X = …;` declaration disappears:
+//!
+//!   * **One use** → always propagate (the declaration is pure
+//!     overhead once its single use is gone).
+//!   * **N > 1 uses** → propagate only when the literal is short
+//!     (`literal_cost <= MAX_MULTIUSE_LITERAL_LEN`), so duplicating it
+//!     across the uses doesn't outweigh deleting the declaration. A
+//!     long string constant used in twenty places stays a `const`.
+//!
+//! The pass itself only *propagates*; it leaves the now-unreferenced
+//! `const` declaration in place. `remove-unused-vars` (which runs
+//! after it and already deletes unreferenced top-level bindings with
+//! literal initializers) removes the husk. Keeping the two concerns
+//! separate mirrors how the inline pass leaves dead functions for
+//! treeshake.
+//!
+//! # Where this pass sits
+//!
+//! `depends_on = ["constant-fold"]` so a folded initializer
+//! (`const X = 1 + 2` → `const X = 3`) is a literal by the time this
+//! pass looks at it. It runs before `remove-unused-vars` (which clears
+//! the emptied declaration) and feeds `constant-fold` on the next
+//! fixed-point sweep (`base * 2` with a now-literal operand).
+
+use std::collections::HashMap;
+
+use coding_adventures_closure_pass_pipeline::{
+    IterationPolicy, Pass, PassContext, PassError, PassOutput, PassStats,
+};
+use coding_adventures_javascript_ast::statement::TaggedStatement;
+use coding_adventures_javascript_ast::{
+    AssignmentTarget, BindingTarget, Declaration, Expression, ForInit, FunctionParam, Program,
+    ProgramItem, PropertyKey, Statement, VarKind, VariableDeclaration,
+};
+
+/// `Pass::depends_on` value — constant-fold first, so a folded
+/// initializer is already a literal when we scan for candidates.
+const DEPS: &[&str] = &["constant-fold"];
+
+/// A literal used at more than one site is propagated only when its
+/// emitted form is at most this many bytes — short enough that
+/// duplicating it across the uses is outweighed by deleting the whole
+/// `const` declaration. Numbers, booleans, `null`, and short strings
+/// clear this; long string/number constants used many times do not.
+const MAX_MULTIUSE_LITERAL_LEN: usize = 8;
+
+/// Constant-propagation pass. See crate-level docs for the exact
+/// (provably-safe) slice it implements.
+///
+/// Zero-sized type: no per-instance state. Pass-internal state (the
+/// candidate map, the per-name substitution) lives in pass-local maps
+/// constructed inside [`Pass::run`] per CLOC06 §"Pass-internal state."
+#[derive(Debug, Default, Clone, Copy)]
+pub struct InlineVariablesPass;
+
+impl InlineVariablesPass {
+    /// Zero-arg constructor for ergonomic
+    /// `PassPipeline::add(Box::new(InlineVariablesPass::new()))`.
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Pass for InlineVariablesPass {
+    fn name(&self) -> &'static str {
+        "inline-variables"
+    }
+
+    fn depends_on(&self) -> &[&'static str] {
+        // constant-fold first: a folded initializer (`const X = 1 + 2`
+        // → `const X = 3`) is then a literal we can propagate.
+        DEPS
+    }
+
+    fn iteration_policy(&self) -> IterationPolicy {
+        // FixedPoint: propagating a constant exposes new folding
+        // (`base * RATE` → `base * 2`) and the emptied declaration for
+        // remove-unused-vars. Re-running converges — once a `const`'s
+        // uses are gone the next pass finds zero sites and reports no
+        // change.
+        IterationPolicy::FixedPoint
+    }
+
+    fn cost(&self) -> u32 {
+        // A shadow-count walk, a per-candidate use count, and a
+        // substitution walk — comparable to DCE's mark+sweep.
+        3
+    }
+
+    fn run(&self, ctx: PassContext<'_>) -> Result<PassOutput, PassError> {
+        let mut program = ctx.program.clone();
+        let mut nodes_touched: u32 = 1; // the program root
+        let changed = inline_variables_program(&mut program, &mut nodes_touched);
+
+        Ok(PassOutput {
+            program,
+            contributions: Vec::new(),
+            changed,
+            diagnostics: Vec::new(),
+            stats: PassStats { nodes_touched },
+        })
+    }
+}
+
+// =========================================================================
+// Constant-propagation implementation (top-level `const = literal`)
+// =========================================================================
+
+/// One propagatable constant: its name and a clone of the literal value
+/// to substitute at each use site.
+struct ConstCandidate {
+    name: String,
+    value: Expression,
+}
+
+/// Walk the whole program and propagate every qualifying top-level
+/// `const = literal`. Returns whether anything changed.
+fn inline_variables_program(program: &mut Program, nodes_touched: &mut u32) -> bool {
+    // Phase 1 — count how many times each name is declared as a binding
+    // anywhere in the program (function names, parameters, var/let/const
+    // targets). A candidate's name must be declared exactly once, so no
+    // other scope shadows it and every use of the identifier resolves to
+    // this `const`.
+    let mut decl_counts: HashMap<String, usize> = HashMap::new();
+    count_decl_names_program(program, &mut decl_counts, nodes_touched);
+
+    // Phase 2 — collect candidates from top-level `const` declarators
+    // whose initializer is a literal and whose name is declared once.
+    let mut candidates: Vec<ConstCandidate> = Vec::new();
+    for (idx, item) in program.body.iter().enumerate() {
+        // The bridge emits a top-level declaration either as a bare
+        // `ProgramItem::Declaration` or wrapped in
+        // `ProgramItem::Statement(Statement::Declaration(..))`; handle
+        // both shapes (same lesson as remove-unused-vars).
+        let vd = match item {
+            ProgramItem::Declaration(Declaration::VariableDeclaration(vd)) => vd,
+            ProgramItem::Statement(Statement::Declaration(Declaration::VariableDeclaration(
+                vd,
+            ))) => vd,
+            _ => continue,
+        };
+        if !matches!(vd.kind, VarKind::Const) {
+            continue; // let/var can be reassigned — not safe to propagate
+        }
+        // Single declarator only. A multi-declarator `const A = f(), X = 2`
+        // evaluates earlier siblings (which may call code that reads X)
+        // before X initializes — the TDZ scan below only looks at whole
+        // top-level items, not within a declaration, so we skip these.
+        if vd.declarations.len() != 1 {
+            continue;
+        }
+        let d = &vd.declarations[0];
+        let BindingTarget::Identifier(id) = &d.id;
+        if decl_counts.get(&id.name).copied().unwrap_or(0) != 1 {
+            continue; // shadowed somewhere — can't resolve uses by name
+        }
+        let init = match &d.init {
+            Some(i) => i,
+            None => continue,
+        };
+        if !is_literal(init) {
+            continue;
+        }
+        // Temporal-dead-zone guard. A top-level `const` cannot be read
+        // before its declaration line runs — doing so throws
+        // `ReferenceError`. If anything *executes* before this line (a
+        // top-level call, or any statement that runs code), a function it
+        // reaches could read the binding in its TDZ; propagating the
+        // literal would erase that throw. We require every preceding
+        // top-level item to be *inert* — a function declaration (hoisted,
+        // doesn't run) or a variable declaration with only literal
+        // initializers (binds a constant, runs no code). Then nothing has
+        // read the binding by the time its declaration initializes it.
+        if !prefix_is_inert(&program.body[..idx]) {
+            continue;
+        }
+        candidates.push(ConstCandidate {
+            name: id.name.clone(),
+            value: init.clone(),
+        });
+    }
+    if candidates.is_empty() {
+        return false;
+    }
+
+    // Phase 3 — propagate. For each candidate, count its uses; propagate
+    // when there is at least one use and either it is single-use or the
+    // literal is short enough for the multi-use budget.
+    let mut changed = false;
+    for cand in &candidates {
+        let uses = count_uses_program(program, &cand.name);
+        if uses == 0 {
+            continue; // nothing to propagate (remove-unused-vars will drop it)
+        }
+        if uses > 1 && literal_cost(&cand.value) > MAX_MULTIUSE_LITERAL_LEN {
+            continue; // literal too large to duplicate across the uses
+        }
+        if propagate_all(program, cand) {
+            changed = true;
+        }
+    }
+    changed
+}
+
+/// Are all of the top-level `items` *inert* — do they run no code that
+/// could read a binding before it initializes?
+///
+/// An item is inert when it is a **function declaration** (hoisted; its
+/// body doesn't execute until called) or a **variable declaration whose
+/// every initializer is a literal** (binds a constant, runs nothing).
+/// Anything else — an expression statement, an `if`/loop, a `var` with a
+/// call/expression initializer — *executes*, and what it executes might
+/// read a not-yet-initialized `const`, so it blocks propagation (the TDZ
+/// guard). See the call site in [`inline_variables_program`].
+fn prefix_is_inert(items: &[ProgramItem]) -> bool {
+    items.iter().all(|item| match item {
+        ProgramItem::Declaration(d) => decl_is_inert(d),
+        ProgramItem::Statement(Statement::Declaration(d)) => decl_is_inert(d),
+        // An expression statement, control-flow, etc. runs code.
+        ProgramItem::Statement(_) => false,
+    })
+}
+
+/// A declaration is inert (runs no code at the point it appears) when it
+/// is a function declaration or a variable declaration with only literal
+/// (or absent) initializers. See [`prefix_is_inert`].
+fn decl_is_inert(decl: &Declaration) -> bool {
+    match decl {
+        // A function declaration only hoists here; its body runs when the
+        // function is called, which (given every preceding item is inert)
+        // cannot happen before a later `const` initializes.
+        Declaration::FunctionDeclaration(_) => true,
+        Declaration::VariableDeclaration(vd) => vd.declarations.iter().all(|d| match &d.init {
+            None => true,
+            Some(init) => is_literal(init),
+        }),
+    }
+}
+
+/// Is `expr` an immutable literal we can safely duplicate?
+fn is_literal(expr: &Expression) -> bool {
+    matches!(
+        expr,
+        Expression::NumericLiteral(_)
+            | Expression::StringLiteral(_)
+            | Expression::BooleanLiteral(_)
+            | Expression::NullLiteral(_)
+            | Expression::BigIntLiteral(_)
+            | Expression::UndefinedLiteral(_)
+    )
+}
+
+/// Approximate emitted byte length of a literal — the multi-use budget
+/// gate. Over-estimating is safe (it just declines a borderline win).
+fn literal_cost(expr: &Expression) -> usize {
+    match expr {
+        Expression::NumericLiteral(n) => n.raw.len().max(1),
+        Expression::StringLiteral(s) => s.value.len() + 2, // surrounding quotes
+        Expression::BooleanLiteral(b) => {
+            if b.value {
+                4
+            } else {
+                5
+            }
+        }
+        Expression::NullLiteral(_) => 4,
+        Expression::BigIntLiteral(b) => b.raw.len().max(1),
+        Expression::UndefinedLiteral(_) => 9,
+        // Non-literals never reach here (gated by `is_literal`), but be
+        // safe: treat as "too large" so they are never multi-propagated.
+        _ => usize::MAX,
+    }
+}
+
+// ---- name-declaration counting (shadow detection) ------------------------
+
+/// Count every binding-name *declaration* in the whole program —
+/// function names, parameters, and `var`/`let`/`const` targets,
+/// recursing into nested function bodies — accumulating occurrence
+/// counts into `out`. `nodes_touched` is bumped per statement.
+fn count_decl_names_program(
+    program: &Program,
+    out: &mut HashMap<String, usize>,
+    nodes_touched: &mut u32,
+) {
+    for item in &program.body {
+        match item {
+            ProgramItem::Declaration(d) => count_decl_names_decl(d, out, nodes_touched),
+            ProgramItem::Statement(s) => count_decl_names_stmt(s, out, nodes_touched),
+        }
+    }
+}
+
+fn count_decl_names_decl(
+    decl: &Declaration,
+    out: &mut HashMap<String, usize>,
+    nodes_touched: &mut u32,
+) {
+    *nodes_touched += 1;
+    match decl {
+        Declaration::VariableDeclaration(vd) => count_decl_names_var(vd, out),
+        Declaration::FunctionDeclaration(fd) => {
+            *out.entry(fd.id.name.clone()).or_insert(0) += 1;
+            for p in &fd.params {
+                let FunctionParam::Identifier(id) = p;
+                *out.entry(id.name.clone()).or_insert(0) += 1;
+            }
+            for s in &fd.body.body {
+                count_decl_names_stmt(s, out, nodes_touched);
+            }
+        }
+    }
+}
+
+fn count_decl_names_var(vd: &VariableDeclaration, out: &mut HashMap<String, usize>) {
+    for d in &vd.declarations {
+        let BindingTarget::Identifier(id) = &d.id;
+        *out.entry(id.name.clone()).or_insert(0) += 1;
+    }
+}
+
+fn count_decl_names_stmt(
+    stmt: &Statement,
+    out: &mut HashMap<String, usize>,
+    nodes_touched: &mut u32,
+) {
+    *nodes_touched += 1;
+    match stmt {
+        Statement::Declaration(d) => count_decl_names_decl(d, out, nodes_touched),
+        Statement::Tagged(t) => match t {
+            TaggedStatement::BlockStatement(b) => {
+                for s in &b.body {
+                    count_decl_names_stmt(s, out, nodes_touched);
+                }
+            }
+            TaggedStatement::IfStatement(is) => {
+                count_decl_names_stmt(&is.consequent, out, nodes_touched);
+                if let Some(alt) = &is.alternate {
+                    count_decl_names_stmt(alt, out, nodes_touched);
+                }
+            }
+            TaggedStatement::WhileStatement(ws) => {
+                count_decl_names_stmt(&ws.body, out, nodes_touched)
+            }
+            TaggedStatement::ForStatement(fs) => {
+                if let Some(ForInit::VariableDeclaration(vd)) = &fs.init {
+                    count_decl_names_var(vd, out);
+                }
+                count_decl_names_stmt(&fs.body, out, nodes_touched);
+            }
+            TaggedStatement::LabeledStatement(ls) => {
+                count_decl_names_stmt(&ls.body, out, nodes_touched)
+            }
+            TaggedStatement::SwitchStatement(ss) => {
+                for c in &ss.cases {
+                    for s in &c.consequent {
+                        count_decl_names_stmt(s, out, nodes_touched);
+                    }
+                }
+            }
+            // Statements that introduce no binding in the Phase-1 AST.
+            // Exhaustive on purpose: a future binding-introducing
+            // statement (a `try`/`catch`, a `class` declaration) must be
+            // handled here so a shadowing name can't slip past the
+            // shadow guard. The compiler flags the omission.
+            TaggedStatement::ExpressionStatement(_)
+            | TaggedStatement::ReturnStatement(_)
+            | TaggedStatement::ThrowStatement(_)
+            | TaggedStatement::BreakStatement(_)
+            | TaggedStatement::ContinueStatement(_)
+            | TaggedStatement::EmptyStatement(_) => {}
+        },
+    }
+}
+
+// ---- use counting --------------------------------------------------------
+
+/// Count the *uses* (binding-use-position occurrences) of `name` across
+/// the whole program — the occurrences [`propagate_all`] will rewrite.
+/// Declarations, property names, label names, and assignment *targets*
+/// are not counted (a `const` is never an assignment target in valid
+/// code, but we skip them defensively — you cannot assign to a literal).
+fn count_uses_program(program: &Program, name: &str) -> usize {
+    let mut count = 0;
+    for item in &program.body {
+        match item {
+            ProgramItem::Declaration(d) => count_uses_decl(d, name, &mut count),
+            ProgramItem::Statement(s) => count_uses_stmt(s, name, &mut count),
+        }
+    }
+    count
+}
+
+fn count_uses_decl(decl: &Declaration, name: &str, count: &mut usize) {
+    match decl {
+        Declaration::VariableDeclaration(vd) => {
+            for d in &vd.declarations {
+                if let Some(init) = &d.init {
+                    count_uses_expr(init, name, count);
+                }
+            }
+        }
+        Declaration::FunctionDeclaration(fd) => {
+            for s in &fd.body.body {
+                count_uses_stmt(s, name, count);
+            }
+        }
+    }
+}
+
+fn count_uses_stmt(stmt: &Statement, name: &str, count: &mut usize) {
+    match stmt {
+        Statement::Declaration(d) => count_uses_decl(d, name, count),
+        Statement::Tagged(t) => match t {
+            TaggedStatement::ExpressionStatement(es) => {
+                count_uses_expr(&es.expression, name, count)
+            }
+            TaggedStatement::BlockStatement(b) => {
+                for s in &b.body {
+                    count_uses_stmt(s, name, count);
+                }
+            }
+            TaggedStatement::IfStatement(is) => {
+                count_uses_expr(&is.test, name, count);
+                count_uses_stmt(&is.consequent, name, count);
+                if let Some(alt) = &is.alternate {
+                    count_uses_stmt(alt, name, count);
+                }
+            }
+            TaggedStatement::WhileStatement(ws) => {
+                count_uses_expr(&ws.test, name, count);
+                count_uses_stmt(&ws.body, name, count);
+            }
+            TaggedStatement::ForStatement(fs) => {
+                if let Some(init) = &fs.init {
+                    match init {
+                        ForInit::VariableDeclaration(vd) => {
+                            for d in &vd.declarations {
+                                if let Some(i) = &d.init {
+                                    count_uses_expr(i, name, count);
+                                }
+                            }
+                        }
+                        ForInit::Expression(e) => count_uses_expr(e, name, count),
+                    }
+                }
+                if let Some(test) = &fs.test {
+                    count_uses_expr(test, name, count);
+                }
+                if let Some(update) = &fs.update {
+                    count_uses_expr(update, name, count);
+                }
+                count_uses_stmt(&fs.body, name, count);
+            }
+            TaggedStatement::ReturnStatement(rs) => {
+                if let Some(a) = &rs.argument {
+                    count_uses_expr(a, name, count);
+                }
+            }
+            TaggedStatement::ThrowStatement(ts) => count_uses_expr(&ts.argument, name, count),
+            TaggedStatement::LabeledStatement(ls) => count_uses_stmt(&ls.body, name, count),
+            TaggedStatement::SwitchStatement(ss) => {
+                count_uses_expr(&ss.discriminant, name, count);
+                for c in &ss.cases {
+                    if let Some(test) = &c.test {
+                        count_uses_expr(test, name, count);
+                    }
+                    for s in &c.consequent {
+                        count_uses_stmt(s, name, count);
+                    }
+                }
+            }
+            TaggedStatement::BreakStatement(_)
+            | TaggedStatement::ContinueStatement(_)
+            | TaggedStatement::EmptyStatement(_) => {}
+        },
+    }
+}
+
+fn count_uses_expr(expr: &Expression, name: &str, count: &mut usize) {
+    match expr {
+        Expression::Identifier(id) => {
+            if id.name == name {
+                *count += 1;
+            }
+        }
+        Expression::NumericLiteral(_)
+        | Expression::StringLiteral(_)
+        | Expression::BooleanLiteral(_)
+        | Expression::NullLiteral(_)
+        | Expression::BigIntLiteral(_)
+        | Expression::UndefinedLiteral(_) => {}
+        Expression::BinaryExpression(be) => {
+            count_uses_expr(&be.left, name, count);
+            count_uses_expr(&be.right, name, count);
+        }
+        Expression::LogicalExpression(le) => {
+            count_uses_expr(&le.left, name, count);
+            count_uses_expr(&le.right, name, count);
+        }
+        Expression::UnaryExpression(ue) => count_uses_expr(&ue.argument, name, count),
+        Expression::AssignmentExpression(ae) => {
+            // The assignment TARGET is a write, not a use we propagate
+            // into (you can't assign to a literal). Only the member-
+            // object side of a member target, and the right-hand side,
+            // are use positions.
+            if let AssignmentTarget::MemberExpression(m) = &ae.left {
+                count_uses_member(&m.object, &m.property, m.computed, name, count);
+            }
+            count_uses_expr(&ae.right, name, count);
+        }
+        Expression::ConditionalExpression(ce) => {
+            count_uses_expr(&ce.test, name, count);
+            count_uses_expr(&ce.consequent, name, count);
+            count_uses_expr(&ce.alternate, name, count);
+        }
+        Expression::CallExpression(ce) => {
+            count_uses_expr(&ce.callee, name, count);
+            for a in &ce.arguments {
+                count_uses_expr(a, name, count);
+            }
+        }
+        Expression::MemberExpression(m) => {
+            count_uses_member(&m.object, &m.property, m.computed, name, count)
+        }
+        Expression::ArrayExpression(ae) => {
+            for el in ae.elements.iter().flatten() {
+                count_uses_expr(el, name, count);
+            }
+        }
+        Expression::ObjectExpression(oe) => {
+            for prop in &oe.properties {
+                if prop.computed {
+                    if let PropertyKey::Expression(e) = &prop.key {
+                        count_uses_expr(e, name, count);
+                    }
+                }
+                count_uses_expr(&prop.value, name, count);
+            }
+        }
+    }
+}
+
+fn count_uses_member(
+    object: &Expression,
+    property: &Expression,
+    computed: bool,
+    name: &str,
+    count: &mut usize,
+) {
+    count_uses_expr(object, name, count);
+    // A non-computed `.name` is a property name, not a binding use.
+    if computed {
+        count_uses_expr(property, name, count);
+    }
+}
+
+// ---- propagation (replace every use of the name with the literal) --------
+
+/// Replace EVERY use of `cand.name` in the program with a clone of the
+/// constant's literal value. Returns whether any replacement was made.
+/// The walk does not short-circuit — it rewrites all use sites.
+fn propagate_all(program: &mut Program, cand: &ConstCandidate) -> bool {
+    let mut changed = false;
+    for item in &mut program.body {
+        changed |= match item {
+            ProgramItem::Declaration(d) => propagate_in_decl(d, cand),
+            ProgramItem::Statement(s) => propagate_in_stmt(s, cand),
+        };
+    }
+    changed
+}
+
+fn propagate_in_decl(decl: &mut Declaration, cand: &ConstCandidate) -> bool {
+    let mut changed = false;
+    match decl {
+        Declaration::VariableDeclaration(vd) => {
+            for d in &mut vd.declarations {
+                if let Some(init) = &mut d.init {
+                    changed |= propagate_in_expr(init, cand);
+                }
+            }
+        }
+        Declaration::FunctionDeclaration(fd) => {
+            for s in &mut fd.body.body {
+                changed |= propagate_in_stmt(s, cand);
+            }
+        }
+    }
+    changed
+}
+
+fn propagate_in_stmt(stmt: &mut Statement, cand: &ConstCandidate) -> bool {
+    let mut changed = false;
+    match stmt {
+        Statement::Declaration(d) => changed |= propagate_in_decl(d, cand),
+        Statement::Tagged(t) => match t {
+            TaggedStatement::ExpressionStatement(es) => {
+                changed |= propagate_in_expr(&mut es.expression, cand)
+            }
+            TaggedStatement::BlockStatement(b) => {
+                for s in &mut b.body {
+                    changed |= propagate_in_stmt(s, cand);
+                }
+            }
+            TaggedStatement::IfStatement(is) => {
+                changed |= propagate_in_expr(&mut is.test, cand);
+                changed |= propagate_in_stmt(&mut is.consequent, cand);
+                if let Some(alt) = &mut is.alternate {
+                    changed |= propagate_in_stmt(alt, cand);
+                }
+            }
+            TaggedStatement::WhileStatement(ws) => {
+                changed |= propagate_in_expr(&mut ws.test, cand);
+                changed |= propagate_in_stmt(&mut ws.body, cand);
+            }
+            TaggedStatement::ForStatement(fs) => {
+                if let Some(init) = &mut fs.init {
+                    match init {
+                        ForInit::VariableDeclaration(vd) => {
+                            for d in &mut vd.declarations {
+                                if let Some(i) = &mut d.init {
+                                    changed |= propagate_in_expr(i, cand);
+                                }
+                            }
+                        }
+                        ForInit::Expression(e) => changed |= propagate_in_expr(e, cand),
+                    }
+                }
+                if let Some(test) = &mut fs.test {
+                    changed |= propagate_in_expr(test, cand);
+                }
+                if let Some(update) = &mut fs.update {
+                    changed |= propagate_in_expr(update, cand);
+                }
+                changed |= propagate_in_stmt(&mut fs.body, cand);
+            }
+            TaggedStatement::ReturnStatement(rs) => {
+                if let Some(a) = &mut rs.argument {
+                    changed |= propagate_in_expr(a, cand);
+                }
+            }
+            TaggedStatement::ThrowStatement(ts) => {
+                changed |= propagate_in_expr(&mut ts.argument, cand)
+            }
+            TaggedStatement::LabeledStatement(ls) => {
+                changed |= propagate_in_stmt(&mut ls.body, cand)
+            }
+            TaggedStatement::SwitchStatement(ss) => {
+                changed |= propagate_in_expr(&mut ss.discriminant, cand);
+                for c in &mut ss.cases {
+                    if let Some(test) = &mut c.test {
+                        changed |= propagate_in_expr(test, cand);
+                    }
+                    for s in &mut c.consequent {
+                        changed |= propagate_in_stmt(s, cand);
+                    }
+                }
+            }
+            TaggedStatement::BreakStatement(_)
+            | TaggedStatement::ContinueStatement(_)
+            | TaggedStatement::EmptyStatement(_) => {}
+        },
+    }
+    changed
+}
+
+fn propagate_in_expr(expr: &mut Expression, cand: &ConstCandidate) -> bool {
+    // A bare identifier in use position that matches the constant's name
+    // becomes the literal. This is the only place a replacement happens;
+    // every other arm just recurses into use-position sub-expressions.
+    if let Expression::Identifier(id) = expr {
+        if id.name == cand.name {
+            *expr = cand.value.clone();
+            return true;
+        }
+        return false;
+    }
+
+    let mut changed = false;
+    match expr {
+        // Identifier handled above; literals have no sub-expressions.
+        Expression::Identifier(_)
+        | Expression::NumericLiteral(_)
+        | Expression::StringLiteral(_)
+        | Expression::BooleanLiteral(_)
+        | Expression::NullLiteral(_)
+        | Expression::BigIntLiteral(_)
+        | Expression::UndefinedLiteral(_) => {}
+        Expression::BinaryExpression(be) => {
+            changed |= propagate_in_expr(&mut be.left, cand);
+            changed |= propagate_in_expr(&mut be.right, cand);
+        }
+        Expression::LogicalExpression(le) => {
+            changed |= propagate_in_expr(&mut le.left, cand);
+            changed |= propagate_in_expr(&mut le.right, cand);
+        }
+        Expression::UnaryExpression(ue) => changed |= propagate_in_expr(&mut ue.argument, cand),
+        Expression::AssignmentExpression(ae) => {
+            // The target identifier is a write — never replaced (a
+            // `const` can't be assigned, and you can't assign to a
+            // literal). Only the member-object side and the RHS recurse.
+            if let AssignmentTarget::MemberExpression(m) = &mut ae.left {
+                changed |= propagate_in_member(m, cand);
+            }
+            changed |= propagate_in_expr(&mut ae.right, cand);
+        }
+        Expression::ConditionalExpression(ce) => {
+            changed |= propagate_in_expr(&mut ce.test, cand);
+            changed |= propagate_in_expr(&mut ce.consequent, cand);
+            changed |= propagate_in_expr(&mut ce.alternate, cand);
+        }
+        Expression::CallExpression(ce) => {
+            changed |= propagate_in_expr(&mut ce.callee, cand);
+            for a in &mut ce.arguments {
+                changed |= propagate_in_expr(a, cand);
+            }
+        }
+        Expression::MemberExpression(m) => changed |= propagate_in_member(m, cand),
+        Expression::ArrayExpression(ae) => {
+            for el in ae.elements.iter_mut().flatten() {
+                changed |= propagate_in_expr(el, cand);
+            }
+        }
+        Expression::ObjectExpression(oe) => {
+            for prop in &mut oe.properties {
+                // A computed key `[expr]` is a use position; a plain
+                // identifier / string / number key is a property name.
+                if prop.computed {
+                    if let PropertyKey::Expression(e) = &mut prop.key {
+                        changed |= propagate_in_expr(e, cand);
+                    }
+                }
+                changed |= propagate_in_expr(&mut prop.value, cand);
+            }
+        }
+    }
+    changed
+}
+
+fn propagate_in_member(
+    m: &mut coding_adventures_javascript_ast::MemberExpression,
+    cand: &ConstCandidate,
+) -> bool {
+    let mut changed = propagate_in_expr(&mut m.object, cand);
+    // Only a computed property `o[expr]` is a use position; a
+    // non-computed `.name` is a property name.
+    if m.computed {
+        changed |= propagate_in_expr(&mut m.property, cand);
+    }
+    changed
+}
+
+#[cfg(test)]
+mod tests {
+    //! Tests pin the public contract (name, policy, cost, deps), the
+    //! `PassPipeline` integration, and the propagation behaviour itself
+    //! — driven end-to-end through the real source → bridge →
+    //! inline-variables → emit roundtrip so they exercise the exact AST
+    //! shape the parser produces.
+    use super::*;
+    use coding_adventures_closure_emitter::{emit, EmitOptions};
+    use coding_adventures_closure_pass_constant_fold::ConstantFoldPass;
+    use coding_adventures_closure_pass_pipeline::{PassContext, PassPipeline, PipelineOutput};
+    use coding_adventures_correlation_vector::CVLog;
+    use coding_adventures_javascript_ast::{Program, SourceType};
+    use coding_adventures_javascript_parser::{bridge, parse_javascript_typed};
+    use coding_adventures_javascript_tokens::EsVersion;
+    use coding_adventures_type_sidecar::Sidecar;
+
+    fn program() -> Program {
+        Program::new("prog.1".to_string(), EsVersion::Es2025, SourceType::Module)
+    }
+
+    /// Parse `src`, bridge to a typed `Program`, run the pass, emit.
+    fn propagate_source(src: &str) -> String {
+        let es = EsVersion::Es2025;
+        let node = parse_javascript_typed(src, es).expect("parse");
+        let prog = bridge::grammar_to_program(&node, es).expect("bridge");
+
+        let pass = InlineVariablesPass::new();
+        let sidecar = Sidecar::new();
+        let mut cv = CVLog::new(false);
+        let out = pass
+            .run(PassContext {
+                program: &prog,
+                sidecar: &sidecar,
+                cv: &mut cv,
+            })
+            .expect("inline-variables");
+
+        let mut cv2 = CVLog::new(false);
+        let opts = EmitOptions {
+            source_map: false,
+            ..Default::default()
+        };
+        emit(&out.program, &sidecar, &mut cv2, &opts)
+            .expect("emit")
+            .code
+    }
+
+    // ----- metadata contract -----
+
+    #[test]
+    fn name_is_inline_variables() {
+        assert_eq!(InlineVariablesPass::new().name(), "inline-variables");
+    }
+
+    #[test]
+    fn iteration_policy_is_fixed_point() {
+        assert_eq!(
+            InlineVariablesPass::new().iteration_policy(),
+            IterationPolicy::FixedPoint
+        );
+    }
+
+    #[test]
+    fn cost_is_three_pass_units() {
+        assert_eq!(InlineVariablesPass::new().cost(), 3);
+    }
+
+    #[test]
+    fn depends_on_constant_fold() {
+        assert_eq!(InlineVariablesPass::new().depends_on(), &["constant-fold"]);
+    }
+
+    #[test]
+    fn invalidates_empty_in_v1() {
+        assert!(InlineVariablesPass::new().invalidates().is_empty());
+    }
+
+    #[test]
+    fn run_on_empty_program_returns_unchanged_identity() {
+        let pass = InlineVariablesPass::new();
+        let prog = program();
+        let sidecar = Sidecar::new();
+        let mut cv = CVLog::new(true);
+        let out = pass
+            .run(PassContext {
+                program: &prog,
+                sidecar: &sidecar,
+                cv: &mut cv,
+            })
+            .expect("pass should succeed");
+        assert_eq!(out.program.cv, prog.cv);
+        assert!(!out.changed);
+        assert!(out.contributions.is_empty());
+        assert_eq!(out.stats.nodes_touched, 1);
+    }
+
+    #[test]
+    fn pipeline_orders_constant_fold_before_inline_variables() {
+        let mut pipeline = PassPipeline::new();
+        pipeline.add(Box::new(InlineVariablesPass::new()));
+        pipeline.add(Box::new(ConstantFoldPass::new()));
+        let mut cv = CVLog::new(true);
+        let out: PipelineOutput = pipeline
+            .run(program(), &Sidecar::new(), &mut cv)
+            .expect("pipeline should run cleanly");
+        assert_eq!(
+            out.execution_order,
+            vec!["constant-fold".to_string(), "inline-variables".to_string()],
+            "inline-variables must run after constant-fold"
+        );
+    }
+
+    #[test]
+    fn pass_is_default_and_clone() {
+        let _a: InlineVariablesPass = Default::default();
+        let _b: InlineVariablesPass = InlineVariablesPass::new();
+        let _c = _b;
+        let _d = _c.clone();
+    }
+
+    // =====================================================================
+    // Propagation behaviour (source → bridge → inline-variables → emit)
+    // =====================================================================
+    //
+    // NOTE: the pass only PROPAGATES — it leaves the now-unreferenced
+    // `const` declaration in place (remove-unused-vars removes it
+    // downstream). These tests assert the value reached the use sites;
+    // the husk `const X=…;` is expected to remain at the pass level.
+
+    #[test]
+    fn propagates_single_use_const() {
+        assert_eq!(
+            propagate_source("const RATE = 2; use(RATE);"),
+            "const RATE=2;use(2);"
+        );
+    }
+
+    #[test]
+    fn propagates_const_into_expression() {
+        assert_eq!(
+            propagate_source("const RATE = 2; total(base * RATE);"),
+            "const RATE=2;total(base * 2);"
+        );
+    }
+
+    #[test]
+    fn propagates_short_literal_at_multiple_sites() {
+        assert_eq!(
+            propagate_source("const N = 3; a(N); b(N); c(N);"),
+            "const N=3;a(3);b(3);c(3);"
+        );
+    }
+
+    #[test]
+    fn propagates_boolean_and_null_literals() {
+        assert_eq!(
+            propagate_source("const ON = true; const NONE = null; f(ON, NONE);"),
+            "const ON=true;const NONE=null;f(true,null);"
+        );
+    }
+
+    #[test]
+    fn does_not_propagate_long_literal_at_multiple_sites() {
+        // The string is longer than the multi-use budget, so duplicating
+        // it across two sites is not worth deleting the declaration.
+        assert_eq!(
+            propagate_source("const MSG = \"a long message value\"; a(MSG); b(MSG);"),
+            "const MSG=\"a long message value\";a(MSG);b(MSG);"
+        );
+    }
+
+    #[test]
+    fn propagates_long_literal_at_a_single_site() {
+        // A single use is always worth it — the whole declaration goes.
+        assert_eq!(
+            propagate_source("const MSG = \"a long message value\"; a(MSG);"),
+            "const MSG=\"a long message value\";a(\"a long message value\");"
+        );
+    }
+
+    #[test]
+    fn does_not_propagate_let_or_var() {
+        // `let`/`var` can be reassigned — never propagated.
+        assert_eq!(propagate_source("let X = 5; use(X);"), "let X=5;use(X);");
+        assert_eq!(propagate_source("var Y = 5; use(Y);"), "var Y=5;use(Y);");
+    }
+
+    #[test]
+    fn does_not_propagate_non_literal_value() {
+        // `const X = expr` where expr is not a literal is left alone:
+        // an identifier value could be reassigned; a call/member could
+        // have side effects.
+        assert_eq!(
+            propagate_source("const X = other; use(X);"),
+            "const X=other;use(X);"
+        );
+        assert_eq!(
+            propagate_source("const X = make(); use(X);"),
+            "const X=make();use(X);"
+        );
+    }
+
+    #[test]
+    fn does_not_propagate_shadowed_name() {
+        // `RATE` is declared twice (the const and a parameter of `f`), so
+        // a use of `RATE` could resolve to either binding. Declined.
+        assert_eq!(
+            propagate_source("const RATE = 2; function f(RATE) { return RATE; }"),
+            "const RATE=2;function f(RATE){return RATE};"
+        );
+    }
+
+    #[test]
+    fn does_not_replace_property_name() {
+        // `obj.RATE` — `RATE` here is a property name, not a use of the
+        // const, so it is not replaced and the const has zero uses.
+        assert_eq!(
+            propagate_source("const RATE = 2; use(obj.RATE);"),
+            "const RATE=2;use(obj.RATE);"
+        );
+    }
+
+    #[test]
+    fn replaces_computed_member() {
+        // A computed `obj[RATE]` IS a use position — replaced.
+        assert_eq!(
+            propagate_source("const RATE = 2; use(obj[RATE]);"),
+            "const RATE=2;use(obj[2]);"
+        );
+    }
+
+    // ----- temporal dead zone (TDZ) guard -----
+
+    #[test]
+    fn propagates_through_an_inert_const_block() {
+        // Every item before `X` is inert (a literal-valued `const`), so
+        // nothing runs before `X` initializes — both constants propagate.
+        assert_eq!(
+            propagate_source("const A = 1; const X = 2; f(A, X);"),
+            "const A=1;const X=2;f(1,2);"
+        );
+    }
+
+    #[test]
+    fn propagates_into_a_function_declared_before_the_const() {
+        // `helper` is declared before `X` but a function declaration only
+        // hoists — it can't run until called, and the only call
+        // (`run(helper)`) is after `X` initializes. So reading `X` inside
+        // `helper` is never in the TDZ, and propagation is sound.
+        assert_eq!(
+            propagate_source("function helper() { return X; } const X = 5; run(helper);"),
+            "function helper(){return 5};const X=5;run(helper);"
+        );
+    }
+
+    #[test]
+    fn does_not_propagate_when_code_runs_before_the_declaration() {
+        // SOUNDNESS (TDZ): a top-level call `g()` runs before `const X`
+        // initializes. `g` (or anything it reaches) could read `X` in its
+        // temporal dead zone and throw `ReferenceError`; propagating the
+        // literal would erase that throw. The prefix is not inert, so `X`
+        // is declined and left untouched.
+        assert_eq!(
+            propagate_source("g(); const X = 5; use(X);"),
+            "g();const X=5;use(X);"
+        );
+    }
+
+    #[test]
+    fn does_not_propagate_a_const_after_a_non_literal_initializer() {
+        // `const SETUP = init();` runs `init()` before `const X` — not an
+        // inert prefix, so `X` is declined (TDZ guard). `SETUP` itself is
+        // not a candidate (its initializer is a call, not a literal).
+        assert_eq!(
+            propagate_source("const SETUP = init(); const X = 5; use(X);"),
+            "const SETUP=init();const X=5;use(X);"
+        );
+    }
+
+    #[test]
+    fn does_not_propagate_multi_declarator_const() {
+        // A multi-declarator `const A = 1, X = 2` is conservatively
+        // skipped (an earlier sibling could be a call the TDZ scan, which
+        // works at item granularity, would not see).
+        assert_eq!(
+            propagate_source("const A = 1, X = 2; f(A, X);"),
+            "const A=1,X=2;f(A,X);"
+        );
+    }
+}

--- a/code/programs/rust/closurec/CHANGELOG.md
+++ b/code/programs/rust/closurec/CHANGELOG.md
@@ -2,6 +2,43 @@
 
 All notable changes to the `coding-adventures-closurec` binary will be documented in this file.
 
+## [0.148.0] - 2026-06-17
+
+### Added (CLOC13.H — `inline-variables` constant propagation in SIMPLE)
+
+The SIMPLE pipeline gains a new pass, `inline-variables`
+(`coding-adventures-closure-pass-inline-variables` `0.1.0`), registered
+between `inline` and `remove-unused-vars`. It propagates a top-level `const`
+bound to a **literal** to its use sites, so remove-unused-vars deletes the
+now-unreferenced binding and the fixed-point constant-fold sweep folds the
+result:
+
+```js
+const RATE = 2;
+total(base * RATE);
+margin(RATE + 1);
+//  closurec --compilation_level SIMPLE  ⇒  total(base * 2); margin(3);
+```
+
+Only `const` (never `let`/`var` — reassignable) bound to a literal (never an
+identifier/call/member — which could change or have getters) is propagated,
+and only when the name is declared exactly once in the whole program (no
+shadowing). Single use → always; multiple uses → only when the literal is
+short. `SIMPLE_PASS_NAMES` is now
+`constant-fold → fold-control-flow → dce → inline → inline-variables →
+remove-unused-vars → treeshake → rename`.
+
+### Fixtures / tests
+
+- New `tests/diff/simple-inline-variables/` fixture + harness
+  (`const RATE = 2; total(base * RATE); margin(RATE + 1);` →
+  `total(base * 2);margin(3);`), plus a
+  `simple_propagates_const_literal_and_removes_binding` unit test.
+- Updated the `simple_v2` CV trace's `passes` assertion to include
+  `inline-variables`.
+- Version bumped `0.147.0 → 0.148.0` (`Cargo.toml`, `cli.spec.json`,
+  help-markdown fixture).
+
 ## [0.147.0] - 2026-06-17
 
 ### Changed (CLOC13.G — `inline` now inlines small functions at multiple sites)

--- a/code/programs/rust/closurec/Cargo.toml
+++ b/code/programs/rust/closurec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closurec"
-version = "0.147.0"
+version = "0.148.0"
 edition = "2021"
 description = "closurec — CLI driver for the Closure Compiler clone. Mirrors the upstream Java Closure Compiler's command-line flag surface (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility. Per CLOC08."
 
@@ -28,6 +28,7 @@ coding-adventures-closure-pass-constant-fold = { path = "../../../packages/rust/
 coding-adventures-closure-pass-fold-control-flow = { path = "../../../packages/rust/closure-pass-fold-control-flow" }
 coding-adventures-closure-pass-dce = { path = "../../../packages/rust/closure-pass-dce" }
 coding-adventures-closure-pass-inline = { path = "../../../packages/rust/closure-pass-inline" }
+coding-adventures-closure-pass-inline-variables = { path = "../../../packages/rust/closure-pass-inline-variables" }
 coding-adventures-closure-pass-rename = { path = "../../../packages/rust/closure-pass-rename" }
 coding-adventures-closure-pass-treeshake = { path = "../../../packages/rust/closure-pass-treeshake" }
 coding-adventures-closure-pass-collapse-properties = { path = "../../../packages/rust/closure-pass-collapse-properties" }

--- a/code/programs/rust/closurec/cli.spec.json
+++ b/code/programs/rust/closurec/cli.spec.json
@@ -2,7 +2,7 @@
   "cli_builder_spec_version": "1.0",
   "name": "closurec",
   "description": "closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.",
-  "version": "0.147.0",
+  "version": "0.148.0",
   "parsing_mode": "gnu",
   "flags": [
     { "id": "browser_featureset_year", "long": "browser_featureset_year", "type": "integer", "default": 0, "description": "Shortcut for defining goog.FEATURESET_YEAR=YYYY (minimum 2012)." },

--- a/code/programs/rust/closurec/src/run.rs
+++ b/code/programs/rust/closurec/src/run.rs
@@ -243,6 +243,7 @@ const SIMPLE_PASS_NAMES: &[&str] = &[
     "fold-control-flow",
     "dce",
     "inline",
+    "inline-variables",
     "remove-unused-vars",
     "treeshake",
     "rename",
@@ -278,6 +279,7 @@ fn run_simple_pipeline(
     use coding_adventures_closure_pass_dce::DcePass;
     use coding_adventures_closure_pass_fold_control_flow::FoldControlFlowPass;
     use coding_adventures_closure_pass_inline::InlinePass;
+    use coding_adventures_closure_pass_inline_variables::InlineVariablesPass;
     use coding_adventures_closure_pass_pipeline::PassPipeline;
     use coding_adventures_closure_pass_remove_unused_vars::RemoveUnusedVarsPass;
     use coding_adventures_closure_pass_rename::RenamePass;
@@ -302,6 +304,10 @@ fn run_simple_pipeline(
     pipeline.add(Box::new(FoldControlFlowPass::new()));
     pipeline.add(Box::new(DcePass::new()));
     pipeline.add(Box::new(InlinePass::new()));
+    // inline-variables propagates a top-level `const = literal` to its
+    // use sites; it runs before remove-unused-vars, which then deletes
+    // the now-unreferenced `const` declaration.
+    pipeline.add(Box::new(InlineVariablesPass::new()));
     pipeline.add(Box::new(RemoveUnusedVarsPass::new()));
     pipeline.add(Box::new(TreeshakePass::new()));
     // rename runs last: it shortens leaf-function parameter names after
@@ -5998,6 +6004,24 @@ mod tests {
     }
 
     #[test]
+    fn simple_propagates_const_literal_and_removes_binding() {
+        // CLOC13.H: a top-level `const` bound to a literal is propagated
+        // to its use sites, remove-unused-vars deletes the binding, and
+        // constant-fold folds the now-concrete `2 + 1`.
+        let cfg = CompilerConfig {
+            compilation: crate::config::CompilationConfig {
+                level: crate::config::CompilationLevel::Simple,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let out =
+            transform_source("const RATE = 2; total(base * RATE); margin(RATE + 1);", &cfg)
+                .expect("ok");
+        assert_eq!(out, "total(base * 2);margin(3);");
+    }
+
+    #[test]
     fn simple_level_bridge_ok_status_in_cv() {
         // When the source parses cleanly, the CV contribution for the
         // `compilation_level` stage must carry bridge_status = "ok".
@@ -6036,7 +6060,7 @@ mod tests {
         // The pass pipeline must be recorded in the trace, in order.
         assert!(
             body.contains(
-                "\"passes\":[\"constant-fold\",\"fold-control-flow\",\"dce\",\"inline\",\"remove-unused-vars\",\"treeshake\",\"rename\"]"
+                "\"passes\":[\"constant-fold\",\"fold-control-flow\",\"dce\",\"inline\",\"inline-variables\",\"remove-unused-vars\",\"treeshake\",\"rename\"]"
             ),
             "expected passes list in CV sidecar: {body}"
         );

--- a/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
@@ -2,7 +2,7 @@
 
 closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.
 
-Version: 0.147.0
+Version: 0.148.0
 
 ## Flags
 

--- a/code/programs/rust/closurec/tests/diff/simple-inline-variables/README.md
+++ b/code/programs/rust/closurec/tests/diff/simple-inline-variables/README.md
@@ -1,0 +1,34 @@
+# Fixture: `simple-inline-variables`
+
+End-to-end oracle for the `inline-variables` (constant-propagation) pass
+in `--compilation_level SIMPLE` (CLOC13.H).
+
+| File | Role |
+|------|------|
+| `flags.txt` | `--compilation_level SIMPLE --js input/a.js` |
+| `input/a.js` | A top-level `const` bound to a literal, used in two expressions |
+| `expected.stdout` | `total(base * 2);margin(3);` |
+
+The SIMPLE pipeline is now
+`constant-fold → fold-control-flow → dce → inline → inline-variables →
+remove-unused-vars → treeshake → rename`. The new pass propagates a
+top-level `const` whose value is a literal to its use sites:
+
+| Sweep | What happens |
+|-------|--------------|
+| 1 | `RATE` (`const = 2`) is propagated → `base * 2` and `2 + 1`; the `const RATE = 2;` declaration is now unreferenced and removed by `remove-unused-vars` |
+| 2 | `constant-fold` folds `2 + 1` → `3` |
+| 3 | nothing changes → converged |
+
+`base` is a free variable, so `base * 2` cannot be folded further. Only
+`const` bound to a *literal* is propagated — `let`/`var` (reassignable)
+and non-literal initializers are left alone. See the
+`closure-pass-inline-variables` crate for the full (conservative) rules.
+
+Regenerate the expected file after an intentional behavior change:
+
+```sh
+cargo run -- --compilation_level SIMPLE \
+    --js tests/diff/simple-inline-variables/input/a.js \
+    > tests/diff/simple-inline-variables/expected.stdout
+```

--- a/code/programs/rust/closurec/tests/diff/simple-inline-variables/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/simple-inline-variables/expected.stdout
@@ -1,0 +1,1 @@
+total(base * 2);margin(3);

--- a/code/programs/rust/closurec/tests/diff/simple-inline-variables/flags.txt
+++ b/code/programs/rust/closurec/tests/diff/simple-inline-variables/flags.txt
@@ -1,0 +1,4 @@
+--compilation_level
+SIMPLE
+--js
+tests/diff/simple-inline-variables/input/a.js

--- a/code/programs/rust/closurec/tests/diff/simple-inline-variables/input/a.js
+++ b/code/programs/rust/closurec/tests/diff/simple-inline-variables/input/a.js
@@ -1,0 +1,17 @@
+// SIMPLE-level constant propagation (CLOC13.H).
+//
+// The `inline-variables` pass propagates a top-level `const` bound to a
+// literal to its use sites; remove-unused-vars then deletes the emptied
+// declaration, and the fixed-point constant-fold sweep folds the now
+// concrete arithmetic:
+//
+//   sweep 1: `RATE` (a const = 2) is propagated → `base * 2` and
+//            `2 + 1`; the `const RATE = 2;` declaration is now unused
+//            and removed by remove-unused-vars.
+//   sweep 2: constant-fold folds `2 + 1` → `3`.
+//
+// Result: `total(base * 2); margin(3);`. `base` is a free variable, so
+// `base * 2` cannot be folded further.
+const RATE = 2;
+total(base * RATE);
+margin(RATE + 1);

--- a/code/programs/rust/closurec/tests/diff_simple_inline_variables.rs
+++ b/code/programs/rust/closurec/tests/diff_simple_inline_variables.rs
@@ -1,0 +1,46 @@
+//! Integration test for the `tests/diff/simple-inline-variables/` fixture.
+//!
+//! Exercises CLOC13.H — the `inline-variables` pass propagates a
+//! top-level `const = literal` to its use sites; remove-unused-vars
+//! deletes the emptied declaration and the fixed-point constant-fold
+//! sweep folds the now-concrete arithmetic. `const RATE = 2;
+//! total(base * RATE); margin(RATE + 1);` becomes
+//! `total(base * 2); margin(3);`.
+
+use std::process::Command;
+
+const BINARY: &str = env!("CARGO_BIN_EXE_closurec");
+
+fn read_flags() -> Vec<String> {
+    let raw = std::fs::read_to_string("tests/diff/simple-inline-variables/flags.txt")
+        .expect("read flags.txt");
+    raw.lines()
+        .filter(|l| !l.is_empty())
+        .map(|s| s.to_string())
+        .collect()
+}
+
+#[test]
+fn simple_inline_variables_fixture_matches_expected_stdout() {
+    let flags = read_flags();
+    let out = Command::new(BINARY)
+        .args(&flags)
+        .output()
+        .expect("run closurec");
+
+    assert!(
+        out.status.success(),
+        "exit: {:?}, stderr: {}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stderr),
+    );
+
+    let actual = String::from_utf8_lossy(&out.stdout);
+    let expected = std::fs::read_to_string("tests/diff/simple-inline-variables/expected.stdout")
+        .expect("read expected.stdout");
+    assert_eq!(
+        actual.trim_end_matches('\n'),
+        expected.trim_end_matches('\n'),
+        "mismatch.\nflags: {flags:?}\nactual:\n{actual}\nexpected:\n{expected}",
+    );
+}


### PR DESCRIPTION
## What

A new pass crate — Closure Compiler's `InlineVariables` in miniature. It propagates a **top-level `const NAME = <literal>`** to all of its use sites, so `remove-unused-vars` deletes the now-unreferenced binding and the fixed-point `constant-fold` sweep folds the result. Wired into closurec's SIMPLE pipeline between `inline` and `remove-unused-vars`:

```js
const RATE = 2;
total(base * RATE);
margin(RATE + 1);
// closurec --compilation_level SIMPLE  ⇒  total(base * 2); margin(3);
```

The pass only propagates; it leaves the emptied `const` for `remove-unused-vars` to delete (mirrors how `inline` leaves dead functions for `treeshake`).

## Soundness

Three restrictions, plus the inline pass's whole-program **shadow guard** (the name must be declared exactly once):

1. **`const` only** — `let`/`var` can be reassigned, so the initializer isn't a safe substitute.
2. **literal value only** — immutable, no getters, safe to duplicate. `const X = y;` (could change) and `const X = o.p;` (getter) are **not** propagated.
3. **temporal-dead-zone guard** — a `const` read *before* its declaration line runs throws `ReferenceError` (even from a function called early), so propagating the literal would erase the throw. We only propagate when **every top-level item before the declaration is inert** — a function declaration (hoists, runs nothing) or a variable declaration with only literal initializers — so nothing executes and nothing can read the binding in its TDZ. Single-declarator `const`s only (an earlier sibling in `const A = f(), X = 2` could run a call first).

Single use → always propagate; multi-use → only when the literal is short (`<= MAX_MULTIUSE_LITERAL_LEN`). Self-contained name-based analysis over the Phase-1 AST.

## Changes

- **New** `closure-pass-inline-variables` `0.1.0` (Cargo/BUILD/README/CHANGELOG/required_capabilities + 24 tests: metadata + pipeline ordering + source→bridge→pass→emit roundtrips covering single/multi-use, the literal-size budget, and every rejection — let/var, non-literal value, shadowed name, property name, computed member, and the TDZ cases).
- `closurec` `0.147.0 → 0.148.0`: `SIMPLE_PASS_NAMES` gains `inline-variables` (before `remove-unused-vars`); new `tests/diff/simple-inline-variables/` fixture + harness + unit test; `simple_v2` CV `passes` assertion updated.

## Verification

- New crate: **24 passed**. Full `closurec` suite: **0 failures**.
- End-to-end: `const RATE = 2; total(base * RATE); margin(RATE + 1);` under SIMPLE → `total(base * 2);margin(3);`.
- fmt clean; clippy clean (one pre-existing `_c.clone()` test-pattern warning shared with sibling crates).
- **Security review: PASSED** — the first review found a TDZ soundness bug (propagating a `const` read before its declaration); I added the inert-prefix TDZ guard and a **follow-up review confirmed the hole is closed** and the fix introduces no new soundness/termination/panic issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)