### PR TITLE
feat(r-27): output formatting — format(), formatC(), prettyNum(), toString(), vectorized sprintf()

### DIFF
--- a/code/packages/rust/r-runtime/CHANGELOG.md
+++ b/code/packages/rust/r-runtime/CHANGELOG.md
@@ -26,7 +26,9 @@ All notable changes to this project will be documented in this file.
     since R-5; R-27 adds the regression coverage.
   - **Security**: all field widths/precisions are capped at 1 MiB
     (`MAX_FIELD`), so a crafted `fmt` or a huge `width=`/`nsmall=`/`digits=`
-    cannot trigger a giant allocation.
+    cannot trigger a giant allocation; the vectorized formatters additionally
+    enforce a 256 MiB total-output budget (width × vector length) so a long
+    vector formatted to a wide field is a clean error, not an OOM.
   - 13 new R-syntax tests.
   - **Deferred to R-28**: exotic `formatC` corners (`format = "g"` rounding,
     the `" "`/`"#"` flags, `scientific=`).

--- a/code/packages/rust/r-runtime/CHANGELOG.md
+++ b/code/packages/rust/r-runtime/CHANGELOG.md
@@ -2,6 +2,35 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.22.0] - 2026-06-20
+
+### Added (via the shared `s-runtime`)
+
+- **R-27 — output-formatting functions**: a pivot off the R5/OOP lane into a
+  fresh data/utility area. All pure builtins in the shared `s-runtime` (no
+  grammar change), reached through ordinary R syntax. Deterministic, locale-free
+  output (fixed `","` thousands separator and `"."` decimal point).
+  - **`format`** — `format(3.14159, nsmall = 2)` → `"3.14"`;
+    `format(42, width = 5)` → `"   42"`; `format(c(1, 10, 100))` →
+    `c("  1", " 10", "100")` (a numeric vector pads to a common width);
+    `format(c("a","bb"), justify = "right")` → `c(" a", "bb")`;
+    `format(1234567, big.mark = ",")` → `"1,234,567"`.
+  - **`formatC`** — `formatC(3.14159, format = "f", digits = 2)` → `"3.14"`;
+    `formatC(42, width = 6, flag = "0")` → `"000042"`; `formatC(255, format =
+    "x")` → `"ff"`; vectorized over `x`.
+  - **`prettyNum`** — `prettyNum(1234567, big.mark = ",")` → `"1,234,567"`.
+  - **`toString`** — `toString(1:3)` → `"1, 2, 3"`;
+    `toString(c("a","b"), sep = "; ")` → `"a; b"`.
+  - **`sprintf`** (vectorized) — `sprintf("%d-%s", 1:2, c("a","b"))` →
+    `c("1-a", "2-b")`; `sprintf("%05.2f", 3.1)` → `"03.10"`. Already vectorized
+    since R-5; R-27 adds the regression coverage.
+  - **Security**: all field widths/precisions are capped at 1 MiB
+    (`MAX_FIELD`), so a crafted `fmt` or a huge `width=`/`nsmall=`/`digits=`
+    cannot trigger a giant allocation.
+  - 13 new R-syntax tests.
+  - **Deferred to R-28**: exotic `formatC` corners (`format = "g"` rounding,
+    the `" "`/`"#"` flags, `scientific=`).
+
 ## [0.21.0] - 2026-06-20
 
 ### Added (via the shared `s-runtime`)

--- a/code/packages/rust/r-runtime/README.md
+++ b/code/packages/rust/r-runtime/README.md
@@ -129,6 +129,23 @@ celsius*9/5+32 else celsius <<- (v-32)*5/9 }` makes `t$fahrenheit` compute and
 and B's fields/methods (left-to-right precedence), with `is`/`inherits`/`class`
 seeing every base, diamonds de-duplicated, and mutual-inheritance cycles rejected.
 
+**Output formatting (R-27)** — a pivot off the R5/OOP lane into a fresh
+data/utility area, with deterministic, locale-free output (fixed `","` thousands
+separator and `"."` decimal point). `format(x, nsmall=, width=, justify=,
+big.mark=)` formats numbers and character vectors — a numeric vector pads to a
+*common* width (`format(c(1, 10, 100))` → `c("  1", " 10", "100")`),
+`format(3.14159, nsmall = 2)` → `"3.14"`, `format(42, width = 5)` → `"   42"`,
+character `justify` is `"left"`/`"right"`/`"centre"`, and `big.mark` groups
+thousands. `formatC(x, format=, digits=, width=, flag=)` is the C-style
+formatter (`format` `"d"`/`"f"`/`"e"`/`"g"`/`"s"`/`"x"`, `flag` `"-"`/`"0"`/`"+"`):
+`formatC(3.14159, format = "f", digits = 2)` → `"3.14"`, `formatC(42, width = 6,
+flag = "0")` → `"000042"`. `prettyNum(1234567, big.mark = ",")` → `"1,234,567"`,
+`toString(1:3)` → `"1, 2, 3"`, and `sprintf` recycles over vector arguments
+(`sprintf("%d-%s", 1:2, c("a","b"))` → `c("1-a", "2-b")`). Every field width and
+precision is capped at 1 MiB so a crafted `fmt` or a huge `width=` cannot trigger
+a giant allocation. (Exotic `formatC` corners — `format = "g"` rounding, the
+`" "`/`"#"` flags, `scientific=` — are deferred to R-28.)
+
 ## Usage
 
 ```rust

--- a/code/packages/rust/r-runtime/src/lib.rs
+++ b/code/packages/rust/r-runtime/src/lib.rs
@@ -2470,4 +2470,166 @@ mod tests {
             a <- Base$new(x = 1)\nb <- a\nb$set(9)\nd <- a$copy()\nd$set(100)\nc(a$x, d$x)\n";
         assert_eq!(nums(src2), vec![9.0, 100.0]);
     }
