### PR TITLE
feat(mycin-2026): primary-source backfill round 3 — dermatomyositis→anti-Jo-1

### DIFF
--- a/code/specs/data/mycin-2026/USMLE-DOMAIN-MAP.md
+++ b/code/specs/data/mycin-2026/USMLE-DOMAIN-MAP.md
@@ -109,7 +109,7 @@ unchanged. Adding a relation just widens the schema — the engine already binds
 | Pharmacology | Pharmacology | drug_class, mechanism, adverse_effect, antidote_for | 10 grounded (ADJ-only) | ✓ |
 | Immunology | Immunology | mediated_by, associated_hla, gene_defect, deficiency_of | 7 grounded (ADJ-only) | ✓ |
 | Genetics | Genetics | inheritance, gene_defect, trinucleotide_repeat, imprinting | 10 grounded (ADJ-only) | ✓ |
-| Rheumatology (Tier-2) | Path/Immuno | associated_autoantibody | 10 grounded (ADJ-only) | ✓ |
+| Rheumatology (Tier-2) | Path/Immuno | associated_autoantibody | 11 grounded (ADJ-only) | ✓ |
 | Oncology (Tier-2) | Pathology/neoplasia | tumor_marker | 5 grounded (ADJ-only) | ✓ |
 | Histology buzzwords (Tier-2) | Pathology | seen_in (finding→condition) | 7 grounded (ADJ-only) | ✓ |
 | Cardiology murmurs (Tier-2) | Cardiology | murmur_indicates (murmur→lesion) | 5 grounded (ADJ-only) | ✓ |

