### PR TITLE
feat(r-19): empty-arm switch() fall-through

### DIFF
--- a/code/grammars/r.grammar
+++ b/code/grammars/r.grammar
@@ -107,7 +107,16 @@ arg_list = arg { COMMA arg } ;
 
 # Named argument (NAME = expr) tried before a positional expression. `==` is the
 # EQEQ token (distinct from EQ), so `f(x == 1)` is a positional comparison.
-arg = NAME EQ expr
+#
+# The value after `NAME EQ` is OPTIONAL: `NAME EQ [expr]`. This admits an EMPTY
+# named argument — `a = ,` or `a = )` — which `switch` uses for fall-through:
+# `switch("a", a = , b = "hit")` returns `"hit"` (an empty arm falls through to
+# the next non-empty arm's value). The empty form parses everywhere an arg list
+# appears, but is only MEANINGFUL in `switch`; an empty arg in an ordinary call
+# (`f(x = )`) is rejected at eval time, matching R. The optional `expr` is only
+# ever followed by `COMMA` or `RPAREN` (the arg_list / call_suffix terminators),
+# so the rule stays LL(1).
+arg = NAME EQ [ expr ]
     | expr ;
 
 # =============================================================================

--- a/code/grammars/s.grammar
+++ b/code/grammars/s.grammar
@@ -145,7 +145,16 @@ arg_list = arg { COMMA arg } ;
 
 # A named argument (NAME = expr) is tried before a positional expression.
 # `==` is the EQEQ token, distinct from EQ, so `f(x == 1)` is positional.
-arg = NAME EQ expr
+#
+# The value after `NAME EQ` is OPTIONAL: `NAME EQ [expr]`. This admits an EMPTY
+# named argument — `a = ,` or `a = )` — which `switch` uses for fall-through:
+# `switch("a", a = , b = "hit")` returns `"hit"` (an empty arm falls through to
+# the next non-empty arm's value). The empty form parses everywhere an arg list
+# appears, but is only MEANINGFUL in `switch`; an empty arg in an ordinary call
+# (`f(x = )`) is rejected at eval time, matching R. Because the optional `expr`
+# is followed only by `COMMA` or `RPAREN` (the arg_list / call_suffix
+# terminators, both distinct from any `expr` start token), the rule stays LL(1).
+arg = NAME EQ [ expr ]
     | expr ;
 
 # =============================================================================

--- a/code/packages/rust/r-parser/CHANGELOG.md
+++ b/code/packages/rust/r-parser/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.3.0] - 2026-06-19
+
+### Changed
+
+- **R-19 grammar**: the `arg` rule now allows an **empty named-argument value** —
+  `arg = NAME EQ [expr] | expr`, mirroring the shared S/R grammar change. A named
+  argument may omit its value (`a = ,` / `a = )`), enabling `switch`'s empty-arm
+  fall-through (`switch("a", a = , b = "hit")` → `"hit"`). The optional `expr` is
+  only ever followed by `COMMA` or `RPAREN`, so the rule stays LL(1). Regenerated
+  the embedded `src/_grammar.rs` (single-line functional change:
+  `expr` → `Optional(expr)`).
+
 ## [0.2.0] - 2026-06-16
 
 ### Added

--- a/code/packages/rust/r-parser/README.md
+++ b/code/packages/rust/r-parser/README.md
@@ -25,7 +25,10 @@ The only grammar differences from S are where R departs from S:
 
 Inside a call, `f(x = 1)` is still a *named argument*: the `arg` rule tries
 `NAME = expr` before the positional `expr`, so `=`-as-assignment at the top level
-and `=`-as-named-arg inside calls coexist.
+and `=`-as-named-arg inside calls coexist. Since R-19 the value is **optional** —
+`arg = NAME EQ [expr] | expr` — so a named argument may omit its value (`a = ,`).
+This admits `switch`'s empty-arm fall-through (`switch("a", a = , b = "hit")` →
+`"hit"`); the empty value parses anywhere but is only meaningful in `switch`.
 
 ## Usage
 

