### PR TITLE
Expose SPICE deck control diagnostics in run artifacts

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ### Added
 
+- **Deck run control diagnostic artifacts** —
+  `run_deck_analysis()` selected-run artifacts now include existing `.control`
+  body policy diagnostic codes in `Diagnostics` / `DiagnosticCodeList`, and
+  those codes flow through stable run-artifact tables, CSV/JSON helpers, and
+  ordered `table_artifacts`, matching Rust and TypeScript.
+
 - **Deck execution table export artifacts** —
   `run_deck_analysis()` selected executions now expose ordered
   `table_artifacts` with each stable table's text, CSV, compact JSON, and

--- a/code/packages/python/spice-engine/README.md
+++ b/code/packages/python/spice-engine/README.md
@@ -115,6 +115,9 @@ Fourier table. Executions also include a selected-run artifact summary plus
 `format_deck_run_artifact_table()` and `format_deck_run_artifact_csv()` output
 for stable result-row, table, analysis-directive, output-probe,
 output-directive, measurement, Fourier, and diagnostic count/name lists.
+Existing `.control` body policy diagnostics flow into those selected-run
+artifact `Diagnostics` / `DiagnosticCodeList` fields and through the same
+run-artifact table, CSV, JSON, and `table_artifacts` records.
 `format_deck_table_csv()` also converts any stable
 tab-separated deck table to CSV, `format_deck_table_json()` converts the same
 tables to compact JSON records, and `deck_table_records()` returns

--- a/code/packages/python/spice-engine/src/spice_engine/engine.py
+++ b/code/packages/python/spice-engine/src/spice_engine/engine.py
@@ -71,6 +71,7 @@ from spice_engine.compatibility import (
     DeckInitialConditionSummary,
     DeckMeasurementCard,
     DeckNodeCondition,
+    analyze_deck_controls,
     resolve_deck_analyses,
     resolve_deck_fourier,
     resolve_deck_measurements,
@@ -2563,6 +2564,22 @@ def _deck_analysis_diagnostic_codes(
     ]
 
 
+def _deck_control_diagnostic_codes(netlist: str) -> list[str]:
+    summary = analyze_deck_controls(netlist)
+    return [
+        diagnostic.code
+        for diagnostic in summary.diagnostics
+        if diagnostic.code.startswith("SPICE_DECK_CONTROL_")
+    ]
+
+
+def _deck_run_diagnostic_codes(netlist: str, plan: DeckAnalysisPlan) -> list[str]:
+    return [
+        *_deck_analysis_diagnostic_codes(netlist, plan),
+        *_deck_control_diagnostic_codes(netlist),
+    ]
+
+
 def format_deck_run_artifact_table(artifacts: Iterable[DeckRunArtifact]) -> str:
     """Format selected deck-run artifacts as a stable summary table."""
 
@@ -2720,7 +2737,7 @@ def run_deck_analysis(
     """Select one deck analysis card, execute it, and format deck-selected output."""
 
     plan = select_deck_analysis_plan(netlist, analysis)
-    diagnostic_codes = _deck_analysis_diagnostic_codes(netlist, plan)
+    diagnostic_codes = _deck_run_diagnostic_codes(netlist, plan)
     analysis_directives = _deck_analysis_directives(plan)
     if plan.analysis == "op":
         result = dc_op(circuit)

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -7341,6 +7341,49 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
     )
 
 
+def test_run_deck_analysis_surfaces_control_diagnostics_in_artifacts() -> None:
+    circuit = Circuit()
+    circuit.add(VoltageSource("V1", "in", "0", 1.0))
+    circuit.add(Resistor("R1", "in", "0", 1000.0))
+    netlist = """
+.save V(in)
+.control
+source other.cir
+cd /tmp
+if v(in) > 0
+let gain = 2
+.endc
+.op
+.end
+"""
+
+    execution = run_deck_analysis(circuit, netlist, "op")
+    expected_codes = [
+        "SPICE_DECK_CONTROL_SCRIPT_COMMAND",
+        "SPICE_DECK_CONTROL_WORKDIR_COMMAND",
+        "SPICE_DECK_CONTROL_FLOW_COMMAND",
+        "SPICE_DECK_CONTROL_VARIABLE_COMMAND",
+    ]
+    code_list = ";".join(expected_codes)
+
+    assert execution.run_artifacts[0].diagnostic_count == len(expected_codes)
+    assert execution.run_artifacts[0].diagnostic_codes == expected_codes
+    record = deck_table_records(execution.run_artifact_table)[0]
+    assert record["Diagnostics"] == str(len(expected_codes))
+    assert record["DiagnosticCodeList"] == code_list
+    assert execution.table_artifacts[-1].name == "run-artifact"
+    assert execution.table_artifacts[-1].records[0]["DiagnosticCodeList"] == code_list
+    assert execution.table_artifacts[-1].csv == format_deck_run_artifact_csv(
+        execution.run_artifacts
+    )
+    assert execution.table_artifacts[-1].json == format_deck_run_artifact_json(
+        execution.run_artifacts
+    )
+    assert json.loads(format_deck_run_artifact_json(execution.run_artifacts))[0][
+        "DiagnosticCodeList"
+    ] == code_list
+
+
 def test_run_deck_analysis_exposes_selected_fourier_artifacts() -> None:
     circuit = Circuit()
     circuit.add(VoltageSource("V1", "vin", "0", 1.0))

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Surface existing `.control` body policy diagnostic codes in selected
+  `run_deck_analysis` run artifacts and propagate them through stable
+  run-artifact tables, CSV/JSON helpers, and ordered `table_artifacts`,
+  matching Python and TypeScript.
 - Add ordered `table_artifacts` to selected `run_deck_analysis` execution
   results with each stable table's text, CSV, compact JSON, and header-keyed
   records beside the existing table inventory, matching Python and TypeScript.

--- a/code/packages/rust/spice-engine/README.md
+++ b/code/packages/rust/spice-engine/README.md
@@ -189,7 +189,10 @@ results and a stable Fourier table. Executions also include selected-run
 artifact summaries plus `format_deck_run_artifact_table` and
 `format_deck_run_artifact_csv` / `format_deck_run_artifact_json` output for
 stable result-row, table, analysis-directive, output-probe, output-directive,
-measurement, Fourier, and diagnostic count/name lists. `format_deck_table_csv` also converts any stable
+measurement, Fourier, and diagnostic count/name lists. Existing `.control` body
+policy diagnostics flow into those selected-run artifact `Diagnostics` /
+`DiagnosticCodeList` fields and through the same run-artifact table, CSV, JSON,
+and `table_artifacts` records. `format_deck_table_csv` also converts any stable
 tab-separated deck table to CSV, `format_deck_table_json` converts the same
 tables to compact JSON records, and `deck_table_records` returns header-keyed
 native records for host integrations.

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -10199,6 +10199,21 @@ fn deck_analysis_diagnostic_codes(netlist: &str, plan: &DeckAnalysisPlan) -> Vec
         .collect()
 }
 
