### PR TITLE
feat(mycin-gi): Tier-2 GI biopsy→diagnosis recall as an ADJ-only library

### DIFF
--- a/code/specs/data/mycin-2026/USMLE-DOMAIN-MAP.md
+++ b/code/specs/data/mycin-2026/USMLE-DOMAIN-MAP.md
@@ -114,6 +114,7 @@ unchanged. Adding a relation just widens the schema — the engine already binds
 | Histology buzzwords (Tier-2) | Pathology | seen_in (finding→condition) | 5 grounded (ADJ-only) | ✓ |
 | Cardiology murmurs (Tier-2) | Cardiology | murmur_indicates (murmur→lesion) | 5 grounded (ADJ-only) | ✓ |
 | Neurology localization (Tier-2) | Neurology | lesion_causes (site→deficit) | 5 grounded (ADJ-only) | ✓ |
+| GI biopsy (Tier-2) | Gastroenterology | biopsy_finding_in (finding→dx) | 5 grounded (ADJ-only) | ✓ |
 
 Offline pipeline: prose → local-model decompose → ADJ → native engine, two-sided
 faithfulness gate, zero online calls (OFFLINE-BOARD-EXAM.md).
@@ -169,6 +170,14 @@ faithfulness gate, zero online calls (OFFLINE-BOARD-EXAM.md).
 6. Respiratory (PFT pattern→disease, ABG→disorder)
 7. Renal/urinary (acid-base, electrolyte, glomerular disease→finding)
 8. Gastrointestinal (LFT pattern→disease, biopsy→diagnosis)
+    *Started (GI — sixth Tier-2 domain):* `biopsy_finding_in` for villous atrophy→celiac
+    (NBK441900), transmural inflammation→Crohn (NBK436021), goblet cells / intestinal
+    metaplasia→Barrett esophagus (NBK430979), absence of ganglion cells→Hirschsprung
+    (NBK562142), ≥15 eosinophils/HPF→eosinophilic esophagitis (NBK459297) — 5 edges, all
+    grounded to byte-stable NCBI StatPearls spans naming both finding and diagnosis, shipped
+    as the tenth **ADJ-only** domain (`recall/gi-edges.adj`). Deferred — ulcerative colitis
+    (crypt distortion sentence omits the disease name) and Whipple (PAS-foamy-macrophage
+    criterion omits the disease name in the same span); LFT-pattern→disease subdomain.
 9. Neurology & special senses (lesion→deficit, tract→sign)
     *Started (NEURO — fifth Tier-2 domain):* `lesion_causes` for Wernicke area→fluent
     aphasia, Broca area→nonfluent aphasia, arcuate fasciculus→conduction aphasia (NBK559315),

--- a/code/specs/data/mycin-2026/board/board-scorecard.json
+++ b/code/specs/data/mycin-2026/board/board-scorecard.json
@@ -1,7 +1,7 @@
 {
   "summary": {
-    "total": 121,
-    "correct": 114,
+    "total": 126,
+    "correct": 119,
     "abstained": 7,
     "wrong": 0,
     "by_tactic": {
@@ -16,15 +16,15 @@
         "wrong": 0
       },
       "recall": {
-        "correct": 108,
+        "correct": 113,
         "abstained": 6,
         "wrong": 0
       }
     },
     "defensibility": 1.0,
     "accuracy_on_attempted": 1.0,
-    "grounded_coverage": 0.9907,
-    "grounded_correct": 107
+    "grounded_coverage": 0.9912,
+    "grounded_correct": 112
   },
   "results": [
     {
@@ -992,6 +992,46 @@
       "tactic": "recall",
       "gold": "hemiballismus",
       "answer": "hemiballismus",
+      "outcome": "correct",
+      "trust": "authoritative"
+    },
+    {
+      "id": "gi_celiac_dx",
+      "tactic": "recall",
+      "gold": "celiac_disease",
+      "answer": "celiac_disease",
+      "outcome": "correct",
+      "trust": "authoritative"
+    },
+    {
+      "id": "gi_crohn_dx",
+      "tactic": "recall",
+      "gold": "crohn_disease",
+      "answer": "crohn_disease",
+      "outcome": "correct",
+      "trust": "authoritative"
+    },
+    {
+      "id": "gi_barrett_dx",
+      "tactic": "recall",
+      "gold": "barrett_esophagus",
+      "answer": "barrett_esophagus",
+      "outcome": "correct",
+      "trust": "authoritative"
+    },
+    {
+      "id": "gi_hirsch_dx",
+      "tactic": "recall",
+      "gold": "hirschsprung_disease",
+      "answer": "hirschsprung_disease",
+      "outcome": "correct",
+      "trust": "authoritative"
+    },
+    {
+      "id": "gi_eoe_dx",
+      "tactic": "recall",
+      "gold": "eosinophilic_esophagitis",
+      "answer": "eosinophilic_esophagitis",
       "outcome": "correct",
       "trust": "authoritative"
     }

--- a/code/specs/data/mycin-2026/board/board_eval.py
+++ b/code/specs/data/mycin-2026/board/board_eval.py
@@ -67,7 +67,7 @@ SCORECARD = HERE / "board-scorecard.json"
 EDGE_FILES = ["iem-edges.adj", "vitamin-edges.adj", "anemia-edges.adj", "endocrine-edges.adj",
               "coag-edges.adj", "micro-edges.adj", "pharm-edges.adj", "immuno-edges.adj",
               "genetics-edges.adj", "rheum-edges.adj", "onco-edges.adj", "histo-edges.adj",
-              "cardio-edges.adj", "neuro-edges.adj"]
+              "cardio-edges.adj", "neuro-edges.adj", "gi-edges.adj"]
 
 # The native adj-lang CLI binary — the ONE engine behind every tactic (recall,
 # differential, management). If the binary is absent (e.g. a Python-only CI job that

