### PR TITLE
feat(mycin-cc3c): comorbidity-driven exclusions (new front-2 constraint family)

### DIFF
--- a/code/specs/data/mycin-2026/CHART-AS-CONSTRAINTS.md
+++ b/code/specs/data/mycin-2026/CHART-AS-CONSTRAINTS.md
@@ -312,6 +312,24 @@ risks Y") — decision support, not a hidden choice.
       severity dimension can gate anaphylaxis caution). The current cut is subclass-level,
       which is correct for the formulary's drugs (no formulary cephalosporin shares a penicillin
       side chain) but should refine to side-chain identity as the formulary grows.
+- **CC-3c — COMORBIDITY-driven exclusions (new constraint family). ✅ DONE.** A patient
+  COMORBIDITY now activates a clinical context the engine joins against the grounded
+  contraindication rulebook — the same `ist(c, φ)` mechanism as allergy/pregnancy, no new
+  Python rule layer. A `comorbidity` chart fact maps via `_CONTEXT_FROM_FACT` to a context, and
+  `derive()` asks the engine `? contraindicated($D, $C)`. First grounded members:
+  - **G6PD deficiency → tmp_smx** (NEW grounding, `ci_tmpsmx_g6pd` in
+    `treatment-constraints-grounding.json`; FDA sulfamethoxazole-trimethoprim label §5.12
+    Hemolysis: *"In glucose-6-phosphate dehydrogenase deficient individuals, hemolysis may
+    occur."* at `trust authoritative`) — the sulfonamide is engine-excluded for a G6PD patient.
+  - **QT prolongation → moxifloxacin** — the already-grounded `ci_fluoroquinolone_qt` class
+    rule, now REACHABLE from a chart (previously a rulebook-only genericity demo with no chart
+    fact wired to it).
+  The exclusion is engine-derived with its FDA byte-quote; adding a comorbidity = one
+  `_CONTEXT_FROM_FACT` row + a grounded fact, no drug-name logic. Verified by
+  `test_contraindications.test_g6pd_deficiency_excludes_the_sulfonamide`,
+  `test_chart_to_cop.test_comorbidity_activates_a_context`, and a new board item `mgmt_g6pd`
+  (a G6PD-deficient adult correctly gets ceftriaxone+vancomycin with tmp_smx engine-excluded —
+  exercising the comorbidity path end-to-end in CI; board 154 items, management 7/7, 0 wrong).
 - **CC-4 — cost + side-effect objective. ✅ DONE.** The set-cover objective is now the
   weighted blend `minimize Σ (w_cost·tier + w_tox·side_effects)·x_d`, emitted to the engine's
   integer optimizer (coefficients stay integer). A chart `objective_priority` fact selects the

--- a/code/specs/data/mycin-2026/board/board-scorecard.json
+++ b/code/specs/data/mycin-2026/board/board-scorecard.json
@@ -1,7 +1,7 @@
 {
   "summary": {
-    "total": 153,
-    "correct": 146,
+    "total": 154,
+    "correct": 147,
     "abstained": 7,
     "wrong": 0,
     "by_tactic": {
@@ -11,7 +11,7 @@
         "wrong": 0
       },
       "management": {
-        "correct": 6,
+        "correct": 7,
         "abstained": 0,
         "wrong": 0
       },
@@ -557,6 +557,14 @@
     },
     {
       "id": "mgmt_hepatorenal",
+      "tactic": "management",
+      "gold": "ceftriaxone+vancomycin",
+      "answer": "ceftriaxone+vancomycin",
+      "outcome": "correct",
+      "trust": null
+    },
+    {
+      "id": "mgmt_g6pd",
       "tactic": "management",
       "gold": "ceftriaxone+vancomycin",
       "answer": "ceftriaxone+vancomycin",

--- a/code/specs/data/mycin-2026/board/items.json
+++ b/code/specs/data/mycin-2026/board/items.json
@@ -76,6 +76,7 @@
     {"id": "mgmt_pregnant_adult",    "domain": "meningitis_tx", "tactic": "management", "chart": [["age_band", "adult", "28-year-old"], ["pregnancy", "present", "G2P1 at 24 weeks"]],            "gold": ["ceftriaxone", "vancomycin"]},
     {"id": "mgmt_betalactam_allergic","domain": "meningitis_tx", "tactic": "management", "chart": [["age_band", "adult", "adult"], ["allergy", "betalactam", "anaphylaxis to multiple beta-lactams (whole-class)"]],       "gold": "INFEASIBLE"},
     {"id": "mgmt_hepatorenal",       "domain": "meningitis_tx", "tactic": "management", "chart": [["age_band", "adult", "58-year-old"], ["hepatic_status", "hepatic_moderate", "Child-Pugh B cirrhosis"], ["renal_status", "renal_moderate", "CrCl 38 mL/min"]], "gold": ["ceftriaxone", "vancomycin"]},
+    {"id": "mgmt_g6pd",              "domain": "meningitis_tx", "tactic": "management", "chart": [["age_band", "adult", "26-year-old"], ["comorbidity", "g6pd_deficiency", "known G6PD deficiency"]], "gold": ["ceftriaxone", "vancomycin"]},
 
     {"id": "micro_saureus_gram",   "domain": "micro", "tactic": "recall", "relation": "gram_stain", "subject": "staphylococcus_aureus",    "var": "Result",  "gold": "gram_positive"},
     {"id": "micro_saureus_shape",  "domain": "micro", "tactic": "recall", "relation": "morphology", "subject": "staphylococcus_aureus",    "var": "Shape",   "gold": "cocci"},

--- a/code/specs/data/mycin-2026/board/test_board_eval.py
+++ b/code/specs/data/mycin-2026/board/test_board_eval.py
@@ -265,6 +265,12 @@ def test_management_runs_the_constraint_engine_when_cli_present() -> None:
     # stays FEASIBLE and dose-adjusted (cap, don't forbid): ceftriaxone + vancomycin.
     assert by_id["mgmt_hepatorenal"].outcome == "correct"
     assert by_id["mgmt_hepatorenal"].answer == "ceftriaxone+vancomycin"
+    # CC-3c: a comorbidity (G6PD deficiency) activates a clinical context; the engine derives
+    # tmp_smx as contraindicated (sulfonamide hemolysis) and folds it into forced_zero. The
+    # standard adult regimen is unaffected (tmp_smx wasn't used), so the answer stays correct —
+    # exercising the full comorbidity→context→engine-contraindication path end-to-end in CI.
+    assert by_id["mgmt_g6pd"].outcome == "correct"
+    assert by_id["mgmt_g6pd"].answer == "ceftriaxone+vancomycin"
 
 
 def _card_with_diff():

--- a/code/specs/data/mycin-2026/grounding/treatment-constraints-grounding.json
+++ b/code/specs/data/mycin-2026/grounding/treatment-constraints-grounding.json
@@ -261,6 +261,33 @@
         "final_verdict": "grounded"
       },
       "spider_status": "grounded"
+    },
+    {
+      "id": "ci_tmpsmx_g6pd",
+      "kind": "contraindication",
+      "claim": "Trimethoprim-sulfamethoxazole (a sulfonamide) is contraindicated / cautioned in G6PD (glucose-6-phosphate dehydrogenase) deficiency, where it can precipitate hemolysis / hemolytic anemia.",
+      "grounded": {
+        "id": "ci_tmpsmx_g6pd",
+        "resolved_url": "https://dailymed.nlm.nih.gov/dailymed/fda/fdaDrugXsl.cfm?setid=793c75eb-dd65-4b6d-ac46-6e57ce1334f7",
+        "source_title": "DailyMed — SULFAMETHOXAZOLE AND TRIMETHOPRIM injection (FDA prescribing information), WARNINGS AND PRECAUTIONS (5.12 Hemolysis)",
+        "byte_quote": "In glucose-6-phosphate dehydrogenase deficient individuals, hemolysis may occur.",
+        "value_found": "Directional (relative) contraindication: in G6PD-deficient patients, sulfamethoxazole-trimethoprim can precipitate hemolysis. The FDA label states it as a §5.12 Hemolysis WARNING (avoid / use with caution + monitor), not an absolute 'contraindicated' line — but the direction (G6PD deficiency → don't give the sulfonamide, choose another agent) is unambiguous, which is what the exclusion encodes.",
+        "direction_correct": true,
+        "verdict": "grounded",
+        "discards": [
+          "Framing G6PD-hemolysis as a class-wide effect of ALL the formulary's drugs — the hemolysis warning is specific to the sulfonamide (sulfamethoxazole) component; only tmp_smx is excluded, the β-lactams/vancomycin are not. Encoding it more broadly would misrepresent the label.",
+          "Secondary aggregators (drugs.com, UpToDate G6PD drug lists) — discarded per primary-source-first; the FDA label states the G6PD hemolysis warning directly."
+        ],
+        "note": "DIRECTIONAL contraindication ENTAILED. The verbatim §5.12 sentence ties hemolysis to G6PD deficiency for this sulfonamide; the comorbidity exclusion encodes the direction (a G6PD-deficient patient should not receive tmp_smx — pick another Listeria/coverage agent), exactly the engine-derived contraindication the rulebook joins from active_context(g6pd_deficiency). A contraindication is binary/directional (exclude, not a magnitude), so a directional grounding is sufficient at trust authoritative — consistent with the other contraindication records (e.g. ci_fluoroquinolone_qt)."
+      },
+      "verify": {
+        "id": "ci_tmpsmx_g6pd",
+        "byte_stable": true,
+        "reextracted_value": "Re-fetched the 793c75eb DailyMed sulfamethoxazole-trimethoprim label: WARNINGS AND PRECAUTIONS §5.12 (Hemolysis) states 'In glucose-6-phosphate dehydrogenase deficient individuals, hemolysis may occur.'",
+        "refute_attempt": "Strongest refutation: the label calls this a WARNING, not an absolute CONTRAINDICATION, so modeling it as an exclusion could be too strong. Conceded in framing (it is a relative contraindication) but the DIRECTION is unambiguous — a G6PD-deficient patient should not receive the sulfonamide when an equally-covering non-hemolytic agent exists, which is what the exclusion expresses; in a scenario where tmp_smx is the only option the engine's INFEASIBLE/abstention is the honest result. Second angle: hemolysis is dose/oxidative-stress dependent, not universal — true, but the label states it 'may occur', and avoidance is the standard G6PD precaution. The exclusion is directionally faithful to the label.",
+        "final_verdict": "grounded"
+      },
+      "spider_status": "grounded"
     }
   ]
 }

