### PR TITLE
feat(x86-sim): PR-S1 — integer core + MachineCodeHarness (run x86_64 codegen locally)

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -264,6 +264,7 @@ members = [
     "r-runtime",
     "r-vector",
     "riscv-simulator",
+    "x86-simulator",
     "rom-bios",
     "ruby-lexer",
     "ruby-parser",

--- a/code/packages/rust/x86-simulator/BUILD
+++ b/code/packages/rust/x86-simulator/BUILD
@@ -1,0 +1,1 @@
+cargo test -p x86-simulator -- --nocapture

--- a/code/packages/rust/x86-simulator/BUILD_windows
+++ b/code/packages/rust/x86-simulator/BUILD_windows
@@ -1,0 +1,1 @@
+cargo test -p x86-simulator -- --nocapture

--- a/code/packages/rust/x86-simulator/CHANGELOG.md
+++ b/code/packages/rust/x86-simulator/CHANGELOG.md
@@ -1,0 +1,40 @@
+# Changelog — x86-simulator
+
+## 0.1.0 — 2026-06-21 — integer core + MachineCodeHarness (x86-sim PR-S1)
+
+The first runnable slice: a Rust runtime simulator that decodes and executes the
+64-bit x86 integer subset the `x86_64-backend` emits, and a harness that runs the
+backend's compiled output locally — closing the gap where the x86_64 backend was
+verified locally only by byte tests and *executed* only on an x86 CI runner.
+
+### Added
+- **`state`** — `CpuState`: 16 GPRs (hardware numbering), `rip`, the RFLAGS
+  subset (CF/ZF/SF/OF/PF/AF) emitted code uses, and the XMM file (for the coming
+  SSE2 phase).
+- **`flags`** — `add_with_flags`/`sub_with_flags`/`logic_flags` and the 16
+  condition codes via `condition_holds`, per `07w-x86-64-simulator.md`.
+- **`memory`** — a flat, little-endian, **bounds-checked** address space (a
+  sandbox) with a monotonic bump heap backing `__twig_alloc_bytes`.
+- **`decode`** — a REX/ModRM/SIB decoder for the `x86_64-encoder` subset:
+  `push`/`pop`, `mov` (reg/mem/imm), `movzx`, `lea`, `add`/`sub`/`cmp`/`and`/
+  `or`/`xor`/`test` (reg + imm), `shl`/`shr`/`sar`, `imul`, `jmp`/`jcc`/`call`/
+  `ret`, `ud2`. Unknown opcodes → a clean `DecodeError` (fail-closed).
+- **`execute`** — per-instruction execution with full flag computation and a
+  `Flow` the step loop acts on.
+- **`Simulator`** (`lib`) — `step`/`run`; `ret` to a stack sentinel halts and
+  yields the exit code (`rax & 0xFF`); host-import shims for `__twig_alloc_bytes`
+  / `putchar` / `getchar` / `print_i64` (System V ABI), like `wasm-runtime`.
+- **`harness::MachineCodeHarness`** — load the backend's per-function byte blobs
+  + relocations, patch internal `call`s, route external calls to host shims, set
+  up the stack, and produce a ready-to-run `Simulator`.
+
+### Verified
+- Decodes the exact prologue/`const`/`ret` bytes the `x86_64-backend` emits.
+- **End-to-end**: compiles `const 42; ret` and `40 + 2` with the **real**
+  `x86_64-backend` and runs the machine code → exit **42**, locally (on an
+  aarch64 host). 15 tests (flags, decode, memory, execute, integration).
+
+### Next
+S2 — SSE2 scalar doubles (run E3 ALGOL `real` x86_64 output); S3 — wire a local
+`run_x86_sim` matrix path + retro-verify E5 native arrays / E3 floats; S4 —
+32-bit x86.

--- a/code/packages/rust/x86-simulator/Cargo.toml
+++ b/code/packages/rust/x86-simulator/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "x86-simulator"
+version = "0.1.0"
+edition = "2021"
+description = "x86/x86-64 runtime simulator — decode + execute machine code, and run the x86_64-backend's emitted code locally (host-arch-independent)"
+
+[dependencies]
+x86_64-encoder = { path = "../x86_64-encoder" }
+
+[dev-dependencies]
+x86_64-backend = { path = "../x86_64-backend" }
+jit-core = { path = "../jit-core" }

--- a/code/packages/rust/x86-simulator/README.md
+++ b/code/packages/rust/x86-simulator/README.md
@@ -1,0 +1,67 @@
+# x86 / x86-64 Runtime Simulator (Rust)
+
+A runtime simulator that **decodes and executes the 64-bit x86 machine code the
+in-repo `x86_64-backend` emits** — so that backend's output can be *run* on any
+host architecture, not just byte-compared. On an Apple Silicon (aarch64) machine
+the LANG-FULL matrix's `NativeAot` cell only ever runs the *aarch64* backend; the
+x86_64 backend is verified locally by byte tests and actually executed only on an
+x86 CI runner. This crate closes that gap: it runs x86_64 codegen **locally**.
+
+It is the runtime sibling of `riscv-simulator` (same `new`/`load`/`run`/`step`
+shape) and uses the ISA semantics in
+[`07w-x86-64-simulator.md`](../../../specs/07w-x86-64-simulator.md).
+
+## What it runs
+
+The subset the `x86_64-encoder` emits (and growing):
+
+- **Moves / addressing**: `mov` reg↔reg, reg↔`[base+disp]`, `mov reg,imm32`,
+  `movzx reg,byte[mem]`, `lea reg,[mem]` (incl. RIP-relative); REX/ModRM/SIB.
+- **Integer ALU**: `add` / `sub` / `cmp` / `and` / `or` / `xor` / `test` (reg and
+  imm forms), `shl` / `shr` / `sar`, `imul` — all with full CF/ZF/SF/OF/PF flags.
+- **Control flow**: `jmp`, `jcc` (all 16 conditions), `call` / `ret`, `push` /
+  `pop`, and `ud2` → an illegal-instruction **trap** (how an E5 out-of-bounds
+  array access aborts).
+
+Pending phases: SSE2 scalar doubles (`movsd`/`addsd`/`ucomisd`/`cvt*`, for E3
+ALGOL `real`), and 32-bit x86. Anything unimplemented is a clean `DecodeError`.
+
+## How to use it
+
+The high-level entry is the **`MachineCodeHarness`** — the bridge that runs the
+backend's output, mirroring `wasm-runtime`'s host-import model:
+
+```rust
+use x86_simulator::harness::{MachineCodeHarness, Reloc};
+
+// `bytes` + `relocs` come from x86_64_backend::compile_function_with_relocs(...)
+let mut sim = MachineCodeHarness::new()
+    .function("main", &bytes, &relocs)
+    .build("main")?;
+let exit_code = sim.run()?;   // executes the real x86_64 machine code
+```
+
+The harness lays the function bytes into a flat sandboxed address space, patches
+internal `call` relocations, routes external calls (`__twig_alloc_bytes` via a
+bump heap, `putchar` / `print_i64` via captured I/O) to host shims, sets up a
+stack with a return sentinel, and runs from the entry — returning `rax & 0xFF`
+as the exit code (the same convention as `run_native` / `run_wasm`).
+
+## Safety
+
+The simulator is a sandbox: every memory access is bounds-checked and every
+unknown/illegal instruction or unresolved symbol is a `Trap`. A guest program
+can only ever fault — it cannot escape or touch host memory.
+
+## Layout
+
+```
+src/
+├── state.rs    # CpuState: 16 GPRs, rip, RFLAGS subset, XMM file
+├── flags.rs    # add/sub_with_flags, condition_holds (07w rules)
+├── memory.rs   # flat little-endian address space + bump heap
+├── decode.rs   # REX/ModRM/SIB decoder → typed Instr
+├── execute.rs  # per-instruction execution
+├── harness.rs  # MachineCodeHarness — load + run backend output
+└── lib.rs      # Simulator (step/run) + host imports
+```

--- a/code/packages/rust/x86-simulator/src/decode.rs
+++ b/code/packages/rust/x86-simulator/src/decode.rs
@@ -1,0 +1,318 @@
+//! A decoder for the 64-bit x86 subset the in-repo `x86_64-encoder` emits.
+//!
+//! This is **not** a full x86 decoder — it covers the instructions our backend
+//! generates (and grows as the backend grows). Anything else is a clean
+//! [`Trap::DecodeError`] (fail-closed). All operations are 64-bit operand size
+//! (REX.W), the only width the backend uses for register values, plus the byte
+//! loads/stores the byte-tape/array element headers use.
+//!
+//! ## Instruction encoding (the parts we need)
+//!
+//! ```text
+//!   [REX] opcode [ModRM [SIB] [disp]] [imm]
+//! ```
+//! - **REX** (`0x40..=0x4F`): `0100 WRXB`. `W`=64-bit operand, `R`=ModRM.reg
+//!   bit 3, `X`=SIB.index bit 3, `B`=ModRM.rm / opcode-reg bit 3.
+//! - **ModRM**: `mod(2) reg(3) rm(3)`. `mod==11` ⇒ rm is a register; otherwise a
+//!   memory operand (`[base + disp]`, with `rm==101 && mod==00` meaning RIP-rel,
+//!   `rm==100` meaning a SIB byte follows).
+
+use crate::state::Reg;
+use crate::trap::Trap;
+
+/// A decoded source/destination location.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Operand {
+    /// A register.
+    Reg(Reg),
+    /// `[base + index*scale + disp]`. `index == None` for no index; `rip` true
+    /// for RIP-relative (`disp` is relative to the *next* instruction).
+    Mem { base: Option<Reg>, index: Option<Reg>, scale: u8, disp: i64, rip: bool },
+}
+
+/// A decoded instruction (the subset we execute — see [`super::execute`]).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Instr {
+    Push(Reg),
+    Pop(Reg),
+    /// `mov dst, src` — 64-bit. Exactly one of dst/src is memory (or both reg).
+    Mov { dst: Operand, src: Operand },
+    /// `mov reg, imm` (imm sign-extended to 64).
+    MovImm { dst: Operand, imm: i64 },
+    /// `movzx reg64, byte [mem]`.
+    Movzx { dst: Reg, src: Operand },
+    /// `lea reg, mem`.
+    Lea { dst: Reg, src: Operand },
+    /// Integer ALU `op dst, src` (dst is reg or mem, src reg/mem/imm).
+    Alu { op: AluOp, dst: Operand, src: Operand },
+    /// `op dst, imm` (imm sign-extended).
+    AluImm { op: AluOp, dst: Operand, imm: i64 },
+    /// `shl/shr/sar dst, imm8`.
+    Shift { op: ShiftOp, dst: Operand, amount: u8 },
+    /// `imul reg, rm` (two-operand).
+    Imul { dst: Reg, src: Operand },
+    /// `jmp rel` (absolute target already resolved from rip+rel).
+    Jmp(i64),
+    /// `jcc rel` — relative displacement; the condition nibble is `cond`.
+    Jcc { cond: u8, rel: i64 },
+    /// `call rel` — relative displacement (resolved to a target at execute time).
+    Call(i64),
+    Ret,
+    /// `ud2` — illegal-instruction trap.
+    Ud2,
+    /// `nop`.
+    Nop,
+}
+
+/// Integer ALU ops we decode (all set flags).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[allow(missing_docs)]
+pub enum AluOp { Add, Sub, Cmp, And, Or, Xor, Test }
+
+/// Shift ops.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[allow(missing_docs)]
+pub enum ShiftOp { Shl, Shr, Sar }
+
+/// One decoded instruction plus its byte length.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Decoded {
+    pub instr: Instr,
+    pub len: usize,
+}
+
+/// Decode the instruction at `code[off..]`. `off` is the byte offset *within the
+/// code region*; RIP-relative displacements are resolved against `off + len`.
+pub fn decode(code: &[u8], off: usize) -> Result<Decoded, Trap> {
+    let mut p = off;
+    let at = |p: usize| -> Result<u8, Trap> {
+        code.get(p).copied().ok_or(Trap::DecodeError { offset: p as u64, opcode: 0 })
+    };
+
+    // ── REX prefix ──────────────────────────────────────────────────────────
+    let mut rex_w = false;
+    let mut rex_r = false;
+    let mut rex_x = false;
+    let mut rex_b = false;
+    let b0 = at(p)?;
+    if (0x40..=0x4F).contains(&b0) {
+        rex_w = b0 & 0x8 != 0;
+        rex_r = b0 & 0x4 != 0;
+        rex_x = b0 & 0x2 != 0;
+        rex_b = b0 & 0x1 != 0;
+        p += 1;
+    }
+    let _ = rex_w; // every op we handle is 64-bit; tracked for future widths
+    let _ = rex_x;
+
+    let op = at(p)?;
+    p += 1;
+
+    // push/pop r64 (REX.B extends the register).
+    if (0x50..=0x57).contains(&op) {
+        let r = Reg::from_index((op - 0x50) | ((rex_b as u8) << 3));
+        return Ok(Decoded { instr: Instr::Push(r), len: p - off });
+    }
+    if (0x58..=0x5F).contains(&op) {
+        let r = Reg::from_index((op - 0x58) | ((rex_b as u8) << 3));
+        return Ok(Decoded { instr: Instr::Pop(r), len: p - off });
+    }
+
+    match op {
+        0xC3 => return Ok(Decoded { instr: Instr::Ret, len: p - off }),
+        0x90 => return Ok(Decoded { instr: Instr::Nop, len: p - off }),
+        // jmp rel8 / rel32
+        0xEB => { let r = at(p)? as i8 as i64; p += 1; return Ok(Decoded { instr: Instr::Jmp(rel_target(p, r)), len: p - off }); }
+        0xE9 => { let r = read_i32(code, p)? as i64; p += 4; return Ok(Decoded { instr: Instr::Jmp(rel_target(p, r)), len: p - off }); }
+        0xE8 => { let r = read_i32(code, p)? as i64; p += 4; return Ok(Decoded { instr: Instr::Call(rel_target(p, r)), len: p - off }); }
+        // jcc rel8 (0x70..0x7F)
+        0x70..=0x7F => { let r = at(p)? as i8 as i64; p += 1; return Ok(Decoded { instr: Instr::Jcc { cond: op - 0x70, rel: rel_target(p, r) }, len: p - off }); }
+        _ => {}
+    }
+
+    // Two-byte 0F opcodes.
+    if op == 0x0F {
+        let op2 = at(p)?; p += 1;
+        match op2 {
+            0x0B => return Ok(Decoded { instr: Instr::Ud2, len: p - off }),
+            0xAF => { // imul r64, r/m64
+                let (m, np) = modrm(code, p, rex_r, rex_x, rex_b)?; p = np;
+                let dst = reg_of(m.reg);
+                return Ok(Decoded { instr: Instr::Imul { dst, src: m.rm }, len: p - off });
+            }
+            0xB6 => { // movzx r64, r/m8
+                let (m, np) = modrm(code, p, rex_r, rex_x, rex_b)?; p = np;
+                return Ok(Decoded { instr: Instr::Movzx { dst: reg_of(m.reg), src: m.rm }, len: p - off });
+            }
+            0x80..=0x8F => { // jcc rel32
+                let r = read_i32(code, p)? as i64; p += 4;
+                return Ok(Decoded { instr: Instr::Jcc { cond: op2 - 0x80, rel: rel_target(p, r) }, len: p - off });
+            }
+            other => return Err(Trap::DecodeError { offset: (p - 1) as u64, opcode: other }),
+        }
+    }
+
+    // ModRM-based one-byte opcodes.
+    match op {
+        0x89 => { let (m, np) = modrm(code, p, rex_r, rex_x, rex_b)?; Ok(Decoded { instr: Instr::Mov { dst: m.rm, src: Operand::Reg(reg_of(m.reg)) }, len: np - off }) }
+        0x8B => { let (m, np) = modrm(code, p, rex_r, rex_x, rex_b)?; Ok(Decoded { instr: Instr::Mov { dst: Operand::Reg(reg_of(m.reg)), src: m.rm }, len: np - off }) }
+        0x8D => { let (m, np) = modrm(code, p, rex_r, rex_x, rex_b)?; Ok(Decoded { instr: Instr::Lea { dst: reg_of(m.reg), src: m.rm }, len: np - off }) }
+        0x01 => alu_rr(code, p, rex_r, rex_x, rex_b, off, AluOp::Add, true),
+        0x03 => alu_rr(code, p, rex_r, rex_x, rex_b, off, AluOp::Add, false),
+        0x29 => alu_rr(code, p, rex_r, rex_x, rex_b, off, AluOp::Sub, true),
+        0x2B => alu_rr(code, p, rex_r, rex_x, rex_b, off, AluOp::Sub, false),
+        0x39 => alu_rr(code, p, rex_r, rex_x, rex_b, off, AluOp::Cmp, true),
+        0x3B => alu_rr(code, p, rex_r, rex_x, rex_b, off, AluOp::Cmp, false),
+        0x21 => alu_rr(code, p, rex_r, rex_x, rex_b, off, AluOp::And, true),
+        0x09 => alu_rr(code, p, rex_r, rex_x, rex_b, off, AluOp::Or, true),
+        0x31 => alu_rr(code, p, rex_r, rex_x, rex_b, off, AluOp::Xor, true),
+        0x85 => alu_rr(code, p, rex_r, rex_x, rex_b, off, AluOp::Test, true),
+        // group1: op r/m64, imm32 (0x81) or imm8 (0x83); /reg selects the op.
+        0x81 | 0x83 => {
+            let (m, np) = modrm(code, p, rex_r, rex_x, rex_b)?;
+            let mut p2 = np;
+            let imm = if op == 0x81 { let v = read_i32(code, p2)? as i64; p2 += 4; v }
+                      else { let v = code.get(p2).copied().ok_or(Trap::DecodeError { offset: p2 as u64, opcode: 0 })? as i8 as i64; p2 += 1; v };
+            let aop = match m.reg & 0x7 {
+                0 => AluOp::Add, 1 => AluOp::Or, 4 => AluOp::And, 5 => AluOp::Sub, 7 => AluOp::Cmp, 6 => AluOp::Xor,
+                other => return Err(Trap::DecodeError { offset: off as u64, opcode: 0x80 | other }),
+            };
+            Ok(Decoded { instr: Instr::AluImm { op: aop, dst: m.rm, imm }, len: p2 - off })
+        }
+        // mov r/m64, imm32  (0xC7 /0)
+        0xC7 => {
+            let (m, np) = modrm(code, p, rex_r, rex_x, rex_b)?;
+            let imm = read_i32(code, np)? as i64;
+            Ok(Decoded { instr: Instr::MovImm { dst: m.rm, imm }, len: np + 4 - off })
+        }
+        // shift r/m64, imm8 (0xC1 /4=shl /5=shr /7=sar)
+        0xC1 => {
+            let (m, np) = modrm(code, p, rex_r, rex_x, rex_b)?;
+            let amt = code.get(np).copied().ok_or(Trap::DecodeError { offset: np as u64, opcode: 0 })?;
+            let sop = match m.reg & 0x7 { 4 => ShiftOp::Shl, 5 => ShiftOp::Shr, 7 => ShiftOp::Sar,
+                other => return Err(Trap::DecodeError { offset: off as u64, opcode: 0xC0 | other }) };
+            Ok(Decoded { instr: Instr::Shift { op: sop, dst: m.rm, amount: amt }, len: np + 1 - off })
+        }
+        other => Err(Trap::DecodeError { offset: (p - 1) as u64, opcode: other }),
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn alu_rr(code: &[u8], p: usize, r: bool, x: bool, b: bool, off: usize, op: AluOp, rm_is_dst: bool) -> Result<Decoded, Trap> {
+    let (m, np) = modrm(code, p, r, x, b)?;
+    let (dst, src) = if rm_is_dst { (m.rm, Operand::Reg(reg_of(m.reg))) }
+                     else { (Operand::Reg(reg_of(m.reg)), m.rm) };
+    Ok(Decoded { instr: Instr::Alu { op, dst, src }, len: np - off })
+}
+
+/// Resolve a relative branch to an absolute *code-region* offset. `cursor` is
+/// the byte offset just past the instruction (= rip-relative base), so the
+/// target is `cursor + rel`.
+fn rel_target(cursor: usize, rel: i64) -> i64 { cursor as i64 + rel }
+
+fn reg_of(i: u8) -> Reg { Reg::from_index(i) }
+
+struct ModRm { reg: u8, rm: Operand }
+
+/// Decode a ModRM byte (and any SIB/displacement). Returns the parsed operand
+/// info and the new cursor position.
+fn modrm(code: &[u8], p: usize, rex_r: bool, rex_x: bool, rex_b: bool) -> Result<(ModRm, usize), Trap> {
+    let byte = code.get(p).copied().ok_or(Trap::DecodeError { offset: p as u64, opcode: 0 })?;
+    let mut cur = p + 1;
+    let md = byte >> 6;
+    let reg = (byte >> 3 & 0x7) | ((rex_r as u8) << 3);
+    let rm_field = byte & 0x7;
+
+    if md == 0b11 {
+        let r = Reg::from_index(rm_field | ((rex_b as u8) << 3));
+        return Ok((ModRm { reg, rm: Operand::Reg(r) }, cur));
+    }
+
+    // Memory operand.
+    let mut base: Option<Reg> = None;
+    let mut index: Option<Reg> = None;
+    let mut scale = 1u8;
+    let mut rip = false;
+
+    if rm_field == 0b100 {
+        // SIB byte.
+        let sib = code.get(cur).copied().ok_or(Trap::DecodeError { offset: cur as u64, opcode: 0 })?;
+        cur += 1;
+        scale = 1 << (sib >> 6);
+        let idx = (sib >> 3 & 0x7) | ((rex_x as u8) << 3);
+        if idx != 0b100 { index = Some(Reg::from_index(idx)); } // index==100 (no REX.X) → none
+        let bas = (sib & 0x7) | ((rex_b as u8) << 3);
+        // base==101 with mod==00 means disp32 with no base; otherwise a register.
+        if (sib & 0x7) == 0b101 && md == 0b00 { base = None; } else { base = Some(Reg::from_index(bas)); }
+    } else if rm_field == 0b101 && md == 0b00 {
+        rip = true; // RIP-relative
+    } else {
+        base = Some(Reg::from_index(rm_field | ((rex_b as u8) << 3)));
+    }
+
+    let disp: i64 = match md {
+        0b00 => if rip || (rm_field == 0b100 && base.is_none()) { let d = read_i32(code, cur)? as i64; cur += 4; d } else { 0 },
+        0b01 => { let d = code.get(cur).copied().ok_or(Trap::DecodeError { offset: cur as u64, opcode: 0 })? as i8 as i64; cur += 1; d }
+        0b10 => { let d = read_i32(code, cur)? as i64; cur += 4; d }
+        _ => 0,
+    };
+
+    Ok((ModRm { reg, rm: Operand::Mem { base, index, scale, disp, rip } }, cur))
+}
+
+fn read_i32(code: &[u8], p: usize) -> Result<i32, Trap> {
+    let b = code.get(p..p + 4).ok_or(Trap::DecodeError { offset: p as u64, opcode: 0 })?;
+    Ok(i32::from_le_bytes([b[0], b[1], b[2], b[3]]))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // The exact prologue/const/ret bytes the x86_64-backend emits for
+    // `const_u64 v=42; ret_u64 v` (captured from compile_function_with_relocs).
+    const MIN_FN: &[u8] = &[
+        0x55,                                     // push rbp
+        0x48, 0x89, 0xE5,                         // mov rbp, rsp
+        0x48, 0x81, 0xEC, 0x10, 0x00, 0x00, 0x00, // sub rsp, 0x10
+        0x48, 0xC7, 0xC0, 0x2A, 0x00, 0x00, 0x00, // mov rax, 42
+        0x48, 0x89, 0x85, 0xF8, 0xFF, 0xFF, 0xFF, // mov [rbp-8], rax
+        0x48, 0x8B, 0x85, 0xF8, 0xFF, 0xFF, 0xFF, // mov rax, [rbp-8]
+        0x48, 0x89, 0xEC,                         // mov rsp, rbp
+        0x5D,                                     // pop rbp
+        0xC3,                                     // ret
+    ];
+
+    fn decode_all(code: &[u8]) -> Vec<Instr> {
+        let mut out = Vec::new();
+        let mut off = 0;
+        while off < code.len() {
+            let d = decode(code, off).unwrap_or_else(|e| panic!("decode at {off}: {e}"));
+            out.push(d.instr.clone());
+            off += d.len;
+        }
+        out
+    }
+
+    #[test]
+    fn decodes_the_backend_prologue_const_ret() {
+        let instrs = decode_all(MIN_FN);
+        assert_eq!(instrs[0], Instr::Push(Reg::Rbp));
+        assert_eq!(instrs[1], Instr::Mov { dst: Operand::Reg(Reg::Rbp), src: Operand::Reg(Reg::Rsp) });
+        assert_eq!(instrs[2], Instr::AluImm { op: AluOp::Sub, dst: Operand::Reg(Reg::Rsp), imm: 0x10 });
+        assert_eq!(instrs[3], Instr::MovImm { dst: Operand::Reg(Reg::Rax), imm: 42 });
+        // mov [rbp-8], rax
+        assert_eq!(instrs[4], Instr::Mov {
+            dst: Operand::Mem { base: Some(Reg::Rbp), index: None, scale: 1, disp: -8, rip: false },
+            src: Operand::Reg(Reg::Rax) });
+        assert_eq!(instrs.last(), Some(&Instr::Ret));
+    }
+
+    #[test]
+    fn ud2_and_jcc_decode() {
+        assert_eq!(decode(&[0x0F, 0x0B], 0).unwrap().instr, Instr::Ud2);
+        // jb rel8 +5  (0x72 0x05)
+        let d = decode(&[0x72, 0x05], 0).unwrap();
+        assert_eq!(d.instr, Instr::Jcc { cond: 0x2, rel: 7 }); // 2 (len) + 5
+    }
+}

--- a/code/packages/rust/x86-simulator/src/execute.rs
+++ b/code/packages/rust/x86-simulator/src/execute.rs
@@ -1,0 +1,168 @@
+//! Execute one decoded [`Instr`] against the CPU + memory.
+//!
+//! All register operations are 64-bit. `Cmp`/`Test` set flags without writing a
+//! result; the other ALU ops write back. Control-flow instructions return a
+//! [`Flow`] the step loop acts on.
+
+use crate::decode::{AluOp, Instr, Operand, ShiftOp};
+use crate::flags::{add_with_flags, logic_flags, sub_with_flags};
+use crate::state::{CpuState, Reg};
+use crate::memory::Memory;
+use crate::trap::Trap;
+
+/// What the step loop should do after an instruction.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Flow {
+    /// Fall through to `next_ip`.
+    Next,
+    /// Set rip to this absolute address.
+    Jump(u64),
+    /// `call`: `target` is the internal address; `site` is the rel32 patch offset
+    /// the step loop checks against the relocation table — if it names an external
+    /// symbol a host shim runs, otherwise it's an internal call to `target`.
+    Call { target: u64, site: usize },
+    /// `ret`: pop the return address into rip.
+    Ret,
+    /// `ud2`.
+    Trap,
+}
+
+/// Effective address of a memory operand. `next_ip` is the absolute address of
+/// the *following* instruction (RIP-relative base).
+fn effective_addr(st: &CpuState, op: &Operand, next_ip: u64) -> u64 {
+    match op {
+        Operand::Reg(_) => unreachable!("effective_addr on a register operand"),
+        Operand::Mem { base, index, scale, disp, rip } => {
+            let mut a = if *rip { next_ip } else { 0 };
+            if let Some(b) = base { a = a.wrapping_add(st.get(*b)); }
+            if let Some(i) = index { a = a.wrapping_add(st.get(*i).wrapping_mul(*scale as u64)); }
+            a.wrapping_add(*disp as u64)
+        }
+    }
+}
+
+/// Read an operand as a `width`-byte (1/8) value, zero-extended.
+fn read_op(st: &CpuState, mem: &Memory, op: &Operand, next_ip: u64, width: u8) -> Result<u64, Trap> {
+    match op {
+        Operand::Reg(r) => Ok(if width == 8 { st.get(*r) } else { st.get(*r) & ((1u64 << (8 * width)) - 1) }),
+        Operand::Mem { .. } => mem.load(effective_addr(st, op, next_ip), width),
+    }
+}
+
+/// Write a `width`-byte value to an operand.
+fn write_op(st: &mut CpuState, mem: &mut Memory, op: &Operand, next_ip: u64, width: u8, v: u64) -> Result<(), Trap> {
+    match op {
+        Operand::Reg(r) => { st.set(*r, v); Ok(()) }
+        Operand::Mem { .. } => { let a = effective_addr(st, op, next_ip); mem.store(a, width, v) }
+    }
+}
+
+/// Execute one instruction. `code_base` is where the code region starts in
+/// memory (branch targets are code-region offsets); `next_ip` is the absolute
+/// address of the following instruction.
+pub fn exec_one(
+    st: &mut CpuState,
+    mem: &mut Memory,
+    ins: &Instr,
+    code_base: u64,
+    next_ip: u64,
+    instr_off: usize,
+) -> Result<Flow, Trap> {
+    match ins {
+        Instr::Nop => Ok(Flow::Next),
+        Instr::Push(r) => {
+            let sp = st.get(Reg::Rsp).wrapping_sub(8);
+            mem.store(sp, 8, st.get(*r))?;
+            st.set(Reg::Rsp, sp);
+            Ok(Flow::Next)
+        }
+        Instr::Pop(r) => {
+            let sp = st.get(Reg::Rsp);
+            let v = mem.load(sp, 8)?;
+            st.set(*r, v);
+            st.set(Reg::Rsp, sp.wrapping_add(8));
+            Ok(Flow::Next)
+        }
+        Instr::Mov { dst, src } => {
+            let v = read_op(st, mem, src, next_ip, 8)?;
+            write_op(st, mem, dst, next_ip, 8, v)?;
+            Ok(Flow::Next)
+        }
+        Instr::MovImm { dst, imm } => {
+            write_op(st, mem, dst, next_ip, 8, *imm as u64)?;
+            Ok(Flow::Next)
+        }
+        Instr::Movzx { dst, src } => {
+            let v = read_op(st, mem, src, next_ip, 1)?;
+            st.set(*dst, v & 0xFF);
+            Ok(Flow::Next)
+        }
+        Instr::Lea { dst, src } => {
+            let a = effective_addr(st, src, next_ip);
+            st.set(*dst, a);
+            Ok(Flow::Next)
+        }
+        Instr::Alu { op, dst, src } => {
+            let a = read_op(st, mem, dst, next_ip, 8)?;
+            let b = read_op(st, mem, src, next_ip, 8)?;
+            apply_alu(st, mem, *op, dst, next_ip, a, b)
+        }
+        Instr::AluImm { op, dst, imm } => {
+            let a = read_op(st, mem, dst, next_ip, 8)?;
+            apply_alu(st, mem, *op, dst, next_ip, a, *imm as u64)
+        }
+        Instr::Shift { op, dst, amount } => {
+            let a = read_op(st, mem, dst, next_ip, 8)?;
+            let s = (*amount as u32) & 63;
+            let res = match op {
+                ShiftOp::Shl => a.wrapping_shl(s),
+                ShiftOp::Shr => a.wrapping_shr(s),
+                ShiftOp::Sar => (a as i64).wrapping_shr(s) as u64,
+            };
+            // Flags after a shift: ZF/SF/PF from the result (CF/OF modelling is
+            // not needed by emitted code, which only branches on the value).
+            st.flags = logic_flags(res);
+            write_op(st, mem, dst, next_ip, 8, res)?;
+            Ok(Flow::Next)
+        }
+        Instr::Imul { dst, src } => {
+            let a = st.get(*dst);
+            let b = read_op(st, mem, src, next_ip, 8)?;
+            st.set(*dst, a.wrapping_mul(b));
+            Ok(Flow::Next)
+        }
+        Instr::Jmp(t) => Ok(Flow::Jump(code_base.wrapping_add(*t as u64))),
+        Instr::Jcc { cond, rel } => {
+            let c = crate::flags::Cond::from_nibble(*cond);
+            if crate::flags::condition_holds(c, &st.flags) {
+                Ok(Flow::Jump(code_base.wrapping_add(*rel as u64)))
+            } else {
+                Ok(Flow::Next)
+            }
+        }
+        Instr::Call(t) => {
+            // `instr_off` is this call's offset; the rel32 patch site is at +1.
+            // The step loop decides internal vs external using that site.
+            Ok(Flow::Call { target: code_base.wrapping_add(*t as u64), site: instr_off + 1 })
+        }
+        Instr::Ret => Ok(Flow::Ret),
+        Instr::Ud2 => Ok(Flow::Trap),
+    }
+}
+
+fn apply_alu(st: &mut CpuState, mem: &mut Memory, op: AluOp, dst: &Operand, next_ip: u64, a: u64, b: u64) -> Result<Flow, Trap> {
+    let (res, flags, writes) = match op {
+        AluOp::Add => { let (r, f) = add_with_flags(a, b); (r, f, true) }
+        AluOp::Sub => { let (r, f) = sub_with_flags(a, b); (r, f, true) }
+        AluOp::Cmp => { let (r, f) = sub_with_flags(a, b); (r, f, false) }
+        AluOp::And => { let r = a & b; (r, logic_flags(r), true) }
+        AluOp::Or => { let r = a | b; (r, logic_flags(r), true) }
+        AluOp::Xor => { let r = a ^ b; (r, logic_flags(r), true) }
+        AluOp::Test => { let r = a & b; (r, logic_flags(r), false) }
+    };
+    st.flags = flags;
+    if writes {
+        write_op(st, mem, dst, next_ip, 8, res)?;
+    }
+    Ok(Flow::Next)
+}

--- a/code/packages/rust/x86-simulator/src/flags.rs
+++ b/code/packages/rust/x86-simulator/src/flags.rs
@@ -1,0 +1,143 @@
+//! RFLAGS computation and condition-code evaluation.
+//!
+//! These mirror the rules in `07w-x86-64-simulator.md`: `add`/`sub` (and the
+//! `cmp` that is a throw-away `sub`) compute CF/ZF/SF/OF/PF/AF, and the `jcc`/
+//! `setcc`/`cmovcc` family read those flags through [`condition_holds`].
+//!
+//! All arithmetic is done at 64-bit width (the only width the backend uses for
+//! register values).
+
+use crate::state::Flags;
+
+/// `dst + src` with full 64-bit flag computation. Returns `(result, flags)`.
+pub fn add_with_flags(dst: u64, src: u64) -> (u64, Flags) {
+    let (res, carry) = dst.overflowing_add(src);
+    let mut f = Flags { cf: carry, ..Flags::default() };
+    f.zf = res == 0;
+    f.sf = (res >> 63) & 1 == 1;
+    // Signed overflow: both operands same sign, result differs.
+    f.of = ((dst ^ res) & (src ^ res)) >> 63 & 1 == 1;
+    f.af = ((dst ^ src ^ res) >> 4) & 1 == 1;
+    f.pf = parity(res);
+    (res, f)
+}
+
+/// `dst - src` with full 64-bit flag computation (also used by `cmp`).
+pub fn sub_with_flags(dst: u64, src: u64) -> (u64, Flags) {
+    let (res, borrow) = dst.overflowing_sub(src);
+    let mut f = Flags { cf: borrow, ..Flags::default() };
+    f.zf = res == 0;
+    f.sf = (res >> 63) & 1 == 1;
+    // Signed overflow on subtract: operands differ in sign and result sign
+    // differs from the minuend.
+    f.of = ((dst ^ src) & (dst ^ res)) >> 63 & 1 == 1;
+    f.af = ((dst ^ src ^ res) >> 4) & 1 == 1;
+    f.pf = parity(res);
+    (res, f)
+}
+
+/// Flags for a logical result (AND/OR/XOR/TEST): CF=OF=0, ZF/SF/PF from the value.
+pub fn logic_flags(res: u64) -> Flags {
+    Flags {
+        cf: false,
+        of: false,
+        zf: res == 0,
+        sf: (res >> 63) & 1 == 1,
+        pf: parity(res),
+        af: false,
+    }
+}
+
+/// Even-parity of the low 8 bits (x86 PF is computed over the low byte only).
+fn parity(v: u64) -> bool {
+    (v as u8).count_ones() & 1 == 0
+}
+
+/// x86 condition codes (the `tttn` nibble of `Jcc`/`SETcc`/`CMOVcc`). The
+/// numeric value matches the opcode's low nibble so the decoder can pass it
+/// straight through.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[allow(missing_docs)]
+pub enum Cond {
+    O = 0x0, No = 0x1, B = 0x2, Ae = 0x3, E = 0x4, Ne = 0x5, Be = 0x6, A = 0x7,
+    S = 0x8, Ns = 0x9, P = 0xA, Np = 0xB, L = 0xC, Ge = 0xD, Le = 0xE, G = 0xF,
+}
+
+impl Cond {
+    /// Decode the `tttn` condition nibble.
+    pub fn from_nibble(n: u8) -> Cond {
+        match n & 0xF {
+            0x0 => Cond::O, 0x1 => Cond::No, 0x2 => Cond::B, 0x3 => Cond::Ae,
+            0x4 => Cond::E, 0x5 => Cond::Ne, 0x6 => Cond::Be, 0x7 => Cond::A,
+            0x8 => Cond::S, 0x9 => Cond::Ns, 0xA => Cond::P, 0xB => Cond::Np,
+            0xC => Cond::L, 0xD => Cond::Ge, 0xE => Cond::Le, _ => Cond::G,
+        }
+    }
+}
+
+/// Does the given condition hold under `f`? (The ARM ARM-style truth table for
+/// x86 condition codes — see 07w §"Condition Codes".)
+pub fn condition_holds(c: Cond, f: &Flags) -> bool {
+    match c {
+        Cond::O => f.of,
+        Cond::No => !f.of,
+        Cond::B => f.cf,                       // unsigned <
+        Cond::Ae => !f.cf,                     // unsigned >=
+        Cond::E => f.zf,                        // ==
+        Cond::Ne => !f.zf,                      // !=
+        Cond::Be => f.cf || f.zf,              // unsigned <=
+        Cond::A => !f.cf && !f.zf,             // unsigned >
+        Cond::S => f.sf,
+        Cond::Ns => !f.sf,
+        Cond::P => f.pf,
+        Cond::Np => !f.pf,
+        Cond::L => f.sf != f.of,               // signed <
+        Cond::Ge => f.sf == f.of,              // signed >=
+        Cond::Le => f.zf || (f.sf != f.of),    // signed <=
+        Cond::G => !f.zf && (f.sf == f.of),    // signed >
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn add_sets_zero_and_carry() {
+        let (r, f) = add_with_flags(u64::MAX, 1);
+        assert_eq!(r, 0);
+        assert!(f.zf && f.cf);
+        assert!(!f.of); // -1 + 1 = 0, no signed overflow
+    }
+
+    #[test]
+    fn sub_borrow_and_sign() {
+        let (r, f) = sub_with_flags(0, 1);
+        assert_eq!(r, u64::MAX);
+        assert!(f.cf && f.sf && !f.zf);
+    }
+
+    #[test]
+    fn signed_overflow_on_add() {
+        // i64::MAX + 1 → signed overflow.
+        let (_, f) = add_with_flags(i64::MAX as u64, 1);
+        assert!(f.of && f.sf);
+    }
+
+    #[test]
+    fn unsigned_and_signed_compares() {
+        // cmp 3, 5  →  3 - 5: CF (unsigned <) and SF!=OF (signed <).
+        let (_, f) = sub_with_flags(3, 5);
+        assert!(condition_holds(Cond::B, &f));   // 3 <u 5
+        assert!(condition_holds(Cond::L, &f));   // 3 <s 5
+        assert!(!condition_holds(Cond::Ae, &f));
+        assert!(condition_holds(Cond::Ne, &f));
+    }
+
+    #[test]
+    fn negative_index_is_unsigned_above() {
+        // The E5 bounds check: idx = -1 (huge unsigned) vs len = 3.
+        let (_, f) = sub_with_flags((-1i64) as u64, 3);
+        assert!(!condition_holds(Cond::B, &f)); // NOT unsigned-below → traps
+    }
+}

--- a/code/packages/rust/x86-simulator/src/harness.rs
+++ b/code/packages/rust/x86-simulator/src/harness.rs
@@ -1,0 +1,169 @@
+//! Load the `x86_64-backend`'s emitted machine code into a runnable [`Simulator`].
+//!
+//! This is the bridge that makes the backend's output executable on any host. It
+//! mirrors `wasm-runtime`'s loader: take each function's byte blob + its
+//! relocations, lay the code out in the address space, resolve **internal** calls
+//! (to other functions in the module) by patching their `rel32`, route
+//! **external** calls (`__twig_alloc_bytes`, `putchar`, `print_i64`, …) to host
+//! shims, set up a stack with a return sentinel, and point `rip` at the entry.
+
+use std::collections::HashMap;
+
+use crate::memory::Memory;
+use crate::state::{CpuState, Reg};
+use crate::Simulator;
+
+/// A relocation site: the byte offset of a `rel32` field *within its function*,
+/// and the symbol it targets. (The lightweight mirror of the backend's
+/// `ExternalReloc`, so this crate stays dependency-light — callers map their
+/// reloc type onto this.)
+#[derive(Debug, Clone)]
+pub struct Reloc {
+    /// Offset of the 4-byte `rel32` within the function's bytes.
+    pub patch_offset: usize,
+    /// The target symbol name.
+    pub symbol: String,
+}
+
+/// Why a harness could not be built. All of these are returned (never panicked)
+/// so the loader is fail-closed even on a malformed function/relocation table.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum BuildError {
+    /// The named entry function was not added.
+    NoSuchEntry(String),
+    /// A relocation's `rel32` site (`patch_offset..patch_offset+4`) lies outside
+    /// its function's bytes — a malformed reloc.
+    BadReloc { symbol: String, patch_offset: usize, fn_len: usize },
+    /// The concatenated code is larger than the simulator's address space.
+    CodeTooLarge { code_len: usize, capacity: u64 },
+}
+
+impl std::fmt::Display for BuildError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            BuildError::NoSuchEntry(n) => write!(f, "no function named {n:?} was added"),
+            BuildError::BadReloc { symbol, patch_offset, fn_len } =>
+                write!(f, "relocation for {symbol:?} at patch_offset {patch_offset} is outside its {fn_len}-byte function"),
+            BuildError::CodeTooLarge { code_len, capacity } =>
+                write!(f, "code region ({code_len} bytes) exceeds the {capacity}-byte address space"),
+        }
+    }
+}
+impl std::error::Error for BuildError {}
+
+/// Builder for a [`Simulator`] from backend function blobs.
+#[derive(Default)]
+pub struct MachineCodeHarness {
+    funcs: Vec<(String, Vec<u8>, Vec<Reloc>)>,
+}
+
+// Layout constants for the flat address space.
+const MEM_SIZE: usize = 1 << 20; // 1 MiB
+const CODE_BASE: u64 = 0x1000;
+const STACK_TOP: u64 = MEM_SIZE as u64 - 16; // 16-aligned-ish top of stack
+const STACK_BOTTOM: u64 = 0x8_0000; // heap may grow up to here
+const RETURN_SENTINEL: u64 = 0xDEAD_0000_0000_0000;
+const STEP_LIMIT: u64 = 10_000_000;
+
+impl MachineCodeHarness {
+    /// A fresh, empty harness.
+    pub fn new() -> Self {
+        MachineCodeHarness::default()
+    }
+
+    /// Add a compiled function (name, machine-code bytes, relocations).
+    pub fn function(mut self, name: &str, bytes: &[u8], relocs: &[Reloc]) -> Self {
+        self.funcs.push((name.to_string(), bytes.to_vec(), relocs.to_vec()));
+        self
+    }
+
+    /// Assemble the loaded functions into a ready-to-run [`Simulator`] starting
+    /// at `entry`.
+    pub fn build(self, entry: &str) -> Result<Simulator, BuildError> {
+        // 1. Concatenate function bytes; record each function's global offset.
+        let mut code: Vec<u8> = Vec::new();
+        let mut fn_offset: HashMap<String, usize> = HashMap::new();
+        let mut relocs: Vec<(usize, String)> = Vec::new(); // global patch_offset → symbol
+        for (name, bytes, rs) in &self.funcs {
+            let base = code.len();
+            fn_offset.insert(name.clone(), base);
+            code.extend_from_slice(bytes);
+            for r in rs {
+                // The rel32 site must lie within this function's bytes.
+                if r.patch_offset.checked_add(4).map_or(true, |e| e > bytes.len()) {
+                    return Err(BuildError::BadReloc {
+                        symbol: r.symbol.clone(),
+                        patch_offset: r.patch_offset,
+                        fn_len: bytes.len(),
+                    });
+                }
+                relocs.push((base + r.patch_offset, r.symbol.clone()));
+            }
+        }
+
+        let entry_off = *fn_offset.get(entry).ok_or_else(|| BuildError::NoSuchEntry(entry.to_string()))?;
+
+        // 2. Resolve relocations: an internal call (symbol is a function in this
+        //    module) is patched so its decoded target lands on the callee; an
+        //    external call stays in the `externals` map for a host shim.
+        let mut externals: HashMap<usize, String> = HashMap::new();
+        for (patch_off, symbol) in relocs {
+            if let Some(&target) = fn_offset.get(&symbol) {
+                // rel32 = target - (patch_off + 4), so decode resolves to `target`.
+                let rel = (target as i64) - (patch_off as i64 + 4);
+                let bytes = (rel as i32).to_le_bytes();
+                code[patch_off..patch_off + 4].copy_from_slice(&bytes);
+            } else {
+                externals.insert(patch_off, symbol);
+            }
+        }
+
+        // 3. Lay out memory: code at CODE_BASE, then the bump heap up to
+        //    STACK_BOTTOM, then the stack from STACK_BOTTOM..STACK_TOP. The code
+        //    must fit below the heap window, else the layout is invalid.
+        let heap_base = ((CODE_BASE + code.len() as u64) + 15) & !15;
+        if heap_base >= STACK_BOTTOM {
+            return Err(BuildError::CodeTooLarge { code_len: code.len(), capacity: STACK_BOTTOM - CODE_BASE });
+        }
+        let mut mem = Memory::new(MEM_SIZE, heap_base, STACK_BOTTOM);
+        // These stores are now provably in-bounds (heap_base < STACK_BOTTOM <
+        // STACK_TOP < MEM_SIZE), so a failure is a harness bug, not guest input.
+        mem.write_block(CODE_BASE, &code).expect("code region is in-bounds after the size check");
+        let mut state = CpuState::default();
+        let sp = (STACK_TOP & !0xF) - 8;
+        mem.store(sp, 8, RETURN_SENTINEL).expect("stack top is in-bounds");
+        state.set(Reg::Rsp, sp);
+        state.set(Reg::Rbp, sp);
+        state.rip = CODE_BASE + entry_off as u64;
+
+        Ok(Simulator {
+            state,
+            mem,
+            stdout: Vec::new(),
+            code,
+            code_base: CODE_BASE,
+            externals,
+            return_sentinel: RETURN_SENTINEL,
+            step_limit: STEP_LIMIT,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn missing_entry_fails_closed() {
+        let err = MachineCodeHarness::new().function("f", &[0xC3], &[]).build("nope").unwrap_err();
+        assert!(matches!(err, BuildError::NoSuchEntry(_)));
+    }
+
+    #[test]
+    fn out_of_range_reloc_fails_closed_not_panic() {
+        // A reloc whose rel32 site is past the 1-byte function → BadReloc, no panic.
+        let relocs = [Reloc { patch_offset: 9999, symbol: "__twig_alloc_bytes".into() }];
+        let err = MachineCodeHarness::new().function("f", &[0xC3], &relocs).build("f").unwrap_err();
+        assert!(matches!(err, BuildError::BadReloc { .. }));
+    }
+}

--- a/code/packages/rust/x86-simulator/src/lib.rs
+++ b/code/packages/rust/x86-simulator/src/lib.rs
@@ -1,0 +1,169 @@
+//! # x86 / x86-64 runtime simulator
+//!
+//! A Rust runtime simulator that decodes and executes the 64-bit x86 machine
+//! code the in-repo `x86_64-backend` emits — so that backend's output can be
+//! **run on any host architecture** (notably aarch64 / Apple Silicon), instead
+//! of only byte-compared locally and executed on an x86 CI runner. It is the
+//! runtime sibling of `riscv-simulator`, and uses the ISA semantics specified in
+//! `code/specs/07w-x86-64-simulator.md` (referenced, not restated).
+//!
+//! ## Two ways in
+//!
+//! - [`Simulator`] — the low-level engine: a [`CpuState`] + [`Memory`] + a loaded
+//!   code region, with `step`/`run`.
+//! - [`harness::MachineCodeHarness`] — loads the backend's per-function byte blobs
+//!   + relocations, wires the System V runtime host imports (`__twig_alloc_bytes`
+//!   / `putchar` / `print_i64`), and produces a ready-to-run [`Simulator`] whose
+//!   `run()` returns the program's exit code. This is the piece the LANG-FULL
+//!   matrix uses to execute the x86_64 column locally.
+//!
+//! Everything is **fail-closed**: an unknown opcode, an out-of-range access, a
+//! `ud2`, or an unresolved external symbol is a [`Trap`] — a guest program can
+//! never escape the sandbox.
+#![allow(clippy::doc_lazy_continuation)]
+
+pub mod decode;
+pub mod execute;
+pub mod flags;
+pub mod harness;
+pub mod memory;
+pub mod state;
+pub mod trap;
+
+use std::collections::HashMap;
+
+use decode::decode;
+use execute::{exec_one, Flow};
+pub use memory::Memory;
+pub use state::{CpuState, Reg};
+pub use trap::Trap;
+
+/// Outcome of a single [`Simulator::step`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum StepOutcome {
+    /// Execution continues.
+    Continue,
+    /// The entry function returned; carries `rax` (the raw return value).
+    Halt(u64),
+}
+
+/// The x86-64 execution engine: CPU + memory + a loaded code region.
+#[derive(Debug)]
+pub struct Simulator {
+    /// Architectural CPU state.
+    pub state: CpuState,
+    /// The flat address space.
+    pub mem: Memory,
+    /// Captured bytes written by host I/O shims (`putchar`/`print_i64`).
+    pub stdout: Vec<u8>,
+    /// The concatenated code bytes (relocations already patched).
+    code: Vec<u8>,
+    /// Where the code region begins in `mem`.
+    code_base: u64,
+    /// rel32-patch-offset (global, within `code`) → external runtime symbol.
+    externals: HashMap<usize, String>,
+    /// When `ret` pops this address, the entry function has returned.
+    return_sentinel: u64,
+    /// Runaway-loop backstop.
+    step_limit: u64,
+}
+
+impl Simulator {
+    /// Execute one instruction. Returns whether to continue or halt.
+    pub fn step(&mut self) -> Result<StepOutcome, Trap> {
+        let off = self.state.rip.wrapping_sub(self.code_base) as usize;
+        let d = decode(&self.code, off)?;
+        let next_ip = self.code_base.wrapping_add((off + d.len) as u64);
+        let flow = exec_one(&mut self.state, &mut self.mem, &d.instr, self.code_base, next_ip, off)?;
+        match flow {
+            Flow::Next => { self.state.rip = next_ip; Ok(StepOutcome::Continue) }
+            Flow::Jump(t) => { self.state.rip = t; Ok(StepOutcome::Continue) }
+            Flow::Trap => Err(Trap::IllegalInstruction(self.state.rip)),
+            Flow::Ret => {
+                let sp = self.state.get(Reg::Rsp);
+                let ret = self.mem.load(sp, 8)?;
+                self.state.set(Reg::Rsp, sp.wrapping_add(8));
+                if ret == self.return_sentinel {
+                    Ok(StepOutcome::Halt(self.state.get(Reg::Rax)))
+                } else {
+                    self.state.rip = ret;
+                    Ok(StepOutcome::Continue)
+                }
+            }
+            Flow::Call { target, site } => {
+                if let Some(sym) = self.externals.get(&site).cloned() {
+                    self.host_call(&sym)?;
+                    self.state.rip = next_ip; // host shim ran; skip past the call
+                } else {
+                    // Internal call: push the return address and jump.
+                    let sp = self.state.get(Reg::Rsp).wrapping_sub(8);
+                    self.mem.store(sp, 8, next_ip)?;
+                    self.state.set(Reg::Rsp, sp);
+                    self.state.rip = target;
+                }
+                Ok(StepOutcome::Continue)
+            }
+        }
+    }
+
+    /// Run from the entry until the entry function returns; return the process
+    /// exit code (`rax & 0xFF`, matching `run_native`/`run_wasm`).
+    pub fn run(&mut self) -> Result<i32, Trap> {
+        for _ in 0..self.step_limit {
+            if let StepOutcome::Halt(rax) = self.step()? {
+                return Ok((rax & 0xFF) as i32);
+            }
+        }
+        Err(Trap::StepLimitExceeded)
+    }
+
+    /// Dispatch a System V call to a host runtime symbol (args in rdi/rsi/…,
+    /// result in rax) — the analogue of `wasm-runtime`'s host imports.
+    fn host_call(&mut self, sym: &str) -> Result<(), Trap> {
+        match sym {
+            // `void* __twig_alloc_bytes(size_t n)` — bump-allocate `n` zeroed bytes.
+            "__twig_alloc_bytes" => {
+                let n = self.state.get(Reg::Rdi);
+                let ptr = self.mem.alloc(n)?;
+                self.state.set(Reg::Rax, ptr);
+            }
+            // `int putchar(int c)` — capture the byte.
+            "putchar" => {
+                let c = self.state.get(Reg::Rdi) as u8;
+                self.stdout.push(c);
+                self.state.set(Reg::Rax, c as u64);
+            }
+            // `int getchar()` — no stdin in v1; returns EOF (-1).
+            "getchar" => { self.state.set(Reg::Rax, u64::MAX); }
+            // `void __twig_print_i64(i64)` — print the decimal value.
+            "__twig_print_i64" | "__print_i64" | "print_i64" => {
+                let v = self.state.get(Reg::Rdi) as i64;
+                self.stdout.extend(v.to_string().into_bytes());
+            }
+            other => return Err(Trap::UnresolvedExternal(other.to_string())),
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // The exact bytes the x86_64-backend emits for `const_u64 v=42; ret_u64 v`.
+    const MIN_FN: &[u8] = &[
+        0x55, 0x48, 0x89, 0xE5, 0x48, 0x81, 0xEC, 0x10, 0x00, 0x00, 0x00,
+        0x48, 0xC7, 0xC0, 0x2A, 0x00, 0x00, 0x00, 0x48, 0x89, 0x85, 0xF8,
+        0xFF, 0xFF, 0xFF, 0x48, 0x8B, 0x85, 0xF8, 0xFF, 0xFF, 0xFF, 0x48,
+        0x89, 0xEC, 0x5D, 0xC3,
+    ];
+
+    #[test]
+    fn runs_a_backend_compiled_const_ret_to_exit_42() {
+        let mut sim = harness::MachineCodeHarness::new()
+            .function("main", MIN_FN, &[])
+            .build("main")
+            .expect("entry exists");
+        assert_eq!(sim.run().unwrap(), 42, "the simulator runs real x86_64 codegen → 42");
+    }
+}

--- a/code/packages/rust/x86-simulator/src/memory.rs
+++ b/code/packages/rust/x86-simulator/src/memory.rs
@@ -1,0 +1,116 @@
+//! A flat, little-endian, bounds-checked address space.
+//!
+//! The simulator is itself a sandbox: every access is range-checked, so a buggy
+//! emitted program faults cleanly ([`Trap::MemoryFault`]) instead of touching
+//! host memory. The address space holds three regions the harness lays out:
+//!
+//! ```text
+//!   0x0000…              code region (loaded function bytes)
+//!   heap_base …          bump heap (backs __twig_alloc_bytes)
+//!   … stack_top          stack (rsp starts near the top, grows down)
+//! ```
+//!
+//! x86 is little-endian, matching the host byte order we read/write with.
+
+use crate::trap::Trap;
+
+/// A flat byte-addressable memory.
+#[derive(Debug, Clone)]
+pub struct Memory {
+    bytes: Vec<u8>,
+    /// Next free heap offset (monotonic bump allocator for `__twig_alloc_bytes`).
+    heap_next: u64,
+    heap_end: u64,
+}
+
+impl Memory {
+    /// Create a `size`-byte address space with a heap window `[heap_base, heap_end)`.
+    pub fn new(size: usize, heap_base: u64, heap_end: u64) -> Memory {
+        Memory { bytes: vec![0; size], heap_next: heap_base, heap_end }
+    }
+
+    /// Total size in bytes.
+    pub fn size(&self) -> u64 { self.bytes.len() as u64 }
+
+    /// Copy `data` to `addr` (used to load the code region). Panics only on a
+    /// programming error in the harness (load past the end), not on guest input.
+    pub fn write_block(&mut self, addr: u64, data: &[u8]) -> Result<(), Trap> {
+        let end = addr.checked_add(data.len() as u64).ok_or(Trap::MemoryFault(addr))?;
+        if end > self.size() {
+            return Err(Trap::MemoryFault(addr));
+        }
+        self.bytes[addr as usize..end as usize].copy_from_slice(data);
+        Ok(())
+    }
+
+    fn check(&self, addr: u64, width: u64) -> Result<usize, Trap> {
+        let end = addr.checked_add(width).ok_or(Trap::MemoryFault(addr))?;
+        if end > self.size() {
+            return Err(Trap::MemoryFault(addr));
+        }
+        Ok(addr as usize)
+    }
+
+    /// Read a `width`-byte (1/2/4/8) little-endian value, zero-extended to u64.
+    pub fn load(&self, addr: u64, width: u8) -> Result<u64, Trap> {
+        let i = self.check(addr, width as u64)?;
+        let mut v = 0u64;
+        for b in 0..width as usize {
+            v |= (self.bytes[i + b] as u64) << (8 * b);
+        }
+        Ok(v)
+    }
+
+    /// Write the low `width` bytes of `val` little-endian to `addr`.
+    pub fn store(&mut self, addr: u64, width: u8, val: u64) -> Result<(), Trap> {
+        let i = self.check(addr, width as u64)?;
+        for b in 0..width as usize {
+            self.bytes[i + b] = (val >> (8 * b)) as u8;
+        }
+        Ok(())
+    }
+
+    /// The bump-allocator behind `__twig_alloc_bytes(n)` — reserve `n` zeroed
+    /// bytes (memory is zero-initialised) and return the base pointer, or a fault
+    /// when the heap window is exhausted. 8-byte aligned so array headers/elements
+    /// are naturally aligned.
+    pub fn alloc(&mut self, n: u64) -> Result<u64, Trap> {
+        let base = (self.heap_next + 7) & !7;
+        let end = base.checked_add(n).ok_or(Trap::MemoryFault(base))?;
+        if end > self.heap_end {
+            return Err(Trap::MemoryFault(base));
+        }
+        self.heap_next = end;
+        Ok(base)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn load_store_little_endian() {
+        let mut m = Memory::new(64, 32, 48);
+        m.store(0, 8, 0x1122_3344_5566_7788).unwrap();
+        assert_eq!(m.load(0, 8).unwrap(), 0x1122_3344_5566_7788);
+        assert_eq!(m.load(0, 1).unwrap(), 0x88); // low byte first
+        assert_eq!(m.load(0, 4).unwrap(), 0x5566_7788);
+    }
+
+    #[test]
+    fn out_of_range_faults() {
+        let m = Memory::new(16, 0, 0);
+        assert!(matches!(m.load(12, 8), Err(Trap::MemoryFault(_))));
+    }
+
+    #[test]
+    fn bump_alloc_is_aligned_and_bounded() {
+        let mut m = Memory::new(128, 32, 64);
+        let a = m.alloc(3).unwrap();
+        assert_eq!(a, 32);
+        let b = m.alloc(8).unwrap();
+        assert_eq!(b, 40, "8-byte aligned bump past the 3-byte alloc");
+        assert!(m.alloc(1000).is_err(), "heap window exhausted → fault");
+    }
+}

--- a/code/packages/rust/x86-simulator/src/state.rs
+++ b/code/packages/rust/x86-simulator/src/state.rs
@@ -1,0 +1,103 @@
+//! CPU state for the x86-64 runtime simulator.
+//!
+//! The architectural state a 64-bit x86 program observes, restricted to what
+//! the in-repo `x86_64-backend` actually uses: the 16 general-purpose registers,
+//! the instruction pointer, and the arithmetic flags. (Segment registers, the
+//! x87 stack, control/debug registers, etc. are out of scope — see the spec.)
+//!
+//! Register *numbering* follows the hardware encoding so a decoded ModRM/REX
+//! register index maps straight onto `gpr[idx]`:
+//!
+//! | idx | 0   | 1   | 2   | 3   | 4   | 5   | 6   | 7   | 8..15 |
+//! |-----|-----|-----|-----|-----|-----|-----|-----|-----|-------|
+//! | reg | RAX | RCX | RDX | RBX | RSP | RBP | RSI | RDI | R8..R15 |
+
+/// The 16 x86-64 general-purpose registers, by hardware index.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[allow(missing_docs)]
+pub enum Reg {
+    Rax = 0, Rcx = 1, Rdx = 2, Rbx = 3,
+    Rsp = 4, Rbp = 5, Rsi = 6, Rdi = 7,
+    R8 = 8, R9 = 9, R10 = 10, R11 = 11,
+    R12 = 12, R13 = 13, R14 = 14, R15 = 15,
+}
+
+impl Reg {
+    /// Map a 0..=15 hardware register number to a [`Reg`].
+    pub fn from_index(i: u8) -> Reg {
+        match i & 0xF {
+            0 => Reg::Rax, 1 => Reg::Rcx, 2 => Reg::Rdx, 3 => Reg::Rbx,
+            4 => Reg::Rsp, 5 => Reg::Rbp, 6 => Reg::Rsi, 7 => Reg::Rdi,
+            8 => Reg::R8, 9 => Reg::R9, 10 => Reg::R10, 11 => Reg::R11,
+            12 => Reg::R12, 13 => Reg::R13, 14 => Reg::R14, _ => Reg::R15,
+        }
+    }
+}
+
+/// The arithmetic subset of RFLAGS the backend's comparisons and branches use.
+///
+/// (CF/ZF/SF/OF/PF/AF — the flags `add`/`sub`/`cmp`/`test`/`shl` set and the
+/// `jcc`/`setcc`/`cmovcc` family reads. The control flags — IF, DF, TF — are
+/// not exercised by emitted code.)
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct Flags {
+    /// Carry — unsigned overflow / borrow.
+    pub cf: bool,
+    /// Zero — result was 0.
+    pub zf: bool,
+    /// Sign — high bit of the result.
+    pub sf: bool,
+    /// Overflow — signed overflow.
+    pub of: bool,
+    /// Parity — even number of set bits in the low byte.
+    pub pf: bool,
+    /// Auxiliary carry — carry out of bit 3 (BCD); tracked for completeness.
+    pub af: bool,
+}
+
+/// The full CPU state.
+#[derive(Debug, Clone, Default)]
+pub struct CpuState {
+    /// The 16 GPRs, indexed by [`Reg`] as `usize`.
+    pub gpr: [u64; 16],
+    /// Instruction pointer (next instruction to fetch).
+    pub rip: u64,
+    /// Arithmetic flags.
+    pub flags: Flags,
+    /// XMM register file (raw 128-bit lanes) — used by the SSE2 phase. Present
+    /// now so the integer core and the float phase share one state type.
+    pub xmm: [u128; 16],
+}
+
+impl CpuState {
+    /// Read a register's full 64-bit value.
+    #[inline]
+    pub fn get(&self, r: Reg) -> u64 { self.gpr[r as usize] }
+
+    /// Write a register's full 64-bit value.
+    #[inline]
+    pub fn set(&mut self, r: Reg, v: u64) { self.gpr[r as usize] = v; }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reg_index_round_trips_the_hardware_numbering() {
+        assert_eq!(Reg::from_index(0), Reg::Rax);
+        assert_eq!(Reg::from_index(4), Reg::Rsp);
+        assert_eq!(Reg::from_index(5), Reg::Rbp);
+        assert_eq!(Reg::from_index(15), Reg::R15);
+        // The low nibble selects the register (REX.B is folded in by the decoder).
+        assert_eq!(Reg::from_index(0x10), Reg::Rax);
+    }
+
+    #[test]
+    fn get_set_round_trip() {
+        let mut s = CpuState::default();
+        s.set(Reg::Rdi, 0xDEAD_BEEF);
+        assert_eq!(s.get(Reg::Rdi), 0xDEAD_BEEF);
+        assert_eq!(s.get(Reg::Rax), 0);
+    }
+}

--- a/code/packages/rust/x86-simulator/src/trap.rs
+++ b/code/packages/rust/x86-simulator/src/trap.rs
@@ -1,0 +1,39 @@
+//! Faults that stop execution.
+//!
+//! Anything that would, on real hardware, raise a fault or that this simulator
+//! does not (yet) model is surfaced as a `Trap` and propagated out of `step`/
+//! `run` — fail-closed. A guest program can only ever *trap*; it cannot escape
+//! the sandbox or affect the host.
+
+/// A fault that halts the simulator.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Trap {
+    /// `ud2` (or any instruction the decoder maps to "illegal") executed — this
+    /// is how an E5 out-of-bounds array access aborts (SIGILL analogue).
+    IllegalInstruction(u64),
+    /// A memory access outside the address space, or heap exhaustion.
+    MemoryFault(u64),
+    /// An opcode the decoder does not understand yet (carries the byte offset).
+    /// Distinct from `IllegalInstruction` so "unimplemented" is never mistaken
+    /// for a program-level trap.
+    DecodeError { offset: u64, opcode: u8 },
+    /// A `call` to an external symbol the harness did not provide a host shim for.
+    UnresolvedExternal(String),
+    /// Execution ran longer than the step budget (runaway-loop backstop).
+    StepLimitExceeded,
+}
+
+impl std::fmt::Display for Trap {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Trap::IllegalInstruction(a) => write!(f, "illegal instruction (ud2) at {a:#x}"),
+            Trap::MemoryFault(a) => write!(f, "memory fault at {a:#x}"),
+            Trap::DecodeError { offset, opcode } =>
+                write!(f, "undecoded opcode {opcode:#04x} at {offset:#x}"),
+            Trap::UnresolvedExternal(s) => write!(f, "unresolved external symbol {s:?}"),
+            Trap::StepLimitExceeded => write!(f, "step limit exceeded"),
+        }
+    }
+}
+
+impl std::error::Error for Trap {}

--- a/code/packages/rust/x86-simulator/tests/runs_backend_output.rs
+++ b/code/packages/rust/x86-simulator/tests/runs_backend_output.rs
@@ -1,0 +1,45 @@
+//! End-to-end: compile a function with the REAL `x86_64-backend`, then run its
+//! machine code on the simulator — locally, on whatever host arch this is.
+
+use jit_core::backend::FunctionContext;
+use jit_core::cir::{CIRInstr, CIROperand};
+use x86_64_backend::{compile_function_with_relocs, X86_64Abi};
+use x86_simulator::harness::{MachineCodeHarness, Reloc};
+
+fn run(cir: Vec<CIRInstr>) -> i32 {
+    let ctx = FunctionContext { name: "main", params: &[], return_type: "u64" };
+    let (bytes, relocs) = compile_function_with_relocs(&ctx, &cir, X86_64Abi::SysV).unwrap();
+    let relocs: Vec<Reloc> = relocs.into_iter()
+        .map(|r| Reloc { patch_offset: r.patch_offset, symbol: r.symbol })
+        .collect();
+    let mut sim = MachineCodeHarness::new()
+        .function("main", &bytes, &relocs)
+        .build("main")
+        .unwrap();
+    sim.run().unwrap()
+}
+
+fn konst(dest: &str, n: i64) -> CIRInstr {
+    CIRInstr { op: "const_u64".into(), dest: Some(dest.into()), srcs: vec![CIROperand::Int(n)], ty: "u64".into(), deopt_to: None }
+}
+fn ret(src: &str) -> CIRInstr {
+    CIRInstr { op: "ret_u64".into(), dest: None, srcs: vec![CIROperand::Var(src.into())], ty: "u64".into(), deopt_to: None }
+}
+
+#[test]
+fn const_ret() {
+    assert_eq!(run(vec![konst("v", 42), ret("v")]), 42);
+}
+
+#[test]
+fn integer_add() {
+    // c = 40 + 2 ; ret c
+    let cir = vec![
+        konst("a", 40),
+        konst("b", 2),
+        CIRInstr { op: "add_u64".into(), dest: Some("c".into()),
+                   srcs: vec![CIROperand::Var("a".into()), CIROperand::Var("b".into())], ty: "u64".into(), deopt_to: None },
+        ret("c"),
+    ];
+    assert_eq!(run(cir), 42, "the simulator runs real x86_64 add codegen");
+}


### PR DESCRIPTION
## x86-sim PR-S1 — the simulator runs real x86_64 codegen, **locally on aarch64**

First runnable slice of the x86/x86-64 runtime simulator (spec in [#6406](https://github.com/adhithyan15/coding-adventures/pull/6406)). It closes the gap you flagged: on this Apple Silicon mac the matrix's `NativeAot` cell only runs the *aarch64* backend — the **x86_64 backend is verified locally by byte tests and actually executed only on an x86 CI runner**. This crate runs x86_64 codegen *locally*.

### New crate `x86-simulator` (runtime sibling of `riscv-simulator`)
- **`state`** — `CpuState`: 16 GPRs (hardware index), `rip`, the RFLAGS subset (CF/ZF/SF/OF/PF/AF), XMM file (for the coming SSE2 phase).
- **`flags`** — `add`/`sub_with_flags` + the 16 condition codes via `condition_holds`, per `07w-x86-64-simulator.md`.
- **`memory`** — a flat little-endian **bounds-checked** address space (a sandbox) + a bump heap backing `__twig_alloc_bytes`.
- **`decode`** — a REX/ModRM/SIB decoder for the `x86_64-encoder` subset: `push`/`pop`, `mov` (reg/mem/imm), `movzx`, `lea`, `add`/`sub`/`cmp`/`and`/`or`/`xor`/`test`, `shl`/`shr`/`sar`, `imul`, `jmp`/`jcc`/`call`/`ret`, `ud2`. Unknown opcode → clean `DecodeError`.
- **`execute`** + **`Simulator`** — per-instruction execution with full flags; `step`/`run`; `ret` to a stack sentinel halts → exit code (`rax & 0xFF`); host-import shims (`__twig_alloc_bytes`/`putchar`/`print_i64`, System V ABI) like `wasm-runtime`.
- **`harness::MachineCodeHarness`** — load the backend's function blobs + relocations, patch internal calls, route external calls to host shims, set up the stack, produce a ready-to-run `Simulator`.

### Verified — *runs real backend output*
- Decodes the exact prologue/`const`/`ret` bytes the `x86_64-backend` emits.
- **End-to-end**: compiles `const 42; ret` **and** `40 + 2` with the **real** `x86_64-backend` (`compile_function_with_relocs`) and runs the machine code → exit **42**, locally on aarch64. 17 tests; clippy clean.

### Security
`/security-review` → core is sandbox-safe (every guest read bounds-checked, register indices masked 0..15, a 10M-step budget, bounded heap, no `unsafe`, no guest value ever used as a host pointer — a hostile blob can only `Trap`). The one finding (an unchecked reloc `patch_offset` could panic at build time) is **fixed**: out-of-range relocs and oversized code return `BuildError`, with a fail-closed regression test.

### Next
S2 — SSE2 scalar doubles (run E3 ALGOL `real` x86_64 output) → S3 — wire a local `run_x86_sim` matrix path + **retro-verify E5 native arrays / E3 floats locally** → S4 — 32-bit x86.

🤖 Generated with [Claude Code](https://claude.com/claude-code)