### PR TITLE
feat(r-lang): R-31 — set-op & ordering refinements (incomparables=, unique fromLast, rank random ties)

### DIFF
--- a/code/packages/rust/r-runtime/CHANGELOG.md
+++ b/code/packages/rust/r-runtime/CHANGELOG.md
@@ -2,6 +2,36 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.26.0] - 2026-06-21
+
+### Added (via the shared `s-runtime`)
+
+- **R-31 — set-op & ordering refinements**: the R-30 deferrals with clean
+  semantics on the shared `as_character`-key path, plus the RNG-backed tie method.
+  All extensions of the R-29/R-30 dedup & ranking handlers (no grammar change),
+  reached through ordinary R syntax, numeric- and character-aware.
+  - **`incomparables =` on `duplicated` / `anyDuplicated` / `unique`** — default
+    `FALSE` means "no incomparables"; a vector lists elements that are **never
+    equal to anything**, so they are never flagged/removed as duplicates (and never
+    suppress a later real one). `duplicated(c(1,1,2,2), incomparables = 1)` →
+    `c(FALSE, FALSE, FALSE, TRUE)`; `unique(c(1,1,2,2), incomparables = 1)` →
+    `c(1, 1, 2)`; `anyDuplicated(c(1,2,1), incomparables = 1)` → `0`;
+    `anyDuplicated(c(1,2,2), incomparables = 1)` → `3`.
+  - **`unique(x, fromLast = TRUE)`** — keeps the **last** occurrence of each value,
+    in input order. Mirrors R-30's `duplicated(fromLast =)`; composes with
+    `incomparables =`. `unique(c(1,2,1), fromLast = TRUE)` → `c(2, 1)`.
+  - **`rank(x, ties.method = "random")`** — tied positions get consecutive ranks in
+    a uniform random order from the `set.seed`-seeded session RNG (a Fisher–Yates
+    shuffle), so `set.seed(s); rank(x, ties.method = "random")` is reproducible.
+    `"average"` stays the default; `"min"/"max"/"first"` unchanged.
+  - **Security**: no new user-controlled multiplier; `incomparables` adds one
+    bounded `HashSet`; `"random"` draws ≤ `n` `u32`s total; named-arg readers
+    reject malformed `ties.method` / `fromLast =` / `incomparables =` gracefully
+    (`Err`, never panic); no path indexes out of bounds.
+  - 4 new R-syntax tests (numeric + character; seed-reproducibility for `"random"`).
+  - **Deferred to R-32**: `incomparables =` / `fromLast =` on the binary set ops
+    (`union` / `intersect` / `setdiff`) — ambiguous R semantics, own pass.
+
 ## [0.25.0] - 2026-06-21
 
 ### Added (via the shared `s-runtime`)

