### PR TITLE
feat(mycin-cc2b): conjunctive hepatorenal dose cap for ceftriaxone

### DIFF
--- a/code/specs/data/mycin-2026/CHART-AS-CONSTRAINTS.md
+++ b/code/specs/data/mycin-2026/CHART-AS-CONSTRAINTS.md
@@ -54,7 +54,7 @@ feasibility/`check`, simplex `minimize`/`maximize`, observed-value substitution)
 | **Allergy** (penicillin) | exclusion | hard: `x_d = 0` | β-lactams excluded |
 | **Pregnancy** | exclusion | hard: `x_d = 0` | moxifloxacin, TMP-SMX excluded |
 | **Renal impairment** (eGFR/CrCl lab) | dose cap | `dose_d ≤ ceiling_d(renal)` | vancomycin ceiling shrinks; renally-cleared drugs capped |
-| **Hepatic impairment** | dose cap / exclusion | `dose_d ≤ ceiling_d(hepatic)` | |
+| **Hepatic impairment** | dose cap (conjunctive) | `dose_d ≤ ceiling_d(hepatic ∧ renal)` | ceftriaxone capped only when hepatic **and** renal impairment co-occur (FDA label); hepatic alone needs no adjustment (§3a) |
 | **Concurrent meds** | drug–drug interaction | exclusion or dose cap | other nephrotoxin → vancomycin ceiling ↓ (additive toxicity) |
 | **Comorbidity** (QT, G6PD, seizure hx, myasthenia) | exclusion / penalty | hard or soft | avoid QT-prolonging agents; avoid seizure-threshold-lowering |
 | **Dose-window** (efficacy ↔ toxicity) | feasibility band | `floor_d ≤ dose_d ≤ ceiling_d` | UNSAT when no safe-and-effective dose exists |
@@ -153,6 +153,26 @@ risks Y") — decision support, not a hidden choice.
   self-documenting about *why* each drug is out, the infeasibility verdict is the engine's, and
   the exclusion reasoning lives in ADJ, not the compiler. (Reasons are sanitized before reaching
   the `%` comment.)
