### PR TITLE
feat(closurec): ADVANCED diverges from SIMPLE — wire rename-globals + --externs (CLOC13.I)

### DIFF
--- a/code/programs/rust/closurec/CHANGELOG.md
+++ b/code/programs/rust/closurec/CHANGELOG.md
@@ -2,6 +2,48 @@
 
 All notable changes to the `coding-adventures-closurec` binary will be documented in this file.
 
+## [0.149.0] - 2026-06-18
+
+### Added (CLOC13.I — ADVANCED diverges from SIMPLE: aggressive top-level renaming)
+
+`--compilation_level ADVANCED` now produces genuinely smaller output than
+SIMPLE for the first time. ADVANCED runs the SIMPLE pipeline PLUS the
+`rename-globals` pass (`coding-adventures-closure-pass-rename-globals`),
+appended after `rename`, which shortens program-private top-level names
+(`function` / `var` / `let` / `const`) that survive the structural passes:
+
+```js
+function helper() { sideEffect(); return value; }
+helper();
+//  SIMPLE   => function helper(){sideEffect();return value};helper();
+//  ADVANCED => function a(){sideEffect();return value};a();
+```
+
+- **`--externs` is now read** (it was parsed-then-discarded). Each externs file
+  is parsed and its top-level declared names collected into the **do-not-rename
+  set** — the external boundary ADVANCED must preserve. Degrade-safe: an
+  unreadable / unparseable / bridge-rejected externs file contributes no names
+  rather than failing the build. A `--externs` file declaring `helper` keeps it
+  under ADVANCED.
+- SIMPLE is unchanged (it never touches top-level names, since in a Script a
+  top-level name may be externally visible). The ADVANCED rename is sound only
+  under Closure's whole-program / externs contract — see the
+  `closure-pass-rename-globals` crate.
+- The `advanced_v1` CV trace's `passes` now lists `rename-globals`
+  (`ADVANCED_PASS_NAMES`); SIMPLE's `simple_v2` list is unchanged.
+
+### Fixtures / tests
+
+- New `tests/diff/advanced-rename-globals/` fixture + a dual-level harness that
+  runs BOTH levels and asserts ADVANCED renamed the top-level `helper` while
+  SIMPLE kept it (and ADVANCED is smaller), plus a
+  `advanced_renames_surviving_top_level_function` unit test.
+- Updated the `advanced-optimizes` fixture (ADVANCED now renames its surviving
+  `compute`) and the `advanced_matches_simple_output` test's comment (the two
+  levels match only when no top-level name survives).
+- Version bumped `0.148.0 -> 0.149.0` (`Cargo.toml`, `cli.spec.json`,
+  help-markdown fixture).
+
 ## [0.148.0] - 2026-06-17
 
 ### Added (CLOC13.H — `inline-variables` constant propagation in SIMPLE)

--- a/code/programs/rust/closurec/Cargo.toml
+++ b/code/programs/rust/closurec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closurec"
-version = "0.148.0"
+version = "0.149.0"
 edition = "2021"
 description = "closurec — CLI driver for the Closure Compiler clone. Mirrors the upstream Java Closure Compiler's command-line flag surface (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility. Per CLOC08."
 
