### PR TITLE
feat(visicalc-flutter): Undo / Redo over dart:ffi

### DIFF
--- a/demo/visicalc-flutter/README.md
+++ b/demo/visicalc-flutter/README.md
@@ -131,7 +131,11 @@ serialize the whole workbook (`InfiniteSheetModel.saveBook` over the C ABI's
 `sc_serialize`) to a JSON document held in memory and restore it
 (`loadBook` / `sc_deserialize`): the document captures only the source (formula
 text + typed literals) and per-cell formats — not the computed values, which the
-engine recomputes on load, so a loaded formula stays live. `InfiniteSheetModel`
+engine recomputes on load, so a loaded formula stays live. The **Undo / Redo**
+buttons walk the engine's snapshot history (`InfiniteSheetModel.undoEdit`/
+`redoEdit` over the C ABI's `sc_undo`/`sc_redo`); they disable at the history
+ends via `canUndo`/`canRedo`. Every edit is reversible and a restored formula
+recomputes live. `InfiniteSheetModel`
 (in `lib/engine.dart`) seeds far-flung sparse cells (`Z1000`, `BA50`, `BB50`) so
 there's something to scroll to, and derives the extent from `usedRange()` + a
 margin.
@@ -144,8 +148,10 @@ engine-computed + dense (A1=15, E1=38, E5=169), a formula 1000 rows down
 AA/BA, and editing `A1` dirties the far dependent `Z1000` via `changedSince`. It
 also covers `InfiniteSheetModel` directly (`rowCells` one-read rows, `selectInf`
 clamping + source load, `commitInf` recompute, drag-fill, clipboard copy/cut/
-paste, and a save/load round trip — serialize → mutate → restore, with the
-loaded formula staying live and malformed input rejected).
+paste, a save/load round trip — serialize → mutate → restore, with the loaded
+formula staying live and malformed input rejected — and an undo/redo walk on a
+fresh session (two edits → undo both → redo both with the formula recomputing
+live → a fresh edit forks history)).
 
 `test/infinite_grid_test.dart` is a **widget test** that pumps the real
 `InfiniteGrid` tree on the live engine, taps the A1 cell, edits `15`→`115` in the

--- a/demo/visicalc-flutter/lib/engine.dart
+++ b/demo/visicalc-flutter/lib/engine.dart
@@ -79,6 +79,9 @@ typedef _ClipD = void Function(Pointer<Void>, Pointer<Uint8>, Pointer<Uint8>);
 // sc_paste(session, dst_start) → int (1 applied, 0 no-op).
 typedef _PasteC = Int32 Function(Pointer<Void>, Pointer<Uint8>);
 typedef _PasteD = int Function(Pointer<Void>, Pointer<Uint8>);
