### PR TITLE
feat(mycin-rheum): backfill RA→anti-CCP and Sjögren→anti-Ro/La (primary-source-first)

### DIFF
--- a/code/specs/data/mycin-2026/USMLE-DOMAIN-MAP.md
+++ b/code/specs/data/mycin-2026/USMLE-DOMAIN-MAP.md
@@ -109,7 +109,7 @@ unchanged. Adding a relation just widens the schema — the engine already binds
 | Pharmacology | Pharmacology | drug_class, mechanism, adverse_effect, antidote_for | 9 grounded (ADJ-only) | ✓ |
 | Immunology | Immunology | mediated_by, associated_hla, gene_defect, deficiency_of | 7 grounded (ADJ-only) | ✓ |
 | Genetics | Genetics | inheritance, gene_defect, trinucleotide_repeat, imprinting | 7 grounded (ADJ-only) | ✓ |
-| Rheumatology (Tier-2) | Path/Immuno | associated_autoantibody | 6 grounded (ADJ-only) | ✓ |
+| Rheumatology (Tier-2) | Path/Immuno | associated_autoantibody | 9 grounded (ADJ-only) | ✓ |
 | Oncology (Tier-2) | Pathology/neoplasia | tumor_marker | 4 grounded (ADJ-only) | ✓ |
 | Histology buzzwords (Tier-2) | Pathology | seen_in (finding→condition) | 5 grounded (ADJ-only) | ✓ |
 | Cardiology murmurs (Tier-2) | Cardiology | murmur_indicates (murmur→lesion) | 5 grounded (ADJ-only) | ✓ |
@@ -204,9 +204,11 @@ faithfulness gate, zero online calls (OFFLINE-BOARD-EXAM.md).
     *Started (RHEUM — first Tier-2 domain):* `associated_autoantibody` for SLE (anti-dsDNA,
     anti-Sm, anti-ribosomal-P), GPA (PR3-ANCA), systemic sclerosis (anti-Scl-70,
     anti-centromere) — 6 edges, all grounded to byte-stable NCBI StatPearls spans, shipped
-    as the fifth **ADJ-only** domain (`recall/rheum-edges.adj`). Remaining: RA→anti-CCP,
-    PBC→anti-mitochondrial, Sjögren→anti-Ro/La, polymyositis→anti-Jo1 (deferred — pages
-    discuss these in risk-factor/criteria context, no clean both-endpoints-named span yet).
+    as the fifth **ADJ-only** domain (`recall/rheum-edges.adj`). **Backfilled** (primary-
+    source-first, zero-deferral): RA→anti-CCP (NBK441999, ACPA defined = anti-CCP on page)
+    and Sjögren→anti-Ro/SSA + anti-La/SSB (NBK431049, one span names disease + both markers)
+    — now 9 grounded edges. Still pursued for the next backfill (need a both-endpoints span
+    from a primary source): PBC→anti-mitochondrial, polymyositis/antisynthetase→anti-Jo1.
 11. Skin/derm (lesion→diagnosis)
     *Started (DERM — seventh Tier-2 domain):* `skin_finding_in` for target lesions→erythema
     multiforme (NBK470259), silvery scales→psoriasis (NBK448194), umbilicated papules→

