### PR TITLE
feat(mycin-cardio): Tier-2 cardiology murmur→lesion recall as an ADJ-only library

### DIFF
--- a/code/specs/data/mycin-2026/USMLE-DOMAIN-MAP.md
+++ b/code/specs/data/mycin-2026/USMLE-DOMAIN-MAP.md
@@ -112,6 +112,7 @@ unchanged. Adding a relation just widens the schema — the engine already binds
 | Rheumatology (Tier-2) | Path/Immuno | associated_autoantibody | 6 grounded (ADJ-only) | ✓ |
 | Oncology (Tier-2) | Pathology/neoplasia | tumor_marker | 4 grounded (ADJ-only) | ✓ |
 | Histology buzzwords (Tier-2) | Pathology | seen_in (finding→condition) | 5 grounded (ADJ-only) | ✓ |
+| Cardiology murmurs (Tier-2) | Cardiology | murmur_indicates (murmur→lesion) | 5 grounded (ADJ-only) | ✓ |
 
 Offline pipeline: prose → local-model decompose → ADJ → native engine, two-sided
 faithfulness gate, zero online calls (OFFLINE-BOARD-EXAM.md).
@@ -154,6 +155,16 @@ faithfulness gate, zero online calls (OFFLINE-BOARD-EXAM.md).
 
 **Tier 2 — organ-system pathology (Step 1/2 diagnosis):**
 5. Cardiovascular (murmurs→lesion, ECG→arrhythmia, drug→effect)
+    *Started (CARDIO — fourth Tier-2 domain):* `murmur_indicates` for mitral regurgitation
+    (holosystolic apical), aortic stenosis (crescendo-decrescendo systolic), mitral valve
+    prolapse (late systolic with mid-systolic click), tricuspid regurgitation (holosystolic
+    at the lower-left sternal border), aortic regurgitation (decrescendo diastolic) — 5
+    edges, all grounded to byte-stable NCBI StatPearls spans naming both murmur and lesion,
+    shipped as the eighth **ADJ-only** domain (`recall/cardio-edges.adj`). Two lesions share
+    the "holosystolic" timing; the finding name carries the disambiguating auscultation site
+    (apex vs lower-left-sternal-border). Remaining: mitral stenosis (deferred — opening snap
+    and diastolic rumble described in separate sentences, no both-endpoints-named span yet);
+    ECG→arrhythmia and drug→effect subdomains.
 6. Respiratory (PFT pattern→disease, ABG→disorder)
 7. Renal/urinary (acid-base, electrolyte, glomerular disease→finding)
 8. Gastrointestinal (LFT pattern→disease, biopsy→diagnosis)

--- a/code/specs/data/mycin-2026/board/board-scorecard.json
+++ b/code/specs/data/mycin-2026/board/board-scorecard.json
@@ -1,7 +1,7 @@
 {
   "summary": {
-    "total": 111,
-    "correct": 104,
+    "total": 116,
+    "correct": 109,
     "abstained": 7,
     "wrong": 0,
     "by_tactic": {
@@ -16,15 +16,15 @@
         "wrong": 0
       },
       "recall": {
-        "correct": 98,
+        "correct": 103,
         "abstained": 6,
         "wrong": 0
       }
     },
     "defensibility": 1.0,
     "accuracy_on_attempted": 1.0,
-    "grounded_coverage": 0.9898,
-    "grounded_correct": 97
+    "grounded_coverage": 0.9903,
+    "grounded_correct": 102
   },
   "results": [
     {
@@ -912,6 +912,46 @@
       "tactic": "recall",
       "gold": "g6pd_deficiency",
       "answer": "g6pd_deficiency",
+      "outcome": "correct",
+      "trust": "authoritative"
+    },
+    {
+      "id": "cardio_mr_lesion",
+      "tactic": "recall",
+      "gold": "mitral_regurgitation",
+      "answer": "mitral_regurgitation",
+      "outcome": "correct",
+      "trust": "authoritative"
+    },
+    {
+      "id": "cardio_as_lesion",
+      "tactic": "recall",
+      "gold": "aortic_stenosis",
+      "answer": "aortic_stenosis",
+      "outcome": "correct",
+      "trust": "authoritative"
+    },
+    {
+      "id": "cardio_mvp_lesion",
+      "tactic": "recall",
+      "gold": "mitral_valve_prolapse",
+      "answer": "mitral_valve_prolapse",
+      "outcome": "correct",
+      "trust": "authoritative"
+    },
+    {
+      "id": "cardio_tr_lesion",
+      "tactic": "recall",
+      "gold": "tricuspid_regurgitation",
+      "answer": "tricuspid_regurgitation",
+      "outcome": "correct",
+      "trust": "authoritative"
+    },
+    {
+      "id": "cardio_ar_lesion",
+      "tactic": "recall",
+      "gold": "aortic_regurgitation",
+      "answer": "aortic_regurgitation",
       "outcome": "correct",
       "trust": "authoritative"
     }

--- a/code/specs/data/mycin-2026/board/board_eval.py
+++ b/code/specs/data/mycin-2026/board/board_eval.py
@@ -66,7 +66,8 @@ SCORECARD = HERE / "board-scorecard.json"
 # board_offline.py. The engine that ANSWERS is always the native CPU reasoner.)
 EDGE_FILES = ["iem-edges.adj", "vitamin-edges.adj", "anemia-edges.adj", "endocrine-edges.adj",
               "coag-edges.adj", "micro-edges.adj", "pharm-edges.adj", "immuno-edges.adj",
-              "genetics-edges.adj", "rheum-edges.adj", "onco-edges.adj", "histo-edges.adj"]
+              "genetics-edges.adj", "rheum-edges.adj", "onco-edges.adj", "histo-edges.adj",
+              "cardio-edges.adj"]
 
 # The native adj-lang CLI binary — the ONE engine behind every tactic (recall,
 # differential, management). If the binary is absent (e.g. a Python-only CI job that

