### PR TITLE
feat(r-lang): R-29 — vector set operations & ordering (union/intersect/setdiff/is.element/duplicated/rank)

### DIFF
--- a/code/packages/rust/r-runtime/CHANGELOG.md
+++ b/code/packages/rust/r-runtime/CHANGELOG.md
@@ -2,6 +2,36 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.24.0] - 2026-06-21
+
+### Added (via the shared `s-runtime`)
+
+- **R-29 — vector set operations & ordering**: the set-theory and ranking corner
+  of R's base toolkit. All pure builtins in the shared `s-runtime` (no grammar
+  change), reached through ordinary R syntax, numeric- and character-aware.
+  - **`union(x, y)`** — `union(c(1,2), c(2,3))` → `c(1, 2, 3)` (distinct elements
+    of `c(x, y)`, first-occurrence order).
+  - **`intersect(x, y)`** — `intersect(c(1,2,3), c(2,3,4))` → `c(2, 3)` (elements
+    in both, in `x`'s order, deduplicated).
+  - **`setdiff(x, y)`** — `setdiff(c(1,2,3,4), c(2,4))` → `c(1, 3)` (elements of
+    `x` not in `y`, deduplicated).
+  - **`is.element(el, set)`** — `is.element(2, c(1,2,3))` → `TRUE` (the function
+    spelling of `el %in% set`, vectorized over `el`).
+  - **`duplicated(x)`** — `duplicated(c(1,1,2,3,3))` →
+    `c(FALSE, TRUE, FALSE, FALSE, TRUE)` (TRUE where an element repeats an earlier
+    one).
+  - **`rank(x)`** — sample ranks with **average** tie handling (R's default):
+    `rank(c(3,1,2))` → `c(3, 1, 2)`; `rank(c(1,1,2))` → `c(1.5, 1.5, 3)`. Numeric
+    ranks numerically, character lexicographically; result is always numeric.
+  - **Security**: outputs are bounded by the inputs (union ≤ `|x|+|y|`, others ≤
+    `|x|`, each already `MAX_SEQ_LEN`-bounded), so no fresh cap is needed;
+    `rank` is `O(n log n)` with one `f64` per element and no user multiplier;
+    empty inputs yield empty results, `NA` is an ordinary matchable key.
+  - 5 new R-syntax tests (numeric + character).
+  - **Deferred to R-30**: `rank`'s other `ties.method` options, the
+    `incomparables=`/`fromLast=` set-op arguments, `anyDuplicated`, and multi-key
+    `order`.
+
 ## [0.23.0] - 2026-06-21
 
 ### Added (via the shared `s-runtime`)

--- a/code/packages/rust/r-runtime/README.md
+++ b/code/packages/rust/r-runtime/README.md
@@ -160,7 +160,21 @@ and `tabulate(bin, nbins = max(bin))` counts occurrences of `1..nbins`
 count with `checked_mul` against the sequence cap *before* allocating and
 `tabulate` clamps `nbins`, so neither can be turned into an OOM. (The `%o%`
 infix alias, matrix dimnames, multi-way `tapply`, and `simplify = FALSE` are
-deferred to R-29.)
+deferred to a later pass.)
+
+**Vector set operations & ordering (R-29)** — the set-theory and ranking corner
+of R's base toolkit, all numeric- and character-aware. `union(x, y)` is the
+distinct elements of `c(x, y)` in first-occurrence order (`union(c(1,2),
+c(2,3))` → `c(1, 2, 3)`); `intersect(c(1,2,3), c(2,3,4))` → `c(2, 3)` and
+`setdiff(c(1,2,3,4), c(2,4))` → `c(1, 3)` keep the elements in / not-in `y`,
+deduplicated and in `x`'s order. `is.element(2, c(1,2,3))` → `TRUE` is the
+function spelling of `el %in% set`. `duplicated(c(1,1,2,3,3))` →
+`c(FALSE, TRUE, FALSE, FALSE, TRUE)` flags repeats of earlier elements. `rank(x)`
+gives sample ranks with **average** tie handling (R's default): `rank(c(3,1,2))`
+→ `c(3, 1, 2)` and `rank(c(1,1,2))` → `c(1.5, 1.5, 3)`. Outputs are bounded by
+the inputs (each already sequence-capped) and `rank` is `O(n log n)`, so none is
+a DoS vector. (Other `ties.method` options, `incomparables=`/`fromLast=`,
+`anyDuplicated`, and multi-key `order` are deferred to R-30.)
 
 ## Usage
 

--- a/code/packages/rust/r-runtime/src/lib.rs
+++ b/code/packages/rust/r-runtime/src/lib.rs
@@ -2793,10 +2793,7 @@ mod tests {
     #[test]
     fn is_element_matches_in_operator() {
         assert_eq!(show("is.element(2, c(1, 2, 3))\n"), "[1] TRUE");
-        assert_eq!(
-            show("is.element(c(1, 5), c(1, 2, 3))\n"),
-            "[1]  TRUE FALSE"
-        );
+        assert_eq!(show("is.element(c(1, 5), c(1, 2, 3))\n"), "[1]  TRUE FALSE");
     }
 
     #[test]
@@ -2816,9 +2813,6 @@ mod tests {
         assert_eq!(nums("rank(c(3, 1, 2))\n"), vec![3.0, 1.0, 2.0]);
         assert_eq!(nums("rank(c(1, 1, 2))\n"), vec![1.5, 1.5, 3.0]);
         // Character ranks lexicographically; tied "a"s average their positions.
-        assert_eq!(
-            nums("rank(c(\"b\", \"a\", \"a\"))\n"),
-            vec![3.0, 1.5, 1.5]
-        );
+        assert_eq!(nums("rank(c(\"b\", \"a\", \"a\"))\n"), vec![3.0, 1.5, 1.5]);
     }
 }

--- a/code/packages/rust/r-runtime/src/lib.rs
+++ b/code/packages/rust/r-runtime/src/lib.rs
@@ -2764,4 +2764,61 @@ mod tests {
         // A modest outer still succeeds (sanity: the guard is not over-eager).
         assert_eq!(nums("dim(outer(1:10, 1:10))\n"), vec![10.0, 10.0]);
     }
+
+    // --- R-29: vector set operations & ordering (R syntax) --------------
+
+    #[test]
+    fn union_intersect_setdiff_numeric() {
+        assert_eq!(nums("union(c(1, 2), c(2, 3))\n"), vec![1.0, 2.0, 3.0]);
+        assert_eq!(nums("intersect(c(1, 2, 3), c(2, 3, 4))\n"), vec![2.0, 3.0]);
+        assert_eq!(nums("setdiff(c(1, 2, 3, 4), c(2, 4))\n"), vec![1.0, 3.0]);
+    }
+
+    #[test]
+    fn union_intersect_setdiff_character() {
+        assert_eq!(
+            show("union(c(\"a\", \"b\"), c(\"b\", \"c\"))\n"),
+            "[1] \"a\" \"b\" \"c\""
+        );
+        assert_eq!(
+            show("intersect(c(\"a\", \"b\", \"c\"), c(\"c\", \"a\"))\n"),
+            "[1] \"a\" \"c\""
+        );
+        assert_eq!(
+            show("setdiff(c(\"a\", \"b\", \"c\"), c(\"b\"))\n"),
+            "[1] \"a\" \"c\""
+        );
+    }
+
+    #[test]
+    fn is_element_matches_in_operator() {
+        assert_eq!(show("is.element(2, c(1, 2, 3))\n"), "[1] TRUE");
+        assert_eq!(
+            show("is.element(c(1, 5), c(1, 2, 3))\n"),
+            "[1]  TRUE FALSE"
+        );
+    }
+
+    #[test]
+    fn duplicated_flags_repeats() {
+        assert_eq!(
+            show("duplicated(c(1, 1, 2, 3, 3))\n"),
+            "[1] FALSE  TRUE FALSE FALSE  TRUE"
+        );
+        assert_eq!(
+            show("duplicated(c(\"a\", \"b\", \"a\"))\n"),
+            "[1] FALSE FALSE  TRUE"
+        );
+    }
+
+    #[test]
+    fn rank_average_ties() {
+        assert_eq!(nums("rank(c(3, 1, 2))\n"), vec![3.0, 1.0, 2.0]);
+        assert_eq!(nums("rank(c(1, 1, 2))\n"), vec![1.5, 1.5, 3.0]);
+        // Character ranks lexicographically; tied "a"s average their positions.
+        assert_eq!(
+            nums("rank(c(\"b\", \"a\", \"a\"))\n"),
+            vec![3.0, 1.5, 1.5]
+        );
+    }
 }

--- a/code/packages/rust/s-runtime/CHANGELOG.md
+++ b/code/packages/rust/s-runtime/CHANGELOG.md
@@ -2,6 +2,60 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.25.0] - 2026-06-21
+
+### Added
+
+- **Vector set operations & ordering (R-29)** — pure builtins available to both
+  S and R via the shared tree-walker; no grammar change. They treat vectors as
+  multisets and reuse the existing `as_character` key, `value::index`,
+  `value::membership`, and `combine` machinery. Numeric and character vectors are
+  handled uniformly (the comparison key is the coerced character form, exactly as
+  `unique`/`%in%` already do).
+  - **`union(x, y)`** — the distinct elements of `c(x, y)` in **first-occurrence
+    order** (i.e. `unique(c(x, y))`, *not* a sorted set). `union(c(1,2), c(2,3))`
+    → `c(1, 2, 3)`.
+  - **`intersect(x, y)`** — the elements present in both, in `x`'s order,
+    deduplicated. `intersect(c(1,2,3), c(2,3,4))` → `c(2, 3)`.
+  - **`setdiff(x, y)`** — the elements of `x` not in `y`, deduplicated,
+    order-preserving by `x`. `setdiff(c(1,2,3,4), c(2,4))` → `c(1, 3)`.
+  - **`is.element(el, set)`** — the function spelling of `el %in% set` (a
+    vectorized logical, one entry per element of `el`); a thin alias over
+    `value::membership`. `is.element(2, c(1,2,3))` → `TRUE`.
+  - **`duplicated(x)`** — a logical vector, `TRUE` where an element repeats one
+    seen earlier (first occurrence is `FALSE`). `duplicated(c(1,1,2,3,3))` →
+    `c(FALSE, TRUE, FALSE, FALSE, TRUE)`.
+  - **`rank(x)`** — sample ranks with **average** tie handling (R's default
+    `ties.method = "average"`): each element's rank is its 1-based position in
+    ascending order, and a run of equal values shares the mean of the positions
+    it spans. `rank(c(3,1,2))` → `c(3, 1, 2)`; `rank(c(1,1,2))` → `c(1.5, 1.5, 3)`.
+    Numeric ranks numerically, character lexicographically; result is always
+    numeric, `NA` sorts last.
+
+### Security
+
+- **Output-size caps.** Every input is data. The set ops produce at most
+  `length(x) + length(y)` (union) or `length(x)` (intersect/setdiff) elements —
+  each operand already `MAX_SEQ_LEN`-bounded and `union` routes through `combine`
+  (itself bounded), so no result can exceed what the inputs already permit; no
+  fresh cap is introduced. `duplicated`/`is.element` emit one logical per input
+  element; `rank` allocates one `f64` per element and sorts in `O(n log n)` with
+  no user-controlled multiplier. Empty inputs yield empty results and `NA` is an
+  ordinary matchable key, never an index panic.
+
+### Tests
+
+- A `r29_set_ops` module: union/intersect/setdiff (numeric + character;
+  first-occurrence / x-order / dedup), is.element (scalar + vectorized),
+  duplicated, rank (no-ties / average-ties / character), and the empty /
+  all-removed degenerate edges.
+
+### Deferred to R-30
+
+- `rank`'s other `ties.method` options (`"first"`/`"min"`/`"max"`/`"random"`);
+  the `incomparables=`/`fromLast=` set-op arguments; `anyDuplicated`; and
+  multi-key `order(x, y, …)` (single-key `order` from R-13 is unchanged).
+
 ## [0.24.0] - 2026-06-21
 
 ### Added

