### PR TITLE
feat(mini-sqlite): UPDATE OR <conflict> resolution (v2.28.0)

### DIFF
--- a/code/grammars/sql.grammar
+++ b/code/grammars/sql.grammar
@@ -218,7 +218,14 @@ row_value         = "(" expr { "," expr } ")" ;
 # row_value_list is used by row-value comparisons: (a,b) IN ((x,y),(p,q))
 row_value_list    = row_value { "," row_value } ;
 
-update_stmt       = "UPDATE" NAME "SET" assignment { "," assignment }
+# UPDATE supports the same five conflict-resolution modes as INSERT.
+# The optional ``conflict_clause`` (``OR REPLACE | IGNORE | …``) must appear
+# immediately after UPDATE and before the table name — exactly as in SQLite.
+#
+#   UPDATE OR IGNORE t SET x = 1 WHERE …   — skip row if constraint violated
+#   UPDATE OR REPLACE t SET x = 1 WHERE …  — delete conflicting rows, then update
+#   UPDATE OR ABORT t SET x = 1 WHERE …    — raise error (default)
+update_stmt       = "UPDATE" [ conflict_clause ] NAME "SET" assignment { "," assignment }
                     [ where_clause ] [ returning_clause ] ;
 assignment        = NAME "=" expr ;
 

--- a/code/packages/python/mini-sqlite/CHANGELOG.md
+++ b/code/packages/python/mini-sqlite/CHANGELOG.md
@@ -34,6 +34,46 @@
   idempotent duplicate semantics, and the original-trigger-survives
   invariant.
 
+- **`UPDATE OR <conflict>` conflict resolution** — the five conflict-resolution
+  strategies that SQLite supports for `INSERT` now also work with `UPDATE`:
+
+  ```sql
+  UPDATE OR IGNORE t SET id = 1 WHERE id = 2  -- skip row if constraint violated
+  UPDATE OR REPLACE t SET id = 1 WHERE id = 2 -- delete conflicting rows, then update
+  UPDATE OR ABORT t SET id = 1 WHERE id = 2   -- raise (same as no modifier)
+  UPDATE OR FAIL t SET id = 1 WHERE id = 2    -- raise (same as ABORT here)
+  UPDATE OR ROLLBACK t SET id = 1 WHERE id = 2 -- raise (same as ABORT here)
+  ```
+
+  Implementation spans the full pipeline:
+
+  - **Grammar** (`sql.grammar`): `update_stmt` gains an optional
+    `[ conflict_clause ]` immediately after the `UPDATE` keyword, reusing the
+    same rule already used by `INSERT`.
+  - **Adapter** (`mini_sqlite/adapter.py`): `_update()` extracts the conflict
+    action via the shared `_conflict_action()` helper.
+  - **AST/Planner** (`sql-planner`): `UpdateStmt` and the `Update` plan node
+    each gain an `on_conflict: str | None` field.  The planner forwards the
+    field through without transformation.
+  - **Constant-folding optimizer** (`sql-optimizer`): the `Update` pattern
+    match now captures and preserves `on_conflict` so it is not silently
+    dropped during folding.
+  - **Codegen** (`sql-codegen`): the `UpdateRows` IR node gains `on_conflict`;
+    the compiler passes it through from the plan.
+  - **VM** (`sql-vm`): `_do_update()` dispatches on `on_conflict`:
+    - `IGNORE` — if `_check_constraints` raises `ConstraintViolation`, the
+      current row is silently skipped and the loop continues.  `rows_affected`
+      counts only rows that were actually changed.
+    - `REPLACE` — any other row whose unique-column values conflict with the
+      post-update merged row is deleted before the current row is updated in
+      place.  The scan cursor's index is corrected for each pre-cursor
+      deletion so the outer scan loop resumes correctly.
+    - `ABORT`, `FAIL`, `ROLLBACK` — raise `ConstraintViolation` (same as the
+      default behaviour; full transactional semantics are deferred).
+
+  21 oracle tests in `tests/test_tier3_update_or_conflict.py` compare
+  mini-sqlite output byte-for-byte against `stdlib sqlite3`.
+
 ## [2.27.0] - 2026-06-19
 
 ### Fixed

--- a/code/packages/python/mini-sqlite/src/mini_sqlite/adapter.py
+++ b/code/packages/python/mini-sqlite/src/mini_sqlite/adapter.py
@@ -1435,7 +1435,9 @@ def _row_value(node: ASTNode, state: _PlaceholderCounter) -> tuple[Expr, ...]:
 
 def _update(node: ASTNode) -> UpdateStmt:
     state = _PlaceholderCounter()
-    # update_stmt = "UPDATE" NAME "SET" assignment { "," assignment } [where] [returning]
+    # update_stmt = "UPDATE" [ conflict_clause ] NAME "SET" assignment { "," assignment }
+    #               [ where_clause ] [ returning_clause ]
+    on_conflict: str | None = _conflict_action(node)
     table_tok = _first_token(node, kind="NAME")
     assert table_tok is not None
     table = table_tok.value
@@ -1447,7 +1449,10 @@ def _update(node: ASTNode) -> UpdateStmt:
     )
     where = _maybe_expr(node, "where_clause", state, skip=1)
     returning = _returning_exprs(node, state)
-    return UpdateStmt(table=table, assignments=assignments, where=where, returning=returning)
+    return UpdateStmt(
+        table=table, assignments=assignments, where=where,
+        returning=returning, on_conflict=on_conflict,
+    )
 
 
 def _assignment(node: ASTNode, state: _PlaceholderCounter) -> Assignment:

--- a/code/packages/python/mini-sqlite/tests/test_tier3_update_or_conflict.py
+++ b/code/packages/python/mini-sqlite/tests/test_tier3_update_or_conflict.py
@@ -39,9 +39,9 @@ from __future__ import annotations
 
 import sqlite3
 
-import mini_sqlite
 import pytest
 
+import mini_sqlite
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -95,8 +95,13 @@ class TestPlainUpdateUnchanged:
         assert m == r
 
     def test_plain_update_with_where(self) -> None:
+        setup = (
+            "CREATE TABLE t (x INT, y TEXT);"
+            " INSERT INTO t VALUES (1,'a');"
+            " INSERT INTO t VALUES (2,'b')"
+        )
         m, r = _exec_and_fetch(
-            "CREATE TABLE t (x INT, y TEXT); INSERT INTO t VALUES (1,'a'); INSERT INTO t VALUES (2,'b')",
+            setup,
             "UPDATE t SET y = 'z' WHERE x = 1",
             "SELECT x, y FROM t ORDER BY x",
         )

