### PR TITLE
Add smart home mesh readiness handoff tools

### DIFF
--- a/code/packages/rust/chief-of-staff-smart-home-tools/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/CHANGELOG.md
@@ -125,6 +125,9 @@ All notable changes to this package will be documented in this file.
 - Added D18D handlers for D23 mesh substrate action queues and action-readiness
   rollups: `smart_home.list_integration_mesh_substrate_actions` and
   `smart_home.get_integration_mesh_action_readiness_summary`.
+- Added D18D handlers for D23 mesh readiness handoff packages:
+  `smart_home.list_integration_mesh_readiness_handoffs` and
+  `smart_home.get_integration_mesh_readiness_handoff_summary`.
 - Added D18D handlers for D23A activation remediation work orders:
   `smart_home.list_integration_activation_remediation` and
   `smart_home.get_integration_activation_remediation_summary`.

--- a/code/packages/rust/chief-of-staff-smart-home-tools/README.md
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/README.md
@@ -59,6 +59,7 @@ Chief of Staff job/session/agent
      low-level protocol release blockers
   -> mesh readiness package, stage-release, and action-readiness reads for
      release go/no-go
+  -> mesh readiness handoff list and summary reads for release coordination
   -> activation-dossier list and summary reads for bundled decision evidence
   -> activation-dashboard list and summary reads for priority-wave status cards
   -> activation-timeline list and summary reads for ordered wave milestones
@@ -148,6 +149,8 @@ Chief of Staff job/session/agent
 - `smart_home.get_integration_mesh_readiness_package_summary`
 - `smart_home.get_integration_mesh_stage_release_summary`
 - `smart_home.get_integration_mesh_action_readiness_summary`
+- `smart_home.list_integration_mesh_readiness_handoffs`
+- `smart_home.get_integration_mesh_readiness_handoff_summary`
 - `smart_home.list_integration_activation_dossiers`
 - `smart_home.get_integration_activation_dossier_summary`
 - `smart_home.list_integration_activation_readouts`

