### PR TITLE
feat(mycin-onco): Tier-2 oncology tumor-marker recall as an ADJ-only library

### DIFF
--- a/code/specs/data/mycin-2026/USMLE-DOMAIN-MAP.md
+++ b/code/specs/data/mycin-2026/USMLE-DOMAIN-MAP.md
@@ -110,6 +110,7 @@ unchanged. Adding a relation just widens the schema — the engine already binds
 | Immunology | Immunology | mediated_by, associated_hla, gene_defect, deficiency_of | 7 grounded (ADJ-only) | ✓ |
 | Genetics | Genetics | inheritance, gene_defect, trinucleotide_repeat, imprinting | 7 grounded (ADJ-only) | ✓ |
 | Rheumatology (Tier-2) | Path/Immuno | associated_autoantibody | 6 grounded (ADJ-only) | ✓ |
+| Oncology (Tier-2) | Pathology/neoplasia | tumor_marker | 4 grounded (ADJ-only) | ✓ |
 
 Offline pipeline: prose → local-model decompose → ADJ → native engine, two-sided
 faithfulness gate, zero online calls (OFFLINE-BOARD-EXAM.md).
@@ -206,10 +207,11 @@ manifest). MICRO onward, the order is grounding-FIRST (never seed authored-debt)
 ## Coverage accounting (the watchable number)
 
 The north-star metric: **% of the USMLE content outline covered by grounded, scored
-domains.** Today: 10 recall domains + ID differential/management (a slice of Multisystem,
+domains.** Today: 11 recall domains + ID differential/management (a slice of Multisystem,
 Endocrine, Hematology, Biochemistry, Nutrition, Microbiology, Pharmacology, Immunology,
-Genetics, Rheumatology — 91/92 board recall answers cite an authoritative grounded edge).
-All four Tier-1 foundational-recall domains (microbiology, pharmacology, immunology,
-genetics) are grounded & scored; RHEUM is the first Tier-2 organ-system pathology domain. Each merged domain PR moves this number;
+Genetics, Rheumatology, Oncology — 94/95 board recall answers cite an authoritative
+grounded edge). All four Tier-1 foundational-recall domains (microbiology, pharmacology,
+immunology, genetics) are grounded & scored; RHEUM (autoantibodies) and ONCO (tumor
+markers) are the first two Tier-2 organ-system pathology domains. Each merged domain PR moves this number;
 this map is the denominator. The campaign is done when every Tier-1/2/3 cell above has a
 grounded, scored domain and the board bank samples each.

--- a/code/specs/data/mycin-2026/board/board-scorecard.json
+++ b/code/specs/data/mycin-2026/board/board-scorecard.json
@@ -1,7 +1,7 @@
 {
   "summary": {
-    "total": 105,
-    "correct": 98,
+    "total": 108,
+    "correct": 101,
     "abstained": 7,
     "wrong": 0,
     "by_tactic": {
@@ -16,15 +16,15 @@
         "wrong": 0
       },
       "recall": {
-        "correct": 92,
+        "correct": 95,
         "abstained": 6,
         "wrong": 0
       }
     },
     "defensibility": 1.0,
     "accuracy_on_attempted": 1.0,
-    "grounded_coverage": 0.9891,
-    "grounded_correct": 91
+    "grounded_coverage": 0.9895,
+    "grounded_correct": 94
   },
   "results": [
     {
@@ -864,6 +864,30 @@
       "tactic": "recall",
       "gold": "anti_scl70",
       "answer": "anti_scl70",
+      "outcome": "correct",
+      "trust": "authoritative"
+    },
+    {
+      "id": "onco_ovarian_marker",
+      "tactic": "recall",
+      "gold": "ca_125",
+      "answer": "ca_125",
+      "outcome": "correct",
+      "trust": "authoritative"
+    },
+    {
+      "id": "onco_mtc_marker",
+      "tactic": "recall",
+      "gold": "calcitonin",
+      "answer": "calcitonin",
+      "outcome": "correct",
+      "trust": "authoritative"
+    },
+    {
+      "id": "onco_hcc_marker",
+      "tactic": "recall",
+      "gold": "alpha_fetoprotein",
+      "answer": "alpha_fetoprotein",
       "outcome": "correct",
       "trust": "authoritative"
     }

--- a/code/specs/data/mycin-2026/board/board_eval.py
+++ b/code/specs/data/mycin-2026/board/board_eval.py
@@ -66,7 +66,7 @@ SCORECARD = HERE / "board-scorecard.json"
 # board_offline.py. The engine that ANSWERS is always the native CPU reasoner.)
 EDGE_FILES = ["iem-edges.adj", "vitamin-edges.adj", "anemia-edges.adj", "endocrine-edges.adj",
               "coag-edges.adj", "micro-edges.adj", "pharm-edges.adj", "immuno-edges.adj",
-              "genetics-edges.adj", "rheum-edges.adj"]
+              "genetics-edges.adj", "rheum-edges.adj", "onco-edges.adj"]
 
 # The native adj-lang CLI binary — the ONE engine behind every tactic (recall,
 # differential, management). If the binary is absent (e.g. a Python-only CI job that

