### PR TITLE
feat(mycin-genetics): Tier-1 genetics recall as an ADJ-only grounded library

### DIFF
--- a/code/specs/data/mycin-2026/USMLE-DOMAIN-MAP.md
+++ b/code/specs/data/mycin-2026/USMLE-DOMAIN-MAP.md
@@ -108,6 +108,7 @@ unchanged. Adding a relation just widens the schema — the engine already binds
 | Microbiology | Microbiology | gram_stain, morphology, causes | 13 grounded (ADJ-only) | ✓ |
 | Pharmacology | Pharmacology | drug_class, mechanism, adverse_effect, antidote_for | 9 grounded (ADJ-only) | ✓ |
 | Immunology | Immunology | mediated_by, associated_hla, gene_defect, deficiency_of | 7 grounded (ADJ-only) | ✓ |
+| Genetics | Genetics | inheritance, gene_defect, trinucleotide_repeat, imprinting | 7 grounded (ADJ-only) | ✓ |
 
 Offline pipeline: prose → local-model decompose → ADJ → native engine, two-sided
 faithfulness gate, zero online calls (OFFLINE-BOARD-EXAM.md).
@@ -140,6 +141,13 @@ faithfulness gate, zero online calls (OFFLINE-BOARD-EXAM.md).
    (celiac→DQ2, narcolepsy→DR2 — deferred, no clean self-contained span yet), cytokines.
 4. **Genetics** — inheritance patterns, trinucleotide repeats, imprinting, gene defects
    (extends the IEM substrate).
+   *Started (GENETICS):* `inheritance` (Huntington/Marfan→AD), `trinucleotide_repeat`
+   (Huntington→CAG, fragile X→CGG), `imprinting` (Prader-Willi→paternal), `gene_defect`
+   (Huntington→HTT, fragile X→FMR1) — 7 edges, all grounded to byte-stable NCBI StatPearls
+   spans, shipped as the fourth **ADJ-only** domain (`recall/genetics-edges.adj`; reuses
+   `gene_defect` from IMMUNO over disjoint disorders). Remaining: X-linked / AR patterns
+   (Duchenne, CF), more repeats (myotonic→CTG, Friedreich→GAA), Angelman→maternal,
+   Marfan→FBN1 (deferred — its page's FBN1 mentions are citation titles / negative clauses).
 
 **Tier 2 — organ-system pathology (Step 1/2 diagnosis):**
 5. Cardiovascular (murmurs→lesion, ECG→arrhythmia, drug→effect)
@@ -191,8 +199,10 @@ manifest). MICRO onward, the order is grounding-FIRST (never seed authored-debt)
 ## Coverage accounting (the watchable number)
 
 The north-star metric: **% of the USMLE content outline covered by grounded, scored
-domains.** Today: 8 recall domains + ID differential/management (a slice of Multisystem,
-Endocrine, Hematology, Biochemistry, Nutrition, Microbiology, Pharmacology, Immunology —
-81/82 board recall answers cite an authoritative grounded edge). Each merged domain PR moves this number;
+domains.** Today: 9 recall domains + ID differential/management (a slice of Multisystem,
+Endocrine, Hematology, Biochemistry, Nutrition, Microbiology, Pharmacology, Immunology,
+Genetics — 88/89 board recall answers cite an authoritative grounded edge). All four
+Tier-1 foundational-recall domains (microbiology, pharmacology, immunology, genetics) are
+now grounded & scored. Each merged domain PR moves this number;
 this map is the denominator. The campaign is done when every Tier-1/2/3 cell above has a
 grounded, scored domain and the board bank samples each.

