### PR TITLE
feat(closurec): Automatic Semicolon Insertion — `}`/EOF rule (CLOC26 Phase 1)

### DIFF
--- a/code/packages/rust/javascript-parser/CHANGELOG.md
+++ b/code/packages/rust/javascript-parser/CHANGELOG.md
@@ -2,6 +2,44 @@
 
 All notable changes to the `coding-adventures-javascript-parser` crate will be documented in this file.
 
+## [0.15.0] - 2026-06-21
+
+### Added — CLOC26 Phase 1: Automatic Semicolon Insertion (`}` / EOF rule)
+
+New `asi` module implementing ECMAScript ASI **Rule 2** — a `;` is inserted
+before a `}` (or at end of input) that would otherwise be a syntax error. The
+grammar spells `SEMICOLON` out as a required terminal in every statement, so
+semicolon-light source (`function f(){return 1}`, `{ g() }`) previously failed
+to parse — and closurec degraded the whole program to WHITESPACE_ONLY.
+
+`asi::parse_with_asi(tokens, version)` drives insertion **from the parser**:
+parse the stream; only if it fails *specifically because a `SEMICOLON` was
+expected before a `}`/EOF* (`GrammarParseError` carries both the message and the
+offending token), synthesize a `;` at that position and re-parse; bounded loop
+with a same-position guard against non-progress. Any non-ASI error is returned
+unchanged (caller degrades as before).
+
+**The load-bearing property: a `;` is inserted only when parsing genuinely
+failed for lack of one, so ASI is a no-op on any input that already parses** —
+it can never change a valid program's parse. (This *retry-on-error* design was
+chosen over the lookahead-table the design spec first sketched, precisely
+because it guarantees byte-identical output on already-valid input — verified
+by the full closurec fixture suite staying byte-for-byte unchanged.)
+
+Wired into `parse_javascript_typed` (the entry closurec uses); other entry
+points are unchanged for now. Implemented entirely within this crate — **no
+changes to the shared `grammar-tools`/`parser` crates or to any `.grammar`
+file** (semicolons stay mandatory in the grammar; ASI supplies them in the
+token stream).
+
+Phases 2 (line-terminator rule, via the lexer's existing
+`TOKEN_PRECEDED_BY_NEWLINE` flag) and 3 (restricted productions) are follow-ups
+per `code/specs/CLOC26-asi.md`.
+
+- 7 unit tests: `}`/EOF recovery, no-op on already-valid input, idempotence on
+  recovered input, a genuine syntax error is not papered over, and an empty
+  block is not given a semicolon.
+
 ## [0.14.0] - 2026-06-20
 
 ### Added — CLOC23: bridge `for_of_statement` → `ForOfStatement`

--- a/code/packages/rust/javascript-parser/Cargo.toml
+++ b/code/packages/rust/javascript-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-javascript-parser"
-version = "0.14.0"
+version = "0.15.0"
 edition = "2021"
 description = "JavaScript parser — parses JavaScript source code against any ECMAScript edition (es1 through es2025) using the grammar-driven parser. Includes correlation-vector plumbing per CLOC03 and a typed-AST bridge (GrammarASTNode → javascript_ast::Program) per CLOC12.136."
 

