### PR TITLE
Surface smart-home mesh evidence disposition tools

### DIFF
--- a/code/packages/rust/chief-of-staff-smart-home-tools/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/src/lib.rs
@@ -73,6 +73,8 @@ use smart_home_integration_catalog::{
     mesh_protocol_substrate_preflight_repair_slot_audit_rows,
     mesh_protocol_substrate_preflight_repair_slot_audit_summary,
     mesh_protocol_substrate_preflight_repair_slot_execution_evidence_packets,
+    mesh_protocol_substrate_preflight_repair_slot_execution_evidence_review_disposition_summary,
+    mesh_protocol_substrate_preflight_repair_slot_execution_evidence_review_dispositions,
     mesh_protocol_substrate_preflight_repair_slot_execution_evidence_review_summary,
     mesh_protocol_substrate_preflight_repair_slot_execution_evidence_reviews,
     mesh_protocol_substrate_preflight_repair_slot_execution_evidence_summary,
@@ -177,6 +179,8 @@ use smart_home_integration_catalog::{
     IntegrationMeshProtocolSubstratePreflightRepairSlotAuditSummary,
     IntegrationMeshProtocolSubstratePreflightRepairSlotExecutionEvidencePacket,
     IntegrationMeshProtocolSubstratePreflightRepairSlotExecutionEvidenceReview,
+    IntegrationMeshProtocolSubstratePreflightRepairSlotExecutionEvidenceReviewDisposition,
+    IntegrationMeshProtocolSubstratePreflightRepairSlotExecutionEvidenceReviewDispositionSummary,
     IntegrationMeshProtocolSubstratePreflightRepairSlotExecutionEvidenceReviewSummary,
     IntegrationMeshProtocolSubstratePreflightRepairSlotExecutionEvidenceSummary,
     IntegrationMeshProtocolSubstratePreflightRepairSlotExecutionTicket,
@@ -408,6 +412,10 @@ pub const SMART_HOME_LIST_INTEGRATION_MESH_PREFLIGHT_REPAIR_SLOT_EXECUTION_EVIDE
     &str = "smart_home.list_integration_mesh_preflight_repair_slot_execution_evidence_reviews";
 pub const SMART_HOME_GET_INTEGRATION_MESH_PREFLIGHT_REPAIR_SLOT_EXECUTION_EVIDENCE_REVIEW_SUMMARY_TOOL_ID:
     &str = "smart_home.get_integration_mesh_preflight_repair_slot_execution_evidence_review_summary";
+pub const SMART_HOME_LIST_INTEGRATION_MESH_PREFLIGHT_REPAIR_SLOT_EXECUTION_EVIDENCE_REVIEW_DISPOSITIONS_TOOL_ID:
+    &str = "smart_home.list_integration_mesh_preflight_repair_slot_execution_evidence_review_dispositions";
+pub const SMART_HOME_GET_INTEGRATION_MESH_PREFLIGHT_REPAIR_SLOT_EXECUTION_EVIDENCE_REVIEW_DISPOSITION_SUMMARY_TOOL_ID:
+    &str = "smart_home.get_integration_mesh_preflight_repair_slot_execution_evidence_review_disposition_summary";
 pub const SMART_HOME_GET_INTEGRATION_MESH_PREFLIGHT_READINESS_SUMMARY_TOOL_ID: &str =
     "smart_home.get_integration_mesh_preflight_readiness_summary";
 pub const SMART_HOME_GET_INTEGRATION_MESH_PREFLIGHT_REPAIR_READINESS_SUMMARY_TOOL_ID: &str =
@@ -1064,6 +1072,24 @@ impl SmartHomeToolBridge {
                     let query = integration_readiness_query(&arguments)?;
                     Ok(
                         get_integration_mesh_preflight_repair_slot_execution_evidence_review_summary_output_handler_output(
+                            query,
+                        ),
+                    )
+                }
+                SMART_HOME_LIST_INTEGRATION_MESH_PREFLIGHT_REPAIR_SLOT_EXECUTION_EVIDENCE_REVIEW_DISPOSITIONS_TOOL_ID =>
+                {
+                    let query = integration_readiness_query(&arguments)?;
+                    Ok(
+                        list_integration_mesh_preflight_repair_slot_execution_evidence_review_dispositions_output_handler_output(
+                            query,
+                        ),
+                    )
+                }
+                SMART_HOME_GET_INTEGRATION_MESH_PREFLIGHT_REPAIR_SLOT_EXECUTION_EVIDENCE_REVIEW_DISPOSITION_SUMMARY_TOOL_ID =>
+                {
+                    let query = integration_readiness_query(&arguments)?;
+                    Ok(
+                        get_integration_mesh_preflight_repair_slot_execution_evidence_review_disposition_summary_output_handler_output(
                             query,
                         ),
                     )
@@ -3206,6 +3232,41 @@ pub fn smart_home_tool_definitions() -> Vec<ToolDefinition> {
             SMART_HOME_GET_INTEGRATION_MESH_PREFLIGHT_REPAIR_SLOT_EXECUTION_EVIDENCE_REVIEW_SUMMARY_TOOL_ID,
             "Get smart-home integration mesh preflight repair slot execution evidence review summary",
             "Return compact D23 mesh preflight repair slot execution evidence review counts.",
+            integration_readiness_query_schema(true),
+            object_schema(
+                vec![SchemaProperty::new("summary", JsonSchema::Any)],
+                vec!["summary"],
+                false,
+            ),
+        ),
+        read_definition(
+            SMART_HOME_LIST_INTEGRATION_MESH_PREFLIGHT_REPAIR_SLOT_EXECUTION_EVIDENCE_REVIEW_DISPOSITIONS_TOOL_ID,
+            "List smart-home integration mesh preflight repair slot execution evidence review dispositions",
+            "List D23 mesh preflight repair slot execution evidence review disposition items derived from review work.",
+            integration_readiness_query_schema(true),
+            object_schema(
+                vec![
+                    SchemaProperty::new(
+                        "mesh_preflight_repair_slot_execution_evidence_review_dispositions",
+                        JsonSchema::Array {
+                            items: Box::new(JsonSchema::Any),
+                        },
+                    ),
+                    SchemaProperty::new("summary", JsonSchema::Any),
+                    SchemaProperty::new("count", JsonSchema::Integer),
+                ],
+                vec![
+                    "mesh_preflight_repair_slot_execution_evidence_review_dispositions",
+                    "summary",
+                    "count",
+                ],
+                false,
+            ),
+        ),
+        read_definition(
+            SMART_HOME_GET_INTEGRATION_MESH_PREFLIGHT_REPAIR_SLOT_EXECUTION_EVIDENCE_REVIEW_DISPOSITION_SUMMARY_TOOL_ID,
+            "Get smart-home integration mesh preflight repair slot execution evidence review disposition summary",
+            "Return compact D23 mesh preflight repair slot execution evidence review disposition counts.",
             integration_readiness_query_schema(true),
             object_schema(
                 vec![SchemaProperty::new("summary", JsonSchema::Any)],
@@ -17790,6 +17851,42 @@ fn integration_mesh_preflight_repair_slot_execution_evidence_review_summary_for_
     }
 }
 
+fn integration_mesh_preflight_repair_slot_execution_evidence_review_dispositions_for_query(
+    query: &IntegrationReadinessQuery,
+) -> Vec<IntegrationMeshProtocolSubstratePreflightRepairSlotExecutionEvidenceReviewDisposition> {
+    let mut dispositions =
+        mesh_protocol_substrate_preflight_repair_slot_execution_evidence_review_dispositions(
+            &query.available_primitives,
+        );
+
+    if query.activation_ready == Some(true) {
+        dispositions.clear();
+    }
+    if let Some(limit) = query.limit {
+        dispositions.truncate(limit);
+    }
+
+    dispositions
+}
+
+fn integration_mesh_preflight_repair_slot_execution_evidence_review_disposition_summary_for_query(
+    query: &IntegrationReadinessQuery,
+) -> IntegrationMeshProtocolSubstratePreflightRepairSlotExecutionEvidenceReviewDispositionSummary {
+    if query.activation_ready.is_some() || query.limit.is_some() {
+        let dispositions =
+            integration_mesh_preflight_repair_slot_execution_evidence_review_dispositions_for_query(
+                query,
+            );
+        IntegrationMeshProtocolSubstratePreflightRepairSlotExecutionEvidenceReviewDispositionSummary::from_dispositions(
+            dispositions.iter(),
+        )
+    } else {
+        mesh_protocol_substrate_preflight_repair_slot_execution_evidence_review_disposition_summary(
+            &query.available_primitives,
+        )
+    }
+}
+
 fn integration_mesh_preflight_readiness_summary_for_query(
     query: &IntegrationReadinessQuery,
 ) -> IntegrationMeshPreflightReadinessSummary {
@@ -22844,6 +22941,112 @@ fn get_integration_mesh_preflight_repair_slot_execution_evidence_review_summary_
                 integer(summary.operator_required_reviews as i64),
             ),
             ("has_reviews", JsonValue::Bool(summary.has_reviews())),
+        ]),
+    )
+}
+
+fn list_integration_mesh_preflight_repair_slot_execution_evidence_review_dispositions_output_handler_output(
+    query: IntegrationReadinessQuery,
+) -> ToolHandlerOutput {
+    let dispositions =
+        integration_mesh_preflight_repair_slot_execution_evidence_review_dispositions_for_query(
+            &query,
+        );
+    let summary =
+        IntegrationMeshProtocolSubstratePreflightRepairSlotExecutionEvidenceReviewDispositionSummary::from_dispositions(
+            dispositions.iter(),
+        );
+    let count = dispositions.len();
+
+    ToolHandlerOutput::new(object([
+        (
+            "mesh_preflight_repair_slot_execution_evidence_review_dispositions",
+            JsonValue::Array(
+                dispositions
+                    .iter()
+                    .map(mesh_protocol_substrate_preflight_repair_slot_execution_evidence_review_disposition_json)
+                    .collect(),
+            ),
+        ),
+        (
+            "summary",
+            mesh_protocol_substrate_preflight_repair_slot_execution_evidence_review_disposition_summary_json(
+                &summary,
+            ),
+        ),
+        ("count", integer(count as i64)),
+    ]))
+    .with_event(
+        ToolEventKind::Progress,
+        object([
+            (
+                "operation",
+                string(
+                    "list_integration_mesh_preflight_repair_slot_execution_evidence_review_dispositions",
+                ),
+            ),
+            ("evidence_review_dispositions", integer(count as i64)),
+            (
+                "scheduled_actions",
+                integer(summary.scheduled_actions as i64),
+            ),
+            (
+                "operator_handoff_dispositions",
+                integer(summary.operator_handoff_dispositions as i64),
+            ),
+            (
+                "repair_required_dispositions",
+                integer(summary.repair_required_dispositions as i64),
+            ),
+            (
+                "execution_evidence_review_dispositions_ready",
+                JsonValue::Bool(summary.execution_evidence_review_dispositions_ready),
+            ),
+        ]),
+    )
+}
+
+fn get_integration_mesh_preflight_repair_slot_execution_evidence_review_disposition_summary_output_handler_output(
+    query: IntegrationReadinessQuery,
+) -> ToolHandlerOutput {
+    let summary =
+        integration_mesh_preflight_repair_slot_execution_evidence_review_disposition_summary_for_query(&query);
+
+    ToolHandlerOutput::new(object([(
+        "summary",
+        mesh_protocol_substrate_preflight_repair_slot_execution_evidence_review_disposition_summary_json(
+            &summary,
+        ),
+    )]))
+    .with_event(
+        ToolEventKind::Progress,
+        object([
+            (
+                "operation",
+                string(
+                    "get_integration_mesh_preflight_repair_slot_execution_evidence_review_disposition_summary",
+                ),
+            ),
+            (
+                "total_dispositions",
+                integer(summary.total_dispositions as i64),
+            ),
+            (
+                "scheduled_actions",
+                integer(summary.scheduled_actions as i64),
+            ),
+            (
+                "operator_handoff_dispositions",
+                integer(summary.operator_handoff_dispositions as i64),
+            ),
+            (
+                "repair_required_dispositions",
+                integer(summary.repair_required_dispositions as i64),
+            ),
+            (
+                "has_dispositions",
+                JsonValue::Bool(summary.has_dispositions()),
+            ),
         ]),
     )
 }
