### PR TITLE
Expose deck run Fourier probe names

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ### Added
 
+- **Deck run Fourier artifact probes** —
+  `run_deck_analysis()` selected-run artifacts now include selected Fourier
+  probe names alongside the Fourier result count, and
+  `format_deck_run_artifact_table()` renders a stable `FourierList` column,
+  matching Rust and TypeScript.
+
 - **Deck run measurement artifact names** —
   `run_deck_analysis()` selected-run artifacts now include selected
   measurement names alongside the measurement count, and

--- a/code/packages/python/spice-engine/README.md
+++ b/code/packages/python/spice-engine/README.md
@@ -65,7 +65,7 @@ print(result.diagnostics.solver)   # "dense_real" or "sparse_real"
 | `fourier` | `.FOUR` | Harmonic magnitudes/phases and THD from transient output |
 | `format_dc_table`, `format_transient_table` | `.PRINT` / `.PLOT` output | Stable tabular node voltages and branch currents |
 | `resolve_deck_outputs`, `format_deck_*_table` | `.SAVE` / `.PROBE` / `.PRINT` / `.PLOT` output | Parsed deck-selected OP, DC sweep, AC, and transient tables |
-| `format_deck_run_artifact_table` | Deck execution artifact | Stable selected-run row, output-probe and measurement count/name lists plus Fourier counts |
+| `format_deck_run_artifact_table` | Deck execution artifact | Stable selected-run row, output-probe, measurement, and Fourier count/name lists |
 | `measure_transient_probe`, `measure_dc_sweep_probe`, `measure_ac_sweep_probe`, `format_measurement_table` | `.MEASURE` output | Stable scalar transient, DC sweep, and AC sweep probe measurements |
 
 `diode_at_temperature()`, `bjt_at_temperature()`, `mosfet_at_temperature()`,
@@ -109,8 +109,8 @@ stable measurement table for `.dc`, `.ac`, and `.tran` executions. Selected
 `.tran` plans also return selected `.four` harmonic results and a stable
 Fourier table. Executions also include a selected-run artifact summary plus
 `format_deck_run_artifact_table()` output for stable result-row,
-output-probe and measurement count/name lists plus Fourier counts. They route `START` output
-filtering, use `.tran TSTEP` as the output print grid, apply `MAXSTEP` as an
+output-probe, measurement, and Fourier count/name lists. They route `START`
+output filtering, use `.tran TSTEP` as the output print grid, apply `MAXSTEP` as an
 internal fixed-step cap, and carry `UIC` initial-condition intent through that
 stable transient table surface.
 `resolve_deck_outputs()` and `select_deck_output_probes()` extract `.save`,
@@ -218,9 +218,9 @@ downstream deck execution helpers.
 `run_deck_analysis()` routes that selected plan into the matching solver and
 stable deck-selected table output with normalized output-probe artifacts,
 selected measurement artifacts, selected transient Fourier artifacts,
-selected-run artifact summaries with output-probe and measurement name lists,
-`.ac LIN`, `.ac DEC`, `.ac OCT` frequency grids, and `.tran` `START` /
-print-step `TSTEP` / `MAXSTEP` / `UIC` controls.
+selected-run artifact summaries with output-probe, measurement, and Fourier
+probe name lists, `.ac LIN`, `.ac DEC`, `.ac OCT` frequency grids, and `.tran`
+`START` / print-step `TSTEP` / `MAXSTEP` / `UIC` controls.
 
 ## Controlled source examples
 

--- a/code/packages/python/spice-engine/src/spice_engine/engine.py
+++ b/code/packages/python/spice-engine/src/spice_engine/engine.py
@@ -2306,6 +2306,7 @@ class DeckRunArtifact:
     measurement_count: int
     measurement_names: list[str]
     fourier_count: int
+    fourier_probes: list[str]
 
 
 @dataclass(frozen=True)
@@ -2381,6 +2382,9 @@ def _deck_run_artifacts(
             measurement_count=len(measurements),
             measurement_names=[measurement.name for measurement in measurements],
             fourier_count=len(fourier),
+            fourier_probes=[
+                probe.probe for result in fourier for probe in result.probes
+            ],
         )
     ]
 
