### PR TITLE
feat(r-28): apply-family & grouping — outer(), tapply(), split(), tabulate()

### DIFF
--- a/code/packages/rust/r-runtime/CHANGELOG.md
+++ b/code/packages/rust/r-runtime/CHANGELOG.md
@@ -2,6 +2,35 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.23.0] - 2026-06-21
+
+### Added (via the shared `s-runtime`)
+
+- **R-28 — apply-family & grouping**: a second pivot into the data/utility area,
+  the grouping and table builtins that pair R's functional toolkit (R-10) with
+  matrices (R-11) and factors. All pure builtins in the shared `s-runtime` (no
+  grammar change), reached through ordinary R syntax.
+  - **`outer(X, Y, FUN = "*")`** — `outer(1:3, 1:2)` → the 3×2 column-major
+    product matrix `c(1,2,3,2,4,6)`; `outer(1:2, 1:2, "+")` → the sums;
+    `outer(1:2, 1:2, \(a, b) a*10 + b)` → `c(11,21,12,22)` (an arbitrary
+    function, called per `(i, j)` pair).
+  - **`tapply(X, INDEX, FUN)`** — `tapply(c(1,2,3,4), c("a","b","a","b"), sum)`
+    → the named vector `c(a = 4, b = 6)`; a factor `INDEX` works too.
+  - **`split(x, f)`** — `split(1:4, c("a","b","a","b"))` →
+    `list(a = c(1,3), b = c(2,4))` (a named list, one element per level).
+  - **`tabulate(bin, nbins = max(bin))`** — `tabulate(c(1,2,2,3,3,3))` →
+    `c(1,2,3)`; `tabulate(c(2,3,5), nbins = 5)` → `c(0,1,1,0,1)`.
+  - **`names()`** now reports a named list's element names (so
+    `names(split(...))` returns the levels rather than `NULL`).
+  - **Security**: `outer` guards `nrow*ncol` with `checked_mul` against
+    `MAX_SEQ_LEN` *before* allocating (a crafted `outer(1:1e6, 1:1e6)` is a clean
+    error, not an OOM); `tabulate` clamps `nbins` to `[0, MAX_SEQ_LEN]`. A
+    non-callable `FUN`, a length-mismatched `INDEX`, and empty inputs are all
+    clean errors / empty results, never panics.
+  - 8 new R-syntax tests.
+  - **Deferred to R-29**: the `%o%` infix alias (needs a grammar rule), matrix
+    dimnames, multi-way `tapply`, and `simplify = FALSE`.
+
 ## [0.22.0] - 2026-06-20
 
 ### Added (via the shared `s-runtime`)

