### PR TITLE
Add mesh release readiness summary

### DIFF
--- a/code/packages/rust/chief-of-staff-smart-home-tools/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/CHANGELOG.md
@@ -125,6 +125,8 @@ All notable changes to this package will be documented in this file.
 - Added D18D handlers for D23 mesh substrate action queues and action-readiness
   rollups: `smart_home.list_integration_mesh_substrate_actions` and
   `smart_home.get_integration_mesh_action_readiness_summary`.
+- Added D18D handler for D23 mesh release-readiness rollups:
+  `smart_home.get_integration_mesh_release_readiness_summary`.
 - Added D18D handlers for D23A activation remediation work orders:
   `smart_home.list_integration_activation_remediation` and
   `smart_home.get_integration_activation_remediation_summary`.

--- a/code/packages/rust/chief-of-staff-smart-home-tools/README.md
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/README.md
@@ -57,8 +57,8 @@ Chief of Staff job/session/agent
      lane rollups
   -> mesh primitive-readiness, substrate-stage, and substrate-action reads for
      low-level protocol release blockers
-  -> mesh readiness package, stage-release, and action-readiness reads for
-     release go/no-go
+  -> mesh readiness package, stage-release, action-readiness, and release
+     readiness reads for release go/no-go
   -> activation-dossier list and summary reads for bundled decision evidence
   -> activation-dashboard list and summary reads for priority-wave status cards
   -> activation-timeline list and summary reads for ordered wave milestones
@@ -148,6 +148,7 @@ Chief of Staff job/session/agent
 - `smart_home.get_integration_mesh_readiness_package_summary`
 - `smart_home.get_integration_mesh_stage_release_summary`
 - `smart_home.get_integration_mesh_action_readiness_summary`
+- `smart_home.get_integration_mesh_release_readiness_summary`
 - `smart_home.list_integration_activation_dossiers`
 - `smart_home.get_integration_activation_dossier_summary`
 - `smart_home.list_integration_activation_readouts`

