### PR TITLE
feat(sir-runtime-core): no-block-given yield raises LocalJumpError (Q10a)

### DIFF
--- a/code/packages/python/sir-runtime-core/CHANGELOG.md
+++ b/code/packages/python/sir-runtime-core/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to `coding-adventures-sir-runtime-core` are documented here.
 
+## [0.1.3] - 2026-06-19
+
+### Added (Q10a — no-block-given `LocalJumpError`)
+
+- New `LocalJumpError` exception. `apply(None, args)` now raises it
+  ("no block given (yield)") instead of a generic `TypeError`. This is
+  the SIR analogue of Ruby's `LocalJumpError`: under the explicit
+  block-param ABI a method that `yield`s through a block parameter the
+  caller never supplied reaches `apply` with a `None` target, and that
+  failure is now distinct and recognisable (a genuine non-closure, e.g.
+  applying an int, still raises `TypeError`). Exported from the package
+  root. Ruby's exact class identity is not modelled — the analogue is
+  keyed to the error's shape, not Ruby's hierarchy.
+
 ## [0.1.2] - 2026-06-15
 
 ### Changed

--- a/code/packages/python/sir-runtime-core/src/coding_adventures_sir_runtime_core/__init__.py
+++ b/code/packages/python/sir-runtime-core/src/coding_adventures_sir_runtime_core/__init__.py
@@ -22,6 +22,7 @@ from .pairs import Pair, car, cdr, cons, is_pair
 from .pairs import set_display as _set_pairs_display
 from .runtime import (
     Closure,
+    LocalJumpError,
     apply,
     builtin_closure,
     call_builtin,
@@ -70,6 +71,7 @@ __all__ = [
     "gt",
     # closures / globals / dispatch
     "Closure",
+    "LocalJumpError",
     "apply",
     "make_closure",
     "global_set",

--- a/code/packages/python/sir-runtime-core/src/coding_adventures_sir_runtime_core/runtime.py
+++ b/code/packages/python/sir-runtime-core/src/coding_adventures_sir_runtime_core/runtime.py
@@ -25,6 +25,22 @@ from .symbols import Symbol
 # --- Closures --------------------------------------------------------------
 
 
+class LocalJumpError(Exception):
+    """Raised when a closure-shaped call has no closure to invoke.
+
+    SIR's explicit-block-param ABI threads a method's block as an ordinary
+    trailing parameter and lowers ``yield`` to an ``IndirectCall`` through
+    it.  When the caller passed **no** block, that parameter is ``nil``
+    (Python ``None``), so the ``IndirectCall`` reaches :func:`apply` with a
+    ``None`` target.  Ruby raises ``LocalJumpError`` ("no block given
+    (yield)") in exactly this situation; we mirror that with a dedicated
+    exception so the failure is recognisable rather than a generic
+    ``TypeError`` about an internal "non-closure".  The exact Ruby class
+    identity is not modelled — this is the SIR analogue, keyed to the
+    *shape* of the error, not Ruby's class hierarchy.
+    """
+
+
 class Closure:
     """A callable handle wrapping a Python function."""
 
@@ -35,7 +51,15 @@ class Closure:
 
 
 def apply(c: Any, args: list[Any]) -> Any:
-    """Invoke a closure handle with ``args``.  Errors on a non-closure."""
+    """Invoke a closure handle with ``args``.
+
+    A ``None`` target is the no-block-given case (see
+    :class:`LocalJumpError`): a ``yield`` reached through a nil block
+    parameter.  It is reported distinctly from other non-closures (a
+    genuine type error) so the two failures don't read alike.
+    """
+    if c is None:
+        raise LocalJumpError("no block given (yield)")
     if not isinstance(c, Closure):
         raise TypeError("apply on non-closure")
     return c.fn(*args)

--- a/code/packages/python/sir-runtime-core/tests/test_core.py
+++ b/code/packages/python/sir-runtime-core/tests/test_core.py
@@ -142,6 +142,25 @@ def test_apply_rejects_non_closure() -> None:
         sir.apply(42, [])
 
 
+def test_apply_nil_target_raises_local_jump_error() -> None:
+    # No-block-given case: a `yield` reached through a nil block parameter
+    # (apply target is None) raises the dedicated LocalJumpError, not the
+    # generic non-closure TypeError.
+    with pytest.raises(sir.LocalJumpError):
+        sir.apply(None, [1, 2])
+
+
+def test_local_jump_error_message_mentions_no_block() -> None:
+    with pytest.raises(sir.LocalJumpError, match="no block given"):
+        sir.apply(None, [])
+
+
+def test_local_jump_error_is_distinct_from_type_error() -> None:
+    # The nil case must NOT be a TypeError (so the two failure modes stay
+    # distinguishable for callers / future rescue mapping).
+    assert not issubclass(sir.LocalJumpError, TypeError)
+
+
 # --- globals ---------------------------------------------------------------
 
 

--- a/code/packages/typescript/sir-runtime-core/CHANGELOG.md
+++ b/code/packages/typescript/sir-runtime-core/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to `@coding-adventures/sir-runtime-core` are documented here.
 
+## [0.1.4] - 2026-06-19
+
+### Added (Q10a — no-block-given `LocalJumpError`)
+
+- New `LocalJumpError` class. `apply(null, args)` (and `undefined`) now
+  throws it ("no block given (yield)") instead of a generic `TypeError`.
+  This is the SIR analogue of Ruby's `LocalJumpError`: under the explicit
+  block-param ABI a method that `yield`s through a block parameter the
+  caller never supplied reaches `apply` with a `null` target, and that
+  failure is now distinct and recognisable (a genuine non-closure still
+  throws `TypeError`). Exported from the package root. Ruby's exact class
+  identity is not modelled — the analogue is keyed to the error's shape.
+
 ## [0.1.3] - 2026-06-15
 
 ### Changed

--- a/code/packages/typescript/sir-runtime-core/src/index.ts
+++ b/code/packages/typescript/sir-runtime-core/src/index.ts
@@ -24,6 +24,7 @@ export type { Val, ClosureLike } from "./values.js";
 export { add, sub, mul, div, lt, gt } from "./arithmetic.js";
 export {
   Closure,
+  LocalJumpError,
   apply,
   makeClosure,
   globalSet,

--- a/code/packages/typescript/sir-runtime-core/src/runtime.ts
+++ b/code/packages/typescript/sir-runtime-core/src/runtime.ts
@@ -18,14 +18,44 @@ import type { ClosureLike, Val } from "./values.js";
 
 // --- Closures --------------------------------------------------------------
 
+/**
+ * Raised when a closure-shaped call has no closure to invoke.
+ *
+ * SIR's explicit-block-param ABI threads a method's block as an ordinary
+ * trailing parameter and lowers `yield` to an `IndirectCall` through it.
+ * When the caller passed **no** block, that parameter is `nil` (`null`), so
+ * the `IndirectCall` reaches {@link apply} with a `null` target. Ruby raises
+ * `LocalJumpError` ("no block given (yield)") in exactly this situation; we
+ * mirror that with a dedicated error so the failure is recognisable rather
+ * than a generic `TypeError` about an internal "non-closure". The exact Ruby
+ * class identity is not modelled — this is the SIR analogue, keyed to the
+ * *shape* of the error, not Ruby's class hierarchy.
+ */
+export class LocalJumpError extends Error {
+  constructor(message = "no block given (yield)") {
+    super(message);
+    this.name = "LocalJumpError";
+  }
+}
+
 /** A callable handle wrapping a function. */
 export class Closure implements ClosureLike {
   readonly __sirClosure = true as const;
   constructor(public readonly fn: (...args: Val[]) => Val) {}
 }
 
-/** Invoke a closure handle with `args`. Throws on a non-closure. */
+/**
+ * Invoke a closure handle with `args`.
+ *
+ * A `null`/`undefined` target is the no-block-given case (see
+ * {@link LocalJumpError}): a `yield` reached through a nil block parameter.
+ * It is reported distinctly from other non-closures (a genuine type error)
+ * so the two failures don't read alike.
+ */
 export function apply(c: Val, args: Val[]): Val {
+  if (c === null || c === undefined) {
+    throw new LocalJumpError();
+  }
   if (!(c instanceof Closure)) {
     throw new TypeError("apply on non-closure");
   }

--- a/code/packages/typescript/sir-runtime-core/tests/core.test.ts
+++ b/code/packages/typescript/sir-runtime-core/tests/core.test.ts
@@ -115,6 +115,14 @@ describe("closures, globals, dispatch", () => {
     expect(() => sir.apply(42, [])).toThrow(TypeError);
   });
 
+  it("apply on a nil target raises LocalJumpError (no block given)", () => {
+    // No-block-given case: a `yield` reached through a nil block parameter.
+    expect(() => sir.apply(null, [1, 2])).toThrow(sir.LocalJumpError);
+    expect(() => sir.apply(null, [])).toThrow(/no block given/);
+    // Distinct from the non-closure TypeError so the two stay separable.
+    expect(new sir.LocalJumpError()).not.toBeInstanceOf(TypeError);
+  });
+
   it("global store roundtrip", () => {
     sir.globalSet("g1", 99);
     expect(sir.globalGet("g1")).toBe(99);


### PR DESCRIPTION
## Q10a — no-block-given `yield` raises `LocalJumpError`

Closes the first of the deferred Q9 v0 cut-lines: a `yield` through a nil
block now fails with a recognizable error.

Under the explicit block-param ABI (Q9e/Q9f), a method that `yield`s
through a block parameter the caller never supplied reaches
`apply` with a nil target (Python `None` / JS `null`). That previously
surfaced as a generic "apply on non-closure" `TypeError`, indistinguishable
from genuinely applying a non-callable.

### Change
- New `LocalJumpError` in `sir-runtime-core` (Python `Exception` subclass,
  TS `Error` subclass), exported from both package roots.
- `apply(nil, …)` raises it with the Ruby-style message
  `"no block given (yield)"`. A genuine non-closure still raises `TypeError`,
  so the two failure modes stay separable.

### Tests
- Python: 33 pass, 100% coverage; `ruff` + `mypy --strict` clean.
- TS: 19 pass; `tsc` strict clean.

### Honest note
Ruby's exact `LocalJumpError` class identity isn't modelled (SIR has no
Ruby class hierarchy) — the analogue is keyed to the error's *shape*, not
Ruby's exception hierarchy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
