### PR TITLE
feat(r-23): closure environments & parent.frame() reflection

### DIFF
--- a/code/packages/rust/r-runtime/CHANGELOG.md
+++ b/code/packages/rust/r-runtime/CHANGELOG.md
@@ -2,6 +2,34 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.18.0] - 2026-06-20
+
+### Added (via the shared `s-runtime`)
+
+- **R-23 — closure environments & call-frame reflection**: reaches R unchanged
+  through the shared evaluator (everything lives in `s-runtime` — no grammar
+  change). In R syntax:
+  - **`environment(f)`** — a closure's captured (defining) env. For a top-level
+    closure that is the global env, so `environmentName(environment(f))` is
+    `"R_GlobalEnv"` and `is.environment(environment(f))` is `TRUE`. A non-closure
+    argument returns `NULL` (R's `environment(sum)`).
+  - **`environment(f) <- e`** — re-home a closure: after it, a free variable in
+    `f`'s body resolves from `e`'s chain (`assign("k", 99, envir = e);
+    environment(f) <- e; f()` → `99`). A non-environment value is a clean error.
+  - **`environmentName(e)`** — `"R_GlobalEnv"` / `"R_EmptyEnv"` / `""`.
+  - **`globalenv()` / `emptyenv()` / `baseenv()`** — the well-known environments
+    as values (`baseenv()` aliases the global env in this runtime — no separate
+    base namespace yet).
+  - **`parent.frame(n = 1)`** — the **caller's** environment: `g <- function()
+    get("x", envir = parent.frame()); f <- function() { x <- 42; g() }; f()` →
+    `42`. `parent.frame(2)` reaches the caller's caller. At top level, or for `n`
+    past the bottom of the stack, it **clamps** to the global env (never panics);
+    a non-positive `n` is a clean error.
+  - **`is.environment(x)`** — `TRUE` for an environment, `FALSE` otherwise.
+  - See `s-runtime` 0.19.0 for the (unchanged) Rc-cycle ownership model: the
+    caller env on the call stack is dropped when its frame is popped, and the
+    captured-env exposure is bounded by `MAX_ENVIRONMENTS`.
+
 ## [0.17.0] - 2026-06-20
 
 ### Added (via the shared `s-runtime`)

--- a/code/packages/rust/r-runtime/README.md
+++ b/code/packages/rust/r-runtime/README.md
@@ -79,8 +79,18 @@ sorted; and an environment is **mutable by reference** — `f <- function(env)
 assign("x", 42, envir = env); f(e); get("x", envir = e)` → `42`. `environment()`
 returns the current env; an env prints as the stable placeholder `<environment>`
 with class `"environment"`. The parent link is a `Weak` so an env-holding-env
-cannot leak (see `s-runtime`). `environment(f)` / `environmentName` are deferred
-to R-23.
+cannot leak (see `s-runtime`).
+
+**Closure environments & frame reflection (R-23)** — `environment(f)` is the env
+a closure captured at definition (a top-level closure captures the global env, so
+`environmentName(environment(f))` → `"R_GlobalEnv"`; a non-closure → `NULL`).
+`environment(f) <- e` re-homes a closure (its free variables then resolve from
+`e`). `environmentName(e)` is `"R_GlobalEnv"` / `"R_EmptyEnv"` / `""`;
+`globalenv()` / `emptyenv()` / `baseenv()` return the well-known environments
+(`baseenv()` aliases global). `parent.frame(n = 1)` is the **caller's** env —
+`g <- function() get("x", envir = parent.frame()); f <- function() { x <- 42;
+g() }; f()` → `42` — clamping to the global env past the bottom of the stack
+rather than panicking. `is.environment(x)` is the type predicate.
 
 ## Usage
 

--- a/code/packages/rust/r-runtime/src/lib.rs
+++ b/code/packages/rust/r-runtime/src/lib.rs
@@ -1714,4 +1714,137 @@ mod tests {
         // R-21: `->>` right-super-assign creates globally.
         assert_eq!(nums("99 ->> zz\nzz\n"), vec![99.0]);
     }
+
+    // --- R-23: closure environments & frame reflection (R syntax) --------
+
+    /// `environment(f)` for a top-level closure is an environment value — the
+    /// captured (global) env.
+    #[test]
+    fn r23_environment_of_closure_is_an_env() {
+        let src = "f <- function() environment()\nis.environment(environment(f))\n";
+        assert_eq!(show(src), "[1] TRUE");
+    }
+
+    /// A top-level closure captures the **global** env, so `environmentName` of
+    /// its captured env is `"R_GlobalEnv"` (our stand-in for
+    /// `identical(environment(f), globalenv())`, since `identical` is not yet a
+    /// builtin).
+    #[test]
+    fn r23_top_level_closure_captures_global() {
+        let src = "f <- function() 1\nenvironmentName(environment(f))\n";
+        assert_eq!(show(src), "[1] \"R_GlobalEnv\"");
+    }
+
+    /// A non-closure argument to `environment` yields `NULL` (matches R's
+    /// `environment(sum)`).
+    #[test]
+    fn r23_environment_of_non_closure_is_null() {
+        assert_eq!(show("environment(1)\n"), "NULL");
+        assert_eq!(show("environment(\"x\")\n"), "NULL");
+    }
+
+    /// The well-known environment names.
+    #[test]
+    fn r23_environment_names() {
+        assert_eq!(
+            show("environmentName(globalenv())\n"),
+            "[1] \"R_GlobalEnv\""
+        );
+        assert_eq!(show("environmentName(emptyenv())\n"), "[1] \"R_EmptyEnv\"");
+        assert_eq!(show("environmentName(new.env())\n"), "[1] \"\"");
+        // baseenv aliases global in this runtime.
+        assert_eq!(show("environmentName(baseenv())\n"), "[1] \"R_GlobalEnv\"");
+    }
+
+    /// `environment(f) <- e` re-homes a closure: free variables in its body now
+    /// resolve from `e`'s chain.
+    #[test]
+    fn r23_set_closure_environment() {
+        let src = "e <- new.env()\nassign(\"k\", 99, envir = e)\n\
+                   f <- function() k\nenvironment(f) <- e\nf()\n";
+        assert_eq!(nums(src), vec![99.0]);
+    }
+
+    /// A non-environment replacement value is a clean error.
+    #[test]
+    fn r23_set_closure_environment_rejects_non_env() {
+        assert!(eval_r("f <- function() 1\nenvironment(f) <- 5\n").is_err());
+    }
+
+    /// `parent.frame()` returns the **caller's** environment: a binding the
+    /// caller made is visible through `get(..., envir = parent.frame())`.
+    #[test]
+    fn r23_parent_frame_sees_caller_binding() {
+        let src = "g <- function() get(\"x\", envir = parent.frame())\n\
+                   f <- function() { x <- 42; g() }\nf()\n";
+        assert_eq!(nums(src), vec![42.0]);
+    }
+
+    /// Two-deep `parent.frame(2)` reaches the caller's caller. `h` calls `g`
+    /// calls `parent.frame(2)`, which is `f`'s frame, where `x` is bound.
+    #[test]
+    fn r23_parent_frame_two_deep() {
+        let src = "g <- function() get(\"x\", envir = parent.frame(2))\n\
+                   h <- function() g()\n\
+                   f <- function() { x <- 7; h() }\nf()\n";
+        assert_eq!(nums(src), vec![7.0]);
+    }
+
+    /// `parent.frame()` at top level clamps to the global env (never panics);
+    /// a global binding is therefore visible through it.
+    #[test]
+    fn r23_parent_frame_top_level_clamps_to_global() {
+        let src = "x <- 11\nget(\"x\", envir = parent.frame())\n";
+        assert_eq!(nums(src), vec![11.0]);
+    }
+
+    /// `parent.frame(n)` past the bottom of the live stack clamps to global
+    /// rather than indexing out of bounds.
+    #[test]
+    fn r23_parent_frame_past_bottom_clamps() {
+        let src = "x <- 5\n\
+                   g <- function() get(\"x\", envir = parent.frame(100))\ng()\n";
+        assert_eq!(nums(src), vec![5.0]);
+    }
+
+    /// A non-positive / non-finite `n` is a clean error, never a panic.
+    #[test]
+    fn r23_parent_frame_bad_n_errors() {
+        assert!(eval_r("g <- function() parent.frame(0)\ng()\n").is_err());
+        assert!(eval_r("g <- function() parent.frame(-1)\ng()\n").is_err());
+    }
+
+    /// `is.environment` discriminates environments from everything else.
+    #[test]
+    fn r23_is_environment_predicate() {
+        assert_eq!(show("is.environment(new.env())\n"), "[1] TRUE");
+        assert_eq!(show("is.environment(globalenv())\n"), "[1] TRUE");
+        assert_eq!(show("is.environment(1)\n"), "[1] FALSE");
+        assert_eq!(show("is.environment(\"e\")\n"), "[1] FALSE");
+        assert_eq!(show("is.environment(function() 1)\n"), "[1] FALSE");
+    }
+
+    /// Regression: R-20..R-22 still work after the R-23 call-stack change
+    /// (the frame now carries a caller env alongside the Recall closure).
+    #[test]
+    fn r20_through_r22_still_work_after_r23() {
+        // R-20: anonymous recursion via Recall (reads the frame's closure).
+        assert_eq!(
+            nums("(function(n) if (n <= 1) 1 else n * Recall(n - 1))(5)\n"),
+            vec![120.0]
+        );
+        // R-21: counter closure via `<<-`.
+        let counter = "make <- function() { n <- 0; function() { n <<- n + 1; n } }\n\
+                       c1 <- make()\nc1(); c1(); c1()\n";
+        assert_eq!(nums(counter), vec![3.0]);
+        // R-22: by-reference mutation through an env value.
+        let byref = "e <- new.env()\n\
+                     f <- function(env) assign(\"x\", 8, envir = env)\nf(e)\nget(\"x\", envir = e)\n";
+        assert_eq!(nums(byref), vec![8.0]);
+        // R-22: env can hold itself, still safe.
+        assert_eq!(
+            show("e <- new.env()\nassign(\"self\", e, envir = e)\nexists(\"self\", envir = e)\n"),
+            "[1] TRUE"
+        );
+    }
 }

--- a/code/packages/rust/s-runtime/CHANGELOG.md
+++ b/code/packages/rust/s-runtime/CHANGELOG.md
@@ -2,6 +2,49 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.19.0] - 2026-06-20
+
+### Added
+
+- **Closure environments & call-frame reflection (R-23)** — builds on the R-22
+  `SValue::Environment` value, the `MAX_ENVIRONMENTS` cap, and the R-20 call
+  stack. Grammar-free; lives in the shared runtime so both S and R inherit it.
+  - **`environment(f)`** — the environment a closure **captured** at definition,
+    read straight from `Closure { env, .. }` and handed back as an
+    `SValue::Environment`. A non-closure argument (a builtin, a number, …) returns
+    `NULL`, matching R (`environment(sum)`). `environment()` (no argument)
+    continues to return the current scope. Reifying either env counts against
+    `MAX_ENVIRONMENTS`.
+  - **`environment(f) <- e`** — a new `environment<-` builtin wired through the
+    R-15/R-16 replacement-function lvalue path. Returns a *fresh* `Closure` with
+    its `env` swapped (closures are immutable values; the variable is rebound, as
+    in R), so the re-homed closure's free variables now resolve from `e`'s chain.
+    A non-closure target or non-environment value is a clean error.
+  - **`environmentName(e)`** — `"R_GlobalEnv"` / `"R_EmptyEnv"` / `""` decided by
+    `Rc` **pointer** identity (`env::same_env`, `Rc::ptr_eq`) against the
+    interpreter's long-lived `global`/`empty` handles — O(1), re-entrancy-safe
+    (never borrows the `RefCell`).
+  - **`globalenv()` / `emptyenv()` / `baseenv()`** — the well-known environments
+    as values. `globalenv()`/`baseenv()` both return the session global env
+    (no separate base namespace yet, so `baseenv()` aliases global — documented);
+    `emptyenv()` returns a new long-lived **empty** root (`Scope::empty`: no
+    parent, no bindings). All three hand back the *same* `Rc` each call and
+    allocate nothing, so none counts against `MAX_ENVIRONMENTS`.
+  - **`parent.frame(n = 1)`** — the **caller's** environment `n` frames up. The
+    call stack now records a `(closure, caller_env)` `CallFrame` per call (R-20
+    recorded only the closure, for `Recall`); `call_closure` pushes the env the
+    call expression was evaluated in, and `parent.frame` reads it. **Clamps** to
+    the global env past the bottom of the live stack (and at top level), so it
+    never indexes out of bounds or panics; `n` must be a positive, finite whole
+    number, else a clean `BadArgs`.
+  - **`is.environment(x)`** — scalar type predicate.
+  - **Ownership model unchanged.** The caller env on the call stack is dropped
+    when its frame is popped (the RAII `CallFrameGuard`), so it never outlives the
+    call; the captured-env exposure is the same strong-`Rc` situation as
+    `environment()`, bounded by the same `MAX_ENVIRONMENTS` cap; the `Weak` parent
+    link still prevents any parent-chain cycle. `env.rs` gains `Scope::empty` and
+    `same_env`.
+
 ## [0.18.0] - 2026-06-20
 
 ### Added

--- a/code/packages/rust/s-runtime/README.md
+++ b/code/packages/rust/s-runtime/README.md
@@ -118,7 +118,15 @@ a hand-written loop. See [What "S-flavored" means here](#what-s-flavored-means-h
   `Weak`: an env value owns the only strong `Rc` to its scope, parents are
   referenced but never owned, so no strong-`Rc` cycle is constructible from
   source. An environment prints as the stable placeholder `<environment>`, never a
-  heap address. `environment(f)` / `environmentName` are deferred to R-23.
+  heap address.
+- **Closure environments & frame reflection** (R-23): `environment(f)` is the env
+  a closure captured at definition (non-closure → `NULL`); `environment(f) <- e`
+  re-homes a closure via the replacement-function lvalue path; `environmentName(e)`
+  is `"R_GlobalEnv"` / `"R_EmptyEnv"` / `""` by `Rc` identity; `globalenv()` /
+  `emptyenv()` / `baseenv()` return the well-known envs (`baseenv()` aliases
+  global); `parent.frame(n = 1)` is the caller's env, recorded on the R-20 call
+  stack and **clamped** to global past the bottom rather than panicking;
+  `is.environment(x)` is the type predicate.
 - The **`d`/`p`/`q`/`r` distribution family** (R-8) over `statistics-core`:
   density/CDF/quantile/sampling for the normal, uniform, and exponential
   distributions, plus `set.seed` for a reproducible per-session RNG.

--- a/code/packages/rust/s-runtime/src/builtins.rs
+++ b/code/packages/rust/s-runtime/src/builtins.rs
@@ -86,6 +86,13 @@ pub fn install(env: &Env) {
     define(env, "any", builtin("any", b_any));
     define(env, "all", builtin("all", b_all));
     define(env, "is.na", builtin("is.na", b_is_na));
+    // R-23 — environment predicate + the `environment(f) <- e` replacement.
+    define(env, "is.environment", builtin("is.environment", b_is_environment));
+    define(
+        env,
+        "environment<-",
+        builtin("environment<-", b_environment_replace),
+    );
     define(env, "cumsum", builtin("cumsum", b_cumsum));
     define(env, "cumprod", builtin("cumprod", b_cumprod));
     define(env, "paste", builtin("paste", b_paste));
@@ -1799,6 +1806,63 @@ fn b_is_na(_interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
             .collect(),
     };
     Ok(SValue::Logical(flags))
+}
+
+/// `is.environment(x)` (R-23) — `TRUE` iff `x` is a first-class environment
+/// value, `FALSE` otherwise. A scalar predicate matching R: it inspects the
+/// single value's *type*, so `is.environment(new.env())` is `TRUE` and
+/// `is.environment(1)` / `is.environment("e")` are `FALSE`. The tests assert a
+/// closure's captured env through this (`is.environment(environment(f))`).
+fn b_is_environment(_interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
+    let v = first_positional(args)?;
+    Ok(SValue::Logical(vec![Some(matches!(
+        v,
+        SValue::Environment(_)
+    ))]))
+}
+
+/// `environment(f) <- e` (R-23), reached through the R-15/R-16 replacement-
+/// function lvalue path (`f(x) <- v` ≡ ``x <- `f<-`(x, v)``). The replacement
+/// convention passes `(x, value)`: `x` is the closure whose captured environment
+/// is being set (positional[0]); `value` is the new environment (the `value =`
+/// named arg, or positional[1]).
+///
+/// Closures are **immutable values** here, so we return a *fresh* `Closure` with
+/// its `env` field swapped to `e` and the same `params`/`body` (the caller — the
+/// replacement-assignment desugaring — rebinds the variable to this result, as R
+/// does). The new closure now closes over `e`, so free variables in its body
+/// resolve from `e`'s chain. Errors are clean (never panics): a non-closure `x`
+/// is a `TypeError`, a missing or non-environment `value` is a `BadArgs`.
+fn b_environment_replace(_interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
+    let x = first_positional(args)?.clone();
+    let value = args
+        .iter()
+        .find(|a| a.name.as_deref() == Some("value"))
+        .map(|a| a.value.clone())
+        .or_else(|| nth_positional(args, 1).cloned())
+        .ok_or_else(|| {
+            SError::BadArgs("environment(f) <- value: the replacement value is missing".into())
+        })?;
+    let new_env = match value {
+        SValue::Environment(e) => e,
+        other => {
+            return Err(SError::BadArgs(format!(
+                "environment(f) <- value: value must be an environment, got {}",
+                other.type_name()
+            )))
+        }
+    };
+    match x {
+        SValue::Closure { params, body, .. } => Ok(SValue::Closure {
+            params,
+            body,
+            env: new_env,
+        }),
+        other => Err(SError::TypeError(format!(
+            "environment(f) <- value: f must be a closure, got {}",
+            other.type_name()
+        ))),
+    }
 }
 
 /// `cumsum(x)` — running totals (delegates to statistics-core).

--- a/code/packages/rust/s-runtime/src/env.rs
+++ b/code/packages/rust/s-runtime/src/env.rs
@@ -102,6 +102,32 @@ impl Scope {
             parent: Some(Rc::downgrade(parent)),
         }))
     }
+
+    /// Create *the* empty environment (R-23) — a parentless scope with no
+    /// bindings. This is the terminus R exposes as `emptyenv()`: structurally
+    /// identical to [`Scope::global`] (both are parentless roots) but kept as a
+    /// **separate** long-lived handle on the interpreter so that
+    /// `environmentName` can tell the two apart by `Rc` pointer identity. It owns
+    /// no builtins and is never written to, so a lookup that walks *up to* it (a
+    /// chain rooted at the empty env) simply finds nothing and stops — exactly R's
+    /// behaviour for the empty environment.
+    pub fn empty() -> Env {
+        Rc::new(RefCell::new(Scope {
+            vars: HashMap::new(),
+            parent: None,
+        }))
+    }
+}
+
+/// Reference (pointer) equality of two environment handles: do `a` and `b` name
+/// the *same* underlying scope? This is the identity test R's `identical()` and
+/// `environmentName` use — two environments are "the same" iff they share one
+/// `Rc<RefCell<Scope>>`, never by comparing their (mutable) contents. Uses
+/// [`Rc::ptr_eq`], so it is O(1) and never borrows the `RefCell` (so it can never
+/// trip a re-entrant-borrow panic, even if called while a scope is mutably
+/// borrowed elsewhere).
+pub fn same_env(a: &Env, b: &Env) -> bool {
+    Rc::ptr_eq(a, b)
 }
 
 /// Upgrade a scope's parent link to a strong handle, or `None` if the scope is a

--- a/code/packages/rust/s-runtime/src/eval.rs
+++ b/code/packages/rust/s-runtime/src/eval.rs
@@ -17,7 +17,7 @@
 //! call) is visible, exactly as in S.
 
 use crate::builtins;
-use crate::env::{define, exists, lookup, names_in, remove, super_assign, Env, Scope};
+use crate::env::{define, exists, lookup, names_in, remove, same_env, super_assign, Env, Scope};
 use crate::error::{SError, SResult};
 use crate::value::{
     arithmetic, assign_index, assign_index2d, bounded_sequence, class_of, compare, format_value,
@@ -44,6 +44,12 @@ pub struct Outcome {
 /// accumulated `print()` output and the current visibility flag.
 pub struct Interpreter {
     global: Env,
+    /// The session's **empty** environment (R-23): a parentless, bindingless root
+    /// owned for the whole session, exactly like `global`. It is what `emptyenv()`
+    /// returns and what `environmentName` recognises as `"R_EmptyEnv"`. Kept as a
+    /// distinct strong `Rc` (never the same allocation as `global`) so the two can
+    /// be told apart by `Rc` pointer identity. See [`Scope::empty`].
+    empty: Env,
     out: RefCell<String>,
     visible: Cell<bool>,
     /// Current `eval_node` recursion depth, bounded by [`MAX_EVAL_DEPTH`] so
@@ -79,14 +85,31 @@ pub struct Interpreter {
     /// hits a clean error at the cap instead. The cap is far beyond any realistic
     /// program's environment count.
     envs_created: Cell<usize>,
-    /// The stack of closures currently being evaluated, innermost last (R-20).
-    /// `call_closure` pushes the function it is about to run and pops it on the
-    /// way out (via an RAII guard, so an early-return/error still pops), so the
-    /// top is always "the function we are inside right now". `Recall()` reads the
-    /// top to re-invoke the enclosing function for anonymous recursion. Its depth
-    /// is naturally bounded by [`MAX_EVAL_DEPTH`] — every nested call increments
-    /// the eval depth — so it cannot grow without limit.
-    call_stack: RefCell<Vec<SValue>>,
+    /// The stack of call frames currently being evaluated, innermost last
+    /// (R-20 / R-23). Each [`CallFrame`] records both the **closure** being run
+    /// (so `Recall()` can re-invoke the enclosing function for anonymous
+    /// recursion) and the **caller's environment** — the scope in which the call
+    /// expression was evaluated — so `parent.frame()` (R-23) can reflect the
+    /// caller's frame. `call_closure` pushes a frame before running the body and
+    /// pops it on the way out via an RAII guard, so an early-return/error still
+    /// pops and the top is always "the call we are inside right now". Its depth is
+    /// naturally bounded by [`MAX_EVAL_DEPTH`] — every nested call increments the
+    /// eval depth — so it cannot grow without limit, and because the caller env is
+    /// dropped when its frame is popped it never outlives the call (no extra
+    /// Rc-lifetime exposure beyond the live call).
+    call_stack: RefCell<Vec<CallFrame>>,
+}
+
+/// One entry on the interpreter's call stack (R-23). Pairs the closure being run
+/// (for `Recall`) with the environment of its **caller** (for `parent.frame()`).
+#[derive(Clone)]
+struct CallFrame {
+    /// The closure currently executing in this frame (reconstructed cheaply from
+    /// its `Rc` parts at the call site). Read by `Recall()`.
+    closure: SValue,
+    /// The environment in which the call expression was evaluated — i.e. the
+    /// *caller's* current scope. Read by `parent.frame()`.
+    caller: Env,
 }
 
 /// The most warnings retained per program. Beyond this, further `warning()`
@@ -126,15 +149,17 @@ impl Drop for DepthGuard<'_> {
     }
 }
 
-/// RAII guard that pushes a closure onto the interpreter's call stack (R-20) on
-/// construction and pops it on drop, so the stack stays balanced even when the
-/// closure body returns early via `?` or raises an error. `Recall()` reads the
-/// top of this stack to re-invoke the enclosing function.
-struct CallFrameGuard<'a>(&'a RefCell<Vec<SValue>>);
+/// RAII guard that pushes a [`CallFrame`] onto the interpreter's call stack
+/// (R-20 / R-23) on construction and pops it on drop, so the stack stays balanced
+/// even when the closure body returns early via `?` or raises an error.
+/// `Recall()` reads the top frame's closure; `parent.frame()` reads its caller
+/// env. Because the frame (and the `Rc` to the caller env it holds) is dropped
+/// here, the caller env never outlives the call.
+struct CallFrameGuard<'a>(&'a RefCell<Vec<CallFrame>>);
 
 impl<'a> CallFrameGuard<'a> {
-    fn push(stack: &'a RefCell<Vec<SValue>>, f: SValue) -> Self {
-        stack.borrow_mut().push(f);
+    fn push(stack: &'a RefCell<Vec<CallFrame>>, frame: CallFrame) -> Self {
+        stack.borrow_mut().push(frame);
         CallFrameGuard(stack)
     }
 }
@@ -158,6 +183,8 @@ impl Interpreter {
         builtins::install(&global);
         Interpreter {
             global,
+            // A distinct parentless root — the `emptyenv()` terminus (R-23).
+            empty: Scope::empty(),
             out: RefCell::new(String::new()),
             visible: Cell::new(false),
             depth: Cell::new(0),
@@ -182,10 +209,33 @@ impl Interpreter {
         Ok(())
     }
 
-    /// The function currently being evaluated, if any — the top of the call
-    /// stack. `Recall()` (R-20) uses this to re-invoke the enclosing closure.
+    /// The function currently being evaluated, if any — the closure of the top
+    /// call frame. `Recall()` (R-20) uses this to re-invoke the enclosing closure.
     pub(crate) fn current_function(&self) -> Option<SValue> {
-        self.call_stack.borrow().last().cloned()
+        self.call_stack
+            .borrow()
+            .last()
+            .map(|frame| frame.closure.clone())
+    }
+
+    /// The caller's environment `n` frames up the call stack (R-23,
+    /// `parent.frame(n)`). `n == 1` is the immediate caller (the top frame's
+    /// recorded caller env); larger `n` walks further out. **Clamps** rather than
+    /// indexes: an `n` that reaches past the bottom of the live stack (or
+    /// `parent.frame()` evaluated at top level, where there is no enclosing call)
+    /// falls back to the **global** environment, matching R's `R_GlobalEnv`
+    /// terminus — so this can never index out of bounds or panic. `n` is a 1-based
+    /// frame count; the caller has already validated `n >= 1`.
+    pub(crate) fn caller_frame(&self, n: usize) -> Env {
+        let stack = self.call_stack.borrow();
+        // The top frame (last) is `parent.frame(1)`; the k-th from the top is
+        // `parent.frame(k)`. `n.checked_sub(1)` and `len.checked_sub(n)` keep the
+        // arithmetic panic-free; any underflow (n past the bottom) clamps to
+        // global below.
+        match stack.len().checked_sub(n) {
+            Some(idx) => stack[idx].caller.clone(),
+            None => Rc::clone(&self.global),
+        }
     }
 
     /// Record and print a warning raised by `warning(...)`. The buffer is capped
@@ -873,6 +923,11 @@ impl Interpreter {
                         "new.env" => self.eval_new_env(&raw, env),
                         "environment" => self.eval_environment(&raw, env),
                         "ls" => self.eval_ls(&raw, env),
+                        // R-23 closure environments & frame reflection.
+                        "environmentName" => self.eval_environment_name(&raw, env),
+                        "globalenv" | "baseenv" => self.eval_globalenv(),
+                        "emptyenv" => self.eval_emptyenv(),
+                        "parent.frame" => self.eval_parent_frame(&raw, env),
                         _ => unreachable!(),
                     };
                 }
@@ -1004,7 +1059,7 @@ impl Interpreter {
     /// Apply a callable value at a top-level call site, applying S's result
     /// visibility rules (`print` is invisible and emits output; other calls are
     /// visible; a closure's body decides its own visibility).
-    fn apply(&self, callee: SValue, args: &[Arg], _env: &Env) -> SResult<SValue> {
+    fn apply(&self, callee: SValue, args: &[Arg], env: &Env) -> SResult<SValue> {
         match callee {
             SValue::Builtin { name, func } => {
                 let result = func(self, args)?;
@@ -1017,7 +1072,11 @@ impl Interpreter {
                     self.as_visible(result)
                 }
             }
-            SValue::Closure { params, body, env } => self.call_closure(&params, &body, &env, args),
+            // The call site's `env` is the *caller's* environment — record it on
+            // the frame so `parent.frame()` (R-23) inside the body can reflect it.
+            SValue::Closure { params, body, env: cenv } => {
+                self.call_closure(&params, &body, &cenv, env, args)
+            }
             SValue::Negated(inner) => self.as_visible(self.call_negated(&inner, args)?),
             other => Err(SError::NotCallable(other.type_name().to_string())),
         }
@@ -1040,7 +1099,17 @@ impl Interpreter {
     pub(crate) fn call_value(&self, callee: SValue, args: &[Arg]) -> SResult<SValue> {
         match callee {
             SValue::Builtin { func, .. } => func(self, args),
-            SValue::Closure { params, body, env } => self.call_closure(&params, &body, &env, args),
+            // Invoked from a builtin (e.g. `sapply`/`Reduce`/`do.call`), there is
+            // no R-level caller frame to thread through. The caller env is taken to
+            // be the **global** environment, so a `parent.frame()` inside such a
+            // callback sees the global frame — a faithful, panic-free default
+            // (R itself reports the calling context here, which for our purposes is
+            // the top level). Threading a real caller env through every builtin is
+            // out of scope and far more invasive.
+            SValue::Closure { params, body, env } => {
+                let global = Rc::clone(&self.global);
+                self.call_closure(&params, &body, &env, &global, args)
+            }
             SValue::Negated(inner) => self.call_negated(&inner, args),
             other => Err(SError::NotCallable(other.type_name().to_string())),
         }
@@ -1051,20 +1120,26 @@ impl Interpreter {
         params: &[Param],
         body: &Rc<GrammarASTNode>,
         closure_env: &Env,
+        caller_env: &Env,
         args: &[Arg],
     ) -> SResult<SValue> {
-        // Record the function we are about to run so `Recall()` (R-20) can
-        // re-invoke it. The guard pops it again on the way out — including on an
-        // early `?`/error — so the stack stays balanced. Reconstructing the
+        // Record the call frame we are about to run: the function (so `Recall()`
+        // (R-20) can re-invoke it) and the *caller's* environment (so
+        // `parent.frame()` (R-23) can reflect it). The guard pops the frame again
+        // on the way out — including on an early `?`/error — so the stack stays
+        // balanced and the caller env never outlives the call. Reconstructing the
         // `Closure` value here is cheap: `params`/`body`/`env` are all `Rc`/clone
         // -friendly, and the alternative (threading the value through every call
         // site) is far more invasive.
         let _frame = CallFrameGuard::push(
             &self.call_stack,
-            SValue::Closure {
-                params: params.to_vec(),
-                body: Rc::clone(body),
-                env: Rc::clone(closure_env),
+            CallFrame {
+                closure: SValue::Closure {
+                    params: params.to_vec(),
+                    body: Rc::clone(body),
+                    env: Rc::clone(closure_env),
+                },
+                caller: Rc::clone(caller_env),
             },
         );
 
@@ -1557,24 +1632,110 @@ impl Interpreter {
         self.as_visible(SValue::Environment(scope))
     }
 
-    /// `environment()` — the **current** environment as a first-class value (R-22).
-    /// The `environment(f)` form (a closure's captured environment) is **deferred
-    /// to R-23**: it requires reaching into the `Closure { env, .. }` payload, a
-    /// smaller orthogonal follow-up. Passing any argument is therefore a clean
-    /// `BadArgs` error here, not a wrong answer.
+    /// `environment([f])` — the **current** environment (no argument, R-22) or, in
+    /// the R-23 `environment(f)` form, the environment a closure `f` **captured**
+    /// at definition. A `Closure` stores its defining scope in `Closure { env }`;
+    /// we hand it back as an `SValue::Environment`, so for a top-level closure
+    /// `identical(environment(f), globalenv())` is `TRUE`. A non-closure argument
+    /// (a builtin, a number, …) yields `NULL`, matching R (`environment(sum)` is
+    /// `NULL`). Reifying *either* environment counts against `MAX_ENVIRONMENTS`
+    /// (both can participate in a value-binding cycle).
     fn eval_environment(&self, raw: &[RawArg], env: &Env) -> SResult<SValue> {
-        if raw.iter().any(|(_, n)| arm_body(n).is_some()) {
-            return Err(SError::BadArgs(
-                "environment(f): a closure's captured environment is deferred to R-23; \
-                 environment() with no argument returns the current environment"
-                    .into(),
-            ));
+        // The `environment(f)` form: a single argument with a body expression.
+        if let Some(arg_node) = raw.iter().find_map(|(_, n)| arm_body(n)) {
+            let value = self.eval_node(arg_node, env)?;
+            return match value {
+                // A closure carries its captured (defining) environment.
+                SValue::Closure { env: captured, .. } => {
+                    self.account_environment()?;
+                    self.as_visible(SValue::Environment(captured))
+                }
+                // R returns NULL for a primitive/builtin or any non-closure.
+                _ => self.as_visible(SValue::Null),
+            };
         }
         // `environment()` reifies the current scope as a value too — count it
         // against the same cap (it can equally participate in a value-binding
         // cycle, e.g. `assign("self", environment(), envir = environment())`).
         self.account_environment()?;
         self.as_visible(SValue::Environment(Rc::clone(env)))
+    }
+
+    /// `environmentName(e)` (R-23) — the well-known *name* of an environment:
+    /// `"R_GlobalEnv"` for the session global env, `"R_EmptyEnv"` for the empty
+    /// env, and `""` for every other environment (R does not name anonymous
+    /// frames). Identity is by `Rc` **pointer** equality against the interpreter's
+    /// long-lived `global`/`empty` handles — never by comparing contents — so it
+    /// is O(1) and re-entrancy-safe. A non-environment argument is a clean
+    /// `BadArgs` error.
+    fn eval_environment_name(&self, raw: &[RawArg], env: &Env) -> SResult<SValue> {
+        let node = self
+            .positional_nodes(raw)
+            .into_iter()
+            .next()
+            .ok_or_else(|| SError::BadArgs("environmentName: the environment is missing".into()))?;
+        let target = match self.eval_node(node, env)? {
+            SValue::Environment(e) => e,
+            other => {
+                return Err(SError::BadArgs(format!(
+                    "environmentName: expected an environment, got {}",
+                    other.type_name()
+                )))
+            }
+        };
+        let name = if same_env(&target, &self.global) {
+            "R_GlobalEnv"
+        } else if same_env(&target, &self.empty) {
+            "R_EmptyEnv"
+        } else {
+            ""
+        };
+        self.as_visible(SValue::Character(vec![Some(name.to_string())]))
+    }
+
+    /// `globalenv()` / `baseenv()` (R-23) — the session **global** environment as
+    /// a value. This runtime installs its builtins directly into the global frame
+    /// (there is no separate base namespace), so `baseenv()` deliberately aliases
+    /// the global env — documented in the spec. Hands back the *same* `Rc` every
+    /// call (so `identical(globalenv(), globalenv())` holds); allocates nothing, so
+    /// it does not count against `MAX_ENVIRONMENTS`.
+    fn eval_globalenv(&self) -> SResult<SValue> {
+        self.as_visible(SValue::Environment(Rc::clone(&self.global)))
+    }
+
+    /// `emptyenv()` (R-23) — the session **empty** environment as a value (the
+    /// parentless, bindingless root). Same `Rc` every call; allocates nothing.
+    fn eval_emptyenv(&self) -> SResult<SValue> {
+        self.as_visible(SValue::Environment(Rc::clone(&self.empty)))
+    }
+
+    /// `parent.frame(n = 1)` (R-23) — the environment of the **caller** `n` frames
+    /// up the call stack. R-20's call stack already records the closure being run;
+    /// R-23 records the caller's env alongside it, which this reads. `n` defaults
+    /// to `1` (the immediate caller) and must be a **positive whole number**; a
+    /// non-positive, non-finite, or non-numeric `n` is a clean `BadArgs` error.
+    /// The walk **clamps** to the global env past the bottom of the stack (or at
+    /// top level), so it can never index out of bounds — see
+    /// [`Interpreter::caller_frame`].
+    fn eval_parent_frame(&self, raw: &[RawArg], env: &Env) -> SResult<SValue> {
+        let n = match self.positional_nodes(raw).into_iter().next() {
+            None => 1usize,
+            Some(node) => {
+                let v = self.eval_node(node, env)?;
+                let x = scalar_f64(&v).map_err(|_| {
+                    SError::BadArgs("parent.frame: n must be a single number".into())
+                })?;
+                if !x.is_finite() || x < 1.0 {
+                    return Err(SError::BadArgs(
+                        "parent.frame: n must be a positive whole number".into(),
+                    ));
+                }
+                // Truncate toward zero (R coerces to integer); we have x >= 1.0 and
+                // finite, so this is a safe, bounded cast.
+                x as usize
+            }
+        };
+        self.as_visible(SValue::Environment(self.caller_frame(n)))
     }
 
     /// `ls([envir = e])` — the names bound **directly** in the target frame (not
@@ -1716,6 +1877,15 @@ fn special_form_name(primary: &GrammarASTNode) -> Option<&'static str> {
         [("NAME", "new.env")] => Some("new.env"),
         [("NAME", "environment")] => Some("environment"),
         [("NAME", "ls")] => Some("ls"),
+        // R-23 closure environments & frame reflection. These also need the
+        // *current* environment (`parent.frame` reads the caller frame; the
+        // others read the interpreter's well-known handles), so they are special
+        // forms too. The dotted `parent.frame` lexes as a single `NAME` token.
+        [("NAME", "environmentName")] => Some("environmentName"),
+        [("NAME", "globalenv")] => Some("globalenv"),
+        [("NAME", "emptyenv")] => Some("emptyenv"),
+        [("NAME", "baseenv")] => Some("baseenv"),
+        [("NAME", "parent.frame")] => Some("parent.frame"),
         _ => None,
     }
 }

--- a/code/packages/rust/s-runtime/src/lib.rs
+++ b/code/packages/rust/s-runtime/src/lib.rs
@@ -1677,23 +1677,49 @@ mod r22_environments {
         assert_eq!(nums(src), vec![1.0]);
     }
 
-    /// `environment(f)` (a closure's captured env) is deferred to R-23 — a clean
-    /// error, not a wrong answer.
+    /// `environment(f)` (a closure's captured env) now lands in R-23: for a
+    /// top-level closure it is the global env, so it is an environment value.
     #[test]
-    fn environment_of_a_function_is_deferred() {
-        assert!(eval_s("f <- function() 1\nenvironment(f)\n").is_err());
+    fn environment_of_a_function_is_the_captured_env() {
+        assert_eq!(
+            show("f <- function() 1\nis.environment(environment(f))\n"),
+            "[1] TRUE"
+        );
+        // A non-closure argument yields NULL (R's `environment(sum)` is NULL).
+        assert_eq!(show("environment(1)\n"), "NULL");
     }
 
-    /// Hardening: degenerate inputs to the R-22 forms must never panic.
+    /// R-23 well-known environment names (S syntax).
+    #[test]
+    fn r23_environment_names() {
+        assert_eq!(
+            show("environmentName(globalenv())\n"),
+            "[1] \"R_GlobalEnv\""
+        );
+        assert_eq!(show("environmentName(emptyenv())\n"), "[1] \"R_EmptyEnv\"");
+        assert_eq!(show("environmentName(new.env())\n"), "[1] \"\"");
+        // baseenv aliases the global env in this runtime.
+        assert_eq!(show("environmentName(baseenv())\n"), "[1] \"R_GlobalEnv\"");
+    }
+
+    /// Hardening: degenerate inputs to the R-22/R-23 forms must never panic.
     #[test]
     fn r22_forms_do_not_panic() {
         for src in [
-            "new.env(1, 2, 3)\n",                  // extra args ignored
-            "environment(1)\n",                    // environment(f) deferred → error
-            "ls(1)\n",                             // non-env positional → error
-            "ls(envir = 1)\n",                     // non-env envir → error
-            "get(\"x\", envir = e)\n",             // envir refers to an unbound name
-            "assign(\"x\", 1, envir = list(1))\n", // non-env envir → error
+            "new.env(1, 2, 3)\n",                    // extra args ignored
+            "environment(1)\n",                      // non-closure → NULL
+            "ls(1)\n",                               // non-env positional → error
+            "ls(envir = 1)\n",                       // non-env envir → error
+            "get(\"x\", envir = e)\n",               // envir refers to an unbound name
+            "assign(\"x\", 1, envir = list(1))\n",   // non-env envir → error
+            "environmentName(1)\n",                  // non-env → error
+            "environmentName()\n",                   // missing arg → error
+            "parent.frame(0)\n",                     // n < 1 → error
+            "parent.frame(-3)\n",                    // negative n → error
+            "parent.frame(1000000)\n",               // n past the bottom → clamps
+            "parent.frame()\n",                      // top-level → clamps to global
+            "f <- function() 1\nenvironment(f) <- 1\n", // non-env value → error
+            "environment(\"x\") <- globalenv()\n",   // non-closure target → error
         ] {
             let _ = eval_s(src);
         }

--- a/code/specs/R00-r-language.md
+++ b/code/specs/R00-r-language.md
@@ -497,9 +497,8 @@ unchanged.
     two independent environments. A lazy special form (it needs the current
     `env`).
   - **`environment()`** — the **current** environment as a value. The
-    `environment(f)` form (a closure's captured environment) is **deferred to
-    R-23** with a clear note: it requires reaching into the `Closure { env, .. }`
-    payload, which is a smaller, orthogonal follow-up.
+    `environment(f)` form (a closure's captured environment) lands in **R-23**
+    (it reaches into the `Closure { env, .. }` payload).
   - **`envir = e` on `assign`/`get`/`exists`/`rm`** — operate on the passed
     environment **value** rather than the current scope. R-21's runtime rejection
     is replaced by the real behaviour: `assign("x", 1, envir = e)` binds `x` in
@@ -514,12 +513,79 @@ unchanged.
     otherwise copy-on-modify value semantics.
   - **`ls(envir = e)`** — the names bound directly in `e` (its own frame, not the
     enclosing chain), **sorted** as a character vector. `ls()` with no `envir`
-    lists the current environment. `environmentName` is **deferred to R-23**.
+    lists the current environment. `environmentName` lands in **R-23**.
   - **Printing.** An environment prints as `<environment>` — a **stable
     placeholder**, deliberately *not* the real heap address R shows
     (`<environment: 0x55...>`), so test output is deterministic across runs and
     platforms. Its implicit class is `"environment"` and `type_name` is
     `"environment"`.
+
+- **R-23 — closure environments & call-frame reflection** *(this PR)*. Builds
+  directly on the R-22 `SValue::Environment` value, the `MAX_ENVIRONMENTS` cap,
+  and the R-20 call stack. Everything lands in the shared `s-runtime`; no grammar
+  change (every name lexes as an ordinary identifier).
+  - **Two well-known environments held by the interpreter.** R-22 kept one
+    long-lived strong handle: `Interpreter::global`. R-23 adds a second, the
+    **empty** environment — a single root scope with **no parent and no bindings**
+    that the interpreter owns for the whole session (a strong `Rc`, exactly like
+    `global`). It is the terminus R uses for `emptyenv()` and the value that
+    `environmentName` recognises as `"R_EmptyEnv"`. Holding it on the interpreter
+    means `emptyenv()`/`globalenv()` hand back the *same* `Rc` every call, so
+    `identical`-style reference equality (pointer equality on the `Rc`) is stable.
+  - **`environment(f)`** — the environment a closure **captured** at definition.
+    A `Closure` already stores its defining scope in `Closure { env, .. }`; R-23
+    exposes that `env` as an `SValue::Environment`. For a closure defined at top
+    level this is the global env, so `identical(environment(f), globalenv())` is
+    `TRUE`. A non-closure argument (a builtin, a number, …) returns `NULL`,
+    matching R (`environment(sum)` is `NULL`). Reifying the captured env counts
+    against `MAX_ENVIRONMENTS` like any other reification — it can equally
+    participate in a value-binding cycle.
+  - **`environment(f) <- e`** — set a closure's captured environment, reusing the
+    R-15/R-16 replacement-function lvalue path (`f(x) <- v` ≡
+    ``x <- `f<-`(x, v)``). A new `environment<-` builtin takes the closure and the
+    replacement environment `value = e` and returns a **fresh** `Closure` with its
+    `env` field swapped (closures are immutable values; we rebind the variable, as
+    R does). The first argument must be a closure and `value` must be an
+    environment, else a clean `BadArgs`/`TypeError` (never a panic). Because the
+    new closure now closes over `e`, free variables in its body resolve from `e`'s
+    chain.
+  - **`environmentName(e)`** — `"R_GlobalEnv"` if `e` **is** the global env (`Rc`
+    pointer equality against `Interpreter::global`), `"R_EmptyEnv"` if it is the
+    empty env, `""` otherwise. A non-environment argument is a clean error.
+  - **`globalenv()` / `emptyenv()` / `baseenv()`** — the well-known environments
+    as values. `globalenv()` and `baseenv()` both return the session global env
+    (this runtime installs its builtins directly into the global frame — there is
+    no separate base namespace, so `baseenv()` aliases the global env, documented
+    as a deliberate simplification); `emptyenv()` returns the interpreter's empty
+    env. All three are lazy special forms (they need the interpreter, not the
+    current `env`); none allocate, so none counts against `MAX_ENVIRONMENTS`.
+  - **`parent.frame(n = 1)`** — the environment of the **caller** `n` frames up
+    the call stack. R-20's call stack recorded the *closure* being run (for
+    `Recall`); R-23 records the **caller's environment** alongside it, so a frame
+    is now `(closure, caller_env)`. `call_closure` pushes the env in which the
+    call expression was evaluated; `parent.frame()` reads the top caller env,
+    `parent.frame(n)` the n-th from the top. A binding the caller made is visible
+    through it: `g <- function() get("x", envir = parent.frame()); f <- function()
+    { x <- 42; g() }; f()` → `42`. **Clamping (not panicking) past the bottom.**
+    `n` larger than the live frame depth, or `parent.frame()` at top level, falls
+    back to the **global** environment — R returns `R_GlobalEnv` there — so the
+    walk can never index out of bounds. `n` must be a positive whole number; a
+    non-positive or non-finite `n` is a clean `BadArgs` error.
+  - **`is.environment(x)`** — `TRUE` iff `x` is an environment value, else
+    `FALSE` (the predicate the tests assert `environment(f)` through). A trivial
+    one-element logical, vectorised over… nothing (it inspects the single value's
+    type), matching R's scalar predicate.
+  - **Rc-cycle safety (unchanged model, two new exposure points).** R-23 hands out
+    two *new* kinds of environment value — a closure's captured env and a caller
+    frame's env — but neither widens the ownership model R-22 established. The
+    caller-env stored on the call stack is dropped when the frame is popped (the
+    RAII `CallFrameGuard`), so it never outlives the call; `parent.frame()` clones
+    the `Rc` out for the duration of one expression. A closure's captured env was
+    already reachable (the closure owned a strong `Rc` to it); exposing it as a
+    value adds another strong `Rc`, the same situation as `environment()`, and is
+    bounded by the same `MAX_ENVIRONMENTS` cap. The `Weak` parent link still
+    prevents any parent-chain cycle. `parent.frame(n)` clamps rather than indexes,
+    so a crafted deep `n` cannot panic.
 
 ## §4 Reuse strategy
 
@@ -533,12 +599,15 @@ unchanged.
 
 ## §5 Out of scope (for now)
 
-Pipes (`|>`) and backslash lambdas (`\(x)`); the `environment(f)` form (a
-closure's captured environment) and `environmentName` — **deferred to R-23** (the
-`SValue::Environment` value, `new.env()`, `environment()`, `ls(envir=)`, and the
-`envir = e` argument of `assign`/`get`/`exists`/`rm` all land in **R-22**);
-S4/R5/R6 OO; namespaces and `library()`; the C interface; graphics. These layer
-on later, following ST00.
+Pipes (`|>`) and backslash lambdas (`\(x)`). The `SValue::Environment` value,
+`new.env()`, `environment()`, `ls(envir=)`, and the `envir = e` argument of
+`assign`/`get`/`exists`/`rm` land in **R-22**; the `environment(f)` form,
+`environment(f) <-`, `environmentName`, `globalenv()`/`emptyenv()`/`baseenv()`,
+`parent.frame()`, and `is.environment()` land in **R-23**. Still out of scope:
+`sys.call`/`sys.function`/`match.call` and the rest of the call-introspection
+family; S4/R5/R6 OO; namespaces and `library()` (so `baseenv()` aliases the
+global env for now); the C interface; graphics. These layer on later, following
+ST00.
 
 ## §6 References
 

--- a/code/specs/S00-s-language.md
+++ b/code/specs/S00-s-language.md
@@ -426,6 +426,20 @@ essential: `switch("a", a = stop("no"), b = "ok")` must not raise, and a
    possible — a strong `Rc` stored inside its own scope, which `Rc` cannot reclaim
    without a tracing GC — and is a documented limitation bounded by a per-session
    `MAX_ENVIRONMENTS` cap rather than collected.
+6. **Closure environments & call-frame reflection (R-23, shared value).** Builds
+   on the R-22 variant. `s-runtime` gains a second long-lived interpreter handle —
+   the **empty** environment (a parentless, bindingless root, owned for the whole
+   session like the global env) — plus a closure's captured-env accessor and
+   replacer, and a **caller environment** recorded alongside the R-20 call-stack
+   closure so the caller's frame can be reflected. The S/R surface
+   (`environment(f)`, `environment(f) <-`, `environmentName`,
+   `globalenv()`/`emptyenv()`/`baseenv()`, `parent.frame()`, `is.environment()`)
+   is driven from the R frontend (R-23) but lives in `s-runtime`. No new ownership
+   risk: the caller env on the call stack is dropped when its frame is popped (RAII
+   guard), and the captured-env exposure is the same strong-`Rc` situation as
+   `environment()`, bounded by the same `MAX_ENVIRONMENTS` cap. `parent.frame(n)`
+   **clamps** to the global env past the bottom of the stack rather than indexing
+   out of bounds.
 
 ## §10 References
 


### PR DESCRIPTION
## R-23 — closure environments & call-frame reflection

Delivers the R-22-deferred `environment(f)` / `environmentName` plus call-frame reflection, all in the shared `s-runtime` (no grammar change; both S and R inherit it). Builds directly on R-22's `SValue::Environment`, the `MAX_ENVIRONMENTS` cap, and R-20's call stack.

### Shipped
- **`environment(f)`** — a closure's captured (defining) env as an `SValue::Environment` (read from `Closure { env, .. }`); non-closure → `NULL` (matches R's `environment(sum)`).
- **`environment(f) <- e`** — new `environment<-` builtin via the R-15/R-16 replacement-function lvalue path; returns a fresh `Closure` with its `env` swapped, so the re-homed closure's free variables resolve from `e`.
- **`environmentName(e)`** — `"R_GlobalEnv"` / `"R_EmptyEnv"` / `""`, decided by `Rc` pointer identity (`env::same_env`, `Rc::ptr_eq`) against the interpreter's long-lived `global`/`empty` handles.
- **`globalenv()` / `emptyenv()` / `baseenv()`** — well-known envs as values. `baseenv()` aliases the global env (no separate base namespace yet — documented); `emptyenv()` returns a new long-lived parentless/bindingless root (`Scope::empty`). None allocates per call, so none counts against the cap.
- **`parent.frame(n = 1)`** — the **caller's** env. The call stack now records a `(closure, caller_env)` `CallFrame` per call (R-20 recorded only the closure, for `Recall`); `parent.frame` reads the caller env and **clamps** to the global env past the bottom of the stack rather than indexing/panicking. `n` must be a positive finite whole number.
- **`is.environment(x)`** — scalar type predicate.

**`parent.frame()` shipped** — the scope guard's deferral path was not needed; the call-frame env plumbing was contained (one new `caller_env` field threaded through `call_closure`, populated from the existing call-site `env`).

### Rc-cycle safety
No change to the R-22 ownership model. The caller env recorded on the call stack is dropped when its frame is popped (RAII `CallFrameGuard::drop`, fires on early `?`/error too), so it never outlives the call — no frame→closure→env strong cycle persists. Exposing a closure's captured env is the same strong-`Rc` situation as `environment()`, bounded by the unchanged `MAX_ENVIRONMENTS` (2^20) cap. The `Weak` parent link still prevents any parent-chain cycle. `parent.frame(n)` uses `stack.len().checked_sub(n)` so it can never underflow/panic.

### Tests
- r-runtime: +12 R-syntax tests (environment(f) is-an-env / captures-global / NULL-for-non-closure; environmentName for global/empty/anon/base; environment(f) <- e re-homes a closure; parent.frame sees-caller-binding / two-deep / top-level-clamp / past-bottom-clamp / bad-n-error; is.environment; R-20..R-22 regression after the call-stack change). **148 pass.**
- s-runtime: updated the R-22 test that asserted `environment(f)` was deferred; added R-23 name + hardening cases (parent.frame(0)/(-3)/(1e6), non-env value, non-closure target — must not panic). **192 pass.** Coverage stays well above 80% (every new path — each getter, both error arms of `environment<-`, the clamp, the bad-`n` guard, the predicate — is exercised).

### Security review
A senior-Rust-security sub-agent reviewed `git diff origin/main...HEAD` focused on Rc cycles/leaks from the new env exposure, the `MAX_ENVIRONMENTS` cap, RefCell re-entrancy, the `parent.frame(n)` clamp, integer casts, and panics on user input. **Verdict: PASS** — no CRITICAL/HIGH/MEDIUM findings (one optional INFO: a huge finite `n` saturates on `as usize` but is then clamped to global — harmless).

`git diff` is functional-only (no workspace/crate-wide rustfmt churn; only the touched regions changed). Specs committed first (R00/S00), then impl, tests, CHANGELOGs, READMEs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