--- a/code/packages/rust/r-runtime/README.md
+++ b/code/packages/rust/r-runtime/README.md
@@ -144,7 +144,23 @@ flag = "0")` → `"000042"`. `prettyNum(1234567, big.mark = ",")` → `"1,234,56
 (`sprintf("%d-%s", 1:2, c("a","b"))` → `c("1-a", "2-b")`). Every field width and
 precision is capped at 1 MiB so a crafted `fmt` or a huge `width=` cannot trigger
 a giant allocation. (Exotic `formatC` corners — `format = "g"` rounding, the
-`" "`/`"#"` flags, `scientific=` — are deferred to R-28.)
+`" "`/`"#"` flags, `scientific=` — are deferred to a later formatting pass.)
+
+**Apply-family & grouping (R-28)** — the grouping and table builtins that pair
+R's functional toolkit (R-10) with matrices (R-11) and factors. `outer(X, Y,
+FUN = "*")` builds the `length(X) × length(Y)` column-major matrix of
+`FUN(X[i], Y[j])`: `outer(1:3, 1:2)` → the 3×2 product matrix, and `FUN` may be
+`"*"`/`"+"` or an arbitrary function (`outer(1:2, 1:2, \(a, b) a*10 + b)` →
+`c(11, 21, 12, 22)`). `tapply(X, INDEX, FUN)` groups `X` by `INDEX` and applies
+`FUN` per group, returning a named vector (`tapply(c(1,2,3,4),
+c("a","b","a","b"), sum)` → `c(a = 4, b = 6)`). `split(x, f)` partitions into a
+named list (`split(1:4, c("a","b","a","b"))` → `list(a = c(1,3), b = c(2,4))`),
+and `tabulate(bin, nbins = max(bin))` counts occurrences of `1..nbins`
+(`tabulate(c(2,3,5), nbins = 5)` → `c(0,1,1,0,1)`). `outer` guards its element
+count with `checked_mul` against the sequence cap *before* allocating and
+`tabulate` clamps `nbins`, so neither can be turned into an OOM. (The `%o%`
+infix alias, matrix dimnames, multi-way `tapply`, and `simplify = FALSE` are
+deferred to R-29.)
 
 ## Usage
 

--- a/code/packages/rust/r-runtime/src/lib.rs
+++ b/code/packages/rust/r-runtime/src/lib.rs
@@ -2643,4 +2643,125 @@ mod tests {
         // An empty (length-0) input formats to a length-0 character vector.
         assert_eq!(eval_r("format(c())\n").unwrap().length(), 0);
     }
+
+    // --- R-28: apply-family & grouping ----------------------------------
+
+    #[test]
+    fn outer_default_is_the_product_matrix() {
+        // outer(1:3, 1:2) is the 3x2 matrix of products, stored column-major:
+        //   col 0 (Y=1): 1, 2, 3   col 1 (Y=2): 2, 4, 6
+        assert_eq!(
+            nums("c(outer(1:3, 1:2))\n"),
+            vec![1.0, 2.0, 3.0, 2.0, 4.0, 6.0]
+        );
+        // Dimensions are c(length(X), length(Y)).
+        assert_eq!(nums("dim(outer(1:3, 1:2))\n"), vec![3.0, 2.0]);
+    }
+
+    #[test]
+    fn outer_with_plus_sums_the_grid() {
+        // outer(1:2, 1:2, "+") column-major: col0(Y=1): 2,3  col1(Y=2): 3,4
+        assert_eq!(nums("c(outer(1:2, 1:2, \"+\"))\n"), vec![2.0, 3.0, 3.0, 4.0]);
+    }
+
+    #[test]
+    fn outer_with_an_arbitrary_function() {
+        // outer(1:2, 1:2, \(a, b) a*10 + b) — FUN called per (i, j) pair.
+        //   col 0 (Y=1): 11, 21   col 1 (Y=2): 12, 22
+        assert_eq!(
+            nums("c(outer(1:2, 1:2, \\(a, b) a * 10 + b))\n"),
+            vec![11.0, 21.0, 12.0, 22.0]
+        );
+        // FUN = named form also works.
+        assert_eq!(
+            nums("c(outer(c(2, 3), c(4, 5), FUN = \\(a, b) a + b))\n"),
+            vec![6.0, 7.0, 7.0, 8.0]
+        );
+    }
+
+    #[test]
+    fn tapply_groups_and_applies_named() {
+        // Group by INDEX, apply per group, named by sorted unique levels.
+        assert_eq!(
+            nums("tapply(c(1, 2, 3, 4), c(\"a\", \"b\", \"a\", \"b\"), sum)\n"),
+            vec![4.0, 6.0]
+        );
+        assert_eq!(
+            names_of("names(tapply(c(1, 2, 3, 4), c(\"a\", \"b\", \"a\", \"b\"), sum))\n"),
+            vec!["a", "b"]
+        );
+        // A non-sum reducer (mean) and a factor INDEX both work.
+        assert_eq!(
+            nums("tapply(c(10, 20, 30, 40), factor(c(\"x\", \"y\", \"x\", \"y\")), mean)\n"),
+            vec![20.0, 30.0]
+        );
+    }
+
+    #[test]
+    fn split_partitions_into_a_named_list() {
+        // split(1:4, c("a","b","a","b")) → list(a = c(1, 3), b = c(2, 4)).
+        assert_eq!(
+            nums("split(1:4, c(\"a\", \"b\", \"a\", \"b\"))[[\"a\"]]\n"),
+            vec![1.0, 3.0]
+        );
+        assert_eq!(
+            nums("split(1:4, c(\"a\", \"b\", \"a\", \"b\"))[[\"b\"]]\n"),
+            vec![2.0, 4.0]
+        );
+        assert_eq!(
+            names_of("names(split(1:4, c(\"a\", \"b\", \"a\", \"b\")))\n"),
+            vec!["a", "b"]
+        );
+        // The result is a list of length nlevels.
+        assert_eq!(
+            nums("length(split(1:4, c(\"a\", \"b\", \"a\", \"b\")))\n"),
+            vec![2.0]
+        );
+    }
+
+    #[test]
+    fn tabulate_counts_one_through_nbins() {
+        // Default nbins = max(bin): counts of 1, 2, 3 are 1, 2, 3.
+        assert_eq!(nums("tabulate(c(1, 2, 2, 3, 3, 3))\n"), vec![1.0, 2.0, 3.0]);
+        // Explicit nbins: gaps are zeros, values > nbins are dropped.
+        assert_eq!(
+            nums("tabulate(c(2, 3, 5), nbins = 5)\n"),
+            vec![0.0, 1.0, 1.0, 0.0, 1.0]
+        );
+        // Values < 1 and > nbins are ignored.
+        assert_eq!(nums("tabulate(c(0, 1, 2, 99), nbins = 2)\n"), vec![1.0, 1.0]);
+    }
+
+    #[test]
+    fn r28_malformed_inputs_do_not_panic() {
+        // outer with a non-callable FUN → clean error, no panic.
+        assert!(eval_r("outer(1:2, 1:2, 5)\n").is_err());
+        // tapply with a non-callable FUN → clean error.
+        assert!(eval_r("tapply(c(1, 2), c(\"a\", \"b\"), 7)\n").is_err());
+        // An INDEX shorter than X simply truncates (extra X elements with no
+        // label are dropped) rather than panicking.
+        assert_eq!(
+            nums("tapply(c(1, 2, 3), c(\"a\", \"b\"), sum)\n"),
+            vec![1.0, 2.0]
+        );
+        // An empty input yields an empty (length-0) result, not a panic.
+        assert_eq!(eval_r("split(c(), c())\n").unwrap().length(), 0);
+        assert_eq!(eval_r("tabulate(c())\n").unwrap().length(), 0);
+        // tabulate with a non-finite/negative nbins clamps to length 0.
+        assert_eq!(
+            eval_r("tabulate(c(1, 2), nbins = -5)\n").unwrap().length(),
+            0
+        );
+    }
+
+    #[test]
+    fn outer_output_size_is_capped() {
+        // outer(1:1e6, 1:1e6) would be 1e12 elements (~8 TB) — rejected by the
+        // checked_mul + MAX_SEQ_LEN guard BEFORE any allocation, not OOM.
+        assert!(eval_r("outer(1:1000000, 1:1000000)\n").is_err());
+        // tabulate with a giant nbins is likewise rejected cleanly.
+        assert!(eval_r("tabulate(c(1), nbins = 1e18)\n").is_err());
+        // A modest outer still succeeds (sanity: the guard is not over-eager).
+        assert_eq!(nums("dim(outer(1:10, 1:10))\n"), vec![10.0, 10.0]);
+    }
 }

--- a/code/packages/rust/s-runtime/CHANGELOG.md
+++ b/code/packages/rust/s-runtime/CHANGELOG.md
@@ -2,6 +2,50 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.24.0] - 2026-06-21
+
+### Added
+
+- **Apply-family & grouping builtins (R-28)** — pure builtins available to both
+  S and R via the shared tree-walker; no grammar change. Pair the R-10
+  functional toolkit with R-11 matrices, R-6 lists, and factors.
+  - **`outer(X, Y, FUN = "*")`** — the outer product generalised to any binary
+    operation: the `length(X) × length(Y)` column-major matrix of
+    `FUN(X[i], Y[j])`. `FUN` defaults to `"*"` and may be `"*"`/`"+"` (taken on a
+    fast numeric path) **or any callable** (closure / builtin / `\(a, b) …`
+    lambda), invoked once per `(i, j)` pair. `outer(1:3, 1:2)` → the 3×2 product
+    matrix; `outer(1:2, 1:2, \(a, b) a*10 + b)` → `[[11,12],[21,22]]`.
+  - **`tapply(X, INDEX, FUN)`** — group `X` by `INDEX` (a factor or any vector
+    coerced to character labels), apply `FUN` per group, return a **named**
+    vector (names = sorted unique levels). `tapply(c(1,2,3,4),
+    c("a","b","a","b"), sum)` → `c(a = 4, b = 6)`.
+  - **`split(x, f)`** — partition `x` by `f` into a **named list** (one element
+    per level). `split(1:4, c("a","b","a","b"))` → `list(a = c(1,3), b = c(2,4))`.
+  - **`tabulate(bin, nbins = max(bin))`** — count occurrences of each of
+    `1..nbins` in `bin`; values `< 1`, `> nbins`, and `NA` are ignored.
+    `tabulate(c(2,3,5), nbins = 5)` → `c(0,1,1,0,1)`.
+- **`names()` on a named list** now returns its element names (an unset element
+  name renders as `""`, a wholly-unnamed list as `NULL`) — correct R behaviour
+  that `split()`'s named-list result relies on.
+
+### Security
+
+- **Output-size caps.** `outer` computes its element count `nrow*ncol` with
+  `checked_mul` and rejects an overflowing or `> MAX_SEQ_LEN` product with a
+  clean `Index` error **before** any allocation, so a crafted
+  `outer(1:1e6, 1:1e6)` cannot OOM. `tabulate` clamps `nbins` to
+  `[0, MAX_SEQ_LEN]` (non-finite/negative → `0`; over-large → clean error), so a
+  crafted `nbins = 1e18` cannot allocate terabytes. A non-callable `FUN`
+  (to `outer`/`tapply`) is a clean `NotCallable` error; an `INDEX`/`f` whose
+  length differs from the data recycles/truncates against the data length rather
+  than panicking; empty groups and empty inputs yield empty results.
+
+### Deferred to R-29
+
+- The `%o%` infix alias for `outer` (needs a grammar rule), matrix dimnames
+  carried by `outer`/`tapply`, multi-way `tapply` (a list of factors →
+  N-dimensional array), and `simplify = FALSE`.
+
 ## [0.23.0] - 2026-06-20
 
 ### Added

--- a/code/packages/rust/s-runtime/README.md
+++ b/code/packages/rust/s-runtime/README.md
@@ -175,7 +175,19 @@ a hand-written loop. See [What "S-flavored" means here](#what-s-flavored-means-h
   collapses a vector to one string. The `MAX_FIELD = 1 MiB` field-width cap is
   shared across all of them, so a crafted `fmt` or a huge `width=`/`nsmall=`/
   `digits=` cannot trigger a giant allocation. (Exotic `formatC` corners —
-  `format = "g"` rounding, `" "`/`"#"` flags, `scientific=` — deferred to R-28.)
+  `format = "g"` rounding, `" "`/`"#"` flags, `scientific=` — deferred to a later
+  formatting pass.)
+- **Apply-family & grouping builtins** (R-28): `outer`, `tapply`, `split`, and
+  `tabulate` — the grouping/table functions that pair the R-10 functional toolkit
+  with R-11 matrices, R-6 lists, and factors. `outer(X, Y, FUN = "*")` builds the
+  `length(X) × length(Y)` column-major matrix of `FUN(X[i], Y[j])` (`FUN` is
+  `"*"`/`"+"` on a fast numeric path, or any callable per `(i, j)` pair);
+  `tapply(X, INDEX, FUN)` groups `X` by `INDEX` and returns a named vector;
+  `split(x, f)` returns a named list partitioning `x` by level; `tabulate(bin,
+  nbins = max(bin))` counts `1..nbins`. `outer` guards `nrow*ncol` with
+  `checked_mul` against `MAX_SEQ_LEN` *before* allocating and `tabulate` clamps
+  `nbins`, so neither is a DoS vector. (`%o%` infix, matrix dimnames, multi-way
+  `tapply`, and `simplify = FALSE` are deferred to R-29.)
 - The **`d`/`p`/`q`/`r` distribution family** (R-8) over `statistics-core`:
   density/CDF/quantile/sampling for the normal, uniform, and exponential
   distributions, plus `set.seed` for a reproducible per-session RNG.

--- a/code/packages/rust/s-runtime/src/builtins.rs
+++ b/code/packages/rust/s-runtime/src/builtins.rs
@@ -121,6 +121,13 @@ pub fn install(env: &Env) {
     define(env, "Negate", builtin("Negate", b_negate));
     define(env, "Recall", builtin("Recall", b_recall));
 
+    // Apply-family & grouping (R-28) — pair the functional toolkit (R-10) with
+    // matrices (R-11), lists (R-6), and factors (F4).
+    define(env, "outer", builtin("outer", b_outer));
+    define(env, "tapply", builtin("tapply", b_tapply));
+    define(env, "split", builtin("split", b_split));
+    define(env, "tabulate", builtin("tabulate", b_tabulate));
+
     // Regular expressions (R-7).
     define(env, "grepl", builtin("grepl", b_grepl));
     define(env, "grep", builtin("grep", b_grep));
@@ -312,6 +319,15 @@ fn b_names(_interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
             Ok(SValue::Character(names.iter().cloned().map(Some).collect()))
         }
         SValue::Named { names, .. } => Ok(SValue::Character(names.clone())),
+        // A named list (R-6 / R-28 `split`): report its element names. R renders an
+        // *unset* element name as `""` rather than `NA`, and a list with *no* names
+        // at all as `NULL`.
+        SValue::List { names, .. } if names.iter().any(|n| n.is_some()) => Ok(SValue::Character(
+            names
+                .iter()
+                .map(|n| Some(n.clone().unwrap_or_default()))
+                .collect(),
+        )),
         _ => Ok(SValue::Null),
     }
 }
@@ -3418,6 +3434,319 @@ fn b_vapply(interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
         });
     }
     Ok(combine(&results))
+}
+
+// ===========================================================================
+// Apply-family & grouping (R-28)
+// ===========================================================================
+//
+// These pair the R-10 functional toolkit (`split_fun`, `interp.call_value`) with
+// the R-11 matrix, the R-6 list, and the factor machinery (F4). They are pure
+// builtins — no grammar change. The watchword is *bounded allocation*: `outer`
+// is O(len(X)·len(Y)), so the product is guarded with `checked_mul` against
+// `MAX_SEQ_LEN` *before* anything is allocated; `tabulate` caps `nbins`.
+
+/// `outer(X, Y, FUN = "*")` — the **outer product** generalised to any binary
+/// operation. The result is the `length(X) × length(Y)` matrix whose `(i, j)`
+/// entry is `FUN(X[i], Y[j])`, stored **column-major** (R-11 `SValue::Matrix`,
+/// element `(i, j)` at `j*nrow + i`).
+///
+/// ```text
+///   X = c(1, 2, 3), Y = c(1, 2), FUN = "*"
+///
+///        Y[0]=1  Y[1]=2          column-major data:
+///   X0=1   1       2               col 0 (Y=1): 1, 2, 3
+///   X1=2   2       4               col 1 (Y=2): 2, 4, 6
+///   X2=3   3       6             → c(1, 2, 3, 2, 4, 6), nrow=3, ncol=2
+/// ```
+///
+/// `FUN` defaults to `"*"` and may be:
+///   - the string `"*"` or `"+"` — taken on a **fast numeric path** (no per-cell
+///     function call), or
+///   - **any callable** (a closure, builtin, or R-9 lambda), invoked once per
+///     `(i, j)` pair through `interp.call_value` — so
+///     `outer(1:2, 1:2, \(a, b) a*10 + b)` works.
+///
+/// **Output-size cap (security).** The element count `nrow*ncol` is computed with
+/// [`usize::checked_mul`] and rejected with a clean `Index` error when it
+/// overflows or exceeds [`MAX_SEQ_LEN`] — *before* the result `Vec` is allocated,
+/// so a crafted `outer(1:1e6, 1:1e6)` cannot OOM. A non-callable `FUN` is a clean
+/// `NotCallable` error.
+fn b_outer(interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
+    let positional: Vec<&Arg> = args.iter().filter(|a| a.name.is_none()).collect();
+    let x = positional
+        .first()
+        .map(|a| a.value.clone())
+        .ok_or_else(|| SError::BadArgs("outer: missing X".into()))?;
+    let y = positional
+        .get(1)
+        .map(|a| a.value.clone())
+        .ok_or_else(|| SError::BadArgs("outer: missing Y".into()))?;
+    // `FUN` is the third positional or the `FUN =` named argument; default "*".
+    let fun = args
+        .iter()
+        .find(|a| a.name.as_deref() == Some("FUN"))
+        .map(|a| a.value.clone())
+        .or_else(|| positional.get(2).map(|a| a.value.clone()))
+        .unwrap_or_else(|| SValue::Character(vec![Some("*".to_string())]));
+
+    let nrow = x.length();
+    let ncol = y.length();
+    // Guard the product BEFORE allocating: refuse overflow or > MAX_SEQ_LEN.
+    let total = nrow.checked_mul(ncol).filter(|&t| t <= MAX_SEQ_LEN).ok_or_else(|| {
+        SError::Index(format!("outer: result too large (limit {MAX_SEQ_LEN} elements)"))
+    })?;
+
+    // Fast numeric paths for the two arithmetic primitives, identified by the
+    // string forms "*" / "+". Anything else (including a function value) goes
+    // through the general per-cell `call_value` path.
+    let op: Option<fn(f64, f64) -> f64> = match fun.strip_names() {
+        SValue::Character(v) if v.len() == 1 => match v[0].as_deref() {
+            Some("*") => Some(|a, b| a * b),
+            Some("+") => Some(|a, b| a + b),
+            _ => None,
+        },
+        _ => None,
+    };
+
+    if let Some(op) = op {
+        // Numeric fast path: read both inputs as doubles once, then fill
+        // column-major. NA in either operand propagates through f64 NA.
+        let xs = x.as_double()?;
+        let ys = y.as_double()?;
+        let mut out = vec![0.0; total];
+        for j in 0..ncol {
+            let yj = ys.get_value(j).unwrap_or_else(na_real);
+            for i in 0..nrow {
+                let xi = xs.get_value(i).unwrap_or_else(na_real);
+                out[j * nrow + i] = if is_na_real(xi) || is_na_real(yj) {
+                    na_real()
+                } else {
+                    op(xi, yj)
+                };
+            }
+        }
+        return Ok(SValue::Matrix {
+            data: Double::from_values(out),
+            nrow,
+            ncol,
+        });
+    }
+
+    // General path: `FUN` must be callable. Invoke it once per (i, j), reading a
+    // single double back from each result (R simplifies length-1 atomics).
+    if !fun.is_callable() {
+        return Err(SError::NotCallable(fun.type_name().to_string()));
+    }
+    let mut out = vec![0.0; total];
+    for j in 0..ncol {
+        let yj = nth_element(&y, j);
+        for i in 0..nrow {
+            let xi = nth_element(&x, i);
+            let r = interp.call_value(
+                fun.clone(),
+                &[
+                    Arg { name: None, value: xi },
+                    Arg {
+                        name: None,
+                        value: yj.clone(),
+                    },
+                ],
+            )?;
+            // Take the first element as a double (NA if absent/empty).
+            out[j * nrow + i] = r.as_double()?.get_value(0).unwrap_or_else(na_real);
+        }
+    }
+    Ok(SValue::Matrix {
+        data: Double::from_values(out),
+        nrow,
+        ncol,
+    })
+}
+
+/// Compute the **sorted, distinct, non-NA** group labels of an `INDEX`/`f`
+/// argument, *plus* the per-element label (one `Option<String>` per element of
+/// `index`, `None` where the element is `NA`). A `Factor` keeps its declared
+/// `levels` order (R semantics: factor levels define the group order even if some
+/// are empty); any other vector is coerced to character labels and the distinct
+/// labels are sorted.
+///
+/// Returns `(levels, labels)` where `labels[k]` is the group of element `k`.
+fn group_labels(index: &SValue) -> (Vec<String>, Vec<Option<String>>) {
+    match index.strip_names() {
+        SValue::Factor { codes, levels } => {
+            let labels: Vec<Option<String>> = codes
+                .iter()
+                .map(|c| c.and_then(|k| levels.get((k as usize).wrapping_sub(1)).cloned()))
+                .collect();
+            (levels.clone(), labels)
+        }
+        other => {
+            let labels = other.as_character();
+            let mut seen: HashSet<String> = HashSet::new();
+            let mut levels: Vec<String> = labels
+                .iter()
+                .flatten()
+                .filter(|s| seen.insert((*s).clone()))
+                .cloned()
+                .collect();
+            levels.sort();
+            (levels, labels)
+        }
+    }
+}
+
+/// Partition the elements of `x` into groups keyed by `labels`, one bucket per
+/// entry of `levels` (in `levels` order). Each bucket holds the `nth_element`
+/// values of `x` whose label matches; elements whose label is `NA` or not a level
+/// are dropped (R's `split`/`tapply` semantics). The data length governs the
+/// iteration, so a shorter/longer `INDEX` simply truncates/ignores extra labels —
+/// never an index panic.
+fn partition_by_group(x: &SValue, levels: &[String], labels: &[Option<String>]) -> Vec<SValue> {
+    let mut buckets: Vec<Vec<Arg>> = vec![Vec::new(); levels.len()];
+    let n = x.length();
+    for k in 0..n {
+        if let Some(Some(label)) = labels.get(k) {
+            if let Some(g) = levels.iter().position(|lv| lv == label) {
+                buckets[g].push(Arg {
+                    name: None,
+                    value: nth_element(x, k),
+                });
+            }
+        }
+    }
+    buckets.iter().map(|b| combine(b)).collect()
+}
+
+/// `tapply(X, INDEX, FUN)` — **table apply**: split `X` into groups by `INDEX`,
+/// apply `FUN` to each group, and return a **named** vector (names = the sorted
+/// unique levels, in lockstep with the per-group results).
+///
+/// ```text
+///   tapply(c(1, 2, 3, 4), c("a", "b", "a", "b"), sum)
+///     group "a" = c(1, 3) → sum = 4
+///     group "b" = c(2, 4) → sum = 6
+///   → c(a = 4, b = 6)
+/// ```
+///
+/// Reuses `split_fun` (to locate the callable `FUN`) and `group_labels` /
+/// `partition_by_group`. A non-callable `FUN` is a clean `NotCallable` error.
+fn b_tapply(interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
+    // The function is the callable argument (FUN =, or the callable positional);
+    // the remaining positionals are X then INDEX.
+    let (fun, data) = split_fun(args, "tapply")?;
+    let x = data
+        .first()
+        .cloned()
+        .ok_or_else(|| SError::BadArgs("tapply: missing X".into()))?;
+    let index = data
+        .get(1)
+        .cloned()
+        .ok_or_else(|| SError::BadArgs("tapply: missing INDEX".into()))?;
+
+    let (levels, labels) = group_labels(&index);
+    let groups = partition_by_group(&x, &levels, &labels);
+
+    // Apply FUN to each group, taking the first element of the (length-1) result.
+    let mut values: Vec<f64> = Vec::with_capacity(groups.len());
+    for group in &groups {
+        let r = interp.call_value(
+            fun.clone(),
+            &[Arg {
+                name: None,
+                value: group.clone(),
+            }],
+        )?;
+        values.push(r.as_double()?.get_value(0).unwrap_or_else(na_real));
+    }
+    let names: Vec<Option<String>> = levels.into_iter().map(Some).collect();
+    Ok(SValue::with_names(SValue::doubles(values), names))
+}
+
+/// `split(x, f)` — partition `x` by the factor (or coerced vector) `f`, returning
+/// a **named list**: one element per level (in sorted-unique-level order), names
+/// = the levels.
+///
+/// ```text
+///   split(1:4, c("a", "b", "a", "b"))
+///     → list(a = c(1, 3), b = c(2, 4))
+/// ```
+///
+/// Reuses the R-6 `SValue::List` construction via `group_labels` /
+/// `partition_by_group`.
+fn b_split(_interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
+    let positional: Vec<&Arg> = args.iter().filter(|a| a.name.is_none()).collect();
+    let x = positional
+        .first()
+        .map(|a| a.value.clone())
+        .ok_or_else(|| SError::BadArgs("split: missing x".into()))?;
+    let f = args
+        .iter()
+        .find(|a| a.name.as_deref() == Some("f"))
+        .map(|a| a.value.clone())
+        .or_else(|| positional.get(1).map(|a| a.value.clone()))
+        .ok_or_else(|| SError::BadArgs("split: missing f".into()))?;
+
+    let (levels, labels) = group_labels(&f);
+    let groups = partition_by_group(&x, &levels, &labels);
+    let names: Vec<Option<String>> = levels.into_iter().map(Some).collect();
+    Ok(SValue::List {
+        names,
+        items: groups,
+    })
+}
+
+/// `tabulate(bin, nbins = max(bin))` — count how many times each of `1..nbins`
+/// appears in the integer vector `bin`. Returns an integer (double) vector of
+/// length `nbins`. Values `< 1`, `> nbins`, and `NA` are silently ignored
+/// (matching R).
+///
+/// ```text
+///   tabulate(c(1, 2, 2, 3, 3, 3))   → c(1, 2, 3)   (nbins defaults to max = 3)
+///   tabulate(c(2, 3, 5), nbins = 5) → c(0, 1, 1, 0, 1)
+/// ```
+///
+/// **Output-size cap (security).** `nbins` is **data** — a crafted `nbins = 1e18`
+/// (or a `bin` containing a huge value, which feeds the default) must not allocate
+/// terabytes. `nbins` is clamped to `[0, MAX_SEQ_LEN]`: a non-finite or negative
+/// request becomes `0`, and an over-large one is a clean `Index` error.
+fn b_tabulate(_interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
+    let bin = first_positional(args)?.as_double()?;
+
+    // Default nbins = max(bin) (0 when bin is empty or has no finite element).
+    let default_nbins = bin
+        .iter()
+        .filter(|x| !is_na_real(*x) && x.is_finite())
+        .fold(0.0f64, |acc, x| acc.max(x))
+        .floor();
+    let nbins_f = match args.iter().find(|a| a.name.as_deref() == Some("nbins")) {
+        Some(a) => a.value.as_double()?.get_value(0).unwrap_or(default_nbins),
+        None => default_nbins,
+    };
+
+    // Clamp to a sane, allocation-safe range. Non-finite / negative → 0.
+    let nbins: usize = if !nbins_f.is_finite() || nbins_f < 1.0 {
+        0
+    } else if nbins_f > MAX_SEQ_LEN as f64 {
+        return Err(SError::Index(format!(
+            "tabulate: nbins too large (limit {MAX_SEQ_LEN})"
+        )));
+    } else {
+        nbins_f.floor() as usize
+    };
+
+    let mut counts = vec![0.0f64; nbins];
+    for x in bin.iter() {
+        if is_na_real(x) || !x.is_finite() {
+            continue;
+        }
+        // R floors toward the integer bin; values in [1, nbins] count.
+        let b = x.floor();
+        if b >= 1.0 && b <= nbins as f64 {
+            counts[(b as usize) - 1] += 1.0;
+        }
+    }
+    Ok(SValue::doubles(counts))
 }
 
 fn builtin(name: &str, func: fn(&Interpreter, &[Arg]) -> SResult<SValue>) -> SValue {

--- a/code/specs/R00-r-language.md
+++ b/code/specs/R00-r-language.md
@@ -854,6 +854,58 @@ unchanged.
     `big.mark=` on `formatC`, and scientific-notation control on `format()` (`scientific=`)
     — kept out to keep this PR a clean partial rather than a sprawling one.
 
+- **R-28 — apply-family & grouping** *(this PR)*. A second pivot into the data/utility
+  area: the **grouping and table** builtins that pair R's functional toolkit (R-10's
+  `sapply`/`Reduce`/`Map`) with its matrix (R-11) and factor (R's F4) machinery.
+  Everything is a pure builtin in the shared `s-runtime` (R inherits via the
+  tree-walker); **no grammar change**. Four functions:
+  - **`outer(X, Y, FUN = "*")`** — the *outer product* generalised to any binary
+    operation. Builds the `length(X) × length(Y)` matrix whose `(i, j)` entry is
+    `FUN(X[i], Y[j])`, stored **column-major** (reusing the R-11 `SValue::Matrix`
+    representation), so `outer(1:3, 1:2)` is the 3×2 matrix `[[1,2,3],[2,4,6]]`
+    (column-major data `c(1,2,3,2,4,6)`). `FUN` defaults to `"*"` and may be the
+    string `"*"` or `"+"` (taken fast, element-by-element) **or an arbitrary
+    function** — a closure, a builtin, or an R-9 lambda — invoked through
+    `interp.call_value` once per `(i, j)` pair: `outer(1:2, 1:2, \(a, b) a*10 + b)`
+    is `[[11,12],[21,22]]` (column-major `c(11, 21, 12, 22)`). (The `%o%` infix
+    alias is **deferred to R-29** — it needs a grammar rule; the named `outer(...)`
+    form covers the same ground.)
+  - **`tapply(X, INDEX, FUN)`** — *table apply*: split `X` into groups by `INDEX`
+    (a factor, or any vector coerced to its character labels), apply `FUN` to each
+    group, and return a **named** vector — names are the **sorted unique levels**,
+    in lockstep with the per-group results. `tapply(c(1,2,3,4), c("a","b","a","b"),
+    sum)` is the named vector `c(a = 4, b = 6)`. Reuses the R-10 `split_fun` /
+    `call_value` plumbing and the factor-level machinery (F4).
+  - **`split(x, f)`** — partition `x` by the factor (or coerced vector) `f`, returning
+    a **named list** (one element per level, in sorted-unique-level order, names = the
+    levels): `split(1:4, c("a","b","a","b"))` is `list(a = c(1, 3), b = c(2, 4))`.
+    Reuses the R-6 `SValue::List` construction.
+  - **`tabulate(bin, nbins = max(bin))`** — count how many times each of `1..nbins`
+    appears in the integer vector `bin`, returning an integer vector of length
+    `nbins`. Values `< 1` or `> nbins` (and `NA`) are silently ignored, matching R:
+    `tabulate(c(1,2,2,3,3,3))` is `c(1, 2, 3)`; `tabulate(c(2,3,5), nbins = 5)` is
+    `c(0, 1, 1, 0, 1)`.
+  - **Output-size caps (security).** `X`, `Y`, `bin`, `nbins` are all **data** and a
+    crafted call must never trigger a giant allocation or a panic. `outer` is
+    `O(length(X) · length(Y))`: the element count is computed with **`checked_mul`**
+    and rejected (clean `Index` error) when it overflows or exceeds **`MAX_SEQ_LEN`**
+    *before* any `Vec` is allocated. `tabulate` caps `nbins` at `MAX_SEQ_LEN` (a
+    crafted `nbins = 1e18` or a `bin` containing a huge value must not allocate
+    terabytes); a non-finite or negative `nbins` clamps to `0`. `tapply`/`split`
+    allocate at most one slot per input element (already `MAX_SEQ_LEN`-bounded) plus
+    one group per distinct level (≤ element count), so no extra cap is needed. A
+    non-callable `FUN` (to `outer`/`tapply`) is a clean `NotCallable` error; an
+    `INDEX`/`f` whose length differs from `X`/`x` recycles/truncates against the data
+    length rather than panicking; empty groups and an empty input yield empty results,
+    never an index panic.
+  - **Scope outcome / deferred to R-29.** `outer` (with `"*"`, `"+"`, and an
+    arbitrary function), `tapply`, `split`, and `tabulate` ship **solidly**. Deferred
+    to **R-29**: the `%o%` infix alias for `outer` (needs a grammar rule); matrix
+    **dimnames** carried by `outer`/`tapply` (the results are unnamed in the matrix
+    dimension, named only where R-15's vector/list `names` already reach);
+    `tapply` over a *multi-way* `INDEX` (a list of factors → an N-dimensional array);
+    and `simplify = FALSE` (always-list `tapply`).
+
 ## §4 Reuse strategy
 
 - **Lexer/parser:** the grammar-tools framework, exactly as S uses it. `r.tokens`
@@ -879,7 +931,10 @@ active bindings, and multiple inheritance (`contains = c("A", "B")`) completing
 the R5 system in **R-26**); the output-formatting family (`format`, `formatC`,
 `prettyNum`, `toString`, vectorized `sprintf`) lands in **R-27**, with the exotic
 `formatC` corners (`format = "g"` rounding edges, the `" "`/`"#"` flags,
-`scientific=`) deferred to **R-28**; namespaces and `library()`
+`scientific=`) deferred to a later formatting pass; the apply-family & grouping
+builtins (`outer`, `tapply`, `split`, `tabulate`) land in **R-28**, with the `%o%`
+infix alias, matrix dimnames, multi-way `tapply`, and `simplify = FALSE` deferred to
+**R-29**; namespaces and `library()`
 (so `baseenv()` aliases the
 global env for now); the C interface; graphics. These layer on later, following
 ST00.


