### PR TITLE
Expose SPICE deck control command inventory artifacts

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 ### Added
 
+- **Deck run control command inventory artifacts** —
+  `analyze_deck_controls()` now exposes normalized `.control` command lines
+  separately from full active deck input, and `run_deck_analysis()`
+  selected-run artifacts carry those commands in `ControlLines` /
+  `ControlLineList` across stable tables, CSV/JSON helpers, and ordered
+  `table_artifacts`, matching Rust and TypeScript.
+
 - **Deck run control diagnostic artifacts** —
   `run_deck_analysis()` selected-run artifacts now include existing `.control`
   body policy diagnostic codes in `Diagnostics` / `DiagnosticCodeList`, and

--- a/code/packages/python/spice-engine/README.md
+++ b/code/packages/python/spice-engine/README.md
@@ -65,7 +65,7 @@ print(result.diagnostics.solver)   # "dense_real" or "sparse_real"
 | `fourier` | `.FOUR` | Harmonic magnitudes/phases and THD from transient output |
 | `format_dc_table`, `format_transient_table` | `.PRINT` / `.PLOT` output | Stable tabular node voltages and branch currents |
 | `resolve_deck_outputs`, `format_deck_*_table`, `format_deck_table_csv`, `format_deck_table_json`, `deck_table_records` | `.SAVE` / `.PROBE` / `.PRINT` / `.PLOT` output | Parsed deck-selected OP, DC sweep, AC, and transient tables plus deterministic CSV/JSON/record conversion |
-| `format_deck_run_artifact_table`, `format_deck_run_artifact_csv`, `format_deck_run_artifact_json` | Deck execution artifact | Stable selected-run row, table, analysis-directive, output-probe, output-directive, measurement, Fourier, and diagnostic count/name lists |
+| `format_deck_run_artifact_table`, `format_deck_run_artifact_csv`, `format_deck_run_artifact_json` | Deck execution artifact | Stable selected-run row, table, analysis-directive, output-probe, output-directive, measurement, Fourier, control-command, and diagnostic count/name lists |
 | `measure_transient_probe`, `measure_dc_sweep_probe`, `measure_ac_sweep_probe`, `format_measurement_table` | `.MEASURE` output | Stable scalar transient, DC sweep, and AC sweep probe measurements |
 
 `diode_at_temperature()`, `bjt_at_temperature()`, `mosfet_at_temperature()`,
@@ -115,6 +115,8 @@ Fourier table. Executions also include a selected-run artifact summary plus
 `format_deck_run_artifact_table()` and `format_deck_run_artifact_csv()` output
 for stable result-row, table, analysis-directive, output-probe,
 output-directive, measurement, Fourier, and diagnostic count/name lists.
+Normalized accepted `.control` commands are surfaced separately in
+`ControlLines` / `ControlLineList` artifact fields.
 Existing `.control` body policy diagnostics flow into those selected-run
 artifact `Diagnostics` / `DiagnosticCodeList` fields and through the same
 run-artifact table, CSV, JSON, and `table_artifacts` records.
@@ -232,7 +234,7 @@ stable deck-selected table output with normalized table-inventory,
 analysis-directive, output-probe, and output-directive artifacts,
 selected measurement artifacts, selected transient Fourier artifacts,
 selected-run artifact summaries with analysis-directive, output-probe, output-directive,
-measurement, and Fourier probe name lists, `.ac LIN`, `.ac DEC`, `.ac OCT`
+measurement, Fourier probe, and `.control` command inventories, `.ac LIN`, `.ac DEC`, `.ac OCT`
 frequency grids, and `.tran`
 `START` / print-step `TSTEP` / `MAXSTEP` / `UIC` controls.
 

--- a/code/packages/python/spice-engine/src/spice_engine/compatibility.py
+++ b/code/packages/python/spice-engine/src/spice_engine/compatibility.py
@@ -56,6 +56,7 @@ class DeckControlSummary:
     """Normalized active deck lines plus deck-control diagnostics."""
 
     active_lines: tuple[str, ...]
+    control_lines: tuple[str, ...]
     terminated: bool
     end_line_number: int | None
     diagnostics: tuple[DeckControlDiagnostic, ...]
@@ -607,6 +608,7 @@ def analyze_deck_controls(netlist: str) -> DeckControlSummary:
     """Return active pre-``.end`` lines and unsupported deck-control diagnostics."""
 
     active_lines: list[str] = []
+    control_lines: list[str] = []
     diagnostics: list[DeckControlDiagnostic] = []
     end_line_number: int | None = None
     in_control_block = False
@@ -623,6 +625,7 @@ def analyze_deck_controls(netlist: str) -> DeckControlSummary:
             control_line = _control_block_command_as_deck_line(stripped)
             if control_line is not None:
                 active_lines.append(control_line)
+                control_lines.append(control_line)
                 continue
             if _is_noop_control_block_command(stripped):
                 continue
@@ -706,6 +709,7 @@ def analyze_deck_controls(netlist: str) -> DeckControlSummary:
 
     return DeckControlSummary(
         active_lines=tuple(active_lines),
+        control_lines=tuple(control_lines),
         terminated=end_line_number is not None,
         end_line_number=end_line_number,
         diagnostics=tuple(diagnostics),

--- a/code/packages/python/spice-engine/src/spice_engine/engine.py
+++ b/code/packages/python/spice-engine/src/spice_engine/engine.py
@@ -2351,6 +2351,8 @@ class DeckRunArtifact:
     measurement_names: list[str]
     fourier_count: int
     fourier_probes: list[str]
+    control_line_count: int
+    control_lines: list[str]
     diagnostic_count: int
     diagnostic_codes: list[str]
 
@@ -2467,6 +2469,8 @@ _DECK_RUN_ARTIFACT_COLUMNS = [
     "MeasurementList",
     "Fourier",
     "FourierList",
+    "ControlLines",
+    "ControlLineList",
     "Diagnostics",
     "DiagnosticCodeList",
 ]
@@ -2502,6 +2506,7 @@ def _deck_run_artifacts(
     output_directives: list[str],
     measurements: list[ProbeMeasurement],
     fourier: list[FourierResult],
+    control_lines: list[str],
     diagnostic_codes: list[str],
 ) -> list[DeckRunArtifact]:
     is_transient = plan.analysis == "tran"
@@ -2545,6 +2550,8 @@ def _deck_run_artifacts(
             fourier_probes=[
                 probe.probe for result in fourier for probe in result.probes
             ],
+            control_line_count=len(control_lines),
+            control_lines=list(control_lines),
             diagnostic_count=len(diagnostic_codes),
             diagnostic_codes=list(diagnostic_codes),
         )
@@ -2571,6 +2578,10 @@ def _deck_control_diagnostic_codes(netlist: str) -> list[str]:
         for diagnostic in summary.diagnostics
         if diagnostic.code.startswith("SPICE_DECK_CONTROL_")
     ]
+
+
+def _deck_control_lines(netlist: str) -> list[str]:
+    return list(analyze_deck_controls(netlist).control_lines)
 
 
 def _deck_run_diagnostic_codes(netlist: str, plan: DeckAnalysisPlan) -> list[str]:
@@ -2623,6 +2634,8 @@ def _deck_run_artifact_cells(artifact: DeckRunArtifact) -> list[str]:
         ";".join(artifact.measurement_names),
         str(artifact.fourier_count),
         ";".join(artifact.fourier_probes),
+        str(artifact.control_line_count),
+        ";".join(artifact.control_lines),
         str(artifact.diagnostic_count),
         ";".join(artifact.diagnostic_codes),
     ]
