### PR TITLE
feat(r-20): functional helpers — Find, Position, Negate, Reduce(accumulate)

### DIFF
--- a/code/packages/rust/r-runtime/CHANGELOG.md
+++ b/code/packages/rust/r-runtime/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.15.0] - 2026-06-20
+
+### Added (via the shared `s-runtime`)
+
+- **R-20 — functional helpers**: `Find`, `Position`, `Negate`,
+  `Reduce(..., accumulate = TRUE)`, and `Recall` reach R unchanged through the
+  shared evaluator (they are plain `s-runtime` builtins — no grammar change).
+  In R syntax: `Find(\(x) x > 2, 1:5)` → `3`, `Position(\(x) x > 2, 1:5)` → `3`
+  (`NULL` when nothing matches); `Negate(is.na)(NA)` → `FALSE` and
+  `Negate(\(x) x > 0)(5)` → `FALSE`; `Reduce(\(a, b) a + b, 1:4,
+  accumulate = TRUE)` → `c(1, 3, 6, 10)` (with an init,
+  `Reduce(\(a, b) a + b, 1:3, 10, accumulate = TRUE)` → `c(10, 11, 13, 16)`);
+  and `Recall` drives anonymous recursion —
+  `(\(n) if (n <= 1) 1 else n * Recall(n - 1))(5)` → `120`. All take the function
+  by name (`f =`), so they compose with the pipe (`1:5 |> Find(f = \(x) x > 2)`).
+  See `s-runtime` 0.16.0.
+
 ## [0.14.0] - 2026-06-19
 
 ### Added (via the shared `s-runtime`)

--- a/code/packages/rust/r-runtime/README.md
+++ b/code/packages/rust/r-runtime/README.md
@@ -52,6 +52,17 @@ An **empty arm** falls through to the next non-empty arm (R-19):
 (`arg = NAME EQ [expr] | expr`) so `a = ,` parses; an empty arg in an ordinary
 call is an eval-time error.
 
