### PR TITLE
feat(inline): nested splice for uniquely-declared top-level refs (CLOC16 Slice B1)

### DIFF
--- a/code/packages/rust/closure-pass-inline/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-inline/CHANGELOG.md
@@ -2,6 +2,61 @@
 
 All notable changes to the `coding-adventures-closure-pass-inline` crate will be documented in this file.
 
+## [0.12.0] - 2026-06-19
+
+### Added (CLOC16 Slice B1 — nested splice sites via a global-uniqueness gate)
+
+Slice A admitted a free identifier resolving to a top-level declaration but
+restricted such a candidate to **top-level** splice sites (where no scope can
+shadow a top-level name). Slice B1 lifts that restriction for the common case
+**without any scope walk**, using a global-uniqueness check:
+
+```js
+function dep() { return 1; } dep(); dep();
+function f()   { log(0); use(dep); }
+function main(){ f(); }            // f's only call — NESTED
+main(); main();
+// SIMPLE ⇒ function main(){ log(0); use(dep) }   (f now spliced into main)
+```
+
+**The gate.** `count_decl_names_*` counts **every** binding declaration at
+every depth program-wide (its catch-all arm is deliberately exhaustive), so
+`decl_counts[name]` is exact. If a top-level free ident has
+`decl_counts[name] == 1`, it is declared **exactly once** in the entire program
+(the top-level declaration) — **no other binding of that name exists anywhere**,
+so it cannot be shadowed at *any* splice site. Such a name therefore behaves
+like a true global for splice-location purposes: the candidate carries no
+top-level-only obligation and inlines even at nested sites.
+
+A top-level name that is **also** declared elsewhere (`decl_counts > 1`) keeps
+the Slice A top-level-only obligation — a local of that name could shadow it at
+a nested site, so the splice is declined there:
+
+```js
+function dep() { keep(); return 1; } dep();
+function f()   { log(0); use(dep); }
+function g()   { let dep = 99; f(); }   // dep declared twice ⇒ f stays top-level-only
+g(); g();
+// f is NOT inlined into g by the inline pass in isolation (decl_counts[dep] == 2).
+```
+
+This is sound on the pass's own terms: the gate reads `decl_counts` of the
+program the pass actually receives, so a `== 1` count genuinely means the name
+is unshadowable in that program. (An earlier pass that renamed away a shadowing
+local merely makes the program the inliner sees have no shadow — still sound.)
+
+**Implementation.** One classification branch in `void_candidate_from_function`:
+a top-level free ident with `decl_counts == 1` is treated like a true global
+(no obligation); `> 1` keeps the Slice A `free_top_level` (top-level-only)
+behaviour. The splice-site guards are unchanged. 4 new/repurposed tests (76
+total): the two former Slice A nested/block *decline* tests used a
+singly-declared `const K`, so they are now positive Slice B1 cases
+(`inlines_unique_top_level_ref_at_nested_site`, `inlines_unique_top_level_ref_in_block`);
+new decline/admit tests cover the multiply-declared name at nested vs. top-level
+sites. Resolves CLOC16 **Slice B1**; **Slice B2** (an in-scope-binding scope
+walk to admit the multiply-declared, genuinely-unshadowed nested case) remains
+future work.
+
 ## [0.11.0] - 2026-06-19
 
 ### Added (CLOC16 Slice A — free idents resolving to top-level declarations)

--- a/code/packages/rust/closure-pass-inline/Cargo.toml
+++ b/code/packages/rust/closure-pass-inline/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-inline"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2021"
 description = "Function-inlining pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Substitutes small or single-use function bodies at their call sites to enable downstream folding and shrink call overhead."
 

--- a/code/packages/rust/closure-pass-inline/README.md
+++ b/code/packages/rust/closure-pass-inline/README.md
@@ -126,16 +126,22 @@ structurally cannot do. It is admitted only under a tight, sound subset
 5. **Callee locals alpha-renamed to program-fresh names** before
    splicing — a spliced `let e` can never collide with the call-site
    scope.
