### PR TITLE
feat(closure-pass-rename-properties): aggressive property renaming core (CLOC13.J)

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -558,6 +558,7 @@ members = [
     "closure-pass-remove-unused-vars",
     "closure-pass-rename",
     "closure-pass-rename-globals",
+    "closure-pass-rename-properties",
     "closure-pass-treeshake",
     "closure-scope-analyzer",
     "closure-source-map",

--- a/code/packages/rust/closure-pass-rename-properties/BUILD
+++ b/code/packages/rust/closure-pass-rename-properties/BUILD
@@ -1,0 +1,1 @@
+cargo test -p coding-adventures-closure-pass-rename-properties -- --nocapture

--- a/code/packages/rust/closure-pass-rename-properties/BUILD_windows
+++ b/code/packages/rust/closure-pass-rename-properties/BUILD_windows
@@ -1,0 +1,1 @@
+cargo test -p coding-adventures-closure-pass-rename-properties -- --nocapture

--- a/code/packages/rust/closure-pass-rename-properties/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-rename-properties/CHANGELOG.md
@@ -1,0 +1,44 @@
+# Changelog
+
+All notable changes to the `coding-adventures-closure-pass-rename-properties` crate will be documented in this file.
+
+## [0.1.0] - 2026-06-18
+
+### Added (CLOC13.J — aggressive property renaming, algorithmic core)
+
+New crate per CLOC06's canonical pass set — Closure Compiler's `RENAME_PROPERTIES`
+in miniature. `RenamePropertiesPass::run` consistently shortens program-private
+object **property names** across the whole program (every dotted `obj.x` member
+access and every unquoted `{ x: … }` key of a renameable name → a fresh short
+name). Property access is by name, so renaming a name at every occurrence is
+semantics-preserving regardless of which objects carry it.
+
+- **ADVANCED-only, sound under the externs contract.** A property name is
+  renamed only when it: appears dotted/unquoted; is NOT quoted via a computed
+  string member (`obj["x"]` — the bridge preserves this signal); is not a
+  `BUILTIN_PROPERTIES` (a bundled ECMAScript default-externs substitute —
+  `length`, `prototype`, `toString`, `push`, …); is not in the externs
+  do-not-rename set; and is longer than one character. Each renameable property
+  gets a distinct fresh name. Property names live in their own namespace, so the
+  fresh name only avoids other property names + the built-ins + the externs set.
+- **Honest limitations (documented in the crate):**
+  - The built-in list covers ECMAScript but NOT the DOM/host — host property
+    names (`innerHTML`, `addEventListener`, …) must be supplied via `--externs`.
+  - The parser bridge currently collapses a *quoted object key* `{ "x": 1 }` to
+    an identifier key, so object-key quoting is not a usable do-not-rename
+    signal (only computed-member quoting `obj["x"]` is); protect such names via
+    externs. (A separate bridge fix is tracked.)
+  - Dynamic computed access `obj[runtimeString]` is the author's contract
+    responsibility, exactly as in Closure.
+- `name = "rename-properties"`, `depends_on = []`, `iteration_policy = OneShot`,
+  `cost = 3`. `new(do_not_rename)` / `with_builtins_only()`.
+
+This is the algorithmic core; wiring into ADVANCED (collecting externs property
+names + deciding the safe-by-default policy — require externs / bundle DOM
+externs) is a deliberate follow-up.
+
+### Tests
+- 13 tests: metadata contract + source → bridge → rename-properties → emit
+  roundtrips covering consistent dotted+object-key renaming, computed-member
+  quoting decline, built-in protection, externs protection, dynamic computed
+  key, single-char skip, and a nested property chain.

--- a/code/packages/rust/closure-pass-rename-properties/Cargo.toml
+++ b/code/packages/rust/closure-pass-rename-properties/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "coding-adventures-closure-pass-rename-properties"
+version = "0.1.0"
+edition = "2021"
+description = "Aggressive property renaming pass for the Closure Compiler clone (ADVANCED-only). Consistently shortens program-private object property names that are never quoted/computed and not in the built-in or externs do-not-rename boundary."
+
+[dependencies]
+coding-adventures-closure-pass-pipeline = { path = "../closure-pass-pipeline" }
+coding-adventures-javascript-ast = { path = "../javascript-ast" }
+
+[dev-dependencies]
+coding-adventures-javascript-tokens = { path = "../javascript-tokens" }
+coding-adventures-javascript-parser = { path = "../javascript-parser" }
+coding-adventures-closure-emitter = { path = "../closure-emitter" }
+coding-adventures-type-sidecar = { path = "../type-sidecar" }
+coding_adventures_correlation_vector = { path = "../correlation-vector" }

--- a/code/packages/rust/closure-pass-rename-properties/README.md
+++ b/code/packages/rust/closure-pass-rename-properties/README.md
@@ -1,0 +1,68 @@
+# coding-adventures-closure-pass-rename-properties
+
+Aggressive property renaming pass for the Closure Compiler clone
+(**ADVANCED**-only) — Closure Compiler's `RENAME_PROPERTIES` in miniature.
+Consistently shortens program-private object **property names**. Per
+[CLOC06](../../../specs/CLOC06-pass-interface-contract.md).
+
+## What it does
+
+```js
+// before
+obj.computeTotal = function () {};
+widget.computeTotal();
+var cfg = { renderMode: 1 };
+
+// after rename-properties (ADVANCED)
+obj.a = function () {};
+widget.a();
+var cfg = { b: 1 };
+```
+
+Property access is *by name*, so renaming a name at **every** occurrence
+(dotted `obj.x` + unquoted `{ x: … }`) is semantics-preserving no matter
+which objects carry it.
+
+## Soundness — the externs contract
+
+A property name is renamed only when it:
+
+1. appears dotted / unquoted;
+2. is NOT quoted via a computed string member (`obj["x"]` — the bridge
+   preserves this; the author quoted it to mean "external/dynamic");
+3. is not a `BUILTIN_PROPERTIES` (a bundled ECMAScript default-externs
+   substitute — `length`, `prototype`, `toString`, `push`, …);
+4. is not in the externs do-not-rename set; and
+5. is longer than one character.
+
+Each renameable property gets a **distinct** fresh name. The fresh name
+only avoids other property names + the built-ins + the externs set
+(property names are their own namespace; a property may become `a` even
+when a variable `a` exists).
+
+### Honest limitations
+
+- The built-in list covers ECMAScript but **not the DOM/host** — host
+  property names (`innerHTML`, `addEventListener`, …) must be supplied via
+  `--externs` or they will be renamed.
+- The parser bridge currently collapses a quoted object key `{ "x": 1 }`
+  to an identifier key, so object-key quoting is **not** a usable
+  do-not-rename signal (only computed-member quoting `obj["x"]` is) —
+  protect such names via externs.
+- Dynamic computed access `obj[runtimeString]` is the author's contract
+  responsibility, exactly as in Closure.
+
+## Status
+
+This crate is the **algorithmic core**; wiring it into ADVANCED (collect
+externs property names + decide the safe-by-default policy) is a
+deliberate follow-up.
+
+## Dependency whitelist
+
+- `coding-adventures-closure-pass-pipeline` — `Pass` trait + types.
+- `coding-adventures-javascript-ast` — `Program` and the typed AST.
+
+Dev-deps: `coding-adventures-javascript-tokens`,
+`coding-adventures-javascript-parser`, `coding-adventures-closure-emitter`,
+`coding-adventures-type-sidecar`, `coding_adventures_correlation_vector`.

--- a/code/packages/rust/closure-pass-rename-properties/required_capabilities.json
+++ b/code/packages/rust/closure-pass-rename-properties/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "rust/closure-pass-rename-properties",
+  "capabilities": [],
+  "justification": "Pure data transformation over an AST. No filesystem, network, process, or environment access needed."
+}