--- a/code/specs/data/mycin-2026/treatment/antibiotics/chart_to_cop.py
+++ b/code/specs/data/mycin-2026/treatment/antibiotics/chart_to_cop.py
@@ -114,6 +114,12 @@ _CONTEXT_FROM_FACT = {
     ("allergy", "penicillin"): "penicillin_allergy",
     ("allergy", "cephalosporin"): "cephalosporin_allergy",
     ("allergy", "betalactam"): "betalactam_allergy",
+    # CC-3c comorbidity-driven contexts: a patient comorbidity activates a clinical context the
+    # engine joins against the grounded contraindication rulebook (same mechanism as allergy/
+    # pregnancy). g6pd_deficiency → the sulfonamide (tmp_smx) is hemolytic; qt_prolongation →
+    # the fluoroquinolone (moxifloxacin) is QT-prolonging — both already grounded in the rulebook.
+    ("comorbidity", "g6pd_deficiency"): "g6pd_deficiency",
+    ("comorbidity", "qt_prolongation"): "qt_prolongation",
 }
 
 # CC-4: a chart `objective_priority` fact → the (w_cost, w_tox) objective blend the
@@ -264,6 +270,23 @@ def compile_cop(facts: list[ChartFact]) -> Cop:
             else:
                 cop.discards.append({"fact": f"pregnancy={f.value}",
                                      "reason": "pregnancy value not 'present' → no context activated"})
