### PR TITLE
feat(closurec): strip `debugger` at SIMPLE/ADVANCED (CLOC24)

### DIFF
--- a/code/packages/rust/closure-pass-dce/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-dce/CHANGELOG.md
@@ -2,6 +2,33 @@
 
 All notable changes to the `coding-adventures-closure-pass-dce` crate will be documented in this file.
 
+## [0.15.0] - 2026-06-20
+
+### Added — CLOC24: strip `debugger` statements at SIMPLE/ADVANCED
+
+The pass now removes `debugger;` statements from statement lists, matching the
+upstream Closure Compiler. A `debugger` statement is a development-only
+breakpoint: it pauses execution only when a debugger is attached and is a no-op
+otherwise, so removing it from a shipped program is semantics-preserving. Two
+sweeps cover the two list contexts:
+
+- **block bodies** — `dce_block_statement` retains out `debugger` statements
+  alongside the existing empty-statement sweep (`{ x; debugger; y; }` →
+  `{ x; y; }`; a block of only `debugger`s collapses to `{}`);
+- **program top level** — `dce_program` sweeps `debugger` from the program body
+  (which is a list of `ProgramItem`s, not a `BlockStatement`).
+
+Because the dce pass runs only inside the typed (SIMPLE/ADVANCED) pipeline,
+`debugger` is preserved at WHITESPACE_ONLY — exactly the upstream behaviour. A
+new `removed-debugger` contribution is recorded per sweep (and flips `changed`).
+
+**Documented limitation:** a `debugger` reaching a *non-list* position (e.g. a
+brace-less `if (c) debugger;` consequent) is left intact — the sweep is
+list-scoped, consistent with how the empty-statement sweep already works.
+
+- 4 new tests: block strip, top-level strip, all-`debugger` block → empty, and
+  the preserved brace-less-consequent limitation.
+
 ## [0.14.0] - 2026-06-20
 
 ### Added — CLOC23: DCE inside `for`-`of`

--- a/code/packages/rust/closure-pass-dce/Cargo.toml
+++ b/code/packages/rust/closure-pass-dce/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-dce"
-version = "0.14.0"
+version = "0.15.0"
 edition = "2021"
 description = "Dead-code elimination pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Drops code after definite-terminator statements and removes EmptyStatement noise."
 

