### PR TITLE
feat(r-21): environments & scoping — local(), <<-, assign/get/exists

### DIFF
--- a/code/packages/rust/r-runtime/CHANGELOG.md
+++ b/code/packages/rust/r-runtime/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.16.0] - 2026-06-20
+
+### Added (via the shared `s-runtime`)
+
+- **R-21 — environments & scoping (core subset)**: R's environment model reaches
+  R unchanged through the shared evaluator (the scope chain and the new forms all
+  live in `s-runtime` — no grammar change; the `<<-`/`->>` tokens already lex and
+  parse). In R syntax:
+  - **`local({ x <- 5; x * 2 })`** → `10`, and `x` is unbound afterward (locals
+    don't leak).
+  - **`<<-` super-assignment** rebinds the nearest *enclosing* binding, else
+    creates one globally: `f <- function() { y <<- 99 }; f(); y` → `99`. The
+    counter idiom `make_counter <- function() { n <- 0; function() { n <<- n + 1;
+    n } }` advances across calls. The R-only right form `->>` (`7 ->> z`) behaves
+    identically.
+  - **`assign("q", 7); get("q")`** → `7`; **`exists("zzz")`** → `FALSE`,
+    `exists("mean")` → `TRUE`; **`rm("d")`** removes a binding from the current
+    scope.
+  - Deferred to **R-22** (first-class environment values): `new.env()`,
+    `environment()`, and the `envir = e` argument (rejected today with a clear
+    error). See `s-runtime` 0.17.0.
+
 ## [0.15.0] - 2026-06-20
 
 ### Added (via the shared `s-runtime`)

--- a/code/packages/rust/r-runtime/README.md
+++ b/code/packages/rust/r-runtime/README.md
@@ -63,6 +63,17 @@ anonymous recursion (`(\(n) if (n <= 1) 1 else n * Recall(n - 1))(5)` → `120`)
 All take the function by name, so they compose with the pipe
 (`1:5 |> Find(f = \(x) x > 2)`).
 
+**Environments & scoping (R-21)** — R's environment-model core subset.
+`local({ x <- 5; x * 2 })` → `10` and `x` does not leak (the block runs in a
+fresh child scope). `<<-` super-assignment rebinds the nearest *enclosing*
+binding — `f <- function() { y <<- 99 }; f(); y` → `99` (created globally when no
+enclosing binding exists) — and the counter idiom `make_counter <- function() {
+n <- 0; function() { n <<- n + 1; n } }` advances across calls; the R-only `->>`
+form is the mirror image. `assign("q", 7); get("q")` → `7`; `exists("zzz")` →
+`FALSE`; `rm("d")` removes a binding. First-class environment *values*
+(`new.env()`, `environment()`, the `envir = e` argument) are deferred to R-22 and
+rejected today with a clear error.
+
 ## Usage
 
 ```rust

--- a/code/packages/rust/r-runtime/src/lib.rs
+++ b/code/packages/rust/r-runtime/src/lib.rs
@@ -1536,4 +1536,80 @@ mod tests {
         // R-19: empty-arm switch() fall-through.
         assert_eq!(show("switch(\"a\", a = , b = \"hit\")\n"), "[1] \"hit\"");
     }
+
+    // --- R-21: environments & scoping (R syntax) -------------------------
+
+    /// `local({...})` returns the block's value and does not leak its locals.
+    #[test]
+    fn r21_local_scopes_its_bindings() {
+        assert_eq!(nums("local({ x <- 5; x * 2 })\n"), vec![10.0]);
+        // `x` was local to the block — referencing it afterward is an error.
+        assert!(
+            eval_r("local({ x <- 5 })\nx\n").is_err(),
+            "local() bindings must not escape"
+        );
+    }
+
+    /// `<<-` from a function with no enclosing binding creates the name globally.
+    #[test]
+    fn r21_super_assign_creates_global() {
+        assert_eq!(nums("f <- function() { y <<- 99 }\nf()\ny\n"), vec![99.0]);
+    }
+
+    /// A counter closure mutates the `n` captured in its enclosing frame via
+    /// `<<-`, so repeated calls advance the count.
+    #[test]
+    fn r21_counter_closure_with_super_assign() {
+        let src = "make_counter <- function() {\n\
+                   \x20 n <- 0\n\
+                   \x20 function() { n <<- n + 1; n }\n\
+                   }\n\
+                   counter <- make_counter()\n\
+                   counter()\ncounter()\ncounter()\n";
+        assert_eq!(nums(src), vec![3.0]);
+    }
+
+    /// The R-only right-super-assign `->>` (value on the left) behaves like `<<-`.
+    /// This form lives in `r.grammar` (not `s.grammar`), so it is tested here.
+    #[test]
+    fn r21_right_super_assign() {
+        assert_eq!(nums("f <- function() { 7 ->> z }\nf()\nz\n"), vec![7.0]);
+    }
+
+    /// `assign`/`get` round-trip; `exists` reports presence; an unbound name is
+    /// `FALSE`.
+    #[test]
+    fn r21_assign_get_exists() {
+        assert_eq!(nums("assign(\"q\", 3 + 4)\nget(\"q\")\n"), vec![7.0]);
+        assert_eq!(show("exists(\"zzz\")\n"), "[1] FALSE");
+        assert_eq!(show("kk <- 1\nexists(\"kk\")\n"), "[1] TRUE");
+        // `_` is a name character in R, so `my_name` is one identifier — assign
+        // through it to confirm the R lexer path round-trips.
+        assert_eq!(nums("my_name <- \"w\"\nassign(my_name, 11)\nget(my_name)\n"), vec![11.0]);
+    }
+
+    /// `rm` removes a binding; referencing it afterward errors.
+    #[test]
+    fn r21_rm_removes_binding() {
+        assert!(eval_r("d <- 5\nrm(\"d\")\nd\n").is_err());
+    }
+
+    /// Earlier lanes still work after the R-21 changes (regression guard).
+    #[test]
+    fn r18_r19_r20_still_work_after_r21() {
+        // R-18: tryCatch.
+        assert_eq!(
+            show("tryCatch(stop(\"boom\"), error = function(e) \"caught\")\n"),
+            "[1] \"caught\""
+        );
+        // R-19: empty-arm switch fall-through.
+        assert_eq!(show("switch(\"a\", a = , b = \"hit\")\n"), "[1] \"hit\"");
+        // R-20: Find / Reduce(accumulate) / Negate.
+        assert_eq!(nums("Find(\\(x) x > 2, 1:5)\n"), vec![3.0]);
+        assert_eq!(
+            nums("Reduce(\\(a, b) a + b, 1:4, accumulate = TRUE)\n"),
+            vec![1.0, 3.0, 6.0, 10.0]
+        );
+        assert_eq!(show("Negate(is.na)(NA)\n"), "[1] FALSE");
+    }
 }

--- a/code/packages/rust/s-runtime/CHANGELOG.md
+++ b/code/packages/rust/s-runtime/CHANGELOG.md
@@ -2,6 +2,41 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.17.0] - 2026-06-20
+
+### Added
+
+- **Environments & scoping (R-21)** — R's environment-model core subset, living
+  in the shared runtime so both S and R inherit it. Grammar-free: the `<<-`
+  super-assign token already lexed and parsed.
+  - **`<<-` super-assignment** — a new `env::super_assign` walks the chain of
+    *enclosing* environments (skipping the current frame) and rebinds the
+    **nearest** existing binding of the name; if none exists, it creates the
+    binding in the **global** environment. This is what makes the counter-closure
+    idiom work — `make <- function() { n <- 0; function() { n <<- n + 1; n } }`
+    mutates the captured `n` rather than shadowing it. The walk is iterative (no
+    native-stack recursion) over the finite, acyclic scope list, so it always
+    terminates; a non-name target (`x[i] <<- v`) is a clean error.
+  - **`local({ ... })`** — evaluates a block in a fresh child environment and
+    returns its value; bindings made inside do not leak
+    (`local({ x <- 5; x * 2 })` → `10`, `x` unbound after).
+  - **`assign(x, value)` / `get(x)` / `exists(x)` / `rm(x)`** — by-name binding
+    ops against the **current** environment, implemented as lazy special forms
+    (intercepted at the call site like `switch`/`tryCatch`, since they need the
+    live scope). The name is a length-one character (a variable holding the name
+    works too); `get` of an unbound name errors, `exists` searches the whole
+    chain, `rm` deletes from the current frame.
+  - `env.rs` gains `exists` and `remove` helpers alongside `super_assign`.
+
+### Deferred to R-22
+
+- First-class environment **values**: `new.env()`, `environment()` /
+  `environment(f)`, and the `envir = e` argument of
+  `assign`/`get`/`exists`/`rm`/`local` (they need a new `SValue::Environment`
+  variant and a fresh round of Rc-cycle / leak analysis). The `envir` argument is
+  rejected today with a clear "deferred to R-22" error rather than silently
+  ignored.
+
 ## [0.16.0] - 2026-06-20
 
 ### Added

--- a/code/packages/rust/s-runtime/README.md
+++ b/code/packages/rust/s-runtime/README.md
@@ -97,6 +97,17 @@ a hand-written loop. See [What "S-flavored" means here](#what-s-flavored-means-h
   `call_closure` (RAII-popped). Recursion is bounded by `MAX_EVAL_DEPTH` and the
   accumulator by `MAX_SEQ_LEN`; non-callable predicates and out-of-closure
   `Recall` fail closed.
+- **Environments & scoping** (R-21): `<<-` super-assignment (`env::super_assign`)
+  walks the *enclosing* scope chain to rebind the nearest existing binding, else
+  creates it in the global environment — the engine behind the counter-closure
+  idiom `function() { n <- 0; function() { n <<- n + 1; n } }`. `local({ ... })`
+  evaluates a block in a fresh child scope and returns its value without leaking
+  locals (`local({ x <- 5; x * 2 })` → `10`). `assign`/`get`/`exists`/`rm` are
+  lazy special forms (like `switch`/`tryCatch`) operating by name against the
+  current scope. The chain walk is iterative over a finite acyclic scope list, so
+  it always terminates; non-name super-assign targets and the not-yet-supported
+  `envir = e` argument fail closed. First-class environment *values* (`new.env`,
+  `environment`) are deferred to R-22.
 - The **`d`/`p`/`q`/`r` distribution family** (R-8) over `statistics-core`:
   density/CDF/quantile/sampling for the normal, uniform, and exponential
   distributions, plus `set.seed` for a reproducible per-session RNG.

--- a/code/packages/rust/s-runtime/src/env.rs
+++ b/code/packages/rust/s-runtime/src/env.rs
@@ -119,6 +119,15 @@ pub fn super_assign(env: &Env, name: &str, value: SValue) {
     // frame at all (we were already at global), bind here.
     match last {
         Some(global) => {
+            // `last` is the final frame the walk reached, so by the acyclic-chain
+            // invariant it must be the parent-less root (the global env). Assert
+            // that invariant in debug builds — if it ever fails, the scope chain
+            // has been wired into a cycle or a non-root terminus, which would be a
+            // construction bug elsewhere.
+            debug_assert!(
+                global.borrow().parent.is_none(),
+                "super_assign reached a non-root frame; scope chain is not rooted at global"
+            );
             global.borrow_mut().vars.insert(name.to_string(), value);
         }
         None => define(env, name, value),

--- a/code/packages/rust/s-runtime/src/env.rs
+++ b/code/packages/rust/s-runtime/src/env.rs
@@ -57,3 +57,70 @@ pub fn lookup(env: &Env, name: &str) -> Option<SValue> {
         None => None,
     }
 }
+
+/// Is `name` bound *anywhere* on the chain (current frame or any enclosing one)?
+/// This is the engine behind R's `exists(x)`: a cheap presence test that does not
+/// clone the value. Like [`lookup`] it walks outward to the global frame.
+pub fn exists(env: &Env, name: &str) -> bool {
+    if env.borrow().vars.contains_key(name) {
+        return true;
+    }
+    let parent = env.borrow().parent.clone();
+    match parent {
+        Some(p) => exists(&p, name),
+        None => false,
+    }
+}
+
+/// Remove `name` from the **current** frame's bindings, returning whether a
+/// binding was actually present. This is R's `rm(x)`: it only ever deletes from
+/// the frame it is called in (it does not reach into enclosing scopes), matching
+/// R's `rm(..., envir = environment())` default.
+pub fn remove(env: &Env, name: &str) -> bool {
+    env.borrow_mut().vars.remove(name).is_some()
+}
+
+/// Super-assignment (`x <<- value`). R's rule: search the chain of **enclosing**
+/// environments — i.e. start at the *parent*, skipping the current frame — for an
+/// existing binding of `name`, and rebind the **nearest** one found. If no
+/// enclosing frame binds the name, create it in the **global** (root) environment.
+///
+/// Why skip the current frame? `<<-` exists precisely to reach *past* the local
+/// scope: inside a counter closure, `n <<- n + 1` must mutate the `n` captured in
+/// the enclosing function frame, not shadow it with a fresh local `n`. (If `<<-`
+/// looked at the current frame first it would behave like `<-` whenever a local
+/// of the same name existed — the opposite of what it is for.)
+///
+/// ## Termination
+///
+/// The walk follows `parent` links only. Every [`Scope`] is created by
+/// [`Scope::global`] (no parent) or [`Scope::child`] (parent is an *already
+/// existing* env), so the chain is a finite, acyclic list rooted at the global
+/// frame — there is no way to construct a cycle from S/R source. The loop below
+/// therefore always reaches a parent-less frame and stops. We walk iteratively
+/// (not recursively) so even a pathologically deep chain cannot overflow the
+/// native stack here; the chain depth is in turn bounded by `MAX_EVAL_DEPTH`,
+/// since each nested call frame costs eval-recursion to create.
+pub fn super_assign(env: &Env, name: &str, value: SValue) {
+    // Start from the enclosing frame (skip the current one).
+    let mut cursor = env.borrow().parent.clone();
+    let mut last: Option<Env> = None;
+    while let Some(frame) = cursor {
+        if frame.borrow().vars.contains_key(name) {
+            // Found an existing enclosing binding — rebind it in place.
+            frame.borrow_mut().vars.insert(name.to_string(), value);
+            return;
+        }
+        last = Some(Rc::clone(&frame));
+        cursor = frame.borrow().parent.clone();
+    }
+    // No enclosing frame had the name. R creates it in the global environment,
+    // which is the root we just walked to (`last`). If there was no enclosing
+    // frame at all (we were already at global), bind here.
+    match last {
+        Some(global) => {
+            global.borrow_mut().vars.insert(name.to_string(), value);
+        }
+        None => define(env, name, value),
+    }
+}

--- a/code/packages/rust/s-runtime/src/eval.rs
+++ b/code/packages/rust/s-runtime/src/eval.rs
@@ -17,7 +17,7 @@
 //! call) is visible, exactly as in S.
 
 use crate::builtins;
-use crate::env::{define, lookup, Env, Scope};
+use crate::env::{define, exists, lookup, remove, super_assign, Env, Scope};
 use crate::error::{SError, SResult};
 use crate::value::{
     arithmetic, assign_index, assign_index2d, bounded_sequence, class_of, compare, format_value,
@@ -324,14 +324,33 @@ impl Interpreter {
             (nodes[0], nodes[1]) // target <- value
         };
         let value = self.eval_node(value_node, env)?;
+        // `<<-` / `->>` are *super-assignment* (R-21): rebind the nearest
+        // ENCLOSING binding of the name, or create one in the global environment
+        // if none exists. They only ever target a bare name (R does not define
+        // `x[i] <<- v` sub-assignment in this subset).
+        let is_super = op == "<<-" || op == "->>";
         // A bare-name target is the simple case; otherwise try `x[...] <- v`
         // sub-assignment (R-14) before giving up.
         match lvalue_name(target_node) {
             Ok(name) => {
-                define(env, &name, value.clone());
+                if is_super {
+                    super_assign(env, &name, value.clone());
+                } else {
+                    define(env, &name, value.clone());
+                }
                 self.as_invisible(value)
             }
-            Err(simple_err) => self.eval_indexed_assignment(target_node, value, env, simple_err),
+            Err(simple_err) => {
+                if is_super {
+                    // `<<-` with a non-name target (e.g. `x[1] <<- v`) is not
+                    // supported in this subset — fail cleanly rather than silently
+                    // falling through to ordinary (current-scope) sub-assignment.
+                    return Err(SError::TypeError(
+                        "super-assignment (`<<-`/`->>`) requires a bare-name target".into(),
+                    ));
+                }
+                self.eval_indexed_assignment(target_node, value, env, simple_err)
+            }
         }
     }
 
@@ -802,6 +821,12 @@ impl Interpreter {
                     return match special {
                         "switch" => self.eval_switch(&raw, env),
                         "tryCatch" => self.eval_try_catch(&raw, env),
+                        // R-21 environment forms.
+                        "local" => self.eval_local(&raw, env),
+                        "assign" => self.eval_assign_fn(&raw, env),
+                        "get" => self.eval_get_fn(&raw, env),
+                        "exists" => self.eval_exists_fn(&raw, env),
+                        "rm" => self.eval_rm_fn(&raw, env),
                         _ => unreachable!(),
                     };
                 }
@@ -1354,6 +1379,142 @@ impl Interpreter {
     }
 
     // -----------------------------------------------------------------------
+    // R-21 environment forms (local / assign / get / exists / rm)
+    //
+    // These are *lazy special forms* rather than ordinary builtins because they
+    // must see the **current** environment `env`: `local` evaluates its block in
+    // a fresh child of it, and the by-name binding ops read/write it directly.
+    // (Ordinary builtins receive only their evaluated argument *values*, never
+    // the live scope.) Each rejects the `envir = e` argument with a clear "not
+    // yet supported" error — first-class environment values land in R-22.
+    // -----------------------------------------------------------------------
+
+    /// `local({ ... })` — evaluate the (single, unevaluated) expression argument
+    /// in a **fresh child environment** of the current scope and return its
+    /// value. Because the block runs in its own frame, any `<-` bindings it makes
+    /// are locals that do not leak: `local({ x <- 5; x * 2 })` is `10`, and `x`
+    /// stays unbound in the caller. (R also accepts `local(expr, envir)`; the
+    /// second form needs a first-class environment value and is deferred to R-22.)
+    fn eval_local(&self, raw: &[RawArg], env: &Env) -> SResult<SValue> {
+        if raw.iter().any(|(name, _)| name.as_deref() == Some("envir")) {
+            return Err(SError::BadArgs(
+                "local(expr, envir = e): the `envir` argument needs a first-class \
+                 environment value, deferred to R-22"
+                    .into(),
+            ));
+        }
+        let expr = raw
+            .first()
+            .and_then(|(_, n)| arm_body(n))
+            .ok_or_else(|| SError::BadArgs("local: expr is missing".into()))?;
+        // A fresh child scope: locals live and die here.
+        let scope = Scope::child(env);
+        self.eval_node(expr, &scope)
+    }
+
+    /// `assign(x, value)` — bind the name given by the length-one character `x`
+    /// to `value` in the **current** environment (the `<-` target scope). Returns
+    /// `value` invisibly, like R. `assign("y", 1 + 1)` then `y` → `2`. The
+    /// `envir = e` argument is rejected (deferred to R-22).
+    fn eval_assign_fn(&self, raw: &[RawArg], env: &Env) -> SResult<SValue> {
+        self.reject_envir(raw, "assign")?;
+        let positionals = self.positional_nodes(raw);
+        let name_node = positionals
+            .first()
+            .ok_or_else(|| SError::BadArgs("assign: `x` (the name) is missing".into()))?;
+        let value_node = positionals
+            .get(1)
+            .ok_or_else(|| SError::BadArgs("assign: `value` is missing".into()))?;
+        let name = self.eval_name_string(name_node, env, "assign")?;
+        let value = self.eval_node(value_node, env)?;
+        define(env, &name, value.clone());
+        self.as_invisible(value)
+    }
+
+    /// `get(x)` — return the value currently bound to the name `x`, searching the
+    /// scope chain (current frame outward). An unbound name is a clean error,
+    /// exactly as in R (`Error: object 'x' not found`). `envir` is deferred.
+    fn eval_get_fn(&self, raw: &[RawArg], env: &Env) -> SResult<SValue> {
+        self.reject_envir(raw, "get")?;
+        let positionals = self.positional_nodes(raw);
+        let name_node = positionals
+            .first()
+            .ok_or_else(|| SError::BadArgs("get: `x` (the name) is missing".into()))?;
+        let name = self.eval_name_string(name_node, env, "get")?;
+        let value = lookup(env, &name).ok_or_else(|| SError::Undefined(name.clone()))?;
+        self.as_visible(value)
+    }
+
+    /// `exists(x)` — `TRUE` if the name `x` is bound anywhere on the scope chain,
+    /// `FALSE` otherwise. `exists("mean")` → `TRUE` (a builtin in the global
+    /// frame); `exists("zzz")` → `FALSE`. `envir` is deferred.
+    fn eval_exists_fn(&self, raw: &[RawArg], env: &Env) -> SResult<SValue> {
+        self.reject_envir(raw, "exists")?;
+        let positionals = self.positional_nodes(raw);
+        let name_node = positionals
+            .first()
+            .ok_or_else(|| SError::BadArgs("exists: `x` (the name) is missing".into()))?;
+        let name = self.eval_name_string(name_node, env, "exists")?;
+        self.as_visible(SValue::Logical(vec![Some(exists(env, &name))]))
+    }
+
+    /// `rm(x)` — remove the binding `x` from the **current** frame (it does not
+    /// reach into enclosing scopes, matching R's `rm(..., envir =
+    /// environment())` default). Returns `NULL` invisibly. Removing a name that
+    /// is not bound in the current frame is a no-op (R warns; we stay quiet).
+    fn eval_rm_fn(&self, raw: &[RawArg], env: &Env) -> SResult<SValue> {
+        self.reject_envir(raw, "rm")?;
+        let positionals = self.positional_nodes(raw);
+        let name_node = positionals
+            .first()
+            .ok_or_else(|| SError::BadArgs("rm: a name to remove is missing".into()))?;
+        let name = self.eval_name_string(name_node, env, "rm")?;
+        remove(env, &name);
+        self.as_invisible(SValue::Null)
+    }
+
+    /// Reject an `envir = e` argument for the R-21 binding forms — that argument
+    /// needs a first-class environment value (R-22). Centralised so every form
+    /// gives the identical, discoverable message.
+    fn reject_envir(&self, raw: &[RawArg], who: &str) -> SResult<()> {
+        if raw.iter().any(|(name, _)| name.as_deref() == Some("envir")) {
+            return Err(SError::BadArgs(format!(
+                "{who}(..., envir = e): the `envir` argument needs a first-class \
+                 environment value, deferred to R-22"
+            )));
+        }
+        Ok(())
+    }
+
+    /// The *positional* (unnamed) argument nodes of a raw arg list, in order —
+    /// the binding ops take `x` (and `value`) positionally.
+    fn positional_nodes<'a>(&self, raw: &'a [RawArg<'a>]) -> Vec<&'a GrammarASTNode> {
+        raw.iter()
+            .filter(|(name, _)| name.is_none())
+            .filter_map(|(_, n)| arm_body(n))
+            .collect()
+    }
+
+    /// Evaluate a name-argument node to the `String` it denotes. R's binding ops
+    /// take the name as a length-one **character** value (`get("x")`), and a
+    /// variable holding such a string works too (`nm <- "x"; get(nm)`). We
+    /// therefore evaluate the node and require a length-one character result;
+    /// anything else (a number, a length-≠1 vector) is a clean `BadArgs` error.
+    fn eval_name_string(
+        &self,
+        node: &GrammarASTNode,
+        env: &Env,
+        who: &str,
+    ) -> SResult<String> {
+        let value = self.eval_node(node, env)?;
+        single_string(&value).ok_or_else(|| {
+            SError::BadArgs(format!(
+                "{who}: the name must be a single character string"
+            ))
+        })
+    }
+
+    // -----------------------------------------------------------------------
     // Visibility helpers
     // -----------------------------------------------------------------------
 
@@ -1392,6 +1553,15 @@ fn special_form_name(primary: &GrammarASTNode) -> Option<&'static str> {
     match tokens.as_slice() {
         [("NAME", "switch")] => Some("switch"),
         [("NAME", "tryCatch")] => Some("tryCatch"),
+        // R-21 environment forms — special because they must see the *current*
+        // environment (`local` evaluates its block in a fresh child scope; the
+        // binding ops read/write `env` by name), which ordinary eager builtins
+        // never receive.
+        [("NAME", "local")] => Some("local"),
+        [("NAME", "assign")] => Some("assign"),
+        [("NAME", "get")] => Some("get"),
+        [("NAME", "exists")] => Some("exists"),
+        [("NAME", "rm")] => Some("rm"),
         _ => None,
     }
 }

--- a/code/packages/rust/s-runtime/src/lib.rs
+++ b/code/packages/rust/s-runtime/src/lib.rs
@@ -1381,4 +1381,147 @@ mod r20_functional_helpers {
             let _ = eval_s(src);
         }
     }
+
+}
+
+/// R-21 — environments & scoping. The model lives in `s-runtime` (the shared
+/// scope chain), so these S-syntax tests exercise it directly; the R-syntax
+/// integration tests mirror them in `r-runtime`.
+#[cfg(test)]
+mod r21_environments {
+    use super::*;
+
+    fn nums(src: &str) -> Vec<f64> {
+        match eval_s(src).unwrap().strip_names() {
+            SValue::Double(d) => d.data().to_vec(),
+            other => panic!("expected double, got {}", other.type_name()),
+        }
+    }
+
+    fn show(src: &str) -> String {
+        format_value(&eval_s(src).unwrap()).join("\n")
+    }
+
+    /// `local({...})` runs its block in a fresh child scope; the block's value
+    /// comes back but its local bindings do not leak into the caller.
+    #[test]
+    fn local_returns_value_and_does_not_leak() {
+        assert_eq!(nums("local({ x <- 5; x * 2 })\n"), vec![10.0]);
+        // `x` was a local of the block, so it is unbound afterward.
+        assert!(
+            eval_s("local({ x <- 5 })\nx\n").is_err(),
+            "local's bindings must not escape into the caller"
+        );
+    }
+
+    /// `<<-` from inside a function with no enclosing binding creates the name
+    /// in the GLOBAL environment (the value is visible after the call returns).
+    #[test]
+    fn super_assign_creates_in_global() {
+        assert_eq!(
+            nums("f <- function() { y <<- 99 }\nf()\ny\n"),
+            vec![99.0]
+        );
+    }
+
+    /// A counter closure: `<<-` mutates the `n` captured in the ENCLOSING frame
+    /// rather than shadowing it with a fresh local, so successive calls advance.
+    #[test]
+    fn super_assign_mutates_enclosing_state() {
+        let src = "make <- function() { n <- 0; function() { n <<- n + 1; n } }\n\
+                   c1 <- make()\n\
+                   c1(); c1(); c1()\n";
+        assert_eq!(nums(src), vec![3.0]);
+        // A second counter has its OWN enclosing `n` — they don't interfere.
+        let src2 = "make <- function() { n <- 0; function() { n <<- n + 1; n } }\n\
+                    a <- make()\nb <- make()\n\
+                    a(); a(); b()\n";
+        assert_eq!(nums(src2), vec![1.0]);
+    }
+
+    /// `<<-` rebinds the NEAREST enclosing binding, not the global one, when an
+    /// intermediate frame already binds the name.
+    #[test]
+    fn super_assign_targets_nearest_enclosing() {
+        let src = "g <- 1\n\
+                   outer <- function() { g <- 10; inner <- function() { g <<- 42 }; inner(); g }\n\
+                   outer()\n";
+        // `inner`'s `<<-` hits `outer`'s `g` (= 42), leaving the global `g` at 1.
+        assert_eq!(nums(src), vec![42.0]);
+        assert_eq!(nums(&format!("{src}g\n")), vec![1.0]);
+    }
+
+    // (The right-super-assign form `->>` is R-grammar-only — `s.grammar`'s
+    // `assignment` rule has no `RIGHT_SUPER_ASSIGN`, so it is exercised through
+    // the R parser in `r-runtime`'s tests, not here.)
+
+    /// `assign`/`get` round-trip against the current scope; `get` of an unbound
+    /// name is a clean error (not a panic).
+    #[test]
+    fn assign_get_round_trip() {
+        assert_eq!(nums("assign(\"q\", 3 + 4)\nget(\"q\")\n"), vec![7.0]);
+        // A variable holding the name works too.
+        assert_eq!(nums("nm <- \"w\"\nassign(nm, 11)\nget(nm)\n"), vec![11.0]);
+        assert!(eval_s("get(\"never_bound\")\n").is_err());
+    }
+
+    /// `exists` searches the whole chain: a builtin and a user binding are
+    /// `TRUE`; an unbound name is `FALSE`.
+    #[test]
+    fn exists_reports_binding_presence() {
+        assert_eq!(show("exists(\"mean\")\n"), "[1] TRUE");
+        assert_eq!(show("exists(\"zzz\")\n"), "[1] FALSE");
+        assert_eq!(show("kk <- 1\nexists(\"kk\")\n"), "[1] TRUE");
+    }
+
+    /// `rm` removes a binding from the current frame; the name is gone afterward.
+    #[test]
+    fn rm_removes_binding() {
+        assert_eq!(nums("d <- 5\nd\n"), vec![5.0]);
+        assert!(eval_s("d <- 5\nrm(\"d\")\nd\n").is_err());
+        // Removing an unbound name is a quiet no-op, not an error.
+        assert!(eval_s("rm(\"never_there\")\n").is_ok());
+    }
+
+    /// The `envir = e` argument is explicitly rejected (deferred to R-22) with a
+    /// clean error rather than a silent wrong answer or a panic.
+    #[test]
+    fn envir_argument_is_rejected_for_now() {
+        for src in [
+            "assign(\"x\", 1, envir = 2)\n",
+            "get(\"x\", envir = 2)\n",
+            "exists(\"x\", envir = 2)\n",
+            "rm(\"x\", envir = 2)\n",
+            "local({ 1 }, envir = 2)\n",
+        ] {
+            assert!(eval_s(src).is_err(), "{src:?} should reject `envir`");
+        }
+    }
+
+    /// Hardening: degenerate inputs to the new environment forms must never
+    /// panic — only `Ok` or a recoverable `Err`.
+    #[test]
+    fn environment_forms_do_not_panic() {
+        for src in [
+            "local()\n",            // no block
+            "assign()\n",           // no name, no value
+            "assign(\"x\")\n",      // name but no value
+            "assign(1, 2)\n",       // non-string name
+            "get()\n",              // no name
+            "get(1)\n",             // non-string name
+            "exists()\n",           // no name
+            "rm()\n",               // no name
+            "x <<- 1\n",            // super-assign at top level (no enclosing)
+            "(1:3)[1] <<- 9\n",     // super-assign with a non-name target
+        ] {
+            let _ = eval_s(src);
+        }
+    }
+
+    /// Top-level `<<-` (no enclosing frame at all) binds in the current (global)
+    /// scope rather than erroring or looping.
+    #[test]
+    fn top_level_super_assign_binds_globally() {
+        assert_eq!(nums("p <<- 8\np\n"), vec![8.0]);
+    }
 }