--- a/code/specs/data/mycin-2026/board/decompose_query.py
+++ b/code/specs/data/mycin-2026/board/decompose_query.py
@@ -59,11 +59,11 @@ HERE = Path(__file__).resolve().parent
 RECALL = HERE.parent / "recall"
 EDGE_FILES = ["iem-edges.adj", "vitamin-edges.adj", "anemia-edges.adj",
               "endocrine-edges.adj", "coag-edges.adj", "micro-edges.adj", "pharm-edges.adj",
-              "immuno-edges.adj", "genetics-edges.adj", "rheum-edges.adj"]
+              "immuno-edges.adj", "genetics-edges.adj", "rheum-edges.adj", "onco-edges.adj"]
 
 # Each recall relation binds one conventional variable (the "what is being asked").
-# This is the controlled query vocabulary the model must choose from — 26 relations
-# across nine domains. The engine ultimately validates the subject; this map
+# This is the controlled query vocabulary the model must choose from — 27 relations
+# across ten domains. The engine ultimately validates the subject; this map
 # pins the legal relation set and the variable name each relation answers.
 REL_VAR = {
     "deficient_in": "Enzyme",          # IEM: which enzyme is deficient
@@ -92,6 +92,7 @@ REL_VAR = {
     "trinucleotide_repeat": "Repeat",  # genetics: the expanded triplet (CAG / CGG / CTG / GAA)
     "imprinting": "Parent",            # genetics: the parent-of-origin lesion (PWS / Angelman)
     "associated_autoantibody": "Antibody",  # rheumatology: the serologic marker of a disease
+    "tumor_marker": "Marker",          # oncology: the serum tumor marker of a neoplasm
 }
 
 _RELATE_RE = re.compile(r"^\s*relate\s+([a-z_][a-z0-9_]*)\s*\(([^)]*)\)\s*$")

--- a/code/specs/data/mycin-2026/board/items.json
+++ b/code/specs/data/mycin-2026/board/items.json
@@ -118,6 +118,10 @@
 
     {"id": "rheum_sle_ab",   "domain": "rheum", "tactic": "recall", "relation": "associated_autoantibody", "subject": "systemic_lupus_erythematosus",   "var": "Antibody", "gold": "anti_dsdna"},
     {"id": "rheum_gpa_ab",   "domain": "rheum", "tactic": "recall", "relation": "associated_autoantibody", "subject": "granulomatosis_with_polyangiitis","var": "Antibody", "gold": "pr3"},
-    {"id": "rheum_ssc_ab",   "domain": "rheum", "tactic": "recall", "relation": "associated_autoantibody", "subject": "systemic_sclerosis",            "var": "Antibody", "gold": "anti_scl70"}
+    {"id": "rheum_ssc_ab",   "domain": "rheum", "tactic": "recall", "relation": "associated_autoantibody", "subject": "systemic_sclerosis",            "var": "Antibody", "gold": "anti_scl70"},
+
+    {"id": "onco_ovarian_marker", "domain": "onco", "tactic": "recall", "relation": "tumor_marker", "subject": "ovarian_cancer",               "var": "Marker", "gold": "ca_125"},
+    {"id": "onco_mtc_marker",     "domain": "onco", "tactic": "recall", "relation": "tumor_marker", "subject": "medullary_thyroid_carcinoma",   "var": "Marker", "gold": "calcitonin"},
+    {"id": "onco_hcc_marker",     "domain": "onco", "tactic": "recall", "relation": "tumor_marker", "subject": "hepatocellular_carcinoma",      "var": "Marker", "gold": "alpha_fetoprotein"}
   ]
 }

--- a/code/specs/data/mycin-2026/board/test_board_eval.py
+++ b/code/specs/data/mycin-2026/board/test_board_eval.py
@@ -41,16 +41,17 @@ def test_covered_items_answer_correctly_with_a_proof() -> None:
     assert by_id["tay_sachs_enzyme"].answer == "hexosaminidase_a"
     # A correct recall answer carries the citing edge's trust tier (its proof).
     assert by_id["tay_sachs_enzyme"].trust is not None
