### PR TITLE
feat(mycin-immuno): Tier-1 immunology recall as an ADJ-only grounded library

### DIFF
--- a/code/specs/data/mycin-2026/USMLE-DOMAIN-MAP.md
+++ b/code/specs/data/mycin-2026/USMLE-DOMAIN-MAP.md
@@ -107,6 +107,7 @@ unchanged. Adding a relation just widens the schema — the engine already binds
 | Bacteremia / UTI | Infectious dz | organism-id + treatment | grounded | ✓ |
 | Microbiology | Microbiology | gram_stain, morphology, causes | 13 grounded (ADJ-only) | ✓ |
 | Pharmacology | Pharmacology | drug_class, mechanism, adverse_effect, antidote_for | 9 grounded (ADJ-only) | ✓ |
+| Immunology | Immunology | mediated_by, associated_hla, gene_defect, deficiency_of | 7 grounded (ADJ-only) | ✓ |
 
 Offline pipeline: prose → local-model decompose → ADJ → native engine, two-sided
 faithfulness gate, zero online calls (OFFLINE-BOARD-EXAM.md).
@@ -131,6 +132,12 @@ faithfulness gate, zero online calls (OFFLINE-BOARD-EXAM.md).
    declined for now — propranolol class (no drug-named span) and the one-hop
    adverse_effect(lisinopril, dry_cough) (attributed to the class, not the drug).
 3. **Immunology** — hypersensitivity types, immunodeficiencies, HLA associations, cytokines.
+   *Started (IMMUNO):* `mediated_by` (type I→IgE, type IV→T cells), `associated_hla`
+   (ankylosing spondylitis→HLA-B27), `gene_defect` (XLA→BTK, DiGeorge→22q11.2 deletion),
+   `deficiency_of` (CGD→NADPH oxidase, DiGeorge→T cells) — 7 edges, all grounded to byte-
+   stable NCBI StatPearls spans, shipped as the third **ADJ-only** domain
+   (`recall/immuno-edges.adj`). Remaining: type II/III mediators, more HLA links
+   (celiac→DQ2, narcolepsy→DR2 — deferred, no clean self-contained span yet), cytokines.
 4. **Genetics** — inheritance patterns, trinucleotide repeats, imprinting, gene defects
    (extends the IEM substrate).
 
@@ -184,8 +191,8 @@ manifest). MICRO onward, the order is grounding-FIRST (never seed authored-debt)
 ## Coverage accounting (the watchable number)
 
 The north-star metric: **% of the USMLE content outline covered by grounded, scored
-domains.** Today: 7 recall domains + ID differential/management (a slice of Multisystem,
-Endocrine, Hematology, Biochemistry, Nutrition, Microbiology, Pharmacology — 74/75 board
-recall answers cite an authoritative grounded edge). Each merged domain PR moves this number;
+domains.** Today: 8 recall domains + ID differential/management (a slice of Multisystem,
+Endocrine, Hematology, Biochemistry, Nutrition, Microbiology, Pharmacology, Immunology —
+81/82 board recall answers cite an authoritative grounded edge). Each merged domain PR moves this number;
 this map is the denominator. The campaign is done when every Tier-1/2/3 cell above has a
 grounded, scored domain and the board bank samples each.