--- a/code/specs/R00-r-language.md
+++ b/code/specs/R00-r-language.md
@@ -405,6 +405,53 @@ unchanged.
     the native stack. This makes the classic anonymous factorial work:
     `(\(n) if (n <= 1) 1 else n * Recall(n - 1))(5)` → `120`.
 
+- **R-21 — environments & scoping (core subset)** *(this PR)*. R's *environment
+  model* — the machinery behind lexical scoping — made writable from R source.
+  R reuses the shared S scope chain (`env::Scope`, an `Rc<RefCell<…>>` frame with
+  an optional parent), so this item is **grammar-free**: the `<<-`/`->>` tokens
+  already lex (they were reserved in `s.tokens`/`r.tokens` from the start and the
+  `->>` right form was wired through the `assignment` rule by R-3), and the new
+  by-name binding operations are **lazy special forms** intercepted at the call
+  site (like R-18's `switch`/`tryCatch`), since they need the *current*
+  environment, which ordinary eager builtins never see. This PR ships the core
+  subset; first-class environment **values** are deferred to R-22 (see below).
+  - **`<<-` super-assignment** (and its right form `->>`). Where `<-` binds in
+    the *current* scope, `<<-` walks the chain of **enclosing** scopes (skipping
+    the current one) looking for an existing binding of the name and rebinds the
+    **nearest** one it finds. If no enclosing scope binds the name, the value is
+    created in the **global** environment (matching R). This is what makes the
+    counter-closure idiom work: `make_counter <- function() { n <- 0; function()
+    { n <<- n + 1; n } }` — the inner function mutates the `n` captured in its
+    enclosing frame rather than shadowing it locally. The chain walk is bounded
+    by the finite scope depth (every frame is a distinct `Rc`, and `child` only
+    ever links to an existing parent, so the chain is a DAG-free finite list — no
+    cycle is constructible from R source), so the walk always terminates.
+  - **`local({ … })`** — evaluate a block in a **fresh child environment** of the
+    current scope and return the block's value. Bindings made with `<-` inside the
+    block are locals and do **not** leak: `local({ x <- 5; x * 2 })` → `10`, and
+    `x` is unbound afterwards. A lazy special form: the unevaluated block argument
+    is evaluated in `Scope::child(env)`. (R also accepts a second `envir`
+    argument; that requires first-class environment values and is deferred.)
+  - **`assign(x, value)` / `get(x)` / `exists(x)` / `rm(x)`** — by-name binding
+    operations against the **current** environment. `assign("y", 10)` binds `y`;
+    `get("y")` returns it (erroring if unbound, like R); `exists("y")` is
+    `TRUE`/`FALSE` searching the whole chain (so `exists("mean")` is `TRUE`,
+    `exists("zzz")` is `FALSE`); `rm("y")` removes a binding from the current
+    frame. These are special forms because they must touch `env`; the name
+    argument is a length-one string evaluated normally (so `assign(nm, v)` with a
+    variable name works). The optional `envir = e` argument is **deferred** to
+    R-22 (it needs a first-class environment value to point at).
+  - **Deferred to R-22 (first-class environment values).** `new.env()`,
+    `environment()` / `environment(f)`, and the `envir = e` argument of
+    `assign`/`get`/`exists`/`rm`/`local` all require a new `SValue::Environment`
+    variant that boxes an `Env` handle and survives being passed as a value.
+    That is a larger change (printing, `is`-dispatch, copy semantics, and a fresh
+    round of Rc-cycle / leak analysis), so per the roadmap's "clean subset beats a
+    sprawling PR" guidance it is split out. The subset above already delivers the
+    *behaviour* R programs reach for most (`local`, `<<-`, `exists`/`get`/`assign`
+    against the current scope); R-22 adds the reified handles on top without
+    changing any of it.
+
 ## §4 Reuse strategy
 
 - **Lexer/parser:** the grammar-tools framework, exactly as S uses it. `r.tokens`
@@ -417,9 +464,12 @@ unchanged.
 
 ## §5 Out of scope (for now)
 
-Pipes (`|>`) and backslash lambdas (`\(x)`); environments/`<<-` semantics beyond
-the S subset; S4/R5/R6 OO; namespaces and `library()`; the C interface; graphics.
-These layer on later, following ST00.
+Pipes (`|>`) and backslash lambdas (`\(x)`); **first-class environment values**
+(`new.env()`, `environment()`, and the `envir = e` argument of
+`assign`/`get`/`exists`/`rm`/`local`) — deferred to **R-21's follow-up R-22**
+once an `SValue::Environment` variant lands (R-21 ships `local()` + `<<-` +
+current-scope `assign`/`get`/`exists`/`rm`); S4/R5/R6 OO; namespaces and
+`library()`; the C interface; graphics. These layer on later, following ST00.
 
 ## §6 References
 

--- a/code/specs/S00-s-language.md
+++ b/code/specs/S00-s-language.md
@@ -79,7 +79,7 @@ arguments inside a call) — also faithful to the era.
 
 S3/S4 method dispatch; lazy-evaluation promises; data frames, factors, and
 formulas (`y ~ x`); the `d/p/q/r` distribution family and modeling (`lm`);
