### PR TITLE
Add smart-home activation waiver release signoff tools

### DIFF
--- a/code/packages/rust/chief-of-staff-smart-home-tools/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/src/lib.rs
@@ -663,6 +663,10 @@ pub const SMART_HOME_LIST_INTEGRATION_ACTIVATION_WAIVER_RELEASE_CLOSURES_TOOL_ID
     "smart_home.list_integration_activation_waiver_release_closures";
 pub const SMART_HOME_GET_INTEGRATION_ACTIVATION_WAIVER_RELEASE_CLOSURE_SUMMARY_TOOL_ID: &str =
     "smart_home.get_integration_activation_waiver_release_closure_summary";
+pub const SMART_HOME_LIST_INTEGRATION_ACTIVATION_WAIVER_RELEASE_SIGNOFFS_TOOL_ID: &str =
+    "smart_home.list_integration_activation_waiver_release_signoffs";
+pub const SMART_HOME_GET_INTEGRATION_ACTIVATION_WAIVER_RELEASE_SIGNOFF_SUMMARY_TOOL_ID: &str =
+    "smart_home.get_integration_activation_waiver_release_signoff_summary";
 pub const SMART_HOME_LIST_INTEGRATION_ACTIVATION_RISK_TOOL_ID: &str =
     "smart_home.list_integration_activation_risk";
 pub const SMART_HOME_GET_INTEGRATION_ACTIVATION_RISK_SUMMARY_TOOL_ID: &str =
