### PR TITLE
Add smart home mesh release readiness tools

### DIFF
--- a/code/packages/rust/chief-of-staff-smart-home-tools/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/CHANGELOG.md
@@ -130,6 +130,9 @@ All notable changes to this package will be documented in this file.
 - Added D18D handlers for D23 mesh readiness handoff packages:
   `smart_home.list_integration_mesh_readiness_handoffs` and
   `smart_home.get_integration_mesh_readiness_handoff_summary`.
+- Added D18D handlers for D23 mesh release-readiness gate checks:
+  `smart_home.list_integration_mesh_release_readiness_checks` and
+  `smart_home.get_integration_mesh_release_readiness_summary`.
 - Added D18D handlers for D23A activation remediation work orders:
   `smart_home.list_integration_activation_remediation` and
   `smart_home.get_integration_activation_remediation_summary`.

--- a/code/packages/rust/chief-of-staff-smart-home-tools/README.md
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/README.md
@@ -60,6 +60,7 @@ Chief of Staff job/session/agent
   -> mesh readiness package, stage-release, action-readiness, and
      release-readiness reads for release go/no-go
   -> mesh readiness handoff list and summary reads for release coordination
+  -> mesh release-readiness check list and summary reads for final gate review
   -> activation-dossier list and summary reads for bundled decision evidence
   -> activation-dashboard list and summary reads for priority-wave status cards
   -> activation-timeline list and summary reads for ordered wave milestones
@@ -152,6 +153,8 @@ Chief of Staff job/session/agent
 - `smart_home.get_integration_mesh_release_readiness_summary`
 - `smart_home.list_integration_mesh_readiness_handoffs`
 - `smart_home.get_integration_mesh_readiness_handoff_summary`
+- `smart_home.list_integration_mesh_release_readiness_checks`
+- `smart_home.get_integration_mesh_release_readiness_summary`
 - `smart_home.list_integration_activation_dossiers`
 - `smart_home.get_integration_activation_dossier_summary`
 - `smart_home.list_integration_activation_readouts`

--- a/code/packages/rust/chief-of-staff-smart-home-tools/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/src/lib.rs
@@ -65,8 +65,8 @@ use smart_home_integration_catalog::{
     entries_requiring_primitive, find_entry, first_party_catalog, mesh_action_readiness_summary,
     mesh_protocol_primitive_readiness_rows, mesh_protocol_substrate_actions,
     mesh_protocol_substrate_stage_rows, mesh_readiness_handoff_packages,
-    mesh_readiness_handoff_summary, mesh_readiness_package_summary, mesh_release_readiness_summary,
-    mesh_stage_release_summary,
+    mesh_readiness_handoff_summary, mesh_readiness_package_summary, mesh_release_readiness_checks,
+    mesh_release_readiness_summary, mesh_stage_release_summary,
     policy_surface_inventory_at_or_before_priority, primitive_backlog_at_or_before_priority,
     primitive_backlog_with_ecosystem_coverage, primitive_family_descriptors, query_integrations,
     readiness_gap_inventory_from_reports, readiness_report_for_plan,
@@ -148,13 +148,15 @@ use smart_home_integration_catalog::{
     IntegrationMeshProtocolSubstrateStageSummary, IntegrationMeshReadinessHandoffKind,
     IntegrationMeshReadinessHandoffPackage, IntegrationMeshReadinessHandoffStatus,
     IntegrationMeshReadinessHandoffSummary, IntegrationMeshReadinessPackageSummary,
+    IntegrationMeshReleaseReadinessCheck, IntegrationMeshReleaseReadinessCheckKind,
+    IntegrationMeshReleaseReadinessCheckSummary, IntegrationMeshReleaseReadinessStatus,
     IntegrationMeshReleaseReadinessSummary, IntegrationMeshStageReleaseSummary,
-    IntegrationPolicySurface,
-    IntegrationPolicySurfaceInventoryItem, IntegrationPolicySurfaceSummary,
-    IntegrationReadinessCapabilityGap, IntegrationReadinessDependencyGap,
-    IntegrationReadinessGapInventory, IntegrationReadinessPrimitiveGap, IntegrationReadinessReport,
-    IntegrationReadinessSummary, PrimitiveBacklogCoverageItem, PrimitiveBacklogCoverageSummary,
-    PrimitiveBacklogItem, PrimitiveFamily, PrimitiveFamilyDescriptor, SourceReference,
+    IntegrationPolicySurface, IntegrationPolicySurfaceInventoryItem,
+    IntegrationPolicySurfaceSummary, IntegrationReadinessCapabilityGap,
+    IntegrationReadinessDependencyGap, IntegrationReadinessGapInventory,
+    IntegrationReadinessPrimitiveGap, IntegrationReadinessReport, IntegrationReadinessSummary,
+    PrimitiveBacklogCoverageItem, PrimitiveBacklogCoverageSummary, PrimitiveBacklogItem,
+    PrimitiveFamily, PrimitiveFamilyDescriptor, SourceReference,
 };
 use smart_home_registry::RegistryTopologySummary;
 use smart_home_registry::StateRefreshReason;
@@ -343,6 +345,8 @@ pub const SMART_HOME_LIST_INTEGRATION_MESH_READINESS_HANDOFFS_TOOL_ID: &str =
     "smart_home.list_integration_mesh_readiness_handoffs";
 pub const SMART_HOME_GET_INTEGRATION_MESH_READINESS_HANDOFF_SUMMARY_TOOL_ID: &str =
     "smart_home.get_integration_mesh_readiness_handoff_summary";
+pub const SMART_HOME_LIST_INTEGRATION_MESH_RELEASE_READINESS_CHECKS_TOOL_ID: &str =
+    "smart_home.list_integration_mesh_release_readiness_checks";
 pub const SMART_HOME_LIST_INTEGRATION_ACTIVATION_DOSSIERS_TOOL_ID: &str =
     "smart_home.list_integration_activation_dossiers";
 pub const SMART_HOME_GET_INTEGRATION_ACTIVATION_DOSSIER_SUMMARY_TOOL_ID: &str =
@@ -855,6 +859,10 @@ impl SmartHomeToolBridge {
                 SMART_HOME_GET_INTEGRATION_MESH_READINESS_HANDOFF_SUMMARY_TOOL_ID => {
                     let query = integration_readiness_query(&arguments)?;
                     Ok(get_integration_mesh_readiness_handoff_summary_output_handler_output(query))
+                }
+                SMART_HOME_LIST_INTEGRATION_MESH_RELEASE_READINESS_CHECKS_TOOL_ID => {
+                    let query = integration_readiness_query(&arguments)?;
+                    Ok(list_integration_mesh_release_readiness_checks_output_handler_output(query))
                 }
                 SMART_HOME_LIST_INTEGRATION_ACTIVATION_DOSSIERS_TOOL_ID => {
                     let query = integration_activation_dossier_query(&arguments)?;
@@ -2706,6 +2714,23 @@ pub fn smart_home_tool_definitions() -> Vec<ToolDefinition> {
             object_schema(
                 vec![SchemaProperty::new("summary", JsonSchema::Any)],
                 vec!["summary"],
+                false,
+            ),
+        ),
+        read_definition(
+            SMART_HOME_LIST_INTEGRATION_MESH_RELEASE_READINESS_CHECKS_TOOL_ID,
+            "List smart-home integration mesh release readiness checks",
+            "List D23 mesh release-readiness gate checks derived from handoff packages, evidence remediation, operator work, and release packet readiness.",
+            integration_readiness_query_schema(true),
+            object_schema(
+                vec![
+                    SchemaProperty::new("mesh_release_readiness_checks", JsonSchema::Array {
+                        items: Box::new(JsonSchema::Any),
+                    }),
+                    SchemaProperty::new("summary", JsonSchema::Any),
+                    SchemaProperty::new("count", JsonSchema::Integer),
+                ],
+                vec!["mesh_release_readiness_checks", "summary", "count"],
                 false,
             ),
         ),
@@ -16943,6 +16968,25 @@ fn integration_mesh_readiness_handoff_summary_for_query(
     )
 }
 
+fn integration_mesh_release_readiness_checks_for_query(
+    query: &IntegrationReadinessQuery,
+) -> Vec<IntegrationMeshReleaseReadinessCheck> {
+    let mut checks = mesh_release_readiness_checks(
+        &query.available_primitives,
+        &query.allowed_capabilities,
+        &query.enabled_integrations,
+    );
+
+    if let Some(activation_ready) = query.activation_ready {
+        checks.retain(|check| check.ready() == activation_ready);
+    }
+    if let Some(limit) = query.limit {
+        checks.truncate(limit);
+    }
+
+    checks
+}
+
 fn integration_activation_dependency_graph_for_query(
     query: &IntegrationActivationDependencyQuery,
 ) -> (IntegrationActivationDependencyGraph, usize) {
@@ -21285,6 +21329,50 @@ fn get_integration_mesh_readiness_handoff_summary_output_handler_output(
             (
                 "ready_for_handoff",
                 JsonValue::Bool(summary.ready_for_handoff()),
+            ),
+        ]),
+    )
+}
+
+fn list_integration_mesh_release_readiness_checks_output_handler_output(
+    query: IntegrationReadinessQuery,
+) -> ToolHandlerOutput {
+    let checks = integration_mesh_release_readiness_checks_for_query(&query);
+    let summary = IntegrationMeshReleaseReadinessCheckSummary::from_parts(
+        integration_mesh_readiness_handoff_summary_for_query(&query),
+        checks.iter(),
+    );
+    let count = checks.len();
+
+    ToolHandlerOutput::new(object([
+        (
+            "mesh_release_readiness_checks",
+            JsonValue::Array(
+                checks
+                    .iter()
+                    .map(mesh_release_readiness_check_json)
+                    .collect(),
+            ),
+        ),
+        (
+            "summary",
+            mesh_release_readiness_check_summary_json(&summary),
+        ),
+        ("count", integer(count as i64)),
+    ]))
+    .with_event(
+        ToolEventKind::Progress,
+        object([
+            (
+                "operation",
+                string("list_integration_mesh_release_readiness_checks"),
+            ),
+            ("checks", integer(count as i64)),
+            ("ready_checks", integer(summary.ready_checks as i64)),
+            ("blocked_checks", integer(summary.blocked_checks as i64)),
+            (
+                "release_packet_ready",
+                JsonValue::Bool(summary.release_packet_ready),
             ),
         ]),
     )
@@ -42885,6 +42973,214 @@ fn mesh_readiness_handoff_summary_json(
     ])
 }
 