-`<<-` superassignment; user-defined `%op%` infix operators; complex numbers and
+user-defined `%op%` infix operators; complex numbers and
 the integer-`L` suffix; negative/logical/named indexing and `[[ ]]`/`$`;
 attributes beyond `names`; graphics. The numeric/statistical depth lives in
 ST02–ST12 and `statistics-core`; this spec is only the language frontend.
@@ -89,7 +89,7 @@ ST02–ST12 and `statistics-core`; this spec is only the language frontend.
 | Token | Pattern / value | Notes |
 |-------|-----------------|-------|
 | `ASSIGN` | `<-` | primary assignment |
-| `SUPER_ASSIGN` | `<<-` | lexed (reserved); v1 treats as `<-` |
+| `SUPER_ASSIGN` | `<<-` | super-assignment (R-21): rebinds in the nearest enclosing scope, else global |
 | `RIGHT_ASSIGN` | `->` | right assignment |
 | `UNDERSCORE` | `_` | **historical assignment** |
 | `NUMBER` | `[0-9]*\.?[0-9]+([eE][+-]?[0-9]+)?` | double literal |


### PR DESCRIPTION
## R-21 — environments & scoping

Implements R's environment-model **core subset** in the shared `s-runtime`
tree-walker (R inherits it through the same evaluator; the changes also give
historical S real `<<-` super-assignment).