+**Functional helpers (R-20)** — the rest of R's functional toolkit, on top of the
+R-10 family. `Find(f, x)` returns the first element where `f` is `TRUE`
+(`NULL` if none); `Position(f, x)` returns its 1-based index. `Negate(f)` is a
+new function computing `!f(...)` (`Negate(is.na)(NA)` → `FALSE`).
+`Reduce(f, x, accumulate = TRUE)` returns the running folds
+(`Reduce(\(a, b) a + b, 1:4, accumulate = TRUE)` → `c(1, 3, 6, 10)`; an init
+seeds the first element). `Recall(...)` re-invokes the enclosing function for
+anonymous recursion (`(\(n) if (n <= 1) 1 else n * Recall(n - 1))(5)` → `120`).
+All take the function by name, so they compose with the pipe
+(`1:5 |> Find(f = \(x) x > 2)`).
+
 ## Usage
 
 ```rust

--- a/code/packages/rust/r-runtime/src/lib.rs
+++ b/code/packages/rust/r-runtime/src/lib.rs
@@ -1367,6 +1367,137 @@ mod tests {
         );
     }
 
+    // --- R-20: functional helpers (Find / Position / Negate / Reduce
+    //           accumulate / Recall), in R syntax -------------------------
+
+    #[test]
+    fn find_returns_first_matching_element() {
+        // The first element greater than 2 in 1:5 is 3.
+        assert_eq!(nums("Find(\\(x) x > 2, 1:5)\n"), vec![3.0]);
+        // Short-circuits on the first hit, so a later predicate error is never
+        // reached: the first element > 1 is 2, returned before x reaches the NA.
+        assert_eq!(nums("Find(\\(x) x > 1, c(2, 3, NA))\n"), vec![2.0]);
+    }
+
+    #[test]
+    fn find_with_no_match_is_null() {
+        // No element satisfies the predicate -> NULL.
+        assert_eq!(show("Find(\\(x) x > 9, 1:5)\n"), "NULL");
+    }
+
+    #[test]
+    fn position_returns_first_matching_index() {
+        // 3 is the first element > 2, and it sits at (1-based) index 3.
+        assert_eq!(nums("Position(\\(x) x > 2, 1:5)\n"), vec![3.0]);
+        // Position returns the INDEX (here 1) where Find returns the VALUE.
+        assert_eq!(nums("Position(\\(x) x == 10, c(10, 20, 30))\n"), vec![1.0]);
+    }
+
+    #[test]
+    fn position_with_no_match_is_null() {
+        assert_eq!(show("Position(\\(x) x > 9, 1:5)\n"), "NULL");
+    }
+
+    #[test]
+    fn negate_flips_a_predicate() {
+        // Negate(is.na)(NA) -> FALSE (because is.na(NA) is TRUE).
+        assert_eq!(show("Negate(is.na)(NA)\n"), "[1] FALSE");
+        // Negate(is.na)(1) -> TRUE.
+        assert_eq!(show("Negate(is.na)(1)\n"), "[1] TRUE");
+        // Negate of a user lambda: !(5 > 0) -> FALSE.
+        assert_eq!(show("Negate(\\(x) x > 0)(5)\n"), "[1] FALSE");
+        assert_eq!(show("Negate(\\(x) x > 0)(-5)\n"), "[1] TRUE");
+    }
+
+    #[test]
+    fn negate_composes_with_filter() {
+        // Filter on the negated predicate keeps the ODD numbers.
+        assert_eq!(
+            nums("Filter(Negate(\\(x) x %% 2 == 0), 1:6)\n"),
+            vec![1.0, 3.0, 5.0]
+        );
+    }
+
+    #[test]
+    fn negate_of_non_function_errors() {
+        // A non-callable argument is a clean error, never a panic.
+        assert!(eval_r("Negate(3)\n").is_err());
+    }
+
+    #[test]
+    fn reduce_accumulate_returns_running_folds() {
+        // Running sums of 1:4: 1, 1+2, ...+3, ...+4.
+        assert_eq!(
+            nums("Reduce(\\(a, b) a + b, 1:4, accumulate = TRUE)\n"),
+            vec![1.0, 3.0, 6.0, 10.0]
+        );
+    }
+
+    #[test]
+    fn reduce_accumulate_with_init_seeds_first_element() {
+        // With an init, the init is the FIRST accumulated element:
+        // 10, 10+1, 11+2, 13+3.
+        assert_eq!(
+            nums("Reduce(\\(a, b) a + b, 1:3, 10, accumulate = TRUE)\n"),
+            vec![10.0, 11.0, 13.0, 16.0]
+        );
+    }
+
+    #[test]
+    fn reduce_without_accumulate_is_unchanged() {
+        // The R-10 behaviour must still hold (final fold only).
+        assert_eq!(nums("Reduce(\\(a, b) a + b, 1:4)\n"), vec![10.0]);
+        assert_eq!(nums("Reduce(\\(a, b) a + b, 1:4, 100)\n"), vec![110.0]);
+        // accumulate = FALSE is the explicit default.
+        assert_eq!(
+            nums("Reduce(\\(a, b) a + b, 1:4, accumulate = FALSE)\n"),
+            vec![10.0]
+        );
+    }
+
+    #[test]
+    fn functionals_compose_with_the_pipe_r20() {
+        // The new helpers take the function by name, so a piped vector lands in
+        // the data slot: 1:5 |> Find(> 2) -> 3, 1:5 |> Position(> 2) -> 3.
+        assert_eq!(nums("1:5 |> Find(f = \\(x) x > 2)\n"), vec![3.0]);
+        assert_eq!(nums("1:5 |> Position(f = \\(x) x > 2)\n"), vec![3.0]);
+        // Reduce(accumulate) over a pipe too.
+        assert_eq!(
+            nums("1:4 |> Reduce(f = \\(a, b) a + b, accumulate = TRUE)\n"),
+            vec![1.0, 3.0, 6.0, 10.0]
+        );
+    }
+
+    #[test]
+    fn recall_drives_anonymous_recursion() {
+        // The classic anonymous factorial: 5! = 120.
+        assert_eq!(
+            nums("(\\(n) if (n <= 1) 1 else n * Recall(n - 1))(5)\n"),
+            vec![120.0]
+        );
+        // 0! = 1 (base case taken immediately).
+        assert_eq!(
+            nums("(\\(n) if (n <= 1) 1 else n * Recall(n - 1))(0)\n"),
+            vec![1.0]
+        );
+    }
+
+    #[test]
+    fn recall_works_inside_a_named_function() {
+        // Recall re-invokes whatever function is currently running — including a
+        // named one. fib(7) = 13.
+        assert_eq!(
+            nums("fib <- function(n) if (n < 2) n else Recall(n - 1) + Recall(n - 2)\nfib(7)\n"),
+            vec![13.0]
+        );
+    }
+
+    #[test]
+    fn recall_outside_a_closure_errors() {
+        // Called at top level there is no enclosing function -> clean error.
+        assert!(eval_r("Recall(1)\n").is_err());
+    }
+
     // --- regressions: R-15 / R-16 / R-17 still work ---------------------
 
     #[test]
@@ -1388,5 +1519,21 @@ mod tests {
             nums("modifyList(list(a = 1, b = 2), list(b = 20))$b\n"),
             vec![20.0]
         );
+    }
+
+    #[test]
+    fn r10_r18_r19_still_work_after_r20() {
+        // R-10: the original functionals are intact (no accumulate -> final fold).
+        assert_eq!(nums("Reduce(\\(a, b) a - b, c(1, 2, 3), 10)\n"), vec![4.0]);
+        assert_eq!(nums("Filter(\\(x) x %% 2 == 0, 1:6)\n"), vec![2.0, 4.0, 6.0]);
+        assert_eq!(nums("Map(\\(x, y) x + y, 1:3, 4:6)[[2]]\n"), vec![7.0]);
+        // R-18: switch() + tryCatch still behave.
+        assert_eq!(show("switch(\"b\", a = \"x\", b = \"y\")\n"), "[1] \"y\"");
+        assert_eq!(
+            show("tryCatch(stop(\"boom\"), error = function(e) \"caught\")\n"),
+            "[1] \"caught\""
+        );
+        // R-19: empty-arm switch() fall-through.
+        assert_eq!(show("switch(\"a\", a = , b = \"hit\")\n"), "[1] \"hit\"");
     }
 }

--- a/code/packages/rust/s-runtime/CHANGELOG.md
+++ b/code/packages/rust/s-runtime/CHANGELOG.md
@@ -2,6 +2,40 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.16.0] - 2026-06-20
+
+### Added
+
+- **Functional helpers (R-20)** — the remaining members of R's
+  functional-programming toolkit, built on the R-10 family (`Map`/`Reduce`/
+  `Filter`/`mapply`/`vapply`) and, like it, plain builtins in the shared runtime
+  (no grammar change). They take the function by `f =`/`FUN =` or the first
+  callable positional (the R-10 `split_fun` helper), so they compose with the
+  pipe (`1:5 |> Find(f = \(x) x > 2)`).
+  - **`Find(f, x)`** — the first element of `x` where `f(element)` is `TRUE`, or
+    an invisible `NULL` if none. Short-circuits on the first hit.
+  - **`Position(f, x)`** — the 1-based index of the first matching element
+    (`Find` returns the value, `Position` the index); `NULL` if none.
+  - **`Negate(f)`** — a new callable computing `!f(...)`. Implemented as a small
+    dedicated value, `SValue::Negated(Box<SValue>)`, recognized by the call
+    dispatcher (`apply`/`call_value`): it invokes the wrapped `f` through the
+    normal depth-bounded path and logically negates the verdict (new `logical_not`
+    helper — `NA`-preserving, like `!`). `Negate(is.na)(NA)` → `FALSE`. The
+    wrapper is a function for `class`/`type_name`/`length`/`is_callable`. A
+    non-callable `f` is a clean `NotCallable` error.
+  - **`Reduce(f, x, ..., accumulate = TRUE)`** — extends the R-10 left fold to
+    return the vector/list of *running* folds; with an `init`, the init is the
+    first accumulated element (`Reduce(\(a, b) a + b, 1:3, 10, accumulate=TRUE)`
+    → `c(10, 11, 13, 16)`). Built with the shared `combine`/`c()` engine; the
+    no-`accumulate` behaviour is unchanged. Bounded by `MAX_SEQ_LEN` (the
+    accumulator can be no longer than `x`, itself capped).
+  - **`Recall(...)`** — anonymous recursion: re-invokes the enclosing function.
+    The interpreter now keeps a small call stack of the currently-executing
+    closures (pushed/popped by `call_closure` via an RAII `CallFrameGuard`, so it
+    is exception-safe); `Recall` reads the top. Outside any function it is an
+    error. Recursion is bounded by `MAX_EVAL_DEPTH`, so runaway anonymous
+    recursion fails cleanly instead of overflowing the native stack.
+
 ## [0.15.0] - 2026-06-19
 
 ### Added

--- a/code/packages/rust/s-runtime/README.md
+++ b/code/packages/rust/s-runtime/README.md
@@ -83,6 +83,20 @@ a hand-written loop. See [What "S-flavored" means here](#what-s-flavored-means-h
   to `arg = NAME EQ [expr] | expr` so `a = ,` parses; the empty value is only
   meaningful in `switch` — an empty arg in an ordinary call is an eval-time
   error.)
+- **Functional helpers** (R-20): the rest of R's functional toolkit, on top of
+  the R-10 family. `Find(f, x)` returns the first element where `f(element)` is
+  `TRUE` (invisible `NULL` if none, short-circuiting); `Position(f, x)` returns
+  its 1-based index. `Negate(f)` returns a new callable computing `!f(...)` — a
+  small `SValue::Negated` wrapper the call dispatcher recognizes, invoking `f`
+  through the normal depth-bounded path and logically negating the result
+  (`Negate(is.na)(NA)` → `FALSE`). `Reduce(f, x, ..., accumulate = TRUE)` returns
+  the running folds (`Reduce(\(a, b) a + b, 1:4, accumulate = TRUE)` →
+  `c(1, 3, 6, 10)`; an init seeds the first element); the no-`accumulate`
+  behaviour is unchanged. `Recall(...)` re-invokes the enclosing function for
+  anonymous recursion, reading a per-interpreter call stack pushed by
+  `call_closure` (RAII-popped). Recursion is bounded by `MAX_EVAL_DEPTH` and the
+  accumulator by `MAX_SEQ_LEN`; non-callable predicates and out-of-closure
+  `Recall` fail closed.
 - The **`d`/`p`/`q`/`r` distribution family** (R-8) over `statistics-core`:
   density/CDF/quantile/sampling for the normal, uniform, and exponential
   distributions, plus `set.seed` for a reproducible per-session RNG.

--- a/code/packages/rust/s-runtime/src/builtins.rs
+++ b/code/packages/rust/s-runtime/src/builtins.rs
@@ -107,6 +107,12 @@ pub fn install(env: &Env) {
     define(env, "mapply", builtin("mapply", b_mapply));
     define(env, "vapply", builtin("vapply", b_vapply));
 
+    // More functional helpers (R-20) — build on the R-10 family above.
+    define(env, "Find", builtin("Find", b_find));
+    define(env, "Position", builtin("Position", b_position));
+    define(env, "Negate", builtin("Negate", b_negate));
+    define(env, "Recall", builtin("Recall", b_recall));
+
     // Regular expressions (R-7).
     define(env, "grepl", builtin("grepl", b_grepl));
     define(env, "grep", builtin("grep", b_grep));
@@ -2661,8 +2667,24 @@ fn zip_apply(interp: &Interpreter, args: &[Arg], name: &str) -> SResult<(Vec<SVa
     Ok((items, len))
 }
 
-/// `Reduce(f, x[, init])` — left fold. Without `init`, `f` is first applied to
-/// the first two elements; an empty `x` with no `init` is `NULL`.
+/// `Reduce(f, x[, init][, accumulate])` — left fold. Without `init`, `f` is
+/// first applied to the first two elements; an empty `x` with no `init` is
+/// `NULL`.
+///
+/// **`accumulate` (R-20).** When `accumulate = TRUE`, the result is not the
+/// single final fold but the sequence of *running* folds, combined with `c()`
+/// (so atomic folds simplify to a vector, list folds stay a list):
+///
+/// ```text
+/// Reduce(\(a, b) a + b, 1:4)                     -> 10           (final only)
+/// Reduce(\(a, b) a + b, 1:4, accumulate = TRUE)  -> c(1, 3, 6, 10)
+/// Reduce(\(a, b) a + b, 1:3, 10, accumulate=TRUE)-> c(10, 11, 13, 16)
+/// ```
+///
+/// With an `init`, the init is the **first** accumulated element. The number of
+/// accumulated elements is `length(x)` (or `length(x) + 1` with an init), which
+/// is itself bounded by [`MAX_SEQ_LEN`]: `x` cannot be longer than that, so the
+/// accumulator vector is bounded too — no extra cap is needed.
 fn b_reduce(interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
     let (f, data) = split_fun(args, "Reduce")?;
     let x = data
@@ -2675,6 +2697,11 @@ fn b_reduce(interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
         .find(|a| a.name.as_deref() == Some("init"))
         .map(|a| a.value.clone())
         .or_else(|| data.get(1).cloned());
+    // `accumulate =` (named only; defaults to FALSE) selects running-fold output.
+    let accumulate = match args.iter().find(|a| a.name.as_deref() == Some("accumulate")) {
+        Some(a) => a.value.truthy()?,
+        None => false,
+    };
 
     let n = x.length();
     let (mut acc, start) = match init {
@@ -2682,6 +2709,16 @@ fn b_reduce(interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
         None if n == 0 => return Ok(SValue::Null),
         None => (nth_element(&x, 0), 1),
     };
+
+    // The running folds (only collected when `accumulate`), starting from `acc`.
+    let mut running: Vec<Arg> = Vec::new();
+    if accumulate {
+        running.push(Arg {
+            name: None,
+            value: acc.clone(),
+        });
+    }
+
     for i in start..n {
         acc = interp.call_value(
             f.clone(),
@@ -2696,8 +2733,109 @@ fn b_reduce(interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
                 },
             ],
         )?;
+        if accumulate {
+            running.push(Arg {
+                name: None,
+                value: acc.clone(),
+            });
+        }
     }
-    Ok(acc)
+    if accumulate {
+        Ok(combine(&running))
+    } else {
+        Ok(acc)
+    }
+}
+
+/// `Find(f, x)` — the **first** element of `x` for which `f(element)` is `TRUE`,
+/// or an invisible `NULL` if none matches. Short-circuits on the first hit
+/// (unlike `Filter`, which scans the whole vector). `f` is taken by `f =` / the
+/// first callable positional (the R-10 `split_fun` helper), so it composes with
+/// the pipe: `1:5 |> Find(f = \(x) x > 2)` is `3`.
+fn b_find(interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
+    let (f, data) = split_fun(args, "Find")?;
+    let x = data
+        .into_iter()
+        .next()
+        .ok_or_else(|| SError::BadArgs("Find: missing x".into()))?;
+    for i in 0..x.length() {
+        let element = nth_element(&x, i);
+        let verdict = interp.call_value(
+            f.clone(),
+            &[Arg {
+                name: None,
+                value: element.clone(),
+            }],
+        )?;
+        if verdict.truthy()? {
+            return Ok(element);
+        }
+    }
+    Ok(SValue::Null)
+}
+
+/// `Position(f, x)` — the **1-based index** of the first element for which
+/// `f(element)` is `TRUE`, or `NULL` if none. The index counterpart to `Find`
+/// (which returns the value).
+fn b_position(interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
+    let (f, data) = split_fun(args, "Position")?;
+    let x = data
+        .into_iter()
+        .next()
+        .ok_or_else(|| SError::BadArgs("Position: missing x".into()))?;
+    for i in 0..x.length() {
+        let verdict = interp.call_value(
+            f.clone(),
+            &[Arg {
+                name: None,
+                value: nth_element(&x, i),
+            }],
+        )?;
+        if verdict.truthy()? {
+            // R indexes from 1.
+            return Ok(SValue::scalar((i + 1) as f64));
+        }
+    }
+    Ok(SValue::Null)
+}
+
+/// `Negate(f)` — return a **new function** computing `!f(...)`. The wrapped `f`
+/// must be callable (else a clean error). The returned value is an
+/// [`SValue::Negated`], recognized by the call dispatcher: calling it invokes
+/// `f` through the normal depth-bounded path and logically negates the result.
+/// So `Negate(is.na)(NA)` → `FALSE` and `Negate(\(x) x > 0)(5)` → `FALSE`.
+fn b_negate(_interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
+    // The function is the sole argument — by `f =`/`FUN =` or the first callable
+    // positional. There is no data, so `split_fun` returning leftover positionals
+    // would be an error; instead pick the function directly.
+    let f = args
+        .iter()
+        .find(|a| matches!(a.name.as_deref(), Some("f") | Some("FUN")))
+        .map(|a| a.value.clone())
+        .or_else(|| {
+            args.iter()
+                .find(|a| a.name.is_none() && a.value.is_callable())
+                .map(|a| a.value.clone())
+        })
+        .ok_or_else(|| SError::BadArgs("Negate: missing function argument".into()))?;
+    if !f.is_callable() {
+        return Err(SError::NotCallable(f.type_name().to_string()));
+    }
+    Ok(SValue::Negated(Box::new(f)))
+}
+
+/// `Recall(...)` — re-invoke the **enclosing** function (anonymous recursion).
+/// Reads the current function off the interpreter's call stack and calls it with
+/// the supplied arguments. Outside any function it is an error. Recursion is
+/// bounded by `MAX_EVAL_DEPTH` (every `Recall` goes through `call_value` →
+/// `eval_node`), so runaway anonymous recursion fails cleanly rather than
+/// overflowing the native stack. This makes the classic anonymous factorial
+/// `(\(n) if (n <= 1) 1 else n * Recall(n - 1))(5)` evaluate to `120`.
+fn b_recall(interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
+    let current = interp
+        .current_function()
+        .ok_or_else(|| SError::BadArgs("Recall called from outside a closure".into()))?;
+    interp.call_value(current, args)
 }
 
 /// `Filter(f, x)` — keep the elements of `x` for which `f(element)` is true.

--- a/code/packages/rust/s-runtime/src/eval.rs
+++ b/code/packages/rust/s-runtime/src/eval.rs
@@ -21,7 +21,7 @@ use crate::env::{define, lookup, Env, Scope};
 use crate::error::{SError, SResult};
 use crate::value::{
     arithmetic, assign_index, assign_index2d, bounded_sequence, class_of, compare, format_value,
-    index, index2d, membership, negate, Arg, Param, SValue, MAX_SEQ_LEN,
+    index, index2d, logical_not, membership, negate, Arg, Param, SValue, MAX_SEQ_LEN,
 };
 use coding_adventures_s_parser::try_parse_s;
 use parser::grammar_parser::{ASTNodeOrToken, GrammarASTNode};
@@ -62,6 +62,14 @@ pub struct Interpreter {
     /// default, but immediate printing is simpler and equally faithful for a
     /// REPL); the buffer exists so a future `warnings()` accessor can read them.
     warnings: RefCell<Vec<String>>,
+    /// The stack of closures currently being evaluated, innermost last (R-20).
+    /// `call_closure` pushes the function it is about to run and pops it on the
+    /// way out (via an RAII guard, so an early-return/error still pops), so the
+    /// top is always "the function we are inside right now". `Recall()` reads the
+    /// top to re-invoke the enclosing function for anonymous recursion. Its depth
+    /// is naturally bounded by [`MAX_EVAL_DEPTH`] — every nested call increments
+    /// the eval depth — so it cannot grow without limit.
+    call_stack: RefCell<Vec<SValue>>,
 }
 
 /// The most warnings retained per program. Beyond this, further `warning()`
@@ -91,6 +99,25 @@ impl Drop for DepthGuard<'_> {
     }
 }
 
