### PR TITLE
feat(closurec): try/catch/finally end-to-end (CLOC19)

### DIFF
--- a/code/packages/rust/closure-emitter/CHANGELOG.md
+++ b/code/packages/rust/closure-emitter/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to the `coding-adventures-closure-emitter` crate will be documented in this file.
 
+## [0.13.0] - 2026-06-20
+
+### Added — CLOC19: emit `try`/`catch`/`finally`
+
+New `emit_try` writes `try <block> [ catch [(param)] <block> ] [ finally <block> ]`.
+No `required_ws` is needed anywhere: every boundary is keyword↔`{`/`}` or
+`}`↔keyword (`try{…}catch{…}`, `}finally{…}`), which lex cleanly with no
+separator. Pretty mode inserts readability spaces (`try {`, `catch (e) {`,
+`finally {`); minified mode emits the tight form. The optional-catch-binding
+form (`catch { … }`) emits with no parens. Added emitter unit tests pinning the
+minified token boundaries, the optional-binding and no-catch forms, and the
+pretty-mode spacing.
+
 ## [0.12.0] - 2026-06-08
 
 ### Changed

--- a/code/packages/rust/closure-emitter/Cargo.toml
+++ b/code/packages/rust/closure-emitter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-emitter"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 description = "JavaScript code emitter for the Closure Compiler clone. Per CLOC07's emit contract. Takes a finalized Program + sidecar and produces output JavaScript text + companion source map. Runs after every pass in the pipeline."
 

--- a/code/packages/rust/closure-emitter/src/lib.rs
+++ b/code/packages/rust/closure-emitter/src/lib.rs
@@ -66,13 +66,14 @@ use coding_adventures_javascript_ast::{
     statement::TaggedStatement, ArrayExpression, AssignmentExpression, AssignmentOperator,
     AssignmentTarget, BigIntLiteral, BinaryExpression, BinaryOperator, BlockStatement,
     BooleanLiteral,
-    BreakStatement, CallExpression, ConditionalExpression, ContinueStatement, Declaration,
+    BreakStatement, CallExpression, CatchClause, ConditionalExpression, ContinueStatement,
+    Declaration,
     EmptyStatement, Expression, ExpressionStatement, ForInit, ForStatement, FunctionDeclaration,
     FunctionParam, Identifier, IfStatement, LabeledStatement, LogicalExpression, LogicalOperator,
     MemberExpression, NullLiteral, NumericLiteral, ObjectExpression, Program, ProgramItem,
     Property, PropertyKey, PropertyKind, ReturnStatement, Statement, StringLiteral,
-    SwitchCase, SwitchStatement, ThrowStatement, UnaryExpression, UnaryOperator, UndefinedLiteral,
-    VarKind, VariableDeclaration, VariableDeclarator, WhileStatement,
+    SwitchCase, SwitchStatement, ThrowStatement, TryStatement, UnaryExpression, UnaryOperator,
+    UndefinedLiteral, VarKind, VariableDeclaration, VariableDeclarator, WhileStatement,
 };
 use coding_adventures_type_sidecar::Sidecar;
 use std::fmt;
@@ -297,7 +298,38 @@ impl<'a> Emitter<'a> {
             TaggedStatement::LabeledStatement(l) => self.emit_labeled(l),
             TaggedStatement::ThrowStatement(t) => self.emit_throw(t),
             TaggedStatement::SwitchStatement(s) => self.emit_switch(s),
+            TaggedStatement::TryStatement(t) => self.emit_try(t),
             TaggedStatement::EmptyStatement(e) => self.emit_empty(e),
+        }
+    }
+
+    fn emit_try(&mut self, t: &TryStatement) {
+        // try <block> [ catch [(param)] <block> ] [ finally <block> ]
+        // No `required_ws` anywhere: every boundary is keyword↔`{`/`}` or
+        // `}`↔keyword, which lex cleanly with no separator (`try{…}catch{…}`).
+        // `pretty_ws` adds readability spaces only in pretty mode.
+        self.maybe_map(&t.cv);
+        self.write_str("try");
+        self.pretty_ws();
+        self.emit_block_statement(&t.block);
+        if let Some(h) = &t.handler {
+            self.maybe_map(&h.cv);
+            self.pretty_ws();
+            self.write_str("catch");
+            if let Some(param) = &h.param {
+                self.pretty_ws();
+                self.write_str("(");
+                self.write_str(&param.name);
+                self.write_str(")");
+            }
+            self.pretty_ws();
+            self.emit_block_statement(&h.body);
+        }
+        if let Some(finalizer) = &t.finalizer {
+            self.pretty_ws();
+            self.write_str("finally");
+            self.pretty_ws();
+            self.emit_block_statement(finalizer);
         }
     }
 
@@ -2349,6 +2381,104 @@ mod tests {
     // Tracked as a follow-up to CLOC12.10's paren-policy work.
     // The PREC_UNARY entry for UndefinedLiteral is still correct
     // (it'll start firing the moment the emit_member fix lands).
+
+    // ---- try / catch / finally (CLOC19) -----------------------
+
+    /// Build a single-expression-statement block `{ <ident>; }`.
+    fn block_with(name: &str) -> BlockStatement {
+        BlockStatement {
+            cv: None,
+            body: vec![Statement::expression_statement(ExpressionStatement {
+                cv: None,
+                expression: ident(name),
+            })],
+        }
+    }
+
+    fn emit_try_item(t: TryStatement) -> String {
+        let item = ProgramItem::Statement(Statement::try_statement(t));
+        emit_default(program().with_body(vec![item])).code
+    }
+
+    #[test]
+    fn try_catch_finally_emits_with_clean_token_boundaries() {
+        // The whole point of the emitter's "no required_ws" claim: every
+        // boundary (`}catch`, `)`/`{`, `}finally`) lexes cleanly with no
+        // separator. The last statement in a block drops its `;` (the
+        // emitter's minified ASI), so the tight form is exactly this.
+        let t = TryStatement {
+            cv: None,
+            block: block_with("a"),
+            handler: Some(CatchClause {
+                cv: None,
+                param: Some(Identifier {
+                    cv: None,
+                    name: "e".to_string(),
+                }),
+                body: block_with("b"),
+            }),
+            finalizer: Some(block_with("c")),
+        };
+        assert_eq!(emit_try_item(t), "try{a}catch(e){b}finally{c}");
+    }
+
+    #[test]
+    fn try_with_optional_catch_binding_emits_no_parens() {
+        // ES2019 `catch { … }` — handler with no param.
+        let t = TryStatement {
+            cv: None,
+            block: block_with("a"),
+            handler: Some(CatchClause {
+                cv: None,
+                param: None,
+                body: block_with("b"),
+            }),
+            finalizer: None,
+        };
+        assert_eq!(emit_try_item(t), "try{a}catch{b}");
+    }
+
+    #[test]
+    fn try_finally_without_catch_emits() {
+        // A `try … finally` with no handler at all.
+        let t = TryStatement {
+            cv: None,
+            block: block_with("a"),
+            handler: None,
+            finalizer: Some(block_with("c")),
+        };
+        assert_eq!(emit_try_item(t), "try{a}finally{c}");
+    }
+
+    #[test]
+    fn try_catch_finally_pretty_mode_spaces_keywords() {
+        let t = TryStatement {
+            cv: None,
+            block: block_with("a"),
+            handler: Some(CatchClause {
+                cv: None,
+                param: Some(Identifier {
+                    cv: None,
+                    name: "e".to_string(),
+                }),
+                body: block_with("b"),
+            }),
+            finalizer: Some(block_with("c")),
+        };
+        let item = ProgramItem::Statement(Statement::try_statement(t));
+        let out = emit_with(
+            program().with_body(vec![item]),
+            EmitOptions {
+                pretty: true,
+                ..EmitOptions::default()
+            },
+        );
+        // Pretty mode inserts a space after each keyword and around the
+        // blocks; the catch param keeps its `(e)` form.
+        assert!(out.code.contains("try {"), "got:\n{}", out.code);
+        assert!(out.code.contains("catch (e) {"), "got:\n{}", out.code);
+        assert!(out.code.contains("finally {"), "got:\n{}", out.code);
+    }
 
     // ---- EmitError --------------------------------------------
 

--- a/code/packages/rust/closure-pass-constant-fold/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-constant-fold/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to the `coding-adventures-closure-pass-constant-fold` crate will be documented in this file.
 
+## [0.12.0] - 2026-06-20
+
+### Added — CLOC19: fold inside `try`/`catch`/`finally`
+
+`fold_tagged` now has a `TryStatement` arm that recurses constant folding into
+the protected block, the catch handler body, and the finalizer, preserving the
+catch `param` verbatim. Constant initializers and expressions inside try/catch
+blocks (e.g. `1 + 2` ⇒ `3`) now fold like anywhere else.
+
 ## [0.11.0] - 2026-06-19
 
 ### Added — CLOC15.D: fold bitwise & shift operators on numeric literals

--- a/code/packages/rust/closure-pass-constant-fold/Cargo.toml
+++ b/code/packages/rust/closure-pass-constant-fold/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-constant-fold"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2021"
 description = "Constant-folding optimization pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Folds compile-time-evaluable expressions like `2 + 3 → 5`."
 

--- a/code/packages/rust/closure-pass-constant-fold/src/lib.rs
+++ b/code/packages/rust/closure-pass-constant-fold/src/lib.rs
@@ -322,6 +322,35 @@ fn fold_tagged_statement(stmt: &TaggedStatement, st: &mut FoldState) -> TaggedSt
                     .collect(),
             })
         }
+        TaggedStatement::TryStatement(s) => {
+            // Fold within the protected block, the catch body, and the
+            // finalizer — each is an ordinary block. The catch `param` is a
+            // binding name, not an expression, so it is preserved verbatim.
+            let block = BlockStatement {
+                cv: s.block.cv.clone(),
+                body: s.block.body.iter().map(|x| fold_statement(x, st)).collect(),
+            };
+            let handler = s.handler.as_ref().map(|h| {
+                coding_adventures_javascript_ast::CatchClause {
+                    cv: h.cv.clone(),
+                    param: h.param.clone(),
+                    body: BlockStatement {
+                        cv: h.body.cv.clone(),
+                        body: h.body.body.iter().map(|x| fold_statement(x, st)).collect(),
+                    },
+                }
+            });
+            let finalizer = s.finalizer.as_ref().map(|f| BlockStatement {
+                cv: f.cv.clone(),
+                body: f.body.iter().map(|x| fold_statement(x, st)).collect(),
+            });
+            TaggedStatement::TryStatement(coding_adventures_javascript_ast::TryStatement {
+                cv: s.cv.clone(),
+                block,
+                handler,
+                finalizer,
+            })
+        }
         TaggedStatement::BreakStatement(_)
         | TaggedStatement::ContinueStatement(_)
         | TaggedStatement::EmptyStatement(_) => stmt.clone(),

--- a/code/packages/rust/closure-pass-dce/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-dce/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to the `coding-adventures-closure-pass-dce` crate will be documented in this file.
 
+## [0.10.0] - 2026-06-20
+
+### Added — CLOC19: DCE inside `try`/`catch`/`finally`
+
+New `TryStatement` arm recurses dead-code elimination into the protected block,
+the catch handler body, and the finalizer. Dead-after-terminator and
+empty-statement cleanup now apply within those blocks (e.g. a `dead()` call after
+a `return` inside a `catch` handler is truncated). The catch `param` is preserved
+verbatim, and the `try` statement is explicitly NOT treated as a terminator — a
+statement following a `try`/`catch` remains reachable because the handler can
+catch and continue. Added unit tests for both behaviours.
+
 ## [0.9.0] - 2026-06-19
 
 ### Added — dead-code-after-`throw` at block level
@@ -66,7 +78,6 @@ statement variants default to unsafe (preserved) until vetted.
 Six new unit tests (drop-after-throw; the no-op last-statement case; the
 hoisting guard for `throw` and `return`; compound-statement-tail preservation;
 and a droppable `let`-only tail). No closurec fixture churn.
-
 ## [0.8.0] - 2026-06-04
 
 ### Added — CLOC12.36: constant-discriminant switch collapse (gap-014 step 4/N)

--- a/code/packages/rust/closure-pass-dce/Cargo.toml
+++ b/code/packages/rust/closure-pass-dce/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-dce"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2021"
 description = "Dead-code elimination pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Drops code after definite-terminator statements and removes EmptyStatement noise."
 

