### PR TITLE
feat(visicalc-swiftui): Save / Load (serialize) over the C interop

### DIFF
--- a/demo/visicalc-swiftui/README.md
+++ b/demo/visicalc-swiftui/README.md
@@ -92,6 +92,12 @@ The **Copy / Cut / Paste** buttons drive the engine's clipboard
 with its relative references shifted by the destination's offset (absolute `$`
 refs pinned, format carried); a cut clears the source on paste, and `pasteCell`
 returns `false` (a no-op) for an empty clipboard.
+The **Save / Load** buttons serialize the whole workbook
+(`WindowedSheetModel.saveBook` over the C ABI's `sc_serialize`) to a JSON
+document held in memory and restore it (`loadBook` / `sc_deserialize`): the
+document captures only the source (formula text + typed literals) and per-cell
+formats — not the computed values, which the engine recomputes on load, so a
+loaded formula stays live.
 
 Headless proof: `Tests/VisiCalcTests/WindowedModelTests.swift` asserts the
 window is engine-computed and dense, a formula 1000 rows down (`Z1000` = 39) is
@@ -100,7 +106,9 @@ reachable, the gaps are empty (sparse), column letters run AA/BA/BB, editing
 replicates a relative formula down a column (`I1 = =H1*10` filled down ⇒ I2 = 30,
 I3 = 40, source I1 = 20 untouched), and the clipboard (copy `I1 = =H1*2` → paste
 at I2 ⇒ I2 = H2*2 = 14; cut A1 → move to C1, A1 clears, a second paste is a
-no-op). Run with `swift test`.
+no-op), and a save/load round trip (`saveBook` → mutate A1 ⇒ E1 523.00 →
+`loadBook` restores A1 15 / E1 38.00, the loaded formula stays live with A1=5 ⇒
+E1 28.00, and malformed input is rejected). Run with `swift test`.
 
 ## Notes
 

--- a/demo/visicalc-swiftui/Sources/CSpreadsheetEngine/include/spreadsheet.h
+++ b/demo/visicalc-swiftui/Sources/CSpreadsheetEngine/include/spreadsheet.h
@@ -47,25 +47,6 @@ void  sc_set_format(ScSession *s, const char *a1, const char *code);
 char *sc_get_format(ScSession *s, const char *a1);                /* -> code | ""   */
 char *sc_get_display(ScSession *s, const char *a1);               /* -> display str */
 
