### PR TITLE
feat(visicalc-flutter): Save / Load (serialize) over dart:ffi

### DIFF
--- a/demo/visicalc-flutter/README.md
+++ b/demo/visicalc-flutter/README.md
@@ -126,7 +126,12 @@ clipboard (`InfiniteSheetModel.copyCell`/`cutCell`/`pasteCell` over the C ABI's
 `sc_copy`/`sc_cut`/`sc_paste`): copy the selected cell, then paste it elsewhere
 with its relative references shifted by the destination's offset (absolute `$`
 refs pinned, format carried); a cut clears the source on paste, and `pasteCell`
-returns `false` (a no-op) for an empty clipboard. `InfiniteSheetModel`
+returns `false` (a no-op) for an empty clipboard. The **Save / Load** buttons
+serialize the whole workbook (`InfiniteSheetModel.saveBook` over the C ABI's
+`sc_serialize`) to a JSON document held in memory and restore it
+(`loadBook` / `sc_deserialize`): the document captures only the source (formula
+text + typed literals) and per-cell formats — not the computed values, which the
+engine recomputes on load, so a loaded formula stays live. `InfiniteSheetModel`
 (in `lib/engine.dart`) seeds far-flung sparse cells (`Z1000`, `BA50`, `BB50`) so
 there's something to scroll to, and derives the extent from `usedRange()` + a
 margin.
@@ -138,7 +143,9 @@ engine-computed + dense (A1=15, E1=38, E5=169), a formula 1000 rows down
 (`Z1000` = 39) is reachable, the gaps are empty (sparse), column letters run
 AA/BA, and editing `A1` dirties the far dependent `Z1000` via `changedSince`. It
 also covers `InfiniteSheetModel` directly (`rowCells` one-read rows, `selectInf`
-clamping + source load, `commitInf` recompute).
+clamping + source load, `commitInf` recompute, drag-fill, clipboard copy/cut/
+paste, and a save/load round trip — serialize → mutate → restore, with the
+loaded formula staying live and malformed input rejected).
 
 `test/infinite_grid_test.dart` is a **widget test** that pumps the real
 `InfiniteGrid` tree on the live engine, taps the A1 cell, edits `15`→`115` in the

