### PR TITLE
feat(ruby-sir): thread block args at call sites of yielding methods (Q9f)

### DIFF
--- a/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
@@ -2,6 +2,44 @@
 
 All notable changes to the `ruby-to-semantic-ir` crate will be documented in this file.
 
+## [0.91.0] - 2026-06-19
+
+### Added (Q9f — explicit block-param ABI, part 2: call-site normalization)
+
+- A new post-lowering pass in `compile()` threads the matching block
+  argument at every `DirectCall` to a method that gained a trailing
+  `__sir_block__` parameter in Q9e (tracked in `Lowerer::block_param_methods`).
+  Running after the *whole* program is lowered makes the pass
+  order-independent: call-before-def and mutual recursion both thread
+  correctly because the method registry is fully populated first.
+- For each such call, the trailing argument slot is normalized so call
+  arity matches the threaded def:
+  - trailing `MakeClosure` (`foo { … }` / `foo do … end`) — already the
+    block; left as-is.
+  - trailing `BuiltinCall("block_pass", [inner])` (`foo(&p)`) — unwrapped
+    to `inner` (the proc/block value).
+  - otherwise (`foo(1, 2)`) — append `NilLit` (no block passed; the
+    parameter binds nil).
+- New `Lowerer::normalize_block_call_args` + recursive
+  `normalize_calls_in_{stmt,stmts,expr}` walk every function body
+  (user functions + `main`), descending through control flow, nested
+  calls, and `MakeClosure` capture values.
+- New tests: `call_to_yielding_method_with_block_keeps_makeclosure`,
+  `call_to_yielding_method_without_block_appends_nil`,
+  `block_pass_to_yielding_method_unwraps_to_inner`,
+  `call_to_non_block_method_is_unchanged`, `call_before_def_is_threaded`.
+  Every threaded module re-validates.
+
+### Notes / v0 cut-lines
+
+- A **parenless, argless** call to a yielding method (`foo` with no `()`
+  and no block) lowers to a `VarRef`, not a `DirectCall`, so it is not
+  recognized as a call and is left un-threaded — a pre-existing
+  call-detection limitation, not introduced here.
+- A `yield` through a nil block (no block passed) raising the exact Ruby
+  `LocalJumpError` class is deferred; runtime `apply` on nil surfaces a
+  generic error.
+
 ## [0.90.0] - 2026-06-19
 
 ### Added (Q9e — explicit block-param ABI, part 1: def threading + yield rewrite)

