### PR TITLE
feat(closurec): debugger statement end-to-end (CLOC21)

### DIFF
--- a/code/packages/rust/closure-emitter/CHANGELOG.md
+++ b/code/packages/rust/closure-emitter/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to the `coding-adventures-closure-emitter` crate will be documented in this file.
 
+## [0.15.0] - 2026-06-20
+
+### Added — CLOC21: emit `debugger;`
+
+New `emit_debugger` writes `debugger;`. The keyword is followed only by its
+terminator `;` (or, after the semi is popped, a `}`/EOF), so no token-separation
+handling is needed. `DebuggerStatement` is added to
+`last_stmt_uses_terminator_semi` — its `;` is popped before a closing `}` (e.g.
+`{debugger}`), like `return`/`throw`/expression statements. Added emitter unit
+tests for the keyword+semi, terminator-pop, and not-last (semi kept) cases.
+
 ## [0.14.0] - 2026-06-20
 
 ### Added — CLOC20: emit `do`/`while`

--- a/code/packages/rust/closure-emitter/Cargo.toml
+++ b/code/packages/rust/closure-emitter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-emitter"
-version = "0.14.0"
+version = "0.15.0"
 edition = "2021"
 description = "JavaScript code emitter for the Closure Compiler clone. Per CLOC07's emit contract. Takes a finalized Program + sidecar and produces output JavaScript text + companion source map. Runs after every pass in the pipeline."
 

--- a/code/packages/rust/closure-emitter/src/lib.rs
+++ b/code/packages/rust/closure-emitter/src/lib.rs
@@ -67,7 +67,7 @@ use coding_adventures_javascript_ast::{
     AssignmentTarget, BigIntLiteral, BinaryExpression, BinaryOperator, BlockStatement,
     BooleanLiteral,
     BreakStatement, CallExpression, CatchClause, ConditionalExpression, ContinueStatement,
-    Declaration, DoWhileStatement,
+    Declaration, DebuggerStatement, DoWhileStatement,
     EmptyStatement, Expression, ExpressionStatement, ForInit, ForStatement, FunctionDeclaration,
     FunctionParam, Identifier, IfStatement, LabeledStatement, LogicalExpression, LogicalOperator,
     MemberExpression, NullLiteral, NumericLiteral, ObjectExpression, Program, ProgramItem,
@@ -301,6 +301,7 @@ impl<'a> Emitter<'a> {
             TaggedStatement::SwitchStatement(s) => self.emit_switch(s),
             TaggedStatement::TryStatement(t) => self.emit_try(t),
             TaggedStatement::EmptyStatement(e) => self.emit_empty(e),
+            TaggedStatement::DebuggerStatement(d) => self.emit_debugger(d),
         }
     }
 
@@ -544,6 +545,14 @@ impl<'a> Emitter<'a> {
     fn emit_empty(&mut self, e: &EmptyStatement) {
         self.maybe_map(&e.cv);
         self.write_str(";");
+    }
+
+    fn emit_debugger(&mut self, d: &DebuggerStatement) {
+        // `debugger;` — the keyword plus a real terminator `;`. The keyword is
+        // followed only by `;` (or, after the semi is popped, a `}`/EOF), so no
+        // token-separation handling is needed.
+        self.maybe_map(&d.cv);
+        self.write_str("debugger;");
     }
 
     /// `label: stmt`. No trailing semicolon — the body statement
@@ -1325,6 +1334,9 @@ fn last_stmt_uses_terminator_semi(s: &Statement) -> bool {
                 // supply before a closing `}`, so it is safe to pop. (Plain
                 // `while(x)…` is NOT here: its trailing `;` is a body slot.)
                 | TaggedStatement::DoWhileStatement(_)
+                // `debugger;` ends in a real terminator `;`, poppable before a
+                // closing `}` (ASI re-supplies it). The `;` is NOT a body slot.
+                | TaggedStatement::DebuggerStatement(_)
         ),
         // Declarations are conservatively excluded. Both
         // VariableDeclaration and FunctionDeclaration end in
@@ -2505,6 +2517,49 @@ mod tests {
         let item = ProgramItem::Statement(Statement::block_statement(outer));
         let code = emit_default(program().with_body(vec![item])).code;
         assert_eq!(code, "{do{a}while(b)}");
+    }
+
+    // ---- debugger (CLOC21) ------------------------------------
+
+    #[test]
+    fn debugger_statement_emits_keyword_and_semi() {
+        let item = ProgramItem::Statement(Statement::debugger_statement(DebuggerStatement {
+            cv: None,
+        }));
+        let code = emit_default(program().with_body(vec![item])).code;
+        assert_eq!(code, "debugger;");
+    }
+
+    #[test]
+    fn debugger_as_last_block_statement_pops_terminator_semi() {
+        // Inside a block, the trailing `;` of `debugger;` is redundant before
+        // the closing `}` (ASI), so it is popped: `{debugger}`.
+        let outer = BlockStatement {
+            cv: None,
+            body: vec![Statement::debugger_statement(DebuggerStatement { cv: None })],
+        };
+        let item = ProgramItem::Statement(Statement::block_statement(outer));
+        let code = emit_default(program().with_body(vec![item])).code;
+        assert_eq!(code, "{debugger}");
+    }
+
+    #[test]
+    fn debugger_followed_by_statement_keeps_semi() {
+        // `debugger;` followed by another statement keeps its `;` (only the
+        // last statement in a block pops it).
+        let outer = BlockStatement {
+            cv: None,
+            body: vec![
+                Statement::debugger_statement(DebuggerStatement { cv: None }),
+                Statement::expression_statement(ExpressionStatement {
+                    cv: None,
+                    expression: ident("a"),
+                }),
+            ],
+        };
+        let item = ProgramItem::Statement(Statement::block_statement(outer));
+        let code = emit_default(program().with_body(vec![item])).code;
+        assert_eq!(code, "{debugger;a}");
     }
 
     #[test]

--- a/code/packages/rust/closure-pass-constant-fold/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-constant-fold/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to the `coding-adventures-closure-pass-constant-fold` crate will be documented in this file.
 
+## [0.14.0] - 2026-06-20
+
+### Added — CLOC21: handle `DebuggerStatement`
+
+`fold_tagged` now covers `DebuggerStatement` (grouped with the other childless
+leaf statements). A `debugger;` has no foldable sub-expressions, so it is
+returned unchanged — added to keep the match exhaustive over the new variant.
+
 ## [0.13.0] - 2026-06-20
 
 ### Added — CLOC20: fold inside `do`/`while`

--- a/code/packages/rust/closure-pass-constant-fold/Cargo.toml
+++ b/code/packages/rust/closure-pass-constant-fold/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-constant-fold"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 description = "Constant-folding optimization pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Folds compile-time-evaluable expressions like `2 + 3 → 5`."
 

--- a/code/packages/rust/closure-pass-constant-fold/src/lib.rs
+++ b/code/packages/rust/closure-pass-constant-fold/src/lib.rs
@@ -360,7 +360,8 @@ fn fold_tagged_statement(stmt: &TaggedStatement, st: &mut FoldState) -> TaggedSt
         }
         TaggedStatement::BreakStatement(_)
         | TaggedStatement::ContinueStatement(_)
