### PR TITLE
Add mesh release execution readiness summary

### DIFF
--- a/code/packages/rust/smart-home-integration-catalog/CHANGELOG.md
+++ b/code/packages/rust/smart-home-integration-catalog/CHANGELOG.md
@@ -132,6 +132,9 @@ All notable changes to this package will be documented in this file.
 - `IntegrationMeshReleasePacketReadinessSummary` and helpers for condensing
   mesh release-readiness checks into package-facing go/no-go state and first
   actionable gates.
+- `IntegrationMeshReleaseExecutionReadinessSummary` and helpers for combining
+  mesh release packet readiness with release-readiness check slot execution
+  state.
 - Primitive backlog planning helpers for ranking the shared primitive families
   needed by priority-bounded rollout waves.
 - Integration activation planning helpers for resolving virtual aliases,

--- a/code/packages/rust/smart-home-integration-catalog/README.md
+++ b/code/packages/rust/smart-home-integration-catalog/README.md
@@ -107,6 +107,8 @@ runtime and Chief of Staff tools a typed catalog for:
   deterministic operator and release execution work
 - mesh release packet readiness summaries that condense release-readiness
   checks into package-facing go/no-go state and first actionable gates
+- mesh release execution readiness summaries that combine release packet
+  go/no-go state with release-readiness check slot execution state
 - primitive backlog planning for prioritizing the shared families needed by a
   rollout wave
 - activation plans that resolve direct integrations, virtual aliases, and

