### PR TITLE
Surface smart-home mesh evidence review tools

### DIFF
--- a/code/packages/rust/chief-of-staff-smart-home-tools/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/src/lib.rs
@@ -73,6 +73,8 @@ use smart_home_integration_catalog::{
     mesh_protocol_substrate_preflight_repair_slot_audit_rows,
     mesh_protocol_substrate_preflight_repair_slot_audit_summary,
     mesh_protocol_substrate_preflight_repair_slot_execution_evidence_packets,
+    mesh_protocol_substrate_preflight_repair_slot_execution_evidence_review_summary,
+    mesh_protocol_substrate_preflight_repair_slot_execution_evidence_reviews,
     mesh_protocol_substrate_preflight_repair_slot_execution_evidence_summary,
     mesh_protocol_substrate_preflight_repair_slot_execution_ticket_summary,
     mesh_protocol_substrate_preflight_repair_slot_execution_tickets,
@@ -174,6 +176,8 @@ use smart_home_integration_catalog::{
     IntegrationMeshProtocolSubstratePreflightRepairSlotAuditRow,
     IntegrationMeshProtocolSubstratePreflightRepairSlotAuditSummary,
     IntegrationMeshProtocolSubstratePreflightRepairSlotExecutionEvidencePacket,
+    IntegrationMeshProtocolSubstratePreflightRepairSlotExecutionEvidenceReview,
+    IntegrationMeshProtocolSubstratePreflightRepairSlotExecutionEvidenceReviewSummary,
     IntegrationMeshProtocolSubstratePreflightRepairSlotExecutionEvidenceSummary,
     IntegrationMeshProtocolSubstratePreflightRepairSlotExecutionTicket,
     IntegrationMeshProtocolSubstratePreflightRepairSlotExecutionTicketSummary,
@@ -400,6 +404,10 @@ pub const SMART_HOME_LIST_INTEGRATION_MESH_PREFLIGHT_REPAIR_SLOT_EXECUTION_EVIDE
     "smart_home.list_integration_mesh_preflight_repair_slot_execution_evidence";
 pub const SMART_HOME_GET_INTEGRATION_MESH_PREFLIGHT_REPAIR_SLOT_EXECUTION_EVIDENCE_SUMMARY_TOOL_ID:
     &str = "smart_home.get_integration_mesh_preflight_repair_slot_execution_evidence_summary";
+pub const SMART_HOME_LIST_INTEGRATION_MESH_PREFLIGHT_REPAIR_SLOT_EXECUTION_EVIDENCE_REVIEWS_TOOL_ID:
+    &str = "smart_home.list_integration_mesh_preflight_repair_slot_execution_evidence_reviews";
+pub const SMART_HOME_GET_INTEGRATION_MESH_PREFLIGHT_REPAIR_SLOT_EXECUTION_EVIDENCE_REVIEW_SUMMARY_TOOL_ID:
+    &str = "smart_home.get_integration_mesh_preflight_repair_slot_execution_evidence_review_summary";
 pub const SMART_HOME_GET_INTEGRATION_MESH_PREFLIGHT_READINESS_SUMMARY_TOOL_ID: &str =
     "smart_home.get_integration_mesh_preflight_readiness_summary";
 pub const SMART_HOME_GET_INTEGRATION_MESH_PREFLIGHT_REPAIR_READINESS_SUMMARY_TOOL_ID: &str =
@@ -1038,6 +1046,24 @@ impl SmartHomeToolBridge {
                     let query = integration_readiness_query(&arguments)?;
                     Ok(
                         get_integration_mesh_preflight_repair_slot_execution_evidence_summary_output_handler_output(
+                            query,
+                        ),
+                    )
+                }
+                SMART_HOME_LIST_INTEGRATION_MESH_PREFLIGHT_REPAIR_SLOT_EXECUTION_EVIDENCE_REVIEWS_TOOL_ID =>
+                {
+                    let query = integration_readiness_query(&arguments)?;
+                    Ok(
+                        list_integration_mesh_preflight_repair_slot_execution_evidence_reviews_output_handler_output(
+                            query,
+                        ),
+                    )
+                }
+                SMART_HOME_GET_INTEGRATION_MESH_PREFLIGHT_REPAIR_SLOT_EXECUTION_EVIDENCE_REVIEW_SUMMARY_TOOL_ID =>
+                {
+                    let query = integration_readiness_query(&arguments)?;
+                    Ok(
+                        get_integration_mesh_preflight_repair_slot_execution_evidence_review_summary_output_handler_output(
                             query,
                         ),
                     )
@@ -3145,6 +3171,41 @@ pub fn smart_home_tool_definitions() -> Vec<ToolDefinition> {
             SMART_HOME_GET_INTEGRATION_MESH_PREFLIGHT_REPAIR_SLOT_EXECUTION_EVIDENCE_SUMMARY_TOOL_ID,
             "Get smart-home integration mesh preflight repair slot execution evidence summary",
             "Return compact D23 mesh preflight repair slot execution evidence counts.",
+            integration_readiness_query_schema(true),
+            object_schema(
+                vec![SchemaProperty::new("summary", JsonSchema::Any)],
+                vec!["summary"],
+                false,
+            ),
+        ),
+        read_definition(
+            SMART_HOME_LIST_INTEGRATION_MESH_PREFLIGHT_REPAIR_SLOT_EXECUTION_EVIDENCE_REVIEWS_TOOL_ID,
+            "List smart-home integration mesh preflight repair slot execution evidence reviews",
+            "List D23 mesh preflight repair slot execution evidence review items derived from evidence packets.",
+            integration_readiness_query_schema(true),
+            object_schema(
+                vec![
+                    SchemaProperty::new(
+                        "mesh_preflight_repair_slot_execution_evidence_reviews",
+                        JsonSchema::Array {
+                            items: Box::new(JsonSchema::Any),
+                        },
+                    ),
+                    SchemaProperty::new("summary", JsonSchema::Any),
+                    SchemaProperty::new("count", JsonSchema::Integer),
+                ],
+                vec![
+                    "mesh_preflight_repair_slot_execution_evidence_reviews",
+                    "summary",
+                    "count",
+                ],
+                false,
+            ),
+        ),
+        read_definition(
+            SMART_HOME_GET_INTEGRATION_MESH_PREFLIGHT_REPAIR_SLOT_EXECUTION_EVIDENCE_REVIEW_SUMMARY_TOOL_ID,
+            "Get smart-home integration mesh preflight repair slot execution evidence review summary",
+            "Return compact D23 mesh preflight repair slot execution evidence review counts.",
             integration_readiness_query_schema(true),
             object_schema(
                 vec![SchemaProperty::new("summary", JsonSchema::Any)],
@@ -17696,6 +17757,39 @@ fn integration_mesh_preflight_repair_slot_execution_evidence_summary_for_query(
     }
 }
 
+fn integration_mesh_preflight_repair_slot_execution_evidence_reviews_for_query(
+    query: &IntegrationReadinessQuery,
+) -> Vec<IntegrationMeshProtocolSubstratePreflightRepairSlotExecutionEvidenceReview> {
+    let mut reviews = mesh_protocol_substrate_preflight_repair_slot_execution_evidence_reviews(
+        &query.available_primitives,
+    );
+
+    if query.activation_ready == Some(true) {
+        reviews.clear();
+    }
+    if let Some(limit) = query.limit {
+        reviews.truncate(limit);
+    }
+
+    reviews
+}
+
+fn integration_mesh_preflight_repair_slot_execution_evidence_review_summary_for_query(
+    query: &IntegrationReadinessQuery,
+) -> IntegrationMeshProtocolSubstratePreflightRepairSlotExecutionEvidenceReviewSummary {
+    if query.activation_ready.is_some() || query.limit.is_some() {
+        let reviews =
+            integration_mesh_preflight_repair_slot_execution_evidence_reviews_for_query(query);
+        IntegrationMeshProtocolSubstratePreflightRepairSlotExecutionEvidenceReviewSummary::from_reviews(
+            reviews.iter(),
+        )
+    } else {
+        mesh_protocol_substrate_preflight_repair_slot_execution_evidence_review_summary(
+            &query.available_primitives,
+        )
+    }
+}
+
 fn integration_mesh_preflight_readiness_summary_for_query(
     query: &IntegrationReadinessQuery,
 ) -> IntegrationMeshPreflightReadinessSummary {
@@ -22657,6 +22751,99 @@ fn get_integration_mesh_preflight_repair_slot_execution_evidence_summary_output_
                 integer(summary.operator_required_packets as i64),
             ),
             ("has_packets", JsonValue::Bool(summary.has_packets())),
+        ]),
+    )
+}
+
+fn list_integration_mesh_preflight_repair_slot_execution_evidence_reviews_output_handler_output(
+    query: IntegrationReadinessQuery,
+) -> ToolHandlerOutput {
+    let reviews =
+        integration_mesh_preflight_repair_slot_execution_evidence_reviews_for_query(&query);
+    let summary =
+        IntegrationMeshProtocolSubstratePreflightRepairSlotExecutionEvidenceReviewSummary::from_reviews(
+            reviews.iter(),
+        );
+    let count = reviews.len();
+
+    ToolHandlerOutput::new(object([
+        (
+            "mesh_preflight_repair_slot_execution_evidence_reviews",
+            JsonValue::Array(
+                reviews
+                    .iter()
+                    .map(mesh_protocol_substrate_preflight_repair_slot_execution_evidence_review_json)
+                    .collect(),
+            ),
+        ),
+        (
+            "summary",
+            mesh_protocol_substrate_preflight_repair_slot_execution_evidence_review_summary_json(
+                &summary,
+            ),
+        ),
+        ("count", integer(count as i64)),
+    ]))
+    .with_event(
+        ToolEventKind::Progress,
+        object([
+            (
+                "operation",
+                string("list_integration_mesh_preflight_repair_slot_execution_evidence_reviews"),
+            ),
+            ("evidence_reviews", integer(count as i64)),
+            (
+                "scheduled_actions",
+                integer(summary.scheduled_actions as i64),
+            ),
+            (
+                "blocking_reviews",
+                integer(summary.blocking_reviews as i64),
+            ),
+            (
+                "operator_required_reviews",
+                integer(summary.operator_required_reviews as i64),
+            ),
+            (
+                "execution_evidence_reviews_ready",
+                JsonValue::Bool(summary.execution_evidence_reviews_ready),
+            ),
+        ]),
+    )
+}
+
+fn get_integration_mesh_preflight_repair_slot_execution_evidence_review_summary_output_handler_output(
+    query: IntegrationReadinessQuery,
+) -> ToolHandlerOutput {
+    let summary =
+        integration_mesh_preflight_repair_slot_execution_evidence_review_summary_for_query(&query);
+
+    ToolHandlerOutput::new(object([(
+        "summary",
+        mesh_protocol_substrate_preflight_repair_slot_execution_evidence_review_summary_json(
+            &summary,
+        ),
+    )]))
+    .with_event(
+        ToolEventKind::Progress,
+        object([
+            (
+                "operation",
+                string(
+                    "get_integration_mesh_preflight_repair_slot_execution_evidence_review_summary",
+                ),
+            ),
+            ("total_reviews", integer(summary.total_reviews as i64)),
+            (
+                "scheduled_actions",
+                integer(summary.scheduled_actions as i64),
+            ),
+            ("blocking_reviews", integer(summary.blocking_reviews as i64)),
+            (
+                "operator_required_reviews",
+                integer(summary.operator_required_reviews as i64),
+            ),
+            ("has_reviews", JsonValue::Bool(summary.has_reviews())),
         ]),
     )
 }
