### PR TITLE
feat(mycin-resp): Tier-2 respiratory occupational exposure→pneumoconiosis recall (primary-source-first, zero deferral)

### DIFF
--- a/code/specs/data/mycin-2026/USMLE-DOMAIN-MAP.md
+++ b/code/specs/data/mycin-2026/USMLE-DOMAIN-MAP.md
@@ -116,6 +116,7 @@ unchanged. Adding a relation just widens the schema — the engine already binds
 | Neurology localization (Tier-2) | Neurology | lesion_causes (site→deficit) | 5 grounded (ADJ-only) | ✓ |
 | GI biopsy (Tier-2) | Gastroenterology | biopsy_finding_in (finding→dx) | 5 grounded (ADJ-only) | ✓ |
 | Dermatology (Tier-2) | Dermatology | skin_finding_in (lesion→dx) | 4 grounded (ADJ-only) | ✓ |
+| Respiratory occupational (Tier-2) | Pulmonology | inhalation_causes (exposure→dz) | 5 grounded (ADJ-only) | ✓ |
 
 Offline pipeline: prose → local-model decompose → ADJ → native engine, two-sided
 faithfulness gate, zero online calls (OFFLINE-BOARD-EXAM.md).
@@ -169,6 +170,16 @@ faithfulness gate, zero online calls (OFFLINE-BOARD-EXAM.md).
     and diastolic rumble described in separate sentences, no both-endpoints-named span yet);
     ECG→arrhythmia and drug→effect subdomains.
 6. Respiratory (PFT pattern→disease, ABG→disorder)
+    *Started (RESP — eighth Tier-2 domain):* `inhalation_causes` for silica→silicosis
+    (NBK537341), asbestos→asbestosis (NBK555985), beryllium→berylliosis (NBK470364),
+    cotton dust→byssinosis (NBK519549), and **coal dust→coal workers' pneumoconiosis
+    grounded from the CDC/NIOSH primary federal authority** (cdc.gov/niosh/cwhsp) rather
+    than declined — 5 edges, all grounded to byte-stable spans naming both the occupational
+    exposure and the pneumoconiosis, shipped as the twelfth **ADJ-only** domain
+    (`recall/resp-edges.adj`). This is the first edge sourced outside StatPearls: under the
+    **primary-source-first, zero-deferral policy**, an association is grounded to whatever
+    primary authority carries the clean both-endpoints span, never omitted for phrasing.
+    Remaining: PFT-pattern→disease (obstructive/restrictive) and ABG→acid-base-disorder.
 7. Renal/urinary (acid-base, electrolyte, glomerular disease→finding)
 8. Gastrointestinal (LFT pattern→disease, biopsy→diagnosis)
     *Started (GI — sixth Tier-2 domain):* `biopsy_finding_in` for villous atrophy→celiac

--- a/code/specs/data/mycin-2026/board/board-scorecard.json
+++ b/code/specs/data/mycin-2026/board/board-scorecard.json
@@ -1,7 +1,7 @@
 {
   "summary": {
-    "total": 130,
-    "correct": 123,
+    "total": 135,
+    "correct": 128,
     "abstained": 7,
     "wrong": 0,
     "by_tactic": {
@@ -16,15 +16,15 @@
         "wrong": 0
       },
       "recall": {
-        "correct": 117,
+        "correct": 122,
         "abstained": 6,
         "wrong": 0
       }
     },
     "defensibility": 1.0,
     "accuracy_on_attempted": 1.0,
-    "grounded_coverage": 0.9915,
-    "grounded_correct": 116
+    "grounded_coverage": 0.9918,
+    "grounded_correct": 121
   },
   "results": [
     {
@@ -1064,6 +1064,46 @@
       "tactic": "recall",
       "gold": "pityriasis_rosea",
       "answer": "pityriasis_rosea",
+      "outcome": "correct",
+      "trust": "authoritative"
+    },
+    {
+      "id": "resp_silica_dx",
+      "tactic": "recall",
+      "gold": "silicosis",
+      "answer": "silicosis",
+      "outcome": "correct",
+      "trust": "authoritative"
+    },
+    {
+      "id": "resp_asbestos_dx",
+      "tactic": "recall",
+      "gold": "asbestosis",
+      "answer": "asbestosis",
+      "outcome": "correct",
+      "trust": "authoritative"
+    },
+    {
+      "id": "resp_beryl_dx",
+      "tactic": "recall",
+      "gold": "berylliosis",
+      "answer": "berylliosis",
+      "outcome": "correct",
+      "trust": "authoritative"
+    },
+    {
+      "id": "resp_cotton_dx",
+      "tactic": "recall",
+      "gold": "byssinosis",
+      "answer": "byssinosis",
+      "outcome": "correct",
+      "trust": "authoritative"
+    },
+    {
+      "id": "resp_coal_dx",
+      "tactic": "recall",
+      "gold": "coal_workers_pneumoconiosis",
+      "answer": "coal_workers_pneumoconiosis",
       "outcome": "correct",
       "trust": "authoritative"
     }

--- a/code/specs/data/mycin-2026/board/board_eval.py
+++ b/code/specs/data/mycin-2026/board/board_eval.py
@@ -67,7 +67,8 @@ SCORECARD = HERE / "board-scorecard.json"
 EDGE_FILES = ["iem-edges.adj", "vitamin-edges.adj", "anemia-edges.adj", "endocrine-edges.adj",
               "coag-edges.adj", "micro-edges.adj", "pharm-edges.adj", "immuno-edges.adj",
               "genetics-edges.adj", "rheum-edges.adj", "onco-edges.adj", "histo-edges.adj",
-              "cardio-edges.adj", "neuro-edges.adj", "gi-edges.adj", "derm-edges.adj"]
+              "cardio-edges.adj", "neuro-edges.adj", "gi-edges.adj", "derm-edges.adj",
+              "resp-edges.adj"]
 
 # The native adj-lang CLI binary — the ONE engine behind every tactic (recall,
 # differential, management). If the binary is absent (e.g. a Python-only CI job that