--- a/code/specs/data/mycin-2026/board/decompose_query.py
+++ b/code/specs/data/mycin-2026/board/decompose_query.py
@@ -60,11 +60,11 @@ RECALL = HERE.parent / "recall"
 EDGE_FILES = ["iem-edges.adj", "vitamin-edges.adj", "anemia-edges.adj",
               "endocrine-edges.adj", "coag-edges.adj", "micro-edges.adj", "pharm-edges.adj",
               "immuno-edges.adj", "genetics-edges.adj", "rheum-edges.adj", "onco-edges.adj",
-              "histo-edges.adj"]
+              "histo-edges.adj", "cardio-edges.adj"]
 
 # Each recall relation binds one conventional variable (the "what is being asked").
-# This is the controlled query vocabulary the model must choose from — 28 relations
-# across eleven domains. The engine ultimately validates the subject; this map
+# This is the controlled query vocabulary the model must choose from — 29 relations
+# across twelve domains. The engine ultimately validates the subject; this map
 # pins the legal relation set and the variable name each relation answers.
 REL_VAR = {
     "deficient_in": "Enzyme",          # IEM: which enzyme is deficient
@@ -95,6 +95,7 @@ REL_VAR = {
     "associated_autoantibody": "Antibody",  # rheumatology: the serologic marker of a disease
     "tumor_marker": "Marker",          # oncology: the serum tumor marker of a neoplasm
     "seen_in": "Condition",            # pathology: the condition a smear/histology finding points to
+    "murmur_indicates": "Lesion",      # cardiology: the valvular lesion a heart murmur points to
 }
 
 _RELATE_RE = re.compile(r"^\s*relate\s+([a-z_][a-z0-9_]*)\s*\(([^)]*)\)\s*$")

--- a/code/specs/data/mycin-2026/board/items.json
+++ b/code/specs/data/mycin-2026/board/items.json
@@ -126,6 +126,12 @@
 
     {"id": "histo_rs_cond",    "domain": "histo", "tactic": "recall", "relation": "seen_in", "subject": "reed_sternberg_cells", "var": "Condition", "gold": "hodgkin_lymphoma"},
     {"id": "histo_hj_cond",    "domain": "histo", "tactic": "recall", "relation": "seen_in", "subject": "howell_jolly_bodies",  "var": "Condition", "gold": "asplenia"},
-    {"id": "histo_heinz_cond", "domain": "histo", "tactic": "recall", "relation": "seen_in", "subject": "heinz_bodies",        "var": "Condition", "gold": "g6pd_deficiency"}
+    {"id": "histo_heinz_cond", "domain": "histo", "tactic": "recall", "relation": "seen_in", "subject": "heinz_bodies",        "var": "Condition", "gold": "g6pd_deficiency"},
+
+    {"id": "cardio_mr_lesion",  "domain": "cardio", "tactic": "recall", "relation": "murmur_indicates", "subject": "holosystolic_apical",             "var": "Lesion", "gold": "mitral_regurgitation"},
+    {"id": "cardio_as_lesion",  "domain": "cardio", "tactic": "recall", "relation": "murmur_indicates", "subject": "crescendo_decrescendo_systolic",  "var": "Lesion", "gold": "aortic_stenosis"},
+    {"id": "cardio_mvp_lesion", "domain": "cardio", "tactic": "recall", "relation": "murmur_indicates", "subject": "late_systolic_click",            "var": "Lesion", "gold": "mitral_valve_prolapse"},
+    {"id": "cardio_tr_lesion",  "domain": "cardio", "tactic": "recall", "relation": "murmur_indicates", "subject": "holosystolic_left_lower_sternal", "var": "Lesion", "gold": "tricuspid_regurgitation"},
+    {"id": "cardio_ar_lesion",  "domain": "cardio", "tactic": "recall", "relation": "murmur_indicates", "subject": "decrescendo_diastolic",          "var": "Lesion", "gold": "aortic_regurgitation"}
   ]
 }

