### PR TITLE
test(ruby-sir): execution-proof for the non-empty block capture (RB3)

### DIFF
--- a/code/packages/rust/semantic-ir-to-python/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-python/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Changelog
 
+## 0.1.17 — execution-proof for the non-empty block capture (RB3)
+
+RB1/RB2 (in the Ruby frontend) introduced the first SIR shape that emits a
+**non-empty** `MakeClosure` capture: a block passed to a yielding method whose
+own body yields to the *enclosing* method's block.  The inner block is hoisted
+to a top-level function that closes over the enclosing method's `__sir_block__`
+parameter, and the backend binds that by emitting
+`_sir_make_closure(__block_0, [__sir_block__])` plus a hoisted
+`def __block_0(__sir_block__, x):` (captures are prepended to the parameter
+list).
+
+Until now every Ruby→Python test asserted only the *shape* of the emitted
+source.  This release adds `end_to_end_ruby_block_capture_executes_py`, which
+additionally **runs** the emitted module through a real Python interpreter
+(runtime packages on `PYTHONPATH`) and asserts stdout — proving the captured
+block actually reaches the enclosing caller's block at runtime, not just on
+paper.  The harness probes `python3`/`python` with `-c pass` and **skips the
+execution assertion** when no usable interpreter is present (the Windows Store
+`python3` stub is treated as absent), so hosts without Python never hard-fail;
+a present-but-erroring interpreter still fails the test.
+
+No emitter change — this is verification only.  The receiver-form
+(`recv.each { … }`) of the same capture lowers and emits identically, but its
+*execution* additionally depends on collection-method dispatch in
+`sir-runtime-oop` (`call_method` currently returns `nil` for `each`), which is
+the Q10h method-dispatch boundary and out of scope here.
+
 ## 0.1.16 — `defined?` lowers to a non-evaluating description (Q9d)
 
 Fourth item of the Q9 structural-builtin tranche.  Ruby `defined?(x)` reaches

--- a/code/packages/rust/semantic-ir-to-python/src/lib.rs
+++ b/code/packages/rust/semantic-ir-to-python/src/lib.rs
@@ -169,6 +169,96 @@ mod tests {
         }
     }
 
