### PR TITLE
feat(mycin-2026): HISTO expansion — Negri bodies→rabies; correct psammoma→PTC deferral note

### DIFF
--- a/code/specs/data/mycin-2026/USMLE-DOMAIN-MAP.md
+++ b/code/specs/data/mycin-2026/USMLE-DOMAIN-MAP.md
@@ -111,7 +111,7 @@ unchanged. Adding a relation just widens the schema — the engine already binds
 | Genetics | Genetics | inheritance, gene_defect, trinucleotide_repeat, imprinting | 10 grounded (ADJ-only) | ✓ |
 | Rheumatology (Tier-2) | Path/Immuno | associated_autoantibody | 11 grounded (ADJ-only) | ✓ |
 | Oncology (Tier-2) | Pathology/neoplasia | tumor_marker | 7 grounded (ADJ-only) | ✓ |
-| Histology buzzwords (Tier-2) | Pathology | seen_in (finding→condition) | 7 grounded (ADJ-only) | ✓ |
+| Histology buzzwords (Tier-2) | Pathology | seen_in (finding→condition) | 8 grounded (ADJ-only) | ✓ |
 | Cardiology murmurs (Tier-2) | Cardiology | murmur_indicates (murmur→lesion) | 5 grounded (ADJ-only) | ✓ |
 | Neurology localization (Tier-2) | Neurology | lesion_causes (site→deficit) | 5 grounded (ADJ-only) | ✓ |
 | GI biopsy (Tier-2) | Gastroenterology | biopsy_finding_in (finding→dx) | 6 grounded (ADJ-only) | ✓ |

