### PR TITLE
feat(visicalc-xaml): Undo / Redo over P/Invoke

### DIFF
--- a/demo/visicalc-xaml/Engine.cs
+++ b/demo/visicalc-xaml/Engine.cs
@@ -86,6 +86,11 @@ internal static class ScNative
     [DllImport("spreadsheet_capi")]
     internal static extern int sc_deserialize(IntPtr s,
         [MarshalAs(UnmanagedType.LPUTF8Str)] string data);
+    // sc_undo / sc_redo / sc_can_undo / sc_can_redo(session) → int (1/0).
+    [DllImport("spreadsheet_capi")] internal static extern int sc_undo(IntPtr s);
+    [DllImport("spreadsheet_capi")] internal static extern int sc_redo(IntPtr s);
+    [DllImport("spreadsheet_capi")] internal static extern int sc_can_undo(IntPtr s);
+    [DllImport("spreadsheet_capi")] internal static extern int sc_can_redo(IntPtr s);
     [DllImport("spreadsheet_capi")] internal static extern IntPtr sc_used_range(IntPtr s);
     [DllImport("spreadsheet_capi")] internal static extern IntPtr sc_column_letters(IntPtr s, uint index);
     [DllImport("spreadsheet_capi")] internal static extern ulong sc_current_revision(IntPtr s);
@@ -179,6 +184,14 @@ public sealed class SpreadsheetSession : IDisposable
     /// workbook is left untouched — the engine validates before it mutates).
     /// Formulas reload live.
     public bool Deserialize(string data) => ScNative.sc_deserialize(_handle, data) != 0;
+
+    /// Undo / redo: walk the engine's snapshot history. Each returns `true` if it
+    /// changed the document (the host then re-reads the viewport), `false` if
+    /// there was nothing to do. CanUndo/CanRedo gate a host's Undo/Redo controls.
+    public bool Undo() => ScNative.sc_undo(_handle) != 0;
+    public bool Redo() => ScNative.sc_redo(_handle) != 0;
+    public bool CanUndo() => ScNative.sc_can_undo(_handle) != 0;
+    public bool CanRedo() => ScNative.sc_can_redo(_handle) != 0;
 
     /// The display string for a cell — what a spreadsheet should show. Parses
     /// the engine's JSON (the fixed shape every backend's engine emits).
@@ -536,6 +549,32 @@ public sealed class InfiniteSheetModel : IDisposable
     public bool LoadBook(string data)
     {
         bool ok = _session.Deserialize(data);
+        if (ok)
+        {
+            ComputeExtent();
+            Formula = _session.GetRaw(InfAddress);
+        }
+        return ok;
+    }
+
+    /// Undo / redo: walk the engine's snapshot history. On success the extent
+    /// regrows and the formula bar refreshes (any cell could have changed); a
+    /// restored formula stays live. CanUndo/CanRedo gate the buttons.
+    public bool CanUndo => _session.CanUndo();
+    public bool CanRedo => _session.CanRedo();
+    public bool UndoEdit()
+    {
+        bool ok = _session.Undo();
+        if (ok)
+        {
+            ComputeExtent();
+            Formula = _session.GetRaw(InfAddress);
+        }
+        return ok;
+    }
+    public bool RedoEdit()
+    {
+        bool ok = _session.Redo();
         if (ok)
         {
             ComputeExtent();

--- a/demo/visicalc-xaml/InfiniteSheet.xaml
+++ b/demo/visicalc-xaml/InfiniteSheet.xaml
@@ -85,6 +85,18 @@
                         Content="Load"
                         ToolTipService.ToolTip="Restore the workbook from the last save"
                         Click="LoadButton_Click"/>
+                <Button x:Name="UndoButton" Margin="8,0,0,0" Height="28"
+                        Background="#2D2D30" Foreground="#CCCCCC" BorderBrush="#3F3F46"
+                        BorderThickness="1" FontSize="12" FontFamily="Consolas"
+                        Content="Undo"
+                        ToolTipService.ToolTip="Undo the last edit"
+                        Click="UndoButton_Click"/>
+                <Button x:Name="RedoButton" Margin="8,0,0,0" Height="28"
+                        Background="#2D2D30" Foreground="#CCCCCC" BorderBrush="#3F3F46"
+                        BorderThickness="1" FontSize="12" FontFamily="Consolas"
+                        Content="Redo"
+                        ToolTipService.ToolTip="Redo the last undone edit"
+                        Click="RedoButton_Click"/>
             </StackPanel>
         </Grid>
 

--- a/demo/visicalc-xaml/InfiniteSheet.xaml.cs
+++ b/demo/visicalc-xaml/InfiniteSheet.xaml.cs
@@ -214,10 +214,41 @@ public sealed partial class InfiniteSheet : UserControl
         }
     }
 
