### PR TITLE
feat(closure-pass-inline): admit `var` locals in helper bodies (CLOC15 Open Q3)

### DIFF
--- a/code/packages/rust/closure-pass-inline/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-inline/CHANGELOG.md
@@ -2,6 +2,39 @@
 
 All notable changes to the `coding-adventures-closure-pass-inline` crate will be documented in this file.
 
+## [0.14.0] - 2026-06-19
+
+### Added (CLOC15 Open Q3 — `var` locals admitted)
+
+Helper bodies with a `var` local are now inlinable (previously the candidate
+filter declined any `var` declaration, admitting only `let`/`const`). Example
+(SIMPLE):
+
+```js
+function f(x){ var t = x + 1; return t * 2; } var g = f(7); use(g);
+// after:  var g = 16; use(g);   (var local hoisted-and-renamed, then folded)
+```
+
+**Soundness.** A `var` is function-scoped and hoists to the top of the
+*caller's* function on a flat splice, whereas `let`/`const` stay block-scoped.
+That difference is **observationally inert here** because every callee local —
+`var` included — is alpha-renamed to a program-fresh name (one that appears in
+no declaration or use anywhere in the program, per the existing condition-5
+`avoid` set). Nothing reads or writes the fresh name except the spliced body,
+in source order, so where the declaration hoists to cannot matter. The
+collision case is the crux and is tested: a caller binding `var t = 9` is left
+untouched while the helper's `var t` is renamed to a fresh `b`.
+
+The bridge desugars `var t = E` into `var t; t = E`, so an admitted `var`-local
+body contains an assignment to that local. That is sound under renaming (the
+`rename` walk rewrites both the declaration id and the assignment target) and is
+**not** flagged by the 0.13.1 parameter-mutation guard, which only declines
+assignment to a *parameter* — a local is fine.
+
+Four tests: one void-helper positive (flipped from the old decline test), one
+value-capture positive, one local-reassignment positive, and the
+caller-collision case. No closurec fixture churn.
+
 ## [0.13.1] - 2026-06-19
 
 ### Fixed (soundness) — decline helpers that reassign a parameter

--- a/code/packages/rust/closure-pass-inline/Cargo.toml
+++ b/code/packages/rust/closure-pass-inline/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-inline"
-version = "0.13.1"
+version = "0.14.0"
 edition = "2021"
 description = "Function-inlining pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Substitutes small or single-use function bodies at their call sites to enable downstream folding and shrink call overhead."
 

--- a/code/packages/rust/closure-pass-inline/README.md
+++ b/code/packages/rust/closure-pass-inline/README.md
@@ -120,12 +120,15 @@ structurally cannot do. It is admitted only under a tight, sound subset
    position (`x = track(…)`). No result to capture (value capture is a
    later slice).
 3. **Straight-line body to an optional tail `return`** — each statement is
-   an expression statement or a `let`/`const` declaration, plus an optional
-   `return` as the *final* statement; nothing else (no *early* return).
+   an expression statement or a `var` / `let` / `const` declaration, plus an
+   optional `return` as the *final* statement; nothing else (no *early*
+   return).
 4. **No `this` / `arguments`** — frame-bound, would rebind on a splice.
 5. **Callee locals alpha-renamed to program-fresh names** before
-   splicing — a spliced `let e` can never collide with the call-site
-   scope.
+   splicing — a spliced `let e` can never collide with the call-site scope.
+   This is what makes admitting a `var` local sound (CLOC15 Open Q3): a `var`
+   hoists to the caller-function top on a flat splice, but a name that appears
+   nowhere else in the program is observationally inert wherever it hoists.
 6. **Free identifiers must be true globals, uniquely-declared top-level
    names, or top-level names spliced only at a top-level site.** A free ident
    declared *nowhere* is a true global — unshadowable everywhere, spliceable
@@ -143,6 +146,11 @@ structurally cannot do. It is admitted only under a tight, sound subset
    (Slice B2 will widen the multiply-declared nested case via an
    in-scope-binding walk / `closure-scope-analyzer`.)
 7. **Side-effect-free arguments** — the same `is_simple_arg` gate.
