### PR TITLE
feat(closurec): do/while end-to-end (CLOC20)

### DIFF
--- a/code/packages/rust/closure-emitter/CHANGELOG.md
+++ b/code/packages/rust/closure-emitter/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to the `coding-adventures-closure-emitter` crate will be documented in this file.
 
+## [0.14.0] - 2026-06-20
+
+### Added — CLOC20: emit `do`/`while`
+
+New `emit_do_while` writes `do <body> while ( <test> ) ;`. Token-separation: a
+required space is inserted after `do` only when the body is NOT a block (so
+`do{…}` stays tight but `do foo();` does not glue into `dofoo()`). The trailing
+`;` is a real statement terminator, so `DoWhileStatement` is added to
+`last_stmt_uses_terminator_semi` — its `;` is popped before a closing `}` (e.g.
+`{do{a}while(b)}`) just like `return`/`throw`/expression statements, but unlike
+plain `while` (whose trailing `;` is a body slot). Added emitter unit tests for
+the tight, bare-body, pretty-mode, and terminator-pop cases.
+
 ## [0.13.0] - 2026-06-20
 
 ### Added — CLOC19: emit `try`/`catch`/`finally`

--- a/code/packages/rust/closure-emitter/Cargo.toml
+++ b/code/packages/rust/closure-emitter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-emitter"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 description = "JavaScript code emitter for the Closure Compiler clone. Per CLOC07's emit contract. Takes a finalized Program + sidecar and produces output JavaScript text + companion source map. Runs after every pass in the pipeline."
 