--- a/code/packages/rust/r-parser/src/_grammar.rs
+++ b/code/packages/rust/r-parser/src/_grammar.rs
@@ -235,11 +235,11 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Sequence { elements: vec![
                     GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
                     GrammarElement::TokenReference { name: r#"EQ"#.to_string() },
-                    GrammarElement::RuleReference { name: r#"expr"#.to_string() },
+                    GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"expr"#.to_string() }) },
                 ] },
                 GrammarElement::RuleReference { name: r#"expr"#.to_string() },
             ] },
-            line_number: 110,
+            line_number: 119,
         },
         GrammarRule {
             name: r#"primary"#.to_string(),
@@ -271,7 +271,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::RuleReference { name: r#"group"#.to_string() },
                 GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
             ] },
-            line_number: 118,
+            line_number: 127,
         },
         GrammarRule {
             name: r#"group"#.to_string(),
@@ -280,7 +280,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::RuleReference { name: r#"expr"#.to_string() },
                 GrammarElement::TokenReference { name: r#"RPAREN"#.to_string() },
             ] },
-            line_number: 145,
+            line_number: 154,
         },
         GrammarRule {
             name: r#"block"#.to_string(),
@@ -289,7 +289,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"statement_line"#.to_string() }) },
                 GrammarElement::TokenReference { name: r#"RBRACE"#.to_string() },
             ] },
-            line_number: 147,
+            line_number: 156,
         },
         GrammarRule {
             name: r#"func_def"#.to_string(),
@@ -309,7 +309,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     GrammarElement::RuleReference { name: r#"expr"#.to_string() },
                 ] },
             ] },
-            line_number: 152,
+            line_number: 161,
         },
         GrammarRule {
             name: r#"param_list"#.to_string(),
@@ -320,7 +320,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"param"#.to_string() },
                     ] }) },
             ] },
-            line_number: 155,
+            line_number: 164,
         },
         GrammarRule {
             name: r#"param"#.to_string(),
@@ -332,7 +332,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 ] },
                 GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
             ] },
-            line_number: 157,
+            line_number: 166,
         },
         GrammarRule {
             name: r#"if_expr"#.to_string(),
@@ -347,7 +347,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"expr"#.to_string() },
                     ] }) },
             ] },
-            line_number: 160,
+            line_number: 169,
         },
         GrammarRule {
             name: r#"for_expr"#.to_string(),
@@ -360,7 +360,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::TokenReference { name: r#"RPAREN"#.to_string() },
                 GrammarElement::RuleReference { name: r#"expr"#.to_string() },
             ] },
-            line_number: 162,
+            line_number: 171,
         },
         GrammarRule {
             name: r#"while_expr"#.to_string(),
@@ -371,7 +371,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::TokenReference { name: r#"RPAREN"#.to_string() },
                 GrammarElement::RuleReference { name: r#"expr"#.to_string() },
             ] },
-            line_number: 164,
+            line_number: 173,
         },
         GrammarRule {
             name: r#"repeat_expr"#.to_string(),
@@ -379,7 +379,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"repeat"#.to_string() },
                 GrammarElement::RuleReference { name: r#"expr"#.to_string() },
             ] },
-            line_number: 166,
+            line_number: 175,
         },
     ],
         version: 1,

--- a/code/packages/rust/r-parser/src/lib.rs
+++ b/code/packages/rust/r-parser/src/lib.rs
@@ -156,6 +156,18 @@ mod tests {
     }
 
     #[test]