+/// RAII guard that pushes a closure onto the interpreter's call stack (R-20) on
+/// construction and pops it on drop, so the stack stays balanced even when the
+/// closure body returns early via `?` or raises an error. `Recall()` reads the
+/// top of this stack to re-invoke the enclosing function.
+struct CallFrameGuard<'a>(&'a RefCell<Vec<SValue>>);
+
+impl<'a> CallFrameGuard<'a> {
+    fn push(stack: &'a RefCell<Vec<SValue>>, f: SValue) -> Self {
+        stack.borrow_mut().push(f);
+        CallFrameGuard(stack)
+    }
+}
+
+impl Drop for CallFrameGuard<'_> {
+    fn drop(&mut self) {
+        self.0.borrow_mut().pop();
+    }
+}
+
 impl Default for Interpreter {
     fn default() -> Self {
         Self::new()
@@ -109,7 +136,14 @@ impl Interpreter {
             depth: Cell::new(0),
             rng: RefCell::new(RngState::new(DEFAULT_SEED)),
             warnings: RefCell::new(Vec::new()),
+            call_stack: RefCell::new(Vec::new()),
         }
+    }
+
+    /// The function currently being evaluated, if any — the top of the call
+    /// stack. `Recall()` (R-20) uses this to re-invoke the enclosing closure.
+    pub(crate) fn current_function(&self) -> Option<SValue> {
+        self.call_stack.borrow().last().cloned()
     }
 
     /// Record and print a warning raised by `warning(...)`. The buffer is capped
@@ -913,8 +947,20 @@ impl Interpreter {
                 }
             }
             SValue::Closure { params, body, env } => self.call_closure(&params, &body, &env, args),
