### PR TITLE
Add mesh preflight execution readiness summary

### DIFF
--- a/code/packages/rust/smart-home-integration-catalog/CHANGELOG.md
+++ b/code/packages/rust/smart-home-integration-catalog/CHANGELOG.md
@@ -98,6 +98,8 @@ All notable changes to this package will be documented in this file.
 - `IntegrationMeshPreflightSlotReadinessSummary` and helpers for combining mesh
   preflight schedule readiness with repair-slot audit blockers and operator
   handoff counts.
+- `IntegrationMeshPreflightExecutionReadinessSummary` and helpers for combining
+  mesh preflight slot readiness with operator-ready execution ticket counts.
 - `IntegrationMeshReadinessHandoffPackage`, summary helpers, and D23 mesh
   readiness handoff projections for release coordination across substrate
   actions, evidence remediation, and release-ready state.

--- a/code/packages/rust/smart-home-integration-catalog/README.md
+++ b/code/packages/rust/smart-home-integration-catalog/README.md
@@ -83,6 +83,8 @@ runtime and Chief of Staff tools a typed catalog for:
   readiness with deterministic repair execution slots
 - mesh preflight slot readiness summaries that combine schedule readiness with
   slot-audit blocker and operator handoff counts
+- mesh preflight execution readiness summaries that combine slot readiness
+  with operator-ready execution ticket counts
 - mesh readiness handoff packages that project substrate actions, evidence
   remediation, and release-ready state for reusable release coordination
 - mesh release-readiness checks that summarize substrate action, evidence,

