### PR TITLE
feat(visicalc-swiftui): Undo / Redo over the C interop

### DIFF
--- a/demo/visicalc-swiftui/README.md
+++ b/demo/visicalc-swiftui/README.md
@@ -98,6 +98,11 @@ document held in memory and restore it (`loadBook` / `sc_deserialize`): the
 document captures only the source (formula text + typed literals) and per-cell
 formats — not the computed values, which the engine recomputes on load, so a
 loaded formula stays live.
+The **Undo / Redo** buttons walk the engine's snapshot history
+(`WindowedSheetModel.undoEdit`/`redoEdit` over the C ABI's `sc_undo`/`sc_redo`);
+they disable at the history ends via `canUndo`/`canRedo` (re-evaluated whenever
+`revision`, a `@Published`, bumps). Every edit is reversible and a restored
+formula recomputes live.
 
 Headless proof: `Tests/VisiCalcTests/WindowedModelTests.swift` asserts the
 window is engine-computed and dense, a formula 1000 rows down (`Z1000` = 39) is
@@ -108,7 +113,9 @@ I3 = 40, source I1 = 20 untouched), and the clipboard (copy `I1 = =H1*2` → pas
 at I2 ⇒ I2 = H2*2 = 14; cut A1 → move to C1, A1 clears, a second paste is a
 no-op), and a save/load round trip (`saveBook` → mutate A1 ⇒ E1 523.00 →
 `loadBook` restores A1 15 / E1 38.00, the loaded formula stays live with A1=5 ⇒
-E1 28.00, and malformed input is rejected). Run with `swift test`.
+E1 28.00, and malformed input is rejected), and an undo/redo walk (two edits →
+undo both → redo both with the formula recomputing live → a fresh edit forks
+history). Run with `swift test`.
 
 ## Notes
 

--- a/demo/visicalc-swiftui/Sources/CSpreadsheetEngine/include/spreadsheet.h
+++ b/demo/visicalc-swiftui/Sources/CSpreadsheetEngine/include/spreadsheet.h
@@ -84,6 +84,16 @@ int   sc_paste(ScSession *s, const char *dst_start);
 char *sc_serialize(ScSession *s);
 int   sc_deserialize(ScSession *s, const char *data);
 
+/* Undo / redo (session history). sc_undo() reverts the most recent edit, sc_redo()
+   replays the most recently undone one; each returns 1 if it changed the document, 0
+   if there was nothing to do (or s == NULL). The host re-reads via sc_get_window /
+   sc_get_display_window / sc_get_raw afterwards. sc_can_undo() / sc_can_redo() return
+   1/0 so a host can enable/disable its Undo/Redo controls. */
+int   sc_undo(ScSession *s);
+int   sc_redo(ScSession *s);
+int   sc_can_undo(ScSession *s);
+int   sc_can_redo(ScSession *s);
+
 /* Viewport primitive — read just the visible window of the unbounded sheet.
    Coordinates are 1-based and inclusive. Each char* result must be freed with
    sc_string_free(). */

--- a/demo/visicalc-swiftui/Sources/VisiCalc/Engine.swift
+++ b/demo/visicalc-swiftui/Sources/VisiCalc/Engine.swift
@@ -86,6 +86,15 @@ final class SpreadsheetSession {
         sc_deserialize(handle, data) != 0
     }
 
+    /// Undo / redo: walk the engine's snapshot history. Each returns `true` if it
+    /// changed the document (the host then re-reads the viewport), `false` if
+    /// there was nothing to do. canUndo/canRedo gate a host's Undo/Redo controls.
+    /// Reach `sc_undo`/`sc_redo`/`sc_can_undo`/`sc_can_redo`.
+    func undo() -> Bool { sc_undo(handle) != 0 }
+    func redo() -> Bool { sc_redo(handle) != 0 }
+    func canUndo() -> Bool { sc_can_undo(handle) != 0 }
+    func canRedo() -> Bool { sc_can_redo(handle) != 0 }
+
     /// The computed value of a cell as the string a spreadsheet should show.
     /// Parses the engine's JSON (`{"kind":...}`) — the same shape the TS and
     /// WASM engines emit.

--- a/demo/visicalc-swiftui/Sources/VisiCalc/InfiniteGrid.swift
+++ b/demo/visicalc-swiftui/Sources/VisiCalc/InfiniteGrid.swift
@@ -184,6 +184,33 @@ final class WindowedSheetModel: ObservableObject {
         return ok
     }
 
+    /// Undo / redo: walk the engine's snapshot history. On success the extent
+    /// resizes, the formula bar refreshes, and `revision` bumps (which re-renders
+    /// the SwiftUI view, re-evaluating the canUndo/canRedo button gates); a
+    /// restored formula stays live.
+    func canUndo() -> Bool { session.canUndo() }
+    func canRedo() -> Bool { session.canRedo() }
+    @discardableResult
+    func undoEdit() -> Bool {
+        let ok = session.undo()
+        if ok {
+            resize()
+            formulaText = session.getRaw(address(selectedRow, selectedCol))
+            revision += 1
+        }
+        return ok
+    }
+    @discardableResult
+    func redoEdit() -> Bool {
+        let ok = session.redo()
+        if ok {
+            resize()
+            formulaText = session.getRaw(address(selectedRow, selectedCol))
+            revision += 1
+        }
+        return ok
+    }
+
     /// Write `raw` into an explicit A1 cell and return the cells it dirtied.
     /// (Kept for the headless `WindowedModelTests`.)
     @discardableResult
