### PR TITLE
feat(visicalc-compose): Save / Load (serialize) over Java FFM

### DIFF
--- a/demo/visicalc-compose/README.md
+++ b/demo/visicalc-compose/README.md
@@ -94,6 +94,12 @@ The **Copy / Cut / Paste** buttons drive the engine's clipboard
 with its relative references shifted by the destination's offset (absolute `$`
 refs pinned, format carried); a cut clears the source on paste, and `pasteCell`
 returns `false` (a no-op) for an empty clipboard.
+The **Save / Load** buttons serialize the whole workbook
+(`InfiniteSheetModel.saveBook` over the C ABI's `sc_serialize`) to a JSON
+document held in memory and restore it (`loadBook` / `sc_deserialize`): the
+document captures only the source (formula text + typed literals) and per-cell
+formats — not the computed values, which the engine recomputes on load, so a
+loaded formula stays live.
 `InfiniteSheetModel` (in `Engine.kt`) seeds far-flung
 sparse cells (`Z1000`, `BA50`, `BB50`) and derives the extent from `usedRange()`
 + a margin.
@@ -109,7 +115,10 @@ one-read rows, `selectInf` clamping + source load, `commitInf` recompute
 (A2 `8`→`108` ⇒ E2 151, A5 139, E5 269), `fillDown` (`I1 = =H1*10` filled
 down 10 rows ⇒ I2 = H2*10 = 30, I3 = H3*10 = 40, source I1 = 20 untouched), and
 the clipboard (`copyCell` I1 → `pasteCell` at I4 ⇒ I4 = H4*10 = 60; `cutCell` A1
-→ paste at C1 moves it, A1 clears, a second paste returns false).
+→ paste at C1 moves it, A1 clears, a second paste returns false), and a
+save/load round trip (`saveBook` → mutate A1 ⇒ E1 523.00 → `loadBook` restores
+A1 15 / E1 38.00, the loaded formula stays live with A1=5 ⇒ E1 28.00, and
+malformed input is rejected).
 
 The Compose UI itself (`InfiniteSheet.kt` + the `Main.kt` toggle) is verified to
 compile against the real Compose Desktop APIs via `gradle compileKotlin`; the

--- a/demo/visicalc-compose/src/main/kotlin/Engine.kt
+++ b/demo/visicalc-compose/src/main/kotlin/Engine.kt
@@ -55,6 +55,10 @@ class SpreadsheetSession(libraryPath: String = resolveLibraryPath()) : AutoClose
     private val scCut = handle("sc_cut", FunctionDescriptor.ofVoid(ptr, ptr, ptr))
     // sc_paste(session, dst_start) -> int (1 applied, 0 no-op).
     private val scPaste = handle("sc_paste", FunctionDescriptor.of(i32, ptr, ptr))
+    // sc_serialize(session) -> char* (workbook source + formats as JSON);
+    // sc_deserialize(session, data) -> int (1 loaded, 0 malformed/unsupported).
+    private val scSerialize = handle("sc_serialize", FunctionDescriptor.of(ptr, ptr))
+    private val scDeserialize = handle("sc_deserialize", FunctionDescriptor.of(i32, ptr, ptr))
     private val scUsedRange = handle("sc_used_range", FunctionDescriptor.of(ptr, ptr))
     private val scColumnLetters = handle("sc_column_letters", FunctionDescriptor.of(ptr, ptr, i32))
     private val scCurrentRevision = handle("sc_current_revision", FunctionDescriptor.of(i64, ptr))
@@ -155,6 +159,21 @@ class SpreadsheetSession(libraryPath: String = resolveLibraryPath()) : AutoClose
     /// offset; content and format ride along.
     fun paste(dstStart: String): Boolean = Arena.ofConfined().use { a ->
         (scPaste.invoke(session, a.allocateUtf8String(dstStart)) as Int) != 0
+    }
+
+    /// Serialize the whole workbook to a self-contained JSON document — the
+    /// SOURCE (formula text + typed literals) + per-cell formats, not the
+    /// computed values (those recompute on load, so the document is small and
+    /// can't disagree with itself). [take] frees the engine's char*; the host
+    /// persists the returned string wherever it likes.
+    fun serialize(): String = take(scSerialize.invoke(session) as MemorySegment)
+
+    /// Replace the workbook from a document produced by [serialize]. Returns
+    /// `true` on success, `false` for malformed / unsupported input (the workbook
+    /// is left untouched — the engine validates before it mutates). Formulas
+    /// reload live.
+    fun deserialize(data: String): Boolean = Arena.ofConfined().use { a ->
+        (scDeserialize.invoke(session, a.allocateUtf8String(data)) as Int) != 0
     }
 
     /// Dense display strings for the inclusive 1-based rectangle, row-major