--- a/code/packages/rust/closure-pass-dce/src/lib.rs
+++ b/code/packages/rust/closure-pass-dce/src/lib.rs
@@ -482,6 +482,26 @@ fn dce_tagged_statement(stmt: &TaggedStatement, st: &mut DceState) -> TaggedStat
                 cases: new_cases,
             })
         }
+        TaggedStatement::TryStatement(s) => {
+            // Recurse DCE into the protected block, the catch body, and the
+            // finalizer — each is an ordinary block, so dead-after-terminator
+            // and empty-statement cleanup apply within them. The catch `param`
+            // is preserved verbatim (it is a binding, not removable here). We
+            // do NOT treat the `try` itself as a terminator: it can catch and
+            // continue, so code after it is reachable.
+            TaggedStatement::TryStatement(coding_adventures_javascript_ast::TryStatement {
+                cv: s.cv.clone(),
+                block: dce_block_statement(&s.block, st),
+                handler: s.handler.as_ref().map(|h| {
+                    coding_adventures_javascript_ast::CatchClause {
+                        cv: h.cv.clone(),
+                        param: h.param.clone(),
+                        body: dce_block_statement(&h.body, st),
+                    }
+                }),
+                finalizer: s.finalizer.as_ref().map(|f| dce_block_statement(f, st)),
+            })
+        }
         TaggedStatement::BreakStatement(_)
         | TaggedStatement::ContinueStatement(_)
         | TaggedStatement::EmptyStatement(_) => stmt.clone(),
@@ -987,8 +1007,8 @@ mod tests {
     use coding_adventures_closure_pass_fold_control_flow::FoldControlFlowPass;
     use coding_adventures_closure_pass_pipeline::{PassPipeline, PipelineOutput};
     use coding_adventures_javascript_ast::{
-        statement::TaggedStatement, BinaryOperator, BooleanLiteral, EmptyStatement, Identifier,
-        NumericLiteral, SourceType, SwitchCase, SwitchStatement,
+        statement::TaggedStatement, BinaryOperator, BooleanLiteral, CatchClause, EmptyStatement,
+        Identifier, NumericLiteral, SourceType, SwitchCase, SwitchStatement, TryStatement,
     };
     use coding_adventures_javascript_tokens::EsVersion;
     use coding_adventures_type_sidecar::Sidecar;
@@ -2153,5 +2173,94 @@ mod tests {
         // through is_pure_leaf because we'd already have flagged
         // it).
         assert!(block.body.is_empty());
+    }
+
+    // ---- try / catch / finally (CLOC19) -----------------------
+
+    /// Helper: pull the single `TryStatement` out of a function body.
+    fn extract_try(block: &BlockStatement) -> &TryStatement {
+        let Statement::Tagged(TaggedStatement::TryStatement(t)) = &block.body[0] else {
+            panic!("expected a TryStatement at body[0], got {:?}", block.body[0]);
+        };
+        t
+    }
+
+    #[test]
+    fn dce_recurses_into_catch_body_and_drops_dead_after_return() {
+        // try { } catch (e) { return; foo(); }  — the `foo()` after the
+        // `return` inside the catch body is unreachable. DCE must recurse
+        // into the handler block and truncate it, while leaving the catch
+        // param `e` untouched.
+        let try_stmt = Statement::try_statement(TryStatement {
+            cv: None,
+            block: BlockStatement {
+                cv: None,
+                body: vec![],
+            },
+            handler: Some(CatchClause {
+                cv: None,
+                param: Some(Identifier {
+                    cv: None,
+                    name: "e".to_string(),
+                }),
+                body: BlockStatement {
+                    cv: None,
+                    body: vec![return_stmt(), expr_stmt(ident("foo"))],
+                },
+            }),
+            finalizer: None,
+        });
+        let prog = program_with_function(vec![try_stmt], Some("fn.1"));
+        let (out, _, changed, _) = run_pass(prog);
+        assert!(changed, "DCE should report a change (dropped dead foo())");
+
+        let block = extract_function_body(&out);
+        let t = extract_try(block);
+        let handler = t.handler.as_ref().expect("handler preserved");
+        assert_eq!(
+            handler.param.as_ref().map(|p| p.name.as_str()),
+            Some("e"),
+            "catch param must be preserved verbatim",
+        );
+        assert_eq!(
+            handler.body.body.len(),
+            1,
+            "dead-after-return inside catch body must be truncated to just the return",
+        );
+        assert!(
+            matches!(
+                &handler.body.body[0],
+                Statement::Tagged(TaggedStatement::ReturnStatement(_))
+            ),
+            "the surviving statement must be the return",
+        );
+    }
+
+    #[test]
+    fn dce_does_not_treat_try_as_a_terminator() {
+        // try { } finally { }  followed by a reachable statement: the
+        // `after()` call must survive, because a `try` can catch and
+        // continue — it is NOT an unconditional terminator.
+        let try_stmt = Statement::try_statement(TryStatement {
+            cv: None,
+            block: BlockStatement {
+                cv: None,
+                body: vec![],
+            },
+            handler: None,
+            finalizer: Some(BlockStatement {
+                cv: None,
+                body: vec![],
+            }),
+        });
+        let prog = program_with_function(vec![try_stmt, expr_stmt(ident("after"))], Some("fn.1"));
+        let (out, _, _, _) = run_pass(prog);
+        let block = extract_function_body(&out);
+        assert_eq!(
+            block.body.len(),
+            2,
+            "the statement after a try/finally must remain reachable; got {:?}",
+            block.body,
+        );
     }
 }

--- a/code/packages/rust/closure-pass-fold-control-flow/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-fold-control-flow/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to the `coding-adventures-closure-pass-fold-control-flow` crate will be documented in this file.
 
+## [0.9.0] - 2026-06-20
+
+### Added — CLOC19: fold control flow inside `try`/`catch`/`finally`
+
+New `TryStatement` arm recurses control-flow folding through the protected
+block, the catch handler body, and the finalizer (each an ordinary block),
+preserving the catch `param`. The `try` itself is never treated as a terminator —
+it can catch and continue — so code after it stays reachable.
+
 ## [0.8.0] - 2026-06-04
 
 ### Added — CLOC12.37: var hoisting (gap-015)

--- a/code/packages/rust/closure-pass-fold-control-flow/Cargo.toml
+++ b/code/packages/rust/closure-pass-fold-control-flow/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-fold-control-flow"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 description = "Control-flow folding pass for the Closure Compiler clone. Slots between constant-fold and DCE per CLOC06's canonical pass set. Eliminates dead branches (`if (false) A else B → B`), removes unreachable code after `return`/`throw`, and collapses degenerate switch arms."
 

--- a/code/packages/rust/closure-pass-fold-control-flow/src/lib.rs
+++ b/code/packages/rust/closure-pass-fold-control-flow/src/lib.rs
@@ -289,6 +289,29 @@ fn fold_tagged_statement(stmt: &TaggedStatement, st: &mut FoldState) -> Statemen
                 },
             ))
         }
+        TaggedStatement::TryStatement(s) => {
+            // Recurse fold-control-flow into the protected block, catch body,
+            // and finalizer (each an ordinary block). The catch `param` is
+            // preserved. The `try` is not a terminator, so no control-flow
+            // peephole applies to the statement itself here.
+            Statement::Tagged(TaggedStatement::TryStatement(
+                coding_adventures_javascript_ast::TryStatement {
+                    cv: s.cv.clone(),
+                    block: fold_block_statement(&s.block, st),
+                    handler: s.handler.as_ref().map(|h| {
+                        coding_adventures_javascript_ast::CatchClause {
+                            cv: h.cv.clone(),
+                            param: h.param.clone(),
+                            body: fold_block_statement(&h.body, st),
+                        }
+                    }),
+                    finalizer: s
+                        .finalizer
+                        .as_ref()
+                        .map(|f| fold_block_statement(f, st)),
+                },
+            ))
+        }
         TaggedStatement::BreakStatement(_)
         | TaggedStatement::ContinueStatement(_)
         | TaggedStatement::EmptyStatement(_) => Statement::Tagged(stmt.clone()),

--- a/code/packages/rust/closure-pass-inline-variables/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-inline-variables/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to the `coding-adventures-closure-pass-inline-variables` crate will be documented in this file.
 
+## [0.2.0] - 2026-06-20
+
+### Added — CLOC19: variable inlining inside `try`/`catch`/`finally`
+
+`count_decl_names_stmt`, `count_uses_stmt`, and `propagate_in_stmt` now recurse
+through `TryStatement` (protected block, catch handler body, finalizer). The catch
+`param` is counted as a declared binding in `count_decl_names_stmt` so a candidate
+that shadows it is correctly excluded from propagation — preserving soundness when
+a top-level name is also bound by a catch clause.
+
 ## [0.1.0] - 2026-06-17
 
 ### Added (CLOC13.H — constant propagation)

--- a/code/packages/rust/closure-pass-inline-variables/Cargo.toml
+++ b/code/packages/rust/closure-pass-inline-variables/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-inline-variables"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "Constant-propagation pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Replaces references to a top-level `const` bound to a literal with the literal itself, so the binding becomes unused and remove-unused-vars deletes it."
 

--- a/code/packages/rust/closure-pass-inline-variables/src/lib.rs
+++ b/code/packages/rust/closure-pass-inline-variables/src/lib.rs
@@ -434,11 +434,32 @@ fn count_decl_names_stmt(
                     }
                 }
             }
+            TaggedStatement::TryStatement(ts) => {
+                // The catch `param` IS a binding — count it so it participates
+                // in the shadow guard (a top-level const sharing its name is
+                // not "uniquely declared"). Recurse into the three blocks.
+                for s in &ts.block.body {
+                    count_decl_names_stmt(s, out, nodes_touched);
+                }
+                if let Some(h) = &ts.handler {
+                    if let Some(param) = &h.param {
+                        *out.entry(param.name.clone()).or_insert(0) += 1;
+                    }
+                    for s in &h.body.body {
+                        count_decl_names_stmt(s, out, nodes_touched);
+                    }
+                }
+                if let Some(f) = &ts.finalizer {
+                    for s in &f.body {
+                        count_decl_names_stmt(s, out, nodes_touched);
+                    }
+                }
+            }
             // Statements that introduce no binding in the Phase-1 AST.
             // Exhaustive on purpose: a future binding-introducing
-            // statement (a `try`/`catch`, a `class` declaration) must be
-            // handled here so a shadowing name can't slip past the
-            // shadow guard. The compiler flags the omission.
+            // statement (a `class` declaration) must be handled here so a
+            // shadowing name can't slip past the shadow guard. The compiler
+            // flags the omission.
             TaggedStatement::ExpressionStatement(_)
             | TaggedStatement::ReturnStatement(_)
             | TaggedStatement::ThrowStatement(_)
@@ -542,6 +563,25 @@ fn count_uses_stmt(stmt: &Statement, name: &str, count: &mut usize) {
                         count_uses_expr(test, name, count);
                     }
                     for s in &c.consequent {
+                        count_uses_stmt(s, name, count);
+                    }
+                }
+            }
+            TaggedStatement::TryStatement(ts) => {
+                // Count `name` uses inside the three blocks. The catch `param`
+                // binding-site is not a use; references to it inside the body
+                // are counted by recursion (and a candidate can't share its
+                // name — the decl-count guard excludes that).
+                for s in &ts.block.body {
+                    count_uses_stmt(s, name, count);
+                }
+                if let Some(h) = &ts.handler {
+                    for s in &h.body.body {
+                        count_uses_stmt(s, name, count);
+                    }
+                }
+                if let Some(f) = &ts.finalizer {
+                    for s in &f.body {
                         count_uses_stmt(s, name, count);
                     }
                 }
@@ -729,6 +769,25 @@ fn propagate_in_stmt(stmt: &mut Statement, cand: &ConstCandidate) -> bool {
                         changed |= propagate_in_expr(test, cand);
                     }
                     for s in &mut c.consequent {
+                        changed |= propagate_in_stmt(s, cand);
+                    }
+                }
+            }
+            TaggedStatement::TryStatement(ts) => {
+                // Propagate into the three blocks. Sound because a candidate
+                // shadowed by a catch `param` of the same name is excluded
+                // upstream by the decl-count guard, so any `cand.name` use
+                // reached here truly resolves to the candidate.
+                for s in &mut ts.block.body {
+                    changed |= propagate_in_stmt(s, cand);
+                }
+                if let Some(h) = &mut ts.handler {
+                    for s in &mut h.body.body {
+                        changed |= propagate_in_stmt(s, cand);
+                    }
+                }
+                if let Some(f) = &mut ts.finalizer {
+                    for s in &mut f.body {
                         changed |= propagate_in_stmt(s, cand);
                     }
                 }

--- a/code/packages/rust/closure-pass-inline/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-inline/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to the `coding-adventures-closure-pass-inline` crate will be documented in this file.
 
+## [0.16.0] - 2026-06-20
+
+### Added — CLOC19: function inlining across `try`/`catch`/`finally`
+
+Every phase of the pass recurses through `TryStatement`:
+`count_decl_names_stmt`, `tally_stmt`, `inline_in_stmt`, `splice_void_in_stmt`,
+`splice_valued_in_stmt`, and `collect_used_idents_stmt` now descend into the
+protected block, catch handler body, and finalizer. The catch `param` is counted
+as a declared binding (the CLOC16 shadow-guard linchpin — every binding must be
+counted program-wide so shadowing is detected) and is added to the used-idents
+avoid set so inlined temporaries never collide with it. Calls inside try/catch
+blocks are now inlined like anywhere else.
+
 ## [0.15.0] - 2026-06-19
 
 ### Added (CLOC18 — parameter-mutation materialization)

--- a/code/packages/rust/closure-pass-inline/Cargo.toml
+++ b/code/packages/rust/closure-pass-inline/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-inline"
-version = "0.15.0"
+version = "0.16.0"
 edition = "2021"
 description = "Function-inlining pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Substitutes small or single-use function bodies at their call sites to enable downstream folding and shrink call overhead."
 

--- a/code/packages/rust/closure-pass-inline/src/lib.rs
+++ b/code/packages/rust/closure-pass-inline/src/lib.rs
@@ -580,12 +580,34 @@ fn count_decl_names_stmt(
                     }
                 }
             }
