### PR TITLE
[codex] Add mesh release ticket handoff work-order readiness summary

### DIFF
--- a/code/packages/rust/smart-home-integration-catalog/CHANGELOG.md
+++ b/code/packages/rust/smart-home-integration-catalog/CHANGELOG.md
@@ -158,6 +158,9 @@ All notable changes to this package will be documented in this file.
   for combining handoff readiness with execution slot state.
 - `IntegrationMeshReleaseTicketHandoffExecutionWorkOrder` and summary helpers
   for turning release handoff execution slots into lane-scoped work orders.
+- `IntegrationMeshReleaseTicketHandoffWorkOrderReadinessSummary` and helpers
+  for combining handoff execution readiness with deterministic work-order lane
+  state.
 - Primitive backlog planning helpers for ranking the shared primitive families
   needed by priority-bounded rollout waves.
 - Integration activation planning helpers for resolving virtual aliases,

--- a/code/packages/rust/smart-home-integration-catalog/README.md
+++ b/code/packages/rust/smart-home-integration-catalog/README.md
@@ -131,6 +131,8 @@ runtime and Chief of Staff tools a typed catalog for:
   handoff readiness with deterministic execution slot state
 - low-level mesh release ticket handoff execution work orders that turn
   execution slots into lane-scoped operator work
+- mesh release ticket handoff work-order readiness summaries that combine
+  handoff execution readiness with deterministic work-order lane state
 - primitive backlog planning for prioritizing the shared families needed by a
   rollout wave
 - activation plans that resolve direct integrations, virtual aliases, and

