### PR TITLE
feat(r-lang): R-30 — ordering refinements (multi-key order, rank ties.method, duplicated fromLast, anyDuplicated)

### DIFF
--- a/code/packages/rust/r-runtime/CHANGELOG.md
+++ b/code/packages/rust/r-runtime/CHANGELOG.md
@@ -2,6 +2,37 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.25.0] - 2026-06-21
+
+### Added (via the shared `s-runtime`)
+
+- **R-30 — ordering refinements**: the follow-up to R-29, filling in the ties,
+  direction, and multi-key corners of the ordering builtins. All extensions of
+  the existing R-29/R-13 handlers in the shared `s-runtime` (no grammar change),
+  reached through ordinary R syntax, numeric- and character-aware.
+  - **Multi-key `order(x, y, ...)`** — sorts the index permutation lexicographically
+    by the first key, breaking ties by the next, with remaining ties kept in
+    original order (stable). Keys coerced independently (numeric: `NA` last;
+    character: lexicographic), so they may be mixed; all keys must share the first
+    key's length (mismatch → graceful error). The R-13 single-key form is unchanged.
+    `order(c(2,1,2), c(1,2,1))` → `c(2, 1, 3)`.
+  - **`rank(x, ties.method = ...)`** — `"min"`, `"max"`, and `"first"` join the
+    default `"average"`. `rank(c(1,1,2))` → `c(1.5,1.5,3)` / `c(1,1,3)` / `c(2,2,3)`
+    / `c(1,2,3)`. Result stays numeric; unknown method → graceful error.
+  - **`duplicated(x, fromLast = TRUE)`** — right-to-left scan keeps the **last**
+    occurrence; earlier repeats are flagged. Default unchanged.
+    `duplicated(c(1,2,1), fromLast = TRUE)` → `c(TRUE, FALSE, FALSE)`.
+  - **`anyDuplicated(x)`** — the 1-based index of the first duplicated element, or
+    `0` if none. `anyDuplicated(c(1,2,1))` → `3`; `anyDuplicated(c(1,2,3))` → `0`.
+  - **Security**: no new user-controlled multiplier; outputs bounded by the
+    already-`MAX_SEQ_LEN`-capped inputs; the per-key length check guards `order`
+    against out-of-bounds indexing; `NA` stays an ordinary matchable key; empty
+    inputs yield empty/`0`.
+  - 5 new R-syntax tests (numeric + character).
+  - **Deferred to R-31**: `incomparables=` on the set ops / `duplicated` /
+    `anyDuplicated` (needs `NA`-comparison plumbing), the `fromLast=` set-op
+    argument, and `rank`'s `"random"` tie method.
+
 ## [0.24.0] - 2026-06-21
 
 ### Added (via the shared `s-runtime`)

