### PR TITLE
feat(visicalc-xaml): Save / Load (serialize) over P/Invoke

### DIFF
--- a/demo/visicalc-xaml/Engine.cs
+++ b/demo/visicalc-xaml/Engine.cs
@@ -80,6 +80,12 @@ internal static class ScNative
     [DllImport("spreadsheet_capi")]
     internal static extern int sc_paste(IntPtr s,
         [MarshalAs(UnmanagedType.LPUTF8Str)] string dstStart);
+    // sc_serialize(session) → char* (workbook source + formats as JSON);
+    // sc_deserialize(session, data) → int (1 loaded, 0 malformed/unsupported).
+    [DllImport("spreadsheet_capi")] internal static extern IntPtr sc_serialize(IntPtr s);
+    [DllImport("spreadsheet_capi")]
+    internal static extern int sc_deserialize(IntPtr s,
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string data);
     [DllImport("spreadsheet_capi")] internal static extern IntPtr sc_used_range(IntPtr s);
     [DllImport("spreadsheet_capi")] internal static extern IntPtr sc_column_letters(IntPtr s, uint index);
     [DllImport("spreadsheet_capi")] internal static extern ulong sc_current_revision(IntPtr s);
@@ -160,6 +166,19 @@ public sealed class SpreadsheetSession : IDisposable
     /// or off-grid destination. The block's references shift by the destination's
     /// offset; content and format ride along.
     public bool Paste(string dstStart) => ScNative.sc_paste(_handle, dstStart) != 0;
+
+    /// Serialize the whole workbook to a self-contained JSON document — the
+    /// SOURCE (formula text + typed literals) + per-cell formats, not the
+    /// computed values (those recompute on load, so the document is small and
+    /// can't disagree with itself). <see cref="Take"/> frees the engine's char*;
+    /// the host persists the returned string wherever it likes.
+    public string Serialize() => Take(ScNative.sc_serialize(_handle));
+
+    /// Replace the workbook from a document produced by <see cref="Serialize"/>.
+    /// Returns `true` on success, `false` for malformed / unsupported input (the
+    /// workbook is left untouched — the engine validates before it mutates).
+    /// Formulas reload live.
+    public bool Deserialize(string data) => ScNative.sc_deserialize(_handle, data) != 0;
 
     /// The display string for a cell — what a spreadsheet should show. Parses
     /// the engine's JSON (the fixed shape every backend's engine emits).
@@ -505,6 +524,23 @@ public sealed class InfiniteSheetModel : IDisposable
     {
         bool ok = _session.Paste(InfAddress);
         if (ok) ComputeExtent();
+        return ok;
+    }
+
+    /// Save / load: serialize the whole workbook to a JSON document, and restore
+    /// it. The document stores only the source + formats — computed values
+    /// recompute on load, so a loaded formula stays live. <see cref="LoadBook"/>
+    /// returns false (workbook untouched) for malformed input; on success it
+    /// regrows the extent and refreshes the formula bar so the view re-reads.
+    public string SaveBook() => _session.Serialize();
+    public bool LoadBook(string data)
+    {
+        bool ok = _session.Deserialize(data);
+        if (ok)
+        {
+            ComputeExtent();
+            Formula = _session.GetRaw(InfAddress);
+        }
         return ok;
     }
 

--- a/demo/visicalc-xaml/InfiniteSheet.xaml
+++ b/demo/visicalc-xaml/InfiniteSheet.xaml
@@ -73,6 +73,18 @@
                         Content="Paste"
                         ToolTipService.ToolTip="Paste the clipboard at the selected cell, shifting relative references"
                         Click="PasteButton_Click"/>
+                <Button x:Name="SaveButton" Margin="8,0,0,0" Height="28"
+                        Background="#2D2D30" Foreground="#CCCCCC" BorderBrush="#3F3F46"
+                        BorderThickness="1" FontSize="12" FontFamily="Consolas"
+                        Content="Save"
+                        ToolTipService.ToolTip="Serialize the whole workbook to memory"
+                        Click="SaveButton_Click"/>
+                <Button x:Name="LoadButton" Margin="8,0,0,0" Height="28"
+                        Background="#2D2D30" Foreground="#CCCCCC" BorderBrush="#3F3F46"
+                        BorderThickness="1" FontSize="12" FontFamily="Consolas"
+                        Content="Load"
+                        ToolTipService.ToolTip="Restore the workbook from the last save"
+                        Click="LoadButton_Click"/>
             </StackPanel>
         </Grid>
 

