### PR TITLE
feat(smart-home): surface mesh execution evidence tools

### DIFF
--- a/code/packages/rust/chief-of-staff-smart-home-tools/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/src/lib.rs
@@ -72,6 +72,8 @@ use smart_home_integration_catalog::{
     mesh_protocol_substrate_preflight_repair_schedule,
     mesh_protocol_substrate_preflight_repair_slot_audit_rows,
     mesh_protocol_substrate_preflight_repair_slot_audit_summary,
+    mesh_protocol_substrate_preflight_repair_slot_execution_evidence_packets,
+    mesh_protocol_substrate_preflight_repair_slot_execution_evidence_summary,
     mesh_protocol_substrate_preflight_repair_slot_execution_ticket_summary,
     mesh_protocol_substrate_preflight_repair_slot_execution_tickets,
     mesh_protocol_substrate_preflight_repair_slot_execution_work_order_summary,
@@ -171,6 +173,8 @@ use smart_home_integration_catalog::{
     IntegrationMeshProtocolSubstratePreflightRepairScheduleSummary,
     IntegrationMeshProtocolSubstratePreflightRepairSlotAuditRow,
     IntegrationMeshProtocolSubstratePreflightRepairSlotAuditSummary,
+    IntegrationMeshProtocolSubstratePreflightRepairSlotExecutionEvidencePacket,
+    IntegrationMeshProtocolSubstratePreflightRepairSlotExecutionEvidenceSummary,
     IntegrationMeshProtocolSubstratePreflightRepairSlotExecutionTicket,
     IntegrationMeshProtocolSubstratePreflightRepairSlotExecutionTicketSummary,
     IntegrationMeshProtocolSubstratePreflightRepairSlotExecutionWorkOrder,
@@ -392,6 +396,10 @@ pub const SMART_HOME_LIST_INTEGRATION_MESH_PREFLIGHT_REPAIR_SLOT_EXECUTION_WORK_
     &str = "smart_home.list_integration_mesh_preflight_repair_slot_execution_work_orders";
 pub const SMART_HOME_GET_INTEGRATION_MESH_PREFLIGHT_REPAIR_SLOT_EXECUTION_WORK_ORDER_SUMMARY_TOOL_ID:
     &str = "smart_home.get_integration_mesh_preflight_repair_slot_execution_work_order_summary";
+pub const SMART_HOME_LIST_INTEGRATION_MESH_PREFLIGHT_REPAIR_SLOT_EXECUTION_EVIDENCE_TOOL_ID: &str =
+    "smart_home.list_integration_mesh_preflight_repair_slot_execution_evidence";
+pub const SMART_HOME_GET_INTEGRATION_MESH_PREFLIGHT_REPAIR_SLOT_EXECUTION_EVIDENCE_SUMMARY_TOOL_ID:
+    &str = "smart_home.get_integration_mesh_preflight_repair_slot_execution_evidence_summary";
 pub const SMART_HOME_GET_INTEGRATION_MESH_PREFLIGHT_READINESS_SUMMARY_TOOL_ID: &str =
     "smart_home.get_integration_mesh_preflight_readiness_summary";
 pub const SMART_HOME_GET_INTEGRATION_MESH_PREFLIGHT_REPAIR_READINESS_SUMMARY_TOOL_ID: &str =
@@ -1012,6 +1020,24 @@ impl SmartHomeToolBridge {
                     let query = integration_readiness_query(&arguments)?;
                     Ok(
                         get_integration_mesh_preflight_repair_slot_execution_work_order_summary_output_handler_output(
+                            query,
+                        ),
+                    )
+                }
+                SMART_HOME_LIST_INTEGRATION_MESH_PREFLIGHT_REPAIR_SLOT_EXECUTION_EVIDENCE_TOOL_ID =>
+                {
+                    let query = integration_readiness_query(&arguments)?;
+                    Ok(
+                        list_integration_mesh_preflight_repair_slot_execution_evidence_output_handler_output(
+                            query,
+                        ),
+                    )
+                }
+                SMART_HOME_GET_INTEGRATION_MESH_PREFLIGHT_REPAIR_SLOT_EXECUTION_EVIDENCE_SUMMARY_TOOL_ID =>
+                {
+                    let query = integration_readiness_query(&arguments)?;
+                    Ok(
+                        get_integration_mesh_preflight_repair_slot_execution_evidence_summary_output_handler_output(
                             query,
                         ),
                     )
@@ -3084,6 +3110,41 @@ pub fn smart_home_tool_definitions() -> Vec<ToolDefinition> {
             SMART_HOME_GET_INTEGRATION_MESH_PREFLIGHT_REPAIR_SLOT_EXECUTION_WORK_ORDER_SUMMARY_TOOL_ID,
             "Get smart-home integration mesh preflight repair slot execution work order summary",
             "Return compact D23 mesh preflight repair slot execution work order counts.",
+            integration_readiness_query_schema(true),
+            object_schema(
+                vec![SchemaProperty::new("summary", JsonSchema::Any)],
+                vec!["summary"],
+                false,
+            ),
+        ),
+        read_definition(
+            SMART_HOME_LIST_INTEGRATION_MESH_PREFLIGHT_REPAIR_SLOT_EXECUTION_EVIDENCE_TOOL_ID,
+            "List smart-home integration mesh preflight repair slot execution evidence",
+            "List D23 mesh preflight repair slot execution evidence packets derived from execution work orders.",
+            integration_readiness_query_schema(true),
+            object_schema(
+                vec![
+                    SchemaProperty::new(
+                        "mesh_preflight_repair_slot_execution_evidence_packets",
+                        JsonSchema::Array {
+                            items: Box::new(JsonSchema::Any),
+                        },
+                    ),
+                    SchemaProperty::new("summary", JsonSchema::Any),
+                    SchemaProperty::new("count", JsonSchema::Integer),
+                ],
+                vec![
+                    "mesh_preflight_repair_slot_execution_evidence_packets",
+                    "summary",
+                    "count",
+                ],
+                false,
+            ),
+        ),
+        read_definition(
+            SMART_HOME_GET_INTEGRATION_MESH_PREFLIGHT_REPAIR_SLOT_EXECUTION_EVIDENCE_SUMMARY_TOOL_ID,
+            "Get smart-home integration mesh preflight repair slot execution evidence summary",
+            "Return compact D23 mesh preflight repair slot execution evidence counts.",
             integration_readiness_query_schema(true),
             object_schema(
                 vec![SchemaProperty::new("summary", JsonSchema::Any)],
@@ -17602,6 +17663,39 @@ fn integration_mesh_preflight_repair_slot_execution_work_order_summary_for_query
     }
 }
 
+fn integration_mesh_preflight_repair_slot_execution_evidence_packets_for_query(
+    query: &IntegrationReadinessQuery,
+) -> Vec<IntegrationMeshProtocolSubstratePreflightRepairSlotExecutionEvidencePacket> {
+    let mut packets = mesh_protocol_substrate_preflight_repair_slot_execution_evidence_packets(
+        &query.available_primitives,
+    );
+
+    if query.activation_ready == Some(true) {
+        packets.clear();
+    }
+    if let Some(limit) = query.limit {
+        packets.truncate(limit);
+    }
+
+    packets
+}
+
+fn integration_mesh_preflight_repair_slot_execution_evidence_summary_for_query(
+    query: &IntegrationReadinessQuery,
+) -> IntegrationMeshProtocolSubstratePreflightRepairSlotExecutionEvidenceSummary {
+    if query.activation_ready.is_some() || query.limit.is_some() {
+        let packets =
+            integration_mesh_preflight_repair_slot_execution_evidence_packets_for_query(query);
+        IntegrationMeshProtocolSubstratePreflightRepairSlotExecutionEvidenceSummary::from_packets(
+            packets.iter(),
+        )
+    } else {
+        mesh_protocol_substrate_preflight_repair_slot_execution_evidence_summary(
+            &query.available_primitives,
+        )
+    }
+}
+
 fn integration_mesh_preflight_readiness_summary_for_query(
     query: &IntegrationReadinessQuery,
 ) -> IntegrationMeshPreflightReadinessSummary {
@@ -22474,6 +22568,95 @@ fn get_integration_mesh_preflight_repair_slot_execution_work_order_summary_outpu
                 "has_work_orders",
                 JsonValue::Bool(summary.has_work_orders()),
             ),
+        ]),
+    )
+}
+
+fn list_integration_mesh_preflight_repair_slot_execution_evidence_output_handler_output(
+    query: IntegrationReadinessQuery,
+) -> ToolHandlerOutput {
+    let packets =
+        integration_mesh_preflight_repair_slot_execution_evidence_packets_for_query(&query);
+    let summary =
+        IntegrationMeshProtocolSubstratePreflightRepairSlotExecutionEvidenceSummary::from_packets(
+            packets.iter(),
+        );
+    let count = packets.len();
+
+    ToolHandlerOutput::new(object([
+        (
+            "mesh_preflight_repair_slot_execution_evidence_packets",
+            JsonValue::Array(
+                packets
+                    .iter()
+                    .map(mesh_protocol_substrate_preflight_repair_slot_execution_evidence_packet_json)
+                    .collect(),
+            ),
+        ),
+        (
+            "summary",
+            mesh_protocol_substrate_preflight_repair_slot_execution_evidence_summary_json(
+                &summary,
+            ),
+        ),
+        ("count", integer(count as i64)),
+    ]))
+    .with_event(
+        ToolEventKind::Progress,
+        object([
+            (
+                "operation",
+                string("list_integration_mesh_preflight_repair_slot_execution_evidence"),
+            ),
+            ("evidence_packets", integer(count as i64)),
+            (
+                "scheduled_actions",
+                integer(summary.scheduled_actions as i64),
+            ),
+            (
+                "blocking_packets",
+                integer(summary.blocking_packets as i64),
+            ),
+            (
+                "operator_required_packets",
+                integer(summary.operator_required_packets as i64),
+            ),
+            (
+                "execution_evidence_ready",
+                JsonValue::Bool(summary.execution_evidence_ready),
+            ),
+        ]),
+    )
+}
+
+fn get_integration_mesh_preflight_repair_slot_execution_evidence_summary_output_handler_output(
+    query: IntegrationReadinessQuery,
+) -> ToolHandlerOutput {
+    let summary =
+        integration_mesh_preflight_repair_slot_execution_evidence_summary_for_query(&query);
+
+    ToolHandlerOutput::new(object([(
+        "summary",
+        mesh_protocol_substrate_preflight_repair_slot_execution_evidence_summary_json(&summary),
+    )]))
+    .with_event(
+        ToolEventKind::Progress,
+        object([
+            (
+                "operation",
+                string("get_integration_mesh_preflight_repair_slot_execution_evidence_summary"),
+            ),
+            ("total_packets", integer(summary.total_packets as i64)),
+            (
+                "scheduled_actions",
+                integer(summary.scheduled_actions as i64),
+            ),
+            ("blocking_packets", integer(summary.blocking_packets as i64)),
+            (
+                "operator_required_packets",
+                integer(summary.operator_required_packets as i64),
+            ),
+            ("has_packets", JsonValue::Bool(summary.has_packets())),
         ]),
     )
 }
