### PR TITLE
feat(mycin-cc2c): complete dose-penalty grounding (meropenem/aztreonam/tmp_smx)

### DIFF
--- a/code/specs/data/mycin-2026/CHART-AS-CONSTRAINTS.md
+++ b/code/specs/data/mycin-2026/CHART-AS-CONSTRAINTS.md
@@ -190,6 +190,18 @@ risks Y") — decision support, not a hidden choice.
       regenerates the rulebook from the new row. A `renal_severe` chart now derives BOTH the
       vancomycin and cefepime renal caps from the one substrate (`test_dose_caps.py`, 16 tests).
       `verdict direction_only`; the per-kg magnitude stays the illustrative model.
+    - **DOSE-PENALTY GROUNDING COMPLETE (all renally-cleared drugs). ✅ DONE.** The remaining
+      formulary drugs with a renal ceiling penalty are now grounded the same way — pure data
+      rows + grounding records, no code change: `meropenem` (FDA DailyMed `a456013b`, *"Dosage
+      should be reduced in patients with creatinine clearance of 50 mL/min or less."*),
+      `aztreonam` (AZACTAM DailyMed `9a105eaf`, *"the dosage of AZACTAM should be halved in
+      patients with estimated creatinine clearances between 10 and 30 mL/min/1.73 m2 …"*), and
+      `tmp_smx` (DailyMed `793c75eb`, *"When renal function is impaired, a reduced dosage should
+      be employed, as shown in Table 2."*). So **every** drug carrying a `renal_severe` ceiling
+      penalty (vancomycin, cefepime, meropenem, aztreonam, tmp_smx) now has an engine-queryable,
+      FDA-grounded single-factor cap (`test_renal_severe_caps_every_renally_cleared_drug`, 17
+      tests). All `verdict direction_only`; per-kg magnitudes stay the illustrative model. The
+      dose-penalty authored-debt in the dose-window layer is fully retired.
 - **REFACTOR (ADJ-first): every exclusion is now an EXPLICIT engine constraint.** Dose-infeasible
   (CC-2), contraindicated (CC-3), and step-therapy (CC-6) drugs are unified into one
   `forced_zero: {drug → reason}` and emitted as `constrain x_d <= 0   % excluded (reason)` in the

--- a/code/specs/data/mycin-2026/grounding/dose-window-grounding.json
+++ b/code/specs/data/mycin-2026/grounding/dose-window-grounding.json
@@ -363,6 +363,91 @@
         "final_verdict": "direction_only"
       },
       "spider_status": "direction_only"
+    },
+    {
+      "id": "dose_penalty_meropenem_renal",
+      "kind": "dose_penalty",
+      "drug": "meropenem",
+      "claim": "Renal impairment lowers meropenem's safe dose: the dose must be reduced at CrCl <= 50 mL/min (meropenem is substantially renally excreted, so it accumulates) — i.e. the safe ceiling shrinks as renal function falls (the renal_severe ceiling penalty).",
+      "grounded": {
+        "id": "dose_penalty_meropenem_renal",
+        "resolved_url": "https://dailymed.nlm.nih.gov/dailymed/fda/fdaDrugXsl.cfm?setid=a456013b-b20e-4b29-b2f9-06f18f1ea6bd",
+        "source_title": "MEROPENEM for injection — FDA prescribing information (DailyMed / NLM), DOSAGE AND ADMINISTRATION",
+        "byte_quote": "Dosage should be reduced in patients with creatinine clearance of 50 mL/min or less.",
+        "value_found": "Meropenem dose must be reduced at CrCl <= 50 mL/min — the safe ceiling shrinks with renal impairment. DIRECTION only; the per-kg penalty magnitude stays the illustrative feasibility model (the label's adjustment is a CrCl-banded table, not a single per-kg figure).",
+        "direction_correct": true,
+        "verdict": "direction_only",
+        "discards": [
+          "The CrCl-banded dose-reduction table — a multi-row schedule, not a single per-kg ceiling reduction; the formulary's renal_severe per-kg penalty approximates 'shrink the ceiling', not a transcription of the table.",
+          "Secondary aggregators (drugs.com, Sanford) — discarded per primary-source-first; the FDA label states the reduction directly."
+        ],
+        "note": "DIRECTION ENTAILED. The verbatim DOSAGE AND ADMINISTRATION sentence mandates a dose reduction once CrCl <= 50 mL/min (meropenem is substantially renally excreted and accumulates), which is the direction the renal_severe ceiling penalty encodes. Grounds existence + direction of the cap, not its magnitude (the per-kg number stays the standing ILLUSTRATIVE feasibility model)."
+      },
+      "verify": {
+        "id": "dose_penalty_meropenem_renal",
+        "byte_stable": true,
+        "reextracted_value": "Re-fetched the a456013b DailyMed meropenem label: DOSAGE AND ADMINISTRATION states 'Dosage should be reduced in patients with creatinine clearance of 50 mL/min or less.'",
+        "refute_attempt": "Strongest refutation: 'reduced' could mean a longer interval rather than a lower per-dose ceiling. Conceded to the extent the verdict is direction_only: the label, plus its WARNINGS note that meropenem is 'substantially excreted by the kidney' and adverse reactions (seizure, renal/heart failure) rise in renal impairment, make the safety direction unambiguous (shrink the safe exposure); mechanism/magnitude are left to the illustrative model. Generic vs meningitis: dose feasibility under renal impairment is indication-independent.",
+        "final_verdict": "direction_only"
+      },
+      "spider_status": "direction_only"
+    },
+    {
+      "id": "dose_penalty_aztreonam_renal",
+      "kind": "dose_penalty",
+      "drug": "aztreonam",
+      "claim": "Renal impairment lowers aztreonam's safe dose: the dose must be reduced (halved at CrCl 10–30 mL/min/1.73 m2 after a loading dose) as renal function falls — i.e. the safe ceiling shrinks (the renal_severe ceiling penalty).",
+      "grounded": {
+        "id": "dose_penalty_aztreonam_renal",
+        "resolved_url": "https://dailymed.nlm.nih.gov/dailymed/fda/fdaDrugXsl.cfm?setid=9a105eaf-ee77-4016-beeb-d425a5565db2",
+        "source_title": "AZACTAM (aztreonam for injection) — FDA prescribing information (DailyMed / NLM), DOSAGE AND ADMINISTRATION (Renal Impairment in Adult Patients)",
+        "byte_quote": "Therefore, the dosage of AZACTAM should be halved in patients with estimated creatinine clearances between 10 and 30 mL/min/1.73 m2 after an initial loading dose of 1g or 2 g.",
+        "value_found": "Aztreonam dose halved at CrCl 10–30 mL/min/1.73 m2 (after a loading dose) — the maintenance ceiling shrinks with renal impairment. DIRECTION (and, here, the halving factor) grounded; the formulary per-kg penalty stays the illustrative model.",
+        "direction_correct": true,
+        "verdict": "direction_only",
+        "discards": [
+          "Mapping the label's CrCl 10–30 band exactly onto the model's renal_severe token — the model's single renal_severe penalty is a coarse stand-in for 'significant renal impairment'; the label's banded schedule (halve at 10–30) is the basis for the DIRECTION, not a per-band per-kg transcription.",
+          "Secondary aggregators — discarded per primary-source-first; the FDA label states the halving directly."
+        ],
+        "note": "DIRECTION ENTAILED (with a concrete halving factor at the 10–30 band). The verbatim DOSAGE AND ADMINISTRATION sentence reduces the aztreonam maintenance dose in renal impairment, which is the direction the renal_severe ceiling penalty encodes. Grounds existence + direction; the model's single per-kg penalty number stays the standing ILLUSTRATIVE feasibility model rather than transcribing the banded schedule."
+      },
+      "verify": {
+        "id": "dose_penalty_aztreonam_renal",
+        "byte_stable": true,
+        "reextracted_value": "Re-fetched the 9a105eaf DailyMed AZACTAM label: under DOSAGE AND ADMINISTRATION / 'Renal Impairment in Adult Patients' it states 'Therefore, the dosage of AZACTAM should be halved in patients with estimated creatinine clearances between 10 and 30 mL/min/1.73 m2 after an initial loading dose of 1g or 2 g.'",
+        "refute_attempt": "Strongest refutation: the quote specifies a particular CrCl band (10–30), so mapping it to the model's coarse renal_severe token is approximate. Conceded: the model uses a single renal_severe penalty as a stand-in for significant renal impairment; the label unambiguously establishes the DIRECTION (reduce/halve the maintenance dose as renal function falls), which is what is grounded. The exact per-kg magnitude and CrCl banding stay the illustrative feasibility model.",
+        "final_verdict": "direction_only"
+      },
+      "spider_status": "direction_only"
+    },
+    {
+      "id": "dose_penalty_tmp_smx_renal",
+      "kind": "dose_penalty",
+      "drug": "tmp_smx",
+      "claim": "Renal impairment lowers the safe trimethoprim-sulfamethoxazole dose: a reduced dosage must be used when renal function is impaired — i.e. the safe ceiling shrinks (the renal_severe ceiling penalty).",
+      "grounded": {
+        "id": "dose_penalty_tmp_smx_renal",
+        "resolved_url": "https://dailymed.nlm.nih.gov/dailymed/fda/fdaDrugXsl.cfm?setid=793c75eb-dd65-4b6d-ac46-6e57ce1334f7",
+        "source_title": "SULFAMETHOXAZOLE AND TRIMETHOPRIM injection — FDA prescribing information (DailyMed / NLM), DOSAGE AND ADMINISTRATION",
+        "byte_quote": "When renal function is impaired, a reduced dosage should be employed, as shown in Table 2.",
+        "value_found": "Trimethoprim-sulfamethoxazole dose must be reduced when renal function is impaired — the safe ceiling shrinks with renal impairment. DIRECTION only; the per-kg penalty magnitude stays the illustrative feasibility model (Table 2 is a CrCl-banded schedule).",
+        "direction_correct": true,
+        "verdict": "direction_only",
+        "discards": [
+          "Table 2's CrCl-banded reduced-dose schedule — a multi-row table, not a single per-kg ceiling reduction; the formulary's renal_severe per-kg penalty approximates 'shrink the ceiling', not a transcription of Table 2.",
+          "The adjacent 'avoid ... in patients with impaired renal function' caution — the dose-window model expresses graded shrink (penalty) rather than a hard exclusion, consistent with the label's primary instruction to use a REDUCED dosage; not modeled as a contraindication here.",
+          "Secondary aggregators — discarded per primary-source-first; the FDA label states the reduction directly."
+        ],
+        "note": "DIRECTION ENTAILED. The verbatim DOSAGE AND ADMINISTRATION sentence prescribes a reduced dosage in renal impairment, the direction the renal_severe ceiling penalty encodes. Grounds existence + direction of the cap, not its magnitude (the per-kg number stays the standing ILLUSTRATIVE feasibility model)."
+      },
+      "verify": {
+        "id": "dose_penalty_tmp_smx_renal",
+        "byte_stable": true,
+        "reextracted_value": "Re-fetched the 793c75eb DailyMed sulfamethoxazole-trimethoprim label: DOSAGE AND ADMINISTRATION states 'When renal function is impaired, a reduced dosage should be employed, as shown in Table 2.'",
+        "refute_attempt": "Strongest refutation: the same label elsewhere says to AVOID the drug in impaired renal function, which could argue for an exclusion rather than a dose penalty. The primary dosing instruction, however, is to EMPLOY A REDUCED DOSAGE (Table 2) — a graded shrink, which is exactly the renal_severe ceiling penalty; the avoid-caution is a relative one and the dose-window's shrink (which can still go UNSAT if floor>ceiling) faithfully represents 'use less, and not at all if no safe dose exists'. Direction grounded; magnitude illustrative.",
+        "final_verdict": "direction_only"
+      },
+      "spider_status": "direction_only"
     }
   ]
 }