--- a/code/specs/data/mycin-2026/board/board-scorecard.json
+++ b/code/specs/data/mycin-2026/board/board-scorecard.json
@@ -1,7 +1,7 @@
 {
   "summary": {
-    "total": 95,
-    "correct": 88,
+    "total": 102,
+    "correct": 95,
     "abstained": 7,
     "wrong": 0,
     "by_tactic": {
@@ -16,15 +16,15 @@
         "wrong": 0
       },
       "recall": {
-        "correct": 82,
+        "correct": 89,
         "abstained": 6,
         "wrong": 0
       }
     },
     "defensibility": 1.0,
     "accuracy_on_attempted": 1.0,
-    "grounded_coverage": 0.9878,
-    "grounded_correct": 81
+    "grounded_coverage": 0.9888,
+    "grounded_correct": 88
   },
   "results": [
     {
@@ -784,6 +784,62 @@
       "tactic": "recall",
       "gold": "chromosome_22q11_2_deletion",
       "answer": "chromosome_22q11_2_deletion",
+      "outcome": "correct",
+      "trust": "authoritative"
+    },
+    {
+      "id": "genetics_hd_inherit",
+      "tactic": "recall",
+      "gold": "autosomal_dominant",
+      "answer": "autosomal_dominant",
+      "outcome": "correct",
+      "trust": "authoritative"
+    },
+    {
+      "id": "genetics_hd_gene",
+      "tactic": "recall",
+      "gold": "htt",
+      "answer": "htt",
+      "outcome": "correct",
+      "trust": "authoritative"
+    },
+    {
+      "id": "genetics_hd_repeat",
+      "tactic": "recall",
+      "gold": "cag",
+      "answer": "cag",
+      "outcome": "correct",
+      "trust": "authoritative"
+    },
+    {
+      "id": "genetics_marfan_inh",
+      "tactic": "recall",
+      "gold": "autosomal_dominant",
+      "answer": "autosomal_dominant",
+      "outcome": "correct",
+      "trust": "authoritative"
+    },
+    {
+      "id": "genetics_fragx_repeat",
+      "tactic": "recall",
+      "gold": "cgg",
+      "answer": "cgg",
+      "outcome": "correct",
+      "trust": "authoritative"
+    },
+    {
+      "id": "genetics_fragx_gene",
+      "tactic": "recall",
+      "gold": "fmr1",
+      "answer": "fmr1",
+      "outcome": "correct",
+      "trust": "authoritative"
+    },
+    {
+      "id": "genetics_pws_imprint",
+      "tactic": "recall",
+      "gold": "paternal",
+      "answer": "paternal",
       "outcome": "correct",
       "trust": "authoritative"
     }

--- a/code/specs/data/mycin-2026/board/board_eval.py
+++ b/code/specs/data/mycin-2026/board/board_eval.py
@@ -65,7 +65,8 @@ SCORECARD = HERE / "board-scorecard.json"
 # model calls. (A local in-memory model may generate the ADJ program from prose; see
 # board_offline.py. The engine that ANSWERS is always the native CPU reasoner.)
 EDGE_FILES = ["iem-edges.adj", "vitamin-edges.adj", "anemia-edges.adj", "endocrine-edges.adj",
-              "coag-edges.adj", "micro-edges.adj", "pharm-edges.adj", "immuno-edges.adj"]
+              "coag-edges.adj", "micro-edges.adj", "pharm-edges.adj", "immuno-edges.adj",
+              "genetics-edges.adj"]
 
 # The native adj-lang CLI binary — the ONE engine behind every tactic (recall,
 # differential, management). If the binary is absent (e.g. a Python-only CI job that

--- a/code/specs/data/mycin-2026/board/decompose_query.py
+++ b/code/specs/data/mycin-2026/board/decompose_query.py
@@ -59,11 +59,11 @@ HERE = Path(__file__).resolve().parent
 RECALL = HERE.parent / "recall"
 EDGE_FILES = ["iem-edges.adj", "vitamin-edges.adj", "anemia-edges.adj",
               "endocrine-edges.adj", "coag-edges.adj", "micro-edges.adj", "pharm-edges.adj",
-              "immuno-edges.adj"]
+              "immuno-edges.adj", "genetics-edges.adj"]
 
 # Each recall relation binds one conventional variable (the "what is being asked").
