### PR TITLE
feat(mycin-2026): DERM expansion — Nikolsky→pemphigus vulgaris, sandpaper rash→scarlet fever

### DIFF
--- a/code/specs/data/mycin-2026/USMLE-DOMAIN-MAP.md
+++ b/code/specs/data/mycin-2026/USMLE-DOMAIN-MAP.md
@@ -115,7 +115,7 @@ unchanged. Adding a relation just widens the schema — the engine already binds
 | Cardiology murmurs (Tier-2) | Cardiology | murmur_indicates (murmur→lesion) | 5 grounded (ADJ-only) | ✓ |
 | Neurology localization (Tier-2) | Neurology | lesion_causes (site→deficit) | 5 grounded (ADJ-only) | ✓ |
 | GI biopsy (Tier-2) | Gastroenterology | biopsy_finding_in (finding→dx) | 6 grounded (ADJ-only) | ✓ |
-| Dermatology (Tier-2) | Dermatology | skin_finding_in (lesion→dx) | 4 grounded (ADJ-only) | ✓ |
+| Dermatology (Tier-2) | Dermatology | skin_finding_in (lesion→dx) | 6 grounded (ADJ-only) | ✓ |
 | Respiratory occupational (Tier-2) | Pulmonology | inhalation_causes (exposure→dz) | 5 grounded (ADJ-only) | ✓ |
 
 Offline pipeline: prose → local-model decompose → ADJ → native engine, two-sided