--- a/code/packages/rust/closure-emitter/src/lib.rs
+++ b/code/packages/rust/closure-emitter/src/lib.rs
@@ -67,7 +67,7 @@ use coding_adventures_javascript_ast::{
     AssignmentTarget, BigIntLiteral, BinaryExpression, BinaryOperator, BlockStatement,
     BooleanLiteral,
     BreakStatement, CallExpression, CatchClause, ConditionalExpression, ContinueStatement,
-    Declaration,
+    Declaration, DoWhileStatement,
     EmptyStatement, Expression, ExpressionStatement, ForInit, ForStatement, FunctionDeclaration,
     FunctionParam, Identifier, IfStatement, LabeledStatement, LogicalExpression, LogicalOperator,
     MemberExpression, NullLiteral, NumericLiteral, ObjectExpression, Program, ProgramItem,
@@ -291,6 +291,7 @@ impl<'a> Emitter<'a> {
             }
             TaggedStatement::IfStatement(i) => self.emit_if(i),
             TaggedStatement::WhileStatement(w) => self.emit_while(w),
+            TaggedStatement::DoWhileStatement(d) => self.emit_do_while(d),
             TaggedStatement::ForStatement(f) => self.emit_for(f),
             TaggedStatement::ReturnStatement(r) => self.emit_return(r),
             TaggedStatement::BreakStatement(b) => self.emit_break(b),
@@ -449,6 +450,37 @@ impl<'a> Emitter<'a> {
         self.write_str(")");
         self.pretty_ws();
         self.emit_statement(&w.body);
+    }
+
+    fn emit_do_while(&mut self, d: &DoWhileStatement) {
+        // `do <body> while ( <test> ) ;`
+        //
+        // Token-separation: `do` is a keyword sitting directly before the
+        // body, so `do{…}` lexes cleanly when the body is a block, but a
+        // bare-statement body would glue (`do foo()` must not become
+        // `dofoo()`). Insert a required space only when the body is NOT a
+        // block. After the body, a block ends in `}` and every other
+        // statement ends in `;`, so the following `while` always lexes
+        // cleanly. The trailing `;` is a real statement terminator (poppable
+        // before a closing `}` via `last_stmt_uses_terminator_semi`).
+        self.maybe_map(&d.cv);
+        self.write_str("do");
+        if matches!(
+            d.body.as_ref(),
+            Statement::Tagged(TaggedStatement::BlockStatement(_))
+        ) {
+            self.pretty_ws();
+        } else {
+            self.required_ws();
+        }
+        self.emit_statement(&d.body);
+        self.pretty_ws();
+        self.write_str("while");
+        self.pretty_ws();
+        self.write_str("(");
+        self.emit_expression(&d.test);
+        self.write_str(")");
+        self.write_str(";");
     }
 
     fn emit_for(&mut self, f: &ForStatement) {
@@ -1289,6 +1321,10 @@ fn last_stmt_uses_terminator_semi(s: &Statement) -> bool {
                 | TaggedStatement::BreakStatement(_)
                 | TaggedStatement::ContinueStatement(_)
                 | TaggedStatement::ThrowStatement(_)
+                // `do … while(x);` ends in a real terminator `;` that ASI can
+                // supply before a closing `}`, so it is safe to pop. (Plain
+                // `while(x)…` is NOT here: its trailing `;` is a body slot.)
+                | TaggedStatement::DoWhileStatement(_)
         ),
         // Declarations are conservatively excluded. Both
         // VariableDeclaration and FunctionDeclaration end in
@@ -2398,6 +2434,77 @@ mod tests {
     fn emit_try_item(t: TryStatement) -> String {
         let item = ProgramItem::Statement(Statement::try_statement(t));
         emit_default(program().with_body(vec![item])).code
+    }
+
+    // ---- do / while (CLOC20) ----------------------------------
+
+    fn emit_do_while_item(d: DoWhileStatement) -> String {
+        let item = ProgramItem::Statement(Statement::do_while_statement(d));
+        emit_default(program().with_body(vec![item])).code
+    }
+
+    #[test]
+    fn do_while_block_body_emits_tight() {
+        // do { a; } while (b)  — block body needs no separator after `do`
+        // (`do{` lexes cleanly), and the loop ends in a real terminator `;`.
+        let d = DoWhileStatement {
+            cv: None,
+            body: Box::new(Statement::block_statement(block_with("a"))),
+            test: ident("b"),
+        };
+        assert_eq!(emit_do_while_item(d), "do{a}while(b);");
+    }
+
+    #[test]
+    fn do_while_bare_body_inserts_separator() {
+        // do a; while (b)  — a bare expression-statement body MUST be
+        // separated from the `do` keyword (`doa` would mis-lex).
+        let d = DoWhileStatement {
+            cv: None,
+            body: Box::new(Statement::expression_statement(ExpressionStatement {
+                cv: None,
+                expression: ident("a"),
+            })),
+            test: ident("b"),
+        };
+        assert_eq!(emit_do_while_item(d), "do a;while(b);");
+    }
+
+    #[test]
+    fn do_while_pretty_mode_spaces() {
+        let d = DoWhileStatement {
+            cv: None,
+            body: Box::new(Statement::block_statement(block_with("a"))),
+            test: ident("b"),
+        };
+        let item = ProgramItem::Statement(Statement::do_while_statement(d));
+        let out = emit_with(
+            program().with_body(vec![item]),
+            EmitOptions {
+                pretty: true,
+                ..EmitOptions::default()
+            },
+        );
+        assert!(out.code.contains("do {"), "got:\n{}", out.code);
+        assert!(out.code.contains("} while ("), "got:\n{}", out.code);
+    }
+
+    #[test]
+    fn do_while_as_last_block_statement_pops_terminator_semi() {
+        // Inside a block, the do-while's trailing `;` is redundant before the
+        // closing `}` (ASI), so it is popped: `{do{a}while(b)}`.
+        let d = DoWhileStatement {
+            cv: None,
+            body: Box::new(Statement::block_statement(block_with("a"))),
+            test: ident("b"),
+        };
+        let outer = BlockStatement {
+            cv: None,
+            body: vec![Statement::do_while_statement(d)],
+        };
+        let item = ProgramItem::Statement(Statement::block_statement(outer));
+        let code = emit_default(program().with_body(vec![item])).code;
+        assert_eq!(code, "{do{a}while(b)}");
     }
 
     #[test]

--- a/code/packages/rust/closure-pass-constant-fold/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-constant-fold/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to the `coding-adventures-closure-pass-constant-fold` crate will be documented in this file.
 
+## [0.13.0] - 2026-06-20
+
+### Added — CLOC20: fold inside `do`/`while`
+
+`fold_tagged` now has a `DoWhileStatement` arm that recurses constant folding into
+the loop body and test. Constant expressions inside a do-while body (e.g.
+`1 + 2` ⇒ `3`) now fold like anywhere else.
+
 ## [0.12.0] - 2026-06-20
 
 ### Added — CLOC19: fold inside `try`/`catch`/`finally`

--- a/code/packages/rust/closure-pass-constant-fold/Cargo.toml
+++ b/code/packages/rust/closure-pass-constant-fold/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-constant-fold"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 description = "Constant-folding optimization pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Folds compile-time-evaluable expressions like `2 + 3 → 5`."
 

--- a/code/packages/rust/closure-pass-constant-fold/src/lib.rs
+++ b/code/packages/rust/closure-pass-constant-fold/src/lib.rs
@@ -88,7 +88,7 @@ use coding_adventures_javascript_ast::{
     IfStatement, LogicalExpression, LogicalOperator, MemberExpression, NullLiteral, NumericLiteral,
     ObjectExpression, Program, ProgramItem, Property, PropertyKey, ReturnStatement, Statement,
     StringLiteral, UnaryExpression, UnaryOperator, UndefinedLiteral, VariableDeclaration,
-    VariableDeclarator, WhileStatement,
+    DoWhileStatement, VariableDeclarator, WhileStatement,
 };
 use serde_json::json;
 
@@ -267,6 +267,13 @@ fn fold_tagged_statement(stmt: &TaggedStatement, st: &mut FoldState) -> TaggedSt
             test: fold_expression(&s.test, st),
             body: Box::new(fold_statement(&s.body, st)),
         }),
+        TaggedStatement::DoWhileStatement(s) => {
+            TaggedStatement::DoWhileStatement(DoWhileStatement {
+                cv: s.cv.clone(),
+                body: Box::new(fold_statement(&s.body, st)),
+                test: fold_expression(&s.test, st),
+            })
+        }
         TaggedStatement::ForStatement(s) => TaggedStatement::ForStatement(ForStatement {
             cv: s.cv.clone(),
             init: s.init.as_ref().map(|i| match i {

--- a/code/packages/rust/closure-pass-dce/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-dce/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to the `coding-adventures-closure-pass-dce` crate will be documented in this file.
 
+## [0.11.0] - 2026-06-20
+
+### Added — CLOC20: DCE inside `do`/`while`
+
+New `DoWhileStatement` arm recurses dead-code elimination into the loop body and
+test. Like `while`, a `do`-`while` is NOT a terminator — control can fall out of
+the loop — so a statement following it stays reachable. (A do-while in a dead
+tail is preserved by the existing `tail_is_safe_to_truncate` whitelist, which
+defaults new compound statements to unsafe.)
+
 ## [0.10.0] - 2026-06-20
 
 ### Added — CLOC19: DCE inside `try`/`catch`/`finally`

--- a/code/packages/rust/closure-pass-dce/Cargo.toml
+++ b/code/packages/rust/closure-pass-dce/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-dce"
-version = "0.10.0"
+version = "0.11.0"
 edition = "2021"
 description = "Dead-code elimination pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Drops code after definite-terminator statements and removes EmptyStatement noise."
 

--- a/code/packages/rust/closure-pass-dce/src/lib.rs
+++ b/code/packages/rust/closure-pass-dce/src/lib.rs
@@ -76,7 +76,7 @@ use coding_adventures_javascript_ast::{
     FunctionDeclaration, IfStatement, LogicalExpression, MemberExpression, NullLiteral,
     NumericLiteral, ObjectExpression, Program, ProgramItem, Property, PropertyKey,
     ReturnStatement, Statement, StringLiteral, UnaryExpression, UndefinedLiteral, VarKind,
-    VariableDeclaration, VariableDeclarator, WhileStatement,
+    DoWhileStatement, VariableDeclaration, VariableDeclarator, WhileStatement,
 };
 use serde_json::json;
 
@@ -264,6 +264,17 @@ fn dce_tagged_statement(stmt: &TaggedStatement, st: &mut DceState) -> TaggedStat
             test: dce_expression(&s.test, st),
             body: Box::new(dce_statement(&s.body, st)),
         }),
+        // Recurse DCE into the do-while body and test. Like `while`, a
+        // `do`-`while` is NOT a terminator (control can exit the loop), so
+        // code after it stays reachable — we do not add it to the
+        // dead-after-terminator set.
+        TaggedStatement::DoWhileStatement(s) => {
+            TaggedStatement::DoWhileStatement(DoWhileStatement {
+                cv: s.cv.clone(),
+                body: Box::new(dce_statement(&s.body, st)),
+                test: dce_expression(&s.test, st),
+            })
+        }
         TaggedStatement::ForStatement(s) => TaggedStatement::ForStatement(ForStatement {
             cv: s.cv.clone(),
             init: s.init.as_ref().map(|i| match i {

--- a/code/packages/rust/closure-pass-fold-control-flow/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-fold-control-flow/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to the `coding-adventures-closure-pass-fold-control-flow` crate will be documented in this file.
 
+## [0.10.0] - 2026-06-20
+
+### Added — CLOC20: fold control flow inside `do`/`while` (no dead-loop elision)
+
+New `DoWhileStatement` arm recurses control-flow folding into the loop body and
+test. Crucially — unlike `while`, which can be eliminated when its test is
+statically falsy — a `do`-`while` runs its body **at least once**, so it is NEVER
+removed even when `test` folds to a falsy literal (the single body run is
+observable). The arm therefore only recurses structurally.
+
 ## [0.9.0] - 2026-06-20
 
 ### Added — CLOC19: fold control flow inside `try`/`catch`/`finally`

--- a/code/packages/rust/closure-pass-fold-control-flow/Cargo.toml
+++ b/code/packages/rust/closure-pass-fold-control-flow/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-fold-control-flow"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2021"
 description = "Control-flow folding pass for the Closure Compiler clone. Slots between constant-fold and DCE per CLOC06's canonical pass set. Eliminates dead branches (`if (false) A else B → B`), removes unreachable code after `return`/`throw`, and collapses degenerate switch arms."
 

--- a/code/packages/rust/closure-pass-fold-control-flow/src/lib.rs
+++ b/code/packages/rust/closure-pass-fold-control-flow/src/lib.rs
@@ -61,7 +61,7 @@ use coding_adventures_javascript_ast::{
     ForStatement, FunctionDeclaration, Identifier, IfStatement, LogicalExpression, LogicalOperator,
     MemberExpression, ObjectExpression, Program, ProgramItem, Property, PropertyKey,
     ReturnStatement, Statement, UnaryExpression, UnaryOperator, VarKind, VariableDeclaration,
-    VariableDeclarator, WhileStatement,
+    DoWhileStatement, VariableDeclarator, WhileStatement,
 };
 use serde_json::json;
 
@@ -216,6 +216,17 @@ fn fold_tagged_statement(stmt: &TaggedStatement, st: &mut FoldState) -> Statemen
         }
         TaggedStatement::IfStatement(s) => fold_if_statement(s, st),
         TaggedStatement::WhileStatement(s) => fold_while_statement(s, st),
+        // A `do … while(test)` runs its body at least once, so — unlike
+        // `while` — it can NEVER be eliminated as a dead loop even when
+        // `test` is statically falsy (the single body run is observable).
+        // We therefore only recurse structurally: fold the body and the test.
+        TaggedStatement::DoWhileStatement(s) => {
+            Statement::Tagged(TaggedStatement::DoWhileStatement(DoWhileStatement {
+                cv: s.cv.clone(),
+                body: Box::new(fold_statement(&s.body, st)),
+                test: fold_expression(&s.test, st),
+            }))
+        }
         TaggedStatement::ForStatement(s) => {
             Statement::Tagged(TaggedStatement::ForStatement(ForStatement {
                 cv: s.cv.clone(),

--- a/code/packages/rust/closure-pass-inline-variables/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-inline-variables/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to the `coding-adventures-closure-pass-inline-variables` crate will be documented in this file.
 
+## [0.3.0] - 2026-06-20
+
+### Added — CLOC20: variable inlining inside `do`/`while`
+
+`count_decl_names_stmt`, `count_uses_stmt`, and `propagate_in_stmt` now recurse
+through `DoWhileStatement` (loop body and test), mirroring the existing `while`
+handling so const-literal propagation reaches into do-while loops.
+
 ## [0.2.0] - 2026-06-20
 
 ### Added — CLOC19: variable inlining inside `try`/`catch`/`finally`

--- a/code/packages/rust/closure-pass-inline-variables/Cargo.toml
+++ b/code/packages/rust/closure-pass-inline-variables/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-inline-variables"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 description = "Constant-propagation pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Replaces references to a top-level `const` bound to a literal with the literal itself, so the binding becomes unused and remove-unused-vars deletes it."
 

--- a/code/packages/rust/closure-pass-inline-variables/src/lib.rs
+++ b/code/packages/rust/closure-pass-inline-variables/src/lib.rs
@@ -418,6 +418,9 @@ fn count_decl_names_stmt(
             TaggedStatement::WhileStatement(ws) => {
                 count_decl_names_stmt(&ws.body, out, nodes_touched)
             }
+            TaggedStatement::DoWhileStatement(ds) => {
+                count_decl_names_stmt(&ds.body, out, nodes_touched)
+            }
             TaggedStatement::ForStatement(fs) => {
                 if let Some(ForInit::VariableDeclaration(vd)) = &fs.init {
                     count_decl_names_var(vd, out);
@@ -527,6 +530,10 @@ fn count_uses_stmt(stmt: &Statement, name: &str, count: &mut usize) {
             TaggedStatement::WhileStatement(ws) => {
                 count_uses_expr(&ws.test, name, count);
                 count_uses_stmt(&ws.body, name, count);
+            }
+            TaggedStatement::DoWhileStatement(ds) => {
+                count_uses_expr(&ds.test, name, count);
+                count_uses_stmt(&ds.body, name, count);
             }
             TaggedStatement::ForStatement(fs) => {
                 if let Some(init) = &fs.init {
@@ -729,6 +736,10 @@ fn propagate_in_stmt(stmt: &mut Statement, cand: &ConstCandidate) -> bool {
             TaggedStatement::WhileStatement(ws) => {
                 changed |= propagate_in_expr(&mut ws.test, cand);
                 changed |= propagate_in_stmt(&mut ws.body, cand);
+            }
+            TaggedStatement::DoWhileStatement(ds) => {
+                changed |= propagate_in_expr(&mut ds.test, cand);
+                changed |= propagate_in_stmt(&mut ds.body, cand);
             }
             TaggedStatement::ForStatement(fs) => {
                 if let Some(init) = &mut fs.init {

--- a/code/packages/rust/closure-pass-inline/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-inline/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to the `coding-adventures-closure-pass-inline` crate will be documented in this file.
 
+## [0.17.0] - 2026-06-20
+
+### Added — CLOC20: function inlining across `do`/`while`
+
+Every phase of the pass recurses through `DoWhileStatement`:
+`count_decl_names_stmt`, `tally_stmt`, `inline_in_stmt`, `splice_void_in_slot`,
+`splice_valued_in_stmt`, and `collect_used_idents_stmt` now descend into the loop
+body and test, mirroring the existing `while` handling. Calls inside a do-while
+body are now inlined like anywhere else.
+
 ## [0.16.0] - 2026-06-20
 
 ### Added — CLOC19: function inlining across `try`/`catch`/`finally`

--- a/code/packages/rust/closure-pass-inline/Cargo.toml
+++ b/code/packages/rust/closure-pass-inline/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-inline"
-version = "0.16.0"
+version = "0.17.0"
 edition = "2021"
 description = "Function-inlining pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Substitutes small or single-use function bodies at their call sites to enable downstream folding and shrink call overhead."
 

--- a/code/packages/rust/closure-pass-inline/src/lib.rs
+++ b/code/packages/rust/closure-pass-inline/src/lib.rs
@@ -564,6 +564,9 @@ fn count_decl_names_stmt(
             TaggedStatement::WhileStatement(ws) => {
                 count_decl_names_stmt(&ws.body, out, nodes_touched)
             }
+            TaggedStatement::DoWhileStatement(ds) => {
+                count_decl_names_stmt(&ds.body, out, nodes_touched)
+            }
             TaggedStatement::ForStatement(fs) => {
                 if let Some(ForInit::VariableDeclaration(vd)) = &fs.init {
                     count_decl_names_var(vd, out);
@@ -759,6 +762,10 @@ fn tally_stmt(stmt: &Statement, cand: &InlineCandidate, t: &mut Tally) {
             TaggedStatement::WhileStatement(ws) => {
                 tally_expr(&ws.test, cand, t);
                 tally_stmt(&ws.body, cand, t);
+            }
+            TaggedStatement::DoWhileStatement(ds) => {
+                tally_expr(&ds.test, cand, t);
+                tally_stmt(&ds.body, cand, t);
             }
             TaggedStatement::ForStatement(fs) => {
                 if let Some(init) = &fs.init {
@@ -980,6 +987,10 @@ fn inline_in_stmt(stmt: &mut Statement, cand: &InlineCandidate) -> bool {
             TaggedStatement::WhileStatement(ws) => {
                 changed |= inline_in_expr(&mut ws.test, cand);
                 changed |= inline_in_stmt(&mut ws.body, cand);
+            }
+            TaggedStatement::DoWhileStatement(ds) => {
+                changed |= inline_in_expr(&mut ds.test, cand);
+                changed |= inline_in_stmt(&mut ds.body, cand);
             }
             TaggedStatement::ForStatement(fs) => {
                 if let Some(init) = &mut fs.init {
@@ -1895,6 +1906,9 @@ fn splice_void_in_stmt(
             TaggedStatement::WhileStatement(ws) => {
                 splice_void_in_slot(&mut ws.body, cand, avoid, nodes_touched)
             }
+            TaggedStatement::DoWhileStatement(ds) => {
+                splice_void_in_slot(&mut ds.body, cand, avoid, nodes_touched)
+            }
             TaggedStatement::ForStatement(fs) => {
                 splice_void_in_slot(&mut fs.body, cand, avoid, nodes_touched)
             }
@@ -2730,6 +2744,9 @@ fn splice_valued_in_stmt(
             TaggedStatement::WhileStatement(ws) => {
                 splice_valued_in_stmt(&mut ws.body, cand, avoid, nodes_touched)
             }
+            TaggedStatement::DoWhileStatement(ds) => {
+                splice_valued_in_stmt(&mut ds.body, cand, avoid, nodes_touched)
+            }
             TaggedStatement::ForStatement(fs) => {
                 splice_valued_in_stmt(&mut fs.body, cand, avoid, nodes_touched)
             }
@@ -3016,6 +3033,10 @@ fn collect_used_idents_stmt(stmt: &Statement, out: &mut HashSet<String>) {
             TaggedStatement::WhileStatement(ws) => {
                 collect_binding_idents_expr(&ws.test, out);
                 collect_used_idents_stmt(&ws.body, out);
+            }
+            TaggedStatement::DoWhileStatement(ds) => {
+                collect_binding_idents_expr(&ds.test, out);
+                collect_used_idents_stmt(&ds.body, out);
             }
             TaggedStatement::ForStatement(fs) => {
                 if let Some(init) = &fs.init {

--- a/code/packages/rust/closure-pass-rename-globals/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-rename-globals/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to the `coding-adventures-closure-pass-rename-globals` crate will be documented in this file.
 
+## [0.3.0] - 2026-06-20
+
+### Added — CLOC20: global renaming across `do`/`while`
+
+`count_decl_names_stmt`, `collect_all_idents_stmt`, and `rename_apply_tagged`
+recurse through `DoWhileStatement` (loop body and test), mirroring the existing
+`while` handling.
+
 ## [0.2.0] - 2026-06-20
 
 ### Added — CLOC19: global renaming across `try`/`catch`/`finally` (catch-param soundness)

--- a/code/packages/rust/closure-pass-rename-globals/Cargo.toml
+++ b/code/packages/rust/closure-pass-rename-globals/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-rename-globals"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 description = "Aggressive top-level (global) renaming pass for the Closure Compiler clone — the ADVANCED-level complement to closure-pass-rename. Shortens program-private top-level names, gated by an externs do-not-rename boundary."
 

--- a/code/packages/rust/closure-pass-rename-globals/src/lib.rs
+++ b/code/packages/rust/closure-pass-rename-globals/src/lib.rs
@@ -343,6 +343,9 @@ fn count_decl_names_stmt(
             TaggedStatement::WhileStatement(ws) => {
                 count_decl_names_stmt(&ws.body, out, nodes_touched)
             }
+            TaggedStatement::DoWhileStatement(ds) => {
+                count_decl_names_stmt(&ds.body, out, nodes_touched)
+            }
             TaggedStatement::ForStatement(fs) => {
                 if let Some(ForInit::VariableDeclaration(vd)) = &fs.init {
                     count_decl_names_var(vd, out);
@@ -451,6 +454,10 @@ fn collect_all_idents_stmt(stmt: &Statement, out: &mut HashSet<String>) {
             TaggedStatement::WhileStatement(ws) => {
                 collect_all_idents_expr(&ws.test, out);
                 collect_all_idents_stmt(&ws.body, out);
+            }
+            TaggedStatement::DoWhileStatement(ds) => {
+                collect_all_idents_expr(&ds.test, out);
+                collect_all_idents_stmt(&ds.body, out);
             }
             TaggedStatement::ForStatement(fs) => {
                 if let Some(init) = &fs.init {
@@ -677,6 +684,10 @@ fn rename_apply_tagged(t: &mut TaggedStatement, map: &HashMap<String, String>) {
         TaggedStatement::WhileStatement(ws) => {
             rename_apply_expr(&mut ws.test, map);
             rename_apply_stmt(&mut ws.body, map);
+        }
+        TaggedStatement::DoWhileStatement(ds) => {
+            rename_apply_expr(&mut ds.test, map);
+            rename_apply_stmt(&mut ds.body, map);
         }
         TaggedStatement::ForStatement(fs) => {
             if let Some(init) = &mut fs.init {

--- a/code/packages/rust/closure-pass-rename-properties/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-rename-properties/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to the `coding-adventures-closure-pass-rename-properties` crate will be documented in this file.
 
+## [0.5.0] - 2026-06-20
+
+### Added — CLOC20: property renaming recurses through `do`/`while`
+
+`classify_stmt` and `rewrite_stmt` recurse through `DoWhileStatement` (loop body
+and test) so property accesses inside a do-while loop are renamed consistently.
+
 ## [0.4.0] - 2026-06-20
 
 ### Added — CLOC19: property renaming recurses through `try`/`catch`/`finally`

--- a/code/packages/rust/closure-pass-rename-properties/Cargo.toml
+++ b/code/packages/rust/closure-pass-rename-properties/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-rename-properties"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 description = "Aggressive property renaming pass for the Closure Compiler clone (ADVANCED-only). Consistently shortens program-private object property names that are never quoted/computed and not in the built-in or externs do-not-rename boundary."
 

--- a/code/packages/rust/closure-pass-rename-properties/src/lib.rs
+++ b/code/packages/rust/closure-pass-rename-properties/src/lib.rs
@@ -1003,6 +1003,10 @@ fn classify_stmt(stmt: &Statement, cls: &mut Classify, nodes_touched: &mut u32) 
                 classify_expr(&ws.test, cls);
                 classify_stmt(&ws.body, cls, nodes_touched);
             }
+            TaggedStatement::DoWhileStatement(ds) => {
+                classify_expr(&ds.test, cls);
+                classify_stmt(&ds.body, cls, nodes_touched);
+            }
             TaggedStatement::ForStatement(fs) => {
                 if let Some(init) = &fs.init {
                     match init {
@@ -1195,6 +1199,10 @@ fn rewrite_stmt(stmt: &mut Statement, map: &HashMap<String, String>) {
             TaggedStatement::WhileStatement(ws) => {
                 rewrite_expr(&mut ws.test, map);
                 rewrite_stmt(&mut ws.body, map);
+            }
+            TaggedStatement::DoWhileStatement(ds) => {
+                rewrite_expr(&mut ds.test, map);
+                rewrite_stmt(&mut ds.body, map);
             }
             TaggedStatement::ForStatement(fs) => {
                 if let Some(init) = &mut fs.init {

--- a/code/packages/rust/closure-pass-rename/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-rename/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to the `coding-adventures-closure-pass-rename` crate will be documented in this file.
 
+## [0.6.0] - 2026-06-20
+
+### Added — CLOC20: local renaming across `do`/`while`
+
+The pass recurses through `DoWhileStatement` in every phase (`process_tagged`,
+`stmt_has_function`, `collect_decl_occurrences_stmt`, `collect_all_idents_stmt`,
+`rewrite_uses_tagged`), so local renames reach into the loop body and test,
+mirroring the existing `while` handling. A do-while introduces no binding of its
+own, so no special reservation is needed (unlike a catch parameter).
+
 ## [0.5.0] - 2026-06-20
 
 ### Added — CLOC19: local renaming across `try`/`catch`/`finally` (catch-param soundness)

--- a/code/packages/rust/closure-pass-rename/Cargo.toml
+++ b/code/packages/rust/closure-pass-rename/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-rename"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 description = "Variable renaming pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Replaces non-exported binding names with shorter identifiers to reduce output size while preserving externally-visible names and semantics."
 

--- a/code/packages/rust/closure-pass-rename/src/lib.rs
+++ b/code/packages/rust/closure-pass-rename/src/lib.rs
@@ -271,6 +271,9 @@ fn process_tagged(t: &mut TaggedStatement, nodes_touched: &mut u32) -> bool {
         TaggedStatement::WhileStatement(ws) => {
             changed |= process_stmt(&mut ws.body, nodes_touched);
         }
+        TaggedStatement::DoWhileStatement(ds) => {
+            changed |= process_stmt(&mut ds.body, nodes_touched);
+        }
         TaggedStatement::ForStatement(fs) => {
             changed |= process_stmt(&mut fs.body, nodes_touched);
         }
@@ -363,6 +366,7 @@ fn stmt_has_function(stmt: &Statement) -> bool {
                     || is.alternate.as_deref().is_some_and(stmt_has_function)
             }
             TaggedStatement::WhileStatement(ws) => stmt_has_function(&ws.body),
+            TaggedStatement::DoWhileStatement(ds) => stmt_has_function(&ds.body),
             TaggedStatement::ForStatement(fs) => stmt_has_function(&fs.body),
             TaggedStatement::LabeledStatement(ls) => stmt_has_function(&ls.body),
             TaggedStatement::SwitchStatement(ss) => ss
@@ -572,6 +576,9 @@ fn collect_decl_occurrences_stmt(stmt: &Statement, out: &mut Vec<(String, bool)>
             TaggedStatement::WhileStatement(ws) => {
                 collect_decl_occurrences_stmt(&ws.body, out, true)
             }
+            TaggedStatement::DoWhileStatement(ds) => {
+                collect_decl_occurrences_stmt(&ds.body, out, true)
+            }
             TaggedStatement::ForStatement(fs) => {
                 // A `for`-init `let`/`const` is scoped to the loop (never the
                 // whole body), so it is block-scoped → pass `nested = true`.
@@ -682,6 +689,10 @@ fn collect_all_idents_stmt(stmt: &Statement, out: &mut HashSet<String>) {
             TaggedStatement::WhileStatement(ws) => {
                 collect_all_idents_expr(&ws.test, out);
                 collect_all_idents_stmt(&ws.body, out);
+            }
+            TaggedStatement::DoWhileStatement(ds) => {
+                collect_all_idents_expr(&ds.test, out);
+                collect_all_idents_stmt(&ds.body, out);
             }
             TaggedStatement::ForStatement(fs) => {
                 if let Some(init) = &fs.init {
@@ -884,6 +895,10 @@ fn rewrite_uses_tagged(t: &mut TaggedStatement, map: &HashMap<String, String>) {
         TaggedStatement::WhileStatement(ws) => {
             rewrite_uses_expr(&mut ws.test, map);
             rewrite_uses_stmt(&mut ws.body, map);
+        }
+        TaggedStatement::DoWhileStatement(ds) => {
+            rewrite_uses_expr(&mut ds.test, map);
+            rewrite_uses_stmt(&mut ds.body, map);
         }
         TaggedStatement::ForStatement(fs) => {
             if let Some(init) = &mut fs.init {

--- a/code/packages/rust/closure-scope-analyzer/CHANGELOG.md
+++ b/code/packages/rust/closure-scope-analyzer/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to the `coding-adventures-closure-scope-analyzer` crate will be documented in this file.
 
+## [0.6.0] - 2026-06-20
+
+### Added — CLOC20: scope analysis for `do`/`while`
+
+`walk_tagged_statement` now handles `DoWhileStatement`: it walks the body and the
+test in the current scope. Like `while`, a do-while introduces no new scope, so
+this is a straight structural recurse.
+
 ## [0.5.0] - 2026-06-20
 
 ### Added — CLOC19: scope analysis for `try`/`catch`/`finally`

--- a/code/packages/rust/closure-scope-analyzer/Cargo.toml
+++ b/code/packages/rust/closure-scope-analyzer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-scope-analyzer"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 description = "Lexical scope + symbol-table analyzer for the Closure Compiler clone. Per CLOC13 — produces a `ScopeAnalysis` consumed by the rename, inline, treeshake, collapse-properties, and remove-unused-vars passes."
 

--- a/code/packages/rust/closure-scope-analyzer/src/lib.rs
+++ b/code/packages/rust/closure-scope-analyzer/src/lib.rs
@@ -617,6 +617,12 @@ fn walk_tagged_statement(
             walk_expression(&ws.test, ctx, analysis, pending);
             walk_statement(&ws.body, ctx, analysis, pending);
         }
+        TaggedStatement::DoWhileStatement(ds) => {
+            // A do-while introduces no new scope (same as while); walk the
+            // body and the test in the current scope.
+            walk_statement(&ds.body, ctx, analysis, pending);
+            walk_expression(&ds.test, ctx, analysis, pending);
+        }
         TaggedStatement::ForStatement(fs) => {
             if let Some(init) = &fs.init {
                 match init {

--- a/code/packages/rust/javascript-ast/CHANGELOG.md
+++ b/code/packages/rust/javascript-ast/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to the `coding-adventures-javascript-ast` crate will be documented in this file.
 
+## [0.9.0] - 2026-06-20
+
+### Added — CLOC20: `DoWhileStatement` (the test-after-body loop)
+
+Adds `DoWhileStatement { cv, body: Box<Statement>, test: Expression }`, a new
+`TaggedStatement::DoWhileStatement` variant, and a `Statement::do_while_statement`
+constructor. This is the mirror of `WhileStatement` with the field order
+following execution order (`body` before `test`) — a `do`-`while` runs its body
+at least once *before* the test is first evaluated. ESTree wire format:
+
+```json
+{ "type": "DoWhileStatement", "body": <Statement>, "test": <Expression> }
+```
+
+Making it representable lets the closurec CLI optimize programs that use a
+do-while loop; previously any such program fell back to WHITESPACE_ONLY.
+
 ## [0.8.0] - 2026-06-20
 
 ### Added — CLOC19: `TryStatement` + `CatchClause` (closes the try/catch coverage gap)

--- a/code/packages/rust/javascript-ast/Cargo.toml
+++ b/code/packages/rust/javascript-ast/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-javascript-ast"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 description = "Backend-agnostic JavaScript AST — full ESTree-compatible node taxonomy with optional per-node CV id. Reusable by the Closure-Compiler-clone and the future V8-in-Rust clone. Per CLOC02 / CLOC09."
 

--- a/code/packages/rust/javascript-ast/src/lib.rs
+++ b/code/packages/rust/javascript-ast/src/lib.rs
@@ -140,9 +140,10 @@ pub use expression::{
     StringLiteral, UnaryExpression, UnaryOperator, UndefinedLiteral,
 };
 pub use statement::{
-    BlockStatement, BreakStatement, CatchClause, ContinueStatement, EmptyStatement,
-    ExpressionStatement, ForInit, ForStatement, IfStatement, LabeledStatement, ReturnStatement,
-    Statement, SwitchCase, SwitchStatement, ThrowStatement, TryStatement, WhileStatement,
+    BlockStatement, BreakStatement, CatchClause, ContinueStatement, DoWhileStatement,
+    EmptyStatement, ExpressionStatement, ForInit, ForStatement, IfStatement, LabeledStatement,
+    ReturnStatement, Statement, SwitchCase, SwitchStatement, ThrowStatement, TryStatement,
+    WhileStatement,
 };
 
 /// A correlation-vector identifier. Aliased to `String` for v1 to match

--- a/code/packages/rust/javascript-ast/src/statement.rs
+++ b/code/packages/rust/javascript-ast/src/statement.rs
@@ -27,8 +27,11 @@
 //! - [`TryStatement`] + [`CatchClause`] (CLOC19 — `try`/`catch`/`finally`,
 //!   added to unblock the whitespace-only fallback on any program using
 //!   exception handling)
+//! - [`DoWhileStatement`] (CLOC20 — `do body while (test)`, the
+//!   test-after-body loop; unblocks the whitespace-only fallback on any
+//!   program using a do-while loop)
 //!
-//! Phase 2 will add `DoWhileStatement`, `ForInStatement`, `ForOfStatement`,
+//! Phase 2 will add `ForInStatement`, `ForOfStatement`,
 //! `DebuggerStatement`, and `WithStatement`.
 
 use crate::declaration::{Declaration, VariableDeclaration};
@@ -66,6 +69,7 @@ pub enum TaggedStatement {
     BlockStatement(BlockStatement),
     IfStatement(IfStatement),
     WhileStatement(WhileStatement),
+    DoWhileStatement(DoWhileStatement),
     ForStatement(ForStatement),
     ReturnStatement(ReturnStatement),
     BreakStatement(BreakStatement),
@@ -91,6 +95,9 @@ impl Statement {
     }
     pub fn while_statement(s: WhileStatement) -> Self {
         Self::Tagged(TaggedStatement::WhileStatement(s))
+    }
+    pub fn do_while_statement(s: DoWhileStatement) -> Self {
+        Self::Tagged(TaggedStatement::DoWhileStatement(s))
     }
     pub fn for_statement(s: ForStatement) -> Self {
         Self::Tagged(TaggedStatement::ForStatement(s))
@@ -165,6 +172,25 @@ pub struct WhileStatement {
     pub cv: Option<CvId>,
     pub test: Expression,
     pub body: Box<Statement>,
+}
+
+/// `do body while (test)` (CLOC20). The mirror of [`WhileStatement`] with the
+/// test moved to *after* the body, which changes the control flow in one
+/// important way: the body always runs **at least once** before the test is
+/// first evaluated. Field order here follows that execution order (`body`
+/// before `test`) and matches ESTree's `DoWhileStatement`.
+///
+/// The shape is otherwise identical to `while`, so every pass treats it the
+/// same: recurse into `test` (an expression) and `body` (a statement). Like
+/// `while`, a `do`-`while` is **not** a terminator — control can fall out of
+/// the loop, so statements after it stay reachable.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DoWhileStatement {
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub cv: Option<CvId>,
+    pub body: Box<Statement>,
+    pub test: Expression,
 }
 
 /// `for (init; test; update) body`. All three head clauses are
@@ -470,6 +496,18 @@ mod tests {
         });
         assert_eq!(s.clone(), roundtrip(s.clone()));
         assert_eq!(type_tag(&s), "WhileStatement");
+    }
+
+    #[test]
+    fn do_while_statement_roundtrips() {
+        // do {} while (1) — body before test, mirroring execution order.
+        let s = Statement::do_while_statement(DoWhileStatement {
+            cv: Some("dw.1".to_string()),
+            body: Box::new(Statement::empty_statement(EmptyStatement { cv: None })),
+            test: lit(1.0),
+        });
+        assert_eq!(s.clone(), roundtrip(s.clone()));
+        assert_eq!(type_tag(&s), "DoWhileStatement");
     }
 
     #[test]

--- a/code/packages/rust/javascript-parser/CHANGELOG.md
+++ b/code/packages/rust/javascript-parser/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to the `coding-adventures-javascript-parser` crate will be documented in this file.
 
+## [0.11.0] - 2026-06-20
+
+### Added — CLOC20: bridge `do_while_statement` → `DoWhileStatement`
+
+`do_while_statement` no longer lands in the unsupported arm (which raised
+`UnsupportedSyntax` and forced a WHITESPACE_ONLY fallback at the CLI). New
+`convert_do_while_statement` reads the grammar production
+`do statement while ( expression )` — whose Node children are
+`[statement, expression]` (body first, test second) — into the ESTree-shaped
+`DoWhileStatement`. The prior `do_while_is_unsupported` test is replaced by
+`do_while_bridge_shape`, which pins the structural conversion.
+
 ## [0.10.0] - 2026-06-20
 
 ### Added — CLOC19: bridge `try_statement` → `TryStatement`

--- a/code/packages/rust/javascript-parser/Cargo.toml
+++ b/code/packages/rust/javascript-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-javascript-parser"
-version = "0.10.0"
+version = "0.11.0"
 edition = "2021"
 description = "JavaScript parser — parses JavaScript source code against any ECMAScript edition (es1 through es2025) using the grammar-driven parser. Includes correlation-vector plumbing per CLOC03 and a typed-AST bridge (GrammarASTNode → javascript_ast::Program) per CLOC12.136."
 

--- a/code/packages/rust/javascript-parser/src/bridge.rs
+++ b/code/packages/rust/javascript-parser/src/bridge.rs
@@ -61,8 +61,8 @@ use coding_adventures_javascript_ast::{
         UndefinedLiteral,
     },
     statement::{
-        BlockStatement, BreakStatement, CatchClause, ContinueStatement, EmptyStatement,
-        ExpressionStatement, ForInit, ForStatement, IfStatement, LabeledStatement,
+        BlockStatement, BreakStatement, CatchClause, ContinueStatement, DoWhileStatement,
+        EmptyStatement, ExpressionStatement, ForInit, ForStatement, IfStatement, LabeledStatement,
         ReturnStatement, Statement, SwitchCase, SwitchStatement, ThrowStatement, TryStatement,
         WhileStatement,
     },
@@ -266,6 +266,9 @@ fn convert_statement(node: &GrammarASTNode) -> Result<Statement, BridgeError> {
         "expression_statement" => convert_expression_statement(child),
         "if_statement" => convert_if_statement(child).map(Statement::if_statement),
         "while_statement" => convert_while_statement(child).map(Statement::while_statement),
+        "do_while_statement" => {
+            convert_do_while_statement(child).map(Statement::do_while_statement)
+        }
         "for_statement" => convert_for_statement(child).map(Statement::for_statement),
         "continue_statement" => convert_continue_statement(child).map(Statement::continue_statement),
         "break_statement" => convert_break_statement(child).map(Statement::break_statement),
@@ -275,8 +278,7 @@ fn convert_statement(node: &GrammarASTNode) -> Result<Statement, BridgeError> {
         "throw_statement" => convert_throw_statement(child).map(Statement::throw_statement),
         "try_statement" => convert_try_statement(child).map(Statement::try_statement),
         // Phase 2+ — not yet in the typed AST
-        "do_while_statement" | "for_in_statement" | "for_of_statement"
-        | "for_await_of_statement" | "with_statement"
+        "for_in_statement" | "for_of_statement" | "for_await_of_statement" | "with_statement"
         | "debugger_statement" | "using_declaration" | "await_using_declaration" => {
             Err(unsupported(child))
         }
@@ -342,6 +344,22 @@ fn convert_while_statement(node: &GrammarASTNode) -> Result<WhileStatement, Brid
         cv: None,
         test: convert_expression(nodes[0])?,
         body: Box::new(convert_statement(nodes[1])?),
+    })
+}
+
+fn convert_do_while_statement(node: &GrammarASTNode) -> Result<DoWhileStatement, BridgeError> {
+    // do_while_statement = "do" statement "while" LPAREN expression RPAREN [";"]
+    // Node children (tokens filtered out): [statement, expression] — the body
+    // comes first in source order, the test second. This is the mirror of
+    // while_statement, which is [expression, statement].
+    let nodes = node_children(node);
+    if nodes.len() < 2 {
+        return Err(internal(node, "do_while_statement needs 2 node children"));
+    }
+    Ok(DoWhileStatement {
+        cv: None,
+        body: Box::new(convert_statement(nodes[0])?),
+        test: convert_expression(nodes[1])?,
     })
 }
 
@@ -2158,9 +2176,30 @@ mod tests {
     // -----------------------------------------------------------------------
 
     #[test]
-    fn do_while_is_unsupported() {
-        let result = bridge("do { } while (true);");
-        assert!(matches!(result, Err(BridgeError::UnsupportedSyntax { .. })));
+    fn do_while_bridge_shape() {
+        // CLOC20: `do { a(); } while (x)` now bridges to a DoWhileStatement
+        // with the body (a BlockStatement) and the test (the identifier `x`).
+        // Previously this returned UnsupportedSyntax → WHITESPACE_ONLY.
+        let p = bridge_ok("do { a(); } while (x);");
+        let t = match &p.body[0] {
+            ProgramItem::Statement(Statement::Tagged(
+                coding_adventures_javascript_ast::statement::TaggedStatement::DoWhileStatement(d),
+            )) => d.clone(),
+            other => panic!("expected a DoWhileStatement, got {other:?}"),
+        };
+        // body is the `{ a(); }` block
+        assert!(matches!(
+            t.body.as_ref(),
+            Statement::Tagged(
+                coding_adventures_javascript_ast::statement::TaggedStatement::BlockStatement(_)
+            )
+        ));
+        // test is the identifier `x`
+        assert!(
+            matches!(&t.test, Expression::Identifier(id) if id.name == "x"),
+            "expected test to be identifier `x`, got {:?}",
+            t.test
+        );
     }
 
     #[test]

--- a/code/programs/rust/closurec/CHANGELOG.md
+++ b/code/programs/rust/closurec/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 All notable changes to the `coding-adventures-closurec` binary will be documented in this file.
 
+## [0.153.0] - 2026-06-20
+
+### Added — CLOC20: end-to-end `do`/`while` support
+
+Programs containing a `do`-`while` loop now route through the full typed-AST
+optimization pipeline at both SIMPLE and ADVANCED levels. Previously any
+`do`-`while` made the parse/bridge step decline, and closurec silently fell back
+to WHITESPACE_ONLY (no real optimization). Now inlining, constant folding,
+dead-code elimination, and (under ADVANCED) local/global/property renaming all
+run inside the loop body and recurse into its test, while control flow is
+preserved and the statement after the loop stays reachable (a do-while is not a
+terminator).
+
+The end-to-end `simple-do-while` diff fixture pins the behaviour, with a
+regression guard that the output is NOT the whitespace fallback. The
+`simple_level_unsupported_syntax_degrades_gracefully` unit test now uses a
+`for`-`in` loop (still bridge-unsupported) for its example, since `do`-`while`
+no longer degrades.
+
 ## [0.152.0] - 2026-06-20
 
 ### Added — CLOC19: end-to-end `try`/`catch`/`finally` support

--- a/code/programs/rust/closurec/Cargo.toml
+++ b/code/programs/rust/closurec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closurec"
-version = "0.152.0"
+version = "0.153.0"
 edition = "2021"
 description = "closurec — CLI driver for the Closure Compiler clone. Mirrors the upstream Java Closure Compiler's command-line flag surface (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility. Per CLOC08."
 

--- a/code/programs/rust/closurec/cli.spec.json
+++ b/code/programs/rust/closurec/cli.spec.json
@@ -2,7 +2,7 @@
   "cli_builder_spec_version": "1.0",
   "name": "closurec",
   "description": "closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.",
-  "version": "0.152.0",
+  "version": "0.153.0",
   "parsing_mode": "gnu",
   "flags": [
     { "id": "browser_featureset_year", "long": "browser_featureset_year", "type": "integer", "default": 0, "description": "Shortcut for defining goog.FEATURESET_YEAR=YYYY (minimum 2012)." },

--- a/code/programs/rust/closurec/src/run.rs
+++ b/code/programs/rust/closurec/src/run.rs
@@ -6490,10 +6490,11 @@ mod tests {
         let in_path = dir.join("in.js");
         let out_path = dir.join("out.js");
         let sidecar_path = dir.join("out.js.cv.json");
-        // do-while: the grammar parses it, but bridge::grammar_to_program
-        // returns UnsupportedSyntax (do_while_statement is Phase 2+).
-        // Class declarations fail at the grammar parser level, not the bridge.
-        fs::write(&in_path, "do { var x=1; } while (x>0);").expect("setup");
+        // for-in: the grammar parses it, but bridge::grammar_to_program
+        // returns UnsupportedSyntax (for_in_statement is still Phase 2+).
+        // (do-while is now supported as of CLOC20, so it no longer degrades;
+        // class declarations fail at the grammar parser level, not the bridge.)
+        fs::write(&in_path, "for (k in obj) { x(); }").expect("setup");
         let cfg = CompilerConfig {
             io: IoConfig {
                 js_patterns: vec![in_path.to_string_lossy().to_string()],

--- a/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
@@ -2,7 +2,7 @@
 
 closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.
 
-Version: 0.152.0
+Version: 0.153.0
 
 ## Flags
 

--- a/code/programs/rust/closurec/tests/diff/simple-do-while/README.md
+++ b/code/programs/rust/closurec/tests/diff/simple-do-while/README.md
@@ -1,0 +1,36 @@
+# Fixture: `simple-do-while`
+
+End-to-end oracle for `--compilation_level SIMPLE` optimization through a
+`do`/`while` loop (CLOC20).
+
+| File | Role |
+|------|------|
+| `flags.txt` | CLI args: `--compilation_level SIMPLE --js input/a.js` |
+| `input/a.js` | A single-use function, plus a `do { … } while (cond)` whose body holds foldable arithmetic, followed by a statement after the loop |
+| `expected.stdout` | The optimized output (see below) |
+
+```text
+report(1);do{var x=3;step(x)}while(cond);foo();
+```
+
+What this proves now runs **through** a do-while — none of which was
+reachable before CLOC20 (any `do`-`while` forced a WHITESPACE_ONLY
+fallback):
+
+* **Inlining** — `log` is single-use, so `log(1)` becomes `report(1)` and
+  the declaration is deleted.
+* **Constant folding** — `1 + 2` ⇒ `3` even though it sits inside the
+  do-while body.
+* **Control-flow preservation** — `do { … } while (cond)` survives
+  verbatim.
+* **Not a terminator** — `foo()` after the loop stays reachable, because a
+  do-while can fall through (the body runs, the test fails, control
+  continues).
+
+Regenerate the expected file after an intentional behavior change:
+
+```sh
+cargo run -- --compilation_level SIMPLE \
+    --js tests/diff/simple-do-while/input/a.js \
+    > tests/diff/simple-do-while/expected.stdout
+```

--- a/code/programs/rust/closurec/tests/diff/simple-do-while/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/simple-do-while/expected.stdout
@@ -1,0 +1,1 @@
+report(1);do{var x=3;step(x)}while(cond);foo();

--- a/code/programs/rust/closurec/tests/diff/simple-do-while/flags.txt
+++ b/code/programs/rust/closurec/tests/diff/simple-do-while/flags.txt
@@ -1,0 +1,4 @@
+--compilation_level
+SIMPLE
+--js
+tests/diff/simple-do-while/input/a.js

--- a/code/programs/rust/closurec/tests/diff/simple-do-while/input/a.js
+++ b/code/programs/rust/closurec/tests/diff/simple-do-while/input/a.js
@@ -1,0 +1,25 @@
+// SIMPLE-level optimization THROUGH a do-while loop (CLOC20).
+//
+// Before CLOC20, *any* program containing a `do`-`while` loop failed the
+// typed-AST parse (DoWhileStatement was unrepresentable) and closurec
+// silently fell back to WHITESPACE_ONLY — zero optimization. This fixture
+// is the end-to-end oracle proving the SIMPLE pipeline now runs every pass
+// INSIDE the do-while body and recurses into its test:
+//
+//   * `log` is single-use, so the inliner folds `log(1)` into its body
+//     `report(1)` and deletes the now-unused declaration.
+//   * `1 + 2` is constant-folded to `3` even though it lives inside the
+//     do-while body.
+//   * The `do { … } while (cond)` survives verbatim — control flow is
+//     never altered.
+//   * `foo()` AFTER the loop stays reachable: a do-while is not a
+//     terminator (control can fall out of the loop).
+function log(p) {
+  report(p);
+}
+log(1);
+do {
+  var x = 1 + 2;
+  step(x);
+} while (cond);
+foo();

--- a/code/programs/rust/closurec/tests/diff_simple_do_while.rs
+++ b/code/programs/rust/closurec/tests/diff_simple_do_while.rs
@@ -1,0 +1,88 @@
+//! Integration test for the `tests/diff/simple-do-while/` fixture.
+//!
+//! Exercises `--compilation_level SIMPLE` optimization THROUGH a
+//! `do`/`while` loop (CLOC20). Before CLOC20, any program containing a
+//! `do`-`while` failed the typed-AST parse and closurec fell back to
+//! WHITESPACE_ONLY (zero optimization). This fixture is the end-to-end
+//! oracle proving every SIMPLE pass now runs inside the do-while body and
+//! recurses into its test:
+//!
+//! ```text
+//! source ──parse──▶ grammar AST ──bridge──▶ typed Program (w/ DoWhileStatement)
+//!        ──passes──▶ optimized Program ──emit──▶ JS text
+//! ```
+//!
+//! Specifically: `log(1)` is inlined to `report(1)`, the foldable
+//! arithmetic inside the do-while body (`1 + 2`) collapses, the loop is
+//! preserved verbatim, and the `foo()` after the loop stays reachable (a
+//! do-while is not a terminator).
+
+use std::process::Command;
+
+const BINARY: &str = env!("CARGO_BIN_EXE_closurec");
+
+fn read_flags() -> Vec<String> {
+    let raw =
+        std::fs::read_to_string("tests/diff/simple-do-while/flags.txt").expect("read flags.txt");
+    raw.lines()
+        .filter(|l| !l.is_empty())
+        .map(|s| s.to_string())
+        .collect()
+}
+
+#[test]
+fn simple_do_while_fixture_matches_expected_stdout() {
+    let flags = read_flags();
+    let out = Command::new(BINARY)
+        .args(&flags)
+        .output()
+        .expect("run closurec");
+
+    assert!(
+        out.status.success(),
+        "exit: {:?}, stderr: {}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stderr),
+    );
+
+    let actual = String::from_utf8_lossy(&out.stdout);
+    let expected = std::fs::read_to_string("tests/diff/simple-do-while/expected.stdout")
+        .expect("read expected.stdout");
+    assert_eq!(
+        actual.trim_end_matches('\n'),
+        expected.trim_end_matches('\n'),
+        "mismatch.\nflags: {flags:?}\nactual:\n{actual}\nexpected:\n{expected}",
+    );
+}
+
+/// Regression guard: the output must NOT be the WHITESPACE_ONLY fallback.
+/// If `do`-`while` ever stops being representable in the typed AST, the
+/// fixture above would still "pass" against a regenerated expected file, so
+/// we additionally assert that an optimization that can ONLY come from the
+/// typed pipeline (the `log` -> `report` inline) is present, the original
+/// `function log` declaration is gone, AND the statement after the loop
+/// (`foo()`) survives — proving a do-while is treated as non-terminating.
+#[test]
+fn simple_do_while_did_not_fall_back_to_whitespace_only() {
+    let out = Command::new(BINARY)
+        .args(read_flags())
+        .output()
+        .expect("run closurec");
+    let actual = String::from_utf8_lossy(&out.stdout);
+
+    assert!(
+        actual.contains("report(1)"),
+        "expected the single-use `log` to be inlined into `report(1)` \
+         (proving the typed pipeline ran, not the whitespace fallback); \
+         got:\n{actual}",
+    );
+    assert!(
+        !actual.contains("function log"),
+        "expected the inlined `log` declaration to be removed; got:\n{actual}",
+    );
+    assert!(
+        actual.contains("foo()"),
+        "expected the statement after the do-while loop to remain reachable; \
+         got:\n{actual}",
+    );
+}

--- a/code/specs/CLOC20-do-while.md
+++ b/code/specs/CLOC20-do-while.md
@@ -1,0 +1,109 @@
+# CLOC20 — `do` / `while` end-to-end
+
+> **Status:** Shipped. AST node, parser bridge, emitter, scope analyzer, and
+> every optimization pass handle the `do`-`while` loop. An end-to-end diff
+> fixture (`simple-do-while`) pins the behaviour at the CLI.
+
+## Why this spec exists
+
+`do { … } while (test)` was the next Phase-2 statement gap after CLOC19's
+try/catch. The grammar already *parsed* a do-while, but the typed AST had no node
+to represent it, so the parser→typed-AST **bridge** declined
+(`UnsupportedSyntax`) and the CLI fell back to **`WHITESPACE_ONLY`** — emitting
+the source with only inter-token whitespace stripped, applying **zero** real
+optimization. CLOC20 closes that gap with the exact playbook CLOC19 established:
+make the statement representable, then recurse every pass into it.
+
+```text
+source ──parse──▶ grammar AST ──bridge──▶ typed Program (DoWhileStatement)
+       ──passes──▶ optimized Program ──emit──▶ JS text
+```
+
+## The AST node (`coding-adventures-javascript-ast`)
+
+```rust
+pub struct DoWhileStatement {
+    pub cv: Option<CvId>,
+    pub body: Box<Statement>,
+    pub test: Expression,
+}
+```
+
+It is the mirror of `WhileStatement`, with one deliberate difference: the field
+order is `body` before `test`, following **execution order**. A `do`-`while`
+runs its body *at least once* before the test is first evaluated — the single
+most important semantic distinction from `while`, and the one that drives the
+soundness notes below. A new `TaggedStatement::DoWhileStatement` variant and a
+`Statement::do_while_statement` constructor expose it.
+
+## The bridge (`coding-adventures-javascript-parser`)
+
+`do_while_statement` routes to `convert_do_while_statement`. The grammar
+production is `do statement while ( expression )`, so the Node children (tokens
+filtered out) are `[statement, expression]` — body first, test second (the
+mirror of `while_statement`, which is `[expression, statement]`).
+
+## The emitter (`coding-adventures-closure-emitter`)
+
+`emit_do_while` writes `do <body> while ( <test> ) ;`:
+
+* **`do`→body separation.** `do` is a keyword sitting directly before the body.
+  `do{…}` lexes cleanly when the body is a block, but a bare-statement body
+  would glue (`do foo()` must not become `dofoo()`), so a required space is
+  inserted **only when the body is not a block**.
+* **Trailing `;`.** The `while ( test )` tail does not end in `}` or `;`, so the
+  statement emits an explicit terminator `;`. That `;` is a *real* terminator
+  (ASI can supply it before a closing `}`), so `DoWhileStatement` is added to
+  `last_stmt_uses_terminator_semi`: as the last statement in a block its `;` is
+  popped (`{do{a}while(b)}`), exactly like `return`/`throw`/expression
+  statements — but unlike plain `while`, whose trailing `;` is a body slot that
+  must be kept.
+
+## Soundness: a do-while is not eliminable and not a terminator
+
+Two invariants, both flowing from "the body runs at least once":
+
+1. **No dead-loop elimination.** `fold-control-flow` removes a `while (false){…}`
+   because its body never runs. A `do {…} while (false)` runs the body exactly
+   once, so it can **never** be eliminated that way — the do-while arm only
+   recurses structurally (folds body + test), it never elides.
+2. **Not a terminator.** Like `while`, control can fall out of a do-while
+   (body runs, test fails, execution continues), so DCE keeps statements *after*
+   the loop reachable and never adds a do-while to the dead-after-terminator
+   set. In the dead-tail-truncation whitelist (`tail_is_safe_to_truncate`), a
+   do-while — a compound statement that can wrap a hoisted `var` — defaults to
+   **unsafe (preserved)**.
+
+Beyond those, a do-while introduces no binding of its own (unlike a catch
+parameter), so the renaming passes need no special reservation — they just
+recurse into body and test.
+
+### Per-pass handling
+
+| Pass | What it does for `DoWhileStatement` |
+|------|--------------------------------------|
+| `constant-fold` | recurse fold into body + test |
+| `fold-control-flow` | recurse fold into body + test; **never** elide (body runs once) |
+| `dce` | recurse DCE into body + test; not a terminator |
+| `inline-variables` | recurse count/use/propagate into body + test |
+| `inline` | recurse all phases (count/tally/inline/splice/collect) into body + test |
+| `rename` | recurse process/collect/rewrite into body + test |
+| `rename-globals` | recurse count/collect/apply into body + test |
+| `rename-properties` | recurse classify/rewrite into body + test |
+
+The scope analyzer (`closure-scope-analyzer`) walks the body and test in the
+current scope (a do-while introduces no new scope, same as `while`).
+
+## End-to-end oracle (`closurec` diff fixture)
+
+* **`simple-do-while`** — at SIMPLE: a single-use function inlines, arithmetic
+  inside the do-while body folds, the loop survives verbatim, and the statement
+  after the loop stays reachable. A companion assertion proves the output is NOT
+  the whitespace fallback (the `log` ⇒ `report` inline can only come from the
+  typed pipeline).
+
+## Out of scope (future Phase-2 work)
+
+`ForInStatement`, `ForOfStatement`, `WithStatement`, and `DebuggerStatement`
+remain bridge-unsupported (they decline to `WHITESPACE_ONLY`). They follow the
+same playbook and are natural standalone follow-ups.


### PR DESCRIPTION
## Summary

Adds first-class **`do { … } while (test)`** support to closurec — the next Phase-2 statement gap after [#6311](https://github.com/adhithyan15/coding-adventures/pull/6311)'s try/catch. Previously any `do`-`while` made the parser→typed-AST bridge decline, and the CLI silently fell back to `WHITESPACE_ONLY` (zero real optimization). Now the full optimization pipeline runs **inside** the loop body and recurses into its test at both SIMPLE and ADVANCED levels.

```
function log(p){report(p);} log(1);
do { var x = 1 + 2; step(x); } while (cond);
foo();
```
⟶ `report(1);do{var x=3;step(x)}while(cond);foo();`

(log inlined, arithmetic folded inside the body, loop preserved, `foo()` after the loop still reachable.)

## What changed (mirrors the CLOC19 try/catch playbook)

| Layer | Change |
|-------|--------|
| `javascript-ast` | `DoWhileStatement` node (field order `body` before `test`, matching execution order), `TaggedStatement` variant, constructor. |
| `javascript-parser` | Bridge `do_while_statement` → `DoWhileStatement` (grammar `do statement while ( expression )`, node children `[statement, expression]`). |
| `closure-emitter` | `emit_do_while` — `do <body> while(<test>);`, required space after `do` only for non-block bodies, trailing `;` registered as a real terminator (poppable before `}`). |
| `closure-scope-analyzer` | Walk body + test (no new scope). |
| All 8 passes | constant-fold, fold-control-flow, dce, inline-variables, inline, rename, rename-globals, rename-properties recurse into body + test. |

## Soundness — "the body runs at least once"

The one semantic difference from `while` drives two invariants:
- **No dead-loop elimination.** `do{…}while(false)` runs its body once (observable), so it is **never** removed — unlike `while(false){…}`. The fold-control-flow arm only recurses, never elides.
- **Not a terminator.** Control can fall out of the loop, so DCE keeps statements after it reachable; in the dead-tail whitelist it defaults to unsafe (preserved).

A do-while introduces no binding, so the renamers need no special reservation (unlike a catch param). An adversarial inline security review confirmed all of the above plus emitter token-separation and bridge field order.

## Tests

- **javascript-ast**: serde round-trip.
- **javascript-parser**: bridge-shape test (replacing the old `do_while_is_unsupported`).
- **closure-emitter**: tight-block, bare-body separator, pretty-mode, and terminator-`;`-pop tests.
- **closurec**: end-to-end `simple-do-while` diff fixture with a **whitespace-fallback regression guard** (asserts the inline happened and the post-loop statement survives). The `simple_level_unsupported_syntax_degrades_gracefully` test now uses `for`-`in` (still bridge-unsupported).

Full closurec suite **722/722 green**; every touched pass crate green.

## Bookkeeping

Spec: `code/specs/CLOC20-do-while.md`. Version bumps + CHANGELOGs for all 13 touched crates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)