-# This is the controlled query vocabulary the model must choose from — 18 relations
-# across seven domains. The engine ultimately validates the subject; this map
+# This is the controlled query vocabulary the model must choose from — 25 relations
+# across eight domains. The engine ultimately validates the subject; this map
 # pins the legal relation set and the variable name each relation answers.
 REL_VAR = {
     "deficient_in": "Enzyme",          # IEM: which enzyme is deficient
@@ -88,6 +88,9 @@ REL_VAR = {
     "associated_hla": "HLA",           # immunology: the HLA allele a disease associates with
     "gene_defect": "Gene",             # immunology/genetics: the mutated gene behind a disorder
     "deficiency_of": "Component",      # immunology: the immune component missing in an immunodeficiency
+    "inheritance": "Pattern",          # genetics: how a Mendelian disorder is transmitted
+    "trinucleotide_repeat": "Repeat",  # genetics: the expanded triplet (CAG / CGG / CTG / GAA)
+    "imprinting": "Parent",            # genetics: the parent-of-origin lesion (PWS / Angelman)
 }
 
 _RELATE_RE = re.compile(r"^\s*relate\s+([a-z_][a-z0-9_]*)\s*\(([^)]*)\)\s*$")

--- a/code/specs/data/mycin-2026/board/items.json
+++ b/code/specs/data/mycin-2026/board/items.json
@@ -106,6 +106,14 @@
     {"id": "immuno_xla_gene",       "domain": "immuno", "tactic": "recall", "relation": "gene_defect",    "subject": "x_linked_agammaglobulinemia",   "var": "Gene",      "gold": "btk"},
     {"id": "immuno_cgd_deficiency", "domain": "immuno", "tactic": "recall", "relation": "deficiency_of",  "subject": "chronic_granulomatous_disease", "var": "Component", "gold": "nadph_oxidase"},
     {"id": "immuno_digeorge_def",   "domain": "immuno", "tactic": "recall", "relation": "deficiency_of",  "subject": "digeorge_syndrome",             "var": "Component", "gold": "t_cells"},
-    {"id": "immuno_digeorge_gene",  "domain": "immuno", "tactic": "recall", "relation": "gene_defect",    "subject": "digeorge_syndrome",             "var": "Gene",      "gold": "chromosome_22q11_2_deletion"}
+    {"id": "immuno_digeorge_gene",  "domain": "immuno", "tactic": "recall", "relation": "gene_defect",    "subject": "digeorge_syndrome",             "var": "Gene",      "gold": "chromosome_22q11_2_deletion"},
+
+    {"id": "genetics_hd_inherit",   "domain": "genetics", "tactic": "recall", "relation": "inheritance",          "subject": "huntington_disease",   "var": "Pattern", "gold": "autosomal_dominant"},
+    {"id": "genetics_hd_gene",      "domain": "genetics", "tactic": "recall", "relation": "gene_defect",          "subject": "huntington_disease",   "var": "Gene",    "gold": "htt"},
+    {"id": "genetics_hd_repeat",    "domain": "genetics", "tactic": "recall", "relation": "trinucleotide_repeat", "subject": "huntington_disease",   "var": "Repeat",  "gold": "cag"},
+    {"id": "genetics_marfan_inh",   "domain": "genetics", "tactic": "recall", "relation": "inheritance",          "subject": "marfan_syndrome",      "var": "Pattern", "gold": "autosomal_dominant"},
+    {"id": "genetics_fragx_repeat", "domain": "genetics", "tactic": "recall", "relation": "trinucleotide_repeat", "subject": "fragile_x_syndrome",   "var": "Repeat",  "gold": "cgg"},
+    {"id": "genetics_fragx_gene",   "domain": "genetics", "tactic": "recall", "relation": "gene_defect",          "subject": "fragile_x_syndrome",   "var": "Gene",    "gold": "fmr1"},
+    {"id": "genetics_pws_imprint",  "domain": "genetics", "tactic": "recall", "relation": "imprinting",           "subject": "prader_willi_syndrome","var": "Parent",  "gold": "paternal"}
   ]
 }