--- a/code/specs/data/mycin-2026/board/test_board_eval.py
+++ b/code/specs/data/mycin-2026/board/test_board_eval.py
@@ -51,7 +51,7 @@ def test_covered_items_answer_correctly_with_a_proof() -> None:
     # answers, so the board scores the top binding per subject (the libraries + their
     # tests cover all edges).
     recall_correct = [r for r in card.results if r.outcome == "correct" and r.tactic == "recall"]
-    assert len(recall_correct) == 98
+    assert len(recall_correct) == 103
     assert by_id["fabry_enzyme"].outcome == "correct"               # IEM
     assert by_id["thiamine_disease"].answer == "beriberi"           # vitamin
     assert by_id["ida_mcv"].answer == "microcytic"                  # anemia
@@ -81,6 +81,9 @@ def test_covered_items_answer_correctly_with_a_proof() -> None:
     assert by_id["histo_rs_cond"].answer == "hodgkin_lymphoma"   # histology (HISTO, Tier-2)
     assert by_id["histo_heinz_cond"].answer == "g6pd_deficiency"  # histo — seen_in (finding->condition)
     assert by_id["histo_rs_cond"].trust == "authoritative"       # ADJ-only edge, grounded inline
+    assert by_id["cardio_mr_lesion"].answer == "mitral_regurgitation"  # cardiology (CARDIO, Tier-2)
+    assert by_id["cardio_as_lesion"].answer == "aortic_stenosis"  # cardio — murmur_indicates (murmur->lesion)
+    assert by_id["cardio_mr_lesion"].trust == "authoritative"    # ADJ-only edge, grounded inline
 
 
 def test_uncovered_items_abstain_not_fabricate() -> None:
@@ -123,8 +126,8 @@ def test_grounded_coverage_is_the_live_grounding_number() -> None:
     # verbatim, so the framework declines to claim grounding it cannot defend, by design:
     # cortisol_def (endocrine, deficiency_syndrome__cortisol — the only verbatim spans frame
     # cortisol deficiency as a consequence/feature of Addison disease, not the named-syndrome identity).
-    assert s["grounded_coverage"] == round(97 / 98, 4)   # 0.9898
-    assert s["grounded_correct"] == 97
+    assert s["grounded_coverage"] == round(102 / 103, 4)   # 0.9903
+    assert s["grounded_correct"] == 102
     by_id = {r.item_id: r for r in card.results}
     assert by_id["tay_sachs_enzyme"].trust == "authoritative"      # IEM
     assert by_id["ida_mcv"].trust == "authoritative"               # anemia

