### PR TITLE
Add SPICE deck sweep artifacts

### DIFF
--- a/code/packages/python/spice-engine/src/spice_engine/engine.py
+++ b/code/packages/python/spice-engine/src/spice_engine/engine.py
@@ -2320,6 +2320,13 @@ class DeckRunArtifact:
     directive: str
     line_number: int
     source_name: str | None
+    sweep_kind: str | None
+    start_value: float | None
+    stop_value: float | None
+    step_value: float | None
+    point_count: int | None
+    start_frequency_hz: float | None
+    stop_frequency_hz: float | None
     result_rows: int
     output_probe_count: int
     output_probes: list[str]
@@ -2386,6 +2393,10 @@ def _deck_result_row_count(
     return len(result.points)
 
 
+def _format_deck_artifact_float(value: float | None) -> str:
+    return "" if value is None else f"{value:.6e}"
+
+
 def _deck_run_artifacts(
     plan: DeckAnalysisPlan,
     result: DcResult | DcSweepResult | AcResult | TransientResult | TfResult | SensResult | NoiseResult,
@@ -2400,6 +2411,13 @@ def _deck_run_artifacts(
             directive=plan.directive,
             line_number=plan.line_number,
             source_name=plan.source_name,
+            sweep_kind=plan.sweep_kind,
+            start_value=plan.start_value,
+            stop_value=plan.stop_value,
+            step_value=plan.step_value,
+            point_count=plan.point_count,
+            start_frequency_hz=plan.start_frequency,
+            stop_frequency_hz=plan.stop_frequency,
             result_rows=_deck_result_row_count(result),
             output_probe_count=len(output_probes),
             output_probes=list(output_probes),
@@ -2419,7 +2437,7 @@ def format_deck_run_artifact_table(artifacts: Iterable[DeckRunArtifact]) -> str:
     """Format selected deck-run artifacts as a stable summary table."""
 
     rows = [
-        "Analysis\tDirective\tLine\tSourceName\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList"
+        "Analysis\tDirective\tLine\tSourceName\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList"
     ]
     for artifact in artifacts:
         rows.append(
@@ -2429,6 +2447,13 @@ def format_deck_run_artifact_table(artifacts: Iterable[DeckRunArtifact]) -> str:
                     artifact.directive,
                     str(artifact.line_number),
                     artifact.source_name or "",
+                    artifact.sweep_kind or "",
+                    _format_deck_artifact_float(artifact.start_value),
+                    _format_deck_artifact_float(artifact.stop_value),
+                    _format_deck_artifact_float(artifact.step_value),
+                    "" if artifact.point_count is None else str(artifact.point_count),
+                    _format_deck_artifact_float(artifact.start_frequency_hz),
+                    _format_deck_artifact_float(artifact.stop_frequency_hz),
                     str(artifact.result_rows),
                     str(artifact.output_probe_count),
                     ";".join(artifact.output_probes),

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -6796,13 +6796,15 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
     assert op_execution.table == "Index\tV(mid)\n0\t5.000000e-01\n"
     assert op_execution.run_artifacts[0].result_rows == 1
     assert op_execution.run_artifacts[0].source_name is None
+    assert op_execution.run_artifacts[0].sweep_kind is None
+    assert op_execution.run_artifacts[0].point_count is None
     assert op_execution.run_artifacts[0].output_probes == ["V(mid)"]
     assert op_execution.run_artifacts[0].output_directives == [".save"]
     assert op_execution.run_artifacts[0].measurement_names == []
     assert op_execution.run_artifacts[0].fourier_probes == []
     assert op_execution.run_artifact_table == (
-        "Analysis\tDirective\tLine\tSourceName\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\n"
-        f"op\t.op\t{op_execution.plan.line_number}\t\t1\t1\tV(mid)\t1\t.save\t0\t\t0\t\n"
+        "Analysis\tDirective\tLine\tSourceName\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\n"
+        f"op\t.op\t{op_execution.plan.line_number}\t\t\t\t\t\t\t\t\t1\t1\tV(mid)\t1\t.save\t0\t\t0\t\n"
     )
 
     dc_execution = run_deck_analysis(circuit, netlist, "dc")
@@ -6822,13 +6824,16 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
     )
     assert dc_execution.run_artifacts[0].analysis == "dc"
     assert dc_execution.run_artifacts[0].source_name == "V1"
+    assert dc_execution.run_artifacts[0].start_value == pytest.approx(0.0)
+    assert dc_execution.run_artifacts[0].stop_value == pytest.approx(1.0)
+    assert dc_execution.run_artifacts[0].step_value == pytest.approx(1.0)
     assert dc_execution.run_artifacts[0].output_probes == ["V(mid)", "I(V1)"]
     assert dc_execution.run_artifacts[0].output_directives == [".save", ".probe"]
     assert dc_execution.run_artifacts[0].measurement_names == ["mid_avg"]
     assert dc_execution.run_artifacts[0].fourier_probes == []
     assert dc_execution.run_artifact_table == (
-        "Analysis\tDirective\tLine\tSourceName\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\n"
-        f"dc\t.dc\t{dc_execution.plan.line_number}\tV1\t2\t2\tV(mid);I(V1)\t2\t.save;.probe\t1\tmid_avg\t0\t\n"
+        "Analysis\tDirective\tLine\tSourceName\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\n"
+        f"dc\t.dc\t{dc_execution.plan.line_number}\tV1\t\t0.000000e+00\t1.000000e+00\t1.000000e+00\t\t\t\t2\t2\tV(mid);I(V1)\t2\t.save;.probe\t1\tmid_avg\t0\t\n"
     )
 
     ac_execution = run_deck_analysis(circuit, netlist, "ac")
@@ -6846,12 +6851,16 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
     )
     assert ac_execution.run_artifacts[0].output_probes == ["V(mid)"]
     assert ac_execution.run_artifacts[0].source_name is None
+    assert ac_execution.run_artifacts[0].sweep_kind == "dec"
+    assert ac_execution.run_artifacts[0].point_count == 1
+    assert ac_execution.run_artifacts[0].start_frequency_hz == pytest.approx(1.0e3)
+    assert ac_execution.run_artifacts[0].stop_frequency_hz == pytest.approx(1.0e3)
     assert ac_execution.run_artifacts[0].output_directives == [".save"]
     assert ac_execution.run_artifacts[0].measurement_names == ["mid_peak"]
     assert ac_execution.run_artifacts[0].fourier_probes == []
     assert ac_execution.run_artifact_table == (
-        "Analysis\tDirective\tLine\tSourceName\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\n"
-        f"ac\t.ac\t{ac_execution.plan.line_number}\t\t1\t1\tV(mid)\t1\t.save\t1\tmid_peak\t0\t\n"
+        "Analysis\tDirective\tLine\tSourceName\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\n"
+        f"ac\t.ac\t{ac_execution.plan.line_number}\t\tdec\t\t\t\t1\t1.000000e+03\t1.000000e+03\t1\t1\tV(mid)\t1\t.save\t1\tmid_peak\t0\t\n"
     )
 
     tran_execution = run_deck_analysis(circuit, netlist, "tran")
@@ -6875,8 +6884,8 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
     assert tran_execution.run_artifacts[0].measurement_names == ["mid_final"]
     assert tran_execution.run_artifacts[0].fourier_probes == []
     assert tran_execution.run_artifact_table == (
-        "Analysis\tDirective\tLine\tSourceName\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\n"
-        f"tran\t.tran\t{tran_execution.plan.line_number}\t\t2\t1\tV(mid)\t1\t.save\t1\tmid_final\t0\t\n"
+        "Analysis\tDirective\tLine\tSourceName\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\n"
+        f"tran\t.tran\t{tran_execution.plan.line_number}\t\t\t\t\t\t\t\t\t2\t1\tV(mid)\t1\t.save\t1\tmid_final\t0\t\n"
     )
 
     tf_execution = run_deck_analysis(circuit, netlist, "tf")
@@ -6901,8 +6910,8 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
     assert tf_execution.run_artifacts[0].measurement_names == []
     assert tf_execution.run_artifacts[0].fourier_probes == []
     assert tf_execution.run_artifact_table == (
-        "Analysis\tDirective\tLine\tSourceName\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\n"
-        f"tf\t.tf\t{tf_execution.plan.line_number}\tV1\t1\t1\tV(mid)\t0\t\t0\t\t0\t\n"
+        "Analysis\tDirective\tLine\tSourceName\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\n"
+        f"tf\t.tf\t{tf_execution.plan.line_number}\tV1\t\t\t\t\t\t\t\t1\t1\tV(mid)\t0\t\t0\t\t0\t\n"
     )
 
     sens_execution = run_deck_analysis(circuit, netlist, "sens")
@@ -6925,8 +6934,8 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
     assert sens_execution.run_artifacts[0].measurement_names == []
     assert sens_execution.run_artifacts[0].fourier_probes == []
     assert sens_execution.run_artifact_table == (
-        "Analysis\tDirective\tLine\tSourceName\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\n"
-        f"sens\t.sens\t{sens_execution.plan.line_number}\t\t1\t1\tV(mid)\t0\t\t0\t\t0\t\n"
+        "Analysis\tDirective\tLine\tSourceName\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\n"
+        f"sens\t.sens\t{sens_execution.plan.line_number}\t\t\t\t\t\t\t\t\t1\t1\tV(mid)\t0\t\t0\t\t0\t\n"
     )
 
     noise_execution = run_deck_analysis(circuit, netlist, "noise")
@@ -6950,14 +6959,18 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
     )
     assert noise_execution.run_artifacts[0].analysis == "noise"
     assert noise_execution.run_artifacts[0].source_name == "V1"
+    assert noise_execution.run_artifacts[0].sweep_kind == "lin"
+    assert noise_execution.run_artifacts[0].point_count == 1
+    assert noise_execution.run_artifacts[0].start_frequency_hz == pytest.approx(1.0e3)
+    assert noise_execution.run_artifacts[0].stop_frequency_hz == pytest.approx(1.0e3)
     assert noise_execution.run_artifacts[0].result_rows == 1
     assert noise_execution.run_artifacts[0].output_probes == ["V(mid)"]
     assert noise_execution.run_artifacts[0].output_directives == []
     assert noise_execution.run_artifacts[0].measurement_names == []
     assert noise_execution.run_artifacts[0].fourier_probes == []
     assert noise_execution.run_artifact_table == (
-        "Analysis\tDirective\tLine\tSourceName\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\n"
-        f"noise\t.noise\t{noise_execution.plan.line_number}\tV1\t1\t1\tV(mid)\t0\t\t0\t\t0\t\n"
+        "Analysis\tDirective\tLine\tSourceName\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\n"
+        f"noise\t.noise\t{noise_execution.plan.line_number}\tV1\tlin\t\t\t\t1\t1.000000e+03\t1.000000e+03\t1\t1\tV(mid)\t0\t\t0\t\t0\t\n"
     )
 
     tran_window_execution = run_deck_analysis(
@@ -7037,8 +7050,8 @@ def test_run_deck_analysis_exposes_selected_fourier_artifacts() -> None:
     assert tran_execution.run_artifacts[0].measurement_names == []
     assert tran_execution.run_artifacts[0].fourier_probes == ["V(mid)"]
     assert tran_execution.run_artifact_table == (
-        "Analysis\tDirective\tLine\tSourceName\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\n"
-        f"tran\t.tran\t{tran_execution.plan.line_number}\t\t3\t1\tV(mid)\t1\t.save\t0\t\t1\tV(mid)\n"
+        "Analysis\tDirective\tLine\tSourceName\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\n"
+        f"tran\t.tran\t{tran_execution.plan.line_number}\t\t\t\t\t\t\t\t\t3\t1\tV(mid)\t1\t.save\t0\t\t1\tV(mid)\n"
     )
 
 

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -3408,6 +3408,13 @@ pub struct DeckRunArtifact {
     pub directive: String,
     pub line_number: usize,
     pub source_name: Option<String>,
+    pub sweep_kind: Option<String>,
+    pub start_value: Option<f64>,
+    pub stop_value: Option<f64>,
+    pub step_value: Option<f64>,
+    pub point_count: Option<usize>,
+    pub start_frequency_hz: Option<f64>,
+    pub stop_frequency_hz: Option<f64>,
     pub result_rows: usize,
     pub output_probe_count: usize,
     pub output_probes: Vec<String>,
@@ -10089,6 +10096,13 @@ fn deck_run_artifacts(
         directive: plan.directive.clone(),
         line_number: plan.line_number,
         source_name: plan.source_name.clone(),
+        sweep_kind: plan.sweep_kind.clone(),
+        start_value: plan.start_value,
+        stop_value: plan.stop_value,
+        step_value: plan.step_value,
+        point_count: plan.point_count,
+        start_frequency_hz: plan.start_frequency_hz,
+        stop_frequency_hz: plan.stop_frequency_hz,
         result_rows,
         output_probe_count: output_probes.len(),
         output_probes: output_probes.to_vec(),
@@ -10107,18 +10121,32 @@ fn deck_run_artifacts(
     }]
 }
 
+fn format_deck_artifact_float(value: Option<f64>) -> String {
+    value.map(format_table_number).unwrap_or_default()
+}
+
 pub fn format_deck_run_artifact_table(artifacts: &[DeckRunArtifact]) -> String {
     let mut rows = vec![
-        "Analysis\tDirective\tLine\tSourceName\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList"
+        "Analysis\tDirective\tLine\tSourceName\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList"
             .to_string(),
     ];
     for artifact in artifacts {
         rows.push(format!(
-            "{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}",
+            "{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}",
             artifact.analysis,
             artifact.directive,
             artifact.line_number,
             artifact.source_name.as_deref().unwrap_or(""),
+            artifact.sweep_kind.as_deref().unwrap_or(""),
+            format_deck_artifact_float(artifact.start_value),
+            format_deck_artifact_float(artifact.stop_value),
+            format_deck_artifact_float(artifact.step_value),
+            artifact
+                .point_count
+                .map(|value| value.to_string())
+                .unwrap_or_default(),
+            format_deck_artifact_float(artifact.start_frequency_hz),
+            format_deck_artifact_float(artifact.stop_frequency_hz),
             artifact.result_rows,
             artifact.output_probe_count,
             artifact.output_probes.join(";"),

--- a/code/packages/rust/spice-engine/tests/transient_tests.rs
+++ b/code/packages/rust/spice-engine/tests/transient_tests.rs
@@ -1889,6 +1889,8 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
     assert_eq!(op_execution.table, "Index\tV(mid)\n0\t5.000000e-01\n");
     assert_eq!(op_execution.run_artifacts[0].result_rows, 1);
     assert_eq!(op_execution.run_artifacts[0].source_name, None);
+    assert_eq!(op_execution.run_artifacts[0].sweep_kind, None);
+    assert_eq!(op_execution.run_artifacts[0].point_count, None);
     assert_eq!(
         op_execution.run_artifacts[0].output_probes,
         vec!["V(mid)".to_string()]
@@ -1902,7 +1904,7 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
     assert_eq!(
         op_execution.run_artifact_table,
         format!(
-            "Analysis\tDirective\tLine\tSourceName\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\nop\t.op\t{}\t\t1\t1\tV(mid)\t1\t.save\t0\t\t0\t\n",
+            "Analysis\tDirective\tLine\tSourceName\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\nop\t.op\t{}\t\t\t\t\t\t\t\t\t1\t1\tV(mid)\t1\t.save\t0\t\t0\t\n",
             op_execution.plan.line_number
         )
     );
@@ -1931,6 +1933,9 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
         dc_execution.run_artifacts[0].source_name.as_deref(),
         Some("V1")
     );
+    assert_eq!(dc_execution.run_artifacts[0].start_value, Some(0.0));
+    assert_eq!(dc_execution.run_artifacts[0].stop_value, Some(1.0));
+    assert_eq!(dc_execution.run_artifacts[0].step_value, Some(1.0));
     assert_eq!(
         dc_execution.run_artifacts[0].output_probes,
         vec!["V(mid)".to_string(), "I(V1)".to_string()]
@@ -1947,7 +1952,7 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
     assert_eq!(
         dc_execution.run_artifact_table,
         format!(
-            "Analysis\tDirective\tLine\tSourceName\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\ndc\t.dc\t{}\tV1\t2\t2\tV(mid);I(V1)\t2\t.save;.probe\t1\tmid_avg\t0\t\n",
+            "Analysis\tDirective\tLine\tSourceName\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\ndc\t.dc\t{}\tV1\t\t0.000000e+00\t1.000000e+00\t1.000000e+00\t\t\t\t2\t2\tV(mid);I(V1)\t2\t.save;.probe\t1\tmid_avg\t0\t\n",
             dc_execution.plan.line_number
         )
     );
@@ -1973,6 +1978,16 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
     );
     assert_eq!(ac_execution.run_artifacts[0].source_name, None);
     assert_eq!(
+        ac_execution.run_artifacts[0].sweep_kind.as_deref(),
+        Some("dec")
+    );
+    assert_eq!(ac_execution.run_artifacts[0].point_count, Some(1));
+    assert_eq!(
+        ac_execution.run_artifacts[0].start_frequency_hz,
+        Some(1.0e3)
+    );
+    assert_eq!(ac_execution.run_artifacts[0].stop_frequency_hz, Some(1.0e3));
+    assert_eq!(
         ac_execution.run_artifacts[0].output_directives,
         vec![".save".to_string()]
     );
@@ -1984,7 +1999,7 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
     assert_eq!(
         ac_execution.run_artifact_table,
         format!(
-            "Analysis\tDirective\tLine\tSourceName\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\nac\t.ac\t{}\t\t1\t1\tV(mid)\t1\t.save\t1\tmid_peak\t0\t\n",
+            "Analysis\tDirective\tLine\tSourceName\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\nac\t.ac\t{}\t\tdec\t\t\t\t1\t1.000000e+03\t1.000000e+03\t1\t1\tV(mid)\t1\t.save\t1\tmid_peak\t0\t\n",
             ac_execution.plan.line_number
         )
     );
@@ -2021,7 +2036,7 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
     assert_eq!(
         tran_execution.run_artifact_table,
         format!(
-            "Analysis\tDirective\tLine\tSourceName\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\ntran\t.tran\t{}\t\t1\t1\tV(mid)\t1\t.save\t1\tmid_final\t0\t\n",
+            "Analysis\tDirective\tLine\tSourceName\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\ntran\t.tran\t{}\t\t\t\t\t\t\t\t\t1\t1\tV(mid)\t1\t.save\t1\tmid_final\t0\t\n",
             tran_execution.plan.line_number
         )
     );
@@ -2063,7 +2078,7 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
     assert_eq!(
         tf_execution.run_artifact_table,
         format!(
-            "Analysis\tDirective\tLine\tSourceName\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\ntf\t.tf\t{}\tV1\t1\t1\tV(mid)\t0\t\t0\t\t0\t\n",
+            "Analysis\tDirective\tLine\tSourceName\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\ntf\t.tf\t{}\tV1\t\t\t\t\t\t\t\t1\t1\tV(mid)\t0\t\t0\t\t0\t\n",
             tf_execution.plan.line_number
         )
     );
@@ -2100,7 +2115,7 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
     assert_eq!(
         sens_execution.run_artifact_table,
         format!(
-            "Analysis\tDirective\tLine\tSourceName\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\nsens\t.sens\t{}\t\t1\t1\tV(mid)\t0\t\t0\t\t0\t\n",
+            "Analysis\tDirective\tLine\tSourceName\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\nsens\t.sens\t{}\t\t\t\t\t\t\t\t\t1\t1\tV(mid)\t0\t\t0\t\t0\t\n",
             sens_execution.plan.line_number
         )
     );
@@ -2135,6 +2150,19 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
         noise_execution.run_artifacts[0].source_name.as_deref(),
         Some("V1")
     );
+    assert_eq!(
+        noise_execution.run_artifacts[0].sweep_kind.as_deref(),
+        Some("lin")
+    );
+    assert_eq!(noise_execution.run_artifacts[0].point_count, Some(1));
+    assert_eq!(
+        noise_execution.run_artifacts[0].start_frequency_hz,
+        Some(1.0e3)
+    );
+    assert_eq!(
+        noise_execution.run_artifacts[0].stop_frequency_hz,
+        Some(1.0e3)
+    );
     assert_eq!(noise_execution.run_artifacts[0].result_rows, 1);
     assert_eq!(
         noise_execution.run_artifacts[0].output_probes,
@@ -2150,7 +2178,7 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
     assert_eq!(
         noise_execution.run_artifact_table,
         format!(
-            "Analysis\tDirective\tLine\tSourceName\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\nnoise\t.noise\t{}\tV1\t1\t1\tV(mid)\t0\t\t0\t\t0\t\n",
+            "Analysis\tDirective\tLine\tSourceName\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\nnoise\t.noise\t{}\tV1\tlin\t\t\t\t1\t1.000000e+03\t1.000000e+03\t1\t1\tV(mid)\t0\t\t0\t\t0\t\n",
             noise_execution.plan.line_number
         )
     );
@@ -2270,7 +2298,7 @@ fn run_deck_analysis_exposes_selected_fourier_artifacts() {
     assert_eq!(
         tran_execution.run_artifact_table,
         format!(
-            "Analysis\tDirective\tLine\tSourceName\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\ntran\t.tran\t{}\t\t2\t1\tV(mid)\t1\t.save\t0\t\t1\tV(mid)\n",
+            "Analysis\tDirective\tLine\tSourceName\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\ntran\t.tran\t{}\t\t\t\t\t\t\t\t\t2\t1\tV(mid)\t1\t.save\t0\t\t1\tV(mid)\n",
             tran_execution.plan.line_number
         )
     );

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -663,6 +663,13 @@ export interface DeckRunArtifact {
   readonly directive: DeckAnalysisPlan["directive"];
   readonly lineNumber: number;
   readonly sourceName?: string;
+  readonly sweepKind?: DeckAnalysisPlan["sweepKind"];
+  readonly startValue?: number;
+  readonly stopValue?: number;
+  readonly stepValue?: number;
+  readonly pointCount?: number;
+  readonly startFrequencyHz?: number;
+  readonly stopFrequencyHz?: number;
   readonly resultRows: number;
   readonly outputProbeCount: number;
   readonly outputProbes: readonly string[];
@@ -7877,6 +7884,13 @@ function deckRunArtifacts(
       directive: plan.directive,
       lineNumber: plan.lineNumber,
       sourceName: plan.sourceName,
+      sweepKind: plan.sweepKind,
+      startValue: plan.startValue,
+      stopValue: plan.stopValue,
+      stepValue: plan.stepValue,
+      pointCount: plan.pointCount,
+      startFrequencyHz: plan.startFrequencyHz,
+      stopFrequencyHz: plan.stopFrequencyHz,
       resultRows: deckResultRowCount(result),
       outputProbeCount: outputProbes.length,
       outputProbes: [...outputProbes],
@@ -7890,9 +7904,13 @@ function deckRunArtifacts(
   ];
 }
 
+function formatDeckArtifactFloat(value: number | undefined): string {
+  return value === undefined ? "" : formatTableNumber(value);
+}
+
 export function formatDeckRunArtifactTable(artifacts: readonly DeckRunArtifact[]): string {
   const rows = [
-    "Analysis\tDirective\tLine\tSourceName\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList",
+    "Analysis\tDirective\tLine\tSourceName\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList",
   ];
   for (const artifact of artifacts) {
     rows.push(
@@ -7901,6 +7919,13 @@ export function formatDeckRunArtifactTable(artifacts: readonly DeckRunArtifact[]
         artifact.directive,
         String(artifact.lineNumber),
         artifact.sourceName ?? "",
+        artifact.sweepKind ?? "",
+        formatDeckArtifactFloat(artifact.startValue),
+        formatDeckArtifactFloat(artifact.stopValue),
+        formatDeckArtifactFloat(artifact.stepValue),
+        artifact.pointCount === undefined ? "" : String(artifact.pointCount),
+        formatDeckArtifactFloat(artifact.startFrequencyHz),
+        formatDeckArtifactFloat(artifact.stopFrequencyHz),
         String(artifact.resultRows),
         String(artifact.outputProbeCount),
         artifact.outputProbes.join(";"),

--- a/code/packages/typescript/spice-engine/tests/transient.test.ts
+++ b/code/packages/typescript/spice-engine/tests/transient.test.ts
@@ -1470,13 +1470,15 @@ describe("transient", () => {
     expect(opExecution.table).toBe("Index\tV(mid)\n0\t5.000000e-01\n");
     expect(opExecution.runArtifacts[0]?.resultRows).toBe(1);
     expect(opExecution.runArtifacts[0]?.sourceName).toBeUndefined();
+    expect(opExecution.runArtifacts[0]?.sweepKind).toBeUndefined();
+    expect(opExecution.runArtifacts[0]?.pointCount).toBeUndefined();
     expect(opExecution.runArtifacts[0]?.outputProbes).toEqual(["V(mid)"]);
     expect(opExecution.runArtifacts[0]?.outputDirectives).toEqual([".save"]);
     expect(opExecution.runArtifacts[0]?.measurementNames).toEqual([]);
     expect(opExecution.runArtifacts[0]?.fourierProbes).toEqual([]);
     expect(opExecution.runArtifactTable).toBe(
-      "Analysis\tDirective\tLine\tSourceName\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\n" +
-        `op\t.op\t${opExecution.plan.lineNumber}\t\t1\t1\tV(mid)\t1\t.save\t0\t\t0\t\n`,
+      "Analysis\tDirective\tLine\tSourceName\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\n" +
+        `op\t.op\t${opExecution.plan.lineNumber}\t\t\t\t\t\t\t\t\t1\t1\tV(mid)\t1\t.save\t0\t\t0\t\n`,
     );
 
     const dcExecution = runDeckAnalysis(circuit, netlist, "dc");
@@ -1495,13 +1497,16 @@ describe("transient", () => {
     );
     expect(dcExecution.runArtifacts[0]?.analysis).toBe("dc");
     expect(dcExecution.runArtifacts[0]?.sourceName).toBe("V1");
+    expect(dcExecution.runArtifacts[0]?.startValue).toBeCloseTo(0.0, 12);
+    expect(dcExecution.runArtifacts[0]?.stopValue).toBeCloseTo(1.0, 12);
+    expect(dcExecution.runArtifacts[0]?.stepValue).toBeCloseTo(1.0, 12);
     expect(dcExecution.runArtifacts[0]?.outputProbes).toEqual(["V(mid)", "I(V1)"]);
     expect(dcExecution.runArtifacts[0]?.outputDirectives).toEqual([".save", ".probe"]);
     expect(dcExecution.runArtifacts[0]?.measurementNames).toEqual(["mid_avg"]);
     expect(dcExecution.runArtifacts[0]?.fourierProbes).toEqual([]);
     expect(dcExecution.runArtifactTable).toBe(
-      "Analysis\tDirective\tLine\tSourceName\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\n" +
-        `dc\t.dc\t${dcExecution.plan.lineNumber}\tV1\t2\t2\tV(mid);I(V1)\t2\t.save;.probe\t1\tmid_avg\t0\t\n`,
+      "Analysis\tDirective\tLine\tSourceName\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\n" +
+        `dc\t.dc\t${dcExecution.plan.lineNumber}\tV1\t\t0.000000e+00\t1.000000e+00\t1.000000e+00\t\t\t\t2\t2\tV(mid);I(V1)\t2\t.save;.probe\t1\tmid_avg\t0\t\n`,
     );
 
     const acExecution = runDeckAnalysis(circuit, netlist, "ac");
@@ -1518,12 +1523,16 @@ describe("transient", () => {
     );
     expect(acExecution.runArtifacts[0]?.outputProbes).toEqual(["V(mid)"]);
     expect(acExecution.runArtifacts[0]?.sourceName).toBeUndefined();
+    expect(acExecution.runArtifacts[0]?.sweepKind).toBe("dec");
+    expect(acExecution.runArtifacts[0]?.pointCount).toBe(1);
+    expect(acExecution.runArtifacts[0]?.startFrequencyHz).toBeCloseTo(1.0e3, 9);
+    expect(acExecution.runArtifacts[0]?.stopFrequencyHz).toBeCloseTo(1.0e3, 9);
     expect(acExecution.runArtifacts[0]?.outputDirectives).toEqual([".save"]);
     expect(acExecution.runArtifacts[0]?.measurementNames).toEqual(["mid_peak"]);
     expect(acExecution.runArtifacts[0]?.fourierProbes).toEqual([]);
     expect(acExecution.runArtifactTable).toBe(
-      "Analysis\tDirective\tLine\tSourceName\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\n" +
-        `ac\t.ac\t${acExecution.plan.lineNumber}\t\t1\t1\tV(mid)\t1\t.save\t1\tmid_peak\t0\t\n`,
+      "Analysis\tDirective\tLine\tSourceName\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\n" +
+        `ac\t.ac\t${acExecution.plan.lineNumber}\t\tdec\t\t\t\t1\t1.000000e+03\t1.000000e+03\t1\t1\tV(mid)\t1\t.save\t1\tmid_peak\t0\t\n`,
     );
 
     const tranExecution = runDeckAnalysis(circuit, netlist, "tran");
@@ -1544,8 +1553,8 @@ describe("transient", () => {
     expect(tranExecution.runArtifacts[0]?.measurementNames).toEqual(["mid_final"]);
     expect(tranExecution.runArtifacts[0]?.fourierProbes).toEqual([]);
     expect(tranExecution.runArtifactTable).toBe(
-      "Analysis\tDirective\tLine\tSourceName\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\n" +
-        `tran\t.tran\t${tranExecution.plan.lineNumber}\t\t1\t1\tV(mid)\t1\t.save\t1\tmid_final\t0\t\n`,
+      "Analysis\tDirective\tLine\tSourceName\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\n" +
+        `tran\t.tran\t${tranExecution.plan.lineNumber}\t\t\t\t\t\t\t\t\t1\t1\tV(mid)\t1\t.save\t1\tmid_final\t0\t\n`,
     );
 
     const tfExecution = runDeckAnalysis(circuit, netlist, "tf");
@@ -1574,8 +1583,8 @@ describe("transient", () => {
     expect(tfExecution.runArtifacts[0]?.measurementNames).toEqual([]);
     expect(tfExecution.runArtifacts[0]?.fourierProbes).toEqual([]);
     expect(tfExecution.runArtifactTable).toBe(
-      "Analysis\tDirective\tLine\tSourceName\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\n" +
-        `tf\t.tf\t${tfExecution.plan.lineNumber}\tV1\t1\t1\tV(mid)\t0\t\t0\t\t0\t\n`,
+      "Analysis\tDirective\tLine\tSourceName\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\n" +
+        `tf\t.tf\t${tfExecution.plan.lineNumber}\tV1\t\t\t\t\t\t\t\t1\t1\tV(mid)\t0\t\t0\t\t0\t\n`,
     );
 
     const sensExecution = runDeckAnalysis(circuit, netlist, "sens");
@@ -1601,8 +1610,8 @@ describe("transient", () => {
     expect(sensExecution.runArtifacts[0]?.measurementNames).toEqual([]);
     expect(sensExecution.runArtifacts[0]?.fourierProbes).toEqual([]);
     expect(sensExecution.runArtifactTable).toBe(
-      "Analysis\tDirective\tLine\tSourceName\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\n" +
-        `sens\t.sens\t${sensExecution.plan.lineNumber}\t\t1\t1\tV(mid)\t0\t\t0\t\t0\t\n`,
+      "Analysis\tDirective\tLine\tSourceName\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\n" +
+        `sens\t.sens\t${sensExecution.plan.lineNumber}\t\t\t\t\t\t\t\t\t1\t1\tV(mid)\t0\t\t0\t\t0\t\n`,
     );
 
     const noiseExecution = runDeckAnalysis(circuit, netlist, "noise");
@@ -1625,14 +1634,18 @@ describe("transient", () => {
     )).toBe(true);
     expect(noiseExecution.runArtifacts[0]?.analysis).toBe("noise");
     expect(noiseExecution.runArtifacts[0]?.sourceName).toBe("V1");
+    expect(noiseExecution.runArtifacts[0]?.sweepKind).toBe("lin");
+    expect(noiseExecution.runArtifacts[0]?.pointCount).toBe(1);
+    expect(noiseExecution.runArtifacts[0]?.startFrequencyHz).toBeCloseTo(1.0e3, 9);
+    expect(noiseExecution.runArtifacts[0]?.stopFrequencyHz).toBeCloseTo(1.0e3, 9);
     expect(noiseExecution.runArtifacts[0]?.resultRows).toBe(1);
     expect(noiseExecution.runArtifacts[0]?.outputProbes).toEqual(["V(mid)"]);
     expect(noiseExecution.runArtifacts[0]?.outputDirectives).toEqual([]);
     expect(noiseExecution.runArtifacts[0]?.measurementNames).toEqual([]);
     expect(noiseExecution.runArtifacts[0]?.fourierProbes).toEqual([]);
     expect(noiseExecution.runArtifactTable).toBe(
-      "Analysis\tDirective\tLine\tSourceName\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\n" +
-        `noise\t.noise\t${noiseExecution.plan.lineNumber}\tV1\t1\t1\tV(mid)\t0\t\t0\t\t0\t\n`,
+      "Analysis\tDirective\tLine\tSourceName\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\n" +
+        `noise\t.noise\t${noiseExecution.plan.lineNumber}\tV1\tlin\t\t\t\t1\t1.000000e+03\t1.000000e+03\t1\t1\tV(mid)\t0\t\t0\t\t0\t\n`,
     );
 
     const tranWindowExecution = runDeckAnalysis(
@@ -1715,8 +1728,8 @@ describe("transient", () => {
     expect(tranExecution.runArtifacts[0]?.measurementNames).toEqual([]);
     expect(tranExecution.runArtifacts[0]?.fourierProbes).toEqual(["V(mid)"]);
     expect(tranExecution.runArtifactTable).toBe(
-      "Analysis\tDirective\tLine\tSourceName\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\n" +
-        `tran\t.tran\t${tranExecution.plan.lineNumber}\t\t2\t1\tV(mid)\t1\t.save\t0\t\t1\tV(mid)\n`,
+      "Analysis\tDirective\tLine\tSourceName\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\n" +
+        `tran\t.tran\t${tranExecution.plan.lineNumber}\t\t\t\t\t\t\t\t\t2\t1\tV(mid)\t1\t.save\t0\t\t1\tV(mid)\n`,
     );
   });
 

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -803,6 +803,17 @@ downstream tools to compare.
     - The stable run-artifact table now includes `SourceName`, with an empty
       cell for analysis cards that do not name a source.
 
+73. Deck run sweep artifacts.
+    - Status: completed in this deck run sweep artifact slice.
+    - Python, Rust, and TypeScript selected deck executions now copy sweep-shape
+      metadata from selected analysis plans into deck-run artifacts, preserving
+      `.dc` source sweep bounds plus `.ac` and `.noise` sweep kind, point count,
+      and frequency bounds.
+    - The stable run-artifact table now includes `SweepKind`, `StartValue`,
+      `StopValue`, `StepValue`, `PointCount`, `StartFrequencyHz`, and
+      `StopFrequencyHz`, with empty cells for analysis cards without that
+      sweep metadata.
+
 ## Backlog
 
 1. Deck execution layer.


### PR DESCRIPTION
## Summary
- Thread selected deck-analysis sweep metadata through Python, Rust, and TypeScript DeckRunArtifact surfaces.
- Add SweepKind, StartValue, StopValue, StepValue, PointCount, StartFrequencyHz, and StopFrequencyHz to the stable deck run artifact table.
- Mark the deck run sweep artifact slice complete in the full-SPICE implementation plan.

## Verification
- cargo fmt --manifest-path code/packages/rust/spice-engine/Cargo.toml -- --check
- /Users/adhithya/.local/share/mise/installs/python/3.12.13/bin/ruff check code/packages/python/spice-engine
- PYTEST_ADDOPTS=--no-cov PYTHONPATH=code/packages/python/device-physics/src:code/packages/python/mosfet-models/src:code/packages/python/spice-engine/src /Users/adhithya/.local/share/mise/installs/python/3.12.13/bin/python3.12 -m pytest code/packages/python/spice-engine/tests/test_compatibility.py code/packages/python/spice-engine/tests/test_engine.py -q
- cargo test --manifest-path code/packages/rust/spice-engine/Cargo.toml
- PATH=/Users/adhithya/.local/share/mise/installs/node/22.22.3/bin:$PATH npm --prefix code/packages/typescript/spice-engine run build
- PATH=/Users/adhithya/.local/share/mise/installs/node/22.22.3/bin:$PATH npm --prefix code/packages/typescript/spice-engine test