### PR TITLE
feat(visicalc-qt): Undo / Redo over the C ABI

### DIFF
--- a/demo/visicalc-qt/InfiniteSheet.qml
+++ b/demo/visicalc-qt/InfiniteSheet.qml
@@ -149,6 +149,22 @@ Item {
                 ToolTip.text: "Restore the workbook from the last save"
                 onClicked: if (doc) doc.deserialize(sheet.savedSnapshot)
             }
+            // Undo / redo: walk the engine's snapshot history. The buttons enable
+            // off the model's canUndo/canRedo (which notify on every edit).
+            Button {
+                text: "Undo"
+                enabled: doc ? doc.canUndo : false
+                ToolTip.visible: hovered
+                ToolTip.text: "Undo the last edit"
+                onClicked: if (doc) doc.undo()
+            }
+            Button {
+                text: "Redo"
+                enabled: doc ? doc.canRedo : false
+                ToolTip.visible: hovered
+                ToolTip.text: "Redo the last undone edit"
+                onClicked: if (doc) doc.redo()
+            }
         }
 
         // ── Column-letter header (frozen vertically, scrolls horizontally) ──

--- a/demo/visicalc-qt/README.md
+++ b/demo/visicalc-qt/README.md
@@ -117,6 +117,11 @@ the C ABI's `sc_serialize`) to a JSON document held in memory and restore it
 (`model.deserialize` / `sc_deserialize`): the document captures only the source
 (formula text + typed literals) and per-cell formats — not the computed values,
 which the engine recomputes on load, so a loaded formula stays live.
+The **Undo / Redo** buttons walk the engine's snapshot history (`model.undo`/
+`redo` over the C ABI's `sc_undo`/`sc_redo`); they enable off the `canUndo`/
+`canRedo` Q_PROPERTYs (which notify on `revisionChanged`, so they re-evaluate
+after every edit). Every edit is reversible and a restored formula recomputes
+live.
 
 The model seeds far-flung sparse cells (`Z1000`, `BA50`, `BB50`) on top of the
 budget so there's something to scroll to; the extent (`totalRows`/`totalCols`)
@@ -131,9 +136,10 @@ reachable, the gaps are empty (sparse), column letters run AA/BA, and editing
 the infinite-view binding layer directly: `rowCells` returns one engine-read
 row, `selectInf` selects + clamps and loads the source, and `commitInf` edits
 `A2` 8 → 108 with every dependent recomputing (E2 → 151, A5 → 139, E5 → 269).