--- a/code/packages/rust/r-runtime/README.md
+++ b/code/packages/rust/r-runtime/README.md
@@ -173,8 +173,20 @@ function spelling of `el %in% set`. `duplicated(c(1,1,2,3,3))` →
 gives sample ranks with **average** tie handling (R's default): `rank(c(3,1,2))`
 → `c(3, 1, 2)` and `rank(c(1,1,2))` → `c(1.5, 1.5, 3)`. Outputs are bounded by
 the inputs (each already sequence-capped) and `rank` is `O(n log n)`, so none is
-a DoS vector. (Other `ties.method` options, `incomparables=`/`fromLast=`,
-`anyDuplicated`, and multi-key `order` are deferred to R-30.)
+a DoS vector.
+
+**Ordering refinements (R-30)** — extensions of the R-29/R-13 builtins. Multi-key
+`order(x, y, ...)` sorts lexicographically by the first key, breaking ties by the
+next, remaining ties kept in original order (`order(c(2,1,2), c(1,2,1))` →
+`c(2, 1, 3)`; keys may mix numeric and character, and all must share the first
+key's length). `rank(x, ties.method=)` adds `"min"`, `"max"`, and `"first"` to the
+default `"average"` (`rank(c(1,1,2))` → `c(1.5,1.5,3)` / `c(1,1,3)` / `c(2,2,3)` /
+`c(1,2,3)`). `duplicated(x, fromLast=TRUE)` keeps the *last* occurrence
+(`duplicated(c(1,2,1), fromLast=TRUE)` → `c(TRUE, FALSE, FALSE)`).
+`anyDuplicated(x)` returns the 1-based index of the first duplicated element, or
+`0` if none (`anyDuplicated(c(1,2,1))` → `3`). (`incomparables=` on the set ops /
+`duplicated` / `anyDuplicated`, the `fromLast=` set-op argument, and `rank`'s
+`"random"` method are deferred to R-31.)
 
 ## Usage
 

--- a/code/packages/rust/r-runtime/src/lib.rs
+++ b/code/packages/rust/r-runtime/src/lib.rs
@@ -2815,4 +2815,67 @@ mod tests {
         // Character ranks lexicographically; tied "a"s average their positions.
         assert_eq!(nums("rank(c(\"b\", \"a\", \"a\"))\n"), vec![3.0, 1.5, 1.5]);
     }
+
+    // --- R-30: ordering refinements (R syntax) --------------------------
+
+    #[test]
+    fn order_multi_key_breaks_ties_by_second() {
+        // order(c(2,1,2), c(1,2,1)) → c(2, 1, 3): the lone 1 first, then the two
+        // 2s tied on both keys, kept in original order (idx 1 before idx 3).
+        assert_eq!(nums("order(c(2, 1, 2), c(1, 2, 1))\n"), vec![2.0, 1.0, 3.0]);
+        // A discriminating secondary key actually reorders the tie.
+        assert_eq!(nums("order(c(2, 1, 2), c(5, 2, 1))\n"), vec![2.0, 3.0, 1.0]);
+    }
+
+    #[test]
+    fn order_single_key_still_works() {
+        assert_eq!(nums("order(c(3, 1, 2))\n"), vec![2.0, 3.0, 1.0]);
+        assert_eq!(nums("order(c(\"b\", \"a\", \"c\"))\n"), vec![2.0, 1.0, 3.0]);
+    }
+
+    #[test]
+    fn rank_ties_method_variants() {
+        assert_eq!(nums("rank(c(1, 1, 2))\n"), vec![1.5, 1.5, 3.0]); // average default
+        assert_eq!(
+            nums("rank(c(1, 1, 2), ties.method = \"min\")\n"),
+            vec![1.0, 1.0, 3.0]
+        );
+        assert_eq!(
+            nums("rank(c(1, 1, 2), ties.method = \"max\")\n"),
+            vec![2.0, 2.0, 3.0]
+        );
+        assert_eq!(
+            nums("rank(c(1, 1, 2), ties.method = \"first\")\n"),
+            vec![1.0, 2.0, 3.0]
+        );
+        // Character vectors honour ties.method too.
+        assert_eq!(
+            nums("rank(c(\"b\", \"a\", \"a\"), ties.method = \"first\")\n"),
+            vec![3.0, 1.0, 2.0]
+        );
+    }
+
+    #[test]
+    fn duplicated_from_last() {
+        // Default keeps the FIRST occurrence; fromLast keeps the LAST.
+        assert_eq!(
+            show("duplicated(c(1, 2, 1))\n"),
+            "[1] FALSE FALSE  TRUE"
+        );
+        assert_eq!(
+            show("duplicated(c(1, 2, 1), fromLast = TRUE)\n"),
+            "[1]  TRUE FALSE FALSE"
+        );
+        assert_eq!(
+            show("duplicated(c(\"a\", \"b\", \"a\"), fromLast = TRUE)\n"),
+            "[1]  TRUE FALSE FALSE"
+        );
+    }
+
+    #[test]
+    fn any_duplicated_index_or_zero() {
+        assert_eq!(nums("anyDuplicated(c(1, 2, 1))\n"), vec![3.0]);
+        assert_eq!(nums("anyDuplicated(c(1, 2, 3))\n"), vec![0.0]);
+        assert_eq!(nums("anyDuplicated(c(\"a\", \"b\", \"a\"))\n"), vec![3.0]);
+    }
 }

--- a/code/packages/rust/s-runtime/CHANGELOG.md
+++ b/code/packages/rust/s-runtime/CHANGELOG.md
@@ -2,6 +2,64 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.26.0] - 2026-06-21
+
+### Added
+
+- **Ordering refinements (R-30)** — extensions of the R-29/R-13 ordering builtins,
+  available to both S and R via the shared tree-walker; no new value type, no
+  grammar change. They reuse the existing `as_character` key, `value::index`,
+  `truthy()` (the `na.rm =` boolean reader), and `as_character()` string-keyword
+  reads (the `factor(levels =, labels =)` pattern).
+  - **Multi-key `order(x, y, ...)`** — sort the index permutation lexicographically
+    by the first key, breaking ties by the second, then the next, …; indices still
+    tied after every key keep their **original order** (a stable sort). Each key is
+    coerced independently — numeric keys compare numerically with `NA` sorting last
+    (`na.last = TRUE`), character keys lexicographically — so numeric and character
+    keys may be mixed across positions. All keys must share the first key's length
+    (a mismatch is a graceful error, never an out-of-bounds index). The single-key
+    R-13 form is the arity-1 special case, unchanged.
+    `order(c(2,1,2), c(1,2,1))` → `c(2, 1, 3)`.
+  - **`rank(x, ties.method = ...)`** — adds `"min"` (every tie takes the lowest
+    position in its run), `"max"` (the highest), and `"first"` (consecutive ranks
+    in original order, so ties get distinct ranks) alongside the default
+    `"average"` (unchanged). An unrecognised method is a graceful error. The result
+    stays numeric. `rank(c(1,1,2))` → `c(1.5,1.5,3)` / `c(1,1,3)` / `c(2,2,3)` /
+    `c(1,2,3)` for average / min / max / first.
+  - **`duplicated(x, fromLast = TRUE)`** — runs the duplicate scan right-to-left,
+    so the **last** occurrence of each value is the keeper (`FALSE`) and earlier
+    repeats are flagged. Default (`fromLast = FALSE`) unchanged.
+    `duplicated(c(1,2,1), fromLast = TRUE)` → `c(TRUE, FALSE, FALSE)`.
+  - **`anyDuplicated(x)`** — the 1-based index of the first duplicated element
+    (the first position whose value appeared earlier), or `0` when there are none;
+    agrees with `which(duplicated(x))[1]`. `anyDuplicated(c(1,2,1))` → `3`;
+    `anyDuplicated(c(1,2,3))` → `0`. Numeric and character vectors.
+
+### Security
+
+- **Output-size caps.** No new user-controlled multiplier. `order` allocates one
+  `usize` per element of the first key and sorts `O(n log n)`; the per-key length
+  check rejects mismatched keys before any indexing. `rank` (all methods) and
+  `duplicated` (both directions) emit exactly one entry per input element, and
+  `anyDuplicated` scans once. Every operand is already `MAX_SEQ_LEN`-bounded, so
+  outputs are bounded by the (capped) input lengths; `NA` remains an ordinary
+  matchable key; empty inputs yield empty/`0` results; no path can index out of
+  bounds.
+
+### Deferred to R-31
+
+- `incomparables =` on the set ops / `duplicated` / `anyDuplicated` (needs
+  `NA`-comparison plumbing — a way to mark values "never equal to anything", which
+  the `as_character`-key path does not model), the `fromLast =` set-op argument,
+  and `rank`'s `"random"` tie method (needs an RNG-seed contract).
+
+### Tests
+
+- New `r30_ordering` module: 17 tests covering multi-key `order` (tie-break,
+  stable fallback, character + mixed keys, length-mismatch error), `rank`
+  ties.method (average/min/max/first, numeric + character, unknown-method error),
+  `duplicated(fromLast=)`, and `anyDuplicated` (numeric + character + empty).
+
 ## [0.25.0] - 2026-06-21
 
 ### Added