--- a/code/specs/data/mycin-2026/treatment/antibiotics/dose-cap-manifest.json
+++ b/code/specs/data/mycin-2026/treatment/antibiotics/dose-cap-manifest.json
@@ -90,7 +90,37 @@
       "trust": "authoritative",
       "source": "Adjust the dose of Cefepime Injection in patients with creatinine clearance less than or equal to 60 mL/min to compensate for the slower rate of renal elimination. Neurotoxicity: May occur especially in patients with renal impairment administered unadjusted doses.",
       "url": "https://dailymed.nlm.nih.gov/dailymed/fda/fdaDrugXsl.cfm?setid=be5f8ca6-7232-423a-a2d5-cccb7abe7921"
+    },
+    "dose_capped_under__meropenem__renal_severe": {
+      "relation": "dose_capped_under",
+      "subject": "meropenem",
+      "risk": "renal_severe",
+      "grounding_id": "dose_penalty_meropenem_renal",
+      "verdict": "ACCEPT",
+      "trust": "authoritative",
+      "source": "Dosage should be reduced in patients with creatinine clearance of 50 mL/min or less.",
+      "url": "https://dailymed.nlm.nih.gov/dailymed/fda/fdaDrugXsl.cfm?setid=a456013b-b20e-4b29-b2f9-06f18f1ea6bd"
+    },
+    "dose_capped_under__aztreonam__renal_severe": {
+      "relation": "dose_capped_under",
+      "subject": "aztreonam",
+      "risk": "renal_severe",
+      "grounding_id": "dose_penalty_aztreonam_renal",
+      "verdict": "ACCEPT",
+      "trust": "authoritative",
+      "source": "Therefore, the dosage of AZACTAM should be halved in patients with estimated creatinine clearances between 10 and 30 mL/min/1.73 m2 after an initial loading dose of 1g or 2 g.",
+      "url": "https://dailymed.nlm.nih.gov/dailymed/fda/fdaDrugXsl.cfm?setid=9a105eaf-ee77-4016-beeb-d425a5565db2"
+    },
+    "dose_capped_under__tmp_smx__renal_severe": {
+      "relation": "dose_capped_under",
+      "subject": "tmp_smx",
+      "risk": "renal_severe",
+      "grounding_id": "dose_penalty_tmp_smx_renal",
+      "verdict": "ACCEPT",
+      "trust": "authoritative",
+      "source": "When renal function is impaired, a reduced dosage should be employed, as shown in Table 2.",
+      "url": "https://dailymed.nlm.nih.gov/dailymed/fda/fdaDrugXsl.cfm?setid=793c75eb-dd65-4b6d-ac46-6e57ce1334f7"
     }
   },