+            SValue::Negated(inner) => self.as_visible(self.call_negated(&inner, args)?),
             other => Err(SError::NotCallable(other.type_name().to_string())),
         }
+    }
+
+    /// Invoke a `Negate(f)` wrapper (R-20): call the wrapped `f` with `args`
+    /// through the normal (depth-bounded) call path, then return the **logical
+    /// negation** of its verdict. `!` flips `TRUE`/`FALSE` element-wise and
+    /// preserves `NA`, so `Negate(is.na)(NA)` → `FALSE` and
+    /// `Negate(\(x) x > 0)(5)` → `FALSE`. A non-callable inner `f` yields a clean
+    /// `NotCallable` error (never a panic).
+    fn call_negated(&self, inner: &SValue, args: &[Arg]) -> SResult<SValue> {
+        let verdict = self.call_value(inner.clone(), args)?;
+        logical_not(&verdict)
     }
 
     /// Call a callable value and return its result, *without* the top-level
@@ -924,6 +970,7 @@ impl Interpreter {
         match callee {
             SValue::Builtin { func, .. } => func(self, args),
             SValue::Closure { params, body, env } => self.call_closure(&params, &body, &env, args),
+            SValue::Negated(inner) => self.call_negated(&inner, args),
             other => Err(SError::NotCallable(other.type_name().to_string())),
         }
     }