@@ -2389,7 +2393,7 @@ def format_deck_run_artifact_table(artifacts: Iterable[DeckRunArtifact]) -> str:
     """Format selected deck-run artifacts as a stable summary table."""
 
     rows = [
-        "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tOutputProbeList\tMeasurements\tMeasurementList\tFourier"
+        "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tOutputProbeList\tMeasurements\tMeasurementList\tFourier\tFourierList"
     ]
     for artifact in artifacts:
         rows.append(
@@ -2404,6 +2408,7 @@ def format_deck_run_artifact_table(artifacts: Iterable[DeckRunArtifact]) -> str:
                     str(artifact.measurement_count),
                     ";".join(artifact.measurement_names),
                     str(artifact.fourier_count),
+                    ";".join(artifact.fourier_probes),
                 ]
             )
         )

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -6793,9 +6793,10 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
     assert op_execution.run_artifacts[0].result_rows == 1
     assert op_execution.run_artifacts[0].output_probes == ["V(mid)"]
     assert op_execution.run_artifacts[0].measurement_names == []
+    assert op_execution.run_artifacts[0].fourier_probes == []
     assert op_execution.run_artifact_table == (
-        "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tOutputProbeList\tMeasurements\tMeasurementList\tFourier\n"
-        f"op\t.op\t{op_execution.plan.line_number}\t1\t1\tV(mid)\t0\t\t0\n"
+        "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tOutputProbeList\tMeasurements\tMeasurementList\tFourier\tFourierList\n"
+        f"op\t.op\t{op_execution.plan.line_number}\t1\t1\tV(mid)\t0\t\t0\t\n"
     )
 
     dc_execution = run_deck_analysis(circuit, netlist, "dc")
@@ -6816,9 +6817,10 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
     assert dc_execution.run_artifacts[0].analysis == "dc"
     assert dc_execution.run_artifacts[0].output_probes == ["V(mid)", "I(V1)"]
     assert dc_execution.run_artifacts[0].measurement_names == ["mid_avg"]
+    assert dc_execution.run_artifacts[0].fourier_probes == []
     assert dc_execution.run_artifact_table == (
-        "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tOutputProbeList\tMeasurements\tMeasurementList\tFourier\n"
-        f"dc\t.dc\t{dc_execution.plan.line_number}\t2\t2\tV(mid);I(V1)\t1\tmid_avg\t0\n"
+        "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tOutputProbeList\tMeasurements\tMeasurementList\tFourier\tFourierList\n"
+        f"dc\t.dc\t{dc_execution.plan.line_number}\t2\t2\tV(mid);I(V1)\t1\tmid_avg\t0\t\n"
     )
 
     ac_execution = run_deck_analysis(circuit, netlist, "ac")
@@ -6836,9 +6838,10 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
     )
     assert ac_execution.run_artifacts[0].output_probes == ["V(mid)"]
     assert ac_execution.run_artifacts[0].measurement_names == ["mid_peak"]
+    assert ac_execution.run_artifacts[0].fourier_probes == []
     assert ac_execution.run_artifact_table == (
-        "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tOutputProbeList\tMeasurements\tMeasurementList\tFourier\n"
-        f"ac\t.ac\t{ac_execution.plan.line_number}\t1\t1\tV(mid)\t1\tmid_peak\t0\n"
+        "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tOutputProbeList\tMeasurements\tMeasurementList\tFourier\tFourierList\n"
+        f"ac\t.ac\t{ac_execution.plan.line_number}\t1\t1\tV(mid)\t1\tmid_peak\t0\t\n"
     )
 
     tran_execution = run_deck_analysis(circuit, netlist, "tran")
@@ -6858,9 +6861,10 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
     )
     assert tran_execution.run_artifacts[0].output_probes == ["V(mid)"]
     assert tran_execution.run_artifacts[0].measurement_names == ["mid_final"]