--- a/demo/visicalc-xaml/InfiniteSheet.xaml.cs
+++ b/demo/visicalc-xaml/InfiniteSheet.xaml.cs
@@ -47,6 +47,11 @@ public sealed partial class InfiniteSheet : UserControl
 
     private readonly InfiniteSheetModel _model = new();
     private List<int> _rowNumbers = new();
+
+    // In-memory "saved file" slot for the Save / Load buttons: Save stows the
+    // serialized workbook here, Load restores from it. (A real app would write it
+    // to a file; the demo keeps the round trip self-contained.)
+    private string _savedSnapshot = string.Empty;
     private ScrollViewer? _bodyInnerSv, _gutterInnerSv;
 
     public InfiniteSheet()
@@ -191,6 +196,22 @@ public sealed partial class InfiniteSheet : UserControl
     private void PasteButton_Click(object sender, RoutedEventArgs e)
     {
         if (_model.PasteCell()) RepaintRealizedRows();
+    }
+
+    /// Save / load: serialize the whole workbook (formulas + formats) to a JSON
+    /// document held in memory, and restore it. Computed values recompute on load,
+    /// so a loaded formula stays live; the formula bar and rows re-read after Load.
+    private void SaveButton_Click(object sender, RoutedEventArgs e) =>
+        _savedSnapshot = _model.SaveBook();
+
+    private void LoadButton_Click(object sender, RoutedEventArgs e)
+    {
+        if (_savedSnapshot.Length == 0) return;
+        if (_model.LoadBook(_savedSnapshot))
+        {
+            RefreshFormulaBar();
+            RepaintRealizedRows();
+        }
     }
 
     private void RefreshFormulaBar()

--- a/demo/visicalc-xaml/README.md
+++ b/demo/visicalc-xaml/README.md
@@ -155,6 +155,12 @@ The **Copy / Cut / Paste** buttons drive the engine's clipboard
 with its relative references shifted by the destination's offset (absolute `$`
 refs pinned, format carried); a cut clears the source on paste, and `PasteCell`
 returns `false` (a no-op) for an empty clipboard.
+The **Save / Load** buttons serialize the whole workbook
+(`InfiniteSheetModel.SaveBook` over the C ABI's `sc_serialize`) to a JSON
+document held in memory and restore it (`LoadBook` / `sc_deserialize`): the
+document captures only the source (formula text + typed literals) and per-cell
+formats — not the computed values, which the engine recomputes on load, so a
+loaded formula stays live.
 
 `InfiniteSheetModel` (in `Engine.cs`, WinUI-free) seeds far-flung sparse cells
 (`Z1000`, `BA50`, `BB50`) and derives the extent from `UsedRange()` + a margin
@@ -172,8 +178,11 @@ seeds far-flung sparse cells and asserts the window is engine-computed + dense
 (A1=15, E1=38, E5=169), a formula 1000 rows down (`Z1000` = 39) is reachable, the
 gaps are empty (sparse), column letters run AA/BA, and editing `A1` dirties the
 far dependent `Z1000` via `ChangedSince`. It also drives `InfiniteSheetModel`
-directly: `RowCells` one-read rows, `SelectInf` clamping + source load, and
-`CommitInf` recompute (A2 `8`→`108` ⇒ E2 151, A5 139, E5 269).
+directly: `RowCells` one-read rows, `SelectInf` clamping + source load,
+`CommitInf` recompute (A2 `8`→`108` ⇒ E2 151, A5 139, E5 269), drag-fill,
+clipboard copy/cut/paste, and a save/load round trip (`SaveBook` → mutate A1 ⇒
+E1 523.00 → `LoadBook` restores A1 15 / E1 38.00, the loaded formula stays live
+with A1=5 ⇒ E1 28.00, and malformed input is rejected).
 
 ## Where this fits in the cross-backend demo plan
 

--- a/demo/visicalc-xaml/test/Program.cs
+++ b/demo/visicalc-xaml/test/Program.cs
@@ -154,5 +154,23 @@ using (var inf = new InfiniteSheetModel())
     inf.SelectInf(1, 5); Check("inf cut buffer consumed", inf.PasteCell().ToString(), "False");
 }
 