+            TaggedStatement::TryStatement(ts) => {
+                // Count the catch `param` as a program-wide binding so the
+                // exact-decl-count shadow guard (CLOC16 Slice B1) stays exact:
+                // a free body identifier resolving to a name ALSO bound by a
+                // catch param is multiply-declared, so it is not treated as
+                // unshadowable. Recurse into the three blocks.
+                for s in &ts.block.body {
+                    count_decl_names_stmt(s, out, nodes_touched);
+                }
+                if let Some(h) = &ts.handler {
+                    if let Some(param) = &h.param {
+                        *out.entry(param.name.clone()).or_insert(0) += 1;
+                    }
+                    for s in &h.body.body {
+                        count_decl_names_stmt(s, out, nodes_touched);
+                    }
+                }
+                if let Some(f) = &ts.finalizer {
+                    for s in &f.body {
+                        count_decl_names_stmt(s, out, nodes_touched);
+                    }
+                }
+            }
             // Statements that introduce no binding in the Phase-1 AST.
             // Exhaustive on purpose: a future binding-introducing
-            // statement (a `try`/`catch`, a `class` declaration) must be
-            // handled here so a shadowing name can't slip past the
-            // shadow guard and make an unsound inline. The compiler
-            // flags the omission.
+            // statement (a `class` declaration) must be handled here so a
+            // shadowing name can't slip past the shadow guard and make an
+            // unsound inline. The compiler flags the omission.
             TaggedStatement::ExpressionStatement(_)
             | TaggedStatement::ReturnStatement(_)
             | TaggedStatement::ThrowStatement(_)
@@ -773,6 +795,23 @@ fn tally_stmt(stmt: &Statement, cand: &InlineCandidate, t: &mut Tally) {
                         tally_expr(test, cand, t);
                     }
                     for s in &c.consequent {
+                        tally_stmt(s, cand, t);
+                    }
+                }
+            }
+            TaggedStatement::TryStatement(ts) => {
+                // Tally candidate uses / inlinable calls inside the three
+                // blocks — a call site can live in any of them.
+                for s in &ts.block.body {
+                    tally_stmt(s, cand, t);
+                }
+                if let Some(h) = &ts.handler {
+                    for s in &h.body.body {
+                        tally_stmt(s, cand, t);
+                    }
+                }
+                if let Some(f) = &ts.finalizer {
+                    for s in &f.body {
                         tally_stmt(s, cand, t);
                     }
                 }
@@ -979,6 +1018,22 @@ fn inline_in_stmt(stmt: &mut Statement, cand: &InlineCandidate) -> bool {
                         changed |= inline_in_expr(test, cand);
                     }
                     for s in &mut c.consequent {
+                        changed |= inline_in_stmt(s, cand);
+                    }
+                }
+            }
+            TaggedStatement::TryStatement(ts) => {
+                // Expression-inline call sites inside the three blocks.
+                for s in &mut ts.block.body {
+                    changed |= inline_in_stmt(s, cand);
+                }
+                if let Some(h) = &mut ts.handler {
+                    for s in &mut h.body.body {
+                        changed |= inline_in_stmt(s, cand);
+                    }
+                }
+                if let Some(f) = &mut ts.finalizer {
+                    for s in &mut f.body {
                         changed |= inline_in_stmt(s, cand);
                     }
                 }
@@ -1854,6 +1909,21 @@ fn splice_void_in_stmt(
                 }
                 changed
             }
+            TaggedStatement::TryStatement(ts) => {
+                // Splice the void target call in any of the three blocks'
+                // statement lists. Fresh-renamed locals avoid the catch param
+                // (it is in the `avoid` set via `collect_used_idents`).
+                let mut changed =
+                    splice_void_in_stmt_vec(&mut ts.block.body, cand, avoid, nodes_touched);
+                if let Some(h) = &mut ts.handler {
+                    changed |=
+                        splice_void_in_stmt_vec(&mut h.body.body, cand, avoid, nodes_touched);
+                }
+                if let Some(f) = &mut ts.finalizer {
+                    changed |= splice_void_in_stmt_vec(&mut f.body, cand, avoid, nodes_touched);
+                }
+                changed
+            }
             // Leaf / expression-only statements hold no nested statement
             // list to splice into. (A target call inside one of these — an
             // `ExpressionStatement` whose expression is NOT the bare call,
@@ -2674,6 +2744,20 @@ fn splice_valued_in_stmt(
                 }
                 changed
             }
+            TaggedStatement::TryStatement(ts) => {
+                // Value-capture splice within any of the three blocks.
+                let mut changed =
+                    splice_valued_in_stmt_vec(&mut ts.block.body, cand, avoid, nodes_touched);
+                if let Some(h) = &mut ts.handler {
+                    changed |=
+                        splice_valued_in_stmt_vec(&mut h.body.body, cand, avoid, nodes_touched);
+                }
+                if let Some(f) = &mut ts.finalizer {
+                    changed |=
+                        splice_valued_in_stmt_vec(&mut f.body, cand, avoid, nodes_touched);
+                }
+                changed
+            }
             TaggedStatement::ExpressionStatement(_)
             | TaggedStatement::ReturnStatement(_)
             | TaggedStatement::ThrowStatement(_)
@@ -2968,6 +3052,28 @@ fn collect_used_idents_stmt(stmt: &Statement, out: &mut HashSet<String>) {
                         collect_binding_idents_expr(test, out);
                     }
                     for s in &c.consequent {
+                        collect_used_idents_stmt(s, out);
+                    }
+                }
+            }
+            TaggedStatement::TryStatement(ts) => {
+                // The catch `param` MUST join the avoid set: a callee local
+                // alpha-renamed to a fresh name at a splice site inside the
+                // catch body must not collide with `param`. Recurse into the
+                // three blocks for every other used identifier.
+                for s in &ts.block.body {
+                    collect_used_idents_stmt(s, out);
+                }
+                if let Some(h) = &ts.handler {
+                    if let Some(param) = &h.param {
+                        out.insert(param.name.clone());
+                    }
+                    for s in &h.body.body {
+                        collect_used_idents_stmt(s, out);
+                    }
+                }
+                if let Some(f) = &ts.finalizer {
+                    for s in &f.body {
                         collect_used_idents_stmt(s, out);
                     }
                 }

--- a/code/packages/rust/closure-pass-rename-globals/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-rename-globals/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to the `coding-adventures-closure-pass-rename-globals` crate will be documented in this file.
 
+## [0.2.0] - 2026-06-20
+
+### Added — CLOC19: global renaming across `try`/`catch`/`finally` (catch-param soundness)
+
+`count_decl_names_stmt`, `collect_all_idents_stmt`, and `rename_apply_tagged`
+recurse through `TryStatement`. As in the local renamer, the catch `param` is
+counted as a declared binding and added to the avoid set, so a global rename can
+never produce a name that collides with a catch binding and the param itself is
+never rewritten.
+
 ## [0.1.0] - 2026-06-18
 
 ### Added (CLOC13.I — aggressive top-level / global renaming)

--- a/code/packages/rust/closure-pass-rename-globals/Cargo.toml
+++ b/code/packages/rust/closure-pass-rename-globals/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-rename-globals"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "Aggressive top-level (global) renaming pass for the Closure Compiler clone — the ADVANCED-level complement to closure-pass-rename. Shortens program-private top-level names, gated by an externs do-not-rename boundary."
 

--- a/code/packages/rust/closure-pass-rename-globals/src/lib.rs
+++ b/code/packages/rust/closure-pass-rename-globals/src/lib.rs
@@ -359,6 +359,28 @@ fn count_decl_names_stmt(
                     }
                 }
             }
+            TaggedStatement::TryStatement(ts) => {
+                // Count the catch `param` as a declared binding: a top-level
+                // global of the same name is then shadowed (count > 1) and the
+                // shadow guard skips renaming it — sound. Recurse into the
+                // three blocks for their declarations.
+                for s in &ts.block.body {
+                    count_decl_names_stmt(s, out, nodes_touched);
+                }
+                if let Some(h) = &ts.handler {
+                    if let Some(param) = &h.param {
+                        *out.entry(param.name.clone()).or_insert(0) += 1;
+                    }
+                    for s in &h.body.body {
+                        count_decl_names_stmt(s, out, nodes_touched);
+                    }
+                }
+                if let Some(f) = &ts.finalizer {
+                    for s in &f.body {
+                        count_decl_names_stmt(s, out, nodes_touched);
+                    }
+                }
+            }
             // No binding introduced in the Phase-1 AST. Exhaustive on
             // purpose: a future binding-introducing statement must be
             // handled here so a shadowing name can't slip past the guard.
@@ -482,6 +504,26 @@ fn collect_all_idents_stmt(stmt: &Statement, out: &mut HashSet<String>) {
             TaggedStatement::ContinueStatement(c) => {
                 if let Some(l) = &c.label {
                     out.insert(l.name.clone());
+                }
+            }
+            TaggedStatement::TryStatement(ts) => {
+                // Add the catch `param` to the avoid set so a renamed global
+                // never collides with it; recurse into the three blocks.
+                if let Some(h) = &ts.handler {
+                    if let Some(param) = &h.param {
+                        out.insert(param.name.clone());
+                    }
+                    for s in &h.body.body {
+                        collect_all_idents_stmt(s, out);
+                    }
+                }
+                for s in &ts.block.body {
+                    collect_all_idents_stmt(s, out);
+                }
+                if let Some(f) = &ts.finalizer {
+                    for s in &f.body {
+                        collect_all_idents_stmt(s, out);
+                    }
                 }
             }
             TaggedStatement::EmptyStatement(_) => {}
@@ -675,6 +717,25 @@ fn rename_apply_tagged(t: &mut TaggedStatement, map: &HashMap<String, String>) {
                     rename_apply_expr(test, map);
                 }
                 for s in &mut c.consequent {
+                    rename_apply_stmt(s, map);
+                }
+            }
+        }
+        TaggedStatement::TryStatement(ts) => {
+            // Rewrite renamed-global uses inside the three blocks. A global
+            // shadowed by the catch `param` was skipped by the shadow guard
+            // (not in `map`), so uses of the param resolve correctly and are
+            // left untouched; the param name itself is never a map key.
+            for s in &mut ts.block.body {
+                rename_apply_stmt(s, map);
+            }
+            if let Some(h) = &mut ts.handler {
+                for s in &mut h.body.body {
+                    rename_apply_stmt(s, map);
+                }
+            }
+            if let Some(f) = &mut ts.finalizer {
+                for s in &mut f.body {
                     rename_apply_stmt(s, map);
                 }
             }

--- a/code/packages/rust/closure-pass-rename-properties/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-rename-properties/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to the `coding-adventures-closure-pass-rename-properties` crate will be documented in this file.
 
+## [0.4.0] - 2026-06-20
+
+### Added — CLOC19: property renaming recurses through `try`/`catch`/`finally`
+
+`classify_stmt` and `rewrite_stmt` recurse through `TryStatement` so property
+accesses inside the protected block, catch handler, and finalizer are renamed
+consistently. No catch-param handling is required here: property renaming
+operates on member/key names, not variable bindings, so the catch `param` (a
+variable binding) is irrelevant to this pass.
+
 ## [0.3.0] - 2026-06-18
 
 ### Added (CLOC13.L — bundled DOM/host property boundary, `DOM_PROPERTIES`)

--- a/code/packages/rust/closure-pass-rename-properties/Cargo.toml
+++ b/code/packages/rust/closure-pass-rename-properties/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-rename-properties"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 description = "Aggressive property renaming pass for the Closure Compiler clone (ADVANCED-only). Consistently shortens program-private object property names that are never quoted/computed and not in the built-in or externs do-not-rename boundary."
 

--- a/code/packages/rust/closure-pass-rename-properties/src/lib.rs
+++ b/code/packages/rust/closure-pass-rename-properties/src/lib.rs
@@ -1042,6 +1042,24 @@ fn classify_stmt(stmt: &Statement, cls: &mut Classify, nodes_touched: &mut u32) 
                     }
                 }
             }
