### PR TITLE
feat(lang-full): E5 PR-1 — array<T> IR ops + bounds-checked vm-core arrays

### DIFF
--- a/code/packages/rust/interpreter-ir/CHANGELOG.md
+++ b/code/packages/rust/interpreter-ir/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog — interpreter-ir
 
+## [0.7.0] — 2026-06-20 (LANG-FULL E5 — array primitive)
+
+### Added — `array<T>` type + four array opcodes
+
+The IIR surface for bounded, indexable aggregates (enabler E5 — ALGOL/BASIC
+arrays, Twig lists). Representation-agnostic by design (see
+`code/specs/lang-full-e5-arrays.md`):
+
+- **Type helpers** `make_array_type`/`is_array_type`/`array_elem_type` mirror the
+  existing `ref<T>` helpers, encoding the element type as `"array<T>"`.
+- **Opcodes** `alloc_array` (→ `array<T>`), `array_len` (→ `i64`), `array_get`
+  (bounds-checked load → `T`), `array_set` (bounds-checked store) — `is_array_op`
+  predicate; the value-producing three join `is_value_producing`, `alloc_array`
+  joins `is_allocating`. `array_get`/`array_set` are bounds-checked *by
+  definition* (out-of-range index → trap).
+
+No backend lowers these yet except `vm-core` 0.7.0 (the reference interpreter);
+backends and frontends follow in the E5 PR sequence.
+
 ## [0.6.0] — 2026-05-12
 
 ### Added (LANG34 — First-Class Closure Opcodes)

--- a/code/packages/rust/interpreter-ir/Cargo.toml
+++ b/code/packages/rust/interpreter-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "interpreter-ir"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 description = "InterpreterIR (IIR) — the bytecode for the LANG JIT/AOT pipeline"
 

--- a/code/packages/rust/interpreter-ir/src/opcodes.rs
+++ b/code/packages/rust/interpreter-ir/src/opcodes.rs
@@ -124,6 +124,71 @@ pub fn make_ref_type(inner: &str) -> String {
 }
 
 // ---------------------------------------------------------------------------
+// Array-type helpers (LANG-FULL E5)
+// ---------------------------------------------------------------------------
+//
+// A bounded, indexable aggregate uses the `"array<T>"` encoding, mirroring
+// `ref<T>`.  The *element* type `T` is any scalar hint — v1 carries `i64` /
+// `f64`.  The model is representation-agnostic (see
+// `code/specs/lang-full-e5-arrays.md`): each backend lowers an `array<T>` to a
+// managed array (JVM/CLR/WasmGC) or a length-prefixed flat block
+// (LLVM/native/vm), but the IIR type string is the same.
+
+const ARRAY_PREFIX: &str = "array<";
+const ARRAY_SUFFIX: &str = ">";
+
+/// Return `true` if `type_hint` is an array type `"array<T>"`.
+///
+/// ```
+/// use interpreter_ir::opcodes::is_array_type;
+/// assert!(is_array_type("array<i64>"));
+/// assert!(!is_array_type("ref<i64>"));
+/// assert!(!is_array_type("i64"));
+/// ```
+pub fn is_array_type(type_hint: &str) -> bool {
+    type_hint.starts_with(ARRAY_PREFIX) && type_hint.ends_with(ARRAY_SUFFIX)
+}
+
+/// Return `Some(T)` for `"array<T>"`, else `None`.
+///
+/// ```
+/// use interpreter_ir::opcodes::array_elem_type;
+/// assert_eq!(array_elem_type("array<i64>"), Some("i64".to_string()));
+/// assert_eq!(array_elem_type("array<array<f64>>"), Some("array<f64>".to_string()));
+/// assert_eq!(array_elem_type("i64"), None);
+/// ```
+pub fn array_elem_type(type_hint: &str) -> Option<String> {
+    if !is_array_type(type_hint) {
+        return None;
+    }
+    Some(type_hint[ARRAY_PREFIX.len()..type_hint.len() - ARRAY_SUFFIX.len()].to_string())
+}
+
+/// Wrap `elem` as an array type string.  Inverse of [`array_elem_type`].
+///
+/// ```
+/// use interpreter_ir::opcodes::make_array_type;
+/// assert_eq!(make_array_type("i64"), "array<i64>");
+/// assert_eq!(make_array_type("f64"), "array<f64>");
+/// ```
+pub fn make_array_type(elem: &str) -> String {
+    format!("{ARRAY_PREFIX}{elem}{ARRAY_SUFFIX}")
+}
+
+/// The four array opcodes (LANG-FULL E5).  `alloc_array`/`array_len`/`array_get`
+/// produce a value; `array_set` does not.  All indexing is bounds-checked —
+/// `array_get`/`array_set` trap on an out-of-range index.
+///
+/// ```
+/// use interpreter_ir::opcodes::is_array_op;
+/// assert!(is_array_op("array_get"));
+/// assert!(!is_array_op("load_byte"));
+/// ```
+pub fn is_array_op(op: &str) -> bool {
+    matches!(op, "alloc_array" | "array_len" | "array_get" | "array_set")
+}
+
+// ---------------------------------------------------------------------------
 // Opcode category predicates
 // ---------------------------------------------------------------------------
 //