@@ -2738,6 +2751,7 @@ def run_deck_analysis(
 
     plan = select_deck_analysis_plan(netlist, analysis)
     diagnostic_codes = _deck_run_diagnostic_codes(netlist, plan)
+    control_lines = _deck_control_lines(netlist)
     analysis_directives = _deck_analysis_directives(plan)
     if plan.analysis == "op":
         result = dc_op(circuit)
@@ -2756,6 +2770,7 @@ def run_deck_analysis(
             output_directives,
             measurements,
             fourier,
+            control_lines,
             diagnostic_codes,
         )
         measurement_table = format_measurement_table(measurements)
@@ -2810,6 +2825,7 @@ def run_deck_analysis(
             output_directives,
             measurements,
             fourier,
+            control_lines,
             diagnostic_codes,
         )
         measurement_table = format_measurement_table(measurements)
@@ -2866,6 +2882,7 @@ def run_deck_analysis(
             output_directives,
             measurements,
             fourier,
+            control_lines,
             diagnostic_codes,
         )
         measurement_table = format_measurement_table(measurements)
@@ -2928,6 +2945,7 @@ def run_deck_analysis(
             output_directives,
             measurements,
             fourier,
+            control_lines,
             diagnostic_codes,
         )
         measurement_table = format_measurement_table(measurements)
@@ -2978,6 +2996,7 @@ def run_deck_analysis(
             output_directives,
             measurements,
             fourier,
+            control_lines,
             diagnostic_codes,
         )
         measurement_table = format_measurement_table(measurements)
@@ -3027,6 +3046,7 @@ def run_deck_analysis(
             output_directives,
             measurements,
             fourier,
+            control_lines,
             diagnostic_codes,
         )
         measurement_table = format_measurement_table(measurements)
@@ -3095,6 +3115,7 @@ def run_deck_analysis(
             output_directives,
             measurements,
             fourier,
+            control_lines,
             diagnostic_codes,
         )
         measurement_table = format_measurement_table(measurements)

--- a/code/packages/python/spice-engine/tests/test_compatibility.py
+++ b/code/packages/python/spice-engine/tests/test_compatibility.py
@@ -102,6 +102,7 @@ V1 in 0 DC 1
     assert summary.terminated is True
     assert summary.end_line_number == 5
     assert summary.active_lines == ("V1 in 0 DC 1", ".op")
+    assert summary.control_lines == ()
     assert summary.diagnostics == ()
 
 
@@ -166,6 +167,16 @@ quit
     assert summary.active_lines == (
         ".include models.inc",
         ".LIB vendor.lib TT",
+        ".op",
+        ".save V(in)",
+        ".probe V(out)",
+        ".print op V(in)",
+        ".measure tran vmax MAX V(out)",
+        ".meas dc imax MAX I(V1)",
+        ".four 1k V(out)",
+        ".four 2k V(in)",
+    )
+    assert summary.control_lines == (
         ".op",
         ".save V(in)",
         ".probe V(out)",

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -6843,11 +6843,13 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
     assert op_execution.run_artifacts[0].analysis_directives == [".op"]
     assert op_execution.run_artifacts[0].measurement_names == []
     assert op_execution.run_artifacts[0].fourier_probes == []
+    assert op_execution.run_artifacts[0].control_line_count == 0
+    assert op_execution.run_artifacts[0].control_lines == []
     assert op_execution.run_artifacts[0].diagnostic_count == 0
     assert op_execution.run_artifacts[0].diagnostic_codes == []
     assert op_execution.run_artifact_table == (
-        "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tDiagnostics\tDiagnosticCodeList\n"
-        f"op\t.op\t1\t.op\t{op_execution.plan.line_number}\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t1\t2\tIndex;V(mid)\t2\tresult;run-artifact\t1\tV(mid)\t1\t.save\t0\t\t0\t\t0\t\n"
+        "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tDiagnostics\tDiagnosticCodeList\n"
+        f"op\t.op\t1\t.op\t{op_execution.plan.line_number}\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t1\t2\tIndex;V(mid)\t2\tresult;run-artifact\t1\tV(mid)\t1\t.save\t0\t\t0\t\t0\t\t0\t\n"
     )
     assert op_execution.table_artifacts[1].name == "run-artifact"
     assert op_execution.table_artifacts[1].table == op_execution.run_artifact_table
@@ -6864,8 +6866,8 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
         format_deck_run_artifact_json(op_execution.run_artifacts)
     )
     assert format_deck_run_artifact_csv(op_execution.run_artifacts) == (
-        "Analysis,Directive,AnalysisDirectives,AnalysisDirectiveList,Line,SourceName,OutputNode,SweepKind,StartValue,StopValue,StepValue,PointCount,StartFrequencyHz,StopFrequencyHz,StepTime,StopTime,StartTime,MaxStep,UseInitialConditions,ResultRows,ResultColumns,ResultColumnList,Tables,TableList,OutputProbes,OutputProbeList,OutputDirectives,OutputDirectiveList,Measurements,MeasurementList,Fourier,FourierList,Diagnostics,DiagnosticCodeList\n"
-        f"op,.op,1,.op,{op_execution.plan.line_number},,,,,,,,,,,,,,,1,2,Index;V(mid),2,result;run-artifact,1,V(mid),1,.save,0,,0,,0,\n"
+        "Analysis,Directive,AnalysisDirectives,AnalysisDirectiveList,Line,SourceName,OutputNode,SweepKind,StartValue,StopValue,StepValue,PointCount,StartFrequencyHz,StopFrequencyHz,StepTime,StopTime,StartTime,MaxStep,UseInitialConditions,ResultRows,ResultColumns,ResultColumnList,Tables,TableList,OutputProbes,OutputProbeList,OutputDirectives,OutputDirectiveList,Measurements,MeasurementList,Fourier,FourierList,ControlLines,ControlLineList,Diagnostics,DiagnosticCodeList\n"
+        f"op,.op,1,.op,{op_execution.plan.line_number},,,,,,,,,,,,,,,1,2,Index;V(mid),2,result;run-artifact,1,V(mid),1,.save,0,,0,,0,,0,\n"
     )
     assert format_deck_table_csv('Name\tValue\nprobe\tSPICE,"QUOTED"\n') == (
         'Name,Value\nprobe,"SPICE,""QUOTED"""\n'
@@ -6911,6 +6913,8 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
         "MeasurementList",
         "Fourier",
         "FourierList",
+        "ControlLines",
+        "ControlLineList",
         "Diagnostics",
         "DiagnosticCodeList",
     ]
@@ -6948,6 +6952,8 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
             "MeasurementList": "",
             "Fourier": "0",
             "FourierList": "",
+            "ControlLines": "0",
+            "ControlLineList": "",
             "Diagnostics": "0",
             "DiagnosticCodeList": "",
         }
