### PR TITLE
feat(mycin-derm): ground erythema migrans → Lyme disease edge

### DIFF
--- a/code/specs/data/mycin-2026/recall/derm-edges.adj
+++ b/code/specs/data/mycin-2026/recall/derm-edges.adj
@@ -83,4 +83,12 @@ rulebook derm_facts {
         source "Scarlet fever is a syndrome characterized by a blanching, erythematous, maculopapular rash often described as sandpaper-like, strawberry tongue, and exudative pharyngitis"
         locator "https://www.ncbi.nlm.nih.gov/books/NBK507889/"
         trust authoritative
+
+    % --- EXPAND: erythema migrans -> Lyme disease ------------------------------
+    % The Lyme Disease page states the lesion and the disease in one declarative:
+    % erythema migrans is the most common initial manifestation of Lyme disease.
+    relate skin_finding_in(erythema_migrans, lyme_disease)
+        source "In most cases, however, patients develop symptoms of Lyme disease, with erythema migrans being the most common initial manifestation."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK431066/"
+        trust authoritative
 }

--- a/code/specs/data/mycin-2026/recall/derm-recall.query.adj
+++ b/code/specs/data/mycin-2026/recall/derm-recall.query.adj
@@ -19,3 +19,4 @@ import "derm-edges.adj"
 ? skin_finding_in(herald_patch, $Disease)         % expect pityriasis_rosea
 ? skin_finding_in(nikolsky_sign, $Disease)        % expect pemphigus_vulgaris (expand)
 ? skin_finding_in(sandpaper_rash, $Disease)       % expect scarlet_fever (expand)
+? skin_finding_in(erythema_migrans, $Disease)     % expect lyme_disease (expand)

--- a/code/specs/data/mycin-2026/recall/test_derm_recall.py
+++ b/code/specs/data/mycin-2026/recall/test_derm_recall.py
@@ -36,6 +36,7 @@ EXPECTED = {
     "herald_patch": "pityriasis_rosea",
     "nikolsky_sign": "pemphigus_vulgaris",   # expand (NBK560860)
     "sandpaper_rash": "scarlet_fever",       # expand (NBK507889)
+    "erythema_migrans": "lyme_disease",      # expand (NBK431066)
 }
 REL = "skin_finding_in"
 VAR = "Disease"
@@ -58,7 +59,7 @@ def test_library_is_pure_adj_and_fully_grounded() -> None:
     text = ADJ.read_text()
     assert "trust consensus" not in text, "DERM ships no authored-debt; ground or omit"
     assert "[FLAG:" not in text
-    edge_count = len(EXPECTED)  # 4
+    edge_count = len(EXPECTED)  # 7
     assert text.count("    relate ") == edge_count
     assert text.count("trust authoritative") == edge_count
     assert text.count('\n        locator "') == edge_count


### PR DESCRIPTION
## What

Adds the seventh grounded edge to the DERM morphology recall library (`code/specs/data/mycin-2026/recall/`): **erythema_migrans → lyme_disease**.

## Grounding

- **source** (verbatim, byte-stable): `In most cases, however, patients develop symptoms of Lyme disease, with erythema migrans being the most common initial manifestation.`
- **locator**: https://www.ncbi.nlm.nih.gov/books/NBK431066/
- **trust**: authoritative

One self-contained declarative naming both the lesion morphology (erythema migrans) and the disease (Lyme disease) — high-yield board buzzword.

## Changes (data-only)

- `derm-edges.adj` — +1 `relate` clause (inline source+locator, `trust authoritative`)
- `derm-recall.query.adj` — +1 binding query
- `test_derm_recall.py` — `EXPECTED` +1; stale `edge_count` comment fixed (4→7); `malar_rash` negative-control abstain test unchanged

## Verification

- `test_derm_recall: 3/3 passed` (engine binds `lyme_disease` with authoritative citation; shape checks; off-vocabulary finding abstains)
- ruff clean
- data-only security review passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)