### PR TITLE
feat(closurec): ASI line-terminator rule (CLOC26 Phase 2)

### DIFF
--- a/code/packages/rust/javascript-parser/CHANGELOG.md
+++ b/code/packages/rust/javascript-parser/CHANGELOG.md
@@ -2,6 +2,37 @@
 
 All notable changes to the `coding-adventures-javascript-parser` crate will be documented in this file.
 
+## [0.16.0] - 2026-06-21
+
+### Added — CLOC26 Phase 2: ASI line-terminator rule (Rule 1)
+
+`asi` now also inserts a `;` before an offending token that is **preceded by a
+line terminator** (ECMAScript §12.10 Rule 1), not just before a `}`/EOF
+(Rule 2). So `a = 1` ⏎ `b = 2` parses as two statements.
+
+The lexer discards newlines as trivia and does **not** populate the
+`TOKEN_PRECEDED_BY_NEWLINE` flag, so detection is derived from the `line` field
+the lexer records on every token: a line terminator sits between `tokens[idx-1]`
+and `tokens[idx]` exactly when the offending token starts on a *higher line*
+than its predecessor **and** that predecessor is single-line (its own text
+contains no newline — a multi-line predecessor such as a template literal makes
+the comparison ambiguous, so we conservatively decline). This needs **no change
+to the shared lexer/parser crates**.
+
+Soundness is unchanged from Phase 1: insertion happens only on a genuine parse
+*failure*, so any program that already parses is byte-for-byte untouched.
+Requiring an actual line terminator for the non-`}`/EOF case is what keeps a
+true one-line error (`a = 1 b = 2`) from being silently "recovered" — it still
+fails and the caller degrades exactly as before.
+
+`is_asi_recoverable` is replaced by `asi_applies_at(tokens, idx)`, which the
+retry loop consults after locating the offending token's index (Rule 1 needs the
+predecessor).
+
+- 5 new tests: newline-separated statements recovered; one-line two-statements
+  NOT recovered; a multi-statement no-semicolon program; a valid multi-line
+  program is a no-op; a binary expression continued on the next line is not split.
+
 ## [0.15.0] - 2026-06-21
 
 ### Added — CLOC26 Phase 1: Automatic Semicolon Insertion (`}` / EOF rule)

--- a/code/packages/rust/javascript-parser/Cargo.toml
+++ b/code/packages/rust/javascript-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-javascript-parser"
-version = "0.15.0"
+version = "0.16.0"
 edition = "2021"
 description = "JavaScript parser — parses JavaScript source code against any ECMAScript edition (es1 through es2025) using the grammar-driven parser. Includes correlation-vector plumbing per CLOC03 and a typed-AST bridge (GrammarASTNode → javascript_ast::Program) per CLOC12.136."
 

--- a/code/packages/rust/javascript-parser/src/asi.rs
+++ b/code/packages/rust/javascript-parser/src/asi.rs
@@ -1,4 +1,5 @@
-//! Automatic Semicolon Insertion (ASI) — Phase 1: the `}` / end-of-input rule.
+//! Automatic Semicolon Insertion (ASI) — the `}` / end-of-input rule (Rule 2)
+//! and the line-terminator rule (Rule 1).
 //!
 //! # Why this module exists
 //!
@@ -17,19 +18,24 @@
 //!
 //! # The approach: retry-on-parse-error (byte-identical by construction)
 //!
-//! Phase 1 implements only ASI **Rule 2** — a `;` is inserted before a `}` (or
-//! at end of input) that would otherwise be a syntax error. This rule does *not*
-//! depend on line terminators, which is convenient because the lexer discards
-//! newlines as trivia (the line-terminator rule is Phase 2, using the
-//! `TOKEN_PRECEDED_BY_NEWLINE` flag the lexer already records).
+//! Two ASI rules are implemented (§12.10):
+//!
+//! * **Rule 2** (`}` / end-of-input) — a `;` is inserted before a `}` (or at end
+//!   of input) that would otherwise be a syntax error. No line terminator needed.
+//! * **Rule 1** (line terminator) — a `;` is inserted before an offending token
+//!   that is **preceded by a line terminator**. The lexer discards newlines as
+//!   trivia, but each token records the `line` it starts on, so a line
+//!   terminator sits between two tokens exactly when the later one starts on a
+//!   higher line (and its single-line predecessor did not itself span lines —
+//!   see [`asi_applies_at`]). No shared-lexer change is required.
 //!
 //! Rather than guess insertion points from a lookahead table (the approach the
 //! design spec first sketched), we drive insertion from the parser itself:
 //!
 //! 1. Parse the token stream.
 //! 2. If it parses, we are done — **nothing is inserted**.
