### PR TITLE
feat(mycin-cc2c): ground cefepime renal dose cap (write-once-use-many, 2nd drug)

### DIFF
--- a/code/specs/data/mycin-2026/CHART-AS-CONSTRAINTS.md
+++ b/code/specs/data/mycin-2026/CHART-AS-CONSTRAINTS.md
@@ -180,6 +180,16 @@ risks Y") — decision support, not a hidden choice.
       scorecard — stays byte-identical; this only enriches provenance and proves the substrate
       now covers both cap shapes. Verified by `test_dose_caps.py` (single-factor renal +
       nephrotoxin caps grounded; compound still requires two categories; 15 tests).
+    - **WRITE-ONCE-USE-MANY (2nd drug, cefepime). ✅ DONE.** The completed substrate now grounds
+      a SECOND drug's renal cap as PURE DATA — a grounding record (`dose_penalty_cefepime_renal`,
+      FDA cefepime label DailyMed `be5f8ca6`: §2.3 *"Adjust the dose of Cefepime Injection in
+      patients with creatinine clearance less than or equal to 60 mL/min …"* + §5.2
+      *"Neurotoxicity: May occur especially in patients with renal impairment administered
+      unadjusted doses."*) + one `SINGLE_FACTOR_CAPS` row → `dose_capped_under(cefepime,
+      renal_severe)`. No engine, compiler, or rulebook-code change; `dose_caps_build.py`
+      regenerates the rulebook from the new row. A `renal_severe` chart now derives BOTH the
+      vancomycin and cefepime renal caps from the one substrate (`test_dose_caps.py`, 16 tests).
+      `verdict direction_only`; the per-kg magnitude stays the illustrative model.
 - **REFACTOR (ADJ-first): every exclusion is now an EXPLICIT engine constraint.** Dose-infeasible
   (CC-2), contraindicated (CC-3), and step-therapy (CC-6) drugs are unified into one
   `forced_zero: {drug → reason}` and emitted as `constrain x_d <= 0   % excluded (reason)` in the

--- a/code/specs/data/mycin-2026/grounding/dose-window-grounding.json
+++ b/code/specs/data/mycin-2026/grounding/dose-window-grounding.json
@@ -335,6 +335,34 @@
         "final_verdict": "direction_only"
       },
       "spider_status": "direction_only"
+    },
+    {
+      "id": "dose_penalty_cefepime_renal",
+      "kind": "dose_penalty",
+      "drug": "cefepime",
+      "claim": "Renal impairment lowers cefepime's safe dose: the dose must be adjusted in patients with CrCl ≤ 60 mL/min because of slower renal elimination, and neurotoxicity occurs especially when renally-impaired patients receive UNADJUSTED doses — i.e. the safe ceiling shrinks as renal function falls (the renal_severe ceiling penalty).",
+      "grounded": {
+        "id": "dose_penalty_cefepime_renal",
+        "resolved_url": "https://dailymed.nlm.nih.gov/dailymed/fda/fdaDrugXsl.cfm?setid=be5f8ca6-7232-423a-a2d5-cccb7abe7921",
+        "source_title": "CEFEPIME for injection — FDA prescribing information (DailyMed / NLM); DOSAGE AND ADMINISTRATION §2.3 + WARNINGS AND PRECAUTIONS §5.2 Neurotoxicity",
+        "byte_quote": "Adjust the dose of Cefepime Injection in patients with creatinine clearance less than or equal to 60 mL/min to compensate for the slower rate of renal elimination. Neurotoxicity: May occur especially in patients with renal impairment administered unadjusted doses.",
+        "value_found": "Cefepime dose must be reduced as renal function falls (CrCl ≤ 60 mL/min), and failure to adjust in renal impairment causes neurotoxicity — i.e. the safe ceiling shrinks with renal impairment. DIRECTION only; the per-kg penalty magnitude in formulary.json stays the illustrative feasibility model (the label's adjustment is a CrCl-banded table, not a single per-kg figure).",
+        "direction_correct": true,
+        "verdict": "direction_only",
+        "discards": [
+          "The CrCl-banded maintenance-dose grid (label Table 2) — a numeric dose-by-CrCl schedule, but it is a multi-row table (not a single per-kg ceiling reduction) and renders as tabular data; the formulary's single renal_severe per-kg penalty is an illustrative approximation of 'shrink the ceiling', not a transcription of Table 2, so the table is not cited for a numeric value.",
+          "Secondary aggregators (drugs.com, Sanford, UpToDate cefepime renal dosing) — discarded per primary-source-first; the FDA label states the adjustment + the neurotoxicity-on-unadjusted-dose warning directly."
+        ],
+        "note": "DIRECTION ENTAILED. Two verbatim sentences jointly establish the direction the dose-window model encodes for cefepime: (a) §2.3 mandates a dose adjustment once CrCl ≤ 60 mL/min (slower elimination → accumulation), and (b) §5.2 warns neurotoxicity occurs ESPECIALLY when renally-impaired patients get UNADJUSTED doses — both say the safe ceiling must shrink as renal function falls. Grounds the EXISTENCE + DIRECTION of cefepime's renal ceiling penalty, not its magnitude (the formulary renal_severe per-kg number stays the standing ILLUSTRATIVE feasibility model). This is the write-once-use-many demonstration: the same dose_caps.adj single-factor substrate now grounds a SECOND drug (cefepime) from a data row + this record, no engine/compiler change."
+      },
+      "verify": {
+        "id": "dose_penalty_cefepime_renal",
+        "byte_stable": true,
+        "reextracted_value": "Re-fetched the be5f8ca6 DailyMed cefepime label: §2.3 (DOSAGE AND ADMINISTRATION) states 'Adjust the dose of Cefepime Injection in patients with creatinine clearance less than or equal to 60 mL/min to compensate for the slower rate of renal elimination.' and §5.2 (WARNINGS AND PRECAUTIONS / Neurotoxicity, also in Highlights) states 'Neurotoxicity: May occur especially in patients with renal impairment administered unadjusted doses.'",
+        "refute_attempt": "Strongest refutation: §2.3 'adjust the dose' could mean lengthen the INTERVAL rather than lower the per-dose CEILING, so it might not justify a ceiling penalty. Conceded to the extent the verdict is direction_only (not a numeric grounding): the §5.2 neurotoxicity-on-UNADJUSTED-doses warning makes the safety direction unambiguous — an unreduced cefepime exposure in renal impairment is harmful, which is exactly the 'shrink the safe ceiling' direction the model encodes; the precise mechanism (interval vs per-dose) and magnitude are left to the illustrative feasibility model and not over-claimed. Second angle: the quote is generic cefepime PK, not meningitis-specific — but dose feasibility under renal impairment is indication-independent, so the direction holds for the meningitis dose too.",
+        "final_verdict": "direction_only"
+      },
+      "spider_status": "direction_only"
     }
   ]
 }

--- a/code/specs/data/mycin-2026/treatment/antibiotics/dose-cap-manifest.json
+++ b/code/specs/data/mycin-2026/treatment/antibiotics/dose-cap-manifest.json
@@ -80,7 +80,17 @@
       "trust": "authoritative",
       "source": "In order to minimize the risk of nephrotoxicity when treating patients with underlying renal dysfunction or patients receiving concomitant therapy with an aminoglycoside, serial monitoring of renal function should be performed, and particular care should be taken in following appropriate dosing schedules.",
       "url": "https://dailymed.nlm.nih.gov/dailymed/fda/fdaDrugXsl.cfm?setid=75a6a873-21b9-4f48-89a9-c1476294c0ce"
+    },
+    "dose_capped_under__cefepime__renal_severe": {
+      "relation": "dose_capped_under",
+      "subject": "cefepime",
+      "risk": "renal_severe",
+      "grounding_id": "dose_penalty_cefepime_renal",
+      "verdict": "ACCEPT",
+      "trust": "authoritative",
+      "source": "Adjust the dose of Cefepime Injection in patients with creatinine clearance less than or equal to 60 mL/min to compensate for the slower rate of renal elimination. Neurotoxicity: May occur especially in patients with renal impairment administered unadjusted doses.",
+      "url": "https://dailymed.nlm.nih.gov/dailymed/fda/fdaDrugXsl.cfm?setid=be5f8ca6-7232-423a-a2d5-cccb7abe7921"
     }
   },
-  "hash": "9c3a7c2bf2db2b6f"
+  "hash": "e260c9f8b07b8d64"
 }

--- a/code/specs/data/mycin-2026/treatment/antibiotics/dose_caps.adj
+++ b/code/specs/data/mycin-2026/treatment/antibiotics/dose_caps.adj
@@ -81,6 +81,10 @@ rulebook dose_caps {
         source "In order to minimize the risk of nephrotoxicity when treating patients with underlying renal dysfunction or patients receiving concomitant therapy with an aminoglycoside, serial monitoring of renal function should be performed, and particular care should be taken in following appropriate dosing schedules."
         locator "https://dailymed.nlm.nih.gov/dailymed/fda/fdaDrugXsl.cfm?setid=75a6a873-21b9-4f48-89a9-c1476294c0ce"
         trust authoritative
+    relate dose_capped_under(cefepime, renal_severe)
+        source "Adjust the dose of Cefepime Injection in patients with creatinine clearance less than or equal to 60 mL/min to compensate for the slower rate of renal elimination. Neurotoxicity: May occur especially in patients with renal impairment administered unadjusted doses."
+        locator "https://dailymed.nlm.nih.gov/dailymed/fda/fdaDrugXsl.cfm?setid=be5f8ca6-7232-423a-a2d5-cccb7abe7921"
+        trust authoritative
 
     % --- the GENERIC conjunction rules ---------------------------------------
     % a compound risk holds when an active risk is in its first category AND a

--- a/code/specs/data/mycin-2026/treatment/antibiotics/dose_caps_build.py
+++ b/code/specs/data/mycin-2026/treatment/antibiotics/dose_caps_build.py
@@ -124,6 +124,11 @@ SINGLE_FACTOR_CAPS: list[tuple[str, str, str, str]] = [
     ("dose_penalty_vancomycin_nephrotoxin", "vancomycin", "nephrotoxin_interaction",
      "Concomitant therapy with another nephrotoxin (e.g. an aminoglycoside) compounds "
      "vancomycin nephrotoxicity, requiring careful/adjusted dosing (FDA label)."),
+    # write-once-use-many: the SAME single-factor substrate grounds a SECOND drug (cefepime)
+    # from a data row + a grounding record — no engine/compiler change.
+    ("dose_penalty_cefepime_renal", "cefepime", "renal_severe",
+     "Cefepime dose must be adjusted in renal impairment (CrCl <= 60 mL/min); neurotoxicity "
+     "occurs especially when renally-impaired patients receive unadjusted doses (FDA label)."),
 ]
 
 

--- a/code/specs/data/mycin-2026/treatment/antibiotics/formulary.json
+++ b/code/specs/data/mycin-2026/treatment/antibiotics/formulary.json
@@ -29,6 +29,7 @@
                      "source": "IDSA Tunkel 2004 (ampicillin for Listeria)"},
     "cefepime":     {"covers": ["n_meningitidis", "pseudomonas", "gram_negative", "s_pneumoniae_susceptible"], "csf_penetrant": true, "betalactam": true, "contraindications": ["betalactam_allergy_severe"], "tier": 2,
                      "dose": {"floor_mg_per_kg": 25, "ceiling_base_mg_per_kg": 50, "ceiling_penalty_mg_per_kg": {"renal_severe": 4}},
+                     "dose_penalty_source": "FDA cefepime label (DailyMed be5f8ca6): adjust dose at CrCl <= 60 mL/min, neurotoxicity if unadjusted in renal impairment — DIRECTION grounded in dose-window-grounding.json (dose_penalty_cefepime_renal); the per-kg magnitude stays the illustrative feasibility model",
                      "source": "IDSA Tunkel 2004 (cefepime for Pseudomonas / nosocomial)"},
     "meropenem":    {"covers": ["n_meningitidis", "listeria", "pseudomonas", "gram_negative", "s_pneumoniae_susceptible"], "csf_penetrant": true, "betalactam": true, "contraindications": ["betalactam_allergy_severe"], "tier": 3,
                      "dose": {"floor_mg_per_kg": 20, "ceiling_base_mg_per_kg": 40, "ceiling_penalty_mg_per_kg": {"renal_severe": 3}},

--- a/code/specs/data/mycin-2026/treatment/antibiotics/test_dose_caps.py
+++ b/code/specs/data/mycin-2026/treatment/antibiotics/test_dose_caps.py
@@ -141,6 +141,19 @@ def test_single_factor_nephrotoxin_cap_is_grounded():
     assert "nephrotoxicity" in van["source"].lower()
 
 
+def test_single_factor_cefepime_renal_cap_is_grounded():
+    cli = _cli_or_skip()
+    # write-once-use-many: a SECOND drug (cefepime) is capped under renal_severe via the same
+    # single-factor substrate — pure data (a grounding record + a row), no engine change.
+    risks, caps = dc.derive_dose_caps(cli, {"renal_severe"})
+    assert risks == set()
+    cef = next((c for c in caps if c["drug"] == "cefepime"), None)
+    assert cef and cef["risk"] == "renal_severe" and cef["trust"] == "authoritative", caps
+    assert "renal" in cef["source"].lower()
+    # vancomycin is ALSO capped under renal_severe — the substrate serves many drugs at once.
+    assert any(c["drug"] == "vancomycin" for c in caps), caps
+
+
 def test_unknown_single_risk_caps_nothing():
     cli = _cli_or_skip()
     # A risk token with no dose_capped_under fact and no category → no compound, no cap.


### PR DESCRIPTION
## Write-once-use-many: the completed dose-cap substrate grounds a 2nd drug as pure data

This grounding increment exercises the now-complete `dose_caps.adj` substrate (#6364) for a **second drug (cefepime)** as **pure data** — no engine, compiler, or rulebook-code change. Adding a drug's grounded renal cap = a grounding record + one `SINGLE_FACTOR_CAPS` row.

### The grounded direction (FDA cefepime label, DailyMed `be5f8ca6`)
- **§2.3 DOSAGE AND ADMINISTRATION:** *"Adjust the dose of Cefepime Injection in patients with creatinine clearance less than or equal to 60 mL/min to compensate for the slower rate of renal elimination."*
- **§5.2 WARNINGS AND PRECAUTIONS (Neurotoxicity):** *"Neurotoxicity: May occur especially in patients with renal impairment administered unadjusted doses."*

Together: the safe ceiling must shrink as renal function falls (the formulary's existing cefepime `renal_severe` penalty). `verdict: direction_only` — only the direction is grounded; the per-kg magnitude stays the illustrative feasibility model.

### Changes (data only)
- `dose-window-grounding.json`: + record `dose_penalty_cefepime_renal` (12 records), byte-stable verify + honest refute (interval-vs-ceiling, conceded → `direction_only`).
- `dose_caps_build.py`: + one `SINGLE_FACTOR_CAPS` row → `dose_capped_under(cefepime, renal_severe)`. **No logic change**; the generator regenerates the rulebook.
- `dose_caps.adj` + manifest: regenerated. `formulary.json`: cefepime `dose_penalty_source` pointer (doesn't touch the dose sub-object or CAS digest).
- `test_dose_caps.py`: **16 tests** — a `renal_severe` chart now derives **both** the cefepime and vancomycin caps from the one substrate.
- `CHART-AS-CONSTRAINTS.md`: CC-2c "write-once-use-many (2nd drug)" subsection.

### Verified
`dose_caps_build --check` + `formulary_build --check` up to date; `test_dose_caps` 16/16; ruff clean; **board 0 wrong / defensibility 100%**; **`board-scorecard.json` byte-identical** (provenance-only, numeric solve unchanged).

Security review (data-only diff; generator/runtime/guard unchanged): **PASSED — no vulnerabilities found**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)