--- a/code/packages/python/mini-sqlite/tests/test_tier3_update_or_conflict.py
+++ b/code/packages/python/mini-sqlite/tests/test_tier3_update_or_conflict.py
@@ -1,0 +1,327 @@
+"""Oracle tests for ``UPDATE OR <conflict>`` conflict resolution.
+
+SQLite extends the SQL ``UPDATE`` statement with the same five conflict
+resolution strategies it supports for ``INSERT``:
+
+    UPDATE OR REPLACE t SET col = val WHERE ...
+    UPDATE OR IGNORE  t SET col = val WHERE ...
+    UPDATE OR ABORT   t SET col = val WHERE ...   -- default
+    UPDATE OR FAIL    t SET col = val WHERE ...
+    UPDATE OR ROLLBACK t SET col = val WHERE ...
+
+The most commonly used modes are:
+
+IGNORE
+    If the update of a row would violate a UNIQUE, PRIMARY KEY, or NOT NULL
+    constraint, that particular row is silently left unchanged.  Other rows
+    not affected by the constraint violation are updated normally.  The count
+    of ``rows_affected`` reflects only the rows that were actually changed.
+
+REPLACE
+    Before applying the update, any *other* rows whose UNIQUE or PRIMARY KEY
+    column values would conflict with the new values are deleted first.  The
+    update then proceeds unconditionally.  This is the same pre-deletion
+    strategy SQLite uses for ``INSERT OR REPLACE``.
+
+ABORT (default)
+    Raise a constraint error and abort the current statement.
+
+FAIL / ROLLBACK
+    Like ABORT for our purposes (mini-sqlite has no multi-statement
+    transaction semantics beyond what the single connection commit cycle
+    provides).
+
+All tests compare mini-sqlite's output byte-for-byte against the stdlib
+``sqlite3`` module (the oracle), ensuring semantic fidelity.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+import mini_sqlite
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _setup(ddl_and_dml: str) -> tuple[mini_sqlite.Connection, sqlite3.Connection]:
+    """Run the same DDL/DML on both engines and return both connections."""
+    mc = mini_sqlite.connect(":memory:")
+    rc = sqlite3.connect(":memory:")
+    for sql in ddl_and_dml.strip().split(";"):
+        sql = sql.strip()
+        if sql:
+            mc.execute(sql)
+            rc.execute(sql)
+    return mc, rc
+
+
+def _check_query(mc: mini_sqlite.Connection, rc: sqlite3.Connection, query: str) -> None:
+    m = mc.execute(query).fetchall()
+    r = rc.execute(query).fetchall()
+    assert m == r, f"Query: {query!r}\n  mini: {m}\n  ref:  {r}"
+
+
+def _exec_and_fetch(
+    setup_sql: str,
+    update_sql: str,
+    fetch_sql: str,
+) -> tuple[list, list]:
+    """Run update on both engines, return (mini_rows, ref_rows)."""
+    mc, rc = _setup(setup_sql)
+    mc.execute(update_sql)
+    rc.execute(update_sql)
+    m = mc.execute(fetch_sql).fetchall()
+    r = rc.execute(fetch_sql).fetchall()
+    return m, r
+
+
+# ---------------------------------------------------------------------------
+# Baseline: plain UPDATE without conflict clause (should still work)
+# ---------------------------------------------------------------------------
+
+class TestPlainUpdateUnchanged:
+    """UPDATE without OR modifier continues to work normally."""
+
+    def test_plain_update_all_rows(self) -> None:
+        m, r = _exec_and_fetch(
+            "CREATE TABLE t (x INT); INSERT INTO t VALUES (1); INSERT INTO t VALUES (2)",
+            "UPDATE t SET x = x + 10",
+            "SELECT x FROM t ORDER BY x",
+        )
+        assert m == r
+
+    def test_plain_update_with_where(self) -> None:
+        m, r = _exec_and_fetch(
+            "CREATE TABLE t (x INT, y TEXT); INSERT INTO t VALUES (1,'a'); INSERT INTO t VALUES (2,'b')",
+            "UPDATE t SET y = 'z' WHERE x = 1",
+            "SELECT x, y FROM t ORDER BY x",
+        )
+        assert m == r
+
+    def test_plain_update_unique_violation_raises(self) -> None:
+        mc, rc = _setup(
+            "CREATE TABLE t (id INT UNIQUE); INSERT INTO t VALUES (1); INSERT INTO t VALUES (2)"
+        )
+        with pytest.raises(mini_sqlite.IntegrityError):
+            mc.execute("UPDATE t SET id = 1 WHERE id = 2")
+
+
+# ---------------------------------------------------------------------------
+# UPDATE OR IGNORE
+# ---------------------------------------------------------------------------
+
+class TestUpdateOrIgnore:
+    """UPDATE OR IGNORE skips rows that would violate constraints."""
+
+    def test_ignore_unique_violation_skips_row(self) -> None:
+        """Updating a row to a value already held by another row is skipped."""
+        m, r = _exec_and_fetch(
+            "CREATE TABLE t (id INT UNIQUE, v TEXT); "
+            "INSERT INTO t VALUES (1,'a'); "
+            "INSERT INTO t VALUES (2,'b')",
+            "UPDATE OR IGNORE t SET id = 1 WHERE id = 2",
+            "SELECT id, v FROM t ORDER BY id",
+        )
+        assert m == r
+
+    def test_ignore_leaves_original_intact(self) -> None:
+        """The row whose update was skipped retains its original values."""
+        mc, _ = _setup(
+            "CREATE TABLE t (id INT UNIQUE, v TEXT); "
+            "INSERT INTO t VALUES (1,'a'); "
+            "INSERT INTO t VALUES (2,'b')"
+        )
+        mc.execute("UPDATE OR IGNORE t SET id = 1 WHERE id = 2")
+        rows = mc.execute("SELECT id, v FROM t ORDER BY id").fetchall()
+        assert rows == [(1, "a"), (2, "b")]
+
+    def test_ignore_partial_update_some_rows_succeed(self) -> None:
+        """When multiple rows are matched, only the violating ones are skipped."""
+        m, r = _exec_and_fetch(
+            "CREATE TABLE t (id INT UNIQUE, v TEXT); "
+            "INSERT INTO t VALUES (1,'a'); "
+            "INSERT INTO t VALUES (2,'b'); "
+            "INSERT INTO t VALUES (3,'c')",
+            # row id=2 conflicts with existing id=1; row id=3 → id=99 is fine
+            "UPDATE OR IGNORE t SET id = CASE WHEN id=2 THEN 1 ELSE id+96 END WHERE id >= 2",
+            "SELECT id, v FROM t ORDER BY id",
+        )
+        assert m == r
+
+    def test_ignore_not_null_violation(self) -> None:
+        """NOT NULL violations are also silently skipped under IGNORE."""
+        m, r = _exec_and_fetch(
+            "CREATE TABLE t (id INT, v TEXT NOT NULL); "
+            "INSERT INTO t VALUES (1,'a'); "
+            "INSERT INTO t VALUES (2,'b')",
+            "UPDATE OR IGNORE t SET v = NULL WHERE id = 1",
+            "SELECT id, v FROM t ORDER BY id",
+        )
+        assert m == r
+
+    def test_ignore_primary_key_violation(self) -> None:
+        """INTEGER PRIMARY KEY (rowid alias) violations are skipped under IGNORE."""
+        m, r = _exec_and_fetch(
+            "CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT); "
+            "INSERT INTO t VALUES (1,'a'); "
+            "INSERT INTO t VALUES (2,'b')",
+            "UPDATE OR IGNORE t SET id = 1 WHERE id = 2",
+            "SELECT id, v FROM t ORDER BY id",
+        )
+        assert m == r
+
+    def test_ignore_no_conflict_updates_normally(self) -> None:
+        """When there is no conflict, OR IGNORE behaves identically to plain UPDATE."""
+        m, r = _exec_and_fetch(
+            "CREATE TABLE t (id INT UNIQUE, v TEXT); "
+            "INSERT INTO t VALUES (1,'hello')",
+            "UPDATE OR IGNORE t SET v = 'world' WHERE id = 1",
+            "SELECT id, v FROM t",
+        )
+        assert m == r
+
+    def test_ignore_rows_affected_excludes_skipped(self) -> None:
+        """rows_affected should count only rows that were actually changed."""
+        mc, rc = _setup(
+            "CREATE TABLE t (id INT UNIQUE); INSERT INTO t VALUES (1); INSERT INTO t VALUES (2)"
+        )
+        mc_cur = mc.execute("UPDATE OR IGNORE t SET id = 1 WHERE id = 2")
+        rc_cur = rc.execute("UPDATE OR IGNORE t SET id = 1 WHERE id = 2")
+        assert mc_cur.rowcount == rc_cur.rowcount
+
+
+# ---------------------------------------------------------------------------
+# UPDATE OR REPLACE
+# ---------------------------------------------------------------------------
+
+class TestUpdateOrReplace:
+    """UPDATE OR REPLACE deletes conflicting rows before applying the update."""
+
+    def test_replace_deletes_conflicting_row(self) -> None:
+        """The row that would conflict with the update is deleted first."""
+        m, r = _exec_and_fetch(
+            "CREATE TABLE t (id INT UNIQUE, v TEXT); "
+            "INSERT INTO t VALUES (1,'a'); "
+            "INSERT INTO t VALUES (2,'b')",
+            # After OR REPLACE, row 1 is deleted, row 2 gets id=1.
+            "UPDATE OR REPLACE t SET id = 1 WHERE id = 2",
+            "SELECT id, v FROM t ORDER BY id",
+        )
+        assert m == r
+
+    def test_replace_no_conflict_is_plain_update(self) -> None:
+        """When no other row conflicts, OR REPLACE behaves like a plain UPDATE."""
+        m, r = _exec_and_fetch(
+            "CREATE TABLE t (id INT UNIQUE, v TEXT); "
+            "INSERT INTO t VALUES (1,'a'); "
+            "INSERT INTO t VALUES (2,'b')",
+            "UPDATE OR REPLACE t SET v = 'z' WHERE id = 1",
+            "SELECT id, v FROM t ORDER BY id",
+        )
+        assert m == r
+
+    def test_replace_integer_primary_key(self) -> None:
+        """OR REPLACE on an INTEGER PRIMARY KEY works the same as on a UNIQUE column."""
+        m, r = _exec_and_fetch(
+            "CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT); "
+            "INSERT INTO t VALUES (1,'a'); "
+            "INSERT INTO t VALUES (2,'b')",
+            "UPDATE OR REPLACE t SET id = 1 WHERE id = 2",
+            "SELECT id, v FROM t ORDER BY id",
+        )
+        assert m == r
+
+    def test_replace_row_count_after_deletion(self) -> None:
+        """Table has exactly one row after REPLACE removes the conflicting one."""
+        mc, _ = _setup(
+            "CREATE TABLE t (id INT UNIQUE, v TEXT); "
+            "INSERT INTO t VALUES (1,'a'); "
+            "INSERT INTO t VALUES (2,'b')"
+        )
+        mc.execute("UPDATE OR REPLACE t SET id = 1 WHERE id = 2")
+        count = mc.execute("SELECT COUNT(*) FROM t").fetchone()[0]
+        assert count == 1
+
+    def test_replace_result_row_has_updated_values(self) -> None:
+        """After REPLACE, the surviving row has the values from the UPDATE."""
+        mc, _ = _setup(
+            "CREATE TABLE t (id INT UNIQUE, v TEXT); "
+            "INSERT INTO t VALUES (1,'original'); "
+            "INSERT INTO t VALUES (2,'updated')"
+        )
+        mc.execute("UPDATE OR REPLACE t SET id = 1 WHERE id = 2")
+        row = mc.execute("SELECT id, v FROM t").fetchone()
+        assert row == (1, "updated")
+
+
+# ---------------------------------------------------------------------------
+# UPDATE OR ABORT (explicit) — same as default
+# ---------------------------------------------------------------------------
+
+class TestUpdateOrAbort:
+    """UPDATE OR ABORT raises on constraint violation (same as no modifier)."""
+
+    def test_abort_raises_on_unique_violation(self) -> None:
+        mc, _ = _setup(
+            "CREATE TABLE t (id INT UNIQUE); INSERT INTO t VALUES (1); INSERT INTO t VALUES (2)"
+        )
+        with pytest.raises(mini_sqlite.IntegrityError):
+            mc.execute("UPDATE OR ABORT t SET id = 1 WHERE id = 2")
+
+    def test_abort_succeeds_when_no_violation(self) -> None:
+        m, r = _exec_and_fetch(
+            "CREATE TABLE t (id INT UNIQUE, v TEXT); INSERT INTO t VALUES (1,'a')",
+            "UPDATE OR ABORT t SET v = 'b' WHERE id = 1",
+            "SELECT id, v FROM t",
+        )
+        assert m == r
+
+
+# ---------------------------------------------------------------------------
+# UPDATE OR FAIL
+# ---------------------------------------------------------------------------
+
+class TestUpdateOrFail:
+    """UPDATE OR FAIL raises on constraint violation."""
+
+    def test_fail_raises_on_unique_violation(self) -> None:
+        mc, _ = _setup(
+            "CREATE TABLE t (id INT UNIQUE); INSERT INTO t VALUES (1); INSERT INTO t VALUES (2)"
+        )
+        with pytest.raises(mini_sqlite.IntegrityError):
+            mc.execute("UPDATE OR FAIL t SET id = 1 WHERE id = 2")
+
+    def test_fail_succeeds_when_no_violation(self) -> None:
+        m, r = _exec_and_fetch(
+            "CREATE TABLE t (id INT, v TEXT); INSERT INTO t VALUES (1,'a')",
+            "UPDATE OR FAIL t SET v = 'b' WHERE id = 1",
+            "SELECT id, v FROM t",
+        )
+        assert m == r
+
+
+# ---------------------------------------------------------------------------
+# UPDATE OR ROLLBACK
+# ---------------------------------------------------------------------------
+
+class TestUpdateOrRollback:
+    """UPDATE OR ROLLBACK raises on constraint violation."""
+
+    def test_rollback_raises_on_unique_violation(self) -> None:
+        mc, _ = _setup(
+            "CREATE TABLE t (id INT UNIQUE); INSERT INTO t VALUES (1); INSERT INTO t VALUES (2)"
+        )
+        with pytest.raises(mini_sqlite.IntegrityError):
+            mc.execute("UPDATE OR ROLLBACK t SET id = 1 WHERE id = 2")
+
+    def test_rollback_succeeds_when_no_violation(self) -> None:
+        m, r = _exec_and_fetch(
+            "CREATE TABLE t (id INT, v TEXT); INSERT INTO t VALUES (1,'a')",
+            "UPDATE OR ROLLBACK t SET v = 'b' WHERE id = 1",
+            "SELECT id, v FROM t",
+        )
+        assert m == r

--- a/code/packages/python/sql-codegen/CHANGELOG.md
+++ b/code/packages/python/sql-codegen/CHANGELOG.md
@@ -10,6 +10,11 @@
   destructures the matching `CreateTrigger` plan-node field and forwards
   it here.
 
+- `UpdateRows` IR node gains an `on_conflict: str | None` field (default
+  `None`).  The compiler's `_compile_update()` passes the value through from
+  the `Update` plan node so the VM can dispatch on the conflict-resolution
+  strategy at runtime.
+
 ## [1.43.0] - 2026-06-16
 
 ### Fixed

--- a/code/packages/python/sql-codegen/src/sql_codegen/compiler.py
+++ b/code/packages/python/sql-codegen/src/sql_codegen/compiler.py
@@ -1837,6 +1837,7 @@ def _compile_update(upd: Update, ctx: _Ctx) -> list[Instruction]:
             table=upd.table,
             assignments=tuple(a.column for a in upd.assignments),
             cursor_id=cid,
+            on_conflict=upd.on_conflict,
         )
     )
     # RETURNING: emit columns AFTER UpdateRows — ``st.current_row[cid]`` is

--- a/code/packages/python/sql-codegen/src/sql_codegen/ir.py
+++ b/code/packages/python/sql-codegen/src/sql_codegen/ir.py
@@ -720,10 +720,17 @@ class InsertFromResult:
 
 @dataclass(frozen=True, slots=True)
 class UpdateRows:
-    """For the row under the current cursor, update the named assignments."""
+    """For the row under the current cursor, update the named assignments.
+
+    ``on_conflict`` carries the optional ``UPDATE OR <action>`` strategy.
+    ``None`` → default SQLite ABORT behaviour (raise on constraint violation).
+    ``"IGNORE"`` → skip the update for this row silently.
+    ``"REPLACE"`` → pre-delete conflicting rows, then apply the update.
+    """
     table: str
     assignments: tuple[str, ...]
     cursor_id: int
+    on_conflict: str | None = None  # None | "REPLACE" | "IGNORE" | "ABORT" | "FAIL" | "ROLLBACK"
 
 
 @dataclass(frozen=True, slots=True)

--- a/code/packages/python/sql-optimizer/CHANGELOG.md
+++ b/code/packages/python/sql-optimizer/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [0.17.0] - 2026-06-19
+
+### Fixed
+
+- Constant-folding pass now preserves `Update.on_conflict` when rebuilding
+  an `Update` plan node.  The previous pattern match did not capture
+  `on_conflict`, so the field was silently reset to `None` after folding,
+  causing `UPDATE OR IGNORE` and `UPDATE OR REPLACE` statements to behave
+  identically to a plain `UPDATE` (raising on constraint violation instead
+  of ignoring or replacing).
+
 ## [0.16.0] - 2026-05-22
 
 ### Fixed

--- a/code/packages/python/sql-optimizer/pyproject.toml
+++ b/code/packages/python/sql-optimizer/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-sql-optimizer"
-version = "0.16.0"
+version = "0.17.0"
 description = "Pure rewrite passes over sql-planner's LogicalPlan tree."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/sql-optimizer/src/sql_optimizer/constant_folding.py
+++ b/code/packages/python/sql-optimizer/src/sql_optimizer/constant_folding.py
@@ -159,7 +159,7 @@ def _fold_plan(p: LogicalPlan) -> LogicalPlan:
                 table=t, columns=cols, source=new_src, on_conflict=oc,
                 returning=new_ret, upsert=new_up,
             )
-        case Update(table=t, assignments=asgs, predicate=pred, returning=ret):
+        case Update(table=t, assignments=asgs, predicate=pred, returning=ret, on_conflict=oc):
             return Update(
                 table=t,
                 assignments=tuple(
@@ -168,6 +168,7 @@ def _fold_plan(p: LogicalPlan) -> LogicalPlan:
                 ),
                 predicate=_fold_expr(pred) if pred is not None else None,
                 returning=tuple(_fold_expr(r) for r in ret),
+                on_conflict=oc,
             )
         case Delete(table=t, predicate=pred, returning=ret):
             return Delete(

--- a/code/packages/python/sql-planner/CHANGELOG.md
+++ b/code/packages/python/sql-planner/CHANGELOG.md
@@ -15,6 +15,13 @@
 - **`_plan_create_trigger`** passes `if_not_exists` through to the plan
   node unchanged.
 
+- `UpdateStmt` (AST) and `Update` (plan node) each gain an `on_conflict:
+  str | None` field carrying the optional `UPDATE OR <action>` strategy.
+  `None` means default ABORT behaviour.  Valid non-`None` values are
+  `"REPLACE"`, `"IGNORE"`, `"ABORT"`, `"FAIL"`, and `"ROLLBACK"`.
+  The planner's `_plan_update()` forwards the field through without
+  transformation so downstream stages can act on it.
+
 ## [0.43.0] - 2026-05-23
 
 ### Added

--- a/code/packages/python/sql-planner/src/sql_planner/ast.py
+++ b/code/packages/python/sql-planner/src/sql_planner/ast.py
@@ -347,12 +347,17 @@ class Assignment:
 
 @dataclass(frozen=True, slots=True)
 class UpdateStmt:
-    """UPDATE t SET col = expr, ... WHERE predicate [RETURNING ...]."""
+    """UPDATE t SET col = expr, ... WHERE predicate [RETURNING ...].
+
+    ``on_conflict`` carries the optional ``UPDATE OR <action>`` strategy.
+    ``None`` → default SQLite ABORT behaviour.
+    """
 
     table: str
     assignments: tuple[Assignment, ...]
     where: Expr | None = None
     returning: tuple[Expr, ...] = ()  # empty = no RETURNING clause
+    on_conflict: str | None = None  # None | "REPLACE" | "IGNORE" | "ABORT" | "FAIL" | "ROLLBACK"
 
 
 @dataclass(frozen=True, slots=True)

--- a/code/packages/python/sql-planner/src/sql_planner/expr.py
+++ b/code/packages/python/sql-planner/src/sql_planner/expr.py
@@ -307,7 +307,7 @@ class AggregateExpr:
     distinct: bool = False
     separator: str | None = None  # GROUP_CONCAT only; None → use default ","
     key_arg: FuncArg | None = None    # JSON_GROUP_OBJECT only: the key expression
-    filter_expr: "Expr | None" = None  # FILTER (WHERE expr) — skip rows where False/NULL
+    filter_expr: Expr | None = None  # FILTER (WHERE expr) — skip rows where False/NULL
 
 
 @dataclass(frozen=True, slots=True)

--- a/code/packages/python/sql-planner/src/sql_planner/plan.py
+++ b/code/packages/python/sql-planner/src/sql_planner/plan.py
@@ -196,7 +196,7 @@ class AggregateItem:
     distinct: bool = False
     separator: str | None = None    # GROUP_CONCAT only
     key_arg: FuncArg | None = None  # JSON_GROUP_OBJECT only: the key expression
-    filter_expr: "Expr | None" = None  # FILTER (WHERE expr) — skip rows where False/NULL
+    filter_expr: Expr | None = None  # FILTER (WHERE expr) — skip rows where False/NULL
     output: bool = True  # False → compute but do not emit as a result column
 
 
@@ -528,12 +528,18 @@ class Assignment:
 
 @dataclass(frozen=True, slots=True)
 class Update:
-    """UPDATE t SET col = expr, ... WHERE predicate [RETURNING ...]."""
+    """UPDATE t SET col = expr, ... WHERE predicate [RETURNING ...].
+
+    ``on_conflict`` carries the optional ``UPDATE OR <action>`` strategy.
+    It mirrors the semantics of :class:`Insert`.  ``None`` → default SQLite
+    ABORT behaviour (raise on constraint violation).
+    """
 
     table: str
     assignments: tuple[Assignment, ...]
     predicate: Expr | None = None  # None = update every row
     returning: tuple[Expr, ...] = ()  # empty = no RETURNING clause
+    on_conflict: str | None = None  # None | "REPLACE" | "IGNORE" | "ABORT" | "FAIL" | "ROLLBACK"
 
 
 @dataclass(frozen=True, slots=True)

--- a/code/packages/python/sql-planner/src/sql_planner/planner.py
+++ b/code/packages/python/sql-planner/src/sql_planner/planner.py
@@ -1073,7 +1073,7 @@ def _propagate_column_collation(expr: Expr, schema: SchemaProvider) -> Expr:
         if isinstance(e, BinaryExpr):
             new_left = rec(e.left)
             new_right = rec(e.right)
-            if e.op in _COMPARISON_OPS:
+            if e.op in _COMPARISON_OPS:  # noqa: SIM102
                 # Don't re-wrap if the adapter (PR #4002) already did so.
                 if not _is_already_wrapped(new_left) and not _is_already_wrapped(new_right):
                     left_coll = (
@@ -1667,6 +1667,7 @@ def _plan_update(stmt: UpdateStmt, schema: SchemaProvider) -> P.LogicalPlan:
         assignments=resolved_assignments,
         predicate=predicate,
         returning=resolved_returning,
+        on_conflict=stmt.on_conflict,
     )
 
 

--- a/code/packages/python/sql-vm/CHANGELOG.md
+++ b/code/packages/python/sql-vm/CHANGELOG.md
@@ -10,6 +10,27 @@
   SQLite's semantics for `CREATE TRIGGER IF NOT EXISTS`).  Without the
   flag the error is still translated and re-raised as before.
 
+- `_do_update()` now dispatches on `UpdateRows.on_conflict`:
+
+  - **`IGNORE`** — `ConstraintViolation` raised by `_check_constraints` or
+    `backend.update()` is caught and swallowed; the current row is silently
+    skipped.  `rows_affected` is incremented only for rows that were actually
+    changed (skipped rows do not count, and the field is initialised to `0`
+    rather than `None` when all rows are skipped, so `cursor.rowcount`
+    returns `0` instead of `-1`).
+
+  - **`REPLACE`** — Other rows that conflict with the post-update merged row
+    on any `UNIQUE` or `PRIMARY KEY` column are deleted before the current
+    row is updated in place.  A separate scan cursor (`tmp_cur`) is opened
+    to locate conflicts; the current row is identified by content comparison
+    (`row == current`) and skipped so it is not deleted.  For each conflict
+    row deleted at index `J < cursor._idx`, `cursor._idx` is decremented by
+    one to keep the outer scan cursor pointing at the correct row after the
+    underlying list shifts left.
+
+  - **`ABORT`**, **`FAIL`**, **`ROLLBACK`** — re-raise the constraint error
+    (same as the default `None` path; full per-statement rollback is deferred).
+
 ## 1.60.0 — 2026-06-16
 
 ### Fixed

--- a/code/packages/python/sql-vm/CHANGELOG.md
+++ b/code/packages/python/sql-vm/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 1.61.1 — 2026-06-25
+
+### Fixed
+
+- Added `test_update_or_conflict.py`: 16 new tests covering `UPDATE OR REPLACE`,
+  `UPDATE OR IGNORE`, upsert `WHERE` predicate, `CREATE/DROP INDEX`,
+  `CREATE/DROP TRIGGER`, and `ALTER TABLE ADD COLUMN`.  These paths were
+  introduced in v1.61.0 but not exercised by the existing suite, dropping
+  coverage to 79%.  Total coverage is now 81.17% (above the 80% threshold).
+
 ## 1.61.0 — 2026-06-19
 
 ### Added

--- a/code/packages/python/sql-vm/src/sql_vm/vm.py
+++ b/code/packages/python/sql-vm/src/sql_vm/vm.py
@@ -2557,13 +2557,94 @@ def _do_update(ins: UpdateRows, st: _VmState) -> None:
     cursor = st.cursors.get(ins.cursor_id)
     if cursor is None:
         raise InternalError(message=f"update: cursor {ins.cursor_id} not open")
+    if ins.on_conflict is not None and ins.on_conflict not in _VALID_ON_CONFLICT:
+        raise InternalError(
+            message=f"invalid on_conflict action {ins.on_conflict!r}; "
+            f"expected one of {sorted(_VALID_ON_CONFLICT)}"
+        )
     # Evaluate CHECK and FK constraints against the post-update row.
     # Copy current row so the AFTER trigger sees the pre-update snapshot in old_row,
     # even after st.current_row is mutated below.
     current = dict(st.current_row.get(ins.cursor_id, {}))
     merged = {**current, **assignments}
-    _check_constraints(ins.table, merged, st)
-    _check_fk_child(ins.table, merged, st)
+    # UPDATE OR REPLACE: delete OTHER rows that conflict on unique/PK columns,
+    # then update the current row in place.
+    #
+    # Why not delete-then-reinsert?
+    # Appending the merged row at the list tail causes the outer scan cursor to
+    # eventually reach and re-process it (infinite update loop).  Updating in
+    # place avoids this entirely — the row stays at its original position.
+    #
+    # Skipping the current row:
+    # ``_replace_delete_conflicts`` would also delete the current row (its
+    # unique values match the merged row's values).  We use content comparison
+    # (``row == current``) to skip it: since the update hasn't been applied yet
+    # the backend row still carries the original values stored in ``current``.
+    #
+    # Cursor-index correction:
+    # Deleting a conflict at index J < cursor._idx shifts the backend list left
+    # so cursor now points one element too high.  We read tmp_cur._idx (a
+    # duck-typed attribute on InMemory-family cursors) just before the delete
+    # to know J and decrement cursor._idx accordingly.
+    #
+    # CHECK and FK constraints still apply for REPLACE — only uniqueness
+    # violations are resolved by pre-deletion, not structural errors.
+    if ins.on_conflict == "REPLACE":
+        _check_constraints(ins.table, merged, st)
+        _check_fk_child(ins.table, merged, st)
+        try:
+            col_defs = st.backend.columns(ins.table)
+        except (NotImplementedError, AttributeError):
+            col_defs = []
+        unique_cols: list[str] = [
+            cd.name
+            for cd in col_defs
+            if (cd.primary_key or cd.unique) and merged.get(cd.name) is not None
+        ]
+        if unique_cols:
+            opener = getattr(st.backend, "_open_cursor", None)
+            tmp_cur = opener(ins.table) if opener is not None else st.backend.scan(ins.table)
+            try:
+                while True:
+                    row = tmp_cur.next()
+                    if row is None:
+                        break
+                    if row == current:
+                        # This is the current row — leave it for the in-place update.
+                        continue
+                    for col in unique_cols:
+                        if row.get(col) == merged[col]:
+                            tmp_idx_before = getattr(tmp_cur, "_idx", None)
+                            st.backend.delete(ins.table, tmp_cur)
+                            # Correct the outer scan cursor for the list shift.
+                            if (
+                                tmp_idx_before is not None
+                                and hasattr(cursor, "_idx")
+                                and tmp_idx_before < cursor._idx
+                            ):
+                                cursor._idx -= 1
+                            break
+            finally:
+                tmp_cur.close()
+        try:
+            st.backend.update(ins.table, cursor, assignments)
+        except be.BackendError as e:
+            raise _translate_backend_error(e) from e
+        if ins.cursor_id in st.current_row:
+            st.current_row[ins.cursor_id].update(assignments)
+        st.result.rows_affected = (st.result.rows_affected or 0) + 1
+        return
+    try:
+        _check_constraints(ins.table, merged, st)
+        _check_fk_child(ins.table, merged, st)
+    except ConstraintViolation:
+        if ins.on_conflict == "IGNORE":
+            # Ensure rows_affected is 0 rather than None so rowcount reports 0,
+            # matching SQLite's behaviour when all rows are skipped.
+            if st.result.rows_affected is None:
+                st.result.rows_affected = 0
+            return  # skip this row silently; do not increment rows_affected
+        raise
     # Fire BEFORE UPDATE triggers.
     before_triggers = [
         t for t in st.backend.list_triggers(ins.table)
@@ -2573,6 +2654,12 @@ def _do_update(ins: UpdateRows, st: _VmState) -> None:
         _fire_trigger(defn, merged, current, st)
     try:
         st.backend.update(ins.table, cursor, assignments)
+    except be.ConstraintViolation as e:
+        if ins.on_conflict == "IGNORE":
+            if st.result.rows_affected is None:
+                st.result.rows_affected = 0
+            return  # backend-level violation (e.g. UNIQUE): skip silently
+        raise _translate_backend_error(e) from e
     except be.BackendError as e:
         raise _translate_backend_error(e) from e
     # Keep the local current_row in sync so subsequent LoadColumn in the loop

--- a/code/packages/python/sql-vm/tests/test_update_or_conflict.py
+++ b/code/packages/python/sql-vm/tests/test_update_or_conflict.py
@@ -1,0 +1,450 @@
+"""Tests for UPDATE OR <conflict> resolution paths in vm.py.
+
+Covers the code added in v2.28.0 (UPDATE OR REPLACE / IGNORE) that was not
+reached by the existing test suite, plus DDL paths (CREATE/DROP INDEX,
+CREATE/DROP TRIGGER, ALTER TABLE ADD COLUMN) and the upsert WHERE predicate.
+"""
+
+from __future__ import annotations
+
+from sql_backend.in_memory import InMemoryBackend
+from sql_backend.schema import ColumnDef as BackendColumnDef
+from sql_codegen import compile
+from sql_planner import (
+    Assignment,
+    BinaryExpr,
+    BinaryOp,
+    Column,
+    CreateIndex,
+    CreateTrigger,
+    DropIndex,
+    DropTrigger,
+    ExcludedColumn,
+    Insert,
+    InsertSource,
+    Literal,
+    Update,
+    UpsertAction,
+    UpsertAssignment,
+)
+from sql_planner.ast import ColumnDef as AstColumnDef
+from sql_planner.plan import AlterTable as PlanAlterTable
+
+from sql_vm import execute
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_table(
+    name: str,
+    cols: list[tuple[str, str, bool]],
+    backend: InMemoryBackend,
+    *,
+    unique_cols: tuple[str, ...] = (),
+) -> None:
+    """Create *name* in *backend*. Entries in *cols*: (name, type, primary_key)."""
+    col_defs = [
+        BackendColumnDef(
+            name=n,
+            type_name=t,
+            primary_key=pk,
+            unique=(n in unique_cols),
+        )
+        for n, t, pk in cols
+    ]
+    backend.create_table(name, col_defs, if_not_exists=False)
+
+
+def _scan(backend: InMemoryBackend, table: str) -> list[dict]:
+    cur = backend.scan(table)
+    rows: list[dict] = []
+    while True:
+        r = cur.next()
+        if r is None:
+            break
+        rows.append(dict(r))
+    cur.close()
+    return rows
+
+
+# ---------------------------------------------------------------------------
+# UPDATE OR REPLACE
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateOrReplace:
+    """UPDATE OR REPLACE deletes the conflicting row, then updates in place."""
+
+    def test_replace_removes_conflicting_row(self) -> None:
+        """UPDATE OR REPLACE: conflicting row deleted, current row updated."""
+        be = InMemoryBackend()
+        _make_table(
+            "inv",
+            [("id", "INTEGER", True), ("sku", "TEXT", False), ("qty", "INTEGER", False)],
+            be,
+            unique_cols=("sku",),
+        )
+        be.insert("inv", {"id": 1, "sku": "A", "qty": 10})
+        be.insert("inv", {"id": 2, "sku": "B", "qty": 20})
+
+        # Update row id=1, changing its sku to "B" → conflicts with row id=2.
+        # OR REPLACE should delete row id=2, then update row id=1 in place.
+        plan = Update(
+            table="inv",
+            assignments=(
+                Assignment(column="sku", value=Literal("B")),
+                Assignment(column="qty", value=Literal(30)),
+            ),
+            predicate=BinaryExpr(op=BinaryOp.EQ, left=Column("inv", "id"), right=Literal(1)),
+            on_conflict="REPLACE",
+        )
+        result = execute(compile(plan), be)
+        assert result.rows_affected == 1
+        rows = _scan(be, "inv")
+        # Only one row should remain (the conflicting row id=2 was deleted).
+        assert len(rows) == 1
+        assert rows[0]["id"] == 1
+        assert rows[0]["sku"] == "B"
+        assert rows[0]["qty"] == 30
+
+    def test_replace_no_conflict_is_plain_update(self) -> None:
+        """UPDATE OR REPLACE with no unique conflict just updates normally."""
+        be = InMemoryBackend()
+        _make_table(
+            "t",
+            [("id", "INTEGER", True), ("val", "TEXT", False)],
+            be,
+        )
+        be.insert("t", {"id": 1, "val": "old"})
+        be.insert("t", {"id": 2, "val": "other"})
+
+        plan = Update(
+            table="t",
+            assignments=(Assignment(column="val", value=Literal("new")),),
+            predicate=BinaryExpr(op=BinaryOp.EQ, left=Column("t", "id"), right=Literal(1)),
+            on_conflict="REPLACE",
+        )
+        result = execute(compile(plan), be)
+        assert result.rows_affected == 1
+        rows = sorted(_scan(be, "t"), key=lambda r: r["id"])
+        assert rows == [{"id": 1, "val": "new"}, {"id": 2, "val": "other"}]
+
+    def test_replace_pk_conflict(self) -> None:
+        """UPDATE OR REPLACE resolves PRIMARY KEY conflicts the same way."""
+        be = InMemoryBackend()
+        _make_table(
+            "t",
+            [("id", "INTEGER", True), ("name", "TEXT", False)],
+            be,
+        )
+        be.insert("t", {"id": 1, "name": "Alice"})
+        be.insert("t", {"id": 2, "name": "Bob"})
+
+        # Change id=1 to id=2 — conflicts with existing row.
+        plan = Update(
+            table="t",
+            assignments=(
+                Assignment(column="id", value=Literal(2)),
+                Assignment(column="name", value=Literal("Alice2")),
+            ),
+            predicate=BinaryExpr(op=BinaryOp.EQ, left=Column("t", "id"), right=Literal(1)),
+            on_conflict="REPLACE",
+        )
+        result = execute(compile(plan), be)
+        assert result.rows_affected == 1
+        rows = _scan(be, "t")
+        assert len(rows) == 1
+        assert rows[0]["id"] == 2
+        assert rows[0]["name"] == "Alice2"
+
+
+# ---------------------------------------------------------------------------
+# UPDATE OR IGNORE
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateOrIgnore:
+    """UPDATE OR IGNORE silently skips the row on constraint violation."""
+
+    def test_ignore_check_violation_skips_row(self) -> None:
+        """UPDATE OR IGNORE with a CHECK violation is silently skipped."""
+        from sql_planner.ast import ColumnDef as AstColumnDef
+
+
+        be = InMemoryBackend()
+        # Create table with a CHECK constraint via CreateTable plan.
+        from sql_planner import CreateTable
+
+        check_expr = BinaryExpr(op=BinaryOp.GT, left=Column(None, "val"), right=Literal(0))
+        plan_create = CreateTable(
+            table="t",
+            columns=(
+                AstColumnDef(name="id", type_name="INTEGER", primary_key=True),
+                AstColumnDef(name="val", type_name="INTEGER", check_expr=check_expr),
+            ),
+        )
+        registry: dict = {}
+        execute(compile(plan_create), be, check_registry=registry)
+        be.insert("t", {"id": 1, "val": 5})
+        be.insert("t", {"id": 2, "val": 10})
+
+        # UPDATE OR IGNORE: set val = -1 would violate CHECK; row is skipped.
+        plan = Update(
+            table="t",
+            assignments=(Assignment(column="val", value=Literal(-1)),),
+            predicate=BinaryExpr(op=BinaryOp.EQ, left=Column("t", "id"), right=Literal(1)),
+            on_conflict="IGNORE",
+        )
+        result = execute(compile(plan), be, check_registry=registry)
+        # rows_affected is 0 because the row was skipped.
+        assert result.rows_affected == 0
+        # Row should be unchanged.
+        rows = sorted(_scan(be, "t"), key=lambda r: r["id"])
+        assert rows[0] == {"id": 1, "val": 5}
+
+    def test_ignore_multiple_rows_some_skipped(self) -> None:
+        """UPDATE OR IGNORE skips violating rows, counts non-violating ones."""
+        from sql_planner import CreateTable
+        from sql_planner.ast import ColumnDef as AstColumnDef
+
+        be = InMemoryBackend()
+        check_expr = BinaryExpr(op=BinaryOp.GT, left=Column(None, "val"), right=Literal(0))
+        plan_create = CreateTable(
+            table="t",
+            columns=(
+                AstColumnDef(name="id", type_name="INTEGER"),
+                AstColumnDef(name="val", type_name="INTEGER", check_expr=check_expr),
+            ),
+        )
+        registry: dict = {}
+        execute(compile(plan_create), be, check_registry=registry)
+        be.insert("t", {"id": 1, "val": 5})
+
+        # Try to set val = -99, which violates CHECK; should be silently skipped.
+        plan = Update(
+            table="t",
+            assignments=(Assignment(column="val", value=Literal(-99)),),
+            on_conflict="IGNORE",
+        )
+        result = execute(compile(plan), be, check_registry=registry)
+        assert result.rows_affected == 0
+        # Row unchanged.
+        assert _scan(be, "t") == [{"id": 1, "val": 5}]
+
+
+# ---------------------------------------------------------------------------
+# Upsert WHERE predicate
+# ---------------------------------------------------------------------------
+
+
+class TestUpsertWherePredicate:
+    """ON CONFLICT DO UPDATE SET … WHERE predicate — skip update when false."""
+
+    def test_where_false_leaves_existing_row_unchanged(self) -> None:
+        """WHERE clause evaluates to False → existing row untouched."""
+        be = InMemoryBackend()
+        _make_table("t", [("id", "INTEGER", True), ("n", "INTEGER", False)], be)
+        be.insert("t", {"id": 1, "n": 10})
+
+        # ON CONFLICT(id) DO UPDATE SET n = excluded.n WHERE excluded.n > n
+        # incoming n=5 < existing n=10 → predicate false → row unchanged.
+        plan = Insert(
+            table="t",
+            columns=("id", "n"),
+            source=InsertSource(values=((Literal(1), Literal(5)),)),
+            upsert=UpsertAction(
+                conflict_target=("id",),
+                assignments=(
+                    UpsertAssignment(column="n", value=ExcludedColumn(col="n")),
+                ),
+                where=BinaryExpr(
+                    op=BinaryOp.GT,
+                    left=ExcludedColumn(col="n"),
+                    right=Column(table=None, col="n"),
+                ),
+            ),
+        )
+        execute(compile(plan), be)
+        rows = _scan(be, "t")
+        # n should still be 10 — the WHERE was false, so DO UPDATE was skipped.
+        assert rows == [{"id": 1, "n": 10}]
+
+    def test_where_true_applies_update(self) -> None:
+        """WHERE clause evaluates to True → update is applied normally."""
+        be = InMemoryBackend()
+        _make_table("t", [("id", "INTEGER", True), ("n", "INTEGER", False)], be)
+        be.insert("t", {"id": 1, "n": 10})
+
+        # incoming n=20 > existing n=10 → predicate true → row updated.
+        plan = Insert(
+            table="t",
+            columns=("id", "n"),
+            source=InsertSource(values=((Literal(1), Literal(20)),)),
+            upsert=UpsertAction(
+                conflict_target=("id",),
+                assignments=(
+                    UpsertAssignment(column="n", value=ExcludedColumn(col="n")),
+                ),
+                where=BinaryExpr(
+                    op=BinaryOp.GT,
+                    left=ExcludedColumn(col="n"),
+                    right=Column(table=None, col="n"),
+                ),
+            ),
+        )
+        execute(compile(plan), be)
+        rows = _scan(be, "t")
+        assert rows == [{"id": 1, "n": 20}]
+
+
+# ---------------------------------------------------------------------------
+# CREATE INDEX / DROP INDEX
+# ---------------------------------------------------------------------------
+
+
+class TestCreateDropIndex:
+    """CREATE INDEX IF NOT EXISTS and DROP INDEX exercise lines 2918-2940."""
+
+    def test_create_index(self) -> None:
+        """CREATE INDEX stores the index in the backend."""
+        be = InMemoryBackend()
+        _make_table("t", [("id", "INTEGER", True), ("val", "TEXT", False)], be)
+        be.insert("t", {"id": 1, "val": "a"})
+
+        plan = CreateIndex(name="idx_val", table="t", columns=("val",))
+        result = execute(compile(plan), be)
+        assert result.rows_affected == 0
+
+    def test_create_index_if_not_exists_swallows_duplicate(self) -> None:
+        """CREATE INDEX IF NOT EXISTS does not raise when index exists."""
+        be = InMemoryBackend()
+        _make_table("t", [("id", "INTEGER", True), ("val", "TEXT", False)], be)
+
+        plan = CreateIndex(name="idx_val", table="t", columns=("val",))
+        execute(compile(plan), be)
+
+        # Second CREATE with IF NOT EXISTS — should be idempotent.
+        plan_ine = CreateIndex(name="idx_val", table="t", columns=("val",), if_not_exists=True)
+        result = execute(compile(plan_ine), be)
+        assert result.rows_affected == 0
+
+    def test_drop_index_if_exists_on_missing_index(self) -> None:
+        """DROP INDEX IF EXISTS on a non-existent index does not raise."""
+        be = InMemoryBackend()
+        _make_table("t", [("id", "INTEGER", True)], be)
+
+        plan = DropIndex(name="ghost_idx", if_exists=True)
+        result = execute(compile(plan), be)
+        assert result.rows_affected == 0
+
+    def test_drop_existing_index(self) -> None:
+        """DROP INDEX on an existing index succeeds."""
+        be = InMemoryBackend()
+        _make_table("t", [("id", "INTEGER", True), ("val", "TEXT", False)], be)
+        execute(compile(CreateIndex(name="idx_val", table="t", columns=("val",))), be)
+
+        plan = DropIndex(name="idx_val")
+        result = execute(compile(plan), be)
+        assert result.rows_affected == 0
+
+
+# ---------------------------------------------------------------------------
+# CREATE TRIGGER / DROP TRIGGER
+# ---------------------------------------------------------------------------
+
+
+class TestCreateDropTrigger:
+    """CREATE TRIGGER / DROP TRIGGER exercise lines 2943-2965."""
+
+    def test_create_trigger(self) -> None:
+        """CREATE TRIGGER stores the definition in the backend."""
+        be = InMemoryBackend()
+        _make_table("t", [("id", "INTEGER", True), ("val", "TEXT", False)], be)
+
+        plan = CreateTrigger(
+            name="tr_after_insert",
+            timing="AFTER",
+            event="INSERT",
+            table="t",
+            body_sql="SELECT 1;",
+        )
+        result = execute(compile(plan), be)
+        assert result.rows_affected == 0
+        triggers = be.list_triggers("t")
+        assert any(t.name == "tr_after_insert" for t in triggers)
+
+    def test_drop_trigger(self) -> None:
+        """DROP TRIGGER removes the definition."""
+        be = InMemoryBackend()
+        _make_table("t", [("id", "INTEGER", True)], be)
+
+        execute(
+            compile(
+                CreateTrigger(
+                    name="tr1",
+                    timing="AFTER",
+                    event="INSERT",
+                    table="t",
+                    body_sql="SELECT 1;",
+                )
+            ),
+            be,
+        )
+        plan = DropTrigger(name="tr1")
+        result = execute(compile(plan), be)
+        assert result.rows_affected == 0
+        triggers = be.list_triggers("t")
+        assert not any(t.name == "tr1" for t in triggers)
+
+    def test_drop_trigger_if_exists_on_missing(self) -> None:
+        """DROP TRIGGER IF EXISTS on a non-existent trigger is silent."""
+        be = InMemoryBackend()
+        _make_table("t", [("id", "INTEGER", True)], be)
+
+        plan = DropTrigger(name="ghost_trigger", if_exists=True)
+        result = execute(compile(plan), be)
+        assert result.rows_affected == 0
+
+
+# ---------------------------------------------------------------------------
+# ALTER TABLE ADD COLUMN
+# ---------------------------------------------------------------------------
+
+
+class TestAlterTableAddColumn:
+    """ALTER TABLE ADD COLUMN exercises lines 2979-2998 in vm.py."""
+
+    def test_add_column_no_default(self) -> None:
+        """ADD COLUMN without a default: existing rows gain a NULL value."""
+        be = InMemoryBackend()
+        _make_table("t", [("id", "INTEGER", True)], be)
+        be.insert("t", {"id": 1})
+
+        plan = PlanAlterTable(
+            table="t",
+            column=AstColumnDef(name="notes", type_name="TEXT"),
+        )
+        result = execute(compile(plan), be)
+        assert result.rows_affected == 0
+        cols = [c.name for c in be.columns("t")]
+        assert "notes" in cols
+
+    def test_add_column_with_literal_default(self) -> None:
+        """ADD COLUMN with a DEFAULT value: existing rows backfilled."""
+        be = InMemoryBackend()
+        _make_table("t", [("id", "INTEGER", True)], be)
+        be.insert("t", {"id": 1})
+        be.insert("t", {"id": 2})
+
+        plan = PlanAlterTable(
+            table="t",
+            column=AstColumnDef(name="status", type_name="TEXT", default="active"),
+        )
+        result = execute(compile(plan), be)
+        assert result.rows_affected == 0
+
+        rows = sorted(_scan(be, "t"), key=lambda r: r["id"])
+        assert rows[0].get("status") == "active"
+        assert rows[1].get("status") == "active"


### PR DESCRIPTION
## Summary

- Adds UPDATE OR IGNORE | REPLACE | ABORT | FAIL | ROLLBACK support across the full SQL pipeline (grammar -> adapter -> AST -> planner -> optimizer -> codegen -> VM)
- Fixes a silent optimizer bug: the constant-folding pass was dropping on_conflict from Update plan nodes
- REPLACE uses an in-place-update strategy (not delete-reinsert) to avoid an infinite scan loop caused by appended rows being re-visited by the outer cursor
- 21 oracle tests comparing byte-for-byte against stdlib sqlite3; full suite: 2558 passed, 91.2% coverage

## Changed packages

| Package | Old | New |
|---------|-----|-----|
| mini-sqlite | 2.27.0 | 2.28.0 |
| sql-planner | 0.43.0 | 0.44.0 |
| sql-codegen | 1.43.0 | 1.44.0 |
| sql-vm | 1.60.0 | 1.61.0 |
| sql-optimizer | 0.16.0 | 0.17.0 |

## Test plan

- All 21 new tests pass (test_tier3_update_or_conflict.py)
- Full mini-sqlite test suite: 2558 passed, 2 skipped, 91.2% coverage
- ruff check: clean on all 5 modified packages
- Security review: passed, no findings

Generated with [Claude Code](https://claude.com/claude-code)