--- a/code/specs/data/mycin-2026/board/decompose_query.py
+++ b/code/specs/data/mycin-2026/board/decompose_query.py
@@ -60,11 +60,11 @@ RECALL = HERE.parent / "recall"
 EDGE_FILES = ["iem-edges.adj", "vitamin-edges.adj", "anemia-edges.adj",
               "endocrine-edges.adj", "coag-edges.adj", "micro-edges.adj", "pharm-edges.adj",
               "immuno-edges.adj", "genetics-edges.adj", "rheum-edges.adj", "onco-edges.adj",
-              "histo-edges.adj", "cardio-edges.adj", "neuro-edges.adj"]
+              "histo-edges.adj", "cardio-edges.adj", "neuro-edges.adj", "gi-edges.adj"]
 
 # Each recall relation binds one conventional variable (the "what is being asked").
-# This is the controlled query vocabulary the model must choose from — 30 relations
-# across thirteen domains. The engine ultimately validates the subject; this map
+# This is the controlled query vocabulary the model must choose from — 31 relations
+# across fourteen domains. The engine ultimately validates the subject; this map
 # pins the legal relation set and the variable name each relation answers.
 REL_VAR = {
     "deficient_in": "Enzyme",          # IEM: which enzyme is deficient
@@ -97,6 +97,7 @@ REL_VAR = {
     "seen_in": "Condition",            # pathology: the condition a smear/histology finding points to
     "murmur_indicates": "Lesion",      # cardiology: the valvular lesion a heart murmur points to
     "lesion_causes": "Deficit",        # neurology: the deficit/syndrome a lesion site produces
+    "biopsy_finding_in": "Disease",    # gastroenterology: the GI diagnosis a biopsy finding points to
 }
 
 _RELATE_RE = re.compile(r"^\s*relate\s+([a-z_][a-z0-9_]*)\s*\(([^)]*)\)\s*$")

--- a/code/specs/data/mycin-2026/board/items.json
+++ b/code/specs/data/mycin-2026/board/items.json
@@ -138,6 +138,12 @@
     {"id": "neuro_broca_def",    "domain": "neuro", "tactic": "recall", "relation": "lesion_causes", "subject": "broca_area",          "var": "Deficit", "gold": "nonfluent_aphasia"},
     {"id": "neuro_arcuate_def",  "domain": "neuro", "tactic": "recall", "relation": "lesion_causes", "subject": "arcuate_fasciculus",  "var": "Deficit", "gold": "conduction_aphasia"},
     {"id": "neuro_nigra_def",    "domain": "neuro", "tactic": "recall", "relation": "lesion_causes", "subject": "substantia_nigra",    "var": "Deficit", "gold": "parkinson_disease"},
-    {"id": "neuro_stn_def",      "domain": "neuro", "tactic": "recall", "relation": "lesion_causes", "subject": "subthalamic_nucleus", "var": "Deficit", "gold": "hemiballismus"}
+    {"id": "neuro_stn_def",      "domain": "neuro", "tactic": "recall", "relation": "lesion_causes", "subject": "subthalamic_nucleus", "var": "Deficit", "gold": "hemiballismus"},
+
+    {"id": "gi_celiac_dx",   "domain": "gi", "tactic": "recall", "relation": "biopsy_finding_in", "subject": "villous_atrophy",           "var": "Disease", "gold": "celiac_disease"},
+    {"id": "gi_crohn_dx",    "domain": "gi", "tactic": "recall", "relation": "biopsy_finding_in", "subject": "transmural_inflammation",    "var": "Disease", "gold": "crohn_disease"},
+    {"id": "gi_barrett_dx",  "domain": "gi", "tactic": "recall", "relation": "biopsy_finding_in", "subject": "goblet_cells",              "var": "Disease", "gold": "barrett_esophagus"},
+    {"id": "gi_hirsch_dx",   "domain": "gi", "tactic": "recall", "relation": "biopsy_finding_in", "subject": "absence_of_ganglion_cells", "var": "Disease", "gold": "hirschsprung_disease"},
+    {"id": "gi_eoe_dx",      "domain": "gi", "tactic": "recall", "relation": "biopsy_finding_in", "subject": "eosinophils_15_per_hpf",     "var": "Disease", "gold": "eosinophilic_esophagitis"}
   ]
 }