+8. **No parameter reassignment** — a parameter is substituted by its argument
+   expression, so a body that assigns to a parameter (`x = …`, `x += …`) is
+   declined; substituting a non-lvalue argument or reading the pre-assignment
+   value would miscompile. (A *local* reassignment is fine — the local is
+   renamed.) Reachable only since assignment statements parse (CLOC17).
 
 Since the call site discards the result (CLOC15 PR-2), a **tail `return E`**
 is normalized: dropped when `E` is provably inert (a literal or a bare

--- a/code/packages/rust/closure-pass-inline/src/lib.rs
+++ b/code/packages/rust/closure-pass-inline/src/lib.rs
@@ -1511,12 +1511,20 @@ fn void_candidate_from_function(
         match stmt {
             Statement::Tagged(TaggedStatement::ExpressionStatement(_)) => {}
             Statement::Declaration(Declaration::VariableDeclaration(vd)) => {
-                // (3) `var` is function-scoped and would hoist into the
-                // caller on a flat splice — out of this slice; let/const
-                // are block-scoped, so a fresh-renamed binding is inert.
-                if vd.kind == VarKind::Var {
-                    return None;
-                }
+                // (3) `var` / `let` / `const` locals are all admitted (CLOC15
+                // Open Q3). Each declared name is collected so the splice
+                // alpha-renames it to a program-fresh name (condition 5). A
+                // `var` is function-scoped and hoists to the top of the
+                // *caller's* function on a flat splice, whereas `let`/`const`
+                // stay block-scoped — but once the binding is renamed to a name
+                // that appears nowhere else in the program (it is not in
+                // `avoid`), the hoist is observationally inert: nothing reads or
+                // writes the fresh name except the spliced body, in source
+                // order. (The bridge desugars `var t = E` into `var t; t = E`,
+                // so an admitted `var`-local body contains an assignment to that
+                // local — sound under renaming, and not flagged by the
+                // parameter-mutation guard below since the target is a local,
+                // not a parameter.)
                 for d in &vd.declarations {
                     let BindingTarget::Identifier(id) = &d.id;
                     locals.push(id.name.clone());
@@ -3402,12 +3410,14 @@ mod tests {
     }
 
     #[test]
-    fn does_not_inline_void_helper_with_var_local() {
-        // `var` is function-scoped and would hoist into the caller on a
-        // flat splice — outside the first slice (let/const only).
+    fn inlines_void_helper_with_var_local() {
+        // CLOC15 Open Q3: a `var` local is now admitted. The bridge desugars
+        // `var t = x` into `var t; t = x`, and the local `t` is alpha-renamed
+        // to a program-fresh name (`b`) — so the hoisted `var b` is inert
+        // (nothing else references `b`). Previously this slice declined `var`.
         assert_eq!(
             inline_source("function f(x) { var t = x; sink(t); } f(a);"),
-            "function f(x){var t=x;sink(t)};f(a);"
+            "function f(x){var t=x;sink(t)};var b=a;sink(b);"
         );
     }
 
@@ -4087,6 +4097,44 @@ mod tests {
         assert_eq!(
             inline_source("function f(x) { glob = x; return x; } var g = f(7);"),
             "function f(x){glob=x;return x};glob=7;const a=7;var g=a;"
+        );
+    }
+
+    // ===== CLOC15 Open Q3 — `var` locals admitted (alpha-renamed) =====
+
+    #[test]
+    fn inlines_helper_with_var_local_value_capture() {
+        // A `var` local in a valued helper. The bridge desugars `var t = x + 1`
+        // into `var t; t = x + 1`; the local `t` is alpha-renamed to a fresh
+        // `b`, params substituted, and the tail captured into the temp `a`. The
+        // hoisted `var b` is inert because `b` appears nowhere else.
+        assert_eq!(
+            inline_source("function f(x) { var t = x + 1; return t * 2; } var g = f(7);"),
+            "function f(x){var t=x + 1;return t * 2};var b=7 + 1;const a=b * 2;var g=a;"
+        );
+    }
+
+    #[test]
+    fn inlines_helper_that_reassigns_a_var_local() {
+        // Reassigning a *local* (not a parameter) is sound — the local is
+        // renamed, so both the declaration and the `t = t + 1` assignment
+        // target become the fresh name. (Contrast the parameter-reassignment
+        // guard above, which declines mutating a *parameter*.)
+        assert_eq!(
+            inline_source("function f(x) { var t = x; t = t + 1; return t; } var g = f(7);"),
+            "function f(x){var t=x;t=t + 1;return t};var b=7;b=b + 1;const a=b;var g=a;"
+        );
+    }
+
+    #[test]
+    fn var_local_is_renamed_away_from_a_colliding_caller_binding() {
+        // The soundness crux: the caller has its OWN `t`. The helper's `var t`
+        // must be renamed to a fresh name so the splice cannot capture or
+        // clobber the caller's `t`. Here `f`'s `t` becomes `b`; the caller's
+        // `t` (declared `var t = 9` → kept as `var t=9`) is untouched.
+        assert_eq!(
+            inline_source("var t = 9; function f(x) { var t = x; return t; } var g = f(5);"),
+            "var t=9;function f(x){var t=x;return t};var b=5;const a=b;var g=a;"
         );
     }
 }

--- a/code/specs/CLOC15-multi-statement-inlining.md
+++ b/code/specs/CLOC15-multi-statement-inlining.md
@@ -377,6 +377,12 @@ Empirical behaviour of the merged slices, confirmed by running the real
 3. **`var` hoisting vs. let/const.** First slice should restrict callee locals
    to `let`/`const` to sidestep hoisting reasoning, then admit `var` once the
    fresh-rename argument (condition 5) is reviewed as sufficient.
+   **Resolved:** `var` locals are now admitted. The fresh-rename argument *is*
+   sufficient: condition 5 renames every callee local — `var` included — to a
+   name that appears in no declaration or use program-wide, so wherever the
+   `var` hoists to (the caller-function top) is unobservable; nothing but the
+   spliced body, in source order, touches the name. The collision case (a
+   caller binding of the same spelling) is the crux and is covered by a test.
 
 4. **Interaction with the fixed-point pipeline.** Statement inlining can expose
    new single-use candidates and new constant-folding opportunities; confirm the


### PR DESCRIPTION
## Summary

Helper bodies with a **`var` local** are now inlinable — previously the candidate filter declined any `var` declaration, admitting only `let`/`const`. This is the documented next slice, **CLOC15 Open Question 3**, unblocked by the CLOC17 grammar fix (the bridge desugars `var t = E` into `var t; t = E`, so a `var`-local body contains an assignment that only parses post-CLOC17).

```js
function f(x){ var t = x + 1; return t * 2; } var g = f(7); use(g);
// SIMPLE  ⇒  var g = 16; use(g);
```

## Soundness

A `var` is function-scoped and hoists to the top of the **caller's** function on a flat splice, whereas `let`/`const` stay block-scoped. The fresh-rename argument (condition 5) makes that difference **observationally inert**: every callee local — `var` included — is alpha-renamed to a **program-fresh name** absent from the whole program's declared-or-used identifier set. Nothing but the spliced body, in source order, touches the fresh name, so where it hoists to cannot matter. The one case where `var`-vs-`let` cell identity is observable (a closure capturing the local across loop iterations) is ruled out by the unchanged **straight-line / no-nested-function** filter. The pass keeps the binding a `var` (never reinterprets it as `let`), so within-helper semantics like read-before-assign → `undefined` are preserved.

The desugared `t = E` assignment to the local is sound under renaming (the kind-agnostic `rename` walk rewrites both the declaration id and the assignment target) and is **not** flagged by the 0.13.1 parameter-mutation guard, which only declines assignment to a *parameter*.

**The change is one removed guard** (`if vd.kind == VarKind::Var { return None; }`); the `var` name was already collected into `locals` for renaming.

## Verification

- Verified end-to-end through the real `closurec` binary, including the **collision crux**: a caller `var t = 9` is left untouched while the helper's `var t` is fresh-renamed to `b` (no capture/clobber).
- **4 tests**: void-helper positive (flipped from the old decline test), value-capture positive, local-reassignment positive, and the caller-name-collision case. `closure-pass-inline`: **90 tests pass**.
- **No closurec fixture churn**: closurec **680 tests pass**.
- Resolved Open Q3 in spec CLOC15; README condition 3 updated + new condition 8 (parameter-reassignment).
- `closure-pass-inline` 0.13.1 → 0.14.0.
- Inline security review **passed** — an adversarial soundness analysis (read-before-assign, loop cell-sharing, closure capture, TDZ/redeclaration, rename-miss, multi-site) found no miscompiling input; confirmed `BindingTarget` has no destructuring variant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)