### PR TITLE
Expose deck run measurement names

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ### Added
 
+- **Deck run measurement artifact names** —
+  `run_deck_analysis()` selected-run artifacts now include selected
+  measurement names alongside the measurement count, and
+  `format_deck_run_artifact_table()` renders a stable `MeasurementList`
+  column, matching Rust and TypeScript.
+
 - **Deck run output-probe artifact names** —
   `run_deck_analysis()` selected-run artifacts now include the normalized
   output-probe names alongside the output-probe count, and

--- a/code/packages/python/spice-engine/README.md
+++ b/code/packages/python/spice-engine/README.md
@@ -65,7 +65,7 @@ print(result.diagnostics.solver)   # "dense_real" or "sparse_real"
 | `fourier` | `.FOUR` | Harmonic magnitudes/phases and THD from transient output |
 | `format_dc_table`, `format_transient_table` | `.PRINT` / `.PLOT` output | Stable tabular node voltages and branch currents |
 | `resolve_deck_outputs`, `format_deck_*_table` | `.SAVE` / `.PROBE` / `.PRINT` / `.PLOT` output | Parsed deck-selected OP, DC sweep, AC, and transient tables |
-| `format_deck_run_artifact_table` | Deck execution artifact | Stable selected-run row, output-probe count/name list, measurement, and Fourier counts |
+| `format_deck_run_artifact_table` | Deck execution artifact | Stable selected-run row, output-probe and measurement count/name lists plus Fourier counts |
 | `measure_transient_probe`, `measure_dc_sweep_probe`, `measure_ac_sweep_probe`, `format_measurement_table` | `.MEASURE` output | Stable scalar transient, DC sweep, and AC sweep probe measurements |
 
 `diode_at_temperature()`, `bjt_at_temperature()`, `mosfet_at_temperature()`,
@@ -109,7 +109,7 @@ stable measurement table for `.dc`, `.ac`, and `.tran` executions. Selected
 `.tran` plans also return selected `.four` harmonic results and a stable
 Fourier table. Executions also include a selected-run artifact summary plus
 `format_deck_run_artifact_table()` output for stable result-row,
-output-probe count/name list, measurement, and Fourier counts. They route `START` output
+output-probe and measurement count/name lists plus Fourier counts. They route `START` output
 filtering, use `.tran TSTEP` as the output print grid, apply `MAXSTEP` as an
 internal fixed-step cap, and carry `UIC` initial-condition intent through that
 stable transient table surface.
@@ -218,9 +218,9 @@ downstream deck execution helpers.
 `run_deck_analysis()` routes that selected plan into the matching solver and
 stable deck-selected table output with normalized output-probe artifacts,
 selected measurement artifacts, selected transient Fourier artifacts,
-selected-run artifact summaries with output-probe name lists, `.ac LIN`,
-`.ac DEC`, `.ac OCT` frequency grids, and `.tran` `START` / print-step
-`TSTEP` / `MAXSTEP` / `UIC` controls.
+selected-run artifact summaries with output-probe and measurement name lists,
+`.ac LIN`, `.ac DEC`, `.ac OCT` frequency grids, and `.tran` `START` /
+print-step `TSTEP` / `MAXSTEP` / `UIC` controls.
 
 ## Controlled source examples
 

--- a/code/packages/python/spice-engine/src/spice_engine/engine.py
+++ b/code/packages/python/spice-engine/src/spice_engine/engine.py
@@ -2304,6 +2304,7 @@ class DeckRunArtifact:
     output_probe_count: int
     output_probes: list[str]
     measurement_count: int
+    measurement_names: list[str]
     fourier_count: int
 
 
@@ -2378,6 +2379,7 @@ def _deck_run_artifacts(
             output_probe_count=len(output_probes),
             output_probes=list(output_probes),
             measurement_count=len(measurements),
+            measurement_names=[measurement.name for measurement in measurements],
             fourier_count=len(fourier),
         )
     ]
