### PR TITLE
[codex] Add mesh release task readiness summary

### DIFF
--- a/code/packages/rust/smart-home-integration-catalog/CHANGELOG.md
+++ b/code/packages/rust/smart-home-integration-catalog/CHANGELOG.md
@@ -137,6 +137,8 @@ All notable changes to this package will be documented in this file.
   state.
 - `IntegrationMeshReleaseExecutionTask` and summary helpers for turning mesh
   release-readiness check slots into deterministic low-level operator work.
+- `IntegrationMeshReleaseTaskReadinessSummary` and helpers for combining mesh
+  release execution readiness with deterministic task state.
 - Primitive backlog planning helpers for ranking the shared primitive families
   needed by priority-bounded rollout waves.
 - Integration activation planning helpers for resolving virtual aliases,

--- a/code/packages/rust/smart-home-integration-catalog/README.md
+++ b/code/packages/rust/smart-home-integration-catalog/README.md
@@ -111,6 +111,8 @@ runtime and Chief of Staff tools a typed catalog for:
   go/no-go state with release-readiness check slot execution state
 - low-level mesh release execution tasks that turn release-readiness check
   slots into deterministic operator work
+- mesh release task readiness summaries that combine execution readiness with
+  deterministic task state
 - primitive backlog planning for prioritizing the shared families needed by a
   rollout wave
 - activation plans that resolve direct integrations, virtual aliases, and