+    assert tran_execution.run_artifacts[0].fourier_probes == []
     assert tran_execution.run_artifact_table == (
-        "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tOutputProbeList\tMeasurements\tMeasurementList\tFourier\n"
-        f"tran\t.tran\t{tran_execution.plan.line_number}\t2\t1\tV(mid)\t1\tmid_final\t0\n"
+        "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tOutputProbeList\tMeasurements\tMeasurementList\tFourier\tFourierList\n"
+        f"tran\t.tran\t{tran_execution.plan.line_number}\t2\t1\tV(mid)\t1\tmid_final\t0\t\n"
     )
 
     tran_window_execution = run_deck_analysis(
@@ -6936,9 +6940,10 @@ def test_run_deck_analysis_exposes_selected_fourier_artifacts() -> None:
     assert tran_execution.run_artifacts[0].fourier_count == 1
     assert tran_execution.run_artifacts[0].output_probes == ["V(mid)"]
     assert tran_execution.run_artifacts[0].measurement_names == []
+    assert tran_execution.run_artifacts[0].fourier_probes == ["V(mid)"]
     assert tran_execution.run_artifact_table == (
-        "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tOutputProbeList\tMeasurements\tMeasurementList\tFourier\n"
-        f"tran\t.tran\t{tran_execution.plan.line_number}\t3\t1\tV(mid)\t0\t\t1\n"
+        "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tOutputProbeList\tMeasurements\tMeasurementList\tFourier\tFourierList\n"
+        f"tran\t.tran\t{tran_execution.plan.line_number}\t3\t1\tV(mid)\t0\t\t1\tV(mid)\n"
     )
 
 

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Add selected Fourier probe names to selected-run artifacts in
+  `run_deck_analysis` and render them in a stable `FourierList` column from
+  `format_deck_run_artifact_table`, matching Python and TypeScript.
 - Add selected measurement names to selected-run artifacts in
   `run_deck_analysis` and render them in a stable `MeasurementList` column
   from `format_deck_run_artifact_table`, matching Python and TypeScript.

--- a/code/packages/rust/spice-engine/README.md
+++ b/code/packages/rust/spice-engine/README.md
@@ -183,7 +183,7 @@ an internal fixed-step cap, and `UIC` initial-condition intent through that
 stable transient table surface. They also return selected `.four` harmonic
 results and a stable Fourier table. Executions also include selected-run
 artifact summaries plus `format_deck_run_artifact_table` output for stable
-result-row, output-probe and measurement count/name lists plus Fourier counts.
+result-row, output-probe, measurement, and Fourier count/name lists.
 `resolve_deck_fourier`, `fourier_transient_cards`,
 `fourier_transient_deck`, and `format_deck_fourier_table` extract parsed
 `.four` / `.FOUR` cards before `.end` and route transient samples into the
@@ -228,6 +228,6 @@ downstream deck execution helpers.
 `run_deck_analysis` routes that selected plan into the matching solver and
 stable deck-selected table output with normalized output-probe artifacts,
 selected measurement artifacts, selected transient Fourier artifacts,
-selected-run artifact summaries with output-probe and measurement name lists,
-`.ac LIN`, `.ac DEC`, `.ac OCT` frequency grids, and `.tran` `START` /
-print-step `TSTEP` / `MAXSTEP` / `UIC` controls.
+selected-run artifact summaries with output-probe, measurement, and Fourier
+probe name lists, `.ac LIN`, `.ac DEC`, `.ac OCT` frequency grids, and `.tran`
+`START` / print-step `TSTEP` / `MAXSTEP` / `UIC` controls.

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -3409,6 +3409,7 @@ pub struct DeckRunArtifact {
     pub measurement_count: usize,
     pub measurement_names: Vec<String>,
     pub fourier_count: usize,
+    pub fourier_probes: Vec<String>,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -9804,17 +9805,21 @@ fn deck_run_artifacts(
             .map(|measurement| measurement.name.clone())
             .collect(),
         fourier_count: fourier.len(),
+        fourier_probes: fourier
+            .iter()
+            .flat_map(|result| result.probes.iter().map(|probe| probe.probe.clone()))
+            .collect(),
     }]
 }
 
 pub fn format_deck_run_artifact_table(artifacts: &[DeckRunArtifact]) -> String {
     let mut rows = vec![
-        "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tOutputProbeList\tMeasurements\tMeasurementList\tFourier"
+        "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tOutputProbeList\tMeasurements\tMeasurementList\tFourier\tFourierList"
             .to_string(),
     ];
     for artifact in artifacts {
         rows.push(format!(
-            "{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}",
+            "{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}",
             artifact.analysis,
             artifact.directive,
             artifact.line_number,
@@ -9823,7 +9828,8 @@ pub fn format_deck_run_artifact_table(artifacts: &[DeckRunArtifact]) -> String {
             artifact.output_probes.join(";"),
             artifact.measurement_count,
             artifact.measurement_names.join(";"),
-            artifact.fourier_count
+            artifact.fourier_count,
+            artifact.fourier_probes.join(";")
         ));
     }
     format!("{}\n", rows.join("\n"))

--- a/code/packages/rust/spice-engine/tests/transient_tests.rs
+++ b/code/packages/rust/spice-engine/tests/transient_tests.rs
@@ -1889,10 +1889,11 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
         vec!["V(mid)".to_string()]
     );
     assert!(op_execution.run_artifacts[0].measurement_names.is_empty());
+    assert!(op_execution.run_artifacts[0].fourier_probes.is_empty());
     assert_eq!(
         op_execution.run_artifact_table,
         format!(
-            "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tOutputProbeList\tMeasurements\tMeasurementList\tFourier\nop\t.op\t{}\t1\t1\tV(mid)\t0\t\t0\n",
+            "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tOutputProbeList\tMeasurements\tMeasurementList\tFourier\tFourierList\nop\t.op\t{}\t1\t1\tV(mid)\t0\t\t0\t\n",
             op_execution.plan.line_number
         )
     );
@@ -1925,10 +1926,11 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
         dc_execution.run_artifacts[0].measurement_names,
         vec!["mid_avg".to_string()]
     );