+    fn empty_named_argument_parses() {
+        // R-19: `arg = NAME EQ [expr]` — a named argument may omit its value,
+        // which `switch`'s empty-arm fall-through relies on.
+        assert!(parses("switch(\"a\", a = , b = \"hit\")\n"));
+        assert!(parses("switch(\"b\", a = \"A\", b = )\n"));
+        assert!(parses("switch(\"a\", a = , b = , c = \"z\")\n"));
+        // Empty value parses in any call (eval rejects it outside switch).
+        assert!(parses("f(x = )\n"));
+        assert!(parses("f(x = 1, y = 2)\n"));
+    }
+
+    #[test]
     fn typed_na_constants_parse() {
         for src in ["NA_integer_\n", "NA_real_\n", "NA_character_\n"] {
             assert!(parses(src), "should parse: {src:?}");

--- a/code/packages/rust/r-runtime/CHANGELOG.md
+++ b/code/packages/rust/r-runtime/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.14.0] - 2026-06-19
+
+### Added (via the shared `s-runtime`)
+
+- **R-19 — empty-arm `switch()` fall-through**: `switch("a", a = , b = "hit")`
+  now returns `"hit"` in R syntax too. R-18 deferred this because the shared S/R
+  grammar had no empty named-argument production; R-19 extends `r.grammar`'s `arg`
+  rule to `arg = NAME EQ [expr] | expr` (mirroring the S change) and regenerates
+  `r-parser`'s embedded `_grammar.rs`. Fall-through chains across several empty
+  arms (`a = , b = , c = "z"` → `"z"`); a matched empty arm with nothing
+  non-empty after it yields `NULL`. An empty arg in an ordinary call is an
+  eval-time error, matching R. See `s-runtime` 0.15.0.
+
 ## [0.13.0] - 2026-06-19
 
 ### Added (via the shared `s-runtime`)

--- a/code/packages/rust/r-runtime/README.md
+++ b/code/packages/rust/r-runtime/README.md
@@ -46,6 +46,11 @@ does not raise). `stop(...)` raises an error, `warning(...)` emits a warning and
 returns invisibly without aborting, and `tryCatch(expr, error = fn, finally =
 cleanup)` runs `expr`, routes any error to `error` (with a condition object whose
 `conditionMessage(e)` / `e$message` give the message), and always runs `finally`.
+An **empty arm** falls through to the next non-empty arm (R-19):
+`switch("a", a = , b = "hit")` → `"hit"`, chaining across several empties
+(`a = , b = , c = "z"` → `"z"`). This needed a shared-grammar change
+(`arg = NAME EQ [expr] | expr`) so `a = ,` parses; an empty arg in an ordinary
+call is an eval-time error.
 
 ## Usage
 

--- a/code/packages/rust/r-runtime/src/lib.rs
+++ b/code/packages/rust/r-runtime/src/lib.rs
@@ -1229,6 +1229,42 @@ mod tests {
         assert_eq!(show("switch(\"z\", a = \"A\", b = \"B\")\n"), "NULL");
     }
 
+    // --- R-19: empty-arm switch() fall-through (R syntax) ---------------
+
+    #[test]
+    fn switch_empty_arm_falls_through_r_syntax() {
+        // R-19: `switch("a", a = , b = "hit")` → "hit". The empty arm `a = ,`
+        // now parses (grammar `arg = NAME EQ [expr]`) and falls through.
+        assert_eq!(show("switch(\"a\", a = , b = \"hit\")\n"), "[1] \"hit\"");
+    }
+
+    #[test]
+    fn switch_empty_arm_chains_r_syntax() {
+        // Multi fall-through: a = , b = , c = "z" → "z".
+        assert_eq!(
+            show("switch(\"a\", a = , b = , c = \"z\")\n"),
+            "[1] \"z\""
+        );
+        // Matching a middle empty arm chains forward to the next value.
+        assert_eq!(
+            show("switch(\"b\", a = \"A\", b = , c = \"z\")\n"),
+            "[1] \"z\""
+        );
+    }
+
+    #[test]
+    fn switch_last_arm_empty_yields_null_r_syntax() {
+        // Matched arm empty with nothing after → invisible NULL.
+        assert_eq!(show("switch(\"b\", a = \"A\", b = )\n"), "NULL");
+    }
+
+    #[test]
+    fn empty_named_arg_in_ordinary_call_errors_r_syntax() {
+        // The empty value is only meaningful in switch; in an ordinary call it
+        // is an eval-time error (no panic), matching R.
+        assert!(eval_r("c(x = )\n").is_err());
+    }
+
     #[test]
     fn switch_numeric_position_r_syntax() {
         assert_eq!(

--- a/code/packages/rust/s-parser/CHANGELOG.md
+++ b/code/packages/rust/s-parser/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.3.0] - 2026-06-19
+
+### Changed
+
+- **R-19 grammar**: the `arg` rule now allows an **empty named-argument value** —
+  `arg = NAME EQ [expr] | expr`. A named argument may omit its value (`a = ,` /
+  `a = )`), which `switch`'s empty-arm fall-through relies on
+  (`switch("a", a = , b = "hit")` → `"hit"`). The optional `expr` is only ever
+  followed by `COMMA` or `RPAREN`, so the rule stays LL(1). This is a shared
+  S/R grammar change; `r-parser` carries the mirror. Regenerated the embedded
+  `src/_grammar.rs` (single-line functional change: `expr` → `Optional(expr)`).
+
 ## [0.2.0] - 2026-06-15
 
 ### Added

--- a/code/packages/rust/s-parser/src/_grammar.rs
+++ b/code/packages/rust/s-parser/src/_grammar.rs
@@ -223,11 +223,11 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Sequence { elements: vec![
                     GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
                     GrammarElement::TokenReference { name: r#"EQ"#.to_string() },
-                    GrammarElement::RuleReference { name: r#"expr"#.to_string() },
+                    GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"expr"#.to_string() }) },
                 ] },
                 GrammarElement::RuleReference { name: r#"expr"#.to_string() },
             ] },
-            line_number: 148,
+            line_number: 157,
         },
         GrammarRule {
             name: r#"primary"#.to_string(),
@@ -253,7 +253,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::RuleReference { name: r#"group"#.to_string() },
                 GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
             ] },
-            line_number: 159,
+            line_number: 168,
         },
         GrammarRule {
             name: r#"group"#.to_string(),
@@ -262,7 +262,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::RuleReference { name: r#"expr"#.to_string() },
                 GrammarElement::TokenReference { name: r#"RPAREN"#.to_string() },
             ] },
-            line_number: 180,
+            line_number: 189,
         },
         GrammarRule {
             name: r#"block"#.to_string(),
@@ -271,7 +271,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"statement_line"#.to_string() }) },
                 GrammarElement::TokenReference { name: r#"RBRACE"#.to_string() },
             ] },
