### PR TITLE
feat(mycin-2026): ONCO expansion — prostate→PSA, choriocarcinoma→hCG

### DIFF
--- a/code/specs/data/mycin-2026/USMLE-DOMAIN-MAP.md
+++ b/code/specs/data/mycin-2026/USMLE-DOMAIN-MAP.md
@@ -110,7 +110,7 @@ unchanged. Adding a relation just widens the schema — the engine already binds
 | Immunology | Immunology | mediated_by, associated_hla, gene_defect, deficiency_of | 7 grounded (ADJ-only) | ✓ |
 | Genetics | Genetics | inheritance, gene_defect, trinucleotide_repeat, imprinting | 10 grounded (ADJ-only) | ✓ |
 | Rheumatology (Tier-2) | Path/Immuno | associated_autoantibody | 11 grounded (ADJ-only) | ✓ |
-| Oncology (Tier-2) | Pathology/neoplasia | tumor_marker | 5 grounded (ADJ-only) | ✓ |
+| Oncology (Tier-2) | Pathology/neoplasia | tumor_marker | 7 grounded (ADJ-only) | ✓ |
 | Histology buzzwords (Tier-2) | Pathology | seen_in (finding→condition) | 7 grounded (ADJ-only) | ✓ |
 | Cardiology murmurs (Tier-2) | Cardiology | murmur_indicates (murmur→lesion) | 5 grounded (ADJ-only) | ✓ |
 | Neurology localization (Tier-2) | Neurology | lesion_causes (site→deficit) | 5 grounded (ADJ-only) | ✓ |