+    assert!(dc_execution.run_artifacts[0].fourier_probes.is_empty());
     assert_eq!(
         dc_execution.run_artifact_table,
         format!(
-            "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tOutputProbeList\tMeasurements\tMeasurementList\tFourier\ndc\t.dc\t{}\t2\t2\tV(mid);I(V1)\t1\tmid_avg\t0\n",
+            "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tOutputProbeList\tMeasurements\tMeasurementList\tFourier\tFourierList\ndc\t.dc\t{}\t2\t2\tV(mid);I(V1)\t1\tmid_avg\t0\t\n",
             dc_execution.plan.line_number
         )
     );
@@ -1956,10 +1958,11 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
         ac_execution.run_artifacts[0].measurement_names,
         vec!["mid_peak".to_string()]
     );
+    assert!(ac_execution.run_artifacts[0].fourier_probes.is_empty());
     assert_eq!(
         ac_execution.run_artifact_table,
         format!(
-            "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tOutputProbeList\tMeasurements\tMeasurementList\tFourier\nac\t.ac\t{}\t1\t1\tV(mid)\t1\tmid_peak\t0\n",
+            "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tOutputProbeList\tMeasurements\tMeasurementList\tFourier\tFourierList\nac\t.ac\t{}\t1\t1\tV(mid)\t1\tmid_peak\t0\t\n",
             ac_execution.plan.line_number
         )
     );
@@ -1987,10 +1990,11 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
         tran_execution.run_artifacts[0].measurement_names,
         vec!["mid_final".to_string()]
     );
+    assert!(tran_execution.run_artifacts[0].fourier_probes.is_empty());
     assert_eq!(
         tran_execution.run_artifact_table,
         format!(
-            "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tOutputProbeList\tMeasurements\tMeasurementList\tFourier\ntran\t.tran\t{}\t1\t1\tV(mid)\t1\tmid_final\t0\n",
+            "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tOutputProbeList\tMeasurements\tMeasurementList\tFourier\tFourierList\ntran\t.tran\t{}\t1\t1\tV(mid)\t1\tmid_final\t0\t\n",
             tran_execution.plan.line_number
         )
     );
