### PR TITLE
feat(mycin-derm): Tier-2 dermatology lesion→diagnosis recall as an ADJ-only library

### DIFF
--- a/code/specs/data/mycin-2026/USMLE-DOMAIN-MAP.md
+++ b/code/specs/data/mycin-2026/USMLE-DOMAIN-MAP.md
@@ -115,6 +115,7 @@ unchanged. Adding a relation just widens the schema — the engine already binds
 | Cardiology murmurs (Tier-2) | Cardiology | murmur_indicates (murmur→lesion) | 5 grounded (ADJ-only) | ✓ |
 | Neurology localization (Tier-2) | Neurology | lesion_causes (site→deficit) | 5 grounded (ADJ-only) | ✓ |
 | GI biopsy (Tier-2) | Gastroenterology | biopsy_finding_in (finding→dx) | 5 grounded (ADJ-only) | ✓ |
+| Dermatology (Tier-2) | Dermatology | skin_finding_in (lesion→dx) | 4 grounded (ADJ-only) | ✓ |
 
 Offline pipeline: prose → local-model decompose → ADJ → native engine, two-sided
 faithfulness gate, zero online calls (OFFLINE-BOARD-EXAM.md).
@@ -196,6 +197,15 @@ faithfulness gate, zero online calls (OFFLINE-BOARD-EXAM.md).
     PBC→anti-mitochondrial, Sjögren→anti-Ro/La, polymyositis→anti-Jo1 (deferred — pages
     discuss these in risk-factor/criteria context, no clean both-endpoints-named span yet).
 11. Skin/derm (lesion→diagnosis)
+    *Started (DERM — seventh Tier-2 domain):* `skin_finding_in` for target lesions→erythema
+    multiforme (NBK470259), silvery scales→psoriasis (NBK448194), umbilicated papules→
+    molluscum contagiosum (NBK441898), herald patch→pityriasis rosea (NBK448091) — 4 edges,
+    all grounded to byte-stable NCBI StatPearls spans naming both finding and diagnosis,
+    shipped as the eleventh **ADJ-only** domain (`recall/derm-edges.adj`). Deferred — impetigo
+    (its honey-colored-crust sentence does not name impetigo; only a negative "Bullous
+    impetigo does not form a honey-colored crust") and herpes zoster (dermatomal-distribution
+    sentences omit the disease name). Spans favor the disease-named declarative; the molluscum
+    span uses the page's defined abbreviation "MC".
 12. Reproductive (ob/gyn + male), Breast
 
 **Tier 3 — clinical reasoning (Step 2/3):**

--- a/code/specs/data/mycin-2026/board/board-scorecard.json
+++ b/code/specs/data/mycin-2026/board/board-scorecard.json
@@ -1,7 +1,7 @@
 {
   "summary": {
-    "total": 126,
-    "correct": 119,
+    "total": 130,
+    "correct": 123,
     "abstained": 7,
     "wrong": 0,
     "by_tactic": {
@@ -16,15 +16,15 @@
         "wrong": 0
       },
       "recall": {
-        "correct": 113,
+        "correct": 117,
         "abstained": 6,
         "wrong": 0
       }
     },
     "defensibility": 1.0,
     "accuracy_on_attempted": 1.0,
-    "grounded_coverage": 0.9912,
-    "grounded_correct": 112
+    "grounded_coverage": 0.9915,
+    "grounded_correct": 116
   },
   "results": [
     {
@@ -1032,6 +1032,38 @@
       "tactic": "recall",
       "gold": "eosinophilic_esophagitis",
       "answer": "eosinophilic_esophagitis",
+      "outcome": "correct",
+      "trust": "authoritative"
+    },
+    {
+      "id": "derm_em_dx",
+      "tactic": "recall",
+      "gold": "erythema_multiforme",
+      "answer": "erythema_multiforme",
+      "outcome": "correct",
+      "trust": "authoritative"
+    },
+    {
+      "id": "derm_psoriasis_dx",
+      "tactic": "recall",
+      "gold": "psoriasis",
+      "answer": "psoriasis",
+      "outcome": "correct",
+      "trust": "authoritative"
+    },
+    {
+      "id": "derm_mc_dx",
+      "tactic": "recall",
+      "gold": "molluscum_contagiosum",
+      "answer": "molluscum_contagiosum",
+      "outcome": "correct",
+      "trust": "authoritative"
+    },
+    {
+      "id": "derm_pr_dx",
+      "tactic": "recall",
+      "gold": "pityriasis_rosea",
+      "answer": "pityriasis_rosea",
       "outcome": "correct",
       "trust": "authoritative"
     }

--- a/code/specs/data/mycin-2026/board/board_eval.py
+++ b/code/specs/data/mycin-2026/board/board_eval.py
@@ -67,7 +67,7 @@ SCORECARD = HERE / "board-scorecard.json"
 EDGE_FILES = ["iem-edges.adj", "vitamin-edges.adj", "anemia-edges.adj", "endocrine-edges.adj",
               "coag-edges.adj", "micro-edges.adj", "pharm-edges.adj", "immuno-edges.adj",
               "genetics-edges.adj", "rheum-edges.adj", "onco-edges.adj", "histo-edges.adj",
-              "cardio-edges.adj", "neuro-edges.adj", "gi-edges.adj"]
+              "cardio-edges.adj", "neuro-edges.adj", "gi-edges.adj", "derm-edges.adj"]
 
 # The native adj-lang CLI binary — the ONE engine behind every tactic (recall,
 # differential, management). If the binary is absent (e.g. a Python-only CI job that

