### PR TITLE
Add SPICE deck execution table inventory

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ### Added
 
+- **Deck execution table inventory** —
+  `run_deck_analysis()` selected executions now expose stable table count/name
+  lists beside analysis directives, output probes, output directives, and
+  selected-run artifacts, matching Rust and TypeScript.
+
 - **Deck run table artifacts** —
   `run_deck_analysis()` selected-run artifacts now include stable table
   count/name lists and `format_deck_run_artifact_table()` renders `TableList`,

--- a/code/packages/python/spice-engine/README.md
+++ b/code/packages/python/spice-engine/README.md
@@ -104,7 +104,8 @@ implicit `.op`, and reports ambiguity before solver dispatch.
 `run_deck_analysis()` executes one selected `.op`, `.dc`, `.ac LIN`,
 `.ac DEC`, `.ac OCT`, or `.tran` plan against an existing `Circuit` and
 returns the plan, solver result, deck-selected output table, and normalized
-analysis directive, output probes, and output directives that produced the table, plus selected
+table count/name list, analysis directive, output probes, and output directives
+that produced the table, plus selected
 `.measure` results and a stable measurement table for `.dc`, `.ac`, and `.tran`
 executions. Selected
 `.tran` plans also return selected `.four` harmonic results and a stable
@@ -222,8 +223,8 @@ diagnostics for malformed deck-level analysis controls.
 `select_deck_analysis_plan()` returns one selected or implicit plan for
 downstream deck execution helpers.
 `run_deck_analysis()` routes that selected plan into the matching solver and
-stable deck-selected table output with normalized analysis-directive,
-output-probe, and output-directive artifacts,
+stable deck-selected table output with normalized table-inventory,
+analysis-directive, output-probe, and output-directive artifacts,
 selected measurement artifacts, selected transient Fourier artifacts,
 selected-run artifact summaries with analysis-directive, output-probe, output-directive,
 measurement, and Fourier probe name lists, `.ac LIN`, `.ac DEC`, `.ac OCT`

--- a/code/packages/python/spice-engine/src/spice_engine/engine.py
+++ b/code/packages/python/spice-engine/src/spice_engine/engine.py
@@ -2364,6 +2364,8 @@ class DeckAnalysisExecution:
     output_probes: list[str]
     output_directives: list[str]
     analysis_directives: list[str]
+    table_count: int
+    tables: list[str]
     measurements: list[ProbeMeasurement]
     measurement_table: str
     fourier: list[FourierResult]
@@ -2700,6 +2702,7 @@ def run_deck_analysis(
             fourier,
             diagnostic_codes,
         )
