### PR TITLE
feat(closure-pass-inline): inline tail-return void helpers (CLOC15 PR-2)

### DIFF
--- a/code/packages/rust/closure-pass-inline/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-inline/CHANGELOG.md
@@ -2,6 +2,56 @@
 
 All notable changes to the `coding-adventures-closure-pass-inline` crate will be documented in this file.
 
+## [0.6.0] - 2026-06-18
+
+### Added (CLOC15 PR-2 — tail `return` with a discarded result)
+
+The void statement-helper inliner (PR-1) now admits an **optional trailing
+`return`** as the body's final statement. Because the call site discards
+the result (the use is a statement call, not a value), the returned value
+is never read, so the tail return is normalized for the splice:
+
+```js
+function init(n) { setup(n); return ready(); }
+init(cfg);
+// SIMPLE  ⇒  setup(cfg); ready();
+//   (the tail `return ready()` is kept as `ready();` for its side effect;
+//    the dead declaration is then removed by remove-unused-vars/treeshake)
+```
+
+`normalize_tail_return`:
+
+- `return;` (no argument) → **dropped** (a no-op once the value is discarded);
+- `return E;` where `E` is **provably inert** — a literal, or a bare read
+  of a parameter / callee-local (a binding that always exists, so the read
+  neither throws nor has a side effect) → **dropped**;
+- `return E;` otherwise → rewritten to `E;` (an `ExpressionStatement`), so
+  `E` is still evaluated for its side effects with the value discarded —
+  exactly what the original function did before returning.
+
+A bare *global* identifier (`return glob`) is deliberately **not** dropped:
+reading an undeclared global throws `ReferenceError`, which must be
+preserved as `glob;`.
+
+This also unlocks a shape the expression inliner cannot reach — a body that
+is a single `return g()` where `g` is a free global: the expression inliner
+requires every identifier to be a parameter, but the discarded-statement
+splice turns `f();` into `g();`.
+
+Soundness rests on the **tail** restriction: a `return` anywhere but the
+final position would change control flow when spliced (the caller's
+following statements would still run), so an early `return` is a hard
+reject — the body must be straight-line to the optional tail return.
+
+- 6 new pass tests (literal/bare/param-identifier dropped, effectful call
+  kept as `E;`, single-`return`-of-free-global splice, free-global
+  identifier kept, early-`return` declined).
+- Two closurec fixtures (`simple_dce_drops_dead_after_return`,
+  `advanced-rename-globals`) updated: their helpers are now called twice so
+  they survive the single-use statement-inliner, preserving each test's
+  original intent (observing DCE-after-return / ADVANCED renaming a
+  *surviving* top-level function) rather than collapsing away.
+
 ## [0.5.0] - 2026-06-18
 
 ### Added (CLOC15 PR-1 — void multi-statement statement-helper inlining)

--- a/code/packages/rust/closure-pass-inline/Cargo.toml
+++ b/code/packages/rust/closure-pass-inline/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-inline"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 description = "Function-inlining pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Substitutes small or single-use function bodies at their call sites to enable downstream folding and shrink call overhead."
 

--- a/code/packages/rust/closure-pass-inline/README.md
+++ b/code/packages/rust/closure-pass-inline/README.md
@@ -117,10 +117,11 @@ structurally cannot do. It is admitted only under a tight, sound subset
 
 1. **Single-use, single-declaration** — name declared once, used once.
 2. **The use is a discarded statement call** (`track(…);`), not a value
-   position (`x = track(…)`). No result to capture (capture is a later
-   slice).
-3. **Straight-line body, no `return`** — each statement is an expression
-   statement or a `let`/`const` declaration; nothing else.
+   position (`x = track(…)`). No result to capture (value capture is a
+   later slice).
+3. **Straight-line body to an optional tail `return`** — each statement is
+   an expression statement or a `let`/`const` declaration, plus an optional
+   `return` as the *final* statement; nothing else (no *early* return).
 4. **No `this` / `arguments`** — frame-bound, would rebind on a splice.
 5. **Callee locals alpha-renamed to program-fresh names** before
    splicing — a spliced `let e` can never collide with the call-site
