### PR TITLE
feat(r-26): R5 callSuper(), active bindings, multiple inheritance

### DIFF
--- a/code/packages/rust/r-runtime/CHANGELOG.md
+++ b/code/packages/rust/r-runtime/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.21.0] - 2026-06-20
+
+### Added (via the shared `s-runtime`)
+
+- **R-26 — R5 `callSuper()`, active bindings, and multiple inheritance**:
+  completes the R5 system through the shared evaluator (all logic in
+  `s-runtime/src/refclass.rs`; no grammar change). In R syntax:
+  - **`callSuper()`** — an overriding method re-uses its parent's same-named method:
+    `Sub <- setRefClass("Sub", contains = "Base", methods = list(describe =
+    function() paste(callSuper(), "sub")))` → `Sub$new()$describe()` is
+    `"base sub"`. Chains across levels (`C→B→A`), forwards args, runs against the
+    instance (can read/write fields), and returns `NULL` past the root.
+  - **Active bindings** — a function-valued field is a getter/setter:
+    `Temp <- setRefClass("Temp", fields = list(celsius = "numeric", fahrenheit =
+    function(v) { if (missing(v)) celsius*9/5+32 else celsius <<- (v-32)*5/9 }))`
+    → `t$fahrenheit` computes `212`; `t$fahrenheit <- 32` sets `t$celsius` to `0`.
+    Inherited and `$copy()`-independent.
+  - **Multiple inheritance** — `contains = c("A", "B")`: a `C` unions A's and B's
+    fields and methods (`o$fa()`, `o$fb()`), with left-to-right precedence;
+    `is`/`inherits`/`class` see every base; diamonds de-dup the shared ancestor;
+    mutual-inheritance cycles are rejected.
+  - 16 new R-syntax tests.
+
 ## [0.20.0] - 2026-06-20
 
 ### Added (via the shared `s-runtime`)

--- a/code/packages/rust/r-runtime/README.md
+++ b/code/packages/rust/r-runtime/README.md
@@ -114,8 +114,20 @@ same-named base method. `b <- a$copy()` is a **deep, independent** copy —
 aliases. `is(s, "Base")`, `inherits(s, "Base")`, and `class(s)` walk the class
 chain `c("Sub", "Base", "envRefClass", "environment")`; `Sub$fields()` and
 `Sub$methods()` return the sorted field/method names including inherited ones. A
-cyclic or unknown `contains =` is a clean error. Multiple inheritance and active
-bindings are deferred to R-26.
+cyclic or unknown `contains =` is a clean error.
+
+**R5 `callSuper()`, active bindings, and multiple inheritance (R-26)** — completes
+the R5 system. `callSuper()` inside an overriding method invokes the parent's
+same-named method (`Sub <- setRefClass("Sub", contains = "Base", methods =
+list(describe = function() paste(callSuper(), "sub")))` → `Sub$new()$describe()`
+is `"base sub"`); it chains across levels, forwards args, runs against the
+instance, and returns `NULL` past the root. A **function-valued field** is an
+**active binding** — a getter/setter: `fahrenheit = function(v) { if (missing(v))
+celsius*9/5+32 else celsius <<- (v-32)*5/9 }` makes `t$fahrenheit` compute and
+`t$fahrenheit <- 32` assign `t$celsius`; active bindings are inherited and
+`$copy()`-independent. **Multiple inheritance** `contains = c("A", "B")` unions A's
+and B's fields/methods (left-to-right precedence), with `is`/`inherits`/`class`
+seeing every base, diamonds de-duplicated, and mutual-inheritance cycles rejected.
 
 ## Usage
 

--- a/code/packages/rust/r-runtime/src/lib.rs
+++ b/code/packages/rust/r-runtime/src/lib.rs
@@ -2266,4 +2266,208 @@ mod tests {
             c1 <- Counter$new(n = 0)\nc1$bump_twice()\nc1$n\n";
         assert_eq!(nums(selfcall), vec![2.0]);
     }
+
+    // --------------------------------------------------------------------
+    // R-26 — R5 callSuper(), active bindings, multiple inheritance
+    // --------------------------------------------------------------------
+
+    #[test]
+    fn refclass_call_super_chains_to_base() {
+        // The headline callSuper() case: Sub$describe overrides Base$describe and
+        // re-uses it via callSuper().
+        let src = "Base <- setRefClass(\"Base\",\n  \
+            methods = list(describe = function() \"base\"))\n\
+            Sub <- setRefClass(\"Sub\", contains = \"Base\",\n  \
+            methods = list(describe = function() paste(callSuper(), \"sub\")))\n\
+            Sub$new()$describe()\n";
+        assert_eq!(show(src), "[1] \"base sub\"");
+    }
+
+    #[test]
+    fn refclass_call_super_forwards_args() {
+        // callSuper(x) forwards its evaluated argument to the parent method.
+        let src = "Base <- setRefClass(\"Base\",\n  \
+            methods = list(twice = function(x) x * 2))\n\
+            Sub <- setRefClass(\"Sub\", contains = \"Base\",\n  \
+            methods = list(twice = function(x) callSuper(x) + 1))\n\
+            Sub$new()$twice(10)\n";
+        assert_eq!(nums(src), vec![21.0]);
+    }
+
+    #[test]
+    fn refclass_call_super_three_levels() {
+        // C -> B -> A: each describe() chains one level up, walking to the root.
+        let src = "A <- setRefClass(\"A\",\n  \
+            methods = list(d = function() \"a\"))\n\
+            B <- setRefClass(\"B\", contains = \"A\",\n  \
+            methods = list(d = function() paste(callSuper(), \"b\")))\n\
+            C <- setRefClass(\"C\", contains = \"B\",\n  \
+            methods = list(d = function() paste(callSuper(), \"c\")))\n\
+            C$new()$d()\n";
+        assert_eq!(show(src), "[1] \"a b c\"");
+    }
+
+    #[test]
+    fn refclass_call_super_past_root_is_null() {
+        // A callSuper() in a root-class method (no parent definition) is a clean
+        // NULL — no recursion, no panic.
+        // `length(NULL)` is 0, so a past-root callSuper() yields length 0 (no error,
+        // no recursion).
+        let src = "Base <- setRefClass(\"Base\",\n  \
+            methods = list(f = function() length(callSuper())))\n\
+            Base$new()$f()\n";
+        assert_eq!(nums(src), vec![0.0]);
+    }
+
+    #[test]
+    fn refclass_call_super_can_mutate_via_field() {
+        // The super method runs against the instance, so it can read/write fields.
+        let src = "Base <- setRefClass(\"Base\",\n  \
+            fields = list(n = \"numeric\"),\n  \
+            methods = list(bump = function() { n <<- n + 1 }))\n\
+            Sub <- setRefClass(\"Sub\", contains = \"Base\",\n  \
+            methods = list(bump = function() { callSuper(); n <<- n + 10 }))\n\
+            s <- Sub$new(n = 0)\ns$bump()\ns$n\n";
+        assert_eq!(nums(src), vec![11.0]);
+    }
+
+    #[test]
+    fn refclass_active_binding_getter() {
+        // Reading t$fahrenheit calls the getter (missing(v) TRUE branch).
+        let src = "Temp <- setRefClass(\"Temp\",\n  \
+            fields = list(celsius = \"numeric\",\n    \
+            fahrenheit = function(v) { if (missing(v)) celsius * 9 / 5 + 32 else celsius <<- (v - 32) * 5 / 9 }))\n\
+            t <- Temp$new(celsius = 100)\nt$fahrenheit\n";
+        assert_eq!(nums(src), vec![212.0]);
+    }
+
+    #[test]
+    fn refclass_active_binding_setter() {
+        // Assigning to t$fahrenheit calls the setter (missing(v) FALSE branch),
+        // which writes the celsius field.
+        let src = "Temp <- setRefClass(\"Temp\",\n  \
+            fields = list(celsius = \"numeric\",\n    \
+            fahrenheit = function(v) { if (missing(v)) celsius * 9 / 5 + 32 else celsius <<- (v - 32) * 5 / 9 }))\n\
+            t <- Temp$new(celsius = 100)\nt$fahrenheit <- 32\nt$celsius\n";
+        assert_eq!(nums(src), vec![0.0]);
+    }
+
+    #[test]
+    fn refclass_active_binding_roundtrip() {
+        // Set then get should be consistent.
+        let src = "Temp <- setRefClass(\"Temp\",\n  \
+            fields = list(celsius = \"numeric\",\n    \
+            fahrenheit = function(v) { if (missing(v)) celsius * 9 / 5 + 32 else celsius <<- (v - 32) * 5 / 9 }))\n\
+            t <- Temp$new(celsius = 0)\nt$fahrenheit <- 212\nc(t$celsius, t$fahrenheit)\n";
+        assert_eq!(nums(src), vec![100.0, 212.0]);
+    }
+
+    #[test]
+    fn refclass_active_binding_inherited() {
+        // An active binding declared on a base class works on a Sub instance.
+        let src = "Base <- setRefClass(\"Base\",\n  \
+            fields = list(celsius = \"numeric\",\n    \
+            fahrenheit = function(v) { if (missing(v)) celsius * 9 / 5 + 32 else celsius <<- (v - 32) * 5 / 9 }))\n\
+            Sub <- setRefClass(\"Sub\", contains = \"Base\")\n\
+            s <- Sub$new(celsius = 100)\ns$fahrenheit\n";
+        assert_eq!(nums(src), vec![212.0]);
+    }
+
+    #[test]
+    fn refclass_active_binding_copy_is_independent() {
+        // $copy() re-homes the active binding onto the copy; mutating the copy's
+        // binding must not touch the original.
+        let src = "Temp <- setRefClass(\"Temp\",\n  \
+            fields = list(celsius = \"numeric\",\n    \
+            fahrenheit = function(v) { if (missing(v)) celsius * 9 / 5 + 32 else celsius <<- (v - 32) * 5 / 9 }))\n\
+            a <- Temp$new(celsius = 100)\nb <- a$copy()\nb$fahrenheit <- 32\nc(a$celsius, b$celsius)\n";
+        assert_eq!(nums(src), vec![100.0, 0.0]);
+    }
+
+    #[test]
+    fn refclass_multiple_inheritance_unions_methods() {
+        // contains = c("A", "B"): C unions A's and B's fields and methods.
+        let src = "A <- setRefClass(\"A\", fields = list(a = \"numeric\"),\n  \
+            methods = list(fa = function() a))\n\
+            B <- setRefClass(\"B\", fields = list(b = \"numeric\"),\n  \
+            methods = list(fb = function() b))\n\
+            C <- setRefClass(\"C\", contains = c(\"A\", \"B\"))\n\
+            o <- C$new(a = 1, b = 2)\nc(o$fa(), o$fb())\n";
+        assert_eq!(nums(src), vec![1.0, 2.0]);
+    }
+
+    #[test]
+    fn refclass_multiple_inheritance_left_to_right_precedence() {
+        // Both A and B define `who`; left-to-right precedence means A wins.
+        let src = "A <- setRefClass(\"A\", methods = list(who = function() \"A\"))\n\
+            B <- setRefClass(\"B\", methods = list(who = function() \"B\"))\n\
+            C <- setRefClass(\"C\", contains = c(\"A\", \"B\"))\n\
+            C$new()$who()\n";
+        assert_eq!(show(src), "[1] \"A\"");
+    }
+
+    #[test]
+    fn refclass_multiple_inheritance_is_and_inherits() {
+        // C is an A and a B.
+        let src = "A <- setRefClass(\"A\")\nB <- setRefClass(\"B\")\n\
+            C <- setRefClass(\"C\", contains = c(\"A\", \"B\"))\n\
+            o <- C$new()\nc(is(o, \"A\"), is(o, \"B\"), inherits(o, \"C\"))\n";
+        assert_eq!(show(src), "[1] TRUE TRUE TRUE");
+    }
+
+    #[test]
+    fn refclass_multiple_inheritance_diamond_dedups() {
+        // Z is a common base of A and B; the DFS linearization lists it once.
+        let src = "Z <- setRefClass(\"Z\", fields = list(z = \"numeric\"),\n  \
+            methods = list(fz = function() z))\n\
+            A <- setRefClass(\"A\", contains = \"Z\")\n\
+            B <- setRefClass(\"B\", contains = \"Z\")\n\
+            C <- setRefClass(\"C\", contains = c(\"A\", \"B\"))\n\
+            o <- C$new(z = 7)\no$fz()\n";
+        assert_eq!(nums(src), vec![7.0]);
+    }
+
+    #[test]
+    fn refclass_multiple_inheritance_class_chain() {
+        let src = "A <- setRefClass(\"A\")\nB <- setRefClass(\"B\")\n\
+            C <- setRefClass(\"C\", contains = c(\"A\", \"B\"))\n\
+            class(C$new())\n";
+        assert_eq!(
+            show(src),
+            "[1]           \"C\"           \"A\"           \"B\" \"envRefClass\" \"environment\""
+        );
+    }
+
+    #[test]
+    fn refclass_multiple_inheritance_cycle_rejected() {
+        // A contains B, then making B contain A across multiple parents is a cycle.
+        let src = "A <- setRefClass(\"A\")\n\
+            B <- setRefClass(\"B\", contains = \"A\")\n\
+            A2 <- setRefClass(\"A\", contains = c(\"B\", \"A\"))\n";
+        assert!(eval_r(src).is_err());
+    }
+
+    #[test]
+    fn refclass_missing_outside_method_reports_unbound() {
+        // missing(x) is a faithful subset: TRUE when the formal was not supplied.
+        let src = "f <- function(x) missing(x)\nc(f(), f(5))\n";
+        assert_eq!(show(src), "[1]  TRUE FALSE");
+    }
+
+    #[test]
+    fn refclass_r24_r25_regressions_still_hold() {
+        // Single inheritance + override + $copy still work after the R-26 refactor.
+        let src = "Base <- setRefClass(\"Base\",\n  \
+            fields = list(x = \"numeric\"),\n  \
+            methods = list(get = function() x, label = function() \"base\"))\n\
+            Sub <- setRefClass(\"Sub\", contains = \"Base\",\n  \
+            methods = list(label = function() \"sub\"))\n\
+            s <- Sub$new(x = 3)\nc(s$get(), if (s$label() == \"sub\") 1 else 0)\n";
+        assert_eq!(nums(src), vec![3.0, 1.0]);
+        // Alias still shares; copy is independent.
+        let src2 = "Base <- setRefClass(\"Base\", fields = list(x = \"numeric\"),\n  \
+            methods = list(set = function(v) { x <<- v }))\n\
+            a <- Base$new(x = 1)\nb <- a\nb$set(9)\nd <- a$copy()\nd$set(100)\nc(a$x, d$x)\n";
+        assert_eq!(nums(src2), vec![9.0, 100.0]);
+    }
 }

