### PR TITLE
feat(closure-pass-inline): assignment-target value capture (CLOC15 PR-6)

### DIFF
--- a/code/packages/rust/closure-pass-inline/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-inline/CHANGELOG.md
@@ -2,6 +2,49 @@
 
 All notable changes to the `coding-adventures-closure-pass-inline` crate will be documented in this file.
 
+## [0.13.0] - 2026-06-19
+
+### Added (CLOC15 PR-6 — assignment-target value capture, `g = f(x)`)
+
+Completes the value-capture family (after PR-3 const-init `const r = f(x)` and
+PR-5 return `return f(x)`) with the assignment-target case — CLOC15 Open
+Question 2's last form. A single-use multi-statement helper whose call is the
+entire right-hand side of a **simple assignment to a bare identifier**
+(`g = f(x)`) now has its body hoisted before the assignment, with the callee's
+tail `return E` re-emitted as `g = E` — no temp, the value flows straight into
+the target. Example (SIMPLE, post-fold):
+
+```js
+function f(x){ side(); return x * 2; } var g; g = f(7); use(g);
+// before:  function f(x){side();return x*2};var g;g=f(7);use(g);
+// after:   var g;side();g=14;use(g);
+```
+
+This was prototyped during PR-5 but could not fire — or even be unit-tested
+through the bridge-based `inline_source` harness — until assignment-expression
+statements parsed (the CLOC17 grammar fix, `javascript-parser` 0.9.0). It is
+now reachable.
+
+**Soundness (why the gate is narrow):**
+- Only the simple `=` operator is admitted. **Compound** assignment
+  (`g += f(x)`) reads the old `g` *before* the call runs; hoisting the body
+  ahead (`body…; g += E`) would read `g` *after* the body's effects — if the
+  body mutates `g` the two differ, so it is declined.
+- Only a **bare identifier** target is admitted. **Member** targets
+  (`obj.k = f(x)`) evaluate the reference to `obj` *before* the call; hoisting
+  the body ahead could reorder observable effects (an `obj` getter, or the body
+  mutating `obj`), so they are declined.
+- The call must be the **entire** right-hand side (a `CallExpression`); a
+  `g = f(x) + 1` RHS is a `BinaryExpression` and is declined.
+- A void helper (no tail-return *value*) is not a valued candidate, so
+  `g = f(1)` against such a helper is left intact.
+
+Implemented as a third `CaptureTail::IntoAssignment` variant sharing
+`build_captured_body` with the const-init and return paths, plus a
+`capture_splice_for_assignment` recognizer wired into `try_capture_in_stmt`.
+Six new unit tests (one positive, one composing local-rename + non-simple-arg
+materialisation, four decline cases). No closurec fixture churn.
+
 ## [0.12.0] - 2026-06-19
 
 ### Added (CLOC16 Slice B1 — nested splice sites via a global-uniqueness gate)

--- a/code/packages/rust/closure-pass-inline/Cargo.toml
+++ b/code/packages/rust/closure-pass-inline/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-inline"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 description = "Function-inlining pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Substitutes small or single-use function bodies at their call sites to enable downstream folding and shrink call overhead."
 

--- a/code/packages/rust/closure-pass-inline/README.md
+++ b/code/packages/rust/closure-pass-inline/README.md
@@ -180,8 +180,8 @@ single-declarator** `var`/`let`/`const` — nothing is evaluated before it and
 an initializer is never short-circuited. `var x = a + f()` (reorders `a`),
 `var x = f(), y = …` (multi-declarator), `var x = h(f())` (not the top
 expression), and a body with no tail-return value are all declined. The
-`return`-argument value position is admitted by PR-5 (below); assignment
-targets remain a later slice.
+`return`-argument value position is admitted by PR-5, and the
+assignment-target position (`g = f(x)`) by PR-6 (both below).
 
 ### Non-simple arguments — per-argument temps (CLOC15 PR-4a)
 
@@ -241,6 +241,30 @@ call must be the *whole* argument: `return cond && f(x)` (right operand of
 `&&`), `return c ? f(x) : y` (a conditional branch), and a void helper used as
 `return f(x)` (no value to return) are all declined. Composes with local
 alpha-renaming and PR-4a per-argument temps.