-        | TaggedStatement::EmptyStatement(_) => stmt.clone(),
+        | TaggedStatement::EmptyStatement(_)
+        | TaggedStatement::DebuggerStatement(_) => stmt.clone(),
     }
 }
 

--- a/code/packages/rust/closure-pass-dce/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-dce/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to the `coding-adventures-closure-pass-dce` crate will be documented in this file.
 
+## [0.12.0] - 2026-06-20
+
+### Added — CLOC21: handle `DebuggerStatement`
+
+`dce_tagged_statement` now covers `DebuggerStatement` (grouped with the other
+childless leaf statements), preserved as-is. A `debugger;` is a no-op leaf with
+no bindings; stripping it is intentionally left as future work, so v1 keeps it.
+
 ## [0.11.0] - 2026-06-20
 
 ### Added — CLOC20: DCE inside `do`/`while`

--- a/code/packages/rust/closure-pass-dce/Cargo.toml
+++ b/code/packages/rust/closure-pass-dce/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-dce"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2021"
 description = "Dead-code elimination pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Drops code after definite-terminator statements and removes EmptyStatement noise."
 

--- a/code/packages/rust/closure-pass-dce/src/lib.rs
+++ b/code/packages/rust/closure-pass-dce/src/lib.rs
@@ -515,7 +515,10 @@ fn dce_tagged_statement(stmt: &TaggedStatement, st: &mut DceState) -> TaggedStat
         }
         TaggedStatement::BreakStatement(_)
         | TaggedStatement::ContinueStatement(_)
-        | TaggedStatement::EmptyStatement(_) => stmt.clone(),
+        | TaggedStatement::EmptyStatement(_)
+        // A `debugger;` statement is a childless leaf with no bindings — like
+        // EmptyStatement, DCE preserves it as-is. (Stripping it is future work.)
+        | TaggedStatement::DebuggerStatement(_) => stmt.clone(),
     }
 }
 

--- a/code/packages/rust/closure-pass-fold-control-flow/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-fold-control-flow/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to the `coding-adventures-closure-pass-fold-control-flow` crate will be documented in this file.
 
+## [0.11.0] - 2026-06-20
+
+### Added — CLOC21: handle `DebuggerStatement`
+
+The statement dispatch now covers `DebuggerStatement` (grouped with the other
+childless leaf statements), returned unchanged. Added to keep the match
+exhaustive over the new AST variant.
+
 ## [0.10.0] - 2026-06-20
 
 ### Added — CLOC20: fold control flow inside `do`/`while` (no dead-loop elision)

--- a/code/packages/rust/closure-pass-fold-control-flow/Cargo.toml
+++ b/code/packages/rust/closure-pass-fold-control-flow/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-fold-control-flow"
-version = "0.10.0"
+version = "0.11.0"
 edition = "2021"
 description = "Control-flow folding pass for the Closure Compiler clone. Slots between constant-fold and DCE per CLOC06's canonical pass set. Eliminates dead branches (`if (false) A else B → B`), removes unreachable code after `return`/`throw`, and collapses degenerate switch arms."
 

--- a/code/packages/rust/closure-pass-fold-control-flow/src/lib.rs
+++ b/code/packages/rust/closure-pass-fold-control-flow/src/lib.rs
@@ -325,7 +325,8 @@ fn fold_tagged_statement(stmt: &TaggedStatement, st: &mut FoldState) -> Statemen
         }
         TaggedStatement::BreakStatement(_)
         | TaggedStatement::ContinueStatement(_)
-        | TaggedStatement::EmptyStatement(_) => Statement::Tagged(stmt.clone()),
+        | TaggedStatement::EmptyStatement(_)
+        | TaggedStatement::DebuggerStatement(_) => Statement::Tagged(stmt.clone()),
     }
 }
 

--- a/code/packages/rust/closure-pass-inline-variables/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-inline-variables/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to the `coding-adventures-closure-pass-inline-variables` crate will be documented in this file.
 
+## [0.4.0] - 2026-06-20
+
+### Added — CLOC21: handle `DebuggerStatement`
+
+The statement walks (`count_decl_names_stmt`, `count_uses_stmt`,
+`propagate_in_stmt`) now cover `DebuggerStatement` (grouped with the other
+childless leaf statements) as a no-op. Added to keep the matches exhaustive over
+the new AST variant.
+
 ## [0.3.0] - 2026-06-20
 
 ### Added — CLOC20: variable inlining inside `do`/`while`

--- a/code/packages/rust/closure-pass-inline-variables/Cargo.toml
+++ b/code/packages/rust/closure-pass-inline-variables/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-inline-variables"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 description = "Constant-propagation pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Replaces references to a top-level `const` bound to a literal with the literal itself, so the binding becomes unused and remove-unused-vars deletes it."
 

--- a/code/packages/rust/closure-pass-inline-variables/src/lib.rs
+++ b/code/packages/rust/closure-pass-inline-variables/src/lib.rs
@@ -468,7 +468,8 @@ fn count_decl_names_stmt(
             | TaggedStatement::ThrowStatement(_)
             | TaggedStatement::BreakStatement(_)
             | TaggedStatement::ContinueStatement(_)
-            | TaggedStatement::EmptyStatement(_) => {}
+            | TaggedStatement::EmptyStatement(_)
+            | TaggedStatement::DebuggerStatement(_) => {}
         },
     }
 }
@@ -595,7 +596,8 @@ fn count_uses_stmt(stmt: &Statement, name: &str, count: &mut usize) {
             }
             TaggedStatement::BreakStatement(_)
             | TaggedStatement::ContinueStatement(_)
-            | TaggedStatement::EmptyStatement(_) => {}
+            | TaggedStatement::EmptyStatement(_)
+            | TaggedStatement::DebuggerStatement(_) => {}
         },
     }
 }