+// sc_undo / sc_redo / sc_can_undo / sc_can_redo(session) → int (1/0).
+typedef _FlagC = Int32 Function(Pointer<Void>);
+typedef _FlagD = int Function(Pointer<Void>);
 
 /// A single spreadsheet session, owning the opaque C handle.
 class SpreadsheetSession {
@@ -101,6 +104,10 @@ class SpreadsheetSession {
   // string → 1/0).
   late final _NoArgD _serializeFn;
   late final _PasteD _deserializeFn;
+  late final _FlagD _undoFn;
+  late final _FlagD _redoFn;
+  late final _FlagD _canUndoFn;
+  late final _FlagD _canRedoFn;
   late final _NoArgD _usedRangeFn;
   late final _ColLettersD _columnLettersFn;
   late final _CurrentRevD _currentRevisionFn;
@@ -126,6 +133,10 @@ class SpreadsheetSession {
     _pasteFn = _lib.lookupFunction<_PasteC, _PasteD>('sc_paste');
     _serializeFn = _lib.lookupFunction<_NoArgC, _NoArgD>('sc_serialize');
     _deserializeFn = _lib.lookupFunction<_PasteC, _PasteD>('sc_deserialize');
+    _undoFn = _lib.lookupFunction<_FlagC, _FlagD>('sc_undo');
+    _redoFn = _lib.lookupFunction<_FlagC, _FlagD>('sc_redo');
+    _canUndoFn = _lib.lookupFunction<_FlagC, _FlagD>('sc_can_undo');
+    _canRedoFn = _lib.lookupFunction<_FlagC, _FlagD>('sc_can_redo');
     _usedRangeFn = _lib.lookupFunction<_NoArgC, _NoArgD>('sc_used_range');
     _columnLettersFn = _lib.lookupFunction<_ColLettersC, _ColLettersD>('sc_column_letters');
     _currentRevisionFn = _lib.lookupFunction<_CurrentRevC, _CurrentRevD>('sc_current_revision');
@@ -349,6 +360,14 @@ class SpreadsheetSession {
       _freeCString(dataPtr);
     }
   }
+
+  /// Undo / redo: walk the engine's snapshot history. Each returns `true` if it
+  /// changed the document (the host then re-reads the viewport), `false` if there
+  /// was nothing to do. canUndo/canRedo gate a host's Undo/Redo controls.
+  bool undo() => _undoFn(_handle) != 0;
+  bool redo() => _redoFn(_handle) != 0;
+  bool canUndo() => _canUndoFn(_handle) != 0;
+  bool canRedo() => _canRedoFn(_handle) != 0;
 
   /// Dense display strings for the inclusive 1-based rectangle, row-major
   /// (empty cells become ''). Empty list on a bad/oversized request.
@@ -604,6 +623,28 @@ class InfiniteSheetModel {
   String saveBook() => _session.serialize();
   bool loadBook(String data) {
     final ok = _session.deserialize(data);
+    if (ok) {
+      computeExtent();
+      formula = _session.getRaw(infAddress);
+    }
+    return ok;
+  }
+
+  /// Undo / redo: walk the engine's snapshot history. On success the extent
+  /// regrows and the formula bar refreshes (any cell could have changed); a
+  /// restored formula stays live. canUndo/canRedo gate the buttons.
+  bool get canUndo => _session.canUndo();
+  bool get canRedo => _session.canRedo();
+  bool undoEdit() {
+    final ok = _session.undo();
+    if (ok) {
+      computeExtent();
+      formula = _session.getRaw(infAddress);
+    }
+    return ok;
+  }
+  bool redoEdit() {
+    final ok = _session.redo();
     if (ok) {
       computeExtent();
       formula = _session.getRaw(infAddress);

--- a/demo/visicalc-flutter/lib/infinite_grid.dart
+++ b/demo/visicalc-flutter/lib/infinite_grid.dart
@@ -138,6 +138,34 @@ class _InfiniteGridState extends State<InfiniteGrid> {
     });
   }
 
+  // Undo / redo: walk the engine's snapshot history. On success the whole grid
+  // re-reads and the formula bar re-syncs; the buttons disable at the history
+  // ends via the model's canUndo/canRedo.
+  void _undo() {
+    if (!_model.undoEdit()) return;
+    setState(() => _formulaCtrl.text = _model.formula);
+  }
+  void _redo() {
+    if (!_model.redoEdit()) return;
+    setState(() => _formulaCtrl.text = _model.formula);
+  }
+
+  // A clipboard-style button that disables when `enabled` is false (Undo/Redo).
+  Widget _gatedButton(String label, String tip, bool enabled, VoidCallback onPressed) {
+    return Tooltip(
+      message: tip,
+      child: OutlinedButton(
+        onPressed: enabled ? onPressed : null,
+        style: OutlinedButton.styleFrom(
+          foregroundColor: _ink,
+          side: const BorderSide(color: _border),
+          padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+        ),
+        child: Text(label, style: const TextStyle(fontFamily: _mono, fontSize: 12)),
+      ),
+    );
+  }
+
   // A compact outlined button for the clipboard controls, matching "Fill ↓ 10".
   Widget _clipButton(String label, String tip, VoidCallback onPressed) {
     return Tooltip(
@@ -223,6 +251,11 @@ class _InfiniteGridState extends State<InfiniteGrid> {
           _clipButton('Save', 'Serialize the whole workbook to memory', _save),
           const SizedBox(width: 8),
           _clipButton('Load', 'Restore the workbook from the last save', _load),
+          const SizedBox(width: 8),
+          // Undo / redo: walk the engine's snapshot history.
+          _gatedButton('Undo', 'Undo the last edit', _model.canUndo, _undo),
+          const SizedBox(width: 8),
+          _gatedButton('Redo', 'Redo the last undone edit', _model.canRedo, _redo),
         ],
       ),
     );

--- a/demo/visicalc-flutter/test/window_test.dart
+++ b/demo/visicalc-flutter/test/window_test.dart
@@ -67,6 +67,36 @@ void main() {
       expect(diff.changed, contains('Z1000')); // far dependent recomputed
       expect(s.window(1000, 26, 1000, 26)[0][0], '139'); // 115+8+12+4
     });
+
+    test('undo / redo walks the snapshot history with live recompute', () {
+      // A fresh, unseeded session so the initial history is empty.
+      final s = SpreadsheetSession();
+      addTearDown(s.dispose);
+      expect(s.canUndo(), isFalse);
+      s.setCell('A1', '1');
+      s.setCell('B1', '=A1*10'); // 10
+      expect(s.canUndo(), isTrue);
+
+      // Undo the formula, then the literal.
+      expect(s.undo(), isTrue);
+      expect(s.window(1, 2, 1, 2)[0][0], ''); // B1 cleared
+      expect(s.undo(), isTrue);
+      expect(s.window(1, 1, 1, 1)[0][0], ''); // A1 cleared
+      expect(s.canUndo(), isFalse);
+      expect(s.undo(), isFalse); // nothing left to undo
+
+      // Redo both: B1 recomputes live (10).
+      expect(s.redo(), isTrue);
+      expect(s.redo(), isTrue);
+      expect(s.window(1, 2, 1, 2)[0][0], '10');
+      expect(s.canRedo(), isFalse);
+
+      // A fresh edit forks history (drops the redo branch).
+      s.undo(); // back: B1 gone
+      expect(s.canRedo(), isTrue);
+      s.setCell('C1', '9');
+      expect(s.canRedo(), isFalse);
+    });
   });
 
   // The infinite-view binding layer (InfiniteGrid drives these): one engine read