@@ -1781,6 +1785,22 @@ impl SmartHomeToolBridge {
                     let query = integration_activation_waiver_release_closure_query(&arguments)?;
                     Ok(
                         get_integration_activation_waiver_release_closure_summary_output_handler_output(
+                            query,
+                        ),
+                    )
+                }
+                SMART_HOME_LIST_INTEGRATION_ACTIVATION_WAIVER_RELEASE_SIGNOFFS_TOOL_ID => {
+                    let query = integration_activation_waiver_release_signoff_query(&arguments)?;
+                    Ok(
+                        list_integration_activation_waiver_release_signoffs_output_handler_output(
+                            query,
+                        ),
+                    )
+                }
+                SMART_HOME_GET_INTEGRATION_ACTIVATION_WAIVER_RELEASE_SIGNOFF_SUMMARY_TOOL_ID => {
+                    let query = integration_activation_waiver_release_signoff_query(&arguments)?;
+                    Ok(
+                        get_integration_activation_waiver_release_signoff_summary_output_handler_output(
                             query,
                         ),
                     )
@@ -5212,6 +5232,40 @@ pub fn smart_home_tool_definitions() -> Vec<ToolDefinition> {
             "Get smart-home integration activation waiver release closure summary",
             "Return compact D23A activation waiver release closure counts by closure status, release lane, source linkage, blocker, receipt finalization, and release readiness.",
             integration_activation_waiver_release_closure_query_schema(),
+            object_schema(
+                vec![SchemaProperty::new("summary", JsonSchema::Any)],
+                vec!["summary"],
+                false,
+            ),
+        ),
+        read_definition(
+            SMART_HOME_LIST_INTEGRATION_ACTIVATION_WAIVER_RELEASE_SIGNOFFS_TOOL_ID,
+            "List smart-home integration activation waiver release signoffs",
+            "List Chief-facing D23A activation waiver release signoff rows derived from release closures with signoff status, signoff lane, source-lineage posture, and release action.",
+            integration_activation_waiver_release_signoff_query_schema(),
+            object_schema(
+                vec![
+                    SchemaProperty::new("activation_waiver_release_signoffs", JsonSchema::Array {
+                        items: Box::new(JsonSchema::Any),
+                    }),
+                    SchemaProperty::new("summary", JsonSchema::Any),
+                    SchemaProperty::new("count", JsonSchema::Integer),
+                    SchemaProperty::new("catalog_count", JsonSchema::Integer),
+                ],
+                vec![
+                    "activation_waiver_release_signoffs",
+                    "summary",
+                    "count",
+                    "catalog_count",
+                ],
+                false,
+            ),
+        ),
+        read_definition(
+            SMART_HOME_GET_INTEGRATION_ACTIVATION_WAIVER_RELEASE_SIGNOFF_SUMMARY_TOOL_ID,
+            "Get smart-home integration activation waiver release signoff summary",
+            "Return compact D23A activation waiver release signoff counts by signoff status, signoff lane, source linkage, blocker, closure finalization, and release readiness.",
+            integration_activation_waiver_release_signoff_query_schema(),
             object_schema(
                 vec![SchemaProperty::new("summary", JsonSchema::Any)],
                 vec!["summary"],
@@ -15009,6 +15063,322 @@ struct IntegrationActivationWaiverReleaseClosureQuery {
     release_closure_limit: Option<usize>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum IntegrationActivationWaiverReleaseSignoffStatus {
+    Blocked,
+    ClosureRequired,
+    SignoffRequired,
+    ReadyForRelease,
+}
+
+impl IntegrationActivationWaiverReleaseSignoffStatus {
+    fn from_release_closure_record(
+        record: &IntegrationActivationWaiverReleaseClosureRecord,
+    ) -> Self {
+        if record.is_blocked() {
+            Self::Blocked
+        } else if !record.has_source_lineage() || !record.closed() {
+            Self::ClosureRequired
+        } else if record.receipt.source.signoff_required {
+            Self::SignoffRequired
+        } else {
+            Self::ReadyForRelease
+        }
+    }
+
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Blocked => "blocked",
+            Self::ClosureRequired => "closure_required",
+            Self::SignoffRequired => "signoff_required",
+            Self::ReadyForRelease => "ready_for_release",
+        }
+    }
+
+    fn is_blocked(self) -> bool {
+        matches!(self, Self::Blocked)
+    }
+
+    fn signoff_required(self) -> bool {
+        matches!(self, Self::SignoffRequired)
+    }
+
+    fn requires_attention(self) -> bool {
+        matches!(
+            self,
+            Self::Blocked | Self::ClosureRequired | Self::SignoffRequired
+        )
+    }
+
+    fn release_ready(self) -> bool {
+        matches!(self, Self::ReadyForRelease)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct IntegrationActivationWaiverReleaseSignoffRecord {
+    sequence: usize,
+    release_signoff_id: String,
+    source_release_closure_id: String,
+    source_receipt_id: String,
+    source_erasure_id: String,
+    release_signoff_status: IntegrationActivationWaiverReleaseSignoffStatus,
+    signoff_lane: IntegrationActivationResponseOwnerLane,
+    signoff_reason: String,
+    signoff_action: String,
+    release_closure: IntegrationActivationWaiverReleaseClosureRecord,
+}
+
+impl IntegrationActivationWaiverReleaseSignoffRecord {
+    fn from_release_closure_record(
+        sequence: usize,
+        record: &IntegrationActivationWaiverReleaseClosureRecord,
+    ) -> Self {
+        let release_signoff_status =
+            IntegrationActivationWaiverReleaseSignoffStatus::from_release_closure_record(record);
+        Self {
+            sequence,
+            release_signoff_id: format!("activation-waiver-release-signoff-{sequence}"),
+            source_release_closure_id: record.release_closure_id.clone(),
+            source_receipt_id: record.source_receipt_id.clone(),
+            source_erasure_id: record.source_erasure_id.clone(),
+            release_signoff_status,
+            signoff_lane: activation_waiver_release_signoff_lane(record, release_signoff_status),
+            signoff_reason: activation_waiver_release_signoff_reason(
+                record,
+                release_signoff_status,
+            )
+            .to_string(),
+            signoff_action: activation_waiver_release_signoff_action(release_signoff_status)
+                .to_string(),
+            release_closure: record.clone(),
+        }
+    }
+
+    fn has_source_lineage(&self) -> bool {
+        self.release_closure.has_source_lineage()
+    }
+
+    fn is_blocked(&self) -> bool {
+        self.release_signoff_status.is_blocked()
+    }
+
+    fn signoff_required(&self) -> bool {
+        self.release_signoff_status.signoff_required()
+    }
+
+    fn requires_attention(&self) -> bool {
+        self.release_closure.requires_attention()
+            || self.release_signoff_status.requires_attention()
+    }
+
+    fn release_ready(&self) -> bool {
+        self.release_signoff_status.release_ready()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct IntegrationActivationWaiverReleaseSignoffSummary {
+    total_records: usize,
+    unique_integrations: usize,
+    records_requiring_attention: usize,
+    blocked_records: usize,
+    closure_required_records: usize,
+    signoff_required_records: usize,
+    ready_for_release_records: usize,
+    release_ready_records: usize,
+    closed_records: usize,
+    receipted_records: usize,
+    erased_records: usize,
+    purged_records: usize,
+    source_linked_records: usize,
+    reviewer_required_records: usize,
+    exception_required_records: usize,
+    source_signoff_required_records: usize,
+    platform_signoff_records: usize,
+    integration_signoff_records: usize,
+    security_signoff_records: usize,
+    reviewer_signoff_records: usize,
+    verification_signoff_records: usize,
+    audit_signoff_records: usize,
+    first_attention_priority: Option<u8>,
+    first_blocked_priority: Option<u8>,
+    first_ready_priority: Option<u8>,
+    next_release_signoff_status: Option<IntegrationActivationWaiverReleaseSignoffStatus>,
+    next_signoff_lane: Option<IntegrationActivationResponseOwnerLane>,
+    next_signoff_action: Option<String>,
+    highest_policy_tier: PrivilegeTier,
+    overall_status: IntegrationActivationHealthStatus,
+}
+
+impl IntegrationActivationWaiverReleaseSignoffSummary {
+    fn from_records<'a>(
+        records: impl IntoIterator<Item = &'a IntegrationActivationWaiverReleaseSignoffRecord>,
+    ) -> Self {
+        let mut summary = Self {
+            total_records: 0,
+            unique_integrations: 0,
+            records_requiring_attention: 0,
+            blocked_records: 0,
+            closure_required_records: 0,
+            signoff_required_records: 0,
+            ready_for_release_records: 0,
+            release_ready_records: 0,
+            closed_records: 0,
+            receipted_records: 0,
+            erased_records: 0,
+            purged_records: 0,
+            source_linked_records: 0,
+            reviewer_required_records: 0,
+            exception_required_records: 0,
+            source_signoff_required_records: 0,
+            platform_signoff_records: 0,
+            integration_signoff_records: 0,
+            security_signoff_records: 0,
+            reviewer_signoff_records: 0,
+            verification_signoff_records: 0,
+            audit_signoff_records: 0,
+            first_attention_priority: None,
+            first_blocked_priority: None,
+            first_ready_priority: None,
+            next_release_signoff_status: None,
+            next_signoff_lane: None,
+            next_signoff_action: None,
+            highest_policy_tier: PrivilegeTier::ReadOnly,
+            overall_status: IntegrationActivationHealthStatus::Empty,
+        };
+        let mut integration_ids = BTreeSet::new();
+
+        for record in records {
+            summary.total_records += 1;
+            if summary.next_release_signoff_status.is_none() {
+                summary.next_release_signoff_status = Some(record.release_signoff_status);
+                summary.next_signoff_lane = Some(record.signoff_lane);
+                summary.next_signoff_action = Some(record.signoff_action.clone());
+            }
+            let source = &record.release_closure.receipt.source;
+            for integration_id in &source.integration_ids {
+                integration_ids.insert(integration_id.clone());
+            }
+            if record.requires_attention() {
+                summary.records_requiring_attention += 1;
+                summary.first_attention_priority =
+                    min_optional_priority(summary.first_attention_priority, source.priority);
+            }
+            if record.is_blocked() {
+                summary.blocked_records += 1;
+                summary.first_blocked_priority =
+                    min_optional_priority(summary.first_blocked_priority, source.priority);
+            }
+            if record.release_ready() {
+                summary.release_ready_records += 1;
+                summary.ready_for_release_records += 1;
+                summary.first_ready_priority =
+                    min_optional_priority(summary.first_ready_priority, source.priority);
+            }
+            if record.release_closure.closed() {
+                summary.closed_records += 1;
+            }
+            if record.release_closure.receipt.receipted() {
+                summary.receipted_records += 1;
+            }
+            if source.erased {
+                summary.erased_records += 1;
+            }
+            if source.purged {
+                summary.purged_records += 1;
+            }
+            if record.has_source_lineage() {
+                summary.source_linked_records += 1;
+            }
+            if source.reviewer_required {
+                summary.reviewer_required_records += 1;
+            }
+            if source.exception_required {
+                summary.exception_required_records += 1;
+            }
+            if source.signoff_required {
+                summary.source_signoff_required_records += 1;
+            }
+            match record.release_signoff_status {
+                IntegrationActivationWaiverReleaseSignoffStatus::Blocked => {}
+                IntegrationActivationWaiverReleaseSignoffStatus::ClosureRequired => {
+                    summary.closure_required_records += 1
+                }
+                IntegrationActivationWaiverReleaseSignoffStatus::SignoffRequired => {
+                    summary.signoff_required_records += 1
+                }
+                IntegrationActivationWaiverReleaseSignoffStatus::ReadyForRelease => {}
+            }
+            match record.signoff_lane {
+                IntegrationActivationResponseOwnerLane::Platform => {
+                    summary.platform_signoff_records += 1
+                }
+                IntegrationActivationResponseOwnerLane::Integration => {
+                    summary.integration_signoff_records += 1
+                }
+                IntegrationActivationResponseOwnerLane::Security => {
+                    summary.security_signoff_records += 1
+                }
+                IntegrationActivationResponseOwnerLane::Reviewer => {
+                    summary.reviewer_signoff_records += 1
+                }
+                IntegrationActivationResponseOwnerLane::Verification => {
+                    summary.verification_signoff_records += 1
+                }
+                IntegrationActivationResponseOwnerLane::Audit => summary.audit_signoff_records += 1,
+            }
+            summary.highest_policy_tier = summary.highest_policy_tier.max(source.required_tier);
+        }
+
+        summary.unique_integrations = integration_ids.len();
+        summary.overall_status = if summary.total_records == 0 {
+            IntegrationActivationHealthStatus::Empty
+        } else if summary.blocked_records > 0 {
+            IntegrationActivationHealthStatus::Blocked
+        } else if summary.closure_required_records > 0 || summary.signoff_required_records > 0 {
+            IntegrationActivationHealthStatus::NeedsReview
+        } else {
+            IntegrationActivationHealthStatus::Ready
+        };
+        summary
+    }
+
+    fn has_blockers(&self) -> bool {
+        self.blocked_records > 0
+    }
+
+    fn requires_attention(&self) -> bool {
+        self.records_requiring_attention > 0
+            || self.closure_required_records > 0
+            || self.signoff_required_records > 0
+    }
+}
+
+#[derive(Debug, Clone)]
+struct IntegrationActivationWaiverReleaseSignoffQuery {
+    waiver_release_closure: Box<IntegrationActivationWaiverReleaseClosureQuery>,
+    release_signoff_status: Option<IntegrationActivationWaiverReleaseSignoffStatus>,
+    signoff_lane: Option<IntegrationActivationResponseOwnerLane>,
+    release_lane: Option<IntegrationActivationResponseOwnerLane>,
+    receipt_lane: Option<IntegrationActivationResponseOwnerLane>,
+    closure_lane: Option<IntegrationActivationResponseOwnerLane>,
+    owner_lane: Option<IntegrationActivationResponseOwnerLane>,
+    approval_lane: Option<IntegrationActivationResponseOwnerLane>,
+    evidence_kind: Option<String>,
+    requires_attention: Option<bool>,
+    blocked: Option<bool>,
+    release_ready: Option<bool>,
+    release_closed: Option<bool>,
+    signoff_required: Option<bool>,
+    source_signoff_required: Option<bool>,
+    reviewer_required: Option<bool>,
+    receipted: Option<bool>,
+    erased: Option<bool>,
+    purged: Option<bool>,
+    release_signoff_limit: Option<usize>,
+}
+
 fn activation_exception_reason(focus: IntegrationActivationGuardrailKind) -> &'static str {
     match focus {
         IntegrationActivationGuardrailKind::Incident => "incident evidence closure required",
@@ -15710,6 +16080,69 @@ fn activation_waiver_release_closure_action(
             "record_waiver_release_closure"
         }
         IntegrationActivationWaiverReleaseClosureStatus::Closed => "monitor_waiver_release_closure",
+    }
+}
+
+fn activation_waiver_release_signoff_lane(
+    record: &IntegrationActivationWaiverReleaseClosureRecord,
+    status: IntegrationActivationWaiverReleaseSignoffStatus,
+) -> IntegrationActivationResponseOwnerLane {
+    match status {
+        IntegrationActivationWaiverReleaseSignoffStatus::Blocked
+        | IntegrationActivationWaiverReleaseSignoffStatus::ClosureRequired => record.release_lane,
+        IntegrationActivationWaiverReleaseSignoffStatus::SignoffRequired => {
+            if record.receipt.source.reviewer_required {
+                IntegrationActivationResponseOwnerLane::Reviewer
+            } else {
+                record.receipt.source.approval_lane
+            }
+        }
+        IntegrationActivationWaiverReleaseSignoffStatus::ReadyForRelease => {
+            IntegrationActivationResponseOwnerLane::Audit
+        }
+    }
+}
+
+fn activation_waiver_release_signoff_reason(
+    record: &IntegrationActivationWaiverReleaseClosureRecord,
+    status: IntegrationActivationWaiverReleaseSignoffStatus,
+) -> &'static str {
+    match status {
+        IntegrationActivationWaiverReleaseSignoffStatus::Blocked => {
+            "blocking waiver release closure must clear before signoff"
+        }
+        IntegrationActivationWaiverReleaseSignoffStatus::ClosureRequired => {
+            "waiver release closure must be recorded before signoff"
+        }
+        IntegrationActivationWaiverReleaseSignoffStatus::SignoffRequired => {
+            if record.receipt.source.reviewer_required {
+                "reviewer signoff required before waiver release"
+            } else {
+                "owner signoff required before waiver release"
+            }
+        }
+        IntegrationActivationWaiverReleaseSignoffStatus::ReadyForRelease => {
+            "waiver release closure is ready for release"
+        }
+    }
+}
+
+fn activation_waiver_release_signoff_action(
+    status: IntegrationActivationWaiverReleaseSignoffStatus,
+) -> &'static str {
+    match status {
+        IntegrationActivationWaiverReleaseSignoffStatus::Blocked => {
+            "clear_waiver_release_signoff_blocker"
+        }
+        IntegrationActivationWaiverReleaseSignoffStatus::ClosureRequired => {
+            "record_waiver_release_closure"
+        }
+        IntegrationActivationWaiverReleaseSignoffStatus::SignoffRequired => {
+            "collect_waiver_release_signoff"
+        }
+        IntegrationActivationWaiverReleaseSignoffStatus::ReadyForRelease => {
+            "monitor_waiver_release_signoff"
+        }
     }
 }
 
@@ -18066,6 +18499,85 @@ fn integration_activation_waiver_release_closure_query(
         signoff_required: optional_bool(arguments, "signoff_required")?,
         release_closure_limit: optional_u64(arguments, "waiver_release_closure_limit")?
             .or(optional_u64(arguments, "release_closure_limit")?)
+            .or(optional_u64(arguments, "record_limit")?)
+            .map(|value| value as usize),
+    })
+}
+
+fn integration_activation_waiver_release_signoff_query(
+    arguments: &JsonValue,
+) -> Result<IntegrationActivationWaiverReleaseSignoffQuery, ToolCallError> {
+    let release_signoff_status = optional_string(arguments, "waiver_release_signoff_status")?
+        .or(optional_string(arguments, "release_signoff_status")?)
+        .map(|label| parse_activation_waiver_release_signoff_status(&label))
+        .transpose()?;
+    let signoff_lane = optional_string(arguments, "waiver_release_signoff_lane")?
+        .or(optional_string(arguments, "release_signoff_lane")?)
+        .or(optional_string(arguments, "signoff_lane")?)
+        .map(|label| parse_activation_response_owner_lane(&label))
+        .transpose()?;
+    let release_lane = optional_string(arguments, "waiver_release_signoff_release_lane")?
+        .or(optional_string(arguments, "release_lane")?)
+        .map(|label| parse_activation_response_owner_lane(&label))
+        .transpose()?;
+    let receipt_lane = optional_string(arguments, "waiver_release_signoff_receipt_lane")?
+        .or(optional_string(arguments, "receipt_lane")?)
+        .map(|label| parse_activation_response_owner_lane(&label))
+        .transpose()?;
+    let closure_lane = optional_string(arguments, "waiver_release_signoff_source_closure_lane")?
+        .or(optional_string(arguments, "closure_lane")?)
+        .map(|label| parse_activation_response_owner_lane(&label))
+        .transpose()?;
+    let owner_lane = optional_string(arguments, "waiver_release_signoff_owner_lane")?
+        .or(optional_string(arguments, "owner_lane")?)
+        .map(|label| parse_activation_response_owner_lane(&label))
+        .transpose()?;
+    let approval_lane = optional_string(arguments, "waiver_release_signoff_approval_lane")?
+        .or(optional_string(arguments, "approval_lane")?)
+        .map(|label| parse_activation_response_owner_lane(&label))
+        .transpose()?;
+
+    Ok(IntegrationActivationWaiverReleaseSignoffQuery {
+        waiver_release_closure: Box::new(integration_activation_waiver_release_closure_query(
+            arguments,
+        )?),
+        release_signoff_status,
+        signoff_lane,
+        release_lane,
+        receipt_lane,
+        closure_lane,
+        owner_lane,
+        approval_lane,
+        evidence_kind: optional_string(arguments, "waiver_release_signoff_evidence_kind")?
+            .or(optional_string(arguments, "evidence_kind")?),
+        requires_attention: optional_bool(arguments, "waiver_release_signoff_requires_attention")?
+            .or(optional_bool(
+                arguments,
+                "release_signoff_requires_attention",
+            )?),
+        blocked: optional_bool(arguments, "waiver_release_signoff_blocked")?
+            .or(optional_bool(arguments, "release_signoff_blocked")?),
+        release_ready: optional_bool(arguments, "waiver_release_signoff_ready")?
+            .or(optional_bool(arguments, "release_ready")?),
+        release_closed: optional_bool(arguments, "waiver_release_signoff_closed")?
+            .or(optional_bool(arguments, "release_closed")?)
+            .or(optional_bool(arguments, "closed")?),
+        signoff_required: optional_bool(arguments, "waiver_release_signoff_required")?
+            .or(optional_bool(arguments, "release_signoff_required")?),
+        source_signoff_required: optional_bool(
+            arguments,
+            "waiver_release_signoff_source_signoff_required",
+        )?
+        .or(optional_bool(arguments, "signoff_required")?),
+        reviewer_required: optional_bool(arguments, "reviewer_required")?,
+        receipted: optional_bool(arguments, "waiver_release_signoff_receipted")?
+            .or(optional_bool(arguments, "receipted")?),
+        erased: optional_bool(arguments, "waiver_release_signoff_erased")?
+            .or(optional_bool(arguments, "erased")?),
+        purged: optional_bool(arguments, "waiver_release_signoff_purged")?
+            .or(optional_bool(arguments, "purged")?),
+        release_signoff_limit: optional_u64(arguments, "waiver_release_signoff_limit")?
+            .or(optional_u64(arguments, "release_signoff_limit")?)
             .or(optional_u64(arguments, "record_limit")?)
             .map(|value| value as usize),
     })
@@ -21427,6 +21939,89 @@ fn integration_activation_waiver_release_closures_for_query(
         records.retain(|record| record.receipt.source.signoff_required == signoff_required);
     }
     if let Some(limit) = query.release_closure_limit {
+        records.truncate(limit);
+    }
+
+    (records, catalog_count)
+}
+
+fn integration_activation_waiver_release_signoffs_for_query(
+    query: &IntegrationActivationWaiverReleaseSignoffQuery,
+) -> (Vec<IntegrationActivationWaiverReleaseSignoffRecord>, usize) {
+    let (closure_records, catalog_count) =
+        integration_activation_waiver_release_closures_for_query(&query.waiver_release_closure);
+    let mut records: Vec<_> = closure_records
+        .iter()
+        .enumerate()
+        .map(|(index, record)| {
+            IntegrationActivationWaiverReleaseSignoffRecord::from_release_closure_record(
+                index + 1,
+                record,
+            )
+        })
+        .collect();
+
+    if let Some(status) = query.release_signoff_status {
+        records.retain(|record| record.release_signoff_status == status);
+    }
+    if let Some(signoff_lane) = query.signoff_lane {
+        records.retain(|record| record.signoff_lane == signoff_lane);
+    }
+    if let Some(release_lane) = query.release_lane {
+        records.retain(|record| record.release_closure.release_lane == release_lane);
+    }
+    if let Some(receipt_lane) = query.receipt_lane {
+        records.retain(|record| record.release_closure.receipt.receipt_lane == receipt_lane);
+    }
+    if let Some(closure_lane) = query.closure_lane {
+        records.retain(|record| record.release_closure.receipt.source.closure_lane == closure_lane);
+    }
+    if let Some(owner_lane) = query.owner_lane {
+        records.retain(|record| record.release_closure.receipt.source.owner_lane == owner_lane);
+    }
+    if let Some(approval_lane) = query.approval_lane {
+        records
+            .retain(|record| record.release_closure.receipt.source.approval_lane == approval_lane);
+    }
+    if let Some(evidence_kind) = &query.evidence_kind {
+        records
+            .retain(|record| record.release_closure.receipt.source.evidence_kind == *evidence_kind);
+    }
+    if let Some(requires_attention) = query.requires_attention {
+        records.retain(|record| record.requires_attention() == requires_attention);
+    }
+    if let Some(blocked) = query.blocked {
+        records.retain(|record| record.is_blocked() == blocked);
+    }
+    if let Some(release_ready) = query.release_ready {
+        records.retain(|record| record.release_ready() == release_ready);
+    }
+    if let Some(release_closed) = query.release_closed {
+        records.retain(|record| record.release_closure.closed() == release_closed);
+    }
+    if let Some(signoff_required) = query.signoff_required {
+        records.retain(|record| record.signoff_required() == signoff_required);
+    }
+    if let Some(source_signoff_required) = query.source_signoff_required {
+        records.retain(|record| {
+            record.release_closure.receipt.source.signoff_required == source_signoff_required
+        });
+    }
+    if let Some(reviewer_required) = query.reviewer_required {
+        records.retain(|record| {
+            record.release_closure.receipt.source.reviewer_required == reviewer_required
+        });
+    }
+    if let Some(receipted) = query.receipted {
+        records.retain(|record| record.release_closure.receipt.receipted() == receipted);
+    }
+    if let Some(erased) = query.erased {
+        records.retain(|record| record.release_closure.receipt.source.erased == erased);
+    }
+    if let Some(purged) = query.purged {
+        records.retain(|record| record.release_closure.receipt.source.purged == purged);
+    }
+    if let Some(limit) = query.release_signoff_limit {
         records.truncate(limit);
     }
 
@@ -28503,6 +29098,92 @@ fn get_integration_activation_waiver_release_closure_summary_output_handler_outp
                 integer(summary.records_requiring_attention as i64),
             ),
             ("blocked_records", integer(summary.blocked_records as i64)),