@@ -45475,6 +45662,180 @@ fn mesh_protocol_substrate_preflight_repair_slot_execution_evidence_summary_json
     ])
 }
 
+fn mesh_protocol_substrate_preflight_repair_slot_execution_evidence_review_json(
+    review: &IntegrationMeshProtocolSubstratePreflightRepairSlotExecutionEvidenceReview,
+) -> JsonValue {
+    object([
+        ("sequence", integer(review.sequence as i64)),
+        ("review_key", string(&review.review_key)),
+        (
+            "evidence_sequence",
+            integer(review.evidence_sequence as i64),
+        ),
+        ("evidence_key", string(&review.evidence_key)),
+        (
+            "work_order_sequence",
+            integer(review.work_order_sequence as i64),
+        ),
+        ("work_order_key", string(&review.work_order_key)),
+        ("ticket_sequence", integer(review.ticket_sequence as i64)),
+        ("ticket_key", string(&review.ticket_key)),
+        ("slot_sequence", integer(review.slot_sequence as i64)),
+        ("batch_sequence", integer(review.batch_sequence as i64)),
+        ("stage", string(review.stage.as_str())),
+        (
+            "action_kind",
+            mesh_substrate_preflight_action_kind_json(review.action_kind),
+        ),
+        ("status", string(review.status.as_str())),
+        ("action_count", integer(review.action_count as i64)),
+        ("protocol_count", integer(review.protocol_count as i64)),
+        ("primitive_count", integer(review.primitive_count as i64)),
+        ("protocols", protocol_family_array_json(&review.protocols)),
+        (
+            "primitives",
+            primitive_family_array_json(&review.primitives),
+        ),
+        ("release_blocking", JsonValue::Bool(review.release_blocking)),
+        (
+            "operator_required",
+            JsonValue::Bool(review.operator_required),
+        ),
+        ("lineage_complete", JsonValue::Bool(review.lineage_complete)),
+        ("review_required", JsonValue::Bool(review.review_required)),
+        (
+            "ready_for_execution",
+            JsonValue::Bool(review.ready_for_execution),
+        ),
+        (
+            "blocks_preflight",
+            JsonValue::Bool(review.blocks_preflight()),
+        ),
+        (
+            "requires_operator",
+            JsonValue::Bool(review.requires_operator()),
+        ),
+        ("has_lineage", JsonValue::Bool(review.has_lineage())),
+        ("needs_review", JsonValue::Bool(review.needs_review())),
+        (
+            "is_ready_for_execution",
+            JsonValue::Bool(review.is_ready_for_execution()),
+        ),
+    ])
+}
+
+fn mesh_protocol_substrate_preflight_repair_slot_execution_evidence_review_summary_json(
+    summary: &IntegrationMeshProtocolSubstratePreflightRepairSlotExecutionEvidenceReviewSummary,
+) -> JsonValue {
+    object([
+        ("total_reviews", integer(summary.total_reviews as i64)),
+        (
+            "scheduled_actions",
+            integer(summary.scheduled_actions as i64),
+        ),
+        ("blocking_reviews", integer(summary.blocking_reviews as i64)),
+        (
+            "operator_required_reviews",
+            integer(summary.operator_required_reviews as i64),
+        ),
+        (
+            "lineage_complete_reviews",
+            integer(summary.lineage_complete_reviews as i64),
+        ),
+        (
+            "review_required_reviews",
+            integer(summary.review_required_reviews as i64),
+        ),
+        (
+            "execution_ready_reviews",
+            integer(summary.execution_ready_reviews as i64),
+        ),
+        (
+            "protocol_mentions",
+            integer(summary.protocol_mentions as i64),
+        ),
+        (
+            "primitive_mentions",
+            integer(summary.primitive_mentions as i64),
+        ),
+        (
+            "first_review_key",
+            summary
+                .first_review_key
+                .as_ref()
+                .map(string)
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_blocking_review_key",
+            summary
+                .first_blocking_review_key
+                .as_ref()
+                .map(string)
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_operator_review_key",
+            summary
+                .first_operator_review_key
+                .as_ref()
+                .map(string)
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_evidence_key",
+            summary
+                .first_evidence_key
+                .as_ref()
+                .map(string)
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_work_order_key",
+            summary
+                .first_work_order_key
+                .as_ref()
+                .map(string)
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_ticket_key",
+            summary
+                .first_ticket_key
+                .as_ref()
+                .map(string)
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_stage",
+            summary
+                .first_stage
+                .map(|stage| string(stage.as_str()))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_action_kind",
+            summary
+                .first_action_kind
+                .map(mesh_substrate_preflight_action_kind_json)
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "execution_evidence_reviews_ready",
+            JsonValue::Bool(summary.execution_evidence_reviews_ready),
+        ),
+        ("is_empty", JsonValue::Bool(summary.is_empty())),
+        ("has_reviews", JsonValue::Bool(summary.has_reviews())),
+        ("has_blockers", JsonValue::Bool(summary.has_blockers())),
+        ("needs_operator", JsonValue::Bool(summary.needs_operator())),
+        ("needs_review", JsonValue::Bool(summary.needs_review())),
+        (
+            "has_complete_lineage",
+            JsonValue::Bool(summary.has_complete_lineage()),
+        ),
+    ])
+}
+
 fn mesh_preflight_slot_readiness_summary_json(
     summary: &IntegrationMeshPreflightSlotReadinessSummary,
 ) -> JsonValue {
@@ -53342,7 +53703,7 @@ mod tests {
         let definitions = smart_home_tool_definitions();
         let export = ToolCatalogExport::from_definitions(definitions.iter());
 
-        assert_eq!(definitions.len(), 220);
+        assert_eq!(definitions.len(), 222);
         assert!(
             export.ok(),
             "tool export validation failed: {:?}",
@@ -53587,6 +53948,12 @@ mod tests {
         ));
         assert!(export.tool_ids().contains(
             &SMART_HOME_GET_INTEGRATION_MESH_PREFLIGHT_REPAIR_SLOT_EXECUTION_EVIDENCE_SUMMARY_TOOL_ID
+        ));
+        assert!(export.tool_ids().contains(
+            &SMART_HOME_LIST_INTEGRATION_MESH_PREFLIGHT_REPAIR_SLOT_EXECUTION_EVIDENCE_REVIEWS_TOOL_ID
+        ));
+        assert!(export.tool_ids().contains(
+            &SMART_HOME_GET_INTEGRATION_MESH_PREFLIGHT_REPAIR_SLOT_EXECUTION_EVIDENCE_REVIEW_SUMMARY_TOOL_ID
         ));
         assert!(export
             .tool_ids()
@@ -53979,7 +54346,7 @@ mod tests {
         ));
         assert_eq!(
             export.summary.required_capability_count("smart_home:read"),
-            212
+            214
         );
         assert_eq!(
             export
@@ -54120,6 +54487,14 @@ mod tests {
         .is_some());
         assert!(smart_home_tool_definition(
             SMART_HOME_GET_INTEGRATION_MESH_PREFLIGHT_REPAIR_SLOT_EXECUTION_EVIDENCE_SUMMARY_TOOL_ID
+        )
+        .is_some());
+        assert!(smart_home_tool_definition(
+            SMART_HOME_LIST_INTEGRATION_MESH_PREFLIGHT_REPAIR_SLOT_EXECUTION_EVIDENCE_REVIEWS_TOOL_ID
+        )
+        .is_some());
+        assert!(smart_home_tool_definition(
+            SMART_HOME_GET_INTEGRATION_MESH_PREFLIGHT_REPAIR_SLOT_EXECUTION_EVIDENCE_REVIEW_SUMMARY_TOOL_ID
         )
         .is_some());
         assert!(smart_home_tool_definition(
@@ -54779,11 +55154,11 @@ mod tests {
         let tool_catalog_summary = field(tool_catalog_summary_output, "summary").unwrap();
         assert_eq!(
             field(tool_catalog_summary, "total_tools"),
-            Some(&integer(220))
+            Some(&integer(222))
         );
         assert_eq!(
             field(tool_catalog_summary, "read_tools"),
-            Some(&integer(212))
+            Some(&integer(214))
         );
         assert_eq!(
             field(tool_catalog_summary, "risky_tool_count"),
@@ -58177,6 +58552,170 @@ mod tests {
             field(
                 mesh_preflight_repair_slot_execution_evidence_rollup,
                 "execution_evidence_ready"
+            ),
+            Some(&JsonValue::Bool(false))
+        );
+
+        let list_mesh_preflight_repair_slot_execution_evidence_reviews_request = request(
+            "call-list-integration-mesh-preflight-repair-slot-execution-evidence-reviews",
+            SMART_HOME_LIST_INTEGRATION_MESH_PREFLIGHT_REPAIR_SLOT_EXECUTION_EVIDENCE_REVIEWS_TOOL_ID,
+            object([
+                (
+                    "available_primitives",
+                    JsonValue::Array(vec![
+                        string("usb"),
+                        string("serial_controller"),
+                        string("radio_802154"),
+                        string("supervision"),
+                    ]),
+                ),
+                ("activation_ready", JsonValue::Bool(false)),
+            ]),
+            5_929_102,
+        );
+        let list_mesh_preflight_repair_slot_execution_evidence_reviews_trace = tool_runtime
+            .invoke_with_events(
+                &list_mesh_preflight_repair_slot_execution_evidence_reviews_request,
+            );
+        assert!(
+            list_mesh_preflight_repair_slot_execution_evidence_reviews_trace
+                .result
+                .ok
+        );
+        assert_eq!(
+            list_mesh_preflight_repair_slot_execution_evidence_reviews_trace
+                .summary()
+                .progress_event_count,
+            1
+        );
+        let list_mesh_preflight_repair_slot_execution_evidence_reviews_output =
+            list_mesh_preflight_repair_slot_execution_evidence_reviews_trace
+                .result
+                .output
+                .as_ref()
+                .unwrap();
+        assert_eq!(
+            field(
+                list_mesh_preflight_repair_slot_execution_evidence_reviews_output,
+                "count"
+            ),
+            Some(&integer(3))
+        );
+        let mesh_preflight_repair_slot_execution_evidence_review_summary = field(
+            list_mesh_preflight_repair_slot_execution_evidence_reviews_output,
+            "summary",
+        )
+        .unwrap();
+        assert_eq!(
+            field(
+                mesh_preflight_repair_slot_execution_evidence_review_summary,
+                "scheduled_actions"
+            ),
+            Some(&integer(5))
+        );
+        assert_eq!(
+            field(
+                mesh_preflight_repair_slot_execution_evidence_review_summary,
+                "review_required_reviews"
+            ),
+            Some(&integer(3))
+        );
+        let mesh_preflight_repair_slot_execution_evidence_review = array_item(
+            field(
+                list_mesh_preflight_repair_slot_execution_evidence_reviews_output,
+                "mesh_preflight_repair_slot_execution_evidence_reviews",
+            )
+            .unwrap(),
+            0,
+        )
+        .unwrap();
+        assert_eq!(
+            field(
+                mesh_preflight_repair_slot_execution_evidence_review,
+                "review_key"
+            ),
+            Some(&string("review-01-radio-provision_radio"))
+        );
+        assert_eq!(
+            field(
+                mesh_preflight_repair_slot_execution_evidence_review,
+                "evidence_key"
+            ),
+            Some(&string("evidence-01-radio-provision_radio"))
+        );
+        assert_eq!(
+            field(
+                mesh_preflight_repair_slot_execution_evidence_review,
+                "needs_review"
+            ),
+            Some(&JsonValue::Bool(true))
+        );
+        assert_eq!(
+            field(
+                mesh_preflight_repair_slot_execution_evidence_review,
+                "is_ready_for_execution"
+            ),
+            Some(&JsonValue::Bool(false))
+        );
+
+        let mesh_preflight_repair_slot_execution_evidence_review_summary_request = request(
+            "call-integration-mesh-preflight-repair-slot-execution-evidence-review-summary",
+            SMART_HOME_GET_INTEGRATION_MESH_PREFLIGHT_REPAIR_SLOT_EXECUTION_EVIDENCE_REVIEW_SUMMARY_TOOL_ID,
+            object([(
+                "available_primitives",
+                JsonValue::Array(vec![
+                    string("usb"),
+                    string("serial_controller"),
+                    string("radio_802154"),
+                    string("supervision"),
+                ]),
+            )]),
+            5_929_103,
+        );
+        let mesh_preflight_repair_slot_execution_evidence_review_summary_trace = tool_runtime
+            .invoke_with_events(
+                &mesh_preflight_repair_slot_execution_evidence_review_summary_request,
+            );
+        assert!(
+            mesh_preflight_repair_slot_execution_evidence_review_summary_trace
+                .result
+                .ok
+        );
+        assert_eq!(
+            mesh_preflight_repair_slot_execution_evidence_review_summary_trace
+                .summary()
+                .progress_event_count,
+            1
+        );
+        let mesh_preflight_repair_slot_execution_evidence_review_summary_output =
+            mesh_preflight_repair_slot_execution_evidence_review_summary_trace
+                .result
+                .output
+                .as_ref()
+                .unwrap();
+        let mesh_preflight_repair_slot_execution_evidence_review_rollup = field(
+            mesh_preflight_repair_slot_execution_evidence_review_summary_output,
+            "summary",
+        )
+        .unwrap();
+        assert_eq!(
+            field(
+                mesh_preflight_repair_slot_execution_evidence_review_rollup,
+                "total_reviews"
+            ),
+            Some(&integer(3))
+        );
+        assert_eq!(
+            field(
+                mesh_preflight_repair_slot_execution_evidence_review_rollup,
+                "blocking_reviews"
+            ),
+            Some(&integer(3))
+        );
+        assert_eq!(
+            field(
+                mesh_preflight_repair_slot_execution_evidence_review_rollup,
+                "execution_evidence_reviews_ready"
             ),
             Some(&JsonValue::Bool(false))
         );

--- a/code/packages/rust/smart-home-core/src/lib.rs
+++ b/code/packages/rust/smart-home-core/src/lib.rs
@@ -1612,6 +1612,8 @@ pub enum SmartHomeTool {
     GetIntegrationMeshPreflightRepairSlotExecutionWorkOrderSummary,
     ListIntegrationMeshPreflightRepairSlotExecutionEvidence,
     GetIntegrationMeshPreflightRepairSlotExecutionEvidenceSummary,
+    ListIntegrationMeshPreflightRepairSlotExecutionEvidenceReviews,
+    GetIntegrationMeshPreflightRepairSlotExecutionEvidenceReviewSummary,
     GetIntegrationMeshPreflightReadinessSummary,
     GetIntegrationMeshPreflightRepairReadinessSummary,
     GetIntegrationMeshPreflightBatchReadinessSummary,
@@ -2158,6 +2160,12 @@ impl SmartHomeTool {
             ),
             Self::GetIntegrationMeshPreflightRepairSlotExecutionEvidenceSummary => read_tool(
                 "smart_home.get_integration_mesh_preflight_repair_slot_execution_evidence_summary",
+            ),
+            Self::ListIntegrationMeshPreflightRepairSlotExecutionEvidenceReviews => read_tool(
+                "smart_home.list_integration_mesh_preflight_repair_slot_execution_evidence_reviews",
+            ),
+            Self::GetIntegrationMeshPreflightRepairSlotExecutionEvidenceReviewSummary => read_tool(
+                "smart_home.get_integration_mesh_preflight_repair_slot_execution_evidence_review_summary",
             ),
             Self::GetIntegrationMeshPreflightReadinessSummary => {
                 read_tool("smart_home.get_integration_mesh_preflight_readiness_summary")
@@ -2973,6 +2981,8 @@ pub fn smart_home_tool_catalog() -> Vec<ToolDescriptor> {
         SmartHomeTool::GetIntegrationMeshPreflightRepairSlotExecutionWorkOrderSummary,
         SmartHomeTool::ListIntegrationMeshPreflightRepairSlotExecutionEvidence,
         SmartHomeTool::GetIntegrationMeshPreflightRepairSlotExecutionEvidenceSummary,
+        SmartHomeTool::ListIntegrationMeshPreflightRepairSlotExecutionEvidenceReviews,
+        SmartHomeTool::GetIntegrationMeshPreflightRepairSlotExecutionEvidenceReviewSummary,
         SmartHomeTool::GetIntegrationMeshPreflightReadinessSummary,
         SmartHomeTool::GetIntegrationMeshPreflightRepairReadinessSummary,
         SmartHomeTool::GetIntegrationMeshPreflightBatchReadinessSummary,
@@ -3821,7 +3831,7 @@ mod tests {
             .find(|tool| tool.tool_id == "smart_home.command")
             .unwrap();
 
-        assert_eq!(catalog.len(), 220);
+        assert_eq!(catalog.len(), 222);
         assert!(catalog
             .iter()
             .any(|tool| tool.tool_id == "smart_home.list_integrations"
@@ -4069,6 +4079,8 @@ mod tests {
             "smart_home.get_integration_mesh_release_readiness_summary",
             "smart_home.list_integration_mesh_preflight_repair_slot_execution_evidence",
             "smart_home.get_integration_mesh_preflight_repair_slot_execution_evidence_summary",
+            "smart_home.list_integration_mesh_preflight_repair_slot_execution_evidence_reviews",
+            "smart_home.get_integration_mesh_preflight_repair_slot_execution_evidence_review_summary",
             "smart_home.get_integration_mesh_preflight_slot_readiness_summary",
             "smart_home.list_integration_mesh_readiness_handoffs",
             "smart_home.get_integration_mesh_readiness_handoff_summary",
@@ -4652,6 +4664,14 @@ mod tests {
             && tool.side_effects == ToolSideEffects::Read
             && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
         assert!(catalog.iter().any(|tool| tool.tool_id
+            == "smart_home.list_integration_mesh_preflight_repair_slot_execution_evidence_reviews"
+            && tool.side_effects == ToolSideEffects::Read
+            && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
+        assert!(catalog.iter().any(|tool| tool.tool_id
+            == "smart_home.get_integration_mesh_preflight_repair_slot_execution_evidence_review_summary"
+            && tool.side_effects == ToolSideEffects::Read
+            && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
+        assert!(catalog.iter().any(|tool| tool.tool_id
             == "smart_home.get_integration_mesh_preflight_readiness_summary"
             && tool.side_effects == ToolSideEffects::Read
             && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
@@ -4682,15 +4702,15 @@ mod tests {
         let summary = smart_home_tool_catalog_summary();
         let pair_bridge = SmartHomeTool::PairBridge.descriptor();
 
-        assert_eq!(summary.total_tools, 220);
-        assert_eq!(summary.read_tools, 212);
+        assert_eq!(summary.total_tools, 222);
+        assert_eq!(summary.read_tools, 214);
         assert_eq!(summary.write_tools, 2);
         assert_eq!(summary.external_tools, 6);
-        assert_eq!(summary.read_only_tier_tools, 212);
+        assert_eq!(summary.read_only_tier_tools, 214);
         assert_eq!(summary.low_risk_tier_tools, 6);
         assert_eq!(summary.high_risk_tier_tools, 0);
         assert_eq!(summary.human_approval_tier_tools, 2);
-        assert_eq!(summary.total_required_capabilities, 220);
+        assert_eq!(summary.total_required_capabilities, 222);
         assert_eq!(summary.risky_tool_count(), 8);
         assert_eq!(summary.approval_gated_tool_count(), 2);
         assert!(pair_bridge.requires_human_approval());

--- a/code/packages/rust/smart-home-integration-catalog/src/lib.rs
+++ b/code/packages/rust/smart-home-integration-catalog/src/lib.rs
@@ -1673,6 +1673,195 @@ impl IntegrationMeshProtocolSubstratePreflightRepairSlotExecutionEvidenceSummary
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IntegrationMeshProtocolSubstratePreflightRepairSlotExecutionEvidenceReview {
+    pub sequence: usize,
+    pub review_key: String,
+    pub evidence_sequence: usize,
+    pub evidence_key: String,
+    pub work_order_sequence: usize,
+    pub work_order_key: String,
+    pub ticket_sequence: usize,
+    pub ticket_key: String,
+    pub slot_sequence: usize,
+    pub batch_sequence: usize,
+    pub stage: IntegrationMeshProtocolSubstrateStage,
+    pub action_kind: IntegrationMeshProtocolSubstratePreflightActionKind,
+    pub status: IntegrationMeshProtocolSubstratePreflightRepairSlotExecutionStatus,
+    pub action_count: usize,
+    pub protocol_count: usize,
+    pub primitive_count: usize,
+    pub protocols: Vec<ProtocolFamily>,
+    pub primitives: Vec<PrimitiveFamily>,
+    pub release_blocking: bool,
+    pub operator_required: bool,
+    pub lineage_complete: bool,
+    pub review_required: bool,
+    pub ready_for_execution: bool,
+}
+
+impl IntegrationMeshProtocolSubstratePreflightRepairSlotExecutionEvidenceReview {
+    pub fn from_packet(
+        sequence: usize,
+        packet: &IntegrationMeshProtocolSubstratePreflightRepairSlotExecutionEvidencePacket,
+    ) -> Self {
+        let review_required =
+            packet.blocks_preflight() || packet.requires_operator() || !packet.has_lineage();
+        let ready_for_execution =
+            !packet.blocks_preflight() && !packet.requires_operator() && packet.has_lineage();
+
+        Self {
+            sequence,
+            review_key: format!(
+                "review-{sequence:02}-{}-{}",
+                packet.stage.as_str(),
+                packet.action_kind.as_str()
+            ),
+            evidence_sequence: packet.sequence,
+            evidence_key: packet.evidence_key.clone(),
+            work_order_sequence: packet.work_order_sequence,
+            work_order_key: packet.work_order_key.clone(),
+            ticket_sequence: packet.ticket_sequence,
+            ticket_key: packet.ticket_key.clone(),
+            slot_sequence: packet.slot_sequence,
+            batch_sequence: packet.batch_sequence,
+            stage: packet.stage,
+            action_kind: packet.action_kind,
+            status: packet.status,
+            action_count: packet.action_count,
+            protocol_count: packet.protocol_count,
+            primitive_count: packet.primitive_count,
+            protocols: packet.protocols.clone(),
+            primitives: packet.primitives.clone(),
+            release_blocking: packet.blocks_preflight(),
+            operator_required: packet.requires_operator(),
+            lineage_complete: packet.has_lineage(),
+            review_required,
+            ready_for_execution,
+        }
+    }
+
+    pub fn blocks_preflight(&self) -> bool {
+        self.release_blocking
+    }
+
+    pub fn requires_operator(&self) -> bool {
+        self.operator_required
+    }
+
+    pub fn has_lineage(&self) -> bool {
+        self.lineage_complete
+    }
+
+    pub fn needs_review(&self) -> bool {
+        self.review_required
+    }
+
+    pub fn is_ready_for_execution(&self) -> bool {
+        self.ready_for_execution
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IntegrationMeshProtocolSubstratePreflightRepairSlotExecutionEvidenceReviewSummary {
+    pub total_reviews: usize,
+    pub scheduled_actions: usize,
+    pub blocking_reviews: usize,
+    pub operator_required_reviews: usize,
+    pub lineage_complete_reviews: usize,
+    pub review_required_reviews: usize,
+    pub execution_ready_reviews: usize,
+    pub protocol_mentions: usize,
+    pub primitive_mentions: usize,
+    pub first_review_key: Option<String>,
+    pub first_blocking_review_key: Option<String>,
+    pub first_operator_review_key: Option<String>,
+    pub first_evidence_key: Option<String>,
+    pub first_work_order_key: Option<String>,
+    pub first_ticket_key: Option<String>,
+    pub first_stage: Option<IntegrationMeshProtocolSubstrateStage>,
+    pub first_action_kind: Option<IntegrationMeshProtocolSubstratePreflightActionKind>,
+    pub execution_evidence_reviews_ready: bool,
+}
+
+impl IntegrationMeshProtocolSubstratePreflightRepairSlotExecutionEvidenceReviewSummary {
+    pub fn from_reviews<'a>(
+        reviews: impl IntoIterator<
+            Item = &'a IntegrationMeshProtocolSubstratePreflightRepairSlotExecutionEvidenceReview,
+        >,
+    ) -> Self {
+        let reviews = reviews.into_iter().collect::<Vec<_>>();
+        let first_review = reviews.iter().min_by_key(|review| review.sequence);
+        let first_blocking_review = reviews
+            .iter()
+            .filter(|review| review.blocks_preflight())
+            .min_by_key(|review| review.sequence);
+        let first_operator_review = reviews
+            .iter()
+            .filter(|review| review.requires_operator())
+            .min_by_key(|review| review.sequence);
+
+        Self {
+            total_reviews: reviews.len(),
+            scheduled_actions: reviews.iter().map(|review| review.action_count).sum(),
+            blocking_reviews: reviews
+                .iter()
+                .filter(|review| review.blocks_preflight())
+                .count(),
+            operator_required_reviews: reviews
+                .iter()
+                .filter(|review| review.requires_operator())
+                .count(),
+            lineage_complete_reviews: reviews.iter().filter(|review| review.has_lineage()).count(),
+            review_required_reviews: reviews
+                .iter()
+                .filter(|review| review.needs_review())
+                .count(),
+            execution_ready_reviews: reviews
+                .iter()
+                .filter(|review| review.is_ready_for_execution())
+                .count(),
+            protocol_mentions: reviews.iter().map(|review| review.protocol_count).sum(),
+            primitive_mentions: reviews.iter().map(|review| review.primitive_count).sum(),
+            first_review_key: first_review.map(|review| review.review_key.clone()),
+            first_blocking_review_key: first_blocking_review
+                .map(|review| review.review_key.clone()),
+            first_operator_review_key: first_operator_review
+                .map(|review| review.review_key.clone()),
+            first_evidence_key: first_review.map(|review| review.evidence_key.clone()),
+            first_work_order_key: first_review.map(|review| review.work_order_key.clone()),
+            first_ticket_key: first_review.map(|review| review.ticket_key.clone()),
+            first_stage: first_review.map(|review| review.stage),
+            first_action_kind: first_review.map(|review| review.action_kind),
+            execution_evidence_reviews_ready: reviews.is_empty(),
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.total_reviews == 0
+    }
+
+    pub fn has_reviews(&self) -> bool {
+        self.total_reviews > 0
+    }
+
+    pub fn has_blockers(&self) -> bool {
+        self.blocking_reviews > 0
+    }
+
+    pub fn needs_operator(&self) -> bool {
+        self.operator_required_reviews > 0
+    }
+
+    pub fn needs_review(&self) -> bool {
+        self.review_required_reviews > 0
+    }
+
+    pub fn has_complete_lineage(&self) -> bool {
+        self.lineage_complete_reviews == self.total_reviews
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct IntegrationMeshProtocolPrimitiveReadinessRow {
     pub protocol: ProtocolFamily,
     pub required_primitives: Vec<PrimitiveFamily>,
@@ -23305,6 +23494,32 @@ pub fn mesh_protocol_substrate_preflight_repair_slot_execution_evidence_summary(
     )
 }
 
+pub fn mesh_protocol_substrate_preflight_repair_slot_execution_evidence_reviews(
+    available_primitives: &[PrimitiveFamily],
+) -> Vec<IntegrationMeshProtocolSubstratePreflightRepairSlotExecutionEvidenceReview> {
+    mesh_protocol_substrate_preflight_repair_slot_execution_evidence_packets(available_primitives)
+        .iter()
+        .enumerate()
+        .map(|(index, packet)| {
+            IntegrationMeshProtocolSubstratePreflightRepairSlotExecutionEvidenceReview::from_packet(
+                index + 1,
+                packet,
+            )
+        })
+        .collect()
+}
+
+pub fn mesh_protocol_substrate_preflight_repair_slot_execution_evidence_review_summary(
+    available_primitives: &[PrimitiveFamily],
+) -> IntegrationMeshProtocolSubstratePreflightRepairSlotExecutionEvidenceReviewSummary {
+    let reviews = mesh_protocol_substrate_preflight_repair_slot_execution_evidence_reviews(
+        available_primitives,
+    );
+    IntegrationMeshProtocolSubstratePreflightRepairSlotExecutionEvidenceReviewSummary::from_reviews(
+        reviews.iter(),
+    )
+}
+
 pub fn mesh_readiness_package_summary_for_catalog(
     catalog: &[IntegrationCatalogEntry],
     available_primitives: &[PrimitiveFamily],
@@ -30995,6 +31210,133 @@ mod tests {
         assert!(!summary.has_packets());
         assert!(!summary.has_blockers());
         assert!(!summary.needs_operator());
+        assert!(summary.has_complete_lineage());
+    }
+
+    #[test]
+    fn mesh_protocol_substrate_preflight_repair_slot_execution_evidence_reviews_track_readiness() {
+        let available_primitives = vec![
+            PrimitiveFamily::Usb,
+            PrimitiveFamily::SerialController,
+            PrimitiveFamily::Radio802154,
+            PrimitiveFamily::Supervision,
+        ];
+        let reviews = mesh_protocol_substrate_preflight_repair_slot_execution_evidence_reviews(
+            &available_primitives,
+        );
+        let summary =
+            IntegrationMeshProtocolSubstratePreflightRepairSlotExecutionEvidenceReviewSummary::from_reviews(
+                reviews.iter(),
+            );
+
+        assert_eq!(reviews.len(), 3);
+        assert_eq!(summary.total_reviews, 3);
+        assert_eq!(summary.scheduled_actions, 5);
+        assert_eq!(summary.blocking_reviews, 3);
+        assert_eq!(summary.operator_required_reviews, 2);
+        assert_eq!(summary.lineage_complete_reviews, 3);
+        assert_eq!(summary.review_required_reviews, 3);
+        assert_eq!(summary.execution_ready_reviews, 0);
+        assert_eq!(summary.protocol_mentions, 5);
+        assert_eq!(summary.primitive_mentions, 3);
+        assert_eq!(
+            summary.first_review_key,
+            Some("review-01-radio-provision_radio".to_string())
+        );
+        assert_eq!(
+            summary.first_blocking_review_key,
+            Some("review-01-radio-provision_radio".to_string())
+        );
+        assert_eq!(
+            summary.first_operator_review_key,
+            Some("review-01-radio-provision_radio".to_string())
+        );
+        assert_eq!(
+            summary.first_evidence_key,
+            Some("evidence-01-radio-provision_radio".to_string())
+        );
+        assert_eq!(
+            summary.first_work_order_key,
+            Some("work-01-radio-provision_radio".to_string())
+        );
+        assert_eq!(
+            summary.first_ticket_key,
+            Some("slot-01-radio-provision_radio".to_string())
+        );
+        assert_eq!(
+            summary.first_stage,
+            Some(IntegrationMeshProtocolSubstrateStage::Radio)
+        );
+        assert_eq!(
+            summary.first_action_kind,
+            Some(IntegrationMeshProtocolSubstratePreflightActionKind::ProvisionRadio)
+        );
+        assert!(!summary.execution_evidence_reviews_ready);
+        assert!(summary.has_reviews());
+        assert!(summary.has_blockers());
+        assert!(summary.needs_operator());
+        assert!(summary.needs_review());
+        assert!(summary.has_complete_lineage());
+
+        let first = &reviews[0];
+        assert_eq!(first.sequence, 1);
+        assert_eq!(first.review_key, "review-01-radio-provision_radio");
+        assert_eq!(first.evidence_sequence, 1);
+        assert_eq!(first.evidence_key, "evidence-01-radio-provision_radio");
+        assert_eq!(first.work_order_sequence, 1);
+        assert_eq!(first.work_order_key, "work-01-radio-provision_radio");
+        assert_eq!(first.ticket_sequence, 1);
+        assert_eq!(first.ticket_key, "slot-01-radio-provision_radio");
+        assert_eq!(first.slot_sequence, 1);
+        assert_eq!(first.batch_sequence, 1);
+        assert_eq!(
+            first.status,
+            IntegrationMeshProtocolSubstratePreflightRepairSlotExecutionStatus::OperatorHandoff
+        );
+        assert_eq!(first.action_count, 1);
+        assert_eq!(first.protocols, vec![ProtocolFamily::ZWave]);
+        assert_eq!(first.primitives, vec![PrimitiveFamily::ZWaveSerialApi]);
+        assert!(first.blocks_preflight());
+        assert!(first.requires_operator());
+        assert!(first.has_lineage());
+        assert!(first.needs_review());
+        assert!(!first.is_ready_for_execution());
+    }
+
+    #[test]
+    fn mesh_protocol_substrate_preflight_repair_slot_execution_evidence_reviews_empty_when_ready() {
+        let reviews = mesh_protocol_substrate_preflight_repair_slot_execution_evidence_reviews(
+            all_primitive_families(),
+        );
+        let summary =
+            mesh_protocol_substrate_preflight_repair_slot_execution_evidence_review_summary(
+                all_primitive_families(),
+            );
+
+        assert!(reviews.is_empty());
+        assert_eq!(summary.total_reviews, 0);
+        assert_eq!(summary.scheduled_actions, 0);
+        assert_eq!(summary.blocking_reviews, 0);
+        assert_eq!(summary.operator_required_reviews, 0);
+        assert_eq!(summary.lineage_complete_reviews, 0);
+        assert_eq!(summary.review_required_reviews, 0);
+        assert_eq!(summary.execution_ready_reviews, 0);
+        assert_eq!(summary.protocol_mentions, 0);
+        assert_eq!(summary.primitive_mentions, 0);
+        assert_eq!(summary.first_review_key, None);
+        assert_eq!(summary.first_blocking_review_key, None);
+        assert_eq!(summary.first_operator_review_key, None);
+        assert_eq!(summary.first_evidence_key, None);
+        assert_eq!(summary.first_work_order_key, None);
+        assert_eq!(summary.first_ticket_key, None);
+        assert_eq!(summary.first_stage, None);
+        assert_eq!(summary.first_action_kind, None);
+        assert!(summary.execution_evidence_reviews_ready);
+        assert!(summary.is_empty());
+        assert!(!summary.has_reviews());
+        assert!(!summary.has_blockers());
+        assert!(!summary.needs_operator());
+        assert!(!summary.needs_review());
         assert!(summary.has_complete_lineage());
     }
 


### PR DESCRIPTION
## Summary
- add reusable smart-home integration catalog evidence review items and summaries derived from mesh execution evidence packets
- register two new read-only smart-home core tool descriptors for evidence review listing and rollup
- expose the review list and summary through Chief D18D tool definitions, handlers, JSON projection, and end-to-end runtime coverage

## Validation
- cargo test -p smart-home-core
- cargo test -p smart-home-integration-catalog
- cargo test -p hue-core
- cargo test -p smart-home-runtime
- cargo test -p smart-home-testkit
- cargo test -p smart-home-local-http
- cargo test -p smart-home-discovery
- cargo test -p chief-of-staff-smart-home-tools
- cargo test -p smart-home-runtime discover_tool -- --nocapture
- sh BUILD in smart-home-core
- sh BUILD in smart-home-integration-catalog
- sh BUILD in hue-core
- sh BUILD in smart-home-runtime
- sh BUILD in smart-home-testkit
- sh BUILD in smart-home-local-http
- sh BUILD in smart-home-discovery
- sh BUILD in chief-of-staff-smart-home-tools

Generated code/packages/rust/Cargo.lock was removed before commit.