-    # The bank spans TEN recall domains: 18 IEM + 8 vitamin + 8 anemia + 8 endocrine
+    # The bank spans ELEVEN recall domains: 18 IEM + 8 vitamin + 8 anemia + 8 endocrine
     # + 11 coagulation (REL-13) + 13 microbiology (MICRO) + 9 pharmacology (PHARM) + 7
-    # immunology (IMMUNO) + 7 genetics (GENETICS) + 3 rheumatology (RHEUM) = 92 covered
-    # recall items, all over one merged store. MICRO/PHARM/IMMUNO/GENETICS/RHEUM are
-    # ADJ-ONLY domains: their *-edges.adj are hand-authored libraries carrying byte-
-    # provenance inline (no Python gate / JSON / manifest). RHEUM is the first Tier-2
-    # organ-system domain; a disease binds several autoantibodies, so the board scores the
-    # top binding per disease (the library + test_rheum_recall cover all six edges).
+    # immunology (IMMUNO) + 7 genetics (GENETICS) + 3 rheumatology (RHEUM) + 3 oncology
+    # (ONCO) = 95 covered recall items, all over one merged store.
+    # MICRO/PHARM/IMMUNO/GENETICS/RHEUM/ONCO are ADJ-ONLY domains: their *-edges.adj are
+    # hand-authored libraries carrying byte-provenance inline (no Python gate/JSON/manifest).
+    # RHEUM and ONCO are Tier-2 organ-system domains where a disease binds several markers,
+    # so the board scores the top binding per disease (the libraries + their tests cover
+    # all edges).
     recall_correct = [r for r in card.results if r.outcome == "correct" and r.tactic == "recall"]
-    assert len(recall_correct) == 92
+    assert len(recall_correct) == 95
     assert by_id["fabry_enzyme"].outcome == "correct"               # IEM
     assert by_id["thiamine_disease"].answer == "beriberi"           # vitamin
     assert by_id["ida_mcv"].answer == "microcytic"                  # anemia
@@ -74,6 +75,9 @@ def test_covered_items_answer_correctly_with_a_proof() -> None:
     assert by_id["rheum_sle_ab"].answer == "anti_dsdna"          # rheumatology (RHEUM, Tier-2)
     assert by_id["rheum_gpa_ab"].answer == "pr3"                 # rheum — autoantibody association
     assert by_id["rheum_sle_ab"].trust == "authoritative"        # ADJ-only edge, grounded inline
+    assert by_id["onco_ovarian_marker"].answer == "ca_125"       # oncology (ONCO, Tier-2)
+    assert by_id["onco_hcc_marker"].answer == "alpha_fetoprotein"  # onco — tumor_marker relation
+    assert by_id["onco_ovarian_marker"].trust == "authoritative"  # ADJ-only edge, grounded inline
 
 
 def test_uncovered_items_abstain_not_fabricate() -> None:
@@ -108,16 +112,16 @@ def test_grounded_coverage_is_the_live_grounding_number() -> None:
     # contains the relation ("Factor VII deficiency is a bleeding disorder characterized
     # by a lack in the production of factor VII"), lifting it to authoritative. The ADJ-only
     # domains MICRO (13 microbiology), PHARM (9 pharmacology), IMMUNO (7 immunology),
-    # GENETICS (7 genetics), and RHEUM (3 scored rheumatology) edges — all spider-grounded
-    # to NCBI StatPearls byte-stable spans — add 39 more authoritative recall answers. 91 of
-    # the 92 recall answers across all TEN domains now cite an authoritative edge:
-    # grounded-coverage 99%. ONE holdout stays consensus + FLAG (direction_only) — the
-    # adversarial verify could not pin it verbatim, so the framework declines to claim
-    # grounding it cannot defend, by design: cortisol_def (endocrine,
-    # deficiency_syndrome__cortisol — the only verbatim spans frame cortisol deficiency as a
-    # consequence/feature of Addison disease, not the named-syndrome identity).
-    assert s["grounded_coverage"] == round(91 / 92, 4)   # 0.9891
-    assert s["grounded_correct"] == 91
+    # GENETICS (7 genetics), RHEUM (3 scored rheumatology), and ONCO (3 scored oncology)
+    # edges — all spider-grounded to NCBI StatPearls byte-stable spans — add 42 more
+    # authoritative recall answers. 94 of the 95 recall answers across all ELEVEN domains
+    # now cite an authoritative edge: grounded-coverage 99%. ONE holdout stays consensus +
+    # FLAG (direction_only) — the adversarial verify could not pin it verbatim, so the
+    # framework declines to claim grounding it cannot defend, by design: cortisol_def
+    # (endocrine, deficiency_syndrome__cortisol — the only verbatim spans frame cortisol
+    # deficiency as a consequence/feature of Addison disease, not the named-syndrome identity).
+    assert s["grounded_coverage"] == round(94 / 95, 4)   # 0.9895
+    assert s["grounded_correct"] == 94
     by_id = {r.item_id: r for r in card.results}
     assert by_id["tay_sachs_enzyme"].trust == "authoritative"      # IEM
     assert by_id["ida_mcv"].trust == "authoritative"               # anemia