--- a/code/packages/rust/chief-of-staff-smart-home-tools/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/src/lib.rs
@@ -64,7 +64,8 @@ use smart_home_integration_catalog::{
     ecosystem_platform_coverage, ecosystem_platforms_requiring_primitive, ecosystem_survey_sources,
     entries_requiring_primitive, find_entry, first_party_catalog, mesh_action_readiness_summary,
     mesh_protocol_primitive_readiness_rows, mesh_protocol_substrate_actions,
-    mesh_protocol_substrate_stage_rows, mesh_readiness_package_summary, mesh_stage_release_summary,
+    mesh_protocol_substrate_stage_rows, mesh_readiness_handoff_packages,
+    mesh_readiness_handoff_summary, mesh_readiness_package_summary, mesh_stage_release_summary,
     policy_surface_inventory_at_or_before_priority, primitive_backlog_at_or_before_priority,
     primitive_backlog_with_ecosystem_coverage, primitive_family_descriptors, query_integrations,
     readiness_gap_inventory_from_reports, readiness_report_for_plan,
@@ -143,7 +144,9 @@ use smart_home_integration_catalog::{
     IntegrationMeshProtocolPrimitiveReadinessRow, IntegrationMeshProtocolPrimitiveReadinessSummary,
     IntegrationMeshProtocolSubstrateAction, IntegrationMeshProtocolSubstrateActionSummary,
     IntegrationMeshProtocolSubstrateStage, IntegrationMeshProtocolSubstrateStageRow,
-    IntegrationMeshProtocolSubstrateStageSummary, IntegrationMeshReadinessPackageSummary,
+    IntegrationMeshProtocolSubstrateStageSummary, IntegrationMeshReadinessHandoffKind,
+    IntegrationMeshReadinessHandoffPackage, IntegrationMeshReadinessHandoffStatus,
+    IntegrationMeshReadinessHandoffSummary, IntegrationMeshReadinessPackageSummary,
     IntegrationMeshStageReleaseSummary, IntegrationPolicySurface,
     IntegrationPolicySurfaceInventoryItem, IntegrationPolicySurfaceSummary,
     IntegrationReadinessCapabilityGap, IntegrationReadinessDependencyGap,
@@ -332,6 +335,10 @@ pub const SMART_HOME_GET_INTEGRATION_MESH_STAGE_RELEASE_SUMMARY_TOOL_ID: &str =
     "smart_home.get_integration_mesh_stage_release_summary";
 pub const SMART_HOME_GET_INTEGRATION_MESH_ACTION_READINESS_SUMMARY_TOOL_ID: &str =
     "smart_home.get_integration_mesh_action_readiness_summary";
+pub const SMART_HOME_LIST_INTEGRATION_MESH_READINESS_HANDOFFS_TOOL_ID: &str =
+    "smart_home.list_integration_mesh_readiness_handoffs";
+pub const SMART_HOME_GET_INTEGRATION_MESH_READINESS_HANDOFF_SUMMARY_TOOL_ID: &str =
+    "smart_home.get_integration_mesh_readiness_handoff_summary";
 pub const SMART_HOME_LIST_INTEGRATION_ACTIVATION_DOSSIERS_TOOL_ID: &str =
     "smart_home.list_integration_activation_dossiers";
 pub const SMART_HOME_GET_INTEGRATION_ACTIVATION_DOSSIER_SUMMARY_TOOL_ID: &str =
@@ -832,6 +839,14 @@ impl SmartHomeToolBridge {
                 SMART_HOME_GET_INTEGRATION_MESH_ACTION_READINESS_SUMMARY_TOOL_ID => {
                     let query = integration_readiness_query(&arguments)?;
                     Ok(get_integration_mesh_action_readiness_summary_output_handler_output(query))
+                }
+                SMART_HOME_LIST_INTEGRATION_MESH_READINESS_HANDOFFS_TOOL_ID => {
+                    let query = integration_readiness_query(&arguments)?;
+                    Ok(list_integration_mesh_readiness_handoffs_output_handler_output(query))
+                }
+                SMART_HOME_GET_INTEGRATION_MESH_READINESS_HANDOFF_SUMMARY_TOOL_ID => {
+                    let query = integration_readiness_query(&arguments)?;
+                    Ok(get_integration_mesh_readiness_handoff_summary_output_handler_output(query))
                 }
                 SMART_HOME_LIST_INTEGRATION_ACTIVATION_DOSSIERS_TOOL_ID => {
                     let query = integration_activation_dossier_query(&arguments)?;
@@ -2640,6 +2655,34 @@ pub fn smart_home_tool_definitions() -> Vec<ToolDefinition> {
             SMART_HOME_GET_INTEGRATION_MESH_ACTION_READINESS_SUMMARY_TOOL_ID,
             "Get smart-home integration mesh action readiness summary",
             "Return D23 mesh action readiness counts combining queued substrate actions with stage release blockers.",
+            integration_readiness_query_schema(true),
+            object_schema(
+                vec![SchemaProperty::new("summary", JsonSchema::Any)],
+                vec!["summary"],
+                false,
+            ),
+        ),
+        read_definition(
+            SMART_HOME_LIST_INTEGRATION_MESH_READINESS_HANDOFFS_TOOL_ID,
+            "List smart-home integration mesh readiness handoffs",
+            "List D23 mesh readiness handoff packages that Chief can use to coordinate substrate-action blockers, evidence remediation, and release-ready state.",
+            integration_readiness_query_schema(true),
+            object_schema(
+                vec![
+                    SchemaProperty::new("mesh_readiness_handoffs", JsonSchema::Array {
+                        items: Box::new(JsonSchema::Any),
+                    }),
+                    SchemaProperty::new("summary", JsonSchema::Any),
+                    SchemaProperty::new("count", JsonSchema::Integer),
+                ],
+                vec!["mesh_readiness_handoffs", "summary", "count"],
+                false,
+            ),
+        ),
+        read_definition(
+            SMART_HOME_GET_INTEGRATION_MESH_READINESS_HANDOFF_SUMMARY_TOOL_ID,
+            "Get smart-home integration mesh readiness handoff summary",
+            "Return compact D23 mesh readiness handoff counts for Chief release coordination without crossing into D18D policy.",
             integration_readiness_query_schema(true),
             object_schema(
                 vec![SchemaProperty::new("summary", JsonSchema::Any)],
@@ -16842,6 +16885,35 @@ fn integration_mesh_action_readiness_summary_for_query(
     )
 }
 
+fn integration_mesh_readiness_handoffs_for_query(
+    query: &IntegrationReadinessQuery,
+) -> Vec<IntegrationMeshReadinessHandoffPackage> {
+    let mut packages = mesh_readiness_handoff_packages(
+        &query.available_primitives,
+        &query.allowed_capabilities,
+        &query.enabled_integrations,
+    );
+
+    if let Some(activation_ready) = query.activation_ready {
+        packages.retain(|package| package.ready_for_handoff() == activation_ready);
+    }
+    if let Some(limit) = query.limit {
+        packages.truncate(limit);
+    }
+
+    packages
+}
+
+fn integration_mesh_readiness_handoff_summary_for_query(
+    query: &IntegrationReadinessQuery,
+) -> IntegrationMeshReadinessHandoffSummary {
+    mesh_readiness_handoff_summary(
+        &query.available_primitives,
+        &query.allowed_capabilities,
+        &query.enabled_integrations,
+    )
+}
+
 fn integration_activation_dependency_graph_for_query(
     query: &IntegrationActivationDependencyQuery,
 ) -> (IntegrationActivationDependencyGraph, usize) {
@@ -21078,6 +21150,80 @@ fn get_integration_mesh_action_readiness_summary_output_handler_output(
                 integer(summary.remediation_item_count as i64),
             ),
             ("release_ready", JsonValue::Bool(summary.release_ready)),
+        ]),
+    )
+}
+
+fn list_integration_mesh_readiness_handoffs_output_handler_output(
+    query: IntegrationReadinessQuery,
+) -> ToolHandlerOutput {
+    let packages = integration_mesh_readiness_handoffs_for_query(&query);
+    let summary = IntegrationMeshReadinessHandoffSummary::from_parts(
+        integration_mesh_action_readiness_summary_for_query(&query),
+        packages.iter(),
+    );
+    let count = packages.len();
+
+    ToolHandlerOutput::new(object([
+        (
+            "mesh_readiness_handoffs",
+            JsonValue::Array(
+                packages
+                    .iter()
+                    .map(mesh_readiness_handoff_package_json)
+                    .collect(),
+            ),
+        ),
+        ("summary", mesh_readiness_handoff_summary_json(&summary)),
+        ("count", integer(count as i64)),
+    ]))
+    .with_event(
+        ToolEventKind::Progress,
+        object([
+            (
+                "operation",
+                string("list_integration_mesh_readiness_handoffs"),
+            ),
+            ("packages", integer(count as i64)),
+            ("action_packages", integer(summary.action_packages as i64)),
+            (
+                "remediation_packages",
+                integer(summary.remediation_packages as i64),
+            ),
+            ("release_ready", JsonValue::Bool(summary.release_ready)),
+        ]),
+    )
+}
+
+fn get_integration_mesh_readiness_handoff_summary_output_handler_output(
+    query: IntegrationReadinessQuery,
+) -> ToolHandlerOutput {
+    let summary = integration_mesh_readiness_handoff_summary_for_query(&query);
+
+    ToolHandlerOutput::new(object([(
+        "summary",
+        mesh_readiness_handoff_summary_json(&summary),
+    )]))
+    .with_event(
+        ToolEventKind::Progress,
+        object([
+            (
+                "operation",
+                string("get_integration_mesh_readiness_handoff_summary"),
+            ),
+            ("total_packages", integer(summary.total_packages as i64)),
+            (
+                "queued_substrate_actions",
+                integer(summary.queued_substrate_actions as i64),
+            ),
+            (
+                "remediation_item_count",
+                integer(summary.remediation_item_count as i64),
+            ),
+            (
+                "ready_for_handoff",
+                JsonValue::Bool(summary.ready_for_handoff()),
+            ),
         ]),
     )
 }
@@ -42332,6 +42478,264 @@ fn mesh_stage_release_summary_json(summary: &IntegrationMeshStageReleaseSummary)
     ])
 }
 