+        tables = _deck_stable_tables(measurements, fourier)
         return DeckAnalysisExecution(
             plan=plan,
             result=result,
@@ -2707,6 +2710,8 @@ def run_deck_analysis(
             output_probes=output_probes,
             output_directives=output_directives,
             analysis_directives=analysis_directives,
+            table_count=len(tables),
+            tables=tables,
             measurements=measurements,
             measurement_table=format_measurement_table(measurements),
             fourier=fourier,
@@ -2739,6 +2744,7 @@ def run_deck_analysis(
             fourier,
             diagnostic_codes,
         )
+        tables = _deck_stable_tables(measurements, fourier)
         return DeckAnalysisExecution(
             plan=plan,
             result=result,
@@ -2746,6 +2752,8 @@ def run_deck_analysis(
             output_probes=output_probes,
             output_directives=output_directives,
             analysis_directives=analysis_directives,
+            table_count=len(tables),
+            tables=tables,
             measurements=measurements,
             measurement_table=format_measurement_table(measurements),
             fourier=fourier,
@@ -2780,6 +2788,7 @@ def run_deck_analysis(
             fourier,
             diagnostic_codes,
         )
+        tables = _deck_stable_tables(measurements, fourier)
         return DeckAnalysisExecution(
             plan=plan,
             result=result,
@@ -2787,6 +2796,8 @@ def run_deck_analysis(
             output_probes=output_probes,
             output_directives=output_directives,
             analysis_directives=analysis_directives,
+            table_count=len(tables),
+            tables=tables,
             measurements=measurements,
             measurement_table=format_measurement_table(measurements),
             fourier=fourier,
@@ -2827,6 +2838,7 @@ def run_deck_analysis(
             fourier,
             diagnostic_codes,
         )
+        tables = _deck_stable_tables(measurements, fourier)
         return DeckAnalysisExecution(
             plan=plan,
             result=result,
@@ -2834,6 +2846,8 @@ def run_deck_analysis(
             output_probes=output_probes,
             output_directives=output_directives,
             analysis_directives=analysis_directives,
+            table_count=len(tables),
+            tables=tables,
             measurements=measurements,
             measurement_table=format_measurement_table(measurements),
             fourier=fourier,
@@ -2862,6 +2876,7 @@ def run_deck_analysis(
             fourier,
             diagnostic_codes,
         )
+        tables = _deck_stable_tables(measurements, fourier)
         return DeckAnalysisExecution(
             plan=plan,
             result=result,
@@ -2869,6 +2884,8 @@ def run_deck_analysis(
             output_probes=output_probes,
             output_directives=output_directives,
             analysis_directives=analysis_directives,
+            table_count=len(tables),
+            tables=tables,
             measurements=measurements,
             measurement_table=format_measurement_table(measurements),
             fourier=fourier,
@@ -2896,6 +2913,7 @@ def run_deck_analysis(
             fourier,
             diagnostic_codes,
         )
+        tables = _deck_stable_tables(measurements, fourier)
         return DeckAnalysisExecution(
             plan=plan,
             result=result,
@@ -2903,6 +2921,8 @@ def run_deck_analysis(
             output_probes=output_probes,
             output_directives=output_directives,
             analysis_directives=analysis_directives,
+            table_count=len(tables),
+            tables=tables,
             measurements=measurements,
             measurement_table=format_measurement_table(measurements),
             fourier=fourier,
@@ -2949,6 +2969,7 @@ def run_deck_analysis(
             fourier,
             diagnostic_codes,
         )
+        tables = _deck_stable_tables(measurements, fourier)
         return DeckAnalysisExecution(
             plan=plan,
             result=result,
@@ -2956,6 +2977,8 @@ def run_deck_analysis(
             output_probes=output_probes,
             output_directives=output_directives,
             analysis_directives=analysis_directives,
+            table_count=len(tables),
+            tables=tables,
             measurements=measurements,
             measurement_table=format_measurement_table(measurements),
             fourier=fourier,

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -6801,6 +6801,8 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
     assert op_execution.output_probes == ["V(mid)"]
     assert op_execution.output_directives == [".save"]
     assert op_execution.analysis_directives == [".op"]
+    assert op_execution.table_count == 2
+    assert op_execution.tables == ["result", "run-artifact"]
     assert op_execution.measurements == []
     assert op_execution.measurement_table == "Name\tAnalysis\tProbe\tMode\tFrom\tTo\tValue\n"
     assert op_execution.table == "Index\tV(mid)\n0\t5.000000e-01\n"
@@ -6961,6 +6963,8 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
     assert dc_execution.output_probes == ["V(mid)", "I(V1)"]
     assert dc_execution.output_directives == [".save", ".probe"]
     assert dc_execution.analysis_directives == [".dc"]
+    assert dc_execution.table_count == 3
+    assert dc_execution.tables == ["result", "measurement", "run-artifact"]
     assert [measurement.name for measurement in dc_execution.measurements] == ["mid_avg"]
     assert dc_execution.measurement_table == (
         "Name\tAnalysis\tProbe\tMode\tFrom\tTo\tValue\n"
@@ -7009,6 +7013,8 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
     assert ac_execution.output_probes == ["V(mid)"]
     assert ac_execution.output_directives == [".save"]
     assert ac_execution.analysis_directives == [".ac"]
+    assert ac_execution.table_count == 3
+    assert ac_execution.tables == ["result", "measurement", "run-artifact"]
     assert [measurement.name for measurement in ac_execution.measurements] == ["mid_peak"]
     assert ac_execution.measurement_table == (
         "Name\tAnalysis\tProbe\tMode\tFrom\tTo\tValue\n"
@@ -7057,6 +7063,8 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
     assert tran_execution.output_probes == ["V(mid)"]
     assert tran_execution.output_directives == [".save"]
     assert tran_execution.analysis_directives == [".tran"]
+    assert tran_execution.table_count == 3
+    assert tran_execution.tables == ["result", "measurement", "run-artifact"]
     assert [measurement.name for measurement in tran_execution.measurements] == [
         "mid_final"
     ]
@@ -7106,6 +7114,8 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
     assert tf_execution.output_probes == ["V(mid)"]
     assert tf_execution.output_directives == []
     assert tf_execution.analysis_directives == [".tf"]
+    assert tf_execution.table_count == 2
+    assert tf_execution.tables == ["result", "run-artifact"]
     assert tf_execution.measurements == []
     assert tf_execution.measurement_table == "Name\tAnalysis\tProbe\tMode\tFrom\tTo\tValue\n"
     assert tf_execution.table == (
@@ -7143,6 +7153,8 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
     assert len(sens_execution.result.entries) == 3
     assert sens_execution.output_probes == ["V(mid)"]
     assert sens_execution.analysis_directives == [".sens"]
+    assert sens_execution.table_count == 2
+    assert sens_execution.tables == ["result", "run-artifact"]
     assert sens_execution.measurements == []
     assert sens_execution.measurement_table == "Name\tAnalysis\tProbe\tMode\tFrom\tTo\tValue\n"
     assert sens_execution.table.startswith(
@@ -7188,6 +7200,8 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
     assert len(noise_execution.result.points) == 1
     assert noise_execution.output_probes == ["V(mid)"]
     assert noise_execution.analysis_directives == [".noise"]
+    assert noise_execution.table_count == 2
+    assert noise_execution.tables == ["result", "run-artifact"]
     assert noise_execution.measurements == []
     assert noise_execution.measurement_table == "Name\tAnalysis\tProbe\tMode\tFrom\tTo\tValue\n"
     assert noise_execution.table == format_deck_noise_table(noise_execution.result)
@@ -7252,6 +7266,8 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
         "result",
         "run-artifact",
     ]
+    assert tran_window_execution.table_count == 2
+    assert tran_window_execution.tables == ["result", "run-artifact"]
     assert tran_window_execution.output_probes == ["V(mid)"]
     assert isinstance(tran_window_execution.result, TransientResult)
     assert [point.time for point in tran_window_execution.result.points] == pytest.approx(
@@ -7311,9 +7327,13 @@ def test_run_deck_analysis_exposes_selected_fourier_artifacts() -> None:
     op_execution = run_deck_analysis(circuit, netlist, "op")
     assert op_execution.fourier == []
     assert op_execution.fourier_table == ""
+    assert op_execution.table_count == 2
+    assert op_execution.tables == ["result", "run-artifact"]
 
     tran_execution = run_deck_analysis(circuit, netlist, "tran")
     assert len(tran_execution.fourier) == 1
+    assert tran_execution.table_count == 3
+    assert tran_execution.tables == ["result", "fourier", "run-artifact"]
     result = tran_execution.fourier[0]
     assert result.fundamental_frequency == pytest.approx(2000.0)
     assert result.probes[0].probe == "V(mid)"

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Add stable table count/name lists directly to selected `run_deck_analysis`
+  execution results beside analysis directives, output probes, output
+  directives, and selected-run artifacts, matching Python and TypeScript.
 - Add stable table count/name lists to selected-run artifacts in
   `run_deck_analysis` and render them in a stable `TableList` column from
   `format_deck_run_artifact_table`, matching Python and TypeScript.

--- a/code/packages/rust/spice-engine/README.md
+++ b/code/packages/rust/spice-engine/README.md
@@ -176,7 +176,8 @@ card by analysis alias, defaults decks without analysis cards to an implicit
 `run_deck_analysis` executes one selected `.op`, `.dc`, `.ac LIN`, `.ac DEC`,
 `.ac OCT`, or `.tran` plan against an existing `Circuit` and returns the plan,
 solver result, deck-selected output table, and normalized analysis directive,
-output probes, and output directives that produced the table, plus selected `.measure` results and
+table count/name list, output probes, and output directives that produced the
+table, plus selected `.measure` results and
 a stable measurement table for `.dc`, `.ac`, and `.tran` executions. Selected
 `.tran` plans route
 `START` output filtering, `.tran TSTEP` as the output print grid, `MAXSTEP` as
@@ -232,8 +233,8 @@ malformed deck-level analysis controls.
 `select_deck_analysis_plan` returns one selected or implicit plan for
 downstream deck execution helpers.
 `run_deck_analysis` routes that selected plan into the matching solver and
-stable deck-selected table output with normalized output-probe and
-output-directive artifacts,
+stable deck-selected table output with normalized table-inventory, output-probe
+and output-directive artifacts,
 selected measurement artifacts, selected transient Fourier artifacts,
 selected-run artifact summaries with table, analysis-directive, output-probe, output-directive,
 measurement, and Fourier probe name lists, `.ac LIN`, `.ac DEC`, `.ac OCT`

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -3448,6 +3448,8 @@ pub struct DeckAnalysisExecution {
     pub output_probes: Vec<String>,
     pub output_directives: Vec<String>,
     pub analysis_directives: Vec<String>,
+    pub table_count: usize,
+    pub tables: Vec<String>,
     pub measurements: Vec<ProbeMeasurement>,
     pub measurement_table: String,
     pub fourier: Vec<FourierResult>,
@@ -10503,6 +10505,7 @@ pub fn run_deck_analysis(
                 &diagnostic_codes,
             );
             let run_artifact_table = format_deck_run_artifact_table(&run_artifacts);
+            let tables = deck_stable_tables(&measurements, &fourier);
             Ok(DeckAnalysisExecution {
                 plan,
                 result: DeckAnalysisExecutionResult::Op(result),
@@ -10510,6 +10513,8 @@ pub fn run_deck_analysis(
                 output_probes,
                 output_directives,
                 analysis_directives,
+                table_count: tables.len(),
+                tables,
                 measurements,
                 measurement_table,
                 fourier,
@@ -10546,6 +10551,7 @@ pub fn run_deck_analysis(
                 &diagnostic_codes,
             );
             let run_artifact_table = format_deck_run_artifact_table(&run_artifacts);
+            let tables = deck_stable_tables(&measurements, &fourier);
             Ok(DeckAnalysisExecution {
                 plan,
                 result: DeckAnalysisExecutionResult::DcSweep(result),
@@ -10553,6 +10559,8 @@ pub fn run_deck_analysis(
                 output_probes,
                 output_directives,
                 analysis_directives,
+                table_count: tables.len(),
+                tables,
                 measurements,
                 measurement_table,
                 fourier,
@@ -10590,6 +10598,7 @@ pub fn run_deck_analysis(
                 &diagnostic_codes,
             );
             let run_artifact_table = format_deck_run_artifact_table(&run_artifacts);
+            let tables = deck_stable_tables(&measurements, &fourier);
             Ok(DeckAnalysisExecution {
                 plan,
                 result: DeckAnalysisExecutionResult::Ac(result),
@@ -10597,6 +10606,8 @@ pub fn run_deck_analysis(
                 output_probes,
                 output_directives,
                 analysis_directives,
+                table_count: tables.len(),
+                tables,
                 measurements,
                 measurement_table,
                 fourier,
@@ -10637,6 +10648,7 @@ pub fn run_deck_analysis(
                 &diagnostic_codes,
             );
             let run_artifact_table = format_deck_run_artifact_table(&run_artifacts);
+            let tables = deck_stable_tables(&measurements, &fourier);
             Ok(DeckAnalysisExecution {
                 plan,
                 result: DeckAnalysisExecutionResult::Tran(result),
@@ -10644,6 +10656,8 @@ pub fn run_deck_analysis(
                 output_probes,
                 output_directives,
                 analysis_directives,
+                table_count: tables.len(),
+                tables,
                 measurements,
                 measurement_table,
                 fourier,
@@ -10678,6 +10692,7 @@ pub fn run_deck_analysis(
                 &diagnostic_codes,
             );
             let run_artifact_table = format_deck_run_artifact_table(&run_artifacts);
+            let tables = deck_stable_tables(&measurements, &fourier);
             Ok(DeckAnalysisExecution {
                 plan,
                 result: DeckAnalysisExecutionResult::Tf(result.clone()),
@@ -10685,6 +10700,8 @@ pub fn run_deck_analysis(
                 output_probes,
                 output_directives,
                 analysis_directives,
+                table_count: tables.len(),
+                tables,
                 measurements,
                 measurement_table,
                 fourier,
@@ -10717,6 +10734,7 @@ pub fn run_deck_analysis(
                 &diagnostic_codes,
             );
             let run_artifact_table = format_deck_run_artifact_table(&run_artifacts);
+            let tables = deck_stable_tables(&measurements, &fourier);
             Ok(DeckAnalysisExecution {
                 plan,
                 result: DeckAnalysisExecutionResult::Sens(result.clone()),
@@ -10724,6 +10742,8 @@ pub fn run_deck_analysis(
                 output_probes,
                 output_directives,
                 analysis_directives,
+                table_count: tables.len(),
+                tables,
                 measurements,
                 measurement_table,
                 fourier,
@@ -10768,6 +10788,7 @@ pub fn run_deck_analysis(
                 &diagnostic_codes,
             );
             let run_artifact_table = format_deck_run_artifact_table(&run_artifacts);
+            let tables = deck_stable_tables(&measurements, &fourier);
             Ok(DeckAnalysisExecution {
                 plan,
                 result: DeckAnalysisExecutionResult::Noise(result.clone()),
@@ -10775,6 +10796,8 @@ pub fn run_deck_analysis(
                 output_probes,
                 output_directives,
                 analysis_directives,
+                table_count: tables.len(),
+                tables,
                 measurements,
                 measurement_table,
                 fourier,

--- a/code/packages/rust/spice-engine/tests/transient_tests.rs
+++ b/code/packages/rust/spice-engine/tests/transient_tests.rs
@@ -1890,6 +1890,11 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
     assert_eq!(op_execution.table, "Index\tV(mid)\n0\t5.000000e-01\n");
     assert_eq!(op_execution.output_directives, vec![".save".to_string()]);
     assert_eq!(op_execution.analysis_directives, vec![".op".to_string()]);
+    assert_eq!(op_execution.table_count, 2);
+    assert_eq!(
+        op_execution.tables,
+        vec!["result".to_string(), "run-artifact".to_string()]
+    );
     assert_eq!(
         format_deck_table_csv(&op_execution.table),
         "Index,V(mid)\n0,5.000000e-01\n"
@@ -2056,6 +2061,15 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
         vec![".save".to_string(), ".probe".to_string()]
     );
     assert_eq!(dc_execution.analysis_directives, vec![".dc".to_string()]);
+    assert_eq!(dc_execution.table_count, 3);
+    assert_eq!(
+        dc_execution.tables,
+        vec![
+            "result".to_string(),
+            "measurement".to_string(),
+            "run-artifact".to_string()
+        ]
+    );
     assert_eq!(dc_execution.measurements[0].name, "mid_avg");
     assert_eq!(
         dc_execution.measurement_table,
@@ -2129,6 +2143,15 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
     assert_eq!(ac_execution.output_probes, vec!["V(mid)".to_string()]);
     assert_eq!(ac_execution.output_directives, vec![".save".to_string()]);
     assert_eq!(ac_execution.analysis_directives, vec![".ac".to_string()]);
+    assert_eq!(ac_execution.table_count, 3);
+    assert_eq!(
+        ac_execution.tables,
+        vec![
+            "result".to_string(),
+            "measurement".to_string(),
+            "run-artifact".to_string()
+        ]
+    );
     assert_eq!(ac_execution.measurements[0].name, "mid_peak");
     assert_eq!(
         ac_execution.measurement_table,
@@ -2205,6 +2228,15 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
     assert_eq!(
         tran_execution.analysis_directives,
         vec![".tran".to_string()]
+    );
+    assert_eq!(tran_execution.table_count, 3);
+    assert_eq!(
+        tran_execution.tables,
+        vec![
+            "result".to_string(),
+            "measurement".to_string(),
+            "run-artifact".to_string()
+        ]
     );
     assert_eq!(tran_execution.measurements[0].name, "mid_final");
     assert_eq!(
@@ -2284,6 +2316,11 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
     assert_eq!(tf_execution.output_probes, vec!["V(mid)".to_string()]);
     assert!(tf_execution.output_directives.is_empty());
     assert_eq!(tf_execution.analysis_directives, vec![".tf".to_string()]);
+    assert_eq!(tf_execution.table_count, 2);
+    assert_eq!(
+        tf_execution.tables,
+        vec!["result".to_string(), "run-artifact".to_string()]
+    );
     assert!(tf_execution.measurements.is_empty());
     assert_eq!(
         tf_execution.measurement_table,
@@ -2348,6 +2385,11 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
     assert_eq!(
         sens_execution.analysis_directives,
         vec![".sens".to_string()]
+    );
+    assert_eq!(sens_execution.table_count, 2);
+    assert_eq!(
+        sens_execution.tables,
+        vec!["result".to_string(), "run-artifact".to_string()]
     );
     assert!(sens_execution.measurements.is_empty());
     assert_eq!(
@@ -2419,6 +2461,11 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
     assert_eq!(
         noise_execution.analysis_directives,
         vec![".noise".to_string()]
+    );
+    assert_eq!(noise_execution.table_count, 2);
+    assert_eq!(
+        noise_execution.tables,
+        vec!["result".to_string(), "run-artifact".to_string()]
     );
     assert!(noise_execution.measurements.is_empty());
     assert_eq!(
@@ -2542,6 +2589,11 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
         tran_window_execution.run_artifacts[0].tables,
         vec!["result".to_string(), "run-artifact".to_string()]
     );
+    assert_eq!(tran_window_execution.table_count, 2);
+    assert_eq!(
+        tran_window_execution.tables,
+        vec!["result".to_string(), "run-artifact".to_string()]
+    );
     assert_eq!(
         tran_window_execution.output_probes,
         vec!["V(mid)".to_string()]
@@ -2629,9 +2681,23 @@ fn run_deck_analysis_exposes_selected_fourier_artifacts() {
     let op_execution = run_deck_analysis(&circuit, netlist, Some("op")).unwrap();
     assert!(op_execution.fourier.is_empty());
     assert_eq!(op_execution.fourier_table, "");
+    assert_eq!(op_execution.table_count, 2);
+    assert_eq!(
+        op_execution.tables,
+        vec!["result".to_string(), "run-artifact".to_string()]
+    );
 
     let tran_execution = run_deck_analysis(&circuit, netlist, Some("tran")).unwrap();
     assert_eq!(tran_execution.fourier.len(), 1);
+    assert_eq!(tran_execution.table_count, 3);
+    assert_eq!(
+        tran_execution.tables,
+        vec![
+            "result".to_string(),
+            "fourier".to_string(),
+            "run-artifact".to_string()
+        ]
+    );
     let result = &tran_execution.fourier[0];
     assert!((result.fundamental_frequency_hz - 2_000.0).abs() < 1.0e-12);
     assert_eq!(result.probes[0].probe, "V(mid)");

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Add stable table count/name lists directly to selected `runDeckAnalysis`
+  execution results beside analysis directives, output probes, output
+  directives, and selected-run artifacts, matching Python and Rust.
 - Add stable table count/name lists to selected-run artifacts in
   `runDeckAnalysis` and render them in a stable `TableList` column from
   `formatDeckRunArtifactTable`, matching Python and Rust.

--- a/code/packages/typescript/spice-engine/README.md
+++ b/code/packages/typescript/spice-engine/README.md
@@ -92,7 +92,8 @@ and reports ambiguity before solver dispatch.
 `runDeckAnalysis` executes one selected `.op`, `.dc`, `.ac LIN`, `.ac DEC`,
 `.ac OCT`, or `.tran` plan against an existing `Circuit` and returns the plan,
 solver result, deck-selected output table, and normalized analysis directive,
-output probes, and output directives that produced the table, plus selected `.measure` results and
+table count/name list, output probes, and output directives that produced the
+table, plus selected `.measure` results and
 a stable measurement table for `.dc`, `.ac`, and `.tran` executions. Selected
 `.tran` plans route
 `START` output filtering, `.tran TSTEP` as the output print grid, `MAXSTEP` as
@@ -196,8 +197,8 @@ malformed deck-level analysis controls.
 `selectDeckAnalysisPlan` returns one selected or implicit plan for downstream
 deck execution helpers.
 `runDeckAnalysis` routes that selected plan into the matching solver and stable
-deck-selected table output with normalized output-probe and output-directive
-artifacts, selected measurement artifacts, selected transient Fourier artifacts,
+deck-selected table output with normalized table-inventory, output-probe, and
+output-directive artifacts, selected measurement artifacts, selected transient Fourier artifacts,
 selected-run artifact summaries with table, analysis-directive, output-probe, output-directive,
 measurement, and Fourier probe name lists, `.ac LIN`, `.ac DEC`, `.ac OCT`
 frequency grids, and `.tran` `START` /

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -702,6 +702,8 @@ export interface DeckAnalysisExecution {
   readonly outputProbes: readonly string[];
   readonly outputDirectives: readonly string[];
   readonly analysisDirectives: readonly string[];
+  readonly tableCount: number;
+  readonly tables: readonly string[];
   readonly measurements: readonly ProbeMeasurement[];
   readonly measurementTable: string;
   readonly fourier: readonly FourierResult[];
@@ -8184,6 +8186,7 @@ export function runDeckAnalysis(
       fourier,
       diagnosticCodes,
     );
+    const tables = deckStableTables(measurements, fourier);
     return {
       plan,
       result,
@@ -8191,6 +8194,8 @@ export function runDeckAnalysis(
       outputProbes,
       outputDirectives,
       analysisDirectives,
+      tableCount: tables.length,
+      tables,
       measurements,
       measurementTable: formatMeasurementTable(measurements),
       fourier,
@@ -8224,6 +8229,7 @@ export function runDeckAnalysis(
       fourier,
       diagnosticCodes,
     );
+    const tables = deckStableTables(measurements, fourier);
     return {
       plan,
       result,
@@ -8231,6 +8237,8 @@ export function runDeckAnalysis(
       outputProbes,
       outputDirectives,
       analysisDirectives,
+      tableCount: tables.length,
+      tables,
       measurements,
       measurementTable: formatMeasurementTable(measurements),
       fourier,
@@ -8275,6 +8283,7 @@ export function runDeckAnalysis(
       fourier,
       diagnosticCodes,
     );
+    const tables = deckStableTables(measurements, fourier);
     return {
       plan,
       result,
@@ -8282,6 +8291,8 @@ export function runDeckAnalysis(
       outputProbes,
       outputDirectives,
       analysisDirectives,
+      tableCount: tables.length,
+      tables,
       measurements,
       measurementTable: formatMeasurementTable(measurements),
       fourier,
@@ -8321,6 +8332,7 @@ export function runDeckAnalysis(
       fourier,
       diagnosticCodes,
     );
+    const tables = deckStableTables(measurements, fourier);
     return {
       plan,
       result,
@@ -8328,6 +8340,8 @@ export function runDeckAnalysis(
       outputProbes,
       outputDirectives,
       analysisDirectives,
+      tableCount: tables.length,
+      tables,
       measurements,
       measurementTable: formatMeasurementTable(measurements),
       fourier,
@@ -8357,6 +8371,7 @@ export function runDeckAnalysis(
       fourier,
       diagnosticCodes,
     );
+    const tables = deckStableTables(measurements, fourier);
     return {
       plan,
       result,
@@ -8364,6 +8379,8 @@ export function runDeckAnalysis(
       outputProbes,
       outputDirectives,
       analysisDirectives,
+      tableCount: tables.length,
+      tables,
       measurements,
       measurementTable: formatMeasurementTable(measurements),
       fourier,
@@ -8392,6 +8409,7 @@ export function runDeckAnalysis(
       fourier,
       diagnosticCodes,
     );
+    const tables = deckStableTables(measurements, fourier);
     return {
       plan,
       result,
@@ -8399,6 +8417,8 @@ export function runDeckAnalysis(
       outputProbes,
       outputDirectives,
       analysisDirectives,
+      tableCount: tables.length,
+      tables,
       measurements,
       measurementTable: formatMeasurementTable(measurements),
       fourier,
@@ -8437,6 +8457,7 @@ export function runDeckAnalysis(
       fourier,
       diagnosticCodes,
     );
+    const tables = deckStableTables(measurements, fourier);
     return {
       plan,
       result,
@@ -8444,6 +8465,8 @@ export function runDeckAnalysis(
       outputProbes,
       outputDirectives,
       analysisDirectives,
+      tableCount: tables.length,
+      tables,
       measurements,
       measurementTable: formatMeasurementTable(measurements),
       fourier,

--- a/code/packages/typescript/spice-engine/tests/transient.test.ts
+++ b/code/packages/typescript/spice-engine/tests/transient.test.ts
@@ -1473,6 +1473,8 @@ describe("transient", () => {
     expect(opExecution.outputProbes).toEqual(["V(mid)"]);
     expect(opExecution.outputDirectives).toEqual([".save"]);
     expect(opExecution.analysisDirectives).toEqual([".op"]);
+    expect(opExecution.tableCount).toBe(2);
+    expect(opExecution.tables).toEqual(["result", "run-artifact"]);
     expect(opExecution.measurements).toEqual([]);
     expect(opExecution.measurementTable).toBe("Name\tAnalysis\tProbe\tMode\tFrom\tTo\tValue\n");
     expect(opExecution.table).toBe("Index\tV(mid)\n0\t5.000000e-01\n");
@@ -1635,6 +1637,8 @@ describe("transient", () => {
     expect(dcExecution.outputProbes).toEqual(["V(mid)", "I(V1)"]);
     expect(dcExecution.outputDirectives).toEqual([".save", ".probe"]);
     expect(dcExecution.analysisDirectives).toEqual([".dc"]);
+    expect(dcExecution.tableCount).toBe(3);
+    expect(dcExecution.tables).toEqual(["result", "measurement", "run-artifact"]);
     expect(dcExecution.measurements.map((measurement) => measurement.name)).toEqual(["mid_avg"]);
     expect(dcExecution.measurementTable).toBe(
       "Name\tAnalysis\tProbe\tMode\tFrom\tTo\tValue\n" +
@@ -1682,6 +1686,8 @@ describe("transient", () => {
     expect(acExecution.outputProbes).toEqual(["V(mid)"]);
     expect(acExecution.outputDirectives).toEqual([".save"]);
     expect(acExecution.analysisDirectives).toEqual([".ac"]);
+    expect(acExecution.tableCount).toBe(3);
+    expect(acExecution.tables).toEqual(["result", "measurement", "run-artifact"]);
     expect(acExecution.measurements.map((measurement) => measurement.name)).toEqual(["mid_peak"]);
     expect(acExecution.measurementTable).toBe(
       "Name\tAnalysis\tProbe\tMode\tFrom\tTo\tValue\n" +
@@ -1729,6 +1735,8 @@ describe("transient", () => {
     expect(tranExecution.outputProbes).toEqual(["V(mid)"]);
     expect(tranExecution.outputDirectives).toEqual([".save"]);
     expect(tranExecution.analysisDirectives).toEqual([".tran"]);
+    expect(tranExecution.tableCount).toBe(3);
+    expect(tranExecution.tables).toEqual(["result", "measurement", "run-artifact"]);
     expect(tranExecution.measurements.map((measurement) => measurement.name)).toEqual(["mid_final"]);
     expect(tranExecution.measurementTable).toBe(
       "Name\tAnalysis\tProbe\tMode\tFrom\tTo\tValue\n" +
@@ -1779,6 +1787,8 @@ describe("transient", () => {
     expect(tfExecution.outputProbes).toEqual(["V(mid)"]);
     expect(tfExecution.outputDirectives).toEqual([]);
     expect(tfExecution.analysisDirectives).toEqual([".tf"]);
+    expect(tfExecution.tableCount).toBe(2);
+    expect(tfExecution.tables).toEqual(["result", "run-artifact"]);
     expect(tfExecution.measurements).toEqual([]);
     expect(tfExecution.measurementTable).toBe("Name\tAnalysis\tProbe\tMode\tFrom\tTo\tValue\n");
     expect(tfExecution.table).toBe(
@@ -1819,6 +1829,8 @@ describe("transient", () => {
     expect(sensResult.entries).toHaveLength(3);
     expect(sensExecution.outputProbes).toEqual(["V(mid)"]);
     expect(sensExecution.analysisDirectives).toEqual([".sens"]);
+    expect(sensExecution.tableCount).toBe(2);
+    expect(sensExecution.tables).toEqual(["result", "run-artifact"]);
     expect(sensExecution.measurements).toEqual([]);
     expect(sensExecution.measurementTable).toBe("Name\tAnalysis\tProbe\tMode\tFrom\tTo\tValue\n");
     expect(sensExecution.table.startsWith(
@@ -1864,6 +1876,8 @@ describe("transient", () => {
     expect(noiseResult.points).toHaveLength(1);
     expect(noiseExecution.outputProbes).toEqual(["V(mid)"]);
     expect(noiseExecution.analysisDirectives).toEqual([".noise"]);
+    expect(noiseExecution.tableCount).toBe(2);
+    expect(noiseExecution.tables).toEqual(["result", "run-artifact"]);
     expect(noiseExecution.measurements).toEqual([]);
     expect(noiseExecution.measurementTable).toBe("Name\tAnalysis\tProbe\tMode\tFrom\tTo\tValue\n");
     expect(noiseExecution.table).toBe(formatDeckNoiseTable(noiseResult));
@@ -1923,6 +1937,8 @@ describe("transient", () => {
       "result",
       "run-artifact",
     ]);
+    expect(tranWindowExecution.tableCount).toBe(2);
+    expect(tranWindowExecution.tables).toEqual(["result", "run-artifact"]);
     expect(tranWindowExecution.outputProbes).toEqual(["V(mid)"]);
     const tranWindowPoints = tranWindowExecution.result as { time: number }[];
     expect(tranWindowPoints).toHaveLength(3);
@@ -1985,9 +2001,13 @@ describe("transient", () => {
     const opExecution = runDeckAnalysis(circuit, netlist, "op");
     expect(opExecution.fourier).toEqual([]);
     expect(opExecution.fourierTable).toBe("");
+    expect(opExecution.tableCount).toBe(2);
+    expect(opExecution.tables).toEqual(["result", "run-artifact"]);
 
     const tranExecution = runDeckAnalysis(circuit, netlist, "tran");
     expect(tranExecution.fourier).toHaveLength(1);
+    expect(tranExecution.tableCount).toBe(3);
+    expect(tranExecution.tables).toEqual(["result", "fourier", "run-artifact"]);
     const result = tranExecution.fourier[0]!;
     expect(result.fundamentalFrequencyHz).toBeCloseTo(2_000.0, 12);
     expect(result.probes[0]?.probe).toBe("V(mid)");

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -79,9 +79,9 @@ downstream tools to compare.
      `START` output filtering, `MAXSTEP` fixed-step caps, and `UIC`
      initial-condition intent; selected `.tran` execution now keeps `.tran
      TSTEP` as the deck output print grid while `MAXSTEP` caps internal solver
-     stepping; deck executions now expose normalized selected analysis
-     directives, output probes, and output directives as inspectable artifacts
-     alongside the stable table;
+     stepping; deck executions now expose normalized selected table
+     count/name lists, analysis directives, output probes, and output
+     directives as inspectable artifacts alongside the stable table;
      selected `.measure` outputs now travel with deck execution results as
      structured measurements plus stable measurement tables; selected transient
      `.four` outputs now
@@ -89,8 +89,10 @@ downstream tools to compare.
      stable Fourier tables; selected deck executions now include structured
      run-artifact summaries plus stable row/count tables for result rows,
      stable table names, output probes, measurements, and Fourier artifacts,
-     with normalized table, output-probe, measurement, and Fourier probe name lists included in the
-     run artifacts; transfer-function, sensitivity, and noise run artifacts now
+     with normalized table, output-probe, measurement, and Fourier probe name
+     lists included in the run artifacts, and selected executions now expose the
+     same stable table count/name inventory directly; transfer-function,
+     sensitivity, and noise run artifacts now
      also expose their selected output node, and selected-run artifacts can now
      render as stable CSV and compact JSON beside the existing tab-separated
      table; stable deck output tables can now also convert to deterministic CSV
@@ -928,11 +930,22 @@ downstream tools to compare.
       measurement, Fourier, and run-artifact tables belong to a run without
       deriving the inventory from optional side tables.
 
+86. Deck execution table inventory artifacts.
+    - Status: completed in this deck execution table inventory slice.
+    - Python, Rust, and TypeScript selected deck executions now expose stable
+      table count/name lists directly on the execution result beside selected
+      analysis directives, output probes, output directives, and selected-run
+      artifacts.
+    - Host and browser integrations can inspect the selected result,
+      measurement, Fourier, and run-artifact table inventory without drilling
+      into the run-artifact table or reconstructing optional side-table
+      presence.
+
 ## Backlog
 
 1. Deck execution layer.
    - Expand selected-plan execution beyond fixed-step transient basics,
-     including richer deck-owned run artifacts beyond selected table, output,
+     including richer deck-owned run artifacts beyond selected table inventory, output,
      output-directive, measurement, Fourier, and transfer-function probe lists,
      plus output-plan integration beyond stable table routing.
    - Expand deck-controlled output-plan integration beyond stable table


### PR DESCRIPTION
## Summary
- expose stable table count/name lists directly on selected deck execution results in Python, Rust, and TypeScript
- keep the execution inventory aligned with selected-run artifact table lists
- document the new surface in package README/changelog files and mark the completed SPICE plan slice

## Verification
- PYTHONPATH=code/packages/python/spice-engine/src:code/packages/python/mosfet-models/src:code/packages/python/device-physics/src:code/packages/python/symbolic/src:code/packages/python/hardware/src /Users/adhithya/.local/share/mise/installs/python/3.12.13/bin/python -m pytest code/packages/python/spice-engine/tests -q --no-cov
- /Users/adhithya/.local/share/mise/installs/python/3.12.13/bin/ruff check code/packages/python/spice-engine/src/spice_engine/engine.py code/packages/python/spice-engine/tests/test_engine.py
- cargo test --manifest-path code/packages/rust/spice-engine/Cargo.toml
- cargo fmt --manifest-path code/packages/rust/spice-engine/Cargo.toml -- --check
- npm --prefix code/packages/typescript/spice-engine run build
- npm --prefix code/packages/typescript/spice-engine test