### PR TITLE
docs(specs): CLOC18 — parameter-mutation materialization in inline

### DIFF
--- a/code/specs/CLOC18-parameter-mutation-materialization.md
+++ b/code/specs/CLOC18-parameter-mutation-materialization.md
@@ -1,0 +1,155 @@
+# CLOC18 — parameter-mutation materialization in `inline`
+
+**Status:** SPEC (design complete, no open questions). Implementation deferred
+to a focused follow-up because this **reverses the 0.13.1 soundness guard**
+(`closure-pass-inline` PR #6272, which *declines* helpers that reassign a
+parameter) and replaces it with a *sound transform*. Reversing a safety guard
+is categorically riskier than the additive inline slices around it (value
+capture, `var` locals), so it is specced before the change per the repo's
+specs-first standard.
+
+## Motivation
+
+The inliner substitutes each parameter occurrence with its **argument
+expression**, treating the parameter as an immutable value. A helper that
+*reassigns* a parameter therefore cannot be inlined that way — `function f(x){
+x = x + 1; return x; }` at `var g = f(7)` would miscompile to `g = 7` (the
+pre-assignment argument) instead of `8`. PR #6272 made this **sound by
+declining** such helpers (`body_assigns_to_param` → `return None`).
+
+Parameter reassignment is *ubiquitous* in real JavaScript — the
+default-argument idiom `function f(x){ x = x || DEFAULT; … }`, accumulator
+loops, normalization (`x = String(x)`), etc. Declining all of them leaves a
+large class of real helpers un-inlined. CLOC18 makes them inlinable by
+**materialising the mutated parameter into a fresh mutable local seeded from the
+argument**, which is exactly the semantics a real call has.
+
+## The core finding (why a mutated param can't use `substitute`)
+
+`substitute` (`closure-pass-inline/src/lib.rs`, the `AssignmentExpression`
+arm, ~L1120) **deliberately does not rewrite a bare-identifier assignment
+target**:
+
+```rust
+Expression::AssignmentExpression(ae) => {
+    // ... only the member-object side and the RHS are substituted;
+    // a bare-identifier target is left as-is (substituting a literal
+    // there is impossible and an identifier target keeps the write
+    // well-defined).
+    if let AssignmentTarget::MemberExpression(m) = &mut ae.left { /* … */ }
+    substitute(&mut ae.right, map);
+}
+```
+
+So routing a mutated parameter through `substitute` would leave `x = x + 1`'s
+target `x` untouched (writing a stray global) while rewriting the RHS — the
+exact #6272 miscompile. The **`rename` walk**, by contrast, *does* rewrite a
+bare-identifier assignment target (`rename_in_expr`'s `AssignmentExpression`
+arm renames `AssignmentTarget::Identifier`). Therefore a mutated parameter must
+flow through the **rename** path, not the **substitute** path.
+
+## Design
+
+Treat a mutated parameter like a callee **local** seeded from the argument:
+
+1. **Materialise** it once into a fresh, *mutable* binding at the top of the
+   spliced body: `let <p_fresh> = <arg>;`. Always materialise (even a simple
+   argument) — you cannot reassign a substituted literal or a caller-scope
+   identifier, and the argument must be evaluated exactly once regardless of
+   how many times the parameter is read or written.
+2. **Route the parameter through the rename map** (`<p> → <p_fresh>`), so every
+   read *and every assignment target* of the parameter in the body (and, for
+   the value-capture path, in the captured return expression) becomes
+   `<p_fresh>`.
+
+This is observationally identical to a real call: a parameter is a local
+binding initialised from the argument value; reassigning it never affects the
+caller's argument (JS is pass-by-value — the binding holds a copy of the
+primitive or a copy of the object *reference*); and the argument is evaluated
+once. The fresh `let` is block-scoped, but because `<p_fresh>` appears nowhere
+else in the program (minted from the `avoid` set) the scoping is inert — the
+same argument that makes `var`-local admission sound (CLOC15 Open Q3).
+
+**Member targets are unaffected.** `x.k = 5` mutates a *property* of the
+argument, not the parameter binding, so `x` is not a "mutated parameter"; it
+stays on the substitute path (`arg.k = 5`), exactly as today.
+
+### Worked example (the #6272 case, now inlined correctly)
+
+```js
+function f(x){ x = x + 1; return x; } var g = f(7); use(g);
+// CLOC18 (inline pass):
+//   let p = 7; p = p + 1; const t = p; var g = t; use(g);
+// SIMPLE (after fold/propagate/DCE):
+//   var g = 8; use(g);   ✓  (was g = 7 — a miscompile — before #6272 declined it)
+```
+
+## Implementation plan
+
+All in `code/packages/rust/closure-pass-inline/src/lib.rs`.
+
+1. **`VoidStmtCandidate`** — add `mutated_params: HashSet<String>`.
+2. **Candidate filter** (`void_candidate_from_function`) — replace the #6272
+   decline
+   ```rust
+   if body_assigns_to_param(&fd.body.body, &param_set) { return None; }
+   ```
+   with a collector that records the mutated set and stores it on the
+   candidate:
+   ```rust
+   let mutated_params = collect_mutated_params(&fd.body.body, &param_set);
+   ```
+   Convert the existing `body_assigns_to_param` / `stmt_assigns_to_param` /
+   `expr_assigns_to_param` (bool) walkers into `collect_*` variants that insert
+   matched parameter names into an out-set (same traversal — every expression
+   position, `AssignmentTarget::Identifier` targets only).
+3. **`materialize_args`** — return a **3-tuple** `(prelude, substitute_map,
+   mutated_rename)`:
+   - Fast path (no prelude, direct substitution) only when **all args are
+     simple AND `cand.mutated_params` is empty**.
+   - Otherwise, per `(param, arg)` in source order, mint a fresh temp:
+     - param **mutated** ⇒ emit `let <fresh> = <arg>;`, insert `param → <fresh>`
+       into `mutated_rename`;
+     - param **not mutated** ⇒ emit `const <fresh> = <arg>;`, insert
+       `param → Identifier(<fresh>)` into `substitute_map` (today's behaviour).
+4. **`build_spliced_body`** and **`build_captured_body`** — merge
+   `mutated_rename` into the local-`rename` map, apply rename when
+   `!rename.is_empty()` (not `!cand.locals.is_empty()`), then substitute with
+   `substitute_map`. `build_captured_body` must also rename the captured
+   `return_value` with the merged map (it already does for locals).
+
+## Tests
+
+- **Flip** the three #6272 decline tests (`does_not_inline_helper_that_reassigns_param`,
+  `…compound_param_assignment`, `…nested_param_assignment`) to
+  materialisation-positive assertions.
+- Add: a **value-capture** mutated-param case computing the correct value
+  (`var g = f(7)` ⇒ `g === 8` after fold), a **multi-parameter mixed**
+  case (one mutated, one not — mutated gets `let`+rename, other substitutes),
+  a **side-effecting argument evaluated once** case (`f(side())` with a mutated
+  param materialises `side()` once into the `let`), and a **collision** case (a
+  caller binding sharing the parameter's spelling is untouched).
+- Confirm **no closurec fixture churn** beyond programs that now inline where
+  they previously did not.
+
+## Soundness checklist (for the implementation's adversarial review)
+
+- The materialised binding is reassignable (`let`, not `const`).
+- The argument is evaluated **exactly once** (into the `let`), even when the
+  parameter is read/written multiple times.
+- `<p_fresh>` is program-fresh (from `avoid`), so the `let`'s block scope is
+  inert and cannot collide with or shadow any caller binding.
+- A mutated parameter never reaches `substitute` (which would drop the target
+  rewrite) — it is in `mutated_rename`, applied by the target-aware `rename`.
+- Member-target writes through a parameter (`x.k = …`) are **not** treated as
+  parameter mutation and keep substituting.
+- Interaction with the **multi-use void path**: each splice mints distinct
+  fresh `let` names from a growing `avoid` set, so N call sites get N
+  independent materialised locals — confirm no cross-site aliasing.
+
+## Downstream
+
+Once CLOC18 lands, the 0.13.1 parameter-mutation guard is fully superseded for
+the common cases; the only remaining declines would be parameter mutation via
+forms the typed AST cannot represent (e.g. `++`/`--` `UpdateExpression`, still
+Phase 2) — which therefore cannot occur and need no handling.


### PR DESCRIPTION
## Summary

Specs the next `inline` slice: make helpers that **reassign a parameter** inlinable. They are currently **declined** by the 0.13.1 soundness guard ([#6272](https://github.com/adhithyan15/coding-adventures/pull/6272)); CLOC18 makes them inlinable by **materialising each mutated parameter into a fresh mutable local seeded from the argument** — exactly a real call's semantics.

Parameter reassignment is ubiquitous in real JS (`function f(x){ x = x || DEFAULT; … }`, accumulators, normalization), so declining all of it leaves a large class of real helpers un-inlined.

## Why spec-first

This **reverses a just-shipped soundness guard** (#6272). If implemented subtly wrong it re-ships the exact miscompile #6272 fixed (`g = 7` instead of `8`). That makes it categorically riskier than the surrounding *additive* inline slices (value capture, `var` locals), so — per the repo's specs-first standard and "soundness over cleverness" — the design is pinned in a spec before the change. **The design is complete with no open questions.**

## Key content

- **Core finding**: `substitute` *deliberately* does not rewrite a bare-identifier assignment target ("substituting a literal there is impossible"), so a mutated parameter must flow through the target-aware **`rename`** walk, not `substitute`. This is the non-obvious insight that makes the whole slice tractable.
- **Plan**: `materialize_args` → `(prelude, substitute_map, mutated_rename)`; a mutated param emits `let <fresh> = <arg>` (always — even simple args) and routes `param → <fresh>` through the rename map merged at both splice sites; fast path requires all-simple args **and** no mutated params.
- **Soundness**: materialised param = pass-by-value copy; reassigning the local never affects the caller's argument; argument evaluated once; the fresh `let` is program-fresh so its block scope is inert (same argument as CLOC15 `var` locals). Member-target writes (`x.k =`) stay on `substitute`.
- **Worked example**: `function f(x){ x = x+1; return x } var g = f(7)` now inlines to the correct `var g = 8`.
- **Test plan + soundness checklist** for the implementation's adversarial review (flip #6272's three decline tests; add value-capture, multi-param-mixed, side-effecting-arg-once, collision cases).

Pure documentation — no code or security surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)