### PR TITLE
feat(closurec): wire ADVANCED property renaming, fail-closed on --externs (CLOC13.K)

### DIFF
--- a/code/packages/rust/closure-pass-rename-properties/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-rename-properties/CHANGELOG.md
@@ -2,6 +2,33 @@
 
 All notable changes to the `coding-adventures-closure-pass-rename-properties` crate will be documented in this file.
 
+## [0.2.0] - 2026-06-18
+
+### Added (CLOC13.K — `collect_property_names`, the externs property boundary)
+
+A public function `collect_property_names(program) -> HashSet<String>` that
+returns **every property name appearing anywhere** in a program — dotted member
+accesses (`el.innerHTML`), quoted member accesses (`obj["data-id"]`), unquoted
+object keys (`{ onload: f }`), and quoted object keys (`{ "aria-label": s }`).
+
+This is the property-namespace analogue of collecting an externs file's
+top-level variable/function names (the value-namespace boundary). A driver
+(closurec) walks each `--externs` file through this function and unions the
+results into the `do_not_rename` set it hands `RenamePropertiesPass::new`, so the
+external host/library property surface is preserved while program-private
+properties are still shortened.
+
+- **Over-collects on purpose.** Both renameable (dotted) and off-limits (quoted)
+  occurrences are returned: as an externs boundary, every named property is
+  external and must be protected. Forgoing a rename is never a miscompile;
+  renaming a genuinely external property is. Dynamic computed keys
+  (`obj[runtimeExpr]`) contribute nothing — there is no static name to protect.
+- Reuses the pass's existing whole-program `classify_item` walk (no second
+  traversal implementation to keep in sync).
+- 9 new unit tests + 1 doctest covering each occurrence shape, dynamic-key
+  exclusion, function-body recursion, and an end-to-end "collected externs
+  protect a property" round-trip.
+
 ## [0.1.0] - 2026-06-18
 
 ### Added (CLOC13.J — aggressive property renaming, algorithmic core)

--- a/code/packages/rust/closure-pass-rename-properties/Cargo.toml
+++ b/code/packages/rust/closure-pass-rename-properties/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-rename-properties"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "Aggressive property renaming pass for the Closure Compiler clone (ADVANCED-only). Consistently shortens program-private object property names that are never quoted/computed and not in the built-in or externs do-not-rename boundary."
 

--- a/code/packages/rust/closure-pass-rename-properties/README.md
+++ b/code/packages/rust/closure-pass-rename-properties/README.md
@@ -52,11 +52,37 @@ when a variable `a` exists).
 - Dynamic computed access `obj[runtimeString]` is the author's contract
   responsibility, exactly as in Closure.
 
+## Building the externs property boundary — `collect_property_names`
+
+The pass protects a `do_not_rename` set, but a driver needs to *build* that
+set from the user's `--externs` files. The crate exposes:
+
+```rust
+pub fn collect_property_names(program: &Program) -> HashSet<String>
+```
+
+It returns **every property name appearing anywhere** in a program — dotted
+(`el.innerHTML`), quoted (`obj["data-id"]`), and object keys (unquoted
+`{ onload: f }` and quoted `{ "aria-label": s }`). A driver parses each
+`--externs` file, walks it through `collect_property_names`, unions the
+results, and hands that set to `RenamePropertiesPass::new`. It over-collects
+deliberately: any property an externs file names is external and must be
+preserved, and forgoing a rename is never a miscompile. Dynamic computed
+keys (`obj[runtimeExpr]`) contribute nothing — there is no static name.
+
+This is the property-namespace twin of collecting an externs file's
+top-level variable/function names (the value-namespace boundary that gates
+`rename-globals`).
+
 ## Status
 
-This crate is the **algorithmic core**; wiring it into ADVANCED (collect
-externs property names + decide the safe-by-default policy) is a
-deliberate follow-up.
+This crate is the **algorithmic core** plus the externs-boundary collector.
+It is wired into closurec's ADVANCED level under a **safe-by-default policy**:
+property renaming runs only when the user passes at least one `--externs`
+file (opting into the externs contract and supplying the host/DOM property
+boundary). Without `--externs`, ADVANCED leaves property names untouched —
+the built-in list omits the DOM, so renaming by default would miscompile
+browser code.
 
 ## Dependency whitelist
 

--- a/code/packages/rust/closure-pass-rename-properties/src/lib.rs
+++ b/code/packages/rust/closure-pass-rename-properties/src/lib.rs
@@ -384,6 +384,55 @@ fn rename_properties(
     true
 }
 