--- a/code/specs/data/mycin-2026/board/board-scorecard.json
+++ b/code/specs/data/mycin-2026/board/board-scorecard.json
@@ -1,7 +1,7 @@
 {
   "summary": {
-    "total": 151,
-    "correct": 144,
+    "total": 152,
+    "correct": 145,
     "abstained": 7,
     "wrong": 0,
     "by_tactic": {
@@ -16,7 +16,7 @@
         "wrong": 0
       },
       "recall": {
-        "correct": 138,
+        "correct": 139,
         "abstained": 6,
         "wrong": 0
       }
@@ -24,7 +24,7 @@
     "defensibility": 1.0,
     "accuracy_on_attempted": 1.0,
     "grounded_coverage": 0.9928,
-    "grounded_correct": 137
+    "grounded_correct": 138
   },
   "results": [
     {
@@ -1016,6 +1016,14 @@
       "tactic": "recall",
       "gold": "meningioma",
       "answer": "meningioma",
+      "outcome": "correct",
+      "trust": "authoritative"
+    },
+    {
+      "id": "histo_negri_cond",
+      "tactic": "recall",
+      "gold": "rabies",
+      "answer": "rabies",
       "outcome": "correct",
       "trust": "authoritative"
     },

--- a/code/specs/data/mycin-2026/board/items.json
+++ b/code/specs/data/mycin-2026/board/items.json
@@ -140,6 +140,7 @@
     {"id": "histo_heinz_cond", "domain": "histo", "tactic": "recall", "relation": "seen_in", "subject": "heinz_bodies",        "var": "Condition", "gold": "g6pd_deficiency"},
     {"id": "histo_auer_cond",  "domain": "histo", "tactic": "recall", "relation": "seen_in", "subject": "auer_rods",          "var": "Condition", "gold": "acute_promyelocytic_leukemia"},
     {"id": "histo_psammoma_cond", "domain": "histo", "tactic": "recall", "relation": "seen_in", "subject": "psammoma_bodies", "var": "Condition", "gold": "meningioma"},
+    {"id": "histo_negri_cond", "domain": "histo", "tactic": "recall", "relation": "seen_in", "subject": "negri_bodies",     "var": "Condition", "gold": "rabies"},
 
     {"id": "cardio_mr_lesion",  "domain": "cardio", "tactic": "recall", "relation": "murmur_indicates", "subject": "holosystolic_apical",             "var": "Lesion", "gold": "mitral_regurgitation"},
     {"id": "cardio_as_lesion",  "domain": "cardio", "tactic": "recall", "relation": "murmur_indicates", "subject": "crescendo_decrescendo_systolic",  "var": "Lesion", "gold": "aortic_stenosis"},

--- a/code/specs/data/mycin-2026/board/test_board_eval.py
+++ b/code/specs/data/mycin-2026/board/test_board_eval.py
@@ -59,7 +59,7 @@ def test_covered_items_answer_correctly_with_a_proof() -> None:
     # answers, so the board scores the top binding per subject (the libraries + their
     # tests cover all edges).
     recall_correct = [r for r in card.results if r.outcome == "correct" and r.tactic == "recall"]
-    assert len(recall_correct) == 138
+    assert len(recall_correct) == 139
     assert by_id["fabry_enzyme"].outcome == "correct"               # IEM
     assert by_id["thiamine_disease"].answer == "beriberi"           # vitamin
     assert by_id["ida_mcv"].answer == "microcytic"                  # anemia
@@ -101,6 +101,7 @@ def test_covered_items_answer_correctly_with_a_proof() -> None:
     assert by_id["histo_rs_cond"].trust == "authoritative"       # ADJ-only edge, grounded inline
     assert by_id["histo_auer_cond"].answer == "acute_promyelocytic_leukemia"  # primary-source backfill
     assert by_id["histo_psammoma_cond"].answer == "meningioma"   # primary-source backfill (psammoma→meningioma)
+    assert by_id["histo_negri_cond"].answer == "rabies"          # expand: Negri bodies→rabies (NBK448076)
     assert by_id["rheum_pbc_ab"].answer == "anti_mitochondrial"  # primary-source backfill: PBC→AMA (NBK459209)
     assert by_id["rheum_pbc_ab"].trust == "authoritative"        # previously deferred, now grounded
     assert by_id["rheum_dm_ab"].answer == "anti_jo1"            # primary-source backfill: DM→anti-Jo-1 (NBK558917)
@@ -169,8 +170,8 @@ def test_grounded_coverage_is_the_live_grounding_number() -> None:
     # verbatim, so the framework declines to claim grounding it cannot defend, by design:
     # cortisol_def (endocrine, deficiency_syndrome__cortisol — the only verbatim spans frame
     # cortisol deficiency as a consequence/feature of Addison disease, not the named-syndrome identity).
-    assert s["grounded_coverage"] == round(137 / 138, 4)   # 0.9928
-    assert s["grounded_correct"] == 137
+    assert s["grounded_coverage"] == round(138 / 139, 4)   # 0.9928
+    assert s["grounded_correct"] == 138
     by_id = {r.item_id: r for r in card.results}
     assert by_id["tay_sachs_enzyme"].trust == "authoritative"      # IEM
     assert by_id["ida_mcv"].trust == "authoritative"               # anemia

--- a/code/specs/data/mycin-2026/recall/histo-edges.adj
+++ b/code/specs/data/mycin-2026/recall/histo-edges.adj
@@ -28,13 +28,17 @@
 % contained span (both finding AND condition named) are included. Under the primary-
 % source-first, zero-deferral policy, two previously-deferred buzzwords are now GROUNDED:
 % Auer rods → acute promyelocytic leukemia (the AML page names abundant Auer rods as a
-% pathognomonic APL feature) and psammoma bodies → meningioma (the meningioma page names
-% psammoma-body formation as a histopathological characteristic). Still deferred (re-checked):
-% psammoma bodies → papillary thyroid carcinoma — the PTC page (NBK536943) lists psammoma
-% bodies only as an isolated bullet, and the only both-endpoints span on the Thyroid-Gland
-% histology page (NBK551659) wraps "Orphan Annie eye" in DOUBLE quotes (plus inline citation
-% brackets), which cannot be carried verbatim inside an ADJ double-quoted source string.
-% Declined rather than mangle the span — honest absence beats a doctored citation.
+% pathognomonic APL feature), psammoma bodies → meningioma (the meningioma page names
+% psammoma-body formation as a histopathological characteristic), and Negri bodies →
+% rabies (the Rabies page names them pathognomonic in one clean sentence).
+% Still deferred (re-checked): psammoma bodies → papillary thyroid carcinoma. NOTE the
+% blocker has narrowed: ADJ string literals now carry escaped double quotes (adj-lang
+% 0.16.1, PR #6330), so the "Orphan Annie eye" quotes are no longer the obstacle. The
+% remaining obstacle is that NO checked authoritative page states both endpoints in one
+% clean sentence — both dedicated PTC pages (NBK536943, NBK459299) name psammoma bodies
+% and papillary thyroid carcinoma only in SEPARATE sentences, and the sole both-endpoints
+% location (Thyroid-Gland histology, NBK551659) spans a citation-marker boundary
+% ([43][40]) between its two endpoint sentences. Honest absence beats a stitched span.
 % ============================================================================
 
 dictionary histo_vocab {
@@ -83,5 +87,11 @@ rulebook histo_facts {
     relate seen_in(psammoma_bodies, meningioma)
         source "One of the histopathological characteristics of meningiomas is the growth of meningothelial cells that eventually mineralize to form psammoma bodies."
         locator "https://www.ncbi.nlm.nih.gov/books/NBK560538/"
+        trust authoritative
+
+    % --- EXPAND: Negri bodies -> rabies (pathognomonic) -------------------------
+    relate seen_in(negri_bodies, rabies)
+        source "Intracytoplasmic Negri bodies are pathognomonic for rabies but are only present in 20% to 60% of cases."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK448076/"
         trust authoritative
 }

--- a/code/specs/data/mycin-2026/recall/histo-recall.query.adj
+++ b/code/specs/data/mycin-2026/recall/histo-recall.query.adj
@@ -19,3 +19,4 @@ import "histo-edges.adj"
 ? seen_in(heinz_bodies, $Condition)           % expect g6pd_deficiency / methemoglobinemia
 ? seen_in(auer_rods, $Condition)              % expect acute_promyelocytic_leukemia (backfill)
 ? seen_in(psammoma_bodies, $Condition)        % expect meningioma (backfill)
+? seen_in(negri_bodies, $Condition)           % expect rabies (expand)

--- a/code/specs/data/mycin-2026/recall/test_histo_recall.py
+++ b/code/specs/data/mycin-2026/recall/test_histo_recall.py
@@ -35,6 +35,7 @@ EXPECTED = {
     "heinz_bodies": {"g6pd_deficiency", "methemoglobinemia"},
     "auer_rods": {"acute_promyelocytic_leukemia"},        # primary-source backfill (NBK507875)
     "psammoma_bodies": {"meningioma"},                    # primary-source backfill (NBK560538)
+    "negri_bodies": {"rabies"},                           # expand (NBK448076)
 }
 REL = "seen_in"
 VAR = "Condition"


### PR DESCRIPTION
## What

Grounds a new high-yield histology buzzword and corrects an out-of-date deferral note in light of the merged escape support (#6330):

| Edge | Source | Locator |
|---|---|---|
| `seen_in(negri_bodies, rabies)` | "Intracytoplasmic Negri bodies are pathognomonic for rabies but are only present in 20% to 60% of cases." | StatPearls *Rabies* (NBK448076) |

## The interlock outcome (honest)

The old HISTO note blamed the **"Orphan Annie eye" double quotes** for blocking psammoma bodies → papillary thyroid carcinoma. Now that ADJ string literals carry escaped quotes (adj-lang 0.16.1, **#6330**), that is no longer the obstacle — so I re-checked and **corrected the note**. The honest remaining blocker: **no checked authoritative page states both endpoints in one clean sentence** — both dedicated PTC pages (NBK536943, NBK459299) name psammoma bodies and papillary thyroid carcinoma only in *separate* sentences, and the sole both-endpoints location (Thyroid-Gland histology, NBK551659) spans a **citation-marker boundary** (`[43][40]`) between its two endpoint sentences.

So the ADJ-language work **narrowed** the blocker but did not eliminate it; psammoma→PTC stays honestly deferred, with the reason now recorded accurately rather than papered over. (This is the two-stream interlock playing out — and being truthful when it only partly pays off.)

## Numbers

- Board scorecard: **138→139** recall correct, **137→138** grounded, coverage holds **0.9928**, **wrong still 0** / defensibility **1.0**.
- Domain map: HISTO 7→8.

## Verification

- All **19** recall suites pass against the native `adj-lang-cli`.
- The **12**-test board scorecard passes (memoized).
- The dedicated `mycin-2026` CI gate exercises both on every PR.
- Security review passed (data/test/docs only — no executable surface).

🤖 Generated with [Claude Code](https://claude.com/claude-code)