### PR TITLE
feat(r-24): R5 Reference Classes — setRefClass, fields, methods, reference semantics

### DIFF
--- a/code/packages/rust/r-runtime/CHANGELOG.md
+++ b/code/packages/rust/r-runtime/CHANGELOG.md
@@ -2,6 +2,32 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.19.0] - 2026-06-20
+
+### Added (via the shared `s-runtime`)
+
+- **R-24 — R5 reference classes (`setRefClass`)**: reaches R unchanged through
+  the shared evaluator (everything lives in `s-runtime` — `$` already existed, so
+  no grammar change). In R syntax:
+  - **`setRefClass("Acc", fields = list(total = "numeric"), methods = list(add = function(x) { total <<- total + x }, get = function() total))`**
+    → a **generator**; **`Acc$new(total = 0)`** → an **instance** (an environment
+    holding the fields).
+  - **`a$add(5); a$add(3); a$total`** → `8` and **`a$get()`** → `8`: a method's
+    body sees the fields directly and writes them back with `<<-`.
+  - **`a$total <- 100; a$total`** → `100`: field write **by reference**.
+  - **Reference semantics**: `b <- a; b$add(1); a$total` reflects b's change (the
+    two names share one instance — unlike R's copy-on-modify). Two `$new`
+    instances are independent.
+  - **`.self`** is bound in the instance, so a method can call a sibling as
+    `.self$other()` and write a field as `.self$field <- v`.
+  - Field type strings are **not enforced** in this subset; a class may have no
+    fields and/or no methods. Malformed `setRefClass`/`$new` arguments are clean
+    errors, never panics.
+  - See `s-runtime` 0.20.0 for the instance⇄method Rc-cycle handling (broken by
+    construction — method closures close over the *generator*, instance-bound
+    closures are rebuilt lazily per access and never stored) and the deferral of
+    inheritance / `$copy()` / active bindings / introspection to R-25.
+
 ## [0.18.0] - 2026-06-20
 
 ### Added (via the shared `s-runtime`)

--- a/code/packages/rust/r-runtime/README.md
+++ b/code/packages/rust/r-runtime/README.md
@@ -92,6 +92,19 @@ a closure captured at definition (a top-level closure captures the global env, s
 g() }; f()` → `42` — clamping to the global env past the bottom of the stack
 rather than panicking. `is.environment(x)` is the type predicate.
 
+**R5 reference classes (R-24)** — `setRefClass("Acc", fields = list(total =
+"numeric"), methods = list(add = function(x) { total <<- total + x }, get =
+function() total))` builds a **generator**; `Acc$new(total = 0)` builds an
+**instance** (an environment holding the fields). A method's body sees the fields
+directly and updates them with `<<-`, so `a$add(5); a$add(3); a$total` → `8`.
+`a$total <- 100` writes a field **by reference**. The headline R5 behaviour is
+**reference semantics**: `b <- a; b$add(1); a$total` reflects b's change (the two
+names share one instance, unlike R's copy-on-modify), while two separate `$new`
+calls are independent. `.self` is bound in the instance, so a method can reach a
+sibling as `.self$other()`. Field type strings are recorded but not enforced in
+this subset; inheritance, `$copy()`, active bindings, and `$methods()`/`$fields()`
+introspection are deferred to R-25.
+
 ## Usage
 
 ```rust

--- a/code/packages/rust/r-runtime/src/lib.rs
+++ b/code/packages/rust/r-runtime/src/lib.rs
@@ -1847,4 +1847,162 @@ mod tests {
             "[1] TRUE"
         );
     }
+
+    // =====================================================================
+    // R-24 — R5 reference classes (setRefClass)
+    // =====================================================================
+
+    /// A program preamble defining the canonical `Acc` accumulator class, reused
+    /// across the R-24 tests. Fields: `total` (numeric). Methods: `add(x)` adds to
+    /// the running total via `<<-`; `get()` returns it.
+    const ACC: &str = "Acc <- setRefClass(\"Acc\",\n  \
+        fields = list(total = \"numeric\"),\n  \
+        methods = list(\n    \
+            add = function(x) { total <<- total + x },\n    \
+            get = function() total\n  ))\n";
+
+    #[test]
+    fn refclass_method_updates_field_via_superassign() {
+        // a$add(5); a$add(3) => total 8; a$get() also 8.
+        let src = format!("{ACC}a <- Acc$new(total = 0)\na$add(5)\na$add(3)\na$total\n");
+        assert_eq!(nums(&src), vec![8.0]);
+        let via_method = format!("{ACC}a <- Acc$new(total = 0)\na$add(5)\na$add(3)\na$get()\n");
+        assert_eq!(nums(&via_method), vec![8.0]);
+    }
+
+    #[test]
+    fn refclass_field_write_by_dollar() {
+        // Direct `a$total <- 100` writes the field by reference.
+        let src = format!("{ACC}a <- Acc$new(total = 0)\na$total <- 100\na$total\n");
+        assert_eq!(nums(&src), vec![100.0]);
+    }
+
+    #[test]
+    fn refclass_reference_semantics_alias() {
+        // `b <- a` SHARES state (unlike normal R copy-on-modify): b's mutation is
+        // visible through a. This is the headline R5 behaviour.
+        let src = format!(
+            "{ACC}a <- Acc$new(total = 0)\nb <- a\nb$add(1)\nb$add(4)\na$total\n"
+        );
+        assert_eq!(nums(&src), vec![5.0]);
+        // And a field write through `b` is visible through `a`.
+        let write = format!("{ACC}a <- Acc$new(total = 7)\nb <- a\nb$total <- 99\na$total\n");
+        assert_eq!(nums(&write), vec![99.0]);
+    }
+
+    #[test]
+    fn refclass_two_instances_are_independent() {
+        // Two `$new` calls build distinct scopes — their fields do not interfere.
+        let src = format!(
+            "{ACC}a <- Acc$new(total = 0)\nb <- Acc$new(total = 0)\n\
+             a$add(10)\nb$add(3)\nc(a$total, b$total)\n"
+        );
+        assert_eq!(nums(&src), vec![10.0, 3.0]);
+    }
+
+    #[test]
+    fn refclass_method_calls_sibling_via_self() {
+        // A method reaching a sibling method through `.self$other()`.
+        let src = "Counter <- setRefClass(\"Counter\",\n  \
+            fields = list(n = \"numeric\"),\n  \
+            methods = list(\n    \
+                bump = function() { n <<- n + 1 },\n    \
+                bump_twice = function() { .self$bump(); .self$bump() }\n  ))\n\
+            c1 <- Counter$new(n = 0)\nc1$bump_twice()\nc1$n\n";
+        assert_eq!(nums(src), vec![2.0]);
+    }
+
+    #[test]
+    fn refclass_self_field_write() {
+        // `.self$field <- v` inside a method mutates the instance by reference.
+        let src = "Box <- setRefClass(\"Box\",\n  \
+            fields = list(v = \"numeric\"),\n  \
+            methods = list(set = function(x) { .self$v <- x }))\n\
+            b <- Box$new(v = 0)\nb$set(42)\nb$v\n";
+        assert_eq!(nums(src), vec![42.0]);
+    }
+
+    #[test]
+    fn refclass_two_fields_and_character_field() {
+        // Multiple fields of different declared types; the type strings are not
+        // enforced in this subset, so a character field just holds a string.
+        let src = "Pt <- setRefClass(\"Pt\",\n  \
+            fields = list(x = \"numeric\", label = \"character\"),\n  \
+            methods = list(move = function(dx) { x <<- x + dx }))\n\
+            p <- Pt$new(x = 1, label = \"origin\")\np$move(4)\np$x\n";
+        assert_eq!(nums(src), vec![5.0]);
+        let lbl = "Pt <- setRefClass(\"Pt\",\n  \
+            fields = list(x = \"numeric\", label = \"character\"),\n  \
+            methods = list())\n\
+            p <- Pt$new(x = 1, label = \"origin\")\np$label\n";
+        assert_eq!(show(lbl), "[1] \"origin\"");
+    }
+
+    #[test]
+    fn refclass_omitted_field_defaults_null() {
+        // A field not supplied to `$new` reads as NULL.
+        let src = format!("{ACC}a <- Acc$new()\na$total\n");
+        assert_eq!(show(&src), "NULL");
+    }
+
+    #[test]
+    fn refclass_class_with_no_fields_or_methods() {
+        // Degenerate but legal: a class with neither fields nor methods.
+        let src = "Empty <- setRefClass(\"Empty\")\ne <- Empty$new()\nis.environment(e)\n";
+        assert_eq!(show(src), "[1] TRUE");
+    }
+
+    #[test]
+    fn refclass_method_reads_field_without_mutating() {
+        // A method that only reads (no `<<-`) still sees the current field value.
+        let src = format!("{ACC}a <- Acc$new(total = 9)\na$get()\n");
+        assert_eq!(nums(&src), vec![9.0]);
+    }
+
+    // --- error / edge cases (clean errors, never panics) -----------------
+
+    #[test]
+    fn refclass_unknown_new_arg_errors() {
+        let src = format!("{ACC}Acc$new(bogus = 1)\n");
+        assert!(eval_r(&src).is_err());
+    }
+
+    #[test]
+    fn refclass_non_function_method_errors() {
+        let src = "setRefClass(\"Bad\", fields = list(x = \"numeric\"), \
+                   methods = list(m = 5))\n";
+        assert!(eval_r(src).is_err());
+    }
+
+    #[test]
+    fn refclass_non_character_name_errors() {
+        assert!(eval_r("setRefClass(123)\n").is_err());
+    }
+
+    #[test]
+    fn refclass_dollar_assign_on_non_env_errors() {
+        // `$<-` on a plain vector is not supported (only environments / ref
+        // objects). Must be a clean error, not a panic.
+        assert!(eval_r("x <- c(1, 2)\nx$foo <- 3\n").is_err());
+    }
+
+    /// Regression: R-20..R-23 still work after the R-24 `$`/`$<-`/apply changes.
+    #[test]
+    fn r20_through_r23_still_work_after_r24() {
+        // R-22 by-reference env mutation.
+        let byref = "e <- new.env()\n\
+                     f <- function(env) assign(\"x\", 8, envir = env)\nf(e)\nget(\"x\", envir = e)\n";
+        assert_eq!(nums(byref), vec![8.0]);
+        // Plain `env$name` read/write still works for a non-ref environment.
+        assert_eq!(nums("e <- new.env()\ne$y <- 11\ne$y\n"), vec![11.0]);
+        // Data-frame `$` column access is untouched.
+        assert_eq!(
+            nums("df <- data.frame(a = c(1, 2), b = c(3, 4))\ndf$b\n"),
+            vec![3.0, 4.0]
+        );
+        // R-23 parent.frame still reflects the caller.
+        let pf = "g <- function() get(\"x\", envir = parent.frame())\n\
+                  f <- function() { x <- 42; g() }\nf()\n";
+        assert_eq!(nums(pf), vec![42.0]);
+    }
 }