--- a/code/packages/rust/s-runtime/CHANGELOG.md
+++ b/code/packages/rust/s-runtime/CHANGELOG.md
@@ -2,6 +2,46 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.22.0] - 2026-06-20
+
+### Added
+
+- **R5 `callSuper()`, active bindings, and multiple inheritance (R-26)** —
+  completes the R5 reference-class system on R-24/R-25's `src/refclass.rs`
+  generator/instance model; grammar-free.
+  - **`callSuper(...)`** — inside an overriding method, invoke the **same-named**
+    parent method. `rebuild_method` now materialises each instance-bound method
+    inside a thin **super-context** scope (parent = the instance) that records two
+    private markers: `.refSuperGens` (the parent generators of the class that
+    *defined* the running method version, where same-name resolution restarts) and
+    `.refMethodName`. `callSuper` is a new lazy special form: it reads those markers
+    from the current env, resolves the method starting at the super generators,
+    re-homes it onto the instance with a *fresh* super-context one level further up
+    (so chained `callSuper()` walks `C→B→A`), and applies it to the forwarded args.
+    **Past-the-root** (no parent definition) returns `NULL` — no recursion, no panic.
+  - **Active bindings** — a `fields = list(ab = function(v) …)` entry whose value is
+    a closure is an **active binding**: reading `obj$ab` **calls** it as a nullary
+    getter (`missing(v)` TRUE); `obj$ab <- val` **calls** it as a setter (`v` bound,
+    `missing(v)` FALSE). The function is re-homed onto each instance (so it reads
+    sibling fields and writes them with `<<-`); `$new`/`$copy` install it per
+    instance (the copy gets its *own* re-homed binding, never the source's). New
+    `missing(x)` special form reports whether a formal was supplied in the current
+    frame. Getter/setter run through the depth-bounded call path, so a
+    self-referential getter hits `MAX_EVAL_DEPTH` cleanly rather than borrow-panicking
+    or hanging.
+  - **Multiple inheritance** — `contains = c("A", "B")`. The single `.refParent`
+    link becomes a `.refParents` **list**; a new `linearization` does a left-to-right
+    **depth-first** pre-order walk (de-duping shared ancestors, so a diamond's base
+    appears once) that all the effective-field/method/class-chain computations and
+    the cycle check now consult. Method/field precedence is most-derived-first,
+    left-to-right (own ⊳ A ⊳ B ⊳ ancestors). C3 is **not** implemented (documented
+    simple DFS). The name-in-ancestry cycle check runs over **every** listed parent,
+    so the multi-parent graph stays a DAG; all walks bounded by `MAX_CHAIN_DEPTH`.
+  - **Rc-cycle / re-entrancy safety.** All new edges (`.refParents`, the
+    super-context's parent-to-instance link, an active binding's instance-homed
+    closure) are DAG/lazy edges; no new at-rest instance⇄method or generator cycle.
+    16 new R-syntax tests (in `r-runtime`).
+
 ## [0.21.0] - 2026-06-20
 
 ### Added

--- a/code/packages/rust/s-runtime/README.md
+++ b/code/packages/rust/s-runtime/README.md
@@ -149,7 +149,21 @@ a hand-written loop. See [What "S-flavored" means here](#what-s-flavored-means-h
   "Base")` / `class(obj)` walk the class chain `c("Sub", "Base", …, "envRefClass",
   "environment")`; `generator$fields()` / `generator$methods()` return the sorted
   effective names. A cyclic `contains =` is rejected; all chain walks are bounded by
-  `MAX_CHAIN_DEPTH`. Multiple inheritance and active bindings are deferred to R-26.
+  `MAX_CHAIN_DEPTH`.
+- **R5 `callSuper()`, active bindings, and multiple inheritance** (R-26,
+  `src/refclass.rs`): `callSuper()` (a lazy special form) invokes the parent's
+  same-named method — each instance-bound method is materialised inside a
+  **super-context** scope recording `.refSuperGens`/`.refMethodName`, so the call
+  resolves the same name starting one level up and chains to the root (past-the-root
+  is a clean `NULL`). A **function-valued field** is an **active binding**: `obj$ab`
+  calls a nullary getter, `obj$ab <- v` calls a setter (`v` bound), distinguished by
+  the new `missing(x)` special form; the binding is re-homed per instance (so a
+  `$copy()` is independent) and runs through the depth-bounded call path (a
+  self-referential getter errors at `MAX_EVAL_DEPTH`, never borrow-panics). **Multiple
+  inheritance** `contains = c("A", "B")` stores a `.refParents` list; a left-to-right
+  DFS `linearization` (de-duping diamonds; C3 not implemented) drives all
+  effective-set/class-chain walks with most-derived-first precedence, and the cycle
+  check runs over every parent so the multi-parent graph stays a DAG.
 - The **`d`/`p`/`q`/`r` distribution family** (R-8) over `statistics-core`:
   density/CDF/quantile/sampling for the normal, uniform, and exponential
   distributions, plus `set.seed` for a reproducible per-session RNG.

--- a/code/packages/rust/s-runtime/src/eval.rs
+++ b/code/packages/rust/s-runtime/src/eval.rs
@@ -536,6 +536,23 @@ impl Interpreter {
         let target = self.eval_node(primary, env)?;
         match target {
             SValue::Environment(e) => {
+                // R-26 active binding: `obj$ab <- val` **calls** the binding function
+                // as a setter with `v = val` (so `missing(v)` is FALSE inside it),
+                // rather than overwriting the binding. Invoked through the ordinary
+                // depth-bounded call path (same re-entrancy / borrow protection as the
+                // getter). The assignment expression's value is the RHS (invisible).
+                if let Some(setter) = crate::refclass::active_binding_fn(&e, &field) {
+                    // Passed **positionally** so it binds the setter's single formal
+                    // whatever it is named (`function(v)`, `function(value)`, …); that
+                    // formal then tests FALSE under `missing()`, distinguishing the
+                    // setter direction from the nullary getter.
+                    let arg = [Arg {
+                        name: None,
+                        value: rhs.clone(),
+                    }];
+                    self.call_value(setter, &arg)?;
+                    return self.as_invisible(rhs);
+                }
                 // In-place, by-reference field write. `env::define` takes and
                 // releases the scope's `RefCell` borrow within the call, so a
                 // method mutating a field mid-call never holds two borrows of the
@@ -981,6 +998,9 @@ impl Interpreter {
                         "parent.frame" => self.eval_parent_frame(&raw, env),
                         // R-24 R5 reference classes.
                         "setRefClass" => self.eval_set_ref_class(&raw, env),
+                        // R-26 R5 method helpers.
+                        "missing" => self.eval_missing(&raw, env),
+                        "callSuper" => self.eval_call_super(&raw, env),
                         _ => unreachable!(),
                     };
                 }
@@ -1813,6 +1833,60 @@ impl Interpreter {
         self.as_visible(SValue::Environment(self.caller_frame(n)))
     }
 
+    /// `missing(x)` (R-26) — is the parameter `x` **absent** in the current call
+    /// frame? Its single argument is a bare **name** (never evaluated). We report
+    /// `TRUE` iff that name is not bound in the *immediate* frame `env` — which is
+    /// exactly what distinguishes an R5 active binding's nullary getter call
+    /// (`function(v)` invoked with no arg → `v` unbound → `missing(v)` TRUE) from its
+    /// setter call (`v` supplied → bound → FALSE). A non-name argument is a clean
+    /// error. (This is a faithful subset of R's `missing`: it does not chase default
+    /// expressions or promise state, which this runtime does not model — an unbound
+    /// formal is simply one no argument filled.)
+    fn eval_missing(&self, raw: &[RawArg], env: &Env) -> SResult<SValue> {
+        let node = self.positional_nodes(raw).into_iter().next().ok_or_else(|| {
+            SError::BadArgs("missing: an argument name is required".into())
+        })?;
+        let name = lvalue_name(node)
+            .map_err(|_| SError::BadArgs("missing: the argument must be a variable name".into()))?;
+        // Frame-local only: `missing(x)` asks about *this* function's formal, not an
+        // enclosing binding of the same name. `lookup_local` reads exactly this frame.
+        let absent = crate::env::lookup_local(env, &name).is_none();
+        self.as_visible(SValue::Logical(vec![Some(absent)]))
+    }
+
+    /// `callSuper(...)` (R-26) — inside an overriding R5 method, invoke the
+    /// **same-named** method from the parent class. The running method's
+    /// super-context (placed by `refclass::rebuild_method`) is read from the current
+    /// environment to learn the method name and the generator(s) at which to restart
+    /// resolution; the resolved super method is re-homed onto the **instance** (found
+    /// via `.self`) and applied to the forwarded (evaluated) args. **Past-the-root**
+    /// (no super definition of the name) returns `NULL` — R5's behaviour — with no
+    /// recursion and no panic.
+    fn eval_call_super(&self, raw: &[RawArg], env: &Env) -> SResult<SValue> {
+        // The instance is reachable via `.self`, bound on the instance frame which is
+        // an ancestor of the method-body env. Absent (`callSuper()` outside any R5
+        // method) → a clean NULL rather than an error, matching R's lenient handling.
+        let instance = match lookup(env, crate::refclass::KEY_SELF) {
+            Some(SValue::Environment(e)) => e,
+            _ => return self.as_visible(SValue::Null),
+        };
+        let Some(super_closure) = crate::refclass::call_super_method(env, &instance) else {
+            // No super method of this name → NULL (no recursion past the root).
+            return self.as_visible(SValue::Null);
+        };
+        // Forward the call args (evaluated in the *caller* env) to the super method.
+        let mut args: Vec<Arg> = Vec::new();
+        for (name, node) in raw {
+            if let Some(body) = arm_body(node) {
+                args.push(Arg {
+                    name: name.clone(),
+                    value: self.eval_node(body, env)?,
+                });
+            }
+        }
+        self.as_visible(self.call_value(super_closure, &args)?)
+    }
+
     // -----------------------------------------------------------------------
     // R-24 R5 reference classes (setRefClass)
     // -----------------------------------------------------------------------
@@ -1842,56 +1916,66 @@ impl Interpreter {
             .eval_named_arg(raw, "methods", env)?
             .unwrap_or(SValue::Null);
 
-        // R-25: `contains =` (single inheritance). The argument is the parent
-        // **generator** value, or a length-1 character giving the parent class
-        // *name* (resolved by evaluating that name as a variable in the current
-        // env — the generator was bound there by an earlier `setRefClass`). A
+        // R-25/R-26: `contains =`. The argument is a parent **generator** value, a
+        // length-1 character giving a parent class *name* (resolved by evaluating that
+        // name as a variable in the current env — the generator was bound there by an
+        // earlier `setRefClass`), or — for R-26 **multiple inheritance** — a character
+        // vector `c("A", "B")` (each element a parent class name, left-to-right). A
         // missing `contains =` means a root (non-inheriting) class.
-        let parent_env = match self.eval_named_arg(raw, "contains", env)? {
-            None | Some(SValue::Null) => None,
-            Some(value) => Some(self.resolve_contains(&value, env)?),
+        let parents = match self.eval_named_arg(raw, "contains", env)? {
+            None | Some(SValue::Null) => Vec::new(),
+            Some(value) => self.resolve_contains(&value, env)?,
         };
 
         // Reifying the generator environment counts against the session cap, like
         // any `new.env()` — it can equally participate in a value-binding cycle.
         self.account_environment()?;
-        let generator = crate::refclass::make_generator(
-            &class_name,
-            &fields,
-            &methods,
-            parent_env.as_ref(),
-            env,
-        )?;
+        let generator =
+            crate::refclass::make_generator(&class_name, &fields, &methods, &parents, env)?;
         self.as_visible(generator)
     }
 
-    /// Resolve a `contains =` argument to the parent **generator** environment.
-    /// Accepts either the generator value directly (an `SValue::Environment`), or a
-    /// length-1 character naming the parent class — in which case that name is
-    /// looked up as a variable in `env` (where `setRefClass` binds its result). A
-    /// name that is unbound, or bound to a non-environment, is a clean error
-    /// (never a panic). The generator-ness of the resolved env is re-checked inside
-    /// `make_generator`.
-    fn resolve_contains(&self, value: &SValue, env: &Env) -> SResult<Env> {
+    /// Resolve a `contains =` argument to the parent **generator** environments, in
+    /// left-to-right order. Accepts the generator value directly (an
+    /// `SValue::Environment`, single parent), or a **character vector** of one or
+    /// more parent class *names* — each looked up as a variable in `env` (where
+    /// `setRefClass` binds its result). `c("A", "B")` is R-26 multiple inheritance.
+    /// A name that is unbound, or bound to a non-environment, is a clean error (never
+    /// a panic). The generator-ness of each resolved env is re-checked inside
+    /// `make_generator`. An empty character vector yields no parents (a root class).
+    fn resolve_contains(&self, value: &SValue, env: &Env) -> SResult<Vec<Env>> {
         match value {
-            SValue::Environment(e) => Ok(e.clone()),
+            SValue::Environment(e) => Ok(vec![e.clone()]),
             other => {
-                // A character class name → look up the variable of that name.
+                // A character vector of class names → resolve each, in order.
                 let names = other.as_character();
-                let name = names.into_iter().flatten().next().ok_or_else(|| {
-                    SError::TypeError(
-                        "setRefClass: `contains =` must be a generator or a class name".into(),
-                    )
-                })?;
-                match lookup(env, &name) {
-                    Some(SValue::Environment(e)) => Ok(e),
-                    Some(_) => Err(SError::TypeError(format!(
-                        "setRefClass: `contains = \"{name}\"` is not a reference-class generator"
-                    ))),
-                    None => Err(SError::BadArgs(format!(
-                        "setRefClass: `contains = \"{name}\"`: no such reference class in scope"
-                    ))),
+                if names.is_empty() {
+                    return Err(SError::TypeError(
+                        "setRefClass: `contains =` must be a generator or class name(s)".into(),
+                    ));
                 }
