### PR TITLE
Expose SPICE deck rawfile write marker artifacts

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 ### Added
 
+- **Deck rawfile write marker artifacts** —
+  `analyze_deck_controls()` and selected `run_deck_analysis()` executions now
+  expose normalized accepted `.control` `write` / `wrdata` marker inventories
+  as `write_marker_count` / `write_markers`, and selected-run artifacts carry
+  stable `WriteMarkers` / `WriteMarkerList` columns through tables, CSV/JSON,
+  and ordered `table_artifacts`, matching Rust and TypeScript.
+
 - **Deck execution diagnostic artifacts** —
   `run_deck_analysis()` selected executions now expose selected diagnostic
   inventories directly as `diagnostic_count` / `diagnostic_codes` alongside

--- a/code/packages/python/spice-engine/README.md
+++ b/code/packages/python/spice-engine/README.md
@@ -114,10 +114,14 @@ Selected
 Fourier table. Executions also include a selected-run artifact summary plus
 `format_deck_run_artifact_table()` and `format_deck_run_artifact_csv()` output
 for stable result-row, table, analysis-directive, output-probe,
-output-directive, measurement, Fourier, and diagnostic count/name lists.
+output-directive, measurement, Fourier, write-marker, and diagnostic
+count/name lists.
 Normalized accepted `.control` commands are surfaced separately in
 `control_line_count` / `control_lines` execution fields and in
 `ControlLines` / `ControlLineList` artifact fields.
+Accepted `.control` `write` / `wrdata` rawfile/data-write markers are surfaced
+as `write_marker_count` / `write_markers` execution fields and as
+`WriteMarkers` / `WriteMarkerList` artifact fields without serializing files.
 Existing `.control` body policy diagnostics flow into those selected-run
 artifact `Diagnostics` / `DiagnosticCodeList` fields and through the same
 run-artifact table, CSV, JSON, and `table_artifacts` records.
@@ -235,11 +239,11 @@ stable deck-selected table output with normalized table-inventory,
 analysis-directive, output-probe, and output-directive artifacts,
 selected measurement artifacts, selected transient Fourier artifacts,
 selected-run artifact summaries with analysis-directive, output-probe,
-output-directive, measurement, Fourier probe, `.control` command, and diagnostic
-inventories, `.ac LIN`, `.ac DEC`, `.ac OCT` frequency grids, and `.tran`
+output-directive, measurement, Fourier probe, `.control` command, write-marker,
+and diagnostic inventories, `.ac LIN`, `.ac DEC`, `.ac OCT` frequency grids, and `.tran`
 `START` / print-step `TSTEP` / `MAXSTEP` / `UIC` controls. Selected execution
-fields expose `.control` command and diagnostic inventories directly for host
-integrations.
+fields expose `.control` command, write-marker, and diagnostic inventories
+directly for host integrations.
 
 ## Controlled source examples
 

--- a/code/packages/python/spice-engine/src/spice_engine/compatibility.py
+++ b/code/packages/python/spice-engine/src/spice_engine/compatibility.py
@@ -57,6 +57,7 @@ class DeckControlSummary:
 
     active_lines: tuple[str, ...]
     control_lines: tuple[str, ...]
+    write_markers: tuple[str, ...]
     terminated: bool
     end_line_number: int | None
     diagnostics: tuple[DeckControlDiagnostic, ...]
@@ -609,6 +610,7 @@ def analyze_deck_controls(netlist: str) -> DeckControlSummary:
 
     active_lines: list[str] = []
     control_lines: list[str] = []
+    write_markers: list[str] = []
     diagnostics: list[DeckControlDiagnostic] = []
     end_line_number: int | None = None
     in_control_block = False
@@ -626,6 +628,10 @@ def analyze_deck_controls(netlist: str) -> DeckControlSummary:
             if control_line is not None:
                 active_lines.append(control_line)
                 control_lines.append(control_line)
+                continue
+            write_marker = _control_block_write_marker(stripped)
+            if write_marker is not None:
+                write_markers.append(write_marker)
                 continue
             if _is_noop_control_block_command(stripped):
                 continue
@@ -710,6 +716,7 @@ def analyze_deck_controls(netlist: str) -> DeckControlSummary:
     return DeckControlSummary(
         active_lines=tuple(active_lines),
         control_lines=tuple(control_lines),
+        write_markers=tuple(write_markers),
         terminated=end_line_number is not None,
         end_line_number=end_line_number,
         diagnostics=tuple(diagnostics),
@@ -3724,6 +3731,20 @@ def _control_block_command_as_deck_line(line: str) -> str | None:
     if len(parts) == 1:
         return directive
     return f"{directive} {parts[1]}"
+
+
+def _control_block_write_marker(line: str) -> str | None:
+    parts = line.split(maxsplit=1)
+    if not parts:
+        return None
+    command = parts[0].lower()
+    if command in _NOOP_CONTROL_BLOCK_ARGUMENT_COMMANDS and len(parts) == 2:
+        return f"{command.removeprefix('.')} {parts[1]}"
+    if command in _NOOP_CONTROL_BLOCK_VECTOR_ARGUMENT_COMMANDS and len(parts) == 2:
+        vector_parts = parts[1].split()
+        if len(vector_parts) >= 2:
+            return f"{command.removeprefix('.')} {parts[1]}"
+    return None
 
 
 def _is_noop_control_block_command(line: str) -> bool:

--- a/code/packages/python/spice-engine/src/spice_engine/engine.py
+++ b/code/packages/python/spice-engine/src/spice_engine/engine.py
@@ -2353,6 +2353,8 @@ class DeckRunArtifact:
     fourier_probes: list[str]
     control_line_count: int
     control_lines: list[str]
+    write_marker_count: int
+    write_markers: list[str]
     diagnostic_count: int
     diagnostic_codes: list[str]
 
@@ -2380,6 +2382,8 @@ class DeckAnalysisExecution:
     analysis_directives: list[str]
     control_line_count: int
     control_lines: list[str]
+    write_marker_count: int
+    write_markers: list[str]
     diagnostic_count: int
     diagnostic_codes: list[str]
     table_count: int
@@ -2475,6 +2479,8 @@ _DECK_RUN_ARTIFACT_COLUMNS = [
     "FourierList",
     "ControlLines",
     "ControlLineList",
+    "WriteMarkers",
+    "WriteMarkerList",
     "Diagnostics",
     "DiagnosticCodeList",
 ]
@@ -2511,6 +2517,7 @@ def _deck_run_artifacts(
     measurements: list[ProbeMeasurement],
     fourier: list[FourierResult],
     control_lines: list[str],
+    write_markers: list[str],
     diagnostic_codes: list[str],
 ) -> list[DeckRunArtifact]:
     is_transient = plan.analysis == "tran"
@@ -2556,6 +2563,8 @@ def _deck_run_artifacts(
             ],
             control_line_count=len(control_lines),
             control_lines=list(control_lines),
+            write_marker_count=len(write_markers),
+            write_markers=list(write_markers),
             diagnostic_count=len(diagnostic_codes),
             diagnostic_codes=list(diagnostic_codes),
         )
@@ -2586,6 +2595,10 @@ def _deck_control_diagnostic_codes(netlist: str) -> list[str]:
 
 def _deck_control_lines(netlist: str) -> list[str]:
     return list(analyze_deck_controls(netlist).control_lines)
+
+
+def _deck_control_write_markers(netlist: str) -> list[str]:
+    return list(analyze_deck_controls(netlist).write_markers)
 
 
 def _deck_run_diagnostic_codes(netlist: str, plan: DeckAnalysisPlan) -> list[str]:
@@ -2640,6 +2653,8 @@ def _deck_run_artifact_cells(artifact: DeckRunArtifact) -> list[str]:
         ";".join(artifact.fourier_probes),
         str(artifact.control_line_count),
         ";".join(artifact.control_lines),
+        str(artifact.write_marker_count),
+        ";".join(artifact.write_markers),
         str(artifact.diagnostic_count),
         ";".join(artifact.diagnostic_codes),
     ]