@@ -2099,9 +2103,13 @@ fn run_deck_analysis_exposes_selected_fourier_artifacts() {
     );
     assert!(tran_execution.run_artifacts[0].measurement_names.is_empty());
     assert_eq!(
+        tran_execution.run_artifacts[0].fourier_probes,
+        vec!["V(mid)".to_string()]
+    );
+    assert_eq!(
         tran_execution.run_artifact_table,
         format!(
-            "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tOutputProbeList\tMeasurements\tMeasurementList\tFourier\ntran\t.tran\t{}\t2\t1\tV(mid)\t0\t\t1\n",
+            "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tOutputProbeList\tMeasurements\tMeasurementList\tFourier\tFourierList\ntran\t.tran\t{}\t2\t1\tV(mid)\t0\t\t1\tV(mid)\n",
             tran_execution.plan.line_number
         )
     );

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Add selected Fourier probe names to selected-run artifacts in
+  `runDeckAnalysis` and render them in a stable `FourierList` column from
+  `formatDeckRunArtifactTable`, matching Python and Rust.
 - Add selected measurement names to selected-run artifacts in
   `runDeckAnalysis` and render them in a stable `MeasurementList` column from
   `formatDeckRunArtifactTable`, matching Python and Rust.

--- a/code/packages/typescript/spice-engine/README.md
+++ b/code/packages/typescript/spice-engine/README.md
@@ -99,7 +99,7 @@ an internal fixed-step cap, and `UIC` initial-condition intent through that
 stable transient table surface. They also return selected `.four` harmonic
 results and a stable Fourier table. Executions also include selected-run
 artifact summaries plus `formatDeckRunArtifactTable` output for stable
-result-row, output-probe and measurement count/name lists plus Fourier counts.
+result-row, output-probe, measurement, and Fourier count/name lists.
 `resolveDeckOutputs` and `selectDeckOutputProbes` extract `.save`, scoped or
 global `.probe`, scoped `.print <analysis> ...`, and scoped
 `.plot <analysis> ...` cards before `.end`, normalize and deduplicate output
@@ -192,6 +192,6 @@ deck execution helpers.
 `runDeckAnalysis` routes that selected plan into the matching solver and stable
 deck-selected table output with normalized output-probe artifacts, selected
 measurement artifacts, selected transient Fourier artifacts, selected-run
