### PR TITLE
feat(closurec): hoist redundant `else` after a terminating consequent (CLOC25)

### DIFF
--- a/code/packages/rust/closure-pass-fold-control-flow/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-fold-control-flow/CHANGELOG.md
@@ -2,6 +2,42 @@
 
 All notable changes to the `coding-adventures-closure-pass-fold-control-flow` crate will be documented in this file.
 
+## [0.14.0] - 2026-06-20
+
+### Added — CLOC25: drop a redundant `else` after a terminating consequent
+
+`fold_block_statement` now removes the `else` from an `if` whose consequent
+unconditionally terminates, hoisting the `else` body into the enclosing block —
+upstream Closure's `MinimizeExitPoints`:
+
+```text
+if (c) { …; return x; } else { B }   →   if (c) { …; return x; } B
+if (bad) throw e; else use(v);        →   if (bad) throw e; use(v);
+```
+
+When `c` is true the consequent exits (`return`/`throw`), so control reaches the
+`else` body only when `c` was false — exactly the `else` semantics. Removing the
+`else` deletes a keyword and (for a block) a pair of braces, and un-nests
+`else if` chains.
+
+- New helpers: `consequent_definitely_terminates` (accepts `return`/`throw`, and
+  a block whose last statement does — it is broader than the return-only
+  `is_terminator` that still gates the dead-code-after-terminator drop);
+  `block_is_scope_safe_to_hoist` / `alternate_is_hoistable`.
+- **Soundness — scope safety.** The `else` body is hoisted only when splicing it
+  into the enclosing block changes no binding's scope: a block containing a
+  block-scoped `let`/`const`/`function` declaration is **not** hoisted (it would
+  leak the binding or cause a TDZ collision); plain `var` is function-scoped and
+  hoists harmlessly. A bare (non-block) `else` body that is a `Declaration` is
+  likewise declined. Mirrors `closure-pass-dce`'s `block_is_scope_safe_to_flatten`.
+- When the hoisted tail itself ends in a terminator, the existing
+  dead-code-after-terminator drop then removes any statements that followed the
+  original `if`. A `removed-`-style `hoisted-else-after-terminator` contribution
+  is recorded (and flips `changed`).
+- 5 new tests: block-`else` hoist after `return`; bare-`else` hoist after
+  `throw`; a `let` in the `else` block blocks the hoist; a non-terminating
+  consequent is left alone; and the hoisted-tail dead-code drop.
+
 ## [0.13.0] - 2026-06-20
 
 ### Added — CLOC23: fold control flow inside `for`-`of`

--- a/code/packages/rust/closure-pass-fold-control-flow/Cargo.toml
+++ b/code/packages/rust/closure-pass-fold-control-flow/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-fold-control-flow"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 description = "Control-flow folding pass for the Closure Compiler clone. Slots between constant-fold and DCE per CLOC06's canonical pass set. Eliminates dead branches (`if (false) A else B → B`), removes unreachable code after `return`/`throw`, and collapses degenerate switch arms."
 

--- a/code/packages/rust/closure-pass-fold-control-flow/src/lib.rs
+++ b/code/packages/rust/closure-pass-fold-control-flow/src/lib.rs
@@ -371,6 +371,56 @@ fn fold_block_statement(b: &BlockStatement, st: &mut FoldState) -> BlockStatemen
             continue;
         }
         let folded = fold_statement(s, st);