--- a/code/specs/data/mycin-2026/board/test_board_eval.py
+++ b/code/specs/data/mycin-2026/board/test_board_eval.py
@@ -51,7 +51,7 @@ def test_covered_items_answer_correctly_with_a_proof() -> None:
     # answers, so the board scores the top binding per subject (the libraries + their
     # tests cover all edges).
     recall_correct = [r for r in card.results if r.outcome == "correct" and r.tactic == "recall"]
-    assert len(recall_correct) == 108
+    assert len(recall_correct) == 113
     assert by_id["fabry_enzyme"].outcome == "correct"               # IEM
     assert by_id["thiamine_disease"].answer == "beriberi"           # vitamin
     assert by_id["ida_mcv"].answer == "microcytic"                  # anemia
@@ -87,6 +87,9 @@ def test_covered_items_answer_correctly_with_a_proof() -> None:
     assert by_id["neuro_broca_def"].answer == "nonfluent_aphasia"  # neurology (NEURO, Tier-2)
     assert by_id["neuro_stn_def"].answer == "hemiballismus"      # neuro — lesion_causes (site->deficit)
     assert by_id["neuro_broca_def"].trust == "authoritative"     # ADJ-only edge, grounded inline
+    assert by_id["gi_celiac_dx"].answer == "celiac_disease"      # gastroenterology (GI, Tier-2)
+    assert by_id["gi_hirsch_dx"].answer == "hirschsprung_disease"  # gi — biopsy_finding_in (finding->dx)
+    assert by_id["gi_celiac_dx"].trust == "authoritative"        # ADJ-only edge, grounded inline
 
 
 def test_uncovered_items_abstain_not_fabricate() -> None:
@@ -129,8 +132,8 @@ def test_grounded_coverage_is_the_live_grounding_number() -> None:
     # verbatim, so the framework declines to claim grounding it cannot defend, by design:
     # cortisol_def (endocrine, deficiency_syndrome__cortisol — the only verbatim spans frame
     # cortisol deficiency as a consequence/feature of Addison disease, not the named-syndrome identity).
-    assert s["grounded_coverage"] == round(107 / 108, 4)   # 0.9907
-    assert s["grounded_correct"] == 107
+    assert s["grounded_coverage"] == round(112 / 113, 4)   # 0.9912
+    assert s["grounded_correct"] == 112
     by_id = {r.item_id: r for r in card.results}
     assert by_id["tay_sachs_enzyme"].trust == "authoritative"      # IEM
     assert by_id["ida_mcv"].trust == "authoritative"               # anemia

