### PR TITLE
Add mesh preflight repair readiness summary

### DIFF
--- a/code/packages/rust/smart-home-integration-catalog/CHANGELOG.md
+++ b/code/packages/rust/smart-home-integration-catalog/CHANGELOG.md
@@ -80,6 +80,8 @@ All notable changes to this package will be documented in this file.
   remediation blockers.
 - `IntegrationMeshPreflightReadinessSummary` and helpers for combining mesh
   release readiness with substrate preflight gates.
+- `IntegrationMeshPreflightRepairReadinessSummary` and helpers for combining
+  mesh preflight readiness with protocol-scoped repair actions.
 - `IntegrationMeshReadinessHandoffPackage`, summary helpers, and D23 mesh
   readiness handoff projections for release coordination across substrate
   actions, evidence remediation, and release-ready state.

--- a/code/packages/rust/smart-home-integration-catalog/README.md
+++ b/code/packages/rust/smart-home-integration-catalog/README.md
@@ -67,6 +67,8 @@ runtime and Chief of Staff tools a typed catalog for:
   readiness rollup
 - mesh action readiness summaries that combine release readiness with the
   substrate action queue and next concrete low-level action
+- mesh preflight repair readiness summaries that combine release readiness,
+  substrate preflight gates, and protocol-scoped repair queues
 - primitive backlog planning for prioritizing the shared families needed by a
   rollout wave
 - activation plans that resolve direct integrations, virtual aliases, and

