### PR TITLE
feat(mycin-micro): Tier-1 microbiology recall as an ADJ-only grounded library

### DIFF
--- a/code/specs/data/mycin-2026/USMLE-DOMAIN-MAP.md
+++ b/code/specs/data/mycin-2026/USMLE-DOMAIN-MAP.md
@@ -105,6 +105,7 @@ unchanged. Adding a relation just widens the schema — the engine already binds
 | Coagulation | Hematology | factor_deficiency, coag_inheritance, prolonged_test | 15 grounded | ✓ |
 | Meningitis | Infectious dz | **differential** (LR) + **management** (constraints) | grounded LRs + formulary | ✓ |
 | Bacteremia / UTI | Infectious dz | organism-id + treatment | grounded | ✓ |
+| Microbiology | Microbiology | gram_stain, morphology, causes | 13 grounded (ADJ-only) | ✓ |
 
 Offline pipeline: prose → local-model decompose → ADJ → native engine, two-sided
 faithfulness gate, zero online calls (OFFLINE-BOARD-EXAM.md).
@@ -114,6 +115,11 @@ faithfulness gate, zero online calls (OFFLINE-BOARD-EXAM.md).
 **Tier 1 — high-yield foundational recall (Step 1 backbone):**
 1. **Microbiology** — bacteria/virus/fungi/parasite → gram-stain, morphology, disease,
    virulence factor, treatment. The single densest recall region; clean relational facts.
+   *Started (MICRO):* `gram_stain` / `morphology` / `causes` for 6 board-classic bacteria
+   (13 edges, all grounded to byte-stable NCBI StatPearls spans) shipped as the first
+   **ADJ-only** domain (`recall/micro-edges.adj` — facts + inline byte-provenance, no
+   Python gate / JSON). Remaining: `virulence_factor`, `treated_with`, `transmission`;
+   viruses / fungi / parasites; M. tuberculosis (acid-fast) and the declined causes-edges.
 2. **Pharmacology** — drug → mechanism, class, indication, adverse effect, antidote.
    Dense, relational, subject-named in stems.
 3. **Immunology** — hypersensitivity types, immunodeficiencies, HLA associations, cytokines.
@@ -139,13 +145,20 @@ faithfulness gate, zero online calls (OFFLINE-BOARD-EXAM.md).
 
 ## Build protocol (per domain, one PR each)
 
-Each domain follows the proven REL-10/11/12 + grounding pattern:
-1. **Spec/edges** — define the relations; author the `<domain>-edges.adj` skeleton via
-   the gate (`<domain>_edge_ground.py`), initially `trust consensus` (authored-debt).
-2. **Spider-ground** — run the grounding spider → byte-provenance JSON → adversarial
-   write-gate (N readers × byte-stability × blind judge) → ACCEPT/FLAG → regenerate.
-   Decline (leave `consensus`) any edge no authoritative self-contained span defends —
-   honest abstention beats fabricated grounding.
+Each domain ships an **ADJ-only** library — the `.adj` file is the sole source of
+truth, carrying its facts AND byte-provenance inline (no Python gate, no JSON, no
+manifest). MICRO onward, the order is grounding-FIRST (never seed authored-debt):
+1. **Spider-ground first** — act as the spider: fetch an authoritative source per edge,
+   extract the VERBATIM self-contained span (byte-stable: re-fetch + normalize + verify
+   the span is present character-for-character), adversarially refute. Decline any edge
+   no authoritative self-contained span defends — honest absence beats a fabricated
+   citation. (No `trust consensus` authored-debt seed; an edge is grounded or omitted.)
+2. **Write the `.adj` directly** — one `relate rel(subject, object)` clause per grounded
+   edge, with `source "<verbatim span>"` + `locator "<url>"` + `trust authoritative`
+   inline. A query is just another `.adj` that `import`s the library and asks
+   `? rel(subject, $Var)` — the shape an LLM produces to recall a fact. (Earlier domains
+   IEM/vitamin/anemia/endocrine/coag still use the legacy `_edge_ground.py` gate + JSON;
+   they regenerate the same ADJ shape and can migrate to ADJ-only incrementally.)
 3. **Board items** — add free-text + structured board questions; wire into
    `board/items.json` + `board/free_text_board.json` + `EDGE_FILES`.
 4. **Score** — `board_eval` (native engine) + `board_offline` (offline, 0 online calls);
@@ -163,7 +176,8 @@ Each domain follows the proven REL-10/11/12 + grounding pattern:
 ## Coverage accounting (the watchable number)
 
 The north-star metric: **% of the USMLE content outline covered by grounded, scored
