### PR TITLE
feat(mycin-cc2c-adj): single-factor grounded dose caps in dose_caps.adj

### DIFF
--- a/code/specs/data/mycin-2026/CHART-AS-CONSTRAINTS.md
+++ b/code/specs/data/mycin-2026/CHART-AS-CONSTRAINTS.md
@@ -163,8 +163,23 @@ risks Y") — decision support, not a hidden choice.
     direction the `renal_severe`/`renal_moderate`/`nephrotoxin_interaction` ceiling penalties
     encode. As with every dose number, only the DIRECTION is grounded; the per-kg penalty
     magnitudes in `formulary.json` stay the standing **ILLUSTRATIVE** feasibility model (the
-    label gives no closed-form per-kg reduction). Pure ledger/provenance increment — no engine
-    or compiler logic changed, so the regimen output is byte-identical.
+    label gives no closed-form per-kg reduction).
+    - **ADJ-NATIVE (single-factor caps are now ENGINE-QUERYABLE). ✅ DONE.** The `dose_caps.adj`
+      substrate (CC-2b) handled only **compound** (conjunctive) caps; it now also expresses
+      **single-factor** grounded caps via the same `dose_capped_under` relation + a third generic
+      rule (`dose_capped($D,$R) when active_risk($R), dose_capped_under($D,$R)`). The three
+      vancomycin penalties land as grounded facts —
+      `dose_capped_under(vancomycin, renal_severe)`, `(…, renal_moderate)`,
+      `(…, nephrotoxin_interaction)` — each carrying the FDA byte-quote from the records above
+      (`dose_caps_build.py` reads them from `dose-window-grounding.json`). `chart_to_cop.derive()`
+      now surfaces every engine-derived cap (compound *and* single-factor) as a
+      provenance-bearing `dose_risk` constraint, so the renal/nephrotoxin penalties carry their
+      FDA quote **at answer time**, engine-derived — not just in the ledger. `derive_dose_caps`
+      returns a list of `{drug, risk, source, locator, trust}` (a drug may be capped under
+      several risks). The numeric solve is unchanged, so the regimen output — and the board
+      scorecard — stays byte-identical; this only enriches provenance and proves the substrate
+      now covers both cap shapes. Verified by `test_dose_caps.py` (single-factor renal +
+      nephrotoxin caps grounded; compound still requires two categories; 15 tests).
 - **REFACTOR (ADJ-first): every exclusion is now an EXPLICIT engine constraint.** Dose-infeasible
   (CC-2), contraindicated (CC-3), and step-therapy (CC-6) drugs are unified into one
   `forced_zero: {drug → reason}` and emitted as `constrain x_d <= 0   % excluded (reason)` in the