### PR DESCRIPTION
## R-28 — apply-family & grouping

Implements four grouping/table builtins in the shared `s-runtime` (R inherits via the tree-walker) — pure builtins, **no grammar change**. Builds on R-10's functional toolkit (`split_fun`, `call_value`), R-11 matrices, R-6 lists, and factors (F4).

### Shipped
- **`outer(X, Y, FUN = "*")`** — `length(X) × length(Y)` column-major matrix of `FUN(X[i], Y[j])`. Fast numeric path for `"*"`/`"+"`; arbitrary callable `FUN` (closure / builtin / `\(a, b) …` lambda) invoked once per `(i, j)` pair via `interp.call_value`. `outer(1:3, 1:2)` → the 3×2 product matrix; `outer(1:2, 1:2, \(a, b) a*10 + b)` → `c(11, 21, 12, 22)`.
- **`tapply(X, INDEX, FUN)`** — group `X` by `INDEX` (factor or coerced vector), apply `FUN` per group, **named** vector (names = sorted unique levels). `tapply(c(1,2,3,4), c("a","b","a","b"), sum)` → `c(a = 4, b = 6)`.
- **`split(x, f)`** — **named list** partitioning `x` by level. `split(1:4, c("a","b","a","b"))` → `list(a = c(1,3), b = c(2,4))`.
- **`tabulate(bin, nbins = max(bin))`** — integer counts of `1..nbins`; values `< 1`, `> nbins`, `NA` ignored. `tabulate(c(2,3,5), nbins = 5)` → `c(0,1,1,0,1)`.
- **`names()` on a named list** now returns its element names (was `NULL`) — correct R behaviour that `split()`'s result relies on.