--- a/code/specs/data/mycin-2026/board/board-scorecard.json
+++ b/code/specs/data/mycin-2026/board/board-scorecard.json
@@ -1,7 +1,7 @@
 {
   "summary": {
-    "total": 88,
-    "correct": 81,
+    "total": 95,
+    "correct": 88,
     "abstained": 7,
     "wrong": 0,
     "by_tactic": {
@@ -16,15 +16,15 @@
         "wrong": 0
       },
       "recall": {
-        "correct": 75,
+        "correct": 82,
         "abstained": 6,
         "wrong": 0
       }
     },
     "defensibility": 1.0,
     "accuracy_on_attempted": 1.0,
-    "grounded_coverage": 0.9867,
-    "grounded_correct": 74
+    "grounded_coverage": 0.9878,
+    "grounded_correct": 81
   },
   "results": [
     {
@@ -728,6 +728,62 @@
       "tactic": "recall",
       "gold": "flumazenil",
       "answer": "flumazenil",
+      "outcome": "correct",
+      "trust": "authoritative"
+    },
+    {
+      "id": "immuno_type1_mediator",
+      "tactic": "recall",
+      "gold": "ige",
+      "answer": "ige",
+      "outcome": "correct",
+      "trust": "authoritative"
+    },
+    {
+      "id": "immuno_type4_mediator",
+      "tactic": "recall",
+      "gold": "t_cells",
+      "answer": "t_cells",
+      "outcome": "correct",
+      "trust": "authoritative"
+    },
+    {
+      "id": "immuno_as_hla",
+      "tactic": "recall",
+      "gold": "hla_b27",
+      "answer": "hla_b27",
+      "outcome": "correct",
+      "trust": "authoritative"
+    },
+    {
+      "id": "immuno_xla_gene",
+      "tactic": "recall",
+      "gold": "btk",
+      "answer": "btk",
+      "outcome": "correct",
+      "trust": "authoritative"
+    },
+    {
+      "id": "immuno_cgd_deficiency",
+      "tactic": "recall",
+      "gold": "nadph_oxidase",
+      "answer": "nadph_oxidase",
+      "outcome": "correct",
+      "trust": "authoritative"
+    },
+    {
+      "id": "immuno_digeorge_def",
+      "tactic": "recall",
+      "gold": "t_cells",
+      "answer": "t_cells",
+      "outcome": "correct",
+      "trust": "authoritative"
+    },
+    {
+      "id": "immuno_digeorge_gene",
+      "tactic": "recall",
+      "gold": "chromosome_22q11_2_deletion",
+      "answer": "chromosome_22q11_2_deletion",
       "outcome": "correct",
       "trust": "authoritative"
     }

--- a/code/specs/data/mycin-2026/board/board_eval.py
+++ b/code/specs/data/mycin-2026/board/board_eval.py
@@ -65,7 +65,7 @@ SCORECARD = HERE / "board-scorecard.json"
 # model calls. (A local in-memory model may generate the ADJ program from prose; see
 # board_offline.py. The engine that ANSWERS is always the native CPU reasoner.)
 EDGE_FILES = ["iem-edges.adj", "vitamin-edges.adj", "anemia-edges.adj", "endocrine-edges.adj",
-              "coag-edges.adj", "micro-edges.adj", "pharm-edges.adj"]
+              "coag-edges.adj", "micro-edges.adj", "pharm-edges.adj", "immuno-edges.adj"]
 
 # The native adj-lang CLI binary — the ONE engine behind every tactic (recall,
 # differential, management). If the binary is absent (e.g. a Python-only CI job that

--- a/code/specs/data/mycin-2026/board/decompose_query.py
+++ b/code/specs/data/mycin-2026/board/decompose_query.py
@@ -58,7 +58,8 @@ from pathlib import Path
 HERE = Path(__file__).resolve().parent
 RECALL = HERE.parent / "recall"
 EDGE_FILES = ["iem-edges.adj", "vitamin-edges.adj", "anemia-edges.adj",
-              "endocrine-edges.adj", "coag-edges.adj", "micro-edges.adj", "pharm-edges.adj"]
+              "endocrine-edges.adj", "coag-edges.adj", "micro-edges.adj", "pharm-edges.adj",
+              "immuno-edges.adj"]
 
 # Each recall relation binds one conventional variable (the "what is being asked").
 # This is the controlled query vocabulary the model must choose from — 18 relations