@@ -45150,6 +45333,148 @@ fn mesh_protocol_substrate_preflight_repair_slot_execution_work_order_summary_js
     ])
 }
 
+fn mesh_protocol_substrate_preflight_repair_slot_execution_evidence_packet_json(
+    packet: &IntegrationMeshProtocolSubstratePreflightRepairSlotExecutionEvidencePacket,
+) -> JsonValue {
+    object([
+        ("sequence", integer(packet.sequence as i64)),
+        ("evidence_key", string(&packet.evidence_key)),
+        (
+            "work_order_sequence",
+            integer(packet.work_order_sequence as i64),
+        ),
+        ("work_order_key", string(&packet.work_order_key)),
+        ("ticket_sequence", integer(packet.ticket_sequence as i64)),
+        ("ticket_key", string(&packet.ticket_key)),
+        ("slot_sequence", integer(packet.slot_sequence as i64)),
+        ("batch_sequence", integer(packet.batch_sequence as i64)),
+        ("stage", string(packet.stage.as_str())),
+        (
+            "action_kind",
+            mesh_substrate_preflight_action_kind_json(packet.action_kind),
+        ),
+        ("status", string(packet.status.as_str())),
+        ("action_count", integer(packet.action_count as i64)),
+        ("protocol_count", integer(packet.protocol_count as i64)),
+        ("primitive_count", integer(packet.primitive_count as i64)),
+        ("protocols", protocol_family_array_json(&packet.protocols)),
+        (
+            "primitives",
+            primitive_family_array_json(&packet.primitives),
+        ),
+        ("release_blocking", JsonValue::Bool(packet.release_blocking)),
+        (
+            "operator_required",
+            JsonValue::Bool(packet.operator_required),
+        ),
+        ("lineage_complete", JsonValue::Bool(packet.lineage_complete)),
+        (
+            "blocks_preflight",
+            JsonValue::Bool(packet.blocks_preflight()),
+        ),
+        (
+            "requires_operator",
+            JsonValue::Bool(packet.requires_operator()),
+        ),
+        ("has_lineage", JsonValue::Bool(packet.has_lineage())),
+    ])
+}
+
+fn mesh_protocol_substrate_preflight_repair_slot_execution_evidence_summary_json(
+    summary: &IntegrationMeshProtocolSubstratePreflightRepairSlotExecutionEvidenceSummary,
+) -> JsonValue {
+    object([
+        ("total_packets", integer(summary.total_packets as i64)),
+        (
+            "scheduled_actions",
+            integer(summary.scheduled_actions as i64),
+        ),
+        ("blocking_packets", integer(summary.blocking_packets as i64)),
+        (
+            "operator_required_packets",
+            integer(summary.operator_required_packets as i64),
+        ),
+        (
+            "lineage_complete_packets",
+            integer(summary.lineage_complete_packets as i64),
+        ),
+        (
+            "protocol_mentions",
+            integer(summary.protocol_mentions as i64),
+        ),
+        (
+            "primitive_mentions",
+            integer(summary.primitive_mentions as i64),
+        ),
+        (
+            "first_evidence_key",
+            summary
+                .first_evidence_key
+                .as_ref()
+                .map(string)
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_blocking_evidence_key",
+            summary
+                .first_blocking_evidence_key
+                .as_ref()
+                .map(string)
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_operator_evidence_key",
+            summary
+                .first_operator_evidence_key
+                .as_ref()
+                .map(string)
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_work_order_key",
+            summary
+                .first_work_order_key
+                .as_ref()
+                .map(string)
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_ticket_key",
+            summary
+                .first_ticket_key
+                .as_ref()
+                .map(string)
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_stage",
+            summary
+                .first_stage
+                .map(|stage| string(stage.as_str()))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_action_kind",
+            summary
+                .first_action_kind
+                .map(mesh_substrate_preflight_action_kind_json)
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "execution_evidence_ready",
+            JsonValue::Bool(summary.execution_evidence_ready),
+        ),
+        ("is_empty", JsonValue::Bool(summary.is_empty())),
+        ("has_packets", JsonValue::Bool(summary.has_packets())),
+        ("has_blockers", JsonValue::Bool(summary.has_blockers())),
+        ("needs_operator", JsonValue::Bool(summary.needs_operator())),
+        (
+            "has_complete_lineage",
+            JsonValue::Bool(summary.has_complete_lineage()),
+        ),
+    ])
+}
+
 fn mesh_preflight_slot_readiness_summary_json(
     summary: &IntegrationMeshPreflightSlotReadinessSummary,
 ) -> JsonValue {
@@ -53017,7 +53342,7 @@ mod tests {
         let definitions = smart_home_tool_definitions();
         let export = ToolCatalogExport::from_definitions(definitions.iter());
 
-        assert_eq!(definitions.len(), 218);
+        assert_eq!(definitions.len(), 220);
         assert!(
             export.ok(),
             "tool export validation failed: {:?}",
@@ -53256,6 +53581,12 @@ mod tests {
         ));
         assert!(export.tool_ids().contains(
             &SMART_HOME_GET_INTEGRATION_MESH_PREFLIGHT_REPAIR_SLOT_EXECUTION_WORK_ORDER_SUMMARY_TOOL_ID
+        ));
+        assert!(export.tool_ids().contains(
+            &SMART_HOME_LIST_INTEGRATION_MESH_PREFLIGHT_REPAIR_SLOT_EXECUTION_EVIDENCE_TOOL_ID
+        ));
+        assert!(export.tool_ids().contains(
+            &SMART_HOME_GET_INTEGRATION_MESH_PREFLIGHT_REPAIR_SLOT_EXECUTION_EVIDENCE_SUMMARY_TOOL_ID
         ));
         assert!(export
             .tool_ids()
@@ -53648,7 +53979,7 @@ mod tests {
         ));
         assert_eq!(
             export.summary.required_capability_count("smart_home:read"),
-            210
+            212
         );
         assert_eq!(
             export
@@ -53781,6 +54112,14 @@ mod tests {
         .is_some());
         assert!(smart_home_tool_definition(
             SMART_HOME_GET_INTEGRATION_MESH_PREFLIGHT_REPAIR_SLOT_EXECUTION_WORK_ORDER_SUMMARY_TOOL_ID
+        )
+        .is_some());
+        assert!(smart_home_tool_definition(
+            SMART_HOME_LIST_INTEGRATION_MESH_PREFLIGHT_REPAIR_SLOT_EXECUTION_EVIDENCE_TOOL_ID
+        )
+        .is_some());
+        assert!(smart_home_tool_definition(
+            SMART_HOME_GET_INTEGRATION_MESH_PREFLIGHT_REPAIR_SLOT_EXECUTION_EVIDENCE_SUMMARY_TOOL_ID
         )
         .is_some());
         assert!(smart_home_tool_definition(
@@ -54440,11 +54779,11 @@ mod tests {
         let tool_catalog_summary = field(tool_catalog_summary_output, "summary").unwrap();
         assert_eq!(
             field(tool_catalog_summary, "total_tools"),
-            Some(&integer(218))
+            Some(&integer(220))
         );
         assert_eq!(
             field(tool_catalog_summary, "read_tools"),
-            Some(&integer(210))
+            Some(&integer(212))
         );
         assert_eq!(
             field(tool_catalog_summary, "risky_tool_count"),
@@ -57678,6 +58017,166 @@ mod tests {
             field(
                 mesh_preflight_repair_slot_execution_work_order_rollup,
                 "execution_work_orders_ready"
+            ),
+            Some(&JsonValue::Bool(false))
+        );
+
+        let list_mesh_preflight_repair_slot_execution_evidence_request = request(
+            "call-list-integration-mesh-preflight-repair-slot-execution-evidence",
+            SMART_HOME_LIST_INTEGRATION_MESH_PREFLIGHT_REPAIR_SLOT_EXECUTION_EVIDENCE_TOOL_ID,
+            object([
+                (
+                    "available_primitives",
+                    JsonValue::Array(vec![
+                        string("usb"),
+                        string("serial_controller"),
+                        string("radio_802154"),
+                        string("supervision"),
+                    ]),
+                ),
+                ("activation_ready", JsonValue::Bool(false)),
+            ]),
+            5_929_100,
+        );
+        let list_mesh_preflight_repair_slot_execution_evidence_trace = tool_runtime
+            .invoke_with_events(&list_mesh_preflight_repair_slot_execution_evidence_request);
+        assert!(
+            list_mesh_preflight_repair_slot_execution_evidence_trace
+                .result
+                .ok
+        );
+        assert_eq!(
+            list_mesh_preflight_repair_slot_execution_evidence_trace
+                .summary()
+                .progress_event_count,
+            1
+        );
+        let list_mesh_preflight_repair_slot_execution_evidence_output =
+            list_mesh_preflight_repair_slot_execution_evidence_trace
+                .result
+                .output
+                .as_ref()
+                .unwrap();
+        assert_eq!(
+            field(
+                list_mesh_preflight_repair_slot_execution_evidence_output,
+                "count"
+            ),
+            Some(&integer(3))
+        );
+        let mesh_preflight_repair_slot_execution_evidence_summary = field(
+            list_mesh_preflight_repair_slot_execution_evidence_output,
+            "summary",
+        )
+        .unwrap();
+        assert_eq!(
+            field(
+                mesh_preflight_repair_slot_execution_evidence_summary,
+                "scheduled_actions"
+            ),
+            Some(&integer(5))
+        );
+        assert_eq!(
+            field(
+                mesh_preflight_repair_slot_execution_evidence_summary,
+                "lineage_complete_packets"
+            ),
+            Some(&integer(3))
+        );
+        let mesh_preflight_repair_slot_execution_evidence_packet = array_item(
+            field(
+                list_mesh_preflight_repair_slot_execution_evidence_output,
+                "mesh_preflight_repair_slot_execution_evidence_packets",
+            )
+            .unwrap(),
+            0,
+        )
+        .unwrap();
+        assert_eq!(
+            field(
+                mesh_preflight_repair_slot_execution_evidence_packet,
+                "evidence_key"
+            ),
+            Some(&string("evidence-01-radio-provision_radio"))
+        );
+        assert_eq!(
+            field(
+                mesh_preflight_repair_slot_execution_evidence_packet,
+                "work_order_key"
+            ),
+            Some(&string("work-01-radio-provision_radio"))
+        );
+        assert_eq!(
+            field(
+                mesh_preflight_repair_slot_execution_evidence_packet,
+                "ticket_key"
+            ),
+            Some(&string("slot-01-radio-provision_radio"))
+        );
+        assert_eq!(
+            field(
+                mesh_preflight_repair_slot_execution_evidence_packet,
+                "lineage_complete"
+            ),
+            Some(&JsonValue::Bool(true))
+        );
+
+        let mesh_preflight_repair_slot_execution_evidence_summary_request = request(
+            "call-integration-mesh-preflight-repair-slot-execution-evidence-summary",
+            SMART_HOME_GET_INTEGRATION_MESH_PREFLIGHT_REPAIR_SLOT_EXECUTION_EVIDENCE_SUMMARY_TOOL_ID,
+            object([(
+                "available_primitives",
+                JsonValue::Array(vec![
+                    string("usb"),
+                    string("serial_controller"),
+                    string("radio_802154"),
+                    string("supervision"),
+                ]),
+            )]),
+            5_929_101,
+        );
+        let mesh_preflight_repair_slot_execution_evidence_summary_trace = tool_runtime
+            .invoke_with_events(&mesh_preflight_repair_slot_execution_evidence_summary_request);
+        assert!(
+            mesh_preflight_repair_slot_execution_evidence_summary_trace
+                .result
+                .ok
+        );
+        assert_eq!(
+            mesh_preflight_repair_slot_execution_evidence_summary_trace
+                .summary()
+                .progress_event_count,
+            1
+        );
+        let mesh_preflight_repair_slot_execution_evidence_summary_output =
+            mesh_preflight_repair_slot_execution_evidence_summary_trace
+                .result
+                .output
+                .as_ref()
+                .unwrap();
+        let mesh_preflight_repair_slot_execution_evidence_rollup = field(
+            mesh_preflight_repair_slot_execution_evidence_summary_output,
+            "summary",
+        )
+        .unwrap();
+        assert_eq!(
+            field(
+                mesh_preflight_repair_slot_execution_evidence_rollup,
+                "total_packets"
+            ),
+            Some(&integer(3))
+        );
+        assert_eq!(
+            field(
+                mesh_preflight_repair_slot_execution_evidence_rollup,
+                "blocking_packets"
+            ),
+            Some(&integer(3))
+        );
+        assert_eq!(
+            field(
+                mesh_preflight_repair_slot_execution_evidence_rollup,
+                "execution_evidence_ready"
             ),
             Some(&JsonValue::Bool(false))
         );

--- a/code/packages/rust/smart-home-core/src/lib.rs
+++ b/code/packages/rust/smart-home-core/src/lib.rs
@@ -1610,6 +1610,8 @@ pub enum SmartHomeTool {
     GetIntegrationMeshPreflightRepairSlotExecutionTicketSummary,
     ListIntegrationMeshPreflightRepairSlotExecutionWorkOrders,
     GetIntegrationMeshPreflightRepairSlotExecutionWorkOrderSummary,
+    ListIntegrationMeshPreflightRepairSlotExecutionEvidence,
+    GetIntegrationMeshPreflightRepairSlotExecutionEvidenceSummary,
     GetIntegrationMeshPreflightReadinessSummary,
     GetIntegrationMeshPreflightRepairReadinessSummary,
     GetIntegrationMeshPreflightBatchReadinessSummary,
@@ -2150,6 +2152,12 @@ impl SmartHomeTool {
             ),
             Self::GetIntegrationMeshPreflightRepairSlotExecutionWorkOrderSummary => read_tool(
                 "smart_home.get_integration_mesh_preflight_repair_slot_execution_work_order_summary",
+            ),
+            Self::ListIntegrationMeshPreflightRepairSlotExecutionEvidence => read_tool(
+                "smart_home.list_integration_mesh_preflight_repair_slot_execution_evidence",
+            ),
+            Self::GetIntegrationMeshPreflightRepairSlotExecutionEvidenceSummary => read_tool(
+                "smart_home.get_integration_mesh_preflight_repair_slot_execution_evidence_summary",
             ),
             Self::GetIntegrationMeshPreflightReadinessSummary => {
                 read_tool("smart_home.get_integration_mesh_preflight_readiness_summary")
@@ -2963,6 +2971,8 @@ pub fn smart_home_tool_catalog() -> Vec<ToolDescriptor> {
         SmartHomeTool::GetIntegrationMeshPreflightRepairSlotExecutionTicketSummary,
         SmartHomeTool::ListIntegrationMeshPreflightRepairSlotExecutionWorkOrders,
         SmartHomeTool::GetIntegrationMeshPreflightRepairSlotExecutionWorkOrderSummary,
+        SmartHomeTool::ListIntegrationMeshPreflightRepairSlotExecutionEvidence,
+        SmartHomeTool::GetIntegrationMeshPreflightRepairSlotExecutionEvidenceSummary,
         SmartHomeTool::GetIntegrationMeshPreflightReadinessSummary,
         SmartHomeTool::GetIntegrationMeshPreflightRepairReadinessSummary,
         SmartHomeTool::GetIntegrationMeshPreflightBatchReadinessSummary,
@@ -3811,7 +3821,7 @@ mod tests {
             .find(|tool| tool.tool_id == "smart_home.command")
             .unwrap();
 
-        assert_eq!(catalog.len(), 218);
+        assert_eq!(catalog.len(), 220);
         assert!(catalog
             .iter()
             .any(|tool| tool.tool_id == "smart_home.list_integrations"
@@ -4057,6 +4067,8 @@ mod tests {
             "smart_home.get_integration_mesh_stage_release_summary",
             "smart_home.get_integration_mesh_action_readiness_summary",
             "smart_home.get_integration_mesh_release_readiness_summary",
+            "smart_home.list_integration_mesh_preflight_repair_slot_execution_evidence",
+            "smart_home.get_integration_mesh_preflight_repair_slot_execution_evidence_summary",
             "smart_home.get_integration_mesh_preflight_slot_readiness_summary",
             "smart_home.list_integration_mesh_readiness_handoffs",
             "smart_home.get_integration_mesh_readiness_handoff_summary",
@@ -4632,6 +4644,14 @@ mod tests {
             && tool.side_effects == ToolSideEffects::Read
             && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
         assert!(catalog.iter().any(|tool| tool.tool_id
+            == "smart_home.list_integration_mesh_preflight_repair_slot_execution_evidence"
+            && tool.side_effects == ToolSideEffects::Read
+            && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
+        assert!(catalog.iter().any(|tool| tool.tool_id
+            == "smart_home.get_integration_mesh_preflight_repair_slot_execution_evidence_summary"
+            && tool.side_effects == ToolSideEffects::Read
+            && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
+        assert!(catalog.iter().any(|tool| tool.tool_id
             == "smart_home.get_integration_mesh_preflight_readiness_summary"
             && tool.side_effects == ToolSideEffects::Read
             && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
@@ -4662,15 +4682,15 @@ mod tests {
         let summary = smart_home_tool_catalog_summary();
         let pair_bridge = SmartHomeTool::PairBridge.descriptor();
 
-        assert_eq!(summary.total_tools, 218);
-        assert_eq!(summary.read_tools, 210);
+        assert_eq!(summary.total_tools, 220);
+        assert_eq!(summary.read_tools, 212);
         assert_eq!(summary.write_tools, 2);
         assert_eq!(summary.external_tools, 6);
-        assert_eq!(summary.read_only_tier_tools, 210);
+        assert_eq!(summary.read_only_tier_tools, 212);
         assert_eq!(summary.low_risk_tier_tools, 6);
         assert_eq!(summary.high_risk_tier_tools, 0);
         assert_eq!(summary.human_approval_tier_tools, 2);
-        assert_eq!(summary.total_required_capabilities, 218);
+        assert_eq!(summary.total_required_capabilities, 220);
         assert_eq!(summary.risky_tool_count(), 8);
         assert_eq!(summary.approval_gated_tool_count(), 2);
         assert!(pair_bridge.requires_human_approval());

--- a/code/packages/rust/smart-home-integration-catalog/src/lib.rs
+++ b/code/packages/rust/smart-home-integration-catalog/src/lib.rs
@@ -1515,6 +1515,164 @@ impl IntegrationMeshProtocolSubstratePreflightRepairSlotExecutionWorkOrderSummar
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IntegrationMeshProtocolSubstratePreflightRepairSlotExecutionEvidencePacket {
+    pub sequence: usize,
+    pub evidence_key: String,
+    pub work_order_sequence: usize,
+    pub work_order_key: String,
+    pub ticket_sequence: usize,
+    pub ticket_key: String,
+    pub slot_sequence: usize,
+    pub batch_sequence: usize,
+    pub stage: IntegrationMeshProtocolSubstrateStage,
+    pub action_kind: IntegrationMeshProtocolSubstratePreflightActionKind,
+    pub status: IntegrationMeshProtocolSubstratePreflightRepairSlotExecutionStatus,
+    pub action_count: usize,
+    pub protocol_count: usize,
+    pub primitive_count: usize,
+    pub protocols: Vec<ProtocolFamily>,
+    pub primitives: Vec<PrimitiveFamily>,
+    pub release_blocking: bool,
+    pub operator_required: bool,
+    pub lineage_complete: bool,
+}
+
+impl IntegrationMeshProtocolSubstratePreflightRepairSlotExecutionEvidencePacket {
+    pub fn from_work_order(
+        sequence: usize,
+        work_order: &IntegrationMeshProtocolSubstratePreflightRepairSlotExecutionWorkOrder,
+    ) -> Self {
+        let lineage_complete = !work_order.work_order_key.is_empty()
+            && work_order.ticket_sequence > 0
+            && !work_order.ticket_key.is_empty()
+            && work_order.slot_sequence > 0
+            && work_order.batch_sequence > 0;
+
+        Self {
+            sequence,
+            evidence_key: format!(
+                "evidence-{sequence:02}-{}-{}",
+                work_order.stage.as_str(),
+                work_order.action_kind.as_str()
+            ),
+            work_order_sequence: work_order.sequence,
+            work_order_key: work_order.work_order_key.clone(),
+            ticket_sequence: work_order.ticket_sequence,
+            ticket_key: work_order.ticket_key.clone(),
+            slot_sequence: work_order.slot_sequence,
+            batch_sequence: work_order.batch_sequence,
+            stage: work_order.stage,
+            action_kind: work_order.action_kind,
+            status: work_order.status,
+            action_count: work_order.action_count,
+            protocol_count: work_order.protocol_count,
+            primitive_count: work_order.primitive_count,
+            protocols: work_order.protocols.clone(),
+            primitives: work_order.primitives.clone(),
+            release_blocking: work_order.blocks_preflight(),
+            operator_required: work_order.requires_operator(),
+            lineage_complete,
+        }
+    }
+
+    pub fn blocks_preflight(&self) -> bool {
+        self.release_blocking
+    }
+
+    pub fn requires_operator(&self) -> bool {
+        self.operator_required
+    }
+
+    pub fn has_lineage(&self) -> bool {
+        self.lineage_complete
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IntegrationMeshProtocolSubstratePreflightRepairSlotExecutionEvidenceSummary {
+    pub total_packets: usize,
+    pub scheduled_actions: usize,
+    pub blocking_packets: usize,
+    pub operator_required_packets: usize,
+    pub lineage_complete_packets: usize,
+    pub protocol_mentions: usize,
+    pub primitive_mentions: usize,
+    pub first_evidence_key: Option<String>,
+    pub first_blocking_evidence_key: Option<String>,
+    pub first_operator_evidence_key: Option<String>,
+    pub first_work_order_key: Option<String>,
+    pub first_ticket_key: Option<String>,
+    pub first_stage: Option<IntegrationMeshProtocolSubstrateStage>,
+    pub first_action_kind: Option<IntegrationMeshProtocolSubstratePreflightActionKind>,
+    pub execution_evidence_ready: bool,
+}
+
+impl IntegrationMeshProtocolSubstratePreflightRepairSlotExecutionEvidenceSummary {
+    pub fn from_packets<'a>(
+        packets: impl IntoIterator<
+            Item = &'a IntegrationMeshProtocolSubstratePreflightRepairSlotExecutionEvidencePacket,
+        >,
+    ) -> Self {
+        let packets = packets.into_iter().collect::<Vec<_>>();
+        let first_packet = packets.iter().min_by_key(|packet| packet.sequence);
+        let first_blocking_packet = packets
+            .iter()
+            .filter(|packet| packet.blocks_preflight())
+            .min_by_key(|packet| packet.sequence);
+        let first_operator_packet = packets
+            .iter()
+            .filter(|packet| packet.requires_operator())
+            .min_by_key(|packet| packet.sequence);
+
+        Self {
+            total_packets: packets.len(),
+            scheduled_actions: packets.iter().map(|packet| packet.action_count).sum(),
+            blocking_packets: packets
+                .iter()
+                .filter(|packet| packet.blocks_preflight())
+                .count(),
+            operator_required_packets: packets
+                .iter()
+                .filter(|packet| packet.requires_operator())
+                .count(),
+            lineage_complete_packets: packets.iter().filter(|packet| packet.has_lineage()).count(),
+            protocol_mentions: packets.iter().map(|packet| packet.protocol_count).sum(),
+            primitive_mentions: packets.iter().map(|packet| packet.primitive_count).sum(),
+            first_evidence_key: first_packet.map(|packet| packet.evidence_key.clone()),
+            first_blocking_evidence_key: first_blocking_packet
+                .map(|packet| packet.evidence_key.clone()),
+            first_operator_evidence_key: first_operator_packet
+                .map(|packet| packet.evidence_key.clone()),
+            first_work_order_key: first_packet.map(|packet| packet.work_order_key.clone()),
+            first_ticket_key: first_packet.map(|packet| packet.ticket_key.clone()),
+            first_stage: first_packet.map(|packet| packet.stage),
+            first_action_kind: first_packet.map(|packet| packet.action_kind),
+            execution_evidence_ready: packets.is_empty(),
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.total_packets == 0
+    }
+
+    pub fn has_packets(&self) -> bool {
+        self.total_packets > 0
+    }
+
+    pub fn has_blockers(&self) -> bool {
+        self.blocking_packets > 0
+    }
+
+    pub fn needs_operator(&self) -> bool {
+        self.operator_required_packets > 0
+    }
+
+    pub fn has_complete_lineage(&self) -> bool {
+        self.lineage_complete_packets == self.total_packets
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct IntegrationMeshProtocolPrimitiveReadinessRow {
     pub protocol: ProtocolFamily,
     pub required_primitives: Vec<PrimitiveFamily>,
@@ -23121,6 +23279,32 @@ pub fn mesh_protocol_substrate_preflight_repair_slot_execution_work_order_summar
     )
 }
 
+pub fn mesh_protocol_substrate_preflight_repair_slot_execution_evidence_packets(
+    available_primitives: &[PrimitiveFamily],
+) -> Vec<IntegrationMeshProtocolSubstratePreflightRepairSlotExecutionEvidencePacket> {
+    mesh_protocol_substrate_preflight_repair_slot_execution_work_orders(available_primitives)
+        .iter()
+        .enumerate()
+        .map(|(index, work_order)| {
+            IntegrationMeshProtocolSubstratePreflightRepairSlotExecutionEvidencePacket::from_work_order(
+                index + 1,
+                work_order,
+            )
+        })
+        .collect()
+}
+
+pub fn mesh_protocol_substrate_preflight_repair_slot_execution_evidence_summary(
+    available_primitives: &[PrimitiveFamily],
+) -> IntegrationMeshProtocolSubstratePreflightRepairSlotExecutionEvidenceSummary {
+    let packets = mesh_protocol_substrate_preflight_repair_slot_execution_evidence_packets(
+        available_primitives,
+    );
+    IntegrationMeshProtocolSubstratePreflightRepairSlotExecutionEvidenceSummary::from_packets(
+        packets.iter(),
+    )
+}
+
 pub fn mesh_readiness_package_summary_for_catalog(
     catalog: &[IntegrationCatalogEntry],
     available_primitives: &[PrimitiveFamily],
@@ -30701,6 +30885,117 @@ mod tests {
         assert!(!summary.has_work_orders());
         assert!(!summary.has_blockers());
         assert!(!summary.needs_operator());
+    }
+
+    #[test]
+    fn mesh_protocol_substrate_preflight_repair_slot_execution_evidence_surfaces_lineage() {
+        let available_primitives = vec![
+            PrimitiveFamily::Usb,
+            PrimitiveFamily::SerialController,
+            PrimitiveFamily::Radio802154,
+            PrimitiveFamily::Supervision,
+        ];
+        let packets = mesh_protocol_substrate_preflight_repair_slot_execution_evidence_packets(
+            &available_primitives,
+        );
+        let summary =
+            IntegrationMeshProtocolSubstratePreflightRepairSlotExecutionEvidenceSummary::from_packets(
+                packets.iter(),
+            );
+
+        assert_eq!(packets.len(), 3);
+        assert_eq!(summary.total_packets, 3);
+        assert_eq!(summary.scheduled_actions, 5);
+        assert_eq!(summary.blocking_packets, 3);
+        assert_eq!(summary.operator_required_packets, 2);
+        assert_eq!(summary.lineage_complete_packets, 3);
+        assert_eq!(summary.protocol_mentions, 5);
+        assert_eq!(summary.primitive_mentions, 3);
+        assert_eq!(
+            summary.first_evidence_key,
+            Some("evidence-01-radio-provision_radio".to_string())
+        );
+        assert_eq!(
+            summary.first_blocking_evidence_key,
+            Some("evidence-01-radio-provision_radio".to_string())
+        );
+        assert_eq!(
+            summary.first_operator_evidence_key,
+            Some("evidence-01-radio-provision_radio".to_string())
+        );
+        assert_eq!(
+            summary.first_work_order_key,
+            Some("work-01-radio-provision_radio".to_string())
+        );
+        assert_eq!(
+            summary.first_ticket_key,
+            Some("slot-01-radio-provision_radio".to_string())
+        );
+        assert_eq!(
+            summary.first_stage,
+            Some(IntegrationMeshProtocolSubstrateStage::Radio)
+        );
+        assert_eq!(
+            summary.first_action_kind,
+            Some(IntegrationMeshProtocolSubstratePreflightActionKind::ProvisionRadio)
+        );
+        assert!(!summary.execution_evidence_ready);
+        assert!(summary.has_packets());
+        assert!(summary.has_blockers());
+        assert!(summary.needs_operator());
+        assert!(summary.has_complete_lineage());
+
+        let first = &packets[0];
+        assert_eq!(first.sequence, 1);
+        assert_eq!(first.evidence_key, "evidence-01-radio-provision_radio");
+        assert_eq!(first.work_order_sequence, 1);
+        assert_eq!(first.work_order_key, "work-01-radio-provision_radio");
+        assert_eq!(first.ticket_sequence, 1);
+        assert_eq!(first.ticket_key, "slot-01-radio-provision_radio");
+        assert_eq!(first.slot_sequence, 1);
+        assert_eq!(first.batch_sequence, 1);
+        assert_eq!(
+            first.status,
+            IntegrationMeshProtocolSubstratePreflightRepairSlotExecutionStatus::OperatorHandoff
+        );
+        assert_eq!(first.action_count, 1);
+        assert_eq!(first.protocols, vec![ProtocolFamily::ZWave]);
+        assert_eq!(first.primitives, vec![PrimitiveFamily::ZWaveSerialApi]);
+        assert!(first.blocks_preflight());
+        assert!(first.requires_operator());
+        assert!(first.has_lineage());
+    }
+
+    #[test]
+    fn mesh_protocol_substrate_preflight_repair_slot_execution_evidence_empty_when_ready() {
+        let packets = mesh_protocol_substrate_preflight_repair_slot_execution_evidence_packets(
+            all_primitive_families(),
+        );
+        let summary = mesh_protocol_substrate_preflight_repair_slot_execution_evidence_summary(
+            all_primitive_families(),
+        );
+
+        assert!(packets.is_empty());
+        assert_eq!(summary.total_packets, 0);
+        assert_eq!(summary.scheduled_actions, 0);
+        assert_eq!(summary.blocking_packets, 0);
+        assert_eq!(summary.operator_required_packets, 0);
+        assert_eq!(summary.lineage_complete_packets, 0);
+        assert_eq!(summary.protocol_mentions, 0);
+        assert_eq!(summary.primitive_mentions, 0);
+        assert_eq!(summary.first_evidence_key, None);
+        assert_eq!(summary.first_blocking_evidence_key, None);
+        assert_eq!(summary.first_operator_evidence_key, None);
+        assert_eq!(summary.first_work_order_key, None);
+        assert_eq!(summary.first_ticket_key, None);
+        assert_eq!(summary.first_stage, None);
+        assert_eq!(summary.first_action_kind, None);
+        assert!(summary.execution_evidence_ready);
+        assert!(summary.is_empty());
+        assert!(!summary.has_packets());
+        assert!(!summary.has_blockers());
+        assert!(!summary.needs_operator());
+        assert!(summary.has_complete_lineage());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add reusable integration-catalog execution evidence packets and summaries derived from mesh preflight execution work orders
- advertise the new read-only evidence tools through smart-home-core descriptors
- expose Chief/D18D list and summary handlers with runtime E2E coverage

## Validation
- cargo test -p smart-home-core
- cargo test -p smart-home-integration-catalog
- cargo test -p hue-core
- cargo test -p smart-home-runtime
- cargo test -p smart-home-testkit
- cargo test -p smart-home-local-http
- cargo test -p smart-home-discovery
- cargo test -p chief-of-staff-smart-home-tools
- cargo test -p smart-home-runtime discover_tool -- --nocapture
- sh BUILD in smart-home-core, smart-home-integration-catalog, hue-core, smart-home-runtime, smart-home-testkit, smart-home-local-http, smart-home-discovery, chief-of-staff-smart-home-tools