+            TaggedStatement::TryStatement(ts) => {
+                // Property renaming is variable-agnostic — recurse into the
+                // three blocks; the catch `param` is a variable binding, not a
+                // property, so nothing special is needed.
+                for s in &ts.block.body {
+                    classify_stmt(s, cls, nodes_touched);
+                }
+                if let Some(h) = &ts.handler {
+                    for s in &h.body.body {
+                        classify_stmt(s, cls, nodes_touched);
+                    }
+                }
+                if let Some(f) = &ts.finalizer {
+                    for s in &f.body {
+                        classify_stmt(s, cls, nodes_touched);
+                    }
+                }
+            }
             TaggedStatement::BreakStatement(_)
             | TaggedStatement::ContinueStatement(_)
             | TaggedStatement::EmptyStatement(_) => {}
@@ -1213,6 +1231,22 @@ fn rewrite_stmt(stmt: &mut Statement, map: &HashMap<String, String>) {
                         rewrite_expr(test, map);
                     }
                     for s in &mut c.consequent {
+                        rewrite_stmt(s, map);
+                    }
+                }
+            }
+            TaggedStatement::TryStatement(ts) => {
+                // Rewrite property accesses inside the three blocks.
+                for s in &mut ts.block.body {
+                    rewrite_stmt(s, map);
+                }
+                if let Some(h) = &mut ts.handler {
+                    for s in &mut h.body.body {
+                        rewrite_stmt(s, map);
+                    }
+                }
+                if let Some(f) = &mut ts.finalizer {
+                    for s in &mut f.body {
                         rewrite_stmt(s, map);
                     }
                 }

--- a/code/packages/rust/closure-pass-rename/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-rename/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 All notable changes to the `coding-adventures-closure-pass-rename` crate will be documented in this file.
 
+## [0.5.0] - 2026-06-20
+
+### Added — CLOC19: local renaming across `try`/`catch`/`finally` (catch-param soundness)
+
+The pass now recurses through `TryStatement` in every phase
+(`process_tagged`, `stmt_has_function`, `collect_decl_occurrences_stmt`,
+`collect_all_idents_stmt`, `rewrite_uses_tagged`), so local renames reach into the
+protected block, catch handler, and finalizer. The catch `param` is treated as a
+**reserved binding**:
+
+* it is collected as an INELIGIBLE occurrence (never itself renamed), and
+* it is added to the fresh-name avoid set, so no other local can be renamed to a
+  name that collides with it.
+
+A regression test pins the killer case: when the catch param is literally `a`,
+the function's own param is renamed to `b` (not `a`) — proving a generated short
+name never aliases the caught value. Without either guard the handler would
+miscompile.
+
 ## [0.4.0] - 2026-06-16
 
 ### Added — local variables, not just parameters

--- a/code/packages/rust/closure-pass-rename/Cargo.toml
+++ b/code/packages/rust/closure-pass-rename/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-rename"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 description = "Variable renaming pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Replaces non-exported binding names with shorter identifiers to reduce output size while preserving externally-visible names and semantics."
 

--- a/code/packages/rust/closure-pass-rename/src/lib.rs
+++ b/code/packages/rust/closure-pass-rename/src/lib.rs
@@ -284,6 +284,24 @@ fn process_tagged(t: &mut TaggedStatement, nodes_touched: &mut u32) -> bool {
                 }
             }
         }
+        TaggedStatement::TryStatement(ts) => {
+            // Drive leaf-function renaming into the three blocks so nested
+            // functions inside try/catch/finally are processed. The catch
+            // `param` is preserved.
+            for s in &mut ts.block.body {
+                changed |= process_stmt(s, nodes_touched);
+            }
+            if let Some(h) = &mut ts.handler {
+                for s in &mut h.body.body {
+                    changed |= process_stmt(s, nodes_touched);
+                }
+            }
+            if let Some(f) = &mut ts.finalizer {
+                for s in &mut f.body {
+                    changed |= process_stmt(s, nodes_touched);
+                }
+            }
+        }
         // No nested statements that could hold a function declaration.
         TaggedStatement::ExpressionStatement(_)
         | TaggedStatement::ReturnStatement(_)
@@ -351,6 +369,17 @@ fn stmt_has_function(stmt: &Statement) -> bool {
                 .cases
                 .iter()
                 .any(|c| c.consequent.iter().any(stmt_has_function)),
+            TaggedStatement::TryStatement(ts) => {
+                ts.block.body.iter().any(stmt_has_function)
+                    || ts
+                        .handler
+                        .as_ref()
+                        .is_some_and(|h| h.body.body.iter().any(stmt_has_function))
+                    || ts
+                        .finalizer
+                        .as_ref()
+                        .is_some_and(|f| f.body.iter().any(stmt_has_function))
+            }
             // Statements that cannot (in the Phase-1 AST) contain a
             // function declaration. Listed EXHAUSTIVELY on purpose: when
             // the AST grows a new scope-introducing construct (a class
@@ -562,12 +591,31 @@ fn collect_decl_occurrences_stmt(stmt: &Statement, out: &mut Vec<(String, bool)>
                     }
                 }
             }
+            TaggedStatement::TryStatement(ts) => {
+                // The catch `param` is a block-scoped binding (like a nested
+                // `let`): record it as INELIGIBLE so it is never renamed
+                // function-wide, and so a function-scoped `var` of the same
+                // name becomes a duplicate occurrence → skipped (ambiguous),
+                // which is the sound conservative outcome. Recurse into the
+                // three blocks as nested scopes (their `var`s remain eligible
+                // via `push_var_occurrences`; their `let`/`const` are
+                // block-scoped → ineligible).
+                collect_decl_occurrences(&ts.block, out, true);
+                if let Some(h) = &ts.handler {
+                    if let Some(param) = &h.param {
+                        out.push((param.name.clone(), false));
+                    }
+                    collect_decl_occurrences(&h.body, out, true);
+                }
+                if let Some(f) = &ts.finalizer {
+                    collect_decl_occurrences(f, out, true);
+                }
+            }
             // Statements that introduce no binding in the Phase-1 AST.
             // Exhaustive on purpose: a future binding-introducing
-            // statement (a `try`/`catch`, a `class` declaration) must be
-            // handled here, otherwise its name could shadow a local
-            // without our noticing and we'd rename unsoundly. The compiler
-            // will flag the omission.
+            // statement (a `class` declaration) must be handled here,
+            // otherwise its name could shadow a local without our noticing
+            // and we'd rename unsoundly. The compiler will flag the omission.
             TaggedStatement::ExpressionStatement(_)
             | TaggedStatement::ReturnStatement(_)
             | TaggedStatement::ThrowStatement(_)
@@ -687,6 +735,21 @@ fn collect_all_idents_stmt(stmt: &Statement, out: &mut HashSet<String>) {
             TaggedStatement::ContinueStatement(c) => {
                 if let Some(l) = &c.label {
                     out.insert(l.name.clone());
+                }
+            }
+            TaggedStatement::TryStatement(ts) => {
+                // Add the catch `param` to the avoid set so no renamed local
+                // can collide with it (it is itself left unrenamed). Recurse
+                // into the three blocks to collect every other identifier.
+                collect_all_idents_block(&ts.block, out);
+                if let Some(h) = &ts.handler {
+                    if let Some(param) = &h.param {
+                        out.insert(param.name.clone());
+                    }
+                    collect_all_idents_block(&h.body, out);
+                }
+                if let Some(f) = &ts.finalizer {
+                    collect_all_idents_block(f, out);
                 }
             }
             TaggedStatement::EmptyStatement(_) => {}
@@ -865,6 +928,18 @@ fn rewrite_uses_tagged(t: &mut TaggedStatement, map: &HashMap<String, String>) {
                 for s in &mut c.consequent {
                     rewrite_uses_stmt(s, map);
                 }
+            }
+        }
+        TaggedStatement::TryStatement(ts) => {
+            // Rewrite renamed-binding uses inside the three blocks. The catch
+            // `param` is never in `map` (it is not collected as a renameable),
+            // so its binding site and its uses are left untouched.
+            rewrite_uses_block(&mut ts.block, map);
+            if let Some(h) = &mut ts.handler {
+                rewrite_uses_block(&mut h.body, map);
+            }
+            if let Some(f) = &mut ts.finalizer {
+                rewrite_uses_block(f, map);
             }
         }
         // Labels (break/continue) live in a separate label namespace, not
@@ -1127,6 +1202,51 @@ mod tests {
         assert_eq!(
             rename_source("function f(longName) { return longName + 1; }"),
             "function f(a){return a + 1};"
+        );
+    }
+
+    // ---- catch-param soundness (CLOC19) -----------------------
+
+    #[test]
+    fn rewrites_param_use_inside_catch_body() {
+        // The param `longName` is used inside the catch handler. Renaming
+        // must reach into the catch body and rewrite the use, while the
+        // catch binding `e` is preserved verbatim (catch params are never
+        // in the local-rename set).
+        assert_eq!(
+            rename_source(
+                "function f(longName) { try { risky(); } catch (e) { return longName; } }"
+            ),
+            "function f(a){try{risky()}catch(e){return a}};"
+        );
+    }
+
+    #[test]
+    fn does_not_rename_catch_param_itself() {
+        // A long catch-binding name is NOT shortened — catch params are
+        // bindings the renamer treats as reserved, not locals to compress.
+        assert_eq!(
+            rename_source(
+                "function f(p) { try { risky(); } catch (longError) { report(longError); } }"
+            ),
+            // `p` is already 1 char (no byte savings), so it stays; the
+            // catch binding `longError` is reserved and stays verbatim too.
+            "function f(p){try{risky()}catch(longError){report(longError)}};"
+        );
+    }
+
+    #[test]
+    fn fresh_name_avoids_colliding_with_catch_param() {
+        // The killer case: the catch param is literally `a`, the name the
+        // allocator would otherwise hand to the function's own param. The
+        // soundness guard adds the catch param to the avoid set, so
+        // `longName` must become `b` (NOT `a`) — otherwise the renamed
+        // param would alias the caught value and miscompile `use(a, …)`.
+        assert_eq!(
+            rename_source(
+                "function f(longName) { try { risky(); } catch (a) { use(a, longName); } }"
+            ),
+            "function f(b){try{risky()}catch(a){use(a,b)}};"
         );
     }
 

--- a/code/packages/rust/closure-scope-analyzer/CHANGELOG.md
+++ b/code/packages/rust/closure-scope-analyzer/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to the `coding-adventures-closure-scope-analyzer` crate will be documented in this file.
 
+## [0.5.0] - 2026-06-20
+
+### Added — CLOC19: scope analysis for `try`/`catch`/`finally`
+
+`walk_tagged_statement` now handles `TryStatement`: it walks the protected
+block, opens a dedicated `ScopeKind::Block` scope for the catch handler and emits
+the catch `param` as a `BindingKind::Let` binding scoped to the handler body
+(catch params bind only within `catch { … }`, never the surrounding scope), then
+walks the handler body and the finalizer. This keeps the analyzer's binding model
+accurate for programs containing try/catch.
+
 ## [0.4.1] - 2026-06-16
 
 ### Docs

