### PR TITLE
feat(lang-full): f64 (ALGOL real) native codegen on aarch64 (E3-native, aarch64)

### DIFF
--- a/code/packages/rust/aarch64-backend/CHANGELOG.md
+++ b/code/packages/rust/aarch64-backend/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Changelog — `aarch64-backend`
 
+## 0.11.0 — 2026-06-20 — `f64` (ALGOL `real`) arithmetic + comparisons (LANG-FULL E3)
+
+### Added — native double-precision codegen on aarch64
+
+The backend rejected `const_f64`/float operands. It now lowers `f64` (enabler
+E3 — ALGOL `real`):
+
+- **`const_f64`** materialises the IEEE-754 bit pattern in `X0` and `str`s it —
+  a double rides its 8-byte stack slot as raw bits, identical to an integer
+  slot, so loading a *constant* needs no FP register.
+- **`add_f64`/`sub_f64`/`mul_f64`/`div_f64`** load both operands into `D0`/`D1`
+  (`ldr_d`), run `fadd`/`fsub`/`fmul`/`fdiv`, and `str_d` the result. IEEE
+  division by zero is `±inf`/`NaN` (no trap) — matching every other backend.
+- **`cmp_*_f64`** load `D0`/`D1`, `fcmp`, then `cset X0, <cond>` (the boolean is
+  an `int` 0/1). The condition codes give IEEE **ordered** semantics: a NaN
+  operand makes `<`/`<=`/`>`/`>=`/`==` false (`!=` true) — `Lt`→`MI`, `Le`→`LS`,
+  `Gt`→`GT`, `Ge`→`GE`, `Eq`→`EQ`, `Ne`→`NE`.
+
+**Verified by RUNNING on real Apple-Silicon hardware** (`jit-loader-macos`
+installs the generated code and *calls* it): `2.5 * 2.0` → the bits of `5.0`,
+`7.0 / 2.0` → `3.5`, and all six comparisons return the right 0/1. Plus a
+host-agnostic structural test (compiles on the x86 CI box). Integer programs are
+untouched (the FP path keys on `ty == "f64"`). Uses `aarch64-encoder` 0.4.0's FP
+instructions. (x86_64 SSE + the lang-aot matrix `NativeAot` proof are the E3-native
+follow-up.)
+
 ## 0.10.0 — 2026-06-15 — narrow-width unsigned masking (LANG-FULL E2, native-AOT leg)
 
 Native registers are 64-bit, so a `u8` add of `200 + 100` previously computed

--- a/code/packages/rust/aarch64-backend/Cargo.toml
+++ b/code/packages/rust/aarch64-backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aarch64-backend"
-version = "0.10.0"
+version = "0.11.0"
 edition = "2021"
 description = "ARM64 (AArch64) backend for jit-core / aot-core — lowers CIR to native machine code via aarch64-encoder."
 

