### PR TITLE
[codex] Add mesh handoff work-order guardrail readiness summary

### DIFF
--- a/code/packages/rust/smart-home-integration-catalog/CHANGELOG.md
+++ b/code/packages/rust/smart-home-integration-catalog/CHANGELOG.md
@@ -164,6 +164,8 @@ All notable changes to this package will be documented in this file.
 - `IntegrationMeshReleaseTicketHandoffExecutionWorkOrderGuardrail` and summary
   helpers for classifying handoff work-order lanes into release blockers,
   operator handoffs, review gates, and ready-to-execute checks.
+- `IntegrationMeshReleaseTicketHandoffWorkOrderGuardrailReadinessSummary` and
+  helpers for combining work-order readiness with handoff guardrail state.
 - Primitive backlog planning helpers for ranking the shared primitive families
   needed by priority-bounded rollout waves.
 - Integration activation planning helpers for resolving virtual aliases,

--- a/code/packages/rust/smart-home-integration-catalog/README.md
+++ b/code/packages/rust/smart-home-integration-catalog/README.md
@@ -136,6 +136,9 @@ runtime and Chief of Staff tools a typed catalog for:
 - low-level mesh release ticket handoff execution work-order guardrails that
   classify lane work into release blockers, operator handoffs, review gates,
   and ready-to-execute checks
+- mesh release ticket handoff work-order guardrail readiness summaries that
+  combine work-order readiness with guardrail counts and first actionable
+  handoff work
 - primitive backlog planning for prioritizing the shared families needed by a
   rollout wave
 - activation plans that resolve direct integrations, virtual aliases, and