@@ -45836,6 +46039,257 @@ fn mesh_protocol_substrate_preflight_repair_slot_execution_evidence_review_summa
     ])
 }
 
+fn mesh_protocol_substrate_preflight_repair_slot_execution_evidence_review_disposition_json(
+    disposition: &IntegrationMeshProtocolSubstratePreflightRepairSlotExecutionEvidenceReviewDisposition,
+) -> JsonValue {
+    object([
+        ("sequence", integer(disposition.sequence as i64)),
+        ("disposition_key", string(&disposition.disposition_key)),
+        (
+            "review_sequence",
+            integer(disposition.review_sequence as i64),
+        ),
+        ("review_key", string(&disposition.review_key)),
+        (
+            "evidence_sequence",
+            integer(disposition.evidence_sequence as i64),
+        ),
+        ("evidence_key", string(&disposition.evidence_key)),
+        (
+            "work_order_sequence",
+            integer(disposition.work_order_sequence as i64),
+        ),
+        ("work_order_key", string(&disposition.work_order_key)),
+        (
+            "ticket_sequence",
+            integer(disposition.ticket_sequence as i64),
+        ),
+        ("ticket_key", string(&disposition.ticket_key)),
+        ("slot_sequence", integer(disposition.slot_sequence as i64)),
+        ("batch_sequence", integer(disposition.batch_sequence as i64)),
+        ("stage", string(disposition.stage.as_str())),
+        (
+            "action_kind",
+            mesh_substrate_preflight_action_kind_json(disposition.action_kind),
+        ),
+        ("status", string(disposition.status.as_str())),
+        (
+            "disposition_kind",
+            string(disposition.disposition_kind.as_str()),
+        ),
+        ("action_count", integer(disposition.action_count as i64)),
+        ("protocol_count", integer(disposition.protocol_count as i64)),
+        (
+            "primitive_count",
+            integer(disposition.primitive_count as i64),
+        ),
+        (
+            "protocols",
+            protocol_family_array_json(&disposition.protocols),
+        ),
+        (
+            "primitives",
+            primitive_family_array_json(&disposition.primitives),
+        ),
+        (
+            "release_blocking",
+            JsonValue::Bool(disposition.release_blocking),
+        ),
+        (
+            "operator_required",
+            JsonValue::Bool(disposition.operator_required),
+        ),
+        (
+            "lineage_complete",
+            JsonValue::Bool(disposition.lineage_complete),
+        ),
+        (
+            "review_required",
+            JsonValue::Bool(disposition.review_required),
+        ),
+        (
+            "ready_for_execution",
+            JsonValue::Bool(disposition.ready_for_execution),
+        ),
+        (
+            "blocks_preflight",
+            JsonValue::Bool(disposition.blocks_preflight()),
+        ),
+        (
+            "requires_operator",
+            JsonValue::Bool(disposition.requires_operator()),
+        ),
+        ("has_lineage", JsonValue::Bool(disposition.has_lineage())),
+        ("needs_review", JsonValue::Bool(disposition.needs_review())),
+        (
+            "is_operator_handoff",
+            JsonValue::Bool(disposition.is_operator_handoff()),
+        ),
+        (
+            "is_repair_required",
+            JsonValue::Bool(disposition.is_repair_required()),
+        ),
+        (
+            "is_lineage_gap",
+            JsonValue::Bool(disposition.is_lineage_gap()),
+        ),
+        (
+            "is_ready_for_execution",
+            JsonValue::Bool(disposition.is_ready_for_execution()),
+        ),
+    ])
+}
+
+fn mesh_protocol_substrate_preflight_repair_slot_execution_evidence_review_disposition_summary_json(
+    summary: &IntegrationMeshProtocolSubstratePreflightRepairSlotExecutionEvidenceReviewDispositionSummary,
+) -> JsonValue {
+    object([
+        (
+            "total_dispositions",
+            integer(summary.total_dispositions as i64),
+        ),
+        (
+            "scheduled_actions",
+            integer(summary.scheduled_actions as i64),
+        ),
+        (
+            "blocking_dispositions",
+            integer(summary.blocking_dispositions as i64),
+        ),
+        (
+            "operator_handoff_dispositions",
+            integer(summary.operator_handoff_dispositions as i64),
+        ),
+        (
+            "repair_required_dispositions",
+            integer(summary.repair_required_dispositions as i64),
+        ),
+        (
+            "lineage_gap_dispositions",
+            integer(summary.lineage_gap_dispositions as i64),
+        ),
+        (
+            "review_required_dispositions",
+            integer(summary.review_required_dispositions as i64),
+        ),
+        (
+            "execution_ready_dispositions",
+            integer(summary.execution_ready_dispositions as i64),
+        ),
+        (
+            "lineage_complete_dispositions",
+            integer(summary.lineage_complete_dispositions as i64),
+        ),
+        (
+            "protocol_mentions",
+            integer(summary.protocol_mentions as i64),
+        ),
+        (
+            "primitive_mentions",
+            integer(summary.primitive_mentions as i64),
+        ),
+        (
+            "first_disposition_key",
+            summary
+                .first_disposition_key
+                .as_ref()
+                .map(string)
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_operator_handoff_disposition_key",
+            summary
+                .first_operator_handoff_disposition_key
+                .as_ref()
+                .map(string)
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_repair_required_disposition_key",
+            summary
+                .first_repair_required_disposition_key
+                .as_ref()
+                .map(string)
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_lineage_gap_disposition_key",
+            summary
+                .first_lineage_gap_disposition_key
+                .as_ref()
+                .map(string)
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_review_key",
+            summary
+                .first_review_key
+                .as_ref()
+                .map(string)
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_evidence_key",
+            summary
+                .first_evidence_key
+                .as_ref()
+                .map(string)
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_work_order_key",
+            summary
+                .first_work_order_key
+                .as_ref()
+                .map(string)
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_ticket_key",
+            summary
+                .first_ticket_key
+                .as_ref()
+                .map(string)
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_stage",
+            summary
+                .first_stage
+                .map(|stage| string(stage.as_str()))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_action_kind",
+            summary
+                .first_action_kind
+                .map(mesh_substrate_preflight_action_kind_json)
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "execution_evidence_review_dispositions_ready",
+            JsonValue::Bool(summary.execution_evidence_review_dispositions_ready),
+        ),
+        ("is_empty", JsonValue::Bool(summary.is_empty())),
+        (
+            "has_dispositions",
+            JsonValue::Bool(summary.has_dispositions()),
+        ),
+        ("has_blockers", JsonValue::Bool(summary.has_blockers())),
+        ("needs_operator", JsonValue::Bool(summary.needs_operator())),
+        ("needs_repair", JsonValue::Bool(summary.needs_repair())),
+        ("needs_review", JsonValue::Bool(summary.needs_review())),
+        (
+            "has_lineage_gaps",
+            JsonValue::Bool(summary.has_lineage_gaps()),
+        ),
+        (
+            "has_complete_lineage",
+            JsonValue::Bool(summary.has_complete_lineage()),
+        ),
+    ])
+}
+
 fn mesh_preflight_slot_readiness_summary_json(
     summary: &IntegrationMeshPreflightSlotReadinessSummary,
 ) -> JsonValue {
@@ -53703,7 +54157,7 @@ mod tests {
         let definitions = smart_home_tool_definitions();
         let export = ToolCatalogExport::from_definitions(definitions.iter());
 
-        assert_eq!(definitions.len(), 222);
+        assert_eq!(definitions.len(), 224);
         assert!(
             export.ok(),
             "tool export validation failed: {:?}",
@@ -53954,6 +54408,12 @@ mod tests {
         ));
         assert!(export.tool_ids().contains(
             &SMART_HOME_GET_INTEGRATION_MESH_PREFLIGHT_REPAIR_SLOT_EXECUTION_EVIDENCE_REVIEW_SUMMARY_TOOL_ID
+        ));
+        assert!(export.tool_ids().contains(
+            &SMART_HOME_LIST_INTEGRATION_MESH_PREFLIGHT_REPAIR_SLOT_EXECUTION_EVIDENCE_REVIEW_DISPOSITIONS_TOOL_ID
+        ));
+        assert!(export.tool_ids().contains(
+            &SMART_HOME_GET_INTEGRATION_MESH_PREFLIGHT_REPAIR_SLOT_EXECUTION_EVIDENCE_REVIEW_DISPOSITION_SUMMARY_TOOL_ID
         ));
         assert!(export
             .tool_ids()
@@ -54346,7 +54806,7 @@ mod tests {
         ));
         assert_eq!(
             export.summary.required_capability_count("smart_home:read"),
-            214
+            216
         );
         assert_eq!(
             export
@@ -54495,6 +54955,14 @@ mod tests {
         .is_some());
         assert!(smart_home_tool_definition(
             SMART_HOME_GET_INTEGRATION_MESH_PREFLIGHT_REPAIR_SLOT_EXECUTION_EVIDENCE_REVIEW_SUMMARY_TOOL_ID
+        )
+        .is_some());
+        assert!(smart_home_tool_definition(
+            SMART_HOME_LIST_INTEGRATION_MESH_PREFLIGHT_REPAIR_SLOT_EXECUTION_EVIDENCE_REVIEW_DISPOSITIONS_TOOL_ID
+        )
+        .is_some());
+        assert!(smart_home_tool_definition(
+            SMART_HOME_GET_INTEGRATION_MESH_PREFLIGHT_REPAIR_SLOT_EXECUTION_EVIDENCE_REVIEW_DISPOSITION_SUMMARY_TOOL_ID
         )
         .is_some());
         assert!(smart_home_tool_definition(
@@ -55154,11 +55622,11 @@ mod tests {
         let tool_catalog_summary = field(tool_catalog_summary_output, "summary").unwrap();
         assert_eq!(
             field(tool_catalog_summary, "total_tools"),
-            Some(&integer(222))
+            Some(&integer(224))
         );
         assert_eq!(
             field(tool_catalog_summary, "read_tools"),
-            Some(&integer(214))
+            Some(&integer(216))
         );
         assert_eq!(
             field(tool_catalog_summary, "risky_tool_count"),
@@ -58716,6 +59184,172 @@ mod tests {
             field(
                 mesh_preflight_repair_slot_execution_evidence_review_rollup,
                 "execution_evidence_reviews_ready"
+            ),
+            Some(&JsonValue::Bool(false))
+        );
+
+        let list_mesh_preflight_repair_slot_execution_evidence_review_dispositions_request =
+            request(
+                "call-list-integration-mesh-preflight-repair-slot-execution-evidence-review-dispositions",
+                SMART_HOME_LIST_INTEGRATION_MESH_PREFLIGHT_REPAIR_SLOT_EXECUTION_EVIDENCE_REVIEW_DISPOSITIONS_TOOL_ID,
+                object([
+                    (
+                        "available_primitives",
+                        JsonValue::Array(vec![
+                            string("usb"),
+                            string("serial_controller"),
+                            string("radio_802154"),
+                            string("supervision"),
+                        ]),
+                    ),
+                    ("activation_ready", JsonValue::Bool(false)),
+                ]),
+                5_929_104,
+            );
+        let list_mesh_preflight_repair_slot_execution_evidence_review_dispositions_trace =
+            tool_runtime.invoke_with_events(
+                &list_mesh_preflight_repair_slot_execution_evidence_review_dispositions_request,
+            );
+        assert!(
+            list_mesh_preflight_repair_slot_execution_evidence_review_dispositions_trace
+                .result
+                .ok
+        );
+        assert_eq!(
+            list_mesh_preflight_repair_slot_execution_evidence_review_dispositions_trace
+                .summary()
+                .progress_event_count,
+            1
+        );
+        let list_mesh_preflight_repair_slot_execution_evidence_review_dispositions_output =
+            list_mesh_preflight_repair_slot_execution_evidence_review_dispositions_trace
+                .result
+                .output
+                .as_ref()
+                .unwrap();
+        assert_eq!(
+            field(
+                list_mesh_preflight_repair_slot_execution_evidence_review_dispositions_output,
+                "count"
+            ),
+            Some(&integer(3))
+        );
+        let mesh_preflight_repair_slot_execution_evidence_review_disposition_summary = field(
+            list_mesh_preflight_repair_slot_execution_evidence_review_dispositions_output,
+            "summary",
+        )
+        .unwrap();
+        assert_eq!(
+            field(
+                mesh_preflight_repair_slot_execution_evidence_review_disposition_summary,
+                "operator_handoff_dispositions"
+            ),
+            Some(&integer(2))
+        );
+        assert_eq!(
+            field(
+                mesh_preflight_repair_slot_execution_evidence_review_disposition_summary,
+                "repair_required_dispositions"
+            ),
+            Some(&integer(1))
+        );
+        let mesh_preflight_repair_slot_execution_evidence_review_disposition = array_item(
+            field(
+                list_mesh_preflight_repair_slot_execution_evidence_review_dispositions_output,
+                "mesh_preflight_repair_slot_execution_evidence_review_dispositions",
+            )
+            .unwrap(),
+            0,
+        )
+        .unwrap();
+        assert_eq!(
+            field(
+                mesh_preflight_repair_slot_execution_evidence_review_disposition,
+                "disposition_key"
+            ),
+            Some(&string("disposition-01-radio-provision_radio"))
+        );
+        assert_eq!(
+            field(
+                mesh_preflight_repair_slot_execution_evidence_review_disposition,
+                "review_key"
+            ),
+            Some(&string("review-01-radio-provision_radio"))
+        );
+        assert_eq!(
+            field(
+                mesh_preflight_repair_slot_execution_evidence_review_disposition,
+                "disposition_kind"
+            ),
+            Some(&string("operator_handoff"))
+        );
+        assert_eq!(
+            field(
+                mesh_preflight_repair_slot_execution_evidence_review_disposition,
+                "is_operator_handoff"
+            ),
+            Some(&JsonValue::Bool(true))
+        );
+
+        let mesh_preflight_repair_slot_execution_evidence_review_disposition_summary_request =
+            request(
+                "call-integration-mesh-preflight-repair-slot-execution-evidence-review-disposition-summary",
+                SMART_HOME_GET_INTEGRATION_MESH_PREFLIGHT_REPAIR_SLOT_EXECUTION_EVIDENCE_REVIEW_DISPOSITION_SUMMARY_TOOL_ID,
+                object([(
+                    "available_primitives",
+                    JsonValue::Array(vec![
+                        string("usb"),
+                        string("serial_controller"),
+                        string("radio_802154"),
+                        string("supervision"),
+                    ]),
+                )]),
+                5_929_105,
+            );
+        let mesh_preflight_repair_slot_execution_evidence_review_disposition_summary_trace =
+            tool_runtime.invoke_with_events(
+                &mesh_preflight_repair_slot_execution_evidence_review_disposition_summary_request,
+            );
+        assert!(
+            mesh_preflight_repair_slot_execution_evidence_review_disposition_summary_trace
+                .result
+                .ok
+        );
+        assert_eq!(
+            mesh_preflight_repair_slot_execution_evidence_review_disposition_summary_trace
+                .summary()
+                .progress_event_count,
+            1
+        );
+        let mesh_preflight_repair_slot_execution_evidence_review_disposition_summary_output =
+            mesh_preflight_repair_slot_execution_evidence_review_disposition_summary_trace
+                .result
+                .output
+                .as_ref()
+                .unwrap();
+        let mesh_preflight_repair_slot_execution_evidence_review_disposition_rollup = field(
+            mesh_preflight_repair_slot_execution_evidence_review_disposition_summary_output,
+            "summary",
+        )
+        .unwrap();
+        assert_eq!(
+            field(
+                mesh_preflight_repair_slot_execution_evidence_review_disposition_rollup,
+                "total_dispositions"
+            ),
+            Some(&integer(3))
+        );
+        assert_eq!(
+            field(
+                mesh_preflight_repair_slot_execution_evidence_review_disposition_rollup,
+                "lineage_gap_dispositions"
+            ),
+            Some(&integer(0))
+        );
+        assert_eq!(
+            field(
+                mesh_preflight_repair_slot_execution_evidence_review_disposition_rollup,
+                "execution_evidence_review_dispositions_ready"
             ),
             Some(&JsonValue::Bool(false))
         );

--- a/code/packages/rust/smart-home-core/src/lib.rs
+++ b/code/packages/rust/smart-home-core/src/lib.rs
@@ -1614,6 +1614,8 @@ pub enum SmartHomeTool {
     GetIntegrationMeshPreflightRepairSlotExecutionEvidenceSummary,
     ListIntegrationMeshPreflightRepairSlotExecutionEvidenceReviews,
     GetIntegrationMeshPreflightRepairSlotExecutionEvidenceReviewSummary,
+    ListIntegrationMeshPreflightRepairSlotExecutionEvidenceReviewDispositions,
+    GetIntegrationMeshPreflightRepairSlotExecutionEvidenceReviewDispositionSummary,
     GetIntegrationMeshPreflightReadinessSummary,
     GetIntegrationMeshPreflightRepairReadinessSummary,
     GetIntegrationMeshPreflightBatchReadinessSummary,
@@ -2167,6 +2169,12 @@ impl SmartHomeTool {
             Self::GetIntegrationMeshPreflightRepairSlotExecutionEvidenceReviewSummary => read_tool(
                 "smart_home.get_integration_mesh_preflight_repair_slot_execution_evidence_review_summary",
             ),
+            Self::ListIntegrationMeshPreflightRepairSlotExecutionEvidenceReviewDispositions => {
+                read_tool("smart_home.list_integration_mesh_preflight_repair_slot_execution_evidence_review_dispositions")
+            }
+            Self::GetIntegrationMeshPreflightRepairSlotExecutionEvidenceReviewDispositionSummary => {
+                read_tool("smart_home.get_integration_mesh_preflight_repair_slot_execution_evidence_review_disposition_summary")
+            }
             Self::GetIntegrationMeshPreflightReadinessSummary => {
                 read_tool("smart_home.get_integration_mesh_preflight_readiness_summary")
             }
@@ -2983,6 +2991,8 @@ pub fn smart_home_tool_catalog() -> Vec<ToolDescriptor> {
         SmartHomeTool::GetIntegrationMeshPreflightRepairSlotExecutionEvidenceSummary,
         SmartHomeTool::ListIntegrationMeshPreflightRepairSlotExecutionEvidenceReviews,
         SmartHomeTool::GetIntegrationMeshPreflightRepairSlotExecutionEvidenceReviewSummary,
+        SmartHomeTool::ListIntegrationMeshPreflightRepairSlotExecutionEvidenceReviewDispositions,
+        SmartHomeTool::GetIntegrationMeshPreflightRepairSlotExecutionEvidenceReviewDispositionSummary,
         SmartHomeTool::GetIntegrationMeshPreflightReadinessSummary,
         SmartHomeTool::GetIntegrationMeshPreflightRepairReadinessSummary,
         SmartHomeTool::GetIntegrationMeshPreflightBatchReadinessSummary,
@@ -3831,7 +3841,7 @@ mod tests {
             .find(|tool| tool.tool_id == "smart_home.command")
             .unwrap();
 
-        assert_eq!(catalog.len(), 222);
+        assert_eq!(catalog.len(), 224);
         assert!(catalog
             .iter()
             .any(|tool| tool.tool_id == "smart_home.list_integrations"
@@ -4081,6 +4091,8 @@ mod tests {
             "smart_home.get_integration_mesh_preflight_repair_slot_execution_evidence_summary",
             "smart_home.list_integration_mesh_preflight_repair_slot_execution_evidence_reviews",
             "smart_home.get_integration_mesh_preflight_repair_slot_execution_evidence_review_summary",
+            "smart_home.list_integration_mesh_preflight_repair_slot_execution_evidence_review_dispositions",
+            "smart_home.get_integration_mesh_preflight_repair_slot_execution_evidence_review_disposition_summary",
             "smart_home.get_integration_mesh_preflight_slot_readiness_summary",
             "smart_home.list_integration_mesh_readiness_handoffs",
             "smart_home.get_integration_mesh_readiness_handoff_summary",
@@ -4672,6 +4684,14 @@ mod tests {
             && tool.side_effects == ToolSideEffects::Read
             && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
         assert!(catalog.iter().any(|tool| tool.tool_id
+            == "smart_home.list_integration_mesh_preflight_repair_slot_execution_evidence_review_dispositions"
+            && tool.side_effects == ToolSideEffects::Read
+            && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
+        assert!(catalog.iter().any(|tool| tool.tool_id
+            == "smart_home.get_integration_mesh_preflight_repair_slot_execution_evidence_review_disposition_summary"
+            && tool.side_effects == ToolSideEffects::Read
+            && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
+        assert!(catalog.iter().any(|tool| tool.tool_id
             == "smart_home.get_integration_mesh_preflight_readiness_summary"
             && tool.side_effects == ToolSideEffects::Read
             && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
@@ -4702,15 +4722,15 @@ mod tests {
         let summary = smart_home_tool_catalog_summary();
         let pair_bridge = SmartHomeTool::PairBridge.descriptor();
 
-        assert_eq!(summary.total_tools, 222);
-        assert_eq!(summary.read_tools, 214);
+        assert_eq!(summary.total_tools, 224);
+        assert_eq!(summary.read_tools, 216);
         assert_eq!(summary.write_tools, 2);
         assert_eq!(summary.external_tools, 6);
-        assert_eq!(summary.read_only_tier_tools, 214);
+        assert_eq!(summary.read_only_tier_tools, 216);
         assert_eq!(summary.low_risk_tier_tools, 6);
         assert_eq!(summary.high_risk_tier_tools, 0);
         assert_eq!(summary.human_approval_tier_tools, 2);
-        assert_eq!(summary.total_required_capabilities, 222);
+        assert_eq!(summary.total_required_capabilities, 224);
         assert_eq!(summary.risky_tool_count(), 8);
         assert_eq!(summary.approval_gated_tool_count(), 2);
         assert!(pair_bridge.requires_human_approval());

--- a/code/packages/rust/smart-home-integration-catalog/src/lib.rs
+++ b/code/packages/rust/smart-home-integration-catalog/src/lib.rs
@@ -1861,6 +1861,286 @@ impl IntegrationMeshProtocolSubstratePreflightRepairSlotExecutionEvidenceReviewS
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum IntegrationMeshProtocolSubstratePreflightRepairSlotExecutionEvidenceReviewDispositionKind {
+    OperatorHandoff,
+    RepairRequired,
+    LineageGap,
+    ReadyForExecution,
+}
+
+impl IntegrationMeshProtocolSubstratePreflightRepairSlotExecutionEvidenceReviewDispositionKind {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::OperatorHandoff => "operator_handoff",
+            Self::RepairRequired => "repair_required",
+            Self::LineageGap => "lineage_gap",
+            Self::ReadyForExecution => "ready_for_execution",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IntegrationMeshProtocolSubstratePreflightRepairSlotExecutionEvidenceReviewDisposition {
+    pub sequence: usize,
+    pub disposition_key: String,
+    pub review_sequence: usize,
+    pub review_key: String,
+    pub evidence_sequence: usize,
+    pub evidence_key: String,
+    pub work_order_sequence: usize,
+    pub work_order_key: String,
+    pub ticket_sequence: usize,
+    pub ticket_key: String,
+    pub slot_sequence: usize,
+    pub batch_sequence: usize,
+    pub stage: IntegrationMeshProtocolSubstrateStage,
+    pub action_kind: IntegrationMeshProtocolSubstratePreflightActionKind,
+    pub status: IntegrationMeshProtocolSubstratePreflightRepairSlotExecutionStatus,
+    pub disposition_kind:
+        IntegrationMeshProtocolSubstratePreflightRepairSlotExecutionEvidenceReviewDispositionKind,
+    pub action_count: usize,
+    pub protocol_count: usize,
+    pub primitive_count: usize,
+    pub protocols: Vec<ProtocolFamily>,
+    pub primitives: Vec<PrimitiveFamily>,
+    pub release_blocking: bool,
+    pub operator_required: bool,
+    pub lineage_complete: bool,
+    pub review_required: bool,
+    pub ready_for_execution: bool,
+}
+
+impl IntegrationMeshProtocolSubstratePreflightRepairSlotExecutionEvidenceReviewDisposition {
+    pub fn from_review(
+        sequence: usize,
+        review: &IntegrationMeshProtocolSubstratePreflightRepairSlotExecutionEvidenceReview,
+    ) -> Self {
+        let disposition_kind = if !review.has_lineage() {
+            IntegrationMeshProtocolSubstratePreflightRepairSlotExecutionEvidenceReviewDispositionKind::LineageGap
+        } else if review.requires_operator() {
+            IntegrationMeshProtocolSubstratePreflightRepairSlotExecutionEvidenceReviewDispositionKind::OperatorHandoff
+        } else if review.blocks_preflight() || review.needs_review() {
+            IntegrationMeshProtocolSubstratePreflightRepairSlotExecutionEvidenceReviewDispositionKind::RepairRequired
+        } else {
+            IntegrationMeshProtocolSubstratePreflightRepairSlotExecutionEvidenceReviewDispositionKind::ReadyForExecution
+        };
+
+        Self {
+            sequence,
+            disposition_key: format!(
+                "disposition-{sequence:02}-{}-{}",
+                review.stage.as_str(),
+                review.action_kind.as_str()
+            ),
+            review_sequence: review.sequence,
+            review_key: review.review_key.clone(),
+            evidence_sequence: review.evidence_sequence,
+            evidence_key: review.evidence_key.clone(),
+            work_order_sequence: review.work_order_sequence,
+            work_order_key: review.work_order_key.clone(),
+            ticket_sequence: review.ticket_sequence,
+            ticket_key: review.ticket_key.clone(),
+            slot_sequence: review.slot_sequence,
+            batch_sequence: review.batch_sequence,
+            stage: review.stage,
+            action_kind: review.action_kind,
+            status: review.status,
+            disposition_kind,
+            action_count: review.action_count,
+            protocol_count: review.protocol_count,
+            primitive_count: review.primitive_count,
+            protocols: review.protocols.clone(),
+            primitives: review.primitives.clone(),
+            release_blocking: review.blocks_preflight(),
+            operator_required: review.requires_operator(),
+            lineage_complete: review.has_lineage(),
+            review_required: review.needs_review(),
+            ready_for_execution: review.is_ready_for_execution(),
+        }
+    }
+
+    pub fn blocks_preflight(&self) -> bool {
+        self.release_blocking
+    }
+
+    pub fn requires_operator(&self) -> bool {
+        self.operator_required
+    }
+
+    pub fn has_lineage(&self) -> bool {
+        self.lineage_complete
+    }
+
+    pub fn needs_review(&self) -> bool {
+        self.review_required
+    }
+
+    pub fn is_ready_for_execution(&self) -> bool {
+        self.ready_for_execution
+    }
+
+    pub fn is_operator_handoff(&self) -> bool {
+        self.disposition_kind
+            == IntegrationMeshProtocolSubstratePreflightRepairSlotExecutionEvidenceReviewDispositionKind::OperatorHandoff
+    }
+
+    pub fn is_repair_required(&self) -> bool {
+        self.disposition_kind
+            == IntegrationMeshProtocolSubstratePreflightRepairSlotExecutionEvidenceReviewDispositionKind::RepairRequired
+    }
+
+    pub fn is_lineage_gap(&self) -> bool {
+        self.disposition_kind
+            == IntegrationMeshProtocolSubstratePreflightRepairSlotExecutionEvidenceReviewDispositionKind::LineageGap
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IntegrationMeshProtocolSubstratePreflightRepairSlotExecutionEvidenceReviewDispositionSummary
+{
+    pub total_dispositions: usize,
+    pub scheduled_actions: usize,
+    pub blocking_dispositions: usize,
+    pub operator_handoff_dispositions: usize,
+    pub repair_required_dispositions: usize,
+    pub lineage_gap_dispositions: usize,
+    pub review_required_dispositions: usize,
+    pub execution_ready_dispositions: usize,
+    pub lineage_complete_dispositions: usize,
+    pub protocol_mentions: usize,
+    pub primitive_mentions: usize,
+    pub first_disposition_key: Option<String>,
+    pub first_operator_handoff_disposition_key: Option<String>,
+    pub first_repair_required_disposition_key: Option<String>,
+    pub first_lineage_gap_disposition_key: Option<String>,
+    pub first_review_key: Option<String>,
+    pub first_evidence_key: Option<String>,
+    pub first_work_order_key: Option<String>,
+    pub first_ticket_key: Option<String>,
+    pub first_stage: Option<IntegrationMeshProtocolSubstrateStage>,
+    pub first_action_kind: Option<IntegrationMeshProtocolSubstratePreflightActionKind>,
+    pub execution_evidence_review_dispositions_ready: bool,
+}
+
+impl IntegrationMeshProtocolSubstratePreflightRepairSlotExecutionEvidenceReviewDispositionSummary {
+    pub fn from_dispositions<'a>(
+        dispositions: impl IntoIterator<
+            Item = &'a IntegrationMeshProtocolSubstratePreflightRepairSlotExecutionEvidenceReviewDisposition,
+        >,
+    ) -> Self {
+        let dispositions = dispositions.into_iter().collect::<Vec<_>>();
+        let first_disposition = dispositions
+            .iter()
+            .min_by_key(|disposition| disposition.sequence);
+        let first_operator_handoff_disposition = dispositions
+            .iter()
+            .filter(|disposition| disposition.is_operator_handoff())
+            .min_by_key(|disposition| disposition.sequence);
+        let first_repair_required_disposition = dispositions
+            .iter()
+            .filter(|disposition| disposition.is_repair_required())
+            .min_by_key(|disposition| disposition.sequence);
+        let first_lineage_gap_disposition = dispositions
+            .iter()
+            .filter(|disposition| disposition.is_lineage_gap())
+            .min_by_key(|disposition| disposition.sequence);
+
+        Self {
+            total_dispositions: dispositions.len(),
+            scheduled_actions: dispositions
+                .iter()
+                .map(|disposition| disposition.action_count)
+                .sum(),
+            blocking_dispositions: dispositions
+                .iter()
+                .filter(|disposition| disposition.blocks_preflight())
+                .count(),
+            operator_handoff_dispositions: dispositions
+                .iter()
+                .filter(|disposition| disposition.is_operator_handoff())
+                .count(),
+            repair_required_dispositions: dispositions
+                .iter()
+                .filter(|disposition| disposition.is_repair_required())
+                .count(),
+            lineage_gap_dispositions: dispositions
+                .iter()
+                .filter(|disposition| disposition.is_lineage_gap())
+                .count(),
+            review_required_dispositions: dispositions
+                .iter()
+                .filter(|disposition| disposition.needs_review())
+                .count(),
+            execution_ready_dispositions: dispositions
+                .iter()
+                .filter(|disposition| disposition.is_ready_for_execution())
+                .count(),
+            lineage_complete_dispositions: dispositions
+                .iter()
+                .filter(|disposition| disposition.has_lineage())
+                .count(),
+            protocol_mentions: dispositions
+                .iter()
+                .map(|disposition| disposition.protocol_count)
+                .sum(),
+            primitive_mentions: dispositions
+                .iter()
+                .map(|disposition| disposition.primitive_count)
+                .sum(),
+            first_disposition_key: first_disposition
+                .map(|disposition| disposition.disposition_key.clone()),
+            first_operator_handoff_disposition_key: first_operator_handoff_disposition
+                .map(|disposition| disposition.disposition_key.clone()),
+            first_repair_required_disposition_key: first_repair_required_disposition
+                .map(|disposition| disposition.disposition_key.clone()),
+            first_lineage_gap_disposition_key: first_lineage_gap_disposition
+                .map(|disposition| disposition.disposition_key.clone()),
+            first_review_key: first_disposition.map(|disposition| disposition.review_key.clone()),
+            first_evidence_key: first_disposition
+                .map(|disposition| disposition.evidence_key.clone()),
+            first_work_order_key: first_disposition
+                .map(|disposition| disposition.work_order_key.clone()),
+            first_ticket_key: first_disposition.map(|disposition| disposition.ticket_key.clone()),
+            first_stage: first_disposition.map(|disposition| disposition.stage),
+            first_action_kind: first_disposition.map(|disposition| disposition.action_kind),
+            execution_evidence_review_dispositions_ready: dispositions.is_empty(),
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.total_dispositions == 0
+    }
+
+    pub fn has_dispositions(&self) -> bool {
+        self.total_dispositions > 0
+    }
+
+    pub fn has_blockers(&self) -> bool {
+        self.blocking_dispositions > 0
+    }
+
+    pub fn needs_operator(&self) -> bool {
+        self.operator_handoff_dispositions > 0
+    }
+
+    pub fn needs_repair(&self) -> bool {
+        self.repair_required_dispositions > 0
+    }
+
+    pub fn needs_review(&self) -> bool {
+        self.review_required_dispositions > 0
+    }
+
+    pub fn has_lineage_gaps(&self) -> bool {
+        self.lineage_gap_dispositions > 0
+    }
+
+    pub fn has_complete_lineage(&self) -> bool {
+        self.lineage_complete_dispositions == self.total_dispositions
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct IntegrationMeshProtocolPrimitiveReadinessRow {
     pub protocol: ProtocolFamily,
@@ -23520,6 +23800,33 @@ pub fn mesh_protocol_substrate_preflight_repair_slot_execution_evidence_review_s
     )
 }
 
+pub fn mesh_protocol_substrate_preflight_repair_slot_execution_evidence_review_dispositions(
+    available_primitives: &[PrimitiveFamily],
+) -> Vec<IntegrationMeshProtocolSubstratePreflightRepairSlotExecutionEvidenceReviewDisposition> {
+    mesh_protocol_substrate_preflight_repair_slot_execution_evidence_reviews(available_primitives)
+        .iter()
+        .enumerate()
+        .map(|(index, review)| {
+            IntegrationMeshProtocolSubstratePreflightRepairSlotExecutionEvidenceReviewDisposition::from_review(
+                index + 1,
+                review,
+            )
+        })
+        .collect()
+}
+
+pub fn mesh_protocol_substrate_preflight_repair_slot_execution_evidence_review_disposition_summary(
+    available_primitives: &[PrimitiveFamily],
+) -> IntegrationMeshProtocolSubstratePreflightRepairSlotExecutionEvidenceReviewDispositionSummary {
+    let dispositions =
+        mesh_protocol_substrate_preflight_repair_slot_execution_evidence_review_dispositions(
+            available_primitives,
+        );
+    IntegrationMeshProtocolSubstratePreflightRepairSlotExecutionEvidenceReviewDispositionSummary::from_dispositions(
+        dispositions.iter(),
+    )
+}
+
 pub fn mesh_readiness_package_summary_for_catalog(
     catalog: &[IntegrationCatalogEntry],
     available_primitives: &[PrimitiveFamily],
@@ -31337,6 +31644,152 @@ mod tests {
         assert!(!summary.has_blockers());
         assert!(!summary.needs_operator());
         assert!(!summary.needs_review());
+        assert!(summary.has_complete_lineage());
+    }
+
+    #[test]
+    fn mesh_protocol_substrate_preflight_repair_slot_execution_evidence_review_dispositions_classify_work(
+    ) {
+        let available_primitives = vec![
+            PrimitiveFamily::Usb,
+            PrimitiveFamily::SerialController,
+            PrimitiveFamily::Radio802154,
+            PrimitiveFamily::Supervision,
+        ];
+        let dispositions =
+            mesh_protocol_substrate_preflight_repair_slot_execution_evidence_review_dispositions(
+                &available_primitives,
+            );
+        let summary =
+            IntegrationMeshProtocolSubstratePreflightRepairSlotExecutionEvidenceReviewDispositionSummary::from_dispositions(
+                dispositions.iter(),
+            );
+
+        assert_eq!(dispositions.len(), 3);
+        assert_eq!(summary.total_dispositions, 3);
+        assert_eq!(summary.scheduled_actions, 5);
+        assert_eq!(summary.blocking_dispositions, 3);
+        assert_eq!(summary.operator_handoff_dispositions, 2);
+        assert_eq!(summary.repair_required_dispositions, 1);
+        assert_eq!(summary.lineage_gap_dispositions, 0);
+        assert_eq!(summary.review_required_dispositions, 3);
+        assert_eq!(summary.execution_ready_dispositions, 0);
+        assert_eq!(summary.lineage_complete_dispositions, 3);
+        assert_eq!(summary.protocol_mentions, 5);
+        assert_eq!(summary.primitive_mentions, 3);
+        assert_eq!(
+            summary.first_disposition_key,
+            Some("disposition-01-radio-provision_radio".to_string())
+        );
+        assert_eq!(
+            summary.first_operator_handoff_disposition_key,
+            Some("disposition-01-radio-provision_radio".to_string())
+        );
+        assert_eq!(summary.first_lineage_gap_disposition_key, None);
+        assert_eq!(
+            summary.first_review_key,
+            Some("review-01-radio-provision_radio".to_string())
+        );
+        assert_eq!(
+            summary.first_evidence_key,
+            Some("evidence-01-radio-provision_radio".to_string())
+        );
+        assert_eq!(
+            summary.first_work_order_key,
+            Some("work-01-radio-provision_radio".to_string())
+        );
+        assert_eq!(
+            summary.first_ticket_key,
+            Some("slot-01-radio-provision_radio".to_string())
+        );
+        assert_eq!(
+            summary.first_stage,
+            Some(IntegrationMeshProtocolSubstrateStage::Radio)
+        );
+        assert_eq!(
+            summary.first_action_kind,
+            Some(IntegrationMeshProtocolSubstratePreflightActionKind::ProvisionRadio)
+        );
+        assert!(!summary.execution_evidence_review_dispositions_ready);
+        assert!(summary.has_dispositions());
+        assert!(summary.has_blockers());
+        assert!(summary.needs_operator());
+        assert!(summary.needs_repair());
+        assert!(summary.needs_review());
+        assert!(!summary.has_lineage_gaps());
+        assert!(summary.has_complete_lineage());
+
+        let first = &dispositions[0];
+        assert_eq!(first.sequence, 1);
+        assert_eq!(
+            first.disposition_key,
+            "disposition-01-radio-provision_radio"
+        );
+        assert_eq!(first.review_sequence, 1);
+        assert_eq!(first.review_key, "review-01-radio-provision_radio");
+        assert_eq!(first.evidence_sequence, 1);
+        assert_eq!(first.evidence_key, "evidence-01-radio-provision_radio");
+        assert_eq!(first.work_order_sequence, 1);
+        assert_eq!(first.work_order_key, "work-01-radio-provision_radio");
+        assert_eq!(first.ticket_sequence, 1);
+        assert_eq!(first.ticket_key, "slot-01-radio-provision_radio");
+        assert_eq!(
+            first.disposition_kind,
+            IntegrationMeshProtocolSubstratePreflightRepairSlotExecutionEvidenceReviewDispositionKind::OperatorHandoff
+        );
+        assert_eq!(first.disposition_kind.as_str(), "operator_handoff");
+        assert!(first.blocks_preflight());
+        assert!(first.requires_operator());
+        assert!(first.has_lineage());
+        assert!(first.needs_review());
+        assert!(first.is_operator_handoff());
+        assert!(!first.is_repair_required());
+        assert!(!first.is_lineage_gap());
+        assert!(!first.is_ready_for_execution());
+    }
+
+    #[test]
+    fn mesh_protocol_substrate_preflight_repair_slot_execution_evidence_review_dispositions_empty_when_ready(
+    ) {
+        let dispositions =
+            mesh_protocol_substrate_preflight_repair_slot_execution_evidence_review_dispositions(
+                all_primitive_families(),
+            );
+        let summary =
+            mesh_protocol_substrate_preflight_repair_slot_execution_evidence_review_disposition_summary(
+                all_primitive_families(),
+            );
+
+        assert!(dispositions.is_empty());
+        assert_eq!(summary.total_dispositions, 0);
+        assert_eq!(summary.scheduled_actions, 0);
+        assert_eq!(summary.blocking_dispositions, 0);
+        assert_eq!(summary.operator_handoff_dispositions, 0);
+        assert_eq!(summary.repair_required_dispositions, 0);
+        assert_eq!(summary.lineage_gap_dispositions, 0);
+        assert_eq!(summary.review_required_dispositions, 0);
+        assert_eq!(summary.execution_ready_dispositions, 0);
+        assert_eq!(summary.lineage_complete_dispositions, 0);
+        assert_eq!(summary.protocol_mentions, 0);
+        assert_eq!(summary.primitive_mentions, 0);
+        assert_eq!(summary.first_disposition_key, None);
+        assert_eq!(summary.first_operator_handoff_disposition_key, None);
+        assert_eq!(summary.first_repair_required_disposition_key, None);
+        assert_eq!(summary.first_lineage_gap_disposition_key, None);
+        assert_eq!(summary.first_review_key, None);
+        assert_eq!(summary.first_evidence_key, None);
+        assert_eq!(summary.first_work_order_key, None);
+        assert_eq!(summary.first_ticket_key, None);
+        assert_eq!(summary.first_stage, None);
+        assert_eq!(summary.first_action_kind, None);
+        assert!(summary.execution_evidence_review_dispositions_ready);
+        assert!(summary.is_empty());
+        assert!(!summary.has_dispositions());
+        assert!(!summary.has_blockers());
+        assert!(!summary.needs_operator());
+        assert!(!summary.needs_repair());
+        assert!(!summary.needs_review());
+        assert!(!summary.has_lineage_gaps());
         assert!(summary.has_complete_lineage());
     }
 


### PR DESCRIPTION
## Summary
- add catalog-level mesh execution evidence review disposition records and summary rollups
- expose read-only smart-home tool descriptors for listing dispositions and reading their summary
- project the new disposition tools through the Chief D18D bridge without moving platform logic into Chief

## Validation
- cargo test -p smart-home-core
- cargo test -p smart-home-integration-catalog
- cargo test -p hue-core
- cargo test -p smart-home-runtime
- cargo test -p smart-home-testkit
- cargo test -p smart-home-local-http
- cargo test -p smart-home-discovery
- cargo test -p chief-of-staff-smart-home-tools
- cargo test -p smart-home-runtime discover_tool -- --nocapture
- sh BUILD in smart-home-core, smart-home-integration-catalog, hue-core, smart-home-runtime, smart-home-testkit, smart-home-local-http, smart-home-discovery, chief-of-staff-smart-home-tools