+// Save / load (the Save / Load buttons drive SaveBook/LoadBook): serialize a
+// fresh seeded workbook, mutate it, restore the snapshot, and confirm the
+// loaded formula stays LIVE (the document stores source + formats, not values).
+using (var sl = new InfiniteSheetModel())
+{
+    string snapshot = sl.SaveBook();
+    Check("serialize non-empty", (snapshot.Length > 0).ToString(), "True");
+    sl.SelectInf(1, 1); sl.CommitInf("500");                 // E1 → 500+3+12+8 = 523
+    Check("mutated E1", sl.RowCells(1)[4], "523.00");
+    Check("loadBook ok", sl.LoadBook(snapshot).ToString(), "True");
+    Check("loaded A1", sl.RowCells(1)[0], "15");             // restored
+    Check("loaded E1 formatted", sl.RowCells(1)[4], "38.00"); // recomputed through format
+    sl.SelectInf(1, 1); sl.CommitInf("5");                   // live: 5+3+12+8 = 28
+    Check("loaded formula live", sl.RowCells(1)[4], "28.00");
+    Check("loadBook rejects garbage", sl.LoadBook("not a workbook").ToString(), "False");
+    Check("workbook intact after reject", sl.RowCells(1)[4], "28.00");
+}
+
 Console.WriteLine(failures == 0 ? "\nALL PASS" : $"\n{failures} FAILURE(S)");
 return failures == 0 ? 0 : 1;


### PR DESCRIPTION
## Summary

Fifth of the six save/load demo rollouts (web [#6161](https://github.com/adhithyan15/coding-adventures/pull/6161), Qt [#6163](https://github.com/adhithyan15/coding-adventures/pull/6163), Flutter [#6168](https://github.com/adhithyan15/coding-adventures/pull/6168), Compose [#6173](https://github.com/adhithyan15/coding-adventures/pull/6173) merged). Adds **Save / Load** to the XAML infinite-sheet demo, driving the engine's save/load (spreadsheet-capi 0.8.0 `sc_serialize` / `sc_deserialize`) over **P/Invoke**.

- `Engine.cs`: `[DllImport]` `sc_serialize(IntPtr) -> IntPtr` and `sc_deserialize(IntPtr, LPUTF8Str) -> int`. `Serialize()` reads the `char*` via the existing `Take` helper (`Marshal.PtrToStringUTF8` + `sc_string_free` — returning `IntPtr` not a marshalled `string`, so the marshaller never cross-allocator-frees the Rust pointer); `Deserialize(string) -> bool`. Malformed/unsupported input returns false and leaves the workbook untouched.
- `InfiniteSheetModel.SaveBook()` / `LoadBook(data)`: LoadBook regrows the extent and refreshes the formula bar on success.
- `InfiniteSheet.xaml`/`.xaml.cs` gain **Save / Load** buttons next to Copy/Cut/Paste, holding the serialized document in an in-memory `_savedSnapshot` field; Load refreshes the formula bar + repaints realized rows.
- The document stores only the *source* + formats; computed values recompute on load, so a loaded formula stays live.

## Test plan
- `scripts/verify.sh` (`dotnet run`, .NET 9 console harness) — **ALL PASS**. New save/load round trip: serialize the seeded workbook, mutate A1 (E1 → 523.00), restore (A1 → 15, E1 → 38.00 through its format), confirm the loaded formula stays live (A1=5 ⇒ E1=28.00), garbage rejected. (The WinUI view itself is Windows-only; the engine-backed model is proven cross-platform by this headless harness, per the demo's established boundary.)
- Re-vendored `libspreadsheet_capi.dylib` (0.8.0) into `native/` (gitignored).
- `/security-review`: PASSED (engine `char*` freed once via `Take`; `IntPtr` return avoids cross-allocator free; `LPUTF8Str` inbound; null-session-safe; no UAF/double-free).

Next (last): SwiftUI — after it merges, save/load is complete across all 6 backends.

🤖 Generated with [Claude Code](https://claude.com/claude-code)