--- a/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
@@ -5230,6 +5230,139 @@ mod tests {
     // defensive; no source-level test can exercise it today.)
 
     // -----------------------------------------------------------------------
+    // Phase Q9f — explicit block-param ABI, part 2: call-site
+    // normalization.  Calls to a yielding method get the matching block
+    // argument threaded into the trailing slot so arity matches the def.
+    // -----------------------------------------------------------------------
+
+    /// Recursively locate the first `DirectCall` to `name` reachable from
+    /// a block's statements / value (one finder shared by the Q9f tests).
+    fn find_direct_call<'a>(b: &'a semantic_ir::Block, name: &str) -> Option<&'a Expr> {
+        fn in_expr<'a>(e: &'a Expr, name: &str) -> Option<&'a Expr> {
+            match e {
+                Expr::DirectCall { fn_name, args, .. } => {
+                    if fn_name == name {
+                        return Some(e);
+                    }
+                    args.iter().find_map(|a| in_expr(a, name))
+                }
+                Expr::BuiltinCall { args, .. } | Expr::Intrinsic { args, .. } => {
+                    args.iter().find_map(|a| in_expr(a, name))
+                }
+                Expr::IndirectCall { target, args, .. } => in_expr(target, name)
+                    .or_else(|| args.iter().find_map(|a| in_expr(a, name))),
+                Expr::If { cond, then_branch, else_branch, .. } => in_expr(cond, name)
+                    .or_else(|| in_block(then_branch, name))
+                    .or_else(|| in_block(else_branch, name)),
+                Expr::Block(b) => in_block(b, name),
+                Expr::SeqLit { items, .. } => items.iter().find_map(|i| in_expr(i, name)),
+                _ => None,
+            }
+        }
+        fn in_stmt<'a>(s: &'a Stmt, name: &str) -> Option<&'a Expr> {
+            match s {
+                Stmt::LetBinding { value, .. }
+                | Stmt::LetStarBinding { value, .. }
+                | Stmt::Assign { value, .. }
+                | Stmt::ExprStmt { expr: value, .. } => in_expr(value, name),
+                _ => None,
+            }
+        }
+        fn in_block<'a>(b: &'a semantic_ir::Block, name: &str) -> Option<&'a Expr> {
+            b.stmts
+                .iter()
+                .find_map(|s| in_stmt(s, name))
+                .or_else(|| in_expr(&b.value, name))
+        }
+        in_block(b, name)
+    }
+
+    #[test]
+    fn call_to_yielding_method_with_block_keeps_makeclosure() {
+        let m = lower("def t\n  yield 5\nend\nt { |x| puts x }\n");
+        let call = find_direct_call(main_body(&m), "t").expect("DirectCall to t");
+        if let Expr::DirectCall { args, .. } = call {
+            assert_eq!(args.len(), 1, "block arg occupies the single trailing slot");
+            assert!(
+                matches!(args.last(), Some(Expr::MakeClosure { .. })),
+                "explicit block stays a MakeClosure, got {:?}",
+                args.last()
+            );
+        }
+        // Arity matches the threaded def (1 param: __sir_block__).
+        let t = func(&m, "t");
+        assert_eq!(t.params.len(), 1);
+        assert!(semantic_ir::validate(&m).is_ok(), "validates: {:?}", semantic_ir::validate(&m));
+    }
+
+    #[test]
+    fn call_to_yielding_method_without_block_appends_nil() {
+        // `t(1)` passes no block, so a trailing nil is appended to match
+        // the def's threaded arity (params: `a`, `__sir_block__`).
+        let m = lower("def t(a)\n  yield a\nend\nt(1)\n");
+        let call = find_direct_call(main_body(&m), "t").expect("DirectCall to t");
+        if let Expr::DirectCall { args, .. } = call {
+            assert_eq!(args.len(), 2, "positional arg + appended nil block slot");
+            assert!(matches!(&args[0], Expr::IntLit { value: 1, .. }));
+            assert!(
+                matches!(args.last(), Some(Expr::NilLit { .. })),
+                "no-block call binds nil, got {:?}",
+                args.last()
+            );
+        }
+        // Arity matches the threaded def (params: a, __sir_block__).
+        assert_eq!(func(&m, "t").params.len(), 2);
+        assert!(semantic_ir::validate(&m).is_ok(), "validates: {:?}", semantic_ir::validate(&m));
+    }
+
+    #[test]
+    fn block_pass_to_yielding_method_unwraps_to_inner() {
+        // `foo(&p)` — the block_pass envelope is unwrapped to the proc
+        // value `p` itself in the trailing slot.
+        let m = lower("def foo\n  yield 5\nend\np = 1\nfoo(&p)\n");
+        let call = find_direct_call(main_body(&m), "foo").expect("DirectCall to foo");
+        if let Expr::DirectCall { args, .. } = call {
+            assert_eq!(args.len(), 1);
+            match args.last() {
+                Some(Expr::VarRef { name, .. }) => assert_eq!(name, "p"),
+                other => panic!("expected unwrapped VarRef(p), got {:?}", other),
+            }
+            // The block_pass envelope must NOT survive.
+            assert!(
+                !matches!(args.last(), Some(Expr::BuiltinCall { name, .. }) if name == "block_pass"),
+                "block_pass envelope must be unwrapped"
+            );
+        }
+        assert!(semantic_ir::validate(&m).is_ok(), "validates: {:?}", semantic_ir::validate(&m));
+    }
+
+    #[test]
+    fn call_to_non_block_method_is_unchanged() {
+        // `g` does not yield, so its call site keeps its exact args — no
+        // spurious trailing nil.
+        let m = lower("def g(x)\n  x + 1\nend\ng(1)\n");
+        let call = find_direct_call(main_body(&m), "g").expect("DirectCall to g");
+        if let Expr::DirectCall { args, .. } = call {
+            assert_eq!(args.len(), 1, "non-yielding call keeps its arity");
+            assert!(matches!(args.last(), Some(Expr::IntLit { value: 1, .. })));
+        }
+        assert!(semantic_ir::validate(&m).is_ok(), "validates: {:?}", semantic_ir::validate(&m));
+    }
+
+    #[test]
+    fn call_before_def_is_threaded() {
+        // The pass runs after the whole program is lowered, so a call
+        // appearing before the `def` is still threaded (order-independent).
+        let m = lower("t { |x| puts x }\ndef t\n  yield 5\nend\n");
+        let call = find_direct_call(main_body(&m), "t").expect("DirectCall to t");
+        if let Expr::DirectCall { args, .. } = call {
+            assert_eq!(args.len(), 1);
+            assert!(matches!(args.last(), Some(Expr::MakeClosure { .. })));
+        }
+        assert!(semantic_ir::validate(&m).is_ok(), "validates: {:?}", semantic_ir::validate(&m));
+    }
+
+    // -----------------------------------------------------------------------
     // Phase 22d — `super` keyword lowering
     //
     //   super        → ExprStmt(BuiltinCall("zsuper", []))   (forward ALL)