-Further cases cover drag-fill, clipboard copy/cut/paste, and a save/load round
+Further cases cover drag-fill, clipboard copy/cut/paste, a save/load round
 trip (serialize → mutate → restore, with the loaded formula staying live and
-malformed input rejected):
+malformed input rejected), and an undo/redo walk (two edits → undo both → redo
+both with the formula recomputing live → a fresh edit forks history):
 
 ```bash
 cd test && qmake tst_window.pro && make && ./tst_window

--- a/demo/visicalc-qt/src/SpreadsheetModel.cpp
+++ b/demo/visicalc-qt/src/SpreadsheetModel.cpp
@@ -378,3 +378,41 @@ bool SpreadsheetModel::deserialize(const QString &data) {
     }
     return ok;
 }
+
+// Undo / redo availability — thin reads of the engine's history stacks; the
+// canUndo/canRedo Q_PROPERTYs are bound to revisionChanged so the QML buttons
+// re-evaluate these after every edit (and after undo/redo themselves).
+bool SpreadsheetModel::canUndo() const { return sc_can_undo(session_) != 0; }
+bool SpreadsheetModel::canRedo() const { return sc_can_redo(session_) != 0; }
+
+// Undo / redo: revert / replay the most recent edit. On success (returned true)
+// any cell could have changed, so we recompute the grid, regrow the extent,
+// refresh the formula bar, and bump `revision` — which also re-evaluates the
+// canUndo/canRedo bindings. Shared body for both directions.
+bool SpreadsheetModel::undo() {
+    const bool ok = sc_undo(session_) != 0;
+    if (ok) {
+        recompute();
+        computeExtent();
+        infFormula_ = rawAt(infAddress());
+        revision_++;
+        emit changed();
+        emit infSelectionChanged();
+        emit revisionChanged();
+    }
+    return ok;
+}
+
+bool SpreadsheetModel::redo() {
+    const bool ok = sc_redo(session_) != 0;
+    if (ok) {
+        recompute();
+        computeExtent();
+        infFormula_ = rawAt(infAddress());
+        revision_++;
+        emit changed();
+        emit infSelectionChanged();
+        emit revisionChanged();
+    }
+    return ok;
+}

--- a/demo/visicalc-qt/src/SpreadsheetModel.h
+++ b/demo/visicalc-qt/src/SpreadsheetModel.h
@@ -99,6 +99,10 @@ public:
     Q_PROPERTY(QString infAddress READ infAddress NOTIFY infSelectionChanged)
     Q_PROPERTY(QString infFormula READ infFormula NOTIFY infSelectionChanged)
     Q_PROPERTY(int revision READ revision NOTIFY revisionChanged)
+    // Undo/redo availability — bound to revisionChanged, which every mutating op
+    // (incl. undo/redo themselves) emits, so the QML buttons enable/disable live.
+    Q_PROPERTY(bool canUndo READ canUndo NOTIFY revisionChanged)
+    Q_PROPERTY(bool canRedo READ canRedo NOTIFY revisionChanged)
 
     int totalRows() const { return totalRows_; }
     int totalCols() const { return totalCols_; }
@@ -107,6 +111,8 @@ public:
     QString infAddress() const;
     QString infFormula() const { return infFormula_; }
     int revision() const { return revision_; }
+    bool canUndo() const;
+    bool canRedo() const;
 
     // One row's display strings (a QVariantList of QString, columns 1..totalCols)
     // — what a windowed ListView delegate renders. One engine read per row.
@@ -137,6 +143,12 @@ public:
     // regrows the extent, and bumps `revision` so the visible rows re-fetch.
     Q_INVOKABLE QString serialize() const;
     Q_INVOKABLE bool deserialize(const QString &data);
+    // Undo / redo: walk the engine's snapshot history. Each returns true if it
+    // changed the document; on success the grid recomputes, the extent regrows,
+    // the formula bar refreshes, and `revision` bumps (which re-evaluates the
+    // canUndo/canRedo bindings).
+    Q_INVOKABLE bool undo();
+    Q_INVOKABLE bool redo();
 
 signals:
     // viewportRows changed (after a recompute) — QML rebinds the grid.

--- a/demo/visicalc-qt/test/tst_window.cpp
+++ b/demo/visicalc-qt/test/tst_window.cpp
@@ -25,6 +25,7 @@ private slots:
     void fillReplicatesShiftingReferences();
     void clipboardCopyCutPaste();
     void saveLoadRoundTrips();
+    void undoRedoWalksHistory();
 };
 
 // Helper: the display string at window (1-based) cell (row, col), given the
@@ -201,6 +202,39 @@ void TstWindow::saveLoadRoundTrips() {
     // Garbage in is rejected (false), leaving the workbook intact.
     QVERIFY(!m.deserialize(QStringLiteral("not a workbook")));
     QCOMPARE(m.window(1, 5, 1, 5).at(0).toList().at(0).toString(), QStringLiteral("28.00"));
+}
+
+// Undo / redo (the Undo / Redo controls drive model.undo/redo): make two edits,
+// walk history back and forward, and confirm a restored formula recomputes live.
+void TstWindow::undoRedoWalksHistory() {
+    SpreadsheetModel m;
+    // (The model seeds its budget through set_cell, so those seed edits are
+    // themselves undoable — history is non-empty from construction.)
+    // Two fresh edits on a clear column: H1 = 2, I1 = H1*5 = 10 (col 8/9).
+    m.setCell("H1", "2");
+    m.setCell("I1", "=H1*5");
+    QCOMPARE(m.window(1, 9, 1, 9).at(0).toList().at(0).toString(), QStringLiteral("10"));
+    QVERIFY(m.canUndo());
+
+    // Undo the formula, then the literal.
+    QVERIFY(m.undo());
+    QCOMPARE(m.window(1, 9, 1, 9).at(0).toList().at(0).toString(), QString()); // I1 gone
+    QVERIFY(m.undo());
+    QCOMPARE(m.window(1, 8, 1, 8).at(0).toList().at(0).toString(), QString()); // H1 gone
+
+    // Redo both: I1 recomputes live (10).
+    QVERIFY(m.canRedo());
+    QVERIFY(m.redo());
+    QVERIFY(m.redo());
+    QCOMPARE(m.window(1, 9, 1, 9).at(0).toList().at(0).toString(), QStringLiteral("10"));
+    QVERIFY(!m.canRedo());
+    QVERIFY(!m.redo()); // nothing left to redo
+
+    // A fresh edit forks history (drops the redo branch).
+    QVERIFY(m.undo()); // back: I1 gone
+    QVERIFY(m.canRedo());
+    m.setCell("A1", "7");
+    QVERIFY(!m.canRedo());
 }
 
 QTEST_MAIN(TstWindow)


### PR DESCRIPTION
## Summary

Second of the six undo/redo demo rollouts (web [#6205](https://github.com/adhithyan15/coding-adventures/pull/6205) merged). Adds **Undo / Redo** to the Qt infinite-sheet demo, driving the session's snapshot history (spreadsheet-capi 0.9.0 `sc_undo`/`sc_redo`/`sc_can_undo`/`sc_can_redo`).

- `SpreadsheetModel` gains `Q_INVOKABLE undo()`/`redo()` → `bool` and `canUndo()`/`canRedo()` reads, surfaced as `canUndo`/`canRedo` **Q_PROPERTYs** bound to the existing `revisionChanged` notify — every mutating op (incl. undo/redo) bumps `revision`, so the buttons re-evaluate live. On a successful undo/redo the grid recomputes, the extent regrows, the formula bar refreshes, and `revision` bumps.
- `InfiniteSheet.qml` gains **Undo / Redo** buttons next to Save/Load, enabled off `doc.canUndo` / `doc.canRedo`.

## Test plan
- `cd test && qmake tst_window.pro && make && ./tst_window` — **10/10 PASS** (Qt 6.11). New `undoRedoWalksHistory`: two edits (H1, I1=H1*5=10), undo both (I1 then H1 gone), redo both (I1 recomputes live → 10), can-undo/can-redo gating, and a fresh edit forking history.
- Re-vendored `libspreadsheet_capi.a` + `spreadsheet.h` (0.9.0) into `Vendor/`.
- `/security-review`: PASSED (argument-free null-safe C calls; no UAF/leak; emit-after-mutation ordering makes the `revisionChanged`→property-read binding re-entrancy benign).

ℹ️ Note: the model seeds its budget via `set_cell`, so those seed edits are themselves undoable (history is non-empty from construction). A "clean baseline after seed" is a possible follow-up across all demos.

Next: Flutter → Compose → XAML → SwiftUI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)