-  "hash": "e260c9f8b07b8d64"
+  "hash": "ff85c294c1cdd6c2"
 }

--- a/code/specs/data/mycin-2026/treatment/antibiotics/dose_caps.adj
+++ b/code/specs/data/mycin-2026/treatment/antibiotics/dose_caps.adj
@@ -85,6 +85,18 @@ rulebook dose_caps {
         source "Adjust the dose of Cefepime Injection in patients with creatinine clearance less than or equal to 60 mL/min to compensate for the slower rate of renal elimination. Neurotoxicity: May occur especially in patients with renal impairment administered unadjusted doses."
         locator "https://dailymed.nlm.nih.gov/dailymed/fda/fdaDrugXsl.cfm?setid=be5f8ca6-7232-423a-a2d5-cccb7abe7921"
         trust authoritative
+    relate dose_capped_under(meropenem, renal_severe)
+        source "Dosage should be reduced in patients with creatinine clearance of 50 mL/min or less."
+        locator "https://dailymed.nlm.nih.gov/dailymed/fda/fdaDrugXsl.cfm?setid=a456013b-b20e-4b29-b2f9-06f18f1ea6bd"
+        trust authoritative
+    relate dose_capped_under(aztreonam, renal_severe)
+        source "Therefore, the dosage of AZACTAM should be halved in patients with estimated creatinine clearances between 10 and 30 mL/min/1.73 m2 after an initial loading dose of 1g or 2 g."
+        locator "https://dailymed.nlm.nih.gov/dailymed/fda/fdaDrugXsl.cfm?setid=9a105eaf-ee77-4016-beeb-d425a5565db2"
+        trust authoritative
+    relate dose_capped_under(tmp_smx, renal_severe)
+        source "When renal function is impaired, a reduced dosage should be employed, as shown in Table 2."
+        locator "https://dailymed.nlm.nih.gov/dailymed/fda/fdaDrugXsl.cfm?setid=793c75eb-dd65-4b6d-ac46-6e57ce1334f7"
+        trust authoritative
 
     % --- the GENERIC conjunction rules ---------------------------------------
     % a compound risk holds when an active risk is in its first category AND a

--- a/code/specs/data/mycin-2026/treatment/antibiotics/dose_caps_build.py
+++ b/code/specs/data/mycin-2026/treatment/antibiotics/dose_caps_build.py
@@ -129,6 +129,16 @@ SINGLE_FACTOR_CAPS: list[tuple[str, str, str, str]] = [
     ("dose_penalty_cefepime_renal", "cefepime", "renal_severe",
      "Cefepime dose must be adjusted in renal impairment (CrCl <= 60 mL/min); neurotoxicity "
      "occurs especially when renally-impaired patients receive unadjusted doses (FDA label)."),
+    # Completing dose-penalty grounding coverage: the remaining renal-cleared formulary drugs.
+    ("dose_penalty_meropenem_renal", "meropenem", "renal_severe",
+     "Meropenem dosage must be reduced at CrCl <= 50 mL/min (substantially renally excreted, "
+     "so it accumulates in renal impairment) (FDA label)."),
+    ("dose_penalty_aztreonam_renal", "aztreonam", "renal_severe",
+     "Aztreonam dosage must be reduced in renal impairment (halved at CrCl 10-30 mL/min/1.73 m2 "
+     "after a loading dose) (FDA label)."),
+    ("dose_penalty_tmp_smx_renal", "tmp_smx", "renal_severe",
+     "Trimethoprim-sulfamethoxazole requires a reduced dosage when renal function is impaired "
+     "(FDA label)."),
 ]
 
 

--- a/code/specs/data/mycin-2026/treatment/antibiotics/formulary.json
+++ b/code/specs/data/mycin-2026/treatment/antibiotics/formulary.json
@@ -33,15 +33,18 @@
                      "source": "IDSA Tunkel 2004 (cefepime for Pseudomonas / nosocomial)"},
     "meropenem":    {"covers": ["n_meningitidis", "listeria", "pseudomonas", "gram_negative", "s_pneumoniae_susceptible"], "csf_penetrant": true, "betalactam": true, "contraindications": ["betalactam_allergy_severe"], "tier": 3,
                      "dose": {"floor_mg_per_kg": 20, "ceiling_base_mg_per_kg": 40, "ceiling_penalty_mg_per_kg": {"renal_severe": 3}},
+                     "dose_penalty_source": "FDA meropenem label (DailyMed a456013b): reduce dose at CrCl <= 50 mL/min — DIRECTION grounded in dose-window-grounding.json (dose_penalty_meropenem_renal); per-kg magnitude is the illustrative feasibility model",
                      "source": "IDSA Tunkel 2004 (meropenem; covers Listeria + Pseudomonas)"},
     "moxifloxacin": {"covers": ["s_pneumoniae_resistant", "n_meningitidis"], "csf_penetrant": true, "betalactam": false, "contraindications": [], "tier": 4,
                      "dose": {"floor_mg_per_kg": 5, "ceiling_base_mg_per_kg": 8, "ceiling_penalty_mg_per_kg": {}},
                      "source": "Beta-lactam-sparing pneumococcal/meningococcal option (IDSA 2004 alt)"},
     "aztreonam":    {"covers": ["n_meningitidis", "gram_negative", "pseudomonas"], "csf_penetrant": true, "betalactam": false, "contraindications": [], "tier": 4,
                      "dose": {"floor_mg_per_kg": 20, "ceiling_base_mg_per_kg": 40, "ceiling_penalty_mg_per_kg": {"renal_severe": 4}},
+                     "dose_penalty_source": "FDA AZACTAM (aztreonam) label (DailyMed 9a105eaf): halve dose at CrCl 10-30 mL/min/1.73 m2 after a loading dose — DIRECTION grounded in dose-window-grounding.json (dose_penalty_aztreonam_renal); per-kg magnitude is the illustrative feasibility model",
                      "source": "Monobactam; safe in penicillin allergy (no cross-reactivity)"},
     "tmp_smx":      {"covers": ["listeria"], "csf_penetrant": true, "betalactam": false, "contraindications": [], "tier": 3,
                      "dose": {"floor_mg_per_kg": 5, "ceiling_base_mg_per_kg": 10, "ceiling_penalty_mg_per_kg": {"renal_severe": 3}},
+                     "dose_penalty_source": "FDA sulfamethoxazole-trimethoprim label (DailyMed 793c75eb): reduced dosage when renal function is impaired — DIRECTION grounded in dose-window-grounding.json (dose_penalty_tmp_smx_renal); per-kg magnitude is the illustrative feasibility model",
                      "source": "TMP-SMX for Listeria when ampicillin contraindicated"}
   }
 }