--- a/code/packages/rust/closure-pass-dce/src/lib.rs
+++ b/code/packages/rust/closure-pass-dce/src/lib.rs
@@ -212,11 +212,32 @@ fn is_pure_leaf(expr: &Expression) -> bool {
 
 fn dce_program(prog: &Program, st: &mut DceState) -> Program {
     st.visit();
-    let new_body = prog
+    let mut new_body: Vec<ProgramItem> = prog
         .body
         .iter()
         .map(|item| dce_program_item(item, st))
         .collect();
+
+    // Strip top-level `debugger;` statements (CLOC24).
+    //
+    // The program body is a list of `ProgramItem`s, not a `BlockStatement`,
+    // so it needs its own sweep separate from `dce_block_statement`'s. Same
+    // rationale: a `debugger` statement is a development-only breakpoint with
+    // no effect on a shipped program, so at SIMPLE/ADVANCED we remove it — and
+    // because this pass never runs at WHITESPACE_ONLY, `debugger` survives
+    // there, matching upstream Closure exactly. See `is_debugger_statement`.
+    let before_debugger_drop = new_body.len();
+    new_body.retain(|item| !is_debugger_program_item(item));
+    let dropped_debuggers = before_debugger_drop - new_body.len();
+    if dropped_debuggers > 0 {
+        st.record(
+            &prog.cv,
+            "removed-debugger",
+            &format!("program with {} top-level items", before_debugger_drop),
+            &format!("dropped {} top-level debugger statements", dropped_debuggers),
+        );
+    }
+
     Program {
         cv: prog.cv.clone(),
         version: prog.version,
@@ -543,8 +564,14 @@ fn dce_tagged_statement(stmt: &TaggedStatement, st: &mut DceState) -> TaggedStat
         TaggedStatement::BreakStatement(_)
         | TaggedStatement::ContinueStatement(_)
         | TaggedStatement::EmptyStatement(_)
-        // A `debugger;` statement is a childless leaf with no bindings — like
-        // EmptyStatement, DCE preserves it as-is. (Stripping it is future work.)
+        // A `debugger;` reaching HERE is a non-list child (e.g. a brace-less
+        // `if (c) debugger;` consequent), so it is preserved as-is. The
+        // CLOC24 strip operates on statement *lists* — the block-body sweep in
+        // `dce_block_statement` and the top-level sweep in `dce_program` —
+        // where a `debugger` can be removed without leaving a dangling
+        // single-statement slot. (A bare consequent could be stripped too, but
+        // that is a rarer shape left for future work, consistent with how the
+        // empty-statement sweep is also list-scoped.)
         | TaggedStatement::DebuggerStatement(_) => stmt.clone(),
     }
 }
@@ -661,6 +688,29 @@ fn dce_block_statement(b: &BlockStatement, st: &mut DceState) -> BlockStatement 
             "removed-empty-statement",
             &format!("block with {} statements", before_empty_drop),
             &format!("dropped {} empty statements", dropped_empties),
+        );
+    }
+
+    // Strip `debugger;` statements (CLOC24).
+    //
+    // A `debugger` statement is a development-only breakpoint: it pauses
+    // execution ONLY when a debugger is attached and is a no-op otherwise, so
+    // removing it from a shipped program preserves the program's observable
+    // behaviour. At SIMPLE/ADVANCED upstream Closure strips it; we do the same
+    // here (and only here — this pass never runs at WHITESPACE_ONLY, where the
+    // statement is preserved). We sweep it from the statement list exactly like
+    // empty statements; a `debugger` reaching a non-list position (e.g. a
+    // brace-less `if (c) debugger;` consequent) is left intact — see
+    // `dce_tagged_statement`'s leaf arm.
+    let before_debugger_drop = working.len();
+    working.retain(|s| !is_debugger_statement(s));
+    let dropped_debuggers = before_debugger_drop - working.len();
+    if dropped_debuggers > 0 {
+        st.record(
+            &b.cv,
+            "removed-debugger",
+            &format!("block with {} statements", before_debugger_drop),
+            &format!("dropped {} debugger statements", dropped_debuggers),
         );
     }
 
@@ -901,6 +951,27 @@ fn is_empty_statement(stmt: &Statement) -> bool {
     )
 }
 
+/// Is this a `debugger;` statement?
+///
+/// Used by the block-body and top-level sweeps (CLOC24) to strip `debugger`
+/// statements at SIMPLE/ADVANCED — a development-only breakpoint with no effect
+/// on a shipped program, so removing it is a sound size win (this matches
+/// upstream Closure). Because the dce pass runs only inside the typed pipeline,
+/// `debugger` is preserved at WHITESPACE_ONLY, which never reaches here.
+fn is_debugger_statement(stmt: &Statement) -> bool {
+    matches!(
+        stmt,
+        Statement::Tagged(TaggedStatement::DebuggerStatement(_))
+    )
+}
+
+/// Is this top-level program item a `debugger;` statement? The program body is
+/// a list of `ProgramItem`s rather than `Statement`s, so the top-level sweep in
+/// `dce_program` needs this thin wrapper over [`is_debugger_statement`].
+fn is_debugger_program_item(item: &ProgramItem) -> bool {
+    matches!(item, ProgramItem::Statement(s) if is_debugger_statement(s))
+}
+
 // =====================================================================
 // Declarations
 // =====================================================================
