### PR TITLE
feat(closurec): for-in end-to-end (CLOC22)

### DIFF
--- a/code/packages/rust/closure-emitter/CHANGELOG.md
+++ b/code/packages/rust/closure-emitter/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to the `coding-adventures-closure-emitter` crate will be documented in this file.
 
+## [0.16.0] - 2026-06-20
+
+### Added — CLOC22: emit `for (… in …)`
+
+New `emit_for_in` writes `for ( <left> in <right> ) <body>`. The `in` keyword is
+separated on both sides with `required_ws` (a single space): the left ends in an
+identifier (`var k` / `k` / `o.p`) and the right starts with one, so `kin` /
+`inobj` would otherwise mis-lex. In the rare `a[b] in` / `in (x)` cases the space
+is one redundant byte but never wrong, matching upstream Closure's spacing around
+`in`. Added emitter unit tests for the `var`/`const` declaration left and the
+expression-left (bare-body) forms.
+
 ## [0.15.0] - 2026-06-20
 
 ### Added — CLOC21: emit `debugger;`

--- a/code/packages/rust/closure-emitter/Cargo.toml
+++ b/code/packages/rust/closure-emitter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-emitter"
-version = "0.15.0"
+version = "0.16.0"
 edition = "2021"
 description = "JavaScript code emitter for the Closure Compiler clone. Per CLOC07's emit contract. Takes a finalized Program + sidecar and produces output JavaScript text + companion source map. Runs after every pass in the pipeline."
 

--- a/code/packages/rust/closure-emitter/src/lib.rs
+++ b/code/packages/rust/closure-emitter/src/lib.rs
@@ -68,7 +68,8 @@ use coding_adventures_javascript_ast::{
     BooleanLiteral,
     BreakStatement, CallExpression, CatchClause, ConditionalExpression, ContinueStatement,
     Declaration, DebuggerStatement, DoWhileStatement,
-    EmptyStatement, Expression, ExpressionStatement, ForInit, ForStatement, FunctionDeclaration,
+    EmptyStatement, Expression, ExpressionStatement, ForInStatement, ForInit, ForStatement,
+    FunctionDeclaration,
     FunctionParam, Identifier, IfStatement, LabeledStatement, LogicalExpression, LogicalOperator,
     MemberExpression, NullLiteral, NumericLiteral, ObjectExpression, Program, ProgramItem,
     Property, PropertyKey, PropertyKind, ReturnStatement, Statement, StringLiteral,
@@ -293,6 +294,7 @@ impl<'a> Emitter<'a> {
             TaggedStatement::WhileStatement(w) => self.emit_while(w),
             TaggedStatement::DoWhileStatement(d) => self.emit_do_while(d),
             TaggedStatement::ForStatement(f) => self.emit_for(f),
+            TaggedStatement::ForInStatement(f) => self.emit_for_in(f),
             TaggedStatement::ReturnStatement(r) => self.emit_return(r),
             TaggedStatement::BreakStatement(b) => self.emit_break(b),
             TaggedStatement::ContinueStatement(c) => self.emit_continue(c),
@@ -507,6 +509,34 @@ impl<'a> Emitter<'a> {
             self.pretty_ws();
             self.emit_expression(u);
         }
+        self.write_str(")");
+        self.pretty_ws();
+        self.emit_statement(&f.body);
+    }
+
+    fn emit_for_in(&mut self, f: &ForInStatement) {
+        // `for ( <left> in <right> ) <body>`
+        //
+        // The `in` keyword needs a separator on BOTH sides: the left ends in an
+        // identifier (`var k` / `k` / `o.p`) and the right starts with one, so
+        // `kin` / `inobj` would mis-lex. `required_ws` is always inserted (a
+        // single space) — in the rare `a[b] in` / `in (x)` cases the space is
+        // one redundant byte but never wrong, matching upstream Closure's
+        // spacing around `in`.
+        self.maybe_map(&f.cv);
+        self.write_str("for");
+        self.pretty_ws();
+        self.write_str("(");
+        match &f.left {
+            ForInit::VariableDeclaration(v) => {
+                self.emit_variable_declaration(v, /*top_level=*/ false);
+            }
+            ForInit::Expression(e) => self.emit_expression(e),
+        }
+        self.required_ws();
+        self.write_str("in");
+        self.required_ws();
+        self.emit_expression(&f.right);
         self.write_str(")");
         self.pretty_ws();
         self.emit_statement(&f.body);
@@ -2560,6 +2590,74 @@ mod tests {
         let item = ProgramItem::Statement(Statement::block_statement(outer));
         let code = emit_default(program().with_body(vec![item])).code;
         assert_eq!(code, "{debugger;a}");
+    }
+
+    // ---- for / in (CLOC22) ------------------------------------
+
+    fn for_in_var_left(name: &str, kind: VarKind) -> ForInit {
+        ForInit::VariableDeclaration(VariableDeclaration {
+            cv: None,
+            kind,
+            declarations: vec![VariableDeclarator {
+                cv: None,
+                id: coding_adventures_javascript_ast::BindingTarget::Identifier(Identifier {
+                    cv: None,
+                    name: name.to_string(),
+                }),
+                init: None,
+            }],
+        })
+    }
+
+    #[test]
+    fn for_in_var_left_block_body_emits_with_spaced_in() {
+        // `for (var k in obj) { a }` — `in` is spaced on both sides so `k in`
+        // and `in obj` don't mis-lex.
+        let f = ForInStatement {
+            cv: None,
+            left: for_in_var_left("k", VarKind::Var),
+            right: ident("obj"),
+            body: Box::new(Statement::block_statement(block_with("a"))),
+        };
+        let item = ProgramItem::Statement(Statement::for_in_statement(f));
+        assert_eq!(
+            emit_default(program().with_body(vec![item])).code,
+            "for(var k in obj){a}"
+        );
+    }
+
+    #[test]
+    fn for_in_const_left_emits() {
+        let f = ForInStatement {
+            cv: None,
+            left: for_in_var_left("k", VarKind::Const),
+            right: ident("obj"),
+            body: Box::new(Statement::block_statement(block_with("a"))),
+        };
+        let item = ProgramItem::Statement(Statement::for_in_statement(f));
+        assert_eq!(
+            emit_default(program().with_body(vec![item])).code,
+            "for(const k in obj){a}"
+        );
+    }
+
+    #[test]
+    fn for_in_expression_left_bare_body_emits() {
+        // `for (k in obj) a;` — existing-target left, bare-statement body.
+        let f = ForInStatement {
+            cv: None,
+            left: ForInit::Expression(ident("k")),
+            right: ident("obj"),
+            body: Box::new(Statement::expression_statement(ExpressionStatement {
+                cv: None,
+                expression: ident("a"),
+            })),
+        };
+        let item = ProgramItem::Statement(Statement::for_in_statement(f));
+        assert_eq!(
+            emit_default(program().with_body(vec![item])).code,
+            "for(k in obj)a;"
+        );
     }
 
     #[test]

--- a/code/packages/rust/closure-pass-constant-fold/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-constant-fold/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to the `coding-adventures-closure-pass-constant-fold` crate will be documented in this file.
 
+## [0.15.0] - 2026-06-20
+
+### Added — CLOC22: fold inside `for`-`in`
+
+`fold_tagged` now has a `ForInStatement` arm that recurses constant folding into
+the loop's left (declaration/expression), the enumerated right expression, and
+the body. Constant expressions inside a for-in body fold like anywhere else.
+
 ## [0.14.0] - 2026-06-20
 
 ### Added — CLOC21: handle `DebuggerStatement`

--- a/code/packages/rust/closure-pass-constant-fold/Cargo.toml
+++ b/code/packages/rust/closure-pass-constant-fold/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-constant-fold"
-version = "0.14.0"
+version = "0.15.0"
 edition = "2021"
 description = "Constant-folding optimization pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Folds compile-time-evaluable expressions like `2 + 3 → 5`."
 

--- a/code/packages/rust/closure-pass-constant-fold/src/lib.rs
+++ b/code/packages/rust/closure-pass-constant-fold/src/lib.rs
@@ -84,7 +84,8 @@ use coding_adventures_correlation_vector::{CVLog, Contribution};
 use coding_adventures_javascript_ast::{
     statement::TaggedStatement, ArrayExpression, AssignmentExpression, BinaryExpression,
     BinaryOperator, BlockStatement, BooleanLiteral, CallExpression, ConditionalExpression,
-    Declaration, Expression, ExpressionStatement, ForInit, ForStatement, FunctionDeclaration,
+    Declaration, Expression, ExpressionStatement, ForInStatement, ForInit, ForStatement,
+    FunctionDeclaration,
     IfStatement, LogicalExpression, LogicalOperator, MemberExpression, NullLiteral, NumericLiteral,
     ObjectExpression, Program, ProgramItem, Property, PropertyKey, ReturnStatement, Statement,
     StringLiteral, UnaryExpression, UnaryOperator, UndefinedLiteral, VariableDeclaration,
@@ -284,6 +285,17 @@ fn fold_tagged_statement(stmt: &TaggedStatement, st: &mut FoldState) -> TaggedSt
             }),
             test: s.test.as_ref().map(|e| fold_expression(e, st)),
             update: s.update.as_ref().map(|e| fold_expression(e, st)),
+            body: Box::new(fold_statement(&s.body, st)),
+        }),
+        TaggedStatement::ForInStatement(s) => TaggedStatement::ForInStatement(ForInStatement {
+            cv: s.cv.clone(),
+            left: match &s.left {
+                ForInit::VariableDeclaration(v) => {
+                    ForInit::VariableDeclaration(fold_variable_declaration(v, st))
+                }
+                ForInit::Expression(e) => ForInit::Expression(fold_expression(e, st)),
+            },
+            right: fold_expression(&s.right, st),
             body: Box::new(fold_statement(&s.body, st)),
         }),
         TaggedStatement::ReturnStatement(s) => TaggedStatement::ReturnStatement(ReturnStatement {

--- a/code/packages/rust/closure-pass-dce/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-dce/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to the `coding-adventures-closure-pass-dce` crate will be documented in this file.
 
+## [0.13.0] - 2026-06-20
+
+### Added — CLOC22: DCE inside `for`-`in`
+
+New `ForInStatement` arm recurses dead-code elimination into the loop's left,
+right expression, and body. Like the other loops, a for-in is NOT a terminator
+(the body may run zero times), so code after it stays reachable.
+
 ## [0.12.0] - 2026-06-20
 
 ### Added — CLOC21: handle `DebuggerStatement`

--- a/code/packages/rust/closure-pass-dce/Cargo.toml
+++ b/code/packages/rust/closure-pass-dce/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-dce"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 description = "Dead-code elimination pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Drops code after definite-terminator statements and removes EmptyStatement noise."
 

--- a/code/packages/rust/closure-pass-dce/src/lib.rs
+++ b/code/packages/rust/closure-pass-dce/src/lib.rs
@@ -72,7 +72,8 @@ use coding_adventures_correlation_vector::{CVLog, Contribution};
 use coding_adventures_javascript_ast::{
     statement::TaggedStatement, ArrayExpression, AssignmentExpression, BigIntLiteral,
     BinaryExpression, BlockStatement, BooleanLiteral, CallExpression, ConditionalExpression,
-    Declaration, EmptyStatement, Expression, ExpressionStatement, ForInit, ForStatement,
+    Declaration, EmptyStatement, Expression, ExpressionStatement, ForInStatement, ForInit,
+    ForStatement,
     FunctionDeclaration, IfStatement, LogicalExpression, MemberExpression, NullLiteral,
     NumericLiteral, ObjectExpression, Program, ProgramItem, Property, PropertyKey,
     ReturnStatement, Statement, StringLiteral, UnaryExpression, UndefinedLiteral, VarKind,
@@ -285,6 +286,20 @@ fn dce_tagged_statement(stmt: &TaggedStatement, st: &mut DceState) -> TaggedStat
             }),
             test: s.test.as_ref().map(|e| dce_expression(e, st)),
             update: s.update.as_ref().map(|e| dce_expression(e, st)),
+            body: Box::new(dce_statement(&s.body, st)),
+        }),
+        // Recurse DCE into the for-in left, right, and body. Like the other
+        // loops, a for-in is NOT a terminator (the body may run zero times),
+        // so code after it stays reachable.
+        TaggedStatement::ForInStatement(s) => TaggedStatement::ForInStatement(ForInStatement {
+            cv: s.cv.clone(),
+            left: match &s.left {
+                ForInit::VariableDeclaration(v) => {
+                    ForInit::VariableDeclaration(dce_variable_declaration(v, st))
+                }
+                ForInit::Expression(e) => ForInit::Expression(dce_expression(e, st)),
+            },
+            right: dce_expression(&s.right, st),
             body: Box::new(dce_statement(&s.body, st)),
         }),
         TaggedStatement::ReturnStatement(s) => {

--- a/code/packages/rust/closure-pass-fold-control-flow/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-fold-control-flow/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to the `coding-adventures-closure-pass-fold-control-flow` crate will be documented in this file.
 
+## [0.12.0] - 2026-06-20
+
+### Added — CLOC22: fold control flow inside `for`-`in`
+
+New `ForInStatement` arm recurses control-flow folding into the loop's left,
+right expression, and body. Like the other loops, a for-in is not eliminated and
+is not a terminator (the body may run zero times).
+
 ## [0.11.0] - 2026-06-20
 
 ### Added — CLOC21: handle `DebuggerStatement`

--- a/code/packages/rust/closure-pass-fold-control-flow/Cargo.toml
+++ b/code/packages/rust/closure-pass-fold-control-flow/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-fold-control-flow"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2021"
 description = "Control-flow folding pass for the Closure Compiler clone. Slots between constant-fold and DCE per CLOC06's canonical pass set. Eliminates dead branches (`if (false) A else B → B`), removes unreachable code after `return`/`throw`, and collapses degenerate switch arms."
 

--- a/code/packages/rust/closure-pass-fold-control-flow/src/lib.rs
+++ b/code/packages/rust/closure-pass-fold-control-flow/src/lib.rs
@@ -58,7 +58,8 @@ use coding_adventures_javascript_ast::{
     statement::TaggedStatement, ArrayExpression, AssignmentExpression, AssignmentOperator,
     AssignmentTarget, BinaryExpression, BindingTarget, BlockStatement, CallExpression,
     ConditionalExpression, Declaration, EmptyStatement, Expression, ExpressionStatement, ForInit,
-    ForStatement, FunctionDeclaration, Identifier, IfStatement, LogicalExpression, LogicalOperator,
+    ForInStatement, ForStatement, FunctionDeclaration, Identifier, IfStatement, LogicalExpression,
+    LogicalOperator,
     MemberExpression, ObjectExpression, Program, ProgramItem, Property, PropertyKey,
     ReturnStatement, Statement, UnaryExpression, UnaryOperator, VarKind, VariableDeclaration,
     DoWhileStatement, VariableDeclarator, WhileStatement,
@@ -238,6 +239,19 @@ fn fold_tagged_statement(stmt: &TaggedStatement, st: &mut FoldState) -> Statemen
                 }),
                 test: s.test.as_ref().map(|e| fold_expression(e, st)),
                 update: s.update.as_ref().map(|e| fold_expression(e, st)),