--- a/code/specs/data/mycin-2026/board/test_board_eval.py
+++ b/code/specs/data/mycin-2026/board/test_board_eval.py
@@ -41,13 +41,15 @@ def test_covered_items_answer_correctly_with_a_proof() -> None:
     assert by_id["tay_sachs_enzyme"].answer == "hexosaminidase_a"
     # A correct recall answer carries the citing edge's trust tier (its proof).
     assert by_id["tay_sachs_enzyme"].trust is not None
-    # The bank spans EIGHT recall domains: 18 IEM + 8 vitamin + 8 anemia + 8 endocrine
+    # The bank spans NINE recall domains: 18 IEM + 8 vitamin + 8 anemia + 8 endocrine
     # + 11 coagulation (REL-13) + 13 microbiology (MICRO) + 9 pharmacology (PHARM) + 7
-    # immunology (IMMUNO) = 82 covered recall items, all over one merged store. MICRO,
-    # PHARM, and IMMUNO are ADJ-ONLY domains: their *-edges.adj are hand-authored
-    # libraries carrying byte-provenance inline (no Python gate / JSON / manifest).
+    # immunology (IMMUNO) + 7 genetics (GENETICS) = 89 covered recall items, all over one
+    # merged store. MICRO, PHARM, IMMUNO, and GENETICS are ADJ-ONLY domains: their
+    # *-edges.adj are hand-authored libraries carrying byte-provenance inline (no Python
+    # gate / JSON / manifest). GENETICS reuses the `gene_defect` relation from IMMUNO over
+    # disjoint disorders — the engine merges facts across the imported dictionaries.
     recall_correct = [r for r in card.results if r.outcome == "correct" and r.tactic == "recall"]
-    assert len(recall_correct) == 82
+    assert len(recall_correct) == 89
     assert by_id["fabry_enzyme"].outcome == "correct"               # IEM
     assert by_id["thiamine_disease"].answer == "beriberi"           # vitamin
     assert by_id["ida_mcv"].answer == "microcytic"                  # anemia
@@ -64,6 +66,10 @@ def test_covered_items_answer_correctly_with_a_proof() -> None:
     assert by_id["immuno_as_hla"].answer == "hla_b27"             # immunology (IMMUNO)
     assert by_id["immuno_type1_mediator"].answer == "ige"         # immuno — mediated_by relation
     assert by_id["immuno_as_hla"].trust == "authoritative"        # ADJ-only edge, grounded inline
+    assert by_id["genetics_hd_repeat"].answer == "cag"           # genetics (GENETICS)
+    assert by_id["genetics_pws_imprint"].answer == "paternal"    # genetics — imprinting relation
+    assert by_id["genetics_hd_gene"].answer == "htt"             # gene_defect shared w/ IMMUNO, disjoint subj
+    assert by_id["genetics_hd_repeat"].trust == "authoritative"   # ADJ-only edge, grounded inline
 
 
 def test_uncovered_items_abstain_not_fabricate() -> None:
@@ -97,16 +103,16 @@ def test_grounded_coverage_is_the_live_grounding_number() -> None:
     # landed at direction_only. REL-14 found a stronger source whose verbatim span self-
     # contains the relation ("Factor VII deficiency is a bleeding disorder characterized
     # by a lack in the production of factor VII"), lifting it to authoritative. The ADJ-only
