### PR TITLE
feat(mini-sqlite): column-level ON CONFLICT clause in CREATE TABLE (v2.27.0)

### DIFF
--- a/code/grammars/sql.grammar
+++ b/code/grammars/sql.grammar
@@ -262,11 +262,24 @@ col_def           = NAME col_type { col_constraint } ;
 # (VARCHAR(8), DECIMAL(10,2)) — the length/precision arguments are parsed
 # but ignored; the engine uses SQLite's type-affinity rules internally.
 col_type          = NAME [ "(" NUMBER { "," NUMBER } ")" ] ;
-col_constraint    = ( "NOT" "NULL" ) | "NULL" | ( "PRIMARY" "KEY" [ "AUTOINCREMENT" ] )
-                  | "UNIQUE" | ( "DEFAULT" primary )
+col_constraint    = ( "NOT" "NULL" [ col_conflict_clause ] ) | "NULL"
+                  | ( "PRIMARY" "KEY" [ "AUTOINCREMENT" ] [ col_conflict_clause ] )
+                  | ( "UNIQUE" [ col_conflict_clause ] )
+                  | ( "DEFAULT" primary )
                   | ( "CHECK" "(" expr ")" )
                   | ( "COLLATE" NAME )
                   | ( "REFERENCES" NAME [ "(" NAME ")" ] ) ;
+# Column-level conflict clause — parsed and accepted but not enforced.
+# SQLite allows each constraint to carry its own conflict-resolution policy:
+#   x INT NOT NULL ON CONFLICT REPLACE
+#   x INT UNIQUE ON CONFLICT IGNORE
+# Mini-sqlite always uses ABORT semantics; these clauses are silently ignored.
+# col_conflict_clause is a nested sub-rule so its keyword tokens do NOT
+# appear as direct children of col_constraint — the adapter's kw_seq logic
+# sees only the constraint-type keywords (NOT NULL, PRIMARY KEY, UNIQUE) and
+# is unaffected.
+col_conflict_clause = "ON" "CONFLICT"
+                      ( "ROLLBACK" | "ABORT" | "FAIL" | "IGNORE" | "REPLACE" ) ;
 # AUTOINCREMENT (SQLite-only): only valid immediately after PRIMARY KEY on
 # an INTEGER column.  The engine recognises the keyword and sets
 # ``ColumnDef.autoincrement = True``; behaviour is "rowids monotonically

--- a/code/packages/python/mini-sqlite/CHANGELOG.md
+++ b/code/packages/python/mini-sqlite/CHANGELOG.md
@@ -1,5 +1,45 @@
 # Changelog
 
+## [2.27.0] - 2026-06-19
+
+### Fixed
+
+- **Column-level `ON CONFLICT` clause now accepted in `CREATE TABLE`** —
+  SQLite allows each `NOT NULL`, `UNIQUE`, and `PRIMARY KEY` column
+  constraint to carry its own conflict-resolution policy:
+
+  ```sql
+  CREATE TABLE t (x INT NOT NULL ON CONFLICT IGNORE, y TEXT)
+  CREATE TABLE t (x INT UNIQUE ON CONFLICT REPLACE, y TEXT)
+  CREATE TABLE t (x INT PRIMARY KEY ON CONFLICT ABORT, y TEXT)
+  CREATE TABLE t (x INTEGER PRIMARY KEY AUTOINCREMENT ON CONFLICT REPLACE, y TEXT)
+  ```
+
+  Previously all such forms raised a parse error.  The fix adds an optional
+  nested `col_conflict_clause` sub-rule to `col_constraint` in `sql.grammar`.
+  Using a *nested* sub-rule is deliberate: the adapter's keyword-sequence
+  matching in `_col_def` collects only the *direct* keyword children of each
+  `col_constraint` node, so the `ON / CONFLICT / action` tokens stay inside
+  the sub-node and existing logic (`NOT NULL → not_null=True`, `UNIQUE →
+  unique=True`, etc.) is completely unaffected.
+
+  Mini-sqlite always uses `ABORT` semantics for constraint violations; the
+  per-column action is parsed and silently ignored.
+
+  | SQL form                                              | Before      | After |
+  |-------------------------------------------------------|-------------|-------|
+  | `x INT NOT NULL ON CONFLICT IGNORE`                   | Parse error | OK    |
+  | `x INT NOT NULL ON CONFLICT REPLACE`                  | Parse error | OK    |
+  | `x INT UNIQUE ON CONFLICT ABORT`                      | Parse error | OK    |
+  | `x INT PRIMARY KEY ON CONFLICT FAIL`                  | Parse error | OK    |
+  | `x INT PRIMARY KEY AUTOINCREMENT ON CONFLICT REPLACE` | Parse error | OK    |
+  | All five actions: ROLLBACK, ABORT, FAIL, IGNORE, REPLACE | Parse error | OK |
+
+- **26 new oracle tests** in `test_tier3_col_conflict_clause.py` cover
+  all three constraint types × all five conflict actions, mixed
+  multi-column tables, COLLATE coexistence, table-level constraint
+  coexistence, and WITHOUT ROWID.
+
 ## [2.26.0] - 2026-06-16
 
 ### Fixed