-domains.** Today: 5 recall domains + ID differential/management (a slice of Multisystem,
-Endocrine, Hematology, Biochemistry, Nutrition). Each merged domain PR moves this number;
+domains.** Today: 6 recall domains + ID differential/management (a slice of Multisystem,
+Endocrine, Hematology, Biochemistry, Nutrition, Microbiology — 65/66 board recall
+answers cite an authoritative grounded edge). Each merged domain PR moves this number;
 this map is the denominator. The campaign is done when every Tier-1/2/3 cell above has a
 grounded, scored domain and the board bank samples each.

--- a/code/specs/data/mycin-2026/board/board-scorecard.json
+++ b/code/specs/data/mycin-2026/board/board-scorecard.json
@@ -1,7 +1,7 @@
 {
   "summary": {
-    "total": 66,
-    "correct": 59,
+    "total": 79,
+    "correct": 72,
     "abstained": 7,
     "wrong": 0,
     "by_tactic": {
@@ -16,15 +16,15 @@
         "wrong": 0
       },
       "recall": {
-        "correct": 53,
+        "correct": 66,
         "abstained": 6,
         "wrong": 0
       }
     },
     "defensibility": 1.0,
     "accuracy_on_attempted": 1.0,
-    "grounded_coverage": 0.9811,
-    "grounded_correct": 52
+    "grounded_coverage": 0.9848,
+    "grounded_correct": 65
   },
   "results": [
     {
@@ -554,6 +554,110 @@
       "answer": "INFEASIBLE",
       "outcome": "correct",
       "trust": null
+    },
+    {
+      "id": "micro_saureus_gram",
+      "tactic": "recall",
+      "gold": "gram_positive",
+      "answer": "gram_positive",
+      "outcome": "correct",
+      "trust": "authoritative"
+    },
+    {
+      "id": "micro_saureus_shape",
+      "tactic": "recall",
+      "gold": "cocci",
+      "answer": "cocci",
+      "outcome": "correct",
+      "trust": "authoritative"
+    },
+    {
+      "id": "micro_nmen_gram",
+      "tactic": "recall",
+      "gold": "gram_negative",
+      "answer": "gram_negative",
+      "outcome": "correct",
+      "trust": "authoritative"
+    },
+    {
+      "id": "micro_nmen_shape",
+      "tactic": "recall",
+      "gold": "diplococci",
+      "answer": "diplococci",
+      "outcome": "correct",
+      "trust": "authoritative"
+    },
+    {
+      "id": "micro_vibrio_gram",
+      "tactic": "recall",
+      "gold": "gram_negative",
+      "answer": "gram_negative",
+      "outcome": "correct",
+      "trust": "authoritative"
+    },
+    {
+      "id": "micro_vibrio_shape",
+      "tactic": "recall",
+      "gold": "comma_shaped",
+      "answer": "comma_shaped",
+      "outcome": "correct",
+      "trust": "authoritative"
+    },
+    {
+      "id": "micro_vibrio_causes",
+      "tactic": "recall",
+      "gold": "cholera",
+      "answer": "cholera",
+      "outcome": "correct",
+      "trust": "authoritative"
+    },
+    {
+      "id": "micro_ecoli_gram",
+      "tactic": "recall",
+      "gold": "gram_negative",
+      "answer": "gram_negative",
+      "outcome": "correct",
+      "trust": "authoritative"
+    },
+    {
+      "id": "micro_ecoli_shape",
+      "tactic": "recall",
+      "gold": "bacilli",
+      "answer": "bacilli",
+      "outcome": "correct",
+      "trust": "authoritative"
+    },
+    {
+      "id": "micro_pseud_gram",
+      "tactic": "recall",
+      "gold": "gram_negative",
+      "answer": "gram_negative",
+      "outcome": "correct",
+      "trust": "authoritative"
+    },
+    {
+      "id": "micro_pseud_shape",
+      "tactic": "recall",
+      "gold": "bacilli",
+      "answer": "bacilli",
+      "outcome": "correct",
+      "trust": "authoritative"
+    },
+    {
+      "id": "micro_spneumo_gram",
+      "tactic": "recall",
+      "gold": "gram_positive",
+      "answer": "gram_positive",
+      "outcome": "correct",
+      "trust": "authoritative"
+    },
+    {
+      "id": "micro_spneumo_causes",
+      "tactic": "recall",
+      "gold": "community_acquired_pneumonia",
+      "answer": "community_acquired_pneumonia",
+      "outcome": "correct",
+      "trust": "authoritative"
     }
   ]
 }

