### PR TITLE
feat(mycin-train): eval_decompose --model mode — score a fine-tune's decompose fidelity end-to-end

### DIFF
--- a/code/specs/data/mycin-2026/train/README.md
+++ b/code/specs/data/mycin-2026/train/README.md
@@ -91,12 +91,21 @@ faithfulness is measurable without re-running the model.
 
 A held-out benchmark to score against: **`decompose_eval.jsonl`** — a small, HAND-CURATED set of
 prose vignettes + gold IR across both shapes and the hard cases (near-miss family-history /
-absence / efficacy / hedge, and honest abstain). `eval_decompose.py` scores a model's predictions
-against it (`--pred predictions.jsonl`) and reports the aggregate; `--self-check` scores the gold
-as the prediction (a perfect 1.0 / zero violations — the offline CI sanity check). The set is
-curated, not teacher-generated, so it stays a stable benchmark; `test_eval_decompose.py` pins that
-every gold span is verbatim, every chart-fact is COP-consumable, every near-miss is a discard, and
-the set + scorer compose to a perfect self-check.
+absence / efficacy / hedge, and honest abstain). `eval_decompose.py` scores a model three ways:
+`--model <path> [--adapter ...]` runs an MLX model (base or base+LoRA) as the decomposer over the
+eval notes — using the SAME prompts the training data was generated under (so train and eval
+match) — parses its JSON, and reports the fidelity aggregate; `--pred predictions.jsonl` scores
+pre-computed predictions; `--self-check` scores the gold as the prediction (a perfect 1.0 / zero
+violations — the offline CI sanity check). The set is curated, not teacher-generated, so it stays
+a stable benchmark. `test_eval_decompose.py` pins that every gold span is verbatim, every
+chart-fact is COP-consumable, every near-miss is a discard, the set + scorer compose to a perfect
+self-check, AND the `--model` wiring (prompt → generate → parse → score) is correct end-to-end via
+an injected stub generator — so the whole path is verified without needing MLX in CI.
+
+```sh
+# score a fine-tune's decompose FIDELITY directly (facts/spans/discards/near-misses):
+python3 eval_decompose.py --model mlx-community/gemma-3-1b-it-4bit --adapter adapters
+```
 
 ## Result
 

--- a/code/specs/data/mycin-2026/train/eval_decompose.py
+++ b/code/specs/data/mycin-2026/train/eval_decompose.py
@@ -60,21 +60,77 @@ def score_predictions(records: list[dict], predictions: dict[str, dict]) -> tupl
     return rows, ds.aggregate(scores)
 
 
+def parse_ir(raw: str) -> dict:
+    """Extract the first JSON object from a model's raw decode (it may wrap the JSON in prose or
+    code fences). Returns {} if nothing parses — scored as an empty IR (penalized, never crashes)."""
+    i, j = raw.find("{"), raw.rfind("}")
+    if i == -1 or j <= i:
+        return {}
+    try:
+        return json.loads(raw[i:j + 1])
+    except (ValueError, TypeError):
+        return {}
+
+
+def build_prompt(rec: dict, dictionary: dict) -> str:
+    """The shape-appropriate decompose prompt the model is asked — the SAME prompts the training
+    data was generated under (gen_chart_data for chart-facts; warm/decompose for findings), so the
+    eval matches training. Imported lazily so the offline path pulls no heavy modules."""
+    if rec["shape"] == "chart_facts":
+        import gen_chart_data  # noqa: PLC0415
+        return gen_chart_data.prompt_for_chart(rec["note"])
+    warm = str(HERE.parent / "warm")
+    if warm not in sys.path:
+        sys.path.insert(0, warm)
+    import decompose  # noqa: PLC0415
+    return decompose.prompt_for(rec["note"], dictionary)
+
+
+def predict_with_model(records: list[dict], gen, dictionary: dict) -> dict[str, dict]:
+    """Run a text-generation `gen(prompt) -> str` (an MLX model, or a test stub) over each eval
+    note and parse its output into a predicted IR keyed by id. `gen` is the only dependency, so
+    the model is fully injectable and this is unit-testable without MLX."""
+    return {rec["id"]: parse_ir(gen(build_prompt(rec, dictionary))) for rec in records}
+
+
+def _mlx_gen(model_path: str, adapter: str | None):
+    """Lazy MLX text generator (mirrors eval_specialist.mlx_generate_fn) — imported only when a
+    --model run is requested, so importing this module stays dependency-free for the offline path."""
+    from mlx_lm import generate, load  # noqa: PLC0415
+    from mlx_lm.sample_utils import make_sampler  # noqa: PLC0415
+    model, tok = load(model_path, adapter_path=adapter)
+    sampler = make_sampler(temp=0.0)  # greedy / deterministic
+
+    def gen(prompt: str) -> str:
+        text = tok.apply_chat_template([{"role": "user", "content": prompt}],
+                                       add_generation_prompt=True)
+        out = generate(model, tok, prompt=text, max_tokens=512, sampler=sampler, verbose=False)
+        for stop in ("<end_of_turn>", "<eos>", "<pad>", "<start_of_turn>"):
+            out = out.split(stop)[0]
+        return out.strip()
+    return gen
+
+
 def main() -> int:
     ap = argparse.ArgumentParser()
     ap.add_argument("--self-check", action="store_true",
                     help="score the gold as the prediction (must be perfect); offline sanity check")
     ap.add_argument("--pred", type=Path, help="JSONL of model predictions keyed by eval id")
+    ap.add_argument("--model", help="run this MLX model as the decomposer over the eval notes")
+    ap.add_argument("--adapter", default=None, help="optional LoRA adapter path for --model")
     args = ap.parse_args()
 
     records = load_eval()
     if args.self_check:
         predictions = {r["id"]: r["gold"] for r in records}