--- a/code/packages/rust/closure-scope-analyzer/Cargo.toml
+++ b/code/packages/rust/closure-scope-analyzer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-scope-analyzer"
-version = "0.4.1"
+version = "0.5.0"
 edition = "2021"
 description = "Lexical scope + symbol-table analyzer for the Closure Compiler clone. Per CLOC13 — produces a `ScopeAnalysis` consumed by the rename, inline, treeshake, collapse-properties, and remove-unused-vars passes."
 

--- a/code/packages/rust/closure-scope-analyzer/src/lib.rs
+++ b/code/packages/rust/closure-scope-analyzer/src/lib.rs
@@ -661,6 +661,36 @@ fn walk_tagged_statement(
                 }
             }
         }
+        TaggedStatement::TryStatement(ts) => {
+            // `try { block } catch (param) { body } finally { fin }`.
+            // The protected block and the finalizer are ordinary blocks. The
+            // catch clause introduces a `param` binding scoped to the catch
+            // body — modeled as a Block scope holding a (block-scoped) binding,
+            // walked with the param in scope.
+            walk_block_statement(&ts.block, ctx, analysis, pending);
+            if let Some(handler) = &ts.handler {
+                let catch_scope = emit_scope(ScopeKind::Block, ctx.current, analysis);
+                if let Some(param) = &handler.param {
+                    emit_binding(
+                        param.name.clone(),
+                        BindingKind::Let,
+                        catch_scope,
+                        param.cv.clone(),
+                        analysis,
+                    );
+                }
+                let catch_ctx = WalkCtx {
+                    current: catch_scope,
+                    enclosing_function: ctx.enclosing_function,
+                };
+                for stmt in &handler.body.body {
+                    walk_statement(stmt, catch_ctx, analysis, pending);
+                }
+            }
+            if let Some(finalizer) = &ts.finalizer {
+                walk_block_statement(finalizer, ctx, analysis, pending);
+            }
+        }
         TaggedStatement::BreakStatement(_) => {}
         TaggedStatement::ContinueStatement(_) => {}
         TaggedStatement::EmptyStatement(_) => {}

--- a/code/packages/rust/javascript-ast/CHANGELOG.md
+++ b/code/packages/rust/javascript-ast/CHANGELOG.md
@@ -2,6 +2,41 @@
 
 All notable changes to the `coding-adventures-javascript-ast` crate will be documented in this file.
 
+## [0.8.0] - 2026-06-20
+
+### Added — CLOC19: `TryStatement` + `CatchClause` (closes the try/catch coverage gap)
+
+Adds `TryStatement { cv, block, handler: Option<CatchClause>, finalizer: Option<BlockStatement> }`
+and `CatchClause { cv, param: Option<Identifier>, body: BlockStatement }`, a new
+`TaggedStatement::TryStatement` variant, and a `Statement::try_statement`
+convenience constructor. This makes `try`/`catch`/`finally` representable in the
+typed AST for the first time — previously any program containing `try` could not
+be lowered and the closurec CLI fell back to WHITESPACE_ONLY (zero optimization).
+
+ESTree wire format:
+
+```json
+{
+  "type": "TryStatement",
+  "block": <BlockStatement>,
+  "handler": { "type": "CatchClause", "param": <Identifier> | (absent), "body": <BlockStatement> } | (absent),
+  "finalizer": <BlockStatement> | (absent)
+}
+```
+
+`param` is absent for the ES2019 optional-catch-binding form (`catch { … }`).
+Destructuring catch params are intentionally not modelled — the bridge declines
+them rather than mis-binding (sound WHITESPACE_ONLY fallback at the CLI).
+
+### Fixed — serde double-tagging on `TryStatement`
+
+The initial `TryStatement` struct carried its own `#[serde(tag = "type")]` *and*
+was a variant of the internally-tagged `TaggedStatement` enum, which injects the
+tag from the variant name. The two tags collided and a serialized `TryStatement`
+failed to deserialize back into the untagged outer `Statement` enum. Removed the
+struct-level tag so it matches every sibling statement struct (only `rename_all`);
+added round-trip tests covering the full, optional-binding, and no-catch forms.
+
 ## [0.7.0] - 2026-06-04
 
 ### Added — CLOC12.33: `SwitchStatement` + `SwitchCase` (Phase 1.x, closes gap-014)

--- a/code/packages/rust/javascript-ast/Cargo.toml
+++ b/code/packages/rust/javascript-ast/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-javascript-ast"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
 description = "Backend-agnostic JavaScript AST — full ESTree-compatible node taxonomy with optional per-node CV id. Reusable by the Closure-Compiler-clone and the future V8-in-Rust clone. Per CLOC02 / CLOC09."
 

--- a/code/packages/rust/javascript-ast/src/lib.rs
+++ b/code/packages/rust/javascript-ast/src/lib.rs
@@ -140,9 +140,9 @@ pub use expression::{
     StringLiteral, UnaryExpression, UnaryOperator, UndefinedLiteral,
 };
 pub use statement::{
-    BlockStatement, BreakStatement, ContinueStatement, EmptyStatement, ExpressionStatement,
-    ForInit, ForStatement, IfStatement, LabeledStatement, ReturnStatement, Statement,
-    SwitchCase, SwitchStatement, ThrowStatement, WhileStatement,
+    BlockStatement, BreakStatement, CatchClause, ContinueStatement, EmptyStatement,
+    ExpressionStatement, ForInit, ForStatement, IfStatement, LabeledStatement, ReturnStatement,
+    Statement, SwitchCase, SwitchStatement, ThrowStatement, TryStatement, WhileStatement,
 };
 
 /// A correlation-vector identifier. Aliased to `String` for v1 to match

--- a/code/packages/rust/javascript-ast/src/statement.rs
+++ b/code/packages/rust/javascript-ast/src/statement.rs
@@ -24,9 +24,12 @@
 //!   collapses to the inner `{"type": "VariableDeclaration", ...}`
 //!   shape directly.
 //!
-//! Phase 2 will add `TryStatement`, `DoWhileStatement`,
-//! `ForInStatement`, `ForOfStatement`, `DebuggerStatement`, and
-//! `WithStatement`.
+//! - [`TryStatement`] + [`CatchClause`] (CLOC19 — `try`/`catch`/`finally`,
+//!   added to unblock the whitespace-only fallback on any program using
+//!   exception handling)
+//!
+//! Phase 2 will add `DoWhileStatement`, `ForInStatement`, `ForOfStatement`,
+//! `DebuggerStatement`, and `WithStatement`.
 
 use crate::declaration::{Declaration, VariableDeclaration};
 use crate::expression::{Expression, Identifier};
@@ -70,6 +73,7 @@ pub enum TaggedStatement {
     LabeledStatement(LabeledStatement),
     ThrowStatement(ThrowStatement),
     SwitchStatement(SwitchStatement),
+    TryStatement(TryStatement),
     EmptyStatement(EmptyStatement),
 }
 
@@ -108,6 +112,9 @@ impl Statement {
     }
     pub fn switch_statement(s: SwitchStatement) -> Self {
         Self::Tagged(TaggedStatement::SwitchStatement(s))
+    }
+    pub fn try_statement(s: TryStatement) -> Self {
+        Self::Tagged(TaggedStatement::TryStatement(s))
     }
     pub fn empty_statement(s: EmptyStatement) -> Self {
         Self::Tagged(TaggedStatement::EmptyStatement(s))
@@ -304,6 +311,53 @@ pub struct SwitchCase {
     /// `case expr:` form.
     pub test: Option<Expression>,
     pub consequent: Vec<Statement>,
+}
+
+/// `try { … } catch (e) { … } finally { … }` (CLOC19). ESTree shape:
+/// `block` is the protected block, `handler` is an optional [`CatchClause`],
+/// and `finalizer` is the optional `finally` block. The grammar guarantees at
+/// least one of `handler` / `finalizer` is present (a bare `try { }` is a
+/// SyntaxError), but the AST does not enforce that.
+///
+/// Control flow: the `block` runs; if it throws and a `handler` is present, the
+/// thrown value binds to the handler's `param` and the handler `body` runs; the
+/// `finalizer` (if any) always runs last, on every exit path. A `try` is
+/// therefore NOT an unconditional terminator — it can catch and continue.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+// NB: no self `#[serde(tag = "type")]` here. `TryStatement` is a variant of the
+// internally-tagged `TaggedStatement` enum, which injects `"type":
+// "TryStatement"` from the variant name. Adding a second `type` tag on the
+// struct itself double-tags it and breaks deserialization back into
+// `Statement` (the untagged outer enum) — every sibling statement struct
+// (IfStatement, SwitchStatement, …) likewise carries only `rename_all`.
+#[serde(rename_all = "camelCase")]
+pub struct TryStatement {
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub cv: Option<CvId>,
+    pub block: BlockStatement,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub handler: Option<CatchClause>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub finalizer: Option<BlockStatement>,
+}
+
+/// The `catch (param) { body }` arm of a [`TryStatement`].
+///
+/// - `param: Some(id)` — the bound identifier the thrown value is assigned to.
+///   (Destructuring catch params are not represented yet — the bridge declines
+///   them, falling back to whitespace-only, which is sound.)
+/// - `param: None` — the optional-catch-binding form `catch { … }` (ES2019).
+///
+/// The `param` is a binding scoped to `body` (and nowhere else). Passes that
+/// rename or remove bindings MUST treat it as such — see the per-pass handling.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "type", rename = "CatchClause", rename_all = "camelCase")]
+pub struct CatchClause {
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub cv: Option<CvId>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub param: Option<Identifier>,
+    pub body: BlockStatement,
 }
 
 /// A lone semicolon `;`. Rare in user code but legal everywhere a
@@ -661,6 +715,88 @@ mod tests {
         });
         let json = serde_json::to_string(&s).unwrap();
         assert!(!json.contains("\"cv\""), "expected no cv key; got {}", json);
+        assert_eq!(s.clone(), roundtrip(s));
+    }
+
+    // ---- try / catch / finally (CLOC19) -----------------------
+
+    /// Build `try { ; } catch (e) { ; } finally { ; }` with the catch
+    /// param `e` and a trivial body in each block.
+    fn full_try() -> TryStatement {
+        let one = || BlockStatement {
+            cv: None,
+            body: vec![Statement::empty_statement(EmptyStatement { cv: None })],
+        };
+        TryStatement {
+            cv: Some("try.1".to_string()),
+            block: one(),
+            handler: Some(CatchClause {
+                cv: Some("catch.1".to_string()),
+                param: Some(Identifier {
+                    cv: None,
+                    name: "e".to_string(),
+                }),
+                body: one(),
+            }),
+            finalizer: Some(one()),
+        }
+    }
+
+    #[test]
+    fn try_statement_full_roundtrips() {
+        let s = Statement::try_statement(full_try());
+        assert_eq!(type_tag(&s), "TryStatement");
+        assert_eq!(s.clone(), roundtrip(s));
+    }
+
+    #[test]
+    fn try_statement_optional_catch_binding_roundtrips() {
+        // `catch { … }` — handler present, param None.
+        let s = Statement::try_statement(TryStatement {
+            cv: None,
+            block: BlockStatement {
+                cv: None,
+                body: vec![],
+            },
+            handler: Some(CatchClause {
+                cv: None,
+                param: None,
+                body: BlockStatement {
+                    cv: None,
+                    body: vec![],
+                },
+            }),
+            finalizer: None,
+        });
+        let json = serde_json::to_string(&s).unwrap();
+        // An absent param must not serialize a `param` key (skip-if-none).
+        assert!(
+            !json.contains("\"param\""),
+            "optional-catch-binding should omit the param key; got {json}",
+        );
+        assert_eq!(s.clone(), roundtrip(s));
+    }
+
+    #[test]
+    fn try_finally_without_catch_roundtrips() {
+        // `try { } finally { }` — handler omitted entirely.
+        let s = Statement::try_statement(TryStatement {
+            cv: None,
+            block: BlockStatement {
+                cv: None,
+                body: vec![],
+            },
+            handler: None,
+            finalizer: Some(BlockStatement {
+                cv: None,
+                body: vec![],
+            }),
+        });
+        let json = serde_json::to_string(&s).unwrap();
+        assert!(
+            !json.contains("\"handler\""),
+            "absent handler should omit the key; got {json}",
+        );
         assert_eq!(s.clone(), roundtrip(s));
     }
 

--- a/code/packages/rust/javascript-parser/CHANGELOG.md
+++ b/code/packages/rust/javascript-parser/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to the `coding-adventures-javascript-parser` crate will be documented in this file.
 