@@ -805,7 +807,8 @@ fn propagate_in_stmt(stmt: &mut Statement, cand: &ConstCandidate) -> bool {
             }
             TaggedStatement::BreakStatement(_)
             | TaggedStatement::ContinueStatement(_)
-            | TaggedStatement::EmptyStatement(_) => {}
+            | TaggedStatement::EmptyStatement(_)
+            | TaggedStatement::DebuggerStatement(_) => {}
         },
     }
     changed

--- a/code/packages/rust/closure-pass-inline/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-inline/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to the `coding-adventures-closure-pass-inline` crate will be documented in this file.
 
+## [0.18.0] - 2026-06-20
+
+### Added — CLOC21: handle `DebuggerStatement`
+
+Every phase of the pass now covers `DebuggerStatement` (grouped with the other
+childless leaf statements) as a no-op (`false` for the contains-function checks).
+Added to keep the matches exhaustive over the new AST variant.
+
 ## [0.17.0] - 2026-06-20
 
 ### Added — CLOC20: function inlining across `do`/`while`

--- a/code/packages/rust/closure-pass-inline/Cargo.toml
+++ b/code/packages/rust/closure-pass-inline/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-inline"
-version = "0.17.0"
+version = "0.18.0"
 edition = "2021"
 description = "Function-inlining pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Substitutes small or single-use function bodies at their call sites to enable downstream folding and shrink call overhead."
 

--- a/code/packages/rust/closure-pass-inline/src/lib.rs
+++ b/code/packages/rust/closure-pass-inline/src/lib.rs
@@ -616,7 +616,8 @@ fn count_decl_names_stmt(
             | TaggedStatement::ThrowStatement(_)
             | TaggedStatement::BreakStatement(_)
             | TaggedStatement::ContinueStatement(_)
-            | TaggedStatement::EmptyStatement(_) => {}
+            | TaggedStatement::EmptyStatement(_)
+            | TaggedStatement::DebuggerStatement(_) => {}
         },
     }
 }
@@ -827,7 +828,8 @@ fn tally_stmt(stmt: &Statement, cand: &InlineCandidate, t: &mut Tally) {
             // hold no variable uses.
             TaggedStatement::BreakStatement(_)
             | TaggedStatement::ContinueStatement(_)
-            | TaggedStatement::EmptyStatement(_) => {}
+            | TaggedStatement::EmptyStatement(_)
+            | TaggedStatement::DebuggerStatement(_) => {}
         },
     }
 }
@@ -1051,7 +1053,8 @@ fn inline_in_stmt(stmt: &mut Statement, cand: &InlineCandidate) -> bool {
             }
             TaggedStatement::BreakStatement(_)
             | TaggedStatement::ContinueStatement(_)
-            | TaggedStatement::EmptyStatement(_) => {}
+            | TaggedStatement::EmptyStatement(_)
+            | TaggedStatement::DebuggerStatement(_) => {}
         },
     }
     changed
@@ -1948,7 +1951,8 @@ fn splice_void_in_stmt(
             | TaggedStatement::ThrowStatement(_)
             | TaggedStatement::BreakStatement(_)
             | TaggedStatement::ContinueStatement(_)
-            | TaggedStatement::EmptyStatement(_) => false,
+            | TaggedStatement::EmptyStatement(_)
+            | TaggedStatement::DebuggerStatement(_) => false,
         },
     }
 }
@@ -2780,7 +2784,8 @@ fn splice_valued_in_stmt(
             | TaggedStatement::ThrowStatement(_)
             | TaggedStatement::BreakStatement(_)
             | TaggedStatement::ContinueStatement(_)
-            | TaggedStatement::EmptyStatement(_) => false,
+            | TaggedStatement::EmptyStatement(_)
+            | TaggedStatement::DebuggerStatement(_) => false,
         },
     }
 }
@@ -3101,7 +3106,8 @@ fn collect_used_idents_stmt(stmt: &Statement, out: &mut HashSet<String>) {
             }
             TaggedStatement::BreakStatement(_)
             | TaggedStatement::ContinueStatement(_)
-            | TaggedStatement::EmptyStatement(_) => {}
+            | TaggedStatement::EmptyStatement(_)
+            | TaggedStatement::DebuggerStatement(_) => {}
         },
     }
 }

--- a/code/packages/rust/closure-pass-rename-globals/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-rename-globals/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to the `coding-adventures-closure-pass-rename-globals` crate will be documented in this file.
 
+## [0.4.0] - 2026-06-20
+
+### Added — CLOC21: handle `DebuggerStatement`
+
+Every phase of the pass now covers `DebuggerStatement` (grouped with the other
+childless leaf statements) as a no-op. Added to keep the matches exhaustive over
+the new AST variant.
+
 ## [0.3.0] - 2026-06-20
 
 ### Added — CLOC20: global renaming across `do`/`while`

--- a/code/packages/rust/closure-pass-rename-globals/Cargo.toml
+++ b/code/packages/rust/closure-pass-rename-globals/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-rename-globals"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 description = "Aggressive top-level (global) renaming pass for the Closure Compiler clone — the ADVANCED-level complement to closure-pass-rename. Shortens program-private top-level names, gated by an externs do-not-rename boundary."
 

--- a/code/packages/rust/closure-pass-rename-globals/src/lib.rs
+++ b/code/packages/rust/closure-pass-rename-globals/src/lib.rs
@@ -392,7 +392,7 @@ fn count_decl_names_stmt(
             | TaggedStatement::ThrowStatement(_)
             | TaggedStatement::BreakStatement(_)
             | TaggedStatement::ContinueStatement(_)
-            | TaggedStatement::EmptyStatement(_) => {}
+            | TaggedStatement::EmptyStatement(_) | TaggedStatement::DebuggerStatement(_) => {}
         },
     }
 }
@@ -533,7 +533,7 @@ fn collect_all_idents_stmt(stmt: &Statement, out: &mut HashSet<String>) {
                     }
                 }
             }
-            TaggedStatement::EmptyStatement(_) => {}
+            TaggedStatement::EmptyStatement(_) | TaggedStatement::DebuggerStatement(_) => {}
         },
     }
 }
@@ -754,7 +754,7 @@ fn rename_apply_tagged(t: &mut TaggedStatement, map: &HashMap<String, String>) {
         // Labels live in a separate namespace from variables.
         TaggedStatement::BreakStatement(_)
         | TaggedStatement::ContinueStatement(_)
-        | TaggedStatement::EmptyStatement(_) => {}
+        | TaggedStatement::EmptyStatement(_) | TaggedStatement::DebuggerStatement(_) => {}
     }
 }
 