@@ -271,6 +298,17 @@ struct InfiniteGridView: View {
                 .font(.system(size: 11, design: .monospaced))
                 .disabled(savedSnapshot.isEmpty)
                 .help("Restore the workbook from the last save")
+            // Undo / redo: walk the engine's snapshot history. The buttons gate
+            // off canUndo/canRedo, re-evaluated whenever `revision` (a @Published)
+            // bumps after an edit.
+            Button("Undo") { model.undoEdit() }
+                .font(.system(size: 11, design: .monospaced))
+                .disabled(!model.canUndo())
+                .help("Undo the last edit")
+            Button("Redo") { model.redoEdit() }
+                .font(.system(size: 11, design: .monospaced))
+                .disabled(!model.canRedo())
+                .help("Redo the last undone edit")
         }
         .padding(.bottom, 8)
     }

--- a/demo/visicalc-swiftui/Tests/VisiCalcTests/WindowedModelTests.swift
+++ b/demo/visicalc-swiftui/Tests/VisiCalcTests/WindowedModelTests.swift
@@ -120,4 +120,37 @@ final class WindowedModelTests: XCTestCase {
         XCTAssertFalse(m.loadBook("not a workbook"))
         XCTAssertEqual(m.window(rows: 1...1, cols: 5...5)[0][0], "28.00")
     }
+
+    /// Undo / redo: make two edits, walk history back and forward, and confirm a
+    /// restored formula recomputes live. (The model seeds its budget via setCell,
+    /// so history is non-empty from construction — undoing into the seed is
+    /// expected; this test only asserts the round trip of its own two edits.)
+    func testUndoRedoWalksHistory() {
+        let m = WindowedSheetModel()
+        // Two fresh edits on a clear column: H1 = 2 (col 8), I1 = H1*5 = 10 (col 9).
+        m.setCell("H1", "2")
+        m.setCell("I1", "=H1*5")
+        XCTAssertEqual(m.window(rows: 1...1, cols: 9...9)[0][0], "10")
+        XCTAssertTrue(m.canUndo())
+
+        // Undo the formula, then the literal.
+        XCTAssertTrue(m.undoEdit())
+        XCTAssertEqual(m.window(rows: 1...1, cols: 9...9)[0][0], "") // I1 gone
+        XCTAssertTrue(m.undoEdit())
+        XCTAssertEqual(m.window(rows: 1...1, cols: 8...8)[0][0], "") // H1 gone
+
+        // Redo both: I1 recomputes live (10).
+        XCTAssertTrue(m.canRedo())
+        XCTAssertTrue(m.redoEdit())
+        XCTAssertTrue(m.redoEdit())
+        XCTAssertEqual(m.window(rows: 1...1, cols: 9...9)[0][0], "10")
+        XCTAssertFalse(m.canRedo())
+        XCTAssertFalse(m.redoEdit()) // nothing left to redo
+
+        // A fresh edit forks history (drops the redo branch).
+        XCTAssertTrue(m.undoEdit()) // back: I1 gone
+        XCTAssertTrue(m.canRedo())
+        m.setCell("A1", "7")
+        XCTAssertFalse(m.canRedo())
+    }
 }


### PR DESCRIPTION
## Summary

The **last** of the six undo/redo demo rollouts (web [#6205](https://github.com/adhithyan15/coding-adventures/pull/6205), Qt [#6207](https://github.com/adhithyan15/coding-adventures/pull/6207), Flutter [#6211](https://github.com/adhithyan15/coding-adventures/pull/6211), Compose [#6214](https://github.com/adhithyan15/coding-adventures/pull/6214), XAML [#6219](https://github.com/adhithyan15/coding-adventures/pull/6219) merged). Adds **Undo / Redo** to the SwiftUI infinite-sheet demo, driving the session's snapshot history (spreadsheet-capi 0.9.0 `sc_undo`/`sc_redo`/`sc_can_undo`/`sc_can_redo`) over the CSpreadsheetEngine C interop.

- `Engine.swift`: `undo()`/`redo()`/`canUndo()`/`canRedo()` → `Bool` (argument-free, no marshalling).
- `WindowedSheetModel.undoEdit()`/`redoEdit()` (resize extent + refresh formula bar + bump `revision` on success) and `canUndo()`/`canRedo()`.
- `InfiniteGrid.swift` gains **Undo / Redo** buttons next to Save/Load, disabled off `model.canUndo()`/`canRedo()` — re-evaluated whenever the `@Published revision` bumps after an edit.

## Test plan
- `swift test` — **9/9 PASS**. New `testUndoRedoWalksHistory`: two edits (H1, I1=H1*5=10), undo both (I1 then H1 gone), redo both (I1 recomputes live → 10), can-gates at the ends, fresh-edit history fork.
- Updated the **tracked** `Sources/CSpreadsheetEngine/include/spreadsheet.h` with the `sc_undo`/`sc_redo`/`sc_can_undo`/`sc_can_redo` declarations (synced from canonical); re-vendored `libspreadsheet_capi.a` (0.9.0) into `Vendor/macos/`.
- `/security-review`: PASSED (Int32-returning calls need no free; only the opaque handle crosses the boundary; null-session-safe; no leak/UAF).

## 🎉 Undo/redo complete across all six backends
With this merge, **Undo / Redo** works on every VisiCalc backend — web (WASM), Qt, Flutter, Compose, XAML, SwiftUI — all driving the one shared Rust engine's snapshot-based session history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)