--- a/code/packages/rust/smart-home-integration-catalog/src/lib.rs
+++ b/code/packages/rust/smart-home-integration-catalog/src/lib.rs
@@ -5345,6 +5345,166 @@ impl IntegrationMeshReleaseExecutionTaskSummary {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IntegrationMeshReleaseTaskReadinessSummary {
+    pub release_execution_readiness_summary: IntegrationMeshReleaseExecutionReadinessSummary,
+    pub release_execution_task_summary: IntegrationMeshReleaseExecutionTaskSummary,
+    pub total_checks: usize,
+    pub ready_checks: usize,
+    pub blocked_checks: usize,
+    pub review_required_checks: usize,
+    pub operator_required_checks: usize,
+    pub checks_requiring_attention: usize,
+    pub total_slots: usize,
+    pub ready_slots: usize,
+    pub blocked_slots: usize,
+    pub review_required_slots: usize,
+    pub operator_required_slots: usize,
+    pub slots_requiring_attention: usize,
+    pub total_tasks: usize,
+    pub ready_tasks: usize,
+    pub blocked_tasks: usize,
+    pub review_required_tasks: usize,
+    pub operator_required_tasks: usize,
+    pub tasks_requiring_attention: usize,
+    pub queued_substrate_actions: usize,
+    pub remediation_item_count: usize,
+    pub review_required_packages: usize,
+    pub operator_required_packages: usize,
+    pub blocked_packages: usize,
+    pub first_task_key: Option<String>,
+    pub first_blocked_task_key: Option<String>,
+    pub first_review_task_key: Option<String>,
+    pub first_operator_task_key: Option<String>,
+    pub next_task_key: Option<String>,
+    pub next_slot_key: Option<String>,
+    pub next_check_kind: Option<IntegrationMeshReleaseReadinessCheckKind>,
+    pub next_check_status: Option<IntegrationMeshReleaseReadinessStatus>,
+    pub next_package_kind: Option<IntegrationMeshReadinessHandoffKind>,
+    pub next_handoff_status: Option<IntegrationMeshReadinessHandoffStatus>,
+    pub packet_status: IntegrationMeshReleaseReadinessStatus,
+    pub execution_status: IntegrationMeshReleaseReadinessStatus,
+    pub release_packet_ready: bool,
+    pub release_check_slots_ready: bool,
+    pub release_execution_ready: bool,
+    pub release_tasks_ready: bool,
+}
+
+impl IntegrationMeshReleaseTaskReadinessSummary {
+    pub fn from_summaries(
+        release_execution_readiness_summary: IntegrationMeshReleaseExecutionReadinessSummary,
+        release_execution_task_summary: IntegrationMeshReleaseExecutionTaskSummary,
+    ) -> Self {
+        let next_package_kind = release_execution_task_summary
+            .next_package_kind
+            .or(release_execution_readiness_summary.next_package_kind);
+        let next_handoff_status = release_execution_task_summary
+            .next_handoff_status
+            .or(release_execution_readiness_summary.next_handoff_status);
+        let release_tasks_ready = release_execution_task_summary.ready_for_execution();
+        let release_execution_ready =
+            release_execution_readiness_summary.ready_for_execution() && release_tasks_ready;
+
+        Self {
+            total_checks: release_execution_readiness_summary.total_checks,
+            ready_checks: release_execution_readiness_summary.ready_checks,
+            blocked_checks: release_execution_readiness_summary.blocked_checks,
+            review_required_checks: release_execution_readiness_summary.review_required_checks,
+            operator_required_checks: release_execution_readiness_summary.operator_required_checks,
+            checks_requiring_attention: release_execution_readiness_summary
+                .checks_requiring_attention,
+            total_slots: release_execution_readiness_summary.total_slots,
+            ready_slots: release_execution_readiness_summary.ready_slots,
+            blocked_slots: release_execution_readiness_summary.blocked_slots,
+            review_required_slots: release_execution_readiness_summary.review_required_slots,
+            operator_required_slots: release_execution_readiness_summary.operator_required_slots,
+            slots_requiring_attention: release_execution_readiness_summary
+                .slots_requiring_attention,
+            total_tasks: release_execution_task_summary.total_tasks,
+            ready_tasks: release_execution_task_summary.ready_tasks,
+            blocked_tasks: release_execution_task_summary.blocked_tasks,
+            review_required_tasks: release_execution_task_summary.review_required_tasks,
+            operator_required_tasks: release_execution_task_summary.operator_required_tasks,
+            tasks_requiring_attention: release_execution_task_summary.tasks_requiring_attention,
+            queued_substrate_actions: release_execution_readiness_summary.queued_substrate_actions,
+            remediation_item_count: release_execution_readiness_summary.remediation_item_count,
+            review_required_packages: release_execution_readiness_summary.review_required_packages,
+            operator_required_packages: release_execution_readiness_summary
+                .operator_required_packages,
+            blocked_packages: release_execution_readiness_summary.blocked_packages,
+            first_task_key: release_execution_task_summary.first_task_key.clone(),
+            first_blocked_task_key: release_execution_task_summary
+                .first_blocked_task_key
+                .clone(),
+            first_review_task_key: release_execution_task_summary.first_review_task_key.clone(),
+            first_operator_task_key: release_execution_task_summary
+                .first_operator_task_key
+                .clone(),
+            next_task_key: release_execution_task_summary.next_task_key.clone(),
+            next_slot_key: release_execution_task_summary.next_slot_key.clone(),
+            next_check_kind: release_execution_task_summary.next_check_kind,
+            next_check_status: release_execution_task_summary.next_check_status,
+            next_package_kind,
+            next_handoff_status,
+            packet_status: release_execution_readiness_summary.packet_status,
+            execution_status: release_execution_readiness_summary.execution_status,
+            release_packet_ready: release_execution_readiness_summary.release_packet_ready,
+            release_check_slots_ready: release_execution_readiness_summary
+                .release_check_slots_ready,
+            release_execution_ready,
+            release_tasks_ready,
+            release_execution_readiness_summary,
+            release_execution_task_summary,
+        }
+    }
+
+    pub fn ready_for_release_execution(&self) -> bool {
+        self.execution_status == IntegrationMeshReleaseReadinessStatus::Ready
+            && self.release_packet_ready
+            && self.release_check_slots_ready
+            && self.release_execution_ready
+            && self.release_tasks_ready
+            && !self.has_blockers()
+            && !self.has_review_work()
+    }
+
+    pub fn has_release_tasks(&self) -> bool {
+        self.total_tasks > 0
+    }
+
+    pub fn has_blockers(&self) -> bool {
+        self.blocked_checks > 0
+            || self.blocked_slots > 0
+            || self.blocked_tasks > 0
+            || self.blocked_packages > 0
+            || self.queued_substrate_actions > 0
+    }
+
+    pub fn has_review_work(&self) -> bool {
+        self.review_required_checks > 0
+            || self.review_required_slots > 0
+            || self.review_required_tasks > 0
+            || self.review_required_packages > 0
+    }
+
+    pub fn needs_operator(&self) -> bool {
+        self.operator_required_checks > 0
+            || self.operator_required_slots > 0
+            || self.operator_required_tasks > 0
+            || self.operator_required_packages > 0
+    }
+
+    pub fn requires_attention(&self) -> bool {
+        self.checks_requiring_attention > 0
+            || self.slots_requiring_attention > 0
+            || self.tasks_requiring_attention > 0
+            || self.has_blockers()
+            || self.has_review_work()
+            || self.needs_operator()
+            || !self.release_tasks_ready
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct IntegrationCatalogEntry {
     pub integration_id: IntegrationId,
     pub display_name: String,
@@ -26527,6 +26687,45 @@ pub fn mesh_release_execution_task_summary(
     )
 }
 
+pub fn mesh_release_task_readiness_summary_for_catalog(
+    catalog: &[IntegrationCatalogEntry],
+    available_primitives: &[PrimitiveFamily],
+    allowed_capabilities: &[CapabilityId],
+    enabled_integrations: &[IntegrationId],
+) -> IntegrationMeshReleaseTaskReadinessSummary {
+    let release_execution_readiness_summary = mesh_release_execution_readiness_summary_for_catalog(
+        catalog,
+        available_primitives,
+        allowed_capabilities,
+        enabled_integrations,
+    );
+    let release_execution_task_summary = mesh_release_execution_task_summary_for_catalog(
+        catalog,
+        available_primitives,
+        allowed_capabilities,
+        enabled_integrations,
+    );
+
+    IntegrationMeshReleaseTaskReadinessSummary::from_summaries(
+        release_execution_readiness_summary,
+        release_execution_task_summary,
+    )
+}
+
+pub fn mesh_release_task_readiness_summary(
+    available_primitives: &[PrimitiveFamily],
+    allowed_capabilities: &[CapabilityId],
+    enabled_integrations: &[IntegrationId],
+) -> IntegrationMeshReleaseTaskReadinessSummary {
+    let catalog = first_party_catalog();
+    mesh_release_task_readiness_summary_for_catalog(
+        &catalog,
+        available_primitives,
+        allowed_capabilities,
+        enabled_integrations,
+    )
+}
+
 fn mesh_protocol_catalog_entries(
     catalog: &[IntegrationCatalogEntry],
 ) -> Vec<IntegrationCatalogEntry> {
@@ -36299,6 +36498,166 @@ mod tests {
         assert!(!summary.needs_operator());
         assert!(!summary.requires_attention());
         assert!(tasks.iter().all(IntegrationMeshReleaseExecutionTask::ready));
+    }
+
+    #[test]
+    fn mesh_release_task_readiness_summary_surfaces_next_task_blocker() {
+        let available_primitives = vec![
+            PrimitiveFamily::Usb,
+            PrimitiveFamily::SerialController,
+            PrimitiveFamily::Radio802154,
+            PrimitiveFamily::Supervision,
+        ];
+        let allowed_capabilities = vec![CapabilityId::trusted("smart_home.read")];
+        let summary =
+            mesh_release_task_readiness_summary(&available_primitives, &allowed_capabilities, &[]);
+
+        assert_eq!(summary.total_checks, 5);
+        assert_eq!(summary.ready_checks, 0);
+        assert_eq!(summary.blocked_checks, 3);
+        assert_eq!(summary.review_required_checks, 2);
+        assert_eq!(summary.operator_required_checks, 4);
+        assert_eq!(summary.total_slots, 5);
+        assert_eq!(summary.ready_slots, 0);
+        assert_eq!(summary.blocked_slots, 3);
+        assert_eq!(summary.review_required_slots, 2);
+        assert_eq!(summary.operator_required_slots, 4);
+        assert_eq!(summary.total_tasks, 5);
+        assert_eq!(summary.ready_tasks, 0);
+        assert_eq!(summary.blocked_tasks, 3);
+        assert_eq!(summary.review_required_tasks, 2);
+        assert_eq!(summary.operator_required_tasks, 4);
+        assert_eq!(summary.tasks_requiring_attention, 5);
+        assert_eq!(summary.queued_substrate_actions, 5);
+        assert_eq!(summary.remediation_item_count, 2);
+        assert_eq!(summary.review_required_packages, 1);
+        assert_eq!(summary.operator_required_packages, 6);
+        assert_eq!(summary.blocked_packages, 5);
+        assert_eq!(
+            summary.first_task_key,
+            Some("release-execution-task-01-substrate_actions".to_string())
+        );
+        assert_eq!(
+            summary.first_blocked_task_key,
+            Some("release-execution-task-01-substrate_actions".to_string())
+        );
+        assert_eq!(
+            summary.first_review_task_key,
+            Some("release-execution-task-02-evidence_remediation".to_string())
+        );
+        assert_eq!(
+            summary.first_operator_task_key,
+            Some("release-execution-task-01-substrate_actions".to_string())
+        );
+        assert_eq!(
+            summary.next_task_key,
+            Some("release-execution-task-01-substrate_actions".to_string())
+        );
+        assert_eq!(
+            summary.next_slot_key,
+            Some("release-check-slot-01-substrate_actions".to_string())
+        );
+        assert_eq!(
+            summary.next_check_kind,
+            Some(IntegrationMeshReleaseReadinessCheckKind::SubstrateActions)
+        );
+        assert_eq!(
+            summary.next_check_status,
+            Some(IntegrationMeshReleaseReadinessStatus::Blocked)
+        );
+        assert_eq!(
+            summary.next_package_kind,
+            Some(IntegrationMeshReadinessHandoffKind::SubstrateAction)
+        );
+        assert_eq!(
+            summary.next_handoff_status,
+            Some(IntegrationMeshReadinessHandoffStatus::Blocked)
+        );
+        assert_eq!(
+            summary.packet_status,
+            IntegrationMeshReleaseReadinessStatus::Blocked
+        );
+        assert_eq!(
+            summary.execution_status,
+            IntegrationMeshReleaseReadinessStatus::Blocked
+        );
+        assert!(!summary.release_packet_ready);
+        assert!(!summary.release_check_slots_ready);
+        assert!(!summary.release_execution_ready);
+        assert!(!summary.release_tasks_ready);
+        assert!(!summary.ready_for_release_execution());
+        assert!(summary.has_release_tasks());
+        assert!(summary.has_blockers());
+        assert!(summary.has_review_work());
+        assert!(summary.needs_operator());
+        assert!(summary.requires_attention());
+    }
+
+    #[test]
+    fn mesh_release_task_readiness_summary_marks_release_execution_ready() {
+        let catalog = vec![hue_entry()];
+        let allowed_capabilities = vec![
+            CapabilityId::trusted("smart_home.read"),
+            CapabilityId::trusted("smart_home.command.light"),
+            CapabilityId::trusted("smart_home.pair"),
+        ];
+        let summary = mesh_release_task_readiness_summary_for_catalog(
+            &catalog,
+            all_primitive_families(),
+            &allowed_capabilities,
+            &[],
+        );
+
+        assert_eq!(summary.total_checks, 5);
+        assert_eq!(summary.ready_checks, 5);
+        assert_eq!(summary.blocked_checks, 0);
+        assert_eq!(summary.review_required_checks, 0);
+        assert_eq!(summary.operator_required_checks, 0);
+        assert_eq!(summary.total_slots, 5);
+        assert_eq!(summary.ready_slots, 5);
+        assert_eq!(summary.blocked_slots, 0);
+        assert_eq!(summary.review_required_slots, 0);
+        assert_eq!(summary.operator_required_slots, 0);
+        assert_eq!(summary.total_tasks, 5);
+        assert_eq!(summary.ready_tasks, 5);
+        assert_eq!(summary.blocked_tasks, 0);
+        assert_eq!(summary.review_required_tasks, 0);
+        assert_eq!(summary.operator_required_tasks, 0);
+        assert_eq!(summary.tasks_requiring_attention, 0);
+        assert_eq!(
+            summary.first_task_key,
+            Some("release-execution-task-01-substrate_actions".to_string())
+        );
+        assert_eq!(summary.next_task_key, None);
+        assert_eq!(summary.next_slot_key, None);
+        assert_eq!(summary.next_check_kind, None);
+        assert_eq!(summary.next_check_status, None);
+        assert_eq!(
+            summary.next_package_kind,
+            Some(IntegrationMeshReadinessHandoffKind::ReleaseReady)
+        );
+        assert_eq!(
+            summary.next_handoff_status,
+            Some(IntegrationMeshReadinessHandoffStatus::Ready)
+        );
+        assert_eq!(
+            summary.packet_status,
+            IntegrationMeshReleaseReadinessStatus::Ready
+        );
+        assert_eq!(
+            summary.execution_status,
+            IntegrationMeshReleaseReadinessStatus::Ready
+        );
+        assert!(summary.release_packet_ready);
+        assert!(summary.release_check_slots_ready);
+        assert!(summary.release_execution_ready);
+        assert!(summary.release_tasks_ready);
+        assert!(summary.ready_for_release_execution());
+        assert!(summary.has_release_tasks());
+        assert!(!summary.has_blockers());
+        assert!(!summary.has_review_work());
+        assert!(!summary.needs_operator());
+        assert!(!summary.requires_attention());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add `IntegrationMeshReleaseTaskReadinessSummary` to combine release execution readiness with deterministic task state
- expose first/next task, gate/package status, and release execution booleans through catalog and first-party helpers
- document the new package-facing smart-home mesh readiness surface

## Validation
- `cargo test --manifest-path code\packages\rust\smart-home-integration-catalog\Cargo.toml mesh_release_task_readiness -- --nocapture`
- `cargo test --manifest-path code\packages\rust\smart-home-integration-catalog\Cargo.toml`
- `cargo fmt --manifest-path code\packages\rust\smart-home-integration-catalog\Cargo.toml --check`
- `git diff --check`