--- a/demo/visicalc-flutter/lib/engine.dart
+++ b/demo/visicalc-flutter/lib/engine.dart
@@ -96,6 +96,11 @@ class SpreadsheetSession {
   late final _ClipD _copyFn;
   late final _ClipD _cutFn;
   late final _PasteD _pasteFn;
+  // Save / load: sc_serialize(session) → char* (same shape as the no-arg reads);
+  // sc_deserialize(session, data) → int (same shape as sc_paste: session + one
+  // string → 1/0).
+  late final _NoArgD _serializeFn;
+  late final _PasteD _deserializeFn;
   late final _NoArgD _usedRangeFn;
   late final _ColLettersD _columnLettersFn;
   late final _CurrentRevD _currentRevisionFn;
@@ -119,6 +124,8 @@ class SpreadsheetSession {
     _copyFn = _lib.lookupFunction<_ClipC, _ClipD>('sc_copy');
     _cutFn = _lib.lookupFunction<_ClipC, _ClipD>('sc_cut');
     _pasteFn = _lib.lookupFunction<_PasteC, _PasteD>('sc_paste');
+    _serializeFn = _lib.lookupFunction<_NoArgC, _NoArgD>('sc_serialize');
+    _deserializeFn = _lib.lookupFunction<_PasteC, _PasteD>('sc_deserialize');
     _usedRangeFn = _lib.lookupFunction<_NoArgC, _NoArgD>('sc_used_range');
     _columnLettersFn = _lib.lookupFunction<_ColLettersC, _ColLettersD>('sc_column_letters');
     _currentRevisionFn = _lib.lookupFunction<_CurrentRevC, _CurrentRevD>('sc_current_revision');
@@ -321,6 +328,25 @@ class SpreadsheetSession {
       return _pasteFn(_handle, dstPtr) != 0;
     } finally {
       _freeCString(dstPtr);
+    }
+  }
+
+  /// Serialize the whole workbook to a self-contained JSON document — the
+  /// SOURCE (formula text + typed literals) + per-cell formats, not the computed
+  /// values (those recompute on load, so the document is small and can't disagree
+  /// with itself). The engine owns no I/O; the host persists the returned string
+  /// wherever it likes. (`_takeString` frees the engine's char* allocation.)
+  String serialize() => _takeString(_serializeFn(_handle));
+
+  /// Replace the workbook from a document produced by [serialize]. Returns `true`
+  /// on success, `false` for malformed / unsupported input (the workbook is left
+  /// untouched — the engine validates before it mutates). Formulas reload live.
+  bool deserialize(String data) {
+    final dataPtr = _toCString(data);
+    try {
+      return _deserializeFn(_handle, dataPtr) != 0;
+    } finally {
+      _freeCString(dataPtr);
     }
   }
 
@@ -567,6 +593,21 @@ class InfiniteSheetModel {
   bool pasteCell() {
     final ok = _session.paste(infAddress);
     if (ok) computeExtent();
+    return ok;
+  }
+
+  /// Save / load: serialize the whole workbook to a JSON document, and restore
+  /// it. The document stores only the source + formats — computed values
+  /// recompute on load, so a loaded formula stays live. [loadBook] returns false
+  /// (workbook untouched) for malformed input; on success it regrows the extent
+  /// and refreshes the formula bar so the view re-reads.
+  String saveBook() => _session.serialize();
+  bool loadBook(String data) {
+    final ok = _session.deserialize(data);
+    if (ok) {
+      computeExtent();
+      formula = _session.getRaw(infAddress);
+    }
     return ok;
   }
 }

--- a/demo/visicalc-flutter/lib/infinite_grid.dart
+++ b/demo/visicalc-flutter/lib/infinite_grid.dart
@@ -65,6 +65,11 @@ class _InfiniteGridState extends State<InfiniteGrid> {
 
   final _formulaCtrl = TextEditingController();
 
+  // In-memory "saved file" slot for the Save / Load buttons: Save stows the
+  // serialized workbook here, Load restores from it. (A real app would write
+  // this string to a file; the demo keeps the round trip self-contained.)
+  String _savedSnapshot = '';
+
   @override
   void initState() {
     super.initState();
@@ -120,6 +125,18 @@ class _InfiniteGridState extends State<InfiniteGrid> {
   void _copy() => _model.copyCell();
   void _cut() => _model.cutCell();
   void _paste() => setState(() => _model.pasteCell());
+
+  // Save / load: serialize the whole workbook (formulas + formats) to a JSON
+  // document held in memory, and restore it. Computed values recompute on load,
+  // so a loaded formula stays live; the formula bar re-reads after a load.
+  void _save() => setState(() => _savedSnapshot = _model.saveBook());
+  void _load() {
+    if (_savedSnapshot.isEmpty) return;
+    setState(() {
+      _model.loadBook(_savedSnapshot);
+      _formulaCtrl.text = _model.formula;
+    });
+  }
 
   // A compact outlined button for the clipboard controls, matching "Fill ↓ 10".
   Widget _clipButton(String label, String tip, VoidCallback onPressed) {
@@ -201,6 +218,11 @@ class _InfiniteGridState extends State<InfiniteGrid> {
           _clipButton('Cut', 'Cut the selected cell (cleared when you paste)', _cut),
           const SizedBox(width: 8),
           _clipButton('Paste', 'Paste the clipboard at the selected cell, shifting relative references', _paste),
+          const SizedBox(width: 8),
+          // Save / load: serialize the whole workbook to memory, and restore it.
+          _clipButton('Save', 'Serialize the whole workbook to memory', _save),
+          const SizedBox(width: 8),
+          _clipButton('Load', 'Restore the workbook from the last save', _load),
         ],
       ),
     );

--- a/demo/visicalc-flutter/test/window_test.dart
+++ b/demo/visicalc-flutter/test/window_test.dart
@@ -154,5 +154,26 @@ void main() {
       expect(m.rowCells(1)[0], ''); // A1 cleared
       m.selectInf(1, 5); expect(m.pasteCell(), isFalse); // buffer consumed
     });
+
+    test('saveBook/loadBook round trips and keeps formulas live', () {
+      final m = InfiniteSheetModel();
+      addTearDown(m.dispose);
+      // Default seed: A1=15, E1 = SUM(A1:D1) = 38 (formatted "38.00").
+      final snapshot = m.saveBook();
+      expect(snapshot, isNotEmpty);
+      // Mutate away from the saved state so a load has to visibly undo it.
+      m.selectInf(1, 1); m.commitInf('500'); // E1 → 500+3+12+8 = 523
+      expect(m.rowCells(1)[4], '523.00');
+      // Restore: A1 → 15, E1 recomputes through its format back to "38.00".
+      expect(m.loadBook(snapshot), isTrue);
+      expect(m.rowCells(1)[0], '15');
+      expect(m.rowCells(1)[4], '38.00');
+      // The loaded formula is live, not frozen: edit a precedent and E1 recomputes.
+      m.selectInf(1, 1); m.commitInf('5'); // 5+3+12+8 = 28
+      expect(m.rowCells(1)[4], '28.00');
+      // Garbage in is rejected (false), leaving the workbook intact.
+      expect(m.loadBook('not a workbook'), isFalse);
+      expect(m.rowCells(1)[4], '28.00');
+    });
   });
 }