+        elif f.kind == "comorbidity":
+            # CC-3c: a patient comorbidity (G6PD deficiency, QT prolongation, …) activates a
+            # clinical CONTEXT. As with allergy/pregnancy, it does NOT name the excluded drugs —
+            # the engine derives those in derive() from the grounded contraindication rulebook
+            # (g6pd_deficiency → tmp_smx; qt_prolongation → moxifloxacin). New comorbidity = one
+            # row in _CONTEXT_FROM_FACT + a grounded fact, no drug-name logic here.
+            context = _CONTEXT_FROM_FACT.get((f.kind, f.value))
+            if context:
+                cop.active_contexts.add(context)
+                cop.constraints.append({"type": "context", "from": f"comorbidity={f.value}",
+                                        "rule": f"comorbidity → active clinical context '{context}' "
+                                                "(gates the contraindication rules)",
+                                        "detail": context, "span": f.span})
+            else:
+                cop.discards.append({"fact": f"comorbidity={f.value}",
+                                     "reason": "no grounded contraindication context for this "
+                                               "comorbidity yet (want g6pd_deficiency/qt_prolongation)"})
         elif f.kind == "culture_status":
             # CC-5: whether the culture is back drives the wait-vs-treat-now decision.
             if f.value in ("pending", "resulted"):