--- a/code/specs/data/mycin-2026/board/decompose_query.py
+++ b/code/specs/data/mycin-2026/board/decompose_query.py
@@ -61,11 +61,11 @@ EDGE_FILES = ["iem-edges.adj", "vitamin-edges.adj", "anemia-edges.adj",
               "endocrine-edges.adj", "coag-edges.adj", "micro-edges.adj", "pharm-edges.adj",
               "immuno-edges.adj", "genetics-edges.adj", "rheum-edges.adj", "onco-edges.adj",
               "histo-edges.adj", "cardio-edges.adj", "neuro-edges.adj", "gi-edges.adj",
-              "derm-edges.adj"]
+              "derm-edges.adj", "resp-edges.adj"]
 
 # Each recall relation binds one conventional variable (the "what is being asked").
-# This is the controlled query vocabulary the model must choose from — 32 relations
-# across fifteen domains. The engine ultimately validates the subject; this map
+# This is the controlled query vocabulary the model must choose from — 33 relations
+# across sixteen domains. The engine ultimately validates the subject; this map
 # pins the legal relation set and the variable name each relation answers.
 REL_VAR = {
     "deficient_in": "Enzyme",          # IEM: which enzyme is deficient
@@ -100,6 +100,7 @@ REL_VAR = {
     "lesion_causes": "Deficit",        # neurology: the deficit/syndrome a lesion site produces
     "biopsy_finding_in": "Disease",    # gastroenterology: the GI diagnosis a biopsy finding points to
     "skin_finding_in": "Disease",      # dermatology: the diagnosis a skin lesion morphology points to
+    "inhalation_causes": "Disease",    # respiratory: the pneumoconiosis an occupational exposure causes
 }
 
 _RELATE_RE = re.compile(r"^\s*relate\s+([a-z_][a-z0-9_]*)\s*\(([^)]*)\)\s*$")

--- a/code/specs/data/mycin-2026/board/items.json
+++ b/code/specs/data/mycin-2026/board/items.json
@@ -149,6 +149,12 @@
     {"id": "derm_em_dx",      "domain": "derm", "tactic": "recall", "relation": "skin_finding_in", "subject": "target_lesions",      "var": "Disease", "gold": "erythema_multiforme"},
     {"id": "derm_psoriasis_dx","domain": "derm", "tactic": "recall", "relation": "skin_finding_in", "subject": "silvery_scales",      "var": "Disease", "gold": "psoriasis"},
     {"id": "derm_mc_dx",      "domain": "derm", "tactic": "recall", "relation": "skin_finding_in", "subject": "umbilicated_papules", "var": "Disease", "gold": "molluscum_contagiosum"},
-    {"id": "derm_pr_dx",      "domain": "derm", "tactic": "recall", "relation": "skin_finding_in", "subject": "herald_patch",        "var": "Disease", "gold": "pityriasis_rosea"}
+    {"id": "derm_pr_dx",      "domain": "derm", "tactic": "recall", "relation": "skin_finding_in", "subject": "herald_patch",        "var": "Disease", "gold": "pityriasis_rosea"},
+
+    {"id": "resp_silica_dx",   "domain": "resp", "tactic": "recall", "relation": "inhalation_causes", "subject": "silica",      "var": "Disease", "gold": "silicosis"},
+    {"id": "resp_asbestos_dx", "domain": "resp", "tactic": "recall", "relation": "inhalation_causes", "subject": "asbestos",    "var": "Disease", "gold": "asbestosis"},
+    {"id": "resp_beryl_dx",    "domain": "resp", "tactic": "recall", "relation": "inhalation_causes", "subject": "beryllium",   "var": "Disease", "gold": "berylliosis"},
+    {"id": "resp_cotton_dx",   "domain": "resp", "tactic": "recall", "relation": "inhalation_causes", "subject": "cotton_dust", "var": "Disease", "gold": "byssinosis"},
+    {"id": "resp_coal_dx",     "domain": "resp", "tactic": "recall", "relation": "inhalation_causes", "subject": "coal_dust",   "var": "Disease", "gold": "coal_workers_pneumoconiosis"}
   ]
 }