@@ -277,6 +342,10 @@ pub fn is_value_producing(op: &str) -> bool {
                 | "unbox"
                 | "field_load"
                 | "is_null"
+                // Array ops that produce a value (LANG-FULL E5)
+                | "alloc_array"
+                | "array_len"
+                | "array_get"
                 // Global variable read (LANG32)
                 | "global_load"
                 // Closure allocation and application (LANG34)
@@ -368,6 +437,8 @@ pub fn is_allocating(op: &str) -> bool {
     matches!(
         op,
         "alloc" | "box" | "safepoint"
+            // Array allocation (LANG-FULL E5)
+            | "alloc_array"
             // Closure allocation (LANG34)
             | "alloc_closure"
             // Concurrency allocators (LANG28)

--- a/code/packages/rust/vm-core/CHANGELOG.md
+++ b/code/packages/rust/vm-core/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog — vm-core
 
+## [0.7.0] — 2026-06-20 (LANG-FULL E5 — bounds-checked arrays)
+
+### Added — `alloc_array` / `array_len` / `array_get` / `array_set`
+
+The reference-interpreter execution of the E5 array primitive. A new `arrays:
+Vec<Vec<Value>>` heap holds each allocation; `alloc_array count` pushes a fresh
+`count`-element `Vec` (default-initialised — `f64` arrays to `0.0`, else `0`) and
+binds its 0-based index as the array *handle*. `array_get`/`array_set` are
+**bounds-checked**: a negative or `>= len` index returns a `VMError` (the
+interpreter's analogue of the managed runtimes' `IndexOutOfBoundsException` and
+the native backends' trap). `array_len` reads the length.
+
+Per-allocation `Vec`s mean **distinct arrays never alias** (unlike the single
+Brainfuck byte-tape, which is one flat space). `max_memory_entries` is enforced as
+a true **aggregate** ceiling — both the number of arrays and the running total of
+elements across every live array are bounded — so neither a single
+`alloc_array i64::MAX` nor a loop allocating many arrays can OOM the process.
+8 unit tests: round-trip, default-init, length, f64 arrays, out-of-bounds trap,
+negative-index trap, no-alias, and the aggregate allocation cap. Integer/float
+programs are unaffected (`DispatchCtx` gains an `arrays` field; existing handlers
+are untouched). Uses `interpreter-ir` 0.7.0's `array<T>` type + opcodes.
+
 ## [0.6.0] — 2026-06-20 (LANG-FULL E3 — floating-point execution)
 
 ### Added — `f64` arithmetic and ordered comparisons

--- a/code/packages/rust/vm-core/Cargo.toml
+++ b/code/packages/rust/vm-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vm-core"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 description = "Generic register interpreter for InterpreterIR — the vm-core of the LANG pipeline.  v0.5.0 (LANG-FULL E2 — register width & wrap, backend 1/6): integer arithmetic / bitwise / shift handlers now mask their result to the width named by the instruction's type_hint (u4→&0xF, u8→&0xFF, u16, u32), so a u8-typed `add` of 200+100 yields 44 and `~x` on a u8 flips 8 bits — the register-arithmetic analogue of the existing byte-tape store_byte mask, on top of the legacy whole-module u8_wrap flag.  v0.4.0 (LANG-MATRIX Phase V): adds the byte-tape ops alloc_bytes/load_byte/store_byte over the flat memory address space (a cell is memory[base+idx], store_byte masks to a byte for Brainfuck's 8-bit wrap), so the generic VM runs Brainfuck — every matrix language now runs on this one register interpreter."
 

--- a/code/packages/rust/vm-core/src/core.rs
+++ b/code/packages/rust/vm-core/src/core.rs
@@ -128,6 +128,16 @@ pub struct VMCore {
     /// Flat address-space memory (used by `load_mem` / `store_mem` / I/O).
     memory: HashMap<i64, Value>,
 
+    /// Heap of bounds-checked arrays (LANG-FULL E5). `alloc_array` pushes a new
+    /// `Vec<Value>` and binds its 0-based index as the array *handle* (an
+    /// `i64`); `array_get`/`array_set` index the `Vec` with a range check, and
+    /// `array_len` reads its length. This is the interpreter's representation of
+    /// the representation-agnostic IIR array — the managed backends use a native
+    /// array, the static backends a length-prefixed flat block, but the VM keeps
+    /// it simplest with a per-allocation `Vec` so distinct arrays never alias
+    /// (unlike the single Brainfuck byte-tape, which is one flat space).
+    arrays: Vec<Vec<Value>>,
+
     /// JIT handler registry.  When a `call` instruction names a function
     /// listed here, the handler is called instead of the interpreter.
     jit_handlers: HashMap<String, Box<dyn Fn(&[Value]) -> Value + Send + Sync>>,
@@ -181,6 +191,7 @@ impl VMCore {
             max_instructions: None, // unlimited — trusted code path
             frames: Vec::new(),
             memory: HashMap::new(),
+            arrays: Vec::new(),
             jit_handlers: HashMap::new(),
             extra_opcodes: HashMap::new(),
             builtins: BuiltinRegistry::new(),
@@ -302,6 +313,7 @@ impl VMCore {
             module_fns: &mut module.functions,
             builtins: &self.builtins,
             memory: &mut self.memory,
+            arrays: &mut self.arrays,
             u8_wrap: self.u8_wrap,
             max_frames: self.max_frames,
             max_memory_entries: self.max_memory_entries,
@@ -374,6 +386,7 @@ impl VMCore {
             module_fns: &mut module.functions,
             builtins: &self.builtins,
             memory: &mut self.memory,
+            arrays: &mut self.arrays,
             u8_wrap: self.u8_wrap,
             max_frames: self.max_frames,
             max_memory_entries: self.max_memory_entries,
@@ -1115,5 +1128,146 @@ mod tests {
         m.add_or_replace(fn_);
         let r = VMCore::new().execute(&mut m, "main", &[]).unwrap().unwrap();
         assert_eq!(r, Value::Float(-2.5));
+    }
+
+    // ---- E5: bounds-checked arrays ----
+
+    /// Helper: build `main` from instrs returning `ret_ty`, run, return result.
+    fn run_arr(instrs: Vec<IIRInstr>, ret_ty: &str) -> Result<Option<Value>, crate::errors::VMError> {
+        let fn_ = IIRFunction::new("main", vec![], ret_ty, instrs);
+        let mut m = IIRModule::new("test", "test");
+        m.add_or_replace(fn_);
+        VMCore::new().execute(&mut m, "main", &[])
+    }
+
+    /// `integer array A[3]; A[0]:=10; A[2]:=12; ret A[0]+A[2]` → 22.
+    #[test]
+    fn array_alloc_set_get_roundtrip() {
+        let r = run_arr(vec![
+            IIRInstr::new("const", Some("n".into()), vec![Operand::Int(3)], "i64"),
+            IIRInstr::new("alloc_array", Some("a".into()), vec![Operand::Var("n".into())], "array<i64>"),
+            IIRInstr::new("const", Some("i0".into()), vec![Operand::Int(0)], "i64"),
+            IIRInstr::new("const", Some("i2".into()), vec![Operand::Int(2)], "i64"),
+            IIRInstr::new("const", Some("v10".into()), vec![Operand::Int(10)], "i64"),
+            IIRInstr::new("const", Some("v12".into()), vec![Operand::Int(12)], "i64"),
+            IIRInstr::new("array_set", None, vec![Operand::Var("a".into()), Operand::Var("i0".into()), Operand::Var("v10".into())], "array<i64>"),
+            IIRInstr::new("array_set", None, vec![Operand::Var("a".into()), Operand::Var("i2".into()), Operand::Var("v12".into())], "array<i64>"),
+            IIRInstr::new("array_get", Some("x".into()), vec![Operand::Var("a".into()), Operand::Var("i0".into())], "i64"),
+            IIRInstr::new("array_get", Some("y".into()), vec![Operand::Var("a".into()), Operand::Var("i2".into())], "i64"),
+            IIRInstr::new("add", Some("r".into()), vec![Operand::Var("x".into()), Operand::Var("y".into())], "i64"),
+            IIRInstr::new("ret", None, vec![Operand::Var("r".into())], "i64"),
+        ], "i64");
+        assert_eq!(r.unwrap(), Some(Value::Int(22)));
+    }
+
+    /// A fresh array is zero-initialised: reading an unset element gives 0.
+    #[test]
+    fn array_default_initialised_to_zero() {
+        let r = run_arr(vec![
+            IIRInstr::new("const", Some("n".into()), vec![Operand::Int(4)], "i64"),
+            IIRInstr::new("alloc_array", Some("a".into()), vec![Operand::Var("n".into())], "array<i64>"),
+            IIRInstr::new("const", Some("i".into()), vec![Operand::Int(1)], "i64"),
+            IIRInstr::new("array_get", Some("r".into()), vec![Operand::Var("a".into()), Operand::Var("i".into())], "i64"),
+            IIRInstr::new("ret", None, vec![Operand::Var("r".into())], "i64"),
+        ], "i64");
+        assert_eq!(r.unwrap(), Some(Value::Int(0)));
+    }
+
+    /// `array_len` returns the element count.
+    #[test]
+    fn array_len_returns_count() {
+        let r = run_arr(vec![
+            IIRInstr::new("const", Some("n".into()), vec![Operand::Int(7)], "i64"),
+            IIRInstr::new("alloc_array", Some("a".into()), vec![Operand::Var("n".into())], "array<i64>"),
+            IIRInstr::new("array_len", Some("r".into()), vec![Operand::Var("a".into())], "i64"),
+            IIRInstr::new("ret", None, vec![Operand::Var("r".into())], "i64"),
+        ], "i64");
+        assert_eq!(r.unwrap(), Some(Value::Int(7)));
+    }
+
+    /// An `f64` array zero-inits to `0.0` and round-trips a real value.
+    #[test]
+    fn f64_array_roundtrips() {
+        let r = run_arr(vec![
+            IIRInstr::new("const", Some("n".into()), vec![Operand::Int(2)], "i64"),
+            IIRInstr::new("alloc_array", Some("a".into()), vec![Operand::Var("n".into())], "array<f64>"),
+            IIRInstr::new("const", Some("i".into()), vec![Operand::Int(0)], "i64"),
+            IIRInstr::new("const", Some("v".into()), vec![Operand::Float(2.5)], "f64"),
+            IIRInstr::new("array_set", None, vec![Operand::Var("a".into()), Operand::Var("i".into()), Operand::Var("v".into())], "array<f64>"),
+            IIRInstr::new("array_get", Some("r".into()), vec![Operand::Var("a".into()), Operand::Var("i".into())], "f64"),
+            IIRInstr::new("ret", None, vec![Operand::Var("r".into())], "f64"),
+        ], "f64");
+        assert_eq!(r.unwrap(), Some(Value::Float(2.5)));
+    }
+
+    /// An out-of-bounds `array_get` traps (the index check is by-definition).
+    #[test]
+    fn array_get_out_of_bounds_traps() {
+        let r = run_arr(vec![
+            IIRInstr::new("const", Some("n".into()), vec![Operand::Int(3)], "i64"),
+            IIRInstr::new("alloc_array", Some("a".into()), vec![Operand::Var("n".into())], "array<i64>"),
+            IIRInstr::new("const", Some("i".into()), vec![Operand::Int(5)], "i64"),
+            IIRInstr::new("array_get", Some("r".into()), vec![Operand::Var("a".into()), Operand::Var("i".into())], "i64"),
+            IIRInstr::new("ret", None, vec![Operand::Var("r".into())], "i64"),
+        ], "i64");
+        assert!(r.is_err(), "out-of-bounds array_get must trap, got {r:?}");
+    }
+
+    /// A negative index also traps (the lower-bound half of the check).
+    #[test]
+    fn array_set_negative_index_traps() {
+        let r = run_arr(vec![
+            IIRInstr::new("const", Some("n".into()), vec![Operand::Int(3)], "i64"),
+            IIRInstr::new("alloc_array", Some("a".into()), vec![Operand::Var("n".into())], "array<i64>"),
+            IIRInstr::new("const", Some("i".into()), vec![Operand::Int(-1)], "i64"),
+            IIRInstr::new("const", Some("v".into()), vec![Operand::Int(9)], "i64"),
+            IIRInstr::new("array_set", None, vec![Operand::Var("a".into()), Operand::Var("i".into()), Operand::Var("v".into())], "array<i64>"),
+            IIRInstr::new("ret", None, vec![Operand::Var("a".into())], "i64"),
+        ], "i64");
+        assert!(r.is_err(), "negative array_set index must trap, got {r:?}");
+    }
+
+    /// Distinct arrays do not alias (the per-allocation Vec model).
+    #[test]
+    fn distinct_arrays_do_not_alias() {
+        let r = run_arr(vec![
+            IIRInstr::new("const", Some("n".into()), vec![Operand::Int(2)], "i64"),
+            IIRInstr::new("alloc_array", Some("a".into()), vec![Operand::Var("n".into())], "array<i64>"),
+            IIRInstr::new("alloc_array", Some("b".into()), vec![Operand::Var("n".into())], "array<i64>"),
+            IIRInstr::new("const", Some("i".into()), vec![Operand::Int(0)], "i64"),
+            IIRInstr::new("const", Some("va".into()), vec![Operand::Int(11)], "i64"),
+            IIRInstr::new("const", Some("vb".into()), vec![Operand::Int(22)], "i64"),
+            IIRInstr::new("array_set", None, vec![Operand::Var("a".into()), Operand::Var("i".into()), Operand::Var("va".into())], "array<i64>"),
+            IIRInstr::new("array_set", None, vec![Operand::Var("b".into()), Operand::Var("i".into()), Operand::Var("vb".into())], "array<i64>"),
+            // a[0] must still be 11 (not clobbered by b[0]=22).
+            IIRInstr::new("array_get", Some("r".into()), vec![Operand::Var("a".into()), Operand::Var("i".into())], "i64"),
+            IIRInstr::new("ret", None, vec![Operand::Var("r".into())], "i64"),
+        ], "i64");
+        assert_eq!(r.unwrap(), Some(Value::Int(11)));
+    }
+
+    /// `max_memory_entries` is an **aggregate** ceiling: many small arrays whose
+    /// element counts sum past the cap must trap, not just one oversized array.
+    /// (Defeats an `alloc_array`-in-a-loop OOM, the E5 security-review finding.)
+    #[test]
+    fn aggregate_array_allocation_is_capped() {
+        let mut m = IIRModule::new("test", "test");
+        m.add_or_replace(IIRFunction::new(
+            "main",
+            vec![],
+            "i64",
+            vec![
+                IIRInstr::new("const", Some("n".into()), vec![Operand::Int(6)], "i64"),
+                // First 6-element array: fits under a cap of 10.
+                IIRInstr::new("alloc_array", Some("a".into()), vec![Operand::Var("n".into())], "array<i64>"),
+                // Second 6-element array: 6 + 6 = 12 > 10 → must trap.
+                IIRInstr::new("alloc_array", Some("b".into()), vec![Operand::Var("n".into())], "array<i64>"),
+                IIRInstr::new("ret", None, vec![Operand::Var("a".into())], "i64"),
+            ],
+        ));
+        let mut vm = VMCore::new();
+        vm.max_memory_entries = 10;
+        let r = vm.execute(&mut m, "main", &[]);
+        assert!(r.is_err(), "aggregate over-allocation must trap, got {r:?}");
     }
 }

--- a/code/packages/rust/vm-core/src/dispatch.rs
+++ b/code/packages/rust/vm-core/src/dispatch.rs
@@ -54,6 +54,9 @@ pub struct DispatchCtx<'a> {
     pub frames: &'a mut Vec<VMFrame>,
     pub module_fns: &'a mut Vec<interpreter_ir::function::IIRFunction>,
     pub memory: &'a mut HashMap<i64, Value>,
+    /// Heap of bounds-checked arrays (LANG-FULL E5). Indexed by the array
+    /// *handle* (`alloc_array`'s 0-based result). See [`crate::core::VMCore`].
+    pub arrays: &'a mut Vec<Vec<Value>>,
     pub builtins: &'a crate::builtins::BuiltinRegistry,
     pub u8_wrap: bool,
     pub max_frames: usize,
@@ -743,6 +746,135 @@ fn handle_store_byte(ctx: &mut DispatchCtx, instr: &IIRInstr) -> Result<Option<V
     Ok(None)
 }
 
+// Arrays (LANG-FULL E5) ------------------------------------------------------
+//
+// A bounded, indexable aggregate. `alloc_array count` allocates a fresh
+// `count`-element array (default-initialised by element type) and binds its
+// *handle* — the 0-based index into `ctx.arrays` — to `dest` as an `Int`.
+// `array_get`/`array_set` are **bounds-checked**: an out-of-range (or negative)
+// index is a `VMError` (the interpreter's analogue of the managed runtimes'
+// `IndexOutOfBoundsException` and the native backends' trap). This is the
+// representation-agnostic IIR array's reference implementation; see
+// `code/specs/lang-full-e5-arrays.md`.
+
+/// `alloc_array dest <- count : array<T>` — allocate a `count`-element array,
+/// each element the default for `T` (`f64` → `0.0`, everything else → `0`).
+fn handle_alloc_array(ctx: &mut DispatchCtx, instr: &IIRInstr) -> Result<Option<Value>, VMError> {
+    let count = {
+        let frame = ctx.frames.last().ok_or_else(|| VMError::Custom("no frame".into()))?;
+        resolve_src(frame, &instr.srcs, 0)?.as_i64()
+            .ok_or_else(|| VMError::Custom("alloc_array count must be an integer".into()))?
+    };
+    if count < 0 {
+        return Err(VMError::Custom(format!("alloc_array negative count {count}")));
+    }
+    // Make `max_memory_entries` a true **aggregate** ceiling for array storage,
+    // so neither a single huge `alloc_array i64::MAX` nor a loop allocating many
+    // arrays can OOM the process. We bound (a) the number of arrays (so an
+    // `alloc_array 0` spam loop can't grow the outer Vec unbounded) and (b) the
+    // running total of elements across every live array. The sum walks at most
+    // `arrays.len()` entries, itself bounded by the cap. (Parallels the byte-tape's
+    // `max_memory_entries` guard, generalised across allocations.)
+    if ctx.arrays.len() >= ctx.max_memory_entries {
+        return Err(VMError::Custom(format!(
+            "array count exceeds the {} allocation cap", ctx.max_memory_entries
+        )));
+    }
+    let live_elems: usize = ctx.arrays.iter().map(|a| a.len()).sum();
+    if live_elems.saturating_add(count as usize) > ctx.max_memory_entries {
+        return Err(VMError::Custom(format!(
+            "array length {count} would exceed the {} total-element cap (live: {live_elems})",
+            ctx.max_memory_entries
+        )));
+    }
+    // The element default: `f64` arrays zero to `0.0`; integer/other to `Int(0)`.
+    let elem = interpreter_ir::opcodes::array_elem_type(&instr.type_hint);
+    let default = if elem.as_deref() == Some("f64") || elem.as_deref() == Some("f32") {
+        Value::Float(0.0)
+    } else {
+        Value::Int(0)
+    };
+    let handle = ctx.arrays.len() as i64;
+    ctx.arrays.push(vec![default; count as usize]);
+    let value = Value::Int(handle);
+    if let Some(dest) = &instr.dest {
+        ctx.frames.last_mut().unwrap().assign(dest, value.clone());
+    }
+    Ok(Some(value))
+}
+
+/// `array_len dest <- arr` — the element count of array `arr`.
+fn handle_array_len(ctx: &mut DispatchCtx, instr: &IIRInstr) -> Result<Option<Value>, VMError> {
+    let handle = {
+        let frame = ctx.frames.last().ok_or_else(|| VMError::Custom("no frame".into()))?;
+        resolve_src(frame, &instr.srcs, 0)?.as_i64()
+            .ok_or_else(|| VMError::Custom("array_len: arr handle must be an integer".into()))?
+    };
+    let arr = array_ref(ctx, handle)?;
+    let value = Value::Int(arr.len() as i64);
+    if let Some(dest) = &instr.dest {
+        ctx.frames.last_mut().unwrap().assign(dest, value.clone());
+    }
+    Ok(Some(value))
+}
+
+/// `array_get dest <- arr, idx` — bounds-checked load `dest = arr[idx]`.
+fn handle_array_get(ctx: &mut DispatchCtx, instr: &IIRInstr) -> Result<Option<Value>, VMError> {
+    let (handle, idx) = {
+        let frame = ctx.frames.last().ok_or_else(|| VMError::Custom("no frame".into()))?;
+        let h = resolve_src(frame, &instr.srcs, 0)?.as_i64()
+            .ok_or_else(|| VMError::Custom("array_get: arr handle must be an integer".into()))?;
+        let i = resolve_src(frame, &instr.srcs, 1)?.as_i64()
+            .ok_or_else(|| VMError::Custom("array_get: index must be an integer".into()))?;
+        (h, i)
+    };
+    let arr = array_ref(ctx, handle)?;
+    let value = bounds_checked(arr, idx, "array_get")?.clone();
+    if let Some(dest) = &instr.dest {
+        ctx.frames.last_mut().unwrap().assign(dest, value.clone());
+    }
+    Ok(Some(value))
+}
+
+/// `array_set arr, idx, val` (no dest) — bounds-checked store `arr[idx] = val`.
+fn handle_array_set(ctx: &mut DispatchCtx, instr: &IIRInstr) -> Result<Option<Value>, VMError> {
+    let (handle, idx, val) = {
+        let frame = ctx.frames.last().ok_or_else(|| VMError::Custom("no frame".into()))?;
+        let h = resolve_src(frame, &instr.srcs, 0)?.as_i64()
+            .ok_or_else(|| VMError::Custom("array_set: arr handle must be an integer".into()))?;
+        let i = resolve_src(frame, &instr.srcs, 1)?.as_i64()
+            .ok_or_else(|| VMError::Custom("array_set: index must be an integer".into()))?;
+        let v = resolve_src(frame, &instr.srcs, 2)?;
+        (h, i, v)
+    };
+    // Bounds-check before mutating.
+    {
+        let arr = array_ref(ctx, handle)?;
+        bounds_checked(arr, idx, "array_set")?;
+    }
+    ctx.arrays[handle as usize][idx as usize] = val;
+    Ok(None)
+}
+
+/// Resolve an array handle to its backing `Vec`, or a clean error.
+fn array_ref<'c>(ctx: &'c DispatchCtx, handle: i64) -> Result<&'c Vec<Value>, VMError> {
+    if handle < 0 {
+        return Err(VMError::Custom(format!("invalid array handle {handle}")));
+    }
+    ctx.arrays.get(handle as usize)
+        .ok_or_else(|| VMError::Custom(format!("invalid array handle {handle}")))
+}
+
+/// Range-check `idx` against `arr` and return the element reference, or a trap.
+fn bounds_checked<'c>(arr: &'c [Value], idx: i64, op: &str) -> Result<&'c Value, VMError> {
+    if idx < 0 || idx as usize >= arr.len() {
+        return Err(VMError::Custom(format!(
+            "{op}: index {idx} out of bounds for array of length {}", arr.len()
+        )));
+    }
+    Ok(&arr[idx as usize])
+}
+
 // Function calls ------------------------------------------------------------
 
 /// Handle a `call fn_name arg1 arg2 …` instruction.
@@ -960,6 +1092,10 @@ pub(crate) fn lookup_standard(op: &str) -> Option<StdHandlerFn> {
         "alloc_bytes"  => Some(handle_alloc_bytes),
         "load_byte"    => Some(handle_load_byte),
         "store_byte"   => Some(handle_store_byte),
+        "alloc_array"  => Some(handle_alloc_array),
+        "array_len"    => Some(handle_array_len),
+        "array_get"    => Some(handle_array_get),
+        "array_set"    => Some(handle_array_set),
         "call_builtin" => Some(handle_call_builtin),
         "io_in"        => Some(handle_io_in),
         "io_out"       => Some(handle_io_out),

--- a/code/specs/lang-full-e5-arrays.md
+++ b/code/specs/lang-full-e5-arrays.md
@@ -160,10 +160,12 @@ E5 is large, so it ships as a sequence, each a `feat(lang-full): …` PR babysat
 merge before the next:
 
 0. **E5-spec** (this document) — committed specs-first, for design sign-off.
-1. **E5-ir + vm** — define the 4 ops + `array<T>` type helpers in `interpreter-ir`;
-   implement bounds-checked execution in `vm-core` (+ jit-core). Unit tests:
-   alloc/len/get/set, and an out-of-bounds trap. *No matrix Prog yet (needs a
-   frontend), but a direct IIR unit test proves it runs.*
+1. **E5-ir + vm** — ✅ **done** (interpreter-ir 0.7.0, vm-core 0.7.0). The 4 ops +
+   `array<T>` type helpers in `interpreter-ir`; bounds-checked execution in
+   `vm-core` (per-allocation `Vec<Value>` heap, default-init, OOB → `VMError`).
+   7 unit tests incl. out-of-bounds + negative-index traps and no-alias. (jit-core
+   array execution deferred to a later slice — it has no byte-tape either; the
+   matrix Jit column joins with the frontend PR.)
 2. **E5-algol-frontend** — `algol-iir-compiler` lowers `integer array` decls +
    subscripts (AL2, 1-D first); a matrix `Prog` runs on VM + JIT.
 3. **E5-managed-backends** — JVM, CLR, WASM array lowering (native managed


### PR DESCRIPTION
## E5 PR-1 of the array enabler

First implementation slice of **enabler E5 (arrays)** per the merged design spec [`code/specs/lang-full-e5-arrays.md`](code/specs/lang-full-e5-arrays.md). Defines the representation-agnostic IIR surface and the reference-interpreter execution. No backend lowers arrays yet except `vm-core` (the reference interpreter); managed backends, static backends, and the ALGOL frontend follow one PR at a time.

### `interpreter-ir` 0.6.0 → 0.7.0
- `array<T>` type helpers (`make_array_type` / `is_array_type` / `array_elem_type`), mirroring the existing `ref<T>` helpers.
- Four opcodes: `alloc_array` (→ `array<T>`), `array_len` (→ `i64`), `array_get` (bounds-checked load → `T`), `array_set` (bounds-checked store). New `is_array_op` predicate; the value-producing three join `is_value_producing`, `alloc_array` joins `is_allocating`.

### `vm-core` 0.6.0 → 0.7.0
- New `arrays: Vec<Vec<Value>>` heap. `alloc_array count` pushes a fresh `count`-element `Vec` (default-init `f64`→`0.0`, else `0`); the 0-based index is the array handle.
- `array_get` / `array_set` are **bounds-checked**: a negative or `>= len` index returns a `VMError` — the interpreter's analogue of the managed runtimes' `IndexOutOfBoundsException` and the native backends' `ud2`/`udf` trap.
- Per-allocation `Vec`s ⇒ **distinct arrays never alias**.
- `max_memory_entries` enforced as a true **aggregate** ceiling (array count + total live elements) so neither one oversized alloc nor a loop of allocs can OOM. *(Hardening from the security review.)*

### Verification
- **8 vm-core unit tests** — round-trip, default-init, length, f64 arrays, out-of-bounds trap, negative-index trap, no-alias, aggregate cap. All pass (`cargo test -p vm-core`: 60 + 6 doctests green).
- interpreter-ir tests green; downstream `jit-core` + `lang-aot` build clean.
- No matrix `Prog` yet (needs a frontend) — a direct IIR unit test proves it runs; the matrix VM/JIT column joins in **E5 PR-2** (ALGOL frontend).

### Security
`/security-review` ran on the inline diff → memory-safety **passed** (every direct `Vec` index guarded; negatives rejected before `usize` cast; no `unsafe`; no aliasing). The one Low/informational finding (aggregate OOM) is fixed in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)