--- a/code/packages/python/mini-sqlite/pyproject.toml
+++ b/code/packages/python/mini-sqlite/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-mini-sqlite"
-version = "2.26.0"
+version = "2.27.0"
 description = "PEP 249 DB-API 2.0 facade over the sql-lexer / parser / planner / optimizer / codegen / vm / backend stack."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/mini-sqlite/tests/test_tier3_col_conflict_clause.py
+++ b/code/packages/python/mini-sqlite/tests/test_tier3_col_conflict_clause.py
@@ -1,0 +1,207 @@
+"""Oracle tests: column-level ON CONFLICT clause in CREATE TABLE.
+
+SQLite lets each NOT NULL, UNIQUE, and PRIMARY KEY column constraint carry
+its own conflict-resolution policy via an optional ``ON CONFLICT`` suffix::
+
+    x INT NOT NULL ON CONFLICT IGNORE
+    x INT UNIQUE ON CONFLICT REPLACE
+    x INT PRIMARY KEY ON CONFLICT ABORT
+
+Previously mini-sqlite raised a parse error for every such form because
+the ``col_constraint`` grammar rule did not include the optional clause.
+The fix adds a nested ``col_conflict_clause`` sub-rule so the adapter's
+keyword-sequence matching remains unaffected (the ON/CONFLICT/action
+keywords live in the sub-node, not in col_constraint's direct children).
+
+Mini-sqlite does not enforce the per-column conflict action — it always
+uses ABORT semantics on constraint violations.  The tests confirm that:
+
+  1. All five actions (ROLLBACK, ABORT, FAIL, IGNORE, REPLACE) parse
+     without error on all three constraint types.
+  2. The schema is usable: rows can be inserted and queried normally.
+  3. The explicit ABORT action (which *is* mini-sqlite's default) matches
+     real SQLite behaviour end-to-end via oracle comparison.
+
+Pattern: every oracle test runs the same SQL against both sqlite3 (the
+reference engine) and mini_sqlite and asserts byte-for-byte identical
+output.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+import mini_sqlite
+
+
+def _ref(sql: str, setup: list[str] | None = None) -> list[tuple]:
+    con = sqlite3.connect(":memory:")
+    if setup:
+        for s in setup:
+            con.execute(s)
+    return con.execute(sql).fetchall()
+
+
+def _our(sql: str, setup: list[str] | None = None) -> list[tuple]:
+    con = mini_sqlite.connect(":memory:")
+    if setup:
+        for s in setup:
+            con.execute(s)
+    return con.execute(sql).fetchall()
+
+
+def _our_exec(sql: str) -> None:
+    mini_sqlite.connect(":memory:").execute(sql)
+
+
+class TestNotNullOnConflict:
+    """NOT NULL with each conflict action."""
+
+    def test_not_null_ignore_parses(self) -> None:
+        _our_exec("CREATE TABLE t (x INT NOT NULL ON CONFLICT IGNORE, y TEXT)")
+
+    def test_not_null_replace_parses(self) -> None:
+        _our_exec("CREATE TABLE t (x INT NOT NULL ON CONFLICT REPLACE, y TEXT)")
+
+    def test_not_null_abort_parses(self) -> None:
+        _our_exec("CREATE TABLE t (x INT NOT NULL ON CONFLICT ABORT, y TEXT)")
+
+    def test_not_null_fail_parses(self) -> None:
+        _our_exec("CREATE TABLE t (x INT NOT NULL ON CONFLICT FAIL, y TEXT)")
+
+    def test_not_null_rollback_parses(self) -> None:
+        _our_exec("CREATE TABLE t (x INT NOT NULL ON CONFLICT ROLLBACK, y TEXT)")
+
+    def test_not_null_abort_insert_and_select(self) -> None:
+        """ABORT is mini-sqlite's native behaviour — full oracle comparison."""
+        sql = "SELECT x, y FROM t ORDER BY x"
+        setup = [
+            "CREATE TABLE t (x INT NOT NULL ON CONFLICT ABORT, y TEXT)",
+            "INSERT INTO t VALUES (1, 'a')",
+            "INSERT INTO t VALUES (2, 'b')",
+        ]
+        assert _our(sql, setup) == _ref(sql, setup)
+
+    def test_not_null_with_default(self) -> None:
+        """ON CONFLICT may coexist with a DEFAULT clause."""
+        sql = "SELECT x FROM t"
+        setup = [
+            "CREATE TABLE t (x INT NOT NULL ON CONFLICT ABORT DEFAULT 0, y TEXT)",
+            "INSERT INTO t (y) VALUES ('hello')",
+        ]
+        assert _our(sql, setup) == _ref(sql, setup)
+
+    def test_pragma_table_info_not_null_flag(self) -> None:
+        """NOT NULL ON CONFLICT must still register notnull=1 in table_info."""
+        setup = ["CREATE TABLE t (x INT NOT NULL ON CONFLICT ABORT, y TEXT)"]
+        sql = "PRAGMA table_info('t')"
+        assert _our(sql, setup) == _ref(sql, setup)
+
+
+class TestUniqueOnConflict:
+    """UNIQUE with each conflict action."""
+
+    def test_unique_ignore_parses(self) -> None:
+        _our_exec("CREATE TABLE t (x INT UNIQUE ON CONFLICT IGNORE, y TEXT)")
+
+    def test_unique_replace_parses(self) -> None:
+        _our_exec("CREATE TABLE t (x INT UNIQUE ON CONFLICT REPLACE, y TEXT)")
+
+    def test_unique_abort_parses(self) -> None:
+        _our_exec("CREATE TABLE t (x INT UNIQUE ON CONFLICT ABORT, y TEXT)")
+
+    def test_unique_fail_parses(self) -> None:
+        _our_exec("CREATE TABLE t (x INT UNIQUE ON CONFLICT FAIL, y TEXT)")
+
+    def test_unique_rollback_parses(self) -> None:
+        _our_exec("CREATE TABLE t (x INT UNIQUE ON CONFLICT ROLLBACK, y TEXT)")
+
+    def test_unique_abort_insert_and_select(self) -> None:
+        sql = "SELECT x, y FROM t ORDER BY x"
+        setup = [
+            "CREATE TABLE t (x INT UNIQUE ON CONFLICT ABORT, y TEXT)",
+            "INSERT INTO t VALUES (1, 'a')",
+            "INSERT INTO t VALUES (2, 'b')",
+        ]
+        assert _our(sql, setup) == _ref(sql, setup)
+
+    def test_pragma_table_info_unique_abort(self) -> None:
+        setup = ["CREATE TABLE t (x INT UNIQUE ON CONFLICT ABORT, y TEXT)"]
+        sql = "PRAGMA table_info('t')"
+        assert _our(sql, setup) == _ref(sql, setup)
+
+
+class TestPrimaryKeyOnConflict:
+    """PRIMARY KEY with each conflict action."""
+
+    def test_pk_ignore_parses(self) -> None:
+        _our_exec("CREATE TABLE t (x INT PRIMARY KEY ON CONFLICT IGNORE, y TEXT)")
+
+    def test_pk_replace_parses(self) -> None:
+        _our_exec("CREATE TABLE t (x INT PRIMARY KEY ON CONFLICT REPLACE, y TEXT)")
+
+    def test_pk_abort_parses(self) -> None:
+        _our_exec("CREATE TABLE t (x INT PRIMARY KEY ON CONFLICT ABORT, y TEXT)")
+
+    def test_pk_fail_parses(self) -> None:
+        _our_exec("CREATE TABLE t (x INT PRIMARY KEY ON CONFLICT FAIL, y TEXT)")
+
+    def test_pk_rollback_parses(self) -> None:
+        _our_exec("CREATE TABLE t (x INT PRIMARY KEY ON CONFLICT ROLLBACK, y TEXT)")
+
+    def test_pk_abort_insert_and_select(self) -> None:
+        sql = "SELECT x, y FROM t ORDER BY x"
+        setup = [
+            "CREATE TABLE t (x INT PRIMARY KEY ON CONFLICT ABORT, y TEXT)",
+            "INSERT INTO t VALUES (1, 'a')",
+            "INSERT INTO t VALUES (2, 'b')",
+        ]
+        assert _our(sql, setup) == _ref(sql, setup)
+
+    def test_pk_autoincrement_with_conflict(self) -> None:
+        """PRIMARY KEY AUTOINCREMENT ON CONFLICT must parse."""
+        _our_exec(
+            "CREATE TABLE t (x INTEGER PRIMARY KEY AUTOINCREMENT ON CONFLICT REPLACE, y TEXT)"
+        )
+
+
+class TestMixedConstraints:
+    """ON CONFLICT may coexist with other column and table constraints."""
+
+    def test_multiple_cols_different_actions(self) -> None:
+        """Different ON CONFLICT actions on different columns in one table."""
+        sql = "SELECT x, y FROM t ORDER BY x"
+        setup = [
+            "CREATE TABLE t ("
+            "x INT NOT NULL ON CONFLICT ABORT, "
+            "y TEXT UNIQUE ON CONFLICT IGNORE"
+            ")",
+            "INSERT INTO t VALUES (1, 'a')",
+            "INSERT INTO t VALUES (2, 'b')",
+        ]
+        assert _our(sql, setup) == _ref(sql, setup)
+
+    def test_col_conflict_plus_collate(self) -> None:
+        """UNIQUE ON CONFLICT and COLLATE NOCASE on the same column."""
+        sql = "SELECT x FROM t ORDER BY x"
+        setup = [
+            "CREATE TABLE t (x TEXT UNIQUE ON CONFLICT ABORT COLLATE NOCASE)",
+            "INSERT INTO t VALUES ('hello')",
+        ]
+        assert _our(sql, setup) == _ref(sql, setup)
+
+    def test_col_conflict_plus_table_constraint(self) -> None:
+        """Column-level ON CONFLICT and table-level constraint in the same DDL."""
+        sql = "SELECT x, y FROM t ORDER BY x"
+        setup = [
+            "CREATE TABLE t (x INT NOT NULL ON CONFLICT ABORT, y INT, UNIQUE(y))",
+            "INSERT INTO t VALUES (1, 10)",
+            "INSERT INTO t VALUES (2, 20)",
+        ]
+        assert _our(sql, setup) == _ref(sql, setup)
+
+    def test_without_rowid_plus_pk_conflict(self) -> None:
+        """PRIMARY KEY ON CONFLICT ABORT plus WITHOUT ROWID must parse."""
+        _our_exec(
+            "CREATE TABLE t (x INT PRIMARY KEY ON CONFLICT ABORT, y TEXT) WITHOUT ROWID"
+        )