+fn deck_control_diagnostic_codes(netlist: &str) -> Vec<String> {
+    analyze_deck_controls(netlist)
+        .diagnostics
+        .into_iter()
+        .filter(|diagnostic| diagnostic.code.starts_with("SPICE_DECK_CONTROL_"))
+        .map(|diagnostic| diagnostic.code)
+        .collect()
+}
+
+fn deck_run_diagnostic_codes(netlist: &str, plan: &DeckAnalysisPlan) -> Vec<String> {
+    let mut codes = deck_analysis_diagnostic_codes(netlist, plan);
+    codes.extend(deck_control_diagnostic_codes(netlist));
+    codes
+}
+
 fn format_deck_artifact_float(value: Option<f64>) -> String {
     value.map(format_table_number).unwrap_or_default()
 }
@@ -10519,7 +10534,7 @@ pub fn run_deck_analysis(
     analysis: Option<&str>,
 ) -> Result<DeckAnalysisExecution, SpiceError> {
     let plan = select_deck_analysis_plan(netlist, analysis)?;
-    let diagnostic_codes = deck_analysis_diagnostic_codes(netlist, &plan);
+    let diagnostic_codes = deck_run_diagnostic_codes(netlist, &plan);
     let analysis_directives = deck_analysis_directives(&plan);
     match plan.analysis.as_str() {
         "op" => {

--- a/code/packages/rust/spice-engine/tests/transient_tests.rs
+++ b/code/packages/rust/spice-engine/tests/transient_tests.rs
@@ -2712,6 +2712,63 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
 }
 
 #[test]
+fn run_deck_analysis_surfaces_control_diagnostics_in_artifacts() {
+    let mut circuit = Circuit::new();
+    circuit.add(Element::VoltageSource(VoltageSource::new(
+        "V1", "in", "0", 1.0,
+    )));
+    circuit.add(Element::Resistor(Resistor::new("R1", "in", "0", 1_000.0)));
+    let netlist = "
+.save V(in)
+.control
+source other.cir
+cd /tmp
+if v(in) > 0
+let gain = 2
+.endc
+.op
+.end
+";
+
+    let execution = run_deck_analysis(&circuit, netlist, Some("op")).unwrap();
+    let expected_codes = vec![
+        "SPICE_DECK_CONTROL_SCRIPT_COMMAND".to_string(),
+        "SPICE_DECK_CONTROL_WORKDIR_COMMAND".to_string(),
+        "SPICE_DECK_CONTROL_FLOW_COMMAND".to_string(),
+        "SPICE_DECK_CONTROL_VARIABLE_COMMAND".to_string(),
+    ];
+    let code_list = expected_codes.join(";");
+
+    assert_eq!(
+        execution.run_artifacts[0].diagnostic_count,
+        expected_codes.len()
+    );
+    assert_eq!(execution.run_artifacts[0].diagnostic_codes, expected_codes);
+    let records = deck_table_records(&execution.run_artifact_table);
+    assert_eq!(records[0].get("Diagnostics").map(String::as_str), Some("4"));
+    assert_eq!(
+        records[0].get("DiagnosticCodeList").map(String::as_str),
+        Some(code_list.as_str())
+    );
+    let run_artifact = execution.table_artifacts.last().unwrap();
+    assert_eq!(run_artifact.name, "run-artifact");
+    assert_eq!(
+        run_artifact.records[0]
+            .get("DiagnosticCodeList")
+            .map(String::as_str),
+        Some(code_list.as_str())
+    );
+    assert_eq!(
+        run_artifact.csv,
+        format_deck_run_artifact_csv(&execution.run_artifacts)
+    );
+    assert_eq!(
+        run_artifact.json,
+        format_deck_run_artifact_json(&execution.run_artifacts)
+    );
+}
+
+#[test]
 fn run_deck_analysis_exposes_selected_fourier_artifacts() {
     let mut circuit = Circuit::new();
     circuit.add(Element::VoltageSource(VoltageSource::new(

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Surface existing `.control` body policy diagnostic codes in selected
+  `runDeckAnalysis` run artifacts and propagate them through stable
+  run-artifact tables, CSV/JSON helpers, and ordered `tableArtifacts`,
+  matching Python and Rust.
 - Add ordered `tableArtifacts` to selected `runDeckAnalysis` execution results
   with each stable table's text, CSV, compact JSON, and header-keyed records
   beside the existing table inventory, matching Python and Rust.

--- a/code/packages/typescript/spice-engine/README.md
+++ b/code/packages/typescript/spice-engine/README.md
@@ -105,7 +105,10 @@ results and a stable Fourier table. Executions also include selected-run
 artifact summaries plus `formatDeckRunArtifactTable` and
 `formatDeckRunArtifactCsv` / `formatDeckRunArtifactJson` output for stable
 result-row, table, analysis-directive, output-probe, output-directive,
-measurement, Fourier, and diagnostic count/name lists. `formatDeckTableCsv` also converts any stable tab-separated deck table to
+measurement, Fourier, and diagnostic count/name lists. Existing `.control` body
+policy diagnostics flow into those selected-run artifact `Diagnostics` /
+`DiagnosticCodeList` fields and through the same run-artifact table, CSV, JSON,
+and `tableArtifacts` records. `formatDeckTableCsv` also converts any stable tab-separated deck table to
 CSV, `formatDeckTableJson` converts the same tables to compact JSON records,
 and `deckTableRecords` returns header-keyed native records for browser and host
 integrations.

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -7977,6 +7977,19 @@ function deckAnalysisDiagnosticCodes(netlist: string, plan: DeckAnalysisPlan): s
     .map((diagnostic) => diagnostic.code);
 }
 
+function deckControlDiagnosticCodes(netlist: string): string[] {
+  return analyzeDeckControls(netlist).diagnostics
+    .filter((diagnostic) => diagnostic.code.startsWith("SPICE_DECK_CONTROL_"))
+    .map((diagnostic) => diagnostic.code);
+}
+
+function deckRunDiagnosticCodes(netlist: string, plan: DeckAnalysisPlan): string[] {
+  return [
+    ...deckAnalysisDiagnosticCodes(netlist, plan),
+    ...deckControlDiagnosticCodes(netlist),
+  ];
+}
+
 function formatDeckArtifactFloat(value: number | undefined): string {
   return value === undefined ? "" : formatTableNumber(value);
 }
@@ -8203,7 +8216,7 @@ export function runDeckAnalysis(
   analysis?: string,
 ): DeckAnalysisExecution {
   const plan = selectDeckAnalysisPlan(netlist, analysis);
-  const diagnosticCodes = deckAnalysisDiagnosticCodes(netlist, plan);
+  const diagnosticCodes = deckRunDiagnosticCodes(netlist, plan);
   const analysisDirectives = deckAnalysisDirectives(plan);
   if (plan.analysis === "op") {
     const result = dcOp(circuit);

--- a/code/packages/typescript/spice-engine/tests/transient.test.ts
+++ b/code/packages/typescript/spice-engine/tests/transient.test.ts
@@ -2010,6 +2010,43 @@ describe("transient", () => {
     );
   });
 
+  it("surfaces control diagnostics in selected run artifacts", () => {
+    const circuit = new Circuit();
+    circuit.add(voltageSource("V1", "in", "0", 1.0));
+    circuit.add(resistor("R1", "in", "0", 1_000.0));
+    const netlist = `
+.save V(in)
+.control
+source other.cir
+cd /tmp
+if v(in) > 0
+let gain = 2
+.endc
+.op
+.end
+`;
+
+    const execution = runDeckAnalysis(circuit, netlist, "op");
+    const expectedCodes = [
+      "SPICE_DECK_CONTROL_SCRIPT_COMMAND",
+      "SPICE_DECK_CONTROL_WORKDIR_COMMAND",
+      "SPICE_DECK_CONTROL_FLOW_COMMAND",
+      "SPICE_DECK_CONTROL_VARIABLE_COMMAND",
+    ];
+    const codeList = expectedCodes.join(";");
+
+    expect(execution.runArtifacts[0]?.diagnosticCount).toBe(expectedCodes.length);
+    expect(execution.runArtifacts[0]?.diagnosticCodes).toEqual(expectedCodes);
+    const record = deckTableRecords(execution.runArtifactTable)[0]!;
+    expect(record["Diagnostics"]).toBe(String(expectedCodes.length));
+    expect(record["DiagnosticCodeList"]).toBe(codeList);
+    const runArtifact = execution.tableArtifacts[execution.tableArtifacts.length - 1]!;
+    expect(runArtifact.name).toBe("run-artifact");
+    expect(runArtifact.records[0]?.["DiagnosticCodeList"]).toBe(codeList);
+    expect(runArtifact.csv).toBe(formatDeckRunArtifactCsv(execution.runArtifacts));
+    expect(runArtifact.json).toBe(formatDeckRunArtifactJson(execution.runArtifacts));
+  });
+
   it("exposes selected Fourier artifacts from deck transient execution", () => {
     const circuit = new Circuit();
     circuit.add(voltageSource("V1", "vin", "0", 1.0));

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -99,7 +99,9 @@ downstream tools to compare.
      and compact JSON records or host-native header-keyed records across
      Python, Rust, and TypeScript, and selected executions now expose ordered
      table export artifacts with text, CSV, compact JSON, and host-native
-     records for each stable table.
+     records for each stable table; selected deck run artifacts now also carry
+     existing `.control` body policy diagnostic codes through their stable
+     table, CSV, compact JSON, and ordered table export artifacts.
    - Expand remaining deck-controlled analyses toward full SPICE compatibility
      while keeping unsupported control-flow diagnostics explicit.
 
@@ -950,6 +952,16 @@ downstream tools to compare.
     - Each table artifact carries the stable table text, deterministic CSV,
       compact JSON records, and host-native header-keyed records for the
       selected result, measurement, Fourier, and run-artifact tables.
+
+88. Deck run control diagnostic artifacts.
+    - Status: completed in this deck run control diagnostic artifact slice.
+    - Python, Rust, and TypeScript selected deck executions now add existing
+      `.control` body policy diagnostics to selected-run artifact
+      `Diagnostics` / `DiagnosticCodeList` metadata.
+    - The diagnostic counts and code lists propagate through stable
+      run-artifact tables, CSV/JSON export helpers, and ordered table export
+      artifacts without executing control-flow, variables, external scripts,
+      or working-directory mutations.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- add existing .control body policy diagnostic codes to selected deck run artifacts in Python, Rust, and TypeScript
- propagate diagnostic counts/code lists through run-artifact tables, CSV/JSON helpers, and ordered table export artifacts
- document the slice in package docs/changelogs and mark Slice 88 complete in the SPICE plan

## Verification
- PYTHONPATH=code/packages/python/spice-engine/src:code/packages/python/mosfet-models/src:code/packages/python/device-physics/src:code/packages/python/symbolic/src:code/packages/python/hardware/src /Users/adhithya/.local/share/mise/installs/python/3.12.13/bin/python -m pytest code/packages/python/spice-engine/tests -q --no-cov
- /Users/adhithya/.local/share/mise/installs/python/3.12.13/bin/ruff check code/packages/python/spice-engine/src/spice_engine/engine.py code/packages/python/spice-engine/tests/test_engine.py
- cargo test --manifest-path code/packages/rust/spice-engine/Cargo.toml
- cargo fmt --manifest-path code/packages/rust/spice-engine/Cargo.toml -- --check
- npm --prefix code/packages/typescript/spice-engine run build
- npm --prefix code/packages/typescript/spice-engine test
- git diff --check