-//! 3. If it fails *specifically because a `SEMICOLON` was expected before a `}`
-//!    or end-of-input*, synthesize a `;` at that position and re-parse.
+//! 3. If it fails *specifically because a `SEMICOLON` was expected* at a point
+//!    where Rule 1 or Rule 2 applies, synthesize a `;` there and re-parse.
 //! 4. Any other failure is returned unchanged (closurec then degrades as before).
 //!
 //! The decisive property: a semicolon is inserted **only when parsing genuinely
@@ -77,7 +83,20 @@ pub fn parse_with_asi(
         match parser.parse() {
             Ok(ast) => return Ok(ast),
             Err(e) => {
-                if !is_asi_recoverable(&e) {
+                // A `;` must be among what the parser expected here, or this is
+                // not a missing-semicolon situation at all.
+                if !e.message.contains("SEMICOLON") {
+                    return Err(e);
+                }
+                // Locate the offending token so we can inspect its predecessor
+                // (the line-terminator rule needs it).
+                let idx = match find_token_index(&tokens, &e.token) {
+                    Some(i) => i,
+                    // Not locatable (should not happen — full-identity match is
+                    // unique); bail safely.
+                    None => return Err(e),
+                };
+                if !asi_applies_at(&tokens, idx) {
                     return Err(e);
                 }
                 let fail_pos = (e.token.line, e.token.column);
@@ -86,12 +105,7 @@ pub fn parse_with_asi(
                     // fails here — give up with the real error.
                     return Err(e);
                 }
-                match find_token_index(&tokens, &e.token) {
-                    Some(idx) => tokens.insert(idx, synthetic_semicolon(&e.token)),
-                    // The offending token isn't locatable in our stream (should
-                    // not happen — full-identity match is unique); bail safely.
-                    None => return Err(e),
-                }
+                tokens.insert(idx, synthetic_semicolon(&e.token));
             }
         }
     }
@@ -101,19 +115,72 @@ pub fn parse_with_asi(
     GrammarParser::new(tokens, grammar).parse()
 }
 
-/// Is this parse failure one that inserting a `;` before a `}` / end-of-input
-/// could plausibly fix? We require BOTH that a `SEMICOLON` was among the
-/// expected tokens AND that the offending token is a closing brace or EOF —
-/// the only positions ASI Rule 2 applies. Anything else is a genuine syntax
-/// error we must not paper over.
-fn is_asi_recoverable(e: &GrammarParseError) -> bool {
-    let expects_semicolon = e.message.contains("SEMICOLON");
-    let off = &e.token;
-    let is_close_brace = off.type_ == TokenType::RBrace
+/// Does an ASI insertion apply *before the token at `idx`* (which the parser
+/// rejected while expecting a `SEMICOLON`)? Two ECMAScript §12.10 rules:
+///
+/// * **Rule 2** — the offending token is a `}` or end-of-input. A statement may
+///   always be terminated there; no line terminator is required.
+/// * **Rule 1** — the offending token is **preceded by a line terminator**.
+///   The lexer discards newlines as trivia, but every token still records the
+///   `line` it starts on, so a line terminator sits between `tokens[idx-1]` and
+///   `tokens[idx]` exactly when the offending token starts on a *later line*
+///   than its predecessor. We only trust that comparison when the predecessor
+///   is **single-line** (its own text contains no newline); a multi-line
+///   predecessor — e.g. a template literal spanning lines — makes the
+///   start-line comparison ambiguous, so we conservatively decline (a missed
+///   optimization, never a miscompile).
+///
+/// Soundness: this is only ever consulted on a genuine parse *failure*, so a
+/// program that already parses is untouched. Requiring an actual line
+/// terminator for the non-`}`/EOF case is what keeps a true one-line syntax
+/// error (`a=1 b=2`) from being silently "recovered".
+fn asi_applies_at(tokens: &[Token], idx: usize) -> bool {
+    let off = &tokens[idx];
+
+    // Rule 2: before a `}` or EOF.
+    if off.type_ == TokenType::RBrace
         || off.type_name.as_deref() == Some("RBRACE")
-        || off.value == "}";
-    let is_eof = off.type_ == TokenType::Eof;
-    expects_semicolon && (is_close_brace || is_eof)
+        || off.value == "}"
+        || off.type_ == TokenType::Eof
+    {
+        return true;
+    }
+
+    // Rule 1: a line terminator between the predecessor and this token.
+    if idx == 0 {
+        return false;
+    }
+    let prev = &tokens[idx - 1];
+    off.line > prev.line && !token_may_span_lines(prev)
+}
+
+/// Could this token's lexeme cross source lines *without that being visible in
+/// its `value`* — making the start-line comparison in [`asi_applies_at`]
+/// unreliable?
+///
+/// The lexer stores the **cooked** text in `value` (escapes resolved), so a
+/// token can span multiple source lines while `value` contains no raw newline:
+///
+/// * a **string** can use a backslash line-continuation (`"a\<LF>b"` → `"ab"`),
+/// * **template literals** and **regex** can embed or escape newlines.
+///
+/// For any such kind we cannot conclude from `off.line > prev.line` that a real
+/// line terminator separates the two tokens (the higher line may just be the
+/// predecessor's own continuation), so we treat it as line-spanning and decline
+/// Rule 1 — a missed optimization, never a miscompile. (A token whose `value`
+/// already contains a raw newline is obviously multi-line and likewise
+/// declined.) Identifiers, numbers, punctuators, and keywords are always
+/// single-line, so the start-line comparison is exact for them.
+///
+/// MAINTENANCE: this enumerates the lexer's only multi-line-capable token
+/// kinds. If a future grammar adds another (e.g. a token-preserving multi-line
+/// comment, or a heredoc/raw-string variant), it MUST be added here or Rule 1
+/// could wrongly fire across it.
+fn token_may_span_lines(t: &Token) -> bool {
+    matches!(t.type_, TokenType::String)
+        || matches!(t.type_name.as_deref(), Some("STRING") | Some("REGEX"))
+        || t.type_name.as_deref().is_some_and(|n| n.starts_with("TEMPLATE"))
+        || t.value.contains('\n')
 }
 
 /// A synthesized `;` token positioned at the offending token. The parser matches
@@ -224,5 +291,69 @@ mod tests {
         let src = "function f(){}";
         assert!(parses_without_asi(src));
         assert!(parses_with_asi(src));
+    }
+
+    // --- Phase 2: the line-terminator rule (ECMAScript Rule 1) ------------
+
+    #[test]
+    fn statements_separated_by_a_newline_are_recovered() {
+        // `a = 1` then `b = 2` on the next line: the offending token `b` is
+        // preceded by a line terminator, so ASI inserts a `;` after `1`.
+        let src = "a = 1\nb = 2";
+        assert!(!parses_without_asi(src), "precondition: should fail raw");
+        assert!(parses_with_asi(src), "ASI Rule 1 should split across the newline");
+    }
+
+    #[test]
+    fn two_statements_on_one_line_are_not_recovered() {
+        // No line terminator between `1` and `b`: this is a genuine syntax
+        // error (ASI does NOT apply mid-line), so it must stay a failure — we
+        // must not paper it over.
+        let src = "a = 1 b = 2";
+        assert!(!parses_with_asi(src), "one-line `a=1 b=2` is a real error, not ASI");
+    }
+
+    #[test]
+    fn newline_after_assignment_keyword_call() {
+        // A multi-line sequence of statements with no semicolons anywhere.
+        let src = "var x = f()\nvar y = g()\nh(x, y)";
+        assert!(!parses_without_asi(src));
+        assert!(parses_with_asi(src));
+    }
+
+    #[test]
+    fn valid_multiline_program_is_a_noop() {
+        // Already valid (explicit semicolons), spanning lines: ASI must not
+        // change the parse — it succeeds on the first try.
+        let src = "var x = 1;\nvar y = 2;\nh(x, y);";
+        assert!(parses_without_asi(src), "precondition: valid as-is");
+        assert!(parses_with_asi(src));
+    }
+
+    #[test]
+    fn continuation_on_next_line_is_not_split() {
+        // A binary expression continued on the next line is ONE statement; the
+        // `+` can continue it, so the parser does not fail at `b` and ASI never
+        // fires. (`a + b` is a single expression statement.) This guards against
+        // wrongly splitting a legal multi-line expression.
+        let src = "var a = 1, b = 2;\nvar c = a\n+ b;";
+        assert!(parses_with_asi(src));
+    }
+
+    #[test]
+    fn statement_ending_in_a_string_before_a_newline_is_declined() {
+        // Documented Phase-2 limitation: when the token before the newline is a
+        // STRING (a kind that *could* span source lines while its cooked value
+        // hides it), `asi_applies_at` conservatively declines Rule 1 rather than
+        // trust the start-line comparison. So this does NOT recover — a missed
+        // optimization, never a miscompile. (Recoverable later with token
+        // end-position tracking.) `token_may_span_lines` is what makes the
+        // line-terminator heuristic sound regardless of lexer escape handling.
+        let src = "var s = \"x\"\nlog(s)";
+        assert!(!parses_without_asi(src), "precondition: should fail raw");
+        assert!(
+            !parses_with_asi(src),
+            "string predecessor is conservatively declined for Rule 1"
+        );
     }
 }

--- a/code/programs/rust/closurec/CHANGELOG.md
+++ b/code/programs/rust/closurec/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 All notable changes to the `coding-adventures-closurec` binary will be documented in this file.
 
+## [0.160.0] - 2026-06-21
+
+### Changed — CLOC26 Phase 2: optimize newline-separated, semicolon-free source
+
+closurec now applies ASI Rule 1 (insert a `;` before a token preceded by a line
+terminator) in addition to the Phase 1 `}`/EOF rule, so a program that uses
+newlines instead of semicolons — e.g.
+
+```js
+var w = 4
+var s = 1 + 2
+report(w * s)
+```
+
+— **parses and gets optimized** at `SIMPLE`/`ADVANCED` (`1 + 2` folds to `3`)
+instead of degrading to `WHITESPACE_ONLY`. ASI lives in the
+`coding-adventures-javascript-parser` crate (bumped to 0.16.0).
+
+New end-to-end fixture `simple-asi-newline`; the
+`simple_asi_newline_did_not_fall_back_to_whitespace_only` guard asserts the
+folded `s=3` is present and `1+2` absent. Two statements on the *same* line
+(`a = 1 b = 2`) remain a genuine error and still degrade, and the full existing
+fixture suite stays byte-for-byte unchanged (ASI only acts on real parse
+failures).
+
 ## [0.159.0] - 2026-06-21
 
 ### Changed — CLOC26 Phase 1: optimize semicolon-light source via ASI

--- a/code/programs/rust/closurec/Cargo.toml
+++ b/code/programs/rust/closurec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closurec"
-version = "0.159.0"
+version = "0.160.0"
 edition = "2021"
 description = "closurec — CLI driver for the Closure Compiler clone. Mirrors the upstream Java Closure Compiler's command-line flag surface (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility. Per CLOC08."
 

--- a/code/programs/rust/closurec/cli.spec.json
+++ b/code/programs/rust/closurec/cli.spec.json
@@ -2,7 +2,7 @@
   "cli_builder_spec_version": "1.0",
   "name": "closurec",
   "description": "closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.",
-  "version": "0.159.0",
+  "version": "0.160.0",
   "parsing_mode": "gnu",
   "flags": [
     { "id": "browser_featureset_year", "long": "browser_featureset_year", "type": "integer", "default": 0, "description": "Shortcut for defining goog.FEATURESET_YEAR=YYYY (minimum 2012)." },

--- a/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
@@ -2,7 +2,7 @@
 
 closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.
 
-Version: 0.159.0
+Version: 0.160.0
 
 ## Flags
 

--- a/code/programs/rust/closurec/tests/diff/simple-asi-newline/README.md
+++ b/code/programs/rust/closurec/tests/diff/simple-asi-newline/README.md
@@ -1,0 +1,42 @@
+# Fixture: `simple-asi-newline`
+
+End-to-end oracle for **CLOC26 Phase 2** — Automatic Semicolon Insertion at a
+**line terminator** (ECMAScript ASI Rule 1). Implemented in the
+`javascript-parser` `asi` module (retry-on-parse-error).
+
+| File | Role |
+|------|------|
+| `flags.txt` | CLI args: `--compilation_level SIMPLE --js input/a.js` |
+| `input/a.js` | Three statements on separate lines with **no** semicolons |
+| `expected.stdout` | The optimized output (see below) |
+
+```text
+var w=4;var s=3;report(w * s);
+```
+
+What this proves:
+
+* **The program parses at all** — before Phase 2, a statement boundary marked
+  only by a newline (no `;`) failed the grammar parse and closurec degraded the
+  *whole program* to `WHITESPACE_ONLY`. ASI Rule 1 inserts a `;` before each
+  token that is preceded by a line terminator, so the typed pipeline runs.
+* **`1 + 2` folds to `3`** (`var s=3`) — an optimization only reachable from the
+  SIMPLE pipeline. Its presence is the proof ASI worked: a WHITESPACE_ONLY
+  fallback keeps `var s=1+2` verbatim.
+
+The `simple_asi_newline_did_not_fall_back_to_whitespace_only` guard asserts the
+output contains `s=3` and does **not** contain `1+2`.
+
+Soundness note: ASI Rule 1 fires *only* when a token is preceded by a line
+terminator — two statements on the **same** line (`a = 1 b = 2`) remain a
+genuine syntax error and are not "recovered" (closurec degrades them, exactly as
+before). And because ASI only acts on a real parse failure, any program that
+already parses is byte-for-byte unchanged.
+
+Regenerate the expected file after an intentional behavior change:
+
+```sh
+cargo run -- --compilation_level SIMPLE \
+    --js tests/diff/simple-asi-newline/input/a.js \
+    > tests/diff/simple-asi-newline/expected.stdout
+```

--- a/code/programs/rust/closurec/tests/diff/simple-asi-newline/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/simple-asi-newline/expected.stdout
@@ -1,0 +1,1 @@
+var w=4;var s=3;report(w * s);

--- a/code/programs/rust/closurec/tests/diff/simple-asi-newline/flags.txt
+++ b/code/programs/rust/closurec/tests/diff/simple-asi-newline/flags.txt
@@ -1,0 +1,4 @@
+--compilation_level
+SIMPLE
+--js
+tests/diff/simple-asi-newline/input/a.js

--- a/code/programs/rust/closurec/tests/diff/simple-asi-newline/input/a.js
+++ b/code/programs/rust/closurec/tests/diff/simple-asi-newline/input/a.js
@@ -1,0 +1,16 @@
+// CLOC26 Phase 2 — Automatic Semicolon Insertion at a line terminator.
+//
+// This program has NO semicolons at all; each statement sits on its own line.
+// ECMAScript inserts a semicolon before a token that is preceded by a line
+// terminator (ASI Rule 1), so `var w = 4` and `var s = 1 + 2` are separate
+// statements. Before Phase 2 the grammar parser required explicit semicolons,
+// so this whole program failed to parse and closurec degraded to
+// WHITESPACE_ONLY. ASI now supplies the semicolons at the line breaks, the
+// program parses, and the SIMPLE pipeline folds `1 + 2` to `3`.
+//
+// At SIMPLE this becomes:
+//   var w=4;var s=3;report(w * s);
+// while WHITESPACE_ONLY keeps `1+2` verbatim (it runs no passes).
+var w = 4
+var s = 1 + 2
+report(w * s)

--- a/code/programs/rust/closurec/tests/diff_simple_asi_newline.rs
+++ b/code/programs/rust/closurec/tests/diff_simple_asi_newline.rs
@@ -1,0 +1,75 @@
+//! Integration test for the `tests/diff/simple-asi-newline/` fixture.
+//!
+//! Exercises CLOC26 Phase 2 — Automatic Semicolon Insertion at a line
+//! terminator (ECMAScript ASI Rule 1), implemented in the `javascript-parser`
+//! `asi` module. The input has no semicolons; statements are separated only by
+//! newlines. Before Phase 2 this failed the grammar parse and closurec degraded
+//! the whole program to WHITESPACE_ONLY. ASI now inserts a `;` before each
+//! token preceded by a line terminator, the program parses, and `1 + 2` folds
+//! to `3`:
+//!
+//! ```text
+//! var w=4;var s=3;report(w * s);
+//! ```
+
+use std::process::Command;
+
+const BINARY: &str = env!("CARGO_BIN_EXE_closurec");
+
+fn read_flags() -> Vec<String> {
+    let raw = std::fs::read_to_string("tests/diff/simple-asi-newline/flags.txt")
+        .expect("read flags.txt");
+    raw.lines()
+        .filter(|l| !l.is_empty())
+        .map(|s| s.to_string())
+        .collect()
+}
+
+#[test]
+fn simple_asi_newline_fixture_matches_expected_stdout() {
+    let flags = read_flags();
+    let out = Command::new(BINARY)
+        .args(&flags)
+        .output()
+        .expect("run closurec");
+
+    assert!(
+        out.status.success(),
+        "exit: {:?}, stderr: {}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stderr),
+    );
+
+    let actual = String::from_utf8_lossy(&out.stdout);
+    let expected = std::fs::read_to_string("tests/diff/simple-asi-newline/expected.stdout")
+        .expect("read expected.stdout");
+    assert_eq!(
+        actual.trim_end_matches('\n'),
+        expected.trim_end_matches('\n'),
+        "mismatch.\nflags: {flags:?}\nactual:\n{actual}\nexpected:\n{expected}",
+    );
+}
+
+/// Regression guard: the output must NOT be the WHITESPACE_ONLY fallback. The
+/// input has no semicolons; without ASI Rule 1 the program fails to parse and
+/// degrades to whitespace-only, which keeps `1+2` verbatim. So an optimized
+/// SIMPLE run — only reachable because ASI made the program parse — must show
+/// the folded `s=3` and contain no `1+2`.
+#[test]
+fn simple_asi_newline_did_not_fall_back_to_whitespace_only() {
+    let out = Command::new(BINARY)
+        .args(read_flags())
+        .output()
+        .expect("run closurec");
+    let actual = String::from_utf8_lossy(&out.stdout);
+
+    assert!(
+        actual.contains("s=3"),
+        "expected `1 + 2` to fold to `3` (proving ASI Rule 1 made the typed \
+         pipeline run, not the whitespace fallback); got:\n{actual}",
+    );
+    assert!(
+        !actual.contains("1+2") && !actual.contains("1 + 2"),
+        "expected the folded form, not the literal `1+2`; got:\n{actual}",
+    );
+}

--- a/code/specs/CLOC26-asi.md
+++ b/code/specs/CLOC26-asi.md
@@ -1,8 +1,9 @@
 # CLOC26 — Automatic Semicolon Insertion (ASI)
 
-> **Status:** **Phase 1 shipped** (the `}` / EOF rule, in
-> `javascript-parser/src/asi.rs`); Phases 2–3 pending. This document was
-> committed *before* any implementation code, per the repo standard.
+> **Status:** **Phases 1 and 2 shipped** (the `}` / EOF rule and the
+> line-terminator rule, in `javascript-parser/src/asi.rs`); Phase 3 (restricted
+> productions) pending. This document was committed *before* any implementation
+> code, per the repo standard.
 >
 > **Implementation refinement (Phase 1):** the shipped implementation uses the
 > **retry-on-parse-error** strategy, not the lookahead table this spec first
@@ -173,10 +174,27 @@ etc. Unit tests for the transform + closurec e2e fixtures (`simple-asi-block`)
 that previously degraded now optimize. **Regression guard: every existing
 fixture is byte-identical.**
 
-**Phase 2 — line-terminator rule (Rule 1).** Extend the transform to insert
-before an offending token preceded by a newline, using the continuation-token
-denylist. Requires the newline-survival answer from Phase 1. Tests:
-`a=1\n b=2`, and negative cases (`a\n .b`, `a\n +b` stay single statements).
+**Phase 2 — line-terminator rule (Rule 1). ✅ SHIPPED.** The retry harness now
+also inserts before an offending token preceded by a line terminator. Because
+the lexer discards newlines as trivia and does **not** set
+`TOKEN_PRECEDED_BY_NEWLINE`, "preceded by a line terminator" is derived from the
+per-token `line` field: the offending token starts on a higher line than its
+*single-line* predecessor (a multi-line predecessor is declined as ambiguous).
+The retry-on-error design means no continuation-token denylist is needed — a
+legal multi-line expression (`var c = a` ⏎ `+ b`) simply parses on the first
+try, so ASI never fires. Tests cover `a=1`⏎`b=2` (recovered), one-line
+`a=1 b=2` (a real error, NOT recovered), and the continued-expression no-op.
+
+**Soundness guard (`token_may_span_lines`).** Because `value` holds the *cooked*
+text, a predecessor that can span source lines while its value hides it (a
+string, template, or regex) would make `off.line > prev.line` an unreliable
+signal. Such predecessor kinds are therefore excluded — Rule 1 fires only when
+the predecessor is provably single-line (identifier, number, punctuator,
+keyword) or its value already contains a raw newline. **Documented limitation:**
+a statement ending in a string/template/regex literal immediately before a
+newline is conservatively *not* recovered (it degrades, as before). This is a
+missed optimization, never a miscompile, and is recoverable in a follow-up by
+tracking each token's end position. (Surfaced by the Phase-2 security review.)
 
 **Phase 3 — restricted productions (Rule 3).** Force ASI after
 `return`/`throw`/`break`/`continue`/`yield` + newline, and around postfix


### PR DESCRIPTION
## Summary

Phase 2 of the [CLOC26 ASI spec](code/specs/CLOC26-asi.md): ECMAScript §12.10 **Rule 1** — a `;` is inserted before an offending token that is **preceded by a line terminator** (Phase 1 covered only `}`/EOF). So a program that uses newlines instead of semicolons now parses and gets optimized:

```js
var w = 4
var s = 1 + 2
report(w * s)
// SIMPLE ⇒  var w=4;var s=3;report(w * s);   (1+2 folded)
```

## How (no shared-lexer change)

The lexer discards newlines as trivia but records each token's start `line`. `asi_applies_at(tokens, idx)` concludes a line terminator sits between `tokens[idx-1]` and `tokens[idx]` when the offending token starts on a **higher line** than its predecessor. (`is_asi_recoverable` was replaced by this index-aware predicate.)

## Soundness (2-round security review)

`value` holds the **cooked** text, so a predecessor that can span source lines while its value hides it (string/template/regex) would make the start-line comparison unreliable — the first review caught this as a HIGH miscompile risk. Fixed with `token_may_span_lines`, which restricts Rule 1 to **provably single-line** predecessors (identifiers/numbers/punctuators/keywords) and excludes string/template/regex kinds (and any value already containing a raw newline).
- **Documented limitation:** a statement ending in a string/template/regex literal immediately before a newline is conservatively **not** recovered (a missed optimization, never a miscompile; recoverable later via token end-position tracking).
- **Core invariant preserved:** insertion happens **only on a genuine parse failure**, so any program that already parses is byte-for-byte untouched. Requiring an actual line terminator for the non-`}`/EOF case keeps a true one-line error (`a = 1 b = 2`) from being silently "recovered".

## Testing
- 13 `asi` unit tests (6 new): newline-separated statements recovered; **one-line `a=1 b=2` NOT recovered**; multi-statement no-semicolon program; valid multi-line program is a no-op; continued multi-line expression not split; string-predecessor conservatively declined.
- 64 `javascript-parser` + **734 closurec** tests green.
- **REGRESSION GUARD:** the entire existing closurec fixture suite is **byte-for-byte unchanged**.
- New e2e fixture `simple-asi-newline` with a whitespace-fallback guard.

## Follow-up
Phase 3 (restricted productions: no line break after `return`/`throw`/`break`/`continue`/`yield`/postfix `++`/`--`), per spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)