--- a/code/specs/data/mycin-2026/board/board_eval.py
+++ b/code/specs/data/mycin-2026/board/board_eval.py
@@ -65,7 +65,7 @@ SCORECARD = HERE / "board-scorecard.json"
 # model calls. (A local in-memory model may generate the ADJ program from prose; see
 # board_offline.py. The engine that ANSWERS is always the native CPU reasoner.)
 EDGE_FILES = ["iem-edges.adj", "vitamin-edges.adj", "anemia-edges.adj", "endocrine-edges.adj",
-              "coag-edges.adj"]
+              "coag-edges.adj", "micro-edges.adj"]
 
 # The native adj-lang CLI binary — the ONE engine behind every tactic (recall,
 # differential, management). If the binary is absent (e.g. a Python-only CI job that

--- a/code/specs/data/mycin-2026/board/decompose_query.py
+++ b/code/specs/data/mycin-2026/board/decompose_query.py
@@ -58,11 +58,11 @@ from pathlib import Path
 HERE = Path(__file__).resolve().parent
 RECALL = HERE.parent / "recall"
 EDGE_FILES = ["iem-edges.adj", "vitamin-edges.adj", "anemia-edges.adj",
-              "endocrine-edges.adj", "coag-edges.adj"]
+              "endocrine-edges.adj", "coag-edges.adj", "micro-edges.adj"]
 
 # Each recall relation binds one conventional variable (the "what is being asked").
-# This is the controlled query vocabulary the model must choose from — 11 relations
-# across five organ systems. The engine ultimately validates the subject; this map
+# This is the controlled query vocabulary the model must choose from — 14 relations
+# across six organ systems. The engine ultimately validates the subject; this map
 # pins the legal relation set and the variable name each relation answers.
 REL_VAR = {
     "deficient_in": "Enzyme",          # IEM: which enzyme is deficient
@@ -76,6 +76,9 @@ REL_VAR = {
     "factor_deficiency": "Factor",     # coagulation: which clotting factor
     "coag_inheritance": "Pattern",     # coagulation: inheritance pattern
     "prolonged_test": "Test",          # coagulation: which lab test is prolonged
+    "gram_stain": "Result",            # microbiology: Gram reaction (positive / negative)
+    "morphology": "Shape",             # microbiology: cell shape (cocci / bacilli / …)
+    "causes": "Disease",               # microbiology: signature disease the organism causes
 }
 
 _RELATE_RE = re.compile(r"^\s*relate\s+([a-z_][a-z0-9_]*)\s*\(([^)]*)\)\s*$")

--- a/code/specs/data/mycin-2026/board/items.json
+++ b/code/specs/data/mycin-2026/board/items.json
@@ -74,6 +74,20 @@
     {"id": "mgmt_older_adult",       "domain": "meningitis_tx", "tactic": "management", "chart": [["age_band", "older_adult", "aged 72"]],                                                        "gold": ["ampicillin", "ceftriaxone", "vancomycin"]},
     {"id": "mgmt_neurosurgical",     "domain": "meningitis_tx", "tactic": "management", "chart": [["setting", "post_neurosurgical", "POD#3 craniotomy"]],                                         "gold": ["cefepime", "vancomycin"]},
     {"id": "mgmt_pregnant_adult",    "domain": "meningitis_tx", "tactic": "management", "chart": [["age_band", "adult", "28-year-old"], ["pregnancy", "present", "G2P1 at 24 weeks"]],            "gold": ["ceftriaxone", "vancomycin"]},
-    {"id": "mgmt_betalactam_allergic","domain": "meningitis_tx", "tactic": "management", "chart": [["age_band", "adult", "adult"], ["allergy", "betalactam", "anaphylaxis to multiple beta-lactams (whole-class)"]],       "gold": "INFEASIBLE"}
+    {"id": "mgmt_betalactam_allergic","domain": "meningitis_tx", "tactic": "management", "chart": [["age_band", "adult", "adult"], ["allergy", "betalactam", "anaphylaxis to multiple beta-lactams (whole-class)"]],       "gold": "INFEASIBLE"},
+
+    {"id": "micro_saureus_gram",   "domain": "micro", "tactic": "recall", "relation": "gram_stain", "subject": "staphylococcus_aureus",    "var": "Result",  "gold": "gram_positive"},
+    {"id": "micro_saureus_shape",  "domain": "micro", "tactic": "recall", "relation": "morphology", "subject": "staphylococcus_aureus",    "var": "Shape",   "gold": "cocci"},
+    {"id": "micro_nmen_gram",      "domain": "micro", "tactic": "recall", "relation": "gram_stain", "subject": "neisseria_meningitidis",   "var": "Result",  "gold": "gram_negative"},
+    {"id": "micro_nmen_shape",     "domain": "micro", "tactic": "recall", "relation": "morphology", "subject": "neisseria_meningitidis",   "var": "Shape",   "gold": "diplococci"},
+    {"id": "micro_vibrio_gram",    "domain": "micro", "tactic": "recall", "relation": "gram_stain", "subject": "vibrio_cholerae",          "var": "Result",  "gold": "gram_negative"},
+    {"id": "micro_vibrio_shape",   "domain": "micro", "tactic": "recall", "relation": "morphology", "subject": "vibrio_cholerae",          "var": "Shape",   "gold": "comma_shaped"},
+    {"id": "micro_vibrio_causes",  "domain": "micro", "tactic": "recall", "relation": "causes",     "subject": "vibrio_cholerae",          "var": "Disease", "gold": "cholera"},
+    {"id": "micro_ecoli_gram",     "domain": "micro", "tactic": "recall", "relation": "gram_stain", "subject": "escherichia_coli",         "var": "Result",  "gold": "gram_negative"},
+    {"id": "micro_ecoli_shape",    "domain": "micro", "tactic": "recall", "relation": "morphology", "subject": "escherichia_coli",         "var": "Shape",   "gold": "bacilli"},
+    {"id": "micro_pseud_gram",     "domain": "micro", "tactic": "recall", "relation": "gram_stain", "subject": "pseudomonas_aeruginosa",   "var": "Result",  "gold": "gram_negative"},
+    {"id": "micro_pseud_shape",    "domain": "micro", "tactic": "recall", "relation": "morphology", "subject": "pseudomonas_aeruginosa",   "var": "Shape",   "gold": "bacilli"},
+    {"id": "micro_spneumo_gram",   "domain": "micro", "tactic": "recall", "relation": "gram_stain", "subject": "streptococcus_pneumoniae", "var": "Result",  "gold": "gram_positive"},
+    {"id": "micro_spneumo_causes", "domain": "micro", "tactic": "recall", "relation": "causes",     "subject": "streptococcus_pneumoniae", "var": "Disease", "gold": "community_acquired_pneumonia"}
   ]
 }