--- a/code/packages/rust/s-runtime/README.md
+++ b/code/packages/rust/s-runtime/README.md
@@ -187,7 +187,20 @@ a hand-written loop. See [What "S-flavored" means here](#what-s-flavored-means-h
   nbins = max(bin))` counts `1..nbins`. `outer` guards `nrow*ncol` with
   `checked_mul` against `MAX_SEQ_LEN` *before* allocating and `tabulate` clamps
   `nbins`, so neither is a DoS vector. (`%o%` infix, matrix dimnames, multi-way
-  `tapply`, and `simplify = FALSE` are deferred to R-29.)
+  `tapply`, and `simplify = FALSE` are deferred to a later pass.)
+- **Vector set operations & ordering** (R-29): `union`, `intersect`, `setdiff`,
+  `is.element`, `duplicated`, and `rank` — vectors treated as multisets, all
+  numeric- and character-aware (they key on the same coerced-character form as
+  `unique`/`%in%`). `union(x, y)` is the distinct elements of `c(x, y)` in
+  first-occurrence order (`union(c(1,2), c(2,3))` → `c(1,2,3)`); `intersect`/
+  `setdiff` keep the elements in/not-in `y`, deduplicated and in `x`'s order;
+  `is.element(el, set)` is the function spelling of `el %in% set`; `duplicated(x)`
+  flags repeats of earlier elements (`duplicated(c(1,1,2,3,3))` →
+  `c(F,T,F,F,T)`); and `rank(x)` gives sample ranks with **average** ties
+  (`rank(c(1,1,2))` → `c(1.5, 1.5, 3)`). Outputs are bounded by the inputs (each
+  already `MAX_SEQ_LEN`-bounded) and `rank` is `O(n log n)`, so none is a DoS
+  vector. (Other `ties.method` options, `incomparables=`/`fromLast=`,
+  `anyDuplicated`, and multi-key `order` are deferred to R-30.)
 - The **`d`/`p`/`q`/`r` distribution family** (R-8) over `statistics-core`:
   density/CDF/quantile/sampling for the normal, uniform, and exponential
   distributions, plus `set.seed` for a reproducible per-session RNG.

--- a/code/packages/rust/s-runtime/src/builtins.rs
+++ b/code/packages/rust/s-runtime/src/builtins.rs
@@ -10,8 +10,8 @@ use crate::env::{define, lookup, Env};
 use crate::error::{SError, SResult};
 use crate::eval::{nth_element, Interpreter};
 use crate::value::{
-    bounded_sequence, class_of, combine, format_number, index, Arg, SValue, MAX_ATTRIBUTES,
-    MAX_SEQ_LEN,
+    bounded_sequence, class_of, combine, format_number, index, membership, Arg, SValue,
+    MAX_ATTRIBUTES, MAX_SEQ_LEN,
 };
 use r_vector::{is_na_real, na_real, Double};
 use statistics_core::distributions::{dnorm, pnorm, qnorm, rnorm};
@@ -83,6 +83,13 @@ pub fn install(env: &Env) {
     define(env, "order", builtin("order", b_order));
     define(env, "rep", builtin("rep", b_rep));
     define(env, "unique", builtin("unique", b_unique));
+    // R-29 — vector set operations & ordering.
+    define(env, "union", builtin("union", b_union));
+    define(env, "intersect", builtin("intersect", b_intersect));
+    define(env, "setdiff", builtin("setdiff", b_setdiff));
+    define(env, "is.element", builtin("is.element", b_is_element));
+    define(env, "duplicated", builtin("duplicated", b_duplicated));
+    define(env, "rank", builtin("rank", b_rank));
     define(env, "which", builtin("which", b_which));
     define(env, "any", builtin("any", b_any));
     define(env, "all", builtin("all", b_all));
@@ -1818,6 +1825,218 @@ fn b_unique(_interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
         .filter_map(|(i, k)| seen.insert(k.clone()).then_some((i + 1) as f64))
         .collect();
     index(v, &SValue::doubles(keep))
+}
+
+// ─── R-29 — vector set operations & ordering ─────────────────────────────────
+//
+// R treats vectors as *multisets* when you ask for set operations: `union`,
+// `intersect`, and `setdiff` all deduplicate, and — crucially — they preserve
+// **first-occurrence order** rather than sorting (R's `union(c(3,1), c(1,2))`
+// is `c(3, 1, 2)`, not `c(1, 2, 3)`). The comparison key is the same coerced
+// *character* form that `unique` and `%in%` already use (`as_character`), so a
+// single code path handles numeric and character vectors uniformly: two values
+// are "the same element" iff their character renderings match. We never build a
+// new value type — we compute which 1-based positions to keep and hand them to
+// `value::index`, which gathers them while preserving the original element type.
+//
+//     union(x, y)     = unique(c(x, y))                  first-occurrence order
+//     intersect(x, y) = keep x[i] once, if key(x[i]) ∈ keys(y)
+//     setdiff(x, y)   = keep x[i] once, if key(x[i]) ∉ keys(y)
+//
+// Output size is bounded by the inputs (union ≤ |x|+|y|, the others ≤ |x|), and
+// every operand is already `MAX_SEQ_LEN`-bounded, so no fresh cap is needed.
+
+/// Read the **two** positional arguments (`x`, `y`) a binary set op expects.
+/// Missing or surplus named arguments are ignored; the *second positional* (not
+/// merely the second argument) is `y`, matching R's argument matching for these
+/// purely positional builtins.
+fn two_positional(args: &[Arg]) -> SResult<(&SValue, &SValue)> {
+    let mut pos = args.iter().filter(|a| a.name.is_none()).map(|a| &a.value);
+    let x = pos
+        .next()
+        .ok_or_else(|| SError::BadArgs("argument \"x\" is missing".into()))?;
+    let y = pos
+        .next()
+        .ok_or_else(|| SError::BadArgs("argument \"y\" is missing".into()))?;
+    Ok((x, y))
+}
+
+/// `union(x, y)` — the distinct elements of `c(x, y)`, in first-occurrence
+/// order. Implemented as `unique(combine(x, y))`: concatenate (reusing `combine`,
+/// the engine behind `c(...)`), then keep the first sighting of each character
+/// key. The result's element type is whatever `combine` produced (numeric if
+/// both sides are numeric, character if either side is character) — identical to
+/// what `c(x, y)` would yield, then deduplicated.
+fn b_union(_interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
+    let (x, y) = two_positional(args)?;
+    let joined = combine(&[
+        Arg {
+            name: None,
+            value: x.clone(),
+        },
+        Arg {
+            name: None,
+            value: y.clone(),
+        },
+    ]);
+    let keys = joined.as_character();
+    let mut seen: HashSet<Option<String>> = HashSet::new();
+    let keep: Vec<f64> = keys
+        .iter()
+        .enumerate()
+        .filter_map(|(i, k)| seen.insert(k.clone()).then_some((i + 1) as f64))
+        .collect();
+    index(&joined, &SValue::doubles(keep))
+}
+
+/// `intersect(x, y)` — the elements present in **both** `x` and `y`, in `x`'s
+/// order, deduplicated. We build `y`'s key-set once, then walk `x` keeping each
+/// position whose key is in `y` *and* has not already been kept (the `seen` set
+/// enforces the dedup).
+fn b_intersect(_interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
+    let (x, y) = two_positional(args)?;
+    let y_keys: HashSet<Option<String>> = y.as_character().into_iter().collect();
+    let mut seen: HashSet<Option<String>> = HashSet::new();
+    let keep: Vec<f64> = x
+        .as_character()
+        .iter()
+        .enumerate()
+        .filter_map(|(i, k)| {
+            (y_keys.contains(k) && seen.insert(k.clone())).then_some((i + 1) as f64)
+        })
+        .collect();
+    index(x, &SValue::doubles(keep))
+}
+
+/// `setdiff(x, y)` — the elements of `x` **not** in `y`, deduplicated, in `x`'s
+/// order. The mirror of `intersect`: keep a position whose key is *absent* from
+/// `y` and not yet seen.
+fn b_setdiff(_interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
+    let (x, y) = two_positional(args)?;
+    let y_keys: HashSet<Option<String>> = y.as_character().into_iter().collect();
+    let mut seen: HashSet<Option<String>> = HashSet::new();
+    let keep: Vec<f64> = x
+        .as_character()
+        .iter()
+        .enumerate()
+        .filter_map(|(i, k)| {
+            (!y_keys.contains(k) && seen.insert(k.clone())).then_some((i + 1) as f64)
+        })
+        .collect();
+    index(x, &SValue::doubles(keep))
+}
+
+/// `is.element(el, set)` — the function spelling of `el %in% set`: a logical
+/// vector, one entry per element of `el`, `TRUE` where it appears in `set`. A
+/// thin alias over `value::membership` so the two stay bug-for-bug identical
+/// (same coercion, same `NA`-matches-`NA` rule).
+fn b_is_element(_interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
+    let (el, set) = two_positional(args)?;
+    Ok(membership(el, set))
+}
+
+/// `duplicated(x)` — a logical vector, `TRUE` for an element that equals one
+/// seen **earlier** (so the first occurrence of every distinct value is
+/// `FALSE`). Same `as_character`-key + `seen`-set scan as `unique`, but it emits
+/// the flag instead of gathering: `seen.insert(k)` returns `true` the first time
+/// we meet a key (→ not a duplicate) and `false` thereafter (→ a duplicate).
+fn b_duplicated(_interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
+    let x = first_positional(args)?;
+    let mut seen: HashSet<Option<String>> = HashSet::new();
+    let flags: Vec<Option<bool>> = x
+        .as_character()
+        .into_iter()
+        .map(|k| Some(!seen.insert(k)))
+        .collect();
+    Ok(SValue::Logical(flags))
+}
+
+/// `rank(x)` — **sample ranks** with **average** tie handling (R's default
+/// `ties.method = "average"`). Conceptually: sort the values ascending; an
+/// element's rank is its 1-based position in that order, and a run of equal
+/// values shares the **mean** of the positions it spans.
+///
+/// ```text
+/// x          = c(1, 1, 2)
+/// sorted     =   1   1   2     positions 1   2   3
+/// the two 1s span positions 1,2  -> average (1+2)/2 = 1.5
+/// rank(x)    = c(1.5, 1.5, 3)
+/// ```
+///
+/// Implementation: sort an index permutation `order` (so `order[p]` is the
+/// original index of the value at sorted-position `p`), then walk `order` in
+/// runs of equal keys, assigning every member of a run the average of the
+/// `[run_start+1 ..= run_end+1]` positions. Numeric input compares numerically;
+/// character input lexicographically. The result is always numeric (averages
+/// are fractional), matching R. `O(n log n)` time, one `f64` per element — no
+/// user-controlled multiplier, so no extra allocation cap is required.
+fn b_rank(_interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
+    let x = first_positional(args)?;
+    // Compute a totally-ordered comparison and a "same key" test from one coerced
+    // form. For numeric vectors we rank on the f64 values (NA sorts last, like R's
+    // default na.last); for character (or anything else) we rank on the string keys.
+    let n = x.length();
+    if n == 0 {
+        return Ok(SValue::doubles(vec![]));
+    }
+
+    // `keys[i]` is the order-and-equality key for the original element `i`.
+    // We use the character rendering for everything except a pure numeric vector,
+    // where numeric comparison is what R uses (and "10" must rank above "9").
+    enum Keys {
+        Num(Vec<f64>),
+        Str(Vec<Option<String>>),
+    }
+    let keys = match x.strip_names().strip_attrs() {
+        SValue::Character(_) | SValue::Factor { .. } => Keys::Str(x.as_character()),
+        other => Keys::Num(other.as_double()?.iter().collect()),
+    };
+
+    let mut order: Vec<usize> = (0..n).collect();
+    match &keys {
+        Keys::Num(v) => order.sort_by(|&a, &b| {
+            // NA (NaN) sorts last, mirroring R's default `na.last = TRUE`.
+            match (is_na_real(v[a]), is_na_real(v[b])) {
+                (true, true) => std::cmp::Ordering::Equal,
+                (true, false) => std::cmp::Ordering::Greater,
+                (false, true) => std::cmp::Ordering::Less,
+                (false, false) => v[a].partial_cmp(&v[b]).unwrap_or(std::cmp::Ordering::Equal),
+            }
+        }),
+        Keys::Str(v) => order.sort_by(|&a, &b| match (&v[a], &v[b]) {
+            (None, None) => std::cmp::Ordering::Equal,
+            (None, Some(_)) => std::cmp::Ordering::Greater,
+            (Some(_), None) => std::cmp::Ordering::Less,
+            (Some(a), Some(b)) => a.cmp(b),
+        }),
+    }
+
+    // Two sorted neighbours are tied iff their keys are equal.
+    let tied = |a: usize, b: usize| -> bool {
+        match &keys {
+            Keys::Num(v) => v[a] == v[b] || (is_na_real(v[a]) && is_na_real(v[b])),
+            Keys::Str(v) => v[a] == v[b],
+        }
+    };
+
+    // Walk the sorted permutation in runs of equal keys; each run gets the
+    // average of the 1-based positions it occupies.
+    let mut ranks = vec![0.0_f64; n];
+    let mut p = 0usize;
+    while p < n {
+        let mut q = p + 1;
+        while q < n && tied(order[p], order[q]) {
+            q += 1;
+        }
+        // Positions p..q (0-based) are 1-based p+1 ..= q; their average is the
+        // midpoint of the first and last 1-based position.
+        let avg = ((p + 1) as f64 + q as f64) / 2.0;
+        for k in p..q {
+            ranks[order[k]] = avg;
+        }
+        p = q;
+    }
+    Ok(SValue::doubles(ranks))
 }
 
 /// `which(x)` — the 1-based indices where logical `x` is `TRUE`.