--- a/code/specs/data/mycin-2026/board/test_board_eval.py
+++ b/code/specs/data/mycin-2026/board/test_board_eval.py
@@ -51,7 +51,7 @@ def test_covered_items_answer_correctly_with_a_proof() -> None:
     # answers, so the board scores the top binding per subject (the libraries + their
     # tests cover all edges).
     recall_correct = [r for r in card.results if r.outcome == "correct" and r.tactic == "recall"]
-    assert len(recall_correct) == 117
+    assert len(recall_correct) == 122
     assert by_id["fabry_enzyme"].outcome == "correct"               # IEM
     assert by_id["thiamine_disease"].answer == "beriberi"           # vitamin
     assert by_id["ida_mcv"].answer == "microcytic"                  # anemia
@@ -93,6 +93,11 @@ def test_covered_items_answer_correctly_with_a_proof() -> None:
     assert by_id["derm_em_dx"].answer == "erythema_multiforme"   # dermatology (DERM, Tier-2)
     assert by_id["derm_psoriasis_dx"].answer == "psoriasis"      # derm — skin_finding_in (finding->dx)
     assert by_id["derm_em_dx"].trust == "authoritative"          # ADJ-only edge, grounded inline
+    assert by_id["resp_silica_dx"].answer == "silicosis"         # respiratory (RESP, Tier-2)
+    assert by_id["resp_asbestos_dx"].answer == "asbestosis"      # resp — inhalation_causes (exposure->dz)
+    assert by_id["resp_silica_dx"].trust == "authoritative"      # ADJ-only edge, grounded inline
+    assert by_id["resp_coal_dx"].answer == "coal_workers_pneumoconiosis"  # primary-source-first: no deferral
+    assert by_id["resp_coal_dx"].trust == "authoritative"        # grounded from CDC/NIOSH (cdc.gov), not StatPearls
 
 
 def test_uncovered_items_abstain_not_fabricate() -> None:
@@ -135,8 +140,8 @@ def test_grounded_coverage_is_the_live_grounding_number() -> None:
     # verbatim, so the framework declines to claim grounding it cannot defend, by design:
     # cortisol_def (endocrine, deficiency_syndrome__cortisol — the only verbatim spans frame
     # cortisol deficiency as a consequence/feature of Addison disease, not the named-syndrome identity).
-    assert s["grounded_coverage"] == round(116 / 117, 4)   # 0.9915
-    assert s["grounded_correct"] == 116
+    assert s["grounded_coverage"] == round(121 / 122, 4)   # 0.9918
+    assert s["grounded_correct"] == 121
     by_id = {r.item_id: r for r in card.results}
     assert by_id["tay_sachs_enzyme"].trust == "authoritative"      # IEM
     assert by_id["ida_mcv"].trust == "authoritative"               # anemia

