### PR TITLE
feat(mycin-neuro): ground caudate→Huntington localization edge

### DIFF
--- a/code/specs/data/mycin-2026/recall/neuro-edges.adj
+++ b/code/specs/data/mycin-2026/recall/neuro-edges.adj
@@ -72,4 +72,14 @@ rulebook neuro_facts {
         source "Damage to the subthalamic nucleus can result in a disorder of movement called hemiballismus."
         locator "https://www.ncbi.nlm.nih.gov/books/NBK559002/"
         trust authoritative
+
+    % --- caudate nucleus (striatal) atrophy -> Huntington disease -------------
+    % Parallels the substantia-nigra -> Parkinson edge: the disease is characterized by
+    % degeneration at the named site. The HD page states the lesion site AND the disease in
+    % one self-contained span (its other pathophysiology sentences mention the caudate and HD
+    % separately, so this declarative is the clean both-endpoints source).
+    relate lesion_causes(caudate_nucleus, huntington_disease)
+        source "Adult-onset Huntington disease is typically characterized by early striatal atrophy in the caudate."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK559166/"
+        trust authoritative
 }

--- a/code/specs/data/mycin-2026/recall/neuro-recall.query.adj
+++ b/code/specs/data/mycin-2026/recall/neuro-recall.query.adj
@@ -18,3 +18,4 @@ import "neuro-edges.adj"
 ? lesion_causes(arcuate_fasciculus, $Deficit)   % expect conduction_aphasia
 ? lesion_causes(substantia_nigra, $Deficit)     % expect parkinson_disease
 ? lesion_causes(subthalamic_nucleus, $Deficit)  % expect hemiballismus
+? lesion_causes(caudate_nucleus, $Deficit)      % expect huntington_disease

--- a/code/specs/data/mycin-2026/recall/test_neuro_recall.py
+++ b/code/specs/data/mycin-2026/recall/test_neuro_recall.py
@@ -34,6 +34,7 @@ EXPECTED = {
     "arcuate_fasciculus": "conduction_aphasia",
     "substantia_nigra": "parkinson_disease",
     "subthalamic_nucleus": "hemiballismus",
+    "caudate_nucleus": "huntington_disease",
 }
 REL = "lesion_causes"
 VAR = "Deficit"
@@ -56,7 +57,7 @@ def test_library_is_pure_adj_and_fully_grounded() -> None:
     text = ADJ.read_text()
     assert "trust consensus" not in text, "NEURO ships no authored-debt; ground or omit"
     assert "[FLAG:" not in text
-    edge_count = len(EXPECTED)  # 5
+    edge_count = len(EXPECTED)  # 6
     assert text.count("    relate ") == edge_count
     assert text.count("trust authoritative") == edge_count
     assert text.count('\n        locator "') == edge_count


### PR DESCRIPTION
## What

Adds the sixth grounded localization to the NEURO recall library (`code/specs/data/mycin-2026/recall/`): **caudate_nucleus → huntington_disease**.

Parallels the existing `substantia_nigra → parkinson_disease` edge: the disease is characterized by degeneration at the named site, and one self-contained StatPearls span names both the lesion site (striatal/caudate atrophy) and the disease.

## Grounding

- **source** (verbatim, byte-stable on the page): "Adult-onset Huntington disease is typically characterized by early striatal atrophy in the caudate."
- **locator**: https://www.ncbi.nlm.nih.gov/books/NBK559166/
- **trust**: authoritative

## Changes (data-only)

- `neuro-edges.adj` — +1 `relate` clause (inline source+locator, `trust authoritative`)
- `neuro-recall.query.adj` — +1 binding query
- `test_neuro_recall.py` — `EXPECTED` +1 (`edge_count` 5→6); hippocampus negative-control abstain test unchanged

## Verification

- `test_neuro_recall: 3/3 passed` (engine binds `huntington_disease` with authoritative citation; shape checks; off-vocabulary site abstains)
- ruff clean
- data-only security review passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)