--- a/code/packages/rust/s-runtime/src/lib.rs
+++ b/code/packages/rust/s-runtime/src/lib.rs
@@ -1928,10 +1928,7 @@ mod r29_set_ops {
     #[test]
     fn is_element_scalar_and_vectorized() {
         assert_eq!(show("is.element(2, c(1, 2, 3))\n"), "[1] TRUE");
-        assert_eq!(
-            show("is.element(c(1, 5), c(1, 2, 3))\n"),
-            "[1]  TRUE FALSE"
-        );
+        assert_eq!(show("is.element(c(1, 5), c(1, 2, 3))\n"), "[1]  TRUE FALSE");
         assert_eq!(show("is.element(\"x\", c(\"a\", \"x\"))\n"), "[1] TRUE");
     }
 
@@ -1971,10 +1968,7 @@ mod r29_set_ops {
     #[test]
     fn rank_character_lexicographic() {
         // "a" < "b" < "c"; the two "a"s share positions 1,2 → 1.5 each.
-        assert_eq!(
-            nums("rank(c(\"b\", \"a\", \"a\"))\n"),
-            vec![3.0, 1.5, 1.5]
-        );
+        assert_eq!(nums("rank(c(\"b\", \"a\", \"a\"))\n"), vec![3.0, 1.5, 1.5]);
     }
 
     // --- degenerate edges ----------------------------------------------
@@ -1992,6 +1986,9 @@ mod r29_set_ops {
 
     #[test]
     fn setdiff_everything_removed_is_empty() {
-        assert_eq!(eval_s("setdiff(c(1, 2), c(1, 2, 3))\n").unwrap().length(), 0);
+        assert_eq!(
+            eval_s("setdiff(c(1, 2), c(1, 2, 3))\n").unwrap().length(),
+            0
+        );
     }
 }

--- a/code/packages/rust/s-runtime/src/lib.rs
+++ b/code/packages/rust/s-runtime/src/lib.rs
@@ -1851,3 +1851,147 @@ mod r24_reference_classes {
         assert_eq!(nums(src), vec![10.0, 2.0]);
     }
 }
+
+#[cfg(test)]
+mod r29_set_ops {
+    //! R-29 vector set operations & ordering, exercised through **S** syntax
+    //! (the shared tree-walker is language-neutral; R inherits the same
+    //! behaviour). Covers `union`/`intersect`/`setdiff`/`is.element`/
+    //! `duplicated`/`rank` over both numeric and character vectors, plus the
+    //! degenerate (empty / all-tied) edges.
+    use super::*;
+
+    fn show(src: &str) -> String {
+        format_value(&eval_s(src).unwrap()).join("\n")
+    }
+
+    fn nums(src: &str) -> Vec<f64> {
+        match eval_s(src).unwrap().strip_names() {
+            SValue::Double(d) => d.data().to_vec(),
+            other => panic!("expected double, got {}", other.type_name()),
+        }
+    }
+
+    // --- union ----------------------------------------------------------
+
+    #[test]
+    fn union_numeric_first_occurrence_order() {
+        assert_eq!(nums("union(c(1, 2), c(2, 3))\n"), vec![1.0, 2.0, 3.0]);
+        // Dedup within each side and across: order follows first sighting.
+        assert_eq!(nums("union(c(3, 3, 1), c(1, 2))\n"), vec![3.0, 1.0, 2.0]);
+    }
+
+    #[test]
+    fn union_character() {
+        assert_eq!(
+            show("union(c(\"a\", \"b\"), c(\"b\", \"c\"))\n"),
+            "[1] \"a\" \"b\" \"c\""
+        );
+    }
+
+    // --- intersect ------------------------------------------------------
+
+    #[test]
+    fn intersect_numeric_order_by_x_dedup() {
+        assert_eq!(nums("intersect(c(1, 2, 3), c(2, 3, 4))\n"), vec![2.0, 3.0]);
+        // A repeated common value appears once, in x's order.
+        assert_eq!(nums("intersect(c(2, 2, 1), c(1, 2))\n"), vec![2.0, 1.0]);
+    }
+
+    #[test]
+    fn intersect_character() {
+        assert_eq!(
+            show("intersect(c(\"a\", \"b\", \"c\"), c(\"c\", \"a\"))\n"),
+            "[1] \"a\" \"c\""
+        );
+    }
+
+    // --- setdiff --------------------------------------------------------
+
+    #[test]
+    fn setdiff_numeric_dedup_order_preserving() {
+        assert_eq!(nums("setdiff(c(1, 2, 3, 4), c(2, 4))\n"), vec![1.0, 3.0]);
+        // Duplicates in x collapse; order follows x.
+        assert_eq!(nums("setdiff(c(1, 1, 2, 3), c(2))\n"), vec![1.0, 3.0]);
+    }
+
+    #[test]
+    fn setdiff_character() {
+        assert_eq!(
+            show("setdiff(c(\"a\", \"b\", \"c\"), c(\"b\"))\n"),
+            "[1] \"a\" \"c\""
+        );
+    }
+
+    // --- is.element -----------------------------------------------------
+
+    #[test]
+    fn is_element_scalar_and_vectorized() {
+        assert_eq!(show("is.element(2, c(1, 2, 3))\n"), "[1] TRUE");
+        assert_eq!(
+            show("is.element(c(1, 5), c(1, 2, 3))\n"),
+            "[1]  TRUE FALSE"
+        );
+        assert_eq!(show("is.element(\"x\", c(\"a\", \"x\"))\n"), "[1] TRUE");
+    }
+
+    // --- duplicated -----------------------------------------------------
+
+    #[test]
+    fn duplicated_numeric() {
+        assert_eq!(
+            show("duplicated(c(1, 1, 2, 3, 3))\n"),
+            "[1] FALSE  TRUE FALSE FALSE  TRUE"
+        );
+    }
+
+    #[test]
+    fn duplicated_character() {
+        assert_eq!(
+            show("duplicated(c(\"a\", \"b\", \"a\"))\n"),
+            "[1] FALSE FALSE  TRUE"
+        );
+    }
+
+    // --- rank (average ties) --------------------------------------------
+
+    #[test]
+    fn rank_no_ties() {
+        assert_eq!(nums("rank(c(3, 1, 2))\n"), vec![3.0, 1.0, 2.0]);
+    }
+
+    #[test]
+    fn rank_average_ties() {
+        // The two 1s occupy positions 1 and 2 → average 1.5; the 2 is at 3.
+        assert_eq!(nums("rank(c(1, 1, 2))\n"), vec![1.5, 1.5, 3.0]);
+        // A triple tie shares the mean of positions 1,2,3 = 2.
+        assert_eq!(nums("rank(c(5, 5, 5))\n"), vec![2.0, 2.0, 2.0]);
+    }
+
+    #[test]
+    fn rank_character_lexicographic() {
+        // "a" < "b" < "c"; the two "a"s share positions 1,2 → 1.5 each.
+        assert_eq!(
+            nums("rank(c(\"b\", \"a\", \"a\"))\n"),
+            vec![3.0, 1.5, 1.5]
+        );
+    }
+
+    // --- degenerate edges ----------------------------------------------
+
+    #[test]
+    fn empty_inputs_yield_empty_results() {
+        assert_eq!(eval_s("union(c(), c())\n").unwrap().length(), 0);
+        assert_eq!(eval_s("intersect(c(), c(1))\n").unwrap().length(), 0);
+        assert_eq!(eval_s("setdiff(c(), c(1))\n").unwrap().length(), 0);
+        assert_eq!(eval_s("duplicated(c())\n").unwrap().length(), 0);
+        assert_eq!(eval_s("rank(c())\n").unwrap().length(), 0);
+        // is.element over an empty `el` is an empty logical.
+        assert_eq!(eval_s("is.element(c(), c(1))\n").unwrap().length(), 0);
+    }
+
+    #[test]
+    fn setdiff_everything_removed_is_empty() {
+        assert_eq!(eval_s("setdiff(c(1, 2), c(1, 2, 3))\n").unwrap().length(), 0);
+    }
+}

--- a/code/specs/R00-r-language.md
+++ b/code/specs/R00-r-language.md
@@ -906,6 +906,60 @@ unchanged.
     `tapply` over a *multi-way* `INDEX` (a list of factors → an N-dimensional array);
     and `simplify = FALSE` (always-list `tapply`).
 
+- **R-29 — vector set operations & ordering** *(this PR)*. A pivot into the
+  **set-theory and ranking** corner of R's base toolkit: the small, pure builtins
+  R users reach for when treating vectors as multisets (`union`/`intersect`/`setdiff`),
+  testing membership (`is.element`), spotting repeats (`duplicated`), or assigning
+  sample ranks (`rank`). All ship as pure builtins in the shared `s-runtime` (R
+  inherits via the tree-walker); **no grammar change** (none is an operator). They
+  reuse the existing vector machinery wholesale — `as_character` (the order-preserving
+  string key used by `unique`/`%in%`), `value::index` (the 1-based gather that
+  preserves element type), `value::membership` (the `%in%` engine), `combine` (for
+  `c(x, y)`), and `first_positional`. Six functions:
+  - **`union(x, y)`** — the distinct elements of `c(x, y)`, in **first-occurrence
+    order** (R's order-preserving union, *not* a sorted set). Implemented as
+    `unique(c(x, y))`: concatenate with `combine`, then keep the first sighting of
+    each `as_character` key. `union(c(1,2), c(2,3))` is `c(1, 2, 3)`. Works on numeric
+    and character vectors (the comparison key is the coerced character form, exactly
+    as `unique`/`%in%` already do).
+  - **`intersect(x, y)`** — the elements present in **both** `x` and `y`, in `x`'s
+    order, **deduplicated** (each distinct value appears once). A value of `x` is kept
+    iff its key is in `y`'s key-set *and* it has not already been kept.
+    `intersect(c(1,2,3), c(2,3,4))` is `c(2, 3)`.
+  - **`setdiff(x, y)`** — the elements of `x` **not** in `y`, deduplicated,
+    order-preserving by `x`. `setdiff(c(1,2,3,4), c(2,4))` is `c(1, 3)`.
+  - **`is.element(el, set)`** — exactly `el %in% set` (a vectorized logical, one entry
+    per element of `el`). `is.element(2, c(1,2,3))` is `TRUE`. A thin alias over
+    `value::membership` so the two stay bug-for-bug identical.
+  - **`duplicated(x)`** — a logical vector, `TRUE` where an element equals one that
+    appeared **earlier** (first occurrence is always `FALSE`).
+    `duplicated(c(1,1,2,3,3))` is `c(FALSE, TRUE, FALSE, FALSE, TRUE)`. Uses the same
+    `as_character`-key + "seen" set as `unique`, but emits the flag instead of gathering.
+  - **`rank(x)`** — **sample ranks** with **average tie handling** (R's default
+    `ties.method = "average"`). Each element's rank is its 1-based position in
+    ascending order; tied values share the **mean** of the positions they span.
+    `rank(c(3,1,2))` is `c(3, 1, 2)`; `rank(c(1,1,2))` is `c(1.5, 1.5, 3)` (the two
+    1s occupy positions 1 and 2, averaging to 1.5). Numeric ranks numerically;
+    character ranks lexicographically. The output is always numeric (averages are
+    fractional), matching R.
+  - **Output-size caps (security).** Every input is **data**, so a crafted call must
+    not allocate unboundedly or panic. The set ops produce **at most** `length(x) +
+    length(y)` (union) or `length(x)` (intersect/setdiff) elements — each operand is
+    already `MAX_SEQ_LEN`-bounded, and `union` routes through `combine` (whose result
+    is itself a vector subject to the same limit), so no result can exceed what the
+    inputs already permit; no separate cap is introduced. `duplicated`/`is.element`
+    emit exactly one logical per input element. `rank` allocates one `f64` per element
+    and sorts the index permutation in `O(n log n)`; there is no quadratic blowup and
+    no user-controlled multiplier. Empty inputs yield empty results; `NA` is treated
+    as an ordinary (matchable) key via `as_character`'s `None`, never an index panic.
+  - **Scope outcome / deferred to R-30.** `union`, `intersect`, `setdiff`,
+    `is.element`, `duplicated`, and `rank` (average ties) ship **solidly**. Deferred
+    to **R-30**: `rank`'s other `ties.method` options (`"first"`, `"min"`, `"max"`,
+    `"random"`); the `incomparables =`/`fromLast =` arguments of the set ops and
+    `duplicated`; `anyDuplicated`; and **multi-key `order(x, y, ...)`** (the single-key
+    `order` from R-13 is unchanged). The `%o%` infix alias for `outer` carried over
+    from R-28's deferral list also remains open for a later grammar pass.
+
 ## §4 Reuse strategy
 
 - **Lexer/parser:** the grammar-tools framework, exactly as S uses it. `r.tokens`
@@ -934,7 +988,10 @@ the R5 system in **R-26**); the output-formatting family (`format`, `formatC`,
 `scientific=`) deferred to a later formatting pass; the apply-family & grouping
 builtins (`outer`, `tapply`, `split`, `tabulate`) land in **R-28**, with the `%o%`
 infix alias, matrix dimnames, multi-way `tapply`, and `simplify = FALSE` deferred to
