### PR TITLE
feat(mycin-pharm): Tier-1 pharmacology recall as an ADJ-only grounded library

### DIFF
--- a/code/specs/data/mycin-2026/USMLE-DOMAIN-MAP.md
+++ b/code/specs/data/mycin-2026/USMLE-DOMAIN-MAP.md
@@ -106,6 +106,7 @@ unchanged. Adding a relation just widens the schema — the engine already binds
 | Meningitis | Infectious dz | **differential** (LR) + **management** (constraints) | grounded LRs + formulary | ✓ |
 | Bacteremia / UTI | Infectious dz | organism-id + treatment | grounded | ✓ |
 | Microbiology | Microbiology | gram_stain, morphology, causes | 13 grounded (ADJ-only) | ✓ |
+| Pharmacology | Pharmacology | drug_class, mechanism, adverse_effect, antidote_for | 9 grounded (ADJ-only) | ✓ |
 
 Offline pipeline: prose → local-model decompose → ADJ → native engine, two-sided
 faithfulness gate, zero online calls (OFFLINE-BOARD-EXAM.md).
@@ -122,6 +123,13 @@ faithfulness gate, zero online calls (OFFLINE-BOARD-EXAM.md).
    viruses / fungi / parasites; M. tuberculosis (acid-fast) and the declined causes-edges.
 2. **Pharmacology** — drug → mechanism, class, indication, adverse effect, antidote.
    Dense, relational, subject-named in stems.
+   *Started (PHARM):* `drug_class` / `mechanism` / `adverse_effect` / `antidote_for` for
+   6 board-classic drugs (metformin, lisinopril, naloxone, flumazenil, warfarin,
+   acetaminophen — 9 edges, all grounded to byte-stable NCBI StatPearls spans) shipped
+   as the second **ADJ-only** domain (`recall/pharm-edges.adj`). Remaining: `treats`,
+   `metabolized_by`; more antidotes (protamine, vitamin K, atropine, fomepizole);
+   declined for now — propranolol class (no drug-named span) and the one-hop
+   adverse_effect(lisinopril, dry_cough) (attributed to the class, not the drug).
 3. **Immunology** — hypersensitivity types, immunodeficiencies, HLA associations, cytokines.
 4. **Genetics** — inheritance patterns, trinucleotide repeats, imprinting, gene defects
    (extends the IEM substrate).
@@ -176,8 +184,8 @@ manifest). MICRO onward, the order is grounding-FIRST (never seed authored-debt)
 ## Coverage accounting (the watchable number)
 
 The north-star metric: **% of the USMLE content outline covered by grounded, scored
-domains.** Today: 6 recall domains + ID differential/management (a slice of Multisystem,
-Endocrine, Hematology, Biochemistry, Nutrition, Microbiology — 65/66 board recall
-answers cite an authoritative grounded edge). Each merged domain PR moves this number;
+domains.** Today: 7 recall domains + ID differential/management (a slice of Multisystem,
+Endocrine, Hematology, Biochemistry, Nutrition, Microbiology, Pharmacology — 74/75 board
+recall answers cite an authoritative grounded edge). Each merged domain PR moves this number;
 this map is the denominator. The campaign is done when every Tier-1/2/3 cell above has a
 grounded, scored domain and the board bank samples each.

