### PR TITLE
feat(mycin-neuro): Tier-2 neurology lesion→deficit recall as an ADJ-only library

### DIFF
--- a/code/specs/data/mycin-2026/USMLE-DOMAIN-MAP.md
+++ b/code/specs/data/mycin-2026/USMLE-DOMAIN-MAP.md
@@ -113,6 +113,7 @@ unchanged. Adding a relation just widens the schema — the engine already binds
 | Oncology (Tier-2) | Pathology/neoplasia | tumor_marker | 4 grounded (ADJ-only) | ✓ |
 | Histology buzzwords (Tier-2) | Pathology | seen_in (finding→condition) | 5 grounded (ADJ-only) | ✓ |
 | Cardiology murmurs (Tier-2) | Cardiology | murmur_indicates (murmur→lesion) | 5 grounded (ADJ-only) | ✓ |
+| Neurology localization (Tier-2) | Neurology | lesion_causes (site→deficit) | 5 grounded (ADJ-only) | ✓ |
 
 Offline pipeline: prose → local-model decompose → ADJ → native engine, two-sided
 faithfulness gate, zero online calls (OFFLINE-BOARD-EXAM.md).
@@ -169,6 +170,15 @@ faithfulness gate, zero online calls (OFFLINE-BOARD-EXAM.md).
 7. Renal/urinary (acid-base, electrolyte, glomerular disease→finding)
 8. Gastrointestinal (LFT pattern→disease, biopsy→diagnosis)
 9. Neurology & special senses (lesion→deficit, tract→sign)
+    *Started (NEURO — fifth Tier-2 domain):* `lesion_causes` for Wernicke area→fluent
+    aphasia, Broca area→nonfluent aphasia, arcuate fasciculus→conduction aphasia (NBK559315),
+    substantia nigra→Parkinson disease (NBK470193), subthalamic nucleus→hemiballismus
+    (NBK559002) — 5 edges, all grounded to byte-stable NCBI StatPearls spans naming both the
+    lesion site and the deficit, shipped as the ninth **ADJ-only** domain
+    (`recall/neuro-edges.adj`). Remaining: spinal-cord tracts (Brown-Séquard, dorsal column,
+    corticospinal), cranial-nerve lesions, cerebellar→ataxia (deferred — its page names the
+    "cerebellar syndrome" and limb incoordination but not "ataxia" alongside the site in one
+    declarative); tract→sign and visual-pathway-defect subdomains.
 10. Musculoskeletal / rheumatology (autoantibody→disease)
     *Started (RHEUM — first Tier-2 domain):* `associated_autoantibody` for SLE (anti-dsDNA,
     anti-Sm, anti-ribosomal-P), GPA (PR3-ANCA), systemic sclerosis (anti-Scl-70,

--- a/code/specs/data/mycin-2026/board/board-scorecard.json
+++ b/code/specs/data/mycin-2026/board/board-scorecard.json
@@ -1,7 +1,7 @@
 {
   "summary": {
-    "total": 116,
-    "correct": 109,
+    "total": 121,
+    "correct": 114,
     "abstained": 7,
     "wrong": 0,
     "by_tactic": {
@@ -16,15 +16,15 @@
         "wrong": 0
       },
       "recall": {
-        "correct": 103,
+        "correct": 108,
         "abstained": 6,
         "wrong": 0
       }
     },
     "defensibility": 1.0,
     "accuracy_on_attempted": 1.0,
-    "grounded_coverage": 0.9903,
-    "grounded_correct": 102
+    "grounded_coverage": 0.9907,
+    "grounded_correct": 107
   },
   "results": [
     {
@@ -952,6 +952,46 @@
       "tactic": "recall",
       "gold": "aortic_regurgitation",
       "answer": "aortic_regurgitation",
+      "outcome": "correct",
+      "trust": "authoritative"
+    },
+    {
+      "id": "neuro_wernicke_def",
+      "tactic": "recall",
+      "gold": "fluent_aphasia",
+      "answer": "fluent_aphasia",
+      "outcome": "correct",
+      "trust": "authoritative"
+    },
+    {
+      "id": "neuro_broca_def",
+      "tactic": "recall",
+      "gold": "nonfluent_aphasia",
+      "answer": "nonfluent_aphasia",
+      "outcome": "correct",
+      "trust": "authoritative"
+    },
+    {
+      "id": "neuro_arcuate_def",
+      "tactic": "recall",
+      "gold": "conduction_aphasia",
+      "answer": "conduction_aphasia",
+      "outcome": "correct",
+      "trust": "authoritative"
+    },
+    {
+      "id": "neuro_nigra_def",
+      "tactic": "recall",
+      "gold": "parkinson_disease",
+      "answer": "parkinson_disease",
+      "outcome": "correct",
+      "trust": "authoritative"
+    },
+    {
+      "id": "neuro_stn_def",
+      "tactic": "recall",
+      "gold": "hemiballismus",
+      "answer": "hemiballismus",
       "outcome": "correct",
       "trust": "authoritative"
     }

--- a/code/specs/data/mycin-2026/board/board_eval.py
+++ b/code/specs/data/mycin-2026/board/board_eval.py
@@ -67,7 +67,7 @@ SCORECARD = HERE / "board-scorecard.json"
 EDGE_FILES = ["iem-edges.adj", "vitamin-edges.adj", "anemia-edges.adj", "endocrine-edges.adj",
               "coag-edges.adj", "micro-edges.adj", "pharm-edges.adj", "immuno-edges.adj",
               "genetics-edges.adj", "rheum-edges.adj", "onco-edges.adj", "histo-edges.adj",
-              "cardio-edges.adj"]
+              "cardio-edges.adj", "neuro-edges.adj"]
 
 # The native adj-lang CLI binary — the ONE engine behind every tactic (recall,
 # differential, management). If the binary is absent (e.g. a Python-only CI job that

--- a/code/specs/data/mycin-2026/board/decompose_query.py
+++ b/code/specs/data/mycin-2026/board/decompose_query.py
@@ -60,11 +60,11 @@ RECALL = HERE.parent / "recall"
 EDGE_FILES = ["iem-edges.adj", "vitamin-edges.adj", "anemia-edges.adj",
               "endocrine-edges.adj", "coag-edges.adj", "micro-edges.adj", "pharm-edges.adj",
               "immuno-edges.adj", "genetics-edges.adj", "rheum-edges.adj", "onco-edges.adj",
-              "histo-edges.adj", "cardio-edges.adj"]
+              "histo-edges.adj", "cardio-edges.adj", "neuro-edges.adj"]
 
 # Each recall relation binds one conventional variable (the "what is being asked").
