### PR TITLE
feat(inline): value capture in `return`-argument position (CLOC15 PR-5)

### DIFF
--- a/code/packages/rust/closure-pass-inline/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-inline/CHANGELOG.md
@@ -2,6 +2,51 @@
 
 All notable changes to the `coding-adventures-closure-pass-inline` crate will be documented in this file.
 
+## [0.10.0] - 2026-06-19
+
+### Added (CLOC15 PR-5 — value capture in `return`-argument position)
+
+The value-capture path now admits the call appearing as the **entire argument
+of a `return` statement** (`return f(x)`), the ubiquitous "tail-call a helper"
+shape. PR-3 already handled `const r = f(x)` / `let r = f(x)`; this slice adds
+the return position, where the helper's tail value becomes the **caller's own
+return value** — with no temp, because the value flows straight out:
+
+```js
+function helper(p) { log(p); return p + 1; }
+function main()    { return helper(3); }
+main(); main();
+// SIMPLE  ⇒  function main(){ log(3); return 4 }  (helper declaration removed)
+```
+
+Soundness: `return` is a terminator, so the single `return f(x)` is the last
+reachable statement on its path. Replacing it with `body…; return E` runs the
+body's effects exactly as they ran inside the callee before its own return,
+then returns the same value; any statement textually after `return f(x)` was
+dead before and remains dead after.
+
+Declined positions (the call is not the *entire* return argument, so hoisting
+the body would change evaluation order):
+
+- `return cond && f(x)` — the call is the right operand of `&&`
+  (a `LogicalExpression`, not a bare call);
+- `return c ? f(x) : y` — the call is a branch of a `ConditionalExpression`;
+- `return f(x)` where `f` has no tail-return *value* (a bare `return;`) — a
+  void candidate, not a valued one, so nothing is synthesized.
+
+Composes with the existing machinery: callee locals are alpha-renamed
+program-fresh and non-simple arguments are materialised once into per-argument
+temps (PR-4a) before the spliced body, exactly as in the `const`-init path.
+
+**Implementation.** `build_captured_body` now takes a `CaptureTail` —
+`IntoTemp(&temp)` (the PR-3 `const <temp> = E;` tail) or `AsReturn` (the new
+`return E;` tail) — so the rename / substitute / arg-materialisation logic is
+shared and only the final statement differs. `try_capture_in_stmt` matches a
+`ReturnStatement` whose argument is exactly the target call via the new
+`capture_splice_for_return`. 5 new tests (70 total).
+
+This resolves CLOC15 spec **Open question 2**'s return-argument case.
+
 ## [0.9.0] - 2026-06-19
 
 ### Added (CLOC15 PR-4b — `if` without an early exit in the body)

--- a/code/packages/rust/closure-pass-inline/Cargo.toml
+++ b/code/packages/rust/closure-pass-inline/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-inline"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2021"
 description = "Function-inlining pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Substitutes small or single-use function bodies at their call sites to enable downstream folding and shrink call overhead."
 

--- a/code/packages/rust/closure-pass-inline/README.md
+++ b/code/packages/rust/closure-pass-inline/README.md
@@ -166,8 +166,9 @@ airtight subset is when the call is the **entire initializer of a
 single-declarator** `var`/`let`/`const` — nothing is evaluated before it and
 an initializer is never short-circuited. `var x = a + f()` (reorders `a`),
 `var x = f(), y = …` (multi-declarator), `var x = h(f())` (not the top
-expression), and a body with no tail-return value are all declined. Broader
-value positions (assignment targets, `return` arguments) are later slices.
+expression), and a body with no tail-return value are all declined. The
+`return`-argument value position is admitted by PR-5 (below); assignment
+targets remain a later slice.
 
 ### Non-simple arguments — per-argument temps (CLOC15 PR-4a)
 
