### PR TITLE
Add Chief mesh action readiness tools

### DIFF
--- a/code/packages/rust/chief-of-staff-smart-home-tools/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/CHANGELOG.md
@@ -119,6 +119,9 @@ All notable changes to this package will be documented in this file.
   `smart_home.get_integration_mesh_substrate_stage_summary`,
   `smart_home.get_integration_mesh_readiness_package_summary`, and
   `smart_home.get_integration_mesh_stage_release_summary`.
+- Added D18D handlers for D23 mesh substrate action queues and action-readiness
+  rollups: `smart_home.list_integration_mesh_substrate_actions` and
+  `smart_home.get_integration_mesh_action_readiness_summary`.
 - Added D18D handlers for D23A activation remediation work orders:
   `smart_home.list_integration_activation_remediation` and
   `smart_home.get_integration_activation_remediation_summary`.

--- a/code/packages/rust/chief-of-staff-smart-home-tools/README.md
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/README.md
@@ -57,7 +57,8 @@ Chief of Staff job/session/agent
      lane rollups
   -> mesh primitive-readiness and substrate-stage reads for low-level protocol
      release blockers
-  -> mesh readiness package and stage-release summary reads for release go/no-go
+  -> mesh readiness package, stage-release, and action-readiness reads for
+     release go/no-go
   -> activation-dossier list and summary reads for bundled decision evidence
   -> activation-dashboard list and summary reads for priority-wave status cards
   -> activation-timeline list and summary reads for ordered wave milestones
@@ -144,6 +145,8 @@ Chief of Staff job/session/agent
 - `smart_home.get_integration_mesh_substrate_stage_summary`
 - `smart_home.get_integration_mesh_readiness_package_summary`
 - `smart_home.get_integration_mesh_stage_release_summary`
+- `smart_home.list_integration_mesh_substrate_actions`
+- `smart_home.get_integration_mesh_action_readiness_summary`
 - `smart_home.list_integration_activation_dossiers`
 - `smart_home.get_integration_activation_dossier_summary`
 - `smart_home.list_integration_activation_readouts`

