### PR TITLE
Expose SPICE deck rawfile option artifacts

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 ### Added
 
+- **Deck rawfile option artifacts** —
+  `analyze_deck_controls()` and selected `run_deck_analysis()` executions now
+  expose normalized accepted `.control` rawfile option inventories as
+  `rawfile_option_count` / `rawfile_options`, and selected-run artifacts carry
+  stable `RawfileOptions` / `RawfileOptionList` columns through tables,
+  CSV/JSON, and ordered `table_artifacts`, matching Rust and TypeScript.
+
 - **Deck rawfile write marker artifacts** —
   `analyze_deck_controls()` and selected `run_deck_analysis()` executions now
   expose normalized accepted `.control` `write` / `wrdata` marker inventories

--- a/code/packages/python/spice-engine/README.md
+++ b/code/packages/python/spice-engine/README.md
@@ -114,14 +114,18 @@ Selected
 Fourier table. Executions also include a selected-run artifact summary plus
 `format_deck_run_artifact_table()` and `format_deck_run_artifact_csv()` output
 for stable result-row, table, analysis-directive, output-probe,
-output-directive, measurement, Fourier, write-marker, and diagnostic
-count/name lists.
+output-directive, measurement, Fourier, write-marker, rawfile-option, and
+diagnostic count/name lists.
 Normalized accepted `.control` commands are surfaced separately in
 `control_line_count` / `control_lines` execution fields and in
 `ControlLines` / `ControlLineList` artifact fields.
 Accepted `.control` `write` / `wrdata` rawfile/data-write markers are surfaced
 as `write_marker_count` / `write_markers` execution fields and as
 `WriteMarkers` / `WriteMarkerList` artifact fields without serializing files.
+Accepted `.control` rawfile output options (`set filetype=ascii`,
+`set wr_vecnames`, `set wr_singlescale`, and `set appendwrite`) are surfaced as
+`rawfile_option_count` / `rawfile_options` execution fields and as
+`RawfileOptions` / `RawfileOptionList` artifact fields.
 Existing `.control` body policy diagnostics flow into those selected-run
 artifact `Diagnostics` / `DiagnosticCodeList` fields and through the same
 run-artifact table, CSV, JSON, and `table_artifacts` records.
@@ -240,10 +244,10 @@ analysis-directive, output-probe, and output-directive artifacts,
 selected measurement artifacts, selected transient Fourier artifacts,
 selected-run artifact summaries with analysis-directive, output-probe,
 output-directive, measurement, Fourier probe, `.control` command, write-marker,
-and diagnostic inventories, `.ac LIN`, `.ac DEC`, `.ac OCT` frequency grids, and `.tran`
-`START` / print-step `TSTEP` / `MAXSTEP` / `UIC` controls. Selected execution
-fields expose `.control` command, write-marker, and diagnostic inventories
-directly for host integrations.
+rawfile-option, and diagnostic inventories, `.ac LIN`, `.ac DEC`, `.ac OCT`
+frequency grids, and `.tran` `START` / print-step `TSTEP` / `MAXSTEP` / `UIC`
+controls. Selected execution fields expose `.control` command, write-marker,
+rawfile-option, and diagnostic inventories directly for host integrations.
 
 ## Controlled source examples
 

--- a/code/packages/python/spice-engine/src/spice_engine/compatibility.py
+++ b/code/packages/python/spice-engine/src/spice_engine/compatibility.py
@@ -58,6 +58,7 @@ class DeckControlSummary:
     active_lines: tuple[str, ...]
     control_lines: tuple[str, ...]
     write_markers: tuple[str, ...]
+    rawfile_options: tuple[str, ...]
     terminated: bool
     end_line_number: int | None
     diagnostics: tuple[DeckControlDiagnostic, ...]
@@ -550,8 +551,11 @@ _NOOP_CONTROL_BLOCK_COMMANDS = frozenset(
 )
 _NOOP_CONTROL_BLOCK_ARGUMENT_COMMANDS = frozenset({"write", ".write"})
 _NOOP_CONTROL_BLOCK_VECTOR_ARGUMENT_COMMANDS = frozenset({"wrdata", ".wrdata"})
-_NOOP_CONTROL_BLOCK_SET_OPTIONS = frozenset(
-    {"noaskquit", "filetype=ascii", "wr_vecnames", "wr_singlescale", "appendwrite"}
+_NOOP_CONTROL_BLOCK_RAWFILE_OPTIONS = frozenset(
+    {"filetype=ascii", "wr_vecnames", "wr_singlescale", "appendwrite"}
+)
+_NOOP_CONTROL_BLOCK_SET_OPTIONS = (
+    frozenset({"noaskquit"}) | _NOOP_CONTROL_BLOCK_RAWFILE_OPTIONS
 )
 _SCRIPT_CONTROL_BLOCK_COMMANDS = frozenset({"source", ".source", "shell", ".shell"})
 _WORKDIR_CONTROL_BLOCK_COMMANDS = frozenset({"cd", ".cd"})
@@ -611,6 +615,7 @@ def analyze_deck_controls(netlist: str) -> DeckControlSummary:
     active_lines: list[str] = []
     control_lines: list[str] = []
     write_markers: list[str] = []
+    rawfile_options: list[str] = []
     diagnostics: list[DeckControlDiagnostic] = []
     end_line_number: int | None = None
     in_control_block = False
@@ -632,6 +637,10 @@ def analyze_deck_controls(netlist: str) -> DeckControlSummary:
             write_marker = _control_block_write_marker(stripped)
             if write_marker is not None:
                 write_markers.append(write_marker)
+                continue
+            rawfile_option = _control_block_rawfile_option(stripped)
+            if rawfile_option is not None:
+                rawfile_options.append(rawfile_option)
                 continue
             if _is_noop_control_block_command(stripped):
                 continue
@@ -717,6 +726,7 @@ def analyze_deck_controls(netlist: str) -> DeckControlSummary:
         active_lines=tuple(active_lines),
         control_lines=tuple(control_lines),
         write_markers=tuple(write_markers),
+        rawfile_options=tuple(rawfile_options),
         terminated=end_line_number is not None,
         end_line_number=end_line_number,
         diagnostics=tuple(diagnostics),
@@ -3744,6 +3754,19 @@ def _control_block_write_marker(line: str) -> str | None:
         vector_parts = parts[1].split()
         if len(vector_parts) >= 2:
             return f"{command.removeprefix('.')} {parts[1]}"
+    return None
+
+
+def _control_block_rawfile_option(line: str) -> str | None:
+    parts = line.split()
+    if len(parts) != 2:
+        return None
+    command = parts[0].lower()
+    if command not in {"set", ".set"}:
+        return None
+    option = parts[1].lower()
+    if option in _NOOP_CONTROL_BLOCK_RAWFILE_OPTIONS:
+        return f"set {option}"
     return None
 
 

--- a/code/packages/python/spice-engine/src/spice_engine/engine.py
+++ b/code/packages/python/spice-engine/src/spice_engine/engine.py
@@ -2355,6 +2355,8 @@ class DeckRunArtifact:
     control_lines: list[str]
     write_marker_count: int
     write_markers: list[str]
+    rawfile_option_count: int
+    rawfile_options: list[str]
     diagnostic_count: int
     diagnostic_codes: list[str]
 
@@ -2384,6 +2386,8 @@ class DeckAnalysisExecution:
     control_lines: list[str]
     write_marker_count: int
     write_markers: list[str]
+    rawfile_option_count: int
+    rawfile_options: list[str]
     diagnostic_count: int
     diagnostic_codes: list[str]
     table_count: int
@@ -2481,6 +2485,8 @@ _DECK_RUN_ARTIFACT_COLUMNS = [
     "ControlLineList",
     "WriteMarkers",
     "WriteMarkerList",
+    "RawfileOptions",
+    "RawfileOptionList",
     "Diagnostics",
     "DiagnosticCodeList",
 ]
@@ -2518,6 +2524,7 @@ def _deck_run_artifacts(
     fourier: list[FourierResult],
     control_lines: list[str],
     write_markers: list[str],
+    rawfile_options: list[str],
     diagnostic_codes: list[str],
 ) -> list[DeckRunArtifact]:
     is_transient = plan.analysis == "tran"
@@ -2565,6 +2572,8 @@ def _deck_run_artifacts(
             control_lines=list(control_lines),
             write_marker_count=len(write_markers),
             write_markers=list(write_markers),
+            rawfile_option_count=len(rawfile_options),
+            rawfile_options=list(rawfile_options),
             diagnostic_count=len(diagnostic_codes),
             diagnostic_codes=list(diagnostic_codes),
         )
@@ -2599,6 +2608,10 @@ def _deck_control_lines(netlist: str) -> list[str]:
 
 def _deck_control_write_markers(netlist: str) -> list[str]:
     return list(analyze_deck_controls(netlist).write_markers)
+
+
+def _deck_control_rawfile_options(netlist: str) -> list[str]:
+    return list(analyze_deck_controls(netlist).rawfile_options)
 
 
 def _deck_run_diagnostic_codes(netlist: str, plan: DeckAnalysisPlan) -> list[str]:
@@ -2655,6 +2668,8 @@ def _deck_run_artifact_cells(artifact: DeckRunArtifact) -> list[str]:
         ";".join(artifact.control_lines),
         str(artifact.write_marker_count),
         ";".join(artifact.write_markers),
+        str(artifact.rawfile_option_count),
+        ";".join(artifact.rawfile_options),
         str(artifact.diagnostic_count),
         ";".join(artifact.diagnostic_codes),
     ]