--- a/code/specs/data/mycin-2026/recall/resp-edges.adj
+++ b/code/specs/data/mycin-2026/recall/resp-edges.adj
@@ -1,0 +1,80 @@
+% ============================================================================
+% resp-edges — the occupational-lung-disease knowledge-graph (MYCIN-2026 RESP).
+% ============================================================================
+% A Tier-2 organ-system pathology domain (USMLE-DOMAIN-MAP §"Tier 2", #6 respiratory):
+% the inhaled occupational exposure and the pneumoconiosis it causes. "A sandblaster
+% develops progressive dyspnea — what occupational lung disease?" reduces to the exposure
+% the history names, then the binding query
+%     ? inhalation_causes(silica, $Disease).
+%
+% Direction note: the relation is exposure -> disease (`inhalation_causes`), the board
+% direction — the history gives the dust/fiber exposure and you must name the
+% pneumoconiosis. The cited spans are written disease-first ("Silicosis is occupational
+% pneumoconiosis caused by inhalation of crystalline silicon dioxide"; "Berylliosis ...
+% is a granulomatous disease caused by exposure to beryllium") — what matters for
+% grounding is that one self-contained span names BOTH the exposure AND the disease. Each
+% exposure here maps to one canonical pneumoconiosis, so a query binds a single answer.
+%
+% This file is the SHIPPED ARTIFACT and the SOLE source of truth — no generator, no
+% JSON, no manifest (the twelfth ADJ-only recall domain; eighth Tier-2 organ-system
+% domain after RHEUM, ONCO, HISTO, CARDIO, NEURO, GI, DERM). Each fact is a `relate`
+% clause whose byte-provenance lives INLINE:
+%     source   — the VERBATIM span copied from the cited page (byte-stable: it appears
+%                character-for-character in the page's normalized text).
+%     locator  — the URL the span was read from (NCBI StatPearls / Bookshelf, NIH).
+%     trust    — authoritative (a primary, citable reference).
+% An LLM (or a human) recalls a fact by writing a tiny query .adj that `import`s this
+% library and asks a binding query — see resp-recall.query.adj. Nothing here is asserted
+% "from memory": every edge is defended by a span a reader can re-fetch and check.
+% (See feedback_nothing_human_authored, feedback_adj_only_shipped_artifacts.)
+%
+% Sourcing: every exposure->disease edge is defended by a primary, citable authority that
+% names BOTH the exposure AND the disease in one byte-stable span. Where the StatPearls
+% disease page writes the association finding-first (dropping the disease name), we ground
+% from the primary federal authority on occupational lung disease instead — the CDC/NIOSH
+% pneumoconioses program — rather than declining the edge. (This is the primary-source-
+% first, zero-deferral policy: an association is grounded to a primary source, never
+% omitted for phrasing.) The silica span names the exposure by its chemical form
+% "crystalline silicon dioxide" (= silica).
+% ============================================================================
+
+dictionary resp_vocab {
+    define exposure : entity   surface "occupational exposure", "inhaled dust or fiber"
+    define disease  : entity   surface "pneumoconiosis", "occupational lung disease"
+
+    define inhalation_causes : relation from exposure to disease  % the pneumoconiosis an exposure causes
+}
+
+rulebook resp_facts {
+    use resp_vocab
+
+    % --- silica (crystalline silicon dioxide) -> silicosis ---------------------
+    relate inhalation_causes(silica, silicosis)
+        source "Silicosis is occupational pneumoconiosis caused by inhalation of crystalline silicon dioxide."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK537341/"
+        trust authoritative
+
+    % --- asbestos fibers -> asbestosis -----------------------------------------
+    relate inhalation_causes(asbestos, asbestosis)
+        source "Asbestosis is a chronic, progressive interstitial lung disease caused by inhaling asbestos fibers"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK555985/"
+        trust authoritative
+
+    % --- beryllium -> berylliosis (chronic beryllium disease) ------------------
+    relate inhalation_causes(beryllium, berylliosis)
+        source "Berylliosis, also known as chronic beryllium disease (CBD), is a granulomatous disease caused by exposure to beryllium."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK470364/"
+        trust authoritative
+
+    % --- cotton dust -> byssinosis ---------------------------------------------
+    relate inhalation_causes(cotton_dust, byssinosis)
+        source "Classically, exposure to cotton dust during the spinning and manufacturing process causes byssinosis."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK519549/"
+        trust authoritative
+
+    % --- coal mine dust -> coal workers' pneumoconiosis (CDC/NIOSH primary source) ---
+    relate inhalation_causes(coal_dust, coal_workers_pneumoconiosis)
+        source "Coal workers' pneumoconiosis or black lung is caused by inhaling coal mine dust and can be severe."
+        locator "https://www.cdc.gov/niosh/cwhsp/about/index.html"
+        trust authoritative
+}

--- a/code/specs/data/mycin-2026/recall/resp-recall.query.adj
+++ b/code/specs/data/mycin-2026/recall/resp-recall.query.adj
@@ -1,0 +1,20 @@
+% ============================================================================
+% resp-recall.query.adj — a worked recall query over the occupational-lung library.
+% ============================================================================
+% The shape an LLM (or a clinician) produces to ANSWER a "this exposure causes which
+% occupational lung disease?" question: it states no respiratory fact — it only `import`s
+% the grounded library and asks binding queries. The native adj-lang engine resolves each
+% `?` against the imported `relate` edges and returns the binding + the citing clause's
+% source/locator/trust. All knowledge is in the library; none is here.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli resp-recall.query.adj
+% ============================================================================
+
+import "resp-edges.adj"
+
+? inhalation_causes(silica, $Disease)       % expect silicosis
+? inhalation_causes(asbestos, $Disease)     % expect asbestosis
+? inhalation_causes(beryllium, $Disease)    % expect berylliosis
+? inhalation_causes(cotton_dust, $Disease)  % expect byssinosis
+? inhalation_causes(coal_dust, $Disease)    % expect coal_workers_pneumoconiosis

--- a/code/specs/data/mycin-2026/recall/test_resp_recall.py
+++ b/code/specs/data/mycin-2026/recall/test_resp_recall.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""test_resp_recall.py — the ADJ-only occupational-lung-disease library (MYCIN-2026 RESP).
+
+The twelfth recall domain shipped as a pure ADJ artifact (eighth Tier-2 organ-system
+domain, after RHEUM, ONCO, HISTO, CARDIO, NEURO, GI, DERM). `resp-edges.adj` is the SOLE
+source of truth — facts + byte-provenance inline, no Python gate, no JSON, no manifest.
+This test pins the property that matters: the native adj-lang engine, given a query .adj
+that only `import`s the library and asks binding queries (`resp-recall.query.adj` — the
+shape an LLM produces), binds the grounded pneumoconiosis for each exposure, each carrying
+an AUTHORITATIVE citation with a real source span + locator. Knowledge lives in ADJ; the
+engine answers.
+
+If the native CLI isn't built (a Python-only CI lane), the engine-backed checks skip —
+the file-shape checks (every clause grounded, no authored-debt) still run.
+
+Run:  python3 test_resp_recall.py
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+ADJ = HERE / "resp-edges.adj"
+QUERY = HERE / "resp-recall.query.adj"
+CLI = HERE.parents[3] / "packages" / "rust" / "target" / "debug" / "adj-lang-cli"
+
+# Every grounded edge: occupational exposure -> the pneumoconiosis the library binds.
+EXPECTED = {
+    "silica": "silicosis",
+    "asbestos": "asbestosis",
+    "beryllium": "berylliosis",
+    "cotton_dust": "byssinosis",
+    "coal_dust": "coal_workers_pneumoconiosis",
+}
+# Every edge cites a primary authority; we accept any of the recognized authoritative
+# hosts (NCBI StatPearls/Bookshelf and CDC/NIOSH), not a single hardcoded domain — the
+# primary-source-first policy grounds an edge wherever the clean both-endpoints span lives.
+_AUTH_HOSTS = ("https://www.ncbi.nlm.nih.gov/", "https://www.cdc.gov/")
+REL = "inhalation_causes"
+VAR = "Disease"
+
+
+def _cli_available() -> bool:
+    return CLI.exists()
+
+
+def _run(program: Path) -> dict:
+    out = subprocess.run([str(CLI), str(program)], capture_output=True, text=True,
+                         cwd=str(HERE), timeout=60)
+    assert out.returncode == 0, f"adj-lang-cli failed: {out.stderr}"
+    return json.loads(out.stdout)
+
+
+# ---- 1. the ADJ file is the artifact — every clause grounded, no authored-debt ----
+
+def test_library_is_pure_adj_and_fully_grounded() -> None:
+    text = ADJ.read_text()
+    assert "trust consensus" not in text, "RESP ships no authored-debt; ground or omit"
+    assert "[FLAG:" not in text
+    edge_count = len(EXPECTED)  # 4
+    assert text.count("    relate ") == edge_count
+    assert text.count("trust authoritative") == edge_count
+    assert text.count('\n        locator "') == edge_count
+    assert text.count('\n        source "') == edge_count
+    assert not (HERE / "resp_edge_ground.py").exists()
+    assert not (HERE / "resp-edge-grounding.json").exists()
+    assert not (HERE / "resp-edge-manifest.json").exists()
+
+
+# ---- 2. the engine binds each pneumoconiosis, each with an authoritative citation ----
+
+def test_engine_binds_every_disease_with_authoritative_citation() -> None:
+    if not _cli_available():
+        return
+    result = _run(QUERY)
+    by_query = {r["query"]: r for r in result["recall"]}
+    for exposure, disease in EXPECTED.items():
+        q = f"{REL}({exposure}, {VAR})"
+        r = by_query.get(q)
+        assert r is not None and not r["abstained"], f"{q} abstained — edge missing?"
+        bound = {}
+        for a in r["answers"]:
+            bound[a["bindings"][VAR]] = (a.get("citations") or [{}])[0]
+        assert set(bound) == {disease}, f"{exposure}: bound {set(bound)} != {{{disease}}}"
+        cite = bound[disease]
+        assert cite.get("trust") == "authoritative", f"{exposure}/{disease} not authoritative"
+        assert cite.get("source"), f"{exposure}/{disease} has no source span"
+        assert cite.get("locator", "").startswith(_AUTH_HOSTS), f"{exposure} locator not a primary host"
+
+
+# ---- 3. an off-vocabulary exposure abstains, never fabricates ----------------------
+
+def test_unknown_exposure_abstains() -> None:
+    if not _cli_available():
+        return
+    import os
+    import tempfile
+    fd, path = tempfile.mkstemp(suffix=".adj", prefix=".resp_q_", dir=HERE)
+    try:
+        with os.fdopen(fd, "w") as fh:
+            # tobacco_smoke is not in the library → must abstain
+            fh.write(f'import "resp-edges.adj"\n? {REL}(tobacco_smoke, ${VAR})\n')
+        res = _run(Path(path))
+        r = res["recall"][0] if res["recall"] else None
+        assert r is not None and r["abstained"], "an ungrounded exposure must abstain"
+    finally:
+        os.unlink(path)
+
+
+def _run_all() -> int:
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    failed = 0
+    for t in tests:
+        try:
+            t()
+            print(f"  PASS  {t.__name__}")
+        except AssertionError as exc:
+            failed += 1
+            print(f"  FAIL  {t.__name__}: {exc}")
+    print(f"\ntest_resp_recall: {len(tests) - failed}/{len(tests)} passed")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(_run_all())


### PR DESCRIPTION
## What

The **twelfth ADJ-only recall domain** (eighth Tier-2 organ-system): inhaled occupational **exposure → pneumoconiosis**. `recall/resp-edges.adj` is the sole shipped artifact — facts + **inline byte-provenance**, no Python gate, no JSON, no manifest. Query shape: `? inhalation_causes(<exposure>, $Disease)`.

## The five edges (each a byte-stable verbatim span naming BOTH exposure AND disease)

| exposure | pneumoconiosis | source |
|---|---|---|
| silica | silicosis | StatPearls NBK537341 |
| asbestos | asbestosis | StatPearls NBK555985 |
| beryllium | berylliosis | StatPearls NBK470364 |
| cotton dust | byssinosis | StatPearls NBK519549 |
| **coal dust** | **coal workers' pneumoconiosis** | **CDC/NIOSH — cdc.gov/niosh/cwhsp** |

## Primary-source-first, zero-deferral policy (new)

An association is grounded to whatever **primary authority** carries a clean both-endpoints span — **never declined for phrasing**. `coal_dust → CWP` is the first edge sourced **outside StatPearls**: its StatPearls page writes the association finding-first (dropping the disease name), so it is grounded instead from the **primary federal authority on occupational lung disease, CDC/NIOSH** — *"Coal workers' pneumoconiosis or black lung is caused by inhaling coal mine dust..."*. The board harness now recognizes a set of authoritative hosts (NCBI + CDC), not one hardcoded domain.

## Verification
- `test_resp_recall.py` **3/3** — engine binds every pneumoconiosis with an authoritative citation (locator from NCBI **or** CDC); off-vocab exposure (`tobacco_smoke`) abstains.
- `test_board_eval.py` **12/12** — recall 117→**122** correct, grounded 116→**121** (121/122 = **0.9918**), **0 wrong**, **defensibility 1.0**.
- Security review: **PASSED**.

## Wiring
`resp-edges.adj` → `EDGE_FILES` in `board_eval.py` + `decompose_query.py`; `REL_VAR["inhalation_causes"]="Disease"` (33 relations / sixteen domains); 5 board items; scorecard regenerated; USMLE-DOMAIN-MAP updated.

> Note: `code/specs/data/mycin-2026` is not wired into CI (no BUILD file); local runs above are the verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)