--- a/code/specs/data/mycin-2026/treatment/antibiotics/test_dose_caps.py
+++ b/code/specs/data/mycin-2026/treatment/antibiotics/test_dose_caps.py
@@ -154,6 +154,18 @@ def test_single_factor_cefepime_renal_cap_is_grounded():
     assert any(c["drug"] == "vancomycin" for c in caps), caps
 
 
+def test_renal_severe_caps_every_renally_cleared_drug():
+    cli = _cli_or_skip()
+    # Dose-penalty grounding is COMPLETE: every formulary drug with a renal_severe ceiling
+    # penalty now has an engine-queryable, FDA-grounded single-factor cap. A renal_severe chart
+    # derives the cap for all of them, each at authoritative trust.
+    _, caps = dc.derive_dose_caps(cli, {"renal_severe"})
+    capped = {c["drug"] for c in caps if c["risk"] == "renal_severe"}
+    assert capped == {"vancomycin", "cefepime", "meropenem", "aztreonam", "tmp_smx"}, capped
+    assert all(c["trust"] == "authoritative" and c["source"]
+               for c in caps if c["risk"] == "renal_severe"), caps
+
+
 def test_unknown_single_risk_caps_nothing():
     cli = _cli_or_skip()
     # A risk token with no dose_capped_under fact and no category → no compound, no cap.