--- a/code/packages/rust/smart-home-integration-catalog/src/lib.rs
+++ b/code/packages/rust/smart-home-integration-catalog/src/lib.rs
@@ -2123,6 +2123,97 @@ impl IntegrationMeshPreflightSlotReadinessSummary {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IntegrationMeshPreflightExecutionReadinessSummary {
+    pub slot_readiness_summary: IntegrationMeshPreflightSlotReadinessSummary,
+    pub execution_ticket_summary:
+        IntegrationMeshProtocolSubstratePreflightRepairSlotExecutionTicketSummary,
+    pub total_protocols: usize,
+    pub total_preflight_checks: usize,
+    pub preflight_blocker_count: usize,
+    pub release_blocker_count: usize,
+    pub queued_preflight_actions: usize,
+    pub repair_batch_count: usize,
+    pub repair_slot_count: usize,
+    pub scheduled_preflight_actions: usize,
+    pub slot_audit_rows: usize,
+    pub execution_ticket_count: usize,
+    pub ticketed_preflight_actions: usize,
+    pub blocking_execution_tickets: usize,
+    pub operator_required_execution_tickets: usize,
+    pub first_execution_ticket_key: Option<String>,
+    pub first_blocking_execution_ticket_key: Option<String>,
+    pub first_operator_execution_ticket_key: Option<String>,
+    pub first_execution_ticket_stage: Option<IntegrationMeshProtocolSubstrateStage>,
+    pub first_execution_ticket_action_kind:
+        Option<IntegrationMeshProtocolSubstratePreflightActionKind>,
+    pub preflight_ready: bool,
+    pub repair_actions_ready: bool,
+    pub repair_batches_ready: bool,
+    pub repair_schedule_ready: bool,
+    pub repair_slot_audit_ready: bool,
+    pub execution_tickets_ready: bool,
+    pub release_ready: bool,
+    pub ready_for_release: bool,
+}
+
+impl IntegrationMeshPreflightExecutionReadinessSummary {
+    pub fn from_parts(
+        slot_readiness_summary: IntegrationMeshPreflightSlotReadinessSummary,
+        execution_ticket_summary: IntegrationMeshProtocolSubstratePreflightRepairSlotExecutionTicketSummary,
+    ) -> Self {
+        let execution_tickets_ready = execution_ticket_summary.execution_tickets_ready;
+        let ready_for_release = slot_readiness_summary.ready_for_release && execution_tickets_ready;
+
+        Self {
+            total_protocols: slot_readiness_summary.total_protocols,
+            total_preflight_checks: slot_readiness_summary.total_preflight_checks,
+            preflight_blocker_count: slot_readiness_summary.preflight_blocker_count,
+            release_blocker_count: slot_readiness_summary.release_blocker_count,
+            queued_preflight_actions: slot_readiness_summary.queued_preflight_actions,
+            repair_batch_count: slot_readiness_summary.repair_batch_count,
+            repair_slot_count: slot_readiness_summary.repair_slot_count,
+            scheduled_preflight_actions: slot_readiness_summary.scheduled_preflight_actions,
+            slot_audit_rows: slot_readiness_summary.slot_audit_rows,
+            execution_ticket_count: execution_ticket_summary.total_tickets,
+            ticketed_preflight_actions: execution_ticket_summary.scheduled_actions,
+            blocking_execution_tickets: execution_ticket_summary.blocking_tickets,
+            operator_required_execution_tickets: execution_ticket_summary.operator_required_tickets,
+            first_execution_ticket_key: execution_ticket_summary.first_ticket_key.clone(),
+            first_blocking_execution_ticket_key: execution_ticket_summary
+                .first_blocking_ticket_key
+                .clone(),
+            first_operator_execution_ticket_key: execution_ticket_summary
+                .first_operator_ticket_key
+                .clone(),
+            first_execution_ticket_stage: execution_ticket_summary.first_stage,
+            first_execution_ticket_action_kind: execution_ticket_summary.first_action_kind,
+            preflight_ready: slot_readiness_summary.preflight_ready,
+            repair_actions_ready: slot_readiness_summary.repair_actions_ready,
+            repair_batches_ready: slot_readiness_summary.repair_batches_ready,
+            repair_schedule_ready: slot_readiness_summary.repair_schedule_ready,
+            repair_slot_audit_ready: slot_readiness_summary.repair_slot_audit_ready,
+            release_ready: slot_readiness_summary.release_ready,
+            slot_readiness_summary,
+            execution_ticket_summary,
+            execution_tickets_ready,
+            ready_for_release,
+        }
+    }
+
+    pub fn has_execution_tickets(&self) -> bool {
+        self.execution_ticket_count > 0
+    }
+
+    pub fn has_blockers(&self) -> bool {
+        !self.ready_for_release
+    }
+
+    pub fn needs_operator(&self) -> bool {
+        self.operator_required_execution_tickets > 0 || self.slot_readiness_summary.needs_operator()
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum IntegrationMeshReadinessHandoffKind {
     SubstrateAction,
@@ -23071,6 +23162,43 @@ pub fn mesh_preflight_slot_readiness_summary(
     )
 }
 
+pub fn mesh_preflight_execution_readiness_summary_for_catalog(
+    catalog: &[IntegrationCatalogEntry],
+    available_primitives: &[PrimitiveFamily],
+    allowed_capabilities: &[CapabilityId],
+    enabled_integrations: &[IntegrationId],
+) -> IntegrationMeshPreflightExecutionReadinessSummary {
+    let slot_readiness_summary = mesh_preflight_slot_readiness_summary_for_catalog(
+        catalog,
+        available_primitives,
+        allowed_capabilities,
+        enabled_integrations,
+    );
+    let execution_ticket_summary =
+        mesh_protocol_substrate_preflight_repair_slot_execution_ticket_summary(
+            available_primitives,
+        );
+
+    IntegrationMeshPreflightExecutionReadinessSummary::from_parts(
+        slot_readiness_summary,
+        execution_ticket_summary,
+    )
+}
+
+pub fn mesh_preflight_execution_readiness_summary(
+    available_primitives: &[PrimitiveFamily],
+    allowed_capabilities: &[CapabilityId],
+    enabled_integrations: &[IntegrationId],
+) -> IntegrationMeshPreflightExecutionReadinessSummary {
+    let catalog = first_party_catalog();
+    mesh_preflight_execution_readiness_summary_for_catalog(
+        &catalog,
+        available_primitives,
+        allowed_capabilities,
+        enabled_integrations,
+    )
+}
+
 fn mesh_readiness_handoff_packages_from_summary(
     summary: &IntegrationMeshActionReadinessSummary,
     actions: &[IntegrationMeshProtocolSubstrateAction],
@@ -30803,6 +30931,112 @@ mod tests {
         assert!(summary.release_ready);
         assert!(summary.ready_for_release);
         assert!(!summary.has_slot_audit_rows());
+        assert!(!summary.has_blockers());
+        assert!(!summary.needs_operator());
+    }
+
+    #[test]
+    fn mesh_preflight_execution_readiness_summary_surfaces_execution_tickets() {
+        let available_primitives = vec![
+            PrimitiveFamily::Usb,
+            PrimitiveFamily::SerialController,
+            PrimitiveFamily::Radio802154,
+            PrimitiveFamily::Supervision,
+        ];
+        let allowed_capabilities = vec![CapabilityId::trusted("smart_home.read")];
+        let summary = mesh_preflight_execution_readiness_summary(
+            &available_primitives,
+            &allowed_capabilities,
+            &[],
+        );
+
+        assert_eq!(summary.total_protocols, 3);
+        assert_eq!(summary.total_preflight_checks, 16);
+        assert_eq!(summary.preflight_blocker_count, 5);
+        assert_eq!(summary.queued_preflight_actions, 5);
+        assert_eq!(summary.repair_slot_count, 3);
+        assert_eq!(summary.scheduled_preflight_actions, 5);
+        assert_eq!(summary.slot_audit_rows, 3);
+        assert_eq!(summary.execution_ticket_count, 3);
+        assert_eq!(summary.ticketed_preflight_actions, 5);
+        assert_eq!(summary.blocking_execution_tickets, 3);
+        assert_eq!(summary.operator_required_execution_tickets, 2);
+        assert_eq!(
+            summary.first_execution_ticket_key,
+            Some("slot-01-radio-provision_radio".to_string())
+        );
+        assert_eq!(
+            summary.first_blocking_execution_ticket_key,
+            Some("slot-01-radio-provision_radio".to_string())
+        );
+        assert_eq!(
+            summary.first_operator_execution_ticket_key,
+            Some("slot-01-radio-provision_radio".to_string())
+        );
+        assert_eq!(
+            summary.first_execution_ticket_stage,
+            Some(IntegrationMeshProtocolSubstrateStage::Radio)
+        );
+        assert_eq!(
+            summary.first_execution_ticket_action_kind,
+            Some(IntegrationMeshProtocolSubstratePreflightActionKind::ProvisionRadio)
+        );
+        assert!(!summary.preflight_ready);
+        assert!(!summary.repair_actions_ready);
+        assert!(!summary.repair_batches_ready);
+        assert!(!summary.repair_schedule_ready);
+        assert!(!summary.repair_slot_audit_ready);
+        assert!(!summary.execution_tickets_ready);
+        assert!(!summary.ready_for_release);
+        assert!(summary.has_execution_tickets());
+        assert!(summary.has_blockers());
+        assert!(summary.needs_operator());
+        assert_eq!(
+            summary.execution_ticket_summary.first_ticket_key,
+            summary.first_execution_ticket_key
+        );
+    }
+
+    #[test]
+    fn mesh_preflight_execution_readiness_summary_marks_ready_release() {
+        let catalog = vec![hue_entry()];
+        let allowed_capabilities = vec![
+            CapabilityId::trusted("smart_home.read"),
+            CapabilityId::trusted("smart_home.command.light"),
+            CapabilityId::trusted("smart_home.pair"),
+        ];
+        let summary = mesh_preflight_execution_readiness_summary_for_catalog(
+            &catalog,
+            all_primitive_families(),
+            &allowed_capabilities,
+            &[],
+        );
+
+        assert_eq!(summary.total_protocols, 3);
+        assert_eq!(summary.preflight_blocker_count, 0);
+        assert_eq!(summary.release_blocker_count, 0);
+        assert_eq!(summary.queued_preflight_actions, 0);
+        assert_eq!(summary.repair_slot_count, 0);
+        assert_eq!(summary.scheduled_preflight_actions, 0);
+        assert_eq!(summary.slot_audit_rows, 0);
+        assert_eq!(summary.execution_ticket_count, 0);
+        assert_eq!(summary.ticketed_preflight_actions, 0);
+        assert_eq!(summary.blocking_execution_tickets, 0);
+        assert_eq!(summary.operator_required_execution_tickets, 0);
+        assert_eq!(summary.first_execution_ticket_key, None);
+        assert_eq!(summary.first_blocking_execution_ticket_key, None);
+        assert_eq!(summary.first_operator_execution_ticket_key, None);
+        assert_eq!(summary.first_execution_ticket_stage, None);
+        assert_eq!(summary.first_execution_ticket_action_kind, None);
+        assert!(summary.preflight_ready);
+        assert!(summary.repair_actions_ready);
+        assert!(summary.repair_batches_ready);
+        assert!(summary.repair_schedule_ready);
+        assert!(summary.repair_slot_audit_ready);
+        assert!(summary.execution_tickets_ready);
+        assert!(summary.release_ready);
+        assert!(summary.ready_for_release);
+        assert!(!summary.has_execution_tickets());
         assert!(!summary.has_blockers());
         assert!(!summary.needs_operator());
     }


### PR DESCRIPTION
## Summary
- add a higher-level mesh preflight execution readiness summary over slot readiness and execution-ticket counts
- expose execution-ticket counts, blocker/operator handoff state, and first ticket routing fields
- document the new execution-readiness layer in the smart-home integration catalog README and changelog

## Validation
- `cargo fmt --manifest-path code\packages\rust\smart-home-integration-catalog\Cargo.toml`
- `cargo test --manifest-path code\packages\rust\smart-home-integration-catalog\Cargo.toml`
- `git diff --check`