--- a/code/packages/rust/closure-pass-rename-properties/src/lib.rs
+++ b/code/packages/rust/closure-pass-rename-properties/src/lib.rs
@@ -1,0 +1,947 @@
+//! Aggressive property renaming pass for the Closure Compiler clone
+//! (**ADVANCED**-only) — Closure Compiler's `RENAME_PROPERTIES` in
+//! miniature. Consistently shortens program-private object **property
+//! names** across the whole program:
+//!
+//! ```js
+//! // before
+//! obj.computeTotal = function () {};
+//! widget.computeTotal();
+//! var cfg = { renderMode: 1 };
+//! use(cfg.renderMode);
+//!
+//! // after rename-properties (ADVANCED)
+//! obj.a = function () {};
+//! widget.a();
+//! var cfg = { b: 1 };
+//! use(cfg.b);
+//! ```
+//!
+//! Property access is *by name*: renaming a property name at **every**
+//! place it appears keeps the program's meaning, no matter which objects
+//! carry it. So `computeTotal` → `a` is applied to every `.computeTotal`
+//! dotted access and every unquoted `{ computeTotal: … }` key.
+//!
+//! # Soundness — the externs / quoting contract
+//!
+//! Property renaming is sound only under Closure's **externs contract**
+//! (the property analogue of the contract the global renamer uses): every
+//! property name reachable from *outside* this compilation — a DOM
+//! property the browser calls (`onload`), a field another file reads, a
+//! key accessed by a dynamically-built string — must be in the
+//! do-not-rename boundary. Everything else is private and may be
+//! shortened. A name is renamed only when ALL hold:
+//!
+//!   * **It appears in a renameable (dotted / unquoted-key) position.**
+//!     `obj.x` and the key in `{ x: 1 }` are *identifier* positions.
+//!   * **It is NOT quoted via a computed string member.** `obj["x"]` is a
+//!     *string* position the bridge preserves; the author quoted it to
+//!     signal "external / dynamic — leave it alone." A name quoted this
+//!     way anywhere is declined everywhere (renaming the dotted
+//!     occurrences would desync them from the quoted access we never
+//!     touch). **Bridge limitation:** a *quoted object key*
+//!     `{ "x": 1 }` is currently collapsed to an identifier key by the
+//!     parser bridge, so it is NOT a usable quoting signal — protect such
+//!     names via `--externs` instead.
+//!   * **It is not a [`BUILTIN_PROPERTIES`]** (`length`, `prototype`,
+//!     `toString`, `push`, …). closurec ships no browser/ECMAScript
+//!     externs file, so this list is the default-externs substitute that
+//!     keeps `arr.length` from becoming `arr.a`. It covers the common
+//!     ECMAScript surface but **not the DOM/host** — host property names
+//!     (`innerHTML`, `addEventListener`, …) must be supplied via
+//!     `--externs`. The [`RenamePropertiesPass::new`] do-not-rename set
+//!     extends the built-ins with the externs files' property names.
+//!   * **It is longer than one character** (already minimal otherwise).
+//!
+//! **Dynamic computed access (`obj[expr]`) is the author's
+//! responsibility**, exactly as in Closure: reaching a renameable
+//! property through a runtime-built string requires quoting its
+//! definitions (or listing it in externs). We cannot see the runtime
+//! string, so this is a documented contract, not something we can check.
+//!
+//! Each distinct renameable property gets a **distinct** fresh name (no
+//! reuse), so renamed properties never collide. Property names live in
+//! their own namespace, so a property may be renamed to `a` even when a
+//! *variable* `a` exists — the fresh name only avoids other property
+//! names, the built-ins, and the do-not-rename set.
+//!
+//! # Why ADVANCED-only
+//!
+//! SIMPLE never renames property names (it cannot assume the quoting
+//! contract holds). ADVANCED does, which is part of what makes ADVANCED
+//! output smaller. This pass runs after the structural passes and the
+//! variable renamers.
+
+use std::collections::{HashMap, HashSet};
+
+use coding_adventures_closure_pass_pipeline::{
+    IterationPolicy, Pass, PassContext, PassError, PassOutput, PassStats,
+};
+use coding_adventures_javascript_ast::statement::TaggedStatement;
+use coding_adventures_javascript_ast::{
+    AssignmentTarget, Declaration, Expression, ForInit, Program, ProgramItem, PropertyKey,
+    Statement,
+};
+
+/// `Pass::depends_on` value — empty. Property renaming is correct
+/// standalone.
+const DEPS: &[&str] = &[];
+
+/// Reserved words we must never emit as a fresh short name.
+const RESERVED: &[&str] = &["do", "if", "in", "of", "as", "is", "or"];
+
+/// Built-in property names that must never be renamed — the
+/// default-externs substitute (closurec ships no browser/ECMAScript
+/// externs file). Renaming any of these would break code that uses the
+/// standard library (`arr.length`, `x.toString()`, `p.then(...)`, …). The
+/// user's `--externs` files extend this boundary; this list covers the
+/// common ECMAScript surface so the pass is safe by default.
+///
+/// It is intentionally conservative (over-protecting a user-defined
+/// property that happens to share a built-in's name merely forgoes a
+/// rename — never a miscompile).
+const BUILTIN_PROPERTIES: &[&str] = &[
+    // Object / function plumbing
+    "prototype",
+    "constructor",
+    "__proto__",
+    "name",
+    "length",
+    "arguments",
+    "caller",
+    "hasOwnProperty",
+    "isPrototypeOf",
+    "propertyIsEnumerable",
+    "toString",
+    "toLocaleString",
+    "valueOf",
+    "call",
+    "apply",
+    "bind",
+    // Error
+    "message",
+    "stack",
+    "cause",
+    // Promise / iterator / generator
+    "then",
+    "catch",
+    "finally",
+    "next",
+    "return",
+    "throw",
+    "value",
+    "done",
+    "resolve",
+    "reject",
+    "all",
+    "race",
+    "any",
+    "allSettled",
+    // Collections
+    "size",
+    "add",
+    "has",
+    "get",
+    "set",
+    "delete",
+    "clear",
+    "keys",
+    "values",
+    "entries",
+    "forEach",
+    // Array
+    "push",
+    "pop",
+    "shift",
+    "unshift",
+    "slice",
+    "splice",
+    "concat",
+    "join",
+    "indexOf",
+    "lastIndexOf",
+    "includes",
+    "find",
+    "findIndex",
+    "findLast",
+    "findLastIndex",
+    "filter",
+    "map",
+    "reduce",
+    "reduceRight",
+    "some",
+    "every",
+    "sort",
+    "reverse",
+    "fill",
+    "flat",
+    "flatMap",
+    "copyWithin",
+    "at",
+    "from",
+    "of",
+    "isArray",
+    // String
+    "charAt",
+    "charCodeAt",
+    "codePointAt",
+    "substring",
+    "substr",
+    "replace",
+    "replaceAll",
+    "split",
+    "trim",
+    "trimStart",
+    "trimEnd",
+    "toLowerCase",
+    "toUpperCase",
+    "toLocaleLowerCase",
+    "toLocaleUpperCase",
+    "padStart",
+    "padEnd",
+    "startsWith",
+    "endsWith",
+    "repeat",
+    "normalize",
+    "localeCompare",
+    "match",
+    "matchAll",
+    "search",
+    "fromCharCode",
+    "fromCodePoint",
+    "raw",
+    // Number / Math / RegExp / JSON / Date
+    "toFixed",
+    "toPrecision",
+    "toExponential",
+    "test",
+    "exec",
+    "source",
+    "flags",
+    "global",
+    "ignoreCase",
+    "multiline",
+    "lastIndex",
+    "parse",
+    "stringify",
+    "now",
+    "getTime",
+    "getFullYear",
+    "getMonth",
+    "getDate",
+    "getDay",
+    "getHours",
+    "getMinutes",
+    "getSeconds",
+    "getMilliseconds",
+    "setFullYear",
+    "toISOString",
+    "toJSON",
+    // Console / common host
+    "log",
+    "warn",
+    "error",
+    "info",
+    "debug",
+    "assert",
+];
+
+/// Aggressive property renaming pass. Holds the **do-not-rename set** of
+/// property names supplied at construction (typically the property names
+/// collected from `--externs` files); the built-in property list is
+/// always protected on top of it.
+#[derive(Debug, Default, Clone)]
+pub struct RenamePropertiesPass {
+    do_not_rename: HashSet<String>,
+}
+
+impl RenamePropertiesPass {
+    /// Construct with an externs property do-not-rename set (extends the
+    /// always-protected [`BUILTIN_PROPERTIES`]).
+    pub fn new(do_not_rename: HashSet<String>) -> Self {
+        Self { do_not_rename }
+    }
+
+    /// Construct protecting only the built-in properties (no extra
+    /// externs property names).
+    pub fn with_builtins_only() -> Self {
+        Self {
+            do_not_rename: HashSet::new(),
+        }
+    }
+}
+
+impl Pass for RenamePropertiesPass {
+    fn name(&self) -> &'static str {
+        "rename-properties"
+    }
+
+    fn depends_on(&self) -> &[&'static str] {
+        DEPS
+    }
+
+    fn iteration_policy(&self) -> IterationPolicy {
+        // After one whole-program walk every renameable property has been
+        // shortened; re-running does nothing.
+        IterationPolicy::OneShot
+    }
+
+    fn cost(&self) -> u32 {
+        // Two whole-program walks: classify (dotted vs quoted) + rewrite.
+        3
+    }
+
+    fn run(&self, ctx: PassContext<'_>) -> Result<PassOutput, PassError> {
+        let mut program = ctx.program.clone();
+        let mut nodes_touched: u32 = 1;
+        let changed = rename_properties(&mut program, &self.do_not_rename, &mut nodes_touched);
+
+        Ok(PassOutput {
+            program,
+            contributions: Vec::new(),
+            changed,
+            diagnostics: Vec::new(),
+            stats: PassStats { nodes_touched },
+        })
+    }
+}
+
+// =========================================================================
+// Implementation
+// =========================================================================
+
+/// The per-name evidence gathered in the classification walk.
+#[derive(Default)]
+struct Classify {
+    /// Names seen in a renameable (dotted / unquoted-key) position, in
+    /// first-seen source order (deterministic fresh-name assignment).
+    dotted_order: Vec<String>,
+    dotted_seen: HashSet<String>,
+    /// Names seen in a quoted position (`obj["x"]` / `{ "x": 1 }`) — these
+    /// are off-limits and disable the name everywhere.
+    quoted: HashSet<String>,
+}
+
+impl Classify {
+    fn see_dotted(&mut self, name: &str) {
+        if self.dotted_seen.insert(name.to_string()) {
+            self.dotted_order.push(name.to_string());
+        }
+    }
+    fn see_quoted(&mut self, name: &str) {
+        self.quoted.insert(name.to_string());
+    }
+}
+
+fn rename_properties(
+    program: &mut Program,
+    do_not_rename: &HashSet<String>,
+    nodes_touched: &mut u32,
+) -> bool {
+    // 1. Classify every property occurrence as dotted (renameable shape)
+    //    or quoted (off-limits).
+    let mut cls = Classify::default();
+    for item in &program.body {
+        classify_item(item, &mut cls, nodes_touched);
+    }
+
+    // 2. Decide the renames. A property is renameable when it appears
+    //    dotted, never quoted, is not a built-in, is not in the externs
+    //    do-not-rename set, and is longer than one character.
+    let builtins: HashSet<&str> = BUILTIN_PROPERTIES.iter().copied().collect();
+    // Fresh names avoid every property name in the program plus the
+    // built-ins and externs set (property namespace only — variable names
+    // are irrelevant).
+    let mut avoid: HashSet<String> = HashSet::new();
+    avoid.extend(cls.dotted_seen.iter().cloned());
+    avoid.extend(cls.quoted.iter().cloned());
+    avoid.extend(BUILTIN_PROPERTIES.iter().map(|s| s.to_string()));
+    avoid.extend(do_not_rename.iter().cloned());
+
+    let mut map: HashMap<String, String> = HashMap::new();
+    let mut gen = FreshNames::new();
+    for name in &cls.dotted_order {
+        if cls.quoted.contains(name)
+            || builtins.contains(name.as_str())
+            || do_not_rename.contains(name)
+            || name.len() <= 1
+        {
+            continue;
+        }
+        let fresh = gen.next(&avoid);
+        avoid.insert(fresh.clone());
+        map.insert(name.clone(), fresh);
+    }
+
+    if map.is_empty() {
+        return false;
+    }
+
+    // 3. Rewrite every dotted / unquoted-key occurrence of a renamed name.
+    for item in &mut program.body {
+        rewrite_item(item, &map);
+    }
+    true
+}
+
+/// Generates `a`, `b`, …, `z`, `aa`, … skipping reserved words and the
+/// caller's `avoid` set.
+struct FreshNames {
+    counter: usize,
+}
+
+impl FreshNames {
+    fn new() -> Self {
+        FreshNames { counter: 0 }
+    }
+    fn next(&mut self, avoid: &HashSet<String>) -> String {
+        loop {
+            let name = encode(self.counter);
+            self.counter += 1;
+            if !RESERVED.contains(&name.as_str()) && !avoid.contains(&name) {
+                return name;
+            }
+        }
+    }
+}
+
+/// Bijective base-26 encoding: 0→a, 25→z, 26→aa, …
+fn encode(mut n: usize) -> String {
+    let mut s = Vec::new();
+    loop {
+        s.push(b'a' + (n % 26) as u8);
+        if n < 26 {
+            break;
+        }
+        n = n / 26 - 1;
+    }
+    s.reverse();
+    String::from_utf8(s).expect("ascii")
+}
+
+// ---- classification ------------------------------------------------------
+
+fn classify_item(item: &ProgramItem, cls: &mut Classify, nodes_touched: &mut u32) {
+    match item {
+        ProgramItem::Declaration(d) => classify_decl(d, cls, nodes_touched),
+        ProgramItem::Statement(s) => classify_stmt(s, cls, nodes_touched),
+    }
+}
+
+fn classify_decl(decl: &Declaration, cls: &mut Classify, nodes_touched: &mut u32) {
+    *nodes_touched += 1;
+    match decl {
+        Declaration::VariableDeclaration(vd) => {
+            for d in &vd.declarations {
+                if let Some(init) = &d.init {
+                    classify_expr(init, cls);
+                }
+            }
+        }
+        Declaration::FunctionDeclaration(fd) => {
+            for s in &fd.body.body {
+                classify_stmt(s, cls, nodes_touched);
+            }
+        }
+    }
+}
+
+fn classify_stmt(stmt: &Statement, cls: &mut Classify, nodes_touched: &mut u32) {
+    *nodes_touched += 1;
+    match stmt {
+        Statement::Declaration(d) => classify_decl(d, cls, nodes_touched),
+        Statement::Tagged(t) => match t {
+            TaggedStatement::ExpressionStatement(es) => classify_expr(&es.expression, cls),
+            TaggedStatement::BlockStatement(b) => {
+                for s in &b.body {
+                    classify_stmt(s, cls, nodes_touched);
+                }
+            }
+            TaggedStatement::IfStatement(is) => {
+                classify_expr(&is.test, cls);
+                classify_stmt(&is.consequent, cls, nodes_touched);
+                if let Some(alt) = &is.alternate {
+                    classify_stmt(alt, cls, nodes_touched);
+                }
+            }
+            TaggedStatement::WhileStatement(ws) => {
+                classify_expr(&ws.test, cls);
+                classify_stmt(&ws.body, cls, nodes_touched);
+            }
+            TaggedStatement::ForStatement(fs) => {
+                if let Some(init) = &fs.init {
+                    match init {
+                        ForInit::VariableDeclaration(vd) => {
+                            for d in &vd.declarations {
+                                if let Some(i) = &d.init {
+                                    classify_expr(i, cls);
+                                }
+                            }
+                        }
+                        ForInit::Expression(e) => classify_expr(e, cls),
+                    }
+                }
+                if let Some(test) = &fs.test {
+                    classify_expr(test, cls);
+                }
+                if let Some(update) = &fs.update {
+                    classify_expr(update, cls);
+                }
+                classify_stmt(&fs.body, cls, nodes_touched);
+            }
+            TaggedStatement::ReturnStatement(rs) => {
+                if let Some(a) = &rs.argument {
+                    classify_expr(a, cls);
+                }
+            }
+            TaggedStatement::ThrowStatement(ts) => classify_expr(&ts.argument, cls),
+            TaggedStatement::LabeledStatement(ls) => classify_stmt(&ls.body, cls, nodes_touched),
+            TaggedStatement::SwitchStatement(ss) => {
+                classify_expr(&ss.discriminant, cls);
+                for c in &ss.cases {
+                    if let Some(test) = &c.test {
+                        classify_expr(test, cls);
+                    }
+                    for s in &c.consequent {
+                        classify_stmt(s, cls, nodes_touched);
+                    }
+                }
+            }
+            TaggedStatement::BreakStatement(_)
+            | TaggedStatement::ContinueStatement(_)
+            | TaggedStatement::EmptyStatement(_) => {}
+        },
+    }
+}
+
+fn classify_expr(expr: &Expression, cls: &mut Classify) {
+    match expr {
+        Expression::Identifier(_)
+        | Expression::NumericLiteral(_)
+        | Expression::StringLiteral(_)
+        | Expression::BooleanLiteral(_)
+        | Expression::NullLiteral(_)
+        | Expression::BigIntLiteral(_)
+        | Expression::UndefinedLiteral(_) => {}
+        Expression::BinaryExpression(be) => {
+            classify_expr(&be.left, cls);
+            classify_expr(&be.right, cls);
+        }
+        Expression::LogicalExpression(le) => {
+            classify_expr(&le.left, cls);
+            classify_expr(&le.right, cls);
+        }
+        Expression::UnaryExpression(ue) => classify_expr(&ue.argument, cls),
+        Expression::AssignmentExpression(ae) => {
+            if let AssignmentTarget::MemberExpression(m) = &ae.left {
+                classify_member(&m.object, &m.property, m.computed, cls);
+            }
+            classify_expr(&ae.right, cls);
+        }
+        Expression::ConditionalExpression(ce) => {
+            classify_expr(&ce.test, cls);
+            classify_expr(&ce.consequent, cls);
+            classify_expr(&ce.alternate, cls);
+        }
+        Expression::CallExpression(ce) => {
+            classify_expr(&ce.callee, cls);
+            for a in &ce.arguments {
+                classify_expr(a, cls);
+            }
+        }
+        Expression::MemberExpression(m) => classify_member(&m.object, &m.property, m.computed, cls),
+        Expression::ArrayExpression(ae) => {
+            for el in ae.elements.iter().flatten() {
+                classify_expr(el, cls);
+            }
+        }
+        Expression::ObjectExpression(oe) => {
+            for prop in &oe.properties {
+                if prop.computed {
+                    // `{ [expr]: v }` — Phase-1 rejects this at the bridge,
+                    // but be defensive: recurse the key, record nothing.
+                    if let PropertyKey::Expression(e) = &prop.key {
+                        classify_expr(e, cls);
+                    }
+                } else {
+                    match &prop.key {
+                        // `{ x: v }` — a renameable dotted key.
+                        PropertyKey::Identifier(id) => cls.see_dotted(&id.name),
+                        // `{ "x": v }` — a quoted key disables `x`.
+                        PropertyKey::StringLiteral(s) => cls.see_quoted(&s.value),
+                        // Numeric keys / others — not renameable identifiers.
+                        _ => {}
+                    }
+                }
+                classify_expr(&prop.value, cls);
+            }
+        }
+    }
+}
+
+fn classify_member(object: &Expression, property: &Expression, computed: bool, cls: &mut Classify) {
+    classify_expr(object, cls);
+    if computed {
+        // `obj["x"]` — a quoted access disables `x`. Any other computed
+        // key is a dynamic access (the author's contract responsibility);
+        // we still recurse it for nested property accesses.
+        if let Expression::StringLiteral(s) = property {
+            cls.see_quoted(&s.value);
+        } else {
+            classify_expr(property, cls);
+        }
+    } else if let Expression::Identifier(id) = property {
+        // `obj.x` — a renameable dotted access.
+        cls.see_dotted(&id.name);
+    }
+}
+
+// ---- rewrite -------------------------------------------------------------
+
+fn rewrite_item(item: &mut ProgramItem, map: &HashMap<String, String>) {
+    match item {
+        ProgramItem::Declaration(d) => rewrite_decl(d, map),
+        ProgramItem::Statement(s) => rewrite_stmt(s, map),
+    }
+}
+
+fn rewrite_decl(decl: &mut Declaration, map: &HashMap<String, String>) {
+    match decl {
+        Declaration::VariableDeclaration(vd) => {
+            for d in &mut vd.declarations {
+                if let Some(init) = &mut d.init {
+                    rewrite_expr(init, map);
+                }
+            }
+        }
+        Declaration::FunctionDeclaration(fd) => {
+            for s in &mut fd.body.body {
+                rewrite_stmt(s, map);
+            }
+        }
+    }
+}
+
+fn rewrite_stmt(stmt: &mut Statement, map: &HashMap<String, String>) {
+    match stmt {
+        Statement::Declaration(d) => rewrite_decl(d, map),
+        Statement::Tagged(t) => match t {
+            TaggedStatement::ExpressionStatement(es) => rewrite_expr(&mut es.expression, map),
+            TaggedStatement::BlockStatement(b) => {
+                for s in &mut b.body {
+                    rewrite_stmt(s, map);
+                }
+            }
+            TaggedStatement::IfStatement(is) => {
+                rewrite_expr(&mut is.test, map);
+                rewrite_stmt(&mut is.consequent, map);
+                if let Some(alt) = &mut is.alternate {
+                    rewrite_stmt(alt, map);
+                }
+            }
+            TaggedStatement::WhileStatement(ws) => {
+                rewrite_expr(&mut ws.test, map);
+                rewrite_stmt(&mut ws.body, map);
+            }
+            TaggedStatement::ForStatement(fs) => {
+                if let Some(init) = &mut fs.init {
+                    match init {
+                        ForInit::VariableDeclaration(vd) => {
+                            for d in &mut vd.declarations {
+                                if let Some(i) = &mut d.init {
+                                    rewrite_expr(i, map);
+                                }
+                            }
+                        }
+                        ForInit::Expression(e) => rewrite_expr(e, map),
+                    }
+                }
+                if let Some(test) = &mut fs.test {
+                    rewrite_expr(test, map);
+                }
+                if let Some(update) = &mut fs.update {
+                    rewrite_expr(update, map);
+                }
+                rewrite_stmt(&mut fs.body, map);
+            }
+            TaggedStatement::ReturnStatement(rs) => {
+                if let Some(a) = &mut rs.argument {
+                    rewrite_expr(a, map);
+                }
+            }
+            TaggedStatement::ThrowStatement(ts) => rewrite_expr(&mut ts.argument, map),
+            TaggedStatement::LabeledStatement(ls) => rewrite_stmt(&mut ls.body, map),
+            TaggedStatement::SwitchStatement(ss) => {
+                rewrite_expr(&mut ss.discriminant, map);
+                for c in &mut ss.cases {
+                    if let Some(test) = &mut c.test {
+                        rewrite_expr(test, map);
+                    }
+                    for s in &mut c.consequent {
+                        rewrite_stmt(s, map);
+                    }
+                }
+            }
+            TaggedStatement::BreakStatement(_)
+            | TaggedStatement::ContinueStatement(_)
+            | TaggedStatement::EmptyStatement(_) => {}
+        },
+    }
+}
+
+fn rewrite_expr(expr: &mut Expression, map: &HashMap<String, String>) {
+    match expr {
+        Expression::Identifier(_)
+        | Expression::NumericLiteral(_)
+        | Expression::StringLiteral(_)
+        | Expression::BooleanLiteral(_)
+        | Expression::NullLiteral(_)
+        | Expression::BigIntLiteral(_)
+        | Expression::UndefinedLiteral(_) => {}
+        Expression::BinaryExpression(be) => {
+            rewrite_expr(&mut be.left, map);
+            rewrite_expr(&mut be.right, map);
+        }
+        Expression::LogicalExpression(le) => {
+            rewrite_expr(&mut le.left, map);
+            rewrite_expr(&mut le.right, map);
+        }
+        Expression::UnaryExpression(ue) => rewrite_expr(&mut ue.argument, map),
+        Expression::AssignmentExpression(ae) => {
+            if let AssignmentTarget::MemberExpression(m) = &mut ae.left {
+                rewrite_member(&mut m.object, &mut m.property, m.computed, map);
+            }
+            rewrite_expr(&mut ae.right, map);
+        }
+        Expression::ConditionalExpression(ce) => {
+            rewrite_expr(&mut ce.test, map);
+            rewrite_expr(&mut ce.consequent, map);
+            rewrite_expr(&mut ce.alternate, map);
+        }
+        Expression::CallExpression(ce) => {
+            rewrite_expr(&mut ce.callee, map);
+            for a in &mut ce.arguments {
+                rewrite_expr(a, map);
+            }
+        }
+        Expression::MemberExpression(m) => {
+            rewrite_member(&mut m.object, &mut m.property, m.computed, map)
+        }
+        Expression::ArrayExpression(ae) => {
+            for el in ae.elements.iter_mut().flatten() {
+                rewrite_expr(el, map);
+            }
+        }
+        Expression::ObjectExpression(oe) => {
+            for prop in &mut oe.properties {
+                if prop.computed {
+                    if let PropertyKey::Expression(e) = &mut prop.key {
+                        rewrite_expr(e, map);
+                    }
+                } else if let PropertyKey::Identifier(id) = &mut prop.key {
+                    // Rewrite a renameable unquoted key; a `StringLiteral`
+                    // (quoted) key is never in `map`, so it is left alone.
+                    if let Some(new) = map.get(&id.name) {
+                        id.name = new.clone();
+                    }
+                }
+                rewrite_expr(&mut prop.value, map);
+            }
+        }
+    }
+}
+
+fn rewrite_member(
+    object: &mut Expression,
+    property: &mut Expression,
+    computed: bool,
+    map: &HashMap<String, String>,
+) {
+    rewrite_expr(object, map);
+    if computed {
+        // A quoted `obj["x"]` is never renamed (the name was disabled at
+        // classification); a dynamic key is recursed for nested accesses.
+        rewrite_expr(property, map);
+    } else if let Expression::Identifier(id) = property {
+        if let Some(new) = map.get(&id.name) {
+            id.name = new.clone();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    //! Source → bridge → rename-properties → emit roundtrips, plus the
+    //! metadata contract.
+    use super::*;
+    use coding_adventures_closure_emitter::{emit, EmitOptions};
+    use coding_adventures_closure_pass_pipeline::PassContext;
+    use coding_adventures_correlation_vector::CVLog;
+    use coding_adventures_javascript_ast::{Program, SourceType};
+    use coding_adventures_javascript_parser::{bridge, parse_javascript_typed};
+    use coding_adventures_javascript_tokens::EsVersion;
+    use coding_adventures_type_sidecar::Sidecar;
+
+    fn program() -> Program {
+        Program::new("prog.1".to_string(), EsVersion::Es2025, SourceType::Module)
+    }
+
+    fn rename_with(src: &str, externs: &[&str]) -> String {
+        let es = EsVersion::Es2025;
+        let node = parse_javascript_typed(src, es).expect("parse");
+        let prog = bridge::grammar_to_program(&node, es).expect("bridge");
+        let set: HashSet<String> = externs.iter().map(|s| s.to_string()).collect();
+        let pass = RenamePropertiesPass::new(set);
+        let sidecar = Sidecar::new();
+        let mut cv = CVLog::new(false);
+        let out = pass
+            .run(PassContext {
+                program: &prog,
+                sidecar: &sidecar,
+                cv: &mut cv,
+            })
+            .expect("rename-properties");
+        let mut cv2 = CVLog::new(false);
+        let opts = EmitOptions {
+            source_map: false,
+            ..Default::default()
+        };
+        emit(&out.program, &sidecar, &mut cv2, &opts)
+            .expect("emit")
+            .code
+    }
+
+    fn rename(src: &str) -> String {
+        rename_with(src, &[])
+    }
+
+    // ----- metadata -----
+
+    #[test]
+    fn name_is_rename_properties() {
+        assert_eq!(
+            RenamePropertiesPass::with_builtins_only().name(),
+            "rename-properties"
+        );
+    }
+
+    #[test]
+    fn iteration_policy_is_one_shot() {
+        assert_eq!(
+            RenamePropertiesPass::with_builtins_only().iteration_policy(),
+            IterationPolicy::OneShot
+        );
+    }
+
+    #[test]
+    fn cost_is_three() {
+        assert_eq!(RenamePropertiesPass::with_builtins_only().cost(), 3);
+    }
+
+    #[test]
+    fn depends_on_is_empty() {
+        assert!(RenamePropertiesPass::with_builtins_only()
+            .depends_on()
+            .is_empty());
+    }
+
+    #[test]
+    fn run_on_empty_program_is_identity() {
+        let pass = RenamePropertiesPass::with_builtins_only();
+        let prog = program();
+        let sidecar = Sidecar::new();
+        let mut cv = CVLog::new(true);
+        let out = pass
+            .run(PassContext {
+                program: &prog,
+                sidecar: &sidecar,
+                cv: &mut cv,
+            })
+            .expect("ok");
+        assert!(!out.changed);
+        assert_eq!(out.stats.nodes_touched, 1);
+    }
+
+    #[test]
+    fn pass_is_default_and_clone() {
+        let _a: RenamePropertiesPass = Default::default();
+        let _b = RenamePropertiesPass::with_builtins_only();
+        let _c = _b.clone();
+    }
+
+    // ----- behaviour -----
+
+    // NOTE on inputs: a member-ASSIGNMENT statement (`obj.x = 1;`) is not
+    // in the Phase-1 grammar, so these tests drive property accesses via
+    // member READS (call args / initializers) and object literals.
+
+    #[test]
+    fn renames_a_dotted_property_consistently() {
+        // `renderMode` appears dotted on two different objects and as an
+        // unquoted key; all three become the same fresh name.
+        assert_eq!(
+            rename("read(a.renderMode); read(b.renderMode); var c = { renderMode: 3 };"),
+            "read(a.a);read(b.a);var c={a:3};"
+        );
+    }
+
+    #[test]
+    fn does_not_rename_a_property_quoted_via_computed_member() {
+        // `mode` appears quoted (`other["mode"]`, a computed string member
+        // — which the bridge preserves as a StringLiteral). That disables
+        // `mode` everywhere, even at the dotted `obj.mode` (renaming would
+        // desync it from the quoted access we never touch).
+        assert_eq!(
+            rename("read(obj.mode); read(other[\"mode\"]);"),
+            "read(obj.mode);read(other[\"mode\"]);"
+        );
+    }
+
+    #[test]
+    fn does_not_rename_builtins() {
+        // `length` / `push` / `toString` are built-ins → never renamed.
+        // The user property `tally` (an object key) IS renamed.
+        assert_eq!(
+            rename("var n = arr.length; list.push(x); s.toString(); var o = { tally: 1 };"),
+            "var n=arr.length;list.push(x);s.toString();var o={a:1};"
+        );
+    }
+
+    #[test]
+    fn does_not_rename_externs_property() {
+        // `apiField` is supplied as an externs property → kept; the
+        // private `helperField` is renamed.
+        assert_eq!(
+            rename_with("read(obj.apiField); read(obj.helperField);", &["apiField"]),
+            "read(obj.apiField);read(obj.a);"
+        );
+    }
+
+    #[test]
+    fn renames_a_computed_member_object_but_not_the_dynamic_key() {
+        // `obj[idx]` — `idx` is a variable (dynamic), not a property name,
+        // so it is left alone; the dotted `obj.field` IS renamed. (`idx`
+        // never appears dotted, so it is not a property at all.)
+        assert_eq!(
+            rename("var v = obj[idx]; read(obj.field);"),
+            "var v=obj[idx];read(obj.a);"
+        );
+    }
+
+    #[test]
+    fn skips_single_char_property() {
+        // Already minimal.
+        assert_eq!(
+            rename("read(obj.x); read(obj.x);"),
+            "read(obj.x);read(obj.x);"
+        );
+    }
+
+    #[test]
+    fn renames_nested_property_chain() {
+        // Both links of `a.outerField.innerField` are renameable; the
+        // outer object's property (`outerField`) is seen first → `a`,
+        // then `innerField` → `b`.
+        assert_eq!(rename("read(a.outerField.innerField);"), "read(a.a.b);");
+    }
+}


### PR DESCRIPTION
## What

A new pass crate — Closure Compiler's `RENAME_PROPERTIES` in miniature. `RenamePropertiesPass` consistently shortens program-private object **property names** across the whole program:

```js
obj.computeTotal = fn; widget.computeTotal(); var cfg = { renderMode: 1 };
// => obj.a = fn; widget.a(); var cfg = { b: 1 };
```

Property access is *by name*, so renaming a name at **every** renameable occurrence (dotted `obj.x` + unquoted `{ x: … }`) is semantics-preserving regardless of which objects carry it. This is the next big ADVANCED win after global renaming.

## Soundness — the externs contract

Sound under Closure's **externs contract** (the property analogue of the global renamer's): every property reachable from *outside* this compilation must be in the do-not-rename boundary. A name is renamed only when it:

1. appears dotted / unquoted;
2. is **not** quoted via a computed string member (`obj["x"]` — the bridge preserves this signal);
3. is **not** a `BUILTIN_PROPERTIES` (a baked-in ECMAScript default-externs substitute — `length`, `prototype`, `toString`, `push`, …);
4. is **not** in the externs do-not-rename set; and
5. is longer than one character.

Each renameable property gets a **distinct** fresh name; the avoid set is the property namespace only (variables are a separate namespace, so a property may become `a` even when a variable `a` exists).

## Honest, documented limitations

- The built-in list covers ECMAScript but **not the DOM/host** — host property names (`innerHTML`, `addEventListener`, …) must be supplied via `--externs`.
- The parser bridge currently collapses a quoted object key `{ "x": 1 }` to an identifier key, so object-key quoting is **not** a usable do-not-rename signal (only computed-member quoting `obj["x"]` is) — **tracked as a separate bridge fix**. The security review confirmed this is a *missed external-protection hint* (governed by the externs contract), **not a miscompile** — renaming `{x:1}` and `obj.x` together stays internally consistent.
- Dynamic `obj[runtimeString]` is the author's contract responsibility, exactly as in Closure.

## Why pass-crate-first

This ships the **algorithmic core** (fully tested, security-reviewed). Wiring into ADVANCED — collecting externs *property* names and deciding the safe-by-default policy (require externs / bundle a DOM externs list, since the bundled built-ins don't cover the DOM) — is a deliberate follow-up, because turning it on by default without DOM externs would rename DOM properties. Same crate-first-then-wire pattern as `rename-globals`.

## Verification

- `closure-pass-rename-properties`: **13 passed** — metadata contract + source→bridge→pass→emit roundtrips covering consistent dotted+object-key renaming, computed-member quoting decline, built-in + externs protection, dynamic computed key, single-char skip, nested chain.
- fmt + clippy clean.
- **Security review: PASSED** — internal α-rewrite consistency (every renameable occurrence renamed, none missed/extra), no desync, distinct collision-free fresh names, sound variable/property namespace separation, panic-free + terminating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)