@@ -2387,7 +2389,7 @@ def format_deck_run_artifact_table(artifacts: Iterable[DeckRunArtifact]) -> str:
     """Format selected deck-run artifacts as a stable summary table."""
 
     rows = [
-        "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tOutputProbeList\tMeasurements\tFourier"
+        "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tOutputProbeList\tMeasurements\tMeasurementList\tFourier"
     ]
     for artifact in artifacts:
         rows.append(
@@ -2400,6 +2402,7 @@ def format_deck_run_artifact_table(artifacts: Iterable[DeckRunArtifact]) -> str:
                     str(artifact.output_probe_count),
                     ";".join(artifact.output_probes),
                     str(artifact.measurement_count),
+                    ";".join(artifact.measurement_names),
                     str(artifact.fourier_count),
                 ]
             )

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -6792,9 +6792,10 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
     assert op_execution.table == "Index\tV(mid)\n0\t5.000000e-01\n"
     assert op_execution.run_artifacts[0].result_rows == 1
     assert op_execution.run_artifacts[0].output_probes == ["V(mid)"]
+    assert op_execution.run_artifacts[0].measurement_names == []
     assert op_execution.run_artifact_table == (
-        "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tOutputProbeList\tMeasurements\tFourier\n"
-        f"op\t.op\t{op_execution.plan.line_number}\t1\t1\tV(mid)\t0\t0\n"
+        "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tOutputProbeList\tMeasurements\tMeasurementList\tFourier\n"
+        f"op\t.op\t{op_execution.plan.line_number}\t1\t1\tV(mid)\t0\t\t0\n"
     )
 
     dc_execution = run_deck_analysis(circuit, netlist, "dc")
@@ -6814,9 +6815,10 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
     )
     assert dc_execution.run_artifacts[0].analysis == "dc"
     assert dc_execution.run_artifacts[0].output_probes == ["V(mid)", "I(V1)"]
+    assert dc_execution.run_artifacts[0].measurement_names == ["mid_avg"]
     assert dc_execution.run_artifact_table == (
-        "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tOutputProbeList\tMeasurements\tFourier\n"
-        f"dc\t.dc\t{dc_execution.plan.line_number}\t2\t2\tV(mid);I(V1)\t1\t0\n"
+        "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tOutputProbeList\tMeasurements\tMeasurementList\tFourier\n"
+        f"dc\t.dc\t{dc_execution.plan.line_number}\t2\t2\tV(mid);I(V1)\t1\tmid_avg\t0\n"
     )
 
     ac_execution = run_deck_analysis(circuit, netlist, "ac")
@@ -6833,9 +6835,10 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
         "0\t1.000000e+03\tV(mid)\t5.000000e-01\t0.000000e+00\t5.000000e-01\t0.000000e+00\n"
     )
     assert ac_execution.run_artifacts[0].output_probes == ["V(mid)"]
+    assert ac_execution.run_artifacts[0].measurement_names == ["mid_peak"]
     assert ac_execution.run_artifact_table == (
-        "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tOutputProbeList\tMeasurements\tFourier\n"
-        f"ac\t.ac\t{ac_execution.plan.line_number}\t1\t1\tV(mid)\t1\t0\n"
+        "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tOutputProbeList\tMeasurements\tMeasurementList\tFourier\n"
+        f"ac\t.ac\t{ac_execution.plan.line_number}\t1\t1\tV(mid)\t1\tmid_peak\t0\n"
     )
 
     tran_execution = run_deck_analysis(circuit, netlist, "tran")
@@ -6854,9 +6857,10 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
         "1\t1.000000e-03\t5.000000e-01\n"
     )
     assert tran_execution.run_artifacts[0].output_probes == ["V(mid)"]