@@ -206,6 +207,27 @@ guard(value);
 
 The `if`'s test is unrestricted (its identifiers are vetted normally).
 Nested `if` / loops are kept for a later slice.
+
+### Result returned — `return f(x)` (CLOC15 PR-5)
+
+The other airtight value position is a call that is the **entire argument of a
+`return`** — the everyday "tail-call a helper" shape. Here no temp is needed:
+the helper's tail value becomes the **caller's own return value**, because
+`return` is a terminator (nothing after it on that path runs):
+
+```js
+function helper(p) { log(p); return p + 1; }
+function main()    { return helper(3); }
+main(); main();
+// SIMPLE  ⇒  function main(){ log(3); return 4 }   (helper declaration removed)
+```
+
+Replacing `return f(x)` with `body…; return E` runs the body's effects exactly
+as they ran inside the callee, then returns the same value. As with PR-3 the
+call must be the *whole* argument: `return cond && f(x)` (right operand of
+`&&`), `return c ? f(x) : y` (a conditional branch), and a void helper used as
+`return f(x)` (no value to return) are all declined. Composes with local
+alpha-renaming and PR-4a per-argument temps.
 
 ## Where this pass sits
 

--- a/code/packages/rust/closure-pass-inline/src/lib.rs
+++ b/code/packages/rust/closure-pass-inline/src/lib.rs
@@ -123,7 +123,7 @@ use std::collections::{HashMap, HashSet};
 use coding_adventures_closure_pass_pipeline::{
     IterationPolicy, Pass, PassContext, PassError, PassOutput, PassStats,
 };