--- a/code/packages/rust/s-runtime/CHANGELOG.md
+++ b/code/packages/rust/s-runtime/CHANGELOG.md
@@ -2,6 +2,49 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.20.0] - 2026-06-20
+
+### Added
+
+- **R5 reference classes (R-24)** — `setRefClass`, generators, and instances,
+  living in the shared runtime so both S and R inherit them. Grammar-free (`$`
+  already existed). New `src/refclass.rs` module.
+  - **`setRefClass("Name", fields = list(x = "numeric", …), methods = list(m = function(…) …))`**
+    → a **generator** (a first-class environment carrying `.refClassName`,
+    `.refFields`, and `.refMethods`). A *lazy special form*: it evaluates the
+    `fields`/`methods` arguments in the current scope, so each method
+    `function(...)` closes over where the class was defined. Field *type* strings
+    are recorded but **not enforced** in this subset. Two `fields` shapes are
+    accepted: a named `list(x = "numeric", …)` and a bare character vector
+    `c("x", "y")`.
+  - **`generator$new(x = …, …)`** → an **instance**: a fresh child environment
+    binding each declared field (to the matching `new()` argument, or `NULL` when
+    omitted), `.self` (the instance, for `.self$method()`), and `.refMethods`. An
+    unknown `new()` argument is a clean error.
+  - **`obj$field`** reads a field (frame-local), **`obj$field <- v`** writes it
+    **in place by reference** (the `$<-` lvalue path now accepts an environment
+    target), and **`obj$method(args)`** rebuilds a fresh instance-bound closure on
+    access and applies it — so `field <<- value` (R-21 super-assignment) and
+    `.self$field <- v` mutate the live instance.
+  - **Reference (alias) semantics** — `b <- a` shares state (both reference the
+    same instance scope), unlike R's copy-on-modify; two separate `$new` instances
+    are independent.
+  - **Rc-cycle safety (instance⇄method).** The naïve encoding (method closures
+    stored in the instance, closing over the instance) is a strong, uncollectable
+    cycle. Broken **by construction**: the instance stores only fields, `.self`,
+    and `.refMethods` (whose closures close over the *generator*, not the
+    instance); the instance-bound closure is materialised lazily per `obj$method`
+    access and never stored. The lone remaining `.self` strong self-reference is
+    the documented, `MAX_ENVIRONMENTS`-bounded R-22 value-binding self-cycle.
+  - New **`env::lookup_local`** (frame-local read, no parent walk) so an instance
+    — a child of its generator — is never misclassified as a generator.
+  - Malformed `setRefClass`/`$new` arguments (non-character name, non-list
+    `fields`/`methods`, non-function method, unknown field, `$<-` on a non-env)
+    are all clean errors, never panics.
+  - Each reified generator/instance environment counts against `MAX_ENVIRONMENTS`.
+  - **Deferred to R-25:** inheritance (`contains =`), `$copy()`, active bindings,
+    `$methods()`/`$fields()` introspection.
+
 ## [0.19.0] - 2026-06-20
 
 ### Added

--- a/code/packages/rust/s-runtime/README.md
+++ b/code/packages/rust/s-runtime/README.md
@@ -127,6 +127,19 @@ a hand-written loop. See [What "S-flavored" means here](#what-s-flavored-means-h
   global); `parent.frame(n = 1)` is the caller's env, recorded on the R-20 call
   stack and **clamped** to global past the bottom rather than panicking;
   `is.environment(x)` is the type predicate.
+- **R5 reference classes** (R-24, `src/refclass.rs`): `setRefClass("Name",
+  fields = …, methods = …)` builds a **generator** (an environment carrying the
+  class name, field names, and method closures); `generator$new(field = …)` builds
+  an **instance** (an environment holding the fields). `obj$field` reads a field,
+  `obj$field <- v` writes it **in place by reference**, and `obj$method(args)`
+  rebuilds a fresh instance-bound closure on access so `field <<- value` and
+  `.self$field <- v` mutate the live instance. `b <- a` *aliases* the same instance
+  (reference semantics — the deliberate exception to copy-on-modify). The
+  instance⇄method `Rc` cycle is broken by construction (instance-bound closures are
+  rebuilt lazily and never stored; the stored method closures close over the
+  *generator*); the lone `.self` self-reference is the documented,
+  `MAX_ENVIRONMENTS`-bounded R-22 value-binding cycle. Inheritance, `$copy()`,
+  active bindings, and `$methods()`/`$fields()` introspection are deferred to R-25.
 - The **`d`/`p`/`q`/`r` distribution family** (R-8) over `statistics-core`:
   density/CDF/quantile/sampling for the normal, uniform, and exponential
   distributions, plus `set.seed` for a reproducible per-session RNG.

--- a/code/packages/rust/s-runtime/src/env.rs
+++ b/code/packages/rust/s-runtime/src/env.rs
@@ -163,6 +163,17 @@ pub fn lookup(env: &Env, name: &str) -> Option<SValue> {
     }
 }
 
