### PR TITLE
Add SPICE deck output-node artifacts

### DIFF
--- a/code/packages/python/spice-engine/src/spice_engine/engine.py
+++ b/code/packages/python/spice-engine/src/spice_engine/engine.py
@@ -2320,6 +2320,7 @@ class DeckRunArtifact:
     directive: str
     line_number: int
     source_name: str | None
+    output_node: str | None
     sweep_kind: str | None
     start_value: float | None
     stop_value: float | None
@@ -2411,6 +2412,7 @@ def _deck_run_artifacts(
             directive=plan.directive,
             line_number=plan.line_number,
             source_name=plan.source_name,
+            output_node=plan.output_node,
             sweep_kind=plan.sweep_kind,
             start_value=plan.start_value,
             stop_value=plan.stop_value,
@@ -2437,7 +2439,7 @@ def format_deck_run_artifact_table(artifacts: Iterable[DeckRunArtifact]) -> str:
     """Format selected deck-run artifacts as a stable summary table."""
 
     rows = [
-        "Analysis\tDirective\tLine\tSourceName\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList"
+        "Analysis\tDirective\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList"
     ]
     for artifact in artifacts:
         rows.append(
@@ -2447,6 +2449,7 @@ def format_deck_run_artifact_table(artifacts: Iterable[DeckRunArtifact]) -> str:
                     artifact.directive,
                     str(artifact.line_number),
                     artifact.source_name or "",
+                    artifact.output_node or "",
                     artifact.sweep_kind or "",
                     _format_deck_artifact_float(artifact.start_value),
                     _format_deck_artifact_float(artifact.stop_value),

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -6796,6 +6796,7 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
     assert op_execution.table == "Index\tV(mid)\n0\t5.000000e-01\n"
     assert op_execution.run_artifacts[0].result_rows == 1
     assert op_execution.run_artifacts[0].source_name is None
+    assert op_execution.run_artifacts[0].output_node is None
     assert op_execution.run_artifacts[0].sweep_kind is None
     assert op_execution.run_artifacts[0].point_count is None
     assert op_execution.run_artifacts[0].output_probes == ["V(mid)"]
@@ -6803,8 +6804,8 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
     assert op_execution.run_artifacts[0].measurement_names == []
     assert op_execution.run_artifacts[0].fourier_probes == []
     assert op_execution.run_artifact_table == (
-        "Analysis\tDirective\tLine\tSourceName\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\n"
-        f"op\t.op\t{op_execution.plan.line_number}\t\t\t\t\t\t\t\t\t1\t1\tV(mid)\t1\t.save\t0\t\t0\t\n"
+        "Analysis\tDirective\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\n"
+        f"op\t.op\t{op_execution.plan.line_number}\t\t\t\t\t\t\t\t\t\t1\t1\tV(mid)\t1\t.save\t0\t\t0\t\n"
     )
 
     dc_execution = run_deck_analysis(circuit, netlist, "dc")
@@ -6824,6 +6825,7 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
     )
     assert dc_execution.run_artifacts[0].analysis == "dc"
     assert dc_execution.run_artifacts[0].source_name == "V1"
+    assert dc_execution.run_artifacts[0].output_node is None
     assert dc_execution.run_artifacts[0].start_value == pytest.approx(0.0)
     assert dc_execution.run_artifacts[0].stop_value == pytest.approx(1.0)
     assert dc_execution.run_artifacts[0].step_value == pytest.approx(1.0)
@@ -6832,8 +6834,8 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
     assert dc_execution.run_artifacts[0].measurement_names == ["mid_avg"]
     assert dc_execution.run_artifacts[0].fourier_probes == []
     assert dc_execution.run_artifact_table == (
-        "Analysis\tDirective\tLine\tSourceName\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\n"
-        f"dc\t.dc\t{dc_execution.plan.line_number}\tV1\t\t0.000000e+00\t1.000000e+00\t1.000000e+00\t\t\t\t2\t2\tV(mid);I(V1)\t2\t.save;.probe\t1\tmid_avg\t0\t\n"
+        "Analysis\tDirective\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\n"
+        f"dc\t.dc\t{dc_execution.plan.line_number}\tV1\t\t\t0.000000e+00\t1.000000e+00\t1.000000e+00\t\t\t\t2\t2\tV(mid);I(V1)\t2\t.save;.probe\t1\tmid_avg\t0\t\n"
     )
 
     ac_execution = run_deck_analysis(circuit, netlist, "ac")
@@ -6851,6 +6853,7 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
     )
     assert ac_execution.run_artifacts[0].output_probes == ["V(mid)"]
     assert ac_execution.run_artifacts[0].source_name is None
+    assert ac_execution.run_artifacts[0].output_node is None
     assert ac_execution.run_artifacts[0].sweep_kind == "dec"
     assert ac_execution.run_artifacts[0].point_count == 1
     assert ac_execution.run_artifacts[0].start_frequency_hz == pytest.approx(1.0e3)