-**R-29**; namespaces and `library()`
+a later pass; the vector set-operation & ranking builtins (`union`, `intersect`,
+`setdiff`, `is.element`, `duplicated`, `rank`) land in **R-29**, with `rank`'s other
+`ties.method` options, the `incomparables=`/`fromLast=` set-op arguments,
+`anyDuplicated`, and multi-key `order` deferred to **R-30**; namespaces and `library()`
 (so `baseenv()` aliases the
 global env for now); the C interface; graphics. These layer on later, following
 ST00.

--- a/code/specs/S00-s-language.md
+++ b/code/specs/S00-s-language.md
@@ -264,6 +264,18 @@ needs a string assignment target: `"%between%" <- function(x, r) x >= r[1] & x <
   paste paste0`. (No underscore-named helpers like R's `seq_len`/`seq_along`:
   in historical S `_` is assignment, so such names cannot be written — `seq()`
   and `1:n` cover the need.)
+- **Set operations & ranking** *(R-29)*: `union(x, y)` (distinct elements of
+  `c(x, y)`, first-occurrence order — i.e. `unique(c(x, y))`), `intersect(x, y)`
+  (elements in both, in `x`'s order, deduplicated), `setdiff(x, y)` (elements of
+  `x` not in `y`, deduplicated), `is.element(el, set)` (the function spelling of
+  `el %in% set`), `duplicated(x)` (a logical vector, `TRUE` where an element
+  repeats an earlier one), and `rank(x)` (sample ranks with **average** tie
+  handling — `rank(c(1,1,2))` is `c(1.5, 1.5, 3)`). All are pure, numeric- and
+  character-aware (they key on the same coerced-character form as `unique`/`%in%`)
+  and reuse the existing `as_character` / `index` / `membership` / `combine`
+  machinery. Other `ties.method` options for `rank`, the `incomparables=` /
+  `fromLast=` set-op arguments, `anyDuplicated`, and multi-key `order` are deferred
+  to a later pass (R-30).
 - **Apply family:** `sapply(x, f)` / `lapply(x, f)` map a function over elements
   (`sapply` simplifies length-1 atomic results to a vector).
 


