### PR TITLE
feat(adj-lang): multi-source corroboration (cites … locator …, ADJ-A9)

### DIFF
--- a/code/grammars/adj_lang.grammar
+++ b/code/grammars/adj_lang.grammar
@@ -236,18 +236,24 @@ import_decl   = "import" STRING ;
 
 # ----------------------------------------------------------------
 # Annotations attach a citation / locator / trust tier to the
-# preceding clause. The lowerer accepts at most one of each kind
-# per statement.
+# preceding clause. The lowerer accepts at most one of each of
+# source / locator / trust per statement. `cites` (ADJ-A9) is the
+# exception: it is REPEATABLE — each one records a corroborating
+# citation (a co-equal source for the same fact) with its own
+# required locator, reusing the `locator` keyword as the separator
+# so no new short keyword (`at`) has to be reserved.
 # ----------------------------------------------------------------
 
 annotation = source_annotation
            | locator_annotation
            | trust_annotation
+           | cites_annotation
            ;
 
 source_annotation  = "source" STRING ;
 locator_annotation = "locator" STRING ;
 trust_annotation   = "trust" trust_tier ;
+cites_annotation   = "cites" STRING "locator" STRING ;
 
 trust_tier = "consensus"
            | "authoritative"

--- a/code/grammars/adj_lang.tokens
+++ b/code/grammars/adj_lang.tokens
@@ -148,6 +148,7 @@ keywords:
   source
   trust
   locator
+  cites
   consensus
   authoritative
   empirical

--- a/code/packages/rust/adj-lang-cli/CHANGELOG.md
+++ b/code/packages/rust/adj-lang-cli/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.9.0] - 2026-06-21 — render corroborating citations (ADJ-A9)
+
+### Added
+
+- Each clause's provenance JSON now carries a **`"corroborations"`** array —
+  `[{ "source": …, "locator": … }]` — listing the co-equal citations attached to
+  the clause via `cites … locator …`. Empty in the common single-citation case.
+  Existing `"source"/"locator"/"trust"` fields are unchanged, so existing
+  recall/proof consumers keep working.
+
 ## [0.8.0] - 2026-06-17 — governing answers carry their grounded `context` (ADJ73 PR-B-3)
 
 ### Added

--- a/code/packages/rust/adj-lang-cli/Cargo.toml
+++ b/code/packages/rust/adj-lang-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adj-lang-cli"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 description = "Command-line driver for the adj-lang adjudication DSL. Reads a .adj program (rulebook clauses + observe/query), compiles it through the adj-lang frontend, runs the logic-engine differential on the CPU, and emits the decision plus a byte-cited proof DAG as JSON. Argument parsing is declarative via cli-builder. Zero answer-time model calls — this is the CPU-bound reasoner that the MYCIN-2026 prototype shells out to."
 

--- a/code/packages/rust/adj-lang-cli/src/main.rs
+++ b/code/packages/rust/adj-lang-cli/src/main.rs
@@ -88,17 +88,32 @@ fn trust(t: &TrustTier) -> &'static str {
     }
 }
 
-/// The `"source"/"locator"/"trust"` fields of a clause's provenance.
+/// The `"source"/"locator"/"trust"/"corroborations"` fields of a clause's
+/// provenance. `corroborations` (ADJ-A9) is an array of co-equal citations for
+/// the same fact — empty in the common single-citation case.
 fn prov(p: &Provenance) -> String {
     let loc = match &p.locator {
         Some(l) => format!("\"{}\"", esc(l)),
         None => "null".to_string(),
     };
+    let corro = p
+        .corroborations
+        .iter()
+        .map(|c| {
+            format!(
+                "{{\"source\":\"{}\",\"locator\":\"{}\"}}",
+                esc(&c.source),
+                esc(&c.locator)
+            )
+        })
+        .collect::<Vec<_>>()
+        .join(",");
     format!(
-        "\"source\":\"{}\",\"locator\":{},\"trust\":\"{}\"",
+        "\"source\":\"{}\",\"locator\":{},\"trust\":\"{}\",\"corroborations\":[{}]",
         esc(&p.source),
         loc,
-        trust(&p.trust_tier)
+        trust(&p.trust_tier),
+        corro
     )
 }
 