--- a/code/packages/rust/smart-home-integration-catalog/src/lib.rs
+++ b/code/packages/rust/smart-home-integration-catalog/src/lib.rs
@@ -1308,6 +1308,76 @@ impl IntegrationMeshPreflightReadinessSummary {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IntegrationMeshPreflightRepairReadinessSummary {
+    pub preflight_readiness_summary: IntegrationMeshPreflightReadinessSummary,
+    pub preflight_action_summary: IntegrationMeshProtocolSubstratePreflightActionSummary,
+    pub total_protocols: usize,
+    pub total_preflight_checks: usize,
+    pub preflight_blocker_count: usize,
+    pub release_blocker_count: usize,
+    pub queued_preflight_actions: usize,
+    pub blocking_preflight_actions: usize,
+    pub operator_required_actions: usize,
+    pub queued_stage_count: usize,
+    pub queued_primitive_count: usize,
+    pub first_repair_protocol: Option<ProtocolFamily>,
+    pub first_repair_stage: Option<IntegrationMeshProtocolSubstrateStage>,
+    pub first_repair_primitive: Option<PrimitiveFamily>,
+    pub first_repair_action_kind: Option<IntegrationMeshProtocolSubstratePreflightActionKind>,
+    pub preflight_ready: bool,
+    pub preflight_actions_ready: bool,
+    pub release_ready: bool,
+    pub ready_for_release: bool,
+}
+
+impl IntegrationMeshPreflightRepairReadinessSummary {
+    pub fn from_parts(
+        preflight_readiness_summary: IntegrationMeshPreflightReadinessSummary,
+        preflight_action_summary: IntegrationMeshProtocolSubstratePreflightActionSummary,
+    ) -> Self {
+        let preflight_actions_ready = preflight_action_summary.preflight_actions_ready;
+        let ready_for_release =
+            preflight_readiness_summary.ready_for_release && preflight_actions_ready;
+
+        Self {
+            total_protocols: preflight_readiness_summary.total_protocols,
+            total_preflight_checks: preflight_readiness_summary.total_preflight_checks,
+            preflight_blocker_count: preflight_readiness_summary.preflight_blocker_count,
+            release_blocker_count: preflight_readiness_summary.release_blocker_count,
+            queued_preflight_actions: preflight_action_summary.total_actions,
+            blocking_preflight_actions: preflight_action_summary.blocking_actions,
+            operator_required_actions: preflight_action_summary.operator_required_actions,
+            queued_stage_count: mesh_substrate_preflight_action_stage_count(
+                &preflight_action_summary,
+            ),
+            queued_primitive_count: preflight_action_summary.unique_primitives,
+            first_repair_protocol: preflight_action_summary.first_protocol.clone(),
+            first_repair_stage: preflight_action_summary.first_stage,
+            first_repair_primitive: preflight_action_summary.first_primitive,
+            first_repair_action_kind: preflight_action_summary.first_action_kind,
+            preflight_ready: preflight_readiness_summary.preflight_ready,
+            release_ready: preflight_readiness_summary.release_ready,
+            preflight_readiness_summary,
+            preflight_action_summary,
+            preflight_actions_ready,
+            ready_for_release,
+        }
+    }
+
+    pub fn has_repair_actions(&self) -> bool {
+        self.queued_preflight_actions > 0
+    }
+
+    pub fn has_blockers(&self) -> bool {
+        !self.ready_for_release
+    }
+
+    pub fn needs_operator(&self) -> bool {
+        self.operator_required_actions > 0 || self.preflight_readiness_summary.needs_operator()
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum IntegrationMeshReadinessHandoffKind {
     SubstrateAction,
@@ -21754,6 +21824,41 @@ pub fn mesh_preflight_readiness_summary(
     )
 }
 
+pub fn mesh_preflight_repair_readiness_summary_for_catalog(
+    catalog: &[IntegrationCatalogEntry],
+    available_primitives: &[PrimitiveFamily],
+    allowed_capabilities: &[CapabilityId],
+    enabled_integrations: &[IntegrationId],
+) -> IntegrationMeshPreflightRepairReadinessSummary {
+    let preflight_readiness_summary = mesh_preflight_readiness_summary_for_catalog(
+        catalog,
+        available_primitives,
+        allowed_capabilities,
+        enabled_integrations,
+    );
+    let preflight_action_summary =
+        mesh_protocol_substrate_preflight_action_summary(available_primitives);
+
+    IntegrationMeshPreflightRepairReadinessSummary::from_parts(
+        preflight_readiness_summary,
+        preflight_action_summary,
+    )
+}
+
+pub fn mesh_preflight_repair_readiness_summary(
+    available_primitives: &[PrimitiveFamily],
+    allowed_capabilities: &[CapabilityId],
+    enabled_integrations: &[IntegrationId],
+) -> IntegrationMeshPreflightRepairReadinessSummary {
+    let catalog = first_party_catalog();
+    mesh_preflight_repair_readiness_summary_for_catalog(
+        &catalog,
+        available_primitives,
+        allowed_capabilities,
+        enabled_integrations,
+    )
+}
+
 fn mesh_readiness_handoff_packages_from_summary(
     summary: &IntegrationMeshActionReadinessSummary,
     actions: &[IntegrationMeshProtocolSubstrateAction],
@@ -21992,6 +22097,21 @@ fn protocol_sort_token(protocol: &ProtocolFamily) -> String {
 
 fn mesh_substrate_action_stage_count(
     summary: &IntegrationMeshProtocolSubstrateActionSummary,
+) -> usize {
+    [
+        summary.controller_actions,
+        summary.radio_actions,
+        summary.discovery_actions,
+        summary.network_security_actions,
+        summary.supervision_actions,
+    ]
+    .into_iter()
+    .filter(|count| *count > 0)
+    .count()
+}
+
+fn mesh_substrate_preflight_action_stage_count(
+    summary: &IntegrationMeshProtocolSubstratePreflightActionSummary,
 ) -> usize {
     [
         summary.controller_actions,
@@ -28597,6 +28717,86 @@ mod tests {
         assert!(summary.preflight_ready);
         assert_eq!(summary.total_blocker_count, summary.release_blocker_count);
         assert_eq!(summary.ready_for_release, summary.release_ready);
+        assert!(!summary.needs_operator());
+    }
+
+    #[test]
+    fn mesh_preflight_repair_readiness_summary_surfaces_repair_queue() {
+        let available_primitives = vec![
+            PrimitiveFamily::Usb,
+            PrimitiveFamily::SerialController,
+            PrimitiveFamily::Radio802154,
+            PrimitiveFamily::Supervision,
+        ];
+        let allowed_capabilities = vec![CapabilityId::trusted("smart_home.read")];
+        let summary = mesh_preflight_repair_readiness_summary(
+            &available_primitives,
+            &allowed_capabilities,
+            &[],
+        );
+
+        assert_eq!(summary.total_protocols, 3);
+        assert_eq!(summary.total_preflight_checks, 16);
+        assert_eq!(summary.preflight_blocker_count, 5);
+        assert_eq!(summary.queued_preflight_actions, 5);
+        assert_eq!(summary.blocking_preflight_actions, 5);
+        assert_eq!(summary.operator_required_actions, 4);
+        assert_eq!(summary.queued_stage_count, 3);
+        assert_eq!(summary.queued_primitive_count, 3);
+        assert_eq!(summary.first_repair_protocol, Some(ProtocolFamily::ZWave));
+        assert_eq!(
+            summary.first_repair_stage,
+            Some(IntegrationMeshProtocolSubstrateStage::Radio)
+        );
+        assert_eq!(
+            summary.first_repair_primitive,
+            Some(PrimitiveFamily::ZWaveSerialApi)
+        );
+        assert_eq!(
+            summary.first_repair_action_kind,
+            Some(IntegrationMeshProtocolSubstratePreflightActionKind::ProvisionRadio)
+        );
+        assert!(!summary.preflight_ready);
+        assert!(!summary.preflight_actions_ready);
+        assert!(!summary.ready_for_release);
+        assert!(summary.has_repair_actions());
+        assert!(summary.has_blockers());
+        assert!(summary.needs_operator());
+        assert_eq!(summary.preflight_action_summary.network_security_actions, 3);
+    }
+
+    #[test]
+    fn mesh_preflight_repair_readiness_summary_marks_ready_release() {
+        let catalog = vec![hue_entry()];
+        let allowed_capabilities = vec![
+            CapabilityId::trusted("smart_home.read"),
+            CapabilityId::trusted("smart_home.command.light"),
+            CapabilityId::trusted("smart_home.pair"),
+        ];
+        let summary = mesh_preflight_repair_readiness_summary_for_catalog(
+            &catalog,
+            all_primitive_families(),
+            &allowed_capabilities,
+            &[],
+        );
+
+        assert_eq!(summary.total_protocols, 3);
+        assert_eq!(summary.preflight_blocker_count, 0);
+        assert_eq!(summary.release_blocker_count, 0);
+        assert_eq!(summary.queued_preflight_actions, 0);
+        assert_eq!(summary.operator_required_actions, 0);
+        assert_eq!(summary.queued_stage_count, 0);
+        assert_eq!(summary.queued_primitive_count, 0);
+        assert_eq!(summary.first_repair_protocol, None);
+        assert_eq!(summary.first_repair_stage, None);
+        assert_eq!(summary.first_repair_primitive, None);
+        assert_eq!(summary.first_repair_action_kind, None);
+        assert!(summary.preflight_ready);
+        assert!(summary.preflight_actions_ready);
+        assert!(summary.release_ready);
+        assert!(summary.ready_for_release);
+        assert!(!summary.has_repair_actions());
+        assert!(!summary.has_blockers());
         assert!(!summary.needs_operator());
     }
 


### PR DESCRIPTION
## Summary
- add a mesh preflight repair readiness rollup that combines preflight release state with protocol-scoped repair actions
- surface queued repair actions, operator-required work, first repair target, and release-ready state
- document the new package-facing mesh preflight repair readiness helper

## Tests
- cargo fmt --manifest-path code\\packages\\rust\\smart-home-integration-catalog\\Cargo.toml
- cargo test --manifest-path code\\packages\\rust\\smart-home-integration-catalog\\Cargo.toml
- git diff --check