+fn mesh_release_readiness_check_kind_json(
+    kind: IntegrationMeshReleaseReadinessCheckKind,
+) -> JsonValue {
+    string(kind.as_str())
+}
+
+fn mesh_release_readiness_status_json(status: IntegrationMeshReleaseReadinessStatus) -> JsonValue {
+    string(status.as_str())
+}
+
+fn mesh_release_readiness_check_json(check: &IntegrationMeshReleaseReadinessCheck) -> JsonValue {
+    object([
+        ("sequence", integer(check.sequence as i64)),
+        (
+            "check_kind",
+            mesh_release_readiness_check_kind_json(check.check_kind),
+        ),
+        ("status", mesh_release_readiness_status_json(check.status)),
+        (
+            "package_kind",
+            check
+                .package_kind
+                .map(mesh_readiness_handoff_kind_json)
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "handoff_status",
+            check
+                .handoff_status
+                .map(mesh_readiness_handoff_status_json)
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "queued_substrate_actions",
+            integer(check.queued_substrate_actions as i64),
+        ),
+        (
+            "queued_stage_count",
+            integer(check.queued_stage_count as i64),
+        ),
+        (
+            "queued_primitive_count",
+            integer(check.queued_primitive_count as i64),
+        ),
+        (
+            "remediation_item_count",
+            integer(check.remediation_item_count as i64),
+        ),
+        (
+            "review_required_packages",
+            integer(check.review_required_packages as i64),
+        ),
+        (
+            "operator_required_packages",
+            integer(check.operator_required_packages as i64),
+        ),
+        ("blocked_packages", integer(check.blocked_packages as i64)),
+        (
+            "packages_requiring_attention",
+            integer(check.packages_requiring_attention as i64),
+        ),
+        ("ready", JsonValue::Bool(check.ready())),
+        ("blocked", JsonValue::Bool(check.blocked())),
+        ("review_required", JsonValue::Bool(check.review_required())),
+        (
+            "operator_required",
+            JsonValue::Bool(check.operator_required()),
+        ),
+        (
+            "requires_attention",
+            JsonValue::Bool(check.requires_attention()),
+        ),
+    ])
+}
+
+fn mesh_release_readiness_check_summary_json(
+    summary: &IntegrationMeshReleaseReadinessCheckSummary,
+) -> JsonValue {
+    object([
+        (
+            "handoff_summary",
+            mesh_readiness_handoff_summary_json(&summary.handoff_summary),
+        ),
+        ("total_checks", integer(summary.total_checks as i64)),
+        ("ready_checks", integer(summary.ready_checks as i64)),
+        ("blocked_checks", integer(summary.blocked_checks as i64)),
+        (
+            "review_required_checks",
+            integer(summary.review_required_checks as i64),
+        ),
+        (
+            "operator_required_checks",
+            integer(summary.operator_required_checks as i64),
+        ),
+        (
+            "checks_requiring_attention",
+            integer(summary.checks_requiring_attention as i64),
+        ),
+        (
+            "queued_substrate_actions",
+            integer(summary.queued_substrate_actions as i64),
+        ),
+        (
+            "queued_stage_count",
+            integer(summary.queued_stage_count as i64),
+        ),
+        (
+            "queued_primitive_count",
+            integer(summary.queued_primitive_count as i64),
+        ),
+        (
+            "remediation_item_count",
+            integer(summary.remediation_item_count as i64),
+        ),
+        (
+            "review_required_packages",
+            integer(summary.review_required_packages as i64),
+        ),
+        (
+            "operator_required_packages",
+            integer(summary.operator_required_packages as i64),
+        ),
+        ("blocked_packages", integer(summary.blocked_packages as i64)),
+        (
+            "packages_requiring_attention",
+            integer(summary.packages_requiring_attention as i64),
+        ),
+        (
+            "next_check_kind",
+            summary
+                .next_check_kind
+                .map(mesh_release_readiness_check_kind_json)
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "next_check_status",
+            summary
+                .next_check_status
+                .map(mesh_release_readiness_status_json)
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "next_check_sequence",
+            summary
+                .next_check_sequence
+                .map(|sequence| integer(sequence as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_blocked_check_sequence",
+            summary
+                .first_blocked_check_sequence
+                .map(|sequence| integer(sequence as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_review_check_sequence",
+            summary
+                .first_review_check_sequence
+                .map(|sequence| integer(sequence as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_operator_check_sequence",
+            summary
+                .first_operator_check_sequence
+                .map(|sequence| integer(sequence as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "next_package_kind",
+            summary
+                .next_package_kind
+                .map(mesh_readiness_handoff_kind_json)
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "next_handoff_status",
+            summary
+                .next_handoff_status
+                .map(mesh_readiness_handoff_status_json)
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "substrate_actions_ready",
+            JsonValue::Bool(summary.substrate_actions_ready),
+        ),
+        ("release_ready", JsonValue::Bool(summary.release_ready)),
+        (
+            "ready_for_handoff",
+            JsonValue::Bool(summary.ready_for_handoff),
+        ),
+        (
+            "release_packet_ready",
+            JsonValue::Bool(summary.release_packet_ready),
+        ),
+        ("has_blockers", JsonValue::Bool(summary.has_blockers())),
+        (
+            "has_review_work",
+            JsonValue::Bool(summary.has_review_work()),
+        ),
+        (
+            "requires_attention",
+            JsonValue::Bool(summary.requires_attention()),
+        ),
+    ])
+}
+
 fn readiness_report_json(report: &IntegrationReadinessReport) -> JsonValue {
     object([
         (
@@ -49722,7 +50018,7 @@ mod tests {
         let definitions = smart_home_tool_definitions();
         let export = ToolCatalogExport::from_definitions(definitions.iter());
 
-        assert_eq!(definitions.len(), 196);
+        assert_eq!(definitions.len(), 197);
         assert!(
             export.ok(),
             "tool export validation failed: {:?}",
@@ -49929,6 +50225,9 @@ mod tests {
         assert!(export
             .tool_ids()
             .contains(&SMART_HOME_GET_INTEGRATION_MESH_READINESS_HANDOFF_SUMMARY_TOOL_ID));
+        assert!(export
+            .tool_ids()
+            .contains(&SMART_HOME_LIST_INTEGRATION_MESH_RELEASE_READINESS_CHECKS_TOOL_ID));
         assert!(export.tool_ids().contains(&SMART_HOME_DISCOVER_TOOL_ID));
         assert!(export
             .tool_ids()
@@ -50287,7 +50586,7 @@ mod tests {
         ));
         assert_eq!(
             export.summary.required_capability_count("smart_home:read"),
-            188
+            189
         );
         assert_eq!(
             export
@@ -50376,6 +50675,10 @@ mod tests {
         .is_some());
         assert!(smart_home_tool_definition(
             SMART_HOME_GET_INTEGRATION_MESH_READINESS_HANDOFF_SUMMARY_TOOL_ID
+        )
+        .is_some());
+        assert!(smart_home_tool_definition(
+            SMART_HOME_LIST_INTEGRATION_MESH_RELEASE_READINESS_CHECKS_TOOL_ID
         )
         .is_some());
         assert!(smart_home_tool_definition(
@@ -50991,11 +51294,11 @@ mod tests {
         let tool_catalog_summary = field(tool_catalog_summary_output, "summary").unwrap();
         assert_eq!(
             field(tool_catalog_summary, "total_tools"),
-            Some(&integer(196))
+            Some(&integer(197))
         );
         assert_eq!(
             field(tool_catalog_summary, "read_tools"),
-            Some(&integer(188))
+            Some(&integer(189))
         );
         assert_eq!(
             field(tool_catalog_summary, "risky_tool_count"),
@@ -53627,11 +53930,7 @@ mod tests {
             field(mesh_release_readiness_rollup, "release_ready"),
             Some(&JsonValue::Bool(false))
         );
-        assert!(field(
-            mesh_release_readiness_rollup,
-            "action_readiness_summary"
-        )
-        .is_some());
+        assert!(field(mesh_release_readiness_rollup, "action_readiness_summary").is_some());
 
         let list_mesh_readiness_handoffs_request = request(
             "call-list-integration-mesh-readiness-handoffs",
@@ -53759,6 +54058,81 @@ mod tests {
         assert_eq!(
             field(mesh_readiness_handoff_rollup, "has_blockers"),
             Some(&JsonValue::Bool(true))
+        );
+
+        let list_mesh_release_readiness_checks_request = request(
+            "call-list-integration-mesh-release-readiness-checks",
+            SMART_HOME_LIST_INTEGRATION_MESH_RELEASE_READINESS_CHECKS_TOOL_ID,
+            object([
+                (
+                    "available_primitives",
+                    JsonValue::Array(vec![
+                        string("usb"),
+                        string("serial_controller"),
+                        string("radio_802154"),
+                        string("supervision"),
+                    ]),
+                ),
+                (
+                    "allowed_capability_ids",
+                    JsonValue::Array(vec![string("smart_home.read")]),
+                ),
+                ("activation_ready", JsonValue::Bool(false)),
+            ]),
+            5_915,
+        );
+        let list_mesh_release_readiness_checks_trace =
+            tool_runtime.invoke_with_events(&list_mesh_release_readiness_checks_request);
+        assert!(list_mesh_release_readiness_checks_trace.result.ok);
+        assert_eq!(
+            list_mesh_release_readiness_checks_trace
+                .summary()
+                .progress_event_count,
+            1
+        );
+        let list_mesh_release_readiness_checks_output = list_mesh_release_readiness_checks_trace
+            .result
+            .output
+            .as_ref()
+            .unwrap();
+        assert_eq!(
+            field(list_mesh_release_readiness_checks_output, "count"),
+            Some(&integer(5))
+        );
+        let mesh_release_readiness_summary =
+            field(list_mesh_release_readiness_checks_output, "summary").unwrap();
+        assert_eq!(
+            field(mesh_release_readiness_summary, "blocked_checks"),
+            Some(&integer(3))
+        );
+        assert_eq!(
+            field(mesh_release_readiness_summary, "review_required_checks"),
+            Some(&integer(2))
+        );
+        assert_eq!(
+            field(mesh_release_readiness_summary, "release_packet_ready"),
+            Some(&JsonValue::Bool(false))
+        );
+        let mesh_release_readiness_check = array_item(
+            field(
+                list_mesh_release_readiness_checks_output,
+                "mesh_release_readiness_checks",
+            )
+            .unwrap(),
+            0,
+        )
+        .unwrap();
+        assert_eq!(
+            field(mesh_release_readiness_check, "check_kind"),
+            Some(&string("substrate_actions"))
+        );
+        assert_eq!(
+            field(mesh_release_readiness_check, "status"),
+            Some(&string("blocked"))
+        );
+        assert_eq!(
+            field(mesh_release_readiness_check, "package_kind"),
+            Some(&string("substrate_action"))
         );
 
         let list_activation_dossiers_request = request(

--- a/code/packages/rust/smart-home-core/CHANGELOG.md
+++ b/code/packages/rust/smart-home-core/CHANGELOG.md
@@ -87,6 +87,9 @@ All notable changes to this package will be documented in this file.
 - `smart_home.list_integration_mesh_readiness_handoffs` and
   `smart_home.get_integration_mesh_readiness_handoff_summary` descriptors for
   read-only D23 mesh readiness handoff planning.
+- `smart_home.list_integration_mesh_release_readiness_checks` and
+  `smart_home.get_integration_mesh_release_readiness_summary` descriptors for
+  read-only D23 mesh release-readiness gate planning.
 - `smart_home.list_integration_activation_dossiers` and
   `smart_home.get_integration_activation_dossier_summary` tool descriptors
   for read-only bundled activation decision and evidence planning.

--- a/code/packages/rust/smart-home-core/README.md
+++ b/code/packages/rust/smart-home-core/README.md
@@ -77,6 +77,8 @@ Current scope:
   queue planning derived from approval packets
 - D18D integration activation-evidence descriptors for read-only evidence rows
   behind approval and blocker decisions
+- D18D integration mesh-release descriptors for read-only Zigbee, Z-Wave, and
+  Thread primitive, substrate, handoff, and release-readiness gate planning
 - D18D integration activation-dossier descriptors for read-only bundled
   decision and evidence planning
 - D18D integration activation-readout descriptors for priority-wave health,

--- a/code/packages/rust/smart-home-core/src/lib.rs
+++ b/code/packages/rust/smart-home-core/src/lib.rs
@@ -1602,6 +1602,7 @@ pub enum SmartHomeTool {
     GetIntegrationMeshReleaseReadinessSummary,
     ListIntegrationMeshReadinessHandoffs,
     GetIntegrationMeshReadinessHandoffSummary,
+    ListIntegrationMeshReleaseReadinessChecks,
     Discover,
     PairBridge,
     CompletePairing,
@@ -2104,6 +2105,9 @@ impl SmartHomeTool {
             }
             Self::GetIntegrationMeshReadinessHandoffSummary => {
                 read_tool("smart_home.get_integration_mesh_readiness_handoff_summary")
+            }
+            Self::ListIntegrationMeshReleaseReadinessChecks => {
+                read_tool("smart_home.list_integration_mesh_release_readiness_checks")
             }
             Self::Discover => ToolDescriptor {
                 tool_id: "smart_home.discover",
@@ -2867,6 +2871,7 @@ pub fn smart_home_tool_catalog() -> Vec<ToolDescriptor> {
         SmartHomeTool::GetIntegrationMeshReleaseReadinessSummary,
         SmartHomeTool::ListIntegrationMeshReadinessHandoffs,
         SmartHomeTool::GetIntegrationMeshReadinessHandoffSummary,
+        SmartHomeTool::ListIntegrationMeshReleaseReadinessChecks,
         SmartHomeTool::Discover,
         SmartHomeTool::PairBridge,
         SmartHomeTool::CompletePairing,
@@ -3701,7 +3706,7 @@ mod tests {
             .find(|tool| tool.tool_id == "smart_home.command")
             .unwrap();
 
-        assert_eq!(catalog.len(), 196);
+        assert_eq!(catalog.len(), 197);
         assert!(catalog
             .iter()
             .any(|tool| tool.tool_id == "smart_home.list_integrations"
@@ -3949,6 +3954,7 @@ mod tests {
             "smart_home.get_integration_mesh_release_readiness_summary",
             "smart_home.list_integration_mesh_readiness_handoffs",
             "smart_home.get_integration_mesh_readiness_handoff_summary",
+            "smart_home.list_integration_mesh_release_readiness_checks",
         ] {
             assert!(catalog.iter().any(|tool| tool.tool_id == tool_id
                 && tool.side_effects == ToolSideEffects::Read
@@ -4469,15 +4475,15 @@ mod tests {
         let summary = smart_home_tool_catalog_summary();
         let pair_bridge = SmartHomeTool::PairBridge.descriptor();
 
-        assert_eq!(summary.total_tools, 196);
-        assert_eq!(summary.read_tools, 188);
+        assert_eq!(summary.total_tools, 197);
+        assert_eq!(summary.read_tools, 189);
         assert_eq!(summary.write_tools, 2);
         assert_eq!(summary.external_tools, 6);
-        assert_eq!(summary.read_only_tier_tools, 188);
+        assert_eq!(summary.read_only_tier_tools, 189);
         assert_eq!(summary.low_risk_tier_tools, 6);
         assert_eq!(summary.high_risk_tier_tools, 0);
         assert_eq!(summary.human_approval_tier_tools, 2);
-        assert_eq!(summary.total_required_capabilities, 196);
+        assert_eq!(summary.total_required_capabilities, 197);
         assert_eq!(summary.risky_tool_count(), 8);
         assert_eq!(summary.approval_gated_tool_count(), 2);
         assert!(pair_bridge.requires_human_approval());

--- a/code/packages/rust/smart-home-integration-catalog/CHANGELOG.md
+++ b/code/packages/rust/smart-home-integration-catalog/CHANGELOG.md
@@ -85,6 +85,9 @@ All notable changes to this package will be documented in this file.
 - `IntegrationMeshReadinessHandoffPackage`, summary helpers, and D23 mesh
   readiness handoff projections for release coordination across substrate
   actions, evidence remediation, and release-ready state.
+- `IntegrationMeshReleaseReadinessCheck`, summary helpers, and D23 mesh
+  release-readiness gate projections for substrate actions, evidence
+  remediation, human review, operator handoff, and release packet state.
 - Primitive backlog planning helpers for ranking the shared primitive families
   needed by priority-bounded rollout waves.
 - Integration activation planning helpers for resolving virtual aliases,

--- a/code/packages/rust/smart-home-integration-catalog/README.md
+++ b/code/packages/rust/smart-home-integration-catalog/README.md
@@ -69,6 +69,10 @@ runtime and Chief of Staff tools a typed catalog for:
   substrate action queue and next concrete low-level action
 - mesh preflight repair readiness summaries that combine release readiness,
   substrate preflight gates, and protocol-scoped repair queues
+- mesh readiness handoff packages that project substrate actions, evidence
+  remediation, and release-ready state for reusable release coordination
+- mesh release-readiness checks that summarize substrate action, evidence,
+  human-review, operator handoff, and release packet gates
 - primitive backlog planning for prioritizing the shared families needed by a
   rollout wave
 - activation plans that resolve direct integrations, virtual aliases, and

--- a/code/packages/rust/smart-home-integration-catalog/src/lib.rs
+++ b/code/packages/rust/smart-home-integration-catalog/src/lib.rs
@@ -1709,6 +1709,256 @@ impl IntegrationMeshReadinessHandoffSummary {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum IntegrationMeshReleaseReadinessCheckKind {
+    SubstrateActions,
+    EvidenceRemediation,
+    HumanReview,
+    OperatorHandoff,
+    ReleasePacket,
+}
+
+impl IntegrationMeshReleaseReadinessCheckKind {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::SubstrateActions => "substrate_actions",
+            Self::EvidenceRemediation => "evidence_remediation",
+            Self::HumanReview => "human_review",
+            Self::OperatorHandoff => "operator_handoff",
+            Self::ReleasePacket => "release_packet",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum IntegrationMeshReleaseReadinessStatus {
+    Ready,
+    NeedsReview,
+    Blocked,
+}
+
+impl IntegrationMeshReleaseReadinessStatus {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Ready => "ready",
+            Self::NeedsReview => "needs_review",
+            Self::Blocked => "blocked",
+        }
+    }
+
+    pub fn requires_attention(self) -> bool {
+        matches!(self, Self::NeedsReview | Self::Blocked)
+    }
+
+    fn as_handoff_status(self) -> IntegrationMeshReadinessHandoffStatus {
+        match self {
+            Self::Ready => IntegrationMeshReadinessHandoffStatus::Ready,
+            Self::NeedsReview => IntegrationMeshReadinessHandoffStatus::NeedsReview,
+            Self::Blocked => IntegrationMeshReadinessHandoffStatus::Blocked,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IntegrationMeshReleaseReadinessCheck {
+    pub sequence: usize,
+    pub check_kind: IntegrationMeshReleaseReadinessCheckKind,
+    pub status: IntegrationMeshReleaseReadinessStatus,
+    pub package_kind: Option<IntegrationMeshReadinessHandoffKind>,
+    pub handoff_status: Option<IntegrationMeshReadinessHandoffStatus>,
+    pub queued_substrate_actions: usize,
+    pub queued_stage_count: usize,
+    pub queued_primitive_count: usize,
+    pub remediation_item_count: usize,
+    pub review_required_packages: usize,
+    pub operator_required_packages: usize,
+    pub blocked_packages: usize,
+    pub packages_requiring_attention: usize,
+    pub ready: bool,
+    pub blocked: bool,
+    pub review_required: bool,
+    pub operator_required: bool,
+    pub requires_attention: bool,
+}
+
+impl IntegrationMeshReleaseReadinessCheck {
+    fn from_summary(
+        sequence: usize,
+        check_kind: IntegrationMeshReleaseReadinessCheckKind,
+        status: IntegrationMeshReleaseReadinessStatus,
+        package_kind: Option<IntegrationMeshReadinessHandoffKind>,
+        handoff_status: Option<IntegrationMeshReadinessHandoffStatus>,
+        handoff_summary: &IntegrationMeshReadinessHandoffSummary,
+        operator_required: bool,
+    ) -> Self {
+        let ready = status == IntegrationMeshReleaseReadinessStatus::Ready;
+        let blocked = status == IntegrationMeshReleaseReadinessStatus::Blocked;
+        let review_required = status == IntegrationMeshReleaseReadinessStatus::NeedsReview;
+
+        Self {
+            sequence,
+            check_kind,
+            status,
+            package_kind,
+            handoff_status,
+            queued_substrate_actions: handoff_summary.queued_substrate_actions,
+            queued_stage_count: handoff_summary.queued_stage_count,
+            queued_primitive_count: handoff_summary.queued_primitive_count,
+            remediation_item_count: handoff_summary.remediation_item_count,
+            review_required_packages: handoff_summary.review_required_packages,
+            operator_required_packages: handoff_summary.operator_required_packages,
+            blocked_packages: handoff_summary.blocked_packages,
+            packages_requiring_attention: handoff_summary.packages_requiring_attention,
+            ready,
+            blocked,
+            review_required,
+            operator_required,
+            requires_attention: status.requires_attention() || operator_required,
+        }
+    }
+
+    pub fn ready(&self) -> bool {
+        self.ready
+    }
+
+    pub fn blocked(&self) -> bool {
+        self.blocked
+    }
+
+    pub fn review_required(&self) -> bool {
+        self.review_required
+    }
+
+    pub fn operator_required(&self) -> bool {
+        self.operator_required
+    }
+
+    pub fn requires_attention(&self) -> bool {
+        self.requires_attention
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IntegrationMeshReleaseReadinessCheckSummary {
+    pub handoff_summary: IntegrationMeshReadinessHandoffSummary,
+    pub total_checks: usize,
+    pub ready_checks: usize,
+    pub blocked_checks: usize,
+    pub review_required_checks: usize,
+    pub operator_required_checks: usize,
+    pub checks_requiring_attention: usize,
+    pub queued_substrate_actions: usize,
+    pub queued_stage_count: usize,
+    pub queued_primitive_count: usize,
+    pub remediation_item_count: usize,
+    pub review_required_packages: usize,
+    pub operator_required_packages: usize,
+    pub blocked_packages: usize,
+    pub packages_requiring_attention: usize,
+    pub next_check_kind: Option<IntegrationMeshReleaseReadinessCheckKind>,
+    pub next_check_status: Option<IntegrationMeshReleaseReadinessStatus>,
+    pub next_check_sequence: Option<usize>,
+    pub first_blocked_check_sequence: Option<usize>,
+    pub first_review_check_sequence: Option<usize>,
+    pub first_operator_check_sequence: Option<usize>,
+    pub next_package_kind: Option<IntegrationMeshReadinessHandoffKind>,
+    pub next_handoff_status: Option<IntegrationMeshReadinessHandoffStatus>,
+    pub substrate_actions_ready: bool,
+    pub release_ready: bool,
+    pub ready_for_handoff: bool,
+    pub release_packet_ready: bool,
+}
+
+impl IntegrationMeshReleaseReadinessCheckSummary {
+    pub fn from_parts<'a>(
+        handoff_summary: IntegrationMeshReadinessHandoffSummary,
+        checks: impl IntoIterator<Item = &'a IntegrationMeshReleaseReadinessCheck>,
+    ) -> Self {
+        let checks = checks.into_iter().collect::<Vec<_>>();
+        let ready_for_handoff = handoff_summary.ready_for_handoff();
+        let mut summary = Self {
+            queued_substrate_actions: handoff_summary.queued_substrate_actions,
+            queued_stage_count: handoff_summary.queued_stage_count,
+            queued_primitive_count: handoff_summary.queued_primitive_count,
+            remediation_item_count: handoff_summary.remediation_item_count,
+            review_required_packages: handoff_summary.review_required_packages,
+            operator_required_packages: handoff_summary.operator_required_packages,
+            blocked_packages: handoff_summary.blocked_packages,
+            packages_requiring_attention: handoff_summary.packages_requiring_attention,
+            next_package_kind: handoff_summary.next_package_kind,
+            next_handoff_status: handoff_summary.next_handoff_status,
+            substrate_actions_ready: handoff_summary.substrate_actions_ready,
+            release_ready: handoff_summary.release_ready,
+            ready_for_handoff,
+            release_packet_ready: ready_for_handoff,
+            handoff_summary,
+            total_checks: 0,
+            ready_checks: 0,
+            blocked_checks: 0,
+            review_required_checks: 0,
+            operator_required_checks: 0,
+            checks_requiring_attention: 0,
+            next_check_kind: None,
+            next_check_status: None,
+            next_check_sequence: None,
+            first_blocked_check_sequence: None,
+            first_review_check_sequence: None,
+            first_operator_check_sequence: None,
+        };
+
+        for check in checks {
+            summary.total_checks += 1;
+
+            if check.ready() {
+                summary.ready_checks += 1;
+            }
+            if check.blocked() {
+                summary.blocked_checks += 1;
+                summary.first_blocked_check_sequence = summary
+                    .first_blocked_check_sequence
+                    .or(Some(check.sequence));
+            }
+            if check.review_required() {
+                summary.review_required_checks += 1;
+                summary.first_review_check_sequence =
+                    summary.first_review_check_sequence.or(Some(check.sequence));
+            }
+            if check.operator_required() {
+                summary.operator_required_checks += 1;
+                summary.first_operator_check_sequence = summary
+                    .first_operator_check_sequence
+                    .or(Some(check.sequence));
+            }
+            if check.requires_attention() {
+                summary.checks_requiring_attention += 1;
+            }
+
+            if summary.next_check_sequence.is_none() && check.requires_attention() {
+                summary.next_check_kind = Some(check.check_kind);
+                summary.next_check_status = Some(check.status);
+                summary.next_check_sequence = Some(check.sequence);
+            }
+        }
+
+        summary
+    }
+
+    pub fn has_blockers(&self) -> bool {
+        self.blocked_checks > 0 || self.handoff_summary.has_blockers()
+    }
+
+    pub fn has_review_work(&self) -> bool {
+        self.review_required_checks > 0 || self.handoff_summary.has_review_work()
+    }
+
+    pub fn requires_attention(&self) -> bool {
+        self.checks_requiring_attention > 0
+            || self.has_blockers()
+            || self.has_review_work()
+            || !self.release_packet_ready
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct IntegrationCatalogEntry {
     pub integration_id: IntegrationId,
@@ -21947,6 +22197,161 @@ pub fn mesh_readiness_handoff_summary(
     )
 }
 
+fn mesh_release_packet_status(
+    summary: &IntegrationMeshReadinessHandoffSummary,
+) -> IntegrationMeshReleaseReadinessStatus {
+    if summary.ready_for_handoff() {
+        IntegrationMeshReleaseReadinessStatus::Ready
+    } else if summary.has_blockers() {
+        IntegrationMeshReleaseReadinessStatus::Blocked
+    } else if summary.has_review_work() || summary.requires_attention() {
+        IntegrationMeshReleaseReadinessStatus::NeedsReview
+    } else {
+        IntegrationMeshReleaseReadinessStatus::Blocked
+    }
+}
+
+fn mesh_release_readiness_checks_from_summary(
+    summary: &IntegrationMeshReadinessHandoffSummary,
+) -> Vec<IntegrationMeshReleaseReadinessCheck> {
+    let substrate_status = if summary.substrate_actions_ready {
+        IntegrationMeshReleaseReadinessStatus::Ready
+    } else {
+        IntegrationMeshReleaseReadinessStatus::Blocked
+    };
+    let evidence_status = if summary.remediation_item_count == 0 {
+        IntegrationMeshReleaseReadinessStatus::Ready
+    } else if summary.review_required_packages > 0 {
+        IntegrationMeshReleaseReadinessStatus::NeedsReview
+    } else {
+        IntegrationMeshReleaseReadinessStatus::Blocked
+    };
+    let human_review_status = if summary.review_required_packages == 0 {
+        IntegrationMeshReleaseReadinessStatus::Ready
+    } else {
+        IntegrationMeshReleaseReadinessStatus::NeedsReview
+    };
+    let operator_status = if summary.operator_required_packages == 0 {
+        IntegrationMeshReleaseReadinessStatus::Ready
+    } else if summary.blocked_packages > 0 {
+        IntegrationMeshReleaseReadinessStatus::Blocked
+    } else {
+        IntegrationMeshReleaseReadinessStatus::NeedsReview
+    };
+    let release_packet_status = mesh_release_packet_status(summary);
+
+    vec![
+        IntegrationMeshReleaseReadinessCheck::from_summary(
+            1,
+            IntegrationMeshReleaseReadinessCheckKind::SubstrateActions,
+            substrate_status,
+            Some(IntegrationMeshReadinessHandoffKind::SubstrateAction),
+            Some(substrate_status.as_handoff_status()),
+            summary,
+            !summary.substrate_actions_ready,
+        ),
+        IntegrationMeshReleaseReadinessCheck::from_summary(
+            2,
+            IntegrationMeshReleaseReadinessCheckKind::EvidenceRemediation,
+            evidence_status,
+            Some(IntegrationMeshReadinessHandoffKind::EvidenceRemediation),
+            Some(evidence_status.as_handoff_status()),
+            summary,
+            summary.remediation_item_count > 0,
+        ),
+        IntegrationMeshReleaseReadinessCheck::from_summary(
+            3,
+            IntegrationMeshReleaseReadinessCheckKind::HumanReview,
+            human_review_status,
+            Some(IntegrationMeshReadinessHandoffKind::EvidenceRemediation),
+            Some(human_review_status.as_handoff_status()),
+            summary,
+            false,
+        ),
+        IntegrationMeshReleaseReadinessCheck::from_summary(
+            4,
+            IntegrationMeshReleaseReadinessCheckKind::OperatorHandoff,
+            operator_status,
+            summary.next_package_kind,
+            summary
+                .next_handoff_status
+                .or(Some(operator_status.as_handoff_status())),
+            summary,
+            summary.operator_required_packages > 0,
+        ),
+        IntegrationMeshReleaseReadinessCheck::from_summary(
+            5,
+            IntegrationMeshReleaseReadinessCheckKind::ReleasePacket,
+            release_packet_status,
+            Some(IntegrationMeshReadinessHandoffKind::ReleaseReady),
+            Some(release_packet_status.as_handoff_status()),
+            summary,
+            !summary.ready_for_handoff() && summary.operator_required_packages > 0,
+        ),
+    ]
+}
+
+pub fn mesh_release_readiness_checks_for_catalog(
+    catalog: &[IntegrationCatalogEntry],
+    available_primitives: &[PrimitiveFamily],
+    allowed_capabilities: &[CapabilityId],
+    enabled_integrations: &[IntegrationId],
+) -> Vec<IntegrationMeshReleaseReadinessCheck> {
+    let summary = mesh_readiness_handoff_summary_for_catalog(
+        catalog,
+        available_primitives,
+        allowed_capabilities,
+        enabled_integrations,
+    );
+
+    mesh_release_readiness_checks_from_summary(&summary)
+}
+
+pub fn mesh_release_readiness_checks(
+    available_primitives: &[PrimitiveFamily],
+    allowed_capabilities: &[CapabilityId],
+    enabled_integrations: &[IntegrationId],
+) -> Vec<IntegrationMeshReleaseReadinessCheck> {
+    let catalog = first_party_catalog();
+    mesh_release_readiness_checks_for_catalog(
+        &catalog,
+        available_primitives,
+        allowed_capabilities,
+        enabled_integrations,
+    )
+}
+
+pub fn mesh_release_readiness_check_summary_for_catalog(
+    catalog: &[IntegrationCatalogEntry],
+    available_primitives: &[PrimitiveFamily],
+    allowed_capabilities: &[CapabilityId],
+    enabled_integrations: &[IntegrationId],
+) -> IntegrationMeshReleaseReadinessCheckSummary {
+    let handoff_summary = mesh_readiness_handoff_summary_for_catalog(
+        catalog,
+        available_primitives,
+        allowed_capabilities,
+        enabled_integrations,
+    );
+    let checks = mesh_release_readiness_checks_from_summary(&handoff_summary);
+
+    IntegrationMeshReleaseReadinessCheckSummary::from_parts(handoff_summary, checks.iter())
+}
+
+pub fn mesh_release_readiness_check_summary(
+    available_primitives: &[PrimitiveFamily],
+    allowed_capabilities: &[CapabilityId],
+    enabled_integrations: &[IntegrationId],
+) -> IntegrationMeshReleaseReadinessCheckSummary {
+    let catalog = first_party_catalog();
+    mesh_release_readiness_check_summary_for_catalog(
+        &catalog,
+        available_primitives,
+        allowed_capabilities,
+        enabled_integrations,
+    )
+}
+
 fn mesh_protocol_catalog_entries(
     catalog: &[IntegrationCatalogEntry],
 ) -> Vec<IntegrationCatalogEntry> {
@@ -28927,6 +29332,165 @@ mod tests {
         );
         assert!(package.ready_for_handoff());
         assert!(!package.operator_required());
+    }
+
+    #[test]
+    fn mesh_release_readiness_checks_surface_blocked_release_gates() {
+        let available_primitives = vec![
+            PrimitiveFamily::Usb,
+            PrimitiveFamily::SerialController,
+            PrimitiveFamily::Radio802154,
+            PrimitiveFamily::Supervision,
+        ];
+        let allowed_capabilities = vec![CapabilityId::trusted("smart_home.read")];
+        let checks =
+            mesh_release_readiness_checks(&available_primitives, &allowed_capabilities, &[]);
+        let summary =
+            mesh_release_readiness_check_summary(&available_primitives, &allowed_capabilities, &[]);
+
+        assert_eq!(checks.len(), 5);
+        assert_eq!(summary.total_checks, 5);
+        assert_eq!(summary.ready_checks, 0);
+        assert_eq!(summary.blocked_checks, 3);
+        assert_eq!(summary.review_required_checks, 2);
+        assert_eq!(summary.operator_required_checks, 4);
+        assert_eq!(summary.checks_requiring_attention, 5);
+        assert_eq!(summary.next_check_sequence, Some(1));
+        assert_eq!(
+            summary.next_check_kind,
+            Some(IntegrationMeshReleaseReadinessCheckKind::SubstrateActions)
+        );
+        assert_eq!(
+            summary.next_check_status,
+            Some(IntegrationMeshReleaseReadinessStatus::Blocked)
+        );
+        assert_eq!(summary.first_blocked_check_sequence, Some(1));
+        assert_eq!(summary.first_review_check_sequence, Some(2));
+        assert_eq!(summary.first_operator_check_sequence, Some(1));
+        assert_eq!(
+            summary.next_package_kind,
+            Some(IntegrationMeshReadinessHandoffKind::SubstrateAction)
+        );
+        assert_eq!(
+            summary.next_handoff_status,
+            Some(IntegrationMeshReadinessHandoffStatus::Blocked)
+        );
+        assert_eq!(summary.queued_substrate_actions, 5);
+        assert_eq!(summary.remediation_item_count, 2);
+        assert!(!summary.substrate_actions_ready);
+        assert!(!summary.release_ready);
+        assert!(!summary.ready_for_handoff);
+        assert!(!summary.release_packet_ready);
+        assert!(summary.has_blockers());
+        assert!(summary.has_review_work());
+        assert!(summary.requires_attention());
+
+        let substrate = &checks[0];
+        assert_eq!(
+            substrate.check_kind,
+            IntegrationMeshReleaseReadinessCheckKind::SubstrateActions
+        );
+        assert_eq!(
+            substrate.status,
+            IntegrationMeshReleaseReadinessStatus::Blocked
+        );
+        assert_eq!(
+            substrate.package_kind,
+            Some(IntegrationMeshReadinessHandoffKind::SubstrateAction)
+        );
+        assert_eq!(
+            substrate.handoff_status,
+            Some(IntegrationMeshReadinessHandoffStatus::Blocked)
+        );
+        assert!(substrate.blocked());
+        assert!(substrate.operator_required());
+        assert!(substrate.requires_attention());
+
+        let evidence = &checks[1];
+        assert_eq!(
+            evidence.check_kind,
+            IntegrationMeshReleaseReadinessCheckKind::EvidenceRemediation
+        );
+        assert_eq!(
+            evidence.status,
+            IntegrationMeshReleaseReadinessStatus::NeedsReview
+        );
+        assert!(evidence.review_required());
+        assert!(evidence.operator_required());
+
+        let release_packet = &checks[4];
+        assert_eq!(
+            release_packet.check_kind,
+            IntegrationMeshReleaseReadinessCheckKind::ReleasePacket
+        );
+        assert_eq!(
+            release_packet.status,
+            IntegrationMeshReleaseReadinessStatus::Blocked
+        );
+        assert_eq!(
+            release_packet.package_kind,
+            Some(IntegrationMeshReadinessHandoffKind::ReleaseReady)
+        );
+    }
+
+    #[test]
+    fn mesh_release_readiness_checks_mark_release_packet_ready() {
+        let catalog = vec![hue_entry()];
+        let allowed_capabilities = vec![
+            CapabilityId::trusted("smart_home.read"),
+            CapabilityId::trusted("smart_home.command.light"),
+            CapabilityId::trusted("smart_home.pair"),
+        ];
+        let checks = mesh_release_readiness_checks_for_catalog(
+            &catalog,
+            all_primitive_families(),
+            &allowed_capabilities,
+            &[],
+        );
+        let summary = mesh_release_readiness_check_summary_for_catalog(
+            &catalog,
+            all_primitive_families(),
+            &allowed_capabilities,
+            &[],
+        );
+
+        assert_eq!(checks.len(), 5);
+        assert_eq!(summary.total_checks, 5);
+        assert_eq!(summary.ready_checks, 5);
+        assert_eq!(summary.blocked_checks, 0);
+        assert_eq!(summary.review_required_checks, 0);
+        assert_eq!(summary.operator_required_checks, 0);
+        assert_eq!(summary.checks_requiring_attention, 0);
+        assert_eq!(summary.next_check_kind, None);
+        assert_eq!(summary.first_blocked_check_sequence, None);
+        assert_eq!(
+            summary.next_package_kind,
+            Some(IntegrationMeshReadinessHandoffKind::ReleaseReady)
+        );
+        assert_eq!(
+            summary.next_handoff_status,
+            Some(IntegrationMeshReadinessHandoffStatus::Ready)
+        );
+        assert_eq!(summary.queued_substrate_actions, 0);
+        assert_eq!(summary.remediation_item_count, 0);
+        assert!(summary.substrate_actions_ready);
+        assert!(summary.release_ready);
+        assert!(summary.ready_for_handoff);
+        assert!(summary.release_packet_ready);
+        assert!(!summary.has_blockers());
+        assert!(!summary.has_review_work());
+        assert!(!summary.requires_attention());
+        assert!(checks
+            .iter()
+            .all(IntegrationMeshReleaseReadinessCheck::ready));
+        assert_eq!(
+            checks[4].check_kind,
+            IntegrationMeshReleaseReadinessCheckKind::ReleasePacket
+        );
+        assert_eq!(
+            checks[4].status,
+            IntegrationMeshReleaseReadinessStatus::Ready
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add catalog-owned mesh release-readiness checks and summary rollups over handoff/action/remediation state
- expose two read-only smart-home-core descriptors and D18D Chief tool handlers for release-readiness checks and summary
- update Chief end-to-end coverage and package docs/changelogs

## Validation
- cargo test -p smart-home-core
- cargo test -p smart-home-integration-catalog
- cargo test -p hue-core
- cargo test -p smart-home-runtime
- cargo test -p smart-home-testkit
- cargo test -p smart-home-local-http
- cargo test -p smart-home-discovery
- cargo test -p chief-of-staff-smart-home-tools
- cargo test -p smart-home-runtime discover_tool -- --nocapture
- sh BUILD in smart-home-core, smart-home-integration-catalog, hue-core, smart-home-runtime, smart-home-testkit, smart-home-local-http, smart-home-discovery, and chief-of-staff-smart-home-tools