--- a/code/specs/data/mycin-2026/board/test_board_eval.py
+++ b/code/specs/data/mycin-2026/board/test_board_eval.py
@@ -41,10 +41,12 @@ def test_covered_items_answer_correctly_with_a_proof() -> None:
     assert by_id["tay_sachs_enzyme"].answer == "hexosaminidase_a"
     # A correct recall answer carries the citing edge's trust tier (its proof).
     assert by_id["tay_sachs_enzyme"].trust is not None
-    # The bank spans FIVE recall domains: 18 IEM + 8 vitamin + 8 anemia + 8 endocrine
-    # + 11 coagulation (REL-13) = 53 covered recall items, all over one merged store.
+    # The bank spans SIX recall domains: 18 IEM + 8 vitamin + 8 anemia + 8 endocrine
+    # + 11 coagulation (REL-13) + 13 microbiology (MICRO) = 66 covered recall items, all
+    # over one merged store. MICRO is the first ADJ-ONLY domain: micro-edges.adj is a
+    # hand-authored library carrying its byte-provenance inline (no Python gate / JSON).
     recall_correct = [r for r in card.results if r.outcome == "correct" and r.tactic == "recall"]
-    assert len(recall_correct) == 53
+    assert len(recall_correct) == 66
     assert by_id["fabry_enzyme"].outcome == "correct"               # IEM
     assert by_id["thiamine_disease"].answer == "beriberi"           # vitamin
     assert by_id["ida_mcv"].answer == "microcytic"                  # anemia
@@ -52,6 +54,9 @@ def test_covered_items_answer_correctly_with_a_proof() -> None:
     assert by_id["adh_def"].answer == "central_diabetes_insipidus"
     assert by_id["hemophilia_a_factor"].answer == "factor_viii"     # coagulation (REL-13)
     assert by_id["vwd_test"].answer == "bleeding_time"              # coag — prolonged_test relation
+    assert by_id["micro_saureus_gram"].answer == "gram_positive"   # microbiology (MICRO)
+    assert by_id["micro_vibrio_causes"].answer == "cholera"        # micro — causes relation
+    assert by_id["micro_saureus_gram"].trust == "authoritative"    # ADJ-only edge, grounded inline
 
 
 def test_uncovered_items_abstain_not_fabricate() -> None:
@@ -84,15 +89,17 @@ def test_grounded_coverage_is_the_live_grounding_number() -> None:
     # the disorder's onset/category but not the deficiency-OF-factor identity, so verify
     # landed at direction_only. REL-14 found a stronger source whose verbatim span self-
     # contains the relation ("Factor VII deficiency is a bleeding disorder characterized