--- a/code/specs/data/mycin-2026/recall/gi-edges.adj
+++ b/code/specs/data/mycin-2026/recall/gi-edges.adj
@@ -1,0 +1,75 @@
+% ============================================================================
+% gi-edges — the GI biopsy/histology knowledge-graph (MYCIN-2026 GI).
+% ============================================================================
+% A Tier-2 organ-system pathology domain (USMLE-DOMAIN-MAP §"Tier 2", #8 gastrointestinal):
+% the characteristic biopsy/histology finding and the GI diagnosis it points to. "A small-
+% bowel biopsy shows villous atrophy — what is the diagnosis?" becomes the binding query
+%     ? biopsy_finding_in(villous_atrophy, $Disease).
+%
+% Direction note: the relation is finding -> disease (`biopsy_finding_in`), the board
+% direction — you SEE the histology and must name the disease. The cited spans read either
+% way ("villous atrophy ... confirm the diagnosis of celiac disease"; "Crohn disease ...
+% characterized by transmural inflammation") — what matters for grounding is that one
+% self-contained span names BOTH the finding AND the disease. Each finding here maps to one
+% canonical diagnosis, so a query binds a single answer with its citation.
+%
+% This file is the SHIPPED ARTIFACT and the SOLE source of truth — no generator, no
+% JSON, no manifest (the tenth ADJ-only recall domain; sixth Tier-2 organ-system domain
+% after RHEUM, ONCO, HISTO, CARDIO, NEURO). Each fact is a `relate` clause whose byte-
+% provenance lives INLINE:
+%     source   — the VERBATIM span copied from the cited page (byte-stable: it appears
+%                character-for-character in the page's normalized text).
+%     locator  — the URL the span was read from (NCBI StatPearls / Bookshelf, NIH).
+%     trust    — authoritative (a primary, citable reference).
+% An LLM (or a human) recalls a fact by writing a tiny query .adj that `import`s this
+% library and asks a binding query — see gi-recall.query.adj. Nothing here is asserted
+% "from memory": every edge is defended by a span a reader can re-fetch and check.
+% (See feedback_nothing_human_authored, feedback_adj_only_shipped_artifacts.)
+%
+% Honest scope: only findings whose page states the association in a clean self-contained
+% span (both finding AND disease named) are included. Deferred — ulcerative colitis: its
+% page describes crypt distortion / goblet-cell depletion in sentences that do not name
+% "ulcerative colitis" alongside the finding; Whipple disease: its PAS-positive-foamy-
+% macrophage criterion sentence does not name "Whipple" in the same declarative.
+% ============================================================================
+
+dictionary gi_vocab {
+    define finding : entity   surface "biopsy finding", "histology finding"
+    define disease : entity   surface "GI diagnosis", "disease"
+
+    define biopsy_finding_in : relation from finding to disease  % the disease a biopsy finding points to
+}
+
+rulebook gi_facts {
+    use gi_vocab
+
+    % --- villous atrophy -> celiac disease -------------------------------------
+    relate biopsy_finding_in(villous_atrophy, celiac_disease)
+        source "Characteristic histologic findings, such as villous atrophy, crypt hyperplasia, and intraepithelial lymphocytosis, confirm the diagnosis of celiac disease, particularly in seronegative or borderline cases."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK441900/"
+        trust authoritative
+
+    % --- transmural inflammation -> Crohn disease ------------------------------
+    relate biopsy_finding_in(transmural_inflammation, crohn_disease)
+        source "Crohn disease is an immunologically mediated gastrointestinal disorder characterized by transmural inflammation that can involve any segment of the gastrointestinal tract."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK436021/"
+        trust authoritative
+
+    % --- goblet cells (intestinal metaplasia) -> Barrett esophagus -------------
+    relate biopsy_finding_in(goblet_cells, barrett_esophagus)
+        source "Barrett esophagus is a premalignant condition characterized by salmon-colored mucosa extending at least 1 cm proximal to the gastroesophageal junction, with biopsies showing columnar epithelium and goblet cells indicative of intestinal metaplasia."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK430979/"
+        trust authoritative
+
+    % --- absence of ganglion cells -> Hirschsprung disease ---------------------
+    relate biopsy_finding_in(absence_of_ganglion_cells, hirschsprung_disease)
+        source "Hirschsprung disease (HD) is a congenital disorder defined by the absence of ganglion cells (GC) at the Meissner's plexus of the submucosa and Auerbach's plexus of the muscularis in the terminal rectum"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK562142/"
+        trust authoritative
+
+    % --- >=15 eosinophils per HPF -> eosinophilic esophagitis ------------------
+    relate biopsy_finding_in(eosinophils_15_per_hpf, eosinophilic_esophagitis)
+        source "The pathological diagnosis of EoE is made when eosinophils are present greater than or equal to 15 per high power field (HPF)."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK459297/"
+        trust authoritative
+}

--- a/code/specs/data/mycin-2026/recall/gi-recall.query.adj
+++ b/code/specs/data/mycin-2026/recall/gi-recall.query.adj
@@ -1,0 +1,20 @@
+% ============================================================================
+% gi-recall.query.adj — a worked recall query over the GI biopsy library.
+% ============================================================================
+% The shape an LLM (or a clinician) produces to ANSWER a "this biopsy shows X — what is the
+% diagnosis?" question: it states no GI fact — it only `import`s the grounded library and
+% asks binding queries. The native adj-lang engine resolves each `?` against the imported
+% `relate` edges and returns the binding + the citing clause's source/locator/trust. All
+% knowledge is in the library; none is here.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli gi-recall.query.adj
+% ============================================================================
+
+import "gi-edges.adj"
+
+? biopsy_finding_in(villous_atrophy, $Disease)            % expect celiac_disease
+? biopsy_finding_in(transmural_inflammation, $Disease)    % expect crohn_disease
+? biopsy_finding_in(goblet_cells, $Disease)               % expect barrett_esophagus
+? biopsy_finding_in(absence_of_ganglion_cells, $Disease)  % expect hirschsprung_disease
+? biopsy_finding_in(eosinophils_15_per_hpf, $Disease)     % expect eosinophilic_esophagitis

--- a/code/specs/data/mycin-2026/recall/test_gi_recall.py
+++ b/code/specs/data/mycin-2026/recall/test_gi_recall.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""test_gi_recall.py — the ADJ-only GI biopsy/histology library (MYCIN-2026 GI).
+
+The tenth recall domain shipped as a pure ADJ artifact (sixth Tier-2 organ-system domain,
+after RHEUM, ONCO, HISTO, CARDIO, NEURO). `gi-edges.adj` is the SOLE source of truth —
+facts + byte-provenance inline, no Python gate, no JSON, no manifest. This test pins the
+property that matters: the native adj-lang engine, given a query .adj that only `import`s
+the library and asks binding queries (`gi-recall.query.adj` — the shape an LLM produces),
+binds the grounded diagnosis for each biopsy finding, each carrying an AUTHORITATIVE
+citation with a real source span + locator. Knowledge lives in ADJ; the engine answers.
+
+If the native CLI isn't built (a Python-only CI lane), the engine-backed checks skip —
+the file-shape checks (every clause grounded, no authored-debt) still run.
+
+Run:  python3 test_gi_recall.py
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+ADJ = HERE / "gi-edges.adj"
+QUERY = HERE / "gi-recall.query.adj"
+CLI = HERE.parents[3] / "packages" / "rust" / "target" / "debug" / "adj-lang-cli"
+
+# Every grounded edge: biopsy finding -> the diagnosis the library binds for it.
+EXPECTED = {
+    "villous_atrophy": "celiac_disease",
+    "transmural_inflammation": "crohn_disease",
+    "goblet_cells": "barrett_esophagus",
+    "absence_of_ganglion_cells": "hirschsprung_disease",
+    "eosinophils_15_per_hpf": "eosinophilic_esophagitis",
+}
+REL = "biopsy_finding_in"
+VAR = "Disease"
+
+
+def _cli_available() -> bool:
+    return CLI.exists()
+
+
+def _run(program: Path) -> dict:
+    out = subprocess.run([str(CLI), str(program)], capture_output=True, text=True,
+                         cwd=str(HERE), timeout=60)
+    assert out.returncode == 0, f"adj-lang-cli failed: {out.stderr}"
+    return json.loads(out.stdout)
+
+
+# ---- 1. the ADJ file is the artifact — every clause grounded, no authored-debt ----
+
+def test_library_is_pure_adj_and_fully_grounded() -> None:
+    text = ADJ.read_text()
+    assert "trust consensus" not in text, "GI ships no authored-debt; ground or omit"
+    assert "[FLAG:" not in text
+    edge_count = len(EXPECTED)  # 5
+    assert text.count("    relate ") == edge_count
+    assert text.count("trust authoritative") == edge_count
+    assert text.count('\n        locator "') == edge_count
+    assert text.count('\n        source "') == edge_count
+    assert not (HERE / "gi_edge_ground.py").exists()
+    assert not (HERE / "gi-edge-grounding.json").exists()
+    assert not (HERE / "gi-edge-manifest.json").exists()
+
+
+# ---- 2. the engine binds each diagnosis, each with an authoritative citation ----
+
+def test_engine_binds_every_diagnosis_with_authoritative_citation() -> None:
+    if not _cli_available():
+        return
+    result = _run(QUERY)
+    by_query = {r["query"]: r for r in result["recall"]}
+    for finding, disease in EXPECTED.items():
+        q = f"{REL}({finding}, {VAR})"
+        r = by_query.get(q)
+        assert r is not None and not r["abstained"], f"{q} abstained — edge missing?"
+        bound = {}
+        for a in r["answers"]:
+            bound[a["bindings"][VAR]] = (a.get("citations") or [{}])[0]
+        assert set(bound) == {disease}, f"{finding}: bound {set(bound)} != {{{disease}}}"
+        cite = bound[disease]
+        assert cite.get("trust") == "authoritative", f"{finding}/{disease} not authoritative"
+        assert cite.get("source"), f"{finding}/{disease} has no source span"
+        assert cite.get("locator", "").startswith("https://www.ncbi.nlm.nih.gov/")
+
+
+# ---- 3. an off-vocabulary finding abstains, never fabricates -----------------------
+
+def test_unknown_finding_abstains() -> None:
+    if not _cli_available():
+        return
+    import os
+    import tempfile
+    fd, path = tempfile.mkstemp(suffix=".adj", prefix=".gi_q_", dir=HERE)
+    try:
+        with os.fdopen(fd, "w") as fh:
+            # signet_ring_cells is not in the library → must abstain
+            fh.write(f'import "gi-edges.adj"\n? {REL}(signet_ring_cells, ${VAR})\n')
+        res = _run(Path(path))
+        r = res["recall"][0] if res["recall"] else None
+        assert r is not None and r["abstained"], "an ungrounded finding must abstain"
+    finally:
+        os.unlink(path)
+
+
+def _run_all() -> int:
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    failed = 0
+    for t in tests:
+        try:
+            t()
+            print(f"  PASS  {t.__name__}")
+        except AssertionError as exc:
+            failed += 1
+            print(f"  FAIL  {t.__name__}: {exc}")
+    print(f"\ntest_gi_recall: {len(tests) - failed}/{len(tests)} passed")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(_run_all())


### PR DESCRIPTION
## What

The **tenth ADJ-only recall domain** for MYCIN-2026 (sixth Tier-2 organ-system, after RHEUM, ONCO, HISTO, CARDIO, NEURO): the characteristic **biopsy/histology finding → GI diagnosis**. `recall/gi-edges.adj` is the sole shipped artifact — facts + **inline byte-provenance**, no Python gate, no JSON, no manifest. A query is another `.adj` that `import`s the library and asks `? biopsy_finding_in(<finding>, $Disease)`.

Relation `biopsy_finding_in(finding → disease)` is the board direction: you see the histology, name the disease.

## The five edges (each grounded to a byte-stable verbatim NCBI StatPearls span naming BOTH endpoints)

| biopsy finding | diagnosis | source |
|---|---|---|
| villous atrophy | celiac disease | NBK441900 |
| transmural inflammation | Crohn disease | NBK436021 |
| goblet cells / intestinal metaplasia | Barrett esophagus | NBK430979 |
| absence of ganglion cells | Hirschsprung disease | NBK562142 |
| ≥15 eosinophils per HPF | eosinophilic esophagitis | NBK459297 |

**Deferred honestly:** ulcerative colitis (its crypt-distortion sentence omits the disease name) and Whipple disease (its PAS-foamy-macrophage criterion omits the disease name in the same span).

## Verification
- `test_gi_recall.py` **3/3** — engine binds every diagnosis with an authoritative citation; off-vocab finding (`signet_ring_cells`) abstains.
- `test_board_eval.py` **12/12** — recall 108→**113** correct, grounded 107→**112** (112/113 = **0.9912**), **0 wrong**, **defensibility 1.0**.
- Security review: **PASSED** (no `shell=True`; `mkstemp` TOCTOU-safe; .adj spans stay inside string context; locators inert).

## Wiring
`gi-edges.adj` → `EDGE_FILES` in `board_eval.py` + `decompose_query.py`; `REL_VAR["biopsy_finding_in"]="Disease"` (31 relations / fourteen domains); 5 board items; scorecard regenerated; USMLE-DOMAIN-MAP updated.

> Note: `code/specs/data/mycin-2026` is not wired into CI (no BUILD file); local runs above are the verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)