--- a/code/specs/data/mycin-2026/board/board-scorecard.json
+++ b/code/specs/data/mycin-2026/board/board-scorecard.json
@@ -1,7 +1,7 @@
 {
   "summary": {
-    "total": 79,
-    "correct": 72,
+    "total": 88,
+    "correct": 81,
     "abstained": 7,
     "wrong": 0,
     "by_tactic": {
@@ -16,15 +16,15 @@
         "wrong": 0
       },
       "recall": {
-        "correct": 66,
+        "correct": 75,
         "abstained": 6,
         "wrong": 0
       }
     },
     "defensibility": 1.0,
     "accuracy_on_attempted": 1.0,
-    "grounded_coverage": 0.9848,
-    "grounded_correct": 65
+    "grounded_coverage": 0.9867,
+    "grounded_correct": 74
   },
   "results": [
     {
@@ -656,6 +656,78 @@
       "tactic": "recall",
       "gold": "community_acquired_pneumonia",
       "answer": "community_acquired_pneumonia",
+      "outcome": "correct",
+      "trust": "authoritative"
+    },
+    {
+      "id": "pharm_metformin_class",
+      "tactic": "recall",
+      "gold": "biguanide",
+      "answer": "biguanide",
+      "outcome": "correct",
+      "trust": "authoritative"
+    },
+    {
+      "id": "pharm_lisinopril_class",
+      "tactic": "recall",
+      "gold": "ace_inhibitor",
+      "answer": "ace_inhibitor",
+      "outcome": "correct",
+      "trust": "authoritative"
+    },
+    {
+      "id": "pharm_naloxone_class",
+      "tactic": "recall",
+      "gold": "opioid_antagonist",
+      "answer": "opioid_antagonist",
+      "outcome": "correct",
+      "trust": "authoritative"
+    },
+    {
+      "id": "pharm_flumazenil_class",
+      "tactic": "recall",
+      "gold": "benzodiazepine_antagonist",
+      "answer": "benzodiazepine_antagonist",
+      "outcome": "correct",
+      "trust": "authoritative"
+    },
+    {
+      "id": "pharm_warfarin_moa",
+      "tactic": "recall",
+      "gold": "inhibits_vitamin_k_dependent_clotting_factor_synthesis",
+      "answer": "inhibits_vitamin_k_dependent_clotting_factor_synthesis",
+      "outcome": "correct",
+      "trust": "authoritative"
+    },
+    {
+      "id": "pharm_apap_adverse",
+      "tactic": "recall",
+      "gold": "hepatic_necrosis",
+      "answer": "hepatic_necrosis",
+      "outcome": "correct",
+      "trust": "authoritative"
+    },
+    {
+      "id": "pharm_apap_antidote",
+      "tactic": "recall",
+      "gold": "acetylcysteine",
+      "answer": "acetylcysteine",
+      "outcome": "correct",
+      "trust": "authoritative"
+    },
+    {
+      "id": "pharm_opioid_antidote",
+      "tactic": "recall",
+      "gold": "naloxone",
+      "answer": "naloxone",
+      "outcome": "correct",
+      "trust": "authoritative"
+    },
+    {
+      "id": "pharm_benzo_antidote",
+      "tactic": "recall",
+      "gold": "flumazenil",
+      "answer": "flumazenil",
       "outcome": "correct",
       "trust": "authoritative"
     }

--- a/code/specs/data/mycin-2026/board/board_eval.py
+++ b/code/specs/data/mycin-2026/board/board_eval.py
@@ -65,7 +65,7 @@ SCORECARD = HERE / "board-scorecard.json"
 # model calls. (A local in-memory model may generate the ADJ program from prose; see
 # board_offline.py. The engine that ANSWERS is always the native CPU reasoner.)
 EDGE_FILES = ["iem-edges.adj", "vitamin-edges.adj", "anemia-edges.adj", "endocrine-edges.adj",
-              "coag-edges.adj", "micro-edges.adj"]
+              "coag-edges.adj", "micro-edges.adj", "pharm-edges.adj"]
 
 # The native adj-lang CLI binary — the ONE engine behind every tactic (recall,
 # differential, management). If the binary is absent (e.g. a Python-only CI job that

--- a/code/specs/data/mycin-2026/board/decompose_query.py
+++ b/code/specs/data/mycin-2026/board/decompose_query.py
@@ -58,11 +58,11 @@ from pathlib import Path
 HERE = Path(__file__).resolve().parent
 RECALL = HERE.parent / "recall"
 EDGE_FILES = ["iem-edges.adj", "vitamin-edges.adj", "anemia-edges.adj",
-              "endocrine-edges.adj", "coag-edges.adj", "micro-edges.adj"]
+              "endocrine-edges.adj", "coag-edges.adj", "micro-edges.adj", "pharm-edges.adj"]
 
 # Each recall relation binds one conventional variable (the "what is being asked").