--- a/code/specs/data/mycin-2026/treatment/antibiotics/chart_to_cop.py
+++ b/code/specs/data/mycin-2026/treatment/antibiotics/chart_to_cop.py
@@ -403,20 +403,25 @@ def derive(cli: Path, facts: list[ChartFact], disease: str = "meningitis") -> di
     surfaced (honest abstention). CC-5: the wait-vs-treat-now decision is computed from
     the chart's culture/clinical status against the disease's grounded time-criticality."""
     cop = compile_cop(facts)
-    # CC-2b: ask the ENGINE which COMPOUND risks the patient's active risk tokens trigger, by
-    # running the grounded dose-cap rulebook (? derived_risk / ? dose_capped). The hepatorenal
-    # conjunction (hepatic ∧ renal) is the engine's, not a Python `if` — a single risk derives
-    # nothing (hepatic alone needs no adjustment). Fold any derived compound risk into the COP's
-    # risk set BEFORE the dose-window solve so its grounded ceiling penalty fires; each capped
-    # drug carries its FDA byte-quote into the provenance.
-    derived_risks, dose_cap_info = dc.derive_dose_caps(cli, cop.risks)
+    # CC-2b/CC-2c: ask the ENGINE which dose caps the patient's active risk tokens trigger, by
+    # running the grounded dose-cap rulebook (? derived_risk / ? dose_capped). Two shapes, one
+    # rulebook: a COMPOUND cap (hepatorenal = hepatic ∧ renal) is the engine's conjunction, not a
+    # Python `if` (a single organ risk derives nothing); a SINGLE-FACTOR cap (vancomycin under
+    # renal/nephrotoxin) fires on one active risk and carries the FDA byte-quote that grounds the
+    # renal/nephrotoxin ceiling penalty. Fold any DERIVED compound risk into the COP's risk set
+    # BEFORE the dose-window solve so its ceiling penalty fires; surface every grounded cap as a
+    # provenance-bearing constraint so the FDA quote reaches the answer.
+    derived_risks, dose_caps_found = dc.derive_dose_caps(cli, cop.risks)
     cop.risks |= derived_risks
-    for drug, info in sorted(dose_cap_info.items()):
-        cop.constraints.append({"type": "dose_risk", "from": f"derived_risk({info['risk']})",
-                                "rule": f"{drug} dose-capped under {info['risk']} "
-                                        "(engine-derived conjunction of patient risk factors)",
-                                "detail": drug, "source": info.get("source"),
-                                "locator": info.get("locator"), "trust": info.get("trust")})
+    for cap in dose_caps_found:
+        compound = cap["risk"] in derived_risks
+        origin = f"derived_risk({cap['risk']})" if compound else f"active_risk({cap['risk']})"
+        kind = "engine-derived conjunction of patient risk factors" if compound \
+            else "engine-derived single-factor cap"
+        cop.constraints.append({"type": "dose_risk", "from": origin,
+                                "rule": f"{cap['drug']} dose-capped under {cap['risk']} ({kind})",
+                                "detail": cap["drug"], "source": cap.get("source"),
+                                "locator": cap.get("locator"), "trust": cap.get("trust")})
     # CC-2: drop drugs that can't be safely + effectively dosed for this patient.
     undosable = dose_infeasible(cli, reg.candidates(cop.exclusions), cop.risks, cop.weight)
     for d, w in undosable.items():

--- a/code/specs/data/mycin-2026/treatment/antibiotics/dose-cap-manifest.json
+++ b/code/specs/data/mycin-2026/treatment/antibiotics/dose-cap-manifest.json
@@ -50,7 +50,37 @@
       "trust": "authoritative",
       "source": "Patients with hepatic impairment and significant renal impairment should not receive more than 2 grams per day of ceftriaxone.",
       "url": "https://dailymed.nlm.nih.gov/dailymed/fda/fdaDrugXsl.cfm?setid=5cd2d96f-83e5-4326-ae87-d0ede4ba493a"
+    },
+    "dose_capped_under__vancomycin__renal_severe": {
+      "relation": "dose_capped_under",
+      "subject": "vancomycin",
+      "risk": "renal_severe",
+      "grounding_id": "dose_penalty_vancomycin_renal",
+      "verdict": "ACCEPT",
+      "trust": "authoritative",
+      "source": "Vancomycin should be used with caution in patients with renal insufficiency because the risk of toxicity is appreciably increased by high, prolonged blood concentrations. Dosage of vancomycin hydrochloride for injection must be adjusted for patients with renal dysfunction.",
+      "url": "https://dailymed.nlm.nih.gov/dailymed/fda/fdaDrugXsl.cfm?setid=75a6a873-21b9-4f48-89a9-c1476294c0ce"
+    },
+    "dose_capped_under__vancomycin__renal_moderate": {
+      "relation": "dose_capped_under",
+      "subject": "vancomycin",
+      "risk": "renal_moderate",
+      "grounding_id": "dose_penalty_vancomycin_renal",
+      "verdict": "ACCEPT",
+      "trust": "authoritative",
+      "source": "Vancomycin should be used with caution in patients with renal insufficiency because the risk of toxicity is appreciably increased by high, prolonged blood concentrations. Dosage of vancomycin hydrochloride for injection must be adjusted for patients with renal dysfunction.",
+      "url": "https://dailymed.nlm.nih.gov/dailymed/fda/fdaDrugXsl.cfm?setid=75a6a873-21b9-4f48-89a9-c1476294c0ce"
+    },
+    "dose_capped_under__vancomycin__nephrotoxin_interaction": {
+      "relation": "dose_capped_under",
+      "subject": "vancomycin",
+      "risk": "nephrotoxin_interaction",
+      "grounding_id": "dose_penalty_vancomycin_nephrotoxin",
+      "verdict": "ACCEPT",
+      "trust": "authoritative",
+      "source": "In order to minimize the risk of nephrotoxicity when treating patients with underlying renal dysfunction or patients receiving concomitant therapy with an aminoglycoside, serial monitoring of renal function should be performed, and particular care should be taken in following appropriate dosing schedules.",
+      "url": "https://dailymed.nlm.nih.gov/dailymed/fda/fdaDrugXsl.cfm?setid=75a6a873-21b9-4f48-89a9-c1476294c0ce"
     }
   },
-  "hash": "868ee1af5642270e"
+  "hash": "9c3a7c2bf2db2b6f"
 }

--- a/code/specs/data/mycin-2026/treatment/antibiotics/dose_caps.adj
+++ b/code/specs/data/mycin-2026/treatment/antibiotics/dose_caps.adj
@@ -62,10 +62,24 @@ rulebook dose_caps {
     relate compound_first(hepatorenal, hepatic)
     relate compound_second(hepatorenal, renal)
 
-    % --- grounded dose caps (the clinical claim) ----------------------------
+    % --- grounded COMPOUND dose caps (the clinical claim) -------------------
     relate dose_capped_under(ceftriaxone, hepatorenal)
         source "Patients with hepatic impairment and significant renal impairment should not receive more than 2 grams per day of ceftriaxone."
         locator "https://dailymed.nlm.nih.gov/dailymed/fda/fdaDrugXsl.cfm?setid=5cd2d96f-83e5-4326-ae87-d0ede4ba493a"
+        trust authoritative
+
+    % --- grounded SINGLE-FACTOR dose caps (renal / nephrotoxin) -------------
+    relate dose_capped_under(vancomycin, renal_severe)
+        source "Vancomycin should be used with caution in patients with renal insufficiency because the risk of toxicity is appreciably increased by high, prolonged blood concentrations. Dosage of vancomycin hydrochloride for injection must be adjusted for patients with renal dysfunction."
+        locator "https://dailymed.nlm.nih.gov/dailymed/fda/fdaDrugXsl.cfm?setid=75a6a873-21b9-4f48-89a9-c1476294c0ce"
+        trust authoritative
+    relate dose_capped_under(vancomycin, renal_moderate)
+        source "Vancomycin should be used with caution in patients with renal insufficiency because the risk of toxicity is appreciably increased by high, prolonged blood concentrations. Dosage of vancomycin hydrochloride for injection must be adjusted for patients with renal dysfunction."
+        locator "https://dailymed.nlm.nih.gov/dailymed/fda/fdaDrugXsl.cfm?setid=75a6a873-21b9-4f48-89a9-c1476294c0ce"
+        trust authoritative
+    relate dose_capped_under(vancomycin, nephrotoxin_interaction)
+        source "In order to minimize the risk of nephrotoxicity when treating patients with underlying renal dysfunction or patients receiving concomitant therapy with an aminoglycoside, serial monitoring of renal function should be performed, and particular care should be taken in following appropriate dosing schedules."
+        locator "https://dailymed.nlm.nih.gov/dailymed/fda/fdaDrugXsl.cfm?setid=75a6a873-21b9-4f48-89a9-c1476294c0ce"
         trust authoritative
 
     % --- the GENERIC conjunction rules ---------------------------------------
@@ -82,5 +96,11 @@ rulebook dose_caps {
         when: compound_first($C, $CatA), risk_in_category($Ra, $CatA), active_risk($Ra),
               compound_second($C, $CatB), risk_in_category($Rb, $CatB), active_risk($Rb),
               dose_capped_under($D, $C)
+    }
+    % SINGLE-FACTOR cap: a drug is dose-capped when it is capped under a risk that is itself
+    % directly active (no conjunction). The same dose_capped query target serves both shapes.
+    rule {
+        head: dose_capped($D, $R)
+        when: active_risk($R), dose_capped_under($D, $R)
     }
 }

--- a/code/specs/data/mycin-2026/treatment/antibiotics/dose_caps.py
+++ b/code/specs/data/mycin-2026/treatment/antibiotics/dose_caps.py
@@ -51,18 +51,21 @@ def _safe_risk(tok: str) -> str:
     return tok
 
 
-def derive_dose_caps(cli: Path, active_risks) -> tuple[set[str], dict[str, dict]]:
+def derive_dose_caps(cli: Path, active_risks) -> tuple[set[str], list[dict]]:
     """Run the dose-cap rulebook under the patient's `active_risks` and return
     (derived_risks, caps):
       * derived_risks — the set of COMPOUND risk tokens the engine derives as holding
         (e.g. {"hepatorenal"}); fold these into the COP's risk set so the dose-window
         penalty fires.