-            line_number: 182,
+            line_number: 191,
         },
         GrammarRule {
             name: r#"func_def"#.to_string(),
@@ -282,7 +282,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::TokenReference { name: r#"RPAREN"#.to_string() },
                 GrammarElement::RuleReference { name: r#"expr"#.to_string() },
             ] },
-            line_number: 191,
+            line_number: 200,
         },
         GrammarRule {
             name: r#"param_list"#.to_string(),
@@ -293,7 +293,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"param"#.to_string() },
                     ] }) },
             ] },
-            line_number: 193,
+            line_number: 202,
         },
         GrammarRule {
             name: r#"param"#.to_string(),
@@ -305,7 +305,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 ] },
                 GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
             ] },
-            line_number: 195,
+            line_number: 204,
         },
         GrammarRule {
             name: r#"if_expr"#.to_string(),
@@ -320,7 +320,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"expr"#.to_string() },
                     ] }) },
             ] },
-            line_number: 198,
+            line_number: 207,
         },
         GrammarRule {
             name: r#"for_expr"#.to_string(),
@@ -333,7 +333,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::TokenReference { name: r#"RPAREN"#.to_string() },
                 GrammarElement::RuleReference { name: r#"expr"#.to_string() },
             ] },
-            line_number: 200,
+            line_number: 209,
         },
         GrammarRule {
             name: r#"while_expr"#.to_string(),
@@ -344,7 +344,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::TokenReference { name: r#"RPAREN"#.to_string() },
                 GrammarElement::RuleReference { name: r#"expr"#.to_string() },
             ] },
-            line_number: 202,
+            line_number: 211,
         },
         GrammarRule {
             name: r#"repeat_expr"#.to_string(),
@@ -352,7 +352,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"repeat"#.to_string() },
                 GrammarElement::RuleReference { name: r#"expr"#.to_string() },
             ] },
-            line_number: 204,
+            line_number: 213,
         },
     ],
         version: 1,

--- a/code/packages/rust/s-parser/src/lib.rs
+++ b/code/packages/rust/s-parser/src/lib.rs
@@ -143,6 +143,22 @@ mod tests {
     }
 
     #[test]