@@ -2772,6 +2787,7 @@ def run_deck_analysis(
     diagnostic_codes = _deck_run_diagnostic_codes(netlist, plan)
     control_lines = _deck_control_lines(netlist)
     write_markers = _deck_control_write_markers(netlist)
+    rawfile_options = _deck_control_rawfile_options(netlist)
     analysis_directives = _deck_analysis_directives(plan)
     if plan.analysis == "op":
         result = dc_op(circuit)
@@ -2792,6 +2808,7 @@ def run_deck_analysis(
             fourier,
             control_lines,
             write_markers,
+            rawfile_options,
             diagnostic_codes,
         )
         measurement_table = format_measurement_table(measurements)
@@ -2817,6 +2834,8 @@ def run_deck_analysis(
             control_lines=list(control_lines),
             write_marker_count=len(write_markers),
             write_markers=list(write_markers),
+            rawfile_option_count=len(rawfile_options),
+            rawfile_options=list(rawfile_options),
             diagnostic_count=len(diagnostic_codes),
             diagnostic_codes=list(diagnostic_codes),
             table_count=len(tables),
@@ -2854,6 +2873,7 @@ def run_deck_analysis(
             fourier,
             control_lines,
             write_markers,
+            rawfile_options,
             diagnostic_codes,
         )
         measurement_table = format_measurement_table(measurements)
@@ -2879,6 +2899,8 @@ def run_deck_analysis(
             control_lines=list(control_lines),
             write_marker_count=len(write_markers),
             write_markers=list(write_markers),
+            rawfile_option_count=len(rawfile_options),
+            rawfile_options=list(rawfile_options),
             diagnostic_count=len(diagnostic_codes),
             diagnostic_codes=list(diagnostic_codes),
             table_count=len(tables),
@@ -2918,6 +2940,7 @@ def run_deck_analysis(
             fourier,
             control_lines,
             write_markers,
+            rawfile_options,
             diagnostic_codes,
         )
         measurement_table = format_measurement_table(measurements)
@@ -2943,6 +2966,8 @@ def run_deck_analysis(
             control_lines=list(control_lines),
             write_marker_count=len(write_markers),
             write_markers=list(write_markers),
+            rawfile_option_count=len(rawfile_options),
+            rawfile_options=list(rawfile_options),
             diagnostic_count=len(diagnostic_codes),
             diagnostic_codes=list(diagnostic_codes),
             table_count=len(tables),
@@ -2988,6 +3013,7 @@ def run_deck_analysis(
             fourier,
             control_lines,
             write_markers,
+            rawfile_options,
             diagnostic_codes,
         )
         measurement_table = format_measurement_table(measurements)
@@ -3013,6 +3039,8 @@ def run_deck_analysis(
             control_lines=list(control_lines),
             write_marker_count=len(write_markers),
             write_markers=list(write_markers),
+            rawfile_option_count=len(rawfile_options),
+            rawfile_options=list(rawfile_options),
             diagnostic_count=len(diagnostic_codes),
             diagnostic_codes=list(diagnostic_codes),
             table_count=len(tables),
@@ -3046,6 +3074,7 @@ def run_deck_analysis(
             fourier,
             control_lines,
             write_markers,
+            rawfile_options,
             diagnostic_codes,
         )
         measurement_table = format_measurement_table(measurements)
@@ -3071,6 +3100,8 @@ def run_deck_analysis(
             control_lines=list(control_lines),
             write_marker_count=len(write_markers),
             write_markers=list(write_markers),
+            rawfile_option_count=len(rawfile_options),
+            rawfile_options=list(rawfile_options),
             diagnostic_count=len(diagnostic_codes),
             diagnostic_codes=list(diagnostic_codes),
             table_count=len(tables),
@@ -3103,6 +3134,7 @@ def run_deck_analysis(
             fourier,
             control_lines,
             write_markers,
+            rawfile_options,
             diagnostic_codes,
         )
         measurement_table = format_measurement_table(measurements)
@@ -3128,6 +3160,8 @@ def run_deck_analysis(
             control_lines=list(control_lines),
             write_marker_count=len(write_markers),
             write_markers=list(write_markers),
+            rawfile_option_count=len(rawfile_options),
+            rawfile_options=list(rawfile_options),
             diagnostic_count=len(diagnostic_codes),
             diagnostic_codes=list(diagnostic_codes),
             table_count=len(tables),
@@ -3179,6 +3213,7 @@ def run_deck_analysis(
             fourier,
             control_lines,
             write_markers,
+            rawfile_options,
             diagnostic_codes,
         )
         measurement_table = format_measurement_table(measurements)
@@ -3204,6 +3239,8 @@ def run_deck_analysis(
             control_lines=list(control_lines),
             write_marker_count=len(write_markers),
             write_markers=list(write_markers),
+            rawfile_option_count=len(rawfile_options),
+            rawfile_options=list(rawfile_options),
             diagnostic_count=len(diagnostic_codes),
             diagnostic_codes=list(diagnostic_codes),
             table_count=len(tables),

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -6851,8 +6851,8 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
     assert op_execution.run_artifacts[0].diagnostic_count == 0
     assert op_execution.run_artifacts[0].diagnostic_codes == []
     assert op_execution.run_artifact_table == (
-        "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tWriteMarkers\tWriteMarkerList\tDiagnostics\tDiagnosticCodeList\n"
-        f"op\t.op\t1\t.op\t{op_execution.plan.line_number}\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t1\t2\tIndex;V(mid)\t2\tresult;run-artifact\t1\tV(mid)\t1\t.save\t0\t\t0\t\t0\t\t0\t\t0\t\n"
+        "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tWriteMarkers\tWriteMarkerList\tRawfileOptions\tRawfileOptionList\tDiagnostics\tDiagnosticCodeList\n"
+        f"op\t.op\t1\t.op\t{op_execution.plan.line_number}\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t1\t2\tIndex;V(mid)\t2\tresult;run-artifact\t1\tV(mid)\t1\t.save\t0\t\t0\t\t0\t\t0\t\t0\t\t0\t\n"
     )
     assert op_execution.table_artifacts[1].name == "run-artifact"
     assert op_execution.table_artifacts[1].table == op_execution.run_artifact_table
@@ -6869,8 +6869,8 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
         format_deck_run_artifact_json(op_execution.run_artifacts)
     )
     assert format_deck_run_artifact_csv(op_execution.run_artifacts) == (
-        "Analysis,Directive,AnalysisDirectives,AnalysisDirectiveList,Line,SourceName,OutputNode,SweepKind,StartValue,StopValue,StepValue,PointCount,StartFrequencyHz,StopFrequencyHz,StepTime,StopTime,StartTime,MaxStep,UseInitialConditions,ResultRows,ResultColumns,ResultColumnList,Tables,TableList,OutputProbes,OutputProbeList,OutputDirectives,OutputDirectiveList,Measurements,MeasurementList,Fourier,FourierList,ControlLines,ControlLineList,WriteMarkers,WriteMarkerList,Diagnostics,DiagnosticCodeList\n"
-        f"op,.op,1,.op,{op_execution.plan.line_number},,,,,,,,,,,,,,,1,2,Index;V(mid),2,result;run-artifact,1,V(mid),1,.save,0,,0,,0,,0,,0,\n"
+        "Analysis,Directive,AnalysisDirectives,AnalysisDirectiveList,Line,SourceName,OutputNode,SweepKind,StartValue,StopValue,StepValue,PointCount,StartFrequencyHz,StopFrequencyHz,StepTime,StopTime,StartTime,MaxStep,UseInitialConditions,ResultRows,ResultColumns,ResultColumnList,Tables,TableList,OutputProbes,OutputProbeList,OutputDirectives,OutputDirectiveList,Measurements,MeasurementList,Fourier,FourierList,ControlLines,ControlLineList,WriteMarkers,WriteMarkerList,RawfileOptions,RawfileOptionList,Diagnostics,DiagnosticCodeList\n"
+        f"op,.op,1,.op,{op_execution.plan.line_number},,,,,,,,,,,,,,,1,2,Index;V(mid),2,result;run-artifact,1,V(mid),1,.save,0,,0,,0,,0,,0,,0,\n"
     )
     assert format_deck_table_csv('Name\tValue\nprobe\tSPICE,"QUOTED"\n') == (
         'Name,Value\nprobe,"SPICE,""QUOTED"""\n'
@@ -6920,6 +6920,8 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
         "ControlLineList",
         "WriteMarkers",
         "WriteMarkerList",
+        "RawfileOptions",
+        "RawfileOptionList",
         "Diagnostics",
         "DiagnosticCodeList",
     ]
@@ -6961,6 +6963,8 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
             "ControlLineList": "",
             "WriteMarkers": "0",
             "WriteMarkerList": "",
+            "RawfileOptions": "0",
+            "RawfileOptionList": "",
             "Diagnostics": "0",
             "DiagnosticCodeList": "",
         }
@@ -6983,7 +6987,7 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
         diagnostic_codes=["SPICE_DECK_ANALYSIS_TOKEN", 'SPICE,"QUOTED"'],
     )
     assert format_deck_run_artifact_csv([quoted_diagnostic_artifact]).endswith(
-        ',0,,2,"SPICE_DECK_ANALYSIS_TOKEN;SPICE,""QUOTED"""\n'
+        ',0,,0,,0,,2,"SPICE_DECK_ANALYSIS_TOKEN;SPICE,""QUOTED"""\n'
     )
     assert json.loads(format_deck_run_artifact_json([quoted_diagnostic_artifact]))[
         0
@@ -7049,8 +7053,8 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
     assert dc_execution.run_artifacts[0].measurement_names == ["mid_avg"]
     assert dc_execution.run_artifacts[0].fourier_probes == []
     assert dc_execution.run_artifact_table == (
-        "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tWriteMarkers\tWriteMarkerList\tDiagnostics\tDiagnosticCodeList\n"
-        f"dc\t.dc\t1\t.dc\t{dc_execution.plan.line_number}\tV1\t\t\t0.000000e+00\t1.000000e+00\t1.000000e+00\t\t\t\t\t\t\t\t\t2\t5\tIndex;Source;Value;V(mid);I(V1)\t3\tresult;measurement;run-artifact\t2\tV(mid);I(V1)\t2\t.save;.probe\t1\tmid_avg\t0\t\t0\t\t0\t\t0\t\n"
+        "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tWriteMarkers\tWriteMarkerList\tRawfileOptions\tRawfileOptionList\tDiagnostics\tDiagnosticCodeList\n"
+        f"dc\t.dc\t1\t.dc\t{dc_execution.plan.line_number}\tV1\t\t\t0.000000e+00\t1.000000e+00\t1.000000e+00\t\t\t\t\t\t\t\t\t2\t5\tIndex;Source;Value;V(mid);I(V1)\t3\tresult;measurement;run-artifact\t2\tV(mid);I(V1)\t2\t.save;.probe\t1\tmid_avg\t0\t\t0\t\t0\t\t0\t\t0\t\n"
     )
 
     ac_execution = run_deck_analysis(circuit, netlist, "ac")
@@ -7099,8 +7103,8 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
     assert ac_execution.run_artifacts[0].measurement_names == ["mid_peak"]
     assert ac_execution.run_artifacts[0].fourier_probes == []
     assert ac_execution.run_artifact_table == (
-        "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tWriteMarkers\tWriteMarkerList\tDiagnostics\tDiagnosticCodeList\n"
-        f"ac\t.ac\t1\t.ac\t{ac_execution.plan.line_number}\t\t\tdec\t\t\t\t1\t1.000000e+03\t1.000000e+03\t\t\t\t\t\t1\t7\tIndex;Frequency;Probe;Real;Imaginary;Magnitude;Phase\t3\tresult;measurement;run-artifact\t1\tV(mid)\t1\t.save\t1\tmid_peak\t0\t\t0\t\t0\t\t0\t\n"
+        "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tWriteMarkers\tWriteMarkerList\tRawfileOptions\tRawfileOptionList\tDiagnostics\tDiagnosticCodeList\n"
+        f"ac\t.ac\t1\t.ac\t{ac_execution.plan.line_number}\t\t\tdec\t\t\t\t1\t1.000000e+03\t1.000000e+03\t\t\t\t\t\t1\t7\tIndex;Frequency;Probe;Real;Imaginary;Magnitude;Phase\t3\tresult;measurement;run-artifact\t1\tV(mid)\t1\t.save\t1\tmid_peak\t0\t\t0\t\t0\t\t0\t\t0\t\n"
     )
 
     tran_execution = run_deck_analysis(circuit, netlist, "tran")
@@ -7144,8 +7148,8 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
     assert tran_execution.run_artifacts[0].diagnostic_count == 0
     assert tran_execution.run_artifacts[0].diagnostic_codes == []
     assert tran_execution.run_artifact_table == (
-        "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tWriteMarkers\tWriteMarkerList\tDiagnostics\tDiagnosticCodeList\n"
-        f"tran\t.tran\t1\t.tran\t{tran_execution.plan.line_number}\t\t\t\t\t\t\t\t\t\t1.000000e-03\t1.000000e-03\t\t\tfalse\t2\t3\tIndex;Time;V(mid)\t3\tresult;measurement;run-artifact\t1\tV(mid)\t1\t.save\t1\tmid_final\t0\t\t0\t\t0\t\t0\t\n"
+        "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tWriteMarkers\tWriteMarkerList\tRawfileOptions\tRawfileOptionList\tDiagnostics\tDiagnosticCodeList\n"
+        f"tran\t.tran\t1\t.tran\t{tran_execution.plan.line_number}\t\t\t\t\t\t\t\t\t\t1.000000e-03\t1.000000e-03\t\t\tfalse\t2\t3\tIndex;Time;V(mid)\t3\tresult;measurement;run-artifact\t1\tV(mid)\t1\t.save\t1\tmid_final\t0\t\t0\t\t0\t\t0\t\t0\t\n"
     )
 
     tf_execution = run_deck_analysis(circuit, netlist, "tf")
@@ -7185,8 +7189,8 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
     assert tf_execution.run_artifacts[0].measurement_names == []
     assert tf_execution.run_artifacts[0].fourier_probes == []
     assert tf_execution.run_artifact_table == (
-        "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tWriteMarkers\tWriteMarkerList\tDiagnostics\tDiagnosticCodeList\n"
-        f"tf\t.tf\t1\t.tf\t{tf_execution.plan.line_number}\tV1\tmid\t\t\t\t\t\t\t\t\t\t\t\t\t1\t3\tTransferRatio;InputImpedance;OutputImpedance\t2\tresult;run-artifact\t1\tV(mid)\t0\t\t0\t\t0\t\t0\t\t0\t\t0\t\n"
+        "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tWriteMarkers\tWriteMarkerList\tRawfileOptions\tRawfileOptionList\tDiagnostics\tDiagnosticCodeList\n"
+        f"tf\t.tf\t1\t.tf\t{tf_execution.plan.line_number}\tV1\tmid\t\t\t\t\t\t\t\t\t\t\t\t\t1\t3\tTransferRatio;InputImpedance;OutputImpedance\t2\tresult;run-artifact\t1\tV(mid)\t0\t\t0\t\t0\t\t0\t\t0\t\t0\t\t0\t\n"
     )
 
     sens_execution = run_deck_analysis(circuit, netlist, "sens")
@@ -7227,8 +7231,8 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
     assert sens_execution.run_artifacts[0].measurement_names == []
     assert sens_execution.run_artifacts[0].fourier_probes == []
     assert sens_execution.run_artifact_table == (
-        "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tWriteMarkers\tWriteMarkerList\tDiagnostics\tDiagnosticCodeList\n"
-        f"sens\t.sens\t1\t.sens\t{sens_execution.plan.line_number}\t\tmid\t\t\t\t\t\t\t\t\t\t\t\t\t1\t7\tOutputNode;NominalVoltage;Element;Parameter;NominalValue;Sensitivity;RelativeSensitivity\t2\tresult;run-artifact\t1\tV(mid)\t0\t\t0\t\t0\t\t0\t\t0\t\t0\t\n"
+        "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tWriteMarkers\tWriteMarkerList\tRawfileOptions\tRawfileOptionList\tDiagnostics\tDiagnosticCodeList\n"
+        f"sens\t.sens\t1\t.sens\t{sens_execution.plan.line_number}\t\tmid\t\t\t\t\t\t\t\t\t\t\t\t\t1\t7\tOutputNode;NominalVoltage;Element;Parameter;NominalValue;Sensitivity;RelativeSensitivity\t2\tresult;run-artifact\t1\tV(mid)\t0\t\t0\t\t0\t\t0\t\t0\t\t0\t\t0\t\n"
     )
 
     noise_execution = run_deck_analysis(circuit, netlist, "noise")
@@ -7283,8 +7287,8 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
     assert noise_execution.run_artifacts[0].measurement_names == []
     assert noise_execution.run_artifacts[0].fourier_probes == []
     assert noise_execution.run_artifact_table == (
-        "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tWriteMarkers\tWriteMarkerList\tDiagnostics\tDiagnosticCodeList\n"
-        f"noise\t.noise\t1\t.noise\t{noise_execution.plan.line_number}\tV1\tmid\tlin\t\t\t\t1\t1.000000e+03\t1.000000e+03\t\t\t\t\t\t1\t10\tIndex;Frequency;OutputNode;InputSource;OutputPSD;InputReferredPSD;Element;Type;SourcePSD;ContributionPSD\t2\tresult;run-artifact\t1\tV(mid)\t0\t\t0\t\t0\t\t0\t\t0\t\t0\t\n"
+        "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tWriteMarkers\tWriteMarkerList\tRawfileOptions\tRawfileOptionList\tDiagnostics\tDiagnosticCodeList\n"
+        f"noise\t.noise\t1\t.noise\t{noise_execution.plan.line_number}\tV1\tmid\tlin\t\t\t\t1\t1.000000e+03\t1.000000e+03\t\t\t\t\t\t1\t10\tIndex;Frequency;OutputNode;InputSource;OutputPSD;InputReferredPSD;Element;Type;SourcePSD;ContributionPSD\t2\tresult;run-artifact\t1\tV(mid)\t0\t\t0\t\t0\t\t0\t\t0\t\t0\t\t0\t\n"
     )
 
     tran_window_execution = run_deck_analysis(
@@ -7324,8 +7328,8 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
         "2\t6.000000e-03\t5.000000e-01\n"
     )
     assert tran_window_execution.run_artifact_table == (
-        "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tWriteMarkers\tWriteMarkerList\tDiagnostics\tDiagnosticCodeList\n"
-        f"tran\t.tran\t1\t.tran\t{tran_window_execution.plan.line_number}\t\t\t\t\t\t\t\t\t\t2.000000e-03\t6.000000e-03\t2.000000e-03\t1.000000e-03\ttrue\t3\t3\tIndex;Time;V(mid)\t2\tresult;run-artifact\t1\tV(mid)\t1\t.save\t0\t\t0\t\t0\t\t0\t\t0\t\n"
+        "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tWriteMarkers\tWriteMarkerList\tRawfileOptions\tRawfileOptionList\tDiagnostics\tDiagnosticCodeList\n"
+        f"tran\t.tran\t1\t.tran\t{tran_window_execution.plan.line_number}\t\t\t\t\t\t\t\t\t\t2.000000e-03\t6.000000e-03\t2.000000e-03\t1.000000e-03\ttrue\t3\t3\tIndex;Time;V(mid)\t2\tresult;run-artifact\t1\tV(mid)\t1\t.save\t0\t\t0\t\t0\t\t0\t\t0\t\t0\t\n"
     )
 
     with pytest.raises(ValueError, match="multiple analysis cards"):
@@ -7363,6 +7367,11 @@ def test_run_deck_analysis_surfaces_control_diagnostics_in_artifacts() -> None:
 .control
 save V(in)
 probe V(in)
+set filetype=ascii
+set wr_vecnames
+set wr_singlescale
+set appendwrite
+.set WR_VECNAMES
 write out.raw V(in)
 wrdata out.dat V(in)
 source other.cir
@@ -7386,17 +7395,31 @@ let gain = 2
     control_line_list = ";".join(expected_control_lines)
     expected_write_markers = ["write out.raw V(in)", "wrdata out.dat V(in)"]
     write_marker_list = ";".join(expected_write_markers)
+    expected_rawfile_options = [
+        "set filetype=ascii",
+        "set wr_vecnames",
+        "set wr_singlescale",
+        "set appendwrite",
+        "set wr_vecnames",
+    ]
+    rawfile_option_list = ";".join(expected_rawfile_options)
 
     assert execution.control_line_count == len(expected_control_lines)
     assert execution.control_lines == expected_control_lines
     assert execution.write_marker_count == len(expected_write_markers)
     assert execution.write_markers == expected_write_markers
+    assert execution.rawfile_option_count == len(expected_rawfile_options)
+    assert execution.rawfile_options == expected_rawfile_options
     assert execution.diagnostic_count == len(expected_codes)
     assert execution.diagnostic_codes == expected_codes
     assert execution.run_artifacts[0].control_line_count == len(expected_control_lines)
     assert execution.run_artifacts[0].control_lines == expected_control_lines
     assert execution.run_artifacts[0].write_marker_count == len(expected_write_markers)
     assert execution.run_artifacts[0].write_markers == expected_write_markers
+    assert execution.run_artifacts[0].rawfile_option_count == len(
+        expected_rawfile_options
+    )
+    assert execution.run_artifacts[0].rawfile_options == expected_rawfile_options
     assert execution.run_artifacts[0].diagnostic_count == len(expected_codes)
     assert execution.run_artifacts[0].diagnostic_codes == expected_codes
     record = deck_table_records(execution.run_artifact_table)[0]
@@ -7404,12 +7427,18 @@ let gain = 2
     assert record["ControlLineList"] == control_line_list
     assert record["WriteMarkers"] == str(len(expected_write_markers))
     assert record["WriteMarkerList"] == write_marker_list
+    assert record["RawfileOptions"] == str(len(expected_rawfile_options))
+    assert record["RawfileOptionList"] == rawfile_option_list
     assert record["Diagnostics"] == str(len(expected_codes))
     assert record["DiagnosticCodeList"] == code_list
     assert execution.table_artifacts[-1].name == "run-artifact"
     assert execution.table_artifacts[-1].records[0]["ControlLineList"] == control_line_list
     assert (
         execution.table_artifacts[-1].records[0]["WriteMarkerList"] == write_marker_list
+    )
+    assert (
+        execution.table_artifacts[-1].records[0]["RawfileOptionList"]
+        == rawfile_option_list
     )
     assert execution.table_artifacts[-1].records[0]["DiagnosticCodeList"] == code_list
     assert execution.table_artifacts[-1].csv == format_deck_run_artifact_csv(
@@ -7424,6 +7453,9 @@ let gain = 2
     assert json.loads(format_deck_run_artifact_json(execution.run_artifacts))[0][
         "WriteMarkerList"
     ] == write_marker_list
+    assert json.loads(format_deck_run_artifact_json(execution.run_artifacts))[0][
+        "RawfileOptionList"
+    ] == rawfile_option_list
     assert json.loads(format_deck_run_artifact_json(execution.run_artifacts))[0][
         "DiagnosticCodeList"
     ] == code_list
@@ -7449,6 +7481,37 @@ wrdata empty.dat
         "write dotted.raw V(a)",
         "wrdata dotted.dat V(a)",
     )
+
+
+def test_analyze_deck_controls_surfaces_rawfile_options() -> None:
+    summary = analyze_deck_controls(
+        """
+.control
+set filetype=ascii
+set wr_vecnames
+set wr_singlescale
+set appendwrite
+.set WR_VECNAMES
+set noaskquit
+set filetype=binary
+set temp=27
+.endc
+.end
+"""
+    )
+
+    assert summary.rawfile_options == (
+        "set filetype=ascii",
+        "set wr_vecnames",
+        "set wr_singlescale",
+        "set appendwrite",
+        "set wr_vecnames",
+    )
+    assert [diagnostic.code for diagnostic in summary.diagnostics] == [
+        "SPICE_DECK_UNSUPPORTED_DIRECTIVE",
+        "SPICE_DECK_CONTROL_VARIABLE_COMMAND",
+        "SPICE_DECK_CONTROL_VARIABLE_COMMAND",
+    ]
 
 
 def test_run_deck_analysis_exposes_selected_fourier_artifacts() -> None:
@@ -7514,8 +7577,8 @@ def test_run_deck_analysis_exposes_selected_fourier_artifacts() -> None:
     assert tran_execution.run_artifacts[0].measurement_names == []
     assert tran_execution.run_artifacts[0].fourier_probes == ["V(mid)"]
     assert tran_execution.run_artifact_table == (
-        "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tWriteMarkers\tWriteMarkerList\tDiagnostics\tDiagnosticCodeList\n"
-        f"tran\t.tran\t1\t.tran\t{tran_execution.plan.line_number}\t\t\t\t\t\t\t\t\t\t5.000000e-04\t1.000000e-03\t\t\tfalse\t3\t3\tIndex;Time;V(mid)\t3\tresult;fourier;run-artifact\t1\tV(mid)\t1\t.save\t0\t\t1\tV(mid)\t0\t\t0\t\t0\t\n"
+        "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tWriteMarkers\tWriteMarkerList\tRawfileOptions\tRawfileOptionList\tDiagnostics\tDiagnosticCodeList\n"
+        f"tran\t.tran\t1\t.tran\t{tran_execution.plan.line_number}\t\t\t\t\t\t\t\t\t\t5.000000e-04\t1.000000e-03\t\t\tfalse\t3\t3\tIndex;Time;V(mid)\t3\tresult;fourier;run-artifact\t1\tV(mid)\t1\t.save\t0\t\t1\tV(mid)\t0\t\t0\t\t0\t\t0\t\n"
     )
 
 

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+- Expose accepted `.control` rawfile option inventories from
+  `analyze_deck_controls` and selected `run_deck_analysis` execution results as
+  `rawfile_option_count` / `rawfile_options`, and carry them through
+  selected-run artifacts as stable `RawfileOptions` / `RawfileOptionList`
+  table, CSV/JSON, and ordered `table_artifacts` fields, matching Python and
+  TypeScript.
 - Expose accepted `.control` `write` / `wrdata` marker inventories from
   `analyze_deck_controls` and selected `run_deck_analysis` execution results as
   `write_marker_count` / `write_markers`, and carry them through selected-run

--- a/code/packages/rust/spice-engine/README.md
+++ b/code/packages/rust/spice-engine/README.md
@@ -189,14 +189,18 @@ results and a stable Fourier table. Executions also include selected-run
 artifact summaries plus `format_deck_run_artifact_table` and
 `format_deck_run_artifact_csv` / `format_deck_run_artifact_json` output for
 stable result-row, table, analysis-directive, output-probe, output-directive,
-measurement, Fourier, control-command, write-marker, and diagnostic count/name
-lists.
+measurement, Fourier, control-command, write-marker, rawfile-option, and
+diagnostic count/name lists.
 Normalized accepted `.control` commands are surfaced separately in
 `control_line_count` / `control_lines` execution fields and in
 `ControlLines` / `ControlLineList` artifact fields.
 Accepted `.control` `write` / `wrdata` rawfile/data-write markers are surfaced
 as `write_marker_count` / `write_markers` execution fields and as
 `WriteMarkers` / `WriteMarkerList` artifact fields without serializing files.
+Accepted `.control` rawfile output options (`set filetype=ascii`,
+`set wr_vecnames`, `set wr_singlescale`, and `set appendwrite`) are surfaced as
+`rawfile_option_count` / `rawfile_options` execution fields and as
+`RawfileOptions` / `RawfileOptionList` artifact fields.
 Existing `.control` body policy diagnostics flow into those selected-run artifact `Diagnostics` /
 `DiagnosticCodeList` fields and through the same run-artifact table, CSV, JSON,
 and `table_artifacts` records. `format_deck_table_csv` also converts any stable
@@ -250,7 +254,8 @@ and output-directive artifacts,
 selected measurement artifacts, selected transient Fourier artifacts,
 selected-run artifact summaries with table, analysis-directive, output-probe,
 output-directive, measurement, Fourier probe, `.control` command, and
-write-marker and diagnostic inventories, `.ac LIN`, `.ac DEC`, `.ac OCT`
-frequency grids, and `.tran` `START` / print-step `TSTEP` / `MAXSTEP` / `UIC`
-controls. Selected execution fields expose `.control` command, write-marker,
-and diagnostic inventories directly for host integrations.
+write-marker, rawfile-option, and diagnostic inventories, `.ac LIN`, `.ac DEC`,
+`.ac OCT` frequency grids, and `.tran` `START` / print-step `TSTEP` /
+`MAXSTEP` / `UIC` controls. Selected execution fields expose `.control`
+command, write-marker, rawfile-option, and diagnostic inventories directly for
+host integrations.

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -3150,6 +3150,7 @@ pub struct DeckControlSummary {
     pub active_lines: Vec<String>,
     pub control_lines: Vec<String>,
     pub write_markers: Vec<String>,
+    pub rawfile_options: Vec<String>,
     pub terminated: bool,
     pub end_line_number: Option<usize>,
     pub diagnostics: Vec<DeckControlDiagnostic>,
@@ -3442,6 +3443,8 @@ pub struct DeckRunArtifact {
     pub control_lines: Vec<String>,
     pub write_marker_count: usize,
     pub write_markers: Vec<String>,
+    pub rawfile_option_count: usize,
+    pub rawfile_options: Vec<String>,
     pub diagnostic_count: usize,
     pub diagnostic_codes: Vec<String>,
 }
@@ -3467,6 +3470,8 @@ pub struct DeckAnalysisExecution {
     pub control_lines: Vec<String>,
     pub write_marker_count: usize,
     pub write_markers: Vec<String>,
+    pub rawfile_option_count: usize,
+    pub rawfile_options: Vec<String>,
     pub diagnostic_count: usize,
     pub diagnostic_codes: Vec<String>,
     pub table_count: usize,
@@ -3607,6 +3612,7 @@ pub fn analyze_deck_controls(netlist: &str) -> DeckControlSummary {
     let mut active_lines = Vec::new();
     let mut control_lines = Vec::new();
     let mut write_markers = Vec::new();
+    let mut rawfile_options = Vec::new();
     let mut diagnostics = Vec::new();
     let mut end_line_number = None;
     let mut in_control_block = false;
@@ -3630,6 +3636,10 @@ pub fn analyze_deck_controls(netlist: &str) -> DeckControlSummary {
             }
             if let Some(write_marker) = control_block_write_marker(stripped) {
                 write_markers.push(write_marker);
+                continue;
+            }
+            if let Some(rawfile_option) = control_block_rawfile_option(stripped) {
+                rawfile_options.push(rawfile_option);
                 continue;
             }
             if is_noop_control_block_command(stripped) {
@@ -3714,6 +3724,7 @@ pub fn analyze_deck_controls(netlist: &str) -> DeckControlSummary {
         active_lines,
         control_lines,
         write_markers,
+        rawfile_options,
         terminated: end_line_number.is_some(),
         end_line_number,
         diagnostics,
@@ -7348,6 +7359,25 @@ fn control_block_write_marker(line: &str) -> Option<String> {
     None
 }
 
+fn control_block_rawfile_option(line: &str) -> Option<String> {
+    let mut parts = line.split_whitespace();
+    let command = parts.next()?.to_ascii_lowercase();
+    if !matches!(command.as_str(), "set" | ".set") {
+        return None;
+    }
+    let option = parts.next()?.to_ascii_lowercase();
+    if parts.next().is_some() {
+        return None;
+    }
+    if matches!(
+        option.as_str(),
+        "filetype=ascii" | "wr_vecnames" | "wr_singlescale" | "appendwrite"
+    ) {
+        return Some(format!("set {option}"));
+    }
+    None
+}
+
 fn is_noop_control_block_command(line: &str) -> bool {
     let mut parts = line.split_whitespace();
     let Some(command) = parts.next().map(|command| command.to_ascii_lowercase()) else {
@@ -10162,6 +10192,7 @@ fn deck_run_artifacts(
     fourier: &[FourierResult],
     control_lines: &[String],
     write_markers: &[String],
+    rawfile_options: &[String],
     diagnostic_codes: &[String],
 ) -> Vec<DeckRunArtifact> {
     let is_transient = plan.analysis == "tran";
@@ -10210,6 +10241,8 @@ fn deck_run_artifacts(
         control_lines: control_lines.to_vec(),
         write_marker_count: write_markers.len(),
         write_markers: write_markers.to_vec(),
+        rawfile_option_count: rawfile_options.len(),
+        rawfile_options: rawfile_options.to_vec(),
         diagnostic_count: diagnostic_codes.len(),
         diagnostic_codes: diagnostic_codes.to_vec(),
     }]
@@ -10263,6 +10296,10 @@ fn deck_control_write_markers(netlist: &str) -> Vec<String> {
     analyze_deck_controls(netlist).write_markers
 }
 
+fn deck_control_rawfile_options(netlist: &str) -> Vec<String> {
+    analyze_deck_controls(netlist).rawfile_options
+}
+
 fn deck_run_diagnostic_codes(netlist: &str, plan: &DeckAnalysisPlan) -> Vec<String> {
     let mut codes = deck_analysis_diagnostic_codes(netlist, plan);
     codes.extend(deck_control_diagnostic_codes(netlist));
@@ -10314,6 +10351,8 @@ const DECK_RUN_ARTIFACT_COLUMNS: &[&str] = &[
     "ControlLineList",
     "WriteMarkers",
     "WriteMarkerList",
+    "RawfileOptions",
+    "RawfileOptionList",
     "Diagnostics",
     "DiagnosticCodeList",
 ];
@@ -10359,6 +10398,8 @@ fn deck_run_artifact_cells(artifact: &DeckRunArtifact) -> Vec<String> {
         artifact.control_lines.join(";"),
         artifact.write_marker_count.to_string(),
         artifact.write_markers.join(";"),
+        artifact.rawfile_option_count.to_string(),
+        artifact.rawfile_options.join(";"),
         artifact.diagnostic_count.to_string(),
         artifact.diagnostic_codes.join(";"),
     ]
@@ -10600,6 +10641,7 @@ pub fn run_deck_analysis(
     let diagnostic_codes = deck_run_diagnostic_codes(netlist, &plan);
     let control_lines = deck_control_lines(netlist);
     let write_markers = deck_control_write_markers(netlist);
+    let rawfile_options = deck_control_rawfile_options(netlist);
     let analysis_directives = deck_analysis_directives(&plan);
     match plan.analysis.as_str() {
         "op" => {
@@ -10623,6 +10665,7 @@ pub fn run_deck_analysis(
                 &fourier,
                 &control_lines,
                 &write_markers,
+                &rawfile_options,
                 &diagnostic_codes,
             );
             let run_artifact_table = format_deck_run_artifact_table(&run_artifacts);
@@ -10646,6 +10689,8 @@ pub fn run_deck_analysis(
                 control_lines: control_lines.clone(),
                 write_marker_count: write_markers.len(),
                 write_markers: write_markers.clone(),
+                rawfile_option_count: rawfile_options.len(),
+                rawfile_options: rawfile_options.clone(),
                 diagnostic_count: diagnostic_codes.len(),
                 diagnostic_codes: diagnostic_codes.clone(),
                 table_count: tables.len(),
@@ -10686,6 +10731,7 @@ pub fn run_deck_analysis(
                 &fourier,
                 &control_lines,
                 &write_markers,
+                &rawfile_options,
                 &diagnostic_codes,
             );
             let run_artifact_table = format_deck_run_artifact_table(&run_artifacts);
@@ -10709,6 +10755,8 @@ pub fn run_deck_analysis(
                 control_lines: control_lines.clone(),
                 write_marker_count: write_markers.len(),
                 write_markers: write_markers.clone(),
+                rawfile_option_count: rawfile_options.len(),
+                rawfile_options: rawfile_options.clone(),
                 diagnostic_count: diagnostic_codes.len(),
                 diagnostic_codes: diagnostic_codes.clone(),
                 table_count: tables.len(),
@@ -10750,6 +10798,7 @@ pub fn run_deck_analysis(
                 &fourier,
                 &control_lines,
                 &write_markers,
+                &rawfile_options,
                 &diagnostic_codes,
             );
             let run_artifact_table = format_deck_run_artifact_table(&run_artifacts);
@@ -10773,6 +10822,8 @@ pub fn run_deck_analysis(
                 control_lines: control_lines.clone(),
                 write_marker_count: write_markers.len(),
                 write_markers: write_markers.clone(),
+                rawfile_option_count: rawfile_options.len(),
+                rawfile_options: rawfile_options.clone(),
                 diagnostic_count: diagnostic_codes.len(),
                 diagnostic_codes: diagnostic_codes.clone(),
                 table_count: tables.len(),
@@ -10817,6 +10868,7 @@ pub fn run_deck_analysis(
                 &fourier,
                 &control_lines,
                 &write_markers,
+                &rawfile_options,
                 &diagnostic_codes,
             );
             let run_artifact_table = format_deck_run_artifact_table(&run_artifacts);
@@ -10840,6 +10892,8 @@ pub fn run_deck_analysis(
                 control_lines: control_lines.clone(),
                 write_marker_count: write_markers.len(),
                 write_markers: write_markers.clone(),
+                rawfile_option_count: rawfile_options.len(),
+                rawfile_options: rawfile_options.clone(),
                 diagnostic_count: diagnostic_codes.len(),
                 diagnostic_codes: diagnostic_codes.clone(),
                 table_count: tables.len(),
@@ -10878,6 +10932,7 @@ pub fn run_deck_analysis(
                 &fourier,
                 &control_lines,
                 &write_markers,
+                &rawfile_options,
                 &diagnostic_codes,
             );
             let run_artifact_table = format_deck_run_artifact_table(&run_artifacts);
@@ -10901,6 +10956,8 @@ pub fn run_deck_analysis(
                 control_lines: control_lines.clone(),
                 write_marker_count: write_markers.len(),
                 write_markers: write_markers.clone(),
+                rawfile_option_count: rawfile_options.len(),
+                rawfile_options: rawfile_options.clone(),
                 diagnostic_count: diagnostic_codes.len(),
                 diagnostic_codes: diagnostic_codes.clone(),
                 table_count: tables.len(),
@@ -10937,6 +10994,7 @@ pub fn run_deck_analysis(
                 &fourier,
                 &control_lines,
                 &write_markers,
+                &rawfile_options,
                 &diagnostic_codes,
             );
             let run_artifact_table = format_deck_run_artifact_table(&run_artifacts);
@@ -10960,6 +11018,8 @@ pub fn run_deck_analysis(
                 control_lines: control_lines.clone(),
                 write_marker_count: write_markers.len(),
                 write_markers: write_markers.clone(),
+                rawfile_option_count: rawfile_options.len(),
+                rawfile_options: rawfile_options.clone(),
                 diagnostic_count: diagnostic_codes.len(),
                 diagnostic_codes: diagnostic_codes.clone(),
                 table_count: tables.len(),
@@ -11008,6 +11068,7 @@ pub fn run_deck_analysis(
                 &fourier,
                 &control_lines,
                 &write_markers,
+                &rawfile_options,
                 &diagnostic_codes,
             );
             let run_artifact_table = format_deck_run_artifact_table(&run_artifacts);
@@ -11031,6 +11092,8 @@ pub fn run_deck_analysis(
                 control_lines: control_lines.clone(),
                 write_marker_count: write_markers.len(),
                 write_markers: write_markers.clone(),
+                rawfile_option_count: rawfile_options.len(),
+                rawfile_options: rawfile_options.clone(),
                 diagnostic_count: diagnostic_codes.len(),
                 diagnostic_codes: diagnostic_codes.clone(),
                 table_count: tables.len(),

--- a/code/packages/rust/spice-engine/tests/compatibility_tests.rs
+++ b/code/packages/rust/spice-engine/tests/compatibility_tests.rs
@@ -216,6 +216,15 @@ quit
             "wrdata out.dat V(out)".to_string(),
         ]
     );
+    assert_eq!(
+        summary.rawfile_options,
+        &[
+            "set filetype=ascii".to_string(),
+            "set wr_vecnames".to_string(),
+            "set wr_singlescale".to_string(),
+            "set appendwrite".to_string(),
+        ]
+    );
     let diagnostics = summary
         .diagnostics
         .iter()

--- a/code/packages/rust/spice-engine/tests/transient_tests.rs
+++ b/code/packages/rust/spice-engine/tests/transient_tests.rs
@@ -1969,7 +1969,7 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
     assert_eq!(
         op_execution.run_artifact_table,
         format!(
-            "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tWriteMarkers\tWriteMarkerList\tDiagnostics\tDiagnosticCodeList\nop\t.op\t1\t.op\t{}\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t1\t2\tIndex;V(mid)\t2\tresult;run-artifact\t1\tV(mid)\t1\t.save\t0\t\t0\t\t0\t\t0\t\t0\t\n",
+            "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tWriteMarkers\tWriteMarkerList\tRawfileOptions\tRawfileOptionList\tDiagnostics\tDiagnosticCodeList\nop\t.op\t1\t.op\t{}\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t1\t2\tIndex;V(mid)\t2\tresult;run-artifact\t1\tV(mid)\t1\t.save\t0\t\t0\t\t0\t\t0\t\t0\t\t0\t\n",
             op_execution.plan.line_number
         )
     );
@@ -2021,7 +2021,7 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
     assert_eq!(
         format_deck_run_artifact_csv(&op_execution.run_artifacts),
         format!(
-            "Analysis,Directive,AnalysisDirectives,AnalysisDirectiveList,Line,SourceName,OutputNode,SweepKind,StartValue,StopValue,StepValue,PointCount,StartFrequencyHz,StopFrequencyHz,StepTime,StopTime,StartTime,MaxStep,UseInitialConditions,ResultRows,ResultColumns,ResultColumnList,Tables,TableList,OutputProbes,OutputProbeList,OutputDirectives,OutputDirectiveList,Measurements,MeasurementList,Fourier,FourierList,ControlLines,ControlLineList,WriteMarkers,WriteMarkerList,Diagnostics,DiagnosticCodeList\nop,.op,1,.op,{},,,,,,,,,,,,,,,1,2,Index;V(mid),2,result;run-artifact,1,V(mid),1,.save,0,,0,,0,,0,,0,\n",
+            "Analysis,Directive,AnalysisDirectives,AnalysisDirectiveList,Line,SourceName,OutputNode,SweepKind,StartValue,StopValue,StepValue,PointCount,StartFrequencyHz,StopFrequencyHz,StepTime,StopTime,StartTime,MaxStep,UseInitialConditions,ResultRows,ResultColumns,ResultColumnList,Tables,TableList,OutputProbes,OutputProbeList,OutputDirectives,OutputDirectiveList,Measurements,MeasurementList,Fourier,FourierList,ControlLines,ControlLineList,WriteMarkers,WriteMarkerList,RawfileOptions,RawfileOptionList,Diagnostics,DiagnosticCodeList\nop,.op,1,.op,{},,,,,,,,,,,,,,,1,2,Index;V(mid),2,result;run-artifact,1,V(mid),1,.save,0,,0,,0,,0,,0,,0,\n",
             op_execution.plan.line_number
         )
     );
@@ -2048,7 +2048,7 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
     assert!(artifact_json.contains("\"TableList\":\"result;run-artifact\""));
     assert!(artifact_json.contains("\"OutputProbeList\":\"V(mid)\""));
     assert!(artifact_json.ends_with(
-        "\"ControlLines\":\"0\",\"ControlLineList\":\"\",\"WriteMarkers\":\"0\",\"WriteMarkerList\":\"\",\"Diagnostics\":\"0\",\"DiagnosticCodeList\":\"\"}]\n"
+        "\"ControlLines\":\"0\",\"ControlLineList\":\"\",\"WriteMarkers\":\"0\",\"WriteMarkerList\":\"\",\"RawfileOptions\":\"0\",\"RawfileOptionList\":\"\",\"Diagnostics\":\"0\",\"DiagnosticCodeList\":\"\"}]\n"
     ));
     let mut diagnostic_artifact = op_execution.run_artifacts[0].clone();
     diagnostic_artifact.diagnostic_codes = vec![
@@ -2077,10 +2077,10 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
     quoted_diagnostic_artifact.diagnostic_count = quoted_diagnostic_artifact.diagnostic_codes.len();
     assert!(
         format_deck_run_artifact_csv(&[quoted_diagnostic_artifact.clone()])
-            .ends_with(",0,,2,\"SPICE_DECK_ANALYSIS_TOKEN;SPICE,\"\"QUOTED\"\"\"\n")
+            .ends_with(",0,,0,,0,,2,\"SPICE_DECK_ANALYSIS_TOKEN;SPICE,\"\"QUOTED\"\"\"\n")
     );
     assert!(format_deck_run_artifact_json(&[quoted_diagnostic_artifact]).ends_with(
-        ",\"ControlLines\":\"0\",\"ControlLineList\":\"\",\"WriteMarkers\":\"0\",\"WriteMarkerList\":\"\",\"Diagnostics\":\"2\",\"DiagnosticCodeList\":\"SPICE_DECK_ANALYSIS_TOKEN;SPICE,\\\"QUOTED\\\"\"}]\n"
+        ",\"ControlLines\":\"0\",\"ControlLineList\":\"\",\"WriteMarkers\":\"0\",\"WriteMarkerList\":\"\",\"RawfileOptions\":\"0\",\"RawfileOptionList\":\"\",\"Diagnostics\":\"2\",\"DiagnosticCodeList\":\"SPICE_DECK_ANALYSIS_TOKEN;SPICE,\\\"QUOTED\\\"\"}]\n"
     ));
 
     let dc_execution = run_deck_analysis(&circuit, netlist, Some("dc")).unwrap();
@@ -2191,7 +2191,7 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
     assert_eq!(
         dc_execution.run_artifact_table,
         format!(
-            "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tWriteMarkers\tWriteMarkerList\tDiagnostics\tDiagnosticCodeList\ndc\t.dc\t1\t.dc\t{}\tV1\t\t\t0.000000e+00\t1.000000e+00\t1.000000e+00\t\t\t\t\t\t\t\t\t2\t5\tIndex;Source;Value;V(mid);I(V1)\t3\tresult;measurement;run-artifact\t2\tV(mid);I(V1)\t2\t.save;.probe\t1\tmid_avg\t0\t\t0\t\t0\t\t0\t\n",
+            "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tWriteMarkers\tWriteMarkerList\tRawfileOptions\tRawfileOptionList\tDiagnostics\tDiagnosticCodeList\ndc\t.dc\t1\t.dc\t{}\tV1\t\t\t0.000000e+00\t1.000000e+00\t1.000000e+00\t\t\t\t\t\t\t\t\t2\t5\tIndex;Source;Value;V(mid);I(V1)\t3\tresult;measurement;run-artifact\t2\tV(mid);I(V1)\t2\t.save;.probe\t1\tmid_avg\t0\t\t0\t\t0\t\t0\t\t0\t\n",
             dc_execution.plan.line_number
         )
     );
@@ -2274,7 +2274,7 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
     assert_eq!(
         ac_execution.run_artifact_table,
         format!(
-            "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tWriteMarkers\tWriteMarkerList\tDiagnostics\tDiagnosticCodeList\nac\t.ac\t1\t.ac\t{}\t\t\tdec\t\t\t\t1\t1.000000e+03\t1.000000e+03\t\t\t\t\t\t1\t7\tIndex;Frequency;Probe;Real;Imaginary;Magnitude;Phase\t3\tresult;measurement;run-artifact\t1\tV(mid)\t1\t.save\t1\tmid_peak\t0\t\t0\t\t0\t\t0\t\n",
+            "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tWriteMarkers\tWriteMarkerList\tRawfileOptions\tRawfileOptionList\tDiagnostics\tDiagnosticCodeList\nac\t.ac\t1\t.ac\t{}\t\t\tdec\t\t\t\t1\t1.000000e+03\t1.000000e+03\t\t\t\t\t\t1\t7\tIndex;Frequency;Probe;Real;Imaginary;Magnitude;Phase\t3\tresult;measurement;run-artifact\t1\tV(mid)\t1\t.save\t1\tmid_peak\t0\t\t0\t\t0\t\t0\t\t0\t\n",
             ac_execution.plan.line_number
         )
     );
@@ -2354,7 +2354,7 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
     assert_eq!(
         tran_execution.run_artifact_table,
         format!(
-            "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tWriteMarkers\tWriteMarkerList\tDiagnostics\tDiagnosticCodeList\ntran\t.tran\t1\t.tran\t{}\t\t\t\t\t\t\t\t\t\t1.000000e-03\t1.000000e-03\t\t\tfalse\t1\t3\tIndex;Time;V(mid)\t3\tresult;measurement;run-artifact\t1\tV(mid)\t1\t.save\t1\tmid_final\t0\t\t0\t\t0\t\t0\t\n",
+            "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tWriteMarkers\tWriteMarkerList\tRawfileOptions\tRawfileOptionList\tDiagnostics\tDiagnosticCodeList\ntran\t.tran\t1\t.tran\t{}\t\t\t\t\t\t\t\t\t\t1.000000e-03\t1.000000e-03\t\t\tfalse\t1\t3\tIndex;Time;V(mid)\t3\tresult;measurement;run-artifact\t1\tV(mid)\t1\t.save\t1\tmid_final\t0\t\t0\t\t0\t\t0\t\t0\t\n",
             tran_execution.plan.line_number
         )
     );
@@ -2423,7 +2423,7 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
     assert_eq!(
         tf_execution.run_artifact_table,
         format!(
-            "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tWriteMarkers\tWriteMarkerList\tDiagnostics\tDiagnosticCodeList\ntf\t.tf\t1\t.tf\t{}\tV1\tmid\t\t\t\t\t\t\t\t\t\t\t\t\t1\t3\tTransferRatio;InputImpedance;OutputImpedance\t2\tresult;run-artifact\t1\tV(mid)\t0\t\t0\t\t0\t\t0\t\t0\t\t0\t\n",
+            "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tWriteMarkers\tWriteMarkerList\tRawfileOptions\tRawfileOptionList\tDiagnostics\tDiagnosticCodeList\ntf\t.tf\t1\t.tf\t{}\tV1\tmid\t\t\t\t\t\t\t\t\t\t\t\t\t1\t3\tTransferRatio;InputImpedance;OutputImpedance\t2\tresult;run-artifact\t1\tV(mid)\t0\t\t0\t\t0\t\t0\t\t0\t\t0\t\t0\t\n",
             tf_execution.plan.line_number
         )
     );
@@ -2493,7 +2493,7 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
     assert_eq!(
         sens_execution.run_artifact_table,
         format!(
-            "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tWriteMarkers\tWriteMarkerList\tDiagnostics\tDiagnosticCodeList\nsens\t.sens\t1\t.sens\t{}\t\tmid\t\t\t\t\t\t\t\t\t\t\t\t\t1\t7\tOutputNode;NominalVoltage;Element;Parameter;NominalValue;Sensitivity;RelativeSensitivity\t2\tresult;run-artifact\t1\tV(mid)\t0\t\t0\t\t0\t\t0\t\t0\t\t0\t\n",
+            "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tWriteMarkers\tWriteMarkerList\tRawfileOptions\tRawfileOptionList\tDiagnostics\tDiagnosticCodeList\nsens\t.sens\t1\t.sens\t{}\t\tmid\t\t\t\t\t\t\t\t\t\t\t\t\t1\t7\tOutputNode;NominalVoltage;Element;Parameter;NominalValue;Sensitivity;RelativeSensitivity\t2\tresult;run-artifact\t1\tV(mid)\t0\t\t0\t\t0\t\t0\t\t0\t\t0\t\t0\t\n",
             sens_execution.plan.line_number
         )
     );
@@ -2595,7 +2595,7 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
     assert_eq!(
         noise_execution.run_artifact_table,
         format!(
-            "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tWriteMarkers\tWriteMarkerList\tDiagnostics\tDiagnosticCodeList\nnoise\t.noise\t1\t.noise\t{}\tV1\tmid\tlin\t\t\t\t1\t1.000000e+03\t1.000000e+03\t\t\t\t\t\t1\t10\tIndex;Frequency;OutputNode;InputSource;OutputPSD;InputReferredPSD;Element;Type;SourcePSD;ContributionPSD\t2\tresult;run-artifact\t1\tV(mid)\t0\t\t0\t\t0\t\t0\t\t0\t\t0\t\n",
+            "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tWriteMarkers\tWriteMarkerList\tRawfileOptions\tRawfileOptionList\tDiagnostics\tDiagnosticCodeList\nnoise\t.noise\t1\t.noise\t{}\tV1\tmid\tlin\t\t\t\t1\t1.000000e+03\t1.000000e+03\t\t\t\t\t\t1\t10\tIndex;Frequency;OutputNode;InputSource;OutputPSD;InputReferredPSD;Element;Type;SourcePSD;ContributionPSD\t2\tresult;run-artifact\t1\tV(mid)\t0\t\t0\t\t0\t\t0\t\t0\t\t0\t\t0\t\n",
             noise_execution.plan.line_number
         )
     );
@@ -2672,7 +2672,7 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
     assert_eq!(
         tran_window_execution.run_artifact_table,
         format!(
-            "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tWriteMarkers\tWriteMarkerList\tDiagnostics\tDiagnosticCodeList\ntran\t.tran\t1\t.tran\t{}\t\t\t\t\t\t\t\t\t\t2.000000e-03\t6.000000e-03\t2.000000e-03\t1.000000e-03\ttrue\t3\t3\tIndex;Time;V(mid)\t2\tresult;run-artifact\t1\tV(mid)\t1\t.save\t0\t\t0\t\t0\t\t0\t\t0\t\n",
+            "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tWriteMarkers\tWriteMarkerList\tRawfileOptions\tRawfileOptionList\tDiagnostics\tDiagnosticCodeList\ntran\t.tran\t1\t.tran\t{}\t\t\t\t\t\t\t\t\t\t2.000000e-03\t6.000000e-03\t2.000000e-03\t1.000000e-03\ttrue\t3\t3\tIndex;Time;V(mid)\t2\tresult;run-artifact\t1\tV(mid)\t1\t.save\t0\t\t0\t\t0\t\t0\t\t0\t\t0\t\n",
             tran_window_execution.plan.line_number
         )
     );
@@ -2729,6 +2729,11 @@ fn run_deck_analysis_surfaces_control_diagnostics_in_artifacts() {
 .control
 save V(in)
 probe V(in)
+set filetype=ascii
+set wr_vecnames
+set wr_singlescale
+set appendwrite
+.set WR_VECNAMES
 write out.raw V(in)
 wrdata out.dat V(in)
 source other.cir
@@ -2755,11 +2760,24 @@ let gain = 2
         "wrdata out.dat V(in)".to_string(),
     ];
     let write_marker_list = expected_write_markers.join(";");
+    let expected_rawfile_options = vec![
+        "set filetype=ascii".to_string(),
+        "set wr_vecnames".to_string(),
+        "set wr_singlescale".to_string(),
+        "set appendwrite".to_string(),
+        "set wr_vecnames".to_string(),
+    ];
+    let rawfile_option_list = expected_rawfile_options.join(";");
 
     assert_eq!(execution.control_line_count, expected_control_lines.len());
     assert_eq!(execution.control_lines, expected_control_lines);
     assert_eq!(execution.write_marker_count, expected_write_markers.len());
     assert_eq!(execution.write_markers, expected_write_markers);
+    assert_eq!(
+        execution.rawfile_option_count,
+        expected_rawfile_options.len()
+    );
+    assert_eq!(execution.rawfile_options, expected_rawfile_options);
     assert_eq!(execution.diagnostic_count, expected_codes.len());
     assert_eq!(execution.diagnostic_codes, expected_codes);
     assert_eq!(
@@ -2777,6 +2795,14 @@ let gain = 2
     assert_eq!(
         execution.run_artifacts[0].write_markers,
         expected_write_markers
+    );
+    assert_eq!(
+        execution.run_artifacts[0].rawfile_option_count,
+        expected_rawfile_options.len()
+    );
+    assert_eq!(
+        execution.run_artifacts[0].rawfile_options,
+        expected_rawfile_options
     );
     assert_eq!(
         execution.run_artifacts[0].diagnostic_count,
@@ -2800,6 +2826,14 @@ let gain = 2
         records[0].get("WriteMarkerList").map(String::as_str),
         Some(write_marker_list.as_str())
     );
+    assert_eq!(
+        records[0].get("RawfileOptions").map(String::as_str),
+        Some("5")
+    );
+    assert_eq!(
+        records[0].get("RawfileOptionList").map(String::as_str),
+        Some(rawfile_option_list.as_str())
+    );
     assert_eq!(records[0].get("Diagnostics").map(String::as_str), Some("4"));
     assert_eq!(
         records[0].get("DiagnosticCodeList").map(String::as_str),
@@ -2818,6 +2852,12 @@ let gain = 2
             .get("WriteMarkerList")
             .map(String::as_str),
         Some(write_marker_list.as_str())
+    );
+    assert_eq!(
+        run_artifact.records[0]
+            .get("RawfileOptionList")
+            .map(String::as_str),
+        Some(rawfile_option_list.as_str())
     );
     assert_eq!(
         run_artifact.records[0]
@@ -2947,7 +2987,7 @@ fn run_deck_analysis_exposes_selected_fourier_artifacts() {
     assert_eq!(
         tran_execution.run_artifact_table,
         format!(
-            "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tWriteMarkers\tWriteMarkerList\tDiagnostics\tDiagnosticCodeList\ntran\t.tran\t1\t.tran\t{}\t\t\t\t\t\t\t\t\t\t5.000000e-04\t1.000000e-03\t\t\tfalse\t2\t3\tIndex;Time;V(mid)\t3\tresult;fourier;run-artifact\t1\tV(mid)\t1\t.save\t0\t\t1\tV(mid)\t0\t\t0\t\t0\t\n",
+            "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tWriteMarkers\tWriteMarkerList\tRawfileOptions\tRawfileOptionList\tDiagnostics\tDiagnosticCodeList\ntran\t.tran\t1\t.tran\t{}\t\t\t\t\t\t\t\t\t\t5.000000e-04\t1.000000e-03\t\t\tfalse\t2\t3\tIndex;Time;V(mid)\t3\tresult;fourier;run-artifact\t1\tV(mid)\t1\t.save\t0\t\t1\tV(mid)\t0\t\t0\t\t0\t\t0\t\n",
             tran_execution.plan.line_number
         )
     );

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- Expose accepted `.control` rawfile option inventories from
+  `analyzeDeckControls` and selected `runDeckAnalysis` execution results as
+  `rawfileOptionCount` / `rawfileOptions`, and carry them through selected-run
+  artifacts as stable `RawfileOptions` / `RawfileOptionList` table, CSV/JSON,
+  and ordered `tableArtifacts` fields, matching Python and Rust.
 - Expose accepted `.control` `write` / `wrdata` marker inventories from
   `analyzeDeckControls` and selected `runDeckAnalysis` execution results as
   `writeMarkerCount` / `writeMarkers`, and carry them through selected-run

--- a/code/packages/typescript/spice-engine/README.md
+++ b/code/packages/typescript/spice-engine/README.md
@@ -105,14 +105,18 @@ results and a stable Fourier table. Executions also include selected-run
 artifact summaries plus `formatDeckRunArtifactTable` and
 `formatDeckRunArtifactCsv` / `formatDeckRunArtifactJson` output for stable
 result-row, table, analysis-directive, output-probe, output-directive,
-measurement, Fourier, control-command, write-marker, and diagnostic count/name
-lists.
+measurement, Fourier, control-command, write-marker, rawfile-option, and
+diagnostic count/name lists.
 Normalized accepted `.control` commands are surfaced separately in
 `controlLineCount` / `controlLines` execution fields and in
 `ControlLines` / `ControlLineList` artifact fields.
 Accepted `.control` `write` / `wrdata` rawfile/data-write markers are surfaced
 as `writeMarkerCount` / `writeMarkers` execution fields and as `WriteMarkers` /
-`WriteMarkerList` artifact fields without serializing files. Existing
+`WriteMarkerList` artifact fields without serializing files.
+Accepted `.control` rawfile output options (`set filetype=ascii`,
+`set wr_vecnames`, `set wr_singlescale`, and `set appendwrite`) are surfaced as
+`rawfileOptionCount` / `rawfileOptions` execution fields and as
+`RawfileOptions` / `RawfileOptionList` artifact fields. Existing
 `.control` body policy diagnostics flow into those selected-run artifact `Diagnostics` /
 `DiagnosticCodeList` fields and through the same run-artifact table, CSV, JSON,
 and `tableArtifacts` records. `formatDeckTableCsv` also converts any stable tab-separated deck table to
@@ -212,8 +216,8 @@ deck execution helpers.
 deck-selected table output with normalized table-inventory, output-probe, and
 output-directive artifacts, selected measurement artifacts, selected transient Fourier artifacts,
 selected-run artifact summaries with table, analysis-directive, output-probe, output-directive,
-measurement, Fourier probe, `.control` command, write-marker, and diagnostic inventories,
-`.ac LIN`, `.ac DEC`, `.ac OCT` frequency grids, and `.tran` `START` /
-print-step `TSTEP` / `MAXSTEP` / `UIC` controls. Selected execution fields
-expose `.control` command, write-marker, and diagnostic inventories directly
-for host integrations.
+measurement, Fourier probe, `.control` command, write-marker, rawfile-option, and
+diagnostic inventories, `.ac LIN`, `.ac DEC`, `.ac OCT` frequency grids, and
+`.tran` `START` / print-step `TSTEP` / `MAXSTEP` / `UIC` controls. Selected
+execution fields expose `.control` command, write-marker, rawfile-option, and
+diagnostic inventories directly for host integrations.

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -429,6 +429,7 @@ export interface DeckControlSummary {
   readonly activeLines: readonly string[];
   readonly controlLines: readonly string[];
   readonly writeMarkers: readonly string[];
+  readonly rawfileOptions: readonly string[];
   readonly terminated: boolean;
   readonly endLineNumber?: number;
   readonly diagnostics: readonly DeckControlDiagnostic[];
@@ -697,6 +698,8 @@ export interface DeckRunArtifact {
   readonly controlLines: readonly string[];
   readonly writeMarkerCount: number;
   readonly writeMarkers: readonly string[];
+  readonly rawfileOptionCount: number;
+  readonly rawfileOptions: readonly string[];
   readonly diagnosticCount: number;
   readonly diagnosticCodes: readonly string[];
 }
@@ -720,6 +723,8 @@ export interface DeckAnalysisExecution {
   readonly controlLines: readonly string[];
   readonly writeMarkerCount: number;
   readonly writeMarkers: readonly string[];
+  readonly rawfileOptionCount: number;
+  readonly rawfileOptions: readonly string[];
   readonly diagnosticCount: number;
   readonly diagnosticCodes: readonly string[];
   readonly tableCount: number;
@@ -2990,6 +2995,7 @@ export function analyzeDeckControls(netlist: string): DeckControlSummary {
   const activeLines: string[] = [];
   const controlLines: string[] = [];
   const writeMarkers: string[] = [];
+  const rawfileOptions: string[] = [];
   const diagnostics: DeckControlDiagnostic[] = [];
   let endLineNumber: number | undefined;
   let inControlBlock = false;
@@ -3016,6 +3022,11 @@ export function analyzeDeckControls(netlist: string): DeckControlSummary {
       const writeMarker = controlBlockWriteMarker(stripped);
       if (writeMarker !== undefined) {
         writeMarkers.push(writeMarker);
+        continue;
+      }
+      const rawfileOption = controlBlockRawfileOption(stripped);
+      if (rawfileOption !== undefined) {
+        rawfileOptions.push(rawfileOption);
         continue;
       }
       if (isNoopControlBlockCommand(stripped)) {
@@ -3094,6 +3105,7 @@ export function analyzeDeckControls(netlist: string): DeckControlSummary {
     activeLines,
     controlLines,
     writeMarkers,
+    rawfileOptions,
     terminated: endLineNumber !== undefined,
     endLineNumber,
     diagnostics,
@@ -6178,6 +6190,27 @@ function controlBlockWriteMarker(line: string): string | undefined {
   return undefined;
 }
 
+function controlBlockRawfileOption(line: string): string | undefined {
+  const parts = line.split(/\s+/);
+  const command = parts[0]?.toLowerCase();
+  if (command !== "set" && command !== ".set") {
+    return undefined;
+  }
+  if (parts.length !== 2) {
+    return undefined;
+  }
+  const option = parts[1]?.toLowerCase() ?? "";
+  if (
+    option === "filetype=ascii" ||
+    option === "wr_vecnames" ||
+    option === "wr_singlescale" ||
+    option === "appendwrite"
+  ) {
+    return `set ${option}`;
+  }
+  return undefined;
+}
+
 function isNoopControlBlockCommand(line: string): boolean {
   const parts = line.split(/\s+/);
   const command = parts[0]?.toLowerCase();
@@ -7946,6 +7979,7 @@ function deckRunArtifacts(
   fourier: readonly FourierResult[],
   controlLines: readonly string[],
   writeMarkers: readonly string[],
+  rawfileOptions: readonly string[],
   diagnosticCodes: readonly string[],
 ): DeckRunArtifact[] {
   const isTransient = plan.analysis === "tran";
@@ -7989,6 +8023,8 @@ function deckRunArtifacts(
       controlLines: [...controlLines],
       writeMarkerCount: writeMarkers.length,
       writeMarkers: [...writeMarkers],
+      rawfileOptionCount: rawfileOptions.length,
+      rawfileOptions: [...rawfileOptions],
       diagnosticCount: diagnosticCodes.length,
       diagnosticCodes: [...diagnosticCodes],
     },
@@ -8034,6 +8070,10 @@ function deckControlLines(netlist: string): string[] {
 
 function deckControlWriteMarkers(netlist: string): string[] {
   return [...analyzeDeckControls(netlist).writeMarkers];
+}
+
+function deckControlRawfileOptions(netlist: string): string[] {
+  return [...analyzeDeckControls(netlist).rawfileOptions];
 }
 
 function deckRunDiagnosticCodes(netlist: string, plan: DeckAnalysisPlan): string[] {
@@ -8088,6 +8128,8 @@ const DECK_RUN_ARTIFACT_COLUMNS = [
   "ControlLineList",
   "WriteMarkers",
   "WriteMarkerList",
+  "RawfileOptions",
+  "RawfileOptionList",
   "Diagnostics",
   "DiagnosticCodeList",
 ] as const;
@@ -8130,6 +8172,8 @@ function deckRunArtifactCells(artifact: DeckRunArtifact): string[] {
     artifact.controlLines.join(";"),
     String(artifact.writeMarkerCount),
     artifact.writeMarkers.join(";"),
+    String(artifact.rawfileOptionCount),
+    artifact.rawfileOptions.join(";"),
     String(artifact.diagnosticCount),
     artifact.diagnosticCodes.join(";"),
   ];
@@ -8280,6 +8324,7 @@ export function runDeckAnalysis(
   const diagnosticCodes = deckRunDiagnosticCodes(netlist, plan);
   const controlLines = deckControlLines(netlist);
   const writeMarkers = deckControlWriteMarkers(netlist);
+  const rawfileOptions = deckControlRawfileOptions(netlist);
   const analysisDirectives = deckAnalysisDirectives(plan);
   if (plan.analysis === "op") {
     const result = dcOp(circuit);
@@ -8300,6 +8345,7 @@ export function runDeckAnalysis(
       fourier,
       controlLines,
       writeMarkers,
+      rawfileOptions,
       diagnosticCodes,
     );
     const tables = deckStableTables(measurements, fourier);
@@ -8325,6 +8371,8 @@ export function runDeckAnalysis(
       controlLines: [...controlLines],
       writeMarkerCount: writeMarkers.length,
       writeMarkers: [...writeMarkers],
+      rawfileOptionCount: rawfileOptions.length,
+      rawfileOptions: [...rawfileOptions],
       diagnosticCount: diagnosticCodes.length,
       diagnosticCodes: [...diagnosticCodes],
       tableCount: tables.length,
@@ -8363,6 +8411,7 @@ export function runDeckAnalysis(
       fourier,
       controlLines,
       writeMarkers,
+      rawfileOptions,
       diagnosticCodes,
     );
     const tables = deckStableTables(measurements, fourier);
@@ -8388,6 +8437,8 @@ export function runDeckAnalysis(
       controlLines: [...controlLines],
       writeMarkerCount: writeMarkers.length,
       writeMarkers: [...writeMarkers],
+      rawfileOptionCount: rawfileOptions.length,
+      rawfileOptions: [...rawfileOptions],
       diagnosticCount: diagnosticCodes.length,
       diagnosticCodes: [...diagnosticCodes],
       tableCount: tables.length,
@@ -8437,6 +8488,7 @@ export function runDeckAnalysis(
       fourier,
       controlLines,
       writeMarkers,
+      rawfileOptions,
       diagnosticCodes,
     );
     const tables = deckStableTables(measurements, fourier);
@@ -8462,6 +8514,8 @@ export function runDeckAnalysis(
       controlLines: [...controlLines],
       writeMarkerCount: writeMarkers.length,
       writeMarkers: [...writeMarkers],
+      rawfileOptionCount: rawfileOptions.length,
+      rawfileOptions: [...rawfileOptions],
       diagnosticCount: diagnosticCodes.length,
       diagnosticCodes: [...diagnosticCodes],
       tableCount: tables.length,
@@ -8506,6 +8560,7 @@ export function runDeckAnalysis(
       fourier,
       controlLines,
       writeMarkers,
+      rawfileOptions,
       diagnosticCodes,
     );
     const tables = deckStableTables(measurements, fourier);
@@ -8531,6 +8586,8 @@ export function runDeckAnalysis(
       controlLines: [...controlLines],
       writeMarkerCount: writeMarkers.length,
       writeMarkers: [...writeMarkers],
+      rawfileOptionCount: rawfileOptions.length,
+      rawfileOptions: [...rawfileOptions],
       diagnosticCount: diagnosticCodes.length,
       diagnosticCodes: [...diagnosticCodes],
       tableCount: tables.length,
@@ -8565,6 +8622,7 @@ export function runDeckAnalysis(
       fourier,
       controlLines,
       writeMarkers,
+      rawfileOptions,
       diagnosticCodes,
     );
     const tables = deckStableTables(measurements, fourier);
@@ -8590,6 +8648,8 @@ export function runDeckAnalysis(
       controlLines: [...controlLines],
       writeMarkerCount: writeMarkers.length,
       writeMarkers: [...writeMarkers],
+      rawfileOptionCount: rawfileOptions.length,
+      rawfileOptions: [...rawfileOptions],
       diagnosticCount: diagnosticCodes.length,
       diagnosticCodes: [...diagnosticCodes],
       tableCount: tables.length,
@@ -8623,6 +8683,7 @@ export function runDeckAnalysis(
       fourier,
       controlLines,
       writeMarkers,
+      rawfileOptions,
       diagnosticCodes,
     );
     const tables = deckStableTables(measurements, fourier);
@@ -8648,6 +8709,8 @@ export function runDeckAnalysis(
       controlLines: [...controlLines],
       writeMarkerCount: writeMarkers.length,
       writeMarkers: [...writeMarkers],
+      rawfileOptionCount: rawfileOptions.length,
+      rawfileOptions: [...rawfileOptions],
       diagnosticCount: diagnosticCodes.length,
       diagnosticCodes: [...diagnosticCodes],
       tableCount: tables.length,
@@ -8691,6 +8754,7 @@ export function runDeckAnalysis(
       fourier,
       controlLines,
       writeMarkers,
+      rawfileOptions,
       diagnosticCodes,
     );
     const tables = deckStableTables(measurements, fourier);
@@ -8716,6 +8780,8 @@ export function runDeckAnalysis(
       controlLines: [...controlLines],
       writeMarkerCount: writeMarkers.length,
       writeMarkers: [...writeMarkers],
+      rawfileOptionCount: rawfileOptions.length,
+      rawfileOptions: [...rawfileOptions],
       diagnosticCount: diagnosticCodes.length,
       diagnosticCodes: [...diagnosticCodes],
       tableCount: tables.length,

--- a/code/packages/typescript/spice-engine/tests/compatibility.test.ts
+++ b/code/packages/typescript/spice-engine/tests/compatibility.test.ts
@@ -193,6 +193,12 @@ quit
       "write out.raw V(out)",
       "wrdata out.dat V(out)",
     ]);
+    expect(summary.rawfileOptions).toStrictEqual([
+      "set filetype=ascii",
+      "set wr_vecnames",
+      "set wr_singlescale",
+      "set appendwrite",
+    ]);
     expect(summary.diagnostics.map(({ directive, lineNumber, severity }) => [
       directive,
       lineNumber,

--- a/code/packages/typescript/spice-engine/tests/transient.test.ts
+++ b/code/packages/typescript/spice-engine/tests/transient.test.ts
@@ -1519,8 +1519,8 @@ describe("transient", () => {
     expect(opExecution.runArtifacts[0]?.diagnosticCount).toBe(0);
     expect(opExecution.runArtifacts[0]?.diagnosticCodes).toEqual([]);
     expect(opExecution.runArtifactTable).toBe(
-      "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tWriteMarkers\tWriteMarkerList\tDiagnostics\tDiagnosticCodeList\n" +
-        `op\t.op\t1\t.op\t${opExecution.plan.lineNumber}\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t1\t2\tIndex;V(mid)\t2\tresult;run-artifact\t1\tV(mid)\t1\t.save\t0\t\t0\t\t0\t\t0\t\t0\t\n`,
+      "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tWriteMarkers\tWriteMarkerList\tRawfileOptions\tRawfileOptionList\tDiagnostics\tDiagnosticCodeList\n" +
+        `op\t.op\t1\t.op\t${opExecution.plan.lineNumber}\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t1\t2\tIndex;V(mid)\t2\tresult;run-artifact\t1\tV(mid)\t1\t.save\t0\t\t0\t\t0\t\t0\t\t0\t\t0\t\n`,
     );
     expect(opExecution.tableArtifacts[1]?.name).toBe("run-artifact");
     expect(opExecution.tableArtifacts[1]?.table).toBe(opExecution.runArtifactTable);
@@ -1537,8 +1537,8 @@ describe("transient", () => {
       JSON.parse(formatDeckRunArtifactJson(opExecution.runArtifacts)),
     );
     expect(formatDeckRunArtifactCsv(opExecution.runArtifacts)).toBe(
-      "Analysis,Directive,AnalysisDirectives,AnalysisDirectiveList,Line,SourceName,OutputNode,SweepKind,StartValue,StopValue,StepValue,PointCount,StartFrequencyHz,StopFrequencyHz,StepTime,StopTime,StartTime,MaxStep,UseInitialConditions,ResultRows,ResultColumns,ResultColumnList,Tables,TableList,OutputProbes,OutputProbeList,OutputDirectives,OutputDirectiveList,Measurements,MeasurementList,Fourier,FourierList,ControlLines,ControlLineList,WriteMarkers,WriteMarkerList,Diagnostics,DiagnosticCodeList\n" +
-        `op,.op,1,.op,${opExecution.plan.lineNumber},,,,,,,,,,,,,,,1,2,Index;V(mid),2,result;run-artifact,1,V(mid),1,.save,0,,0,,0,,0,,0,\n`,
+      "Analysis,Directive,AnalysisDirectives,AnalysisDirectiveList,Line,SourceName,OutputNode,SweepKind,StartValue,StopValue,StepValue,PointCount,StartFrequencyHz,StopFrequencyHz,StepTime,StopTime,StartTime,MaxStep,UseInitialConditions,ResultRows,ResultColumns,ResultColumnList,Tables,TableList,OutputProbes,OutputProbeList,OutputDirectives,OutputDirectiveList,Measurements,MeasurementList,Fourier,FourierList,ControlLines,ControlLineList,WriteMarkers,WriteMarkerList,RawfileOptions,RawfileOptionList,Diagnostics,DiagnosticCodeList\n" +
+        `op,.op,1,.op,${opExecution.plan.lineNumber},,,,,,,,,,,,,,,1,2,Index;V(mid),2,result;run-artifact,1,V(mid),1,.save,0,,0,,0,,0,,0,,0,\n`,
     );
     expect(formatDeckTableCsv('Name\tValue\nprobe\tSPICE,"QUOTED"\n')).toBe(
       'Name,Value\nprobe,"SPICE,""QUOTED"""\n',
@@ -1588,6 +1588,8 @@ describe("transient", () => {
       "ControlLineList",
       "WriteMarkers",
       "WriteMarkerList",
+      "RawfileOptions",
+      "RawfileOptionList",
       "Diagnostics",
       "DiagnosticCodeList",
     ]);
@@ -1629,6 +1631,8 @@ describe("transient", () => {
         ControlLineList: "",
         WriteMarkers: "0",
         WriteMarkerList: "",
+        RawfileOptions: "0",
+        RawfileOptionList: "",
         Diagnostics: "0",
         DiagnosticCodeList: "",
       },
@@ -1651,7 +1655,7 @@ describe("transient", () => {
       diagnosticCodes: ["SPICE_DECK_ANALYSIS_TOKEN", 'SPICE,"QUOTED"'],
     };
     expect(formatDeckRunArtifactCsv([quotedDiagnosticArtifact])).toMatch(
-      /,0,,2,"SPICE_DECK_ANALYSIS_TOKEN;SPICE,""QUOTED"""\n$/u,
+      /,0,,0,,0,,2,"SPICE_DECK_ANALYSIS_TOKEN;SPICE,""QUOTED"""\n$/u,
     );
     expect(
       (JSON.parse(formatDeckRunArtifactJson([quotedDiagnosticArtifact])) as Array<Record<string, string>>)[0]?.[
@@ -1715,8 +1719,8 @@ describe("transient", () => {
     expect(dcExecution.runArtifacts[0]?.measurementNames).toEqual(["mid_avg"]);
     expect(dcExecution.runArtifacts[0]?.fourierProbes).toEqual([]);
     expect(dcExecution.runArtifactTable).toBe(
-      "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tWriteMarkers\tWriteMarkerList\tDiagnostics\tDiagnosticCodeList\n" +
-        `dc\t.dc\t1\t.dc\t${dcExecution.plan.lineNumber}\tV1\t\t\t0.000000e+00\t1.000000e+00\t1.000000e+00\t\t\t\t\t\t\t\t\t2\t5\tIndex;Source;Value;V(mid);I(V1)\t3\tresult;measurement;run-artifact\t2\tV(mid);I(V1)\t2\t.save;.probe\t1\tmid_avg\t0\t\t0\t\t0\t\t0\t\n`,
+      "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tWriteMarkers\tWriteMarkerList\tRawfileOptions\tRawfileOptionList\tDiagnostics\tDiagnosticCodeList\n" +
+        `dc\t.dc\t1\t.dc\t${dcExecution.plan.lineNumber}\tV1\t\t\t0.000000e+00\t1.000000e+00\t1.000000e+00\t\t\t\t\t\t\t\t\t2\t5\tIndex;Source;Value;V(mid);I(V1)\t3\tresult;measurement;run-artifact\t2\tV(mid);I(V1)\t2\t.save;.probe\t1\tmid_avg\t0\t\t0\t\t0\t\t0\t\t0\t\n`,
     );
 
     const acExecution = runDeckAnalysis(circuit, netlist, "ac");
@@ -1764,8 +1768,8 @@ describe("transient", () => {
     expect(acExecution.runArtifacts[0]?.measurementNames).toEqual(["mid_peak"]);
     expect(acExecution.runArtifacts[0]?.fourierProbes).toEqual([]);
     expect(acExecution.runArtifactTable).toBe(
-      "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tWriteMarkers\tWriteMarkerList\tDiagnostics\tDiagnosticCodeList\n" +
-        `ac\t.ac\t1\t.ac\t${acExecution.plan.lineNumber}\t\t\tdec\t\t\t\t1\t1.000000e+03\t1.000000e+03\t\t\t\t\t\t1\t7\tIndex;Frequency;Probe;Real;Imaginary;Magnitude;Phase\t3\tresult;measurement;run-artifact\t1\tV(mid)\t1\t.save\t1\tmid_peak\t0\t\t0\t\t0\t\t0\t\n`,
+      "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tWriteMarkers\tWriteMarkerList\tRawfileOptions\tRawfileOptionList\tDiagnostics\tDiagnosticCodeList\n" +
+        `ac\t.ac\t1\t.ac\t${acExecution.plan.lineNumber}\t\t\tdec\t\t\t\t1\t1.000000e+03\t1.000000e+03\t\t\t\t\t\t1\t7\tIndex;Frequency;Probe;Real;Imaginary;Magnitude;Phase\t3\tresult;measurement;run-artifact\t1\tV(mid)\t1\t.save\t1\tmid_peak\t0\t\t0\t\t0\t\t0\t\t0\t\n`,
     );
 
     const tranExecution = runDeckAnalysis(circuit, netlist, "tran");
@@ -1806,8 +1810,8 @@ describe("transient", () => {
     expect(tranExecution.runArtifacts[0]?.diagnosticCount).toBe(0);
     expect(tranExecution.runArtifacts[0]?.diagnosticCodes).toEqual([]);
     expect(tranExecution.runArtifactTable).toBe(
-      "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tWriteMarkers\tWriteMarkerList\tDiagnostics\tDiagnosticCodeList\n" +
-        `tran\t.tran\t1\t.tran\t${tranExecution.plan.lineNumber}\t\t\t\t\t\t\t\t\t\t1.000000e-03\t1.000000e-03\t\t\tfalse\t1\t3\tIndex;Time;V(mid)\t3\tresult;measurement;run-artifact\t1\tV(mid)\t1\t.save\t1\tmid_final\t0\t\t0\t\t0\t\t0\t\n`,
+      "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tWriteMarkers\tWriteMarkerList\tRawfileOptions\tRawfileOptionList\tDiagnostics\tDiagnosticCodeList\n" +
+        `tran\t.tran\t1\t.tran\t${tranExecution.plan.lineNumber}\t\t\t\t\t\t\t\t\t\t1.000000e-03\t1.000000e-03\t\t\tfalse\t1\t3\tIndex;Time;V(mid)\t3\tresult;measurement;run-artifact\t1\tV(mid)\t1\t.save\t1\tmid_final\t0\t\t0\t\t0\t\t0\t\t0\t\n`,
     );
 
     const tfExecution = runDeckAnalysis(circuit, netlist, "tf");
@@ -1851,8 +1855,8 @@ describe("transient", () => {
     expect(tfExecution.runArtifacts[0]?.measurementNames).toEqual([]);
     expect(tfExecution.runArtifacts[0]?.fourierProbes).toEqual([]);
     expect(tfExecution.runArtifactTable).toBe(
-      "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tWriteMarkers\tWriteMarkerList\tDiagnostics\tDiagnosticCodeList\n" +
-        `tf\t.tf\t1\t.tf\t${tfExecution.plan.lineNumber}\tV1\tmid\t\t\t\t\t\t\t\t\t\t\t\t\t1\t3\tTransferRatio;InputImpedance;OutputImpedance\t2\tresult;run-artifact\t1\tV(mid)\t0\t\t0\t\t0\t\t0\t\t0\t\t0\t\n`,
+      "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tWriteMarkers\tWriteMarkerList\tRawfileOptions\tRawfileOptionList\tDiagnostics\tDiagnosticCodeList\n" +
+        `tf\t.tf\t1\t.tf\t${tfExecution.plan.lineNumber}\tV1\tmid\t\t\t\t\t\t\t\t\t\t\t\t\t1\t3\tTransferRatio;InputImpedance;OutputImpedance\t2\tresult;run-artifact\t1\tV(mid)\t0\t\t0\t\t0\t\t0\t\t0\t\t0\t\t0\t\n`,
     );
 
     const sensExecution = runDeckAnalysis(circuit, netlist, "sens");
@@ -1896,8 +1900,8 @@ describe("transient", () => {
     expect(sensExecution.runArtifacts[0]?.measurementNames).toEqual([]);
     expect(sensExecution.runArtifacts[0]?.fourierProbes).toEqual([]);
     expect(sensExecution.runArtifactTable).toBe(
-      "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tWriteMarkers\tWriteMarkerList\tDiagnostics\tDiagnosticCodeList\n" +
-        `sens\t.sens\t1\t.sens\t${sensExecution.plan.lineNumber}\t\tmid\t\t\t\t\t\t\t\t\t\t\t\t\t1\t7\tOutputNode;NominalVoltage;Element;Parameter;NominalValue;Sensitivity;RelativeSensitivity\t2\tresult;run-artifact\t1\tV(mid)\t0\t\t0\t\t0\t\t0\t\t0\t\t0\t\n`,
+      "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tWriteMarkers\tWriteMarkerList\tRawfileOptions\tRawfileOptionList\tDiagnostics\tDiagnosticCodeList\n" +
+        `sens\t.sens\t1\t.sens\t${sensExecution.plan.lineNumber}\t\tmid\t\t\t\t\t\t\t\t\t\t\t\t\t1\t7\tOutputNode;NominalVoltage;Element;Parameter;NominalValue;Sensitivity;RelativeSensitivity\t2\tresult;run-artifact\t1\tV(mid)\t0\t\t0\t\t0\t\t0\t\t0\t\t0\t\t0\t\n`,
     );
 
     const noiseExecution = runDeckAnalysis(circuit, netlist, "noise");
@@ -1951,8 +1955,8 @@ describe("transient", () => {
     expect(noiseExecution.runArtifacts[0]?.measurementNames).toEqual([]);
     expect(noiseExecution.runArtifacts[0]?.fourierProbes).toEqual([]);
     expect(noiseExecution.runArtifactTable).toBe(
-      "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tWriteMarkers\tWriteMarkerList\tDiagnostics\tDiagnosticCodeList\n" +
-        `noise\t.noise\t1\t.noise\t${noiseExecution.plan.lineNumber}\tV1\tmid\tlin\t\t\t\t1\t1.000000e+03\t1.000000e+03\t\t\t\t\t\t1\t10\tIndex;Frequency;OutputNode;InputSource;OutputPSD;InputReferredPSD;Element;Type;SourcePSD;ContributionPSD\t2\tresult;run-artifact\t1\tV(mid)\t0\t\t0\t\t0\t\t0\t\t0\t\t0\t\n`,
+      "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tWriteMarkers\tWriteMarkerList\tRawfileOptions\tRawfileOptionList\tDiagnostics\tDiagnosticCodeList\n" +
+        `noise\t.noise\t1\t.noise\t${noiseExecution.plan.lineNumber}\tV1\tmid\tlin\t\t\t\t1\t1.000000e+03\t1.000000e+03\t\t\t\t\t\t1\t10\tIndex;Frequency;OutputNode;InputSource;OutputPSD;InputReferredPSD;Element;Type;SourcePSD;ContributionPSD\t2\tresult;run-artifact\t1\tV(mid)\t0\t\t0\t\t0\t\t0\t\t0\t\t0\t\t0\t\n`,
     );
 
     const tranWindowExecution = runDeckAnalysis(
@@ -1993,8 +1997,8 @@ describe("transient", () => {
         "2\t6.000000e-03\t5.000000e-01\n",
     );
     expect(tranWindowExecution.runArtifactTable).toBe(
-      "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tWriteMarkers\tWriteMarkerList\tDiagnostics\tDiagnosticCodeList\n" +
-        `tran\t.tran\t1\t.tran\t${tranWindowExecution.plan.lineNumber}\t\t\t\t\t\t\t\t\t\t2.000000e-03\t6.000000e-03\t2.000000e-03\t1.000000e-03\ttrue\t3\t3\tIndex;Time;V(mid)\t2\tresult;run-artifact\t1\tV(mid)\t1\t.save\t0\t\t0\t\t0\t\t0\t\t0\t\n`,
+      "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tWriteMarkers\tWriteMarkerList\tRawfileOptions\tRawfileOptionList\tDiagnostics\tDiagnosticCodeList\n" +
+        `tran\t.tran\t1\t.tran\t${tranWindowExecution.plan.lineNumber}\t\t\t\t\t\t\t\t\t\t2.000000e-03\t6.000000e-03\t2.000000e-03\t1.000000e-03\ttrue\t3\t3\tIndex;Time;V(mid)\t2\tresult;run-artifact\t1\tV(mid)\t1\t.save\t0\t\t0\t\t0\t\t0\t\t0\t\t0\t\n`,
     );
 
     expect(() => runDeckAnalysis(circuit, netlist)).toThrow(/multiple analysis cards/);
@@ -2031,6 +2035,11 @@ describe("transient", () => {
 .control
 save V(in)
 probe V(in)
+set filetype=ascii
+set wr_vecnames
+set wr_singlescale
+set appendwrite
+.set WR_VECNAMES
 write out.raw V(in)
 wrdata out.dat V(in)
 source other.cir
@@ -2054,17 +2063,29 @@ let gain = 2
     const controlLineList = expectedControlLines.join(";");
     const expectedWriteMarkers = ["write out.raw V(in)", "wrdata out.dat V(in)"];
     const writeMarkerList = expectedWriteMarkers.join(";");
+    const expectedRawfileOptions = [
+      "set filetype=ascii",
+      "set wr_vecnames",
+      "set wr_singlescale",
+      "set appendwrite",
+      "set wr_vecnames",
+    ];
+    const rawfileOptionList = expectedRawfileOptions.join(";");
 
     expect(execution.controlLineCount).toBe(expectedControlLines.length);
     expect(execution.controlLines).toEqual(expectedControlLines);
     expect(execution.writeMarkerCount).toBe(expectedWriteMarkers.length);
     expect(execution.writeMarkers).toEqual(expectedWriteMarkers);
+    expect(execution.rawfileOptionCount).toBe(expectedRawfileOptions.length);
+    expect(execution.rawfileOptions).toEqual(expectedRawfileOptions);
     expect(execution.diagnosticCount).toBe(expectedCodes.length);
     expect(execution.diagnosticCodes).toEqual(expectedCodes);
     expect(execution.runArtifacts[0]?.controlLineCount).toBe(expectedControlLines.length);
     expect(execution.runArtifacts[0]?.controlLines).toEqual(expectedControlLines);
     expect(execution.runArtifacts[0]?.writeMarkerCount).toBe(expectedWriteMarkers.length);
     expect(execution.runArtifacts[0]?.writeMarkers).toEqual(expectedWriteMarkers);
+    expect(execution.runArtifacts[0]?.rawfileOptionCount).toBe(expectedRawfileOptions.length);
+    expect(execution.runArtifacts[0]?.rawfileOptions).toEqual(expectedRawfileOptions);
     expect(execution.runArtifacts[0]?.diagnosticCount).toBe(expectedCodes.length);
     expect(execution.runArtifacts[0]?.diagnosticCodes).toEqual(expectedCodes);
     const record = deckTableRecords(execution.runArtifactTable)[0]!;
@@ -2072,12 +2093,15 @@ let gain = 2
     expect(record["ControlLineList"]).toBe(controlLineList);
     expect(record["WriteMarkers"]).toBe(String(expectedWriteMarkers.length));
     expect(record["WriteMarkerList"]).toBe(writeMarkerList);
+    expect(record["RawfileOptions"]).toBe(String(expectedRawfileOptions.length));
+    expect(record["RawfileOptionList"]).toBe(rawfileOptionList);
     expect(record["Diagnostics"]).toBe(String(expectedCodes.length));
     expect(record["DiagnosticCodeList"]).toBe(codeList);
     const runArtifact = execution.tableArtifacts[execution.tableArtifacts.length - 1]!;
     expect(runArtifact.name).toBe("run-artifact");
     expect(runArtifact.records[0]?.["ControlLineList"]).toBe(controlLineList);
     expect(runArtifact.records[0]?.["WriteMarkerList"]).toBe(writeMarkerList);
+    expect(runArtifact.records[0]?.["RawfileOptionList"]).toBe(rawfileOptionList);
     expect(runArtifact.records[0]?.["DiagnosticCodeList"]).toBe(codeList);
     expect(runArtifact.csv).toBe(formatDeckRunArtifactCsv(execution.runArtifacts));
     expect(runArtifact.json).toBe(formatDeckRunArtifactJson(execution.runArtifacts));
@@ -2142,8 +2166,8 @@ let gain = 2
     expect(tranExecution.runArtifacts[0]?.measurementNames).toEqual([]);
     expect(tranExecution.runArtifacts[0]?.fourierProbes).toEqual(["V(mid)"]);
     expect(tranExecution.runArtifactTable).toBe(
-      "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tWriteMarkers\tWriteMarkerList\tDiagnostics\tDiagnosticCodeList\n" +
-        `tran\t.tran\t1\t.tran\t${tranExecution.plan.lineNumber}\t\t\t\t\t\t\t\t\t\t5.000000e-04\t1.000000e-03\t\t\tfalse\t2\t3\tIndex;Time;V(mid)\t3\tresult;fourier;run-artifact\t1\tV(mid)\t1\t.save\t0\t\t1\tV(mid)\t0\t\t0\t\t0\t\n`,
+      "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tWriteMarkers\tWriteMarkerList\tRawfileOptions\tRawfileOptionList\tDiagnostics\tDiagnosticCodeList\n" +
+        `tran\t.tran\t1\t.tran\t${tranExecution.plan.lineNumber}\t\t\t\t\t\t\t\t\t\t5.000000e-04\t1.000000e-03\t\t\tfalse\t2\t3\tIndex;Time;V(mid)\t3\tresult;fourier;run-artifact\t1\tV(mid)\t1\t.save\t0\t\t1\tV(mid)\t0\t\t0\t\t0\t\t0\t\n`,
     );
   });
 

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -112,7 +112,11 @@ downstream tools to compare.
      artifacts; accepted rawfile/data-write marker inventories for `.control`
      `write` / `wrdata` commands now travel through direct selected-execution
      fields and stable selected-run artifact tables, CSV/JSON helpers, and
-     ordered table export artifacts without serializing files.
+     ordered table export artifacts without serializing files, and accepted
+     rawfile output option inventories for `.control` `set filetype=ascii`,
+     `set wr_vecnames`, `set wr_singlescale`, and `set appendwrite` now travel
+     through the same direct selected-execution fields and selected-run
+     artifact exports.
    - Expand remaining deck-controlled analyses toward full SPICE compatibility
      while keeping unsupported control-flow diagnostics explicit.
 
@@ -1010,6 +1014,15 @@ downstream tools to compare.
     - Selected deck executions carry those write-marker inventories directly and
       through selected-run artifact tables, CSV/JSON helpers, and ordered table
       export artifacts without serializing files.
+
+93. Deck rawfile option artifacts.
+    - Status: completed in this deck rawfile option artifact slice.
+    - Python, Rust, and TypeScript control analyzers now expose normalized
+      accepted `.control` rawfile option inventories for `set filetype=ascii`,
+      `set wr_vecnames`, `set wr_singlescale`, and `set appendwrite`.
+    - Selected deck executions carry those rawfile option inventories directly
+      and through selected-run artifact tables, CSV/JSON helpers, and ordered
+      table export artifacts without serializing rawfiles.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- Surface accepted `.control` rawfile options as normalized analyzer inventories across Python, Rust, and TypeScript.
- Carry rawfile option counts/lists through selected execution fields and stable run-artifact table, CSV, JSON, and ordered table records.
- Document the new artifact surface and mark the SPICE plan slice complete.

## Verification
- `PYTHONPATH="/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-spice-deck-rawfile-option-artifacts/code/packages/python/spice-engine/src:/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-spice-deck-rawfile-option-artifacts/code/packages/python/spice-netlist-parser/src:/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-spice-deck-rawfile-option-artifacts/code/packages/python/mosfet-models/src:/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-spice-deck-rawfile-option-artifacts/code/packages/python/device-physics/src" /Users/adhithya/.local/share/mise/installs/python/3.12.13/bin/python -m pytest code/packages/python/spice-engine/tests/test_engine.py`
- `/Users/adhithya/.local/share/mise/installs/python/3.12.13/bin/python -m ruff check code/packages/python/spice-engine/src/spice_engine/engine.py code/packages/python/spice-engine/src/spice_engine/compatibility.py code/packages/python/spice-engine/tests/test_engine.py`
- `cargo test --manifest-path code/packages/rust/spice-engine/Cargo.toml`
- `cargo fmt --manifest-path code/packages/rust/spice-engine/Cargo.toml -- --check`
- `npm --prefix code/packages/typescript/spice-engine test`
- `npm --prefix code/packages/typescript/spice-engine run build`
- `git diff --check`