+/// Collect **every property name that appears anywhere** in `program` —
+/// the property-namespace boundary an externs file declares.
+///
+/// This is the property-renaming analogue of collecting an externs file's
+/// top-level variable/function names (the *value*-namespace boundary). A
+/// driver that wants to feed an externs file's properties into a
+/// [`RenamePropertiesPass`] `do_not_rename` set walks each externs program
+/// through this function and unions the results.
+///
+/// We return the **union of dotted and quoted occurrences**, deliberately
+/// over-collecting:
+///
+/// * `el.innerHTML` (dotted)        → `innerHTML`
+/// * `obj["data-id"]` (quoted)      → `data-id`
+/// * `{ onload: f }` (unquoted key) → `onload`
+/// * `{ "aria-label": s }` (quoted) → `aria-label`
+///
+/// Why every occurrence, not just the renameable (dotted) ones? Because an
+/// externs file is a *declaration of the external boundary*: any property
+/// it names is part of the host/library contract and must be preserved in
+/// the program being compiled. Including quoted names too only ever
+/// *protects more* — forgoing a rename is never a miscompile, whereas
+/// renaming a genuinely external property is. (Computed dynamic keys like
+/// `obj[runtimeExpr]` contribute nothing — there is no static name to
+/// protect; that access is the author's own contract, exactly as in the
+/// pass itself.)
+///
+/// ```
+/// use coding_adventures_closure_pass_rename_properties::collect_property_names;
+/// use coding_adventures_javascript_ast::{Program, SourceType};
+/// use coding_adventures_javascript_tokens::EsVersion;
+/// // An empty externs program declares no property boundary.
+/// let empty = Program::new("ext.1".to_string(), EsVersion::Es2025, SourceType::Module);
+/// assert!(collect_property_names(&empty).is_empty());
+/// ```
+pub fn collect_property_names(program: &Program) -> HashSet<String> {
+    let mut cls = Classify::default();
+    let mut nodes_touched: u32 = 0;
+    for item in &program.body {
+        classify_item(item, &mut cls, &mut nodes_touched);
+    }
+    // The union of both buckets: dotted (renameable-shape) and quoted
+    // (off-limits-shape) occurrences. As an externs boundary, both kinds
+    // are equally external and must be protected.
+    let mut names = cls.dotted_seen;
+    names.extend(cls.quoted);
+    names
+}
+
 /// Generates `a`, `b`, …, `z`, `aa`, … skipping reserved words and the
 /// caller's `avoid` set.
 struct FreshNames {
@@ -943,5 +992,94 @@ mod tests {
         // outer object's property (`outerField`) is seen first → `a`,
         // then `innerField` → `b`.
         assert_eq!(rename("read(a.outerField.innerField);"), "read(a.a.b);");
+    }
+
+    // ----- collect_property_names (externs property boundary) -----
+
+    /// Parse `src` and collect its property names — the helper a driver
+    /// uses to turn an externs file into a `do_not_rename` set.
+    fn collect(src: &str) -> HashSet<String> {
+        let es = EsVersion::Es2025;
+        let node = parse_javascript_typed(src, es).expect("parse");
+        let prog = bridge::grammar_to_program(&node, es).expect("bridge");
+        collect_property_names(&prog)
+    }
+
+    #[test]
+    fn collect_empty_program_is_empty() {
+        assert!(collect_property_names(&program()).is_empty());
+    }
+
+    #[test]
+    fn collect_dotted_member_read() {
+        // `el.innerHTML` — a dotted access names `innerHTML` as external.
+        let names = collect("read(el.innerHTML);");
+        assert!(names.contains("innerHTML"));
+    }
+
+    #[test]
+    fn collect_quoted_member_read() {
+        // `obj["data-id"]` — a quoted access still names `data-id`. As an
+        // externs boundary we protect it (over-collecting is always safe).
+        let names = collect("read(obj[\"data-id\"]);");
+        assert!(names.contains("data-id"));
+    }
+
+    #[test]
+    fn collect_unquoted_object_key() {
+        // `{ onload: f }` — an unquoted key names `onload`.
+        let names = collect("var handlers = { onload: cb };");
+        assert!(names.contains("onload"));
+    }
+
+    #[test]
+    fn collect_quoted_object_key() {
+        // `{ "aria-label": s }` — a quoted key names `aria-label`.
+        let names = collect("var attrs = { \"aria-label\": label };");
+        assert!(names.contains("aria-label"));
+    }
+
+    #[test]
+    fn collect_unions_multiple_occurrences() {
+        // Dotted + quoted + object-key occurrences all land in one set.
+        let names =
+            collect("read(el.innerHTML); read(node[\"textContent\"]); var o = { onclick: h };");
+        assert!(names.contains("innerHTML"));
+        assert!(names.contains("textContent"));
+        assert!(names.contains("onclick"));
+    }
+
+    #[test]
+    fn collect_ignores_dynamic_computed_key() {
+        // `obj[runtimeKey]` has no static name — there is nothing to
+        // protect, so it contributes nothing to the boundary. (`prefix`
+        // is still collected from the dotted access.)
+        let names = collect("read(obj[runtimeKey]); read(obj.prefix);");
+        assert!(names.contains("prefix"));
+        assert!(!names.contains("runtimeKey"));
+    }
+
+    #[test]
+    fn collect_walks_into_function_bodies() {
+        // Property accesses nested inside a function declaration are still
+        // part of the externs boundary.
+        let names = collect("function api(x){ return x.payload; }");
+        assert!(names.contains("payload"));
+    }
+
+    #[test]
+    fn collected_externs_protect_a_property_from_rename() {
+        // End-to-end intent: feeding collected externs names into the pass
+        // keeps those properties while still renaming program-private ones.
+        let externs = collect("read(boundary.innerHTML);");
+        let externs_vec: Vec<&str> = externs.iter().map(|s| s.as_str()).collect();
+        // `innerHTML` is in the boundary → kept; `secretField` is private
+        // → renamed to a short name.
+        let out = rename_with(
+            "read(node.innerHTML); read(node.secretField); read(node.secretField);",
+            &externs_vec,
+        );
+        assert!(out.contains(".innerHTML"));
+        assert!(!out.contains("secretField"));
     }
 }