--- a/code/specs/data/mycin-2026/treatment/antibiotics/contraindication-manifest.json
+++ b/code/specs/data/mycin-2026/treatment/antibiotics/contraindication-manifest.json
@@ -79,6 +79,16 @@
       "source": "Some epidemiologic studies suggest that exposure to sulfamethoxazole and trimethoprim during pregnancy may be associated with an increased risk of congenital malformations, particularly neural tube defects, cardiovascular malformations, urinary tract defects, oral clefts, and club foot.",
       "url": "https://dailymed.nlm.nih.gov/dailymed/lookup.cfm?setid=793c75eb-dd65-4b6d-ac46-6e57ce1334f7"
     },
+    "drug_contraindicated_in__tmp_smx__g6pd_deficiency": {
+      "relation": "drug_contraindicated_in",
+      "subject": "tmp_smx",
+      "context": "g6pd_deficiency",
+      "grounding_id": "ci_tmpsmx_g6pd",
+      "verdict": "ACCEPT",
+      "trust": "authoritative",
+      "source": "In glucose-6-phosphate dehydrogenase deficient individuals, hemolysis may occur.",
+      "url": "https://dailymed.nlm.nih.gov/dailymed/fda/fdaDrugXsl.cfm?setid=793c75eb-dd65-4b6d-ac46-6e57ce1334f7"
+    },
     "class_contraindicated_in__penicillin__penicillin_allergy": {
       "relation": "class_contraindicated_in",
       "subject": "penicillin",
@@ -120,5 +130,5 @@
       "grounding_id": null
     }
   },
-  "hash": "feeebda9736e326b"
+  "hash": "c63c38b0d2e27b31"
 }

