### PR TITLE
feat(closurec): for-of end-to-end (CLOC23)

### DIFF
--- a/code/packages/rust/closure-emitter/CHANGELOG.md
+++ b/code/packages/rust/closure-emitter/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to the `coding-adventures-closure-emitter` crate will be documented in this file.
 
+## [0.17.0] - 2026-06-20
+
+### Added — CLOC23: emit `for (… of …)`
+
+New `emit_for_of` writes `for ( <left> of <right> ) <body>` — identical to
+`emit_for_in` but with the `of` keyword, spaced on both sides for the same
+token-separation reason (the left ends in an identifier and the right starts
+with one). Added emitter unit tests for the `var` declaration-left and
+expression-left forms.
+
 ## [0.16.0] - 2026-06-20
 
 ### Added — CLOC22: emit `for (… in …)`

--- a/code/packages/rust/closure-emitter/Cargo.toml
+++ b/code/packages/rust/closure-emitter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-emitter"
-version = "0.16.0"
+version = "0.17.0"
 edition = "2021"
 description = "JavaScript code emitter for the Closure Compiler clone. Per CLOC07's emit contract. Takes a finalized Program + sidecar and produces output JavaScript text + companion source map. Runs after every pass in the pipeline."
 

--- a/code/packages/rust/closure-emitter/src/lib.rs
+++ b/code/packages/rust/closure-emitter/src/lib.rs
@@ -68,7 +68,8 @@ use coding_adventures_javascript_ast::{
     BooleanLiteral,
     BreakStatement, CallExpression, CatchClause, ConditionalExpression, ContinueStatement,
     Declaration, DebuggerStatement, DoWhileStatement,
-    EmptyStatement, Expression, ExpressionStatement, ForInStatement, ForInit, ForStatement,
+    EmptyStatement, Expression, ExpressionStatement, ForInStatement, ForInit, ForOfStatement,
+    ForStatement,
     FunctionDeclaration,
     FunctionParam, Identifier, IfStatement, LabeledStatement, LogicalExpression, LogicalOperator,
     MemberExpression, NullLiteral, NumericLiteral, ObjectExpression, Program, ProgramItem,
@@ -295,6 +296,7 @@ impl<'a> Emitter<'a> {
             TaggedStatement::DoWhileStatement(d) => self.emit_do_while(d),
             TaggedStatement::ForStatement(f) => self.emit_for(f),
             TaggedStatement::ForInStatement(f) => self.emit_for_in(f),
+            TaggedStatement::ForOfStatement(f) => self.emit_for_of(f),
             TaggedStatement::ReturnStatement(r) => self.emit_return(r),
             TaggedStatement::BreakStatement(b) => self.emit_break(b),
             TaggedStatement::ContinueStatement(c) => self.emit_continue(c),
@@ -535,6 +537,29 @@ impl<'a> Emitter<'a> {
         }
         self.required_ws();
         self.write_str("in");
+        self.required_ws();
+        self.emit_expression(&f.right);
+        self.write_str(")");
+        self.pretty_ws();
+        self.emit_statement(&f.body);
+    }
+
+    fn emit_for_of(&mut self, f: &ForOfStatement) {
+        // `for ( <left> of <right> ) <body>` — identical to for-in but with the
+        // `of` keyword, spaced on both sides for the same token-separation
+        // reason (the left ends in an identifier and the right starts with one).
+        self.maybe_map(&f.cv);
+        self.write_str("for");
+        self.pretty_ws();
+        self.write_str("(");
+        match &f.left {
+            ForInit::VariableDeclaration(v) => {
+                self.emit_variable_declaration(v, /*top_level=*/ false);
+            }
+            ForInit::Expression(e) => self.emit_expression(e),
+        }
+        self.required_ws();
+        self.write_str("of");
         self.required_ws();
         self.emit_expression(&f.right);
         self.write_str(")");
@@ -2657,6 +2682,43 @@ mod tests {
         assert_eq!(
             emit_default(program().with_body(vec![item])).code,
             "for(k in obj)a;"
+        );
+    }
+
+    // ---- for / of (CLOC23) ------------------------------------
+
+    #[test]
+    fn for_of_var_left_block_body_emits_with_spaced_of() {
+        // `for (var v of it) { a }` — `of` spaced on both sides.
+        let f = ForOfStatement {
+            cv: None,
+            left: for_in_var_left("v", VarKind::Var),
+            right: ident("it"),
+            body: Box::new(Statement::block_statement(block_with("a"))),
+        };
+        let item = ProgramItem::Statement(Statement::for_of_statement(f));
+        assert_eq!(
+            emit_default(program().with_body(vec![item])).code,
+            "for(var v of it){a}"
+        );
+    }
+
+    #[test]
+    fn for_of_expression_left_bare_body_emits() {
+        // `for (v of it) a;` — existing-target left, bare-statement body.
+        let f = ForOfStatement {
+            cv: None,
+            left: ForInit::Expression(ident("v")),
+            right: ident("it"),
+            body: Box::new(Statement::expression_statement(ExpressionStatement {
+                cv: None,
+                expression: ident("a"),
+            })),
+        };
+        let item = ProgramItem::Statement(Statement::for_of_statement(f));
+        assert_eq!(
+            emit_default(program().with_body(vec![item])).code,
+            "for(v of it)a;"
         );
     }
 

--- a/code/packages/rust/closure-pass-constant-fold/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-constant-fold/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to the `coding-adventures-closure-pass-constant-fold` crate will be documented in this file.
 
+## [0.16.0] - 2026-06-20
+
+### Added — CLOC23: fold inside `for`-`of`
+
+`fold_tagged` now has a `ForOfStatement` arm that recurses constant folding into
+the loop's left, the iterable right expression, and the body — identical to the
+`for`-`in` handling.
+
 ## [0.15.0] - 2026-06-20
 
 ### Added — CLOC22: fold inside `for`-`in`

--- a/code/packages/rust/closure-pass-constant-fold/Cargo.toml
+++ b/code/packages/rust/closure-pass-constant-fold/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-constant-fold"
-version = "0.15.0"
+version = "0.16.0"
 edition = "2021"
 description = "Constant-folding optimization pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Folds compile-time-evaluable expressions like `2 + 3 → 5`."
 

--- a/code/packages/rust/closure-pass-constant-fold/src/lib.rs
+++ b/code/packages/rust/closure-pass-constant-fold/src/lib.rs
@@ -84,7 +84,8 @@ use coding_adventures_correlation_vector::{CVLog, Contribution};
 use coding_adventures_javascript_ast::{
     statement::TaggedStatement, ArrayExpression, AssignmentExpression, BinaryExpression,
     BinaryOperator, BlockStatement, BooleanLiteral, CallExpression, ConditionalExpression,
-    Declaration, Expression, ExpressionStatement, ForInStatement, ForInit, ForStatement,
+    Declaration, Expression, ExpressionStatement, ForInStatement, ForInit, ForOfStatement,
+    ForStatement,
     FunctionDeclaration,
     IfStatement, LogicalExpression, LogicalOperator, MemberExpression, NullLiteral, NumericLiteral,
     ObjectExpression, Program, ProgramItem, Property, PropertyKey, ReturnStatement, Statement,
@@ -288,6 +289,17 @@ fn fold_tagged_statement(stmt: &TaggedStatement, st: &mut FoldState) -> TaggedSt
             body: Box::new(fold_statement(&s.body, st)),
         }),
         TaggedStatement::ForInStatement(s) => TaggedStatement::ForInStatement(ForInStatement {
+            cv: s.cv.clone(),
+            left: match &s.left {
+                ForInit::VariableDeclaration(v) => {
+                    ForInit::VariableDeclaration(fold_variable_declaration(v, st))
+                }
+                ForInit::Expression(e) => ForInit::Expression(fold_expression(e, st)),
+            },
+            right: fold_expression(&s.right, st),
+            body: Box::new(fold_statement(&s.body, st)),
+        }),
+        TaggedStatement::ForOfStatement(s) => TaggedStatement::ForOfStatement(ForOfStatement {
             cv: s.cv.clone(),
             left: match &s.left {
                 ForInit::VariableDeclaration(v) => {

--- a/code/packages/rust/closure-pass-dce/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-dce/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to the `coding-adventures-closure-pass-dce` crate will be documented in this file.
 
+## [0.14.0] - 2026-06-20
+
+### Added — CLOC23: DCE inside `for`-`of`
+
+New `ForOfStatement` arm recurses dead-code elimination into the loop's left,
+right expression, and body. Like the other loops, a for-of is NOT a terminator
+(the iterable may be empty), so code after it stays reachable.
+
 ## [0.13.0] - 2026-06-20
 
 ### Added — CLOC22: DCE inside `for`-`in`

--- a/code/packages/rust/closure-pass-dce/Cargo.toml
+++ b/code/packages/rust/closure-pass-dce/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-dce"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 description = "Dead-code elimination pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Drops code after definite-terminator statements and removes EmptyStatement noise."
 

--- a/code/packages/rust/closure-pass-dce/src/lib.rs
+++ b/code/packages/rust/closure-pass-dce/src/lib.rs
@@ -73,6 +73,7 @@ use coding_adventures_javascript_ast::{
     statement::TaggedStatement, ArrayExpression, AssignmentExpression, BigIntLiteral,
     BinaryExpression, BlockStatement, BooleanLiteral, CallExpression, ConditionalExpression,
     Declaration, EmptyStatement, Expression, ExpressionStatement, ForInStatement, ForInit,
+    ForOfStatement,
     ForStatement,
     FunctionDeclaration, IfStatement, LogicalExpression, MemberExpression, NullLiteral,
     NumericLiteral, ObjectExpression, Program, ProgramItem, Property, PropertyKey,
@@ -292,6 +293,17 @@ fn dce_tagged_statement(stmt: &TaggedStatement, st: &mut DceState) -> TaggedStat
         // loops, a for-in is NOT a terminator (the body may run zero times),
         // so code after it stays reachable.
         TaggedStatement::ForInStatement(s) => TaggedStatement::ForInStatement(ForInStatement {
+            cv: s.cv.clone(),
+            left: match &s.left {
+                ForInit::VariableDeclaration(v) => {
+                    ForInit::VariableDeclaration(dce_variable_declaration(v, st))
+                }
+                ForInit::Expression(e) => ForInit::Expression(dce_expression(e, st)),
+            },
+            right: dce_expression(&s.right, st),
+            body: Box::new(dce_statement(&s.body, st)),
+        }),
+        TaggedStatement::ForOfStatement(s) => TaggedStatement::ForOfStatement(ForOfStatement {
             cv: s.cv.clone(),
             left: match &s.left {
                 ForInit::VariableDeclaration(v) => {

--- a/code/packages/rust/closure-pass-fold-control-flow/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-fold-control-flow/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to the `coding-adventures-closure-pass-fold-control-flow` crate will be documented in this file.
 
+## [0.13.0] - 2026-06-20
+
+### Added — CLOC23: fold control flow inside `for`-`of`
+
+New `ForOfStatement` arm recurses control-flow folding into the loop's left,
+right expression, and body. Like the other loops, a for-of is not eliminated and
+is not a terminator (the iterable may be empty, so the body may run zero times).
+
 ## [0.12.0] - 2026-06-20
 
 ### Added — CLOC22: fold control flow inside `for`-`in`

--- a/code/packages/rust/closure-pass-fold-control-flow/Cargo.toml
+++ b/code/packages/rust/closure-pass-fold-control-flow/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-fold-control-flow"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 description = "Control-flow folding pass for the Closure Compiler clone. Slots between constant-fold and DCE per CLOC06's canonical pass set. Eliminates dead branches (`if (false) A else B → B`), removes unreachable code after `return`/`throw`, and collapses degenerate switch arms."
 

--- a/code/packages/rust/closure-pass-fold-control-flow/src/lib.rs
+++ b/code/packages/rust/closure-pass-fold-control-flow/src/lib.rs
@@ -58,7 +58,8 @@ use coding_adventures_javascript_ast::{
     statement::TaggedStatement, ArrayExpression, AssignmentExpression, AssignmentOperator,
     AssignmentTarget, BinaryExpression, BindingTarget, BlockStatement, CallExpression,
     ConditionalExpression, Declaration, EmptyStatement, Expression, ExpressionStatement, ForInit,
-    ForInStatement, ForStatement, FunctionDeclaration, Identifier, IfStatement, LogicalExpression,
+    ForInStatement, ForOfStatement, ForStatement, FunctionDeclaration, Identifier, IfStatement,
+    LogicalExpression,
     LogicalOperator,
     MemberExpression, ObjectExpression, Program, ProgramItem, Property, PropertyKey,
     ReturnStatement, Statement, UnaryExpression, UnaryOperator, VarKind, VariableDeclaration,
@@ -244,6 +245,19 @@ fn fold_tagged_statement(stmt: &TaggedStatement, st: &mut FoldState) -> Statemen
         }
         TaggedStatement::ForInStatement(s) => {
             Statement::Tagged(TaggedStatement::ForInStatement(ForInStatement {
+                cv: s.cv.clone(),
+                left: match &s.left {
+                    ForInit::VariableDeclaration(v) => {
+                        ForInit::VariableDeclaration(fold_variable_declaration(v, st))
+                    }
+                    ForInit::Expression(e) => ForInit::Expression(fold_expression(e, st)),
+                },
+                right: fold_expression(&s.right, st),
+                body: Box::new(fold_statement(&s.body, st)),
+            }))
+        }
+        TaggedStatement::ForOfStatement(s) => {
+            Statement::Tagged(TaggedStatement::ForOfStatement(ForOfStatement {
                 cv: s.cv.clone(),
                 left: match &s.left {
                     ForInit::VariableDeclaration(v) => {

--- a/code/packages/rust/closure-pass-inline-variables/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-inline-variables/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to the `coding-adventures-closure-pass-inline-variables` crate will be documented in this file.
 
+## [0.6.0] - 2026-06-20
+
+### Added — CLOC23: variable inlining inside `for`-`of`
+
+`count_decl_names_stmt`, `count_uses_stmt`, and `propagate_in_stmt` now recurse
+through `ForOfStatement`, counting the `left` declaration as the loop-variable
+binding — identical to the `for`-`in` handling.
+
 ## [0.5.0] - 2026-06-20
 
 ### Added — CLOC22: variable inlining inside `for`-`in`

--- a/code/packages/rust/closure-pass-inline-variables/Cargo.toml
+++ b/code/packages/rust/closure-pass-inline-variables/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-inline-variables"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 description = "Constant-propagation pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Replaces references to a top-level `const` bound to a literal with the literal itself, so the binding becomes unused and remove-unused-vars deletes it."
 

--- a/code/packages/rust/closure-pass-inline-variables/src/lib.rs
+++ b/code/packages/rust/closure-pass-inline-variables/src/lib.rs
@@ -434,6 +434,13 @@ fn count_decl_names_stmt(
                 }
                 count_decl_names_stmt(&fs.body, out, nodes_touched);
             }
+            TaggedStatement::ForOfStatement(fs) => {
+                // The for-in `left`, when a declaration, binds the loop variable.
+                if let ForInit::VariableDeclaration(vd) = &fs.left {
+                    count_decl_names_var(vd, out);
+                }
+                count_decl_names_stmt(&fs.body, out, nodes_touched);
+            }
             TaggedStatement::LabeledStatement(ls) => {
                 count_decl_names_stmt(&ls.body, out, nodes_touched)
             }
@@ -565,6 +572,20 @@ fn count_uses_stmt(stmt: &Statement, name: &str, count: &mut usize) {
                 count_uses_stmt(&fs.body, name, count);
             }
             TaggedStatement::ForInStatement(fs) => {
+                match &fs.left {
+                    ForInit::VariableDeclaration(vd) => {
+                        for d in &vd.declarations {
+                            if let Some(i) = &d.init {
+                                count_uses_expr(i, name, count);
+                            }
+                        }
+                    }
+                    ForInit::Expression(e) => count_uses_expr(e, name, count),
+                }
+                count_uses_expr(&fs.right, name, count);
+                count_uses_stmt(&fs.body, name, count);
+            }
+            TaggedStatement::ForOfStatement(fs) => {
                 match &fs.left {
                     ForInit::VariableDeclaration(vd) => {
                         for d in &vd.declarations {
@@ -786,6 +807,20 @@ fn propagate_in_stmt(stmt: &mut Statement, cand: &ConstCandidate) -> bool {
                 changed |= propagate_in_stmt(&mut fs.body, cand);
             }
             TaggedStatement::ForInStatement(fs) => {
+                match &mut fs.left {
+                    ForInit::VariableDeclaration(vd) => {
+                        for d in &mut vd.declarations {
+                            if let Some(i) = &mut d.init {
+                                changed |= propagate_in_expr(i, cand);
+                            }
+                        }
+                    }
+                    ForInit::Expression(e) => changed |= propagate_in_expr(e, cand),
+                }
+                changed |= propagate_in_expr(&mut fs.right, cand);
+                changed |= propagate_in_stmt(&mut fs.body, cand);
+            }
+            TaggedStatement::ForOfStatement(fs) => {
                 match &mut fs.left {
                     ForInit::VariableDeclaration(vd) => {
                         for d in &mut vd.declarations {

--- a/code/packages/rust/closure-pass-inline/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-inline/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to the `coding-adventures-closure-pass-inline` crate will be documented in this file.
 
+## [0.20.0] - 2026-06-20
+
+### Added — CLOC23: function inlining across `for`-`of`
+
+Every phase of the pass recurses through `ForOfStatement` (left / right
+expression / body), counting the `left` declaration as the loop-variable
+binding — identical to the `for`-`in` handling.
+
 ## [0.19.0] - 2026-06-20
 
 ### Added — CLOC22: function inlining across `for`-`in`

--- a/code/packages/rust/closure-pass-inline/Cargo.toml
+++ b/code/packages/rust/closure-pass-inline/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-inline"
-version = "0.19.0"
+version = "0.20.0"
 edition = "2021"
 description = "Function-inlining pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Substitutes small or single-use function bodies at their call sites to enable downstream folding and shrink call overhead."
 

--- a/code/packages/rust/closure-pass-inline/src/lib.rs
+++ b/code/packages/rust/closure-pass-inline/src/lib.rs
@@ -580,6 +580,13 @@ fn count_decl_names_stmt(
                 }
                 count_decl_names_stmt(&fs.body, out, nodes_touched);
             }
+            TaggedStatement::ForOfStatement(fs) => {
+                // The for-in `left`, when a declaration, binds the loop variable.
+                if let ForInit::VariableDeclaration(vd) = &fs.left {
+                    count_decl_names_var(vd, out);
+                }
+                count_decl_names_stmt(&fs.body, out, nodes_touched);
+            }
             TaggedStatement::LabeledStatement(ls) => {
                 count_decl_names_stmt(&ls.body, out, nodes_touched)
             }
@@ -797,6 +804,20 @@ fn tally_stmt(stmt: &Statement, cand: &InlineCandidate, t: &mut Tally) {
                 tally_stmt(&fs.body, cand, t);
             }
             TaggedStatement::ForInStatement(fs) => {
+                match &fs.left {
+                    ForInit::VariableDeclaration(vd) => {
+                        for d in &vd.declarations {
+                            if let Some(i) = &d.init {
+                                tally_expr(i, cand, t);
+                            }
+                        }
+                    }
+                    ForInit::Expression(e) => tally_expr(e, cand, t),
+                }
+                tally_expr(&fs.right, cand, t);
+                tally_stmt(&fs.body, cand, t);
+            }
+            TaggedStatement::ForOfStatement(fs) => {
                 match &fs.left {
                     ForInit::VariableDeclaration(vd) => {
                         for d in &vd.declarations {
@@ -1037,6 +1058,20 @@ fn inline_in_stmt(stmt: &mut Statement, cand: &InlineCandidate) -> bool {
                 changed |= inline_in_stmt(&mut fs.body, cand);
             }
             TaggedStatement::ForInStatement(fs) => {
+                match &mut fs.left {
+                    ForInit::VariableDeclaration(vd) => {
+                        for d in &mut vd.declarations {
+                            if let Some(i) = &mut d.init {
+                                changed |= inline_in_expr(i, cand);
+                            }
+                        }
+                    }
+                    ForInit::Expression(e) => changed |= inline_in_expr(e, cand),
+                }
+                changed |= inline_in_expr(&mut fs.right, cand);
+                changed |= inline_in_stmt(&mut fs.body, cand);
+            }
+            TaggedStatement::ForOfStatement(fs) => {
                 match &mut fs.left {
                     ForInit::VariableDeclaration(vd) => {
                         for d in &mut vd.declarations {
@@ -1953,6 +1988,9 @@ fn splice_void_in_stmt(
             TaggedStatement::ForInStatement(fs) => {
                 splice_void_in_slot(&mut fs.body, cand, avoid, nodes_touched)
             }
+            TaggedStatement::ForOfStatement(fs) => {
+                splice_void_in_slot(&mut fs.body, cand, avoid, nodes_touched)
+            }
             TaggedStatement::LabeledStatement(ls) => {
                 splice_void_in_slot(&mut ls.body, cand, avoid, nodes_touched)
             }
@@ -2795,6 +2833,9 @@ fn splice_valued_in_stmt(
             TaggedStatement::ForInStatement(fs) => {
                 splice_valued_in_stmt(&mut fs.body, cand, avoid, nodes_touched)
             }
+            TaggedStatement::ForOfStatement(fs) => {
+                splice_valued_in_stmt(&mut fs.body, cand, avoid, nodes_touched)
+            }
             TaggedStatement::LabeledStatement(ls) => {
                 splice_valued_in_stmt(&mut ls.body, cand, avoid, nodes_touched)
             }
@@ -3106,6 +3147,20 @@ fn collect_used_idents_stmt(stmt: &Statement, out: &mut HashSet<String>) {
                 collect_used_idents_stmt(&fs.body, out);
             }
             TaggedStatement::ForInStatement(fs) => {
+                match &fs.left {
+                    ForInit::VariableDeclaration(vd) => {
+                        for d in &vd.declarations {
+                            if let Some(i) = &d.init {
+                                collect_binding_idents_expr(i, out);
+                            }
+                        }
+                    }
+                    ForInit::Expression(e) => collect_binding_idents_expr(e, out),
+                }
+                collect_binding_idents_expr(&fs.right, out);
+                collect_used_idents_stmt(&fs.body, out);
+            }
+            TaggedStatement::ForOfStatement(fs) => {
                 match &fs.left {
                     ForInit::VariableDeclaration(vd) => {
                         for d in &vd.declarations {

--- a/code/packages/rust/closure-pass-rename-globals/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-rename-globals/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to the `coding-adventures-closure-pass-rename-globals` crate will be documented in this file.
 
+## [0.6.0] - 2026-06-20
+
+### Added — CLOC23: global renaming across `for`-`of`
+
+`count_decl_names_stmt`, `collect_all_idents_stmt`, and `rename_apply_tagged`
+recurse through `ForOfStatement` (left / right / body), mirroring the `for`-`in`
+handling so the loop variable and uses inside the body rename consistently.
+
 ## [0.5.0] - 2026-06-20
 
 ### Added — CLOC22: global renaming across `for`-`in`

--- a/code/packages/rust/closure-pass-rename-globals/Cargo.toml
+++ b/code/packages/rust/closure-pass-rename-globals/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-rename-globals"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 description = "Aggressive top-level (global) renaming pass for the Closure Compiler clone — the ADVANCED-level complement to closure-pass-rename. Shortens program-private top-level names, gated by an externs do-not-rename boundary."
 

--- a/code/packages/rust/closure-pass-rename-globals/src/lib.rs
+++ b/code/packages/rust/closure-pass-rename-globals/src/lib.rs
@@ -358,6 +358,12 @@ fn count_decl_names_stmt(
                 }
                 count_decl_names_stmt(&fs.body, out, nodes_touched);
             }
+            TaggedStatement::ForOfStatement(fs) => {
+                if let ForInit::VariableDeclaration(vd) = &fs.left {
+                    count_decl_names_var(vd, out);
+                }
+                count_decl_names_stmt(&fs.body, out, nodes_touched);
+            }
             TaggedStatement::LabeledStatement(ls) => {
                 count_decl_names_stmt(&ls.body, out, nodes_touched)
             }
@@ -489,6 +495,22 @@ fn collect_all_idents_stmt(stmt: &Statement, out: &mut HashSet<String>) {
                 collect_all_idents_stmt(&fs.body, out);
             }
             TaggedStatement::ForInStatement(fs) => {
+                match &fs.left {
+                    ForInit::VariableDeclaration(vd) => {
+                        for d in &vd.declarations {
+                            let BindingTarget::Identifier(id) = &d.id;
+                            out.insert(id.name.clone());
+                            if let Some(i) = &d.init {
+                                collect_all_idents_expr(i, out);
+                            }
+                        }
+                    }
+                    ForInit::Expression(e) => collect_all_idents_expr(e, out),
+                }
+                collect_all_idents_expr(&fs.right, out);
+                collect_all_idents_stmt(&fs.body, out);
+            }
+            TaggedStatement::ForOfStatement(fs) => {
                 match &fs.left {
                     ForInit::VariableDeclaration(vd) => {
                         for d in &vd.declarations {
@@ -737,6 +759,24 @@ fn rename_apply_tagged(t: &mut TaggedStatement, map: &HashMap<String, String>) {
             rename_apply_stmt(&mut fs.body, map);
         }
         TaggedStatement::ForInStatement(fs) => {
+            match &mut fs.left {
+                ForInit::VariableDeclaration(vd) => {
+                    for d in &mut vd.declarations {
+                        let BindingTarget::Identifier(id) = &mut d.id;
+                        if let Some(new) = map.get(&id.name) {
+                            id.name = new.clone();
+                        }
+                        if let Some(i) = &mut d.init {
+                            rename_apply_expr(i, map);
+                        }
+                    }
+                }
+                ForInit::Expression(e) => rename_apply_expr(e, map),
+            }
+            rename_apply_expr(&mut fs.right, map);
+            rename_apply_stmt(&mut fs.body, map);
+        }
+        TaggedStatement::ForOfStatement(fs) => {
             match &mut fs.left {
                 ForInit::VariableDeclaration(vd) => {
                     for d in &mut vd.declarations {

--- a/code/packages/rust/closure-pass-rename-properties/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-rename-properties/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to the `coding-adventures-closure-pass-rename-properties` crate will be documented in this file.
 
+## [0.8.0] - 2026-06-20
+
+### Added — CLOC23: property renaming recurses through `for`-`of`
+
+`classify_stmt` and `rewrite_stmt` recurse through `ForOfStatement` (left / right
+/ body) so property accesses inside a for-of loop and in the iterable expression
+are renamed consistently — identical to the `for`-`in` handling.
+
 ## [0.7.0] - 2026-06-20
 
 ### Added — CLOC22: property renaming recurses through `for`-`in`

--- a/code/packages/rust/closure-pass-rename-properties/Cargo.toml
+++ b/code/packages/rust/closure-pass-rename-properties/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-rename-properties"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
 description = "Aggressive property renaming pass for the Closure Compiler clone (ADVANCED-only). Consistently shortens program-private object property names that are never quoted/computed and not in the built-in or externs do-not-rename boundary."
 

--- a/code/packages/rust/closure-pass-rename-properties/src/lib.rs
+++ b/code/packages/rust/closure-pass-rename-properties/src/lib.rs
@@ -1042,6 +1042,20 @@ fn classify_stmt(stmt: &Statement, cls: &mut Classify, nodes_touched: &mut u32) 
                 classify_expr(&fs.right, cls);
                 classify_stmt(&fs.body, cls, nodes_touched);
             }
+            TaggedStatement::ForOfStatement(fs) => {
+                match &fs.left {
+                    ForInit::VariableDeclaration(vd) => {
+                        for d in &vd.declarations {
+                            if let Some(i) = &d.init {
+                                classify_expr(i, cls);
+                            }
+                        }
+                    }
+                    ForInit::Expression(e) => classify_expr(e, cls),
+                }
+                classify_expr(&fs.right, cls);
+                classify_stmt(&fs.body, cls, nodes_touched);
+            }
             TaggedStatement::ReturnStatement(rs) => {
                 if let Some(a) = &rs.argument {
                     classify_expr(a, cls);
@@ -1241,6 +1255,20 @@ fn rewrite_stmt(stmt: &mut Statement, map: &HashMap<String, String>) {
                 rewrite_stmt(&mut fs.body, map);
             }
             TaggedStatement::ForInStatement(fs) => {
+                match &mut fs.left {
+                    ForInit::VariableDeclaration(vd) => {
+                        for d in &mut vd.declarations {
+                            if let Some(i) = &mut d.init {
+                                rewrite_expr(i, map);
+                            }
+                        }
+                    }
+                    ForInit::Expression(e) => rewrite_expr(e, map),
+                }
+                rewrite_expr(&mut fs.right, map);
+                rewrite_stmt(&mut fs.body, map);
+            }
+            TaggedStatement::ForOfStatement(fs) => {
                 match &mut fs.left {
                     ForInit::VariableDeclaration(vd) => {
                         for d in &mut vd.declarations {

--- a/code/packages/rust/closure-pass-rename/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-rename/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to the `coding-adventures-closure-pass-rename` crate will be documented in this file.
 
+## [0.9.0] - 2026-06-20
+
+### Added — CLOC23: local renaming across `for`-`of` (loop-variable soundness)
+
+Every phase of the pass recurses through `ForOfStatement`, treating the loop
+variable identically to `for`-`in`: for `for (var/let/const v of it)` the `left`
+binding is recorded as a rename occurrence and its declared name is rewritten via
+the rename map, so the binding and its uses inside the body rename *consistently*.
+Verified end-to-end: `for (var entry of values)` with `sum + entry` →
+`for (var c of a)` with `b + c` under ADVANCED.
+
 ## [0.8.0] - 2026-06-20
 
 ### Added — CLOC22: local renaming across `for`-`in` (loop-variable soundness)

--- a/code/packages/rust/closure-pass-rename/Cargo.toml
+++ b/code/packages/rust/closure-pass-rename/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-rename"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 description = "Variable renaming pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Replaces non-exported binding names with shorter identifiers to reduce output size while preserving externally-visible names and semantics."
 

--- a/code/packages/rust/closure-pass-rename/src/lib.rs
+++ b/code/packages/rust/closure-pass-rename/src/lib.rs
@@ -280,6 +280,9 @@ fn process_tagged(t: &mut TaggedStatement, nodes_touched: &mut u32) -> bool {
         TaggedStatement::ForInStatement(fs) => {
             changed |= process_stmt(&mut fs.body, nodes_touched);
         }
+        TaggedStatement::ForOfStatement(fs) => {
+            changed |= process_stmt(&mut fs.body, nodes_touched);
+        }
         TaggedStatement::LabeledStatement(ls) => {
             changed |= process_stmt(&mut ls.body, nodes_touched);
         }
@@ -372,6 +375,7 @@ fn stmt_has_function(stmt: &Statement) -> bool {
             TaggedStatement::DoWhileStatement(ds) => stmt_has_function(&ds.body),
             TaggedStatement::ForStatement(fs) => stmt_has_function(&fs.body),
             TaggedStatement::ForInStatement(fs) => stmt_has_function(&fs.body),
+            TaggedStatement::ForOfStatement(fs) => stmt_has_function(&fs.body),
             TaggedStatement::LabeledStatement(ls) => stmt_has_function(&ls.body),
             TaggedStatement::SwitchStatement(ss) => ss
                 .cases
@@ -600,6 +604,14 @@ fn collect_decl_occurrences_stmt(stmt: &Statement, out: &mut Vec<(String, bool)>
                 }
                 collect_decl_occurrences_stmt(&fs.body, out, true);
             }
+            TaggedStatement::ForOfStatement(fs) => {
+                // The for-in `left` binding (`for (var/let/const k in o)`) is the
+                // loop variable — a rename target scoped to the loop.
+                if let ForInit::VariableDeclaration(vd) = &fs.left {
+                    push_var_occurrences(vd, out, true);
+                }
+                collect_decl_occurrences_stmt(&fs.body, out, true);
+            }
             // A label does not introduce a variable scope; keep `nested`.
             TaggedStatement::LabeledStatement(ls) => {
                 collect_decl_occurrences_stmt(&ls.body, out, nested)
@@ -731,6 +743,22 @@ fn collect_all_idents_stmt(stmt: &Statement, out: &mut HashSet<String>) {
                 collect_all_idents_stmt(&fs.body, out);
             }
             TaggedStatement::ForInStatement(fs) => {
+                match &fs.left {
+                    ForInit::VariableDeclaration(vd) => {
+                        for d in &vd.declarations {
+                            let BindingTarget::Identifier(id) = &d.id;
+                            out.insert(id.name.clone());
+                            if let Some(i) = &d.init {
+                                collect_all_idents_expr(i, out);
+                            }
+                        }
+                    }
+                    ForInit::Expression(e) => collect_all_idents_expr(e, out),
+                }
+                collect_all_idents_expr(&fs.right, out);
+                collect_all_idents_stmt(&fs.body, out);
+            }
+            TaggedStatement::ForOfStatement(fs) => {
                 match &fs.left {
                     ForInit::VariableDeclaration(vd) => {
                         for d in &vd.declarations {
@@ -957,6 +985,27 @@ fn rewrite_uses_tagged(t: &mut TaggedStatement, map: &HashMap<String, String>) {
             rewrite_uses_stmt(&mut fs.body, map);
         }
         TaggedStatement::ForInStatement(fs) => {
+            // Rewrite the loop-variable binding name (for the declaration form)
+            // or the assignment-target uses (for the expression form), then the
+            // enumerated expression and the body.
+            match &mut fs.left {
+                ForInit::VariableDeclaration(vd) => {
+                    for d in &mut vd.declarations {
+                        let BindingTarget::Identifier(id) = &mut d.id;
+                        if let Some(new) = map.get(&id.name) {
+                            id.name = new.clone();
+                        }
+                        if let Some(i) = &mut d.init {
+                            rewrite_uses_expr(i, map);
+                        }
+                    }
+                }
+                ForInit::Expression(e) => rewrite_uses_expr(e, map),
+            }
+            rewrite_uses_expr(&mut fs.right, map);
+            rewrite_uses_stmt(&mut fs.body, map);
+        }
+        TaggedStatement::ForOfStatement(fs) => {
             // Rewrite the loop-variable binding name (for the declaration form)
             // or the assignment-target uses (for the expression form), then the
             // enumerated expression and the body.

--- a/code/packages/rust/closure-scope-analyzer/CHANGELOG.md
+++ b/code/packages/rust/closure-scope-analyzer/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to the `coding-adventures-closure-scope-analyzer` crate will be documented in this file.
 
+## [0.9.0] - 2026-06-20
+
+### Added — CLOC23: scope analysis for `for`-`of`
+
+`walk_tagged_statement` now handles `ForOfStatement`: it walks the `left` (a
+loop-variable binding or assignment target), the iterable `right`, then the
+body — identical to the `for`-`in` handling.
+
 ## [0.8.0] - 2026-06-20
 
 ### Added — CLOC22: scope analysis for `for`-`in`

--- a/code/packages/rust/closure-scope-analyzer/Cargo.toml
+++ b/code/packages/rust/closure-scope-analyzer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-scope-analyzer"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 description = "Lexical scope + symbol-table analyzer for the Closure Compiler clone. Per CLOC13 — produces a `ScopeAnalysis` consumed by the rename, inline, treeshake, collapse-properties, and remove-unused-vars passes."
 

--- a/code/packages/rust/closure-scope-analyzer/src/lib.rs
+++ b/code/packages/rust/closure-scope-analyzer/src/lib.rs
@@ -652,6 +652,18 @@ fn walk_tagged_statement(
             walk_expression(&fs.right, ctx, analysis, pending);
             walk_statement(&fs.body, ctx, analysis, pending);
         }
+        TaggedStatement::ForOfStatement(fs) => {
+            // The for-in `left` declares (or targets) the loop variable; walk
+            // it, then the enumerated `right`, then the body.
+            match &fs.left {
+                ForInit::VariableDeclaration(vd) => {
+                    walk_variable_declaration(vd, ctx, analysis, pending);
+                }
+                ForInit::Expression(e) => walk_expression(e, ctx, analysis, pending),
+            }
+            walk_expression(&fs.right, ctx, analysis, pending);
+            walk_statement(&fs.body, ctx, analysis, pending);
+        }
         TaggedStatement::ReturnStatement(rs) => {
             if let Some(arg) = &rs.argument {
                 walk_expression(arg, ctx, analysis, pending);

--- a/code/packages/rust/javascript-ast/CHANGELOG.md
+++ b/code/packages/rust/javascript-ast/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to the `coding-adventures-javascript-ast` crate will be documented in this file.
 
+## [0.12.0] - 2026-06-20
+
+### Added — CLOC23: `ForOfStatement` (`for (left of right) body`)
+
+Adds `ForOfStatement { cv, left: ForInit, right: Expression, body: Box<Statement> }`,
+a new `TaggedStatement::ForOfStatement` variant, and a
+`Statement::for_of_statement` constructor. Structurally identical to
+`ForInStatement` (only the `of` vs `in` keyword and the iteration protocol
+differ), so the `left` reuses [`ForInit`] the same way. Making it representable
+lets the closurec CLI optimize for-of loops; previously any such program fell
+back to WHITESPACE_ONLY. (Destructuring left-hand sides and `using` bindings are
+not represented — the bridge declines them.)
+
 ## [0.11.0] - 2026-06-20
 
 ### Added — CLOC22: `ForInStatement` (`for (left in right) body`)

--- a/code/packages/rust/javascript-ast/Cargo.toml
+++ b/code/packages/rust/javascript-ast/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-javascript-ast"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2021"
 description = "Backend-agnostic JavaScript AST — full ESTree-compatible node taxonomy with optional per-node CV id. Reusable by the Closure-Compiler-clone and the future V8-in-Rust clone. Per CLOC02 / CLOC09."
 

--- a/code/packages/rust/javascript-ast/src/lib.rs
+++ b/code/packages/rust/javascript-ast/src/lib.rs
@@ -141,9 +141,9 @@ pub use expression::{
 };
 pub use statement::{
     BlockStatement, BreakStatement, CatchClause, ContinueStatement, DebuggerStatement,
-    DoWhileStatement, EmptyStatement, ExpressionStatement, ForInStatement, ForInit, ForStatement,
-    IfStatement, LabeledStatement, ReturnStatement, Statement, SwitchCase, SwitchStatement,
-    ThrowStatement, TryStatement, WhileStatement,
+    DoWhileStatement, EmptyStatement, ExpressionStatement, ForInStatement, ForInit, ForOfStatement,
+    ForStatement, IfStatement, LabeledStatement, ReturnStatement, Statement, SwitchCase,
+    SwitchStatement, ThrowStatement, TryStatement, WhileStatement,
 };
 
 /// A correlation-vector identifier. Aliased to `String` for v1 to match

--- a/code/packages/rust/javascript-ast/src/statement.rs
+++ b/code/packages/rust/javascript-ast/src/statement.rs
@@ -37,7 +37,10 @@
 //! - [`ForInStatement`] (CLOC22 — `for (left in right) body`, the
 //!   property-enumerating loop)
 //!
-//! Phase 2 will add `ForOfStatement` and `WithStatement`.
+//! - [`ForOfStatement`] (CLOC23 — `for (left of right) body`, the iterator
+//!   loop)
+//!
+//! Phase 2 will add `WithStatement`.
 
 use crate::declaration::{Declaration, VariableDeclaration};
 use crate::expression::{Expression, Identifier};
@@ -77,6 +80,7 @@ pub enum TaggedStatement {
     DoWhileStatement(DoWhileStatement),
     ForStatement(ForStatement),
     ForInStatement(ForInStatement),
+    ForOfStatement(ForOfStatement),
     ReturnStatement(ReturnStatement),
     BreakStatement(BreakStatement),
     ContinueStatement(ContinueStatement),
@@ -111,6 +115,9 @@ impl Statement {
     }
     pub fn for_in_statement(s: ForInStatement) -> Self {
         Self::Tagged(TaggedStatement::ForInStatement(s))
+    }
+    pub fn for_of_statement(s: ForOfStatement) -> Self {
+        Self::Tagged(TaggedStatement::ForOfStatement(s))
     }
     pub fn return_statement(s: ReturnStatement) -> Self {
         Self::Tagged(TaggedStatement::ReturnStatement(s))
@@ -251,6 +258,30 @@ pub enum ForInit {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ForInStatement {
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub cv: Option<CvId>,
+    pub left: ForInit,
+    pub right: Expression,
+    pub body: Box<Statement>,
+}
+
+/// `for (left of right) body` (CLOC23). The iterator loop: `right` is evaluated
+/// to an iterable, and `body` runs with `left` bound to each yielded value in
+/// turn. Structurally identical to [`ForInStatement`] — only the keyword (`of`
+/// vs `in`) and the iteration protocol differ — so it reuses [`ForInit`] for the
+/// left in exactly the same way:
+/// - `ForInit::VariableDeclaration` for `for (var/let/const v of it)`.
+/// - `ForInit::Expression` for `for (v of it)` / `for (o.p of it)`.
+///
+/// Destructuring left-hand sides and `using` bindings are not represented; the
+/// bridge declines them (sound whitespace-only fallback). `for await (… of …)`
+/// is a distinct grammar production and is likewise not handled here.
+///
+/// Like the other loops, a `for`-`of` is NOT a terminator — the iterable may be
+/// empty, so the body can run zero times and control can fall through.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ForOfStatement {
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub cv: Option<CvId>,
     pub left: ForInit,
@@ -642,6 +673,52 @@ mod tests {
         });
         assert_eq!(s.clone(), roundtrip(s.clone()));
         assert_eq!(type_tag(&s), "ForInStatement");
+    }
+
+    #[test]
+    fn for_of_statement_with_declaration_left_roundtrips() {
+        // for (const v of it) {}
+        let s = Statement::for_of_statement(ForOfStatement {
+            cv: Some("forof.1".to_string()),
+            left: ForInit::VariableDeclaration(VariableDeclaration {
+                cv: None,
+                kind: VarKind::Const,
+                declarations: vec![VariableDeclarator {
+                    cv: None,
+                    id: BindingTarget::Identifier(Identifier {
+                        cv: None,
+                        name: "v".to_string(),
+                    }),
+                    init: None,
+                }],
+            }),
+            right: Expression::Identifier(Identifier {
+                cv: None,
+                name: "it".to_string(),
+            }),
+            body: Box::new(Statement::empty_statement(EmptyStatement { cv: None })),
+        });
+        assert_eq!(s.clone(), roundtrip(s.clone()));
+        assert_eq!(type_tag(&s), "ForOfStatement");
+    }
+
+    #[test]
+    fn for_of_statement_with_expression_left_roundtrips() {
+        // for (v of it) {}  — an existing assignment target as the left.
+        let s = Statement::for_of_statement(ForOfStatement {
+            cv: None,
+            left: ForInit::Expression(Expression::Identifier(Identifier {
+                cv: None,
+                name: "v".to_string(),
+            })),
+            right: Expression::Identifier(Identifier {
+                cv: None,
+                name: "it".to_string(),
+            }),
+            body: Box::new(Statement::empty_statement(EmptyStatement { cv: None })),
+        });
+        assert_eq!(s.clone(), roundtrip(s.clone()));
+        assert_eq!(type_tag(&s), "ForOfStatement");
     }
 
     #[test]

--- a/code/packages/rust/javascript-parser/CHANGELOG.md
+++ b/code/packages/rust/javascript-parser/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to the `coding-adventures-javascript-parser` crate will be documented in this file.
 
+## [0.14.0] - 2026-06-20
+
+### Added — CLOC23: bridge `for_of_statement` → `ForOfStatement`
+
+`for_of_statement` no longer lands in the unsupported arm. New
+`convert_for_of_statement` mirrors `convert_for_in_statement` but phase-splits on
+the `of` token; it detects `var`/`let`/`const` for the binding kind and
+**declines** the `using` binding form (scans for a `using` token →
+`UnsupportedSyntax`). Destructuring and other unrepresentable lefts decline
+gracefully (whitespace-only fallback). `for await (… of …)` is a distinct
+grammar production and remains unsupported.
+
 ## [0.13.0] - 2026-06-20
 
 ### Added — CLOC22: bridge `for_in_statement` → `ForInStatement`

--- a/code/packages/rust/javascript-parser/Cargo.toml
+++ b/code/packages/rust/javascript-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-javascript-parser"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 description = "JavaScript parser — parses JavaScript source code against any ECMAScript edition (es1 through es2025) using the grammar-driven parser. Includes correlation-vector plumbing per CLOC03 and a typed-AST bridge (GrammarASTNode → javascript_ast::Program) per CLOC12.136."
 

--- a/code/packages/rust/javascript-parser/src/bridge.rs
+++ b/code/packages/rust/javascript-parser/src/bridge.rs
@@ -63,8 +63,8 @@ use coding_adventures_javascript_ast::{
     statement::{
         BlockStatement, BreakStatement, CatchClause, ContinueStatement, DebuggerStatement,
         DoWhileStatement, EmptyStatement, ExpressionStatement, ForInStatement, ForInit,
-        ForStatement, IfStatement, LabeledStatement, ReturnStatement, Statement, SwitchCase,
-        SwitchStatement, ThrowStatement, TryStatement, WhileStatement,
+        ForOfStatement, ForStatement, IfStatement, LabeledStatement, ReturnStatement, Statement,
+        SwitchCase, SwitchStatement, ThrowStatement, TryStatement, WhileStatement,
     },
     Program, ProgramItem, SourceType,
 };
@@ -271,6 +271,7 @@ fn convert_statement(node: &GrammarASTNode) -> Result<Statement, BridgeError> {
         }
         "for_statement" => convert_for_statement(child).map(Statement::for_statement),
         "for_in_statement" => convert_for_in_statement(child).map(Statement::for_in_statement),
+        "for_of_statement" => convert_for_of_statement(child).map(Statement::for_of_statement),
         "continue_statement" => convert_continue_statement(child).map(Statement::continue_statement),
         "break_statement" => convert_break_statement(child).map(Statement::break_statement),
         "return_statement" => convert_return_statement(child).map(Statement::return_statement),
@@ -282,8 +283,8 @@ fn convert_statement(node: &GrammarASTNode) -> Result<Statement, BridgeError> {
         // typed node is a bare marker. (CLOC21.)
         "debugger_statement" => Ok(Statement::debugger_statement(DebuggerStatement { cv: None })),
         // Phase 2+ — not yet in the typed AST
-        "for_of_statement" | "for_await_of_statement" | "with_statement"
-        | "using_declaration" | "await_using_declaration" => Err(unsupported(child)),
+        "for_await_of_statement" | "with_statement" | "using_declaration"
+        | "await_using_declaration" => Err(unsupported(child)),
         other => Err(BridgeError::InternalError {
             msg: format!("unknown statement child rule '{other}'"),
             rule: node.rule_name.clone(),
@@ -516,6 +517,82 @@ fn convert_for_in_statement(node: &GrammarASTNode) -> Result<ForInStatement, Bri
     let body = Box::new(convert_statement(body_node)?);
 
     Ok(ForInStatement {
+        cv: None,
+        left,
+        right,
+        body,
+    })
+}
+
+fn convert_for_of_statement(node: &GrammarASTNode) -> Result<ForOfStatement, BridgeError> {
+    // for_of_statement = "for" LPAREN
+    //   ( "var" variable_declaration | "let" binding_element
+    //   | "const" binding_element | "using" binding_element
+    //   | left_hand_side_expression )
+    //   "of" assignment_expression RPAREN statement ;
+    //
+    // Structurally identical to for_in_statement, but the phase delimiter is
+    // the `of` token (not `in`). A `using` binding declaration is not
+    // represented — we decline it (graceful WHITESPACE_ONLY fallback).
+    let mut phase = 0usize;
+    let mut left_kind: Option<VarKind> = None;
+    let mut saw_using = false;
+    let mut phase_nodes: [Vec<&GrammarASTNode>; 3] = [vec![], vec![], vec![]];
+
+    for child in &node.children {
+        match child {
+            ASTNodeOrToken::Token(t) if phase == 0 && t.value == "of" => phase = 1,
+            ASTNodeOrToken::Token(t) if phase == 1 && t.value == ")" => phase = 2,
+            ASTNodeOrToken::Token(t) if phase == 0 => match t.value.as_str() {
+                "var" => left_kind = Some(VarKind::Var),
+                "let" => left_kind = Some(VarKind::Let),
+                "const" => left_kind = Some(VarKind::Const),
+                "using" => saw_using = true,
+                _ => {}
+            },
+            ASTNodeOrToken::Node(n) => phase_nodes[phase.min(2)].push(n),
+            ASTNodeOrToken::Token(_) => {}
+        }
+    }
+
+    // `using` declarations are not modelled — decline gracefully.
+    if saw_using {
+        return Err(unsupported(node));
+    }
+
+    // Left: a binding (var/let/const) or an existing assignment target.
+    let left_node = *phase_nodes[0]
+        .first()
+        .ok_or_else(|| internal(node, "for_of_statement: missing left"))?;
+    let left = match left_kind {
+        Some(kind) => {
+            // A single declarator with no initializer. `convert_variable_declarator`
+            // declines destructuring; any other unrepresentable shape is mapped
+            // to a graceful decline rather than a hard error.
+            let declarator =
+                convert_variable_declarator(left_node).map_err(|_| unsupported(left_node))?;
+            ForInit::VariableDeclaration(VariableDeclaration {
+                cv: None,
+                kind,
+                declarations: vec![declarator],
+            })
+        }
+        None => ForInit::Expression(convert_expression(left_node)?),
+    };
+
+    // Right: the iterable expression (an assignment_expression).
+    let right_node = *phase_nodes[1]
+        .first()
+        .ok_or_else(|| internal(node, "for_of_statement: missing right expression"))?;
+    let right = convert_expression(right_node)?;
+
+    // Body.
+    let body_node = *phase_nodes[2]
+        .first()
+        .ok_or_else(|| internal(node, "for_of_statement: missing body"))?;
+    let body = Box::new(convert_statement(body_node)?);
+
+    Ok(ForOfStatement {
         cv: None,
         left,
         right,
@@ -2382,6 +2459,80 @@ mod tests {
                 continue; // parse declined — sound fallback
             };
             let _ = grammar_to_program(&node, DEFAULT_ES_VERSION); // must not panic
+        }
+    }
+
+    /// Pull the single `ForOfStatement` out of a one-statement program.
+    fn bridge_for_of(src: &str) -> ForOfStatement {
+        let p = bridge_ok(src);
+        match &p.body[0] {
+            ProgramItem::Statement(Statement::Tagged(
+                coding_adventures_javascript_ast::statement::TaggedStatement::ForOfStatement(f),
+            )) => f.clone(),
+            other => panic!("expected a ForOfStatement, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn for_of_bridge_shapes() {
+        // CLOC23: all the binding-kind left forms plus the expression left.
+        for (src, want) in [
+            ("for (var v of it) { f(v); }", VarKind::Var),
+            ("for (let v of it) { f(v); }", VarKind::Let),
+            ("for (const v of it) { f(v); }", VarKind::Const),
+        ] {
+            let f = bridge_for_of(src);
+            match &f.left {
+                ForInit::VariableDeclaration(vd) => {
+                    assert_eq!(vd.kind, want, "kind mismatch for {src}");
+                    assert_eq!(vd.declarations.len(), 1);
+                    assert!(vd.declarations[0].init.is_none());
+                }
+                other => panic!("expected a declaration left for {src}, got {other:?}"),
+            }
+            assert!(
+                matches!(&f.right, Expression::Identifier(id) if id.name == "it"),
+                "expected right = `it` for {src}, got {:?}",
+                f.right
+            );
+        }
+        // Expression left.
+        let f = bridge_for_of("for (v of it) { f(v); }");
+        assert!(
+            matches!(&f.left, ForInit::Expression(Expression::Identifier(id)) if id.name == "v"),
+            "expected expression left `v`, got {:?}",
+            f.left
+        );
+    }
+
+    #[test]
+    fn for_of_using_or_destructuring_left_does_not_hard_error() {
+        // A `using` binding (`for (using v of it)`) and destructuring lefts are
+        // not modelled; they must DECLINE gracefully (parse-error or
+        // UnsupportedSyntax → WHITESPACE_ONLY), never hard-error or mis-bind.
+        for src in [
+            "for (using v of it) { f(); }",
+            "for (var [a] of it) { f(); }",
+            "for (const {a} of it) { f(); }",
+        ] {
+            let Ok(node) = parse_javascript_typed(src, DEFAULT_ES_VERSION) else {
+                continue; // parse declined — sound fallback
+            };
+            // Must not panic. If a ForOfStatement is produced at all, its left
+            // must be a plain (non-destructuring) binding.
+            if let Ok(p) = grammar_to_program(&node, DEFAULT_ES_VERSION) {
+                if let Some(ProgramItem::Statement(Statement::Tagged(
+                    coding_adventures_javascript_ast::statement::TaggedStatement::ForOfStatement(f),
+                ))) = p.body.first()
+                {
+                    if let ForInit::VariableDeclaration(vd) = &f.left {
+                        for d in &vd.declarations {
+                            let coding_adventures_javascript_ast::BindingTarget::Identifier(_) =
+                                &d.id;
+                        }
+                    }
+                }
+            }
         }
     }
 

--- a/code/programs/rust/closurec/CHANGELOG.md
+++ b/code/programs/rust/closurec/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 All notable changes to the `coding-adventures-closurec` binary will be documented in this file.
 
+## [0.156.0] - 2026-06-20
+
+### Added — CLOC23: end-to-end `for`-`of` support
+
+Programs containing a `for`-`of` loop now route through the full typed-AST
+optimization pipeline at both SIMPLE and ADVANCED levels. Previously any
+`for`-`of` made the parse/bridge step decline, and closurec silently fell back
+to WHITESPACE_ONLY (no real optimization). Now inlining, constant folding, DCE,
+and (under ADVANCED) local/global/property renaming all run inside the loop body
+and recurse into the iterable expression. All the common left forms are
+supported (`for (var/let/const v of it)` and `for (v of it)`); `using` bindings
+and destructuring left-hand sides decline to WHITESPACE_ONLY. The loop variable
+renames consistently under ADVANCED (e.g. `for (var entry of values)` with
+`sum + entry` → `for (var c of a)` with `b + c`).
+
+With for-of, every common Phase-2 statement is now representable; only the
+`with` statement (renaming-unsafe, a deliberate non-target) remains
+bridge-unsupported. The `simple_level_unsupported_syntax_degrades_gracefully`
+test accordingly now uses a `with` statement for its example.
+
+The end-to-end `simple-for-of` diff fixture pins the behaviour, with a
+regression guard that the output is NOT the whitespace fallback.
+
 ## [0.155.0] - 2026-06-20
 
 ### Added — CLOC22: end-to-end `for`-`in` support

--- a/code/programs/rust/closurec/Cargo.toml
+++ b/code/programs/rust/closurec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closurec"
-version = "0.155.0"
+version = "0.156.0"
 edition = "2021"
 description = "closurec — CLI driver for the Closure Compiler clone. Mirrors the upstream Java Closure Compiler's command-line flag surface (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility. Per CLOC08."
 

--- a/code/programs/rust/closurec/cli.spec.json
+++ b/code/programs/rust/closurec/cli.spec.json
@@ -2,7 +2,7 @@
   "cli_builder_spec_version": "1.0",
   "name": "closurec",
   "description": "closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.",
-  "version": "0.155.0",
+  "version": "0.156.0",
   "parsing_mode": "gnu",
   "flags": [
     { "id": "browser_featureset_year", "long": "browser_featureset_year", "type": "integer", "default": 0, "description": "Shortcut for defining goog.FEATURESET_YEAR=YYYY (minimum 2012)." },

--- a/code/programs/rust/closurec/src/run.rs
+++ b/code/programs/rust/closurec/src/run.rs
@@ -6490,12 +6490,13 @@ mod tests {
         let in_path = dir.join("in.js");
         let out_path = dir.join("out.js");
         let sidecar_path = dir.join("out.js.cv.json");
-        // for-of: the grammar parses it, but bridge::grammar_to_program
-        // returns UnsupportedSyntax (for_of_statement is still Phase 2+).
-        // (do-while is supported as of CLOC20 and for-in as of CLOC22, so
-        // neither degrades; class declarations fail at the grammar parser
-        // level, not the bridge.)
-        fs::write(&in_path, "for (k of arr) { x(); }").expect("setup");
+        // with-statement: the grammar parses it, but bridge::grammar_to_program
+        // returns UnsupportedSyntax (with_statement is still Phase 2+ — and
+        // renaming-unsafe, so it is a deliberate non-target). do-while (CLOC20),
+        // for-in (CLOC22), and for-of (CLOC23) are all supported now and no
+        // longer degrade; class declarations fail at the grammar parser level,
+        // not the bridge.
+        fs::write(&in_path, "with (obj) { x(); }").expect("setup");
         let cfg = CompilerConfig {
             io: IoConfig {
                 js_patterns: vec![in_path.to_string_lossy().to_string()],

--- a/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
@@ -2,7 +2,7 @@
 
 closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.
 
-Version: 0.155.0
+Version: 0.156.0
 
 ## Flags
 

--- a/code/programs/rust/closurec/tests/diff/simple-for-of/README.md
+++ b/code/programs/rust/closurec/tests/diff/simple-for-of/README.md
@@ -1,0 +1,33 @@
+# Fixture: `simple-for-of`
+
+End-to-end oracle for `--compilation_level SIMPLE` optimization through a
+`for`-`of` loop (CLOC23).
+
+| File | Role |
+|------|------|
+| `flags.txt` | CLI args: `--compilation_level SIMPLE --js input/a.js` |
+| `input/a.js` | A single-use function, plus a `for (const item of items) { … }` whose body holds foldable arithmetic, followed by a statement after the loop |
+| `expected.stdout` | The optimized output (see below) |
+
+```text
+report(1);for(const item of items){var x=3;use(item,x)}after();
+```
+
+What this proves now runs **through** a for-of loop — none of which was
+reachable before CLOC23 (any `for`-`of` forced a WHITESPACE_ONLY fallback):
+
+* **Inlining** — `log` is single-use, so `log(1)` becomes `report(1)` and the
+  declaration is deleted.
+* **Constant folding** — `1 + 2` ⇒ `3` even though it sits inside the loop body.
+* **Control-flow preservation** — `for (const item of items) { … }` survives
+  verbatim, including the loop variable.
+* **Not a terminator** — `after()` after the loop stays reachable, because a
+  for-of body may run zero times (an empty iterable).
+
+Regenerate the expected file after an intentional behavior change:
+
+```sh
+cargo run -- --compilation_level SIMPLE \
+    --js tests/diff/simple-for-of/input/a.js \
+    > tests/diff/simple-for-of/expected.stdout
+```

--- a/code/programs/rust/closurec/tests/diff/simple-for-of/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/simple-for-of/expected.stdout
@@ -1,0 +1,1 @@
+report(1);for(const item of items){var x=3;use(item,x)}after();

--- a/code/programs/rust/closurec/tests/diff/simple-for-of/flags.txt
+++ b/code/programs/rust/closurec/tests/diff/simple-for-of/flags.txt
@@ -1,0 +1,4 @@
+--compilation_level
+SIMPLE
+--js
+tests/diff/simple-for-of/input/a.js

--- a/code/programs/rust/closurec/tests/diff/simple-for-of/input/a.js
+++ b/code/programs/rust/closurec/tests/diff/simple-for-of/input/a.js
@@ -1,0 +1,25 @@
+// SIMPLE-level optimization THROUGH a for-of loop (CLOC23).
+//
+// Before CLOC23, *any* program containing a `for`-`of` loop failed the
+// typed-AST parse (ForOfStatement was unrepresentable) and closurec silently
+// fell back to WHITESPACE_ONLY — zero optimization. This fixture is the
+// end-to-end oracle proving the SIMPLE pipeline now runs every pass inside the
+// for-of body and recurses into its iterable expression:
+//
+//   * `log` is single-use, so the inliner folds `log(1)` into its body
+//     `report(1)` and deletes the now-unused declaration.
+//   * `1 + 2` is constant-folded to `3` even though it lives inside the loop
+//     body.
+//   * The `for (const item of items) { … }` survives verbatim — control flow
+//     and the loop variable are preserved.
+//   * `after()` AFTER the loop stays reachable: a for-of is not a terminator
+//     (the iterable may be empty, so the body may run zero times).
+function log(p) {
+  report(p);
+}
+log(1);
+for (const item of items) {
+  var x = 1 + 2;
+  use(item, x);
+}
+after();

--- a/code/programs/rust/closurec/tests/diff_simple_for_of.rs
+++ b/code/programs/rust/closurec/tests/diff_simple_for_of.rs
@@ -1,0 +1,79 @@
+//! Integration test for the `tests/diff/simple-for-of/` fixture.
+//!
+//! Exercises `--compilation_level SIMPLE` optimization THROUGH a `for`-`of`
+//! loop (CLOC23). Before CLOC23, any program containing a for-of loop failed
+//! the typed-AST parse and closurec fell back to WHITESPACE_ONLY (zero
+//! optimization). This fixture is the end-to-end oracle proving every SIMPLE
+//! pass now runs inside the for-of body and recurses into its iterable
+//! expression: `log(1)` is inlined to `report(1)`, `1 + 2` folds to `3`, the
+//! loop is preserved, and `after()` stays reachable.
+
+use std::process::Command;
+
+const BINARY: &str = env!("CARGO_BIN_EXE_closurec");
+
+fn read_flags() -> Vec<String> {
+    let raw =
+        std::fs::read_to_string("tests/diff/simple-for-of/flags.txt").expect("read flags.txt");
+    raw.lines()
+        .filter(|l| !l.is_empty())
+        .map(|s| s.to_string())
+        .collect()
+}
+
+#[test]
+fn simple_for_of_fixture_matches_expected_stdout() {
+    let flags = read_flags();
+    let out = Command::new(BINARY)
+        .args(&flags)
+        .output()
+        .expect("run closurec");
+
+    assert!(
+        out.status.success(),
+        "exit: {:?}, stderr: {}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stderr),
+    );
+
+    let actual = String::from_utf8_lossy(&out.stdout);
+    let expected = std::fs::read_to_string("tests/diff/simple-for-of/expected.stdout")
+        .expect("read expected.stdout");
+    assert_eq!(
+        actual.trim_end_matches('\n'),
+        expected.trim_end_matches('\n'),
+        "mismatch.\nflags: {flags:?}\nactual:\n{actual}\nexpected:\n{expected}",
+    );
+}
+
+/// Regression guard: the output must NOT be the WHITESPACE_ONLY fallback. If
+/// `for`-`of` ever stops being representable in the typed AST, the fixture
+/// above would still "pass" against a regenerated expected file, so we
+/// additionally assert that an optimization that can ONLY come from the typed
+/// pipeline (the `log` -> `report` inline) is present, the original
+/// `function log` declaration is gone, and the statement after the loop
+/// (`after()`) survives — proving a for-of is treated as non-terminating.
+#[test]
+fn simple_for_of_did_not_fall_back_to_whitespace_only() {
+    let out = Command::new(BINARY)
+        .args(read_flags())
+        .output()
+        .expect("run closurec");
+    let actual = String::from_utf8_lossy(&out.stdout);
+
+    assert!(
+        actual.contains("report(1)"),
+        "expected the single-use `log` to be inlined into `report(1)` \
+         (proving the typed pipeline ran, not the whitespace fallback); \
+         got:\n{actual}",
+    );
+    assert!(
+        !actual.contains("function log"),
+        "expected the inlined `log` declaration to be removed; got:\n{actual}",
+    );
+    assert!(
+        actual.contains("after()"),
+        "expected the statement after the for-of loop to remain reachable; \
+         got:\n{actual}",
+    );
+}

--- a/code/specs/CLOC23-for-of.md
+++ b/code/specs/CLOC23-for-of.md
@@ -1,0 +1,84 @@
+# CLOC23 — `for`-`of` end-to-end
+
+> **Status:** Shipped. AST node, parser bridge, emitter, scope analyzer, and
+> every optimization pass handle the `for`-`of` loop. An end-to-end diff fixture
+> (`simple-for-of`) pins the behaviour at the CLI. With this, every common
+> Phase-2 statement is representable; only `with` remains bridge-unsupported.
+
+## Why this spec exists
+
+`for (left of right) body` iterates the values of an iterable. It was the last
+common bridge-unsupported Phase-2 statement: the grammar parsed it, but the
+typed AST had no node, so the bridge declined (`UnsupportedSyntax`) and the CLI
+fell back to `WHITESPACE_ONLY` for *any* program using a for-of loop. CLOC23
+closes that gap.
+
+## Relationship to CLOC22 (`for`-`in`)
+
+`for`-`of` is **structurally identical** to `for`-`in` — only the keyword (`of`
+vs `in`) and the runtime iteration protocol differ. This spec therefore mirrors
+[CLOC22](CLOC22-for-in.md) exactly; only the differences are called out here.
+See CLOC22 for the full design of the shared shape (the `ForInit` left, the
+loop-variable-as-binding soundness, the not-a-terminator property, and the
+per-pass recursion).
+
+## The AST node
+
+```rust
+pub struct ForOfStatement {
+    pub cv: Option<CvId>,
+    pub left: ForInit,        // VariableDeclaration | Expression
+    pub right: Expression,
+    pub body: Box<Statement>,
+}
+```
+
+Identical fields to `ForInStatement`. (They are distinct Rust types — even though
+the fields match, a single match arm cannot bind both via an or-pattern, so each
+pass carries a separate, identical `ForOfStatement` arm.)
+
+## Differences from `for`-`in`
+
+1. **Bridge keyword + `using` decline.** `convert_for_of_statement` mirrors
+   `convert_for_in_statement` but phase-splits on the `of` token. The for-of
+   grammar additionally admits a `using` binding declaration
+   (`for (using x of it)`); `using` is **not** modelled, so the bridge scans for
+   a `using` token and declines (graceful WHITESPACE_ONLY fallback). As in
+   for-in, destructuring lefts and any other unrepresentable binding decline
+   gracefully rather than hard-erroring.
+2. **Emitter keyword.** `emit_for_of` writes `for ( <left> of <right> ) <body>`
+   — identical to `emit_for_in` with `of` in place of `in`, spaced on both sides
+   for the same token-separation reason.
+3. **`for await (… of …)`** is a *distinct* grammar production
+   (`for_await_of_statement`) and remains bridge-unsupported (declines).
+
+Everything else — the `ForInit` left handling, the loop-variable rename
+consistency across `rename`/`rename-globals`, the not-a-terminator treatment in
+`dce`/`fold-control-flow`, and the per-pass recursion into left/right/body — is
+the same as CLOC22 and verified the same way.
+
+## Soundness (loop variable)
+
+For `for (var/let/const v of it)`, the rename passes treat the `left` binding
+exactly like a for-loop init binding, so `v` renames consistently at its
+declaration and every body use. Verified end-to-end:
+`for (var entry of values)` with `sum + entry` ⟶ `for (var c of a)` with
+`b + c` under ADVANCED. The `for (v of it)` expression-left form is a use only,
+never a declaration.
+
+## End-to-end oracle
+
+* **`simple-for-of`** — at SIMPLE: a single-use function inlines, arithmetic
+  inside the for-of body folds, the loop survives verbatim, and the statement
+  after the loop stays reachable. A companion assertion proves the output is NOT
+  the whitespace fallback.
+
+## Phase-2 statement campaign status
+
+With for-of, the representable Phase-2 statements are complete:
+`DoWhileStatement` (CLOC20), `DebuggerStatement` (CLOC21), `ForInStatement`
+(CLOC22), and `ForOfStatement` (CLOC23) join the Phase-1 set. The only remaining
+bridge-unsupported statement is **`with`**, which is intentionally *not* a target:
+its dynamic scope makes renaming inside a `with` body unsound, so it is left to
+decline to WHITESPACE_ONLY. `using`/`await using` declarations and
+`for await (… of …)` also remain out of scope.


### PR DESCRIPTION
## Summary

Adds first-class **`for (left of right) body`** support to closurec — the iterator loop, and the **last common bridge-unsupported Phase-2 statement**. Previously any for-of fell back to `WHITESPACE_ONLY`; now the full SIMPLE/ADVANCED pipeline runs across it. Completes the run: do-while ([#6334](https://github.com/adhithyan15/coding-adventures/pull/6334)), debugger ([#6343](https://github.com/adhithyan15/coding-adventures/pull/6343)), for-in ([#6354](https://github.com/adhithyan15/coding-adventures/pull/6354)), and now for-of.

```
function log(p){report(p);} log(1);
for (const item of items) { var x = 1 + 2; use(item, x); }
after();
```
⟶ `report(1);for(const item of items){var x=3;use(item,x)}after();`

## What changed (mirrors the merged for-in)

| Layer | Change |
|-------|--------|
| `javascript-ast` | `ForOfStatement { cv, left: ForInit, right, body }` — same shape as `ForInStatement`. |
| `javascript-parser` | `convert_for_of_statement` mirrors the for-in bridge but phase-splits on the `of` token; **declines the `using` binding form** (scans for a `using` token → `UnsupportedSyntax`) and destructuring. `for await (… of …)` stays unsupported. |
| `closure-emitter` | `emit_for_of` → `for(<left> of <right>)<body>` with `of` spaced both sides. |
| `closure-scope-analyzer` + all 8 passes | A `ForOfStatement` arm identical to the `ForInStatement` arm. |

All common left forms work (`for (var/let/const v of it)` and `for (v of it)`); `using` bindings and destructuring decline to whitespace-only.

> The 20 read-only pass arms were generated by a brace-matching script that duplicated each `ForInStatement` arm and renamed the variant. An adversarial inline security review **specifically verified** each generated arm is a complete, correct duplicate (no truncation/over-extension/stray substitution) and that no `ForInStatement` arm was damaged.

## Soundness — loop variable renames consistently

For `for (var/let/const v of it)`, the rename passes treat the `left` binding like a for-loop init binding, so `v` renames consistently at its declaration and every body use: `for (var entry of values)` with `sum + entry` ⟶ `for (var c of a)` with `b + c` under ADVANCED. The `for (v of it)` form is a use only. for-of is **not** a terminator (the iterable may be empty).

## Phase-2 statement campaign — complete

With for-of, every common Phase-2 statement is representable (do-while, debugger, for-in, for-of join Phase 1). Only **`with`** remains bridge-unsupported — intentionally, since its dynamic scope makes renaming inside it unsound. The `simple_level_unsupported_syntax_degrades_gracefully` test now uses `with` for its example.

## Tests

AST serde round-trips, bridge-shape tests (var/let/const/expr + `using`/destructuring decline guards), emitter tests, and an end-to-end `simple-for-of` diff fixture with a **whitespace-fallback regression guard**. Full closurec suite **728/728 green**; every touched pass crate green.

## Bookkeeping

Spec: `code/specs/CLOC23-for-of.md`. Version bumps + CHANGELOGs for all 13 touched crates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)