--- a/code/specs/data/mycin-2026/board/decompose_query.py
+++ b/code/specs/data/mycin-2026/board/decompose_query.py
@@ -60,11 +60,12 @@ RECALL = HERE.parent / "recall"
 EDGE_FILES = ["iem-edges.adj", "vitamin-edges.adj", "anemia-edges.adj",
               "endocrine-edges.adj", "coag-edges.adj", "micro-edges.adj", "pharm-edges.adj",
               "immuno-edges.adj", "genetics-edges.adj", "rheum-edges.adj", "onco-edges.adj",
-              "histo-edges.adj", "cardio-edges.adj", "neuro-edges.adj", "gi-edges.adj"]
+              "histo-edges.adj", "cardio-edges.adj", "neuro-edges.adj", "gi-edges.adj",
+              "derm-edges.adj"]
 
 # Each recall relation binds one conventional variable (the "what is being asked").
-# This is the controlled query vocabulary the model must choose from — 31 relations
-# across fourteen domains. The engine ultimately validates the subject; this map
+# This is the controlled query vocabulary the model must choose from — 32 relations
+# across fifteen domains. The engine ultimately validates the subject; this map
 # pins the legal relation set and the variable name each relation answers.
 REL_VAR = {
     "deficient_in": "Enzyme",          # IEM: which enzyme is deficient
@@ -98,6 +99,7 @@ REL_VAR = {
     "murmur_indicates": "Lesion",      # cardiology: the valvular lesion a heart murmur points to
     "lesion_causes": "Deficit",        # neurology: the deficit/syndrome a lesion site produces
     "biopsy_finding_in": "Disease",    # gastroenterology: the GI diagnosis a biopsy finding points to
+    "skin_finding_in": "Disease",      # dermatology: the diagnosis a skin lesion morphology points to
 }
 
 _RELATE_RE = re.compile(r"^\s*relate\s+([a-z_][a-z0-9_]*)\s*\(([^)]*)\)\s*$")

--- a/code/specs/data/mycin-2026/board/items.json
+++ b/code/specs/data/mycin-2026/board/items.json
@@ -144,6 +144,11 @@
     {"id": "gi_crohn_dx",    "domain": "gi", "tactic": "recall", "relation": "biopsy_finding_in", "subject": "transmural_inflammation",    "var": "Disease", "gold": "crohn_disease"},
     {"id": "gi_barrett_dx",  "domain": "gi", "tactic": "recall", "relation": "biopsy_finding_in", "subject": "goblet_cells",              "var": "Disease", "gold": "barrett_esophagus"},
     {"id": "gi_hirsch_dx",   "domain": "gi", "tactic": "recall", "relation": "biopsy_finding_in", "subject": "absence_of_ganglion_cells", "var": "Disease", "gold": "hirschsprung_disease"},
-    {"id": "gi_eoe_dx",      "domain": "gi", "tactic": "recall", "relation": "biopsy_finding_in", "subject": "eosinophils_15_per_hpf",     "var": "Disease", "gold": "eosinophilic_esophagitis"}
+    {"id": "gi_eoe_dx",      "domain": "gi", "tactic": "recall", "relation": "biopsy_finding_in", "subject": "eosinophils_15_per_hpf",     "var": "Disease", "gold": "eosinophilic_esophagitis"},
+
+    {"id": "derm_em_dx",      "domain": "derm", "tactic": "recall", "relation": "skin_finding_in", "subject": "target_lesions",      "var": "Disease", "gold": "erythema_multiforme"},
+    {"id": "derm_psoriasis_dx","domain": "derm", "tactic": "recall", "relation": "skin_finding_in", "subject": "silvery_scales",      "var": "Disease", "gold": "psoriasis"},
+    {"id": "derm_mc_dx",      "domain": "derm", "tactic": "recall", "relation": "skin_finding_in", "subject": "umbilicated_papules", "var": "Disease", "gold": "molluscum_contagiosum"},
+    {"id": "derm_pr_dx",      "domain": "derm", "tactic": "recall", "relation": "skin_finding_in", "subject": "herald_patch",        "var": "Disease", "gold": "pityriasis_rosea"}
   ]
 }