@@ -83,6 +84,10 @@ REL_VAR = {
     "mechanism": "MOA",                # pharmacology: mechanism of action
     "adverse_effect": "Effect",        # pharmacology: a notable adverse effect
     "antidote_for": "Antidote",        # pharmacology: what reverses a poisoning/overdose
+    "mediated_by": "Mediator",         # immunology: effector driving a hypersensitivity reaction
+    "associated_hla": "HLA",           # immunology: the HLA allele a disease associates with
+    "gene_defect": "Gene",             # immunology/genetics: the mutated gene behind a disorder
+    "deficiency_of": "Component",      # immunology: the immune component missing in an immunodeficiency
 }
 
 _RELATE_RE = re.compile(r"^\s*relate\s+([a-z_][a-z0-9_]*)\s*\(([^)]*)\)\s*$")

--- a/code/specs/data/mycin-2026/board/items.json
+++ b/code/specs/data/mycin-2026/board/items.json
@@ -98,6 +98,14 @@
     {"id": "pharm_apap_adverse",     "domain": "pharm", "tactic": "recall", "relation": "adverse_effect", "subject": "acetaminophen",          "var": "Effect",   "gold": "hepatic_necrosis"},
     {"id": "pharm_apap_antidote",    "domain": "pharm", "tactic": "recall", "relation": "antidote_for",   "subject": "acetaminophen_poisoning","var": "Antidote", "gold": "acetylcysteine"},
     {"id": "pharm_opioid_antidote",  "domain": "pharm", "tactic": "recall", "relation": "antidote_for",   "subject": "opioid_toxicity",        "var": "Antidote", "gold": "naloxone"},
-    {"id": "pharm_benzo_antidote",   "domain": "pharm", "tactic": "recall", "relation": "antidote_for",   "subject": "benzodiazepine_overdose","var": "Antidote", "gold": "flumazenil"}
+    {"id": "pharm_benzo_antidote",   "domain": "pharm", "tactic": "recall", "relation": "antidote_for",   "subject": "benzodiazepine_overdose","var": "Antidote", "gold": "flumazenil"},
+
+    {"id": "immuno_type1_mediator", "domain": "immuno", "tactic": "recall", "relation": "mediated_by",    "subject": "type_i_hypersensitivity",       "var": "Mediator",  "gold": "ige"},
+    {"id": "immuno_type4_mediator", "domain": "immuno", "tactic": "recall", "relation": "mediated_by",    "subject": "type_iv_hypersensitivity",      "var": "Mediator",  "gold": "t_cells"},
+    {"id": "immuno_as_hla",         "domain": "immuno", "tactic": "recall", "relation": "associated_hla", "subject": "ankylosing_spondylitis",        "var": "HLA",       "gold": "hla_b27"},
+    {"id": "immuno_xla_gene",       "domain": "immuno", "tactic": "recall", "relation": "gene_defect",    "subject": "x_linked_agammaglobulinemia",   "var": "Gene",      "gold": "btk"},
+    {"id": "immuno_cgd_deficiency", "domain": "immuno", "tactic": "recall", "relation": "deficiency_of",  "subject": "chronic_granulomatous_disease", "var": "Component", "gold": "nadph_oxidase"},
+    {"id": "immuno_digeorge_def",   "domain": "immuno", "tactic": "recall", "relation": "deficiency_of",  "subject": "digeorge_syndrome",             "var": "Component", "gold": "t_cells"},
+    {"id": "immuno_digeorge_gene",  "domain": "immuno", "tactic": "recall", "relation": "gene_defect",    "subject": "digeorge_syndrome",             "var": "Gene",      "gold": "chromosome_22q11_2_deletion"}
   ]
 }

--- a/code/specs/data/mycin-2026/board/test_board_eval.py
+++ b/code/specs/data/mycin-2026/board/test_board_eval.py
@@ -41,13 +41,13 @@ def test_covered_items_answer_correctly_with_a_proof() -> None:
     assert by_id["tay_sachs_enzyme"].answer == "hexosaminidase_a"
     # A correct recall answer carries the citing edge's trust tier (its proof).
     assert by_id["tay_sachs_enzyme"].trust is not None
