### PR TITLE
Add mesh preflight slot readiness summary

### DIFF
--- a/code/packages/rust/smart-home-integration-catalog/CHANGELOG.md
+++ b/code/packages/rust/smart-home-integration-catalog/CHANGELOG.md
@@ -92,6 +92,9 @@ All notable changes to this package will be documented in this file.
   mesh preflight repair readiness with stage/action-kind repair batches.
 - `IntegrationMeshPreflightScheduleReadinessSummary` and helpers for combining
   mesh preflight batch readiness with deterministic repair execution slots.
+- `IntegrationMeshPreflightSlotReadinessSummary` and helpers for combining mesh
+  preflight schedule readiness with repair-slot audit blockers and operator
+  handoff counts.
 - `IntegrationMeshReadinessHandoffPackage`, summary helpers, and D23 mesh
   readiness handoff projections for release coordination across substrate
   actions, evidence remediation, and release-ready state.

--- a/code/packages/rust/smart-home-integration-catalog/README.md
+++ b/code/packages/rust/smart-home-integration-catalog/README.md
@@ -79,6 +79,8 @@ runtime and Chief of Staff tools a typed catalog for:
   stage/action-kind repair batches
 - mesh preflight schedule readiness summaries that combine repair-batch
   readiness with deterministic repair execution slots
+- mesh preflight slot readiness summaries that combine schedule readiness with
+  slot-audit blocker and operator handoff counts
 - mesh readiness handoff packages that project substrate actions, evidence
   remediation, and release-ready state for reusable release coordination
 - mesh release-readiness checks that summarize substrate action, evidence,