--- a/code/specs/data/mycin-2026/board/board-scorecard.json
+++ b/code/specs/data/mycin-2026/board/board-scorecard.json
@@ -1,7 +1,7 @@
 {
   "summary": {
-    "total": 146,
-    "correct": 139,
+    "total": 147,
+    "correct": 140,
     "abstained": 7,
     "wrong": 0,
     "by_tactic": {
@@ -16,7 +16,7 @@
         "wrong": 0
       },
       "recall": {
-        "correct": 133,
+        "correct": 134,
         "abstained": 6,
         "wrong": 0
       }
@@ -24,7 +24,7 @@
     "defensibility": 1.0,
     "accuracy_on_attempted": 1.0,
     "grounded_coverage": 0.9925,
-    "grounded_correct": 132
+    "grounded_correct": 133
   },
   "results": [
     {
@@ -920,6 +920,14 @@
       "tactic": "recall",
       "gold": "anti_mitochondrial",
       "answer": "anti_mitochondrial",
+      "outcome": "correct",
+      "trust": "authoritative"
+    },
+    {
+      "id": "rheum_dm_ab",
+      "tactic": "recall",
+      "gold": "anti_jo1",
+      "answer": "anti_jo1",
       "outcome": "correct",
       "trust": "authoritative"
     },

--- a/code/specs/data/mycin-2026/board/items.json
+++ b/code/specs/data/mycin-2026/board/items.json
@@ -126,6 +126,7 @@
     {"id": "rheum_ra_ab",    "domain": "rheum", "tactic": "recall", "relation": "associated_autoantibody", "subject": "rheumatoid_arthritis",           "var": "Antibody", "gold": "anti_ccp"},
     {"id": "rheum_sjo_ab",   "domain": "rheum", "tactic": "recall", "relation": "associated_autoantibody", "subject": "sjogren_syndrome",              "var": "Antibody", "gold": "anti_ro"},
     {"id": "rheum_pbc_ab",   "domain": "rheum", "tactic": "recall", "relation": "associated_autoantibody", "subject": "primary_biliary_cholangitis",   "var": "Antibody", "gold": "anti_mitochondrial"},
+    {"id": "rheum_dm_ab",    "domain": "rheum", "tactic": "recall", "relation": "associated_autoantibody", "subject": "dermatomyositis",               "var": "Antibody", "gold": "anti_jo1"},
 
     {"id": "onco_ovarian_marker", "domain": "onco", "tactic": "recall", "relation": "tumor_marker", "subject": "ovarian_cancer",               "var": "Marker", "gold": "ca_125"},
     {"id": "onco_mtc_marker",     "domain": "onco", "tactic": "recall", "relation": "tumor_marker", "subject": "medullary_thyroid_carcinoma",   "var": "Marker", "gold": "calcitonin"},

--- a/code/specs/data/mycin-2026/board/test_board_eval.py
+++ b/code/specs/data/mycin-2026/board/test_board_eval.py
@@ -59,7 +59,7 @@ def test_covered_items_answer_correctly_with_a_proof() -> None:
     # answers, so the board scores the top binding per subject (the libraries + their
     # tests cover all edges).
     recall_correct = [r for r in card.results if r.outcome == "correct" and r.tactic == "recall"]
-    assert len(recall_correct) == 133
+    assert len(recall_correct) == 134
     assert by_id["fabry_enzyme"].outcome == "correct"               # IEM
     assert by_id["thiamine_disease"].answer == "beriberi"           # vitamin
     assert by_id["ida_mcv"].answer == "microcytic"                  # anemia
@@ -100,6 +100,8 @@ def test_covered_items_answer_correctly_with_a_proof() -> None:
     assert by_id["histo_psammoma_cond"].answer == "meningioma"   # primary-source backfill (psammoma→meningioma)
     assert by_id["rheum_pbc_ab"].answer == "anti_mitochondrial"  # primary-source backfill: PBC→AMA (NBK459209)
     assert by_id["rheum_pbc_ab"].trust == "authoritative"        # previously deferred, now grounded
+    assert by_id["rheum_dm_ab"].answer == "anti_jo1"            # primary-source backfill: DM→anti-Jo-1 (NBK558917)
+    assert by_id["rheum_dm_ab"].trust == "authoritative"        # previously deferred, now grounded
     assert by_id["cardio_mr_lesion"].answer == "mitral_regurgitation"  # cardiology (CARDIO, Tier-2)
     assert by_id["cardio_as_lesion"].answer == "aortic_stenosis"  # cardio — murmur_indicates (murmur->lesion)
     assert by_id["cardio_mr_lesion"].trust == "authoritative"    # ADJ-only edge, grounded inline
@@ -161,8 +163,8 @@ def test_grounded_coverage_is_the_live_grounding_number() -> None:
     # verbatim, so the framework declines to claim grounding it cannot defend, by design:
     # cortisol_def (endocrine, deficiency_syndrome__cortisol — the only verbatim spans frame
     # cortisol deficiency as a consequence/feature of Addison disease, not the named-syndrome identity).
-    assert s["grounded_coverage"] == round(132 / 133, 4)   # 0.9925
-    assert s["grounded_correct"] == 132
+    assert s["grounded_coverage"] == round(133 / 134, 4)   # 0.9925
+    assert s["grounded_correct"] == 133
     by_id = {r.item_id: r for r in card.results}
     assert by_id["tay_sachs_enzyme"].trust == "authoritative"      # IEM
     assert by_id["ida_mcv"].trust == "authoritative"               # anemia

--- a/code/specs/data/mycin-2026/recall/gi-edges.adj
+++ b/code/specs/data/mycin-2026/recall/gi-edges.adj
@@ -30,11 +30,13 @@
 % span (both finding AND disease named) are included. Under the primary-source-first
 % policy, ulcerative colitis → crypt abscesses is now GROUNDED: the Inflammatory Bowel
 % Disease page (NBK470312) carries a Histopathology span naming "ulcerative colitis" and
-% its "cryptic abscesses" together. Still deferred (checked, no both-endpoints declarative
-% on the cited page): Whipple disease — its dedicated page (NBK441937) splits the diagnosis
-% ("The diagnosis of Whipple disease is made by a biopsy of the intestine...") from the
-% criterion ("...positive results for PAS-positive foamy macrophages in the small bowel
-% biopsy"), naming "Whipple" and "PAS-positive macrophages" in separate sentences.
+% its "cryptic abscesses" together. Still deferred (re-checked): Whipple disease → PAS-
+% positive macrophages — its dedicated page (NBK441937) splits the diagnosis ("The diagnosis
+% of Whipple disease is made by a biopsy of the intestine...") from the criterion
+% ("...positive results for PAS-positive foamy macrophages in the small bowel biopsy"), and
+% the Tropheryma review (PMC88990) likewise names the PAS-positive macrophages in a sentence
+% that does not contain "Whipple". No primary page checked carries a single both-endpoints
+% declarative, so the edge stays out — honest absence beats an over-reaching citation.
 % ============================================================================
 
 dictionary gi_vocab {

--- a/code/specs/data/mycin-2026/recall/histo-edges.adj
+++ b/code/specs/data/mycin-2026/recall/histo-edges.adj
@@ -29,10 +29,12 @@
 % source-first, zero-deferral policy, two previously-deferred buzzwords are now GROUNDED:
 % Auer rods → acute promyelocytic leukemia (the AML page names abundant Auer rods as a
 % pathognomonic APL feature) and psammoma bodies → meningioma (the meningioma page names
-% psammoma-body formation as a histopathological characteristic). Still pursued for the
-% next backfill (its disease page lists psammoma bodies only inside a run-on feature
-% list, not a both-endpoints-named declarative): psammoma bodies → papillary thyroid
-% carcinoma.
+% psammoma-body formation as a histopathological characteristic). Still deferred (re-checked):
+% psammoma bodies → papillary thyroid carcinoma — the PTC page (NBK536943) lists psammoma
+% bodies only as an isolated bullet, and the only both-endpoints span on the Thyroid-Gland
+% histology page (NBK551659) wraps "Orphan Annie eye" in DOUBLE quotes (plus inline citation
+% brackets), which cannot be carried verbatim inside an ADJ double-quoted source string.
+% Declined rather than mangle the span — honest absence beats a doctored citation.
 % ============================================================================
 
 dictionary histo_vocab {

--- a/code/specs/data/mycin-2026/recall/rheum-edges.adj
+++ b/code/specs/data/mycin-2026/recall/rheum-edges.adj
@@ -28,10 +28,13 @@
 % mitochondrial antibody (the StatPearls page titled "Primary Biliary Cholangitis" carries
 % a contiguous Pathophysiology span naming the disease — by its legacy name "Primary
 % biliary cirrhosis" — and its hallmark anti-mitochondrial antibody together).
-% Still deferred (checked, no both-endpoints declarative on the cited page): polymyositis /
-% antisynthetase → anti-Jo-1 — the Autoimmune Myopathies page (NBK532860) calls Jo-1 "the
-% most studied and commonly detected antisynthetase antibody" but does not name a disease
-% in the same sentence. Honest absence beats an over-reaching citation.
+% A fourth backfill is now GROUNDED: dermatomyositis → anti-Jo-1 (the dedicated
+% Dermatomyositis page, NBK558917, names "Anti-Jo" as the most common antisynthetase
+% antibody found in dermatomyositis — both endpoints in one sentence). The earlier
+% holdout was the Autoimmune Myopathies page (NBK532860), which calls Jo-1 "the most
+% studied and commonly detected antisynthetase antibody" but names no disease alongside;
+% the disease-specific Dermatomyositis page supplies the clean both-endpoints span.
+% Nothing rheumatologic remains deferred. (Honest absence still beats over-reach.)
 % ============================================================================
 
 dictionary rheum_vocab {
@@ -98,5 +101,13 @@ rulebook rheum_facts {
     relate associated_autoantibody(primary_biliary_cholangitis, anti_mitochondrial)
         source "Primary biliary cirrhosis is associated with highly specific autoantibodies. The anti-mitochondrial antibody is found in 85% of the cases."
         locator "https://www.ncbi.nlm.nih.gov/books/NBK459209/"
+        trust authoritative
+
+    % --- BACKFILL (primary-source-first): dermatomyositis → anti-Jo-1 -----------------
+    % The disease-specific Dermatomyositis page names both endpoints in one sentence,
+    % where the Autoimmune Myopathies overview (NBK532860) named only the antibody.
+    relate associated_autoantibody(dermatomyositis, anti_jo1)
+        source "Anti-Jo is the most common antisynthetase antibody found in dermatomyositis."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK558917/"
         trust authoritative
 }

--- a/code/specs/data/mycin-2026/recall/rheum-recall.query.adj
+++ b/code/specs/data/mycin-2026/recall/rheum-recall.query.adj
@@ -20,3 +20,4 @@ import "rheum-edges.adj"
 ? associated_autoantibody(rheumatoid_arthritis, $Antibody)           % expect anti_ccp        (backfill)
 ? associated_autoantibody(sjogren_syndrome, $Antibody)               % expect anti_ro / anti_la (backfill)
 ? associated_autoantibody(primary_biliary_cholangitis, $Antibody)    % expect anti_mitochondrial (backfill)
+? associated_autoantibody(dermatomyositis, $Antibody)                % expect anti_jo1 (backfill)

--- a/code/specs/data/mycin-2026/recall/test_rheum_recall.py
+++ b/code/specs/data/mycin-2026/recall/test_rheum_recall.py
@@ -36,6 +36,7 @@ EXPECTED = {
     "rheumatoid_arthritis": {"anti_ccp"},                 # primary-source backfill (NBK441999)
     "sjogren_syndrome": {"anti_ro", "anti_la"},           # primary-source backfill (NBK431049)
     "primary_biliary_cholangitis": {"anti_mitochondrial"},  # primary-source backfill (NBK459209)
+    "dermatomyositis": {"anti_jo1"},                       # primary-source backfill (NBK558917)
 }
 REL = "associated_autoantibody"
 VAR = "Antibody"
@@ -103,8 +104,8 @@ def test_unknown_disease_abstains() -> None:
     fd, path = tempfile.mkstemp(suffix=".adj", prefix=".rheum_q_", dir=HERE)
     try:
         with os.fdopen(fd, "w") as fh:
-            # dermatomyositis is not in the library → must abstain
-            fh.write(f'import "rheum-edges.adj"\n? {REL}(dermatomyositis, ${VAR})\n')
+            # behcet_syndrome is not in the library → must abstain
+            fh.write(f'import "rheum-edges.adj"\n? {REL}(behcet_syndrome, ${VAR})\n')
         res = _run(Path(path))
         r = res["recall"][0] if res["recall"] else None
         assert r is not None and r["abstained"], "an ungrounded disease must abstain"


### PR DESCRIPTION
## What

Retires the **last rheumatology deferral**, primary-source-first. The dedicated *Dermatomyositis* StatPearls page supplies the clean both-endpoints span the *Autoimmune Myopathies* overview lacked:

| Domain | Edge | Source | Locator |
|---|---|---|---|
| RHEUM | `associated_autoantibody(dermatomyositis, anti_jo1)` | "Anti-Jo is the most common antisynthetase antibody found in dermatomyositis." | StatPearls *Dermatomyositis* (NBK558917) |

The edge ships inline byte-provenance, is engine-queryable (added to `rheum-recall.query.adj`), and is mirrored into the board bank. The RHEUM abstain-probe (was `dermatomyositis`) is swapped to `behcet_syndrome` so the "unknown disease abstains" test still exercises a genuinely off-vocab subject.

## Honestly still deferred (re-checked this round)

Each library's note now records exactly which sources were inspected and why the edge was declined:

- **psammoma bodies → papillary thyroid carcinoma** — the only both-endpoints span (Thyroid-Gland histology, NBK551659) wraps "Orphan Annie eye" in **double quotes** + inline citation brackets, which cannot be carried verbatim inside an ADJ double-quoted `source` string without mangling it. The PTC page (NBK536943) lists psammoma only as an isolated bullet.
- **Whipple disease → PAS-positive macrophages** — the dedicated page (NBK441937) and the Tropheryma review (PMC88990) both name the PAS macrophages in sentences that do **not** contain "Whipple".

Declined rather than over-reach: honest absence beats a doctored citation.

## Numbers

- Board scorecard: **133→134** recall correct, **132→133** grounded, coverage holds **0.9925**, **wrong still 0** / defensibility **1.0**.
- Domain map: RHEUM 10→11.

## Verification

- All **19** recall suites pass against the native `adj-lang-cli`.
- The **12**-test board scorecard passes (memoized).
- The dedicated `mycin-2026` CI workflow exercises both on every PR.
- Security review passed (data/test/docs only — no executable surface).

🤖 Generated with [Claude Code](https://claude.com/claude-code)