--- a/code/packages/rust/closure-pass-rename-properties/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-rename-properties/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to the `coding-adventures-closure-pass-rename-properties` crate will be documented in this file.
 
+## [0.6.0] - 2026-06-20
+
+### Added — CLOC21: handle `DebuggerStatement`
+
+`classify_stmt` and `rewrite_stmt` now cover `DebuggerStatement` (grouped with
+the other childless leaf statements) as a no-op. A `debugger;` has no property
+accesses — added to keep the matches exhaustive over the new AST variant.
+
 ## [0.5.0] - 2026-06-20
 
 ### Added — CLOC20: property renaming recurses through `do`/`while`

--- a/code/packages/rust/closure-pass-rename-properties/Cargo.toml
+++ b/code/packages/rust/closure-pass-rename-properties/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-rename-properties"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 description = "Aggressive property renaming pass for the Closure Compiler clone (ADVANCED-only). Consistently shortens program-private object property names that are never quoted/computed and not in the built-in or externs do-not-rename boundary."
 

--- a/code/packages/rust/closure-pass-rename-properties/src/lib.rs
+++ b/code/packages/rust/closure-pass-rename-properties/src/lib.rs
@@ -1066,7 +1066,8 @@ fn classify_stmt(stmt: &Statement, cls: &mut Classify, nodes_touched: &mut u32) 
             }
             TaggedStatement::BreakStatement(_)
             | TaggedStatement::ContinueStatement(_)
-            | TaggedStatement::EmptyStatement(_) => {}
+            | TaggedStatement::EmptyStatement(_)
+            | TaggedStatement::DebuggerStatement(_) => {}
         },
     }
 }
@@ -1261,7 +1262,8 @@ fn rewrite_stmt(stmt: &mut Statement, map: &HashMap<String, String>) {
             }
             TaggedStatement::BreakStatement(_)
             | TaggedStatement::ContinueStatement(_)
-            | TaggedStatement::EmptyStatement(_) => {}
+            | TaggedStatement::EmptyStatement(_)
+            | TaggedStatement::DebuggerStatement(_) => {}
         },
     }
 }

--- a/code/packages/rust/closure-pass-rename/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-rename/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to the `coding-adventures-closure-pass-rename` crate will be documented in this file.
 
+## [0.7.0] - 2026-06-20
+
+### Added — CLOC21: handle `DebuggerStatement`
+
+Every phase of the pass now covers `DebuggerStatement` (grouped with the other
+childless leaf statements) as a no-op. A `debugger;` binds and references
+nothing, so there is nothing to rename — added to keep the matches exhaustive
+over the new AST variant.
+
 ## [0.6.0] - 2026-06-20
 
 ### Added — CLOC20: local renaming across `do`/`while`

--- a/code/packages/rust/closure-pass-rename/Cargo.toml
+++ b/code/packages/rust/closure-pass-rename/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-rename"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 description = "Variable renaming pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Replaces non-exported binding names with shorter identifiers to reduce output size while preserving externally-visible names and semantics."
 

--- a/code/packages/rust/closure-pass-rename/src/lib.rs
+++ b/code/packages/rust/closure-pass-rename/src/lib.rs
@@ -311,7 +311,7 @@ fn process_tagged(t: &mut TaggedStatement, nodes_touched: &mut u32) -> bool {
         | TaggedStatement::ThrowStatement(_)
         | TaggedStatement::BreakStatement(_)
         | TaggedStatement::ContinueStatement(_)
-        | TaggedStatement::EmptyStatement(_) => {}
+        | TaggedStatement::EmptyStatement(_) | TaggedStatement::DebuggerStatement(_) => {}
     }
     changed
 }
@@ -397,7 +397,8 @@ fn stmt_has_function(stmt: &Statement) -> bool {
             | TaggedStatement::ThrowStatement(_)
             | TaggedStatement::BreakStatement(_)
             | TaggedStatement::ContinueStatement(_)
-            | TaggedStatement::EmptyStatement(_) => false,
+            | TaggedStatement::EmptyStatement(_)
+            | TaggedStatement::DebuggerStatement(_) => false,
         },
     }
 }
@@ -628,7 +629,7 @@ fn collect_decl_occurrences_stmt(stmt: &Statement, out: &mut Vec<(String, bool)>
             | TaggedStatement::ThrowStatement(_)
             | TaggedStatement::BreakStatement(_)
             | TaggedStatement::ContinueStatement(_)
-            | TaggedStatement::EmptyStatement(_) => {}
+            | TaggedStatement::EmptyStatement(_) | TaggedStatement::DebuggerStatement(_) => {}
         },
     }
 }
@@ -763,7 +764,7 @@ fn collect_all_idents_stmt(stmt: &Statement, out: &mut HashSet<String>) {
                     collect_all_idents_block(f, out);
                 }
             }
-            TaggedStatement::EmptyStatement(_) => {}
+            TaggedStatement::EmptyStatement(_) | TaggedStatement::DebuggerStatement(_) => {}
         },
     }
 }
@@ -961,7 +962,7 @@ fn rewrite_uses_tagged(t: &mut TaggedStatement, map: &HashMap<String, String>) {
         // the variable namespace — never rewritten.
         TaggedStatement::BreakStatement(_)
         | TaggedStatement::ContinueStatement(_)
-        | TaggedStatement::EmptyStatement(_) => {}
+        | TaggedStatement::EmptyStatement(_) | TaggedStatement::DebuggerStatement(_) => {}
     }
 }
 

--- a/code/packages/rust/closure-scope-analyzer/CHANGELOG.md
+++ b/code/packages/rust/closure-scope-analyzer/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to the `coding-adventures-closure-scope-analyzer` crate will be documented in this file.
 
+## [0.7.0] - 2026-06-20
+
+### Added — CLOC21: handle `DebuggerStatement`
+
+`walk_tagged_statement` now has a `DebuggerStatement` arm. A `debugger;` has no
+children and binds nothing, so the arm is a no-op — added only to keep the
+statement match exhaustive over the new AST variant.
+
 ## [0.6.0] - 2026-06-20
 
 ### Added — CLOC20: scope analysis for `do`/`while`

--- a/code/packages/rust/closure-scope-analyzer/Cargo.toml
+++ b/code/packages/rust/closure-scope-analyzer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-scope-analyzer"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 description = "Lexical scope + symbol-table analyzer for the Closure Compiler clone. Per CLOC13 — produces a `ScopeAnalysis` consumed by the rename, inline, treeshake, collapse-properties, and remove-unused-vars passes."
 