+/// Look up `name` in **only** the current frame (no parent walk), returning the
+/// bound value if this exact scope binds it. This is the lookup the R-24
+/// reference-class machinery needs to classify an object: an instance is a *child*
+/// of its generator, so a chain-walking [`lookup`] of a generator's private marker
+/// (`.refClassName`) would find it *through the parent* and misclassify the
+/// instance as a generator. A frame-local read sees only the markers actually
+/// placed on *this* object's own frame, so generator and instance stay distinct.
+pub fn lookup_local(env: &Env, name: &str) -> Option<SValue> {
+    env.borrow().vars.get(name).cloned()
+}
+
 /// Is `name` bound *anywhere* on the chain (current frame or any enclosing one)?
 /// This is the engine behind R's `exists(x)`: a cheap presence test that does not
 /// clone the value. Like [`lookup`] it walks outward (iteratively) to the root.

--- a/code/packages/rust/s-runtime/src/eval.rs
+++ b/code/packages/rust/s-runtime/src/eval.rs
@@ -463,15 +463,27 @@ impl Interpreter {
         let parts = node_children(postfix);
         let (primary, suffix) = match parts.as_slice() {
             [primary, suffix]
-                if suffix.rule_name == "index_suffix" || suffix.rule_name == "call_suffix" =>
+                if suffix.rule_name == "index_suffix"
+                    || suffix.rule_name == "call_suffix"
+                    || suffix.rule_name == "dollar_suffix" =>
             {
                 (*primary, *suffix)
             }
             _ => return Err(SError::TypeError(
-                "unsupported assignment target (only `x[...] <- v` and `f(x) <- v` are supported)"
+                "unsupported assignment target (only `x[...] <- v`, `x$name <- v` and `f(x) <- v` are supported)"
                     .into(),
             )),
         };
+
+        // `obj$name <- value` (R-24). When `obj` evaluates to an environment (an
+        // R5 instance, or any first-class environment), this is a **mutate-by-
+        // reference** write: we bind `name` *in place* in that live scope, so two
+        // references to the same instance both see the change. This is the
+        // headline R5 reference semantics, and it falls straight out of reusing
+        // R-22's shared `SValue::Environment`.
+        if suffix.rule_name == "dollar_suffix" {
+            return self.eval_dollar_assignment(primary, suffix, rhs, env);
+        }
 
         // `f(x) <- value` — a replacement-function call. R desugars this to
         // `x <- \`f<-\`(x, value)`: the inner argument must be a bare-name
@@ -497,6 +509,45 @@ impl Interpreter {
         };
         define(env, &base_name, updated);
         self.as_invisible(rhs)
+    }
+
+    /// Handle `obj$name <- value` (R-24). The `primary` expression is evaluated to
+    /// the target; when it is an [`SValue::Environment`] (an R5 instance, or any
+    /// first-class environment) the write is a **mutate-by-reference** `env::define`
+    /// **in place** — the live scope gains/updates the `name` binding, so every
+    /// reference to that same instance (`b <- a`) observes the change. This is the
+    /// defining R5 reference semantic.
+    ///
+    /// Crucially `primary` is *evaluated* (not required to be a bare name): both
+    /// `a$total <- v` (where `a` is a variable) and `.self$total <- v` (inside a
+    /// method, where `.self` is the instance) resolve the same way — they each
+    /// yield the shared `Rc` to the instance scope, and the `define` mutates it.
+    /// A non-environment `obj` is a clean error (R5 `$<-` is only meaningful on a
+    /// reference object / environment in this subset).
+    fn eval_dollar_assignment(
+        &self,
+        primary: &GrammarASTNode,
+        dollar_suffix: &GrammarASTNode,
+        rhs: SValue,
+        env: &Env,
+    ) -> SResult<SValue> {
+        let field = name_token(dollar_suffix)
+            .ok_or_else(|| SError::Parse("malformed `$` assignment target".into()))?;
+        let target = self.eval_node(primary, env)?;
+        match target {
+            SValue::Environment(e) => {
+                // In-place, by-reference field write. `env::define` takes and
+                // releases the scope's `RefCell` borrow within the call, so a
+                // method mutating a field mid-call never holds two borrows of the
+                // same scope at once (no re-entrant-borrow panic).
+                define(&e, &field, rhs.clone());
+                self.as_invisible(rhs)
+            }
+            other => Err(SError::TypeError(format!(
+                "$<- is invalid for {} (only environments / reference objects support `obj$name <- v`)",
+                other.type_name()
+            ))),
+        }
     }
 
     /// Handle a **replacement-function** assignment `f(x) <- value` (R-15).
@@ -928,6 +979,8 @@ impl Interpreter {
                         "globalenv" | "baseenv" => self.eval_globalenv(),
                         "emptyenv" => self.eval_emptyenv(),
                         "parent.frame" => self.eval_parent_frame(&raw, env),
+                        // R-24 R5 reference classes.
+                        "setRefClass" => self.eval_set_ref_class(&raw, env),
                         _ => unreachable!(),
                     };
                 }
@@ -977,10 +1030,11 @@ impl Interpreter {
                     self.visible.set(true);
                 }
                 "dollar_suffix" => {
-                    // `df$name` — column by name.
+                    // `df$name` — column by name; `obj$field` / `obj$method` /
+                    // `generator$new` for an R5 reference object (R-24).
                     let name = name_token(suffix)
                         .ok_or_else(|| SError::Parse("malformed $ access".into()))?;
-                    value = crate::dataframe::column_by_name(&value, &name)?;
+                    value = self.dollar_read(&value, &name)?;
                     self.visible.set(true);
                 }
                 other => return Err(SError::Parse(format!("unexpected suffix '{other}'"))),