@@ -6859,8 +6862,8 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
     assert ac_execution.run_artifacts[0].measurement_names == ["mid_peak"]
     assert ac_execution.run_artifacts[0].fourier_probes == []
     assert ac_execution.run_artifact_table == (
-        "Analysis\tDirective\tLine\tSourceName\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\n"
-        f"ac\t.ac\t{ac_execution.plan.line_number}\t\tdec\t\t\t\t1\t1.000000e+03\t1.000000e+03\t1\t1\tV(mid)\t1\t.save\t1\tmid_peak\t0\t\n"
+        "Analysis\tDirective\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\n"
+        f"ac\t.ac\t{ac_execution.plan.line_number}\t\t\tdec\t\t\t\t1\t1.000000e+03\t1.000000e+03\t1\t1\tV(mid)\t1\t.save\t1\tmid_peak\t0\t\n"
     )
 
     tran_execution = run_deck_analysis(circuit, netlist, "tran")
@@ -6880,12 +6883,13 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
     )
     assert tran_execution.run_artifacts[0].output_probes == ["V(mid)"]
     assert tran_execution.run_artifacts[0].source_name is None
+    assert tran_execution.run_artifacts[0].output_node is None
     assert tran_execution.run_artifacts[0].output_directives == [".save"]
     assert tran_execution.run_artifacts[0].measurement_names == ["mid_final"]
     assert tran_execution.run_artifacts[0].fourier_probes == []
     assert tran_execution.run_artifact_table == (
-        "Analysis\tDirective\tLine\tSourceName\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\n"
-        f"tran\t.tran\t{tran_execution.plan.line_number}\t\t\t\t\t\t\t\t\t2\t1\tV(mid)\t1\t.save\t1\tmid_final\t0\t\n"
+        "Analysis\tDirective\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\n"
+        f"tran\t.tran\t{tran_execution.plan.line_number}\t\t\t\t\t\t\t\t\t\t2\t1\tV(mid)\t1\t.save\t1\tmid_final\t0\t\n"
     )
 
     tf_execution = run_deck_analysis(circuit, netlist, "tf")
@@ -6904,14 +6908,15 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
     )
     assert tf_execution.run_artifacts[0].analysis == "tf"
     assert tf_execution.run_artifacts[0].source_name == "V1"
+    assert tf_execution.run_artifacts[0].output_node == "mid"
     assert tf_execution.run_artifacts[0].result_rows == 1
     assert tf_execution.run_artifacts[0].output_probes == ["V(mid)"]
     assert tf_execution.run_artifacts[0].output_directives == []
     assert tf_execution.run_artifacts[0].measurement_names == []
     assert tf_execution.run_artifacts[0].fourier_probes == []
     assert tf_execution.run_artifact_table == (
-        "Analysis\tDirective\tLine\tSourceName\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\n"
-        f"tf\t.tf\t{tf_execution.plan.line_number}\tV1\t\t\t\t\t\t\t\t1\t1\tV(mid)\t0\t\t0\t\t0\t\n"
+        "Analysis\tDirective\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\n"
+        f"tf\t.tf\t{tf_execution.plan.line_number}\tV1\tmid\t\t\t\t\t\t\t\t1\t1\tV(mid)\t0\t\t0\t\t0\t\n"
     )
 
     sens_execution = run_deck_analysis(circuit, netlist, "sens")
@@ -6928,14 +6933,15 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
     )
     assert sens_execution.run_artifacts[0].analysis == "sens"
     assert sens_execution.run_artifacts[0].source_name is None
+    assert sens_execution.run_artifacts[0].output_node == "mid"
     assert sens_execution.run_artifacts[0].result_rows == 1
     assert sens_execution.run_artifacts[0].output_probes == ["V(mid)"]
     assert sens_execution.run_artifacts[0].output_directives == []
     assert sens_execution.run_artifacts[0].measurement_names == []
     assert sens_execution.run_artifacts[0].fourier_probes == []
     assert sens_execution.run_artifact_table == (
-        "Analysis\tDirective\tLine\tSourceName\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\n"
-        f"sens\t.sens\t{sens_execution.plan.line_number}\t\t\t\t\t\t\t\t\t1\t1\tV(mid)\t0\t\t0\t\t0\t\n"
+        "Analysis\tDirective\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\n"
+        f"sens\t.sens\t{sens_execution.plan.line_number}\t\tmid\t\t\t\t\t\t\t\t1\t1\tV(mid)\t0\t\t0\t\t0\t\n"
     )
 
     noise_execution = run_deck_analysis(circuit, netlist, "noise")
@@ -6959,6 +6965,7 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
     )
     assert noise_execution.run_artifacts[0].analysis == "noise"
     assert noise_execution.run_artifacts[0].source_name == "V1"
