### PR TITLE
fix(closure-pass-inline): decline helpers that reassign a parameter (soundness)

### DIFF
--- a/code/packages/rust/closure-pass-inline/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-inline/CHANGELOG.md
@@ -2,6 +2,36 @@
 
 All notable changes to the `coding-adventures-closure-pass-inline` crate will be documented in this file.
 
+## [0.13.1] - 2026-06-19
+
+### Fixed (soundness) — decline helpers that reassign a parameter
+
+A helper that **reassigns one of its parameters** (`function f(x){ x = x + 1;
+return x; }`) was being inlined, producing a **miscompile**: inlining
+substitutes each parameter occurrence with its *argument expression*, treating
+the parameter as an immutable value, so `var g = f(7)` became `var g = 7`
+(plus a stray global write `x = 8`) instead of the correct `var g = 8`. The
+same broke in `return`/assignment capture positions.
+
+This was a latent hazard that only became **reachable** once assignment-
+expression statements parsed (the CLOC17 grammar fix, `javascript-parser`
+0.9.0) — before that, any helper body containing `x = …` made the whole
+program fall back to whitespace-only, so the inliner never saw it.
+
+The candidate filter now declines any helper whose body assigns to a parameter
+(`x = …`, `x += …`, or nested forms like `y = (x = 5)` / `f(x = 5)` — a new
+recursive `body_assigns_to_param` walk covers every expression position). A
+member-target whose *base* is a parameter (`x.k = 5`) is still admitted: it
+mutates a property of the argument, not the parameter binding, and is sound
+under substitution. (`++`/`--` parameter mutation is not reachable — the typed
+AST has no `UpdateExpression` yet.)
+
+Correctly inlining a mutated parameter would require materialising it into a
+fresh local seeded from the argument; that is left as a future slice.
+Declining is never a miscompile. Four new unit tests (three decline cases, one
+positive control proving a *free*-variable assignment still inlines). No
+closurec fixture churn.
+
 ## [0.13.0] - 2026-06-19
 
 ### Added (CLOC15 PR-6 — assignment-target value capture, `g = f(x)`)

--- a/code/packages/rust/closure-pass-inline/Cargo.toml
+++ b/code/packages/rust/closure-pass-inline/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-inline"
-version = "0.13.0"
+version = "0.13.1"
 edition = "2021"
 description = "Function-inlining pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Substitutes small or single-use function bodies at their call sites to enable downstream folding and shrink call overhead."
 

--- a/code/packages/rust/closure-pass-inline/src/lib.rs
+++ b/code/packages/rust/closure-pass-inline/src/lib.rs
@@ -1351,6 +1351,113 @@ fn collect_top_level_decl_names(program: &Program) -> HashSet<String> {
     out
 }
 