+    assert tran_execution.run_artifacts[0].measurement_names == ["mid_final"]
     assert tran_execution.run_artifact_table == (
-        "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tOutputProbeList\tMeasurements\tFourier\n"
-        f"tran\t.tran\t{tran_execution.plan.line_number}\t2\t1\tV(mid)\t1\t0\n"
+        "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tOutputProbeList\tMeasurements\tMeasurementList\tFourier\n"
+        f"tran\t.tran\t{tran_execution.plan.line_number}\t2\t1\tV(mid)\t1\tmid_final\t0\n"
     )
 
     tran_window_execution = run_deck_analysis(
@@ -6931,9 +6935,10 @@ def test_run_deck_analysis_exposes_selected_fourier_artifacts() -> None:
     assert tran_execution.fourier_table == format_fourier_table(result)
     assert tran_execution.run_artifacts[0].fourier_count == 1
     assert tran_execution.run_artifacts[0].output_probes == ["V(mid)"]
+    assert tran_execution.run_artifacts[0].measurement_names == []
     assert tran_execution.run_artifact_table == (
-        "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tOutputProbeList\tMeasurements\tFourier\n"
-        f"tran\t.tran\t{tran_execution.plan.line_number}\t3\t1\tV(mid)\t0\t1\n"
+        "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tOutputProbeList\tMeasurements\tMeasurementList\tFourier\n"
+        f"tran\t.tran\t{tran_execution.plan.line_number}\t3\t1\tV(mid)\t0\t\t1\n"
     )
 
 

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Add selected measurement names to selected-run artifacts in
+  `run_deck_analysis` and render them in a stable `MeasurementList` column
+  from `format_deck_run_artifact_table`, matching Python and TypeScript.
 - Add normalized output-probe names to selected-run artifacts in
   `run_deck_analysis` and render them in a stable `OutputProbeList` column
   from `format_deck_run_artifact_table`, matching Python and TypeScript.

--- a/code/packages/rust/spice-engine/README.md
+++ b/code/packages/rust/spice-engine/README.md
@@ -183,7 +183,7 @@ an internal fixed-step cap, and `UIC` initial-condition intent through that
 stable transient table surface. They also return selected `.four` harmonic
 results and a stable Fourier table. Executions also include selected-run
 artifact summaries plus `format_deck_run_artifact_table` output for stable
-result-row, output-probe count/name list, measurement, and Fourier counts.
+result-row, output-probe and measurement count/name lists plus Fourier counts.
 `resolve_deck_fourier`, `fourier_transient_cards`,
 `fourier_transient_deck`, and `format_deck_fourier_table` extract parsed
 `.four` / `.FOUR` cards before `.end` and route transient samples into the
@@ -228,6 +228,6 @@ downstream deck execution helpers.
 `run_deck_analysis` routes that selected plan into the matching solver and
 stable deck-selected table output with normalized output-probe artifacts,
 selected measurement artifacts, selected transient Fourier artifacts,
-selected-run artifact summaries with output-probe name lists, `.ac LIN`,
-`.ac DEC`, `.ac OCT` frequency grids, and `.tran` `START` / print-step
-`TSTEP` / `MAXSTEP` / `UIC` controls.
+selected-run artifact summaries with output-probe and measurement name lists,
+`.ac LIN`, `.ac DEC`, `.ac OCT` frequency grids, and `.tran` `START` /
+print-step `TSTEP` / `MAXSTEP` / `UIC` controls.

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -3407,6 +3407,7 @@ pub struct DeckRunArtifact {
     pub output_probe_count: usize,
     pub output_probes: Vec<String>,
     pub measurement_count: usize,
+    pub measurement_names: Vec<String>,
     pub fourier_count: usize,
 }
 
@@ -9798,18 +9799,22 @@ fn deck_run_artifacts(
         output_probe_count: output_probes.len(),
         output_probes: output_probes.to_vec(),
         measurement_count: measurements.len(),
+        measurement_names: measurements
+            .iter()
+            .map(|measurement| measurement.name.clone())
+            .collect(),
         fourier_count: fourier.len(),
     }]
 }
 
 pub fn format_deck_run_artifact_table(artifacts: &[DeckRunArtifact]) -> String {
     let mut rows = vec![
-        "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tOutputProbeList\tMeasurements\tFourier"
+        "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tOutputProbeList\tMeasurements\tMeasurementList\tFourier"
             .to_string(),
     ];
     for artifact in artifacts {
         rows.push(format!(
-            "{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}",
+            "{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}",
             artifact.analysis,
             artifact.directive,
             artifact.line_number,
@@ -9817,6 +9822,7 @@ pub fn format_deck_run_artifact_table(artifacts: &[DeckRunArtifact]) -> String {
             artifact.output_probe_count,
             artifact.output_probes.join(";"),
             artifact.measurement_count,
+            artifact.measurement_names.join(";"),
             artifact.fourier_count
         ));
     }

--- a/code/packages/rust/spice-engine/tests/transient_tests.rs
+++ b/code/packages/rust/spice-engine/tests/transient_tests.rs
@@ -1888,10 +1888,11 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
         op_execution.run_artifacts[0].output_probes,
         vec!["V(mid)".to_string()]
     );
+    assert!(op_execution.run_artifacts[0].measurement_names.is_empty());
     assert_eq!(
         op_execution.run_artifact_table,
         format!(
-            "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tOutputProbeList\tMeasurements\tFourier\nop\t.op\t{}\t1\t1\tV(mid)\t0\t0\n",
+            "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tOutputProbeList\tMeasurements\tMeasurementList\tFourier\nop\t.op\t{}\t1\t1\tV(mid)\t0\t\t0\n",
             op_execution.plan.line_number
         )
     );
@@ -1921,9 +1922,13 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
         vec!["V(mid)".to_string(), "I(V1)".to_string()]
     );
     assert_eq!(
+        dc_execution.run_artifacts[0].measurement_names,
+        vec!["mid_avg".to_string()]
+    );
+    assert_eq!(
         dc_execution.run_artifact_table,
         format!(
-            "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tOutputProbeList\tMeasurements\tFourier\ndc\t.dc\t{}\t2\t2\tV(mid);I(V1)\t1\t0\n",
+            "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tOutputProbeList\tMeasurements\tMeasurementList\tFourier\ndc\t.dc\t{}\t2\t2\tV(mid);I(V1)\t1\tmid_avg\t0\n",
             dc_execution.plan.line_number
         )
     );