@@ -30,6 +30,7 @@ coding-adventures-closure-pass-dce = { path = "../../../packages/rust/closure-pa
 coding-adventures-closure-pass-inline = { path = "../../../packages/rust/closure-pass-inline" }
 coding-adventures-closure-pass-inline-variables = { path = "../../../packages/rust/closure-pass-inline-variables" }
 coding-adventures-closure-pass-rename = { path = "../../../packages/rust/closure-pass-rename" }
+coding-adventures-closure-pass-rename-globals = { path = "../../../packages/rust/closure-pass-rename-globals" }
 coding-adventures-closure-pass-treeshake = { path = "../../../packages/rust/closure-pass-treeshake" }
 coding-adventures-closure-pass-collapse-properties = { path = "../../../packages/rust/closure-pass-collapse-properties" }
 coding-adventures-closure-pass-remove-unused-vars = { path = "../../../packages/rust/closure-pass-remove-unused-vars" }

--- a/code/programs/rust/closurec/cli.spec.json
+++ b/code/programs/rust/closurec/cli.spec.json
@@ -2,7 +2,7 @@
   "cli_builder_spec_version": "1.0",
   "name": "closurec",
   "description": "closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.",
-  "version": "0.148.0",
+  "version": "0.149.0",
   "parsing_mode": "gnu",
   "flags": [
     { "id": "browser_featureset_year", "long": "browser_featureset_year", "type": "integer", "default": 0, "description": "Shortcut for defining goog.FEATURESET_YEAR=YYYY (minimum 2012)." },

--- a/code/programs/rust/closurec/src/run.rs
+++ b/code/programs/rust/closurec/src/run.rs
@@ -191,7 +191,7 @@ pub fn transform_source(
 /// |--------------------|--------------------|------------------|------------------------------------------|
 /// | WhitespaceOnly     | `compilation_level`| `whitespace_only`| `{input_byte_len, output_byte_len}`      |
 /// | Simple             | `compilation_level`| `simple_v2`      | `{level, bridge_status, passes, input_byte_len, output_byte_len}` |
-/// | Advanced           | `compilation_level`| `advanced_v1`    | same shape as `simple_v2` (shares the pipeline)  |
+/// | Advanced           | `compilation_level`| `advanced_v1`    | same shape as `simple_v2`; `passes` adds `rename-globals` (aggressive top-level renaming) |
 /// | Bundle / Transpile | `compilation_level`| `identity`       | `{level: "BUNDLE" \| "TRANSPILE_ONLY"}` |
 /// | Defines            | `defines`          | `applied`        | `{input_byte_len, output_byte_len, defines_count}` |
 ///
@@ -249,6 +249,24 @@ const SIMPLE_PASS_NAMES: &[&str] = &[
     "rename",
 ];
 
+/// The ADVANCED pipeline = every SIMPLE pass, then `rename-globals` —
+/// aggressive renaming of program-private top-level names (the canonical
+/// ADVANCED-over-SIMPLE win). It runs *after* `rename` (which shortens
+/// leaf-function locals) so the two renamers shorten disjoint name
+/// layers. `rename-globals` is gated by the `--externs` do-not-rename
+/// boundary; see [`externs_do_not_rename`].
+const ADVANCED_PASS_NAMES: &[&str] = &[
+    "constant-fold",
+    "fold-control-flow",
+    "dce",
+    "inline",
+    "inline-variables",
+    "remove-unused-vars",
+    "treeshake",
+    "rename",
+    "rename-globals",
+];
+
 /// Run the SIMPLE optimization pipeline over a bridged `Program` and
 /// emit the result as JavaScript text.
 ///
@@ -274,6 +292,19 @@ fn run_simple_pipeline(
     program: coding_adventures_javascript_ast::Program,
     status: &mut Option<String>,
 ) -> Option<String> {
+    run_typed_pipeline(program, status, None)
+}
+
+/// Run the typed-AST optimization pipeline. `advanced_externs`
+/// distinguishes the two levels: `None` is SIMPLE; `Some(set)` is
+/// ADVANCED, which appends the `rename-globals` pass (gated by the
+/// externs do-not-rename `set`) after the SIMPLE passes. See
+/// [`run_simple_pipeline`] / [`SIMPLE_PASS_NAMES`] / [`ADVANCED_PASS_NAMES`].
+fn run_typed_pipeline(
+    program: coding_adventures_javascript_ast::Program,
+    status: &mut Option<String>,
+    advanced_externs: Option<std::collections::HashSet<String>>,
+) -> Option<String> {
     use coding_adventures_closure_emitter::{emit, EmitOptions};
     use coding_adventures_closure_pass_constant_fold::ConstantFoldPass;
     use coding_adventures_closure_pass_dce::DcePass;
@@ -283,6 +314,7 @@ fn run_simple_pipeline(
     use coding_adventures_closure_pass_pipeline::PassPipeline;
     use coding_adventures_closure_pass_remove_unused_vars::RemoveUnusedVarsPass;
     use coding_adventures_closure_pass_rename::RenamePass;
+    use coding_adventures_closure_pass_rename_globals::RenameGlobalsPass;
     use coding_adventures_closure_pass_treeshake::TreeshakePass;
     use coding_adventures_correlation_vector::CVLog;
     use coding_adventures_type_sidecar::Sidecar;
@@ -310,11 +342,18 @@ fn run_simple_pipeline(
     pipeline.add(Box::new(InlineVariablesPass::new()));
     pipeline.add(Box::new(RemoveUnusedVarsPass::new()));
     pipeline.add(Box::new(TreeshakePass::new()));
-    // rename runs last: it shortens leaf-function parameter names after
-    // every structural pass has finished removing/rewriting code. It has
-    // no dependencies (correct standalone), so registration order places
-    // it at the end.
+    // rename runs last among the SIMPLE passes: it shortens leaf-function
+    // parameter names after every structural pass has finished
+    // removing/rewriting code. It has no dependencies (correct
+    // standalone), so registration order places it at the end.
     pipeline.add(Box::new(RenamePass::new()));
+
+    // ADVANCED only: shorten program-private TOP-LEVEL names too, gated by
+    // the externs do-not-rename boundary. Registered after `rename` so the
+    // two renamers shorten disjoint name layers (locals vs top-level).
+    if let Some(externs) = advanced_externs {
+        pipeline.add(Box::new(RenameGlobalsPass::new(externs)));
+    }
 
     let optimized = match pipeline.run(program, &sidecar, &mut pass_cv) {
         Ok(out) => out.program,
@@ -429,7 +468,16 @@ pub fn transform_source_with_cv(
                     None
                 }
                 Ok(node) => match bridge::grammar_to_program(&node, es_version) {
-                    Ok(program) => run_simple_pipeline(program, &mut simple_bridge_status),
+                    Ok(program) => {
+                        // ADVANCED adds aggressive top-level renaming,
+                        // gated by the externs do-not-rename boundary;
+                        // SIMPLE runs the typed pipeline unchanged.
+                        let advanced_externs = match config.compilation.level {
+                            CompilationLevel::Advanced => Some(externs_do_not_rename(config)),
+                            _ => None,
+                        };
+                        run_typed_pipeline(program, &mut simple_bridge_status, advanced_externs)
+                    }
                     Err(BridgeError::UnsupportedSyntax { rule, location }) => {
                         simple_bridge_status =
                             Some(format!("unsupported_syntax:{rule}@{location}"));
@@ -486,9 +534,9 @@ pub fn transform_source_with_cv(
                 // passes today (it is ≥ SIMPLE) and gains advanced-only
                 // passes here as they land.
                 CompilationLevel::Simple | CompilationLevel::Advanced => {
-                    let (tag, level) = match config.compilation.level {
-                        CompilationLevel::Advanced => ("advanced_v1", "ADVANCED"),
-                        _ => ("simple_v2", "SIMPLE"),
+                    let (tag, level, passes_list) = match config.compilation.level {
+                        CompilationLevel::Advanced => ("advanced_v1", "ADVANCED", ADVANCED_PASS_NAMES),
+                        _ => ("simple_v2", "SIMPLE", SIMPLE_PASS_NAMES),
                     };
                     (
                         tag,
@@ -508,7 +556,7 @@ pub fn transform_source_with_cv(
                             (
                                 "passes",
                                 serde_json::Value::Array(
-                                    SIMPLE_PASS_NAMES
+                                    passes_list
                                         .iter()
                                         .map(|p| serde_json::Value::String((*p).into()))
                                         .collect(),
@@ -643,6 +691,64 @@ pub fn resolve_externs(config: &CompilerConfig) -> Result<Vec<PathBuf>, Compiler
         return Ok(Vec::new());
     }
     globs::expand_js_patterns(&config.io.externs).map_err(CompilerError::ExternsGlobExpansion)
+}
+
+/// Collect the externs **do-not-rename** set — the top-level names
+/// declared in the `--externs` files. These are the program's external
+/// boundary: ADVANCED's `rename-globals` pass renames every other
+/// top-level name but must keep these (they're referenced from outside
+/// this compilation). Returns the union of every externs file's top-level
+/// `function` ids and `var`/`let`/`const` target names.
+///
+/// **Degrade-safe.** A glob failure, an unreadable file, a parse error,
+/// or a bridge rejection on any externs file simply contributes no names
+/// from that file rather than failing the compile — the same best-effort
+/// posture the typed pipeline uses on the main input. (A genuine
+/// bad-glob is surfaced earlier, by `resolve_externs` in `run_compiler`.)
+fn externs_do_not_rename(config: &CompilerConfig) -> std::collections::HashSet<String> {
+    use coding_adventures_javascript_ast::{BindingTarget, Declaration, ProgramItem, Statement};
+
+    let mut names = std::collections::HashSet::new();
+    let paths = match resolve_externs(config) {
+        Ok(p) => p,
+        Err(_) => return names,
+    };
+    let es = map_language_in_to_es_version(config);
+    for path in paths {
+        let src = match fs::read_to_string(&path) {
+            Ok(s) => s,
+            Err(_) => continue,
+        };
+        let node = match parse_javascript_typed(&src, es) {
+            Ok(n) => n,
+            Err(_) => continue,
+        };
+        let program = match bridge::grammar_to_program(&node, es) {
+            Ok(p) => p,
+            Err(_) => continue,
+        };
+        for item in &program.body {
+            match item {
+                ProgramItem::Declaration(Declaration::FunctionDeclaration(fd))
+                | ProgramItem::Statement(Statement::Declaration(
+                    Declaration::FunctionDeclaration(fd),
+                )) => {
+                    names.insert(fd.id.name.clone());
+                }
+                ProgramItem::Declaration(Declaration::VariableDeclaration(vd))
+                | ProgramItem::Statement(Statement::Declaration(
+                    Declaration::VariableDeclaration(vd),
+                )) => {
+                    for d in &vd.declarations {
+                        let BindingTarget::Identifier(id) = &d.id;
+                        names.insert(id.name.clone());
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+    names
 }
 
 /// Run the compiler with `config`.
@@ -5941,9 +6047,13 @@ mod tests {
 
     #[test]
     fn advanced_matches_simple_output() {
-        // ADVANCED reuses the SIMPLE pipeline today, so the two levels
-        // produce identical output. (When advanced-only passes land, this
-        // test documents the point at which they diverge.)
+        // ADVANCED adds `rename-globals` on top of the SIMPLE pipeline, but
+        // it only differs when a top-level name SURVIVES to the end. Here
+        // `g` is a single-use leaf function, so `inline`/`treeshake`
+        // delete it entirely — nothing top-level remains, so ADVANCED and
+        // SIMPLE produce identical output for THIS input. See
+        // `advanced_renames_surviving_top_level_function` for the divergent
+        // case.
         let src = "var dead = 1 + 2; function g(value) { return value * 2; } use(g(4));";
         let mk = |level| {
             transform_source(
@@ -5961,6 +6071,40 @@ mod tests {
         assert_eq!(
             mk(crate::config::CompilationLevel::Advanced),
             mk(crate::config::CompilationLevel::Simple),
+        );
+    }
+
+    #[test]
+    fn advanced_renames_surviving_top_level_function() {
+        // CLOC13.I: a top-level function that SURVIVES SIMPLE (multi-
+        // statement body, so `inline` leaves it; called, so `treeshake`
+        // keeps it) is shortened by ADVANCED's `rename-globals` pass —
+        // the first point where ADVANCED produces smaller output than
+        // SIMPLE. SIMPLE keeps the top-level name (it may be external).
+        let src = "function helper() { sideEffect(); return value; } helper();";
+        let mk = |level| {
+            transform_source(
+                src,
+                &CompilerConfig {
+                    compilation: crate::config::CompilationConfig {
+                        level,
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                },
+            )
+            .expect("ok")
+        };
+        let simple = mk(crate::config::CompilationLevel::Simple);
+        let advanced = mk(crate::config::CompilationLevel::Advanced);
+        assert_eq!(
+            simple,
+            "function helper(){sideEffect();return value};helper();"
+        );
+        assert_eq!(advanced, "function a(){sideEffect();return value};a();");
+        assert!(
+            advanced.len() < simple.len(),
+            "ADVANCED must be smaller than SIMPLE here"
         );
     }
 

--- a/code/programs/rust/closurec/tests/diff/advanced-optimizes/README.md
+++ b/code/programs/rust/closurec/tests/diff/advanced-optimizes/README.md
@@ -7,7 +7,7 @@ pipeline (CLOC12.161).
 |------|------|
 | `flags.txt` | `--compilation_level ADVANCED --js input/a.js` |
 | `input/a.js` | A program with a foldable expr, an unused var, and a renameable param |
-| `expected.stdout` | `function compute(a){return a + 1};report(compute(7));sink(compute);` |
+| `expected.stdout` | `function c(a){return a + 1};report(c(7));sink(c);` |
 
 ADVANCED used to be a **literal no-op** — it returned the source verbatim. It
 now runs the **same typed optimization pipeline as SIMPLE** (it is specified to
@@ -24,9 +24,12 @@ inliner would substitute the body at the call site, so the value use keeps
 this fixture's focus on fold + dead-code removal + rename. Inlining has its
 own pass-crate tests.
 
-ADVANCED and SIMPLE produce identical output today; advanced-only passes
-(aggressive property/global renaming, cross-module tree-shaking) layer on as
-they are implemented.
+ADVANCED now DIVERGES from SIMPLE: the `rename-globals` pass shortens the
+private top-level function `compute` to `c` (SIMPLE keeps `compute`, since a
+top-level name may be externally visible). `report` / `sink` are free globals
+and `--externs` could protect `compute`; both are left alone here. Further
+advanced-only passes (aggressive property renaming, cross-module tree-shaking)
+layer on as they are implemented.
 
 Regenerate the expected file after an intentional behavior change:
 

--- a/code/programs/rust/closurec/tests/diff/advanced-optimizes/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/advanced-optimizes/expected.stdout
@@ -1,1 +1,1 @@
-function compute(a){return a + 1};report(compute(7));sink(compute);
+function c(a){return a + 1};report(c(7));sink(c);

--- a/code/programs/rust/closurec/tests/diff/advanced-rename-globals/README.md
+++ b/code/programs/rust/closurec/tests/diff/advanced-rename-globals/README.md
@@ -1,0 +1,35 @@
+# Fixture: `advanced-rename-globals`
+
+End-to-end oracle for the `rename-globals` pass — the first place
+`--compilation_level ADVANCED` produces **smaller** output than SIMPLE
+(CLOC13.I).
+
+| File | Role |
+|------|------|
+| `flags.txt` | `--compilation_level ADVANCED --js input/a.js` |
+| `input/a.js` | A top-level helper that survives SIMPLE (multi-statement body, called) |
+| `expected.stdout` | `function a(){sideEffect();return value};a();` |
+
+`helper` is a top-level `function` with a multi-statement body, so `inline`
+leaves it, and it is called, so `treeshake` keeps it. The divergence:
+
+| Level | Output |
+|-------|--------|
+| SIMPLE | `function helper(){sideEffect();return value};helper();` (top-level name kept — it may be externally visible) |
+| ADVANCED | `function a(){sideEffect();return value};a();` (`rename-globals` shortens the private `helper` → `a`) |
+
+`sideEffect` / `value` are free globals (not declared here) → never renamed.
+A `--externs` file declaring `helper` would keep its name under ADVANCED too,
+since the externs set is the do-not-rename boundary that makes the rename
+sound.
+
+The companion harness `tests/diff_advanced_rename_globals.rs` runs BOTH levels
+on this input and asserts ADVANCED renamed `helper` while SIMPLE kept it.
+
+Regenerate the expected file after an intentional behavior change:
+
+```sh
+cargo run -- --compilation_level ADVANCED \
+    --js tests/diff/advanced-rename-globals/input/a.js \
+    > tests/diff/advanced-rename-globals/expected.stdout
+```

--- a/code/programs/rust/closurec/tests/diff/advanced-rename-globals/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/advanced-rename-globals/expected.stdout
@@ -1,0 +1,1 @@
+function a(){sideEffect();return value};a();

--- a/code/programs/rust/closurec/tests/diff/advanced-rename-globals/flags.txt
+++ b/code/programs/rust/closurec/tests/diff/advanced-rename-globals/flags.txt
@@ -1,0 +1,4 @@
+--compilation_level
+ADVANCED
+--js
+tests/diff/advanced-rename-globals/input/a.js

--- a/code/programs/rust/closurec/tests/diff/advanced-rename-globals/input/a.js
+++ b/code/programs/rust/closurec/tests/diff/advanced-rename-globals/input/a.js
@@ -1,0 +1,20 @@
+// ADVANCED-only global renaming (CLOC13.I wiring).
+//
+// `helper` is a top-level function with a multi-statement body, so the
+// `inline` pass leaves it, and it is called, so `treeshake` keeps it.
+// Under SIMPLE it survives with its full name (a top-level name might be
+// externally visible, so SIMPLE never renames it). Under ADVANCED the
+// `rename-globals` pass shortens the private top-level `helper` to `a`,
+// rewriting the call site too. `sideEffect` and `value` are free globals
+// (not declared here) and are left alone.
+//
+//   SIMPLE   => function helper(){sideEffect();return value};helper();
+//   ADVANCED => function a(){sideEffect();return value};a();
+//
+// (A `--externs` file declaring `helper` would keep the name under
+// ADVANCED too — that boundary is what makes the rename sound.)
+function helper() {
+  sideEffect();
+  return value;
+}
+helper();

--- a/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
@@ -2,7 +2,7 @@
 
 closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.
 
-Version: 0.148.0
+Version: 0.149.0
 
 ## Flags
 

--- a/code/programs/rust/closurec/tests/diff_advanced_rename_globals.rs
+++ b/code/programs/rust/closurec/tests/diff_advanced_rename_globals.rs
@@ -1,0 +1,61 @@
+//! Integration test for the `tests/diff/advanced-rename-globals/` fixture.
+//!
+//! Exercises CLOC13.I — `rename-globals` wired into ADVANCED. This is the
+//! first point where ADVANCED produces SMALLER output than SIMPLE: the
+//! private top-level `helper` (which survives `inline`/`treeshake`) is
+//! shortened to `a` under ADVANCED but kept under SIMPLE (a top-level name
+//! may be externally visible). The test runs BOTH levels on the same
+//! input and asserts the divergence.
+
+use std::process::Command;
+
+const BINARY: &str = env!("CARGO_BIN_EXE_closurec");
+
+fn run(level: &str) -> String {
+    let out = Command::new(BINARY)
+        .args([
+            "--compilation_level",
+            level,
+            "--js",
+            "tests/diff/advanced-rename-globals/input/a.js",
+        ])
+        .output()
+        .expect("run closurec");
+    assert!(
+        out.status.success(),
+        "exit: {:?}, stderr: {}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stderr),
+    );
+    String::from_utf8_lossy(&out.stdout)
+        .trim_end_matches('\n')
+        .to_string()
+}
+
+#[test]
+fn advanced_rename_globals_fixture_matches_expected_stdout() {
+    let expected = std::fs::read_to_string("tests/diff/advanced-rename-globals/expected.stdout")
+        .expect("read expected.stdout");
+    assert_eq!(run("ADVANCED"), expected.trim_end_matches('\n'));
+}
+
+#[test]
+fn advanced_renames_top_level_helper_that_simple_keeps() {
+    let simple = run("SIMPLE");
+    let advanced = run("ADVANCED");
+
+    // SIMPLE keeps the top-level name; ADVANCED renames it away.
+    assert!(
+        simple.contains("function helper("),
+        "SIMPLE should keep the top-level `helper`: {simple}"
+    );
+    assert!(
+        !advanced.contains("helper"),
+        "ADVANCED should rename `helper` away: {advanced}"
+    );
+    // The divergence is a net size win.
+    assert!(
+        advanced.len() < simple.len(),
+        "ADVANCED ({advanced}) should be smaller than SIMPLE ({simple})"
+    );
+}


### PR DESCRIPTION
## What

**`--compilation_level ADVANCED` now produces genuinely smaller output than SIMPLE for the first time.** ADVANCED runs the SIMPLE typed pipeline **plus** the (already-merged) `rename-globals` pass, appended after `rename`, which shortens program-private top-level names that survive the structural passes:

```js
function helper() { sideEffect(); return value; }
helper();
// SIMPLE   => function helper(){sideEffect();return value};helper();
// ADVANCED => function a(){sideEffect();return value};a();
```

## `--externs` is now wired

It was parsed then **discarded** (`let _resolved_externs` at run.rs). Now each `--externs` file is parsed + bridged and its **top-level declared names** collected into the **do-not-rename set** — the external boundary ADVANCED must preserve. A `--externs` file declaring `helper` keeps that name under ADVANCED.

- **Degrade-safe:** an unreadable / unparseable / bridge-rejected externs file contributes no names rather than failing the build (same best-effort posture as the typed pipeline).
- **SIMPLE is byte-for-byte unchanged** — it never touches top-level names (in a Script a top-level name may be externally visible). The ADVANCED rename is sound only under Closure's whole-program / externs contract (see the `closure-pass-rename-globals` crate).

## How

- `run_simple_pipeline` now delegates to a shared `run_typed_pipeline(program, status, advanced_externs: Option<HashSet<String>>)`: `None` → SIMPLE (unchanged), `Some(set)` → ADVANCED (appends `RenameGlobalsPass::new(set)`).
- The `Simple | Advanced` match arm computes the externs set only for ADVANCED.
- CV trace: `advanced_v1`'s `passes` now lists `rename-globals` (new `ADVANCED_PASS_NAMES`); `simple_v2` unchanged.

## Changes

- `closurec` `0.148.0 → 0.149.0`; dep on `coding-adventures-closure-pass-rename-globals`.
- **New** `tests/diff/advanced-rename-globals/` fixture + a **dual-level harness** that runs BOTH levels on the same input and asserts ADVANCED renamed the top-level `helper` while SIMPLE kept it (and ADVANCED is smaller), plus an `advanced_renames_surviving_top_level_function` unit test.
- Updated the `advanced-optimizes` fixture (ADVANCED now renames its surviving `compute`→`c`) and the `advanced_matches_simple_output` comment (the levels match only when no top-level name survives).

## Verification

- Full `closurec` suite: **0 failures** (incl. both new fixture tests + the unit test). `cargo build --workspace` for the affected crates clean.
- End-to-end: `function helper(){sideEffect();return value} helper();` → SIMPLE keeps `helper`, ADVANCED → `function a(){…};a();`; `--externs` declaring `helper` keeps it.
- fmt: no new drift (closurec's pre-existing fmt-diff hunk count is unchanged by this PR); my one new match arm hand-formatted.
- **Security review: PASSED** — wiring sound (SIMPLE identical), externs reading panic-free + degrade-safe, no path-traversal/DoS/injection concern.

This completes the first end-to-end ADVANCED-vs-SIMPLE divergence. Next in the arc: aggressive property renaming (needs a property-level externs boundary) or further sound advanced passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)