### PR TITLE
feat(ruby): trailing block on receiver/dotted method calls (RB1)

### DIFF
--- a/code/grammars/ruby.grammar
+++ b/code/grammars/ruby.grammar
@@ -424,7 +424,7 @@ rightward_assignment = expression "=>" NAME ;
 # Setter calls (`foo.bar = 1`) and bracket access (`arr[0]`) are
 # deliberately out of scope for this chunk — they get their own phases.
 method_call  = ( NAME | KEYWORD ) LPAREN [ call_arg { COMMA call_arg } ] RPAREN { dot_call } ;
-dot_call     = "." ( NAME | KEYWORD ) [ LPAREN [ call_arg { COMMA call_arg } ] RPAREN ] ;
+dot_call     = "." ( NAME | KEYWORD ) [ LPAREN [ call_arg { COMMA call_arg } ] RPAREN ] [ block ] ;
 # Phase 15d (FC) — scope-resolution operator `Foo::Bar` (and chains
 # `A::B::C`).  The lexer emits `::` as a `Colon` token whose VALUE is
 # "::", so the grammar literal `"::"` matches it by value.  A

--- a/code/packages/rust/ruby-parser/CHANGELOG.md
+++ b/code/packages/rust/ruby-parser/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to the `coding-adventures-ruby-parser` crate will be documented in this file.
 
+## [0.79.0] - 2026-06-19
+
+### Added (RB1 — trailing block on receiver/dotted method calls)
+
+- `dot_call` now accepts an optional trailing `block`:
+  `dot_call = "." (NAME|KEYWORD) [ LPAREN [args] RPAREN ] [ block ] ;`.
+  This makes the dominant Ruby iterator idiom parse — `[1, 2].each { |x|
+  … }` and `foo.bar do … end` — which previously parse-panicked because a
+  block could only follow a *bare-name* call (`method_with_block`), never
+  a receiver/dotted call. `_grammar.rs` regenerated from `ruby.grammar`
+  via `grammar-tools`. Full parser suite unchanged (268 tests); the new
+  optional block is greedy but does not regress existing hash-literal or
+  chain parses.
+
 ## [0.78.0] - 2026-06-03
 
 ### Added (FC — array splat and find patterns)

--- a/code/packages/rust/ruby-parser/src/_grammar.rs
+++ b/code/packages/rust/ruby-parser/src/_grammar.rs
@@ -759,6 +759,7 @@ pub fn parser_grammar() -> ParserGrammar {
                             ] }) },
                         GrammarElement::TokenReference { name: r#"RPAREN"#.to_string() },
                     ] }) },
+                GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"block"#.to_string() }) },
             ] },
             line_number: 427,
         },

--- a/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to the `ruby-to-semantic-ir` crate will be documented in this file.
 
+## [0.94.0] - 2026-06-19
+
+### Added (RB1 — hoist a trailing block on a receiver/dotted method call)
+
+- `fold_one_dot_call` now detects the optional trailing `block` the
+  grammar admits on a `dot_call` (`recv.each { … }` / `recv.each do …
+  end`), hoists it to a top-level Function via `hoist_block_to_function`,
+  and appends the resulting `MakeClosure` as the `__method__` envelope's
+  trailing argument — mirroring `method_with_block` for bare-name calls.
+  Previously the block was silently dropped (lowered as a plain
+  `__method__(recv, "each")`). Captures remain empty in v0 (shared
+  block-closure limitation).
+- New tests: `receiver_method_brace_block_is_hoisted_and_attached`,
+  `receiver_method_do_end_block_is_hoisted_and_attached`,
+  `receiver_method_without_block_has_no_closure`. Each validates.
+
+### Notes
+
+- This is RB1 of the receiver-block series. Threading the block as the
+  enclosing method's implicit block when its body `yield`s (RB2 / the
+  reopened Q10d) and backend execution-proof (RB3) follow as separate PRs.
+
 ## [0.93.0] - 2026-06-19
 
 ### Added (Q10c — parenless/argless call to a yielding method)