+    fn empty_named_argument_parses() {
+        // R-19: `arg = NAME EQ [expr]` — a named argument may omit its value.
+        // This is what `switch`'s empty-arm fall-through relies on.
+        assert!(parses("switch(\"a\", a = , b = \"hit\")\n"));
+        // An empty arm followed by `)` (last-arm-empty) parses too.
+        assert!(parses("switch(\"b\", a = \"A\", b = )\n"));
+        // Multiple consecutive empties.
+        assert!(parses("switch(\"a\", a = , b = , c = \"z\")\n"));
+        // The empty value is grammatically valid in any call (eval rejects it
+        // outside switch, but it must PARSE).
+        assert!(parses("f(x = )\n"));
+        // A normal named arg with a value still parses (no regression).
+        assert!(parses("f(x = 1, y = 2)\n"));
+    }
+
+    #[test]
     fn arithmetic_and_precedence_nodes() {
         let ast = parse_s("1 + 2 * 3 ^ 2\n");
         for rule in ["additive", "multiplicative", "power"] {

--- a/code/packages/rust/s-runtime/CHANGELOG.md
+++ b/code/packages/rust/s-runtime/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.15.0] - 2026-06-19
+
+### Added
+
+- **Empty-arm `switch()` fall-through (R-19)** — `switch("a", a = , b = "hit")`
+  now returns `"hit"`. R-18 already implemented the fall-through in `eval_switch`
+  (an empty arm has `arm_body() == None`, so the loop over `arms[pos..]` skips to
+  the next non-empty value), but it was inert because the shared S/R grammar's
+  `arg = NAME EQ expr` rejected an empty value. R-19 extends the grammar to
+  `arg = NAME EQ [expr] | expr` (see `s-parser`/`r-parser` 0.3.0) and regenerates
+  both compiled `_grammar.rs`, so `a = ,` finally parses. The fall-through chains
+  across several empty arms (`a = , b = , c = "z"` → `"z"`); a matched empty arm
+  with nothing non-empty after it yields invisible `NULL`.
+
+### Note
+
+- The empty named-argument value parses everywhere an arg list appears, but is
+  only **meaningful** in `switch`. In an ordinary call (`c(x = )`) it surfaces as
+  an eval-time parse-style error via `eval_arg`'s `only_node` (no panic),
+  matching R's "argument is missing" behaviour.
+
 ## [0.14.0] - 2026-06-19
 
 ### Added

--- a/code/packages/rust/s-runtime/README.md
+++ b/code/packages/rust/s-runtime/README.md
@@ -76,8 +76,13 @@ a hand-written loop. See [What "S-flavored" means here](#what-s-flavored-means-h
   error to its `error` handler with a minimal condition object (`list(message,
   call)` classed `c("simpleError", "error", "condition")`, so `conditionMessage`
   / `e$message` work) and always runs `finally`. Loop-control signals
-  (`break`/`next`) are not caught. *(Empty-arm fall-through is implemented but
-  deferred to R-19 pending a grammar production for empty args.)*
+  (`break`/`next`) are not caught. An **empty arm** falls through to the next
+  non-empty arm (R-19): `switch("a", a = , b = "hit")` → `"hit"`, chaining across
+  several empties (`a = , b = , c = "z"` → `"z"`); a matched empty arm with
+  nothing non-empty after it yields `NULL`. (R-19 extended the shared S/R grammar
+  to `arg = NAME EQ [expr] | expr` so `a = ,` parses; the empty value is only
+  meaningful in `switch` — an empty arg in an ordinary call is an eval-time
+  error.)
 - The **`d`/`p`/`q`/`r` distribution family** (R-8) over `statistics-core`:
   density/CDF/quantile/sampling for the normal, uniform, and exponential
   distributions, plus `set.seed` for a reproducible per-session RNG.

--- a/code/packages/rust/s-runtime/src/lib.rs
+++ b/code/packages/rust/s-runtime/src/lib.rs
@@ -1094,11 +1094,48 @@ mod tests {
         );
         // No match and no default → invisible NULL.
         assert_eq!(show("switch(\"z\", a = \"A\", b = \"B\")\n"), "NULL");
-        // NOTE: empty-arm fall-through (`switch("a", a = , b = "hit")`) is
-        // deferred to R-19 — the shared S/R grammar's `arg = NAME EQ expr` has no
-        // empty-value production, so `a = ,` is a *parse* error. `eval_switch`
-        // already implements the fall-through (see `arm_body`/the loop over
-        // `arms[pos..]`); it activates once the grammar admits empty args.
+    }
+
+    // --- R-19: empty-arm switch() fall-through (in S syntax) ------------
+
+    #[test]
+    fn switch_empty_arm_falls_through_to_next_non_empty() {
+        // R-19: an empty arm (`a = ,`) falls through to the next non-empty arm.
+        // This is now parseable (the grammar's `arg = NAME EQ [expr]` admits an
+        // empty value) and eval_switch consumes it.
+        assert_eq!(show("switch(\"a\", a = , b = \"hit\")\n"), "[1] \"hit\"");
+    }
+
+    #[test]
+    fn switch_empty_arm_chains_across_multiple_empties() {
+        // Several empty arms in a row all fall through to the first non-empty.
+        assert_eq!(
+            show("switch(\"a\", a = , b = , c = \"z\")\n"),
+            "[1] \"z\""
+        );
+        // Matching a middle empty arm also chains forward.
+        assert_eq!(
+            show("switch(\"b\", a = \"A\", b = , c = \"z\")\n"),
+            "[1] \"z\""
+        );
+    }
+
+    #[test]
+    fn switch_last_arm_empty_yields_null() {
+        // If the matched arm is empty and nothing non-empty follows, the result
+        // is an invisible NULL (we fell off the end with only empty arms).
+        assert_eq!(show("switch(\"b\", a = \"A\", b = )\n"), "NULL");
+    }
+
+    #[test]
+    fn empty_named_arg_in_ordinary_call_is_an_error_not_a_panic() {
+        // The empty-value form parses everywhere but is only meaningful in
+        // switch. An empty arg in an ordinary call is an eval-time error (no
+        // panic), matching R's "argument is missing" behaviour.
+        assert!(eval_s("c(x = )\n").is_err());
+        // `switch(x)` with only EXPR and no arms is still well-formed → NULL
+        // when the selector is character with no matching arm.
+        assert_eq!(show("switch(\"a\")\n"), "NULL");
     }
 
     #[test]

--- a/code/packages/rust/s-runtime/src/lib.rs
+++ b/code/packages/rust/s-runtime/src/lib.rs
@@ -1275,3 +1275,30 @@ mod tests {
         );
     }
 }