+fn mesh_readiness_handoff_kind_json(kind: IntegrationMeshReadinessHandoffKind) -> JsonValue {
+    string(kind.as_str())
+}
+
+fn mesh_readiness_handoff_status_json(status: IntegrationMeshReadinessHandoffStatus) -> JsonValue {
+    string(status.as_str())
+}
+
+fn mesh_readiness_handoff_package_json(
+    package: &IntegrationMeshReadinessHandoffPackage,
+) -> JsonValue {
+    object([
+        ("sequence", integer(package.sequence as i64)),
+        (
+            "package_kind",
+            mesh_readiness_handoff_kind_json(package.package_kind),
+        ),
+        (
+            "handoff_status",
+            mesh_readiness_handoff_status_json(package.handoff_status),
+        ),
+        (
+            "action_sequence",
+            package
+                .action_sequence
+                .map(|sequence| integer(sequence as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "protocol",
+            package
+                .protocol
+                .as_ref()
+                .map(protocol_family_label)
+                .map(string)
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "stage",
+            package
+                .stage
+                .map(|stage| string(stage.as_str()))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "primitive",
+            package
+                .primitive
+                .map(|primitive| string(primitive.as_str()))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "remediation_kind",
+            package
+                .remediation_kind
+                .map(|kind| string(kind.as_str()))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "queued_substrate_actions",
+            integer(package.queued_substrate_actions as i64),
+        ),
+        (
+            "remediation_item_count",
+            integer(package.remediation_item_count as i64),
+        ),
+        (
+            "stage_blocker_count",
+            integer(package.stage_blocker_count as i64),
+        ),
+        (
+            "primitive_blocker_count",
+            integer(package.primitive_blocker_count as i64),
+        ),
+        (
+            "substrate_actions_ready",
+            JsonValue::Bool(package.substrate_actions_ready),
+        ),
+        ("release_ready", JsonValue::Bool(package.release_ready)),
+        (
+            "ready_for_handoff",
+            JsonValue::Bool(package.ready_for_handoff()),
+        ),
+        ("blocked", JsonValue::Bool(package.blocked())),
+        (
+            "review_required",
+            JsonValue::Bool(package.review_required()),
+        ),
+        (
+            "operator_required",
+            JsonValue::Bool(package.operator_required()),
+        ),
+        (
+            "requires_attention",
+            JsonValue::Bool(package.requires_attention()),
+        ),
+    ])
+}
+
+fn mesh_readiness_handoff_summary_json(
+    summary: &IntegrationMeshReadinessHandoffSummary,
+) -> JsonValue {
+    object([
+        (
+            "action_readiness_summary",
+            mesh_action_readiness_summary_json(&summary.action_readiness_summary),
+        ),
+        ("total_packages", integer(summary.total_packages as i64)),
+        ("action_packages", integer(summary.action_packages as i64)),
+        (
+            "remediation_packages",
+            integer(summary.remediation_packages as i64),
+        ),
+        ("ready_packages", integer(summary.ready_packages as i64)),
+        (
+            "review_required_packages",
+            integer(summary.review_required_packages as i64),
+        ),
+        ("blocked_packages", integer(summary.blocked_packages as i64)),
+        (
+            "operator_required_packages",
+            integer(summary.operator_required_packages as i64),
+        ),
+        (
+            "packages_requiring_attention",
+            integer(summary.packages_requiring_attention as i64),
+        ),
+        (
+            "queued_substrate_actions",
+            integer(summary.queued_substrate_actions as i64),
+        ),
+        (
+            "queued_stage_count",
+            integer(summary.queued_stage_count as i64),
+        ),
+        (
+            "queued_primitive_count",
+            integer(summary.queued_primitive_count as i64),
+        ),
+        (
+            "remediation_item_count",
+            integer(summary.remediation_item_count as i64),
+        ),
+        (
+            "stage_blocker_count",
+            integer(summary.stage_blocker_count as i64),
+        ),
+        (
+            "primitive_blocker_count",
+            integer(summary.primitive_blocker_count as i64),
+        ),
+        (
+            "next_handoff_status",
+            summary
+                .next_handoff_status
+                .map(mesh_readiness_handoff_status_json)
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "next_package_kind",
+            summary
+                .next_package_kind
+                .map(mesh_readiness_handoff_kind_json)
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "next_package_sequence",
+            summary
+                .next_package_sequence
+                .map(|sequence| integer(sequence as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_action_sequence",
+            summary
+                .first_action_sequence
+                .map(|sequence| integer(sequence as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_remediation_sequence",
+            summary
+                .first_remediation_sequence
+                .map(|sequence| integer(sequence as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_ready_sequence",
+            summary
+                .first_ready_sequence
+                .map(|sequence| integer(sequence as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_blocked_sequence",
+            summary
+                .first_blocked_sequence
+                .map(|sequence| integer(sequence as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_review_sequence",
+            summary
+                .first_review_sequence
+                .map(|sequence| integer(sequence as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_action_protocol",
+            summary
+                .first_action_protocol
+                .as_ref()
+                .map(protocol_family_label)
+                .map(string)
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_action_stage",
+            summary
+                .first_action_stage
+                .map(|stage| string(stage.as_str()))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_action_primitive",
+            summary
+                .first_action_primitive
+                .map(|primitive| string(primitive.as_str()))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "next_remediation_kind",
+            summary
+                .next_remediation_kind
+                .map(|kind| string(kind.as_str()))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "substrate_actions_ready",
+            JsonValue::Bool(summary.substrate_actions_ready),
+        ),
+        ("release_ready", JsonValue::Bool(summary.release_ready)),
+        (
+            "ready_for_handoff",
+            JsonValue::Bool(summary.ready_for_handoff()),
+        ),
+        ("has_blockers", JsonValue::Bool(summary.has_blockers())),
+        (
+            "has_review_work",
+            JsonValue::Bool(summary.has_review_work()),
+        ),
+        (
+            "requires_attention",
+            JsonValue::Bool(summary.requires_attention()),
+        ),
+    ])
+}
+
 fn readiness_report_json(report: &IntegrationReadinessReport) -> JsonValue {
     object([
         (
@@ -49169,7 +49573,7 @@ mod tests {
         let definitions = smart_home_tool_definitions();
         let export = ToolCatalogExport::from_definitions(definitions.iter());
 
-        assert_eq!(definitions.len(), 193);
+        assert_eq!(definitions.len(), 195);
         assert!(
             export.ok(),
             "tool export validation failed: {:?}",
@@ -49367,6 +49771,12 @@ mod tests {
         assert!(export
             .tool_ids()
             .contains(&SMART_HOME_GET_INTEGRATION_MESH_ACTION_READINESS_SUMMARY_TOOL_ID));
+        assert!(export
+            .tool_ids()
+            .contains(&SMART_HOME_LIST_INTEGRATION_MESH_READINESS_HANDOFFS_TOOL_ID));
+        assert!(export
+            .tool_ids()
+            .contains(&SMART_HOME_GET_INTEGRATION_MESH_READINESS_HANDOFF_SUMMARY_TOOL_ID));
         assert!(export.tool_ids().contains(&SMART_HOME_DISCOVER_TOOL_ID));
         assert!(export
             .tool_ids()
@@ -49725,7 +50135,7 @@ mod tests {
         ));
         assert_eq!(
             export.summary.required_capability_count("smart_home:read"),
-            185
+            187
         );
         assert_eq!(
             export
@@ -49794,6 +50204,22 @@ mod tests {
         .is_some());
         assert!(smart_home_tool_definition(
             SMART_HOME_GET_INTEGRATION_MESH_STAGE_RELEASE_SUMMARY_TOOL_ID
+        )
+        .is_some());
+        assert!(smart_home_tool_definition(
+            SMART_HOME_LIST_INTEGRATION_MESH_SUBSTRATE_ACTIONS_TOOL_ID
+        )
+        .is_some());
+        assert!(smart_home_tool_definition(
+            SMART_HOME_GET_INTEGRATION_MESH_ACTION_READINESS_SUMMARY_TOOL_ID
+        )
+        .is_some());
+        assert!(smart_home_tool_definition(
+            SMART_HOME_LIST_INTEGRATION_MESH_READINESS_HANDOFFS_TOOL_ID
+        )
+        .is_some());
+        assert!(smart_home_tool_definition(
+            SMART_HOME_GET_INTEGRATION_MESH_READINESS_HANDOFF_SUMMARY_TOOL_ID
         )
         .is_some());
         assert!(smart_home_tool_definition(
@@ -50409,11 +50835,11 @@ mod tests {
         let tool_catalog_summary = field(tool_catalog_summary_output, "summary").unwrap();
         assert_eq!(
             field(tool_catalog_summary, "total_tools"),
-            Some(&integer(193))
+            Some(&integer(195))
         );
         assert_eq!(
             field(tool_catalog_summary, "read_tools"),
-            Some(&integer(185))
+            Some(&integer(187))
         );
         assert_eq!(
             field(tool_catalog_summary, "risky_tool_count"),
@@ -52709,18 +53135,11 @@ mod tests {
             Some(&JsonValue::Bool(true))
         );
         let mesh_substrate_action = array_item(
-            field(
-                list_mesh_substrate_actions_output,
-                "mesh_substrate_actions",
-            )
-            .unwrap(),
+            field(list_mesh_substrate_actions_output, "mesh_substrate_actions").unwrap(),
             0,
         )
         .unwrap();
-        assert_eq!(
-            field(mesh_substrate_action, "sequence"),
-            Some(&integer(1))
-        );
+        assert_eq!(field(mesh_substrate_action, "sequence"), Some(&integer(1)));
         assert_eq!(
             field(mesh_substrate_action, "protocol"),
             Some(&string("zwave"))
@@ -52997,6 +53416,134 @@ mod tests {
         assert_eq!(
             field(mesh_action_summary, "network_security_actions"),
             Some(&integer(3))
+        );
+
+        let list_mesh_readiness_handoffs_request = request(
+            "call-list-integration-mesh-readiness-handoffs",
+            SMART_HOME_LIST_INTEGRATION_MESH_READINESS_HANDOFFS_TOOL_ID,
+            object([
+                (
+                    "available_primitives",
+                    JsonValue::Array(vec![
+                        string("usb"),
+                        string("serial_controller"),
+                        string("radio_802154"),
+                        string("supervision"),
+                    ]),
+                ),
+                (
+                    "allowed_capability_ids",
+                    JsonValue::Array(vec![string("smart_home.read")]),
+                ),
+                ("activation_ready", JsonValue::Bool(false)),
+            ]),
+            5_913,
+        );
+        let list_mesh_readiness_handoffs_trace =
+            tool_runtime.invoke_with_events(&list_mesh_readiness_handoffs_request);
+        assert!(list_mesh_readiness_handoffs_trace.result.ok);
+        assert_eq!(
+            list_mesh_readiness_handoffs_trace
+                .summary()
+                .progress_event_count,
+            1
+        );
+        let list_mesh_readiness_handoffs_output = list_mesh_readiness_handoffs_trace
+            .result
+            .output
+            .as_ref()
+            .unwrap();
+        assert_eq!(
+            field(list_mesh_readiness_handoffs_output, "count"),
+            Some(&integer(6))
+        );
+        let mesh_readiness_handoff_summary =
+            field(list_mesh_readiness_handoffs_output, "summary").unwrap();
+        assert_eq!(
+            field(mesh_readiness_handoff_summary, "action_packages"),
+            Some(&integer(5))
+        );
+        assert_eq!(
+            field(mesh_readiness_handoff_summary, "remediation_packages"),
+            Some(&integer(1))
+        );
+        assert_eq!(
+            field(mesh_readiness_handoff_summary, "ready_for_handoff"),
+            Some(&JsonValue::Bool(false))
+        );
+        let mesh_readiness_handoff = array_item(
+            field(
+                list_mesh_readiness_handoffs_output,
+                "mesh_readiness_handoffs",
+            )
+            .unwrap(),
+            0,
+        )
+        .unwrap();
+        assert_eq!(
+            field(mesh_readiness_handoff, "package_kind"),
+            Some(&string("substrate_action"))
+        );
+        assert_eq!(
+            field(mesh_readiness_handoff, "handoff_status"),
+            Some(&string("blocked"))
+        );
+        assert_eq!(
+            field(mesh_readiness_handoff, "stage"),
+            Some(&string("radio"))
+        );
+        assert_eq!(
+            field(mesh_readiness_handoff, "primitive"),
+            Some(&string("zwave_serial_api"))
+        );
+
+        let mesh_readiness_handoff_summary_request = request(
+            "call-integration-mesh-readiness-handoff-summary",
+            SMART_HOME_GET_INTEGRATION_MESH_READINESS_HANDOFF_SUMMARY_TOOL_ID,
+            object([
+                (
+                    "available_primitives",
+                    JsonValue::Array(vec![
+                        string("usb"),
+                        string("serial_controller"),
+                        string("radio_802154"),
+                        string("supervision"),
+                    ]),
+                ),
+                (
+                    "allowed_capability_ids",
+                    JsonValue::Array(vec![string("smart_home.read")]),
+                ),
+            ]),
+            5_914,
+        );
+        let mesh_readiness_handoff_summary_trace =
+            tool_runtime.invoke_with_events(&mesh_readiness_handoff_summary_request);
+        assert!(mesh_readiness_handoff_summary_trace.result.ok);
+        assert_eq!(
+            mesh_readiness_handoff_summary_trace
+                .summary()
+                .progress_event_count,
+            1
+        );
+        let mesh_readiness_handoff_summary_output = mesh_readiness_handoff_summary_trace
+            .result
+            .output
+            .as_ref()
+            .unwrap();
+        let mesh_readiness_handoff_rollup =
+            field(mesh_readiness_handoff_summary_output, "summary").unwrap();
+        assert_eq!(
+            field(mesh_readiness_handoff_rollup, "queued_substrate_actions"),
+            Some(&integer(5))
+        );
+        assert_eq!(
+            field(mesh_readiness_handoff_rollup, "next_package_kind"),
+            Some(&string("substrate_action"))
+        );
+        assert_eq!(
+            field(mesh_readiness_handoff_rollup, "has_blockers"),
+            Some(&JsonValue::Bool(true))
         );
 
         let list_activation_dossiers_request = request(

--- a/code/packages/rust/smart-home-core/CHANGELOG.md
+++ b/code/packages/rust/smart-home-core/CHANGELOG.md
@@ -81,6 +81,9 @@ All notable changes to this package will be documented in this file.
 - `smart_home.list_integration_mesh_substrate_actions` and
   `smart_home.get_integration_mesh_action_readiness_summary` descriptors for
   read-only D23 mesh substrate action and action-readiness planning.
+- `smart_home.list_integration_mesh_readiness_handoffs` and
+  `smart_home.get_integration_mesh_readiness_handoff_summary` descriptors for
+  read-only D23 mesh readiness handoff planning.
 - `smart_home.list_integration_activation_dossiers` and
   `smart_home.get_integration_activation_dossier_summary` tool descriptors
   for read-only bundled activation decision and evidence planning.

--- a/code/packages/rust/smart-home-core/src/lib.rs
+++ b/code/packages/rust/smart-home-core/src/lib.rs
@@ -1599,6 +1599,8 @@ pub enum SmartHomeTool {
     GetIntegrationMeshReadinessPackageSummary,
     GetIntegrationMeshStageReleaseSummary,
     GetIntegrationMeshActionReadinessSummary,
+    ListIntegrationMeshReadinessHandoffs,
+    GetIntegrationMeshReadinessHandoffSummary,
     Discover,
     PairBridge,
     CompletePairing,
@@ -2092,6 +2094,12 @@ impl SmartHomeTool {
             }
             Self::GetIntegrationMeshActionReadinessSummary => {
                 read_tool("smart_home.get_integration_mesh_action_readiness_summary")
+            }
+            Self::ListIntegrationMeshReadinessHandoffs => {
+                read_tool("smart_home.list_integration_mesh_readiness_handoffs")
+            }
+            Self::GetIntegrationMeshReadinessHandoffSummary => {
+                read_tool("smart_home.get_integration_mesh_readiness_handoff_summary")
             }
             Self::Discover => ToolDescriptor {
                 tool_id: "smart_home.discover",
@@ -2852,6 +2860,8 @@ pub fn smart_home_tool_catalog() -> Vec<ToolDescriptor> {
         SmartHomeTool::GetIntegrationMeshReadinessPackageSummary,
         SmartHomeTool::GetIntegrationMeshStageReleaseSummary,
         SmartHomeTool::GetIntegrationMeshActionReadinessSummary,
+        SmartHomeTool::ListIntegrationMeshReadinessHandoffs,
+        SmartHomeTool::GetIntegrationMeshReadinessHandoffSummary,
         SmartHomeTool::Discover,
         SmartHomeTool::PairBridge,
         SmartHomeTool::CompletePairing,
@@ -3686,7 +3696,7 @@ mod tests {
             .find(|tool| tool.tool_id == "smart_home.command")
             .unwrap();
 
-        assert_eq!(catalog.len(), 193);
+        assert_eq!(catalog.len(), 195);
         assert!(catalog
             .iter()
             .any(|tool| tool.tool_id == "smart_home.list_integrations"
@@ -3931,6 +3941,8 @@ mod tests {
             "smart_home.get_integration_mesh_readiness_package_summary",
             "smart_home.get_integration_mesh_stage_release_summary",
             "smart_home.get_integration_mesh_action_readiness_summary",
+            "smart_home.list_integration_mesh_readiness_handoffs",
+            "smart_home.get_integration_mesh_readiness_handoff_summary",
         ] {
             assert!(catalog.iter().any(|tool| tool.tool_id == tool_id
                 && tool.side_effects == ToolSideEffects::Read
@@ -4451,15 +4463,15 @@ mod tests {
         let summary = smart_home_tool_catalog_summary();
         let pair_bridge = SmartHomeTool::PairBridge.descriptor();
 
-        assert_eq!(summary.total_tools, 193);
-        assert_eq!(summary.read_tools, 185);
+        assert_eq!(summary.total_tools, 195);
+        assert_eq!(summary.read_tools, 187);
         assert_eq!(summary.write_tools, 2);
         assert_eq!(summary.external_tools, 6);
-        assert_eq!(summary.read_only_tier_tools, 185);
+        assert_eq!(summary.read_only_tier_tools, 187);
         assert_eq!(summary.low_risk_tier_tools, 6);
         assert_eq!(summary.high_risk_tier_tools, 0);
         assert_eq!(summary.human_approval_tier_tools, 2);
-        assert_eq!(summary.total_required_capabilities, 193);
+        assert_eq!(summary.total_required_capabilities, 195);
         assert_eq!(summary.risky_tool_count(), 8);
         assert_eq!(summary.approval_gated_tool_count(), 2);
         assert!(pair_bridge.requires_human_approval());

--- a/code/packages/rust/smart-home-integration-catalog/CHANGELOG.md
+++ b/code/packages/rust/smart-home-integration-catalog/CHANGELOG.md
@@ -70,6 +70,9 @@ All notable changes to this package will be documented in this file.
 - `IntegrationMeshActionReadinessSummary` and helpers for combining mesh
   release readiness with the substrate action queue and next concrete low-level
   action.
+- `IntegrationMeshReadinessHandoffPackage`, summary helpers, and D23 mesh
+  readiness handoff projections for release coordination across substrate
+  actions, evidence remediation, and release-ready state.
 - Primitive backlog planning helpers for ranking the shared primitive families
   needed by priority-bounded rollout waves.
 - Integration activation planning helpers for resolving virtual aliases,

--- a/code/packages/rust/smart-home-integration-catalog/src/lib.rs
+++ b/code/packages/rust/smart-home-integration-catalog/src/lib.rs
@@ -900,6 +900,337 @@ impl IntegrationMeshActionReadinessSummary {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum IntegrationMeshReadinessHandoffKind {
+    SubstrateAction,
+    EvidenceRemediation,
+    ReleaseReady,
+}
+
+impl IntegrationMeshReadinessHandoffKind {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::SubstrateAction => "substrate_action",
+            Self::EvidenceRemediation => "evidence_remediation",
+            Self::ReleaseReady => "release_ready",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum IntegrationMeshReadinessHandoffStatus {
+    Ready,
+    NeedsReview,
+    Blocked,
+}
+
+impl IntegrationMeshReadinessHandoffStatus {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Ready => "ready",
+            Self::NeedsReview => "needs_review",
+            Self::Blocked => "blocked",
+        }
+    }
+
+    pub fn requires_attention(self) -> bool {
+        matches!(self, Self::NeedsReview | Self::Blocked)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IntegrationMeshReadinessHandoffPackage {
+    pub sequence: usize,
+    pub package_kind: IntegrationMeshReadinessHandoffKind,
+    pub handoff_status: IntegrationMeshReadinessHandoffStatus,
+    pub action_sequence: Option<usize>,
+    pub protocol: Option<ProtocolFamily>,
+    pub stage: Option<IntegrationMeshProtocolSubstrateStage>,
+    pub primitive: Option<PrimitiveFamily>,
+    pub remediation_kind: Option<IntegrationActivationEvidenceRemediationKind>,
+    pub queued_substrate_actions: usize,
+    pub remediation_item_count: usize,
+    pub stage_blocker_count: usize,
+    pub primitive_blocker_count: usize,
+    pub substrate_actions_ready: bool,
+    pub release_ready: bool,
+    pub ready_for_handoff: bool,
+    pub blocked: bool,
+    pub review_required: bool,
+    pub operator_required: bool,
+    pub requires_attention: bool,
+}
+
+impl IntegrationMeshReadinessHandoffPackage {
+    fn from_substrate_action(
+        action: &IntegrationMeshProtocolSubstrateAction,
+        summary: &IntegrationMeshActionReadinessSummary,
+    ) -> Self {
+        Self {
+            sequence: 0,
+            package_kind: IntegrationMeshReadinessHandoffKind::SubstrateAction,
+            handoff_status: IntegrationMeshReadinessHandoffStatus::Blocked,
+            action_sequence: Some(action.sequence),
+            protocol: Some(action.protocol.clone()),
+            stage: Some(action.stage),
+            primitive: Some(action.primitive),
+            remediation_kind: None,
+            queued_substrate_actions: summary.queued_substrate_actions,
+            remediation_item_count: summary.remediation_item_count,
+            stage_blocker_count: summary.release_summary.stage_blocker_count,
+            primitive_blocker_count: summary.release_summary.primitive_blocker_count,
+            substrate_actions_ready: false,
+            release_ready: false,
+            ready_for_handoff: false,
+            blocked: true,
+            review_required: false,
+            operator_required: true,
+            requires_attention: true,
+        }
+    }
+
+    fn evidence_remediation(summary: &IntegrationMeshActionReadinessSummary) -> Option<Self> {
+        summary.has_remediations().then(|| {
+            let review_required = summary
+                .release_summary
+                .package_summary
+                .requires_human_review;
+            let handoff_status = if review_required {
+                IntegrationMeshReadinessHandoffStatus::NeedsReview
+            } else {
+                IntegrationMeshReadinessHandoffStatus::Blocked
+            };
+
+            Self {
+                sequence: 0,
+                package_kind: IntegrationMeshReadinessHandoffKind::EvidenceRemediation,
+                handoff_status,
+                action_sequence: None,
+                protocol: None,
+                stage: None,
+                primitive: None,
+                remediation_kind: summary.release_summary.next_remediation_kind,
+                queued_substrate_actions: summary.queued_substrate_actions,
+                remediation_item_count: summary.remediation_item_count,
+                stage_blocker_count: summary.release_summary.stage_blocker_count,
+                primitive_blocker_count: summary.release_summary.primitive_blocker_count,
+                substrate_actions_ready: summary.substrate_actions_ready,
+                release_ready: false,
+                ready_for_handoff: false,
+                blocked: handoff_status == IntegrationMeshReadinessHandoffStatus::Blocked,
+                review_required,
+                operator_required: true,
+                requires_attention: true,
+            }
+        })
+    }
+
+    fn release_ready(summary: &IntegrationMeshActionReadinessSummary) -> Option<Self> {
+        summary.release_ready.then(|| Self {
+            sequence: 0,
+            package_kind: IntegrationMeshReadinessHandoffKind::ReleaseReady,
+            handoff_status: IntegrationMeshReadinessHandoffStatus::Ready,
+            action_sequence: None,
+            protocol: None,
+            stage: None,
+            primitive: None,
+            remediation_kind: None,
+            queued_substrate_actions: 0,
+            remediation_item_count: 0,
+            stage_blocker_count: 0,
+            primitive_blocker_count: 0,
+            substrate_actions_ready: true,
+            release_ready: true,
+            ready_for_handoff: true,
+            blocked: false,
+            review_required: false,
+            operator_required: false,
+            requires_attention: false,
+        })
+    }
+
+    pub fn ready_for_handoff(&self) -> bool {
+        self.ready_for_handoff
+    }
+
+    pub fn blocked(&self) -> bool {
+        self.blocked
+    }
+
+    pub fn review_required(&self) -> bool {
+        self.review_required
+    }
+
+    pub fn operator_required(&self) -> bool {
+        self.operator_required
+    }
+
+    pub fn requires_attention(&self) -> bool {
+        self.requires_attention || self.handoff_status.requires_attention()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IntegrationMeshReadinessHandoffSummary {
+    pub action_readiness_summary: IntegrationMeshActionReadinessSummary,
+    pub total_packages: usize,
+    pub action_packages: usize,
+    pub remediation_packages: usize,
+    pub ready_packages: usize,
+    pub review_required_packages: usize,
+    pub blocked_packages: usize,
+    pub operator_required_packages: usize,
+    pub packages_requiring_attention: usize,
+    pub queued_substrate_actions: usize,
+    pub queued_stage_count: usize,
+    pub queued_primitive_count: usize,
+    pub remediation_item_count: usize,
+    pub stage_blocker_count: usize,
+    pub primitive_blocker_count: usize,
+    pub next_handoff_status: Option<IntegrationMeshReadinessHandoffStatus>,
+    pub next_package_kind: Option<IntegrationMeshReadinessHandoffKind>,
+    pub next_package_sequence: Option<usize>,
+    pub first_action_sequence: Option<usize>,
+    pub first_remediation_sequence: Option<usize>,
+    pub first_ready_sequence: Option<usize>,
+    pub first_blocked_sequence: Option<usize>,
+    pub first_review_sequence: Option<usize>,
+    pub first_action_protocol: Option<ProtocolFamily>,
+    pub first_action_stage: Option<IntegrationMeshProtocolSubstrateStage>,
+    pub first_action_primitive: Option<PrimitiveFamily>,
+    pub next_remediation_kind: Option<IntegrationActivationEvidenceRemediationKind>,
+    pub substrate_actions_ready: bool,
+    pub release_ready: bool,
+}
+
+impl IntegrationMeshReadinessHandoffSummary {
+    pub fn from_parts<'a>(
+        action_readiness_summary: IntegrationMeshActionReadinessSummary,
+        packages: impl IntoIterator<Item = &'a IntegrationMeshReadinessHandoffPackage>,
+    ) -> Self {
+        let packages = packages.into_iter().collect::<Vec<_>>();
+        let mut summary = Self {
+            queued_substrate_actions: action_readiness_summary.queued_substrate_actions,
+            queued_stage_count: action_readiness_summary.queued_stage_count,
+            queued_primitive_count: action_readiness_summary.queued_primitive_count,
+            remediation_item_count: action_readiness_summary.remediation_item_count,
+            stage_blocker_count: action_readiness_summary.release_summary.stage_blocker_count,
+            primitive_blocker_count: action_readiness_summary
+                .release_summary
+                .primitive_blocker_count,
+            next_remediation_kind: action_readiness_summary
+                .release_summary
+                .next_remediation_kind,
+            substrate_actions_ready: action_readiness_summary.substrate_actions_ready,
+            release_ready: action_readiness_summary.release_ready,
+            action_readiness_summary,
+            total_packages: 0,
+            action_packages: 0,
+            remediation_packages: 0,
+            ready_packages: 0,
+            review_required_packages: 0,
+            blocked_packages: 0,
+            operator_required_packages: 0,
+            packages_requiring_attention: 0,
+            next_handoff_status: None,
+            next_package_kind: None,
+            next_package_sequence: None,
+            first_action_sequence: None,
+            first_remediation_sequence: None,
+            first_ready_sequence: None,
+            first_blocked_sequence: None,
+            first_review_sequence: None,
+            first_action_protocol: None,
+            first_action_stage: None,
+            first_action_primitive: None,
+        };
+
+        for package in packages {
+            summary.total_packages += 1;
+
+            if summary.next_handoff_status.is_none() {
+                summary.next_handoff_status = Some(package.handoff_status);
+                summary.next_package_kind = Some(package.package_kind);
+                summary.next_package_sequence = Some(package.sequence);
+            }
+
+            match package.package_kind {
+                IntegrationMeshReadinessHandoffKind::SubstrateAction => {
+                    summary.action_packages += 1;
+                    summary.first_action_sequence =
+                        summary.first_action_sequence.or(Some(package.sequence));
+                    summary.first_action_protocol = summary
+                        .first_action_protocol
+                        .clone()
+                        .or_else(|| package.protocol.clone());
+                    summary.first_action_stage = summary.first_action_stage.or(package.stage);
+                    summary.first_action_primitive =
+                        summary.first_action_primitive.or(package.primitive);
+                }
+                IntegrationMeshReadinessHandoffKind::EvidenceRemediation => {
+                    summary.remediation_packages += 1;
+                    summary.first_remediation_sequence = summary
+                        .first_remediation_sequence
+                        .or(Some(package.sequence));
+                }
+                IntegrationMeshReadinessHandoffKind::ReleaseReady => {
+                    summary.ready_packages += 1;
+                    summary.first_ready_sequence =
+                        summary.first_ready_sequence.or(Some(package.sequence));
+                }
+            }
+
+            if package.ready_for_handoff() {
+                if package.package_kind != IntegrationMeshReadinessHandoffKind::ReleaseReady {
+                    summary.ready_packages += 1;
+                }
+                summary.first_ready_sequence =
+                    summary.first_ready_sequence.or(Some(package.sequence));
+            }
+            if package.blocked() {
+                summary.blocked_packages += 1;
+                summary.first_blocked_sequence =
+                    summary.first_blocked_sequence.or(Some(package.sequence));
+            }
+            if package.review_required() {
+                summary.review_required_packages += 1;
+                summary.first_review_sequence =
+                    summary.first_review_sequence.or(Some(package.sequence));
+            }
+            if package.operator_required() {
+                summary.operator_required_packages += 1;
+            }
+            if package.requires_attention() {
+                summary.packages_requiring_attention += 1;
+            }
+        }
+
+        summary
+    }
+
+    pub fn ready_for_handoff(&self) -> bool {
+        self.release_ready
+            && self.ready_packages > 0
+            && !self.has_blockers()
+            && !self.has_review_work()
+    }
+
+    pub fn has_blockers(&self) -> bool {
+        self.blocked_packages > 0
+            || self.queued_substrate_actions > 0
+            || self.stage_blocker_count > 0
+            || self.primitive_blocker_count > 0
+    }
+
+    pub fn has_review_work(&self) -> bool {
+        self.review_required_packages > 0
+    }
+
+    pub fn requires_attention(&self) -> bool {
+        self.packages_requiring_attention > 0 || self.has_blockers() || self.has_review_work()
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct IntegrationCatalogEntry {
     pub integration_id: IntegrationId,
@@ -20903,6 +21234,94 @@ pub fn mesh_action_readiness_summary(
     )
 }
 
+fn mesh_readiness_handoff_packages_from_summary(
+    summary: &IntegrationMeshActionReadinessSummary,
+    actions: &[IntegrationMeshProtocolSubstrateAction],
+) -> Vec<IntegrationMeshReadinessHandoffPackage> {
+    let mut packages = actions
+        .iter()
+        .map(|action| {
+            IntegrationMeshReadinessHandoffPackage::from_substrate_action(action, summary)
+        })
+        .collect::<Vec<_>>();
+
+    if let Some(package) = IntegrationMeshReadinessHandoffPackage::evidence_remediation(summary) {
+        packages.push(package);
+    }
+    if let Some(package) = IntegrationMeshReadinessHandoffPackage::release_ready(summary) {
+        packages.push(package);
+    }
+
+    for (index, package) in packages.iter_mut().enumerate() {
+        package.sequence = index + 1;
+    }
+
+    packages
+}
+
+pub fn mesh_readiness_handoff_packages_for_catalog(
+    catalog: &[IntegrationCatalogEntry],
+    available_primitives: &[PrimitiveFamily],
+    allowed_capabilities: &[CapabilityId],
+    enabled_integrations: &[IntegrationId],
+) -> Vec<IntegrationMeshReadinessHandoffPackage> {
+    let summary = mesh_action_readiness_summary_for_catalog(
+        catalog,
+        available_primitives,
+        allowed_capabilities,
+        enabled_integrations,
+    );
+    let actions = mesh_protocol_substrate_actions(available_primitives);
+
+    mesh_readiness_handoff_packages_from_summary(&summary, &actions)
+}
+
+pub fn mesh_readiness_handoff_packages(
+    available_primitives: &[PrimitiveFamily],
+    allowed_capabilities: &[CapabilityId],
+    enabled_integrations: &[IntegrationId],
+) -> Vec<IntegrationMeshReadinessHandoffPackage> {
+    let catalog = first_party_catalog();
+    mesh_readiness_handoff_packages_for_catalog(
+        &catalog,
+        available_primitives,
+        allowed_capabilities,
+        enabled_integrations,
+    )
+}
+
+pub fn mesh_readiness_handoff_summary_for_catalog(
+    catalog: &[IntegrationCatalogEntry],
+    available_primitives: &[PrimitiveFamily],
+    allowed_capabilities: &[CapabilityId],
+    enabled_integrations: &[IntegrationId],
+) -> IntegrationMeshReadinessHandoffSummary {
+    let summary = mesh_action_readiness_summary_for_catalog(
+        catalog,
+        available_primitives,
+        allowed_capabilities,
+        enabled_integrations,
+    );
+    let actions = mesh_protocol_substrate_actions(available_primitives);
+    let packages = mesh_readiness_handoff_packages_from_summary(&summary, &actions);
+
+    IntegrationMeshReadinessHandoffSummary::from_parts(summary, packages.iter())
+}
+
+pub fn mesh_readiness_handoff_summary(
+    available_primitives: &[PrimitiveFamily],
+    allowed_capabilities: &[CapabilityId],
+    enabled_integrations: &[IntegrationId],
+) -> IntegrationMeshReadinessHandoffSummary {
+    let catalog = first_party_catalog();
+    mesh_readiness_handoff_summary_for_catalog(
+        &catalog,
+        available_primitives,
+        allowed_capabilities,
+        enabled_integrations,
+    )
+}
+
 fn mesh_protocol_catalog_entries(
     catalog: &[IntegrationCatalogEntry],
 ) -> Vec<IntegrationCatalogEntry> {
@@ -26433,6 +26852,8 @@ mod tests {
         let allowed_capabilities = vec![
             CapabilityId::trusted("smart_home.read"),
             CapabilityId::trusted("smart_home.command.light"),
+            CapabilityId::trusted("smart_home.command.lock"),
+            CapabilityId::trusted("smart_home.manage_network"),
             CapabilityId::trusted("smart_home.pair"),
         ];
         let summary =
@@ -26506,6 +26927,8 @@ mod tests {
         let allowed_capabilities = vec![
             CapabilityId::trusted("smart_home.read"),
             CapabilityId::trusted("smart_home.command.light"),
+            CapabilityId::trusted("smart_home.command.lock"),
+            CapabilityId::trusted("smart_home.manage_network"),
             CapabilityId::trusted("smart_home.pair"),
         ];
         let summary = hue_activation_evidence_briefing_summary(
@@ -27322,6 +27745,135 @@ mod tests {
         assert!(!summary.has_substrate_actions());
         assert_eq!(summary.action_summary.total_actions, 0);
         assert_eq!(summary.release_summary.stage_blocker_count, 0);
+    }
+
+    #[test]
+    fn mesh_readiness_handoff_packages_bundle_actions_and_remediation() {
+        let available_primitives = vec![
+            PrimitiveFamily::Usb,
+            PrimitiveFamily::SerialController,
+            PrimitiveFamily::Radio802154,
+            PrimitiveFamily::Supervision,
+        ];
+        let allowed_capabilities = vec![CapabilityId::trusted("smart_home.read")];
+        let packages =
+            mesh_readiness_handoff_packages(&available_primitives, &allowed_capabilities, &[]);
+        let summary =
+            mesh_readiness_handoff_summary(&available_primitives, &allowed_capabilities, &[]);
+
+        assert_eq!(packages.len(), 6);
+        assert_eq!(summary.total_packages, 6);
+        assert_eq!(summary.action_packages, 5);
+        assert_eq!(summary.remediation_packages, 1);
+        assert_eq!(summary.ready_packages, 0);
+        assert_eq!(summary.blocked_packages, 5);
+        assert_eq!(summary.review_required_packages, 1);
+        assert_eq!(summary.queued_substrate_actions, 5);
+        assert_eq!(summary.queued_stage_count, 3);
+        assert_eq!(summary.queued_primitive_count, 3);
+        assert!(summary.remediation_item_count > 0);
+        assert_eq!(summary.stage_blocker_count, 5);
+        assert_eq!(summary.primitive_blocker_count, 3);
+        assert_eq!(
+            summary.next_handoff_status,
+            Some(IntegrationMeshReadinessHandoffStatus::Blocked)
+        );
+        assert_eq!(
+            summary.next_package_kind,
+            Some(IntegrationMeshReadinessHandoffKind::SubstrateAction)
+        );
+        assert_eq!(summary.first_action_sequence, Some(1));
+        assert_eq!(summary.first_remediation_sequence, Some(6));
+        assert_eq!(summary.first_blocked_sequence, Some(1));
+        assert_eq!(summary.first_action_protocol, Some(ProtocolFamily::ZWave));
+        assert_eq!(
+            summary.first_action_stage,
+            Some(IntegrationMeshProtocolSubstrateStage::Radio)
+        );
+        assert_eq!(
+            summary.first_action_primitive,
+            Some(PrimitiveFamily::ZWaveSerialApi)
+        );
+        assert!(!summary.substrate_actions_ready);
+        assert!(!summary.release_ready);
+        assert!(!summary.ready_for_handoff());
+        assert!(summary.has_blockers());
+        assert!(summary.requires_attention());
+
+        let first = &packages[0];
+        assert_eq!(first.sequence, 1);
+        assert_eq!(
+            first.package_kind,
+            IntegrationMeshReadinessHandoffKind::SubstrateAction
+        );
+        assert_eq!(
+            first.handoff_status,
+            IntegrationMeshReadinessHandoffStatus::Blocked
+        );
+        assert_eq!(first.action_sequence, Some(1));
+        assert_eq!(
+            first.stage,
+            Some(IntegrationMeshProtocolSubstrateStage::Radio)
+        );
+        assert_eq!(first.primitive, Some(PrimitiveFamily::ZWaveSerialApi));
+        assert!(first.blocked());
+        assert!(first.operator_required());
+
+        let remediation = packages.last().unwrap();
+        assert_eq!(
+            remediation.package_kind,
+            IntegrationMeshReadinessHandoffKind::EvidenceRemediation
+        );
+        assert!(remediation.remediation_kind.is_some());
+        assert!(remediation.requires_attention());
+    }
+
+    #[test]
+    fn mesh_readiness_handoff_packages_mark_release_ready() {
+        let catalog = vec![hue_entry()];
+        let allowed_capabilities = vec![
+            CapabilityId::trusted("smart_home.read"),
+            CapabilityId::trusted("smart_home.command.light"),
+            CapabilityId::trusted("smart_home.pair"),
+        ];
+        let packages = mesh_readiness_handoff_packages_for_catalog(
+            &catalog,
+            all_primitive_families(),
+            &allowed_capabilities,
+            &[],
+        );
+        let summary = mesh_readiness_handoff_summary_for_catalog(
+            &catalog,
+            all_primitive_families(),
+            &allowed_capabilities,
+            &[],
+        );
+
+        assert_eq!(packages.len(), 1);
+        assert_eq!(summary.total_packages, 1);
+        assert_eq!(summary.action_packages, 0);
+        assert_eq!(summary.remediation_packages, 0);
+        assert_eq!(summary.ready_packages, 1);
+        assert_eq!(summary.blocked_packages, 0);
+        assert_eq!(summary.queued_substrate_actions, 0);
+        assert_eq!(summary.stage_blocker_count, 0);
+        assert!(summary.substrate_actions_ready);
+        assert!(summary.release_ready);
+        assert!(summary.ready_for_handoff());
+        assert!(!summary.has_blockers());
+        assert!(!summary.requires_attention());
+
+        let package = &packages[0];
+        assert_eq!(
+            package.package_kind,
+            IntegrationMeshReadinessHandoffKind::ReleaseReady
+        );
+        assert_eq!(
+            package.handoff_status,
+            IntegrationMeshReadinessHandoffStatus::Ready
+        );
+        assert!(package.ready_for_handoff());
+        assert!(!package.operator_required());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add catalog-owned mesh readiness handoff packages and summaries for substrate actions, evidence remediation, and release-ready state
- expose read-only Chief tools plus shared core descriptors for `smart_home.list_integration_mesh_readiness_handoffs` and `smart_home.get_integration_mesh_readiness_handoff_summary`
- update Chief tool docs, changelogs, and the end-to-end runtime/tool assertions

## Validation
- `cargo test -p smart-home-core`
- `cargo test -p smart-home-integration-catalog`
- `cargo test -p hue-core`
- `cargo test -p smart-home-runtime`
- `cargo test -p smart-home-testkit`
- `cargo test -p smart-home-local-http`
- `cargo test -p smart-home-discovery`
- `cargo test -p chief-of-staff-smart-home-tools`
- `cargo test -p smart-home-runtime discover_tool -- --nocapture`
- `sh BUILD` in `smart-home-core`
- `sh BUILD` in `smart-home-integration-catalog`
- `sh BUILD` in `hue-core`
- `sh BUILD` in `smart-home-runtime`
- `sh BUILD` in `smart-home-testkit`
- `sh BUILD` in `smart-home-local-http`
- `sh BUILD` in `smart-home-discovery`
- `sh BUILD` in `chief-of-staff-smart-home-tools`
- removed generated `code/packages/rust/Cargo.lock`