@@ -1948,9 +1953,13 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
         vec!["V(mid)".to_string()]
     );
     assert_eq!(
+        ac_execution.run_artifacts[0].measurement_names,
+        vec!["mid_peak".to_string()]
+    );
+    assert_eq!(
         ac_execution.run_artifact_table,
         format!(
-            "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tOutputProbeList\tMeasurements\tFourier\nac\t.ac\t{}\t1\t1\tV(mid)\t1\t0\n",
+            "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tOutputProbeList\tMeasurements\tMeasurementList\tFourier\nac\t.ac\t{}\t1\t1\tV(mid)\t1\tmid_peak\t0\n",
             ac_execution.plan.line_number
         )
     );
@@ -1975,9 +1984,13 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
         vec!["V(mid)".to_string()]
     );
     assert_eq!(
+        tran_execution.run_artifacts[0].measurement_names,
+        vec!["mid_final".to_string()]
+    );
+    assert_eq!(
         tran_execution.run_artifact_table,
         format!(
-            "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tOutputProbeList\tMeasurements\tFourier\ntran\t.tran\t{}\t1\t1\tV(mid)\t1\t0\n",
+            "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tOutputProbeList\tMeasurements\tMeasurementList\tFourier\ntran\t.tran\t{}\t1\t1\tV(mid)\t1\tmid_final\t0\n",
             tran_execution.plan.line_number
         )
     );
@@ -2084,10 +2097,11 @@ fn run_deck_analysis_exposes_selected_fourier_artifacts() {
         tran_execution.run_artifacts[0].output_probes,
         vec!["V(mid)".to_string()]
     );
