### PR TITLE
[codex] Add mesh release handoff execution work orders

### DIFF
--- a/code/packages/rust/smart-home-integration-catalog/CHANGELOG.md
+++ b/code/packages/rust/smart-home-integration-catalog/CHANGELOG.md
@@ -156,6 +156,8 @@ All notable changes to this package will be documented in this file.
   sequencing dispatch handoff packets into deterministic lane execution slots.
 - `IntegrationMeshReleaseTicketHandoffExecutionReadinessSummary` and helpers
   for combining handoff readiness with execution slot state.
+- `IntegrationMeshReleaseTicketHandoffExecutionWorkOrder` and summary helpers
+  for turning release handoff execution slots into lane-scoped work orders.
 - Primitive backlog planning helpers for ranking the shared primitive families
   needed by priority-bounded rollout waves.
 - Integration activation planning helpers for resolving virtual aliases,

--- a/code/packages/rust/smart-home-integration-catalog/README.md
+++ b/code/packages/rust/smart-home-integration-catalog/README.md
@@ -129,6 +129,8 @@ runtime and Chief of Staff tools a typed catalog for:
   packets into deterministic lane execution work
 - mesh release ticket handoff execution readiness summaries that combine
   handoff readiness with deterministic execution slot state
+- low-level mesh release ticket handoff execution work orders that turn
+  execution slots into lane-scoped operator work
 - primitive backlog planning for prioritizing the shared families needed by a
   rollout wave
 - activation plans that resolve direct integrations, virtual aliases, and