+    assert noise_execution.run_artifacts[0].output_node == "mid"
     assert noise_execution.run_artifacts[0].sweep_kind == "lin"
     assert noise_execution.run_artifacts[0].point_count == 1
     assert noise_execution.run_artifacts[0].start_frequency_hz == pytest.approx(1.0e3)
@@ -6969,8 +6976,8 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
     assert noise_execution.run_artifacts[0].measurement_names == []
     assert noise_execution.run_artifacts[0].fourier_probes == []
     assert noise_execution.run_artifact_table == (
-        "Analysis\tDirective\tLine\tSourceName\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\n"
-        f"noise\t.noise\t{noise_execution.plan.line_number}\tV1\tlin\t\t\t\t1\t1.000000e+03\t1.000000e+03\t1\t1\tV(mid)\t0\t\t0\t\t0\t\n"
+        "Analysis\tDirective\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\n"
+        f"noise\t.noise\t{noise_execution.plan.line_number}\tV1\tmid\tlin\t\t\t\t1\t1.000000e+03\t1.000000e+03\t1\t1\tV(mid)\t0\t\t0\t\t0\t\n"
     )
 
     tran_window_execution = run_deck_analysis(
@@ -7045,13 +7052,14 @@ def test_run_deck_analysis_exposes_selected_fourier_artifacts() -> None:
     assert tran_execution.fourier_table == format_fourier_table(result)
     assert tran_execution.run_artifacts[0].fourier_count == 1
     assert tran_execution.run_artifacts[0].source_name is None
+    assert tran_execution.run_artifacts[0].output_node is None
     assert tran_execution.run_artifacts[0].output_probes == ["V(mid)"]
     assert tran_execution.run_artifacts[0].output_directives == [".save"]
     assert tran_execution.run_artifacts[0].measurement_names == []
     assert tran_execution.run_artifacts[0].fourier_probes == ["V(mid)"]
     assert tran_execution.run_artifact_table == (
-        "Analysis\tDirective\tLine\tSourceName\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\n"
-        f"tran\t.tran\t{tran_execution.plan.line_number}\t\t\t\t\t\t\t\t\t3\t1\tV(mid)\t1\t.save\t0\t\t1\tV(mid)\n"
+        "Analysis\tDirective\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\n"
+        f"tran\t.tran\t{tran_execution.plan.line_number}\t\t\t\t\t\t\t\t\t\t3\t1\tV(mid)\t1\t.save\t0\t\t1\tV(mid)\n"
     )
 
 

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -3408,6 +3408,7 @@ pub struct DeckRunArtifact {
     pub directive: String,
     pub line_number: usize,
     pub source_name: Option<String>,
+    pub output_node: Option<String>,
     pub sweep_kind: Option<String>,
     pub start_value: Option<f64>,
     pub stop_value: Option<f64>,
@@ -10096,6 +10097,7 @@ fn deck_run_artifacts(
         directive: plan.directive.clone(),
         line_number: plan.line_number,
         source_name: plan.source_name.clone(),
+        output_node: plan.output_node.clone(),
         sweep_kind: plan.sweep_kind.clone(),
         start_value: plan.start_value,
         stop_value: plan.stop_value,
@@ -10127,16 +10129,17 @@ fn format_deck_artifact_float(value: Option<f64>) -> String {
 
 pub fn format_deck_run_artifact_table(artifacts: &[DeckRunArtifact]) -> String {
     let mut rows = vec![
-        "Analysis\tDirective\tLine\tSourceName\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList"
+        "Analysis\tDirective\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList"
             .to_string(),
     ];
     for artifact in artifacts {
         rows.push(format!(
-            "{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}",
+            "{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}",
             artifact.analysis,
             artifact.directive,
             artifact.line_number,
             artifact.source_name.as_deref().unwrap_or(""),
+            artifact.output_node.as_deref().unwrap_or(""),
             artifact.sweep_kind.as_deref().unwrap_or(""),
             format_deck_artifact_float(artifact.start_value),
             format_deck_artifact_float(artifact.stop_value),

--- a/code/packages/rust/spice-engine/tests/transient_tests.rs
+++ b/code/packages/rust/spice-engine/tests/transient_tests.rs
@@ -1889,6 +1889,7 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
     assert_eq!(op_execution.table, "Index\tV(mid)\n0\t5.000000e-01\n");
     assert_eq!(op_execution.run_artifacts[0].result_rows, 1);
     assert_eq!(op_execution.run_artifacts[0].source_name, None);
+    assert_eq!(op_execution.run_artifacts[0].output_node, None);
     assert_eq!(op_execution.run_artifacts[0].sweep_kind, None);
     assert_eq!(op_execution.run_artifacts[0].point_count, None);
     assert_eq!(
@@ -1904,7 +1905,7 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
     assert_eq!(
         op_execution.run_artifact_table,
         format!(
-            "Analysis\tDirective\tLine\tSourceName\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\nop\t.op\t{}\t\t\t\t\t\t\t\t\t1\t1\tV(mid)\t1\t.save\t0\t\t0\t\n",
+            "Analysis\tDirective\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\nop\t.op\t{}\t\t\t\t\t\t\t\t\t\t1\t1\tV(mid)\t1\t.save\t0\t\t0\t\n",
             op_execution.plan.line_number
         )
     );
@@ -1933,6 +1934,7 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
         dc_execution.run_artifacts[0].source_name.as_deref(),
         Some("V1")
     );
+    assert_eq!(dc_execution.run_artifacts[0].output_node, None);
     assert_eq!(dc_execution.run_artifacts[0].start_value, Some(0.0));
     assert_eq!(dc_execution.run_artifacts[0].stop_value, Some(1.0));
     assert_eq!(dc_execution.run_artifacts[0].step_value, Some(1.0));
@@ -1952,7 +1954,7 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
     assert_eq!(
         dc_execution.run_artifact_table,
         format!(
-            "Analysis\tDirective\tLine\tSourceName\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\ndc\t.dc\t{}\tV1\t\t0.000000e+00\t1.000000e+00\t1.000000e+00\t\t\t\t2\t2\tV(mid);I(V1)\t2\t.save;.probe\t1\tmid_avg\t0\t\n",
+            "Analysis\tDirective\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\ndc\t.dc\t{}\tV1\t\t\t0.000000e+00\t1.000000e+00\t1.000000e+00\t\t\t\t2\t2\tV(mid);I(V1)\t2\t.save;.probe\t1\tmid_avg\t0\t\n",
             dc_execution.plan.line_number
         )
     );
@@ -1977,6 +1979,7 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
         vec!["V(mid)".to_string()]
     );
     assert_eq!(ac_execution.run_artifacts[0].source_name, None);
+    assert_eq!(ac_execution.run_artifacts[0].output_node, None);
     assert_eq!(
         ac_execution.run_artifacts[0].sweep_kind.as_deref(),
         Some("dec")
@@ -1999,7 +2002,7 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
     assert_eq!(
         ac_execution.run_artifact_table,
         format!(
-            "Analysis\tDirective\tLine\tSourceName\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\nac\t.ac\t{}\t\tdec\t\t\t\t1\t1.000000e+03\t1.000000e+03\t1\t1\tV(mid)\t1\t.save\t1\tmid_peak\t0\t\n",
+            "Analysis\tDirective\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\nac\t.ac\t{}\t\t\tdec\t\t\t\t1\t1.000000e+03\t1.000000e+03\t1\t1\tV(mid)\t1\t.save\t1\tmid_peak\t0\t\n",
             ac_execution.plan.line_number
         )
     );
@@ -2024,6 +2027,7 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
         vec!["V(mid)".to_string()]
     );
     assert_eq!(tran_execution.run_artifacts[0].source_name, None);
+    assert_eq!(tran_execution.run_artifacts[0].output_node, None);
     assert_eq!(
         tran_execution.run_artifacts[0].output_directives,
         vec![".save".to_string()]
@@ -2036,7 +2040,7 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
     assert_eq!(
         tran_execution.run_artifact_table,
         format!(
-            "Analysis\tDirective\tLine\tSourceName\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\ntran\t.tran\t{}\t\t\t\t\t\t\t\t\t1\t1\tV(mid)\t1\t.save\t1\tmid_final\t0\t\n",
+            "Analysis\tDirective\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\ntran\t.tran\t{}\t\t\t\t\t\t\t\t\t\t1\t1\tV(mid)\t1\t.save\t1\tmid_final\t0\t\n",
             tran_execution.plan.line_number
         )
     );
@@ -2067,6 +2071,10 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
         tf_execution.run_artifacts[0].source_name.as_deref(),
         Some("V1")
     );
+    assert_eq!(
+        tf_execution.run_artifacts[0].output_node.as_deref(),
+        Some("mid")
+    );
     assert_eq!(tf_execution.run_artifacts[0].result_rows, 1);
     assert_eq!(
         tf_execution.run_artifacts[0].output_probes,
@@ -2078,7 +2086,7 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
     assert_eq!(
         tf_execution.run_artifact_table,
         format!(
-            "Analysis\tDirective\tLine\tSourceName\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\ntf\t.tf\t{}\tV1\t\t\t\t\t\t\t\t1\t1\tV(mid)\t0\t\t0\t\t0\t\n",
+            "Analysis\tDirective\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\ntf\t.tf\t{}\tV1\tmid\t\t\t\t\t\t\t\t1\t1\tV(mid)\t0\t\t0\t\t0\t\n",
             tf_execution.plan.line_number
         )
     );
@@ -2104,6 +2112,10 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
     ));
     assert_eq!(sens_execution.run_artifacts[0].analysis, "sens");
     assert_eq!(sens_execution.run_artifacts[0].source_name, None);
+    assert_eq!(
+        sens_execution.run_artifacts[0].output_node.as_deref(),
+        Some("mid")
+    );
     assert_eq!(sens_execution.run_artifacts[0].result_rows, 1);
     assert_eq!(
         sens_execution.run_artifacts[0].output_probes,
@@ -2115,7 +2127,7 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
     assert_eq!(
         sens_execution.run_artifact_table,
         format!(
-            "Analysis\tDirective\tLine\tSourceName\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\nsens\t.sens\t{}\t\t\t\t\t\t\t\t\t1\t1\tV(mid)\t0\t\t0\t\t0\t\n",
+            "Analysis\tDirective\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\nsens\t.sens\t{}\t\tmid\t\t\t\t\t\t\t\t1\t1\tV(mid)\t0\t\t0\t\t0\t\n",
             sens_execution.plan.line_number
         )
     );
@@ -2151,6 +2163,10 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
         Some("V1")
     );
     assert_eq!(
+        noise_execution.run_artifacts[0].output_node.as_deref(),
+        Some("mid")
+    );
+    assert_eq!(
         noise_execution.run_artifacts[0].sweep_kind.as_deref(),
         Some("lin")
     );
@@ -2178,7 +2194,7 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
     assert_eq!(
         noise_execution.run_artifact_table,
         format!(
-            "Analysis\tDirective\tLine\tSourceName\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\nnoise\t.noise\t{}\tV1\tlin\t\t\t\t1\t1.000000e+03\t1.000000e+03\t1\t1\tV(mid)\t0\t\t0\t\t0\t\n",
+            "Analysis\tDirective\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\nnoise\t.noise\t{}\tV1\tmid\tlin\t\t\t\t1\t1.000000e+03\t1.000000e+03\t1\t1\tV(mid)\t0\t\t0\t\t0\t\n",
             noise_execution.plan.line_number
         )
     );
@@ -2282,6 +2298,7 @@ fn run_deck_analysis_exposes_selected_fourier_artifacts() {
     assert_eq!(tran_execution.fourier_table, format_fourier_table(result));
     assert_eq!(tran_execution.run_artifacts[0].fourier_count, 1);
     assert_eq!(tran_execution.run_artifacts[0].source_name, None);
+    assert_eq!(tran_execution.run_artifacts[0].output_node, None);
     assert_eq!(
         tran_execution.run_artifacts[0].output_probes,
         vec!["V(mid)".to_string()]
@@ -2298,7 +2315,7 @@ fn run_deck_analysis_exposes_selected_fourier_artifacts() {
     assert_eq!(
         tran_execution.run_artifact_table,
         format!(
-            "Analysis\tDirective\tLine\tSourceName\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\ntran\t.tran\t{}\t\t\t\t\t\t\t\t\t2\t1\tV(mid)\t1\t.save\t0\t\t1\tV(mid)\n",
+            "Analysis\tDirective\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\ntran\t.tran\t{}\t\t\t\t\t\t\t\t\t\t2\t1\tV(mid)\t1\t.save\t0\t\t1\tV(mid)\n",
             tran_execution.plan.line_number
         )
     );

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -663,6 +663,7 @@ export interface DeckRunArtifact {
   readonly directive: DeckAnalysisPlan["directive"];
   readonly lineNumber: number;
   readonly sourceName?: string;
+  readonly outputNode?: string;
   readonly sweepKind?: DeckAnalysisPlan["sweepKind"];
   readonly startValue?: number;
   readonly stopValue?: number;
@@ -7884,6 +7885,7 @@ function deckRunArtifacts(
       directive: plan.directive,
       lineNumber: plan.lineNumber,
       sourceName: plan.sourceName,
+      outputNode: plan.outputNode,
       sweepKind: plan.sweepKind,
       startValue: plan.startValue,
       stopValue: plan.stopValue,
@@ -7910,7 +7912,7 @@ function formatDeckArtifactFloat(value: number | undefined): string {
 
 export function formatDeckRunArtifactTable(artifacts: readonly DeckRunArtifact[]): string {
   const rows = [
-    "Analysis\tDirective\tLine\tSourceName\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList",
+    "Analysis\tDirective\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList",
   ];
   for (const artifact of artifacts) {
     rows.push(
@@ -7919,6 +7921,7 @@ export function formatDeckRunArtifactTable(artifacts: readonly DeckRunArtifact[]
         artifact.directive,
         String(artifact.lineNumber),
         artifact.sourceName ?? "",
+        artifact.outputNode ?? "",
         artifact.sweepKind ?? "",
         formatDeckArtifactFloat(artifact.startValue),
         formatDeckArtifactFloat(artifact.stopValue),

--- a/code/packages/typescript/spice-engine/tests/transient.test.ts
+++ b/code/packages/typescript/spice-engine/tests/transient.test.ts
@@ -1470,6 +1470,7 @@ describe("transient", () => {
     expect(opExecution.table).toBe("Index\tV(mid)\n0\t5.000000e-01\n");
     expect(opExecution.runArtifacts[0]?.resultRows).toBe(1);
     expect(opExecution.runArtifacts[0]?.sourceName).toBeUndefined();
+    expect(opExecution.runArtifacts[0]?.outputNode).toBeUndefined();
     expect(opExecution.runArtifacts[0]?.sweepKind).toBeUndefined();
     expect(opExecution.runArtifacts[0]?.pointCount).toBeUndefined();
     expect(opExecution.runArtifacts[0]?.outputProbes).toEqual(["V(mid)"]);
@@ -1477,8 +1478,8 @@ describe("transient", () => {
     expect(opExecution.runArtifacts[0]?.measurementNames).toEqual([]);
     expect(opExecution.runArtifacts[0]?.fourierProbes).toEqual([]);
     expect(opExecution.runArtifactTable).toBe(
-      "Analysis\tDirective\tLine\tSourceName\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\n" +
-        `op\t.op\t${opExecution.plan.lineNumber}\t\t\t\t\t\t\t\t\t1\t1\tV(mid)\t1\t.save\t0\t\t0\t\n`,
+      "Analysis\tDirective\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\n" +
+        `op\t.op\t${opExecution.plan.lineNumber}\t\t\t\t\t\t\t\t\t\t1\t1\tV(mid)\t1\t.save\t0\t\t0\t\n`,
     );
 
     const dcExecution = runDeckAnalysis(circuit, netlist, "dc");
@@ -1497,6 +1498,7 @@ describe("transient", () => {
     );
     expect(dcExecution.runArtifacts[0]?.analysis).toBe("dc");
     expect(dcExecution.runArtifacts[0]?.sourceName).toBe("V1");
+    expect(dcExecution.runArtifacts[0]?.outputNode).toBeUndefined();
     expect(dcExecution.runArtifacts[0]?.startValue).toBeCloseTo(0.0, 12);
     expect(dcExecution.runArtifacts[0]?.stopValue).toBeCloseTo(1.0, 12);
     expect(dcExecution.runArtifacts[0]?.stepValue).toBeCloseTo(1.0, 12);
@@ -1505,8 +1507,8 @@ describe("transient", () => {
     expect(dcExecution.runArtifacts[0]?.measurementNames).toEqual(["mid_avg"]);
     expect(dcExecution.runArtifacts[0]?.fourierProbes).toEqual([]);
     expect(dcExecution.runArtifactTable).toBe(
-      "Analysis\tDirective\tLine\tSourceName\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\n" +
-        `dc\t.dc\t${dcExecution.plan.lineNumber}\tV1\t\t0.000000e+00\t1.000000e+00\t1.000000e+00\t\t\t\t2\t2\tV(mid);I(V1)\t2\t.save;.probe\t1\tmid_avg\t0\t\n`,
+      "Analysis\tDirective\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\n" +
+        `dc\t.dc\t${dcExecution.plan.lineNumber}\tV1\t\t\t0.000000e+00\t1.000000e+00\t1.000000e+00\t\t\t\t2\t2\tV(mid);I(V1)\t2\t.save;.probe\t1\tmid_avg\t0\t\n`,
     );
 
     const acExecution = runDeckAnalysis(circuit, netlist, "ac");
@@ -1523,6 +1525,7 @@ describe("transient", () => {
     );
     expect(acExecution.runArtifacts[0]?.outputProbes).toEqual(["V(mid)"]);
     expect(acExecution.runArtifacts[0]?.sourceName).toBeUndefined();
+    expect(acExecution.runArtifacts[0]?.outputNode).toBeUndefined();
     expect(acExecution.runArtifacts[0]?.sweepKind).toBe("dec");
     expect(acExecution.runArtifacts[0]?.pointCount).toBe(1);
     expect(acExecution.runArtifacts[0]?.startFrequencyHz).toBeCloseTo(1.0e3, 9);
@@ -1531,8 +1534,8 @@ describe("transient", () => {
     expect(acExecution.runArtifacts[0]?.measurementNames).toEqual(["mid_peak"]);
     expect(acExecution.runArtifacts[0]?.fourierProbes).toEqual([]);
     expect(acExecution.runArtifactTable).toBe(
-      "Analysis\tDirective\tLine\tSourceName\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\n" +
-        `ac\t.ac\t${acExecution.plan.lineNumber}\t\tdec\t\t\t\t1\t1.000000e+03\t1.000000e+03\t1\t1\tV(mid)\t1\t.save\t1\tmid_peak\t0\t\n`,
+      "Analysis\tDirective\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\n" +
+        `ac\t.ac\t${acExecution.plan.lineNumber}\t\t\tdec\t\t\t\t1\t1.000000e+03\t1.000000e+03\t1\t1\tV(mid)\t1\t.save\t1\tmid_peak\t0\t\n`,
     );
 
     const tranExecution = runDeckAnalysis(circuit, netlist, "tran");
@@ -1549,12 +1552,13 @@ describe("transient", () => {
     );
     expect(tranExecution.runArtifacts[0]?.outputProbes).toEqual(["V(mid)"]);
     expect(tranExecution.runArtifacts[0]?.sourceName).toBeUndefined();
+    expect(tranExecution.runArtifacts[0]?.outputNode).toBeUndefined();
     expect(tranExecution.runArtifacts[0]?.outputDirectives).toEqual([".save"]);
     expect(tranExecution.runArtifacts[0]?.measurementNames).toEqual(["mid_final"]);
     expect(tranExecution.runArtifacts[0]?.fourierProbes).toEqual([]);
     expect(tranExecution.runArtifactTable).toBe(
-      "Analysis\tDirective\tLine\tSourceName\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\n" +
-        `tran\t.tran\t${tranExecution.plan.lineNumber}\t\t\t\t\t\t\t\t\t1\t1\tV(mid)\t1\t.save\t1\tmid_final\t0\t\n`,
+      "Analysis\tDirective\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\n" +
+        `tran\t.tran\t${tranExecution.plan.lineNumber}\t\t\t\t\t\t\t\t\t\t1\t1\tV(mid)\t1\t.save\t1\tmid_final\t0\t\n`,
     );
 
     const tfExecution = runDeckAnalysis(circuit, netlist, "tf");
@@ -1577,14 +1581,15 @@ describe("transient", () => {
     );
     expect(tfExecution.runArtifacts[0]?.analysis).toBe("tf");
     expect(tfExecution.runArtifacts[0]?.sourceName).toBe("V1");
+    expect(tfExecution.runArtifacts[0]?.outputNode).toBe("mid");
     expect(tfExecution.runArtifacts[0]?.resultRows).toBe(1);
     expect(tfExecution.runArtifacts[0]?.outputProbes).toEqual(["V(mid)"]);
     expect(tfExecution.runArtifacts[0]?.outputDirectives).toEqual([]);
     expect(tfExecution.runArtifacts[0]?.measurementNames).toEqual([]);
     expect(tfExecution.runArtifacts[0]?.fourierProbes).toEqual([]);
     expect(tfExecution.runArtifactTable).toBe(
-      "Analysis\tDirective\tLine\tSourceName\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\n" +
-        `tf\t.tf\t${tfExecution.plan.lineNumber}\tV1\t\t\t\t\t\t\t\t1\t1\tV(mid)\t0\t\t0\t\t0\t\n`,
+      "Analysis\tDirective\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\n" +
+        `tf\t.tf\t${tfExecution.plan.lineNumber}\tV1\tmid\t\t\t\t\t\t\t\t1\t1\tV(mid)\t0\t\t0\t\t0\t\n`,
     );
 
     const sensExecution = runDeckAnalysis(circuit, netlist, "sens");
@@ -1604,14 +1609,15 @@ describe("transient", () => {
     )).toBe(true);
     expect(sensExecution.runArtifacts[0]?.analysis).toBe("sens");
     expect(sensExecution.runArtifacts[0]?.sourceName).toBeUndefined();
+    expect(sensExecution.runArtifacts[0]?.outputNode).toBe("mid");
     expect(sensExecution.runArtifacts[0]?.resultRows).toBe(1);
     expect(sensExecution.runArtifacts[0]?.outputProbes).toEqual(["V(mid)"]);
     expect(sensExecution.runArtifacts[0]?.outputDirectives).toEqual([]);
     expect(sensExecution.runArtifacts[0]?.measurementNames).toEqual([]);
     expect(sensExecution.runArtifacts[0]?.fourierProbes).toEqual([]);
     expect(sensExecution.runArtifactTable).toBe(
-      "Analysis\tDirective\tLine\tSourceName\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\n" +
-        `sens\t.sens\t${sensExecution.plan.lineNumber}\t\t\t\t\t\t\t\t\t1\t1\tV(mid)\t0\t\t0\t\t0\t\n`,
+      "Analysis\tDirective\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\n" +
+        `sens\t.sens\t${sensExecution.plan.lineNumber}\t\tmid\t\t\t\t\t\t\t\t1\t1\tV(mid)\t0\t\t0\t\t0\t\n`,
     );
 
     const noiseExecution = runDeckAnalysis(circuit, netlist, "noise");
@@ -1634,6 +1640,7 @@ describe("transient", () => {
     )).toBe(true);
     expect(noiseExecution.runArtifacts[0]?.analysis).toBe("noise");
     expect(noiseExecution.runArtifacts[0]?.sourceName).toBe("V1");
+    expect(noiseExecution.runArtifacts[0]?.outputNode).toBe("mid");
     expect(noiseExecution.runArtifacts[0]?.sweepKind).toBe("lin");
     expect(noiseExecution.runArtifacts[0]?.pointCount).toBe(1);
     expect(noiseExecution.runArtifacts[0]?.startFrequencyHz).toBeCloseTo(1.0e3, 9);
@@ -1644,8 +1651,8 @@ describe("transient", () => {
     expect(noiseExecution.runArtifacts[0]?.measurementNames).toEqual([]);
     expect(noiseExecution.runArtifacts[0]?.fourierProbes).toEqual([]);
     expect(noiseExecution.runArtifactTable).toBe(
-      "Analysis\tDirective\tLine\tSourceName\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\n" +
-        `noise\t.noise\t${noiseExecution.plan.lineNumber}\tV1\tlin\t\t\t\t1\t1.000000e+03\t1.000000e+03\t1\t1\tV(mid)\t0\t\t0\t\t0\t\n`,
+      "Analysis\tDirective\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\n" +
+        `noise\t.noise\t${noiseExecution.plan.lineNumber}\tV1\tmid\tlin\t\t\t\t1\t1.000000e+03\t1.000000e+03\t1\t1\tV(mid)\t0\t\t0\t\t0\t\n`,
     );
 
     const tranWindowExecution = runDeckAnalysis(
@@ -1723,13 +1730,14 @@ describe("transient", () => {
     expect(tranExecution.fourierTable).toBe(formatFourierTable(result));
     expect(tranExecution.runArtifacts[0]?.fourierCount).toBe(1);
     expect(tranExecution.runArtifacts[0]?.sourceName).toBeUndefined();
+    expect(tranExecution.runArtifacts[0]?.outputNode).toBeUndefined();
     expect(tranExecution.runArtifacts[0]?.outputProbes).toEqual(["V(mid)"]);
     expect(tranExecution.runArtifacts[0]?.outputDirectives).toEqual([".save"]);
     expect(tranExecution.runArtifacts[0]?.measurementNames).toEqual([]);
     expect(tranExecution.runArtifacts[0]?.fourierProbes).toEqual(["V(mid)"]);
     expect(tranExecution.runArtifactTable).toBe(
-      "Analysis\tDirective\tLine\tSourceName\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\n" +
-        `tran\t.tran\t${tranExecution.plan.lineNumber}\t\t\t\t\t\t\t\t\t2\t1\tV(mid)\t1\t.save\t0\t\t1\tV(mid)\n`,
+      "Analysis\tDirective\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\n" +
+        `tran\t.tran\t${tranExecution.plan.lineNumber}\t\t\t\t\t\t\t\t\t\t2\t1\tV(mid)\t1\t.save\t0\t\t1\tV(mid)\n`,
     );
   });
 

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -88,7 +88,8 @@ downstream tools to compare.
      run-artifact summaries plus stable row/count tables for result rows,
      output probes, measurements, and Fourier artifacts, with normalized
      output-probe, measurement, and Fourier probe name lists included in the
-     run artifacts.
+     run artifacts; transfer-function, sensitivity, and noise run artifacts now
+     also expose their selected output node.
    - Expand remaining deck-controlled analyses toward full SPICE compatibility
      while keeping unsupported control-flow diagnostics explicit.
 
@@ -813,6 +814,15 @@ downstream tools to compare.
       `StopValue`, `StepValue`, `PointCount`, `StartFrequencyHz`, and
       `StopFrequencyHz`, with empty cells for analysis cards without that
       sweep metadata.
+
+74. Deck run output-node artifacts.
+    - Status: completed in this deck run output-node artifact slice.
+    - Python, Rust, and TypeScript selected deck executions now copy each
+      selected analysis plan's output node into deck-run artifacts, preserving
+      `.tf`, `.sens`, and `.noise` output-target provenance beside source and
+      sweep metadata.
+    - The stable run-artifact table now includes `OutputNode`, with an empty
+      cell for analysis cards that do not select a single output node.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- copy selected analysis output-node metadata into Python/Rust/TypeScript deck-run artifacts
- add the stable OutputNode column to deck run artifact tables
- record SPICE plan item 74 for the output-node artifact slice

## Verification
- cargo fmt --manifest-path code/packages/rust/spice-engine/Cargo.toml -- --check
- /Users/adhithya/.local/share/mise/installs/python/3.12.13/bin/ruff check code/packages/python/spice-engine
- PYTEST_ADDOPTS=--no-cov PYTHONPATH=code/packages/python/device-physics/src:code/packages/python/mosfet-models/src:code/packages/python/spice-engine/src /Users/adhithya/.local/share/mise/installs/python/3.12.13/bin/python3.12 -m pytest code/packages/python/spice-engine/tests/test_compatibility.py code/packages/python/spice-engine/tests/test_engine.py -q
- cargo test --manifest-path code/packages/rust/spice-engine/Cargo.toml
- PATH=/Users/adhithya/.local/share/mise/installs/node/22.22.3/bin:$PATH npm --prefix code/packages/typescript/spice-engine ci
- PATH=/Users/adhithya/.local/share/mise/installs/node/22.22.3/bin:$PATH npm --prefix code/packages/typescript/spice-engine run build
- PATH=/Users/adhithya/.local/share/mise/installs/node/22.22.3/bin:$PATH npm --prefix code/packages/typescript/spice-engine test