-# This is the controlled query vocabulary the model must choose from — 14 relations
-# across six organ systems. The engine ultimately validates the subject; this map
+# This is the controlled query vocabulary the model must choose from — 18 relations
+# across seven domains. The engine ultimately validates the subject; this map
 # pins the legal relation set and the variable name each relation answers.
 REL_VAR = {
     "deficient_in": "Enzyme",          # IEM: which enzyme is deficient
@@ -79,6 +79,10 @@ REL_VAR = {
     "gram_stain": "Result",            # microbiology: Gram reaction (positive / negative)
     "morphology": "Shape",             # microbiology: cell shape (cocci / bacilli / …)
     "causes": "Disease",               # microbiology: signature disease the organism causes
+    "drug_class": "Class",             # pharmacology: pharmacologic class of a drug
+    "mechanism": "MOA",                # pharmacology: mechanism of action
+    "adverse_effect": "Effect",        # pharmacology: a notable adverse effect
+    "antidote_for": "Antidote",        # pharmacology: what reverses a poisoning/overdose
 }
 
 _RELATE_RE = re.compile(r"^\s*relate\s+([a-z_][a-z0-9_]*)\s*\(([^)]*)\)\s*$")

--- a/code/specs/data/mycin-2026/board/items.json
+++ b/code/specs/data/mycin-2026/board/items.json
@@ -88,6 +88,16 @@
     {"id": "micro_pseud_gram",     "domain": "micro", "tactic": "recall", "relation": "gram_stain", "subject": "pseudomonas_aeruginosa",   "var": "Result",  "gold": "gram_negative"},
     {"id": "micro_pseud_shape",    "domain": "micro", "tactic": "recall", "relation": "morphology", "subject": "pseudomonas_aeruginosa",   "var": "Shape",   "gold": "bacilli"},
     {"id": "micro_spneumo_gram",   "domain": "micro", "tactic": "recall", "relation": "gram_stain", "subject": "streptococcus_pneumoniae", "var": "Result",  "gold": "gram_positive"},
-    {"id": "micro_spneumo_causes", "domain": "micro", "tactic": "recall", "relation": "causes",     "subject": "streptococcus_pneumoniae", "var": "Disease", "gold": "community_acquired_pneumonia"}
+    {"id": "micro_spneumo_causes", "domain": "micro", "tactic": "recall", "relation": "causes",     "subject": "streptococcus_pneumoniae", "var": "Disease", "gold": "community_acquired_pneumonia"},
+
+    {"id": "pharm_metformin_class",  "domain": "pharm", "tactic": "recall", "relation": "drug_class",     "subject": "metformin",              "var": "Class",    "gold": "biguanide"},
+    {"id": "pharm_lisinopril_class", "domain": "pharm", "tactic": "recall", "relation": "drug_class",     "subject": "lisinopril",             "var": "Class",    "gold": "ace_inhibitor"},
+    {"id": "pharm_naloxone_class",   "domain": "pharm", "tactic": "recall", "relation": "drug_class",     "subject": "naloxone",               "var": "Class",    "gold": "opioid_antagonist"},
+    {"id": "pharm_flumazenil_class", "domain": "pharm", "tactic": "recall", "relation": "drug_class",     "subject": "flumazenil",             "var": "Class",    "gold": "benzodiazepine_antagonist"},
+    {"id": "pharm_warfarin_moa",     "domain": "pharm", "tactic": "recall", "relation": "mechanism",      "subject": "warfarin",               "var": "MOA",      "gold": "inhibits_vitamin_k_dependent_clotting_factor_synthesis"},
+    {"id": "pharm_apap_adverse",     "domain": "pharm", "tactic": "recall", "relation": "adverse_effect", "subject": "acetaminophen",          "var": "Effect",   "gold": "hepatic_necrosis"},
+    {"id": "pharm_apap_antidote",    "domain": "pharm", "tactic": "recall", "relation": "antidote_for",   "subject": "acetaminophen_poisoning","var": "Antidote", "gold": "acetylcysteine"},
+    {"id": "pharm_opioid_antidote",  "domain": "pharm", "tactic": "recall", "relation": "antidote_for",   "subject": "opioid_toxicity",        "var": "Antidote", "gold": "naloxone"},
+    {"id": "pharm_benzo_antidote",   "domain": "pharm", "tactic": "recall", "relation": "antidote_for",   "subject": "benzodiazepine_overdose","var": "Antidote", "gold": "flumazenil"}
   ]
 }