--- a/code/specs/data/mycin-2026/board/test_board_eval.py
+++ b/code/specs/data/mycin-2026/board/test_board_eval.py
@@ -51,7 +51,7 @@ def test_covered_items_answer_correctly_with_a_proof() -> None:
     # answers, so the board scores the top binding per subject (the libraries + their
     # tests cover all edges).
     recall_correct = [r for r in card.results if r.outcome == "correct" and r.tactic == "recall"]
-    assert len(recall_correct) == 113
+    assert len(recall_correct) == 117
     assert by_id["fabry_enzyme"].outcome == "correct"               # IEM
     assert by_id["thiamine_disease"].answer == "beriberi"           # vitamin
     assert by_id["ida_mcv"].answer == "microcytic"                  # anemia
@@ -90,6 +90,9 @@ def test_covered_items_answer_correctly_with_a_proof() -> None:
     assert by_id["gi_celiac_dx"].answer == "celiac_disease"      # gastroenterology (GI, Tier-2)
     assert by_id["gi_hirsch_dx"].answer == "hirschsprung_disease"  # gi — biopsy_finding_in (finding->dx)
     assert by_id["gi_celiac_dx"].trust == "authoritative"        # ADJ-only edge, grounded inline
+    assert by_id["derm_em_dx"].answer == "erythema_multiforme"   # dermatology (DERM, Tier-2)
+    assert by_id["derm_psoriasis_dx"].answer == "psoriasis"      # derm — skin_finding_in (finding->dx)
+    assert by_id["derm_em_dx"].trust == "authoritative"          # ADJ-only edge, grounded inline
 
 
 def test_uncovered_items_abstain_not_fabricate() -> None:
@@ -132,8 +135,8 @@ def test_grounded_coverage_is_the_live_grounding_number() -> None:
     # verbatim, so the framework declines to claim grounding it cannot defend, by design:
     # cortisol_def (endocrine, deficiency_syndrome__cortisol — the only verbatim spans frame
     # cortisol deficiency as a consequence/feature of Addison disease, not the named-syndrome identity).
-    assert s["grounded_coverage"] == round(112 / 113, 4)   # 0.9912
-    assert s["grounded_correct"] == 112
+    assert s["grounded_coverage"] == round(116 / 117, 4)   # 0.9915
+    assert s["grounded_correct"] == 116
     by_id = {r.item_id: r for r in card.results}
     assert by_id["tay_sachs_enzyme"].trust == "authoritative"      # IEM
     assert by_id["ida_mcv"].trust == "authoritative"               # anemia