+
+        // CLOC25 — drop a redundant `else` after a terminating consequent.
+        //
+        // `if (C) <T-that-terminates> else <E>` is equivalent to
+        // `if (C) <T>` followed by `E`: when `C` is true the consequent exits
+        // (return/throw), so control reaches `E` only when `C` was false —
+        // exactly the `else` semantics. Removing the `else` deletes a keyword
+        // and (for a block) a pair of braces, and un-nests `else if` chains.
+        // We only hoist when `E` is scope-safe to splice into this block (no
+        // block-scoped declarations leaking out). See
+        // `consequent_definitely_terminates` / `alternate_is_hoistable`.
+        if let Statement::Tagged(TaggedStatement::IfStatement(if_s)) = &folded {
+            if let Some(alt) = &if_s.alternate {
+                if consequent_definitely_terminates(&if_s.consequent)
+                    && alternate_is_hoistable(alt)
+                {
+                    // Push `if (C) T` with the `else` stripped.
+                    new_body.push(Statement::if_statement(IfStatement {
+                        cv: if_s.cv.clone(),
+                        test: if_s.test.clone(),
+                        consequent: if_s.consequent.clone(),
+                        alternate: None,
+                    }));
+                    // Splice the former `else` body into this block.
+                    match alt.as_ref() {
+                        Statement::Tagged(TaggedStatement::BlockStatement(eb)) => {
+                            for inner in &eb.body {
+                                new_body.push(inner.clone());
+                            }
+                        }
+                        other => new_body.push(other.clone()),
+                    }
+                    st.record_fold(
+                        &if_s.cv,
+                        "hoisted-else-after-terminator",
+                        "if (C) <terminates> else <E>",
+                        "if (C) <terminates> followed by <E>",
+                    );
+                    // The trimmed `if` is NOT itself a terminator (a false test
+                    // falls through), but the hoisted tail might end in one —
+                    // if so, mark it so the dead-code-after-terminator drop
+                    // applies to any following statements.
+                    if new_body.last().map(is_terminator).unwrap_or(false) {
+                        hit_terminator = true;
+                    }
+                    continue;
+                }
+            }
+        }
+
         let terminates = is_terminator(&folded);
         new_body.push(folded);
         if terminates {
@@ -395,11 +445,84 @@ fn fold_block_statement(b: &BlockStatement, st: &mut FoldState) -> BlockStatemen
 /// enclosing block. In Phase 1, only `ReturnStatement` qualifies
 /// — Phase 2 adds `ThrowStatement`, and `BreakStatement` /
 /// `ContinueStatement` qualify in their enclosing loop scope.
+///
+/// NOTE: this gates the dead-code-after-terminator drop in
+/// [`fold_block_statement`]; keeping it return-only preserves that pass's
+/// long-standing behaviour. The `else`-hoist (CLOC25) uses the broader
+/// [`consequent_definitely_terminates`] instead, which also accepts `throw`.
 fn is_terminator(stmt: &Statement) -> bool {
     matches!(
         stmt,
         Statement::Tagged(TaggedStatement::ReturnStatement(_))
     )
+}
+
+/// Does this statement, used as an `if` **consequent**, unconditionally leave
+/// the enclosing block — so that the matching `else` branch only runs when the
+/// consequent did NOT, and can therefore be hoisted out after the `if`?
+/// (CLOC25, upstream Closure's `MinimizeExitPoints`.)
+///
+/// `return` and `throw` both qualify. A `BlockStatement` qualifies when its
+/// LAST statement does. We deliberately do NOT look inside nested
+/// `if`/loops/`try` (a conservative check — declining merely forgoes an
+/// optimization and is never a miscompile).
+///
+/// ```text
+///   if (c) { …; return x; } else { B }   →   if (c) { …; return x; } B
+///   if (bad) throw e; else use(v);        →   if (bad) throw e; use(v);
+/// ```
+fn consequent_definitely_terminates(stmt: &Statement) -> bool {
+    match stmt {
+        Statement::Tagged(TaggedStatement::ReturnStatement(_))
+        | Statement::Tagged(TaggedStatement::ThrowStatement(_)) => true,
+        Statement::Tagged(TaggedStatement::BlockStatement(b)) => b
+            .body
+            .last()
+            .map(consequent_definitely_terminates)
+            .unwrap_or(false),
+        _ => false,
+    }
+}
+
+/// Can an `else` block's statements be spliced into the enclosing block
+/// without changing any binding's scope? Block-scoped declarations
+/// (`let`/`const`/`function`) would leak upward or collide if moved out, so
+/// they make the block unsafe to hoist; a plain `var` is function-scoped and
+/// hoists harmlessly. Mirrors `closure-pass-dce`'s
+/// `block_is_scope_safe_to_flatten`.
+fn block_is_scope_safe_to_hoist(b: &BlockStatement) -> bool {
+    b.body.iter().all(|s| match s {
+        Statement::Declaration(Declaration::VariableDeclaration(v)) => {
+            matches!(v.kind, VarKind::Var)
+        }
+        Statement::Declaration(Declaration::FunctionDeclaration(_)) => false,
+        // Tagged statements introduce no lexical binding of their own.
+        Statement::Tagged(_) => true,
+    })
+}
+
+/// Is this `else` branch safe to hoist into the enclosing block (CLOC25)?
+///
+/// - A `BlockStatement` is gated on [`block_is_scope_safe_to_hoist`].
+/// - A non-block single statement cannot be a bare lexical/`function`
+///   declaration in valid JS (those require braces), so any single *tagged*
+///   statement is safe to hoist as-is.
+/// - A bare `Declaration` (e.g. `else var x;` / Annex-B `else function f(){}`)
+///   is declined — moving it could change its scope.
+///
+/// INVARIANT (load-bearing for soundness): every binding-introducing form —
+/// `var`/`let`/`const` and `function` declarations — is represented as
+/// `Statement::Declaration(..)`, never wrapped in a `TaggedStatement`. The
+/// `Tagged(_) => true` arm therefore admits only non-declaration statements. If
+/// the parser ever wrapped a declaration in `TaggedStatement`, this arm would
+/// start leaking a block-scoped binding into the outer scope — so that
+/// representation invariant must hold.
+fn alternate_is_hoistable(alt: &Statement) -> bool {
+    match alt {
+        Statement::Tagged(TaggedStatement::BlockStatement(b)) => block_is_scope_safe_to_hoist(b),
+        Statement::Tagged(_) => true,
+        Statement::Declaration(_) => false,
+    }
 }
 
 /// Fold an `IfStatement`. When `test` is a known-truthy/falsy
@@ -1830,6 +1953,217 @@ mod tests {
                 init,
             }],
         }))
