### PR TITLE
Add SPICE deck table export artifacts

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ### Added
 
+- **Deck execution table export artifacts** —
+  `run_deck_analysis()` selected executions now expose ordered
+  `table_artifacts` with each stable table's text, CSV, compact JSON, and
+  header-keyed records beside the existing table inventory, matching Rust and
+  TypeScript.
+
 - **Deck execution table inventory** —
   `run_deck_analysis()` selected executions now expose stable table count/name
   lists beside analysis directives, output probes, output directives, and

--- a/code/packages/python/spice-engine/README.md
+++ b/code/packages/python/spice-engine/README.md
@@ -107,7 +107,9 @@ returns the plan, solver result, deck-selected output table, and normalized
 table count/name list, analysis directive, output probes, and output directives
 that produced the table, plus selected
 `.measure` results and a stable measurement table for `.dc`, `.ac`, and `.tran`
-executions. Selected
+executions. Execution `table_artifacts` preserve the same order as `tables` and
+carry each stable table's text, CSV, compact JSON, and header-keyed records.
+Selected
 `.tran` plans also return selected `.four` harmonic results and a stable
 Fourier table. Executions also include a selected-run artifact summary plus
 `format_deck_run_artifact_table()` and `format_deck_run_artifact_csv()` output

--- a/code/packages/python/spice-engine/src/spice_engine/engine.py
+++ b/code/packages/python/spice-engine/src/spice_engine/engine.py
@@ -2355,6 +2355,17 @@ class DeckRunArtifact:
 
 
 @dataclass(frozen=True)
+class DeckTableArtifact:
+    """Stable text and structured exports for one selected deck output table."""
+
+    name: str
+    table: str
+    csv: str
+    json: str
+    records: list[dict[str, str]]
+
+
+@dataclass(frozen=True)
 class DeckAnalysisExecution:
     """A selected deck analysis plan plus its executed solver output."""
 
@@ -2366,6 +2377,7 @@ class DeckAnalysisExecution:
     analysis_directives: list[str]
     table_count: int
     tables: list[str]
+    table_artifacts: list[DeckTableArtifact]
     measurements: list[ProbeMeasurement]
     measurement_table: str
     fourier: list[FourierResult]
@@ -2655,6 +2667,33 @@ def format_deck_table_json(table: str) -> str:
     return json.dumps(deck_table_records(table), separators=(",", ":")) + "\n"
 
 
+def _deck_table_artifact(name: str, table: str) -> DeckTableArtifact:
+    return DeckTableArtifact(
+        name=name,
+        table=table,
+        csv=format_deck_table_csv(table),
+        json=format_deck_table_json(table),
+        records=deck_table_records(table),
+    )
+
+
+def _deck_table_artifacts(
+    result_table: str,
+    measurement_table: str,
+    fourier_table: str,
+    run_artifact_table: str,
+    measurements: list[ProbeMeasurement],
+    fourier: list[FourierResult],
+) -> list[DeckTableArtifact]:
+    artifacts = [_deck_table_artifact("result", result_table)]
+    if measurements:
+        artifacts.append(_deck_table_artifact("measurement", measurement_table))
+    if fourier:
+        artifacts.append(_deck_table_artifact("fourier", fourier_table))
+    artifacts.append(_deck_table_artifact("run-artifact", run_artifact_table))
+    return artifacts
+
+
 def format_deck_run_artifact_csv(artifacts: Iterable[DeckRunArtifact]) -> str:
     """Format selected deck-run artifacts as stable RFC 4180-style CSV."""
 
@@ -2702,7 +2741,18 @@ def run_deck_analysis(
             fourier,
             diagnostic_codes,
         )
+        measurement_table = format_measurement_table(measurements)
+        fourier_table = format_deck_fourier_table(fourier)
+        run_artifact_table = format_deck_run_artifact_table(run_artifacts)
         tables = _deck_stable_tables(measurements, fourier)