### What shipped
- **`<<-` / `->>` super-assignment** — `env::super_assign` walks the chain of
  *enclosing* environments (skipping the current frame), rebinds the **nearest**
  existing binding of the name, and creates the binding in the **global**
  environment if none exists. This is the engine behind the counter-closure
  idiom (`make <- function() { n <- 0; function() { n <<- n + 1; n } }`).
- **`local({ ... })`** — evaluates a block in a fresh child scope and returns its
  value; locals don't leak (`local({ x <- 5; x * 2 })` → `10`, `x` unbound after).
- **`assign` / `get` / `exists` / `rm`** against the **current** environment,
  implemented as lazy special forms (intercepted at the call site like
  `switch`/`tryCatch`, since they need the live scope). The name argument is a
  length-one character (a variable holding the name works too).

### Deferred to R-22 (documented in spec §3.5/§5)
First-class environment **values** — `new.env()`, `environment()` /
`environment(f)`, and the `envir = e` argument of
`assign`/`get`/`exists`/`rm`/`local`. These need a new `SValue::Environment`
variant plus a fresh round of Rc-cycle / leak analysis, so per the roadmap's
"clean subset beats a sprawling PR" guidance they are split out. The `envir`
argument is **rejected today** with a clear "deferred to R-22" error rather than
silently ignored. A clean partial.