-use coding_adventures_javascript_ast::statement::TaggedStatement;
+use coding_adventures_javascript_ast::statement::{ReturnStatement, TaggedStatement};
 use coding_adventures_javascript_ast::{
     AssignmentTarget, BindingTarget, BlockStatement, CallExpression, Declaration, Expression,
     ExpressionStatement, ForInit, FunctionDeclaration, FunctionParam, Identifier, IfStatement,
@@ -302,15 +302,20 @@ fn inline_program(program: &mut Program, nodes_touched: &mut u32) -> bool {
     // removes call sites, never declarations).
     changed |= inline_void_statement_helpers(program, &decl_counts, nodes_touched);
 
-    // Phase 5 — CLOC15 PR-3: inline a single-use multi-statement helper
+    // Phase 5 — CLOC15 PR-3/PR-5: inline a single-use multi-statement helper
     // whose RESULT IS USED, by hoisting its body before the enclosing
-    // statement and capturing the tail-return value into a fresh temp. The
-    // sound subset is narrow (the call is the entire initializer of a
-    // single-declarator `var`/`let`/`const`), so hoisting the body before
-    // the declaration cannot reorder any other evaluation. See
-    // [`inline_valued_statement_helpers`]. Runs after Phase 4 because the
-    // void pass consumes the discarded-statement uses first, so this pass
-    // only ever sees the value-position use.
+    // statement and consuming the tail-return value at the call site. The
+    // sound value positions are:
+    //   - PR-3: the call is the entire initializer of a single-declarator
+    //     `var`/`let`/`const` (`const r = f(x)`), captured into a fresh temp;
+    //   - PR-5: the call is the entire argument of a `return` (`return f(x)`),
+    //     re-emitted as the caller's own `return E` — no temp, since the
+    //     value flows straight out and `return` is a terminator.
+    // Both reject the call appearing under a short-circuit / conditional
+    // operator (`a && f(x)`, `c ? f(x) : y`), where hoisting would change
+    // evaluation. See [`inline_valued_statement_helpers`]. Runs after Phase 4
+    // because the void pass consumes the discarded-statement uses first, so
+    // this pass only ever sees the value-position use.
     changed |= inline_valued_statement_helpers(program, &decl_counts, nodes_touched);
 
     changed
@@ -2005,10 +2010,53 @@ fn try_capture_in_stmt(
     avoid: &mut HashSet<String>,
     nodes_touched: &mut u32,
 ) -> Option<Vec<Statement>> {
-    if let Statement::Declaration(Declaration::VariableDeclaration(vd)) = stmt {
-        return capture_splice_for_vardecl(vd, cand, avoid, nodes_touched);
+    match stmt {
+        // `const r = f(x);` / `let r = f(x);` — PR-3 value capture into the
+        // declared binding via a hoisted temp.
+        Statement::Declaration(Declaration::VariableDeclaration(vd)) => {
+            capture_splice_for_vardecl(vd, cand, avoid, nodes_touched)
+        }
+        // `return f(x);` — PR-5 value capture in return-argument position.
+        Statement::Tagged(TaggedStatement::ReturnStatement(rs)) => {
+            capture_splice_for_return(rs, cand, avoid, nodes_touched)
+        }
+        _ => None,
     }
-    None
+}
+
+/// The return-position capture core (CLOC15 PR-5): a `return` statement
+/// qualifies iff its argument is **exactly** `cand.name(args)` (matching
+/// arity, the call is the entire argument — not `return a + f(x)` nor
+/// `return c ? f(x) : y`, which are not `CallExpression`s and so are
+/// declined). The replacement is the hoisted body with the callee's tail
+/// `return E` re-emitted as *this* function's `return E` — no temp, because
+/// the value flows straight out.
+///
+/// Soundness: `return` is a terminator, so the single `return f(x)` statement
+/// is the last reachable statement on its path; replacing it with
+/// `body…; return E` runs the body's effects (exactly as they ran inside the
+/// callee before its own return) and then returns the same value. Anything
+/// textually after `return f(x)` was dead before and remains dead after.
+fn capture_splice_for_return(
+    rs: &ReturnStatement,
+    cand: &VoidStmtCandidate,
+    avoid: &mut HashSet<String>,
+    nodes_touched: &mut u32,
+) -> Option<Vec<Statement>> {
+    let arg = rs.argument.as_ref()?;
+    let Expression::CallExpression(ce) = arg else {
+        return None; // the call must be the ENTIRE return argument
+    };
+    if !is_void_target_call(ce, cand) {
+        return None;
+    }
+    Some(build_captured_body(
+        cand,
+        &ce.arguments,
+        CaptureTail::AsReturn,
+        avoid,
+        nodes_touched,
+    ))
 }
 
 /// The capture core: a `VariableDeclaration` qualifies iff it has EXACTLY
@@ -2042,7 +2090,13 @@ fn capture_splice_for_vardecl(
         t
     };
 
-    let mut out = build_captured_body(cand, &ce.arguments, &temp, avoid, nodes_touched);
+    let mut out = build_captured_body(
+        cand,
+        &ce.arguments,
+        CaptureTail::IntoTemp(&temp),
+        avoid,
+        nodes_touched,
+    );
 
     // The original declaration, initializer rewritten to the temp.
     let mut new_vd = vd.clone();
@@ -2056,14 +2110,34 @@ fn capture_splice_for_vardecl(
     Some(out)
 }
 
+/// How a captured tail-return value is consumed at the splice site. The
+/// rename/substitute/arg-materialisation work is identical; only the final
+/// statement differs, so the two value-capture paths share
+/// [`build_captured_body`] and vary only this tail.
+enum CaptureTail<'a> {
+    /// Bind the value into a fresh `const <temp>;`. Used when the call was a
+    /// variable initializer (`const r = f(x)`) or expression-statement result:
+    /// a later statement reads the value through `<temp>` (CLOC15 PR-3).
+    IntoTemp(&'a str),
+    /// The call was itself the argument of a `return` statement
+    /// (`return f(x)`). Emit `return <value>;` directly — no temp is needed
+    /// because the value flows straight out as the enclosing function's return
+    /// value. Sound because `return` is a terminator: nothing in the caller's
+    /// statement list runs after it, so splicing `body; return E` in place of
+    /// `return f(x)` preserves both the effects and the returned value
+    /// (CLOC15 PR-5).
+    AsReturn,
+}
+
 /// Build the hoisted body for a captured call: the callee body with its
 /// tail `return E` removed, locals alpha-renamed, params substituted, and a
-/// trailing `const <temp> = E;` capturing the (renamed/substituted) return
-/// value.
+/// trailing statement consuming the (renamed/substituted) return value per
+/// `tail` — either `const <temp> = E;` ([`CaptureTail::IntoTemp`]) or
+/// `return E;` ([`CaptureTail::AsReturn`]).
 fn build_captured_body(
     cand: &VoidStmtCandidate,
     args: &[Expression],
-    temp: &str,
+    tail: CaptureTail<'_>,
     avoid: &mut HashSet<String>,
     nodes_touched: &mut u32,
 ) -> Vec<Statement> {
@@ -2113,21 +2187,35 @@ fn build_captured_body(
         substitute(&mut return_value, &param_map);
     }
 
-    // Capture the return value into the fresh temp.
-    body.push(Statement::Declaration(Declaration::VariableDeclaration(
-        VariableDeclaration {
-            cv: None,
-            kind: VarKind::Const,
-            declarations: vec![VariableDeclarator {
-                cv: None,
-                id: BindingTarget::Identifier(Identifier {
+    // Consume the (renamed/substituted) return value per the requested tail.
+    match tail {
+        // `const <temp> = E;` — a later statement reads it through `<temp>`.
+        CaptureTail::IntoTemp(temp) => {
+            body.push(Statement::Declaration(Declaration::VariableDeclaration(
+                VariableDeclaration {
                     cv: None,
-                    name: temp.to_string(),
-                }),
-                init: Some(return_value),
-            }],
-        },
-    )));
+                    kind: VarKind::Const,
+                    declarations: vec![VariableDeclarator {
+                        cv: None,
+                        id: BindingTarget::Identifier(Identifier {
+                            cv: None,
+                            name: temp.to_string(),
+                        }),
+                        init: Some(return_value),
+                    }],
+                },
+            )));
+        }
+        // `return E;` — the value flows straight out (no temp).
+        CaptureTail::AsReturn => {
+            body.push(Statement::Tagged(TaggedStatement::ReturnStatement(
+                ReturnStatement {
+                    cv: None,
+                    argument: Some(return_value),
+                },
+            )));
+        }
+    }
 
     *nodes_touched += body.len() as u32;
 
@@ -3346,6 +3434,77 @@ mod tests {
         assert_eq!(
             inline_source("function f(a) { g(); return; } var x = f(1);"),
             "function f(a){g();return};var x=f(1);"
+        );
+    }
+
+    // ---- CLOC15 PR-5: value capture in `return`-argument position --------
+
+    #[test]
+    fn captures_helper_in_return_position() {
+        // The signature PR-5 case: `return f(x)` where `f` is a single-use
+        // multi-statement helper. The body is hoisted into the caller and the
+        // callee's tail `return a` (param substituted by `7`) becomes the
+        // caller's own `return 7` — no temp, the value flows straight out.
+        assert_eq!(
+            inline_source("function f(a) { g(); return a; } function main() { return f(7); }"),
+            "function f(a){g();return a};function main(){g();return 7};"
+        );
+    }
+
+    #[test]
+    fn captures_return_position_with_local_and_nonsimple_arg() {
+        // Return-position capture composes with local alpha-renaming AND the
+        // PR-4a per-argument temp: the non-simple argument `compute()` is
+        // materialised once into a fresh temp before the body, the callee
+        // local `t` is renamed program-fresh, and the tail expression becomes
+        // the caller's return value.
+        assert_eq!(
+            inline_source(
+                "function f(p) { const t = p + 1; return t; } \
+                 function main() { return f(compute()); }"
+            ),
+            "function f(p){const t=p + 1;return t};\
+             function main(){const a=compute();const b=a + 1;return b};"
+        );
+    }
+
+    #[test]
+    fn does_not_capture_return_under_short_circuit() {
+        // `return cond && f(x)` — the call is not the *entire* return argument
+        // (it is the right operand of `&&`), so hoisting the body before the
+        // `return` would run it unconditionally, changing semantics. The
+        // argument is a `LogicalExpression`, not a `CallExpression`, so it is
+        // declined.
+        assert_eq!(
+            inline_source(
+                "function f(a) { g(); return a; } function main() { return cond && f(7); }"
+            ),
+            "function f(a){g();return a};function main(){return cond && f(7)};"
+        );
+    }
+
+    #[test]
+    fn does_not_capture_return_conditional() {
+        // `return c ? f(x) : y` — same reasoning: the return argument is a
+        // `ConditionalExpression`, not a bare call, so the body must not be
+        // hoisted out of the conditional. Declined.
+        assert_eq!(
+            inline_source(
+                "function f(a) { g(); return a; } function main() { return c ? f(7) : 0; }"
+            ),
+            "function f(a){g();return a};function main(){return c?f(7):0};"
+        );
+    }
+
+    #[test]
+    fn does_not_capture_void_helper_in_return_position() {
+        // A helper with no tail-return *value* (bare `return;`) is a void
+        // candidate, not a valued one; `return f(x)` would return its
+        // `undefined`, which the valued path does not synthesize — so the
+        // call is left intact rather than mis-spliced.
+        assert_eq!(
+            inline_source("function f(a) { g(); return; } function main() { return f(1); }"),
+            "function f(a){g();return};function main(){return f(1)};"
         );
     }
 }

--- a/code/specs/CLOC15-multi-statement-inlining.md
+++ b/code/specs/CLOC15-multi-statement-inlining.md
@@ -267,6 +267,43 @@ fresh-rename treatment — and (ii) extending the body-shape walk to accept the
 admitted control constructs while still rejecting early exits. Defer until 4a
 ships; it is independent.
 
+### PR-5 — value capture in `return`-argument position (**merged**)
+
+**Status:** merged. PR-3 captured a used result only when the call was the
+entire initializer of a single-declarator `var`/`let`/`const`. PR-5 admits the
+other airtight value position from *Open question 2*: a call that is the
+**entire argument of a `return`** (`return f(x)`), the everyday "tail-call a
+helper" shape.
+
+**The transform.** Replace `return f(args);` with the hoisted body followed by
+the callee's tail return re-emitted as **this** function's return — *no temp*,
+because the value flows straight out:
+
+```js
+function helper(p) { log(p); return p + 1; }
+function main()    { return helper(3); }
+// ⇒
+function main()    { log(3); return 4; }   // (after fold; helper decl removed)
+```
+
+**Soundness.** `return` is a terminator: the single `return f(x)` is the last
+reachable statement on its path, so splicing `body…; return E` in its place
+runs the body's effects exactly as they ran inside the callee before its own
+return, then returns the same value. Any statement textually after
+`return f(x)` was dead before and remains dead after. The call must be the
+*entire* return argument — `return cond && f(x)` (a `LogicalExpression`),
+`return c ? f(x) : y` (a `ConditionalExpression`), and a void helper used as
+`return f(x)` (no tail-return value to surface) are declined. Local
+alpha-renaming and PR-4a per-argument temps compose unchanged.
+
+**Implementation.** `build_captured_body` gained a `CaptureTail` parameter —
+`IntoTemp(&temp)` (PR-3's `const <temp> = E;`) or `AsReturn` (PR-5's
+`return E;`) — so the rename / substitute / arg-materialisation logic is shared
+and only the final statement varies. `try_capture_in_stmt` matches a
+`ReturnStatement` whose argument is exactly the target call
+(`capture_splice_for_return`); because that helper is invoked from
+`splice_valued_in_stmt_vec`, it fires inside any nested function body.
+
 ## Implementation findings (after PR-1..PR-3, verified against `closurec`)
 
 Empirical behaviour of the merged slices, confirmed by running the real
@@ -309,6 +346,11 @@ Empirical behaviour of the merged slices, confirmed by running the real
    call when its enclosing statement is a plain `ExpressionStatement`,
    `VariableDeclaration` init, or `return` argument, and the call is not under a
    short-circuit/conditional operator."
+   **Resolved:** PR-3 implemented the `VariableDeclaration`-init position and
+   PR-5 the `return`-argument position (see the staged plan above); both reject
+   the short-circuit/conditional sub-positions. Assignment-target capture
+   remains unbuilt (and is moot until the typed bridge supports assignment
+   expressions — see *Implementation findings*).
 
 3. **`var` hoisting vs. let/const.** First slice should restrict callee locals
    to `let`/`const` to sidestep hoisting reasoning, then admit `var` once the


### PR DESCRIPTION
## What

Extends the function-inliner's **value-capture path** (`closure-pass-inline`) to admit a single-use multi-statement helper called as the **entire argument of a `return`** statement (`return f(x)`) — the everyday "tail-call a helper" shape. PR-3 already captured `const r = f(x)` / `let r = f(x)` into a hoisted temp; PR-5 adds the return position, where the helper's tail value becomes the caller's **own** return value, with **no temp** (the value flows straight out):

```js
function helper(p) { log(p); return p + 1; }
function main()    { return helper(3); }
main(); main();
// SIMPLE ⇒ function main(){ log(3); return 4 }   (helper declaration removed)
```

This is the next sound slice in the [CLOC15](code/specs/CLOC15-multi-statement-inlining.md) staged plan, resolving the `return`-argument case of **Open question 2**.

## Why it's sound

`return` is a terminator: the single `return f(x)` is the last reachable statement on its path. Replacing it with `body…; return E` runs the body's effects exactly as they ran inside the callee before its own return, then returns the same value. Anything textually after `return f(x)` was dead before and remains dead after.

**Declined positions** (the call is not the *entire* return argument, so hoisting would change evaluation):
- `return cond && f(x)` — right operand of `&&` (a `LogicalExpression`, not a bare call)
- `return c ? f(x) : y` — a `ConditionalExpression` branch
- `return f(x)` where `f` has only a bare `return;` — a void candidate, no value to surface

Composes unchanged with callee-local alpha-renaming and PR-4a per-argument temps for non-simple arguments.

## Implementation

`build_captured_body` now takes a `CaptureTail` — `IntoTemp(&temp)` (PR-3's `const <temp> = E;`) or `AsReturn` (PR-5's `return E;`) — so the rename / substitute / arg-materialisation logic is shared and only the final statement varies. `try_capture_in_stmt` matches a `ReturnStatement` whose argument is exactly the target call via the new `capture_splice_for_return`; because it's invoked from `splice_valued_in_stmt_vec`, it fires inside any nested function body.

## Verification

- **5 new unit tests** (70 total in the crate), incl. the three declined positions.
- **All 680 closurec integration tests green** (fresh rebuild; no fixture churn).
- **Downstream consumer** `closure-pass-remove-unused-vars` tests green (21).
- **End-to-end through the real `closurec --compilation_level SIMPLE` binary**: `return helper(3)` → `function main(){log(3);return 4}` with the helper declaration removed.
- **Inline security review (Rust): PASSED** — no panics/overflow/DoS; the soundness gate structurally excludes method calls, `new`, chained calls, member access, and short-circuit/conditional return positions.

## Housekeeping

- crate `0.9.0` → `0.10.0`; CHANGELOG, README, and the CLOC15 spec (new PR-5 section + OQ2 marked resolved) updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)