--- a/code/packages/rust/smart-home-integration-catalog/src/lib.rs
+++ b/code/packages/rust/smart-home-integration-catalog/src/lib.rs
@@ -8151,6 +8151,383 @@ impl IntegrationMeshReleaseTicketHandoffWorkOrderReadinessSummary {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IntegrationMeshReleaseTicketHandoffWorkOrderGuardrailReadinessSummary {
+    pub release_ticket_handoff_work_order_readiness_summary:
+        IntegrationMeshReleaseTicketHandoffWorkOrderReadinessSummary,
+    pub release_ticket_handoff_execution_work_order_guardrail_summary:
+        IntegrationMeshReleaseTicketHandoffExecutionWorkOrderGuardrailSummary,
+    pub total_tickets: usize,
+    pub ready_tickets: usize,
+    pub blocked_tickets: usize,
+    pub review_required_tickets: usize,
+    pub operator_required_tickets: usize,
+    pub dispatch_required_tickets: usize,
+    pub total_handoff_packets: usize,
+    pub total_execution_slots: usize,
+    pub total_work_orders: usize,
+    pub ready_work_orders: usize,
+    pub blocked_work_orders: usize,
+    pub review_required_work_orders: usize,
+    pub operator_required_work_orders: usize,
+    pub dispatch_required_work_orders: usize,
+    pub release_lane_work_orders: usize,
+    pub operator_lane_work_orders: usize,
+    pub repair_lane_work_orders: usize,
+    pub review_lane_work_orders: usize,
+    pub execution_required_work_orders: usize,
+    pub total_guardrails: usize,
+    pub release_blocker_guardrails: usize,
+    pub operator_handoff_guardrails: usize,
+    pub review_gate_guardrails: usize,
+    pub ready_to_execute_guardrails: usize,
+    pub release_blocking_guardrails: usize,
+    pub operator_required_guardrails: usize,
+    pub review_required_guardrails: usize,
+    pub dispatch_required_guardrails: usize,
+    pub execution_required_guardrails: usize,
+    pub queued_substrate_actions: usize,
+    pub remediation_item_count: usize,
+    pub review_required_packages: usize,
+    pub operator_required_packages: usize,
+    pub blocked_packages: usize,
+    pub first_guardrail_key: Option<String>,
+    pub first_guardrail_work_order_key: Option<String>,
+    pub first_release_blocker_work_order_key: Option<String>,
+    pub first_operator_handoff_work_order_key: Option<String>,
+    pub first_review_gate_work_order_key: Option<String>,
+    pub first_ready_to_execute_work_order_key: Option<String>,
+    pub first_guardrail_kind:
+        Option<IntegrationMeshReleaseTicketHandoffExecutionWorkOrderGuardrailKind>,
+    pub first_handoff_lane: Option<IntegrationMeshReleaseDispatchTicketHandoffLane>,
+    pub first_check_kind: Option<IntegrationMeshReleaseReadinessCheckKind>,
+    pub first_check_status: Option<IntegrationMeshReleaseReadinessStatus>,
+    pub next_work_order_key: Option<String>,
+    pub next_execution_slot_key: Option<String>,
+    pub next_packet_key: Option<String>,
+    pub next_ticket_key: Option<String>,
+    pub next_dispatch_key: Option<String>,
+    pub next_task_key: Option<String>,
+    pub next_slot_key: Option<String>,
+    pub next_check_kind: Option<IntegrationMeshReleaseReadinessCheckKind>,
+    pub next_check_status: Option<IntegrationMeshReleaseReadinessStatus>,
+    pub next_package_kind: Option<IntegrationMeshReadinessHandoffKind>,
+    pub next_handoff_status: Option<IntegrationMeshReadinessHandoffStatus>,
+    pub next_handoff_lane: Option<IntegrationMeshReleaseDispatchTicketHandoffLane>,
+    pub packet_status: IntegrationMeshReleaseReadinessStatus,
+    pub execution_status: IntegrationMeshReleaseReadinessStatus,
+    pub release_packet_ready: bool,
+    pub release_execution_ready: bool,
+    pub release_tasks_ready: bool,
+    pub release_dispatch_ready: bool,
+    pub release_ticket_ready: bool,
+    pub release_handoff_ready: bool,
+    pub release_handoff_execution_ready: bool,
+    pub release_ticket_handoff_execution_ready: bool,
+    pub release_handoff_execution_work_orders_ready: bool,
+    pub release_ticket_handoff_work_orders_ready: bool,
+    pub release_handoff_execution_work_order_guardrails_ready: bool,
+    pub release_ticket_handoff_work_order_guardrails_ready: bool,
+}
+
+impl IntegrationMeshReleaseTicketHandoffWorkOrderGuardrailReadinessSummary {
+    pub fn from_summaries(
+        release_ticket_handoff_work_order_readiness_summary: IntegrationMeshReleaseTicketHandoffWorkOrderReadinessSummary,
+        release_ticket_handoff_execution_work_order_guardrail_summary: IntegrationMeshReleaseTicketHandoffExecutionWorkOrderGuardrailSummary,
+    ) -> Self {
+        let release_handoff_execution_work_order_guardrails_ready =
+            release_ticket_handoff_execution_work_order_guardrail_summary
+                .release_handoff_execution_work_order_guardrails_ready;
+        let release_ticket_handoff_work_order_guardrails_ready =
+            release_ticket_handoff_work_order_readiness_summary
+                .ready_for_release_ticket_handoff_work_orders()
+                && release_handoff_execution_work_order_guardrails_ready;
+        let next_guardrail_work_order_key =
+            if release_ticket_handoff_execution_work_order_guardrail_summary.requires_attention() {
+                release_ticket_handoff_execution_work_order_guardrail_summary
+                    .first_work_order_key
+                    .clone()
+            } else {
+                None
+            };
+        let next_guardrail_check_kind =
+            if release_ticket_handoff_execution_work_order_guardrail_summary.requires_attention() {
+                release_ticket_handoff_execution_work_order_guardrail_summary.first_check_kind
+            } else {
+                None
+            };
+        let next_guardrail_check_status =
+            if release_ticket_handoff_execution_work_order_guardrail_summary.requires_attention() {
+                release_ticket_handoff_execution_work_order_guardrail_summary.first_check_status
+            } else {
+                None
+            };
+        let next_guardrail_handoff_lane =
+            if release_ticket_handoff_execution_work_order_guardrail_summary.requires_attention() {
+                release_ticket_handoff_execution_work_order_guardrail_summary.first_handoff_lane
+            } else {
+                None
+            };
+
+        Self {
+            total_tickets: release_ticket_handoff_work_order_readiness_summary.total_tickets,
+            ready_tickets: release_ticket_handoff_work_order_readiness_summary.ready_tickets,
+            blocked_tickets: release_ticket_handoff_work_order_readiness_summary.blocked_tickets,
+            review_required_tickets: release_ticket_handoff_work_order_readiness_summary
+                .review_required_tickets,
+            operator_required_tickets: release_ticket_handoff_work_order_readiness_summary
+                .operator_required_tickets,
+            dispatch_required_tickets: release_ticket_handoff_work_order_readiness_summary
+                .dispatch_required_tickets,
+            total_handoff_packets: release_ticket_handoff_work_order_readiness_summary
+                .total_handoff_packets,
+            total_execution_slots: release_ticket_handoff_work_order_readiness_summary
+                .total_execution_slots,
+            total_work_orders: release_ticket_handoff_work_order_readiness_summary
+                .total_work_orders,
+            ready_work_orders: release_ticket_handoff_work_order_readiness_summary
+                .ready_work_orders,
+            blocked_work_orders: release_ticket_handoff_work_order_readiness_summary
+                .blocked_work_orders,
+            review_required_work_orders: release_ticket_handoff_work_order_readiness_summary
+                .review_required_work_orders,
+            operator_required_work_orders: release_ticket_handoff_work_order_readiness_summary
+                .operator_required_work_orders,
+            dispatch_required_work_orders: release_ticket_handoff_work_order_readiness_summary
+                .dispatch_required_work_orders,
+            release_lane_work_orders: release_ticket_handoff_work_order_readiness_summary
+                .release_lane_work_orders,
+            operator_lane_work_orders: release_ticket_handoff_work_order_readiness_summary
+                .operator_lane_work_orders,
+            repair_lane_work_orders: release_ticket_handoff_work_order_readiness_summary
+                .repair_lane_work_orders,
+            review_lane_work_orders: release_ticket_handoff_work_order_readiness_summary
+                .review_lane_work_orders,
+            execution_required_work_orders: release_ticket_handoff_work_order_readiness_summary
+                .execution_required_work_orders,
+            total_guardrails: release_ticket_handoff_execution_work_order_guardrail_summary
+                .total_guardrails,
+            release_blocker_guardrails:
+                release_ticket_handoff_execution_work_order_guardrail_summary
+                    .release_blocker_guardrails,
+            operator_handoff_guardrails:
+                release_ticket_handoff_execution_work_order_guardrail_summary
+                    .operator_handoff_guardrails,
+            review_gate_guardrails: release_ticket_handoff_execution_work_order_guardrail_summary
+                .review_gate_guardrails,
+            ready_to_execute_guardrails:
+                release_ticket_handoff_execution_work_order_guardrail_summary
+                    .ready_to_execute_guardrails,
+            release_blocking_guardrails:
+                release_ticket_handoff_execution_work_order_guardrail_summary
+                    .release_blocking_guardrails,
+            operator_required_guardrails:
+                release_ticket_handoff_execution_work_order_guardrail_summary
+                    .operator_required_guardrails,
+            review_required_guardrails:
+                release_ticket_handoff_execution_work_order_guardrail_summary
+                    .review_required_guardrails,
+            dispatch_required_guardrails:
+                release_ticket_handoff_execution_work_order_guardrail_summary
+                    .dispatch_required_guardrails,
+            execution_required_guardrails:
+                release_ticket_handoff_execution_work_order_guardrail_summary
+                    .execution_required_guardrails,
+            queued_substrate_actions: release_ticket_handoff_work_order_readiness_summary
+                .queued_substrate_actions,
+            remediation_item_count: release_ticket_handoff_work_order_readiness_summary
+                .remediation_item_count,
+            review_required_packages: release_ticket_handoff_work_order_readiness_summary
+                .review_required_packages,
+            operator_required_packages: release_ticket_handoff_work_order_readiness_summary
+                .operator_required_packages,
+            blocked_packages: release_ticket_handoff_work_order_readiness_summary.blocked_packages,
+            first_guardrail_key: release_ticket_handoff_execution_work_order_guardrail_summary
+                .first_guardrail_key
+                .clone(),
+            first_guardrail_work_order_key:
+                release_ticket_handoff_execution_work_order_guardrail_summary
+                    .first_work_order_key
+                    .clone(),
+            first_release_blocker_work_order_key:
+                release_ticket_handoff_execution_work_order_guardrail_summary
+                    .first_release_blocker_work_order_key
+                    .clone(),
+            first_operator_handoff_work_order_key:
+                release_ticket_handoff_execution_work_order_guardrail_summary
+                    .first_operator_handoff_work_order_key
+                    .clone(),
+            first_review_gate_work_order_key:
+                release_ticket_handoff_execution_work_order_guardrail_summary
+                    .first_review_gate_work_order_key
+                    .clone(),
+            first_ready_to_execute_work_order_key:
+                release_ticket_handoff_execution_work_order_guardrail_summary
+                    .first_ready_to_execute_work_order_key
+                    .clone(),
+            first_guardrail_kind: release_ticket_handoff_execution_work_order_guardrail_summary
+                .first_guardrail_kind,
+            first_handoff_lane: release_ticket_handoff_execution_work_order_guardrail_summary
+                .first_handoff_lane,
+            first_check_kind: release_ticket_handoff_execution_work_order_guardrail_summary
+                .first_check_kind,
+            first_check_status: release_ticket_handoff_execution_work_order_guardrail_summary
+                .first_check_status,
+            next_work_order_key: next_guardrail_work_order_key.or_else(|| {
+                release_ticket_handoff_work_order_readiness_summary
+                    .next_work_order_key
+                    .clone()
+            }),
+            next_execution_slot_key: release_ticket_handoff_execution_work_order_guardrail_summary
+                .next_execution_slot_key
+                .clone()
+                .or_else(|| {
+                    release_ticket_handoff_work_order_readiness_summary
+                        .next_execution_slot_key
+                        .clone()
+                }),
+            next_packet_key: release_ticket_handoff_execution_work_order_guardrail_summary
+                .next_packet_key
+                .clone()
+                .or_else(|| {
+                    release_ticket_handoff_work_order_readiness_summary
+                        .next_packet_key
+                        .clone()
+                }),
+            next_ticket_key: release_ticket_handoff_execution_work_order_guardrail_summary
+                .next_ticket_key
+                .clone()
+                .or_else(|| {
+                    release_ticket_handoff_work_order_readiness_summary
+                        .next_ticket_key
+                        .clone()
+                }),
+            next_dispatch_key: release_ticket_handoff_work_order_readiness_summary
+                .next_dispatch_key
+                .clone(),
+            next_task_key: release_ticket_handoff_work_order_readiness_summary
+                .next_task_key
+                .clone(),
+            next_slot_key: release_ticket_handoff_work_order_readiness_summary
+                .next_slot_key
+                .clone(),
+            next_check_kind: next_guardrail_check_kind
+                .or(release_ticket_handoff_work_order_readiness_summary.next_check_kind),
+            next_check_status: next_guardrail_check_status
+                .or(release_ticket_handoff_work_order_readiness_summary.next_check_status),
+            next_package_kind: release_ticket_handoff_work_order_readiness_summary
+                .next_package_kind,
+            next_handoff_status: release_ticket_handoff_work_order_readiness_summary
+                .next_handoff_status,
+            next_handoff_lane: next_guardrail_handoff_lane
+                .or(release_ticket_handoff_work_order_readiness_summary.next_handoff_lane),
+            packet_status: release_ticket_handoff_work_order_readiness_summary.packet_status,
+            execution_status: release_ticket_handoff_work_order_readiness_summary.execution_status,
+            release_packet_ready: release_ticket_handoff_work_order_readiness_summary
+                .release_packet_ready,
+            release_execution_ready: release_ticket_handoff_work_order_readiness_summary
+                .release_execution_ready,
+            release_tasks_ready: release_ticket_handoff_work_order_readiness_summary
+                .release_tasks_ready,
+            release_dispatch_ready: release_ticket_handoff_work_order_readiness_summary
+                .release_dispatch_ready,
+            release_ticket_ready: release_ticket_handoff_work_order_readiness_summary
+                .release_ticket_ready,
+            release_handoff_ready: release_ticket_handoff_work_order_readiness_summary
+                .release_handoff_ready,
+            release_handoff_execution_ready: release_ticket_handoff_work_order_readiness_summary
+                .release_handoff_execution_ready,
+            release_ticket_handoff_execution_ready:
+                release_ticket_handoff_work_order_readiness_summary
+                    .release_ticket_handoff_execution_ready,
+            release_handoff_execution_work_orders_ready:
+                release_ticket_handoff_work_order_readiness_summary
+                    .release_handoff_execution_work_orders_ready,
+            release_ticket_handoff_work_orders_ready:
+                release_ticket_handoff_work_order_readiness_summary
+                    .release_ticket_handoff_work_orders_ready,
+            release_handoff_execution_work_order_guardrails_ready,
+            release_ticket_handoff_work_order_guardrails_ready,
+            release_ticket_handoff_work_order_readiness_summary,
+            release_ticket_handoff_execution_work_order_guardrail_summary,
+        }
+    }
+
+    pub fn has_guardrails(&self) -> bool {
+        self.total_guardrails > 0
+    }
+
+    pub fn ready_for_release_ticket_handoff_work_order_guardrails(&self) -> bool {
+        self.execution_status == IntegrationMeshReleaseReadinessStatus::Ready
+            && self.release_packet_ready
+            && self.release_execution_ready
+            && self.release_tasks_ready
+            && self.release_dispatch_ready
+            && self.release_ticket_ready
+            && self.release_handoff_ready
+            && self.release_handoff_execution_ready
+            && self.release_ticket_handoff_execution_ready
+            && self.release_handoff_execution_work_orders_ready
+            && self.release_ticket_handoff_work_orders_ready
+            && self.release_handoff_execution_work_order_guardrails_ready
+            && self.release_ticket_handoff_work_order_guardrails_ready
+            && !self.requires_attention()
+    }
+
+    pub fn has_blockers(&self) -> bool {
+        self.release_blocker_guardrails > 0
+            || self.release_blocking_guardrails > 0
+            || self
+                .release_ticket_handoff_work_order_readiness_summary
+                .has_blockers()
+            || self
+                .release_ticket_handoff_execution_work_order_guardrail_summary
+                .has_release_blockers()
+    }
+
+    pub fn has_review_work(&self) -> bool {
+        self.review_gate_guardrails > 0
+            || self.review_required_guardrails > 0
+            || self
+                .release_ticket_handoff_work_order_readiness_summary
+                .has_review_work()
+            || self
+                .release_ticket_handoff_execution_work_order_guardrail_summary
+                .has_review_gates()
+    }
+
+    pub fn needs_operator(&self) -> bool {
+        self.operator_handoff_guardrails > 0
+            || self.operator_required_guardrails > 0
+            || self
+                .release_ticket_handoff_work_order_readiness_summary
+                .needs_operator()
+            || self
+                .release_ticket_handoff_execution_work_order_guardrail_summary
+                .needs_operator()
+    }
+
+    pub fn requires_execution(&self) -> bool {
+        self.execution_required_work_orders > 0 || self.execution_required_guardrails > 0
+    }
+
+    pub fn requires_attention(&self) -> bool {
+        self.requires_execution()
+            || self.dispatch_required_work_orders > 0
+            || self.dispatch_required_guardrails > 0
+            || self.has_blockers()
+            || self.has_review_work()
+            || self.needs_operator()
+            || self
+                .release_ticket_handoff_work_order_readiness_summary
+                .requires_attention()
+            || self
+                .release_ticket_handoff_execution_work_order_guardrail_summary
+                .requires_attention()
+            || !self.release_ticket_handoff_work_order_guardrails_ready
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct IntegrationCatalogEntry {
     pub integration_id: IntegrationId,
     pub display_name: String,
@@ -30055,6 +30432,47 @@ pub fn mesh_release_ticket_handoff_work_order_readiness_summary(
     )
 }
 
+pub fn mesh_release_ticket_handoff_work_order_guardrail_readiness_summary_for_catalog(
+    catalog: &[IntegrationCatalogEntry],
+    available_primitives: &[PrimitiveFamily],
+    allowed_capabilities: &[CapabilityId],
+    enabled_integrations: &[IntegrationId],
+) -> IntegrationMeshReleaseTicketHandoffWorkOrderGuardrailReadinessSummary {
+    let release_ticket_handoff_work_order_readiness_summary =
+        mesh_release_ticket_handoff_work_order_readiness_summary_for_catalog(
+            catalog,
+            available_primitives,
+            allowed_capabilities,
+            enabled_integrations,
+        );
+    let release_ticket_handoff_execution_work_order_guardrail_summary =
+        mesh_release_ticket_handoff_execution_work_order_guardrail_summary_for_catalog(
+            catalog,
+            available_primitives,
+            allowed_capabilities,
+            enabled_integrations,
+        );
+
+    IntegrationMeshReleaseTicketHandoffWorkOrderGuardrailReadinessSummary::from_summaries(
+        release_ticket_handoff_work_order_readiness_summary,
+        release_ticket_handoff_execution_work_order_guardrail_summary,
+    )
+}
+
+pub fn mesh_release_ticket_handoff_work_order_guardrail_readiness_summary(
+    available_primitives: &[PrimitiveFamily],
+    allowed_capabilities: &[CapabilityId],
+    enabled_integrations: &[IntegrationId],
+) -> IntegrationMeshReleaseTicketHandoffWorkOrderGuardrailReadinessSummary {
+    let catalog = first_party_catalog();
+    mesh_release_ticket_handoff_work_order_guardrail_readiness_summary_for_catalog(
+        &catalog,
+        available_primitives,
+        allowed_capabilities,
+        enabled_integrations,
+    )
+}
+
 fn mesh_protocol_catalog_entries(
     catalog: &[IntegrationCatalogEntry],
 ) -> Vec<IntegrationCatalogEntry> {
@@ -42013,6 +42431,227 @@ mod tests {
         assert!(summary.ready_for_release_ticket_handoff_work_orders());
         assert!(summary.has_work_orders());
         assert!(!summary.has_repair_work());
+        assert!(!summary.has_blockers());
+        assert!(!summary.has_review_work());
+        assert!(!summary.needs_operator());
+        assert!(!summary.requires_execution());
+        assert!(!summary.requires_attention());
+    }
+
+    #[test]
+    fn mesh_release_ticket_handoff_work_order_guardrail_readiness_summary_surfaces_guardrail_attention(
+    ) {
+        let available_primitives = vec![
+            PrimitiveFamily::Usb,
+            PrimitiveFamily::SerialController,
+            PrimitiveFamily::Radio802154,
+            PrimitiveFamily::Supervision,
+        ];
+        let allowed_capabilities = vec![CapabilityId::trusted("smart_home.read")];
+        let summary = mesh_release_ticket_handoff_work_order_guardrail_readiness_summary(
+            &available_primitives,
+            &allowed_capabilities,
+            &[],
+        );
+
+        assert_eq!(summary.total_tickets, 5);
+        assert_eq!(summary.blocked_tickets, 3);
+        assert_eq!(summary.review_required_tickets, 2);
+        assert_eq!(summary.operator_required_tickets, 4);
+        assert_eq!(summary.dispatch_required_tickets, 5);
+        assert_eq!(summary.total_work_orders, 5);
+        assert_eq!(summary.ready_work_orders, 0);
+        assert_eq!(summary.blocked_work_orders, 3);
+        assert_eq!(summary.review_required_work_orders, 2);
+        assert_eq!(summary.operator_required_work_orders, 4);
+        assert_eq!(summary.dispatch_required_work_orders, 5);
+        assert_eq!(summary.release_lane_work_orders, 0);
+        assert_eq!(summary.repair_lane_work_orders, 3);
+        assert_eq!(summary.review_lane_work_orders, 2);
+        assert_eq!(summary.execution_required_work_orders, 5);
+        assert_eq!(summary.total_guardrails, 5);
+        assert_eq!(summary.release_blocker_guardrails, 3);
+        assert_eq!(summary.operator_handoff_guardrails, 0);
+        assert_eq!(summary.review_gate_guardrails, 2);
+        assert_eq!(summary.ready_to_execute_guardrails, 0);
+        assert_eq!(summary.release_blocking_guardrails, 3);
+        assert_eq!(summary.operator_required_guardrails, 4);
+        assert_eq!(summary.review_required_guardrails, 2);
+        assert_eq!(summary.dispatch_required_guardrails, 5);
+        assert_eq!(summary.execution_required_guardrails, 5);
+        assert_eq!(summary.queued_substrate_actions, 5);
+        assert_eq!(summary.remediation_item_count, 2);
+        assert_eq!(summary.review_required_packages, 1);
+        assert_eq!(summary.operator_required_packages, 6);
+        assert_eq!(summary.blocked_packages, 5);
+        assert_eq!(
+            summary.first_guardrail_key,
+            Some(
+                "release-ticket-handoff-execution-work-order-guardrail-01-release_blocker-substrate_actions"
+                    .to_string()
+            )
+        );
+        assert_eq!(
+            summary.first_guardrail_work_order_key,
+            Some(
+                "release-ticket-handoff-execution-work-order-01-repair-substrate_actions"
+                    .to_string()
+            )
+        );
+        assert_eq!(
+            summary.first_release_blocker_work_order_key,
+            Some(
+                "release-ticket-handoff-execution-work-order-01-repair-substrate_actions"
+                    .to_string()
+            )
+        );
+        assert_eq!(
+            summary.first_review_gate_work_order_key,
+            Some(
+                "release-ticket-handoff-execution-work-order-02-review-evidence_remediation"
+                    .to_string()
+            )
+        );
+        assert_eq!(
+            summary.first_guardrail_kind,
+            Some(
+                IntegrationMeshReleaseTicketHandoffExecutionWorkOrderGuardrailKind::ReleaseBlocker
+            )
+        );
+        assert_eq!(
+            summary.first_handoff_lane,
+            Some(IntegrationMeshReleaseDispatchTicketHandoffLane::Repair)
+        );
+        assert_eq!(
+            summary.next_work_order_key,
+            Some(
+                "release-ticket-handoff-execution-work-order-01-repair-substrate_actions"
+                    .to_string()
+            )
+        );
+        assert_eq!(
+            summary.next_execution_slot_key,
+            Some("release-ticket-handoff-execution-slot-01-repair-substrate_actions".to_string())
+        );
+        assert_eq!(
+            summary.next_packet_key,
+            Some("release-dispatch-handoff-packet-01-substrate_actions".to_string())
+        );
+        assert_eq!(
+            summary.next_ticket_key,
+            Some("release-dispatch-ticket-01-substrate_actions".to_string())
+        );
+        assert_eq!(
+            summary.next_check_kind,
+            Some(IntegrationMeshReleaseReadinessCheckKind::SubstrateActions)
+        );
+        assert_eq!(
+            summary.next_check_status,
+            Some(IntegrationMeshReleaseReadinessStatus::Blocked)
+        );
+        assert_eq!(
+            summary.next_handoff_lane,
+            Some(IntegrationMeshReleaseDispatchTicketHandoffLane::Repair)
+        );
+        assert!(!summary.release_handoff_execution_work_order_guardrails_ready);
+        assert!(!summary.release_ticket_handoff_work_order_guardrails_ready);
+        assert!(!summary.ready_for_release_ticket_handoff_work_order_guardrails());
+        assert!(summary.has_guardrails());
+        assert!(summary.has_blockers());
+        assert!(summary.has_review_work());
+        assert!(summary.needs_operator());
+        assert!(summary.requires_execution());
+        assert!(summary.requires_attention());
+    }
+
+    #[test]
+    fn mesh_release_ticket_handoff_work_order_guardrail_readiness_summary_marks_release_ready() {
+        let catalog = vec![hue_entry()];
+        let allowed_capabilities = vec![
+            CapabilityId::trusted("smart_home.read"),
+            CapabilityId::trusted("smart_home.command.light"),
+            CapabilityId::trusted("smart_home.pair"),
+        ];
+        let summary =
+            mesh_release_ticket_handoff_work_order_guardrail_readiness_summary_for_catalog(
+                &catalog,
+                all_primitive_families(),
+                &allowed_capabilities,
+                &[],
+            );
+
+        assert_eq!(summary.total_tickets, 5);
+        assert_eq!(summary.ready_tickets, 5);
+        assert_eq!(summary.blocked_tickets, 0);
+        assert_eq!(summary.total_work_orders, 5);
+        assert_eq!(summary.ready_work_orders, 5);
+        assert_eq!(summary.blocked_work_orders, 0);
+        assert_eq!(summary.release_lane_work_orders, 5);
+        assert_eq!(summary.execution_required_work_orders, 0);
+        assert_eq!(summary.total_guardrails, 5);
+        assert_eq!(summary.release_blocker_guardrails, 0);
+        assert_eq!(summary.operator_handoff_guardrails, 0);
+        assert_eq!(summary.review_gate_guardrails, 0);
+        assert_eq!(summary.ready_to_execute_guardrails, 5);
+        assert_eq!(summary.release_blocking_guardrails, 0);
+        assert_eq!(summary.operator_required_guardrails, 0);
+        assert_eq!(summary.review_required_guardrails, 0);
+        assert_eq!(summary.dispatch_required_guardrails, 0);
+        assert_eq!(summary.execution_required_guardrails, 0);
+        assert_eq!(
+            summary.first_guardrail_key,
+            Some(
+                "release-ticket-handoff-execution-work-order-guardrail-01-ready_to_execute-substrate_actions"
+                    .to_string()
+            )
+        );
+        assert_eq!(
+            summary.first_guardrail_work_order_key,
+            Some(
+                "release-ticket-handoff-execution-work-order-01-release-substrate_actions"
+                    .to_string()
+            )
+        );
+        assert_eq!(summary.first_release_blocker_work_order_key, None);
+        assert_eq!(summary.first_operator_handoff_work_order_key, None);
+        assert_eq!(summary.first_review_gate_work_order_key, None);
+        assert_eq!(
+            summary.first_ready_to_execute_work_order_key,
+            Some(
+                "release-ticket-handoff-execution-work-order-01-release-substrate_actions"
+                    .to_string()
+            )
+        );
+        assert_eq!(
+            summary.first_guardrail_kind,
+            Some(
+                IntegrationMeshReleaseTicketHandoffExecutionWorkOrderGuardrailKind::ReadyToExecute
+            )
+        );
+        assert_eq!(
+            summary.first_handoff_lane,
+            Some(IntegrationMeshReleaseDispatchTicketHandoffLane::Release)
+        );
+        assert_eq!(summary.next_work_order_key, None);
+        assert_eq!(summary.next_execution_slot_key, None);
+        assert_eq!(summary.next_packet_key, None);
+        assert_eq!(summary.next_ticket_key, None);
+        assert_eq!(summary.next_check_kind, None);
+        assert_eq!(summary.next_check_status, None);
+        assert_eq!(
+            summary.next_package_kind,
+            Some(IntegrationMeshReadinessHandoffKind::ReleaseReady)
+        );
+        assert_eq!(
+            summary.next_handoff_status,
+            Some(IntegrationMeshReadinessHandoffStatus::Ready)
+        );
+        assert_eq!(summary.next_handoff_lane, None);
+        assert!(summary.release_ticket_handoff_work_orders_ready);
+        assert!(summary.release_handoff_execution_work_order_guardrails_ready);
+        assert!(summary.release_ticket_handoff_work_order_guardrails_ready);
+        assert!(summary.ready_for_release_ticket_handoff_work_order_guardrails());
+        assert!(summary.has_guardrails());
         assert!(!summary.has_blockers());
         assert!(!summary.has_review_work());
         assert!(!summary.needs_operator());


### PR DESCRIPTION
## Summary
- add a mesh release ticket handoff work-order guardrail readiness summary that combines work-order readiness with guardrail counts
- expose catalog and first-party helper functions for the combined rollup
- document the new summary and cover blocker and release-ready paths

## Verification
- cargo test mesh_release_ticket_handoff_work_order_guardrail_readiness_summary -- --nocapture
- cargo test
- cargo fmt --check
- git diff --check