### PR TITLE
Expose deck run output probe names

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ### Added
 
+- **Deck run output-probe artifact names** —
+  `run_deck_analysis()` selected-run artifacts now include the normalized
+  output-probe names alongside the output-probe count, and
+  `format_deck_run_artifact_table()` renders a stable `OutputProbeList`
+  column, matching Rust and TypeScript.
+
 - **Deck control variable policy diagnostics** —
   `analyze_deck_controls()` and `resolve_deck_sources()` now emit explicit
   policy diagnostics for selected `.control` block variable/state mutation

--- a/code/packages/python/spice-engine/README.md
+++ b/code/packages/python/spice-engine/README.md
@@ -65,7 +65,7 @@ print(result.diagnostics.solver)   # "dense_real" or "sparse_real"
 | `fourier` | `.FOUR` | Harmonic magnitudes/phases and THD from transient output |
 | `format_dc_table`, `format_transient_table` | `.PRINT` / `.PLOT` output | Stable tabular node voltages and branch currents |
 | `resolve_deck_outputs`, `format_deck_*_table` | `.SAVE` / `.PROBE` / `.PRINT` / `.PLOT` output | Parsed deck-selected OP, DC sweep, AC, and transient tables |
-| `format_deck_run_artifact_table` | Deck execution artifact | Stable selected-run row, output-probe, measurement, and Fourier counts |
+| `format_deck_run_artifact_table` | Deck execution artifact | Stable selected-run row, output-probe count/name list, measurement, and Fourier counts |
 | `measure_transient_probe`, `measure_dc_sweep_probe`, `measure_ac_sweep_probe`, `format_measurement_table` | `.MEASURE` output | Stable scalar transient, DC sweep, and AC sweep probe measurements |
 
 `diode_at_temperature()`, `bjt_at_temperature()`, `mosfet_at_temperature()`,
@@ -109,7 +109,7 @@ stable measurement table for `.dc`, `.ac`, and `.tran` executions. Selected
 `.tran` plans also return selected `.four` harmonic results and a stable
 Fourier table. Executions also include a selected-run artifact summary plus
 `format_deck_run_artifact_table()` output for stable result-row,
-output-probe, measurement, and Fourier counts. They route `START` output
+output-probe count/name list, measurement, and Fourier counts. They route `START` output
 filtering, use `.tran TSTEP` as the output print grid, apply `MAXSTEP` as an
 internal fixed-step cap, and carry `UIC` initial-condition intent through that
 stable transient table surface.
@@ -218,8 +218,9 @@ downstream deck execution helpers.
 `run_deck_analysis()` routes that selected plan into the matching solver and
 stable deck-selected table output with normalized output-probe artifacts,
 selected measurement artifacts, selected transient Fourier artifacts,
-selected-run artifact summaries, `.ac LIN`, `.ac DEC`, `.ac OCT` frequency
-grids, and `.tran` `START` / print-step `TSTEP` / `MAXSTEP` / `UIC` controls.
+selected-run artifact summaries with output-probe name lists, `.ac LIN`,
+`.ac DEC`, `.ac OCT` frequency grids, and `.tran` `START` / print-step
+`TSTEP` / `MAXSTEP` / `UIC` controls.
 
 ## Controlled source examples
 

--- a/code/packages/python/spice-engine/src/spice_engine/engine.py
+++ b/code/packages/python/spice-engine/src/spice_engine/engine.py
@@ -2302,6 +2302,7 @@ class DeckRunArtifact:
     line_number: int
     result_rows: int
     output_probe_count: int
+    output_probes: list[str]
     measurement_count: int
     fourier_count: int
 
@@ -2375,6 +2376,7 @@ def _deck_run_artifacts(
             line_number=plan.line_number,
             result_rows=_deck_result_row_count(result),
             output_probe_count=len(output_probes),
+            output_probes=list(output_probes),
             measurement_count=len(measurements),
             fourier_count=len(fourier),
         )