-      * caps — {drug: {risk, source, locator, trust}} for every drug the engine derives as
-        dose-capped, each carrying the grounded byte-quote from the cap fact it joined.
-    An empty/falsy `active_risks` short-circuits to (set(), {}) without invoking the engine."""
+      * caps — a list of {drug, risk, source, locator, trust}, ONE per (drug, risk) the engine
+        derives as dose-capped, each carrying the grounded byte-quote from the cap fact it
+        joined. A drug may appear under several risks (e.g. vancomycin under renal_severe AND
+        nephrotoxin_interaction), hence a list rather than a drug-keyed dict. Covers both the
+        COMPOUND caps (risk ∈ derived_risks) and the SINGLE-FACTOR caps (risk ∈ active_risks).
+    An empty/falsy `active_risks` short-circuits to (set(), []) without invoking the engine."""
     toks = sorted({_safe_risk(r) for r in active_risks})
     if not toks:
-        return set(), {}
+        return set(), []
 
     program = RULEBOOK.read_text() + "\n"
     program += "".join(f"relate active_risk({t})\n" for t in toks)
@@ -82,7 +85,8 @@ def derive_dose_caps(cli: Path, active_risks) -> tuple[set[str], dict[str, dict]
         Path(tmp.name).unlink(missing_ok=True)
 
     derived_risks: set[str] = set()
-    caps: dict[str, dict] = {}
+    caps: list[dict] = []
+    seen: set[tuple[str, str]] = set()
     for rec in out.get("recall", []):
         q = rec.get("query", "")
         if q.startswith("derived_risk("):
@@ -94,14 +98,16 @@ def derive_dose_caps(cli: Path, active_risks) -> tuple[set[str], dict[str, dict]
             for ans in rec.get("answers", []):
                 b = ans.get("bindings", {})
                 drug, risk = b.get("D"), b.get("R")
-                if not drug or not risk:
+                if not drug or not risk or (drug, risk) in seen:
                     continue
+                seen.add((drug, risk))
                 # The grounding lives on the dose_capped_under fact the derivation joined;
                 # surface the first cited clause that carries a source (the grounded quote).
                 cite = next((c for c in ans.get("citations", []) if c.get("source")), {})
-                caps.setdefault(drug, {"risk": risk, "source": cite.get("source", ""),
-                                       "locator": cite.get("locator"),
-                                       "trust": cite.get("trust", "unattributed")})
+                caps.append({"drug": drug, "risk": risk, "source": cite.get("source", ""),
+                             "locator": cite.get("locator"),
+                             "trust": cite.get("trust", "unattributed")})
+    caps.sort(key=lambda c: (c["drug"], c["risk"]))
     return derived_risks, caps
 
 
@@ -114,5 +120,5 @@ if __name__ == "__main__":  # tiny demo
     if cli is None:
         print("dose_caps: adj-lang-cli not built", file=sys.stderr)
         raise SystemExit(3)
-    risks_dr, caps = derive_dose_caps(cli, {"hepatic_severe", "renal_moderate"})
+    risks_dr, caps = derive_dose_caps(cli, {"hepatic_severe", "renal_moderate", "nephrotoxin_interaction"})
     print(json.dumps({"derived_risks": sorted(risks_dr), "caps": caps}, indent=2, ensure_ascii=False))

--- a/code/specs/data/mycin-2026/treatment/antibiotics/dose_caps_build.py
+++ b/code/specs/data/mycin-2026/treatment/antibiotics/dose_caps_build.py
@@ -106,6 +106,26 @@ DOSE_CAPS: list[tuple[str, str, str, str]] = [
      "impairment and significant renal impairment (FDA label)."),
 ]
 
+# SINGLE-FACTOR grounded dose caps: (grounding_id, drug, active risk token, authored_fallback).
+# Unlike the COMPOUND caps above, these fire on ONE active risk directly (no conjunction). They
+# reuse the same `dose_capped_under` relation + the third generic rule below, so the substrate
+# now covers both shapes uniformly. The grounding ids point at the same dose-window records that
+# back the formulary's numeric ceiling penalties — making the FDA byte-quote ENGINE-QUERYABLE and
+# letting it flow as provenance onto the renal/nephrotoxin dose-risk constraints at answer time.
+# (The numeric per-kg shrink stays the formulary's illustrative model; only the DIRECTION/source
+# is grounded — verdict direction_only.)
+SINGLE_FACTOR_CAPS: list[tuple[str, str, str, str]] = [
+    ("dose_penalty_vancomycin_renal", "vancomycin", "renal_severe",
+     "Vancomycin dosage must be adjusted (the safe ceiling shrinks) in renal dysfunction "
+     "because toxicity rises with high, prolonged blood concentrations (FDA label)."),
+    ("dose_penalty_vancomycin_renal", "vancomycin", "renal_moderate",
+     "Vancomycin dosage must be adjusted (the safe ceiling shrinks) in renal dysfunction "
+     "because toxicity rises with high, prolonged blood concentrations (FDA label)."),
+    ("dose_penalty_vancomycin_nephrotoxin", "vancomycin", "nephrotoxin_interaction",
+     "Concomitant therapy with another nephrotoxin (e.g. an aminoglycoside) compounds "
+     "vancomycin nephrotoxicity, requiring careful/adjusted dosing (FDA label)."),
+]
+
 
 def _gate(rec: dict | None) -> tuple[str, str]:
     """Map a grounding record to (verdict, trust).  A dose cap is directional, so a `grounded`
@@ -219,6 +239,12 @@ RULES = """\
               compound_second($C, $CatB), risk_in_category($Rb, $CatB), active_risk($Rb),
               dose_capped_under($D, $C)
     }