@@ -1060,6 +1114,13 @@ impl Interpreter {
     /// visibility rules (`print` is invisible and emits output; other calls are
     /// visible; a closure's body decides its own visibility).
     fn apply(&self, callee: SValue, args: &[Arg], env: &Env) -> SResult<SValue> {
+        // `generator$new(...)` (R-24): `generator$new` evaluated to an
+        // instantiation marker; applying it builds a fresh instance. Handled
+        // before the ordinary callable dispatch because the marker is not a
+        // `Closure`/`Builtin`.
+        if let Some(generator) = crate::refclass::as_new_marker(&callee) {
+            return self.apply_ref_new(&generator, args);
+        }
         match callee {
             SValue::Builtin { name, func } => {
                 let result = func(self, args)?;
@@ -1097,6 +1158,10 @@ impl Interpreter {
     /// visibility/printing side effects. This is the entry point built-ins use
     /// to invoke a user function (`sapply`, `lapply`) or an S3 method.
     pub(crate) fn call_value(&self, callee: SValue, args: &[Arg]) -> SResult<SValue> {
+        // `generator$new(...)` reached via a builtin (`do.call(gen$new, …)`).
+        if let Some(generator) = crate::refclass::as_new_marker(&callee) {
+            return self.apply_ref_new(&generator, args);
+        }
         match callee {
             SValue::Builtin { func, .. } => func(self, args),
             // Invoked from a builtin (e.g. `sapply`/`Reduce`/`do.call`), there is
@@ -1738,6 +1803,97 @@ impl Interpreter {
         self.as_visible(SValue::Environment(self.caller_frame(n)))
     }
 
+    // -----------------------------------------------------------------------
+    // R-24 R5 reference classes (setRefClass)
+    // -----------------------------------------------------------------------
+
+    /// `setRefClass("Name", fields = …, methods = …)` (R-24) — build a reference
+    /// class **generator**. A lazy special form: it evaluates the class name and
+    /// the `fields`/`methods` arguments *in the current environment* (so the
+    /// method `function(...)` definitions close over the scope where the class was
+    /// declared), then hands the pieces to [`crate::refclass::make_generator`].
+    /// The generator is a first-class environment value carrying the class name,
+    /// field names, and method closures, and it counts against `MAX_ENVIRONMENTS`.
+    ///
+    /// The class name is the first **positional** argument (a length-1 character);
+    /// `fields` and `methods` are matched **by name** (R5's call shape). A missing
+    /// `fields`/`methods` defaults to "no fields"/"no methods". A non-character
+    /// name, or a malformed `fields`/`methods`, is a clean error (never a panic).
+    fn eval_set_ref_class(&self, raw: &[RawArg], env: &Env) -> SResult<SValue> {
+        // First positional argument → the class name.
+        let name_node = self.positional_nodes(raw).into_iter().next().ok_or_else(|| {
+            SError::BadArgs("setRefClass: the class name is required".into())
+        })?;
+        let class_name = self.eval_name_string(name_node, env, "setRefClass")?;
+
+        // `fields =` / `methods =` (named); each defaults to NULL when omitted.
+        let fields = self.eval_named_arg(raw, "fields", env)?.unwrap_or(SValue::Null);
+        let methods = self
+            .eval_named_arg(raw, "methods", env)?
+            .unwrap_or(SValue::Null);
+
+        // Reifying the generator environment counts against the session cap, like
+        // any `new.env()` — it can equally participate in a value-binding cycle.
+        self.account_environment()?;
+        let generator = crate::refclass::make_generator(&class_name, &fields, &methods, env)?;
+        self.as_visible(generator)
+    }
+
+    /// Apply a `generator$new(field = …, …)` instantiation (R-24): charge the new
+    /// instance environment against `MAX_ENVIRONMENTS` (it is a fresh reified
+    /// scope, exactly like `new.env()`, and `.self` makes it a value-binding
+    /// self-cycle — the documented, bounded R-22 case), then build the instance via
+    /// [`crate::refclass::instantiate`]. The already-evaluated `args` carry their
+    /// names so fields are matched by keyword.
+    fn apply_ref_new(&self, generator: &Env, args: &[Arg]) -> SResult<SValue> {
+        self.account_environment()?;
+        let init: Vec<(Option<String>, SValue)> = args
+            .iter()
+            .map(|a| (a.name.clone(), a.value.clone()))
+            .collect();
+        let instance = crate::refclass::instantiate(generator, &init)?;
+        self.as_visible(instance)
+    }
+
+    /// Resolve `obj$name` for a `$` *read* (R-24). An [`SValue::Environment`]
+    /// target is routed through [`crate::refclass::dollar_access`], which handles
+    /// `generator$new` (returns the instantiation marker), `obj$method` (rebuilds
+    /// a fresh instance-bound closure on access — see the refclass module note on
+    /// the instance⇄method cycle), and falls through (`None`) to an ordinary field
+    /// / binding lookup in the environment. A `NULL` is returned for an unset field
+    /// (matching R5). Every other target keeps the existing data-frame / list `$`
+    /// behaviour.
+    fn dollar_read(&self, target: &SValue, name: &str) -> SResult<SValue> {
+        if let SValue::Environment(e) = target {
+            if let Some(v) = crate::refclass::dollar_access(e, name) {
+                return Ok(v);
+            }
+            // Ordinary environment access: the binding's value, or NULL if unset
+            // (R5 reads an unset field as NULL; a plain `env$x` for a missing name
+            // is likewise NULL in R rather than an error).
+            return Ok(lookup(e, name).unwrap_or(SValue::Null));
+        }
+        crate::dataframe::column_by_name(target, name)
+    }
+
+    /// Evaluate the named argument `key` of a raw arg list (`key = expr`), if
+    /// present, returning `Ok(None)` when it is absent. An empty arm (`key =`
+    /// with no expression) is a clean error. Shared by `setRefClass`'s
+    /// `fields =`/`methods =` handling.
+    fn eval_named_arg(
+        &self,
+        raw: &[RawArg],
+        key: &str,
+        env: &Env,
+    ) -> SResult<Option<SValue>> {
+        let Some((_, node)) = raw.iter().find(|(name, _)| name.as_deref() == Some(key)) else {
+            return Ok(None);
+        };
+        let expr = arm_body(node)
+            .ok_or_else(|| SError::BadArgs(format!("setRefClass: `{key} = ` is missing a value")))?;
+        Ok(Some(self.eval_node(expr, env)?))
+    }
+
     /// `ls([envir = e])` — the names bound **directly** in the target frame (not
     /// the enclosing chain), as a **sorted** character vector (R-22). `ls(e)`
     /// accepts the environment positionally too (R's `ls` takes the env as its
@@ -1886,6 +2042,14 @@ fn special_form_name(primary: &GrammarASTNode) -> Option<&'static str> {
         [("NAME", "emptyenv")] => Some("emptyenv"),
         [("NAME", "baseenv")] => Some("baseenv"),
         [("NAME", "parent.frame")] => Some("parent.frame"),
+        // R-24 R5 reference classes. `setRefClass` is a special form because it
+        // must (a) capture the *current* environment as the generator's lexical
+        // parent — so a method's free variables resolve to where the class was
+        // defined — and (b) evaluate `fields`/`methods` itself (the methods are
+        // function definitions that must close over that captured scope). An
+        // ordinary eager builtin receives neither the current env nor control over
+        // argument evaluation.
+        [("NAME", "setRefClass")] => Some("setRefClass"),
         _ => None,
     }
 }

--- a/code/packages/rust/s-runtime/src/lib.rs
+++ b/code/packages/rust/s-runtime/src/lib.rs
@@ -33,6 +33,7 @@ mod dataframe;
 mod env;
 mod error;
 mod eval;
+mod refclass;
 mod value;
 
 pub use error::{SError, SResult};
@@ -1723,5 +1724,130 @@ mod r22_environments {
         ] {
             let _ = eval_s(src);
         }
+    }
+}
+
+#[cfg(test)]
+mod r24_reference_classes {
+    //! R-24 R5 reference classes, exercised through **S** syntax (the shared
+    //! tree-walker is language-neutral; R inherits the same behaviour). These
+    //! cover the `refclass` module's classification, instantiation, `$` read /
+    //! write, method rebuild, and the headline reference (alias) semantics.
+    use super::*;
+
+    fn nums(src: &str) -> Vec<f64> {
+        match eval_s(src).unwrap().strip_names() {
+            SValue::Double(d) => d.data().to_vec(),
+            other => panic!("expected double, got {}", other.type_name()),
+        }
+    }
+
+    fn show(src: &str) -> String {
+        format_value(&eval_s(src).unwrap()).join("\n")
+    }
+
+    const ACC: &str = "Acc <- setRefClass(\"Acc\",\n  \
+        fields = list(total = \"numeric\"),\n  \
+        methods = list(\n    \
+            add = function(x) { total <<- total + x },\n    \
+            get = function() total\n  ))\n";
+
+    #[test]
+    fn add_and_get() {
+        assert_eq!(
+            nums(&format!("{ACC}a <- Acc$new(total = 0)\na$add(5)\na$add(3)\na$total\n")),
+            vec![8.0]
+        );
+        assert_eq!(
+            nums(&format!("{ACC}a <- Acc$new(total = 0)\na$add(5)\na$get()\n")),
+            vec![5.0]
+        );
+    }
+
+    #[test]
+    fn direct_field_write() {
+        assert_eq!(
+            nums(&format!("{ACC}a <- Acc$new(total = 1)\na$total <- 100\na$total\n")),
+            vec![100.0]
+        );
+    }
+
+    #[test]
+    fn reference_semantics() {
+        // b <- a aliases the same instance (reference, not copy).
+        assert_eq!(
+            nums(&format!("{ACC}a <- Acc$new(total = 0)\nb <- a\nb$add(7)\na$total\n")),
+            vec![7.0]
+        );
+    }
+
+    #[test]
+    fn independent_instances() {
+        assert_eq!(
+            nums(&format!(
+                "{ACC}a <- Acc$new(total = 0)\nb <- Acc$new(total = 0)\n\
+                 a$add(2)\nb$add(9)\nc(a$total, b$total)\n"
+            )),
+            vec![2.0, 9.0]
+        );
+    }
+
+    #[test]
+    fn generator_is_an_environment() {
+        // The generator reifies as an environment value.
+        assert_eq!(show(&format!("{ACC}is.environment(Acc)\n")), "[1] TRUE");
+        // ...and so is an instance.
+        assert_eq!(
+            show(&format!("{ACC}a <- Acc$new(total = 0)\nis.environment(a)\n")),
+            "[1] TRUE"
+        );
+    }
+
+    #[test]
+    fn omitted_field_is_null() {
+        assert_eq!(show(&format!("{ACC}Acc$new()$total\n")), "NULL");
+    }
+
+    #[test]
+    fn self_method_dispatch() {
+        let src = "C <- setRefClass(\"C\",\n  \
+            fields = list(n = \"numeric\"),\n  \
+            methods = list(\n    \
+                bump = function() { n <<- n + 1 },\n    \
+                twice = function() { .self$bump(); .self$bump() }\n  ))\n\
+            x <- C$new(n = 0)\nx$twice()\nx$n\n";
+        assert_eq!(nums(src), vec![2.0]);
+    }
+
+    #[test]
+    fn no_fields_no_methods() {
+        assert_eq!(
+            show("E <- setRefClass(\"E\")\nis.environment(E$new())\n"),
+            "[1] TRUE"
+        );
+    }
+
+    #[test]
+    fn malformed_inputs_are_clean_errors() {
+        for src in [
+            "setRefClass(123)\n",                                       // non-char name
+            "setRefClass()\n",                                          // missing name
+            "setRefClass(\"X\", methods = list(m = 5))\n",              // non-fn method
+            "setRefClass(\"X\", methods = 5)\n",                        // methods not a list
+            "setRefClass(\"X\", fields = 5)\n",                         // fields not list/char
+            "Acc <- setRefClass(\"X\", fields = list(a = \"numeric\"))\nAcc$new(bad = 1)\n", // unknown field
+            "v <- c(1, 2)\nv$x <- 3\n",                                 // $<- on non-env
+        ] {
+            assert!(eval_s(src).is_err(), "expected error for {src:?}");
+        }
+    }
+
+    #[test]
+    fn fields_as_character_vector() {
+        // R also accepts `fields = c("a", "b")`; the elements are the names.
+        let src = "K <- setRefClass(\"K\", fields = c(\"a\", \"b\"),\n  \
+            methods = list(seta = function(v) { a <<- v }))\n\
+            k <- K$new(a = 1, b = 2)\nk$seta(10)\nc(k$a, k$b)\n";
+        assert_eq!(nums(src), vec![10.0, 2.0]);
     }
 }

--- a/code/packages/rust/s-runtime/src/refclass.rs
+++ b/code/packages/rust/s-runtime/src/refclass.rs
@@ -242,9 +242,16 @@ fn validate_methods(methods: &SValue) -> SResult<SValue> {
                         ))
                     }
                     Some(name) => {
-                        if !v.is_callable() {
+                        // A method must be a user `function(...) ...` (an
+                        // `SValue::Closure`) so it can be *re-homed* onto the
+                        // instance on access (see `rebuild_method`). A builtin or
+                        // `Negate(f)` wrapper is callable but has no re-parentable
+                        // body, so it could never see the instance's fields —
+                        // reject it up front with a clear error rather than have it
+                        // silently read back as `NULL` later.
+                        if !matches!(v, SValue::Closure { .. }) {
                             return Err(SError::TypeError(format!(
-                                "setRefClass: method '{name}' must be a function"
+                                "setRefClass: method '{name}' must be a function defined with `function(...)`"
                             )));
                         }
                     }

--- a/code/packages/rust/s-runtime/src/refclass.rs
+++ b/code/packages/rust/s-runtime/src/refclass.rs
@@ -1,0 +1,432 @@
+//! R5 **reference classes** — `setRefClass`, generators, and instances.
+//!
+//! This is the payoff of the R-21/22/23 environment work. The central idea is
+//! deceptively small:
+//!
+//! > **An R5 object *is* an environment**, holding its fields as bindings, and a
+//! > **method *is* a closure** whose enclosing environment is that instance
+//! > environment — so the method body sees the fields directly and writes them
+//! > back by reference.
+//!
+//! Everything else falls out of reusing the shared [`SValue::Environment`] value
+//! (a live, mutate-by-reference scope) plus R-21's `<<-` super-assignment.
+//!
+//! ## The object graph
+//!
+//! There are two kinds of object, both encoded as [`SValue::Environment`] but
+//! distinguished by the *private bindings* they carry (names beginning with a
+//! dot, which ordinary `obj$field` access never collides with because a user
+//! field of the same dotted name would simply shadow it):
+//!
+//! ```text
+//!   setRefClass("Acc", fields = …, methods = …)
+//!        │
+//!        ▼
+//!   GENERATOR  (an Environment)
+//!     .refClassName = "Acc"                 # character
+//!     .refFields    = c("total")            # field names, declaration order
+//!     .refMethods   = list(add=<closure>,   # methods AS WRITTEN — each closes
+//!                          get=<closure>)    #   over the GENERATOR's scope
+//!        │
+//!        │  generator$new(total = 0)
+//!        ▼
+//!   INSTANCE  (a fresh child Environment of the generator's defining scope)
+//!     total       = 0                       # the field bindings (mutable)
+//!     .self       = <Environment → itself>  # so a method can call .self$other()
+//!     .refMethods = list(add=…, get=…)      # carried so methods rebuild on access
+//! ```
+//!
+//! ## Why methods are rebuilt lazily (the instance⇄method Rc-cycle)
+//!
+//! The *obvious* encoding — bind each method as a closure **in the instance's own
+//! bindings**, with that closure's `env` being the instance — forms a **strong
+//! reference cycle**:
+//!
+//! ```text
+//!   instance.vars["add"]  ──▶  Closure { env: <strong Rc to instance> }
+//!         ▲                                   │
+//!         └───────────────────────────────────┘   (uncollectable by Rc alone)
+//! ```
+//!
+//! `Rc` never reclaims a cycle, so every such instance would leak its whole scope
+//! the moment it became unreachable. **We break the cycle by never storing the
+//! instance-bound closures at all.** The instance holds only its field bindings,
+//! `.self`, and `.refMethods` — and the closures inside `.refMethods` close over
+//! the **generator's** scope, *not* the instance's, so they form no edge back to
+//! the instance. The instance-bound method closure (whose `env` *is* the instance)
+//! is materialised **lazily, on each `obj$method` access**, lives only for the
+//! duration of that one call, and is dropped immediately after. Because it is
+//! never stored anywhere reachable from the instance, the
+//! instance → method → instance edge never exists *at rest* — there is nothing for
+//! `Rc` to fail to collect.
+//!
+//! The one remaining strong self-reference is `.self` (an `Environment` to the
+//! instance, stored inside the instance). That is exactly the *documented,
+//! pre-existing* R-22 value-binding self-cycle — `assign("self", e, envir = e)` —
+//! which we do not claim to collect but which is *bounded* (not unbounded) by the
+//! `MAX_ENVIRONMENTS` session cap. We inherit that boundary verbatim rather than
+//! widening the ownership model.
+//!
+//! ## Reference (alias) semantics
+//!
+//! Because an instance *is* an [`SValue::Environment`] — a strong `Rc` to a live
+//! scope — `b <- a` copies the **handle**, not the scope's contents. `a` and `b`
+//! then name the *same* instance: `b$add(1)` mutates the shared scope and
+//! `a$total` sees it. This is the deliberate exception to R's otherwise
+//! copy-on-modify value semantics, and it is the headline behaviour of R5.
+
+use crate::env::{self, Env};
+use crate::error::{SError, SResult};
+use crate::value::SValue;
+
+/// Private binding: the reference class's **name** (a length-1 character),
+/// carried on the generator. Dotted so it never collides with a user field.
+pub const KEY_CLASS_NAME: &str = ".refClassName";
+
+/// Private binding: the **field names** (a character vector, declaration order),
+/// carried on the generator. Used by `$new` to know which fields to bind.
+pub const KEY_FIELDS: &str = ".refFields";
+
+/// Private binding: the **methods** (an `SValue::List` of closures *as written*,
+/// each closing over the generator's defining scope), carried on **both** the
+/// generator and every instance. The instance copy is what `obj$method` consults
+/// to rebuild a fresh instance-bound closure on access — see the module note on
+/// the instance⇄method cycle.
+pub const KEY_METHODS: &str = ".refMethods";
+
+/// Private binding: `.self`, an [`SValue::Environment`] pointing at the instance
+/// itself, bound inside the instance so a method body can reach a sibling method
+/// as `.self$other(...)`.
+pub const KEY_SELF: &str = ".self";
+
+/// Is `env` a **reference-class generator** (carries the class-name marker)?
+/// Distinguishes a generator from an ordinary `new.env()` environment so the `$`
+/// dispatch can route `generator$new`. A plain environment has none of the
+/// private bindings, so this is `false` for it.
+pub fn is_generator(env: &Env) -> bool {
+    // **Frame-local** markers only: an instance is a *child* of its generator, so
+    // a chain-walking lookup of the generator's `.refClassName` would find it
+    // through the parent and misclassify the instance. A generator binds
+    // `.refClassName` directly and never binds `.self`.
+    env::lookup_local(env, KEY_CLASS_NAME).is_some()
+        && env::lookup_local(env, KEY_FIELDS).is_some()
+        && env::lookup_local(env, KEY_SELF).is_none()
+}
+
+/// Is `env` a reference-class **instance** (carries `.self` and `.refMethods` in
+/// its own frame)? An instance always binds `.self` to itself; a generator never
+/// does. Frame-local for the same reason as [`is_generator`].
+pub fn is_instance(env: &Env) -> bool {
+    env::lookup_local(env, KEY_SELF).is_some() && env::lookup_local(env, KEY_METHODS).is_some()
+}
+
+/// Pull the method **closures** carried by a generator/instance as `(name,
+/// closure)` pairs. Returns an empty list when the `.refMethods` binding is
+/// absent or is not a list (a defensive default — never a panic). Only entries
+/// that are actually callable closures are surfaced; a non-closure method entry
+/// (which `setRefClass` rejects up front) is silently skipped here as a second
+/// line of defence.
+fn methods_of(env: &Env) -> Vec<(String, SValue)> {
+    match env::lookup_local(env, KEY_METHODS) {
+        Some(SValue::List { names, items }) => names
+            .into_iter()
+            .zip(items)
+            .filter_map(|(n, v)| match (n, &v) {
+                (Some(name), SValue::Closure { .. }) => Some((name, v)),
+                _ => None,
+            })
+            .collect(),
+        _ => Vec::new(),
+    }
+}
+
+/// The declared field names of a generator (the `.refFields` character vector),
+/// in declaration order. An absent or non-character marker yields an empty list.
+fn field_names(env: &Env) -> Vec<String> {
+    match env::lookup_local(env, KEY_FIELDS) {
+        Some(SValue::Character(v)) => v.into_iter().flatten().collect(),
+        _ => Vec::new(),
+    }
+}
+
+/// Build a reference-class **generator** from already-evaluated pieces:
+/// `class_name`, the `fields` value (a list whose *names* are the field names —
+/// the type strings are recorded but not enforced in this subset), and the
+/// `methods` value (a list of closures). `defining_env` becomes the generator
+/// scope's parent (so a method's free variables can still resolve up the lexical
+/// chain to where `setRefClass` was called).
+///
+/// Each argument is validated; a malformed one is a clean `BadArgs`/`TypeError`,
+/// never a panic. The generator is returned as an [`SValue::Environment`]; the
+/// caller is responsible for charging it against `MAX_ENVIRONMENTS`.
+pub fn make_generator(
+    class_name: &str,
+    fields: &SValue,
+    methods: &SValue,
+    defining_env: &Env,
+) -> SResult<SValue> {
+    // The field NAMES come from the `fields = list(x = "numeric", …)` argument's
+    // names attribute. R also accepts a bare character vector (`fields =
+    // c("x", "y")`); we support both shapes.
+    let field_vec = extract_field_names(fields)?;
+
+    // Validate the methods list: it must be a (possibly empty) list of *named*
+    // closures. Anything else is a clean error.
+    let method_list = validate_methods(methods)?;
+
+    let scope = env::Scope::child(defining_env);
+    env::define(
+        &scope,
+        KEY_CLASS_NAME,
+        SValue::Character(vec![Some(class_name.to_string())]),
+    );
+    env::define(
+        &scope,
+        KEY_FIELDS,
+        SValue::Character(field_vec.into_iter().map(Some).collect()),
+    );
+    env::define(&scope, KEY_METHODS, method_list);
+    Ok(SValue::Environment(scope))
+}
+
+/// Extract field names from the `fields =` argument. Two shapes are accepted:
+/// a **named list** `list(x = "numeric", y = "character")` (the field names are
+/// the list's names; the type strings are ignored in this subset), or a plain
+/// **character vector** `c("x", "y")` (the elements *are* the field names). A
+/// missing `fields` (R allows a class with no fields) yields an empty list. Any
+/// other shape — an unnamed list, a numeric vector — is a clean error.
+fn extract_field_names(fields: &SValue) -> SResult<Vec<String>> {
+    match fields.strip_attrs() {
+        SValue::Null => Ok(Vec::new()),
+        SValue::List { names, .. } => {
+            let mut out = Vec::with_capacity(names.len());
+            for n in names {
+                match n {
+                    Some(name) => out.push(name.clone()),
+                    None => {
+                        return Err(SError::BadArgs(
+                            "setRefClass: every entry in `fields` must be named".into(),
+                        ))
+                    }
+                }
+            }
+            Ok(out)
+        }
+        SValue::Character(v) => v
+            .iter()
+            .map(|o| {
+                o.clone().ok_or_else(|| {
+                    SError::BadArgs("setRefClass: a field name may not be NA".into())
+                })
+            })
+            .collect(),
+        other => Err(SError::TypeError(format!(
+            "setRefClass: `fields` must be a list or character vector, got {}",
+            other.type_name()
+        ))),
+    }
+}
+
+/// Validate the `methods =` argument into a normalised `list` of named closures.
+/// `NULL` (no methods) becomes the empty list. A non-list, an unnamed entry, or
+/// a non-function entry is a clean error — never a panic.
+fn validate_methods(methods: &SValue) -> SResult<SValue> {
+    match methods.strip_attrs() {
+        SValue::Null => Ok(SValue::list(Vec::new())),
+        SValue::List { names, items } => {
+            for (n, v) in names.iter().zip(items.iter()) {
+                match n {
+                    None => {
+                        return Err(SError::BadArgs(
+                            "setRefClass: every entry in `methods` must be named".into(),
+                        ))
+                    }
+                    Some(name) => {
+                        if !v.is_callable() {
+                            return Err(SError::TypeError(format!(
+                                "setRefClass: method '{name}' must be a function"
+                            )));
+                        }
+                    }
+                }
+            }
+            Ok(SValue::List {
+                names: names.clone(),
+                items: items.clone(),
+            })
+        }
+        other => Err(SError::TypeError(format!(
+            "setRefClass: `methods` must be a list, got {}",
+            other.type_name()
+        ))),
+    }
+}
+
+/// Instantiate a generator: `generator$new(field = value, …)`. Builds a fresh
+/// **instance** environment (a child of the generator's defining scope), binds
+/// each declared field — to the matching `new(field = …)` argument value, or
+/// `NULL` when omitted — and binds the two private markers `.self` (the instance,
+/// for `.self$method()`) and `.refMethods` (carried from the generator so
+/// `obj$method` can rebuild a closure on access). An argument naming a field that
+/// the class did not declare is a clean error. The instance is returned as an
+/// [`SValue::Environment`]; the caller charges it against `MAX_ENVIRONMENTS`.
+///
+/// `init_args` are `(optional name, value)` pairs as supplied at the call site;
+/// `new` matches them **by name** (R5 `$new` is keyword-only for fields).
+pub fn instantiate(generator: &Env, init_args: &[(Option<String>, SValue)]) -> SResult<SValue> {
+    if !is_generator(generator) {
+        return Err(SError::TypeError(
+            "$new: the target is not a reference-class generator".into(),
+        ));
+    }
+    let fields = field_names(generator);
+
+    // The generator's *defining scope* is the instance's lexical parent, so a
+    // method's free variables resolve up to where the class was defined. The
+    // generator scope's own parent is that defining scope (see `make_generator`),
+    // so we parent the instance on the generator scope itself — a method then sees
+    // the generator's private bindings shadowed only by the instance's fields,
+    // which is harmless (a user field never starts with a dot).
+    let scope = env::Scope::child(generator);
+
+    // Bind every declared field, defaulting to NULL when `new` omitted it.
+    for field in &fields {
+        let value = init_args
+            .iter()
+            .find(|(name, _)| name.as_deref() == Some(field.as_str()))
+            .map(|(_, v)| v.clone())
+            .unwrap_or(SValue::Null);
+        env::define(&scope, field, value);
+    }
+
+    // Reject any `new(arg = …)` whose name is not a declared field — a typo
+    // should fail loudly rather than silently create a stray binding.
+    for (name, _) in init_args {
+        match name {
+            Some(n) if fields.iter().any(|f| f == n) => {}
+            Some(n) => {
+                return Err(SError::BadArgs(format!(
+                    "$new: '{n}' is not a field of this reference class"
+                )))
+            }
+            None => {
+                return Err(SError::BadArgs(
+                    "$new: fields must be supplied by name (e.g. new(total = 0))".into(),
+                ))
+            }
+        }
+    }
+
+    // Carry the methods list (closures over the generator scope) onto the
+    // instance so `obj$method` can rebuild an instance-bound closure on demand.
+    if let Some(methods) = env::lookup(generator, KEY_METHODS) {
+        env::define(&scope, KEY_METHODS, methods);
+    }
+
+    // `.self` — a strong Environment value to the instance itself, so a method
+    // can reach a sibling via `.self$other(...)`. This is the one (documented,
+    // bounded) R-22 value-binding self-cycle; see the module note.
+    env::define(&scope, KEY_SELF, SValue::Environment(scope.clone()));
+
+    Ok(SValue::Environment(scope))
+}
+
+/// Resolve `obj$name` where `obj` is a reference-class object (generator or
+/// instance). Returns `Some(value)` if `name` is handled here, or `None` to let
+/// the caller fall through to plain-environment `$` access (an ordinary field /
+/// binding lookup). The three reference-class-specific cases are:
+///
+/// * **`generator$new`** → a callable that the trailing `call_suffix` applies.
+///   We hand back a marker the dispatcher recognises (see [`new_marker`]); the
+///   actual instantiation happens in [`instantiate`] once the args are evaluated.
+/// * **`obj$method`** (a name present in `.refMethods`) → a **fresh** closure
+///   whose `env` is the **instance** (so its body sees the fields and updates
+///   them with `<<-`). Built lazily here and never stored — see the module note
+///   on the instance⇄method cycle.
+/// * everything else → `None` (fall through to a field/binding lookup).
+///
+/// A field that *shadows* a method name is read as a field (the instance's own
+/// binding wins), matching the lookup order a user expects.
+pub fn dollar_access(obj: &Env, name: &str) -> Option<SValue> {
+    if is_instance(obj) {
+        // A **field** binding on the instance frame always wins over a method of
+        // the same name (matching the lookup order a user expects). Read it
+        // frame-locally so `obj$x` never leaks a generator/parent binding.
+        if let Some(value) = env::lookup_local(obj, name) {
+            return Some(value);
+        }
+        // Not a field → a method? Rebuild a fresh instance-bound closure on
+        // access (never stored — see the module note on the instance⇄method
+        // cycle).
+        if let Some(closure) = rebuild_method(obj, name) {
+            return Some(closure);
+        }
+        // Unknown member → NULL, as R5 reads an unset field / missing method.
+        return Some(SValue::Null);
+    }
+
+    if is_generator(obj) {
+        // `generator$new` → the instantiation marker. Any other name on a
+        // generator reads its (private or user) binding via the ordinary path.
+        if name == "new" {
+            return Some(new_marker(obj));
+        }
+        return None;
+    }
+
+    None
+}
+
+/// Rebuild a fresh **instance-bound** closure for method `name`: take the method
+/// closure as written (which closes over the *generator* scope) and return a new
+/// `Closure` with the same params/body but its `env` swapped to the **instance**.
+/// The body then sees the instance's fields as free variables and writes them
+/// back with `<<-`. Returns `None` if `name` is not a method. **Never stored** —
+/// this lives only for the call that triggered it, so it forms no lasting
+/// instance⇄method `Rc` cycle (see the module note).
+fn rebuild_method(instance: &Env, name: &str) -> Option<SValue> {
+    for (mname, m) in methods_of(instance) {
+        if mname == name {
+            if let SValue::Closure { params, body, .. } = m {
+                return Some(SValue::Closure {
+                    params,
+                    body,
+                    env: instance.clone(),
+                });
+            }
+        }
+    }
+    None
+}
+
+/// The marker value returned for `generator$new`: a `Classed` wrapper carrying
+/// the generator environment and the private class `".refGeneratorNew"`, which
+/// the call dispatcher in `eval.rs` recognises to route to [`instantiate`].
+/// Using a value the existing `apply` path can recognise (rather than a bespoke
+/// `SValue` variant) keeps the change localised and the exhaustive matches
+/// elsewhere untouched.
+pub fn new_marker(generator: &Env) -> SValue {
+    SValue::Classed {
+        inner: Box::new(SValue::Environment(generator.clone())),
+        class: vec![CLASS_NEW_MARKER.to_string()],
+    }
+}
+
+/// The private S3 class tag the `$new` marker carries; the call dispatcher keys
+/// on it to route a `generator$new(...)` application to [`instantiate`].
+pub const CLASS_NEW_MARKER: &str = ".refGeneratorNew";
+
+/// If `value` is the `generator$new` marker produced by [`new_marker`], return
+/// the generator environment it wraps; otherwise `None`. Lets the call
+/// dispatcher detect the marker without matching on the private class string in
+/// more than one place.
+pub fn as_new_marker(value: &SValue) -> Option<Env> {
+    if let SValue::Classed { inner, class } = value {
+        if class.iter().any(|c| c == CLASS_NEW_MARKER) {
+            if let SValue::Environment(e) = inner.as_ref() {
+                return Some(e.clone());
+            }
+        }
+    }
+    None
+}

--- a/code/specs/R00-r-language.md
+++ b/code/specs/R00-r-language.md
@@ -587,6 +587,88 @@ unchanged.
     prevents any parent-chain cycle. `parent.frame(n)` clamps rather than indexes,
     so a crafted deep `n` cannot panic.
 
+- **R-24 — R5 reference classes (`setRefClass`)** *(this PR)*. The payoff of the
+  R-21/22/23 environment work: an R5 object **is** an environment holding its
+  fields, and a method **is** a closure whose enclosing environment is the
+  instance environment — so a method body sees fields directly and writes them
+  back with `<<-`. Everything lands in the shared `s-runtime`; no grammar change
+  (`$` already exists from the data-frame work).
+  - **`setRefClass("Name", fields = list(x = "numeric", …), methods = list(m = function(…) …))`**
+    → a **generator** object. `setRefClass` is a **lazy special form** (like
+    `switch`/`new.env`): it must capture the `methods = list(…)` *function
+    definitions unevaluated* and the *current environment* (the generator's
+    enclosing scope), neither of which an eager builtin receives. The generator
+    is represented as an `SValue::Environment` — a fresh scope carrying three
+    private bindings: `.refClassName` (the class name, a character), `.refFields`
+    (the field names, a character vector, in declaration order), and `.refMethods`
+    (a `list` of the method **closures** as written, each closing over the
+    generator's defining scope). The field *type* strings (`"numeric"`,
+    `"character"`) are recorded but **not enforced** in this subset — R5 type
+    checking is deferred — so a field may hold any value. Reifying the generator
+    env counts against `MAX_ENVIRONMENTS`.
+  - **`generator$new(x = …, y = …)`** → an **instance**. `new` creates a *fresh*
+    child environment of the generator's defining scope and binds: every declared
+    field (to the matching `new(field = …)` argument, or `NULL` when omitted),
+    `.self` (an `SValue::Environment` pointing at the instance itself), and
+    `.refMethods` (carried from the generator so methods can be rebuilt on
+    access). The instance also counts against `MAX_ENVIRONMENTS`.
+  - **`obj$field`** reads a field — an ordinary `env::lookup` in the instance
+    scope (the `$` read path, extended for `SValue::Environment`, returns the
+    bound value, or `NULL` for an unset field, matching R5).
+  - **`obj$field <- v`** writes a field **by reference**. The `$<-` lvalue path is
+    extended for an `SValue::Environment` target: it `env::define`s the name in the
+    *instance scope in place*, mutating the live environment rather than rebinding a
+    copy. This is what gives R5 its **reference semantics** — see below.
+  - **`obj$method(args)`** calls a method. The `$` read path, seeing a name that is
+    *not* a field but *is* present in `.refMethods`, **reconstructs** a fresh
+    `Closure` whose `env` is the **instance** environment (not the generator's),
+    then the trailing `call_suffix` applies it. Because the method closes over the
+    instance scope, its body sees the fields as free variables and updates them
+    with `field <<- value` (super-assignment walks to the enclosing instance frame
+    and rebinds in place — R-21's `<<-`), or via `.self$field <- v`. `.self` is
+    bound in the instance, so a method may call a sibling method as
+    `.self$other(…)`.
+  - **Reference semantics (the headline).** `b <- a` copies the *environment
+    handle* (a strong `Rc` to the same scope), **not** the scope's contents — so
+    `a` and `b` are two references to one instance. `b$add(1)` mutates the shared
+    scope and `a$total` reflects it. This is the deliberate exception to R's
+    otherwise copy-on-modify value semantics, and it falls straight out of reusing
+    R-22's first-class, mutate-by-reference `SValue::Environment`: the instance *is*
+    a live scope, and assigning it to a new name aliases rather than clones it. Two
+    instances built by two separate `$new` calls are *independent* (distinct
+    scopes), so their fields do not interfere.
+  - **Rc-cycle safety (the instance⇄method trap, broken by construction).** The
+    obvious encoding — bind each method *as a closure* directly in the instance's
+    `vars`, with that closure's `env` being the instance — forms a **strong
+    reference cycle**: `instance.vars["m"]` is a `Closure` whose `env` is a strong
+    `Rc` back to `instance`. `Rc` never reclaims a cycle, so every such instance
+    would leak its whole scope. **We break it by never storing the
+    instance-bound closures.** The instance holds only the *field bindings*, `.self`,
+    and `.refMethods` — and the closures inside `.refMethods` close over the
+    **generator's** scope, *not* the instance's, so they create no edge back to the
+    instance. The instance-bound method closure is materialised **lazily, per
+    access**, in `obj$method`, lives only for the duration of that one call, and is
+    dropped immediately after — it is never stored anywhere reachable from the
+    instance, so the instance→method→instance edge never exists at rest. The one
+    remaining strong self-reference is `.self` (an `Environment` to the instance
+    stored *inside* the instance) — exactly the *documented, pre-existing* R-22
+    value-binding self-cycle, bounded (not collected) by the `MAX_ENVIRONMENTS`
+    session cap; we inherit that boundary verbatim rather than widening it.
+  - **Borrow-panic safety.** A method that mutates a field mid-call goes through
+    `env::define`/`env::lookup`, each of which takes and releases the instance
+    scope's `RefCell` borrow *per operation* (the iterative-walk discipline R-22
+    established), so a method reading one field and writing another never holds two
+    borrows of the same scope at once. Malformed `setRefClass`/`$new` arguments — a
+    non-character class name, a `fields`/`methods` that is not a list, a method
+    entry that is not a function, an unknown `new()` argument — are all clean
+    `BadArgs`/`TypeError` results, never panics.
+  - **Deferred to R-25 (scope guard).** Inheritance (`contains = "Base"`),
+    `$copy()` (a deep value-copy breaking the reference sharing), active bindings,
+    and the `$methods()`/`$fields()` introspection accessors are **out of scope**
+    here. This PR ships fields + methods + `$new` + `$field` read/write + method
+    calls with `<<-`/`.self$field <-` field update, solidly and with full
+    reference-semantics tests. A clean partial beats a sprawling one.
+
 ## §4 Reuse strategy
 
 - **Lexer/parser:** the grammar-tools framework, exactly as S uses it. `r.tokens`
@@ -605,7 +687,9 @@ Pipes (`|>`) and backslash lambdas (`\(x)`). The `SValue::Environment` value,
 `environment(f) <-`, `environmentName`, `globalenv()`/`emptyenv()`/`baseenv()`,
 `parent.frame()`, and `is.environment()` land in **R-23**. Still out of scope:
 `sys.call`/`sys.function`/`match.call` and the rest of the call-introspection
-family; S4/R5/R6 OO; namespaces and `library()` (so `baseenv()` aliases the
+family; S4 and R6 OO (R5 reference classes land in **R-24**, with inheritance,
+`$copy()`, active bindings and `$methods()`/`$fields()` introspection deferred to
+**R-25**); namespaces and `library()` (so `baseenv()` aliases the
 global env for now); the C interface; graphics. These layer on later, following
 ST00.
 


### PR DESCRIPTION
## R-24 — R5 Reference Classes (`setRefClass`)

The payoff of the R-21/22/23 environment work: **an R5 object IS an environment** holding its fields, and **a method IS a closure** whose enclosing environment is the instance env — so a method body sees the fields directly and writes them back by reference. Implemented in the shared `s-runtime` (new `src/refclass.rs`); R inherits it through the language-neutral tree-walker. No grammar change — `$` already existed.

### Shipped
- **`setRefClass("Name", fields = list(x = "numeric", …), methods = list(m = function(…) …))`** → a **generator** (a first-class environment carrying `.refClassName`, `.refFields`, `.refMethods`). A lazy special form so methods close over where the class was defined. Field type strings are recorded but **not enforced** in this subset. `fields` accepts a named list or a bare character vector.
- **`generator$new(field = …)`** → an **instance**: a fresh child environment binding the fields (omitted → `NULL`), `.self`, and `.refMethods`. Unknown `new()` arg → clean error.
- **`obj$field`** reads a field (frame-local); **`obj$field <- v`** writes it **in place by reference**; **`obj$method(args)`** rebuilds a fresh instance-bound closure on access and applies it, so `field <<- value` and `.self$field <- v` mutate the live instance. `.self` lets a method call a sibling via `.self$other()`.
- **Reference (alias) semantics** — `b <- a` shares state (both reference one instance scope), unlike R's copy-on-modify; two separate `$new` instances are independent. Tested explicitly.

### The instance⇄method Rc-cycle (handled by construction)
The naïve encoding — bind each method *as a closure in the instance*, with the closure's `env` being the instance — is a strong, uncollectable `Rc` cycle that leaks. **Broken by never storing instance-bound closures:** the instance holds only fields, `.self`, and `.refMethods`, and the closures in `.refMethods` close over the **generator's** scope, not the instance — so they form no edge back. The instance-bound closure (whose `env` *is* the instance) is materialised **lazily per `obj$method` access** and dropped after the call, never stored. The one remaining strong self-reference is `.self` — exactly the documented, `MAX_ENVIRONMENTS`-bounded R-22 value-binding self-cycle, inherited verbatim. New `env::lookup_local` (frame-local read) keeps an instance — a child of its generator — from being misclassified as a generator.

### Deferred to R-25 (scope guard)
Inheritance (`contains =`), `$copy()`, active bindings, and `$methods()`/`$fields()` introspection.

### Tests
24 new tests — 14 in `r-runtime` (R syntax: `add`/`get` via `<<-`, `$field` read/write, reference-semantics alias, independent instances, `.self` sibling dispatch, `.self$field <-`, character field, omitted-field-NULL, empty class, error cases) and 10 in `s-runtime` (S syntax, plus `refclass` module classification / malformed-input coverage). Full suites green: **s-runtime 163, r-runtime 202**, doctests pass. `cargo clippy` clean on both crates. Plus R-20..R-23 regression tests after the `$`/`$<-`/apply changes.

### Security review — PASS
A senior-Rust-security sub-agent reviewed the full diff focused on Rc cycles, RefCell re-entrancy, panics, and resource exhaustion. **No CRITICAL/HIGH/MEDIUM.** Confirmed: no new unbounded cycle source (lazy rebuild never stored; `.self` is the bounded R-22 case); borrows are taken/released per op (no re-entrancy panic); all malformed inputs return clean `SError`s (no unwrap/index/cast panics); every reified env is charged against `MAX_ENVIRONMENTS`. One INFO note addressed in a follow-up commit: `setRefClass` now requires methods to be user `function(...)` closures (a builtin method would have silently read back as `NULL`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
