### PR TITLE
feat(visicalc-qt): Save / Load (serialize) over the C ABI

### DIFF
--- a/demo/visicalc-qt/InfiniteSheet.qml
+++ b/demo/visicalc-qt/InfiniteSheet.qml
@@ -41,6 +41,12 @@ Item {
     // Alias it once as `doc` and use that everywhere to dodge the shadowing.
     readonly property var doc: model
 
+    // In-memory "saved file" slot for the Save / Load buttons: Save stows the
+    // serialized workbook here, Load restores from it. (A real app would write
+    // this string to a file or QSettings; the demo keeps it in memory so the
+    // round trip is self-contained.)
+    property string savedSnapshot: ""
+
     // Cell geometry (pixels). The gutter and body share rowH so their two
     // ListViews scroll in lockstep.
     readonly property int rowH: 24
@@ -126,6 +132,22 @@ Item {
                 ToolTip.visible: hovered
                 ToolTip.text: "Paste the clipboard at the selected cell, shifting relative references"
                 onClicked: if (doc) doc.paste(doc.infAddress)
+            }
+            // Save / load: serialize the whole workbook (formulas + formats) to a
+            // JSON document and restore it. The document stores only the source —
+            // computed values recompute on load, so a loaded formula stays live.
+            Button {
+                text: "Save"
+                ToolTip.visible: hovered
+                ToolTip.text: "Serialize the whole workbook to memory"
+                onClicked: if (doc) sheet.savedSnapshot = doc.serialize()
+            }
+            Button {
+                text: "Load"
+                enabled: sheet.savedSnapshot.length > 0
+                ToolTip.visible: hovered
+                ToolTip.text: "Restore the workbook from the last save"
+                onClicked: if (doc) doc.deserialize(sheet.savedSnapshot)
             }
         }
 

--- a/demo/visicalc-qt/README.md
+++ b/demo/visicalc-qt/README.md
@@ -112,6 +112,11 @@ buttons drive the engine's clipboard (`model.copy`/`cut`/`paste` over the C ABI'
 with its relative references shifted by the destination's offset (absolute `$`
 refs pinned, format carried); a cut clears the source on paste. `paste` returns a
 `bool` — false (a no-op) for an empty clipboard, malformed address, or off-grid.