+    }
+
+    // ---------------- CLOC25: else-hoist after terminating consequent ----
+
+    /// `function f(x){ if(x){return 1;} else { g; } }`
+    /// → `function f(x){ if(x){return 1;} g; }` — the `else` is hoisted.
+    #[test]
+    fn else_block_hoisted_after_returning_consequent() {
+        let consequent = Statement::block_statement(BlockStatement {
+            cv: None,
+            body: vec![Statement::return_statement(ReturnStatement {
+                cv: None,
+                argument: Some(num(1.0, None)),
+            })],
+        });
+        let alternate = Statement::block_statement(BlockStatement {
+            cv: None,
+            body: vec![expr_stmt(ident("g"), None)],
+        });
+        let if_stmt = Statement::if_statement(IfStatement {
+            cv: Some("if.1".to_string()),
+            test: ident("x"),
+            consequent: Box::new(consequent),
+            alternate: Some(Box::new(alternate)),
+        });
+        let prog = fdecl_with_body(vec![if_stmt]);
+        let (out, contribs, changed, _) = run_pass(prog);
+        assert!(changed);
+        assert!(
+            contribs
+                .iter()
+                .any(|c| c.tag == "hoisted-else-after-terminator"),
+            "expected hoisted-else-after-terminator; got {:?}",
+            contribs
+        );
+        let body = extract_fn_body(&out);
+        assert_eq!(
+            body.body.len(),
+            2,
+            "expected [if(x){{return 1}}, g]; got {:?}",
+            body.body
+        );
+        let Statement::Tagged(TaggedStatement::IfStatement(if_out)) = &body.body[0] else {
+            panic!("expected if; got {:?}", body.body[0]);
+        };
+        assert!(if_out.alternate.is_none(), "the else must be removed");
+        assert!(matches!(
+            &body.body[1],
+            Statement::Tagged(TaggedStatement::ExpressionStatement(_))
+        ));
+    }
+
+    /// A bare `throw` consequent with a bare `else` body also hoists:
+    /// `if(bad) throw e; else use;` → `if(bad) throw e; use;`.
+    #[test]
+    fn else_hoisted_after_throwing_consequent() {
+        let consequent =
+            Statement::throw_statement(coding_adventures_javascript_ast::ThrowStatement {
+                cv: None,
+                argument: ident("e"),
+            });
+        let alternate = expr_stmt(ident("use"), None);
+        let if_stmt = Statement::if_statement(IfStatement {
+            cv: None,
+            test: ident("bad"),
+            consequent: Box::new(consequent),
+            alternate: Some(Box::new(alternate)),
+        });
+        let prog = fdecl_with_body(vec![if_stmt]);
+        let (out, _contribs, changed, _) = run_pass(prog);
+        assert!(changed);
+        let body = extract_fn_body(&out);
+        assert_eq!(body.body.len(), 2, "got {:?}", body.body);
+        let Statement::Tagged(TaggedStatement::IfStatement(if_out)) = &body.body[0] else {
+            panic!("expected if; got {:?}", body.body[0]);
+        };
+        assert!(if_out.alternate.is_none());
+        assert!(matches!(
+            &body.body[1],
+            Statement::Tagged(TaggedStatement::ExpressionStatement(_))
+        ));
+    }
+
+    /// An `else` block that declares a `let` is NOT hoisted — moving the
+    /// binding out of its block would leak it / risk a TDZ collision.
+    #[test]
+    fn else_block_with_let_is_not_hoisted() {
+        let consequent = Statement::block_statement(BlockStatement {
+            cv: None,
+            body: vec![Statement::return_statement(ReturnStatement {
+                cv: None,
+                argument: None,
+            })],
+        });
+        let alternate = Statement::block_statement(BlockStatement {
+            cv: None,
+            body: vec![make_let_decl("y", Some(num(1.0, None))), expr_stmt(ident("g"), None)],
+        });
+        let if_stmt = Statement::if_statement(IfStatement {
+            cv: None,
+            test: ident("x"),
+            consequent: Box::new(consequent),
+            alternate: Some(Box::new(alternate)),
+        });
+        let prog = fdecl_with_body(vec![if_stmt]);
+        let (out, contribs, _changed, _) = run_pass(prog);
+        assert!(
+            !contribs
+                .iter()
+                .any(|c| c.tag == "hoisted-else-after-terminator"),
+            "a let in the else block must block the hoist; got {:?}",
+            contribs
+        );
+        let body = extract_fn_body(&out);
+        assert_eq!(body.body.len(), 1, "if-else stays a single statement; got {:?}", body.body);
+        let Statement::Tagged(TaggedStatement::IfStatement(if_out)) = &body.body[0] else {
+            panic!("expected if; got {:?}", body.body[0]);
+        };
+        assert!(if_out.alternate.is_some(), "the else must be preserved");
+    }
+
+    /// When the consequent does NOT unconditionally terminate, the `else`
+    /// stays: `if(x){g; m} else {h}` is unchanged. (The consequent has two
+    /// statements so the if-else→ternary fold also does not apply — isolating
+    /// the else-hoist's terminator gate as the reason it stays.)
+    #[test]
+    fn else_not_hoisted_when_consequent_falls_through() {
+        let consequent = Statement::block_statement(BlockStatement {
+            cv: None,
+            body: vec![expr_stmt(ident("g"), None), expr_stmt(ident("m"), None)],
+        });
+        let alternate = Statement::block_statement(BlockStatement {
+            cv: None,
+            body: vec![expr_stmt(ident("h"), None)],
+        });
+        let if_stmt = Statement::if_statement(IfStatement {
+            cv: None,
+            test: ident("x"),
+            consequent: Box::new(consequent),
+            alternate: Some(Box::new(alternate)),
+        });
+        let prog = fdecl_with_body(vec![if_stmt]);
+        let (out, contribs, _changed, _) = run_pass(prog);
+        assert!(
+            !contribs
+                .iter()
+                .any(|c| c.tag == "hoisted-else-after-terminator"),
+            "a non-terminating consequent must NOT hoist; got {:?}",
+            contribs
+        );
+        let body = extract_fn_body(&out);
+        assert_eq!(body.body.len(), 1);
+        let Statement::Tagged(TaggedStatement::IfStatement(if_out)) = &body.body[0] else {
+            panic!("expected if; got {:?}", body.body[0]);
+        };
+        assert!(if_out.alternate.is_some());
+    }
+
+    /// After hoisting an `else` whose body itself ends in a terminator, code
+    /// following the original `if` becomes dead and is dropped in the same
+    /// pass: `if(x){return 1} else {cleanup; return 2} after;`
+    /// → `if(x){return 1} cleanup; return 2;` (`after` gone). (The else has
+    /// two statements, so the if-else→ternary fold does not apply — the
+    /// else-hoist does.)
+    #[test]
+    fn hoisted_returning_else_drops_following_dead_code() {
+        let consequent = Statement::block_statement(BlockStatement {
+            cv: None,
+            body: vec![Statement::return_statement(ReturnStatement {
+                cv: None,
+                argument: Some(num(1.0, None)),
+            })],
+        });
+        let alternate = Statement::block_statement(BlockStatement {
+            cv: None,
+            body: vec![
+                expr_stmt(ident("cleanup"), None),
+                Statement::return_statement(ReturnStatement {
+                    cv: None,
+                    argument: Some(num(2.0, None)),
+                }),
+            ],
+        });
+        let if_stmt = Statement::if_statement(IfStatement {
+            cv: Some("if.1".to_string()),
+            test: ident("x"),
+            consequent: Box::new(consequent),
+            alternate: Some(Box::new(alternate)),
+        });
+        let prog = fdecl_with_body(vec![if_stmt, expr_stmt(ident("after"), None)]);
+        let (out, contribs, changed, _) = run_pass(prog);
+        assert!(changed);
+        assert!(
+            contribs
+                .iter()
+                .any(|c| c.tag == "hoisted-else-after-terminator"),
+            "got {:?}",
+            contribs
+        );
+        let body = extract_fn_body(&out);
+        // [if(x){return 1}, cleanup, return 2] — `after` dropped as dead code.
+        assert_eq!(
+            body.body.len(),
+            3,
+            "expected `after` to be dropped; got {:?}",
+            body.body
+        );
+        assert!(matches!(
+            &body.body[2],
+            Statement::Tagged(TaggedStatement::ReturnStatement(_))
+        ));
     }
 
     /// `function f() { if (cond) { var y = 1; } }` →