-# This is the controlled query vocabulary the model must choose from — 29 relations
-# across twelve domains. The engine ultimately validates the subject; this map
+# This is the controlled query vocabulary the model must choose from — 30 relations
+# across thirteen domains. The engine ultimately validates the subject; this map
 # pins the legal relation set and the variable name each relation answers.
 REL_VAR = {
     "deficient_in": "Enzyme",          # IEM: which enzyme is deficient
@@ -96,6 +96,7 @@ REL_VAR = {
     "tumor_marker": "Marker",          # oncology: the serum tumor marker of a neoplasm
     "seen_in": "Condition",            # pathology: the condition a smear/histology finding points to
     "murmur_indicates": "Lesion",      # cardiology: the valvular lesion a heart murmur points to
+    "lesion_causes": "Deficit",        # neurology: the deficit/syndrome a lesion site produces
 }
 
 _RELATE_RE = re.compile(r"^\s*relate\s+([a-z_][a-z0-9_]*)\s*\(([^)]*)\)\s*$")

--- a/code/specs/data/mycin-2026/board/items.json
+++ b/code/specs/data/mycin-2026/board/items.json
@@ -132,6 +132,12 @@
     {"id": "cardio_as_lesion",  "domain": "cardio", "tactic": "recall", "relation": "murmur_indicates", "subject": "crescendo_decrescendo_systolic",  "var": "Lesion", "gold": "aortic_stenosis"},
     {"id": "cardio_mvp_lesion", "domain": "cardio", "tactic": "recall", "relation": "murmur_indicates", "subject": "late_systolic_click",            "var": "Lesion", "gold": "mitral_valve_prolapse"},
     {"id": "cardio_tr_lesion",  "domain": "cardio", "tactic": "recall", "relation": "murmur_indicates", "subject": "holosystolic_left_lower_sternal", "var": "Lesion", "gold": "tricuspid_regurgitation"},
-    {"id": "cardio_ar_lesion",  "domain": "cardio", "tactic": "recall", "relation": "murmur_indicates", "subject": "decrescendo_diastolic",          "var": "Lesion", "gold": "aortic_regurgitation"}
+    {"id": "cardio_ar_lesion",  "domain": "cardio", "tactic": "recall", "relation": "murmur_indicates", "subject": "decrescendo_diastolic",          "var": "Lesion", "gold": "aortic_regurgitation"},
+
+    {"id": "neuro_wernicke_def", "domain": "neuro", "tactic": "recall", "relation": "lesion_causes", "subject": "wernicke_area",       "var": "Deficit", "gold": "fluent_aphasia"},
+    {"id": "neuro_broca_def",    "domain": "neuro", "tactic": "recall", "relation": "lesion_causes", "subject": "broca_area",          "var": "Deficit", "gold": "nonfluent_aphasia"},
+    {"id": "neuro_arcuate_def",  "domain": "neuro", "tactic": "recall", "relation": "lesion_causes", "subject": "arcuate_fasciculus",  "var": "Deficit", "gold": "conduction_aphasia"},
+    {"id": "neuro_nigra_def",    "domain": "neuro", "tactic": "recall", "relation": "lesion_causes", "subject": "substantia_nigra",    "var": "Deficit", "gold": "parkinson_disease"},
+    {"id": "neuro_stn_def",      "domain": "neuro", "tactic": "recall", "relation": "lesion_causes", "subject": "subthalamic_nucleus", "var": "Deficit", "gold": "hemiballismus"}
   ]
 }

