### PR TITLE
feat(lang-full): E5 PR-4a — LLVM static arrays (length-prefixed @calloc + explicit bounds-trap)

### DIFF
--- a/code/packages/rust/iir-to-llvm/CHANGELOG.md
+++ b/code/packages/rust/iir-to-llvm/CHANGELOG.md
@@ -3,6 +3,45 @@
 All notable changes to this crate are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.14.0] — 2026-06-21 — arrays via length-prefixed `@calloc` + explicit bounds-trap (LANG-FULL E5 PR-4a)
+
+The four E5 array opcodes now lower to the **static** array representation — a
+flat `@calloc` block with the length in a header and an **explicit** out-of-bounds
+trap (the native/LLVM target has no managed runtime to bounds-check for it, unlike
+the JVM/CLR backends). Layout, with the IIR *handle* pointing at the payload:
+
+```
+base ──► [ i64 length | element 0 | element 1 | … ]   (zero-filled by calloc)
+         └─ 8 bytes ──┘ ▲ handle = base + 8
+```
+
+| IIR op | LLVM IR |
+|--------|---------|
+| `alloc_array dest <- count` (`array<T>`) | `mul`+`add` size; `call ptr @calloc`; `store i64 count`; `getelementptr i8 … 8` |
+| `array_get dest <- handle, idx` | load len at `handle−8`; `icmp uge`; `br` to trap; `getelementptr <T>`; `load <T>` |
+| `array_set handle, idx, val` | same bounds check; `getelementptr <T>`; `store <T>` |
+| `array_len dest <- handle` | `getelementptr i8 … -8`; `load i64` |
+
+- **Explicit bounds check**: one **unsigned** compare (`icmp uge i64 idx, len`)
+  catches both a `>= len` index and a negative one (a negative `i64` is a huge
+  unsigned value); out-of-range branches to a block that does `call void
+  @llvm.trap(); unreachable` — the static-backend realisation of E5's "OOB → trap".
+- Element type (`i64`/`double`/`i32`/`float`) comes from `T`; the handle is an
+  opaque `ptr`, and the typed `getelementptr <T>` does the index scaling. The
+  index is always `i64` (LLVM keeps the uniform word model — no `i64`→`i32`).
+- New `declare ptr @calloc` / `declare void @llvm.trap()` emitted only when a
+  module uses an array op. The validator now accepts an `array<T>` `type_hint` by
+  checking its **element** type (the `alloc_array` handle is a `ptr`, not a scalar).
+- 3 new unit tests (calloc+trap+GEP shape, `double` element ops, `array<T>`
+  validates). Verified end to end: a straight-line ALGOL array program assembles
+  with `clang` and runs → exit 42.
+
+Scope note: the ALGOL *for-loop* array program (`lang_matrix.rs`, exit 55) runs on
+VM/JIT/JVM/CLR but **not yet LLVM** — an ALGOL `for` loop hits a *separate*,
+pre-existing LLVM-only lowering bug (an `i1`-typed loop-guard `icmp` over `i64`
+operands, double-emitted) unrelated to E5; the LLVM array proof uses a
+straight-line cell, and the for-loop bug is tracked as a follow-up.
+
 ## [0.13.0] — 2026-06-20 — `f64` variable slots (LANG-FULL enabler E3, code-gen backend 1)
 
 ### Fixed — `real` (f64) variables produced invalid IR

--- a/code/packages/rust/iir-to-llvm/Cargo.toml
+++ b/code/packages/rust/iir-to-llvm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iir-to-llvm"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 description = "IIR → textual LLVM IR backend — emits .ll source for an LLVM target triple.  v0.12.0 (LANG-FULL — bitwise `not`): LLVM has no `not` instruction, so the IIR `not` op now lowers to `xor x, -1`; a narrow unsigned width (u4/u8/u16/u32) reuses the E2 compute-wide+mask path so `~0u8 = 255`.  This was the one backend of seven lacking `not`; it unblocks Nib N3-`~` / Oct O2-`~`.  v0.11.0 (LANG-FULL E2 — register width & wrap): a narrow unsigned op (u4/u8/u16/u32) computes at i64 then masks with `and i64 <tmp>, <mask>` (0xF/0xFF/0xFFFF/0xFFFFFFFF), so `200u8+100u8=44`.  Every IIR value rides an i64 slot here, so typing the op at its narrow LLVM width (`add i8 %a, %b` over i64 operands) was invalid IR clang rejects; the value-mask matches the VM/JIT/wasm/JVM/CLR backends.  Adds `u4` to the supported type set.  v0.9.0 (LLVM05, LANG-MATRIX LM-L Brainfuck): adds the byte-tape ops `alloc_bytes`→`@calloc`, `load_byte`/`store_byte` (zero-extend/truncate at the byte boundary), and the `putchar`/`getchar` libc builtins, plus a slot-dest SSA rename so a stack-slot variable assigned 2+ times by a real op no longer emits a duplicate `%name`.  v0.4.0 (LLVM04): adds `call` of user-defined functions (per-arg types resolved via pre-built callee-signature map) and `call_builtin print_i64` → `declare/call @__print_i64(i64)`, completing the LLVM backend's user-callable surface."
 