+                let mut out = Vec::with_capacity(names.len());
+                for n in names {
+                    let name = n.ok_or_else(|| {
+                        SError::TypeError(
+                            "setRefClass: `contains =` class name may not be NA".into(),
+                        )
+                    })?;
+                    match lookup(env, &name) {
+                        Some(SValue::Environment(e)) => out.push(e),
+                        Some(_) => {
+                            return Err(SError::TypeError(format!(
+                                "setRefClass: `contains = \"{name}\"` is not a reference-class generator"
+                            )))
+                        }
+                        None => {
+                            return Err(SError::BadArgs(format!(
+                                "setRefClass: `contains = \"{name}\"`: no such reference class in scope"
+                            )))
+                        }
+                    }
+                }
+                Ok(out)
             }
         }
     }
@@ -1934,6 +2018,14 @@ impl Interpreter {
     /// behaviour.
     fn dollar_read(&self, target: &SValue, name: &str) -> SResult<SValue> {
         if let SValue::Environment(e) = target {
+            // R-26 active binding: reading `obj$ab` **calls** the binding function as
+            // a getter (no argument — so `missing(v)` is TRUE inside it). Invoked
+            // through the ordinary depth-bounded call path, so a getter that reads
+            // its *own* binding recurses and hits `MAX_EVAL_DEPTH` with a clean error
+            // rather than a borrow panic or a hang.
+            if let Some(getter) = crate::refclass::active_binding_fn(e, name) {
+                return self.call_value(getter, &[]);
+            }
             if let Some(v) = crate::refclass::dollar_access(e, name) {
                 return Ok(v);
             }
@@ -2119,6 +2211,13 @@ fn special_form_name(primary: &GrammarASTNode) -> Option<&'static str> {
         // ordinary eager builtin receives neither the current env nor control over
         // argument evaluation.
         [("NAME", "setRefClass")] => Some("setRefClass"),
+        // R-26 R5 method helpers. `missing(x)` must inspect whether the *named
+        // parameter* `x` was supplied in the **current** call frame — it never
+        // evaluates `x`, so it cannot be an eager builtin. `callSuper(...)` must read
+        // the running method's super-context markers from the *current* environment
+        // and forward its (evaluated) args to the resolved super method.
+        [("NAME", "missing")] => Some("missing"),
+        [("NAME", "callSuper")] => Some("callSuper"),
         _ => None,
     }
 }

--- a/code/packages/rust/s-runtime/src/refclass.rs
+++ b/code/packages/rust/s-runtime/src/refclass.rs
@@ -87,6 +87,15 @@ pub const KEY_CLASS_NAME: &str = ".refClassName";
 /// carried on the generator. Used by `$new` to know which fields to bind.
 pub const KEY_FIELDS: &str = ".refFields";
 
+/// Private binding (R-26): the original `fields =` **list value** as passed to
+/// `setRefClass`, carried on the generator so `$new` can recover which fields are
+/// **active bindings** — a field whose declared "type" is a `function(v)` closure
+/// rather than a character type string. The names live in [`KEY_FIELDS`]; this
+/// keeps the *values* (the binding functions) so they can be re-homed onto each
+/// instance. A bare character-vector `fields` carries no function values, so this
+/// degenerates to a plain character vector with no active bindings.
+pub const KEY_FIELD_SPEC: &str = ".refFieldSpec";
+
 /// Private binding: the **methods** (an `SValue::List` of closures *as written*,
 /// each closing over the generator's defining scope), carried on **both** the
 /// generator and every instance. The instance copy is what `obj$method` consults
@@ -99,15 +108,37 @@ pub const KEY_METHODS: &str = ".refMethods";
 /// as `.self$other(...)`.
 pub const KEY_SELF: &str = ".self";
 
-/// Private binding (R-25): the **parent generator** for a subclass defined with
-/// `contains = "Base"`, stored on the subclass generator as an
-/// [`SValue::Environment`] pointing at the parent generator. Absent on a root
-/// (non-inheriting) class. This single link is what makes the class an inheritance
-/// **chain**: walking `.refParent` from a generator yields its ancestors in order.
-/// The edge is a strict child → parent **DAG** edge — a cyclic `contains =` is
-/// rejected at [`make_generator`] time (see [`would_form_cycle`]) — so it can never
-/// create an `Rc` cycle through the generators.
-pub const KEY_PARENT: &str = ".refParent";
+/// Private binding (R-25/R-26): the **parent generators** for a subclass defined
+/// with `contains = "Base"` (single) or `contains = c("A", "B")` (multiple),
+/// stored on the subclass generator as an [`SValue::List`] of [`SValue::Environment`]
+/// values, one per parent in **left-to-right** declaration order. Absent on a root
+/// (non-inheriting) class. This list is what makes the class an inheritance
+/// **DAG**: a depth-first walk from a generator over its `.refParents` (and each
+/// parent's `.refParents`) yields all its ancestors. Every edge is a strict
+/// child → parent **DAG** edge — a cyclic `contains =` (`A ↔ B`, self-inheritance)
+/// is rejected at [`make_generator`] time (see [`would_form_cycle`]) over *each*
+/// listed parent — so it can never create an `Rc` cycle through the generators.
+///
+/// R-25 stored a single parent under `.refParent`; R-26 generalises to a list under
+/// `.refParents`. The reader [`parent_generators`] returns a `Vec<Env>`, so a single
+/// `contains =` is just the one-element case and all the chain walks below are
+/// uniform DFS over a possibly-branching ancestry.
+pub const KEY_PARENTS: &str = ".refParents";
+
+/// Private binding (R-26): on a **materialised, instance-bound method closure's**
+/// super-context scope — the generator at which a `callSuper()` inside that method
+/// should *restart* same-name resolution (i.e. the **parent** of the class that
+/// defined the method version currently running). See [`rebuild_method`] and the
+/// module note on `callSuper`. Stored as an [`SValue::List`] of parent generators
+/// (so multiple inheritance super-resolution can try each parent left-to-right),
+/// or absent/`Null` when the defining class is a root (no super → `callSuper()`
+/// is a clean `NULL`).
+pub const KEY_SUPER_GENS: &str = ".refSuperGens";
+
+/// Private binding (R-26): on a materialised method's super-context scope — the
+/// **name** of the method currently running, so `callSuper()` knows which name to
+/// resolve in the super class(es). Paired with [`KEY_SUPER_GENS`].
+pub const KEY_METHOD_NAME: &str = ".refMethodName";
 
 /// Private binding (R-25): the **generator** an instance was built from, stored on
 /// the instance as a strong [`SValue::Environment`]. R-24 instances had no need to
@@ -177,6 +208,52 @@ fn field_names(env: &Env) -> Vec<String> {
     }
 }
 