+    // ── Execution-proof: block-capture round-trip actually *runs* ──────
+    //
+    // Every other Ruby→Python test above asserts the *shape* of the emitted
+    // source.  This one additionally executes it through a real interpreter,
+    // because RB1/RB2 introduced the first SIR shape that emits a **non-empty**
+    // `MakeClosure` capture — a hoisted block that closes over the enclosing
+    // method's block parameter — and we want proof the backend binds that
+    // capture correctly at runtime, not just on paper.
+
+    /// Probe whether `exe` is a usable Python interpreter by running `-c pass`.
+    /// This distinguishes a genuinely-absent interpreter (and the Windows Store
+    /// `python3` stub, which refuses to run and exits non-zero) from a real one,
+    /// so the caller can *skip* cleanly rather than mistaking "no Python" for a
+    /// test failure.
+    fn python_is_runnable(exe: &str) -> bool {
+        std::process::Command::new(exe)
+            .args(["-c", "pass"])
+            .output()
+            .map(|o| o.status.success())
+            .unwrap_or(false)
+    }
+
+    /// Run emitted Python `source` with the local SIR runtime packages on
+    /// `PYTHONPATH`, returning captured stdout with newlines normalised.
+    /// Returns `None` (⇒ skip the execution assertion) when no usable
+    /// interpreter exists, so CI hosts without Python never hard-fail.  A
+    /// present-but-erroring interpreter panics with the captured stderr — that
+    /// is a real regression, not a skip.
+    fn run_emitted_python(source: &str) -> Option<String> {
+        let exe = ["python3", "python"].into_iter().find(|e| python_is_runnable(e))?;
+
+        // Runtime packages live at <crate>/../../python/<pkg>/src (src layout).
+        let py_root = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("../../python");
+        let pythonpath = std::env::join_paths([
+            py_root.join("sir-runtime-core/src"),
+            py_root.join("sir-runtime-pairs/src"),
+        ])
+        .expect("join PYTHONPATH");
+
+        let file = std::env::temp_dir().join(format!("sir_rb3_{}.py", std::process::id()));
+        std::fs::write(&file, source).expect("write temp python");
+        let out = std::process::Command::new(exe)
+            .arg(&file)
+            .env("PYTHONPATH", &pythonpath)
+            .output()
+            .expect("spawn python");
+        let _ = std::fs::remove_file(&file);
+
+        assert!(
+            out.status.success(),
+            "emitted Python failed under {exe}:\n{}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+        Some(String::from_utf8_lossy(&out.stdout).replace("\r\n", "\n"))
+    }
+
+    #[test]
+    fn end_to_end_ruby_block_capture_executes_py() {
+        // `outer`'s block `{ |x| yield x }` is hoisted to `__block_0` and its
+        // `yield x` re-targets the *enclosing* method's block — so `__block_0`
+        // closes over `outer`'s `__sir_block__`.  That is the first non-empty
+        // `MakeClosure` capture in the pipeline.  `print` is one of the few
+        // builtins `sir-runtime-core` implements natively, so the whole chain
+        // (`outer` → `twice` → captured block → enclosing block) is runnable.
+        let src = "def twice\n  yield 1\n  yield 2\nend\n\
+                   def outer\n  twice { |x| yield x }\nend\n\
+                   outer { |n| print n }\n";
+        let module = ruby_to_semantic_ir::compile_source(src, "demo").expect("lower ruby");
+        let a = compile(&module).expect("compile to python");
+
+        // Shape: the capture is threaded into the hoisted block, and the block
+        // receives it as a prepended parameter (make_closure prepends captures).
+        assert!(
+            a.source.contains("def __block_0(__sir_block__, x):"),
+            "hoisted block must take the captured block first; got:\n{}",
+            a.source
+        );
+        assert!(
+            a.source.contains("twice(_sir_make_closure(__block_0, [__sir_block__]))"),
+            "enclosing block must be threaded into the non-empty capture; got:\n{}",
+            a.source
+        );
+
+        // Execution-proof: running it prints the two yielded values, proving the
+        // captured block reaches `outer`'s caller block at runtime.
+        if let Some(stdout) = run_emitted_python(&a.source) {
+            assert_eq!(stdout, "1\n2\n", "emitted python printed unexpected output");
+        }
+    }
+
     #[test]
     fn compiles_minimal_module() {
         let m = minimal_module();

--- a/code/packages/rust/semantic-ir-to-typescript/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-typescript/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 0.1.16 — emitted-shape proof for the non-empty block capture (RB3)
+
+Mirror of the Python backend's 0.1.17.  RB1/RB2 (Ruby frontend) introduced the
+first SIR shape with a **non-empty** `MakeClosure` capture: a hoisted block that
+closes over the enclosing method's `__sir_block__`.  TypeScript captures by
+native lexical closure rather than a positional array, so the binding emits as
+`twice(new __Sir.Closure((..._a) => __block_0(__sir_block__, ..._a)))` with the
+hoisted `function __block_0(__sir_block__: __Sir.Val, x: __Sir.Val)` taking the
+captured block as its first parameter.
+
+New test `end_to_end_ruby_block_capture_emits_native_capture_ts` asserts that
+binding.  Unlike the Python sibling it does **not** execute: Node cannot run the
+emitted *TypeScript* directly (type annotations; the runtime package ships as
+`.ts` with no `dist/`), so this proves the capture by shape.  No emitter change
+— verification only.
+
 ## 0.1.15 — `defined?` lowers to a non-evaluating description (Q9d)
 
 Fourth item of the Q9 structural-builtin tranche.  Ruby `defined?(x)` reaches

--- a/code/packages/rust/semantic-ir-to-typescript/src/lib.rs
+++ b/code/packages/rust/semantic-ir-to-typescript/src/lib.rs
@@ -208,6 +208,43 @@ mod tests {
     }
 
     #[test]
+    fn end_to_end_ruby_block_capture_emits_native_capture_ts() {
+        // RB1/RB2 mirror of the Python execution-proof: `outer`'s block
+        // `{ |x| yield x }` is hoisted to `__block_0` whose `yield x` re-targets
+        // the *enclosing* method's block, so the block closes over `outer`'s
+        // `__sir_block__` — the first non-empty `MakeClosure` capture.  Node
+        // cannot run the emitted *TypeScript* directly (it carries type
+        // annotations and the runtime package ships as `.ts`), so unlike the
+        // Python sibling this proves the binding by shape: TS captures via a
+        // native closure that forwards the captured block as the first argument.
+        let src = "def twice\n  yield 1\n  yield 2\nend\n\
+                   def outer\n  twice { |x| yield x }\nend\n\
+                   outer { |n| print n }\n";
+        let module = ruby_to_semantic_ir::compile_source(src, "demo").expect("lower ruby");
+        let a = compile(&module).expect("compile to ts");
+
+        // The hoisted block declares the captured block as its first parameter.
+        assert!(
+            a.source.contains("function __block_0(__sir_block__: __Sir.Val, x: __Sir.Val)"),
+            "hoisted block must take the captured block first; got:\n{}",
+            a.source
+        );
+        // The enclosing block is closed over and forwarded as the first arg via
+        // a native closure (TS has no positional-capture array; it uses scope).
+        assert!(
+            a.source.contains("__block_0(__sir_block__, ..._a)"),
+            "captured block must be forwarded into the hoisted block; got:\n{}",
+            a.source
+        );
+        // And it is threaded into `twice` as that block's value.
+        assert!(
+            a.source.contains("twice(new __Sir.Closure((..._a: __Sir.Val[]) => __block_0(__sir_block__, ..._a)))"),
+            "enclosing block must be threaded through the non-empty capture; got:\n{}",
+            a.source
+        );
+    }
+
+    #[test]
     fn compiles_minimal_module() {
         let m = minimal_module();
         let a = compile(&m).expect("compile");


### PR DESCRIPTION
## RB3 — execution-proof for the non-empty block capture

RB1 (grammar receiver-blocks + lowerer hoist) and RB2 (yield-inside-a-hoisted-block captures the enclosing `__sir_block__`) together produced the **first SIR shape that emits a non-empty `MakeClosure` capture**. This PR proves the backends bind that capture correctly — by **shape** on both backends and by **execution** on Python.

### The shape under test

```ruby
def twice
  yield 1
  yield 2
end
def outer
  twice { |x| yield x }   # block yields to outer's OWN block
end
outer { |n| print n }
```

`outer`'s block is hoisted to `__block_0`; its `yield x` re-targets the enclosing method's block, so `__block_0` closes over `outer`'s `__sir_block__`.

**Python** binds it positionally (make_closure prepends captures):
```python
def __block_0(__sir_block__, x):
    _sir_apply(__sir_block__, [x])
...
def outer(__sir_block__):
    twice(_sir_make_closure(__block_0, [__sir_block__]))
```

**TypeScript** binds it via a native lexical closure forwarding the captured block first:
```ts
function __block_0(__sir_block__: __Sir.Val, x: __Sir.Val) { __Sir.apply(__sir_block__, [x]); ... }
function outer(__sir_block__: __Sir.Val) {
  twice(new __Sir.Closure((..._a: __Sir.Val[]) => __block_0(__sir_block__, ..._a)));
}
```

### Tests
- `semantic-ir-to-python::end_to_end_ruby_block_capture_executes_py` — asserts the shape **and runs** the emitted module through a real Python interpreter (runtime packages on `PYTHONPATH`), checking stdout is `1\n2`. Skips the execution assertion gracefully when no usable interpreter exists (probes `python3`/`python` with `-c pass`; the Windows Store `python3` stub is treated as absent), so CI hosts without Python never hard-fail; a present-but-erroring interpreter still fails.
- `semantic-ir-to-typescript::end_to_end_ruby_block_capture_emits_native_capture_ts` — emitted-shape proof of the same binding. Node v20 cannot run the emitted TypeScript directly (type annotations; the runtime package ships as `.ts` with no `dist/`), so this is shape-only.

### Scope notes (honest)
- **No emitter change** — verification only.
- The **receiver form** (`recv.each { … }`) of this same capture lowers and emits identically, but its *execution* additionally needs collection-method dispatch in `sir-runtime-oop` (`call_method` returns `nil` for `each` today). That is the **Q10h method-dispatch boundary** and out of scope here; the bare-name form above exercises the identical non-empty-capture machinery without depending on it.

CHANGELOG: `semantic-ir-to-python` 0.1.17, `semantic-ir-to-typescript` 0.1.16.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