--- a/code/packages/rust/iir-to-llvm/README.md
+++ b/code/packages/rust/iir-to-llvm/README.md
@@ -92,7 +92,30 @@ you actually intend to run `llc` for a non-default architecture.
 | v0.11.0 | **Narrow unsigned arithmetic wraps mod-2ⁿ** (LANG-FULL E2). A `u4`/`u8`/`u16`/`u32` op computes at i64 then `and i64 …, <mask>` (see below). Adds `u4` to the supported types. |
 | v0.12.0 | **Bitwise `not`** — synthesised as `xor x, -1` (LLVM has no `not`); a narrow width masks the result (`~0u8 = 255`). Unblocks Nib N3-`~` / Oct O2-`~`. |
 | v0.13.0 | **`f64` variable slots** (LANG-FULL E3). An `f64` local gets an `alloca double` slot (`store/load double`); a float `cmp_*` result `zext i1 → i64` (not the invalid `→ double`); `f64` literals render as LLVM's exact hex double `0x…`. **ALGOL 60 reals run on LLVM.** |
+| v0.14.0 | **Bounds-checked arrays** (LANG-FULL E5, static model). `alloc_array`→length-prefixed `@calloc` `[i64 len][elems…]`; `array_get`/`array_set` emit an explicit `icmp uge idx, len` + `br` to a `call void @llvm.trap()` block (OOB → trap), then a typed `getelementptr`+`load`/`store`; `array_len` reads the header. Declares `@calloc`/`@llvm.trap` on demand. |
 | (later) | GC, debug info via `!dbg`. |
+
+### Bounds-checked arrays (v0.14.0)
+
+An IIR array (LANG-FULL E5) is a single `@calloc` block laid out as a length
+header followed by the elements; the **handle** is a `ptr` to the payload
+(`base + 8`), so element access is a typed `getelementptr <T>` and the length
+lives at `handle − 8`:
+
+```
+base ──► [ i64 length | element 0 | element 1 | … ]   (zero-filled)
+         └─ 8 bytes ──┘ ▲ handle
+```
+
+Unlike the JVM/CLR managed-array backends (whose runtime bounds-checks every
+element access for free), the native/LLVM target has no such runtime, so each
+`array_get`/`array_set` emits an **explicit** unsigned compare against the stored
+length (`icmp uge i64 idx, len` — a single check that catches both `>= len` and a
+negative index, since a negative `i64` is a huge unsigned value) and branches to a
+`call void @llvm.trap(); unreachable` block when out of range. This is the
+static-backend realisation of E5's "out-of-bounds → trap" rule. The element type
+(`i64`/`double`/`i32`/`float`) comes from the op's `type_hint`; the index is always
+`i64`.
 
 ### Byte-tape memory (v0.9.0)
 

--- a/code/packages/rust/iir-to-llvm/src/lib.rs
+++ b/code/packages/rust/iir-to-llvm/src/lib.rs
@@ -80,6 +80,7 @@
 //! assert!(ll.contains("ret i64 42"));
 //! ```
 
+use interpreter_ir::opcodes::array_elem_type;
 use interpreter_ir::{IIRFunction, IIRInstr, IIRModule, Operand};
 use std::collections::HashMap;
 use std::fmt;
@@ -250,6 +251,12 @@ const SUPPORTED_OPS: &[&str] = &[
     // x86_64 / native AOT backend already supports (LANG76); we add the LLVM
     // lowering so Brainfuck — which builds an implicit byte tape — compiles.
     "alloc_bytes", "load_byte", "store_byte",
+    // LANG-FULL E5 — bounds-checked arrays (the *static* representation:
+    // length-prefixed flat `calloc` block + an explicit compare/trap, vs the
+    // JVM/CLR managed-array native check). `alloc_array` allocates `[i64 len]
+    // [elems…]`; `array_get`/`array_set` bounds-check the index then GEP+load/
+    // store; `array_len` reads the header.
+    "alloc_array", "array_get", "array_set", "array_len",
 ];
 
 /// Builtins the LLVM backend knows how to lower.
@@ -354,8 +361,14 @@ pub fn validate_for_llvm(module: &IIRModule) -> Vec<String> {
                 ));
             }
             // `ret_void` carries type_hint "void"; everything else carries a