+/// The **active-binding functions** declared *directly* on `generator` (its
+/// `.refFieldSpec`), as `(field_name, closure)` pairs — i.e. the entries of the
+/// `fields = list(...)` value whose value is a `function(v)` closure rather than a
+/// character type string. An ordinary data field (a character type) is skipped, as
+/// is a bare-character-vector `fields` (which has no function values). This reads
+/// only this class's own spec; the effective set across inheritance is assembled by
+/// [`effective_active_bindings`].
+fn own_active_bindings(generator: &Env) -> Vec<(String, SValue)> {
+    match env::lookup_local(generator, KEY_FIELD_SPEC) {
+        Some(SValue::List { names, items }) => names
+            .into_iter()
+            .zip(items)
+            .filter_map(|(n, v)| match (n, &v) {
+                (Some(name), SValue::Closure { .. }) => Some((name, v)),
+                _ => None,
+            })
+            .collect(),
+        _ => Vec::new(),
+    }
+}
+
+/// The **effective active bindings** of a generator: the union of this class's own
+/// active-binding functions with every ancestor's, with a **more-derived class
+/// overriding** a same-named ancestor binding (and overriding/over­ridden by an
+/// ordinary field of the same name — last writer in the linearization wins). Built
+/// by walking the [`linearization`] ancestors-first so the most-derived definition
+/// wins, exactly like [`effective_methods`]. Returns `(name, closure)` pairs.
+fn effective_active_bindings(generator: &Env) -> Vec<(String, SValue)> {
+    let mut chain = linearization(generator);
+    chain.reverse(); // ancestors first
+    let mut order: Vec<String> = Vec::new();
+    let mut map: std::collections::HashMap<String, SValue> = std::collections::HashMap::new();
+    for g in &chain {
+        for (name, closure) in own_active_bindings(g) {
+            if !map.contains_key(&name) {
+                order.push(name.clone());
+            }
+            map.insert(name, closure);
+        }
+    }
+    order
+        .into_iter()
+        .filter_map(|n| map.get(&n).cloned().map(|v| (n, v)))
+        .collect()
+}
+
 /// The **effective field names** of a generator: the union of this class's own
 /// fields with every ancestor's, in **base-first declaration order** (a field
 /// inherited from the base precedes a field newly declared on the subclass), with