+/// Does any statement in `body` reassign one of `params`? Used to decline a
+/// candidate whose parameter is mutated — see the soundness note at the call
+/// site (parameter substitution assumes parameters are immutable). Walks every
+/// expression position, so a nested assignment (`y = (x = 5)`, `f(x = 5)`,
+/// `c ? (x = 5) : 0`) is caught too. Only `AssignmentTarget::Identifier`
+/// matters: a member-target whose *base* is a parameter (`x.k = 5`) mutates a
+/// property of the argument, not the parameter binding, and is sound under
+/// substitution.
+fn body_assigns_to_param(body: &[Statement], params: &HashSet<String>) -> bool {
+    body.iter().any(|s| stmt_assigns_to_param(s, params))
+}
+
+fn stmt_assigns_to_param(stmt: &Statement, params: &HashSet<String>) -> bool {
+    match stmt {
+        Statement::Declaration(Declaration::VariableDeclaration(vd)) => vd
+            .declarations
+            .iter()
+            .filter_map(|d| d.init.as_ref())
+            .any(|e| expr_assigns_to_param(e, params)),
+        Statement::Declaration(_) => false,
+        Statement::Tagged(t) => match t {
+            TaggedStatement::ExpressionStatement(es) => {
+                expr_assigns_to_param(&es.expression, params)
+            }
+            TaggedStatement::ReturnStatement(rs) => rs
+                .argument
+                .as_ref()
+                .is_some_and(|a| expr_assigns_to_param(a, params)),
+            TaggedStatement::IfStatement(is) => {
+                expr_assigns_to_param(&is.test, params)
+                    || stmt_assigns_to_param(&is.consequent, params)
+                    || is
+                        .alternate
+                        .as_ref()
+                        .is_some_and(|a| stmt_assigns_to_param(a, params))
+            }
+            TaggedStatement::BlockStatement(b) => body_assigns_to_param(&b.body, params),
+            TaggedStatement::ThrowStatement(ts) => expr_assigns_to_param(&ts.argument, params),
+            // The remaining forms never appear in an admitted candidate body
+            // (the shape filter rejects loops/switch/labeled/break/continue
+            // before this check). Treat them as non-mutating; if the shape
+            // filter ever widens, this must widen with it.
+            _ => false,
+        },
+    }
+}
+
+fn expr_assigns_to_param(expr: &Expression, params: &HashSet<String>) -> bool {
+    match expr {
+        Expression::AssignmentExpression(ae) => {
+            let target_is_param = matches!(
+                &ae.left,
+                AssignmentTarget::Identifier(id) if params.contains(&id.name)
+            );
+            target_is_param
+                || matches!(&ae.left,
+                    AssignmentTarget::MemberExpression(m) if expr_assigns_to_param(&m.object, params)
+                        || (m.computed && expr_assigns_to_param(&m.property, params)))
+                || expr_assigns_to_param(&ae.right, params)
+        }
+        Expression::BinaryExpression(be) => {
+            expr_assigns_to_param(&be.left, params) || expr_assigns_to_param(&be.right, params)
+        }
+        Expression::LogicalExpression(le) => {
+            expr_assigns_to_param(&le.left, params) || expr_assigns_to_param(&le.right, params)
+        }
+        Expression::UnaryExpression(ue) => expr_assigns_to_param(&ue.argument, params),
+        Expression::ConditionalExpression(ce) => {
+            expr_assigns_to_param(&ce.test, params)
+                || expr_assigns_to_param(&ce.consequent, params)
+                || expr_assigns_to_param(&ce.alternate, params)
+        }
+        Expression::CallExpression(ce) => {
+            expr_assigns_to_param(&ce.callee, params)
+                || ce.arguments.iter().any(|a| expr_assigns_to_param(a, params))
+        }
+        Expression::MemberExpression(m) => {
+            expr_assigns_to_param(&m.object, params)
+                || (m.computed && expr_assigns_to_param(&m.property, params))
+        }
+        // Array/object literals: recurse every contained expression. The typed
+        // AST has no spread element (`[...e]` / `{...e}` are Phase 2) and no
+        // function-expression variant, so a parameter assignment cannot hide in
+        // a spread argument or a getter/method body — `prop.value` is always a
+        // plain sub-expression, and an unrepresentable form makes the whole
+        // program bridge as unsupported (never reaching the inliner). If either
+        // becomes representable, add a recursion arm here.
+        Expression::ArrayExpression(ae) => ae
+            .elements
+            .iter()
+            .flatten()
+            .any(|el| expr_assigns_to_param(el, params)),
+        Expression::ObjectExpression(oe) => oe.properties.iter().any(|prop| {
+            (prop.computed
+                && matches!(&prop.key, PropertyKey::Expression(e) if expr_assigns_to_param(e, params)))
+                || expr_assigns_to_param(&prop.value, params)
+        }),
+        Expression::Identifier(_)
+        | Expression::NumericLiteral(_)
+        | Expression::StringLiteral(_)
+        | Expression::BooleanLiteral(_)
+        | Expression::NullLiteral(_)
+        | Expression::BigIntLiteral(_)
+        | Expression::UndefinedLiteral(_) => false,
+    }
+}
+
 /// Decide whether a top-level function declaration is a void
 /// statement-helper candidate. Returns its name, params, body statements,
 /// declared local names, and the free identifiers that resolve to top-level