--- a/code/specs/data/mycin-2026/recall/cardio-edges.adj
+++ b/code/specs/data/mycin-2026/recall/cardio-edges.adj
@@ -1,0 +1,77 @@
+% ============================================================================
+% cardio-edges — the auscultation knowledge-graph (MYCIN-2026 CARDIO).
+% ============================================================================
+% A Tier-2 organ-system pathology domain (USMLE-DOMAIN-MAP §"Tier 2", #5 cardiovascular):
+% the characteristic heart murmur and the valvular lesion it points to. "You hear a
+% holosystolic murmur at the apex radiating to the axilla — which lesion?" becomes the
+% binding query  ? murmur_indicates(holosystolic_apical, $Lesion).
+%
+% Direction note: the relation is murmur -> lesion (`murmur_indicates`), the board
+% direction — you HEAR the murmur and must name the lesion. The cited spans read either
+% way ("Mitral valve regurgitation causes a holosystolic murmur ..."; "Aortic stenosis:
+% a mid-systolic, crescendo-decrescendo murmur ...") — what matters for grounding is that
+% one self-contained span names BOTH the murmur AND the lesion. Two lesions share the
+% "holosystolic" timing (mitral vs tricuspid regurgitation); the finding name carries the
+% disambiguating auscultation site (apex vs lower-left-sternal-border), exactly as a
+% clinician disambiguates them at the bedside.
+%
+% This file is the SHIPPED ARTIFACT and the SOLE source of truth — no generator, no
+% JSON, no manifest (the eighth ADJ-only recall domain; fourth Tier-2 organ-system domain
+% after RHEUM, ONCO, HISTO). Each fact is a `relate` clause whose byte-provenance lives
+% INLINE:
+%     source   — the VERBATIM span copied from the cited page (byte-stable: it appears
+%                character-for-character in the page's normalized text).
+%     locator  — the URL the span was read from (NCBI StatPearls / Bookshelf, NIH).
+%     trust    — authoritative (a primary, citable reference).
+% An LLM (or a human) recalls a fact by writing a tiny query .adj that `import`s this
+% library and asks a binding query — see cardio-recall.query.adj. Nothing here is
+% asserted "from memory": every edge is defended by a span a reader can re-fetch and
+% check. (See feedback_nothing_human_authored, feedback_adj_only_shipped_artifacts.)
+%
+% Honest scope: only murmurs whose page states the association in a clean self-contained
+% span (both murmur AND lesion named) are included. Deferred — mitral stenosis: its page
+% describes the opening snap and the "low-pitched, middiastolic rumbling murmur" in
+% separate sentences, neither of which names "mitral stenosis" in the same span, so no
+% both-endpoints-named declarative defends a murmur_indicates edge yet.
+% ============================================================================
+
+dictionary cardio_vocab {
+    define murmur : entity   surface "heart murmur", "auscultation finding"
+    define lesion : entity   surface "valvular lesion", "valve disease"
+
+    define murmur_indicates : relation from murmur to lesion  % the lesion a murmur points to
+}
+
+rulebook cardio_facts {
+    use cardio_vocab
+
+    % --- holosystolic at the apex, radiating to the axilla -> mitral regurgitation ---
+    relate murmur_indicates(holosystolic_apical, mitral_regurgitation)
+        source "Mitral valve regurgitation causes a holosystolic murmur that is heard best at the apex of the heart, with the sound radiating to the left axilla"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK553135/"
+        trust authoritative
+
+    % --- mid-systolic crescendo-decrescendo, radiating to the neck -> aortic stenosis ---
+    relate murmur_indicates(crescendo_decrescendo_systolic, aortic_stenosis)
+        source "Aortic stenosis: a mid-systolic, crescendo-decrescendo murmur with radiation toward the neck"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK553135/"
+        trust authoritative
+
+    % --- late systolic murmur with a mid-systolic click -> mitral valve prolapse ------
+    relate murmur_indicates(late_systolic_click, mitral_valve_prolapse)
+        source "Mitral valve prolapse: a late systolic murmur heard best at the cardiac apex but with a mid-systolic click"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK553135/"
+        trust authoritative
+
+    % --- holosystolic at the lower-left sternal border, louder on inspiration -> TR ----
+    relate murmur_indicates(holosystolic_left_lower_sternal, tricuspid_regurgitation)
+        source "Tricuspid regurgitation: a high-pitched, blowing, holosystolic murmur heard best at the lower left sternal border, with radiation to the right lower sternal border; increases with inspiration"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK553135/"
+        trust authoritative
+
+    % --- high-frequency decrescendo diastolic at the left sternal border -> aortic regurg ---
+    relate murmur_indicates(decrescendo_diastolic, aortic_regurgitation)
+        source "Patients with chronic aortic insufficiency will have a widened pulse pressure, may likely have a laterally and inferiorly displaced apical impulse, a high-frequency decrescendo diastolic murmur best heard at the 3rd or 4th intercostal space at the left sternal border, Austin Flint murmur, diminished S1, soft S2."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK557428/"
+        trust authoritative
+}

--- a/code/specs/data/mycin-2026/recall/cardio-recall.query.adj
+++ b/code/specs/data/mycin-2026/recall/cardio-recall.query.adj
@@ -1,0 +1,20 @@
+% ============================================================================
+% cardio-recall.query.adj — a worked recall query over the auscultation library.
+% ============================================================================
+% The shape an LLM (or a clinician) produces to ANSWER a "which valvular lesion makes
+% this murmur?" question: it states no cardiology fact — it only `import`s the grounded
+% library and asks binding queries. The native adj-lang engine resolves each `?` against
+% the imported `relate` edges and returns the binding + the citing clause's
+% source/locator/trust. All knowledge is in the library; none is here.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli cardio-recall.query.adj
+% ============================================================================
+
+import "cardio-edges.adj"
+
+? murmur_indicates(holosystolic_apical, $Lesion)               % expect mitral_regurgitation
+? murmur_indicates(crescendo_decrescendo_systolic, $Lesion)    % expect aortic_stenosis
+? murmur_indicates(late_systolic_click, $Lesion)               % expect mitral_valve_prolapse
+? murmur_indicates(holosystolic_left_lower_sternal, $Lesion)   % expect tricuspid_regurgitation
+? murmur_indicates(decrescendo_diastolic, $Lesion)             % expect aortic_regurgitation

--- a/code/specs/data/mycin-2026/recall/test_cardio_recall.py
+++ b/code/specs/data/mycin-2026/recall/test_cardio_recall.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""test_cardio_recall.py — the ADJ-only auscultation library (MYCIN-2026 CARDIO).
+
+The eighth recall domain shipped as a pure ADJ artifact (fourth Tier-2 organ-system
+domain, after RHEUM, ONCO, HISTO). `cardio-edges.adj` is the SOLE source of truth — facts
++ byte-provenance inline, no Python gate, no JSON, no manifest. This test pins the
+property that matters: the native adj-lang engine, given a query .adj that only `import`s
+the library and asks binding queries (`cardio-recall.query.adj` — the shape an LLM
+produces), binds the grounded lesion for each murmur, each carrying an AUTHORITATIVE
+citation with a real source span + locator. Knowledge lives in ADJ; the engine answers.
+
+If the native CLI isn't built (a Python-only CI lane), the engine-backed checks skip —
+the file-shape checks (every clause grounded, no authored-debt) still run.
+
+Run:  python3 test_cardio_recall.py
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+ADJ = HERE / "cardio-edges.adj"
+QUERY = HERE / "cardio-recall.query.adj"
+CLI = HERE.parents[3] / "packages" / "rust" / "target" / "debug" / "adj-lang-cli"
+
+# Every grounded edge: murmur -> the lesion the library binds for it.
+EXPECTED = {
+    "holosystolic_apical": "mitral_regurgitation",
+    "crescendo_decrescendo_systolic": "aortic_stenosis",
+    "late_systolic_click": "mitral_valve_prolapse",
+    "holosystolic_left_lower_sternal": "tricuspid_regurgitation",
+    "decrescendo_diastolic": "aortic_regurgitation",
+}
+REL = "murmur_indicates"
+VAR = "Lesion"
+
+
+def _cli_available() -> bool:
+    return CLI.exists()
+
+
+def _run(program: Path) -> dict:
+    out = subprocess.run([str(CLI), str(program)], capture_output=True, text=True,
+                         cwd=str(HERE), timeout=60)
+    assert out.returncode == 0, f"adj-lang-cli failed: {out.stderr}"
+    return json.loads(out.stdout)
+
+
+# ---- 1. the ADJ file is the artifact — every clause grounded, no authored-debt ----
+
+def test_library_is_pure_adj_and_fully_grounded() -> None:
+    text = ADJ.read_text()
+    assert "trust consensus" not in text, "CARDIO ships no authored-debt; ground or omit"
+    assert "[FLAG:" not in text
+    edge_count = len(EXPECTED)  # 5
+    assert text.count("    relate ") == edge_count
+    assert text.count("trust authoritative") == edge_count
+    assert text.count('\n        locator "') == edge_count
+    assert text.count('\n        source "') == edge_count
+    assert not (HERE / "cardio_edge_ground.py").exists()
+    assert not (HERE / "cardio-edge-grounding.json").exists()
+    assert not (HERE / "cardio-edge-manifest.json").exists()
+
+
+# ---- 2. the engine binds each lesion, each with an authoritative citation ----
+
+def test_engine_binds_every_lesion_with_authoritative_citation() -> None:
+    if not _cli_available():
+        return
+    result = _run(QUERY)
+    by_query = {r["query"]: r for r in result["recall"]}
+    for murmur, lesion in EXPECTED.items():
+        q = f"{REL}({murmur}, {VAR})"
+        r = by_query.get(q)
+        assert r is not None and not r["abstained"], f"{q} abstained — edge missing?"
+        bound = {}
+        for a in r["answers"]:
+            bound[a["bindings"][VAR]] = (a.get("citations") or [{}])[0]
+        assert set(bound) == {lesion}, f"{murmur}: bound {set(bound)} != {{{lesion}}}"
+        cite = bound[lesion]
+        assert cite.get("trust") == "authoritative", f"{murmur}/{lesion} not authoritative"
+        assert cite.get("source"), f"{murmur}/{lesion} has no source span"
+        assert cite.get("locator", "").startswith("https://www.ncbi.nlm.nih.gov/")
+
+
+# ---- 3. an off-vocabulary murmur abstains, never fabricates ----------------------
+
+def test_unknown_murmur_abstains() -> None:
+    if not _cli_available():
+        return
+    import os
+    import tempfile
+    fd, path = tempfile.mkstemp(suffix=".adj", prefix=".cardio_q_", dir=HERE)
+    try:
+        with os.fdopen(fd, "w") as fh:
+            # continuous_machinery (PDA) is not in the library → must abstain
+            fh.write(f'import "cardio-edges.adj"\n? {REL}(continuous_machinery, ${VAR})\n')
+        res = _run(Path(path))
+        r = res["recall"][0] if res["recall"] else None
+        assert r is not None and r["abstained"], "an ungrounded murmur must abstain"
+    finally:
+        os.unlink(path)
+
+
+def _run_all() -> int:
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    failed = 0
+    for t in tests:
+        try:
+            t()
+            print(f"  PASS  {t.__name__}")
+        except AssertionError as exc:
+            failed += 1
+            print(f"  FAIL  {t.__name__}: {exc}")
+    print(f"\ntest_cardio_recall: {len(tests) - failed}/{len(tests)} passed")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(_run_all())


### PR DESCRIPTION
## What

The **eighth ADJ-only recall domain** for MYCIN-2026 (fourth Tier-2 organ-system, after RHEUM, ONCO, HISTO): the characteristic heart **murmur → valvular lesion**. `recall/cardio-edges.adj` is the sole shipped artifact — facts + **inline byte-provenance**, no Python gate, no JSON, no manifest. A query is just another `.adj` that `import`s the library and asks `? murmur_indicates(<murmur>, $Lesion)` — the shape an LLM produces to recall a fact.

Relation `murmur_indicates(murmur → lesion)` is the board direction: you *hear* the murmur, *name* the lesion.

## The five edges (each grounded to a byte-stable verbatim NCBI StatPearls span naming BOTH endpoints)

| murmur | lesion | source |
|---|---|---|
| holosystolic, apical, → axilla | mitral_regurgitation | NBK553135 |
| crescendo-decrescendo systolic, → neck | aortic_stenosis | NBK553135 |
| late systolic + mid-systolic click | mitral_valve_prolapse | NBK553135 |
| holosystolic, lower-left sternal, ↑inspiration | tricuspid_regurgitation | NBK553135 |
| decrescendo diastolic, left sternal border | aortic_regurgitation | NBK557428 |

Two lesions share the *holosystolic* timing (mitral vs tricuspid regurgitation); the finding name carries the disambiguating **auscultation site** (apex vs lower-left-sternal-border), exactly as a clinician disambiguates them at the bedside.

**Deferred honestly:** mitral stenosis — its page states the opening snap and the *low-pitched, middiastolic rumbling murmur* in separate sentences, neither naming *mitral stenosis* in the same span, so no both-endpoints-named declarative defends a `murmur_indicates` edge yet.

## Verification
- `test_cardio_recall.py` **3/3** — engine binds every lesion with an authoritative citation; off-vocab murmur (`continuous_machinery`) abstains.
- `test_board_eval.py` **12/12** — recall 98→**103** correct, grounded 97→**102** (102/103 = **0.9903**), **0 wrong**, **defensibility 1.0**.
- Security review: **PASSED** (no `shell=True`; `mkstemp` TOCTOU-safe; .adj spans stay inside string context; locators inert).

## Wiring
`cardio-edges.adj` → `EDGE_FILES` in `board_eval.py` + `decompose_query.py`; `REL_VAR["murmur_indicates"]="Lesion"` (29 relations / twelve domains); 5 board items; scorecard regenerated; USMLE-DOMAIN-MAP updated.

> Note: `code/specs/data/mycin-2026` is not wired into CI (no BUILD file); local runs above are the verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)