-    # by a lack in the production of factor VII"), lifting it to authoritative. 52 of the
-    # 53 recall answers across all FIVE domains now cite an authoritative edge:
-    # grounded-coverage 98%. ONE holdout stays consensus + FLAG (direction_only) — the
-    # adversarial verify could not pin it verbatim, so the framework declines to claim
-    # grounding it cannot defend, by design: cortisol_def (endocrine,
-    # deficiency_syndrome__cortisol — the only verbatim spans frame cortisol deficiency
-    # as a consequence/feature of Addison disease, not the named-syndrome identity).
-    assert s["grounded_coverage"] == round(52 / 53, 4)   # 0.9811
-    assert s["grounded_correct"] == 52
+    # by a lack in the production of factor VII"), lifting it to authoritative. The MICRO
+    # domain (13 ADJ-only microbiology edges, all spider-grounded to NCBI StatPearls byte-
+    # stable spans) adds 13 more authoritative recall answers. 65 of the 66 recall answers
+    # across all SIX domains now cite an authoritative edge: grounded-coverage 98%. ONE
+    # holdout stays consensus + FLAG (direction_only) — the adversarial verify could not
+    # pin it verbatim, so the framework declines to claim grounding it cannot defend, by
+    # design: cortisol_def (endocrine, deficiency_syndrome__cortisol — the only verbatim
+    # spans frame cortisol deficiency as a consequence/feature of Addison disease, not the
+    # named-syndrome identity).
+    assert s["grounded_coverage"] == round(65 / 66, 4)   # 0.9848
+    assert s["grounded_correct"] == 65
     by_id = {r.item_id: r for r in card.results}
     assert by_id["tay_sachs_enzyme"].trust == "authoritative"      # IEM
     assert by_id["ida_mcv"].trust == "authoritative"               # anemia