@@ -1443,6 +1550,25 @@ fn void_candidate_from_function(
     // decline outright when params and locals collide. (Declining is never
     // a miscompile.)
     if params.iter().any(|p| local_set.contains(p)) {
+        return None;
+    }
+
+    // (4b) A reassigned PARAMETER is unsound to inline. Inlining substitutes
+    // each parameter occurrence with its ARGUMENT EXPRESSION, treating the
+    // parameter as an immutable value. If the body reassigns the parameter
+    // (`x = …`, `x += …`), that model breaks two ways: (1) when the argument
+    // is a non-lvalue (`f(7)` → the assignment target becomes the literal
+    // `7`), and (2) the captured tail value is read from the substituted
+    // argument, not the post-assignment parameter — so `function f(x){ x = x+1;
+    // return x; }` inlined at `g = f(7)` yields `g = 7` instead of `8`, a
+    // miscompile. (This only became reachable once assignment-expression
+    // statements parsed, CLOC17 — before that such a helper made the whole
+    // program fall back to whitespace-only.) Correctly inlining a mutated
+    // parameter would require materialising it into a fresh local seeded from
+    // the argument; until that slice lands, decline. (Declining is never a
+    // miscompile. Parameter reassignment via `++`/`--` is not reachable: the
+    // typed AST has no `UpdateExpression` yet.)
+    if body_assigns_to_param(&fd.body.body, &param_set) {
         return None;
     }
 
@@ -3908,6 +4034,59 @@ mod tests {
         assert_eq!(
             inline_source("function f(a) { g(); return; } var h; h = f(1);"),
             "function f(a){g();return};var h;h=f(1);"
+        );
+    }
+
+    // ===== Parameter-reassignment soundness guard =====
+    // Inlining substitutes each parameter with its ARGUMENT EXPRESSION, so a
+    // helper that REASSIGNS a parameter cannot be inlined: substituting a
+    // non-lvalue argument would target a literal, and the captured value would
+    // read the pre-assignment argument. (Reachable only since CLOC17 made
+    // assignment statements parse.) These pin that such helpers are declined.
+
+    #[test]
+    fn does_not_inline_helper_that_reassigns_param() {
+        // `function f(x){ x = x + 1; return x; }` returns 8 for `f(7)`.
+        // Substituting `x -> 7` would yield `7 = 7 + 1` / a `g = 7` capture —
+        // a miscompile — so the helper is left intact.
+        assert_eq!(
+            inline_source("function f(x) { x = x + 1; return x; } var g = f(7);"),
+            "function f(x){x=x + 1;return x};var g=f(7);"
+        );
+    }
+
+    #[test]
+    fn does_not_inline_helper_with_compound_param_assignment() {
+        // Compound assignment (`x += 1`) is a parameter mutation too.
+        assert_eq!(
+            inline_source("function f(x) { x += 1; return x; } var g = f(7);"),
+            "function f(x){x+=1;return x};var g=f(7);"
+        );
+    }
+
+    #[test]
+    fn does_not_inline_helper_with_nested_param_assignment() {
+        // The mutation need not be a top-level statement: `y = (x = 5)` mutates
+        // `x` inside a larger expression. The walker recurses every expression
+        // position, so this is caught and the helper declined.
+        assert_eq!(
+            inline_source("function f(x) { var y; y = (x = 5); return y; } var g = f(7);"),
+            "function f(x){var y;y=x=5;return y};var g=f(7);"
+        );
+    }
+
+    #[test]
+    fn still_inlines_helper_that_assigns_a_free_variable() {
+        // Assigning a FREE (non-parameter) variable is sound — it is not
+        // substituted, so the spliced body writes the same binding the helper
+        // did. Only parameter mutation is unsound, so this helper still inlines:
+        // `glob = 7` is spliced and the tail value captured into a temp that
+        // the declaration reads (`const a = 7; var g = a`). (The inline pass
+        // runs alone here; constant-fold/propagate would later collapse the
+        // temp to `var g = 7` in the full SIMPLE pipeline.)
+        assert_eq!(
+            inline_source("function f(x) { glob = x; return x; } var g = f(7);"),
+            "function f(x){glob=x;return x};glob=7;const a=7;var g=a;"
         );
     }
 }

--- a/code/specs/CLOC15-multi-statement-inlining.md
+++ b/code/specs/CLOC15-multi-statement-inlining.md
@@ -156,6 +156,22 @@ miscompile, miscompiling is).
    identifier argument must not be captured by a callee-local of the same name —
    prevented by condition 5 (locals are fresh) plus 7 (args are simple).
 
+9. **Parameters are not reassigned.** Substitution (condition 1) replaces every
+   parameter occurrence with its *argument expression*, which is only sound if
+   the parameter behaves as an immutable value. If the body reassigns a
+   parameter (`x = …`, `x += …`, or a nested `y = (x = 5)` / `f(x = 5)`), the
+   model breaks: a non-lvalue argument would become an assignment target
+   (`7 = …`), and a captured tail value would read the pre-assignment argument
+   rather than the post-assignment parameter — so `function f(x){ x = x+1;
+   return x }` inlined at `var g = f(7)` would yield `g = 7` instead of `8`, a
+   miscompile. Reject any candidate whose body assigns to a parameter
+   (`body_assigns_to_param`, recursing every expression position). A
+   member-target whose base is a parameter (`x.k = 5`) mutates a *property* of
+   the argument, not the parameter binding, and stays admitted. (Only reachable
+   once assignment statements parse — CLOC17; before that such a helper made
+   the whole program fall back to whitespace-only.) Materialising a mutated
+   parameter into a fresh local seeded from the argument is a future slice.
+
 If any condition is unprovable from the local AST, **reject**.
 
 ## Staged implementation plan