+    % SINGLE-FACTOR cap: a drug is dose-capped when it is capped under a risk that is itself
+    % directly active (no conjunction). The same dose_capped query target serves both shapes.
+    rule {
+        head: dose_capped($D, $R)
+        when: active_risk($R), dose_capped_under($D, $R)
+    }
 """
 
 
@@ -248,8 +274,15 @@ def build(check: bool = False) -> int:
             "verdict": "DEFINITIONAL", "trust": "definitional", "grounding_id": None}
 
     body.append("")
-    body.append("    % --- grounded dose caps (the clinical claim) " + "-" * 28)
+    body.append("    % --- grounded COMPOUND dose caps (the clinical claim) " + "-" * 19)
     for gid, drug, risk, authored in DOSE_CAPS:
+        block, entry = _cap_block(drug, risk, gid, authored, recs.get(gid))
+        body.append(block)
+        clauses[f"dose_capped_under__{drug}__{risk}"] = entry
+
+    body.append("")
+    body.append("    % --- grounded SINGLE-FACTOR dose caps (renal / nephrotoxin) " + "-" * 13)
+    for gid, drug, risk, authored in SINGLE_FACTOR_CAPS:
         block, entry = _cap_block(drug, risk, gid, authored, recs.get(gid))
         body.append(block)
         clauses[f"dose_capped_under__{drug}__{risk}"] = entry

--- a/code/specs/data/mycin-2026/treatment/antibiotics/test_chart_to_cop.py
+++ b/code/specs/data/mycin-2026/treatment/antibiotics/test_chart_to_cop.py
@@ -93,9 +93,10 @@ def test_hepatic_renal_conjunction_caps_ceftriaxone():
     assert not hep_only and not caps_only, (hep_only, caps_only)
     both_risks, both_caps = dose_caps.derive_dose_caps(cli, {"hepatic_severe", "renal_moderate"})
     assert "hepatorenal" in both_risks, both_risks
-    assert both_caps.get("ceftriaxone", {}).get("trust") == "authoritative", both_caps
-    assert "hepatic impairment and significant renal impairment" in \
-        both_caps["ceftriaxone"]["source"], both_caps
+    # caps is a list of {drug, risk, source, locator, trust}; find the ceftriaxone hepatorenal cap.
+    cef = next((c for c in both_caps if c["drug"] == "ceftriaxone"), None)
+    assert cef and cef["risk"] == "hepatorenal" and cef["trust"] == "authoritative", both_caps
+    assert "hepatic impairment and significant renal impairment" in cef["source"], both_caps
     # End-to-end through derive(): the conjunction shrinks ceftriaxone's ceiling but it stays
     # FEASIBLE — a dose-ADJUSTMENT, not a fabricated INFEASIBLE — so the regimen survives, and
     # the grounded cap surfaces as a provenance-bearing constraint.

--- a/code/specs/data/mycin-2026/treatment/antibiotics/test_dose_caps.py
+++ b/code/specs/data/mycin-2026/treatment/antibiotics/test_dose_caps.py
@@ -43,8 +43,11 @@ def test_generated_rulebook_is_grounded_and_parseable():
     # The compound is defined structurally as TWO distinct component categories.
     assert "compound_first(hepatorenal, hepatic)" in text
     assert "compound_second(hepatorenal, renal)" in text
-    # The two GENERIC conjunction rules are present (not a drug-specific Python `if`).
-    assert text.count("rule {") == 2 and "derived_risk($C)" in text
+    # SINGLE-FACTOR grounded caps (vancomycin renal / nephrotoxin) reuse dose_capped_under.
+    assert "dose_capped_under(vancomycin, renal_severe)" in text
+    assert "dose_capped_under(vancomycin, nephrotoxin_interaction)" in text
+    # THREE GENERIC rules now: derived_risk + compound dose_capped + single-factor dose_capped.
+    assert text.count("rule {") == 3 and "derived_risk($C)" in text
 
 
 # --------------------------------------------------------------------------
@@ -58,7 +61,7 @@ def test_unsafe_risk_tokens_are_rejected(bad):
 
 def test_no_active_risks_short_circuits_without_the_engine():
     # An empty risk set must NOT touch the engine (cli unused) and derive nothing.
-    assert dc.derive_dose_caps(_DUMMY_CLI, set()) == (set(), {})
+    assert dc.derive_dose_caps(_DUMMY_CLI, set()) == (set(), [])
 
 
 class _DummyCli:
@@ -80,27 +83,31 @@ def _cli_or_skip():
     return cli
 
 
-def test_conjunction_requires_both_categories():
+def _drugs(caps):
+    return {c["drug"] for c in caps}
+
+
+def test_compound_requires_both_categories():
     cli = _cli_or_skip()
-    # A single organ risk derives NOTHING — hepatic alone, or renal alone, needs no compound
-    # cap (faithful to the label: hepatic impairment alone needs no dose adjustment).
-    assert dc.derive_dose_caps(cli, {"hepatic_severe"}) == (set(), {})
-    assert dc.derive_dose_caps(cli, {"renal_moderate"}) == (set(), {})
-    # Two hepatic risks (still no renal) must NOT fire — the rule needs two DISTINCT categories.
-    assert dc.derive_dose_caps(cli, {"hepatic_severe", "hepatic_moderate"}) == (set(), {})
+    # The COMPOUND (derived_risk) needs two DISTINCT organ categories: a single hepatic risk,
+    # or two hepatic risks, derive NO compound (faithful: hepatic alone needs no adjustment).
+    risks, caps = dc.derive_dose_caps(cli, {"hepatic_severe"})
+    assert risks == set() and caps == [], (risks, caps)  # hepatic has no single-factor cap either
+    risks2, _ = dc.derive_dose_caps(cli, {"hepatic_severe", "hepatic_moderate"})
+    assert risks2 == set(), risks2  # two hepatic, no renal → no hepatorenal
 
 
 def test_both_categories_derive_hepatorenal_with_grounded_provenance():
     cli = _cli_or_skip()
     risks, caps = dc.derive_dose_caps(cli, {"hepatic_severe", "renal_moderate"})
     assert risks == {"hepatorenal"}, risks
-    assert set(caps) == {"ceftriaxone"}, caps
-    info = caps["ceftriaxone"]
-    assert info["risk"] == "hepatorenal"
+    # caps is a list; the compound ceftriaxone cap AND the single-factor vancomycin renal cap.
+    cef = next((c for c in caps if c["drug"] == "ceftriaxone"), None)
+    assert cef and cef["risk"] == "hepatorenal"
     # the grounded FDA byte-quote flows through to the cap.
-    assert info["trust"] == "authoritative" and info["source"]
-    assert "hepatic impairment and significant renal impairment" in info["source"]
-    assert info["locator"] and "dailymed" in info["locator"]
+    assert cef["trust"] == "authoritative" and cef["source"]
+    assert "hepatic impairment and significant renal impairment" in cef["source"]
+    assert cef["locator"] and "dailymed" in cef["locator"]
 
 
 def test_graded_severities_all_map_to_their_category():
@@ -110,13 +117,34 @@ def test_graded_severities_all_map_to_their_category():
     for hep in ("hepatic_severe", "hepatic_moderate"):
         for ren in ("renal_severe", "renal_moderate"):
             risks, caps = dc.derive_dose_caps(cli, {hep, ren})
-            assert risks == {"hepatorenal"} and "ceftriaxone" in caps, (hep, ren)
+            assert risks == {"hepatorenal"} and "ceftriaxone" in _drugs(caps), (hep, ren)
 
 
-def test_unrelated_single_risk_caps_nothing():
+def test_single_factor_renal_cap_is_grounded():
     cli = _cli_or_skip()
-    # A non-organ risk token (e.g. an interaction) is not in any category → no compound, no cap.
-    assert dc.derive_dose_caps(cli, {"nephrotoxin_interaction"}) == (set(), {})
+    # CC-2c: a single renal risk caps vancomycin (no conjunction needed), carrying the FDA quote.
+    for ren in ("renal_severe", "renal_moderate"):
+        risks, caps = dc.derive_dose_caps(cli, {ren})
+        assert risks == set(), (ren, risks)  # single factor → no COMPOUND derived
+        van = next((c for c in caps if c["drug"] == "vancomycin"), None)
+        assert van and van["risk"] == ren and van["trust"] == "authoritative", (ren, caps)
+        assert "renal" in van["source"].lower()
+
+
+def test_single_factor_nephrotoxin_cap_is_grounded():
+    cli = _cli_or_skip()
+    # CC-2c: a concomitant nephrotoxin caps vancomycin, carrying the PRECAUTIONS byte-quote.
+    risks, caps = dc.derive_dose_caps(cli, {"nephrotoxin_interaction"})
+    assert risks == set()
+    van = next((c for c in caps if c["drug"] == "vancomycin"), None)
+    assert van and van["risk"] == "nephrotoxin_interaction" and van["trust"] == "authoritative", caps
+    assert "nephrotoxicity" in van["source"].lower()
+
+
+def test_unknown_single_risk_caps_nothing():
+    cli = _cli_or_skip()
+    # A risk token with no dose_capped_under fact and no category → no compound, no cap.
+    assert dc.derive_dose_caps(cli, {"qt_prolongation"}) == (set(), [])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## ADJ-language follow-up to #6363 — single-factor caps are now engine-queryable

The `dose_caps.adj` substrate (#6358) handled only **compound** (conjunctive) caps. It now also expresses **single-factor** grounded caps, so the vancomycin renal/nephrotoxin penalties grounded in #6363 become **engine-queryable** and their FDA byte-quotes flow as provenance onto the live dose-risk constraints.

### What changed
- **`dose_caps.adj`** (generated): + grounded facts `dose_capped_under(vancomycin, renal_severe)` / `(…, renal_moderate)` / `(…, nephrotoxin_interaction)`, each carrying the FDA byte-quote from `dose-window-grounding.json` (records `dose_penalty_vancomycin_renal` / `_nephrotoxin`), + a **third generic rule** `dose_capped($D,$R) when active_risk($R), dose_capped_under($D,$R)`. The same `dose_capped` query target serves both shapes; no double-fire (compound risks aren't asserted as `active_risk`).
- **`dose_caps_build.py`**: + `SINGLE_FACTOR_CAPS` table + rendering (reuses the `_cap_block` ACCEPT/FLAG gate). `--check` stable.
- **`dose_caps.py`**: `derive_dose_caps` now returns `caps` as a **list** of `{drug, risk, source, locator, trust}` (a drug may be capped under several risks — vancomycin under renal **and** nephrotoxin), with `(drug,risk)` dedup. Injection guard / argv subprocess / tempfile handling unchanged.
- **`chart_to_cop.derive()`**: iterates the caps list and surfaces every engine-derived cap (compound via `derived_risk(...)`, single-factor via `active_risk(...)`) as a provenance-bearing `dose_risk` constraint — so the renal/nephrotoxin **FDA quote reaches the answer**, engine-derived.

### Behavior preserved (verified by running)
The numeric dose-window solve is unchanged → regimen output and **`board-scorecard.json` are byte-identical** (0 wrong, management 6/6, defensibility 100%). This only enriches provenance and proves the substrate covers both cap shapes.

- `test_dose_caps.py` — **15/15** (single-factor renal+nephrotoxin grounded with FDA quotes; compound still requires two distinct categories; injection guard).
- `test_chart_to_cop.py` — green; `board/test_board_eval.py` path unchanged; `dose_caps_build.py --check` up to date; `ruff` clean.
- Spec `CHART-AS-CONSTRAINTS.md` CC-2c updated with the ADJ-native single-factor subsection.

Security review (Python, diff inline): **PASSED — no vulnerabilities found** (guard/subprocess/tempfile unchanged; new code is static data + list refactor over trusted engine output).

🤖 Generated with [Claude Code](https://claude.com/claude-code)