--- a/code/packages/rust/closure-scope-analyzer/src/lib.rs
+++ b/code/packages/rust/closure-scope-analyzer/src/lib.rs
@@ -700,6 +700,8 @@ fn walk_tagged_statement(
         TaggedStatement::BreakStatement(_) => {}
         TaggedStatement::ContinueStatement(_) => {}
         TaggedStatement::EmptyStatement(_) => {}
+        // `debugger;` has no children and binds nothing — nothing to analyze.
+        TaggedStatement::DebuggerStatement(_) => {}
     }
 }
 

--- a/code/packages/rust/javascript-ast/CHANGELOG.md
+++ b/code/packages/rust/javascript-ast/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to the `coding-adventures-javascript-ast` crate will be documented in this file.
 
+## [0.10.0] - 2026-06-20
+
+### Added — CLOC21: `DebuggerStatement` (`debugger;`)
+
+Adds `DebuggerStatement { cv }`, a new `TaggedStatement::DebuggerStatement`
+variant, and a `Statement::debugger_statement` constructor. Like
+`EmptyStatement` it carries no children. ESTree wire format:
+`{ "type": "DebuggerStatement" }`. Making it representable lets the closurec
+CLI optimize the rest of a program containing a `debugger` statement;
+previously any such program fell back to WHITESPACE_ONLY. v1 preserves the
+statement (stripping it, as upstream Closure does, is future work).
+
 ## [0.9.0] - 2026-06-20
 
 ### Added — CLOC20: `DoWhileStatement` (the test-after-body loop)

--- a/code/packages/rust/javascript-ast/Cargo.toml
+++ b/code/packages/rust/javascript-ast/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-javascript-ast"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2021"
 description = "Backend-agnostic JavaScript AST — full ESTree-compatible node taxonomy with optional per-node CV id. Reusable by the Closure-Compiler-clone and the future V8-in-Rust clone. Per CLOC02 / CLOC09."
 

--- a/code/packages/rust/javascript-ast/src/lib.rs
+++ b/code/packages/rust/javascript-ast/src/lib.rs
@@ -140,10 +140,10 @@ pub use expression::{
     StringLiteral, UnaryExpression, UnaryOperator, UndefinedLiteral,
 };
 pub use statement::{
-    BlockStatement, BreakStatement, CatchClause, ContinueStatement, DoWhileStatement,
-    EmptyStatement, ExpressionStatement, ForInit, ForStatement, IfStatement, LabeledStatement,
-    ReturnStatement, Statement, SwitchCase, SwitchStatement, ThrowStatement, TryStatement,
-    WhileStatement,
+    BlockStatement, BreakStatement, CatchClause, ContinueStatement, DebuggerStatement,
+    DoWhileStatement, EmptyStatement, ExpressionStatement, ForInit, ForStatement, IfStatement,
+    LabeledStatement, ReturnStatement, Statement, SwitchCase, SwitchStatement, ThrowStatement,
+    TryStatement, WhileStatement,
 };
 
 /// A correlation-vector identifier. Aliased to `String` for v1 to match

--- a/code/packages/rust/javascript-ast/src/statement.rs
+++ b/code/packages/rust/javascript-ast/src/statement.rs
@@ -31,8 +31,10 @@
 //!   test-after-body loop; unblocks the whitespace-only fallback on any
 //!   program using a do-while loop)
 //!
-//! Phase 2 will add `ForInStatement`, `ForOfStatement`,
-//! `DebuggerStatement`, and `WithStatement`.
+//! - [`DebuggerStatement`] (CLOC21 — `debugger;`, the breakpoint hook;
+//!   unblocks the whitespace-only fallback on any program using it)
+//!
+//! Phase 2 will add `ForInStatement`, `ForOfStatement`, and `WithStatement`.
 
 use crate::declaration::{Declaration, VariableDeclaration};
 use crate::expression::{Expression, Identifier};
@@ -79,6 +81,7 @@ pub enum TaggedStatement {
     SwitchStatement(SwitchStatement),
     TryStatement(TryStatement),
     EmptyStatement(EmptyStatement),
+    DebuggerStatement(DebuggerStatement),
 }
 
 // Convenience constructors so call sites don't have to write
@@ -125,6 +128,9 @@ impl Statement {
     }
     pub fn empty_statement(s: EmptyStatement) -> Self {
         Self::Tagged(TaggedStatement::EmptyStatement(s))
+    }
+    pub fn debugger_statement(s: DebuggerStatement) -> Self {
+        Self::Tagged(TaggedStatement::DebuggerStatement(s))
     }
 }
 
@@ -391,6 +397,20 @@ pub struct CatchClause {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct EmptyStatement {
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub cv: Option<CvId>,
+}
+
+/// `debugger;` (CLOC21). A breakpoint hook: it pauses execution if a debugger
+/// is attached and is otherwise a no-op. Like [`EmptyStatement`] it carries no
+/// children. Making it representable lets the typed pipeline optimize the rest
+/// of a program that contains a `debugger` statement (previously any such
+/// program fell back to WHITESPACE_ONLY). v1 preserves the statement verbatim;
+/// stripping it (as the upstream Closure Compiler does at SIMPLE/ADVANCED) is a
+/// future enhancement.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DebuggerStatement {
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub cv: Option<CvId>,
 }
@@ -695,6 +715,15 @@ mod tests {
         });
         assert_eq!(s.clone(), roundtrip(s.clone()));
         assert_eq!(type_tag(&s), "EmptyStatement");
+    }
+
+    #[test]
+    fn debugger_statement_roundtrips() {
+        let s = Statement::debugger_statement(DebuggerStatement {
+            cv: Some("dbg.1".to_string()),
+        });
+        assert_eq!(s.clone(), roundtrip(s.clone()));
+        assert_eq!(type_tag(&s), "DebuggerStatement");
     }
 
     #[test]

--- a/code/packages/rust/javascript-parser/CHANGELOG.md
+++ b/code/packages/rust/javascript-parser/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to the `coding-adventures-javascript-parser` crate will be documented in this file.
 
+## [0.12.0] - 2026-06-20
+
+### Added — CLOC21: bridge `debugger_statement` → `DebuggerStatement`
+
+`debugger_statement` no longer lands in the unsupported arm (which raised
+`UnsupportedSyntax` and forced a WHITESPACE_ONLY fallback at the CLI). The
+grammar production is `"debugger" SEMICOLON` — no node children — so the bridge
+emits a bare `DebuggerStatement` marker. Added a `debugger_bridge_shape` test.
+
 ## [0.11.0] - 2026-06-20
 
 ### Added — CLOC20: bridge `do_while_statement` → `DoWhileStatement`