--- a/code/specs/data/mycin-2026/board/test_board_eval.py
+++ b/code/specs/data/mycin-2026/board/test_board_eval.py
@@ -41,12 +41,13 @@ def test_covered_items_answer_correctly_with_a_proof() -> None:
     assert by_id["tay_sachs_enzyme"].answer == "hexosaminidase_a"
     # A correct recall answer carries the citing edge's trust tier (its proof).
     assert by_id["tay_sachs_enzyme"].trust is not None
-    # The bank spans SIX recall domains: 18 IEM + 8 vitamin + 8 anemia + 8 endocrine
-    # + 11 coagulation (REL-13) + 13 microbiology (MICRO) = 66 covered recall items, all
-    # over one merged store. MICRO is the first ADJ-ONLY domain: micro-edges.adj is a
-    # hand-authored library carrying its byte-provenance inline (no Python gate / JSON).
+    # The bank spans SEVEN recall domains: 18 IEM + 8 vitamin + 8 anemia + 8 endocrine
+    # + 11 coagulation (REL-13) + 13 microbiology (MICRO) + 9 pharmacology (PHARM) = 75
+    # covered recall items, all over one merged store. MICRO and PHARM are ADJ-ONLY
+    # domains: their *-edges.adj are hand-authored libraries carrying byte-provenance
+    # inline (no Python gate / JSON / manifest).
     recall_correct = [r for r in card.results if r.outcome == "correct" and r.tactic == "recall"]
-    assert len(recall_correct) == 66
+    assert len(recall_correct) == 75
     assert by_id["fabry_enzyme"].outcome == "correct"               # IEM
     assert by_id["thiamine_disease"].answer == "beriberi"           # vitamin
     assert by_id["ida_mcv"].answer == "microcytic"                  # anemia
@@ -57,6 +58,9 @@ def test_covered_items_answer_correctly_with_a_proof() -> None:
     assert by_id["micro_saureus_gram"].answer == "gram_positive"   # microbiology (MICRO)
     assert by_id["micro_vibrio_causes"].answer == "cholera"        # micro — causes relation
     assert by_id["micro_saureus_gram"].trust == "authoritative"    # ADJ-only edge, grounded inline
+    assert by_id["pharm_metformin_class"].answer == "biguanide"    # pharmacology (PHARM)
+    assert by_id["pharm_opioid_antidote"].answer == "naloxone"     # pharm — antidote_for relation
+    assert by_id["pharm_metformin_class"].trust == "authoritative"  # ADJ-only edge, grounded inline
 
 
 def test_uncovered_items_abstain_not_fabricate() -> None:
@@ -89,17 +93,17 @@ def test_grounded_coverage_is_the_live_grounding_number() -> None:
     # the disorder's onset/category but not the deficiency-OF-factor identity, so verify
     # landed at direction_only. REL-14 found a stronger source whose verbatim span self-
     # contains the relation ("Factor VII deficiency is a bleeding disorder characterized