+    elif args.model:
+        dictionary = json.loads((HERE.parent / "warm" / "dictionary.json").read_text())
+        predictions = predict_with_model(records, _mlx_gen(args.model, args.adapter), dictionary)
     elif args.pred:
         predictions = {p["id"]: p for p in
                        (json.loads(line) for line in args.pred.read_text().splitlines() if line.strip())}
     else:
-        print("eval_decompose: pass --self-check or --pred <file>", file=sys.stderr)
+        print("eval_decompose: pass --self-check, --model <path>, or --pred <file>", file=sys.stderr)
         return 2
 
     rows, agg = score_predictions(records, predictions)

--- a/code/specs/data/mycin-2026/train/test_eval_decompose.py
+++ b/code/specs/data/mycin-2026/train/test_eval_decompose.py
@@ -93,6 +93,43 @@ def test_a_near_miss_prediction_is_caught_by_the_eval():
     assert s["near_miss_violations"] == 1 and s["false_positive_facts"] == 1, s
 
 
+def test_parse_ir_extracts_json_from_noisy_output():
+    # The model may wrap its JSON in prose / code fences; parse_ir pulls the first object out.
+    assert ed.parse_ir('Sure! ```json\n{"chart_facts": [], "discard": []}\n``` done')["chart_facts"] == []
+    assert ed.parse_ir("no json here") == {}  # garbage → empty IR (penalized, never crashes)
+    assert ed.parse_ir('{"findings": [{"functor": "fever"}]}')["findings"][0]["functor"] == "fever"
+
+
+def test_model_mode_wiring_scores_a_stub_generator_perfectly():
+    # The --model path is exercised end-to-end WITHOUT MLX via an injected `gen`: the stub finds
+    # which eval note is in the prompt and returns that record's gold as JSON. predict_with_model
+    # builds the (shape-correct) prompt, calls gen, parses, and scores → a perfect self-equivalent
+    # run. This pins the prompt-build → generate → parse → score wiring offline.
+    import json as _json
+    dictionary = _json.loads((ed.HERE.parent / "warm" / "dictionary.json").read_text())
+
+    def stub_gen(prompt: str) -> str:
+        rec = next(r for r in RECORDS if r["note"] in prompt)
+        return "model says: " + _json.dumps(rec["gold"])  # prose wrapper exercises parse_ir too
+
+    preds = ed.predict_with_model(RECORDS, stub_gen, dictionary)
+    assert set(preds) == {r["id"] for r in RECORDS}
+    _, agg = ed.score_predictions(RECORDS, preds)
+    assert agg["fact_f1"] == 1.0 and agg["span_faithfulness"] == 1.0
+    assert agg["near_miss_violations"] == 0 and agg["false_positive_facts"] == 0
+
+
+def test_build_prompt_is_shape_appropriate_and_contains_the_note():
+    cf = next(r for r in RECORDS if r["shape"] == "chart_facts")
+    fnd = next(r for r in RECORDS if r["shape"] == "findings")
+    import json as _json
+    dictionary = _json.loads((ed.HERE.parent / "warm" / "dictionary.json").read_text())
+    p_cf = ed.build_prompt(cf, dictionary)
+    p_fnd = ed.build_prompt(fnd, dictionary)
+    assert cf["note"] in p_cf and "chart" in p_cf.lower()
+    assert fnd["note"] in p_fnd and "finding" in p_fnd.lower()
+
+
 def main() -> int:
     tests = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
     failed = 0


### PR DESCRIPTION
## What

Capstone of the decomposer **train → measure → eval** loop: makes the held-out eval set ([#6165](https://github.com/adhithyan15/coding-adventures/pull/6165)) + the fidelity scorer ([#6160](https://github.com/adhithyan15/coding-adventures/pull/6160)) **runnable against an actual model in one command**, so a Gemma/Qwen fine-tune's faithfulness (facts/spans/discards/near-misses) is measured *directly* — not only via the downstream-diagnosis proxy (`eval_specialist`) or pre-computed predictions.

## How

`eval_decompose.py` gains **`--model <path> [--adapter <path>]`**: for each held-out note it builds the **shape-appropriate** decompose prompt (the *same* prompts training was generated under — `gen_chart_data.prompt_for_chart` for chart-facts, `warm/decompose.prompt_for` for findings, so train and eval match), runs an MLX model (lazy import; greedy/deterministic, mirrors `eval_specialist.mlx_generate_fn`), parses the JSON, and scores via `decompose_score` + `aggregate`. New helpers:
- `parse_ir(raw)` — pulls the first `{...}` object out of a model decode (prose/code-fence tolerant); garbage → `{}` (scored as empty IR, never crashes);
- `build_prompt(rec, dictionary)` — per-shape prompt (lazy imports, so the offline path stays dependency-free);
- `predict_with_model(records, gen, dictionary)` — `gen` is the **only** dependency → fully injectable.

## Why it's safe to land without MLX in CI

The model run is the caller's local step; the **wiring is unit-tested offline with an injected stub generator** (no MLX): the stub returns each note's gold as JSON, and the prompt → generate → parse → score path scores a perfect 1.0. Plus tests for `parse_ir` robustness and shape-appropriate prompts.

**9/9 `test_eval_decompose` tests pass; `--self-check` still perfect; `ruff` clean; `/security-review` PASSED** (model output flows only into `json.loads`; no shell/exec/network/writes; operator names their own model).

## Scope

No engine/package change, no version bump (the MLX dep is lazy + caller-side). Completes the decomposer faithfulness toolchain: **train data → fidelity scorer → held-out benchmark → one-command model fidelity eval.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)