+The **Save / Load** buttons serialize the whole workbook (`model.serialize` over
+the C ABI's `sc_serialize`) to a JSON document held in memory and restore it
+(`model.deserialize` / `sc_deserialize`): the document captures only the source
+(formula text + typed literals) and per-cell formats — not the computed values,
+which the engine recomputes on load, so a loaded formula stays live.
 
 The model seeds far-flung sparse cells (`Z1000`, `BA50`, `BB50`) on top of the
 budget so there's something to scroll to; the extent (`totalRows`/`totalCols`)
@@ -125,7 +130,10 @@ reachable, the gaps are empty (sparse), column letters run AA/BA, and editing
 `A1` dirties the far dependent `Z1000` via `changedSince`. A fourth case drives
 the infinite-view binding layer directly: `rowCells` returns one engine-read
 row, `selectInf` selects + clamps and loads the source, and `commitInf` edits
-`A2` 8 → 108 with every dependent recomputing (E2 → 151, A5 → 139, E5 → 269):
+`A2` 8 → 108 with every dependent recomputing (E2 → 151, A5 → 139, E5 → 269).
+Further cases cover drag-fill, clipboard copy/cut/paste, and a save/load round
+trip (serialize → mutate → restore, with the loaded formula staying live and
+malformed input rejected):
 
 ```bash
 cd test && qmake tst_window.pro && make && ./tst_window

--- a/demo/visicalc-qt/src/SpreadsheetModel.cpp
+++ b/demo/visicalc-qt/src/SpreadsheetModel.cpp
@@ -352,3 +352,29 @@ bool SpreadsheetModel::paste(const QString &dstStart) {
     }
     return applied;
 }
+
+// Save: serialize the whole workbook (source + formats) to a JSON document. The
+// host stores the returned string wherever it likes (a file, QSettings, …); the
+// engine owns no I/O. takeString frees the C string with the engine's allocator.
+QString SpreadsheetModel::serialize() const {
+    return takeString(sc_serialize(session_));
+}
+
+// Load: replace the workbook from a document produced by serialize(). Returns
+// false (workbook untouched) for malformed / unsupported input; on success the
+// formulas reload live, so we recompute the grid, regrow the extent, refresh the
+// formula bar, and bump `revision` so the visible rows re-fetch.
+bool SpreadsheetModel::deserialize(const QString &data) {
+    const QByteArray d = data.toUtf8();
+    const bool ok = sc_deserialize(session_, d.constData()) != 0;
+    if (ok) {
+        recompute();
+        computeExtent();
+        infFormula_ = rawAt(infAddress());
+        revision_++;
+        emit changed();
+        emit infSelectionChanged();
+        emit revisionChanged();
+    }
+    return ok;
+}

--- a/demo/visicalc-qt/src/SpreadsheetModel.h
+++ b/demo/visicalc-qt/src/SpreadsheetModel.h
@@ -129,6 +129,14 @@ public:
     Q_INVOKABLE void copy(const QString &start, const QString &end);
     Q_INVOKABLE void cut(const QString &start, const QString &end);
     Q_INVOKABLE bool paste(const QString &dstStart);
+    // Save / load: serialize() returns a self-contained JSON document of the
+    // workbook's SOURCE (formula text + typed literals) + per-cell formats — not
+    // the computed values, which recompute on load. deserialize() replaces the
+    // workbook from such a document: returns true on success, false for malformed
+    // / unsupported input (the workbook is left untouched), recomputes the grid,
+    // regrows the extent, and bumps `revision` so the visible rows re-fetch.
+    Q_INVOKABLE QString serialize() const;
+    Q_INVOKABLE bool deserialize(const QString &data);
 
 signals:
     // viewportRows changed (after a recompute) — QML rebinds the grid.

--- a/demo/visicalc-qt/test/tst_window.cpp
+++ b/demo/visicalc-qt/test/tst_window.cpp
@@ -24,6 +24,7 @@ private slots:
     void infiniteViewSelectEditAndRowCells();
     void fillReplicatesShiftingReferences();
     void clipboardCopyCutPaste();
+    void saveLoadRoundTrips();
 };
 
 // Helper: the display string at window (1-based) cell (row, col), given the
@@ -175,6 +176,31 @@ void TstWindow::clipboardCopyCutPaste() {
     QCOMPARE(m.window(1, 11, 1, 11).at(0).toList().at(0).toString(), QStringLiteral("99"));
     QCOMPARE(m.window(1, 1, 1, 1).at(0).toList().at(0).toString(), QString()); // A1 cleared
     QVERIFY(!m.paste("M1")); // buffer consumed
+}
+
+// Save / load (the Save / Load controls drive model.serialize/deserialize):
+// serialize the workbook, scribble over it, then restore the snapshot and
+// confirm the workbook comes back — and that a loaded formula stays LIVE.
+void TstWindow::saveLoadRoundTrips() {
+    SpreadsheetModel m;
+    // Default seed: A1=15, E1 = SUM(A1:D1) = 38 (formatted "38.00").
+    const QString snapshot = m.serialize();
+    QVERIFY2(!snapshot.isEmpty(), "serialize produced a JSON document");
+
+    // Mutate away from the saved state so a successful load has to undo it.
+    m.setCell("A1", "500"); // E1 → 500+3+12+8 = 523
+    QCOMPARE(m.window(1, 5, 1, 5).at(0).toList().at(0).toString(), QStringLiteral("523.00"));
+
+    // Restore the snapshot: E1 recomputes through its format back to "38.00".
+    QVERIFY(m.deserialize(snapshot));
+    QCOMPARE(m.window(1, 1, 1, 1).at(0).toList().at(0).toString(), QStringLiteral("15"));  // A1 restored
+    QCOMPARE(m.window(1, 5, 1, 5).at(0).toList().at(0).toString(), QStringLiteral("38.00")); // E1 formatted
+    // The loaded formula is live, not frozen: edit a precedent and E1 recomputes.
+    m.setCell("A1", "5"); // 5+3+12+8 = 28
+    QCOMPARE(m.window(1, 5, 1, 5).at(0).toList().at(0).toString(), QStringLiteral("28.00"));
+    // Garbage in is rejected (false), leaving the workbook intact.
+    QVERIFY(!m.deserialize(QStringLiteral("not a workbook")));
+    QCOMPARE(m.window(1, 5, 1, 5).at(0).toList().at(0).toString(), QStringLiteral("28.00"));
 }
 
 QTEST_MAIN(TstWindow)


### PR DESCRIPTION
## Summary

Second of the six save/load demo rollouts (web [#6161](https://github.com/adhithyan15/coding-adventures/pull/6161) merged). Adds **Save / Load** to the Qt infinite-sheet demo, driving the engine's save/load (spreadsheet-capi 0.8.0 `sc_serialize` / `sc_deserialize`) through the C ABI.

- `SpreadsheetModel` gains `Q_INVOKABLE serialize() -> QString` and `deserialize(QString) -> bool`. serialize delegates to `sc_serialize` (freed via the `takeString` allocator helper); deserialize calls `sc_deserialize` and, on success, recomputes the grid, regrows the extent, refreshes the formula bar, and bumps `revision`. Malformed/unsupported input returns false and leaves the workbook untouched.
- `InfiniteSheet.qml` gains **Save / Load** buttons next to Copy/Cut/Paste, holding the serialized document in an in-memory `savedSnapshot` slot (Load disabled until something is saved).
- The document captures only the *source* (formula text + literals) + formats — computed values recompute on load, so a loaded formula stays live.

## Test plan
- `cd test && qmake tst_window.pro && make && ./tst_window` — **9/9 PASS** (Qt 6.11). New `saveLoadRoundTrips`: serialize the seeded workbook, mutate A1 (E1 → 523.00), restore (A1 → 15, E1 → 38.00 through its format), confirm the loaded formula stays live (A1=5 ⇒ E1=28.00), and that garbage input is rejected without disturbing the workbook.
- Re-vendored `libspreadsheet_capi.a` + `spreadsheet.h` (0.8.0) into `Vendor/` (gitignored).
- `/security-review`: PASSED (named `QByteArray` local avoids the dangling-temporary hazard; C-ABI string freed once via `takeString`; null-session paths safe; deserialization non-executing).

Next in the rollout: Flutter → Compose → XAML → SwiftUI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)