+    assert!(tran_execution.run_artifacts[0].measurement_names.is_empty());
     assert_eq!(
         tran_execution.run_artifact_table,
         format!(
-            "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tOutputProbeList\tMeasurements\tFourier\ntran\t.tran\t{}\t2\t1\tV(mid)\t0\t1\n",
+            "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tOutputProbeList\tMeasurements\tMeasurementList\tFourier\ntran\t.tran\t{}\t2\t1\tV(mid)\t0\t\t1\n",
             tran_execution.plan.line_number
         )
     );

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Add selected measurement names to selected-run artifacts in
+  `runDeckAnalysis` and render them in a stable `MeasurementList` column from
+  `formatDeckRunArtifactTable`, matching Python and Rust.
 - Add normalized output-probe names to selected-run artifacts in
   `runDeckAnalysis` and render them in a stable `OutputProbeList` column from
   `formatDeckRunArtifactTable`, matching Python and Rust.

--- a/code/packages/typescript/spice-engine/README.md
+++ b/code/packages/typescript/spice-engine/README.md
@@ -99,7 +99,7 @@ an internal fixed-step cap, and `UIC` initial-condition intent through that
 stable transient table surface. They also return selected `.four` harmonic
 results and a stable Fourier table. Executions also include selected-run
 artifact summaries plus `formatDeckRunArtifactTable` output for stable
-result-row, output-probe count/name list, measurement, and Fourier counts.
+result-row, output-probe and measurement count/name lists plus Fourier counts.
 `resolveDeckOutputs` and `selectDeckOutputProbes` extract `.save`, scoped or
 global `.probe`, scoped `.print <analysis> ...`, and scoped
 `.plot <analysis> ...` cards before `.end`, normalize and deduplicate output
@@ -192,6 +192,6 @@ deck execution helpers.
 `runDeckAnalysis` routes that selected plan into the matching solver and stable
 deck-selected table output with normalized output-probe artifacts, selected
 measurement artifacts, selected transient Fourier artifacts, selected-run
-artifact summaries with output-probe name lists, `.ac LIN`, `.ac DEC`,
-`.ac OCT` frequency grids, and `.tran` `START` / print-step `TSTEP` /
-`MAXSTEP` / `UIC` controls.
+artifact summaries with output-probe and measurement name lists, `.ac LIN`,
+`.ac DEC`, `.ac OCT` frequency grids, and `.tran` `START` / print-step
+`TSTEP` / `MAXSTEP` / `UIC` controls.

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -662,6 +662,7 @@ export interface DeckRunArtifact {
   readonly outputProbeCount: number;
   readonly outputProbes: readonly string[];
   readonly measurementCount: number;
+  readonly measurementNames: readonly string[];
   readonly fourierCount: number;
 }
 
@@ -7624,6 +7625,7 @@ function deckRunArtifacts(
       outputProbeCount: outputProbes.length,
       outputProbes: [...outputProbes],
       measurementCount: measurements.length,
+      measurementNames: measurements.map((measurement) => measurement.name),
       fourierCount: fourier.length,
     },
   ];