--- a/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
@@ -5415,6 +5415,66 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
+    // RB1 — trailing block on a receiver/dotted method call
+    // (`recv.each { … }` / `recv.each do … end`).  The block is hoisted to
+    // a top-level Function and attached as the `__method__` envelope's
+    // trailing MakeClosure argument (previously the block was dropped /
+    // the whole construct failed to parse).
+    // -----------------------------------------------------------------------
+
+    /// The hoisted block function name on a `__method__` call's trailing
+    /// `MakeClosure` argument, if present.
+    fn method_block_closure(e: &Expr) -> Option<&str> {
+        if let Expr::BuiltinCall { name, args, .. } = e {
+            if name == "__method__" {
+                if let Some(Expr::MakeClosure { fn_name, .. }) = args.last() {
+                    return Some(fn_name.as_str());
+                }
+            }
+        }
+        None
+    }
+
+    #[test]
+    fn receiver_method_brace_block_is_hoisted_and_attached() {
+        let m = lower("[1, 2].each { |x| puts x }\n");
+        let v = &main_body(&m).value;
+        let blk = method_block_closure(v)
+            .expect("each-with-block must attach a hoisted MakeClosure");
+        // The hoisted function exists and carries the block body.
+        let bf = m.functions.iter().find(|f| f.name == blk).expect("hoisted block fn");
+        assert!(
+            !bf.body.stmts.is_empty() || !matches!(bf.body.value, Expr::NilLit { .. }),
+            "hoisted block must carry its body"
+        );
+        assert!(semantic_ir::validate(&m).is_ok(), "validates: {:?}", semantic_ir::validate(&m));
+    }
+
+    #[test]
+    fn receiver_method_do_end_block_is_hoisted_and_attached() {
+        let m = lower("[1, 2].each do |x|\n  puts x\nend\n");
+        let v = &main_body(&m).value;
+        assert!(
+            method_block_closure(v).is_some(),
+            "do/end block on a receiver call must attach a MakeClosure, got {:?}",
+            v
+        );
+        assert!(semantic_ir::validate(&m).is_ok(), "validates: {:?}", semantic_ir::validate(&m));
+    }
+
+    #[test]
+    fn receiver_method_without_block_has_no_closure() {
+        // A plain dotted call keeps its `__method__` shape with no trailing
+        // closure (the block arm must not fire spuriously).
+        let m = lower("[1, 2].length\n");
+        assert!(
+            method_block_closure(&main_body(&m).value).is_none(),
+            "no block ⇒ no MakeClosure on the __method__ envelope"
+        );
+        assert!(semantic_ir::validate(&m).is_ok());
+    }
+
+    // -----------------------------------------------------------------------
     // Phase Q10b — block_given? → not(null?(__sir_block__))
     // -----------------------------------------------------------------------
 
@@ -7842,6 +7902,3 @@ b = "y"
         );
     }
 }
-
-
-

--- a/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
@@ -7533,13 +7533,33 @@ impl Lowerer {
         // The synthetic StrLit triggers the Strings feature, which the
         // post-pass adds to the manifest unconditionally.
         self.features_used.insert(Feature::Strings);
-        let mut full_args = Vec::with_capacity(args.len() + 2);
+        let mut full_args = Vec::with_capacity(args.len() + 3);
         full_args.push(receiver);
         full_args.push(Expr::StrLit {
             value: method_name,
             span: name_span,
         });
         full_args.extend(args);
+
+        // RB1 (FC) — a trailing block on a receiver/dotted method call
+        // (`recv.each { … }` / `recv.each do … end`).  The grammar now
+        // admits an optional `block` after the dot_call's argument list;
+        // hoist it to a top-level Function and append the resulting
+        // `MakeClosure` as the call's trailing argument, exactly as
+        // `method_with_block` does for bare-name calls.  Without this the
+        // block would be silently dropped.  Captures are empty in v0
+        // (block bodies referencing outer locals remain a known
+        // limitation, shared with `method_with_block`).
+        if let Some(block_node) = self.find_node_child(dot_node, "block") {
+            let fn_name = self.hoist_block_to_function(block_node)?;
+            full_args.push(Expr::MakeClosure {
+                fn_name,
+                captures: Vec::new(),
+                span: self.span_of(block_node),
+            });
+            self.features_used.insert(Feature::Closures);
+        }
+
         Ok(Expr::BuiltinCall {
             name: "__method__".to_string(),
             args: full_args,


### PR DESCRIPTION
## RB1 — trailing block on receiver/dotted method calls

Fixes the real grammar gap behind the dominant Ruby iterator idiom:
`[1, 2].each { |x| ... }` and `foo.bar do ... end` previously
**parse-panicked**. A block could only follow a *bare-name* call
(`method_with_block`), never a receiver/dotted call.

(This is also the correction to an earlier mistaken "yield/return inside a
block is grammar-unreachable" finding — the true cause was that
receiver-blocks didn't parse at all.)

### Grammar
```
dot_call = "." (NAME|KEYWORD) [ LPAREN [args] RPAREN ] [ block ] ;   # + [block]
```
`_grammar.rs` regenerated from `ruby.grammar` via `grammar-tools`.

### Lowerer
`fold_one_dot_call` detects the trailing `block`, hoists it to a top-level
Function (`hoist_block_to_function`), and appends the resulting
`MakeClosure` as the `__method__` envelope's trailing argument — mirroring
`method_with_block`. Previously the block was silently dropped.

### Tests / no regressions
- New: `receiver_method_brace_block_is_hoisted_and_attached`,
  `receiver_method_do_end_block_is_hoisted_and_attached`,
  `receiver_method_without_block_has_no_closure`.
- Suites green: ruby-parser 268, ruby-to-semantic-ir 363,
  semantic-ir-to-python 59, semantic-ir-to-typescript 70. clippy clean.

### Series
RB1 of the receiver-block work. **RB2** threads the block as the enclosing
method's implicit block when its body `yield`s (the reopened Q10d);
**RB3** adds backend execution-proof (`.each { }` → Python/TS). v0:
block-closure captures remain empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