--- a/code/packages/rust/chief-of-staff-smart-home-tools/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/src/lib.rs
@@ -64,7 +64,8 @@ use smart_home_integration_catalog::{
     ecosystem_platform_coverage, ecosystem_platforms_requiring_primitive, ecosystem_survey_sources,
     entries_requiring_primitive, find_entry, first_party_catalog, mesh_action_readiness_summary,
     mesh_protocol_primitive_readiness_rows, mesh_protocol_substrate_actions,
-    mesh_protocol_substrate_stage_rows, mesh_readiness_package_summary, mesh_stage_release_summary,
+    mesh_protocol_substrate_stage_rows, mesh_readiness_package_summary,
+    mesh_release_readiness_summary, mesh_stage_release_summary,
     policy_surface_inventory_at_or_before_priority, primitive_backlog_at_or_before_priority,
     primitive_backlog_with_ecosystem_coverage, primitive_family_descriptors, query_integrations,
     readiness_gap_inventory_from_reports, readiness_report_for_plan,
@@ -144,7 +145,8 @@ use smart_home_integration_catalog::{
     IntegrationMeshProtocolSubstrateAction, IntegrationMeshProtocolSubstrateActionSummary,
     IntegrationMeshProtocolSubstrateStage, IntegrationMeshProtocolSubstrateStageRow,
     IntegrationMeshProtocolSubstrateStageSummary, IntegrationMeshReadinessPackageSummary,
-    IntegrationMeshStageReleaseSummary, IntegrationPolicySurface,
+    IntegrationMeshReleaseReadinessSummary, IntegrationMeshStageReleaseSummary,
+    IntegrationPolicySurface,
     IntegrationPolicySurfaceInventoryItem, IntegrationPolicySurfaceSummary,
     IntegrationReadinessCapabilityGap, IntegrationReadinessDependencyGap,
     IntegrationReadinessGapInventory, IntegrationReadinessPrimitiveGap, IntegrationReadinessReport,
@@ -332,6 +334,8 @@ pub const SMART_HOME_GET_INTEGRATION_MESH_STAGE_RELEASE_SUMMARY_TOOL_ID: &str =
     "smart_home.get_integration_mesh_stage_release_summary";
 pub const SMART_HOME_GET_INTEGRATION_MESH_ACTION_READINESS_SUMMARY_TOOL_ID: &str =
     "smart_home.get_integration_mesh_action_readiness_summary";
+pub const SMART_HOME_GET_INTEGRATION_MESH_RELEASE_READINESS_SUMMARY_TOOL_ID: &str =
+    "smart_home.get_integration_mesh_release_readiness_summary";
 pub const SMART_HOME_LIST_INTEGRATION_ACTIVATION_DOSSIERS_TOOL_ID: &str =
     "smart_home.list_integration_activation_dossiers";
 pub const SMART_HOME_GET_INTEGRATION_ACTIVATION_DOSSIER_SUMMARY_TOOL_ID: &str =
@@ -832,6 +836,10 @@ impl SmartHomeToolBridge {
                 SMART_HOME_GET_INTEGRATION_MESH_ACTION_READINESS_SUMMARY_TOOL_ID => {
                     let query = integration_readiness_query(&arguments)?;
                     Ok(get_integration_mesh_action_readiness_summary_output_handler_output(query))
+                }
+                SMART_HOME_GET_INTEGRATION_MESH_RELEASE_READINESS_SUMMARY_TOOL_ID => {
+                    let query = integration_readiness_query(&arguments)?;
+                    Ok(get_integration_mesh_release_readiness_summary_output_handler_output(query))
                 }
                 SMART_HOME_LIST_INTEGRATION_ACTIVATION_DOSSIERS_TOOL_ID => {
                     let query = integration_activation_dossier_query(&arguments)?;
@@ -2640,6 +2648,17 @@ pub fn smart_home_tool_definitions() -> Vec<ToolDefinition> {
             SMART_HOME_GET_INTEGRATION_MESH_ACTION_READINESS_SUMMARY_TOOL_ID,
             "Get smart-home integration mesh action readiness summary",
             "Return D23 mesh action readiness counts combining queued substrate actions with stage release blockers.",
+            integration_readiness_query_schema(true),
+            object_schema(
+                vec![SchemaProperty::new("summary", JsonSchema::Any)],
+                vec!["summary"],
+                false,
+            ),
+        ),
+        read_definition(
+            SMART_HOME_GET_INTEGRATION_MESH_RELEASE_READINESS_SUMMARY_TOOL_ID,
+            "Get smart-home integration mesh release readiness summary",
+            "Return package-facing D23 mesh release readiness counts across package, substrate-stage, queued-action, and remediation blockers.",
             integration_readiness_query_schema(true),
             object_schema(
                 vec![SchemaProperty::new("summary", JsonSchema::Any)],
@@ -16842,6 +16861,16 @@ fn integration_mesh_action_readiness_summary_for_query(
     )
 }
 
+fn integration_mesh_release_readiness_summary_for_query(
+    query: &IntegrationReadinessQuery,
+) -> IntegrationMeshReleaseReadinessSummary {
+    mesh_release_readiness_summary(
+        &query.available_primitives,
+        &query.allowed_capabilities,
+        &query.enabled_integrations,
+    )
+}
+
 fn integration_activation_dependency_graph_for_query(
     query: &IntegrationActivationDependencyQuery,
 ) -> (IntegrationActivationDependencyGraph, usize) {
@@ -21072,6 +21101,39 @@ fn get_integration_mesh_action_readiness_summary_output_handler_output(
             (
                 "queued_stage_count",
                 integer(summary.queued_stage_count as i64),
+            ),
+            (
+                "remediation_item_count",
+                integer(summary.remediation_item_count as i64),
+            ),
+            ("release_ready", JsonValue::Bool(summary.release_ready)),
+        ]),
+    )
+}
+
+fn get_integration_mesh_release_readiness_summary_output_handler_output(
+    query: IntegrationReadinessQuery,
+) -> ToolHandlerOutput {
+    let summary = integration_mesh_release_readiness_summary_for_query(&query);
+
+    ToolHandlerOutput::new(object([(
+        "summary",
+        mesh_release_readiness_summary_json(&summary),
+    )]))
+    .with_event(
+        ToolEventKind::Progress,
+        object([
+            (
+                "operation",
+                string("get_integration_mesh_release_readiness_summary"),
+            ),
+            (
+                "release_blocker_count",
+                integer(summary.release_blocker_count as i64),
+            ),
+            (
+                "queued_substrate_actions",
+                integer(summary.queued_substrate_actions as i64),
             ),
             (
                 "remediation_item_count",
@@ -42254,6 +42316,93 @@ fn mesh_action_readiness_summary_json(
     ])
 }
 
+fn mesh_release_readiness_summary_json(
+    summary: &IntegrationMeshReleaseReadinessSummary,
+) -> JsonValue {
+    object([
+        (
+            "action_readiness_summary",
+            mesh_action_readiness_summary_json(&summary.action_readiness_summary),
+        ),
+        ("total_protocols", integer(summary.total_protocols as i64)),
+        (
+            "release_blocker_count",
+            integer(summary.release_blocker_count as i64),
+        ),
+        (
+            "stage_blocker_count",
+            integer(summary.stage_blocker_count as i64),
+        ),
+        (
+            "primitive_blocker_count",
+            integer(summary.primitive_blocker_count as i64),
+        ),
+        (
+            "remediation_item_count",
+            integer(summary.remediation_item_count as i64),
+        ),
+        (
+            "queued_substrate_actions",
+            integer(summary.queued_substrate_actions as i64),
+        ),
+        (
+            "first_blocked_protocol",
+            summary
+                .first_blocked_protocol
+                .as_ref()
+                .map(protocol_family_label)
+                .map(string)
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_blocked_stage",
+            summary
+                .first_blocked_stage
+                .map(|stage| string(stage.as_str()))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_action_protocol",
+            summary
+                .first_action_protocol
+                .as_ref()
+                .map(protocol_family_label)
+                .map(string)
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_action_stage",
+            summary
+                .first_action_stage
+                .map(|stage| string(stage.as_str()))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "next_remediation_kind",
+            summary
+                .next_remediation_kind
+                .map(|kind| string(kind.as_str()))
+                .unwrap_or(JsonValue::Null),
+        ),
+        ("package_ready", JsonValue::Bool(summary.package_ready)),
+        ("substrate_ready", JsonValue::Bool(summary.substrate_ready)),
+        (
+            "substrate_actions_ready",
+            JsonValue::Bool(summary.substrate_actions_ready),
+        ),
+        ("release_ready", JsonValue::Bool(summary.release_ready)),
+        ("has_blockers", JsonValue::Bool(summary.has_blockers())),
+        (
+            "has_queued_actions",
+            JsonValue::Bool(summary.has_queued_actions()),
+        ),
+        (
+            "has_remediations",
+            JsonValue::Bool(summary.has_remediations()),
+        ),
+    ])
+}
+
 fn mesh_stage_release_summary_json(summary: &IntegrationMeshStageReleaseSummary) -> JsonValue {
     object([
         (
@@ -49169,7 +49318,7 @@ mod tests {
         let definitions = smart_home_tool_definitions();
         let export = ToolCatalogExport::from_definitions(definitions.iter());
 
-        assert_eq!(definitions.len(), 193);
+        assert_eq!(definitions.len(), 194);
         assert!(
             export.ok(),
             "tool export validation failed: {:?}",
@@ -49367,6 +49516,9 @@ mod tests {
         assert!(export
             .tool_ids()
             .contains(&SMART_HOME_GET_INTEGRATION_MESH_ACTION_READINESS_SUMMARY_TOOL_ID));
+        assert!(export
+            .tool_ids()
+            .contains(&SMART_HOME_GET_INTEGRATION_MESH_RELEASE_READINESS_SUMMARY_TOOL_ID));
         assert!(export.tool_ids().contains(&SMART_HOME_DISCOVER_TOOL_ID));
         assert!(export
             .tool_ids()
@@ -49725,7 +49877,7 @@ mod tests {
         ));
         assert_eq!(
             export.summary.required_capability_count("smart_home:read"),
-            185
+            186
         );
         assert_eq!(
             export
@@ -49794,6 +49946,10 @@ mod tests {
         .is_some());
         assert!(smart_home_tool_definition(
             SMART_HOME_GET_INTEGRATION_MESH_STAGE_RELEASE_SUMMARY_TOOL_ID
+        )
+        .is_some());
+        assert!(smart_home_tool_definition(
+            SMART_HOME_GET_INTEGRATION_MESH_RELEASE_READINESS_SUMMARY_TOOL_ID
         )
         .is_some());
         assert!(smart_home_tool_definition(
@@ -50409,11 +50565,11 @@ mod tests {
         let tool_catalog_summary = field(tool_catalog_summary_output, "summary").unwrap();
         assert_eq!(
             field(tool_catalog_summary, "total_tools"),
-            Some(&integer(193))
+            Some(&integer(194))
         );
         assert_eq!(
             field(tool_catalog_summary, "read_tools"),
-            Some(&integer(185))
+            Some(&integer(186))
         );
         assert_eq!(
             field(tool_catalog_summary, "risky_tool_count"),
@@ -52998,6 +53154,65 @@ mod tests {
             field(mesh_action_summary, "network_security_actions"),
             Some(&integer(3))
         );
+
+        let mesh_release_readiness_summary_request = request(
+            "call-integration-mesh-release-readiness-summary",
+            SMART_HOME_GET_INTEGRATION_MESH_RELEASE_READINESS_SUMMARY_TOOL_ID,
+            object([
+                (
+                    "available_primitives",
+                    JsonValue::Array(vec![
+                        string("usb"),
+                        string("serial_controller"),
+                        string("radio_802154"),
+                        string("supervision"),
+                    ]),
+                ),
+                (
+                    "allowed_capability_ids",
+                    JsonValue::Array(vec![string("smart_home.read")]),
+                ),
+            ]),
+            5_913,
+        );
+        let mesh_release_readiness_summary_trace =
+            tool_runtime.invoke_with_events(&mesh_release_readiness_summary_request);
+        assert!(mesh_release_readiness_summary_trace.result.ok);
+        assert_eq!(
+            mesh_release_readiness_summary_trace
+                .summary()
+                .progress_event_count,
+            1
+        );
+        let mesh_release_readiness_summary_output = mesh_release_readiness_summary_trace
+            .result
+            .output
+            .as_ref()
+            .unwrap();
+        let mesh_release_readiness_rollup =
+            field(mesh_release_readiness_summary_output, "summary").unwrap();
+        assert_eq!(
+            field(mesh_release_readiness_rollup, "queued_substrate_actions"),
+            Some(&integer(5))
+        );
+        assert!(
+            integer_value(field(mesh_release_readiness_rollup, "release_blocker_count").unwrap())
+                .unwrap()
+                >= 5
+        );
+        assert_eq!(
+            field(mesh_release_readiness_rollup, "substrate_actions_ready"),
+            Some(&JsonValue::Bool(false))
+        );
+        assert_eq!(
+            field(mesh_release_readiness_rollup, "release_ready"),
+            Some(&JsonValue::Bool(false))
+        );
+        assert!(field(
+            mesh_release_readiness_rollup,
+            "action_readiness_summary"
+        )
+        .is_some());
 
         let list_activation_dossiers_request = request(
             "call-list-integration-activation-dossiers",

--- a/code/packages/rust/smart-home-core/CHANGELOG.md
+++ b/code/packages/rust/smart-home-core/CHANGELOG.md
@@ -81,6 +81,8 @@ All notable changes to this package will be documented in this file.
 - `smart_home.list_integration_mesh_substrate_actions` and
   `smart_home.get_integration_mesh_action_readiness_summary` descriptors for
   read-only D23 mesh substrate action and action-readiness planning.
+- `smart_home.get_integration_mesh_release_readiness_summary` descriptor for
+  read-only D23 mesh package release readiness planning.
 - `smart_home.list_integration_activation_dossiers` and
   `smart_home.get_integration_activation_dossier_summary` tool descriptors
   for read-only bundled activation decision and evidence planning.

--- a/code/packages/rust/smart-home-core/src/lib.rs
+++ b/code/packages/rust/smart-home-core/src/lib.rs
@@ -1599,6 +1599,7 @@ pub enum SmartHomeTool {
     GetIntegrationMeshReadinessPackageSummary,
     GetIntegrationMeshStageReleaseSummary,
     GetIntegrationMeshActionReadinessSummary,
+    GetIntegrationMeshReleaseReadinessSummary,
     Discover,
     PairBridge,
     CompletePairing,
@@ -2092,6 +2093,9 @@ impl SmartHomeTool {
             }
             Self::GetIntegrationMeshActionReadinessSummary => {
                 read_tool("smart_home.get_integration_mesh_action_readiness_summary")
+            }
+            Self::GetIntegrationMeshReleaseReadinessSummary => {
+                read_tool("smart_home.get_integration_mesh_release_readiness_summary")
             }
             Self::Discover => ToolDescriptor {
                 tool_id: "smart_home.discover",
@@ -2852,6 +2856,7 @@ pub fn smart_home_tool_catalog() -> Vec<ToolDescriptor> {
         SmartHomeTool::GetIntegrationMeshReadinessPackageSummary,
         SmartHomeTool::GetIntegrationMeshStageReleaseSummary,
         SmartHomeTool::GetIntegrationMeshActionReadinessSummary,
+        SmartHomeTool::GetIntegrationMeshReleaseReadinessSummary,
         SmartHomeTool::Discover,
         SmartHomeTool::PairBridge,
         SmartHomeTool::CompletePairing,
@@ -3686,7 +3691,7 @@ mod tests {
             .find(|tool| tool.tool_id == "smart_home.command")
             .unwrap();
 
-        assert_eq!(catalog.len(), 193);
+        assert_eq!(catalog.len(), 194);
         assert!(catalog
             .iter()
             .any(|tool| tool.tool_id == "smart_home.list_integrations"
@@ -3931,6 +3936,7 @@ mod tests {
             "smart_home.get_integration_mesh_readiness_package_summary",
             "smart_home.get_integration_mesh_stage_release_summary",
             "smart_home.get_integration_mesh_action_readiness_summary",
+            "smart_home.get_integration_mesh_release_readiness_summary",
         ] {
             assert!(catalog.iter().any(|tool| tool.tool_id == tool_id
                 && tool.side_effects == ToolSideEffects::Read
@@ -4451,15 +4457,15 @@ mod tests {
         let summary = smart_home_tool_catalog_summary();
         let pair_bridge = SmartHomeTool::PairBridge.descriptor();
 
-        assert_eq!(summary.total_tools, 193);
-        assert_eq!(summary.read_tools, 185);
+        assert_eq!(summary.total_tools, 194);
+        assert_eq!(summary.read_tools, 186);
         assert_eq!(summary.write_tools, 2);
         assert_eq!(summary.external_tools, 6);
-        assert_eq!(summary.read_only_tier_tools, 185);
+        assert_eq!(summary.read_only_tier_tools, 186);
         assert_eq!(summary.low_risk_tier_tools, 6);
         assert_eq!(summary.high_risk_tier_tools, 0);
         assert_eq!(summary.human_approval_tier_tools, 2);
-        assert_eq!(summary.total_required_capabilities, 193);
+        assert_eq!(summary.total_required_capabilities, 194);
         assert_eq!(summary.risky_tool_count(), 8);
         assert_eq!(summary.approval_gated_tool_count(), 2);
         assert!(pair_bridge.requires_human_approval());

--- a/code/packages/rust/smart-home-integration-catalog/CHANGELOG.md
+++ b/code/packages/rust/smart-home-integration-catalog/CHANGELOG.md
@@ -70,6 +70,9 @@ All notable changes to this package will be documented in this file.
 - `IntegrationMeshActionReadinessSummary` and helpers for combining mesh
   release readiness with the substrate action queue and next concrete low-level
   action.
+- `IntegrationMeshReleaseReadinessSummary` and helpers for package-facing mesh
+  release readiness across package, substrate-stage, queued-action, and
+  remediation blockers.
 - Primitive backlog planning helpers for ranking the shared primitive families
   needed by priority-bounded rollout waves.
 - Integration activation planning helpers for resolving virtual aliases,

--- a/code/packages/rust/smart-home-integration-catalog/src/lib.rs
+++ b/code/packages/rust/smart-home-integration-catalog/src/lib.rs
@@ -901,6 +901,69 @@ impl IntegrationMeshActionReadinessSummary {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IntegrationMeshReleaseReadinessSummary {
+    pub action_readiness_summary: IntegrationMeshActionReadinessSummary,
+    pub total_protocols: usize,
+    pub release_blocker_count: usize,
+    pub stage_blocker_count: usize,
+    pub primitive_blocker_count: usize,
+    pub remediation_item_count: usize,
+    pub queued_substrate_actions: usize,
+    pub first_blocked_protocol: Option<ProtocolFamily>,
+    pub first_blocked_stage: Option<IntegrationMeshProtocolSubstrateStage>,
+    pub first_action_protocol: Option<ProtocolFamily>,
+    pub first_action_stage: Option<IntegrationMeshProtocolSubstrateStage>,
+    pub next_remediation_kind: Option<IntegrationActivationEvidenceRemediationKind>,
+    pub package_ready: bool,
+    pub substrate_ready: bool,
+    pub substrate_actions_ready: bool,
+    pub release_ready: bool,
+}
+
+impl IntegrationMeshReleaseReadinessSummary {
+    pub fn from_action_readiness_summary(
+        action_readiness_summary: IntegrationMeshActionReadinessSummary,
+    ) -> Self {
+        let stage_summary = &action_readiness_summary.release_summary;
+        let release_blocker_count = stage_summary.stage_blocker_count
+            + stage_summary.primitive_blocker_count
+            + stage_summary.remediation_item_count
+            + action_readiness_summary.queued_substrate_actions;
+
+        Self {
+            total_protocols: action_readiness_summary.total_protocols,
+            release_blocker_count,
+            stage_blocker_count: stage_summary.stage_blocker_count,
+            primitive_blocker_count: stage_summary.primitive_blocker_count,
+            remediation_item_count: stage_summary.remediation_item_count,
+            queued_substrate_actions: action_readiness_summary.queued_substrate_actions,
+            first_blocked_protocol: stage_summary.first_blocked_protocol.clone(),
+            first_blocked_stage: stage_summary.first_blocked_stage,
+            first_action_protocol: action_readiness_summary.first_action_protocol.clone(),
+            first_action_stage: action_readiness_summary.first_action_stage,
+            next_remediation_kind: stage_summary.next_remediation_kind,
+            package_ready: stage_summary.package_ready,
+            substrate_ready: stage_summary.substrate_ready,
+            substrate_actions_ready: action_readiness_summary.substrate_actions_ready,
+            release_ready: action_readiness_summary.release_ready,
+            action_readiness_summary,
+        }
+    }
+
+    pub fn has_blockers(&self) -> bool {
+        !self.release_ready
+    }
+
+    pub fn has_queued_actions(&self) -> bool {
+        self.queued_substrate_actions > 0
+    }
+
+    pub fn has_remediations(&self) -> bool {
+        self.remediation_item_count > 0
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct IntegrationCatalogEntry {
     pub integration_id: IntegrationId,
     pub display_name: String,
@@ -20903,6 +20966,36 @@ pub fn mesh_action_readiness_summary(
     )
 }
 
+pub fn mesh_release_readiness_summary_for_catalog(
+    catalog: &[IntegrationCatalogEntry],
+    available_primitives: &[PrimitiveFamily],
+    allowed_capabilities: &[CapabilityId],
+    enabled_integrations: &[IntegrationId],
+) -> IntegrationMeshReleaseReadinessSummary {
+    let action_readiness_summary = mesh_action_readiness_summary_for_catalog(
+        catalog,
+        available_primitives,
+        allowed_capabilities,
+        enabled_integrations,
+    );
+
+    IntegrationMeshReleaseReadinessSummary::from_action_readiness_summary(action_readiness_summary)
+}
+
+pub fn mesh_release_readiness_summary(
+    available_primitives: &[PrimitiveFamily],
+    allowed_capabilities: &[CapabilityId],
+    enabled_integrations: &[IntegrationId],
+) -> IntegrationMeshReleaseReadinessSummary {
+    let catalog = first_party_catalog();
+    mesh_release_readiness_summary_for_catalog(
+        &catalog,
+        available_primitives,
+        allowed_capabilities,
+        enabled_integrations,
+    )
+}
+
 fn mesh_protocol_catalog_entries(
     catalog: &[IntegrationCatalogEntry],
 ) -> Vec<IntegrationCatalogEntry> {
@@ -27322,6 +27415,65 @@ mod tests {
         assert!(!summary.has_substrate_actions());
         assert_eq!(summary.action_summary.total_actions, 0);
         assert_eq!(summary.release_summary.stage_blocker_count, 0);
+    }
+
+    #[test]
+    fn mesh_release_readiness_summary_surfaces_package_blockers() {
+        let available_primitives = vec![
+            PrimitiveFamily::Usb,
+            PrimitiveFamily::SerialController,
+            PrimitiveFamily::Radio802154,
+            PrimitiveFamily::Supervision,
+        ];
+        let allowed_capabilities = vec![CapabilityId::trusted("smart_home.read")];
+        let summary =
+            mesh_release_readiness_summary(&available_primitives, &allowed_capabilities, &[]);
+
+        assert_eq!(summary.total_protocols, 3);
+        assert_eq!(summary.queued_substrate_actions, 5);
+        assert_eq!(summary.stage_blocker_count, 5);
+        assert!(summary.release_blocker_count >= summary.queued_substrate_actions);
+        assert_eq!(summary.first_action_protocol, Some(ProtocolFamily::ZWave));
+        assert_eq!(
+            summary.first_action_stage,
+            Some(IntegrationMeshProtocolSubstrateStage::Radio)
+        );
+        assert!(!summary.package_ready);
+        assert!(!summary.substrate_ready);
+        assert!(!summary.substrate_actions_ready);
+        assert!(!summary.release_ready);
+        assert!(summary.has_blockers());
+        assert!(summary.has_queued_actions());
+        assert!(summary.has_remediations());
+    }
+
+    #[test]
+    fn mesh_release_readiness_summary_marks_clear_substrate_actions() {
+        let allowed_capabilities = vec![
+            CapabilityId::trusted("smart_home.read"),
+            CapabilityId::trusted("smart_home.command.light"),
+            CapabilityId::trusted("smart_home.command.lock"),
+            CapabilityId::trusted("smart_home.manage_network"),
+        ];
+        let summary =
+            mesh_release_readiness_summary(all_primitive_families(), &allowed_capabilities, &[]);
+
+        assert_eq!(summary.total_protocols, 3);
+        assert_eq!(summary.queued_substrate_actions, 0);
+        assert_eq!(summary.stage_blocker_count, 0);
+        assert_eq!(summary.primitive_blocker_count, 0);
+        assert_eq!(summary.first_action_protocol, None);
+        assert_eq!(summary.first_action_stage, None);
+        assert!(summary.substrate_ready);
+        assert!(summary.substrate_actions_ready);
+        assert!(!summary.has_queued_actions());
+        assert_eq!(
+            summary
+                .action_readiness_summary
+                .action_summary
+                .total_actions,
+            0
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add `IntegrationMeshReleaseReadinessSummary` over the existing mesh action-readiness rollup
- expose `smart_home.get_integration_mesh_release_readiness_summary` through shared core descriptors and chief-of-staff handlers
- document the new package-facing mesh release readiness surface

## Tests
- `cargo test --manifest-path code\\packages\\rust\\smart-home-integration-catalog\\Cargo.toml`
- `cargo test --manifest-path code\\packages\\rust\\smart-home-core\\Cargo.toml`
- `cargo test --manifest-path code\\packages\\rust\\chief-of-staff-smart-home-tools\\Cargo.toml`
- `git diff --check`