-    # The bank spans SEVEN recall domains: 18 IEM + 8 vitamin + 8 anemia + 8 endocrine
-    # + 11 coagulation (REL-13) + 13 microbiology (MICRO) + 9 pharmacology (PHARM) = 75
-    # covered recall items, all over one merged store. MICRO and PHARM are ADJ-ONLY
-    # domains: their *-edges.adj are hand-authored libraries carrying byte-provenance
-    # inline (no Python gate / JSON / manifest).
+    # The bank spans EIGHT recall domains: 18 IEM + 8 vitamin + 8 anemia + 8 endocrine
+    # + 11 coagulation (REL-13) + 13 microbiology (MICRO) + 9 pharmacology (PHARM) + 7
+    # immunology (IMMUNO) = 82 covered recall items, all over one merged store. MICRO,
+    # PHARM, and IMMUNO are ADJ-ONLY domains: their *-edges.adj are hand-authored
+    # libraries carrying byte-provenance inline (no Python gate / JSON / manifest).
     recall_correct = [r for r in card.results if r.outcome == "correct" and r.tactic == "recall"]
-    assert len(recall_correct) == 75
+    assert len(recall_correct) == 82
     assert by_id["fabry_enzyme"].outcome == "correct"               # IEM
     assert by_id["thiamine_disease"].answer == "beriberi"           # vitamin
     assert by_id["ida_mcv"].answer == "microcytic"                  # anemia
@@ -61,6 +61,9 @@ def test_covered_items_answer_correctly_with_a_proof() -> None:
     assert by_id["pharm_metformin_class"].answer == "biguanide"    # pharmacology (PHARM)
     assert by_id["pharm_opioid_antidote"].answer == "naloxone"     # pharm — antidote_for relation
     assert by_id["pharm_metformin_class"].trust == "authoritative"  # ADJ-only edge, grounded inline
+    assert by_id["immuno_as_hla"].answer == "hla_b27"             # immunology (IMMUNO)
+    assert by_id["immuno_type1_mediator"].answer == "ige"         # immuno — mediated_by relation
+    assert by_id["immuno_as_hla"].trust == "authoritative"        # ADJ-only edge, grounded inline
 
 
 def test_uncovered_items_abstain_not_fabricate() -> None:
@@ -94,16 +97,16 @@ def test_grounded_coverage_is_the_live_grounding_number() -> None:
     # landed at direction_only. REL-14 found a stronger source whose verbatim span self-
     # contains the relation ("Factor VII deficiency is a bleeding disorder characterized
     # by a lack in the production of factor VII"), lifting it to authoritative. The ADJ-only
-    # domains MICRO (13 microbiology edges) and PHARM (9 pharmacology edges) — all spider-
-    # grounded to NCBI StatPearls byte-stable spans — add 22 more authoritative recall
-    # answers. 74 of the 75 recall answers across all SEVEN domains now cite an
-    # authoritative edge: grounded-coverage 99%. ONE holdout stays consensus + FLAG
-    # (direction_only) — the adversarial verify could not pin it verbatim, so the framework
-    # declines to claim grounding it cannot defend, by design: cortisol_def (endocrine,
-    # deficiency_syndrome__cortisol — the only verbatim spans frame cortisol deficiency as a
-    # consequence/feature of Addison disease, not the named-syndrome identity).
-    assert s["grounded_coverage"] == round(74 / 75, 4)   # 0.9867
-    assert s["grounded_correct"] == 74
+    # domains MICRO (13 microbiology), PHARM (9 pharmacology), and IMMUNO (7 immunology)
+    # edges — all spider-grounded to NCBI StatPearls byte-stable spans — add 29 more
+    # authoritative recall answers. 81 of the 82 recall answers across all EIGHT domains
+    # now cite an authoritative edge: grounded-coverage 99%. ONE holdout stays consensus +
+    # FLAG (direction_only) — the adversarial verify could not pin it verbatim, so the
+    # framework declines to claim grounding it cannot defend, by design: cortisol_def
+    # (endocrine, deficiency_syndrome__cortisol — the only verbatim spans frame cortisol
+    # deficiency as a consequence/feature of Addison disease, not the named-syndrome identity).
+    assert s["grounded_coverage"] == round(81 / 82, 4)   # 0.9878
+    assert s["grounded_correct"] == 81
     by_id = {r.item_id: r for r in card.results}
     assert by_id["tay_sachs_enzyme"].trust == "authoritative"      # IEM
     assert by_id["ida_mcv"].trust == "authoritative"               # anemia