+
+    // --- R-27: output-formatting functions ------------------------------
+    //
+    // Helper: pull the raw string from a length-1 character result (no `[1]`
+    // prefix, no surrounding quotes — just the bytes).
+    fn chr(src: &str) -> Vec<String> {
+        match eval_r(src).unwrap() {
+            SValue::Character(v) => v.into_iter().map(|o| o.unwrap_or_default()).collect(),
+            other => panic!("expected character, got {}", other.type_name()),
+        }
+    }
+
+    #[test]
+    fn format_nsmall_pads_decimals() {
+        // In this R-27 subset, a supplied `nsmall` is the decimal count: it both
+        // pads short values and rounds long ones to exactly nsmall places.
+        assert_eq!(chr("format(3.14159, nsmall = 2)\n"), vec!["3.14"]);
+        assert_eq!(chr("format(3, nsmall = 2)\n"), vec!["3.00"]);
+        assert_eq!(chr("format(2.5, nsmall = 3)\n"), vec!["2.500"]);
+        // nsmall = 0 (the default) uses R's default rendering, untouched.
+        assert_eq!(chr("format(3.14159)\n"), vec!["3.14159"]);
+    }
+
+    #[test]
+    fn format_width_pads_field() {
+        assert_eq!(chr("format(42, width = 5)\n"), vec!["   42"]);
+    }
+
+    #[test]
+    fn format_numeric_vector_common_width() {
+        // R right-justifies the whole vector to the widest element.
+        assert_eq!(chr("format(c(1, 10, 100))\n"), vec!["  1", " 10", "100"]);
+    }
+
+    #[test]
+    fn format_character_justify() {
+        assert_eq!(
+            chr("format(c(\"a\", \"bb\"), justify = \"left\")\n"),
+            vec!["a ", "bb"]
+        );
+        assert_eq!(
+            chr("format(c(\"a\", \"bb\"), justify = \"right\")\n"),
+            vec![" a", "bb"]
+        );
+        assert_eq!(
+            chr("format(\"x\", width = 5, justify = \"centre\")\n"),
+            vec!["  x  "]
+        );
+    }
+
+    #[test]
+    fn format_big_mark() {
+        assert_eq!(
+            chr("format(1234567, big.mark = \",\")\n"),
+            vec!["1,234,567"]
+        );
+    }
+
+    #[test]
+    fn format_c_fixed_and_zero_pad() {
+        assert_eq!(
+            chr("formatC(3.14159, format = \"f\", digits = 2)\n"),
+            vec!["3.14"]
+        );
+        assert_eq!(chr("formatC(42, width = 6, flag = \"0\")\n"), vec!["000042"]);
+    }
+
+    #[test]
+    fn format_c_left_justify_and_plus_and_hex() {
+        assert_eq!(chr("formatC(7, width = 4, flag = \"-\")\n"), vec!["7   "]);
+        assert_eq!(chr("formatC(7, flag = \"+\")\n"), vec!["+7"]);
+        assert_eq!(chr("formatC(255, format = \"x\")\n"), vec!["ff"]);
+        assert_eq!(chr("formatC(\"hi\", width = 5)\n"), vec!["   hi"]);
+        // e conversion.
+        assert_eq!(
+            chr("formatC(1000, format = \"e\", digits = 2)\n"),
+            vec!["1.00e3"]
+        );
+    }
+
+    #[test]
+    fn format_c_vectorized() {
+        assert_eq!(
+            chr("formatC(c(1, 22, 333), format = \"d\", width = 4)\n"),
+            vec!["   1", "  22", " 333"]
+        );
+    }
+
+    #[test]
+    fn pretty_num_thousands() {
+        assert_eq!(
+            chr("prettyNum(1234567, big.mark = \",\")\n"),
+            vec!["1,234,567"]
+        );
+        // Default big.mark is ",".
+        assert_eq!(chr("prettyNum(1000)\n"), vec!["1,000"]);
+        // Negative sign preserved, not grouped.
+        assert_eq!(chr("prettyNum(-12345, big.mark = \",\")\n"), vec!["-12,345"]);
+    }
+
+    #[test]
+    fn to_string_collapses() {
+        assert_eq!(chr("toString(1:3)\n"), vec!["1, 2, 3"]);
+        assert_eq!(
+            chr("toString(c(\"a\", \"b\"), sep = \"; \")\n"),
+            vec!["a; b"]
+        );
+        // Always length-1.
+        assert_eq!(eval_r("toString(1:3)\n").unwrap().length(), 1);
+    }
+
+    #[test]
+    fn sprintf_vectorized_recycling() {
+        // R-5 added scalar sprintf; R-27 confirms full vector recycling.
+        assert_eq!(
+            chr("sprintf(\"%d-%s\", 1:2, c(\"a\", \"b\"))\n"),
+            vec!["1-a", "2-b"]
+        );
+        // Width + precision + zero-pad on a float.
+        assert_eq!(chr("sprintf(\"%05.2f\", 3.1)\n"), vec!["03.10"]);
+        // Shorter args recycle to the longest.
+        assert_eq!(
+            chr("sprintf(\"%d:%d\", 1:4, 10)\n"),
+            vec!["1:10", "2:10", "3:10", "4:10"]
+        );
+    }
+
+    #[test]
+    fn sprintf_scalar_regression_still_works() {
+        // The R-5 scalar contract must not have regressed.
+        assert_eq!(
+            show("sprintf(\"%s has %d\", \"x\", 3L)\n"),
+            "[1] \"x has 3\""
+        );
+    }
+
+    #[test]
+    fn format_width_dos_capped() {
+        // A crafted huge width is CLAMPED to MAX_FIELD (1 MiB), not turned into a
+        // multi-GB allocation. We measure the result with `nchar` (so the giant
+        // string is never auto-printed) and confirm it is exactly the cap.
+        assert_eq!(
+            nums("nchar(formatC(1, width = 100000000))\n"),
+            vec![(1 << 20) as f64]
+        );
+        // `format`'s width is clamped the same way.
+        assert_eq!(
+            nums("nchar(format(\"x\", width = 1e9))\n"),
+            vec![(1 << 20) as f64]
+        );
+        // sprintf's own cap REJECTS an oversize literal width (clean error).
+        assert!(eval_r("sprintf(\"%99999999999d\", 1)\n").is_err());
+    }
+
+    #[test]
+    fn format_na_and_empty() {
+        assert_eq!(chr("format(NA)\n"), vec!["NA"]);
+        // toString of an empty vector (c() is NULL/length-0) is the empty string.
+        assert_eq!(chr("toString(c())\n"), vec![""]);
+        // An empty (length-0) input formats to a length-0 character vector.
+        assert_eq!(eval_r("format(c())\n").unwrap().length(), 0);
+    }
 }

--- a/code/packages/rust/r-runtime/src/lib.rs
+++ b/code/packages/rust/r-runtime/src/lib.rs
@@ -2625,6 +2625,17 @@ mod tests {
     }
 
     #[test]