+## [0.10.0] - 2026-06-20
+
+### Added — CLOC19: bridge `try_statement` → `TryStatement`
+
+`try_statement` no longer lands in the unsupported arm (which raised
+`UnsupportedSyntax` and forced a WHITESPACE_ONLY fallback at the CLI). New
+`convert_try_statement` reads the first `block` child and walks the remaining
+children for a `catch_clause` / `finally_clause`; `convert_catch_clause` extracts
+the single `NAME` token as the catch binding (or `None` for the ES2019
+optional-catch-binding form). The grammar restricts the catch binding to a simple
+`NAME`, so a destructuring catch param fails to parse or bridge and declines
+cleanly — it is never lowered to a fabricated simple identifier.
+
+Added structural bridge tests for the full `try/catch/finally`,
+optional-catch-binding, and `try/finally` (no catch) forms, plus a guard test
+that a destructuring catch param never mis-binds.
+
 ## [0.9.0] - 2026-06-19
 
 ### Fixed — assignment-expression statements failed to parse (CLOC17)

--- a/code/packages/rust/javascript-parser/Cargo.toml
+++ b/code/packages/rust/javascript-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-javascript-parser"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2021"
 description = "JavaScript parser — parses JavaScript source code against any ECMAScript edition (es1 through es2025) using the grammar-driven parser. Includes correlation-vector plumbing per CLOC03 and a typed-AST bridge (GrammarASTNode → javascript_ast::Program) per CLOC12.136."
 

--- a/code/packages/rust/javascript-parser/src/bridge.rs
+++ b/code/packages/rust/javascript-parser/src/bridge.rs
@@ -61,9 +61,9 @@ use coding_adventures_javascript_ast::{
         UndefinedLiteral,
     },
     statement::{
-        BlockStatement, BreakStatement, ContinueStatement, EmptyStatement,
+        BlockStatement, BreakStatement, CatchClause, ContinueStatement, EmptyStatement,
         ExpressionStatement, ForInit, ForStatement, IfStatement, LabeledStatement,
-        ReturnStatement, Statement, SwitchCase, SwitchStatement, ThrowStatement,
+        ReturnStatement, Statement, SwitchCase, SwitchStatement, ThrowStatement, TryStatement,
         WhileStatement,
     },
     Program, ProgramItem, SourceType,
@@ -273,9 +273,10 @@ fn convert_statement(node: &GrammarASTNode) -> Result<Statement, BridgeError> {
         "switch_statement" => convert_switch_statement(child).map(Statement::switch_statement),
         "labelled_statement" => convert_labeled_statement(child).map(Statement::labeled_statement),
         "throw_statement" => convert_throw_statement(child).map(Statement::throw_statement),
+        "try_statement" => convert_try_statement(child).map(Statement::try_statement),
         // Phase 2+ — not yet in the typed AST
         "do_while_statement" | "for_in_statement" | "for_of_statement"
-        | "for_await_of_statement" | "try_statement" | "with_statement"
+        | "for_await_of_statement" | "with_statement"
         | "debugger_statement" | "using_declaration" | "await_using_declaration" => {
             Err(unsupported(child))
         }
@@ -536,6 +537,76 @@ fn convert_labeled_statement(node: &GrammarASTNode) -> Result<LabeledStatement, 
         cv: None,
         label: Identifier { cv: None, name: label_name },
         body: Box::new(convert_statement(body_n)?),
+    })
+}
+
+// -------------------------------------------------------------------------
+// try_statement / catch_clause (CLOC19)
+// -------------------------------------------------------------------------
+
+fn convert_try_statement(node: &GrammarASTNode) -> Result<TryStatement, BridgeError> {
+    // try_statement = "try" block ( catch_clause [ finally_clause ]
+    //                             | finally_clause ) ;
+    // Groups flatten, so the Node children are, in order: the try `block`,
+    // then an optional `catch_clause` and/or `finally_clause`.
+    let children = node_children(node);
+    let block_n = children
+        .first()
+        .filter(|n| n.rule_name == "block")
+        .ok_or_else(|| internal(node, "try_statement: missing try block"))?;
+    let block = convert_block_statement(block_n)?;
+
+    let mut handler = None;
+    let mut finalizer = None;
+    for n in children.iter().skip(1) {
+        match n.rule_name.as_str() {
+            "catch_clause" => handler = Some(convert_catch_clause(n)?),
+            "finally_clause" => {
+                // finally_clause = "finally" block
+                let fb = node_children(n)
+                    .into_iter()
+                    .find(|c| c.rule_name == "block")
+                    .ok_or_else(|| internal(n, "finally_clause: missing block"))?;
+                finalizer = Some(convert_block_statement(fb)?);
+            }
+            _ => {}
+        }
+    }
+
+    Ok(TryStatement {
+        cv: None,
+        block,
+        handler,
+        finalizer,
+    })
+}
+
+fn convert_catch_clause(node: &GrammarASTNode) -> Result<CatchClause, BridgeError> {
+    // catch_clause = "catch" [ LPAREN NAME RPAREN ] block ;
+    // The grammar restricts the binding to a simple NAME (no destructuring),
+    // so the optional param is the single token that is neither the `catch`
+    // keyword nor a paren. Missing ⇒ the ES2019 optional-catch-binding form
+    // `catch { … }`.
+    let param = node.children.iter().find_map(|c| match c {
+        ASTNodeOrToken::Token(t)
+            if t.value != "catch" && t.value != "(" && t.value != ")" =>
+        {
+            Some(Identifier {
+                cv: None,
+                name: t.value.clone(),
+            })
+        }
+        _ => None,
+    });
+    let body_n = node_children(node)
+        .into_iter()
+        .find(|c| c.rule_name == "block")
+        .ok_or_else(|| internal(node, "catch_clause: missing body block"))?;
+    let body = convert_block_statement(body_n)?;
+    Ok(CatchClause {
+        cv: None,
+        param,
+        body,
     })
 }
 
@@ -2129,6 +2200,104 @@ mod tests {
                 coding_adventures_javascript_ast::statement::TaggedStatement::SwitchStatement(_)
             ))
         ));