--- a/code/packages/rust/javascript-parser/src/asi.rs
+++ b/code/packages/rust/javascript-parser/src/asi.rs
@@ -1,0 +1,228 @@
+//! Automatic Semicolon Insertion (ASI) — Phase 1: the `}` / end-of-input rule.
+//!
+//! # Why this module exists
+//!
+//! ECMAScript lets you omit many statement-ending semicolons; the language
+//! inserts them automatically (§12.10). closurec's grammar, however, spells
+//! `SEMICOLON` out as a *required* terminal in every statement production, so
+//! ordinary semicolon-light source fails to parse:
+//!
+//! ```text
+//!   function f(x) { if (x) { return 1 } else { g() } }
+//!                                     ^^^ no `;` before `}`  →  parse error
+//! ```
+//!
+//! When that happens, closurec degrades the *whole program* to
+//! `WHITESPACE_ONLY` — every optimization pass is skipped. ASI closes that gap.
+//!
+//! # The approach: retry-on-parse-error (byte-identical by construction)
+//!
+//! Phase 1 implements only ASI **Rule 2** — a `;` is inserted before a `}` (or
+//! at end of input) that would otherwise be a syntax error. This rule does *not*
+//! depend on line terminators, which is convenient because the lexer discards
+//! newlines as trivia (the line-terminator rule is Phase 2, using the
+//! `TOKEN_PRECEDED_BY_NEWLINE` flag the lexer already records).
+//!
+//! Rather than guess insertion points from a lookahead table (the approach the
+//! design spec first sketched), we drive insertion from the parser itself:
+//!
+//! 1. Parse the token stream.
+//! 2. If it parses, we are done — **nothing is inserted**.
+//! 3. If it fails *specifically because a `SEMICOLON` was expected before a `}`
+//!    or end-of-input*, synthesize a `;` at that position and re-parse.
+//! 4. Any other failure is returned unchanged (closurec then degrades as before).
+//!
+//! The decisive property: a semicolon is inserted **only when parsing genuinely
+//! failed for lack of one**. Therefore ASI is a *no-op on any input that already
+//! parses* — it can never change a valid program's parse. This is what makes the
+//! transform safe to drop into the parse path: every existing fixture (which all
+//! use explicit semicolons) is byte-for-byte unaffected, and the only programs
+//! whose behaviour changes are ones that previously failed outright.
+//!
+//! The cost is re-parsing once per inserted semicolon (O(insertions × n)). For a
+//! build-time minifier this is acceptable; a batched single-pass insertion is a
+//! possible future optimization, but correctness-by-construction comes first.
+
+use coding_adventures_javascript_tokens::EsVersion;
+use lexer::token::{Token, TokenType};
+use parser::grammar_parser::{GrammarASTNode, GrammarParseError, GrammarParser};
+
+/// Parse `tokens` with Phase-1 ASI applied.
+///
+/// Returns the parsed tree on success, or the final [`GrammarParseError`] if the
+/// program cannot be parsed even with `}`/EOF semicolons supplied (so the caller
+/// still degrades exactly as it did before ASI existed).
+pub fn parse_with_asi(
+    tokens: Vec<Token>,
+    version: EsVersion,
+) -> Result<GrammarASTNode, GrammarParseError> {
+    let grammar = crate::_grammar::parser_grammar(version.as_str())
+        .expect("compiled JavaScript parser grammar missing supported version");
+
+    let mut tokens = tokens;
+    // Each insertion adds exactly one token and (when it helps) lets the parser
+    // advance past one more `}`/EOF, so the number of useful insertions is
+    // bounded by the token count. The `+ 1` covers the final EOF position.
+    let max_insertions = tokens.len() + 1;
+    // Positions we have already tried inserting a `;` before. If a failure
+    // recurs at a position we have already addressed — even non-consecutively
+    // (an A→B→A oscillation) — the inserted `;` is not making progress, so we
+    // stop rather than churn up to the hard cap. With correct insertion the
+    // failure position strictly advances, so this set only guards pathological
+    // input; the `max_insertions` cap is the hard backstop.
+    let mut tried: std::collections::HashSet<(usize, usize)> = std::collections::HashSet::new();
+
+    for _ in 0..max_insertions {
+        let mut parser = GrammarParser::new(tokens.clone(), grammar.clone());
+        match parser.parse() {
+            Ok(ast) => return Ok(ast),
+            Err(e) => {
+                if !is_asi_recoverable(&e) {
+                    return Err(e);
+                }
+                let fail_pos = (e.token.line, e.token.column);
+                if !tried.insert(fail_pos) {
+                    // Already inserted a `;` for this position and parsing still
+                    // fails here — give up with the real error.
+                    return Err(e);
+                }
+                match find_token_index(&tokens, &e.token) {
+                    Some(idx) => tokens.insert(idx, synthetic_semicolon(&e.token)),
+                    // The offending token isn't locatable in our stream (should
+                    // not happen — full-identity match is unique); bail safely.
+                    None => return Err(e),
+                }
+            }
+        }
+    }
+
+    // Budget exhausted (pathological input). Return the final outcome so the
+    // caller sees a real error rather than a silent wrong parse.
+    GrammarParser::new(tokens, grammar).parse()
+}
+
+/// Is this parse failure one that inserting a `;` before a `}` / end-of-input
+/// could plausibly fix? We require BOTH that a `SEMICOLON` was among the
+/// expected tokens AND that the offending token is a closing brace or EOF —
+/// the only positions ASI Rule 2 applies. Anything else is a genuine syntax
+/// error we must not paper over.
+fn is_asi_recoverable(e: &GrammarParseError) -> bool {
+    let expects_semicolon = e.message.contains("SEMICOLON");
+    let off = &e.token;
+    let is_close_brace = off.type_ == TokenType::RBrace
+        || off.type_name.as_deref() == Some("RBRACE")
+        || off.value == "}";
+    let is_eof = off.type_ == TokenType::Eof;
+    expects_semicolon && (is_close_brace || is_eof)
+}
+
+/// A synthesized `;` token positioned at the offending token. The parser matches
+/// tokens by `type_name` first, so `type_name = "SEMICOLON"` is what makes this
+/// satisfy a `SEMICOLON` grammar reference; `type_` and `value` are filled in to
+/// match a real semicolon for any consumer that inspects them.
+fn synthetic_semicolon(offending: &Token) -> Token {
+    Token {
+        type_: TokenType::Semicolon,
+        value: ";".to_string(),
+        line: offending.line,
+        column: offending.column,
+        type_name: Some("SEMICOLON".to_string()),
+        flags: None,
+    }
+}
+
+/// Locate the offending token in the stream. We match on **full token
+/// identity** — kind (`type_`), text (`value`), and position (`line`,
+/// `column`) — not position alone. This matters because the synthetic `;` we
+/// insert is deliberately stamped with the offending token's own `(line,
+/// column)` (good for diagnostics/source maps), so a position-only match could
+/// later find that injected `;` instead of a real `}`/EOF. A `;` differs from a
+/// `}`/EOF in `type_` and `value`, so including those fields keeps the match
+/// unambiguous even when positions collide. Returns the index to insert the
+/// synthetic `;` *before*.
+fn find_token_index(tokens: &[Token], offending: &Token) -> Option<usize> {
+    tokens.iter().position(|t| {
+        t.line == offending.line
+            && t.column == offending.column
+            && t.type_ == offending.type_
+            && t.value == offending.value
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tokenize(src: &str) -> Vec<Token> {
+        coding_adventures_javascript_lexer::tokenize_javascript_typed(src, EsVersion::Es2025)
+            .expect("tokenize")
+    }
+
+    /// Count how many SEMICOLON tokens ASI would add by diffing the stream the
+    /// parser ultimately accepts against the original. We re-run the insertion
+    /// loop indirectly via `parse_with_asi`; here we just assert parse success.
+    fn parses_with_asi(src: &str) -> bool {
+        parse_with_asi(tokenize(src), EsVersion::Es2025).is_ok()
+    }
+
+    fn parses_without_asi(src: &str) -> bool {
+        let grammar = crate::_grammar::parser_grammar("es2025").unwrap();
+        GrammarParser::new(tokenize(src), grammar).parse().is_ok()
+    }
+
+    #[test]
+    fn return_before_close_brace_is_recovered() {
+        // No `;` before the `}` — fails without ASI, parses with it.
+        let src = "function f(){return 1}";
+        assert!(!parses_without_asi(src), "precondition: should fail raw");
+        assert!(parses_with_asi(src), "ASI should insert a semicolon before the close brace");
+    }
+
+    #[test]
+    fn call_before_close_brace_is_recovered() {
+        let src = "function f(){g()}";
+        assert!(!parses_without_asi(src));
+        assert!(parses_with_asi(src));
+    }
+
+    #[test]
+    fn expression_statement_at_eof_is_recovered() {
+        // Top-level expression statement with no trailing `;` at end of input.
+        let src = "a()";
+        assert!(!parses_without_asi(src));
+        assert!(parses_with_asi(src));
+    }
+
+    #[test]
+    fn already_valid_input_is_a_noop_passthrough() {
+        // With explicit semicolons the program already parses; ASI must not
+        // change anything — it parses, and the FIRST parse (no insertion) wins.
+        let src = "function f(){return 1;}";
+        assert!(parses_without_asi(src), "precondition: valid as-is");
+        assert!(parses_with_asi(src));
+    }
+
+    #[test]
+    fn idempotent_on_recovered_input() {
+        // Running ASI is stable: a stream that needed one insertion still parses
+        // (and the inserted `;` doesn't trigger further spurious insertions).
+        let src = "function f(){if(x){return 1}else{g()}}";
+        assert!(parses_with_asi(src));
+    }
+
+    #[test]
+    fn genuine_syntax_error_is_not_papered_over() {
+        // A real error (mismatched paren) is NOT a missing-semicolon case, so
+        // ASI must return the error rather than loop or wrongly "recover".
+        let src = "function f({)}";
+        assert!(!parses_with_asi(src), "non-ASI syntax error must still fail");
+    }
+
+    #[test]
+    fn empty_block_is_not_given_a_semicolon() {
+        // `function f(){}` already parses; ASI must not insert into `{}`.
+        let src = "function f(){}";
+        assert!(parses_without_asi(src));
+        assert!(parses_with_asi(src));
+    }
+}

--- a/code/packages/rust/javascript-parser/src/lib.rs
+++ b/code/packages/rust/javascript-parser/src/lib.rs
@@ -27,6 +27,7 @@ use std::collections::HashMap;
 pub const DEFAULT_ES_VERSION: EsVersion = EsVersion::Es2025;
 
 mod _grammar;
+pub mod asi;
 pub mod bridge;
 
 /// Parse JavaScript source and return a fully typed [`Program`] AST
@@ -94,10 +95,13 @@ pub fn parse_javascript_typed(
     source: &str,
     version: EsVersion,
 ) -> Result<GrammarASTNode, String> {
-    let mut parser = create_javascript_parser_typed(source, version)?;
-    parser
-        .parse()
-        .map_err(|e| format!("JavaScript parse failed: {e}"))
+    // Apply Phase-1 ASI: the parser requires explicit `SEMICOLON` terminals, so
+    // semicolon-light source (`{ a() }`, `return 1}`) would otherwise fail and
+    // closurec would degrade the whole program to WHITESPACE_ONLY. `parse_with_asi`
+    // only inserts a `;` before a `}`/EOF when parsing genuinely failed for lack
+    // of one, so it is a no-op on any input that already parses. See [`asi`].
+    let tokens = tokenize_javascript_typed(source, version)?;
+    asi::parse_with_asi(tokens, version).map_err(|e| format!("JavaScript parse failed: {e}"))
 }
 
 /// A parsed program paired with the correlation-vector ID assigned to its

--- a/code/programs/rust/closurec/CHANGELOG.md
+++ b/code/programs/rust/closurec/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 All notable changes to the `coding-adventures-closurec` binary will be documented in this file.
 
+## [0.159.0] - 2026-06-21
+
+### Changed — CLOC26 Phase 1: optimize semicolon-light source via ASI
+
+closurec now applies Automatic Semicolon Insertion (the `}` / end-of-input
+rule) before the typed pipeline runs, so programs that omit a `;` before a `}`
+or at end of input — e.g. `function f(){return 1}` — **parse and get optimized**
+at `SIMPLE`/`ADVANCED` instead of silently degrading to `WHITESPACE_ONLY`. This
+was the single largest reason real-world, semicolon-light code got no
+optimization. ASI lives in the `coding-adventures-javascript-parser` crate
+(bumped to 0.15.0); the change here is the resulting behaviour.
+
+New end-to-end fixture `simple-asi-block`: a function omitting the `;` before
+its closing `}` now folds `1 + 2` to `3` at SIMPLE
+(`function area(w){var s;s=3;return w * s};report(area(10));`). The
+`simple_asi_block_did_not_fall_back_to_whitespace_only` guard asserts the folded
+`s=3` is present and `1+2` is absent — an optimization only reachable because
+ASI made the program parse.
+
+**No regression:** ASI only inserts a `;` when parsing genuinely failed for lack
+of one, so it is a no-op on already-valid input — the entire existing fixture
+suite is byte-for-byte unchanged.
+
 ## [0.158.0] - 2026-06-20
 
 ### Changed — CLOC25: drop a redundant `else` after a terminating `if` consequent

--- a/code/programs/rust/closurec/Cargo.toml
+++ b/code/programs/rust/closurec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closurec"
-version = "0.158.0"
+version = "0.159.0"
 edition = "2021"
 description = "closurec — CLI driver for the Closure Compiler clone. Mirrors the upstream Java Closure Compiler's command-line flag surface (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility. Per CLOC08."
 

--- a/code/programs/rust/closurec/cli.spec.json
+++ b/code/programs/rust/closurec/cli.spec.json
@@ -2,7 +2,7 @@
   "cli_builder_spec_version": "1.0",
   "name": "closurec",
   "description": "closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.",
-  "version": "0.158.0",
+  "version": "0.159.0",
   "parsing_mode": "gnu",
   "flags": [
     { "id": "browser_featureset_year", "long": "browser_featureset_year", "type": "integer", "default": 0, "description": "Shortcut for defining goog.FEATURESET_YEAR=YYYY (minimum 2012)." },

--- a/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
@@ -2,7 +2,7 @@
 
 closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.
 
-Version: 0.158.0
+Version: 0.159.0
 
 ## Flags
 

--- a/code/programs/rust/closurec/tests/diff/simple-asi-block/README.md
+++ b/code/programs/rust/closurec/tests/diff/simple-asi-block/README.md
@@ -1,0 +1,35 @@
+# Fixture: `simple-asi-block`
+
+End-to-end oracle for **CLOC26 Phase 1** — Automatic Semicolon Insertion before
+a `}` / end-of-input. Implemented in the `javascript-parser` crate's `asi`
+module (retry-on-parse-error).
+
+| File | Role |
+|------|------|
+| `flags.txt` | CLI args: `--compilation_level SIMPLE --js input/a.js` |
+| `input/a.js` | A function whose body omits the `;` after `return w * s` (no `;` before the `}`) |
+| `expected.stdout` | The optimized output (see below) |
+
+```text
+function area(w){var s;s=3;return w * s};report(area(10));
+```
+
+What this proves:
+
+* **The program parses at all** — before ASI, a missing `;` before the `}`
+  failed the grammar parse and closurec degraded the *whole program* to
+  `WHITESPACE_ONLY`. ASI supplies the `;`, so the typed pipeline runs.
+* **`1 + 2` folds to `3`** (`var s; s = 3;`) — an optimization that can *only*
+  come from the SIMPLE pipeline. Its presence is the proof ASI worked: a
+  WHITESPACE_ONLY fallback would keep `var s=1+2` verbatim.
+
+The `simple_asi_block_did_not_fall_back_to_whitespace_only` guard asserts the
+output contains `s=3` and does **not** contain `1+2`.
+
+Regenerate the expected file after an intentional behavior change:
+
+```sh
+cargo run -- --compilation_level SIMPLE \
+    --js tests/diff/simple-asi-block/input/a.js \
+    > tests/diff/simple-asi-block/expected.stdout
+```

--- a/code/programs/rust/closurec/tests/diff/simple-asi-block/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/simple-asi-block/expected.stdout
@@ -1,0 +1,1 @@
+function area(w){var s;s=3;return w * s};report(area(10));

--- a/code/programs/rust/closurec/tests/diff/simple-asi-block/flags.txt
+++ b/code/programs/rust/closurec/tests/diff/simple-asi-block/flags.txt
@@ -1,0 +1,4 @@
+--compilation_level
+SIMPLE
+--js
+tests/diff/simple-asi-block/input/a.js

--- a/code/programs/rust/closurec/tests/diff/simple-asi-block/input/a.js
+++ b/code/programs/rust/closurec/tests/diff/simple-asi-block/input/a.js
@@ -1,0 +1,21 @@
+// CLOC26 Phase 1 — Automatic Semicolon Insertion before `}` / end-of-input.
+//
+// `area`'s body omits the semicolon after `return w * s` — there is no `;`
+// before the closing `}`. Before ASI, the grammar parser required an explicit
+// `SEMICOLON` there, so this whole program failed to parse and closurec
+// silently degraded to WHITESPACE_ONLY (no optimization at all). ASI now
+// inserts the missing `;` before the `}`, the program parses, and the SIMPLE
+// pipeline runs: `1 + 2` constant-folds to `3`.
+//
+// (The inner `var s = 1 + 2;` keeps its explicit semicolon — Phase 1 only
+// supplies semicolons before `}` / EOF, not between statements on the same
+// line; that statement is followed by `return`, not a `}`.)
+//
+// At SIMPLE this becomes:
+//   function area(w){var s;s=3;return w * s};report(area(10));
+// while WHITESPACE_ONLY keeps `var s=1+2` verbatim (it runs no passes).
+function area(w) {
+  var s = 1 + 2;
+  return w * s
+}
+report(area(10));

--- a/code/programs/rust/closurec/tests/diff_simple_asi_block.rs
+++ b/code/programs/rust/closurec/tests/diff_simple_asi_block.rs
@@ -1,0 +1,73 @@
+//! Integration test for the `tests/diff/simple-asi-block/` fixture.
+//!
+//! Exercises CLOC26 Phase 1 — Automatic Semicolon Insertion before a `}` /
+//! end-of-input, implemented in the `javascript-parser` `asi` module. The input
+//! omits the `;` after `return w * s`; before ASI this failed the grammar parse
+//! and closurec degraded the whole program to WHITESPACE_ONLY. ASI now supplies
+//! the missing `;`, the program parses, and `1 + 2` constant-folds to `3`:
+//!
+//! ```text
+//! function area(w){var s;s=3;return w * s};report(area(10));
+//! ```
+
+use std::process::Command;
+
+const BINARY: &str = env!("CARGO_BIN_EXE_closurec");
+
+fn read_flags() -> Vec<String> {
+    let raw = std::fs::read_to_string("tests/diff/simple-asi-block/flags.txt")
+        .expect("read flags.txt");
+    raw.lines()
+        .filter(|l| !l.is_empty())
+        .map(|s| s.to_string())
+        .collect()
+}
+
+#[test]
+fn simple_asi_block_fixture_matches_expected_stdout() {
+    let flags = read_flags();
+    let out = Command::new(BINARY)
+        .args(&flags)
+        .output()
+        .expect("run closurec");
+
+    assert!(
+        out.status.success(),
+        "exit: {:?}, stderr: {}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stderr),
+    );
+
+    let actual = String::from_utf8_lossy(&out.stdout);
+    let expected = std::fs::read_to_string("tests/diff/simple-asi-block/expected.stdout")
+        .expect("read expected.stdout");
+    assert_eq!(
+        actual.trim_end_matches('\n'),
+        expected.trim_end_matches('\n'),
+        "mismatch.\nflags: {flags:?}\nactual:\n{actual}\nexpected:\n{expected}",
+    );
+}
+
+/// Regression guard: the output must NOT be the WHITESPACE_ONLY fallback. The
+/// input omits a `;` before a `}`; without ASI the program fails to parse and
+/// degrades to whitespace-only, which keeps `1+2` verbatim. So an optimized
+/// SIMPLE run — only reachable because ASI made the program parse — must show
+/// the folded `s=3` and contain no `1+2`.
+#[test]
+fn simple_asi_block_did_not_fall_back_to_whitespace_only() {
+    let out = Command::new(BINARY)
+        .args(read_flags())
+        .output()
+        .expect("run closurec");
+    let actual = String::from_utf8_lossy(&out.stdout);
+
+    assert!(
+        actual.contains("s=3"),
+        "expected `1 + 2` to fold to `3` (proving ASI made the typed pipeline \
+         run, not the whitespace fallback); got:\n{actual}",
+    );
+    assert!(
+        !actual.contains("1+2") && !actual.contains("1 + 2"),
+        "expected the folded form, not the literal `1+2`; got:\n{actual}",
+    );
+}

--- a/code/specs/CLOC26-asi.md
+++ b/code/specs/CLOC26-asi.md
@@ -1,8 +1,23 @@
 # CLOC26 — Automatic Semicolon Insertion (ASI)
 
-> **Status:** Design spec (specs-first). This document is committed *before* any
-> implementation code, per the repo standard. It defines the architecture and a
-> phased implementation plan; each phase below lands as its own follow-up PR.
+> **Status:** **Phase 1 shipped** (the `}` / EOF rule, in
+> `javascript-parser/src/asi.rs`); Phases 2–3 pending. This document was
+> committed *before* any implementation code, per the repo standard.
+>
+> **Implementation refinement (Phase 1):** the shipped implementation uses the
+> **retry-on-parse-error** strategy, not the lookahead table this spec first
+> sketched under "What counts as an offending token". The two reach the same
+> insertion points for the `}`/EOF rule, but retry-on-error has a decisive
+> safety advantage: it inserts a `;` *only when parsing genuinely failed for
+> lack of one*, so it is **byte-identical-by-construction** on any input that
+> already parses — it cannot over-insert. (The "parser-feedback" option this
+> spec had rejected was about mutating the shared `GrammarParser` mid-parse;
+> the shipped approach instead re-parses from scratch with a fresh parser after
+> inserting a token, so it stays entirely within `javascript-parser` and the
+> packrat-memo concern does not apply.) The full closurec fixture suite stays
+> byte-for-byte unchanged, confirming the no-regression property. Phases 2–3
+> (which depend on line-terminator info) will reuse the same retry harness,
+> extending the "is this failure ASI-recoverable?" predicate.
 
 ## The problem this solves
 
@@ -56,7 +71,18 @@ The parsing framework was built ASI-ready:
 ASI supplies them in the token stream). This is the load-bearing reason ASI is
 safe to add: it cannot regress any other language.
 
-### Open design question (resolve in Phase 1)
+### Open design question — RESOLVED in Phase 1
+
+**Answer:** newlines do **not** reach the parser as tokens. The `.tokens`
+grammar lists `WHITESPACE` (whose regex `/[ \t\r\n\v\f]+/` includes `\n`) under
+`skip:`, so the lexer discards all trivia — the parser's stream is
+significant-tokens-only plus one trailing `EOF`. The `}`/EOF rule (Phase 1)
+needs no newline info, so it ships now. For Phases 2–3, line-terminator
+information is still available **per token** via the lexer's
+`TOKEN_PRECEDED_BY_NEWLINE` flag (`lexer::token::Token.flags`), so those phases
+do not need newline *tokens* either — they read the flag on the offending token.
+
+<details><summary>Original open question (for the record)</summary>
 
 The hook receives whatever token stream `tokenize_javascript_typed` produces.
 `Newline` is classified as trivia (`is_trivia()` groups
@@ -76,6 +102,8 @@ so it may already be filtered out before `GrammarParser::new`. Two sub-cases:
 Phase 1 begins by confirming which case holds (a 5-line probe test) and pins the
 hook location accordingly. The `}`/EOF rules (Phase 1) do **not** need newlines,
 so Phase 1 can proceed regardless; only Phases 2–3 depend on the answer.
+
+</details>
 
 ## The three ASI rules (ECMAScript §12.10)
 
@@ -134,7 +162,7 @@ therefore isolated to Phase 3 with dedicated adversarial tests
 
 ## Phased implementation plan (one PR per phase)
 
-**Phase 1 — `}` and EOF insertion (the high-value, newline-free slice).**
+**Phase 1 — `}` and EOF insertion (the high-value, newline-free slice). ✅ SHIPPED.**
 New `javascript-parser/src/asi.rs` with
 `fn insert_automatic_semicolons(tokens: Vec<Token>) -> Vec<Token>` implementing
 Rule 2 only: insert `;` before a `}` / EOF when the preceding significant token


### PR DESCRIPTION
## Summary

Implements **Phase 1** of the [CLOC26 ASI design spec](code/specs/CLOC26-asi.md): **Automatic Semicolon Insertion** for the `}` / end-of-input case (ECMAScript ASI Rule 2).

closurec's grammar parser requires explicit `SEMICOLON` terminals, so ordinary semicolon-light JS — `function f(){return 1}`, `{ g() }` — failed to parse and the **whole program silently degraded to `WHITESPACE_ONLY`** (no optimization at all). This was the single largest reason real-world code got nothing from closurec's SIMPLE/ADVANCED pipeline. ASI closes that gap.

## Design: retry-on-parse-error (byte-identical by construction)

`asi::parse_with_asi(tokens, version)` drives insertion **from the parser itself**:
1. Parse the token stream.
2. If it parses → done, **nothing inserted**.
3. If it fails *specifically because a `SEMICOLON` was expected before a `}`/EOF* (`GrammarParseError` carries the message + the offending token), synthesize a `;` there and re-parse.
4. Any other failure is returned unchanged (caller degrades exactly as before).

**The load-bearing property:** a `;` is inserted *only when parsing genuinely failed for lack of one*, so ASI is a **no-op on any input that already parses** — it can never change a valid program's parse. (This refines the lookahead-table the spec first sketched; retry-on-error is byte-identical-by-construction, which a lookahead table is not.)

**Localized:** implemented entirely in `javascript-parser` — **no changes to the shared `grammar-tools`/`parser` crates or to any `.grammar` file**. Semicolons stay mandatory in the grammar; ASI supplies them in the token stream. Cannot regress any other language frontend.

## Security-hardened (2-round inline review)
- The offending token is located by **full identity** (`type_` + `value` + `line` + `column`), not position alone — so the synthetic `;` (stamped at the offending token's coords) can never be mis-selected on a later iteration.
- A `HashSet` of tried positions guards against A→B→A oscillation (not just consecutive repeats); the `tokens.len()+1` cap is the hard backstop.

## Testing
- 7 `asi` unit tests: `}`/EOF recovery, **no-op on already-valid input**, idempotence, a genuine syntax error is still not papered over, empty block untouched.
- 59 `javascript-parser` tests + **732 closurec tests** green.
- **CRITICAL REGRESSION GUARD:** the entire existing closurec fixture suite (730 fixtures) is **byte-for-byte unchanged**, empirically confirming zero over-insertion.
- New e2e fixture `simple-asi-block`: a function omitting the `;` before its `}` now folds `1+2`→`3` at SIMPLE (`function area(w){var s;s=3;return w * s};report(area(10));`), with a guard asserting the folded `s=3` is present and `1+2` absent — an optimization only reachable because ASI made the program parse.

## Follow-ups (per spec)
Phase 2 (line-terminator rule, via the lexer's existing `TOKEN_PRECEDED_BY_NEWLINE` flag) and Phase 3 (restricted productions), each its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)