--- a/code/packages/rust/smart-home-integration-catalog/src/lib.rs
+++ b/code/packages/rust/smart-home-integration-catalog/src/lib.rs
@@ -1891,6 +1891,87 @@ impl IntegrationMeshPreflightScheduleReadinessSummary {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IntegrationMeshPreflightSlotReadinessSummary {
+    pub schedule_readiness_summary: IntegrationMeshPreflightScheduleReadinessSummary,
+    pub slot_audit_summary: IntegrationMeshProtocolSubstratePreflightRepairSlotAuditSummary,
+    pub total_protocols: usize,
+    pub total_preflight_checks: usize,
+    pub preflight_blocker_count: usize,
+    pub release_blocker_count: usize,
+    pub queued_preflight_actions: usize,
+    pub repair_batch_count: usize,
+    pub repair_slot_count: usize,
+    pub scheduled_preflight_actions: usize,
+    pub slot_audit_rows: usize,
+    pub audited_preflight_actions: usize,
+    pub blocking_slot_audit_rows: usize,
+    pub operator_required_slot_audit_rows: usize,
+    pub first_blocking_slot_sequence: Option<usize>,
+    pub first_operator_slot_sequence: Option<usize>,
+    pub first_slot_stage: Option<IntegrationMeshProtocolSubstrateStage>,
+    pub first_slot_action_kind: Option<IntegrationMeshProtocolSubstratePreflightActionKind>,
+    pub preflight_ready: bool,
+    pub repair_actions_ready: bool,
+    pub repair_batches_ready: bool,
+    pub repair_schedule_ready: bool,
+    pub repair_slot_audit_ready: bool,
+    pub release_ready: bool,
+    pub ready_for_release: bool,
+}
+
+impl IntegrationMeshPreflightSlotReadinessSummary {
+    pub fn from_parts(
+        schedule_readiness_summary: IntegrationMeshPreflightScheduleReadinessSummary,
+        slot_audit_summary: IntegrationMeshProtocolSubstratePreflightRepairSlotAuditSummary,
+    ) -> Self {
+        let repair_slot_audit_ready = slot_audit_summary.repair_slot_audit_ready;
+        let ready_for_release =
+            schedule_readiness_summary.ready_for_release && repair_slot_audit_ready;
+
+        Self {
+            total_protocols: schedule_readiness_summary.total_protocols,
+            total_preflight_checks: schedule_readiness_summary.total_preflight_checks,
+            preflight_blocker_count: schedule_readiness_summary.preflight_blocker_count,
+            release_blocker_count: schedule_readiness_summary.release_blocker_count,
+            queued_preflight_actions: schedule_readiness_summary.queued_preflight_actions,
+            repair_batch_count: schedule_readiness_summary.repair_batch_count,
+            repair_slot_count: schedule_readiness_summary.repair_slot_count,
+            scheduled_preflight_actions: schedule_readiness_summary.scheduled_preflight_actions,
+            slot_audit_rows: slot_audit_summary.total_rows,
+            audited_preflight_actions: slot_audit_summary.scheduled_actions,
+            blocking_slot_audit_rows: slot_audit_summary.blocking_rows,
+            operator_required_slot_audit_rows: slot_audit_summary.operator_required_rows,
+            first_blocking_slot_sequence: slot_audit_summary.first_blocking_sequence,
+            first_operator_slot_sequence: slot_audit_summary.first_operator_required_sequence,
+            first_slot_stage: slot_audit_summary.first_stage,
+            first_slot_action_kind: slot_audit_summary.first_action_kind,
+            preflight_ready: schedule_readiness_summary.preflight_ready,
+            repair_actions_ready: schedule_readiness_summary.repair_actions_ready,
+            repair_batches_ready: schedule_readiness_summary.repair_batches_ready,
+            repair_schedule_ready: schedule_readiness_summary.repair_schedule_ready,
+            release_ready: schedule_readiness_summary.release_ready,
+            schedule_readiness_summary,
+            slot_audit_summary,
+            repair_slot_audit_ready,
+            ready_for_release,
+        }
+    }
+
+    pub fn has_slot_audit_rows(&self) -> bool {
+        self.slot_audit_rows > 0
+    }
+
+    pub fn has_blockers(&self) -> bool {
+        !self.ready_for_release
+    }
+
+    pub fn needs_operator(&self) -> bool {
+        self.operator_required_slot_audit_rows > 0
+            || self.schedule_readiness_summary.needs_operator()
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum IntegrationMeshReadinessHandoffKind {
     SubstrateAction,
@@ -22779,6 +22860,41 @@ pub fn mesh_preflight_schedule_readiness_summary(
     )
 }
 
+pub fn mesh_preflight_slot_readiness_summary_for_catalog(
+    catalog: &[IntegrationCatalogEntry],
+    available_primitives: &[PrimitiveFamily],
+    allowed_capabilities: &[CapabilityId],
+    enabled_integrations: &[IntegrationId],
+) -> IntegrationMeshPreflightSlotReadinessSummary {
+    let schedule_readiness_summary = mesh_preflight_schedule_readiness_summary_for_catalog(
+        catalog,
+        available_primitives,
+        allowed_capabilities,
+        enabled_integrations,
+    );
+    let slot_audit_summary =
+        mesh_protocol_substrate_preflight_repair_slot_audit_summary(available_primitives);
+
+    IntegrationMeshPreflightSlotReadinessSummary::from_parts(
+        schedule_readiness_summary,
+        slot_audit_summary,
+    )
+}
+
+pub fn mesh_preflight_slot_readiness_summary(
+    available_primitives: &[PrimitiveFamily],
+    allowed_capabilities: &[CapabilityId],
+    enabled_integrations: &[IntegrationId],
+) -> IntegrationMeshPreflightSlotReadinessSummary {
+    let catalog = first_party_catalog();
+    mesh_preflight_slot_readiness_summary_for_catalog(
+        &catalog,
+        available_primitives,
+        allowed_capabilities,
+        enabled_integrations,
+    )
+}
+
 fn mesh_readiness_handoff_packages_from_summary(
     summary: &IntegrationMeshActionReadinessSummary,
     actions: &[IntegrationMeshProtocolSubstrateAction],
@@ -30318,6 +30434,94 @@ mod tests {
         assert!(summary.release_ready);
         assert!(summary.ready_for_release);
         assert!(!summary.has_repair_schedule());
+        assert!(!summary.has_blockers());
+        assert!(!summary.needs_operator());
+    }
+
+    #[test]
+    fn mesh_preflight_slot_readiness_summary_surfaces_slot_audit() {
+        let available_primitives = vec![
+            PrimitiveFamily::Usb,
+            PrimitiveFamily::SerialController,
+            PrimitiveFamily::Radio802154,
+            PrimitiveFamily::Supervision,
+        ];
+        let allowed_capabilities = vec![CapabilityId::trusted("smart_home.read")];
+        let summary = mesh_preflight_slot_readiness_summary(
+            &available_primitives,
+            &allowed_capabilities,
+            &[],
+        );
+
+        assert_eq!(summary.total_protocols, 3);
+        assert_eq!(summary.total_preflight_checks, 16);
+        assert_eq!(summary.preflight_blocker_count, 5);
+        assert_eq!(summary.queued_preflight_actions, 5);
+        assert_eq!(summary.repair_slot_count, 3);
+        assert_eq!(summary.scheduled_preflight_actions, 5);
+        assert_eq!(summary.slot_audit_rows, 3);
+        assert_eq!(summary.audited_preflight_actions, 5);
+        assert_eq!(summary.blocking_slot_audit_rows, 3);
+        assert_eq!(summary.operator_required_slot_audit_rows, 2);
+        assert_eq!(summary.first_blocking_slot_sequence, Some(1));
+        assert_eq!(summary.first_operator_slot_sequence, Some(1));
+        assert_eq!(
+            summary.first_slot_stage,
+            Some(IntegrationMeshProtocolSubstrateStage::Radio)
+        );
+        assert_eq!(
+            summary.first_slot_action_kind,
+            Some(IntegrationMeshProtocolSubstratePreflightActionKind::ProvisionRadio)
+        );
+        assert!(!summary.preflight_ready);
+        assert!(!summary.repair_actions_ready);
+        assert!(!summary.repair_batches_ready);
+        assert!(!summary.repair_schedule_ready);
+        assert!(!summary.repair_slot_audit_ready);
+        assert!(!summary.ready_for_release);
+        assert!(summary.has_slot_audit_rows());
+        assert!(summary.has_blockers());
+        assert!(summary.needs_operator());
+        assert_eq!(summary.slot_audit_summary.protocol_mentions, 5);
+    }
+
+    #[test]
+    fn mesh_preflight_slot_readiness_summary_marks_ready_release() {
+        let catalog = vec![hue_entry()];
+        let allowed_capabilities = vec![
+            CapabilityId::trusted("smart_home.read"),
+            CapabilityId::trusted("smart_home.command.light"),
+            CapabilityId::trusted("smart_home.pair"),
+        ];
+        let summary = mesh_preflight_slot_readiness_summary_for_catalog(
+            &catalog,
+            all_primitive_families(),
+            &allowed_capabilities,
+            &[],
+        );
+
+        assert_eq!(summary.total_protocols, 3);
+        assert_eq!(summary.preflight_blocker_count, 0);
+        assert_eq!(summary.release_blocker_count, 0);
+        assert_eq!(summary.queued_preflight_actions, 0);
+        assert_eq!(summary.repair_slot_count, 0);
+        assert_eq!(summary.scheduled_preflight_actions, 0);
+        assert_eq!(summary.slot_audit_rows, 0);
+        assert_eq!(summary.audited_preflight_actions, 0);
+        assert_eq!(summary.blocking_slot_audit_rows, 0);
+        assert_eq!(summary.operator_required_slot_audit_rows, 0);
+        assert_eq!(summary.first_blocking_slot_sequence, None);
+        assert_eq!(summary.first_operator_slot_sequence, None);
+        assert_eq!(summary.first_slot_stage, None);
+        assert_eq!(summary.first_slot_action_kind, None);
+        assert!(summary.preflight_ready);
+        assert!(summary.repair_actions_ready);
+        assert!(summary.repair_batches_ready);
+        assert!(summary.repair_schedule_ready);
+        assert!(summary.repair_slot_audit_ready);
+        assert!(summary.release_ready);
+        assert!(summary.ready_for_release);
+        assert!(!summary.has_slot_audit_rows());
         assert!(!summary.has_blockers());
         assert!(!summary.needs_operator());
     }


### PR DESCRIPTION
## Summary
- add `IntegrationMeshPreflightSlotReadinessSummary` to combine schedule readiness with repair-slot audit blockers and operator handoff counts
- add catalog/default helper constructors for the new high-level slot readiness view
- document the new summary in the smart-home integration catalog README and changelog

## Validation
- `cargo fmt --manifest-path code\packages\rust\smart-home-integration-catalog\Cargo.toml`
- `cargo test --manifest-path code\packages\rust\smart-home-integration-catalog\Cargo.toml`
- `git diff --check`