--- a/code/programs/rust/closurec/CHANGELOG.md
+++ b/code/programs/rust/closurec/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 All notable changes to the `coding-adventures-closurec` binary will be documented in this file.
 
+## [0.158.0] - 2026-06-20
+
+### Changed — CLOC25: drop a redundant `else` after a terminating `if` consequent
+
+At `--compilation_level SIMPLE` / `ADVANCED`, an `if` whose consequent
+unconditionally terminates (`return` / `throw`) now has its `else` removed and
+the `else` body hoisted out after the `if` — upstream Closure's
+`MinimizeExitPoints`. The transform lives in the `fold-control-flow` pass
+(bumped to 0.14.0); `WHITESPACE_ONLY`, which runs no passes, keeps the `else`.
+
+New end-to-end fixture `simple-else-hoist`:
+
+```text
+function classify(n){if(n < 0){return negative(n)}record(n);return positive(n)}
+```
+
+— the `else` body (`record(n); return positive(n);`) is lifted out of the
+`else`. The `simple_else_hoist_did_not_fall_back_to_whitespace_only` guard
+asserts the optimized output contains **no** `else` (a whitespace-only fallback
+would keep it).
+
+Depends on `coding-adventures-closure-pass-fold-control-flow` 0.14.0.
+
 ## [0.157.0] - 2026-06-20
 
 ### Changed — CLOC24: strip `debugger` statements at SIMPLE/ADVANCED