--- a/code/packages/rust/smart-home-integration-catalog/src/lib.rs
+++ b/code/packages/rust/smart-home-integration-catalog/src/lib.rs
@@ -5000,6 +5000,145 @@ impl IntegrationMeshReleasePacketReadinessSummary {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IntegrationMeshReleaseExecutionReadinessSummary {
+    pub release_packet_readiness_summary: IntegrationMeshReleasePacketReadinessSummary,
+    pub release_check_slot_summary: IntegrationMeshReleaseReadinessCheckSlotSummary,
+    pub total_checks: usize,
+    pub ready_checks: usize,
+    pub blocked_checks: usize,
+    pub review_required_checks: usize,
+    pub operator_required_checks: usize,
+    pub checks_requiring_attention: usize,
+    pub total_slots: usize,
+    pub ready_slots: usize,
+    pub blocked_slots: usize,
+    pub review_required_slots: usize,
+    pub operator_required_slots: usize,
+    pub slots_requiring_attention: usize,
+    pub queued_substrate_actions: usize,
+    pub remediation_item_count: usize,
+    pub review_required_packages: usize,
+    pub operator_required_packages: usize,
+    pub blocked_packages: usize,
+    pub next_check_kind: Option<IntegrationMeshReleaseReadinessCheckKind>,
+    pub next_check_status: Option<IntegrationMeshReleaseReadinessStatus>,
+    pub next_check_sequence: Option<usize>,
+    pub next_package_kind: Option<IntegrationMeshReadinessHandoffKind>,
+    pub next_handoff_status: Option<IntegrationMeshReadinessHandoffStatus>,
+    pub next_slot_key: Option<String>,
+    pub first_blocked_slot_key: Option<String>,
+    pub first_review_slot_key: Option<String>,
+    pub first_operator_slot_key: Option<String>,
+    pub packet_status: IntegrationMeshReleaseReadinessStatus,
+    pub execution_status: IntegrationMeshReleaseReadinessStatus,
+    pub release_packet_ready: bool,
+    pub release_check_slots_ready: bool,
+    pub release_execution_ready: bool,
+}
+
+impl IntegrationMeshReleaseExecutionReadinessSummary {
+    pub fn from_summaries(
+        release_packet_readiness_summary: IntegrationMeshReleasePacketReadinessSummary,
+        release_check_slot_summary: IntegrationMeshReleaseReadinessCheckSlotSummary,
+    ) -> Self {
+        let release_execution_ready = release_packet_readiness_summary.ready_for_release()
+            && release_check_slot_summary.release_check_slots_ready;
+        let execution_status = if release_execution_ready {
+            IntegrationMeshReleaseReadinessStatus::Ready
+        } else if release_packet_readiness_summary.has_blockers()
+            || release_check_slot_summary.has_blockers()
+        {
+            IntegrationMeshReleaseReadinessStatus::Blocked
+        } else if release_packet_readiness_summary.needs_review()
+            || release_check_slot_summary.has_review_work()
+            || release_packet_readiness_summary.requires_attention()
+            || release_check_slot_summary.requires_attention()
+        {
+            IntegrationMeshReleaseReadinessStatus::NeedsReview
+        } else {
+            IntegrationMeshReleaseReadinessStatus::Blocked
+        };
+
+        Self {
+            total_checks: release_packet_readiness_summary.total_checks,
+            ready_checks: release_packet_readiness_summary.ready_checks,
+            blocked_checks: release_packet_readiness_summary.blocked_checks,
+            review_required_checks: release_packet_readiness_summary.review_required_checks,
+            operator_required_checks: release_packet_readiness_summary.operator_required_checks,
+            checks_requiring_attention: release_packet_readiness_summary.checks_requiring_attention,
+            total_slots: release_check_slot_summary.total_slots,
+            ready_slots: release_check_slot_summary.ready_slots,
+            blocked_slots: release_check_slot_summary.blocked_slots,
+            review_required_slots: release_check_slot_summary.review_required_slots,
+            operator_required_slots: release_check_slot_summary.operator_required_slots,
+            slots_requiring_attention: release_check_slot_summary.slots_requiring_attention,
+            queued_substrate_actions: release_packet_readiness_summary.queued_substrate_actions,
+            remediation_item_count: release_packet_readiness_summary.remediation_item_count,
+            review_required_packages: release_packet_readiness_summary.review_required_packages,
+            operator_required_packages: release_packet_readiness_summary.operator_required_packages,
+            blocked_packages: release_packet_readiness_summary.blocked_packages,
+            next_check_kind: release_packet_readiness_summary.next_check_kind,
+            next_check_status: release_packet_readiness_summary.next_check_status,
+            next_check_sequence: release_packet_readiness_summary.next_check_sequence,
+            next_package_kind: release_packet_readiness_summary.next_package_kind,
+            next_handoff_status: release_packet_readiness_summary.next_handoff_status,
+            next_slot_key: release_check_slot_summary.next_slot_key.clone(),
+            first_blocked_slot_key: release_check_slot_summary.first_blocked_slot_key.clone(),
+            first_review_slot_key: release_check_slot_summary.first_review_slot_key.clone(),
+            first_operator_slot_key: release_check_slot_summary.first_operator_slot_key.clone(),
+            packet_status: release_packet_readiness_summary.packet_status,
+            execution_status,
+            release_packet_ready: release_packet_readiness_summary.release_packet_ready,
+            release_check_slots_ready: release_check_slot_summary.release_check_slots_ready,
+            release_execution_ready,
+            release_packet_readiness_summary,
+            release_check_slot_summary,
+        }
+    }
+
+    pub fn ready_for_execution(&self) -> bool {
+        self.execution_status == IntegrationMeshReleaseReadinessStatus::Ready
+            && self.release_execution_ready
+            && !self.has_blockers()
+            && !self.needs_review()
+    }
+
+    pub fn has_release_slots(&self) -> bool {
+        self.total_slots > 0
+    }
+
+    pub fn has_blockers(&self) -> bool {
+        self.execution_status == IntegrationMeshReleaseReadinessStatus::Blocked
+            || self.blocked_checks > 0
+            || self.blocked_slots > 0
+            || self.blocked_packages > 0
+            || self.queued_substrate_actions > 0
+    }
+
+    pub fn needs_review(&self) -> bool {
+        self.execution_status == IntegrationMeshReleaseReadinessStatus::NeedsReview
+            || self.review_required_checks > 0
+            || self.review_required_slots > 0
+            || self.review_required_packages > 0
+    }
+
+    pub fn needs_operator(&self) -> bool {
+        self.operator_required_checks > 0
+            || self.operator_required_slots > 0
+            || self.operator_required_packages > 0
+    }
+
+    pub fn requires_attention(&self) -> bool {
+        self.execution_status.requires_attention()
+            || self.checks_requiring_attention > 0
+            || self.slots_requiring_attention > 0
+            || self.needs_operator()
+            || self.has_blockers()
+            || self.needs_review()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct IntegrationCatalogEntry {
     pub integration_id: IntegrationId,
     pub display_name: String,
@@ -26047,6 +26186,45 @@ pub fn mesh_release_packet_readiness_summary(
     )
 }
 
+pub fn mesh_release_execution_readiness_summary_for_catalog(
+    catalog: &[IntegrationCatalogEntry],
+    available_primitives: &[PrimitiveFamily],
+    allowed_capabilities: &[CapabilityId],
+    enabled_integrations: &[IntegrationId],
+) -> IntegrationMeshReleaseExecutionReadinessSummary {
+    let release_packet_readiness_summary = mesh_release_packet_readiness_summary_for_catalog(
+        catalog,
+        available_primitives,
+        allowed_capabilities,
+        enabled_integrations,
+    );
+    let release_check_slot_summary = mesh_release_readiness_check_slot_summary_for_catalog(
+        catalog,
+        available_primitives,
+        allowed_capabilities,
+        enabled_integrations,
+    );
+
+    IntegrationMeshReleaseExecutionReadinessSummary::from_summaries(
+        release_packet_readiness_summary,
+        release_check_slot_summary,
+    )
+}
+
+pub fn mesh_release_execution_readiness_summary(
+    available_primitives: &[PrimitiveFamily],
+    allowed_capabilities: &[CapabilityId],
+    enabled_integrations: &[IntegrationId],
+) -> IntegrationMeshReleaseExecutionReadinessSummary {
+    let catalog = first_party_catalog();
+    mesh_release_execution_readiness_summary_for_catalog(
+        &catalog,
+        available_primitives,
+        allowed_capabilities,
+        enabled_integrations,
+    )
+}
+
 fn mesh_protocol_catalog_entries(
     catalog: &[IntegrationCatalogEntry],
 ) -> Vec<IntegrationCatalogEntry> {
@@ -35535,6 +35713,147 @@ mod tests {
         assert!(summary.ready_for_handoff);
         assert!(summary.release_packet_ready);
         assert!(summary.ready_for_release());
+        assert!(!summary.has_blockers());
+        assert!(!summary.needs_review());
+        assert!(!summary.needs_operator());
+        assert!(!summary.requires_attention());
+    }
+
+    #[test]
+    fn mesh_release_execution_readiness_summary_surfaces_slot_blockers() {
+        let available_primitives = vec![
+            PrimitiveFamily::Usb,
+            PrimitiveFamily::SerialController,
+            PrimitiveFamily::Radio802154,
+            PrimitiveFamily::Supervision,
+        ];
+        let allowed_capabilities = vec![CapabilityId::trusted("smart_home.read")];
+        let summary = mesh_release_execution_readiness_summary(
+            &available_primitives,
+            &allowed_capabilities,
+            &[],
+        );
+
+        assert_eq!(summary.total_checks, 5);
+        assert_eq!(summary.ready_checks, 0);
+        assert_eq!(summary.blocked_checks, 3);
+        assert_eq!(summary.review_required_checks, 2);
+        assert_eq!(summary.operator_required_checks, 4);
+        assert_eq!(summary.checks_requiring_attention, 5);
+        assert_eq!(summary.total_slots, 5);
+        assert_eq!(summary.ready_slots, 0);
+        assert_eq!(summary.blocked_slots, 3);
+        assert_eq!(summary.review_required_slots, 2);
+        assert_eq!(summary.operator_required_slots, 4);
+        assert_eq!(summary.slots_requiring_attention, 5);
+        assert_eq!(summary.queued_substrate_actions, 5);
+        assert_eq!(summary.remediation_item_count, 2);
+        assert_eq!(summary.review_required_packages, 1);
+        assert_eq!(summary.operator_required_packages, 6);
+        assert_eq!(summary.blocked_packages, 5);
+        assert_eq!(summary.next_check_sequence, Some(1));
+        assert_eq!(
+            summary.next_check_kind,
+            Some(IntegrationMeshReleaseReadinessCheckKind::SubstrateActions)
+        );
+        assert_eq!(
+            summary.next_check_status,
+            Some(IntegrationMeshReleaseReadinessStatus::Blocked)
+        );
+        assert_eq!(
+            summary.next_package_kind,
+            Some(IntegrationMeshReadinessHandoffKind::SubstrateAction)
+        );
+        assert_eq!(
+            summary.next_handoff_status,
+            Some(IntegrationMeshReadinessHandoffStatus::Blocked)
+        );
+        assert_eq!(
+            summary.next_slot_key,
+            Some("release-check-slot-01-substrate_actions".to_string())
+        );
+        assert_eq!(
+            summary.first_blocked_slot_key,
+            Some("release-check-slot-01-substrate_actions".to_string())
+        );
+        assert_eq!(
+            summary.first_review_slot_key,
+            Some("release-check-slot-02-evidence_remediation".to_string())
+        );
+        assert_eq!(
+            summary.first_operator_slot_key,
+            Some("release-check-slot-01-substrate_actions".to_string())
+        );
+        assert_eq!(
+            summary.packet_status,
+            IntegrationMeshReleaseReadinessStatus::Blocked
+        );
+        assert_eq!(
+            summary.execution_status,
+            IntegrationMeshReleaseReadinessStatus::Blocked
+        );
+        assert!(!summary.release_packet_ready);
+        assert!(!summary.release_check_slots_ready);
+        assert!(!summary.release_execution_ready);
+        assert!(!summary.ready_for_execution());
+        assert!(summary.has_release_slots());
+        assert!(summary.has_blockers());
+        assert!(summary.needs_review());
+        assert!(summary.needs_operator());
+        assert!(summary.requires_attention());
+    }
+
+    #[test]
+    fn mesh_release_execution_readiness_summary_marks_execution_ready() {
+        let catalog = vec![hue_entry()];
+        let allowed_capabilities = vec![
+            CapabilityId::trusted("smart_home.read"),
+            CapabilityId::trusted("smart_home.command.light"),
+            CapabilityId::trusted("smart_home.pair"),
+        ];
+        let summary = mesh_release_execution_readiness_summary_for_catalog(
+            &catalog,
+            all_primitive_families(),
+            &allowed_capabilities,
+            &[],
+        );
+
+        assert_eq!(summary.total_checks, 5);
+        assert_eq!(summary.ready_checks, 5);
+        assert_eq!(summary.blocked_checks, 0);
+        assert_eq!(summary.review_required_checks, 0);
+        assert_eq!(summary.operator_required_checks, 0);
+        assert_eq!(summary.checks_requiring_attention, 0);
+        assert_eq!(summary.total_slots, 5);
+        assert_eq!(summary.ready_slots, 5);
+        assert_eq!(summary.blocked_slots, 0);
+        assert_eq!(summary.review_required_slots, 0);
+        assert_eq!(summary.operator_required_slots, 0);
+        assert_eq!(summary.slots_requiring_attention, 0);
+        assert_eq!(summary.next_slot_key, None);
+        assert_eq!(summary.next_check_kind, None);
+        assert_eq!(summary.next_check_status, None);
+        assert_eq!(
+            summary.next_package_kind,
+            Some(IntegrationMeshReadinessHandoffKind::ReleaseReady)
+        );
+        assert_eq!(
+            summary.next_handoff_status,
+            Some(IntegrationMeshReadinessHandoffStatus::Ready)
+        );
+        assert_eq!(
+            summary.packet_status,
+            IntegrationMeshReleaseReadinessStatus::Ready
+        );
+        assert_eq!(
+            summary.execution_status,
+            IntegrationMeshReleaseReadinessStatus::Ready
+        );
+        assert!(summary.release_packet_ready);
+        assert!(summary.release_check_slots_ready);
+        assert!(summary.release_execution_ready);
+        assert!(summary.ready_for_execution());
+        assert!(summary.has_release_slots());
         assert!(!summary.has_blockers());
         assert!(!summary.needs_review());
         assert!(!summary.needs_operator());


### PR DESCRIPTION
## Summary
- add `IntegrationMeshReleaseExecutionReadinessSummary` to combine release packet go/no-go state with release-readiness check slot execution state
- add catalog/default helper functions for the combined execution readiness rollup
- document the new package-facing summary and cover blocked-slot plus ready-release paths

## Validation
- `cargo test --manifest-path code\packages\rust\smart-home-integration-catalog\Cargo.toml mesh_release_execution_readiness -- --nocapture`
- `cargo test --manifest-path code\packages\rust\smart-home-integration-catalog\Cargo.toml`
- `cargo fmt --manifest-path code\packages\rust\smart-home-integration-catalog\Cargo.toml --check`
- `git diff --check`