--- a/code/specs/data/mycin-2026/board/board-scorecard.json
+++ b/code/specs/data/mycin-2026/board/board-scorecard.json
@@ -1,7 +1,7 @@
 {
   "summary": {
-    "total": 147,
-    "correct": 140,
+    "total": 149,
+    "correct": 142,
     "abstained": 7,
     "wrong": 0,
     "by_tactic": {
@@ -16,15 +16,15 @@
         "wrong": 0
       },
       "recall": {
-        "correct": 134,
+        "correct": 136,
         "abstained": 6,
         "wrong": 0
       }
     },
     "defensibility": 1.0,
     "accuracy_on_attempted": 1.0,
-    "grounded_coverage": 0.9925,
-    "grounded_correct": 133
+    "grounded_coverage": 0.9926,
+    "grounded_correct": 135
   },
   "results": [
     {
@@ -960,6 +960,22 @@
       "tactic": "recall",
       "gold": "cea",
       "answer": "cea",
+      "outcome": "correct",
+      "trust": "authoritative"
+    },
+    {
+      "id": "onco_prostate_marker",
+      "tactic": "recall",
+      "gold": "psa",
+      "answer": "psa",
+      "outcome": "correct",
+      "trust": "authoritative"
+    },
+    {
+      "id": "onco_chorio_marker",
+      "tactic": "recall",
+      "gold": "hcg",
+      "answer": "hcg",
       "outcome": "correct",
       "trust": "authoritative"
     },

--- a/code/specs/data/mycin-2026/board/items.json
+++ b/code/specs/data/mycin-2026/board/items.json
@@ -132,6 +132,8 @@
     {"id": "onco_mtc_marker",     "domain": "onco", "tactic": "recall", "relation": "tumor_marker", "subject": "medullary_thyroid_carcinoma",   "var": "Marker", "gold": "calcitonin"},
     {"id": "onco_hcc_marker",     "domain": "onco", "tactic": "recall", "relation": "tumor_marker", "subject": "hepatocellular_carcinoma",      "var": "Marker", "gold": "alpha_fetoprotein"},
     {"id": "onco_crc_marker",     "domain": "onco", "tactic": "recall", "relation": "tumor_marker", "subject": "colorectal_cancer",            "var": "Marker", "gold": "cea"},
+    {"id": "onco_prostate_marker","domain": "onco", "tactic": "recall", "relation": "tumor_marker", "subject": "prostate_cancer",             "var": "Marker", "gold": "psa"},
+    {"id": "onco_chorio_marker",  "domain": "onco", "tactic": "recall", "relation": "tumor_marker", "subject": "choriocarcinoma",             "var": "Marker", "gold": "hcg"},
 
     {"id": "histo_rs_cond",    "domain": "histo", "tactic": "recall", "relation": "seen_in", "subject": "reed_sternberg_cells", "var": "Condition", "gold": "hodgkin_lymphoma"},
     {"id": "histo_hj_cond",    "domain": "histo", "tactic": "recall", "relation": "seen_in", "subject": "howell_jolly_bodies",  "var": "Condition", "gold": "asplenia"},

--- a/code/specs/data/mycin-2026/board/test_board_eval.py
+++ b/code/specs/data/mycin-2026/board/test_board_eval.py
@@ -59,7 +59,7 @@ def test_covered_items_answer_correctly_with_a_proof() -> None:
     # answers, so the board scores the top binding per subject (the libraries + their
     # tests cover all edges).
     recall_correct = [r for r in card.results if r.outcome == "correct" and r.tactic == "recall"]
-    assert len(recall_correct) == 134
+    assert len(recall_correct) == 136
     assert by_id["fabry_enzyme"].outcome == "correct"               # IEM
     assert by_id["thiamine_disease"].answer == "beriberi"           # vitamin
     assert by_id["ida_mcv"].answer == "microcytic"                  # anemia
@@ -93,6 +93,9 @@ def test_covered_items_answer_correctly_with_a_proof() -> None:
     assert by_id["onco_ovarian_marker"].answer == "ca_125"       # oncology (ONCO, Tier-2)
     assert by_id["onco_hcc_marker"].answer == "alpha_fetoprotein"  # onco — tumor_marker relation
     assert by_id["onco_ovarian_marker"].trust == "authoritative"  # ADJ-only edge, grounded inline
+    assert by_id["onco_prostate_marker"].answer == "psa"         # expand: prostate→PSA (NBK470550)
+    assert by_id["onco_chorio_marker"].answer == "hcg"           # expand: choriocarcinoma→hCG (NBK532950)
+    assert by_id["onco_prostate_marker"].trust == "authoritative"  # previously deferred, now grounded
     assert by_id["histo_rs_cond"].answer == "hodgkin_lymphoma"   # histology (HISTO, Tier-2)
     assert by_id["histo_heinz_cond"].answer == "g6pd_deficiency"  # histo — seen_in (finding->condition)
     assert by_id["histo_rs_cond"].trust == "authoritative"       # ADJ-only edge, grounded inline
@@ -163,8 +166,8 @@ def test_grounded_coverage_is_the_live_grounding_number() -> None:
     # verbatim, so the framework declines to claim grounding it cannot defend, by design:
     # cortisol_def (endocrine, deficiency_syndrome__cortisol — the only verbatim spans frame
     # cortisol deficiency as a consequence/feature of Addison disease, not the named-syndrome identity).
-    assert s["grounded_coverage"] == round(133 / 134, 4)   # 0.9925
-    assert s["grounded_correct"] == 133
+    assert s["grounded_coverage"] == round(135 / 136, 4)   # 0.9926
+    assert s["grounded_correct"] == 135
     by_id = {r.item_id: r for r in card.results}
     assert by_id["tay_sachs_enzyme"].trust == "authoritative"      # IEM
     assert by_id["ida_mcv"].trust == "authoritative"               # anemia

--- a/code/specs/data/mycin-2026/recall/onco-edges.adj
+++ b/code/specs/data/mycin-2026/recall/onco-edges.adj
@@ -22,8 +22,16 @@
 % names both endpoints are included. Spans were taken from the per-marker / per-cancer
 % pages (the aggregate "tumor biomarkers" page discusses markers mostly in sensitivity /
 % false-positive / procedure-context, not a clean both-endpoints-named declarative).
-% Deferred (no clean self-contained span yet here): PSA→prostate (the marker page frames
-% PSA by its limited specificity), CEA→colorectal, beta-hCG→germ-cell/choriocarcinoma.
+% Under the primary-source-first policy, PSA→prostate is now GROUNDED from the Prostate
+% Cancer page (NBK470550: "Elevated PSA levels have long been associated with prostate
+% cancer.") — the disease-specific page supplies the clean both-endpoints span the PSA
+% marker page (which frames PSA by its limited specificity) lacked. CEA→colorectal was
+% grounded earlier (NBK578172). hCG→choriocarcinoma is also now GROUNDED (NBK532950: hCG
+% testing aids the diagnosis of choriocarcinoma) — the marker atom is `hcg` to match the
+% span (the board buzzword "beta-hCG" is the assayed subunit of the named hCG). Still
+% deferred (re-checked): CA 19-9→pancreatic — the Pancreatic Cancer page (NBK518996) names
+% the marker only as a "pancreatic tumor marker (CA 19-9 and CEA)", not alongside
+% "pancreatic cancer" in one sentence. Honest absence beats an over-reaching citation.
 % ============================================================================
 
 dictionary onco_vocab {
@@ -62,5 +70,21 @@ rulebook onco_facts {
     relate tumor_marker(colorectal_cancer, cea)
         source "Carcinoembryonic antigen (CEA) is a nonspecific serum biomarker that is elevated in many malignancies, including colorectal cancer, medullary thyroid cancer, breast cancer, and mucinous ovarian cancer"
         locator "https://www.ncbi.nlm.nih.gov/books/NBK578172/"
+        trust authoritative
+
+    % --- EXPAND (primary-source-first): prostate cancer (PSA) -----------
+    % The Prostate Cancer page supplies the clean both-endpoints span the PSA
+    % marker page lacked (that page frames PSA by its limited specificity).
+    relate tumor_marker(prostate_cancer, psa)
+        source "Elevated PSA levels have long been associated with prostate cancer."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK470550/"
+        trust authoritative
+
+    % --- EXPAND (primary-source-first): choriocarcinoma (hCG) -----------
+    % Marker atom is `hcg` to match the span verbatim (the board buzzword
+    % "beta-hCG" is the clinically-assayed subunit of the hCG named here).
+    relate tumor_marker(choriocarcinoma, hcg)
+        source "In addition, hCG testing can aid in the diagnosis of certain cancers, such as choriocarcinoma and some extra-uterine malignancies."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK532950/"
         trust authoritative
 }

--- a/code/specs/data/mycin-2026/recall/onco-recall.query.adj
+++ b/code/specs/data/mycin-2026/recall/onco-recall.query.adj
@@ -18,3 +18,5 @@ import "onco-edges.adj"
 ? tumor_marker(medullary_thyroid_carcinoma, $Marker)   % expect calcitonin / cea
 ? tumor_marker(hepatocellular_carcinoma, $Marker)      % expect alpha_fetoprotein
 ? tumor_marker(colorectal_cancer, $Marker)             % expect cea (expand)
+? tumor_marker(prostate_cancer, $Marker)               % expect psa (expand)
+? tumor_marker(choriocarcinoma, $Marker)               % expect hcg (expand)

--- a/code/specs/data/mycin-2026/recall/test_onco_recall.py
+++ b/code/specs/data/mycin-2026/recall/test_onco_recall.py
@@ -34,6 +34,8 @@ EXPECTED = {
     "medullary_thyroid_carcinoma": {"calcitonin", "cea"},
     "hepatocellular_carcinoma": {"alpha_fetoprotein"},
     "colorectal_cancer": {"cea"},                        # expand (NBK578172)
+    "prostate_cancer": {"psa"},                          # expand (NBK470550)
+    "choriocarcinoma": {"hcg"},                           # expand (NBK532950)
 }
 REL = "tumor_marker"
 VAR = "Marker"


### PR DESCRIPTION
## What

Expands the oncology tumor-marker domain with two high-yield edges, primary-source-first (each disease-specific page supplied the clean both-endpoints span the aggregate marker page lacked):

| Edge | Source | Locator |
|---|---|---|
| `tumor_marker(prostate_cancer, psa)` | "Elevated PSA levels have long been associated with prostate cancer." | StatPearls *Prostate Cancer* (NBK470550) |
| `tumor_marker(choriocarcinoma, hcg)` | "...hCG testing can aid in the diagnosis of certain cancers, such as choriocarcinoma and some extra-uterine malignancies." | StatPearls *Human Chorionic Gonadotropin* (NBK532950) |

Both ship inline byte-provenance, are engine-queryable (added to `onco-recall.query.adj`), and are mirrored into the board bank. The hCG marker atom is `hcg` to match the span verbatim — the board buzzword "beta-hCG" is the clinically-assayed subunit of the named hCG.

## Still deferred (re-checked, recorded in the ONCO note)

- **CA 19-9 → pancreatic** — the Pancreatic Cancer page (NBK518996) names the marker only as a "pancreatic tumor marker (CA 19-9 and CEA)", not alongside "pancreatic cancer" in one sentence. Honest absence beats an over-reaching citation.

## Numbers

- Board scorecard: **134→136** recall correct, **133→135** grounded, coverage **0.9925→0.9926**, **wrong still 0** / defensibility **1.0**.
- Domain map: ONCO 5→7.

## Verification

- All **19** recall suites pass against the native `adj-lang-cli`.
- The **12**-test board scorecard passes (memoized).
- The dedicated `mycin-2026` CI workflow exercises both on every PR.
- Security review passed (data/test/docs only — no executable surface).

🤖 Generated with [Claude Code](https://claude.com/claude-code)