### PR TITLE
feat(closure-pass-rename-properties): bundle DOM/host property boundary (CLOC13.L)

### DIFF
--- a/code/packages/rust/closure-pass-rename-properties/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-rename-properties/CHANGELOG.md
@@ -2,6 +2,36 @@
 
 All notable changes to the `coding-adventures-closure-pass-rename-properties` crate will be documented in this file.
 
+## [0.3.0] - 2026-06-18
+
+### Added (CLOC13.L — bundled DOM/host property boundary, `DOM_PROPERTIES`)
+
+A curated `DOM_PROPERTIES` list (~300 names) is now **always protected**
+alongside the ECMAScript `BUILTIN_PROPERTIES`, closing the documented gap
+that "the built-in list covers ECMAScript but NOT the DOM/host." Common
+browser-surface property names — `innerHTML`, `textContent`, `classList`,
+`addEventListener`, `onclick`/`onload`/… inline handlers, `querySelector`,
+`getAttribute`, `style`, `dataset`, Window/Document/Location/History/
+Storage/Navigator members, XHR/fetch/Response fields, drag-and-drop, and
+event-object properties — are kept out of the box, so the pass no longer
+renames a DOM property the author never listed in `--externs` (which would
+silently break browser code).
+
+- **Always-on, additive, sound.** The protected baseline is now
+  `BUILTIN_PROPERTIES ∪ DOM_PROPERTIES`; `--externs` still unions on top.
+  Over-protecting a program-private property that happens to share a DOM
+  name merely forgoes a rename — never a miscompile (the same posture the
+  ECMAScript list already had). The bundle is a safety net, not a
+  replacement: vendor-/library-specific external properties still need a
+  `--externs` file, which remains the authoritative boundary.
+- Grouped by host area (EventTarget/events, inline `on*` handlers,
+  Node/Element, classList, form/input, attributes, CSSOM, Document, Window,
+  Location/History/Storage/Navigator, XHR/fetch/Response, drag-and-drop) for
+  auditability.
+- 2 new tests: a DOM property (`innerHTML`/`addEventListener`/`onclick`) is
+  kept with no `--externs` while a program-private property is still
+  renamed; a lone unlisted DOM property is kept (the safety net).
+
 ## [0.2.0] - 2026-06-18
 
 ### Added (CLOC13.K — `collect_property_names`, the externs property boundary)

--- a/code/packages/rust/closure-pass-rename-properties/Cargo.toml
+++ b/code/packages/rust/closure-pass-rename-properties/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-rename-properties"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 description = "Aggressive property renaming pass for the Closure Compiler clone (ADVANCED-only). Consistently shortens program-private object property names that are never quoted/computed and not in the built-in or externs do-not-rename boundary."
 

--- a/code/packages/rust/closure-pass-rename-properties/README.md
+++ b/code/packages/rust/closure-pass-rename-properties/README.md
@@ -30,8 +30,10 @@ A property name is renamed only when it:
 1. appears dotted / unquoted;
 2. is NOT quoted via a computed string member (`obj["x"]` — the bridge
    preserves this; the author quoted it to mean "external/dynamic");
-3. is not a `BUILTIN_PROPERTIES` (a bundled ECMAScript default-externs
-   substitute — `length`, `prototype`, `toString`, `push`, …);
+3. is not a bundled built-in — neither `BUILTIN_PROPERTIES` (the ECMAScript
+   surface — `length`, `prototype`, `toString`, `push`, …) nor
+   `DOM_PROPERTIES` (the browser/host surface — `innerHTML`, `classList`,
+   `addEventListener`, `onclick`, `querySelector`, …);
 4. is not in the externs do-not-rename set; and
 5. is longer than one character.
 
@@ -40,11 +42,19 @@ only avoids other property names + the built-ins + the externs set
 (property names are their own namespace; a property may become `a` even
 when a variable `a` exists).
 
+The bundled boundary now covers both the **ECMAScript** surface
+(`BUILTIN_PROPERTIES`) and the common **DOM/host** surface (`DOM_PROPERTIES`
+— ~300 names: events, inline `on*` handlers, Node/Element, form/input,
+attributes, CSSOM, Document, Window, Location/History/Storage/Navigator,
+XHR/fetch/Response, drag-and-drop). So `el.innerHTML` and `node.onclick`
+are kept out of the box with no `--externs` file.
+
 ### Honest limitations
 