@@ -935,6 +982,21 @@ impl Interpreter {
         closure_env: &Env,
         args: &[Arg],
     ) -> SResult<SValue> {
+        // Record the function we are about to run so `Recall()` (R-20) can
+        // re-invoke it. The guard pops it again on the way out — including on an
+        // early `?`/error — so the stack stays balanced. Reconstructing the
+        // `Closure` value here is cheap: `params`/`body`/`env` are all `Rc`/clone
+        // -friendly, and the alternative (threading the value through every call
+        // site) is far more invasive.
+        let _frame = CallFrameGuard::push(
+            &self.call_stack,
+            SValue::Closure {
+                params: params.to_vec(),
+                body: Rc::clone(body),
+                env: Rc::clone(closure_env),
+            },
+        );
+
         let scope = Scope::child(closure_env);
         let mut bound = vec![false; params.len()];
 

--- a/code/packages/rust/s-runtime/src/lib.rs
+++ b/code/packages/rust/s-runtime/src/lib.rs
@@ -1302,3 +1302,83 @@ mod r19_degenerate_probes {
         }
     }
 }
+
+#[cfg(test)]
+mod r20_functional_helpers {
+    //! R-20 lives in `s-runtime` (R inherits it through the shared evaluator);
+    //! these S-syntax tests exercise the builtins directly. The R-syntax
+    //! integration tests mirror these in `r-runtime`.
+    use super::*;
+
+    fn nums(src: &str) -> Vec<f64> {
+        match eval_s(src).unwrap().strip_names() {
+            SValue::Double(d) => d.data().to_vec(),
+            other => panic!("expected double, got {}", other.type_name()),
+        }
+    }
+
+    fn show(src: &str) -> String {
+        format_value(&eval_s(src).unwrap()).join("\n")
+    }
+
+    #[test]
+    fn find_and_position() {
+        assert_eq!(nums("Find(function(x) x > 2, 1:5)\n"), vec![3.0]);
+        assert_eq!(show("Find(function(x) x > 9, 1:5)\n"), "NULL");
+        assert_eq!(nums("Position(function(x) x > 2, 1:5)\n"), vec![3.0]);
+        assert_eq!(show("Position(function(x) x > 9, 1:5)\n"), "NULL");
+    }
+
+    #[test]
+    fn negate_negates_and_is_callable() {
+        assert_eq!(show("Negate(is.na)(NA)\n"), "[1] FALSE");
+        assert_eq!(show("Negate(function(x) x > 0)(5)\n"), "[1] FALSE");
+        // The wrapper is itself a function (R's class() reports "function").
+        assert_eq!(show("class(Negate(is.na))\n"), "[1] \"function\"");
+    }
+
+    #[test]
+    fn reduce_accumulate() {
+        assert_eq!(
+            nums("Reduce(function(a, b) a + b, 1:4, accumulate = TRUE)\n"),
+            vec![1.0, 3.0, 6.0, 10.0]
+        );
+        assert_eq!(
+            nums("Reduce(function(a, b) a + b, 1:3, 10, accumulate = TRUE)\n"),
+            vec![10.0, 11.0, 13.0, 16.0]
+        );
+        // Empty x with no init is NULL even under accumulate.
+        assert_eq!(
+            show("Reduce(function(a, b) a + b, c(), accumulate = TRUE)\n"),
+            "NULL"
+        );
+    }
+
+    #[test]
+    fn recall_anonymous_recursion() {
+        assert_eq!(
+            nums("(function(n) if (n <= 1) 1 else n * Recall(n - 1))(5)\n"),
+            vec![120.0]
+        );
+    }
+
+    /// Hardening: degenerate or adversarial inputs to the new helpers must never
+    /// panic — only `Ok` or a recoverable `Err`. The test body is the panic
+    /// boundary, so a crash inside `eval_s` fails the test directly.
+    #[test]
+    fn degenerate_inputs_do_not_panic() {
+        for src in [
+            "Find()\n",                 // no function, no data
+            "Find(function(x) x)\n",    // function, no data
+            "Position(1, 1:3)\n",       // non-callable predicate
+            "Negate()\n",               // no function
+            "Negate(3)\n",              // non-callable
+            "Negate(is.na)()\n",        // negated wrapper called with no args
+            "Recall()\n",               // outside any closure
+            "Recall(1)\n",              // outside any closure, with an arg
+            "Reduce(function(a, b) a + b, accumulate = TRUE)\n", // no x
+        ] {
+            let _ = eval_s(src);
+        }
+    }
+}