+
+### Result assigned — `g = f(x)` (CLOC15 PR-6)
+
+The third airtight value position is a call that is the **entire right-hand
+side of a simple assignment to a bare identifier** — the everyday "store a
+helper's result" shape. As with PR-5 no temp is needed: the helper's tail value
+becomes the **assignment's right-hand side**:
+
+```js
+function f(x) { side(); return x * 2; }
+var g; g = f(7); use(g);
+// SIMPLE  ⇒  var g; side(); g = 14; use(g);
+```
+
+`g = f(x)` evaluates the (trivial) reference to the bare target `g`, then the
+call, then assigns — so splicing `body…; g = E` preserves that order exactly,
+and the assignment statement's result value is discarded anyway. The gate is
+deliberately narrow: **compound** assignment (`g += f(x)`, which reads the old
+`g` *before* the call), a **member** target (`o.k = f(x)`, whose base `o` is
+evaluated *before* the call), a call that is not the whole RHS (`g = f(x) + 1`),
+and a void helper (no value) are all declined — each would reorder an
+observable effect. Reachable only since the CLOC17 grammar fix made
+assignment-expression statements parse. Composes with local alpha-renaming and
+PR-4a per-argument temps.
 
 ## Where this pass sits
 

--- a/code/packages/rust/closure-pass-inline/src/lib.rs
+++ b/code/packages/rust/closure-pass-inline/src/lib.rs
@@ -125,10 +125,10 @@ use coding_adventures_closure_pass_pipeline::{
 };
 use coding_adventures_javascript_ast::statement::{ReturnStatement, TaggedStatement};
 use coding_adventures_javascript_ast::{
-    AssignmentTarget, BindingTarget, BlockStatement, CallExpression, Declaration, Expression,
-    ExpressionStatement, ForInit, FunctionDeclaration, FunctionParam, Identifier, IfStatement,
-    NullLiteral, Program, ProgramItem, PropertyKey, Statement, VarKind, VariableDeclaration,
-    VariableDeclarator,
+    AssignmentExpression, AssignmentOperator, AssignmentTarget, BindingTarget, BlockStatement,
+    CallExpression, Declaration, Expression, ExpressionStatement, ForInit, FunctionDeclaration,
+    FunctionParam, Identifier, IfStatement, NullLiteral, Program, ProgramItem, PropertyKey,
+    Statement, VarKind, VariableDeclaration, VariableDeclarator,
 };
 
 /// `Pass::depends_on` value. Kept as a `const` so future tests and
@@ -2130,6 +2130,12 @@ fn try_capture_in_stmt(
         Statement::Tagged(TaggedStatement::ReturnStatement(rs)) => {
             capture_splice_for_return(rs, cand, avoid, nodes_touched)
         }
+        // `g = f(x);` — PR-6 value capture in assignment-target position
+        // (CLOC15 Open Question 2's last case). Reachable only now that
+        // assignment-expression statements parse (CLOC17).
+        Statement::Tagged(TaggedStatement::ExpressionStatement(es)) => {
+            capture_splice_for_assignment(es, cand, avoid, nodes_touched)
+        }
         _ => None,
     }
 }
