### PR TITLE
feat(board): relation-faithfulness gate — close the offline-decompose residual

### DIFF
--- a/code/specs/data/mycin-2026/OFFLINE-BOARD-EXAM.md
+++ b/code/specs/data/mycin-2026/OFFLINE-BOARD-EXAM.md
@@ -49,15 +49,24 @@ faithfully answers the wrong question and returns a confident **wrong** answer. 
 live 4B demo did exactly this on ~5/27 stems before the gate (grounding kills
 *fabrication*, not *misdirection*).
 
-The fix is a **decomposition-faithfulness gate** (`decompose_query.attested_in_stem`):
-the chosen subject must be attested by the **stem's own bytes** — byte-provenance
-applied to the query, the same principle the whole framework rests on. A subject the
-question never names is rejected, so a mis-decomposition becomes an **abstention**
-instead of a wrong answer. With the gate, a weak model's errors show up as *more
-abstention*, not wrong answers — which is exactly what lets a small on-device model
-(Qwen-0.5B, Gemma-1B/4B) drive the board safely: the floor is honest "UNKNOWN", not
-hallucination. The reasoning is in the framework; the model is a translator on a short,
-*checked* leash.
+The fix is a **two-sided decomposition-faithfulness gate** — byte-provenance applied to
+the query, the same principle the whole framework rests on:
+
+- **subject gate** (`decompose_query.attested_in_stem`): the chosen entity must be
+  named by the stem. Rejects "Von Gierke disease" → subject `fabry`.
+- **relation gate** (`decompose_query.relation_attested_in_stem`): the stem's
+  interrogative must ASK for what the relation answers (cues derived from the relation
+  name + its conventional variable — `has_mcv`+`Class` → `{mcv, class}` — no new
+  hand-authored knowledge, whole-word matched). Rejects a stem asking for the classic
+  *finding* decomposed as `has_mcv(...)` — right subject, wrong question.
+
+Either gate failing rejects the query, so a mis-decomposition (wrong entity OR wrong
+question-type) becomes an **abstention** instead of a wrong answer. With both gates, a
+weak model's errors show up as *more abstention*, not wrong answers — on the recorded
+live runs **both Gemma-3-4B and Qwen-0.5B reach 0 wrong / 100% defensibility** (see
+board/OFFLINE-DEMO.md). That is exactly what lets a small on-device model drive the
+board safely: the floor is honest "UNKNOWN", not hallucination. The reasoning is in the
+framework; the model is a translator on a short, *checked* leash.
 
 ## Proving "no online call" instead of promising it
 

--- a/code/specs/data/mycin-2026/board/OFFLINE-DEMO.md
+++ b/code/specs/data/mycin-2026/board/OFFLINE-DEMO.md
@@ -58,16 +58,30 @@ pre-gate); the gate only converts a wrong answer into an abstention. It is the
 mechanism, not a claim: "no wrong answers" is enforced by checking the query against
 the source, exactly as the rest of the framework checks facts against grounded bytes.
 
-## The honest residual
+## The residual — now closed by the RELATION gate (REL-OFFLINE-2)
 
-The gate validates the **subject**, not the **relation**. Qwen2.5-0.5B's 2 remaining
-wrong answers are right-subject / wrong-relation: e.g. it asked `has_mcv(hereditary_
-spherocytosis)` for a stem about the classic *finding* — `hereditary_spherocytosis`
-**is** named in the stem (so it passes the subject gate), but `has_mcv` resolves to a
-real edge (`normocytic`) that isn't what the question asked. Gating the relation
-against the question's interrogative (what is being asked — an enzyme? a finding? a
-test?) is the clear next slice; it would close this gap without hand-authoring, by the
-same attestation principle.
+The subject gate alone left one gap: right-subject / **wrong-relation**. Qwen2.5-0.5B
+asked `has_mcv(hereditary_spherocytosis)` for a stem about the classic *finding* —
+`hereditary_spherocytosis` **is** named (so the subject gate passes), but `has_mcv`
+resolves to a real edge (`normocytic`) that isn't what the question asked → a confident
+wrong answer.
+
+The **relation gate** (`decompose_query.relation_attested_in_stem`) closes it: the
+stem's interrogative must contain a cue for the chosen relation (cues derived purely
+from the relation name + its conventional variable — `has_mcv` + `Class` →
+`{mcv, class}` — no new hand-authored knowledge; whole-word match so `class` is not
+found inside `classic`). Re-scoring the committed transcripts through both gates
+(deterministic — the gate is a pure function of the recorded `model_query` + stem):
+
+| model | recorded wrong | + relation gate |
+|---|---|---|
+| Gemma-3-4B-it | 0 | 19 correct · 8 abstained · **0 wrong** · 100% |
+| Qwen2.5-0.5B-it | 2 | 4 correct · 23 abstained · **0 wrong** · **100%** |
+
+Qwen's two `has_mcv`-on-finding errors (`ft_hs_finding`, `ft_g6pd_finding`) flip to
+abstentions; Gemma is unchanged (its mis-maps were already caught by the subject gate).
+**Both models now reach 0 wrong / 100% defensibility on the recorded runs** — a weak
+local model's errors are honest UNKNOWNs, never confident wrong answers.
 
 ## Caveats
 

