### PR TITLE
feat(mycin-2026): primary-source backfills round 2 — PBC→AMA, UC→crypt abscesses

### DIFF
--- a/code/specs/data/mycin-2026/USMLE-DOMAIN-MAP.md
+++ b/code/specs/data/mycin-2026/USMLE-DOMAIN-MAP.md
@@ -109,12 +109,12 @@ unchanged. Adding a relation just widens the schema — the engine already binds
 | Pharmacology | Pharmacology | drug_class, mechanism, adverse_effect, antidote_for | 10 grounded (ADJ-only) | ✓ |
 | Immunology | Immunology | mediated_by, associated_hla, gene_defect, deficiency_of | 7 grounded (ADJ-only) | ✓ |
 | Genetics | Genetics | inheritance, gene_defect, trinucleotide_repeat, imprinting | 10 grounded (ADJ-only) | ✓ |
-| Rheumatology (Tier-2) | Path/Immuno | associated_autoantibody | 9 grounded (ADJ-only) | ✓ |
+| Rheumatology (Tier-2) | Path/Immuno | associated_autoantibody | 10 grounded (ADJ-only) | ✓ |
 | Oncology (Tier-2) | Pathology/neoplasia | tumor_marker | 5 grounded (ADJ-only) | ✓ |
 | Histology buzzwords (Tier-2) | Pathology | seen_in (finding→condition) | 7 grounded (ADJ-only) | ✓ |
 | Cardiology murmurs (Tier-2) | Cardiology | murmur_indicates (murmur→lesion) | 5 grounded (ADJ-only) | ✓ |
 | Neurology localization (Tier-2) | Neurology | lesion_causes (site→deficit) | 5 grounded (ADJ-only) | ✓ |
-| GI biopsy (Tier-2) | Gastroenterology | biopsy_finding_in (finding→dx) | 5 grounded (ADJ-only) | ✓ |
+| GI biopsy (Tier-2) | Gastroenterology | biopsy_finding_in (finding→dx) | 6 grounded (ADJ-only) | ✓ |
 | Dermatology (Tier-2) | Dermatology | skin_finding_in (lesion→dx) | 4 grounded (ADJ-only) | ✓ |
 | Respiratory occupational (Tier-2) | Pulmonology | inhalation_causes (exposure→dz) | 5 grounded (ADJ-only) | ✓ |
 