@@ -2382,10 +2384,10 @@ def _deck_run_artifacts(
 
 
 def format_deck_run_artifact_table(artifacts: Iterable[DeckRunArtifact]) -> str:
-    """Format selected deck-run artifacts as a stable count summary table."""
+    """Format selected deck-run artifacts as a stable summary table."""
 
     rows = [
-        "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tMeasurements\tFourier"
+        "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tOutputProbeList\tMeasurements\tFourier"
     ]
     for artifact in artifacts:
         rows.append(
@@ -2396,6 +2398,7 @@ def format_deck_run_artifact_table(artifacts: Iterable[DeckRunArtifact]) -> str:
                     str(artifact.line_number),
                     str(artifact.result_rows),
                     str(artifact.output_probe_count),
+                    ";".join(artifact.output_probes),
                     str(artifact.measurement_count),
                     str(artifact.fourier_count),
                 ]

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -6791,9 +6791,10 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
     assert op_execution.measurement_table == "Name\tAnalysis\tProbe\tMode\tFrom\tTo\tValue\n"
     assert op_execution.table == "Index\tV(mid)\n0\t5.000000e-01\n"
     assert op_execution.run_artifacts[0].result_rows == 1
+    assert op_execution.run_artifacts[0].output_probes == ["V(mid)"]
     assert op_execution.run_artifact_table == (
-        "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tMeasurements\tFourier\n"
-        f"op\t.op\t{op_execution.plan.line_number}\t1\t1\t0\t0\n"
+        "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tOutputProbeList\tMeasurements\tFourier\n"
+        f"op\t.op\t{op_execution.plan.line_number}\t1\t1\tV(mid)\t0\t0\n"
     )
 
     dc_execution = run_deck_analysis(circuit, netlist, "dc")
@@ -6812,9 +6813,10 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
         "1\tV1\t1.000000e+00\t5.000000e-01\t-5.000000e-04\n"
     )
     assert dc_execution.run_artifacts[0].analysis == "dc"
+    assert dc_execution.run_artifacts[0].output_probes == ["V(mid)", "I(V1)"]
     assert dc_execution.run_artifact_table == (
-        "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tMeasurements\tFourier\n"
-        f"dc\t.dc\t{dc_execution.plan.line_number}\t2\t2\t1\t0\n"
+        "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tOutputProbeList\tMeasurements\tFourier\n"
+        f"dc\t.dc\t{dc_execution.plan.line_number}\t2\t2\tV(mid);I(V1)\t1\t0\n"
     )
 
     ac_execution = run_deck_analysis(circuit, netlist, "ac")
@@ -6830,9 +6832,10 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
         "Index\tFrequency\tProbe\tReal\tImaginary\tMagnitude\tPhase\n"
         "0\t1.000000e+03\tV(mid)\t5.000000e-01\t0.000000e+00\t5.000000e-01\t0.000000e+00\n"
     )
+    assert ac_execution.run_artifacts[0].output_probes == ["V(mid)"]
     assert ac_execution.run_artifact_table == (
-        "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tMeasurements\tFourier\n"
-        f"ac\t.ac\t{ac_execution.plan.line_number}\t1\t1\t1\t0\n"
+        "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tOutputProbeList\tMeasurements\tFourier\n"
+        f"ac\t.ac\t{ac_execution.plan.line_number}\t1\t1\tV(mid)\t1\t0\n"
     )
 
     tran_execution = run_deck_analysis(circuit, netlist, "tran")
@@ -6850,9 +6853,10 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
         "0\t0.000000e+00\t5.000000e-01\n"
         "1\t1.000000e-03\t5.000000e-01\n"
     )
