### PR TITLE
feat(ruby-sir): block_given? → not(null?(__sir_block__)) (Q10b)

### DIFF
--- a/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to the `ruby-to-semantic-ir` crate will be documented in this file.
 
+## [0.92.0] - 2026-06-19
+
+### Added (Q10b — `block_given?`)
+
+- `block_given?` (which reaches the lowerer as a bare `VarRef` named
+  `"block_given?"`, being parenless) is now rewritten, inside a method
+  body, to `not(null?(__sir_block__))` — i.e. "is the threaded block
+  parameter non-nil". Both builtins are already supported (a native
+  `not` arm + runtime-core `null?` dispatch), so it emits with no backend
+  change and validates.
+- The explicit-block-param detection (`thread_block_param`) now fires on
+  `block_given?` as well as `yield`, so a method that only queries
+  `block_given?` (and never yields) still gains the trailing
+  `__sir_block__` parameter and is registered in `block_param_methods`
+  (so Q9f threads the block at its call sites). The rewrite reuses the
+  existing control-flow-descending walk and still does not descend into
+  `MakeClosure`.
+- New tests: `block_given_in_yielding_method_becomes_nil_check`,
+  `block_given_alone_threads_block_param`,
+  `method_without_block_given_or_yield_is_unchanged`. Each threaded
+  module re-validates.
+
 ## [0.91.0] - 2026-06-19
 
 ### Added (Q9f — explicit block-param ABI, part 2: call-site normalization)

--- a/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
@@ -5363,6 +5363,135 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
+    // Phase Q10b — block_given? → not(null?(__sir_block__))
+    // -----------------------------------------------------------------------
+
+    /// Whether a `block_given?`-shaped nil-check —
+    /// `not(null?(VarRef __sir_block__))` — appears anywhere in a block.
+    fn finds_block_given_check(b: &semantic_ir::Block) -> bool {
+        fn is_check(e: &Expr) -> bool {
+            if let Expr::BuiltinCall { name, args, .. } = e {
+                if name == "not" && args.len() == 1 {
+                    if let Expr::BuiltinCall { name: inner, args: ia, .. } = &args[0] {
+                        if inner == "null?" && ia.len() == 1 {
+                            return matches!(&ia[0],
+                                Expr::VarRef { name, scope, .. }
+                                    if name == "__sir_block__" && *scope == Scope::Param);
+                        }
+                    }
+                }
+            }
+            false
+        }
+        fn in_expr(e: &Expr) -> bool {
+            if is_check(e) {
+                return true;
+            }
+            match e {
+                Expr::DirectCall { args, .. }
+                | Expr::BuiltinCall { args, .. }
+                | Expr::Intrinsic { args, .. } => args.iter().any(in_expr),
+                Expr::IndirectCall { target, args, .. } => {
+                    in_expr(target) || args.iter().any(in_expr)
+                }
+                Expr::If { cond, then_branch, else_branch, .. } => {
+                    in_expr(cond) || in_blk(then_branch) || in_blk(else_branch)
+                }
+                Expr::Block(b) => in_blk(b),
+                Expr::SeqLit { items, .. } => items.iter().any(in_expr),
+                Expr::LogicalAnd { lhs, rhs, .. } | Expr::LogicalOr { lhs, rhs, .. } => {
+                    in_expr(lhs) || in_expr(rhs)
+                }
+                _ => false,
+            }
+        }
+        fn in_blk(b: &semantic_ir::Block) -> bool {
+            b.stmts.iter().any(|s| match s {
+                Stmt::LetBinding { value, .. }
+                | Stmt::LetStarBinding { value, .. }
+                | Stmt::Assign { value, .. }
+                | Stmt::ExprStmt { expr: value, .. } => in_expr(value),
+                _ => false,
+            }) || in_expr(&b.value)
+        }
+        in_blk(b)
+    }
+
+    /// Whether a `VarRef` named `name` appears anywhere in a block (used to
+    /// assert the raw `block_given?` ref was fully rewritten away).
+    fn body_mentions_varref(b: &semantic_ir::Block, name: &str) -> bool {
+        fn in_expr(e: &Expr, name: &str) -> bool {
+            match e {
+                Expr::VarRef { name: n, .. } => n == name,
+                Expr::DirectCall { args, .. }
+                | Expr::BuiltinCall { args, .. }
+                | Expr::Intrinsic { args, .. } => args.iter().any(|a| in_expr(a, name)),
+                Expr::IndirectCall { target, args, .. } => {
+                    in_expr(target, name) || args.iter().any(|a| in_expr(a, name))
+                }
+                Expr::If { cond, then_branch, else_branch, .. } => {
+                    in_expr(cond, name) || in_blk(then_branch, name) || in_blk(else_branch, name)
+                }
+                Expr::Block(b) => in_blk(b, name),
+                Expr::SeqLit { items, .. } => items.iter().any(|i| in_expr(i, name)),
+                Expr::LogicalAnd { lhs, rhs, .. } | Expr::LogicalOr { lhs, rhs, .. } => {
+                    in_expr(lhs, name) || in_expr(rhs, name)
+                }
+                _ => false,
+            }
+        }
+        fn in_blk(b: &semantic_ir::Block, name: &str) -> bool {
+            b.stmts.iter().any(|s| match s {
+                Stmt::LetBinding { value, .. }
+                | Stmt::LetStarBinding { value, .. }
+                | Stmt::Assign { value, .. }
+                | Stmt::ExprStmt { expr: value, .. } => in_expr(value, name),
+                _ => false,
+            }) || in_expr(&b.value, name)
+        }
+        in_blk(b, name)
+    }
+
+    #[test]
+    fn block_given_in_yielding_method_becomes_nil_check() {
+        let m = lower("def t\n  if block_given?\n    yield 5\n  end\nend\n");
+        let t = func(&m, "t");
+        assert_eq!(t.params.last().map(|p| p.name.as_str()), Some("__sir_block__"));
+        assert!(
+            finds_block_given_check(&t.body),
+            "block_given? must become not(null?(__sir_block__))"
+        );
+        assert!(
+            !body_mentions_varref(&t.body, "block_given?"),
+            "no raw block_given? VarRef may remain"
+        );
+        assert!(semantic_ir::validate(&m).is_ok(), "validates: {:?}", semantic_ir::validate(&m));
+    }
+
+    #[test]
+    fn block_given_alone_threads_block_param() {
+        // A method that queries block_given? but never yields must STILL be
+        // threaded (detection fires on block_given?, not only yield).
+        let m = lower("def t\n  if block_given?\n    1\n  else\n    2\n  end\nend\n");
+        let t = func(&m, "t");
+        assert_eq!(
+            t.params.last().map(|p| p.name.as_str()),
+            Some("__sir_block__"),
+            "block_given?-only method must still gain __sir_block__"
+        );
+        assert!(finds_block_given_check(&t.body));
+        assert!(semantic_ir::validate(&m).is_ok(), "validates: {:?}", semantic_ir::validate(&m));
+    }
+
+    #[test]
+    fn method_without_block_given_or_yield_is_unchanged() {
+        let m = lower("def g(x)\n  x + 1\nend\n");
+        let g = func(&m, "g");
+        assert_eq!(g.params.len(), 1, "non-block method keeps its arity");
+        assert!(!finds_block_given_check(&g.body));
+    }
+
+    // -----------------------------------------------------------------------
     // Phase 22d — `super` keyword lowering
     //
     //   super        → ExprStmt(BuiltinCall("zsuper", []))   (forward ALL)