-6. **Free identifiers must be true globals, or top-level declarations
-   spliced only at a top-level site.** A free ident declared *nowhere* is a
-   true global — unshadowable everywhere, spliceable anywhere. A free ident
-   that resolves to a **top-level declaration** (a sibling `function`, a
-   top-level `const`/`let`/`var`) is admitted by **CLOC16 Slice A** but marks
-   the candidate top-level-only: it splices **only when its single call is a
-   direct `program.body` member** (program scope can't shadow a top-level
-   name); at any nested call site the splice is declined. A free ident
-   declared only *inside another function* is still rejected. (Slice B will
-   widen nested sites via an in-scope-binding walk / `closure-scope-analyzer`.)
+6. **Free identifiers must be true globals, uniquely-declared top-level
+   names, or top-level names spliced only at a top-level site.** A free ident
+   declared *nowhere* is a true global — unshadowable everywhere, spliceable
+   anywhere. A free ident resolving to a **top-level declaration** (a sibling
+   `function`, a top-level `const`/`let`/`var`) is admitted by **CLOC16**:
+   - if it is declared **exactly once** program-wide (`decl_counts == 1`), no
+     other binding of the name exists, so it is unshadowable everywhere and
+     splices anywhere (**Slice B1**);
+   - if it is **also** declared elsewhere (`decl_counts > 1`), a local could
+     shadow it at a nested site, so the candidate is top-level-only — it
+     splices **only when its single call is a direct `program.body` member**
+     (**Slice A**); at any nested call site it is declined.
+
+   A free ident declared only *inside another function* is still rejected.
+   (Slice B2 will widen the multiply-declared nested case via an
+   in-scope-binding walk / `closure-scope-analyzer`.)
 7. **Side-effect-free arguments** — the same `is_simple_arg` gate.
 
 Since the call site discards the result (CLOC15 PR-2), a **tail `return E`**