+    /// Undo / redo: walk the engine's snapshot history. On success the formula
+    /// bar re-reads and the realized rows repaint (any cell could have changed);
+    /// the buttons enable/disable off CanUndo/CanRedo via RefreshHistoryButtons.
+    private void UndoButton_Click(object sender, RoutedEventArgs e)
+    {
+        if (_model.UndoEdit())
+        {
+            RefreshFormulaBar();
+            RepaintRealizedRows();
+        }
+    }
+
+    private void RedoButton_Click(object sender, RoutedEventArgs e)
+    {
+        if (_model.RedoEdit())
+        {
+            RefreshFormulaBar();
+            RepaintRealizedRows();
+        }
+    }
+
+    /// Keep the Undo/Redo buttons' enabled state in step with the engine's
+    /// history ends. Called from RefreshFormulaBar (so every edit/select/load
+    /// refreshes it) and RepaintRealizedRows (so fill/paste do too).
+    private void RefreshHistoryButtons()
+    {
+        UndoButton.IsEnabled = _model.CanUndo;
+        RedoButton.IsEnabled = _model.CanRedo;
+    }
+
     private void RefreshFormulaBar()
     {
         AddressText.Text = _model.InfAddress;
         FormulaBox.Text = _model.Formula;
+        RefreshHistoryButtons();
     }
 
     /// Rebuild only the currently-realized body rows so selection highlight and
@@ -230,6 +261,7 @@ public sealed partial class InfiniteSheet : UserControl
             if (BodyList.ContainerFromItem(rowNum) is ListViewItem { Content: StackPanel } item)
                 item.Content = BuildRow(rowNum);
         }
+        RefreshHistoryButtons(); // fill/paste mutate the doc → re-gate Undo/Redo
     }
 
     // ── Scroll sync ──────────────────────────────────────────────────

--- a/demo/visicalc-xaml/README.md
+++ b/demo/visicalc-xaml/README.md
@@ -161,6 +161,10 @@ document held in memory and restore it (`LoadBook` / `sc_deserialize`): the
 document captures only the source (formula text + typed literals) and per-cell
 formats — not the computed values, which the engine recomputes on load, so a
 loaded formula stays live.
+The **Undo / Redo** buttons walk the engine's snapshot history
+(`InfiniteSheetModel.UndoEdit`/`RedoEdit` over the C ABI's `sc_undo`/`sc_redo`);
+they enable/disable off `CanUndo`/`CanRedo` (refreshed after every edit). Every
+edit is reversible and a restored formula recomputes live.
 
 `InfiniteSheetModel` (in `Engine.cs`, WinUI-free) seeds far-flung sparse cells
 (`Z1000`, `BA50`, `BB50`) and derives the extent from `UsedRange()` + a margin
@@ -182,7 +186,9 @@ directly: `RowCells` one-read rows, `SelectInf` clamping + source load,
 `CommitInf` recompute (A2 `8`→`108` ⇒ E2 151, A5 139, E5 269), drag-fill,
 clipboard copy/cut/paste, and a save/load round trip (`SaveBook` → mutate A1 ⇒
 E1 523.00 → `LoadBook` restores A1 15 / E1 38.00, the loaded formula stays live
-with A1=5 ⇒ E1 28.00, and malformed input is rejected).
+with A1=5 ⇒ E1 28.00, and malformed input is rejected), and an undo/redo walk on
+a fresh session (two edits → undo both → redo both with the formula recomputing
+live → a fresh edit forks history).
 
 ## Where this fits in the cross-backend demo plan
 

--- a/demo/visicalc-xaml/test/Program.cs
+++ b/demo/visicalc-xaml/test/Program.cs
@@ -172,5 +172,31 @@ using (var sl = new InfiniteSheetModel())
     Check("workbook intact after reject", sl.RowCells(1)[4], "28.00");
 }
 