--- a/code/packages/rust/smart-home-integration-catalog/src/lib.rs
+++ b/code/packages/rust/smart-home-integration-catalog/src/lib.rs
@@ -7602,6 +7602,267 @@ impl IntegrationMeshReleaseTicketHandoffExecutionWorkOrderSummary {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IntegrationMeshReleaseTicketHandoffWorkOrderReadinessSummary {
+    pub release_ticket_handoff_execution_readiness_summary:
+        IntegrationMeshReleaseTicketHandoffExecutionReadinessSummary,
+    pub release_ticket_handoff_execution_work_order_summary:
+        IntegrationMeshReleaseTicketHandoffExecutionWorkOrderSummary,
+    pub total_tickets: usize,
+    pub ready_tickets: usize,
+    pub blocked_tickets: usize,
+    pub review_required_tickets: usize,
+    pub operator_required_tickets: usize,
+    pub dispatch_required_tickets: usize,
+    pub total_handoff_packets: usize,
+    pub total_execution_slots: usize,
+    pub total_work_orders: usize,
+    pub ready_work_orders: usize,
+    pub blocked_work_orders: usize,
+    pub review_required_work_orders: usize,
+    pub operator_required_work_orders: usize,
+    pub dispatch_required_work_orders: usize,
+    pub release_lane_work_orders: usize,
+    pub operator_lane_work_orders: usize,
+    pub repair_lane_work_orders: usize,
+    pub review_lane_work_orders: usize,
+    pub execution_required_work_orders: usize,
+    pub queued_substrate_actions: usize,
+    pub remediation_item_count: usize,
+    pub review_required_packages: usize,
+    pub operator_required_packages: usize,
+    pub blocked_packages: usize,
+    pub first_execution_slot_key: Option<String>,
+    pub first_work_order_key: Option<String>,
+    pub first_release_work_order_key: Option<String>,
+    pub next_work_order_key: Option<String>,
+    pub next_execution_slot_key: Option<String>,
+    pub next_packet_key: Option<String>,
+    pub next_ticket_key: Option<String>,
+    pub next_dispatch_key: Option<String>,
+    pub next_task_key: Option<String>,
+    pub next_slot_key: Option<String>,
+    pub next_check_kind: Option<IntegrationMeshReleaseReadinessCheckKind>,
+    pub next_check_status: Option<IntegrationMeshReleaseReadinessStatus>,
+    pub next_package_kind: Option<IntegrationMeshReadinessHandoffKind>,
+    pub next_handoff_status: Option<IntegrationMeshReadinessHandoffStatus>,
+    pub next_handoff_lane: Option<IntegrationMeshReleaseDispatchTicketHandoffLane>,
+    pub packet_status: IntegrationMeshReleaseReadinessStatus,
+    pub execution_status: IntegrationMeshReleaseReadinessStatus,
+    pub release_packet_ready: bool,
+    pub release_execution_ready: bool,
+    pub release_tasks_ready: bool,
+    pub release_dispatch_ready: bool,
+    pub release_ticket_ready: bool,
+    pub release_handoff_ready: bool,
+    pub release_handoff_execution_ready: bool,
+    pub release_ticket_handoff_execution_ready: bool,
+    pub release_handoff_execution_work_orders_ready: bool,
+    pub release_ticket_handoff_work_orders_ready: bool,
+}
+
+impl IntegrationMeshReleaseTicketHandoffWorkOrderReadinessSummary {
+    pub fn from_summaries(
+        release_ticket_handoff_execution_readiness_summary: IntegrationMeshReleaseTicketHandoffExecutionReadinessSummary,
+        release_ticket_handoff_execution_work_order_summary: IntegrationMeshReleaseTicketHandoffExecutionWorkOrderSummary,
+    ) -> Self {
+        let release_ticket_handoff_work_orders_ready =
+            release_ticket_handoff_execution_readiness_summary
+                .ready_for_release_ticket_handoff_execution()
+                && release_ticket_handoff_execution_work_order_summary
+                    .ready_for_release_handoff_execution_work_orders();
+
+        Self {
+            total_tickets: release_ticket_handoff_execution_readiness_summary.total_tickets,
+            ready_tickets: release_ticket_handoff_execution_readiness_summary.ready_tickets,
+            blocked_tickets: release_ticket_handoff_execution_readiness_summary.blocked_tickets,
+            review_required_tickets: release_ticket_handoff_execution_readiness_summary
+                .review_required_tickets,
+            operator_required_tickets: release_ticket_handoff_execution_readiness_summary
+                .operator_required_tickets,
+            dispatch_required_tickets: release_ticket_handoff_execution_readiness_summary
+                .dispatch_required_tickets,
+            total_handoff_packets: release_ticket_handoff_execution_readiness_summary
+                .total_handoff_packets,
+            total_execution_slots: release_ticket_handoff_execution_readiness_summary
+                .total_execution_slots,
+            total_work_orders: release_ticket_handoff_execution_work_order_summary
+                .total_work_orders,
+            ready_work_orders: release_ticket_handoff_execution_work_order_summary
+                .ready_work_orders,
+            blocked_work_orders: release_ticket_handoff_execution_work_order_summary
+                .blocked_work_orders,
+            review_required_work_orders: release_ticket_handoff_execution_work_order_summary
+                .review_required_work_orders,
+            operator_required_work_orders: release_ticket_handoff_execution_work_order_summary
+                .operator_required_work_orders,
+            dispatch_required_work_orders: release_ticket_handoff_execution_work_order_summary
+                .dispatch_required_work_orders,
+            release_lane_work_orders: release_ticket_handoff_execution_work_order_summary
+                .release_lane_work_orders,
+            operator_lane_work_orders: release_ticket_handoff_execution_work_order_summary
+                .operator_lane_work_orders,
+            repair_lane_work_orders: release_ticket_handoff_execution_work_order_summary
+                .repair_lane_work_orders,
+            review_lane_work_orders: release_ticket_handoff_execution_work_order_summary
+                .review_lane_work_orders,
+            execution_required_work_orders: release_ticket_handoff_execution_work_order_summary
+                .execution_required_work_orders,
+            queued_substrate_actions: release_ticket_handoff_execution_readiness_summary
+                .queued_substrate_actions,
+            remediation_item_count: release_ticket_handoff_execution_readiness_summary
+                .remediation_item_count,
+            review_required_packages: release_ticket_handoff_execution_readiness_summary
+                .review_required_packages,
+            operator_required_packages: release_ticket_handoff_execution_readiness_summary
+                .operator_required_packages,
+            blocked_packages: release_ticket_handoff_execution_readiness_summary.blocked_packages,
+            first_execution_slot_key: release_ticket_handoff_execution_readiness_summary
+                .first_execution_slot_key
+                .clone(),
+            first_work_order_key: release_ticket_handoff_execution_work_order_summary
+                .first_work_order_key
+                .clone(),
+            first_release_work_order_key: release_ticket_handoff_execution_work_order_summary
+                .first_release_work_order_key
+                .clone(),
+            next_work_order_key: release_ticket_handoff_execution_work_order_summary
+                .next_work_order_key
+                .clone(),
+            next_execution_slot_key: release_ticket_handoff_execution_work_order_summary
+                .next_execution_slot_key
+                .clone(),
+            next_packet_key: release_ticket_handoff_execution_work_order_summary
+                .next_packet_key
+                .clone(),
+            next_ticket_key: release_ticket_handoff_execution_work_order_summary
+                .next_ticket_key
+                .clone(),
+            next_dispatch_key: release_ticket_handoff_execution_work_order_summary
+                .next_dispatch_key
+                .clone(),
+            next_task_key: release_ticket_handoff_execution_work_order_summary
+                .next_task_key
+                .clone(),
+            next_slot_key: release_ticket_handoff_execution_work_order_summary
+                .next_slot_key
+                .clone(),
+            next_check_kind: release_ticket_handoff_execution_work_order_summary.next_check_kind,
+            next_check_status: release_ticket_handoff_execution_work_order_summary
+                .next_check_status,
+            next_package_kind: release_ticket_handoff_execution_work_order_summary
+                .next_package_kind,
+            next_handoff_status: release_ticket_handoff_execution_work_order_summary
+                .next_handoff_status,
+            next_handoff_lane: release_ticket_handoff_execution_work_order_summary
+                .next_handoff_lane,
+            packet_status: release_ticket_handoff_execution_readiness_summary.packet_status,
+            execution_status: release_ticket_handoff_execution_readiness_summary.execution_status,
+            release_packet_ready: release_ticket_handoff_execution_readiness_summary
+                .release_packet_ready,
+            release_execution_ready: release_ticket_handoff_execution_readiness_summary
+                .release_execution_ready,
+            release_tasks_ready: release_ticket_handoff_execution_readiness_summary
+                .release_tasks_ready,
+            release_dispatch_ready: release_ticket_handoff_execution_readiness_summary
+                .release_dispatch_ready,
+            release_ticket_ready: release_ticket_handoff_execution_readiness_summary
+                .release_ticket_ready,
+            release_handoff_ready: release_ticket_handoff_execution_readiness_summary
+                .release_handoff_ready,
+            release_handoff_execution_ready: release_ticket_handoff_execution_readiness_summary
+                .release_handoff_execution_ready,
+            release_ticket_handoff_execution_ready:
+                release_ticket_handoff_execution_readiness_summary
+                    .release_ticket_handoff_execution_ready,
+            release_handoff_execution_work_orders_ready:
+                release_ticket_handoff_execution_work_order_summary
+                    .release_handoff_execution_work_orders_ready,
+            release_ticket_handoff_work_orders_ready,
+            release_ticket_handoff_execution_readiness_summary,
+            release_ticket_handoff_execution_work_order_summary,
+        }
+    }
+
+    pub fn has_work_orders(&self) -> bool {
+        self.total_work_orders > 0
+    }
+
+    pub fn ready_for_release_ticket_handoff_work_orders(&self) -> bool {
+        self.execution_status == IntegrationMeshReleaseReadinessStatus::Ready
+            && self.release_packet_ready
+            && self.release_execution_ready
+            && self.release_tasks_ready
+            && self.release_dispatch_ready
+            && self.release_ticket_ready
+            && self.release_handoff_ready
+            && self.release_handoff_execution_ready
+            && self.release_ticket_handoff_execution_ready
+            && self.release_handoff_execution_work_orders_ready
+            && self.release_ticket_handoff_work_orders_ready
+            && !self.requires_attention()
+    }
+
+    pub fn has_repair_work(&self) -> bool {
+        self.repair_lane_work_orders > 0
+            || self
+                .release_ticket_handoff_execution_readiness_summary
+                .has_repair_work()
+            || self
+                .release_ticket_handoff_execution_work_order_summary
+                .has_repair_work()
+    }
+
+    pub fn has_blockers(&self) -> bool {
+        self.blocked_work_orders > 0
+            || self.blocked_packages > 0
+            || self.has_repair_work()
+            || self
+                .release_ticket_handoff_execution_readiness_summary
+                .has_blockers()
+            || self
+                .release_ticket_handoff_execution_work_order_summary
+                .has_blockers()
+    }
+
+    pub fn has_review_work(&self) -> bool {
+        self.review_required_work_orders > 0
+            || self.review_lane_work_orders > 0
+            || self.review_required_packages > 0
+            || self
+                .release_ticket_handoff_execution_readiness_summary
+                .has_review_work()
+            || self
+                .release_ticket_handoff_execution_work_order_summary
+                .has_review_work()
+    }
+
+    pub fn needs_operator(&self) -> bool {
+        self.operator_required_work_orders > 0
+            || self.operator_lane_work_orders > 0
+            || self.operator_required_packages > 0
+            || self
+                .release_ticket_handoff_execution_readiness_summary
+                .needs_operator()
+            || self
+                .release_ticket_handoff_execution_work_order_summary
+                .needs_operator()
+    }
+
+    pub fn requires_execution(&self) -> bool {
+        self.execution_required_work_orders > 0
+    }
+
+    pub fn requires_attention(&self) -> bool {
+        self.requires_execution()
+            || self.dispatch_required_work_orders > 0
+            || self.has_blockers()
+            || self.has_review_work()
+            || self.needs_operator()
+            || !self.release_ticket_handoff_work_orders_ready
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct IntegrationCatalogEntry {
     pub integration_id: IntegrationId,
     pub display_name: String,
@@ -29396,6 +29657,47 @@ pub fn mesh_release_ticket_handoff_execution_work_order_summary(
     )
 }
 
+pub fn mesh_release_ticket_handoff_work_order_readiness_summary_for_catalog(
+    catalog: &[IntegrationCatalogEntry],
+    available_primitives: &[PrimitiveFamily],
+    allowed_capabilities: &[CapabilityId],
+    enabled_integrations: &[IntegrationId],
+) -> IntegrationMeshReleaseTicketHandoffWorkOrderReadinessSummary {
+    let release_ticket_handoff_execution_readiness_summary =
+        mesh_release_ticket_handoff_execution_readiness_summary_for_catalog(
+            catalog,
+            available_primitives,
+            allowed_capabilities,
+            enabled_integrations,
+        );
+    let release_ticket_handoff_execution_work_order_summary =
+        mesh_release_ticket_handoff_execution_work_order_summary_for_catalog(
+            catalog,
+            available_primitives,
+            allowed_capabilities,
+            enabled_integrations,
+        );
+
+    IntegrationMeshReleaseTicketHandoffWorkOrderReadinessSummary::from_summaries(
+        release_ticket_handoff_execution_readiness_summary,
+        release_ticket_handoff_execution_work_order_summary,
+    )
+}
+
+pub fn mesh_release_ticket_handoff_work_order_readiness_summary(
+    available_primitives: &[PrimitiveFamily],
+    allowed_capabilities: &[CapabilityId],
+    enabled_integrations: &[IntegrationId],
+) -> IntegrationMeshReleaseTicketHandoffWorkOrderReadinessSummary {
+    let catalog = first_party_catalog();
+    mesh_release_ticket_handoff_work_order_readiness_summary_for_catalog(
+        &catalog,
+        available_primitives,
+        allowed_capabilities,
+        enabled_integrations,
+    )
+}
+
 fn mesh_protocol_catalog_entries(
     catalog: &[IntegrationCatalogEntry],
 ) -> Vec<IntegrationCatalogEntry> {
@@ -40921,6 +41223,237 @@ mod tests {
         assert!(work_orders
             .iter()
             .all(|work_order| work_order.is_release_lane() && !work_order.execution_required()));
+    }
+
+    #[test]
+    fn mesh_release_ticket_handoff_work_order_readiness_summary_surfaces_work_order_attention() {
+        let available_primitives = vec![
+            PrimitiveFamily::Usb,
+            PrimitiveFamily::SerialController,
+            PrimitiveFamily::Radio802154,
+            PrimitiveFamily::Supervision,
+        ];
+        let allowed_capabilities = vec![CapabilityId::trusted("smart_home.read")];
+        let summary = mesh_release_ticket_handoff_work_order_readiness_summary(
+            &available_primitives,
+            &allowed_capabilities,
+            &[],
+        );
+
+        assert_eq!(summary.total_tickets, 5);
+        assert_eq!(summary.ready_tickets, 0);
+        assert_eq!(summary.blocked_tickets, 3);
+        assert_eq!(summary.review_required_tickets, 2);
+        assert_eq!(summary.operator_required_tickets, 4);
+        assert_eq!(summary.dispatch_required_tickets, 5);
+        assert_eq!(summary.total_handoff_packets, 5);
+        assert_eq!(summary.total_execution_slots, 5);
+        assert_eq!(summary.total_work_orders, 5);
+        assert_eq!(summary.ready_work_orders, 0);
+        assert_eq!(summary.blocked_work_orders, 3);
+        assert_eq!(summary.review_required_work_orders, 2);
+        assert_eq!(summary.operator_required_work_orders, 4);
+        assert_eq!(summary.dispatch_required_work_orders, 5);
+        assert_eq!(summary.release_lane_work_orders, 0);
+        assert_eq!(summary.repair_lane_work_orders, 3);
+        assert_eq!(summary.review_lane_work_orders, 2);
+        assert_eq!(summary.execution_required_work_orders, 5);
+        assert_eq!(summary.queued_substrate_actions, 5);
+        assert_eq!(summary.remediation_item_count, 2);
+        assert_eq!(summary.review_required_packages, 1);
+        assert_eq!(summary.operator_required_packages, 6);
+        assert_eq!(summary.blocked_packages, 5);
+        assert_eq!(
+            summary.first_execution_slot_key,
+            Some("release-ticket-handoff-execution-slot-01-repair-substrate_actions".to_string())
+        );
+        assert_eq!(
+            summary.first_work_order_key,
+            Some(
+                "release-ticket-handoff-execution-work-order-01-repair-substrate_actions"
+                    .to_string()
+            )
+        );
+        assert_eq!(
+            summary.next_work_order_key,
+            Some(
+                "release-ticket-handoff-execution-work-order-01-repair-substrate_actions"
+                    .to_string()
+            )
+        );
+        assert_eq!(
+            summary.next_execution_slot_key,
+            Some("release-ticket-handoff-execution-slot-01-repair-substrate_actions".to_string())
+        );
+        assert_eq!(
+            summary.next_packet_key,
+            Some("release-dispatch-handoff-packet-01-substrate_actions".to_string())
+        );
+        assert_eq!(
+            summary.next_ticket_key,
+            Some("release-dispatch-ticket-01-substrate_actions".to_string())
+        );
+        assert_eq!(
+            summary.next_dispatch_key,
+            Some("release-task-dispatch-01-substrate_actions".to_string())
+        );
+        assert_eq!(
+            summary.next_task_key,
+            Some("release-execution-task-01-substrate_actions".to_string())
+        );
+        assert_eq!(
+            summary.next_slot_key,
+            Some("release-check-slot-01-substrate_actions".to_string())
+        );
+        assert_eq!(
+            summary.next_check_kind,
+            Some(IntegrationMeshReleaseReadinessCheckKind::SubstrateActions)
+        );
+        assert_eq!(
+            summary.next_check_status,
+            Some(IntegrationMeshReleaseReadinessStatus::Blocked)
+        );
+        assert_eq!(
+            summary.next_package_kind,
+            Some(IntegrationMeshReadinessHandoffKind::SubstrateAction)
+        );
+        assert_eq!(
+            summary.next_handoff_status,
+            Some(IntegrationMeshReadinessHandoffStatus::Blocked)
+        );
+        assert_eq!(
+            summary.next_handoff_lane,
+            Some(IntegrationMeshReleaseDispatchTicketHandoffLane::Repair)
+        );
+        assert_eq!(
+            summary.packet_status,
+            IntegrationMeshReleaseReadinessStatus::Blocked
+        );
+        assert_eq!(
+            summary.execution_status,
+            IntegrationMeshReleaseReadinessStatus::Blocked
+        );
+        assert!(!summary.release_packet_ready);
+        assert!(!summary.release_execution_ready);
+        assert!(!summary.release_tasks_ready);
+        assert!(!summary.release_dispatch_ready);
+        assert!(!summary.release_ticket_ready);
+        assert!(!summary.release_handoff_ready);
+        assert!(!summary.release_handoff_execution_ready);
+        assert!(!summary.release_ticket_handoff_execution_ready);
+        assert!(!summary.release_handoff_execution_work_orders_ready);
+        assert!(!summary.release_ticket_handoff_work_orders_ready);
+        assert!(!summary.ready_for_release_ticket_handoff_work_orders());
+        assert!(summary.has_work_orders());
+        assert!(summary.has_repair_work());
+        assert!(summary.has_blockers());
+        assert!(summary.has_review_work());
+        assert!(summary.needs_operator());
+        assert!(summary.requires_execution());
+        assert!(summary.requires_attention());
+    }
+
+    #[test]
+    fn mesh_release_ticket_handoff_work_order_readiness_summary_marks_release_ready() {
+        let catalog = vec![hue_entry()];
+        let allowed_capabilities = vec![
+            CapabilityId::trusted("smart_home.read"),
+            CapabilityId::trusted("smart_home.command.light"),
+            CapabilityId::trusted("smart_home.pair"),
+        ];
+        let summary = mesh_release_ticket_handoff_work_order_readiness_summary_for_catalog(
+            &catalog,
+            all_primitive_families(),
+            &allowed_capabilities,
+            &[],
+        );
+
+        assert_eq!(summary.total_tickets, 5);
+        assert_eq!(summary.ready_tickets, 5);
+        assert_eq!(summary.blocked_tickets, 0);
+        assert_eq!(summary.review_required_tickets, 0);
+        assert_eq!(summary.operator_required_tickets, 0);
+        assert_eq!(summary.dispatch_required_tickets, 0);
+        assert_eq!(summary.total_handoff_packets, 5);
+        assert_eq!(summary.total_execution_slots, 5);
+        assert_eq!(summary.total_work_orders, 5);
+        assert_eq!(summary.ready_work_orders, 5);
+        assert_eq!(summary.blocked_work_orders, 0);
+        assert_eq!(summary.review_required_work_orders, 0);
+        assert_eq!(summary.operator_required_work_orders, 0);
+        assert_eq!(summary.dispatch_required_work_orders, 0);
+        assert_eq!(summary.release_lane_work_orders, 5);
+        assert_eq!(summary.operator_lane_work_orders, 0);
+        assert_eq!(summary.repair_lane_work_orders, 0);
+        assert_eq!(summary.review_lane_work_orders, 0);
+        assert_eq!(summary.execution_required_work_orders, 0);
+        assert_eq!(summary.queued_substrate_actions, 0);
+        assert_eq!(summary.remediation_item_count, 0);
+        assert_eq!(summary.review_required_packages, 0);
+        assert_eq!(summary.operator_required_packages, 0);
+        assert_eq!(summary.blocked_packages, 0);
+        assert_eq!(
+            summary.first_execution_slot_key,
+            Some("release-ticket-handoff-execution-slot-01-release-substrate_actions".to_string())
+        );
+        assert_eq!(
+            summary.first_work_order_key,
+            Some(
+                "release-ticket-handoff-execution-work-order-01-release-substrate_actions"
+                    .to_string()
+            )
+        );
+        assert_eq!(
+            summary.first_release_work_order_key,
+            Some(
+                "release-ticket-handoff-execution-work-order-01-release-substrate_actions"
+                    .to_string()
+            )
+        );
+        assert_eq!(summary.next_work_order_key, None);
+        assert_eq!(summary.next_execution_slot_key, None);
+        assert_eq!(summary.next_packet_key, None);
+        assert_eq!(summary.next_ticket_key, None);
+        assert_eq!(summary.next_dispatch_key, None);
+        assert_eq!(summary.next_task_key, None);
+        assert_eq!(summary.next_slot_key, None);
+        assert_eq!(summary.next_check_kind, None);
+        assert_eq!(summary.next_check_status, None);
+        assert_eq!(
+            summary.next_package_kind,
+            Some(IntegrationMeshReadinessHandoffKind::ReleaseReady)
+        );
+        assert_eq!(
+            summary.next_handoff_status,
+            Some(IntegrationMeshReadinessHandoffStatus::Ready)
+        );
+        assert_eq!(summary.next_handoff_lane, None);
+        assert_eq!(
+            summary.packet_status,
+            IntegrationMeshReleaseReadinessStatus::Ready
+        );
+        assert_eq!(
+            summary.execution_status,
+            IntegrationMeshReleaseReadinessStatus::Ready
+        );
+        assert!(summary.release_packet_ready);
+        assert!(summary.release_execution_ready);
+        assert!(summary.release_tasks_ready);
+        assert!(summary.release_dispatch_ready);
+        assert!(summary.release_ticket_ready);
+        assert!(summary.release_handoff_ready);
+        assert!(summary.release_handoff_execution_ready);
+        assert!(summary.release_ticket_handoff_execution_ready);
+        assert!(summary.release_handoff_execution_work_orders_ready);
+        assert!(summary.release_ticket_handoff_work_orders_ready);
+        assert!(summary.ready_for_release_ticket_handoff_work_orders());
+        assert!(summary.has_work_orders());
+        assert!(!summary.has_repair_work());
+        assert!(!summary.has_blockers());
+        assert!(!summary.has_review_work());
+        assert!(!summary.needs_operator());
+        assert!(!summary.requires_execution());
+        assert!(!summary.requires_attention());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add IntegrationMeshReleaseTicketHandoffWorkOrderReadinessSummary to combine handoff execution readiness with work-order lane state
- expose catalog/default helpers for the new work-order readiness rollup
- document the new smart-home readiness summary surface

## Tests
- cargo test --manifest-path code\\packages\\rust\\smart-home-integration-catalog\\Cargo.toml mesh_release_ticket_handoff_work_order_readiness -- --nocapture
- cargo test --manifest-path code\\packages\\rust\\smart-home-integration-catalog\\Cargo.toml
- cargo fmt --manifest-path code\\packages\\rust\\smart-home-integration-catalog\\Cargo.toml --check
- git diff --check