+    fn format_total_output_budget_rejected() {
+        // Per-field cap is fine, but width × vector-length must also be bounded:
+        // 100k elements each padded to 1 MiB would be ~100 GB — rejected cleanly,
+        // not OOM. (1:100000 builds a 100k-long vector via the `:` sequence.)
+        assert!(eval_r("formatC(1:100000, width = 1048576)\n").is_err());
+        assert!(eval_r("format(1:100000, width = 1000000)\n").is_err());
+        // A modest request still succeeds.
+        assert_eq!(nums("nchar(formatC(1:3, width = 5))\n"), vec![5.0, 5.0, 5.0]);
+    }
+
+    #[test]
     fn format_na_and_empty() {
         assert_eq!(chr("format(NA)\n"), vec!["NA"]);
         // toString of an empty vector (c() is NULL/length-0) is the empty string.

--- a/code/packages/rust/s-runtime/CHANGELOG.md
+++ b/code/packages/rust/s-runtime/CHANGELOG.md
@@ -2,6 +2,44 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.23.0] - 2026-06-20
+
+### Added
+
+- **Output-formatting builtins (R-27)** — a family of pure, deterministic
+  (locale-free) string formatters, available to both S and R via the shared
+  tree-walker; no grammar change.
+  - **`format(x, nsmall=, width=, justify=, big.mark=)`** — the general
+    formatter. A **numeric** vector formats to a *common* width (every element is
+    right-justified to the width of the widest, so columns line up); a
+    **character** vector pads to `max(width, widest)` honouring `justify`
+    (`"left"` / `"right"` / `"centre"`). A supplied `nsmall` is the decimal count
+    (`format(3, nsmall = 2)` → `"3.00"`); `big.mark` inserts a thousands
+    separator. Returns a character vector the length of `x`.
+  - **`formatC(x, format=, digits=, width=, flag=)`** — C-style: `format` one of
+    `"d"`/`"f"`/`"e"`/`"g"`/`"s"`/`"x"`, `digits` precision, `width` minimum field
+    width, `flag` a string of `printf` flags (`"-"` left, `"0"` zero-pad, `"+"`
+    force sign). Reuses the `sprintf` conversion engine.
+  - **`prettyNum(x, big.mark = ",")`** — insert a thousands separator (sign
+    preserved, never grouped).
+  - **`toString(x, sep = ", ")`** — collapse a whole vector to one string.
+  - **`sprintf`** stays fully vectorized (it was since R-5); R-27 adds regression
+    coverage and shares the `printf` core with `formatC`.
+
+### Security
+
+- The `MAX_FIELD = 1 MiB` field-width/precision cap that `sprintf` enforced is
+  **hoisted to module scope** and now shared by `format`/`formatC`: a crafted
+  `fmt` or a huge `width=`/`nsmall=`/`digits=` is clamped (oversize literal
+  `sprintf` widths are a clean error), so no caller-controlled value can trigger
+  a giant allocation. All width arithmetic uses `saturating_*`. There is no
+  `%n`-style conversion, so no write-what-where primitive exists.
+
+### Deferred
+
+- Exotic `formatC` corners — `format = "g"` exact-rounding edge cases, the `" "`
+  and `"#"` flags, and `format()`'s `scientific=` — are left for **R-28**.
+
 ## [0.22.0] - 2026-06-20
 
 ### Added

--- a/code/packages/rust/s-runtime/CHANGELOG.md
+++ b/code/packages/rust/s-runtime/CHANGELOG.md
@@ -32,8 +32,12 @@ All notable changes to this project will be documented in this file.
   **hoisted to module scope** and now shared by `format`/`formatC`: a crafted
   `fmt` or a huge `width=`/`nsmall=`/`digits=` is clamped (oversize literal
   `sprintf` widths are a clean error), so no caller-controlled value can trigger
-  a giant allocation. All width arithmetic uses `saturating_*`. There is no
-  `%n`-style conversion, so no write-what-where primitive exists.
+  a giant allocation. Because the per-field cap does not bound a *long vector ×
+  wide field*, `format`/`formatC`/`prettyNum` also enforce a
+  **`MAX_TOTAL_OUTPUT = 256 MiB`** budget on the *product* (common width ×
+  element count), computed with `saturating_mul`. All width arithmetic uses
+  `saturating_*`. There is no `%n`-style conversion, so no write-what-where
+  primitive exists.
 
 ### Deferred
 