--- a/code/specs/data/mycin-2026/recall/micro-edges.adj
+++ b/code/specs/data/mycin-2026/recall/micro-edges.adj
@@ -1,0 +1,115 @@
+% ============================================================================
+% micro-edges — the clinical-microbiology knowledge-graph (MYCIN-2026 MICRO).
+% ============================================================================
+% A Tier-1 recall domain (USMLE-DOMAIN-MAP §"To build"): the densest, cleanest
+% fact-recall region of Step 1. "Is Staphylococcus aureus gram-positive?" becomes
+% the binding query  ? gram_stain(staphylococcus_aureus, $Result).
+%
+% This file is the SHIPPED ARTIFACT and the SOLE source of truth — there is no
+% generator, no JSON, no manifest. Each fact is a `relate` clause whose byte-
+% provenance lives INLINE:
+%     source   — the VERBATIM span copied from the cited page (byte-stable: it
+%                appears character-for-character in the page's normalized text).
+%     locator  — the URL the span was read from (NCBI StatPearls / Bookshelf, NIH).
+%     trust    — authoritative (a primary, citable reference).
+% An LLM (or a human) recalls a fact by writing a tiny query .adj that
+% `import`s this library and asks a binding query — see micro-recall.query.adj.
+% Nothing here is hand-asserted "from memory": every edge is defended by a span
+% that a reader can re-fetch and check. (See feedback_nothing_human_authored.)
+%
+% Honest scope of THIS file (declined edges left out rather than fabricated):
+%   - Mycobacterium tuberculosis: NBK441916 states "acid-fast bacilli" but never
+%     a self-contained "M tuberculosis is an acid-fast bacillus" span naming the
+%     organism — declined here; deserves its own page/PR, not a stretched quote.
+%   - Neisseria meningitidis `causes(meningococcal_meningitis)`: the organism page
+%     names gram/shape cleanly but has no self-contained "N meningitidis causes
+%     meningococcal meningitis" span — gram_stain + morphology kept, causes declined.
+% Declining an edge that lacks a clean self-contained authoritative span is the
+% correct move: honest absence beats a fabricated citation.
+% ============================================================================
+
+dictionary micro_vocab {
+    define organism : entity   surface "organism", "bacterium", "pathogen"
+    define gram     : entity   surface "Gram stain reaction"
+    define shape    : entity   surface "cellular morphology", "shape"
+    define disease  : entity   surface "infection", "disease"
+
+    define gram_stain : relation from organism to gram      % Gram reaction (positive / negative)
+    define morphology : relation from organism to shape     % cell shape (cocci / bacilli / …)
+    define causes     : relation from organism to disease   % the signature disease it causes
+}
+
+rulebook micro_facts {
+    use micro_vocab
+
+    % --- Staphylococcus aureus -------------------------------------------
+    % One span states BOTH the gram reaction and the shape for the named organism.
+    relate gram_stain(staphylococcus_aureus, gram_positive)
+        source "S aureus are gram-positive cocci that typically appear microscopically in grape-like clusters"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK441868/"
+        trust authoritative
+    relate morphology(staphylococcus_aureus, cocci)
+        source "S aureus are gram-positive cocci that typically appear microscopically in grape-like clusters"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK441868/"
+        trust authoritative
+
+    % --- Neisseria meningitidis ------------------------------------------
+    % "gram-negative diplococcus" — one span, both edges. (causes-edge declined; see header.)
+    relate gram_stain(neisseria_meningitidis, gram_negative)
+        source "N meningitidis is an aerobic or facultative anaerobic, gram-negative diplococcus that exclusively infects humans"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK549849/"
+        trust authoritative
+    relate morphology(neisseria_meningitidis, diplococci)
+        source "N meningitidis is an aerobic or facultative anaerobic, gram-negative diplococcus that exclusively infects humans"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK549849/"
+        trust authoritative
+
+    % --- Vibrio cholerae -------------------------------------------------
+    % The gram/shape span is the appositive of the sentence whose subject is
+    % "Vibrio cholerae" ("…Vibrio cholerae, a gram-negative, comma-shaped bacterium").
+    relate gram_stain(vibrio_cholerae, gram_negative)
+        source "a gram-negative, comma-shaped bacterium"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK526099/"
+        trust authoritative
+    relate morphology(vibrio_cholerae, comma_shaped)
+        source "a gram-negative, comma-shaped bacterium"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK526099/"
+        trust authoritative
+    relate causes(vibrio_cholerae, cholera)
+        source "Cholera is an acute secretory diarrhea caused by toxigenic strains of Vibrio cholerae"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK526099/"
+        trust authoritative
+
+    % --- Escherichia coli ------------------------------------------------
+    % Sentence subject is Escherichia coli (E coli); the quoted clause gives gram + shape.
+    relate gram_stain(escherichia_coli, gram_negative)
+        source "is a gram-negative bacillus that normally inhabits the human intestinal tract"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK564298/"
+        trust authoritative
+    relate morphology(escherichia_coli, bacilli)
+        source "is a gram-negative bacillus that normally inhabits the human intestinal tract"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK564298/"
+        trust authoritative
+
+    % --- Pseudomonas aeruginosa ------------------------------------------
+    % "rod" and "bacillus" are synonyms (a bacillus is a rod-shaped bacterium).
+    relate gram_stain(pseudomonas_aeruginosa, gram_negative)
+        source "Pseudomonas aeruginosa is a gram-negative, aerobic, non-spore forming rod"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK557831/"
+        trust authoritative
+    relate morphology(pseudomonas_aeruginosa, bacilli)
+        source "Pseudomonas aeruginosa is a gram-negative, aerobic, non-spore forming rod"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK557831/"
+        trust authoritative
+
+    % --- Streptococcus pneumoniae ----------------------------------------
+    % One span states the gram reaction AND a signature disease for the named organism.
+    relate gram_stain(streptococcus_pneumoniae, gram_positive)
+        source "Streptococcus pneumoniae is a gram-positive, lancet-shaped bacterium and a cause of community-acquired pneumonia"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK470537/"
+        trust authoritative
+    relate causes(streptococcus_pneumoniae, community_acquired_pneumonia)
+        source "Streptococcus pneumoniae is a gram-positive, lancet-shaped bacterium and a cause of community-acquired pneumonia"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK470537/"
+        trust authoritative
+}

--- a/code/specs/data/mycin-2026/recall/micro-recall.query.adj
+++ b/code/specs/data/mycin-2026/recall/micro-recall.query.adj
@@ -1,0 +1,22 @@
+% ============================================================================
+% micro-recall.query.adj — a worked recall query over the micro library.
+% ============================================================================
+% This is the shape an LLM (or a clinician) produces to ANSWER a recall question:
+% it does NOT restate any medical fact — it only `import`s the grounded libraries
+% and asks a binding query. The native adj-lang engine resolves each `?` against
+% the imported `relate` edges and returns the binding + the citing clause's
+% source/locator/trust. Zero facts live here; all knowledge is in the libraries.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli micro-recall.query.adj
+% ============================================================================
+
+import "micro-edges.adj"
+
+? gram_stain(staphylococcus_aureus, $Result)        % expect gram_positive
+? morphology(staphylococcus_aureus, $Shape)         % expect cocci
+? gram_stain(neisseria_meningitidis, $Result)       % expect gram_negative
+? morphology(vibrio_cholerae, $Shape)               % expect comma_shaped
+? causes(vibrio_cholerae, $Disease)                 % expect cholera
+? gram_stain(escherichia_coli, $Result)             % expect gram_negative
+? causes(streptococcus_pneumoniae, $Disease)        % expect community_acquired_pneumonia

--- a/code/specs/data/mycin-2026/recall/test_micro_recall.py
+++ b/code/specs/data/mycin-2026/recall/test_micro_recall.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""test_micro_recall.py — the ADJ-only microbiology recall library (MYCIN-2026 MICRO).
+
+MICRO is the first recall domain shipped as a pure ADJ artifact: `micro-edges.adj`
+is the SOLE source of truth — facts + byte-provenance inline, no Python gate, no JSON,
+no manifest. So this test does NOT check a generator against a committed file (the
+`test_*_edge_ground.py` pattern); instead it pins the property that actually matters:
+
+  the native adj-lang engine, given a query .adj that only `import`s the library and
+  asks binding queries (`micro-recall.query.adj` — the shape an LLM produces), returns
+  the correct binding for every grounded edge, each carrying an AUTHORITATIVE citation
+  with a real source span + locator. Knowledge lives in ADJ; the engine answers.
+
+If the native CLI isn't built (a Python-only CI lane), the engine-backed checks skip —
+the file-shape checks (every clause grounded, no authored-debt) still run.
+
+Run:  python3 test_micro_recall.py
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+ADJ = HERE / "micro-edges.adj"
+QUERY = HERE / "micro-recall.query.adj"
+CLI = HERE.parents[3] / "packages" / "rust" / "target" / "debug" / "adj-lang-cli"
+
+# The full grounded edge set (subject, relation, expected binding) the engine must
+# resolve. Mirrors micro-edges.adj; a divergence here or there fails the test.
+EXPECTED = [
+    ("staphylococcus_aureus", "gram_stain", "gram_positive"),
+    ("staphylococcus_aureus", "morphology", "cocci"),
+    ("neisseria_meningitidis", "gram_stain", "gram_negative"),
+    ("neisseria_meningitidis", "morphology", "diplococci"),
+    ("vibrio_cholerae", "gram_stain", "gram_negative"),
+    ("vibrio_cholerae", "morphology", "comma_shaped"),
+    ("vibrio_cholerae", "causes", "cholera"),
+    ("escherichia_coli", "gram_stain", "gram_negative"),
+    ("escherichia_coli", "morphology", "bacilli"),
+    ("pseudomonas_aeruginosa", "gram_stain", "gram_negative"),
+    ("pseudomonas_aeruginosa", "morphology", "bacilli"),
+    ("streptococcus_pneumoniae", "gram_stain", "gram_positive"),
+    ("streptococcus_pneumoniae", "causes", "community_acquired_pneumonia"),
+]
+
+
+def _cli_available() -> bool:
+    return CLI.exists()
+
+
+def _run(program: Path) -> dict:
+    out = subprocess.run([str(CLI), str(program)], capture_output=True, text=True,
+                         cwd=str(HERE), timeout=60)
+    assert out.returncode == 0, f"adj-lang-cli failed: {out.stderr}"
+    return json.loads(out.stdout)
+
+
+# ---- 1. the ADJ file is the artifact — every clause grounded, no authored-debt ----
+
+def test_library_is_pure_adj_and_fully_grounded() -> None:
+    text = ADJ.read_text()
+    # No legacy authored-debt markers: every edge is grounded or omitted.
+    assert "trust consensus" not in text, "MICRO ships no authored-debt; ground or omit"
+    assert "[FLAG:" not in text
+    # Every relate clause carries a source + locator + authoritative trust inline.
+    relate_count = text.count("    relate ")
+    assert text.count("trust authoritative") == relate_count == len(EXPECTED)
+    # Count the clause attribute (8-space indented), not the prose mention in the header.
+    assert text.count('\n        locator "') == relate_count
+    assert text.count('\n        source "') == relate_count
+    # No sibling generator / JSON / manifest for this domain (ADJ-only).
+    assert not (HERE / "micro_edge_ground.py").exists()
+    assert not (HERE / "micro-edge-grounding.json").exists()
+    assert not (HERE / "micro-edge-manifest.json").exists()
+
+
+# ---- 2. the engine resolves every grounded edge with an authoritative citation ----
+
+def test_engine_resolves_every_edge_with_authoritative_citation() -> None:
+    if not _cli_available():
+        return  # the native engine answers; skip in a Python-only env
+    result = _run(QUERY)
+    by_query = {r["query"]: r for r in result["recall"]}
+    var = {"gram_stain": "Result", "morphology": "Shape", "causes": "Disease"}
+    # Every edge in micro-edges.adj must be resolvable through an import-only query.
+    for subj, rel, expected in EXPECTED:
+        q = f"{rel}({subj}, {var[rel]})"
+        # The committed query .adj covers a representative subset; run any uncovered
+        # edge directly so the test pins the WHOLE library, not just the demo queries.
+        r = by_query.get(q) or _one(rel, subj, var[rel])
+        assert r is not None and not r["abstained"], f"{q} abstained — edge missing?"
+        ans = r["answers"][0]
+        assert ans["bindings"][var[rel]] == expected, f"{q} -> {ans['bindings']}"
+        cite = ans["citations"][0]
+        assert cite["trust"] == "authoritative", f"{q} citation not authoritative"
+        assert cite["source"], f"{q} citation has no source span"
+        assert cite["locator"].startswith("https://www.ncbi.nlm.nih.gov/"), cite["locator"]
+
+
+def _one(rel: str, subj: str, varname: str) -> dict | None:
+    """Resolve a single edge by writing a throwaway one-line query .adj in this dir
+    (so the relative `import "micro-edges.adj"` resolves) and running the engine."""
+    import os
+    import tempfile
+    fd, path = tempfile.mkstemp(suffix=".adj", prefix=".micro_q_", dir=HERE)
+    try:
+        with os.fdopen(fd, "w") as fh:
+            fh.write(f'import "micro-edges.adj"\n? {rel}({subj}, ${varname})\n')
+        res = _run(Path(path))
+        return res["recall"][0] if res["recall"] else None
+    finally:
+        os.unlink(path)
+
+
+# ---- 3. an off-vocabulary subject abstains, never fabricates ----------------------
+
+def test_unknown_organism_abstains() -> None:
+    if not _cli_available():
+        return
+    r = _one("gram_stain", "treponema_pallidum", "Result")  # not in the library
+    assert r is not None and r["abstained"], "an ungrounded organism must abstain"
+
+
+def _run_all() -> int:
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    failed = 0
+    for t in tests:
+        try:
+            t()
+            print(f"  PASS  {t.__name__}")
+        except AssertionError as exc:
+            failed += 1
+            print(f"  FAIL  {t.__name__}: {exc}")
+    print(f"\ntest_micro_recall: {len(tests) - failed}/{len(tests)} passed")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(_run_all())


### PR DESCRIPTION
## What

The first MYCIN-2026 recall domain shipped as a **pure ADJ artifact** — no Python gate, no JSON grounding file, no manifest. `recall/micro-edges.adj` *is* the source of truth: each fact is a `relate` clause carrying its byte-provenance **inline** (`source` = the verbatim NCBI StatPearls span, `locator` = the URL, `trust authoritative`).

An LLM (or a clinician) recalls a fact by writing a tiny query `.adj` that `import`s the library and asks a binding query — `recall/micro-recall.query.adj` is the worked example. Knowledge lives in ADJ; the native adj-lang engine answers.

```
import "micro-edges.adj"
? gram_stain(staphylococcus_aureus, $Result)   % → gram_positive, cited to NBK441868
```

## Grounding (no authored debt)

Per *"Do not add more authored debt — use Spider and CAS to get the right data and ground even recall facts"*: all **13 edges** (`gram_stain` / `morphology` / `causes` for 6 board-classic bacteria — *S. aureus, N. meningitidis, V. cholerae, E. coli, P. aeruginosa, S. pneumoniae*) are grounded to a **byte-stable verbatim span**, re-verified character-for-character against the live page. No `trust consensus` seed — an edge is grounded or omitted.

Honestly **declined** (no clean self-contained authoritative span): *M. tuberculosis* acid-fast, and the *N. meningitidis* / non-specific `causes` edges.

## Wiring & results

- `board_eval.EDGE_FILES` + `decompose_query.EDGE_FILES` += `micro-edges.adj`; `REL_VAR` += `gram_stain`/`morphology`/`causes` (recall vocab 11 → 14)
- 13 micro board items — all resolve **correct**, all **authoritative**
- Scorecard: recall **53 → 66** correct, grounded **52 → 65** (65/66 = **98%**), **wrong 0**, defensibility **100%**
- `test_micro_recall.py` pins the ADJ-only flow end-to-end through the native CLI (engine resolves every edge with an authoritative citation; an off-vocabulary organism abstains)
- `USMLE-DOMAIN-MAP`: Microbiology marked built; build protocol updated to the **grounding-first, ADJ-only** shape (legacy gate/JSON domains migrate incrementally)

## Verification

- `board_eval` test suite: **12/12**
- `test_micro_recall`: **3/3**
- byte-stability: **7/7** live spans present verbatim
- `/security-review` passed (subprocess/tempfile/string-literal injection — clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)