--- a/code/specs/data/mycin-2026/recall/onco-edges.adj
+++ b/code/specs/data/mycin-2026/recall/onco-edges.adj
@@ -1,0 +1,60 @@
+% ============================================================================
+% onco-edges — the oncology tumor-marker knowledge-graph (MYCIN-2026 ONCO).
+% ============================================================================
+% A Tier-2 organ-system pathology domain (USMLE-DOMAIN-MAP §"Tier 2", neoplasia): the
+% serum tumor-marker → neoplasm associations behind the oncology board questions.
+% "Which tumor marker is associated with ovarian cancer?" becomes the binding query
+%   ? tumor_marker(ovarian_cancer, $Marker).
+%
+% This file is the SHIPPED ARTIFACT and the SOLE source of truth — no generator, no
+% JSON, no manifest (the sixth ADJ-only recall domain). Each fact is a `relate` clause
+% whose byte-provenance lives INLINE:
+%     source   — the VERBATIM span copied from the cited page (byte-stable: it
+%                appears character-for-character in the page's normalized text).
+%     locator  — the URL the span was read from (NCBI StatPearls / Bookshelf, NIH).
+%     trust    — authoritative (a primary, citable reference).
+% An LLM (or a human) recalls a fact by writing a tiny query .adj that `import`s this
+% library and asks a binding query — see onco-recall.query.adj. Nothing here is asserted
+% "from memory": every edge is defended by a span a reader can re-fetch and check.
+% (See feedback_nothing_human_authored, feedback_adj_only_shipped_artifacts.)
+%
+% Honest scope: only edges whose cited span states the marker↔neoplasm association AND
+% names both endpoints are included. Spans were taken from the per-marker / per-cancer
+% pages (the aggregate "tumor biomarkers" page discusses markers mostly in sensitivity /
+% false-positive / procedure-context, not a clean both-endpoints-named declarative).
+% Deferred (no clean self-contained span yet here): PSA→prostate (the marker page frames
+% PSA by its limited specificity), CEA→colorectal, beta-hCG→germ-cell/choriocarcinoma.
+% ============================================================================
+
+dictionary onco_vocab {
+    define neoplasm : entity   surface "cancer", "neoplasm", "tumor"
+    define marker   : entity   surface "tumor marker", "serum biomarker"
+
+    define tumor_marker : relation from neoplasm to marker  % the serum marker of a neoplasm
+}
+
+rulebook onco_facts {
+    use onco_vocab
+
+    % --- Ovarian cancer (CA-125) -----------------------------------------
+    relate tumor_marker(ovarian_cancer, ca_125)
+        source "Cancer antigen 125 (CA125) is an antigenic tumor marker expressed by epithelial ovarian neoplasms and cells lining various organs such as the endometrium, fallopian tubes, pleura, peritoneum, and pericardium."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK562245/"
+        trust authoritative
+
+    % --- Medullary thyroid carcinoma (calcitonin and CEA; one span names both) ---
+    relate tumor_marker(medullary_thyroid_carcinoma, calcitonin)
+        source "Baseline serum calcitonin and carcinoembryonic antigen (CEA) measurements are essential tumor markers in MTC."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK459354/"
+        trust authoritative
+    relate tumor_marker(medullary_thyroid_carcinoma, cea)
+        source "Baseline serum calcitonin and carcinoembryonic antigen (CEA) measurements are essential tumor markers in MTC."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK459354/"
+        trust authoritative
+
+    % --- Hepatocellular carcinoma (alpha-fetoprotein) --------------------
+    relate tumor_marker(hepatocellular_carcinoma, alpha_fetoprotein)
+        source "HCC is diagnosed by elevation of serum biomarkers, including alpha-fetoprotein, imaging including ultrasound, contrast CT/MRI, and biopsy."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK559177/"
+        trust authoritative
+}

--- a/code/specs/data/mycin-2026/recall/onco-recall.query.adj
+++ b/code/specs/data/mycin-2026/recall/onco-recall.query.adj
@@ -1,0 +1,19 @@
+% ============================================================================
+% onco-recall.query.adj — a worked recall query over the oncology library.
+% ============================================================================
+% The shape an LLM (or a clinician) produces to ANSWER an oncology recall question:
+% it states no oncologic fact — it only `import`s the grounded library and asks binding
+% queries. The native adj-lang engine resolves each `?` against the imported `relate`
+% edges and returns the binding + the citing clause's source/locator/trust. All
+% knowledge is in the library; none is here. (A cancer with several markers binds
+% multiple answers — the engine returns each with its own citation.)
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli onco-recall.query.adj
+% ============================================================================
+
+import "onco-edges.adj"
+
+? tumor_marker(ovarian_cancer, $Marker)                % expect ca_125
+? tumor_marker(medullary_thyroid_carcinoma, $Marker)   % expect calcitonin / cea
+? tumor_marker(hepatocellular_carcinoma, $Marker)      % expect alpha_fetoprotein

--- a/code/specs/data/mycin-2026/recall/test_onco_recall.py
+++ b/code/specs/data/mycin-2026/recall/test_onco_recall.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""test_onco_recall.py — the ADJ-only oncology tumor-marker library (MYCIN-2026 ONCO).
+
+The sixth recall domain shipped as a pure ADJ artifact (second Tier-2 organ-system
+domain, after RHEUM). `onco-edges.adj` is the SOLE source of truth — facts +
+byte-provenance inline, no Python gate, no JSON, no manifest. This test pins the
+property that matters: the native adj-lang engine, given a query .adj that only
+`import`s the library and asks binding queries (`onco-recall.query.adj` — the shape an
+LLM produces), binds EVERY grounded marker for each neoplasm (a cancer may have several
+markers), each carrying an AUTHORITATIVE citation with a real source span + locator.
+Knowledge lives in ADJ; the engine answers.
+
+If the native CLI isn't built (a Python-only CI lane), the engine-backed checks skip —
+the file-shape checks (every clause grounded, no authored-debt) still run.
+
+Run:  python3 test_onco_recall.py
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+ADJ = HERE / "onco-edges.adj"
+QUERY = HERE / "onco-recall.query.adj"
+CLI = HERE.parents[3] / "packages" / "rust" / "target" / "debug" / "adj-lang-cli"
+
+# Every grounded edge: neoplasm -> the set of tumor markers the library binds for it.
+EXPECTED = {
+    "ovarian_cancer": {"ca_125"},
+    "medullary_thyroid_carcinoma": {"calcitonin", "cea"},
+    "hepatocellular_carcinoma": {"alpha_fetoprotein"},
+}
+REL = "tumor_marker"
+VAR = "Marker"
+
+
+def _cli_available() -> bool:
+    return CLI.exists()
+
+
+def _run(program: Path) -> dict:
+    out = subprocess.run([str(CLI), str(program)], capture_output=True, text=True,
+                         cwd=str(HERE), timeout=60)
+    assert out.returncode == 0, f"adj-lang-cli failed: {out.stderr}"
+    return json.loads(out.stdout)
+
+
+# ---- 1. the ADJ file is the artifact — every clause grounded, no authored-debt ----
+
+def test_library_is_pure_adj_and_fully_grounded() -> None:
+    text = ADJ.read_text()
+    assert "trust consensus" not in text, "ONCO ships no authored-debt; ground or omit"
+    assert "[FLAG:" not in text
+    edge_count = sum(len(v) for v in EXPECTED.values())  # 4
+    assert text.count("    relate ") == edge_count
+    assert text.count("trust authoritative") == edge_count
+    assert text.count('\n        locator "') == edge_count
+    assert text.count('\n        source "') == edge_count
+    assert not (HERE / "onco_edge_ground.py").exists()
+    assert not (HERE / "onco-edge-grounding.json").exists()
+    assert not (HERE / "onco-edge-manifest.json").exists()
+
+
+# ---- 2. the engine binds every grounded marker, each with an authoritative citation ----
+
+def test_engine_binds_every_marker_with_authoritative_citation() -> None:
+    if not _cli_available():
+        return
+    result = _run(QUERY)
+    by_query = {r["query"]: r for r in result["recall"]}
+    for neoplasm, markers in EXPECTED.items():
+        q = f"{REL}({neoplasm}, {VAR})"
+        r = by_query.get(q)
+        assert r is not None and not r["abstained"], f"{q} abstained — edges missing?"
+        bound = {}
+        for a in r["answers"]:
+            bound[a["bindings"][VAR]] = (a.get("citations") or [{}])[0]
+        assert set(bound) == markers, f"{neoplasm}: bound {set(bound)} != {markers}"
+        for m, cite in bound.items():
+            assert cite.get("trust") == "authoritative", f"{neoplasm}/{m} not authoritative"
+            assert cite.get("source"), f"{neoplasm}/{m} has no source span"
+            assert cite.get("locator", "").startswith("https://www.ncbi.nlm.nih.gov/")
+
+
+# ---- 3. an off-vocabulary neoplasm abstains, never fabricates ----------------------
+
+def test_unknown_neoplasm_abstains() -> None:
+    if not _cli_available():
+        return
+    import os
+    import tempfile
+    fd, path = tempfile.mkstemp(suffix=".adj", prefix=".onco_q_", dir=HERE)
+    try:
+        with os.fdopen(fd, "w") as fh:
+            # pancreatic_cancer is not in the library → must abstain
+            fh.write(f'import "onco-edges.adj"\n? {REL}(pancreatic_cancer, ${VAR})\n')
+        res = _run(Path(path))
+        r = res["recall"][0] if res["recall"] else None
+        assert r is not None and r["abstained"], "an ungrounded neoplasm must abstain"
+    finally:
+        os.unlink(path)
+
+
+def _run_all() -> int:
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    failed = 0
+    for t in tests:
+        try:
+            t()
+            print(f"  PASS  {t.__name__}")
+        except AssertionError as exc:
+            failed += 1
+            print(f"  FAIL  {t.__name__}: {exc}")
+    print(f"\ntest_onco_recall: {len(tests) - failed}/{len(tests)} passed")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(_run_all())


### PR DESCRIPTION
## What

The **sixth ADJ-only** recall domain and the **second Tier-2 organ-system pathology** domain (after RHEUM #6238). `recall/onco-edges.adj` *is* the source of truth — facts + byte-provenance **inline** (`source` = verbatim NCBI StatPearls span, `locator` = URL, `trust authoritative`); no Python gate, no JSON, no manifest.

```
import "onco-edges.adj"
? tumor_marker(ovarian_cancer, $Marker)   % → ca_125, cited to NBK562245
? tumor_marker(medullary_thyroid_carcinoma, $Marker)  % → calcitonin / cea
```

## Grounding (no authored debt)

All **4 `tumor_marker` edges** across **3 neoplasms** grounded to **byte-stable verbatim spans** (3 unique spans; the MTC span names two markers):

| neoplasm | marker(s) | source |
|---|---|---|
| Ovarian cancer | CA-125 | NBK562245 |
| Medullary thyroid carcinoma | calcitonin, CEA | NBK459354 |
| Hepatocellular carcinoma | alpha-fetoprotein | NBK559177 |

Spans taken from the per-marker / per-cancer pages — the aggregate "tumor biomarkers" page discusses markers in sensitivity/false-positive/procedure context, with no clean both-endpoints-named declarative. No `trust consensus` seed — grounded or omitted. **Deferred**: PSA→prostate (page frames PSA by its limited specificity), CEA→colorectal, β-hCG→germ-cell/choriocarcinoma.

## Wiring & results

- `board_eval.EDGE_FILES` + `decompose_query.EDGE_FILES` += `onco-edges.adj`; `REL_VAR` += `tumor_marker` → 27 relations / 10 domains
- 3 onco board items (one per neoplasm, top binding — MTC binds two markers and `resolve_recall` scores `answers[0]`; the library + `test_onco_recall` cover all 4 edges)
- Scorecard: recall **92 → 95** correct, grounded **91 → 94** (94/95 = **99%**), **wrong 0**, defensibility **100%**
- `test_onco_recall.py` is **multi-answer-aware** (each neoplasm binds its full marker set, each with an authoritative citation)
- `USMLE-DOMAIN-MAP`: Oncology marked built — **11 recall domains**; second Tier-2 cell

## Verification

- `board_eval` test suite: **12/12**
- `test_onco_recall`: **3/3**
- byte-stability: **3/3** live spans present verbatim
- `/security-review` passed (subprocess / tempfile / string-literal / SSRF / ReDoS — clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)