--- a/code/programs/rust/closurec/CHANGELOG.md
+++ b/code/programs/rust/closurec/CHANGELOG.md
@@ -2,6 +2,60 @@
 
 All notable changes to the `coding-adventures-closurec` binary will be documented in this file.
 
+## [0.150.0] - 2026-06-18
+
+### Added (CLOC13.K — ADVANCED property renaming, gated on `--externs`)
+
+`--compilation_level ADVANCED` now also shortens program-private **property**
+names via the `rename-properties` pass
+(`coding-adventures-closure-pass-rename-properties` 0.2.0), appended after
+`rename-globals`. Properties live in their own namespace, so this is a second
+independent ADVANCED-over-SIMPLE size win on top of top-level renaming:
+
+```js
+read(obj.innerHTML); read(obj.secretField); read(obj.secretField);
+//  externs file: read(node.innerHTML);   // declares innerHTML external
+//  ADVANCED + --externs => read(obj.innerHTML);read(obj.a);read(obj.a);
+```
+
+**Safe-by-default — gated on `--externs`.** Property renaming runs ONLY when
+the user supplies at least one `--externs` file. The pass's bundled built-in
+list covers ECMAScript but NOT the DOM/host, so renaming properties
+unconditionally would rewrite `el.innerHTML` / `node.onload` and break browser
+code. Supplying `--externs` is the user opting into the externs contract AND
+declaring the external property boundary. Without it, ADVANCED leaves property
+names untouched (only `rename-globals` runs, exactly as in 0.149.0).
+
+- **New `collect_externs_property_names(config)`** — the property-namespace twin
+  of `externs_do_not_rename`. It walks every `--externs` file through the
+  rename-properties crate's new `collect_property_names`, unioning every
+  property name they mention (dotted, quoted, and object keys) into the pass's
+  do-not-rename set.
+- **Fail-closed, NOT degrade-safe.** Unlike `externs_do_not_rename` (whose
+  pass is sound with an empty keep-set), property renaming is sound only
+  *because* the user declared the boundary — so the boundary's contents are
+  what make it safe. If any externs source fails to resolve/read/parse/bridge,
+  `collect_externs_property_names` returns `None` and property renaming is
+  **disabled** for the run, rather than running against an empty/partial
+  boundary (which would rename an externally-observable property — a
+  miscompile, in exactly the case the user opted into safety). The CV `passes`
+  trace is driven off the *same* decision, so it can never claim
+  `rename-properties` ran when it didn't.
+- **`run_typed_pipeline` now takes `Option<AdvancedConfig>`** (was
+  `Option<HashSet<String>>`). `AdvancedConfig` carries both externs boundaries —
+  the value-namespace keep-set for `rename-globals` (always runs under ADVANCED)
+  and the optional property-namespace keep-set that gates `rename-properties`.
+  The now-redundant `run_simple_pipeline` wrapper was removed (the unified
+  caller passes `None` for SIMPLE directly).
+- The correlation-vector `passes` trace lists `rename-properties` for ADVANCED
+  only when `--externs` was supplied (the pass is conditional).
+- SIMPLE output is byte-for-byte unchanged; ADVANCED without `--externs` is
+  unchanged from 0.149.0.
+- 4 new integration tests pin the policy (SIMPLE / no-externs ADVANCED leave
+  properties alone; ADVANCED + externs renames a private property, keeps the
+  externs-declared one, and shrinks output; ADVANCED + an unparseable externs
+  file fails closed and renames nothing).
+
 ## [0.149.0] - 2026-06-18
 
 ### Added (CLOC13.I — ADVANCED diverges from SIMPLE: aggressive top-level renaming)

--- a/code/programs/rust/closurec/Cargo.toml
+++ b/code/programs/rust/closurec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closurec"
-version = "0.149.0"
+version = "0.150.0"
 edition = "2021"
 description = "closurec — CLI driver for the Closure Compiler clone. Mirrors the upstream Java Closure Compiler's command-line flag surface (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility. Per CLOC08."
 