--- a/code/specs/data/mycin-2026/board/board-scorecard.json
+++ b/code/specs/data/mycin-2026/board/board-scorecard.json
@@ -1,7 +1,7 @@
 {
   "summary": {
-    "total": 149,
-    "correct": 142,
+    "total": 151,
+    "correct": 144,
     "abstained": 7,
     "wrong": 0,
     "by_tactic": {
@@ -16,15 +16,15 @@
         "wrong": 0
       },
       "recall": {
-        "correct": 136,
+        "correct": 138,
         "abstained": 6,
         "wrong": 0
       }
     },
     "defensibility": 1.0,
     "accuracy_on_attempted": 1.0,
-    "grounded_coverage": 0.9926,
-    "grounded_correct": 135
+    "grounded_coverage": 0.9928,
+    "grounded_correct": 137
   },
   "results": [
     {
@@ -1176,6 +1176,22 @@
       "tactic": "recall",
       "gold": "pityriasis_rosea",
       "answer": "pityriasis_rosea",
+      "outcome": "correct",
+      "trust": "authoritative"
+    },
+    {
+      "id": "derm_pv_dx",
+      "tactic": "recall",
+      "gold": "pemphigus_vulgaris",
+      "answer": "pemphigus_vulgaris",
+      "outcome": "correct",
+      "trust": "authoritative"
+    },
+    {
+      "id": "derm_sf_dx",
+      "tactic": "recall",
+      "gold": "scarlet_fever",
+      "answer": "scarlet_fever",
       "outcome": "correct",
       "trust": "authoritative"
     },

--- a/code/specs/data/mycin-2026/board/items.json
+++ b/code/specs/data/mycin-2026/board/items.json
@@ -164,6 +164,8 @@
     {"id": "derm_psoriasis_dx","domain": "derm", "tactic": "recall", "relation": "skin_finding_in", "subject": "silvery_scales",      "var": "Disease", "gold": "psoriasis"},
     {"id": "derm_mc_dx",      "domain": "derm", "tactic": "recall", "relation": "skin_finding_in", "subject": "umbilicated_papules", "var": "Disease", "gold": "molluscum_contagiosum"},
     {"id": "derm_pr_dx",      "domain": "derm", "tactic": "recall", "relation": "skin_finding_in", "subject": "herald_patch",        "var": "Disease", "gold": "pityriasis_rosea"},
+    {"id": "derm_pv_dx",      "domain": "derm", "tactic": "recall", "relation": "skin_finding_in", "subject": "nikolsky_sign",       "var": "Disease", "gold": "pemphigus_vulgaris"},
+    {"id": "derm_sf_dx",      "domain": "derm", "tactic": "recall", "relation": "skin_finding_in", "subject": "sandpaper_rash",      "var": "Disease", "gold": "scarlet_fever"},
 
     {"id": "resp_silica_dx",   "domain": "resp", "tactic": "recall", "relation": "inhalation_causes", "subject": "silica",      "var": "Disease", "gold": "silicosis"},
     {"id": "resp_asbestos_dx", "domain": "resp", "tactic": "recall", "relation": "inhalation_causes", "subject": "asbestos",    "var": "Disease", "gold": "asbestosis"},

--- a/code/specs/data/mycin-2026/board/test_board_eval.py
+++ b/code/specs/data/mycin-2026/board/test_board_eval.py
@@ -59,7 +59,7 @@ def test_covered_items_answer_correctly_with_a_proof() -> None:
     # answers, so the board scores the top binding per subject (the libraries + their
     # tests cover all edges).
     recall_correct = [r for r in card.results if r.outcome == "correct" and r.tactic == "recall"]
-    assert len(recall_correct) == 136
+    assert len(recall_correct) == 138
     assert by_id["fabry_enzyme"].outcome == "correct"               # IEM
     assert by_id["thiamine_disease"].answer == "beriberi"           # vitamin
     assert by_id["ida_mcv"].answer == "microcytic"                  # anemia
@@ -119,6 +119,9 @@ def test_covered_items_answer_correctly_with_a_proof() -> None:
     assert by_id["derm_em_dx"].answer == "erythema_multiforme"   # dermatology (DERM, Tier-2)
     assert by_id["derm_psoriasis_dx"].answer == "psoriasis"      # derm — skin_finding_in (finding->dx)
     assert by_id["derm_em_dx"].trust == "authoritative"          # ADJ-only edge, grounded inline
+    assert by_id["derm_pv_dx"].answer == "pemphigus_vulgaris"    # expand: Nikolsky→PV (NBK560860)
+    assert by_id["derm_sf_dx"].answer == "scarlet_fever"         # expand: sandpaper rash→scarlet fever (NBK507889)
+    assert by_id["derm_pv_dx"].trust == "authoritative"          # ADJ-only edge, grounded inline
     assert by_id["resp_silica_dx"].answer == "silicosis"         # respiratory (RESP, Tier-2)
     assert by_id["resp_asbestos_dx"].answer == "asbestosis"      # resp — inhalation_causes (exposure->dz)
     assert by_id["resp_silica_dx"].trust == "authoritative"      # ADJ-only edge, grounded inline
@@ -166,8 +169,8 @@ def test_grounded_coverage_is_the_live_grounding_number() -> None:
     # verbatim, so the framework declines to claim grounding it cannot defend, by design:
     # cortisol_def (endocrine, deficiency_syndrome__cortisol — the only verbatim spans frame
     # cortisol deficiency as a consequence/feature of Addison disease, not the named-syndrome identity).
-    assert s["grounded_coverage"] == round(135 / 136, 4)   # 0.9926
-    assert s["grounded_correct"] == 135
+    assert s["grounded_coverage"] == round(137 / 138, 4)   # 0.9928
+    assert s["grounded_correct"] == 137
     by_id = {r.item_id: r for r in card.results}
     assert by_id["tay_sachs_enzyme"].trust == "authoritative"      # IEM
     assert by_id["ida_mcv"].trust == "authoritative"               # anemia

--- a/code/specs/data/mycin-2026/recall/derm-edges.adj
+++ b/code/specs/data/mycin-2026/recall/derm-edges.adj
@@ -27,12 +27,15 @@
 % (See feedback_nothing_human_authored, feedback_adj_only_shipped_artifacts.)
 %
 % Honest scope: only morphologies whose page states the association in a clean self-
-% contained span (both finding AND disease named) are included. Deferred — impetigo
-% (its honey-colored-crust sentence is phrased without naming impetigo, e.g. only the
-% negative "Bullous impetigo does not form a honey-colored crust"); herpes zoster
-% (its dermatomal-distribution sentences do not name zoster alongside the finding).
-% The molluscum span names the disease by its on-page abbreviation "MC" (= molluscum
-% contagiosum, defined in that StatPearls article's title).
+% contained span (both finding AND disease named) are included. Two on-page-abbreviation
+% spans are accepted (the disease is named by an abbreviation the article defines):
+% molluscum contagiosum via "MC", and pemphigus vulgaris via "PV".
+% Still deferred (re-checked) — impetigo (its honey-colored-crust sentence is phrased
+% without naming impetigo); herpes zoster (its dermatomal-distribution sentences do not
+% name zoster alongside the finding); varicella → "dew drops on a rose petal" (the lesion
+% sentence on NBK448191 does NOT name chickenpox/varicella, so it stays out despite the
+% engine now carrying the quoted finding-phrase verbatim — the missing endpoint, not the
+% quotes, is the blocker).
 % ============================================================================
 
 dictionary derm_vocab {
@@ -67,5 +70,17 @@ rulebook derm_facts {
     relate skin_finding_in(herald_patch, pityriasis_rosea)
         source "Pityriasis rosea (PR) can sometimes be difficult to manage because of factors including variations in the clinical manifestation of the condition and acknowledging instances where the typical herald patch may be absent."
         locator "https://www.ncbi.nlm.nih.gov/books/NBK448091/"
+        trust authoritative
+
+    % --- EXPAND: Nikolsky sign -> pemphigus vulgaris (named on-page as "PV") ----
+    relate skin_finding_in(nikolsky_sign, pemphigus_vulgaris)
+        source "A Nikolsky sign is described as a blister formation with minor pressure or trauma and is seen in PV."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK560860/"
+        trust authoritative
+
+    % --- EXPAND: sandpaper rash -> scarlet fever -------------------------------
+    relate skin_finding_in(sandpaper_rash, scarlet_fever)
+        source "Scarlet fever is a syndrome characterized by a blanching, erythematous, maculopapular rash often described as sandpaper-like, strawberry tongue, and exudative pharyngitis"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK507889/"
         trust authoritative
 }

--- a/code/specs/data/mycin-2026/recall/derm-recall.query.adj
+++ b/code/specs/data/mycin-2026/recall/derm-recall.query.adj
@@ -17,3 +17,5 @@ import "derm-edges.adj"
 ? skin_finding_in(silvery_scales, $Disease)       % expect psoriasis
 ? skin_finding_in(umbilicated_papules, $Disease)  % expect molluscum_contagiosum
 ? skin_finding_in(herald_patch, $Disease)         % expect pityriasis_rosea
+? skin_finding_in(nikolsky_sign, $Disease)        % expect pemphigus_vulgaris (expand)
+? skin_finding_in(sandpaper_rash, $Disease)       % expect scarlet_fever (expand)

--- a/code/specs/data/mycin-2026/recall/test_derm_recall.py
+++ b/code/specs/data/mycin-2026/recall/test_derm_recall.py
@@ -34,6 +34,8 @@ EXPECTED = {
     "silvery_scales": "psoriasis",
     "umbilicated_papules": "molluscum_contagiosum",
     "herald_patch": "pityriasis_rosea",
+    "nikolsky_sign": "pemphigus_vulgaris",   # expand (NBK560860)
+    "sandpaper_rash": "scarlet_fever",       # expand (NBK507889)
 }
 REL = "skin_finding_in"
 VAR = "Disease"


### PR DESCRIPTION
## What

Expands the dermatology lesion→diagnosis domain with two high-yield edges, primary-source-first (each a clean both-endpoints span, no double quotes):

| Edge | Source | Locator |
|---|---|---|
| `skin_finding_in(nikolsky_sign, pemphigus_vulgaris)` | "A Nikolsky sign is described as a blister formation with minor pressure or trauma and is seen in PV." | StatPearls *Pemphigus Vulgaris* (NBK560860) |
| `skin_finding_in(sandpaper_rash, scarlet_fever)` | "Scarlet fever is a syndrome characterized by a blanching, erythematous, maculopapular rash often described as sandpaper-like, strawberry tongue, and exudative pharyngitis" | StatPearls *Scarlet Fever* (NBK507889) |

"PV" is the article's own abbreviation for pemphigus vulgaris — the same on-page-abbreviation pattern already accepted for the molluscum "MC" edge.

Both ship inline byte-provenance, are engine-queryable (added to `derm-recall.query.adj`), and are mirrored into the board bank.

## Still deferred (re-checked, recorded in the DERM note)

- **impetigo → honey-colored crust** and **herpes zoster → dermatomal vesicles** — no single sentence names finding + disease together.
- **varicella → "dew drops on a rose petal"** — the lesion sentence (NBK448191) does **not** name chickenpox/varicella. It stays out despite the engine now carrying the quoted finding-phrase verbatim (PR #6330): the *missing endpoint*, not the quotes, is the blocker.

## Numbers

- Board scorecard: **136→138** recall correct, **135→137** grounded, coverage **0.9926→0.9928**, **wrong still 0** / defensibility **1.0**.
- Domain map: DERM 4→6.

## Verification

- All **19** recall suites pass against the native `adj-lang-cli`.
- The **12**-test board scorecard passes (memoized).
- The dedicated `mycin-2026` CI gate exercises both on every PR.
- Security review passed (data/test/docs only — no executable surface).

🤖 Generated with [Claude Code](https://claude.com/claude-code)