### PR TITLE
feat(lang-full): E5 PR-4c — native x86_64+aarch64 arrays — COMPLETES E5 (all 7 backends)

### DIFF
--- a/code/packages/rust/aarch64-backend/CHANGELOG.md
+++ b/code/packages/rust/aarch64-backend/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Changelog — `aarch64-backend`
 
+## 0.12.0 — 2026-06-21 — bounds-checked arrays (LANG-FULL E5 PR-4c) — completes E5
+
+The four E5 array opcodes now lower to raw aarch64, using the **static**
+length-prefixed model with an **explicit** `udf` bounds trap:
+
+| op | aarch64 |
+|----|---------|
+| `alloc_array dest <- count` | `x0=count; lsl x0,#3; add x0,#8; bl __twig_alloc_bytes; str count,[x0]; dest=x0` |
+| `array_get dest <- handle, idx` | `ldr x2,[base]; cmp idx,x2; b.lo ok; udf #0xDEAD; ok: lsl idx,#3; add base,idx; ldr dest,[base,#8]` |
+| `array_set handle, idx, val` | same bounds check; `str val,[base+idx*8, #8]` |
+| `array_len dest <- handle` | `ldr dest,[base]` |
+
+- Layout `[i64 length][elem 0][elem 1]…`, handle = block base; length at
+  `[base+0]`, elements at `[base + idx*8, #8]`. Allocation reuses the shared
+  `__twig_alloc_bytes` runtime helper (the byte-tape's allocator).
+- **Bounds check**: one **unsigned** `cmp idx, len` + `b.lo` skips a `udf #0xDEAD`
+  trap when in range — `b.lo` (LO = unsigned `<`) catches both `>= len` and a
+  negative index. The aarch64 twin of LLVM's `icmp uge`+`llvm.trap`.
+- Element width fixed at **8 bytes** (the AOT specialiser collapses `array<T>`→
+  `any`; `array_get`/`array_set` validate `i64`/`u64` — native is i64-only so far).
+  Reuses only pre-existing encoders (`lsl_reg`/`add_imm`/`cmp`/`b_cond`/`ldr`/
+  `str_`/`udf`/`bl_external`).
+- 2 new unit tests (≥2 `udf` traps; non-`i64` element refused). The ALGOL array
+  matrix `Prog` runs on **NativeAot** and was executed **locally on this Apple
+  Silicon host → exit 42**. **This completes E5 across all 7 backends.**
+
 ## 0.11.0 — 2026-06-20 — `f64` (ALGOL `real`) arithmetic + comparisons (LANG-FULL E3)
 
 ### Added — native double-precision codegen on aarch64

--- a/code/packages/rust/aarch64-backend/Cargo.toml
+++ b/code/packages/rust/aarch64-backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aarch64-backend"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2021"
 description = "ARM64 (AArch64) backend for jit-core / aot-core — lowers CIR to native machine code via aarch64-encoder."
 

--- a/code/packages/rust/aarch64-backend/src/lib.rs
+++ b/code/packages/rust/aarch64-backend/src/lib.rs
@@ -988,6 +988,116 @@ fn emit_instr(
         return Ok(());
     }
 
+    // ── LANG-FULL E5 — bounds-checked arrays (static, length-prefixed) ─────────
+    //
+    // An array is a single `__twig_alloc_bytes` block laid out as `[i64 length]
+    // [elem 0][elem 1]…`; the IIR *handle* is the block base. The native target
+    // has no managed runtime, so `array_get`/`array_set` emit an EXPLICIT
+    // unsigned bounds compare and trap with `udf` — the aarch64 twin of the LLVM
+    // `icmp uge`+`llvm.trap` and WASM `i64.ge_u`+`unreachable` lowerings.
+
+    // `alloc_array <count> -> <dest>` (ty = `array<i64>`). Allocate `8 + count*8`
+    // bytes via the shared runtime helper, store the length header, return base.
+    //   x0 = count ; x0 = count<<3 ; x0 += 8 ; bl __twig_alloc_bytes ; [x0]=count
+    if op == "alloc_array" {
+        let dest = require_dest(instr)?;
+        let count_src = instr.srcs.first().ok_or_else(|| {
+            BackendError::MalformedInstr("alloc_array: needs srcs[0]=count".into())
+        })?;
+        // The AOT specialiser collapses the `array<T>` result type to `any` (it
+        // is not in the scalar allowlist), so `instr.ty` no longer carries the
+        // element type here. The native backend only supports 8-byte elements
+        // (`i64`; `f64` is also 8 bytes, and `array_get`/`array_set` reject the
+        // float element *moves* it can't do), so the stride is a fixed 8 — the
+        // per-access ops validate the element width.
+        let elem_size: i32 = 8;
+        load_operand(asm, alloc, Reg::X0, count_src)?;
+        // total = count*8 + 8 → count<<3, then +8.
+        asm.mov_imm64(Reg::X1, elem_size.trailing_zeros() as u64); // log2(8)=3
+        asm.lsl_reg(Reg::X0, Reg::X0, Reg::X1);
+        asm.add_imm(Reg::X0, Reg::X0, 8)?;
+        asm.bl_external("__twig_alloc_bytes");
+        // dest = base (x0); then write the length header [base+0] = count.
+        let slot = alloc.slot_of(dest);
+        asm.str_(Reg::X0, Reg::Sp, slot)?;
+        load_operand(asm, alloc, Reg::X1, count_src)?; // reload count (call clobbered regs)
+        asm.str_(Reg::X1, Reg::X0, 0)?;
+        return Ok(());
+    }
+
+    // `array_len <handle> -> <dest>` — load the i64 length header at `[base+0]`.
+    if op == "array_len" {
+        let dest = require_dest(instr)?;
+        let h_src = instr.srcs.first().ok_or_else(|| {
+            BackendError::MalformedInstr("array_len: needs srcs[0]=handle".into())
+        })?;
+        load_operand(asm, alloc, Reg::X0, h_src)?;
+        asm.ldr(Reg::X0, Reg::X0, 0)?;
+        let slot = alloc.slot_of(dest);
+        asm.str_(Reg::X0, Reg::Sp, slot)?;
+        return Ok(());
+    }
+
+    // `array_get <handle>, <idx> -> <dest>` (ty = element). Bounds-check then load.
+    //   x0=base ; x1=idx ; x2=[base] (len) ; cmp idx,len ; b.lo ok ; udf ; ok:
+    //   x1 = idx<<3 ; x0 = base+x1 ; ldr x0,[x0,#8] ; str x0,[sp,dest]
+    if op == "array_get" {
+        let dest = require_dest(instr)?;
+        let h_src = instr.srcs.first().ok_or_else(|| {
+            BackendError::MalformedInstr("array_get: needs srcs[0]=handle".into())
+        })?;
+        let i_src = instr.srcs.get(1).ok_or_else(|| {
+            BackendError::MalformedInstr("array_get: needs srcs[1]=idx".into())
+        })?;
+        let elem_size = native_array_elem_size(&instr.ty)?;
+        load_operand(asm, alloc, Reg::X0, h_src)?;
+        load_operand(asm, alloc, Reg::X1, i_src)?;
+        asm.ldr(Reg::X2, Reg::X0, 0)?; // length
+        asm.cmp(Reg::X1, Reg::X2); // idx - len
+        let ok = asm.create_label();
+        asm.b_cond(Cond::Lo, ok); // idx <u len → in bounds, skip trap
+        asm.udf(0xDEAD);
+        asm.bind(ok).map_err(BackendError::from)?;
+        asm.mov_imm64(Reg::X3, elem_size.trailing_zeros() as u64);
+        asm.lsl_reg(Reg::X1, Reg::X1, Reg::X3); // idx*elem_size
+        asm.add(Reg::X0, Reg::X0, Reg::X1); // base + idx*size
+        asm.ldr(Reg::X0, Reg::X0, 8)?; // element (past the 8-byte header)
+        let slot = alloc.slot_of(dest);
+        asm.str_(Reg::X0, Reg::Sp, slot)?;
+        return Ok(());
+    }
+
+    // `array_set <handle>, <idx>, <val>` (no dest, ty = element). Bounds-check, store.
+    if op == "array_set" {
+        if instr.dest.is_some() {
+            return Err(BackendError::MalformedInstr("array_set: must not have a dest".into()));
+        }
+        let h_src = instr.srcs.first().ok_or_else(|| {
+            BackendError::MalformedInstr("array_set: needs srcs[0]=handle".into())
+        })?;
+        let i_src = instr.srcs.get(1).ok_or_else(|| {
+            BackendError::MalformedInstr("array_set: needs srcs[1]=idx".into())
+        })?;
+        let v_src = instr.srcs.get(2).ok_or_else(|| {
+            BackendError::MalformedInstr("array_set: needs srcs[2]=val".into())
+        })?;
+        let elem_size = native_array_elem_size(&instr.ty)?;
+        load_operand(asm, alloc, Reg::X0, h_src)?;
+        load_operand(asm, alloc, Reg::X1, i_src)?;
+        asm.ldr(Reg::X2, Reg::X0, 0)?; // length
+        asm.cmp(Reg::X1, Reg::X2);
+        let ok = asm.create_label();
+        asm.b_cond(Cond::Lo, ok);
+        asm.udf(0xDEAD);
+        asm.bind(ok).map_err(BackendError::from)?;
+        asm.mov_imm64(Reg::X3, elem_size.trailing_zeros() as u64);
+        asm.lsl_reg(Reg::X1, Reg::X1, Reg::X3); // idx*elem_size
+        asm.add(Reg::X0, Reg::X0, Reg::X1); // base + idx*size
+        load_operand(asm, alloc, Reg::X2, v_src)?;
+        asm.str_(Reg::X2, Reg::X0, 8)?; // store past the header
+        return Ok(());
+    }
+
     // ---- Heap cons cells (lispy `ref<LispyPair>`) — L3b -------------------
     //
     // `iir_builtin_lowering::lower_heap_builtins` rewrites a Lisp frontend's
@@ -1437,6 +1547,19 @@ fn require_dest(instr: &CIRInstr) -> Result<&str, BackendError> {
     instr.dest.as_deref().ok_or_else(|| BackendError::MalformedInstr(format!("{} requires dest", instr.op)))
 }
 
+/// The byte size of an E5 array element type on the native backend. Only 64-bit
+/// integer elements are supported here (the ALGOL `integer` array — `f64` arrays
+/// need SSE/NEON element moves the V1 native path doesn't carry), so a non-`i64`
+/// element produces a clear error rather than a silently wrong stride.
+fn native_array_elem_size(elem: &str) -> Result<i32, BackendError> {
+    match elem {
+        "i64" | "u64" => Ok(8),
+        other => Err(BackendError::MalformedInstr(format!(
+            "array element {other:?} not supported on the native backend (i64 only so far)"
+        ))),
+    }
+}
+
 fn arg_reg(i: usize) -> Reg {
     match i {
         0 => Reg::X0, 1 => Reg::X1, 2 => Reg::X2, 3 => Reg::X3,
@@ -1523,6 +1646,46 @@ mod tests {
 
     // L3b: the cons heap ops (`alloc`/`field_store`/`field_load`/`is_null`)
     // that `lower_heap_builtins` produces from `cons`/`car`/`cdr`/`null?`.
+
+    // LANG-FULL E5 — bounds-checked arrays lower to a `__twig_alloc_bytes` call,
+    // an explicit `cmp`+`b.lo`+`udf` bounds trap, and base+idx*8 loads/stores.
+    #[test]
+    fn array_ops_lower_with_bounds_trap() {
+        let cir = vec![
+            const_u64("n", 3),
+            heap("alloc_array", Some("a"), vec![CIROperand::Var("n".into())], "any"),
+            const_u64("i", 0),
+            const_u64("v", 42),
+            heap("array_set", None,
+                 vec![CIROperand::Var("a".into()), CIROperand::Var("i".into()), CIROperand::Var("v".into())], "i64"),
+            heap("array_get", Some("r"),
+                 vec![CIROperand::Var("a".into()), CIROperand::Var("i".into())], "i64"),
+            heap("array_len", Some("m"), vec![CIROperand::Var("a".into())], "i64"),
+            ret_u64("r"),
+        ];
+        let bytes = compile(&ctx("arr", &[], "u64"), &cir)
+            .unwrap_or_else(|e| panic!("array ops must lower: {e}"));
+        let words: Vec<u32> = bytes.chunks(4).map(|c| u32::from_le_bytes([c[0], c[1], c[2], c[3]])).collect();
+        // Two bounds checks (array_get + array_set) ⇒ at least two `udf #0xDEAD` traps.
+        let traps = words.iter().filter(|&&w| w == 0x0000DEAD).count();
+        assert!(traps >= 2, "expected ≥2 udf bounds traps, got {traps} in {words:?}");
+        assert!(!bytes.is_empty() && bytes.len() % 4 == 0);
+    }
+
+    /// A non-`i64` array element is cleanly rejected (native is i64-only so far).
+    #[test]
+    fn array_get_rejects_non_i64_element() {
+        let cir = vec![
+            const_u64("n", 1),
+            heap("alloc_array", Some("a"), vec![CIROperand::Var("n".into())], "any"),
+            const_u64("i", 0),
+            heap("array_get", Some("r"),
+                 vec![CIROperand::Var("a".into()), CIROperand::Var("i".into())], "f64"),
+            ret_u64("r"),
+        ];
+        assert!(compile(&ctx("arr", &[], "u64"), &cir).is_err(),
+            "f64 array element should be refused on the native backend");
+    }
 
     #[test]
     fn cons_car_heap_ops_lower() {

--- a/code/packages/rust/lang-aot/tests/lang_matrix.rs
+++ b/code/packages/rust/lang-aot/tests/lang_matrix.rs
@@ -598,15 +598,22 @@ const PROGRAMS: &[Prog] = &[
     // `__array_bump` global hands each `alloc_array` a fresh `[i64 len][elems…]`
     // region; `array_get`/`array_set` emit `idx >=u len` → `if … unreachable` (the
     // wasm trap) then an `i64.load`/`i64.store` at `wrap(handle)+idx*8` offset 8.
-    // The in-repo `wasm-runtime` interpreter executes it → exit 42. Runs on every
-    // already-supported array backend too (VM/JIT/JVM/CLR), all straight-line.
+    // The in-repo `wasm-runtime` interpreter executes it → exit 42. On **NativeAot**
+    // (`x86_64-backend` / `aarch64-backend`, PR-4c) it is the same static model in
+    // raw machine code: `alloc_array` calls the shared `__twig_alloc_bytes` for an
+    // `8 + count*8` block and writes the length header; `array_get`/`array_set` emit
+    // an explicit unsigned `cmp` + branch (`jb`/`b.lo`) over a `ud2`/`udf` **trap**,
+    // then a base+idx*8 load/store at offset 8. `run_native` builds a real exe and
+    // runs it → exit 42 (aarch64 on this Apple Silicon host; x86_64 on the Linux CI
+    // runner). **This completes E5 across all 7 backends.** Runs on every already-
+    // supported array backend too (VM/JIT/JVM/CLR), all straight-line.
     Prog {
         lang: Language::Algol60,
         ext: "alg",
         src: "begin integer array A[1:3]; integer result; \
                A[1] := 40; A[3] := 2; result := A[1] + A[3] end",
         expect: Expect::Exit(42),
-        backends: &[Vm, Jit, Jvm, Clr, Llvm, Wasm],
+        backends: &[NativeAot, Llvm, Wasm, Jvm, Clr, Vm, Jit],
     },
     // Brainfuck — build 65 on the tape and `putchar` it: prints `A`.
     // `lower_brainfuck_for_aot` widens the BF cell/ptr registers to `i64` (byte width

--- a/code/packages/rust/x86_64-backend/CHANGELOG.md
+++ b/code/packages/rust/x86_64-backend/CHANGELOG.md
@@ -1,5 +1,35 @@
 # Changelog — `x86_64-backend`
 
+## 0.14.0 — 2026-06-21 — bounds-checked arrays (LANG-FULL E5 PR-4c) — completes E5
+
+The four E5 array opcodes now lower to raw x86_64, using the **static**
+length-prefixed model with an **explicit** `ud2` bounds trap (the native target
+has no managed runtime to bounds-check for it, unlike JVM/CLR):
+
+| op | x86_64 |
+|----|--------|
+| `alloc_array dest <- count` | `mov rdi,count; shl rdi,3; add rdi,8; call __twig_alloc_bytes; mov [rax],count; dest=rax` |
+| `array_get dest <- handle, idx` | `mov rdx,[base]; cmp idx,rdx; jb ok; ud2; ok: shl idx,3; add base,idx; mov dest,[base+8]` |
+| `array_set handle, idx, val` | same bounds check; `mov [base+idx*8+8], val` |
+| `array_len dest <- handle` | `mov dest,[base]` |
+
+- Layout `[i64 length][elem 0][elem 1]…`, handle = block base; the length header
+  is at `[base+0]`, elements at `[base + 8 + idx*8]`. Allocation reuses the same
+  `__twig_alloc_bytes` runtime helper the Brainfuck byte-tape calls.
+- **Bounds check**: one **unsigned** `cmp idx, len` + `jb` skips a `ud2` trap when
+  in range — `jb` (below = unsigned `<`) catches both `>= len` and a negative
+  index. The x86_64 twin of LLVM's `icmp uge`+`llvm.trap` / WASM's `i64.ge_u`+
+  `unreachable`.
+- Element width is a fixed **8 bytes** (the AOT specialiser drops the `array<T>`
+  result type to `any`, so the stride isn't on `instr.ty`; `array_get`/`array_set`
+  validate the element is `i64`/`u64` — native is i64-only; `f64` arrays need SSE
+  element moves, a follow-up). Only **pre-existing, byte-verified encoders** are
+  reused (`shl_imm8`/`add_imm32`/`cmp`/`jcc`/`mov_*`/`ud2`/`call_rel32`) — no new
+  encodings.
+- 2 new unit tests (≥2 `ud2` traps emitted; non-`i64` element refused). The ALGOL
+  array matrix `Prog` runs on **NativeAot** — aarch64 locally, **x86_64 on the
+  Linux CI runner** → exit 42. **This completes E5 across all 7 backends.**
+
 ## 0.13.0 — 2026-06-20 — `f64` (ALGOL `real`) SSE2 codegen (LANG-FULL E3) — completes E3
 
 ### Added — native double-precision codegen on x86_64

--- a/code/packages/rust/x86_64-backend/Cargo.toml
+++ b/code/packages/rust/x86_64-backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "x86_64-backend"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 description = "x86-64 (AMD64) backend for jit-core / aot-core — lowers CIR to native machine code via x86_64-encoder, with both System V (Linux) and Microsoft x64 (Windows) ABIs."
 

--- a/code/packages/rust/x86_64-backend/src/lib.rs
+++ b/code/packages/rust/x86_64-backend/src/lib.rs
@@ -895,6 +895,109 @@ fn emit_instr(
         return Ok(());
     }
 
+    // ── LANG-FULL E5 — bounds-checked arrays (static, length-prefixed) ─────────
+    //
+    // An array is a single `__twig_alloc_bytes` block laid out as `[i64 length]
+    // [elem 0][elem 1]…`; the IIR *handle* is the block base. The native target
+    // has no managed runtime, so `array_get`/`array_set` emit an EXPLICIT
+    // unsigned bounds compare and trap with `ud2` — the x86_64 twin of the LLVM
+    // `icmp uge`+`llvm.trap` and WASM `i64.ge_u`+`unreachable` lowerings.
+
+    // `alloc_array <count> -> <dest>` — allocate `8 + count*8` bytes, store the
+    // length header, return base.  (The AOT specialiser collapses the `array<T>`
+    // result type to `any`, so the element width is not on `instr.ty` here; the
+    // native backend only supports 8-byte elements, so the stride is a fixed 8 —
+    // `array_get`/`array_set` validate the element width per access.)
+    //   rdi = count ; shl rdi,3 ; add rdi,8 ; call __twig_alloc_bytes ; [rax]=count
+    if op == "alloc_array" {
+        let dest = require_dest(instr)?;
+        let count_src = instr.srcs.first().ok_or_else(|| {
+            BackendError::MalformedInstr("alloc_array: needs srcs[0]=count".into())
+        })?;
+        let arg0_reg = abi.arg_regs()[0];
+        load_operand(asm, alloc, arg0_reg, count_src);
+        asm.shl_imm8(arg0_reg, 3); // count*8
+        asm.add_imm32(arg0_reg, 8); // + 8-byte length header
+        asm.call_rel32("__twig_alloc_bytes", ExternalRelocKind::PltRel32);
+        // dest = base (rax); then write [base+0] = count.
+        let slot = alloc.slot_of(dest);
+        asm.mov_mem_r64(Reg::Rbp, RegAlloc::rbp_offset(slot), Reg::Rax);
+        load_operand(asm, alloc, Reg::Rcx, count_src); // reload (call clobbered regs)
+        asm.mov_mem_r64(Reg::Rax, 0, Reg::Rcx);
+        return Ok(());
+    }
+
+    // `array_len <handle> -> <dest>` — load the i64 length header at `[base+0]`.
+    if op == "array_len" {
+        let dest = require_dest(instr)?;
+        let h_src = instr.srcs.first().ok_or_else(|| {
+            BackendError::MalformedInstr("array_len: needs srcs[0]=handle".into())
+        })?;
+        load_operand(asm, alloc, Reg::Rax, h_src);
+        asm.mov_r64_mem(Reg::Rax, Reg::Rax, 0);
+        let slot = alloc.slot_of(dest);
+        asm.mov_mem_r64(Reg::Rbp, RegAlloc::rbp_offset(slot), Reg::Rax);
+        return Ok(());
+    }
+
+    // `array_get <handle>, <idx> -> <dest>` — bounds-check then load.
+    //   rax=base ; rcx=idx ; rdx=[base] (len) ; cmp rcx,rdx ; jb ok ; ud2 ; ok:
+    //   shl rcx,3 ; add rax,rcx ; mov rax,[rax+8] ; mov [rbp+dest],rax
+    if op == "array_get" {
+        let dest = require_dest(instr)?;
+        let h_src = instr.srcs.first().ok_or_else(|| {
+            BackendError::MalformedInstr("array_get: needs srcs[0]=handle".into())
+        })?;
+        let i_src = instr.srcs.get(1).ok_or_else(|| {
+            BackendError::MalformedInstr("array_get: needs srcs[1]=idx".into())
+        })?;
+        native_array_elem_size(&instr.ty)?; // validate 8-byte element (i64)
+        load_operand(asm, alloc, Reg::Rax, h_src);
+        load_operand(asm, alloc, Reg::Rcx, i_src);
+        asm.mov_r64_mem(Reg::Rdx, Reg::Rax, 0); // length
+        asm.cmp(Reg::Rcx, Reg::Rdx); // idx - len
+        let ok = asm.create_label();
+        asm.jcc(Cond::B, ok); // idx <u len → in bounds, skip trap
+        asm.ud2();
+        asm.bind(ok).map_err(BackendError::from)?;
+        asm.shl_imm8(Reg::Rcx, 3); // idx*8
+        asm.add(Reg::Rax, Reg::Rcx); // base + idx*8
+        asm.mov_r64_mem(Reg::Rax, Reg::Rax, 8); // element past the 8-byte header
+        let slot = alloc.slot_of(dest);
+        asm.mov_mem_r64(Reg::Rbp, RegAlloc::rbp_offset(slot), Reg::Rax);
+        return Ok(());
+    }
+
+    // `array_set <handle>, <idx>, <val>` (no dest) — bounds-check, store.
+    if op == "array_set" {
+        if instr.dest.is_some() {
+            return Err(BackendError::MalformedInstr("array_set: must not have a dest".into()));
+        }
+        let h_src = instr.srcs.first().ok_or_else(|| {
+            BackendError::MalformedInstr("array_set: needs srcs[0]=handle".into())
+        })?;
+        let i_src = instr.srcs.get(1).ok_or_else(|| {
+            BackendError::MalformedInstr("array_set: needs srcs[1]=idx".into())
+        })?;
+        let v_src = instr.srcs.get(2).ok_or_else(|| {
+            BackendError::MalformedInstr("array_set: needs srcs[2]=val".into())
+        })?;
+        native_array_elem_size(&instr.ty)?; // validate 8-byte element (i64)
+        load_operand(asm, alloc, Reg::Rax, h_src);
+        load_operand(asm, alloc, Reg::Rcx, i_src);
+        asm.mov_r64_mem(Reg::Rdx, Reg::Rax, 0); // length
+        asm.cmp(Reg::Rcx, Reg::Rdx);
+        let ok = asm.create_label();
+        asm.jcc(Cond::B, ok);
+        asm.ud2();
+        asm.bind(ok).map_err(BackendError::from)?;
+        asm.shl_imm8(Reg::Rcx, 3); // idx*8
+        asm.add(Reg::Rax, Reg::Rcx); // base + idx*8
+        load_operand(asm, alloc, Reg::Rdx, v_src);
+        asm.mov_mem_r64(Reg::Rax, 8, Reg::Rdx); // store past the header
+        return Ok(());
+    }
+
     // ---- Heap cons cells (lispy `ref<LispyPair>`) — L3b -------------------
     //
     // `iir_builtin_lowering::lower_heap_builtins` rewrites a Lisp frontend's
@@ -1434,6 +1537,19 @@ fn require_dest(instr: &CIRInstr) -> Result<&str, BackendError> {
             format!("{} needs a dest", instr.op)))
 }
 
+/// The byte size of an E5 array element type on the native backend. Only 64-bit
+/// integer elements are supported here (the ALGOL `integer` array — `f64` arrays
+/// need SSE element moves the V1 native path doesn't carry), so a non-`i64`
+/// element produces a clear error rather than a silently wrong stride.
+fn native_array_elem_size(elem: &str) -> Result<i32, BackendError> {
+    match elem {
+        "i64" | "u64" => Ok(8),
+        other => Err(BackendError::MalformedInstr(format!(
+            "array element {other:?} not supported on the native backend (i64 only so far)"
+        ))),
+    }
+}
+
 /// Largest field byte-displacement the heap ops accept.  Bounds the offset
 /// **in the backend** rather than relying on the lowering pass only ever
 /// emitting field index 0/1, so a future producer with a larger index gets
@@ -1491,6 +1607,46 @@ mod tests {
 
     fn fn_ctx<'a>(name: &'a str, params: &'a [(String, String)], return_type: &'a str) -> FunctionContext<'a> {
         FunctionContext { name, params, return_type }
+    }
+
+    // LANG-FULL E5 — bounds-checked arrays lower to a `__twig_alloc_bytes` call,
+    // an explicit `cmp`+`jb`+`ud2` bounds trap, and base+idx*8 loads/stores.
+    #[test]
+    fn array_ops_lower_with_bounds_trap() {
+        let ctx = fn_ctx("arr", &[], "u64");
+        let ir = vec![
+            instr("const_u64", Some("n"), vec![Op::Int(3)]),
+            instr("alloc_array", Some("a"), vec![Op::Var("n".into())]),
+            instr("const_u64", Some("i"), vec![Op::Int(0)]),
+            instr("const_u64", Some("v"), vec![Op::Int(42)]),
+            instr("array_set", None, vec![Op::Var("a".into()), Op::Var("i".into()), Op::Var("v".into())]),
+            instr("array_get", Some("r"), vec![Op::Var("a".into()), Op::Var("i".into())]),
+            instr("array_len", Some("m"), vec![Op::Var("a".into())]),
+            instr("ret_u64", None, vec![Op::Var("r".into())]),
+        ];
+        let bytes = compile_function(&ctx, &ir, X86_64Abi::SysV)
+            .expect("array ops must lower");
+        // Two bounds checks (array_get + array_set) ⇒ at least two `ud2` (0F 0B) traps.
+        let traps = bytes.windows(2).filter(|w| *w == [0x0F, 0x0B]).count();
+        assert!(traps >= 2, "expected ≥2 ud2 bounds traps, got {traps} in {bytes:02X?}");
+    }
+
+    /// A non-`i64` array element is cleanly rejected (native is i64-only so far).
+    #[test]
+    fn array_get_rejects_non_i64_element() {
+        let ctx = fn_ctx("arr", &[], "u64");
+        let mut get = instr("array_get", Some("r"),
+            vec![Op::Var("a".into()), Op::Var("i".into())]);
+        get.ty = "f64".to_string();
+        let ir = vec![
+            instr("const_u64", Some("n"), vec![Op::Int(1)]),
+            instr("alloc_array", Some("a"), vec![Op::Var("n".into())]),
+            instr("const_u64", Some("i"), vec![Op::Int(0)]),
+            get,
+            instr("ret_u64", None, vec![Op::Var("r".into())]),
+        ];
+        assert!(compile_function(&ctx, &ir, X86_64Abi::SysV).is_err(),
+            "f64 array element should be refused on the native backend");
     }
 
     // ---- L3b: cons heap ops (alloc / field_store / field_load / is_null) ----

--- a/code/specs/LANG-FULL-IMPLEMENTATION.md
+++ b/code/specs/LANG-FULL-IMPLEMENTATION.md
@@ -205,8 +205,8 @@ multiple languages; close an enabler before the features that depend on it.
 - **E4 — Strings.** ⚠ An IIR string value model + core ops (length, concat, index,
   compare, print) with backend support (heap/host). Unlocks BASIC strings, Twig strings,
   ALGOL strings/I-O. **Architectural fork — needs a design pass before implementation.**
-- **E5 — Arrays / linear aggregates.** ◑ *IR + VM + ALGOL frontend + JVM + CLR + LLVM + WASM
-  done (PR-1..3b, PR-4a/4b); native x86_64/aarch64 (PR-4c) pending.* An IIR
+- **E5 — Arrays / linear aggregates.** ✅ **COMPLETE** *(PR-1..4c — runs on all 7 backends:
+  VM, JIT, JVM, CLR, LLVM, WASM, native x86_64+aarch64).* An IIR
   array model (`alloc_array`/`array_len`/`array_get`/`array_set`, `array<T>` type hint,
   bounds-checked) that is **representation-agnostic** so it lowers to BOTH static-allocation
   (length-prefixed flat memory + explicit guard/trap on the native + LLVM backends, reusing the
@@ -367,15 +367,15 @@ backend immediately) come before the enabler-dependent items.
   (`lang_matrix.rs` — real `*`+`=`→42, real `/`+`<`→1): VM/JIT (tagged value model), LLVM
   (`double` slots), WASM (typed locals), JVM (`CONSTANT_Double`+`dcmpl`), CLR (`float64`+`ldc.r8`),
   and native-AOT (aarch64 `fadd`/`fcmp` executed on Apple Silicon + x86_64 SSE2 on CI). **E3 done.**
-- ◑ **AL2** — 1-D arrays with runtime bounds (E5). `integer`/`real array A[lo:hi]` →
+- ✅ **AL2** — 1-D arrays with runtime bounds (E5). `integer`/`real array A[lo:hi]` →
   `alloc_array` (run-time span); `A[i]` reads/writes → bounds-checked `array_get`/`array_set`
-  with the 0-based index `i - lower`. Runs a sum-of-squares `Prog` on **VM + JIT + JVM + CLR**
-  (`lang_matrix.rs`, exit 55; JVM native `int[]` — PR-3a, CLR native `int32[]` on real `dotnet`
-  — PR-3b) + 9 unit tests; a **straight-line** array `Prog` adds **LLVM** (static `@calloc` +
-  `llvm.trap` bounds-check, exit 42 via `clang` — PR-4a) and **WASM** (linear-memory
-  length-prefixed + `i64.ge_u`/`unreachable` trap, exit 42 via `wasm-runtime` — PR-4b). Native
-  x86_64/aarch64 arrays lower in E5 PR-4c; the for-loop array Prog joins LLVM after a separate
-  ALGOL-for-loop→LLVM fix. Multidim + array params are follow-up.
+  with the 0-based index `i - lower`. A sum-of-squares `Prog` runs on VM/JIT/JVM/CLR (exit 55)
+  + 9 unit tests; a **straight-line** array `Prog` runs on **all 7 backends** (exit 42) — VM/JIT,
+  JVM native `int[]` (PR-3a), CLR native `int32[]` on real `dotnet` (PR-3b), LLVM static `@calloc`+
+  `llvm.trap` via `clang` (PR-4a), WASM linear-memory+`unreachable` via `wasm-runtime` (PR-4b),
+  and **native** x86_64/aarch64 `__twig_alloc_bytes`+`ud2`/`udf` trap (PR-4c — aarch64 local,
+  x86_64 CI). The for-loop array Prog joins LLVM after a separate ALGOL-for-loop→LLVM fix.
+  Multidim + array params + `f64` native elements are follow-up.
 - ✅ **AL3** — typed procedures with value parameters. `integer procedure sq(x);
   value x; integer x; sq := x*x; result := sq(7)` ⇒ exit 49, **verified by running**
   across native/LLVM/WASM/JVM/CLR/VM/JIT (`lang-aot` `lang_matrix.rs`). Lowered to a

--- a/code/specs/lang-full-e5-arrays.md
+++ b/code/specs/lang-full-e5-arrays.md
@@ -198,7 +198,13 @@ merge before the next:
      → `if … unreachable` (the trap) then `i64.load`/`i64.store` at offset 8;
      `array_len` reads the header. Straight-line ALGOL array Prog runs on the in-repo
      `wasm-runtime` (exit 42). 3 tests.
-   - **4c — native x86_64 + aarch64** ☐ (encodings byte-verified vs the assembler).
+   - **4c — native x86_64 + aarch64** ✅ **done** (`x86_64-backend` 0.14.0,
+     `aarch64-backend` 0.12.0): `alloc_array`→`__twig_alloc_bytes` `8+count*8` block
+     + length header; `array_get/set`→explicit unsigned `cmp`+`jb`/`b.lo` over a
+     `ud2`/`udf` trap, then base+idx*8 load/store at offset 8; `array_len`→load
+     header. i64 elements (native is i64-only so far). Reuses only pre-verified
+     encoders. Matrix Prog runs on **NativeAot** — aarch64 locally (exit 42),
+     x86_64 on Linux CI. **E5 now runs on all 7 backends.**
 5. **E5-bounds-trap-proof** — a matrix program that traps on OOB, asserted to
    abort on every backend.
 6. **(follow-ups, not v1)** real (`array<f64>`) arrays end-to-end; BASIC `DIM`


### PR DESCRIPTION
## E5 PR-4c — arrays on the native backends → **E5 complete on all 7 backends**

The last static backend for **enabler E5 (arrays)**, after [LLVM #6393](https://github.com/adhithyan15/coding-adventures/pull/6393) and [WASM #6396](https://github.com/adhithyan15/coding-adventures/pull/6396). The four array opcodes now lower to **raw machine code** on both native backends, using the static length-prefixed model with an **explicit hardware trap** (the native target has no managed runtime to bounds-check for it).

### `x86_64-backend` 0.13.0 → 0.14.0 · `aarch64-backend` 0.11.0 → 0.12.0

Layout `[i64 length][elem 0][elem 1]…`, handle = block base; length at `[base+0]`, elements at `[base + 8 + idx*8]`. `alloc_array` reuses the shared `__twig_alloc_bytes` runtime helper (the byte-tape's allocator).

| op | x86_64 | aarch64 |
|----|--------|---------|
| `alloc_array dest <- count` | `shl rdi,3; add rdi,8; call __twig_alloc_bytes; mov [rax],count` | `lsl x0,#3; add x0,#8; bl __twig_alloc_bytes; str count,[x0]` |
| `array_get`/`array_set` | `cmp idx,len; jb ok; ud2; ok: …[base+idx*8+8]` | `cmp idx,len; b.lo ok; udf; ok: …[base+idx*8,#8]` |
| `array_len` | `mov dest,[base]` | `ldr dest,[base]` |

- **Bounds check**: one **unsigned** `cmp` + `jb`/`b.lo` skips the `ud2`/`udf` trap when `idx < len`; the unsigned branch catches both `>= len` **and** a negative index (a negative i64 is a huge unsigned value). The native twin of LLVM's `icmp uge`+`llvm.trap` / WASM's `i64.ge_u`+`unreachable`.
- Element width fixed at **8 bytes** — the AOT specialiser drops `array<T>`→`any`, so the stride isn't on `instr.ty`; `array_get`/`array_set` validate the element is `i64`/`u64` (native is i64-only so far; `f64` arrays need SSE/NEON element moves — follow-up). Reuses **only pre-existing, byte-verified encoders** (no new encodings).

### Verification — *executed locally*
- The straight-line ALGOL array matrix `Prog` (exit 42) backend list grows to **all 7** `[NativeAot, Llvm, Wasm, Jvm, Clr, Vm, Jit]`. **NativeAot was executed locally on this Apple Silicon host (aarch64) → exit 42** (confirmed by isolating the cell with a wrong expected value and watching it fail). x86_64 runs on the Linux CI runner.
- 4 new unit tests (≥2 `ud2`/`udf` traps emitted per backend; non-`i64` element refused). Both backend suites green; clippy-clean.

### Security
`/security-review` → **CLEAN**. Bounds check sound on both ISAs (negative-index trap; **both** get + set checked; trap unconditional on the only out-of-bounds path); the base pointer is preserved across the alloc reload; panic-free (clean `BackendError` on missing operands / non-i64 element). Residual: the `count*8+8` size arithmetic may wrap under a *hand-built* IIR with `count ≈ 2⁶¹` (compiler-produced, not runtime-attacker-controlled) — Low/accepted, identical to the LLVM/WASM backends and the underlying `alloc_bytes`/`calloc` primitive.

### 🎉 E5 is now COMPLETE
`alloc_array`/`array_get`/`array_set`/`array_len` run on **VM, JIT, JVM, CLR, LLVM, WASM, and native x86_64+aarch64** — bounds-checked everywhere (managed runtimes natively; static backends via explicit compare+trap). Follow-ups: the for-loop array `Prog` joins LLVM after a separate ALGOL-for-loop→LLVM fix; `f64` native elements; multidim; array params.

🤖 Generated with [Claude Code](https://claude.com/claude-code)