### PR DESCRIPTION
## Summary

- Adds optional `ON CONFLICT` suffix to `NOT NULL`, `UNIQUE`, and `PRIMARY KEY` column constraints in `CREATE TABLE` DDL — previously these raised a parse error
- Implemented as a nested `col_conflict_clause` sub-rule in `sql.grammar`; the adapter's `kw_seq` matching logic is completely unaffected (ON/CONFLICT/action keywords live in the sub-node, invisible to direct-children traversal)
- Mini-sqlite always uses ABORT semantics for constraint violations; the per-column conflict action is parsed and silently accepted

## Changes

- `code/grammars/sql.grammar` — adds `col_conflict_clause` rule; updates `col_constraint` alternatives for NOT NULL, PRIMARY KEY, UNIQUE
- `code/packages/python/mini-sqlite/tests/test_tier3_col_conflict_clause.py` — 26 new oracle tests covering all 5 actions × 3 constraint types, AUTOINCREMENT+conflict, COLLATE coexistence, table-level constraint coexistence, WITHOUT ROWID
- `code/packages/python/mini-sqlite/CHANGELOG.md` — 2.27.0 entry
- `code/packages/python/mini-sqlite/pyproject.toml` — version 2.26.0 → 2.27.0

## Test plan

- [ ] All 26 new oracle tests pass (`test_tier3_col_conflict_clause.py`)
- [ ] Full test suite passes with ≥80% coverage
- [ ] `ruff` passes clean on the new test file
- [ ] `NOT NULL ON CONFLICT IGNORE/REPLACE/ABORT/FAIL/ROLLBACK` all parse without error
- [ ] `UNIQUE ON CONFLICT *` and `PRIMARY KEY ON CONFLICT *` likewise
- [ ] `PRAGMA table_info` still reports correct `notnull` flag after constraint with conflict clause

🤖 Generated with [Claude Code](https://claude.com/claude-code)