@@ -31,6 +31,7 @@ coding-adventures-closure-pass-inline = { path = "../../../packages/rust/closure
 coding-adventures-closure-pass-inline-variables = { path = "../../../packages/rust/closure-pass-inline-variables" }
 coding-adventures-closure-pass-rename = { path = "../../../packages/rust/closure-pass-rename" }
 coding-adventures-closure-pass-rename-globals = { path = "../../../packages/rust/closure-pass-rename-globals" }
+coding-adventures-closure-pass-rename-properties = { path = "../../../packages/rust/closure-pass-rename-properties" }
 coding-adventures-closure-pass-treeshake = { path = "../../../packages/rust/closure-pass-treeshake" }
 coding-adventures-closure-pass-collapse-properties = { path = "../../../packages/rust/closure-pass-collapse-properties" }
 coding-adventures-closure-pass-remove-unused-vars = { path = "../../../packages/rust/closure-pass-remove-unused-vars" }

--- a/code/programs/rust/closurec/cli.spec.json
+++ b/code/programs/rust/closurec/cli.spec.json
@@ -2,7 +2,7 @@
   "cli_builder_spec_version": "1.0",
   "name": "closurec",
   "description": "closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.",
-  "version": "0.149.0",
+  "version": "0.150.0",
   "parsing_mode": "gnu",
   "flags": [
     { "id": "browser_featureset_year", "long": "browser_featureset_year", "type": "integer", "default": 0, "description": "Shortcut for defining goog.FEATURESET_YEAR=YYYY (minimum 2012)." },

--- a/code/programs/rust/closurec/src/run.rs
+++ b/code/programs/rust/closurec/src/run.rs
@@ -255,6 +255,13 @@ const SIMPLE_PASS_NAMES: &[&str] = &[
 /// leaf-function locals) so the two renamers shorten disjoint name
 /// layers. `rename-globals` is gated by the `--externs` do-not-rename
 /// boundary; see [`externs_do_not_rename`].
+///
+/// A further `rename-properties` pass runs after `rename-globals` **only
+/// when the user supplied `--externs`** (it is appended dynamically at the
+/// trace site, not listed here, because it is conditional). Property
+/// renaming is unsafe without an externs property boundary — the bundled
+/// built-in list omits the DOM — so it is opt-in via the externs contract.
+/// See [`AdvancedConfig`] and [`collect_externs_property_names`].
 const ADVANCED_PASS_NAMES: &[&str] = &[
     "constant-fold",
     "fold-control-flow",
@@ -267,43 +274,56 @@ const ADVANCED_PASS_NAMES: &[&str] = &[
     "rename-globals",
 ];
 
-/// Run the SIMPLE optimization pipeline over a bridged `Program` and
-/// emit the result as JavaScript text.
+/// ADVANCED-only pipeline configuration. Passing `Some` to
+/// [`run_typed_pipeline`] selects ADVANCED; `None` is SIMPLE.
 ///
-/// This is the "happy path" half of the SIMPLE level. The caller has
-/// already turned source text into a typed [`Program`] via the
-/// grammar parser and the bridge; this function runs the pass
-/// pipeline ([`SIMPLE_PASS_NAMES`]) over it and serialises the
-/// optimized tree back to JS with [`closure_emitter::emit`].
-///
-/// Returns `Some(code)` on success and `None` if a pass or the
-/// emitter fails — in which case the caller degrades to
-/// `whitespace_only`. Either way it records the outcome in
-/// `*status` (`"ok"`, `"pass_error:<e>"`, or `"emit_error:<e>"`) so
-/// the correlation-vector trace can distinguish a true optimized emit
-/// from a degrade.
-///
-/// The pass pipeline and emitter both want a type [`Sidecar`] and a
-/// [`CVLog`]. SIMPLE v2 has no type-inference stage yet, so we pass an
-/// empty sidecar; the pass-internal CV log is created disabled because
-/// the per-byte SIMPLE trace is emitted by the caller's stage block,
-/// not by the individual passes.
-fn run_simple_pipeline(
-    program: coding_adventures_javascript_ast::Program,
-    status: &mut Option<String>,
-) -> Option<String> {
-    run_typed_pipeline(program, status, None)
+/// The two fields encode the two halves of the externs contract — the
+/// value namespace (which top-level identifiers are external) and the
+/// property namespace (which member/key names are external). They are
+/// independent boundaries: `rename-globals` always runs under ADVANCED
+/// (with an empty keep-set when no externs were given, since top-level
+/// renaming is sound under closurec's whole-program contract), whereas
+/// `rename-properties` is **gated on the user supplying `--externs`** —
+/// without an externs file we have no DOM/host property boundary and the
+/// bundled built-in list omits the DOM, so renaming properties by default
+/// would miscompile browser code.
+struct AdvancedConfig {
+    /// Top-level names the `rename-globals` pass must keep (the externs
+    /// value-namespace boundary; empty when no `--externs` were given).
+    do_not_rename_globals: std::collections::HashSet<String>,
+    /// When `Some`, run `rename-properties` gated on this externs
+    /// property-namespace boundary. `None` means property renaming stays
+    /// OFF — either the user passed no `--externs`, or (fail-closed) an
+    /// externs source could not be loaded, so the boundary is untrustworthy
+    /// and renaming would risk a miscompile. See
+    /// [`collect_externs_property_names`].
+    rename_properties_externs: Option<std::collections::HashSet<String>>,
 }
 
-/// Run the typed-AST optimization pipeline. `advanced_externs`
-/// distinguishes the two levels: `None` is SIMPLE; `Some(set)` is
-/// ADVANCED, which appends the `rename-globals` pass (gated by the
-/// externs do-not-rename `set`) after the SIMPLE passes. See
-/// [`run_simple_pipeline`] / [`SIMPLE_PASS_NAMES`] / [`ADVANCED_PASS_NAMES`].
+/// Run the typed-AST optimization pipeline over a bridged `Program` and
+/// emit the result as JavaScript text.
+///
+/// The caller has already turned source text into a typed [`Program`] via
+/// the grammar parser and the bridge; this runs the pass pipeline over it
+/// and serialises the optimized tree back to JS with
+/// [`closure_emitter::emit`]. Returns `Some(code)` on success and `None`
+/// if a pass or the emitter fails — the caller then degrades to
+/// `whitespace_only`. Either way it records the outcome in `*status`
+/// (`"ok"`, `"pass_error:<e>"`, or `"emit_error:<e>"`) so the
+/// correlation-vector trace can distinguish a true optimized emit from a
+/// degrade. SIMPLE v2 has no type-inference stage yet, so an empty
+/// [`Sidecar`] is passed; the pass-internal [`CVLog`] is disabled because
+/// the per-byte trace is emitted by the caller's stage block.
+///
+/// `advanced` distinguishes the two levels: `None` is SIMPLE; `Some(cfg)`
+/// is ADVANCED, which appends `rename-globals` (always) and
+/// `rename-properties` (only when `cfg.rename_properties_externs` is
+/// `Some`) after the SIMPLE passes. See [`SIMPLE_PASS_NAMES`] /
+/// [`ADVANCED_PASS_NAMES`] / [`AdvancedConfig`].
 fn run_typed_pipeline(
     program: coding_adventures_javascript_ast::Program,
     status: &mut Option<String>,
-    advanced_externs: Option<std::collections::HashSet<String>>,
+    advanced: Option<AdvancedConfig>,
 ) -> Option<String> {
     use coding_adventures_closure_emitter::{emit, EmitOptions};
     use coding_adventures_closure_pass_constant_fold::ConstantFoldPass;
@@ -315,6 +335,7 @@ fn run_typed_pipeline(
     use coding_adventures_closure_pass_remove_unused_vars::RemoveUnusedVarsPass;
     use coding_adventures_closure_pass_rename::RenamePass;
     use coding_adventures_closure_pass_rename_globals::RenameGlobalsPass;
+    use coding_adventures_closure_pass_rename_properties::RenamePropertiesPass;
     use coding_adventures_closure_pass_treeshake::TreeshakePass;
     use coding_adventures_correlation_vector::CVLog;
     use coding_adventures_type_sidecar::Sidecar;
@@ -348,11 +369,20 @@ fn run_typed_pipeline(
     // standalone), so registration order places it at the end.
     pipeline.add(Box::new(RenamePass::new()));
 
-    // ADVANCED only: shorten program-private TOP-LEVEL names too, gated by
-    // the externs do-not-rename boundary. Registered after `rename` so the
-    // two renamers shorten disjoint name layers (locals vs top-level).
-    if let Some(externs) = advanced_externs {
-        pipeline.add(Box::new(RenameGlobalsPass::new(externs)));
+    // ADVANCED only. Registered after `rename` so the renamers shorten
+    // disjoint name layers (locals → globals → properties).
+    if let Some(adv) = advanced {
+        // `rename-globals` shortens program-private TOP-LEVEL names, gated
+        // by the externs value-namespace boundary (empty keep-set is sound
+        // here — top-level renaming holds under the whole-program contract).
+        pipeline.add(Box::new(RenameGlobalsPass::new(adv.do_not_rename_globals)));
+        // `rename-properties` shortens program-private PROPERTY names, but
+        // only when the user opted into the externs contract by supplying
+        // `--externs` (the property-namespace boundary). Without it the pass
+        // does not run at all — see [`AdvancedConfig`] for why.
+        if let Some(prop_externs) = adv.rename_properties_externs {
+            pipeline.add(Box::new(RenamePropertiesPass::new(prop_externs)));
+        }
     }
 
     let optimized = match pipeline.run(program, &sidecar, &mut pass_cv) {
@@ -407,6 +437,24 @@ pub fn transform_source_with_cv(
     // contribution below. Other levels leave it None, where the CV block
     // substitutes "n/a".
     let mut simple_bridge_status: Option<String> = None;
+
+    // Decide ADVANCED property renaming ONCE, fail-closed, so the pipeline
+    // and the CV trace below agree (they must never disagree — one running
+    // the pass while the other omits it from the trace). `Some` means
+    // `rename-properties` will run against this externs property boundary;
+    // `None` means it will not (SIMPLE, no `--externs`, or — critically — an
+    // externs source that failed to load, which DISABLES the pass rather
+    // than running it against an empty/partial boundary). See
+    // [`collect_externs_property_names`].
+    let rename_properties_externs: Option<std::collections::HashSet<String>> =
+        if matches!(config.compilation.level, CompilationLevel::Advanced)
+            && !config.io.externs.is_empty()
+        {
+            collect_externs_property_names(config)
+        } else {
+            None
+        };
+    let will_rename_properties = rename_properties_externs.is_some();
 
     // Step 1 — compilation-level transform.
     let after_level = match config.compilation.level {
@@ -469,14 +517,20 @@ pub fn transform_source_with_cv(
                 }
                 Ok(node) => match bridge::grammar_to_program(&node, es_version) {
                     Ok(program) => {
-                        // ADVANCED adds aggressive top-level renaming,
-                        // gated by the externs do-not-rename boundary;
-                        // SIMPLE runs the typed pipeline unchanged.
-                        let advanced_externs = match config.compilation.level {
-                            CompilationLevel::Advanced => Some(externs_do_not_rename(config)),
+                        // ADVANCED adds aggressive renaming on top of the
+                        // SIMPLE pipeline. `rename-globals` runs always
+                        // (gated by the externs value boundary), and
+                        // `rename-properties` runs only with the (fail-closed)
+                        // property boundary decided above — SIMPLE runs the
+                        // typed pipeline unchanged.
+                        let advanced = match config.compilation.level {
+                            CompilationLevel::Advanced => Some(AdvancedConfig {
+                                do_not_rename_globals: externs_do_not_rename(config),
+                                rename_properties_externs,
+                            }),
                             _ => None,
                         };
-                        run_typed_pipeline(program, &mut simple_bridge_status, advanced_externs)
+                        run_typed_pipeline(program, &mut simple_bridge_status, advanced)
                     }
                     Err(BridgeError::UnsupportedSyntax { rule, location }) => {
                         simple_bridge_status =
@@ -534,10 +588,22 @@ pub fn transform_source_with_cv(
                 // passes today (it is ≥ SIMPLE) and gains advanced-only
                 // passes here as they land.
                 CompilationLevel::Simple | CompilationLevel::Advanced => {
-                    let (tag, level, passes_list) = match config.compilation.level {
-                        CompilationLevel::Advanced => ("advanced_v1", "ADVANCED", ADVANCED_PASS_NAMES),
-                        _ => ("simple_v2", "SIMPLE", SIMPLE_PASS_NAMES),
-                    };
+                    // The pass list is dynamic for ADVANCED: `rename-properties`
+                    // appears in the trace exactly when it actually ran —
+                    // `will_rename_properties` is the SAME fail-closed decision
+                    // that gated the pipeline above, so the trace can never
+                    // disagree with what executed.
+                    let (tag, level, passes_list): (&str, &str, Vec<&str>) =
+                        match config.compilation.level {
+                            CompilationLevel::Advanced => {
+                                let mut passes: Vec<&str> = ADVANCED_PASS_NAMES.to_vec();
+                                if will_rename_properties {
+                                    passes.push("rename-properties");
+                                }
+                                ("advanced_v1", "ADVANCED", passes)
+                            }
+                            _ => ("simple_v2", "SIMPLE", SIMPLE_PASS_NAMES.to_vec()),
+                        };
                     (
                         tag,
                         vec![
@@ -749,6 +815,59 @@ fn externs_do_not_rename(config: &CompilerConfig) -> std::collections::HashSet<S
         }
     }
     names
+}
+
+/// Collect the externs **property** do-not-rename set — every property
+/// name mentioned in the `--externs` files. This is the *property*
+/// namespace twin of [`externs_do_not_rename`] (which collects top-level
+/// *variable* names). ADVANCED's `rename-properties` pass renames every
+/// other program-private property but must keep these (they are the
+/// host/library surface — `innerHTML`, `addEventListener`, …).
+///
+/// The actual walk lives in the rename-properties crate
+/// (`collect_property_names`) so there is one whole-program property
+/// traversal to keep in sync, reused here and by the pass itself.
+///
+/// # Fail-closed, NOT degrade-safe
+///
+/// Unlike [`externs_do_not_rename`] (whose pass, `rename-globals`, runs at
+/// ADVANCED regardless and is sound with an empty keep-set under the
+/// whole-program contract), `rename-properties` is sound **only because the
+/// user declared the external property boundary via `--externs`**. So the
+/// boundary's *contents* — not the mere presence of the flag — are what
+/// make renaming safe. If any externs source fails to resolve, read,
+/// parse, or bridge, we return [`None`], and the caller **disables property
+/// renaming entirely** for this run. Silently contributing a partial (or
+/// empty) boundary would let an externally-observable property be renamed —
+/// a miscompile of valid input, in precisely the case the user opted into
+/// safety. A typo'd path, a permission error, or an externs file using
+/// syntax the Phase-1 parser rejects must turn the pass OFF, never run it
+/// against a shrunken boundary.
+///
+/// Returns `Some(set)` only when EVERY resolved externs file successfully
+/// contributed its property names (the set may legitimately be empty if the
+/// externs files mention no properties). Callers only invoke this when
+/// `config.io.externs` is non-empty.
+fn collect_externs_property_names(
+    config: &CompilerConfig,
+) -> Option<std::collections::HashSet<String>> {
+    use coding_adventures_closure_pass_rename_properties::collect_property_names;
+
+    // A glob failure here would already have been surfaced by
+    // `resolve_externs` in `run_compiler`; treat it as fail-closed anyway.
+    let paths = resolve_externs(config).ok()?;
+    let es = map_language_in_to_es_version(config);
+    let mut names = std::collections::HashSet::new();
+    for path in paths {
+        // Any read/parse/bridge failure disables the pass (`?` → None) — a
+        // partial boundary is unsound, so we refuse to optimize rather than
+        // risk renaming an external property.
+        let src = fs::read_to_string(&path).ok()?;
+        let node = parse_javascript_typed(&src, es).ok()?;
+        let program = bridge::grammar_to_program(&node, es).ok()?;
+        names.extend(collect_property_names(&program));
+    }
+    Some(names)
 }
 
 /// Run the compiler with `config`.
@@ -6105,6 +6224,137 @@ mod tests {
         assert!(
             advanced.len() < simple.len(),
             "ADVANCED must be smaller than SIMPLE here"
+        );
+    }
+
+    // ------------------------------------------------------------------
+    // CLOC13.K — ADVANCED property renaming, gated on --externs
+    //
+    // `rename-properties` shortens program-private property names. It is
+    // unsafe to run unconditionally (the bundled built-in list omits the
+    // DOM, so `el.innerHTML`/`node.onload` would be renamed and break
+    // browser code), so closurec runs it ONLY when the user supplies at
+    // least one `--externs` file — opting into the externs contract AND
+    // providing the host/DOM property boundary. These three tests pin the
+    // policy: SIMPLE and no-externs ADVANCED leave properties alone;
+    // ADVANCED + externs renames a private property while keeping an
+    // externs-declared one.
+    // ------------------------------------------------------------------
+
+    /// Top-level program whose property accesses survive every structural
+    /// pass: `secretField` is program-private (renameable), `innerHTML` is
+    /// declared in the externs file below (must be kept). `read`/`obj` are
+    /// free globals, untouched by `rename-globals`.
+    const PROP_INPUT: &str =
+        "read(obj.innerHTML);\nread(obj.secretField);\nread(obj.secretField);\n";
+    /// An externs file declaring `innerHTML` as part of the external
+    /// surface (and nothing about `secretField`).
+    const PROP_EXTERNS: &str = "var node;\nread(node.innerHTML);\n";
+    /// An externs file the Phase-1 bridge REJECTS (member-assignment
+    /// statement). Loading it fails, so the property boundary cannot be
+    /// established — property renaming must fail closed (stay OFF).
+    const BAD_EXTERNS: &str = "node.innerHTML = 1;\n";
+
+    /// Compile `PROP_INPUT` at `level`, optionally with an externs file
+    /// whose body is `externs`, and return stdout. Writes real temp files
+    /// because the externs boundary is collected from `--externs` paths on
+    /// disk. `label` makes the temp paths unique per call so
+    /// concurrently-running tests (cargo runs them on multiple threads)
+    /// never share — and delete — a file.
+    fn compile_prop(
+        level: crate::config::CompilationLevel,
+        externs: Option<&str>,
+        label: &str,
+    ) -> String {
+        let in_path = temp_path(&format!("prop-{label}-in.js"));
+        fs::write(&in_path, PROP_INPUT).expect("setup");
+        let mut io = IoConfig {
+            js_patterns: vec![in_path.to_string_lossy().to_string()],
+            ..Default::default()
+        };
+        let ext_path = temp_path(&format!("prop-{label}-ext.js"));
+        if let Some(body) = externs {
+            fs::write(&ext_path, body).expect("setup");
+            io.externs = vec![ext_path.to_string_lossy().to_string()];
+        }
+        let cfg = CompilerConfig {
+            io,
+            compilation: crate::config::CompilationConfig {
+                level,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let out = run_compiler(&cfg).expect("ok").stdout_text;
+        let _ = fs::remove_file(&in_path);
+        let _ = fs::remove_file(&ext_path);
+        out
+    }
+
+    #[test]
+    fn simple_does_not_rename_properties() {
+        // SIMPLE never renames properties — both names survive verbatim.
+        let out = compile_prop(crate::config::CompilationLevel::Simple, None, "simple");
+        assert!(out.contains(".innerHTML"), "got: {out}");
+        assert!(out.contains(".secretField"), "got: {out}");
+    }
+
+    #[test]
+    fn advanced_without_externs_does_not_rename_properties() {
+        // ADVANCED with NO --externs leaves properties untouched: there is
+        // no host/DOM property boundary, so renaming would be unsound.
+        let out = compile_prop(crate::config::CompilationLevel::Advanced, None, "adv-noext");
+        assert!(out.contains(".innerHTML"), "got: {out}");
+        assert!(out.contains(".secretField"), "got: {out}");
+    }
+
+    #[test]
+    fn advanced_with_externs_renames_private_property_only() {
+        // ADVANCED + --externs: `secretField` (program-private) is renamed
+        // away; `innerHTML` (declared in the externs file) is kept.
+        let out = compile_prop(
+            crate::config::CompilationLevel::Advanced,
+            Some(PROP_EXTERNS),
+            "adv-ext",
+        );
+        assert!(
+            out.contains(".innerHTML"),
+            "externs-declared property must be kept; got: {out}"
+        );
+        assert!(
+            !out.contains("secretField"),
+            "private property must be renamed away; got: {out}"
+        );
+        // And it actually shrank versus the no-externs ADVANCED output.
+        let baseline = compile_prop(crate::config::CompilationLevel::Advanced, None, "adv-base");
+        assert!(
+            out.len() < baseline.len(),
+            "property renaming must shrink output: {} vs {}",
+            out.len(),
+            baseline.len()
+        );
+    }
+
+    #[test]
+    fn advanced_with_unparseable_externs_disables_property_renaming() {
+        // FAIL-CLOSED: the user supplied `--externs`, but the file fails to
+        // parse, so the property boundary can't be established. Property
+        // renaming must NOT run against an empty/partial boundary — doing so
+        // would rename an externally-observable property (a miscompile of
+        // valid input). Both names must survive untouched, exactly as if no
+        // externs had been supplied.
+        let out = compile_prop(
+            crate::config::CompilationLevel::Advanced,
+            Some(BAD_EXTERNS),
+            "adv-bad",
+        );
+        assert!(
+            out.contains(".innerHTML"),
+            "must not rename when externs failed to load; got: {out}"
+        );
+        assert!(
+            out.contains(".secretField"),
+            "must not rename when externs failed to load; got: {out}"
         );
     }
 

--- a/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
@@ -2,7 +2,7 @@
 
 closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.
 
-Version: 0.149.0
+Version: 0.150.0
 
 ## Flags
 


### PR DESCRIPTION
## Summary

`--compilation_level ADVANCED` now also shortens program-private **object property** names via the `rename-properties` pass, appended after `rename-globals`. Properties live in their own namespace, so this is a second independent ADVANCED-over-SIMPLE size win on top of top-level renaming.

```js
read(obj.innerHTML); read(obj.secretField); read(obj.secretField);
//  externs file declares innerHTML external
//  ADVANCED + --externs => read(obj.innerHTML);read(obj.a);read(obj.a);
```

## Safe-by-default — gated on `--externs`

Property renaming runs **only when the user supplies at least one `--externs` file**. The pass's bundled built-in list covers ECMAScript but **not the DOM/host**, so renaming properties unconditionally would rewrite `el.innerHTML` / `node.onload` and break browser code. Supplying `--externs` is the user opting into the externs contract *and* declaring the external property boundary.

- SIMPLE output is byte-for-byte unchanged.
- ADVANCED **without** `--externs` is unchanged from 0.149.0 (only `rename-globals` runs).

## Fail-closed, NOT degrade-safe (closes a HIGH security-review finding)

`rename-properties` is sound *only because* the user declared the boundary — so the boundary's **contents** are what make it safe, not the mere presence of the flag. If any externs source fails to resolve/read/parse/bridge, `collect_externs_property_names` returns `None` and property renaming is **disabled** for the run, rather than running against an empty/partial boundary (which would rename an externally-observable property — a miscompile, in exactly the case the user opted into safety). Given the Phase-1 parser's limits, a real externs file failing to bridge is plausible, so this matters.

The decision is computed once and a single bool drives **both** the pipeline and the correlation-vector `passes` trace, so the trace can never claim `rename-properties` ran when it didn't (closes a LOW finding).

## New reusable primitive

`closure-pass-rename-properties` 0.2.0 exposes `collect_property_names(program) -> HashSet<String>` — the property analogue of collecting an externs file's top-level variable names. It reuses the pass's existing whole-program `classify_item` walk (one traversal to keep in sync) and over-collects (dotted + quoted + object keys) because any property an externs file names is external.

## Tests

- `closure-pass-rename-properties`: +9 unit tests, +1 doctest (each occurrence shape, dynamic-key exclusion, function-body recursion, end-to-end protect-a-property round-trip).
- `closurec`: +4 integration tests pinning the policy — SIMPLE / no-externs ADVANCED leave properties alone; ADVANCED + externs renames a private property, keeps the externs-declared one, and shrinks output; **ADVANCED + an unparseable externs file fails closed and renames nothing**.
- Full closurec suite (680) + rename-properties (22 + doctest) green.

## Security review

Two rounds. Round 1 found a HIGH (empty/partial boundary could drive renaming) and a LOW (trace coupling). Both fixed with the fail-closed `Option` return + single-decision coupling. Round 2: **PASSED — no vulnerabilities found**, move/double-run/panic verified clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)