--- a/code/packages/rust/s-runtime/src/value.rs
+++ b/code/packages/rust/s-runtime/src/value.rs
@@ -60,6 +60,17 @@ pub enum SValue {
     /// A built-in function (`c`, `mean`, …).
     Builtin { name: String, func: Builtin },
 
+    /// The result of `Negate(f)` (R-20) — a *callable* that wraps another
+    /// function `f` and, when called, returns the **logical negation** of
+    /// `f(...)`. Stored as its own value rather than a synthesized closure
+    /// because the S/R grammar has no `!` operator to express
+    /// `function(...) !f(...)` directly; the call dispatcher (`apply` /
+    /// `call_value`) recognizes it, invokes the inner `f` through the normal
+    /// (depth-bounded) call path, and flips the verdict. It is a function for
+    /// all observable purposes: `is_callable`/`class`/`type_name` see a
+    /// `"function"`, exactly like `Closure`/`Builtin`.
+    Negated(Box<SValue>),
+
     /// A factor: integer `codes` (1-based into `levels`, `None` = `NA`) plus the
     /// ordered `levels`. Implicit class `"factor"`.
     Factor {
@@ -251,7 +262,9 @@ pub fn class_of(value: &SValue) -> Vec<String> {
         SValue::Logical(_) => vec!["logical".to_string()],
         SValue::Character(_) => vec!["character".to_string()],
         SValue::Null => vec!["NULL".to_string()],
-        SValue::Closure { .. } | SValue::Builtin { .. } => vec!["function".to_string()],
+        SValue::Closure { .. } | SValue::Builtin { .. } | SValue::Negated(_) => {
+            vec!["function".to_string()]
+        }
         SValue::Matrix { .. } => vec!["matrix".to_string(), "array".to_string()],
         // A names attribute is transparent to `class()` — see through to the
         // underlying value's class (a named numeric is still `"numeric"`).
@@ -275,6 +288,7 @@ impl std::fmt::Debug for SValue {
                 write!(f, "Closure(/{} params/)", params.len())
             }
             SValue::Builtin { name, .. } => write!(f, "Builtin({name})"),
+            SValue::Negated(inner) => write!(f, "Negated({inner:?})"),
             SValue::Factor { codes, levels } => {
                 write!(f, "Factor({} codes, {} levels)", codes.len(), levels.len())
             }
@@ -327,7 +341,7 @@ impl SValue {
             SValue::Logical(_) => "logical",
             SValue::Character(_) => "character",
             SValue::Null => "NULL",
-            SValue::Closure { .. } | SValue::Builtin { .. } => "closure",
+            SValue::Closure { .. } | SValue::Builtin { .. } | SValue::Negated(_) => "closure",
             SValue::Factor { .. } => "factor",
             SValue::DataFrame { .. } => "data.frame",
             SValue::Classed { inner, .. } => inner.type_name(),
@@ -346,7 +360,7 @@ impl SValue {
             SValue::Logical(v) => v.len(),
             SValue::Character(v) => v.len(),
             SValue::Null => 0,
-            SValue::Closure { .. } | SValue::Builtin { .. } => 1,
+            SValue::Closure { .. } | SValue::Builtin { .. } | SValue::Negated(_) => 1,
             SValue::Factor { codes, .. } => codes.len(),
             SValue::DataFrame { columns, .. } => columns.len(),
             SValue::Classed { inner, .. } => inner.length(),
@@ -358,7 +372,10 @@ impl SValue {
     }
 
     pub fn is_callable(&self) -> bool {
-        matches!(self, SValue::Closure { .. } | SValue::Builtin { .. })
+        matches!(
+            self,
+            SValue::Closure { .. } | SValue::Builtin { .. } | SValue::Negated(_)
+        )
     }
 
     /// Coerce to a numeric `Double` for arithmetic and statistics. Logical
@@ -693,6 +710,17 @@ pub fn negate(value: &SValue) -> SResult<SValue> {
             .map(|x| if is_na_real(x) { na_real() } else { -x })
             .collect(),
     )))
+}
+
+/// `!x` — the **logical NOT** (R-20, used by `Negate`). Coerces `x` to logical
+/// (so `!0` is `TRUE`, `!2` is `FALSE`, `!"x"` is an error) and flips each
+/// element, preserving `NA` (`!NA` is `NA`). The result is always a logical
+/// vector the same length as `x`; `!NULL` is `logical(0)`.
+pub fn logical_not(value: &SValue) -> SResult<SValue> {
+    let bits = value.as_logical()?;
+    Ok(SValue::Logical(
+        bits.into_iter().map(|b| b.map(|t| !t)).collect(),
+    ))
 }
 
 /// `x %in% table` — for each element of `x`, whether it appears in `table`.
@@ -1300,6 +1328,10 @@ pub fn format_value(value: &SValue) -> Vec<String> {
         SValue::Builtin { name, .. } => {
             return vec![format!("function ({}) .Primitive", name)];
         }
+        SValue::Negated(_) => {
+            // R prints `Negate(f)` as the generated wrapper `function (...) !f(...)`.
+            return vec!["function (...) !f(...)".to_string()];
+        }
         SValue::Factor { codes, levels } => {
             if codes.is_empty() {
                 return vec![
@@ -1729,6 +1761,39 @@ mod tests {
     fn negate_handles_na() {
         let r = negate(&SValue::doubles(vec![1.0, -2.0])).unwrap();
         assert_eq!(dbl(&r), vec![-1.0, 2.0]);
+    }
+
+    #[test]
+    fn logical_not_flips_and_preserves_na() {
+        // !TRUE/!FALSE flip; !NA stays NA.
+        let r = logical_not(&SValue::Logical(vec![Some(true), Some(false), None])).unwrap();
+        match r {
+            SValue::Logical(v) => assert_eq!(v, vec![Some(false), Some(true), None]),
+            other => panic!("expected logical, got {}", other.type_name()),
+        }
+        // Numeric coerces: !0 is TRUE, !2 is FALSE.
+        let r = logical_not(&SValue::doubles(vec![0.0, 2.0])).unwrap();
+        match r {
+            SValue::Logical(v) => assert_eq!(v, vec![Some(true), Some(false)]),
+            other => panic!("expected logical, got {}", other.type_name()),
+        }
+        // !NULL is the empty logical vector.
+        assert_eq!(logical_not(&SValue::Null).unwrap().length(), 0);
+    }
+
+    #[test]
+    fn negated_value_is_function_like() {
+        // An SValue::Negated wrapper presents as a callable "function" for class,
+        // type_name, length, and is_callable — exactly like Closure/Builtin.
+        let neg = SValue::Negated(Box::new(SValue::Builtin {
+            name: "is.na".to_string(),
+            func: |_, _| Ok(SValue::Null),
+        }));
+        assert!(neg.is_callable());
+        assert_eq!(neg.type_name(), "closure");
+        assert_eq!(neg.length(), 1);
+        assert_eq!(class_of(&neg), vec!["function".to_string()]);
+        assert_eq!(format_value(&neg), vec!["function (...) !f(...)".to_string()]);
     }
 
     // --- comparison -----------------------------------------------------

--- a/code/specs/R00-r-language.md
+++ b/code/specs/R00-r-language.md
@@ -360,6 +360,51 @@ unchanged.
     condition machinery (custom condition classes, calling handlers, restarts) is
     out of scope.
 
+- **R-20 — functional helpers** *(this PR)*. The remaining members of R's
+  functional-programming toolkit (`?funprog`), built on the R-10 family and, like
+  it, living in the shared `s-runtime` (R inherits them through the same
+  evaluator — no grammar change, all plain builtins). They take their function by
+  name (`f =`/`FUN =`) or as the first callable positional and the data as the
+  remaining positionals (the R-10 `split_fun` helper), so they compose with the
+  pipe (`1:5 |> Find(f = \(x) x > 2)`):
+  - **`Find(f, x)`** — the **first** element of `x` for which `f(element)` is
+    `TRUE`; if none matches, an **invisible `NULL`**. `f` is invoked through
+    `Interpreter::call_value`, exactly as `Filter` does, but it short-circuits on
+    the first hit rather than scanning the whole vector.
+  - **`Position(f, x)`** — the **1-based index** of the first matching element
+    (the counterpart to `Find`, which returns the *value*); `NULL` if none match.
+  - **`Negate(f)`** — returns a **new callable** computing `!f(...)`: the logical
+    negation of `f`'s result. Implemented with a small dedicated value,
+    `SValue::Negated(Box<SValue>)`, that wraps the function; calling it invokes
+    the inner `f` (through the same `call_value`/`apply` path, so recursion is
+    bounded by `MAX_EVAL_DEPTH`) and negates the verdict via the shared `negate`
+    coercion (so `Negate(is.na)(NA)` → `FALSE`, `Negate(\(x) x > 0)(5)` →
+    `FALSE`). `is.callable`/`Negate(f)(...)` see it as a function; it negates
+    element-wise and is `NA`-preserving like `!`. The wrapped `f` must itself be
+    callable (else an `NotCallable` error, never a panic).
+  - **`Reduce(f, x, ..., accumulate = FALSE)`** — the R-10 left fold, now with
+    R's **`accumulate`** flag. With `accumulate = TRUE` the result is the vector
+    (or list) of *running* folds rather than the final one:
+    `Reduce(\(a, b) a + b, 1:4, accumulate = TRUE)` → `c(1, 3, 6, 10)`; with an
+    `init`, the init is the **first** accumulated element
+    (`Reduce(\(a, b) a + b, 1:3, 10, accumulate = TRUE)` → `c(10, 11, 13, 16)`).
+    The no-`accumulate` behaviour (with and without `init`) is unchanged. The
+    accumulated result is built with the shared `combine`/`c()` engine, so it
+    simplifies to a vector for atomic folds and stays a list when the folds are
+    themselves lists; an empty `x` with no `init` is `NULL`. The accumulated
+    length never exceeds `length(x) (+1 for init)`, itself bounded by
+    `MAX_SEQ_LEN`.
+  - **`Recall(...)`** — **anonymous recursion**: inside a running function body,
+    `Recall(args…)` re-invokes *that same function*. The interpreter keeps a small
+    **call stack** of the currently-executing closures (pushed/popped by
+    `call_closure` with an RAII guard, so it is exception-safe); `Recall` reads
+    the top and calls it with the supplied arguments. Outside any function it is
+    an error (`"Recall called from outside a closure"`). Recursion is bounded by
+    `MAX_EVAL_DEPTH` (each `Recall` goes through `call_value` → `eval_node`),
+    so runaway anonymous recursion returns a clean error instead of overflowing
+    the native stack. This makes the classic anonymous factorial work:
+    `(\(n) if (n <= 1) 1 else n * Recall(n - 1))(5)` → `120`.
+
 ## §4 Reuse strategy
 
 - **Lexer/parser:** the grammar-tools framework, exactly as S uses it. `r.tokens`


### PR DESCRIPTION
## R-20 — functional helpers

The remaining members of R's functional-programming toolkit (`?funprog`), built on the R-10 family (`Map`/`Reduce`/`Filter`/`mapply`/`vapply`). Like R-10 they live in the shared `s-runtime` (R inherits them through the language-neutral tree-walker) and are **plain builtins — no grammar change**. They take the function by `f =`/`FUN =` or the first callable positional (the R-10 `split_fun` helper), so they compose with the pipe (`1:5 |> Find(f = \(x) x > 2)`).

### Shipped
- **`Find(f, x)`** — the first element of `x` where `f(element)` is `TRUE`; invisible `NULL` if none. Short-circuits on the first hit.
- **`Position(f, x)`** — the 1-based index of the first match (the index counterpart to `Find`, which returns the value); `NULL` if none.
- **`Negate(f)`** — a new callable computing `!f(...)`. Implemented as a small dedicated value `SValue::Negated(Box<SValue>)` recognized by the call dispatcher (`apply`/`call_value`): it invokes the wrapped `f` through the normal depth-bounded path and logically negates the verdict (new `logical_not` helper — `NA`-preserving, like `!`). `Negate(is.na)(NA)` → `FALSE`, `Negate(\(x) x > 0)(5)` → `FALSE`. The wrapper presents as a `"function"` for `class`/`type_name`/`length`/`is_callable`. A non-callable `f` is a clean `NotCallable` error.
- **`Reduce(f, x, ..., accumulate = TRUE)`** — extends the R-10 left fold to return the vector/list of *running* folds (built with the shared `combine`/`c()` engine, so atomic folds simplify and list folds stay lists). With an `init`, the init is the first accumulated element (`Reduce(\(a, b) a + b, 1:3, 10, accumulate = TRUE)` → `c(10, 11, 13, 16)`). The no-`accumulate` behaviour (with/without `init`) is unchanged.
- **`Recall(...)`** — anonymous recursion: re-invokes the *enclosing* function. The interpreter now keeps a small call stack of the currently-executing closures (pushed/popped by `call_closure` via an RAII `CallFrameGuard`, exception-safe); `Recall` reads the top. `(\(n) if (n <= 1) 1 else n * Recall(n - 1))(5)` → `120`. Outside any function it is an error.

**`Recall` shipped** (not deferred) — wiring the current-function handle through the call frame was a clean, contained addition (one `RefCell<Vec<SValue>>` + an RAII guard in the single `call_closure` chokepoint).

### Tests
R-syntax integration tests in `r-runtime` and S-syntax unit tests in `s-runtime`:
- `Find`/`Position` hit + `NULL` miss; short-circuit before a later predicate error.
- `Negate(is.na)(NA)` → FALSE, `Negate(\(x) x > 0)(5)` → FALSE, `Filter(Negate(...))`, non-callable → error.
- `Reduce(accumulate)` with and without init; pipe composition; `accumulate = FALSE` default unchanged.
- `Recall` factorial (anonymous + named `fib`) and out-of-closure error.
- R-10/R-18/R-19 regressions; degenerate-input no-panic probes.

All green: `cargo test -p coding-adventures-s-runtime -p coding-adventures-r-runtime` → 118 + 167 + doctests pass. `cargo clippy` clean for both crates.

### Security review (inline — no Agent tool in this environment)
Reviewed `git diff origin/main...HEAD` as a Rust security engineer. Focus areas:
- **Panics on bad input:** none. `split_fun` returns `Err(NotCallable)` for non-callable `f`; missing `x`, NA-in-condition (`truthy()?`) all return `Err`. No `unwrap`/`unsafe`/raw indexing in production paths. Verified by no-panic degenerate-input probe tests.
- **`accumulate` result size:** bounded — the accumulator is at most `length(x) + 1`, and `length(x) ≤ MAX_SEQ_LEN`.
- **`Negate` re-entry:** `call_negated` invokes inner `f` once (no self-recursion); depth-bounded via the normal call path. RefCell borrows are short-lived (clone-out), no borrow held across a call.
- **`Recall` recursion:** bounded by `MAX_EVAL_DEPTH` — verified that in **release** builds deep `Recall`/recursion returns a clean `"evaluation nested too deeply"` error (no overflow).

**Disclosed pre-existing item (LOW/INFO, not introduced here):** in **debug** builds (small test-thread stack + large unoptimized frames), runtime call recursion deeper than ~150 levels can overflow the native stack and `SIGABRT` *before* the `MAX_EVAL_DEPTH=3000` counter trips. This affects **all** recursion (existing `fib`/factorial paths) equally — `Recall`/`Negate` route through the identical depth-bounded path and add no new exposure. Release (the deployment target) is safe. A repo-wide hardening of the recursion bound for small-stack/debug environments is a good follow-up but is out of scope for this lane.

Diff is functional-only (additive; the small `-8` is the in-place `b_reduce` extension and the function-like match arms). No `cargo fmt` run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)