+
+#[cfg(test)]
+mod r19_degenerate_probes {
+    use super::*;
+
+    /// R-19 hardening: the new empty named-argument production must not let any
+    /// degenerate or adversarial arg list panic the evaluator. Each input below
+    /// must resolve to an `Ok` or a recoverable `Err` — never a crash. (A panic
+    /// inside `eval_s` would propagate and fail this test directly; no
+    /// `catch_unwind` needed because the test itself is the panic boundary.)
+    #[test]
+    fn degenerate_empty_arg_inputs_do_not_panic() {
+        for src in [
+            "f(=)\n",                // bare EQ, no NAME before it
+            "switch()\n",            // no args at all
+            "switch(\"a\")\n",       // selector only, no arms
+            "c(x = )\n",             // empty arg in an ordinary call
+            "switch(\"a\", a = )\n", // single empty arm, matched and last
+            "switch(\"a\", = )\n",   // empty value with no name before EQ
+            "f(x = , )\n",           // empty arg followed by a trailing comma
+            "switch(1, a = )\n",     // numeric selector onto an empty arm
+        ] {
+            // Discarding the Result is the point: we only assert no panic.
+            let _ = eval_s(src);
+        }
+    }
+}

--- a/code/specs/R00-r-language.md
+++ b/code/specs/R00-r-language.md
@@ -341,9 +341,15 @@ unchanged.
     final arm** is the default; no match and no default → invisible `NULL`);
     numeric `EXPR` selects the n-th arm by position (out of range → `NULL`). Only
     the chosen arm evaluates, so `switch("a", a = stop("x"), b = "ok")` does not