@@ -2164,6 +2170,59 @@ fn capture_splice_for_return(
         cand,
         &ce.arguments,
         CaptureTail::AsReturn,
+        avoid,
+        nodes_touched,
+    ))
+}
+
+/// The assignment-target capture core (CLOC15 PR-6 / Open Question 2): an
+/// expression statement qualifies iff it is a **simple** assignment
+/// (`g = …`, operator `=`) to a **bare identifier** whose right-hand side is
+/// **exactly** `cand.name(args)` (the call is the entire RHS). The replacement
+/// is the hoisted body with the callee's tail `return E` re-emitted as
+/// `g = E;` — no temp, because the value flows straight into the assignment
+/// target.
+///
+/// Soundness — why only `=` to a bare identifier:
+/// - `g = f(x)` evaluates the LHS *reference* to `g` (trivial, no side effects
+///   for a bare identifier), then evaluates `f(x)` (the body), then assigns.
+///   Splicing `body…; g = E` runs the body's effects and assigns `E` to `g` in
+///   exactly that order — observationally identical. The assignment
+///   expression's *result value* is discarded (it is an expression statement),
+///   so nothing downstream depends on it.
+/// - **Compound** assignment (`g += f(x)`) is declined: `g += f(x)` reads the
+///   OLD `g` *before* `f(x)` runs, but `body…; g += E` would read `g` *after*
+///   the body — if the body mutates `g`, the two differ. Reordering would
+///   miscompile.
+/// - **Member** targets (`obj.k = f(x)`) are declined: the reference to
+///   `obj.k`'s base (`obj`) is evaluated *before* `f(x)`; hoisting the body
+///   ahead of it could reorder observable effects (a getter on `obj`, or the
+///   body mutating `obj`).
+fn capture_splice_for_assignment(
+    es: &ExpressionStatement,
+    cand: &VoidStmtCandidate,
+    avoid: &mut HashSet<String>,
+    nodes_touched: &mut u32,
+) -> Option<Vec<Statement>> {
+    let Expression::AssignmentExpression(ae) = &es.expression else {
+        return None;
+    };
+    if ae.operator != AssignmentOperator::Eq {
+        return None; // compound assignment reads the target before the call
+    }
+    let AssignmentTarget::Identifier(target) = &ae.left else {
+        return None; // member targets evaluate their base before the call
+    };
+    let Expression::CallExpression(ce) = ae.right.as_ref() else {
+        return None; // the call must be the ENTIRE right-hand side
+    };
+    if !is_void_target_call(ce, cand) {
+        return None;
+    }
+    Some(build_captured_body(
+        cand,
+        &ce.arguments,
+        CaptureTail::IntoAssignment(&target.name),
         avoid,
         nodes_touched,
     ))
@@ -2237,6 +2296,14 @@ enum CaptureTail<'a> {
     /// `return f(x)` preserves both the effects and the returned value
     /// (CLOC15 PR-5).
     AsReturn,
+    /// The call was the entire right-hand side of a simple assignment to a
+    /// bare identifier (`g = f(x)`). Emit `g = <value>;` directly — no temp is
+    /// needed because the value flows straight into the assignment target. The
+    /// caller (`capture_splice_for_assignment`) has already verified the
+    /// operator is `=` and the target is a bare identifier, the two conditions
+    /// that make hoisting the body ahead of the assignment observationally
+    /// inert (CLOC15 PR-6).
+    IntoAssignment(&'a str),
 }
 
 /// Build the hoisted body for a captured call: the callee body with its
@@ -2322,6 +2389,24 @@ fn build_captured_body(
                 ReturnStatement {
                     cv: None,
                     argument: Some(return_value),
+                },
+            )));
+        }
+        // `g = E;` — the value flows straight into the assignment target
+        // (no temp). A bare-identifier simple-assignment expression statement.
+        CaptureTail::IntoAssignment(target) => {
+            body.push(Statement::Tagged(TaggedStatement::ExpressionStatement(
+                ExpressionStatement {
+                    cv: None,
+                    expression: Expression::AssignmentExpression(AssignmentExpression {
+                        cv: None,
+                        operator: AssignmentOperator::Eq,
+                        left: AssignmentTarget::Identifier(Identifier {
+                            cv: None,
+                            name: target.to_string(),
+                        }),
+                        right: Box::new(return_value),
+                    }),
                 },
             )));
         }
@@ -3747,6 +3832,82 @@ mod tests {
         assert_eq!(
             inline_source("function f(a) { g(); return; } function main() { return f(1); }"),
             "function f(a){g();return};function main(){return f(1)};"
+        );
+    }
+
+    // ===== CLOC15 PR-6 — assignment-target value capture (`g = f(x)`) =====
+
+    #[test]
+    fn captures_helper_in_assignment_position() {
+        // The signature PR-6 case: `h = f(7)` where `f` is a single-use
+        // multi-statement helper. The body is hoisted before the assignment
+        // and the callee's tail `return a` (param substituted by `7`) becomes
+        // the caller's own `h = 7` — no temp, the value flows straight into the
+        // assignment target. Reachable only now that assignment-expression
+        // statements parse (CLOC17).
+        assert_eq!(
+            inline_source("function f(a) { g(); return a; } var h; h = f(7);"),
+            "function f(a){g();return a};var h;g();h=7;"
+        );
+    }
+
+    #[test]
+    fn captures_assignment_position_with_local_and_nonsimple_arg() {
+        // Assignment-position capture composes with local alpha-renaming AND
+        // the per-argument temp: the non-simple argument `compute()` is
+        // materialised once into a fresh temp before the body, the callee local
+        // `t` is renamed program-fresh, and the tail expression becomes the
+        // assignment's right-hand side.
+        assert_eq!(
+            inline_source("function f(p) { const t = p + 1; return t; } var h; h = f(compute());"),
+            "function f(p){const t=p + 1;return t};var h;const a=compute();const b=a + 1;h=b;"
+        );
+    }
+
+    #[test]
+    fn does_not_capture_compound_assignment() {
+        // `h += f(7)` reads the OLD `h` *before* `f(7)` runs; hoisting the body
+        // ahead (`g(); h += 7`) would read `h` *after* the body's effects. If
+        // the body mutated `h` the two would differ, so compound assignment is
+        // declined (the call is left intact).
+        assert_eq!(
+            inline_source("function f(a) { g(); return a; } var h = 0; h += f(7);"),
+            "function f(a){g();return a};var h=0;h+=f(7);"
+        );
+    }
+
+    #[test]
+    fn does_not_capture_member_assignment_target() {
+        // `o.k = f(7)` evaluates the reference to `o.k`'s base (`o`) *before*
+        // `f(7)`; hoisting the body ahead could reorder observable effects (an
+        // `o` getter, or the body mutating `o`). Member targets are declined.
+        assert_eq!(
+            inline_source("function f(a) { g(); return a; } var o = {}; o.k = f(7);"),
+            "function f(a){g();return a};var o={};o.k=f(7);"
+        );
+    }
+
+    #[test]
+    fn does_not_capture_assignment_when_call_is_not_entire_rhs() {
+        // `h = f(7) + 1` — the call is the left operand of `+`, not the entire
+        // right-hand side (the RHS is a `BinaryExpression`, not a
+        // `CallExpression`). Hoisting the body would be wrong, so it is
+        // declined.
+        assert_eq!(
+            inline_source("function f(a) { g(); return a; } var h; h = f(7) + 1;"),
+            "function f(a){g();return a};var h;h=f(7) + 1;"
+        );
+    }
+
+    #[test]
+    fn does_not_capture_void_helper_in_assignment_position() {
+        // A helper with no tail-return *value* (bare `return;`) is a void
+        // candidate, not a valued one; `h = f(1)` would assign its `undefined`,
+        // which the valued path does not synthesize — so the call is left
+        // intact rather than mis-spliced.
+        assert_eq!(
+            inline_source("function f(a) { g(); return; } var h; h = f(1);"),
+            "function f(a){g();return};var h;h=f(1);"
         );
     }
 }