+- **CC-2b — hepatic impairment is a CONJUNCTIVE dose cap, not a standalone one. ✅ DONE.** The
+  ceftriaxone FDA label conditions its 2 g/day ceiling on the *joint* presence of two organ
+  impairments: *"Patients with hepatic impairment and significant renal impairment should not
+  receive more than 2 grams per day of ceftriaxone."* (DailyMed setid
+  `5cd2d96f-83e5-4326-ae87-d0ede4ba493a`, §5.7 / USE IN SPECIFIC POPULATIONS; grounded as record
+  `dose_cap_ceftriaxone_hepatorenal` in `dose-window-grounding.json`). Faithfully modeling this
+  means **not** treating hepatic impairment as its own dose cap: a `hepatic_status` chart fact
+  alone adds an audit-only risk marker but **no** dose penalty (the same label says hepatic
+  impairment alone needs no adjustment). Only when a `hepatic_*` risk and a `renal_*` risk
+  co-occur does `chart_to_cop.derive()` synthesize a derived **`hepatorenal`** risk, which then
+  applies ceftriaxone's `ceiling_penalty_mg_per_kg.hepatorenal` reduction (50 → 38 mg/kg in the
+  feasibility model — still ≥ the 25 mg/kg floor, so the regimen stays FEASIBLE but
+  dose-adjusted, mirroring "cap, don't forbid"). This is the first constraint family whose
+  *trigger* is a conjunction of two chart facts rather than a single fact, exercising the
+  derived-risk path. As with every dose number in `formulary.json`, the **mechanism**
+  (conjunction → shrink the ceiling, on ceftriaxone) is grounded; the precise mg/kg shrink is the
+  standing **ILLUSTRATIVE** feasibility model (the label's cap is an absolute 2 g/day), not
+  validated PK/PD. Verified by `test_hepatic_renal_conjunction_caps_ceftriaxone` (hepatic-alone →
+  no `hepatorenal`; hepatic + renal_moderate → `hepatorenal` present and regimen still feasible;
+  unrecognized hepatic value discarded).
 - **CC-3 — contraindication / interaction grounding.** `contraindication-grounding.json` +
   `interaction-grounding.json` via the harness (pregnancy, QT, G6PD, allergy classes,
   drug–drug); gate → CAS; new "treatment constraints" ledger artifact.

--- a/code/specs/data/mycin-2026/board/board-scorecard.json
+++ b/code/specs/data/mycin-2026/board/board-scorecard.json
@@ -1,7 +1,7 @@
 {
   "summary": {
-    "total": 152,
-    "correct": 145,
+    "total": 153,
+    "correct": 146,
     "abstained": 7,
     "wrong": 0,
     "by_tactic": {
@@ -11,7 +11,7 @@
         "wrong": 0
       },
       "management": {
-        "correct": 5,
+        "correct": 6,
         "abstained": 0,
         "wrong": 0
       },
@@ -552,6 +552,14 @@
       "tactic": "management",
       "gold": "INFEASIBLE",
       "answer": "INFEASIBLE",
+      "outcome": "correct",
+      "trust": null
+    },
+    {
+      "id": "mgmt_hepatorenal",
+      "tactic": "management",
+      "gold": "ceftriaxone+vancomycin",
+      "answer": "ceftriaxone+vancomycin",
       "outcome": "correct",
       "trust": null
     },

--- a/code/specs/data/mycin-2026/board/items.json
+++ b/code/specs/data/mycin-2026/board/items.json
@@ -75,6 +75,7 @@
     {"id": "mgmt_neurosurgical",     "domain": "meningitis_tx", "tactic": "management", "chart": [["setting", "post_neurosurgical", "POD#3 craniotomy"]],                                         "gold": ["cefepime", "vancomycin"]},
     {"id": "mgmt_pregnant_adult",    "domain": "meningitis_tx", "tactic": "management", "chart": [["age_band", "adult", "28-year-old"], ["pregnancy", "present", "G2P1 at 24 weeks"]],            "gold": ["ceftriaxone", "vancomycin"]},
     {"id": "mgmt_betalactam_allergic","domain": "meningitis_tx", "tactic": "management", "chart": [["age_band", "adult", "adult"], ["allergy", "betalactam", "anaphylaxis to multiple beta-lactams (whole-class)"]],       "gold": "INFEASIBLE"},
+    {"id": "mgmt_hepatorenal",       "domain": "meningitis_tx", "tactic": "management", "chart": [["age_band", "adult", "58-year-old"], ["hepatic_status", "hepatic_moderate", "Child-Pugh B cirrhosis"], ["renal_status", "renal_moderate", "CrCl 38 mL/min"]], "gold": ["ceftriaxone", "vancomycin"]},
 
     {"id": "micro_saureus_gram",   "domain": "micro", "tactic": "recall", "relation": "gram_stain", "subject": "staphylococcus_aureus",    "var": "Result",  "gold": "gram_positive"},
     {"id": "micro_saureus_shape",  "domain": "micro", "tactic": "recall", "relation": "morphology", "subject": "staphylococcus_aureus",    "var": "Shape",   "gold": "cocci"},

--- a/code/specs/data/mycin-2026/board/test_board_eval.py
+++ b/code/specs/data/mycin-2026/board/test_board_eval.py
@@ -259,6 +259,12 @@ def test_management_runs_the_constraint_engine_when_cli_present() -> None:
     assert by_id["mgmt_adult_community"].answer == "ceftriaxone+vancomycin"
     assert by_id["mgmt_betalactam_allergic"].outcome == "correct"
     assert by_id["mgmt_betalactam_allergic"].answer == "INFEASIBLE"
+    # CC-2b: hepatic + renal impairment is a CONJUNCTIVE dose cap. The chart carries
+    # hepatic_moderate AND renal_moderate, so the engine derives a `hepatorenal` risk that
+    # shrinks ceftriaxone's ceiling (50 -> 38 mg/kg) — still above its floor, so the regimen
+    # stays FEASIBLE and dose-adjusted (cap, don't forbid): ceftriaxone + vancomycin.
+    assert by_id["mgmt_hepatorenal"].outcome == "correct"
+    assert by_id["mgmt_hepatorenal"].answer == "ceftriaxone+vancomycin"
 
 
 def _card_with_diff():

--- a/code/specs/data/mycin-2026/grounding/dose-window-grounding.json
+++ b/code/specs/data/mycin-2026/grounding/dose-window-grounding.json
@@ -249,6 +249,35 @@
         "final_verdict": "direction_only"
       },
       "spider_status": "direction_only"
+    },
+    {
+      "id": "dose_cap_ceftriaxone_hepatorenal",
+      "kind": "dose_cap",
+      "drug": "ceftriaxone",
+      "claim": "In a patient with BOTH hepatic impairment AND significant renal impairment, ceftriaxone must be capped at 2 g/day. The cap is CONJUNCTIVE: hepatic impairment alone needs no dose adjustment, and renal impairment alone is handled by the ordinary renal dose-window; only the joint occurrence triggers this ceiling.",
+      "grounded": {
+        "id": "dose_cap_ceftriaxone_hepatorenal",
+        "resolved_url": "https://dailymed.nlm.nih.gov/dailymed/fda/fdaDrugXsl.cfm?setid=5cd2d96f-83e5-4326-ae87-d0ede4ba493a",
+        "source_title": "CEFTRIAXONE FOR INJECTION, USP — FDA prescribing information (DailyMed / NLM); USE IN SPECIFIC POPULATIONS / section 5.7 Patients with Hepatic and Renal Impairment",
+        "byte_quote": "Patients with hepatic impairment and significant renal impairment should not receive more than 2 grams per day of ceftriaxone.",
+        "value_found": "ceftriaxone capped at 2 g/day for the CONJUNCTION of hepatic impairment AND significant renal impairment; the label states this only for the joint condition, and elsewhere notes that ordinary hepatic impairment alone does not require a dosage adjustment.",
+        "direction_correct": true,
+        "verdict": "grounded",
+        "discards": [
+          "https://dailymed.nlm.nih.gov/dailymed/fda/fdaDrugXsl.cfm?setid=8351aa37-552d-471d-b293-c564dcb6ec29 — a different DailyMed ceftriaxone label revision used for the dose_ceftriaxone record; it carries the meningitis weight-based dosing but the hepatorenal-conjunction sentence used here is quoted from the 5cd2d96f revision where it appears verbatim in both Highlights and section 5.7, so that revision is cited as the primary source for THIS claim.",
+          "Single-condition framing ('hepatic impairment caps ceftriaxone' or 'renal impairment caps ceftriaxone') — DISCARDED as unsupported: the label conditions the 2 g/day cap on the CONJUNCTION ('hepatic impairment AND significant renal impairment'), and separately states no dosage adjustment is needed for hepatic impairment alone. Encoding either single condition as the trigger would misrepresent the source.",
+          "Secondary aggregators (drugs.com, Medscape ceftriaxone monographs) restating the 2 g/day hepatorenal cap — DISCARDED per the primary-source-first requirement; the FDA label states it directly."
+        ],
+        "note": "ENTAILED, and specifically a CONJUNCTIVE constraint. The verbatim sentence ties the 2 g/day ceiling to the JOINT presence of hepatic impairment AND significant renal impairment — not to either alone. This is why chart_to_cop.py models it as a derived 'hepatorenal' risk that exists only when a hepatic_status risk and a renal_status risk co-occur, and applies the dose-ceiling penalty to ceftriaxone only then; hepatic_status alone adds the risk marker (for audit) but no dose penalty, faithfully reflecting that hepatic impairment alone needs no adjustment. The grounded facts are (a) the existence and CONJUNCTIVE trigger of the cap and (b) its target drug (ceftriaxone) and direction (a ceiling, i.e. dose must shrink). The exact mg/kg ceiling-penalty number in formulary.json (a 12 mg/kg/day reduction, 50 -> 38) is the project's ILLUSTRATIVE feasibility model, NOT a verbatim PK/PD figure: the label's cap is an absolute 2 g/day, which the per-kg feasibility model only approximates. The mechanism (conjunction -> shrink the ceiling) is grounded; the precise numeric shrink is illustrative, consistent with formulary.json's standing dose-window disclaimer."
+      },
+      "verify": {
+        "id": "dose_cap_ceftriaxone_hepatorenal",
+        "byte_stable": true,
+        "reextracted_value": "Re-fetched the 5cd2d96f DailyMed ceftriaxone label: the sentence 'Patients with hepatic impairment and significant renal impairment should not receive more than 2 grams per day of ceftriaxone.' appears verbatim under USE IN SPECIFIC POPULATIONS and is referenced from section 5.7 (Patients with Hepatic and Renal Impairment). Confirmed the conjunction wording ('hepatic impairment and significant renal impairment') is the literal trigger.",
+        "refute_attempt": "Strongest refutation: one might read the cap as applying whenever EITHER organ is impaired (treating 'and' loosely), which would make the constraint fire on hepatic-impairment alone and contradict the model's conjunctive gate. This FAILS: the sentence uses a coordinating 'and' joining two required conditions ('hepatic impairment AND significant renal impairment'), and the same label elsewhere states no dosage adjustment is necessary for hepatic impairment alone, so the conjunctive reading is the only one consistent with the full label. Second angle: the cap is an absolute 2 g/day while the model encodes a per-kg ceiling reduction — a units mismatch. This is acknowledged, not hidden: the formulary dose-window numbers are explicitly an illustrative feasibility model, not validated PK/PD; the grounded claim is the conjunctive trigger and the ceiling-shrink direction, both of which the model preserves.",
+        "final_verdict": "grounded"
+      },
+      "spider_status": "grounded"
     }
   ]
 }