-    raise. *(Empty-arm fall-through `switch("a", a = , b = "hit")` is deferred to
-    R-19 — it needs a grammar production for empty args; `eval_switch` already
-    implements the behaviour.)*
+    raise. An **empty arm** falls through to the next non-empty arm:
+    `switch("a", a = , b = "hit")` → `"hit"` (and chains: `a = , b = , c = "z"`
+    → `"z"`). *(R-19 added this.* It extends the shared S/R grammar's `arg` rule
+    to `arg = NAME EQ [expr] | expr` so a named argument may omit its value, then
+    regenerates the compiled `_grammar.rs` for both `s-parser` and `r-parser`.
+    `eval_switch` already implemented the fall-through; the grammar change makes
+    `a = ,` parse instead of erroring. An empty value parses everywhere but is
+    only meaningful in `switch`; an empty arg in an ordinary call is an eval-time
+    error, matching R. See S00 §V2.9.)*
   - **`stop(...)`** raises an error (concatenated message → `SError::User`);
     **`warning(...)`** emits a warning and returns invisibly without aborting;
     **`tryCatch(expr, error = fn, finally = cleanup)`** runs `expr`, routing any

--- a/code/specs/S00-s-language.md
+++ b/code/specs/S00-s-language.md
@@ -355,12 +355,23 @@ essential: `switch("a", a = stop("no"), b = "ok")` must not raise, and a
 - **`switch(EXPR, ...)`** — choose one arm by the value of `EXPR`.
   - **Character `EXPR`** matches against the *names* of the arms. An **unnamed
     final arm** is the **default**, used when no name matches. With no match and
-    no default the result is an **invisible `NULL`**. *(Deferred to R-19:* the
-    **empty-arm fall-through** `switch("a", a = , b = "hit")` → `"hit"`. The
-    shared S/R grammar's `arg = NAME EQ expr` has no empty-value production, so
-    `a = ,` is a parse error today. The evaluator's `eval_switch` already
-    implements the fall-through; it activates once the grammar admits empty
-    args.)*
+    no default the result is an **invisible `NULL`**. An **empty arm**
+    (`a = ,` — a named arm with no value expression) **falls through** to the
+    next non-empty arm's value: `switch("a", a = , b = "hit")` → `"hit"`, and the
+    fall-through chains across several empties: `switch("a", a = , b = , c = "z")`
+    → `"z"`. If only empty arms follow the match (the last matched arm is empty
+    with nothing after it), the result is an invisible `NULL`. *(Implemented in
+    R-19.* The shared S/R grammar previously had only `arg = NAME EQ expr`, with
+    no empty-value production, so `a = ,` was a parse error. R-19 extends the
+    grammar to `arg = NAME EQ [expr] | expr` — a named argument may omit its
+    value — so an empty arm now parses as an `arg` node with a `NAME` and `=`
+    token but no `expr` child. The evaluator's `eval_switch` already consumed
+    such empty arms via `arm_body() == None`; the grammar change activates it.
+    An empty value is accepted **generally** by the grammar but is only
+    *meaningful* in `switch`: an empty arg in an ordinary call (e.g. `f(x = )`)
+    is rejected at **eval time** with a parse-style error — `eval_arg`'s
+    `only_node` requires a value node — matching R, which treats a missing
+    argument value outside `switch`/indexing as an error.)*
   - **Numeric `EXPR`** selects the `n`-th arm by **position** (1-based), ignoring
     names; out of range (or `NA`/`< 1`) → `NULL`. Only the chosen arm is
     evaluated.


### PR DESCRIPTION
## R-19 — empty-arm `switch()` fall-through (+ grammar empty named-arg value)