@@ -2756,6 +2771,7 @@ def run_deck_analysis(
     plan = select_deck_analysis_plan(netlist, analysis)
     diagnostic_codes = _deck_run_diagnostic_codes(netlist, plan)
     control_lines = _deck_control_lines(netlist)
+    write_markers = _deck_control_write_markers(netlist)
     analysis_directives = _deck_analysis_directives(plan)
     if plan.analysis == "op":
         result = dc_op(circuit)
@@ -2775,6 +2791,7 @@ def run_deck_analysis(
             measurements,
             fourier,
             control_lines,
+            write_markers,
             diagnostic_codes,
         )
         measurement_table = format_measurement_table(measurements)
@@ -2798,6 +2815,8 @@ def run_deck_analysis(
             analysis_directives=analysis_directives,
             control_line_count=len(control_lines),
             control_lines=list(control_lines),
+            write_marker_count=len(write_markers),
+            write_markers=list(write_markers),
             diagnostic_count=len(diagnostic_codes),
             diagnostic_codes=list(diagnostic_codes),
             table_count=len(tables),
@@ -2834,6 +2853,7 @@ def run_deck_analysis(
             measurements,
             fourier,
             control_lines,
+            write_markers,
             diagnostic_codes,
         )
         measurement_table = format_measurement_table(measurements)
@@ -2857,6 +2877,8 @@ def run_deck_analysis(
             analysis_directives=analysis_directives,
             control_line_count=len(control_lines),
             control_lines=list(control_lines),
+            write_marker_count=len(write_markers),
+            write_markers=list(write_markers),
             diagnostic_count=len(diagnostic_codes),
             diagnostic_codes=list(diagnostic_codes),
             table_count=len(tables),
@@ -2895,6 +2917,7 @@ def run_deck_analysis(
             measurements,
             fourier,
             control_lines,
+            write_markers,
             diagnostic_codes,
         )
         measurement_table = format_measurement_table(measurements)
@@ -2918,6 +2941,8 @@ def run_deck_analysis(
             analysis_directives=analysis_directives,
             control_line_count=len(control_lines),
             control_lines=list(control_lines),
+            write_marker_count=len(write_markers),
+            write_markers=list(write_markers),
             diagnostic_count=len(diagnostic_codes),
             diagnostic_codes=list(diagnostic_codes),
             table_count=len(tables),
@@ -2962,6 +2987,7 @@ def run_deck_analysis(
             measurements,
             fourier,
             control_lines,
+            write_markers,
             diagnostic_codes,
         )
         measurement_table = format_measurement_table(measurements)
@@ -2985,6 +3011,8 @@ def run_deck_analysis(
             analysis_directives=analysis_directives,
             control_line_count=len(control_lines),
             control_lines=list(control_lines),
+            write_marker_count=len(write_markers),
+            write_markers=list(write_markers),
             diagnostic_count=len(diagnostic_codes),
             diagnostic_codes=list(diagnostic_codes),
             table_count=len(tables),
@@ -3017,6 +3045,7 @@ def run_deck_analysis(
             measurements,
             fourier,
             control_lines,
+            write_markers,
             diagnostic_codes,
         )
         measurement_table = format_measurement_table(measurements)
@@ -3040,6 +3069,8 @@ def run_deck_analysis(
             analysis_directives=analysis_directives,
             control_line_count=len(control_lines),
             control_lines=list(control_lines),
+            write_marker_count=len(write_markers),
+            write_markers=list(write_markers),
             diagnostic_count=len(diagnostic_codes),
             diagnostic_codes=list(diagnostic_codes),
             table_count=len(tables),
@@ -3071,6 +3102,7 @@ def run_deck_analysis(
             measurements,
             fourier,
             control_lines,
+            write_markers,
             diagnostic_codes,
         )
         measurement_table = format_measurement_table(measurements)
@@ -3094,6 +3126,8 @@ def run_deck_analysis(
             analysis_directives=analysis_directives,
             control_line_count=len(control_lines),
             control_lines=list(control_lines),
+            write_marker_count=len(write_markers),
+            write_markers=list(write_markers),
             diagnostic_count=len(diagnostic_codes),
             diagnostic_codes=list(diagnostic_codes),
             table_count=len(tables),
@@ -3144,6 +3178,7 @@ def run_deck_analysis(
             measurements,
             fourier,
             control_lines,
+            write_markers,
             diagnostic_codes,
         )
         measurement_table = format_measurement_table(measurements)
@@ -3167,6 +3202,8 @@ def run_deck_analysis(
             analysis_directives=analysis_directives,
             control_line_count=len(control_lines),
             control_lines=list(control_lines),
+            write_marker_count=len(write_markers),
+            write_markers=list(write_markers),
             diagnostic_count=len(diagnostic_codes),
             diagnostic_codes=list(diagnostic_codes),
             table_count=len(tables),

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -166,6 +166,7 @@ from spice_engine import (
     ac_sweep,
     ac_sweep_corners,
     analyze_custom_model_source,
+    analyze_deck_controls,
     bjt_from_model_card,
     circuit_at_temperature,
     custom_linear_conductance_model,
@@ -6850,8 +6851,8 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
     assert op_execution.run_artifacts[0].diagnostic_count == 0
     assert op_execution.run_artifacts[0].diagnostic_codes == []
     assert op_execution.run_artifact_table == (
-        "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tDiagnostics\tDiagnosticCodeList\n"
-        f"op\t.op\t1\t.op\t{op_execution.plan.line_number}\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t1\t2\tIndex;V(mid)\t2\tresult;run-artifact\t1\tV(mid)\t1\t.save\t0\t\t0\t\t0\t\t0\t\n"
+        "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tWriteMarkers\tWriteMarkerList\tDiagnostics\tDiagnosticCodeList\n"
+        f"op\t.op\t1\t.op\t{op_execution.plan.line_number}\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t1\t2\tIndex;V(mid)\t2\tresult;run-artifact\t1\tV(mid)\t1\t.save\t0\t\t0\t\t0\t\t0\t\t0\t\n"
     )
     assert op_execution.table_artifacts[1].name == "run-artifact"
     assert op_execution.table_artifacts[1].table == op_execution.run_artifact_table
@@ -6868,8 +6869,8 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
         format_deck_run_artifact_json(op_execution.run_artifacts)
     )
     assert format_deck_run_artifact_csv(op_execution.run_artifacts) == (
-        "Analysis,Directive,AnalysisDirectives,AnalysisDirectiveList,Line,SourceName,OutputNode,SweepKind,StartValue,StopValue,StepValue,PointCount,StartFrequencyHz,StopFrequencyHz,StepTime,StopTime,StartTime,MaxStep,UseInitialConditions,ResultRows,ResultColumns,ResultColumnList,Tables,TableList,OutputProbes,OutputProbeList,OutputDirectives,OutputDirectiveList,Measurements,MeasurementList,Fourier,FourierList,ControlLines,ControlLineList,Diagnostics,DiagnosticCodeList\n"
-        f"op,.op,1,.op,{op_execution.plan.line_number},,,,,,,,,,,,,,,1,2,Index;V(mid),2,result;run-artifact,1,V(mid),1,.save,0,,0,,0,,0,\n"
+        "Analysis,Directive,AnalysisDirectives,AnalysisDirectiveList,Line,SourceName,OutputNode,SweepKind,StartValue,StopValue,StepValue,PointCount,StartFrequencyHz,StopFrequencyHz,StepTime,StopTime,StartTime,MaxStep,UseInitialConditions,ResultRows,ResultColumns,ResultColumnList,Tables,TableList,OutputProbes,OutputProbeList,OutputDirectives,OutputDirectiveList,Measurements,MeasurementList,Fourier,FourierList,ControlLines,ControlLineList,WriteMarkers,WriteMarkerList,Diagnostics,DiagnosticCodeList\n"
+        f"op,.op,1,.op,{op_execution.plan.line_number},,,,,,,,,,,,,,,1,2,Index;V(mid),2,result;run-artifact,1,V(mid),1,.save,0,,0,,0,,0,,0,\n"
     )
     assert format_deck_table_csv('Name\tValue\nprobe\tSPICE,"QUOTED"\n') == (
         'Name,Value\nprobe,"SPICE,""QUOTED"""\n'
@@ -6917,6 +6918,8 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
         "FourierList",
         "ControlLines",
         "ControlLineList",
+        "WriteMarkers",
+        "WriteMarkerList",
         "Diagnostics",
         "DiagnosticCodeList",
     ]
@@ -6956,6 +6959,8 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
             "FourierList": "",
             "ControlLines": "0",
             "ControlLineList": "",
+            "WriteMarkers": "0",
+            "WriteMarkerList": "",
             "Diagnostics": "0",
             "DiagnosticCodeList": "",
         }
@@ -7044,8 +7049,8 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
     assert dc_execution.run_artifacts[0].measurement_names == ["mid_avg"]
     assert dc_execution.run_artifacts[0].fourier_probes == []
     assert dc_execution.run_artifact_table == (
-        "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tDiagnostics\tDiagnosticCodeList\n"
-        f"dc\t.dc\t1\t.dc\t{dc_execution.plan.line_number}\tV1\t\t\t0.000000e+00\t1.000000e+00\t1.000000e+00\t\t\t\t\t\t\t\t\t2\t5\tIndex;Source;Value;V(mid);I(V1)\t3\tresult;measurement;run-artifact\t2\tV(mid);I(V1)\t2\t.save;.probe\t1\tmid_avg\t0\t\t0\t\t0\t\n"
+        "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tWriteMarkers\tWriteMarkerList\tDiagnostics\tDiagnosticCodeList\n"
+        f"dc\t.dc\t1\t.dc\t{dc_execution.plan.line_number}\tV1\t\t\t0.000000e+00\t1.000000e+00\t1.000000e+00\t\t\t\t\t\t\t\t\t2\t5\tIndex;Source;Value;V(mid);I(V1)\t3\tresult;measurement;run-artifact\t2\tV(mid);I(V1)\t2\t.save;.probe\t1\tmid_avg\t0\t\t0\t\t0\t\t0\t\n"
     )
 
     ac_execution = run_deck_analysis(circuit, netlist, "ac")
@@ -7094,8 +7099,8 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
     assert ac_execution.run_artifacts[0].measurement_names == ["mid_peak"]
     assert ac_execution.run_artifacts[0].fourier_probes == []
     assert ac_execution.run_artifact_table == (
-        "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tDiagnostics\tDiagnosticCodeList\n"
-        f"ac\t.ac\t1\t.ac\t{ac_execution.plan.line_number}\t\t\tdec\t\t\t\t1\t1.000000e+03\t1.000000e+03\t\t\t\t\t\t1\t7\tIndex;Frequency;Probe;Real;Imaginary;Magnitude;Phase\t3\tresult;measurement;run-artifact\t1\tV(mid)\t1\t.save\t1\tmid_peak\t0\t\t0\t\t0\t\n"
+        "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tWriteMarkers\tWriteMarkerList\tDiagnostics\tDiagnosticCodeList\n"
+        f"ac\t.ac\t1\t.ac\t{ac_execution.plan.line_number}\t\t\tdec\t\t\t\t1\t1.000000e+03\t1.000000e+03\t\t\t\t\t\t1\t7\tIndex;Frequency;Probe;Real;Imaginary;Magnitude;Phase\t3\tresult;measurement;run-artifact\t1\tV(mid)\t1\t.save\t1\tmid_peak\t0\t\t0\t\t0\t\t0\t\n"
     )
 
     tran_execution = run_deck_analysis(circuit, netlist, "tran")
@@ -7139,8 +7144,8 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
     assert tran_execution.run_artifacts[0].diagnostic_count == 0
     assert tran_execution.run_artifacts[0].diagnostic_codes == []
     assert tran_execution.run_artifact_table == (
-        "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tDiagnostics\tDiagnosticCodeList\n"
-        f"tran\t.tran\t1\t.tran\t{tran_execution.plan.line_number}\t\t\t\t\t\t\t\t\t\t1.000000e-03\t1.000000e-03\t\t\tfalse\t2\t3\tIndex;Time;V(mid)\t3\tresult;measurement;run-artifact\t1\tV(mid)\t1\t.save\t1\tmid_final\t0\t\t0\t\t0\t\n"
+        "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tWriteMarkers\tWriteMarkerList\tDiagnostics\tDiagnosticCodeList\n"
+        f"tran\t.tran\t1\t.tran\t{tran_execution.plan.line_number}\t\t\t\t\t\t\t\t\t\t1.000000e-03\t1.000000e-03\t\t\tfalse\t2\t3\tIndex;Time;V(mid)\t3\tresult;measurement;run-artifact\t1\tV(mid)\t1\t.save\t1\tmid_final\t0\t\t0\t\t0\t\t0\t\n"
     )
 
     tf_execution = run_deck_analysis(circuit, netlist, "tf")
@@ -7180,8 +7185,8 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
     assert tf_execution.run_artifacts[0].measurement_names == []
     assert tf_execution.run_artifacts[0].fourier_probes == []
     assert tf_execution.run_artifact_table == (
-        "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tDiagnostics\tDiagnosticCodeList\n"
-        f"tf\t.tf\t1\t.tf\t{tf_execution.plan.line_number}\tV1\tmid\t\t\t\t\t\t\t\t\t\t\t\t\t1\t3\tTransferRatio;InputImpedance;OutputImpedance\t2\tresult;run-artifact\t1\tV(mid)\t0\t\t0\t\t0\t\t0\t\t0\t\n"
+        "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tWriteMarkers\tWriteMarkerList\tDiagnostics\tDiagnosticCodeList\n"
+        f"tf\t.tf\t1\t.tf\t{tf_execution.plan.line_number}\tV1\tmid\t\t\t\t\t\t\t\t\t\t\t\t\t1\t3\tTransferRatio;InputImpedance;OutputImpedance\t2\tresult;run-artifact\t1\tV(mid)\t0\t\t0\t\t0\t\t0\t\t0\t\t0\t\n"
     )
 
     sens_execution = run_deck_analysis(circuit, netlist, "sens")
@@ -7222,8 +7227,8 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
     assert sens_execution.run_artifacts[0].measurement_names == []
     assert sens_execution.run_artifacts[0].fourier_probes == []
     assert sens_execution.run_artifact_table == (
-        "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tDiagnostics\tDiagnosticCodeList\n"
-        f"sens\t.sens\t1\t.sens\t{sens_execution.plan.line_number}\t\tmid\t\t\t\t\t\t\t\t\t\t\t\t\t1\t7\tOutputNode;NominalVoltage;Element;Parameter;NominalValue;Sensitivity;RelativeSensitivity\t2\tresult;run-artifact\t1\tV(mid)\t0\t\t0\t\t0\t\t0\t\t0\t\n"
+        "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tWriteMarkers\tWriteMarkerList\tDiagnostics\tDiagnosticCodeList\n"
+        f"sens\t.sens\t1\t.sens\t{sens_execution.plan.line_number}\t\tmid\t\t\t\t\t\t\t\t\t\t\t\t\t1\t7\tOutputNode;NominalVoltage;Element;Parameter;NominalValue;Sensitivity;RelativeSensitivity\t2\tresult;run-artifact\t1\tV(mid)\t0\t\t0\t\t0\t\t0\t\t0\t\t0\t\n"
     )
 
     noise_execution = run_deck_analysis(circuit, netlist, "noise")
@@ -7278,8 +7283,8 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
     assert noise_execution.run_artifacts[0].measurement_names == []
     assert noise_execution.run_artifacts[0].fourier_probes == []
     assert noise_execution.run_artifact_table == (
-        "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tDiagnostics\tDiagnosticCodeList\n"
-        f"noise\t.noise\t1\t.noise\t{noise_execution.plan.line_number}\tV1\tmid\tlin\t\t\t\t1\t1.000000e+03\t1.000000e+03\t\t\t\t\t\t1\t10\tIndex;Frequency;OutputNode;InputSource;OutputPSD;InputReferredPSD;Element;Type;SourcePSD;ContributionPSD\t2\tresult;run-artifact\t1\tV(mid)\t0\t\t0\t\t0\t\t0\t\t0\t\n"
+        "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tWriteMarkers\tWriteMarkerList\tDiagnostics\tDiagnosticCodeList\n"
+        f"noise\t.noise\t1\t.noise\t{noise_execution.plan.line_number}\tV1\tmid\tlin\t\t\t\t1\t1.000000e+03\t1.000000e+03\t\t\t\t\t\t1\t10\tIndex;Frequency;OutputNode;InputSource;OutputPSD;InputReferredPSD;Element;Type;SourcePSD;ContributionPSD\t2\tresult;run-artifact\t1\tV(mid)\t0\t\t0\t\t0\t\t0\t\t0\t\t0\t\n"
     )
 
     tran_window_execution = run_deck_analysis(
@@ -7319,8 +7324,8 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
         "2\t6.000000e-03\t5.000000e-01\n"
     )
     assert tran_window_execution.run_artifact_table == (
-        "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tDiagnostics\tDiagnosticCodeList\n"
-        f"tran\t.tran\t1\t.tran\t{tran_window_execution.plan.line_number}\t\t\t\t\t\t\t\t\t\t2.000000e-03\t6.000000e-03\t2.000000e-03\t1.000000e-03\ttrue\t3\t3\tIndex;Time;V(mid)\t2\tresult;run-artifact\t1\tV(mid)\t1\t.save\t0\t\t0\t\t0\t\t0\t\n"
+        "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tWriteMarkers\tWriteMarkerList\tDiagnostics\tDiagnosticCodeList\n"
+        f"tran\t.tran\t1\t.tran\t{tran_window_execution.plan.line_number}\t\t\t\t\t\t\t\t\t\t2.000000e-03\t6.000000e-03\t2.000000e-03\t1.000000e-03\ttrue\t3\t3\tIndex;Time;V(mid)\t2\tresult;run-artifact\t1\tV(mid)\t1\t.save\t0\t\t0\t\t0\t\t0\t\t0\t\n"
     )
 
     with pytest.raises(ValueError, match="multiple analysis cards"):
@@ -7358,6 +7363,8 @@ def test_run_deck_analysis_surfaces_control_diagnostics_in_artifacts() -> None:
 .control
 save V(in)
 probe V(in)
+write out.raw V(in)
+wrdata out.dat V(in)
 source other.cir
 cd /tmp
 if v(in) > 0
@@ -7377,22 +7384,33 @@ let gain = 2
     code_list = ";".join(expected_codes)
     expected_control_lines = [".save V(in)", ".probe V(in)"]
     control_line_list = ";".join(expected_control_lines)
+    expected_write_markers = ["write out.raw V(in)", "wrdata out.dat V(in)"]
+    write_marker_list = ";".join(expected_write_markers)
 
     assert execution.control_line_count == len(expected_control_lines)
     assert execution.control_lines == expected_control_lines
+    assert execution.write_marker_count == len(expected_write_markers)
+    assert execution.write_markers == expected_write_markers
     assert execution.diagnostic_count == len(expected_codes)
     assert execution.diagnostic_codes == expected_codes
     assert execution.run_artifacts[0].control_line_count == len(expected_control_lines)
     assert execution.run_artifacts[0].control_lines == expected_control_lines
+    assert execution.run_artifacts[0].write_marker_count == len(expected_write_markers)
+    assert execution.run_artifacts[0].write_markers == expected_write_markers
     assert execution.run_artifacts[0].diagnostic_count == len(expected_codes)
     assert execution.run_artifacts[0].diagnostic_codes == expected_codes
     record = deck_table_records(execution.run_artifact_table)[0]
     assert record["ControlLines"] == str(len(expected_control_lines))
     assert record["ControlLineList"] == control_line_list
+    assert record["WriteMarkers"] == str(len(expected_write_markers))
+    assert record["WriteMarkerList"] == write_marker_list
     assert record["Diagnostics"] == str(len(expected_codes))
     assert record["DiagnosticCodeList"] == code_list
     assert execution.table_artifacts[-1].name == "run-artifact"
     assert execution.table_artifacts[-1].records[0]["ControlLineList"] == control_line_list
+    assert (
+        execution.table_artifacts[-1].records[0]["WriteMarkerList"] == write_marker_list
+    )
     assert execution.table_artifacts[-1].records[0]["DiagnosticCodeList"] == code_list
     assert execution.table_artifacts[-1].csv == format_deck_run_artifact_csv(
         execution.run_artifacts
@@ -7404,8 +7422,33 @@ let gain = 2
         "ControlLineList"
     ] == control_line_list
     assert json.loads(format_deck_run_artifact_json(execution.run_artifacts))[0][
+        "WriteMarkerList"
+    ] == write_marker_list
+    assert json.loads(format_deck_run_artifact_json(execution.run_artifacts))[0][
         "DiagnosticCodeList"
     ] == code_list
+
+
+def test_analyze_deck_controls_surfaces_write_markers() -> None:
+    summary = analyze_deck_controls(
+        """
+.control
+write out.raw V(out)
+wrdata out.dat V(out)
+wrdata empty.dat
+.write dotted.raw V(a)
+.wrdata dotted.dat V(a)
+.endc
+.end
+"""
+    )
+
+    assert summary.write_markers == (
+        "write out.raw V(out)",
+        "wrdata out.dat V(out)",
+        "write dotted.raw V(a)",
+        "wrdata dotted.dat V(a)",
+    )
 
 
 def test_run_deck_analysis_exposes_selected_fourier_artifacts() -> None:
@@ -7471,8 +7514,8 @@ def test_run_deck_analysis_exposes_selected_fourier_artifacts() -> None:
     assert tran_execution.run_artifacts[0].measurement_names == []
     assert tran_execution.run_artifacts[0].fourier_probes == ["V(mid)"]
     assert tran_execution.run_artifact_table == (
-        "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tDiagnostics\tDiagnosticCodeList\n"
-        f"tran\t.tran\t1\t.tran\t{tran_execution.plan.line_number}\t\t\t\t\t\t\t\t\t\t5.000000e-04\t1.000000e-03\t\t\tfalse\t3\t3\tIndex;Time;V(mid)\t3\tresult;fourier;run-artifact\t1\tV(mid)\t1\t.save\t0\t\t1\tV(mid)\t0\t\t0\t\n"
+        "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tWriteMarkers\tWriteMarkerList\tDiagnostics\tDiagnosticCodeList\n"
+        f"tran\t.tran\t1\t.tran\t{tran_execution.plan.line_number}\t\t\t\t\t\t\t\t\t\t5.000000e-04\t1.000000e-03\t\t\tfalse\t3\t3\tIndex;Time;V(mid)\t3\tresult;fourier;run-artifact\t1\tV(mid)\t1\t.save\t0\t\t1\tV(mid)\t0\t\t0\t\t0\t\n"
     )
 
 

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- Expose accepted `.control` `write` / `wrdata` marker inventories from
+  `analyze_deck_controls` and selected `run_deck_analysis` execution results as
+  `write_marker_count` / `write_markers`, and carry them through selected-run
+  artifacts as stable `WriteMarkers` / `WriteMarkerList` table, CSV/JSON, and
+  ordered `table_artifacts` fields, matching Python and TypeScript.
 - Expose selected diagnostic inventories directly on selected
   `run_deck_analysis` execution results as `diagnostic_count` /
   `diagnostic_codes`, matching Python and TypeScript.

--- a/code/packages/rust/spice-engine/README.md
+++ b/code/packages/rust/spice-engine/README.md
@@ -189,11 +189,15 @@ results and a stable Fourier table. Executions also include selected-run
 artifact summaries plus `format_deck_run_artifact_table` and
 `format_deck_run_artifact_csv` / `format_deck_run_artifact_json` output for
 stable result-row, table, analysis-directive, output-probe, output-directive,
-measurement, Fourier, control-command, and diagnostic count/name lists.
+measurement, Fourier, control-command, write-marker, and diagnostic count/name
+lists.
 Normalized accepted `.control` commands are surfaced separately in
 `control_line_count` / `control_lines` execution fields and in
-`ControlLines` / `ControlLineList` artifact fields. Existing `.control` body
-policy diagnostics flow into those selected-run artifact `Diagnostics` /
+`ControlLines` / `ControlLineList` artifact fields.
+Accepted `.control` `write` / `wrdata` rawfile/data-write markers are surfaced
+as `write_marker_count` / `write_markers` execution fields and as
+`WriteMarkers` / `WriteMarkerList` artifact fields without serializing files.
+Existing `.control` body policy diagnostics flow into those selected-run artifact `Diagnostics` /
 `DiagnosticCodeList` fields and through the same run-artifact table, CSV, JSON,
 and `table_artifacts` records. `format_deck_table_csv` also converts any stable
 tab-separated deck table to CSV, `format_deck_table_json` converts the same
@@ -246,7 +250,7 @@ and output-directive artifacts,
 selected measurement artifacts, selected transient Fourier artifacts,
 selected-run artifact summaries with table, analysis-directive, output-probe,
 output-directive, measurement, Fourier probe, `.control` command, and
-diagnostic inventories, `.ac LIN`, `.ac DEC`, `.ac OCT` frequency grids, and
-`.tran` `START` / print-step `TSTEP` / `MAXSTEP` / `UIC` controls. Selected
-execution fields expose `.control` command and diagnostic inventories directly
-for host integrations.
+write-marker and diagnostic inventories, `.ac LIN`, `.ac DEC`, `.ac OCT`
+frequency grids, and `.tran` `START` / print-step `TSTEP` / `MAXSTEP` / `UIC`
+controls. Selected execution fields expose `.control` command, write-marker,
+and diagnostic inventories directly for host integrations.

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -3149,6 +3149,7 @@ pub struct DeckControlDiagnostic {
 pub struct DeckControlSummary {
     pub active_lines: Vec<String>,
     pub control_lines: Vec<String>,
+    pub write_markers: Vec<String>,
     pub terminated: bool,
     pub end_line_number: Option<usize>,
     pub diagnostics: Vec<DeckControlDiagnostic>,
@@ -3439,6 +3440,8 @@ pub struct DeckRunArtifact {
     pub fourier_probes: Vec<String>,
     pub control_line_count: usize,
     pub control_lines: Vec<String>,
+    pub write_marker_count: usize,
+    pub write_markers: Vec<String>,
     pub diagnostic_count: usize,
     pub diagnostic_codes: Vec<String>,
 }
@@ -3462,6 +3465,8 @@ pub struct DeckAnalysisExecution {
     pub analysis_directives: Vec<String>,
     pub control_line_count: usize,
     pub control_lines: Vec<String>,
+    pub write_marker_count: usize,
+    pub write_markers: Vec<String>,
     pub diagnostic_count: usize,
     pub diagnostic_codes: Vec<String>,
     pub table_count: usize,
@@ -3601,6 +3606,7 @@ pub fn compatibility_corpus() -> Vec<CompatibilityDeck> {
 pub fn analyze_deck_controls(netlist: &str) -> DeckControlSummary {
     let mut active_lines = Vec::new();
     let mut control_lines = Vec::new();
+    let mut write_markers = Vec::new();
     let mut diagnostics = Vec::new();
     let mut end_line_number = None;
     let mut in_control_block = false;
@@ -3620,6 +3626,10 @@ pub fn analyze_deck_controls(netlist: &str) -> DeckControlSummary {
             if let Some(control_line) = control_block_command_as_deck_line(stripped) {
                 active_lines.push(control_line.clone());
                 control_lines.push(control_line);
+                continue;
+            }
+            if let Some(write_marker) = control_block_write_marker(stripped) {
+                write_markers.push(write_marker);
                 continue;
             }
             if is_noop_control_block_command(stripped) {
@@ -3703,6 +3713,7 @@ pub fn analyze_deck_controls(netlist: &str) -> DeckControlSummary {
     DeckControlSummary {
         active_lines,
         control_lines,
+        write_markers,
         terminated: end_line_number.is_some(),
         end_line_number,
         diagnostics,
@@ -7317,6 +7328,26 @@ fn control_block_command_as_deck_line(line: &str) -> Option<String> {
     }
 }
 
+fn control_block_write_marker(line: &str) -> Option<String> {
+    let mut parts = line.split_whitespace();
+    let command = parts.next()?.to_ascii_lowercase();
+    if matches!(command.as_str(), "write" | ".write") {
+        let rest = parts.collect::<Vec<_>>();
+        if rest.is_empty() {
+            return None;
+        }
+        return Some(format!("write {}", rest.join(" ")));
+    }
+    if matches!(command.as_str(), "wrdata" | ".wrdata") {
+        let rest = parts.collect::<Vec<_>>();
+        if rest.len() < 2 {
+            return None;
+        }
+        return Some(format!("wrdata {}", rest.join(" ")));
+    }
+    None
+}
+
 fn is_noop_control_block_command(line: &str) -> bool {
     let mut parts = line.split_whitespace();
     let Some(command) = parts.next().map(|command| command.to_ascii_lowercase()) else {
@@ -10130,6 +10161,7 @@ fn deck_run_artifacts(
     measurements: &[ProbeMeasurement],
     fourier: &[FourierResult],
     control_lines: &[String],
+    write_markers: &[String],
     diagnostic_codes: &[String],
 ) -> Vec<DeckRunArtifact> {
     let is_transient = plan.analysis == "tran";
@@ -10176,6 +10208,8 @@ fn deck_run_artifacts(
             .collect(),
         control_line_count: control_lines.len(),
         control_lines: control_lines.to_vec(),
+        write_marker_count: write_markers.len(),
+        write_markers: write_markers.to_vec(),
         diagnostic_count: diagnostic_codes.len(),
         diagnostic_codes: diagnostic_codes.to_vec(),
     }]
@@ -10223,6 +10257,10 @@ fn deck_control_diagnostic_codes(netlist: &str) -> Vec<String> {
 
 fn deck_control_lines(netlist: &str) -> Vec<String> {
     analyze_deck_controls(netlist).control_lines
+}
+
+fn deck_control_write_markers(netlist: &str) -> Vec<String> {
+    analyze_deck_controls(netlist).write_markers
 }
 
 fn deck_run_diagnostic_codes(netlist: &str, plan: &DeckAnalysisPlan) -> Vec<String> {
@@ -10274,6 +10312,8 @@ const DECK_RUN_ARTIFACT_COLUMNS: &[&str] = &[
     "FourierList",
     "ControlLines",
     "ControlLineList",
+    "WriteMarkers",
+    "WriteMarkerList",
     "Diagnostics",
     "DiagnosticCodeList",
 ];
@@ -10317,6 +10357,8 @@ fn deck_run_artifact_cells(artifact: &DeckRunArtifact) -> Vec<String> {
         artifact.fourier_probes.join(";"),
         artifact.control_line_count.to_string(),
         artifact.control_lines.join(";"),
+        artifact.write_marker_count.to_string(),
+        artifact.write_markers.join(";"),
         artifact.diagnostic_count.to_string(),
         artifact.diagnostic_codes.join(";"),
     ]
@@ -10557,6 +10599,7 @@ pub fn run_deck_analysis(
     let plan = select_deck_analysis_plan(netlist, analysis)?;
     let diagnostic_codes = deck_run_diagnostic_codes(netlist, &plan);
     let control_lines = deck_control_lines(netlist);
+    let write_markers = deck_control_write_markers(netlist);
     let analysis_directives = deck_analysis_directives(&plan);
     match plan.analysis.as_str() {
         "op" => {
@@ -10579,6 +10622,7 @@ pub fn run_deck_analysis(
                 &measurements,
                 &fourier,
                 &control_lines,
+                &write_markers,
                 &diagnostic_codes,
             );
             let run_artifact_table = format_deck_run_artifact_table(&run_artifacts);
@@ -10600,6 +10644,8 @@ pub fn run_deck_analysis(
                 analysis_directives,
                 control_line_count: control_lines.len(),
                 control_lines: control_lines.clone(),
+                write_marker_count: write_markers.len(),
+                write_markers: write_markers.clone(),
                 diagnostic_count: diagnostic_codes.len(),
                 diagnostic_codes: diagnostic_codes.clone(),
                 table_count: tables.len(),
@@ -10639,6 +10685,7 @@ pub fn run_deck_analysis(
                 &measurements,
                 &fourier,
                 &control_lines,
+                &write_markers,
                 &diagnostic_codes,
             );
             let run_artifact_table = format_deck_run_artifact_table(&run_artifacts);
@@ -10660,6 +10707,8 @@ pub fn run_deck_analysis(
                 analysis_directives,
                 control_line_count: control_lines.len(),
                 control_lines: control_lines.clone(),
+                write_marker_count: write_markers.len(),
+                write_markers: write_markers.clone(),
                 diagnostic_count: diagnostic_codes.len(),
                 diagnostic_codes: diagnostic_codes.clone(),
                 table_count: tables.len(),
@@ -10700,6 +10749,7 @@ pub fn run_deck_analysis(
                 &measurements,
                 &fourier,
                 &control_lines,
+                &write_markers,
                 &diagnostic_codes,
             );
             let run_artifact_table = format_deck_run_artifact_table(&run_artifacts);
@@ -10721,6 +10771,8 @@ pub fn run_deck_analysis(
                 analysis_directives,
                 control_line_count: control_lines.len(),
                 control_lines: control_lines.clone(),
+                write_marker_count: write_markers.len(),
+                write_markers: write_markers.clone(),
                 diagnostic_count: diagnostic_codes.len(),
                 diagnostic_codes: diagnostic_codes.clone(),
                 table_count: tables.len(),
@@ -10764,6 +10816,7 @@ pub fn run_deck_analysis(
                 &measurements,
                 &fourier,
                 &control_lines,
+                &write_markers,
                 &diagnostic_codes,
             );
             let run_artifact_table = format_deck_run_artifact_table(&run_artifacts);
@@ -10785,6 +10838,8 @@ pub fn run_deck_analysis(
                 analysis_directives,
                 control_line_count: control_lines.len(),
                 control_lines: control_lines.clone(),
+                write_marker_count: write_markers.len(),
+                write_markers: write_markers.clone(),
                 diagnostic_count: diagnostic_codes.len(),
                 diagnostic_codes: diagnostic_codes.clone(),
                 table_count: tables.len(),
@@ -10822,6 +10877,7 @@ pub fn run_deck_analysis(
                 &measurements,
                 &fourier,
                 &control_lines,
+                &write_markers,
                 &diagnostic_codes,
             );
             let run_artifact_table = format_deck_run_artifact_table(&run_artifacts);
@@ -10843,6 +10899,8 @@ pub fn run_deck_analysis(
                 analysis_directives,
                 control_line_count: control_lines.len(),
                 control_lines: control_lines.clone(),
+                write_marker_count: write_markers.len(),
+                write_markers: write_markers.clone(),
                 diagnostic_count: diagnostic_codes.len(),
                 diagnostic_codes: diagnostic_codes.clone(),
                 table_count: tables.len(),
@@ -10878,6 +10936,7 @@ pub fn run_deck_analysis(
                 &measurements,
                 &fourier,
                 &control_lines,
+                &write_markers,
                 &diagnostic_codes,
             );
             let run_artifact_table = format_deck_run_artifact_table(&run_artifacts);
@@ -10899,6 +10958,8 @@ pub fn run_deck_analysis(
                 analysis_directives,
                 control_line_count: control_lines.len(),
                 control_lines: control_lines.clone(),
+                write_marker_count: write_markers.len(),
+                write_markers: write_markers.clone(),
                 diagnostic_count: diagnostic_codes.len(),
                 diagnostic_codes: diagnostic_codes.clone(),
                 table_count: tables.len(),
@@ -10946,6 +11007,7 @@ pub fn run_deck_analysis(
                 &measurements,
                 &fourier,
                 &control_lines,
+                &write_markers,
                 &diagnostic_codes,
             );
             let run_artifact_table = format_deck_run_artifact_table(&run_artifacts);
@@ -10967,6 +11029,8 @@ pub fn run_deck_analysis(
                 analysis_directives,
                 control_line_count: control_lines.len(),
                 control_lines: control_lines.clone(),
+                write_marker_count: write_markers.len(),
+                write_markers: write_markers.clone(),
                 diagnostic_count: diagnostic_codes.len(),
                 diagnostic_codes: diagnostic_codes.clone(),
                 table_count: tables.len(),

--- a/code/packages/rust/spice-engine/tests/compatibility_tests.rs
+++ b/code/packages/rust/spice-engine/tests/compatibility_tests.rs
@@ -209,6 +209,13 @@ quit
             ".four 2k V(in)".to_string(),
         ]
     );
+    assert_eq!(
+        summary.write_markers,
+        &[
+            "write out.raw V(out)".to_string(),
+            "wrdata out.dat V(out)".to_string(),
+        ]
+    );
     let diagnostics = summary
         .diagnostics
         .iter()
@@ -313,6 +320,27 @@ quit
         vec![
             (".four", 1000.0, vec!["V(out)"]),
             (".four", 2000.0, vec!["V(in)"])
+        ]
+    );
+}
+
+#[test]
+fn analyze_deck_controls_surfaces_dotted_write_markers() {
+    let summary = analyze_deck_controls(
+        "
+.control
+.write out.raw V(a)
+.wrdata out.dat V(a)
+.endc
+.end
+",
+    );
+
+    assert_eq!(
+        summary.write_markers,
+        &[
+            "write out.raw V(a)".to_string(),
+            "wrdata out.dat V(a)".to_string(),
         ]
     );
 }

--- a/code/packages/rust/spice-engine/tests/transient_tests.rs
+++ b/code/packages/rust/spice-engine/tests/transient_tests.rs
@@ -1969,7 +1969,7 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
     assert_eq!(
         op_execution.run_artifact_table,
         format!(
-            "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tDiagnostics\tDiagnosticCodeList\nop\t.op\t1\t.op\t{}\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t1\t2\tIndex;V(mid)\t2\tresult;run-artifact\t1\tV(mid)\t1\t.save\t0\t\t0\t\t0\t\t0\t\n",
+            "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tWriteMarkers\tWriteMarkerList\tDiagnostics\tDiagnosticCodeList\nop\t.op\t1\t.op\t{}\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t1\t2\tIndex;V(mid)\t2\tresult;run-artifact\t1\tV(mid)\t1\t.save\t0\t\t0\t\t0\t\t0\t\t0\t\n",
             op_execution.plan.line_number
         )
     );
@@ -2021,7 +2021,7 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
     assert_eq!(
         format_deck_run_artifact_csv(&op_execution.run_artifacts),
         format!(
-            "Analysis,Directive,AnalysisDirectives,AnalysisDirectiveList,Line,SourceName,OutputNode,SweepKind,StartValue,StopValue,StepValue,PointCount,StartFrequencyHz,StopFrequencyHz,StepTime,StopTime,StartTime,MaxStep,UseInitialConditions,ResultRows,ResultColumns,ResultColumnList,Tables,TableList,OutputProbes,OutputProbeList,OutputDirectives,OutputDirectiveList,Measurements,MeasurementList,Fourier,FourierList,ControlLines,ControlLineList,Diagnostics,DiagnosticCodeList\nop,.op,1,.op,{},,,,,,,,,,,,,,,1,2,Index;V(mid),2,result;run-artifact,1,V(mid),1,.save,0,,0,,0,,0,\n",
+            "Analysis,Directive,AnalysisDirectives,AnalysisDirectiveList,Line,SourceName,OutputNode,SweepKind,StartValue,StopValue,StepValue,PointCount,StartFrequencyHz,StopFrequencyHz,StepTime,StopTime,StartTime,MaxStep,UseInitialConditions,ResultRows,ResultColumns,ResultColumnList,Tables,TableList,OutputProbes,OutputProbeList,OutputDirectives,OutputDirectiveList,Measurements,MeasurementList,Fourier,FourierList,ControlLines,ControlLineList,WriteMarkers,WriteMarkerList,Diagnostics,DiagnosticCodeList\nop,.op,1,.op,{},,,,,,,,,,,,,,,1,2,Index;V(mid),2,result;run-artifact,1,V(mid),1,.save,0,,0,,0,,0,,0,\n",
             op_execution.plan.line_number
         )
     );
@@ -2048,7 +2048,7 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
     assert!(artifact_json.contains("\"TableList\":\"result;run-artifact\""));
     assert!(artifact_json.contains("\"OutputProbeList\":\"V(mid)\""));
     assert!(artifact_json.ends_with(
-        "\"ControlLines\":\"0\",\"ControlLineList\":\"\",\"Diagnostics\":\"0\",\"DiagnosticCodeList\":\"\"}]\n"
+        "\"ControlLines\":\"0\",\"ControlLineList\":\"\",\"WriteMarkers\":\"0\",\"WriteMarkerList\":\"\",\"Diagnostics\":\"0\",\"DiagnosticCodeList\":\"\"}]\n"
     ));
     let mut diagnostic_artifact = op_execution.run_artifacts[0].clone();
     diagnostic_artifact.diagnostic_codes = vec![
@@ -2080,7 +2080,7 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
             .ends_with(",0,,2,\"SPICE_DECK_ANALYSIS_TOKEN;SPICE,\"\"QUOTED\"\"\"\n")
     );
     assert!(format_deck_run_artifact_json(&[quoted_diagnostic_artifact]).ends_with(
-        ",\"ControlLines\":\"0\",\"ControlLineList\":\"\",\"Diagnostics\":\"2\",\"DiagnosticCodeList\":\"SPICE_DECK_ANALYSIS_TOKEN;SPICE,\\\"QUOTED\\\"\"}]\n"
+        ",\"ControlLines\":\"0\",\"ControlLineList\":\"\",\"WriteMarkers\":\"0\",\"WriteMarkerList\":\"\",\"Diagnostics\":\"2\",\"DiagnosticCodeList\":\"SPICE_DECK_ANALYSIS_TOKEN;SPICE,\\\"QUOTED\\\"\"}]\n"
     ));
 
     let dc_execution = run_deck_analysis(&circuit, netlist, Some("dc")).unwrap();
@@ -2191,7 +2191,7 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
     assert_eq!(
         dc_execution.run_artifact_table,
         format!(
-            "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tDiagnostics\tDiagnosticCodeList\ndc\t.dc\t1\t.dc\t{}\tV1\t\t\t0.000000e+00\t1.000000e+00\t1.000000e+00\t\t\t\t\t\t\t\t\t2\t5\tIndex;Source;Value;V(mid);I(V1)\t3\tresult;measurement;run-artifact\t2\tV(mid);I(V1)\t2\t.save;.probe\t1\tmid_avg\t0\t\t0\t\t0\t\n",
+            "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tWriteMarkers\tWriteMarkerList\tDiagnostics\tDiagnosticCodeList\ndc\t.dc\t1\t.dc\t{}\tV1\t\t\t0.000000e+00\t1.000000e+00\t1.000000e+00\t\t\t\t\t\t\t\t\t2\t5\tIndex;Source;Value;V(mid);I(V1)\t3\tresult;measurement;run-artifact\t2\tV(mid);I(V1)\t2\t.save;.probe\t1\tmid_avg\t0\t\t0\t\t0\t\t0\t\n",
             dc_execution.plan.line_number
         )
     );
@@ -2274,7 +2274,7 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
     assert_eq!(
         ac_execution.run_artifact_table,
         format!(
-            "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tDiagnostics\tDiagnosticCodeList\nac\t.ac\t1\t.ac\t{}\t\t\tdec\t\t\t\t1\t1.000000e+03\t1.000000e+03\t\t\t\t\t\t1\t7\tIndex;Frequency;Probe;Real;Imaginary;Magnitude;Phase\t3\tresult;measurement;run-artifact\t1\tV(mid)\t1\t.save\t1\tmid_peak\t0\t\t0\t\t0\t\n",
+            "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tWriteMarkers\tWriteMarkerList\tDiagnostics\tDiagnosticCodeList\nac\t.ac\t1\t.ac\t{}\t\t\tdec\t\t\t\t1\t1.000000e+03\t1.000000e+03\t\t\t\t\t\t1\t7\tIndex;Frequency;Probe;Real;Imaginary;Magnitude;Phase\t3\tresult;measurement;run-artifact\t1\tV(mid)\t1\t.save\t1\tmid_peak\t0\t\t0\t\t0\t\t0\t\n",
             ac_execution.plan.line_number
         )
     );
@@ -2354,7 +2354,7 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
     assert_eq!(
         tran_execution.run_artifact_table,
         format!(
-            "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tDiagnostics\tDiagnosticCodeList\ntran\t.tran\t1\t.tran\t{}\t\t\t\t\t\t\t\t\t\t1.000000e-03\t1.000000e-03\t\t\tfalse\t1\t3\tIndex;Time;V(mid)\t3\tresult;measurement;run-artifact\t1\tV(mid)\t1\t.save\t1\tmid_final\t0\t\t0\t\t0\t\n",
+            "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tWriteMarkers\tWriteMarkerList\tDiagnostics\tDiagnosticCodeList\ntran\t.tran\t1\t.tran\t{}\t\t\t\t\t\t\t\t\t\t1.000000e-03\t1.000000e-03\t\t\tfalse\t1\t3\tIndex;Time;V(mid)\t3\tresult;measurement;run-artifact\t1\tV(mid)\t1\t.save\t1\tmid_final\t0\t\t0\t\t0\t\t0\t\n",
             tran_execution.plan.line_number
         )
     );
@@ -2423,7 +2423,7 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
     assert_eq!(
         tf_execution.run_artifact_table,
         format!(
-            "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tDiagnostics\tDiagnosticCodeList\ntf\t.tf\t1\t.tf\t{}\tV1\tmid\t\t\t\t\t\t\t\t\t\t\t\t\t1\t3\tTransferRatio;InputImpedance;OutputImpedance\t2\tresult;run-artifact\t1\tV(mid)\t0\t\t0\t\t0\t\t0\t\t0\t\n",
+            "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tWriteMarkers\tWriteMarkerList\tDiagnostics\tDiagnosticCodeList\ntf\t.tf\t1\t.tf\t{}\tV1\tmid\t\t\t\t\t\t\t\t\t\t\t\t\t1\t3\tTransferRatio;InputImpedance;OutputImpedance\t2\tresult;run-artifact\t1\tV(mid)\t0\t\t0\t\t0\t\t0\t\t0\t\t0\t\n",
             tf_execution.plan.line_number
         )
     );
@@ -2493,7 +2493,7 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
     assert_eq!(
         sens_execution.run_artifact_table,
         format!(
-            "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tDiagnostics\tDiagnosticCodeList\nsens\t.sens\t1\t.sens\t{}\t\tmid\t\t\t\t\t\t\t\t\t\t\t\t\t1\t7\tOutputNode;NominalVoltage;Element;Parameter;NominalValue;Sensitivity;RelativeSensitivity\t2\tresult;run-artifact\t1\tV(mid)\t0\t\t0\t\t0\t\t0\t\t0\t\n",
+            "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tWriteMarkers\tWriteMarkerList\tDiagnostics\tDiagnosticCodeList\nsens\t.sens\t1\t.sens\t{}\t\tmid\t\t\t\t\t\t\t\t\t\t\t\t\t1\t7\tOutputNode;NominalVoltage;Element;Parameter;NominalValue;Sensitivity;RelativeSensitivity\t2\tresult;run-artifact\t1\tV(mid)\t0\t\t0\t\t0\t\t0\t\t0\t\t0\t\n",
             sens_execution.plan.line_number
         )
     );
@@ -2595,7 +2595,7 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
     assert_eq!(
         noise_execution.run_artifact_table,
         format!(
-            "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tDiagnostics\tDiagnosticCodeList\nnoise\t.noise\t1\t.noise\t{}\tV1\tmid\tlin\t\t\t\t1\t1.000000e+03\t1.000000e+03\t\t\t\t\t\t1\t10\tIndex;Frequency;OutputNode;InputSource;OutputPSD;InputReferredPSD;Element;Type;SourcePSD;ContributionPSD\t2\tresult;run-artifact\t1\tV(mid)\t0\t\t0\t\t0\t\t0\t\t0\t\n",
+            "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tWriteMarkers\tWriteMarkerList\tDiagnostics\tDiagnosticCodeList\nnoise\t.noise\t1\t.noise\t{}\tV1\tmid\tlin\t\t\t\t1\t1.000000e+03\t1.000000e+03\t\t\t\t\t\t1\t10\tIndex;Frequency;OutputNode;InputSource;OutputPSD;InputReferredPSD;Element;Type;SourcePSD;ContributionPSD\t2\tresult;run-artifact\t1\tV(mid)\t0\t\t0\t\t0\t\t0\t\t0\t\t0\t\n",
             noise_execution.plan.line_number
         )
     );
@@ -2672,7 +2672,7 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
     assert_eq!(
         tran_window_execution.run_artifact_table,
         format!(
-            "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tDiagnostics\tDiagnosticCodeList\ntran\t.tran\t1\t.tran\t{}\t\t\t\t\t\t\t\t\t\t2.000000e-03\t6.000000e-03\t2.000000e-03\t1.000000e-03\ttrue\t3\t3\tIndex;Time;V(mid)\t2\tresult;run-artifact\t1\tV(mid)\t1\t.save\t0\t\t0\t\t0\t\t0\t\n",
+            "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tWriteMarkers\tWriteMarkerList\tDiagnostics\tDiagnosticCodeList\ntran\t.tran\t1\t.tran\t{}\t\t\t\t\t\t\t\t\t\t2.000000e-03\t6.000000e-03\t2.000000e-03\t1.000000e-03\ttrue\t3\t3\tIndex;Time;V(mid)\t2\tresult;run-artifact\t1\tV(mid)\t1\t.save\t0\t\t0\t\t0\t\t0\t\t0\t\n",
             tran_window_execution.plan.line_number
         )
     );
@@ -2729,6 +2729,8 @@ fn run_deck_analysis_surfaces_control_diagnostics_in_artifacts() {
 .control
 save V(in)
 probe V(in)
+write out.raw V(in)
+wrdata out.dat V(in)
 source other.cir
 cd /tmp
 if v(in) > 0
@@ -2748,9 +2750,16 @@ let gain = 2
     let code_list = expected_codes.join(";");
     let expected_control_lines = vec![".save V(in)".to_string(), ".probe V(in)".to_string()];
     let control_line_list = expected_control_lines.join(";");
+    let expected_write_markers = vec![
+        "write out.raw V(in)".to_string(),
+        "wrdata out.dat V(in)".to_string(),
+    ];
+    let write_marker_list = expected_write_markers.join(";");
 
     assert_eq!(execution.control_line_count, expected_control_lines.len());
     assert_eq!(execution.control_lines, expected_control_lines);
+    assert_eq!(execution.write_marker_count, expected_write_markers.len());
+    assert_eq!(execution.write_markers, expected_write_markers);
     assert_eq!(execution.diagnostic_count, expected_codes.len());
     assert_eq!(execution.diagnostic_codes, expected_codes);
     assert_eq!(
@@ -2760,6 +2769,14 @@ let gain = 2
     assert_eq!(
         execution.run_artifacts[0].control_lines,
         expected_control_lines
+    );
+    assert_eq!(
+        execution.run_artifacts[0].write_marker_count,
+        expected_write_markers.len()
+    );
+    assert_eq!(
+        execution.run_artifacts[0].write_markers,
+        expected_write_markers
     );
     assert_eq!(
         execution.run_artifacts[0].diagnostic_count,
@@ -2775,6 +2792,14 @@ let gain = 2
         records[0].get("ControlLineList").map(String::as_str),
         Some(control_line_list.as_str())
     );
+    assert_eq!(
+        records[0].get("WriteMarkers").map(String::as_str),
+        Some("2")
+    );
+    assert_eq!(
+        records[0].get("WriteMarkerList").map(String::as_str),
+        Some(write_marker_list.as_str())
+    );
     assert_eq!(records[0].get("Diagnostics").map(String::as_str), Some("4"));
     assert_eq!(
         records[0].get("DiagnosticCodeList").map(String::as_str),
@@ -2787,6 +2812,12 @@ let gain = 2
             .get("ControlLineList")
             .map(String::as_str),
         Some(control_line_list.as_str())
+    );
+    assert_eq!(
+        run_artifact.records[0]
+            .get("WriteMarkerList")
+            .map(String::as_str),
+        Some(write_marker_list.as_str())
     );
     assert_eq!(
         run_artifact.records[0]
@@ -2916,7 +2947,7 @@ fn run_deck_analysis_exposes_selected_fourier_artifacts() {
     assert_eq!(
         tran_execution.run_artifact_table,
         format!(
-            "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tDiagnostics\tDiagnosticCodeList\ntran\t.tran\t1\t.tran\t{}\t\t\t\t\t\t\t\t\t\t5.000000e-04\t1.000000e-03\t\t\tfalse\t2\t3\tIndex;Time;V(mid)\t3\tresult;fourier;run-artifact\t1\tV(mid)\t1\t.save\t0\t\t1\tV(mid)\t0\t\t0\t\n",
+            "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tWriteMarkers\tWriteMarkerList\tDiagnostics\tDiagnosticCodeList\ntran\t.tran\t1\t.tran\t{}\t\t\t\t\t\t\t\t\t\t5.000000e-04\t1.000000e-03\t\t\tfalse\t2\t3\tIndex;Time;V(mid)\t3\tresult;fourier;run-artifact\t1\tV(mid)\t1\t.save\t0\t\t1\tV(mid)\t0\t\t0\t\t0\t\n",
             tran_execution.plan.line_number
         )
     );

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- Expose accepted `.control` `write` / `wrdata` marker inventories from
+  `analyzeDeckControls` and selected `runDeckAnalysis` execution results as
+  `writeMarkerCount` / `writeMarkers`, and carry them through selected-run
+  artifacts as stable `WriteMarkers` / `WriteMarkerList` table, CSV/JSON, and
+  ordered `tableArtifacts` fields, matching Python and Rust.
 - Expose selected diagnostic inventories directly on selected
   `runDeckAnalysis` execution results as `diagnosticCount` /
   `diagnosticCodes`, matching Python and Rust.

--- a/code/packages/typescript/spice-engine/README.md
+++ b/code/packages/typescript/spice-engine/README.md
@@ -105,11 +105,15 @@ results and a stable Fourier table. Executions also include selected-run
 artifact summaries plus `formatDeckRunArtifactTable` and
 `formatDeckRunArtifactCsv` / `formatDeckRunArtifactJson` output for stable
 result-row, table, analysis-directive, output-probe, output-directive,
-measurement, Fourier, control-command, and diagnostic count/name lists.
+measurement, Fourier, control-command, write-marker, and diagnostic count/name
+lists.
 Normalized accepted `.control` commands are surfaced separately in
 `controlLineCount` / `controlLines` execution fields and in
-`ControlLines` / `ControlLineList` artifact fields. Existing `.control` body
-policy diagnostics flow into those selected-run artifact `Diagnostics` /
+`ControlLines` / `ControlLineList` artifact fields.
+Accepted `.control` `write` / `wrdata` rawfile/data-write markers are surfaced
+as `writeMarkerCount` / `writeMarkers` execution fields and as `WriteMarkers` /
+`WriteMarkerList` artifact fields without serializing files. Existing
+`.control` body policy diagnostics flow into those selected-run artifact `Diagnostics` /
 `DiagnosticCodeList` fields and through the same run-artifact table, CSV, JSON,
 and `tableArtifacts` records. `formatDeckTableCsv` also converts any stable tab-separated deck table to
 CSV, `formatDeckTableJson` converts the same tables to compact JSON records,
@@ -208,8 +212,8 @@ deck execution helpers.
 deck-selected table output with normalized table-inventory, output-probe, and
 output-directive artifacts, selected measurement artifacts, selected transient Fourier artifacts,
 selected-run artifact summaries with table, analysis-directive, output-probe, output-directive,
-measurement, Fourier probe, `.control` command, and diagnostic inventories,
+measurement, Fourier probe, `.control` command, write-marker, and diagnostic inventories,
 `.ac LIN`, `.ac DEC`, `.ac OCT` frequency grids, and `.tran` `START` /
 print-step `TSTEP` / `MAXSTEP` / `UIC` controls. Selected execution fields
-expose `.control` command and diagnostic inventories directly for host
-integrations.
+expose `.control` command, write-marker, and diagnostic inventories directly
+for host integrations.

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -428,6 +428,7 @@ export interface DeckControlDiagnostic {
 export interface DeckControlSummary {
   readonly activeLines: readonly string[];
   readonly controlLines: readonly string[];
+  readonly writeMarkers: readonly string[];
   readonly terminated: boolean;
   readonly endLineNumber?: number;
   readonly diagnostics: readonly DeckControlDiagnostic[];
@@ -694,6 +695,8 @@ export interface DeckRunArtifact {
   readonly fourierProbes: readonly string[];
   readonly controlLineCount: number;
   readonly controlLines: readonly string[];
+  readonly writeMarkerCount: number;
+  readonly writeMarkers: readonly string[];
   readonly diagnosticCount: number;
   readonly diagnosticCodes: readonly string[];
 }
@@ -715,6 +718,8 @@ export interface DeckAnalysisExecution {
   readonly analysisDirectives: readonly string[];
   readonly controlLineCount: number;
   readonly controlLines: readonly string[];
+  readonly writeMarkerCount: number;
+  readonly writeMarkers: readonly string[];
   readonly diagnosticCount: number;
   readonly diagnosticCodes: readonly string[];
   readonly tableCount: number;
@@ -2984,6 +2989,7 @@ export function compatibilityCorpus(): readonly CompatibilityDeck[] {
 export function analyzeDeckControls(netlist: string): DeckControlSummary {
   const activeLines: string[] = [];
   const controlLines: string[] = [];
+  const writeMarkers: string[] = [];
   const diagnostics: DeckControlDiagnostic[] = [];
   let endLineNumber: number | undefined;
   let inControlBlock = false;
@@ -3005,6 +3011,11 @@ export function analyzeDeckControls(netlist: string): DeckControlSummary {
       if (controlLine !== undefined) {
         activeLines.push(controlLine);
         controlLines.push(controlLine);
+        continue;
+      }
+      const writeMarker = controlBlockWriteMarker(stripped);
+      if (writeMarker !== undefined) {
+        writeMarkers.push(writeMarker);
         continue;
       }
       if (isNoopControlBlockCommand(stripped)) {
@@ -3082,6 +3093,7 @@ export function analyzeDeckControls(netlist: string): DeckControlSummary {
   return {
     activeLines,
     controlLines,
+    writeMarkers,
     terminated: endLineNumber !== undefined,
     endLineNumber,
     diagnostics,
@@ -6149,6 +6161,23 @@ function controlBlockCommandAsDeckLine(line: string): string | undefined {
   return rest.length === 0 ? directive : `${directive} ${rest}`;
 }
 
+function controlBlockWriteMarker(line: string): string | undefined {
+  const parts = line.split(/\s+/);
+  const command = parts[0]?.toLowerCase();
+  if (command === undefined) {
+    return undefined;
+  }
+  if (NOOP_CONTROL_BLOCK_ARGUMENT_COMMANDS.has(command)) {
+    const rest = parts.slice(1);
+    return rest.length === 0 ? undefined : `${command.replace(/^\./, "")} ${rest.join(" ")}`;
+  }
+  if (NOOP_CONTROL_BLOCK_VECTOR_ARGUMENT_COMMANDS.has(command)) {
+    const rest = parts.slice(1);
+    return rest.length < 2 ? undefined : `${command.replace(/^\./, "")} ${rest.join(" ")}`;
+  }
+  return undefined;
+}
+
 function isNoopControlBlockCommand(line: string): boolean {
   const parts = line.split(/\s+/);
   const command = parts[0]?.toLowerCase();
@@ -7916,6 +7945,7 @@ function deckRunArtifacts(
   measurements: readonly ProbeMeasurement[],
   fourier: readonly FourierResult[],
   controlLines: readonly string[],
+  writeMarkers: readonly string[],
   diagnosticCodes: readonly string[],
 ): DeckRunArtifact[] {
   const isTransient = plan.analysis === "tran";
@@ -7957,6 +7987,8 @@ function deckRunArtifacts(
       fourierProbes: fourier.flatMap((result) => result.probes.map((probe) => probe.probe)),
       controlLineCount: controlLines.length,
       controlLines: [...controlLines],
+      writeMarkerCount: writeMarkers.length,
+      writeMarkers: [...writeMarkers],
       diagnosticCount: diagnosticCodes.length,
       diagnosticCodes: [...diagnosticCodes],
     },
@@ -7998,6 +8030,10 @@ function deckControlDiagnosticCodes(netlist: string): string[] {
 
 function deckControlLines(netlist: string): string[] {
   return [...analyzeDeckControls(netlist).controlLines];
+}
+
+function deckControlWriteMarkers(netlist: string): string[] {
+  return [...analyzeDeckControls(netlist).writeMarkers];
 }
 
 function deckRunDiagnosticCodes(netlist: string, plan: DeckAnalysisPlan): string[] {
@@ -8050,6 +8086,8 @@ const DECK_RUN_ARTIFACT_COLUMNS = [
   "FourierList",
   "ControlLines",
   "ControlLineList",
+  "WriteMarkers",
+  "WriteMarkerList",
   "Diagnostics",
   "DiagnosticCodeList",
 ] as const;
@@ -8090,6 +8128,8 @@ function deckRunArtifactCells(artifact: DeckRunArtifact): string[] {
     artifact.fourierProbes.join(";"),
     String(artifact.controlLineCount),
     artifact.controlLines.join(";"),
+    String(artifact.writeMarkerCount),
+    artifact.writeMarkers.join(";"),
     String(artifact.diagnosticCount),
     artifact.diagnosticCodes.join(";"),
   ];
@@ -8239,6 +8279,7 @@ export function runDeckAnalysis(
   const plan = selectDeckAnalysisPlan(netlist, analysis);
   const diagnosticCodes = deckRunDiagnosticCodes(netlist, plan);
   const controlLines = deckControlLines(netlist);
+  const writeMarkers = deckControlWriteMarkers(netlist);
   const analysisDirectives = deckAnalysisDirectives(plan);
   if (plan.analysis === "op") {
     const result = dcOp(circuit);
@@ -8258,6 +8299,7 @@ export function runDeckAnalysis(
       measurements,
       fourier,
       controlLines,
+      writeMarkers,
       diagnosticCodes,
     );
     const tables = deckStableTables(measurements, fourier);
@@ -8281,6 +8323,8 @@ export function runDeckAnalysis(
       analysisDirectives,
       controlLineCount: controlLines.length,
       controlLines: [...controlLines],
+      writeMarkerCount: writeMarkers.length,
+      writeMarkers: [...writeMarkers],
       diagnosticCount: diagnosticCodes.length,
       diagnosticCodes: [...diagnosticCodes],
       tableCount: tables.length,
@@ -8318,6 +8362,7 @@ export function runDeckAnalysis(
       measurements,
       fourier,
       controlLines,
+      writeMarkers,
       diagnosticCodes,
     );
     const tables = deckStableTables(measurements, fourier);
@@ -8341,6 +8386,8 @@ export function runDeckAnalysis(
       analysisDirectives,
       controlLineCount: controlLines.length,
       controlLines: [...controlLines],
+      writeMarkerCount: writeMarkers.length,
+      writeMarkers: [...writeMarkers],
       diagnosticCount: diagnosticCodes.length,
       diagnosticCodes: [...diagnosticCodes],
       tableCount: tables.length,
@@ -8389,6 +8436,7 @@ export function runDeckAnalysis(
       measurements,
       fourier,
       controlLines,
+      writeMarkers,
       diagnosticCodes,
     );
     const tables = deckStableTables(measurements, fourier);
@@ -8412,6 +8460,8 @@ export function runDeckAnalysis(
       analysisDirectives,
       controlLineCount: controlLines.length,
       controlLines: [...controlLines],
+      writeMarkerCount: writeMarkers.length,
+      writeMarkers: [...writeMarkers],
       diagnosticCount: diagnosticCodes.length,
       diagnosticCodes: [...diagnosticCodes],
       tableCount: tables.length,
@@ -8455,6 +8505,7 @@ export function runDeckAnalysis(
       measurements,
       fourier,
       controlLines,
+      writeMarkers,
       diagnosticCodes,
     );
     const tables = deckStableTables(measurements, fourier);
@@ -8478,6 +8529,8 @@ export function runDeckAnalysis(
       analysisDirectives,
       controlLineCount: controlLines.length,
       controlLines: [...controlLines],
+      writeMarkerCount: writeMarkers.length,
+      writeMarkers: [...writeMarkers],
       diagnosticCount: diagnosticCodes.length,
       diagnosticCodes: [...diagnosticCodes],
       tableCount: tables.length,
@@ -8511,6 +8564,7 @@ export function runDeckAnalysis(
       measurements,
       fourier,
       controlLines,
+      writeMarkers,
       diagnosticCodes,
     );
     const tables = deckStableTables(measurements, fourier);
@@ -8534,6 +8588,8 @@ export function runDeckAnalysis(
       analysisDirectives,
       controlLineCount: controlLines.length,
       controlLines: [...controlLines],
+      writeMarkerCount: writeMarkers.length,
+      writeMarkers: [...writeMarkers],
       diagnosticCount: diagnosticCodes.length,
       diagnosticCodes: [...diagnosticCodes],
       tableCount: tables.length,
@@ -8566,6 +8622,7 @@ export function runDeckAnalysis(
       measurements,
       fourier,
       controlLines,
+      writeMarkers,
       diagnosticCodes,
     );
     const tables = deckStableTables(measurements, fourier);
@@ -8589,6 +8646,8 @@ export function runDeckAnalysis(
       analysisDirectives,
       controlLineCount: controlLines.length,
       controlLines: [...controlLines],
+      writeMarkerCount: writeMarkers.length,
+      writeMarkers: [...writeMarkers],
       diagnosticCount: diagnosticCodes.length,
       diagnosticCodes: [...diagnosticCodes],
       tableCount: tables.length,
@@ -8631,6 +8690,7 @@ export function runDeckAnalysis(
       measurements,
       fourier,
       controlLines,
+      writeMarkers,
       diagnosticCodes,
     );
     const tables = deckStableTables(measurements, fourier);
@@ -8654,6 +8714,8 @@ export function runDeckAnalysis(
       analysisDirectives,
       controlLineCount: controlLines.length,
       controlLines: [...controlLines],
+      writeMarkerCount: writeMarkers.length,
+      writeMarkers: [...writeMarkers],
       diagnosticCount: diagnosticCodes.length,
       diagnosticCodes: [...diagnosticCodes],
       tableCount: tables.length,

--- a/code/packages/typescript/spice-engine/tests/compatibility.test.ts
+++ b/code/packages/typescript/spice-engine/tests/compatibility.test.ts
@@ -189,6 +189,10 @@ quit
       ".four 1k V(out)",
       ".four 2k V(in)",
     ]);
+    expect(summary.writeMarkers).toStrictEqual([
+      "write out.raw V(out)",
+      "wrdata out.dat V(out)",
+    ]);
     expect(summary.diagnostics.map(({ directive, lineNumber, severity }) => [
       directive,
       lineNumber,
@@ -258,6 +262,21 @@ quit
     ])).toStrictEqual([
       [".four", 1000, ["V(out)"]],
       [".four", 2000, ["V(in)"]],
+    ]);
+  });
+
+  it("surfaces dotted write markers from control blocks", () => {
+    const summary = analyzeDeckControls(`
+.control
+.write out.raw V(a)
+.wrdata out.dat V(a)
+.endc
+.end
+`);
+
+    expect(summary.writeMarkers).toStrictEqual([
+      "write out.raw V(a)",
+      "wrdata out.dat V(a)",
     ]);
   });
 

--- a/code/packages/typescript/spice-engine/tests/transient.test.ts
+++ b/code/packages/typescript/spice-engine/tests/transient.test.ts
@@ -1519,8 +1519,8 @@ describe("transient", () => {
     expect(opExecution.runArtifacts[0]?.diagnosticCount).toBe(0);
     expect(opExecution.runArtifacts[0]?.diagnosticCodes).toEqual([]);
     expect(opExecution.runArtifactTable).toBe(
-      "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tDiagnostics\tDiagnosticCodeList\n" +
-        `op\t.op\t1\t.op\t${opExecution.plan.lineNumber}\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t1\t2\tIndex;V(mid)\t2\tresult;run-artifact\t1\tV(mid)\t1\t.save\t0\t\t0\t\t0\t\t0\t\n`,
+      "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tWriteMarkers\tWriteMarkerList\tDiagnostics\tDiagnosticCodeList\n" +
+        `op\t.op\t1\t.op\t${opExecution.plan.lineNumber}\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t1\t2\tIndex;V(mid)\t2\tresult;run-artifact\t1\tV(mid)\t1\t.save\t0\t\t0\t\t0\t\t0\t\t0\t\n`,
     );
     expect(opExecution.tableArtifacts[1]?.name).toBe("run-artifact");
     expect(opExecution.tableArtifacts[1]?.table).toBe(opExecution.runArtifactTable);
@@ -1537,8 +1537,8 @@ describe("transient", () => {
       JSON.parse(formatDeckRunArtifactJson(opExecution.runArtifacts)),
     );
     expect(formatDeckRunArtifactCsv(opExecution.runArtifacts)).toBe(
-      "Analysis,Directive,AnalysisDirectives,AnalysisDirectiveList,Line,SourceName,OutputNode,SweepKind,StartValue,StopValue,StepValue,PointCount,StartFrequencyHz,StopFrequencyHz,StepTime,StopTime,StartTime,MaxStep,UseInitialConditions,ResultRows,ResultColumns,ResultColumnList,Tables,TableList,OutputProbes,OutputProbeList,OutputDirectives,OutputDirectiveList,Measurements,MeasurementList,Fourier,FourierList,ControlLines,ControlLineList,Diagnostics,DiagnosticCodeList\n" +
-        `op,.op,1,.op,${opExecution.plan.lineNumber},,,,,,,,,,,,,,,1,2,Index;V(mid),2,result;run-artifact,1,V(mid),1,.save,0,,0,,0,,0,\n`,
+      "Analysis,Directive,AnalysisDirectives,AnalysisDirectiveList,Line,SourceName,OutputNode,SweepKind,StartValue,StopValue,StepValue,PointCount,StartFrequencyHz,StopFrequencyHz,StepTime,StopTime,StartTime,MaxStep,UseInitialConditions,ResultRows,ResultColumns,ResultColumnList,Tables,TableList,OutputProbes,OutputProbeList,OutputDirectives,OutputDirectiveList,Measurements,MeasurementList,Fourier,FourierList,ControlLines,ControlLineList,WriteMarkers,WriteMarkerList,Diagnostics,DiagnosticCodeList\n" +
+        `op,.op,1,.op,${opExecution.plan.lineNumber},,,,,,,,,,,,,,,1,2,Index;V(mid),2,result;run-artifact,1,V(mid),1,.save,0,,0,,0,,0,,0,\n`,
     );
     expect(formatDeckTableCsv('Name\tValue\nprobe\tSPICE,"QUOTED"\n')).toBe(
       'Name,Value\nprobe,"SPICE,""QUOTED"""\n',
@@ -1586,6 +1586,8 @@ describe("transient", () => {
       "FourierList",
       "ControlLines",
       "ControlLineList",
+      "WriteMarkers",
+      "WriteMarkerList",
       "Diagnostics",
       "DiagnosticCodeList",
     ]);
@@ -1625,6 +1627,8 @@ describe("transient", () => {
         FourierList: "",
         ControlLines: "0",
         ControlLineList: "",
+        WriteMarkers: "0",
+        WriteMarkerList: "",
         Diagnostics: "0",
         DiagnosticCodeList: "",
       },
@@ -1711,8 +1715,8 @@ describe("transient", () => {
     expect(dcExecution.runArtifacts[0]?.measurementNames).toEqual(["mid_avg"]);
     expect(dcExecution.runArtifacts[0]?.fourierProbes).toEqual([]);
     expect(dcExecution.runArtifactTable).toBe(
-      "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tDiagnostics\tDiagnosticCodeList\n" +
-        `dc\t.dc\t1\t.dc\t${dcExecution.plan.lineNumber}\tV1\t\t\t0.000000e+00\t1.000000e+00\t1.000000e+00\t\t\t\t\t\t\t\t\t2\t5\tIndex;Source;Value;V(mid);I(V1)\t3\tresult;measurement;run-artifact\t2\tV(mid);I(V1)\t2\t.save;.probe\t1\tmid_avg\t0\t\t0\t\t0\t\n`,
+      "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tWriteMarkers\tWriteMarkerList\tDiagnostics\tDiagnosticCodeList\n" +
+        `dc\t.dc\t1\t.dc\t${dcExecution.plan.lineNumber}\tV1\t\t\t0.000000e+00\t1.000000e+00\t1.000000e+00\t\t\t\t\t\t\t\t\t2\t5\tIndex;Source;Value;V(mid);I(V1)\t3\tresult;measurement;run-artifact\t2\tV(mid);I(V1)\t2\t.save;.probe\t1\tmid_avg\t0\t\t0\t\t0\t\t0\t\n`,
     );
 
     const acExecution = runDeckAnalysis(circuit, netlist, "ac");
@@ -1760,8 +1764,8 @@ describe("transient", () => {
     expect(acExecution.runArtifacts[0]?.measurementNames).toEqual(["mid_peak"]);
     expect(acExecution.runArtifacts[0]?.fourierProbes).toEqual([]);
     expect(acExecution.runArtifactTable).toBe(
-      "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tDiagnostics\tDiagnosticCodeList\n" +
-        `ac\t.ac\t1\t.ac\t${acExecution.plan.lineNumber}\t\t\tdec\t\t\t\t1\t1.000000e+03\t1.000000e+03\t\t\t\t\t\t1\t7\tIndex;Frequency;Probe;Real;Imaginary;Magnitude;Phase\t3\tresult;measurement;run-artifact\t1\tV(mid)\t1\t.save\t1\tmid_peak\t0\t\t0\t\t0\t\n`,
+      "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tWriteMarkers\tWriteMarkerList\tDiagnostics\tDiagnosticCodeList\n" +
+        `ac\t.ac\t1\t.ac\t${acExecution.plan.lineNumber}\t\t\tdec\t\t\t\t1\t1.000000e+03\t1.000000e+03\t\t\t\t\t\t1\t7\tIndex;Frequency;Probe;Real;Imaginary;Magnitude;Phase\t3\tresult;measurement;run-artifact\t1\tV(mid)\t1\t.save\t1\tmid_peak\t0\t\t0\t\t0\t\t0\t\n`,
     );
 
     const tranExecution = runDeckAnalysis(circuit, netlist, "tran");
@@ -1802,8 +1806,8 @@ describe("transient", () => {
     expect(tranExecution.runArtifacts[0]?.diagnosticCount).toBe(0);
     expect(tranExecution.runArtifacts[0]?.diagnosticCodes).toEqual([]);
     expect(tranExecution.runArtifactTable).toBe(
-      "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tDiagnostics\tDiagnosticCodeList\n" +
-        `tran\t.tran\t1\t.tran\t${tranExecution.plan.lineNumber}\t\t\t\t\t\t\t\t\t\t1.000000e-03\t1.000000e-03\t\t\tfalse\t1\t3\tIndex;Time;V(mid)\t3\tresult;measurement;run-artifact\t1\tV(mid)\t1\t.save\t1\tmid_final\t0\t\t0\t\t0\t\n`,
+      "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tWriteMarkers\tWriteMarkerList\tDiagnostics\tDiagnosticCodeList\n" +
+        `tran\t.tran\t1\t.tran\t${tranExecution.plan.lineNumber}\t\t\t\t\t\t\t\t\t\t1.000000e-03\t1.000000e-03\t\t\tfalse\t1\t3\tIndex;Time;V(mid)\t3\tresult;measurement;run-artifact\t1\tV(mid)\t1\t.save\t1\tmid_final\t0\t\t0\t\t0\t\t0\t\n`,
     );
 
     const tfExecution = runDeckAnalysis(circuit, netlist, "tf");
@@ -1847,8 +1851,8 @@ describe("transient", () => {
     expect(tfExecution.runArtifacts[0]?.measurementNames).toEqual([]);
     expect(tfExecution.runArtifacts[0]?.fourierProbes).toEqual([]);
     expect(tfExecution.runArtifactTable).toBe(
-      "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tDiagnostics\tDiagnosticCodeList\n" +
-        `tf\t.tf\t1\t.tf\t${tfExecution.plan.lineNumber}\tV1\tmid\t\t\t\t\t\t\t\t\t\t\t\t\t1\t3\tTransferRatio;InputImpedance;OutputImpedance\t2\tresult;run-artifact\t1\tV(mid)\t0\t\t0\t\t0\t\t0\t\t0\t\n`,
+      "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tWriteMarkers\tWriteMarkerList\tDiagnostics\tDiagnosticCodeList\n" +
+        `tf\t.tf\t1\t.tf\t${tfExecution.plan.lineNumber}\tV1\tmid\t\t\t\t\t\t\t\t\t\t\t\t\t1\t3\tTransferRatio;InputImpedance;OutputImpedance\t2\tresult;run-artifact\t1\tV(mid)\t0\t\t0\t\t0\t\t0\t\t0\t\t0\t\n`,
     );
 
     const sensExecution = runDeckAnalysis(circuit, netlist, "sens");
@@ -1892,8 +1896,8 @@ describe("transient", () => {
     expect(sensExecution.runArtifacts[0]?.measurementNames).toEqual([]);
     expect(sensExecution.runArtifacts[0]?.fourierProbes).toEqual([]);
     expect(sensExecution.runArtifactTable).toBe(
-      "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tDiagnostics\tDiagnosticCodeList\n" +
-        `sens\t.sens\t1\t.sens\t${sensExecution.plan.lineNumber}\t\tmid\t\t\t\t\t\t\t\t\t\t\t\t\t1\t7\tOutputNode;NominalVoltage;Element;Parameter;NominalValue;Sensitivity;RelativeSensitivity\t2\tresult;run-artifact\t1\tV(mid)\t0\t\t0\t\t0\t\t0\t\t0\t\n`,
+      "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tWriteMarkers\tWriteMarkerList\tDiagnostics\tDiagnosticCodeList\n" +
+        `sens\t.sens\t1\t.sens\t${sensExecution.plan.lineNumber}\t\tmid\t\t\t\t\t\t\t\t\t\t\t\t\t1\t7\tOutputNode;NominalVoltage;Element;Parameter;NominalValue;Sensitivity;RelativeSensitivity\t2\tresult;run-artifact\t1\tV(mid)\t0\t\t0\t\t0\t\t0\t\t0\t\t0\t\n`,
     );
 
     const noiseExecution = runDeckAnalysis(circuit, netlist, "noise");
@@ -1947,8 +1951,8 @@ describe("transient", () => {
     expect(noiseExecution.runArtifacts[0]?.measurementNames).toEqual([]);
     expect(noiseExecution.runArtifacts[0]?.fourierProbes).toEqual([]);
     expect(noiseExecution.runArtifactTable).toBe(
-      "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tDiagnostics\tDiagnosticCodeList\n" +
-        `noise\t.noise\t1\t.noise\t${noiseExecution.plan.lineNumber}\tV1\tmid\tlin\t\t\t\t1\t1.000000e+03\t1.000000e+03\t\t\t\t\t\t1\t10\tIndex;Frequency;OutputNode;InputSource;OutputPSD;InputReferredPSD;Element;Type;SourcePSD;ContributionPSD\t2\tresult;run-artifact\t1\tV(mid)\t0\t\t0\t\t0\t\t0\t\t0\t\n`,
+      "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tWriteMarkers\tWriteMarkerList\tDiagnostics\tDiagnosticCodeList\n" +
+        `noise\t.noise\t1\t.noise\t${noiseExecution.plan.lineNumber}\tV1\tmid\tlin\t\t\t\t1\t1.000000e+03\t1.000000e+03\t\t\t\t\t\t1\t10\tIndex;Frequency;OutputNode;InputSource;OutputPSD;InputReferredPSD;Element;Type;SourcePSD;ContributionPSD\t2\tresult;run-artifact\t1\tV(mid)\t0\t\t0\t\t0\t\t0\t\t0\t\t0\t\n`,
     );
 
     const tranWindowExecution = runDeckAnalysis(
@@ -1989,8 +1993,8 @@ describe("transient", () => {
         "2\t6.000000e-03\t5.000000e-01\n",
     );
     expect(tranWindowExecution.runArtifactTable).toBe(
-      "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tDiagnostics\tDiagnosticCodeList\n" +
-        `tran\t.tran\t1\t.tran\t${tranWindowExecution.plan.lineNumber}\t\t\t\t\t\t\t\t\t\t2.000000e-03\t6.000000e-03\t2.000000e-03\t1.000000e-03\ttrue\t3\t3\tIndex;Time;V(mid)\t2\tresult;run-artifact\t1\tV(mid)\t1\t.save\t0\t\t0\t\t0\t\t0\t\n`,
+      "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tWriteMarkers\tWriteMarkerList\tDiagnostics\tDiagnosticCodeList\n" +
+        `tran\t.tran\t1\t.tran\t${tranWindowExecution.plan.lineNumber}\t\t\t\t\t\t\t\t\t\t2.000000e-03\t6.000000e-03\t2.000000e-03\t1.000000e-03\ttrue\t3\t3\tIndex;Time;V(mid)\t2\tresult;run-artifact\t1\tV(mid)\t1\t.save\t0\t\t0\t\t0\t\t0\t\t0\t\n`,
     );
 
     expect(() => runDeckAnalysis(circuit, netlist)).toThrow(/multiple analysis cards/);
@@ -2027,6 +2031,8 @@ describe("transient", () => {
 .control
 save V(in)
 probe V(in)
+write out.raw V(in)
+wrdata out.dat V(in)
 source other.cir
 cd /tmp
 if v(in) > 0
@@ -2046,23 +2052,32 @@ let gain = 2
     const codeList = expectedCodes.join(";");
     const expectedControlLines = [".save V(in)", ".probe V(in)"];
     const controlLineList = expectedControlLines.join(";");
+    const expectedWriteMarkers = ["write out.raw V(in)", "wrdata out.dat V(in)"];
+    const writeMarkerList = expectedWriteMarkers.join(";");
 
     expect(execution.controlLineCount).toBe(expectedControlLines.length);
     expect(execution.controlLines).toEqual(expectedControlLines);
+    expect(execution.writeMarkerCount).toBe(expectedWriteMarkers.length);
+    expect(execution.writeMarkers).toEqual(expectedWriteMarkers);
     expect(execution.diagnosticCount).toBe(expectedCodes.length);
     expect(execution.diagnosticCodes).toEqual(expectedCodes);
     expect(execution.runArtifacts[0]?.controlLineCount).toBe(expectedControlLines.length);
     expect(execution.runArtifacts[0]?.controlLines).toEqual(expectedControlLines);
+    expect(execution.runArtifacts[0]?.writeMarkerCount).toBe(expectedWriteMarkers.length);
+    expect(execution.runArtifacts[0]?.writeMarkers).toEqual(expectedWriteMarkers);
     expect(execution.runArtifacts[0]?.diagnosticCount).toBe(expectedCodes.length);
     expect(execution.runArtifacts[0]?.diagnosticCodes).toEqual(expectedCodes);
     const record = deckTableRecords(execution.runArtifactTable)[0]!;
     expect(record["ControlLines"]).toBe(String(expectedControlLines.length));
     expect(record["ControlLineList"]).toBe(controlLineList);
+    expect(record["WriteMarkers"]).toBe(String(expectedWriteMarkers.length));
+    expect(record["WriteMarkerList"]).toBe(writeMarkerList);
     expect(record["Diagnostics"]).toBe(String(expectedCodes.length));
     expect(record["DiagnosticCodeList"]).toBe(codeList);
     const runArtifact = execution.tableArtifacts[execution.tableArtifacts.length - 1]!;
     expect(runArtifact.name).toBe("run-artifact");
     expect(runArtifact.records[0]?.["ControlLineList"]).toBe(controlLineList);
+    expect(runArtifact.records[0]?.["WriteMarkerList"]).toBe(writeMarkerList);
     expect(runArtifact.records[0]?.["DiagnosticCodeList"]).toBe(codeList);
     expect(runArtifact.csv).toBe(formatDeckRunArtifactCsv(execution.runArtifacts));
     expect(runArtifact.json).toBe(formatDeckRunArtifactJson(execution.runArtifacts));
@@ -2127,8 +2142,8 @@ let gain = 2
     expect(tranExecution.runArtifacts[0]?.measurementNames).toEqual([]);
     expect(tranExecution.runArtifacts[0]?.fourierProbes).toEqual(["V(mid)"]);
     expect(tranExecution.runArtifactTable).toBe(
-      "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tDiagnostics\tDiagnosticCodeList\n" +
-        `tran\t.tran\t1\t.tran\t${tranExecution.plan.lineNumber}\t\t\t\t\t\t\t\t\t\t5.000000e-04\t1.000000e-03\t\t\tfalse\t2\t3\tIndex;Time;V(mid)\t3\tresult;fourier;run-artifact\t1\tV(mid)\t1\t.save\t0\t\t1\tV(mid)\t0\t\t0\t\n`,
+      "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tWriteMarkers\tWriteMarkerList\tDiagnostics\tDiagnosticCodeList\n" +
+        `tran\t.tran\t1\t.tran\t${tranExecution.plan.lineNumber}\t\t\t\t\t\t\t\t\t\t5.000000e-04\t1.000000e-03\t\t\tfalse\t2\t3\tIndex;Time;V(mid)\t3\tresult;fourier;run-artifact\t1\tV(mid)\t1\t.save\t0\t\t1\tV(mid)\t0\t\t0\t\t0\t\n`,
     );
   });
 

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -109,7 +109,10 @@ downstream tools to compare.
      count/list directly beside table, output, measurement, Fourier, and
      analysis-directive artifacts; selected executions now also expose
      diagnostic count/code inventories directly beside those execution-level
-     artifacts.
+     artifacts; accepted rawfile/data-write marker inventories for `.control`
+     `write` / `wrdata` commands now travel through direct selected-execution
+     fields and stable selected-run artifact tables, CSV/JSON helpers, and
+     ordered table export artifacts without serializing files.
    - Expand remaining deck-controlled analyses toward full SPICE compatibility
      while keeping unsupported control-flow diagnostics explicit.
 
@@ -999,6 +1002,14 @@ downstream tools to compare.
       command artifacts.
     - Host and browser integrations can inspect selected execution diagnostic
       provenance without drilling into selected-run artifact tables.
+
+92. Deck rawfile write marker artifacts.
+    - Status: completed in this deck rawfile write marker artifact slice.
+    - Python, Rust, and TypeScript control analyzers now expose normalized
+      accepted `.control` `write` and `wrdata` marker inventories.
+    - Selected deck executions carry those write-marker inventories directly and
+      through selected-run artifact tables, CSV/JSON helpers, and ordered table
+      export artifacts without serializing files.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- expose normalized accepted .control write/wrdata marker inventories across Python, Rust, and TypeScript deck control analyzers
- carry write marker counts/lists through selected run execution fields and stable run-artifact table/CSV/JSON/table-artifact records
- document the new artifact surface and mark the SPICE plan slice complete

## Verification
- PYTHONPATH=code/packages/python/spice-engine/src:code/packages/python/spice-netlist-parser/src:code/packages/python/mosfet-models/src:code/packages/python/device-physics/src /Users/adhithya/.local/share/mise/installs/python/3.12.13/bin/python -m pytest code/packages/python/spice-engine/tests/test_engine.py
- cargo test --manifest-path code/packages/rust/spice-engine/Cargo.toml
- npm --prefix code/packages/typescript/spice-engine test
- npm --prefix code/packages/typescript/spice-engine run build
- /Users/adhithya/.local/share/mise/installs/python/3.12.13/bin/python -m ruff check code/packages/python/spice-engine/src/spice_engine/engine.py code/packages/python/spice-engine/src/spice_engine/compatibility.py code/packages/python/spice-engine/tests/test_engine.py
- cargo fmt --manifest-path code/packages/rust/spice-engine/Cargo.toml -- --check
- git diff --check