@@ -124,7 +139,7 @@ fn proof_json(
             match &st.origin {
                 DerivationOrigin::FromPrior { prior_logit, .. } => {
                     let pj = prior.map(|p| prov(&p.provenance)).unwrap_or_else(|| {
-                        "\"source\":\"\",\"locator\":null,\"trust\":\"unattributed\"".to_string()
+                        "\"source\":\"\",\"locator\":null,\"trust\":\"unattributed\",\"corroborations\":[]".to_string()
                     });
                     steps.push(format!(
                         "{{\"kind\":\"prior\",\"logit\":{},{}}}",
@@ -191,7 +206,7 @@ fn proof_json(
                         .find(|p| p.id == *clause_id)
                         .map(|p| prov(&p.provenance))
                         .unwrap_or_else(|| {
-                            "\"source\":\"\",\"locator\":null,\"trust\":\"unattributed\""
+                            "\"source\":\"\",\"locator\":null,\"trust\":\"unattributed\",\"corroborations\":[]"
                                 .to_string()
                         });
                     steps.push(format!(

--- a/code/packages/rust/adj-lang/CHANGELOG.md
+++ b/code/packages/rust/adj-lang/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## [0.17.0] - 2026-06-21 — multi-source corroboration (`cites … locator …`, ADJ-A9)
+
+### Added
+
+- **`cites "<source>" locator "<locator>"`** — a repeatable annotation that
+  attaches a corroborating citation (a co-equal source for the *same* fact) to
+  any clause (`prior`/`contributes`/`interacts`/`uncertain`/`relate`/rule). Each
+  carries a required locator so the span is re-fetchable. Lowers onto
+  `logic_engine::Provenance::corroborations` (documentary only — no change to the
+  LR arithmetic). New `Annotation::Cites { source, locator }`; one new keyword
+  `cites` (the existing `locator` keyword is reused as the separator, so no short
+  `at` keyword is reserved).
+- New lower tests: `cites_lowers_to_corroborations_in_order`,
+  `cites_repeats_freely_unlike_at_most_once_source`.
+
+### Changed
+
+- `_lexer_grammar.rs` / `_parser_grammar.rs` regenerated (`cites` keyword +
+  `cites_annotation` rule). The at-most-once checks for `source`/`locator`/
+  `trust` are unchanged; only `cites` repeats.
+- README §"awkwardness" updates A9 from "not yet covered" to covered.
+
 ## [0.16.1] - 2026-06-20 — string-literal escape hardening (byte-provenance)
 
 ### Added

--- a/code/packages/rust/adj-lang/Cargo.toml
+++ b/code/packages/rust/adj-lang/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adj-lang"
-version = "0.16.1"
+version = "0.17.0"
 edition = "2021"
 description = "Surface-syntax frontend for the adjudication framework's probabilistic-logic rulebooks. Lexes, parses, and lowers a domain-expert-readable DSL into a `logic-engine` KnowledgeBase. Dissolves ADJ46 awkwardness items A10 (rulebook syntax) and A4 (joint contributions syntactically distinct)."
 

--- a/code/packages/rust/adj-lang/README.md
+++ b/code/packages/rust/adj-lang/README.md
@@ -331,13 +331,31 @@ Adj-Lang dissolves ADJ46 awkwardness items **A4** (joint
 contributions syntactically distinct from atomic, via the `interacts`
 keyword) and **A10** (rulebook surface is hand-written Rust).
 
+**A9** — multi-source corroboration — is covered as of the ADJ-A9 change. A
+clause may carry one or more **corroborating** citations, each a co-equal source
+for the *same* fact, via a repeatable annotation:
+
+```
+contributes 2.5 from neutrophil_predominance to bacterial_meningitis
+    source  "Tunkel et al., IDSA 2004"   locator "https://…/cid/39/9/1267"   trust authoritative
+    cites   "van de Beek et al., NEJM 2006"   locator "https://www.nejm.org/…/NEJMra052116"
+    cites   "Brouwer et al., Clin Microbiol Rev 2010"   locator "https://…/CMR.00070-09"
+```
+
+`cites "<source>" locator "<locator>"` is repeatable (the primary
+`source`/`locator`/`trust` remain at-most-once); the `locator` keyword is reused
+as the separator so no short keyword (`at`) is reserved. Corroborations are
+**documentary only** — they record extra spans an auditor can re-fetch and do
+**not** enter the LR arithmetic (double-counting the same fact would inflate
+posteriors). They lower onto `logic_engine::Provenance::corroborations` and
+render in the CLI's clause provenance as a `"corroborations":[…]` array. See
+[ADJ-A9 spec](../../../specs/ADJ-A9-multi-source-corroboration.md).
+
 Not yet covered (all language-layer follow-ups):
 
 - **A5** — uncertainty markers (`uncertain X over {a,b,c}`).
 - **A7** — kickback as a query-result variant.
 - **A8** — counterfactual queries (`? acs given pmh(htn)=true`).
-- **A9** — source-disagreement aggregation (multiple `via "<source>"`
-  clauses per `(conclusion, evidence)`).
 
 These are small additive extensions of the grammar; each adds one or
 two arms to `parser::parse_statement` and one new variant to the

--- a/code/packages/rust/adj-lang/src/_lexer_grammar.rs
+++ b/code/packages/rust/adj-lang/src/_lexer_grammar.rs
@@ -6,7 +6,9 @@
 // Call `token_grammar()` instead of reading and parsing the .tokens file.
 
 #[allow(unused_imports)]
-use grammar_tools::token_grammar::{ModeTransition, PatternGroup, TokenDefinition, TokenGrammar, TransitionAction};
+use grammar_tools::token_grammar::{
+    ModeTransition, PatternGroup, TokenDefinition, TokenGrammar, TransitionAction,
+};
 #[allow(unused_imports)]
 use std::collections::HashMap;
 
@@ -182,7 +184,27 @@ pub fn token_grammar() -> TokenGrammar {
                 alias: None,
             },
         ],
-        keywords: vec![r#"prior"#.to_string(), r#"for"#.to_string(), r#"contributes"#.to_string(), r#"from"#.to_string(), r#"to"#.to_string(), r#"interacts"#.to_string(), r#"when"#.to_string(), r#"and"#.to_string(), r#"observe"#.to_string(), r#"uncertain"#.to_string(), r#"source"#.to_string(), r#"trust"#.to_string(), r#"locator"#.to_string(), r#"consensus"#.to_string(), r#"authoritative"#.to_string(), r#"empirical"#.to_string(), r#"inferred"#.to_string(), r#"unattributed"#.to_string()],
+        keywords: vec![
+            r#"prior"#.to_string(),
+            r#"for"#.to_string(),
+            r#"contributes"#.to_string(),
+            r#"from"#.to_string(),
+            r#"to"#.to_string(),
+            r#"interacts"#.to_string(),
+            r#"when"#.to_string(),
+            r#"and"#.to_string(),
+            r#"observe"#.to_string(),
+            r#"uncertain"#.to_string(),
+            r#"source"#.to_string(),
+            r#"trust"#.to_string(),
+            r#"locator"#.to_string(),
+            r#"cites"#.to_string(),
+            r#"consensus"#.to_string(),
+            r#"authoritative"#.to_string(),
+            r#"empirical"#.to_string(),
+            r#"inferred"#.to_string(),
+            r#"unattributed"#.to_string(),
+        ],
         mode: None,
         skip_definitions: vec![
             TokenDefinition {

--- a/code/packages/rust/adj-lang/src/_parser_grammar.rs
+++ b/code/packages/rust/adj-lang/src/_parser_grammar.rs
@@ -10,503 +10,1148 @@ use grammar_tools::parser_grammar::{GrammarElement, GrammarRule, ParserGrammar};
 pub fn parser_grammar() -> ParserGrammar {
     ParserGrammar {
         rules: vec![
-        GrammarRule {
-            name: r#"program"#.to_string(),
-            body: GrammarElement::Sequence { elements: vec![
-                GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"statement"#.to_string() }) },
-                GrammarElement::TokenReference { name: r#"EOF"#.to_string() },
-            ] },
-            line_number: 20,
-        },
-        GrammarRule {
-            name: r#"statement"#.to_string(),
-            body: GrammarElement::Alternation { choices: vec![
-                GrammarElement::RuleReference { name: r#"prior_decl"#.to_string() },
-                GrammarElement::RuleReference { name: r#"contributes_decl"#.to_string() },
-                GrammarElement::RuleReference { name: r#"interacts_decl"#.to_string() },
-                GrammarElement::RuleReference { name: r#"uncertain_decl"#.to_string() },
-                GrammarElement::RuleReference { name: r#"observe_decl"#.to_string() },
-                GrammarElement::RuleReference { name: r#"relate_decl"#.to_string() },
-                GrammarElement::RuleReference { name: r#"rule_decl"#.to_string() },
-                GrammarElement::RuleReference { name: r#"functional_decl"#.to_string() },
-                GrammarElement::RuleReference { name: r#"context_order_decl"#.to_string() },
-                GrammarElement::RuleReference { name: r#"query_decl"#.to_string() },
-                GrammarElement::RuleReference { name: r#"let_decl"#.to_string() },
-                GrammarElement::RuleReference { name: r#"symbol_decl"#.to_string() },
-                GrammarElement::RuleReference { name: r#"constrain_decl"#.to_string() },
-                GrammarElement::RuleReference { name: r#"solve_decl"#.to_string() },
-                GrammarElement::RuleReference { name: r#"check_decl"#.to_string() },
-                GrammarElement::RuleReference { name: r#"optimize_decl"#.to_string() },
-                GrammarElement::RuleReference { name: r#"dictionary_decl"#.to_string() },
-                GrammarElement::RuleReference { name: r#"define_decl"#.to_string() },
-                GrammarElement::RuleReference { name: r#"rulebook_decl"#.to_string() },
-                GrammarElement::RuleReference { name: r#"use_decl"#.to_string() },
-                GrammarElement::RuleReference { name: r#"import_decl"#.to_string() },
-            ] },
-            line_number: 22,
-        },
-        GrammarRule {
-            name: r#"prior_decl"#.to_string(),
-            body: GrammarElement::Sequence { elements: vec![
-                GrammarElement::Literal { value: r#"prior"#.to_string() },
-                GrammarElement::TokenReference { name: r#"NUMBER"#.to_string() },
-                GrammarElement::Literal { value: r#"for"#.to_string() },
-                GrammarElement::RuleReference { name: r#"term"#.to_string() },
-                GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"annotation"#.to_string() }) },
-            ] },
-            line_number: 50,
-        },
-        GrammarRule {
-            name: r#"contributes_decl"#.to_string(),
-            body: GrammarElement::Sequence { elements: vec![
-                GrammarElement::Literal { value: r#"contributes"#.to_string() },
-                GrammarElement::TokenReference { name: r#"NUMBER"#.to_string() },
-                GrammarElement::Literal { value: r#"from"#.to_string() },
-                GrammarElement::RuleReference { name: r#"evidence"#.to_string() },
-                GrammarElement::Literal { value: r#"to"#.to_string() },
-                GrammarElement::RuleReference { name: r#"term"#.to_string() },
-                GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"annotation"#.to_string() }) },
-            ] },
-            line_number: 52,
-        },
-        GrammarRule {
-            name: r#"evidence"#.to_string(),
-            body: GrammarElement::Alternation { choices: vec![
-                GrammarElement::RuleReference { name: r#"predicate"#.to_string() },
-                GrammarElement::RuleReference { name: r#"term"#.to_string() },
-            ] },
-            line_number: 62,
-        },
-        GrammarRule {
-            name: r#"predicate"#.to_string(),
-            body: GrammarElement::Sequence { elements: vec![
-                GrammarElement::TokenReference { name: r#"IDENT"#.to_string() },
-                GrammarElement::Group { element: Box::new(GrammarElement::Alternation { choices: vec![
-                        GrammarElement::TokenReference { name: r#"GE"#.to_string() },
-                        GrammarElement::TokenReference { name: r#"LE"#.to_string() },
-                        GrammarElement::TokenReference { name: r#"GT"#.to_string() },
-                        GrammarElement::TokenReference { name: r#"LT"#.to_string() },
-                        GrammarElement::TokenReference { name: r#"EQEQ"#.to_string() },
-                    ] }) },
-                GrammarElement::TokenReference { name: r#"NUMBER"#.to_string() },
-            ] },
-            line_number: 64,
-        },
-        GrammarRule {
-            name: r#"interacts_decl"#.to_string(),
-            body: GrammarElement::Sequence { elements: vec![
-                GrammarElement::Literal { value: r#"interacts"#.to_string() },
-                GrammarElement::TokenReference { name: r#"NUMBER"#.to_string() },
-                GrammarElement::Literal { value: r#"when"#.to_string() },
-                GrammarElement::RuleReference { name: r#"term"#.to_string() },
-                GrammarElement::Literal { value: r#"and"#.to_string() },
-                GrammarElement::RuleReference { name: r#"term"#.to_string() },
-                GrammarElement::Repetition { element: Box::new(GrammarElement::Sequence { elements: vec![
-                        GrammarElement::Literal { value: r#"and"#.to_string() },
-                        GrammarElement::RuleReference { name: r#"term"#.to_string() },
-                    ] }) },
-                GrammarElement::Literal { value: r#"for"#.to_string() },
-                GrammarElement::RuleReference { name: r#"term"#.to_string() },
-                GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"annotation"#.to_string() }) },
-            ] },
-            line_number: 66,
-        },
-        GrammarRule {
-            name: r#"uncertain_decl"#.to_string(),
-            body: GrammarElement::Sequence { elements: vec![
-                GrammarElement::Literal { value: r#"uncertain"#.to_string() },
-                GrammarElement::TokenReference { name: r#"LBRACE"#.to_string() },
-                GrammarElement::RuleReference { name: r#"term"#.to_string() },
-                GrammarElement::Repetition { element: Box::new(GrammarElement::Sequence { elements: vec![
-                        GrammarElement::TokenReference { name: r#"COMMA"#.to_string() },
-                        GrammarElement::RuleReference { name: r#"term"#.to_string() },
-                    ] }) },
-                GrammarElement::TokenReference { name: r#"RBRACE"#.to_string() },
-                GrammarElement::Literal { value: r#"for"#.to_string() },
-                GrammarElement::RuleReference { name: r#"term"#.to_string() },
-                GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"annotation"#.to_string() }) },
-            ] },
-            line_number: 68,
-        },
-        GrammarRule {
-            name: r#"observe_decl"#.to_string(),
-            body: GrammarElement::Sequence { elements: vec![
-                GrammarElement::Literal { value: r#"observe"#.to_string() },
-                GrammarElement::RuleReference { name: r#"term"#.to_string() },
-            ] },
-            line_number: 70,
-        },
-        GrammarRule {
-            name: r#"relate_decl"#.to_string(),
-            body: GrammarElement::Sequence { elements: vec![
-                GrammarElement::Literal { value: r#"relate"#.to_string() },
-                GrammarElement::RuleReference { name: r#"term"#.to_string() },
-                GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"annotation"#.to_string() }) },
-            ] },
-            line_number: 83,
-        },
-        GrammarRule {
-            name: r#"rule_decl"#.to_string(),
-            body: GrammarElement::Sequence { elements: vec![
-                GrammarElement::Literal { value: r#"rule"#.to_string() },
-                GrammarElement::TokenReference { name: r#"LBRACE"#.to_string() },
-                GrammarElement::Literal { value: r#"head"#.to_string() },
-                GrammarElement::TokenReference { name: r#"COLON"#.to_string() },
-                GrammarElement::RuleReference { name: r#"term"#.to_string() },
-                GrammarElement::Literal { value: r#"when"#.to_string() },
-                GrammarElement::TokenReference { name: r#"COLON"#.to_string() },
-                GrammarElement::RuleReference { name: r#"body_literal"#.to_string() },
-                GrammarElement::Repetition { element: Box::new(GrammarElement::Sequence { elements: vec![
-                        GrammarElement::TokenReference { name: r#"COMMA"#.to_string() },
-                        GrammarElement::RuleReference { name: r#"body_literal"#.to_string() },
-                    ] }) },
-                GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"annotation"#.to_string() }) },
-                GrammarElement::Optional { element: Box::new(GrammarElement::Sequence { elements: vec![
-                        GrammarElement::Literal { value: r#"priority"#.to_string() },
-                        GrammarElement::TokenReference { name: r#"COLON"#.to_string() },
-                        GrammarElement::TokenReference { name: r#"IDENT"#.to_string() },
-                    ] }) },
-                GrammarElement::Optional { element: Box::new(GrammarElement::Sequence { elements: vec![
-                        GrammarElement::Literal { value: r#"context"#.to_string() },
-                        GrammarElement::TokenReference { name: r#"COLON"#.to_string() },
-                        GrammarElement::TokenReference { name: r#"IDENT"#.to_string() },
-                    ] }) },
-                GrammarElement::TokenReference { name: r#"RBRACE"#.to_string() },
-            ] },
-            line_number: 105,
-        },
-        GrammarRule {
-            name: r#"body_literal"#.to_string(),
-            body: GrammarElement::Sequence { elements: vec![
-                GrammarElement::Optional { element: Box::new(GrammarElement::Literal { value: r#"not"#.to_string() }) },
-                GrammarElement::RuleReference { name: r#"term"#.to_string() },
-            ] },
-            line_number: 107,
-        },
-        GrammarRule {
-            name: r#"context_order_decl"#.to_string(),
-            body: GrammarElement::Sequence { elements: vec![
-                GrammarElement::Literal { value: r#"context_order"#.to_string() },
-                GrammarElement::TokenReference { name: r#"LBRACE"#.to_string() },
-                GrammarElement::TokenReference { name: r#"IDENT"#.to_string() },
-                GrammarElement::TokenReference { name: r#"GT"#.to_string() },
-                GrammarElement::TokenReference { name: r#"IDENT"#.to_string() },
-                GrammarElement::Repetition { element: Box::new(GrammarElement::Sequence { elements: vec![
-                        GrammarElement::TokenReference { name: r#"COMMA"#.to_string() },
-                        GrammarElement::TokenReference { name: r#"IDENT"#.to_string() },
-                        GrammarElement::TokenReference { name: r#"GT"#.to_string() },
-                        GrammarElement::TokenReference { name: r#"IDENT"#.to_string() },
-                    ] }) },
-                GrammarElement::TokenReference { name: r#"RBRACE"#.to_string() },
-            ] },
-            line_number: 118,
-        },
-        GrammarRule {
-            name: r#"functional_decl"#.to_string(),
-            body: GrammarElement::Sequence { elements: vec![
-                GrammarElement::Literal { value: r#"functional"#.to_string() },
-                GrammarElement::RuleReference { name: r#"term"#.to_string() },
-            ] },
-            line_number: 129,
-        },
-        GrammarRule {
-            name: r#"query_decl"#.to_string(),
-            body: GrammarElement::Sequence { elements: vec![
-                GrammarElement::TokenReference { name: r#"QUESTION"#.to_string() },
-                GrammarElement::RuleReference { name: r#"term"#.to_string() },
-            ] },
-            line_number: 131,
-        },
-        GrammarRule {
-            name: r#"let_decl"#.to_string(),
-            body: GrammarElement::Sequence { elements: vec![
-                GrammarElement::Literal { value: r#"let"#.to_string() },
-                GrammarElement::TokenReference { name: r#"IDENT"#.to_string() },
-                GrammarElement::TokenReference { name: r#"EQUALS"#.to_string() },
-                GrammarElement::RuleReference { name: r#"expr"#.to_string() },
-            ] },
-            line_number: 145,
-        },
-        GrammarRule {
-            name: r#"expr"#.to_string(),
-            body: GrammarElement::Sequence { elements: vec![
-                GrammarElement::RuleReference { name: r#"term_expr"#.to_string() },
-                GrammarElement::Repetition { element: Box::new(GrammarElement::Sequence { elements: vec![
-                        GrammarElement::Group { element: Box::new(GrammarElement::Alternation { choices: vec![
-                                GrammarElement::TokenReference { name: r#"PLUS"#.to_string() },
-                                GrammarElement::TokenReference { name: r#"MINUS"#.to_string() },
-                            ] }) },
-                        GrammarElement::RuleReference { name: r#"term_expr"#.to_string() },
-                    ] }) },
-            ] },
-            line_number: 147,
-        },
-        GrammarRule {
-            name: r#"term_expr"#.to_string(),
-            body: GrammarElement::Sequence { elements: vec![
-                GrammarElement::RuleReference { name: r#"factor"#.to_string() },
-                GrammarElement::Repetition { element: Box::new(GrammarElement::Sequence { elements: vec![
-                        GrammarElement::Group { element: Box::new(GrammarElement::Alternation { choices: vec![
-                                GrammarElement::TokenReference { name: r#"STAR"#.to_string() },
-                                GrammarElement::TokenReference { name: r#"SLASH"#.to_string() },
-                            ] }) },
-                        GrammarElement::RuleReference { name: r#"factor"#.to_string() },
-                    ] }) },
-            ] },
-            line_number: 149,
-        },
-        GrammarRule {
-            name: r#"factor"#.to_string(),
-            body: GrammarElement::Alternation { choices: vec![
-                GrammarElement::RuleReference { name: r#"agg"#.to_string() },
-                GrammarElement::TokenReference { name: r#"NUMBER"#.to_string() },
-                GrammarElement::TokenReference { name: r#"IDENT"#.to_string() },
-                GrammarElement::Sequence { elements: vec![
-                    GrammarElement::TokenReference { name: r#"LPAREN"#.to_string() },
-                    GrammarElement::RuleReference { name: r#"expr"#.to_string() },
-                    GrammarElement::TokenReference { name: r#"RPAREN"#.to_string() },
-                ] },
-            ] },
-            line_number: 151,
-        },
-        GrammarRule {
-            name: r#"agg"#.to_string(),
-            body: GrammarElement::Sequence { elements: vec![
-                GrammarElement::Group { element: Box::new(GrammarElement::Alternation { choices: vec![
-                        GrammarElement::Literal { value: r#"sum"#.to_string() },
-                        GrammarElement::Literal { value: r#"count"#.to_string() },
-                        GrammarElement::Literal { value: r#"min"#.to_string() },
-                        GrammarElement::Literal { value: r#"max"#.to_string() },
-                        GrammarElement::Literal { value: r#"avg"#.to_string() },
-                    ] }) },
-                GrammarElement::TokenReference { name: r#"LPAREN"#.to_string() },
-                GrammarElement::TokenReference { name: r#"IDENT"#.to_string() },
-                GrammarElement::TokenReference { name: r#"RPAREN"#.to_string() },
-            ] },
-            line_number: 153,
-        },
-        GrammarRule {
-            name: r#"symbol_decl"#.to_string(),
-            body: GrammarElement::Sequence { elements: vec![
-                GrammarElement::Literal { value: r#"symbol"#.to_string() },
-                GrammarElement::TokenReference { name: r#"IDENT"#.to_string() },
-                GrammarElement::TokenReference { name: r#"COLON"#.to_string() },
-                GrammarElement::RuleReference { name: r#"term"#.to_string() },
-            ] },
-            line_number: 163,
-        },
-        GrammarRule {
-            name: r#"constrain_decl"#.to_string(),
-            body: GrammarElement::Sequence { elements: vec![
-                GrammarElement::Literal { value: r#"constrain"#.to_string() },
-                GrammarElement::RuleReference { name: r#"expr"#.to_string() },
-                GrammarElement::RuleReference { name: r#"relop"#.to_string() },
-                GrammarElement::RuleReference { name: r#"expr"#.to_string() },
-            ] },
-            line_number: 165,
-        },
-        GrammarRule {
-            name: r#"relop"#.to_string(),
-            body: GrammarElement::Alternation { choices: vec![
-                GrammarElement::TokenReference { name: r#"GE"#.to_string() },
-                GrammarElement::TokenReference { name: r#"LE"#.to_string() },
-                GrammarElement::TokenReference { name: r#"GT"#.to_string() },
-                GrammarElement::TokenReference { name: r#"LT"#.to_string() },
-                GrammarElement::TokenReference { name: r#"EQEQ"#.to_string() },
-                GrammarElement::TokenReference { name: r#"EQUALS"#.to_string() },
-                GrammarElement::TokenReference { name: r#"NE"#.to_string() },
-            ] },
-            line_number: 167,
-        },
-        GrammarRule {
-            name: r#"solve_decl"#.to_string(),
-            body: GrammarElement::Sequence { elements: vec![
-                GrammarElement::Literal { value: r#"solve"#.to_string() },
-                GrammarElement::Literal { value: r#"for"#.to_string() },
-                GrammarElement::TokenReference { name: r#"LBRACE"#.to_string() },
-                GrammarElement::TokenReference { name: r#"IDENT"#.to_string() },
-                GrammarElement::Repetition { element: Box::new(GrammarElement::Sequence { elements: vec![
-                        GrammarElement::TokenReference { name: r#"COMMA"#.to_string() },
-                        GrammarElement::TokenReference { name: r#"IDENT"#.to_string() },
-                    ] }) },
-                GrammarElement::TokenReference { name: r#"RBRACE"#.to_string() },
-            ] },
-            line_number: 169,
-        },
-        GrammarRule {
-            name: r#"check_decl"#.to_string(),
-            body: GrammarElement::Literal { value: r#"check"#.to_string() },
-            line_number: 171,
-        },
-        GrammarRule {
-            name: r#"optimize_decl"#.to_string(),
-            body: GrammarElement::Sequence { elements: vec![
-                GrammarElement::Group { element: Box::new(GrammarElement::Alternation { choices: vec![
-                        GrammarElement::Literal { value: r#"minimize"#.to_string() },
-                        GrammarElement::Literal { value: r#"maximize"#.to_string() },
-                    ] }) },
-                GrammarElement::RuleReference { name: r#"expr"#.to_string() },
-            ] },
-            line_number: 178,
-        },
-        GrammarRule {
-            name: r#"dictionary_decl"#.to_string(),
-            body: GrammarElement::Sequence { elements: vec![
-                GrammarElement::Literal { value: r#"dictionary"#.to_string() },
-                GrammarElement::TokenReference { name: r#"IDENT"#.to_string() },
-                GrammarElement::TokenReference { name: r#"LBRACE"#.to_string() },
-                GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"define_decl"#.to_string() }) },
-                GrammarElement::TokenReference { name: r#"RBRACE"#.to_string() },
-            ] },
-            line_number: 190,
-        },
-        GrammarRule {
-            name: r#"define_decl"#.to_string(),
-            body: GrammarElement::Sequence { elements: vec![
-                GrammarElement::Literal { value: r#"define"#.to_string() },
-                GrammarElement::TokenReference { name: r#"IDENT"#.to_string() },
-                GrammarElement::TokenReference { name: r#"COLON"#.to_string() },
-                GrammarElement::RuleReference { name: r#"define_kind"#.to_string() },
-                GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"surface_clause"#.to_string() }) },
-            ] },
-            line_number: 192,
-        },
-        GrammarRule {
-            name: r#"define_kind"#.to_string(),
-            body: GrammarElement::Alternation { choices: vec![
-                GrammarElement::Literal { value: r#"hypothesis"#.to_string() },
-                GrammarElement::Sequence { elements: vec![
-                    GrammarElement::Literal { value: r#"finding"#.to_string() },
-                    GrammarElement::Optional { element: Box::new(GrammarElement::Sequence { elements: vec![
-                            GrammarElement::Literal { value: r#"values"#.to_string() },
-                            GrammarElement::TokenReference { name: r#"LBRACK"#.to_string() },
-                            GrammarElement::TokenReference { name: r#"IDENT"#.to_string() },
-                            GrammarElement::Repetition { element: Box::new(GrammarElement::Sequence { elements: vec![
-                                    GrammarElement::TokenReference { name: r#"COMMA"#.to_string() },
-                                    GrammarElement::TokenReference { name: r#"IDENT"#.to_string() },
-                                ] }) },
-                            GrammarElement::TokenReference { name: r#"RBRACK"#.to_string() },
-                        ] }) },
-                ] },
-                GrammarElement::Literal { value: r#"entity"#.to_string() },
-                GrammarElement::Sequence { elements: vec![
-                    GrammarElement::Literal { value: r#"relation"#.to_string() },
-                    GrammarElement::Literal { value: r#"from"#.to_string() },
-                    GrammarElement::TokenReference { name: r#"IDENT"#.to_string() },
-                    GrammarElement::Literal { value: r#"to"#.to_string() },
-                    GrammarElement::TokenReference { name: r#"IDENT"#.to_string() },
-                ] },
-            ] },
-            line_number: 194,
-        },
-        GrammarRule {
-            name: r#"surface_clause"#.to_string(),
-            body: GrammarElement::Sequence { elements: vec![
-                GrammarElement::Literal { value: r#"surface"#.to_string() },
-                GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
-                GrammarElement::Repetition { element: Box::new(GrammarElement::Sequence { elements: vec![
-                        GrammarElement::TokenReference { name: r#"COMMA"#.to_string() },
-                        GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
-                    ] }) },
-            ] },
-            line_number: 200,
-        },
-        GrammarRule {
-            name: r#"rulebook_decl"#.to_string(),
-            body: GrammarElement::Sequence { elements: vec![
-                GrammarElement::Literal { value: r#"rulebook"#.to_string() },
-                GrammarElement::TokenReference { name: r#"IDENT"#.to_string() },
-                GrammarElement::TokenReference { name: r#"LBRACE"#.to_string() },
-                GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"statement"#.to_string() }) },
-                GrammarElement::TokenReference { name: r#"RBRACE"#.to_string() },
-            ] },
-            line_number: 217,
-        },
-        GrammarRule {
-            name: r#"use_decl"#.to_string(),
-            body: GrammarElement::Sequence { elements: vec![
-                GrammarElement::Literal { value: r#"use"#.to_string() },
-                GrammarElement::TokenReference { name: r#"IDENT"#.to_string() },
-            ] },
-            line_number: 219,
-        },
-        GrammarRule {
-            name: r#"import_decl"#.to_string(),
-            body: GrammarElement::Sequence { elements: vec![
-                GrammarElement::Literal { value: r#"import"#.to_string() },
-                GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
-            ] },
-            line_number: 235,
-        },
-        GrammarRule {
-            name: r#"annotation"#.to_string(),
-            body: GrammarElement::Alternation { choices: vec![
-                GrammarElement::RuleReference { name: r#"source_annotation"#.to_string() },
-                GrammarElement::RuleReference { name: r#"locator_annotation"#.to_string() },
-                GrammarElement::RuleReference { name: r#"trust_annotation"#.to_string() },
-            ] },
-            line_number: 243,
-        },
-        GrammarRule {
-            name: r#"source_annotation"#.to_string(),
-            body: GrammarElement::Sequence { elements: vec![
-                GrammarElement::Literal { value: r#"source"#.to_string() },
-                GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
-            ] },
-            line_number: 248,
-        },
-        GrammarRule {
-            name: r#"locator_annotation"#.to_string(),
-            body: GrammarElement::Sequence { elements: vec![
-                GrammarElement::Literal { value: r#"locator"#.to_string() },
-                GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
-            ] },
-            line_number: 249,
-        },
-        GrammarRule {
-            name: r#"trust_annotation"#.to_string(),
-            body: GrammarElement::Sequence { elements: vec![
-                GrammarElement::Literal { value: r#"trust"#.to_string() },
-                GrammarElement::RuleReference { name: r#"trust_tier"#.to_string() },
-            ] },
-            line_number: 250,
-        },
-        GrammarRule {
-            name: r#"trust_tier"#.to_string(),
-            body: GrammarElement::Alternation { choices: vec![
-                GrammarElement::Literal { value: r#"consensus"#.to_string() },
-                GrammarElement::Literal { value: r#"authoritative"#.to_string() },
-                GrammarElement::Literal { value: r#"empirical"#.to_string() },
-                GrammarElement::Literal { value: r#"inferred"#.to_string() },
-                GrammarElement::Literal { value: r#"unattributed"#.to_string() },
-            ] },
-            line_number: 252,
-        },
-        GrammarRule {
-            name: r#"term"#.to_string(),
-            body: GrammarElement::Sequence { elements: vec![
-                GrammarElement::TokenReference { name: r#"IDENT"#.to_string() },
-                GrammarElement::Optional { element: Box::new(GrammarElement::Sequence { elements: vec![
-                        GrammarElement::TokenReference { name: r#"LPAREN"#.to_string() },
-                        GrammarElement::Group { element: Box::new(GrammarElement::Alternation { choices: vec![
-                                GrammarElement::RuleReference { name: r#"term"#.to_string() },
-                                GrammarElement::TokenReference { name: r#"NUMBER"#.to_string() },
-                                GrammarElement::TokenReference { name: r#"VAR"#.to_string() },
-                            ] }) },
-                        GrammarElement::Repetition { element: Box::new(GrammarElement::Sequence { elements: vec![
-                                GrammarElement::TokenReference { name: r#"COMMA"#.to_string() },
-                                GrammarElement::Group { element: Box::new(GrammarElement::Alternation { choices: vec![
-                                        GrammarElement::RuleReference { name: r#"term"#.to_string() },
-                                        GrammarElement::TokenReference { name: r#"NUMBER"#.to_string() },
-                                        GrammarElement::TokenReference { name: r#"VAR"#.to_string() },
-                                    ] }) },
-                            ] }) },
-                        GrammarElement::TokenReference { name: r#"RPAREN"#.to_string() },
-                    ] }) },
-            ] },
-            line_number: 274,
-        },
-    ],
+            GrammarRule {
+                name: r#"program"#.to_string(),
+                body: GrammarElement::Sequence {
+                    elements: vec![
+                        GrammarElement::Repetition {
+                            element: Box::new(GrammarElement::RuleReference {
+                                name: r#"statement"#.to_string(),
+                            }),
+                        },
+                        GrammarElement::TokenReference {
+                            name: r#"EOF"#.to_string(),
+                        },
+                    ],
+                },
+                line_number: 20,
+            },
+            GrammarRule {
+                name: r#"statement"#.to_string(),
+                body: GrammarElement::Alternation {
+                    choices: vec![
+                        GrammarElement::RuleReference {
+                            name: r#"prior_decl"#.to_string(),
+                        },
+                        GrammarElement::RuleReference {
+                            name: r#"contributes_decl"#.to_string(),
+                        },
+                        GrammarElement::RuleReference {
+                            name: r#"interacts_decl"#.to_string(),
+                        },
+                        GrammarElement::RuleReference {
+                            name: r#"uncertain_decl"#.to_string(),
+                        },
+                        GrammarElement::RuleReference {
+                            name: r#"observe_decl"#.to_string(),
+                        },
+                        GrammarElement::RuleReference {
+                            name: r#"relate_decl"#.to_string(),
+                        },
+                        GrammarElement::RuleReference {
+                            name: r#"rule_decl"#.to_string(),
+                        },
+                        GrammarElement::RuleReference {
+                            name: r#"functional_decl"#.to_string(),
+                        },
+                        GrammarElement::RuleReference {
+                            name: r#"context_order_decl"#.to_string(),
+                        },
+                        GrammarElement::RuleReference {
+                            name: r#"query_decl"#.to_string(),
+                        },
+                        GrammarElement::RuleReference {
+                            name: r#"let_decl"#.to_string(),
+                        },
+                        GrammarElement::RuleReference {
+                            name: r#"symbol_decl"#.to_string(),
+                        },
+                        GrammarElement::RuleReference {
+                            name: r#"constrain_decl"#.to_string(),
+                        },
+                        GrammarElement::RuleReference {
+                            name: r#"solve_decl"#.to_string(),
+                        },
+                        GrammarElement::RuleReference {
+                            name: r#"check_decl"#.to_string(),
+                        },
+                        GrammarElement::RuleReference {
+                            name: r#"optimize_decl"#.to_string(),
+                        },
+                        GrammarElement::RuleReference {
+                            name: r#"dictionary_decl"#.to_string(),
+                        },
+                        GrammarElement::RuleReference {
+                            name: r#"define_decl"#.to_string(),
+                        },
+                        GrammarElement::RuleReference {
+                            name: r#"rulebook_decl"#.to_string(),
+                        },
+                        GrammarElement::RuleReference {
+                            name: r#"use_decl"#.to_string(),
+                        },
+                        GrammarElement::RuleReference {
+                            name: r#"import_decl"#.to_string(),
+                        },
+                    ],
+                },
+                line_number: 22,
+            },
+            GrammarRule {
+                name: r#"prior_decl"#.to_string(),
+                body: GrammarElement::Sequence {
+                    elements: vec![
+                        GrammarElement::Literal {
+                            value: r#"prior"#.to_string(),
+                        },
+                        GrammarElement::TokenReference {
+                            name: r#"NUMBER"#.to_string(),
+                        },
+                        GrammarElement::Literal {
+                            value: r#"for"#.to_string(),
+                        },
+                        GrammarElement::RuleReference {
+                            name: r#"term"#.to_string(),
+                        },
+                        GrammarElement::Repetition {
+                            element: Box::new(GrammarElement::RuleReference {
+                                name: r#"annotation"#.to_string(),
+                            }),
+                        },
+                    ],
+                },
+                line_number: 50,
+            },
+            GrammarRule {
+                name: r#"contributes_decl"#.to_string(),
+                body: GrammarElement::Sequence {
+                    elements: vec![
+                        GrammarElement::Literal {
+                            value: r#"contributes"#.to_string(),
+                        },
+                        GrammarElement::TokenReference {
+                            name: r#"NUMBER"#.to_string(),
+                        },
+                        GrammarElement::Literal {
+                            value: r#"from"#.to_string(),
+                        },
+                        GrammarElement::RuleReference {
+                            name: r#"evidence"#.to_string(),
+                        },
+                        GrammarElement::Literal {
+                            value: r#"to"#.to_string(),
+                        },
+                        GrammarElement::RuleReference {
+                            name: r#"term"#.to_string(),
+                        },
+                        GrammarElement::Repetition {
+                            element: Box::new(GrammarElement::RuleReference {
+                                name: r#"annotation"#.to_string(),
+                            }),
+                        },
+                    ],
+                },
+                line_number: 52,
+            },
+            GrammarRule {
+                name: r#"evidence"#.to_string(),
+                body: GrammarElement::Alternation {
+                    choices: vec![
+                        GrammarElement::RuleReference {
+                            name: r#"predicate"#.to_string(),
+                        },
+                        GrammarElement::RuleReference {
+                            name: r#"term"#.to_string(),
+                        },
+                    ],
+                },
+                line_number: 62,
+            },
+            GrammarRule {
+                name: r#"predicate"#.to_string(),
+                body: GrammarElement::Sequence {
+                    elements: vec![
+                        GrammarElement::TokenReference {
+                            name: r#"IDENT"#.to_string(),
+                        },
+                        GrammarElement::Group {
+                            element: Box::new(GrammarElement::Alternation {
+                                choices: vec![
+                                    GrammarElement::TokenReference {
+                                        name: r#"GE"#.to_string(),
+                                    },
+                                    GrammarElement::TokenReference {
+                                        name: r#"LE"#.to_string(),
+                                    },
+                                    GrammarElement::TokenReference {
+                                        name: r#"GT"#.to_string(),
+                                    },
+                                    GrammarElement::TokenReference {
+                                        name: r#"LT"#.to_string(),
+                                    },
+                                    GrammarElement::TokenReference {
+                                        name: r#"EQEQ"#.to_string(),
+                                    },
+                                ],
+                            }),
+                        },
+                        GrammarElement::TokenReference {
+                            name: r#"NUMBER"#.to_string(),
+                        },
+                    ],
+                },
+                line_number: 64,
+            },
+            GrammarRule {
+                name: r#"interacts_decl"#.to_string(),
+                body: GrammarElement::Sequence {
+                    elements: vec![
+                        GrammarElement::Literal {
+                            value: r#"interacts"#.to_string(),
+                        },
+                        GrammarElement::TokenReference {
+                            name: r#"NUMBER"#.to_string(),
+                        },
+                        GrammarElement::Literal {
+                            value: r#"when"#.to_string(),
+                        },
+                        GrammarElement::RuleReference {
+                            name: r#"term"#.to_string(),
+                        },
+                        GrammarElement::Literal {
+                            value: r#"and"#.to_string(),
+                        },
+                        GrammarElement::RuleReference {
+                            name: r#"term"#.to_string(),
+                        },
+                        GrammarElement::Repetition {
+                            element: Box::new(GrammarElement::Sequence {
+                                elements: vec![
+                                    GrammarElement::Literal {
+                                        value: r#"and"#.to_string(),
+                                    },
+                                    GrammarElement::RuleReference {
+                                        name: r#"term"#.to_string(),
+                                    },
+                                ],
+                            }),
+                        },
+                        GrammarElement::Literal {
+                            value: r#"for"#.to_string(),
+                        },
+                        GrammarElement::RuleReference {
+                            name: r#"term"#.to_string(),
+                        },
+                        GrammarElement::Repetition {
+                            element: Box::new(GrammarElement::RuleReference {
+                                name: r#"annotation"#.to_string(),
+                            }),
+                        },
+                    ],
+                },
+                line_number: 66,
+            },
+            GrammarRule {
+                name: r#"uncertain_decl"#.to_string(),
+                body: GrammarElement::Sequence {
+                    elements: vec![
+                        GrammarElement::Literal {
+                            value: r#"uncertain"#.to_string(),
+                        },
+                        GrammarElement::TokenReference {
+                            name: r#"LBRACE"#.to_string(),
+                        },
+                        GrammarElement::RuleReference {
+                            name: r#"term"#.to_string(),
+                        },
+                        GrammarElement::Repetition {
+                            element: Box::new(GrammarElement::Sequence {
+                                elements: vec![
+                                    GrammarElement::TokenReference {
+                                        name: r#"COMMA"#.to_string(),
+                                    },
+                                    GrammarElement::RuleReference {
+                                        name: r#"term"#.to_string(),
+                                    },
+                                ],
+                            }),
+                        },
+                        GrammarElement::TokenReference {
+                            name: r#"RBRACE"#.to_string(),
+                        },
+                        GrammarElement::Literal {
+                            value: r#"for"#.to_string(),
+                        },
+                        GrammarElement::RuleReference {
+                            name: r#"term"#.to_string(),
+                        },
+                        GrammarElement::Repetition {
+                            element: Box::new(GrammarElement::RuleReference {
+                                name: r#"annotation"#.to_string(),
+                            }),
+                        },
+                    ],
+                },
+                line_number: 68,
+            },
+            GrammarRule {
+                name: r#"observe_decl"#.to_string(),
+                body: GrammarElement::Sequence {
+                    elements: vec![
+                        GrammarElement::Literal {
+                            value: r#"observe"#.to_string(),
+                        },
+                        GrammarElement::RuleReference {
+                            name: r#"term"#.to_string(),
+                        },
+                    ],
+                },
+                line_number: 70,
+            },
+            GrammarRule {
+                name: r#"relate_decl"#.to_string(),
+                body: GrammarElement::Sequence {
+                    elements: vec![
+                        GrammarElement::Literal {
+                            value: r#"relate"#.to_string(),
+                        },
+                        GrammarElement::RuleReference {
+                            name: r#"term"#.to_string(),
+                        },
+                        GrammarElement::Repetition {
+                            element: Box::new(GrammarElement::RuleReference {
+                                name: r#"annotation"#.to_string(),
+                            }),
+                        },
+                    ],
+                },
+                line_number: 83,
+            },
+            GrammarRule {
+                name: r#"rule_decl"#.to_string(),
+                body: GrammarElement::Sequence {
+                    elements: vec![
+                        GrammarElement::Literal {
+                            value: r#"rule"#.to_string(),
+                        },
+                        GrammarElement::TokenReference {
+                            name: r#"LBRACE"#.to_string(),
+                        },
+                        GrammarElement::Literal {
+                            value: r#"head"#.to_string(),
+                        },
+                        GrammarElement::TokenReference {
+                            name: r#"COLON"#.to_string(),
+                        },
+                        GrammarElement::RuleReference {
+                            name: r#"term"#.to_string(),
+                        },
+                        GrammarElement::Literal {
+                            value: r#"when"#.to_string(),
+                        },
+                        GrammarElement::TokenReference {
+                            name: r#"COLON"#.to_string(),
+                        },
+                        GrammarElement::RuleReference {
+                            name: r#"body_literal"#.to_string(),
+                        },
+                        GrammarElement::Repetition {
+                            element: Box::new(GrammarElement::Sequence {
+                                elements: vec![
+                                    GrammarElement::TokenReference {
+                                        name: r#"COMMA"#.to_string(),
+                                    },
+                                    GrammarElement::RuleReference {
+                                        name: r#"body_literal"#.to_string(),
+                                    },
+                                ],
+                            }),
+                        },
+                        GrammarElement::Repetition {
+                            element: Box::new(GrammarElement::RuleReference {
+                                name: r#"annotation"#.to_string(),
+                            }),
+                        },
+                        GrammarElement::Optional {
+                            element: Box::new(GrammarElement::Sequence {
+                                elements: vec![
+                                    GrammarElement::Literal {
+                                        value: r#"priority"#.to_string(),
+                                    },
+                                    GrammarElement::TokenReference {
+                                        name: r#"COLON"#.to_string(),
+                                    },
+                                    GrammarElement::TokenReference {
+                                        name: r#"IDENT"#.to_string(),
+                                    },
+                                ],
+                            }),
+                        },
+                        GrammarElement::Optional {
+                            element: Box::new(GrammarElement::Sequence {
+                                elements: vec![
+                                    GrammarElement::Literal {
+                                        value: r#"context"#.to_string(),
+                                    },
+                                    GrammarElement::TokenReference {
+                                        name: r#"COLON"#.to_string(),
+                                    },
+                                    GrammarElement::TokenReference {
+                                        name: r#"IDENT"#.to_string(),
+                                    },
+                                ],
+                            }),
+                        },
+                        GrammarElement::TokenReference {
+                            name: r#"RBRACE"#.to_string(),
+                        },
+                    ],
+                },
+                line_number: 105,
+            },
+            GrammarRule {
+                name: r#"body_literal"#.to_string(),
+                body: GrammarElement::Sequence {
+                    elements: vec![
+                        GrammarElement::Optional {
+                            element: Box::new(GrammarElement::Literal {
+                                value: r#"not"#.to_string(),
+                            }),
+                        },
+                        GrammarElement::RuleReference {
+                            name: r#"term"#.to_string(),
+                        },
+                    ],
+                },
+                line_number: 107,
+            },
+            GrammarRule {
+                name: r#"context_order_decl"#.to_string(),
+                body: GrammarElement::Sequence {
+                    elements: vec![
+                        GrammarElement::Literal {
+                            value: r#"context_order"#.to_string(),
+                        },
+                        GrammarElement::TokenReference {
+                            name: r#"LBRACE"#.to_string(),
+                        },
+                        GrammarElement::TokenReference {
+                            name: r#"IDENT"#.to_string(),
+                        },
+                        GrammarElement::TokenReference {
+                            name: r#"GT"#.to_string(),
+                        },
+                        GrammarElement::TokenReference {
+                            name: r#"IDENT"#.to_string(),
+                        },
+                        GrammarElement::Repetition {
+                            element: Box::new(GrammarElement::Sequence {
+                                elements: vec![
+                                    GrammarElement::TokenReference {
+                                        name: r#"COMMA"#.to_string(),
+                                    },
+                                    GrammarElement::TokenReference {
+                                        name: r#"IDENT"#.to_string(),
+                                    },
+                                    GrammarElement::TokenReference {
+                                        name: r#"GT"#.to_string(),
+                                    },
+                                    GrammarElement::TokenReference {
+                                        name: r#"IDENT"#.to_string(),
+                                    },
+                                ],
+                            }),
+                        },
+                        GrammarElement::TokenReference {
+                            name: r#"RBRACE"#.to_string(),
+                        },
+                    ],
+                },
+                line_number: 118,
+            },
+            GrammarRule {
+                name: r#"functional_decl"#.to_string(),
+                body: GrammarElement::Sequence {
+                    elements: vec![
+                        GrammarElement::Literal {
+                            value: r#"functional"#.to_string(),
+                        },
+                        GrammarElement::RuleReference {
+                            name: r#"term"#.to_string(),
+                        },
+                    ],
+                },
+                line_number: 129,
+            },
+            GrammarRule {
+                name: r#"query_decl"#.to_string(),
+                body: GrammarElement::Sequence {
+                    elements: vec![
+                        GrammarElement::TokenReference {
+                            name: r#"QUESTION"#.to_string(),
+                        },
+                        GrammarElement::RuleReference {
+                            name: r#"term"#.to_string(),
+                        },
+                    ],
+                },
+                line_number: 131,
+            },
+            GrammarRule {
+                name: r#"let_decl"#.to_string(),
+                body: GrammarElement::Sequence {
+                    elements: vec![
+                        GrammarElement::Literal {
+                            value: r#"let"#.to_string(),
+                        },
+                        GrammarElement::TokenReference {
+                            name: r#"IDENT"#.to_string(),
+                        },
+                        GrammarElement::TokenReference {
+                            name: r#"EQUALS"#.to_string(),
+                        },
+                        GrammarElement::RuleReference {
+                            name: r#"expr"#.to_string(),
+                        },
+                    ],
+                },
+                line_number: 145,
+            },
+            GrammarRule {
+                name: r#"expr"#.to_string(),
+                body: GrammarElement::Sequence {
+                    elements: vec![
+                        GrammarElement::RuleReference {
+                            name: r#"term_expr"#.to_string(),
+                        },
+                        GrammarElement::Repetition {
+                            element: Box::new(GrammarElement::Sequence {
+                                elements: vec![
+                                    GrammarElement::Group {
+                                        element: Box::new(GrammarElement::Alternation {
+                                            choices: vec![
+                                                GrammarElement::TokenReference {
+                                                    name: r#"PLUS"#.to_string(),
+                                                },
+                                                GrammarElement::TokenReference {
+                                                    name: r#"MINUS"#.to_string(),
+                                                },
+                                            ],
+                                        }),
+                                    },
+                                    GrammarElement::RuleReference {
+                                        name: r#"term_expr"#.to_string(),
+                                    },
+                                ],
+                            }),
+                        },
+                    ],
+                },
+                line_number: 147,
+            },
+            GrammarRule {
+                name: r#"term_expr"#.to_string(),
+                body: GrammarElement::Sequence {
+                    elements: vec![
+                        GrammarElement::RuleReference {
+                            name: r#"factor"#.to_string(),
+                        },
+                        GrammarElement::Repetition {
+                            element: Box::new(GrammarElement::Sequence {
+                                elements: vec![
+                                    GrammarElement::Group {
+                                        element: Box::new(GrammarElement::Alternation {
+                                            choices: vec![
+                                                GrammarElement::TokenReference {
+                                                    name: r#"STAR"#.to_string(),
+                                                },
+                                                GrammarElement::TokenReference {
+                                                    name: r#"SLASH"#.to_string(),
+                                                },
+                                            ],
+                                        }),
+                                    },
+                                    GrammarElement::RuleReference {
+                                        name: r#"factor"#.to_string(),
+                                    },
+                                ],
+                            }),
+                        },
+                    ],
+                },
+                line_number: 149,
+            },
+            GrammarRule {
+                name: r#"factor"#.to_string(),
+                body: GrammarElement::Alternation {
+                    choices: vec![
+                        GrammarElement::RuleReference {
+                            name: r#"agg"#.to_string(),
+                        },
+                        GrammarElement::TokenReference {
+                            name: r#"NUMBER"#.to_string(),
+                        },
+                        GrammarElement::TokenReference {
+                            name: r#"IDENT"#.to_string(),
+                        },
+                        GrammarElement::Sequence {
+                            elements: vec![
+                                GrammarElement::TokenReference {
+                                    name: r#"LPAREN"#.to_string(),
+                                },
+                                GrammarElement::RuleReference {
+                                    name: r#"expr"#.to_string(),
+                                },
+                                GrammarElement::TokenReference {
+                                    name: r#"RPAREN"#.to_string(),
+                                },
+                            ],
+                        },
+                    ],
+                },
+                line_number: 151,
+            },
+            GrammarRule {
+                name: r#"agg"#.to_string(),
+                body: GrammarElement::Sequence {
+                    elements: vec![
+                        GrammarElement::Group {
+                            element: Box::new(GrammarElement::Alternation {
+                                choices: vec![
+                                    GrammarElement::Literal {
+                                        value: r#"sum"#.to_string(),
+                                    },
+                                    GrammarElement::Literal {
+                                        value: r#"count"#.to_string(),
+                                    },
+                                    GrammarElement::Literal {
+                                        value: r#"min"#.to_string(),
+                                    },
+                                    GrammarElement::Literal {
+                                        value: r#"max"#.to_string(),
+                                    },
+                                    GrammarElement::Literal {
+                                        value: r#"avg"#.to_string(),
+                                    },
+                                ],
+                            }),
+                        },
+                        GrammarElement::TokenReference {
+                            name: r#"LPAREN"#.to_string(),
+                        },
+                        GrammarElement::TokenReference {
+                            name: r#"IDENT"#.to_string(),
+                        },
+                        GrammarElement::TokenReference {
+                            name: r#"RPAREN"#.to_string(),
+                        },
+                    ],
+                },
+                line_number: 153,
+            },
+            GrammarRule {
+                name: r#"symbol_decl"#.to_string(),
+                body: GrammarElement::Sequence {
+                    elements: vec![
+                        GrammarElement::Literal {
+                            value: r#"symbol"#.to_string(),
+                        },
+                        GrammarElement::TokenReference {
+                            name: r#"IDENT"#.to_string(),
+                        },
+                        GrammarElement::TokenReference {
+                            name: r#"COLON"#.to_string(),
+                        },
+                        GrammarElement::RuleReference {
+                            name: r#"term"#.to_string(),
+                        },
+                    ],
+                },
+                line_number: 163,
+            },
+            GrammarRule {
+                name: r#"constrain_decl"#.to_string(),
+                body: GrammarElement::Sequence {
+                    elements: vec![
+                        GrammarElement::Literal {
+                            value: r#"constrain"#.to_string(),
+                        },
+                        GrammarElement::RuleReference {
+                            name: r#"expr"#.to_string(),
+                        },
+                        GrammarElement::RuleReference {
+                            name: r#"relop"#.to_string(),
+                        },
+                        GrammarElement::RuleReference {
+                            name: r#"expr"#.to_string(),
+                        },
+                    ],
+                },
+                line_number: 165,
+            },
+            GrammarRule {
+                name: r#"relop"#.to_string(),
+                body: GrammarElement::Alternation {
+                    choices: vec![
+                        GrammarElement::TokenReference {
+                            name: r#"GE"#.to_string(),
+                        },
+                        GrammarElement::TokenReference {
+                            name: r#"LE"#.to_string(),
+                        },
+                        GrammarElement::TokenReference {
+                            name: r#"GT"#.to_string(),
+                        },
+                        GrammarElement::TokenReference {
+                            name: r#"LT"#.to_string(),
+                        },
+                        GrammarElement::TokenReference {
+                            name: r#"EQEQ"#.to_string(),
+                        },
+                        GrammarElement::TokenReference {
+                            name: r#"EQUALS"#.to_string(),
+                        },
+                        GrammarElement::TokenReference {
+                            name: r#"NE"#.to_string(),
+                        },
+                    ],
+                },
+                line_number: 167,
+            },
+            GrammarRule {
+                name: r#"solve_decl"#.to_string(),
+                body: GrammarElement::Sequence {
+                    elements: vec![
+                        GrammarElement::Literal {
+                            value: r#"solve"#.to_string(),
+                        },
+                        GrammarElement::Literal {
+                            value: r#"for"#.to_string(),
+                        },
+                        GrammarElement::TokenReference {
+                            name: r#"LBRACE"#.to_string(),
+                        },
+                        GrammarElement::TokenReference {
+                            name: r#"IDENT"#.to_string(),
+                        },
+                        GrammarElement::Repetition {
+                            element: Box::new(GrammarElement::Sequence {
+                                elements: vec![
+                                    GrammarElement::TokenReference {
+                                        name: r#"COMMA"#.to_string(),
+                                    },
+                                    GrammarElement::TokenReference {
+                                        name: r#"IDENT"#.to_string(),
+                                    },
+                                ],
+                            }),
+                        },
+                        GrammarElement::TokenReference {
+                            name: r#"RBRACE"#.to_string(),
+                        },
+                    ],
+                },
+                line_number: 169,
+            },
+            GrammarRule {
+                name: r#"check_decl"#.to_string(),
+                body: GrammarElement::Literal {
+                    value: r#"check"#.to_string(),
+                },
+                line_number: 171,
+            },
+            GrammarRule {
+                name: r#"optimize_decl"#.to_string(),
+                body: GrammarElement::Sequence {
+                    elements: vec![
+                        GrammarElement::Group {
+                            element: Box::new(GrammarElement::Alternation {
+                                choices: vec![
+                                    GrammarElement::Literal {
+                                        value: r#"minimize"#.to_string(),
+                                    },
+                                    GrammarElement::Literal {
+                                        value: r#"maximize"#.to_string(),
+                                    },
+                                ],
+                            }),
+                        },
+                        GrammarElement::RuleReference {
+                            name: r#"expr"#.to_string(),
+                        },
+                    ],
+                },
+                line_number: 178,
+            },
+            GrammarRule {
+                name: r#"dictionary_decl"#.to_string(),
+                body: GrammarElement::Sequence {
+                    elements: vec![
+                        GrammarElement::Literal {
+                            value: r#"dictionary"#.to_string(),
+                        },
+                        GrammarElement::TokenReference {
+                            name: r#"IDENT"#.to_string(),
+                        },
+                        GrammarElement::TokenReference {
+                            name: r#"LBRACE"#.to_string(),
+                        },
+                        GrammarElement::Repetition {
+                            element: Box::new(GrammarElement::RuleReference {
+                                name: r#"define_decl"#.to_string(),
+                            }),
+                        },
+                        GrammarElement::TokenReference {
+                            name: r#"RBRACE"#.to_string(),
+                        },
+                    ],
+                },
+                line_number: 190,
+            },
+            GrammarRule {
+                name: r#"define_decl"#.to_string(),
+                body: GrammarElement::Sequence {
+                    elements: vec![
+                        GrammarElement::Literal {
+                            value: r#"define"#.to_string(),
+                        },
+                        GrammarElement::TokenReference {
+                            name: r#"IDENT"#.to_string(),
+                        },
+                        GrammarElement::TokenReference {
+                            name: r#"COLON"#.to_string(),
+                        },
+                        GrammarElement::RuleReference {
+                            name: r#"define_kind"#.to_string(),
+                        },
+                        GrammarElement::Repetition {
+                            element: Box::new(GrammarElement::RuleReference {
+                                name: r#"surface_clause"#.to_string(),
+                            }),
+                        },
+                    ],
+                },
+                line_number: 192,
+            },
+            GrammarRule {
+                name: r#"define_kind"#.to_string(),
+                body: GrammarElement::Alternation {
+                    choices: vec![
+                        GrammarElement::Literal {
+                            value: r#"hypothesis"#.to_string(),
+                        },
+                        GrammarElement::Sequence {
+                            elements: vec![
+                                GrammarElement::Literal {
+                                    value: r#"finding"#.to_string(),
+                                },
+                                GrammarElement::Optional {
+                                    element: Box::new(GrammarElement::Sequence {
+                                        elements: vec![
+                                            GrammarElement::Literal {
+                                                value: r#"values"#.to_string(),
+                                            },
+                                            GrammarElement::TokenReference {
+                                                name: r#"LBRACK"#.to_string(),
+                                            },
+                                            GrammarElement::TokenReference {
+                                                name: r#"IDENT"#.to_string(),
+                                            },
+                                            GrammarElement::Repetition {
+                                                element: Box::new(GrammarElement::Sequence {
+                                                    elements: vec![
+                                                        GrammarElement::TokenReference {
+                                                            name: r#"COMMA"#.to_string(),
+                                                        },
+                                                        GrammarElement::TokenReference {
+                                                            name: r#"IDENT"#.to_string(),
+                                                        },
+                                                    ],
+                                                }),
+                                            },
+                                            GrammarElement::TokenReference {
+                                                name: r#"RBRACK"#.to_string(),
+                                            },
+                                        ],
+                                    }),
+                                },
+                            ],
+                        },
+                        GrammarElement::Literal {
+                            value: r#"entity"#.to_string(),
+                        },
+                        GrammarElement::Sequence {
+                            elements: vec![
+                                GrammarElement::Literal {
+                                    value: r#"relation"#.to_string(),
+                                },
+                                GrammarElement::Literal {
+                                    value: r#"from"#.to_string(),
+                                },
+                                GrammarElement::TokenReference {
+                                    name: r#"IDENT"#.to_string(),
+                                },
+                                GrammarElement::Literal {
+                                    value: r#"to"#.to_string(),
+                                },
+                                GrammarElement::TokenReference {
+                                    name: r#"IDENT"#.to_string(),
+                                },
+                            ],
+                        },
+                    ],
+                },
+                line_number: 194,
+            },
+            GrammarRule {
+                name: r#"surface_clause"#.to_string(),
+                body: GrammarElement::Sequence {
+                    elements: vec![
+                        GrammarElement::Literal {
+                            value: r#"surface"#.to_string(),
+                        },
+                        GrammarElement::TokenReference {
+                            name: r#"STRING"#.to_string(),
+                        },
+                        GrammarElement::Repetition {
+                            element: Box::new(GrammarElement::Sequence {
+                                elements: vec![
+                                    GrammarElement::TokenReference {
+                                        name: r#"COMMA"#.to_string(),
+                                    },
+                                    GrammarElement::TokenReference {
+                                        name: r#"STRING"#.to_string(),
+                                    },
+                                ],
+                            }),
+                        },
+                    ],
+                },
+                line_number: 200,
+            },
+            GrammarRule {
+                name: r#"rulebook_decl"#.to_string(),
+                body: GrammarElement::Sequence {
+                    elements: vec![
+                        GrammarElement::Literal {
+                            value: r#"rulebook"#.to_string(),
+                        },
+                        GrammarElement::TokenReference {
+                            name: r#"IDENT"#.to_string(),
+                        },
+                        GrammarElement::TokenReference {
+                            name: r#"LBRACE"#.to_string(),
+                        },
+                        GrammarElement::Repetition {
+                            element: Box::new(GrammarElement::RuleReference {
+                                name: r#"statement"#.to_string(),
+                            }),
+                        },
+                        GrammarElement::TokenReference {
+                            name: r#"RBRACE"#.to_string(),
+                        },
+                    ],
+                },
+                line_number: 217,
+            },
+            GrammarRule {
+                name: r#"use_decl"#.to_string(),
+                body: GrammarElement::Sequence {
+                    elements: vec![
+                        GrammarElement::Literal {
+                            value: r#"use"#.to_string(),
+                        },
+                        GrammarElement::TokenReference {
+                            name: r#"IDENT"#.to_string(),
+                        },
+                    ],
+                },
+                line_number: 219,
+            },
+            GrammarRule {
+                name: r#"import_decl"#.to_string(),
+                body: GrammarElement::Sequence {
+                    elements: vec![
+                        GrammarElement::Literal {
+                            value: r#"import"#.to_string(),
+                        },
+                        GrammarElement::TokenReference {
+                            name: r#"STRING"#.to_string(),
+                        },
+                    ],
+                },
+                line_number: 235,
+            },
+            GrammarRule {
+                name: r#"annotation"#.to_string(),
+                body: GrammarElement::Alternation {
+                    choices: vec![
+                        GrammarElement::RuleReference {
+                            name: r#"source_annotation"#.to_string(),
+                        },
+                        GrammarElement::RuleReference {
+                            name: r#"locator_annotation"#.to_string(),
+                        },
+                        GrammarElement::RuleReference {
+                            name: r#"trust_annotation"#.to_string(),
+                        },
+                        GrammarElement::RuleReference {
+                            name: r#"cites_annotation"#.to_string(),
+                        },
+                    ],
+                },
+                line_number: 247,
+            },
+            GrammarRule {
+                name: r#"source_annotation"#.to_string(),
+                body: GrammarElement::Sequence {
+                    elements: vec![
+                        GrammarElement::Literal {
+                            value: r#"source"#.to_string(),
+                        },
+                        GrammarElement::TokenReference {
+                            name: r#"STRING"#.to_string(),
+                        },
+                    ],
+                },
+                line_number: 253,
+            },
+            GrammarRule {
+                name: r#"locator_annotation"#.to_string(),
+                body: GrammarElement::Sequence {
+                    elements: vec![
+                        GrammarElement::Literal {
+                            value: r#"locator"#.to_string(),
+                        },
+                        GrammarElement::TokenReference {
+                            name: r#"STRING"#.to_string(),
+                        },
+                    ],
+                },
+                line_number: 254,
+            },
+            GrammarRule {
+                name: r#"trust_annotation"#.to_string(),
+                body: GrammarElement::Sequence {
+                    elements: vec![
+                        GrammarElement::Literal {
+                            value: r#"trust"#.to_string(),
+                        },
+                        GrammarElement::RuleReference {
+                            name: r#"trust_tier"#.to_string(),
+                        },
+                    ],
+                },
+                line_number: 255,
+            },
+            GrammarRule {
+                name: r#"cites_annotation"#.to_string(),
+                body: GrammarElement::Sequence {
+                    elements: vec![
+                        GrammarElement::Literal {
+                            value: r#"cites"#.to_string(),
+                        },
+                        GrammarElement::TokenReference {
+                            name: r#"STRING"#.to_string(),
+                        },
+                        GrammarElement::Literal {
+                            value: r#"locator"#.to_string(),
+                        },
+                        GrammarElement::TokenReference {
+                            name: r#"STRING"#.to_string(),
+                        },
+                    ],
+                },
+                line_number: 256,
+            },
+            GrammarRule {
+                name: r#"trust_tier"#.to_string(),
+                body: GrammarElement::Alternation {
+                    choices: vec![
+                        GrammarElement::Literal {
+                            value: r#"consensus"#.to_string(),
+                        },
+                        GrammarElement::Literal {
+                            value: r#"authoritative"#.to_string(),
+                        },
+                        GrammarElement::Literal {
+                            value: r#"empirical"#.to_string(),
+                        },
+                        GrammarElement::Literal {
+                            value: r#"inferred"#.to_string(),
+                        },
+                        GrammarElement::Literal {
+                            value: r#"unattributed"#.to_string(),
+                        },
+                    ],
+                },
+                line_number: 258,
+            },
+            GrammarRule {
+                name: r#"term"#.to_string(),
+                body: GrammarElement::Sequence {
+                    elements: vec![
+                        GrammarElement::TokenReference {
+                            name: r#"IDENT"#.to_string(),
+                        },
+                        GrammarElement::Optional {
+                            element: Box::new(GrammarElement::Sequence {
+                                elements: vec![
+                                    GrammarElement::TokenReference {
+                                        name: r#"LPAREN"#.to_string(),
+                                    },
+                                    GrammarElement::Group {
+                                        element: Box::new(GrammarElement::Alternation {
+                                            choices: vec![
+                                                GrammarElement::RuleReference {
+                                                    name: r#"term"#.to_string(),
+                                                },
+                                                GrammarElement::TokenReference {
+                                                    name: r#"NUMBER"#.to_string(),
+                                                },
+                                                GrammarElement::TokenReference {
+                                                    name: r#"VAR"#.to_string(),
+                                                },
+                                            ],
+                                        }),
+                                    },
+                                    GrammarElement::Repetition {
+                                        element: Box::new(GrammarElement::Sequence {
+                                            elements: vec![
+                                                GrammarElement::TokenReference {
+                                                    name: r#"COMMA"#.to_string(),
+                                                },
+                                                GrammarElement::Group {
+                                                    element: Box::new(
+                                                        GrammarElement::Alternation {
+                                                            choices: vec![
+                                                                GrammarElement::RuleReference {
+                                                                    name: r#"term"#.to_string(),
+                                                                },
+                                                                GrammarElement::TokenReference {
+                                                                    name: r#"NUMBER"#.to_string(),
+                                                                },
+                                                                GrammarElement::TokenReference {
+                                                                    name: r#"VAR"#.to_string(),
+                                                                },
+                                                            ],
+                                                        },
+                                                    ),
+                                                },
+                                            ],
+                                        }),
+                                    },
+                                    GrammarElement::TokenReference {
+                                        name: r#"RPAREN"#.to_string(),
+                                    },
+                                ],
+                            }),
+                        },
+                    ],
+                },
+                line_number: 280,
+            },
+        ],
         version: 1,
     }
 }

--- a/code/packages/rust/adj-lang/src/adapter.rs
+++ b/code/packages/rust/adj-lang/src/adapter.rs
@@ -954,8 +954,28 @@ fn adapt_annotation(node: &GrammarASTNode) -> Result<Annotation, AdapterError> {
             let tier = trust_tier_from_node(tier_node)?;
             Ok(Annotation::Trust(tier))
         }
+        "cites_annotation" => {
+            // cites_annotation = "cites" STRING "locator" STRING  (ADJ-A9)
+            // Two STRING tokens in source order: [source, locator]. The
+            // `locator` keyword between them is reused purely as a separator.
+            let mut strings = child.children.iter().filter_map(|c| match c {
+                ASTNodeOrToken::Token(t) if t.type_ == TokenType::String => {
+                    Some(unquote_string(&t.value))
+                }
+                _ => None,
+            });
+            let source = strings.next().ok_or(AdapterError::MissingChild {
+                rule: "cites_annotation".into(),
+                position: "source STRING",
+            })?;
+            let locator = strings.next().ok_or(AdapterError::MissingChild {
+                rule: "cites_annotation".into(),
+                position: "locator STRING",
+            })?;
+            Ok(Annotation::Cites { source, locator })
+        }
         other => Err(AdapterError::UnexpectedRule {
-            expected: "one of source_annotation / locator_annotation / trust_annotation",
+            expected: "one of source_annotation / locator_annotation / trust_annotation / cites_annotation",
             actual: other.to_string(),
         }),
     }
@@ -1377,7 +1397,10 @@ mod tests {
                         _ => None,
                     })
                     .expect("a Source annotation");
-                assert_eq!(source, "shows \"Orphan Annie eye\" nuclei and psammoma bodies");
+                assert_eq!(
+                    source,
+                    "shows \"Orphan Annie eye\" nuclei and psammoma bodies"
+                );
                 assert!(source.contains('"'), "the span must carry a real quote");
             }
             other => panic!("expected Contributes, got {other:?}"),

--- a/code/packages/rust/adj-lang/src/ast.rs
+++ b/code/packages/rust/adj-lang/src/ast.rs
@@ -315,6 +315,10 @@ pub enum Annotation {
     Locator(String),
     /// `trust <tier>` — sets `Provenance::trust_tier`.
     Trust(TrustTierName),
+    /// `cites "<source>" locator "<locator>"` (ADJ-A9) — appends a
+    /// corroborating citation to `Provenance::corroborations`. Repeatable;
+    /// each carries a required locator so the span is re-fetchable.
+    Cites { source: String, locator: String },
 }
 
 /// Surface name for a trust tier — keywords in the language map

--- a/code/packages/rust/adj-lang/src/lower.rs
+++ b/code/packages/rust/adj-lang/src/lower.rs
@@ -23,9 +23,10 @@ use logic_core::{
     atom as core_atom, compound, float as core_float, var as core_var, LogicVar, Term as CoreTerm,
 };
 use logic_engine::{
-    compute, BodyLiteral, CmpOp as EngineCmpOp, ComputeExpr, ComputeOp, ContributionClause, Fact,
-    JointContributionClause, KbError, KnowledgeBase, PredicateContributionClause, PriorClause,
-    Priority, Provenance, Rule, TrustTier, UncertaintyMarker,
+    compute, BodyLiteral, Citation, CmpOp as EngineCmpOp, ComputeExpr, ComputeOp,
+    ContributionClause, Fact, JointContributionClause, KbError, KnowledgeBase,
+    PredicateContributionClause, PriorClause, Priority, Provenance, Rule, TrustTier,
+    UncertaintyMarker,
 };
 
 use std::collections::HashMap;
@@ -742,6 +743,9 @@ fn annotations_to_provenance(annotations: &[Annotation]) -> Result<Provenance, L
     let mut source: Option<String> = None;
     let mut locator: Option<String> = None;
     let mut trust: Option<TrustTier> = None;
+    // ADJ-A9: corroborating citations are REPEATABLE — accumulate in source
+    // order rather than rejecting duplicates.
+    let mut corroborations: Vec<Citation> = Vec::new();
 
     for a in annotations {
         match a {
@@ -769,6 +773,9 @@ fn annotations_to_provenance(annotations: &[Annotation]) -> Result<Provenance, L
                     TrustTierName::Unattributed => TrustTier::Unattributed,
                 });
             }
+            Annotation::Cites { source, locator } => {
+                corroborations.push(Citation::new(source.clone(), locator.clone()));
+            }
         }
     }
 
@@ -783,11 +790,11 @@ fn annotations_to_provenance(annotations: &[Annotation]) -> Result<Provenance, L
         }
     });
 
-    Ok(Provenance::new(
-        source.unwrap_or_default(),
-        locator,
-        trust_tier,
-    ))
+    let mut prov = Provenance::new(source.unwrap_or_default(), locator, trust_tier);
+    // ADJ-A9: attach any corroborating citations (documentary only — they do
+    // not change the LR arithmetic, only what the audit trail can list).
+    prov.corroborations = corroborations;
+    Ok(prov)
 }
 
 // ---------------------------------------------------------------------------
@@ -1104,6 +1111,53 @@ mod tests {
         let lowered = compile(src).unwrap();
         let contribs = lowered.kb.contributions_for(&core_atom("y"));
         assert_eq!(contribs[0].provenance.trust_tier, TrustTier::Unattributed);
+    }
+
+    #[test]
+    fn cites_lowers_to_corroborations_in_order() {
+        // ADJ-A9: `cites "<src>" locator "<loc>"` is repeatable and accumulates
+        // onto the clause's Provenance::corroborations without disturbing the
+        // primary source/locator/trust.
+        let src = r#"
+            contributes 2.5 from neutrophilia to bacterial_meningitis
+              source "Tunkel 2004"
+              locator "IDSA §3.2"
+              trust authoritative
+              cites "van de Beek 2006" locator "https://nejm.org/a"
+              cites "Brouwer 2010" locator "https://asm.org/b"
+        "#;
+        let lowered = compile(src).unwrap();
+        let contribs = lowered
+            .kb
+            .contributions_for(&core_atom("bacterial_meningitis"));
+        assert_eq!(contribs.len(), 1);
+        let p = &contribs[0].provenance;
+        // Primary citation untouched.
+        assert_eq!(p.source, "Tunkel 2004");
+        assert_eq!(p.locator.as_deref(), Some("IDSA §3.2"));
+        assert_eq!(p.trust_tier, TrustTier::Authoritative);
+        // Corroborations accumulate in source order, each with its locator.
+        assert_eq!(p.corroborations.len(), 2);
+        assert_eq!(p.corroborations[0].source, "van de Beek 2006");
+        assert_eq!(p.corroborations[0].locator, "https://nejm.org/a");
+        assert_eq!(p.corroborations[1].source, "Brouwer 2010");
+        assert_eq!(p.corroborations[1].locator, "https://asm.org/b");
+    }
+
+    #[test]
+    fn cites_repeats_freely_unlike_at_most_once_source() {
+        // A clause with NO corroborations still lowers (the common case).
+        let plain = compile("contributes 1.5 from x to y\n  source \"p\"").unwrap();
+        assert!(plain.kb.contributions_for(&core_atom("y"))[0]
+            .provenance
+            .corroborations
+            .is_empty());
+        // But a SECOND `source` is still rejected — only `cites` repeats.
+        let err = compile("prior 0.1 for y\n  source \"a\"\n  source \"b\"").unwrap_err();
+        assert!(matches!(
+            err,
+            crate::CompileError::Lower(LowerError::DuplicateAnnotation { name: "source" })
+        ));
     }
 
     #[test]

--- a/code/packages/rust/logic-engine/CHANGELOG.md
+++ b/code/packages/rust/logic-engine/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.23.0] - 2026-06-21 — multi-source corroboration on `Provenance` (ADJ-A9)
+
+### Added
+
+- **`Citation` { `source`, `locator` }** — a re-fetchable corroborating citation
+  (both fields required).
+- **`Provenance::corroborations: Vec<Citation>`** — co-equal citations that
+  support the *same* clause/LR. Distinct from `source_disagreements`, which
+  compares *different* clauses whose LRs disagree; these are documentary only
+  and carry **no** evidential weight (the LR arithmetic is unchanged — double-
+  counting the same fact would inflate posteriors). Builder
+  `Provenance::with_corroboration(source, locator)` appends one.
+
+### Compatibility
+
+- Fully additive: the new field defaults to empty in every constructor
+  (`new`, `cited`, `consensus`, `empirical`, `unattributed`, `Default`); all
+  existing callers and downstream consumers (`adj-lang`, `adj-constraint-solver`,
+  `adjudication-connector`, `adjudication-pipeline`, `prolog-loader`) compile and
+  pass unchanged.
+
 ## [0.22.0] - 2026-06-17 — mutual precedence is an honest CONFLICT, not silent double-defeat (ADJ73 §4.3)
 
 ### Fixed

--- a/code/packages/rust/logic-engine/Cargo.toml
+++ b/code/packages/rust/logic-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "logic-engine"
-version = "0.22.0"
+version = "0.23.0"
 edition = "2021"
 description = "Probability-aware facts, rules, KB, SLD find-first/enumerate + WMC posterior + LP19e likelihood-ratio Bayesian aggregation."
 

--- a/code/packages/rust/logic-engine/src/lib.rs
+++ b/code/packages/rust/logic-engine/src/lib.rs
@@ -64,7 +64,7 @@ pub use lr_aggregate::{
     PriorClause, SourceDisagreementReport, SourceLogitDelta, UncertaintyMarker, UncertaintyReport,
 };
 pub use proof_dag::{DerivationOrigin, Proof, ProofDAG, ProofStep};
-pub use provenance::{Provenance, TrustTier};
+pub use provenance::{Citation, Provenance, TrustTier};
 pub use wmc::weighted_model_count;
 
 // ---------------------------------------------------------------------------

--- a/code/packages/rust/logic-engine/src/provenance.rs
+++ b/code/packages/rust/logic-engine/src/provenance.rs
@@ -38,6 +38,38 @@ pub struct Provenance {
     pub locator: Option<String>,
     /// How much weight a reviewer should place on this clause.
     pub trust_tier: TrustTier,
+    /// **Corroborating** citations (ADJ-A9): additional independent sources
+    /// that support the *same* clause/LR. Distinct from the engine's
+    /// `source_disagreements` machinery, which compares *different* clauses
+    /// whose LRs **disagree**; these are co-equal citations for the same
+    /// fact, recorded so the audit trail can list every span a reader can
+    /// re-fetch. They are **documentary only** — they carry no extra
+    /// evidential weight and never enter the LR arithmetic (double-counting
+    /// the same fact would inflate posteriors). Empty for the common
+    /// single-citation case; defaults to empty everywhere.
+    pub corroborations: Vec<Citation>,
+}
+
+/// One corroborating citation (ADJ-A9). Both fields are required: a
+/// corroboration with no locator is not re-checkable, and the whole point is
+/// that an auditor can re-fetch the span. Co-equal with the clause's primary
+/// `source`/`locator`; inherits the clause's [`TrustTier`].
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Citation {
+    /// Human-readable citation span — the verbatim quote or reference.
+    pub source: String,
+    /// Where the span can be re-fetched — URL, page, section.
+    pub locator: String,
+}
+
+impl Citation {
+    /// Construct a corroborating citation from a source span + locator.
+    pub fn new(source: impl Into<String>, locator: impl Into<String>) -> Self {
+        Self {
+            source: source.into(),
+            locator: locator.into(),
+        }
+    }
 }
 
 /// A coarse trust-tier rank. The variants are ordered from highest
@@ -75,15 +107,12 @@ pub enum TrustTier {
 
 impl Provenance {
     /// Construct a `Provenance` with all three fields explicit.
-    pub fn new(
-        source: impl Into<String>,
-        locator: Option<String>,
-        trust_tier: TrustTier,
-    ) -> Self {
+    pub fn new(source: impl Into<String>, locator: Option<String>, trust_tier: TrustTier) -> Self {
         Self {
             source: source.into(),
             locator,
             trust_tier,
+            corroborations: Vec::new(),
         }
     }
 
@@ -116,6 +145,18 @@ impl Provenance {
     /// Returns a new value, leaves the receiver unchanged.
     pub fn with_locator(mut self, locator: impl Into<String>) -> Self {
         self.locator = Some(locator.into());
+        self
+    }
+
+    /// ADJ-A9: append a corroborating citation (a co-equal source for the
+    /// *same* fact). Documentary only — does not affect the LR arithmetic.
+    /// Returns a new value, leaves the receiver unchanged.
+    pub fn with_corroboration(
+        mut self,
+        source: impl Into<String>,
+        locator: impl Into<String>,
+    ) -> Self {
+        self.corroborations.push(Citation::new(source, locator));
         self
     }
 }
@@ -176,5 +217,30 @@ mod tests {
     #[test]
     fn default_is_unattributed() {
         assert_eq!(Provenance::default(), Provenance::unattributed());
+    }
+
+    #[test]
+    fn corroborations_default_empty_and_append_in_order() {
+        // ADJ-A9: the common case carries no corroborations.
+        let p = Provenance::cited("Tunkel 2004");
+        assert!(p.corroborations.is_empty());
+
+        // Two corroborating citations accumulate in call order, each carrying
+        // a required locator, and the primary citation is untouched.
+        let q = Provenance::cited("Tunkel 2004")
+            .with_locator("§3.2")
+            .with_corroboration("van de Beek 2006", "https://nejm.org/a")
+            .with_corroboration("Brouwer 2010", "https://asm.org/b");
+        assert_eq!(q.source, "Tunkel 2004");
+        assert_eq!(q.locator.as_deref(), Some("§3.2"));
+        assert_eq!(q.corroborations.len(), 2);
+        assert_eq!(
+            q.corroborations[0],
+            Citation::new("van de Beek 2006", "https://nejm.org/a")
+        );
+        assert_eq!(q.corroborations[1].source, "Brouwer 2010");
+        assert_eq!(q.corroborations[1].locator, "https://asm.org/b");
+        // Corroborations are documentary: trust tier is unchanged.
+        assert_eq!(q.trust_tier, TrustTier::Authoritative);
     }
 }

--- a/code/specs/ADJ-A9-multi-source-corroboration.md
+++ b/code/specs/ADJ-A9-multi-source-corroboration.md
@@ -1,0 +1,99 @@
+# ADJ-A9 — multi-source corroboration (`cites … locator …`)
+
+## Motivation
+
+ADJ46's awkwardness catalogue listed **A9 — source-disagreement aggregation
+(multiple citations per `(conclusion, evidence)`)** as a language-layer
+follow-up. This spec implements the *corroboration* half of A9: a single clause
+may carry **more than one citation** that all support the **same** likelihood
+ratio / edge.
+
+This is distinct from the engine's existing `source_disagreements` machinery,
+which handles the case where *different* `contributes` clauses (one LR per
+source) **disagree** about magnitude. A9 is the complementary case: the *same*
+LR is **corroborated** by several independent primary sources. The primary-
+source-first grounding discipline (MYCIN-2026) wants exactly this — a grounded
+fact is stronger when two or more re-fetchable spans say the same thing, and the
+audit trail should record every one of them, not just the first.
+
+Today the lowerer rejects a second `source`/`locator` on a clause with
+`LowerError::DuplicateAnnotation`. A9 keeps that rule for the **primary**
+citation (one `source` + one `locator` per clause, unchanged) and adds a new,
+*repeatable* annotation for **corroborating** citations.
+
+## Surface syntax
+
+A new repeatable annotation, valid wherever `source`/`locator`/`trust` are:
+
+```
+contributes 2.5 from neutrophil_predominance to bacterial_meningitis
+    source  "Tunkel et al., IDSA practice guidelines 2004"
+    locator "https://academic.oup.com/cid/article/39/9/1267"
+    trust   authoritative
+    cites   "van de Beek et al., NEJM 2006" locator "https://www.nejm.org/doi/full/10.1056/NEJMra052116"
+    cites   "Brouwer et al., Clin Microbiol Rev 2010" locator "https://journals.asm.org/doi/10.1128/CMR.00070-09"
+```
+
+- `cites STRING locator STRING` — a corroborating citation: a source span and
+  the locator (URL / page / §) where it can be re-fetched. **Both are
+  required** — a corroboration with no locator is not re-checkable, so the
+  grammar mandates the pair.
+- The `locator` keyword is **reused** (no new `at` keyword) to avoid reserving a
+  short, common word that rulebooks might want as an identifier. Only one new
+  keyword, `cites`, is added.
+- Corroborations are **repeatable** (zero or more per clause). The primary
+  `source`/`locator`/`trust` annotations remain **at-most-once** (unchanged).
+- Corroborations inherit the clause's `trust` tier — they are co-equal citations
+  for the same fact, not independent evidence at a different weight.
+
+## Semantics
+
+- Corroborations are **documentary only**: they do **not** change the engine's
+  arithmetic. They are NOT additional evidence and must not be double-counted as
+  extra LR weight — that would inflate posteriors. They ride inside the clause's
+  `Provenance` so every proof step that cites the clause can also list its
+  corroborating sources.
+- The proof DAG is unaffected structurally: corroborations are a field on the
+  existing `Provenance` value already threaded through every `DerivationOrigin`.
+
+## Data model (logic-engine)
+
+`Provenance` gains one additive field:
+
+```rust
+pub struct Provenance {
+    pub source: String,
+    pub locator: Option<String>,
+    pub trust_tier: TrustTier,
+    pub corroborations: Vec<Citation>,   // NEW — default empty
+}
+
+pub struct Citation {       // NEW
+    pub source: String,
+    pub locator: String,    // required: a corroboration must be re-fetchable
+}
+```
+
+The field defaults to empty, so every existing constructor (`new`, `cited`,
+`consensus`, `empirical`, `unattributed`, `Default`) and every existing caller
+is source-compatible. A builder `with_corroboration(source, locator)` appends
+one.
+
+## Lowering (adj-lang)
+
+`annotations_to_provenance` accumulates `Annotation::Cites { source, locator }`
+into `Provenance::corroborations` in source order. The at-most-once checks for
+`source`/`locator`/`trust` are unchanged; `cites` has no duplicate check (it is
+inherently repeatable).
+
+## Rendering (adj-lang-cli)
+
+The clause-provenance JSON gains a `"corroborations":[{ "source":…,
+"locator":… }]` array (empty when none). Existing `"source"/"locator"/"trust"`
+fields are unchanged, so existing recall/proof consumers keep working.
+
+## Out of scope (clean follow-ups)
+
+- Per-corroboration trust tiers (today they inherit the clause tier).
+- Surfacing corroborations in the differential `source_disagreements` report
+  (the disagreement case is already handled across separate clauses).


### PR DESCRIPTION
## What

Implements the **corroboration** half of ADJ46 awkwardness item **A9**: an ADJ clause may now carry one or more **corroborating** citations — co-equal sources for the *same* fact — via a new repeatable annotation:

```
contributes 2.5 from neutrophil_predominance to bacterial_meningitis
    source  "Tunkel et al., IDSA 2004"   locator "https://…/cid/39/9/1267"   trust authoritative
    cites   "van de Beek et al., NEJM 2006"          locator "https://www.nejm.org/…/NEJMra052116"
    cites   "Brouwer et al., Clin Microbiol Rev 2010" locator "https://…/CMR.00070-09"
```

## Why

This is the complement to the engine's existing `source_disagreements` machinery (which compares *different* clauses whose LRs **disagree**). A9 is the **same LR, multiple corroborating sources** case — exactly what primary-source-first grounding wants: a grounded fact is stronger when several re-fetchable spans say the same thing, and the audit trail should record **every** one, not just the first.

Corroborations are **documentary only** — they do **not** enter the LR arithmetic (double-counting the same fact would inflate posteriors). The security review explicitly confirmed there is no data path from a corroboration into any computation.

## Design

- One new keyword, `cites`. The existing `locator` keyword is **reused** as the separator (`cites "<src>" locator "<loc>"`) so the short, common word `at` is *not* reserved as a keyword.
- `cites` is **repeatable**; the primary `source`/`locator`/`trust` stay at-most-once (unchanged).
- Each corroboration requires a locator (a corroboration you can't re-fetch is useless).

## Changes

- **spec** (specs-first): `code/specs/ADJ-A9-multi-source-corroboration.md`
- **grammar**: `adj_lang.{tokens,grammar}` — `cites` keyword + `cites_annotation` rule; `_lexer_grammar.rs`/`_parser_grammar.rs` regenerated via `cargo run -p adj-lang --bin regen_grammars`
- **logic-engine 0.22.0 → 0.23.0**: additive `Provenance::corroborations: Vec<Citation>` + `Citation { source, locator }` + `with_corroboration` builder. Defaults empty in every constructor → fully source-compatible with all callers.
- **adj-lang 0.16.1 → 0.17.0**: `Annotation::Cites`; adapter + lower (accumulate in source order); 2 new lower tests.
- **adj-lang-cli 0.8.0 → 0.9.0**: renders `"corroborations":[{…}]` in clause provenance JSON (existing fields unchanged).
- README A9 marked covered; CHANGELOGs updated.

## Verification

- `cargo test -p logic-engine -p adj-lang -p adj-lang-cli` — all pass (incl. 3 new tests).
- Downstream consumers of the changed `logic-engine` all pass: `adj-constraint-solver`, `adjudication-connector`, `adjudication-pipeline`, `prolog-loader`.
- CLI end-to-end: a `relate` edge with two `cites` renders the `corroborations` array correctly.
- `cargo build --workspace` clean; security review (Rust diff inline) passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)