### PR DESCRIPTION
## Finish the dose-cap arc — 100% dose-penalty grounding coverage

Consolidated grounding PR: **every** formulary drug with a renal ceiling penalty now has an engine-queryable, FDA-grounded single-factor cap. Pure data (grounding records + `SINGLE_FACTOR_CAPS` rows) reusing the completed `dose_caps.adj` substrate — **no engine/compiler change** (write-once-use-many).

### Grounded directions (`verdict: direction_only`)
- **meropenem** (DailyMed `a456013b`, DOSAGE AND ADMINISTRATION): *"Dosage should be reduced in patients with creatinine clearance of 50 mL/min or less."*
- **aztreonam** (AZACTAM, DailyMed `9a105eaf`, Renal Impairment in Adult Patients): *"the dosage of AZACTAM should be halved in patients with estimated creatinine clearances between 10 and 30 mL/min/1.73 m2 after an initial loading dose of 1g or 2 g."*
- **tmp_smx** (DailyMed `793c75eb`, DOSAGE AND ADMINISTRATION): *"When renal function is impaired, a reduced dosage should be employed, as shown in Table 2."*

### Changes (data only)
- `dose-window-grounding.json`: +3 records (now 15), each byte-stable with an honest refute attempt (interval-vs-ceiling; tmp_smx avoid-vs-reduce reconciled to a graded shrink that can still go UNSAT). Per-kg magnitudes stay the illustrative model (labels give CrCl-banded tables).
- `dose_caps_build.py`: +3 `SINGLE_FACTOR_CAPS` rows → `dose_capped_under(meropenem/aztreonam/tmp_smx, renal_severe)`. No logic change; generator regenerates the rulebook (8 ACCEPT).
- `formulary.json`: +3 `dose_penalty_source` pointers (don't touch dose sub-objects or the CAS digest).
- `test_dose_caps.py`: + `test_renal_severe_caps_every_renally_cleared_drug` (**17 tests**) — a `renal_severe` chart now caps **all** of {vancomycin, cefepime, meropenem, aztreonam, tmp_smx} at authoritative trust.
- `CHART-AS-CONSTRAINTS.md`: CC-2c "dose-penalty grounding complete" subsection.

The dose-window-layer dose-penalty authored-debt is **fully retired**.

### Verified
`dose_caps_build --check` + `formulary_build --check` up to date; `test_dose_caps` 17/17; ruff clean; **board 0 wrong / defensibility 100%**; **`board-scorecard.json` byte-identical**.

Security review (data-only; generator/runtime/guard unchanged): **PASSED — no vulnerabilities found**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)