-    # by a lack in the production of factor VII"), lifting it to authoritative. The MICRO
-    # domain (13 ADJ-only microbiology edges, all spider-grounded to NCBI StatPearls byte-
-    # stable spans) adds 13 more authoritative recall answers. 65 of the 66 recall answers
-    # across all SIX domains now cite an authoritative edge: grounded-coverage 98%. ONE
-    # holdout stays consensus + FLAG (direction_only) — the adversarial verify could not
-    # pin it verbatim, so the framework declines to claim grounding it cannot defend, by
-    # design: cortisol_def (endocrine, deficiency_syndrome__cortisol — the only verbatim
-    # spans frame cortisol deficiency as a consequence/feature of Addison disease, not the
-    # named-syndrome identity).
-    assert s["grounded_coverage"] == round(65 / 66, 4)   # 0.9848
-    assert s["grounded_correct"] == 65
+    # by a lack in the production of factor VII"), lifting it to authoritative. The ADJ-only
+    # domains MICRO (13 microbiology edges) and PHARM (9 pharmacology edges) — all spider-
+    # grounded to NCBI StatPearls byte-stable spans — add 22 more authoritative recall
+    # answers. 74 of the 75 recall answers across all SEVEN domains now cite an
+    # authoritative edge: grounded-coverage 99%. ONE holdout stays consensus + FLAG
+    # (direction_only) — the adversarial verify could not pin it verbatim, so the framework
+    # declines to claim grounding it cannot defend, by design: cortisol_def (endocrine,
+    # deficiency_syndrome__cortisol — the only verbatim spans frame cortisol deficiency as a
+    # consequence/feature of Addison disease, not the named-syndrome identity).
+    assert s["grounded_coverage"] == round(74 / 75, 4)   # 0.9867
+    assert s["grounded_correct"] == 74
     by_id = {r.item_id: r for r in card.results}
     assert by_id["tay_sachs_enzyme"].trust == "authoritative"      # IEM
     assert by_id["ida_mcv"].trust == "authoritative"               # anemia