@@ -1091,6 +1162,11 @@ mod tests {
     }
     fn empty_stmt() -> Statement {
         Statement::empty_statement(EmptyStatement { cv: None })
+    }
+    fn debugger_stmt() -> Statement {
+        Statement::debugger_statement(
+            coding_adventures_javascript_ast::DebuggerStatement { cv: None },
+        )
     }
     /// `let <name>;` as a block statement — a non-hoisted (block-scoped)
     /// declaration, which the truncation whitelist treats as safe to drop.
@@ -1378,6 +1454,104 @@ mod tests {
         );
         let new_block = extract_function_body(&out);
         assert_eq!(new_block.body.len(), 2, "expected 2 statements; got {:?}", new_block.body);
+    }
+
+    // --- CLOC24: `debugger` stripping -----------------------------------
+
+    #[test]
+    fn strips_debugger_statement_from_block() {
+        // { x; debugger; y; } → { x; y; }
+        let body = vec![
+            expr_stmt(ident("x")),
+            debugger_stmt(),
+            expr_stmt(ident("y")),
+        ];
+        let prog = program_with_function(body, Some("block.1"));
+        let (out, contribs, changed, _) = run_pass(prog);
+        assert!(changed, "stripping a debugger must mark the program changed");
+        assert!(
+            contribs.iter().any(|c| c.tag == "removed-debugger"),
+            "expected a removed-debugger contribution; got {:?}",
+            contribs
+        );
+        let new_block = extract_function_body(&out);
+        assert_eq!(
+            new_block.body.len(),
+            2,
+            "the debugger should be gone, leaving x; y;; got {:?}",
+            new_block.body
+        );
+        assert!(
+            !new_block.body.iter().any(is_debugger_statement),
+            "no debugger statement should remain; got {:?}",
+            new_block.body
+        );
+    }
+
+    #[test]
+    fn strips_top_level_debugger_statement() {
+        // top-level: x; debugger; → x;
+        let prog = program().with_body(vec![
+            ProgramItem::Statement(expr_stmt(ident("x"))),
+            ProgramItem::Statement(debugger_stmt()),
+        ]);
+        let (out, contribs, changed, _) = run_pass(prog);
+        assert!(changed, "stripping a top-level debugger must mark changed");
+        assert!(
+            contribs.iter().any(|c| c.tag == "removed-debugger"),
+            "expected a removed-debugger contribution; got {:?}",
+            contribs
+        );
+        assert_eq!(
+            out.body.len(),
+            1,
+            "only the top-level debugger should be removed; got {:?}",
+            out.body
+        );
+        assert!(
+            !out.body.iter().any(is_debugger_program_item),
+            "no top-level debugger should remain; got {:?}",
+            out.body
+        );
+    }
+
+    #[test]
+    fn block_of_only_debuggers_becomes_empty() {
+        // { debugger; debugger; } → { }
+        let body = vec![debugger_stmt(), debugger_stmt()];
+        let prog = program_with_function(body, Some("block.1"));
+        let (out, _contribs, changed, _) = run_pass(prog);
+        assert!(changed);
+        let new_block = extract_function_body(&out);
+        assert!(
+            new_block.body.is_empty(),
+            "both debuggers should be gone, leaving an empty block; got {:?}",
+            new_block.body
+        );
+    }
+
+    #[test]
+    fn preserves_braceless_if_consequent_debugger() {
+        // `if (x) debugger;` — the debugger is the consequent, NOT in a
+        // statement list, so the list-scoped sweep leaves it intact. This pins
+        // the documented limitation (see `dce_tagged_statement`'s leaf arm).
+        let body = vec![if_stmt(ident("x"), debugger_stmt())];
+        let prog = program_with_function(body, Some("block.1"));
+        let (out, contribs, _changed, _) = run_pass(prog);
+        assert!(
+            !contribs.iter().any(|c| c.tag == "removed-debugger"),
+            "a brace-less consequent debugger must NOT be swept; got {:?}",
+            contribs
+        );
+        let new_block = extract_function_body(&out);
+        let Statement::Tagged(TaggedStatement::IfStatement(if_s)) = &new_block.body[0] else {
+            panic!("expected the if statement to survive; got {:?}", new_block.body);
+        };
+        assert!(
+            is_debugger_statement(&if_s.consequent),
+            "the consequent debugger should be preserved; got {:?}",
+            if_s.consequent
+        );
     }
 
     #[test]