+                body: Box::new(fold_statement(&s.body, st)),
+            }))
+        }
+        TaggedStatement::ForInStatement(s) => {
+            Statement::Tagged(TaggedStatement::ForInStatement(ForInStatement {
+                cv: s.cv.clone(),
+                left: match &s.left {
+                    ForInit::VariableDeclaration(v) => {
+                        ForInit::VariableDeclaration(fold_variable_declaration(v, st))
+                    }
+                    ForInit::Expression(e) => ForInit::Expression(fold_expression(e, st)),
+                },
+                right: fold_expression(&s.right, st),
                 body: Box::new(fold_statement(&s.body, st)),
             }))
         }

--- a/code/packages/rust/closure-pass-inline-variables/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-inline-variables/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to the `coding-adventures-closure-pass-inline-variables` crate will be documented in this file.
 
+## [0.5.0] - 2026-06-20
+
+### Added — CLOC22: variable inlining inside `for`-`in`
+
+`count_decl_names_stmt`, `count_uses_stmt`, and `propagate_in_stmt` now recurse
+through `ForInStatement`. The for-in `left`, when a declaration, is counted as a
+binding (the loop variable), mirroring the for-statement init handling.
+
 ## [0.4.0] - 2026-06-20
 
 ### Added — CLOC21: handle `DebuggerStatement`

--- a/code/packages/rust/closure-pass-inline-variables/Cargo.toml
+++ b/code/packages/rust/closure-pass-inline-variables/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-inline-variables"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 description = "Constant-propagation pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Replaces references to a top-level `const` bound to a literal with the literal itself, so the binding becomes unused and remove-unused-vars deletes it."
 

--- a/code/packages/rust/closure-pass-inline-variables/src/lib.rs
+++ b/code/packages/rust/closure-pass-inline-variables/src/lib.rs
@@ -427,6 +427,13 @@ fn count_decl_names_stmt(
                 }
                 count_decl_names_stmt(&fs.body, out, nodes_touched);
             }
+            TaggedStatement::ForInStatement(fs) => {
+                // The for-in `left`, when a declaration, binds the loop variable.
+                if let ForInit::VariableDeclaration(vd) = &fs.left {
+                    count_decl_names_var(vd, out);
+                }
+                count_decl_names_stmt(&fs.body, out, nodes_touched);
+            }
             TaggedStatement::LabeledStatement(ls) => {
                 count_decl_names_stmt(&ls.body, out, nodes_touched)
             }