-    # domains MICRO (13 microbiology), PHARM (9 pharmacology), and IMMUNO (7 immunology)
-    # edges — all spider-grounded to NCBI StatPearls byte-stable spans — add 29 more
-    # authoritative recall answers. 81 of the 82 recall answers across all EIGHT domains
-    # now cite an authoritative edge: grounded-coverage 99%. ONE holdout stays consensus +
-    # FLAG (direction_only) — the adversarial verify could not pin it verbatim, so the
-    # framework declines to claim grounding it cannot defend, by design: cortisol_def
-    # (endocrine, deficiency_syndrome__cortisol — the only verbatim spans frame cortisol
-    # deficiency as a consequence/feature of Addison disease, not the named-syndrome identity).
-    assert s["grounded_coverage"] == round(81 / 82, 4)   # 0.9878
-    assert s["grounded_correct"] == 81
+    # domains MICRO (13 microbiology), PHARM (9 pharmacology), IMMUNO (7 immunology), and
+    # GENETICS (7 genetics) edges — all spider-grounded to NCBI StatPearls byte-stable
+    # spans — add 36 more authoritative recall answers. 88 of the 89 recall answers across
+    # all NINE domains now cite an authoritative edge: grounded-coverage 99%. ONE holdout
+    # stays consensus + FLAG (direction_only) — the adversarial verify could not pin it
+    # verbatim, so the framework declines to claim grounding it cannot defend, by design:
+    # cortisol_def (endocrine, deficiency_syndrome__cortisol — the only verbatim spans frame
+    # cortisol deficiency as a consequence/feature of Addison disease, not the named-syndrome identity).
+    assert s["grounded_coverage"] == round(88 / 89, 4)   # 0.9888
+    assert s["grounded_correct"] == 88
     by_id = {r.item_id: r for r in card.results}
     assert by_id["tay_sachs_enzyme"].trust == "authoritative"      # IEM
     assert by_id["ida_mcv"].trust == "authoritative"               # anemia