--- a/code/specs/data/mycin-2026/board/board-scorecard.json
+++ b/code/specs/data/mycin-2026/board/board-scorecard.json
@@ -1,7 +1,7 @@
 {
   "summary": {
-    "total": 144,
-    "correct": 137,
+    "total": 146,
+    "correct": 139,
     "abstained": 7,
     "wrong": 0,
     "by_tactic": {
@@ -16,15 +16,15 @@
         "wrong": 0
       },
       "recall": {
-        "correct": 131,
+        "correct": 133,
         "abstained": 6,
         "wrong": 0
       }
     },
     "defensibility": 1.0,
     "accuracy_on_attempted": 1.0,
-    "grounded_coverage": 0.9924,
-    "grounded_correct": 130
+    "grounded_coverage": 0.9925,
+    "grounded_correct": 132
   },
   "results": [
     {
@@ -916,6 +916,14 @@
       "trust": "authoritative"
     },
     {
+      "id": "rheum_pbc_ab",
+      "tactic": "recall",
+      "gold": "anti_mitochondrial",
+      "answer": "anti_mitochondrial",
+      "outcome": "correct",
+      "trust": "authoritative"
+    },
+    {
       "id": "onco_ovarian_marker",
       "tactic": "recall",
       "gold": "ca_125",
@@ -1104,6 +1112,14 @@
       "tactic": "recall",
       "gold": "eosinophilic_esophagitis",
       "answer": "eosinophilic_esophagitis",
+      "outcome": "correct",
+      "trust": "authoritative"
+    },
+    {
+      "id": "gi_uc_dx",
+      "tactic": "recall",
+      "gold": "ulcerative_colitis",
+      "answer": "ulcerative_colitis",
       "outcome": "correct",
       "trust": "authoritative"
     },

--- a/code/specs/data/mycin-2026/board/items.json
+++ b/code/specs/data/mycin-2026/board/items.json
@@ -125,6 +125,7 @@
     {"id": "rheum_ssc_ab",   "domain": "rheum", "tactic": "recall", "relation": "associated_autoantibody", "subject": "systemic_sclerosis",            "var": "Antibody", "gold": "anti_scl70"},
     {"id": "rheum_ra_ab",    "domain": "rheum", "tactic": "recall", "relation": "associated_autoantibody", "subject": "rheumatoid_arthritis",           "var": "Antibody", "gold": "anti_ccp"},
     {"id": "rheum_sjo_ab",   "domain": "rheum", "tactic": "recall", "relation": "associated_autoantibody", "subject": "sjogren_syndrome",              "var": "Antibody", "gold": "anti_ro"},
+    {"id": "rheum_pbc_ab",   "domain": "rheum", "tactic": "recall", "relation": "associated_autoantibody", "subject": "primary_biliary_cholangitis",   "var": "Antibody", "gold": "anti_mitochondrial"},
 
     {"id": "onco_ovarian_marker", "domain": "onco", "tactic": "recall", "relation": "tumor_marker", "subject": "ovarian_cancer",               "var": "Marker", "gold": "ca_125"},
     {"id": "onco_mtc_marker",     "domain": "onco", "tactic": "recall", "relation": "tumor_marker", "subject": "medullary_thyroid_carcinoma",   "var": "Marker", "gold": "calcitonin"},
@@ -154,6 +155,7 @@
     {"id": "gi_barrett_dx",  "domain": "gi", "tactic": "recall", "relation": "biopsy_finding_in", "subject": "goblet_cells",              "var": "Disease", "gold": "barrett_esophagus"},
     {"id": "gi_hirsch_dx",   "domain": "gi", "tactic": "recall", "relation": "biopsy_finding_in", "subject": "absence_of_ganglion_cells", "var": "Disease", "gold": "hirschsprung_disease"},
     {"id": "gi_eoe_dx",      "domain": "gi", "tactic": "recall", "relation": "biopsy_finding_in", "subject": "eosinophils_15_per_hpf",     "var": "Disease", "gold": "eosinophilic_esophagitis"},
+    {"id": "gi_uc_dx",       "domain": "gi", "tactic": "recall", "relation": "biopsy_finding_in", "subject": "crypt_abscesses",            "var": "Disease", "gold": "ulcerative_colitis"},
 
     {"id": "derm_em_dx",      "domain": "derm", "tactic": "recall", "relation": "skin_finding_in", "subject": "target_lesions",      "var": "Disease", "gold": "erythema_multiforme"},
     {"id": "derm_psoriasis_dx","domain": "derm", "tactic": "recall", "relation": "skin_finding_in", "subject": "silvery_scales",      "var": "Disease", "gold": "psoriasis"},

--- a/code/specs/data/mycin-2026/board/test_board_eval.py
+++ b/code/specs/data/mycin-2026/board/test_board_eval.py
@@ -59,7 +59,7 @@ def test_covered_items_answer_correctly_with_a_proof() -> None:
     # answers, so the board scores the top binding per subject (the libraries + their
     # tests cover all edges).
     recall_correct = [r for r in card.results if r.outcome == "correct" and r.tactic == "recall"]
-    assert len(recall_correct) == 131
+    assert len(recall_correct) == 133
     assert by_id["fabry_enzyme"].outcome == "correct"               # IEM
     assert by_id["thiamine_disease"].answer == "beriberi"           # vitamin
     assert by_id["ida_mcv"].answer == "microcytic"                  # anemia
@@ -98,6 +98,8 @@ def test_covered_items_answer_correctly_with_a_proof() -> None:
     assert by_id["histo_rs_cond"].trust == "authoritative"       # ADJ-only edge, grounded inline
     assert by_id["histo_auer_cond"].answer == "acute_promyelocytic_leukemia"  # primary-source backfill
     assert by_id["histo_psammoma_cond"].answer == "meningioma"   # primary-source backfill (psammoma→meningioma)
+    assert by_id["rheum_pbc_ab"].answer == "anti_mitochondrial"  # primary-source backfill: PBC→AMA (NBK459209)
+    assert by_id["rheum_pbc_ab"].trust == "authoritative"        # previously deferred, now grounded
     assert by_id["cardio_mr_lesion"].answer == "mitral_regurgitation"  # cardiology (CARDIO, Tier-2)
     assert by_id["cardio_as_lesion"].answer == "aortic_stenosis"  # cardio — murmur_indicates (murmur->lesion)
     assert by_id["cardio_mr_lesion"].trust == "authoritative"    # ADJ-only edge, grounded inline
@@ -107,6 +109,8 @@ def test_covered_items_answer_correctly_with_a_proof() -> None:
     assert by_id["gi_celiac_dx"].answer == "celiac_disease"      # gastroenterology (GI, Tier-2)
     assert by_id["gi_hirsch_dx"].answer == "hirschsprung_disease"  # gi — biopsy_finding_in (finding->dx)
     assert by_id["gi_celiac_dx"].trust == "authoritative"        # ADJ-only edge, grounded inline
+    assert by_id["gi_uc_dx"].answer == "ulcerative_colitis"      # primary-source backfill: crypt abscesses→UC (NBK470312)
+    assert by_id["gi_uc_dx"].trust == "authoritative"            # previously deferred, now grounded
     assert by_id["derm_em_dx"].answer == "erythema_multiforme"   # dermatology (DERM, Tier-2)
     assert by_id["derm_psoriasis_dx"].answer == "psoriasis"      # derm — skin_finding_in (finding->dx)
     assert by_id["derm_em_dx"].trust == "authoritative"          # ADJ-only edge, grounded inline
@@ -157,8 +161,8 @@ def test_grounded_coverage_is_the_live_grounding_number() -> None:
     # verbatim, so the framework declines to claim grounding it cannot defend, by design:
     # cortisol_def (endocrine, deficiency_syndrome__cortisol — the only verbatim spans frame
     # cortisol deficiency as a consequence/feature of Addison disease, not the named-syndrome identity).
-    assert s["grounded_coverage"] == round(130 / 131, 4)   # 0.9924
-    assert s["grounded_correct"] == 130
+    assert s["grounded_coverage"] == round(132 / 133, 4)   # 0.9925
+    assert s["grounded_correct"] == 132
     by_id = {r.item_id: r for r in card.results}
     assert by_id["tay_sachs_enzyme"].trust == "authoritative"      # IEM
     assert by_id["ida_mcv"].trust == "authoritative"               # anemia

--- a/code/specs/data/mycin-2026/recall/gi-edges.adj
+++ b/code/specs/data/mycin-2026/recall/gi-edges.adj
@@ -27,10 +27,14 @@
 % (See feedback_nothing_human_authored, feedback_adj_only_shipped_artifacts.)
 %
 % Honest scope: only findings whose page states the association in a clean self-contained
-% span (both finding AND disease named) are included. Deferred — ulcerative colitis: its
-% page describes crypt distortion / goblet-cell depletion in sentences that do not name
-% "ulcerative colitis" alongside the finding; Whipple disease: its PAS-positive-foamy-
-% macrophage criterion sentence does not name "Whipple" in the same declarative.
+% span (both finding AND disease named) are included. Under the primary-source-first
+% policy, ulcerative colitis → crypt abscesses is now GROUNDED: the Inflammatory Bowel
+% Disease page (NBK470312) carries a Histopathology span naming "ulcerative colitis" and
+% its "cryptic abscesses" together. Still deferred (checked, no both-endpoints declarative
+% on the cited page): Whipple disease — its dedicated page (NBK441937) splits the diagnosis
+% ("The diagnosis of Whipple disease is made by a biopsy of the intestine...") from the
+% criterion ("...positive results for PAS-positive foamy macrophages in the small bowel
+% biopsy"), naming "Whipple" and "PAS-positive macrophages" in separate sentences.
 % ============================================================================
 
 dictionary gi_vocab {
@@ -71,5 +75,13 @@ rulebook gi_facts {
     relate biopsy_finding_in(eosinophils_15_per_hpf, eosinophilic_esophagitis)
         source "The pathological diagnosis of EoE is made when eosinophils are present greater than or equal to 15 per high power field (HPF)."
         locator "https://www.ncbi.nlm.nih.gov/books/NBK459297/"
+        trust authoritative
+
+    % --- BACKFILL (primary-source-first): crypt abscesses -> ulcerative colitis ----------
+    % The IBD page's Histopathology span names "ulcerative colitis" and its "cryptic
+    % abscesses" (the board buzzword "crypt abscesses") together in one declarative.
+    relate biopsy_finding_in(crypt_abscesses, ulcerative_colitis)
+        source "The histopathology of ulcerative colitis will show involvement only of the mucosa and submucosa, with the formation of cryptic abscesses and mucosal ulcers."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK470312/"
         trust authoritative
 }

--- a/code/specs/data/mycin-2026/recall/gi-recall.query.adj
+++ b/code/specs/data/mycin-2026/recall/gi-recall.query.adj
@@ -18,3 +18,4 @@ import "gi-edges.adj"
 ? biopsy_finding_in(goblet_cells, $Disease)               % expect barrett_esophagus
 ? biopsy_finding_in(absence_of_ganglion_cells, $Disease)  % expect hirschsprung_disease
 ? biopsy_finding_in(eosinophils_15_per_hpf, $Disease)     % expect eosinophilic_esophagitis
+? biopsy_finding_in(crypt_abscesses, $Disease)            % expect ulcerative_colitis (backfill)

--- a/code/specs/data/mycin-2026/recall/rheum-edges.adj
+++ b/code/specs/data/mycin-2026/recall/rheum-edges.adj
@@ -24,9 +24,14 @@
 % endpoints: rheumatoid arthritis → anti-CCP (the RA page defines ACPA = anti-cyclic
 % citrullinated peptide antibodies and names them among RA's best-known autoantibodies)
 % and Sjögren syndrome → anti-Ro/SSA and anti-La/SSB (one span names the disease and both
-% markers). Still pursued for the next backfill (need a primary source with a both-
-% endpoints span): primary biliary cholangitis → anti-mitochondrial, and polymyositis /
-% antisynthetase → anti-Jo-1.
+% markers). A third backfill is now GROUNDED: primary biliary cholangitis → anti-
+% mitochondrial antibody (the StatPearls page titled "Primary Biliary Cholangitis" carries
+% a contiguous Pathophysiology span naming the disease — by its legacy name "Primary
+% biliary cirrhosis" — and its hallmark anti-mitochondrial antibody together).
+% Still deferred (checked, no both-endpoints declarative on the cited page): polymyositis /
+% antisynthetase → anti-Jo-1 — the Autoimmune Myopathies page (NBK532860) calls Jo-1 "the
+% most studied and commonly detected antisynthetase antibody" but does not name a disease
+% in the same sentence. Honest absence beats an over-reaching citation.
 % ============================================================================
 
 dictionary rheum_vocab {
@@ -85,5 +90,13 @@ rulebook rheum_facts {
     relate associated_autoantibody(sjogren_syndrome, anti_la)
         source "B cells generate autoantibodies characteristic of Sjögren disease, including rheumatoid factor, SSA/Ro, and SSB/La."
         locator "https://www.ncbi.nlm.nih.gov/books/NBK431049/"
+        trust authoritative
+
+    % --- BACKFILL (primary-source-first): primary biliary cholangitis → anti-mitochondrial ---
+    % The page is titled "Primary Biliary Cholangitis"; this Pathophysiology span uses the
+    % disease's legacy name ("Primary biliary cirrhosis") and names its hallmark serology.
+    relate associated_autoantibody(primary_biliary_cholangitis, anti_mitochondrial)
+        source "Primary biliary cirrhosis is associated with highly specific autoantibodies. The anti-mitochondrial antibody is found in 85% of the cases."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK459209/"
         trust authoritative
 }

--- a/code/specs/data/mycin-2026/recall/rheum-recall.query.adj
+++ b/code/specs/data/mycin-2026/recall/rheum-recall.query.adj
@@ -19,3 +19,4 @@ import "rheum-edges.adj"
 ? associated_autoantibody(systemic_sclerosis, $Antibody)             % expect anti_scl70 / anti_centromere
 ? associated_autoantibody(rheumatoid_arthritis, $Antibody)           % expect anti_ccp        (backfill)
 ? associated_autoantibody(sjogren_syndrome, $Antibody)               % expect anti_ro / anti_la (backfill)
+? associated_autoantibody(primary_biliary_cholangitis, $Antibody)    % expect anti_mitochondrial (backfill)

--- a/code/specs/data/mycin-2026/recall/test_gi_recall.py
+++ b/code/specs/data/mycin-2026/recall/test_gi_recall.py
@@ -34,6 +34,7 @@ EXPECTED = {
     "goblet_cells": "barrett_esophagus",
     "absence_of_ganglion_cells": "hirschsprung_disease",
     "eosinophils_15_per_hpf": "eosinophilic_esophagitis",
+    "crypt_abscesses": "ulcerative_colitis",            # primary-source backfill (NBK470312)
 }
 REL = "biopsy_finding_in"
 VAR = "Disease"

--- a/code/specs/data/mycin-2026/recall/test_rheum_recall.py
+++ b/code/specs/data/mycin-2026/recall/test_rheum_recall.py
@@ -35,6 +35,7 @@ EXPECTED = {
     "systemic_sclerosis": {"anti_scl70", "anti_centromere"},
     "rheumatoid_arthritis": {"anti_ccp"},                 # primary-source backfill (NBK441999)
     "sjogren_syndrome": {"anti_ro", "anti_la"},           # primary-source backfill (NBK431049)
+    "primary_biliary_cholangitis": {"anti_mitochondrial"},  # primary-source backfill (NBK459209)
 }
 REL = "associated_autoantibody"
 VAR = "Antibody"


### PR DESCRIPTION
## What

Two previously-deferred Tier-2 recall edges are now **GROUNDED** from primary authorities carrying a clean both-endpoints span (continuing the primary-source-first, zero-deferral policy):

| Domain | Edge | Source | Locator |
|---|---|---|---|
| RHEUM | `associated_autoantibody(primary_biliary_cholangitis, anti_mitochondrial)` | "Primary biliary cirrhosis is associated with highly specific autoantibodies. The anti-mitochondrial antibody is found in 85% of the cases." | StatPearls *Primary Biliary Cholangitis* (NBK459209) |
| GI | `biopsy_finding_in(crypt_abscesses, ulcerative_colitis)` | "The histopathology of ulcerative colitis will show involvement only of the mucosa and submucosa, with the formation of cryptic abscesses and mucosal ulcers." | StatPearls *Inflammatory Bowel Disease* (NBK470312) |

Each edge ships inline byte-provenance (verbatim `source` span + NCBI `locator` + `trust authoritative`), is engine-queryable (added to the two `*-recall.query.adj`), and is mirrored into the board bank.

## Honestly still deferred (checked this round)

- **polymyositis/antisynthetase → anti-Jo-1** — *Autoimmune Myopathies* (NBK532860) names Jo-1 as "the most studied and commonly detected antisynthetase antibody" but does not name a disease in the same sentence.
- **Whipple → PAS-positive macrophages** — *Whipple Disease* (NBK441937) splits the diagnosis sentence from the PAS-criterion sentence.
- **psammoma → papillary thyroid carcinoma** — *Papillary Thyroid Carcinoma* (NBK536943) lists psammoma bodies only as an isolated bullet, not a both-endpoints declarative.

Honest absence beats an over-reaching citation; each library's honest-scope block is updated to record exactly what was checked.

## Numbers

- Board scorecard: **131→133** recall correct, **130→132** grounded, grounded-coverage **0.9924→0.9925**, **wrong still 0** / defensibility **1.0**.
- Domain map: RHEUM 9→10, GI 5→6.

## Verification

- All **19** recall suites pass against the native `adj-lang-cli`.
- The **12**-test board scorecard passes (memoized, ~2:45).
- The dedicated `mycin-2026` CI workflow (merged in #6304) exercises both on every PR.
- Security review passed (data/test/docs only — no executable surface).

🤖 Generated with [Claude Code](https://claude.com/claude-code)