R-18 shipped `switch()` but **deferred empty-arm fall-through**: in R,
`switch("a", a = , b = "hit")` returns `"hit"` (an empty arm falls through to
the next non-empty arm's value). R-18 already implemented this in `eval_switch`,
but it was **inert** because the shared S/R grammar's `arg = NAME EQ expr` had no
empty-value production, so `a = ,` was a *parse* error. R-19 closes that gap.

### What changed

- **Shared S/R grammar** (`code/grammars/s.grammar`, `code/grammars/r.grammar`):
  extended the `arg` rule from `NAME EQ expr | expr` to
  **`arg = NAME EQ [expr] | expr`** — a named argument may omit its value. The
  optional `expr` is only ever followed by `COMMA` or `RPAREN` (the
  arg_list / call_suffix terminators, disjoint from any `expr` start token), so
  the rule stays **LL(1)** — no ambiguity, no left-recursion, no looping
  production.
- **Regenerated** the compiled `_grammar.rs` for **both** `s-parser` and
  `r-parser` via `grammar-tools generate-rust-compiled-grammars s r`. The
  functional change is a single line per file
  (`RuleReference expr` → `Optional { RuleReference expr }`); the rest of the
  generated diff is `line_number` shifts from the added grammar comment block.
  Generated files are **not** hand-edited or `cargo fmt`'d. The `s-lexer` /
  `r-lexer` `_grammar.rs` were left untouched (no `.tokens` change).
- **Runtime**: no code change needed — `eval_switch` already consumes empty arms
  (`arm_body() == None` → fall through `arms[pos..]`). The grammar change simply
  makes `a = ,` parse into an `arg` node with a `NAME` and `=` token but no
  `expr` child.

### Semantics

- `switch("a", a = , b = "hit")` → `"hit"` (single fall-through)
- `switch("a", a = , b = , c = "z")` → `"z"` (chained across multiple empties)
- matched empty arm with nothing non-empty after it → invisible `NULL`
- The empty value parses **everywhere** an arg list appears but is only
  **meaningful** in `switch`. An empty arg in an ordinary call (`c(x = )`) is an
  **eval-time** error (via `eval_arg`'s `only_node`, no panic) — matching R's
  "argument is missing" behaviour.

### Tests — all green (and **S stays green**)

A shared-grammar change must not break S. Verified with
`cargo test -p coding-adventures-s-runtime -p coding-adventures-r-runtime -p coding-adventures-s-parser -p coding-adventures-r-parser`:

- **s-parser** 21 + **r-parser** 13 — new `empty_named_argument_parses` (empty
  arm, last-arm-empty, multiple empties, `f(x = )`, valued named args still
  parse).
- **s-runtime** 160 + **r-runtime** 103 — empty-arm fall-through (single,
  chained, middle-empty), last-arm-empty NULL, empty-arg-in-ordinary-call error,
  plus a `degenerate_empty_arg_inputs_do_not_panic` hardening test (`f(=)`,
  `switch()`, `switch("a")`, `c(x = )`, `switch("a", a = )`, `switch("a", = )`,
  `f(x = , )`, numeric selector onto an empty arm). All R-18 switch/stop/tryCatch
  tests still pass.
- `cargo clippy` clean for all four touched crates (the only clippy warnings are
  pre-existing, in the shared `parser` dependency crate, outside this diff).

### Security review

No `Agent`/`Task` sub-agent tool was available in this environment, so the
review was performed **inline** (disclosed here per CLAUDE.md):

- **Grammar**: the change wraps `expr` in `Optional` (zero-or-one) inside the
  `NAME EQ` arm — **not** a `Repetition` and **not** left-recursive, so it
  cannot loop or recurse unboundedly. LL(1) preserved (FOLLOW of the optional
  `expr` is `{COMMA, RPAREN}`, disjoint from its FIRST set). Same parser code
  path as ~10 existing `Optional` rules.
- **Panics on degenerate input**: `eval_arg`'s `only_node` returns a recoverable
  `SError::Parse` (not a panic) on a missing value; covered by the new
  `degenerate_empty_arg_inputs_do_not_panic` regression test.
- **Unbounded fall-through**: `eval_switch`'s fall-through is a single pass over
  the finite `arms[pos..]` slice, with each arm eval bounded by the existing
  `MAX_EVAL_DEPTH` — no DoS vector.
- No injection / secrets / crypto / path / deserialization surface is touched
  (pure in-process grammar/eval change over already-trusted source text).

**Result: inline security review PASSED — no vulnerabilities.**

### Deferred

The optional error-handling polish (`tryCatch(warning = ...)`,
`withCallingHandlers`/`signalCondition`, `simpleCondition`/`simpleWarning`) is
**deferred** — kept this PR a clean, minimal shared-grammar change rather than
sprawling. The grammar + regen scope landed cleanly with full coverage.

### Specs

`code/specs/S00-s-language.md` §V2.9 and `code/specs/R00-r-language.md` §3
updated to describe the now-implemented behaviour and the grammar change
(committed first, per the specs-first workflow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