--- a/code/specs/data/mycin-2026/board/board-scorecard.json
+++ b/code/specs/data/mycin-2026/board/board-scorecard.json
@@ -1,7 +1,7 @@
 {
   "summary": {
-    "total": 135,
-    "correct": 128,
+    "total": 137,
+    "correct": 130,
     "abstained": 7,
     "wrong": 0,
     "by_tactic": {
@@ -16,15 +16,15 @@
         "wrong": 0
       },
       "recall": {
-        "correct": 122,
+        "correct": 124,
         "abstained": 6,
         "wrong": 0
       }
     },
     "defensibility": 1.0,
     "accuracy_on_attempted": 1.0,
-    "grounded_coverage": 0.9918,
-    "grounded_correct": 121
+    "grounded_coverage": 0.9919,
+    "grounded_correct": 123
   },
   "results": [
     {
@@ -864,6 +864,22 @@
       "tactic": "recall",
       "gold": "anti_scl70",
       "answer": "anti_scl70",
+      "outcome": "correct",
+      "trust": "authoritative"
+    },
+    {
+      "id": "rheum_ra_ab",
+      "tactic": "recall",
+      "gold": "anti_ccp",
+      "answer": "anti_ccp",
+      "outcome": "correct",
+      "trust": "authoritative"
+    },
+    {
+      "id": "rheum_sjo_ab",
+      "tactic": "recall",
+      "gold": "anti_ro",
+      "answer": "anti_ro",
       "outcome": "correct",
       "trust": "authoritative"
     },

--- a/code/specs/data/mycin-2026/board/items.json
+++ b/code/specs/data/mycin-2026/board/items.json
@@ -119,6 +119,8 @@
     {"id": "rheum_sle_ab",   "domain": "rheum", "tactic": "recall", "relation": "associated_autoantibody", "subject": "systemic_lupus_erythematosus",   "var": "Antibody", "gold": "anti_dsdna"},
     {"id": "rheum_gpa_ab",   "domain": "rheum", "tactic": "recall", "relation": "associated_autoantibody", "subject": "granulomatosis_with_polyangiitis","var": "Antibody", "gold": "pr3"},
     {"id": "rheum_ssc_ab",   "domain": "rheum", "tactic": "recall", "relation": "associated_autoantibody", "subject": "systemic_sclerosis",            "var": "Antibody", "gold": "anti_scl70"},
+    {"id": "rheum_ra_ab",    "domain": "rheum", "tactic": "recall", "relation": "associated_autoantibody", "subject": "rheumatoid_arthritis",           "var": "Antibody", "gold": "anti_ccp"},
+    {"id": "rheum_sjo_ab",   "domain": "rheum", "tactic": "recall", "relation": "associated_autoantibody", "subject": "sjogren_syndrome",              "var": "Antibody", "gold": "anti_ro"},
 
     {"id": "onco_ovarian_marker", "domain": "onco", "tactic": "recall", "relation": "tumor_marker", "subject": "ovarian_cancer",               "var": "Marker", "gold": "ca_125"},
     {"id": "onco_mtc_marker",     "domain": "onco", "tactic": "recall", "relation": "tumor_marker", "subject": "medullary_thyroid_carcinoma",   "var": "Marker", "gold": "calcitonin"},

--- a/code/specs/data/mycin-2026/board/test_board_eval.py
+++ b/code/specs/data/mycin-2026/board/test_board_eval.py
@@ -51,7 +51,7 @@ def test_covered_items_answer_correctly_with_a_proof() -> None:
     # answers, so the board scores the top binding per subject (the libraries + their
     # tests cover all edges).
     recall_correct = [r for r in card.results if r.outcome == "correct" and r.tactic == "recall"]
-    assert len(recall_correct) == 122
+    assert len(recall_correct) == 124
     assert by_id["fabry_enzyme"].outcome == "correct"               # IEM
     assert by_id["thiamine_disease"].answer == "beriberi"           # vitamin
     assert by_id["ida_mcv"].answer == "microcytic"                  # anemia
@@ -75,6 +75,9 @@ def test_covered_items_answer_correctly_with_a_proof() -> None:
     assert by_id["rheum_sle_ab"].answer == "anti_dsdna"          # rheumatology (RHEUM, Tier-2)
     assert by_id["rheum_gpa_ab"].answer == "pr3"                 # rheum — autoantibody association
     assert by_id["rheum_sle_ab"].trust == "authoritative"        # ADJ-only edge, grounded inline
+    assert by_id["rheum_ra_ab"].answer == "anti_ccp"            # primary-source backfill: RA→anti-CCP
+    assert by_id["rheum_sjo_ab"].answer == "anti_ro"           # primary-source backfill: Sjögren→anti-Ro/SSA
+    assert by_id["rheum_ra_ab"].trust == "authoritative"        # previously deferred, now grounded
     assert by_id["onco_ovarian_marker"].answer == "ca_125"       # oncology (ONCO, Tier-2)
     assert by_id["onco_hcc_marker"].answer == "alpha_fetoprotein"  # onco — tumor_marker relation
     assert by_id["onco_ovarian_marker"].trust == "authoritative"  # ADJ-only edge, grounded inline
@@ -140,8 +143,8 @@ def test_grounded_coverage_is_the_live_grounding_number() -> None:
     # verbatim, so the framework declines to claim grounding it cannot defend, by design:
     # cortisol_def (endocrine, deficiency_syndrome__cortisol — the only verbatim spans frame
     # cortisol deficiency as a consequence/feature of Addison disease, not the named-syndrome identity).
-    assert s["grounded_coverage"] == round(121 / 122, 4)   # 0.9918
-    assert s["grounded_correct"] == 121
+    assert s["grounded_coverage"] == round(123 / 124, 4)   # 0.9919
+    assert s["grounded_correct"] == 123
     by_id = {r.item_id: r for r in card.results}
     assert by_id["tay_sachs_enzyme"].trust == "authoritative"      # IEM
     assert by_id["ida_mcv"].trust == "authoritative"               # anemia

--- a/code/specs/data/mycin-2026/recall/rheum-edges.adj
+++ b/code/specs/data/mycin-2026/recall/rheum-edges.adj
@@ -19,11 +19,14 @@
 % check. (See feedback_nothing_human_authored, feedback_adj_only_shipped_artifacts.)
 %
 % Honest scope: only edges whose cited span states the autoantibody↔disease association
-% AND names both endpoints are included. Declined here (the pages discuss these antibodies
-% in risk-factor / diagnostic-accuracy / citation-title context, not a self-contained
-% "antibody X marks disease Y" declarative): rheumatoid arthritis → anti-CCP, and primary
-% biliary cholangitis → anti-mitochondrial (the AMA "85% of cases" sentence does not name
-% PBC in-span). They deserve a span that names both endpoints, not an over-reach.
+% AND names both endpoints are included. Under the primary-source-first, zero-deferral
+% policy, two previously-declined associations are now GROUNDED from spans that name both
+% endpoints: rheumatoid arthritis → anti-CCP (the RA page defines ACPA = anti-cyclic
+% citrullinated peptide antibodies and names them among RA's best-known autoantibodies)
+% and Sjögren syndrome → anti-Ro/SSA and anti-La/SSB (one span names the disease and both
+% markers). Still pursued for the next backfill (need a primary source with a both-
+% endpoints span): primary biliary cholangitis → anti-mitochondrial, and polymyositis /
+% antisynthetase → anti-Jo-1.
 % ============================================================================
 
 dictionary rheum_vocab {
@@ -64,5 +67,23 @@ rulebook rheum_facts {
     relate associated_autoantibody(systemic_sclerosis, anti_centromere)
         source "Antinuclear antibodies may be present in more than 90% of cases of systemic sclerosis, and up to 70% of cases exhibit at least one of the more specific autoantibodies (anti-centromere, anti-Scl-70, and anti-RNA polymerase III)."
         locator "https://www.ncbi.nlm.nih.gov/books/NBK430875/"
+        trust authoritative
+
+    % --- BACKFILL (primary-source-first): rheumatoid arthritis → anti-CCP (ACPA) ---
+    % The cited page defines: "These antibodies are called anti-cyclic citrullinated
+    % peptide antibodies (ACPA)." — so ACPA here IS anti-CCP, named among RA's autoantibodies.
+    relate associated_autoantibody(rheumatoid_arthritis, anti_ccp)
+        source "RF and ACPA antibodies are the best-known autoantibodies in RA, but several other autoantibodies are relatively specific for RA."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK441999/"
+        trust authoritative
+
+    % --- BACKFILL: Sjögren syndrome → anti-Ro/SSA and anti-La/SSB (one span names both) ---
+    relate associated_autoantibody(sjogren_syndrome, anti_ro)
+        source "B cells generate autoantibodies characteristic of Sjögren disease, including rheumatoid factor, SSA/Ro, and SSB/La."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK431049/"
+        trust authoritative
+    relate associated_autoantibody(sjogren_syndrome, anti_la)
+        source "B cells generate autoantibodies characteristic of Sjögren disease, including rheumatoid factor, SSA/Ro, and SSB/La."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK431049/"
         trust authoritative
 }

--- a/code/specs/data/mycin-2026/recall/rheum-recall.query.adj
+++ b/code/specs/data/mycin-2026/recall/rheum-recall.query.adj
@@ -17,3 +17,5 @@ import "rheum-edges.adj"
 ? associated_autoantibody(systemic_lupus_erythematosus, $Antibody)   % expect anti_dsdna / anti_smith / anti_ribosomal_p
 ? associated_autoantibody(granulomatosis_with_polyangiitis, $Antibody)  % expect pr3
 ? associated_autoantibody(systemic_sclerosis, $Antibody)             % expect anti_scl70 / anti_centromere
+? associated_autoantibody(rheumatoid_arthritis, $Antibody)           % expect anti_ccp        (backfill)
+? associated_autoantibody(sjogren_syndrome, $Antibody)               % expect anti_ro / anti_la (backfill)

--- a/code/specs/data/mycin-2026/recall/test_rheum_recall.py
+++ b/code/specs/data/mycin-2026/recall/test_rheum_recall.py
@@ -33,6 +33,8 @@ EXPECTED = {
     "systemic_lupus_erythematosus": {"anti_dsdna", "anti_smith", "anti_ribosomal_p"},
     "granulomatosis_with_polyangiitis": {"pr3"},
     "systemic_sclerosis": {"anti_scl70", "anti_centromere"},
+    "rheumatoid_arthritis": {"anti_ccp"},                 # primary-source backfill (NBK441999)
+    "sjogren_syndrome": {"anti_ro", "anti_la"},           # primary-source backfill (NBK431049)
 }
 REL = "associated_autoantibody"
 VAR = "Antibody"


### PR DESCRIPTION
## What

Retroactively **grounds two previously-deferred** rheumatology autoantibody associations, enacting the **primary-source-first / zero-deferral** policy: declining for phrasing is not allowed — an association is grounded from whatever primary authority carries a clean both-endpoints span.

`rheum-edges.adj` **6 → 9 edges** (all byte-stable, both endpoints named):

| disease | autoantibody | source |
|---|---|---|
| rheumatoid arthritis | anti-CCP (ACPA) | NBK441999 — the page defines *anti-cyclic citrullinated peptide antibodies (ACPA)* and names RF + ACPA as RA's best-known autoantibodies |
| Sjögren syndrome | anti-Ro / SSA | NBK431049 — one span names the disease **and** both SSA/Ro and SSB/La |
| Sjögren syndrome | anti-La / SSB | NBK431049 (same span) |

**Still pursued for the next backfill** (need a primary-source both-endpoints span): PBC → anti-mitochondrial, polymyositis/antisynthetase → anti-Jo-1.

## Verification
- `test_rheum_recall.py` **3/3** — multi-answer-aware (Sjögren binds {anti_ro, anti_la}); engine cites authoritative spans; off-vocab abstains.
- `test_board_eval.py` **12/12** — recall 122→**124** correct, grounded 121→**123** (123/124 = **0.9919**), **0 wrong**, **defensibility 1.0**.
- Security review **PASSED** (incl. the non-ASCII "ö" in the Sjögren span — UTF-8, no string-context breakout).

## Wiring
2 query lines + 2 `EXPECTED` entries; 2 board items (`rheum_ra_ab`, `rheum_sjo_ab` — file-order-first answer); scorecard regenerated; USMLE-DOMAIN-MAP RHEUM row 6→9.

> Note: `code/specs/data/mycin-2026` is not wired into CI (no BUILD file); local runs above are the verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)