@@ -130,11 +131,24 @@ structurally cannot do. It is admitted only under a tight, sound subset
    slice widens it via `closure-scope-analyzer`).
 7. **Side-effect-free arguments** — the same `is_simple_arg` gate.
 
+Since the call site discards the result (CLOC15 PR-2), a **tail `return E`**
+is normalized: dropped when `E` is provably inert (a literal or a bare
+parameter/local read), else kept as `E;` for its side effects. A bare
+*global* read is kept (it can throw `ReferenceError`). This also reaches a
+shape the expression inliner cannot — a single `return g()` with a free
+global `g` becomes `g();`.
+
+```js
+function init(n) { setup(n); return ready(); }
+init(cfg);
+// SIMPLE  ⇒  setup(cfg); ready();
+```
+
 An unbraced single-statement slot (`if (c) f();`) gets the spliced body
 wrapped in a block; a real statement list is spliced flat. Later slices
-(tail `return`, value capture, `var` locals, `if`, multi-use) build on
-this same walker. As with the expression path, the now-dead declaration
-is left for `remove-unused-vars` / `treeshake`.
+(value capture into a hoisted temp, `var` locals, `if`, multi-use) build on
+this same walker. As with the expression path, the now-dead declaration is
+left for `remove-unused-vars` / `treeshake`.
 
 ## Where this pass sits
 