-/* Fill / replicate (drag-fill): copy the `src` cell across the inclusive
-   rectangle `dst_start`..`dst_end`. Relative references shift per target,
-   absolute ($) refs pin, the source's format carries along, an empty source
-   clears each target; a malformed address is a no-op. No return — the host
-   re-reads via sc_get_window / sc_get_display_window / sc_get_raw afterwards. */
-void  sc_fill(ScSession *s, const char *src, const char *dst_start, const char *dst_end);
-
-/* Clipboard — cut / copy / paste. copy/cut capture the inclusive rectangle
-   `start`..`end` (content + format + the typed source) as a whole-block copy
-   that pastes as a unit. A copy's buffer survives any number of pastes; a cut is
-   a one-shot move whose paste clears the source it didn't overwrite. paste
-   places the block so its top-left lands at `dst_start`, shifting the block's
-   references by the destination's offset; it returns 1 when applied, 0 for a
-   no-op (empty clipboard / malformed address / off-grid). The host re-reads via
-   sc_get_window / sc_get_display_window / sc_get_raw afterwards. */
-void  sc_copy(ScSession *s, const char *start, const char *end);
-void  sc_cut(ScSession *s, const char *start, const char *end);
-int   sc_paste(ScSession *s, const char *dst_start);
-
 /* Structural edits — insert/delete rows & columns. 1-based `at`, `count` lines.
    The engine relocates cells and rewrites formula references (a reference to a
    deleted line becomes #REF!); the formula echo stays in step. No return — the
@@ -74,6 +55,34 @@ void  sc_insert_rows(ScSession *s, uint32_t at, uint32_t count);
 void  sc_delete_rows(ScSession *s, uint32_t at, uint32_t count);
 void  sc_insert_cols(ScSession *s, uint32_t at, uint32_t count);
 void  sc_delete_cols(ScSession *s, uint32_t at, uint32_t count);
+
+/* Fill / replicate (drag-fill): copy the `src` cell across the inclusive
+   rectangle `dst_start`..`dst_end`. Relative references shift per target,
+   absolute ($) refs pin, the source's format carries along, an empty source
+   clears each target; a malformed address is a no-op. No return — the host
+   re-reads via sc_get_window / sc_get_display_window / sc_get_raw afterwards. */
+void  sc_fill(ScSession *s, const char *src, const char *dst_start, const char *dst_end);
+
+/* Clipboard — cut / copy / paste. copy/cut capture the inclusive rectangle
+   `start`..`end` (content + format + the typed source). A copy's buffer survives
+   any number of pastes; a cut is a one-shot move whose paste clears the source it
+   didn't overwrite. paste places the block so its top-left lands at `dst_start`,
+   shifting the whole block's references by the destination's offset; it returns 1
+   when applied, 0 for a no-op (empty clipboard / malformed address / off-grid).
+   No char* results — the host re-reads via sc_get_window / sc_get_display_window /
+   sc_get_raw afterwards. A malformed/oversized range on copy/cut is a no-op. */
+void  sc_copy(ScSession *s, const char *start, const char *end);
+void  sc_cut(ScSession *s, const char *start, const char *end);
+int   sc_paste(ScSession *s, const char *dst_start);
+
+/* Save / load. sc_serialize() returns a self-contained JSON document holding the
+   workbook's SOURCE (formula text + typed literals) and per-cell formats — not the
+   computed values, which recompute on load (small file, can't disagree with itself).
+   Free the returned string with sc_string_free(). sc_deserialize() replaces the
+   workbook with such a document: returns 1 on success, 0 if the data is malformed or
+   an unsupported version (the existing workbook is left untouched on failure). */
+char *sc_serialize(ScSession *s);
+int   sc_deserialize(ScSession *s, const char *data);
 
 /* Viewport primitive — read just the visible window of the unbounded sheet.
    Coordinates are 1-based and inclusive. Each char* result must be freed with

--- a/demo/visicalc-swiftui/Sources/VisiCalc/Engine.swift
+++ b/demo/visicalc-swiftui/Sources/VisiCalc/Engine.swift
@@ -69,6 +69,23 @@ final class SpreadsheetSession {
         sc_paste(handle, dstStart) != 0
     }
 
+    /// Serialize the whole workbook to a self-contained JSON document — the
+    /// SOURCE (formula text + typed literals) + per-cell formats, not the
+    /// computed values (those recompute on load, so the document is small and
+    /// can't disagree with itself). `take` frees the engine's `char*`; the host
+    /// persists the returned string wherever it likes. Reaches `sc_serialize`.
+    func serialize() -> String {
+        take(sc_serialize(handle))
+    }
+
+    /// Replace the workbook from a document produced by `serialize`. Returns
+    /// `true` on success, `false` for malformed / unsupported input (the workbook
+    /// is left untouched — the engine validates before it mutates). Formulas
+    /// reload live. Reaches `sc_deserialize`.
+    func deserialize(_ data: String) -> Bool {
+        sc_deserialize(handle, data) != 0
+    }
+
     /// The computed value of a cell as the string a spreadsheet should show.
     /// Parses the engine's JSON (`{"kind":...}`) — the same shape the TS and
     /// WASM engines emit.

--- a/demo/visicalc-swiftui/Sources/VisiCalc/InfiniteGrid.swift
+++ b/demo/visicalc-swiftui/Sources/VisiCalc/InfiniteGrid.swift
@@ -164,6 +164,26 @@ final class WindowedSheetModel: ObservableObject {
         return ok
     }
 
+    /// Save / load: serialize the whole workbook to a JSON document, and restore
+    /// it. The document stores only the source + formats — computed values
+    /// recompute on load, so a loaded formula stays live. `loadBook` returns
+    /// `false` (workbook untouched) for malformed input; on success it resizes
+    /// the extent, refreshes the formula bar, and bumps `revision` so the view
+    /// re-reads.
+    func saveBook() -> String {
+        session.serialize()
+    }
+    @discardableResult
+    func loadBook(_ data: String) -> Bool {
+        let ok = session.deserialize(data)
+        if ok {
+            resize()
+            formulaText = session.getRaw(address(selectedRow, selectedCol))
+            revision += 1
+        }
+        return ok
+    }
+
     /// Write `raw` into an explicit A1 cell and return the cells it dirtied.
     /// (Kept for the headless `WindowedModelTests`.)
     @discardableResult
@@ -179,6 +199,11 @@ final class WindowedSheetModel: ObservableObject {
 /// The virtualized, editable grid view.
 struct InfiniteGridView: View {
     @ObservedObject var model: WindowedSheetModel
+
+    // In-memory "saved file" slot for the Save / Load buttons: Save stows the
+    // serialized workbook here, Load restores from it. (A real app would write it
+    // to a file; the demo keeps the round trip self-contained.)
+    @State private var savedSnapshot = ""
 
     static let rowH: CGFloat = 22
     static let colW: CGFloat = 80
@@ -238,6 +263,14 @@ struct InfiniteGridView: View {
             Button("Paste") { model.pasteCell() }
                 .font(.system(size: 11, design: .monospaced))
                 .help("Paste the clipboard at the selected cell, shifting relative references")
+            // Save / load: serialize the whole workbook to memory, and restore it.
+            Button("Save") { savedSnapshot = model.saveBook() }
+                .font(.system(size: 11, design: .monospaced))
+                .help("Serialize the whole workbook to memory")
+            Button("Load") { if !savedSnapshot.isEmpty { model.loadBook(savedSnapshot) } }
+                .font(.system(size: 11, design: .monospaced))
+                .disabled(savedSnapshot.isEmpty)
+                .help("Restore the workbook from the last save")
         }
         .padding(.bottom, 8)
     }

--- a/demo/visicalc-swiftui/Tests/VisiCalcTests/WindowedModelTests.swift
+++ b/demo/visicalc-swiftui/Tests/VisiCalcTests/WindowedModelTests.swift
@@ -97,4 +97,27 @@ final class WindowedModelTests: XCTestCase {
         m.select(row: 1, col: 5)
         XCTAssertFalse(m.pasteCell())          // buffer consumed
     }
+
+    /// Save / load: serialize the workbook, mutate it, then restore the snapshot
+    /// and confirm the workbook comes back — and that a loaded formula stays LIVE
+    /// (the document stores source + formats, not computed values).
+    func testSaveLoadRoundTrips() {
+        let m = WindowedSheetModel()
+        // The default seed has A1=15, E1 = SUM(A1:D1) = 38 (format "#,##0.00").
+        let snapshot = m.saveBook()
+        XCTAssertFalse(snapshot.isEmpty, "serialize produced a JSON document")
+        // Mutate away from the saved state so a load has to visibly undo it.
+        m.setCell("A1", "500") // E1 → 500+3+12+8 = 523
+        XCTAssertEqual(m.window(rows: 1...1, cols: 5...5)[0][0], "523.00")
+        // Restore: A1 → 15, E1 recomputes through its format back to "38.00".
+        XCTAssertTrue(m.loadBook(snapshot))
+        XCTAssertEqual(m.window(rows: 1...1, cols: 1...1)[0][0], "15")
+        XCTAssertEqual(m.window(rows: 1...1, cols: 5...5)[0][0], "38.00")
+        // The loaded formula is live, not frozen: edit a precedent and E1 recomputes.
+        m.setCell("A1", "5") // 5+3+12+8 = 28
+        XCTAssertEqual(m.window(rows: 1...1, cols: 5...5)[0][0], "28.00")
+        // Garbage in is rejected (false), leaving the workbook intact.
+        XCTAssertFalse(m.loadBook("not a workbook"))
+        XCTAssertEqual(m.window(rows: 1...1, cols: 5...5)[0][0], "28.00")
+    }
 }


### PR DESCRIPTION
## Summary

The **last** of the six save/load demo rollouts (web [#6161](https://github.com/adhithyan15/coding-adventures/pull/6161), Qt [#6163](https://github.com/adhithyan15/coding-adventures/pull/6163), Flutter [#6168](https://github.com/adhithyan15/coding-adventures/pull/6168), Compose [#6173](https://github.com/adhithyan15/coding-adventures/pull/6173), XAML [#6175](https://github.com/adhithyan15/coding-adventures/pull/6175) merged). Adds **Save / Load** to the SwiftUI infinite-sheet demo, driving the engine's save/load (spreadsheet-capi 0.8.0 `sc_serialize` / `sc_deserialize`) over the CSpreadsheetEngine C interop.

- `Engine.swift`: `serialize() -> String` (reads `sc_serialize`'s `char*` via the existing `take` helper, freed with `sc_string_free`) and `deserialize(String) -> Bool`. Malformed/unsupported input returns false and leaves the workbook untouched.
- `WindowedSheetModel.saveBook()` / `loadBook(_:)`: loadBook resizes the extent, refreshes the formula bar, and bumps `revision` on success.
- `InfiniteGrid.swift` gains **Save / Load** buttons next to Copy/Cut/Paste, holding the serialized document in an in-memory `@State savedSnapshot` (Load disabled until something is saved).
- The document stores only the *source* + formats; computed values recompute on load, so a loaded formula stays live.

## Test plan
- `swift test` — **8/8 PASS**. New `testSaveLoadRoundTrips`: serialize the seeded workbook, mutate A1 (E1 → 523.00), restore (A1 → 15, E1 → 38.00 through its format), confirm the loaded formula stays live (A1=5 ⇒ E1=28.00), garbage rejected.
- Updated the **tracked** `Sources/CSpreadsheetEngine/include/spreadsheet.h` with the `sc_serialize`/`sc_deserialize` declarations (synced from the canonical capi header); re-vendored `libspreadsheet_capi.a` (0.8.0) into `Vendor/macos/`.
- `/security-review`: PASSED (engine `char*` freed once via `take`'s `defer`; Swift String → `const char *` read-only for the call; null-session-safe; no UAF/double-free).

## 🎉 Save/load complete across all six backends
With this merge, **Save / Load (serialize)** works on every VisiCalc backend — web (WASM), Qt, Flutter, Compose, XAML, SwiftUI — all computing and persisting on the one shared Rust `spreadsheet-core` engine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)