--- a/code/packages/rust/closure-pass-inline/src/lib.rs
+++ b/code/packages/rust/closure-pass-inline/src/lib.rs
@@ -1463,17 +1463,27 @@ fn void_candidate_from_function(
         if param_set.contains(name) || local_set.contains(name) {
             continue; // a parameter or a callee-local — handled by splicing
         }
-        // (6) a free identifier. Three sound cases; anything else is rejected.
+        // (6) a free identifier. Sound cases below; anything else is rejected.
         if top_level_decls.contains(name) {
-            // CLOC16 Slice A: resolves to a top-level declaration. Sound to
-            // splice ONLY at a direct `program.body` site (where program scope
-            // guarantees the same resolution, unshadowed). The splice walker
-            // enforces that; here we just record the obligation. Note this
-            // holds regardless of `decl_counts[name]`: even if the name is
-            // ALSO bound in some nested scope elsewhere, a top-level splice
-            // site sees only program scope, so the reference still resolves to
-            // the top-level binding.
-            free_top_level.insert(name.clone());
+            // Resolves to a top-level declaration. Two sub-cases by how many
+            // times the name is declared **program-wide** (`count_decl_names_*`
+            // counts every binding at every depth, so the count is exact):
+            if decl_counts.get(name).copied().unwrap_or(0) == 1 {
+                // CLOC16 Slice B (uniqueness gate): declared EXACTLY ONCE, and
+                // that declaration is the top-level one. No other binding of
+                // the name exists anywhere in the program, so NO scope — at
+                // any splice site, nested or not — can shadow it. It therefore
+                // behaves like a true global for splice-location purposes: no
+                // obligation, splices everywhere. (A scope walk would be
+                // needed only to admit the multiply-declared case below.)
+            } else {
+                // CLOC16 Slice A: the name is ALSO declared elsewhere (a local
+                // in some other scope could shadow it). Sound to splice ONLY at
+                // a direct `program.body` site, where program scope guarantees
+                // the same resolution. Record the obligation; the splice walker
+                // enforces the top-level-only restriction.
+                free_top_level.insert(name.clone());
+            }
         } else if decl_counts.get(name).copied().unwrap_or(0) == 0 {
             // A true global — declared nowhere, so unshadowable everywhere.
             // No obligation (unchanged behaviour).
@@ -3309,29 +3319,92 @@ mod tests {
         );
     }
 
+    // ----- CLOC16 Slice B: nested sites for UNIQUELY-declared top-level refs
+
     #[test]
-    fn does_not_inline_free_top_level_when_call_is_nested() {
-        // The SAME helper, but its single call sits inside another function.
-        // That is a NESTED splice site where a local could shadow `K`, so
-        // Slice A declines it (the call is left intact). `main` is multi-use
-        // so it is not itself inlined, keeping the call nested.
+    fn inlines_unique_top_level_ref_at_nested_site() {
+        // CLOC16 Slice B (uniqueness gate): `K` is a top-level `const`
+        // declared EXACTLY ONCE program-wide, so no other binding of `K`
+        // exists anywhere — it cannot be shadowed at any site. The helper `f`
+        // therefore carries no top-level-only obligation and inlines even at a
+        // NESTED call site (inside `main`). (`main` is multi-use, so it is not
+        // itself inlined — the call stays nested.) Previously declined by
+        // Slice A's blanket top-level-only rule; admitting it is the intended
+        // Slice B behaviour change.
         assert_eq!(
             inline_source(
                 "const K = 5; function f() { sink(K); } \
                  function main() { f(); } main(); main();"
             ),
-            "const K=5;function f(){sink(K)};function main(){f()};main();main();"
+            "const K=5;function f(){sink(K)};function main(){sink(K)};main();main();"
         );
     }
 
     #[test]
-    fn does_not_inline_free_top_level_when_call_in_top_level_block() {
-        // A call inside a top-level BLOCK is not a direct `program.body`
-        // member — a block-scoped `let K` there could shadow the top-level
-        // `K`, so Slice A declines it.
+    fn inlines_unique_top_level_ref_in_block() {
+        // Likewise inside a top-level block: `K` declared once ⇒ unshadowable,
+        // so the splice is sound there too.
         assert_eq!(
             inline_source("const K = 5; function f() { sink(K); } { f(); }"),
-            "const K=5;function f(){sink(K)};{f()}"
+            "const K=5;function f(){sink(K)};{sink(K)}"
+        );
+    }
+
+    #[test]
+    fn does_not_inline_multiply_declared_top_level_ref_at_nested_site() {
+        // The name is declared TWICE — top-level `function dep` AND a local
+        // `let dep` in `g`. `decl_counts[dep] == 2`, so the uniqueness gate
+        // does NOT apply and `f` keeps the Slice A top-level-only obligation.
+        // Its single call sits inside `g` (a nested site that DOES shadow
+        // `dep`), so the splice is declined — preventing the miscompile where
+        // `use(dep)` would read `g`'s local. `dep` is multi-use+multi-statement
+        // so it is not itself inlined; `g` is multi-use so it stays.
+        assert_eq!(
+            inline_source(
+                "function dep() { keep(); return 1; } dep(); \
+                 function f() { log(0); use(dep); } \
+                 function g() { let dep = 99; f(); } g(); g();"
+            ),
+            "function dep(){keep();return 1};dep();\
+             function f(){log(0);use(dep)};function g(){let dep=99;f()};g();g();"
+        );
+    }
+
+    #[test]
+    fn inlines_multiply_declared_top_level_ref_at_top_level_site() {
+        // The SAME multiply-declared `dep`, but `f`'s single call is at the
+        // top level — a direct `program.body` site where program scope cannot
+        // shadow `dep` (the other `dep` is a local in `other`, out of scope
+        // here). Slice A admits it. This keeps the Slice A top-level path
+        // exercised now that the uniqueness gate handles the single-decl case.
+        assert_eq!(
+            inline_source(
+                "function dep() { keep(); return 1; } dep(); \
+                 function f() { log(0); use(dep); } f(); \
+                 function other() { let dep = 5; return dep; } other(); other();"
+            ),
+            "function dep(){keep();return 1};dep();function f(){log(0);use(dep)};\
+             log(0);use(dep);function other(){let dep=5;return dep};other();other();"
+        );
+    }
+
+    #[test]
+    fn does_not_inline_when_nested_function_shadows_top_level_ref() {
+        // The soundness linchpin for the uniqueness gate: `count_decl_names_*`
+        // counts NESTED function-declaration names too, so the top-level
+        // `function dep` plus the nested `function dep` inside `g` make
+        // `decl_counts[dep] == 2`. `f` therefore keeps the top-level-only
+        // obligation, and its single (nested) call inside `g` is declined —
+        // preventing the miscompile where the spliced `use(dep)` would capture
+        // `g`'s nested `dep` (99) instead of the top-level one.
+        assert_eq!(
+            inline_source(
+                "function dep() { return 1; } dep(); \
+                 function f() { log(0); use(dep); } \
+                 function g() { function dep() { return 99; } f(); dep(); } g(); g();"
+            ),
+            "function dep(){return 1};dep();function f(){log(0);use(dep)};\
+             function g(){function dep(){return 99};f();dep()};g();g();"
         );
     }
 

--- a/code/specs/CLOC16-inline-free-identifier-widening.md
+++ b/code/specs/CLOC16-inline-free-identifier-widening.md
@@ -1,6 +1,7 @@
 # CLOC16 — inline free-identifier widening (top-level declarations)
 
-**Status:** Slice A **implemented** (`closure-pass-inline` 0.11.0); Slice B
+**Status:** Slice A **implemented** (`closure-pass-inline` 0.11.0); Slice B1
+(global-uniqueness gate) **implemented** (0.12.0); Slice B2 (scope walk)
 deferred. Resolves [CLOC15](CLOC15-multi-statement-inlining.md) **Open
 question 1**.
 
@@ -117,18 +118,37 @@ sound enforcement levels:
   > declines it — correctly, since a block-scoped `let`/`const` there could
   > shadow.
 
-- **Slice B (nested splice site — needs an in-scope-binding set).** Thread the
-  set of **binding names in scope at the splice point** through the splice
-  walkers: on entering a function body add its params, its hoisted `var`s, its
-  nested `function` declaration names, and the function's own name; on entering
-  a block add that block's `let`/`const`/`function` names; etc. Before
-  splicing a `free_top_level` candidate, reject (decline, leave the call) if
-  **any** `free_top_level` name is in the current in-scope set. This admits the
-  much larger population of helpers called *inside* other functions, gated by a
-  real (if bootstrap) shadowing analysis. CLOC13's `closure-scope-analyzer`
-  already computes per-node scope information; Slice B may either consume it
-  (preferred long-term) or use a self-contained enclosing-binding walk (simpler
-  bootstrap, matching CLOC15 OQ1's suggestion).
+- **Slice B1 (nested splice site — global-uniqueness gate, IMPLEMENTED).** A
+  much simpler sound mechanism than a scope walk handles the *common* nested
+  case. `count_decl_names_*` counts **every** binding declaration at every
+  depth program-wide (its catch-all arm is deliberately exhaustive), so
+  `decl_counts[name]` is exact. If a top-level free ident has
+  `decl_counts[name] == 1`, it is declared **exactly once** in the whole
+  program — **no other binding of the name exists anywhere**, so it cannot be
+  shadowed at *any* splice site. Such a name carries **no** top-level-only
+  obligation (it is treated like a true global for splice-location): the
+  candidate inlines even at nested sites, with no scope walk. A top-level name
+  with `decl_counts > 1` keeps the Slice A top-level-only obligation. This is
+  sound on the pass's own terms — the gate reads `decl_counts` of the program
+  the pass actually receives, so `== 1` genuinely means unshadowable there.
+  Implemented in `void_candidate_from_function` as a single classification
+  branch; the splice-site guards are unchanged.
+
+- **Slice B2 (nested splice site — in-scope-binding set, FUTURE).** The
+  remaining case is a top-level name that is *also* declared elsewhere
+  (`decl_counts > 1`) but is **not actually shadowed at the specific call
+  site** (the other declaration is in an unrelated scope). Admitting it needs a
+  real shadowing check: thread the set of **binding names in scope at the
+  splice point** through the splice walkers — on entering a function body add
+  its params, its hoisted `var`s, its nested `function` declaration names, and
+  the function's own name; on entering a block add that block's
+  `let`/`const`/`function` names; etc. Before splicing a `free_top_level`
+  candidate, reject if **any** `free_top_level` name is in the current in-scope
+  set. CLOC13's `closure-scope-analyzer` already computes per-node scope
+  information; Slice B2 may consume it (preferred long-term) or use a
+  self-contained enclosing-binding walk (simpler bootstrap, matching CLOC15
+  OQ1's suggestion). Lower priority than B1 since the multiply-declared name is
+  the rarer case and B1 already covers the bulk.
 
 ### 3. Both inline paths share the gate
 


### PR DESCRIPTION
## What

Implements **Slice B1** of [CLOC16](code/specs/CLOC16-inline-free-identifier-widening.md). Slice A admitted a free identifier resolving to a top-level declaration but restricted such a candidate to **top-level** splice sites. Slice B1 lifts that restriction for the common case **with no scope walk**, via a global-uniqueness gate:

```js
function dep(){ return 1; } dep(); dep();
function f(){ log(0); use(dep); }
function main(){ f(); }            // f's only call — NESTED
main(); main();
// SIMPLE ⇒ function main(){ log(0); use(dep) }   (f now spliced into main)
```

## The gate

`count_decl_names_*` counts **every** binding declaration at every depth program-wide (top-level + nested function names + all params + all var/let/const at any depth; its catch-all arm is deliberately exhaustive), so `decl_counts[name]` is exact. A top-level free ident with **`decl_counts == 1`** is declared exactly once in the whole program — **no other binding of the name exists anywhere** — so it cannot be shadowed at *any* splice site and behaves like a true global for splice-location purposes (inlines at nested sites). A top-level name with `decl_counts > 1` keeps the Slice A top-level-only obligation.

Sound on the pass's own terms: the gate reads `decl_counts` of the program the pass actually receives, so `== 1` genuinely means unshadowable there.

## Soundness — verified, including the linchpin

The whole gate rests on `count_decl_names_*` counting **nested function-declaration names**. Verified in code (the `Statement::Declaration` arm, reached through block/function-body recursion, counts `fd.id.name`), as a unit test, **and** end-to-end:

```js
function dep(){ return 1; } dep();
function f(){ log(0); use(dep); }
function g(){ function dep(){ return 99; } f(); dep(); }   // nested `function dep` shadow
g(); g();
// decl_counts[dep] == 2 ⇒ f stays top-level-only ⇒ NOT inlined into g
// (would otherwise capture the nested dep=99). Correctly declined.
```

## Verification

- **77 unit tests** (4 new/repurposed + the nested-function-shadow linchpin). The two former Slice A nested/block *decline* tests used a singly-declared `const K`, so they're now positive Slice B1 cases; new tests cover the multiply-declared name at nested (declined) vs. top-level (admitted) sites.
- **End-to-end through the real `closurec` binary**: the nested-call win + every shadow-prevention case.
- **All 680 closurec integration tests green, no fixture churn.** Downstream `remove-unused-vars` consumer green.
- **Inline Rust security review: PASSED** — the uniqueness gate is airtight given the exhaustive program-wide decl count; no panic/overflow/recursion.

## Implementation

One classification branch in `void_candidate_from_function`; the splice-site guards are unchanged. crate `0.11.0` → `0.12.0`; CHANGELOG, README, and CLOC16 (Slice B split into **B1** implemented / **B2** — the scope-walk for the multiply-declared genuinely-unshadowed nested case — future) updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)