-artifact summaries with output-probe and measurement name lists, `.ac LIN`,
-`.ac DEC`, `.ac OCT` frequency grids, and `.tran` `START` / print-step
-`TSTEP` / `MAXSTEP` / `UIC` controls.
+artifact summaries with output-probe, measurement, and Fourier probe name
+lists, `.ac LIN`, `.ac DEC`, `.ac OCT` frequency grids, and `.tran` `START` /
+print-step `TSTEP` / `MAXSTEP` / `UIC` controls.

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -664,6 +664,7 @@ export interface DeckRunArtifact {
   readonly measurementCount: number;
   readonly measurementNames: readonly string[];
   readonly fourierCount: number;
+  readonly fourierProbes: readonly string[];
 }
 
 export interface DeckAnalysisExecution {
@@ -7627,13 +7628,14 @@ function deckRunArtifacts(
       measurementCount: measurements.length,
       measurementNames: measurements.map((measurement) => measurement.name),
       fourierCount: fourier.length,
+      fourierProbes: fourier.flatMap((result) => result.probes.map((probe) => probe.probe)),
     },
   ];
 }
 
 export function formatDeckRunArtifactTable(artifacts: readonly DeckRunArtifact[]): string {
   const rows = [
-    "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tOutputProbeList\tMeasurements\tMeasurementList\tFourier",
+    "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tOutputProbeList\tMeasurements\tMeasurementList\tFourier\tFourierList",
   ];
   for (const artifact of artifacts) {
     rows.push(
@@ -7647,6 +7649,7 @@ export function formatDeckRunArtifactTable(artifacts: readonly DeckRunArtifact[]
         String(artifact.measurementCount),
         artifact.measurementNames.join(";"),
         String(artifact.fourierCount),
+        artifact.fourierProbes.join(";"),
       ].join("\t"),
     );
   }

--- a/code/packages/typescript/spice-engine/tests/transient.test.ts
+++ b/code/packages/typescript/spice-engine/tests/transient.test.ts
@@ -1466,9 +1466,10 @@ describe("transient", () => {
     expect(opExecution.runArtifacts[0]?.resultRows).toBe(1);
     expect(opExecution.runArtifacts[0]?.outputProbes).toEqual(["V(mid)"]);
     expect(opExecution.runArtifacts[0]?.measurementNames).toEqual([]);
+    expect(opExecution.runArtifacts[0]?.fourierProbes).toEqual([]);
     expect(opExecution.runArtifactTable).toBe(
-      "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tOutputProbeList\tMeasurements\tMeasurementList\tFourier\n" +
-        `op\t.op\t${opExecution.plan.lineNumber}\t1\t1\tV(mid)\t0\t\t0\n`,
+      "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tOutputProbeList\tMeasurements\tMeasurementList\tFourier\tFourierList\n" +
+        `op\t.op\t${opExecution.plan.lineNumber}\t1\t1\tV(mid)\t0\t\t0\t\n`,
     );
 
     const dcExecution = runDeckAnalysis(circuit, netlist, "dc");
@@ -1488,9 +1489,10 @@ describe("transient", () => {
     expect(dcExecution.runArtifacts[0]?.analysis).toBe("dc");
     expect(dcExecution.runArtifacts[0]?.outputProbes).toEqual(["V(mid)", "I(V1)"]);
     expect(dcExecution.runArtifacts[0]?.measurementNames).toEqual(["mid_avg"]);
+    expect(dcExecution.runArtifacts[0]?.fourierProbes).toEqual([]);
     expect(dcExecution.runArtifactTable).toBe(
-      "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tOutputProbeList\tMeasurements\tMeasurementList\tFourier\n" +
-        `dc\t.dc\t${dcExecution.plan.lineNumber}\t2\t2\tV(mid);I(V1)\t1\tmid_avg\t0\n`,
+      "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tOutputProbeList\tMeasurements\tMeasurementList\tFourier\tFourierList\n" +
+        `dc\t.dc\t${dcExecution.plan.lineNumber}\t2\t2\tV(mid);I(V1)\t1\tmid_avg\t0\t\n`,
     );
 
     const acExecution = runDeckAnalysis(circuit, netlist, "ac");
@@ -1507,9 +1509,10 @@ describe("transient", () => {
     );
     expect(acExecution.runArtifacts[0]?.outputProbes).toEqual(["V(mid)"]);
     expect(acExecution.runArtifacts[0]?.measurementNames).toEqual(["mid_peak"]);
+    expect(acExecution.runArtifacts[0]?.fourierProbes).toEqual([]);
     expect(acExecution.runArtifactTable).toBe(
-      "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tOutputProbeList\tMeasurements\tMeasurementList\tFourier\n" +
-        `ac\t.ac\t${acExecution.plan.lineNumber}\t1\t1\tV(mid)\t1\tmid_peak\t0\n`,
+      "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tOutputProbeList\tMeasurements\tMeasurementList\tFourier\tFourierList\n" +
+        `ac\t.ac\t${acExecution.plan.lineNumber}\t1\t1\tV(mid)\t1\tmid_peak\t0\t\n`,
     );
 
     const tranExecution = runDeckAnalysis(circuit, netlist, "tran");
@@ -1526,9 +1529,10 @@ describe("transient", () => {
     );
     expect(tranExecution.runArtifacts[0]?.outputProbes).toEqual(["V(mid)"]);
     expect(tranExecution.runArtifacts[0]?.measurementNames).toEqual(["mid_final"]);
+    expect(tranExecution.runArtifacts[0]?.fourierProbes).toEqual([]);
     expect(tranExecution.runArtifactTable).toBe(
-      "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tOutputProbeList\tMeasurements\tMeasurementList\tFourier\n" +
-        `tran\t.tran\t${tranExecution.plan.lineNumber}\t1\t1\tV(mid)\t1\tmid_final\t0\n`,
+      "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tOutputProbeList\tMeasurements\tMeasurementList\tFourier\tFourierList\n" +
+        `tran\t.tran\t${tranExecution.plan.lineNumber}\t1\t1\tV(mid)\t1\tmid_final\t0\t\n`,
     );
 
     const tranWindowExecution = runDeckAnalysis(
@@ -1607,9 +1611,10 @@ describe("transient", () => {
     expect(tranExecution.runArtifacts[0]?.fourierCount).toBe(1);
     expect(tranExecution.runArtifacts[0]?.outputProbes).toEqual(["V(mid)"]);
     expect(tranExecution.runArtifacts[0]?.measurementNames).toEqual([]);
+    expect(tranExecution.runArtifacts[0]?.fourierProbes).toEqual(["V(mid)"]);
     expect(tranExecution.runArtifactTable).toBe(
-      "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tOutputProbeList\tMeasurements\tMeasurementList\tFourier\n" +
-        `tran\t.tran\t${tranExecution.plan.lineNumber}\t2\t1\tV(mid)\t0\t\t1\n`,
+      "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tOutputProbeList\tMeasurements\tMeasurementList\tFourier\tFourierList\n" +
+        `tran\t.tran\t${tranExecution.plan.lineNumber}\t2\t1\tV(mid)\t0\t\t1\tV(mid)\n`,
     );
   });
 

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -87,7 +87,8 @@ downstream tools to compare.
      stable Fourier tables; selected deck executions now include structured
      run-artifact summaries plus stable row/count tables for result rows,
      output probes, measurements, and Fourier artifacts, with normalized
-     output-probe and measurement name lists included in the run artifacts.
+     output-probe, measurement, and Fourier probe name lists included in the
+     run artifacts.
    - Expand remaining deck-controlled analyses toward full SPICE compatibility
      while keeping unsupported control-flow diagnostics explicit.
 
@@ -750,13 +751,21 @@ downstream tools to compare.
       can inspect deck-owned measurement provenance without reparsing
       measurement tables.
 
+67. Deck run Fourier artifact probes.
+    - Status: completed in this deck run Fourier artifact slice.
+    - Python, Rust, and TypeScript selected deck executions now include the
+      selected Fourier probe names inside selected-run artifacts alongside the
+      existing Fourier result counts.
+    - The stable run-artifact table now includes `FourierList`, so callers can
+      inspect deck-owned Fourier provenance without reparsing Fourier tables.
+
 ## Backlog
 
 1. Deck execution layer.
    - Expand selected-plan execution beyond fixed-step transient basics,
-     including richer deck-owned run artifacts beyond selected output and
-     measurement lists, Fourier metadata, and run summaries, plus output-plan
-     integration beyond stable table routing.
+     including richer deck-owned run artifacts beyond selected output,
+     measurement, and Fourier probe lists, plus output-plan integration beyond
+     stable table routing.
    - Expand deck-controlled output-plan integration beyond stable table
      routing and scoped `.save`, `.probe`, `.print`, `.plot`, and `.four`
      selection toward full SPICE compatibility.


### PR DESCRIPTION
## Summary
- add selected Fourier probe lists to deck run artifacts across Python, Rust, and TypeScript
- extend the stable run-artifact table with a FourierList column while preserving Fourier counts
- update docs, changelogs, and the SPICE implementation plan with completed slice 67

## Verification
- /Users/adhithya/.local/share/mise/installs/python/3.12.13/bin/ruff check code/packages/python/spice-engine
- PYTEST_ADDOPTS=--no-cov PYTHONPATH=code/packages/python/device-physics/src:code/packages/python/mosfet-models/src:code/packages/python/spice-engine/src /Users/adhithya/.local/share/mise/installs/python/3.12.13/bin/python3.12 -m pytest code/packages/python/spice-engine/tests -q
- cargo fmt --manifest-path code/packages/rust/spice-engine/Cargo.toml -- --check
- cargo test --manifest-path code/packages/rust/spice-engine/Cargo.toml
- PATH=/Users/adhithya/.local/share/mise/installs/node/22.22.3/bin:$PATH npm --prefix code/packages/typescript/spice-engine run build
- PATH=/Users/adhithya/.local/share/mise/installs/node/22.22.3/bin:$PATH npm --prefix code/packages/typescript/spice-engine test