--- a/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
@@ -98,6 +98,21 @@ pub fn compile(program: &GrammarASTNode, module_name: &str) -> Result<Module, Ru
     let mut functions = std::mem::take(&mut lw.user_functions);
     functions.push(main);
 
+    // Phase Q9f (FC) — explicit block-param ABI, part 2: call-site
+    // normalization.  Now that every `def` has been lowered,
+    // `lw.block_param_methods` holds the full set of methods that gained
+    // a trailing `__sir_block__` parameter (Q9e).  Walk *all* function
+    // bodies (user functions + `main`) and thread the matching block
+    // argument at every `DirectCall` to one of those methods, so call
+    // arity matches the threaded def regardless of call-before-def or
+    // mutual recursion.  Running here — after the whole program is
+    // lowered — is what makes the pass order-independent.
+    if !lw.block_param_methods.is_empty() {
+        for f in &mut functions {
+            Lowerer::normalize_block_call_args(&mut f.body, &lw.block_param_methods);
+        }
+    }
+
     // SIR's validator requires the manifest to *exactly* match
     // usage (declared-but-unused is a warning, used-but-undeclared
     // is an error).  We've been tallying features as we lowered;
@@ -3148,6 +3163,187 @@ impl Lowerer {
             | Expr::StrLit { .. }
             | Expr::FloatLit { .. }
             | Expr::VarRef { .. } => false,
+        }
+    }
+
+    // -------------------------------------------------------------------
+    // Phase Q9f (FC) — explicit block-param ABI, part 2: call-site
+    // normalization
+    // -------------------------------------------------------------------
+
+    /// Thread the matching block argument at every `DirectCall` to a
+    /// method that gained a trailing `__sir_block__` parameter (recorded
+    /// in `blk` by Q9e's [`Lowerer::thread_block_param`]).
+    ///
+    /// For each such call, the trailing argument slot is normalized so
+    /// the call's arity matches the threaded def's (one extra trailing
+    /// block parameter):
+    ///
+    /// - trailing arg is a `MakeClosure` (`foo { … }` / `foo do … end`) —
+    ///   already the block; **left as-is**.
+    /// - trailing arg is `BuiltinCall("block_pass", [inner])` (`foo(&p)`)
+    ///   — **unwrapped** to `inner`, the proc/block value itself.
+    /// - otherwise (`foo`, `foo(1, 2)`) — **append `NilLit`**: no block
+    ///   was passed, so the parameter binds nil (and a later `yield`
+    ///   through a nil block is the documented v0 LocalJumpError analogue).
+    ///
+    /// The walk descends through every statement, expression, and nested
+    /// call (including `MakeClosure` capture values) so calls anywhere in
+    /// the program are threaded. It is idempotent in practice because it
+    /// runs exactly once, after the whole program is lowered.
+    fn normalize_block_call_args(block: &mut Block, blk: &HashSet<String>) {
+        for s in &mut block.stmts {
+            Self::normalize_calls_in_stmt(s, blk);
+        }
+        Self::normalize_calls_in_expr(&mut block.value, blk);
+    }
+
+    fn normalize_calls_in_stmts(stmts: &mut [Stmt], blk: &HashSet<String>) {
+        for s in stmts {
+            Self::normalize_calls_in_stmt(s, blk);
+        }
+    }
+
+    fn normalize_calls_in_stmt(stmt: &mut Stmt, blk: &HashSet<String>) {
+        match stmt {
+            Stmt::LetBinding { value, .. }
+            | Stmt::LetStarBinding { value, .. }
+            | Stmt::Assign { value, .. }
+            | Stmt::ExprStmt { expr: value, .. } => Self::normalize_calls_in_expr(value, blk),
+            Stmt::While { cond, body, .. } => {
+                Self::normalize_calls_in_expr(cond, blk);
+                Self::normalize_block_call_args(body, blk);
+            }
+            Stmt::ForRange { start, stop, step, body, .. } => {
+                Self::normalize_calls_in_expr(start, blk);
+                Self::normalize_calls_in_expr(stop, blk);
+                Self::normalize_calls_in_expr(step, blk);
+                Self::normalize_block_call_args(body, blk);
+            }
+            Stmt::ForEach { iter, body, .. } => {
+                Self::normalize_calls_in_expr(iter, blk);
+                Self::normalize_block_call_args(body, blk);
+            }
+            Stmt::SeqSet { seq, index, value, .. } => {
+                Self::normalize_calls_in_expr(seq, blk);
+                Self::normalize_calls_in_expr(index, blk);
+                Self::normalize_calls_in_expr(value, blk);
+            }
+            Stmt::MapSet { map, key, value, .. } => {
+                Self::normalize_calls_in_expr(map, blk);
+                Self::normalize_calls_in_expr(key, blk);
+                Self::normalize_calls_in_expr(value, blk);
+            }
+            // Class/module/singleton bodies carry non-`def` statements
+            // (their `def`s are hoisted to top-level functions, which the
+            // outer loop over `functions` already visits) — descend so a
+            // call inside e.g. a constant initializer is threaded too.
+            Stmt::ClassDef { body, .. }
+            | Stmt::ModuleDef { body, .. }
+            | Stmt::SingletonClassDef { body, .. } => Self::normalize_calls_in_stmts(body, blk),
+            Stmt::TryCatch { body, rescues, ensure_body, .. } => {
+                Self::normalize_calls_in_stmts(body, blk);
+                for r in rescues {
+                    Self::normalize_calls_in_stmts(&mut r.body, blk);
+                }
+                if let Some(eb) = ensure_body {
+                    Self::normalize_calls_in_stmts(eb, blk);
+                }
+            }
+        }
+    }
+
+    fn normalize_calls_in_expr(expr: &mut Expr, blk: &HashSet<String>) {
+        match expr {
+            Expr::DirectCall { fn_name, args, span, .. } => {
+                // Normalize nested calls in the arguments first (so an
+                // unwrapped `block_pass` inner / a closure capture value
+                // is itself threaded), then fix this call's trailing slot.
+                for a in args.iter_mut() {
+                    Self::normalize_calls_in_expr(a, blk);
+                }
+                if blk.contains(fn_name) {
+                    let n = args.len();
+                    let trailing_is_closure =
+                        n > 0 && matches!(args[n - 1], Expr::MakeClosure { .. });
+                    let trailing_is_block_pass = n > 0
+                        && matches!(&args[n - 1],
+                            Expr::BuiltinCall { name, .. } if name == "block_pass");
+                    if trailing_is_block_pass {
+                        // Unwrap `block_pass(inner)` → `inner` (the proc
+                        // value passed as the block). A malformed envelope
+                        // (not exactly one operand) is left untouched.
+                        if let Expr::BuiltinCall { args: inner, .. } = &mut args[n - 1] {
+                            if inner.len() == 1 {
+                                let v = inner.remove(0);
+                                args[n - 1] = v;
+                            }
+                        }
+                    } else if !trailing_is_closure {
+                        // No block syntactically passed: bind nil.
+                        args.push(Expr::NilLit { span: span.clone() });
+                    }
+                }
+            }
+            Expr::BuiltinCall { args, .. } | Expr::Intrinsic { args, .. } => {
+                for a in args.iter_mut() {
+                    Self::normalize_calls_in_expr(a, blk);
+                }
+            }
+            Expr::IndirectCall { target, args, .. } => {
+                Self::normalize_calls_in_expr(target, blk);
+                for a in args.iter_mut() {
+                    Self::normalize_calls_in_expr(a, blk);
+                }
+            }
+            Expr::If { cond, then_branch, else_branch, .. } => {
+                Self::normalize_calls_in_expr(cond, blk);
+                Self::normalize_block_call_args(then_branch, blk);
+                Self::normalize_block_call_args(else_branch, blk);
+            }
+            Expr::Block(b) => Self::normalize_block_call_args(b, blk),
+            Expr::MakeClosure { captures, .. } => {
+                for c in captures.iter_mut() {
+                    Self::normalize_calls_in_expr(&mut c.value, blk);
+                }
+            }
+            Expr::SeqLit { items, .. } => {
+                for i in items.iter_mut() {
+                    Self::normalize_calls_in_expr(i, blk);
+                }
+            }
+            Expr::SeqIndex { seq, index, .. } => {
+                Self::normalize_calls_in_expr(seq, blk);
+                Self::normalize_calls_in_expr(index, blk);
+            }
+            Expr::SeqLen { seq, .. } => Self::normalize_calls_in_expr(seq, blk),
+            Expr::MapLit { entries, .. } => {
+                for e in entries.iter_mut() {
+                    Self::normalize_calls_in_expr(&mut e.key, blk);
+                    Self::normalize_calls_in_expr(&mut e.value, blk);
+                }
+            }
+            Expr::MapGet { map, key, .. } => {
+                Self::normalize_calls_in_expr(map, blk);
+                Self::normalize_calls_in_expr(key, blk);
+            }
+            Expr::LogicalAnd { lhs, rhs, .. } | Expr::LogicalOr { lhs, rhs, .. } => {
+                Self::normalize_calls_in_expr(lhs, blk);
+                Self::normalize_calls_in_expr(rhs, blk);
+            }
+            Expr::StrConcat { parts, .. } => {
+                for p in parts.iter_mut() {
+                    Self::normalize_calls_in_expr(p, blk);
+                }
+            }
+            // Atomic literals and VarRef carry no sub-expressions.
+            Expr::IntLit { .. }
+            | Expr::BoolLit { .. }
+            | Expr::NilLit { .. }
+            | Expr::SymLit { .. }
+            | Expr::StrLit { .. }
+            | Expr::FloatLit { .. }
+            | Expr::VarRef { .. } => {}
         }
     }
 