+        table_artifacts = _deck_table_artifacts(
+            table,
+            measurement_table,
+            fourier_table,
+            run_artifact_table,
+            measurements,
+            fourier,
+        )
         return DeckAnalysisExecution(
             plan=plan,
             result=result,
@@ -2712,12 +2762,13 @@ def run_deck_analysis(
             analysis_directives=analysis_directives,
             table_count=len(tables),
             tables=tables,
+            table_artifacts=table_artifacts,
             measurements=measurements,
-            measurement_table=format_measurement_table(measurements),
+            measurement_table=measurement_table,
             fourier=fourier,
-            fourier_table=format_deck_fourier_table(fourier),
+            fourier_table=fourier_table,
             run_artifacts=run_artifacts,
-            run_artifact_table=format_deck_run_artifact_table(run_artifacts),
+            run_artifact_table=run_artifact_table,
         )
     if plan.analysis == "dc":
         source_name = _require_deck_plan_string(plan, "source_name")
@@ -2744,7 +2795,18 @@ def run_deck_analysis(
             fourier,
             diagnostic_codes,
         )
+        measurement_table = format_measurement_table(measurements)
+        fourier_table = format_deck_fourier_table(fourier)
+        run_artifact_table = format_deck_run_artifact_table(run_artifacts)
         tables = _deck_stable_tables(measurements, fourier)
+        table_artifacts = _deck_table_artifacts(
+            table,
+            measurement_table,
+            fourier_table,
+            run_artifact_table,
+            measurements,
+            fourier,
+        )
         return DeckAnalysisExecution(
             plan=plan,
             result=result,
@@ -2754,12 +2816,13 @@ def run_deck_analysis(
             analysis_directives=analysis_directives,
             table_count=len(tables),
             tables=tables,
+            table_artifacts=table_artifacts,
             measurements=measurements,
-            measurement_table=format_measurement_table(measurements),
+            measurement_table=measurement_table,
             fourier=fourier,
-            fourier_table=format_deck_fourier_table(fourier),
+            fourier_table=fourier_table,
             run_artifacts=run_artifacts,
-            run_artifact_table=format_deck_run_artifact_table(run_artifacts),
+            run_artifact_table=run_artifact_table,
         )
     if plan.analysis == "ac":
         sweep_kind = _require_deck_plan_string(plan, "sweep_kind")
@@ -2788,7 +2851,18 @@ def run_deck_analysis(
             fourier,
             diagnostic_codes,
         )
+        measurement_table = format_measurement_table(measurements)
+        fourier_table = format_deck_fourier_table(fourier)
+        run_artifact_table = format_deck_run_artifact_table(run_artifacts)
         tables = _deck_stable_tables(measurements, fourier)
+        table_artifacts = _deck_table_artifacts(
+            table,
+            measurement_table,
+            fourier_table,
+            run_artifact_table,
+            measurements,
+            fourier,
+        )
         return DeckAnalysisExecution(
             plan=plan,
             result=result,
@@ -2798,12 +2872,13 @@ def run_deck_analysis(
             analysis_directives=analysis_directives,
             table_count=len(tables),
             tables=tables,
+            table_artifacts=table_artifacts,
             measurements=measurements,
-            measurement_table=format_measurement_table(measurements),
+            measurement_table=measurement_table,
             fourier=fourier,
-            fourier_table=format_deck_fourier_table(fourier),
+            fourier_table=fourier_table,
             run_artifacts=run_artifacts,
-            run_artifact_table=format_deck_run_artifact_table(run_artifacts),
+            run_artifact_table=run_artifact_table,
         )
     if plan.analysis == "tran":
         step_time = _require_deck_plan_number(plan, "step_time")
@@ -2838,7 +2913,18 @@ def run_deck_analysis(
             fourier,
             diagnostic_codes,
         )
+        measurement_table = format_measurement_table(measurements)
+        fourier_table = format_deck_fourier_table(fourier)
+        run_artifact_table = format_deck_run_artifact_table(run_artifacts)
         tables = _deck_stable_tables(measurements, fourier)
+        table_artifacts = _deck_table_artifacts(
+            table,
+            measurement_table,
+            fourier_table,
+            run_artifact_table,
+            measurements,
+            fourier,
+        )
         return DeckAnalysisExecution(
             plan=plan,
             result=result,
@@ -2848,12 +2934,13 @@ def run_deck_analysis(
             analysis_directives=analysis_directives,
             table_count=len(tables),
             tables=tables,
+            table_artifacts=table_artifacts,
             measurements=measurements,
-            measurement_table=format_measurement_table(measurements),
+            measurement_table=measurement_table,
             fourier=fourier,
-            fourier_table=format_deck_fourier_table(fourier),
+            fourier_table=fourier_table,
             run_artifacts=run_artifacts,
-            run_artifact_table=format_deck_run_artifact_table(run_artifacts),
+            run_artifact_table=run_artifact_table,
         )
     if plan.analysis == "tf":
         output_node = _require_deck_plan_string(plan, "output_node")
@@ -2876,7 +2963,18 @@ def run_deck_analysis(
             fourier,
             diagnostic_codes,
         )
+        measurement_table = format_measurement_table(measurements)
+        fourier_table = format_deck_fourier_table(fourier)
+        run_artifact_table = format_deck_run_artifact_table(run_artifacts)
         tables = _deck_stable_tables(measurements, fourier)
+        table_artifacts = _deck_table_artifacts(
+            table,
+            measurement_table,
+            fourier_table,
+            run_artifact_table,
+            measurements,
+            fourier,
+        )
         return DeckAnalysisExecution(
             plan=plan,
             result=result,
@@ -2886,12 +2984,13 @@ def run_deck_analysis(
             analysis_directives=analysis_directives,
             table_count=len(tables),
             tables=tables,
+            table_artifacts=table_artifacts,
             measurements=measurements,
-            measurement_table=format_measurement_table(measurements),
+            measurement_table=measurement_table,
             fourier=fourier,
-            fourier_table=format_deck_fourier_table(fourier),
+            fourier_table=fourier_table,
             run_artifacts=run_artifacts,
-            run_artifact_table=format_deck_run_artifact_table(run_artifacts),
+            run_artifact_table=run_artifact_table,
         )
     if plan.analysis == "sens":
         output_node = _require_deck_plan_string(plan, "output_node")
@@ -2913,7 +3012,18 @@ def run_deck_analysis(
             fourier,
             diagnostic_codes,
         )
+        measurement_table = format_measurement_table(measurements)
+        fourier_table = format_deck_fourier_table(fourier)
+        run_artifact_table = format_deck_run_artifact_table(run_artifacts)
         tables = _deck_stable_tables(measurements, fourier)
+        table_artifacts = _deck_table_artifacts(
+            table,
+            measurement_table,
+            fourier_table,
+            run_artifact_table,
+            measurements,
+            fourier,
+        )
         return DeckAnalysisExecution(
             plan=plan,
             result=result,
@@ -2923,12 +3033,13 @@ def run_deck_analysis(
             analysis_directives=analysis_directives,
             table_count=len(tables),
             tables=tables,
+            table_artifacts=table_artifacts,
             measurements=measurements,
-            measurement_table=format_measurement_table(measurements),
+            measurement_table=measurement_table,
             fourier=fourier,
-            fourier_table=format_deck_fourier_table(fourier),
+            fourier_table=fourier_table,
             run_artifacts=run_artifacts,
-            run_artifact_table=format_deck_run_artifact_table(run_artifacts),
+            run_artifact_table=run_artifact_table,
         )
     if plan.analysis == "noise":
         output_node = _require_deck_plan_string(plan, "output_node")
@@ -2969,7 +3080,18 @@ def run_deck_analysis(
             fourier,
             diagnostic_codes,
         )
+        measurement_table = format_measurement_table(measurements)
+        fourier_table = format_deck_fourier_table(fourier)
+        run_artifact_table = format_deck_run_artifact_table(run_artifacts)
         tables = _deck_stable_tables(measurements, fourier)
+        table_artifacts = _deck_table_artifacts(
+            table,
+            measurement_table,
+            fourier_table,
+            run_artifact_table,
+            measurements,
+            fourier,
+        )
         return DeckAnalysisExecution(
             plan=plan,
             result=result,
@@ -2979,12 +3101,13 @@ def run_deck_analysis(
             analysis_directives=analysis_directives,
             table_count=len(tables),
             tables=tables,
+            table_artifacts=table_artifacts,
             measurements=measurements,
-            measurement_table=format_measurement_table(measurements),
+            measurement_table=measurement_table,
             fourier=fourier,
-            fourier_table=format_deck_fourier_table(fourier),
+            fourier_table=fourier_table,
             run_artifacts=run_artifacts,
-            run_artifact_table=format_deck_run_artifact_table(run_artifacts),
+            run_artifact_table=run_artifact_table,
         )
     raise ValueError(f"run_deck_analysis: unsupported analysis {plan.analysis!r}")
 

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -6803,6 +6803,9 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
     assert op_execution.analysis_directives == [".op"]
     assert op_execution.table_count == 2
     assert op_execution.tables == ["result", "run-artifact"]
+    assert [artifact.name for artifact in op_execution.table_artifacts] == (
+        op_execution.tables
+    )
     assert op_execution.measurements == []
     assert op_execution.measurement_table == "Name\tAnalysis\tProbe\tMode\tFrom\tTo\tValue\n"
     assert op_execution.table == "Index\tV(mid)\n0\t5.000000e-01\n"
@@ -6813,6 +6816,16 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
     assert json.loads(format_deck_table_json(op_execution.table)) == [
         {"Index": "0", "V(mid)": "5.000000e-01"}
     ]
+    assert op_execution.table_artifacts[0].table == op_execution.table
+    assert op_execution.table_artifacts[0].csv == format_deck_table_csv(
+        op_execution.table
+    )
+    assert op_execution.table_artifacts[0].json == format_deck_table_json(
+        op_execution.table
+    )
+    assert op_execution.table_artifacts[0].records == deck_table_records(
+        op_execution.table
+    )
     assert op_execution.run_artifacts[0].result_rows == 1
     assert op_execution.run_artifacts[0].result_column_count == 2
     assert op_execution.run_artifacts[0].result_columns == ["Index", "V(mid)"]
@@ -6835,6 +6848,11 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
     assert op_execution.run_artifact_table == (
         "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tDiagnostics\tDiagnosticCodeList\n"
         f"op\t.op\t1\t.op\t{op_execution.plan.line_number}\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t1\t2\tIndex;V(mid)\t2\tresult;run-artifact\t1\tV(mid)\t1\t.save\t0\t\t0\t\t0\t\n"
+    )
+    assert op_execution.table_artifacts[1].name == "run-artifact"
+    assert op_execution.table_artifacts[1].table == op_execution.run_artifact_table
+    assert op_execution.table_artifacts[1].records == deck_table_records(
+        op_execution.run_artifact_table
     )
     assert format_deck_table_csv(
         op_execution.run_artifact_table
@@ -6965,10 +6983,23 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
     assert dc_execution.analysis_directives == [".dc"]
     assert dc_execution.table_count == 3
     assert dc_execution.tables == ["result", "measurement", "run-artifact"]
+    assert [artifact.name for artifact in dc_execution.table_artifacts] == (
+        dc_execution.tables
+    )
     assert [measurement.name for measurement in dc_execution.measurements] == ["mid_avg"]
     assert dc_execution.measurement_table == (
         "Name\tAnalysis\tProbe\tMode\tFrom\tTo\tValue\n"
         "mid_avg\tdc\tV(mid)\tavg\t\t\t2.500000e-01\n"
+    )
+    assert dc_execution.table_artifacts[1].table == dc_execution.measurement_table
+    assert dc_execution.table_artifacts[1].csv == format_deck_table_csv(
+        dc_execution.measurement_table
+    )
+    assert dc_execution.table_artifacts[1].json == format_deck_table_json(
+        dc_execution.measurement_table
+    )
+    assert dc_execution.table_artifacts[1].records == deck_table_records(
+        dc_execution.measurement_table
     )
     assert isinstance(dc_execution.result, DcSweepResult)
     assert len(dc_execution.result.points) == 2
@@ -7334,11 +7365,24 @@ def test_run_deck_analysis_exposes_selected_fourier_artifacts() -> None:
     assert len(tran_execution.fourier) == 1
     assert tran_execution.table_count == 3
     assert tran_execution.tables == ["result", "fourier", "run-artifact"]
+    assert [artifact.name for artifact in tran_execution.table_artifacts] == (
+        tran_execution.tables
+    )
     result = tran_execution.fourier[0]
     assert result.fundamental_frequency == pytest.approx(2000.0)
     assert result.probes[0].probe == "V(mid)"
     assert len(result.probes[0].harmonics) == 1
     assert tran_execution.fourier_table == format_fourier_table(result)
+    assert tran_execution.table_artifacts[1].table == tran_execution.fourier_table
+    assert tran_execution.table_artifacts[1].csv == format_deck_table_csv(
+        tran_execution.fourier_table
+    )
+    assert tran_execution.table_artifacts[1].json == format_deck_table_json(
+        tran_execution.fourier_table
+    )
+    assert tran_execution.table_artifacts[1].records == deck_table_records(
+        tran_execution.fourier_table
+    )
     assert tran_execution.run_artifacts[0].fourier_count == 1
     assert tran_execution.run_artifacts[0].source_name is None
     assert tran_execution.run_artifacts[0].output_node is None

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Add ordered `table_artifacts` to selected `run_deck_analysis` execution
+  results with each stable table's text, CSV, compact JSON, and header-keyed
+  records beside the existing table inventory, matching Python and TypeScript.
 - Add stable table count/name lists directly to selected `run_deck_analysis`
   execution results beside analysis directives, output probes, output
   directives, and selected-run artifacts, matching Python and TypeScript.

--- a/code/packages/rust/spice-engine/README.md
+++ b/code/packages/rust/spice-engine/README.md
@@ -178,7 +178,9 @@ card by analysis alias, defaults decks without analysis cards to an implicit
 solver result, deck-selected output table, and normalized analysis directive,
 table count/name list, output probes, and output directives that produced the
 table, plus selected `.measure` results and
-a stable measurement table for `.dc`, `.ac`, and `.tran` executions. Selected
+a stable measurement table for `.dc`, `.ac`, and `.tran` executions.
+Execution `table_artifacts` preserve the same order as `tables` and carry each
+stable table's text, CSV, compact JSON, and header-keyed records. Selected
 `.tran` plans route
 `START` output filtering, `.tran TSTEP` as the output print grid, `MAXSTEP` as
 an internal fixed-step cap, and `UIC` initial-condition intent through that

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -3441,6 +3441,15 @@ pub struct DeckRunArtifact {
 }
 
 #[derive(Debug, Clone, PartialEq)]
+pub struct DeckTableArtifact {
+    pub name: String,
+    pub table: String,
+    pub csv: String,
+    pub json: String,
+    pub records: Vec<BTreeMap<String, String>>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
 pub struct DeckAnalysisExecution {
     pub plan: DeckAnalysisPlan,
     pub result: DeckAnalysisExecutionResult,
@@ -3450,6 +3459,7 @@ pub struct DeckAnalysisExecution {
     pub analysis_directives: Vec<String>,
     pub table_count: usize,
     pub tables: Vec<String>,
+    pub table_artifacts: Vec<DeckTableArtifact>,
     pub measurements: Vec<ProbeMeasurement>,
     pub measurement_table: String,
     pub fourier: Vec<FourierResult>,
@@ -10353,6 +10363,35 @@ pub fn deck_table_records(table: &str) -> Vec<BTreeMap<String, String>> {
         .collect()
 }
 
+fn deck_table_artifact(name: &str, table: &str) -> DeckTableArtifact {
+    DeckTableArtifact {
+        name: name.to_string(),
+        table: table.to_string(),
+        csv: format_deck_table_csv(table),
+        json: format_deck_table_json(table),
+        records: deck_table_records(table),
+    }
+}
+
+fn deck_table_artifacts(
+    result_table: &str,
+    measurement_table: &str,
+    fourier_table: &str,
+    run_artifact_table: &str,
+    measurements: &[ProbeMeasurement],
+    fourier: &[FourierResult],
+) -> Vec<DeckTableArtifact> {
+    let mut artifacts = vec![deck_table_artifact("result", result_table)];
+    if !measurements.is_empty() {
+        artifacts.push(deck_table_artifact("measurement", measurement_table));
+    }
+    if !fourier.is_empty() {
+        artifacts.push(deck_table_artifact("fourier", fourier_table));
+    }
+    artifacts.push(deck_table_artifact("run-artifact", run_artifact_table));
+    artifacts
+}
+
 pub fn format_deck_run_artifact_csv(artifacts: &[DeckRunArtifact]) -> String {
     let mut rows = vec![DECK_RUN_ARTIFACT_COLUMNS.join(",")];
     for artifact in artifacts {
@@ -10505,6 +10544,14 @@ pub fn run_deck_analysis(
                 &diagnostic_codes,
             );
             let run_artifact_table = format_deck_run_artifact_table(&run_artifacts);
+            let table_artifacts = deck_table_artifacts(
+                &table,
+                &measurement_table,
+                &fourier_table,
+                &run_artifact_table,
+                &measurements,
+                &fourier,
+            );
             let tables = deck_stable_tables(&measurements, &fourier);
             Ok(DeckAnalysisExecution {
                 plan,
@@ -10515,6 +10562,7 @@ pub fn run_deck_analysis(
                 analysis_directives,
                 table_count: tables.len(),
                 tables,
+                table_artifacts,
                 measurements,
                 measurement_table,
                 fourier,
@@ -10551,6 +10599,14 @@ pub fn run_deck_analysis(
                 &diagnostic_codes,
             );
             let run_artifact_table = format_deck_run_artifact_table(&run_artifacts);
+            let table_artifacts = deck_table_artifacts(
+                &table,
+                &measurement_table,
+                &fourier_table,
+                &run_artifact_table,
+                &measurements,
+                &fourier,
+            );
             let tables = deck_stable_tables(&measurements, &fourier);
             Ok(DeckAnalysisExecution {
                 plan,
@@ -10561,6 +10617,7 @@ pub fn run_deck_analysis(
                 analysis_directives,
                 table_count: tables.len(),
                 tables,
+                table_artifacts,
                 measurements,
                 measurement_table,
                 fourier,
@@ -10598,6 +10655,14 @@ pub fn run_deck_analysis(
                 &diagnostic_codes,
             );
             let run_artifact_table = format_deck_run_artifact_table(&run_artifacts);
+            let table_artifacts = deck_table_artifacts(
+                &table,
+                &measurement_table,
+                &fourier_table,
+                &run_artifact_table,
+                &measurements,
+                &fourier,
+            );
             let tables = deck_stable_tables(&measurements, &fourier);
             Ok(DeckAnalysisExecution {
                 plan,
@@ -10608,6 +10673,7 @@ pub fn run_deck_analysis(
                 analysis_directives,
                 table_count: tables.len(),
                 tables,
+                table_artifacts,
                 measurements,
                 measurement_table,
                 fourier,
@@ -10648,6 +10714,14 @@ pub fn run_deck_analysis(
                 &diagnostic_codes,
             );
             let run_artifact_table = format_deck_run_artifact_table(&run_artifacts);
+            let table_artifacts = deck_table_artifacts(
+                &table,
+                &measurement_table,
+                &fourier_table,
+                &run_artifact_table,
+                &measurements,
+                &fourier,
+            );
             let tables = deck_stable_tables(&measurements, &fourier);
             Ok(DeckAnalysisExecution {
                 plan,
@@ -10658,6 +10732,7 @@ pub fn run_deck_analysis(
                 analysis_directives,
                 table_count: tables.len(),
                 tables,
+                table_artifacts,
                 measurements,
                 measurement_table,
                 fourier,
@@ -10692,6 +10767,14 @@ pub fn run_deck_analysis(
                 &diagnostic_codes,
             );
             let run_artifact_table = format_deck_run_artifact_table(&run_artifacts);
+            let table_artifacts = deck_table_artifacts(
+                &table,
+                &measurement_table,
+                &fourier_table,
+                &run_artifact_table,
+                &measurements,
+                &fourier,
+            );
             let tables = deck_stable_tables(&measurements, &fourier);
             Ok(DeckAnalysisExecution {
                 plan,
@@ -10702,6 +10785,7 @@ pub fn run_deck_analysis(
                 analysis_directives,
                 table_count: tables.len(),
                 tables,
+                table_artifacts,
                 measurements,
                 measurement_table,
                 fourier,
@@ -10734,6 +10818,14 @@ pub fn run_deck_analysis(
                 &diagnostic_codes,
             );
             let run_artifact_table = format_deck_run_artifact_table(&run_artifacts);
+            let table_artifacts = deck_table_artifacts(
+                &table,
+                &measurement_table,
+                &fourier_table,
+                &run_artifact_table,
+                &measurements,
+                &fourier,
+            );
             let tables = deck_stable_tables(&measurements, &fourier);
             Ok(DeckAnalysisExecution {
                 plan,
@@ -10744,6 +10836,7 @@ pub fn run_deck_analysis(
                 analysis_directives,
                 table_count: tables.len(),
                 tables,
+                table_artifacts,
                 measurements,
                 measurement_table,
                 fourier,
@@ -10788,6 +10881,14 @@ pub fn run_deck_analysis(
                 &diagnostic_codes,
             );
             let run_artifact_table = format_deck_run_artifact_table(&run_artifacts);
+            let table_artifacts = deck_table_artifacts(
+                &table,
+                &measurement_table,
+                &fourier_table,
+                &run_artifact_table,
+                &measurements,
+                &fourier,
+            );
             let tables = deck_stable_tables(&measurements, &fourier);
             Ok(DeckAnalysisExecution {
                 plan,
@@ -10798,6 +10899,7 @@ pub fn run_deck_analysis(
                 analysis_directives,
                 table_count: tables.len(),
                 tables,
+                table_artifacts,
                 measurements,
                 measurement_table,
                 fourier,

--- a/code/packages/rust/spice-engine/tests/transient_tests.rs
+++ b/code/packages/rust/spice-engine/tests/transient_tests.rs
@@ -1910,6 +1910,24 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
         op_records[0].get("V(mid)").map(String::as_str),
         Some("5.000000e-01")
     );
+    assert_eq!(
+        op_execution
+            .table_artifacts
+            .iter()
+            .map(|artifact| artifact.name.as_str())
+            .collect::<Vec<_>>(),
+        vec!["result", "run-artifact"]
+    );
+    assert_eq!(op_execution.table_artifacts[0].table, op_execution.table);
+    assert_eq!(
+        op_execution.table_artifacts[0].csv,
+        format_deck_table_csv(&op_execution.table)
+    );
+    assert_eq!(
+        op_execution.table_artifacts[0].json,
+        format_deck_table_json(&op_execution.table)
+    );
+    assert_eq!(&op_execution.table_artifacts[0].records, &op_records);
     assert_eq!(op_execution.run_artifacts[0].result_rows, 1);
     assert_eq!(op_execution.run_artifacts[0].result_column_count, 2);
     assert_eq!(
@@ -1960,6 +1978,15 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
         format_deck_run_artifact_json(&op_execution.run_artifacts)
     );
     let artifact_records = deck_table_records(&op_execution.run_artifact_table);
+    assert_eq!(
+        op_execution.table_artifacts[1].name.as_str(),
+        "run-artifact"
+    );
+    assert_eq!(
+        op_execution.table_artifacts[1].table,
+        op_execution.run_artifact_table
+    );
+    assert_eq!(&op_execution.table_artifacts[1].records, &artifact_records);
     assert_eq!(artifact_records.len(), 1);
     assert_eq!(
         artifact_records[0].get("Analysis").map(String::as_str),
@@ -2074,6 +2101,30 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
     assert_eq!(
         dc_execution.measurement_table,
         "Name\tAnalysis\tProbe\tMode\tFrom\tTo\tValue\nmid_avg\tdc\tV(mid)\tavg\t\t\t2.500000e-01\n"
+    );
+    assert_eq!(
+        dc_execution
+            .table_artifacts
+            .iter()
+            .map(|artifact| artifact.name.as_str())
+            .collect::<Vec<_>>(),
+        vec!["result", "measurement", "run-artifact"]
+    );
+    assert_eq!(
+        dc_execution.table_artifacts[1].table,
+        dc_execution.measurement_table
+    );
+    assert_eq!(
+        dc_execution.table_artifacts[1].csv,
+        format_deck_table_csv(&dc_execution.measurement_table)
+    );
+    assert_eq!(
+        dc_execution.table_artifacts[1].json,
+        format_deck_table_json(&dc_execution.measurement_table)
+    );
+    assert_eq!(
+        dc_execution.table_artifacts[1].records,
+        deck_table_records(&dc_execution.measurement_table)
     );
     match dc_execution.result {
         DeckAnalysisExecutionResult::DcSweep(points) => assert_eq!(points.len(), 2),
@@ -2698,11 +2749,35 @@ fn run_deck_analysis_exposes_selected_fourier_artifacts() {
             "run-artifact".to_string()
         ]
     );
+    assert_eq!(
+        tran_execution
+            .table_artifacts
+            .iter()
+            .map(|artifact| artifact.name.as_str())
+            .collect::<Vec<_>>(),
+        vec!["result", "fourier", "run-artifact"]
+    );
     let result = &tran_execution.fourier[0];
     assert!((result.fundamental_frequency_hz - 2_000.0).abs() < 1.0e-12);
     assert_eq!(result.probes[0].probe, "V(mid)");
     assert_eq!(result.probes[0].harmonics.len(), 1);
     assert_eq!(tran_execution.fourier_table, format_fourier_table(result));
+    assert_eq!(
+        tran_execution.table_artifacts[1].table,
+        tran_execution.fourier_table
+    );
+    assert_eq!(
+        tran_execution.table_artifacts[1].csv,
+        format_deck_table_csv(&tran_execution.fourier_table)
+    );
+    assert_eq!(
+        tran_execution.table_artifacts[1].json,
+        format_deck_table_json(&tran_execution.fourier_table)
+    );
+    assert_eq!(
+        tran_execution.table_artifacts[1].records,
+        deck_table_records(&tran_execution.fourier_table)
+    );
     assert_eq!(tran_execution.run_artifacts[0].fourier_count, 1);
     assert_eq!(tran_execution.run_artifacts[0].source_name, None);
     assert_eq!(tran_execution.run_artifacts[0].output_node, None);

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Add ordered `tableArtifacts` to selected `runDeckAnalysis` execution results
+  with each stable table's text, CSV, compact JSON, and header-keyed records
+  beside the existing table inventory, matching Python and Rust.
 - Add stable table count/name lists directly to selected `runDeckAnalysis`
   execution results beside analysis directives, output probes, output
   directives, and selected-run artifacts, matching Python and Rust.

--- a/code/packages/typescript/spice-engine/README.md
+++ b/code/packages/typescript/spice-engine/README.md
@@ -94,7 +94,9 @@ and reports ambiguity before solver dispatch.
 solver result, deck-selected output table, and normalized analysis directive,
 table count/name list, output probes, and output directives that produced the
 table, plus selected `.measure` results and
-a stable measurement table for `.dc`, `.ac`, and `.tran` executions. Selected
+a stable measurement table for `.dc`, `.ac`, and `.tran` executions.
+Execution `tableArtifacts` preserve the same order as `tables` and carry each
+stable table's text, CSV, compact JSON, and header-keyed records. Selected
 `.tran` plans route
 `START` output filtering, `.tran TSTEP` as the output print grid, `MAXSTEP` as
 an internal fixed-step cap, and `UIC` initial-condition intent through that

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -695,6 +695,14 @@ export interface DeckRunArtifact {
   readonly diagnosticCodes: readonly string[];
 }
 
+export interface DeckTableArtifact {
+  readonly name: string;
+  readonly table: string;
+  readonly csv: string;
+  readonly json: string;
+  readonly records: ReadonlyArray<Record<string, string>>;
+}
+
 export interface DeckAnalysisExecution {
   readonly plan: DeckAnalysisPlan;
   readonly result: DeckAnalysisExecutionResult;
@@ -704,6 +712,7 @@ export interface DeckAnalysisExecution {
   readonly analysisDirectives: readonly string[];
   readonly tableCount: number;
   readonly tables: readonly string[];
+  readonly tableArtifacts: readonly DeckTableArtifact[];
   readonly measurements: readonly ProbeMeasurement[];
   readonly measurementTable: string;
   readonly fourier: readonly FourierResult[];
@@ -8114,6 +8123,35 @@ export function formatDeckTableJson(table: string): string {
   return `${JSON.stringify(records)}\n`;
 }
 
+function deckTableArtifact(name: string, table: string): DeckTableArtifact {
+  return {
+    name,
+    table,
+    csv: formatDeckTableCsv(table),
+    json: formatDeckTableJson(table),
+    records: deckTableRecords(table),
+  };
+}
+
+function deckTableArtifacts(
+  resultTable: string,
+  measurementTable: string,
+  fourierTable: string,
+  runArtifactTable: string,
+  measurements: readonly ProbeMeasurement[],
+  fourier: readonly FourierResult[],
+): DeckTableArtifact[] {
+  const artifacts = [deckTableArtifact("result", resultTable)];
+  if (measurements.length > 0) {
+    artifacts.push(deckTableArtifact("measurement", measurementTable));
+  }
+  if (fourier.length > 0) {
+    artifacts.push(deckTableArtifact("fourier", fourierTable));
+  }
+  artifacts.push(deckTableArtifact("run-artifact", runArtifactTable));
+  return artifacts;
+}
+
 export function formatDeckRunArtifactCsv(artifacts: readonly DeckRunArtifact[]): string {
   const rows = [DECK_RUN_ARTIFACT_COLUMNS.join(",")];
   for (const artifact of artifacts) {
@@ -8187,6 +8225,17 @@ export function runDeckAnalysis(
       diagnosticCodes,
     );
     const tables = deckStableTables(measurements, fourier);
+    const measurementTable = formatMeasurementTable(measurements);
+    const fourierTable = formatDeckFourierTable(fourier);
+    const runArtifactTable = formatDeckRunArtifactTable(runArtifacts);
+    const tableArtifacts = deckTableArtifacts(
+      table,
+      measurementTable,
+      fourierTable,
+      runArtifactTable,
+      measurements,
+      fourier,
+    );
     return {
       plan,
       result,
@@ -8196,12 +8245,13 @@ export function runDeckAnalysis(
       analysisDirectives,
       tableCount: tables.length,
       tables,
+      tableArtifacts,
       measurements,
-      measurementTable: formatMeasurementTable(measurements),
+      measurementTable,
       fourier,
-      fourierTable: formatDeckFourierTable(fourier),
+      fourierTable,
       runArtifacts,
-      runArtifactTable: formatDeckRunArtifactTable(runArtifacts),
+      runArtifactTable,
     };
   }
   if (plan.analysis === "dc") {
@@ -8230,6 +8280,17 @@ export function runDeckAnalysis(
       diagnosticCodes,
     );
     const tables = deckStableTables(measurements, fourier);
+    const measurementTable = formatMeasurementTable(measurements);
+    const fourierTable = formatDeckFourierTable(fourier);
+    const runArtifactTable = formatDeckRunArtifactTable(runArtifacts);
+    const tableArtifacts = deckTableArtifacts(
+      table,
+      measurementTable,
+      fourierTable,
+      runArtifactTable,
+      measurements,
+      fourier,
+    );
     return {
       plan,
       result,
@@ -8239,12 +8300,13 @@ export function runDeckAnalysis(
       analysisDirectives,
       tableCount: tables.length,
       tables,
+      tableArtifacts,
       measurements,
-      measurementTable: formatMeasurementTable(measurements),
+      measurementTable,
       fourier,
-      fourierTable: formatDeckFourierTable(fourier),
+      fourierTable,
       runArtifacts,
-      runArtifactTable: formatDeckRunArtifactTable(runArtifacts),
+      runArtifactTable,
     };
   }
   if (plan.analysis === "ac") {
@@ -8284,6 +8346,17 @@ export function runDeckAnalysis(
       diagnosticCodes,
     );
     const tables = deckStableTables(measurements, fourier);
+    const measurementTable = formatMeasurementTable(measurements);
+    const fourierTable = formatDeckFourierTable(fourier);
+    const runArtifactTable = formatDeckRunArtifactTable(runArtifacts);
+    const tableArtifacts = deckTableArtifacts(
+      table,
+      measurementTable,
+      fourierTable,
+      runArtifactTable,
+      measurements,
+      fourier,
+    );
     return {
       plan,
       result,
@@ -8293,12 +8366,13 @@ export function runDeckAnalysis(
       analysisDirectives,
       tableCount: tables.length,
       tables,
+      tableArtifacts,
       measurements,
-      measurementTable: formatMeasurementTable(measurements),
+      measurementTable,
       fourier,
-      fourierTable: formatDeckFourierTable(fourier),
+      fourierTable,
       runArtifacts,
-      runArtifactTable: formatDeckRunArtifactTable(runArtifacts),
+      runArtifactTable,
     };
   }
   if (plan.analysis === "tran") {
@@ -8333,6 +8407,17 @@ export function runDeckAnalysis(
       diagnosticCodes,
     );
     const tables = deckStableTables(measurements, fourier);
+    const measurementTable = formatMeasurementTable(measurements);
+    const fourierTable = formatDeckFourierTable(fourier);
+    const runArtifactTable = formatDeckRunArtifactTable(runArtifacts);
+    const tableArtifacts = deckTableArtifacts(
+      table,
+      measurementTable,
+      fourierTable,
+      runArtifactTable,
+      measurements,
+      fourier,
+    );
     return {
       plan,
       result,
@@ -8342,12 +8427,13 @@ export function runDeckAnalysis(
       analysisDirectives,
       tableCount: tables.length,
       tables,
+      tableArtifacts,
       measurements,
-      measurementTable: formatMeasurementTable(measurements),
+      measurementTable,
       fourier,
-      fourierTable: formatDeckFourierTable(fourier),
+      fourierTable,
       runArtifacts,
-      runArtifactTable: formatDeckRunArtifactTable(runArtifacts),
+      runArtifactTable,
     };
   }
   if (plan.analysis === "tf") {
@@ -8372,6 +8458,17 @@ export function runDeckAnalysis(
       diagnosticCodes,
     );
     const tables = deckStableTables(measurements, fourier);
+    const measurementTable = formatMeasurementTable(measurements);
+    const fourierTable = formatDeckFourierTable(fourier);
+    const runArtifactTable = formatDeckRunArtifactTable(runArtifacts);
+    const tableArtifacts = deckTableArtifacts(
+      table,
+      measurementTable,
+      fourierTable,
+      runArtifactTable,
+      measurements,
+      fourier,
+    );
     return {
       plan,
       result,
@@ -8381,12 +8478,13 @@ export function runDeckAnalysis(
       analysisDirectives,
       tableCount: tables.length,
       tables,
+      tableArtifacts,
       measurements,
-      measurementTable: formatMeasurementTable(measurements),
+      measurementTable,
       fourier,
-      fourierTable: formatDeckFourierTable(fourier),
+      fourierTable,
       runArtifacts,
-      runArtifactTable: formatDeckRunArtifactTable(runArtifacts),
+      runArtifactTable,
     };
   }
   if (plan.analysis === "sens") {
@@ -8410,6 +8508,17 @@ export function runDeckAnalysis(
       diagnosticCodes,
     );
     const tables = deckStableTables(measurements, fourier);
+    const measurementTable = formatMeasurementTable(measurements);
+    const fourierTable = formatDeckFourierTable(fourier);
+    const runArtifactTable = formatDeckRunArtifactTable(runArtifacts);
+    const tableArtifacts = deckTableArtifacts(
+      table,
+      measurementTable,
+      fourierTable,
+      runArtifactTable,
+      measurements,
+      fourier,
+    );
     return {
       plan,
       result,
@@ -8419,12 +8528,13 @@ export function runDeckAnalysis(
       analysisDirectives,
       tableCount: tables.length,
       tables,
+      tableArtifacts,
       measurements,
-      measurementTable: formatMeasurementTable(measurements),
+      measurementTable,
       fourier,
-      fourierTable: formatDeckFourierTable(fourier),
+      fourierTable,
       runArtifacts,
-      runArtifactTable: formatDeckRunArtifactTable(runArtifacts),
+      runArtifactTable,
     };
   }
   if (plan.analysis === "noise") {
@@ -8458,6 +8568,17 @@ export function runDeckAnalysis(
       diagnosticCodes,
     );
     const tables = deckStableTables(measurements, fourier);
+    const measurementTable = formatMeasurementTable(measurements);
+    const fourierTable = formatDeckFourierTable(fourier);
+    const runArtifactTable = formatDeckRunArtifactTable(runArtifacts);
+    const tableArtifacts = deckTableArtifacts(
+      table,
+      measurementTable,
+      fourierTable,
+      runArtifactTable,
+      measurements,
+      fourier,
+    );
     return {
       plan,
       result,
@@ -8467,12 +8588,13 @@ export function runDeckAnalysis(
       analysisDirectives,
       tableCount: tables.length,
       tables,
+      tableArtifacts,
       measurements,
-      measurementTable: formatMeasurementTable(measurements),
+      measurementTable,
       fourier,
-      fourierTable: formatDeckFourierTable(fourier),
+      fourierTable,
       runArtifacts,
-      runArtifactTable: formatDeckRunArtifactTable(runArtifacts),
+      runArtifactTable,
     };
   }
   throw invalidElement("runDeckAnalysis", `unsupported analysis ${JSON.stringify(plan.analysis)}`);

--- a/code/packages/typescript/spice-engine/tests/transient.test.ts
+++ b/code/packages/typescript/spice-engine/tests/transient.test.ts
@@ -1475,6 +1475,9 @@ describe("transient", () => {
     expect(opExecution.analysisDirectives).toEqual([".op"]);
     expect(opExecution.tableCount).toBe(2);
     expect(opExecution.tables).toEqual(["result", "run-artifact"]);
+    expect(opExecution.tableArtifacts.map((artifact) => artifact.name)).toEqual(
+      opExecution.tables,
+    );
     expect(opExecution.measurements).toEqual([]);
     expect(opExecution.measurementTable).toBe("Name\tAnalysis\tProbe\tMode\tFrom\tTo\tValue\n");
     expect(opExecution.table).toBe("Index\tV(mid)\n0\t5.000000e-01\n");
@@ -1485,6 +1488,13 @@ describe("transient", () => {
     expect(JSON.parse(formatDeckTableJson(opExecution.table))).toEqual([
       { Index: "0", "V(mid)": "5.000000e-01" },
     ]);
+    expect(opExecution.tableArtifacts[0]).toMatchObject({
+      name: "result",
+      table: opExecution.table,
+      csv: formatDeckTableCsv(opExecution.table),
+      json: formatDeckTableJson(opExecution.table),
+      records: deckTableRecords(opExecution.table),
+    });
     expect(opExecution.runArtifacts[0]?.resultRows).toBe(1);
     expect(opExecution.runArtifacts[0]?.resultColumnCount).toBe(2);
     expect(opExecution.runArtifacts[0]?.resultColumns).toEqual(["Index", "V(mid)"]);
@@ -1507,6 +1517,11 @@ describe("transient", () => {
     expect(opExecution.runArtifactTable).toBe(
       "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tDiagnostics\tDiagnosticCodeList\n" +
         `op\t.op\t1\t.op\t${opExecution.plan.lineNumber}\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t1\t2\tIndex;V(mid)\t2\tresult;run-artifact\t1\tV(mid)\t1\t.save\t0\t\t0\t\t0\t\n`,
+    );
+    expect(opExecution.tableArtifacts[1]?.name).toBe("run-artifact");
+    expect(opExecution.tableArtifacts[1]?.table).toBe(opExecution.runArtifactTable);
+    expect(opExecution.tableArtifacts[1]?.records).toEqual(
+      deckTableRecords(opExecution.runArtifactTable),
     );
     expect(formatDeckTableCsv(opExecution.runArtifactTable)).toBe(
       formatDeckRunArtifactCsv(opExecution.runArtifacts),
@@ -1639,11 +1654,21 @@ describe("transient", () => {
     expect(dcExecution.analysisDirectives).toEqual([".dc"]);
     expect(dcExecution.tableCount).toBe(3);
     expect(dcExecution.tables).toEqual(["result", "measurement", "run-artifact"]);
+    expect(dcExecution.tableArtifacts.map((artifact) => artifact.name)).toEqual(
+      dcExecution.tables,
+    );
     expect(dcExecution.measurements.map((measurement) => measurement.name)).toEqual(["mid_avg"]);
     expect(dcExecution.measurementTable).toBe(
       "Name\tAnalysis\tProbe\tMode\tFrom\tTo\tValue\n" +
         "mid_avg\tdc\tV(mid)\tavg\t\t\t2.500000e-01\n",
     );
+    expect(dcExecution.tableArtifacts[1]).toMatchObject({
+      name: "measurement",
+      table: dcExecution.measurementTable,
+      csv: formatDeckTableCsv(dcExecution.measurementTable),
+      json: formatDeckTableJson(dcExecution.measurementTable),
+      records: deckTableRecords(dcExecution.measurementTable),
+    });
     expect(Array.isArray(dcExecution.result)).toBe(true);
     expect(dcExecution.table).toBe(
       "Index\tSource\tValue\tV(mid)\tI(V1)\n" +
@@ -2008,11 +2033,21 @@ describe("transient", () => {
     expect(tranExecution.fourier).toHaveLength(1);
     expect(tranExecution.tableCount).toBe(3);
     expect(tranExecution.tables).toEqual(["result", "fourier", "run-artifact"]);
+    expect(tranExecution.tableArtifacts.map((artifact) => artifact.name)).toEqual(
+      tranExecution.tables,
+    );
     const result = tranExecution.fourier[0]!;
     expect(result.fundamentalFrequencyHz).toBeCloseTo(2_000.0, 12);
     expect(result.probes[0]?.probe).toBe("V(mid)");
     expect(result.probes[0]?.harmonics).toHaveLength(1);
     expect(tranExecution.fourierTable).toBe(formatFourierTable(result));
+    expect(tranExecution.tableArtifacts[1]).toMatchObject({
+      name: "fourier",
+      table: tranExecution.fourierTable,
+      csv: formatDeckTableCsv(tranExecution.fourierTable),
+      json: formatDeckTableJson(tranExecution.fourierTable),
+      records: deckTableRecords(tranExecution.fourierTable),
+    });
     expect(tranExecution.runArtifacts[0]?.fourierCount).toBe(1);
     expect(tranExecution.runArtifacts[0]?.sourceName).toBeUndefined();
     expect(tranExecution.runArtifacts[0]?.outputNode).toBeUndefined();

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -97,7 +97,9 @@ downstream tools to compare.
      render as stable CSV and compact JSON beside the existing tab-separated
      table; stable deck output tables can now also convert to deterministic CSV
      and compact JSON records or host-native header-keyed records across
-     Python, Rust, and TypeScript.
+     Python, Rust, and TypeScript, and selected executions now expose ordered
+     table export artifacts with text, CSV, compact JSON, and host-native
+     records for each stable table.
    - Expand remaining deck-controlled analyses toward full SPICE compatibility
      while keeping unsupported control-flow diagnostics explicit.
 
@@ -940,6 +942,14 @@ downstream tools to compare.
       measurement, Fourier, and run-artifact table inventory without drilling
       into the run-artifact table or reconstructing optional side-table
       presence.
+
+87. Deck execution table export artifacts.
+    - Status: completed in this deck execution table export artifact slice.
+    - Python, Rust, and TypeScript selected deck executions now expose ordered
+      table export artifacts beside the stable table count/name inventory.
+    - Each table artifact carries the stable table text, deterministic CSV,
+      compact JSON records, and host-native header-keyed records for the
+      selected result, measurement, Fourier, and run-artifact tables.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- expose ordered table export artifacts on selected deck executions in Python, Rust, and TypeScript
- include each stable selected table's text, deterministic CSV, compact JSON, and header-keyed records beside the existing table inventory
- document the new surface and mark the completed SPICE plan slice

## Verification
- PYTHONPATH=code/packages/python/spice-engine/src:code/packages/python/mosfet-models/src:code/packages/python/device-physics/src:code/packages/python/symbolic/src:code/packages/python/hardware/src /Users/adhithya/.local/share/mise/installs/python/3.12.13/bin/python -m pytest code/packages/python/spice-engine/tests -q --no-cov
- /Users/adhithya/.local/share/mise/installs/python/3.12.13/bin/ruff check code/packages/python/spice-engine/src/spice_engine/engine.py code/packages/python/spice-engine/tests/test_engine.py
- cargo test --manifest-path code/packages/rust/spice-engine/Cargo.toml
- cargo fmt --manifest-path code/packages/rust/spice-engine/Cargo.toml -- --check
- npm --prefix code/packages/typescript/spice-engine ci
- npm --prefix code/packages/typescript/spice-engine run build
- npm --prefix code/packages/typescript/spice-engine test