--- a/code/packages/rust/s-runtime/README.md
+++ b/code/packages/rust/s-runtime/README.md
@@ -199,8 +199,22 @@ a hand-written loop. See [What "S-flavored" means here](#what-s-flavored-means-h
   `c(F,T,F,F,T)`); and `rank(x)` gives sample ranks with **average** ties
   (`rank(c(1,1,2))` → `c(1.5, 1.5, 3)`). Outputs are bounded by the inputs (each
   already `MAX_SEQ_LEN`-bounded) and `rank` is `O(n log n)`, so none is a DoS
-  vector. (Other `ties.method` options, `incomparables=`/`fromLast=`,
-  `anyDuplicated`, and multi-key `order` are deferred to R-30.)
+  vector.
+- **Ordering refinements** (R-30): extensions of the R-29/R-13 ordering builtins.
+  **Multi-key `order(x, y, ...)`** sorts the index permutation lexicographically by
+  the first key, breaking ties by the next, with remaining ties kept in original
+  order (stable); keys are coerced independently (numeric: `NA` last; character:
+  lexicographic) and may be mixed, and all must share the first key's length
+  (`order(c(2,1,2), c(1,2,1))` → `c(2, 1, 3)`). **`rank(x, ties.method=)`** adds
+  `"min"`, `"max"`, and `"first"` to the default `"average"` (`rank(c(1,1,2))` →
+  `c(1.5,1.5,3)` / `c(1,1,3)` / `c(2,2,3)` / `c(1,2,3)`). **`duplicated(x,
+  fromLast=TRUE)`** scans right-to-left so the *last* occurrence is the keeper
+  (`duplicated(c(1,2,1), fromLast=TRUE)` → `c(T,F,F)`). **`anyDuplicated(x)`**
+  returns the 1-based index of the first duplicated element, or `0` if none
+  (`anyDuplicated(c(1,2,1))` → `3`). Outputs stay bounded by the (capped) inputs;
+  the per-key length check guards `order` against out-of-bounds indexing.
+  (`incomparables=` on the set ops / `duplicated` / `anyDuplicated`, the `fromLast=`
+  set-op argument, and `rank`'s `"random"` method are deferred to R-31.)
 - The **`d`/`p`/`q`/`r` distribution family** (R-8) over `statistics-core`:
   density/CDF/quantile/sampling for the normal, uniform, and exponential
   distributions, plus `set.seed` for a reproducible per-session RNG.

--- a/code/packages/rust/s-runtime/src/builtins.rs
+++ b/code/packages/rust/s-runtime/src/builtins.rs
@@ -89,6 +89,8 @@ pub fn install(env: &Env) {
     define(env, "setdiff", builtin("setdiff", b_setdiff));
     define(env, "is.element", builtin("is.element", b_is_element));
     define(env, "duplicated", builtin("duplicated", b_duplicated));
+    // R-30 — first-duplicate index (ordering refinements).
+    define(env, "anyDuplicated", builtin("anyDuplicated", b_any_duplicated));
     define(env, "rank", builtin("rank", b_rank));
     define(env, "which", builtin("which", b_which));
     define(env, "any", builtin("any", b_any));
@@ -1768,15 +1770,89 @@ fn b_sort(_interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
 }
 
 /// `order(x)` — the 1-based permutation that sorts `x` ascending.
+/// `order(x, y, ...)` — the permutation of 1-based indices that sorts `x`
+/// ascending, **breaking ties by `y`, then the next key, …**, lexicographically.
+/// Indices still tied after every key are kept in their **original order** (a
+/// *stable* sort), exactly as R does.
+///
+/// ```text
+/// order(c(2, 1, 2), c(1, 2, 1))
+///   element (idx : key1, key2):  1:(2,1)  2:(1,2)  3:(2,1)
+///   sort by key1:                idx2 (1) first; idx1 & idx3 (both 2) tie
+///   break by key2:               idx1 (1) and idx3 (1) STILL tie
+///   stable fallback:             original order → idx1 before idx3
+///   result:                      c(2, 1, 3)
+/// ```
+///
+/// Each key is coerced to a comparison form **independently**: a pure-numeric key
+/// compares numerically (with `NA`/`NaN` sorting **last**, mirroring R's default
+/// `na.last = TRUE`); any other key compares on its character rendering
+/// (lexicographically). That lets numeric and character keys be mixed across
+/// positions. The single-key R-13 form is simply the one-key case.
+///
+/// Every key must have the **same length** as the first; a mismatched length is a
+/// graceful error, never an out-of-bounds index. The only allocation is one
+/// `usize` per element of the first key, sorted in `O(n log n)` — no
+/// user-controlled multiplier, so no extra cap beyond the inputs' own
+/// `MAX_SEQ_LEN` bound.
 fn b_order(_interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
-    let d = first_positional(args)?.as_double()?;
-    let data = d.data();
-    let mut idx: Vec<usize> = (0..data.len()).collect();
-    idx.sort_by(|&a, &b| {
-        data[a]
-            .partial_cmp(&data[b])
-            .unwrap_or(std::cmp::Ordering::Equal)
-    });
+    // Collect the sort keys, in order, from the positional arguments. Each key is
+    // pre-coerced once into a totally-ordered comparison form (numeric or string),
+    // so the comparator below is a cheap lookup rather than a re-coercion.
+    enum Key {
+        Num(Vec<f64>),
+        Str(Vec<Option<String>>),
+    }
+    let positional: Vec<&SValue> = args.iter().filter(|a| a.name.is_none()).map(|a| &a.value).collect();
+    let first = *positional
+        .first()
+        .ok_or_else(|| SError::BadArgs("argument \"x\" is missing".into()))?;
+    let n = first.length();
+
+    let mut keys: Vec<Key> = Vec::with_capacity(positional.len());
+    for v in &positional {
+        // A length mismatch between keys is an error in R ("argument lengths
+        // differ"); we reject it before any indexing can go out of bounds.
+        if v.length() != n {
+            return Err(SError::BadArgs(
+                "argument lengths differ in order()".into(),
+            ));
+        }
+        let key = match v.strip_names().strip_attrs() {
+            SValue::Character(_) | SValue::Factor { .. } => Key::Str(v.as_character()),
+            other => Key::Num(other.as_double()?.iter().collect()),
+        };
+        keys.push(key);
+    }
+
+    // Compare two original indices `a`, `b` by walking the keys left-to-right; the
+    // first key that distinguishes them decides. NA sorts last within a key.
+    let cmp = |a: usize, b: usize| -> std::cmp::Ordering {
+        for key in &keys {
+            let ord = match key {
+                Key::Num(v) => match (is_na_real(v[a]), is_na_real(v[b])) {
+                    (true, true) => std::cmp::Ordering::Equal,
+                    (true, false) => std::cmp::Ordering::Greater,
+                    (false, true) => std::cmp::Ordering::Less,
+                    (false, false) => v[a].partial_cmp(&v[b]).unwrap_or(std::cmp::Ordering::Equal),
+                },
+                Key::Str(v) => match (&v[a], &v[b]) {
+                    (None, None) => std::cmp::Ordering::Equal,
+                    (None, Some(_)) => std::cmp::Ordering::Greater,
+                    (Some(_), None) => std::cmp::Ordering::Less,
+                    (Some(x), Some(y)) => x.cmp(y),
+                },
+            };
+            if ord != std::cmp::Ordering::Equal {
+                return ord;
+            }
+        }
+        std::cmp::Ordering::Equal
+    };
+
+    let mut idx: Vec<usize> = (0..n).collect();
+    // `sort_by` is stable, so indices equal under every key keep original order.
+    idx.sort_by(|&a, &b| cmp(a, b));
     Ok(SValue::doubles(
         idx.iter().map(|i| (i + 1) as f64).collect(),
     ))
@@ -1940,15 +2016,60 @@ fn b_is_element(_interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
 /// `FALSE`). Same `as_character`-key + `seen`-set scan as `unique`, but it emits
 /// the flag instead of gathering: `seen.insert(k)` returns `true` the first time
 /// we meet a key (→ not a duplicate) and `false` thereafter (→ a duplicate).
+///
+/// With **`fromLast = TRUE`** the scan runs **right-to-left** instead, so the
+/// *last* occurrence of each value is the keeper (`FALSE`) and the *earlier*
+/// copies are flagged. We scan in reverse, recording the flag at the element's
+/// real position, so the output stays aligned with the input:
+///
+/// ```text
+/// duplicated(c(1, 2, 1))                 = c(FALSE, FALSE, TRUE)   (keep first 1)
+/// duplicated(c(1, 2, 1), fromLast=TRUE)  = c(TRUE,  FALSE, FALSE)  (keep last  1)
+/// ```
 fn b_duplicated(_interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
     let x = first_positional(args)?;
+    let from_last = match args.iter().find(|a| a.name.as_deref() == Some("fromLast")) {
+        Some(arg) => arg.value.truthy()?,
+        None => false,
+    };
+    let keys = x.as_character();
+    let n = keys.len();
     let mut seen: HashSet<Option<String>> = HashSet::new();
-    let flags: Vec<Option<bool>> = x
-        .as_character()
-        .into_iter()
-        .map(|k| Some(!seen.insert(k)))
-        .collect();
+    let mut flags: Vec<Option<bool>> = vec![Some(false); n];
+    if from_last {
+        // Right-to-left: the first key seen (from the right) is the last
+        // occurrence and is NOT a duplicate; earlier ones are.
+        for i in (0..n).rev() {
+            flags[i] = Some(!seen.insert(keys[i].clone()));
+        }
+    } else {
+        for (i, k) in keys.into_iter().enumerate() {
+            flags[i] = Some(!seen.insert(k));
+        }
+    }
     Ok(SValue::Logical(flags))
+}
+
+/// `anyDuplicated(x)` — the **1-based index of the first duplicated element**
+/// (the first position whose value already appeared earlier), or `0` when `x` has
+/// no duplicates. Defined to agree with `which(duplicated(x))[1]` (and `0` when
+/// that is empty). One forward pass over the shared character keys; numeric and
+/// character vectors alike. The result is a scalar numeric, matching the other
+/// index-returning builtins.
+///
+/// ```text
+/// anyDuplicated(c(1, 2, 1)) = 3   (the second 1, at position 3, is the first dup)
+/// anyDuplicated(c(1, 2, 3)) = 0   (no repeats)
+/// ```
+fn b_any_duplicated(_interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
+    let x = first_positional(args)?;
+    let mut seen: HashSet<Option<String>> = HashSet::new();
+    for (i, k) in x.as_character().into_iter().enumerate() {
+        if !seen.insert(k) {
+            return Ok(SValue::scalar((i + 1) as f64));
+        }
+    }
+    Ok(SValue::scalar(0.0))
 }
 
 /// `rank(x)` — **sample ranks** with **average** tie handling (R's default
@@ -1965,13 +2086,60 @@ fn b_duplicated(_interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
 ///
 /// Implementation: sort an index permutation `order` (so `order[p]` is the
 /// original index of the value at sorted-position `p`), then walk `order` in
-/// runs of equal keys, assigning every member of a run the average of the
-/// `[run_start+1 ..= run_end+1]` positions. Numeric input compares numerically;
-/// character input lexicographically. The result is always numeric (averages
-/// are fractional), matching R. `O(n log n)` time, one `f64` per element — no
-/// user-controlled multiplier, so no extra allocation cap is required.
+/// runs of equal keys, assigning every member of a run a rank determined by the
+/// `ties.method`. Numeric input compares numerically; character input
+/// lexicographically. The result is always numeric, matching R. `O(n log n)`
+/// time, one `f64` per element — no user-controlled multiplier, so no extra
+/// allocation cap is required.
+///
+/// **`ties.method`** (R-30) selects how a run of `m` equal values spanning the
+/// 1-based positions `lo ..= hi` is scored:
+///
+/// ```text
+/// values   c(1, 1, 2)       run of two 1s spans positions 1,2
+/// "average"  (lo+hi)/2       → 1.5, 1.5, 3   (the default — R-29 behaviour)
+/// "min"      lo              → 1,   1,   3
+/// "max"      hi              → 2,   2,   3
+/// "first"    lo, lo+1, …     → 1,   2,   3   (consecutive, in original order)
+/// ```
+///
+/// For `"first"` the run members are scored in **original-index order** (the
+/// sort is stable, so `order` already lists tied indices smallest-first), giving
+/// distinct consecutive ranks. An unrecognised method is a graceful error.
 fn b_rank(_interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
     let x = first_positional(args)?;
+
+    // The tie rule. R's default is "average"; we additionally support "min",
+    // "max", and "first" (the "random" jitter rule needs an RNG seed contract and
+    // is deferred). The keyword is read as a character scalar, mirroring how
+    // `factor(levels=, labels=)` reads its string arguments.
+    enum Ties {
+        Average,
+        Min,
+        Max,
+        First,
+    }
+    let ties = match args.iter().find(|a| a.name.as_deref() == Some("ties.method")) {
+        Some(arg) => match arg
+            .value
+            .as_character()
+            .into_iter()
+            .next()
+            .flatten()
+            .as_deref()
+        {
+            Some("average") | None => Ties::Average,
+            Some("min") => Ties::Min,
+            Some("max") => Ties::Max,
+            Some("first") => Ties::First,
+            Some(other) => {
+                return Err(SError::BadArgs(format!(
+                    "unknown ties.method {other:?} (expected \"average\", \"min\", \"max\", or \"first\")"
+                )));
+            }
+        },
+        None => Ties::Average,
+    };
     // Compute a totally-ordered comparison and a "same key" test from one coerced
     // form. For numeric vectors we rank on the f64 values (NA sorts last, like R's
     // default na.last); for character (or anything else) we rank on the string keys.
@@ -2019,8 +2187,8 @@ fn b_rank(_interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
         }
     };
 
-    // Walk the sorted permutation in runs of equal keys; each run gets the
-    // average of the 1-based positions it occupies.
+    // Walk the sorted permutation in runs of equal keys; each run is scored per
+    // the chosen `ties.method`. A run occupies the 1-based positions `lo ..= hi`.
     let mut ranks = vec![0.0_f64; n];
     let mut p = 0usize;
     while p < n {
@@ -2028,11 +2196,33 @@ fn b_rank(_interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
         while q < n && tied(order[p], order[q]) {
             q += 1;
         }
-        // Positions p..q (0-based) are 1-based p+1 ..= q; their average is the
-        // midpoint of the first and last 1-based position.
-        let avg = ((p + 1) as f64 + q as f64) / 2.0;
-        for k in p..q {
-            ranks[order[k]] = avg;
+        let lo = (p + 1) as f64; // first 1-based position in the run
+        let hi = q as f64; // last 1-based position in the run
+        match ties {
+            Ties::Average => {
+                let avg = (lo + hi) / 2.0;
+                for k in p..q {
+                    ranks[order[k]] = avg;
+                }
+            }
+            Ties::Min => {
+                for k in p..q {
+                    ranks[order[k]] = lo;
+                }
+            }
+            Ties::Max => {
+                for k in p..q {
+                    ranks[order[k]] = hi;
+                }
+            }
+            Ties::First => {
+                // `order` lists tied indices in original order (stable sort), so
+                // walking the run assigns consecutive ranks lo, lo+1, … in that
+                // order — distinct ranks, no ties.
+                for (offset, k) in (p..q).enumerate() {
+                    ranks[order[k]] = lo + offset as f64;
+                }
+            }
         }
         p = q;
     }

--- a/code/packages/rust/s-runtime/src/lib.rs
+++ b/code/packages/rust/s-runtime/src/lib.rs
@@ -1992,3 +1992,173 @@ mod r29_set_ops {
         );
     }
 }
+
+#[cfg(test)]
+mod r30_ordering {
+    //! R-30 ordering refinements (exercised through **S** syntax — the shared
+    //! tree-walker is language-neutral, so R inherits the same behaviour).
+    //! Covers multi-key `order`, `rank` ties.method, `duplicated(fromLast=)`, and
+    //! `anyDuplicated` over both numeric and character vectors.
+    use super::*;
+
+    fn show(src: &str) -> String {
+        format_value(&eval_s(src).unwrap()).join("\n")
+    }
+
+    fn nums(src: &str) -> Vec<f64> {
+        match eval_s(src).unwrap().strip_names() {
+            SValue::Double(d) => d.data().to_vec(),
+            other => panic!("expected double, got {}", other.type_name()),
+        }
+    }
+
+    // --- multi-key order ------------------------------------------------
+
+    #[test]
+    fn order_single_key_unchanged() {
+        // The R-13 single-key form is the arity-1 special case.
+        assert_eq!(nums("order(c(3, 1, 2))\n"), vec![2.0, 3.0, 1.0]);
+    }
+
+    #[test]
+    fn order_two_keys_breaks_ties_by_second() {
+        // values (idx:key1,key2): 1:(2,1) 2:(1,2) 3:(2,1). Sort by key1: idx2
+        // (key1=1) first; then the two key1=2 elements (idx1, idx3) tie on key1
+        // AND key2 → kept in original order: idx1 then idx3. → c(2, 1, 3).
+        assert_eq!(nums("order(c(2, 1, 2), c(1, 2, 1))\n"), vec![2.0, 1.0, 3.0]);
+    }
+
+    #[test]
+    fn order_secondary_actually_separates_ties() {
+        // key1 ties idx1 & idx3 (both 2); key2 breaks them: idx3 (sec=1) before
+        // idx1 (sec=5). → idx2 (key1=1) first, then idx3, then idx1 → c(2, 3, 1).
+        assert_eq!(nums("order(c(2, 1, 2), c(5, 2, 1))\n"), vec![2.0, 3.0, 1.0]);
+    }
+
+    #[test]
+    fn order_character_key() {
+        // Lexicographic by the (single) character key.
+        assert_eq!(
+            nums("order(c(\"b\", \"a\", \"c\"))\n"),
+            vec![2.0, 1.0, 3.0]
+        );
+    }
+
+    #[test]
+    fn order_mixed_numeric_and_character_keys() {
+        // First key numeric (ties idx1 & idx3 at 1), broken by a character second
+        // key: "a" < "b" → idx3 before idx1. idx2 (key1=2) last. → c(3, 1, 2).
+        assert_eq!(
+            nums("order(c(1, 2, 1), c(\"b\", \"z\", \"a\"))\n"),
+            vec![3.0, 1.0, 2.0]
+        );
+    }
+
+    #[test]
+    fn order_length_mismatch_is_graceful_error() {
+        // A secondary key of the wrong length is an error, never a panic.
+        assert!(eval_s("order(c(1, 2, 3), c(1, 2))\n").is_err());
+    }
+
+    // --- rank ties.method -----------------------------------------------
+
+    #[test]
+    fn rank_average_is_default() {
+        assert_eq!(nums("rank(c(1, 1, 2))\n"), vec![1.5, 1.5, 3.0]);
+        assert_eq!(
+            nums("rank(c(1, 1, 2), ties.method = \"average\")\n"),
+            vec![1.5, 1.5, 3.0]
+        );
+    }
+
+    #[test]
+    fn rank_min_max_first() {
+        assert_eq!(
+            nums("rank(c(1, 1, 2), ties.method = \"min\")\n"),
+            vec![1.0, 1.0, 3.0]
+        );
+        assert_eq!(
+            nums("rank(c(1, 1, 2), ties.method = \"max\")\n"),
+            vec![2.0, 2.0, 3.0]
+        );
+        assert_eq!(
+            nums("rank(c(1, 1, 2), ties.method = \"first\")\n"),
+            vec![1.0, 2.0, 3.0]
+        );
+    }
+
+    #[test]
+    fn rank_first_keeps_original_order_within_run() {
+        // Three tied values get consecutive ranks in their original positions.
+        assert_eq!(
+            nums("rank(c(5, 5, 5), ties.method = \"first\")\n"),
+            vec![1.0, 2.0, 3.0]
+        );
+    }
+
+    #[test]
+    fn rank_character_ties_method() {
+        // "a" < "b"; the two "a"s tie at sorted positions 1,2.
+        assert_eq!(
+            nums("rank(c(\"b\", \"a\", \"a\"), ties.method = \"min\")\n"),
+            vec![3.0, 1.0, 1.0]
+        );
+        assert_eq!(
+            nums("rank(c(\"b\", \"a\", \"a\"), ties.method = \"first\")\n"),
+            vec![3.0, 1.0, 2.0]
+        );
+    }
+
+    #[test]
+    fn rank_unknown_ties_method_is_graceful_error() {
+        assert!(eval_s("rank(c(1, 2), ties.method = \"bogus\")\n").is_err());
+    }
+
+    // --- duplicated fromLast --------------------------------------------
+
+    #[test]
+    fn duplicated_default_unchanged() {
+        assert_eq!(
+            show("duplicated(c(1, 1, 2, 3, 3))\n"),
+            "[1] FALSE  TRUE FALSE FALSE  TRUE"
+        );
+    }
+
+    #[test]
+    fn duplicated_from_last_numeric() {
+        // Scanning right-to-left, the LAST occurrence is the keeper; earlier
+        // repeats are the duplicates.
+        assert_eq!(
+            show("duplicated(c(1, 2, 1), fromLast = TRUE)\n"),
+            "[1]  TRUE FALSE FALSE"
+        );
+    }
+
+    #[test]
+    fn duplicated_from_last_character() {
+        assert_eq!(
+            show("duplicated(c(\"a\", \"b\", \"a\"), fromLast = TRUE)\n"),
+            "[1]  TRUE FALSE FALSE"
+        );
+    }
+
+    // --- anyDuplicated --------------------------------------------------
+
+    #[test]
+    fn any_duplicated_returns_first_dup_index() {
+        assert_eq!(nums("anyDuplicated(c(1, 2, 1))\n"), vec![3.0]);
+        assert_eq!(nums("anyDuplicated(c(5, 5, 5))\n"), vec![2.0]);
+    }
+
+    #[test]
+    fn any_duplicated_zero_when_no_dups() {
+        assert_eq!(nums("anyDuplicated(c(1, 2, 3))\n"), vec![0.0]);
+        assert_eq!(nums("anyDuplicated(c())\n"), vec![0.0]);
+    }
+
+    #[test]
+    fn any_duplicated_character() {
+        assert_eq!(nums("anyDuplicated(c(\"a\", \"b\", \"a\"))\n"), vec![3.0]);
+        assert_eq!(nums("anyDuplicated(c(\"x\", \"y\"))\n"), vec![0.0]);
+    }
+}

--- a/code/specs/R00-r-language.md
+++ b/code/specs/R00-r-language.md
@@ -960,6 +960,66 @@ unchanged.
     `order` from R-13 is unchanged). The `%o%` infix alias for `outer` carried over
     from R-28's deferral list also remains open for a later grammar pass.
 
+- **R-30 — ordering refinements** *(this PR)*. The follow-up to R-29 that fills
+  in the *ties, direction, and multi-key* corners of the ordering builtins. All
+  changes are **extensions of the existing R-29/R-13 handlers** in the shared
+  `s-runtime` (no new value type, no grammar change); R inherits them through the
+  tree-walker. They reuse the same machinery: `as_character` (the order-and-equality
+  key shared by `unique`/`%in%`/the set ops), `value::index` (the type-preserving
+  1-based gather), `first_positional`, `arg.value.truthy()` (the `na.rm =` boolean
+  reader pattern), and `arg.value.as_character()` (the string keyword reader the
+  `factor(levels =, labels =)` builtin uses).
+  - **Multi-key `order(x, y, ...)`** — sort the index permutation by the **first**
+    key, breaking ties by the **second**, and so on, lexicographically; remaining
+    ties keep their **original order** (a *stable* sort). The R-13 single-key form is
+    the `...`-arity-1 special case, unchanged. Each key is coerced to its comparison
+    form independently (numeric keys compare numerically with `NA` last, mirroring
+    `na.last = TRUE`; character keys compare lexicographically), so a numeric key and
+    a character key can be mixed across positions. Every key must have the **same
+    length** as the first; a length mismatch is a graceful error, never a panic.
+    `order(c(2,1,2), c(1,2,1))` is `c(2, 1, 3)` (the lone `1` first, then the two `2`s
+    tied on both keys, kept in original order: index 1 before index 3).
+  - **`rank(x, ties.method = ...)`** — the R-29 `rank` gains the **four exact** tie
+    rules (the `"random"` jitter rule stays deferred, as it needs an RNG seed
+    contract): `"average"` (the default, unchanged — tied values share the **mean**
+    of the positions they span); `"min"` (every tie takes the **lowest** position in
+    its run); `"max"` (the **highest**); `"first"` (positions assigned in **original
+    order** within the run, so ties get distinct consecutive ranks). The keyword is
+    read with `arg.value.as_character()`; an unrecognised method is a graceful error.
+    `rank(c(1,1,2))` is `c(1.5,1.5,3)` (average), `c(1,1,3)` (min), `c(2,2,3)` (max),
+    `c(1,2,3)` (first). Min/max/first are **integer-valued** but still returned as
+    numeric (R's `rank` always yields a double), matching the existing return type.
+  - **`duplicated(x, fromLast = TRUE)`** — the R-29 `duplicated` gains the
+    direction flag. By default the **first** occurrence of each value is `FALSE` and
+    later repeats are `TRUE`; with `fromLast = TRUE` the scan runs **right-to-left**,
+    so the **last** occurrence is the keeper (`FALSE`) and the **earlier** repeats are
+    `TRUE`. `duplicated(c(1,2,1))` is `c(FALSE, FALSE, TRUE)`;
+    `duplicated(c(1,2,1), fromLast = TRUE)` is `c(TRUE, FALSE, FALSE)`. The flag is
+    read with `arg.value.truthy()`.
+  - **`anyDuplicated(x)`** — a **scalar integer**: the 1-based index of the **first
+    element that is itself a duplicate** (i.e. the first position whose value was seen
+    earlier), or `0` when `x` has no duplicates. Defined to agree exactly with
+    `which(duplicated(x))[1]` (and `0L` when that is empty). `anyDuplicated(c(1,2,1))`
+    is `3`; `anyDuplicated(c(1,2,3))` is `0`. Works on numeric and character vectors
+    via the shared character key.
+  - **Output-size caps (security).** No new user-controlled multiplier is
+    introduced. `order` allocates one `usize` per element of the first key and sorts
+    `O(n log n)`; the per-key length check rejects mismatched keys before any indexing.
+    `rank` (all methods) allocates one `f64` per element. `duplicated` (both
+    directions) and `anyDuplicated` emit/scan exactly one entry per input element.
+    Every operand is already `MAX_SEQ_LEN`-bounded; outputs are bounded by the
+    (already-capped) input lengths, so no separate cap is added. `NA` remains an
+    ordinary matchable key (`as_character`'s `None`); empty inputs yield empty/`0`
+    results; no path can index out of bounds.
+  - **Scope outcome / deferred to R-31.** Multi-key `order`, `rank`'s
+    `average`/`min`/`max`/`first` tie methods, `duplicated(fromLast =)`, and
+    `anyDuplicated` ship **solidly**. **Deferred to R-31:** `incomparables =` on the
+    set ops / `duplicated` / `anyDuplicated` (it needs `NA`-comparison plumbing — a
+    way to mark certain values as "never equal to anything", which the current
+    `as_character`-key path does not model); `rank`'s `"random"` tie method (needs the
+    RNG-seed contract); and the `fromLast =` argument on the set ops. The `%o%` infix
+    alias for `outer` remains open for a later grammar pass.
+
 ## §4 Reuse strategy
 
 - **Lexer/parser:** the grammar-tools framework, exactly as S uses it. `r.tokens`
@@ -989,9 +1049,11 @@ the R5 system in **R-26**); the output-formatting family (`format`, `formatC`,
 builtins (`outer`, `tapply`, `split`, `tabulate`) land in **R-28**, with the `%o%`
 infix alias, matrix dimnames, multi-way `tapply`, and `simplify = FALSE` deferred to
 a later pass; the vector set-operation & ranking builtins (`union`, `intersect`,
-`setdiff`, `is.element`, `duplicated`, `rank`) land in **R-29**, with `rank`'s other
-`ties.method` options, the `incomparables=`/`fromLast=` set-op arguments,
-`anyDuplicated`, and multi-key `order` deferred to **R-30**; namespaces and `library()`
+`setdiff`, `is.element`, `duplicated`, `rank`) land in **R-29**; the ordering
+refinements (multi-key `order(x, y, ...)`, `rank`'s `ties.method` =
+`average`/`min`/`max`/`first`, `duplicated(fromLast=)`, `anyDuplicated`) land in
+**R-30**, with `incomparables=` on the set ops / `duplicated`, the `fromLast=`
+set-op argument, and `rank`'s `"random"` method deferred to **R-31**; namespaces and `library()`
 (so `baseenv()` aliases the
 global env for now); the C interface; graphics. These layer on later, following
 ST00.

--- a/code/specs/S00-s-language.md
+++ b/code/specs/S00-s-language.md
@@ -273,9 +273,26 @@ needs a string assignment target: `"%between%" <- function(x, r) x >= r[1] & x <
   handling — `rank(c(1,1,2))` is `c(1.5, 1.5, 3)`). All are pure, numeric- and
   character-aware (they key on the same coerced-character form as `unique`/`%in%`)
   and reuse the existing `as_character` / `index` / `membership` / `combine`
-  machinery. Other `ties.method` options for `rank`, the `incomparables=` /
-  `fromLast=` set-op arguments, `anyDuplicated`, and multi-key `order` are deferred
-  to a later pass (R-30).
+  machinery.
+- **Ordering refinements** *(R-30)*: extensions of the R-29/R-13 ordering builtins
+  (no new value type, no grammar change). **Multi-key `order(x, y, ...)`** sorts the
+  index permutation lexicographically by the first key, breaking ties by the second,
+  etc., with remaining ties kept in original order (stable); each key is coerced
+  independently (numeric compares numerically with `NA` last, character
+  lexicographically), all keys must share the first key's length, and the single-key
+  R-13 form is the arity-1 special case (`order(c(2,1,2), c(1,2,1))` is `c(2,1,3)`).
+  **`rank(x, ties.method=)`** gains `"min"` (lowest position in a tie run), `"max"`
+  (highest), and `"first"` (consecutive ranks in original order) alongside the default
+  `"average"` (`rank(c(1,1,2))` → `c(1.5,1.5,3)`/`c(1,1,3)`/`c(2,2,3)`/`c(1,2,3)`);
+  the result is always numeric. **`duplicated(x, fromLast=TRUE)`** runs the dup scan
+  right-to-left, so the **last** occurrence is the keeper and the earlier repeats are
+  `TRUE` (`duplicated(c(1,2,1), fromLast=TRUE)` is `c(TRUE,FALSE,FALSE)`).
+  **`anyDuplicated(x)`** returns the 1-based index of the first duplicated element, or
+  `0` if none (`anyDuplicated(c(1,2,1))` is `3`). The keyword args reuse the existing
+  readers (`truthy()` for `fromLast=`, `as_character()` for `ties.method=`). Deferred
+  to **R-31**: `incomparables=` on the set ops / `duplicated` / `anyDuplicated` (needs
+  `NA`-comparison plumbing), the `fromLast=` set-op argument, and `rank`'s `"random"`
+  method (needs an RNG-seed contract).
 - **Apply family:** `sapply(x, f)` / `lapply(x, f)` map a function over elements
   (`sapply` simplifies length-1 atomic results to a vector).
 


### PR DESCRIPTION
## R-30 — ordering refinements

Fills in the *ties, direction, and multi-key* corners deferred from R-29. All
changes are **extensions of the existing R-29/R-13 handlers** in the shared
`s-runtime` (no new value type, no grammar change); R inherits them through the
tree-walker. They reuse the existing machinery — `as_character` keys,
`value::index`, `truthy()` (the `na.rm =` boolean reader), and `as_character()`
string-keyword reads (the `factor(levels=, labels=)` pattern).

### Added
- **Multi-key `order(x, y, ...)`** — sort the index permutation lexicographically
  by the first key, breaking ties by the next, …; indices still tied after every
  key keep their **original order** (a stable sort). Each key is coerced
  independently (numeric: `NA` last, mirroring `na.last = TRUE`; character:
  lexicographic), so keys may be **mixed** across positions. All keys must share
  the first key's length — a mismatch is a graceful error, never an out-of-bounds
  index. The R-13 single-key form is the arity-1 special case, unchanged.
  `order(c(2,1,2), c(1,2,1))` → `c(2, 1, 3)`.
- **`rank(x, ties.method = ...)`** — adds `"min"` (lowest position in the tie
  run), `"max"` (highest), and `"first"` (consecutive ranks in original order)
  alongside the default `"average"`. Result stays numeric; an unknown method is a
  graceful error. `rank(c(1,1,2))` → `c(1.5,1.5,3)` / `c(1,1,3)` / `c(2,2,3)` /
  `c(1,2,3)` for average / min / max / first.
- **`duplicated(x, fromLast = TRUE)`** — right-to-left scan keeps the **last**
  occurrence (`FALSE`); earlier repeats are flagged. Default unchanged.
  `duplicated(c(1,2,1), fromLast = TRUE)` → `c(TRUE, FALSE, FALSE)`.
- **`anyDuplicated(x)`** — the 1-based index of the first duplicated element, or
  `0` if none (agrees with `which(duplicated(x))[1]`). `anyDuplicated(c(1,2,1))`
  → `3`; `anyDuplicated(c(1,2,3))` → `0`. Numeric and character vectors.

### Security
No new user-controlled multiplier. Outputs are bounded by the
already-`MAX_SEQ_LEN`-capped input lengths; the per-key length check guards
`order` against out-of-bounds indexing (it runs before any comparator access);
`NA` stays an ordinary matchable key; empty inputs yield empty/`0`. A Rust
security sub-agent reviewed the diff and found **no CRITICAL/HIGH issues**.

### Deferred to R-31
- `incomparables =` on the set ops / `duplicated` / `anyDuplicated` — needs
  `NA`-comparison plumbing (a way to mark values "never equal to anything"), which
  the `as_character`-key path does not model.
- The `fromLast =` argument on the set ops, and `rank`'s `"random"` tie method
  (needs an RNG-seed contract).

### Tests
- `s-runtime`: new `r30_ordering` module (17 tests) — **233 passing**.
- `r-runtime`: 5 new R-syntax tests — **233 passing**.
- Single command: `cargo test -p coding-adventures-s-runtime -p coding-adventures-r-runtime`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)