@@ -555,6 +562,20 @@ fn count_uses_stmt(stmt: &Statement, name: &str, count: &mut usize) {
                 if let Some(update) = &fs.update {
                     count_uses_expr(update, name, count);
                 }
+                count_uses_stmt(&fs.body, name, count);
+            }
+            TaggedStatement::ForInStatement(fs) => {
+                match &fs.left {
+                    ForInit::VariableDeclaration(vd) => {
+                        for d in &vd.declarations {
+                            if let Some(i) = &d.init {
+                                count_uses_expr(i, name, count);
+                            }
+                        }
+                    }
+                    ForInit::Expression(e) => count_uses_expr(e, name, count),
+                }
+                count_uses_expr(&fs.right, name, count);
                 count_uses_stmt(&fs.body, name, count);
             }
             TaggedStatement::ReturnStatement(rs) => {
@@ -762,6 +783,20 @@ fn propagate_in_stmt(stmt: &mut Statement, cand: &ConstCandidate) -> bool {
                 if let Some(update) = &mut fs.update {
                     changed |= propagate_in_expr(update, cand);
                 }
+                changed |= propagate_in_stmt(&mut fs.body, cand);
+            }
+            TaggedStatement::ForInStatement(fs) => {
+                match &mut fs.left {
+                    ForInit::VariableDeclaration(vd) => {
+                        for d in &mut vd.declarations {
+                            if let Some(i) = &mut d.init {
+                                changed |= propagate_in_expr(i, cand);
+                            }
+                        }
+                    }
+                    ForInit::Expression(e) => changed |= propagate_in_expr(e, cand),
+                }
+                changed |= propagate_in_expr(&mut fs.right, cand);
                 changed |= propagate_in_stmt(&mut fs.body, cand);
             }
             TaggedStatement::ReturnStatement(rs) => {

--- a/code/packages/rust/closure-pass-inline/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-inline/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to the `coding-adventures-closure-pass-inline` crate will be documented in this file.
 
+## [0.19.0] - 2026-06-20
+
+### Added — CLOC22: function inlining across `for`-`in`
+
+Every phase of the pass recurses through `ForInStatement` (left / right
+expression / body), mirroring the for-statement handling. The for-in `left`,
+when a declaration, is counted as a binding (the loop variable). Calls inside a
+for-in body are now inlined like anywhere else.
+
 ## [0.18.0] - 2026-06-20
 
 ### Added — CLOC21: handle `DebuggerStatement`

--- a/code/packages/rust/closure-pass-inline/Cargo.toml
+++ b/code/packages/rust/closure-pass-inline/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-inline"
-version = "0.18.0"
+version = "0.19.0"
 edition = "2021"
 description = "Function-inlining pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Substitutes small or single-use function bodies at their call sites to enable downstream folding and shrink call overhead."
 

--- a/code/packages/rust/closure-pass-inline/src/lib.rs
+++ b/code/packages/rust/closure-pass-inline/src/lib.rs
@@ -573,6 +573,13 @@ fn count_decl_names_stmt(
                 }
                 count_decl_names_stmt(&fs.body, out, nodes_touched);
             }
+            TaggedStatement::ForInStatement(fs) => {
+                // The for-in `left`, when a declaration, binds the loop variable.
+                if let ForInit::VariableDeclaration(vd) = &fs.left {
+                    count_decl_names_var(vd, out);
+                }
+                count_decl_names_stmt(&fs.body, out, nodes_touched);
+            }
             TaggedStatement::LabeledStatement(ls) => {
                 count_decl_names_stmt(&ls.body, out, nodes_touched)
             }
@@ -787,6 +794,20 @@ fn tally_stmt(stmt: &Statement, cand: &InlineCandidate, t: &mut Tally) {
                 if let Some(update) = &fs.update {
                     tally_expr(update, cand, t);
                 }
+                tally_stmt(&fs.body, cand, t);
+            }
+            TaggedStatement::ForInStatement(fs) => {
+                match &fs.left {
+                    ForInit::VariableDeclaration(vd) => {
+                        for d in &vd.declarations {
+                            if let Some(i) = &d.init {
+                                tally_expr(i, cand, t);
+                            }
+                        }
+                    }
+                    ForInit::Expression(e) => tally_expr(e, cand, t),
+                }
+                tally_expr(&fs.right, cand, t);
                 tally_stmt(&fs.body, cand, t);
             }
             TaggedStatement::ReturnStatement(rs) => {
@@ -1013,6 +1034,20 @@ fn inline_in_stmt(stmt: &mut Statement, cand: &InlineCandidate) -> bool {
                 if let Some(update) = &mut fs.update {
                     changed |= inline_in_expr(update, cand);
                 }
+                changed |= inline_in_stmt(&mut fs.body, cand);
+            }
+            TaggedStatement::ForInStatement(fs) => {
+                match &mut fs.left {
+                    ForInit::VariableDeclaration(vd) => {
+                        for d in &mut vd.declarations {
+                            if let Some(i) = &mut d.init {
+                                changed |= inline_in_expr(i, cand);
+                            }
+                        }
+                    }
+                    ForInit::Expression(e) => changed |= inline_in_expr(e, cand),
+                }
+                changed |= inline_in_expr(&mut fs.right, cand);
                 changed |= inline_in_stmt(&mut fs.body, cand);
             }
             TaggedStatement::ReturnStatement(rs) => {
@@ -1915,6 +1950,9 @@ fn splice_void_in_stmt(
             TaggedStatement::ForStatement(fs) => {
                 splice_void_in_slot(&mut fs.body, cand, avoid, nodes_touched)
             }
+            TaggedStatement::ForInStatement(fs) => {
+                splice_void_in_slot(&mut fs.body, cand, avoid, nodes_touched)
+            }
             TaggedStatement::LabeledStatement(ls) => {
                 splice_void_in_slot(&mut ls.body, cand, avoid, nodes_touched)
             }
@@ -2754,6 +2792,9 @@ fn splice_valued_in_stmt(
             TaggedStatement::ForStatement(fs) => {
                 splice_valued_in_stmt(&mut fs.body, cand, avoid, nodes_touched)
             }
+            TaggedStatement::ForInStatement(fs) => {
+                splice_valued_in_stmt(&mut fs.body, cand, avoid, nodes_touched)
+            }
             TaggedStatement::LabeledStatement(ls) => {
                 splice_valued_in_stmt(&mut ls.body, cand, avoid, nodes_touched)
             }
@@ -3062,6 +3103,20 @@ fn collect_used_idents_stmt(stmt: &Statement, out: &mut HashSet<String>) {
                 if let Some(update) = &fs.update {
                     collect_binding_idents_expr(update, out);
                 }
+                collect_used_idents_stmt(&fs.body, out);
+            }
+            TaggedStatement::ForInStatement(fs) => {
+                match &fs.left {
+                    ForInit::VariableDeclaration(vd) => {
+                        for d in &vd.declarations {
+                            if let Some(i) = &d.init {
+                                collect_binding_idents_expr(i, out);
+                            }
+                        }
+                    }
+                    ForInit::Expression(e) => collect_binding_idents_expr(e, out),
+                }
+                collect_binding_idents_expr(&fs.right, out);
                 collect_used_idents_stmt(&fs.body, out);
             }
             TaggedStatement::ReturnStatement(rs) => {

--- a/code/packages/rust/closure-pass-rename-globals/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-rename-globals/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to the `coding-adventures-closure-pass-rename-globals` crate will be documented in this file.
 
+## [0.5.0] - 2026-06-20
+
+### Added — CLOC22: global renaming across `for`-`in`
+
+`count_decl_names_stmt`, `collect_all_idents_stmt`, and `rename_apply_tagged`
+recurse through `ForInStatement` (left / right / body), mirroring the
+for-statement handling so the loop variable and uses inside the body rename
+consistently.
+
 ## [0.4.0] - 2026-06-20
 
 ### Added — CLOC21: handle `DebuggerStatement`

--- a/code/packages/rust/closure-pass-rename-globals/Cargo.toml
+++ b/code/packages/rust/closure-pass-rename-globals/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-rename-globals"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 description = "Aggressive top-level (global) renaming pass for the Closure Compiler clone — the ADVANCED-level complement to closure-pass-rename. Shortens program-private top-level names, gated by an externs do-not-rename boundary."
 

--- a/code/packages/rust/closure-pass-rename-globals/src/lib.rs
+++ b/code/packages/rust/closure-pass-rename-globals/src/lib.rs
@@ -352,6 +352,12 @@ fn count_decl_names_stmt(
                 }
                 count_decl_names_stmt(&fs.body, out, nodes_touched);
             }
+            TaggedStatement::ForInStatement(fs) => {
+                if let ForInit::VariableDeclaration(vd) = &fs.left {
+                    count_decl_names_var(vd, out);
+                }
+                count_decl_names_stmt(&fs.body, out, nodes_touched);
+            }
             TaggedStatement::LabeledStatement(ls) => {
                 count_decl_names_stmt(&ls.body, out, nodes_touched)
             }
@@ -480,6 +486,22 @@ fn collect_all_idents_stmt(stmt: &Statement, out: &mut HashSet<String>) {
                 if let Some(update) = &fs.update {
                     collect_all_idents_expr(update, out);
                 }
+                collect_all_idents_stmt(&fs.body, out);
+            }
+            TaggedStatement::ForInStatement(fs) => {
+                match &fs.left {
+                    ForInit::VariableDeclaration(vd) => {
+                        for d in &vd.declarations {
+                            let BindingTarget::Identifier(id) = &d.id;
+                            out.insert(id.name.clone());
+                            if let Some(i) = &d.init {
+                                collect_all_idents_expr(i, out);
+                            }
+                        }
+                    }
+                    ForInit::Expression(e) => collect_all_idents_expr(e, out),
+                }
+                collect_all_idents_expr(&fs.right, out);
                 collect_all_idents_stmt(&fs.body, out);
             }
             TaggedStatement::ReturnStatement(rs) => {
@@ -712,6 +734,24 @@ fn rename_apply_tagged(t: &mut TaggedStatement, map: &HashMap<String, String>) {
             if let Some(update) = &mut fs.update {
                 rename_apply_expr(update, map);
             }
+            rename_apply_stmt(&mut fs.body, map);
+        }
+        TaggedStatement::ForInStatement(fs) => {
+            match &mut fs.left {
+                ForInit::VariableDeclaration(vd) => {
+                    for d in &mut vd.declarations {
+                        let BindingTarget::Identifier(id) = &mut d.id;
+                        if let Some(new) = map.get(&id.name) {
+                            id.name = new.clone();
+                        }
+                        if let Some(i) = &mut d.init {
+                            rename_apply_expr(i, map);
+                        }
+                    }
+                }
+                ForInit::Expression(e) => rename_apply_expr(e, map),
+            }
+            rename_apply_expr(&mut fs.right, map);
             rename_apply_stmt(&mut fs.body, map);
         }
         TaggedStatement::ReturnStatement(rs) => {

--- a/code/packages/rust/closure-pass-rename-properties/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-rename-properties/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to the `coding-adventures-closure-pass-rename-properties` crate will be documented in this file.
 
+## [0.7.0] - 2026-06-20
+
+### Added — CLOC22: property renaming recurses through `for`-`in`
+
+`classify_stmt` and `rewrite_stmt` recurse through `ForInStatement` (left / right
+/ body) so property accesses inside a for-in loop — including `obj[key]` member
+reads in the body and the enumerated right-hand expression — are renamed
+consistently.
+
 ## [0.6.0] - 2026-06-20
 
 ### Added — CLOC21: handle `DebuggerStatement`

--- a/code/packages/rust/closure-pass-rename-properties/Cargo.toml
+++ b/code/packages/rust/closure-pass-rename-properties/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-rename-properties"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 description = "Aggressive property renaming pass for the Closure Compiler clone (ADVANCED-only). Consistently shortens program-private object property names that are never quoted/computed and not in the built-in or externs do-not-rename boundary."
 

--- a/code/packages/rust/closure-pass-rename-properties/src/lib.rs
+++ b/code/packages/rust/closure-pass-rename-properties/src/lib.rs
@@ -1028,6 +1028,20 @@ fn classify_stmt(stmt: &Statement, cls: &mut Classify, nodes_touched: &mut u32) 
                 }
                 classify_stmt(&fs.body, cls, nodes_touched);
             }
+            TaggedStatement::ForInStatement(fs) => {
+                match &fs.left {
+                    ForInit::VariableDeclaration(vd) => {
+                        for d in &vd.declarations {
+                            if let Some(i) = &d.init {
+                                classify_expr(i, cls);
+                            }
+                        }
+                    }
+                    ForInit::Expression(e) => classify_expr(e, cls),
+                }
+                classify_expr(&fs.right, cls);
+                classify_stmt(&fs.body, cls, nodes_touched);
+            }
             TaggedStatement::ReturnStatement(rs) => {
                 if let Some(a) = &rs.argument {
                     classify_expr(a, cls);
@@ -1224,6 +1238,20 @@ fn rewrite_stmt(stmt: &mut Statement, map: &HashMap<String, String>) {
                 if let Some(update) = &mut fs.update {
                     rewrite_expr(update, map);
                 }
+                rewrite_stmt(&mut fs.body, map);
+            }
+            TaggedStatement::ForInStatement(fs) => {
+                match &mut fs.left {
+                    ForInit::VariableDeclaration(vd) => {
+                        for d in &mut vd.declarations {
+                            if let Some(i) = &mut d.init {
+                                rewrite_expr(i, map);
+                            }
+                        }
+                    }
+                    ForInit::Expression(e) => rewrite_expr(e, map),
+                }
+                rewrite_expr(&mut fs.right, map);
                 rewrite_stmt(&mut fs.body, map);
             }
             TaggedStatement::ReturnStatement(rs) => {

--- a/code/packages/rust/closure-pass-rename/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-rename/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to the `coding-adventures-closure-pass-rename` crate will be documented in this file.
 
+## [0.8.0] - 2026-06-20
+
+### Added — CLOC22: local renaming across `for`-`in` (loop-variable soundness)
+
+Every phase of the pass recurses through `ForInStatement`. The crux is the loop
+variable: for `for (var/let/const k in o)` the `left` binding is a rename target
+treated exactly like a for-loop init binding — `collect_decl_occurrences_stmt`
+records it (block-scoped to the loop) and `rewrite_uses` rewrites the declared
+name via the rename map, so the binding and its uses inside the body rename
+*consistently*. The expression-left form (`for (k in o)`) has its assignment
+target rewritten as a use. Verified end-to-end: `for (var element in c)` →
+`for (var b in c)` with `c[element]` → `c[b]`.
+
 ## [0.7.0] - 2026-06-20
 
 ### Added — CLOC21: handle `DebuggerStatement`

--- a/code/packages/rust/closure-pass-rename/Cargo.toml
+++ b/code/packages/rust/closure-pass-rename/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-rename"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
 description = "Variable renaming pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Replaces non-exported binding names with shorter identifiers to reduce output size while preserving externally-visible names and semantics."
 

--- a/code/packages/rust/closure-pass-rename/src/lib.rs
+++ b/code/packages/rust/closure-pass-rename/src/lib.rs
@@ -277,6 +277,9 @@ fn process_tagged(t: &mut TaggedStatement, nodes_touched: &mut u32) -> bool {
         TaggedStatement::ForStatement(fs) => {
             changed |= process_stmt(&mut fs.body, nodes_touched);
         }
+        TaggedStatement::ForInStatement(fs) => {
+            changed |= process_stmt(&mut fs.body, nodes_touched);
+        }
         TaggedStatement::LabeledStatement(ls) => {
             changed |= process_stmt(&mut ls.body, nodes_touched);
         }
@@ -368,6 +371,7 @@ fn stmt_has_function(stmt: &Statement) -> bool {
             TaggedStatement::WhileStatement(ws) => stmt_has_function(&ws.body),
             TaggedStatement::DoWhileStatement(ds) => stmt_has_function(&ds.body),
             TaggedStatement::ForStatement(fs) => stmt_has_function(&fs.body),
+            TaggedStatement::ForInStatement(fs) => stmt_has_function(&fs.body),
             TaggedStatement::LabeledStatement(ls) => stmt_has_function(&ls.body),
             TaggedStatement::SwitchStatement(ss) => ss
                 .cases
@@ -588,6 +592,14 @@ fn collect_decl_occurrences_stmt(stmt: &Statement, out: &mut Vec<(String, bool)>
                 }
                 collect_decl_occurrences_stmt(&fs.body, out, true);
             }
+            TaggedStatement::ForInStatement(fs) => {
+                // The for-in `left` binding (`for (var/let/const k in o)`) is the
+                // loop variable — a rename target scoped to the loop.
+                if let ForInit::VariableDeclaration(vd) = &fs.left {
+                    push_var_occurrences(vd, out, true);
+                }
+                collect_decl_occurrences_stmt(&fs.body, out, true);
+            }
             // A label does not introduce a variable scope; keep `nested`.
             TaggedStatement::LabeledStatement(ls) => {
                 collect_decl_occurrences_stmt(&ls.body, out, nested)
@@ -716,6 +728,22 @@ fn collect_all_idents_stmt(stmt: &Statement, out: &mut HashSet<String>) {
                 if let Some(update) = &fs.update {
                     collect_all_idents_expr(update, out);
                 }
+                collect_all_idents_stmt(&fs.body, out);
+            }
+            TaggedStatement::ForInStatement(fs) => {
+                match &fs.left {
+                    ForInit::VariableDeclaration(vd) => {
+                        for d in &vd.declarations {
+                            let BindingTarget::Identifier(id) = &d.id;
+                            out.insert(id.name.clone());
+                            if let Some(i) = &d.init {
+                                collect_all_idents_expr(i, out);
+                            }
+                        }
+                    }
+                    ForInit::Expression(e) => collect_all_idents_expr(e, out),
+                }
+                collect_all_idents_expr(&fs.right, out);
                 collect_all_idents_stmt(&fs.body, out);
             }
             TaggedStatement::ReturnStatement(rs) => {
@@ -926,6 +954,27 @@ fn rewrite_uses_tagged(t: &mut TaggedStatement, map: &HashMap<String, String>) {
             if let Some(update) = &mut fs.update {
                 rewrite_uses_expr(update, map);
             }
+            rewrite_uses_stmt(&mut fs.body, map);
+        }
+        TaggedStatement::ForInStatement(fs) => {
+            // Rewrite the loop-variable binding name (for the declaration form)
+            // or the assignment-target uses (for the expression form), then the
+            // enumerated expression and the body.
+            match &mut fs.left {
+                ForInit::VariableDeclaration(vd) => {
+                    for d in &mut vd.declarations {
+                        let BindingTarget::Identifier(id) = &mut d.id;
+                        if let Some(new) = map.get(&id.name) {
+                            id.name = new.clone();
+                        }
+                        if let Some(i) = &mut d.init {
+                            rewrite_uses_expr(i, map);
+                        }
+                    }
+                }
+                ForInit::Expression(e) => rewrite_uses_expr(e, map),
+            }
+            rewrite_uses_expr(&mut fs.right, map);
             rewrite_uses_stmt(&mut fs.body, map);
         }
         TaggedStatement::ReturnStatement(rs) => {

--- a/code/packages/rust/closure-scope-analyzer/CHANGELOG.md
+++ b/code/packages/rust/closure-scope-analyzer/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to the `coding-adventures-closure-scope-analyzer` crate will be documented in this file.
 
+## [0.8.0] - 2026-06-20
+
+### Added — CLOC22: scope analysis for `for`-`in`
+
+`walk_tagged_statement` now handles `ForInStatement`: it walks the `left` (a
+variable declaration binding the loop variable, or an assignment-target
+expression), then the enumerated `right`, then the body.
+
 ## [0.7.0] - 2026-06-20
 
 ### Added — CLOC21: handle `DebuggerStatement`

--- a/code/packages/rust/closure-scope-analyzer/Cargo.toml
+++ b/code/packages/rust/closure-scope-analyzer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-scope-analyzer"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
 description = "Lexical scope + symbol-table analyzer for the Closure Compiler clone. Per CLOC13 — produces a `ScopeAnalysis` consumed by the rename, inline, treeshake, collapse-properties, and remove-unused-vars passes."
 

--- a/code/packages/rust/closure-scope-analyzer/src/lib.rs
+++ b/code/packages/rust/closure-scope-analyzer/src/lib.rs
@@ -640,6 +640,18 @@ fn walk_tagged_statement(
             }
             walk_statement(&fs.body, ctx, analysis, pending);
         }
+        TaggedStatement::ForInStatement(fs) => {
+            // The for-in `left` declares (or targets) the loop variable; walk
+            // it, then the enumerated `right`, then the body.
+            match &fs.left {
+                ForInit::VariableDeclaration(vd) => {
+                    walk_variable_declaration(vd, ctx, analysis, pending);
+                }
+                ForInit::Expression(e) => walk_expression(e, ctx, analysis, pending),
+            }
+            walk_expression(&fs.right, ctx, analysis, pending);
+            walk_statement(&fs.body, ctx, analysis, pending);
+        }
         TaggedStatement::ReturnStatement(rs) => {
             if let Some(arg) = &rs.argument {
                 walk_expression(arg, ctx, analysis, pending);

--- a/code/packages/rust/javascript-ast/CHANGELOG.md
+++ b/code/packages/rust/javascript-ast/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to the `coding-adventures-javascript-ast` crate will be documented in this file.
 
+## [0.11.0] - 2026-06-20
+
+### Added — CLOC22: `ForInStatement` (`for (left in right) body`)
+
+Adds `ForInStatement { cv, left: ForInit, right: Expression, body: Box<Statement> }`,
+a new `TaggedStatement::ForInStatement` variant, and a
+`Statement::for_in_statement` constructor. The `left` reuses [`ForInit`]:
+`VariableDeclaration` for `for (var/let/const k in o)` (a single-declarator
+binding, no initializer) and `Expression` for `for (k in o)` (an existing
+assignment target). ESTree wire format:
+`{ "type": "ForInStatement", "left": …, "right": <Expression>, "body": <Statement> }`.
+Making it representable lets the closurec CLI optimize for-in loops;
+previously any such program fell back to WHITESPACE_ONLY. (Destructuring
+left-hand sides are not represented — the bridge declines them.)
+
 ## [0.10.0] - 2026-06-20
 
 ### Added — CLOC21: `DebuggerStatement` (`debugger;`)

--- a/code/packages/rust/javascript-ast/Cargo.toml
+++ b/code/packages/rust/javascript-ast/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-javascript-ast"
-version = "0.10.0"
+version = "0.11.0"
 edition = "2021"
 description = "Backend-agnostic JavaScript AST — full ESTree-compatible node taxonomy with optional per-node CV id. Reusable by the Closure-Compiler-clone and the future V8-in-Rust clone. Per CLOC02 / CLOC09."
 

--- a/code/packages/rust/javascript-ast/src/lib.rs
+++ b/code/packages/rust/javascript-ast/src/lib.rs
@@ -141,9 +141,9 @@ pub use expression::{
 };
 pub use statement::{
     BlockStatement, BreakStatement, CatchClause, ContinueStatement, DebuggerStatement,
-    DoWhileStatement, EmptyStatement, ExpressionStatement, ForInit, ForStatement, IfStatement,
-    LabeledStatement, ReturnStatement, Statement, SwitchCase, SwitchStatement, ThrowStatement,
-    TryStatement, WhileStatement,
+    DoWhileStatement, EmptyStatement, ExpressionStatement, ForInStatement, ForInit, ForStatement,
+    IfStatement, LabeledStatement, ReturnStatement, Statement, SwitchCase, SwitchStatement,
+    ThrowStatement, TryStatement, WhileStatement,
 };
 
 /// A correlation-vector identifier. Aliased to `String` for v1 to match

--- a/code/packages/rust/javascript-ast/src/statement.rs
+++ b/code/packages/rust/javascript-ast/src/statement.rs
@@ -34,7 +34,10 @@
 //! - [`DebuggerStatement`] (CLOC21 — `debugger;`, the breakpoint hook;
 //!   unblocks the whitespace-only fallback on any program using it)
 //!
-//! Phase 2 will add `ForInStatement`, `ForOfStatement`, and `WithStatement`.
+//! - [`ForInStatement`] (CLOC22 — `for (left in right) body`, the
+//!   property-enumerating loop)
+//!
+//! Phase 2 will add `ForOfStatement` and `WithStatement`.
 
 use crate::declaration::{Declaration, VariableDeclaration};
 use crate::expression::{Expression, Identifier};
@@ -73,6 +76,7 @@ pub enum TaggedStatement {
     WhileStatement(WhileStatement),
     DoWhileStatement(DoWhileStatement),
     ForStatement(ForStatement),
+    ForInStatement(ForInStatement),
     ReturnStatement(ReturnStatement),
     BreakStatement(BreakStatement),
     ContinueStatement(ContinueStatement),
@@ -104,6 +108,9 @@ impl Statement {
     }
     pub fn for_statement(s: ForStatement) -> Self {
         Self::Tagged(TaggedStatement::ForStatement(s))
+    }
+    pub fn for_in_statement(s: ForInStatement) -> Self {
+        Self::Tagged(TaggedStatement::ForInStatement(s))
     }
     pub fn return_statement(s: ReturnStatement) -> Self {
         Self::Tagged(TaggedStatement::ReturnStatement(s))
@@ -223,6 +230,32 @@ pub struct ForStatement {
 pub enum ForInit {
     VariableDeclaration(VariableDeclaration),
     Expression(Expression),
+}
+
+/// `for (left in right) body` (CLOC22). The enumerating loop: `right` is
+/// evaluated once, and `body` runs with `left` bound to each enumerable
+/// property key in turn.
+///
+/// `left` reuses [`ForInit`]:
+/// - `ForInit::VariableDeclaration` for `for (var k in o)` / `for (let k in o)`
+///   / `for (const k in o)` — a single-declarator binding with no initializer.
+/// - `ForInit::Expression` for `for (k in o)` / `for (o.p in src)` — an
+///   existing assignment target.
+///
+/// (Destructuring left-hand sides are not represented; the bridge declines
+/// them, falling back to whitespace-only, which is sound.)
+///
+/// Like the other loops, a `for`-`in` is NOT a terminator — the loop body may
+/// run zero times (an object with no enumerable keys), so control can fall
+/// through and statements after it stay reachable.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ForInStatement {
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub cv: Option<CvId>,
+    pub left: ForInit,
+    pub right: Expression,
+    pub body: Box<Statement>,
 }
 
 /// `return;` or `return expr;`.
@@ -563,6 +596,52 @@ mod tests {
         });
         assert_eq!(s.clone(), roundtrip(s.clone()));
         assert_eq!(type_tag(&s), "ForStatement");
+    }
+
+    #[test]
+    fn for_in_statement_with_declaration_left_roundtrips() {
+        // for (var k in obj) {}
+        let s = Statement::for_in_statement(ForInStatement {
+            cv: Some("forin.1".to_string()),
+            left: ForInit::VariableDeclaration(VariableDeclaration {
+                cv: None,
+                kind: VarKind::Var,
+                declarations: vec![VariableDeclarator {
+                    cv: None,
+                    id: BindingTarget::Identifier(Identifier {
+                        cv: None,
+                        name: "k".to_string(),
+                    }),
+                    init: None,
+                }],
+            }),
+            right: Expression::Identifier(Identifier {
+                cv: None,
+                name: "obj".to_string(),
+            }),
+            body: Box::new(Statement::empty_statement(EmptyStatement { cv: None })),
+        });
+        assert_eq!(s.clone(), roundtrip(s.clone()));
+        assert_eq!(type_tag(&s), "ForInStatement");
+    }
+
+    #[test]
+    fn for_in_statement_with_expression_left_roundtrips() {
+        // for (k in obj) {}  — an existing assignment target as the left.
+        let s = Statement::for_in_statement(ForInStatement {
+            cv: None,
+            left: ForInit::Expression(Expression::Identifier(Identifier {
+                cv: None,
+                name: "k".to_string(),
+            })),
+            right: Expression::Identifier(Identifier {
+                cv: None,
+                name: "obj".to_string(),
+            }),
+            body: Box::new(Statement::empty_statement(EmptyStatement { cv: None })),
+        });
+        assert_eq!(s.clone(), roundtrip(s.clone()));
+        assert_eq!(type_tag(&s), "ForInStatement");
     }
 
     #[test]

--- a/code/packages/rust/javascript-parser/CHANGELOG.md
+++ b/code/packages/rust/javascript-parser/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to the `coding-adventures-javascript-parser` crate will be documented in this file.
 
+## [0.13.0] - 2026-06-20
+
+### Added — CLOC22: bridge `for_in_statement` → `ForInStatement`
+
+`for_in_statement` no longer lands in the unsupported arm. New
+`convert_for_in_statement` walks the children using the `in` and `)` tokens as
+phase delimiters (left / right-expression / body) and detects the
+`var`/`let`/`const` keyword to set the binding kind. The left binding reuses
+`convert_variable_declarator` (which already declines destructuring); any
+binding shape it can't represent is mapped to a graceful `UnsupportedSyntax`
+decline rather than a hard error, so an unrepresentable for-in left never aborts
+compilation. All four left forms (`var`/`let`/`const` and a left-hand-side
+expression) are covered; destructuring declines to WHITESPACE_ONLY.
+
 ## [0.12.0] - 2026-06-20
 
 ### Added — CLOC21: bridge `debugger_statement` → `DebuggerStatement`

--- a/code/packages/rust/javascript-parser/Cargo.toml
+++ b/code/packages/rust/javascript-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-javascript-parser"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 description = "JavaScript parser — parses JavaScript source code against any ECMAScript edition (es1 through es2025) using the grammar-driven parser. Includes correlation-vector plumbing per CLOC03 and a typed-AST bridge (GrammarASTNode → javascript_ast::Program) per CLOC12.136."
 

--- a/code/packages/rust/javascript-parser/src/bridge.rs
+++ b/code/packages/rust/javascript-parser/src/bridge.rs
@@ -62,9 +62,9 @@ use coding_adventures_javascript_ast::{
     },
     statement::{
         BlockStatement, BreakStatement, CatchClause, ContinueStatement, DebuggerStatement,
-        DoWhileStatement, EmptyStatement, ExpressionStatement, ForInit, ForStatement, IfStatement,
-        LabeledStatement, ReturnStatement, Statement, SwitchCase, SwitchStatement, ThrowStatement,
-        TryStatement, WhileStatement,
+        DoWhileStatement, EmptyStatement, ExpressionStatement, ForInStatement, ForInit,
+        ForStatement, IfStatement, LabeledStatement, ReturnStatement, Statement, SwitchCase,
+        SwitchStatement, ThrowStatement, TryStatement, WhileStatement,
     },
     Program, ProgramItem, SourceType,
 };
@@ -270,6 +270,7 @@ fn convert_statement(node: &GrammarASTNode) -> Result<Statement, BridgeError> {
             convert_do_while_statement(child).map(Statement::do_while_statement)
         }
         "for_statement" => convert_for_statement(child).map(Statement::for_statement),
+        "for_in_statement" => convert_for_in_statement(child).map(Statement::for_in_statement),
         "continue_statement" => convert_continue_statement(child).map(Statement::continue_statement),
         "break_statement" => convert_break_statement(child).map(Statement::break_statement),
         "return_statement" => convert_return_statement(child).map(Statement::return_statement),
@@ -281,7 +282,7 @@ fn convert_statement(node: &GrammarASTNode) -> Result<Statement, BridgeError> {
         // typed node is a bare marker. (CLOC21.)
         "debugger_statement" => Ok(Statement::debugger_statement(DebuggerStatement { cv: None })),
         // Phase 2+ — not yet in the typed AST
-        "for_in_statement" | "for_of_statement" | "for_await_of_statement" | "with_statement"
+        "for_of_statement" | "for_await_of_statement" | "with_statement"
         | "using_declaration" | "await_using_declaration" => Err(unsupported(child)),
         other => Err(BridgeError::InternalError {
             msg: format!("unknown statement child rule '{other}'"),
@@ -447,6 +448,78 @@ fn convert_for_statement(node: &GrammarASTNode) -> Result<ForStatement, BridgeEr
         test,
         update,
         body: Box::new(convert_statement(body)?),
+    })
+}
+
+fn convert_for_in_statement(node: &GrammarASTNode) -> Result<ForInStatement, BridgeError> {
+    // for_in_statement = "for" LPAREN
+    //   ( "var" variable_declaration | "let" binding_element
+    //   | "const" binding_element | left_hand_side_expression )
+    //   "in" expression RPAREN statement ;
+    //
+    // Walk children using the `in` and `)` tokens as phase delimiters:
+    //   phase 0 = the left (before `in`); phase 1 = the right expression
+    //   (between `in` and `)`); phase 2 = the body (after `)`). The
+    //   `var`/`let`/`const` keyword (if present) appears as a phase-0 token.
+    let mut phase = 0usize;
+    let mut left_kind: Option<VarKind> = None;
+    let mut phase_nodes: [Vec<&GrammarASTNode>; 3] = [vec![], vec![], vec![]];
+
+    for child in &node.children {
+        match child {
+            ASTNodeOrToken::Token(t) if phase == 0 && t.value == "in" => phase = 1,
+            ASTNodeOrToken::Token(t) if phase == 1 && t.value == ")" => phase = 2,
+            ASTNodeOrToken::Token(t) if phase == 0 => match t.value.as_str() {
+                "var" => left_kind = Some(VarKind::Var),
+                "let" => left_kind = Some(VarKind::Let),
+                "const" => left_kind = Some(VarKind::Const),
+                _ => {}
+            },
+            ASTNodeOrToken::Node(n) => phase_nodes[phase.min(2)].push(n),
+            ASTNodeOrToken::Token(_) => {}
+        }
+    }
+
+    // Left: a binding (var/let/const) or an existing assignment target.
+    let left_node = *phase_nodes[0]
+        .first()
+        .ok_or_else(|| internal(node, "for_in_statement: missing left"))?;
+    let left = match left_kind {
+        Some(kind) => {
+            // A single declarator with no initializer. `convert_variable_declarator`
+            // declines destructuring (`binding_pattern`) by returning
+            // `UnsupportedSyntax`. We additionally map any other conversion
+            // failure to a graceful decline (whitespace-only fallback) rather
+            // than a hard error, so an unrepresentable binding shape never
+            // aborts compilation.
+            let declarator = convert_variable_declarator(left_node)
+                .map_err(|_| unsupported(left_node))?;
+            ForInit::VariableDeclaration(VariableDeclaration {
+                cv: None,
+                kind,
+                declarations: vec![declarator],
+            })
+        }
+        None => ForInit::Expression(convert_expression(left_node)?),
+    };
+
+    // Right: the enumerated expression.
+    let right_node = *phase_nodes[1]
+        .first()
+        .ok_or_else(|| internal(node, "for_in_statement: missing right expression"))?;
+    let right = convert_expression(right_node)?;
+
+    // Body.
+    let body_node = *phase_nodes[2]
+        .first()
+        .ok_or_else(|| internal(node, "for_in_statement: missing body"))?;
+    let body = Box::new(convert_statement(body_node)?);
+
+    Ok(ForInStatement {
+        cv: None,
+        left,
+        right,
+        body,
     })
 }
 
@@ -2221,6 +2294,95 @@ mod tests {
             "expected a DebuggerStatement, got {:?}",
             p.body[0]
         );
+    }
+
+    /// Pull the single `ForInStatement` out of a one-statement program.
+    fn bridge_for_in(src: &str) -> ForInStatement {
+        let p = bridge_ok(src);
+        match &p.body[0] {
+            ProgramItem::Statement(Statement::Tagged(
+                coding_adventures_javascript_ast::statement::TaggedStatement::ForInStatement(f),
+            )) => f.clone(),
+            other => panic!("expected a ForInStatement, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn for_in_var_bridge_shape() {
+        // CLOC22: `for (var k in obj) { f(k); }` bridges to a ForInStatement
+        // whose left is a `var` declaration of a single binding `k`, right is
+        // the identifier `obj`, and body is the block.
+        let f = bridge_for_in("for (var k in obj) { f(k); }");
+        match &f.left {
+            ForInit::VariableDeclaration(v) => {
+                assert_eq!(v.kind, VarKind::Var);
+                assert_eq!(v.declarations.len(), 1);
+                assert!(v.declarations[0].init.is_none(), "for-in binding has no init");
+            }
+            other => panic!("expected a var declaration left, got {other:?}"),
+        }
+        assert!(
+            matches!(&f.right, Expression::Identifier(id) if id.name == "obj"),
+            "expected right = `obj`, got {:?}",
+            f.right
+        );
+        assert!(matches!(
+            f.body.as_ref(),
+            Statement::Tagged(
+                coding_adventures_javascript_ast::statement::TaggedStatement::BlockStatement(_)
+            )
+        ));
+    }
+
+    #[test]
+    fn for_in_lexical_binding_left_bridge_shape() {
+        // `for (let k in o)` and `for (const k in o)` bridge to a
+        // ForInStatement whose left is a Let/Const single-binding declaration.
+        for (src, want) in [
+            ("for (let k in o) { f(); }", VarKind::Let),
+            ("for (const k in o) { f(); }", VarKind::Const),
+        ] {
+            let f = bridge_for_in(src);
+            match &f.left {
+                ForInit::VariableDeclaration(v) => {
+                    assert_eq!(v.kind, want, "kind mismatch for {src}");
+                    assert_eq!(v.declarations.len(), 1);
+                    assert!(v.declarations[0].init.is_none());
+                }
+                other => panic!("expected a lexical declaration left for {src}, got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn for_in_expression_left_bridge_shape() {
+        // `for (k in obj) { f(k); }` — an existing assignment target as the
+        // left bridges to `ForInit::Expression`.
+        let f = bridge_for_in("for (k in obj) { f(k); }");
+        assert!(
+            matches!(&f.left, ForInit::Expression(Expression::Identifier(id)) if id.name == "k"),
+            "expected expression left `k`, got {:?}",
+            f.left
+        );
+    }
+
+    #[test]
+    fn for_in_destructuring_or_unrepresentable_left_does_not_hard_error() {
+        // A destructuring for-in left (`for (var [a] in o)`) — or any other
+        // left shape the declarator converter can't represent — must DECLINE
+        // gracefully (parse-error or UnsupportedSyntax → WHITESPACE_ONLY at the
+        // CLI), never hard-error or mis-bind. We assert only that bridging does
+        // not panic and that if a ForInStatement IS produced its left is a
+        // plain (non-destructuring) binding.
+        for src in [
+            "for (var [a] in o) { f(); }",
+            "for (let {a} in o) { f(); }",
+        ] {
+            let Ok(node) = parse_javascript_typed(src, DEFAULT_ES_VERSION) else {
+                continue; // parse declined — sound fallback
+            };
+            let _ = grammar_to_program(&node, DEFAULT_ES_VERSION); // must not panic
+        }
     }
 
     #[test]

--- a/code/programs/rust/closurec/CHANGELOG.md
+++ b/code/programs/rust/closurec/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 All notable changes to the `coding-adventures-closurec` binary will be documented in this file.
 
+## [0.155.0] - 2026-06-20
+
+### Added — CLOC22: end-to-end `for`-`in` support
+
+Programs containing a `for`-`in` loop now route through the full typed-AST
+optimization pipeline at both SIMPLE and ADVANCED levels. Previously any
+`for`-`in` made the parse/bridge step decline, and closurec silently fell back
+to WHITESPACE_ONLY (no real optimization). Now inlining, constant folding, DCE,
+and (under ADVANCED) local/global/property renaming all run inside the loop body
+and recurse into the enumerated expression. All four left forms are supported
+(`for (var/let/const k in o)` and `for (k in o)`); destructuring left-hand sides
+decline to WHITESPACE_ONLY. The loop variable renames consistently under
+ADVANCED (e.g. `for (var element in c)` with `c[element]` →
+`for (var b in c)` with `c[b]`).
+
+The end-to-end `simple-for-in` diff fixture pins the behaviour, with a
+regression guard that the output is NOT the whitespace fallback. The
+`simple_level_unsupported_syntax_degrades_gracefully` test now uses a `for`-`of`
+loop (still bridge-unsupported) for its example.
+
 ## [0.154.0] - 2026-06-20
 
 ### Added — CLOC21: `debugger;` no longer forces a WHITESPACE_ONLY fallback

--- a/code/programs/rust/closurec/Cargo.toml
+++ b/code/programs/rust/closurec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closurec"
-version = "0.154.0"
+version = "0.155.0"
 edition = "2021"
 description = "closurec — CLI driver for the Closure Compiler clone. Mirrors the upstream Java Closure Compiler's command-line flag surface (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility. Per CLOC08."
 

--- a/code/programs/rust/closurec/cli.spec.json
+++ b/code/programs/rust/closurec/cli.spec.json
@@ -2,7 +2,7 @@
   "cli_builder_spec_version": "1.0",
   "name": "closurec",
   "description": "closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.",
-  "version": "0.154.0",
+  "version": "0.155.0",
   "parsing_mode": "gnu",
   "flags": [
     { "id": "browser_featureset_year", "long": "browser_featureset_year", "type": "integer", "default": 0, "description": "Shortcut for defining goog.FEATURESET_YEAR=YYYY (minimum 2012)." },

--- a/code/programs/rust/closurec/src/run.rs
+++ b/code/programs/rust/closurec/src/run.rs
@@ -6490,11 +6490,12 @@ mod tests {
         let in_path = dir.join("in.js");
         let out_path = dir.join("out.js");
         let sidecar_path = dir.join("out.js.cv.json");
-        // for-in: the grammar parses it, but bridge::grammar_to_program
-        // returns UnsupportedSyntax (for_in_statement is still Phase 2+).
-        // (do-while is now supported as of CLOC20, so it no longer degrades;
-        // class declarations fail at the grammar parser level, not the bridge.)
-        fs::write(&in_path, "for (k in obj) { x(); }").expect("setup");
+        // for-of: the grammar parses it, but bridge::grammar_to_program
+        // returns UnsupportedSyntax (for_of_statement is still Phase 2+).
+        // (do-while is supported as of CLOC20 and for-in as of CLOC22, so
+        // neither degrades; class declarations fail at the grammar parser
+        // level, not the bridge.)
+        fs::write(&in_path, "for (k of arr) { x(); }").expect("setup");
         let cfg = CompilerConfig {
             io: IoConfig {
                 js_patterns: vec![in_path.to_string_lossy().to_string()],

--- a/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
@@ -2,7 +2,7 @@
 
 closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.
 
-Version: 0.154.0
+Version: 0.155.0
 
 ## Flags
 

--- a/code/programs/rust/closurec/tests/diff/simple-for-in/README.md
+++ b/code/programs/rust/closurec/tests/diff/simple-for-in/README.md
@@ -1,0 +1,33 @@
+# Fixture: `simple-for-in`
+
+End-to-end oracle for `--compilation_level SIMPLE` optimization through a
+`for`-`in` loop (CLOC22).
+
+| File | Role |
+|------|------|
+| `flags.txt` | CLI args: `--compilation_level SIMPLE --js input/a.js` |
+| `input/a.js` | A single-use function, plus a `for (var key in obj) { … }` whose body holds foldable arithmetic, followed by a statement after the loop |
+| `expected.stdout` | The optimized output (see below) |
+
+```text
+report(1);for(var key in obj){var x=3;use(key,x)}after();
+```
+
+What this proves now runs **through** a for-in loop — none of which was
+reachable before CLOC22 (any `for`-`in` forced a WHITESPACE_ONLY fallback):
+
+* **Inlining** — `log` is single-use, so `log(1)` becomes `report(1)` and the
+  declaration is deleted.
+* **Constant folding** — `1 + 2` ⇒ `3` even though it sits inside the loop body.
+* **Control-flow preservation** — `for (var key in obj) { … }` survives
+  verbatim, including the loop variable.
+* **Not a terminator** — `after()` after the loop stays reachable, because a
+  for-in body may run zero times.
+
+Regenerate the expected file after an intentional behavior change:
+
+```sh
+cargo run -- --compilation_level SIMPLE \
+    --js tests/diff/simple-for-in/input/a.js \
+    > tests/diff/simple-for-in/expected.stdout
+```

--- a/code/programs/rust/closurec/tests/diff/simple-for-in/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/simple-for-in/expected.stdout
@@ -1,0 +1,1 @@
+report(1);for(var key in obj){var x=3;use(key,x)}after();

--- a/code/programs/rust/closurec/tests/diff/simple-for-in/flags.txt
+++ b/code/programs/rust/closurec/tests/diff/simple-for-in/flags.txt
@@ -1,0 +1,4 @@
+--compilation_level
+SIMPLE
+--js
+tests/diff/simple-for-in/input/a.js

--- a/code/programs/rust/closurec/tests/diff/simple-for-in/input/a.js
+++ b/code/programs/rust/closurec/tests/diff/simple-for-in/input/a.js
@@ -1,0 +1,25 @@
+// SIMPLE-level optimization THROUGH a for-in loop (CLOC22).
+//
+// Before CLOC22, *any* program containing a `for`-`in` loop failed the
+// typed-AST parse (ForInStatement was unrepresentable) and closurec silently
+// fell back to WHITESPACE_ONLY — zero optimization. This fixture is the
+// end-to-end oracle proving the SIMPLE pipeline now runs every pass inside the
+// for-in body and recurses into its right-hand expression:
+//
+//   * `log` is single-use, so the inliner folds `log(1)` into its body
+//     `report(1)` and deletes the now-unused declaration.
+//   * `1 + 2` is constant-folded to `3` even though it lives inside the loop
+//     body.
+//   * The `for (var key in obj) { … }` survives verbatim — control flow and
+//     the loop variable are preserved.
+//   * `after()` AFTER the loop stays reachable: a for-in is not a terminator
+//     (the body may run zero times).
+function log(p) {
+  report(p);
+}
+log(1);
+for (var key in obj) {
+  var x = 1 + 2;
+  use(key, x);
+}
+after();

--- a/code/programs/rust/closurec/tests/diff_simple_for_in.rs
+++ b/code/programs/rust/closurec/tests/diff_simple_for_in.rs
@@ -1,0 +1,79 @@
+//! Integration test for the `tests/diff/simple-for-in/` fixture.
+//!
+//! Exercises `--compilation_level SIMPLE` optimization THROUGH a `for`-`in`
+//! loop (CLOC22). Before CLOC22, any program containing a for-in loop failed
+//! the typed-AST parse and closurec fell back to WHITESPACE_ONLY (zero
+//! optimization). This fixture is the end-to-end oracle proving every SIMPLE
+//! pass now runs inside the for-in body and recurses into its right-hand
+//! expression: `log(1)` is inlined to `report(1)`, `1 + 2` folds to `3`, the
+//! loop is preserved, and `after()` stays reachable.
+
+use std::process::Command;
+
+const BINARY: &str = env!("CARGO_BIN_EXE_closurec");
+
+fn read_flags() -> Vec<String> {
+    let raw =
+        std::fs::read_to_string("tests/diff/simple-for-in/flags.txt").expect("read flags.txt");
+    raw.lines()
+        .filter(|l| !l.is_empty())
+        .map(|s| s.to_string())
+        .collect()
+}
+
+#[test]
+fn simple_for_in_fixture_matches_expected_stdout() {
+    let flags = read_flags();
+    let out = Command::new(BINARY)
+        .args(&flags)
+        .output()
+        .expect("run closurec");
+
+    assert!(
+        out.status.success(),
+        "exit: {:?}, stderr: {}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stderr),
+    );
+
+    let actual = String::from_utf8_lossy(&out.stdout);
+    let expected = std::fs::read_to_string("tests/diff/simple-for-in/expected.stdout")
+        .expect("read expected.stdout");
+    assert_eq!(
+        actual.trim_end_matches('\n'),
+        expected.trim_end_matches('\n'),
+        "mismatch.\nflags: {flags:?}\nactual:\n{actual}\nexpected:\n{expected}",
+    );
+}
+
+/// Regression guard: the output must NOT be the WHITESPACE_ONLY fallback. If
+/// `for`-`in` ever stops being representable in the typed AST, the fixture
+/// above would still "pass" against a regenerated expected file, so we
+/// additionally assert that an optimization that can ONLY come from the typed
+/// pipeline (the `log` -> `report` inline) is present, the original
+/// `function log` declaration is gone, and the statement after the loop
+/// (`after()`) survives — proving a for-in is treated as non-terminating.
+#[test]
+fn simple_for_in_did_not_fall_back_to_whitespace_only() {
+    let out = Command::new(BINARY)
+        .args(read_flags())
+        .output()
+        .expect("run closurec");
+    let actual = String::from_utf8_lossy(&out.stdout);
+
+    assert!(
+        actual.contains("report(1)"),
+        "expected the single-use `log` to be inlined into `report(1)` \
+         (proving the typed pipeline ran, not the whitespace fallback); \
+         got:\n{actual}",
+    );
+    assert!(
+        !actual.contains("function log"),
+        "expected the inlined `log` declaration to be removed; got:\n{actual}",
+    );
+    assert!(
+        actual.contains("after()"),
+        "expected the statement after the for-in loop to remain reachable; \
+         got:\n{actual}",
+    );
+}

--- a/code/specs/CLOC22-for-in.md
+++ b/code/specs/CLOC22-for-in.md
@@ -1,0 +1,122 @@
+# CLOC22 — `for`-`in` end-to-end
+
+> **Status:** Shipped. AST node, parser bridge, emitter, scope analyzer, and
+> every optimization pass handle the `for`-`in` loop. An end-to-end diff fixture
+> (`simple-for-in`) pins the behaviour at the CLI.
+
+## Why this spec exists
+
+`for (left in right) body` enumerates the property keys of `right`. It was a
+Phase-2 statement gap. The grammar already *parsed* it, but the typed AST had no
+node to represent it, so the parser→typed-AST **bridge** declined
+(`UnsupportedSyntax`) and the CLI fell back to **`WHITESPACE_ONLY`** — applying
+zero real optimization to *any* program with a for-in loop (a very common
+construct). CLOC22 closes that gap with the established playbook: make the
+statement representable, then recurse every pass into it.
+
+```text
+source ──parse──▶ grammar AST ──bridge──▶ typed Program (ForInStatement)
+       ──passes──▶ optimized Program ──emit──▶ JS text
+```
+
+## The AST node (`coding-adventures-javascript-ast`)
+
+```rust
+pub struct ForInStatement {
+    pub cv: Option<CvId>,
+    pub left: ForInit,        // VariableDeclaration | Expression
+    pub right: Expression,
+    pub body: Box<Statement>,
+}
+```
+
+The `left` reuses [`ForInit`] (the for-loop init type), which is a perfect
+structural match:
+
+- `ForInit::VariableDeclaration` for `for (var k in o)` / `for (let k in o)` /
+  `for (const k in o)` — a single-declarator binding with no initializer.
+- `ForInit::Expression` for `for (k in o)` / `for (o.p in src)` — an existing
+  assignment target.
+
+Destructuring left-hand sides are **not** represented; the bridge declines them
+(see below).
+
+## The bridge (`coding-adventures-javascript-parser`)
+
+The grammar production is:
+
+```text
+for_in_statement = "for" "(" ( "var" variable_declaration
+                              | "let" binding_element
+                              | "const" binding_element
+                              | left_hand_side_expression ) "in" expression ")" statement
+```
+
+`convert_for_in_statement` walks the children using the `in` and `)` tokens as
+phase delimiters (phase 0 = left, phase 1 = right expression, phase 2 = body)
+and detects the `var`/`let`/`const` keyword (a phase-0 token) to set the binding
+kind. The left binding is converted with the shared `convert_variable_declarator`
+(which already declines destructuring `binding_pattern`). **Soundness guard:**
+any binding shape the declarator converter can't represent is mapped to a
+graceful `UnsupportedSyntax` decline rather than a hard error, so an
+unrepresentable for-in left never aborts compilation — it falls back to
+whitespace-only, which is sound.
+
+All four left forms are covered end-to-end (`var`/`let`/`const` and a
+left-hand-side expression); destructuring declines.
+
+## The emitter (`coding-adventures-closure-emitter`)
+
+`emit_for_in` writes `for ( <left> in <right> ) <body>`. The `in` keyword is
+separated on **both** sides with `required_ws`: the left ends in an identifier
+(`var k` / `k` / `o.p`) and the right starts with one, so `kin` / `inobj` would
+mis-lex. In the rare `a[b] in` / `in (x)` cases the space is one redundant byte
+but never wrong, matching upstream Closure's spacing around `in`.
+
+## Soundness: the loop variable is a binding
+
+The crux is that `for (var/let/const k in o)` declares the loop variable `k` — a
+binding the renaming passes must handle exactly like a for-loop init binding:
+
+- **`rename` / `rename-globals`**: the `left` declaration is recorded as a rename
+  occurrence (block-scoped to the loop) and the declared name is rewritten via
+  the rename map, so the binding **and its uses inside the body** rename
+  *consistently*. The expression-left form (`for (k in o)`) has its assignment
+  target rewritten as a use.
+- **`inline` / `inline-variables`**: the `left` declaration is counted as a
+  binding in the shadow-guard tallies.
+
+This is verified end-to-end: `for (var element in collection)` with
+`collection[element]` ⟶ `for (var c in a)` with `a[c]` under ADVANCED.
+
+Like the other loops, a `for`-`in` is **not** a terminator — the body may run
+zero times (an object with no enumerable keys), so control can fall through and
+statements after it stay reachable.
+
+### Per-pass handling
+
+| Pass | What it does for `ForInStatement` |
+|------|------------------------------------|
+| `constant-fold` / `fold-control-flow` | recurse fold into left / right / body (never elide) |
+| `dce` | recurse DCE into left / right / body; not a terminator |
+| `inline-variables` / `inline` | recurse; count the `left` declaration as a binding |
+| `rename` / `rename-globals` | recurse; rename the loop variable consistently |
+| `rename-properties` | recurse classify/rewrite into left / right / body |
+
+The scope analyzer (`closure-scope-analyzer`) walks the left (binding or target),
+the right, then the body.
+
+## End-to-end oracle (`closurec` diff fixture)
+
+* **`simple-for-in`** — at SIMPLE: a single-use function inlines, arithmetic
+  inside the for-in body folds, the loop survives verbatim, and the statement
+  after the loop stays reachable. A companion assertion proves the output is NOT
+  the whitespace fallback.
+
+## Out of scope (future work)
+
+* Destructuring for-in left-hand sides (`for (var [a] in o)`) — currently decline
+  to WHITESPACE_ONLY.
+* `ForOfStatement` (`for (x of iter)`) and `WithStatement` remain the last
+  bridge-unsupported Phase-2 statements. `for`-`of` is structurally almost
+  identical to `for`-`in` and is the natural next item.


### PR DESCRIPTION
## Summary

Adds first-class **`for (left in right) body`** support to closurec, so for-in loops no longer fall back to `WHITESPACE_ONLY` — the full SIMPLE/ADVANCED optimization pipeline now runs across them. This is the highest-value remaining Phase-2 statement (for-in is extremely common). Continues the run after do-while ([#6334](https://github.com/adhithyan15/coding-adventures/pull/6334)) and debugger ([#6343](https://github.com/adhithyan15/coding-adventures/pull/6343)).

```
function log(p){report(p);} log(1);
for (var key in obj) { var x = 1 + 2; use(key, x); }
after();
```
⟶ `report(1);for(var key in obj){var x=3;use(key,x)}after();`

(log inlined, `1+2` folded inside the loop body, loop preserved, `after()` reachable.)

## What changed (mirrors `ForStatement`)

| Layer | Change |
|-------|--------|
| `javascript-ast` | `ForInStatement { cv, left: ForInit, right, body }` — `left` reuses `ForInit` (`VariableDeclaration` \| `Expression`). |
| `javascript-parser` | `convert_for_in_statement` walks children using the `in`/`)` tokens as phase delimiters, detects `var`/`let`/`const`, reuses `convert_variable_declarator` (declines destructuring). Any unrepresentable left → graceful `UnsupportedSyntax` decline, **never** a hard error. |
| `closure-emitter` | `emit_for_in` → `for(<left> in <right>)<body>` with `in` spaced both sides (token separation). |
| `closure-scope-analyzer` + all 8 passes | Recurse into left/right/body. |

**All four left forms work** (`for (var/let/const k in o)` and `for (k in o)`); destructuring left-hand sides decline to whitespace-only.

## Soundness — the loop variable is a binding

For `for (var/let/const k in o)`, the `left` declares the loop variable. The rename passes treat it exactly like a for-loop init binding, so **`k` renames consistently** at its declaration and every body use:

`for (var element in collection)` with `collection[element]` ⟶ `for (var c in a)` with `a[c]` under ADVANCED.

The expression-left form `for (k in o)` is a **use only**, never counted as a declaration. for-in is **not** a terminator (the body may run zero times → code after stays reachable). An adversarial inline security review traced both rename passes and confirmed the declaration and uses can never diverge.

## Tests

- **javascript-ast**: serde round-trips (declaration + expression left).
- **javascript-parser**: four bridge-shape tests (`var`/`let`/`const`/expression left) + a destructuring-decline-doesn't-hard-error guard.
- **closure-emitter**: `var`/`const` declaration-left and expression-left (bare-body) tests.
- **closurec**: end-to-end `simple-for-in` diff fixture with a **whitespace-fallback regression guard**. The `simple_level_unsupported_syntax_degrades_gracefully` test now uses `for`-`of` (still bridge-unsupported).

Full closurec suite **726/726 green**; every touched pass crate green.

## Bookkeeping

Spec: `code/specs/CLOC22-for-in.md`. Version bumps + CHANGELOGs for all 13 touched crates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)