--- a/code/packages/rust/javascript-parser/Cargo.toml
+++ b/code/packages/rust/javascript-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-javascript-parser"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2021"
 description = "JavaScript parser — parses JavaScript source code against any ECMAScript edition (es1 through es2025) using the grammar-driven parser. Includes correlation-vector plumbing per CLOC03 and a typed-AST bridge (GrammarASTNode → javascript_ast::Program) per CLOC12.136."
 

--- a/code/packages/rust/javascript-parser/src/bridge.rs
+++ b/code/packages/rust/javascript-parser/src/bridge.rs
@@ -61,10 +61,10 @@ use coding_adventures_javascript_ast::{
         UndefinedLiteral,
     },
     statement::{
-        BlockStatement, BreakStatement, CatchClause, ContinueStatement, DoWhileStatement,
-        EmptyStatement, ExpressionStatement, ForInit, ForStatement, IfStatement, LabeledStatement,
-        ReturnStatement, Statement, SwitchCase, SwitchStatement, ThrowStatement, TryStatement,
-        WhileStatement,
+        BlockStatement, BreakStatement, CatchClause, ContinueStatement, DebuggerStatement,
+        DoWhileStatement, EmptyStatement, ExpressionStatement, ForInit, ForStatement, IfStatement,
+        LabeledStatement, ReturnStatement, Statement, SwitchCase, SwitchStatement, ThrowStatement,
+        TryStatement, WhileStatement,
     },
     Program, ProgramItem, SourceType,
 };
