### PR TITLE
feat(mycin-gi): ground onion-skin fibrosis→PSC biopsy edge

### DIFF
--- a/code/specs/data/mycin-2026/recall/gi-edges.adj
+++ b/code/specs/data/mycin-2026/recall/gi-edges.adj
@@ -86,4 +86,15 @@ rulebook gi_facts {
         source "The histopathology of ulcerative colitis will show involvement only of the mucosa and submucosa, with the formation of cryptic abscesses and mucosal ulcers."
         locator "https://www.ncbi.nlm.nih.gov/books/NBK470312/"
         trust authoritative
+
+    % --- onion-skin periductal fibrosis -> primary sclerosing cholangitis ------
+    % The Histopathology span names the disease (via its page-defined abbreviation "PSC",
+    % expanded at the top of NBK537181 as primary sclerosing cholangitis) AND the board
+    % buzzword "onion-skin" fibrosis together in one clean "X is characterized by Y"
+    % declarative. The abbreviation is noted here for honesty: a reader re-fetching the page
+    % finds "PSC" defined and this exact byte-stable sentence.
+    relate biopsy_finding_in(onion_skin_fibrosis, primary_sclerosing_cholangitis)
+        source "PSC is histologically characterized by concentric, lamellar periductal fibrosis—often referred to as \"onion-skin\" fibrosis."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK537181/"
+        trust authoritative
 }

--- a/code/specs/data/mycin-2026/recall/gi-recall.query.adj
+++ b/code/specs/data/mycin-2026/recall/gi-recall.query.adj
@@ -19,3 +19,4 @@ import "gi-edges.adj"
 ? biopsy_finding_in(absence_of_ganglion_cells, $Disease)  % expect hirschsprung_disease
 ? biopsy_finding_in(eosinophils_15_per_hpf, $Disease)     % expect eosinophilic_esophagitis
 ? biopsy_finding_in(crypt_abscesses, $Disease)            % expect ulcerative_colitis (backfill)
+? biopsy_finding_in(onion_skin_fibrosis, $Disease)        % expect primary_sclerosing_cholangitis

--- a/code/specs/data/mycin-2026/recall/test_gi_recall.py
+++ b/code/specs/data/mycin-2026/recall/test_gi_recall.py
@@ -35,6 +35,7 @@ EXPECTED = {
     "absence_of_ganglion_cells": "hirschsprung_disease",
     "eosinophils_15_per_hpf": "eosinophilic_esophagitis",
     "crypt_abscesses": "ulcerative_colitis",            # primary-source backfill (NBK470312)
+    "onion_skin_fibrosis": "primary_sclerosing_cholangitis",  # NBK537181 (PSC abbrev defined on page)
 }
 REL = "biopsy_finding_in"
 VAR = "Disease"
@@ -57,7 +58,7 @@ def test_library_is_pure_adj_and_fully_grounded() -> None:
     text = ADJ.read_text()
     assert "trust consensus" not in text, "GI ships no authored-debt; ground or omit"
     assert "[FLAG:" not in text
-    edge_count = len(EXPECTED)  # 5
+    edge_count = len(EXPECTED)  # 7
     assert text.count("    relate ") == edge_count
     assert text.count("trust authoritative") == edge_count
     assert text.count('\n        locator "') == edge_count


### PR DESCRIPTION
## What

Adds the seventh grounded edge to the GI biopsy/histology recall library (`code/specs/data/mycin-2026/recall/`): **onion_skin_fibrosis → primary_sclerosing_cholangitis**.

## Grounding

- **source** (verbatim, byte-stable): `PSC is histologically characterized by concentric, lamellar periductal fibrosis—often referred to as "onion-skin" fibrosis.`
- **locator**: https://www.ncbi.nlm.nih.gov/books/NBK537181/
- **trust**: authoritative

One clean "X is characterized by Y" declarative naming the disease (via its page-defined abbreviation **PSC**, expanded at the top of NBK537181 as primary sclerosing cholangitis) and the board buzzword "onion-skin" fibrosis together. The edge comment records the abbreviation explicitly for auditability — a reader re-fetching the page finds both the PSC definition and this exact byte-stable sentence.

## Changes (data-only)

- `gi-edges.adj` — +1 `relate` clause (inline source+locator, `trust authoritative`)
- `gi-recall.query.adj` — +1 binding query
- `test_gi_recall.py` — `EXPECTED` +1; stale `edge_count` comment fixed (5→7); `signet_ring_cells` negative-control abstain test unchanged

## Verification

- `test_gi_recall: 3/3 passed` (engine binds `primary_sclerosing_cholangitis` with authoritative citation; shape checks; off-vocabulary finding abstains)
- ruff clean
- data-only security review passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)