--- a/code/packages/rust/closure-pass-inline/src/lib.rs
+++ b/code/packages/rust/closure-pass-inline/src/lib.rs
@@ -1164,12 +1164,19 @@ fn substitute(expr: &mut Expression, map: &HashMap<String, Expression>) {
 //   2. **The one use is a discarded statement call** — the call is the
 //      entire expression of an `ExpressionStatement` (`track(…);`), not a
 //      value (`x = track(…)`, `log(track(…))`). A discarded result means
-//      there is no return value to capture (that is PR-2/PR-3).
-//   3. **The body is straight-line, no `return`.** Each statement is an
-//      `ExpressionStatement` or a `let` / `const` `VariableDeclaration` —
-//      nothing else (no `return`, `if`, loops, `var`, nested blocks, …).
-//      No control construct means a flat splice cannot mis-scope control
-//      flow; no `var` means no function-scoped hoisting to reason about.
+//      there is no return value to *capture* (capturing a used result is
+//      PR-3); a discarded TAIL return, however, can be inlined (PR-2).
+//   3. **The body is straight-line to an optional tail `return`.** Each
+//      statement is an `ExpressionStatement` or a `let` / `const`
+//      `VariableDeclaration`, plus an OPTIONAL `return` as the FINAL
+//      statement — nothing else (no *early* `return`, no `if`, loops,
+//      `var`, nested blocks, …). No mid-body control construct means a
+//      flat splice cannot mis-scope control flow; no `var` means no
+//      function-scoped hoisting to reason about. Because the call site
+//      discards the result, a tail `return E` is normalized by
+//      [`normalize_tail_return`]: dropped when `E` is provably inert (a
+//      literal or a bare parameter/local read), else kept as `E;` for its
+//      side effects.
 //   4. **No `this` / `arguments`.** Their meaning is bound by the callee's
 //      own call frame; splicing into the caller would silently rebind
 //      them. Rejected explicitly.
@@ -1194,9 +1201,9 @@ fn substitute(expr: &mut Expression, map: &HashMap<String, Expression>) {
 //      locals an argument identifier could be captured by are all fresh.
 //
 // Everything outside this subset is left untouched. Broader shapes
-// (tail-`return` with a discarded or captured result, `var` locals, `if`,
-// non-simple arguments, multi-use under a budget) are the later CLOC15
-// slices on this same walker.
+// (a tail return whose result is *captured* into a hoisted temp, `var`
+// locals, `if`, non-simple arguments, multi-use under a budget) are the
+// later CLOC15 slices on this same walker.
 
 /// One inlinable void multi-statement helper: its name, parameter names in
 /// order, the body statements to splice, and the set of local binding
@@ -1291,12 +1298,22 @@ fn void_candidate_from_function(
         params.push(id.name.clone());
     }
 
-    // (3) Body shape: each statement is an `ExpressionStatement` or a
-    // `let`/`const` `VariableDeclaration`. No `return`, no control flow, no
-    // `var`, no nested blocks. We also collect the local binding names.
+    // (3) Body shape: each statement is an `ExpressionStatement`, a
+    // `let`/`const` `VariableDeclaration`, or — CLOC15 PR-2 — an optional
+    // `return` as the FINAL statement. No early return, no other control
+    // flow, no `var`, no nested blocks. We also collect the local binding
+    // names.
+    //
+    // A tail `return E` is sound here precisely because the call site
+    // discards the result (condition 2): the returned value is never read,
+    // so the splice can drop it (or keep `E;` for its side effects — see
+    // [`normalize_tail_return`]). A `return` anywhere but the last position
+    // would change control flow when spliced (the caller's following
+    // statements would still run), so it is rejected.
     let mut locals: Vec<String> = Vec::new();
     let mut local_set: HashSet<String> = HashSet::new();
-    for stmt in &fd.body.body {
+    let last_index = fd.body.body.len().wrapping_sub(1);
+    for (i, stmt) in fd.body.body.iter().enumerate() {
         match stmt {
             Statement::Tagged(TaggedStatement::ExpressionStatement(_)) => {}
             Statement::Declaration(Declaration::VariableDeclaration(vd)) => {
@@ -1312,9 +1329,12 @@ fn void_candidate_from_function(
                     local_set.insert(id.name.clone());
                 }
             }
-            // Anything else (return, if, while, for, throw, break,
+            // A `return` is admitted ONLY in the final (tail) position;
+            // anywhere earlier it would alter control flow on splice.
+            Statement::Tagged(TaggedStatement::ReturnStatement(_)) if i == last_index => {}
+            // Anything else (early `return`, if, while, for, throw, break,
             // continue, switch, labeled, empty, nested block, a nested
-            // function declaration) is outside the first slice.
+            // function declaration) is outside this slice.
             _ => return None,
         }
     }
@@ -1566,7 +1586,8 @@ fn splice_void_in_decl(
 }
 
 /// Build the statement list to splice in for one call site: a clone of the
-/// body with (a) callee locals alpha-renamed to program-fresh names, then
+/// body with (0) the tail `return` normalized (the result is discarded),
+/// then (a) callee locals alpha-renamed to program-fresh names, then
 /// (b) parameters substituted by their (simple) arguments. Newly minted
 /// fresh names are added to `avoid` so a second splice cannot reuse them.
 fn build_spliced_body(
@@ -1576,6 +1597,13 @@ fn build_spliced_body(
     nodes_touched: &mut u32,
 ) -> Vec<Statement> {
     let mut body = cand.body.clone();
+
+    // (0) Normalize a tail `return E` for the discarded-result call site.
+    // Done first, while the names are still the callee's own, so the
+    // membership test in [`is_drop_safe_return`] sees the original param /
+    // local names; the resulting `E;` (if kept) is then renamed and
+    // substituted by steps (a)/(b) like any other expression statement.
+    normalize_tail_return(&mut body, cand);
 
     // (a) Alpha-rename callee locals → fresh. Renaming the binding *and*
     // every in-body use of it makes a spliced `let event` collision-proof
@@ -1611,6 +1639,66 @@ fn build_spliced_body(
 
     *nodes_touched += body.len() as u32;
     body
+}
+
+/// Normalize a tail `return` for a discarded-result splice (CLOC15 PR-2).
+/// The call site discards the value, so the returned expression is never
+/// read:
+///
+/// - `return;` (no argument) → dropped entirely (a no-op).
+/// - `return E;` where `E` is **provably inert** (a literal, or a bare read
+///   of a parameter / callee-local — a binding that always exists, so the
+///   read neither throws nor has a side effect) → dropped.
+/// - `return E;` otherwise → rewritten to `E;` (an `ExpressionStatement`),
+///   so `E` is still evaluated for its side effects and the value is
+///   discarded — exactly what the original function did before returning.
+///
+/// A bare *global* identifier is deliberately NOT dropped: reading an
+/// undeclared global throws `ReferenceError`, which we must preserve.
+fn normalize_tail_return(body: &mut Vec<Statement>, cand: &VoidStmtCandidate) {
+    let is_tail_return = matches!(
+        body.last(),
+        Some(Statement::Tagged(TaggedStatement::ReturnStatement(_)))
+    );
+    if !is_tail_return {
+        return;
+    }
+    // Pop the tail return; conditionally push back its argument as a plain
+    // expression statement (kept for side effects) unless it is droppable.
+    let Some(Statement::Tagged(TaggedStatement::ReturnStatement(rs))) = body.pop() else {
+        return;
+    };
+    match rs.argument {
+        None => {}                                     // bare return: drop
+        Some(e) if is_drop_safe_return(&e, cand) => {} // inert value: drop
+        Some(e) => body.push(Statement::Tagged(TaggedStatement::ExpressionStatement(
+            ExpressionStatement {
+                cv: None,
+                expression: e,
+            },
+        ))),
+    }
+}
+
+/// Is the discarded return value `e` provably inert — safe to drop rather
+/// than keep as `E;`? True for a literal (no side effect, never throws) or
+/// a bare read of a parameter / callee-local (the binding always exists, so
+/// the read neither throws a `ReferenceError` nor has a side effect). A free
+/// global identifier is NOT inert (an undeclared read throws), nor is any
+/// member access / call / operator (possible getter / throw / side effect).
+fn is_drop_safe_return(e: &Expression, cand: &VoidStmtCandidate) -> bool {
+    match e {
+        Expression::NumericLiteral(_)
+        | Expression::StringLiteral(_)
+        | Expression::BooleanLiteral(_)
+        | Expression::NullLiteral(_)
+        | Expression::BigIntLiteral(_)
+        | Expression::UndefinedLiteral(_) => true,
+        Expression::Identifier(id) => {
+            cand.params.contains(&id.name) || cand.locals.contains(&id.name)
+        }
+        _ => false,
+    }
 }
 
 // ---- statement-level rename (callee-local alpha-renaming) -----------------
@@ -2351,12 +2439,76 @@ mod tests {
         );
     }
 
+    // ----- CLOC15 PR-2: tail `return` with a discarded result -----
+
     #[test]
-    fn does_not_inline_void_helper_with_tail_return() {
-        // A trailing `return` is PR-2, not PR-1 — declined here.
+    fn inlines_tail_return_literal_dropped() {
+        // The call discards the result, so a tail `return <literal>` is
+        // provably inert and dropped entirely; the rest splices as usual.
         assert_eq!(
             inline_source("function f(x) { sink(x); return 1; } f(a);"),
-            "function f(x){sink(x);return 1};f(a);"
+            "function f(x){sink(x);return 1};sink(a);"
+        );
+    }
+
+    #[test]
+    fn inlines_tail_bare_return_dropped() {
+        // A bare `return;` is a no-op once the value is discarded — dropped.
+        assert_eq!(
+            inline_source("function f(x) { sink(x); return; } f(a);"),
+            "function f(x){sink(x);return};sink(a);"
+        );
+    }
+
+    #[test]
+    fn inlines_tail_return_param_identifier_dropped() {
+        // `return x` reads a parameter — a binding that always exists, so
+        // the read neither throws nor has a side effect; dropped.
+        assert_eq!(
+            inline_source("function f(x) { sink(x); return x; } f(a);"),
+            "function f(x){sink(x);return x};sink(a);"
+        );
+    }
+
+    #[test]
+    fn inlines_tail_return_effectful_kept_as_statement() {
+        // `return setup()` may have a side effect, so the value is dropped
+        // but the call is KEPT as a statement (`setup();`) for its effect.
+        assert_eq!(
+            inline_source("function f(x) { log(x); return setup(); } f(a);"),
+            "function f(x){log(x);return setup()};log(a);setup();"
+        );
+    }
+
+    #[test]
+    fn inlines_single_tail_return_with_free_global() {
+        // Body is a single tail `return g()` where `g` is a free global —
+        // the expression inliner (all-idents-must-be-params) cannot touch
+        // this, but the discarded-result statement splice can: `g();`.
+        assert_eq!(
+            inline_source("function f() { return setup(); } f();"),
+            "function f(){return setup()};setup();"
+        );
+    }
+
+    #[test]
+    fn inlines_tail_return_free_global_identifier_kept() {
+        // `return glob` reads a free global, which can throw `ReferenceError`
+        // if undeclared — so the read is preserved as `glob;`, not dropped.
+        assert_eq!(
+            inline_source("function f(x) { sink(x); return glob; } f(a);"),
+            "function f(x){sink(x);return glob};sink(a);glob;"
+        );
+    }
+
+    #[test]
+    fn does_not_inline_void_helper_with_early_return() {
+        // A `return` that is NOT the final statement would change control
+        // flow on a flat splice (the following statements would still run),
+        // so the candidate is declined.
+        assert_eq!(
+            inline_source("function f(x) { return; sink(x); } f(a);"),
+            "function f(x){return;sink(x)};f(a);"
         );
     }
 

--- a/code/programs/rust/closurec/src/run.rs
+++ b/code/programs/rust/closurec/src/run.rs
@@ -5902,11 +5902,14 @@ mod tests {
         // `f` is called so treeshake (now last in the SIMPLE pipeline)
         // keeps the declaration; otherwise the unused function would be
         // removed wholesale and the dce-inside-the-body effect wouldn't
-        // be observable.
-        let out = transform_source("function f() { g(); return 1; dead(); } f();", &cfg)
+        // be observable. It is called TWICE so the single-use void
+        // statement-inliner (CLOC15) declines it — otherwise `f` would be
+        // spliced away entirely and the dce-after-return effect (the point
+        // of this test) would no longer be observable in the output.
+        let out = transform_source("function f() { g(); return 1; dead(); } f(); f();", &cfg)
             .expect("ok");
         assert_eq!(
-            out, "function f(){g();return 1};f();",
+            out, "function f(){g();return 1};f();f();",
             "dce must drop the statement after the return"
         );
     }
@@ -6196,11 +6199,13 @@ mod tests {
     #[test]
     fn advanced_renames_surviving_top_level_function() {
         // CLOC13.I: a top-level function that SURVIVES SIMPLE (multi-
-        // statement body, so `inline` leaves it; called, so `treeshake`
-        // keeps it) is shortened by ADVANCED's `rename-globals` pass —
-        // the first point where ADVANCED produces smaller output than
-        // SIMPLE. SIMPLE keeps the top-level name (it may be external).
-        let src = "function helper() { sideEffect(); return value; } helper();";
+        // statement body, and called MORE THAN ONCE so neither the
+        // expression inliner nor the single-use void statement-inliner
+        // (CLOC15) splices it away; `treeshake` keeps it) is shortened by
+        // ADVANCED's `rename-globals` pass — the first point where ADVANCED
+        // produces smaller output than SIMPLE. SIMPLE keeps the top-level
+        // name (it may be external).
+        let src = "function helper() { sideEffect(); return value; } helper(); helper();";
         let mk = |level| {
             transform_source(
                 src,
@@ -6218,9 +6223,12 @@ mod tests {
         let advanced = mk(crate::config::CompilationLevel::Advanced);
         assert_eq!(
             simple,
-            "function helper(){sideEffect();return value};helper();"
+            "function helper(){sideEffect();return value};helper();helper();"
         );
-        assert_eq!(advanced, "function a(){sideEffect();return value};a();");
+        assert_eq!(
+            advanced,
+            "function a(){sideEffect();return value};a();a();"
+        );
         assert!(
             advanced.len() < simple.len(),
             "ADVANCED must be smaller than SIMPLE here"

--- a/code/programs/rust/closurec/tests/diff/advanced-rename-globals/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/advanced-rename-globals/expected.stdout
@@ -1,1 +1,1 @@
-function a(){sideEffect();return value};a();
+function a(){sideEffect();return value};a();a();

--- a/code/programs/rust/closurec/tests/diff/advanced-rename-globals/input/a.js
+++ b/code/programs/rust/closurec/tests/diff/advanced-rename-globals/input/a.js
@@ -1,20 +1,25 @@
 // ADVANCED-only global renaming (CLOC13.I wiring).
 //
 // `helper` is a top-level function with a multi-statement body, so the
-// `inline` pass leaves it, and it is called, so `treeshake` keeps it.
-// Under SIMPLE it survives with its full name (a top-level name might be
-// externally visible, so SIMPLE never renames it). Under ADVANCED the
-// `rename-globals` pass shortens the private top-level `helper` to `a`,
-// rewriting the call site too. `sideEffect` and `value` are free globals
-// (not declared here) and are left alone.
+// expression `inline` pass leaves it; it is called MORE THAN ONCE, so the
+// single-use void statement-inliner (CLOC15) also declines it, and
+// `treeshake` keeps it (it is referenced). Under SIMPLE it survives with
+// its full name (a top-level name might be externally visible, so SIMPLE
+// never renames it). Under ADVANCED the `rename-globals` pass shortens the
+// private top-level `helper` to `a`, rewriting the call sites too.
+// `sideEffect` and `value` are free globals (not declared here) and are
+// left alone.
 //
-//   SIMPLE   => function helper(){sideEffect();return value};helper();
-//   ADVANCED => function a(){sideEffect();return value};a();
+//   SIMPLE   => function helper(){sideEffect();return value};helper();helper();
+//   ADVANCED => function a(){sideEffect();return value};a();a();
 //
 // (A `--externs` file declaring `helper` would keep the name under
-// ADVANCED too — that boundary is what makes the rename sound.)
+// ADVANCED too — that boundary is what makes the rename sound. The second
+// call is what keeps `helper` from being inlined away entirely — a single
+// call site would be spliced in place by the CLOC15 statement-inliner.)
 function helper() {
   sideEffect();
   return value;
 }
+helper();
 helper();

--- a/code/programs/rust/closurec/tests/diff/simple-dce/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/simple-dce/expected.stdout
@@ -1,2 +1,1 @@
-function f(){keep();return 1};f();
-
+function f(){keep();return 1};f();f();

--- a/code/programs/rust/closurec/tests/diff/simple-dce/input/a.js
+++ b/code/programs/rust/closurec/tests/diff/simple-dce/input/a.js
@@ -15,7 +15,11 @@
 //
 // `f()` is called so treeshake (the last SIMPLE pass) keeps the
 // function; otherwise the whole unused declaration would be removed and
-// the dce-inside-the-body effect wouldn't be observable.
+// the dce-inside-the-body effect wouldn't be observable. It is called
+// TWICE so the single-use void statement-inliner (CLOC15) declines it:
+// once dce reduces the body to `{ keep(); return 1; }`, a single call
+// site would otherwise be spliced away entirely (`keep();`), hiding the
+// dce-inside-the-body effect this fixture is meant to show.
 //
 // Under WHITESPACE_ONLY none of this happens -- every statement survives.
 function f() {
@@ -24,4 +28,5 @@ function f() {
   return 1;
   alsoDead();
 }
+f();
 f();

--- a/code/programs/rust/closurec/tests/diff_simple_dce.rs
+++ b/code/programs/rust/closurec/tests/diff_simple_dce.rs
@@ -16,6 +16,11 @@
 //! ⇒ function f(){keep();return 1};
 //! ```
 //!
+//! `f` is called TWICE so the single-use void statement-inliner (CLOC15)
+//! declines it — once dce reduces the body to `{ keep(); return 1; }`, a
+//! lone call site would otherwise be spliced away entirely (`keep();`),
+//! hiding the dce-inside-the-body effect this fixture exists to show.
+//!
 //! The same input under WHITESPACE_ONLY keeps every statement (see the
 //! `simple_dce_*` unit tests in `src/run.rs`).
 //!


### PR DESCRIPTION
## What

Second staged slice of [CLOC15](code/specs/CLOC15-multi-statement-inlining.md), building on [#6194](https://github.com/adhithyan15/coding-adventures/pull/6194). The void statement-helper inliner now admits an **optional `return` as the body's final statement**. Because the call site discards the result, the returned value is never read, so the tail return is normalized for the splice:

```js
function init(n) { setup(n); return ready(); }
init(cfg);
// SIMPLE  ⇒  setup(cfg); ready();
//   (the tail `return ready()` is kept as `ready();` for its side effect;
//    the dead declaration is then removed by remove-unused-vars / treeshake)
```

Verified end-to-end through the real `closurec` binary (`--compilation_level SIMPLE`).

## `normalize_tail_return`

- `return;` (no argument) → **dropped** (a no-op once the value is discarded);
- `return E;` where `E` is **provably inert** — a literal, or a bare read of a parameter / callee-local (a binding that always exists, so the read neither throws nor has a side effect) → **dropped**;
- `return E;` otherwise → rewritten to `E;` (an `ExpressionStatement`), so `E` is still evaluated for its side effects with the value discarded — exactly what the original function did before returning.

A bare **global** identifier (`return glob`) is deliberately **not** dropped: reading an undeclared global throws `ReferenceError`, which is preserved as `glob;`.

## Soundness

Rests on the **tail** restriction: a `return` anywhere but the final position would change control flow when spliced (the caller's following statements would still run), so an **early `return` is a hard reject** — the body must be straight-line to the optional tail return. Normalization runs *before* alpha-rename/substitution, so `is_drop_safe_return`'s param/local membership test sees the original callee names, and a kept `E;` is then renamed + substituted like any other expression statement.

This also reaches a shape the expression inliner **cannot** — a single `return g()` with a free global `g` becomes `g();` (the expression inliner requires every identifier to be a parameter).

## Security review

Inline review, **passed round 1**: every drop is gated on provable inertness; the load-bearing free-global-read case (potential `ReferenceError`) is correctly preserved as `E;`; ordering, the tail restriction, empty-body `wrapping_sub`, and pop/push are all sound; no panics/overflow/recursion introduced.

## Tests

- bump `closure-pass-inline` 0.5.0 → 0.6.0; CHANGELOG + README + crate docs updated.
- 6 new pass tests (literal/bare/param-identifier dropped, effectful call kept as `E;`, single-`return`-of-free-global splice, free-global identifier kept, early-`return` declined). 46 inline-crate tests total.
- Full `closurec` suite + both downstream consumers (`remove-unused-vars`, `inline-variables`) green.
- Two closurec fixtures (`simple_dce_drops_dead_after_return`, `advanced-rename-globals`) updated to call their helper **twice** so it survives the single-use inliner — preserving each test's original intent (observing DCE-after-return / ADVANCED renaming a *surviving* top-level function) rather than collapsing it away. The new inlining made the single-call versions fully collapse, which is correct but invalidated those tests' premises.

🤖 Generated with [Claude Code](https://claude.com/claude-code)