--- a/code/packages/rust/smart-home-integration-catalog/src/lib.rs
+++ b/code/packages/rust/smart-home-integration-catalog/src/lib.rs
@@ -7254,6 +7254,354 @@ impl IntegrationMeshReleaseTicketHandoffExecutionReadinessSummary {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IntegrationMeshReleaseTicketHandoffExecutionWorkOrder {
+    pub sequence: usize,
+    pub work_order_key: String,
+    pub execution_slot_key: String,
+    pub packet_key: String,
+    pub ticket_key: String,
+    pub dispatch_key: String,
+    pub task_key: String,
+    pub slot_key: String,
+    pub check_sequence: usize,
+    pub check_kind: IntegrationMeshReleaseReadinessCheckKind,
+    pub status: IntegrationMeshReleaseReadinessStatus,
+    pub package_kind: Option<IntegrationMeshReadinessHandoffKind>,
+    pub handoff_status: Option<IntegrationMeshReadinessHandoffStatus>,
+    pub handoff_lane: IntegrationMeshReleaseDispatchTicketHandoffLane,
+    pub ready: bool,
+    pub blocked: bool,
+    pub review_required: bool,
+    pub operator_required: bool,
+    pub dispatch_required: bool,
+    pub execution_required: bool,
+    pub packet_status: IntegrationMeshReleaseReadinessStatus,
+    pub execution_status: IntegrationMeshReleaseReadinessStatus,
+    pub release_dispatch_ready: bool,
+}
+
+impl IntegrationMeshReleaseTicketHandoffExecutionWorkOrder {
+    pub fn from_execution_slot(
+        sequence: usize,
+        execution_slot: &IntegrationMeshReleaseTicketHandoffExecutionSlot,
+    ) -> Self {
+        Self {
+            sequence,
+            work_order_key: format!(
+                "release-ticket-handoff-execution-work-order-{sequence:02}-{}-{}",
+                execution_slot.handoff_lane.as_str(),
+                execution_slot.check_kind.as_str()
+            ),
+            execution_slot_key: execution_slot.execution_slot_key.clone(),
+            packet_key: execution_slot.packet_key.clone(),
+            ticket_key: execution_slot.ticket_key.clone(),
+            dispatch_key: execution_slot.dispatch_key.clone(),
+            task_key: execution_slot.task_key.clone(),
+            slot_key: execution_slot.slot_key.clone(),
+            check_sequence: execution_slot.check_sequence,
+            check_kind: execution_slot.check_kind,
+            status: execution_slot.status,
+            package_kind: execution_slot.package_kind,
+            handoff_status: execution_slot.handoff_status,
+            handoff_lane: execution_slot.handoff_lane,
+            ready: execution_slot.ready(),
+            blocked: execution_slot.blocked(),
+            review_required: execution_slot.review_required(),
+            operator_required: execution_slot.operator_required(),
+            dispatch_required: execution_slot.dispatch_required(),
+            execution_required: execution_slot.execution_required(),
+            packet_status: execution_slot.packet_status,
+            execution_status: execution_slot.execution_status,
+            release_dispatch_ready: execution_slot.release_dispatch_ready,
+        }
+    }
+
+    pub fn ready(&self) -> bool {
+        self.ready
+    }
+
+    pub fn blocked(&self) -> bool {
+        self.blocked
+    }
+
+    pub fn review_required(&self) -> bool {
+        self.review_required
+    }
+
+    pub fn operator_required(&self) -> bool {
+        self.operator_required
+    }
+
+    pub fn dispatch_required(&self) -> bool {
+        self.dispatch_required
+    }
+
+    pub fn execution_required(&self) -> bool {
+        self.execution_required
+    }
+
+    pub fn is_release_lane(&self) -> bool {
+        self.handoff_lane == IntegrationMeshReleaseDispatchTicketHandoffLane::Release
+    }
+
+    pub fn is_operator_lane(&self) -> bool {
+        self.handoff_lane == IntegrationMeshReleaseDispatchTicketHandoffLane::Operator
+    }
+
+    pub fn is_repair_lane(&self) -> bool {
+        self.handoff_lane == IntegrationMeshReleaseDispatchTicketHandoffLane::Repair
+    }
+
+    pub fn is_review_lane(&self) -> bool {
+        self.handoff_lane == IntegrationMeshReleaseDispatchTicketHandoffLane::Review
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IntegrationMeshReleaseTicketHandoffExecutionWorkOrderSummary {
+    pub release_ticket_handoff_execution_readiness_summary:
+        IntegrationMeshReleaseTicketHandoffExecutionReadinessSummary,
+    pub total_work_orders: usize,
+    pub ready_work_orders: usize,
+    pub blocked_work_orders: usize,
+    pub review_required_work_orders: usize,
+    pub operator_required_work_orders: usize,
+    pub dispatch_required_work_orders: usize,
+    pub release_lane_work_orders: usize,
+    pub operator_lane_work_orders: usize,
+    pub repair_lane_work_orders: usize,
+    pub review_lane_work_orders: usize,
+    pub execution_required_work_orders: usize,
+    pub first_work_order_key: Option<String>,
+    pub first_release_work_order_key: Option<String>,
+    pub first_operator_work_order_key: Option<String>,
+    pub first_repair_work_order_key: Option<String>,
+    pub first_review_work_order_key: Option<String>,
+    pub next_work_order_key: Option<String>,
+    pub next_execution_slot_key: Option<String>,
+    pub next_packet_key: Option<String>,
+    pub next_ticket_key: Option<String>,
+    pub next_dispatch_key: Option<String>,
+    pub next_task_key: Option<String>,
+    pub next_slot_key: Option<String>,
+    pub next_check_kind: Option<IntegrationMeshReleaseReadinessCheckKind>,
+    pub next_check_status: Option<IntegrationMeshReleaseReadinessStatus>,
+    pub next_package_kind: Option<IntegrationMeshReadinessHandoffKind>,
+    pub next_handoff_status: Option<IntegrationMeshReadinessHandoffStatus>,
+    pub next_handoff_lane: Option<IntegrationMeshReleaseDispatchTicketHandoffLane>,
+    pub packet_status: IntegrationMeshReleaseReadinessStatus,
+    pub execution_status: IntegrationMeshReleaseReadinessStatus,
+    pub release_packet_ready: bool,
+    pub release_execution_ready: bool,
+    pub release_tasks_ready: bool,
+    pub release_dispatch_ready: bool,
+    pub release_ticket_ready: bool,
+    pub release_handoff_ready: bool,
+    pub release_handoff_execution_ready: bool,
+    pub release_ticket_handoff_execution_ready: bool,
+    pub release_handoff_execution_work_orders_ready: bool,
+}
+
+impl IntegrationMeshReleaseTicketHandoffExecutionWorkOrderSummary {
+    pub fn from_parts<'a>(
+        release_ticket_handoff_execution_readiness_summary: IntegrationMeshReleaseTicketHandoffExecutionReadinessSummary,
+        work_orders: impl IntoIterator<Item = &'a IntegrationMeshReleaseTicketHandoffExecutionWorkOrder>,
+    ) -> Self {
+        let work_orders = work_orders.into_iter().collect::<Vec<_>>();
+        let first_work_order = work_orders
+            .iter()
+            .min_by_key(|work_order| work_order.sequence);
+        let first_release_work_order = work_orders
+            .iter()
+            .filter(|work_order| work_order.is_release_lane())
+            .min_by_key(|work_order| work_order.sequence);
+        let first_operator_work_order = work_orders
+            .iter()
+            .filter(|work_order| work_order.is_operator_lane())
+            .min_by_key(|work_order| work_order.sequence);
+        let first_repair_work_order = work_orders
+            .iter()
+            .filter(|work_order| work_order.is_repair_lane())
+            .min_by_key(|work_order| work_order.sequence);
+        let first_review_work_order = work_orders
+            .iter()
+            .filter(|work_order| work_order.is_review_lane())
+            .min_by_key(|work_order| work_order.sequence);
+        let next_work_order = work_orders
+            .iter()
+            .filter(|work_order| work_order.execution_required())
+            .min_by_key(|work_order| work_order.sequence);
+        let release_handoff_execution_work_orders_ready =
+            release_ticket_handoff_execution_readiness_summary
+                .ready_for_release_ticket_handoff_execution()
+                && !work_orders.is_empty()
+                && work_orders
+                    .iter()
+                    .all(|work_order| work_order.ready() && work_order.is_release_lane());
+
+        Self {
+            total_work_orders: work_orders.len(),
+            ready_work_orders: work_orders
+                .iter()
+                .filter(|work_order| work_order.ready())
+                .count(),
+            blocked_work_orders: work_orders
+                .iter()
+                .filter(|work_order| work_order.blocked())
+                .count(),
+            review_required_work_orders: work_orders
+                .iter()
+                .filter(|work_order| work_order.review_required())
+                .count(),
+            operator_required_work_orders: work_orders
+                .iter()
+                .filter(|work_order| work_order.operator_required())
+                .count(),
+            dispatch_required_work_orders: work_orders
+                .iter()
+                .filter(|work_order| work_order.dispatch_required())
+                .count(),
+            release_lane_work_orders: work_orders
+                .iter()
+                .filter(|work_order| work_order.is_release_lane())
+                .count(),
+            operator_lane_work_orders: work_orders
+                .iter()
+                .filter(|work_order| work_order.is_operator_lane())
+                .count(),
+            repair_lane_work_orders: work_orders
+                .iter()
+                .filter(|work_order| work_order.is_repair_lane())
+                .count(),
+            review_lane_work_orders: work_orders
+                .iter()
+                .filter(|work_order| work_order.is_review_lane())
+                .count(),
+            execution_required_work_orders: work_orders
+                .iter()
+                .filter(|work_order| work_order.execution_required())
+                .count(),
+            first_work_order_key: first_work_order
+                .map(|work_order| work_order.work_order_key.clone()),
+            first_release_work_order_key: first_release_work_order
+                .map(|work_order| work_order.work_order_key.clone()),
+            first_operator_work_order_key: first_operator_work_order
+                .map(|work_order| work_order.work_order_key.clone()),
+            first_repair_work_order_key: first_repair_work_order
+                .map(|work_order| work_order.work_order_key.clone()),
+            first_review_work_order_key: first_review_work_order
+                .map(|work_order| work_order.work_order_key.clone()),
+            next_work_order_key: next_work_order
+                .map(|work_order| work_order.work_order_key.clone()),
+            next_execution_slot_key: next_work_order
+                .map(|work_order| work_order.execution_slot_key.clone()),
+            next_packet_key: next_work_order.map(|work_order| work_order.packet_key.clone()),
+            next_ticket_key: next_work_order.map(|work_order| work_order.ticket_key.clone()),
+            next_dispatch_key: next_work_order.map(|work_order| work_order.dispatch_key.clone()),
+            next_task_key: next_work_order.map(|work_order| work_order.task_key.clone()),
+            next_slot_key: next_work_order
+                .map(|work_order| work_order.slot_key.clone())
+                .or_else(|| {
+                    release_ticket_handoff_execution_readiness_summary
+                        .next_slot_key
+                        .clone()
+                }),
+            next_check_kind: next_work_order
+                .map(|work_order| work_order.check_kind)
+                .or(release_ticket_handoff_execution_readiness_summary.next_check_kind),
+            next_check_status: next_work_order
+                .map(|work_order| work_order.status)
+                .or(release_ticket_handoff_execution_readiness_summary.next_check_status),
+            next_package_kind: next_work_order
+                .and_then(|work_order| work_order.package_kind)
+                .or(release_ticket_handoff_execution_readiness_summary.next_package_kind),
+            next_handoff_status: next_work_order
+                .and_then(|work_order| work_order.handoff_status)
+                .or(release_ticket_handoff_execution_readiness_summary.next_handoff_status),
+            next_handoff_lane: next_work_order
+                .map(|work_order| work_order.handoff_lane)
+                .or(release_ticket_handoff_execution_readiness_summary.next_handoff_lane),
+            packet_status: release_ticket_handoff_execution_readiness_summary.packet_status,
+            execution_status: release_ticket_handoff_execution_readiness_summary.execution_status,
+            release_packet_ready: release_ticket_handoff_execution_readiness_summary
+                .release_packet_ready,
+            release_execution_ready: release_ticket_handoff_execution_readiness_summary
+                .release_execution_ready,
+            release_tasks_ready: release_ticket_handoff_execution_readiness_summary
+                .release_tasks_ready,
+            release_dispatch_ready: release_ticket_handoff_execution_readiness_summary
+                .release_dispatch_ready,
+            release_ticket_ready: release_ticket_handoff_execution_readiness_summary
+                .release_ticket_ready,
+            release_handoff_ready: release_ticket_handoff_execution_readiness_summary
+                .release_handoff_ready,
+            release_handoff_execution_ready: release_ticket_handoff_execution_readiness_summary
+                .release_handoff_execution_ready,
+            release_ticket_handoff_execution_ready:
+                release_ticket_handoff_execution_readiness_summary
+                    .release_ticket_handoff_execution_ready,
+            release_handoff_execution_work_orders_ready,
+            release_ticket_handoff_execution_readiness_summary,
+        }
+    }
+
+    pub fn has_work_orders(&self) -> bool {
+        self.total_work_orders > 0
+    }
+
+    pub fn ready_for_release_handoff_execution_work_orders(&self) -> bool {
+        self.execution_status == IntegrationMeshReleaseReadinessStatus::Ready
+            && self.release_packet_ready
+            && self.release_execution_ready
+            && self.release_tasks_ready
+            && self.release_dispatch_ready
+            && self.release_ticket_ready
+            && self.release_handoff_ready
+            && self.release_handoff_execution_ready
+            && self.release_ticket_handoff_execution_ready
+            && self.release_handoff_execution_work_orders_ready
+            && !self.requires_attention()
+    }
+
+    pub fn has_repair_work(&self) -> bool {
+        self.repair_lane_work_orders > 0
+    }
+
+    pub fn has_blockers(&self) -> bool {
+        self.blocked_work_orders > 0
+            || self.has_repair_work()
+            || self
+                .release_ticket_handoff_execution_readiness_summary
+                .has_blockers()
+    }
+
+    pub fn has_review_work(&self) -> bool {
+        self.review_required_work_orders > 0
+            || self.review_lane_work_orders > 0
+            || self
+                .release_ticket_handoff_execution_readiness_summary
+                .has_review_work()
+    }
+
+    pub fn needs_operator(&self) -> bool {
+        self.operator_required_work_orders > 0
+            || self.operator_lane_work_orders > 0
+            || self
+                .release_ticket_handoff_execution_readiness_summary
+                .needs_operator()
+    }
+
+    pub fn requires_attention(&self) -> bool {
+        self.execution_required_work_orders > 0
+            || self.dispatch_required_work_orders > 0
+            || self.has_blockers()
+            || self.has_review_work()
+            || self.needs_operator()
+            || !self.release_handoff_execution_work_orders_ready
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct IntegrationCatalogEntry {
     pub integration_id: IntegrationId,
     pub display_name: String,
@@ -28971,6 +29319,83 @@ pub fn mesh_release_ticket_handoff_execution_readiness_summary(
     )
 }
 
+pub fn mesh_release_ticket_handoff_execution_work_orders_for_catalog(
+    catalog: &[IntegrationCatalogEntry],
+    available_primitives: &[PrimitiveFamily],
+    allowed_capabilities: &[CapabilityId],
+    enabled_integrations: &[IntegrationId],
+) -> Vec<IntegrationMeshReleaseTicketHandoffExecutionWorkOrder> {
+    mesh_release_ticket_handoff_execution_slots_for_catalog(
+        catalog,
+        available_primitives,
+        allowed_capabilities,
+        enabled_integrations,
+    )
+    .iter()
+    .enumerate()
+    .map(|(index, execution_slot)| {
+        IntegrationMeshReleaseTicketHandoffExecutionWorkOrder::from_execution_slot(
+            index + 1,
+            execution_slot,
+        )
+    })
+    .collect()
+}
+
+pub fn mesh_release_ticket_handoff_execution_work_orders(
+    available_primitives: &[PrimitiveFamily],
+    allowed_capabilities: &[CapabilityId],
+    enabled_integrations: &[IntegrationId],
+) -> Vec<IntegrationMeshReleaseTicketHandoffExecutionWorkOrder> {
+    let catalog = first_party_catalog();
+    mesh_release_ticket_handoff_execution_work_orders_for_catalog(
+        &catalog,
+        available_primitives,
+        allowed_capabilities,
+        enabled_integrations,
+    )
+}
+
+pub fn mesh_release_ticket_handoff_execution_work_order_summary_for_catalog(
+    catalog: &[IntegrationCatalogEntry],
+    available_primitives: &[PrimitiveFamily],
+    allowed_capabilities: &[CapabilityId],
+    enabled_integrations: &[IntegrationId],
+) -> IntegrationMeshReleaseTicketHandoffExecutionWorkOrderSummary {
+    let release_ticket_handoff_execution_readiness_summary =
+        mesh_release_ticket_handoff_execution_readiness_summary_for_catalog(
+            catalog,
+            available_primitives,
+            allowed_capabilities,
+            enabled_integrations,
+        );
+    let work_orders = mesh_release_ticket_handoff_execution_work_orders_for_catalog(
+        catalog,
+        available_primitives,
+        allowed_capabilities,
+        enabled_integrations,
+    );
+
+    IntegrationMeshReleaseTicketHandoffExecutionWorkOrderSummary::from_parts(
+        release_ticket_handoff_execution_readiness_summary,
+        work_orders.iter(),
+    )
+}
+
+pub fn mesh_release_ticket_handoff_execution_work_order_summary(
+    available_primitives: &[PrimitiveFamily],
+    allowed_capabilities: &[CapabilityId],
+    enabled_integrations: &[IntegrationId],
+) -> IntegrationMeshReleaseTicketHandoffExecutionWorkOrderSummary {
+    let catalog = first_party_catalog();
+    mesh_release_ticket_handoff_execution_work_order_summary_for_catalog(
+        &catalog,
+        available_primitives,
+        allowed_capabilities,
+        enabled_integrations,
+    )
+}
+
 fn mesh_protocol_catalog_entries(
     catalog: &[IntegrationCatalogEntry],
 ) -> Vec<IntegrationCatalogEntry> {
@@ -40321,6 +40746,181 @@ mod tests {
         assert!(!summary.has_review_work());
         assert!(!summary.needs_operator());
         assert!(!summary.requires_attention());
+    }
+
+    #[test]
+    fn mesh_release_ticket_handoff_execution_work_orders_sequence_lane_work() {
+        let available_primitives = vec![
+            PrimitiveFamily::Usb,
+            PrimitiveFamily::SerialController,
+            PrimitiveFamily::Radio802154,
+            PrimitiveFamily::Supervision,
+        ];
+        let allowed_capabilities = vec![CapabilityId::trusted("smart_home.read")];
+        let work_orders = mesh_release_ticket_handoff_execution_work_orders(
+            &available_primitives,
+            &allowed_capabilities,
+            &[],
+        );
+        let summary = mesh_release_ticket_handoff_execution_work_order_summary(
+            &available_primitives,
+            &allowed_capabilities,
+            &[],
+        );
+
+        assert_eq!(work_orders.len(), 5);
+        assert_eq!(summary.total_work_orders, 5);
+        assert_eq!(summary.ready_work_orders, 0);
+        assert_eq!(summary.blocked_work_orders, 3);
+        assert_eq!(summary.review_required_work_orders, 2);
+        assert_eq!(summary.operator_required_work_orders, 4);
+        assert_eq!(summary.dispatch_required_work_orders, 5);
+        assert_eq!(summary.release_lane_work_orders, 0);
+        assert_eq!(summary.operator_lane_work_orders, 0);
+        assert_eq!(summary.repair_lane_work_orders, 3);
+        assert_eq!(summary.review_lane_work_orders, 2);
+        assert_eq!(summary.execution_required_work_orders, 5);
+        assert_eq!(
+            summary.first_work_order_key,
+            Some(
+                "release-ticket-handoff-execution-work-order-01-repair-substrate_actions"
+                    .to_string()
+            )
+        );
+        assert_eq!(
+            summary.first_repair_work_order_key,
+            Some(
+                "release-ticket-handoff-execution-work-order-01-repair-substrate_actions"
+                    .to_string()
+            )
+        );
+        assert_eq!(
+            summary.first_review_work_order_key,
+            Some(
+                "release-ticket-handoff-execution-work-order-02-review-evidence_remediation"
+                    .to_string()
+            )
+        );
+        assert_eq!(
+            summary.next_work_order_key,
+            Some(
+                "release-ticket-handoff-execution-work-order-01-repair-substrate_actions"
+                    .to_string()
+            )
+        );
+        assert_eq!(
+            summary.next_execution_slot_key,
+            Some("release-ticket-handoff-execution-slot-01-repair-substrate_actions".to_string())
+        );
+        assert_eq!(
+            summary.next_packet_key,
+            Some("release-dispatch-handoff-packet-01-substrate_actions".to_string())
+        );
+        assert_eq!(
+            summary.next_ticket_key,
+            Some("release-dispatch-ticket-01-substrate_actions".to_string())
+        );
+        assert_eq!(
+            summary.next_handoff_lane,
+            Some(IntegrationMeshReleaseDispatchTicketHandoffLane::Repair)
+        );
+        assert!(!summary.release_handoff_execution_work_orders_ready);
+        assert!(!summary.ready_for_release_handoff_execution_work_orders());
+        assert!(summary.has_work_orders());
+        assert!(summary.has_repair_work());
+        assert!(summary.has_blockers());
+        assert!(summary.has_review_work());
+        assert!(summary.needs_operator());
+        assert!(summary.requires_attention());
+
+        let first = &work_orders[0];
+        assert_eq!(
+            first.work_order_key,
+            "release-ticket-handoff-execution-work-order-01-repair-substrate_actions"
+        );
+        assert_eq!(
+            first.execution_slot_key,
+            "release-ticket-handoff-execution-slot-01-repair-substrate_actions"
+        );
+        assert_eq!(
+            first.handoff_lane,
+            IntegrationMeshReleaseDispatchTicketHandoffLane::Repair
+        );
+        assert!(first.blocked());
+        assert!(first.operator_required());
+        assert!(first.dispatch_required());
+        assert!(first.execution_required());
+    }
+
+    #[test]
+    fn mesh_release_ticket_handoff_execution_work_orders_mark_release_ready() {
+        let catalog = vec![hue_entry()];
+        let allowed_capabilities = vec![
+            CapabilityId::trusted("smart_home.read"),
+            CapabilityId::trusted("smart_home.command.light"),
+            CapabilityId::trusted("smart_home.pair"),
+        ];
+        let work_orders = mesh_release_ticket_handoff_execution_work_orders_for_catalog(
+            &catalog,
+            all_primitive_families(),
+            &allowed_capabilities,
+            &[],
+        );
+        let summary = mesh_release_ticket_handoff_execution_work_order_summary_for_catalog(
+            &catalog,
+            all_primitive_families(),
+            &allowed_capabilities,
+            &[],
+        );
+
+        assert_eq!(work_orders.len(), 5);
+        assert_eq!(summary.total_work_orders, 5);
+        assert_eq!(summary.ready_work_orders, 5);
+        assert_eq!(summary.blocked_work_orders, 0);
+        assert_eq!(summary.review_required_work_orders, 0);
+        assert_eq!(summary.operator_required_work_orders, 0);
+        assert_eq!(summary.dispatch_required_work_orders, 0);
+        assert_eq!(summary.release_lane_work_orders, 5);
+        assert_eq!(summary.operator_lane_work_orders, 0);
+        assert_eq!(summary.repair_lane_work_orders, 0);
+        assert_eq!(summary.review_lane_work_orders, 0);
+        assert_eq!(summary.execution_required_work_orders, 0);
+        assert_eq!(
+            summary.first_work_order_key,
+            Some(
+                "release-ticket-handoff-execution-work-order-01-release-substrate_actions"
+                    .to_string()
+            )
+        );
+        assert_eq!(
+            summary.first_release_work_order_key,
+            Some(
+                "release-ticket-handoff-execution-work-order-01-release-substrate_actions"
+                    .to_string()
+            )
+        );
+        assert_eq!(summary.first_operator_work_order_key, None);
+        assert_eq!(summary.first_repair_work_order_key, None);
+        assert_eq!(summary.first_review_work_order_key, None);
+        assert_eq!(summary.next_work_order_key, None);
+        assert_eq!(summary.next_execution_slot_key, None);
+        assert_eq!(summary.next_packet_key, None);
+        assert_eq!(summary.next_ticket_key, None);
+        assert_eq!(summary.next_handoff_lane, None);
+        assert!(summary.release_handoff_execution_work_orders_ready);
+        assert!(summary.ready_for_release_handoff_execution_work_orders());
+        assert!(summary.has_work_orders());
+        assert!(!summary.has_repair_work());
+        assert!(!summary.has_blockers());
+        assert!(!summary.has_review_work());
+        assert!(!summary.needs_operator());
+        assert!(!summary.requires_attention());
+        assert!(work_orders
+            .iter()
+            .all(IntegrationMeshReleaseTicketHandoffExecutionWorkOrder::ready));
+        assert!(work_orders
+            .iter()
+            .all(|work_order| work_order.is_release_lane() && !work_order.execution_required()));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add low-level mesh release ticket handoff execution work orders derived from execution slots
- expose first-party and custom catalog helpers plus a work-order summary surface
- document the new low-level work-order step in README and CHANGELOG

## Checks
- cargo test --manifest-path code\packages\rust\smart-home-integration-catalog\Cargo.toml
- cargo fmt --manifest-path code\packages\rust\smart-home-integration-catalog\Cargo.toml --check
- git diff --check
- cargo test --manifest-path code\packages\rust\smart-home-integration-catalog\Cargo.toml mesh_release_ticket_handoff_execution -- --nocapture