@@ -6970,7 +6976,7 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
         diagnostic_codes=["SPICE_DECK_ANALYSIS_TOKEN", 'SPICE,"QUOTED"'],
     )
     assert format_deck_run_artifact_csv([quoted_diagnostic_artifact]).endswith(
-        ',2,"SPICE_DECK_ANALYSIS_TOKEN;SPICE,""QUOTED"""\n'
+        ',0,,2,"SPICE_DECK_ANALYSIS_TOKEN;SPICE,""QUOTED"""\n'
     )
     assert json.loads(format_deck_run_artifact_json([quoted_diagnostic_artifact]))[
         0
@@ -7036,8 +7042,8 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
     assert dc_execution.run_artifacts[0].measurement_names == ["mid_avg"]
     assert dc_execution.run_artifacts[0].fourier_probes == []
     assert dc_execution.run_artifact_table == (
-        "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tDiagnostics\tDiagnosticCodeList\n"
-        f"dc\t.dc\t1\t.dc\t{dc_execution.plan.line_number}\tV1\t\t\t0.000000e+00\t1.000000e+00\t1.000000e+00\t\t\t\t\t\t\t\t\t2\t5\tIndex;Source;Value;V(mid);I(V1)\t3\tresult;measurement;run-artifact\t2\tV(mid);I(V1)\t2\t.save;.probe\t1\tmid_avg\t0\t\t0\t\n"
+        "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tDiagnostics\tDiagnosticCodeList\n"
+        f"dc\t.dc\t1\t.dc\t{dc_execution.plan.line_number}\tV1\t\t\t0.000000e+00\t1.000000e+00\t1.000000e+00\t\t\t\t\t\t\t\t\t2\t5\tIndex;Source;Value;V(mid);I(V1)\t3\tresult;measurement;run-artifact\t2\tV(mid);I(V1)\t2\t.save;.probe\t1\tmid_avg\t0\t\t0\t\t0\t\n"
     )
 
     ac_execution = run_deck_analysis(circuit, netlist, "ac")
@@ -7086,8 +7092,8 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
     assert ac_execution.run_artifacts[0].measurement_names == ["mid_peak"]
     assert ac_execution.run_artifacts[0].fourier_probes == []
     assert ac_execution.run_artifact_table == (
-        "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tDiagnostics\tDiagnosticCodeList\n"
-        f"ac\t.ac\t1\t.ac\t{ac_execution.plan.line_number}\t\t\tdec\t\t\t\t1\t1.000000e+03\t1.000000e+03\t\t\t\t\t\t1\t7\tIndex;Frequency;Probe;Real;Imaginary;Magnitude;Phase\t3\tresult;measurement;run-artifact\t1\tV(mid)\t1\t.save\t1\tmid_peak\t0\t\t0\t\n"
+        "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tDiagnostics\tDiagnosticCodeList\n"
+        f"ac\t.ac\t1\t.ac\t{ac_execution.plan.line_number}\t\t\tdec\t\t\t\t1\t1.000000e+03\t1.000000e+03\t\t\t\t\t\t1\t7\tIndex;Frequency;Probe;Real;Imaginary;Magnitude;Phase\t3\tresult;measurement;run-artifact\t1\tV(mid)\t1\t.save\t1\tmid_peak\t0\t\t0\t\t0\t\n"
     )
 
     tran_execution = run_deck_analysis(circuit, netlist, "tran")
@@ -7131,8 +7137,8 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
     assert tran_execution.run_artifacts[0].diagnostic_count == 0
     assert tran_execution.run_artifacts[0].diagnostic_codes == []
     assert tran_execution.run_artifact_table == (
-        "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tDiagnostics\tDiagnosticCodeList\n"
-        f"tran\t.tran\t1\t.tran\t{tran_execution.plan.line_number}\t\t\t\t\t\t\t\t\t\t1.000000e-03\t1.000000e-03\t\t\tfalse\t2\t3\tIndex;Time;V(mid)\t3\tresult;measurement;run-artifact\t1\tV(mid)\t1\t.save\t1\tmid_final\t0\t\t0\t\n"
+        "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tDiagnostics\tDiagnosticCodeList\n"
+        f"tran\t.tran\t1\t.tran\t{tran_execution.plan.line_number}\t\t\t\t\t\t\t\t\t\t1.000000e-03\t1.000000e-03\t\t\tfalse\t2\t3\tIndex;Time;V(mid)\t3\tresult;measurement;run-artifact\t1\tV(mid)\t1\t.save\t1\tmid_final\t0\t\t0\t\t0\t\n"
     )
 
     tf_execution = run_deck_analysis(circuit, netlist, "tf")
@@ -7172,8 +7178,8 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
     assert tf_execution.run_artifacts[0].measurement_names == []
     assert tf_execution.run_artifacts[0].fourier_probes == []
     assert tf_execution.run_artifact_table == (
-        "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tDiagnostics\tDiagnosticCodeList\n"
-        f"tf\t.tf\t1\t.tf\t{tf_execution.plan.line_number}\tV1\tmid\t\t\t\t\t\t\t\t\t\t\t\t\t1\t3\tTransferRatio;InputImpedance;OutputImpedance\t2\tresult;run-artifact\t1\tV(mid)\t0\t\t0\t\t0\t\t0\t\n"
+        "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tDiagnostics\tDiagnosticCodeList\n"
+        f"tf\t.tf\t1\t.tf\t{tf_execution.plan.line_number}\tV1\tmid\t\t\t\t\t\t\t\t\t\t\t\t\t1\t3\tTransferRatio;InputImpedance;OutputImpedance\t2\tresult;run-artifact\t1\tV(mid)\t0\t\t0\t\t0\t\t0\t\t0\t\n"
     )
 
     sens_execution = run_deck_analysis(circuit, netlist, "sens")
@@ -7214,8 +7220,8 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
     assert sens_execution.run_artifacts[0].measurement_names == []
     assert sens_execution.run_artifacts[0].fourier_probes == []
     assert sens_execution.run_artifact_table == (
-        "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tDiagnostics\tDiagnosticCodeList\n"
-        f"sens\t.sens\t1\t.sens\t{sens_execution.plan.line_number}\t\tmid\t\t\t\t\t\t\t\t\t\t\t\t\t1\t7\tOutputNode;NominalVoltage;Element;Parameter;NominalValue;Sensitivity;RelativeSensitivity\t2\tresult;run-artifact\t1\tV(mid)\t0\t\t0\t\t0\t\t0\t\n"
+        "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tDiagnostics\tDiagnosticCodeList\n"
+        f"sens\t.sens\t1\t.sens\t{sens_execution.plan.line_number}\t\tmid\t\t\t\t\t\t\t\t\t\t\t\t\t1\t7\tOutputNode;NominalVoltage;Element;Parameter;NominalValue;Sensitivity;RelativeSensitivity\t2\tresult;run-artifact\t1\tV(mid)\t0\t\t0\t\t0\t\t0\t\t0\t\n"
     )
 
     noise_execution = run_deck_analysis(circuit, netlist, "noise")
@@ -7270,8 +7276,8 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
     assert noise_execution.run_artifacts[0].measurement_names == []
     assert noise_execution.run_artifacts[0].fourier_probes == []
     assert noise_execution.run_artifact_table == (
-        "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tDiagnostics\tDiagnosticCodeList\n"
-        f"noise\t.noise\t1\t.noise\t{noise_execution.plan.line_number}\tV1\tmid\tlin\t\t\t\t1\t1.000000e+03\t1.000000e+03\t\t\t\t\t\t1\t10\tIndex;Frequency;OutputNode;InputSource;OutputPSD;InputReferredPSD;Element;Type;SourcePSD;ContributionPSD\t2\tresult;run-artifact\t1\tV(mid)\t0\t\t0\t\t0\t\t0\t\n"
+        "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tDiagnostics\tDiagnosticCodeList\n"
+        f"noise\t.noise\t1\t.noise\t{noise_execution.plan.line_number}\tV1\tmid\tlin\t\t\t\t1\t1.000000e+03\t1.000000e+03\t\t\t\t\t\t1\t10\tIndex;Frequency;OutputNode;InputSource;OutputPSD;InputReferredPSD;Element;Type;SourcePSD;ContributionPSD\t2\tresult;run-artifact\t1\tV(mid)\t0\t\t0\t\t0\t\t0\t\t0\t\n"
     )
 
     tran_window_execution = run_deck_analysis(
@@ -7311,8 +7317,8 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
         "2\t6.000000e-03\t5.000000e-01\n"
     )
     assert tran_window_execution.run_artifact_table == (
-        "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tDiagnostics\tDiagnosticCodeList\n"
-        f"tran\t.tran\t1\t.tran\t{tran_window_execution.plan.line_number}\t\t\t\t\t\t\t\t\t\t2.000000e-03\t6.000000e-03\t2.000000e-03\t1.000000e-03\ttrue\t3\t3\tIndex;Time;V(mid)\t2\tresult;run-artifact\t1\tV(mid)\t1\t.save\t0\t\t0\t\t0\t\n"
+        "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tDiagnostics\tDiagnosticCodeList\n"
+        f"tran\t.tran\t1\t.tran\t{tran_window_execution.plan.line_number}\t\t\t\t\t\t\t\t\t\t2.000000e-03\t6.000000e-03\t2.000000e-03\t1.000000e-03\ttrue\t3\t3\tIndex;Time;V(mid)\t2\tresult;run-artifact\t1\tV(mid)\t1\t.save\t0\t\t0\t\t0\t\t0\t\n"
     )
 
     with pytest.raises(ValueError, match="multiple analysis cards"):
@@ -7348,6 +7354,8 @@ def test_run_deck_analysis_surfaces_control_diagnostics_in_artifacts() -> None:
     netlist = """
 .save V(in)
 .control
+save V(in)
+probe V(in)
 source other.cir
 cd /tmp
 if v(in) > 0
@@ -7365,13 +7373,20 @@ let gain = 2
         "SPICE_DECK_CONTROL_VARIABLE_COMMAND",
     ]
     code_list = ";".join(expected_codes)
+    expected_control_lines = [".save V(in)", ".probe V(in)"]
+    control_line_list = ";".join(expected_control_lines)
 
+    assert execution.run_artifacts[0].control_line_count == len(expected_control_lines)
+    assert execution.run_artifacts[0].control_lines == expected_control_lines
     assert execution.run_artifacts[0].diagnostic_count == len(expected_codes)
     assert execution.run_artifacts[0].diagnostic_codes == expected_codes
     record = deck_table_records(execution.run_artifact_table)[0]
+    assert record["ControlLines"] == str(len(expected_control_lines))
+    assert record["ControlLineList"] == control_line_list
     assert record["Diagnostics"] == str(len(expected_codes))
     assert record["DiagnosticCodeList"] == code_list
     assert execution.table_artifacts[-1].name == "run-artifact"
+    assert execution.table_artifacts[-1].records[0]["ControlLineList"] == control_line_list
     assert execution.table_artifacts[-1].records[0]["DiagnosticCodeList"] == code_list
     assert execution.table_artifacts[-1].csv == format_deck_run_artifact_csv(
         execution.run_artifacts
@@ -7379,6 +7394,9 @@ let gain = 2
     assert execution.table_artifacts[-1].json == format_deck_run_artifact_json(
         execution.run_artifacts
     )
+    assert json.loads(format_deck_run_artifact_json(execution.run_artifacts))[0][
+        "ControlLineList"
+    ] == control_line_list
     assert json.loads(format_deck_run_artifact_json(execution.run_artifacts))[0][
         "DiagnosticCodeList"
     ] == code_list
@@ -7447,8 +7465,8 @@ def test_run_deck_analysis_exposes_selected_fourier_artifacts() -> None:
     assert tran_execution.run_artifacts[0].measurement_names == []
     assert tran_execution.run_artifacts[0].fourier_probes == ["V(mid)"]
     assert tran_execution.run_artifact_table == (
-        "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tDiagnostics\tDiagnosticCodeList\n"
-        f"tran\t.tran\t1\t.tran\t{tran_execution.plan.line_number}\t\t\t\t\t\t\t\t\t\t5.000000e-04\t1.000000e-03\t\t\tfalse\t3\t3\tIndex;Time;V(mid)\t3\tresult;fourier;run-artifact\t1\tV(mid)\t1\t.save\t0\t\t1\tV(mid)\t0\t\n"
+        "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tDiagnostics\tDiagnosticCodeList\n"
+        f"tran\t.tran\t1\t.tran\t{tran_execution.plan.line_number}\t\t\t\t\t\t\t\t\t\t5.000000e-04\t1.000000e-03\t\t\tfalse\t3\t3\tIndex;Time;V(mid)\t3\tresult;fourier;run-artifact\t1\tV(mid)\t1\t.save\t0\t\t1\tV(mid)\t0\t\t0\t\n"
     )
 
 

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- Add normalized `.control` command inventories to `analyze_deck_controls`
+  separately from full active deck input, and carry those commands through
+  selected `run_deck_analysis` run artifacts as stable `ControlLines` /
+  `ControlLineList` table, CSV/JSON, and ordered `table_artifacts` fields,
+  matching Python and TypeScript.
 - Surface existing `.control` body policy diagnostic codes in selected
   `run_deck_analysis` run artifacts and propagate them through stable
   run-artifact tables, CSV/JSON helpers, and ordered `table_artifacts`,

--- a/code/packages/rust/spice-engine/README.md
+++ b/code/packages/rust/spice-engine/README.md
@@ -189,7 +189,9 @@ results and a stable Fourier table. Executions also include selected-run
 artifact summaries plus `format_deck_run_artifact_table` and
 `format_deck_run_artifact_csv` / `format_deck_run_artifact_json` output for
 stable result-row, table, analysis-directive, output-probe, output-directive,
-measurement, Fourier, and diagnostic count/name lists. Existing `.control` body
+measurement, Fourier, control-command, and diagnostic count/name lists.
+Normalized accepted `.control` commands are surfaced separately in
+`ControlLines` / `ControlLineList` artifact fields. Existing `.control` body
 policy diagnostics flow into those selected-run artifact `Diagnostics` /
 `DiagnosticCodeList` fields and through the same run-artifact table, CSV, JSON,
 and `table_artifacts` records. `format_deck_table_csv` also converts any stable
@@ -242,6 +244,6 @@ stable deck-selected table output with normalized table-inventory, output-probe
 and output-directive artifacts,
 selected measurement artifacts, selected transient Fourier artifacts,
 selected-run artifact summaries with table, analysis-directive, output-probe, output-directive,
-measurement, and Fourier probe name lists, `.ac LIN`, `.ac DEC`, `.ac OCT`
+measurement, Fourier probe, and `.control` command inventories, `.ac LIN`, `.ac DEC`, `.ac OCT`
 frequency grids, and `.tran`
 `START` / print-step `TSTEP` / `MAXSTEP` / `UIC` controls.

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -3148,6 +3148,7 @@ pub struct DeckControlDiagnostic {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DeckControlSummary {
     pub active_lines: Vec<String>,
+    pub control_lines: Vec<String>,
     pub terminated: bool,
     pub end_line_number: Option<usize>,
     pub diagnostics: Vec<DeckControlDiagnostic>,
@@ -3436,6 +3437,8 @@ pub struct DeckRunArtifact {
     pub measurement_names: Vec<String>,
     pub fourier_count: usize,
     pub fourier_probes: Vec<String>,
+    pub control_line_count: usize,
+    pub control_lines: Vec<String>,
     pub diagnostic_count: usize,
     pub diagnostic_codes: Vec<String>,
 }
@@ -3593,6 +3596,7 @@ pub fn compatibility_corpus() -> Vec<CompatibilityDeck> {
 
 pub fn analyze_deck_controls(netlist: &str) -> DeckControlSummary {
     let mut active_lines = Vec::new();
+    let mut control_lines = Vec::new();
     let mut diagnostics = Vec::new();
     let mut end_line_number = None;
     let mut in_control_block = false;
@@ -3610,7 +3614,8 @@ pub fn analyze_deck_controls(netlist: &str) -> DeckControlSummary {
                 continue;
             }
             if let Some(control_line) = control_block_command_as_deck_line(stripped) {
-                active_lines.push(control_line);
+                active_lines.push(control_line.clone());
+                control_lines.push(control_line);
                 continue;
             }
             if is_noop_control_block_command(stripped) {
@@ -3693,6 +3698,7 @@ pub fn analyze_deck_controls(netlist: &str) -> DeckControlSummary {
 
     DeckControlSummary {
         active_lines,
+        control_lines,
         terminated: end_line_number.is_some(),
         end_line_number,
         diagnostics,
@@ -10119,6 +10125,7 @@ fn deck_run_artifacts(
     output_directives: &[String],
     measurements: &[ProbeMeasurement],
     fourier: &[FourierResult],
+    control_lines: &[String],
     diagnostic_codes: &[String],
 ) -> Vec<DeckRunArtifact> {
     let is_transient = plan.analysis == "tran";
@@ -10163,6 +10170,8 @@ fn deck_run_artifacts(
             .iter()
             .flat_map(|result| result.probes.iter().map(|probe| probe.probe.clone()))
             .collect(),
+        control_line_count: control_lines.len(),
+        control_lines: control_lines.to_vec(),
         diagnostic_count: diagnostic_codes.len(),
         diagnostic_codes: diagnostic_codes.to_vec(),
     }]
@@ -10206,6 +10215,10 @@ fn deck_control_diagnostic_codes(netlist: &str) -> Vec<String> {
         .filter(|diagnostic| diagnostic.code.starts_with("SPICE_DECK_CONTROL_"))
         .map(|diagnostic| diagnostic.code)
         .collect()
+}
+
+fn deck_control_lines(netlist: &str) -> Vec<String> {
+    analyze_deck_controls(netlist).control_lines
 }
 
 fn deck_run_diagnostic_codes(netlist: &str, plan: &DeckAnalysisPlan) -> Vec<String> {
@@ -10255,6 +10268,8 @@ const DECK_RUN_ARTIFACT_COLUMNS: &[&str] = &[
     "MeasurementList",
     "Fourier",
     "FourierList",
+    "ControlLines",
+    "ControlLineList",
     "Diagnostics",
     "DiagnosticCodeList",
 ];
@@ -10296,6 +10311,8 @@ fn deck_run_artifact_cells(artifact: &DeckRunArtifact) -> Vec<String> {
         artifact.measurement_names.join(";"),
         artifact.fourier_count.to_string(),
         artifact.fourier_probes.join(";"),
+        artifact.control_line_count.to_string(),
+        artifact.control_lines.join(";"),
         artifact.diagnostic_count.to_string(),
         artifact.diagnostic_codes.join(";"),
     ]
@@ -10535,6 +10552,7 @@ pub fn run_deck_analysis(
 ) -> Result<DeckAnalysisExecution, SpiceError> {
     let plan = select_deck_analysis_plan(netlist, analysis)?;
     let diagnostic_codes = deck_run_diagnostic_codes(netlist, &plan);
+    let control_lines = deck_control_lines(netlist);
     let analysis_directives = deck_analysis_directives(&plan);
     match plan.analysis.as_str() {
         "op" => {
@@ -10556,6 +10574,7 @@ pub fn run_deck_analysis(
                 &output_directives,
                 &measurements,
                 &fourier,
+                &control_lines,
                 &diagnostic_codes,
             );
             let run_artifact_table = format_deck_run_artifact_table(&run_artifacts);
@@ -10611,6 +10630,7 @@ pub fn run_deck_analysis(
                 &output_directives,
                 &measurements,
                 &fourier,
+                &control_lines,
                 &diagnostic_codes,
             );
             let run_artifact_table = format_deck_run_artifact_table(&run_artifacts);
@@ -10667,6 +10687,7 @@ pub fn run_deck_analysis(
                 &output_directives,
                 &measurements,
                 &fourier,
+                &control_lines,
                 &diagnostic_codes,
             );
             let run_artifact_table = format_deck_run_artifact_table(&run_artifacts);
@@ -10726,6 +10747,7 @@ pub fn run_deck_analysis(
                 &output_directives,
                 &measurements,
                 &fourier,
+                &control_lines,
                 &diagnostic_codes,
             );
             let run_artifact_table = format_deck_run_artifact_table(&run_artifacts);
@@ -10779,6 +10801,7 @@ pub fn run_deck_analysis(
                 &output_directives,
                 &measurements,
                 &fourier,
+                &control_lines,
                 &diagnostic_codes,
             );
             let run_artifact_table = format_deck_run_artifact_table(&run_artifacts);
@@ -10830,6 +10853,7 @@ pub fn run_deck_analysis(
                 &output_directives,
                 &measurements,
                 &fourier,
+                &control_lines,
                 &diagnostic_codes,
             );
             let run_artifact_table = format_deck_run_artifact_table(&run_artifacts);
@@ -10893,6 +10917,7 @@ pub fn run_deck_analysis(
                 &output_directives,
                 &measurements,
                 &fourier,
+                &control_lines,
                 &diagnostic_codes,
             );
             let run_artifact_table = format_deck_run_artifact_table(&run_artifacts);

--- a/code/packages/rust/spice-engine/tests/compatibility_tests.rs
+++ b/code/packages/rust/spice-engine/tests/compatibility_tests.rs
@@ -118,6 +118,7 @@ V1 in 0 DC 1
     assert!(summary.terminated);
     assert_eq!(summary.end_line_number, Some(5));
     assert_eq!(summary.active_lines, vec!["V1 in 0 DC 1", ".op"]);
+    assert!(summary.control_lines.is_empty());
     assert!(summary.diagnostics.is_empty());
 }
 
@@ -185,6 +186,19 @@ quit
         &[
             ".include models.inc".to_string(),
             ".LIB vendor.lib TT".to_string(),
+            ".op".to_string(),
+            ".save V(in)".to_string(),
+            ".probe V(out)".to_string(),
+            ".print op V(in)".to_string(),
+            ".measure tran vmax MAX V(out)".to_string(),
+            ".meas dc imax MAX I(V1)".to_string(),
+            ".four 1k V(out)".to_string(),
+            ".four 2k V(in)".to_string(),
+        ]
+    );
+    assert_eq!(
+        summary.control_lines,
+        &[
             ".op".to_string(),
             ".save V(in)".to_string(),
             ".probe V(out)".to_string(),

--- a/code/packages/rust/spice-engine/tests/transient_tests.rs
+++ b/code/packages/rust/spice-engine/tests/transient_tests.rs
@@ -1960,12 +1960,14 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
     );
     assert!(op_execution.run_artifacts[0].measurement_names.is_empty());
     assert!(op_execution.run_artifacts[0].fourier_probes.is_empty());
+    assert_eq!(op_execution.run_artifacts[0].control_line_count, 0);
+    assert!(op_execution.run_artifacts[0].control_lines.is_empty());
     assert_eq!(op_execution.run_artifacts[0].diagnostic_count, 0);
     assert!(op_execution.run_artifacts[0].diagnostic_codes.is_empty());
     assert_eq!(
         op_execution.run_artifact_table,
         format!(
-            "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tDiagnostics\tDiagnosticCodeList\nop\t.op\t1\t.op\t{}\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t1\t2\tIndex;V(mid)\t2\tresult;run-artifact\t1\tV(mid)\t1\t.save\t0\t\t0\t\t0\t\n",
+            "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tDiagnostics\tDiagnosticCodeList\nop\t.op\t1\t.op\t{}\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t1\t2\tIndex;V(mid)\t2\tresult;run-artifact\t1\tV(mid)\t1\t.save\t0\t\t0\t\t0\t\t0\t\n",
             op_execution.plan.line_number
         )
     );
@@ -2017,7 +2019,7 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
     assert_eq!(
         format_deck_run_artifact_csv(&op_execution.run_artifacts),
         format!(
-            "Analysis,Directive,AnalysisDirectives,AnalysisDirectiveList,Line,SourceName,OutputNode,SweepKind,StartValue,StopValue,StepValue,PointCount,StartFrequencyHz,StopFrequencyHz,StepTime,StopTime,StartTime,MaxStep,UseInitialConditions,ResultRows,ResultColumns,ResultColumnList,Tables,TableList,OutputProbes,OutputProbeList,OutputDirectives,OutputDirectiveList,Measurements,MeasurementList,Fourier,FourierList,Diagnostics,DiagnosticCodeList\nop,.op,1,.op,{},,,,,,,,,,,,,,,1,2,Index;V(mid),2,result;run-artifact,1,V(mid),1,.save,0,,0,,0,\n",
+            "Analysis,Directive,AnalysisDirectives,AnalysisDirectiveList,Line,SourceName,OutputNode,SweepKind,StartValue,StopValue,StepValue,PointCount,StartFrequencyHz,StopFrequencyHz,StepTime,StopTime,StartTime,MaxStep,UseInitialConditions,ResultRows,ResultColumns,ResultColumnList,Tables,TableList,OutputProbes,OutputProbeList,OutputDirectives,OutputDirectiveList,Measurements,MeasurementList,Fourier,FourierList,ControlLines,ControlLineList,Diagnostics,DiagnosticCodeList\nop,.op,1,.op,{},,,,,,,,,,,,,,,1,2,Index;V(mid),2,result;run-artifact,1,V(mid),1,.save,0,,0,,0,,0,\n",
             op_execution.plan.line_number
         )
     );
@@ -2043,7 +2045,9 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
     assert!(artifact_json.contains("\"ResultColumnList\":\"Index;V(mid)\""));
     assert!(artifact_json.contains("\"TableList\":\"result;run-artifact\""));
     assert!(artifact_json.contains("\"OutputProbeList\":\"V(mid)\""));
-    assert!(artifact_json.ends_with("\"Diagnostics\":\"0\",\"DiagnosticCodeList\":\"\"}]\n"));
+    assert!(artifact_json.ends_with(
+        "\"ControlLines\":\"0\",\"ControlLineList\":\"\",\"Diagnostics\":\"0\",\"DiagnosticCodeList\":\"\"}]\n"
+    ));
     let mut diagnostic_artifact = op_execution.run_artifacts[0].clone();
     diagnostic_artifact.diagnostic_codes = vec![
         "SPICE_DECK_ANALYSIS_TOKEN".to_string(),
@@ -2071,10 +2075,10 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
     quoted_diagnostic_artifact.diagnostic_count = quoted_diagnostic_artifact.diagnostic_codes.len();
     assert!(
         format_deck_run_artifact_csv(&[quoted_diagnostic_artifact.clone()])
-            .ends_with(",2,\"SPICE_DECK_ANALYSIS_TOKEN;SPICE,\"\"QUOTED\"\"\"\n")
+            .ends_with(",0,,2,\"SPICE_DECK_ANALYSIS_TOKEN;SPICE,\"\"QUOTED\"\"\"\n")
     );
     assert!(format_deck_run_artifact_json(&[quoted_diagnostic_artifact]).ends_with(
-        ",\"Diagnostics\":\"2\",\"DiagnosticCodeList\":\"SPICE_DECK_ANALYSIS_TOKEN;SPICE,\\\"QUOTED\\\"\"}]\n"
+        ",\"ControlLines\":\"0\",\"ControlLineList\":\"\",\"Diagnostics\":\"2\",\"DiagnosticCodeList\":\"SPICE_DECK_ANALYSIS_TOKEN;SPICE,\\\"QUOTED\\\"\"}]\n"
     ));
 
     let dc_execution = run_deck_analysis(&circuit, netlist, Some("dc")).unwrap();
@@ -2185,7 +2189,7 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
     assert_eq!(
         dc_execution.run_artifact_table,
         format!(
-            "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tDiagnostics\tDiagnosticCodeList\ndc\t.dc\t1\t.dc\t{}\tV1\t\t\t0.000000e+00\t1.000000e+00\t1.000000e+00\t\t\t\t\t\t\t\t\t2\t5\tIndex;Source;Value;V(mid);I(V1)\t3\tresult;measurement;run-artifact\t2\tV(mid);I(V1)\t2\t.save;.probe\t1\tmid_avg\t0\t\t0\t\n",
+            "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tDiagnostics\tDiagnosticCodeList\ndc\t.dc\t1\t.dc\t{}\tV1\t\t\t0.000000e+00\t1.000000e+00\t1.000000e+00\t\t\t\t\t\t\t\t\t2\t5\tIndex;Source;Value;V(mid);I(V1)\t3\tresult;measurement;run-artifact\t2\tV(mid);I(V1)\t2\t.save;.probe\t1\tmid_avg\t0\t\t0\t\t0\t\n",
             dc_execution.plan.line_number
         )
     );
@@ -2268,7 +2272,7 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
     assert_eq!(
         ac_execution.run_artifact_table,
         format!(
-            "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tDiagnostics\tDiagnosticCodeList\nac\t.ac\t1\t.ac\t{}\t\t\tdec\t\t\t\t1\t1.000000e+03\t1.000000e+03\t\t\t\t\t\t1\t7\tIndex;Frequency;Probe;Real;Imaginary;Magnitude;Phase\t3\tresult;measurement;run-artifact\t1\tV(mid)\t1\t.save\t1\tmid_peak\t0\t\t0\t\n",
+            "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tDiagnostics\tDiagnosticCodeList\nac\t.ac\t1\t.ac\t{}\t\t\tdec\t\t\t\t1\t1.000000e+03\t1.000000e+03\t\t\t\t\t\t1\t7\tIndex;Frequency;Probe;Real;Imaginary;Magnitude;Phase\t3\tresult;measurement;run-artifact\t1\tV(mid)\t1\t.save\t1\tmid_peak\t0\t\t0\t\t0\t\n",
             ac_execution.plan.line_number
         )
     );
@@ -2348,7 +2352,7 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
     assert_eq!(
         tran_execution.run_artifact_table,
         format!(
-            "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tDiagnostics\tDiagnosticCodeList\ntran\t.tran\t1\t.tran\t{}\t\t\t\t\t\t\t\t\t\t1.000000e-03\t1.000000e-03\t\t\tfalse\t1\t3\tIndex;Time;V(mid)\t3\tresult;measurement;run-artifact\t1\tV(mid)\t1\t.save\t1\tmid_final\t0\t\t0\t\n",
+            "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tDiagnostics\tDiagnosticCodeList\ntran\t.tran\t1\t.tran\t{}\t\t\t\t\t\t\t\t\t\t1.000000e-03\t1.000000e-03\t\t\tfalse\t1\t3\tIndex;Time;V(mid)\t3\tresult;measurement;run-artifact\t1\tV(mid)\t1\t.save\t1\tmid_final\t0\t\t0\t\t0\t\n",
             tran_execution.plan.line_number
         )
     );
@@ -2417,7 +2421,7 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
     assert_eq!(
         tf_execution.run_artifact_table,
         format!(
-            "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tDiagnostics\tDiagnosticCodeList\ntf\t.tf\t1\t.tf\t{}\tV1\tmid\t\t\t\t\t\t\t\t\t\t\t\t\t1\t3\tTransferRatio;InputImpedance;OutputImpedance\t2\tresult;run-artifact\t1\tV(mid)\t0\t\t0\t\t0\t\t0\t\n",
+            "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tDiagnostics\tDiagnosticCodeList\ntf\t.tf\t1\t.tf\t{}\tV1\tmid\t\t\t\t\t\t\t\t\t\t\t\t\t1\t3\tTransferRatio;InputImpedance;OutputImpedance\t2\tresult;run-artifact\t1\tV(mid)\t0\t\t0\t\t0\t\t0\t\t0\t\n",
             tf_execution.plan.line_number
         )
     );
@@ -2487,7 +2491,7 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
     assert_eq!(
         sens_execution.run_artifact_table,
         format!(
-            "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tDiagnostics\tDiagnosticCodeList\nsens\t.sens\t1\t.sens\t{}\t\tmid\t\t\t\t\t\t\t\t\t\t\t\t\t1\t7\tOutputNode;NominalVoltage;Element;Parameter;NominalValue;Sensitivity;RelativeSensitivity\t2\tresult;run-artifact\t1\tV(mid)\t0\t\t0\t\t0\t\t0\t\n",
+            "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tDiagnostics\tDiagnosticCodeList\nsens\t.sens\t1\t.sens\t{}\t\tmid\t\t\t\t\t\t\t\t\t\t\t\t\t1\t7\tOutputNode;NominalVoltage;Element;Parameter;NominalValue;Sensitivity;RelativeSensitivity\t2\tresult;run-artifact\t1\tV(mid)\t0\t\t0\t\t0\t\t0\t\t0\t\n",
             sens_execution.plan.line_number
         )
     );
@@ -2589,7 +2593,7 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
     assert_eq!(
         noise_execution.run_artifact_table,
         format!(
-            "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tDiagnostics\tDiagnosticCodeList\nnoise\t.noise\t1\t.noise\t{}\tV1\tmid\tlin\t\t\t\t1\t1.000000e+03\t1.000000e+03\t\t\t\t\t\t1\t10\tIndex;Frequency;OutputNode;InputSource;OutputPSD;InputReferredPSD;Element;Type;SourcePSD;ContributionPSD\t2\tresult;run-artifact\t1\tV(mid)\t0\t\t0\t\t0\t\t0\t\n",
+            "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tDiagnostics\tDiagnosticCodeList\nnoise\t.noise\t1\t.noise\t{}\tV1\tmid\tlin\t\t\t\t1\t1.000000e+03\t1.000000e+03\t\t\t\t\t\t1\t10\tIndex;Frequency;OutputNode;InputSource;OutputPSD;InputReferredPSD;Element;Type;SourcePSD;ContributionPSD\t2\tresult;run-artifact\t1\tV(mid)\t0\t\t0\t\t0\t\t0\t\t0\t\n",
             noise_execution.plan.line_number
         )
     );
@@ -2666,7 +2670,7 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
     assert_eq!(
         tran_window_execution.run_artifact_table,
         format!(
-            "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tDiagnostics\tDiagnosticCodeList\ntran\t.tran\t1\t.tran\t{}\t\t\t\t\t\t\t\t\t\t2.000000e-03\t6.000000e-03\t2.000000e-03\t1.000000e-03\ttrue\t3\t3\tIndex;Time;V(mid)\t2\tresult;run-artifact\t1\tV(mid)\t1\t.save\t0\t\t0\t\t0\t\n",
+            "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tDiagnostics\tDiagnosticCodeList\ntran\t.tran\t1\t.tran\t{}\t\t\t\t\t\t\t\t\t\t2.000000e-03\t6.000000e-03\t2.000000e-03\t1.000000e-03\ttrue\t3\t3\tIndex;Time;V(mid)\t2\tresult;run-artifact\t1\tV(mid)\t1\t.save\t0\t\t0\t\t0\t\t0\t\n",
             tran_window_execution.plan.line_number
         )
     );
@@ -2721,6 +2725,8 @@ fn run_deck_analysis_surfaces_control_diagnostics_in_artifacts() {
     let netlist = "
 .save V(in)
 .control
+save V(in)
+probe V(in)
 source other.cir
 cd /tmp
 if v(in) > 0
@@ -2738,13 +2744,31 @@ let gain = 2
         "SPICE_DECK_CONTROL_VARIABLE_COMMAND".to_string(),
     ];
     let code_list = expected_codes.join(";");
+    let expected_control_lines = vec![".save V(in)".to_string(), ".probe V(in)".to_string()];
+    let control_line_list = expected_control_lines.join(";");
 
+    assert_eq!(
+        execution.run_artifacts[0].control_line_count,
+        expected_control_lines.len()
+    );
+    assert_eq!(
+        execution.run_artifacts[0].control_lines,
+        expected_control_lines
+    );
     assert_eq!(
         execution.run_artifacts[0].diagnostic_count,
         expected_codes.len()
     );
     assert_eq!(execution.run_artifacts[0].diagnostic_codes, expected_codes);
     let records = deck_table_records(&execution.run_artifact_table);
+    assert_eq!(
+        records[0].get("ControlLines").map(String::as_str),
+        Some("2")
+    );
+    assert_eq!(
+        records[0].get("ControlLineList").map(String::as_str),
+        Some(control_line_list.as_str())
+    );
     assert_eq!(records[0].get("Diagnostics").map(String::as_str), Some("4"));
     assert_eq!(
         records[0].get("DiagnosticCodeList").map(String::as_str),
@@ -2752,6 +2776,12 @@ let gain = 2
     );
     let run_artifact = execution.table_artifacts.last().unwrap();
     assert_eq!(run_artifact.name, "run-artifact");
+    assert_eq!(
+        run_artifact.records[0]
+            .get("ControlLineList")
+            .map(String::as_str),
+        Some(control_line_list.as_str())
+    );
     assert_eq!(
         run_artifact.records[0]
             .get("DiagnosticCodeList")
@@ -2880,7 +2910,7 @@ fn run_deck_analysis_exposes_selected_fourier_artifacts() {
     assert_eq!(
         tran_execution.run_artifact_table,
         format!(
-            "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tDiagnostics\tDiagnosticCodeList\ntran\t.tran\t1\t.tran\t{}\t\t\t\t\t\t\t\t\t\t5.000000e-04\t1.000000e-03\t\t\tfalse\t2\t3\tIndex;Time;V(mid)\t3\tresult;fourier;run-artifact\t1\tV(mid)\t1\t.save\t0\t\t1\tV(mid)\t0\t\n",
+            "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tDiagnostics\tDiagnosticCodeList\ntran\t.tran\t1\t.tran\t{}\t\t\t\t\t\t\t\t\t\t5.000000e-04\t1.000000e-03\t\t\tfalse\t2\t3\tIndex;Time;V(mid)\t3\tresult;fourier;run-artifact\t1\tV(mid)\t1\t.save\t0\t\t1\tV(mid)\t0\t\t0\t\n",
             tran_execution.plan.line_number
         )
     );

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- Add normalized `.control` command inventories to `analyzeDeckControls`
+  separately from full active deck input, and carry those commands through
+  selected `runDeckAnalysis` run artifacts as stable `ControlLines` /
+  `ControlLineList` table, CSV/JSON, and ordered `tableArtifacts` fields,
+  matching Python and Rust.
 - Surface existing `.control` body policy diagnostic codes in selected
   `runDeckAnalysis` run artifacts and propagate them through stable
   run-artifact tables, CSV/JSON helpers, and ordered `tableArtifacts`,

--- a/code/packages/typescript/spice-engine/README.md
+++ b/code/packages/typescript/spice-engine/README.md
@@ -105,7 +105,9 @@ results and a stable Fourier table. Executions also include selected-run
 artifact summaries plus `formatDeckRunArtifactTable` and
 `formatDeckRunArtifactCsv` / `formatDeckRunArtifactJson` output for stable
 result-row, table, analysis-directive, output-probe, output-directive,
-measurement, Fourier, and diagnostic count/name lists. Existing `.control` body
+measurement, Fourier, control-command, and diagnostic count/name lists.
+Normalized accepted `.control` commands are surfaced separately in
+`ControlLines` / `ControlLineList` artifact fields. Existing `.control` body
 policy diagnostics flow into those selected-run artifact `Diagnostics` /
 `DiagnosticCodeList` fields and through the same run-artifact table, CSV, JSON,
 and `tableArtifacts` records. `formatDeckTableCsv` also converts any stable tab-separated deck table to
@@ -205,6 +207,6 @@ deck execution helpers.
 deck-selected table output with normalized table-inventory, output-probe, and
 output-directive artifacts, selected measurement artifacts, selected transient Fourier artifacts,
 selected-run artifact summaries with table, analysis-directive, output-probe, output-directive,
-measurement, and Fourier probe name lists, `.ac LIN`, `.ac DEC`, `.ac OCT`
+measurement, Fourier probe, and `.control` command inventories, `.ac LIN`, `.ac DEC`, `.ac OCT`
 frequency grids, and `.tran` `START` /
 print-step `TSTEP` / `MAXSTEP` / `UIC` controls.

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -427,6 +427,7 @@ export interface DeckControlDiagnostic {
 
 export interface DeckControlSummary {
   readonly activeLines: readonly string[];
+  readonly controlLines: readonly string[];
   readonly terminated: boolean;
   readonly endLineNumber?: number;
   readonly diagnostics: readonly DeckControlDiagnostic[];
@@ -691,6 +692,8 @@ export interface DeckRunArtifact {
   readonly measurementNames: readonly string[];
   readonly fourierCount: number;
   readonly fourierProbes: readonly string[];
+  readonly controlLineCount: number;
+  readonly controlLines: readonly string[];
   readonly diagnosticCount: number;
   readonly diagnosticCodes: readonly string[];
 }
@@ -2976,6 +2979,7 @@ export function compatibilityCorpus(): readonly CompatibilityDeck[] {
 
 export function analyzeDeckControls(netlist: string): DeckControlSummary {
   const activeLines: string[] = [];
+  const controlLines: string[] = [];
   const diagnostics: DeckControlDiagnostic[] = [];
   let endLineNumber: number | undefined;
   let inControlBlock = false;
@@ -2996,6 +3000,7 @@ export function analyzeDeckControls(netlist: string): DeckControlSummary {
       const controlLine = controlBlockCommandAsDeckLine(stripped);
       if (controlLine !== undefined) {
         activeLines.push(controlLine);
+        controlLines.push(controlLine);
         continue;
       }
       if (isNoopControlBlockCommand(stripped)) {
@@ -3072,6 +3077,7 @@ export function analyzeDeckControls(netlist: string): DeckControlSummary {
 
   return {
     activeLines,
+    controlLines,
     terminated: endLineNumber !== undefined,
     endLineNumber,
     diagnostics,
@@ -7905,6 +7911,7 @@ function deckRunArtifacts(
   outputDirectives: readonly string[],
   measurements: readonly ProbeMeasurement[],
   fourier: readonly FourierResult[],
+  controlLines: readonly string[],
   diagnosticCodes: readonly string[],
 ): DeckRunArtifact[] {
   const isTransient = plan.analysis === "tran";
@@ -7944,6 +7951,8 @@ function deckRunArtifacts(
       measurementNames: measurements.map((measurement) => measurement.name),
       fourierCount: fourier.length,
       fourierProbes: fourier.flatMap((result) => result.probes.map((probe) => probe.probe)),
+      controlLineCount: controlLines.length,
+      controlLines: [...controlLines],
       diagnosticCount: diagnosticCodes.length,
       diagnosticCodes: [...diagnosticCodes],
     },
@@ -7981,6 +7990,10 @@ function deckControlDiagnosticCodes(netlist: string): string[] {
   return analyzeDeckControls(netlist).diagnostics
     .filter((diagnostic) => diagnostic.code.startsWith("SPICE_DECK_CONTROL_"))
     .map((diagnostic) => diagnostic.code);
+}
+
+function deckControlLines(netlist: string): string[] {
+  return [...analyzeDeckControls(netlist).controlLines];
 }
 
 function deckRunDiagnosticCodes(netlist: string, plan: DeckAnalysisPlan): string[] {
@@ -8031,6 +8044,8 @@ const DECK_RUN_ARTIFACT_COLUMNS = [
   "MeasurementList",
   "Fourier",
   "FourierList",
+  "ControlLines",
+  "ControlLineList",
   "Diagnostics",
   "DiagnosticCodeList",
 ] as const;
@@ -8069,6 +8084,8 @@ function deckRunArtifactCells(artifact: DeckRunArtifact): string[] {
     artifact.measurementNames.join(";"),
     String(artifact.fourierCount),
     artifact.fourierProbes.join(";"),
+    String(artifact.controlLineCount),
+    artifact.controlLines.join(";"),
     String(artifact.diagnosticCount),
     artifact.diagnosticCodes.join(";"),
   ];
@@ -8217,6 +8234,7 @@ export function runDeckAnalysis(
 ): DeckAnalysisExecution {
   const plan = selectDeckAnalysisPlan(netlist, analysis);
   const diagnosticCodes = deckRunDiagnosticCodes(netlist, plan);
+  const controlLines = deckControlLines(netlist);
   const analysisDirectives = deckAnalysisDirectives(plan);
   if (plan.analysis === "op") {
     const result = dcOp(circuit);
@@ -8235,6 +8253,7 @@ export function runDeckAnalysis(
       outputDirectives,
       measurements,
       fourier,
+      controlLines,
       diagnosticCodes,
     );
     const tables = deckStableTables(measurements, fourier);
@@ -8290,6 +8309,7 @@ export function runDeckAnalysis(
       outputDirectives,
       measurements,
       fourier,
+      controlLines,
       diagnosticCodes,
     );
     const tables = deckStableTables(measurements, fourier);
@@ -8356,6 +8376,7 @@ export function runDeckAnalysis(
       outputDirectives,
       measurements,
       fourier,
+      controlLines,
       diagnosticCodes,
     );
     const tables = deckStableTables(measurements, fourier);
@@ -8417,6 +8438,7 @@ export function runDeckAnalysis(
       outputDirectives,
       measurements,
       fourier,
+      controlLines,
       diagnosticCodes,
     );
     const tables = deckStableTables(measurements, fourier);
@@ -8468,6 +8490,7 @@ export function runDeckAnalysis(
       outputDirectives,
       measurements,
       fourier,
+      controlLines,
       diagnosticCodes,
     );
     const tables = deckStableTables(measurements, fourier);
@@ -8518,6 +8541,7 @@ export function runDeckAnalysis(
       outputDirectives,
       measurements,
       fourier,
+      controlLines,
       diagnosticCodes,
     );
     const tables = deckStableTables(measurements, fourier);
@@ -8578,6 +8602,7 @@ export function runDeckAnalysis(
       outputDirectives,
       measurements,
       fourier,
+      controlLines,
       diagnosticCodes,
     );
     const tables = deckStableTables(measurements, fourier);

--- a/code/packages/typescript/spice-engine/tests/compatibility.test.ts
+++ b/code/packages/typescript/spice-engine/tests/compatibility.test.ts
@@ -107,6 +107,7 @@ V1 in 0 DC 1
     expect(summary.terminated).toBe(true);
     expect(summary.endLineNumber).toBe(5);
     expect(summary.activeLines).toStrictEqual(["V1 in 0 DC 1", ".op"]);
+    expect(summary.controlLines).toStrictEqual([]);
     expect(summary.diagnostics).toStrictEqual([]);
   });
 
@@ -169,6 +170,16 @@ quit
     expect(summary.activeLines).toStrictEqual([
       ".include models.inc",
       ".LIB vendor.lib TT",
+      ".op",
+      ".save V(in)",
+      ".probe V(out)",
+      ".print op V(in)",
+      ".measure tran vmax MAX V(out)",
+      ".meas dc imax MAX I(V1)",
+      ".four 1k V(out)",
+      ".four 2k V(in)",
+    ]);
+    expect(summary.controlLines).toStrictEqual([
       ".op",
       ".save V(in)",
       ".probe V(out)",

--- a/code/packages/typescript/spice-engine/tests/transient.test.ts
+++ b/code/packages/typescript/spice-engine/tests/transient.test.ts
@@ -1512,11 +1512,13 @@ describe("transient", () => {
     expect(opExecution.runArtifacts[0]?.analysisDirectives).toEqual([".op"]);
     expect(opExecution.runArtifacts[0]?.measurementNames).toEqual([]);
     expect(opExecution.runArtifacts[0]?.fourierProbes).toEqual([]);
+    expect(opExecution.runArtifacts[0]?.controlLineCount).toBe(0);
+    expect(opExecution.runArtifacts[0]?.controlLines).toEqual([]);
     expect(opExecution.runArtifacts[0]?.diagnosticCount).toBe(0);
     expect(opExecution.runArtifacts[0]?.diagnosticCodes).toEqual([]);
     expect(opExecution.runArtifactTable).toBe(
-      "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tDiagnostics\tDiagnosticCodeList\n" +
-        `op\t.op\t1\t.op\t${opExecution.plan.lineNumber}\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t1\t2\tIndex;V(mid)\t2\tresult;run-artifact\t1\tV(mid)\t1\t.save\t0\t\t0\t\t0\t\n`,
+      "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tDiagnostics\tDiagnosticCodeList\n" +
+        `op\t.op\t1\t.op\t${opExecution.plan.lineNumber}\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t1\t2\tIndex;V(mid)\t2\tresult;run-artifact\t1\tV(mid)\t1\t.save\t0\t\t0\t\t0\t\t0\t\n`,
     );
     expect(opExecution.tableArtifacts[1]?.name).toBe("run-artifact");
     expect(opExecution.tableArtifacts[1]?.table).toBe(opExecution.runArtifactTable);
@@ -1533,8 +1535,8 @@ describe("transient", () => {
       JSON.parse(formatDeckRunArtifactJson(opExecution.runArtifacts)),
     );
     expect(formatDeckRunArtifactCsv(opExecution.runArtifacts)).toBe(
-      "Analysis,Directive,AnalysisDirectives,AnalysisDirectiveList,Line,SourceName,OutputNode,SweepKind,StartValue,StopValue,StepValue,PointCount,StartFrequencyHz,StopFrequencyHz,StepTime,StopTime,StartTime,MaxStep,UseInitialConditions,ResultRows,ResultColumns,ResultColumnList,Tables,TableList,OutputProbes,OutputProbeList,OutputDirectives,OutputDirectiveList,Measurements,MeasurementList,Fourier,FourierList,Diagnostics,DiagnosticCodeList\n" +
-        `op,.op,1,.op,${opExecution.plan.lineNumber},,,,,,,,,,,,,,,1,2,Index;V(mid),2,result;run-artifact,1,V(mid),1,.save,0,,0,,0,\n`,
+      "Analysis,Directive,AnalysisDirectives,AnalysisDirectiveList,Line,SourceName,OutputNode,SweepKind,StartValue,StopValue,StepValue,PointCount,StartFrequencyHz,StopFrequencyHz,StepTime,StopTime,StartTime,MaxStep,UseInitialConditions,ResultRows,ResultColumns,ResultColumnList,Tables,TableList,OutputProbes,OutputProbeList,OutputDirectives,OutputDirectiveList,Measurements,MeasurementList,Fourier,FourierList,ControlLines,ControlLineList,Diagnostics,DiagnosticCodeList\n" +
+        `op,.op,1,.op,${opExecution.plan.lineNumber},,,,,,,,,,,,,,,1,2,Index;V(mid),2,result;run-artifact,1,V(mid),1,.save,0,,0,,0,,0,\n`,
     );
     expect(formatDeckTableCsv('Name\tValue\nprobe\tSPICE,"QUOTED"\n')).toBe(
       'Name,Value\nprobe,"SPICE,""QUOTED"""\n',
@@ -1580,6 +1582,8 @@ describe("transient", () => {
       "MeasurementList",
       "Fourier",
       "FourierList",
+      "ControlLines",
+      "ControlLineList",
       "Diagnostics",
       "DiagnosticCodeList",
     ]);
@@ -1617,6 +1621,8 @@ describe("transient", () => {
         MeasurementList: "",
         Fourier: "0",
         FourierList: "",
+        ControlLines: "0",
+        ControlLineList: "",
         Diagnostics: "0",
         DiagnosticCodeList: "",
       },
@@ -1639,7 +1645,7 @@ describe("transient", () => {
       diagnosticCodes: ["SPICE_DECK_ANALYSIS_TOKEN", 'SPICE,"QUOTED"'],
     };
     expect(formatDeckRunArtifactCsv([quotedDiagnosticArtifact])).toMatch(
-      /,2,"SPICE_DECK_ANALYSIS_TOKEN;SPICE,""QUOTED"""\n$/u,
+      /,0,,2,"SPICE_DECK_ANALYSIS_TOKEN;SPICE,""QUOTED"""\n$/u,
     );
     expect(
       (JSON.parse(formatDeckRunArtifactJson([quotedDiagnosticArtifact])) as Array<Record<string, string>>)[0]?.[
@@ -1703,8 +1709,8 @@ describe("transient", () => {
     expect(dcExecution.runArtifacts[0]?.measurementNames).toEqual(["mid_avg"]);
     expect(dcExecution.runArtifacts[0]?.fourierProbes).toEqual([]);
     expect(dcExecution.runArtifactTable).toBe(
-      "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tDiagnostics\tDiagnosticCodeList\n" +
-        `dc\t.dc\t1\t.dc\t${dcExecution.plan.lineNumber}\tV1\t\t\t0.000000e+00\t1.000000e+00\t1.000000e+00\t\t\t\t\t\t\t\t\t2\t5\tIndex;Source;Value;V(mid);I(V1)\t3\tresult;measurement;run-artifact\t2\tV(mid);I(V1)\t2\t.save;.probe\t1\tmid_avg\t0\t\t0\t\n`,
+      "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tDiagnostics\tDiagnosticCodeList\n" +
+        `dc\t.dc\t1\t.dc\t${dcExecution.plan.lineNumber}\tV1\t\t\t0.000000e+00\t1.000000e+00\t1.000000e+00\t\t\t\t\t\t\t\t\t2\t5\tIndex;Source;Value;V(mid);I(V1)\t3\tresult;measurement;run-artifact\t2\tV(mid);I(V1)\t2\t.save;.probe\t1\tmid_avg\t0\t\t0\t\t0\t\n`,
     );
 
     const acExecution = runDeckAnalysis(circuit, netlist, "ac");
@@ -1752,8 +1758,8 @@ describe("transient", () => {
     expect(acExecution.runArtifacts[0]?.measurementNames).toEqual(["mid_peak"]);
     expect(acExecution.runArtifacts[0]?.fourierProbes).toEqual([]);
     expect(acExecution.runArtifactTable).toBe(
-      "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tDiagnostics\tDiagnosticCodeList\n" +
-        `ac\t.ac\t1\t.ac\t${acExecution.plan.lineNumber}\t\t\tdec\t\t\t\t1\t1.000000e+03\t1.000000e+03\t\t\t\t\t\t1\t7\tIndex;Frequency;Probe;Real;Imaginary;Magnitude;Phase\t3\tresult;measurement;run-artifact\t1\tV(mid)\t1\t.save\t1\tmid_peak\t0\t\t0\t\n`,
+      "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tDiagnostics\tDiagnosticCodeList\n" +
+        `ac\t.ac\t1\t.ac\t${acExecution.plan.lineNumber}\t\t\tdec\t\t\t\t1\t1.000000e+03\t1.000000e+03\t\t\t\t\t\t1\t7\tIndex;Frequency;Probe;Real;Imaginary;Magnitude;Phase\t3\tresult;measurement;run-artifact\t1\tV(mid)\t1\t.save\t1\tmid_peak\t0\t\t0\t\t0\t\n`,
     );
 
     const tranExecution = runDeckAnalysis(circuit, netlist, "tran");
@@ -1794,8 +1800,8 @@ describe("transient", () => {
     expect(tranExecution.runArtifacts[0]?.diagnosticCount).toBe(0);
     expect(tranExecution.runArtifacts[0]?.diagnosticCodes).toEqual([]);
     expect(tranExecution.runArtifactTable).toBe(
-      "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tDiagnostics\tDiagnosticCodeList\n" +
-        `tran\t.tran\t1\t.tran\t${tranExecution.plan.lineNumber}\t\t\t\t\t\t\t\t\t\t1.000000e-03\t1.000000e-03\t\t\tfalse\t1\t3\tIndex;Time;V(mid)\t3\tresult;measurement;run-artifact\t1\tV(mid)\t1\t.save\t1\tmid_final\t0\t\t0\t\n`,
+      "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tDiagnostics\tDiagnosticCodeList\n" +
+        `tran\t.tran\t1\t.tran\t${tranExecution.plan.lineNumber}\t\t\t\t\t\t\t\t\t\t1.000000e-03\t1.000000e-03\t\t\tfalse\t1\t3\tIndex;Time;V(mid)\t3\tresult;measurement;run-artifact\t1\tV(mid)\t1\t.save\t1\tmid_final\t0\t\t0\t\t0\t\n`,
     );
 
     const tfExecution = runDeckAnalysis(circuit, netlist, "tf");
@@ -1839,8 +1845,8 @@ describe("transient", () => {
     expect(tfExecution.runArtifacts[0]?.measurementNames).toEqual([]);
     expect(tfExecution.runArtifacts[0]?.fourierProbes).toEqual([]);
     expect(tfExecution.runArtifactTable).toBe(
-      "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tDiagnostics\tDiagnosticCodeList\n" +
-        `tf\t.tf\t1\t.tf\t${tfExecution.plan.lineNumber}\tV1\tmid\t\t\t\t\t\t\t\t\t\t\t\t\t1\t3\tTransferRatio;InputImpedance;OutputImpedance\t2\tresult;run-artifact\t1\tV(mid)\t0\t\t0\t\t0\t\t0\t\n`,
+      "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tDiagnostics\tDiagnosticCodeList\n" +
+        `tf\t.tf\t1\t.tf\t${tfExecution.plan.lineNumber}\tV1\tmid\t\t\t\t\t\t\t\t\t\t\t\t\t1\t3\tTransferRatio;InputImpedance;OutputImpedance\t2\tresult;run-artifact\t1\tV(mid)\t0\t\t0\t\t0\t\t0\t\t0\t\n`,
     );
 
     const sensExecution = runDeckAnalysis(circuit, netlist, "sens");
@@ -1884,8 +1890,8 @@ describe("transient", () => {
     expect(sensExecution.runArtifacts[0]?.measurementNames).toEqual([]);
     expect(sensExecution.runArtifacts[0]?.fourierProbes).toEqual([]);
     expect(sensExecution.runArtifactTable).toBe(
-      "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tDiagnostics\tDiagnosticCodeList\n" +
-        `sens\t.sens\t1\t.sens\t${sensExecution.plan.lineNumber}\t\tmid\t\t\t\t\t\t\t\t\t\t\t\t\t1\t7\tOutputNode;NominalVoltage;Element;Parameter;NominalValue;Sensitivity;RelativeSensitivity\t2\tresult;run-artifact\t1\tV(mid)\t0\t\t0\t\t0\t\t0\t\n`,
+      "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tDiagnostics\tDiagnosticCodeList\n" +
+        `sens\t.sens\t1\t.sens\t${sensExecution.plan.lineNumber}\t\tmid\t\t\t\t\t\t\t\t\t\t\t\t\t1\t7\tOutputNode;NominalVoltage;Element;Parameter;NominalValue;Sensitivity;RelativeSensitivity\t2\tresult;run-artifact\t1\tV(mid)\t0\t\t0\t\t0\t\t0\t\t0\t\n`,
     );
 
     const noiseExecution = runDeckAnalysis(circuit, netlist, "noise");
@@ -1939,8 +1945,8 @@ describe("transient", () => {
     expect(noiseExecution.runArtifacts[0]?.measurementNames).toEqual([]);
     expect(noiseExecution.runArtifacts[0]?.fourierProbes).toEqual([]);
     expect(noiseExecution.runArtifactTable).toBe(
-      "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tDiagnostics\tDiagnosticCodeList\n" +
-        `noise\t.noise\t1\t.noise\t${noiseExecution.plan.lineNumber}\tV1\tmid\tlin\t\t\t\t1\t1.000000e+03\t1.000000e+03\t\t\t\t\t\t1\t10\tIndex;Frequency;OutputNode;InputSource;OutputPSD;InputReferredPSD;Element;Type;SourcePSD;ContributionPSD\t2\tresult;run-artifact\t1\tV(mid)\t0\t\t0\t\t0\t\t0\t\n`,
+      "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tDiagnostics\tDiagnosticCodeList\n" +
+        `noise\t.noise\t1\t.noise\t${noiseExecution.plan.lineNumber}\tV1\tmid\tlin\t\t\t\t1\t1.000000e+03\t1.000000e+03\t\t\t\t\t\t1\t10\tIndex;Frequency;OutputNode;InputSource;OutputPSD;InputReferredPSD;Element;Type;SourcePSD;ContributionPSD\t2\tresult;run-artifact\t1\tV(mid)\t0\t\t0\t\t0\t\t0\t\t0\t\n`,
     );
 
     const tranWindowExecution = runDeckAnalysis(
@@ -1981,8 +1987,8 @@ describe("transient", () => {
         "2\t6.000000e-03\t5.000000e-01\n",
     );
     expect(tranWindowExecution.runArtifactTable).toBe(
-      "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tDiagnostics\tDiagnosticCodeList\n" +
-        `tran\t.tran\t1\t.tran\t${tranWindowExecution.plan.lineNumber}\t\t\t\t\t\t\t\t\t\t2.000000e-03\t6.000000e-03\t2.000000e-03\t1.000000e-03\ttrue\t3\t3\tIndex;Time;V(mid)\t2\tresult;run-artifact\t1\tV(mid)\t1\t.save\t0\t\t0\t\t0\t\n`,
+      "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tDiagnostics\tDiagnosticCodeList\n" +
+        `tran\t.tran\t1\t.tran\t${tranWindowExecution.plan.lineNumber}\t\t\t\t\t\t\t\t\t\t2.000000e-03\t6.000000e-03\t2.000000e-03\t1.000000e-03\ttrue\t3\t3\tIndex;Time;V(mid)\t2\tresult;run-artifact\t1\tV(mid)\t1\t.save\t0\t\t0\t\t0\t\t0\t\n`,
     );
 
     expect(() => runDeckAnalysis(circuit, netlist)).toThrow(/multiple analysis cards/);
@@ -2017,6 +2023,8 @@ describe("transient", () => {
     const netlist = `
 .save V(in)
 .control
+save V(in)
+probe V(in)
 source other.cir
 cd /tmp
 if v(in) > 0
@@ -2034,14 +2042,21 @@ let gain = 2
       "SPICE_DECK_CONTROL_VARIABLE_COMMAND",
     ];
     const codeList = expectedCodes.join(";");
+    const expectedControlLines = [".save V(in)", ".probe V(in)"];
+    const controlLineList = expectedControlLines.join(";");
 
+    expect(execution.runArtifacts[0]?.controlLineCount).toBe(expectedControlLines.length);
+    expect(execution.runArtifacts[0]?.controlLines).toEqual(expectedControlLines);
     expect(execution.runArtifacts[0]?.diagnosticCount).toBe(expectedCodes.length);
     expect(execution.runArtifacts[0]?.diagnosticCodes).toEqual(expectedCodes);
     const record = deckTableRecords(execution.runArtifactTable)[0]!;
+    expect(record["ControlLines"]).toBe(String(expectedControlLines.length));
+    expect(record["ControlLineList"]).toBe(controlLineList);
     expect(record["Diagnostics"]).toBe(String(expectedCodes.length));
     expect(record["DiagnosticCodeList"]).toBe(codeList);
     const runArtifact = execution.tableArtifacts[execution.tableArtifacts.length - 1]!;
     expect(runArtifact.name).toBe("run-artifact");
+    expect(runArtifact.records[0]?.["ControlLineList"]).toBe(controlLineList);
     expect(runArtifact.records[0]?.["DiagnosticCodeList"]).toBe(codeList);
     expect(runArtifact.csv).toBe(formatDeckRunArtifactCsv(execution.runArtifacts));
     expect(runArtifact.json).toBe(formatDeckRunArtifactJson(execution.runArtifacts));
@@ -2106,8 +2121,8 @@ let gain = 2
     expect(tranExecution.runArtifacts[0]?.measurementNames).toEqual([]);
     expect(tranExecution.runArtifacts[0]?.fourierProbes).toEqual(["V(mid)"]);
     expect(tranExecution.runArtifactTable).toBe(
-      "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tDiagnostics\tDiagnosticCodeList\n" +
-        `tran\t.tran\t1\t.tran\t${tranExecution.plan.lineNumber}\t\t\t\t\t\t\t\t\t\t5.000000e-04\t1.000000e-03\t\t\tfalse\t2\t3\tIndex;Time;V(mid)\t3\tresult;fourier;run-artifact\t1\tV(mid)\t1\t.save\t0\t\t1\tV(mid)\t0\t\n`,
+      "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tDiagnostics\tDiagnosticCodeList\n" +
+        `tran\t.tran\t1\t.tran\t${tranExecution.plan.lineNumber}\t\t\t\t\t\t\t\t\t\t5.000000e-04\t1.000000e-03\t\t\tfalse\t2\t3\tIndex;Time;V(mid)\t3\tresult;fourier;run-artifact\t1\tV(mid)\t1\t.save\t0\t\t1\tV(mid)\t0\t\t0\t\n`,
     );
   });
 

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -101,6 +101,9 @@ downstream tools to compare.
      table export artifacts with text, CSV, compact JSON, and host-native
      records for each stable table; selected deck run artifacts now also carry
      existing `.control` body policy diagnostic codes through their stable
+     table, CSV, compact JSON, and ordered table export artifacts; normalized
+     accepted `.control` command inventories now travel through
+     `ControlLines` / `ControlLineList` metadata in the same run-artifact
      table, CSV, compact JSON, and ordered table export artifacts.
    - Expand remaining deck-controlled analyses toward full SPICE compatibility
      while keeping unsupported control-flow diagnostics explicit.
@@ -962,6 +965,16 @@ downstream tools to compare.
       run-artifact tables, CSV/JSON export helpers, and ordered table export
       artifacts without executing control-flow, variables, external scripts,
       or working-directory mutations.
+
+89. Deck run control command inventory artifacts.
+    - Status: completed in this deck run control command inventory artifact
+      slice.
+    - Python, Rust, and TypeScript control analyzers now expose normalized
+      `.control` command lines separately from full active deck input.
+    - Selected deck executions now carry those normalized command inventories
+      through `ControlLines` / `ControlLineList` run-artifact metadata,
+      stable run-artifact tables, CSV/JSON export helpers, and ordered table
+      export artifacts.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- add normalized `.control` command inventories to Python/Rust/TypeScript deck-control summaries
- surface those inventories in selected deck run artifacts as `ControlLines` / `ControlLineList` across tables, CSV, JSON, and ordered table artifacts
- update SPICE docs, changelogs, and the full implementation plan with completed Slice 89

## Verification
- `PYTHONPATH=code/packages/python/spice-engine/src:code/packages/python/mosfet-models/src:code/packages/python/device-physics/src:code/packages/python/symbolic/src:code/packages/python/hardware/src /Users/adhithya/.local/share/mise/installs/python/3.12.13/bin/python -m pytest code/packages/python/spice-engine/tests -q --no-cov`
- `/Users/adhithya/.local/share/mise/installs/python/3.12.13/bin/ruff check code/packages/python/spice-engine/src/spice_engine/compatibility.py code/packages/python/spice-engine/src/spice_engine/engine.py code/packages/python/spice-engine/tests/test_compatibility.py code/packages/python/spice-engine/tests/test_engine.py`
- `cargo test --manifest-path code/packages/rust/spice-engine/Cargo.toml`
- `cargo fmt --manifest-path code/packages/rust/spice-engine/Cargo.toml -- --check`
- `npm --prefix code/packages/typescript/spice-engine run build && npm --prefix code/packages/typescript/spice-engine test`
- `git diff --check`