@@ -422,6 +441,21 @@ class InfiniteSheetModel(
     fun pasteCell(): Boolean {
         val ok = session.paste(infAddress())
         if (ok) computeExtent()
+        return ok
+    }
+
+    /// Save / load: serialize the whole workbook to a JSON document, and restore
+    /// it. The document stores only the source + formats — computed values
+    /// recompute on load, so a loaded formula stays live. [loadBook] returns
+    /// false (workbook untouched) for malformed input; on success it regrows the
+    /// extent and refreshes the formula bar so the view re-reads.
+    fun saveBook(): String = session.serialize()
+    fun loadBook(data: String): Boolean {
+        val ok = session.deserialize(data)
+        if (ok) {
+            computeExtent()
+            formula = session.getRaw(infAddress())
+        }
         return ok
     }
 

--- a/demo/visicalc-compose/src/main/kotlin/InfiniteSheet.kt
+++ b/demo/visicalc-compose/src/main/kotlin/InfiniteSheet.kt
@@ -87,6 +87,10 @@ fun InfiniteSheet() {
     var selCol by remember { mutableStateOf(model.selCol) }
     var formula by remember { mutableStateOf(model.formula) }
     var rev by remember { mutableStateOf(0) }
+    // In-memory "saved file" slot for the Save / Load buttons: Save stows the
+    // serialized workbook here, Load restores from it. (A real app would write
+    // it to a file; the demo keeps the round trip self-contained.)
+    var savedSnapshot by remember { mutableStateOf("") }
 
     fun select(row: Int, col: Int) {
         model.selectInf(row, col)
@@ -115,6 +119,19 @@ fun InfiniteSheet() {
     fun cutCell() = model.cutCell()
     fun pasteCell() {
         model.pasteCell()
+        rev++
+    }
+
+    // Save / load: serialize the whole workbook (formulas + formats) to a JSON
+    // document held in memory, and restore it. Computed values recompute on load,
+    // so a loaded formula stays live; the formula bar re-reads after a load.
+    fun saveBook() {
+        savedSnapshot = model.saveBook()
+    }
+    fun loadBook() {
+        if (savedSnapshot.isEmpty()) return
+        model.loadBook(savedSnapshot)
+        formula = model.formula
         rev++
     }
 
@@ -165,6 +182,11 @@ fun InfiniteSheet() {
             clipButton("Cut") { cutCell() }
             Spacer(Modifier.width(8.dp))
             clipButton("Paste") { pasteCell() }
+            // Save / load: serialize the whole workbook to memory, and restore it.
+            Spacer(Modifier.width(8.dp))
+            clipButton("Save") { saveBook() }
+            Spacer(Modifier.width(8.dp))
+            clipButton("Load") { loadBook() }
         }
 
         Spacer(Modifier.height(6.dp))

--- a/demo/visicalc-compose/test/EngineSmoke.kt
+++ b/demo/visicalc-compose/test/EngineSmoke.kt
@@ -154,6 +154,23 @@ fun main() {
     inf.selectInf(1, 5); check("inf cut buffer consumed", inf.pasteCell().toString(), "false")
     inf.close()
 
+    // Save / load (the Save / Load buttons drive saveBook/loadBook): serialize a
+    // fresh seeded workbook, mutate it, restore the snapshot, and confirm the
+    // loaded formula stays LIVE (the document stores source + formats, not values).
+    val sl = InfiniteSheetModel()
+    val snapshot = sl.saveBook()
+    check("serialize non-empty", snapshot.isNotEmpty().toString(), "true")
+    sl.selectInf(1, 1); sl.commitInf("500")              // E1 → 500+3+12+8 = 523
+    check("mutated E1", sl.rowCells(1)[4], "523.00")
+    check("loadBook ok", sl.loadBook(snapshot).toString(), "true")
+    check("loaded A1", sl.rowCells(1)[0], "15")          // restored
+    check("loaded E1 formatted", sl.rowCells(1)[4], "38.00") // recomputed through format
+    sl.selectInf(1, 1); sl.commitInf("5")                // live: 5+3+12+8 = 28
+    check("loaded formula live", sl.rowCells(1)[4], "28.00")
+    check("loadBook rejects garbage", sl.loadBook("not a workbook").toString(), "false")
+    check("workbook intact after reject", sl.rowCells(1)[4], "28.00")
+    sl.close()
+
     println(if (failures == 0) "\nALL PASS" else "\n$failures FAILURE(S)")
     kotlin.system.exitProcess(if (failures == 0) 0 else 1)
 }


### PR DESCRIPTION
## Summary

Fourth of the six save/load demo rollouts (web [#6161](https://github.com/adhithyan15/coding-adventures/pull/6161), Qt [#6163](https://github.com/adhithyan15/coding-adventures/pull/6163), Flutter [#6168](https://github.com/adhithyan15/coding-adventures/pull/6168) merged). Adds **Save / Load** to the Compose Desktop infinite-sheet demo, driving the engine's save/load (spreadsheet-capi 0.8.0 `sc_serialize` / `sc_deserialize`) over **Java FFM**.

- `Engine.kt`: `scSerialize` (`FunctionDescriptor.of(ptr, ptr)`) → `serialize(): String` (reads the `char*` via the existing `take` helper, freed with `sc_string_free`); `scDeserialize` (`of(i32, ptr, ptr)`) → `deserialize(String): Boolean`. Malformed/unsupported input returns false and leaves the workbook untouched.
- `InfiniteSheetModel.saveBook()` / `loadBook(data)`: loadBook regrows the extent and refreshes the formula bar on success.
- `InfiniteSheet.kt` gains **Save / Load** buttons next to Copy/Cut/Paste, holding the serialized document in an in-memory `savedSnapshot` state slot.
- The document stores only the *source* + formats; computed values recompute on load, so a loaded formula stays live.

## Test plan
- `scripts/verify.sh` (kotlinc + JDK 21 preview FFM) — **ALL PASS**. New save/load round trip on a fresh model: serialize the seeded workbook, mutate A1 (E1 → 523.00), restore (A1 → 15, E1 → 38.00 through its format), confirm the loaded formula stays live (A1=5 ⇒ E1=28.00), garbage rejected.
- Re-vendored `libspreadsheet_capi.dylib` (0.8.0) into `native/` (gitignored).
- `/security-review`: PASSED (engine `char*` freed via `take`; FFM args confined to `Arena.ofConfined().use{}`; no native pointer escapes its arena; null-session-safe).

Next in the rollout: XAML → SwiftUI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)