-            // real type.  Both go through `llvm_type_for`.
-            if llvm_type_for(&instr.type_hint, &func.name).is_err() {
+            // real type.  Both go through `llvm_type_for`. An `alloc_array`
+            // carries an `array<T>` hint (LANG-FULL E5) — not a scalar LLVM type,
+            // so validate its *element* `T` instead (the handle itself is a `ptr`).
+            let type_ok = match array_elem_type(&instr.type_hint) {
+                Some(elem) => llvm_type_for(&elem, &func.name).is_ok(),
+                None => llvm_type_for(&instr.type_hint, &func.name).is_ok(),
+            };
+            if !type_ok {
                 errors.push(format!(
                     "UnsupportedType: function {:?}, instr {:?} type_hint {:?} not supported",
                     func.name, instr.op, instr.type_hint
@@ -433,6 +446,9 @@ pub fn lower_iir_to_llvm(
     let mut used_putchar = false;
     let mut used_getchar = false;
     let mut used_alloc_bytes = false;
+    // LANG-FULL E5: any array op needs `@calloc` (the allocation) and `@llvm.trap`
+    // (the out-of-bounds trap). `is_array_op` covers alloc_array/array_*.
+    let mut used_arrays = false;
     // McCarthy W12b: collect the tagged-word lisp builtins actually used, in
     // first-seen order, so each gets exactly one `declare i64 @__twig_lispy_*`.
     let mut used_lispy: Vec<&'static (&'static str, &'static str, usize)> = Vec::new();
@@ -440,6 +456,9 @@ pub fn lower_iir_to_llvm(
         for i in &f.instructions {
             if i.op == "alloc_bytes" {
                 used_alloc_bytes = true;
+            }
+            if interpreter_ir::opcodes::is_array_op(&i.op) {
+                used_arrays = true;
             }
             if i.op == "call_builtin" {
                 if let Some(Operand::Var(name)) = i.srcs.first() {
@@ -466,10 +485,15 @@ pub fn lower_iir_to_llvm(
     // LLVM05 — libc / allocator declarations for the Brainfuck tape & I/O.
     // `calloc(nmemb, size)` returns a zero-filled buffer (BF cells start at 0);
     // `putchar`/`getchar` are the libc character I/O the BF `.`/`,` map to.
-    if used_alloc_bytes || used_putchar || used_getchar {
+    if used_alloc_bytes || used_arrays || used_putchar || used_getchar {
         out.push('\n');
-        if used_alloc_bytes {
+        if used_alloc_bytes || used_arrays {
             out.push_str("declare ptr @calloc(i64, i64)\n");
+        }
+        if used_arrays {
+            // The out-of-bounds trap target (LANG-FULL E5). `llvm.trap` is an
+            // intrinsic — declaring it is harmless and keeps the module explicit.
+            out.push_str("declare void @llvm.trap()\n");
         }
         if used_putchar {
             out.push_str("declare i32 @putchar(i32)\n");
@@ -983,6 +1007,10 @@ fn lower_instr(
         "alloc_bytes" => lower_alloc_bytes(instr, state, out),
         "load_byte" => lower_load_byte(instr, state, out),
         "store_byte" => lower_store_byte(instr, state, out),
+        "alloc_array" => lower_alloc_array(instr, state, out),
+        "array_get" => lower_array_get(instr, state, out),
+        "array_set" => lower_array_set(instr, state, out),
+        "array_len" => lower_array_len(instr, state, out),
 
         other => Err(IIRLlvmError::UnsupportedOp {
             function: fn_name.into(),
@@ -1083,6 +1111,171 @@ fn lower_store_byte(
     out.push_str(&format!("  {p} = getelementptr i8, ptr {base}, i64 {idx}\n"));
     out.push_str(&format!("  {t} = trunc i64 {val} to i8\n"));
     out.push_str(&format!("  store i8 {t}, ptr {p}\n"));
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// LANG-FULL E5 — bounds-checked arrays (static / length-prefixed model)
+// ---------------------------------------------------------------------------
+//
+// An array is a single `calloc` block laid out as a **length header followed by
+// the elements**:
+//
+//   base ──► [ i64 length | element 0 | element 1 | … ]   (zero-filled)
+//            └─ 8 bytes ──┘
+//
+// The IIR *handle* is a pointer to the **payload** (`base + 8`), so element
+// access is a plain typed GEP (`getelementptr <T>, ptr handle, i64 idx`) and the
+// length lives at `handle − 8`. Unlike the JVM/CLR managed arrays (whose runtime
+// bounds-checks `*aload`/`ldelem` for free), the native/LLVM target has no such
+// check, so every `array_get`/`array_set` emits an **explicit** compare against
+// the stored length and branches to a trap (`llvm.trap`) on an out-of-range
+// index — the static-backend realisation of E5's "OOB → trap" rule. A single
+// **unsigned** compare (`icmp uge`) catches both a `>= len` index and a negative
+// one (a negative `i64` is a huge unsigned value).
+
+/// The LLVM element type + its byte size for an array element type hint.
+fn array_elem_llvm(elem: &str, fn_name: &str) -> Result<(&'static str, u32), IIRLlvmError> {
+    let ty = llvm_type_for(elem, fn_name)?;
+    let size = match ty {
+        "i1" | "i8" => 1,
+        "i16" => 2,
+        "i32" | "float" => 4,
+        "i64" | "double" => 8,
+        other => {
+            return Err(IIRLlvmError::UnsupportedType {
+                function: fn_name.into(),
+                type_hint: format!("array element {other}"),
+            })
+        }
+    };
+    Ok((ty, size))
+}
+
+/// Lower `alloc_array dest <- count : array<T>`.
+///
+/// ```llvm
+/// %sz    = mul i64 <count>, <elemsize>
+/// %total = add i64 %sz, 8
+/// %base  = call ptr @calloc(i64 %total, i64 1)
+/// store i64 <count>, ptr %base                 ; length header
+/// %dest  = getelementptr i8, ptr %base, i64 8  ; handle = payload
+/// ```
+///
+/// **Trust boundary (size overflow).** `count` is a *compiler-produced* operand
+/// (a constant or a bounded length expression from a frontend), not an
+/// end-user-controlled value, so the size `mul`/`add` is left as plain wrapping
+/// i64 arithmetic. A hostile *hand-built* IIR could pass `count ≈ 2⁶¹` so
+/// `count*elemsize + 8` wraps to a small `calloc` while the stored `len` stays
+/// huge — letting later in-bounds-looking indices overrun the undersized block at
+/// runtime. This is the same trust contract the existing `alloc_bytes` lowering
+/// already relies on (its `size` is likewise unchecked), and the array path is
+/// strictly *safer*: it adds the per-access bounds check `alloc_bytes` lacks. A
+/// future hardening could gate the size on `@llvm.umul.with.overflow.i64` and
+/// branch to the same trap; unneeded for the trusted-frontend threat model.
+fn lower_alloc_array(
+    instr: &IIRInstr,
+    state: &mut FnState,
+    out: &mut String,
+) -> Result<(), IIRLlvmError> {
+    let dest = require_dest(instr, "alloc_array", state.fn_name)?.to_string();
+    let elem = array_elem_type(&instr.type_hint).ok_or_else(|| IIRLlvmError::InvalidOperand {
+        function: state.fn_name.into(),
+        detail: format!("alloc_array type_hint must be array<T>, got {:?}", instr.type_hint),
+    })?;
+    let (_, elem_size) = array_elem_llvm(&elem, state.fn_name)?;
+    let count = resolve_operand(instr.srcs.first(), &state.env, "i64", state.fn_name)?;
+    let sz = state.fresh("asz");
+    let total = state.fresh("atot");
+    let base = state.fresh("abase");
+    out.push_str(&format!("  {sz} = mul i64 {count}, {elem_size}\n"));
+    out.push_str(&format!("  {total} = add i64 {sz}, 8\n"));
+    out.push_str(&format!("  {base} = call ptr @calloc(i64 {total}, i64 1)\n"));
+    out.push_str(&format!("  store i64 {count}, ptr {base}\n"));
+    out.push_str(&format!("  %{dest} = getelementptr i8, ptr {base}, i64 8\n"));
+    state.env.insert(dest.clone(), format!("%{dest}"));
+    Ok(())
+}
+
+/// Emit the bounds check shared by `array_get`/`array_set`: load the length from
+/// the header at `handle − 8`, compare the index unsigned, and branch to a trap
+/// block on out-of-range. Leaves the cursor in a fresh "ok" block (still open).
+fn emit_bounds_check(
+    handle: &str,
+    idx: &str,
+    state: &mut FnState,
+    out: &mut String,
+) {
+    let hdr = state.fresh("ahdr");
+    let len = state.fresh("alen");
+    let oob = state.fresh("aoob");
+    state.counter += 1;
+    let trap = format!("__atrap{}", state.counter);
+    state.counter += 1;
+    let ok = format!("__aok{}", state.counter);
+    out.push_str(&format!("  {hdr} = getelementptr i8, ptr {handle}, i64 -8\n"));
+    out.push_str(&format!("  {len} = load i64, ptr {hdr}\n"));
+    out.push_str(&format!("  {oob} = icmp uge i64 {idx}, {len}\n"));
+    out.push_str(&format!("  br i1 {oob}, label %{trap}, label %{ok}\n"));
+    out.push_str(&format!("{trap}:\n"));
+    out.push_str("  call void @llvm.trap()\n");
+    out.push_str("  unreachable\n");
+    out.push_str(&format!("{ok}:\n"));
+}
+
+/// Lower `array_get dest <- handle, idx : T` — bounds-checked element load.
+fn lower_array_get(
+    instr: &IIRInstr,
+    state: &mut FnState,
+    out: &mut String,
+) -> Result<(), IIRLlvmError> {
+    let dest = require_dest(instr, "array_get", state.fn_name)?.to_string();
+    let (elem_ty, _) = array_elem_llvm(&instr.type_hint, state.fn_name)?;
+    let handle = resolve_operand(instr.srcs.first(), &state.env, "i64", state.fn_name)?;
+    let idx = resolve_operand(instr.srcs.get(1), &state.env, "i64", state.fn_name)?;
+    emit_bounds_check(&handle, &idx, state, out);
+    let ep = state.fresh("aep");
+    out.push_str(&format!("  {ep} = getelementptr {elem_ty}, ptr {handle}, i64 {idx}\n"));
+    out.push_str(&format!("  %{dest} = load {elem_ty}, ptr {ep}\n"));
+    state.env.insert(dest.clone(), format!("%{dest}"));
+    Ok(())
+}
+
+/// Lower `array_set handle, idx, val : T` (no dest) — bounds-checked element store.
+fn lower_array_set(
+    instr: &IIRInstr,
+    state: &mut FnState,
+    out: &mut String,
+) -> Result<(), IIRLlvmError> {
+    if instr.dest.is_some() {
+        return Err(IIRLlvmError::InvalidOperand {
+            function: state.fn_name.into(),
+            detail: "array_set must not have a dest".into(),
+        });
+    }
+    let (elem_ty, _) = array_elem_llvm(&instr.type_hint, state.fn_name)?;
+    let handle = resolve_operand(instr.srcs.first(), &state.env, "i64", state.fn_name)?;
+    let idx = resolve_operand(instr.srcs.get(1), &state.env, "i64", state.fn_name)?;
+    let val = resolve_operand(instr.srcs.get(2), &state.env, elem_ty, state.fn_name)?;
+    emit_bounds_check(&handle, &idx, state, out);
+    let ep = state.fresh("aep");
+    out.push_str(&format!("  {ep} = getelementptr {elem_ty}, ptr {handle}, i64 {idx}\n"));
+    out.push_str(&format!("  store {elem_ty} {val}, ptr {ep}\n"));
+    Ok(())
+}
+
+/// Lower `array_len dest <- handle` — read the `i64` length header at `handle − 8`.
+fn lower_array_len(
+    instr: &IIRInstr,
+    state: &mut FnState,
+    out: &mut String,
+) -> Result<(), IIRLlvmError> {
+    let dest = require_dest(instr, "array_len", state.fn_name)?.to_string();
+    let handle = resolve_operand(instr.srcs.first(), &state.env, "i64", state.fn_name)?;
+    let hdr = state.fresh("ahdr");
+    out.push_str(&format!("  {hdr} = getelementptr i8, ptr {handle}, i64 -8\n"));
+    out.push_str(&format!("  %{dest} = load i64, ptr {hdr}\n"));
+    state.env.insert(dest.clone(), format!("%{dest}"));
     Ok(())
 }
 

--- a/code/packages/rust/iir-to-llvm/tests/test_backend.rs
+++ b/code/packages/rust/iir-to-llvm/tests/test_backend.rs
@@ -1465,3 +1465,86 @@ fn integer_local_still_gets_i64_slot() {
     assert!(!ll.contains("alloca double"),
         "no double slot should appear for an integer program; got:\n{ll}");
 }
+
+// ===========================================================================
+// LANG-FULL E5 — bounds-checked arrays (static length-prefixed model)
+// ===========================================================================
+
+/// `alloc_array`/`array_set`/`array_get`/`array_len` lower to a length-prefixed
+/// `@calloc` block with an explicit `icmp uge`/`llvm.trap` bounds check and a
+/// typed `getelementptr`+`load`/`store`.
+#[test]
+fn array_ops_emit_calloc_trap_and_gep() {
+    let f = IIRFunction::new(
+        "main",
+        vec![],
+        "i64",
+        vec![
+            IIRInstr::new("const", Some("n".into()), vec![Operand::Int(3)], "i64"),
+            IIRInstr::new("alloc_array", Some("a".into()), vec![Operand::Var("n".into())], "array<i64>"),
+            IIRInstr::new("const", Some("i0".into()), vec![Operand::Int(0)], "i64"),
+            IIRInstr::new("const", Some("v".into()), vec![Operand::Int(42)], "i64"),
+            IIRInstr::new("array_set", None,
+                vec![Operand::Var("a".into()), Operand::Var("i0".into()), Operand::Var("v".into())], "i64"),
+            IIRInstr::new("array_get", Some("r".into()),
+                vec![Operand::Var("a".into()), Operand::Var("i0".into())], "i64"),
+            IIRInstr::new("array_len", Some("m".into()), vec![Operand::Var("a".into())], "i64"),
+            IIRInstr::new("ret", None, vec![Operand::Var("r".into())], "i64"),
+        ],
+    );
+    let ll = lower(&module_with(f));
+    // Allocation: length-prefixed calloc block.
+    assert!(ll.contains("declare ptr @calloc(i64, i64)"), "calloc declared; got:\n{ll}");
+    assert!(ll.contains("call ptr @calloc(i64"), "alloc_array uses calloc");
+    // Trap infra + explicit unsigned bounds check (catches negative + >= len).
+    assert!(ll.contains("declare void @llvm.trap()"), "llvm.trap declared");
+    assert!(ll.contains("icmp uge i64"), "explicit bounds compare");
+    assert!(ll.contains("call void @llvm.trap()") && ll.contains("unreachable"),
+        "OOB branches to a trap block");
+    // Typed element access + length header read.
+    assert!(ll.contains("getelementptr i64, ptr"), "typed element GEP");
+    assert!(ll.contains("store i64"), "array_set stores the element");
+}
+
+/// An `f64` array uses `double` element GEPs / loads / stores.
+#[test]
+fn f64_array_uses_double_element() {
+    let f = IIRFunction::new(
+        "main",
+        vec![],
+        "f64",
+        vec![
+            IIRInstr::new("const", Some("n".into()), vec![Operand::Int(2)], "i64"),
+            IIRInstr::new("alloc_array", Some("a".into()), vec![Operand::Var("n".into())], "array<f64>"),
+            IIRInstr::new("const", Some("i0".into()), vec![Operand::Int(0)], "i64"),
+            IIRInstr::new("const", Some("v".into()), vec![Operand::Float(2.5)], "f64"),
+            IIRInstr::new("array_set", None,
+                vec![Operand::Var("a".into()), Operand::Var("i0".into()), Operand::Var("v".into())], "f64"),
+            IIRInstr::new("array_get", Some("r".into()),
+                vec![Operand::Var("a".into()), Operand::Var("i0".into())], "f64"),
+            IIRInstr::new("ret", None, vec![Operand::Var("r".into())], "f64"),
+        ],
+    );
+    let ll = lower(&module_with(f));
+    assert!(ll.contains("getelementptr double, ptr"), "double element GEP; got:\n{ll}");
+    assert!(ll.contains("store double"), "array_set stores a double");
+    assert!(ll.contains("load double"), "array_get loads a double");
+}
+
+/// `array<T>` validates (its element type is checked, not the wrapper).
+#[test]
+fn array_type_hint_validates() {
+    let f = IIRFunction::new(
+        "main",
+        vec![],
+        "i64",
+        vec![
+            IIRInstr::new("const", Some("n".into()), vec![Operand::Int(1)], "i64"),
+            IIRInstr::new("alloc_array", Some("a".into()), vec![Operand::Var("n".into())], "array<i64>"),
+            IIRInstr::new("array_len", Some("m".into()), vec![Operand::Var("a".into())], "i64"),
+            IIRInstr::new("ret", None, vec![Operand::Var("m".into())], "i64"),
+        ],
+    );
+    assert!(validate_for_llvm(&module_with(f)).is_empty(),
+        "array<T> ops must validate clean");
+}

--- a/code/packages/rust/lang-aot/tests/lang_matrix.rs
+++ b/code/packages/rust/lang-aot/tests/lang_matrix.rs
@@ -569,8 +569,12 @@ const PROGRAMS: &[Prog] = &[
     // `alloc_array`→`newarr System.Int32`, `array_set`→`stelem.i4`, `array_get`→
     // `ldelem.i4`, `array_len`→`ldlen`+`conv.i4`, with CoreCLR's native bounds check
     // (OOB → `System.IndexOutOfRangeException`). Both managed runtimes give E5's trap
-    // for free. The handle is a reference local. The static code-gen backends
-    // (LLVM/WASM/native) join in E5 PR-4, at which point `backends` grows to all 7.
+    // for free. The handle is a reference local. (This `for`-loop cell stays on the
+    // managed backends; the **LLVM** array proof is the straight-line cell below —
+    // an ALGOL `for` loop hits a *separate*, pre-existing LLVM-only lowering bug in
+    // `iir-to-llvm` — an `i1`-typed loop-guard `icmp` over `i64` operands, emitted
+    // twice — that is unrelated to E5 and tracked as a follow-up.) The native
+    // x86_64/aarch64 static backends join in E5 PR-4b/4c.
     Prog {
         lang: Language::Algol60,
         ext: "alg",
@@ -580,6 +584,24 @@ const PROGRAMS: &[Prog] = &[
                for i := 1 step 1 until 5 do result := result + A[i] end",
         expect: Expect::Exit(55),
         backends: &[Vm, Jit, Jvm, Clr],
+    },
+    // ALGOL 60 — *straight-line* 1-D integer array (LANG-FULL E5, the **LLVM**
+    // static-array proof — PR-4a). `A[1] := 40; A[3] := 2; result := A[1] + A[3]`
+    // ⇒ 42, exercising `alloc_array`/`array_set`/`array_get` with no loop. On
+    // **LLVM** (`iir-to-llvm`) this is the *static* array model: a length-prefixed
+    // `@calloc` block `[i64 len][elems…]` with the handle pointing at the payload;
+    // each `array_set`/`array_get` emits an **explicit** `icmp uge idx, len` and a
+    // `br` to a `call void @llvm.trap()` block on out-of-range (the native target
+    // has no managed runtime to bounds-check for it), then a typed `getelementptr`
+    // + `load`/`store`. `clang` compiles the `.ll` and runs it → exit 42. Runs on
+    // every already-supported array backend too (VM/JIT/JVM/CLR), all straight-line.
+    Prog {
+        lang: Language::Algol60,
+        ext: "alg",
+        src: "begin integer array A[1:3]; integer result; \
+               A[1] := 40; A[3] := 2; result := A[1] + A[3] end",
+        expect: Expect::Exit(42),
+        backends: &[Vm, Jit, Jvm, Clr, Llvm],
     },
     // Brainfuck — build 65 on the tape and `putchar` it: prints `A`.
     // `lower_brainfuck_for_aot` widens the BF cell/ptr registers to `i64` (byte width

--- a/code/specs/LANG-FULL-IMPLEMENTATION.md
+++ b/code/specs/LANG-FULL-IMPLEMENTATION.md
@@ -205,8 +205,8 @@ multiple languages; close an enabler before the features that depend on it.
 - **E4 — Strings.** ⚠ An IIR string value model + core ops (length, concat, index,
   compare, print) with backend support (heap/host). Unlocks BASIC strings, Twig strings,
   ALGOL strings/I-O. **Architectural fork — needs a design pass before implementation.**
-- **E5 — Arrays / linear aggregates.** ◑ *IR + VM + ALGOL frontend + JVM + CLR done (PR-1, PR-2,
-  PR-3a, PR-3b); static backends (PR-4) pending.* An IIR
+- **E5 — Arrays / linear aggregates.** ◑ *IR + VM + ALGOL frontend + JVM + CLR + LLVM done
+  (PR-1..3b, PR-4a); WASM + native static backends (PR-4b/4c) pending.* An IIR
   array model (`alloc_array`/`array_len`/`array_get`/`array_set`, `array<T>` type hint,
   bounds-checked) that is **representation-agnostic** so it lowers to BOTH static-allocation
   (length-prefixed flat memory + explicit guard/trap on the native + LLVM backends, reusing the
@@ -371,8 +371,10 @@ backend immediately) come before the enabler-dependent items.
   `alloc_array` (run-time span); `A[i]` reads/writes → bounds-checked `array_get`/`array_set`
   with the 0-based index `i - lower`. Runs a sum-of-squares `Prog` on **VM + JIT + JVM + CLR**
   (`lang_matrix.rs`, exit 55; JVM native `int[]` — PR-3a, CLR native `int32[]` on real `dotnet`
-  — PR-3b) + 9 unit tests. The static code-gen backends (LLVM/WASM/native) lower in E5 PR-4;
-  multidim + array params are follow-up.
+  — PR-3b) + 9 unit tests; a **straight-line** array `Prog` adds **LLVM** (static `@calloc` +
+  `llvm.trap` bounds-check, exit 42 via `clang` — PR-4a). WASM + native static backends lower in
+  E5 PR-4b/4c; the for-loop array Prog joins LLVM after a separate ALGOL-for-loop→LLVM fix.
+  Multidim + array params are follow-up.
 - ✅ **AL3** — typed procedures with value parameters. `integer procedure sq(x);
   value x; integer x; sq := x*x; result := sq(7)` ⇒ exit 49, **verified by running**
   across native/LLVM/WASM/JVM/CLR/VM/JIT (`lang-aot` `lang_matrix.rs`). Lowered to a

--- a/code/specs/lang-full-e5-arrays.md
+++ b/code/specs/lang-full-e5-arrays.md
@@ -186,9 +186,15 @@ merge before the next:
      tests. The binary `clr-simulator` emitter path is a follow-up.
    - *(WASM regrouped: its linear-memory length-prefixed model belongs with the
      static backends in PR-4, not the managed native-array group.)*
-4. **E5-static-backends** — LLVM, WASM (linear memory), then native x86_64 +
-   aarch64 (length-prefixed flat allocation + explicit guard + trap); extend the
-   matrix Prog to all 7. Native encodings byte-verified vs the system assembler.
+4. **E5-static-backends** — length-prefixed flat allocation + explicit guard +
+   trap. Split per backend:
+   - **4a — LLVM** ✅ **done** (`iir-to-llvm` 0.14.0): `alloc_array`→`@calloc`
+     `[i64 len][elems…]`, `array_get/set`→`icmp uge`+`br` to `llvm.trap` then typed
+     `getelementptr`+`load`/`store`, `array_len`→load header. A straight-line ALGOL
+     array program runs via `clang` (exit 42). *(The for-loop array Prog awaits a
+     separate ALGOL-for-loop→LLVM fix before joining the LLVM column.)*
+   - **4b — WASM** ☐ (linear memory, same length-prefixed model + `unreachable` trap).
+   - **4c — native x86_64 + aarch64** ☐ (encodings byte-verified vs the assembler).
 5. **E5-bounds-trap-proof** — a matrix program that traps on OOB, asserted to
    abort on every backend.
 6. **(follow-ups, not v1)** real (`array<f64>`) arrays end-to-end; BASIC `DIM`


### PR DESCRIPTION
## E5 PR-4a — arrays on LLVM, the *static* model

First static-backend slice of **enabler E5 (arrays)**, after the managed pair ([JVM #6378](https://github.com/adhithyan15/coding-adventures/pull/6378), [CLR #6386](https://github.com/adhithyan15/coding-adventures/pull/6386)). The four array opcodes lower to the **static representation** — a flat `@calloc` block with the length in a header and an **explicit software bounds check + trap** (the native/LLVM target has no managed runtime to bounds-check for it).

### `iir-to-llvm` 0.13.0 → 0.14.0

Layout — handle points at the payload (`base + 8`), length at `handle − 8`:
```
base ──► [ i64 length | element 0 | element 1 | … ]   (zero-filled by calloc)
         └─ 8 bytes ──┘ ▲ handle
```

| IIR op | LLVM IR |
|--------|---------|
| `alloc_array dest <- count` (`array<T>`) | `mul`/`add` size; `call ptr @calloc`; `store i64 count`; `getelementptr i8 … 8` |
| `array_get dest <- handle, idx` | load len; `icmp uge i64 idx, len`; `br` to trap; `getelementptr <T>`; `load <T>` |
| `array_set handle, idx, val` | same bounds check; `getelementptr <T>`; `store <T>` |
| `array_len dest <- handle` | `getelementptr i8 … -8`; `load i64` |

- **Explicit bounds check**: one **unsigned** compare (`icmp uge`) catches both `>= len` and a negative index (a negative `i64` is a huge unsigned value); OOB branches to `call void @llvm.trap(); unreachable` — the static realisation of E5's "OOB → trap".
- Element type (`i64`/`double`/…) from `T`; the handle is an opaque `ptr` and the typed `getelementptr <T>` does the scaling. Index always `i64`.
- `@calloc`/`@llvm.trap` declared on demand; the validator accepts `array<T>` by checking its **element** type.

### Verification — *runs via `clang`*
- A **straight-line** ALGOL array `Prog` (`A[1]:=40; A[3]:=2; result:=A[1]+A[3]` ⇒ 42) runs on `[Vm, Jit, Jvm, Clr, Llvm]`; the **LLVM cell compiles the `.ll` with `clang` and runs the native binary → exit 42**. Confirmed it genuinely executes (isolated with a wrong expected value, watched it fail, reverted).
- 3 new unit tests (calloc+trap+GEP shape, `double` element ops, `array<T>` validates). Full suite green; clippy-clean.

### Heads-up: a separate latent bug found
The ALGOL **for-loop** array `Prog` (exit 55) stays on the managed backends — an ALGOL `for` loop hits a **pre-existing, LLVM-only** lowering bug (an `i1`-typed loop-guard `icmp` over `i64` operands, double-emitted) **unrelated to E5**, surfaced because no ALGOL for-loop ran on LLVM before. The LLVM array proof uses a straight-line cell; the for-loop bug is filed as a follow-up and the for-loop Prog joins the LLVM column once it's fixed.

### Security
`/security-review` → **APPROVED**, no must-fix. Bounds check sound (both get/set, negative-index, valid header read); no IR-text injection (only allowlisted `&'static` types + numeric literals + counter SSA names reach the IR); no panic on bad input. One **Low/accepted** note: the size `mul`/`add` may wrap under a *hand-built* IIR with `count ≈ 2⁶¹` — but `count` is compiler-produced and this is **strictly safer than the existing unchecked `alloc_bytes` path** (which has no per-access check at all); documented in `lower_alloc_array`.

### Scope
LLVM. **WASM (PR-4b)** + **native x86_64/aarch64 (PR-4c)** follow, at which point the matrix `Prog` reaches all 7 backends.

🤖 Generated with [Claude Code](https://claude.com/claude-code)