--- a/code/specs/data/mycin-2026/board/decompose_query.py
+++ b/code/specs/data/mycin-2026/board/decompose_query.py
@@ -24,16 +24,24 @@ WHAT GROUNDING DOES AND DOES NOT PROTECT (an honest limit)
 The model's output is CONSTRAINED: the relation must be one of the legal recall
 relations and the subject a canonical entity. This buys ONE guarantee — the engine
 never fabricates a medical fact: every answer it returns cites a real grounded edge,
-and an OFF-vocabulary query (a subject the graph doesn't know) finds no edge and
-ABSTAINS. But it does NOT make decomposition errors free. If the model mis-maps the
-prose to a DIFFERENT but valid entity — "Von Gierke disease" → subject `fabry` — the
-engine faithfully answers the wrong question and returns a confident WRONG answer
-(correct-for-the-wrong-query). Measured on the live demo (see OFFLINE-DEMO.md), a 4B
-local model decomposes ~74% of stems correctly and the ~5/27 it mis-maps become wrong,
-not abstentions. So: grounding kills FABRICATION, not MISDIRECTION. The real mitigation
-is a decomposition-faithfulness gate — require the chosen subject to be attested by the
-stem's own bytes (byte-provenance applied to the query), turning a mis-map into an
-abstention. That is the next slice; today the pipeline reports the honest number.
+and an OFF-vocabulary query finds no edge and ABSTAINS. But grounding alone does NOT
+make decomposition errors free: a mis-map to a DIFFERENT but valid query makes the
+engine faithfully answer the WRONG question (correct-for-the-wrong-query). Grounding
+kills FABRICATION, not MISDIRECTION. So the decomposition itself is gated against the
+stem's own bytes — a TWO-SIDED faithfulness check, byte-provenance applied to the query:
+
+  * SUBJECT gate (attested_in_stem): the chosen entity must be named by the stem.
+    Stops "Von Gierke disease" → subject `fabry`.
+  * RELATION gate (relation_attested_in_stem): the stem's interrogative must ASK for
+    what the relation answers. Stops a stem asking for the classic FINDING being
+    decomposed as has_mcv(...) — right subject, wrong question.
+
+Either gate failing rejects the query, so the engine ABSTAINS rather than answering the
+wrong question. Measured on the live demo (see OFFLINE-DEMO.md): a 4B local model
+decomposes ~74% of stems correctly; with both gates every mis-decomposition (wrong
+entity OR wrong question-type) becomes an abstention, so a weak local model is SAFE —
+its errors are honest UNKNOWNs, never confident wrong answers (0 wrong / 100%
+defensible on the recorded runs for both the 4B and the 0.5B model).
 
 The model is fully INJECTABLE: `decompose(stem, gen, vocab)` takes any
 `gen(prompt) -> str`. Pass `local_gen(model_path)` for a real MLX model, or a stub in
@@ -182,17 +190,58 @@ def attested_in_stem(subject: str, stem: str) -> bool:
     return all(t in stem_tokens for t in tokens)
 
 
+# Structural tokens in a relation name carry no interrogative meaning (prepositions,
+# the domain tag "coag", the auxiliary "has") — they are not cues for "what is asked".
+_CUE_STOPWORDS = {"in", "as", "by", "of", "the", "a", "coag", "has"}
+
+
+def _relation_cues() -> dict[str, set]:
+    """Derive each relation's interrogative cue tokens from the controlled vocabulary
+    ALREADY in REL_VAR — the relation NAME's own word-parts plus its conventional
+    VARIABLE name. No new medical knowledge is authored: a relation's cues are literally
+    the words it is spelled with (deficient_in + Enzyme → {deficient, enzyme};
+    has_mcv + Class → {mcv, class}). This keeps the relation gate symmetric with the
+    subject gate — both are byte-provenance against the question, both read only the
+    vocabulary the decomposer was already given."""
+    cues: dict[str, set] = {}
+    for rel, var in REL_VAR.items():
+        tokens = set(rel.split("_")) | {var.lower()}
+        cues[rel] = {t for t in tokens if t not in _CUE_STOPWORDS}
+    return cues
+
+
+RELATION_CUES = _relation_cues()
+
+
+def relation_attested_in_stem(relation: str, stem: str) -> bool:
+    """Relation-faithfulness check: does the stem's interrogative actually ASK for what
+    this relation answers? True iff at least one of the relation's cue tokens (see
+    _relation_cues) appears as a whole word in the stem. This is the relation-side
+    counterpart of attested_in_stem: it stops a right-subject / wrong-relation
+    mis-decomposition (e.g. a stem asking for the classic FINDING of hereditary
+    spherocytosis, decomposed as has_mcv(...)) from resolving to a real-but-wrong edge.
+    The chosen relation that the stem does not ask for is rejected → the engine
+    ABSTAINS rather than answering the wrong question. Whole-word (not substring)
+    matching is deliberate so a cue like `class` is not spuriously found inside
+    `classic`."""
+    stem_tokens = set(_norm_text(stem).split())
+    return bool(RELATION_CUES.get(relation, set()) & stem_tokens)
+
+
 def decompose(stem: str, gen, vocab: dict, faithful: bool = True) -> dict | None:
     """Decompose one prose stem into a recall query using an injected text generator
     `gen(prompt) -> str` (a local MLX model, or a test stub). Returns the parsed query,
     or None when the model's output can't be parsed into a legal query OR (with
-    faithful=True, the default) when the chosen subject is not attested by the stem —
-    the faithfulness gate that converts a mis-decomposition into an honest abstention
-    rather than a wrong answer (see attested_in_stem)."""
+    faithful=True, the default) when the chosen SUBJECT or RELATION is not attested by
+    the stem. The two-sided faithfulness gate — subject (attested_in_stem) AND relation
+    (relation_attested_in_stem) — converts both kinds of mis-decomposition (wrong
+    entity, wrong question-type) into an honest abstention rather than a confident wrong
+    answer. Grounding stops fabrication; this gate stops misdirection."""
     q = parse_query(gen(build_query_prompt(stem, vocab)))
     if q is None:
         return None
-    if faithful and not attested_in_stem(q["subject"], stem):
+    if faithful and not (attested_in_stem(q["subject"], stem)
+                         and relation_attested_in_stem(q["relation"], stem)):
         return None
     return q
 

--- a/code/specs/data/mycin-2026/board/test_board_offline.py
+++ b/code/specs/data/mycin-2026/board/test_board_offline.py
@@ -122,6 +122,45 @@ def test_faithfulness_gate_turns_misdecomposition_into_abstention() -> None:
         "relation": "deficient_in", "subject": "fabry", "var": "Enzyme"}
 
 
+def test_relation_cues_derive_only_from_controlled_vocab() -> None:
+    # Cues are the relation name's word-parts + its conventional variable — no new
+    # medical knowledge, just the words the relation is already spelled with.
+    assert dq.RELATION_CUES["has_mcv"] == {"mcv", "class"}
+    assert dq.RELATION_CUES["classic_finding"] == {"classic", "finding"}
+    assert dq.RELATION_CUES["deficient_in"] == {"deficient", "enzyme"}  # structural "in" dropped
+
+
+def test_relation_gate_attests_interrogative() -> None:
+    # The stem must ASK for what the relation answers (whole-word cue match).
+    assert dq.relation_attested_in_stem("classic_finding", "What is the classic smear finding?")
+    # has_mcv is NOT what a finding question asks — and 'class' must not match inside 'classic'.
+    assert not dq.relation_attested_in_stem("has_mcv", "What is the classic peripheral-smear finding?")
+    assert dq.relation_attested_in_stem("has_mcv", "What MCV class is iron deficiency anemia?")
+
+
+def test_relation_gate_turns_wrong_relation_into_abstention() -> None:
+    # The documented residual: right subject, WRONG relation (has_mcv on a finding stem)
+    # resolved to a real-but-wrong edge. The relation gate rejects it → abstain.
+    stem = "A patient with hereditary spherocytosis. What is the classic peripheral-smear finding?"
+    vocab = dq.build_vocab()
+    wrong_rel = lambda _p: ('{"relation": "has_mcv", "subject": "hereditary_spherocytosis", '  # noqa: E731
+                            '"var": "Class"}')
+    assert dq.decompose(stem, wrong_rel, vocab, faithful=True) is None
+    # The correct relation for that stem is attested and passes.
+    right_rel = lambda _p: ('{"relation": "classic_finding", "subject": "hereditary_spherocytosis", '  # noqa: E731
+                            '"var": "Finding"}')
+    assert dq.decompose(stem, right_rel, vocab, faithful=True) == {
+        "relation": "classic_finding", "subject": "hereditary_spherocytosis", "var": "Finding"}
+
+
+def test_every_gold_query_passes_both_gates() -> None:
+    # No gold query may be false-rejected by either gate (subject AND relation attested).
+    for it in _items():
+        q, stem = it["query"], it["stem"]
+        assert dq.attested_in_stem(q["subject"], stem), f"subject gate false-rejects {it['id']}"
+        assert dq.relation_attested_in_stem(q["relation"], stem), f"relation gate false-rejects {it['id']}"
+
+
 # ---- 3. end-to-end offline scoring --------------------------------------------
 
 def _items():


### PR DESCRIPTION
## What

Closes the documented honest residual from the offline board-exam pipeline ([#6187](https://github.com/adhithyan15/coding-adventures/pull/6187)): right-subject / **wrong-relation** mis-decompositions. The subject gate stopped a model picking a different *entity*; this adds the symmetric **relation gate** so a model picking the wrong *question-type* also degrades to an honest abstention instead of a confident wrong answer.

## The gap

A weak local model (Qwen2.5-0.5B) asked `has_mcv(hereditary_spherocytosis)` for a stem about the classic **finding**. The subject is named in the stem (so the subject gate passes), but `has_mcv` resolves to a *real-but-wrong* edge (`normocytic`) — grounding stops fabrication, not **misdirection**.

## The fix

`decompose_query.relation_attested_in_stem(relation, stem)` — byte-provenance on the query's relation, symmetric with the subject gate. The stem's interrogative must contain a cue for the chosen relation (whole-word matched, so `class` isn't found inside `classic`). **Cues are derived purely from the controlled vocabulary already in `REL_VAR`** — the relation name's word-parts + its conventional variable (`has_mcv`+`Class` → `{mcv, class}`; `classic_finding` → `{classic, finding}`). No new hand-authored medical knowledge. `decompose(..., faithful=True)` now requires **both** gates.

## Effect (deterministic re-score of the committed demo transcripts — the gate is a pure function of the recorded `model_query` + stem, no MLX re-run)

| model | recorded wrong | + relation gate |
|---|---|---|
| Gemma-3-4B-it | 0 | 19✓ · 8· · **0 wrong** · 100% (unchanged — its mis-maps were already subject-gated) |
| Qwen2.5-0.5B-it | 2 | 4✓ · 23· · **0 wrong** · **100%** (its 2 `has_mcv`-on-finding errors flip to abstain) |

**Both models now reach 0 wrong / 100% defensibility** on the recorded runs — a weak local model's errors are honest UNKNOWNs, never confident wrong answers.

## Scope / safety

- No cached-mode or scorecard change: all 27 gold queries pass both gates (a new test pins this); cached mode uses gold queries directly. `board_offline` cached stays **25✓ · 2· · 0 wrong · 0 online calls**.
- The gate is strictly *more* restrictive (rejects more → engine abstains) — it can never turn an abstention into a wrong answer.

## Verification

- `test_board_offline.py` **18/18** (+4: cue derivation, relation attestation, wrong-relation→abstain, every-gold-passes-both-gates).
- Security review **PASSED** (pure set/string gate; no new I/O/eval/network; `_norm_text` regex is linear, no ReDoS).
- Docs updated: `decompose_query` docstring, `board/OFFLINE-DEMO.md` (residual closed + re-score table), `OFFLINE-BOARD-EXAM.md` spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)