@@ -7631,7 +7633,7 @@ function deckRunArtifacts(
 
 export function formatDeckRunArtifactTable(artifacts: readonly DeckRunArtifact[]): string {
   const rows = [
-    "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tOutputProbeList\tMeasurements\tFourier",
+    "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tOutputProbeList\tMeasurements\tMeasurementList\tFourier",
   ];
   for (const artifact of artifacts) {
     rows.push(
@@ -7643,6 +7645,7 @@ export function formatDeckRunArtifactTable(artifacts: readonly DeckRunArtifact[]
         String(artifact.outputProbeCount),
         artifact.outputProbes.join(";"),
         String(artifact.measurementCount),
+        artifact.measurementNames.join(";"),
         String(artifact.fourierCount),
       ].join("\t"),
     );

--- a/code/packages/typescript/spice-engine/tests/transient.test.ts
+++ b/code/packages/typescript/spice-engine/tests/transient.test.ts
@@ -1465,9 +1465,10 @@ describe("transient", () => {
     expect(opExecution.table).toBe("Index\tV(mid)\n0\t5.000000e-01\n");
     expect(opExecution.runArtifacts[0]?.resultRows).toBe(1);
     expect(opExecution.runArtifacts[0]?.outputProbes).toEqual(["V(mid)"]);
+    expect(opExecution.runArtifacts[0]?.measurementNames).toEqual([]);
     expect(opExecution.runArtifactTable).toBe(
-      "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tOutputProbeList\tMeasurements\tFourier\n" +
-        `op\t.op\t${opExecution.plan.lineNumber}\t1\t1\tV(mid)\t0\t0\n`,
+      "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tOutputProbeList\tMeasurements\tMeasurementList\tFourier\n" +
+        `op\t.op\t${opExecution.plan.lineNumber}\t1\t1\tV(mid)\t0\t\t0\n`,
     );
 
     const dcExecution = runDeckAnalysis(circuit, netlist, "dc");
@@ -1486,9 +1487,10 @@ describe("transient", () => {
     );
     expect(dcExecution.runArtifacts[0]?.analysis).toBe("dc");
     expect(dcExecution.runArtifacts[0]?.outputProbes).toEqual(["V(mid)", "I(V1)"]);
+    expect(dcExecution.runArtifacts[0]?.measurementNames).toEqual(["mid_avg"]);
     expect(dcExecution.runArtifactTable).toBe(
-      "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tOutputProbeList\tMeasurements\tFourier\n" +
-        `dc\t.dc\t${dcExecution.plan.lineNumber}\t2\t2\tV(mid);I(V1)\t1\t0\n`,
+      "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tOutputProbeList\tMeasurements\tMeasurementList\tFourier\n" +
+        `dc\t.dc\t${dcExecution.plan.lineNumber}\t2\t2\tV(mid);I(V1)\t1\tmid_avg\t0\n`,
     );
 
     const acExecution = runDeckAnalysis(circuit, netlist, "ac");
@@ -1504,9 +1506,10 @@ describe("transient", () => {
         "0\t1.000000e+03\tV(mid)\t5.000000e-01\t0.000000e+00\t5.000000e-01\t0.000000e+00\n",
     );
     expect(acExecution.runArtifacts[0]?.outputProbes).toEqual(["V(mid)"]);
+    expect(acExecution.runArtifacts[0]?.measurementNames).toEqual(["mid_peak"]);
     expect(acExecution.runArtifactTable).toBe(
-      "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tOutputProbeList\tMeasurements\tFourier\n" +
-        `ac\t.ac\t${acExecution.plan.lineNumber}\t1\t1\tV(mid)\t1\t0\n`,
+      "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tOutputProbeList\tMeasurements\tMeasurementList\tFourier\n" +
+        `ac\t.ac\t${acExecution.plan.lineNumber}\t1\t1\tV(mid)\t1\tmid_peak\t0\n`,
     );
 
     const tranExecution = runDeckAnalysis(circuit, netlist, "tran");
@@ -1522,9 +1525,10 @@ describe("transient", () => {
         "0\t1.000000e-03\t5.000000e-01\n",
     );
     expect(tranExecution.runArtifacts[0]?.outputProbes).toEqual(["V(mid)"]);
+    expect(tranExecution.runArtifacts[0]?.measurementNames).toEqual(["mid_final"]);
     expect(tranExecution.runArtifactTable).toBe(
-      "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tOutputProbeList\tMeasurements\tFourier\n" +
-        `tran\t.tran\t${tranExecution.plan.lineNumber}\t1\t1\tV(mid)\t1\t0\n`,
+      "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tOutputProbeList\tMeasurements\tMeasurementList\tFourier\n" +
+        `tran\t.tran\t${tranExecution.plan.lineNumber}\t1\t1\tV(mid)\t1\tmid_final\t0\n`,
     );
 
     const tranWindowExecution = runDeckAnalysis(
@@ -1602,9 +1606,10 @@ describe("transient", () => {
     expect(tranExecution.fourierTable).toBe(formatFourierTable(result));
     expect(tranExecution.runArtifacts[0]?.fourierCount).toBe(1);
     expect(tranExecution.runArtifacts[0]?.outputProbes).toEqual(["V(mid)"]);
+    expect(tranExecution.runArtifacts[0]?.measurementNames).toEqual([]);
     expect(tranExecution.runArtifactTable).toBe(
-      "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tOutputProbeList\tMeasurements\tFourier\n" +
-        `tran\t.tran\t${tranExecution.plan.lineNumber}\t2\t1\tV(mid)\t0\t1\n`,
+      "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tOutputProbeList\tMeasurements\tMeasurementList\tFourier\n" +
+        `tran\t.tran\t${tranExecution.plan.lineNumber}\t2\t1\tV(mid)\t0\t\t1\n`,
     );
   });
 

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -87,7 +87,7 @@ downstream tools to compare.
      stable Fourier tables; selected deck executions now include structured
      run-artifact summaries plus stable row/count tables for result rows,
      output probes, measurements, and Fourier artifacts, with normalized
-     output-probe name lists included in the run artifacts.
+     output-probe and measurement name lists included in the run artifacts.
    - Expand remaining deck-controlled analyses toward full SPICE compatibility
      while keeping unsupported control-flow diagnostics explicit.
 
@@ -741,12 +741,21 @@ downstream tools to compare.
       can inspect deck-owned probe provenance without reparsing solver output
       tables.
 
+66. Deck run measurement artifact names.
+    - Status: completed in this deck run measurement artifact slice.
+    - Python, Rust, and TypeScript selected deck executions now include the
+      selected measurement names inside selected-run artifacts alongside the
+      existing measurement counts.
+    - The stable run-artifact table now includes `MeasurementList`, so callers
+      can inspect deck-owned measurement provenance without reparsing
+      measurement tables.
+
 ## Backlog
 
 1. Deck execution layer.
    - Expand selected-plan execution beyond fixed-step transient basics,
-     including richer deck-owned run artifacts beyond selected output,
-     measurement, Fourier, and run-summary metadata, plus output-plan
+     including richer deck-owned run artifacts beyond selected output and
+     measurement lists, Fourier metadata, and run summaries, plus output-plan
      integration beyond stable table routing.
    - Expand deck-controlled output-plan integration beyond stable table
      routing and scoped `.save`, `.probe`, `.print`, `.plot`, and `.four`


### PR DESCRIPTION
## Summary
- add selected measurement name lists to deck run artifacts across Python, Rust, and TypeScript
- extend the stable run-artifact table with a MeasurementList column while preserving measurement counts
- update docs, changelogs, and the SPICE implementation plan with completed slice 66

## Verification
- /Users/adhithya/.local/share/mise/installs/python/3.12.13/bin/ruff check code/packages/python/spice-engine
- PYTEST_ADDOPTS=--no-cov PYTHONPATH=code/packages/python/device-physics/src:code/packages/python/mosfet-models/src:code/packages/python/spice-engine/src /Users/adhithya/.local/share/mise/installs/python/3.12.13/bin/python3.12 -m pytest code/packages/python/spice-engine/tests -q
- cargo fmt --manifest-path code/packages/rust/spice-engine/Cargo.toml -- --check
- cargo test --manifest-path code/packages/rust/spice-engine/Cargo.toml
- PATH=/Users/adhithya/.local/share/mise/installs/node/22.22.3/bin:$PATH npm --prefix code/packages/typescript/spice-engine run build
- PATH=/Users/adhithya/.local/share/mise/installs/node/22.22.3/bin:$PATH npm --prefix code/packages/typescript/spice-engine test