### PR TITLE
feat(visicalc-compose): Undo / Redo over Java FFM

### DIFF
--- a/demo/visicalc-compose/README.md
+++ b/demo/visicalc-compose/README.md
@@ -100,6 +100,10 @@ document held in memory and restore it (`loadBook` / `sc_deserialize`): the
 document captures only the source (formula text + typed literals) and per-cell
 formats — not the computed values, which the engine recomputes on load, so a
 loaded formula stays live.
+The **Undo / Redo** buttons walk the engine's snapshot history
+(`InfiniteSheetModel.undoEdit`/`redoEdit` over the C ABI's `sc_undo`/`sc_redo`);
+they disable at the history ends via `canUndo`/`canRedo`. Every edit is
+reversible and a restored formula recomputes live.
 `InfiniteSheetModel` (in `Engine.kt`) seeds far-flung
 sparse cells (`Z1000`, `BA50`, `BB50`) and derives the extent from `usedRange()`
 + a margin.
@@ -118,7 +122,9 @@ the clipboard (`copyCell` I1 → `pasteCell` at I4 ⇒ I4 = H4*10 = 60; `cutCell
 → paste at C1 moves it, A1 clears, a second paste returns false), and a
 save/load round trip (`saveBook` → mutate A1 ⇒ E1 523.00 → `loadBook` restores
 A1 15 / E1 38.00, the loaded formula stays live with A1=5 ⇒ E1 28.00, and
-malformed input is rejected).
+malformed input is rejected), and an undo/redo walk on a fresh session (two
+edits → undo both → redo both with the formula recomputing live → a fresh edit
+forks history).
 
 The Compose UI itself (`InfiniteSheet.kt` + the `Main.kt` toggle) is verified to
 compile against the real Compose Desktop APIs via `gradle compileKotlin`; the

--- a/demo/visicalc-compose/src/main/kotlin/Engine.kt
+++ b/demo/visicalc-compose/src/main/kotlin/Engine.kt
@@ -59,6 +59,11 @@ class SpreadsheetSession(libraryPath: String = resolveLibraryPath()) : AutoClose
     // sc_deserialize(session, data) -> int (1 loaded, 0 malformed/unsupported).
     private val scSerialize = handle("sc_serialize", FunctionDescriptor.of(ptr, ptr))
     private val scDeserialize = handle("sc_deserialize", FunctionDescriptor.of(i32, ptr, ptr))
+    // sc_undo / sc_redo / sc_can_undo / sc_can_redo(session) -> int (1/0).
+    private val scUndo = handle("sc_undo", FunctionDescriptor.of(i32, ptr))
+    private val scRedo = handle("sc_redo", FunctionDescriptor.of(i32, ptr))
+    private val scCanUndo = handle("sc_can_undo", FunctionDescriptor.of(i32, ptr))
+    private val scCanRedo = handle("sc_can_redo", FunctionDescriptor.of(i32, ptr))
     private val scUsedRange = handle("sc_used_range", FunctionDescriptor.of(ptr, ptr))
     private val scColumnLetters = handle("sc_column_letters", FunctionDescriptor.of(ptr, ptr, i32))
     private val scCurrentRevision = handle("sc_current_revision", FunctionDescriptor.of(i64, ptr))
@@ -175,6 +180,14 @@ class SpreadsheetSession(libraryPath: String = resolveLibraryPath()) : AutoClose
     fun deserialize(data: String): Boolean = Arena.ofConfined().use { a ->
         (scDeserialize.invoke(session, a.allocateUtf8String(data)) as Int) != 0
     }
+
+    /// Undo / redo: walk the engine's snapshot history. Each returns `true` if it
+    /// changed the document (the host then re-reads the viewport), `false` if
+    /// there was nothing to do. canUndo/canRedo gate a host's Undo/Redo controls.
+    fun undo(): Boolean = (scUndo.invoke(session) as Int) != 0
+    fun redo(): Boolean = (scRedo.invoke(session) as Int) != 0
+    fun canUndo(): Boolean = (scCanUndo.invoke(session) as Int) != 0
+    fun canRedo(): Boolean = (scCanRedo.invoke(session) as Int) != 0
 
     /// Dense display strings for the inclusive 1-based rectangle, row-major
     /// (empty cells become ""). Empty list on a bad/oversized request.
@@ -452,6 +465,28 @@ class InfiniteSheetModel(
     fun saveBook(): String = session.serialize()
     fun loadBook(data: String): Boolean {
         val ok = session.deserialize(data)
+        if (ok) {
+            computeExtent()
+            formula = session.getRaw(infAddress())
+        }
+        return ok
+    }
+
+    /// Undo / redo: walk the engine's snapshot history. On success the extent
+    /// regrows and the formula bar refreshes (any cell could have changed); a
+    /// restored formula stays live. canUndo/canRedo gate the buttons.
+    fun canUndo(): Boolean = session.canUndo()
+    fun canRedo(): Boolean = session.canRedo()
+    fun undoEdit(): Boolean {
+        val ok = session.undo()
+        if (ok) {
+            computeExtent()
+            formula = session.getRaw(infAddress())
+        }
+        return ok
+    }
+    fun redoEdit(): Boolean {
+        val ok = session.redo()
         if (ok) {
             computeExtent()
             formula = session.getRaw(infAddress())

--- a/demo/visicalc-compose/src/main/kotlin/InfiniteSheet.kt
+++ b/demo/visicalc-compose/src/main/kotlin/InfiniteSheet.kt
@@ -135,6 +135,20 @@ fun InfiniteSheet() {
         rev++
     }
 
+    // Undo / redo: walk the engine's snapshot history. On success the grid
+    // re-reads (rev++) and the formula bar re-syncs; the buttons gate off the
+    // model's canUndo/canRedo (re-evaluated because rev is read in the layout).
+    fun undo() {
+        if (!model.undoEdit()) return
+        formula = model.formula
+        rev++
+    }
+    fun redo() {
+        if (!model.redoEdit()) return
+        formula = model.formula
+        rev++
+    }
+
     Column(modifier = Modifier.fillMaxSize().padding(8.dp)) {
         // ── Formula bar: the selected cell's address + an editable source ──
         Row(verticalAlignment = Alignment.CenterVertically) {
@@ -187,6 +201,12 @@ fun InfiniteSheet() {
             clipButton("Save") { saveBook() }
             Spacer(Modifier.width(8.dp))
             clipButton("Load") { loadBook() }
+            // Undo / redo: walk the engine's snapshot history. Reading `rev` here
+            // re-evaluates canUndo/canRedo on every edit so the buttons gate live.
+            Spacer(Modifier.width(8.dp))
+            gatedButton("Undo", enabled = rev.let { model.canUndo() }) { undo() }
+            Spacer(Modifier.width(8.dp))
+            gatedButton("Redo", enabled = rev.let { model.canRedo() }) { redo() }
         }
 
         Spacer(Modifier.height(6.dp))
@@ -271,8 +291,15 @@ private fun Text(text: String, color: Color, width: androidx.compose.ui.unit.Dp)
 /// A compact outlined button for the clipboard controls, matching "Fill ↓ 10".
 @Composable
 private fun clipButton(label: String, onClick: () -> Unit) {
+    gatedButton(label, enabled = true, onClick = onClick)
+}
+
+/// A clipboard-style button that disables when `enabled` is false (Undo/Redo).
+@Composable
+private fun gatedButton(label: String, enabled: Boolean, onClick: () -> Unit) {
     androidx.compose.material.OutlinedButton(
         onClick = onClick,
+        enabled = enabled,
         colors = androidx.compose.material.ButtonDefaults.outlinedButtonColors(
             backgroundColor = CHROME,
             contentColor = INK,

--- a/demo/visicalc-compose/test/EngineSmoke.kt
+++ b/demo/visicalc-compose/test/EngineSmoke.kt
@@ -171,6 +171,31 @@ fun main() {
     check("workbook intact after reject", sl.rowCells(1)[4], "28.00")
     sl.close()
 
+    // Undo / redo (the Undo / Redo buttons drive undoEdit/redoEdit): a fresh,
+    // unseeded session so the initial history is empty. Two edits, walk back and
+    // forward, and confirm a restored formula recomputes live.
+    val ur = SpreadsheetSession()
+    check("fresh canUndo false", ur.canUndo().toString(), "false")
+    ur.setCell("A1", "1")
+    ur.setCell("B1", "=A1*10") // 10
+    check("after edits canUndo true", ur.canUndo().toString(), "true")
+    check("undo formula", ur.undo().toString(), "true")
+    check("B1 cleared by undo", ur.window(1, 2, 1, 2)[0][0], "")
+    check("undo literal", ur.undo().toString(), "true")
+    check("A1 cleared by undo", ur.window(1, 1, 1, 1)[0][0], "")
+    check("canUndo false at bottom", ur.canUndo().toString(), "false")
+    check("undo at bottom is noop", ur.undo().toString(), "false")
+    check("redo literal", ur.redo().toString(), "true")
+    check("redo formula", ur.redo().toString(), "true")
+    check("B1 live after redo", ur.window(1, 2, 1, 2)[0][0], "10")
+    check("canRedo false at top", ur.canRedo().toString(), "false")
+    // A fresh edit forks history (drops the redo branch).
+    ur.undo() // back: B1 gone
+    check("canRedo true before fork", ur.canRedo().toString(), "true")
+    ur.setCell("C1", "9")
+    check("fresh edit clears redo", ur.canRedo().toString(), "false")
+    ur.close()
+
     println(if (failures == 0) "\nALL PASS" else "\n$failures FAILURE(S)")
     kotlin.system.exitProcess(if (failures == 0) 0 else 1)
 }


### PR DESCRIPTION
## Summary

Fourth of the six undo/redo demo rollouts (web [#6205](https://github.com/adhithyan15/coding-adventures/pull/6205), Qt [#6207](https://github.com/adhithyan15/coding-adventures/pull/6207), Flutter [#6211](https://github.com/adhithyan15/coding-adventures/pull/6211) merged). Adds **Undo / Redo** to the Compose Desktop infinite-sheet demo, driving the session's snapshot history (spreadsheet-capi 0.9.0 `sc_undo`/`sc_redo`/`sc_can_undo`/`sc_can_redo`) over **Java FFM**.

- `Engine.kt`: `scUndo`/`scRedo`/`scCanUndo`/`scCanRedo` handles (`FunctionDescriptor.of(i32, ptr)`) → `undo()`/`redo()`/`canUndo()`/`canRedo()` → `Boolean`.
- `InfiniteSheetModel.undoEdit()`/`redoEdit()` (regrow extent + refresh formula bar on success) and `canUndo()`/`canRedo()`.
- `InfiniteSheet.kt` gains **Undo / Redo** buttons next to Save/Load via a new `gatedButton` (`clipButton` now delegates to it with `enabled=true`); they read the `rev` state so `canUndo`/`canRedo` re-evaluate after every edit.

## Test plan
- `scripts/verify.sh` (kotlinc + JDK 21 preview FFM) — **ALL PASS**. New undo/redo walk on a fresh (unseeded) session: two edits, undo both (B1 then A1 cleared), redo both (B1 recomputes live → 10), can-gates at the ends, fresh-edit history fork.
- Re-vendored `libspreadsheet_capi.dylib` (0.9.0) into `native/`.
- `/security-review`: PASSED (`of(i32, ptr)` matches `int f(ScSession*)`; no pointer/allocation crosses the boundary; null-session-safe; no leak/UAF).

Next: XAML → SwiftUI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)