-- The built-in list covers ECMAScript but **not the DOM/host** — host
-  property names (`innerHTML`, `addEventListener`, …) must be supplied via
-  `--externs` or they will be renamed.
+- The bundled DOM list is **curated, not exhaustive** — host surfaces evolve
+  and vendor-/library-specific external properties exist. A `--externs` file
+  remains the authoritative boundary; the bundle is the safety net for the
+  common browser surface.
 - The parser bridge currently collapses a quoted object key `{ "x": 1 }`
   to an identifier key, so object-key quoting is **not** a usable
   do-not-rename signal (only computed-member quoting `obj["x"]` is) —
@@ -76,13 +86,14 @@ top-level variable/function names (the value-namespace boundary that gates
 
 ## Status
 
-This crate is the **algorithmic core** plus the externs-boundary collector.
-It is wired into closurec's ADVANCED level under a **safe-by-default policy**:
-property renaming runs only when the user passes at least one `--externs`
-file (opting into the externs contract and supplying the host/DOM property
-boundary). Without `--externs`, ADVANCED leaves property names untouched —
-the built-in list omits the DOM, so renaming by default would miscompile
-browser code.
+This crate is the **algorithmic core**, the externs-boundary collector, and
+the bundled ECMAScript + DOM/host protected lists. It is wired into
+closurec's ADVANCED level under a **safe-by-default policy**: property
+renaming runs only when the user passes at least one `--externs` file
+(opting into the externs contract). The bundled `DOM_PROPERTIES` list keeps
+the common browser surface safe even when the externs file doesn't list it,
+but `--externs` remains the authoritative boundary for vendor-/library-
+specific external properties, so the opt-in gate stays.
 
 ## Dependency whitelist
 

--- a/code/packages/rust/closure-pass-rename-properties/src/lib.rs
+++ b/code/packages/rust/closure-pass-rename-properties/src/lib.rs
@@ -43,14 +43,16 @@
 //!     `{ "x": 1 }` is currently collapsed to an identifier key by the
 //!     parser bridge, so it is NOT a usable quoting signal — protect such
 //!     names via `--externs` instead.
-//!   * **It is not a [`BUILTIN_PROPERTIES`]** (`length`, `prototype`,
-//!     `toString`, `push`, …). closurec ships no browser/ECMAScript
-//!     externs file, so this list is the default-externs substitute that
-//!     keeps `arr.length` from becoming `arr.a`. It covers the common
-//!     ECMAScript surface but **not the DOM/host** — host property names
-//!     (`innerHTML`, `addEventListener`, …) must be supplied via
-//!     `--externs`. The [`RenamePropertiesPass::new`] do-not-rename set
-//!     extends the built-ins with the externs files' property names.
+//!   * **It is not a bundled built-in** — neither [`BUILTIN_PROPERTIES`]
+//!     (the ECMAScript surface: `length`, `prototype`, `toString`, `push`,
+//!     …) nor [`DOM_PROPERTIES`] (the browser/host surface: `innerHTML`,
+//!     `addEventListener`, `onclick`, `classList`, …). closurec ships no
+//!     externs file, so these two lists are the default-externs substitute
+//!     that keeps `arr.length` from becoming `arr.a` and `el.innerHTML`
+//!     from becoming `el.a`. They cover the common ECMAScript + DOM surface
+//!     out of the box; vendor-/library-specific external properties still
+//!     need a `--externs` file, which the [`RenamePropertiesPass::new`]
+//!     do-not-rename set unions on top of the bundled lists.
 //!   * **It is longer than one character** (already minimal otherwise).
 //!
 //! **Dynamic computed access (`obj[expr]`) is the author's
@@ -90,12 +92,14 @@ const DEPS: &[&str] = &[];
 /// Reserved words we must never emit as a fresh short name.
 const RESERVED: &[&str] = &["do", "if", "in", "of", "as", "is", "or"];
 
-/// Built-in property names that must never be renamed — the
-/// default-externs substitute (closurec ships no browser/ECMAScript
-/// externs file). Renaming any of these would break code that uses the
-/// standard library (`arr.length`, `x.toString()`, `p.then(...)`, …). The
-/// user's `--externs` files extend this boundary; this list covers the
-/// common ECMAScript surface so the pass is safe by default.
+/// Built-in **ECMAScript** property names that must never be renamed — the
+/// default-externs substitute (closurec ships no externs file). Renaming
+/// any of these would break code that uses the standard library
+/// (`arr.length`, `x.toString()`, `p.then(...)`, …). The browser/host
+/// surface lives in the companion [`DOM_PROPERTIES`] list; both are always
+/// protected, and the user's `--externs` files extend the boundary further.
+/// Together they cover the common ECMAScript + DOM surface so the pass is
+/// safe by default.
 ///
 /// It is intentionally conservative (over-protecting a user-defined
 /// property that happens to share a built-in's name merely forgoes a
@@ -246,6 +250,482 @@ const BUILTIN_PROPERTIES: &[&str] = &[
     "assert",
 ];
 
+/// Curated **DOM / host** property names that must never be renamed — the
+/// part of the external boundary the bundled [`BUILTIN_PROPERTIES`]
+/// (ECMAScript only) used to omit. closurec ships no browser externs file,
+/// so renaming `el.innerHTML`, `node.addEventListener`, or `btn.onclick`
+/// would silently break browser code that the host (the DOM, the event
+/// system, CSSOM, the fetch/XHR stack, storage, …) reads or writes by name.
+///
+/// Like [`BUILTIN_PROPERTIES`] this list is **always protected** in addition
+/// to the externs do-not-rename set, and is deliberately conservative:
+/// over-protecting a user-defined property that happens to share a DOM name
+/// merely forgoes a rename — never a miscompile. It cannot be exhaustive
+/// (host surfaces evolve and vendor-/library-specific properties exist), so
+/// a `--externs` file remains the authoritative boundary; this bundle is the
+/// safety net that covers the common browser surface out of the box.
+///
+/// Grouped by host area for auditability. Names already covered by
+/// [`BUILTIN_PROPERTIES`] (e.g. `length`, `value`, `name`) are not repeated;
+/// the two lists are unioned where the protected set is built.
+const DOM_PROPERTIES: &[&str] = &[
+    // ---- EventTarget / events ----
+    "addEventListener",
+    "removeEventListener",
+    "dispatchEvent",
+    "preventDefault",
+    "stopPropagation",
+    "stopImmediatePropagation",
+    "target",
+    "currentTarget",
+    "relatedTarget",
+    "srcElement",
+    "type",
+    "bubbles",
+    "cancelable",
+    "composed",
+    "defaultPrevented",
+    "eventPhase",
+    "isTrusted",
+    "timeStamp",
+    "detail",
+    "key",
+    "code",
+    "keyCode",
+    "charCode",
+    "which",
+    "altKey",
+    "ctrlKey",
+    "shiftKey",
+    "metaKey",
+    "button",
+    "buttons",
+    "clientX",
+    "clientY",
+    "screenX",
+    "screenY",
+    "pageX",
+    "pageY",
+    "offsetX",
+    "offsetY",
+    "movementX",
+    "movementY",
+    "deltaX",
+    "deltaY",
+    "deltaZ",
+    "deltaMode",
+    "touches",
+    "targetTouches",
+    "changedTouches",
+    "pointerId",
+    "pointerType",
+    "pressure",
+    // ---- common inline event handlers (on*) ----
+    "onclick",
+    "ondblclick",
+    "onmousedown",
+    "onmouseup",
+    "onmousemove",
+    "onmouseover",
+    "onmouseout",
+    "onmouseenter",
+    "onmouseleave",
+    "oncontextmenu",
+    "onwheel",
+    "onkeydown",
+    "onkeyup",
+    "onkeypress",
+    "onfocus",
+    "onblur",
+    "onfocusin",
+    "onfocusout",
+    "onchange",
+    "oninput",
+    "oninvalid",
+    "onsubmit",
+    "onreset",
+    "onselect",
+    "onload",
+    "onunload",
+    "onbeforeunload",
+    "onerror",
+    "onresize",
+    "onscroll",
+    "onhashchange",
+    "onpopstate",
+    "onpageshow",
+    "onpagehide",
+    "onreadystatechange",
+    "ondomcontentloaded",
+    "onanimationstart",
+    "onanimationend",
+    "onanimationiteration",
+    "ontransitionend",
+    "ondragstart",
+    "ondrag",
+    "ondragend",
+    "ondragenter",
+    "ondragover",
+    "ondragleave",
+    "ondrop",
+    "ontouchstart",
+    "ontouchmove",
+    "ontouchend",
+    "ontouchcancel",
+    "onpointerdown",
+    "onpointerup",
+    "onpointermove",
+    "onpointerenter",
+    "onpointerleave",
+    "onmessage",
+    "onopen",
+    "onclose",
+    // ---- Node / Element ----
+    "nodeType",
+    "nodeName",
+    "nodeValue",
+    "textContent",
+    "innerHTML",
+    "outerHTML",
+    "innerText",
+    "outerText",
+    "tagName",
+    "localName",
+    "namespaceURI",
+    "id",
+    "className",
+    "classList",
+    "attributes",
+    "dataset",
+    "style",
+    "title",
+    "lang",
+    "dir",
+    "hidden",
+    "tabIndex",
+    "contentEditable",
+    "isContentEditable",
+    "draggable",
+    "spellcheck",
+    "accessKey",
+    "parentNode",
+    "parentElement",
+    "childNodes",
+    "children",
+    "firstChild",
+    "lastChild",
+    "firstElementChild",
+    "lastElementChild",
+    "nextSibling",
+    "previousSibling",
+    "nextElementSibling",
+    "previousElementSibling",
+    "childElementCount",
+    "ownerDocument",
+    "shadowRoot",
+    "assignedSlot",
+    "appendChild",
+    "removeChild",
+    "replaceChild",
+    "insertBefore",
+    "cloneNode",
+    "contains",
+    "compareDocumentPosition",
+    "normalize",
+    "append",
+    "prepend",
+    "before",
+    "after",
+    "replaceWith",
+    "remove",
+    "insertAdjacentHTML",
+    "insertAdjacentText",
+    "insertAdjacentElement",
+    "getAttribute",
+    "setAttribute",
+    "removeAttribute",
+    "hasAttribute",
+    "hasAttributes",
+    "getAttributeNS",
+    "setAttributeNS",
+    "removeAttributeNS",
+    "toggleAttribute",
+    "getAttributeNames",
+    "querySelector",
+    "querySelectorAll",
+    "getElementById",
+    "getElementsByClassName",
+    "getElementsByTagName",
+    "getElementsByName",
+    "closest",
+    "matches",
+    "getBoundingClientRect",
+    "getClientRects",
+    "scrollIntoView",
+    "scrollTo",
+    "scrollBy",
+    "focus",
+    "blur",
+    "click",
+    "clientWidth",
+    "clientHeight",
+    "clientLeft",
+    "clientTop",
+    "offsetWidth",
+    "offsetHeight",
+    "offsetLeft",
+    "offsetTop",
+    "offsetParent",
+    "scrollWidth",
+    "scrollHeight",
+    "scrollLeft",
+    "scrollTop",
+    // ---- classList / DOMTokenList ----
+    "toggle",
+    "replace",
+    "item",
+    // ---- form / input ----
+    "checked",
+    "selected",
+    "disabled",
+    "readOnly",
+    "required",
+    "multiple",
+    "placeholder",
+    "defaultValue",
+    "defaultChecked",
+    "selectedIndex",
+    "selectedOptions",
+    "options",
+    "elements",
+    "form",
+    "files",
+    "validity",
+    "validationMessage",
+    "willValidate",
+    "checkValidity",
+    "reportValidity",
+    "setCustomValidity",
+    "setSelectionRange",
+    "select",
+    "submit",
+    "reset",
+    "labels",
+    "htmlFor",
+    "action",
+    "method",
+    "enctype",
+    "autocomplete",
+    "autofocus",
+    "maxLength",
+    "minLength",
+    "min",
+    "max",
+    "step",
+    "pattern",
+    // ---- attributes commonly read by name ----
+    "href",
+    "src",
+    "srcset",
+    "alt",
+    "rel",
+    "media",
+    "content",
+    "width",
+    "height",
+    "rows",
+    "cols",
+    "colSpan",
+    "rowSpan",
+    "cellPadding",
+    "cellSpacing",
+    "crossOrigin",
+    "referrerPolicy",
+    "loading",
+    "decoding",
+    "currentSrc",
+    "naturalWidth",
+    "naturalHeight",
+    "complete",
+    // ---- CSSStyleDeclaration ----
+    "cssText",
+    "getPropertyValue",
+    "setProperty",
+    "removeProperty",
+    "getPropertyPriority",
+    // ---- Document ----
+    "documentElement",
+    "head",
+    "body",
+    "title",
+    "URL",
+    "documentURI",
+    "domain",
+    "referrer",
+    "cookie",
+    "readyState",
+    "characterSet",
+    "contentType",
+    "createElement",
+    "createElementNS",
+    "createTextNode",
+    "createComment",
+    "createDocumentFragment",
+    "createEvent",
+    "createRange",
+    "createTreeWalker",
+    "importNode",
+    "adoptNode",
+    "write",
+    "writeln",
+    "execCommand",
+    "elementFromPoint",
+    "getSelection",
+    "hasFocus",
+    "activeElement",
+    "defaultView",
+    "scrollingElement",
+    "visibilityState",
+    "hidden",
+    // ---- Window ----
+    "document",
+    "location",
+    "navigator",
+    "history",
+    "screen",
+    "frames",
+    "parent",
+    "top",
+    "self",
+    "window",
+    "opener",
+    "frameElement",
+    "innerWidth",
+    "innerHeight",
+    "outerWidth",
+    "outerHeight",
+    "scrollX",
+    "scrollY",
+    "pageXOffset",
+    "pageYOffset",
+    "devicePixelRatio",
+    "localStorage",
+    "sessionStorage",
+    "performance",
+    "crypto",
+    "console",
+    "alert",
+    "confirm",
+    "prompt",
+    "open",
+    "close",
+    "print",
+    "focus",
+    "blur",
+    "scroll",
+    "moveTo",
+    "moveBy",
+    "resizeTo",
+    "resizeBy",
+    "requestAnimationFrame",
+    "cancelAnimationFrame",
+    "requestIdleCallback",
+    "cancelIdleCallback",
+    "setTimeout",
+    "clearTimeout",
+    "setInterval",
+    "clearInterval",
+    "getComputedStyle",
+    "matchMedia",
+    "postMessage",
+    "fetch",
+    "btoa",
+    "atob",
+    "structuredClone",
+    "queueMicrotask",
+    "getSelection",
+    // ---- Location ----
+    "protocol",
+    "host",
+    "hostname",
+    "port",
+    "pathname",
+    "search",
+    "hash",
+    "origin",
+    "username",
+    "password",
+    "assign",
+    "reload",
+    "toString",
+    // ---- History ----
+    "pushState",
+    "replaceState",
+    "go",
+    "back",
+    "forward",
+    "scrollRestoration",
+    // ---- Storage ----
+    "getItem",
+    "setItem",
+    "removeItem",
+    "clear",
+    "key",
+    // ---- Navigator ----
+    "userAgent",
+    "platform",
+    "language",
+    "languages",
+    "onLine",
+    "cookieEnabled",
+    "hardwareConcurrency",
+    "deviceMemory",
+    "maxTouchPoints",
+    "sendBeacon",
+    "vibrate",
+    "clipboard",
+    "geolocation",
+    "mediaDevices",
+    "serviceWorker",
+    "permissions",
+    // ---- XHR / fetch / Response ----
+    "responseType",
+    "responseText",
+    "responseXML",
+    "response",
+    "status",
+    "statusText",
+    "withCredentials",
+    "timeout",
+    "readyState",
+    "send",
+    "abort",
+    "getResponseHeader",
+    "getAllResponseHeaders",
+    "setRequestHeader",
+    "overrideMimeType",
+    "ok",
+    "redirected",
+    "headers",
+    "url",
+    "body",
+    "bodyUsed",
+    "arrayBuffer",
+    "blob",
+    "formData",
+    "clone",
+    "text",
+    "json",
+    // ---- CustomEvent / dataTransfer ----
+    "dataTransfer",
+    "effectAllowed",
+    "dropEffect",
+    "setData",
+    "getData",
+    "clearData",
+    "setDragImage",
+];
+
 /// Aggressive property renaming pass. Holds the **do-not-rename set** of
 /// property names supplied at construction (typically the property names
 /// collected from `--externs` files); the built-in property list is
@@ -346,16 +826,22 @@ fn rename_properties(
     }
 
     // 2. Decide the renames. A property is renameable when it appears
-    //    dotted, never quoted, is not a built-in, is not in the externs
-    //    do-not-rename set, and is longer than one character.
-    let builtins: HashSet<&str> = BUILTIN_PROPERTIES.iter().copied().collect();
+    //    dotted, never quoted, is not a built-in (ECMAScript OR DOM/host),
+    //    is not in the externs do-not-rename set, and is longer than one
+    //    character. The protected baseline is the union of the bundled
+    //    ECMAScript and DOM/host property lists.
+    let builtins: HashSet<&str> = BUILTIN_PROPERTIES
+        .iter()
+        .chain(DOM_PROPERTIES.iter())
+        .copied()
+        .collect();
     // Fresh names avoid every property name in the program plus the
     // built-ins and externs set (property namespace only — variable names
     // are irrelevant).
     let mut avoid: HashSet<String> = HashSet::new();
     avoid.extend(cls.dotted_seen.iter().cloned());
     avoid.extend(cls.quoted.iter().cloned());
-    avoid.extend(BUILTIN_PROPERTIES.iter().map(|s| s.to_string()));
+    avoid.extend(builtins.iter().map(|s| s.to_string()));
     avoid.extend(do_not_rename.iter().cloned());
 
     let mut map: HashMap<String, String> = HashMap::new();
@@ -963,6 +1449,30 @@ mod tests {
         assert_eq!(
             rename_with("read(obj.apiField); read(obj.helperField);", &["apiField"]),
             "read(obj.apiField);read(obj.a);"
+        );
+    }
+
+    #[test]
+    fn does_not_rename_dom_properties() {
+        // The bundled DOM/host list protects `innerHTML`, `addEventListener`,
+        // and `onclick` out of the box — no `--externs` needed — while the
+        // program-private `secretField` is still renamed. Without the DOM
+        // bundle these would be renamed and break browser code.
+        assert_eq!(
+            rename(
+                "el.addEventListener(t, h); read(el.innerHTML); read(el.onclick); read(el.secretField); read(el.secretField);"
+            ),
+            "el.addEventListener(t,h);read(el.innerHTML);read(el.onclick);read(el.a);read(el.a);"
+        );
+    }
+
+    #[test]
+    fn dom_property_protected_without_externs() {
+        // A lone DOM property the author never lists in externs is still
+        // kept — the safety net the DOM bundle provides.
+        assert_eq!(
+            rename("read(node.textContent); read(node.textContent);"),
+            "read(node.textContent);read(node.textContent);"
         );
     }
 


### PR DESCRIPTION
## Summary

Adds a curated, always-protected **`DOM_PROPERTIES`** list (~300 names) alongside the ECMAScript `BUILTIN_PROPERTIES`, closing the documented gap that *"the built-in list covers ECMAScript but NOT the DOM/host."*

The common browser surface is now kept out of the box with **no `--externs` file**: events + inline `on*` handlers (`onclick`/`onload`/…), Node/Element (`innerHTML`, `textContent`, `classList`, `querySelector`, `getAttribute`, `style`, `dataset`, …), form/input, attributes, CSSOM, Document, Window, Location/History/Storage/Navigator, XHR/fetch/Response, and drag-and-drop. Previously the pass would rename a DOM property the author never listed in externs and silently break browser code.

## Always-on, additive, sound

- Protected baseline is now `BUILTIN_PROPERTIES ∪ DOM_PROPERTIES`; `--externs` still unions on top.
- Over-protecting a program-private property that happens to share a DOM name merely forgoes a rename — **never a miscompile** (the same posture the ECMAScript list already had).
- The bundle is a **safety net, not a replacement**: vendor-/library-specific external properties still need a `--externs` file, which remains the authoritative boundary — so closurec's opt-in `--externs` gate stays.

## Verification

- **CLI proof**: `closurec --compilation_level ADVANCED --externs <file>` on `read(obj.innerHTML); read(obj.privateThing); read(obj.privateThing);` (externs declares only an unrelated name) → `read(obj.innerHTML);read(obj.a);read(obj.a);` — `innerHTML` kept *despite not being in externs*, `privateThing` renamed.
- closurec full suite (**680**) unchanged — DOM protection flows through the path dependency transparently (no closurec code change).
- rename-properties: +2 unit tests (DOM property kept without externs while a private property is renamed; a lone unlisted DOM property kept). **24 unit + doctest green.**

## Security review

Passed — the reviewer confirmed the set-union is **monotonic in the safe direction** (adding names to the protected set can only ever *prevent* renames, never enable a wrong one), no panic/DoS, and intra-list duplicates / overlap with `BUILTIN_PROPERTIES` harmlessly dedup via the `HashSet`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)