--- a/code/specs/data/mycin-2026/recall/immuno-edges.adj
+++ b/code/specs/data/mycin-2026/recall/immuno-edges.adj
@@ -1,0 +1,76 @@
+% ============================================================================
+% immuno-edges — the clinical-immunology knowledge-graph (MYCIN-2026 IMMUNO).
+% ============================================================================
+% A Tier-1 recall domain (USMLE-DOMAIN-MAP §"To build"): hypersensitivity mediators,
+% HLA disease associations, and the molecular lesions of primary immunodeficiencies.
+% "What mediates a type I hypersensitivity reaction?" becomes the binding query
+%   ? mediated_by(type_i_hypersensitivity, $Mediator).
+%
+% This file is the SHIPPED ARTIFACT and the SOLE source of truth — no generator, no
+% JSON, no manifest (the third ADJ-only recall domain, after MICRO and PHARM). Each
+% fact is a `relate` clause whose byte-provenance lives INLINE:
+%     source   — the VERBATIM span copied from the cited page (byte-stable: it
+%                appears character-for-character in the page's normalized text).
+%     locator  — the URL the span was read from (NCBI StatPearls / Bookshelf, NIH).
+%     trust    — authoritative (a primary, citable reference).
+% An LLM (or a human) recalls a fact by writing a tiny query .adj that `import`s this
+% library and asks a binding query — see immuno-recall.query.adj. Nothing here is
+% asserted "from memory": every edge is defended by a span a reader can re-fetch and
+% check. (See feedback_nothing_human_authored, feedback_adj_only_shipped_artifacts.)
+%
+% Honest scope: relations chosen so the cited span NAMES both endpoints. Edges with no
+% clean self-contained span (e.g. celiac→HLA-DQ2, narcolepsy→HLA-DR2) are deferred to a
+% later slice rather than grounded on a span that names only the class or only one end.
+% ============================================================================
+
+dictionary immuno_vocab {
+    define reaction   : entity   surface "hypersensitivity reaction", "immune reaction"
+    define mediator   : entity   surface "immune mediator", "effector"
+    define condition  : entity   surface "disease", "immunodeficiency disorder"
+    define hla        : entity   surface "HLA allele"
+    define gene       : entity   surface "gene"
+    define component  : entity   surface "immune component"
+
+    define mediated_by    : relation from reaction to mediator    % the effector that drives the reaction
+    define associated_hla : relation from condition to hla        % the HLA allele a disease associates with
+    define gene_defect    : relation from condition to gene       % the mutated gene behind a disorder
+    define deficiency_of  : relation from condition to component  % the immune component that is missing/defective
+}
+
+rulebook immuno_facts {
+    use immuno_vocab
+
+    % --- Hypersensitivity reactions (Gell & Coombs effectors) ------------
+    relate mediated_by(type_i_hypersensitivity, ige)
+        source "Type I hypersensitivity, also known as immediate hypersensitivity, is an immunoglobulin E (IgE)-mediated immune response that occurs when the immune system overreacts to typically harmless environmental antigens."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK560561/"
+        trust authoritative
+    relate mediated_by(type_iv_hypersensitivity, t_cells)
+        source "Type IV hypersensitivity, or delayed hypersensitivity reactions, are T-cell–mediated immune responses that typically manifest 48 to 72 hours after antigen exposure, although they can take weeks to manifest."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK562228/"
+        trust authoritative
+
+    % --- HLA disease association -----------------------------------------
+    relate associated_hla(ankylosing_spondylitis, hla_b27)
+        source "HLA-B27 contributes to approximately thirty percent of the heritability of ankylosing spondylitis."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK551523/"
+        trust authoritative
+
+    % --- Primary immunodeficiencies: molecular lesion + missing component
+    relate gene_defect(x_linked_agammaglobulinemia, btk)
+        source "X-Linked Agammaglobulinemia XLA is caused by mutations in the BTK gene encoding Bruton tyrosine kinase."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK562182/"
+        trust authoritative
+    relate deficiency_of(chronic_granulomatous_disease, nadph_oxidase)
+        source "Determine the part played by defective NADPH oxidase in the pathophysiology of chronic granulomatous disease."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK493171/"
+        trust authoritative
+    relate deficiency_of(digeorge_syndrome, t_cells)
+        source "Complete DiGeorge syndrome, characterized by complete absence of thymic tissue and profound T-cell lymphopenia, affects less than 1% of individuals with 22q11.2 deletion but represents a life-threatening condition requiring thymus transplantation."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK549798/"
+        trust authoritative
+    relate gene_defect(digeorge_syndrome, chromosome_22q11_2_deletion)
+        source "Approximately 90% of DiGeorge syndrome cases result from a microdeletion on the long arm of chromosome 22 at the 11.2 locus, typically involving a 3-megabase region between low copy repeats LCR22A and LCR22D."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK549798/"
+        trust authoritative
+}

--- a/code/specs/data/mycin-2026/recall/immuno-recall.query.adj
+++ b/code/specs/data/mycin-2026/recall/immuno-recall.query.adj
@@ -1,0 +1,22 @@
+% ============================================================================
+% immuno-recall.query.adj — a worked recall query over the immunology library.
+% ============================================================================
+% The shape an LLM (or a clinician) produces to ANSWER an immunology recall
+% question: it states no immune fact — it only `import`s the grounded library and
+% asks binding queries. The native adj-lang engine resolves each `?` against the
+% imported `relate` edges and returns the binding + the citing clause's
+% source/locator/trust. All knowledge is in the library; none is here.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli immuno-recall.query.adj
+% ============================================================================
+
+import "immuno-edges.adj"
+
+? mediated_by(type_i_hypersensitivity, $Mediator)          % expect ige
+? mediated_by(type_iv_hypersensitivity, $Mediator)         % expect t_cells
+? associated_hla(ankylosing_spondylitis, $HLA)             % expect hla_b27
+? gene_defect(x_linked_agammaglobulinemia, $Gene)          % expect btk
+? deficiency_of(chronic_granulomatous_disease, $Component) % expect nadph_oxidase
+? deficiency_of(digeorge_syndrome, $Component)             % expect t_cells
+? gene_defect(digeorge_syndrome, $Gene)                    % expect chromosome_22q11_2_deletion

--- a/code/specs/data/mycin-2026/recall/test_immuno_recall.py
+++ b/code/specs/data/mycin-2026/recall/test_immuno_recall.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""test_immuno_recall.py — the ADJ-only immunology recall library (MYCIN-2026 IMMUNO).
+
+The third recall domain shipped as a pure ADJ artifact (after MICRO and PHARM):
+`immuno-edges.adj` is the SOLE source of truth — facts + byte-provenance inline, no
+Python gate, no JSON, no manifest. This test pins the property that matters: the native
+adj-lang engine, given a query .adj that only `import`s the library and asks binding
+queries (`immuno-recall.query.adj` — the shape an LLM produces), returns the correct
+binding for every grounded edge, each carrying an AUTHORITATIVE citation with a real
+source span + locator. Knowledge lives in ADJ; the engine answers.
+
+If the native CLI isn't built (a Python-only CI lane), the engine-backed checks skip —
+the file-shape checks (every clause grounded, no authored-debt) still run.
+
+Run:  python3 test_immuno_recall.py
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+ADJ = HERE / "immuno-edges.adj"
+QUERY = HERE / "immuno-recall.query.adj"
+CLI = HERE.parents[3] / "packages" / "rust" / "target" / "debug" / "adj-lang-cli"
+
+# The full grounded edge set (subject, relation, expected binding). Mirrors
+# immuno-edges.adj; a divergence here or there fails the test.
+EXPECTED = [
+    ("type_i_hypersensitivity", "mediated_by", "ige"),
+    ("type_iv_hypersensitivity", "mediated_by", "t_cells"),
+    ("ankylosing_spondylitis", "associated_hla", "hla_b27"),
+    ("x_linked_agammaglobulinemia", "gene_defect", "btk"),
+    ("chronic_granulomatous_disease", "deficiency_of", "nadph_oxidase"),
+    ("digeorge_syndrome", "deficiency_of", "t_cells"),
+    ("digeorge_syndrome", "gene_defect", "chromosome_22q11_2_deletion"),
+]
+VAR = {"mediated_by": "Mediator", "associated_hla": "HLA",
+       "gene_defect": "Gene", "deficiency_of": "Component"}
+
+
+def _cli_available() -> bool:
+    return CLI.exists()
+
+
+def _run(program: Path) -> dict:
+    out = subprocess.run([str(CLI), str(program)], capture_output=True, text=True,
+                         cwd=str(HERE), timeout=60)
+    assert out.returncode == 0, f"adj-lang-cli failed: {out.stderr}"
+    return json.loads(out.stdout)
+
+
+# ---- 1. the ADJ file is the artifact — every clause grounded, no authored-debt ----
+
+def test_library_is_pure_adj_and_fully_grounded() -> None:
+    text = ADJ.read_text()
+    assert "trust consensus" not in text, "IMMUNO ships no authored-debt; ground or omit"
+    assert "[FLAG:" not in text
+    relate_count = text.count("    relate ")
+    assert text.count("trust authoritative") == relate_count == len(EXPECTED)
+    assert text.count('\n        locator "') == relate_count
+    assert text.count('\n        source "') == relate_count
+    # No sibling generator / JSON / manifest for this domain (ADJ-only).
+    assert not (HERE / "immuno_edge_ground.py").exists()
+    assert not (HERE / "immuno-edge-grounding.json").exists()
+    assert not (HERE / "immuno-edge-manifest.json").exists()
+
+
+# ---- 2. the engine resolves every grounded edge with an authoritative citation ----
+
+def test_engine_resolves_every_edge_with_authoritative_citation() -> None:
+    if not _cli_available():
+        return
+    result = _run(QUERY)
+    by_query = {r["query"]: r for r in result["recall"]}
+    for subj, rel, expected in EXPECTED:
+        q = f"{rel}({subj}, {VAR[rel]})"
+        r = by_query.get(q) or _one(rel, subj, VAR[rel])
+        assert r is not None and not r["abstained"], f"{q} abstained — edge missing?"
+        ans = r["answers"][0]
+        assert ans["bindings"][VAR[rel]] == expected, f"{q} -> {ans['bindings']}"
+        cite = ans["citations"][0]
+        assert cite["trust"] == "authoritative", f"{q} citation not authoritative"
+        assert cite["source"], f"{q} citation has no source span"
+        assert cite["locator"].startswith("https://www.ncbi.nlm.nih.gov/"), cite["locator"]
+
+
+def _one(rel: str, subj: str, varname: str) -> dict | None:
+    """Resolve a single edge by writing a throwaway one-line query .adj in this dir
+    (so the relative `import "immuno-edges.adj"` resolves) and running the engine."""
+    import os
+    import tempfile
+    fd, path = tempfile.mkstemp(suffix=".adj", prefix=".immuno_q_", dir=HERE)
+    try:
+        with os.fdopen(fd, "w") as fh:
+            fh.write(f'import "immuno-edges.adj"\n? {rel}({subj}, ${varname})\n')
+        res = _run(Path(path))
+        return res["recall"][0] if res["recall"] else None
+    finally:
+        os.unlink(path)
+
+
+# ---- 3. an off-vocabulary subject abstains, never fabricates ----------------------
+
+def test_unknown_condition_abstains() -> None:
+    if not _cli_available():
+        return
+    r = _one("associated_hla", "rheumatoid_arthritis", "HLA")  # not in the library
+    assert r is not None and r["abstained"], "an ungrounded condition must abstain"
+
+
+def _run_all() -> int:
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    failed = 0
+    for t in tests:
+        try:
+            t()
+            print(f"  PASS  {t.__name__}")
+        except AssertionError as exc:
+            failed += 1
+            print(f"  FAIL  {t.__name__}: {exc}")
+    print(f"\ntest_immuno_recall: {len(tests) - failed}/{len(tests)} passed")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(_run_all())


### PR DESCRIPTION
## What

The **third ADJ-only** recall domain (after MICRO #6212, PHARM #6218). `recall/immuno-edges.adj` *is* the source of truth — facts + byte-provenance **inline** (`source` = verbatim NCBI StatPearls span, `locator` = URL, `trust authoritative`); no Python gate, no JSON, no manifest. An LLM recalls a fact by writing a tiny query `.adj` that `import`s the library and asks a binding query — `recall/immuno-recall.query.adj` is the worked example.

```
import "immuno-edges.adj"
? mediated_by(type_i_hypersensitivity, $Mediator)   % → ige, cited to NBK560561
? associated_hla(ankylosing_spondylitis, $HLA)       % → hla_b27, cited to NBK551523
```

## Grounding (no authored debt)

All **7 edges** across **4 relations** are grounded to **byte-stable verbatim spans**, re-verified character-for-character against the live page (7/7):

| relation | edge | source |
|---|---|---|
| `mediated_by` | type I → IgE; type IV → T cells | NBK560561, NBK562228 |
| `associated_hla` | ankylosing spondylitis → HLA-B27 | NBK551523 |
| `gene_defect` | XLA → BTK; DiGeorge → 22q11.2 deletion | NBK562182, NBK549798 |
| `deficiency_of` | CGD → NADPH oxidase; DiGeorge → T cells | NBK493171, NBK549798 |

No `trust consensus` seed — grounded or omitted. **Deferred** (no clean self-contained span yet): type II/III mediators, celiac→HLA-DQ2, narcolepsy→HLA-DR2.

## Wiring & results

- `board_eval.EDGE_FILES` + `decompose_query.EDGE_FILES` += `immuno-edges.adj`; `REL_VAR` += the 4 relations (recall vocab 18 → 22)
- 7 immuno board items — all resolve **correct**, all **authoritative**
- Scorecard: recall **75 → 82** correct, grounded **74 → 81** (81/82 = **99%**), **wrong 0**, defensibility **100%**
- `test_immuno_recall.py` pins the ADJ-only flow end-to-end through the native CLI (every edge → authoritative citation; off-vocabulary condition abstains)
- `USMLE-DOMAIN-MAP`: Immunology marked built — **8 recall domains** now grounded & scored

## Verification

- `board_eval` test suite: **12/12**
- `test_immuno_recall`: **3/3**
- byte-stability: **7/7** live spans present verbatim
- `/security-review` passed (subprocess / tempfile / string-literal / SSRF — clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)