Shared helpers: `group_labels` (sorted-unique levels + per-element label; factor order preserved) and `partition_by_group` (data-length-bounded bucketing; drops unmatched/NA labels so a shorter/longer `INDEX` never panics).

### Output-size caps (DoS)
- **`outer`** computes `nrow*ncol` with `checked_mul` against `MAX_SEQ_LEN` **before** any allocation — a crafted `outer(1:1e6, 1:1e6)` is a clean `Index` error, not OOM.
- **`tabulate`** clamps `nbins` to `[0, MAX_SEQ_LEN]` (non-finite/negative → `0`; over-large → clean error) — a crafted `nbins = 1e18` cannot allocate terabytes.
- Non-callable `FUN` → `NotCallable`; length-mismatched `INDEX`/`f` recycles/truncates against the data length; empty groups/inputs yield empty results. No panics.

### Deferred to R-29
`%o%` infix alias (needs a grammar rule), matrix dimnames on `outer`/`tapply`, multi-way `tapply` (list of factors → N-d array), and `simplify = FALSE`.

### Tests
8 new R-syntax tests in `r-runtime` (mirroring `nums()`/`names_of()`): outer product/sum/arbitrary-fn + dims, tapply named result + factor INDEX + mean, split named list + names + length, tabulate default/explicit nbins, malformed-input no-panic (non-callable FUN, short INDEX, empty input, negative nbins), and the outer/tabulate size-cap rejection. **All green** — 223 r-runtime + 202 s-runtime tests pass; clippy clean on both crates; diff is functional-only (450 insertions, 0 deletions, no rustfmt churn on pre-existing lines).

### Security review
A sub-agent senior-Rust-security review of `git diff origin/main...HEAD` returned **PASS** with no CRITICAL/HIGH/MEDIUM/LOW findings: the `outer` size guard precedes allocation, `tabulate`'s `nbins` clamp uses an exact f64 comparison (`MAX_SEQ_LEN ≪ 2^53`), and every attacker-controlled index path uses `.get()` / `checked_mul` / `unwrap_or` rather than panicking operations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