+// Undo / redo (the Undo / Redo buttons drive UndoEdit/RedoEdit): a fresh,
+// unseeded session so the initial history is empty. Two edits, walk back and
+// forward, and confirm a restored formula recomputes live.
+using (var ur = new SpreadsheetSession())
+{
+    Check("fresh canUndo false", ur.CanUndo().ToString(), "False");
+    ur.SetCell("A1", "1");
+    ur.SetCell("B1", "=A1*10"); // 10
+    Check("after edits canUndo true", ur.CanUndo().ToString(), "True");
+    Check("undo formula", ur.Undo().ToString(), "True");
+    Check("B1 cleared by undo", ur.Window(1, 2, 1, 2)[0][0], "");
+    Check("undo literal", ur.Undo().ToString(), "True");
+    Check("A1 cleared by undo", ur.Window(1, 1, 1, 1)[0][0], "");
+    Check("canUndo false at bottom", ur.CanUndo().ToString(), "False");
+    Check("undo at bottom is noop", ur.Undo().ToString(), "False");
+    Check("redo literal", ur.Redo().ToString(), "True");
+    Check("redo formula", ur.Redo().ToString(), "True");
+    Check("B1 live after redo", ur.Window(1, 2, 1, 2)[0][0], "10");
+    Check("canRedo false at top", ur.CanRedo().ToString(), "False");
+    // A fresh edit forks history (drops the redo branch).
+    ur.Undo(); // back: B1 gone
+    Check("canRedo true before fork", ur.CanRedo().ToString(), "True");
+    ur.SetCell("C1", "9");
+    Check("fresh edit clears redo", ur.CanRedo().ToString(), "False");
+}
+
 Console.WriteLine(failures == 0 ? "\nALL PASS" : $"\n{failures} FAILURE(S)");
 return failures == 0 ? 0 : 1;


### PR DESCRIPTION
## Summary

Fifth of the six undo/redo demo rollouts (web [#6205](https://github.com/adhithyan15/coding-adventures/pull/6205), Qt [#6207](https://github.com/adhithyan15/coding-adventures/pull/6207), Flutter [#6211](https://github.com/adhithyan15/coding-adventures/pull/6211), Compose [#6214](https://github.com/adhithyan15/coding-adventures/pull/6214) merged). Adds **Undo / Redo** to the XAML infinite-sheet demo, driving the session's snapshot history (spreadsheet-capi 0.9.0 `sc_undo`/`sc_redo`/`sc_can_undo`/`sc_can_redo`) over **P/Invoke**.

- `Engine.cs`: `[DllImport] int sc_undo`/`sc_redo`/`sc_can_undo`/`sc_can_redo(IntPtr)` → `Undo()`/`Redo()`/`CanUndo()`/`CanRedo()` → `bool` (blittable `int(IntPtr)`, no marshalling).
- `InfiniteSheetModel.UndoEdit()`/`RedoEdit()` (regrow extent + refresh formula bar on success) and `CanUndo`/`CanRedo` properties.
- `InfiniteSheet.xaml`/`.xaml.cs` gain **Undo / Redo** buttons next to Save/Load; a new `RefreshHistoryButtons()` (called from `RefreshFormulaBar` + `RepaintRealizedRows`) enables/disables them off `CanUndo`/`CanRedo` after every edit.

## Test plan
- `scripts/verify.sh` (`dotnet run`, .NET 9 console harness) — **ALL PASS**. New undo/redo walk on a fresh (unseeded) `SpreadsheetSession`: two edits, undo both (B1 then A1 cleared), redo both (B1 recomputes live → 10), can-gates at the ends, fresh-edit history fork. (WinUI view is Windows-only; the engine-backed model is proven cross-platform by this harness.)
- Re-vendored `libspreadsheet_capi.dylib` (0.9.0) into `native/`.
- `/security-review`: PASSED (blittable `int(IntPtr)` matches `int f(ScSession*)`; no native allocation crosses the boundary → nothing to free; null-session-safe; no leak/UAF).

Next (last): SwiftUI — after it merges, undo/redo is complete across all 6 backends.

🤖 Generated with [Claude Code](https://claude.com/claude-code)