+    assert tran_execution.run_artifacts[0].output_probes == ["V(mid)"]
     assert tran_execution.run_artifact_table == (
-        "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tMeasurements\tFourier\n"
-        f"tran\t.tran\t{tran_execution.plan.line_number}\t2\t1\t1\t0\n"
+        "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tOutputProbeList\tMeasurements\tFourier\n"
+        f"tran\t.tran\t{tran_execution.plan.line_number}\t2\t1\tV(mid)\t1\t0\n"
     )
 
     tran_window_execution = run_deck_analysis(
@@ -6926,9 +6930,10 @@ def test_run_deck_analysis_exposes_selected_fourier_artifacts() -> None:
     assert len(result.probes[0].harmonics) == 1
     assert tran_execution.fourier_table == format_fourier_table(result)
     assert tran_execution.run_artifacts[0].fourier_count == 1
+    assert tran_execution.run_artifacts[0].output_probes == ["V(mid)"]
     assert tran_execution.run_artifact_table == (
-        "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tMeasurements\tFourier\n"
-        f"tran\t.tran\t{tran_execution.plan.line_number}\t3\t1\t0\t1\n"
+        "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tOutputProbeList\tMeasurements\tFourier\n"
+        f"tran\t.tran\t{tran_execution.plan.line_number}\t3\t1\tV(mid)\t0\t1\n"
     )
 
 

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Add normalized output-probe names to selected-run artifacts in
+  `run_deck_analysis` and render them in a stable `OutputProbeList` column
+  from `format_deck_run_artifact_table`, matching Python and TypeScript.
 - Emit explicit policy diagnostics for selected `.control` block
   variable/state mutation commands, including `let`, `alter`, `alterparam`,
   `set`, and `unset`, in `analyze_deck_controls` and `resolve_deck_sources`,

--- a/code/packages/rust/spice-engine/README.md
+++ b/code/packages/rust/spice-engine/README.md
@@ -183,7 +183,7 @@ an internal fixed-step cap, and `UIC` initial-condition intent through that
 stable transient table surface. They also return selected `.four` harmonic
 results and a stable Fourier table. Executions also include selected-run
 artifact summaries plus `format_deck_run_artifact_table` output for stable
-result-row, output-probe, measurement, and Fourier counts.
+result-row, output-probe count/name list, measurement, and Fourier counts.
 `resolve_deck_fourier`, `fourier_transient_cards`,
 `fourier_transient_deck`, and `format_deck_fourier_table` extract parsed
 `.four` / `.FOUR` cards before `.end` and route transient samples into the
@@ -228,5 +228,6 @@ downstream deck execution helpers.
 `run_deck_analysis` routes that selected plan into the matching solver and
 stable deck-selected table output with normalized output-probe artifacts,
 selected measurement artifacts, selected transient Fourier artifacts,
-selected-run artifact summaries, `.ac LIN`, `.ac DEC`, `.ac OCT` frequency
-grids, and `.tran` `START` / print-step `TSTEP` / `MAXSTEP` / `UIC` controls.
+selected-run artifact summaries with output-probe name lists, `.ac LIN`,
+`.ac DEC`, `.ac OCT` frequency grids, and `.tran` `START` / print-step
+`TSTEP` / `MAXSTEP` / `UIC` controls.

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -3405,6 +3405,7 @@ pub struct DeckRunArtifact {
     pub line_number: usize,
     pub result_rows: usize,
     pub output_probe_count: usize,
+    pub output_probes: Vec<String>,
     pub measurement_count: usize,
     pub fourier_count: usize,
 }
@@ -9795,6 +9796,7 @@ fn deck_run_artifacts(
         line_number: plan.line_number,
         result_rows,
         output_probe_count: output_probes.len(),
+        output_probes: output_probes.to_vec(),
         measurement_count: measurements.len(),
         fourier_count: fourier.len(),
     }]
@@ -9802,16 +9804,18 @@ fn deck_run_artifacts(
 
 pub fn format_deck_run_artifact_table(artifacts: &[DeckRunArtifact]) -> String {
     let mut rows = vec![
-        "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tMeasurements\tFourier".to_string(),
+        "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tOutputProbeList\tMeasurements\tFourier"
+            .to_string(),
     ];
     for artifact in artifacts {
         rows.push(format!(
-            "{}\t{}\t{}\t{}\t{}\t{}\t{}",
+            "{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}",
             artifact.analysis,
             artifact.directive,
             artifact.line_number,
             artifact.result_rows,
             artifact.output_probe_count,
+            artifact.output_probes.join(";"),
             artifact.measurement_count,
             artifact.fourier_count
         ));

--- a/code/packages/rust/spice-engine/tests/transient_tests.rs
+++ b/code/packages/rust/spice-engine/tests/transient_tests.rs
@@ -1885,9 +1885,13 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
     assert_eq!(op_execution.table, "Index\tV(mid)\n0\t5.000000e-01\n");
     assert_eq!(op_execution.run_artifacts[0].result_rows, 1);
     assert_eq!(
+        op_execution.run_artifacts[0].output_probes,
+        vec!["V(mid)".to_string()]
+    );
+    assert_eq!(
         op_execution.run_artifact_table,
         format!(
-            "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tMeasurements\tFourier\nop\t.op\t{}\t1\t1\t0\t0\n",
+            "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tOutputProbeList\tMeasurements\tFourier\nop\t.op\t{}\t1\t1\tV(mid)\t0\t0\n",
             op_execution.plan.line_number
         )
     );
@@ -1913,9 +1917,13 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
     );
     assert_eq!(dc_execution.run_artifacts[0].analysis, "dc");
     assert_eq!(
+        dc_execution.run_artifacts[0].output_probes,
+        vec!["V(mid)".to_string(), "I(V1)".to_string()]
+    );
+    assert_eq!(
         dc_execution.run_artifact_table,
         format!(
-            "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tMeasurements\tFourier\ndc\t.dc\t{}\t2\t2\t1\t0\n",
+            "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tOutputProbeList\tMeasurements\tFourier\ndc\t.dc\t{}\t2\t2\tV(mid);I(V1)\t1\t0\n",
             dc_execution.plan.line_number
         )
     );
@@ -1936,9 +1944,13 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
         "Index\tFrequency\tProbe\tReal\tImaginary\tMagnitude\tPhase\n0\t1.000000e+03\tV(mid)\t5.000000e-01\t0.000000e+00\t5.000000e-01\t0.000000e+00\n"
     );
     assert_eq!(
+        ac_execution.run_artifacts[0].output_probes,
+        vec!["V(mid)".to_string()]
+    );
+    assert_eq!(
         ac_execution.run_artifact_table,
         format!(
-            "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tMeasurements\tFourier\nac\t.ac\t{}\t1\t1\t1\t0\n",
+            "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tOutputProbeList\tMeasurements\tFourier\nac\t.ac\t{}\t1\t1\tV(mid)\t1\t0\n",
             ac_execution.plan.line_number
         )
     );
@@ -1959,9 +1971,13 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
         "Index\tTime\tV(mid)\n0\t1.000000e-03\t5.000000e-01\n"
     );
     assert_eq!(
+        tran_execution.run_artifacts[0].output_probes,
+        vec!["V(mid)".to_string()]
+    );
+    assert_eq!(
         tran_execution.run_artifact_table,
         format!(
-            "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tMeasurements\tFourier\ntran\t.tran\t{}\t1\t1\t1\t0\n",
+            "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tOutputProbeList\tMeasurements\tFourier\ntran\t.tran\t{}\t1\t1\tV(mid)\t1\t0\n",
             tran_execution.plan.line_number
         )
     );