--- a/code/specs/data/mycin-2026/recall/pharm-edges.adj
+++ b/code/specs/data/mycin-2026/recall/pharm-edges.adj
@@ -1,0 +1,95 @@
+% ============================================================================
+% pharm-edges — the clinical-pharmacology knowledge-graph (MYCIN-2026 PHARM).
+% ============================================================================
+% A Tier-1 recall domain (USMLE-DOMAIN-MAP §"To build"): drug → mechanism, class,
+% adverse effect, antidote. "What class of drug is lisinopril?" becomes the binding
+% query  ? drug_class(lisinopril, $Class).
+%
+% This file is the SHIPPED ARTIFACT and the SOLE source of truth — there is no
+% generator, no JSON, no manifest (the second ADJ-only recall domain, after MICRO).
+% Each fact is a `relate` clause whose byte-provenance lives INLINE:
+%     source   — the VERBATIM span copied from the cited page (byte-stable: it
+%                appears character-for-character in the page's normalized text).
+%     locator  — the URL the span was read from (NCBI StatPearls / Bookshelf, NIH).
+%     trust    — authoritative (a primary, citable reference).
+% An LLM (or a human) recalls a fact by writing a tiny query .adj that `import`s
+% this library and asks a binding query — see pharm-recall.query.adj. Nothing here
+% is asserted "from memory": every edge is defended by a span a reader can re-fetch
+% and check. (See feedback_nothing_human_authored, feedback_adj_only_shipped_artifacts.)
+%
+% Honest scope (edges left out rather than fabricated or one-hop-inferred):
+%   - propranolol drug_class: NBK557801 discusses beta-blockers as a group but has
+%     no self-contained "Propranolol is a non-selective beta-blocker" span naming
+%     the drug — declined (no verbatim drug-named class statement).
+%   - adverse_effect(lisinopril, dry_cough): the page attributes dry cough to "ACE
+%     inhibitors" (the class), not to lisinopril by name — that is a one-hop class
+%     inference, not a self-contained span, so it is declined here.
+% Declining an edge with no clean self-contained authoritative span is the correct
+% move: honest absence beats a fabricated or over-reaching citation.
+% ============================================================================
+
+dictionary pharm_vocab {
+    define drug       : entity   surface "drug", "medication", "agent"
+    define drugclass  : entity   surface "drug class", "pharmacologic class"
+    define moa        : entity   surface "mechanism of action"
+    define effect     : entity   surface "adverse effect", "adverse reaction"
+    define poisoning  : entity   surface "poisoning", "toxicity", "overdose"
+    define antidote   : entity   surface "antidote", "reversal agent"
+
+    define drug_class     : relation from drug to drugclass     % pharmacologic class
+    define mechanism      : relation from drug to moa           % how it works
+    define adverse_effect : relation from drug to effect        % a notable harm
+    define antidote_for   : relation from poisoning to antidote % what reverses a poisoning
+}
+
+rulebook pharm_facts {
+    use pharm_vocab
+
+    % --- Metformin -------------------------------------------------------
+    relate drug_class(metformin, biguanide)
+        source "Metformin, classified as a biguanide drug"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK518983/"
+        trust authoritative
+
+    % --- Lisinopril ------------------------------------------------------
+    relate drug_class(lisinopril, ace_inhibitor)
+        source "As a competitive ACE inhibitor, lisinopril prevents the conversion of angiotensin I to angiotensin II, a potent vasoconstrictor."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK482230/"
+        trust authoritative
+
+    % --- Naloxone (opioid antagonist; antidote for opioid toxicity) ------
+    relate drug_class(naloxone, opioid_antagonist)
+        source "Naloxone is a pure, competitive opioid antagonist"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK441910/"
+        trust authoritative
+    relate antidote_for(opioid_toxicity, naloxone)
+        source "Naloxone is indicated for the treatment of opioid toxicity, specifically to reverse respiratory depression from opioid use."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK441910/"
+        trust authoritative
+
+    % --- Flumazenil (benzodiazepine antagonist; antidote for benzo overdose)
+    relate drug_class(flumazenil, benzodiazepine_antagonist)
+        source "Flumazenil is a benzodiazepine antagonist typically used in overdose emergencies."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK470180/"
+        trust authoritative
+    relate antidote_for(benzodiazepine_overdose, flumazenil)
+        source "The primary FDA-approved clinical uses for flumazenil include reversal agents for benzodiazepine overdose and postoperative sedation from benzodiazepine anesthetics."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK470180/"
+        trust authoritative
+
+    % --- Warfarin --------------------------------------------------------
+    relate mechanism(warfarin, inhibits_vitamin_k_dependent_clotting_factor_synthesis)
+        source "Warfarin inhibits the synthesis of vitamin K-dependent clotting factors, reducing clotting ability."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK470313/"
+        trust authoritative
+
+    % --- Acetaminophen (toxicity → hepatic necrosis; antidote acetylcysteine)
+    relate adverse_effect(acetaminophen, hepatic_necrosis)
+        source "Although generally safe at therapeutic doses, acetaminophen poisoning causes hepatic necrosis in overdose."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK441917/"
+        trust authoritative
+    relate antidote_for(acetaminophen_poisoning, acetylcysteine)
+        source "Acetylcysteine, most often given IV, is the critical antidote for acetaminophen poisoning, and is most effective if administered within the first 8 hours after an acute overdose."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK441917/"
+        trust authoritative
+}

--- a/code/specs/data/mycin-2026/recall/pharm-recall.query.adj
+++ b/code/specs/data/mycin-2026/recall/pharm-recall.query.adj
@@ -1,0 +1,22 @@
+% ============================================================================
+% pharm-recall.query.adj — a worked recall query over the pharmacology library.
+% ============================================================================
+% The shape an LLM (or a clinician) produces to ANSWER a pharmacology recall
+% question: it states no drug fact — it only `import`s the grounded library and
+% asks binding queries. The native adj-lang engine resolves each `?` against the
+% imported `relate` edges and returns the binding + the citing clause's
+% source/locator/trust. All knowledge is in the library; none is here.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli pharm-recall.query.adj
+% ============================================================================
+
+import "pharm-edges.adj"
+
+? drug_class(metformin, $Class)                  % expect biguanide
+? drug_class(lisinopril, $Class)                 % expect ace_inhibitor
+? drug_class(naloxone, $Class)                   % expect opioid_antagonist
+? mechanism(warfarin, $MOA)                      % expect inhibits_vitamin_k_dependent_clotting_factor_synthesis
+? adverse_effect(acetaminophen, $Effect)         % expect hepatic_necrosis
+? antidote_for(acetaminophen_poisoning, $Antidote)  % expect acetylcysteine
+? antidote_for(opioid_toxicity, $Antidote)       % expect naloxone

--- a/code/specs/data/mycin-2026/recall/test_pharm_recall.py
+++ b/code/specs/data/mycin-2026/recall/test_pharm_recall.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""test_pharm_recall.py — the ADJ-only pharmacology recall library (MYCIN-2026 PHARM).
+
+The second recall domain shipped as a pure ADJ artifact (after MICRO): `pharm-edges.adj`
+is the SOLE source of truth — facts + byte-provenance inline, no Python gate, no JSON,
+no manifest. This test pins the property that matters: the native adj-lang engine, given
+a query .adj that only `import`s the library and asks binding queries
+(`pharm-recall.query.adj` — the shape an LLM produces), returns the correct binding for
+every grounded edge, each carrying an AUTHORITATIVE citation with a real source span +
+locator. Knowledge lives in ADJ; the engine answers.
+
+If the native CLI isn't built (a Python-only CI lane), the engine-backed checks skip —
+the file-shape checks (every clause grounded, no authored-debt) still run.
+
+Run:  python3 test_pharm_recall.py
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+ADJ = HERE / "pharm-edges.adj"
+QUERY = HERE / "pharm-recall.query.adj"
+CLI = HERE.parents[3] / "packages" / "rust" / "target" / "debug" / "adj-lang-cli"
+
+# The full grounded edge set (subject, relation, expected binding). Mirrors
+# pharm-edges.adj; a divergence here or there fails the test.
+EXPECTED = [
+    ("metformin", "drug_class", "biguanide"),
+    ("lisinopril", "drug_class", "ace_inhibitor"),
+    ("naloxone", "drug_class", "opioid_antagonist"),
+    ("flumazenil", "drug_class", "benzodiazepine_antagonist"),
+    ("warfarin", "mechanism", "inhibits_vitamin_k_dependent_clotting_factor_synthesis"),
+    ("acetaminophen", "adverse_effect", "hepatic_necrosis"),
+    ("acetaminophen_poisoning", "antidote_for", "acetylcysteine"),
+    ("opioid_toxicity", "antidote_for", "naloxone"),
+    ("benzodiazepine_overdose", "antidote_for", "flumazenil"),
+]
+VAR = {"drug_class": "Class", "mechanism": "MOA", "adverse_effect": "Effect",
+       "antidote_for": "Antidote"}
+
+
+def _cli_available() -> bool:
+    return CLI.exists()
+
+
+def _run(program: Path) -> dict:
+    out = subprocess.run([str(CLI), str(program)], capture_output=True, text=True,
+                         cwd=str(HERE), timeout=60)
+    assert out.returncode == 0, f"adj-lang-cli failed: {out.stderr}"
+    return json.loads(out.stdout)
+
+
+# ---- 1. the ADJ file is the artifact — every clause grounded, no authored-debt ----
+
+def test_library_is_pure_adj_and_fully_grounded() -> None:
+    text = ADJ.read_text()
+    assert "trust consensus" not in text, "PHARM ships no authored-debt; ground or omit"
+    assert "[FLAG:" not in text
+    relate_count = text.count("    relate ")
+    assert text.count("trust authoritative") == relate_count == len(EXPECTED)
+    assert text.count('\n        locator "') == relate_count
+    assert text.count('\n        source "') == relate_count
+    # No sibling generator / JSON / manifest for this domain (ADJ-only).
+    assert not (HERE / "pharm_edge_ground.py").exists()
+    assert not (HERE / "pharm-edge-grounding.json").exists()
+    assert not (HERE / "pharm-edge-manifest.json").exists()
+
+
+# ---- 2. the engine resolves every grounded edge with an authoritative citation ----
+
+def test_engine_resolves_every_edge_with_authoritative_citation() -> None:
+    if not _cli_available():
+        return
+    result = _run(QUERY)
+    by_query = {r["query"]: r for r in result["recall"]}
+    for subj, rel, expected in EXPECTED:
+        q = f"{rel}({subj}, {VAR[rel]})"
+        r = by_query.get(q) or _one(rel, subj, VAR[rel])
+        assert r is not None and not r["abstained"], f"{q} abstained — edge missing?"
+        ans = r["answers"][0]
+        assert ans["bindings"][VAR[rel]] == expected, f"{q} -> {ans['bindings']}"
+        cite = ans["citations"][0]
+        assert cite["trust"] == "authoritative", f"{q} citation not authoritative"
+        assert cite["source"], f"{q} citation has no source span"
+        assert cite["locator"].startswith("https://www.ncbi.nlm.nih.gov/"), cite["locator"]
+
+
+def _one(rel: str, subj: str, varname: str) -> dict | None:
+    """Resolve a single edge by writing a throwaway one-line query .adj in this dir
+    (so the relative `import "pharm-edges.adj"` resolves) and running the engine."""
+    import os
+    import tempfile
+    fd, path = tempfile.mkstemp(suffix=".adj", prefix=".pharm_q_", dir=HERE)
+    try:
+        with os.fdopen(fd, "w") as fh:
+            fh.write(f'import "pharm-edges.adj"\n? {rel}({subj}, ${varname})\n')
+        res = _run(Path(path))
+        return res["recall"][0] if res["recall"] else None
+    finally:
+        os.unlink(path)
+
+
+# ---- 3. an off-vocabulary subject abstains, never fabricates ----------------------
+
+def test_unknown_drug_abstains() -> None:
+    if not _cli_available():
+        return
+    r = _one("drug_class", "ibuprofen", "Class")  # not in the library
+    assert r is not None and r["abstained"], "an ungrounded drug must abstain"
+
+
+def _run_all() -> int:
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    failed = 0
+    for t in tests:
+        try:
+            t()
+            print(f"  PASS  {t.__name__}")
+        except AssertionError as exc:
+            failed += 1
+            print(f"  FAIL  {t.__name__}: {exc}")
+    print(f"\ntest_pharm_recall: {len(tests) - failed}/{len(tests)} passed")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(_run_all())


### PR DESCRIPTION
## What

The **second ADJ-only** recall domain (after MICRO #6212). `recall/pharm-edges.adj` *is* the source of truth — facts + byte-provenance **inline** (`source` = verbatim NCBI StatPearls span, `locator` = URL, `trust authoritative`); no Python gate, no JSON, no manifest. An LLM recalls a fact by writing a tiny query `.adj` that `import`s the library and asks a binding query — `recall/pharm-recall.query.adj` is the worked example.

```
import "pharm-edges.adj"
? drug_class(lisinopril, $Class)        % → ace_inhibitor, cited to NBK482230
? antidote_for(opioid_toxicity, $Antidote)   % → naloxone, cited to NBK441910
```

## Grounding (no authored debt)

All **9 edges** across **4 relations** — `drug_class` / `mechanism` / `adverse_effect` / `antidote_for` — for 6 board-classic drugs (metformin→biguanide, lisinopril→ACE inhibitor, naloxone→opioid antagonist, flumazenil→benzodiazepine antagonist, warfarin mechanism, acetaminophen→hepatic necrosis, plus the opioid/benzo/acetaminophen antidotes) are grounded to **byte-stable verbatim spans**, re-verified character-for-character against the live page (9/9). No `trust consensus` seed — grounded or omitted.

**Declined** (honest): propranolol `drug_class` (no drug-named class span on its page) and `adverse_effect(lisinopril, dry_cough)` — the page attributes dry cough to the *class* "ACE inhibitors", not to lisinopril by name (a one-hop inference, not a self-contained span).

## Wiring & results

- `board_eval.EDGE_FILES` + `decompose_query.EDGE_FILES` += `pharm-edges.adj`; `REL_VAR` += the 4 relations (recall vocab 14 → 18)
- 9 pharm board items — all resolve **correct**, all **authoritative**
- Scorecard: recall **66 → 75** correct, grounded **65 → 74** (74/75 = **99%**), **wrong 0**, defensibility **100%**
- `test_pharm_recall.py` pins the ADJ-only flow end-to-end through the native CLI (every edge → authoritative citation; off-vocabulary drug abstains)
- `USMLE-DOMAIN-MAP`: Pharmacology marked built

## Verification

- `board_eval` test suite: **12/12**
- `test_pharm_recall`: **3/3**
- byte-stability: **9/9** live spans present verbatim
- `/security-review` passed (subprocess / tempfile / string-literal / SSRF — clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)