### PR DESCRIPTION
## R-29 — vector set operations & ordering

Implements the set-theory and ranking corner of R's base toolkit as **pure builtins in the shared `s-runtime`** (R inherits via the language-neutral tree-walker; **no grammar change** — none of these is an operator). All are numeric- and character-aware and reuse the existing vector machinery (`as_character` keys, `value::index`, `value::membership`, `combine`, `first_positional`).

### Added
- **`union(x, y)`** — distinct elements of `c(x, y)` in **first-occurrence** order (`unique(c(x, y))`, not a sorted set). `union(c(1,2), c(2,3))` → `c(1, 2, 3)`.
- **`intersect(x, y)`** — elements in both, in `x`'s order, deduplicated. `intersect(c(1,2,3), c(2,3,4))` → `c(2, 3)`.
- **`setdiff(x, y)`** — elements of `x` not in `y`, deduplicated, order-preserving. `setdiff(c(1,2,3,4), c(2,4))` → `c(1, 3)`.
- **`is.element(el, set)`** — the function spelling of `el %in% set` (a thin alias over `membership`). `is.element(2, c(1,2,3))` → `TRUE`.
- **`duplicated(x)`** — logical vector, `TRUE` where an element repeats an earlier one. `duplicated(c(1,1,2,3,3))` → `c(FALSE, TRUE, FALSE, FALSE, TRUE)`.
- **`rank(x)`** — sample ranks with **average tie handling** (R's default `ties.method = "average"`): each element's rank is its 1-based position in ascending order, and a run of equal values shares the **mean** of the positions it spans. `rank(c(3,1,2))` → `c(3, 1, 2)`; `rank(c(1,1,2))` → `c(1.5, 1.5, 3)`. Numeric ranks numerically, character lexicographically; result is always numeric, `NA` sorts last.

### Security
Every input is data; outputs are bounded by the inputs (union ≤ `|x|+|y|`, intersect/setdiff ≤ `|x|`, each operand already `MAX_SEQ_LEN`-bounded, and `union` routes through `combine` which is itself bounded), so no fresh allocation cap is introduced. `rank` is `O(n log n)` with one `f64` per element and no user-controlled multiplier. Empty inputs yield empty results and `NA` is an ordinary matchable key — never an index panic. A Rust security sub-agent reviewed the diff and **passed in one round** with no findings.

### Tests
- `s-runtime`: new `r29_set_ops` module — **216 passed**.
- `r-runtime`: new R-syntax integration tests — **228 passed**.
- Plus 2 doctests. Run: `cargo test -p coding-adventures-s-runtime -p coding-adventures-r-runtime`.

### Deferred to R-30
`rank`'s other `ties.method` options (`"first"`/`"min"`/`"max"`/`"random"`); the `incomparables=`/`fromLast=` arguments of the set ops and `duplicated`; `anyDuplicated`; and **multi-key `order(x, y, …)`** (single-key `order` from R-13 is unchanged). Noted in the R00/S00 specs and both CHANGELOGs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)