@@ -2065,9 +2081,13 @@ fn run_deck_analysis_exposes_selected_fourier_artifacts() {
     assert_eq!(tran_execution.fourier_table, format_fourier_table(result));
     assert_eq!(tran_execution.run_artifacts[0].fourier_count, 1);
     assert_eq!(
+        tran_execution.run_artifacts[0].output_probes,
+        vec!["V(mid)".to_string()]
+    );
+    assert_eq!(
         tran_execution.run_artifact_table,
         format!(
-            "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tMeasurements\tFourier\ntran\t.tran\t{}\t2\t1\t0\t1\n",
+            "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tOutputProbeList\tMeasurements\tFourier\ntran\t.tran\t{}\t2\t1\tV(mid)\t0\t1\n",
             tran_execution.plan.line_number
         )
     );

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Add normalized output-probe names to selected-run artifacts in
+  `runDeckAnalysis` and render them in a stable `OutputProbeList` column from
+  `formatDeckRunArtifactTable`, matching Python and Rust.
 - Emit explicit policy diagnostics for selected `.control` block
   variable/state mutation commands, including `let`, `alter`, `alterparam`,
   `set`, and `unset`, in `analyzeDeckControls` and `resolveDeckSources`,

--- a/code/packages/typescript/spice-engine/README.md
+++ b/code/packages/typescript/spice-engine/README.md
@@ -99,7 +99,7 @@ an internal fixed-step cap, and `UIC` initial-condition intent through that
 stable transient table surface. They also return selected `.four` harmonic
 results and a stable Fourier table. Executions also include selected-run
 artifact summaries plus `formatDeckRunArtifactTable` output for stable
-result-row, output-probe, measurement, and Fourier counts.
+result-row, output-probe count/name list, measurement, and Fourier counts.
 `resolveDeckOutputs` and `selectDeckOutputProbes` extract `.save`, scoped or
 global `.probe`, scoped `.print <analysis> ...`, and scoped
 `.plot <analysis> ...` cards before `.end`, normalize and deduplicate output
@@ -192,5 +192,6 @@ deck execution helpers.
 `runDeckAnalysis` routes that selected plan into the matching solver and stable
 deck-selected table output with normalized output-probe artifacts, selected
 measurement artifacts, selected transient Fourier artifacts, selected-run
-artifact summaries, `.ac LIN`, `.ac DEC`, `.ac OCT` frequency grids, and
-`.tran` `START` / print-step `TSTEP` / `MAXSTEP` / `UIC` controls.
+artifact summaries with output-probe name lists, `.ac LIN`, `.ac DEC`,
+`.ac OCT` frequency grids, and `.tran` `START` / print-step `TSTEP` /
+`MAXSTEP` / `UIC` controls.

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -660,6 +660,7 @@ export interface DeckRunArtifact {
   readonly lineNumber: number;
   readonly resultRows: number;
   readonly outputProbeCount: number;
+  readonly outputProbes: readonly string[];
   readonly measurementCount: number;
   readonly fourierCount: number;
 }
@@ -7621,6 +7622,7 @@ function deckRunArtifacts(
       lineNumber: plan.lineNumber,
       resultRows: deckResultRowCount(result),
       outputProbeCount: outputProbes.length,
+      outputProbes: [...outputProbes],
       measurementCount: measurements.length,
       fourierCount: fourier.length,
     },
@@ -7629,7 +7631,7 @@ function deckRunArtifacts(
 
 export function formatDeckRunArtifactTable(artifacts: readonly DeckRunArtifact[]): string {
   const rows = [
-    "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tMeasurements\tFourier",
+    "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tOutputProbeList\tMeasurements\tFourier",
   ];
   for (const artifact of artifacts) {
     rows.push(
@@ -7639,6 +7641,7 @@ export function formatDeckRunArtifactTable(artifacts: readonly DeckRunArtifact[]
         String(artifact.lineNumber),
         String(artifact.resultRows),
         String(artifact.outputProbeCount),
+        artifact.outputProbes.join(";"),
         String(artifact.measurementCount),
         String(artifact.fourierCount),
       ].join("\t"),

--- a/code/packages/typescript/spice-engine/tests/transient.test.ts
+++ b/code/packages/typescript/spice-engine/tests/transient.test.ts
@@ -1464,9 +1464,10 @@ describe("transient", () => {
     expect(opExecution.measurementTable).toBe("Name\tAnalysis\tProbe\tMode\tFrom\tTo\tValue\n");
     expect(opExecution.table).toBe("Index\tV(mid)\n0\t5.000000e-01\n");
     expect(opExecution.runArtifacts[0]?.resultRows).toBe(1);
+    expect(opExecution.runArtifacts[0]?.outputProbes).toEqual(["V(mid)"]);
     expect(opExecution.runArtifactTable).toBe(
-      "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tMeasurements\tFourier\n" +
-        `op\t.op\t${opExecution.plan.lineNumber}\t1\t1\t0\t0\n`,
+      "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tOutputProbeList\tMeasurements\tFourier\n" +
+        `op\t.op\t${opExecution.plan.lineNumber}\t1\t1\tV(mid)\t0\t0\n`,
     );
 
     const dcExecution = runDeckAnalysis(circuit, netlist, "dc");
@@ -1484,9 +1485,10 @@ describe("transient", () => {
         "1\tV1\t1.000000e+00\t5.000000e-01\t-5.000000e-04\n",
     );
     expect(dcExecution.runArtifacts[0]?.analysis).toBe("dc");
+    expect(dcExecution.runArtifacts[0]?.outputProbes).toEqual(["V(mid)", "I(V1)"]);
     expect(dcExecution.runArtifactTable).toBe(
-      "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tMeasurements\tFourier\n" +
-        `dc\t.dc\t${dcExecution.plan.lineNumber}\t2\t2\t1\t0\n`,
+      "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tOutputProbeList\tMeasurements\tFourier\n" +
+        `dc\t.dc\t${dcExecution.plan.lineNumber}\t2\t2\tV(mid);I(V1)\t1\t0\n`,
     );
 
     const acExecution = runDeckAnalysis(circuit, netlist, "ac");
@@ -1501,9 +1503,10 @@ describe("transient", () => {
       "Index\tFrequency\tProbe\tReal\tImaginary\tMagnitude\tPhase\n" +
         "0\t1.000000e+03\tV(mid)\t5.000000e-01\t0.000000e+00\t5.000000e-01\t0.000000e+00\n",
     );
+    expect(acExecution.runArtifacts[0]?.outputProbes).toEqual(["V(mid)"]);
     expect(acExecution.runArtifactTable).toBe(
-      "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tMeasurements\tFourier\n" +
-        `ac\t.ac\t${acExecution.plan.lineNumber}\t1\t1\t1\t0\n`,
+      "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tOutputProbeList\tMeasurements\tFourier\n" +
+        `ac\t.ac\t${acExecution.plan.lineNumber}\t1\t1\tV(mid)\t1\t0\n`,
     );
 
     const tranExecution = runDeckAnalysis(circuit, netlist, "tran");
@@ -1518,9 +1521,10 @@ describe("transient", () => {
       "Index\tTime\tV(mid)\n" +
         "0\t1.000000e-03\t5.000000e-01\n",
     );
+    expect(tranExecution.runArtifacts[0]?.outputProbes).toEqual(["V(mid)"]);
     expect(tranExecution.runArtifactTable).toBe(
-      "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tMeasurements\tFourier\n" +
-        `tran\t.tran\t${tranExecution.plan.lineNumber}\t1\t1\t1\t0\n`,
+      "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tOutputProbeList\tMeasurements\tFourier\n" +
+        `tran\t.tran\t${tranExecution.plan.lineNumber}\t1\t1\tV(mid)\t1\t0\n`,
     );
 
     const tranWindowExecution = runDeckAnalysis(
@@ -1597,9 +1601,10 @@ describe("transient", () => {
     expect(result.probes[0]?.harmonics).toHaveLength(1);
     expect(tranExecution.fourierTable).toBe(formatFourierTable(result));
     expect(tranExecution.runArtifacts[0]?.fourierCount).toBe(1);
+    expect(tranExecution.runArtifacts[0]?.outputProbes).toEqual(["V(mid)"]);
     expect(tranExecution.runArtifactTable).toBe(
-      "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tMeasurements\tFourier\n" +
-        `tran\t.tran\t${tranExecution.plan.lineNumber}\t2\t1\t0\t1\n`,
+      "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tOutputProbeList\tMeasurements\tFourier\n" +
+        `tran\t.tran\t${tranExecution.plan.lineNumber}\t2\t1\tV(mid)\t0\t1\n`,
     );
   });
 

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -86,7 +86,8 @@ downstream tools to compare.
      travel with deck execution results as structured Fourier artifacts plus
      stable Fourier tables; selected deck executions now include structured
      run-artifact summaries plus stable row/count tables for result rows,
-     output probes, measurements, and Fourier artifacts.
+     output probes, measurements, and Fourier artifacts, with normalized
+     output-probe name lists included in the run artifacts.
    - Expand remaining deck-controlled analyses toward full SPICE compatibility
      while keeping unsupported control-flow diagnostics explicit.
 
@@ -731,13 +732,22 @@ downstream tools to compare.
       non-comment commands inside `.control` blocks remain diagnostic-only so
       unsupported execution policy is explicit.
 
+65. Deck run output-probe artifact names.
+    - Status: completed in this deck run output-probe artifact slice.
+    - Python, Rust, and TypeScript selected deck executions now include the
+      normalized output-probe names inside selected-run artifacts alongside
+      the existing output-probe counts.
+    - The stable run-artifact table now includes `OutputProbeList`, so callers
+      can inspect deck-owned probe provenance without reparsing solver output
+      tables.
+
 ## Backlog
 
 1. Deck execution layer.
    - Expand selected-plan execution beyond fixed-step transient basics,
-     including richer deck-owned run artifacts beyond selected output probes,
-     selected measurement artifacts, selected Fourier artifacts, and selected
-     run summaries, plus output-plan integration beyond stable table routing.
+     including richer deck-owned run artifacts beyond selected output,
+     measurement, Fourier, and run-summary metadata, plus output-plan
+     integration beyond stable table routing.
    - Expand deck-controlled output-plan integration beyond stable table
      routing and scoped `.save`, `.probe`, `.print`, `.plot`, and `.four`
      selection toward full SPICE compatibility.


### PR DESCRIPTION
## Summary
- add normalized output-probe name lists to deck run artifacts across Python, Rust, and TypeScript
- extend the stable run-artifact table with an OutputProbeList column while preserving output-probe counts
- update docs, changelogs, and the SPICE implementation plan with completed slice 65

## Verification
- /Users/adhithya/.local/share/mise/installs/python/3.12.13/bin/ruff check code/packages/python/spice-engine
- PYTEST_ADDOPTS=--no-cov PYTHONPATH=code/packages/python/device-physics/src:code/packages/python/mosfet-models/src:code/packages/python/spice-engine/src /Users/adhithya/.local/share/mise/installs/python/3.12.13/bin/python3.12 -m pytest code/packages/python/spice-engine/tests -q
- cargo fmt --manifest-path code/packages/rust/spice-engine/Cargo.toml -- --check
- cargo test --manifest-path code/packages/rust/spice-engine/Cargo.toml
- PATH=/Users/adhithya/.local/share/mise/installs/node/22.22.3/bin:$PATH npm --prefix code/packages/typescript/spice-engine run build
- PATH=/Users/adhithya/.local/share/mise/installs/node/22.22.3/bin:$PATH npm --prefix code/packages/typescript/spice-engine test