### PR DESCRIPTION
## Q9f — explicit block-param ABI, part 2 (call-site normalization)

Part of TRANCHE 2 (Q9). Q9e (#6235) threaded a trailing `__sir_block__`
parameter through every method that `yield`s and rewrote each `yield`
to an `IndirectCall`. This PR completes the ABI by threading the
matching **block argument** at every call site, so call arity matches
the threaded def. **No backend or `semantic-ir` core change.**

### What changed
- New post-lowering pass in `compile()` over all function bodies (user
  functions + `main`). For each `DirectCall` whose target is in
  `block_param_methods`, the trailing arg slot is normalized:
  - trailing `MakeClosure` (`foo { … }` / `foo do … end`) — already the
    block; left as-is.
  - trailing `BuiltinCall("block_pass", [inner])` (`foo(&p)`) — unwrapped
    to `inner` (the proc value).
  - otherwise (`foo(1, 2)`) — append `NilLit` (no block passed).
- Running after the whole program is lowered makes it
  **order-independent**: call-before-def and mutual recursion thread
  correctly because `block_param_methods` is fully populated first.
- `normalize_block_call_args` + recursive `normalize_calls_in_{stmt,stmts,expr}`
  descend control flow, nested calls, and `MakeClosure` capture values.

### Tests (`-p ruby-to-semantic-ir`, 354 pass)
- `call_to_yielding_method_with_block_keeps_makeclosure`
- `call_to_yielding_method_without_block_appends_nil`
- `block_pass_to_yielding_method_unwraps_to_inner`
- `call_to_non_block_method_is_unchanged`
- `call_before_def_is_threaded` (order-independence)

Every threaded module re-validates. Backend suites
(`semantic-ir-to-python`, `semantic-ir-to-typescript`) stay green — no
backend change.

### v0 cut-lines (documented)
- A **parenless, argless** call (`foo`) lowers to a `VarRef`, not a
  `DirectCall`, so it isn't recognized as a call and is left un-threaded
  — a pre-existing call-detection limitation, not introduced here.
- A `yield` through a nil block raising the exact Ruby `LocalJumpError`
  class is deferred; runtime `apply` on nil surfaces a generic error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