### Grammar status
**No grammar change.** The `<<-` (`SUPER_ASSIGN`) and `->>`
(`RIGHT_SUPER_ASSIGN`) tokens already lex (reserved from the start in
`s.tokens`/`r.tokens`) and `->>` was wired through `r.grammar`'s `assignment`
rule by R-3. The diff contains **no generated `_grammar.rs`** and no
crate/workspace-wide rustfmt churn — functional code + tests + docs/specs only.

### Tests
- `s-runtime` (S syntax, new `r21_environments` module): `local` non-leak,
  global-creating `<<-`, counter closure, nearest-enclosing rebind, assign/get
  round-trip, `exists` TRUE/FALSE, `rm`, `envir` rejection, top-level `<<-`, and
  a no-panic probe over degenerate inputs (missing/non-string args, `x[i] <<- v`).
- `r-runtime` (R syntax): `local`, global `<<-`, counter closure, R-only `->>`,
  `assign`/`get`/`exists`, `rm`, plus an R-18/19/20 regression guard.
- **`cargo test -p coding-adventures-s-runtime -p coding-adventures-r-runtime`**:
  s-runtime **177 passed**, r-runtime **125 passed**, 0 failed. `cargo clippy`
  clean for both crates. Coverage well exceeds 80% (every new function and every
  error/degenerate branch is exercised).

### Security review
A sub-agent acting as a senior Rust security engineer reviewed
`git diff origin/main...HEAD` focusing on Rc cycles / unbounded environment
chains, `<<-` infinite scope-walk, panics on crafted input, and the
`MAX_EVAL_DEPTH` bound. **Verdict: PASS** — no CRITICAL/HIGH/MEDIUM findings. The
scope chain is finite/acyclic (no parent setter; `child` always links to an
existing parent), the walk is iterative, every degenerate path returns `Err`
(never panics), and the depth guard is unbypassed. The one INFO suggestion (a
`debug_assert` documenting the "rooted at global" invariant) was applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
