### PR TITLE
feat(r-18): switch() and error handling — stop, warning, tryCatch

### DIFF
--- a/code/packages/rust/r-runtime/CHANGELOG.md
+++ b/code/packages/rust/r-runtime/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.13.0] - 2026-06-19
+
+### Added (via the shared `s-runtime`)
+
+- **R-18 — `switch()` + error handling**: the value-returning multi-way branch
+  and condition-based error handling reach R unchanged through the shared
+  evaluator. **`switch(EXPR, ...)`** is lazy (only the chosen arm evaluates):
+  character `EXPR` matches arm names (unnamed final arm = default; no match and
+  no default → `NULL`); numeric `EXPR` selects the n-th arm by position (out of
+  range → `NULL`) — so `switch("a", a = "ok", b = stop("x"))` does not raise.
+  **`stop(...)`** raises an error (concatenated message); **`warning(...)`** emits
+  a warning and returns invisibly without aborting; **`tryCatch(expr, error = fn,
+  finally = cleanup)`** runs `expr`, routes any error to `error` (called with a
+  minimal condition object so `conditionMessage(e)` and `e$message` give the
+  message), and always runs `finally`. *(Empty-arm fall-through is deferred to
+  R-19 — it needs a grammar production for empty args.)* See `s-runtime` 0.14.0.
+
 ## [0.12.0] - 2026-06-17
 
 ### Added (via the shared `s-runtime`)

--- a/code/packages/rust/r-runtime/README.md
+++ b/code/packages/rust/r-runtime/README.md
@@ -38,6 +38,14 @@ positional and named arguments (`do.call(paste, list("a", "b", sep = "-"))` →
 `"a-b"`); `modifyList(x, val)` overlays `val` onto `x` by name (replace / append
 / `NULL` removes); and `lst$name` / `lst[["name"]]` / `lst[[i]]` index a list by
 name or position, with a missing name returning `NULL`.
+**`switch()` + error handling (R-18)** — `switch(EXPR, ...)` is a lazy multi-way
+branch: a character `EXPR` matches arm names (unnamed final arm = default; no
+match and no default → `NULL`), a numeric `EXPR` selects the n-th arm by position,
+and **only the chosen arm evaluates** (`switch("a", a = "ok", b = stop("x"))`
+does not raise). `stop(...)` raises an error, `warning(...)` emits a warning and
+returns invisibly without aborting, and `tryCatch(expr, error = fn, finally =
+cleanup)` runs `expr`, routes any error to `error` (with a condition object whose
+`conditionMessage(e)` / `e$message` give the message), and always runs `finally`.
 
 ## Usage
 

--- a/code/packages/rust/r-runtime/src/lib.rs
+++ b/code/packages/rust/r-runtime/src/lib.rs
@@ -1213,4 +1213,144 @@ mod tests {
             vec![2.0]
         );
     }
+
+    // --- R-18: switch() + error handling (R syntax) ---------------------
+
+    #[test]
+    fn switch_character_match_and_default_r_syntax() {
+        // A name match returns that arm's value.
+        assert_eq!(show("switch(\"b\", a = \"A\", b = \"B\")\n"), "[1] \"B\"");
+        // An unnamed final arm is the default when nothing matches.
+        assert_eq!(
+            show("switch(\"z\", a = \"A\", \"fallback\")\n"),
+            "[1] \"fallback\""
+        );
+        // No match and no default → NULL.
+        assert_eq!(show("switch(\"z\", a = \"A\", b = \"B\")\n"), "NULL");
+    }
+
+    #[test]
+    fn switch_numeric_position_r_syntax() {
+        assert_eq!(
+            show("switch(2, \"one\", \"two\", \"three\")\n"),
+            "[1] \"two\""
+        );
+        // Out of range → NULL.
+        assert_eq!(show("switch(9, \"one\", \"two\")\n"), "NULL");
+        assert_eq!(show("switch(0, \"one\")\n"), "NULL");
+    }
+
+    #[test]
+    fn switch_is_lazy_only_selected_arm_evaluates_r_syntax() {
+        // The unselected arm would raise; switch must not evaluate it. This is
+        // the laziness proof: an eager builtin would error here.
+        assert_eq!(
+            show("switch(\"a\", a = \"ok\", b = stop(\"boom\"))\n"),
+            "[1] \"ok\""
+        );
+        // `_` is a name char in R, so undefined_var is a single undefined name;
+        // because it is in the unselected arm, it is never looked up.
+        assert_eq!(show("switch(1, \"ok\", undefined_var)\n"), "[1] \"ok\"");
+    }
+
+    #[test]
+    fn stop_raises_an_error_r_syntax() {
+        assert!(matches!(eval_r("stop(\"boom\")\n"), Err(RError::User(m)) if m == "boom"));
+        // Arguments concatenate into the message.
+        assert!(matches!(eval_r("stop(\"a\", \"b\")\n"), Err(RError::User(m)) if m == "ab"));
+    }
+
+    #[test]
+    fn try_catch_catches_error_and_returns_handler_value_r_syntax() {
+        // The headline case: catch a stop() and return the handler's value.
+        assert_eq!(
+            show("tryCatch(stop(\"x\"), error = function(e) \"caught\")\n"),
+            "[1] \"caught\""
+        );
+        // No error → the protected expression's value.
+        assert_eq!(nums("tryCatch(1 + 1, error = function(e) 0)\n"), vec![2.0]);
+        // The handler reads the condition message (both accessors).
+        assert_eq!(
+            show("tryCatch(stop(\"oops\"), error = function(e) conditionMessage(e))\n"),
+            "[1] \"oops\""
+        );
+        assert_eq!(
+            show("tryCatch(stop(\"oops\"), error = function(e) e$message)\n"),
+            "[1] \"oops\""
+        );
+        // A non-stop runtime error (undefined name) is catchable too.
+        assert_eq!(
+            show("tryCatch(undefined_var, error = function(e) \"recovered\")\n"),
+            "[1] \"recovered\""
+        );
+    }
+
+    #[test]
+    fn try_catch_finally_runs_on_success_and_on_catch_r_syntax() {
+        // finally runs on the success path (observed via cat output).
+        let r = RInterpreter::new();
+        let out = r
+            .eval_str("tryCatch(1, finally = cat(\"done\"))\n")
+            .unwrap();
+        assert!(out.printed.contains("done"), "got: {:?}", out.printed);
+        // finally runs even when the error is caught.
+        let out = r
+            .eval_str("tryCatch(stop(\"x\"), error = function(e) 0, finally = cat(\"cleanup\"))\n")
+            .unwrap();
+        assert!(out.printed.contains("cleanup"), "got: {:?}", out.printed);
+    }
+
+    #[test]
+    fn try_catch_handler_is_lazy_on_success_r_syntax() {
+        // The handler would error if invoked; on success it must not run.
+        assert_eq!(
+            nums("tryCatch(42, error = function(e) stop(\"unreached\"))\n"),
+            vec![42.0]
+        );
+    }
+
+    #[test]
+    fn warning_does_not_abort_r_syntax() {
+        let r = RInterpreter::new();
+        let out = r.eval_str("warning(\"careful\")\n1 + 1\n").unwrap();
+        // Execution continues to the next statement.
+        assert_eq!(format_value(&out.value), vec!["[1] 2".to_string()]);
+        assert!(out.printed.contains("careful"), "got: {:?}", out.printed);
+    }
+
+    #[test]
+    fn nested_try_catch_rethrow_r_syntax() {
+        // The inner handler re-raises; the outer one catches the new message.
+        assert_eq!(
+            show(
+                "tryCatch(\
+                   tryCatch(stop(\"deep\"), error = function(e) stop(\"rethrown\")), \
+                   error = function(e) conditionMessage(e))\n"
+            ),
+            "[1] \"rethrown\""
+        );
+    }
+
+    // --- regressions: R-15 / R-16 / R-17 still work ---------------------
+
+    #[test]
+    fn r15_r16_r17_still_work_after_r18() {
+        // R-15: named-vector access.
+        assert_eq!(nums("v <- c(a = 1, b = 2)\nv[\"b\"]\n"), vec![2.0]);
+        // R-16: attributes round-trip.
+        assert_eq!(
+            show("x <- structure(1:3, foo = \"bar\")\nattr(x, \"foo\")\n"),
+            "[1] \"bar\""
+        );
+        // R-17: do.call still spreads a named list into a call.
+        assert_eq!(
+            show("do.call(paste, list(\"a\", \"b\", sep = \"-\"))\n"),
+            "[1] \"a-b\""
+        );
+        // R-17: modifyList still overlays by name.
+        assert_eq!(
+            nums("modifyList(list(a = 1, b = 2), list(b = 20))$b\n"),
+            vec![20.0]
+        );
+    }
 }