--- a/code/packages/rust/r-runtime/README.md
+++ b/code/packages/rust/r-runtime/README.md
@@ -184,9 +184,20 @@ default `"average"` (`rank(c(1,1,2))` → `c(1.5,1.5,3)` / `c(1,1,3)` / `c(2,2,3
 `c(1,2,3)`). `duplicated(x, fromLast=TRUE)` keeps the *last* occurrence
 (`duplicated(c(1,2,1), fromLast=TRUE)` → `c(TRUE, FALSE, FALSE)`).
 `anyDuplicated(x)` returns the 1-based index of the first duplicated element, or
-`0` if none (`anyDuplicated(c(1,2,1))` → `3`). (`incomparables=` on the set ops /
-`duplicated` / `anyDuplicated`, the `fromLast=` set-op argument, and `rank`'s
-`"random"` method are deferred to R-31.)
+`0` if none (`anyDuplicated(c(1,2,1))` → `3`).
+
+**Set-op & ordering refinements (R-31)** — extensions of the R-29/R-30 dedup &
+ranking builtins. `incomparables=` on `duplicated`, `anyDuplicated`, and `unique`:
+the default `FALSE` means "no incomparables"; a vector lists values that are
+**never equal to anything**, so they are never flagged/removed as duplicates
+(`duplicated(c(1,1,2,2), incomparables=1)` → `c(F,F,F,T)`; `unique(c(1,1,2,2),
+incomparables=1)` → `c(1,1,2)`; `anyDuplicated(c(1,2,1), incomparables=1)` → `0`).
+`unique(x, fromLast=TRUE)` keeps the *last* occurrence in input order, mirroring
+`duplicated(fromLast=)`. `rank(x, ties.method="random")` breaks ties with a
+Fisher–Yates shuffle over the `set.seed`-seeded session RNG, so it is reproducible
+under `set.seed`. Numeric and character vectors; bounded RNG draws; malformed named
+args error gracefully. (`incomparables=`/`fromLast=` on the binary set ops
+`union`/`intersect`/`setdiff` are deferred to R-32.)
 
 ## Usage
 

--- a/code/packages/rust/r-runtime/src/lib.rs
+++ b/code/packages/rust/r-runtime/src/lib.rs
@@ -2878,4 +2878,49 @@ mod tests {
         assert_eq!(nums("anyDuplicated(c(1, 2, 3))\n"), vec![0.0]);
         assert_eq!(nums("anyDuplicated(c(\"a\", \"b\", \"a\"))\n"), vec![3.0]);
     }
+
+    // --- R-31: incomparables=, unique fromLast, rank random (R syntax) --
+
+    #[test]
+    fn duplicated_incomparables() {
+        // 1 is incomparable → never a dup; the second 2 still is.
+        assert_eq!(
+            show("duplicated(c(1, 1, 2, 2), incomparables = 1)\n"),
+            "[1] FALSE FALSE FALSE  TRUE"
+        );
+        // Character incomparables work too.
+        assert_eq!(
+            show("duplicated(c(\"a\", \"a\", \"b\", \"b\"), incomparables = \"a\")\n"),
+            "[1] FALSE FALSE FALSE  TRUE"
+        );
+    }
+
+    #[test]
+    fn unique_incomparables_and_from_last() {
+        // Both 1s kept (incomparable); 2 deduped.
+        assert_eq!(nums("unique(c(1, 1, 2, 2), incomparables = 1)\n"), vec![1.0, 1.0, 2.0]);
+        // fromLast keeps the last occurrence, in input order.
+        assert_eq!(nums("unique(c(1, 2, 1), fromLast = TRUE)\n"), vec![2.0, 1.0]);
+    }
+
+    #[test]
+    fn any_duplicated_incomparables() {
+        // Only repeat is the incomparable 1 → 0.
+        assert_eq!(nums("anyDuplicated(c(1, 2, 1), incomparables = 1)\n"), vec![0.0]);
+        // The repeated 2 at position 3 is comparable → 3.
+        assert_eq!(nums("anyDuplicated(c(1, 2, 2), incomparables = 1)\n"), vec![3.0]);
+    }
+
+    #[test]
+    fn rank_random_ties_reproducible_under_seed() {
+        // The two 3s get {2, 3} in some seed-determined order; the lone 1 gets 1.
+        let a = nums("set.seed(1)\nrank(c(3, 1, 3), ties.method = \"random\")\n");
+        assert_eq!(a[1], 1.0);
+        let mut tied = vec![a[0], a[2]];
+        tied.sort_by(|x, y| x.partial_cmp(y).unwrap());
+        assert_eq!(tied, vec![2.0, 3.0]);
+        // Same seed → identical result.
+        let b = nums("set.seed(1)\nrank(c(3, 1, 3), ties.method = \"random\")\n");
+        assert_eq!(a, b);
+    }
 }

--- a/code/packages/rust/s-runtime/CHANGELOG.md
+++ b/code/packages/rust/s-runtime/CHANGELOG.md
@@ -2,6 +2,56 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.27.0] - 2026-06-21
+
+### Added
+
+- **Set-op & ordering refinements (R-31)** — the two R-30 deferrals that have
+  clean, unambiguous semantics on the existing `as_character`-key path, plus the
+  RNG-backed tie method. All extensions of the R-29/R-30 dedup & ranking handlers
+  (no new value type, no grammar change), available to both S and R.
+  - **`incomparables =` on `duplicated`, `anyDuplicated`, and `unique`** — the
+    default `FALSE` means "no incomparables" (prior behaviour); a **vector** lists
+    the elements to treat as *incomparable*. An incomparable value is **never equal
+    to anything**, so it is never flagged as a duplicate and never removed as one,
+    and it is never recorded in the `seen` set (so it cannot suppress a later
+    genuine duplicate either). Modelled on the same `as_character` key the set-op
+    family already uses, via a shared `incomparables_keys` reader, so numeric and
+    character incomparables both work. `duplicated(c(1,1,2,2), incomparables = 1)` →
+    `c(FALSE, FALSE, FALSE, TRUE)`; `unique(c(1,1,2,2), incomparables = 1)` →
+    `c(1, 1, 2)`; `anyDuplicated(c(1,2,1), incomparables = 1)` → `0`, while
+    `anyDuplicated(c(1,2,2), incomparables = 1)` → `3`.
+  - **`unique(x, fromLast = TRUE)`** — keeps the **last** occurrence of each
+    distinct value (right-to-left scan), gathered in ascending index order so the
+    survivors stay in input order. Mirrors R-30's `duplicated(fromLast =)`, and
+    composes with `incomparables =`. `unique(c(1,2,1), fromLast = TRUE)` →
+    `c(2, 1)`.
+  - **`rank(x, ties.method = "random")`** — scores a tie run as the consecutive
+    ranks `lo..=hi` (like `"first"`) but assigns them to the tied positions in a
+    **uniform random order** drawn from the session RNG (the `set.seed`-seeded
+    generator shared with the R-8 distribution family, via
+    `Interpreter::sample_with` + `RngState::next_u32`). A Fisher–Yates shuffle makes
+    the result **fully reproducible** under `set.seed`. `"average"` remains the
+    default; `"min"/"max"/"first"` are unchanged. Numeric and character vectors.
+
+### Security
+
+- **Bounded work, graceful parsing.** `incomparables =` adds one `HashSet` whose
+  size is bounded by the already-`MAX_SEQ_LEN`-capped `incomparables` vector;
+  membership tests are `O(1)`. `"random"` does one `O(m)` Fisher–Yates pass per
+  tie run with at most one `next_u32` per swap (≤ `n` draws total), so RNG use
+  cannot trigger unbounded work. Named-arg readers reject malformed values
+  gracefully (`Err`, never panic): `ties.method` as a character scalar (unknown →
+  `BadArgs`), `fromLast =` via `truthy()` (non-logical / `NA` → error), and
+  `incomparables =` coerced through the total `as_character`; no path indexes out
+  of bounds.
+
+### Deferred to R-32
+
+- `incomparables =` / `fromLast =` on the binary set ops
+  (`union` / `intersect` / `setdiff`) — their R semantics are ambiguous enough to
+  warrant a separate pass.
+
 ## [0.26.0] - 2026-06-21
 
 ### Added

--- a/code/packages/rust/s-runtime/README.md
+++ b/code/packages/rust/s-runtime/README.md
@@ -213,8 +213,18 @@ a hand-written loop. See [What "S-flavored" means here](#what-s-flavored-means-h
   returns the 1-based index of the first duplicated element, or `0` if none
   (`anyDuplicated(c(1,2,1))` → `3`). Outputs stay bounded by the (capped) inputs;
   the per-key length check guards `order` against out-of-bounds indexing.
-  (`incomparables=` on the set ops / `duplicated` / `anyDuplicated`, the `fromLast=`
-  set-op argument, and `rank`'s `"random"` method are deferred to R-31.)
+- **Set-op & ordering refinements** (R-31): extensions of the R-29/R-30 dedup &
+  ranking builtins. **`incomparables=`** on `duplicated`, `anyDuplicated`, and
+  `unique` — default `FALSE` means "no incomparables"; a vector lists values that
+  are **never equal to anything**, so they are never flagged/removed as duplicates
+  (`duplicated(c(1,1,2,2), incomparables=1)` → `c(F,F,F,T)`; `unique(c(1,1,2,2),
+  incomparables=1)` → `c(1,1,2)`; `anyDuplicated(c(1,2,1), incomparables=1)` → `0`).
+  **`unique(x, fromLast=TRUE)`** keeps the *last* occurrence in input order,
+  mirroring `duplicated(fromLast=)`. **`rank(x, ties.method="random")`** breaks ties
+  with a Fisher–Yates shuffle over the `set.seed`-seeded session RNG, so it is
+  reproducible under `set.seed`. Numeric and character vectors; bounded RNG draws;
+  malformed named args error gracefully. (`incomparables=`/`fromLast=` on the binary
+  set ops `union`/`intersect`/`setdiff` are deferred to R-32.)
 - The **`d`/`p`/`q`/`r` distribution family** (R-8) over `statistics-core`:
   density/CDF/quantile/sampling for the normal, uniform, and exponential
   distributions, plus `set.seed` for a reproducible per-session RNG.

--- a/code/packages/rust/s-runtime/src/builtins.rs
+++ b/code/packages/rust/s-runtime/src/builtins.rs
@@ -1890,15 +1890,85 @@ fn b_rep(_interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
     Ok(combine(&copies))
 }
 
-/// `unique(x)` — distinct elements, first occurrence order preserved.
+/// Parse the **`incomparables =`** keyword argument that `unique`, `duplicated`,
+/// and `anyDuplicated` share (R-31) into a set of *incomparable character keys*.
+///
+/// R's contract: the default is `incomparables = FALSE`, meaning "there are no
+/// incomparable values". Any other value is a **vector listing the elements** to
+/// treat as incomparable — a value listed there is **never considered equal to
+/// anything** (not even another copy of itself), so it is never flagged as a
+/// duplicate and never removed as one. We model "incomparable" on the same coerced
+/// **character** key the dedup builtins already use (`as_character`), so a numeric
+/// `incomparables = 1` and a character `incomparables = "1"` agree, exactly like the
+/// rest of the set-op family.
+///
+/// The single special case is the literal default `FALSE` (a length-1 logical that
+/// is `FALSE`): R spells "no incomparables" that way, so we must NOT treat the
+/// string `"FALSE"` as an incomparable element. Every other value — including a
+/// `TRUE`, a number, a string, or a longer vector — contributes its character keys.
+/// An absent argument yields the empty set. This never errors and never panics:
+/// `as_character` is total, and the result is just a `HashSet` whose size is bounded
+/// by the (already-`MAX_SEQ_LEN`-capped) `incomparables` vector.
+fn incomparables_keys(args: &[Arg]) -> HashSet<Option<String>> {
+    let Some(arg) = args.iter().find(|a| a.name.as_deref() == Some("incomparables")) else {
+        return HashSet::new();
+    };
+    // The default `FALSE` means "no incomparables" — treat it as the empty set.
+    if matches!(&arg.value, SValue::Logical(v) if v.as_slice() == [Some(false)]) {
+        return HashSet::new();
+    }
+    arg.value.as_character().into_iter().collect()
+}
+
+/// `unique(x, incomparables = FALSE, fromLast = FALSE)` — distinct elements,
+/// first-occurrence order preserved.
+///
+/// The base case is the same `as_character`-key + `seen`-set scan as `duplicated`:
+/// keep the 1-based position of each key the first time we meet it.
+///
+/// **`fromLast = TRUE`** (R-31) keeps the **last** occurrence of each distinct value
+/// instead of the first. We scan right-to-left to decide which positions survive,
+/// then gather them in **ascending index order** so the kept elements stay in input
+/// order — R's behaviour (`unique(c(1,2,1), fromLast=TRUE)` is `c(2, 1)`).
+///
+/// **`incomparables =`** (R-31, via [`incomparables_keys`]) lists values that are
+/// never equal to anything: a position whose key is incomparable is **always kept**
+/// and is **never recorded in `seen`** (so it can neither be suppressed nor suppress
+/// a later genuine duplicate). `unique(c(1,1,2,2), incomparables=1)` is `c(1, 1, 2)`.
 fn b_unique(_interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
     let v = first_positional(args)?;
+    let from_last = match args.iter().find(|a| a.name.as_deref() == Some("fromLast")) {
+        Some(arg) => arg.value.truthy()?,
+        None => false,
+    };
+    let incomparable = incomparables_keys(args);
     let keys = v.as_character();
+    let n = keys.len();
     let mut seen: HashSet<Option<String>> = HashSet::new();
-    let keep: Vec<f64> = keys
-        .iter()
-        .enumerate()
-        .filter_map(|(i, k)| seen.insert(k.clone()).then_some((i + 1) as f64))
+    // Decide which positions to keep. A key is kept if it is incomparable, or if
+    // it is the first sighting of a comparable key in the scan direction.
+    let mut keep_flag = vec![false; n];
+    let mut decide = |i: usize| {
+        if incomparable.contains(&keys[i]) {
+            keep_flag[i] = true;
+        } else if seen.insert(keys[i].clone()) {
+            keep_flag[i] = true;
+        }
+    };
+    if from_last {
+        for i in (0..n).rev() {
+            decide(i);
+        }
+    } else {
+        for i in 0..n {
+            decide(i);
+        }
+    }
+    // Gather kept positions in ascending index order (input order), regardless of
+    // scan direction, so `fromLast` only changes *which* copy survives, not order.
+    let keep: Vec<f64> = (0..n)
+        .filter(|&i| keep_flag[i])
+        .map(|i| (i + 1) as f64)
         .collect();
     index(v, &SValue::doubles(keep))
 }
@@ -2026,25 +2096,46 @@ fn b_is_element(_interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
 /// duplicated(c(1, 2, 1))                 = c(FALSE, FALSE, TRUE)   (keep first 1)
 /// duplicated(c(1, 2, 1), fromLast=TRUE)  = c(TRUE,  FALSE, FALSE)  (keep last  1)
 /// ```
+///
+/// **`incomparables =`** (R-31, via [`incomparables_keys`]) lists values that are
+/// never equal to anything: an element whose key is incomparable is **always**
+/// `FALSE` (never a duplicate) and is **never recorded in `seen`**, so it cannot
+/// suppress a later genuine duplicate either:
+///
+/// ```text
+/// duplicated(c(1, 1, 2, 2), incomparables=1) = c(FALSE, FALSE, FALSE, TRUE)
+/// ```
 fn b_duplicated(_interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
     let x = first_positional(args)?;
     let from_last = match args.iter().find(|a| a.name.as_deref() == Some("fromLast")) {
         Some(arg) => arg.value.truthy()?,
         None => false,
     };
+    let incomparable = incomparables_keys(args);
     let keys = x.as_character();
     let n = keys.len();
     let mut seen: HashSet<Option<String>> = HashSet::new();
     let mut flags: Vec<Option<bool>> = vec![Some(false); n];
+    // One element's flag: incomparable keys are never a duplicate (and are never
+    // recorded, so they never suppress a later one); otherwise the first sighting
+    // (in the scan direction) is FALSE and the rest are TRUE.
+    let mut flag = |i: usize, key: &Option<String>| {
+        flags[i] = if incomparable.contains(key) {
+            Some(false)
+        } else {
+            Some(!seen.insert(key.clone()))
+        };
+    };
     if from_last {
-        // Right-to-left: the first key seen (from the right) is the last
-        // occurrence and is NOT a duplicate; earlier ones are.
+        // Right-to-left: the first comparable key seen (from the right) is the
+        // last occurrence and is NOT a duplicate; earlier ones are.
         for i in (0..n).rev() {
-            flags[i] = Some(!seen.insert(keys[i].clone()));
+            let key = keys[i].clone();
+            flag(i, &key);
         }
     } else {
-        for (i, k) in keys.into_iter().enumerate() {
-            flags[i] = Some(!seen.insert(k));
+        for (i, k) in keys.iter().enumerate() {
+            flag(i, k);
         }
     }
     Ok(SValue::Logical(flags))
@@ -2061,10 +2152,23 @@ fn b_duplicated(_interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
 /// anyDuplicated(c(1, 2, 1)) = 3   (the second 1, at position 3, is the first dup)
 /// anyDuplicated(c(1, 2, 3)) = 0   (no repeats)
 /// ```
+///
+/// **`incomparables =`** (R-31, via [`incomparables_keys`]) lists values that are
+/// never equal to anything, so a repeat of an incomparable value is **not** counted
+/// as a duplicate (and the value is never recorded in `seen`):
+///
+/// ```text
+/// anyDuplicated(c(1, 2, 1), incomparables=1) = 0   (the only repeat is incomparable)
+/// anyDuplicated(c(1, 2, 2), incomparables=1) = 3   (the repeated 2 is comparable)
+/// ```
 fn b_any_duplicated(_interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
     let x = first_positional(args)?;
+    let incomparable = incomparables_keys(args);
     let mut seen: HashSet<Option<String>> = HashSet::new();
     for (i, k) in x.as_character().into_iter().enumerate() {
+        if incomparable.contains(&k) {
+            continue;
+        }
         if !seen.insert(k) {
             return Ok(SValue::scalar((i + 1) as f64));
         }
@@ -2106,18 +2210,28 @@ fn b_any_duplicated(_interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
 /// For `"first"` the run members are scored in **original-index order** (the
 /// sort is stable, so `order` already lists tied indices smallest-first), giving
 /// distinct consecutive ranks. An unrecognised method is a graceful error.
-fn b_rank(_interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
+///
+/// **`"random"`** (R-31) scores a run like `"first"` — consecutive ranks
+/// `lo, lo+1, …, hi` — but assigns those ranks to the tied positions in a **uniform
+/// random order** drawn from the **session RNG** (the same generator seeded by
+/// `set.seed` that `runif`/`rnorm` use, reached via `Interpreter::sample_with`). The
+/// permutation is a Fisher–Yates shuffle driven by `RngState::next_u32`, so the
+/// result is **fully reproducible** under `set.seed`. Each swap consumes at most one
+/// `u32`, and there are at most `n` swaps total, so the RNG draw is bounded — no
+/// unbounded work. Because non-tied elements form length-1 runs, `"random"` only
+/// perturbs genuine ties; with no ties it is identical to the plain ranks.
+fn b_rank(interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
     let x = first_positional(args)?;
 
     // The tie rule. R's default is "average"; we additionally support "min",
-    // "max", and "first" (the "random" jitter rule needs an RNG seed contract and
-    // is deferred). The keyword is read as a character scalar, mirroring how
-    // `factor(levels=, labels=)` reads its string arguments.
+    // "max", "first", and "random" (R-31, RNG-backed). The keyword is read as a
+    // character scalar, mirroring how `factor(levels=, labels=)` reads its strings.
     enum Ties {
         Average,
         Min,
         Max,
         First,
+        Random,
     }
     let ties = match args.iter().find(|a| a.name.as_deref() == Some("ties.method")) {
         Some(arg) => match arg
@@ -2132,9 +2246,10 @@ fn b_rank(_interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
             Some("min") => Ties::Min,
             Some("max") => Ties::Max,
             Some("first") => Ties::First,
+            Some("random") => Ties::Random,
             Some(other) => {
                 return Err(SError::BadArgs(format!(
-                    "unknown ties.method {other:?} (expected \"average\", \"min\", \"max\", or \"first\")"
+                    "unknown ties.method {other:?} (expected \"average\", \"min\", \"max\", \"first\", or \"random\")"
                 )));
             }
         },
@@ -2221,6 +2336,28 @@ fn b_rank(_interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
                 // order — distinct ranks, no ties.
                 for (offset, k) in (p..q).enumerate() {
                     ranks[order[k]] = lo + offset as f64;
+                }
+            }
+            Ties::Random => {
+                // Like "first" (consecutive ranks lo..=hi), but the tied positions
+                // receive those ranks in a uniformly random order. We shuffle the
+                // run's slice of `order` in place with Fisher–Yates, drawing each
+                // swap target from the session RNG so the whole thing is reproducible
+                // under `set.seed`. The shuffle is a no-op for a length-1 run, so
+                // non-tied elements keep their natural rank.
+                let m = q - p;
+                let mut slot: Vec<usize> = order[p..q].to_vec();
+                interp.sample_with(|rng| {
+                    // Fisher–Yates: for j from m-1 down to 1, swap slot[j] with a
+                    // uniformly chosen slot[0..=j]. `next_u32() % (j+1)` is bounded
+                    // and consumes exactly one u32 per iteration (≤ n draws total).
+                    for j in (1..m).rev() {
+                        let k = (rng.next_u32() as usize) % (j + 1);
+                        slot.swap(j, k);
+                    }
+                });
+                for (offset, &orig) in slot.iter().enumerate() {
+                    ranks[orig] = lo + offset as f64;
                 }
             }
         }

--- a/code/packages/rust/s-runtime/src/lib.rs
+++ b/code/packages/rust/s-runtime/src/lib.rs
@@ -2161,4 +2161,83 @@ mod r30_ordering {
         assert_eq!(nums("anyDuplicated(c(\"a\", \"b\", \"a\"))\n"), vec![3.0]);
         assert_eq!(nums("anyDuplicated(c(\"x\", \"y\"))\n"), vec![0.0]);
     }
+
+    // --- R-31: incomparables=, unique fromLast, rank random -------------
+
+    #[test]
+    fn duplicated_incomparables_numeric() {
+        // 1 is incomparable → never a dup; the second 2 still is.
+        assert_eq!(
+            show("duplicated(c(1, 1, 2, 2), incomparables = 1)\n"),
+            "[1] FALSE FALSE FALSE  TRUE"
+        );
+        // The default FALSE means "no incomparables" — identical to plain.
+        assert_eq!(
+            show("duplicated(c(1, 1, 2, 2), incomparables = FALSE)\n"),
+            "[1] FALSE  TRUE FALSE  TRUE"
+        );
+    }
+
+    #[test]
+    fn duplicated_incomparables_character_vector() {
+        // "a" listed incomparable; "b" still dedups normally.
+        assert_eq!(
+            show("duplicated(c(\"a\", \"a\", \"b\", \"b\"), incomparables = c(\"a\"))\n"),
+            "[1] FALSE FALSE FALSE  TRUE"
+        );
+    }
+
+    #[test]
+    fn unique_incomparables_keeps_every_copy() {
+        // Both 1s kept (1 incomparable); 2 deduped → c(1, 1, 2).
+        assert_eq!(nums("unique(c(1, 1, 2, 2), incomparables = 1)\n"), vec![1.0, 1.0, 2.0]);
+    }
+
+    #[test]
+    fn unique_from_last_keeps_last_occurrence() {
+        // Default keeps first occurrence; fromLast keeps the last, in input order.
+        assert_eq!(nums("unique(c(1, 2, 1))\n"), vec![1.0, 2.0]);
+        assert_eq!(nums("unique(c(1, 2, 1), fromLast = TRUE)\n"), vec![2.0, 1.0]);
+    }
+
+    #[test]
+    fn unique_from_last_composes_with_incomparables() {
+        // 1 incomparable → kept at both its positions even scanning from last.
+        assert_eq!(
+            nums("unique(c(1, 2, 1), fromLast = TRUE, incomparables = 1)\n"),
+            vec![1.0, 2.0, 1.0]
+        );
+    }
+
+    #[test]
+    fn any_duplicated_incomparables() {
+        // Only repeat is the incomparable 1 → 0.
+        assert_eq!(nums("anyDuplicated(c(1, 2, 1), incomparables = 1)\n"), vec![0.0]);
+        // The repeated 2 at position 3 is comparable → 3.
+        assert_eq!(nums("anyDuplicated(c(1, 2, 2), incomparables = 1)\n"), vec![3.0]);
+    }
+
+    #[test]
+    fn rank_random_assigns_tied_multiset_and_reproduces() {
+        // The two 3s must receive {2, 3} (in a seed-determined order); the lone
+        // 1 always gets rank 1.
+        let a = nums("set.seed(1)\nrank(c(3, 1, 3), ties.method = \"random\")\n");
+        assert_eq!(a[1], 1.0); // the value 1 is the unique smallest
+        let mut tied = vec![a[0], a[2]];
+        tied.sort_by(|x, y| x.partial_cmp(y).unwrap());
+        assert_eq!(tied, vec![2.0, 3.0]);
+        // Same seed → identical result (reproducible).
+        let b = nums("set.seed(1)\nrank(c(3, 1, 3), ties.method = \"random\")\n");
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn rank_random_no_ties_is_a_permutation() {
+        // With no ties, "random" coincides with the plain ranks (each run is
+        // length 1, so the shuffle is a no-op).
+        assert_eq!(
+            nums("set.seed(7)\nrank(c(3, 1, 2), ties.method = \"random\")\n"),
+            vec![3.0, 1.0, 2.0]
+        );
+    }
 }

--- a/code/specs/R00-r-language.md
+++ b/code/specs/R00-r-language.md
@@ -1020,6 +1020,63 @@ unchanged.
     RNG-seed contract); and the `fromLast =` argument on the set ops. The `%o%` infix
     alias for `outer` remains open for a later grammar pass.
 
+- **R-31 — set-op & ordering refinements** *(this PR)*. The follow-up to R-30 that
+  lands the two deferrals which DO have clean, unambiguous semantics on the existing
+  `as_character`-key path, plus the RNG-backed tie method. All three are **extensions
+  of the existing R-29/R-30 handlers** in the shared `s-runtime`; no new value type
+  and no new cap are introduced.
+  - **`incomparables =` on `duplicated`, `anyDuplicated`, and `unique`.** The default
+    is `incomparables = FALSE`, meaning "there are no incomparable values" — identical
+    to the prior behaviour. A **vector** value lists the elements to treat as
+    *incomparable*: a value listed there is **never considered equal to anything**
+    (not even another copy of itself), so it is **never flagged as a duplicate** and
+    **never removed** as one. Mechanically we coerce the `incomparables` vector to the
+    same character key the builtins already use (`as_character`) and build a small
+    `HashSet` of "incomparable keys"; during the dup scan, any element whose key is in
+    that set short-circuits to "not a duplicate" and is **never inserted into the
+    `seen` set** (so it cannot suppress a later genuine duplicate either). Worked
+    examples (numeric and character keys both supported):
+    `duplicated(c(1,1,2,2), incomparables = 1)` is `c(FALSE, FALSE, FALSE, TRUE)` (the
+    1s are never dups; the second 2 still is); `unique(c(1,1,2,2), incomparables = 1)`
+    is `c(1, 1, 2)` (both 1s kept, 2 deduped); `anyDuplicated(c(1,2,1), incomparables = 1)`
+    is `0` (the only repeat is an incomparable), while `anyDuplicated(c(1,2,2),
+    incomparables = 1)` is `3`.
+  - **`unique(x, fromLast = TRUE)`.** R-30 added `fromLast =` to `duplicated`; R-31
+    extends `unique` symmetrically. With `fromLast = TRUE` the dedup keeps the **last**
+    occurrence of each distinct value (scanning right-to-left), versus the default
+    first occurrence. The kept positions are gathered in **ascending index order** so
+    the surviving elements stay in input order (R's behaviour). `incomparables =` and
+    `fromLast =` compose: an incomparable value is kept at every one of its positions
+    regardless of direction.
+  - **`rank(x, ties.method = "random")`.** A run of `m` tied values is assigned the
+    consecutive ranks `lo, lo+1, …, hi` (as in `"first"`), but the **assignment of
+    those ranks to the tied positions is a uniform random permutation** drawn from the
+    **session RNG** — the same generator seeded by `set.seed()` that the R-8
+    distribution family (`runif`/`rnorm`/…) uses (`Interpreter::sample_with`). The
+    permutation is a Fisher–Yates shuffle driven by `RngState::next_u32`, so the result
+    is **fully reproducible** under `set.seed`: `set.seed(s); rank(x, ties.method =
+    "random")` gives the same vector every run. The two 3s in `rank(c(3,1,3),
+    ties.method = "random")` receive ranks `{2, 3}` in a seed-determined order while the
+    lone 1 always gets rank 1. `"average"` remains the default; `"min"/"max"/"first"`
+    are unchanged from R-30.
+  - **Output-size caps (security).** No new user-controlled multiplier. `incomparables`
+    adds one `HashSet` whose size is bounded by the (already-`MAX_SEQ_LEN`-capped)
+    `incomparables` vector; membership tests are `O(1)`. `"random"` does a single
+    `O(m)` Fisher–Yates pass per tie run with **bounded** RNG draws (one `next_u32`
+    per swap, at most `n` total), so RNG use cannot trigger unbounded work. Named-arg
+    readers reject malformed values gracefully (`Err`, never panic): `ties.method` is
+    read as a character scalar (an unknown method is a `BadArgs` error), `fromLast =`
+    via `truthy()` (a non-logical or `NA` is an error), and `incomparables =` is
+    coerced through `as_character` (any vector is acceptable; no path indexes out of
+    bounds).
+  - **Scope outcome / deferred to R-32.** `incomparables =` on `duplicated` /
+    `anyDuplicated` / `unique`, `unique(fromLast =)`, and `rank(ties.method =
+    "random")` ship **solidly**. **Deferred to R-32:** `incomparables =` on the binary
+    set ops (`union`/`intersect`/`setdiff`) — R's semantics there interact with which
+    operand the incomparable belongs to and are ambiguous enough to warrant their own
+    pass — and the `fromLast =` argument on those same binary set ops. The `%o%` infix
+    alias for `outer` remains open for a later grammar pass.
+
 ## §4 Reuse strategy
 
 - **Lexer/parser:** the grammar-tools framework, exactly as S uses it. `r.tokens`
@@ -1052,8 +1109,10 @@ a later pass; the vector set-operation & ranking builtins (`union`, `intersect`,
 `setdiff`, `is.element`, `duplicated`, `rank`) land in **R-29**; the ordering
 refinements (multi-key `order(x, y, ...)`, `rank`'s `ties.method` =
 `average`/`min`/`max`/`first`, `duplicated(fromLast=)`, `anyDuplicated`) land in
-**R-30**, with `incomparables=` on the set ops / `duplicated`, the `fromLast=`
-set-op argument, and `rank`'s `"random"` method deferred to **R-31**; namespaces and `library()`
+**R-30**; the set-op & ordering refinements (`incomparables=` on
+`duplicated`/`anyDuplicated`/`unique`, `unique(fromLast=)`, and `rank`'s `"random"`
+tie method) land in **R-31**, with `incomparables=`/`fromLast=` on the binary set ops
+(`union`/`intersect`/`setdiff`) deferred to **R-32**; namespaces and `library()`
 (so `baseenv()` aliases the
 global env for now); the C interface; graphics. These layer on later, following
 ST00.

--- a/code/specs/S00-s-language.md
+++ b/code/specs/S00-s-language.md
@@ -290,9 +290,28 @@ needs a string assignment target: `"%between%" <- function(x, r) x >= r[1] & x <
   **`anyDuplicated(x)`** returns the 1-based index of the first duplicated element, or
   `0` if none (`anyDuplicated(c(1,2,1))` is `3`). The keyword args reuse the existing
   readers (`truthy()` for `fromLast=`, `as_character()` for `ties.method=`). Deferred
-  to **R-31**: `incomparables=` on the set ops / `duplicated` / `anyDuplicated` (needs
-  `NA`-comparison plumbing), the `fromLast=` set-op argument, and `rank`'s `"random"`
-  method (needs an RNG-seed contract).
+  to **R-31**: `incomparables=` on `duplicated` / `anyDuplicated` / `unique`,
+  `unique(fromLast=)`, and `rank`'s `"random"` method (needs an RNG-seed contract).
+- **Set-op & ordering refinements** *(R-31)*: extensions of the R-29/R-30 dedup &
+  ranking builtins (no new value type, no grammar change). **`incomparables=`** on
+  `duplicated(x, incomparables=)`, `anyDuplicated(x, incomparables=)`, and
+  `unique(x, incomparables=)`: the default `FALSE` means "no incomparables", while a
+  **vector** lists the elements to treat as *incomparable* — such a value is **never
+  equal to anything**, so it is never flagged as a duplicate and never removed as one.
+  We coerce the `incomparables` vector to the same `as_character` key and short-circuit
+  any element whose key is in that set to "not a duplicate" (and never insert it into
+  `seen`). `duplicated(c(1,1,2,2), incomparables=1)` is `c(FALSE,FALSE,FALSE,TRUE)`;
+  `unique(c(1,1,2,2), incomparables=1)` is `c(1,1,2)`; `anyDuplicated(c(1,2,1),
+  incomparables=1)` is `0`. **`unique(x, fromLast=TRUE)`** keeps the **last** occurrence
+  of each distinct value (gathered in ascending index order), mirroring R-30's
+  `duplicated(fromLast=)`. **`rank(x, ties.method="random")`** assigns a run of tied
+  values the consecutive ranks `lo..=hi` but permutes them with a Fisher–Yates shuffle
+  driven by the **session RNG** (the `set.seed`-seeded generator shared with the R-8
+  distribution family via `Interpreter::sample_with`/`RngState::next_u32`), so the
+  result is fully reproducible under `set.seed`. Numeric and character vectors are both
+  supported. Deferred to **R-32**: `incomparables=`/`fromLast=` on the binary set ops
+  (`union`/`intersect`/`setdiff`), whose R semantics are ambiguous enough to warrant
+  their own pass.
 - **Apply family:** `sapply(x, f)` / `lapply(x, f)` map a function over elements
   (`sapply` simplifies length-1 atomic results to a vector).
 


### PR DESCRIPTION
## R-31 — set-op & ordering refinements

The R-30 deferrals that have clean, unambiguous semantics on the existing
`as_character`-key path, plus the RNG-backed tie method. R reuses the shared
S tree-walker, so the work lands in `s-runtime/src/builtins.rs` (extensions of
the R-29/R-30 handlers — no new value type, no grammar change); R-syntax
integration tests live in `r-runtime`.

### Added
- **`incomparables=` on `duplicated`, `anyDuplicated`, and `unique`.** Default
  `FALSE` means "no incomparables"; a vector lists elements to treat as
  *incomparable* — never equal to anything, so never flagged/removed as a
  duplicate, and never recorded in the `seen` set (so it can't suppress a later
  genuine duplicate). Shared `incomparables_keys` reader over the same
  `as_character` key, so numeric and character incomparables both work.
  - `duplicated(c(1,1,2,2), incomparables=1)` → `c(FALSE,FALSE,FALSE,TRUE)`
  - `unique(c(1,1,2,2), incomparables=1)` → `c(1,1,2)`
  - `anyDuplicated(c(1,2,1), incomparables=1)` → `0`; `anyDuplicated(c(1,2,2), incomparables=1)` → `3`
- **`unique(x, fromLast=TRUE)`.** Keeps the *last* occurrence of each distinct
  value (right-to-left scan), gathered in ascending index order so survivors stay
  in input order. Mirrors R-30's `duplicated(fromLast=)`; composes with
  `incomparables=`.
- **`rank(x, ties.method="random")`.** A tie run gets consecutive ranks
  `lo..=hi` (like `"first"`), but assigned to tied positions in a uniform random
  order via a Fisher–Yates shuffle over the **session RNG** — the same
  `set.seed`-seeded generator the R-8 distribution family uses
  (`Interpreter::sample_with` + `RngState::next_u32`). **Fully reproducible**
  under `set.seed`. `"average"` stays default; `"min"/"max"/"first"` unchanged.

### Seed reproducibility
`set.seed(1); rank(c(3,1,3), ties.method="random")` gives the two 3s the ranks
`{2,3}` in a seed-determined order and the lone 1 rank `1`, identically on every
run. Asserted by running twice with the same seed.

### Security
Reviewed via Rust security sub-agent — **PASS, no findings**. `incomparables=`
adds one bounded `HashSet`; `"random"` draws ≤ `n` `u32`s total (no unbounded
work, no div-by-zero, no OOB); malformed `incomparables=`/`ties.method=`/`fromLast=`
values error gracefully (`Err`, never panic).

### Tests
- s-runtime: 241 tests pass (8 new R-31 cases, numeric + character + seed reproducibility)
- r-runtime: 237 tests pass (4 new R-syntax cases)

### Deferred to R-32
`incomparables=` / `fromLast=` on the binary set ops
(`union`/`intersect`/`setdiff`) — their R semantics are ambiguous enough to
warrant a separate pass (spec + CHANGELOG note included).

🤖 Generated with [Claude Code](https://claude.com/claude-code)