@@ -7661,3 +7790,5 @@ b = "y"
         );
     }
 }
+
+

--- a/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
@@ -2925,7 +2925,9 @@ impl Lowerer {
     // -------------------------------------------------------------------
 
     /// Thread an explicit trailing block parameter through a freshly
-    /// lowered method `Function` *iff* its body `yield`s.
+    /// lowered method `Function` *iff* its body `yield`s **or** queries
+    /// `block_given?` (Q10b) — either is a use of the method's implicit
+    /// block and so requires the threaded `__sir_block__` parameter.
     ///
     /// ## Why
     ///
@@ -3152,9 +3154,41 @@ impl Lowerer {
                 }
                 found
             }
+            // Phase Q10b — `block_given?` reaches the lowerer as a bare
+            // `VarRef` named "block_given?" (it is parenless, so the
+            // method-call parser treats it as a name).  Inside a method
+            // it means "was a block passed?", which under the explicit
+            // block-param ABI is exactly "is __sir_block__ non-nil".
+            // Rewrite it to `not(null?(__sir_block__))` — both builtins
+            // are already supported (a native `not` arm + runtime-core
+            // `null?` dispatch) — and count it as a block reference so
+            // `thread_block_param` appends the parameter even when the
+            // method has no `yield`.
+            Expr::VarRef { name, span, .. } if name == "block_given?" => {
+                let span = span.clone();
+                let block_ref = Expr::VarRef {
+                    name: BLOCK_PARAM_NAME.to_string(),
+                    scope: Scope::Param,
+                    span: span.clone(),
+                };
+                let is_nil = Expr::BuiltinCall {
+                    name: "null?".to_string(),
+                    args: vec![block_ref],
+                    effects: EffectSet::PURE,
+                    span: span.clone(),
+                };
+                *expr = Expr::BuiltinCall {
+                    name: "not".to_string(),
+                    args: vec![is_nil],
+                    effects: EffectSet::PURE,
+                    span,
+                };
+                true
+            }
             // MakeClosure is deliberately NOT descended (v0 cut-line:
             // yield inside a hoisted block belongs to the enclosing
-            // method).  Atomic literals and VarRef have no sub-exprs.
+            // method).  Atomic literals and other VarRefs have no
+            // sub-exprs to rewrite.
             Expr::MakeClosure { .. }
             | Expr::IntLit { .. }
             | Expr::BoolLit { .. }


### PR DESCRIPTION
## Q10b — `block_given?` → `not(null?(__sir_block__))`

Closes another deferred Q9 cut-line. `block_given?` previously reached the
lowerer as a bare `VarRef` named `"block_given?"` and would not resolve.

### Change
- Inside a method body, `block_given?` is rewritten to
  `not(null?(__sir_block__))` — "is the threaded block parameter non-nil".
  Both builtins are already supported (native `not` arm + runtime-core
  `null?` dispatch), so it emits with no backend change and validates.
- The explicit-block-param detection (`thread_block_param`) now fires on
  `block_given?` as well as `yield`, so a method that only queries
  `block_given?` (never yields) still gains the trailing `__sir_block__`
  parameter and is registered in `block_param_methods` (Q9f threads the
  block at its call sites). Reuses the control-flow-descending walk; still
  does not descend into `MakeClosure`.

### Tests (`-p ruby-to-semantic-ir`, 357 pass)
- `block_given_in_yielding_method_becomes_nil_check`
- `block_given_alone_threads_block_param`
- `method_without_block_given_or_yield_is_unchanged`

Each threaded module re-validates. Backend suites unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