--- a/code/packages/rust/s-runtime/CHANGELOG.md
+++ b/code/packages/rust/s-runtime/CHANGELOG.md
@@ -2,6 +2,34 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.14.0] - 2026-06-19
+
+### Added
+
+- **`switch()` + error handling (R-18)** — the value-returning multi-way branch
+  and condition-based error handling, in the shared runtime so R and S get them.
+  - **`switch(EXPR, ...)`** is a **special form**, intercepted in `eval_postfix`
+    before argument evaluation so it sees the *unevaluated* arm expressions and
+    evaluates only the chosen one. A character `EXPR` matches arm names (an
+    unnamed final arm is the default; no match and no default → invisible `NULL`);
+    a numeric `EXPR` selects the n-th arm by position (out of range → `NULL`).
+    Because only the selected arm runs, `switch("a", a = "ok", b = stop("x"))`
+    does not raise. *(Empty-arm fall-through `switch("a", a = , b = "hit")` is
+    implemented in `eval_switch` but deferred to R-19 — the shared S/R grammar's
+    `arg = NAME EQ expr` has no empty-value production, so `a = ,` is a parse
+    error today.)*
+  - **`stop(...)`** raises a new typed error variant `SError::User` whose message
+    is the concatenation of its arguments (catchable by `tryCatch`).
+  - **`warning(...)`** records and prints a warning (bounded by `MAX_WARNINGS`)
+    and returns invisibly without aborting.
+  - **`tryCatch(expr, error = handler, finally = cleanup)`** is a **special form**
+    (lazy): it evaluates `expr`, routes any catchable error to the `error` handler
+    (called with a minimal condition object `list(message, call)` classed
+    `c("simpleError", "error", "condition")`, returning the handler's value), and
+    always runs `finally`. Loop-control signals (`break`/`next`) are **not** caught
+    (`SError::is_catchable`).
+  - **`conditionMessage(e)`** / `e$message` recover the condition's message.
+
 ## [0.13.0] - 2026-06-17
 
 ### Added

--- a/code/packages/rust/s-runtime/README.md
+++ b/code/packages/rust/s-runtime/README.md
@@ -64,6 +64,20 @@ a hand-written loop. See [What "S-flavored" means here](#what-s-flavored-means-h
   name or position (missing name → `NULL`), seeing through the transparent
   `Classed`/`Attributed`/`Named` wrappers. Argument/result sizes are bounded and
   malformed input (non-list, non-callable, unnamed `val` element) fails closed.
+- **`switch()` + error handling** (R-18): `switch(EXPR, ...)` and
+  `tryCatch(expr, error = ..., finally = ...)` are **special forms** — the call
+  dispatcher intercepts them before argument evaluation, so only the selected arm
+  / protected expression / chosen handler runs (`switch("a", a = "ok", b =
+  stop("x"))` does not raise). `switch` matches a character `EXPR` against arm
+  names (unnamed final arm = default; no match and no default → invisible `NULL`)
+  or selects an arm by numeric position (out of range → `NULL`). `stop(...)`
+  raises a catchable `SError::User`; `warning(...)` records and prints a warning
+  (bounded by `MAX_WARNINGS`) without aborting; `tryCatch` routes any catchable
+  error to its `error` handler with a minimal condition object (`list(message,
+  call)` classed `c("simpleError", "error", "condition")`, so `conditionMessage`
+  / `e$message` work) and always runs `finally`. Loop-control signals
+  (`break`/`next`) are not caught. *(Empty-arm fall-through is implemented but
+  deferred to R-19 pending a grammar production for empty args.)*
 - The **`d`/`p`/`q`/`r` distribution family** (R-8) over `statistics-core`:
   density/CDF/quantile/sampling for the normal, uniform, and exponential
   distributions, plus `set.seed` for a reproducible per-session RNG.

--- a/code/packages/rust/s-runtime/src/builtins.rs
+++ b/code/packages/rust/s-runtime/src/builtins.rs
@@ -151,6 +151,19 @@ pub fn install(env: &Env) {
 
     // v2 — S3 dispatch and output.
     define(env, "cat", builtin("cat", b_cat));
+
+    // R-18 — error handling. `stop`/`warning` are ordinary (eager) builtins —
+    // their arguments *are* evaluated and concatenated into the message. The
+    // lazy `switch`/`tryCatch` are special forms handled in `eval.rs`, not here.
+    // `conditionMessage` reads the message of a condition object.
+    define(env, "stop", builtin("stop", b_stop));
+    define(env, "warning", builtin("warning", b_warning));
+    define(
+        env,
+        "conditionMessage",
+        builtin("conditionMessage", b_condition_message),
+    );
+
     define(env, "class", builtin("class", b_class));
     define(env, "structure", builtin("structure", b_structure));
     define(env, "inherits", builtin("inherits", b_inherits));
@@ -2820,6 +2833,44 @@ fn b_cat(interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
         .collect();
     interp.emit_raw(&parts.join(&sep));
     Ok(SValue::Null)
+}
+
+/// Concatenate every positional argument into a single message string, the way
+/// `stop`/`warning` build their text (coerce to character, drop names, join with
+/// no separator — R's `.makeMessage` behaviour). NA elements render as the
+/// literal `"NA"`.
+fn concat_message(args: &[Arg]) -> String {
+    args.iter()
+        .filter(|a| a.name.is_none())
+        .flat_map(|a| a.value.as_character())
+        .map(|o| o.unwrap_or_else(|| "NA".to_string()))
+        .collect::<Vec<_>>()
+        .join("")
+}
+
+/// `stop(...)` — raise an error whose message is the concatenation of the
+/// arguments. Surfaces as [`SError::User`], which `tryCatch(error = ...)` can
+/// catch. A bare `stop()` (no message) raises an empty-message error, as in R.
+fn b_stop(_interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
+    Err(SError::User(concat_message(args)))
+}
+
+/// `warning(...)` — emit a warning (concatenated message) without aborting, and
+/// return invisibly. The message is recorded in the session warning buffer and
+/// printed immediately. The evaluator marks builtins invisible by name, but a
+/// `warning()` value is `NULL` anyway.
+fn b_warning(interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
+    interp.warn(&concat_message(args));
+    Ok(SValue::Null)
+}
+
+/// `conditionMessage(e)` — the `message` element of a condition object (the
+/// character string a `tryCatch` handler was handed). Equivalent to `e$message`.
+/// On a value with no `message` element this yields `NULL` (R would error, but
+/// the lenient list `$` access is harmless and keeps us panic-free).
+fn b_condition_message(_interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
+    let cond = first_positional(args)?;
+    crate::dataframe::column_by_name(cond, "message")
 }
 
 /// `seq(to)` is `1:to`; `seq(from, to)` is `from:to` (step 1). A minimal subset

--- a/code/packages/rust/s-runtime/src/error.rs
+++ b/code/packages/rust/s-runtime/src/error.rs
@@ -28,6 +28,12 @@ pub enum SError {
     Domain(String),
     /// `break` / `next` used outside a loop, or any other control misuse.
     Control(String),
+    /// An error raised explicitly by the program via `stop(...)`. Kept distinct
+    /// from the type/index/etc. categories so a user-level `stop` is
+    /// recognizable, but — like every other non-control error — it is catchable
+    /// by `tryCatch(..., error = ...)`. The string is the already-concatenated
+    /// message (the arguments of `stop`, coerced to character and joined).
+    User(String),
 
     /// Internal control signal raised by `break` and caught by the enclosing
     /// loop. It only reaches a user as an error when `break` is used with no
@@ -49,9 +55,28 @@ impl fmt::Display for SError {
             SError::Missing(m) => write!(f, "{m}"),
             SError::Domain(m) => write!(f, "{m}"),
             SError::Control(m) => write!(f, "{m}"),
+            SError::User(m) => write!(f, "{m}"),
             SError::Break => write!(f, "no loop for break/next, jumping to top level"),
             SError::Next => write!(f, "no loop for break/next, jumping to top level"),
         }
+    }
+}
+
+impl SError {
+    /// Whether this error is a *catchable* condition for `tryCatch(error = ...)`.
+    /// Every ordinary error qualifies; the internal [`SError::Break`] /
+    /// [`SError::Next`] control signals do **not** — they are loop control, not
+    /// program errors, and must propagate untouched to their enclosing loop.
+    pub fn is_catchable(&self) -> bool {
+        !matches!(self, SError::Break | SError::Next)
+    }
+
+    /// The human-readable condition message for a catchable error — exactly what
+    /// `conditionMessage(e)` / `e$message` should report. This is the `Display`
+    /// text, so a `stop("boom")` yields `"boom"` and a type error yields its
+    /// message verbatim.
+    pub fn condition_message(&self) -> String {
+        self.to_string()
     }
 }
 
@@ -87,8 +112,29 @@ mod tests {
         assert_eq!(SError::Missing("m".into()).to_string(), "m");
         assert_eq!(SError::Domain("d".into()).to_string(), "d");
         assert_eq!(SError::Control("c".into()).to_string(), "c");
+        assert_eq!(SError::User("boom".into()).to_string(), "boom");
         assert!(SError::Break.to_string().contains("no loop"));
         assert!(SError::Next.to_string().contains("no loop"));
+    }
+
+    #[test]
+    fn catchability_excludes_only_control_signals() {
+        // Ordinary errors are catchable by tryCatch.
+        assert!(SError::User("boom".into()).is_catchable());
+        assert!(SError::TypeError("te".into()).is_catchable());
+        assert!(SError::Undefined("x".into()).is_catchable());
+        // The loop-control signals are not.
+        assert!(!SError::Break.is_catchable());
+        assert!(!SError::Next.is_catchable());
+    }
+
+    #[test]
+    fn condition_message_is_the_display_text() {
+        assert_eq!(SError::User("boom".into()).condition_message(), "boom");
+        assert_eq!(
+            SError::Undefined("x".into()).condition_message(),
+            "object 'x' not found"
+        );
     }
 
     #[test]

--- a/code/packages/rust/s-runtime/src/eval.rs
+++ b/code/packages/rust/s-runtime/src/eval.rs
@@ -1274,7 +1274,12 @@ impl Interpreter {
     /// The handler is normally a `function(e) ...`; we evaluate the handler
     /// expression to a callable and call it with the single condition argument.
     /// A non-callable handler is a clean error.
-    fn call_handler(&self, handler_node: &GrammarASTNode, condition: SValue, env: &Env) -> SResult<SValue> {
+    fn call_handler(
+        &self,
+        handler_node: &GrammarASTNode,
+        condition: SValue,
+        env: &Env,
+    ) -> SResult<SValue> {
         let handler = self.eval_node(handler_node, env)?;
         if !handler.is_callable() {
             return Err(SError::NotCallable(handler.type_name().to_string()));

--- a/code/packages/rust/s-runtime/src/eval.rs
+++ b/code/packages/rust/s-runtime/src/eval.rs
@@ -56,7 +56,18 @@ pub struct Interpreter {
     /// `RefCell` because builtins receive `&Interpreter` but the generator must
     /// advance its state on every draw.
     rng: RefCell<RngState>,
+    /// Warnings raised by `warning(...)` during the current program, in order.
+    /// Bounded by [`MAX_WARNINGS`] so a tight `warning()` loop cannot grow this
+    /// without limit. Each warning is also printed immediately (R defers them by
+    /// default, but immediate printing is simpler and equally faithful for a
+    /// REPL); the buffer exists so a future `warnings()` accessor can read them.
+    warnings: RefCell<Vec<String>>,
 }
+
+/// The most warnings retained per program. Beyond this, further `warning()`
+/// calls still print but are not appended to the buffer — a bound against a
+/// crafted `for (i in 1:1e9) warning("x")` exhausting memory.
+const MAX_WARNINGS: usize = 10_000;
 
 /// The fixed seed a fresh session starts from. Real R seeds from the clock and
 /// process state; we use a constant so a brand-new interpreter is reproducible
@@ -97,7 +108,21 @@ impl Interpreter {
             visible: Cell::new(false),
             depth: Cell::new(0),
             rng: RefCell::new(RngState::new(DEFAULT_SEED)),
+            warnings: RefCell::new(Vec::new()),
         }
+    }
+
+    /// Record and print a warning raised by `warning(...)`. The buffer is capped
+    /// at [`MAX_WARNINGS`]; the message is always printed (so the user sees it)
+    /// even once the buffer is full.
+    pub(crate) fn warn(&self, message: &str) {
+        {
+            let mut w = self.warnings.borrow_mut();
+            if w.len() < MAX_WARNINGS {
+                w.push(message.to_string());
+            }
+        }
+        self.emit_raw(&format!("Warning message:\n{message}\n"));
     }
 
     /// The global environment (for tests and the REPL).
@@ -168,6 +193,7 @@ impl Interpreter {
     /// directly, reusing the entire evaluator.
     pub fn eval_program(&self, program: &GrammarASTNode) -> SResult<Outcome> {
         self.out.borrow_mut().clear();
+        self.warnings.borrow_mut().clear();
 
         let mut last = SValue::Null;
         self.visible.set(false);
@@ -714,6 +740,40 @@ impl Interpreter {
             Some(ASTNodeOrToken::Node(n)) => n,
             _ => return Err(SError::Parse("malformed postfix".into())),
         };
+
+        // --- Special forms: `switch` / `tryCatch` -----------------------------
+        //
+        // These cannot be ordinary (eager) builtins: they must inspect their
+        // *unevaluated* argument expressions and evaluate only the selected arm /
+        // protected expression / chosen handler. We intercept here, at the call
+        // site, when the postfix is exactly `<bare-name> ( args )` — a single
+        // `call_suffix` directly on a bare-name primary — and the name is one of
+        // the special forms. (A name shadowed by a user variable is rare and R
+        // treats these as language constructs; intercepting by name keeps the
+        // laziness guarantee unconditional and simple.) Any other shape (extra
+        // suffixes, indexing) falls through to the ordinary eager path below.
+        if let Some(special) = special_form_name(primary) {
+            // The only suffix nodes (ignoring `(`/`)` tokens) must be a lone
+            // `call_suffix` — `switch(...)` / `tryCatch(...)`.
+            let suffix_nodes: Vec<&GrammarASTNode> = node.children[1..]
+                .iter()
+                .filter_map(|c| match c {
+                    ASTNodeOrToken::Node(n) => Some(n),
+                    ASTNodeOrToken::Token(_) => None,
+                })
+                .collect();
+            if let [suffix] = suffix_nodes.as_slice() {
+                if suffix.rule_name == "call_suffix" {
+                    let raw = raw_args(suffix);
+                    return match special {
+                        "switch" => self.eval_switch(&raw, env),
+                        "tryCatch" => self.eval_try_catch(&raw, env),
+                        _ => unreachable!(),
+                    };
+                }
+            }
+        }
+
         let mut value = self.eval_node(primary, env)?;
         let mut had_suffix = false;
 
@@ -846,7 +906,7 @@ impl Interpreter {
                 // `print`/`cat` produce their own output, and `set.seed` mutates
                 // RNG state — all three return invisibly (R's `invisible(NULL)`);
                 // every other built-in yields a visible value.
-                if name == "print" || name == "cat" || name == "set.seed" {
+                if name == "print" || name == "cat" || name == "set.seed" || name == "warning" {
                     self.as_invisible(result)
                 } else {
                     self.as_visible(result)
@@ -1092,6 +1152,141 @@ impl Interpreter {
     }
 
     // -----------------------------------------------------------------------
+    // Special forms: switch / tryCatch (lazy — only the chosen arm evaluates)
+    // -----------------------------------------------------------------------
+
+    /// `switch(EXPR, ...)` — R's value-returning multi-way branch.
+    ///
+    /// The first argument `EXPR` is evaluated to choose *one* arm; only that arm
+    /// is then evaluated (the rest are never touched — this is why `switch` must
+    /// be a special form).
+    ///
+    /// - **Character `EXPR`**: match against the arm *names*. A matched arm that
+    ///   is **empty** (`a = ,`) falls through to the next non-empty arm's value;
+    ///   an **unnamed final arm** is the default when no name matches; no match
+    ///   and no default yields an invisible `NULL`.
+    /// - **Numeric `EXPR`**: select the n-th *value* arm by position (1-based),
+    ///   ignoring names; out of range (or NA / < 1) yields invisible `NULL`.
+    fn eval_switch(&self, raw: &[RawArg], env: &Env) -> SResult<SValue> {
+        // `raw[0]` is EXPR; the remaining entries are the arms.
+        let expr_node = raw
+            .first()
+            .and_then(|(_, n)| arm_body(n))
+            .ok_or_else(|| SError::BadArgs("switch: EXPR is missing".into()))?;
+        let arms = &raw[1..];
+        let selector = self.eval_node(expr_node, env)?;
+
+        // A length-1 character selector matches by name; anything else is taken
+        // as a numeric position (matching R, which treats an integer selector
+        // positionally).
+        if let Some(name) = single_string(&selector) {
+            // Find the arm whose name equals `name`. On a match, fall through any
+            // empty arms to the next non-empty value.
+            if let Some(pos) = arms
+                .iter()
+                .position(|(arm_name, _)| arm_name.as_deref() == Some(name.as_str()))
+            {
+                for (_, arm) in &arms[pos..] {
+                    if let Some(body) = arm_body(arm) {
+                        return self.eval_node(body, env);
+                    }
+                    // else: an empty arm — fall through to the next.
+                }
+                // Fell off the end with only empty arms → NULL.
+                return self.as_invisible(SValue::Null);
+            }
+            // No name matched: an unnamed final arm is the default.
+            if let Some((arm_name, arm)) = arms.last() {
+                if arm_name.is_none() {
+                    if let Some(body) = arm_body(arm) {
+                        return self.eval_node(body, env);
+                    }
+                }
+            }
+            return self.as_invisible(SValue::Null);
+        }
+
+        // Numeric selector: the n-th arm, 1-based, by position.
+        let n = scalar_f64(&selector).ok();
+        match n {
+            Some(x) if x >= 1.0 => {
+                let idx = x as usize - 1;
+                match arms.get(idx).and_then(|(_, arm)| arm_body(arm)) {
+                    Some(body) => self.eval_node(body, env),
+                    None => self.as_invisible(SValue::Null),
+                }
+            }
+            _ => self.as_invisible(SValue::Null),
+        }
+    }
+
+    /// `tryCatch(expr, error = handler, finally = cleanup)` — evaluate `expr`;
+    /// on *any* catchable error route it to the `error` handler (called with a
+    /// condition object), returning the handler's value; otherwise return the
+    /// value of `expr`. The `finally` expression, if present, always runs (for
+    /// its side effects) afterward. Everything is lazy: handlers and `finally`
+    /// are unevaluated parse-tree nodes until needed.
+    fn eval_try_catch(&self, raw: &[RawArg], env: &Env) -> SResult<SValue> {
+        // The protected expression is the first positional argument; the
+        // `error`/`finally` handlers are matched by name.
+        let expr_node = raw
+            .iter()
+            .find(|(name, _)| name.is_none())
+            .and_then(|(_, n)| arm_body(n))
+            .ok_or_else(|| SError::BadArgs("tryCatch: expr is missing".into()))?;
+        let handler_node = raw
+            .iter()
+            .find(|(name, _)| name.as_deref() == Some("error"))
+            .and_then(|(_, n)| arm_body(n));
+        let finally_node = raw
+            .iter()
+            .find(|(name, _)| name.as_deref() == Some("finally"))
+            .and_then(|(_, n)| arm_body(n));
+
+        // Evaluate the protected expression, intercepting any catchable error.
+        let result = self.eval_node(expr_node, env);
+        let outcome = match result {
+            Ok(value) => Ok(value),
+            Err(e) if e.is_catchable() => match handler_node {
+                Some(h) => {
+                    // Build the condition object and call the handler with it.
+                    let condition = make_condition(&e.condition_message());
+                    self.call_handler(h, condition, env)
+                }
+                // No `error` handler: the error still propagates (but `finally`
+                // must run first — handled below).
+                None => Err(e),
+            },
+            // A non-catchable control signal (break/next) is re-raised untouched,
+            // but `finally` still runs first.
+            Err(e) => Err(e),
+        };
+
+        // `finally` runs regardless of success or failure. If it itself errors,
+        // that error supersedes (matching R).
+        if let Some(f) = finally_node {
+            self.eval_node(f, env)?;
+        }
+        outcome
+    }
+
+    /// Evaluate a `tryCatch` `error =` handler and apply it to the condition.
+    /// The handler is normally a `function(e) ...`; we evaluate the handler
+    /// expression to a callable and call it with the single condition argument.
+    /// A non-callable handler is a clean error.
+    fn call_handler(&self, handler_node: &GrammarASTNode, condition: SValue, env: &Env) -> SResult<SValue> {
+        let handler = self.eval_node(handler_node, env)?;
+        if !handler.is_callable() {
+            return Err(SError::NotCallable(handler.type_name().to_string()));
+        }
+        let args = [Arg {
+            name: None,
+            value: condition,
+        }];
+        self.call_value(handler, &args)
+    }
+
+    // -----------------------------------------------------------------------
     // Visibility helpers
     // -----------------------------------------------------------------------
 
@@ -1113,6 +1308,103 @@ impl Interpreter {
 /// The standard error when the right-hand side of `|>` is not a function call.
 fn pipe_needs_call() -> SError {
     SError::Parse("the right-hand side of |> must be a function call".into())
+}
+
+/// One *unevaluated* call argument: its optional name and its expression node.
+/// Special forms (`switch`/`tryCatch`) work on these so they can choose which
+/// arm to evaluate.
+type RawArg<'a> = (Option<String>, &'a GrammarASTNode);
+
+/// If `primary` is a bare-name reference to one of the lazy special forms
+/// (`switch`, `tryCatch`), return that name; otherwise `None`. A special form is
+/// recognized only when the primary reduces to exactly that single `NAME` token
+/// (so `f()(...)` or an indexed primary never trips the check).
+fn special_form_name(primary: &GrammarASTNode) -> Option<&'static str> {
+    let mut tokens: Vec<(&str, &str)> = Vec::new();
+    collect_tokens(primary, &mut tokens);
+    match tokens.as_slice() {
+        [("NAME", "switch")] => Some("switch"),
+        [("NAME", "tryCatch")] => Some("tryCatch"),
+        _ => None,
+    }
+}
+
+/// Collect the *unevaluated* arguments of a `call_suffix` as `(name, expr-node)`
+/// pairs, preserving order. A named argument (`NAME = expr`) keeps its name; a
+/// positional one has `None`. An empty arm (`a = ,` — a named `arg` with no
+/// inner expression, as in `switch`) is represented by a node whose
+/// [`arm_body`] is `None`.
+fn raw_args(suffix: &GrammarASTNode) -> Vec<RawArg<'_>> {
+    let mut out = Vec::new();
+    let Some(arg_list) = suffix.children.iter().find_map(|c| match c {
+        ASTNodeOrToken::Node(n) if n.rule_name == "arg_list" => Some(n),
+        _ => None,
+    }) else {
+        return out;
+    };
+    for child in &arg_list.children {
+        if let ASTNodeOrToken::Node(arg) = child {
+            if arg.rule_name != "arg" {
+                continue;
+            }
+            // A named argument is `NAME = expr` (two leading tokens); positional
+            // is just `expr`. (Mirrors `eval_arg`'s detection.)
+            let named = matches!(arg.children.first(), Some(ASTNodeOrToken::Token(_)))
+                && matches!(arg.children.get(1), Some(ASTNodeOrToken::Token(t)) if t.value == "=");
+            let name = if named {
+                match arg.children.first() {
+                    Some(ASTNodeOrToken::Token(t)) => Some(t.value.clone()),
+                    _ => None,
+                }
+            } else {
+                None
+            };
+            out.push((name, arg));
+        }
+    }
+    out
+}
+
+/// The expression node inside an `arg`, or `None` if the arg is **empty** (a
+/// `switch` fall-through arm like `a = ,`, which has a name but no value
+/// expression). Used by both `switch` arm selection and `tryCatch` handler
+/// lookup.
+fn arm_body(arg: &GrammarASTNode) -> Option<&GrammarASTNode> {
+    first_node(arg)
+}
+
+/// A length-1 character value as its `String`, else `None`. Sees through the
+/// transparent wrappers. Used by `switch` to decide name- vs position-matching.
+fn single_string(value: &SValue) -> Option<String> {
+    match value.strip_names() {
+        SValue::Character(v) if v.len() == 1 => v[0].clone(),
+        SValue::Classed { inner, .. } => single_string(inner),
+        SValue::Attributed { inner, .. } => single_string(inner),
+        _ => None,
+    }
+}
+
+/// Build the minimal **condition object** handed to a `tryCatch` `error =`
+/// handler: a list `list(message = <chr>, call = NULL)` carrying the S3 class
+/// `c("simpleError", "error", "condition")`. This is enough for
+/// `conditionMessage(e)` and `e$message` to recover the message; full R
+/// condition machinery (custom classes, restarts) is out of scope.
+fn make_condition(message: &str) -> SValue {
+    let inner = SValue::list(vec![
+        (
+            Some("message".to_string()),
+            SValue::Character(vec![Some(message.to_string())]),
+        ),
+        (Some("call".to_string()), SValue::Null),
+    ]);
+    SValue::Classed {
+        inner: Box::new(inner),
+        class: vec![
+            "simpleError".to_string(),
+            "error".to_string(),
+            "condition".to_string(),
+        ],
+    }
 }
 
 /// Descend a single-operand expression chain (`range → unary → power → …`) to

--- a/code/packages/rust/s-runtime/src/lib.rs
+++ b/code/packages/rust/s-runtime/src/lib.rs
@@ -1080,4 +1080,158 @@ mod tests {
         // A replacement target that isn't a registered `f<-` is undefined.
         assert!(eval_s("x <- c(1, 2)\nnope(x) <- 5\n").is_err());
     }
+
+    // --- R-18: switch() + error handling (in S syntax) ------------------
+
+    #[test]
+    fn switch_character_match_default_and_fallthrough() {
+        // A name match returns that arm's value.
+        assert_eq!(show("switch(\"b\", a = \"A\", b = \"B\")\n"), "[1] \"B\"");
+        // An unnamed final arm is the default when nothing matches.
+        assert_eq!(
+            show("switch(\"z\", a = \"A\", \"fallback\")\n"),
+            "[1] \"fallback\""
+        );
+        // No match and no default → invisible NULL.
+        assert_eq!(show("switch(\"z\", a = \"A\", b = \"B\")\n"), "NULL");
+        // NOTE: empty-arm fall-through (`switch("a", a = , b = "hit")`) is
+        // deferred to R-19 — the shared S/R grammar's `arg = NAME EQ expr` has no
+        // empty-value production, so `a = ,` is a *parse* error. `eval_switch`
+        // already implements the fall-through (see `arm_body`/the loop over
+        // `arms[pos..]`); it activates once the grammar admits empty args.
+    }
+
+    #[test]
+    fn switch_numeric_selects_by_position() {
+        assert_eq!(show("switch(2, \"one\", \"two\", \"three\")\n"), "[1] \"two\"");
+        // Out of range → NULL (no error).
+        assert_eq!(show("switch(9, \"one\", \"two\")\n"), "NULL");
+        assert_eq!(show("switch(0, \"one\", \"two\")\n"), "NULL");
+    }
+
+    #[test]
+    fn switch_evaluates_only_the_selected_arm() {
+        // The non-selected arm would error if evaluated; it must not be.
+        assert_eq!(
+            show("switch(\"a\", a = \"ok\", b = stop(\"boom\"))\n"),
+            "[1] \"ok\""
+        );
+        // Numeric form: the unselected arm with an undefined name is untouched.
+        // (In S, `_` is assignment, so the dotted name `missing.name` is used.)
+        assert_eq!(show("switch(1, \"ok\", missing.name)\n"), "[1] \"ok\"");
+    }
+
+    #[test]
+    fn stop_raises_a_user_error() {
+        match eval_s("stop(\"boom\")\n") {
+            Err(SError::User(m)) => assert_eq!(m, "boom"),
+            other => panic!("expected user error, got {other:?}"),
+        }
+        // The message concatenates its arguments (paste0 style).
+        match eval_s("stop(\"a\", \"b\", \"c\")\n") {
+            Err(SError::User(m)) => assert_eq!(m, "abc"),
+            other => panic!("expected user error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn try_catch_catches_and_returns_handler_value() {
+        // The handler's value becomes the result of the tryCatch.
+        assert_eq!(
+            show("tryCatch(stop(\"x\"), error = function(e) \"caught\")\n"),
+            "[1] \"caught\""
+        );
+        // No error: the protected expression's value is returned.
+        assert_eq!(
+            show("tryCatch(1 + 1, error = function(e) \"caught\")\n"),
+            "[1] 2"
+        );
+    }
+
+    #[test]
+    fn try_catch_handler_sees_the_condition_message() {
+        // conditionMessage(e) and e$message both recover the message.
+        assert_eq!(
+            show("tryCatch(stop(\"oops\"), error = function(e) conditionMessage(e))\n"),
+            "[1] \"oops\""
+        );
+        assert_eq!(
+            show("tryCatch(stop(\"oops\"), error = function(e) e$message)\n"),
+            "[1] \"oops\""
+        );
+        // A built-in (non-stop) error is catchable too. (`missing.name` is an
+        // undefined dotted name — `_` is assignment in S.)
+        assert_eq!(
+            show("tryCatch(missing.name, error = function(e) \"recovered\")\n"),
+            "[1] \"recovered\""
+        );
+    }
+
+    #[test]
+    fn try_catch_finally_always_runs() {
+        // finally runs on success (its side effect is captured via cat output).
+        let r = Interpreter::new();
+        let out = r
+            .eval_str("tryCatch(1, finally = cat(\"done\"))\n")
+            .unwrap();
+        assert!(out.printed.contains("done"), "got: {:?}", out.printed);
+        // finally runs even when the error is caught.
+        let r = Interpreter::new();
+        let out = r
+            .eval_str("tryCatch(stop(\"x\"), error = function(e) 0, finally = cat(\"cleanup\"))\n")
+            .unwrap();
+        assert!(out.printed.contains("cleanup"), "got: {:?}", out.printed);
+    }
+
+    #[test]
+    fn try_catch_without_handler_propagates_but_runs_finally() {
+        // With only a finally (no error handler), the error still propagates…
+        let r = Interpreter::new();
+        let res = r.eval_str("tryCatch(stop(\"x\"), finally = cat(\"cleanup\"))\n");
+        assert!(res.is_err());
+    }
+
+    #[test]
+    fn try_catch_is_lazy_handler_not_run_on_success() {
+        // The handler would error if ever invoked; on success it must not be.
+        assert_eq!(
+            show("tryCatch(42, error = function(e) stop(\"should not run\"))\n"),
+            "[1] 42"
+        );
+    }
+
+    #[test]
+    fn warning_does_not_abort_and_prints() {
+        let r = Interpreter::new();
+        let out = r.eval_str("warning(\"careful\")\n1 + 1\n").unwrap();
+        // Execution continues past the warning to the next statement.
+        assert_eq!(format_value(&out.value), vec!["[1] 2".to_string()]);
+        assert!(
+            out.printed.contains("careful"),
+            "warning not printed: {:?}",
+            out.printed
+        );
+    }
+
+    #[test]
+    fn nested_try_catch_inner_handles_first() {
+        // An inner tryCatch handles the error; the outer one never sees it.
+        assert_eq!(
+            show(
+                "tryCatch(tryCatch(stop(\"deep\"), error = function(e) stop(\"rethrown\")), \
+                 error = function(e) conditionMessage(e))\n"
+            ),
+            "[1] \"rethrown\""
+        );
+    }
+
+    #[test]
+    fn switch_does_not_catch_or_swallow_break() {
+        // A break inside a switch arm is not an error condition — it propagates
+        // to the enclosing loop (here it just exits the for).
+        assert_eq!(
+            nums("s <- 0\nfor (i in 1:3) { s <- s + 1\nswitch(\"a\", a = break) }\ns\n"),
+            vec![1.0]
+        );
+    }
 }

--- a/code/packages/rust/s-runtime/src/lib.rs
+++ b/code/packages/rust/s-runtime/src/lib.rs
@@ -1103,7 +1103,10 @@ mod tests {
 
     #[test]
     fn switch_numeric_selects_by_position() {
-        assert_eq!(show("switch(2, \"one\", \"two\", \"three\")\n"), "[1] \"two\"");
+        assert_eq!(
+            show("switch(2, \"one\", \"two\", \"three\")\n"),
+            "[1] \"two\""
+        );
         // Out of range → NULL (no error).
         assert_eq!(show("switch(9, \"one\", \"two\")\n"), "NULL");
         assert_eq!(show("switch(0, \"one\", \"two\")\n"), "NULL");

--- a/code/specs/R00-r-language.md
+++ b/code/specs/R00-r-language.md
@@ -330,6 +330,27 @@ unchanged.
     composes with the access operators above. The result size is bounded by the
     same `MAX_DOCALL_ARGS`-class limit as `do.call`'s argument count so a crafted
     `val` cannot blow the list up without bound.
+- **R-18 — `switch()` + error handling** *(this PR)*. R's value-returning
+  multi-way branch and its condition-based error handling, all in the shared
+  `s-runtime` (R inherits them through the same evaluator). The defining property
+  is **lazy evaluation**: `switch` and `tryCatch` are **special forms** — the
+  call dispatcher intercepts them and evaluates only the selected arm / protected
+  expression / chosen handler, never all arms eagerly. See S00 §V2.9 for the full
+  semantics. In brief:
+  - **`switch(EXPR, ...)`** — character `EXPR` matches arm *names* (an **empty
+    arm falls through** to the next non-empty value; an **unnamed final arm** is
+    the default; no match and no default → invisible `NULL`); numeric `EXPR`
+    selects the n-th arm by position (out of range → `NULL`). Only the chosen arm
+    evaluates, so `switch("a", a = stop("x"), b = "ok")` does not raise.
+  - **`stop(...)`** raises an error (concatenated message → `SError::User`);
+    **`warning(...)`** emits a warning and returns invisibly without aborting;
+    **`tryCatch(expr, error = fn, finally = cleanup)`** runs `expr`, routing any
+    error to `error` (called with a minimal condition object —
+    `list(message, call)` classed `c("simpleError","error","condition")`, so
+    `conditionMessage(e)` and `e$message` give the message), and always running
+    `finally`. **`conditionMessage(e)`** reads the condition's message. Full R
+    condition machinery (custom condition classes, calling handlers, restarts) is
+    out of scope.
 
 ## §4 Reuse strategy
 

--- a/code/specs/R00-r-language.md
+++ b/code/specs/R00-r-language.md
@@ -337,11 +337,13 @@ unchanged.
   call dispatcher intercepts them and evaluates only the selected arm / protected
   expression / chosen handler, never all arms eagerly. See S00 §V2.9 for the full
   semantics. In brief:
-  - **`switch(EXPR, ...)`** — character `EXPR` matches arm *names* (an **empty
-    arm falls through** to the next non-empty value; an **unnamed final arm** is
-    the default; no match and no default → invisible `NULL`); numeric `EXPR`
-    selects the n-th arm by position (out of range → `NULL`). Only the chosen arm
-    evaluates, so `switch("a", a = stop("x"), b = "ok")` does not raise.
+  - **`switch(EXPR, ...)`** — character `EXPR` matches arm *names* (an **unnamed
+    final arm** is the default; no match and no default → invisible `NULL`);
+    numeric `EXPR` selects the n-th arm by position (out of range → `NULL`). Only
+    the chosen arm evaluates, so `switch("a", a = stop("x"), b = "ok")` does not
+    raise. *(Empty-arm fall-through `switch("a", a = , b = "hit")` is deferred to
+    R-19 — it needs a grammar production for empty args; `eval_switch` already
+    implements the behaviour.)*
   - **`stop(...)`** raises an error (concatenated message → `SError::User`);
     **`warning(...)`** emits a warning and returns invisibly without aborting;
     **`tryCatch(expr, error = fn, finally = cleanup)`** runs `expr`, routing any

--- a/code/specs/S00-s-language.md
+++ b/code/specs/S00-s-language.md
@@ -353,11 +353,14 @@ essential: `switch("a", a = stop("no"), b = "ok")` must not raise, and a
 `tryCatch` handler must not run unless its expression actually errors.
 
 - **`switch(EXPR, ...)`** — choose one arm by the value of `EXPR`.
-  - **Character `EXPR`** matches against the *names* of the arms. An **empty
-    arm falls through** to the next non-empty arm's value
-    (`switch("a", a = , b = "hit")` → `"hit"`). An **unnamed final arm** is the
-    **default**, used when no name matches. With no match and no default the
-    result is an **invisible `NULL`**.
+  - **Character `EXPR`** matches against the *names* of the arms. An **unnamed
+    final arm** is the **default**, used when no name matches. With no match and
+    no default the result is an **invisible `NULL`**. *(Deferred to R-19:* the
+    **empty-arm fall-through** `switch("a", a = , b = "hit")` → `"hit"`. The
+    shared S/R grammar's `arg = NAME EQ expr` has no empty-value production, so
+    `a = ,` is a parse error today. The evaluator's `eval_switch` already
+    implements the fall-through; it activates once the grammar admits empty
+    args.)*
   - **Numeric `EXPR`** selects the `n`-th arm by **position** (1-based), ignoring
     names; out of range (or `NA`/`< 1`) → `NULL`. Only the chosen arm is
     evaluated.

--- a/code/specs/S00-s-language.md
+++ b/code/specs/S00-s-language.md
@@ -341,6 +341,48 @@ general map is bounded (`MAX_ATTRIBUTES`) and a `"dim"` reshape is length-checke
 against `MAX_SEQ_LEN`, so attacker-controlled attribute input cannot exhaust
 memory or panic.
 
+### V2.9 `switch()` and error handling (`stop`/`warning`/`tryCatch`)
+
+V2.9 adds R's value-returning multi-way branch and its condition-based error
+handling. The headline implementation note is **laziness**: `switch` and
+`tryCatch` are **special forms**, not ordinary (eager) builtins. The evaluator's
+call dispatcher (`eval_postfix`) intercepts a bare-name call to `switch` or
+`tryCatch` and hands it the *unevaluated* argument expressions, evaluating only
+the selected arm / the protected expression / the chosen handler. This is
+essential: `switch("a", a = stop("no"), b = "ok")` must not raise, and a
+`tryCatch` handler must not run unless its expression actually errors.
+
+- **`switch(EXPR, ...)`** — choose one arm by the value of `EXPR`.
+  - **Character `EXPR`** matches against the *names* of the arms. An **empty
+    arm falls through** to the next non-empty arm's value
+    (`switch("a", a = , b = "hit")` → `"hit"`). An **unnamed final arm** is the
+    **default**, used when no name matches. With no match and no default the
+    result is an **invisible `NULL`**.
+  - **Numeric `EXPR`** selects the `n`-th arm by **position** (1-based), ignoring
+    names; out of range (or `NA`/`< 1`) → `NULL`. Only the chosen arm is
+    evaluated.
+- **`stop(...)`** raises an error whose message is the concatenation of its
+  arguments (coerced to character, like `cat`/`paste0`). It surfaces as a new
+  typed error variant `SError::User(String)` so a `stop()` is distinguishable
+  from an internal type/index error — but both are catchable by `tryCatch`.
+- **`warning(...)`** emits a warning (message concatenated as for `stop`) into a
+  session-held buffer and prints it as `Warning message:\n<msg>`; it does **not**
+  abort and returns an **invisible `NULL`**.
+- **`tryCatch(expr, error = handler, finally = cleanup)`** evaluates `expr`; if it
+  raises *any* error, the `error` handler is called with a **condition object**
+  and its value becomes the result; otherwise the value of `expr` is the result.
+  The `finally` expression, if present, is evaluated for its side effects **after**
+  `expr`/handler regardless of success or failure. The condition object is a
+  minimal `list(message = <chr>, call = NULL)` with S3 class
+  `c("simpleError", "error", "condition")`, so `conditionMessage(e)` and
+  `e$message` both yield the message (full R condition machinery —
+  `simpleCondition`, custom classes, `withCallingHandlers`, restarts — is out of
+  scope). The internal `break`/`next` control signals are **not** caught (they are
+  not user errors). Handler re-entry is bounded by the evaluator's existing
+  `MAX_EVAL_DEPTH`, so a handler that re-raises cannot overflow the stack.
+- **`conditionMessage(e)`** returns the `message` element of a condition object
+  (the character message), for parity with R's accessor.
+
 ## §9 Divergences from ST00 (spec-sync)
 
 1. **S before R.** ST00 specs R first; we implement historical S first. The two


### PR DESCRIPTION
## R-18 — `switch()` + error handling

Implements R's value-returning multi-way branch and condition-based error handling in the shared S tree-walker, so both R and historical S inherit them through the same evaluator (`r-runtime` stays a thin wrapper).

### What shipped

- **`switch(EXPR, ...)`** — a **lazy special form**. The call dispatcher (`eval_postfix`) intercepts a bare-name call to `switch` *before* evaluating its arguments, so it sees the unevaluated arm expressions and evaluates only the selected one.
  - Character `EXPR` matches arm **names**; an **unnamed final arm** is the default; no match and no default → **invisible `NULL`**.
  - Numeric `EXPR` selects the **n-th arm by position** (1-based); out of range / NA / `< 1` → `NULL`.
  - Because only the chosen arm runs, `switch("a", a = "ok", b = stop("x"))` does not raise.
- **`stop(...)`** — raises a new typed error `SError::User` (concatenated message), catchable by `tryCatch`.
- **`warning(...)`** — records + prints a warning (bounded by `MAX_WARNINGS`) and returns **invisibly without aborting**.
- **`tryCatch(expr, error = handler, finally = cleanup)`** — also a **lazy special form**: evaluates `expr`, routes any *catchable* error to the `error` handler (called with a minimal condition object), returns the handler's value, and always runs `finally`. Loop-control signals (`break`/`next`) are **not** caught (`SError::is_catchable`).
- **`conditionMessage(e)`** / `e$message` — recover the condition's message. The condition object is `list(message, call)` classed `c("simpleError", "error", "condition")`.

### Lazy-eval approach

`switch` and `tryCatch` cannot be ordinary (eager) builtins — they need the *unevaluated* argument expressions. They are intercepted in `eval_postfix` at the call site (when the postfix is exactly `<bare-name> ( args )`), and `raw_args` collects `(name, expr-node)` pairs without evaluating anything. Only the selected `switch` arm / `tryCatch` protected expression / chosen handler / `finally` block is then passed to `eval_node`. Each is evaluated **at most once** (no double-evaluation of side effects), proven by tests where an unselected arm or an un-needed handler would `stop()` / reference an undefined name but never runs. Handler re-entry is bounded by the evaluator's existing `MAX_EVAL_DEPTH`.

### Deferred to R-19

- **Empty-arm fall-through** `switch("a", a = , b = "hit")` → `"hit"`. The shared S/R grammar's `arg = NAME EQ expr` has no empty-value production, so `a = ,` is a *parse* error today. `eval_switch` already implements the fall-through (the loop over `arms[pos..]` skipping empty arms); it activates once the grammar admits empty args. This avoids broadening the PR into the parser/grammar packages.

### Tests

- **s-runtime** (S syntax): switch character match / default / no-match→NULL, numeric in-range / out-of-range, laziness (unselected `stop()` arm not run), `stop` raises `SError::User`, `tryCatch(error=)` catches and returns the handler value, `conditionMessage`/`e$message`, `finally` on success and on catch, handler-not-run-on-success, `warning` does not abort, nested rethrow, and that a `break` inside a switch arm is not swallowed. Plus `SError` unit tests for the new variant / `is_catchable` / `condition_message`.
- **r-runtime** (R syntax): mirrors the above through the R parser (using `_`-names like `undefined_var` that only R admits), plus regressions confirming R-15 / R-16 / R-17 still work.
- `cargo test -p coding-adventures-s-runtime -p coding-adventures-r-runtime` — **all green** (s-runtime 155, r-runtime 99, doctests 1 + 1). `cargo clippy` clean for both touched crates.

### Security review

No Agent/Task sub-agent tool exists in this environment, so the review was performed **inline** (senior Rust security engineer lens over `git diff origin/main...HEAD`). **Result: PASSED — no vulnerabilities.** Checked: unbounded recursion via `tryCatch` re-entry (bounded by `MAX_EVAL_DEPTH`); panics/unwrap on malformed `switch`/`tryCatch` args (the `unreachable!()` is provably unreachable; all slice indexing is guarded; `f64 as usize` saturates, `- 1` guarded by `x >= 1.0`); error-message construction (user text is data, never a format string — no injection); the lazy path not double-evaluating side effects (each expression evaluated at most once); and DoS (warning buffer bounded by `MAX_WARNINGS`, no unbounded allocation).

### Diff hygiene

Functional-only: spec + source + tests + changelogs/readmes. No unrelated rustfmt churn — only the changed regions were formatted (local rustfmt 1.9.0 disagrees with CI on some pre-existing R-17 lines, which were left untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