--- a/code/specs/data/mycin-2026/recall/genetics-edges.adj
+++ b/code/specs/data/mycin-2026/recall/genetics-edges.adj
@@ -1,0 +1,79 @@
+% ============================================================================
+% genetics-edges — the medical-genetics knowledge-graph (MYCIN-2026 GENETICS).
+% ============================================================================
+% A Tier-1 recall domain (USMLE-DOMAIN-MAP §"To build"): inheritance patterns,
+% trinucleotide-repeat expansions, parent-of-origin imprinting, and the gene behind a
+% classic Mendelian disorder. "How is Huntington disease inherited?" becomes the
+% binding query  ? inheritance(huntington_disease, $Pattern).
+%
+% This file is the SHIPPED ARTIFACT and the SOLE source of truth — no generator, no
+% JSON, no manifest (the fourth ADJ-only recall domain). Each fact is a `relate` clause
+% whose byte-provenance lives INLINE:
+%     source   — the VERBATIM span copied from the cited page (byte-stable: it
+%                appears character-for-character in the page's normalized text).
+%     locator  — the URL the span was read from (NCBI StatPearls / Bookshelf, NIH).
+%     trust    — authoritative (a primary, citable reference).
+% An LLM (or a human) recalls a fact by writing a tiny query .adj that `import`s this
+% library and asks a binding query — see genetics-recall.query.adj. Nothing here is
+% asserted "from memory": every edge is defended by a span a reader can re-fetch and
+% check. (See feedback_nothing_human_authored, feedback_adj_only_shipped_artifacts.)
+%
+% Honest scope: relations chosen so the cited span NAMES both endpoints. gene_defect
+% reuses the same relation the IMMUNO library uses (the engine binds any grounded
+% `relate(rel, args)`); the disorders here are disjoint from immunology's. Edges with
+% no clean self-contained span (e.g. Marfan→FBN1, where the page's FBN1 mentions are
+% citation titles or negative-finding clauses) are deferred rather than over-claimed.
+% ============================================================================
+
+dictionary genetics_vocab {
+    define disorder : entity   surface "genetic disorder", "Mendelian disorder"
+    define pattern  : entity   surface "inheritance pattern"
+    define gene     : entity   surface "gene"
+    define repeat   : entity   surface "trinucleotide repeat"
+    define parent   : entity   surface "parent of origin"
+
+    define inheritance         : relation from disorder to pattern  % how the disorder is transmitted
+    define gene_defect         : relation from disorder to gene     % the mutated gene
+    define trinucleotide_repeat : relation from disorder to repeat  % the expanded triplet
+    define imprinting          : relation from disorder to parent   % the parent-of-origin lesion
+}
+
+rulebook genetics_facts {
+    use genetics_vocab
+
+    % --- Huntington disease (AD, CAG expansion in HTT) -------------------
+    relate inheritance(huntington_disease, autosomal_dominant)
+        source "Huntington disease, an autosomal dominant inherited neurodegenerative disorder, is characterized by the clinical triad of involuntary choreiform movements with cognitive and behavioral disturbances."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK559166/"
+        trust authoritative
+    relate gene_defect(huntington_disease, htt)
+        source "Huntington disease is an autosomal dominant inherited neurodegenerative disorder caused by the elongation of CAG repeats on the short arm of chromosome 4p16.3 in the HTT gene."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK559166/"
+        trust authoritative
+    relate trinucleotide_repeat(huntington_disease, cag)
+        source "Huntington disease is an autosomal dominant disorder that results from CAG repeat expansions, usually of paternal origin."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK559254/"
+        trust authoritative
+
+    % --- Marfan syndrome (autosomal dominant) ----------------------------
+    relate inheritance(marfan_syndrome, autosomal_dominant)
+        source "One of the most common inherited disorders affecting connective tissue, Marfan syndrome (MFS), is an autosomal dominant condition with a reported incidence of 1 in 3000 to 5000 individuals."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK537339/"
+        trust authoritative
+
+    % --- Fragile X syndrome (CGG expansion in FMR1) ----------------------
+    relate trinucleotide_repeat(fragile_x_syndrome, cgg)
+        source "Fragile X syndrome: This condition results from CGG repeats in the noncoding region of the Fragile X mental retardation 1 ( FMR1 ) gene."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK559254/"
+        trust authoritative
+    relate gene_defect(fragile_x_syndrome, fmr1)
+        source "Fragile X syndrome: This condition results from CGG repeats in the noncoding region of the Fragile X mental retardation 1 ( FMR1 ) gene."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK559254/"
+        trust authoritative
+
+    % --- Prader-Willi syndrome (loss of PATERNAL 15q11-q13; imprinting) --
+    relate imprinting(prader_willi_syndrome, paternal)
+        source "PWS results from the loss of expression of paternally inherited genes on chromosome 15q11.2–q13, most commonly due to paternal deletion, maternal uniparental disomy, or imprinting defects."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK553161/"
+        trust authoritative
+}

--- a/code/specs/data/mycin-2026/recall/genetics-recall.query.adj
+++ b/code/specs/data/mycin-2026/recall/genetics-recall.query.adj
@@ -1,0 +1,22 @@
+% ============================================================================
+% genetics-recall.query.adj — a worked recall query over the genetics library.
+% ============================================================================
+% The shape an LLM (or a clinician) produces to ANSWER a genetics recall question:
+% it states no genetic fact — it only `import`s the grounded library and asks binding
+% queries. The native adj-lang engine resolves each `?` against the imported `relate`
+% edges and returns the binding + the citing clause's source/locator/trust. All
+% knowledge is in the library; none is here.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli genetics-recall.query.adj
+% ============================================================================
+
+import "genetics-edges.adj"
+
+? inheritance(huntington_disease, $Pattern)            % expect autosomal_dominant
+? gene_defect(huntington_disease, $Gene)               % expect htt
+? trinucleotide_repeat(huntington_disease, $Repeat)    % expect cag
+? inheritance(marfan_syndrome, $Pattern)               % expect autosomal_dominant
+? trinucleotide_repeat(fragile_x_syndrome, $Repeat)    % expect cgg
+? gene_defect(fragile_x_syndrome, $Gene)               % expect fmr1
+? imprinting(prader_willi_syndrome, $Parent)           % expect paternal

--- a/code/specs/data/mycin-2026/recall/test_genetics_recall.py
+++ b/code/specs/data/mycin-2026/recall/test_genetics_recall.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""test_genetics_recall.py — the ADJ-only genetics recall library (MYCIN-2026 GENETICS).
+
+The fourth recall domain shipped as a pure ADJ artifact (completing Tier-1 foundational
+recall: MICRO, PHARM, IMMUNO, GENETICS). `genetics-edges.adj` is the SOLE source of
+truth — facts + byte-provenance inline, no Python gate, no JSON, no manifest. This test
+pins the property that matters: the native adj-lang engine, given a query .adj that only
+`import`s the library and asks binding queries (`genetics-recall.query.adj` — the shape
+an LLM produces), returns the correct binding for every grounded edge, each carrying an
+AUTHORITATIVE citation with a real source span + locator. Knowledge lives in ADJ; the
+engine answers. (`gene_defect` is shared with the IMMUNO library; the disorders are
+disjoint, and the combined import resolves both — see board_eval's merged store.)
+
+If the native CLI isn't built (a Python-only CI lane), the engine-backed checks skip —
+the file-shape checks (every clause grounded, no authored-debt) still run.
+
+Run:  python3 test_genetics_recall.py
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+ADJ = HERE / "genetics-edges.adj"
+QUERY = HERE / "genetics-recall.query.adj"
+CLI = HERE.parents[3] / "packages" / "rust" / "target" / "debug" / "adj-lang-cli"
+
+# The full grounded edge set (subject, relation, expected binding). Mirrors
+# genetics-edges.adj; a divergence here or there fails the test.
+EXPECTED = [
+    ("huntington_disease", "inheritance", "autosomal_dominant"),
+    ("huntington_disease", "gene_defect", "htt"),
+    ("huntington_disease", "trinucleotide_repeat", "cag"),
+    ("marfan_syndrome", "inheritance", "autosomal_dominant"),
+    ("fragile_x_syndrome", "trinucleotide_repeat", "cgg"),
+    ("fragile_x_syndrome", "gene_defect", "fmr1"),
+    ("prader_willi_syndrome", "imprinting", "paternal"),
+]
+VAR = {"inheritance": "Pattern", "gene_defect": "Gene",
+       "trinucleotide_repeat": "Repeat", "imprinting": "Parent"}
+
+
+def _cli_available() -> bool:
+    return CLI.exists()
+
+
+def _run(program: Path) -> dict:
+    out = subprocess.run([str(CLI), str(program)], capture_output=True, text=True,
+                         cwd=str(HERE), timeout=60)
+    assert out.returncode == 0, f"adj-lang-cli failed: {out.stderr}"
+    return json.loads(out.stdout)
+
+
+# ---- 1. the ADJ file is the artifact — every clause grounded, no authored-debt ----
+
+def test_library_is_pure_adj_and_fully_grounded() -> None:
+    text = ADJ.read_text()
+    assert "trust consensus" not in text, "GENETICS ships no authored-debt; ground or omit"
+    assert "[FLAG:" not in text
+    relate_count = text.count("    relate ")
+    assert text.count("trust authoritative") == relate_count == len(EXPECTED)
+    assert text.count('\n        locator "') == relate_count
+    assert text.count('\n        source "') == relate_count
+    # No sibling generator / JSON / manifest for this domain (ADJ-only).
+    assert not (HERE / "genetics_edge_ground.py").exists()
+    assert not (HERE / "genetics-edge-grounding.json").exists()
+    assert not (HERE / "genetics-edge-manifest.json").exists()
+
+
+# ---- 2. the engine resolves every grounded edge with an authoritative citation ----
+
+def test_engine_resolves_every_edge_with_authoritative_citation() -> None:
+    if not _cli_available():
+        return
+    result = _run(QUERY)
+    by_query = {r["query"]: r for r in result["recall"]}
+    for subj, rel, expected in EXPECTED:
+        q = f"{rel}({subj}, {VAR[rel]})"
+        r = by_query.get(q) or _one(rel, subj, VAR[rel])
+        assert r is not None and not r["abstained"], f"{q} abstained — edge missing?"
+        ans = r["answers"][0]
+        assert ans["bindings"][VAR[rel]] == expected, f"{q} -> {ans['bindings']}"
+        cite = ans["citations"][0]
+        assert cite["trust"] == "authoritative", f"{q} citation not authoritative"
+        assert cite["source"], f"{q} citation has no source span"
+        assert cite["locator"].startswith("https://www.ncbi.nlm.nih.gov/"), cite["locator"]
+
+
+def _one(rel: str, subj: str, varname: str) -> dict | None:
+    """Resolve a single edge by writing a throwaway one-line query .adj in this dir
+    (so the relative `import "genetics-edges.adj"` resolves) and running the engine."""
+    import os
+    import tempfile
+    fd, path = tempfile.mkstemp(suffix=".adj", prefix=".genetics_q_", dir=HERE)
+    try:
+        with os.fdopen(fd, "w") as fh:
+            fh.write(f'import "genetics-edges.adj"\n? {rel}({subj}, ${varname})\n')
+        res = _run(Path(path))
+        return res["recall"][0] if res["recall"] else None
+    finally:
+        os.unlink(path)
+
+
+# ---- 3. an off-vocabulary subject abstains, never fabricates ----------------------
+
+def test_unknown_disorder_abstains() -> None:
+    if not _cli_available():
+        return
+    r = _one("inheritance", "cystic_fibrosis", "Pattern")  # not in the library
+    assert r is not None and r["abstained"], "an ungrounded disorder must abstain"
+
+
+def _run_all() -> int:
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    failed = 0
+    for t in tests:
+        try:
+            t()
+            print(f"  PASS  {t.__name__}")
+        except AssertionError as exc:
+            failed += 1
+            print(f"  FAIL  {t.__name__}: {exc}")
+    print(f"\ntest_genetics_recall: {len(tests) - failed}/{len(tests)} passed")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(_run_all())


### PR DESCRIPTION
## What

The **fourth ADJ-only** recall domain — **completes Tier-1 foundational recall** (after MICRO #6212, PHARM #6218, IMMUNO #6227). `recall/genetics-edges.adj` *is* the source of truth — facts + byte-provenance **inline** (`source` = verbatim NCBI StatPearls span, `locator` = URL, `trust authoritative`); no Python gate, no JSON, no manifest. An LLM recalls a fact by writing a tiny query `.adj` that `import`s the library and asks a binding query — `recall/genetics-recall.query.adj` is the worked example.

```
import "genetics-edges.adj"
? inheritance(huntington_disease, $Pattern)         % → autosomal_dominant, cited to NBK559166
? trinucleotide_repeat(fragile_x_syndrome, $Repeat) % → cgg, cited to NBK559254
```

## Grounding (no authored debt)

All **7 edges** across **4 relations** are grounded to **byte-stable verbatim spans**, re-verified character-for-character against the live page (6/6 unique spans):

| relation | edge | source |
|---|---|---|
| `inheritance` | Huntington → AD; Marfan → AD | NBK559166, NBK537339 |
| `gene_defect` | Huntington → HTT; fragile X → FMR1 | NBK559166, NBK559254 |
| `trinucleotide_repeat` | Huntington → CAG; fragile X → CGG | NBK559254 |
| `imprinting` | Prader-Willi → paternal | NBK553161 |

`gene_defect` is **reused from IMMUNO** over disjoint disorders — the engine merges facts across the imported dictionaries (verified: `xla→btk` and `huntington→htt` both resolve in one program). No `trust consensus` seed — grounded or omitted. **Deferred**: Duchenne/CF X-linked/AR patterns, myotonic→CTG, Angelman→maternal, Marfan→FBN1 (its page's FBN1 mentions are citation titles / negative-finding clauses).

## Wiring & results

- `board_eval.EDGE_FILES` + `decompose_query.EDGE_FILES` += `genetics-edges.adj`; `REL_VAR` += 3 relations (`gene_defect` already present) → 25 relations / 8 domains
- 7 genetics board items — all resolve **correct**, all **authoritative**
- Scorecard: recall **82 → 89** correct, grounded **81 → 88** (88/89 = **99%**), **wrong 0**, defensibility **100%**
- `test_genetics_recall.py` pins the ADJ-only flow end-to-end through the native CLI
- `USMLE-DOMAIN-MAP`: Genetics marked built — **all four Tier-1 foundational-recall domains** now grounded & scored (**9 recall domains** total)

## Verification

- `board_eval` test suite: **12/12**
- `test_genetics_recall`: **3/3**
- byte-stability: **6/6** live spans present verbatim
- `/security-review` passed (subprocess / tempfile / string-literal / SSRF — clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)