--- a/code/specs/data/mycin-2026/treatment/antibiotics/chart_to_cop.py
+++ b/code/specs/data/mycin-2026/treatment/antibiotics/chart_to_cop.py
@@ -211,6 +211,19 @@ def compile_cop(facts: list[ChartFact]) -> Cop:
             else:
                 cop.discards.append({"fact": f"interaction={f.value}",
                                      "reason": "no grounded dose-interaction rule for this interaction yet (CC-3)"})
+        elif f.kind == "hepatic_status":
+            # CC-2b: hepatic impairment is tracked, but per the ceftriaxone FDA label
+            # hepatic dysfunction ALONE needs no dose adjustment — only the CONJUNCTION
+            # of hepatic + significant renal impairment caps the dose (handled post-loop).
+            if f.value in ("hepatic_severe", "hepatic_moderate"):
+                cop.risks.add(f.value)
+                cop.constraints.append({"type": "dose_risk", "from": f"hepatic_status={f.value}",
+                                        "rule": "hepatic impairment alone needs no adjustment; "
+                                                "combined with renal impairment it caps the dose",
+                                        "span": f.span})
+            else:
+                cop.discards.append({"fact": f"hepatic_status={f.value}",
+                                     "reason": "unrecognized hepatic status (want hepatic_severe/hepatic_moderate)"})
         elif f.kind == "weight":
             try:
                 w = float(f.value)