+    }
+
+    // -----------------------------------------------------------------------
+    // try / catch / finally (CLOC19)
+    //
+    // The bridge maps the grammar's `try_statement` into the ESTree-shaped
+    // `TryStatement { block, handler, finalizer }`. Before CLOC19 the
+    // try_statement node landed in the unsupported arm, which raised
+    // `UnsupportedSyntax` and made closurec fall back to WHITESPACE_ONLY.
+    // These tests pin the structural conversion directly.
+    // -----------------------------------------------------------------------
+
+    /// Pull the single `TryStatement` out of a one-statement program.
+    fn bridge_try(src: &str) -> TryStatement {
+        let p = bridge_ok(src);
+        match &p.body[0] {
+            ProgramItem::Statement(Statement::Tagged(
+                coding_adventures_javascript_ast::statement::TaggedStatement::TryStatement(t),
+            )) => t.clone(),
+            other => panic!("expected a TryStatement, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn try_catch_bridge_shape() {
+        // `try { a(); } catch (e) { b(); }` — protected block + named
+        // handler, no finalizer.
+        let t = bridge_try("try { a(); } catch (e) { b(); }");
+        assert_eq!(t.block.body.len(), 1, "protected block has one statement");
+        let handler = t.handler.expect("handler present");
+        assert_eq!(
+            handler.param.as_ref().map(|p| p.name.as_str()),
+            Some("e"),
+            "catch binding is `e`",
+        );
+        assert_eq!(handler.body.body.len(), 1, "catch body has one statement");
+        assert!(t.finalizer.is_none(), "no finally clause");
+    }
+
+    #[test]
+    fn try_catch_finally_bridge_shape() {
+        // All three clauses present.
+        let t = bridge_try("try { a(); } catch (e) { b(); } finally { c(); }");
+        assert!(t.handler.is_some(), "handler present");
+        let fin = t.finalizer.expect("finalizer present");
+        assert_eq!(fin.body.len(), 1, "finally block has one statement");
+    }
+
+    #[test]
+    fn try_optional_catch_binding_bridge_shape() {
+        // ES2019 `catch { … }` — handler present, but `param` is None.
+        let t = bridge_try("try { a(); } catch { b(); }");
+        let handler = t.handler.expect("handler present");
+        assert!(
+            handler.param.is_none(),
+            "optional-catch-binding has no param",
+        );
+    }
+
+    #[test]
+    fn try_finally_without_catch_bridge_shape() {
+        // `try { … } finally { … }` — no handler at all.
+        let t = bridge_try("try { a(); } finally { c(); }");
+        assert!(t.handler.is_none(), "no catch handler");
+        assert!(t.finalizer.is_some(), "finally present");
+    }
+
+    #[test]
+    fn try_destructuring_catch_param_does_not_misbind() {
+        // A destructuring catch param (`catch ({ message })`) is not
+        // representable yet. The grammar restricts the catch binding to a
+        // simple NAME, so this either fails to parse outright or fails to
+        // bridge — both of which make the CLI fall back to WHITESPACE_ONLY,
+        // which is sound. What must NEVER happen is a TryStatement whose
+        // handler param is a fabricated simple identifier (silently
+        // dropping the destructuring), so we assert that explicitly.
+        let src = "try { a(); } catch ({ message }) { b(); }";
+        let Ok(node) = parse_javascript_typed(src, DEFAULT_ES_VERSION) else {
+            // Parse declined — sound fallback, nothing more to check.
+            return;
+        };
+        let Ok(p) = grammar_to_program(&node, DEFAULT_ES_VERSION) else {
+            // Bridge declined — sound fallback, nothing more to check.
+            return;
+        };
+        if let Some(ProgramItem::Statement(Statement::Tagged(
+            coding_adventures_javascript_ast::statement::TaggedStatement::TryStatement(t),
+        ))) = p.body.first()
+        {
+            assert!(
+                t.handler
+                    .as_ref()
+                    .map(|h| h.param.is_none())
+                    .unwrap_or(true),
+                "a destructuring catch param must not be lowered to a simple \
+                 identifier — that would silently mis-bind the caught value",
+            );
+        }
     }
 
     // -----------------------------------------------------------------------

--- a/code/programs/rust/closurec/CHANGELOG.md
+++ b/code/programs/rust/closurec/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 All notable changes to the `coding-adventures-closurec` binary will be documented in this file.
 
+## [0.152.0] - 2026-06-20
+
+### Added — CLOC19: end-to-end `try`/`catch`/`finally` support
+
+Programs containing `try`/`catch`/`finally` now route through the full typed-AST
+optimization pipeline at both SIMPLE and ADVANCED levels. Previously *any* `try`
+made the parse/bridge step decline, and closurec silently fell back to
+WHITESPACE_ONLY — emitting the input with only inter-token whitespace stripped,
+zero real optimization. This was closurec's single largest coverage gap.
+
+Now inlining, constant folding, dead-code elimination, and (under ADVANCED)
+local/global/property renaming all run inside the protected block, the catch
+handler, and the finalizer, while control flow and the catch binding are
+preserved. The implementation spans the AST (`TryStatement`/`CatchClause`), the
+parser bridge, the emitter, the scope analyzer, and every optimization pass; the
+crucial soundness property is that the catch parameter is treated as a reserved
+binding so renaming never aliases or rewrites the caught value.
+
+Two end-to-end diff fixtures pin the behaviour:
+
+* `simple-try-catch` — SIMPLE inlining + folding + DCE through try/catch/finally,
+  plus a regression guard that the output is NOT the whitespace fallback.
+* `advanced-try-catch-rename` — ADVANCED renaming with the catch binding `err`
+  preserved verbatim and never collided with a generated short name.
+
 ## [0.151.0] - 2026-06-19
 
 ### Fixed (CLOC17 — assignment statements no longer force whitespace-only fallback)

--- a/code/programs/rust/closurec/Cargo.toml
+++ b/code/programs/rust/closurec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closurec"
-version = "0.151.0"
+version = "0.152.0"
 edition = "2021"
 description = "closurec — CLI driver for the Closure Compiler clone. Mirrors the upstream Java Closure Compiler's command-line flag surface (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility. Per CLOC08."
 

--- a/code/programs/rust/closurec/cli.spec.json
+++ b/code/programs/rust/closurec/cli.spec.json
@@ -2,7 +2,7 @@
   "cli_builder_spec_version": "1.0",
   "name": "closurec",
   "description": "closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.",
-  "version": "0.151.0",
+  "version": "0.152.0",
   "parsing_mode": "gnu",
   "flags": [
     { "id": "browser_featureset_year", "long": "browser_featureset_year", "type": "integer", "default": 0, "description": "Shortcut for defining goog.FEATURESET_YEAR=YYYY (minimum 2012)." },

--- a/code/programs/rust/closurec/tests/diff/advanced-try-catch-rename/README.md
+++ b/code/programs/rust/closurec/tests/diff/advanced-try-catch-rename/README.md
@@ -1,0 +1,37 @@
+# Fixture: `advanced-try-catch-rename`
+
+End-to-end oracle for `--compilation_level ADVANCED` renaming soundness
+across a `catch` binding (CLOC19).
+
+| File | Role |
+|------|------|
+| `flags.txt` | CLI args: `--compilation_level ADVANCED --js input/a.js` |
+| `input/a.js` | A function whose body references its param inside a `try` block and references a local inside the `catch` body, with a catch param `err` |
+| `expected.stdout` | The renamed output (see below) |
+
+```text
+function c(a){var b;b=a + 1;try{compute(b)}catch(err){report(err,b)}return b};c(7);
+```
+
+This fixture pins the **catch-param-soundness** guarantee that makes
+ADVANCED renaming safe in the presence of `try`/`catch`:
+
+* `process` ⇒ `c`, `value` ⇒ `a`, `temp` ⇒ `b` — ordinary local/global
+  renaming.
+* The param use *inside the try block* is rewritten consistently
+  (`value + 1` ⇒ `a + 1`) and the local use *inside the catch body*
+  becomes `report(err, b)` — the rewrite reaches into both nested
+  blocks.
+* The catch binding **`err` is preserved verbatim**: it is never
+  renamed (catch params are not in the local-rename set) and no other
+  local is ever aliased onto it (the catch param joins the fresh-name
+  avoid set). If either guard were missing, `err` would collide with a
+  generated short name and miscompile the handler.
+
+Regenerate the expected file after an intentional behavior change:
+
+```sh
+cargo run -- --compilation_level ADVANCED \
+    --js tests/diff/advanced-try-catch-rename/input/a.js \
+    > tests/diff/advanced-try-catch-rename/expected.stdout
+```

--- a/code/programs/rust/closurec/tests/diff/advanced-try-catch-rename/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/advanced-try-catch-rename/expected.stdout
@@ -1,0 +1,1 @@
+function c(a){var b;b=a + 1;try{compute(b)}catch(err){report(err,b)}return b};c(7);

--- a/code/programs/rust/closurec/tests/diff/advanced-try-catch-rename/flags.txt
+++ b/code/programs/rust/closurec/tests/diff/advanced-try-catch-rename/flags.txt
@@ -1,0 +1,4 @@
+--compilation_level
+ADVANCED
+--js
+tests/diff/advanced-try-catch-rename/input/a.js

--- a/code/programs/rust/closurec/tests/diff/advanced-try-catch-rename/input/a.js
+++ b/code/programs/rust/closurec/tests/diff/advanced-try-catch-rename/input/a.js
@@ -1,0 +1,26 @@
+// ADVANCED-level renaming SOUNDNESS across a catch binding (CLOC19).
+//
+// The crux of try/catch support is that the catch parameter is a
+// declared binding that the renamer must treat as RESERVED:
+//
+//   1. It must never itself be renamed (catch params are not in the
+//      local-rename set), and
+//   2. No other local may be renamed to a name that collides with it
+//      (the catch param joins the fresh-name avoid set).
+//
+// Here `process` and its locals get short names (`process` -> `c`,
+// `value` -> `a`, `temp` -> `b`), the param use inside the try block is
+// rewritten consistently (`value + 1` -> `a + 1`), and the catch
+// binding `err` is preserved verbatim and never aliased to `a`/`b`/`c`.
+// `report(err, temp)` becomes `report(err, b)` — proving the rewrite
+// reaches into the catch body while leaving the catch param alone.
+function process(value) {
+  var temp = value + 1;
+  try {
+    compute(temp);
+  } catch (err) {
+    report(err, temp);
+  }
+  return temp;
+}
+process(7);

--- a/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
@@ -2,7 +2,7 @@
 
 closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.
 
-Version: 0.151.0
+Version: 0.152.0
 
 ## Flags
 

--- a/code/programs/rust/closurec/tests/diff/simple-try-catch/README.md
+++ b/code/programs/rust/closurec/tests/diff/simple-try-catch/README.md
@@ -1,0 +1,35 @@
+# Fixture: `simple-try-catch`
+
+End-to-end oracle for `--compilation_level SIMPLE` optimization through a
+`try`/`catch`/`finally` statement (CLOC19).
+
+| File | Role |
+|------|------|
+| `flags.txt` | CLI args: `--compilation_level SIMPLE --js input/a.js` |
+| `input/a.js` | A single-use function, plus a `try`/`catch (e)`/`finally` whose blocks hold foldable arithmetic and dead-code-after-`return` |
+| `expected.stdout` | The optimized output (see below) |
+
+```text
+report(1);try{var x=3;risky(x)}catch(e){var y=12;handle(e,y);return}finally{cleanup()}
+```
+
+What this proves now runs **inside** try/catch/finally — none of which
+was reachable before CLOC19 (any `try` forced a WHITESPACE_ONLY
+fallback):
+
+* **Inlining** — `log` is single-use, so `log(1)` becomes `report(1)`
+  and the declaration is deleted.
+* **Constant folding** — `1 + 2` ⇒ `3` and `3 * 4` ⇒ `12` even though
+  they sit inside the `try` and `catch` blocks.
+* **Dead-code elimination** — `dead(99)` after the `return` in the catch
+  handler is unreachable and gets truncated.
+* **Control-flow preservation** — `try`, `catch (e)`, and `finally`
+  survive verbatim; the catch binding `e` is untouched.
+
+Regenerate the expected file after an intentional behavior change:
+
+```sh
+cargo run -- --compilation_level SIMPLE \
+    --js tests/diff/simple-try-catch/input/a.js \
+    > tests/diff/simple-try-catch/expected.stdout
+```

--- a/code/programs/rust/closurec/tests/diff/simple-try-catch/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/simple-try-catch/expected.stdout
@@ -1,0 +1,1 @@
+report(1);try{var x=3;risky(x)}catch(e){var y=12;handle(e,y);return}finally{cleanup()}

--- a/code/programs/rust/closurec/tests/diff/simple-try-catch/flags.txt
+++ b/code/programs/rust/closurec/tests/diff/simple-try-catch/flags.txt
@@ -1,0 +1,4 @@
+--compilation_level
+SIMPLE
+--js
+tests/diff/simple-try-catch/input/a.js

--- a/code/programs/rust/closurec/tests/diff/simple-try-catch/input/a.js
+++ b/code/programs/rust/closurec/tests/diff/simple-try-catch/input/a.js
@@ -1,0 +1,31 @@
+// SIMPLE-level optimization THROUGH a try/catch/finally (CLOC19).
+//
+// Before CLOC19, *any* program containing `try` failed the typed-AST
+// parse (TryStatement was unrepresentable) and closurec silently fell
+// back to WHITESPACE_ONLY — zero optimization. This fixture is the
+// end-to-end oracle proving the SIMPLE pipeline now runs every pass
+// INSIDE the try block, the catch handler, and the finally block:
+//
+//   * `log` is single-use, so the inliner folds `log(1)` into its body
+//     `report(1)` and deletes the now-unused declaration.
+//   * `1 + 2` and `3 * 4` are constant-folded to `3` and `12` even
+//     though they live inside the try/catch blocks.
+//   * The `dead(99)` call after the `return` in the catch handler is
+//     unreachable, so block-level DCE truncates it.
+//   * `try`, `catch (e)`, and `finally` survive verbatim — control
+//     flow is never altered; the catch binding `e` is preserved.
+function log(p) {
+  report(p);
+}
+log(1);
+try {
+  var x = 1 + 2;
+  risky(x);
+} catch (e) {
+  var y = 3 * 4;
+  handle(e, y);
+  return;
+  dead(99);
+} finally {
+  cleanup();
+}

--- a/code/programs/rust/closurec/tests/diff_advanced_try_catch_rename.rs
+++ b/code/programs/rust/closurec/tests/diff_advanced_try_catch_rename.rs
@@ -1,0 +1,74 @@
+//! Integration test for the `tests/diff/advanced-try-catch-rename/`
+//! fixture.
+//!
+//! Exercises `--compilation_level ADVANCED` renaming SOUNDNESS across a
+//! `catch` binding (CLOC19). The catch parameter is a declared binding
+//! that the renamer must treat as reserved: it is never itself renamed,
+//! and no other local may be renamed onto it. This fixture pins both
+//! halves of that guarantee end-to-end.
+//!
+//! `process`/`value`/`temp` get short names (`c`/`a`/`b`), the param use
+//! inside the `try` block and the local use inside the `catch` body are
+//! both rewritten, and the catch binding `err` is preserved verbatim
+//! and never aliased to a generated name.
+
+use std::process::Command;
+
+const BINARY: &str = env!("CARGO_BIN_EXE_closurec");
+
+fn read_flags() -> Vec<String> {
+    let raw = std::fs::read_to_string("tests/diff/advanced-try-catch-rename/flags.txt")
+        .expect("read flags.txt");
+    raw.lines()
+        .filter(|l| !l.is_empty())
+        .map(|s| s.to_string())
+        .collect()
+}
+
+#[test]
+fn advanced_try_catch_rename_fixture_matches_expected_stdout() {
+    let flags = read_flags();
+    let out = Command::new(BINARY)
+        .args(&flags)
+        .output()
+        .expect("run closurec");
+
+    assert!(
+        out.status.success(),
+        "exit: {:?}, stderr: {}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stderr),
+    );
+
+    let actual = String::from_utf8_lossy(&out.stdout);
+    let expected = std::fs::read_to_string("tests/diff/advanced-try-catch-rename/expected.stdout")
+        .expect("read expected.stdout");
+    assert_eq!(
+        actual.trim_end_matches('\n'),
+        expected.trim_end_matches('\n'),
+        "mismatch.\nflags: {flags:?}\nactual:\n{actual}\nexpected:\n{expected}",
+    );
+}
+
+/// Explicit soundness assertion, independent of the exact short names
+/// the renamer happens to choose: the catch binding `err` must survive
+/// verbatim, and the rewritten body must reference it (`report(err,…)`),
+/// proving no generated name ever shadows or overwrites the handler's
+/// caught value.
+#[test]
+fn advanced_try_catch_rename_preserves_catch_binding() {
+    let out = Command::new(BINARY)
+        .args(read_flags())
+        .output()
+        .expect("run closurec");
+    let actual = String::from_utf8_lossy(&out.stdout);
+
+    assert!(
+        actual.contains("catch(err)"),
+        "catch parameter `err` must be preserved verbatim; got:\n{actual}",
+    );
+    assert!(
+        actual.contains("report(err,"),
+        "catch body must still reference the caught `err`; got:\n{actual}",
+    );
+}

--- a/code/programs/rust/closurec/tests/diff_simple_try_catch.rs
+++ b/code/programs/rust/closurec/tests/diff_simple_try_catch.rs
@@ -1,0 +1,83 @@
+//! Integration test for the `tests/diff/simple-try-catch/` fixture.
+//!
+//! Exercises `--compilation_level SIMPLE` optimization THROUGH a
+//! `try`/`catch`/`finally` statement (CLOC19). Before CLOC19, any
+//! program containing `try` failed the typed-AST parse and closurec
+//! fell back to WHITESPACE_ONLY (zero optimization). This fixture is
+//! the end-to-end oracle proving every SIMPLE pass now runs inside the
+//! try block, the catch handler, and the finally block:
+//!
+//! ```text
+//! source ──parse──▶ grammar AST ──bridge──▶ typed Program (w/ TryStatement)
+//!        ──passes──▶ optimized Program ──emit──▶ JS text
+//! ```
+//!
+//! Specifically: `log(1)` is inlined to `report(1)`, the foldable
+//! arithmetic inside the try/catch blocks (`1 + 2`, `3 * 4`) collapses,
+//! the unreachable `dead(99)` after the catch's `return` is dropped,
+//! and `try`/`catch (e)`/`finally` (including the catch binding `e`)
+//! survive verbatim.
+
+use std::process::Command;
+
+const BINARY: &str = env!("CARGO_BIN_EXE_closurec");
+
+fn read_flags() -> Vec<String> {
+    let raw =
+        std::fs::read_to_string("tests/diff/simple-try-catch/flags.txt").expect("read flags.txt");
+    raw.lines()
+        .filter(|l| !l.is_empty())
+        .map(|s| s.to_string())
+        .collect()
+}
+
+#[test]
+fn simple_try_catch_fixture_matches_expected_stdout() {
+    let flags = read_flags();
+    let out = Command::new(BINARY)
+        .args(&flags)
+        .output()
+        .expect("run closurec");
+
+    assert!(
+        out.status.success(),
+        "exit: {:?}, stderr: {}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stderr),
+    );
+
+    let actual = String::from_utf8_lossy(&out.stdout);
+    let expected = std::fs::read_to_string("tests/diff/simple-try-catch/expected.stdout")
+        .expect("read expected.stdout");
+    assert_eq!(
+        actual.trim_end_matches('\n'),
+        expected.trim_end_matches('\n'),
+        "mismatch.\nflags: {flags:?}\nactual:\n{actual}\nexpected:\n{expected}",
+    );
+}
+
+/// Regression guard: the output must NOT be the WHITESPACE_ONLY
+/// fallback. If try/catch ever stops being representable in the typed
+/// AST, the fixture above would still "pass" against a regenerated
+/// expected file, so we additionally assert that an optimization that
+/// can ONLY come from the typed pipeline (the `log` -> `report` inline)
+/// is present, and the original `function log` declaration is gone.
+#[test]
+fn simple_try_catch_did_not_fall_back_to_whitespace_only() {
+    let out = Command::new(BINARY)
+        .args(read_flags())
+        .output()
+        .expect("run closurec");
+    let actual = String::from_utf8_lossy(&out.stdout);
+
+    assert!(
+        actual.contains("report(1)"),
+        "expected the single-use `log` to be inlined into `report(1)` \
+         (proving the typed pipeline ran, not the whitespace fallback); \
+         got:\n{actual}",
+    );
+    assert!(
+        !actual.contains("function log"),
+        "expected the inlined `log` declaration to be removed; got:\n{actual}",
+    );
+}

--- a/code/specs/CLOC19-try-catch.md
+++ b/code/specs/CLOC19-try-catch.md
@@ -1,0 +1,134 @@
+# CLOC19 — `try` / `catch` / `finally` end-to-end
+
+> **Status:** Shipped. AST node, parser bridge, emitter, scope analyzer, and
+> every optimization pass handle `try`/`catch`/`finally`. Two end-to-end diff
+> fixtures (`simple-try-catch`, `advanced-try-catch-rename`) pin the behaviour at
+> the CLI.
+
+## Why this spec exists
+
+`try`/`catch`/`finally` was closurec's single largest correctness/coverage gap.
+The grammar already *parsed* try statements, but the typed AST had no node to
+represent them, so the parser→typed-AST **bridge** declined (`UnsupportedSyntax`)
+and the CLI fell back to **`WHITESPACE_ONLY`**: it emitted the source with only
+inter-token whitespace stripped and applied **zero** real optimization. Any
+real-world JavaScript bundle uses `try`/`catch`, so this fallback meant closurec
+effectively no-op'd on most realistic inputs.
+
+CLOC19 closes that gap by making try/catch a first-class statement that flows
+through the entire pipeline:
+
+```text
+source ──parse──▶ grammar AST ──bridge──▶ typed Program (TryStatement)
+       ──passes──▶ optimized Program ──emit──▶ JS text
+```
+
+## The AST node (`coding-adventures-javascript-ast`)
+
+ESTree-shaped, mirroring the structure every JS tool expects:
+
+```rust
+pub struct TryStatement {
+    pub cv: Option<CvId>,
+    pub block: BlockStatement,            // the protected block
+    pub handler: Option<CatchClause>,     // the `catch` arm (optional)
+    pub finalizer: Option<BlockStatement>,// the `finally` block (optional)
+}
+
+pub struct CatchClause {
+    pub cv: Option<CvId>,
+    pub param: Option<Identifier>,        // None = ES2019 `catch { … }`
+    pub body: BlockStatement,
+}
+```
+
+A new `TaggedStatement::TryStatement` variant and a `Statement::try_statement`
+constructor expose it. The grammar guarantees at least one of `handler` /
+`finalizer` is present (a bare `try {}` is a SyntaxError), but the AST does not
+enforce that — it models what the parser produces.
+
+**Serde note (a bug fixed during implementation):** `TryStatement` must NOT carry
+its own `#[serde(tag = "type")]`. It is a variant of the internally-tagged
+`TaggedStatement` enum, which already injects `"type": "TryStatement"` from the
+variant name. A second struct-level tag double-tags the node and breaks
+deserialization back into the untagged outer `Statement` enum. Every sibling
+statement struct carries only `rename_all`; `TryStatement` follows suit.
+`CatchClause` (a nested struct, not an enum variant) keeps its own
+`tag = "type"`, exactly like `SwitchCase`.
+
+## The bridge (`coding-adventures-javascript-parser`)
+
+`try_statement` routes to `convert_try_statement`, which takes the first node
+child as the `block` and walks the remaining children for a `catch_clause` /
+`finally_clause`. `convert_catch_clause` reads the single `NAME` token as the
+catch binding (`param`), or `None` for the optional-catch-binding form.
+
+The grammar restricts the catch binding to a simple `NAME`, so a **destructuring**
+catch param (`catch ({ message }) { … }`) cannot parse/bridge into a
+`TryStatement` — it declines, which surfaces as `WHITESPACE_ONLY` at the CLI. This
+is the sound choice: a destructuring binding must never be silently lowered to a
+fabricated simple identifier.
+
+## The emitter (`coding-adventures-closure-emitter`)
+
+`emit_try` writes `try <block> [ catch [(param)] <block> ] [ finally <block> ]`.
+No inter-token separator (`required_ws`) is needed anywhere: every boundary is
+keyword↔`{`/`}` or `}`↔keyword (`try{…}catch{…}`, `}finally{…}`), all of which
+lex cleanly with no space. Pretty mode adds readability spaces; the
+optional-catch-binding form emits `catch{…}` with no parens.
+
+## The catch-param soundness rule (the crux)
+
+The catch parameter is a binding scoped to the handler body and **nowhere else**.
+Every pass that renames or removes bindings MUST treat it as such. Concretely:
+
+1. **It is never renamed.** Renaming passes collect the catch param as an
+   *ineligible* declaration occurrence — it stays in the output verbatim.
+2. **Nothing is renamed onto it.** The catch param joins the fresh-name **avoid
+   set**, so no generated short name can collide with it.
+3. **It is counted as a declared binding** in every `count_decl_names_*` /
+   shadow-guard tally, so a free identifier elsewhere that is also bound by a
+   catch clause is correctly treated as shadowed (CLOC16 linchpin).
+4. **A `try` is not a terminator.** It can catch and continue, so DCE/control-flow
+   passes keep statements *after* a try/catch reachable.
+
+If either of (1)/(2) is missing, a generated short name can alias the caught
+value and miscompile the handler. The regression test
+`fresh_name_avoids_colliding_with_catch_param` pins the killer case: with a catch
+param literally named `a`, the function's own param renames to `b`, not `a`.
+
+### Per-pass handling
+
+| Pass                          | What it does for `TryStatement` |
+|-------------------------------|----------------------------------|
+| `constant-fold`               | recurse fold into block/handler.body/finalizer |
+| `fold-control-flow`           | recurse fold into the three blocks |
+| `dce`                         | recurse DCE; dead-after-terminator inside blocks; `try` is not a terminator |
+| `inline-variables`            | recurse; count catch param as a binding (shadow guard) |
+| `inline`                      | recurse all phases; count catch param (CLOC16 shadow-guard); add to used-idents avoid set |
+| `rename`                      | recurse; catch param reserved (ineligible + avoid set) |
+| `rename-globals`              | recurse; catch param reserved (counted + avoid set) |
+| `rename-properties`           | recurse only — properties ≠ variable bindings, so the catch param is irrelevant |
+
+The scope analyzer (`closure-scope-analyzer`) emits a `ScopeKind::Block` scope for
+the handler and a `BindingKind::Let` binding for the catch param.
+
+## End-to-end oracles (`closurec` diff fixtures)
+
+* **`simple-try-catch`** — at SIMPLE: a single-use function inlines, arithmetic
+  inside the try/catch blocks folds, dead-code after a `return` in the catch is
+  dropped, and `try`/`catch (e)`/`finally` survive verbatim. A companion
+  assertion proves the output is NOT the whitespace fallback (the `log` ⇒
+  `report` inline can only come from the typed pipeline).
+* **`advanced-try-catch-rename`** — at ADVANCED: `process`/`value`/`temp` get
+  short names, uses inside both the try block and the catch body are rewritten,
+  and the catch binding `err` is preserved verbatim and never aliased to a
+  generated name.
+
+## Out of scope (future work)
+
+* Destructuring catch params (`catch ({ message })`) — currently decline to
+  `WHITESPACE_ONLY`; modelling them needs a `BindingTarget` catch param.
+* Optimizations that *reason about* exceptional control flow (e.g. proving a
+  `try` block can't throw and unwrapping it) — CLOC19 only makes try/catch
+  *transparent* to the existing passes; it does not add try-specific rewrites.


### PR DESCRIPTION
## Summary

Adds first-class **`try`/`catch`/`finally`** support to closurec, closing its single largest coverage gap. Previously *any* program containing `try` made the parser→typed-AST bridge decline (the AST couldn't represent a try statement), and the CLI silently fell back to `WHITESPACE_ONLY` — stripping only inter-token whitespace and applying **zero** real optimization. Since essentially all real-world JavaScript uses exception handling, closurec effectively no-op'd on most realistic input. Now the full optimization pipeline runs **inside** try/catch/finally at both SIMPLE and ADVANCED levels.

```
function log(p){report(p);} log(1);
try { var x = 1 + 2; risky(x); }
catch (e) { var y = 3 * 4; handle(e, y); return; dead(99); }
finally { cleanup(); }
```
⟶ `report(1);try{var x=3;risky(x)}catch(e){var y=12;handle(e,y);return}finally{cleanup()}`

(log inlined, arithmetic folded inside the blocks, dead-after-`return` dropped, control flow + catch binding preserved.)

## What changed (whole pipeline)

| Layer | Change |
|-------|--------|
| `javascript-ast` | New `TryStatement` + `CatchClause` nodes, `TaggedStatement::TryStatement` variant, `Statement::try_statement` ctor. **Fixes a serde double-tagging bug** (a struct-level `tag="type"` on an internally-tagged enum variant broke deserialization back into the untagged `Statement`). |
| `javascript-parser` | Bridge `try_statement` → `TryStatement`; destructuring catch params decline cleanly instead of mis-binding. |
| `closure-emitter` | `emit_try` — clean token boundaries (`try{…}catch(e){…}finally{…}`), pretty-mode spacing, optional-catch-binding. |
| `closure-scope-analyzer` | Catch param bound in a fresh `Block` scope. |
| All 8 passes | constant-fold, fold-control-flow, dce, inline-variables, inline, rename, rename-globals, rename-properties recurse into block/handler/finalizer. |

## Catch-param soundness (the crux)

The catch parameter is a binding scoped only to the handler. It is treated as **reserved** everywhere: never renamed, counted in every shadow-guard tally, and added to the fresh-name avoid set — so a generated short name can never alias or overwrite the caught value. A `try` is also explicitly **not** a terminator (a catch can swallow and continue), so DCE keeps code after a try/catch reachable.

Killer regression test: with the catch param literally named `a`, the function's own param renames to **`b`**, not `a` (`function f(longName){try{risky()}catch(a){use(a,longName)}}` ⟶ `function f(b){try{risky()}catch(a){use(a,b)}}`).

## Tests

- **javascript-ast**: serde round-trips (full / optional-binding / try-finally) — these caught the double-tag bug.
- **javascript-parser**: structural bridge tests for all four forms + destructuring-decline guard.
- **closure-emitter**: token-boundary, optional-binding, no-catch, pretty-mode tests.
- **closure-pass-dce**: dead-after-`return`-inside-catch truncation + try-is-not-a-terminator.
- **closure-pass-rename**: catch-param-not-renamed, use-rewritten-in-catch-body, and the collision-avoidance killer case.
- **closurec**: two end-to-end diff fixtures (`simple-try-catch`, `advanced-try-catch-rename`) with **whitespace-fallback regression guards**.

Full closurec suite **720/720 green**; every touched pass crate green. An adversarial inline security review (focused on catch-param soundness across all renaming passes + emitter token separation) passed.

## Bookkeeping

Spec: `code/specs/CLOC19-try-catch.md`. Version bumps + CHANGELOG entries for all 13 touched crates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)