@@ -174,6 +204,22 @@ void main() {
       // Garbage in is rejected (false), leaving the workbook intact.
       expect(m.loadBook('not a workbook'), isFalse);
       expect(m.rowCells(1)[4], '28.00');
+    });
+
+    test('undoEdit/redoEdit reverse and replay a model edit', () {
+      final m = InfiniteSheetModel();
+      addTearDown(m.dispose);
+      // (The model seeds its budget via commitInf, so history is non-empty from
+      // construction — undoing into the seed is expected.) Make one fresh edit.
+      m.selectInf(1, 8); m.commitInf('=A1+1'); // H1 = 15+1 = 16
+      expect(m.rowCells(1)[7], '16');
+      expect(m.canUndo, isTrue);
+      // Undo it: H1 goes away; redo brings it back, recomputed live.
+      expect(m.undoEdit(), isTrue);
+      expect(m.rowCells(1)[7], '');
+      expect(m.canRedo, isTrue);
+      expect(m.redoEdit(), isTrue);
+      expect(m.rowCells(1)[7], '16');
     });
   });
 }


### PR DESCRIPTION
## Summary

Third of the six undo/redo demo rollouts (web [#6205](https://github.com/adhithyan15/coding-adventures/pull/6205), Qt [#6207](https://github.com/adhithyan15/coding-adventures/pull/6207) merged). Adds **Undo / Redo** to the Flutter infinite-sheet demo, driving the session's snapshot history (spreadsheet-capi 0.9.0 `sc_undo`/`sc_redo`/`sc_can_undo`/`sc_can_redo`) over `dart:ffi`.

- `SpreadsheetSession` gains `undo()`/`redo()`/`canUndo()`/`canRedo()` → `bool`, bound via a new `_Flag` typedef (`Int32 Function(Pointer<Void>)` — session-only, no args/strings cross the boundary).
- `InfiniteSheetModel.undoEdit()`/`redoEdit()` (regrow extent + refresh formula bar on success) and `canUndo`/`canRedo` getters.
- `infinite_grid.dart` gains **Undo / Redo** buttons next to Save/Load via a new `_gatedButton` (disables when `canUndo`/`canRedo` is false).

## Test plan
- `flutter test test/window_test.dart` — **12/12 PASS**. Two new cases: a raw-session undo/redo walk on a fresh (unseeded) session (two edits, undo both → B1 then A1 cleared, redo both → B1 recomputes live → 10, can-gates at the ends, fresh-edit history fork) and a model-level `undoEdit`/`redoEdit` reverse+replay.
- `flutter analyze lib/` — clean.
- Re-vendored `libspreadsheet_capi.dylib` (0.9.0) into `native/`.
- `/security-review`: PASSED (FFI signature matches `int f(ScSession*)`; no memory crosses the boundary; null-session-safe; no leak/UAF).

⚠️ Note: the two pre-existing `test/infinite_grid_test.dart` failures (stale unformatted assertions from the formatting campaign) are unrelated to this change — flagged earlier for a separate test-only fix.

Next: Compose → XAML → SwiftUI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)