--- a/code/packages/rust/javascript-ast/CHANGELOG.md
+++ b/code/packages/rust/javascript-ast/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to the `coding-adventures-javascript-ast` crate will be documented in this file.
 
+## [0.13.0] - 2026-06-20
+
+### Changed — CLOC24: `DebuggerStatement` doc reflects stripping
+
+Doc-comment-only change: the `DebuggerStatement` node doc no longer says
+"stripping it … is a future enhancement". `closure-pass-dce` now strips
+`debugger` statements at SIMPLE/ADVANCED (CLOC24), so the comment is updated to
+describe the live behaviour. No structural or behavioural change to the node.
+
 ## [0.12.0] - 2026-06-20
 
 ### Added — CLOC23: `ForOfStatement` (`for (left of right) body`)

--- a/code/packages/rust/javascript-ast/Cargo.toml
+++ b/code/packages/rust/javascript-ast/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-javascript-ast"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 description = "Backend-agnostic JavaScript AST — full ESTree-compatible node taxonomy with optional per-node CV id. Reusable by the Closure-Compiler-clone and the future V8-in-Rust clone. Per CLOC02 / CLOC09."
 

--- a/code/packages/rust/javascript-ast/src/statement.rs
+++ b/code/packages/rust/javascript-ast/src/statement.rs
@@ -469,9 +469,10 @@ pub struct EmptyStatement {
 /// is attached and is otherwise a no-op. Like [`EmptyStatement`] it carries no
 /// children. Making it representable lets the typed pipeline optimize the rest
 /// of a program that contains a `debugger` statement (previously any such
-/// program fell back to WHITESPACE_ONLY). v1 preserves the statement verbatim;
-/// stripping it (as the upstream Closure Compiler does at SIMPLE/ADVANCED) is a
-/// future enhancement.
+/// program fell back to WHITESPACE_ONLY). The node itself just preserves the
+/// statement; the `closure-pass-dce` pass strips `debugger` statements from
+/// statement lists at SIMPLE/ADVANCED (CLOC24, matching the upstream Closure
+/// Compiler), while WHITESPACE_ONLY — which never runs that pass — keeps it.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct DebuggerStatement {

--- a/code/programs/rust/closurec/CHANGELOG.md
+++ b/code/programs/rust/closurec/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 All notable changes to the `coding-adventures-closurec` binary will be documented in this file.
 
+## [0.157.0] - 2026-06-20
+
+### Changed — CLOC24: strip `debugger` statements at SIMPLE/ADVANCED
+
+`debugger;` statements are now **removed** at `--compilation_level SIMPLE` and
+`ADVANCED`, matching the upstream Closure Compiler. A `debugger` statement is a
+development-only breakpoint with no effect on a shipped program, so stripping it
+is a sound size win. The strip lives in the `closure-pass-dce` pass (block-body
+and top-level sweeps), which runs only in the typed pipeline — so `debugger` is
+still preserved at `WHITESPACE_ONLY`.
+
+The `simple-debugger` end-to-end fixture (introduced in CLOC21 to prove
+`debugger` was *representable*) is repurposed as the strip oracle: its expected
+output drops from `report(1);var x=3;debugger;use(x);` to
+`report(1);var x=3;use(x);`, and the whitespace-fallback regression guard now
+asserts the `debugger` is **absent** (its absence doubly confirms the typed
+pipeline ran, since a WHITESPACE_ONLY fallback would have kept it).
+
+Depends on `coding-adventures-closure-pass-dce` 0.15.0 and
+`coding-adventures-javascript-ast` 0.13.0 (doc sync).
+
 ## [0.156.0] - 2026-06-20
 
 ### Added — CLOC23: end-to-end `for`-`of` support

--- a/code/programs/rust/closurec/Cargo.toml
+++ b/code/programs/rust/closurec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closurec"
-version = "0.156.0"
+version = "0.157.0"
 edition = "2021"
 description = "closurec — CLI driver for the Closure Compiler clone. Mirrors the upstream Java Closure Compiler's command-line flag surface (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility. Per CLOC08."
 

--- a/code/programs/rust/closurec/cli.spec.json
+++ b/code/programs/rust/closurec/cli.spec.json
@@ -2,7 +2,7 @@
   "cli_builder_spec_version": "1.0",
   "name": "closurec",
   "description": "closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.",
-  "version": "0.156.0",
+  "version": "0.157.0",
   "parsing_mode": "gnu",
   "flags": [
     { "id": "browser_featureset_year", "long": "browser_featureset_year", "type": "integer", "default": 0, "description": "Shortcut for defining goog.FEATURESET_YEAR=YYYY (minimum 2012)." },

--- a/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
@@ -2,7 +2,7 @@
 
 closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.
 
-Version: 0.156.0
+Version: 0.157.0
 
 ## Flags
 

--- a/code/programs/rust/closurec/tests/diff/simple-debugger/README.md
+++ b/code/programs/rust/closurec/tests/diff/simple-debugger/README.md
@@ -1,7 +1,7 @@
 # Fixture: `simple-debugger`
 
 End-to-end oracle for `--compilation_level SIMPLE` across a `debugger;`
-statement (CLOC21).
+statement: CLOC21 made it representable, **CLOC24 strips it**.
 
 | File | Role |
 |------|------|
@@ -10,7 +10,7 @@ statement (CLOC21).
 | `expected.stdout` | The optimized output (see below) |
 
 ```text
-report(1);var x=3;debugger;use(x);
+report(1);var x=3;use(x);
 ```
 
 What this proves — none of which was reachable before CLOC21 (any `debugger`
@@ -19,9 +19,10 @@ forced a WHITESPACE_ONLY fallback):
 * **Inlining** — `log` is single-use, so `log(1)` becomes `report(1)` and
   the declaration is deleted.
 * **Constant folding** — `1 + 2` ⇒ `3`.
-* **`debugger;` preserved** — v1 makes the statement representable so the rest
-  of the program is optimized; the `debugger` survives verbatim. (Stripping it,
-  as the upstream Closure Compiler does at SIMPLE/ADVANCED, is future work.)
+* **`debugger;` stripped** — CLOC24 removes the `debugger` statement at
+  SIMPLE/ADVANCED, exactly as the upstream Closure Compiler does: a
+  development-only breakpoint has no effect on a shipped program. (At
+  WHITESPACE_ONLY, which runs no optimization passes, the `debugger` is kept.)
 
 Regenerate the expected file after an intentional behavior change:
 

--- a/code/programs/rust/closurec/tests/diff/simple-debugger/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/simple-debugger/expected.stdout
@@ -1,1 +1,1 @@
-report(1);var x=3;debugger;use(x);
+report(1);var x=3;use(x);

--- a/code/programs/rust/closurec/tests/diff/simple-debugger/input/a.js
+++ b/code/programs/rust/closurec/tests/diff/simple-debugger/input/a.js
@@ -1,17 +1,18 @@
-// SIMPLE-level optimization of a program containing `debugger;` (CLOC21).
+// SIMPLE-level optimization of a program containing `debugger;` (CLOC21 made
+// it representable; CLOC24 strips it).
 //
 // Before CLOC21, *any* program containing a `debugger` statement failed the
 // typed-AST parse (DebuggerStatement was unrepresentable) and closurec
-// silently fell back to WHITESPACE_ONLY — zero optimization. This fixture is
-// the end-to-end oracle proving the SIMPLE pipeline now runs across a
-// `debugger` statement, optimizing the rest of the program while preserving
-// the statement verbatim:
+// silently fell back to WHITESPACE_ONLY — zero optimization. CLOC21 made the
+// statement representable; CLOC24 now STRIPS it at SIMPLE/ADVANCED, matching
+// the upstream Closure Compiler. This fixture is the end-to-end oracle:
 //
 //   * `log` is single-use, so the inliner folds `log(1)` into its body
 //     `report(1)` and deletes the now-unused declaration.
 //   * `1 + 2` is constant-folded to `3`.
-//   * `debugger;` survives verbatim — v1 preserves it (stripping it, as the
-//     upstream Closure Compiler does, is future work).
+//   * `debugger;` is REMOVED — a development-only breakpoint has no effect on
+//     a shipped program, so the dce pass strips it at SIMPLE/ADVANCED.
+//     (WHITESPACE_ONLY, which never runs that pass, would keep it.)
 function log(p) {
   report(p);
 }

--- a/code/programs/rust/closurec/tests/diff_simple_debugger.rs
+++ b/code/programs/rust/closurec/tests/diff_simple_debugger.rs
@@ -1,12 +1,12 @@
 //! Integration test for the `tests/diff/simple-debugger/` fixture.
 //!
 //! Exercises `--compilation_level SIMPLE` across a `debugger;` statement
-//! (CLOC21). Before CLOC21, any program containing a `debugger` statement
-//! failed the typed-AST parse and closurec fell back to WHITESPACE_ONLY
-//! (zero optimization). This fixture is the end-to-end oracle proving the
-//! SIMPLE pipeline now runs across a `debugger` statement: `log(1)` is
-//! inlined to `report(1)`, `1 + 2` folds to `3`, and the `debugger;`
-//! statement is preserved verbatim.
+//! (CLOC21 made it representable; CLOC24 strips it). Before CLOC21, any
+//! program containing a `debugger` statement failed the typed-AST parse and
+//! closurec fell back to WHITESPACE_ONLY (zero optimization). This fixture is
+//! the end-to-end oracle proving the SIMPLE pipeline runs across a `debugger`
+//! statement: `log(1)` is inlined to `report(1)`, `1 + 2` folds to `3`, and
+//! the `debugger;` statement is STRIPPED (matching upstream Closure).
 
 use std::process::Command;
 
@@ -51,8 +51,10 @@ fn simple_debugger_fixture_matches_expected_stdout() {
 /// above would still "pass" against a regenerated expected file, so we
 /// additionally assert that an optimization that can ONLY come from the typed
 /// pipeline (the `log` -> `report` inline) is present and the original
-/// `function log` declaration is gone, while the `debugger;` statement
-/// survives verbatim.
+/// `function log` declaration is gone. CLOC24 additionally STRIPS the
+/// `debugger;` statement at SIMPLE — proving the dce pass removed it (a
+/// WHITESPACE_ONLY fallback would have kept `debugger;` verbatim, so its
+/// absence here doubly confirms the typed pipeline ran).
 #[test]
 fn simple_debugger_did_not_fall_back_to_whitespace_only() {
     let out = Command::new(BINARY)
@@ -72,7 +74,8 @@ fn simple_debugger_did_not_fall_back_to_whitespace_only() {
         "expected the inlined `log` declaration to be removed; got:\n{actual}",
     );
     assert!(
-        actual.contains("debugger;"),
-        "expected the `debugger;` statement to be preserved; got:\n{actual}",
+        !actual.contains("debugger"),
+        "expected the `debugger;` statement to be STRIPPED at SIMPLE (CLOC24); \
+         got:\n{actual}",
     );
 }

--- a/code/specs/CLOC24-strip-debugger.md
+++ b/code/specs/CLOC24-strip-debugger.md
@@ -1,0 +1,101 @@
+# CLOC24 — strip `debugger` at SIMPLE/ADVANCED
+
+> **Status:** Shipped. The `closure-pass-dce` pass removes `debugger;`
+> statements from statement lists at the SIMPLE and ADVANCED compilation
+> levels, matching the upstream Closure Compiler. The `simple-debugger`
+> end-to-end fixture (CLOC21) is repurposed as the strip oracle.
+
+## Why this spec exists
+
+CLOC21 made `debugger` *representable* in the typed AST so a program containing
+one would route through the optimization pipeline instead of degrading to
+`WHITESPACE_ONLY`. But CLOC21 deliberately deferred actually *removing* the
+statement — it survived verbatim. The upstream Closure Compiler **strips**
+`debugger` statements at its optimization levels, because a `debugger` is a
+development-only breakpoint: it pauses execution only when a debugger is
+attached and is a no-op otherwise. Removing it from a shipped program is
+therefore semantics-preserving, and it is a (small) size win. CLOC24 closes
+that gap.
+
+## Where the strip lives
+
+In **`closure-pass-dce`**, not a new pass. Dead-code elimination already owns
+"remove statements that don't contribute to the program's observable
+behaviour" (empty statements, dead-after-terminator tails). A `debugger`
+statement is the same shape of removable noise, so it belongs here.
+
+Crucially, the dce pass runs **only inside the typed (SIMPLE/ADVANCED)
+pipeline**. `WHITESPACE_ONLY` does token-stripping only and never constructs a
+typed AST, so it never runs dce. Putting the strip in dce therefore gives the
+exact upstream contract **for free**:
+
+| Level            | `debugger;` |
+|------------------|-------------|
+| `WHITESPACE_ONLY`| preserved   |
+| `SIMPLE`         | stripped    |
+| `ADVANCED`       | stripped    |
+
+## What it does
+
+Two sweeps, one per statement-list context:
+
+1. **Block bodies** (`dce_block_statement`) — after the existing
+   empty-statement sweep, `working.retain(|s| !is_debugger_statement(s))`.
+   - `{ x; debugger; y; }` → `{ x; y; }`
+   - `{ debugger; debugger; }` → `{}`
+2. **Program top level** (`dce_program`) — the program body is a `Vec<ProgramItem>`,
+   not a `BlockStatement`, so it needs its own sweep:
+   `new_body.retain(|item| !is_debugger_program_item(item))`.
+
+Each sweep records a `removed-debugger` contribution (which flips the pass's
+`changed` flag) when it drops at least one statement.
+
+## Soundness
+
+Removing a `debugger` statement changes observable behaviour **only** under an
+attached debugger — exactly the development-time artifact upstream Closure
+strips intentionally. For a shipped program the transform is a no-op on output,
+so it is unconditionally safe at optimization levels. (Unlike dead-code-tail
+truncation, there is no hoisting concern: a `debugger` binds nothing.)
+
+## Documented limitation
+
+The sweep is **list-scoped**: it removes a `debugger` that appears directly in a
+block body or the program body. A `debugger` reaching a *non-list* position —
+e.g. a brace-less `if (c) debugger;` consequent — is preserved, because removing
+it would leave a dangling single-statement slot that would have to be rewritten
+to `;`/`{}`. This mirrors how the empty-statement sweep is also list-scoped, and
+the bare-consequent shape is rare. Handling it (rewriting the slot to an empty
+statement) is future work.
+
+## End-to-end oracle
+
+The CLOC21 **`simple-debugger`** fixture is repurposed. Input:
+
+```js
+function log(p) { report(p); }
+log(1);
+var x = 1 + 2;
+debugger;
+use(x);
+```
+
+At SIMPLE: `log` inlines (`log(1)` → `report(1)`, declaration deleted), `1 + 2`
+folds to `3`, and the top-level `debugger;` is **stripped**:
+
+```text
+report(1);var x=3;use(x);
+```
+
+The whitespace-fallback regression guard now asserts `debugger` is **absent**:
+a `WHITESPACE_ONLY` fallback would have preserved it, so its absence is a second
+independent proof that the typed pipeline ran.
+
+## Relationship to the Phase-2 statement campaign
+
+CLOC20–23 made the four common bridge-unsupported statements (`do`/`while`,
+`debugger`, `for`-`in`, `for`-`of`) representable so programs using them get
+optimized instead of degrading. CLOC24 is the first *real optimization* built on
+top of that representability work — turning `debugger` from "preserved so the
+rest optimizes" into "actually removed, like upstream". It was the explicit
+follow-up deferred from CLOC21.


### PR DESCRIPTION
## Summary

The dead-code-elimination pass now **strips `debugger;` statements** at the SIMPLE and ADVANCED compilation levels, matching the upstream Closure Compiler. A `debugger` statement is a development-only breakpoint — it pauses execution only when a debugger is attached and is a no-op otherwise — so removing it from a shipped program is semantics-preserving and a (small) size win.

This is the **real optimization deferred from CLOC21** (which only made `debugger` *representable* so the rest of a program would optimize instead of degrading to `WHITESPACE_ONLY`). It builds directly on the now-complete Phase-2 statement campaign (do-while, debugger, for-in, for-of).

## What changed

**`closure-pass-dce` (0.14.0 → 0.15.0)** — the strip lives here, not a new pass: DCE already owns "remove statements that don't affect observable behaviour". Two list-scoped sweeps:
- `dce_block_statement` sweeps `debugger` from block bodies (alongside the existing empty-statement sweep): `{ x; debugger; y; }` → `{ x; y; }`; `{ debugger; debugger; }` → `{}`.
- `dce_program` sweeps top-level `debugger` from the program body (a `Vec<ProgramItem>`, so it needs its own sweep).
- New `is_debugger_statement` / `is_debugger_program_item` helpers; a `removed-debugger` Contribution per sweep (flips `changed`).

**Why this gives the upstream contract for free:** the dce pass runs **only** inside the typed (SIMPLE/ADVANCED) pipeline. `WHITESPACE_ONLY` never builds a typed AST, so `debugger` is preserved there:

| Level | `debugger;` |
|-------|-------------|
| `WHITESPACE_ONLY` | preserved |
| `SIMPLE` | stripped |
| `ADVANCED` | stripped |

**Documented limitation:** a `debugger` in a *non-list* position (e.g. a brace-less `if (c) debugger;` consequent) is preserved — the sweep is list-scoped, consistent with how the empty-statement sweep already works. Preserving it is always safe (it stays a no-op).

**`javascript-ast` (0.12.0 → 0.13.0):** doc-comment-only sync on the `DebuggerStatement` node (it no longer calls stripping "future work").

**`closurec` (0.156.0 → 0.157.0):** the CLOC21 `simple-debugger` end-to-end fixture is repurposed as the strip oracle — expected output drops from `report(1);var x=3;debugger;use(x);` to `report(1);var x=3;use(x);`, and the whitespace-fallback regression guard now asserts `debugger` is **absent** (its absence doubly confirms the typed pipeline ran). Help-markdown fixture regenerated for the version bump.

**Spec:** `code/specs/CLOC24-strip-debugger.md`.

## Testing
- 50 `closure-pass-dce` unit tests green (4 new: block strip, top-level strip, all-`debugger` block → `{}`, preserved brace-less consequent).
- 728/728 `closurec` tests green (repurposed fixture + flipped guard).
- End-to-end binary confirms: strip at SIMPLE & ADVANCED (both top-level and in-block), preservation at WHITESPACE_ONLY, brace-less consequent preserved.
- Inline security review passed (no findings): the two `len()` subtractions can't underflow (`retain` only shrinks), predicates match only `DebuggerStatement`, no `unsafe`/new panics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)