--- a/code/packages/rust/aarch64-backend/src/lib.rs
+++ b/code/packages/rust/aarch64-backend/src/lib.rs
@@ -531,7 +531,12 @@ fn emit_instr(
         let imm = match src {
             CIROperand::Int(n)   => *n as u64,
             CIROperand::Bool(b)  => if *b { 1 } else { 0 },
-            CIROperand::Float(_) => return Err(BackendError::UnsupportedOp("const_f64".into())),
+            // An `f64` (ALGOL `real`, LANG-FULL E3) lives in its 8-byte stack
+            // slot as raw IEEE-754 bits — identical to an integer slot — so we
+            // materialise the bit pattern in X0 and `str` it. No FP register is
+            // needed to *load a constant*; only arithmetic/compare use the D
+            // registers (see `emit_fp_binop`/`emit_fp_cmp`).
+            CIROperand::Float(f) => f.to_bits(),
             CIROperand::Var(_)   => return Err(BackendError::MalformedInstr(format!("{op} needs literal source"))),
         };
         asm.mov_imm64(Reg::X0, imm);
@@ -1134,6 +1139,17 @@ fn emit_binop(
     kind: BinKind,
     ty: &str,
 ) -> Result<(), BackendError> {
+    if ty == "f64" {
+        // ALGOL `real` arithmetic (LANG-FULL E3): operands ride D0/D1, the op
+        // is `fadd`/`fsub`/`fmul`, and the double result is `str`'d back. No
+        // E2 width mask (that's integer-only).
+        let fk = match kind {
+            BinKind::Add => FpBin::Add,
+            BinKind::Sub => FpBin::Sub,
+            BinKind::Mul => FpBin::Mul,
+        };
+        return emit_fp_binop(asm, alloc, instr, fk);
+    }
     let dest = require_dest(instr)?;
     if instr.srcs.len() < 2 {
         return Err(BackendError::MalformedInstr(format!("{} needs 2 srcs", instr.op)));
@@ -1146,6 +1162,89 @@ fn emit_binop(
         BinKind::Mul => asm.mul(Reg::X0, Reg::X0, Reg::X1),
     }
     mask_narrow_x0(asm, ty); // E2: wrap u8/u16/u32 results mod 2ⁿ
+    let slot = alloc.slot_of(dest);
+    asm.str_(Reg::X0, Reg::Sp, slot)?;
+    Ok(())
+}
+
+/// Which floating-point binary op (LANG-FULL E3).
+#[derive(Debug, Clone, Copy)]
+enum FpBin { Add, Sub, Mul, Div }
+
+/// Load an `f64` operand into a D register (`Reg`'s `idx` names the D slot).
+/// Frontends materialise constants into stack slots first, so an arithmetic/
+/// compare operand is a `Var` — a `Float` *immediate* operand would need an
+/// `fmov`/scratch-slot dance and isn't emitted on this slice.
+fn load_fp_operand(
+    asm: &mut Assembler,
+    alloc: &mut RegAlloc,
+    dreg: Reg,
+    op: &CIROperand,
+) -> Result<(), BackendError> {
+    match op {
+        CIROperand::Var(name) => {
+            let s = alloc.slot_of(name);
+            asm.ldr_d(dreg, Reg::Sp, s)?;
+            Ok(())
+        }
+        other => Err(BackendError::UnsupportedOp(format!(
+            "f64 operand must be a Var (materialise the constant first), got {other:?}"
+        ))),
+    }
+}
+
+/// Emit an `f64` `add`/`sub`/`mul`/`div`: `ldr d0,[a]; ldr d1,[b]; f<op> d0,d0,d1;
+/// str d0,[dest]` (LANG-FULL E3). IEEE division by zero is `±inf`/`NaN` (no trap).
+fn emit_fp_binop(
+    asm: &mut Assembler,
+    alloc: &mut RegAlloc,
+    instr: &CIRInstr,
+    kind: FpBin,
+) -> Result<(), BackendError> {
+    let dest = require_dest(instr)?;
+    if instr.srcs.len() < 2 {
+        return Err(BackendError::MalformedInstr(format!("{} needs 2 srcs", instr.op)));
+    }
+    load_fp_operand(asm, alloc, Reg::X0, &instr.srcs[0])?; // D0
+    load_fp_operand(asm, alloc, Reg::X1, &instr.srcs[1])?; // D1
+    match kind {
+        FpBin::Add => asm.fadd(Reg::X0, Reg::X0, Reg::X1),
+        FpBin::Sub => asm.fsub(Reg::X0, Reg::X0, Reg::X1),
+        FpBin::Mul => asm.fmul(Reg::X0, Reg::X0, Reg::X1),
+        FpBin::Div => asm.fdiv(Reg::X0, Reg::X0, Reg::X1),
+    }
+    let slot = alloc.slot_of(dest);
+    asm.str_d(Reg::X0, Reg::Sp, slot)?;
+    Ok(())
+}
+
+/// Emit an `f64` comparison: `ldr d0,[a]; ldr d1,[b]; fcmp d0,d1; cset x0,<cond>;
+/// str x0,[dest]` (LANG-FULL E3). The boolean result is an `int` 0/1. FP
+/// condition codes give IEEE *ordered* semantics — a NaN operand makes every
+/// `<`/`<=`/`>`/`>=`/`==` false (and `!=` true).
+fn emit_fp_cmp(
+    asm: &mut Assembler,
+    alloc: &mut RegAlloc,
+    instr: &CIRInstr,
+    rel: CmpRel,
+) -> Result<(), BackendError> {
+    let dest = require_dest(instr)?;
+    if instr.srcs.len() < 2 {
+        return Err(BackendError::MalformedInstr(format!("{} needs 2 srcs", instr.op)));
+    }
+    load_fp_operand(asm, alloc, Reg::X0, &instr.srcs[0])?; // D0
+    load_fp_operand(asm, alloc, Reg::X1, &instr.srcs[1])?; // D1
+    asm.fcmp(Reg::X0, Reg::X1);
+    // After FCMP: less→N=1; equal→Z=1,C=1; greater→C=1; unordered→C=1,V=1.
+    let cond = match rel {
+        CmpRel::Eq => Cond::Eq, // Z=1
+        CmpRel::Ne => Cond::Ne, // Z=0 (includes unordered)
+        CmpRel::Lt => Cond::Mi, // N=1 — only ordered-less-than
+        CmpRel::Le => Cond::Ls, // C=0 or Z=1 — ordered ≤
+        CmpRel::Gt => Cond::Gt, // Z=0 && N==V — ordered >
+        CmpRel::Ge => Cond::Ge, // N==V — ordered ≥
+    };
+    asm.cset(Reg::X0, cond);
     let slot = alloc.slot_of(dest);
     asm.str_(Reg::X0, Reg::Sp, slot)?;
     Ok(())
@@ -1173,6 +1272,9 @@ fn emit_cmp(
     rel: CmpRel,
     ty: &str,
 ) -> Result<(), BackendError> {
+    if ty == "f64" {
+        return emit_fp_cmp(asm, alloc, instr, rel);
+    }
     let dest = require_dest(instr)?;
     if instr.srcs.len() < 2 {
         return Err(BackendError::MalformedInstr(format!("{} needs 2 srcs", instr.op)));
@@ -1221,6 +1323,14 @@ fn emit_div(
     ty: &str,
     want_mod: bool,
 ) -> Result<(), BackendError> {
+    if ty == "f64" {
+        // ALGOL `real` division (LANG-FULL E3). `mod` is integer-only, so a
+        // `mod_f64` would be a frontend bug.
+        if want_mod {
+            return Err(BackendError::UnsupportedOp("mod_f64 (real modulo is undefined)".into()));
+        }
+        return emit_fp_binop(asm, alloc, instr, FpBin::Div);
+    }
     let dest = require_dest(instr)?;
     if instr.srcs.len() < 2 {
         return Err(BackendError::MalformedInstr(format!("{} needs 2 srcs", instr.op)));
@@ -2327,5 +2437,81 @@ mod tests {
         // u32: a 64-bit register does NOT wrap a u32 add for free, so the mask
         // is what makes this correct (unlike wasm, where the i32 op wraps).
         assert_eq!(run_narrow_binop("mul", "u32", 0x1_0000, 0x1_0000), 0);
+    }
+
+    // ---- f64 (ALGOL `real`) — LANG-FULL E3 ----
+
+    fn const_f64(dest: &str, v: f64) -> CIRInstr {
+        CIRInstr { op: "const_f64".into(), dest: Some(dest.into()),
+                   srcs: vec![CIROperand::Float(v)], ty: "f64".into(), deopt_to: None }
+    }
+
+    /// `const a; const b; <op>_f64 v0 = a,b; ret_u64 v0` → returns the f64 result's
+    /// raw bits (the value rides its 8-byte stack slot).
+    fn f64_binop_module(op: &str, a: f64, b: f64) -> Vec<u8> {
+        let cir = vec![
+            const_f64("a", a),
+            const_f64("b", b),
+            make_binop_cir(&format!("{op}_f64"), "v0", "a", "b", "f64"),
+            ret_u64("v0"),
+        ];
+        compile(&ctx("f", &[], "u64"), &cir)
+            .unwrap_or_else(|e| panic!("{op}_f64 compile failed: {e}"))
+    }
+
+    /// `const a; const b; cmp_<rel>_f64 v0 = a,b; ret_u64 v0` → returns 0/1.
+    fn f64_cmp_module(rel: &str, a: f64, b: f64) -> Vec<u8> {
+        let cir = vec![
+            const_f64("a", a),
+            const_f64("b", b),
+            make_binop_cir(&format!("cmp_{rel}_f64"), "v0", "a", "b", "f64"),
+            ret_u64("v0"),
+        ];
+        compile(&ctx("f", &[], "u64"), &cir)
+            .unwrap_or_else(|e| panic!("cmp_{rel}_f64 compile failed: {e}"))
+    }
+
+    /// f64 arithmetic and comparisons compile on every host (structural — runs on
+    /// the x86 CI box too, where the executed proofs below are `cfg`'d out).
+    #[test]
+    fn f64_ops_compile() {
+        for op in ["add", "sub", "mul", "div"] {
+            assert!(!f64_binop_module(op, 2.5, 2.0).is_empty(), "{op}_f64 should compile");
+        }
+        for rel in ["eq", "ne", "lt", "le", "gt", "ge"] {
+            assert!(!f64_cmp_module(rel, 2.5, 2.0).is_empty(), "cmp_{rel}_f64 should compile");
+        }
+    }
+
+    #[cfg(all(target_arch = "aarch64", target_os = "macos"))]
+    fn run_u64(bytes: &[u8]) -> u64 {
+        let page = jit_loader_macos::CodePage::new(bytes).expect("install code page");
+        let f: extern "C" fn() -> u64 = unsafe { page.as_function() };
+        f()
+    }
+
+    /// **Executed** on real Apple-Silicon hardware: f64 arithmetic returns the
+    /// exact IEEE-754 result bits (LANG-FULL E3).
+    #[cfg(all(target_arch = "aarch64", target_os = "macos"))]
+    #[test]
+    fn f64_arithmetic_executes() {
+        assert_eq!(run_u64(&f64_binop_module("mul", 2.5, 2.0)), 5.0_f64.to_bits());
+        assert_eq!(run_u64(&f64_binop_module("add", 2.5, 0.25)), 2.75_f64.to_bits());
+        assert_eq!(run_u64(&f64_binop_module("sub", 2.5, 0.25)), 2.25_f64.to_bits());
+        assert_eq!(run_u64(&f64_binop_module("div", 7.0, 2.0)), 3.5_f64.to_bits());
+    }
+
+    /// **Executed**: f64 comparisons return the right 0/1 boolean.
+    #[cfg(all(target_arch = "aarch64", target_os = "macos"))]
+    #[test]
+    fn f64_comparisons_execute() {
+        assert_eq!(run_u64(&f64_cmp_module("eq", 5.0, 5.0)), 1);
+        assert_eq!(run_u64(&f64_cmp_module("eq", 5.0, 4.0)), 0);
+        assert_eq!(run_u64(&f64_cmp_module("lt", 3.5, 4.0)), 1);
+        assert_eq!(run_u64(&f64_cmp_module("lt", 4.0, 3.5)), 0);
+        assert_eq!(run_u64(&f64_cmp_module("gt", 4.0, 3.5)), 1);
+        assert_eq!(run_u64(&f64_cmp_module("le", 5.0, 5.0)), 1);
+        assert_eq!(run_u64(&f64_cmp_module("ge", 5.0, 5.0)), 1);
+        assert_eq!(run_u64(&f64_cmp_module("ne", 5.0, 4.0)), 1);
     }
 }

--- a/code/packages/rust/aarch64-encoder/CHANGELOG.md
+++ b/code/packages/rust/aarch64-encoder/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog — `aarch64-encoder`
 
+## 0.4.0 — 2026-06-20 (scalar double-precision FP — LANG-FULL E3)
+
+### Added — `ldr_d`/`str_d`/`fadd`/`fsub`/`fmul`/`fdiv`/`fcmp` (double)
+
+Seven scalar double-precision floating-point instructions, for ALGOL `real`
+(enabler E3) on the native-AOT backend:
+
+- `ldr_d Dt, [Xn, #imm]` / `str_d Dt, [Xn, #imm]` — load/store a 64-bit double
+  (`0xFD400000`/`0xFD000000`, scaled-by-8 offset like the `Xt` forms). A
+  `float64` value rides its 8-byte stack slot as raw bits.
+- `fadd`/`fsub`/`fmul`/`fdiv Dd, Dn, Dm` — double arithmetic
+  (`0x1E602800`/`0x1E603800`/`0x1E600800`/`0x1E601800`).
+- `fcmp Dn, Dm` — compare two doubles, set NZCV (`0x1E602000`); read with a
+  following `cset Xd, <cond>`.
+
+The register number reuses `Reg::idx()` (0–31) — the *opcode* (not the register
+field) selects the FP/SIMD register file. **Every encoding was verified
+byte-for-byte against the system assembler** (`clang -c` of the same mnemonics)
+plus exact-encoding unit tests.
+
 ## 0.3.0 — 2026-05-20 (LANG76 — byte memory primitives)
 
 Adds the unsigned-offset byte load/store instructions used by

--- a/code/packages/rust/aarch64-encoder/Cargo.toml
+++ b/code/packages/rust/aarch64-encoder/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aarch64-encoder"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 description = "Pure-Rust ARM64 (AArch64) instruction encoder — covers the subset needed by jit-core / aot-core to lower CIR to native machine code."
 

--- a/code/packages/rust/aarch64-encoder/src/lib.rs
+++ b/code/packages/rust/aarch64-encoder/src/lib.rs
@@ -788,6 +788,67 @@ impl Assembler {
         Ok(())
     }
 
+    // -----------------------------------------------------------------------
+    // Scalar floating-point — double precision (LANG-FULL E3 / ALGOL `real`)
+    //
+    // The register number reuses [`Reg`]'s `idx()` (0..31), but names a `Dn`
+    // FP/SIMD register rather than an `Xn` GPR — the *opcode* (not the register
+    // field) selects the FP register file. A `f64` value lives in an 8-byte
+    // stack slot as raw bits, so `LDR Dt`/`STR Dt` load/store it with the same
+    // scaled-by-8 offset as the `Xt` forms.
+    // -----------------------------------------------------------------------
+
+    /// `LDR Dt, [Xn, #imm]` — load a 64-bit double from memory. Same scaled
+    /// (`imm % 8`, `imm ≤ 32760`) offset as [`ldr`](Self::ldr); only the size/V
+    /// bits differ. Encoding `01 111 1 01 01 imm12 Rn Rt` (`0xFD400000`).
+    pub fn ldr_d(&mut self, dt: Reg, rn: Reg, imm: u32) -> Result<(), EncodeError> {
+        if imm % 8 != 0 || imm > 0x7FF8 {
+            return Err(EncodeError::ImmediateOutOfRange { op: "ldr_d", bits: 12, value: imm as i64 });
+        }
+        let imm12 = imm / 8;
+        self.emit(0xFD400000 | (imm12 << 10) | (rn.idx() << 5) | dt.idx());
+        Ok(())
+    }
+
+    /// `STR Dt, [Xn, #imm]` — store a 64-bit double. Encoding `0xFD000000`.
+    pub fn str_d(&mut self, dt: Reg, rn: Reg, imm: u32) -> Result<(), EncodeError> {
+        if imm % 8 != 0 || imm > 0x7FF8 {
+            return Err(EncodeError::ImmediateOutOfRange { op: "str_d", bits: 12, value: imm as i64 });
+        }
+        let imm12 = imm / 8;
+        self.emit(0xFD000000 | (imm12 << 10) | (rn.idx() << 5) | dt.idx());
+        Ok(())
+    }
+
+    /// `FADD Dd, Dn, Dm` — IEEE-754 double add. Encoding
+    /// `0001_1110_011m_mmmm_0010_10nn_nnnd_dddd` (`0x1E602800`).
+    pub fn fadd(&mut self, dd: Reg, dn: Reg, dm: Reg) {
+        self.emit(0x1E602800 | (dm.idx() << 16) | (dn.idx() << 5) | dd.idx());
+    }
+
+    /// `FSUB Dd, Dn, Dm` — double subtract (`0x1E603800`).
+    pub fn fsub(&mut self, dd: Reg, dn: Reg, dm: Reg) {
+        self.emit(0x1E603800 | (dm.idx() << 16) | (dn.idx() << 5) | dd.idx());
+    }
+
+    /// `FMUL Dd, Dn, Dm` — double multiply (`0x1E600800`).
+    pub fn fmul(&mut self, dd: Reg, dn: Reg, dm: Reg) {
+        self.emit(0x1E600800 | (dm.idx() << 16) | (dn.idx() << 5) | dd.idx());
+    }
+
+    /// `FDIV Dd, Dn, Dm` — double divide (`0x1E601800`). IEEE division by zero
+    /// yields `±inf`/`NaN`, never a trap (matches every other backend's `fdiv`).
+    pub fn fdiv(&mut self, dd: Reg, dn: Reg, dm: Reg) {
+        self.emit(0x1E601800 | (dm.idx() << 16) | (dn.idx() << 5) | dd.idx());
+    }
+
+    /// `FCMP Dn, Dm` — compare two doubles, setting NZCV. Encoding
+    /// `0001_1110_011m_mmmm_0010_00nn_nnn0_0000` (`0x1E602000`). The result is
+    /// read with a following `CSET Xd, <cond>`.
+    pub fn fcmp(&mut self, dn: Reg, dm: Reg) {
+        self.emit(0x1E602000 | (dm.idx() << 16) | (dn.idx() << 5));
+    }
+
     /// `LDRB Wt, [Xn, #imm]` — load one byte, zero-extend to 32 bits (LANG76).
     ///
     /// `imm` is a 12-bit unsigned immediate in the range `[0, 4095]` (the
@@ -1219,6 +1280,41 @@ mod tests {
     fn ldr_rejects_unaligned() {
         let mut a = Assembler::new();
         assert!(a.ldr(Reg::X0, Reg::Sp, 7).is_err()); // not a multiple of 8
+    }
+
+    // ---- scalar double-precision FP (LANG-FULL E3) ----
+
+    #[test]
+    fn fp_ldr_str_d_sp_8() {
+        // ldr d0, [sp, #8]  →  FD4007E0 ; str d0, [sp, #8]  →  FD0007E0
+        let mut a = Assembler::new();
+        a.ldr_d(Reg::X0, Reg::Sp, 8).unwrap();
+        a.str_d(Reg::X0, Reg::Sp, 8).unwrap();
+        assert_eq!(a.finish().unwrap(), words_to_bytes(&[0xFD4007E0, 0xFD0007E0]));
+    }
+
+    #[test]
+    fn fp_arith_d0_d0_d1() {
+        // fadd/fsub/fmul/fdiv d0, d0, d1 (Dm=1 → bit16 set)
+        let mut a = Assembler::new();
+        a.fadd(Reg::X0, Reg::X0, Reg::X1);
+        a.fsub(Reg::X0, Reg::X0, Reg::X1);
+        a.fmul(Reg::X0, Reg::X0, Reg::X1);
+        a.fdiv(Reg::X0, Reg::X0, Reg::X1);
+        assert_eq!(a.finish().unwrap(), words_to_bytes(&[
+            0x1E612800, // fadd d0, d0, d1
+            0x1E613800, // fsub d0, d0, d1
+            0x1E610800, // fmul d0, d0, d1
+            0x1E611800, // fdiv d0, d0, d1
+        ]));
+    }
+
+    #[test]
+    fn fp_fcmp_d0_d1() {
+        // fcmp d0, d1  →  1E612000
+        let mut a = Assembler::new();
+        a.fcmp(Reg::X0, Reg::X1);
+        assert_eq!(a.finish().unwrap(), words_to_bytes(&[0x1E612000]));
     }
 
     // ---- STP / LDP ----

--- a/code/specs/LANG-FULL-IMPLEMENTATION.md
+++ b/code/specs/LANG-FULL-IMPLEMENTATION.md
@@ -180,9 +180,18 @@ multiple languages; close an enabler before the features that depend on it.
       into the integer `if_icmp` path (mis-reading a two-slot double as an int) — fixed with a
       `Double` branch emitting `dcmpl`/`dcmpg` + a unary `ifXX`. **Executed proof on real `java`**:
       both ALGOL real programs run on the JVM matrix column. **E3-codegen-slots COMPLETE.**
-  - ☐ **E3-native** — `x86_64-backend`/`aarch64-backend` reject `const_f64`/`CIROperand::Float`;
-    need SSE (`addsd`/`mulsd`/`comisd`) and AArch64 FP (`fadd`/`fcmp`) emission. (`aot-core`'s
-    `infer`/`specialise` already allow `f64`.)
+  - ◑ **E3-native** — the two direct native backends. (`aot-core`'s `infer`/`specialise` already
+    allow `f64`.)
+    - ✅ **aarch64-backend** (v0.11.0, encoder v0.4.0) — `const_f64` materialises the bit pattern
+      into the slot; `add/sub/mul/div_f64` use `ldr_d`/`fadd…`/`str_d` over `D0`/`D1`; `cmp_*_f64`
+      use `fcmp` + `cset` with IEEE-ordered condition codes (`Lt`→`MI`, NaN → false). Added 7 FP
+      encoders (`ldr_d`/`str_d`/`fadd`/`fsub`/`fmul`/`fdiv`/`fcmp`), **byte-verified vs the system
+      assembler**. **Executed on real Apple-Silicon** via `jit-loader-macos` (`2.5*2.0`→`5.0` bits,
+      `7.0/2.0`→`3.5`, all six comparisons).
+    - ☐ **x86_64-backend** — needs SSE2 (`movsd`/`addsd`/`subsd`/`mulsd`/`divsd`/`ucomisd` +
+      `setcc`) mirroring the aarch64 lowering; structural tests locally, executed on the lang-aot
+      matrix `NativeAot` column on the Linux-x86 CI runner (no local x86 execution — no x86 ISA
+      simulator; the matrix proof + the host-arch run is the standard, same as E2).
   - ✅ **E3-clr** (iir-to-cil-bytecode v0.22.0) — the **textual `.il` emitter** (the real-CLR /
     `ilasm` matrix path) lowers `f64`: `cil_local_type` → `float64` locals, float consts →
     `ldc.r8` (exact LE bytes), comparison result forced to `int32` (CIL `ceq`/`cgt`/`clt` push


### PR DESCRIPTION
## LANG-FULL E3-native (aarch64 half) — `f64` on the direct native backend

The last E3 backend, part 1 of 2. The native-AOT `aarch64-backend` rejected `const_f64`/float operands; it now lowers `f64` (ALGOL `real`). x86_64 SSE + the matrix `NativeAot` proof are the follow-up (this PR is the fully-locally-verifiable aarch64 half — same split the E2 mask work used).

### `aarch64-encoder` 0.4.0 — 7 new FP instructions
`ldr_d`/`str_d` (double load/store), `fadd`/`fsub`/`fmul`/`fdiv`, `fcmp`. The register number reuses `Reg::idx()` — the *opcode* selects the FP/SIMD register file. **Every encoding was verified byte-for-byte against the system assembler** (`clang -c` of the same mnemonics) and has exact-encoding unit tests.

### `aarch64-backend` 0.11.0 — f64 lowering
- **`const_f64`** materialises the IEEE-754 bits into the 8-byte stack slot (a double rides the slot as raw bits — no FP reg needed to load a constant).
- **`add`/`sub`/`mul`/`div_f64`** → `ldr_d D0/D1`; `fadd`/…; `str_d`. IEEE division by zero → `±inf` (no trap), matching every other backend.
- **`cmp_*_f64`** → `fcmp` + `cset` with IEEE-**ordered** condition codes (`Lt`→`MI`, `Le`→`LS`, `Gt`→`GT`, `Ge`→`GE`; a NaN operand makes ordered compares false).

### Verified by RUNNING on real Apple-Silicon hardware
`jit-loader-macos` installs the generated code and **calls** it: `2.5 * 2.0` → the bits of `5.0`, `7.0 / 2.0` → `3.5`, and all six comparisons return the right 0/1. Plus a host-agnostic structural test (compiles on the x86 CI box). Integer programs are byte-identical (the FP path keys on `ty == "f64"`).

`/security-review` passed (verified register-field non-overlap, immediate range checks, test-only `unsafe`). 57 encoder + 52 backend tests green.

**Next:** x86_64 SSE2 (`movsd`/`addsd`/`ucomisd`/`setcc`) mirroring this lowering, then add `NativeAot` to the ALGOL real matrix Progs → **reals on all 7 backends**. Tracked in [`LANG-FULL-IMPLEMENTATION.md`](code/specs/LANG-FULL-IMPLEMENTATION.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)