+            (
+                "release_ready_records",
+                integer(summary.release_ready_records as i64),
+            ),
+            ("overall_status", string(summary.overall_status.as_str())),
+        ]),
+    )
+}
+
+fn list_integration_activation_waiver_release_signoffs_output_handler_output(
+    query: IntegrationActivationWaiverReleaseSignoffQuery,
+) -> ToolHandlerOutput {
+    let (records, catalog_count) = integration_activation_waiver_release_signoffs_for_query(&query);
+    let summary = IntegrationActivationWaiverReleaseSignoffSummary::from_records(records.iter());
+    let count = records.len();
+
+    ToolHandlerOutput::new(object([
+        (
+            "activation_waiver_release_signoffs",
+            JsonValue::Array(
+                records
+                    .iter()
+                    .map(activation_waiver_release_signoff_record_json)
+                    .collect(),
+            ),
+        ),
+        (
+            "summary",
+            integration_activation_waiver_release_signoff_summary_json(&summary),
+        ),
+        ("count", integer(count as i64)),
+        ("catalog_count", integer(catalog_count as i64)),
+    ]))
+    .with_event(
+        ToolEventKind::Progress,
+        object([
+            (
+                "operation",
+                string("list_integration_activation_waiver_release_signoffs"),
+            ),
+            ("records", integer(count as i64)),
+            (
+                "records_requiring_attention",
+                integer(summary.records_requiring_attention as i64),
+            ),
+            ("blocked_records", integer(summary.blocked_records as i64)),
+            (
+                "signoff_required_records",
+                integer(summary.signoff_required_records as i64),
+            ),
+            (
+                "release_ready_records",
+                integer(summary.release_ready_records as i64),
+            ),
+            ("overall_status", string(summary.overall_status.as_str())),
+        ]),
+    )
+}
+
+fn get_integration_activation_waiver_release_signoff_summary_output_handler_output(
+    query: IntegrationActivationWaiverReleaseSignoffQuery,
+) -> ToolHandlerOutput {
+    let (records, _) = integration_activation_waiver_release_signoffs_for_query(&query);
+    let summary = IntegrationActivationWaiverReleaseSignoffSummary::from_records(records.iter());
+
+    ToolHandlerOutput::new(object([(
+        "summary",
+        integration_activation_waiver_release_signoff_summary_json(&summary),
+    )]))
+    .with_event(
+        ToolEventKind::Progress,
+        object([
+            (
+                "operation",
+                string("get_integration_activation_waiver_release_signoff_summary"),
+            ),
+            ("total_records", integer(summary.total_records as i64)),
+            (
+                "records_requiring_attention",
+                integer(summary.records_requiring_attention as i64),
+            ),
+            ("blocked_records", integer(summary.blocked_records as i64)),
+            (
+                "signoff_required_records",
+                integer(summary.signoff_required_records as i64),
+            ),
             (
                 "release_ready_records",
                 integer(summary.release_ready_records as i64),
@@ -45443,6 +46124,297 @@ fn integration_activation_waiver_release_closure_summary_json(
     ]
 }
 
+fn activation_waiver_release_signoff_record_json(
+    record: &IntegrationActivationWaiverReleaseSignoffRecord,
+) -> JsonValue {
+    let release_closure = &record.release_closure;
+    let receipt = &release_closure.receipt;
+    let source = &receipt.source;
+    heap_object![
+        ("sequence", integer(record.sequence as i64)),
+        ("release_signoff_id", string(&record.release_signoff_id)),
+        (
+            "source_release_closure_id",
+            string(&record.source_release_closure_id),
+        ),
+        ("source_receipt_id", string(&record.source_receipt_id)),
+        ("source_erasure_id", string(&record.source_erasure_id)),
+        ("source_purge_id", string(&source.source_purge_id)),
+        ("source_tombstone_id", string(&source.source_tombstone_id)),
+        ("source_disposal_id", string(&source.source_disposal_id)),
+        ("source_expiration_id", string(&source.source_expiration_id)),
+        ("source_retention_id", string(&source.source_retention_id)),
+        ("source_archive_id", string(&source.source_archive_id)),
+        ("source_closure_id", string(&source.source_closure_id)),
+        (
+            "source_remediation_id",
+            string(&source.source_remediation_id),
+        ),
+        (
+            "source_disposition_id",
+            string(&source.source_disposition_id),
+        ),
+        ("source_review_id", string(&source.source_review_id)),
+        ("source_waiver_id", string(&source.source_waiver_id)),
+        ("source_exception_id", string(&source.source_exception_id)),
+        ("source_ledger_id", string(&source.source_ledger_id)),
+        (
+            "source_attestation_id",
+            string(&source.source_attestation_id),
+        ),
+        ("source_compliance_id", string(&source.source_compliance_id)),
+        ("source_governance_id", string(&source.source_governance_id)),
+        ("source_assurance_id", string(&source.source_assurance_id)),
+        ("source_guardrail_id", string(&source.source_guardrail_id)),
+        (
+            "release_signoff_status",
+            string(record.release_signoff_status.as_str()),
+        ),
+        (
+            "release_closure_status",
+            string(release_closure.release_closure_status.as_str()),
+        ),
+        ("receipt_status", string(receipt.receipt_status.as_str())),
+        ("erasure_status", string(source.erasure_status.as_str())),
+        ("purge_status", string(source.purge_status.as_str())),
+        ("tombstone_status", string(source.tombstone_status.as_str())),
+        ("disposal_status", string(source.disposal_status.as_str())),
+        (
+            "expiration_status",
+            string(source.expiration_status.as_str()),
+        ),
+        ("retention_status", string(source.retention_status.as_str())),
+        ("archive_status", string(source.archive_status.as_str())),
+        ("waiver_status", string(source.waiver_status.as_str())),
+        ("exception_status", string(source.exception_status.as_str())),
+        ("signoff_lane", string(record.signoff_lane.as_str())),
+        (
+            "release_lane",
+            string(release_closure.release_lane.as_str())
+        ),
+        ("receipt_lane", string(receipt.receipt_lane.as_str())),
+        ("erasure_lane", string(source.erasure_lane.as_str())),
+        ("purge_lane", string(source.purge_lane.as_str())),
+        ("tombstone_lane", string(source.tombstone_lane.as_str())),
+        ("disposal_lane", string(source.disposal_lane.as_str())),
+        ("expiration_lane", string(source.expiration_lane.as_str())),
+        ("retention_lane", string(source.retention_lane.as_str())),
+        ("archive_lane", string(source.archive_lane.as_str())),
+        ("closure_lane", string(source.closure_lane.as_str())),
+        ("owner_lane", string(source.owner_lane.as_str())),
+        ("approval_lane", string(source.approval_lane.as_str())),
+        ("signoff_reason", string(&record.signoff_reason)),
+        ("signoff_action", string(&record.signoff_action)),
+        ("release_reason", string(&release_closure.release_reason)),
+        ("release_action", string(&release_closure.release_action)),
+        ("receipt_reason", string(&receipt.receipt_reason)),
+        ("receipt_action", string(&receipt.receipt_action)),
+        ("evidence_kind", string(&source.evidence_kind)),
+        ("priority", integer(source.priority as i64)),
+        (
+            "integration_ids",
+            JsonValue::Array(
+                source
+                    .integration_ids
+                    .iter()
+                    .map(|integration_id| string(integration_id.as_str()))
+                    .collect(),
+            ),
+        ),
+        (
+            "integration_count",
+            integer(source.integration_ids.len() as i64),
+        ),
+        (
+            "required_tier",
+            string(privilege_tier_label(source.required_tier)),
+        ),
+        (
+            "reviewer_required",
+            JsonValue::Bool(source.reviewer_required),
+        ),
+        (
+            "exception_required",
+            JsonValue::Bool(source.exception_required),
+        ),
+        (
+            "source_signoff_required",
+            JsonValue::Bool(source.signoff_required),
+        ),
+        (
+            "signoff_required",
+            JsonValue::Bool(record.signoff_required()),
+        ),
+        ("evidence_ready", JsonValue::Bool(source.evidence_ready)),
+        ("waiver_ready", JsonValue::Bool(source.waiver_ready)),
+        ("archive_ready", JsonValue::Bool(source.archive_ready)),
+        ("retention_ready", JsonValue::Bool(source.retention_ready)),
+        ("expiration_ready", JsonValue::Bool(source.expiration_ready)),
+        ("disposal_ready", JsonValue::Bool(source.disposal_ready)),
+        ("tombstone_ready", JsonValue::Bool(source.tombstone_ready)),
+        ("purge_ready", JsonValue::Bool(source.purge_ready)),
+        ("erasure_ready", JsonValue::Bool(source.erasure_ready)),
+        ("receipt_ready", JsonValue::Bool(receipt.receipt_ready())),
+        (
+            "release_closure_ready",
+            JsonValue::Bool(release_closure.release_ready()),
+        ),
+        ("release_ready", JsonValue::Bool(record.release_ready())),
+        ("receipted", JsonValue::Bool(receipt.receipted())),
+        ("release_closed", JsonValue::Bool(release_closure.closed())),
+        ("erased", JsonValue::Bool(source.erased)),
+        ("purged", JsonValue::Bool(source.purged)),
+        ("tombstoned", JsonValue::Bool(source.tombstoned)),
+        ("disposed", JsonValue::Bool(source.disposed)),
+        ("retained", JsonValue::Bool(source.retained)),
+        ("expired", JsonValue::Bool(source.expired)),
+        ("archived", JsonValue::Bool(source.archived)),
+        ("blocked", JsonValue::Bool(record.is_blocked())),
+        (
+            "requires_attention",
+            JsonValue::Bool(record.requires_attention()),
+        ),
+        (
+            "has_source_lineage",
+            JsonValue::Bool(record.has_source_lineage()),
+        ),
+    ]
+}
+
+fn integration_activation_waiver_release_signoff_summary_json(
+    summary: &IntegrationActivationWaiverReleaseSignoffSummary,
+) -> JsonValue {
+    heap_object![
+        ("total_records", integer(summary.total_records as i64)),
+        (
+            "unique_integrations",
+            integer(summary.unique_integrations as i64),
+        ),
+        (
+            "records_requiring_attention",
+            integer(summary.records_requiring_attention as i64),
+        ),
+        ("blocked_records", integer(summary.blocked_records as i64)),
+        (
+            "closure_required_records",
+            integer(summary.closure_required_records as i64),
+        ),
+        (
+            "signoff_required_records",
+            integer(summary.signoff_required_records as i64),
+        ),
+        (
+            "ready_for_release_records",
+            integer(summary.ready_for_release_records as i64),
+        ),
+        (
+            "release_ready_records",
+            integer(summary.release_ready_records as i64),
+        ),
+        ("closed_records", integer(summary.closed_records as i64)),
+        (
+            "receipted_records",
+            integer(summary.receipted_records as i64),
+        ),
+        ("erased_records", integer(summary.erased_records as i64)),
+        ("purged_records", integer(summary.purged_records as i64)),
+        (
+            "source_linked_records",
+            integer(summary.source_linked_records as i64),
+        ),
+        (
+            "reviewer_required_records",
+            integer(summary.reviewer_required_records as i64),
+        ),
+        (
+            "exception_required_records",
+            integer(summary.exception_required_records as i64),
+        ),
+        (
+            "source_signoff_required_records",
+            integer(summary.source_signoff_required_records as i64),
+        ),
+        (
+            "platform_signoff_records",
+            integer(summary.platform_signoff_records as i64),
+        ),
+        (
+            "integration_signoff_records",
+            integer(summary.integration_signoff_records as i64),
+        ),
+        (
+            "security_signoff_records",
+            integer(summary.security_signoff_records as i64),
+        ),
+        (
+            "reviewer_signoff_records",
+            integer(summary.reviewer_signoff_records as i64),
+        ),
+        (
+            "verification_signoff_records",
+            integer(summary.verification_signoff_records as i64),
+        ),
+        (
+            "audit_signoff_records",
+            integer(summary.audit_signoff_records as i64),
+        ),
+        (
+            "first_attention_priority",
+            summary
+                .first_attention_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_blocked_priority",
+            summary
+                .first_blocked_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_ready_priority",
+            summary
+                .first_ready_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "next_release_signoff_status",
+            summary
+                .next_release_signoff_status
+                .map(|status| string(status.as_str()))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "next_signoff_lane",
+            summary
+                .next_signoff_lane
+                .map(|lane| string(lane.as_str()))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "next_signoff_action",
+            summary
+                .next_signoff_action
+                .as_ref()
+                .map(|action| string(action))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "highest_policy_tier",
+            string(privilege_tier_label(summary.highest_policy_tier)),
+        ),
+        ("overall_status", string(summary.overall_status.as_str())),
+        ("is_empty", JsonValue::Bool(summary.total_records == 0)),
+        ("has_blockers", JsonValue::Bool(summary.has_blockers())),
+        (
+            "requires_attention",
+            JsonValue::Bool(summary.requires_attention()),
+        ),
+    ]
+}
+
 fn activation_risk_json(risk: &IntegrationActivationRiskItem) -> JsonValue {
     object([
         ("risk_kind", string(risk.kind.as_str())),
@@ -52915,6 +53887,26 @@ fn parse_activation_waiver_release_closure_status(
     }
 }
 
+fn parse_activation_waiver_release_signoff_status(
+    label: &str,
+) -> Result<IntegrationActivationWaiverReleaseSignoffStatus, ToolCallError> {
+    match label {
+        "blocked" | "blocker" | "hold" | "held" => {
+            Ok(IntegrationActivationWaiverReleaseSignoffStatus::Blocked)
+        }
+        "closure_required" | "needs_closure" | "closure" | "source_required" | "source_linkage" => {
+            Ok(IntegrationActivationWaiverReleaseSignoffStatus::ClosureRequired)
+        }
+        "signoff_required" | "needs_signoff" | "signoff" | "reviewer_required"
+        | "owner_required" => Ok(IntegrationActivationWaiverReleaseSignoffStatus::SignoffRequired),
+        "ready_for_release" | "release_ready" | "ready" | "ready_to_release" | "signed_off"
+        | "signedoff" => Ok(IntegrationActivationWaiverReleaseSignoffStatus::ReadyForRelease),
+        _ => Err(validation_error(format!(
+            "unknown activation waiver release signoff status `{label}`"
+        ))),
+    }
+}
+
 fn parse_activation_risk_kind(label: &str) -> Result<IntegrationActivationRiskKind, ToolCallError> {
     match label {
         "policy_tier" | "tier" | "required_tier" => Ok(IntegrationActivationRiskKind::PolicyTier),
@@ -56353,6 +57345,124 @@ fn integration_activation_waiver_release_closure_query_schema() -> JsonSchema {
     schema
 }
 
+fn integration_activation_waiver_release_signoff_query_schema() -> JsonSchema {
+    let mut schema = integration_activation_waiver_release_closure_query_schema();
+    if let JsonSchema::Object {
+        properties,
+        required: _,
+        allow_unknown_fields: _,
+    } = &mut schema
+    {
+        let mut push_if_absent = |property: SchemaProperty| {
+            if !properties
+                .iter()
+                .any(|existing| existing.name == property.name)
+            {
+                properties.push(property);
+            }
+        };
+        push_if_absent(SchemaProperty::new(
+            "waiver_release_signoff_status",
+            JsonSchema::String,
+        ));
+        push_if_absent(SchemaProperty::new(
+            "release_signoff_status",
+            JsonSchema::String,
+        ));
+        push_if_absent(SchemaProperty::new(
+            "waiver_release_signoff_lane",
+            JsonSchema::String,
+        ));
+        push_if_absent(SchemaProperty::new(
+            "release_signoff_lane",
+            JsonSchema::String,
+        ));
+        push_if_absent(SchemaProperty::new("signoff_lane", JsonSchema::String));
+        push_if_absent(SchemaProperty::new(
+            "waiver_release_signoff_release_lane",
+            JsonSchema::String,
+        ));
+        push_if_absent(SchemaProperty::new(
+            "waiver_release_signoff_receipt_lane",
+            JsonSchema::String,
+        ));
+        push_if_absent(SchemaProperty::new(
+            "waiver_release_signoff_source_closure_lane",
+            JsonSchema::String,
+        ));
+        push_if_absent(SchemaProperty::new(
+            "waiver_release_signoff_owner_lane",
+            JsonSchema::String,
+        ));
+        push_if_absent(SchemaProperty::new(
+            "waiver_release_signoff_approval_lane",
+            JsonSchema::String,
+        ));
+        push_if_absent(SchemaProperty::new(
+            "waiver_release_signoff_evidence_kind",
+            JsonSchema::String,
+        ));
+        push_if_absent(SchemaProperty::new(
+            "waiver_release_signoff_requires_attention",
+            JsonSchema::Boolean,
+        ));
+        push_if_absent(SchemaProperty::new(
+            "release_signoff_requires_attention",
+            JsonSchema::Boolean,
+        ));
+        push_if_absent(SchemaProperty::new(
+            "waiver_release_signoff_blocked",
+            JsonSchema::Boolean,
+        ));
+        push_if_absent(SchemaProperty::new(
+            "release_signoff_blocked",
+            JsonSchema::Boolean,
+        ));
+        push_if_absent(SchemaProperty::new(
+            "waiver_release_signoff_ready",
+            JsonSchema::Boolean,
+        ));
+        push_if_absent(SchemaProperty::new(
+            "waiver_release_signoff_closed",
+            JsonSchema::Boolean,
+        ));
+        push_if_absent(SchemaProperty::new(
+            "waiver_release_signoff_required",
+            JsonSchema::Boolean,
+        ));
+        push_if_absent(SchemaProperty::new(
+            "release_signoff_required",
+            JsonSchema::Boolean,
+        ));
+        push_if_absent(SchemaProperty::new(
+            "waiver_release_signoff_source_signoff_required",
+            JsonSchema::Boolean,
+        ));
+        push_if_absent(SchemaProperty::new(
+            "waiver_release_signoff_receipted",
+            JsonSchema::Boolean,
+        ));
+        push_if_absent(SchemaProperty::new(
+            "waiver_release_signoff_erased",
+            JsonSchema::Boolean,
+        ));
+        push_if_absent(SchemaProperty::new(
+            "waiver_release_signoff_purged",
+            JsonSchema::Boolean,
+        ));
+        push_if_absent(SchemaProperty::new(
+            "waiver_release_signoff_limit",
+            JsonSchema::Integer,
+        ));
+        push_if_absent(SchemaProperty::new(
+            "release_signoff_limit",
+            JsonSchema::Integer,
+        ));
+        push_if_absent(SchemaProperty::new("record_limit", JsonSchema::Integer));
+    }
+    schema
+}
+
 fn integration_activation_risk_query_schema() -> JsonSchema {
     let mut schema = integration_activation_candidate_query_schema(true);
     if let JsonSchema::Object {
@@ -56497,7 +57607,7 @@ mod tests {
         let definitions = smart_home_tool_definitions();
         let export = ToolCatalogExport::from_definitions(definitions.iter());
 
-        assert_eq!(definitions.len(), 232);
+        assert_eq!(definitions.len(), 234);
         assert!(
             export.ok(),
             "tool export validation failed: {:?}",
@@ -57164,7 +58274,7 @@ mod tests {
         ));
         assert_eq!(
             export.summary.required_capability_count("smart_home:read"),
-            224
+            226
         );
         assert_eq!(
             export
@@ -58004,11 +59114,11 @@ mod tests {
         let tool_catalog_summary = field(tool_catalog_summary_output, "summary").unwrap();
         assert_eq!(
             field(tool_catalog_summary, "total_tools"),
-            Some(&integer(232))
+            Some(&integer(234))
         );
         assert_eq!(
             field(tool_catalog_summary, "read_tools"),
-            Some(&integer(224))
+            Some(&integer(226))
         );
         assert_eq!(
             field(tool_catalog_summary, "risky_tool_count"),
@@ -73027,6 +74137,219 @@ mod tests {
         traces.push((
             activation_waiver_release_closure_summary_request,
             activation_waiver_release_closure_summary_trace,
+        ));
+
+        traces
+    }
+
+    #[test]
+    fn activation_waiver_release_signoff_tools_project_closure_lineage_end_to_end() {
+        std::thread::Builder::new()
+            .name("activation-waiver-release-signoff-e2e".to_string())
+            .stack_size(16 * 1024 * 1024)
+            .spawn(activation_waiver_release_signoff_tools_project_closure_lineage_end_to_end_inner)
+            .unwrap()
+            .join()
+            .unwrap();
+    }
+
+    fn activation_waiver_release_signoff_tools_project_closure_lineage_end_to_end_inner() {
+        let runtime = Rc::new(RefCell::new(hue_lighting_runtime()));
+        let bridge = SmartHomeToolBridge::new(runtime, AgentId::trusted(AGENT_ID));
+        let mut tool_runtime = InMemoryToolRuntime::new();
+        bridge.register_all(&mut tool_runtime).unwrap();
+
+        let traces = exercise_activation_waiver_release_signoff_tools(&tool_runtime);
+        let mut journal = ToolExecutionJournal::new();
+        for (request, trace) in traces {
+            journal.record_trace(request, trace);
+        }
+
+        let summary = journal.summary();
+        assert_eq!(summary.invocation_count, 2);
+        assert_eq!(summary.completed_count, 2);
+        assert_eq!(journal.audit_records().len(), 2);
+    }
+
+    fn exercise_activation_waiver_release_signoff_tools(
+        tool_runtime: &InMemoryToolRuntime,
+    ) -> Vec<(ToolInvocationRequest, ToolExecutionTrace)> {
+        let mut traces = Vec::with_capacity(2);
+
+        let list_activation_waiver_release_signoffs_request = request(
+            "call-list-integration-activation-waiver-release-signoffs",
+            SMART_HOME_LIST_INTEGRATION_ACTIVATION_WAIVER_RELEASE_SIGNOFFS_TOOL_ID,
+            object([
+                ("priority_at_or_before", integer(2)),
+                (
+                    "available_primitives",
+                    JsonValue::Array(vec![
+                        string("normalized_model"),
+                        string("discovery_index"),
+                        string("command_mapping"),
+                        string("capability_policy"),
+                        string("supervision"),
+                    ]),
+                ),
+                (
+                    "allowed_capability_ids",
+                    JsonValue::Array(vec![string("smart_home.read")]),
+                ),
+                (
+                    "enabled_integrations",
+                    JsonValue::Array(vec![string("mqtt")]),
+                ),
+                ("waiver_release_signoff_blocked", JsonValue::Bool(true)),
+                (
+                    "waiver_release_signoff_requires_attention",
+                    JsonValue::Bool(true),
+                ),
+                ("waiver_release_signoff_limit", integer(3)),
+            ]),
+            5_409,
+        );
+        let list_activation_waiver_release_signoffs_trace =
+            tool_runtime.invoke_with_events(&list_activation_waiver_release_signoffs_request);
+        assert!(list_activation_waiver_release_signoffs_trace.result.ok);
+        assert_eq!(
+            list_activation_waiver_release_signoffs_trace
+                .summary()
+                .progress_event_count,
+            1
+        );
+        let list_activation_waiver_release_signoffs_output =
+            list_activation_waiver_release_signoffs_trace
+                .result
+                .output
+                .as_ref()
+                .unwrap();
+        let activation_waiver_release_signoff_count =
+            integer_value(field(list_activation_waiver_release_signoffs_output, "count").unwrap())
+                .unwrap();
+        assert!((1..=3).contains(&activation_waiver_release_signoff_count));
+        let activation_waiver_release_signoff_summary =
+            field(list_activation_waiver_release_signoffs_output, "summary").unwrap();
+        assert_eq!(
+            field(activation_waiver_release_signoff_summary, "total_records"),
+            Some(&integer(activation_waiver_release_signoff_count))
+        );
+        assert!(
+            integer_value(
+                field(activation_waiver_release_signoff_summary, "blocked_records").unwrap(),
+            )
+            .unwrap()
+                >= 1
+        );
+        assert_eq!(
+            field(activation_waiver_release_signoff_summary, "has_blockers"),
+            Some(&JsonValue::Bool(true))
+        );
+        assert_eq!(
+            field(
+                activation_waiver_release_signoff_summary,
+                "requires_attention",
+            ),
+            Some(&JsonValue::Bool(true))
+        );
+        let activation_waiver_release_signoff = array_item(
+            field(
+                list_activation_waiver_release_signoffs_output,
+                "activation_waiver_release_signoffs",
+            )
+            .unwrap(),
+            0,
+        )
+        .unwrap();
+        assert!(field(activation_waiver_release_signoff, "release_signoff_id").is_some());
+        assert!(field(
+            activation_waiver_release_signoff,
+            "source_release_closure_id"
+        )
+        .is_some());
+        assert!(field(activation_waiver_release_signoff, "source_receipt_id").is_some());
+        assert!(field(activation_waiver_release_signoff, "source_erasure_id").is_some());
+        assert!(field(activation_waiver_release_signoff, "source_purge_id").is_some());
+        assert!(field(activation_waiver_release_signoff, "source_tombstone_id").is_some());
+        assert!(field(activation_waiver_release_signoff, "source_disposal_id").is_some());
+        assert!(field(activation_waiver_release_signoff, "source_waiver_id").is_some());
+        assert!(field(activation_waiver_release_signoff, "source_exception_id").is_some());
+        assert!(field(activation_waiver_release_signoff, "signoff_lane").is_some());
+        assert!(field(activation_waiver_release_signoff, "signoff_action").is_some());
+        assert_eq!(
+            field(activation_waiver_release_signoff, "blocked"),
+            Some(&JsonValue::Bool(true))
+        );
+        assert_eq!(
+            field(activation_waiver_release_signoff, "requires_attention"),
+            Some(&JsonValue::Bool(true))
+        );
+        assert_eq!(
+            field(activation_waiver_release_signoff, "has_source_lineage"),
+            Some(&JsonValue::Bool(true))
+        );
+        traces.push((
+            list_activation_waiver_release_signoffs_request,
+            list_activation_waiver_release_signoffs_trace,
+        ));
+
+        let activation_waiver_release_signoff_summary_request = request(
+            "call-integration-activation-waiver-release-signoff-summary",
+            SMART_HOME_GET_INTEGRATION_ACTIVATION_WAIVER_RELEASE_SIGNOFF_SUMMARY_TOOL_ID,
+            object([
+                ("priority_at_or_before", integer(2)),
+                (
+                    "available_primitives",
+                    JsonValue::Array(vec![
+                        string("normalized_model"),
+                        string("discovery_index"),
+                        string("command_mapping"),
+                        string("capability_policy"),
+                        string("supervision"),
+                    ]),
+                ),
+                (
+                    "allowed_capability_ids",
+                    JsonValue::Array(vec![string("smart_home.read")]),
+                ),
+                (
+                    "enabled_integrations",
+                    JsonValue::Array(vec![string("mqtt")]),
+                ),
+                ("waiver_release_signoff_blocked", JsonValue::Bool(true)),
+            ]),
+            5_410,
+        );
+        let activation_waiver_release_signoff_summary_trace =
+            tool_runtime.invoke_with_events(&activation_waiver_release_signoff_summary_request);
+        assert!(activation_waiver_release_signoff_summary_trace.result.ok);
+        assert_eq!(
+            activation_waiver_release_signoff_summary_trace
+                .summary()
+                .progress_event_count,
+            1
+        );
+        let activation_waiver_release_signoff_summary_output =
+            activation_waiver_release_signoff_summary_trace
+                .result
+                .output
+                .as_ref()
+                .unwrap();
+        let activation_waiver_release_signoff_rollup =
+            field(activation_waiver_release_signoff_summary_output, "summary").unwrap();
+        assert!(
+            integer_value(
+                field(activation_waiver_release_signoff_rollup, "blocked_records").unwrap(),
+            )
+            .unwrap()
+                >= 1
+        );
+        assert_eq!(
+            field(activation_waiver_release_signoff_rollup, "has_blockers"),
+            Some(&JsonValue::Bool(true))
+        );
+        traces.push((
+            activation_waiver_release_signoff_summary_request,
+            activation_waiver_release_signoff_summary_trace,
         ));
 
         traces

--- a/code/packages/rust/smart-home-core/src/lib.rs
+++ b/code/packages/rust/smart-home-core/src/lib.rs
@@ -1584,6 +1584,8 @@ pub enum SmartHomeTool {
     GetIntegrationActivationWaiverErasureReceiptSummary,
     ListIntegrationActivationWaiverReleaseClosures,
     GetIntegrationActivationWaiverReleaseClosureSummary,
+    ListIntegrationActivationWaiverReleaseSignoffs,
+    GetIntegrationActivationWaiverReleaseSignoffSummary,
     ListIntegrationActivationRisk,
     GetIntegrationActivationRiskSummary,
     ListIntegrationActivationDependencies,
@@ -2088,6 +2090,12 @@ impl SmartHomeTool {
             }
             Self::GetIntegrationActivationWaiverReleaseClosureSummary => {
                 read_tool("smart_home.get_integration_activation_waiver_release_closure_summary")
+            }
+            Self::ListIntegrationActivationWaiverReleaseSignoffs => {
+                read_tool("smart_home.list_integration_activation_waiver_release_signoffs")
+            }
+            Self::GetIntegrationActivationWaiverReleaseSignoffSummary => {
+                read_tool("smart_home.get_integration_activation_waiver_release_signoff_summary")
             }
             Self::ListIntegrationActivationRisk => {
                 read_tool("smart_home.list_integration_activation_risk")
@@ -2993,6 +3001,8 @@ pub fn smart_home_tool_catalog() -> Vec<ToolDescriptor> {
         SmartHomeTool::GetIntegrationActivationWaiverErasureReceiptSummary,
         SmartHomeTool::ListIntegrationActivationWaiverReleaseClosures,
         SmartHomeTool::GetIntegrationActivationWaiverReleaseClosureSummary,
+        SmartHomeTool::ListIntegrationActivationWaiverReleaseSignoffs,
+        SmartHomeTool::GetIntegrationActivationWaiverReleaseSignoffSummary,
         SmartHomeTool::ListIntegrationActivationRisk,
         SmartHomeTool::GetIntegrationActivationRiskSummary,
         SmartHomeTool::ListIntegrationActivationDependencies,
@@ -3881,7 +3891,7 @@ mod tests {
             .find(|tool| tool.tool_id == "smart_home.command")
             .unwrap();
 
-        assert_eq!(catalog.len(), 232);
+        assert_eq!(catalog.len(), 234);
         assert!(catalog
             .iter()
             .any(|tool| tool.tool_id == "smart_home.list_integrations"
@@ -4664,6 +4674,14 @@ mod tests {
             && tool.side_effects == ToolSideEffects::Read
             && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
         assert!(catalog.iter().any(|tool| tool.tool_id
+            == "smart_home.list_integration_activation_waiver_release_signoffs"
+            && tool.side_effects == ToolSideEffects::Read
+            && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
+        assert!(catalog.iter().any(|tool| tool.tool_id
+            == "smart_home.get_integration_activation_waiver_release_signoff_summary"
+            && tool.side_effects == ToolSideEffects::Read
+            && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
+        assert!(catalog.iter().any(|tool| tool.tool_id
             == "smart_home.list_integration_mesh_substrate_preflight_checks"
             && tool.side_effects == ToolSideEffects::Read
             && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
@@ -4798,15 +4816,15 @@ mod tests {
         let summary = smart_home_tool_catalog_summary();
         let pair_bridge = SmartHomeTool::PairBridge.descriptor();
 
-        assert_eq!(summary.total_tools, 232);
-        assert_eq!(summary.read_tools, 224);
+        assert_eq!(summary.total_tools, 234);
+        assert_eq!(summary.read_tools, 226);
         assert_eq!(summary.write_tools, 2);
         assert_eq!(summary.external_tools, 6);
-        assert_eq!(summary.read_only_tier_tools, 224);
+        assert_eq!(summary.read_only_tier_tools, 226);
         assert_eq!(summary.low_risk_tier_tools, 6);
         assert_eq!(summary.high_risk_tier_tools, 0);
         assert_eq!(summary.human_approval_tier_tools, 2);
-        assert_eq!(summary.total_required_capabilities, 232);
+        assert_eq!(summary.total_required_capabilities, 234);
         assert_eq!(summary.risky_tool_count(), 8);
         assert_eq!(summary.approval_gated_tool_count(), 2);
         assert!(pair_bridge.requires_human_approval());


### PR DESCRIPTION
## Summary
- add shared smart-home tool descriptors for activation waiver release signoff list and summary readouts
- derive Chief-side release signoff records from existing activation waiver release closure lineage without mutating platform state
- expose signoff filters, summary rollups, progress events, and an end-to-end Chief bridge test for closure-to-signoff lineage

## Validation
- cargo test -p smart-home-core
- cargo test -p smart-home-integration-catalog
- cargo test -p hue-core
- cargo test -p smart-home-runtime
- cargo test -p smart-home-testkit
- cargo test -p smart-home-local-http
- cargo test -p smart-home-discovery
- cargo test -p chief-of-staff-smart-home-tools
- cargo test -p smart-home-runtime discover_tool -- --nocapture
- sh BUILD in smart-home-core, smart-home-integration-catalog, hue-core, smart-home-runtime, smart-home-testkit, smart-home-local-http, smart-home-discovery, chief-of-staff-smart-home-tools