--- a/code/packages/rust/chief-of-staff-smart-home-tools/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/src/lib.rs
@@ -62,9 +62,9 @@ use smart_home_integration_catalog::{
     activation_verification_checkpoints_from_execution_packets,
     activation_watchtower_signals_from_command_center_sections, describe_primitive_family,
     ecosystem_platform_coverage, ecosystem_platforms_requiring_primitive, ecosystem_survey_sources,
-    entries_requiring_primitive, find_entry, first_party_catalog,
-    mesh_protocol_primitive_readiness_rows, mesh_protocol_substrate_stage_rows,
-    mesh_readiness_package_summary, mesh_stage_release_summary,
+    entries_requiring_primitive, find_entry, first_party_catalog, mesh_action_readiness_summary,
+    mesh_protocol_primitive_readiness_rows, mesh_protocol_substrate_actions,
+    mesh_protocol_substrate_stage_rows, mesh_readiness_package_summary, mesh_stage_release_summary,
     policy_surface_inventory_at_or_before_priority, primitive_backlog_at_or_before_priority,
     primitive_backlog_with_ecosystem_coverage, primitive_family_descriptors, query_integrations,
     readiness_gap_inventory_from_reports, readiness_report_for_plan,
@@ -139,16 +139,17 @@ use smart_home_integration_catalog::{
     IntegrationActivationVerificationStatus, IntegrationActivationVerificationSummary,
     IntegrationActivationWatchtowerSignal, IntegrationActivationWatchtowerSignalKind,
     IntegrationActivationWatchtowerSummary, IntegrationCatalogEntry, IntegrationCatalogQuery,
-    IntegrationCatalogSort, IntegrationCategory, IntegrationMeshProtocolPrimitiveReadinessRow,
-    IntegrationMeshProtocolPrimitiveReadinessSummary, IntegrationMeshProtocolSubstrateStage,
-    IntegrationMeshProtocolSubstrateStageRow, IntegrationMeshProtocolSubstrateStageSummary,
-    IntegrationMeshReadinessPackageSummary, IntegrationMeshStageReleaseSummary,
-    IntegrationPolicySurface, IntegrationPolicySurfaceInventoryItem,
-    IntegrationPolicySurfaceSummary, IntegrationReadinessCapabilityGap,
-    IntegrationReadinessDependencyGap, IntegrationReadinessGapInventory,
-    IntegrationReadinessPrimitiveGap, IntegrationReadinessReport, IntegrationReadinessSummary,
-    PrimitiveBacklogCoverageItem, PrimitiveBacklogCoverageSummary, PrimitiveBacklogItem,
-    PrimitiveFamily, PrimitiveFamilyDescriptor, SourceReference,
+    IntegrationCatalogSort, IntegrationCategory, IntegrationMeshActionReadinessSummary,
+    IntegrationMeshProtocolPrimitiveReadinessRow, IntegrationMeshProtocolPrimitiveReadinessSummary,
+    IntegrationMeshProtocolSubstrateAction, IntegrationMeshProtocolSubstrateActionSummary,
+    IntegrationMeshProtocolSubstrateStage, IntegrationMeshProtocolSubstrateStageRow,
+    IntegrationMeshProtocolSubstrateStageSummary, IntegrationMeshReadinessPackageSummary,
+    IntegrationMeshStageReleaseSummary, IntegrationPolicySurface,
+    IntegrationPolicySurfaceInventoryItem, IntegrationPolicySurfaceSummary,
+    IntegrationReadinessCapabilityGap, IntegrationReadinessDependencyGap,
+    IntegrationReadinessGapInventory, IntegrationReadinessPrimitiveGap, IntegrationReadinessReport,
+    IntegrationReadinessSummary, PrimitiveBacklogCoverageItem, PrimitiveBacklogCoverageSummary,
+    PrimitiveBacklogItem, PrimitiveFamily, PrimitiveFamilyDescriptor, SourceReference,
 };
 use smart_home_registry::RegistryTopologySummary;
 use smart_home_registry::StateRefreshReason;
@@ -325,6 +326,10 @@ pub const SMART_HOME_GET_INTEGRATION_MESH_READINESS_PACKAGE_SUMMARY_TOOL_ID: &st
     "smart_home.get_integration_mesh_readiness_package_summary";
 pub const SMART_HOME_GET_INTEGRATION_MESH_STAGE_RELEASE_SUMMARY_TOOL_ID: &str =
     "smart_home.get_integration_mesh_stage_release_summary";
+pub const SMART_HOME_LIST_INTEGRATION_MESH_SUBSTRATE_ACTIONS_TOOL_ID: &str =
+    "smart_home.list_integration_mesh_substrate_actions";
+pub const SMART_HOME_GET_INTEGRATION_MESH_ACTION_READINESS_SUMMARY_TOOL_ID: &str =
+    "smart_home.get_integration_mesh_action_readiness_summary";
 pub const SMART_HOME_LIST_INTEGRATION_ACTIVATION_DOSSIERS_TOOL_ID: &str =
     "smart_home.list_integration_activation_dossiers";
 pub const SMART_HOME_GET_INTEGRATION_ACTIVATION_DOSSIER_SUMMARY_TOOL_ID: &str =
@@ -813,6 +818,14 @@ impl SmartHomeToolBridge {
                 SMART_HOME_GET_INTEGRATION_MESH_STAGE_RELEASE_SUMMARY_TOOL_ID => {
                     let query = integration_readiness_query(&arguments)?;
                     Ok(get_integration_mesh_stage_release_summary_output_handler_output(query))
+                }
+                SMART_HOME_LIST_INTEGRATION_MESH_SUBSTRATE_ACTIONS_TOOL_ID => {
+                    let query = integration_readiness_query(&arguments)?;
+                    Ok(list_integration_mesh_substrate_actions_output_handler_output(query))
+                }
+                SMART_HOME_GET_INTEGRATION_MESH_ACTION_READINESS_SUMMARY_TOOL_ID => {
+                    let query = integration_readiness_query(&arguments)?;
+                    Ok(get_integration_mesh_action_readiness_summary_output_handler_output(query))
                 }
                 SMART_HOME_LIST_INTEGRATION_ACTIVATION_DOSSIERS_TOOL_ID => {
                     let query = integration_activation_dossier_query(&arguments)?;
@@ -2582,6 +2595,34 @@ pub fn smart_home_tool_definitions() -> Vec<ToolDefinition> {
             SMART_HOME_GET_INTEGRATION_MESH_STAGE_RELEASE_SUMMARY_TOOL_ID,
             "Get smart-home integration mesh stage release summary",
             "Return D23 mesh stage release readiness counts combining substrate stage and package release blockers.",
+            integration_readiness_query_schema(true),
+            object_schema(
+                vec![SchemaProperty::new("summary", JsonSchema::Any)],
+                vec!["summary"],
+                false,
+            ),
+        ),
+        read_definition(
+            SMART_HOME_LIST_INTEGRATION_MESH_SUBSTRATE_ACTIONS_TOOL_ID,
+            "List smart-home integration mesh substrate actions",
+            "List D23 mesh protocol substrate actions that should be cleared before Chief-specific mesh release coordination.",
+            integration_readiness_query_schema(true),
+            object_schema(
+                vec![
+                    SchemaProperty::new("mesh_substrate_actions", JsonSchema::Array {
+                        items: Box::new(JsonSchema::Any),
+                    }),
+                    SchemaProperty::new("summary", JsonSchema::Any),
+                    SchemaProperty::new("count", JsonSchema::Integer),
+                ],
+                vec!["mesh_substrate_actions", "summary", "count"],
+                false,
+            ),
+        ),
+        read_definition(
+            SMART_HOME_GET_INTEGRATION_MESH_ACTION_READINESS_SUMMARY_TOOL_ID,
+            "Get smart-home integration mesh action readiness summary",
+            "Return D23 mesh action readiness counts combining queued substrate actions with stage release blockers.",
             integration_readiness_query_schema(true),
             object_schema(
                 vec![SchemaProperty::new("summary", JsonSchema::Any)],
@@ -16759,6 +16800,31 @@ fn integration_mesh_stage_release_summary_for_query(
     )
 }
 
+fn integration_mesh_substrate_actions_for_query(
+    query: &IntegrationReadinessQuery,
+) -> Vec<IntegrationMeshProtocolSubstrateAction> {
+    let mut actions = mesh_protocol_substrate_actions(&query.available_primitives);
+
+    if matches!(query.activation_ready, Some(true)) {
+        actions.clear();
+    }
+    if let Some(limit) = query.limit {
+        actions.truncate(limit);
+    }
+
+    actions
+}
+
+fn integration_mesh_action_readiness_summary_for_query(
+    query: &IntegrationReadinessQuery,
+) -> IntegrationMeshActionReadinessSummary {
+    mesh_action_readiness_summary(
+        &query.available_primitives,
+        &query.allowed_capabilities,
+        &query.enabled_integrations,
+    )
+}
+
 fn integration_activation_dependency_graph_for_query(
     query: &IntegrationActivationDependencyQuery,
 ) -> (IntegrationActivationDependencyGraph, usize) {
@@ -20872,6 +20938,80 @@ fn get_integration_mesh_stage_release_summary_output_handler_output(
             (
                 "primitive_blocker_count",
                 integer(summary.primitive_blocker_count as i64),
+            ),
+            (
+                "remediation_item_count",
+                integer(summary.remediation_item_count as i64),
+            ),
+            ("release_ready", JsonValue::Bool(summary.release_ready)),
+        ]),
+    )
+}
+
+fn list_integration_mesh_substrate_actions_output_handler_output(
+    query: IntegrationReadinessQuery,
+) -> ToolHandlerOutput {
+    let actions = integration_mesh_substrate_actions_for_query(&query);
+    let summary = IntegrationMeshProtocolSubstrateActionSummary::from_actions(actions.iter());
+    let count = actions.len();
+
+    ToolHandlerOutput::new(object([
+        (
+            "mesh_substrate_actions",
+            JsonValue::Array(
+                actions
+                    .iter()
+                    .map(mesh_protocol_substrate_action_json)
+                    .collect(),
+            ),
+        ),
+        (
+            "summary",
+            mesh_protocol_substrate_action_summary_json(&summary),
+        ),
+        ("count", integer(count as i64)),
+    ]))
+    .with_event(
+        ToolEventKind::Progress,
+        object([
+            (
+                "operation",
+                string("list_integration_mesh_substrate_actions"),
+            ),
+            ("actions", integer(count as i64)),
+            ("unique_protocols", integer(summary.unique_protocols as i64)),
+            (
+                "network_security_actions",
+                integer(summary.network_security_actions as i64),
+            ),
+            ("has_actions", JsonValue::Bool(summary.has_actions())),
+        ]),
+    )
+}
+
+fn get_integration_mesh_action_readiness_summary_output_handler_output(
+    query: IntegrationReadinessQuery,
+) -> ToolHandlerOutput {
+    let summary = integration_mesh_action_readiness_summary_for_query(&query);
+
+    ToolHandlerOutput::new(object([(
+        "summary",
+        mesh_action_readiness_summary_json(&summary),
+    )]))
+    .with_event(
+        ToolEventKind::Progress,
+        object([
+            (
+                "operation",
+                string("get_integration_mesh_action_readiness_summary"),
+            ),
+            (
+                "queued_substrate_actions",
+                integer(summary.queued_substrate_actions as i64),
+            ),
+            (
+                "queued_stage_count",
+                integer(summary.queued_stage_count as i64),
             ),
             (
                 "remediation_item_count",
@@ -41835,6 +41975,74 @@ fn mesh_protocol_substrate_stage_summary_json(
     ])
 }
 
+fn mesh_protocol_substrate_action_json(
+    action: &IntegrationMeshProtocolSubstrateAction,
+) -> JsonValue {
+    object([
+        ("sequence", integer(action.sequence as i64)),
+        ("protocol", string(protocol_family_label(&action.protocol))),
+        ("primitive", string(action.primitive.as_str())),
+        ("stage", string(action.stage.as_str())),
+        ("ready", JsonValue::Bool(false)),
+        ("blocked", JsonValue::Bool(true)),
+    ])
+}
+
+fn mesh_protocol_substrate_action_summary_json(
+    summary: &IntegrationMeshProtocolSubstrateActionSummary,
+) -> JsonValue {
+    object([
+        ("total_actions", integer(summary.total_actions as i64)),
+        ("unique_protocols", integer(summary.unique_protocols as i64)),
+        (
+            "unique_primitives",
+            integer(summary.unique_primitives as i64),
+        ),
+        (
+            "controller_actions",
+            integer(summary.controller_actions as i64),
+        ),
+        ("radio_actions", integer(summary.radio_actions as i64)),
+        (
+            "discovery_actions",
+            integer(summary.discovery_actions as i64),
+        ),
+        (
+            "network_security_actions",
+            integer(summary.network_security_actions as i64),
+        ),
+        (
+            "supervision_actions",
+            integer(summary.supervision_actions as i64),
+        ),
+        (
+            "first_protocol",
+            summary
+                .first_protocol
+                .as_ref()
+                .map(protocol_family_label)
+                .map(string)
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_stage",
+            summary
+                .first_stage
+                .map(|stage| string(stage.as_str()))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_primitive",
+            summary
+                .first_primitive
+                .map(|primitive| string(primitive.as_str()))
+                .unwrap_or(JsonValue::Null),
+        ),
+        ("is_empty", JsonValue::Bool(summary.is_empty())),
+        ("has_actions", JsonValue::Bool(summary.has_actions())),
+    ])
+}
+
 fn mesh_readiness_package_summary_json(
     summary: &IntegrationMeshReadinessPackageSummary,
 ) -> JsonValue {
@@ -41914,6 +42122,74 @@ fn mesh_readiness_package_summary_json(
         (
             "needs_supervision",
             JsonValue::Bool(summary.needs_supervision()),
+        ),
+    ])
+}
+
+fn mesh_action_readiness_summary_json(
+    summary: &IntegrationMeshActionReadinessSummary,
+) -> JsonValue {
+    object([
+        (
+            "release_summary",
+            mesh_stage_release_summary_json(&summary.release_summary),
+        ),
+        (
+            "action_summary",
+            mesh_protocol_substrate_action_summary_json(&summary.action_summary),
+        ),
+        ("total_protocols", integer(summary.total_protocols as i64)),
+        (
+            "queued_substrate_actions",
+            integer(summary.queued_substrate_actions as i64),
+        ),
+        (
+            "queued_stage_count",
+            integer(summary.queued_stage_count as i64),
+        ),
+        (
+            "queued_primitive_count",
+            integer(summary.queued_primitive_count as i64),
+        ),
+        (
+            "remediation_item_count",
+            integer(summary.remediation_item_count as i64),
+        ),
+        (
+            "first_action_protocol",
+            summary
+                .first_action_protocol
+                .as_ref()
+                .map(protocol_family_label)
+                .map(string)
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_action_stage",
+            summary
+                .first_action_stage
+                .map(|stage| string(stage.as_str()))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_action_primitive",
+            summary
+                .first_action_primitive
+                .map(|primitive| string(primitive.as_str()))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "substrate_actions_ready",
+            JsonValue::Bool(summary.substrate_actions_ready),
+        ),
+        ("release_ready", JsonValue::Bool(summary.release_ready)),
+        (
+            "has_substrate_actions",
+            JsonValue::Bool(summary.has_substrate_actions()),
+        ),
+        (
+            "has_remediations",
+            JsonValue::Bool(summary.has_remediations()),
         ),
     ])
 }
@@ -48833,7 +49109,7 @@ mod tests {
         let definitions = smart_home_tool_definitions();
         let export = ToolCatalogExport::from_definitions(definitions.iter());
 
-        assert_eq!(definitions.len(), 190);
+        assert_eq!(definitions.len(), 192);
         assert!(
             export.ok(),
             "tool export validation failed: {:?}",
@@ -49025,6 +49301,12 @@ mod tests {
         assert!(export
             .tool_ids()
             .contains(&SMART_HOME_GET_INTEGRATION_MESH_STAGE_RELEASE_SUMMARY_TOOL_ID));
+        assert!(export
+            .tool_ids()
+            .contains(&SMART_HOME_LIST_INTEGRATION_MESH_SUBSTRATE_ACTIONS_TOOL_ID));
+        assert!(export
+            .tool_ids()
+            .contains(&SMART_HOME_GET_INTEGRATION_MESH_ACTION_READINESS_SUMMARY_TOOL_ID));
         assert!(export.tool_ids().contains(&SMART_HOME_DISCOVER_TOOL_ID));
         assert!(export
             .tool_ids()
@@ -49383,7 +49665,7 @@ mod tests {
         ));
         assert_eq!(
             export.summary.required_capability_count("smart_home:read"),
-            182
+            184
         );
         assert_eq!(
             export
@@ -50067,11 +50349,11 @@ mod tests {
         let tool_catalog_summary = field(tool_catalog_summary_output, "summary").unwrap();
         assert_eq!(
             field(tool_catalog_summary, "total_tools"),
-            Some(&integer(190))
+            Some(&integer(192))
         );
         assert_eq!(
             field(tool_catalog_summary, "read_tools"),
-            Some(&integer(182))
+            Some(&integer(184))
         );
         assert_eq!(
             field(tool_catalog_summary, "risky_tool_count"),
@@ -52421,6 +52703,121 @@ mod tests {
         assert_eq!(
             field(mesh_stage_release_rollup, "has_blockers"),
             Some(&JsonValue::Bool(true))
+        );
+
+        let list_mesh_substrate_actions_request = request(
+            "call-list-integration-mesh-substrate-actions",
+            SMART_HOME_LIST_INTEGRATION_MESH_SUBSTRATE_ACTIONS_TOOL_ID,
+            object([
+                (
+                    "available_primitives",
+                    JsonValue::Array(vec![
+                        string("usb"),
+                        string("serial_controller"),
+                        string("radio_802154"),
+                        string("supervision"),
+                    ]),
+                ),
+                ("activation_ready", JsonValue::Bool(false)),
+                ("limit", integer(2)),
+            ]),
+            5_911,
+        );
+        let list_mesh_substrate_actions_trace =
+            tool_runtime.invoke_with_events(&list_mesh_substrate_actions_request);
+        assert!(list_mesh_substrate_actions_trace.result.ok);
+        assert_eq!(
+            list_mesh_substrate_actions_trace
+                .summary()
+                .progress_event_count,
+            1
+        );
+        let list_mesh_substrate_actions_output = list_mesh_substrate_actions_trace
+            .result
+            .output
+            .as_ref()
+            .unwrap();
+        assert_eq!(
+            field(list_mesh_substrate_actions_output, "count"),
+            Some(&integer(2))
+        );
+        let mesh_substrate_action_summary =
+            field(list_mesh_substrate_actions_output, "summary").unwrap();
+        assert_eq!(
+            field(mesh_substrate_action_summary, "total_actions"),
+            Some(&integer(2))
+        );
+        assert_eq!(
+            field(mesh_substrate_action_summary, "has_actions"),
+            Some(&JsonValue::Bool(true))
+        );
+        let mesh_substrate_action = array_item(
+            field(list_mesh_substrate_actions_output, "mesh_substrate_actions").unwrap(),
+            0,
+        )
+        .unwrap();
+        assert_eq!(field(mesh_substrate_action, "sequence"), Some(&integer(1)));
+        assert_eq!(
+            field(mesh_substrate_action, "blocked"),
+            Some(&JsonValue::Bool(true))
+        );
+        assert!(matches!(
+            field(mesh_substrate_action, "stage"),
+            Some(JsonValue::String(_))
+        ));
+
+        let mesh_action_readiness_summary_request = request(
+            "call-integration-mesh-action-readiness-summary",
+            SMART_HOME_GET_INTEGRATION_MESH_ACTION_READINESS_SUMMARY_TOOL_ID,
+            object([
+                (
+                    "available_primitives",
+                    JsonValue::Array(vec![
+                        string("usb"),
+                        string("serial_controller"),
+                        string("radio_802154"),
+                        string("supervision"),
+                    ]),
+                ),
+                (
+                    "allowed_capability_ids",
+                    JsonValue::Array(vec![string("smart_home.read")]),
+                ),
+            ]),
+            5_912,
+        );
+        let mesh_action_readiness_summary_trace =
+            tool_runtime.invoke_with_events(&mesh_action_readiness_summary_request);
+        assert!(mesh_action_readiness_summary_trace.result.ok);
+        assert_eq!(
+            mesh_action_readiness_summary_trace
+                .summary()
+                .progress_event_count,
+            1
+        );
+        let mesh_action_readiness_summary_output = mesh_action_readiness_summary_trace
+            .result
+            .output
+            .as_ref()
+            .unwrap();
+        let mesh_action_readiness_rollup =
+            field(mesh_action_readiness_summary_output, "summary").unwrap();
+        assert_eq!(
+            field(mesh_action_readiness_rollup, "queued_substrate_actions"),
+            Some(&integer(5))
+        );
+        assert_eq!(
+            field(mesh_action_readiness_rollup, "substrate_actions_ready"),
+            Some(&JsonValue::Bool(false))
+        );
+        assert_eq!(
+            field(mesh_action_readiness_rollup, "release_ready"),
+            Some(&JsonValue::Bool(false))
+        );
+        let mesh_action_summary = field(mesh_action_readiness_rollup, "action_summary").unwrap();
+        assert_eq!(
+            field(mesh_action_summary, "network_security_actions"),
+            Some(&integer(3))
         );
 
         let list_activation_dossiers_request = request(

--- a/code/packages/rust/chief-of-staff-smart-home-tools/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/src/lib.rs
@@ -61904,6 +61904,16 @@ mod tests {
 
     #[test]
     fn activation_waiver_erasure_tools_project_purge_lineage_end_to_end() {
+        std::thread::Builder::new()
+            .name("activation-waiver-erasure-e2e".to_string())
+            .stack_size(16 * 1024 * 1024)
+            .spawn(activation_waiver_erasure_tools_project_purge_lineage_end_to_end_inner)
+            .unwrap()
+            .join()
+            .unwrap();
+    }
+
+    fn activation_waiver_erasure_tools_project_purge_lineage_end_to_end_inner() {
         let runtime = Rc::new(RefCell::new(hue_lighting_runtime()));
         let bridge = SmartHomeToolBridge::new(runtime, AgentId::trusted(AGENT_ID));
         let mut tool_runtime = InMemoryToolRuntime::new();

--- a/code/packages/rust/smart-home-core/CHANGELOG.md
+++ b/code/packages/rust/smart-home-core/CHANGELOG.md
@@ -76,6 +76,9 @@ All notable changes to this package will be documented in this file.
   `smart_home.get_integration_mesh_readiness_package_summary`, and
   `smart_home.get_integration_mesh_stage_release_summary` descriptors for
   read-only D23 mesh readiness release planning.
+- `smart_home.list_integration_mesh_substrate_actions` and
+  `smart_home.get_integration_mesh_action_readiness_summary` descriptors for
+  read-only D23 mesh substrate action and action-readiness planning.
 - `smart_home.list_integration_activation_dossiers` and
   `smart_home.get_integration_activation_dossier_summary` tool descriptors
   for read-only bundled activation decision and evidence planning.

--- a/code/packages/rust/smart-home-core/src/lib.rs
+++ b/code/packages/rust/smart-home-core/src/lib.rs
@@ -1596,6 +1596,8 @@ pub enum SmartHomeTool {
     GetIntegrationMeshSubstrateStageSummary,
     GetIntegrationMeshReadinessPackageSummary,
     GetIntegrationMeshStageReleaseSummary,
+    ListIntegrationMeshSubstrateActions,
+    GetIntegrationMeshActionReadinessSummary,
     Discover,
     PairBridge,
     CompletePairing,
@@ -2080,6 +2082,12 @@ impl SmartHomeTool {
             }
             Self::GetIntegrationMeshStageReleaseSummary => {
                 read_tool("smart_home.get_integration_mesh_stage_release_summary")
+            }
+            Self::ListIntegrationMeshSubstrateActions => {
+                read_tool("smart_home.list_integration_mesh_substrate_actions")
+            }
+            Self::GetIntegrationMeshActionReadinessSummary => {
+                read_tool("smart_home.get_integration_mesh_action_readiness_summary")
             }
             Self::Discover => ToolDescriptor {
                 tool_id: "smart_home.discover",
@@ -2837,6 +2845,8 @@ pub fn smart_home_tool_catalog() -> Vec<ToolDescriptor> {
         SmartHomeTool::GetIntegrationMeshSubstrateStageSummary,
         SmartHomeTool::GetIntegrationMeshReadinessPackageSummary,
         SmartHomeTool::GetIntegrationMeshStageReleaseSummary,
+        SmartHomeTool::ListIntegrationMeshSubstrateActions,
+        SmartHomeTool::GetIntegrationMeshActionReadinessSummary,
         SmartHomeTool::Discover,
         SmartHomeTool::PairBridge,
         SmartHomeTool::CompletePairing,
@@ -3671,7 +3681,7 @@ mod tests {
             .find(|tool| tool.tool_id == "smart_home.command")
             .unwrap();
 
-        assert_eq!(catalog.len(), 190);
+        assert_eq!(catalog.len(), 192);
         assert!(catalog
             .iter()
             .any(|tool| tool.tool_id == "smart_home.list_integrations"
@@ -3913,6 +3923,8 @@ mod tests {
             "smart_home.get_integration_mesh_substrate_stage_summary",
             "smart_home.get_integration_mesh_readiness_package_summary",
             "smart_home.get_integration_mesh_stage_release_summary",
+            "smart_home.list_integration_mesh_substrate_actions",
+            "smart_home.get_integration_mesh_action_readiness_summary",
         ] {
             assert!(catalog.iter().any(|tool| tool.tool_id == tool_id
                 && tool.side_effects == ToolSideEffects::Read
@@ -4433,15 +4445,15 @@ mod tests {
         let summary = smart_home_tool_catalog_summary();
         let pair_bridge = SmartHomeTool::PairBridge.descriptor();
 
-        assert_eq!(summary.total_tools, 190);
-        assert_eq!(summary.read_tools, 182);
+        assert_eq!(summary.total_tools, 192);
+        assert_eq!(summary.read_tools, 184);
         assert_eq!(summary.write_tools, 2);
         assert_eq!(summary.external_tools, 6);
-        assert_eq!(summary.read_only_tier_tools, 182);
+        assert_eq!(summary.read_only_tier_tools, 184);
         assert_eq!(summary.low_risk_tier_tools, 6);
         assert_eq!(summary.high_risk_tier_tools, 0);
         assert_eq!(summary.human_approval_tier_tools, 2);
-        assert_eq!(summary.total_required_capabilities, 190);
+        assert_eq!(summary.total_required_capabilities, 192);
         assert_eq!(summary.risky_tool_count(), 8);
         assert_eq!(summary.approval_gated_tool_count(), 2);
         assert!(pair_bridge.requires_human_approval());


### PR DESCRIPTION
## Summary
- add Core descriptors for D23 mesh substrate action and action-readiness read tools
- expose Chief D18D handlers for queued mesh substrate actions and action-readiness rollups
- update Chief docs/changelogs and runtime smoke coverage for the new tools

## Validation
- cargo test -p smart-home-core
- cargo test -p smart-home-integration-catalog
- cargo test -p hue-core
- cargo test -p smart-home-runtime
- cargo test -p smart-home-testkit
- cargo test -p smart-home-local-http
- cargo test -p smart-home-discovery
- cargo test -p chief-of-staff-smart-home-tools
- cargo test -p smart-home-runtime discover_tool -- --nocapture
- sh BUILD in smart-home-core, smart-home-integration-catalog, hue-core, smart-home-runtime, smart-home-testkit, smart-home-local-http, smart-home-discovery, and chief-of-staff-smart-home-tools

Cargo.lock was generated by validation and removed before push.