@@ -186,19 +263,14 @@ fn field_names(env: &Env) -> Vec<String> {
 /// then de-duplicating while preserving first-seen order. Bounded by
 /// [`MAX_CHAIN_DEPTH`].
 pub fn effective_fields(generator: &Env) -> Vec<String> {
-    // Walk root → self by collecting the chain self → root then reversing.
-    let mut chain: Vec<Env> = Vec::new();
-    let mut cur = Some(generator.clone());
-    let mut depth = 0usize;
-    while let Some(g) = cur {
-        if depth >= MAX_CHAIN_DEPTH {
-            break;
-        }
-        chain.push(g.clone());
-        cur = parent_generator(&g);
-        depth += 1;
-    }
-    chain.reverse(); // root first
+    // Collect each class's own `.refFields` from the **root(s) up to this class** so
+    // base fields precede sub fields: take the linearization (self-first) and reverse
+    // it (so ancestors come first), then de-duplicate while preserving first-seen
+    // order. For multiple inheritance the reversed-DFS order lists A's ancestors,
+    // then A, then B's ancestors, then B, then self — i.e. inherited fields (A before
+    // B) precede the subclass's own newly-declared fields.
+    let mut chain = linearization(generator);
+    chain.reverse(); // ancestors first
 
     let mut out: Vec<String> = Vec::new();
     for g in &chain {
@@ -219,18 +291,12 @@ pub fn effective_fields(generator: &Env) -> Vec<String> {
 /// order (base methods first, then sub-only methods). Bounded by
 /// [`MAX_CHAIN_DEPTH`].
 fn effective_methods(generator: &Env) -> Vec<(String, SValue)> {
-    let mut chain: Vec<Env> = Vec::new();
-    let mut cur = Some(generator.clone());
-    let mut depth = 0usize;
-    while let Some(g) = cur {
-        if depth >= MAX_CHAIN_DEPTH {
-            break;
-        }
-        chain.push(g.clone());
-        cur = parent_generator(&g);
-        depth += 1;
-    }
-    chain.reverse(); // root first
+    // Same linearization as `effective_fields`, reversed so ancestors come first:
+    // iterating ancestors-first and letting a more-derived class *replace* the
+    // closure bound to an already-seen name gives left-to-right, most-derived-first
+    // precedence (self overrides A overrides B overrides their ancestors).
+    let mut chain = linearization(generator);
+    chain.reverse(); // ancestors first
 
     // Preserve first-declaration order for names, but let a more-derived class
     // *replace* the closure bound to an already-seen name (override semantics).
@@ -262,20 +328,17 @@ fn effective_methods(generator: &Env) -> Vec<(String, SValue)> {
 /// object `is()` an `envRefClass` and an `environment`. Bounded by
 /// [`MAX_CHAIN_DEPTH`]. This is what `is()`/`inherits()` consult.
 pub fn class_chain(generator: &Env) -> Vec<String> {
+    // The [`linearization`] is already most-derived-first (self, then parents
+    // left-to-right, then their ancestors), de-duplicated — exactly the class-chain
+    // order. Map each generator to its name and append the two synthetic tail
+    // classes every reference object `is()`.
     let mut out: Vec<String> = Vec::new();
-    let mut cur = Some(generator.clone());
-    let mut depth = 0usize;
-    while let Some(g) = cur {
-        if depth >= MAX_CHAIN_DEPTH {
-            break;
-        }
+    for g in linearization(generator) {
         if let Some(name) = generator_name(&g) {
             if !out.contains(&name) {
                 out.push(name);
             }
         }
-        cur = parent_generator(&g);
-        depth += 1;
     }
     out.push("envRefClass".to_string());
     out.push("environment".to_string());
@@ -331,19 +394,29 @@ fn instance_generator(instance: &Env) -> Option<Env> {
 /// never a panic. The generator is returned as an [`SValue::Environment`]; the
 /// caller is responsible for charging it against `MAX_ENVIRONMENTS`.
 ///
-/// **R-25 inheritance.** When `parent` is `Some(base_generator)`, the new class
-/// is a *subclass*: its own (declared) fields and methods are stored exactly as
-/// for a root class, plus a `.refParent` link to the base generator. The *effective*
-/// field/method union (base ∪ sub) is **not** flattened into the subclass here —
-/// it is computed lazily by walking `.refParent` at `$new`/introspection time
+/// **R-25/R-26 inheritance.** When `parents` is non-empty, the new class is a
+/// *subclass*: its own (declared) fields and methods are stored exactly as for a
+/// root class, plus a `.refParents` list linking the base generator(s). With one
+/// parent this is single inheritance (R-25); with several (`contains = c("A","B")`)
+/// it is multiple inheritance (R-26). The *effective* field/method union is **not**
+/// flattened into the subclass here — it is computed lazily by the DFS
+/// [`linearization`] at `$new`/introspection time
 /// ([`effective_fields`]/[`effective_methods`]). A `contains =` that would close a
-/// cycle (`A contains B contains A`, or self-inheritance by name) is **rejected**
-/// up front via [`would_form_cycle`], so the `.refParent` edges always form a DAG.
+/// cycle (`A contains B contains A`, self-inheritance, or an `A ↔ B` pair across
+/// multiple parents) is **rejected** up front via [`would_form_cycle`] over *every*
+/// listed parent, so the `.refParents` edges always form a DAG.
+///
+/// **Active bindings (R-26).** A `fields = list(x = "numeric", ab = function(v) …)`
+/// entry whose *value* is a closure declares `ab` as an **active binding** rather
+/// than a data field — but at the generator level both are simply field *names*
+/// (the active-binding function is applied per-instance at `$new` time, see
+/// [`instantiate`]). The function bodies travel inside the `fields` list value,
+/// which we record alongside the names so `$new` can install them.
 pub fn make_generator(
     class_name: &str,
     fields: &SValue,
     methods: &SValue,
-    parent: Option<&Env>,
+    parents: &[Env],
     defining_env: &Env,
 ) -> SResult<SValue> {
     // The field NAMES come from the `fields = list(x = "numeric", …)` argument's
@@ -355,21 +428,22 @@ pub fn make_generator(
     // closures. Anything else is a clean error.
     let method_list = validate_methods(methods)?;
 
-    // `contains = parent`: the parent must itself be a reference-class generator,
-    // and the chain must stay acyclic (no `A contains B contains A`, no class
-    // inheriting from one that already bears its name). Reject both up front so the
-    // `.refParent` edges form a strict DAG and every later chain walk terminates.
-    if let Some(p) = parent {
+    // `contains = parents`: every parent must itself be a reference-class generator,
+    // and the hierarchy must stay acyclic (no `A contains B contains A`, no class
+    // inheriting from one that already bears its name, no `A ↔ B` mutual pair).
+    // Reject up front so the `.refParents` edges form a strict DAG and every later
+    // chain walk terminates.
+    for p in parents {
         if !is_generator(p) {
             return Err(SError::TypeError(
-                "setRefClass: `contains =` must name a reference-class generator".into(),
+                "setRefClass: `contains =` must name reference-class generator(s)".into(),
             ));
         }
-        if would_form_cycle(class_name, p) {
-            return Err(SError::BadArgs(format!(
-                "setRefClass: `contains =` would make class '{class_name}' inherit from itself (cyclic hierarchy)"
-            )));
-        }
+    }
+    if would_form_cycle(class_name, parents) {
+        return Err(SError::BadArgs(format!(
+            "setRefClass: `contains =` would make class '{class_name}' inherit from itself (cyclic hierarchy)"
+        )));
     }
 
     let scope = env::Scope::child(defining_env);
@@ -384,33 +458,49 @@ pub fn make_generator(
         SValue::Character(field_vec.into_iter().map(Some).collect()),
     );
     env::define(&scope, KEY_METHODS, method_list);
-    if let Some(p) = parent {
-        env::define(&scope, KEY_PARENT, SValue::Environment(p.clone()));
+    // Record the field *values* (the `fields = list(...)` value), so `$new` can tell
+    // an active-binding (function-valued) field from an ordinary data field and
+    // install the binding function per instance. Stored as the original list value;
+    // a bare character-vector `fields` carries no function values, so this is then
+    // just the names with no bindings.
+    env::define(&scope, KEY_FIELD_SPEC, fields.clone());
+    if !parents.is_empty() {
+        let items: Vec<SValue> = parents
+            .iter()
+            .map(|p| SValue::Environment(p.clone()))
+            .collect();
+        env::define(
+            &scope,
+            KEY_PARENTS,
+            SValue::List {
+                names: vec![None; items.len()],
+                items,
+            },
+        );
     }
     Ok(SValue::Environment(scope))
 }
 
-/// Would making `class_name` a subclass of generator `parent` close a cycle? A
-/// hierarchy is cyclic if the new class's name already appears anywhere in the
-/// prospective parent's own class chain (including the parent itself) — e.g.
-/// `A <- setRefClass("A", contains = B)` where `B`'s chain already contains `"A"`.
-/// Walks `.refParent` from `parent` up to the root, bounded by [`MAX_CHAIN_DEPTH`]
-/// (so even a pre-existing corrupt loop terminates the check). Returns `true` to
-/// **reject** the class.
-fn would_form_cycle(class_name: &str, parent: &Env) -> bool {
-    let mut cur = Some(parent.clone());
-    let mut depth = 0usize;
-    while let Some(g) = cur {
-        if depth >= MAX_CHAIN_DEPTH {
-            // A chain this deep is already pathological; treat it as cyclic and
-            // refuse rather than risk a non-terminating walk.
+/// Would making `class_name` a subclass of the generators `parents` close a cycle?
+/// A hierarchy is cyclic if the new class's name already appears anywhere in **any**
+/// prospective parent's own linearization (including the parent itself) — e.g.
+/// `A <- setRefClass("A", contains = B)` where `B`'s chain already contains `"A"`,
+/// or `contains = c("A", "B")` where `A` (transitively) contains `"B"` and we are
+/// about to name the new class `"B"`. Walks each parent's [`linearization`]
+/// (DFS, bounded by [`MAX_CHAIN_DEPTH`], so even a pre-existing corrupt loop
+/// terminates the check). Returns `true` to **reject** the class.
+fn would_form_cycle(class_name: &str, parents: &[Env]) -> bool {
+    for parent in parents {
+        for g in linearization(parent) {
+            if generator_name(&g).as_deref() == Some(class_name) {
+                return true;
+            }
+        }
+        // A linearization truncated at the depth bound is already pathological;
+        // treat it as cyclic and refuse rather than risk admitting a loop.
+        if linearization(parent).len() >= MAX_CHAIN_DEPTH {
             return true;
         }
-        if generator_name(&g).as_deref() == Some(class_name) {
-            return true;
-        }
-        cur = parent_generator(&g);
-        depth += 1;
     }
     false
 }
@@ -424,14 +514,57 @@ fn generator_name(generator: &Env) -> Option<String> {
     }
 }
 
-/// The parent **generator** of `generator` (its `.refParent` link), or `None` for
-/// a root class. Only an actual generator environment is returned — a malformed
-/// marker yields `None` (defensive, never a panic).
-fn parent_generator(generator: &Env) -> Option<Env> {
-    match env::lookup_local(generator, KEY_PARENT) {
-        Some(SValue::Environment(e)) if is_generator(&e) => Some(e),
-        _ => None,
+/// The parent **generators** of `generator` (its `.refParents` list), in
+/// left-to-right declaration order, or an empty vector for a root class. Only
+/// actual generator environments are returned — a malformed entry is skipped
+/// (defensive, never a panic). A single `contains =` yields a one-element vector,
+/// so every chain walk is uniform DFS over a possibly-branching ancestry.
+fn parent_generators(generator: &Env) -> Vec<Env> {
+    match env::lookup_local(generator, KEY_PARENTS) {
+        Some(SValue::List { items, .. }) => items
+            .into_iter()
+            .filter_map(|v| match v {
+                SValue::Environment(e) if is_generator(&e) => Some(e),
+                _ => None,
+            })
+            .collect(),
+        _ => Vec::new(),
     }
+}
+
+/// The **linearization** of a class hierarchy: a left-to-right **depth-first
+/// pre-order** walk over `.refParents`, listing `generator` first, then each parent
+/// and all of that parent's ancestors before moving to the next parent, **skipping
+/// any generator already seen** (so a diamond's shared base appears once). This is
+/// the order all the "effective" set computations and [`class_chain`] consult.
+///
+/// Simple DFS — **not** C3 linearization. For single inheritance it degenerates to
+/// the straight base-to-derived chain R-25 used. For multiple inheritance it gives
+/// the documented "A before B before their ancestors" precedence. Bounded by
+/// [`MAX_CHAIN_DEPTH`] *nodes visited* — even a (rejected-at-construction, but
+/// belt-and-braces) corrupt cycle terminates because each generator is recorded once
+/// and the visited-set short-circuits re-entry.
+fn linearization(generator: &Env) -> Vec<Env> {
+    let mut out: Vec<Env> = Vec::new();
+    let mut stack: Vec<Env> = vec![generator.clone()];
+    // DFS with an explicit stack; `out` doubles as the visited set (membership by
+    // `Rc` pointer identity via `same_env`). The stack is pushed in reverse so the
+    // first parent is processed first (left-to-right pre-order).
+    while let Some(g) = stack.pop() {
+        if out.len() >= MAX_CHAIN_DEPTH {
+            break;
+        }
+        if out.iter().any(|seen| env::same_env(seen, &g)) {
+            continue;
+        }
+        out.push(g.clone());
+        // Push parents in reverse so the left-most is popped (visited) first.
+        let parents = parent_generators(&g);
+        for p in parents.into_iter().rev() {
+            stack.push(p);
+        }
+    }
+    out
 }
 
 /// Extract field names from the `fields =` argument. Two shapes are accepted:
@@ -593,7 +726,41 @@ pub fn instantiate(generator: &Env, init_args: &[(Option<String>, SValue)]) -> S
     // bounded) R-22 value-binding self-cycle; see the module note.
     env::define(&scope, KEY_SELF, SValue::Environment(scope.clone()));
 
+    // R-26: install **active bindings**. An active-binding field's *value* on the
+    // instance frame is the binding **function re-homed onto the instance** (its
+    // `env` swapped to the instance, exactly like a method) — so its body reads
+    // sibling fields and writes them with `<<-`. The `$` read path (`dollar_access`)
+    // detects a callable field value and invokes it nullary (getter); the `$<-` path
+    // invokes it with the new value (setter). This runs **after** the field loop so
+    // it overwrites the NULL/`new`-supplied default with the binding function.
+    install_active_bindings(generator, &scope);
+
     Ok(SValue::Environment(scope))
+}
+
+/// Bind every **active-binding** field of `generator` (effective, across the whole
+/// inheritance linearization) onto `instance` as a closure **re-homed** onto the
+/// instance — i.e. a fresh `Closure` with the same params/body but `env = instance`,
+/// so its body sees the instance's sibling fields and writes them with `<<-`. The
+/// instance-frame value of such a field is therefore the binding function itself;
+/// `dollar_access`/`$<-` recognise a callable field value and call it as a
+/// getter/setter. An active binding whose name was *also* supplied as a `$new`
+/// argument still ends up as the binding function (R does not pre-set an active
+/// binding from `new`), matching R5.
+fn install_active_bindings(generator: &Env, instance: &Env) {
+    for (name, closure) in effective_active_bindings(generator) {
+        if let SValue::Closure { params, body, .. } = closure {
+            env::define(
+                instance,
+                &name,
+                SValue::Closure {
+                    params,
+                    body,
+                    env: instance.clone(),
+                },
+            );
+        }
+    }
 }
 
 /// The effective methods of `generator` packaged as an `SValue::List` of named
@@ -633,7 +800,18 @@ pub fn copy_instance(instance: &Env) -> SResult<SValue> {
     // Build the fresh sibling scope and re-bind the private markers, mirroring
     // `instantiate` (but copying field *values* rather than reading `new` args).
     let scope = env::Scope::child(&generator);
+    // The names that are **active bindings** must NOT be copied as values (the
+    // source instance's binding closure closes over the *source* — copying it would
+    // make the copy's getter/setter mutate the original). They are re-installed
+    // below via `install_active_bindings`, re-homed onto the new scope.
+    let active: Vec<String> = effective_active_bindings(&generator)
+        .into_iter()
+        .map(|(n, _)| n)
+        .collect();
     for field in effective_fields(&generator) {
+        if active.iter().any(|a| a == &field) {
+            continue; // re-installed below, not value-copied
+        }
         // `env::lookup_local` reads the source instance's *own* field binding; the
         // value is cloned (a shallow `SValue` clone — a nested instance is aliased,
         // not recursed) and bound into the new scope. An absent field defaults to
@@ -642,8 +820,11 @@ pub fn copy_instance(instance: &Env) -> SResult<SValue> {
         env::define(&scope, &field, value);
     }
     env::define(&scope, KEY_METHODS, methods_list_value(&generator));
-    env::define(&scope, KEY_GENERATOR, SValue::Environment(generator));
+    env::define(&scope, KEY_GENERATOR, SValue::Environment(generator.clone()));
     env::define(&scope, KEY_SELF, SValue::Environment(scope.clone()));
+    // R-26: re-home the active bindings onto the *copy* (not the source), so the
+    // copy's getter/setter operate on the copy's own fields.
+    install_active_bindings(&generator, &scope);
     Ok(SValue::Environment(scope))
 }
 
@@ -705,23 +886,146 @@ pub fn dollar_access(obj: &Env, name: &str) -> Option<SValue> {
     None
 }
 
+/// Is `name` an **active binding** of `instance` (a function-valued field declared
+/// in the class spec, across the inheritance linearization)? Used by the `$`
+/// read/write dispatch to decide whether `obj$name` / `obj$name <- v` calls a
+/// getter/setter rather than reading/writing a plain data field. Returns `false`
+/// for a non-instance or an ordinary field. Detected from the class spec (not from
+/// "the instance value happens to be a closure") so a data field that a user
+/// assigned a function to is *not* mistaken for an active binding.
+pub fn is_active_binding(instance: &Env, name: &str) -> bool {
+    match instance_generator(instance) {
+        Some(generator) => effective_active_bindings(&generator)
+            .iter()
+            .any(|(n, _)| n == name),
+        None => false,
+    }
+}
+
+/// The **active-binding function** for `name`, as stored (re-homed) on `instance`'s
+/// own frame — the closure the `$` read/write path calls as a getter (no args) or
+/// setter (`v = value`). Returns `None` if `name` is not an active binding on this
+/// instance. The closure's `env` is the instance, so its body reads sibling fields
+/// and writes them with `<<-`.
+pub fn active_binding_fn(instance: &Env, name: &str) -> Option<SValue> {
+    if !is_active_binding(instance, name) {
+        return None;
+    }
+    match env::lookup_local(instance, name) {
+        Some(c @ SValue::Closure { .. }) => Some(c),
+        _ => None,
+    }
+}
+
 /// Rebuild a fresh **instance-bound** closure for method `name`: take the method
 /// closure as written (which closes over the *generator* scope) and return a new
-/// `Closure` with the same params/body but its `env` swapped to the **instance**.
-/// The body then sees the instance's fields as free variables and writes them
-/// back with `<<-`. Returns `None` if `name` is not a method. **Never stored** —
-/// this lives only for the call that triggered it, so it forms no lasting
-/// instance⇄method `Rc` cycle (see the module note).
+/// `Closure` with the same params/body but its `env` swapped to a thin
+/// **super-context** scope whose parent is the **instance**. The super-context binds
+/// two private markers — [`KEY_SUPER_GENS`] (the parent generators of the class that
+/// *defined this method version*, where a `callSuper()` should restart same-name
+/// resolution) and [`KEY_METHOD_NAME`] — so a `callSuper()` inside the body finds
+/// them by ordinary lexical lookup. The body still reads/writes the instance's
+/// fields because the super-context's parent *is* the instance (and the markers are
+/// dotted, so they never collide with a user field). Returns `None` if `name` is not
+/// a method. **Never stored** — this lives only for the call that triggered it, so it
+/// forms no lasting instance⇄method `Rc` cycle (see the module note).
 fn rebuild_method(instance: &Env, name: &str) -> Option<SValue> {
-    for (mname, m) in methods_of(instance) {
-        if mname == name {
-            if let SValue::Closure { params, body, .. } = m {
-                return Some(SValue::Closure {
-                    params,
-                    body,
-                    env: instance.clone(),
-                });
+    let generator = instance_generator(instance)?;
+    rebuild_method_from(instance, &generator, name)
+}
+
+/// The shared core of [`rebuild_method`] and `callSuper`: materialise the closure
+/// for `name` as resolved **starting at `start_gen`** (the instance's own generator
+/// for a plain `obj$method`; a *super* generator for `callSuper`). The method's
+/// *defining class* is the first generator in `start_gen`'s [`linearization`] that
+/// declares `name` directly; the super-context records **that class's parents** so a
+/// nested `callSuper()` walks one level further up. Returns `None` when no class at
+/// or above `start_gen` defines `name` (a `callSuper()` past the root → clean `None`,
+/// no recursion).
+fn rebuild_method_from(instance: &Env, start_gen: &Env, name: &str) -> Option<SValue> {
+    // Find the defining class (most-derived from `start_gen` that declares `name`)
+    // and its method closure.
+    let mut defining: Option<Env> = None;
+    let mut found: Option<SValue> = None;
+    for g in linearization(start_gen) {
+        // `methods_of` reads a generator's *own* declared `.refMethods`, so the first
+        // class in the linearization that binds `name` is its defining class.
+        for (mname, m) in methods_of(&g) {
+            if mname == name {
+                defining = Some(g.clone());
+                found = Some(m);
+                break;
             }
+        }
+        if found.is_some() {
+            break;
+        }
+    }
+    let (defining, closure) = (defining?, found?);
+    if let SValue::Closure { params, body, .. } = closure {
+        // The super-context parents are the *defining class's* parents — where a
+        // `callSuper()` inside this method restarts same-name resolution.
+        let super_gens = parent_generators(&defining);
+        let ctx = env::Scope::child(instance);
+        let items: Vec<SValue> = super_gens
+            .iter()
+            .map(|g| SValue::Environment(g.clone()))
+            .collect();
+        env::define(
+            &ctx,
+            KEY_SUPER_GENS,
+            SValue::List {
+                names: vec![None; items.len()],
+                items,
+            },
+        );
+        env::define(
+            &ctx,
+            KEY_METHOD_NAME,
+            SValue::Character(vec![Some(name.to_string())]),
+        );
+        return Some(SValue::Closure {
+            params,
+            body,
+            env: ctx,
+        });
+    }
+    None
+}
+
+/// `callSuper(...)` engine (R-26). Resolve the **same-named** method one level up
+/// the inheritance chain from the method currently running, re-home it onto
+/// `instance`, and return it ready to apply to the forwarded args. `caller_env` is
+/// the environment the `callSuper()` call is being evaluated in — it carries the
+/// super-context markers [`KEY_SUPER_GENS`] / [`KEY_METHOD_NAME`] placed by
+/// [`rebuild_method_from`] (found by walking up the lexical chain). Returns:
+///
+/// * `Some(closure)` — the super method, re-homed, with a *fresh* super-context one
+///   level further up (so chained `callSuper()` walks `C → B → A`).
+/// * `None` — there is no super definition (the markers are absent, or no class at or
+///   above the super generators defines the name). The caller treats this as R5's
+///   "no super method" → a clean `NULL`, never recursion or a panic.
+pub fn call_super_method(caller_env: &Env, instance: &Env) -> Option<SValue> {
+    // The method name is read from the nearest enclosing super-context.
+    let name = match env::lookup(caller_env, KEY_METHOD_NAME) {
+        Some(SValue::Character(v)) => v.into_iter().next().flatten()?,
+        _ => return None,
+    };
+    // The super generators to restart resolution at (the defining class's parents).
+    let super_gens: Vec<Env> = match env::lookup(caller_env, KEY_SUPER_GENS) {
+        Some(SValue::List { items, .. }) => items
+            .into_iter()
+            .filter_map(|v| match v {
+                SValue::Environment(e) if is_generator(&e) => Some(e),
+                _ => None,
+            })
+            .collect(),
+        _ => Vec::new(),
+    };
+    // Try each super generator left-to-right; the first that defines `name` wins.
+    for g in &super_gens {
+        if let Some(closure) = rebuild_method_from(instance, g, &name) {
+            return Some(closure);
         }
     }
     None

--- a/code/packages/rust/s-runtime/src/refclass.rs
+++ b/code/packages/rust/s-runtime/src/refclass.rs
@@ -60,12 +60,20 @@
 //! instance → method → instance edge never exists *at rest* — there is nothing for
 //! `Rc` to fail to collect.
 //!
-//! The one remaining strong self-reference is `.self` (an `Environment` to the
-//! instance, stored inside the instance). That is exactly the *documented,
-//! pre-existing* R-22 value-binding self-cycle — `assign("self", e, envir = e)` —
-//! which we do not claim to collect but which is *bounded* (not unbounded) by the
-//! `MAX_ENVIRONMENTS` session cap. We inherit that boundary verbatim rather than
-//! widening the ownership model.
+//! The remaining strong self-references are `.self` (an `Environment` to the
+//! instance, stored inside the instance) and — as of R-26 — each **active-binding**
+//! field, which stores an instance-homed `Closure { env: <strong Rc to instance> }`
+//! under the field name *on the instance frame* (so `obj$ab` can call it as a
+//! getter/setter; see [`install_active_bindings`]). Unlike an ordinary method —
+//! which we deliberately never store, rebuilding it lazily on access to avoid this
+//! very edge — an active binding **must** live on the instance, so it forms the same
+//! `instance → closure → instance` self-cycle that `.self` already does. Both are
+//! exactly the *documented, pre-existing* R-22 value-binding self-cycle —
+//! `assign("self", e, envir = e)` — which we do not claim to collect but which is
+//! *bounded* (not unbounded) by the `MAX_ENVIRONMENTS` session cap: an active binding
+//! points only back at the *same* already-charged instance and creates no new
+//! environment, so it widens no leak boundary. We inherit that boundary verbatim
+//! rather than widening the ownership model.
 //!
 //! ## Reference (alias) semantics
 //!

--- a/code/specs/R00-r-language.md
+++ b/code/specs/R00-r-language.md
@@ -717,10 +717,74 @@ unchanged.
     inputs — a `contains =` naming a non-generator / undefined class, a cyclic
     `contains =`, `$copy()` called on a generator rather than an instance — are clean
     `BadArgs`/`TypeError` results, never panics.
-  - **Deferred to R-26.** Multiple inheritance (`contains = c("A", "B")`) and
-    active bindings remain out of scope. R-25 ships single-`contains=` inheritance +
-    `$copy()` + `is`/`inherits` over the R5 class chain + `$fields()`/`$methods()`,
-    solidly. A clean partial beats a sprawling one.
+  - **Deferred to R-26.** Multiple inheritance (`contains = c("A", "B")`),
+    `callSuper()`, and active bindings remain out of scope. R-25 ships
+    single-`contains=` inheritance + `$copy()` + `is`/`inherits` over the R5 class
+    chain + `$fields()`/`$methods()`, solidly. A clean partial beats a sprawling one.
+
+- **R-26 — R5 `callSuper()`, active bindings, and multiple inheritance** *(this PR)*.
+  Completes the R5 reference-class system on top of R-24/R-25's generator/instance
+  model in `refclass.rs`; no grammar change.
+  - **`callSuper(...)`** — inside an overriding method, invoke the **same-named**
+    method from the parent class. The challenge is method-identity: when `Sub$describe`
+    overrides `Base$describe`, a `callSuper()` inside the running `describe` must reach
+    `Base`'s `describe`, *not* re-enter `Sub`'s (infinite recursion). We solve it by
+    making `rebuild_method` — which already materialises a fresh instance-bound closure
+    on each `obj$method` access — record **which class defined the method version it is
+    about to run** and wrap the closure's captured environment in a thin *super-context*
+    scope binding two private markers: `.refSuperGen` (the defining class's **parent**
+    generator, where same-name resolution should *restart*) and `.refMethodName` (the
+    method's name). The method body runs in a child of that super-context scope, so a
+    `callSuper()` call inside it finds both markers by ordinary lexical lookup. `callSuper`
+    itself is a **lazy special form** (it must read the markers from the *calling*
+    environment, and forward the call args): it resolves the same method name starting at
+    `.refSuperGen`, re-homes that closure onto the instance with a *fresh* super-context
+    pointing one level further up (so a chain `C→B→A` of `callSuper()` walks all the way
+    to the root), and applies it to the forwarded args. **Past-the-root safety:** a
+    `callSuper()` in a method that has no parent definition of that name is a clean,
+    no-recursion `NULL` (matching R5, which silently returns `NULL` when there is no
+    super method) — never a panic and never an unbounded walk.
+  - **Active bindings** — a field whose declared *type* is a `function(v)` becomes an
+    **active binding**: reading `obj$ab` **calls** the function as a getter (with no
+    argument, so `missing(v)` is `TRUE`), and `obj$ab <- val` **calls** it as a setter
+    with `v = val`. In `setRefClass(…, fields = list(celsius = "numeric", fahrenheit =
+    function(v) …))` the function-valued field *is* the active binding; a string-valued
+    field stays an ordinary data field. The active-binding function is stored on the
+    instance frame under the field name (re-homed onto the instance so it reads sibling
+    fields and writes them with `<<-`). The `$` read path detects a callable field value
+    and invokes it nullary; the `$<-` path detects it and invokes it with the new value.
+    `missing(v)` is added as a special form that reports whether the named parameter was
+    actually supplied at the call site — `TRUE` in the getter (no arg), `FALSE` in the
+    setter (`v` supplied) — which is exactly how a single `function(v)` serves both
+    directions. **Re-entrancy / borrow safety:** the getter/setter is invoked through
+    the ordinary depth-bounded call path (`MAX_EVAL_DEPTH`), so a getter that reads its
+    *own* binding (`obj$ab` inside the `ab` getter) recurses through the call path and
+    hits the depth cap with a clean error rather than a borrow panic or a hang; field
+    reads/writes inside the body use the existing per-operation `env::define`/`lookup`
+    borrows (each takes-and-releases the scope `RefCell` within the call), so a setter
+    that mutates a sibling field never holds two borrows of the same scope at once.
+  - **Multiple inheritance** — `contains = c("A", "B")`. A subclass generator now
+    carries a **list** of parent generators (`.refParents`) rather than a single
+    `.refParent`. The **linearization** is a simple **left-to-right depth-first**
+    pre-order walk: the class itself, then A and all of A's ancestors, then B and all
+    of B's ancestors (skipping any already seen). C3 is *not* implemented — the simple
+    DFS order is documented and sufficient for the union semantics. The **effective
+    field set** is the union over the linearization in first-seen order (so A's fields
+    precede B's, both precede the class's own only where re-declared — own declarations
+    extend the set); the **effective method set** is the union with **left-to-right,
+    most-derived-first precedence** (the class's own methods override A's, which override
+    B's, which override their ancestors'). `is`/`inherits` see every class in the
+    linearization. **Cycle / Rc safety:** the `.refParents` edges are all DAG edges
+    (child → parent); a `contains =` that names a class already in *any* prospective
+    parent's chain (the `A ↔ B` mutual-inheritance case, or self-inheritance) is
+    **rejected** at `setRefClass` time by the same name-in-ancestry check, now run over
+    *each* listed parent — so the multi-parent graph stays a DAG and every chain walk is
+    bounded by `MAX_CHAIN_DEPTH`. Diamond inheritance (`C` contains `A` and `B`, both
+    containing a common base `Z`) is fine: the DFS de-dups `Z`, so it appears once.
+  - **Scope outcome.** All three shipped solidly in this PR; nothing deferred to R-27.
+    The two highest-value pieces (`callSuper()` + active bindings) and multiple
+    inheritance all reuse the existing chain-walk + lazy-method-rebuild machinery, so
+    the change stayed contained.
 
 ## §4 Reuse strategy
 
@@ -742,8 +806,9 @@ Pipes (`|>`) and backslash lambdas (`\(x)`). The `SValue::Environment` value,
 `sys.call`/`sys.function`/`match.call` and the rest of the call-introspection
 family; S4 and R6 OO (R5 reference classes land in **R-24**; single-`contains=`
 inheritance, `$copy()`, `is`/`inherits` over the class chain, and
-`$methods()`/`$fields()` introspection land in **R-25**, with multiple
-inheritance and active bindings deferred to **R-26**); namespaces and `library()`
+`$methods()`/`$fields()` introspection land in **R-25**, with `callSuper()`,
+active bindings, and multiple inheritance (`contains = c("A", "B")`) completing
+the R5 system in **R-26**); namespaces and `library()`
 (so `baseenv()` aliases the
 global env for now); the C interface; graphics. These layer on later, following
 ST00.


### PR DESCRIPTION
## R-26 — R5 `callSuper()`, active bindings, multiple inheritance

Completes the R5 reference-class system on top of R-24/R-25 (generators, instances, fields, methods, `$new`, `<<-`/`.self` mutation, single inheritance, `$copy()`, `is`/`inherits`/`class`, `$fields()`/`$methods()`). All logic lives in `s-runtime/src/refclass.rs` + `eval.rs`; no grammar change. **All three features shipped — nothing deferred to R-27.**

### `callSuper(...)`
An overriding method invokes the **same-named** parent method. `rebuild_method` now materialises each instance-bound method inside a thin **super-context** scope (parent = the instance) recording `.refSuperGens` (the parent generators of the class that *defined* the running method version — where same-name resolution restarts) and `.refMethodName`. `callSuper` is a new lazy special form: it reads those markers from the current env, resolves the method starting at the super generators, re-homes it onto the instance with a **fresh super-context one level further up** (so chained `callSuper()` walks `C→B→A`), and forwards its evaluated args. **Past-the-root** (no parent definition of the name) resolves to a clean `NULL` — no recursion, no panic.

### Active bindings
A `fields = list(ab = function(v) …)` entry whose value is a closure is an **active binding**: reading `obj$ab` **calls** it as a nullary getter (`missing(v)` TRUE); `obj$ab <- val` **calls** it as a setter (`v` bound, `missing(v)` FALSE). The function is **re-homed onto each instance** (so it reads sibling fields and writes them with `<<-`); `$new`/`$copy` install it per instance (the copy gets its *own* re-homed binding, never the source's). A new `missing(x)` special form reports whether a formal was supplied in the current frame, which is what distinguishes the two directions.

### Multiple inheritance
`contains = c("A", "B")`. The single `.refParent` link becomes a `.refParents` **list**; a new `linearization` does a **left-to-right depth-first** pre-order walk (de-duping shared ancestors, so a diamond's base appears once) that drives all effective-field/method/active-binding/class-chain computations and the cycle check. Precedence is most-derived-first, left-to-right (own ⊳ A ⊳ B ⊳ ancestors). C3 is **not** implemented (documented simple DFS). `resolve_contains` now accepts a character vector.

### Rc-safety & re-entrancy
- **Active-binding re-entrancy:** getter/setter run through the depth-bounded call path, so a self-referential getter hits `MAX_EVAL_DEPTH` with a clean error rather than borrow-panicking or hanging. Field reads/writes use the existing take-and-release per-operation borrows (no double-borrow).
- **`callSuper` past the root:** clean `NULL`, never a panic or unbounded walk (each step strictly ascends a finite DAG).
- **MI cycles:** the name-in-ancestry check (`would_form_cycle`) runs over **every** listed parent, so `A↔B`, self-inheritance, and cyclic diamonds are rejected at `setRefClass` time; the multi-parent graph stays a DAG. `linearization` uses a `same_env` (pointer-identity) visited set and a `MAX_CHAIN_DEPTH` bound, so it terminates even on a (rejected) corrupt cyclic graph.
- **New Rc edges:** `.refParents` (child→parent DAG), the super-context's `Weak` parent→instance link (transient, never stored), and an active binding's instance-homed closure. The last forms the same `instance → closure → instance` self-cycle as `.self` (active bindings *must* live on the instance), but points only at the *same already-charged* instance and creates no new environment — bounded by `MAX_ENVIRONMENTS`, widening no leak boundary. The module ownership note was updated to document this.

### Tests
16 new R-syntax tests in `r-runtime`: callSuper chaining/arg-forwarding/three-level walk/past-root-NULL/field-mutation; active-binding getter/setter/roundtrip/inherited/copy-independent; MI method+field union, left-to-right precedence, is/inherits, diamond de-dup, class chain, cycle rejection; `missing()`; plus an R-24/R-25 regression guard. `cargo test -p coding-adventures-s-runtime -p coding-adventures-r-runtime` is **green (200 + 202 + 2 doctests)**; `cargo clippy` clean on both crates.

### Security review
A senior-Rust-security-engineer sub-agent reviewed `git diff origin/main...HEAD` against active-binding re-entrancy, `callSuper` past-root, MI cycle detection, Rc cycles, and crafted-input panics. **Verdict: PASS.** The one finding (LOW, doc-only) — that active bindings introduce a new at-rest instance self-cycle not reflected in the module note — was fixed by updating the documentation; it is bounded by `MAX_ENVIRONMENTS` exactly like the pre-existing `.self` cycle and adds no new growth vector.

### Spec
`code/specs/R00-r-language.md` R-26 section replaces the R-25 deferral note with the full design; §5 out-of-scope updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