### PR DESCRIPTION
## Summary

Completes the **value-capture family** — after PR-3 (`const r = f(x)`) and PR-5 (`return f(x)`) — with the **assignment-target** case, CLOC15 Open Question 2's last form. A single-use, multi-statement helper whose call is the entire RHS of a **simple assignment to a bare identifier** (`g = f(x)`) now has its body hoisted before the assignment, with the callee's tail `return E` re-emitted as `g = E`:

```js
function f(x){ side(); return x * 2; } var g; g = f(7); use(g);
// before:  function f(x){side();return x*2};var g;g=f(7);use(g);
// after (SIMPLE, post-fold):  var g;side();g=14;use(g);
```

This was prototyped during PR-5 but **could not fire — or even be unit-tested** through the bridge-based `inline_source` harness — until assignment-expression statements parsed (the **CLOC17 grammar fix**, `javascript-parser` 0.9.0, [#6264](https://github.com/adhithyan15/coding-adventures/pull/6264)). It is now reachable. This is the first optimization to directly exploit that unlock.

## Soundness — the gate is deliberately narrow

The transform moves the helper body **before** the assignment, so each gate guards an evaluation-order hazard:

- **Only `=`.** Compound `g += f(x)` reads the *old* `g` **before** the call; hoisting the body ahead would read `g` **after** the body's effects — if the body mutates `g` they differ. Declined.
- **Only a bare-identifier target.** Member targets `obj.k = f(x)` evaluate the base `obj` **before** the call; hoisting could reorder observable effects (an `obj` getter, or the body mutating `obj`). Declined.
- **The call must be the entire RHS** (a `CallExpression`); `g = f(x) + 1` (a `BinaryExpression` RHS) is declined.
- **Valued helpers only** — a void helper (`return;`) is not a valued candidate, so `g = f(1)` against it is left intact.

The fresh-name `avoid` set is seeded from all program identifiers (including the target `g`), so no minted local can collide with `g`. Reuses the existing `build_captured_body` alpha-rename + param-substitute + arg-materialise capture-safety model unchanged.

## Implementation

Third `CaptureTail::IntoAssignment` variant sharing `build_captured_body` with the const-init and return paths, plus a `capture_splice_for_assignment` recognizer wired into `try_capture_in_stmt`.

## Verification

- **6 new unit tests**: 1 positive, 1 composing local-rename + non-simple-arg materialisation, 4 decline cases (`+=`, `o.k=`, `g=f(7)+1`, void helper). `closure-pass-inline`: **83 tests pass**.
- **No closurec fixture churn**: closurec **680 tests pass**. Downstream consumers green (`remove-unused-vars` 21, `constant-fold` 44).
- Verified end-to-end through the real `closurec` binary (multi-statement body captures; `+=` and member targets correctly left intact).
- `closure-pass-inline` 0.12.0 → 0.13.0; CHANGELOG + README updated.
- Inline security review: **passed** (no miscompile vector, no panic/unsafe surface).

🤖 Generated with [Claude Code](https://claude.com/claude-code)