--- a/code/programs/rust/closurec/Cargo.toml
+++ b/code/programs/rust/closurec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closurec"
-version = "0.157.0"
+version = "0.158.0"
 edition = "2021"
 description = "closurec — CLI driver for the Closure Compiler clone. Mirrors the upstream Java Closure Compiler's command-line flag surface (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility. Per CLOC08."
 

--- a/code/programs/rust/closurec/cli.spec.json
+++ b/code/programs/rust/closurec/cli.spec.json
@@ -2,7 +2,7 @@
   "cli_builder_spec_version": "1.0",
   "name": "closurec",
   "description": "closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.",
-  "version": "0.157.0",
+  "version": "0.158.0",
   "parsing_mode": "gnu",
   "flags": [
     { "id": "browser_featureset_year", "long": "browser_featureset_year", "type": "integer", "default": 0, "description": "Shortcut for defining goog.FEATURESET_YEAR=YYYY (minimum 2012)." },

--- a/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
@@ -2,7 +2,7 @@
 
 closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.
 
-Version: 0.157.0
+Version: 0.158.0
 
 ## Flags
 

--- a/code/programs/rust/closurec/tests/diff/simple-else-hoist/README.md
+++ b/code/programs/rust/closurec/tests/diff/simple-else-hoist/README.md
@@ -1,0 +1,40 @@
+# Fixture: `simple-else-hoist`
+
+End-to-end oracle for **CLOC25** — dropping a redundant `else` after an `if`
+consequent that unconditionally terminates (upstream Closure's
+`MinimizeExitPoints`). The transform lives in the `fold-control-flow` pass.
+
+| File | Role |
+|------|------|
+| `flags.txt` | CLI args: `--compilation_level SIMPLE --js input/a.js` |
+| `input/a.js` | A function whose `if` consequent ends in `return`, with a multi-statement `else` |
+| `expected.stdout` | The optimized output (see below) |
+
+```text
+function classify(n){if(n < 0){return negative(n)}record(n);return positive(n)};report(classify(5));
+```
+
+What this proves:
+
+* **`else` hoisted** — the consequent `{ return negative(n); }` always exits, so
+  the `else` body `{ record(n); return positive(n); }` only runs when the test
+  was false. `fold-control-flow` lifts it out to right after the `if`, deleting
+  the `else` keyword and its braces.
+* **Reachable code preserved** — the hoisted statements (`record(n)` and the
+  `return positive(n)`) and the trailing `report(classify(5))` all survive; the
+  function is not tree-shaken because it is called.
+
+Contrast with `--compilation_level WHITESPACE_ONLY`, which runs no optimization
+passes and keeps the `else` verbatim
+(`if(n<0)return negative(n);else{record(n);return positive(n)}`). The
+`simple_else_hoist_did_not_fall_back_to_whitespace_only` guard asserts the
+optimized output contains **no** `else`, so a silent degrade to the whitespace
+fallback would fail the test.
+
+Regenerate the expected file after an intentional behavior change:
+
+```sh
+cargo run -- --compilation_level SIMPLE \
+    --js tests/diff/simple-else-hoist/input/a.js \
+    > tests/diff/simple-else-hoist/expected.stdout
+```

--- a/code/programs/rust/closurec/tests/diff/simple-else-hoist/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/simple-else-hoist/expected.stdout
@@ -1,0 +1,1 @@
+function classify(n){if(n < 0){return negative(n)}record(n);return positive(n)};report(classify(5));

--- a/code/programs/rust/closurec/tests/diff/simple-else-hoist/flags.txt
+++ b/code/programs/rust/closurec/tests/diff/simple-else-hoist/flags.txt
@@ -1,0 +1,4 @@
+--compilation_level
+SIMPLE
+--js
+tests/diff/simple-else-hoist/input/a.js

--- a/code/programs/rust/closurec/tests/diff/simple-else-hoist/input/a.js
+++ b/code/programs/rust/closurec/tests/diff/simple-else-hoist/input/a.js
@@ -1,0 +1,20 @@
+// CLOC25 — a redundant `else` is hoisted out after a terminating consequent.
+//
+// `classify`'s `if` consequent ends in `return`, so when the test is true the
+// function exits there; the `else` body therefore only runs when the test was
+// false and can be lifted out to right after the `if`, deleting the `else`
+// keyword and its braces. The trailing `report(...)` call keeps `classify`
+// reachable so tree-shaking does not remove it.
+//
+// At SIMPLE this becomes:
+//   function classify(n){if(n < 0){return negative(n)}record(n);return positive(n)}
+// while WHITESPACE_ONLY (which runs no optimization passes) keeps the `else`.
+function classify(n) {
+  if (n < 0) {
+    return negative(n);
+  } else {
+    record(n);
+    return positive(n);
+  }
+}
+report(classify(5));

--- a/code/programs/rust/closurec/tests/diff_simple_else_hoist.rs
+++ b/code/programs/rust/closurec/tests/diff_simple_else_hoist.rs
@@ -1,0 +1,80 @@
+//! Integration test for the `tests/diff/simple-else-hoist/` fixture.
+//!
+//! Exercises CLOC25 — dropping a redundant `else` after an `if` consequent that
+//! unconditionally terminates (upstream Closure's `MinimizeExitPoints`),
+//! implemented in the `fold-control-flow` pass. `classify`'s consequent ends in
+//! `return`, so the `else` body is hoisted out after the `if` and the `else`
+//! keyword + braces are deleted:
+//!
+//! ```text
+//! function classify(n){if(n < 0){return negative(n)}record(n);return positive(n)}
+//! ```
+//!
+//! Under WHITESPACE_ONLY the `else` survives verbatim, so the absence of `else`
+//! here is also a proof that the typed (SIMPLE) pipeline ran.
+
+use std::process::Command;
+
+const BINARY: &str = env!("CARGO_BIN_EXE_closurec");
+
+fn read_flags() -> Vec<String> {
+    let raw = std::fs::read_to_string("tests/diff/simple-else-hoist/flags.txt")
+        .expect("read flags.txt");
+    raw.lines()
+        .filter(|l| !l.is_empty())
+        .map(|s| s.to_string())
+        .collect()
+}
+
+#[test]
+fn simple_else_hoist_fixture_matches_expected_stdout() {
+    let flags = read_flags();
+    let out = Command::new(BINARY)
+        .args(&flags)
+        .output()
+        .expect("run closurec");
+
+    assert!(
+        out.status.success(),
+        "exit: {:?}, stderr: {}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stderr),
+    );
+
+    let actual = String::from_utf8_lossy(&out.stdout);
+    let expected = std::fs::read_to_string("tests/diff/simple-else-hoist/expected.stdout")
+        .expect("read expected.stdout");
+    assert_eq!(
+        actual.trim_end_matches('\n'),
+        expected.trim_end_matches('\n'),
+        "mismatch.\nflags: {flags:?}\nactual:\n{actual}\nexpected:\n{expected}",
+    );
+}
+
+/// Regression guard: the output must NOT be the WHITESPACE_ONLY fallback. Under
+/// WHITESPACE_ONLY the `else` is preserved verbatim, so an optimized SIMPLE run
+/// that hoisted the `else` must contain no `else` at all — while still keeping
+/// the hoisted statements (`record(n)` / `positive(n)`) and the trailing
+/// `report(...)` call reachable.
+#[test]
+fn simple_else_hoist_did_not_fall_back_to_whitespace_only() {
+    let out = Command::new(BINARY)
+        .args(read_flags())
+        .output()
+        .expect("run closurec");
+    let actual = String::from_utf8_lossy(&out.stdout);
+
+    assert!(
+        !actual.contains("else"),
+        "expected the `else` to be hoisted away (CLOC25); a WHITESPACE_ONLY \
+         fallback would have kept it. got:\n{actual}",
+    );
+    assert!(
+        actual.contains("record(n)") && actual.contains("positive(n)"),
+        "expected the hoisted else-body statements to survive; got:\n{actual}",
+    );
+    assert!(
+        actual.contains("report(classify(5))"),
+        "expected the trailing call keeping the function reachable; got:\n{actual}",
+    );
+}

--- a/code/specs/CLOC25-else-hoist.md
+++ b/code/specs/CLOC25-else-hoist.md
@@ -1,0 +1,102 @@
+# CLOC25 — drop a redundant `else` after a terminating `if` consequent
+
+> **Status:** Shipped. The `fold-control-flow` pass removes the `else` from an
+> `if` whose consequent unconditionally terminates, hoisting the `else` body
+> into the enclosing block (when scope-safe). This is upstream Closure's
+> `MinimizeExitPoints`. The `simple-else-hoist` fixture pins it at the CLI.
+
+## Why this spec exists
+
+A frequent pattern is an `if` whose consequent always exits, with an `else`
+holding the fall-through case:
+
+```js
+function classify(n) {
+  if (n < 0) { return negative(n); }
+  else       { record(n); return positive(n); }
+}
+```
+
+The `else` is redundant: when `n < 0` the function `return`s, so control reaches
+the `else` body **only** when the test was false. Removing the `else` and
+splicing its body in after the `if` is semantics-preserving and deletes the
+`else` keyword and its braces:
+
+```js
+function classify(n) {
+  if (n < 0) { return negative(n); }
+  record(n);
+  return positive(n);
+}
+```
+
+Upstream Closure does exactly this (`MinimizeExitPoints`). CLOC25 ports a
+conservative slice.
+
+## Where it lives
+
+In **`fold-control-flow`**, inside `fold_block_statement` — the pass that
+already processes a `BlockStatement.body` as a statement list (dropping
+dead-code-after-`return`, folding constant `if`s, etc.). The `else`-hoist needs
+to splice statements into that enclosing list, so it belongs in exactly this
+list-processing loop. (DCE owns *removing* code; this is control-flow
+*minimization*, fold-control-flow's job.)
+
+## The transform
+
+For each folded statement `if (C) T else E` in a block body where:
+
+1. **`T` definitely terminates** — `consequent_definitely_terminates(T)`: `T` is
+   a `return`/`throw`, or a block whose **last** statement is. (We do not look
+   inside nested `if`/loops/`try` — a conservative check; declining merely
+   forgoes the optimization.)
+2. **`E` is scope-safe to hoist** — `alternate_is_hoistable(E)`:
+   * a block `E` is gated on `block_is_scope_safe_to_hoist` (no block-scoped
+     `let`/`const`/`function` at its top level — those would leak or collide if
+     moved out; plain `var` is function-scoped and hoists harmlessly);
+   * a bare (non-block) tagged statement is safe (a bare lexical/`function`
+     declaration can't be an unbraced `else` body in valid JS);
+   * a bare `Declaration` `else` body is declined.
+
+the pass rewrites it to `if (C) T` followed by the statements of `E`, and
+records a `hoisted-else-after-terminator` contribution.
+
+The trimmed `if (C) T` is **not** itself a terminator (a false test falls
+through), so following statements stay reachable — except when the hoisted tail
+itself ends in a `return`, in which case the existing
+dead-code-after-terminator drop removes anything that followed the original
+`if`.
+
+## Soundness
+
+* **Control flow.** `T` exits unconditionally on the true path, so the true
+  path never reaches `E` or the code after the `if`; the false path runs `E`
+  then the following code. That is identical before and after the rewrite.
+* **Scope.** The only hazard is moving a block-scoped binding out of the `else`
+  block. The `block_is_scope_safe_to_hoist` gate forbids exactly that, mirroring
+  the same guard `closure-pass-dce` uses for block flattening.
+
+## Interaction with the existing if-else→ternary fold
+
+`fold_if_statement` already folds `if (x) return E1; else return E2;` to
+`return x ? E1 : E2` (gap-017) — but only when **both** branches are a single
+`return <expr>`. That fold runs first (via `fold_statement`), so when it
+applies, the block-level `else`-hoist never sees an `if`-with-`else`. The
+`else`-hoist covers the cases the ternary fold cannot: a `throw` consequent, a
+multi-statement `else`, a non-`return` `else`.
+
+## End-to-end oracle
+
+* **`simple-else-hoist`** — `classify` (above) at SIMPLE emits
+  `function classify(n){if(n < 0){return negative(n)}record(n);return positive(n)}`.
+  Under `WHITESPACE_ONLY` the `else` survives verbatim, so the guard asserting
+  the optimized output contains **no** `else` doubly proves the typed pipeline
+  ran.
+
+## Note: the grammar parser has no ASI
+
+The grammar parser requires explicit statement terminators — it does **not**
+implement automatic semicolon insertion. A block body like `{ a() }` (no `;`
+before `}`) fails to parse and closurec degrades the whole program to
+`WHITESPACE_ONLY`. Fixture inputs therefore use explicit semicolons. (ASI
+support is a separate, larger frontend item.)


### PR DESCRIPTION
## Summary

When an `if` consequent **unconditionally terminates** (`return` / `throw`), the matching `else` only runs when the test was false — so it can be lifted out to right after the `if`, deleting the `else` keyword and its braces (and un-nesting `else if` chains). This is upstream Closure's `MinimizeExitPoints`. It runs at SIMPLE/ADVANCED; `WHITESPACE_ONLY` keeps the `else`.

```js
function classify(n) {
  if (n < 0) { return negative(n); }
  else       { record(n); return positive(n); }
}
// SIMPLE ⇒
function classify(n){if(n < 0){return negative(n)}record(n);return positive(n)}
```

## What changed

**`fold-control-flow` (0.13.0 → 0.14.0)** — the transform lives in `fold_block_statement` (the loop that already processes a block's statement list and splices into it):
- Rewrites `if (C) <T-terminates> else <E>` → `if (C) <T>` followed by the statements of `E`.
- New helpers: `consequent_definitely_terminates` (accepts `return`/`throw`, and a block whose **last** statement does — broader than the return-only `is_terminator`, which still gates the dead-code-after-terminator drop); `block_is_scope_safe_to_hoist` / `alternate_is_hoistable`.
- **Soundness — scope safety:** the `else` body is hoisted only when splicing it changes no binding's scope. A block-scoped `let`/`const`/`function` in the `else` blocks the hoist (it would leak the binding / risk a TDZ collision); plain `var` is function-scoped and hoists harmlessly. A bare `Declaration` `else` body is declined. Mirrors `closure-pass-dce`'s `block_is_scope_safe_to_flatten`. The load-bearing representation invariant (declarations are never wrapped in a `TaggedStatement`) is pinned in a comment.
- When the hoisted tail itself ends in a terminator, the existing dead-code-after-terminator drop removes statements that followed the original `if`.
- Complements the existing if-else→ternary fold, which fires only when **both** branches are a single `return <expr>`; this hoist covers the rest (`throw` consequent, multi-statement `else`, non-`return` `else`).

**`closurec` (0.157.0 → 0.158.0)** — new end-to-end fixture `simple-else-hoist`, with a guard asserting the optimized output contains **no** `else` (a whitespace-only fallback would keep it). Help-markdown fixture regenerated for the version bump.

**Spec:** `code/specs/CLOC25-else-hoist.md` — documents the transform, the scope-safety guard, the interaction with the ternary fold, and a note that the grammar parser has no ASI (fixture inputs use explicit semicolons).

## Testing
- 31 `fold-control-flow` unit tests green (5 new: block-`else` hoist after `return`; bare-`else` hoist after `throw`; a `let` in the `else` blocks the hoist; non-terminating consequent left alone; hoisted-tail dead-code drop).
- 730 `closurec` tests green (728 + 2 new); no existing fixture drifted.
- End-to-end binary confirms the hoist at SIMPLE/ADVANCED and the `else` preserved at WHITESPACE_ONLY.
- Inline security review passed (no findings): hoisting soundness and the scope-safety gates were adversarially checked; the predicate asymmetry is conservative in the safe direction; no `unsafe`/panics/underflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)