--- a/code/specs/data/mycin-2026/board/test_board_eval.py
+++ b/code/specs/data/mycin-2026/board/test_board_eval.py
@@ -51,7 +51,7 @@ def test_covered_items_answer_correctly_with_a_proof() -> None:
     # answers, so the board scores the top binding per subject (the libraries + their
     # tests cover all edges).
     recall_correct = [r for r in card.results if r.outcome == "correct" and r.tactic == "recall"]
-    assert len(recall_correct) == 103
+    assert len(recall_correct) == 108
     assert by_id["fabry_enzyme"].outcome == "correct"               # IEM
     assert by_id["thiamine_disease"].answer == "beriberi"           # vitamin
     assert by_id["ida_mcv"].answer == "microcytic"                  # anemia
@@ -84,6 +84,9 @@ def test_covered_items_answer_correctly_with_a_proof() -> None:
     assert by_id["cardio_mr_lesion"].answer == "mitral_regurgitation"  # cardiology (CARDIO, Tier-2)
     assert by_id["cardio_as_lesion"].answer == "aortic_stenosis"  # cardio — murmur_indicates (murmur->lesion)
     assert by_id["cardio_mr_lesion"].trust == "authoritative"    # ADJ-only edge, grounded inline
+    assert by_id["neuro_broca_def"].answer == "nonfluent_aphasia"  # neurology (NEURO, Tier-2)
+    assert by_id["neuro_stn_def"].answer == "hemiballismus"      # neuro — lesion_causes (site->deficit)
+    assert by_id["neuro_broca_def"].trust == "authoritative"     # ADJ-only edge, grounded inline
 
 
 def test_uncovered_items_abstain_not_fabricate() -> None:
@@ -126,8 +129,8 @@ def test_grounded_coverage_is_the_live_grounding_number() -> None:
     # verbatim, so the framework declines to claim grounding it cannot defend, by design:
     # cortisol_def (endocrine, deficiency_syndrome__cortisol — the only verbatim spans frame
     # cortisol deficiency as a consequence/feature of Addison disease, not the named-syndrome identity).
-    assert s["grounded_coverage"] == round(102 / 103, 4)   # 0.9903
-    assert s["grounded_correct"] == 102
+    assert s["grounded_coverage"] == round(107 / 108, 4)   # 0.9907
+    assert s["grounded_correct"] == 107
     by_id = {r.item_id: r for r in card.results}
     assert by_id["tay_sachs_enzyme"].trust == "authoritative"      # IEM
     assert by_id["ida_mcv"].trust == "authoritative"               # anemia