--- a/code/specs/data/mycin-2026/recall/derm-edges.adj
+++ b/code/specs/data/mycin-2026/recall/derm-edges.adj
@@ -1,0 +1,71 @@
+% ============================================================================
+% derm-edges — the dermatology morphology knowledge-graph (MYCIN-2026 DERM).
+% ============================================================================
+% A Tier-2 organ-system pathology domain (USMLE-DOMAIN-MAP §"Tier 2", #11 skin/derm):
+% the classic skin-lesion description and the diagnosis it points to. "A rash shows
+% target lesions — what is the diagnosis?" becomes the binding query
+%     ? skin_finding_in(target_lesions, $Disease).
+%
+% Direction note: the relation is finding -> disease (`skin_finding_in`), the board
+% direction — you SEE the lesion morphology and must name the diagnosis. The cited spans
+% read either way ("the typical lesion of the erythema multiforme is the target lesion";
+% "Psoriasis presents as ... plaques covered with silvery scales") — what matters for
+% grounding is that one self-contained span names BOTH the finding AND the disease. Each
+% finding here maps to one canonical diagnosis, so a query binds a single answer.
+%
+% This file is the SHIPPED ARTIFACT and the SOLE source of truth — no generator, no
+% JSON, no manifest (the eleventh ADJ-only recall domain; seventh Tier-2 organ-system
+% domain after RHEUM, ONCO, HISTO, CARDIO, NEURO, GI). Each fact is a `relate` clause
+% whose byte-provenance lives INLINE:
+%     source   — the VERBATIM span copied from the cited page (byte-stable: it appears
+%                character-for-character in the page's normalized text).
+%     locator  — the URL the span was read from (NCBI StatPearls / Bookshelf, NIH).
+%     trust    — authoritative (a primary, citable reference).
+% An LLM (or a human) recalls a fact by writing a tiny query .adj that `import`s this
+% library and asks a binding query — see derm-recall.query.adj. Nothing here is asserted
+% "from memory": every edge is defended by a span a reader can re-fetch and check.
+% (See feedback_nothing_human_authored, feedback_adj_only_shipped_artifacts.)
+%
+% Honest scope: only morphologies whose page states the association in a clean self-
+% contained span (both finding AND disease named) are included. Deferred — impetigo
+% (its honey-colored-crust sentence is phrased without naming impetigo, e.g. only the
+% negative "Bullous impetigo does not form a honey-colored crust"); herpes zoster
+% (its dermatomal-distribution sentences do not name zoster alongside the finding).
+% The molluscum span names the disease by its on-page abbreviation "MC" (= molluscum
+% contagiosum, defined in that StatPearls article's title).
+% ============================================================================
+
+dictionary derm_vocab {
+    define finding : entity   surface "skin finding", "lesion morphology"
+    define disease : entity   surface "dermatologic diagnosis", "skin disease"
+
+    define skin_finding_in : relation from finding to disease  % the diagnosis a skin finding points to
+}
+
+rulebook derm_facts {
+    use derm_vocab
+
+    % --- target lesions -> erythema multiforme ---------------------------------
+    relate skin_finding_in(target_lesions, erythema_multiforme)
+        source "Clinically, the typical lesion of the erythema multiforme is the target lesion; however, they may not always be present."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK470259/"
+        trust authoritative
+
+    % --- silvery scales (on erythematous plaques) -> psoriasis -----------------
+    relate skin_finding_in(silvery_scales, psoriasis)
+        source "Psoriasis presents as well-defined erythematous plaques covered with silvery scales commonly over the scalp, and extensors of extremity, particularly over knees, elbows, and lumbosacral"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK448194/"
+        trust authoritative
+
+    % --- umbilicated papules -> molluscum contagiosum (MC) ---------------------
+    relate skin_finding_in(umbilicated_papules, molluscum_contagiosum)
+        source "MC is a clinical diagnosis, based on the appearance of characteristic flesh-colored, dome-shaped, umbilicated papules, and does not typically require laboratory confirmation."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK441898/"
+        trust authoritative
+
+    % --- herald patch -> pityriasis rosea --------------------------------------
+    relate skin_finding_in(herald_patch, pityriasis_rosea)
+        source "Pityriasis rosea (PR) can sometimes be difficult to manage because of factors including variations in the clinical manifestation of the condition and acknowledging instances where the typical herald patch may be absent."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK448091/"
+        trust authoritative
+}

--- a/code/specs/data/mycin-2026/recall/derm-recall.query.adj
+++ b/code/specs/data/mycin-2026/recall/derm-recall.query.adj
@@ -1,0 +1,19 @@
+% ============================================================================
+% derm-recall.query.adj — a worked recall query over the dermatology library.
+% ============================================================================
+% The shape an LLM (or a clinician) produces to ANSWER a "this lesion looks like X — what
+% is the diagnosis?" question: it states no derm fact — it only `import`s the grounded
+% library and asks binding queries. The native adj-lang engine resolves each `?` against
+% the imported `relate` edges and returns the binding + the citing clause's
+% source/locator/trust. All knowledge is in the library; none is here.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli derm-recall.query.adj
+% ============================================================================
+
+import "derm-edges.adj"
+
+? skin_finding_in(target_lesions, $Disease)       % expect erythema_multiforme
+? skin_finding_in(silvery_scales, $Disease)       % expect psoriasis
+? skin_finding_in(umbilicated_papules, $Disease)  % expect molluscum_contagiosum
+? skin_finding_in(herald_patch, $Disease)         % expect pityriasis_rosea

--- a/code/specs/data/mycin-2026/recall/test_derm_recall.py
+++ b/code/specs/data/mycin-2026/recall/test_derm_recall.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""test_derm_recall.py — the ADJ-only dermatology morphology library (MYCIN-2026 DERM).
+
+The eleventh recall domain shipped as a pure ADJ artifact (seventh Tier-2 organ-system
+domain, after RHEUM, ONCO, HISTO, CARDIO, NEURO, GI). `derm-edges.adj` is the SOLE source
+of truth — facts + byte-provenance inline, no Python gate, no JSON, no manifest. This test
+pins the property that matters: the native adj-lang engine, given a query .adj that only
+`import`s the library and asks binding queries (`derm-recall.query.adj` — the shape an LLM
+produces), binds the grounded diagnosis for each skin finding, each carrying an
+AUTHORITATIVE citation with a real source span + locator. Knowledge lives in ADJ; the
+engine answers.
+
+If the native CLI isn't built (a Python-only CI lane), the engine-backed checks skip —
+the file-shape checks (every clause grounded, no authored-debt) still run.
+
+Run:  python3 test_derm_recall.py
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+ADJ = HERE / "derm-edges.adj"
+QUERY = HERE / "derm-recall.query.adj"
+CLI = HERE.parents[3] / "packages" / "rust" / "target" / "debug" / "adj-lang-cli"
+
+# Every grounded edge: skin finding -> the diagnosis the library binds for it.
+EXPECTED = {
+    "target_lesions": "erythema_multiforme",
+    "silvery_scales": "psoriasis",
+    "umbilicated_papules": "molluscum_contagiosum",
+    "herald_patch": "pityriasis_rosea",
+}
+REL = "skin_finding_in"
+VAR = "Disease"
+
+
+def _cli_available() -> bool:
+    return CLI.exists()
+
+
+def _run(program: Path) -> dict:
+    out = subprocess.run([str(CLI), str(program)], capture_output=True, text=True,
+                         cwd=str(HERE), timeout=60)
+    assert out.returncode == 0, f"adj-lang-cli failed: {out.stderr}"
+    return json.loads(out.stdout)
+
+
+# ---- 1. the ADJ file is the artifact — every clause grounded, no authored-debt ----
+
+def test_library_is_pure_adj_and_fully_grounded() -> None:
+    text = ADJ.read_text()
+    assert "trust consensus" not in text, "DERM ships no authored-debt; ground or omit"
+    assert "[FLAG:" not in text
+    edge_count = len(EXPECTED)  # 4
+    assert text.count("    relate ") == edge_count
+    assert text.count("trust authoritative") == edge_count
+    assert text.count('\n        locator "') == edge_count
+    assert text.count('\n        source "') == edge_count
+    assert not (HERE / "derm_edge_ground.py").exists()
+    assert not (HERE / "derm-edge-grounding.json").exists()
+    assert not (HERE / "derm-edge-manifest.json").exists()
+
+
+# ---- 2. the engine binds each diagnosis, each with an authoritative citation ----
+
+def test_engine_binds_every_diagnosis_with_authoritative_citation() -> None:
+    if not _cli_available():
+        return
+    result = _run(QUERY)
+    by_query = {r["query"]: r for r in result["recall"]}
+    for finding, disease in EXPECTED.items():
+        q = f"{REL}({finding}, {VAR})"
+        r = by_query.get(q)
+        assert r is not None and not r["abstained"], f"{q} abstained — edge missing?"
+        bound = {}
+        for a in r["answers"]:
+            bound[a["bindings"][VAR]] = (a.get("citations") or [{}])[0]
+        assert set(bound) == {disease}, f"{finding}: bound {set(bound)} != {{{disease}}}"
+        cite = bound[disease]
+        assert cite.get("trust") == "authoritative", f"{finding}/{disease} not authoritative"
+        assert cite.get("source"), f"{finding}/{disease} has no source span"
+        assert cite.get("locator", "").startswith("https://www.ncbi.nlm.nih.gov/")
+
+
+# ---- 3. an off-vocabulary finding abstains, never fabricates -----------------------
+
+def test_unknown_finding_abstains() -> None:
+    if not _cli_available():
+        return
+    import os
+    import tempfile
+    fd, path = tempfile.mkstemp(suffix=".adj", prefix=".derm_q_", dir=HERE)
+    try:
+        with os.fdopen(fd, "w") as fh:
+            # malar_rash is not in the library → must abstain
+            fh.write(f'import "derm-edges.adj"\n? {REL}(malar_rash, ${VAR})\n')
+        res = _run(Path(path))
+        r = res["recall"][0] if res["recall"] else None
+        assert r is not None and r["abstained"], "an ungrounded finding must abstain"
+    finally:
+        os.unlink(path)
+
+
+def _run_all() -> int:
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    failed = 0
+    for t in tests:
+        try:
+            t()
+            print(f"  PASS  {t.__name__}")
+        except AssertionError as exc:
+            failed += 1
+            print(f"  FAIL  {t.__name__}: {exc}")
+    print(f"\ntest_derm_recall: {len(tests) - failed}/{len(tests)} passed")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(_run_all())


### PR DESCRIPTION
## What

The **eleventh ADJ-only recall domain** for MYCIN-2026 (seventh Tier-2 organ-system, after RHEUM, ONCO, HISTO, CARDIO, NEURO, GI): the classic **skin-lesion morphology → diagnosis**. `recall/derm-edges.adj` is the sole shipped artifact — facts + **inline byte-provenance**, no Python gate, no JSON, no manifest. A query is another `.adj` that `import`s the library and asks `? skin_finding_in(<finding>, $Disease)`.

## The four edges (each grounded to a byte-stable verbatim NCBI StatPearls span naming BOTH endpoints)

| skin finding | diagnosis | source |
|---|---|---|
| target lesions | erythema multiforme | NBK470259 |
| silvery scales | psoriasis | NBK448194 |
| umbilicated papules | molluscum contagiosum | NBK441898 |
| herald patch | pityriasis rosea | NBK448091 |

**Deferred honestly:** impetigo (its honey-colored-crust sentence does not name impetigo — only the negative *Bullous impetigo does not form a honey-colored crust*) and herpes zoster (dermatomal-distribution sentences omit the disease name). The molluscum span uses the page's defined abbreviation *MC*.

## Verification
- `test_derm_recall.py` **3/3** — engine binds every diagnosis with an authoritative citation; off-vocab finding (`malar_rash`) abstains.
- `test_board_eval.py` **12/12** — recall 113→**117** correct, grounded 112→**116** (116/117 = **0.9915**), **0 wrong**, **defensibility 1.0**.
- Security review: **PASSED**.

## Wiring
`derm-edges.adj` → `EDGE_FILES` in `board_eval.py` + `decompose_query.py`; `REL_VAR["skin_finding_in"]="Disease"` (32 relations / fifteen domains); 4 board items; scorecard regenerated; USMLE-DOMAIN-MAP updated.

> Note: `code/specs/data/mycin-2026` is not wired into CI (no BUILD file); local runs above are the verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)