### PR TITLE
feat(mycin-cardio): ground the mitral-stenosis murmur edge (retire the deferral)

### DIFF
--- a/code/specs/data/mycin-2026/recall/cardio-edges.adj
+++ b/code/specs/data/mycin-2026/recall/cardio-edges.adj
@@ -29,10 +29,13 @@
 % check. (See feedback_nothing_human_authored, feedback_adj_only_shipped_artifacts.)
 %
 % Honest scope: only murmurs whose page states the association in a clean self-contained
-% span (both murmur AND lesion named) are included. Deferred — mitral stenosis: its page
-% describes the opening snap and the "low-pitched, middiastolic rumbling murmur" in
-% separate sentences, neither of which names "mitral stenosis" in the same span, so no
-% both-endpoints-named declarative defends a murmur_indicates edge yet.
+% span (both murmur AND lesion named) are included. Mitral stenosis (previously deferred —
+% its lesion-specific page splits the opening snap and the "low-pitched, middiastolic
+% rumbling murmur" across separate sentences) is now GROUNDED from the murmurs-overview page,
+% which names the lesion and its diastolic murmur in one span. Still deferred — pulmonic
+% stenosis: the overview names it as "the main murmur ... in Tetralogy of Fallot" in one
+% sentence and describes the crescendo-decrescendo ejection murmur in the next ("It is
+% described as ..."), so no single span names both the lesion and its murmur yet.
 % ============================================================================
 
 dictionary cardio_vocab {
@@ -73,5 +76,17 @@ rulebook cardio_facts {
     relate murmur_indicates(decrescendo_diastolic, aortic_regurgitation)
         source "Patients with chronic aortic insufficiency will have a widened pulse pressure, may likely have a laterally and inferiorly displaced apical impulse, a high-frequency decrescendo diastolic murmur best heard at the 3rd or 4th intercostal space at the left sternal border, Austin Flint murmur, diminished S1, soft S2."
         locator "https://www.ncbi.nlm.nih.gov/books/NBK557428/"
+        trust authoritative
+
+    % --- diastolic murmur at the apex (left 5th midclavicular line) -> mitral stenosis -----
+    % The two DIASTOLIC murmurs disambiguate by SITE, exactly as at the bedside: aortic
+    % regurgitation at the left sternal border (above) vs mitral stenosis at the apex / left
+    % 5th midclavicular line (here). The lesion-specific MS page describes the opening snap and
+    % the mid-diastolic rumble in SEPARATE sentences (neither naming "mitral stenosis" in the
+    % same span — see the deferral note above); the murmurs-overview page instead states the
+    % lesion AND its diastolic murmur in ONE self-contained span, which is what grounds this edge.
+    relate murmur_indicates(diastolic_apical, mitral_stenosis)
+        source "Mitral stenosis is a diastolic murmur, best heard at the left 5th midclavicular line."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK525958/"
         trust authoritative
 }

--- a/code/specs/data/mycin-2026/recall/cardio-recall.query.adj
+++ b/code/specs/data/mycin-2026/recall/cardio-recall.query.adj
@@ -18,3 +18,4 @@ import "cardio-edges.adj"
 ? murmur_indicates(late_systolic_click, $Lesion)               % expect mitral_valve_prolapse
 ? murmur_indicates(holosystolic_left_lower_sternal, $Lesion)   % expect tricuspid_regurgitation
 ? murmur_indicates(decrescendo_diastolic, $Lesion)             % expect aortic_regurgitation
+? murmur_indicates(diastolic_apical, $Lesion)                  % expect mitral_stenosis

--- a/code/specs/data/mycin-2026/recall/test_cardio_recall.py
+++ b/code/specs/data/mycin-2026/recall/test_cardio_recall.py
@@ -34,6 +34,7 @@ EXPECTED = {
     "late_systolic_click": "mitral_valve_prolapse",
     "holosystolic_left_lower_sternal": "tricuspid_regurgitation",
     "decrescendo_diastolic": "aortic_regurgitation",
+    "diastolic_apical": "mitral_stenosis",
 }
 REL = "murmur_indicates"
 VAR = "Lesion"
@@ -56,7 +57,7 @@ def test_library_is_pure_adj_and_fully_grounded() -> None:
     text = ADJ.read_text()
     assert "trust consensus" not in text, "CARDIO ships no authored-debt; ground or omit"
     assert "[FLAG:" not in text
-    edge_count = len(EXPECTED)  # 5
+    edge_count = len(EXPECTED)  # 6
     assert text.count("    relate ") == edge_count
     assert text.count("trust authoritative") == edge_count
     assert text.count('\n        locator "') == edge_count


### PR DESCRIPTION
## Parallel recall-stream increment — CARDIO mitral stenosis (front-1, board north star)

Adds the **sixth CARDIO auscultation edge** — `murmur_indicates(diastolic_apical, mitral_stenosis)` — previously **deferred** because the lesion-specific mitral-stenosis page splits the opening snap and the *"low-pitched, middiastolic rumbling murmur"* across separate sentences (neither naming "mitral stenosis" in the same span). The murmurs-overview page (StatPearls NBK525958) instead states the lesion **and** its diastolic murmur in one self-contained span:

> *"Mitral stenosis is a diastolic murmur, best heard at the left 5th midclavicular line."* — `trust authoritative`

The two **diastolic** murmurs disambiguate by **site**, exactly as at the bedside: aortic regurgitation at the left sternal border vs mitral stenosis at the apex (left 5th midclavicular line) — consistent with the library's existing site-based disambiguation (holosystolic apical vs lower-left-sternal).

### Changes (pure data, `recall/` only)
- `cardio-edges.adj`: + the grounded `relate` (now 6 edges); header deferral note updated (MS grounded; pulmonic stenosis still deferred — the overview splits its lesion name and murmur description across two sentences).
- `cardio-recall.query.adj`: + the worked `?` query (expect mitral_stenosis).
- `test_cardio_recall.py`: + EXPECTED entry (6 edges); the PDA negative-control (`continuous_machinery` abstains) is unaffected.

### Verified
`test_cardio_recall` **3/3** (engine binds mitral_stenosis with an authoritative citation; pure-ADJ/no-authored-debt shape check; unknown murmur still abstains). No Python logic changed.

Security review (data-only; argv subprocess + `json.loads` of trusted CLI stdout unchanged; locator never fetched): **PASSED — no vulnerabilities found**.

Conflict-free with the open treatment-constraints PRs (touches `recall/` files only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)