@@ -277,11 +277,12 @@ fn convert_statement(node: &GrammarASTNode) -> Result<Statement, BridgeError> {
         "labelled_statement" => convert_labeled_statement(child).map(Statement::labeled_statement),
         "throw_statement" => convert_throw_statement(child).map(Statement::throw_statement),
         "try_statement" => convert_try_statement(child).map(Statement::try_statement),
+        // debugger_statement = "debugger" SEMICOLON — no node children, so the
+        // typed node is a bare marker. (CLOC21.)
+        "debugger_statement" => Ok(Statement::debugger_statement(DebuggerStatement { cv: None })),
         // Phase 2+ — not yet in the typed AST
         "for_in_statement" | "for_of_statement" | "for_await_of_statement" | "with_statement"
-        | "debugger_statement" | "using_declaration" | "await_using_declaration" => {
-            Err(unsupported(child))
-        }
+        | "using_declaration" | "await_using_declaration" => Err(unsupported(child)),
         other => Err(BridgeError::InternalError {
             msg: format!("unknown statement child rule '{other}'"),
             rule: node.rule_name.clone(),
@@ -2199,6 +2200,26 @@ mod tests {
             matches!(&t.test, Expression::Identifier(id) if id.name == "x"),
             "expected test to be identifier `x`, got {:?}",
             t.test
+        );
+    }
+
+    #[test]
+    fn debugger_bridge_shape() {
+        // CLOC21: `debugger;` now bridges to a DebuggerStatement (a bare
+        // marker with no children). Previously this returned UnsupportedSyntax
+        // → WHITESPACE_ONLY.
+        let p = bridge_ok("debugger;");
+        assert!(
+            matches!(
+                &p.body[0],
+                ProgramItem::Statement(Statement::Tagged(
+                    coding_adventures_javascript_ast::statement::TaggedStatement::DebuggerStatement(
+                        _
+                    )
+                ))
+            ),
+            "expected a DebuggerStatement, got {:?}",
+            p.body[0]
         );
     }
 

--- a/code/programs/rust/closurec/CHANGELOG.md
+++ b/code/programs/rust/closurec/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to the `coding-adventures-closurec` binary will be documented in this file.
 
+## [0.154.0] - 2026-06-20
+
+### Added — CLOC21: `debugger;` no longer forces a WHITESPACE_ONLY fallback
+
+Programs containing a `debugger` statement now route through the full typed-AST
+optimization pipeline at both SIMPLE and ADVANCED levels. Previously any
+`debugger` made the parse/bridge step decline, and closurec silently fell back
+to WHITESPACE_ONLY (no real optimization). Now inlining, constant folding,
+DCE, and (under ADVANCED) renaming all run across a `debugger` statement, which
+is itself preserved verbatim. (Stripping `debugger` at SIMPLE/ADVANCED, as the
+upstream Closure Compiler does, is a planned follow-up.)
+
+The end-to-end `simple-debugger` diff fixture pins the behaviour, with a
+regression guard that the output is NOT the whitespace fallback.
+
 ## [0.153.0] - 2026-06-20
 
 ### Added — CLOC20: end-to-end `do`/`while` support

--- a/code/programs/rust/closurec/Cargo.toml
+++ b/code/programs/rust/closurec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closurec"
-version = "0.153.0"
+version = "0.154.0"
 edition = "2021"
 description = "closurec — CLI driver for the Closure Compiler clone. Mirrors the upstream Java Closure Compiler's command-line flag surface (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility. Per CLOC08."
 

--- a/code/programs/rust/closurec/cli.spec.json
+++ b/code/programs/rust/closurec/cli.spec.json
@@ -2,7 +2,7 @@
   "cli_builder_spec_version": "1.0",
   "name": "closurec",
   "description": "closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.",
-  "version": "0.153.0",
+  "version": "0.154.0",
   "parsing_mode": "gnu",
   "flags": [
     { "id": "browser_featureset_year", "long": "browser_featureset_year", "type": "integer", "default": 0, "description": "Shortcut for defining goog.FEATURESET_YEAR=YYYY (minimum 2012)." },

--- a/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
@@ -2,7 +2,7 @@
 
 closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.
 
-Version: 0.153.0
+Version: 0.154.0
 
 ## Flags
 

--- a/code/programs/rust/closurec/tests/diff/simple-debugger/README.md
+++ b/code/programs/rust/closurec/tests/diff/simple-debugger/README.md
@@ -1,0 +1,32 @@
+# Fixture: `simple-debugger`
+
+End-to-end oracle for `--compilation_level SIMPLE` across a `debugger;`
+statement (CLOC21).
+
+| File | Role |
+|------|------|
+| `flags.txt` | CLI args: `--compilation_level SIMPLE --js input/a.js` |
+| `input/a.js` | A single-use function and foldable arithmetic surrounding a `debugger;` statement |
+| `expected.stdout` | The optimized output (see below) |
+
+```text
+report(1);var x=3;debugger;use(x);
+```
+
+What this proves — none of which was reachable before CLOC21 (any `debugger`
+forced a WHITESPACE_ONLY fallback):
+
+* **Inlining** — `log` is single-use, so `log(1)` becomes `report(1)` and
+  the declaration is deleted.
+* **Constant folding** — `1 + 2` ⇒ `3`.
+* **`debugger;` preserved** — v1 makes the statement representable so the rest
+  of the program is optimized; the `debugger` survives verbatim. (Stripping it,
+  as the upstream Closure Compiler does at SIMPLE/ADVANCED, is future work.)
+
+Regenerate the expected file after an intentional behavior change:
+
+```sh
+cargo run -- --compilation_level SIMPLE \
+    --js tests/diff/simple-debugger/input/a.js \
+    > tests/diff/simple-debugger/expected.stdout
+```

--- a/code/programs/rust/closurec/tests/diff/simple-debugger/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/simple-debugger/expected.stdout
@@ -1,0 +1,1 @@
+report(1);var x=3;debugger;use(x);

--- a/code/programs/rust/closurec/tests/diff/simple-debugger/flags.txt
+++ b/code/programs/rust/closurec/tests/diff/simple-debugger/flags.txt
@@ -1,0 +1,4 @@
+--compilation_level
+SIMPLE
+--js
+tests/diff/simple-debugger/input/a.js

--- a/code/programs/rust/closurec/tests/diff/simple-debugger/input/a.js
+++ b/code/programs/rust/closurec/tests/diff/simple-debugger/input/a.js
@@ -1,0 +1,21 @@
+// SIMPLE-level optimization of a program containing `debugger;` (CLOC21).
+//
+// Before CLOC21, *any* program containing a `debugger` statement failed the
+// typed-AST parse (DebuggerStatement was unrepresentable) and closurec
+// silently fell back to WHITESPACE_ONLY — zero optimization. This fixture is
+// the end-to-end oracle proving the SIMPLE pipeline now runs across a
+// `debugger` statement, optimizing the rest of the program while preserving
+// the statement verbatim:
+//
+//   * `log` is single-use, so the inliner folds `log(1)` into its body
+//     `report(1)` and deletes the now-unused declaration.
+//   * `1 + 2` is constant-folded to `3`.
+//   * `debugger;` survives verbatim — v1 preserves it (stripping it, as the
+//     upstream Closure Compiler does, is future work).
+function log(p) {
+  report(p);
+}
+log(1);
+var x = 1 + 2;
+debugger;
+use(x);

--- a/code/programs/rust/closurec/tests/diff_simple_debugger.rs
+++ b/code/programs/rust/closurec/tests/diff_simple_debugger.rs
@@ -1,0 +1,78 @@
+//! Integration test for the `tests/diff/simple-debugger/` fixture.
+//!
+//! Exercises `--compilation_level SIMPLE` across a `debugger;` statement
+//! (CLOC21). Before CLOC21, any program containing a `debugger` statement
+//! failed the typed-AST parse and closurec fell back to WHITESPACE_ONLY
+//! (zero optimization). This fixture is the end-to-end oracle proving the
+//! SIMPLE pipeline now runs across a `debugger` statement: `log(1)` is
+//! inlined to `report(1)`, `1 + 2` folds to `3`, and the `debugger;`
+//! statement is preserved verbatim.
+
+use std::process::Command;
+
+const BINARY: &str = env!("CARGO_BIN_EXE_closurec");
+
+fn read_flags() -> Vec<String> {
+    let raw =
+        std::fs::read_to_string("tests/diff/simple-debugger/flags.txt").expect("read flags.txt");
+    raw.lines()
+        .filter(|l| !l.is_empty())
+        .map(|s| s.to_string())
+        .collect()
+}
+
+#[test]
+fn simple_debugger_fixture_matches_expected_stdout() {
+    let flags = read_flags();
+    let out = Command::new(BINARY)
+        .args(&flags)
+        .output()
+        .expect("run closurec");
+
+    assert!(
+        out.status.success(),
+        "exit: {:?}, stderr: {}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stderr),
+    );
+
+    let actual = String::from_utf8_lossy(&out.stdout);
+    let expected = std::fs::read_to_string("tests/diff/simple-debugger/expected.stdout")
+        .expect("read expected.stdout");
+    assert_eq!(
+        actual.trim_end_matches('\n'),
+        expected.trim_end_matches('\n'),
+        "mismatch.\nflags: {flags:?}\nactual:\n{actual}\nexpected:\n{expected}",
+    );
+}
+
+/// Regression guard: the output must NOT be the WHITESPACE_ONLY fallback. If
+/// `debugger` ever stops being representable in the typed AST, the fixture
+/// above would still "pass" against a regenerated expected file, so we
+/// additionally assert that an optimization that can ONLY come from the typed
+/// pipeline (the `log` -> `report` inline) is present and the original
+/// `function log` declaration is gone, while the `debugger;` statement
+/// survives verbatim.
+#[test]
+fn simple_debugger_did_not_fall_back_to_whitespace_only() {
+    let out = Command::new(BINARY)
+        .args(read_flags())
+        .output()
+        .expect("run closurec");
+    let actual = String::from_utf8_lossy(&out.stdout);
+
+    assert!(
+        actual.contains("report(1)"),
+        "expected the single-use `log` to be inlined into `report(1)` \
+         (proving the typed pipeline ran, not the whitespace fallback); \
+         got:\n{actual}",
+    );
+    assert!(
+        !actual.contains("function log"),
+        "expected the inlined `log` declaration to be removed; got:\n{actual}",
+    );
+    assert!(
+        actual.contains("debugger;"),
+        "expected the `debugger;` statement to be preserved; got:\n{actual}",
+    );
+}

--- a/code/specs/CLOC21-debugger.md
+++ b/code/specs/CLOC21-debugger.md
@@ -1,0 +1,88 @@
+# CLOC21 — `debugger;` end-to-end
+
+> **Status:** Shipped (conservative v1: make representable, preserve the
+> statement). AST node, parser bridge, emitter, scope analyzer, and every
+> optimization pass handle the `debugger` statement. An end-to-end diff fixture
+> (`simple-debugger`) pins the behaviour at the CLI.
+
+## Why this spec exists
+
+`debugger;` is a breakpoint hook: it pauses execution if a debugger is attached
+and is otherwise a no-op. It was a Phase-2 statement gap. The grammar already
+*parsed* it, but the typed AST had no node to represent it, so the
+parser→typed-AST **bridge** declined (`UnsupportedSyntax`) and the CLI fell back
+to **`WHITESPACE_ONLY`** — applying zero real optimization to *any* program that
+contained a `debugger` statement (common in development builds). CLOC21 closes
+that gap with the established playbook: make the statement representable, then
+let every pass carry it through.
+
+```text
+source ──parse──▶ grammar AST ──bridge──▶ typed Program (DebuggerStatement)
+       ──passes──▶ optimized Program ──emit──▶ JS text
+```
+
+## Scope of v1: make representable, preserve the statement
+
+This change makes `debugger` representable and **preserves** it verbatim. The
+value is that the *rest* of a program containing `debugger` now gets the full
+SIMPLE/ADVANCED optimization pipeline instead of degrading to whitespace-only.
+
+The upstream Closure Compiler **removes** `debugger` statements at SIMPLE and
+ADVANCED. Stripping is intentionally deferred to a focused follow-up: it is a
+behaviour change (it removes a debugging affordance) and is cleanly separable
+from "make representable". Until then, v1 never regresses — a program that kept
+its `debugger` under the whitespace fallback still keeps it, but now everything
+around it is optimized.
+
+## The AST node (`coding-adventures-javascript-ast`)
+
+```rust
+pub struct DebuggerStatement {
+    pub cv: Option<CvId>,
+}
+```
+
+A childless leaf, structurally identical to `EmptyStatement`. A new
+`TaggedStatement::DebuggerStatement` variant and a `Statement::debugger_statement`
+constructor expose it. ESTree wire format: `{ "type": "DebuggerStatement" }`.
+
+## The bridge (`coding-adventures-javascript-parser`)
+
+The grammar production is `debugger_statement = "debugger" SEMICOLON` — no node
+children — so `convert_statement` maps it directly to a bare `DebuggerStatement`
+marker (no child conversion). It is removed from the unsupported arm.
+
+## The emitter (`coding-adventures-closure-emitter`)
+
+`emit_debugger` writes `debugger;`. The keyword is followed only by its
+terminator `;` (or, once that `;` is popped, a `}`/EOF), so no token-separation
+handling is needed. The trailing `;` is a real statement terminator, so
+`DebuggerStatement` is added to `last_stmt_uses_terminator_semi`: as the last
+statement in a block its `;` is popped (`{debugger}`) — ASI re-supplies it —
+exactly like `return`/`throw`/expression statements.
+
+## Per-pass handling
+
+A `debugger;` has no children, binds nothing, and references nothing, so every
+pass treats it exactly like `EmptyStatement`: a no-op that is carried through
+unchanged. It is grouped with the other childless leaf statements in each
+pass's statement match (`constant-fold`, `fold-control-flow`, `dce`,
+`inline-variables`, `inline`, `rename`, `rename-globals`, `rename-properties`)
+and in the scope analyzer. These arms exist only to keep the matches exhaustive
+over the new AST variant — the fail-closed property of the compiler-driven
+design.
+
+## End-to-end oracle (`closurec` diff fixture)
+
+* **`simple-debugger`** — at SIMPLE: a single-use function inlines, surrounding
+  arithmetic folds, and the `debugger;` statement is preserved verbatim. A
+  companion assertion proves the output is NOT the whitespace fallback (the
+  `log` ⇒ `report` inline can only come from the typed pipeline).
+
+## Out of scope (future work)
+
+* **Stripping `debugger`** at SIMPLE/ADVANCED to match upstream Closure — a
+  focused follow-up (a behaviour change, cleanly separable from this PR).
+* `ForInStatement`, `ForOfStatement`, and `WithStatement` remain the last
+  bridge-unsupported Phase-2 statements; they follow the same playbook (with
+  more involved left-binding handling for the for-in/of forms).


### PR DESCRIPTION
## Summary

Makes the **`debugger;`** statement representable so programs containing it no longer fall back to `WHITESPACE_ONLY` — the rest of the program now gets the full SIMPLE/ADVANCED optimization pipeline. This is the next Phase-2 statement after [#6334](https://github.com/adhithyan15/coding-adventures/pull/6334)'s do-while.

```
function log(p){report(p);} log(1);
var x = 1 + 2;
debugger;
use(x);
```
⟶ `report(1);var x=3;debugger;use(x);`

(log inlined, `1+2` folded, `debugger;` preserved — previously this whole program degraded to whitespace-only.)

## Scope of v1 — make representable, **preserve** the statement

This makes `debugger` representable and preserves it verbatim. The upstream Closure Compiler *removes* `debugger` at SIMPLE/ADVANCED; **stripping is intentionally deferred** to a focused follow-up (it's a separable behaviour change). v1 never regresses — a program that kept its `debugger` under the whitespace fallback still keeps it, but now everything around it is optimized.

## What changed (childless leaf — mirrors `EmptyStatement`)

| Layer | Change |
|-------|--------|
| `javascript-ast` | `DebuggerStatement { cv }` node, `TaggedStatement` variant, constructor, re-export. |
| `javascript-parser` | Bridge `debugger_statement` (grammar `"debugger" SEMICOLON`, no node children) → a bare marker. |
| `closure-emitter` | `emit_debugger` → `debugger;`; the trailing `;` is a real terminator, so it joins `last_stmt_uses_terminator_semi` and pops before `}` (`{debugger}`, ASI re-supplies it). |
| `closure-scope-analyzer` + all 8 passes | A no-op arm grouped with the other childless leaf statements (exhaustiveness over the new variant). |

## Soundness — debugger is never dropped

The shared grouping with `EmptyStatement` is sound because a `debugger;` has no children, binds nothing, and references nothing. Critically, the debugger statement is **never dropped**: DCE's empty-statement removal (`is_empty_statement`) matches **only** `EmptyStatement`, and the dead-tail-truncation whitelist excludes debugger (conservatively preserved). An adversarial inline security review traced these paths and confirmed v1's "preserve" intent holds everywhere, plus verified the emitter `;` handling has no mis-lexing hazard.

## Tests

- **javascript-ast**: serde round-trip.
- **javascript-parser**: bridge-shape test.
- **closure-emitter**: keyword+semi, terminator-pop (`{debugger}`), and not-last-keeps-semi (`{debugger;a}`) tests.
- **closurec**: end-to-end `simple-debugger` diff fixture with a **whitespace-fallback regression guard** (asserts the inline happened and `debugger;` survived).

Full closurec suite **724/724 green**; every touched pass crate green.

## Bookkeeping

Spec: `code/specs/CLOC21-debugger.md`. Version bumps + CHANGELOGs for all 13 touched crates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)