--- a/code/specs/data/mycin-2026/recall/neuro-edges.adj
+++ b/code/specs/data/mycin-2026/recall/neuro-edges.adj
@@ -1,0 +1,75 @@
+% ============================================================================
+% neuro-edges — the neuroanatomical-localization knowledge-graph (MYCIN-2026 NEURO).
+% ============================================================================
+% A Tier-2 organ-system pathology domain (USMLE-DOMAIN-MAP §"Tier 2", #9 neurology):
+% the classic "lesion HERE -> this deficit" localizations. "A lesion of the subthalamic
+% nucleus — what movement disorder results?" becomes the binding query
+%     ? lesion_causes(subthalamic_nucleus, $Deficit).
+%
+% Direction note: the relation is structure -> deficit (`lesion_causes`), the board
+% direction — you are told the lesion site and must name the deficit/syndrome. The cited
+% spans read either way ("a lesion involving the Wernicke area results in fluent aphasia";
+% "Parkinson disease ... characterized by the degeneration of dopaminergic neurons in the
+% substantia nigra") — what matters for grounding is that one self-contained span names
+% BOTH the lesion site AND the resulting deficit. Each structure here maps to one
+% canonical syndrome, so a query binds a single answer with its citation.
+%
+% This file is the SHIPPED ARTIFACT and the SOLE source of truth — no generator, no
+% JSON, no manifest (the ninth ADJ-only recall domain; fifth Tier-2 organ-system domain
+% after RHEUM, ONCO, HISTO, CARDIO). Each fact is a `relate` clause whose byte-provenance
+% lives INLINE:
+%     source   — the VERBATIM span copied from the cited page (byte-stable: it appears
+%                character-for-character in the page's normalized text).
+%     locator  — the URL the span was read from (NCBI StatPearls / Bookshelf, NIH).
+%     trust    — authoritative (a primary, citable reference).
+% An LLM (or a human) recalls a fact by writing a tiny query .adj that `import`s this
+% library and asks a binding query — see neuro-recall.query.adj. Nothing here is asserted
+% "from memory": every edge is defended by a span a reader can re-fetch and check.
+% (See feedback_nothing_human_authored, feedback_adj_only_shipped_artifacts.)
+%
+% Honest scope: only localizations whose page states the association in a clean self-
+% contained span (both lesion site AND deficit named) are included. Deferred — cerebellar
+% hemisphere -> ataxia: its page describes the "cerebellar syndrome" and limb incoordination
+% in sentences that do not name "ataxia" alongside the lesion site in one declarative.
+% ============================================================================
+
+dictionary neuro_vocab {
+    define structure : entity   surface "brain structure", "lesion site", "nucleus", "cortical area"
+    define deficit   : entity   surface "neurological deficit", "syndrome", "movement disorder"
+
+    define lesion_causes : relation from structure to deficit  % the deficit a lesion site produces
+}
+
+rulebook neuro_facts {
+    use neuro_vocab
+
+    % --- Wernicke area lesion -> fluent (receptive) aphasia --------------------
+    relate lesion_causes(wernicke_area, fluent_aphasia)
+        source "A posterior lesion involving the Wernicke area results in fluent aphasia, characterized by impaired comprehension and severe paraphasia."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK559315/"
+        trust authoritative
+
+    % --- Broca area lesion -> nonfluent (expressive) aphasia -------------------
+    relate lesion_causes(broca_area, nonfluent_aphasia)
+        source "In contrast, an anterior lesion affecting the Broca area leads to nonfluent aphasia, in which patients have normal comprehension but produce speech that is telegraphic, effortful, and dysprosodic, without paraphasic errors."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK559315/"
+        trust authoritative
+
+    % --- arcuate fasciculus lesion -> conduction aphasia ----------------------
+    relate lesion_causes(arcuate_fasciculus, conduction_aphasia)
+        source "A lesion in the arcuate fasciculus or the white matter tract connecting the Wernicke and Broca areas results in conduction aphasia, characterized by impaired repetition and phonemic paraphasia."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK559315/"
+        trust authoritative
+
+    % --- substantia nigra degeneration -> Parkinson disease -------------------
+    relate lesion_causes(substantia_nigra, parkinson_disease)
+        source "Parkinson disease (PD) is a progressive neurodegenerative disorder characterized by the degeneration of dopaminergic neurons in the substantia nigra and the accumulation of alpha-synuclein within Lewy bodies."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK470193/"
+        trust authoritative
+
+    % --- subthalamic nucleus lesion -> hemiballismus --------------------------
+    relate lesion_causes(subthalamic_nucleus, hemiballismus)
+        source "Damage to the subthalamic nucleus can result in a disorder of movement called hemiballismus."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK559002/"
+        trust authoritative
+}

--- a/code/specs/data/mycin-2026/recall/neuro-recall.query.adj
+++ b/code/specs/data/mycin-2026/recall/neuro-recall.query.adj
@@ -1,0 +1,20 @@
+% ============================================================================
+% neuro-recall.query.adj — a worked recall query over the localization library.
+% ============================================================================
+% The shape an LLM (or a clinician) produces to ANSWER a "lesion here — which deficit?"
+% question: it states no neurology fact — it only `import`s the grounded library and asks
+% binding queries. The native adj-lang engine resolves each `?` against the imported
+% `relate` edges and returns the binding + the citing clause's source/locator/trust. All
+% knowledge is in the library; none is here.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli neuro-recall.query.adj
+% ============================================================================
+
+import "neuro-edges.adj"
+
+? lesion_causes(wernicke_area, $Deficit)        % expect fluent_aphasia
+? lesion_causes(broca_area, $Deficit)           % expect nonfluent_aphasia
+? lesion_causes(arcuate_fasciculus, $Deficit)   % expect conduction_aphasia
+? lesion_causes(substantia_nigra, $Deficit)     % expect parkinson_disease
+? lesion_causes(subthalamic_nucleus, $Deficit)  % expect hemiballismus

--- a/code/specs/data/mycin-2026/recall/test_neuro_recall.py
+++ b/code/specs/data/mycin-2026/recall/test_neuro_recall.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""test_neuro_recall.py — the ADJ-only neuroanatomical-localization library (MYCIN-2026 NEURO).
+
+The ninth recall domain shipped as a pure ADJ artifact (fifth Tier-2 organ-system domain,
+after RHEUM, ONCO, HISTO, CARDIO). `neuro-edges.adj` is the SOLE source of truth — facts +
+byte-provenance inline, no Python gate, no JSON, no manifest. This test pins the property
+that matters: the native adj-lang engine, given a query .adj that only `import`s the
+library and asks binding queries (`neuro-recall.query.adj` — the shape an LLM produces),
+binds the grounded deficit for each lesion site, each carrying an AUTHORITATIVE citation
+with a real source span + locator. Knowledge lives in ADJ; the engine answers.
+
+If the native CLI isn't built (a Python-only CI lane), the engine-backed checks skip —
+the file-shape checks (every clause grounded, no authored-debt) still run.
+
+Run:  python3 test_neuro_recall.py
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+ADJ = HERE / "neuro-edges.adj"
+QUERY = HERE / "neuro-recall.query.adj"
+CLI = HERE.parents[3] / "packages" / "rust" / "target" / "debug" / "adj-lang-cli"
+
+# Every grounded edge: lesion site -> the deficit the library binds for it.
+EXPECTED = {
+    "wernicke_area": "fluent_aphasia",
+    "broca_area": "nonfluent_aphasia",
+    "arcuate_fasciculus": "conduction_aphasia",
+    "substantia_nigra": "parkinson_disease",
+    "subthalamic_nucleus": "hemiballismus",
+}
+REL = "lesion_causes"
+VAR = "Deficit"
+
+
+def _cli_available() -> bool:
+    return CLI.exists()
+
+
+def _run(program: Path) -> dict:
+    out = subprocess.run([str(CLI), str(program)], capture_output=True, text=True,
+                         cwd=str(HERE), timeout=60)
+    assert out.returncode == 0, f"adj-lang-cli failed: {out.stderr}"
+    return json.loads(out.stdout)
+
+
+# ---- 1. the ADJ file is the artifact — every clause grounded, no authored-debt ----
+
+def test_library_is_pure_adj_and_fully_grounded() -> None:
+    text = ADJ.read_text()
+    assert "trust consensus" not in text, "NEURO ships no authored-debt; ground or omit"
+    assert "[FLAG:" not in text
+    edge_count = len(EXPECTED)  # 5
+    assert text.count("    relate ") == edge_count
+    assert text.count("trust authoritative") == edge_count
+    assert text.count('\n        locator "') == edge_count
+    assert text.count('\n        source "') == edge_count
+    assert not (HERE / "neuro_edge_ground.py").exists()
+    assert not (HERE / "neuro-edge-grounding.json").exists()
+    assert not (HERE / "neuro-edge-manifest.json").exists()
+
+
+# ---- 2. the engine binds each deficit, each with an authoritative citation ----
+
+def test_engine_binds_every_deficit_with_authoritative_citation() -> None:
+    if not _cli_available():
+        return
+    result = _run(QUERY)
+    by_query = {r["query"]: r for r in result["recall"]}
+    for site, deficit in EXPECTED.items():
+        q = f"{REL}({site}, {VAR})"
+        r = by_query.get(q)
+        assert r is not None and not r["abstained"], f"{q} abstained — edge missing?"
+        bound = {}
+        for a in r["answers"]:
+            bound[a["bindings"][VAR]] = (a.get("citations") or [{}])[0]
+        assert set(bound) == {deficit}, f"{site}: bound {set(bound)} != {{{deficit}}}"
+        cite = bound[deficit]
+        assert cite.get("trust") == "authoritative", f"{site}/{deficit} not authoritative"
+        assert cite.get("source"), f"{site}/{deficit} has no source span"
+        assert cite.get("locator", "").startswith("https://www.ncbi.nlm.nih.gov/")
+
+
+# ---- 3. an off-vocabulary lesion site abstains, never fabricates -------------------
+
+def test_unknown_site_abstains() -> None:
+    if not _cli_available():
+        return
+    import os
+    import tempfile
+    fd, path = tempfile.mkstemp(suffix=".adj", prefix=".neuro_q_", dir=HERE)
+    try:
+        with os.fdopen(fd, "w") as fh:
+            # hippocampus is not in the library → must abstain
+            fh.write(f'import "neuro-edges.adj"\n? {REL}(hippocampus, ${VAR})\n')
+        res = _run(Path(path))
+        r = res["recall"][0] if res["recall"] else None
+        assert r is not None and r["abstained"], "an ungrounded lesion site must abstain"
+    finally:
+        os.unlink(path)
+
+
+def _run_all() -> int:
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    failed = 0
+    for t in tests:
+        try:
+            t()
+            print(f"  PASS  {t.__name__}")
+        except AssertionError as exc:
+            failed += 1
+            print(f"  FAIL  {t.__name__}: {exc}")
+    print(f"\ntest_neuro_recall: {len(tests) - failed}/{len(tests)} passed")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(_run_all())


### PR DESCRIPTION
## What

The **ninth ADJ-only recall domain** for MYCIN-2026 (fifth Tier-2 organ-system, after RHEUM, ONCO, HISTO, CARDIO): classic neuroanatomical **localization** — lesion *here* produces *this* deficit. `recall/neuro-edges.adj` is the sole shipped artifact — facts + **inline byte-provenance**, no Python gate, no JSON, no manifest. A query is another `.adj` that `import`s the library and asks `? lesion_causes(<site>, $Deficit)`.

Relation `lesion_causes(structure → deficit)` is the board direction: told the lesion site, name the deficit/syndrome.

## The five edges (each grounded to a byte-stable verbatim NCBI StatPearls span naming BOTH endpoints)

| lesion site | deficit | source |
|---|---|---|
| Wernicke area | fluent (receptive) aphasia | NBK559315 |
| Broca area | nonfluent (expressive) aphasia | NBK559315 |
| arcuate fasciculus | conduction aphasia | NBK559315 |
| substantia nigra (dopaminergic degeneration) | Parkinson disease | NBK470193 |
| subthalamic nucleus | hemiballismus | NBK559002 |

**Deferred honestly:** cerebellar hemisphere → ataxia — its page names the *cerebellar syndrome* and limb incoordination but not *ataxia* alongside the lesion site in one declarative.

## Verification
- `test_neuro_recall.py` **3/3** — engine binds every deficit with an authoritative citation; off-vocab site (`hippocampus`) abstains.
- `test_board_eval.py` **12/12** — recall 103→**108** correct, grounded 102→**107** (107/108 = **0.9907**), **0 wrong**, **defensibility 1.0**.
- Security review: **PASSED** (no `shell=True`; `mkstemp` TOCTOU-safe; .adj spans stay inside string context; locators inert).

## Wiring
`neuro-edges.adj` → `EDGE_FILES` in `board_eval.py` + `decompose_query.py`; `REL_VAR["lesion_causes"]="Deficit"` (30 relations / thirteen domains); 5 board items; scorecard regenerated; USMLE-DOMAIN-MAP updated.

> Note: `code/specs/data/mycin-2026` is not wired into CI (no BUILD file); local runs above are the verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)