@@ -352,11 +368,11 @@ Empirical behaviour of the merged slices, confirmed by running the real
    call when its enclosing statement is a plain `ExpressionStatement`,
    `VariableDeclaration` init, or `return` argument, and the call is not under a
    short-circuit/conditional operator."
-   **Resolved:** PR-3 implemented the `VariableDeclaration`-init position and
-   PR-5 the `return`-argument position (see the staged plan above); both reject
-   the short-circuit/conditional sub-positions. Assignment-target capture
-   remains unbuilt (and is moot until the typed bridge supports assignment
-   expressions — see *Implementation findings*).
+   **Resolved:** PR-3 implemented the `VariableDeclaration`-init position, PR-5
+   the `return`-argument position, and PR-6 the assignment-target position
+   (`g = f(x)`, bare-identifier simple assignment only); all reject the
+   short-circuit/conditional sub-positions. PR-6 became buildable once the
+   typed bridge parsed assignment-expression statements (CLOC17).
 
 3. **`var` hoisting vs. let/const.** First slice should restrict callee locals
    to `let`/`const` to sidestep hoisting reasoning, then admit `var` once the


### PR DESCRIPTION
## Summary

**Soundness fix — a real miscompile.** The function-inlining pass was inlining helpers that **reassign one of their parameters**, producing wrong output. Inlining substitutes each parameter occurrence with its *argument expression* (treating the parameter as immutable), so:

```js
function f(x){ x = x + 1; return x; } var g = f(7); use(g);
// closurec produced:  x=8; const a=7; var g=a; use(g);   →  g = 7  (WRONG, also leaks a global `x`)
// correct:            var g=8; use(g);                    →  f(7) === 8
```

The same broke in `return f(x)` and `g = f(x)` capture positions.

This was a **latent hazard that only became reachable** once assignment-expression statements parsed (the **CLOC17** grammar fix, `javascript-parser` 0.9.0). Before that, any helper body containing `x = …` made the whole program fall back to whitespace-only, so the inliner never saw it. The basic single-use inliner and the value-capture family (PR-3/5/6) were all designed assuming immutable parameters — surfaced now that real assignment-bearing code reaches them.

## Fix

The candidate filter (`void_candidate_from_function`, shared by the void and valued paths) now **declines any helper whose body assigns to a parameter**. A new recursive `body_assigns_to_param` walk covers **every expression position**, so nested assignments (`y = (x = 5)`, `f(x = 5)`, `c ? (x = 5) : 0`) are caught too.

**Precise, sound boundary:**
- A **member-target whose base is a parameter** (`x.k = 5`) stays admitted — it mutates a *property* of the argument, not the parameter binding, and is sound under substitution.
- `++`/`--` parameter mutation is not reachable (the typed AST has no `UpdateExpression`).
- Array spread `[...e]`, object spread `{...e}`, and function-expression/getter/method bodies are **not representable** in the typed AST (verified: `elements: Vec<Option<Expression>>`, spread is "Phase 2", and `Expression` has no function variant), so no parameter assignment can hide in them — an invariant locked with a comment.

Correctly inlining a mutated parameter would require materialising it into a fresh local seeded from the argument; left as a future slice. **Declining is never a miscompile.**

## Verification

- **Reproduced** the miscompile through the real `closurec` binary (`g=7` instead of `8`), then confirmed the fix leaves such helpers intact (correct).
- **4 new unit tests**: three decline cases (`x=x+1`, `x+=1`, nested `y=(x=5)`) + a positive control proving a **free-variable** assignment (`glob = x`) still inlines. `closure-pass-inline`: **87 tests pass**.
- **No closurec fixture churn**: closurec **680 tests pass**.
- Spec CLOC15: added soundness **condition 9** and refreshed the now-stale Open-Q2 note (PR-6 assignment-target capture shipped in [#6267](https://github.com/adhithyan15/coding-adventures/pull/6267)).
- `closure-pass-inline` 0.13.0 → 0.13.1.
- Inline security review (adversarial completeness check on the walker): **passed** after confirming no spread/method/function-expression forms exist in the AST.

🤖 Generated with [Claude Code](https://claude.com/claude-code)