@@ -315,6 +328,18 @@ def compile_cop(facts: list[ChartFact]) -> Cop:
     cop.organisms = list(reg.SCENARIOS[scenario])
     cop.constraints.append({"type": "coverage", "from": "scenario", "rule": scenario,
                             "detail": cop.organisms})
+
+    # CC-2b conjunctive cap: the ceftriaxone FDA label states no hepatic-only adjustment is
+    # needed, but combined hepatic + significant renal impairment caps the dose at 2 g/day.
+    # Emit the grounded `hepatorenal` risk ONLY when both are present, so hepatic-alone leaves
+    # the regimen untouched (faithful) while the conjunction shrinks ceftriaxone's ceiling.
+    has_hepatic = any(r.startswith("hepatic_") for r in cop.risks)
+    has_renal = any(r.startswith("renal_") for r in cop.risks)
+    if has_hepatic and has_renal:
+        cop.risks.add("hepatorenal")
+        cop.constraints.append({"type": "dose_risk", "from": "hepatic_status+renal_status",
+                                "rule": "combined hepatic + significant renal impairment caps "
+                                        "ceftriaxone at 2 g/day (FDA label)"})
     return cop
 
 

--- a/code/specs/data/mycin-2026/treatment/antibiotics/formulary.json
+++ b/code/specs/data/mycin-2026/treatment/antibiotics/formulary.json
@@ -21,7 +21,7 @@
                      "dose": {"floor_mg_per_kg": 15, "ceiling_base_mg_per_kg": 20, "ceiling_penalty_mg_per_kg": {"renal_severe": 6, "nephrotoxin_interaction": 6, "renal_moderate": 2}},
                      "source": "IDSA Tunkel 2004 (empiric vancomycin for resistant pneumococcus)"},
     "ceftriaxone":  {"covers": ["n_meningitidis", "h_influenzae", "s_pneumoniae_susceptible"], "csf_penetrant": true, "betalactam": true, "contraindications": ["betalactam_allergy_severe"], "tier": 1,
-                     "dose": {"floor_mg_per_kg": 25, "ceiling_base_mg_per_kg": 50, "ceiling_penalty_mg_per_kg": {}},
+                     "dose": {"floor_mg_per_kg": 25, "ceiling_base_mg_per_kg": 50, "ceiling_penalty_mg_per_kg": {"hepatorenal": 12}},
                      "source": "IDSA Tunkel 2004 (3rd-gen cephalosporin)"},
     "ampicillin":   {"covers": ["listeria", "e_coli"], "csf_penetrant": true, "betalactam": true, "contraindications": ["betalactam_allergy_severe"], "tier": 1,
                      "dose": {"floor_mg_per_kg": 25, "ceiling_base_mg_per_kg": 50, "ceiling_penalty_mg_per_kg": {}},

--- a/code/specs/data/mycin-2026/treatment/antibiotics/test_chart_to_cop.py
+++ b/code/specs/data/mycin-2026/treatment/antibiotics/test_chart_to_cop.py
@@ -67,6 +67,33 @@ def test_dose_risk_facts_become_dose_constraints():
     assert not bad.risks and any("qt_additive" in d["fact"] for d in bad.discards)
 
 
+def test_hepatic_renal_conjunction_caps_ceftriaxone():
+    # CC-2b (ceftriaxone FDA label): hepatic dysfunction ALONE needs no dose adjustment, but
+    # combined hepatic + significant renal impairment caps the dose. The compiler must record
+    # a hepatic risk yet emit the grounded `hepatorenal` token ONLY when renal is also present.
+    hep = cc.compile_cop([cc.ChartFact("hepatic_status", "hepatic_severe", "cirrhosis")])
+    assert "hepatic_severe" in hep.risks and "hepatorenal" not in hep.risks, hep.risks
+    both = cc.compile_cop([cc.ChartFact("hepatic_status", "hepatic_severe"),
+                           cc.ChartFact("renal_status", "renal_moderate")])
+    assert "hepatorenal" in both.risks, both.risks
+    assert any(c.get("from") == "hepatic_status+renal_status" for c in both.constraints)
+    # an unrecognized hepatic value is discarded, not silently turned into a risk.
+    bad = cc.compile_cop([cc.ChartFact("hepatic_status", "hepatic_mild")])
+    assert not bad.risks and any("hepatic_mild" in d["fact"] for d in bad.discards)
+
+    cli = decide_mod.find_cli()
+    if cli is None:
+        return
+    # End-to-end: the conjunction shrinks ceftriaxone's ceiling but it stays FEASIBLE — a
+    # dose-ADJUSTMENT, not a fabricated INFEASIBLE — so the standard regimen survives.
+    r = cc.derive(cli, [cc.ChartFact("age_band", "adult"),
+                        cc.ChartFact("hepatic_status", "hepatic_severe"),
+                        cc.ChartFact("renal_status", "renal_moderate")])
+    assert r["regimen"] and set(r["regimen"]) == {"ceftriaxone", "vancomycin"}, r
+    assert "ceftriaxone" not in r["dose_infeasible"], r["dose_infeasible"]
+    assert any(c.get("from") == "hepatic_status+renal_status" for c in r["constraints"]), r
+
+
 def test_dose_infeasibility_folds_into_the_cover():
     cli = decide_mod.find_cli()
     if cli is None:
@@ -288,6 +315,7 @@ def main() -> int:
     test_allergy_activates_a_context()
     test_culture_resistance_becomes_defeated_edge()
     test_dose_risk_facts_become_dose_constraints()
+    test_hepatic_renal_conjunction_caps_ceftriaxone()
     test_objective_priority_sets_the_cost_side_effect_weights()
     test_objective_breakdown_surfaced_with_chart_weights()
     test_decide_timing_decision_table()


### PR DESCRIPTION
## Front-2 (diagnostics + constraints): first conjunctive constraint family

Adds the first **chart-as-constraints** family whose *trigger* is a **conjunction of two chart facts** rather than a single fact — exercising the derived-risk path in `chart_to_cop`.

### The grounded fact
The ceftriaxone FDA label (DailyMed setid `5cd2d96f-83e5-4326-ae87-d0ede4ba493a`, USE IN SPECIFIC POPULATIONS / §5.7) caps the dose at 2 g/day **only** for the *joint* condition:

> "Patients with hepatic impairment and significant renal impairment should not receive more than 2 grams per day of ceftriaxone."

Hepatic impairment **alone** needs no adjustment. Modeling it faithfully means **not** treating hepatic status as its own dose cap.

### What changed
- **`chart_to_cop.py`** — a `hepatic_status` fact (`hepatic_severe`/`hepatic_moderate`) adds an audit-only risk marker but **no** dose penalty; unrecognized values are discarded. A derived **`hepatorenal`** risk is synthesized **only** when a `hepatic_*` and a `renal_*` risk co-occur, which then shrinks ceftriaxone's ceiling.
- **`formulary.json`** — ceftriaxone gains `ceiling_penalty_mg_per_kg.hepatorenal: 12` (50 → 38 mg/kg, still ≥ the 25 floor) — a dose **adjustment**, not a fabricated INFEASIBLE. The mechanism (conjunction → shrink the ceiling) is grounded; the precise mg/kg shrink stays the standing **ILLUSTRATIVE** feasibility model (the label's cap is an absolute 2 g/day).

### Grounding + verification
- **`dose-window-grounding.json`** — record `dose_cap_ceftriaxone_hepatorenal` with the verbatim FDA `byte_quote` (WebFetch byte-stable), a conjunctive-reading refutation attempt, and the explicit illustrative-number caveat. `spider_status: grounded`.
- **`test_chart_to_cop.py`** — `test_hepatic_renal_conjunction_caps_ceftriaxone` (hepatic-alone → no `hepatorenal`; hepatic+renal → `hepatorenal` + feasible regimen; bad value discarded). ✅
- **`board/items.json`** — `mgmt_hepatorenal` management item (gold `ceftriaxone+vancomycin`); the board test asserts it scores **correct** end-to-end through the native engine.
- **Scorecard regenerated:** 0 wrong, defensibility 100%, **management 6/6 correct** (153 items total).
- **`CHART-AS-CONSTRAINTS.md`** — §2 taxonomy row updated + new **CC-2b** section marked DONE.

### Tests run locally
- `treatment/antibiotics/test_chart_to_cop.py` — exit 0
- `board/test_board_eval.py` — 12/12 passed
- `board/board_eval.py` — 0 wrong, defensibility 100%, grounded-coverage 99%

Security review (Python + JSON, diff inline): **PASSED — no vulnerabilities found**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)