### PR TITLE
Add SPICE deck transient timing artifacts

### DIFF
--- a/code/packages/python/spice-engine/src/spice_engine/engine.py
+++ b/code/packages/python/spice-engine/src/spice_engine/engine.py
@@ -2328,6 +2328,11 @@ class DeckRunArtifact:
     point_count: int | None
     start_frequency_hz: float | None
     stop_frequency_hz: float | None
+    step_time: float | None
+    stop_time: float | None
+    start_time: float | None
+    max_step: float | None
+    use_initial_conditions: bool | None
     result_rows: int
     output_probe_count: int
     output_probes: list[str]
@@ -2398,6 +2403,10 @@ def _format_deck_artifact_float(value: float | None) -> str:
     return "" if value is None else f"{value:.6e}"
 
 
+def _format_deck_artifact_bool(value: bool | None) -> str:
+    return "" if value is None else str(value).lower()
+
+
 def _deck_run_artifacts(
     plan: DeckAnalysisPlan,
     result: DcResult | DcSweepResult | AcResult | TransientResult | TfResult | SensResult | NoiseResult,
@@ -2406,6 +2415,7 @@ def _deck_run_artifacts(
     measurements: list[ProbeMeasurement],
     fourier: list[FourierResult],
 ) -> list[DeckRunArtifact]:
+    is_transient = plan.analysis == "tran"
     return [
         DeckRunArtifact(
             analysis=plan.analysis,
@@ -2420,6 +2430,13 @@ def _deck_run_artifacts(
             point_count=plan.point_count,
             start_frequency_hz=plan.start_frequency,
             stop_frequency_hz=plan.stop_frequency,
+            step_time=plan.step_time if is_transient else None,
+            stop_time=plan.stop_time if is_transient else None,
+            start_time=plan.start_time if is_transient else None,
+            max_step=plan.max_step if is_transient else None,
+            use_initial_conditions=(
+                plan.use_initial_conditions if is_transient else None
+            ),
             result_rows=_deck_result_row_count(result),
             output_probe_count=len(output_probes),
             output_probes=list(output_probes),
@@ -2439,7 +2456,7 @@ def format_deck_run_artifact_table(artifacts: Iterable[DeckRunArtifact]) -> str:
     """Format selected deck-run artifacts as a stable summary table."""
 
     rows = [
-        "Analysis\tDirective\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList"
+        "Analysis\tDirective\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList"
     ]
     for artifact in artifacts:
         rows.append(
@@ -2457,6 +2474,11 @@ def format_deck_run_artifact_table(artifacts: Iterable[DeckRunArtifact]) -> str:
                     "" if artifact.point_count is None else str(artifact.point_count),
                     _format_deck_artifact_float(artifact.start_frequency_hz),
                     _format_deck_artifact_float(artifact.stop_frequency_hz),
+                    _format_deck_artifact_float(artifact.step_time),
+                    _format_deck_artifact_float(artifact.stop_time),
+                    _format_deck_artifact_float(artifact.start_time),
+                    _format_deck_artifact_float(artifact.max_step),
+                    _format_deck_artifact_bool(artifact.use_initial_conditions),
                     str(artifact.result_rows),
                     str(artifact.output_probe_count),
                     ";".join(artifact.output_probes),

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -6799,13 +6799,15 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
     assert op_execution.run_artifacts[0].output_node is None
     assert op_execution.run_artifacts[0].sweep_kind is None
     assert op_execution.run_artifacts[0].point_count is None
+    assert op_execution.run_artifacts[0].step_time is None
+    assert op_execution.run_artifacts[0].use_initial_conditions is None
     assert op_execution.run_artifacts[0].output_probes == ["V(mid)"]
     assert op_execution.run_artifacts[0].output_directives == [".save"]
     assert op_execution.run_artifacts[0].measurement_names == []
     assert op_execution.run_artifacts[0].fourier_probes == []
     assert op_execution.run_artifact_table == (
-        "Analysis\tDirective\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\n"
-        f"op\t.op\t{op_execution.plan.line_number}\t\t\t\t\t\t\t\t\t\t1\t1\tV(mid)\t1\t.save\t0\t\t0\t\n"
+        "Analysis\tDirective\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\n"
+        f"op\t.op\t{op_execution.plan.line_number}\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t1\t1\tV(mid)\t1\t.save\t0\t\t0\t\n"
     )
 
     dc_execution = run_deck_analysis(circuit, netlist, "dc")
@@ -6829,13 +6831,15 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
     assert dc_execution.run_artifacts[0].start_value == pytest.approx(0.0)
     assert dc_execution.run_artifacts[0].stop_value == pytest.approx(1.0)
     assert dc_execution.run_artifacts[0].step_value == pytest.approx(1.0)
+    assert dc_execution.run_artifacts[0].step_time is None
+    assert dc_execution.run_artifacts[0].use_initial_conditions is None
     assert dc_execution.run_artifacts[0].output_probes == ["V(mid)", "I(V1)"]
     assert dc_execution.run_artifacts[0].output_directives == [".save", ".probe"]
     assert dc_execution.run_artifacts[0].measurement_names == ["mid_avg"]
     assert dc_execution.run_artifacts[0].fourier_probes == []
     assert dc_execution.run_artifact_table == (
-        "Analysis\tDirective\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\n"
-        f"dc\t.dc\t{dc_execution.plan.line_number}\tV1\t\t\t0.000000e+00\t1.000000e+00\t1.000000e+00\t\t\t\t2\t2\tV(mid);I(V1)\t2\t.save;.probe\t1\tmid_avg\t0\t\n"
+        "Analysis\tDirective\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\n"
+        f"dc\t.dc\t{dc_execution.plan.line_number}\tV1\t\t\t0.000000e+00\t1.000000e+00\t1.000000e+00\t\t\t\t\t\t\t\t\t2\t2\tV(mid);I(V1)\t2\t.save;.probe\t1\tmid_avg\t0\t\n"
     )
 
     ac_execution = run_deck_analysis(circuit, netlist, "ac")
@@ -6858,12 +6862,14 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
     assert ac_execution.run_artifacts[0].point_count == 1
     assert ac_execution.run_artifacts[0].start_frequency_hz == pytest.approx(1.0e3)
     assert ac_execution.run_artifacts[0].stop_frequency_hz == pytest.approx(1.0e3)
+    assert ac_execution.run_artifacts[0].step_time is None
+    assert ac_execution.run_artifacts[0].use_initial_conditions is None
     assert ac_execution.run_artifacts[0].output_directives == [".save"]
     assert ac_execution.run_artifacts[0].measurement_names == ["mid_peak"]
     assert ac_execution.run_artifacts[0].fourier_probes == []
     assert ac_execution.run_artifact_table == (
-        "Analysis\tDirective\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\n"
-        f"ac\t.ac\t{ac_execution.plan.line_number}\t\t\tdec\t\t\t\t1\t1.000000e+03\t1.000000e+03\t1\t1\tV(mid)\t1\t.save\t1\tmid_peak\t0\t\n"
+        "Analysis\tDirective\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\n"
+        f"ac\t.ac\t{ac_execution.plan.line_number}\t\t\tdec\t\t\t\t1\t1.000000e+03\t1.000000e+03\t\t\t\t\t\t1\t1\tV(mid)\t1\t.save\t1\tmid_peak\t0\t\n"
     )
 
     tran_execution = run_deck_analysis(circuit, netlist, "tran")
@@ -6884,12 +6890,17 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
     assert tran_execution.run_artifacts[0].output_probes == ["V(mid)"]
     assert tran_execution.run_artifacts[0].source_name is None
     assert tran_execution.run_artifacts[0].output_node is None
+    assert tran_execution.run_artifacts[0].step_time == pytest.approx(1.0e-3)
+    assert tran_execution.run_artifacts[0].stop_time == pytest.approx(1.0e-3)
+    assert tran_execution.run_artifacts[0].start_time is None
+    assert tran_execution.run_artifacts[0].max_step is None
+    assert tran_execution.run_artifacts[0].use_initial_conditions is False
     assert tran_execution.run_artifacts[0].output_directives == [".save"]
     assert tran_execution.run_artifacts[0].measurement_names == ["mid_final"]
     assert tran_execution.run_artifacts[0].fourier_probes == []
     assert tran_execution.run_artifact_table == (
-        "Analysis\tDirective\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\n"
-        f"tran\t.tran\t{tran_execution.plan.line_number}\t\t\t\t\t\t\t\t\t\t2\t1\tV(mid)\t1\t.save\t1\tmid_final\t0\t\n"
+        "Analysis\tDirective\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\n"
+        f"tran\t.tran\t{tran_execution.plan.line_number}\t\t\t\t\t\t\t\t\t\t1.000000e-03\t1.000000e-03\t\t\tfalse\t2\t1\tV(mid)\t1\t.save\t1\tmid_final\t0\t\n"
     )
 
     tf_execution = run_deck_analysis(circuit, netlist, "tf")
@@ -6910,13 +6921,15 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
     assert tf_execution.run_artifacts[0].source_name == "V1"
     assert tf_execution.run_artifacts[0].output_node == "mid"
     assert tf_execution.run_artifacts[0].result_rows == 1
+    assert tf_execution.run_artifacts[0].step_time is None
+    assert tf_execution.run_artifacts[0].use_initial_conditions is None
     assert tf_execution.run_artifacts[0].output_probes == ["V(mid)"]
     assert tf_execution.run_artifacts[0].output_directives == []
     assert tf_execution.run_artifacts[0].measurement_names == []
     assert tf_execution.run_artifacts[0].fourier_probes == []
     assert tf_execution.run_artifact_table == (
-        "Analysis\tDirective\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\n"
-        f"tf\t.tf\t{tf_execution.plan.line_number}\tV1\tmid\t\t\t\t\t\t\t\t1\t1\tV(mid)\t0\t\t0\t\t0\t\n"
+        "Analysis\tDirective\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\n"
+        f"tf\t.tf\t{tf_execution.plan.line_number}\tV1\tmid\t\t\t\t\t\t\t\t\t\t\t\t\t1\t1\tV(mid)\t0\t\t0\t\t0\t\n"
     )
 
     sens_execution = run_deck_analysis(circuit, netlist, "sens")
@@ -6935,13 +6948,15 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
     assert sens_execution.run_artifacts[0].source_name is None
     assert sens_execution.run_artifacts[0].output_node == "mid"
     assert sens_execution.run_artifacts[0].result_rows == 1
+    assert sens_execution.run_artifacts[0].step_time is None
+    assert sens_execution.run_artifacts[0].use_initial_conditions is None
     assert sens_execution.run_artifacts[0].output_probes == ["V(mid)"]
     assert sens_execution.run_artifacts[0].output_directives == []
     assert sens_execution.run_artifacts[0].measurement_names == []
     assert sens_execution.run_artifacts[0].fourier_probes == []
     assert sens_execution.run_artifact_table == (
-        "Analysis\tDirective\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\n"
-        f"sens\t.sens\t{sens_execution.plan.line_number}\t\tmid\t\t\t\t\t\t\t\t1\t1\tV(mid)\t0\t\t0\t\t0\t\n"
+        "Analysis\tDirective\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\n"
+        f"sens\t.sens\t{sens_execution.plan.line_number}\t\tmid\t\t\t\t\t\t\t\t\t\t\t\t\t1\t1\tV(mid)\t0\t\t0\t\t0\t\n"
     )
 
     noise_execution = run_deck_analysis(circuit, netlist, "noise")
@@ -6971,13 +6986,15 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
     assert noise_execution.run_artifacts[0].start_frequency_hz == pytest.approx(1.0e3)
     assert noise_execution.run_artifacts[0].stop_frequency_hz == pytest.approx(1.0e3)
     assert noise_execution.run_artifacts[0].result_rows == 1
+    assert noise_execution.run_artifacts[0].step_time is None
+    assert noise_execution.run_artifacts[0].use_initial_conditions is None
     assert noise_execution.run_artifacts[0].output_probes == ["V(mid)"]
     assert noise_execution.run_artifacts[0].output_directives == []
     assert noise_execution.run_artifacts[0].measurement_names == []
     assert noise_execution.run_artifacts[0].fourier_probes == []
     assert noise_execution.run_artifact_table == (
-        "Analysis\tDirective\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\n"
-        f"noise\t.noise\t{noise_execution.plan.line_number}\tV1\tmid\tlin\t\t\t\t1\t1.000000e+03\t1.000000e+03\t1\t1\tV(mid)\t0\t\t0\t\t0\t\n"
+        "Analysis\tDirective\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\n"
+        f"noise\t.noise\t{noise_execution.plan.line_number}\tV1\tmid\tlin\t\t\t\t1\t1.000000e+03\t1.000000e+03\t\t\t\t\t\t1\t1\tV(mid)\t0\t\t0\t\t0\t\n"
     )
 
     tran_window_execution = run_deck_analysis(
@@ -6987,6 +7004,11 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
     assert tran_window_execution.plan.start_time == pytest.approx(2.0e-3)
     assert tran_window_execution.plan.max_step == pytest.approx(1.0e-3)
     assert tran_window_execution.plan.use_initial_conditions is True
+    assert tran_window_execution.run_artifacts[0].step_time == pytest.approx(2.0e-3)
+    assert tran_window_execution.run_artifacts[0].stop_time == pytest.approx(6.0e-3)
+    assert tran_window_execution.run_artifacts[0].start_time == pytest.approx(2.0e-3)
+    assert tran_window_execution.run_artifacts[0].max_step == pytest.approx(1.0e-3)
+    assert tran_window_execution.run_artifacts[0].use_initial_conditions is True
     assert tran_window_execution.output_probes == ["V(mid)"]
     assert isinstance(tran_window_execution.result, TransientResult)
     assert [point.time for point in tran_window_execution.result.points] == pytest.approx(
@@ -6997,6 +7019,10 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
         "0\t2.000000e-03\t5.000000e-01\n"
         "1\t4.000000e-03\t5.000000e-01\n"
         "2\t6.000000e-03\t5.000000e-01\n"
+    )
+    assert tran_window_execution.run_artifact_table == (
+        "Analysis\tDirective\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\n"
+        f"tran\t.tran\t{tran_window_execution.plan.line_number}\t\t\t\t\t\t\t\t\t\t2.000000e-03\t6.000000e-03\t2.000000e-03\t1.000000e-03\ttrue\t3\t1\tV(mid)\t1\t.save\t0\t\t0\t\n"
     )
 
     with pytest.raises(ValueError, match="multiple analysis cards"):
@@ -7053,13 +7079,18 @@ def test_run_deck_analysis_exposes_selected_fourier_artifacts() -> None:
     assert tran_execution.run_artifacts[0].fourier_count == 1
     assert tran_execution.run_artifacts[0].source_name is None
     assert tran_execution.run_artifacts[0].output_node is None
+    assert tran_execution.run_artifacts[0].step_time == pytest.approx(5.0e-4)
+    assert tran_execution.run_artifacts[0].stop_time == pytest.approx(1.0e-3)
+    assert tran_execution.run_artifacts[0].start_time is None
+    assert tran_execution.run_artifacts[0].max_step is None
+    assert tran_execution.run_artifacts[0].use_initial_conditions is False
     assert tran_execution.run_artifacts[0].output_probes == ["V(mid)"]
     assert tran_execution.run_artifacts[0].output_directives == [".save"]
     assert tran_execution.run_artifacts[0].measurement_names == []
     assert tran_execution.run_artifacts[0].fourier_probes == ["V(mid)"]
     assert tran_execution.run_artifact_table == (
-        "Analysis\tDirective\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\n"
-        f"tran\t.tran\t{tran_execution.plan.line_number}\t\t\t\t\t\t\t\t\t\t3\t1\tV(mid)\t1\t.save\t0\t\t1\tV(mid)\n"
+        "Analysis\tDirective\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\n"
+        f"tran\t.tran\t{tran_execution.plan.line_number}\t\t\t\t\t\t\t\t\t\t5.000000e-04\t1.000000e-03\t\t\tfalse\t3\t1\tV(mid)\t1\t.save\t0\t\t1\tV(mid)\n"
     )
 
 

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -3416,6 +3416,11 @@ pub struct DeckRunArtifact {
     pub point_count: Option<usize>,
     pub start_frequency_hz: Option<f64>,
     pub stop_frequency_hz: Option<f64>,
+    pub step_time: Option<f64>,
+    pub stop_time: Option<f64>,
+    pub start_time: Option<f64>,
+    pub max_step: Option<f64>,
+    pub use_initial_conditions: Option<bool>,
     pub result_rows: usize,
     pub output_probe_count: usize,
     pub output_probes: Vec<String>,
@@ -10092,6 +10097,7 @@ fn deck_run_artifacts(
     measurements: &[ProbeMeasurement],
     fourier: &[FourierResult],
 ) -> Vec<DeckRunArtifact> {
+    let is_transient = plan.analysis == "tran";
     vec![DeckRunArtifact {
         analysis: plan.analysis.clone(),
         directive: plan.directive.clone(),
@@ -10105,6 +10111,11 @@ fn deck_run_artifacts(
         point_count: plan.point_count,
         start_frequency_hz: plan.start_frequency_hz,
         stop_frequency_hz: plan.stop_frequency_hz,
+        step_time: is_transient.then_some(plan.step_time).flatten(),
+        stop_time: is_transient.then_some(plan.stop_time).flatten(),
+        start_time: is_transient.then_some(plan.start_time).flatten(),
+        max_step: is_transient.then_some(plan.max_step).flatten(),
+        use_initial_conditions: is_transient.then_some(plan.use_initial_conditions),
         result_rows,
         output_probe_count: output_probes.len(),
         output_probes: output_probes.to_vec(),
@@ -10127,14 +10138,18 @@ fn format_deck_artifact_float(value: Option<f64>) -> String {
     value.map(format_table_number).unwrap_or_default()
 }
 
+fn format_deck_artifact_bool(value: Option<bool>) -> String {
+    value.map(|value| value.to_string()).unwrap_or_default()
+}
+
 pub fn format_deck_run_artifact_table(artifacts: &[DeckRunArtifact]) -> String {
     let mut rows = vec![
-        "Analysis\tDirective\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList"
+        "Analysis\tDirective\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList"
             .to_string(),
     ];
     for artifact in artifacts {
         rows.push(format!(
-            "{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}",
+            "{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}",
             artifact.analysis,
             artifact.directive,
             artifact.line_number,
@@ -10150,6 +10165,11 @@ pub fn format_deck_run_artifact_table(artifacts: &[DeckRunArtifact]) -> String {
                 .unwrap_or_default(),
             format_deck_artifact_float(artifact.start_frequency_hz),
             format_deck_artifact_float(artifact.stop_frequency_hz),
+            format_deck_artifact_float(artifact.step_time),
+            format_deck_artifact_float(artifact.stop_time),
+            format_deck_artifact_float(artifact.start_time),
+            format_deck_artifact_float(artifact.max_step),
+            format_deck_artifact_bool(artifact.use_initial_conditions),
             artifact.result_rows,
             artifact.output_probe_count,
             artifact.output_probes.join(";"),

--- a/code/packages/rust/spice-engine/tests/transient_tests.rs
+++ b/code/packages/rust/spice-engine/tests/transient_tests.rs
@@ -1892,6 +1892,8 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
     assert_eq!(op_execution.run_artifacts[0].output_node, None);
     assert_eq!(op_execution.run_artifacts[0].sweep_kind, None);
     assert_eq!(op_execution.run_artifacts[0].point_count, None);
+    assert_eq!(op_execution.run_artifacts[0].step_time, None);
+    assert_eq!(op_execution.run_artifacts[0].use_initial_conditions, None);
     assert_eq!(
         op_execution.run_artifacts[0].output_probes,
         vec!["V(mid)".to_string()]
@@ -1905,7 +1907,7 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
     assert_eq!(
         op_execution.run_artifact_table,
         format!(
-            "Analysis\tDirective\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\nop\t.op\t{}\t\t\t\t\t\t\t\t\t\t1\t1\tV(mid)\t1\t.save\t0\t\t0\t\n",
+            "Analysis\tDirective\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\nop\t.op\t{}\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t1\t1\tV(mid)\t1\t.save\t0\t\t0\t\n",
             op_execution.plan.line_number
         )
     );
@@ -1938,6 +1940,8 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
     assert_eq!(dc_execution.run_artifacts[0].start_value, Some(0.0));
     assert_eq!(dc_execution.run_artifacts[0].stop_value, Some(1.0));
     assert_eq!(dc_execution.run_artifacts[0].step_value, Some(1.0));
+    assert_eq!(dc_execution.run_artifacts[0].step_time, None);
+    assert_eq!(dc_execution.run_artifacts[0].use_initial_conditions, None);
     assert_eq!(
         dc_execution.run_artifacts[0].output_probes,
         vec!["V(mid)".to_string(), "I(V1)".to_string()]
@@ -1954,7 +1958,7 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
     assert_eq!(
         dc_execution.run_artifact_table,
         format!(
-            "Analysis\tDirective\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\ndc\t.dc\t{}\tV1\t\t\t0.000000e+00\t1.000000e+00\t1.000000e+00\t\t\t\t2\t2\tV(mid);I(V1)\t2\t.save;.probe\t1\tmid_avg\t0\t\n",
+            "Analysis\tDirective\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\ndc\t.dc\t{}\tV1\t\t\t0.000000e+00\t1.000000e+00\t1.000000e+00\t\t\t\t\t\t\t\t\t2\t2\tV(mid);I(V1)\t2\t.save;.probe\t1\tmid_avg\t0\t\n",
             dc_execution.plan.line_number
         )
     );
@@ -1990,6 +1994,8 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
         Some(1.0e3)
     );
     assert_eq!(ac_execution.run_artifacts[0].stop_frequency_hz, Some(1.0e3));
+    assert_eq!(ac_execution.run_artifacts[0].step_time, None);
+    assert_eq!(ac_execution.run_artifacts[0].use_initial_conditions, None);
     assert_eq!(
         ac_execution.run_artifacts[0].output_directives,
         vec![".save".to_string()]
@@ -2002,7 +2008,7 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
     assert_eq!(
         ac_execution.run_artifact_table,
         format!(
-            "Analysis\tDirective\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\nac\t.ac\t{}\t\t\tdec\t\t\t\t1\t1.000000e+03\t1.000000e+03\t1\t1\tV(mid)\t1\t.save\t1\tmid_peak\t0\t\n",
+            "Analysis\tDirective\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\nac\t.ac\t{}\t\t\tdec\t\t\t\t1\t1.000000e+03\t1.000000e+03\t\t\t\t\t\t1\t1\tV(mid)\t1\t.save\t1\tmid_peak\t0\t\n",
             ac_execution.plan.line_number
         )
     );
@@ -2028,6 +2034,14 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
     );
     assert_eq!(tran_execution.run_artifacts[0].source_name, None);
     assert_eq!(tran_execution.run_artifacts[0].output_node, None);
+    assert_eq!(tran_execution.run_artifacts[0].step_time, Some(1.0e-3));
+    assert_eq!(tran_execution.run_artifacts[0].stop_time, Some(1.0e-3));
+    assert_eq!(tran_execution.run_artifacts[0].start_time, None);
+    assert_eq!(tran_execution.run_artifacts[0].max_step, None);
+    assert_eq!(
+        tran_execution.run_artifacts[0].use_initial_conditions,
+        Some(false)
+    );
     assert_eq!(
         tran_execution.run_artifacts[0].output_directives,
         vec![".save".to_string()]
@@ -2040,7 +2054,7 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
     assert_eq!(
         tran_execution.run_artifact_table,
         format!(
-            "Analysis\tDirective\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\ntran\t.tran\t{}\t\t\t\t\t\t\t\t\t\t1\t1\tV(mid)\t1\t.save\t1\tmid_final\t0\t\n",
+            "Analysis\tDirective\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\ntran\t.tran\t{}\t\t\t\t\t\t\t\t\t\t1.000000e-03\t1.000000e-03\t\t\tfalse\t1\t1\tV(mid)\t1\t.save\t1\tmid_final\t0\t\n",
             tran_execution.plan.line_number
         )
     );
@@ -2076,6 +2090,8 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
         Some("mid")
     );
     assert_eq!(tf_execution.run_artifacts[0].result_rows, 1);
+    assert_eq!(tf_execution.run_artifacts[0].step_time, None);
+    assert_eq!(tf_execution.run_artifacts[0].use_initial_conditions, None);
     assert_eq!(
         tf_execution.run_artifacts[0].output_probes,
         vec!["V(mid)".to_string()]
@@ -2086,7 +2102,7 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
     assert_eq!(
         tf_execution.run_artifact_table,
         format!(
-            "Analysis\tDirective\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\ntf\t.tf\t{}\tV1\tmid\t\t\t\t\t\t\t\t1\t1\tV(mid)\t0\t\t0\t\t0\t\n",
+            "Analysis\tDirective\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\ntf\t.tf\t{}\tV1\tmid\t\t\t\t\t\t\t\t\t\t\t\t\t1\t1\tV(mid)\t0\t\t0\t\t0\t\n",
             tf_execution.plan.line_number
         )
     );
@@ -2117,6 +2133,8 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
         Some("mid")
     );
     assert_eq!(sens_execution.run_artifacts[0].result_rows, 1);
+    assert_eq!(sens_execution.run_artifacts[0].step_time, None);
+    assert_eq!(sens_execution.run_artifacts[0].use_initial_conditions, None);
     assert_eq!(
         sens_execution.run_artifacts[0].output_probes,
         vec!["V(mid)".to_string()]
@@ -2127,7 +2145,7 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
     assert_eq!(
         sens_execution.run_artifact_table,
         format!(
-            "Analysis\tDirective\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\nsens\t.sens\t{}\t\tmid\t\t\t\t\t\t\t\t1\t1\tV(mid)\t0\t\t0\t\t0\t\n",
+            "Analysis\tDirective\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\nsens\t.sens\t{}\t\tmid\t\t\t\t\t\t\t\t\t\t\t\t\t1\t1\tV(mid)\t0\t\t0\t\t0\t\n",
             sens_execution.plan.line_number
         )
     );
@@ -2180,6 +2198,11 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
         Some(1.0e3)
     );
     assert_eq!(noise_execution.run_artifacts[0].result_rows, 1);
+    assert_eq!(noise_execution.run_artifacts[0].step_time, None);
+    assert_eq!(
+        noise_execution.run_artifacts[0].use_initial_conditions,
+        None
+    );
     assert_eq!(
         noise_execution.run_artifacts[0].output_probes,
         vec!["V(mid)".to_string()]
@@ -2194,7 +2217,7 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
     assert_eq!(
         noise_execution.run_artifact_table,
         format!(
-            "Analysis\tDirective\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\nnoise\t.noise\t{}\tV1\tmid\tlin\t\t\t\t1\t1.000000e+03\t1.000000e+03\t1\t1\tV(mid)\t0\t\t0\t\t0\t\n",
+            "Analysis\tDirective\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\nnoise\t.noise\t{}\tV1\tmid\tlin\t\t\t\t1\t1.000000e+03\t1.000000e+03\t\t\t\t\t\t1\t1\tV(mid)\t0\t\t0\t\t0\t\n",
             noise_execution.plan.line_number
         )
     );
@@ -2208,6 +2231,26 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
     assert!((tran_window_execution.plan.start_time.unwrap() - 2.0e-3).abs() < 1.0e-12);
     assert!((tran_window_execution.plan.max_step.unwrap() - 1.0e-3).abs() < 1.0e-12);
     assert!(tran_window_execution.plan.use_initial_conditions);
+    assert_eq!(
+        tran_window_execution.run_artifacts[0].step_time,
+        Some(2.0e-3)
+    );
+    assert_eq!(
+        tran_window_execution.run_artifacts[0].stop_time,
+        Some(6.0e-3)
+    );
+    assert_eq!(
+        tran_window_execution.run_artifacts[0].start_time,
+        Some(2.0e-3)
+    );
+    assert_eq!(
+        tran_window_execution.run_artifacts[0].max_step,
+        Some(1.0e-3)
+    );
+    assert_eq!(
+        tran_window_execution.run_artifacts[0].use_initial_conditions,
+        Some(true)
+    );
     assert_eq!(
         tran_window_execution.output_probes,
         vec!["V(mid)".to_string()]
@@ -2225,6 +2268,13 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
     assert_eq!(
         tran_window_execution.table,
         "Index\tTime\tV(mid)\n0\t2.000000e-03\t5.000000e-01\n1\t4.000000e-03\t5.000000e-01\n2\t6.000000e-03\t5.000000e-01\n"
+    );
+    assert_eq!(
+        tran_window_execution.run_artifact_table,
+        format!(
+            "Analysis\tDirective\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\ntran\t.tran\t{}\t\t\t\t\t\t\t\t\t\t2.000000e-03\t6.000000e-03\t2.000000e-03\t1.000000e-03\ttrue\t3\t1\tV(mid)\t1\t.save\t0\t\t0\t\n",
+            tran_window_execution.plan.line_number
+        )
     );
 
     let error = run_deck_analysis(&circuit, netlist, None).unwrap_err();
@@ -2299,6 +2349,14 @@ fn run_deck_analysis_exposes_selected_fourier_artifacts() {
     assert_eq!(tran_execution.run_artifacts[0].fourier_count, 1);
     assert_eq!(tran_execution.run_artifacts[0].source_name, None);
     assert_eq!(tran_execution.run_artifacts[0].output_node, None);
+    assert_eq!(tran_execution.run_artifacts[0].step_time, Some(5.0e-4));
+    assert_eq!(tran_execution.run_artifacts[0].stop_time, Some(1.0e-3));
+    assert_eq!(tran_execution.run_artifacts[0].start_time, None);
+    assert_eq!(tran_execution.run_artifacts[0].max_step, None);
+    assert_eq!(
+        tran_execution.run_artifacts[0].use_initial_conditions,
+        Some(false)
+    );
     assert_eq!(
         tran_execution.run_artifacts[0].output_probes,
         vec!["V(mid)".to_string()]
@@ -2315,7 +2373,7 @@ fn run_deck_analysis_exposes_selected_fourier_artifacts() {
     assert_eq!(
         tran_execution.run_artifact_table,
         format!(
-            "Analysis\tDirective\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\ntran\t.tran\t{}\t\t\t\t\t\t\t\t\t\t2\t1\tV(mid)\t1\t.save\t0\t\t1\tV(mid)\n",
+            "Analysis\tDirective\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\ntran\t.tran\t{}\t\t\t\t\t\t\t\t\t\t5.000000e-04\t1.000000e-03\t\t\tfalse\t2\t1\tV(mid)\t1\t.save\t0\t\t1\tV(mid)\n",
             tran_execution.plan.line_number
         )
     );

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -671,6 +671,11 @@ export interface DeckRunArtifact {
   readonly pointCount?: number;
   readonly startFrequencyHz?: number;
   readonly stopFrequencyHz?: number;
+  readonly stepTime?: number;
+  readonly stopTime?: number;
+  readonly startTime?: number;
+  readonly maxStep?: number;
+  readonly useInitialConditions?: boolean;
   readonly resultRows: number;
   readonly outputProbeCount: number;
   readonly outputProbes: readonly string[];
@@ -7879,6 +7884,7 @@ function deckRunArtifacts(
   measurements: readonly ProbeMeasurement[],
   fourier: readonly FourierResult[],
 ): DeckRunArtifact[] {
+  const isTransient = plan.analysis === "tran";
   return [
     {
       analysis: plan.analysis,
@@ -7893,6 +7899,11 @@ function deckRunArtifacts(
       pointCount: plan.pointCount,
       startFrequencyHz: plan.startFrequencyHz,
       stopFrequencyHz: plan.stopFrequencyHz,
+      stepTime: isTransient ? plan.stepTime : undefined,
+      stopTime: isTransient ? plan.stopTime : undefined,
+      startTime: isTransient ? plan.startTime : undefined,
+      maxStep: isTransient ? plan.maxStep : undefined,
+      useInitialConditions: isTransient ? plan.useInitialConditions : undefined,
       resultRows: deckResultRowCount(result),
       outputProbeCount: outputProbes.length,
       outputProbes: [...outputProbes],
@@ -7910,9 +7921,13 @@ function formatDeckArtifactFloat(value: number | undefined): string {
   return value === undefined ? "" : formatTableNumber(value);
 }
 
+function formatDeckArtifactBoolean(value: boolean | undefined): string {
+  return value === undefined ? "" : String(value);
+}
+
 export function formatDeckRunArtifactTable(artifacts: readonly DeckRunArtifact[]): string {
   const rows = [
-    "Analysis\tDirective\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList",
+    "Analysis\tDirective\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList",
   ];
   for (const artifact of artifacts) {
     rows.push(
@@ -7929,6 +7944,11 @@ export function formatDeckRunArtifactTable(artifacts: readonly DeckRunArtifact[]
         artifact.pointCount === undefined ? "" : String(artifact.pointCount),
         formatDeckArtifactFloat(artifact.startFrequencyHz),
         formatDeckArtifactFloat(artifact.stopFrequencyHz),
+        formatDeckArtifactFloat(artifact.stepTime),
+        formatDeckArtifactFloat(artifact.stopTime),
+        formatDeckArtifactFloat(artifact.startTime),
+        formatDeckArtifactFloat(artifact.maxStep),
+        formatDeckArtifactBoolean(artifact.useInitialConditions),
         String(artifact.resultRows),
         String(artifact.outputProbeCount),
         artifact.outputProbes.join(";"),

--- a/code/packages/typescript/spice-engine/tests/transient.test.ts
+++ b/code/packages/typescript/spice-engine/tests/transient.test.ts
@@ -1473,13 +1473,15 @@ describe("transient", () => {
     expect(opExecution.runArtifacts[0]?.outputNode).toBeUndefined();
     expect(opExecution.runArtifacts[0]?.sweepKind).toBeUndefined();
     expect(opExecution.runArtifacts[0]?.pointCount).toBeUndefined();
+    expect(opExecution.runArtifacts[0]?.stepTime).toBeUndefined();
+    expect(opExecution.runArtifacts[0]?.useInitialConditions).toBeUndefined();
     expect(opExecution.runArtifacts[0]?.outputProbes).toEqual(["V(mid)"]);
     expect(opExecution.runArtifacts[0]?.outputDirectives).toEqual([".save"]);
     expect(opExecution.runArtifacts[0]?.measurementNames).toEqual([]);
     expect(opExecution.runArtifacts[0]?.fourierProbes).toEqual([]);
     expect(opExecution.runArtifactTable).toBe(
-      "Analysis\tDirective\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\n" +
-        `op\t.op\t${opExecution.plan.lineNumber}\t\t\t\t\t\t\t\t\t\t1\t1\tV(mid)\t1\t.save\t0\t\t0\t\n`,
+      "Analysis\tDirective\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\n" +
+        `op\t.op\t${opExecution.plan.lineNumber}\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t1\t1\tV(mid)\t1\t.save\t0\t\t0\t\n`,
     );
 
     const dcExecution = runDeckAnalysis(circuit, netlist, "dc");
@@ -1502,13 +1504,15 @@ describe("transient", () => {
     expect(dcExecution.runArtifacts[0]?.startValue).toBeCloseTo(0.0, 12);
     expect(dcExecution.runArtifacts[0]?.stopValue).toBeCloseTo(1.0, 12);
     expect(dcExecution.runArtifacts[0]?.stepValue).toBeCloseTo(1.0, 12);
+    expect(dcExecution.runArtifacts[0]?.stepTime).toBeUndefined();
+    expect(dcExecution.runArtifacts[0]?.useInitialConditions).toBeUndefined();
     expect(dcExecution.runArtifacts[0]?.outputProbes).toEqual(["V(mid)", "I(V1)"]);
     expect(dcExecution.runArtifacts[0]?.outputDirectives).toEqual([".save", ".probe"]);
     expect(dcExecution.runArtifacts[0]?.measurementNames).toEqual(["mid_avg"]);
     expect(dcExecution.runArtifacts[0]?.fourierProbes).toEqual([]);
     expect(dcExecution.runArtifactTable).toBe(
-      "Analysis\tDirective\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\n" +
-        `dc\t.dc\t${dcExecution.plan.lineNumber}\tV1\t\t\t0.000000e+00\t1.000000e+00\t1.000000e+00\t\t\t\t2\t2\tV(mid);I(V1)\t2\t.save;.probe\t1\tmid_avg\t0\t\n`,
+      "Analysis\tDirective\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\n" +
+        `dc\t.dc\t${dcExecution.plan.lineNumber}\tV1\t\t\t0.000000e+00\t1.000000e+00\t1.000000e+00\t\t\t\t\t\t\t\t\t2\t2\tV(mid);I(V1)\t2\t.save;.probe\t1\tmid_avg\t0\t\n`,
     );
 
     const acExecution = runDeckAnalysis(circuit, netlist, "ac");
@@ -1530,12 +1534,14 @@ describe("transient", () => {
     expect(acExecution.runArtifacts[0]?.pointCount).toBe(1);
     expect(acExecution.runArtifacts[0]?.startFrequencyHz).toBeCloseTo(1.0e3, 9);
     expect(acExecution.runArtifacts[0]?.stopFrequencyHz).toBeCloseTo(1.0e3, 9);
+    expect(acExecution.runArtifacts[0]?.stepTime).toBeUndefined();
+    expect(acExecution.runArtifacts[0]?.useInitialConditions).toBeUndefined();
     expect(acExecution.runArtifacts[0]?.outputDirectives).toEqual([".save"]);
     expect(acExecution.runArtifacts[0]?.measurementNames).toEqual(["mid_peak"]);
     expect(acExecution.runArtifacts[0]?.fourierProbes).toEqual([]);
     expect(acExecution.runArtifactTable).toBe(
-      "Analysis\tDirective\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\n" +
-        `ac\t.ac\t${acExecution.plan.lineNumber}\t\t\tdec\t\t\t\t1\t1.000000e+03\t1.000000e+03\t1\t1\tV(mid)\t1\t.save\t1\tmid_peak\t0\t\n`,
+      "Analysis\tDirective\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\n" +
+        `ac\t.ac\t${acExecution.plan.lineNumber}\t\t\tdec\t\t\t\t1\t1.000000e+03\t1.000000e+03\t\t\t\t\t\t1\t1\tV(mid)\t1\t.save\t1\tmid_peak\t0\t\n`,
     );
 
     const tranExecution = runDeckAnalysis(circuit, netlist, "tran");
@@ -1553,12 +1559,17 @@ describe("transient", () => {
     expect(tranExecution.runArtifacts[0]?.outputProbes).toEqual(["V(mid)"]);
     expect(tranExecution.runArtifacts[0]?.sourceName).toBeUndefined();
     expect(tranExecution.runArtifacts[0]?.outputNode).toBeUndefined();
+    expect(tranExecution.runArtifacts[0]?.stepTime).toBeCloseTo(1.0e-3, 12);
+    expect(tranExecution.runArtifacts[0]?.stopTime).toBeCloseTo(1.0e-3, 12);
+    expect(tranExecution.runArtifacts[0]?.startTime).toBeUndefined();
+    expect(tranExecution.runArtifacts[0]?.maxStep).toBeUndefined();
+    expect(tranExecution.runArtifacts[0]?.useInitialConditions).toBe(false);
     expect(tranExecution.runArtifacts[0]?.outputDirectives).toEqual([".save"]);
     expect(tranExecution.runArtifacts[0]?.measurementNames).toEqual(["mid_final"]);
     expect(tranExecution.runArtifacts[0]?.fourierProbes).toEqual([]);
     expect(tranExecution.runArtifactTable).toBe(
-      "Analysis\tDirective\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\n" +
-        `tran\t.tran\t${tranExecution.plan.lineNumber}\t\t\t\t\t\t\t\t\t\t1\t1\tV(mid)\t1\t.save\t1\tmid_final\t0\t\n`,
+      "Analysis\tDirective\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\n" +
+        `tran\t.tran\t${tranExecution.plan.lineNumber}\t\t\t\t\t\t\t\t\t\t1.000000e-03\t1.000000e-03\t\t\tfalse\t1\t1\tV(mid)\t1\t.save\t1\tmid_final\t0\t\n`,
     );
 
     const tfExecution = runDeckAnalysis(circuit, netlist, "tf");
@@ -1583,13 +1594,15 @@ describe("transient", () => {
     expect(tfExecution.runArtifacts[0]?.sourceName).toBe("V1");
     expect(tfExecution.runArtifacts[0]?.outputNode).toBe("mid");
     expect(tfExecution.runArtifacts[0]?.resultRows).toBe(1);
+    expect(tfExecution.runArtifacts[0]?.stepTime).toBeUndefined();
+    expect(tfExecution.runArtifacts[0]?.useInitialConditions).toBeUndefined();
     expect(tfExecution.runArtifacts[0]?.outputProbes).toEqual(["V(mid)"]);
     expect(tfExecution.runArtifacts[0]?.outputDirectives).toEqual([]);
     expect(tfExecution.runArtifacts[0]?.measurementNames).toEqual([]);
     expect(tfExecution.runArtifacts[0]?.fourierProbes).toEqual([]);
     expect(tfExecution.runArtifactTable).toBe(
-      "Analysis\tDirective\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\n" +
-        `tf\t.tf\t${tfExecution.plan.lineNumber}\tV1\tmid\t\t\t\t\t\t\t\t1\t1\tV(mid)\t0\t\t0\t\t0\t\n`,
+      "Analysis\tDirective\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\n" +
+        `tf\t.tf\t${tfExecution.plan.lineNumber}\tV1\tmid\t\t\t\t\t\t\t\t\t\t\t\t\t1\t1\tV(mid)\t0\t\t0\t\t0\t\n`,
     );
 
     const sensExecution = runDeckAnalysis(circuit, netlist, "sens");
@@ -1611,13 +1624,15 @@ describe("transient", () => {
     expect(sensExecution.runArtifacts[0]?.sourceName).toBeUndefined();
     expect(sensExecution.runArtifacts[0]?.outputNode).toBe("mid");
     expect(sensExecution.runArtifacts[0]?.resultRows).toBe(1);
+    expect(sensExecution.runArtifacts[0]?.stepTime).toBeUndefined();
+    expect(sensExecution.runArtifacts[0]?.useInitialConditions).toBeUndefined();
     expect(sensExecution.runArtifacts[0]?.outputProbes).toEqual(["V(mid)"]);
     expect(sensExecution.runArtifacts[0]?.outputDirectives).toEqual([]);
     expect(sensExecution.runArtifacts[0]?.measurementNames).toEqual([]);
     expect(sensExecution.runArtifacts[0]?.fourierProbes).toEqual([]);
     expect(sensExecution.runArtifactTable).toBe(
-      "Analysis\tDirective\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\n" +
-        `sens\t.sens\t${sensExecution.plan.lineNumber}\t\tmid\t\t\t\t\t\t\t\t1\t1\tV(mid)\t0\t\t0\t\t0\t\n`,
+      "Analysis\tDirective\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\n" +
+        `sens\t.sens\t${sensExecution.plan.lineNumber}\t\tmid\t\t\t\t\t\t\t\t\t\t\t\t\t1\t1\tV(mid)\t0\t\t0\t\t0\t\n`,
     );
 
     const noiseExecution = runDeckAnalysis(circuit, netlist, "noise");
@@ -1646,13 +1661,15 @@ describe("transient", () => {
     expect(noiseExecution.runArtifacts[0]?.startFrequencyHz).toBeCloseTo(1.0e3, 9);
     expect(noiseExecution.runArtifacts[0]?.stopFrequencyHz).toBeCloseTo(1.0e3, 9);
     expect(noiseExecution.runArtifacts[0]?.resultRows).toBe(1);
+    expect(noiseExecution.runArtifacts[0]?.stepTime).toBeUndefined();
+    expect(noiseExecution.runArtifacts[0]?.useInitialConditions).toBeUndefined();
     expect(noiseExecution.runArtifacts[0]?.outputProbes).toEqual(["V(mid)"]);
     expect(noiseExecution.runArtifacts[0]?.outputDirectives).toEqual([]);
     expect(noiseExecution.runArtifacts[0]?.measurementNames).toEqual([]);
     expect(noiseExecution.runArtifacts[0]?.fourierProbes).toEqual([]);
     expect(noiseExecution.runArtifactTable).toBe(
-      "Analysis\tDirective\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\n" +
-        `noise\t.noise\t${noiseExecution.plan.lineNumber}\tV1\tmid\tlin\t\t\t\t1\t1.000000e+03\t1.000000e+03\t1\t1\tV(mid)\t0\t\t0\t\t0\t\n`,
+      "Analysis\tDirective\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\n" +
+        `noise\t.noise\t${noiseExecution.plan.lineNumber}\tV1\tmid\tlin\t\t\t\t1\t1.000000e+03\t1.000000e+03\t\t\t\t\t\t1\t1\tV(mid)\t0\t\t0\t\t0\t\n`,
     );
 
     const tranWindowExecution = runDeckAnalysis(
@@ -1662,6 +1679,11 @@ describe("transient", () => {
     expect(tranWindowExecution.plan.startTime).toBeCloseTo(2.0e-3, 12);
     expect(tranWindowExecution.plan.maxStep).toBeCloseTo(1.0e-3, 12);
     expect(tranWindowExecution.plan.useInitialConditions).toBe(true);
+    expect(tranWindowExecution.runArtifacts[0]?.stepTime).toBeCloseTo(2.0e-3, 12);
+    expect(tranWindowExecution.runArtifacts[0]?.stopTime).toBeCloseTo(6.0e-3, 12);
+    expect(tranWindowExecution.runArtifacts[0]?.startTime).toBeCloseTo(2.0e-3, 12);
+    expect(tranWindowExecution.runArtifacts[0]?.maxStep).toBeCloseTo(1.0e-3, 12);
+    expect(tranWindowExecution.runArtifacts[0]?.useInitialConditions).toBe(true);
     expect(tranWindowExecution.outputProbes).toEqual(["V(mid)"]);
     const tranWindowPoints = tranWindowExecution.result as { time: number }[];
     expect(tranWindowPoints).toHaveLength(3);
@@ -1677,6 +1699,10 @@ describe("transient", () => {
         "0\t2.000000e-03\t5.000000e-01\n" +
         "1\t4.000000e-03\t5.000000e-01\n" +
         "2\t6.000000e-03\t5.000000e-01\n",
+    );
+    expect(tranWindowExecution.runArtifactTable).toBe(
+      "Analysis\tDirective\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\n" +
+        `tran\t.tran\t${tranWindowExecution.plan.lineNumber}\t\t\t\t\t\t\t\t\t\t2.000000e-03\t6.000000e-03\t2.000000e-03\t1.000000e-03\ttrue\t3\t1\tV(mid)\t1\t.save\t0\t\t0\t\n`,
     );
 
     expect(() => runDeckAnalysis(circuit, netlist)).toThrow(/multiple analysis cards/);
@@ -1731,13 +1757,18 @@ describe("transient", () => {
     expect(tranExecution.runArtifacts[0]?.fourierCount).toBe(1);
     expect(tranExecution.runArtifacts[0]?.sourceName).toBeUndefined();
     expect(tranExecution.runArtifacts[0]?.outputNode).toBeUndefined();
+    expect(tranExecution.runArtifacts[0]?.stepTime).toBeCloseTo(5.0e-4, 12);
+    expect(tranExecution.runArtifacts[0]?.stopTime).toBeCloseTo(1.0e-3, 12);
+    expect(tranExecution.runArtifacts[0]?.startTime).toBeUndefined();
+    expect(tranExecution.runArtifacts[0]?.maxStep).toBeUndefined();
+    expect(tranExecution.runArtifacts[0]?.useInitialConditions).toBe(false);
     expect(tranExecution.runArtifacts[0]?.outputProbes).toEqual(["V(mid)"]);
     expect(tranExecution.runArtifacts[0]?.outputDirectives).toEqual([".save"]);
     expect(tranExecution.runArtifacts[0]?.measurementNames).toEqual([]);
     expect(tranExecution.runArtifacts[0]?.fourierProbes).toEqual(["V(mid)"]);
     expect(tranExecution.runArtifactTable).toBe(
-      "Analysis\tDirective\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\n" +
-        `tran\t.tran\t${tranExecution.plan.lineNumber}\t\t\t\t\t\t\t\t\t\t2\t1\tV(mid)\t1\t.save\t0\t\t1\tV(mid)\n`,
+      "Analysis\tDirective\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\n" +
+        `tran\t.tran\t${tranExecution.plan.lineNumber}\t\t\t\t\t\t\t\t\t\t5.000000e-04\t1.000000e-03\t\t\tfalse\t2\t1\tV(mid)\t1\t.save\t0\t\t1\tV(mid)\n`,
     );
   });
 

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -824,6 +824,15 @@ downstream tools to compare.
     - The stable run-artifact table now includes `OutputNode`, with an empty
       cell for analysis cards that do not select a single output node.
 
+75. Deck run transient timing artifacts.
+    - Status: completed in this deck run transient timing artifact slice.
+    - Python, Rust, and TypeScript selected deck executions now copy `.tran`
+      timing controls into deck-run artifacts, preserving print step, stop
+      time, optional start and max step, and UIC intent.
+    - The stable run-artifact table now includes `StepTime`, `StopTime`,
+      `StartTime`, `MaxStep`, and `UseInitialConditions`, with empty cells for
+      non-transient analyses.
+
 ## Backlog
 
 1. Deck execution layer.


### PR DESCRIPTION
## Summary
- expose selected `.tran` timing metadata in Python/Rust/TypeScript deck run artifacts
- add `StepTime`, `StopTime`, `StartTime`, `MaxStep`, and `UseInitialConditions` to stable run-artifact tables
- document completed SPICE plan item 75 for transient timing artifacts

## Verification
- `cargo fmt --manifest-path code/packages/rust/spice-engine/Cargo.toml -- --check`
- `/Users/adhithya/.local/share/mise/installs/python/3.12.13/bin/ruff check code/packages/python/spice-engine`
- `PYTEST_ADDOPTS=--no-cov PYTHONPATH=code/packages/python/device-physics/src:code/packages/python/mosfet-models/src:code/packages/python/spice-engine/src /Users/adhithya/.local/share/mise/installs/python/3.12.13/bin/python3.12 -m pytest code/packages/python/spice-engine/tests/test_compatibility.py code/packages/python/spice-engine/tests/test_engine.py -q`
- `cargo test --manifest-path code/packages/rust/spice-engine/Cargo.toml`
- `PATH=/Users/adhithya/.local/share/mise/installs/node/22.22.3/bin:$PATH npm --prefix code/packages/typescript/spice-engine run build`
- `PATH=/Users/adhithya/.local/share/mise/installs/node/22.22.3/bin:$PATH npm --prefix code/packages/typescript/spice-engine test`