### PR TITLE
Add SPICE deck output directive artifacts

### DIFF
--- a/code/packages/python/spice-engine/src/spice_engine/__init__.py
+++ b/code/packages/python/spice-engine/src/spice_engine/__init__.py
@@ -45,6 +45,7 @@ from spice_engine.compatibility import (
     resolve_deck_parameters,
     resolve_deck_sources,
     select_deck_analysis_plan,
+    select_deck_output_directives,
     select_deck_output_probes,
 )
 from spice_engine.elements import (
@@ -578,6 +579,7 @@ __all__ = [
     "resolve_deck_parameters",
     "run_deck_analysis",
     "select_deck_analysis_plan",
+    "select_deck_output_directives",
     "select_deck_output_probes",
     "sens_dc",
     "s_parameters",

--- a/code/packages/python/spice-engine/src/spice_engine/compatibility.py
+++ b/code/packages/python/spice-engine/src/spice_engine/compatibility.py
@@ -950,6 +950,30 @@ def select_deck_output_probes(netlist: str, analysis: str) -> list[str]:
     return selected
 
 
+def select_deck_output_directives(netlist: str, analysis: str) -> list[str]:
+    """Return deduplicated output directive kinds selected for an analysis."""
+
+    summary = resolve_deck_outputs(netlist)
+    if summary.diagnostics:
+        diagnostic = summary.diagnostics[0]
+        raise ValueError(
+            f"select_deck_output_directives: line {diagnostic.line_number}: {diagnostic.message}"
+        )
+    selected: list[str] = []
+    seen: set[str] = set()
+    for selection in summary.selections:
+        if selection.analysis is not None and not _deck_output_analysis_matches(
+            selection.analysis,
+            analysis,
+        ):
+            continue
+        if selection.directive in seen:
+            continue
+        seen.add(selection.directive)
+        selected.append(selection.directive)
+    return selected
+
+
 def resolve_deck_analyses(netlist: str) -> DeckAnalysisSummary:
     """Extract supported top-level analysis directives before ``.end``."""
 

--- a/code/packages/python/spice-engine/src/spice_engine/engine.py
+++ b/code/packages/python/spice-engine/src/spice_engine/engine.py
@@ -73,6 +73,7 @@ from spice_engine.compatibility import (
     resolve_deck_fourier,
     resolve_deck_measurements,
     select_deck_analysis_plan,
+    select_deck_output_directives,
     select_deck_output_probes,
 )
 from spice_engine.elements import (
@@ -2321,6 +2322,8 @@ class DeckRunArtifact:
     result_rows: int
     output_probe_count: int
     output_probes: list[str]
+    output_directive_count: int
+    output_directives: list[str]
     measurement_count: int
     measurement_names: list[str]
     fourier_count: int
@@ -2386,6 +2389,7 @@ def _deck_run_artifacts(
     plan: DeckAnalysisPlan,
     result: DcResult | DcSweepResult | AcResult | TransientResult | TfResult | SensResult | NoiseResult,
     output_probes: list[str],
+    output_directives: list[str],
     measurements: list[ProbeMeasurement],
     fourier: list[FourierResult],
 ) -> list[DeckRunArtifact]:
@@ -2397,6 +2401,8 @@ def _deck_run_artifacts(
             result_rows=_deck_result_row_count(result),
             output_probe_count=len(output_probes),
             output_probes=list(output_probes),
+            output_directive_count=len(output_directives),
+            output_directives=list(output_directives),
             measurement_count=len(measurements),
             measurement_names=[measurement.name for measurement in measurements],
             fourier_count=len(fourier),
@@ -2411,7 +2417,7 @@ def format_deck_run_artifact_table(artifacts: Iterable[DeckRunArtifact]) -> str:
     """Format selected deck-run artifacts as a stable summary table."""
 
     rows = [
-        "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tOutputProbeList\tMeasurements\tMeasurementList\tFourier\tFourierList"
+        "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList"
     ]
     for artifact in artifacts:
         rows.append(
@@ -2423,6 +2429,8 @@ def format_deck_run_artifact_table(artifacts: Iterable[DeckRunArtifact]) -> str:
                     str(artifact.result_rows),
                     str(artifact.output_probe_count),
                     ";".join(artifact.output_probes),
+                    str(artifact.output_directive_count),
+                    ";".join(artifact.output_directives),
                     str(artifact.measurement_count),
                     ";".join(artifact.measurement_names),
                     str(artifact.fourier_count),
@@ -2448,8 +2456,9 @@ def run_deck_analysis(
         _select_deck_fourier_cards_for_analysis(netlist, plan.analysis)
         measurements: list[ProbeMeasurement] = []
         output_probes = select_deck_output_probes(netlist, plan.analysis)
+        output_directives = select_deck_output_directives(netlist, plan.analysis)
         run_artifacts = _deck_run_artifacts(
-            plan, result, output_probes, measurements, fourier
+            plan, result, output_probes, output_directives, measurements, fourier
         )
         return DeckAnalysisExecution(
             plan=plan,
@@ -2476,8 +2485,9 @@ def run_deck_analysis(
         fourier = []
         _select_deck_fourier_cards_for_analysis(netlist, plan.analysis)
         output_probes = select_deck_output_probes(netlist, plan.analysis)
+        output_directives = select_deck_output_directives(netlist, plan.analysis)
         run_artifacts = _deck_run_artifacts(
-            plan, result, output_probes, measurements, fourier
+            plan, result, output_probes, output_directives, measurements, fourier
         )
         return DeckAnalysisExecution(
             plan=plan,
@@ -2506,8 +2516,9 @@ def run_deck_analysis(
         fourier = []
         _select_deck_fourier_cards_for_analysis(netlist, plan.analysis)
         output_probes = select_deck_output_probes(netlist, plan.analysis)
+        output_directives = select_deck_output_directives(netlist, plan.analysis)
         run_artifacts = _deck_run_artifacts(
-            plan, result, output_probes, measurements, fourier
+            plan, result, output_probes, output_directives, measurements, fourier
         )
         return DeckAnalysisExecution(
             plan=plan,
@@ -2542,8 +2553,9 @@ def run_deck_analysis(
             _select_deck_fourier_cards_for_analysis(netlist, plan.analysis),
         )
         output_probes = select_deck_output_probes(netlist, plan.analysis)
+        output_directives = select_deck_output_directives(netlist, plan.analysis)
         run_artifacts = _deck_run_artifacts(
-            plan, result, output_probes, measurements, fourier
+            plan, result, output_probes, output_directives, measurements, fourier
         )
         return DeckAnalysisExecution(
             plan=plan,
@@ -2566,8 +2578,9 @@ def run_deck_analysis(
         _select_deck_fourier_cards_for_analysis(netlist, plan.analysis)
         fourier = []
         output_probes = [f"V({output_node})"]
+        output_directives: list[str] = []
         run_artifacts = _deck_run_artifacts(
-            plan, result, output_probes, measurements, fourier
+            plan, result, output_probes, output_directives, measurements, fourier
         )
         return DeckAnalysisExecution(
             plan=plan,
@@ -2589,8 +2602,9 @@ def run_deck_analysis(
         _select_deck_fourier_cards_for_analysis(netlist, plan.analysis)
         fourier = []
         output_probes = [f"V({output_node})"]
+        output_directives = []
         run_artifacts = _deck_run_artifacts(
-            plan, result, output_probes, measurements, fourier
+            plan, result, output_probes, output_directives, measurements, fourier
         )
         return DeckAnalysisExecution(
             plan=plan,
@@ -2631,8 +2645,9 @@ def run_deck_analysis(
         _select_deck_fourier_cards_for_analysis(netlist, plan.analysis)
         fourier = []
         output_probes = [f"V({output_node})"]
+        output_directives = []
         run_artifacts = _deck_run_artifacts(
-            plan, result, output_probes, measurements, fourier
+            plan, result, output_probes, output_directives, measurements, fourier
         )
         return DeckAnalysisExecution(
             plan=plan,

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -6796,11 +6796,12 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
     assert op_execution.table == "Index\tV(mid)\n0\t5.000000e-01\n"
     assert op_execution.run_artifacts[0].result_rows == 1
     assert op_execution.run_artifacts[0].output_probes == ["V(mid)"]
+    assert op_execution.run_artifacts[0].output_directives == [".save"]
     assert op_execution.run_artifacts[0].measurement_names == []
     assert op_execution.run_artifacts[0].fourier_probes == []
     assert op_execution.run_artifact_table == (
-        "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tOutputProbeList\tMeasurements\tMeasurementList\tFourier\tFourierList\n"
-        f"op\t.op\t{op_execution.plan.line_number}\t1\t1\tV(mid)\t0\t\t0\t\n"
+        "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\n"
+        f"op\t.op\t{op_execution.plan.line_number}\t1\t1\tV(mid)\t1\t.save\t0\t\t0\t\n"
     )
 
     dc_execution = run_deck_analysis(circuit, netlist, "dc")
@@ -6820,11 +6821,12 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
     )
     assert dc_execution.run_artifacts[0].analysis == "dc"
     assert dc_execution.run_artifacts[0].output_probes == ["V(mid)", "I(V1)"]
+    assert dc_execution.run_artifacts[0].output_directives == [".save", ".probe"]
     assert dc_execution.run_artifacts[0].measurement_names == ["mid_avg"]
     assert dc_execution.run_artifacts[0].fourier_probes == []
     assert dc_execution.run_artifact_table == (
-        "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tOutputProbeList\tMeasurements\tMeasurementList\tFourier\tFourierList\n"
-        f"dc\t.dc\t{dc_execution.plan.line_number}\t2\t2\tV(mid);I(V1)\t1\tmid_avg\t0\t\n"
+        "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\n"
+        f"dc\t.dc\t{dc_execution.plan.line_number}\t2\t2\tV(mid);I(V1)\t2\t.save;.probe\t1\tmid_avg\t0\t\n"
     )
 
     ac_execution = run_deck_analysis(circuit, netlist, "ac")
@@ -6841,11 +6843,12 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
         "0\t1.000000e+03\tV(mid)\t5.000000e-01\t0.000000e+00\t5.000000e-01\t0.000000e+00\n"
     )
     assert ac_execution.run_artifacts[0].output_probes == ["V(mid)"]
+    assert ac_execution.run_artifacts[0].output_directives == [".save"]
     assert ac_execution.run_artifacts[0].measurement_names == ["mid_peak"]
     assert ac_execution.run_artifacts[0].fourier_probes == []
     assert ac_execution.run_artifact_table == (
-        "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tOutputProbeList\tMeasurements\tMeasurementList\tFourier\tFourierList\n"
-        f"ac\t.ac\t{ac_execution.plan.line_number}\t1\t1\tV(mid)\t1\tmid_peak\t0\t\n"
+        "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\n"
+        f"ac\t.ac\t{ac_execution.plan.line_number}\t1\t1\tV(mid)\t1\t.save\t1\tmid_peak\t0\t\n"
     )
 
     tran_execution = run_deck_analysis(circuit, netlist, "tran")
@@ -6864,11 +6867,12 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
         "1\t1.000000e-03\t5.000000e-01\n"
     )
     assert tran_execution.run_artifacts[0].output_probes == ["V(mid)"]
+    assert tran_execution.run_artifacts[0].output_directives == [".save"]
     assert tran_execution.run_artifacts[0].measurement_names == ["mid_final"]
     assert tran_execution.run_artifacts[0].fourier_probes == []
     assert tran_execution.run_artifact_table == (
-        "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tOutputProbeList\tMeasurements\tMeasurementList\tFourier\tFourierList\n"
-        f"tran\t.tran\t{tran_execution.plan.line_number}\t2\t1\tV(mid)\t1\tmid_final\t0\t\n"
+        "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\n"
+        f"tran\t.tran\t{tran_execution.plan.line_number}\t2\t1\tV(mid)\t1\t.save\t1\tmid_final\t0\t\n"
     )
 
     tf_execution = run_deck_analysis(circuit, netlist, "tf")
@@ -6888,11 +6892,12 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
     assert tf_execution.run_artifacts[0].analysis == "tf"
     assert tf_execution.run_artifacts[0].result_rows == 1
     assert tf_execution.run_artifacts[0].output_probes == ["V(mid)"]
+    assert tf_execution.run_artifacts[0].output_directives == []
     assert tf_execution.run_artifacts[0].measurement_names == []
     assert tf_execution.run_artifacts[0].fourier_probes == []
     assert tf_execution.run_artifact_table == (
-        "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tOutputProbeList\tMeasurements\tMeasurementList\tFourier\tFourierList\n"
-        f"tf\t.tf\t{tf_execution.plan.line_number}\t1\t1\tV(mid)\t0\t\t0\t\n"
+        "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\n"
+        f"tf\t.tf\t{tf_execution.plan.line_number}\t1\t1\tV(mid)\t0\t\t0\t\t0\t\n"
     )
 
     sens_execution = run_deck_analysis(circuit, netlist, "sens")
@@ -6910,11 +6915,12 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
     assert sens_execution.run_artifacts[0].analysis == "sens"
     assert sens_execution.run_artifacts[0].result_rows == 1
     assert sens_execution.run_artifacts[0].output_probes == ["V(mid)"]
+    assert sens_execution.run_artifacts[0].output_directives == []
     assert sens_execution.run_artifacts[0].measurement_names == []
     assert sens_execution.run_artifacts[0].fourier_probes == []
     assert sens_execution.run_artifact_table == (
-        "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tOutputProbeList\tMeasurements\tMeasurementList\tFourier\tFourierList\n"
-        f"sens\t.sens\t{sens_execution.plan.line_number}\t1\t1\tV(mid)\t0\t\t0\t\n"
+        "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\n"
+        f"sens\t.sens\t{sens_execution.plan.line_number}\t1\t1\tV(mid)\t0\t\t0\t\t0\t\n"
     )
 
     noise_execution = run_deck_analysis(circuit, netlist, "noise")
@@ -6939,11 +6945,12 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
     assert noise_execution.run_artifacts[0].analysis == "noise"
     assert noise_execution.run_artifacts[0].result_rows == 1
     assert noise_execution.run_artifacts[0].output_probes == ["V(mid)"]
+    assert noise_execution.run_artifacts[0].output_directives == []
     assert noise_execution.run_artifacts[0].measurement_names == []
     assert noise_execution.run_artifacts[0].fourier_probes == []
     assert noise_execution.run_artifact_table == (
-        "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tOutputProbeList\tMeasurements\tMeasurementList\tFourier\tFourierList\n"
-        f"noise\t.noise\t{noise_execution.plan.line_number}\t1\t1\tV(mid)\t0\t\t0\t\n"
+        "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\n"
+        f"noise\t.noise\t{noise_execution.plan.line_number}\t1\t1\tV(mid)\t0\t\t0\t\t0\t\n"
     )
 
     tran_window_execution = run_deck_analysis(
@@ -7018,11 +7025,12 @@ def test_run_deck_analysis_exposes_selected_fourier_artifacts() -> None:
     assert tran_execution.fourier_table == format_fourier_table(result)
     assert tran_execution.run_artifacts[0].fourier_count == 1
     assert tran_execution.run_artifacts[0].output_probes == ["V(mid)"]
+    assert tran_execution.run_artifacts[0].output_directives == [".save"]
     assert tran_execution.run_artifacts[0].measurement_names == []
     assert tran_execution.run_artifacts[0].fourier_probes == ["V(mid)"]
     assert tran_execution.run_artifact_table == (
-        "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tOutputProbeList\tMeasurements\tMeasurementList\tFourier\tFourierList\n"
-        f"tran\t.tran\t{tran_execution.plan.line_number}\t3\t1\tV(mid)\t0\t\t1\tV(mid)\n"
+        "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\n"
+        f"tran\t.tran\t{tran_execution.plan.line_number}\t3\t1\tV(mid)\t1\t.save\t0\t\t1\tV(mid)\n"
     )
 
 

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -3410,6 +3410,8 @@ pub struct DeckRunArtifact {
     pub result_rows: usize,
     pub output_probe_count: usize,
     pub output_probes: Vec<String>,
+    pub output_directive_count: usize,
+    pub output_directives: Vec<String>,
     pub measurement_count: usize,
     pub measurement_names: Vec<String>,
     pub fourier_count: usize,
@@ -3931,6 +3933,32 @@ pub fn select_deck_output_probes(netlist: &str, analysis: &str) -> Result<Vec<St
             if seen.insert(key) {
                 selected.push(probe);
             }
+        }
+    }
+    Ok(selected)
+}
+
+pub fn select_deck_output_directives(
+    netlist: &str,
+    analysis: &str,
+) -> Result<Vec<String>, SpiceError> {
+    let summary = resolve_deck_outputs(netlist);
+    if let Some(diagnostic) = summary.diagnostics.first() {
+        return Err(table_error(
+            "select_deck_output_directives",
+            &format!("line {}: {}", diagnostic.line_number, diagnostic.message),
+        ));
+    }
+    let mut selected = Vec::new();
+    let mut seen = HashSet::new();
+    for selection in summary.selections {
+        if !selection.analysis.as_deref().map_or(true, |requested| {
+            deck_output_analysis_matches(requested, analysis)
+        }) {
+            continue;
+        }
+        if seen.insert(selection.directive.clone()) {
+            selected.push(selection.directive);
         }
     }
     Ok(selected)
@@ -10051,6 +10079,7 @@ fn deck_run_artifacts(
     plan: &DeckAnalysisPlan,
     result_rows: usize,
     output_probes: &[String],
+    output_directives: &[String],
     measurements: &[ProbeMeasurement],
     fourier: &[FourierResult],
 ) -> Vec<DeckRunArtifact> {
@@ -10061,6 +10090,8 @@ fn deck_run_artifacts(
         result_rows,
         output_probe_count: output_probes.len(),
         output_probes: output_probes.to_vec(),
+        output_directive_count: output_directives.len(),
+        output_directives: output_directives.to_vec(),
         measurement_count: measurements.len(),
         measurement_names: measurements
             .iter()
@@ -10076,18 +10107,20 @@ fn deck_run_artifacts(
 
 pub fn format_deck_run_artifact_table(artifacts: &[DeckRunArtifact]) -> String {
     let mut rows = vec![
-        "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tOutputProbeList\tMeasurements\tMeasurementList\tFourier\tFourierList"
+        "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList"
             .to_string(),
     ];
     for artifact in artifacts {
         rows.push(format!(
-            "{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}",
+            "{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}",
             artifact.analysis,
             artifact.directive,
             artifact.line_number,
             artifact.result_rows,
             artifact.output_probe_count,
             artifact.output_probes.join(";"),
+            artifact.output_directive_count,
+            artifact.output_directives.join(";"),
             artifact.measurement_count,
             artifact.measurement_names.join(";"),
             artifact.fourier_count,
@@ -10153,8 +10186,15 @@ pub fn run_deck_analysis(
             let fourier = Vec::new();
             let fourier_table = format_deck_fourier_table(&fourier);
             let output_probes = select_deck_output_probes(netlist, "op")?;
-            let run_artifacts =
-                deck_run_artifacts(&plan, 1, &output_probes, &measurements, &fourier);
+            let output_directives = select_deck_output_directives(netlist, "op")?;
+            let run_artifacts = deck_run_artifacts(
+                &plan,
+                1,
+                &output_probes,
+                &output_directives,
+                &measurements,
+                &fourier,
+            );
             let run_artifact_table = format_deck_run_artifact_table(&run_artifacts);
             Ok(DeckAnalysisExecution {
                 plan,
@@ -10185,8 +10225,15 @@ pub fn run_deck_analysis(
             let fourier = Vec::new();
             let fourier_table = format_deck_fourier_table(&fourier);
             let output_probes = select_deck_output_probes(netlist, "dc")?;
-            let run_artifacts =
-                deck_run_artifacts(&plan, result.len(), &output_probes, &measurements, &fourier);
+            let output_directives = select_deck_output_directives(netlist, "dc")?;
+            let run_artifacts = deck_run_artifacts(
+                &plan,
+                result.len(),
+                &output_probes,
+                &output_directives,
+                &measurements,
+                &fourier,
+            );
             let run_artifact_table = format_deck_run_artifact_table(&run_artifacts);
             Ok(DeckAnalysisExecution {
                 plan,
@@ -10218,8 +10265,15 @@ pub fn run_deck_analysis(
             let fourier = Vec::new();
             let fourier_table = format_deck_fourier_table(&fourier);
             let output_probes = select_deck_output_probes(netlist, "ac")?;
-            let run_artifacts =
-                deck_run_artifacts(&plan, result.len(), &output_probes, &measurements, &fourier);
+            let output_directives = select_deck_output_directives(netlist, "ac")?;
+            let run_artifacts = deck_run_artifacts(
+                &plan,
+                result.len(),
+                &output_probes,
+                &output_directives,
+                &measurements,
+                &fourier,
+            );
             let run_artifact_table = format_deck_run_artifact_table(&run_artifacts);
             Ok(DeckAnalysisExecution {
                 plan,
@@ -10254,8 +10308,15 @@ pub fn run_deck_analysis(
             let fourier = fourier_transient_cards(&result, &fourier_cards)?;
             let fourier_table = format_deck_fourier_table(&fourier);
             let output_probes = select_deck_output_probes(netlist, "tran")?;
-            let run_artifacts =
-                deck_run_artifacts(&plan, result.len(), &output_probes, &measurements, &fourier);
+            let output_directives = select_deck_output_directives(netlist, "tran")?;
+            let run_artifacts = deck_run_artifacts(
+                &plan,
+                result.len(),
+                &output_probes,
+                &output_directives,
+                &measurements,
+                &fourier,
+            );
             let run_artifact_table = format_deck_run_artifact_table(&run_artifacts);
             Ok(DeckAnalysisExecution {
                 plan,
@@ -10283,8 +10344,15 @@ pub fn run_deck_analysis(
             let fourier = Vec::new();
             let fourier_table = format_deck_fourier_table(&fourier);
             let output_probes = vec![format!("V({output_node})")];
-            let run_artifacts =
-                deck_run_artifacts(&plan, 1, &output_probes, &measurements, &fourier);
+            let output_directives = Vec::new();
+            let run_artifacts = deck_run_artifacts(
+                &plan,
+                1,
+                &output_probes,
+                &output_directives,
+                &measurements,
+                &fourier,
+            );
             let run_artifact_table = format_deck_run_artifact_table(&run_artifacts);
             Ok(DeckAnalysisExecution {
                 plan,
@@ -10310,8 +10378,15 @@ pub fn run_deck_analysis(
             let fourier = Vec::new();
             let fourier_table = format_deck_fourier_table(&fourier);
             let output_probes = vec![format!("V({output_node})")];
-            let run_artifacts =
-                deck_run_artifacts(&plan, 1, &output_probes, &measurements, &fourier);
+            let output_directives = Vec::new();
+            let run_artifacts = deck_run_artifacts(
+                &plan,
+                1,
+                &output_probes,
+                &output_directives,
+                &measurements,
+                &fourier,
+            );
             let run_artifact_table = format_deck_run_artifact_table(&run_artifacts);
             Ok(DeckAnalysisExecution {
                 plan,
@@ -10349,10 +10424,12 @@ pub fn run_deck_analysis(
             let fourier = Vec::new();
             let fourier_table = format_deck_fourier_table(&fourier);
             let output_probes = vec![format!("V({output_node})")];
+            let output_directives = Vec::new();
             let run_artifacts = deck_run_artifacts(
                 &plan,
                 result.points.len(),
                 &output_probes,
+                &output_directives,
                 &measurements,
                 &fourier,
             );

--- a/code/packages/rust/spice-engine/tests/transient_tests.rs
+++ b/code/packages/rust/spice-engine/tests/transient_tests.rs
@@ -1892,12 +1892,16 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
         op_execution.run_artifacts[0].output_probes,
         vec!["V(mid)".to_string()]
     );
+    assert_eq!(
+        op_execution.run_artifacts[0].output_directives,
+        vec![".save".to_string()]
+    );
     assert!(op_execution.run_artifacts[0].measurement_names.is_empty());
     assert!(op_execution.run_artifacts[0].fourier_probes.is_empty());
     assert_eq!(
         op_execution.run_artifact_table,
         format!(
-            "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tOutputProbeList\tMeasurements\tMeasurementList\tFourier\tFourierList\nop\t.op\t{}\t1\t1\tV(mid)\t0\t\t0\t\n",
+            "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\nop\t.op\t{}\t1\t1\tV(mid)\t1\t.save\t0\t\t0\t\n",
             op_execution.plan.line_number
         )
     );
@@ -1927,6 +1931,10 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
         vec!["V(mid)".to_string(), "I(V1)".to_string()]
     );
     assert_eq!(
+        dc_execution.run_artifacts[0].output_directives,
+        vec![".save".to_string(), ".probe".to_string()]
+    );
+    assert_eq!(
         dc_execution.run_artifacts[0].measurement_names,
         vec!["mid_avg".to_string()]
     );
@@ -1934,7 +1942,7 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
     assert_eq!(
         dc_execution.run_artifact_table,
         format!(
-            "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tOutputProbeList\tMeasurements\tMeasurementList\tFourier\tFourierList\ndc\t.dc\t{}\t2\t2\tV(mid);I(V1)\t1\tmid_avg\t0\t\n",
+            "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\ndc\t.dc\t{}\t2\t2\tV(mid);I(V1)\t2\t.save;.probe\t1\tmid_avg\t0\t\n",
             dc_execution.plan.line_number
         )
     );
@@ -1959,6 +1967,10 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
         vec!["V(mid)".to_string()]
     );
     assert_eq!(
+        ac_execution.run_artifacts[0].output_directives,
+        vec![".save".to_string()]
+    );
+    assert_eq!(
         ac_execution.run_artifacts[0].measurement_names,
         vec!["mid_peak".to_string()]
     );
@@ -1966,7 +1978,7 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
     assert_eq!(
         ac_execution.run_artifact_table,
         format!(
-            "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tOutputProbeList\tMeasurements\tMeasurementList\tFourier\tFourierList\nac\t.ac\t{}\t1\t1\tV(mid)\t1\tmid_peak\t0\t\n",
+            "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\nac\t.ac\t{}\t1\t1\tV(mid)\t1\t.save\t1\tmid_peak\t0\t\n",
             ac_execution.plan.line_number
         )
     );
@@ -1991,6 +2003,10 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
         vec!["V(mid)".to_string()]
     );
     assert_eq!(
+        tran_execution.run_artifacts[0].output_directives,
+        vec![".save".to_string()]
+    );
+    assert_eq!(
         tran_execution.run_artifacts[0].measurement_names,
         vec!["mid_final".to_string()]
     );
@@ -1998,7 +2014,7 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
     assert_eq!(
         tran_execution.run_artifact_table,
         format!(
-            "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tOutputProbeList\tMeasurements\tMeasurementList\tFourier\tFourierList\ntran\t.tran\t{}\t1\t1\tV(mid)\t1\tmid_final\t0\t\n",
+            "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\ntran\t.tran\t{}\t1\t1\tV(mid)\t1\t.save\t1\tmid_final\t0\t\n",
             tran_execution.plan.line_number
         )
     );
@@ -2030,12 +2046,13 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
         tf_execution.run_artifacts[0].output_probes,
         vec!["V(mid)".to_string()]
     );
+    assert!(tf_execution.run_artifacts[0].output_directives.is_empty());
     assert!(tf_execution.run_artifacts[0].measurement_names.is_empty());
     assert!(tf_execution.run_artifacts[0].fourier_probes.is_empty());
     assert_eq!(
         tf_execution.run_artifact_table,
         format!(
-            "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tOutputProbeList\tMeasurements\tMeasurementList\tFourier\tFourierList\ntf\t.tf\t{}\t1\t1\tV(mid)\t0\t\t0\t\n",
+            "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\ntf\t.tf\t{}\t1\t1\tV(mid)\t0\t\t0\t\t0\t\n",
             tf_execution.plan.line_number
         )
     );
@@ -2065,12 +2082,13 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
         sens_execution.run_artifacts[0].output_probes,
         vec!["V(mid)".to_string()]
     );
+    assert!(sens_execution.run_artifacts[0].output_directives.is_empty());
     assert!(sens_execution.run_artifacts[0].measurement_names.is_empty());
     assert!(sens_execution.run_artifacts[0].fourier_probes.is_empty());
     assert_eq!(
         sens_execution.run_artifact_table,
         format!(
-            "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tOutputProbeList\tMeasurements\tMeasurementList\tFourier\tFourierList\nsens\t.sens\t{}\t1\t1\tV(mid)\t0\t\t0\t\n",
+            "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\nsens\t.sens\t{}\t1\t1\tV(mid)\t0\t\t0\t\t0\t\n",
             sens_execution.plan.line_number
         )
     );
@@ -2107,13 +2125,16 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
         vec!["V(mid)".to_string()]
     );
     assert!(noise_execution.run_artifacts[0]
+        .output_directives
+        .is_empty());
+    assert!(noise_execution.run_artifacts[0]
         .measurement_names
         .is_empty());
     assert!(noise_execution.run_artifacts[0].fourier_probes.is_empty());
     assert_eq!(
         noise_execution.run_artifact_table,
         format!(
-            "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tOutputProbeList\tMeasurements\tMeasurementList\tFourier\tFourierList\nnoise\t.noise\t{}\t1\t1\tV(mid)\t0\t\t0\t\n",
+            "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\nnoise\t.noise\t{}\t1\t1\tV(mid)\t0\t\t0\t\t0\t\n",
             noise_execution.plan.line_number
         )
     );
@@ -2220,6 +2241,10 @@ fn run_deck_analysis_exposes_selected_fourier_artifacts() {
         tran_execution.run_artifacts[0].output_probes,
         vec!["V(mid)".to_string()]
     );
+    assert_eq!(
+        tran_execution.run_artifacts[0].output_directives,
+        vec![".save".to_string()]
+    );
     assert!(tran_execution.run_artifacts[0].measurement_names.is_empty());
     assert_eq!(
         tran_execution.run_artifacts[0].fourier_probes,
@@ -2228,7 +2253,7 @@ fn run_deck_analysis_exposes_selected_fourier_artifacts() {
     assert_eq!(
         tran_execution.run_artifact_table,
         format!(
-            "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tOutputProbeList\tMeasurements\tMeasurementList\tFourier\tFourierList\ntran\t.tran\t{}\t2\t1\tV(mid)\t0\t\t1\tV(mid)\n",
+            "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\ntran\t.tran\t{}\t2\t1\tV(mid)\t1\t.save\t0\t\t1\tV(mid)\n",
             tran_execution.plan.line_number
         )
     );

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -665,6 +665,8 @@ export interface DeckRunArtifact {
   readonly resultRows: number;
   readonly outputProbeCount: number;
   readonly outputProbes: readonly string[];
+  readonly outputDirectiveCount: number;
+  readonly outputDirectives: readonly string[];
   readonly measurementCount: number;
   readonly measurementNames: readonly string[];
   readonly fourierCount: number;
@@ -3298,6 +3300,30 @@ export function selectDeckOutputProbes(netlist: string, analysis: string): strin
       seen.add(key);
       selected.push(probe);
     }
+  }
+  return selected;
+}
+
+export function selectDeckOutputDirectives(netlist: string, analysis: string): string[] {
+  const summary = resolveDeckOutputs(netlist);
+  if (summary.diagnostics.length > 0) {
+    const diagnostic = summary.diagnostics[0];
+    throw invalidElement(
+      "selectDeckOutputDirectives",
+      `line ${diagnostic.lineNumber}: ${diagnostic.message}`,
+    );
+  }
+  const selected: string[] = [];
+  const seen = new Set<string>();
+  for (const selection of summary.selections) {
+    if (selection.analysis !== undefined && !deckOutputAnalysisMatches(selection.analysis, analysis)) {
+      continue;
+    }
+    if (seen.has(selection.directive)) {
+      continue;
+    }
+    seen.add(selection.directive);
+    selected.push(selection.directive);
   }
   return selected;
 }
@@ -7840,6 +7866,7 @@ function deckRunArtifacts(
   plan: DeckAnalysisPlan,
   result: DeckAnalysisExecutionResult,
   outputProbes: readonly string[],
+  outputDirectives: readonly string[],
   measurements: readonly ProbeMeasurement[],
   fourier: readonly FourierResult[],
 ): DeckRunArtifact[] {
@@ -7851,6 +7878,8 @@ function deckRunArtifacts(
       resultRows: deckResultRowCount(result),
       outputProbeCount: outputProbes.length,
       outputProbes: [...outputProbes],
+      outputDirectiveCount: outputDirectives.length,
+      outputDirectives: [...outputDirectives],
       measurementCount: measurements.length,
       measurementNames: measurements.map((measurement) => measurement.name),
       fourierCount: fourier.length,
@@ -7861,7 +7890,7 @@ function deckRunArtifacts(
 
 export function formatDeckRunArtifactTable(artifacts: readonly DeckRunArtifact[]): string {
   const rows = [
-    "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tOutputProbeList\tMeasurements\tMeasurementList\tFourier\tFourierList",
+    "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList",
   ];
   for (const artifact of artifacts) {
     rows.push(
@@ -7872,6 +7901,8 @@ export function formatDeckRunArtifactTable(artifacts: readonly DeckRunArtifact[]
         String(artifact.resultRows),
         String(artifact.outputProbeCount),
         artifact.outputProbes.join(";"),
+        String(artifact.outputDirectiveCount),
+        artifact.outputDirectives.join(";"),
         String(artifact.measurementCount),
         artifact.measurementNames.join(";"),
         String(artifact.fourierCount),
@@ -7928,7 +7959,15 @@ export function runDeckAnalysis(
     const measurements: ProbeMeasurement[] = [];
     const fourier: FourierResult[] = [];
     const outputProbes = selectDeckOutputProbes(netlist, plan.analysis);
-    const runArtifacts = deckRunArtifacts(plan, result, outputProbes, measurements, fourier);
+    const outputDirectives = selectDeckOutputDirectives(netlist, plan.analysis);
+    const runArtifacts = deckRunArtifacts(
+      plan,
+      result,
+      outputProbes,
+      outputDirectives,
+      measurements,
+      fourier,
+    );
     return {
       plan,
       result,
@@ -7955,7 +7994,15 @@ export function runDeckAnalysis(
     selectDeckFourierCardsForAnalysis(netlist, plan.analysis);
     const fourier: FourierResult[] = [];
     const outputProbes = selectDeckOutputProbes(netlist, plan.analysis);
-    const runArtifacts = deckRunArtifacts(plan, result, outputProbes, measurements, fourier);
+    const outputDirectives = selectDeckOutputDirectives(netlist, plan.analysis);
+    const runArtifacts = deckRunArtifacts(
+      plan,
+      result,
+      outputProbes,
+      outputDirectives,
+      measurements,
+      fourier,
+    );
     return {
       plan,
       result,
@@ -7993,7 +8040,15 @@ export function runDeckAnalysis(
     selectDeckFourierCardsForAnalysis(netlist, plan.analysis);
     const fourier: FourierResult[] = [];
     const outputProbes = selectDeckOutputProbes(netlist, plan.analysis);
-    const runArtifacts = deckRunArtifacts(plan, result, outputProbes, measurements, fourier);
+    const outputDirectives = selectDeckOutputDirectives(netlist, plan.analysis);
+    const runArtifacts = deckRunArtifacts(
+      plan,
+      result,
+      outputProbes,
+      outputDirectives,
+      measurements,
+      fourier,
+    );
     return {
       plan,
       result,
@@ -8026,7 +8081,15 @@ export function runDeckAnalysis(
       selectDeckFourierCardsForAnalysis(netlist, plan.analysis),
     );
     const outputProbes = selectDeckOutputProbes(netlist, plan.analysis);
-    const runArtifacts = deckRunArtifacts(plan, result, outputProbes, measurements, fourier);
+    const outputDirectives = selectDeckOutputDirectives(netlist, plan.analysis);
+    const runArtifacts = deckRunArtifacts(
+      plan,
+      result,
+      outputProbes,
+      outputDirectives,
+      measurements,
+      fourier,
+    );
     return {
       plan,
       result,
@@ -8049,7 +8112,15 @@ export function runDeckAnalysis(
     const measurements: ProbeMeasurement[] = [];
     const fourier: FourierResult[] = [];
     const outputProbes = [`V(${outputNode})`];
-    const runArtifacts = deckRunArtifacts(plan, result, outputProbes, measurements, fourier);
+    const outputDirectives: string[] = [];
+    const runArtifacts = deckRunArtifacts(
+      plan,
+      result,
+      outputProbes,
+      outputDirectives,
+      measurements,
+      fourier,
+    );
     return {
       plan,
       result,
@@ -8071,7 +8142,15 @@ export function runDeckAnalysis(
     const measurements: ProbeMeasurement[] = [];
     const fourier: FourierResult[] = [];
     const outputProbes = [`V(${outputNode})`];
-    const runArtifacts = deckRunArtifacts(plan, result, outputProbes, measurements, fourier);
+    const outputDirectives: string[] = [];
+    const runArtifacts = deckRunArtifacts(
+      plan,
+      result,
+      outputProbes,
+      outputDirectives,
+      measurements,
+      fourier,
+    );
     return {
       plan,
       result,
@@ -8103,7 +8182,15 @@ export function runDeckAnalysis(
     const measurements: ProbeMeasurement[] = [];
     const fourier: FourierResult[] = [];
     const outputProbes = [`V(${outputNode})`];
-    const runArtifacts = deckRunArtifacts(plan, result, outputProbes, measurements, fourier);
+    const outputDirectives: string[] = [];
+    const runArtifacts = deckRunArtifacts(
+      plan,
+      result,
+      outputProbes,
+      outputDirectives,
+      measurements,
+      fourier,
+    );
     return {
       plan,
       result,

--- a/code/packages/typescript/spice-engine/tests/transient.test.ts
+++ b/code/packages/typescript/spice-engine/tests/transient.test.ts
@@ -1470,11 +1470,12 @@ describe("transient", () => {
     expect(opExecution.table).toBe("Index\tV(mid)\n0\t5.000000e-01\n");
     expect(opExecution.runArtifacts[0]?.resultRows).toBe(1);
     expect(opExecution.runArtifacts[0]?.outputProbes).toEqual(["V(mid)"]);
+    expect(opExecution.runArtifacts[0]?.outputDirectives).toEqual([".save"]);
     expect(opExecution.runArtifacts[0]?.measurementNames).toEqual([]);
     expect(opExecution.runArtifacts[0]?.fourierProbes).toEqual([]);
     expect(opExecution.runArtifactTable).toBe(
-      "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tOutputProbeList\tMeasurements\tMeasurementList\tFourier\tFourierList\n" +
-        `op\t.op\t${opExecution.plan.lineNumber}\t1\t1\tV(mid)\t0\t\t0\t\n`,
+      "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\n" +
+        `op\t.op\t${opExecution.plan.lineNumber}\t1\t1\tV(mid)\t1\t.save\t0\t\t0\t\n`,
     );
 
     const dcExecution = runDeckAnalysis(circuit, netlist, "dc");
@@ -1493,11 +1494,12 @@ describe("transient", () => {
     );
     expect(dcExecution.runArtifacts[0]?.analysis).toBe("dc");
     expect(dcExecution.runArtifacts[0]?.outputProbes).toEqual(["V(mid)", "I(V1)"]);
+    expect(dcExecution.runArtifacts[0]?.outputDirectives).toEqual([".save", ".probe"]);
     expect(dcExecution.runArtifacts[0]?.measurementNames).toEqual(["mid_avg"]);
     expect(dcExecution.runArtifacts[0]?.fourierProbes).toEqual([]);
     expect(dcExecution.runArtifactTable).toBe(
-      "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tOutputProbeList\tMeasurements\tMeasurementList\tFourier\tFourierList\n" +
-        `dc\t.dc\t${dcExecution.plan.lineNumber}\t2\t2\tV(mid);I(V1)\t1\tmid_avg\t0\t\n`,
+      "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\n" +
+        `dc\t.dc\t${dcExecution.plan.lineNumber}\t2\t2\tV(mid);I(V1)\t2\t.save;.probe\t1\tmid_avg\t0\t\n`,
     );
 
     const acExecution = runDeckAnalysis(circuit, netlist, "ac");
@@ -1513,11 +1515,12 @@ describe("transient", () => {
         "0\t1.000000e+03\tV(mid)\t5.000000e-01\t0.000000e+00\t5.000000e-01\t0.000000e+00\n",
     );
     expect(acExecution.runArtifacts[0]?.outputProbes).toEqual(["V(mid)"]);
+    expect(acExecution.runArtifacts[0]?.outputDirectives).toEqual([".save"]);
     expect(acExecution.runArtifacts[0]?.measurementNames).toEqual(["mid_peak"]);
     expect(acExecution.runArtifacts[0]?.fourierProbes).toEqual([]);
     expect(acExecution.runArtifactTable).toBe(
-      "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tOutputProbeList\tMeasurements\tMeasurementList\tFourier\tFourierList\n" +
-        `ac\t.ac\t${acExecution.plan.lineNumber}\t1\t1\tV(mid)\t1\tmid_peak\t0\t\n`,
+      "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\n" +
+        `ac\t.ac\t${acExecution.plan.lineNumber}\t1\t1\tV(mid)\t1\t.save\t1\tmid_peak\t0\t\n`,
     );
 
     const tranExecution = runDeckAnalysis(circuit, netlist, "tran");
@@ -1533,11 +1536,12 @@ describe("transient", () => {
         "0\t1.000000e-03\t5.000000e-01\n",
     );
     expect(tranExecution.runArtifacts[0]?.outputProbes).toEqual(["V(mid)"]);
+    expect(tranExecution.runArtifacts[0]?.outputDirectives).toEqual([".save"]);
     expect(tranExecution.runArtifacts[0]?.measurementNames).toEqual(["mid_final"]);
     expect(tranExecution.runArtifacts[0]?.fourierProbes).toEqual([]);
     expect(tranExecution.runArtifactTable).toBe(
-      "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tOutputProbeList\tMeasurements\tMeasurementList\tFourier\tFourierList\n" +
-        `tran\t.tran\t${tranExecution.plan.lineNumber}\t1\t1\tV(mid)\t1\tmid_final\t0\t\n`,
+      "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\n" +
+        `tran\t.tran\t${tranExecution.plan.lineNumber}\t1\t1\tV(mid)\t1\t.save\t1\tmid_final\t0\t\n`,
     );
 
     const tfExecution = runDeckAnalysis(circuit, netlist, "tf");
@@ -1561,11 +1565,12 @@ describe("transient", () => {
     expect(tfExecution.runArtifacts[0]?.analysis).toBe("tf");
     expect(tfExecution.runArtifacts[0]?.resultRows).toBe(1);
     expect(tfExecution.runArtifacts[0]?.outputProbes).toEqual(["V(mid)"]);
+    expect(tfExecution.runArtifacts[0]?.outputDirectives).toEqual([]);
     expect(tfExecution.runArtifacts[0]?.measurementNames).toEqual([]);
     expect(tfExecution.runArtifacts[0]?.fourierProbes).toEqual([]);
     expect(tfExecution.runArtifactTable).toBe(
-      "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tOutputProbeList\tMeasurements\tMeasurementList\tFourier\tFourierList\n" +
-        `tf\t.tf\t${tfExecution.plan.lineNumber}\t1\t1\tV(mid)\t0\t\t0\t\n`,
+      "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\n" +
+        `tf\t.tf\t${tfExecution.plan.lineNumber}\t1\t1\tV(mid)\t0\t\t0\t\t0\t\n`,
     );
 
     const sensExecution = runDeckAnalysis(circuit, netlist, "sens");
@@ -1586,11 +1591,12 @@ describe("transient", () => {
     expect(sensExecution.runArtifacts[0]?.analysis).toBe("sens");
     expect(sensExecution.runArtifacts[0]?.resultRows).toBe(1);
     expect(sensExecution.runArtifacts[0]?.outputProbes).toEqual(["V(mid)"]);
+    expect(sensExecution.runArtifacts[0]?.outputDirectives).toEqual([]);
     expect(sensExecution.runArtifacts[0]?.measurementNames).toEqual([]);
     expect(sensExecution.runArtifacts[0]?.fourierProbes).toEqual([]);
     expect(sensExecution.runArtifactTable).toBe(
-      "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tOutputProbeList\tMeasurements\tMeasurementList\tFourier\tFourierList\n" +
-        `sens\t.sens\t${sensExecution.plan.lineNumber}\t1\t1\tV(mid)\t0\t\t0\t\n`,
+      "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\n" +
+        `sens\t.sens\t${sensExecution.plan.lineNumber}\t1\t1\tV(mid)\t0\t\t0\t\t0\t\n`,
     );
 
     const noiseExecution = runDeckAnalysis(circuit, netlist, "noise");
@@ -1614,11 +1620,12 @@ describe("transient", () => {
     expect(noiseExecution.runArtifacts[0]?.analysis).toBe("noise");
     expect(noiseExecution.runArtifacts[0]?.resultRows).toBe(1);
     expect(noiseExecution.runArtifacts[0]?.outputProbes).toEqual(["V(mid)"]);
+    expect(noiseExecution.runArtifacts[0]?.outputDirectives).toEqual([]);
     expect(noiseExecution.runArtifacts[0]?.measurementNames).toEqual([]);
     expect(noiseExecution.runArtifacts[0]?.fourierProbes).toEqual([]);
     expect(noiseExecution.runArtifactTable).toBe(
-      "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tOutputProbeList\tMeasurements\tMeasurementList\tFourier\tFourierList\n" +
-        `noise\t.noise\t${noiseExecution.plan.lineNumber}\t1\t1\tV(mid)\t0\t\t0\t\n`,
+      "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\n" +
+        `noise\t.noise\t${noiseExecution.plan.lineNumber}\t1\t1\tV(mid)\t0\t\t0\t\t0\t\n`,
     );
 
     const tranWindowExecution = runDeckAnalysis(
@@ -1696,11 +1703,12 @@ describe("transient", () => {
     expect(tranExecution.fourierTable).toBe(formatFourierTable(result));
     expect(tranExecution.runArtifacts[0]?.fourierCount).toBe(1);
     expect(tranExecution.runArtifacts[0]?.outputProbes).toEqual(["V(mid)"]);
+    expect(tranExecution.runArtifacts[0]?.outputDirectives).toEqual([".save"]);
     expect(tranExecution.runArtifacts[0]?.measurementNames).toEqual([]);
     expect(tranExecution.runArtifacts[0]?.fourierProbes).toEqual(["V(mid)"]);
     expect(tranExecution.runArtifactTable).toBe(
-      "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tOutputProbeList\tMeasurements\tMeasurementList\tFourier\tFourierList\n" +
-        `tran\t.tran\t${tranExecution.plan.lineNumber}\t2\t1\tV(mid)\t0\t\t1\tV(mid)\n`,
+      "Analysis\tDirective\tLine\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\n" +
+        `tran\t.tran\t${tranExecution.plan.lineNumber}\t2\t1\tV(mid)\t1\t.save\t0\t\t1\tV(mid)\n`,
     );
   });
 

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -785,6 +785,15 @@ downstream tools to compare.
       solver and stable noise table while exposing deck-run artifacts for the
       noise output probe and selected frequency rows.
 
+71. Deck run output-directive artifacts.
+    - Status: completed in this deck run output-directive artifact slice.
+    - Python, Rust, and TypeScript selected deck executions now expose the
+      selected output directive kinds that contributed to each deck-run
+      artifact, alongside the existing selected output probe list.
+    - The stable run-artifact table now includes `OutputDirectiveList`, so
+      callers can distinguish `.save`, `.probe`, `.print`, and `.plot`
+      provenance without reparsing deck output cards.
+
 ## Backlog
 
 1. Deck execution layer.


### PR DESCRIPTION
## Summary
- expose selected deck output directive kinds in Python, Rust, and TypeScript deck-run artifacts
- add stable `OutputDirectives` / `OutputDirectiveList` columns to the deck run artifact table
- preserve `.save`, `.probe`, `.print`, and `.plot` provenance without reparsing deck output cards

## Verification
- `/Users/adhithya/.local/share/mise/installs/python/3.12.13/bin/ruff check code/packages/python/spice-engine`
- `PYTEST_ADDOPTS=--no-cov PYTHONPATH=code/packages/python/device-physics/src:code/packages/python/mosfet-models/src:code/packages/python/spice-engine/src /Users/adhithya/.local/share/mise/installs/python/3.12.13/bin/python3.12 -m pytest code/packages/python/spice-engine/tests/test_compatibility.py code/packages/python/spice-engine/tests/test_engine.py -q`
- `cargo fmt --manifest-path code/packages/rust/spice-engine/Cargo.toml -- --check`
- `cargo test --manifest-path code/packages/rust/spice-engine/Cargo.toml`
- `PATH=/Users/adhithya/.local/share/mise/installs/node/22.22.3/bin:$PATH npm --prefix code/packages/typescript/spice-engine ci`
- `PATH=/Users/adhithya/.local/share/mise/installs/node/22.22.3/bin:$PATH npm --prefix code/packages/typescript/spice-engine run build`
- `PATH=/Users/adhithya/.local/share/mise/installs/node/22.22.3/bin:$PATH npm --prefix code/packages/typescript/spice-engine test`