### PR DESCRIPTION
## Summary

Third of the six save/load demo rollouts (web [#6161](https://github.com/adhithyan15/coding-adventures/pull/6161), Qt [#6163](https://github.com/adhithyan15/coding-adventures/pull/6163) merged). Adds **Save / Load** to the Flutter infinite-sheet demo, driving the engine's save/load (spreadsheet-capi 0.8.0 `sc_serialize` / `sc_deserialize`) over `dart:ffi`.

- `SpreadsheetSession.serialize() -> String` (reads `sc_serialize`'s `char*` via the existing `_takeString` helper, freed with `sc_string_free`) and `deserialize(String) -> bool` (`sc_deserialize`; reuses the `_NoArg`/`_Paste` FFI typedefs — signatures match). Malformed/unsupported input returns false and leaves the workbook untouched.
- `InfiniteSheetModel.saveBook()` / `loadBook(data)`: loadBook regrows the extent and refreshes the formula bar on success.
- `infinite_grid.dart` gains **Save / Load** buttons next to Copy/Cut/Paste, holding the serialized document in an in-memory `_savedSnapshot` slot.
- The document stores only the *source* + formats; computed values recompute on load, so a loaded formula stays live.

## Test plan
- `flutter test test/window_test.dart` — **10/10 PASS**. New `saveBook/loadBook` round trip: serialize the seeded workbook, mutate A1 (E1 → 523.00), restore (A1 → 15, E1 → 38.00 through its format), confirm the loaded formula stays live (A1=5 ⇒ E1=28.00), garbage rejected.
- `flutter analyze lib/` — clean.
- Re-vendored `libspreadsheet_capi.dylib` (0.8.0) into `native/` (gitignored).
- `/security-review`: PASSED (no native-memory leaks; malloc'd string freed in `finally`; engine `char*` freed via `_takeString`; null-session-safe).

⚠️ Note: two **pre-existing** failures in `test/infinite_grid_test.dart` (asserting unformatted `"38"`/`"138"` the grid no longer paints after the display-formatting campaign) are unrelated to this change — they fail on `origin/main` too. Flagged for a separate test-only fix.

Next in the rollout: Compose → XAML → SwiftUI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)