--- a/code/specs/data/mycin-2026/treatment/antibiotics/contraindications.adj
+++ b/code/specs/data/mycin-2026/treatment/antibiotics/contraindications.adj
@@ -64,6 +64,10 @@ rulebook contraindications {
         source "Some epidemiologic studies suggest that exposure to sulfamethoxazole and trimethoprim during pregnancy may be associated with an increased risk of congenital malformations, particularly neural tube defects, cardiovascular malformations, urinary tract defects, oral clefts, and club foot."
         locator "https://dailymed.nlm.nih.gov/dailymed/lookup.cfm?setid=793c75eb-dd65-4b6d-ac46-6e57ce1334f7"
         trust authoritative
+    relate drug_contraindicated_in(tmp_smx, g6pd_deficiency)
+        source "In glucose-6-phosphate dehydrogenase deficient individuals, hemolysis may occur."
+        locator "https://dailymed.nlm.nih.gov/dailymed/fda/fdaDrugXsl.cfm?setid=793c75eb-dd65-4b6d-ac46-6e57ce1334f7"
+        trust authoritative
 
     % --- DEFINITIONAL allergy class-contraindications (CC-3b) ---------------
     % Tautological (allergy to a class excludes that class) → bare, like has_class.

--- a/code/specs/data/mycin-2026/treatment/antibiotics/contraindications_build.py
+++ b/code/specs/data/mycin-2026/treatment/antibiotics/contraindications_build.py
@@ -114,6 +114,10 @@ DRUG_CONTRA: list[tuple[str, str, str, str]] = [
     ("ci_tmpsmx_pregnancy", "tmp_smx", "pregnancy",
      "Trimethoprim-sulfamethoxazole is avoided in pregnancy (folate antagonism / risk of "
      "neural tube defects)."),
+    # CC-3c comorbidity family: G6PD deficiency → the sulfonamide can precipitate hemolysis.
+    ("ci_tmpsmx_g6pd", "tmp_smx", "g6pd_deficiency",
+     "In glucose-6-phosphate dehydrogenase (G6PD) deficiency, trimethoprim-sulfamethoxazole "
+     "(a sulfonamide) can precipitate hemolysis; avoid it and choose another agent."),
 ]
 
 # DEFINITIONAL class-contraindications (CC-3b): (class, context). These are tautological —

--- a/code/specs/data/mycin-2026/treatment/antibiotics/test_chart_to_cop.py
+++ b/code/specs/data/mycin-2026/treatment/antibiotics/test_chart_to_cop.py
@@ -49,6 +49,20 @@ def test_allergy_activates_a_context():
     assert len(ctx) == 1 and ctx[0]["from"] == "allergy=penicillin"
 
 
+def test_comorbidity_activates_a_context():
+    # CC-3c: a patient comorbidity activates a clinical CONTEXT (the engine then derives the
+    # contraindicated drug in derive()) — g6pd_deficiency and qt_prolongation are recognized;
+    # an unrecognized comorbidity is discarded with a reason.
+    g6pd = cc.compile_cop([cc.ChartFact("comorbidity", "g6pd_deficiency", "G6PD screen positive")])
+    assert g6pd.active_contexts == {"g6pd_deficiency"}
+    ctx = [c for c in g6pd.constraints if c["type"] == "context" and c["detail"] == "g6pd_deficiency"]
+    assert len(ctx) == 1 and ctx[0]["from"] == "comorbidity=g6pd_deficiency"
+    qt = cc.compile_cop([cc.ChartFact("comorbidity", "qt_prolongation")])
+    assert qt.active_contexts == {"qt_prolongation"}
+    bad = cc.compile_cop([cc.ChartFact("comorbidity", "myasthenia_gravis")])
+    assert not bad.active_contexts and any("myasthenia_gravis" in d["fact"] for d in bad.discards)
+
+
 def test_culture_resistance_becomes_defeated_edge():
     cop = cc.compile_cop([cc.ChartFact("culture_resistance", "ceftriaxone:n_meningitidis", "S/I/R panel")])
     assert ("ceftriaxone", "n_meningitidis") in cop.defeated
@@ -327,6 +341,7 @@ def test_engine_reproduces_existing_regimens():
 def main() -> int:
     test_scenario_selection_and_provenance()
     test_allergy_activates_a_context()
+    test_comorbidity_activates_a_context()
     test_culture_resistance_becomes_defeated_edge()
     test_dose_risk_facts_become_dose_constraints()
     test_hepatic_renal_conjunction_caps_ceftriaxone()

--- a/code/specs/data/mycin-2026/treatment/antibiotics/test_contraindications.py
+++ b/code/specs/data/mycin-2026/treatment/antibiotics/test_contraindications.py
@@ -100,6 +100,18 @@ def test_generic_rule_also_fires_for_qt_prolongation():
     assert set(out) == {"moxifloxacin"} and out["moxifloxacin"]["context"] == "qt_prolongation"
 
 
+def test_g6pd_deficiency_excludes_the_sulfonamide():
+    cli = _cli_or_skip()
+    # CC-3c comorbidity family: G6PD deficiency excludes the sulfonamide (tmp_smx) — hemolysis —
+    # via the same engine-derived contraindication mechanism, with the grounded FDA byte-quote.
+    out = ci.derive_contraindications(cli, {"g6pd_deficiency"})
+    assert set(out) == {"tmp_smx"}, out
+    info = out["tmp_smx"]
+    assert info["context"] == "g6pd_deficiency"
+    assert info["trust"] == "authoritative" and info["source"]
+    assert "glucose-6-phosphate dehydrogenase" in info["source"]
+
+
 # --------------------------------------------------------------------------
 # CC-3b — β-lactam allergy is SIDE-CHAIN-scoped, not class-wide.
 # --------------------------------------------------------------------------


### PR DESCRIPTION
## New front-2 constraint family: comorbidity-driven exclusions

A patient **comorbidity** now activates a clinical context the engine joins against the grounded `contraindications.adj` rulebook — the same `ist(c, φ)` mechanism as allergy/pregnancy, **no new Python rule layer**. Adding a comorbidity = one `_CONTEXT_FROM_FACT` row + a grounded fact.

### First grounded members
- **G6PD deficiency → tmp_smx** (NEW grounding `ci_tmpsmx_g6pd`; FDA sulfamethoxazole-trimethoprim label §5.12 Hemolysis: *"In glucose-6-phosphate dehydrogenase deficient individuals, hemolysis may occur."* at `trust authoritative`) — the sulfonamide is engine-excluded for a G6PD patient.
- **QT prolongation → moxifloxacin** — the already-grounded `ci_fluoroquinolone_qt` class rule, now **reachable from a chart** (previously a rulebook-only genericity demo with no chart fact wired to it).

### Changes
- `chart_to_cop.py`: + `comorbidity` handler (mirrors pregnancy/allergy: chart fact → `active_context` via whitelist `_CONTEXT_FROM_FACT`; recognized → context, else discarded with a reason) + 2 context rows. `derive()` asks the engine `? contraindicated($D,$C)` and folds the result into `forced_zero`.
- `treatment-constraints-grounding.json`: + `ci_tmpsmx_g6pd` (byte-stable verify + honest warning-vs-contraindication refute; `verdict grounded`).
- `contraindications_build.py`: + 1 `DRUG_CONTRA` row; `contraindications.adj` + manifest regenerated (`--check` up to date).
- `board/items.json`: + `mgmt_g6pd` (G6PD adult → ceftriaxone+vancomycin, tmp_smx engine-excluded) — end-to-end CI coverage of the comorbidity path; scorecard regenerated (**154 items, management 7/7, 0 wrong, defensibility 100%**).
- tests: `test_g6pd_deficiency_excludes_the_sulfonamide` (16), `test_comorbidity_activates_a_context`, board test 12/12.
- `CHART-AS-CONSTRAINTS.md`: CC-3c subsection.

### Verified
`contraindications_build --check` up to date; all suites green; ruff clean; board 0 wrong / defensibility 100%.

Security review (whitelist-then-`CONTEXT_RE` guard; runtime/subprocess unchanged): **PASSED — no vulnerabilities found**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)