--- a/code/packages/rust/s-runtime/README.md
+++ b/code/packages/rust/s-runtime/README.md
@@ -164,6 +164,18 @@ a hand-written loop. See [What "S-flavored" means here](#what-s-flavored-means-h
   DFS `linearization` (de-duping diamonds; C3 not implemented) drives all
   effective-set/class-chain walks with most-derived-first precedence, and the cycle
   check runs over every parent so the multi-parent graph stays a DAG.
+- **Output-formatting builtins** (R-27): `format`, `formatC`, `prettyNum`,
+  `toString`, and the (already vectorized) `sprintf` — pure, deterministic,
+  locale-free string formatters. `format(x, nsmall=, width=, justify=,
+  big.mark=)` formats a **numeric** vector to a *common* width (right-justified
+  to the widest, so columns line up) or a **character** vector with `justify`;
+  `formatC(x, format=, digits=, width=, flag=)` is the C-style wrapper over the
+  `sprintf` `render_conversion` engine (`"d"`/`"f"`/`"e"`/`"g"`/`"s"`/`"x"`,
+  flags `"-"`/`"0"`/`"+"`); `prettyNum` inserts a thousands separator; `toString`
+  collapses a vector to one string. The `MAX_FIELD = 1 MiB` field-width cap is
+  shared across all of them, so a crafted `fmt` or a huge `width=`/`nsmall=`/
+  `digits=` cannot trigger a giant allocation. (Exotic `formatC` corners —
+  `format = "g"` rounding, `" "`/`"#"` flags, `scientific=` — deferred to R-28.)
 - The **`d`/`p`/`q`/`r` distribution family** (R-8) over `statistics-core`:
   density/CDF/quantile/sampling for the normal, uniform, and exponential
   distributions, plus `set.seed` for a reproducible per-session RNG.

--- a/code/packages/rust/s-runtime/src/builtins.rs
+++ b/code/packages/rust/s-runtime/src/builtins.rs
@@ -10,7 +10,8 @@ use crate::env::{define, lookup, Env};
 use crate::error::{SError, SResult};
 use crate::eval::{nth_element, Interpreter};
 use crate::value::{
-    bounded_sequence, class_of, combine, index, Arg, SValue, MAX_ATTRIBUTES, MAX_SEQ_LEN,
+    bounded_sequence, class_of, combine, format_number, index, Arg, SValue, MAX_ATTRIBUTES,
+    MAX_SEQ_LEN,
 };
 use r_vector::{is_na_real, na_real, Double};
 use statistics_core::distributions::{dnorm, pnorm, qnorm, rnorm};
@@ -158,6 +159,13 @@ pub fn install(env: &Env) {
     define(env, "tolower", builtin("tolower", b_tolower));
     define(env, "substr", builtin("substr", b_substr));
     define(env, "sprintf", builtin("sprintf", b_sprintf));
+
+    // Output formatting (R-27) — turn numbers and vectors into human-readable
+    // text. Pure builtins, deterministic (locale-free) defaults.
+    define(env, "format", builtin("format", b_format));
+    define(env, "formatC", builtin("formatC", b_format_c));
+    define(env, "prettyNum", builtin("prettyNum", b_pretty_num));
+    define(env, "toString", builtin("toString", b_to_string));
 
     // v2 — apply family.
     define(env, "sapply", builtin("sapply", b_sapply));
@@ -2459,6 +2467,14 @@ fn substring(s: &str, start: i64, stop: i64) -> String {
     s.chars().skip(from).take(count).collect()
 }
 
+/// Hard cap on any single field width or precision (1 MiB). A user-supplied
+/// `fmt`, `width`, `nsmall`, or `digits` is *data*; this bound is what stops a
+/// crafted spec like `%999999999d` or `formatC(x, width = 1e9)` from triggering
+/// a giant allocation (a width-DoS). Shared by `sprintf`, `format`, and
+/// `formatC`. There is no `%n`-style conversion, so there is no
+/// write-what-where primitive to worry about — only allocation size.
+const MAX_FIELD: usize = 1 << 20;
+
 /// `sprintf(fmt, ...)` — a minimal C-style formatter supporting `%d`/`%i`,
 /// `%s`, `%f`/`%e`/`%g`, and `%%`, with optional width, `.precision`, and the
 /// `-` (left-justify) and `0` (zero-pad) flags. Vectorized: the result has the
@@ -2548,7 +2564,6 @@ fn format_one(fmt: &str, args: &[&SValue], row: usize) -> SResult<String> {
         }
         // Cap the field width and precision so a crafted format like
         // `%999999999999d` can't trigger an unbounded allocation in `pad`.
-        const MAX_FIELD: usize = 1 << 20; // 1 MiB per field
         if width > MAX_FIELD || precision.is_some_and(|p| p > MAX_FIELD) {
             return Err(SError::BadArgs(
                 "sprintf: field width or precision is too large".into(),
@@ -2627,6 +2642,354 @@ fn pad(body: &str, width: usize, left: bool, zero: bool) -> String {
     } else {
         format!("{fill}{body}")
     }
+}
+
+// ===========================================================================
+// Output formatting (R-27)
+// ===========================================================================
+//
+// A small family of pure builtins for turning numbers and vectors into
+// human-readable text. The design goal is **determinism**: nothing here reads
+// the clock or the host locale. The default thousands separator is `","` and
+// the decimal point is `"."`, fixed everywhere — so a CI run in a `de_DE`
+// locale (where R's real `format()` would use `.` for thousands and `,` for the
+// decimal) produces exactly the same bytes as a run in `C`/`en_US`.
+//
+//   ┌───────────────┬──────────────────────────────────────────────────────┐
+//   │ format(x,…)   │ general formatter; numeric vectors pad to a COMMON     │
+//   │               │ width (R right-justifies all to the widest element)    │
+//   │ formatC(x,…)  │ C-style printf wrapper: format="d"/"f"/"e"/"g"/"s"/"x" │
+//   │ prettyNum(x)  │ insert a thousands separator into the integer part     │
+//   │ toString(x)   │ collapse a whole vector into ONE comma-joined string   │
+//   └───────────────┴──────────────────────────────────────────────────────┘
+
+/// Read a scalar named argument as a non-negative field count (`width`,
+/// `nsmall`, `digits`). Absent → `None`. Present → the value coerced to a
+/// double, floored, and **clamped to `MAX_FIELD`**; a negative or non-finite
+/// value is treated as `0`. The clamp is the width-DoS guard: a caller asking
+/// for `width = 1e9` gets `MAX_FIELD`, not a 1-GB allocation.
+fn named_count(args: &[Arg], name: &str) -> Option<usize> {
+    let raw = args
+        .iter()
+        .find(|a| a.name.as_deref() == Some(name))?
+        .value
+        .as_double()
+        .ok()?
+        .get_value(0)?;
+    if !raw.is_finite() || raw < 0.0 {
+        return Some(0);
+    }
+    Some((raw as usize).min(MAX_FIELD))
+}
+
+/// Read a scalar named *string* argument (`justify`, `big.mark`, `format`,
+/// `flag`, `sep`). Absent or `NA` → `None`.
+fn named_str(args: &[Arg], name: &str) -> Option<String> {
+    args.iter()
+        .find(|a| a.name.as_deref() == Some(name))?
+        .value
+        .as_character()
+        .into_iter()
+        .next()
+        .flatten()
+}
+
+/// Insert `mark` between every group of three digits of an integer-part string,
+/// counting from the right. `"1234567"` → `"1,234,567"`. A leading sign is
+/// preserved and never grouped. Pure string surgery, no locale.
+fn group_thousands(int_part: &str, mark: &str) -> String {
+    if mark.is_empty() {
+        return int_part.to_string();
+    }
+    // Split off an optional leading sign so we group only the digits.
+    let (sign, digits) = match int_part.strip_prefix('-') {
+        Some(rest) => ("-", rest),
+        None => ("", int_part),
+    };
+    // Group from the RIGHT. The leading group is the remainder (1, 2, or 3
+    // digits); every group after it is exactly 3. `"1234567"` → first = 1 →
+    // "1" | "234" | "567" → "1,234,567".
+    let bytes = digits.as_bytes();
+    let len = bytes.len();
+    let first = if len % 3 == 0 { 3 } else { len % 3 };
+    let mut grouped = String::with_capacity(len + len / 3 * mark.len());
+    let mut idx = 0usize;
+    while idx < len {
+        let take = if idx == 0 { first } else { 3 };
+        if idx != 0 {
+            grouped.push_str(mark);
+        }
+        grouped.push_str(std::str::from_utf8(&bytes[idx..idx + take]).unwrap_or(""));
+        idx += take;
+    }
+    format!("{sign}{grouped}")
+}
+
+/// Format one finite number for `format`/`prettyNum`: when `nsmall > 0`, render
+/// with **exactly** `nsmall` decimal places (so `format(3, nsmall = 2)` is
+/// `"3.00"` and `format(3.14159, nsmall = 2)` is `"3.14"`); when `nsmall == 0`,
+/// use R's default rendering (`format_number`). Then optionally group the
+/// integer part with `big.mark`. Non-finite / NA delegate to `format_number`.
+///
+/// (R's real `nsmall` is a *minimum* applied on top of `getOption("digits")`
+/// significant-digit rounding; this subset treats a supplied `nsmall` as the
+/// decimal count directly — simpler, fully deterministic, and matching the
+/// documented R-27 examples. The `scientific=`/significant-digit corner is
+/// deferred to R-28.)
+fn format_number_nsmall(x: f64, nsmall: usize, big_mark: &str) -> String {
+    if !x.is_finite() {
+        return format_number(x);
+    }
+    let rendered = if nsmall == 0 {
+        format_number(x)
+    } else {
+        format!("{x:.nsmall$}")
+    };
+    if big_mark.is_empty() {
+        return rendered;
+    }
+    // Group only the integer part; leave any fractional part untouched.
+    match rendered.split_once('.') {
+        Some((int, frac)) => format!("{}.{}", group_thousands(int, big_mark), frac),
+        None => group_thousands(&rendered, big_mark),
+    }
+}
+
+/// `format(x, nsmall=, width=, justify=, big.mark=)` — the general formatter.
+///
+/// * **Numeric `x`** — each element is rendered with `nsmall` decimal places and
+///   an optional `big.mark` thousands separator, then **the whole vector is
+///   padded to a common width**: R right-justifies every element to the width of
+///   the widest (so columns line up). `width` raises that common width to at
+///   least its value.
+/// * **Character `x`** — each element is padded to the common width (the max of
+///   `width` and the widest element) honouring `justify`: `"left"` (default),
+///   `"right"`, or `"centre"`.
+/// * **Logical `x`** — coerced to `"TRUE"`/`"FALSE"` strings, then treated as a
+///   character vector.
+///
+/// Returns a character vector the same length as `x` (length-0 in, length-0
+/// out). `NA` renders as the string `"NA"`.
+fn b_format(_interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
+    let x = first_positional(args)?;
+    let nsmall = named_count(args, "nsmall").unwrap_or(0);
+    let min_width = named_count(args, "width").unwrap_or(0);
+    let big_mark = named_str(args, "big.mark").unwrap_or_default();
+    let justify = named_str(args, "justify").unwrap_or_else(|| "left".to_string());
+
+    // Render each element to its natural string first; common-width padding is
+    // a second pass so we can measure the widest.
+    let is_numeric = matches!(peel_structural(x), SValue::Double(_) | SValue::Matrix { .. });
+    let rendered: Vec<String> = if is_numeric {
+        let d = x.as_double()?;
+        d.iter()
+            .map(|v| {
+                if is_na_real(v) {
+                    "NA".to_string()
+                } else {
+                    format_number_nsmall(v, nsmall, &big_mark)
+                }
+            })
+            .collect()
+    } else {
+        x.as_character()
+            .into_iter()
+            .map(|o| o.unwrap_or_else(|| "NA".to_string()))
+            .collect()
+    };
+    if rendered.is_empty() {
+        return Ok(SValue::Character(vec![]));
+    }
+
+    let widest = rendered.iter().map(|s| s.chars().count()).max().unwrap_or(0);
+    let target = widest.max(min_width).min(MAX_FIELD);
+
+    // Numeric vectors always right-justify (R lines decimals up on the right);
+    // character vectors honour `justify`.
+    let out: Vec<Option<String>> = rendered
+        .into_iter()
+        .map(|s| {
+            let padded = if is_numeric {
+                pad(&s, target, false, false)
+            } else {
+                pad_justify(&s, target, &justify)
+            };
+            Some(padded)
+        })
+        .collect();
+    Ok(SValue::Character(out))
+}
+
+/// Pad `body` to `width` columns honouring an R `justify` keyword. `"right"`
+/// pads on the left; `"centre"`/`"center"` splits the slack (extra on the
+/// right); anything else (including `"left"`) pads on the right.
+fn pad_justify(body: &str, width: usize, justify: &str) -> String {
+    let len = body.chars().count();
+    if len >= width {
+        return body.to_string();
+    }
+    let slack = width - len;
+    match justify {
+        "right" => format!("{}{}", " ".repeat(slack), body),
+        "centre" | "center" => {
+            let left = slack / 2;
+            let right = slack - left;
+            format!("{}{}{}", " ".repeat(left), body, " ".repeat(right))
+        }
+        _ => format!("{}{}", body, " ".repeat(slack)),
+    }
+}
+
+/// `formatC(x, format=, digits=, width=, flag=)` — the C-style formatter, a
+/// thin wrapper over the shared `printf` engine (`render_conversion` + `pad`).
+///
+/// * `format` — `"d"` integer, `"f"` fixed, `"e"` scientific, `"g"` shortest,
+///   `"s"` string, `"x"` hex (integers). Default: `"d"` for numerics, `"s"` for
+///   character `x`.
+/// * `digits` — precision passed to the conversion.
+/// * `width` — minimum field width (clamped to `MAX_FIELD`).
+/// * `flag` — a string of `printf` flags: `"-"` left-justify, `"0"` zero-pad,
+///   `"+"` force a leading sign on numbers.
+///
+/// Vectorized over `x`; returns a character vector of the same length.
+fn b_format_c(_interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
+    let x = first_positional(args)?;
+    let width = named_count(args, "width").unwrap_or(0);
+    let digits = named_count(args, "digits");
+    let flag = named_str(args, "flag").unwrap_or_default();
+    let left = flag.contains('-');
+    let zero = flag.contains('0');
+    let plus = flag.contains('+');
+
+    let is_char = matches!(
+        peel_structural(x),
+        SValue::Character(_) | SValue::Factor { .. }
+    );
+    let format =
+        named_str(args, "format").unwrap_or_else(|| if is_char { "s".into() } else { "d".into() });
+    let conv = format.chars().next().unwrap_or('s');
+
+    let n = x.length();
+    if n == 0 {
+        return Ok(SValue::Character(vec![]));
+    }
+    let chars = x.as_character();
+    let doubles = x.as_double().ok();
+
+    let mut out = Vec::with_capacity(n);
+    for i in 0..n {
+        // NA renders as the literal "NA" in every conversion.
+        let is_na = match &doubles {
+            Some(d) => d.get_value(i).map(is_na_real).unwrap_or(true),
+            None => chars.get(i).map(|o| o.is_none()).unwrap_or(true),
+        };
+        let body = if is_na && conv != 's' {
+            "NA".to_string()
+        } else {
+            format_c_one(conv, &doubles, &chars, i, digits)?
+        };
+        // A leading `+` forces a sign on non-negative numbers (the printf flag).
+        let signed = if plus && conv != 's' && !body.starts_with('-') && body != "NA" {
+            format!("+{body}")
+        } else {
+            body
+        };
+        out.push(Some(pad(&signed, width, left, zero && !left)));
+    }
+    Ok(SValue::Character(out))
+}
+
+/// Render one element for `formatC` under conversion `conv`. Reuses the
+/// `sprintf` engine for `d`/`f`/`e`/`g`/`s`; adds `x` (hex of an integer).
+fn format_c_one(
+    conv: char,
+    doubles: &Option<Double>,
+    chars: &[Option<String>],
+    i: usize,
+    digits: Option<usize>,
+) -> SResult<String> {
+    if conv == 'x' {
+        // Hex of the integer value; NA/non-finite → "NA".
+        let v = doubles.as_ref().and_then(|d| d.get_value(i));
+        return Ok(match v {
+            Some(x) if x.is_finite() => format!("{:x}", x as i64),
+            _ => "NA".to_string(),
+        });
+    }
+    if conv == 's' {
+        return Ok(chars
+            .get(i)
+            .cloned()
+            .flatten()
+            .unwrap_or_else(|| "NA".to_string()));
+    }
+    // d/f/e/g go through the shared sprintf conversion renderer. Wrap the
+    // element as a one-row SValue so `render_conversion`'s recycling indexes it.
+    let sval = match doubles {
+        Some(d) => SValue::Double(Double::from_values(vec![d.get_value(i).unwrap_or(f64::NAN)])),
+        None => SValue::Character(vec![chars.get(i).cloned().flatten()]),
+    };
+    render_conversion(conv, Some(&sval), 0, digits)
+}
+
+/// `prettyNum(x, big.mark = ",")` — insert a thousands separator into each
+/// number's integer part. A convenience wrapper: `prettyNum(x, big.mark = m)`
+/// is `format(x)` with grouping but no common-width padding and no `nsmall`.
+fn b_pretty_num(_interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
+    let x = first_positional(args)?;
+    let big_mark = named_str(args, "big.mark").unwrap_or_else(|| ",".to_string());
+    let out: Vec<Option<String>> = match peel_structural(x) {
+        SValue::Double(_) | SValue::Matrix { .. } => x
+            .as_double()?
+            .iter()
+            .map(|v| {
+                if is_na_real(v) {
+                    Some("NA".to_string())
+                } else {
+                    Some(format_number_nsmall(v, 0, &big_mark))
+                }
+            })
+            .collect(),
+        // Non-numeric prettyNum just coerces to character (matching R, which
+        // applies big.mark only to the numeric-looking integer part).
+        _ => x
+            .as_character()
+            .into_iter()
+            .map(|o| match o {
+                Some(s) => Some(group_thousands_if_numeric(&s, &big_mark)),
+                None => Some("NA".to_string()),
+            })
+            .collect(),
+    };
+    Ok(SValue::Character(out))
+}
+
+/// For a character `prettyNum`: if the whole string parses as a number, group
+/// it; otherwise pass it through unchanged.
+fn group_thousands_if_numeric(s: &str, mark: &str) -> String {
+    match s.split_once('.') {
+        Some((int, frac))
+            if int.parse::<i64>().is_ok() && frac.chars().all(|c| c.is_ascii_digit()) =>
+        {
+            format!("{}.{}", group_thousands(int, mark), frac)
+        }
+        None if s.parse::<i64>().is_ok() => group_thousands(s, mark),
+        _ => s.to_string(),
+    }
+}
+
+/// `toString(x, sep = ", ")` — collapse a whole vector into a **single** string,
+/// joining the character-coerced elements with `sep`. `toString(1:3)` is
+/// `"1, 2, 3"`. Always length-1 (an empty vector gives `""`).
+fn b_to_string(_interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
+    let x = first_positional(args)?;
+    let sep = named_str(args, "sep").unwrap_or_else(|| ", ".to_string());
+    let parts: Vec<String> = x
+        .as_character()
+        .into_iter()
+        .map(|o| o.unwrap_or_else(|| "NA".to_string()))
+        .collect();
+    Ok(SValue::Character(vec![Some(parts.join(&sep))]))
 }
 
 /// Combine the logical coercions of all positional arguments into one vector.

--- a/code/packages/rust/s-runtime/src/builtins.rs
+++ b/code/packages/rust/s-runtime/src/builtins.rs
@@ -2475,6 +2475,26 @@ fn substring(s: &str, start: i64, stop: i64) -> String {
 /// write-what-where primitive to worry about — only allocation size.
 const MAX_FIELD: usize = 1 << 20;
 
+/// Hard cap on the **total** padded output of a single `format`/`formatC` call
+/// (256 MiB). `MAX_FIELD` bounds each *element*, but a long vector formatted to
+/// a wide common field multiplies: `format(rep(0, 1e7), width = 1e6)` would be
+/// ~10 TB. This budget bounds the *product* (`common_width × element_count`) so
+/// no short expression can demand an unbounded allocation. Oversize is a clean
+/// `BadArgs` error, never an OOM abort.
+const MAX_TOTAL_OUTPUT: usize = 256 << 20;
+
+/// Reject a `format`/`formatC` request whose padded output (`per_element`
+/// columns × `count` elements) would exceed [`MAX_TOTAL_OUTPUT`]. Uses
+/// saturating arithmetic so the multiplication itself can never overflow.
+fn check_output_budget(per_element: usize, count: usize) -> SResult<()> {
+    if per_element.saturating_mul(count) > MAX_TOTAL_OUTPUT {
+        return Err(SError::BadArgs(
+            "format: total output size is too large".into(),
+        ));
+    }
+    Ok(())
+}
+
 /// `sprintf(fmt, ...)` — a minimal C-style formatter supporting `%d`/`%i`,
 /// `%s`, `%f`/`%e`/`%g`, and `%%`, with optional width, `.precision`, and the
 /// `-` (left-justify) and `0` (zero-pad) flags. Vectorized: the result has the
@@ -2803,6 +2823,8 @@ fn b_format(_interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
 
     let widest = rendered.iter().map(|s| s.chars().count()).max().unwrap_or(0);
     let target = widest.max(min_width).min(MAX_FIELD);
+    // Bound the *product* (common width × element count), not just each field.
+    check_output_budget(target, rendered.len())?;
 
     // Numeric vectors always right-justify (R lines decimals up on the right);
     // character vectors honour `justify`.
@@ -2873,6 +2895,10 @@ fn b_format_c(_interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
     if n == 0 {
         return Ok(SValue::Character(vec![]));
     }
+    // Bound the *product*: each element is at most `width` columns from padding
+    // plus roughly `digits` columns from a high-precision `%f`/`%e` body, so the
+    // per-element estimate is `max(width, digits)`. Reject before rendering.
+    check_output_budget(width.max(digits.unwrap_or(0)), n)?;
     let chars = x.as_character();
     let doubles = x.as_double().ok();
 
@@ -2938,6 +2964,10 @@ fn format_c_one(
 fn b_pretty_num(_interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
     let x = first_positional(args)?;
     let big_mark = named_str(args, "big.mark").unwrap_or_else(|| ",".to_string());
+    // Each number's integer part is ≤ ~309 digits, so a long `big.mark` grouped
+    // across a long vector can still amplify (~100 groups × mark.len × count).
+    // Bound the product the same way `format`/`formatC` do.
+    check_output_budget(big_mark.len().saturating_mul(110).max(1), x.length())?;
     let out: Vec<Option<String>> = match peel_structural(x) {
         SValue::Double(_) | SValue::Matrix { .. } => x
             .as_double()?

--- a/code/specs/R00-r-language.md
+++ b/code/specs/R00-r-language.md
@@ -836,7 +836,12 @@ unchanged.
     precision is capped at **`MAX_FIELD = 1 << 20`** (1 MiB) — the same cap the R-5
     `sprintf` already enforced — and `format`/`formatC`/`prettyNum` clamp their
     `width`/`nsmall`/`digits` to that bound (oversize is a clean `BadArgs` error, never a
-    panic or OOM). All field-width arithmetic uses `saturating_*`. There is no `%n`-style
+    panic or OOM). Because the per-field cap alone does **not** bound a *long vector ×
+    wide field* (e.g. `format(rep(0, 1e7), width = 1e6)` would be ≈ 10 TB), the
+    vectorized formatters additionally reject any request whose **product** — common
+    width × element count (or `big.mark` length × count for `prettyNum`) — exceeds
+    **`MAX_TOTAL_OUTPUT = 256 MiB`**, computed with `saturating_mul` so the check itself
+    cannot overflow. All field-width arithmetic uses `saturating_*`. There is no `%n`-style
     conversion (the engine only supports the value-rendering conversions above), so there
     is no write-what-where primitive. A `%`-spec with no matching argument renders from a
     `0`/`""` default rather than panicking; a wrong-typed argument coerces (numbers via

--- a/code/specs/R00-r-language.md
+++ b/code/specs/R00-r-language.md
@@ -786,6 +786,64 @@ unchanged.
     inheritance all reuse the existing chain-walk + lazy-method-rebuild machinery, so
     the change stayed contained.
 
+- **R-27 — output-formatting functions** *(this PR)*. A **pivot off the R5/OOP lane**
+  (R-24…R-26) into a fresh data/utility area: the string-formatting builtins R users
+  reach for when turning numbers and vectors into human-readable text. Everything is a
+  pure builtin in the shared `s-runtime` (R inherits via the tree-walker); **no grammar
+  change**. The watchword is **determinism**: no clock, no locale — the default
+  thousands separator is `","` and the decimal point is `"."`, fixed regardless of host
+  locale, and that choice is documented so the output never surprises a CI run in a
+  different locale. Five functions, all vectorized:
+  - **`format(x, nsmall=, width=, justify=, big.mark=)`** — the general-purpose
+    formatter. For a **numeric** vector: `nsmall` is the *minimum* number of decimal
+    places (so `format(3.14159, nsmall = 2)` is `"3.14"` but `format(3, nsmall = 2)` is
+    `"3.00"`); `big.mark` inserts a thousands separator into the integer part; then —
+    crucially — **a numeric vector formats to a *common* width**: R right-pads every
+    element to the width of the widest, so `format(c(1, 10, 100))` is
+    `c("  1", " 10", "100")`. For a **character** vector, `justify` (`"left"` /
+    `"right"` / `"centre"`, default `"left"`) controls padding within the field. `width`
+    is the *minimum* field width; the effective width is `max(width, widest element)`.
+    Returns a character vector the same length as `x`.
+  - **`formatC(x, format=, digits=, width=, flag=)`** — the C-style formatter, a thin
+    R-level wrapper over the same `printf` engine that powers `sprintf`. `format` is one
+    of `"d"` (integer), `"f"` (fixed), `"e"` (scientific), `"g"` (shortest), `"s"`
+    (string), or `"x"` (hex, integers only); `digits` is the precision; `width` the
+    minimum field width; `flag` a string of `printf` flags (`"-"` left-justify, `"0"`
+    zero-pad, `"+"` force a leading sign). `formatC(3.14159, format = "f", digits = 2)`
+    is `"3.14"`; `formatC(42, width = 6, flag = "0")` is `"000042"`. Vectorized over `x`.
+  - **`prettyNum(x, big.mark = ",")`** — insert a thousands separator into each number's
+    integer part. `prettyNum(1234567, big.mark = ",")` is `"1,234,567"`. Negative
+    numbers and decimal fractions are handled (the separator goes only in the integer
+    part, after any sign).
+  - **`toString(x, sep = ", ")`** — collapse a whole vector into a **single** string,
+    joining the (character-coerced) elements with `sep`. `toString(1:3)` is `"1, 2, 3"`;
+    `toString(c("a", "b"), sep = "; ")` is `"a; b"`. Length-1 result always.
+  - **Vectorized `sprintf(fmt, ...)`** — R-5 shipped a scalar-recycling `sprintf`; R-27
+    confirms and tests the **full vectorized recycling** contract: every `%`-conversion
+    pulls its argument from the matching positional, all arguments are recycled to the
+    longest length, and the result has that length. `sprintf("%d-%s", 1:2, c("a","b"))`
+    is `c("1-a", "2-b")`; `sprintf("%05.2f", 3.1)` is `"03.10"`. (The recycling was
+    already present in the R-5 implementation; R-27 adds the regression coverage and a
+    shared `printf` core that `formatC` reuses.)
+  - **Width-DoS cap (security).** A user `fmt` and the `width`/`nsmall`/`digits`
+    arguments are **data**, and a crafted spec like `%999999999d` or
+    `formatC(x, width = 1e9)` must not trigger a giant allocation. Every field width and
+    precision is capped at **`MAX_FIELD = 1 << 20`** (1 MiB) — the same cap the R-5
+    `sprintf` already enforced — and `format`/`formatC`/`prettyNum` clamp their
+    `width`/`nsmall`/`digits` to that bound (oversize is a clean `BadArgs` error, never a
+    panic or OOM). All field-width arithmetic uses `saturating_*`. There is no `%n`-style
+    conversion (the engine only supports the value-rendering conversions above), so there
+    is no write-what-where primitive. A `%`-spec with no matching argument renders from a
+    `0`/`""` default rather than panicking; a wrong-typed argument coerces (numbers via
+    `as.double`, strings via `as.character`) rather than erroring.
+  - **Scope outcome / deferred to R-28.** `format`, `prettyNum`, `toString`, and the
+    vectorized-`sprintf` regression ship **solidly**. `formatC` ships the common
+    `format`/`digits`/`width`/`flag` combinations (`"d"`/`"f"`/`"e"`/`"g"`/`"s"`/`"x"`).
+    Deferred to **R-28**: the exotic `formatC` corners — `format = "g"`'s exact
+    significant-digit/`%g` rounding edge cases, the `" "` and `"#"` flags, `mode=`/
+    `big.mark=` on `formatC`, and scientific-notation control on `format()` (`scientific=`)
+    — kept out to keep this PR a clean partial rather than a sprawling one.
+
 ## §4 Reuse strategy
 
 - **Lexer/parser:** the grammar-tools framework, exactly as S uses it. `r.tokens`
@@ -808,7 +866,10 @@ family; S4 and R6 OO (R5 reference classes land in **R-24**; single-`contains=`
 inheritance, `$copy()`, `is`/`inherits` over the class chain, and
 `$methods()`/`$fields()` introspection land in **R-25**, with `callSuper()`,
 active bindings, and multiple inheritance (`contains = c("A", "B")`) completing
-the R5 system in **R-26**); namespaces and `library()`
+the R5 system in **R-26**); the output-formatting family (`format`, `formatC`,
+`prettyNum`, `toString`, vectorized `sprintf`) lands in **R-27**, with the exotic
+`formatC` corners (`format = "g"` rounding edges, the `" "`/`"#"` flags,
+`scientific=`) deferred to **R-28**; namespaces and `library()`
 (so `baseenv()` aliases the
 global env for now); the C interface; graphics. These layer on later, following
 ST00.

--- a/code/specs/R00-r-language.md
+++ b/code/specs/R00-r-language.md
@@ -795,9 +795,14 @@ unchanged.
   locale, and that choice is documented so the output never surprises a CI run in a
   different locale. Five functions, all vectorized:
   - **`format(x, nsmall=, width=, justify=, big.mark=)`** — the general-purpose
-    formatter. For a **numeric** vector: `nsmall` is the *minimum* number of decimal
-    places (so `format(3.14159, nsmall = 2)` is `"3.14"` but `format(3, nsmall = 2)` is
-    `"3.00"`); `big.mark` inserts a thousands separator into the integer part; then —
+    formatter. For a **numeric** vector: a supplied `nsmall` is the **decimal count** —
+    it pads short values *and* rounds long ones to exactly that many places (so
+    `format(3.14159, nsmall = 2)` is `"3.14"` and `format(3, nsmall = 2)` is `"3.00"`),
+    while `nsmall = 0` (the default) uses R's default rendering untouched. (Real R's
+    `nsmall` is a *minimum* layered on top of significant-digit rounding; this subset
+    uses the simpler, fully deterministic decimal-count reading and defers the
+    `scientific=`/sig-digit corner to R-28.) `big.mark` inserts a thousands separator
+    into the integer part; then —
     crucially — **a numeric vector formats to a *common* width**: R right-pads every
     element to the width of the widest, so `format(c(1, 10, 100))` is
     `c("  1", " 10", "100")`. For a **character** vector, `justify` (`"left"` /


### PR DESCRIPTION
## R-27 — output-formatting functions

A pivot off the R5/OOP lane (R-24…R-26) into a fresh data/utility area: the string-formatting builtins R users reach for when turning numbers and vectors into human-readable text. All are **pure builtins in the shared `s-runtime`** (R inherits them via the tree-walker) — **no grammar change**. Output is **deterministic and locale-free** (fixed `","` thousands separator, `"."` decimal point) so a CI run in any locale produces identical bytes.

### Shipped solidly
- **`format(x, nsmall=, width=, justify=, big.mark=)`** — numeric vectors format to a **common width** (R right-justifies every element to the widest, so columns line up: `format(c(1, 10, 100))` → `c("  1", " 10", "100")`); character vectors pad to `max(width, widest)` honouring `justify` (`"left"`/`"right"`/`"centre"`). `nsmall` is the decimal count (`format(3, nsmall = 2)` → `"3.00"`); `big.mark` groups thousands.
- **`prettyNum(x, big.mark = ",")`** — thousands separator (sign preserved, not grouped).
- **`toString(x, sep = ", ")`** — collapse a vector to one string.
- **Vectorized `sprintf`** — confirmed full recycling (`sprintf("%d-%s", 1:2, c("a","b"))` → `c("1-a","2-b")`, `sprintf("%05.2f", 3.1)` → `"03.10"`); already vectorized since R-5, now with regression coverage and a shared `printf` core that `formatC` reuses.

### `formatC` — common combinations
- **`formatC(x, format=, digits=, width=, flag=)`** — `format` one of `"d"`/`"f"`/`"e"`/`"g"`/`"s"`/`"x"`, flags `"-"` (left), `"0"` (zero-pad), `"+"` (force sign). `formatC(3.14159, format="f", digits=2)` → `"3.14"`, `formatC(42, width=6, flag="0")` → `"000042"`, `formatC(255, format="x")` → `"ff"`.

### Deferred to R-28
Exotic `formatC` corners — `format="g"` exact-rounding edge cases, the `" "`/`"#"` flags, and `format()`'s `scientific=`. Clean partial over a sprawling PR.

## Security — width/allocation DoS hardening
A user `fmt` and the `width`/`nsmall`/`digits`/`big.mark` arguments are **data**.
- **Per-field cap.** Every field width and precision is capped at **`MAX_FIELD = 1 MiB`** (the cap R-5's `sprintf` already enforced, now hoisted to module scope and shared by `format`/`formatC`). A crafted `%999999999d` or `width = 1e9` is clamped; an oversize literal `sprintf` width is a clean error. All width math uses `saturating_*`. No `%n`-style conversion exists, so there is no write-what-where primitive.
- **Total-output cap (added after security review).** The per-field cap does not bound a *long vector × wide field* (`format(rep(0, 1e7), width = 1e6)` ≈ 10 TB), so `format`/`formatC`/`prettyNum` additionally reject any request whose **product** (common width × element count) exceeds **`MAX_TOTAL_OUTPUT = 256 MiB`**, computed with `saturating_mul`. Oversize is a clean `BadArgs` error, never an OOM.

A security sub-agent (senior Rust security engineer) reviewed the full diff and returned **PASS** — no memory-safety, panic, or write primitives; the multiplicative-DoS finding was fixed and re-verified. One pre-existing, out-of-scope note (vectorized `sprintf` itself lacks the total-output product cap) is tracked as a follow-up, not a regression.

## Tests
13 new R-syntax tests in `r-runtime` covering every function plus both DoS caps and a `sprintf` scalar regression. Full suite: **215 r-runtime + 202 s-runtime tests pass**; `cargo clippy` clean on both crates. Diff is functional-only (no crate-wide rustfmt churn).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
