### PR TITLE
fix(closurec): preserve prefix unary operators at SIMPLE/ADVANCED

### DIFF
--- a/code/packages/rust/closure-emitter/CHANGELOG.md
+++ b/code/packages/rust/closure-emitter/CHANGELOG.md
@@ -2,6 +2,34 @@
 
 All notable changes to the `coding-adventures-closure-emitter` crate will be documented in this file.
 
+## [0.18.0] - 2026-06-21
+
+### Fixed — prefix-unary precedence and `--`/`++` token fusion
+
+`emit_unary` emitted its argument with `emit_expression` (parent precedence 0),
+so a lower-precedence operand was never parenthesised: `!(a == b)` printed as
+`!a == b`, which JS reparses as `(!a) == b` — a **different program**. The
+argument is now emitted at `PREC_UNARY`, so binary / logical / conditional /
+assignment operands are wrapped:
+
+| AST            | before    | after       |
+|----------------|-----------|-------------|
+| `!(a == b)`    | `!a == b` | `!(a == b)` |
+| `-(a + b)`     | `-a + b`  | `-(a + b)`  |
+| `~(a \| b)`    | `~a \| b` | `~(a \| b)` |
+| `!(a ? b : c)` | `!a?b:c`  | `!(a?b:c)`  |
+
+A second fusion hazard is now handled too: a sign operator (`-`/`+`) directly
+followed by a same-sign operand fused into the decrement/increment token —
+`-(-a)` printed `--a` (pre-decrement of `a`), `+(+a)` printed `++a`. `emit_unary`
+now inserts a separating space in exactly those cases (`- -a`, `+ +a`, `- -5`),
+via the new `sign_op_char` / `arg_starts_with_sign` helpers. `!`/`~` never fuse,
+and equal-precedence nests like `!!a` are left paren-free.
+
+These miscompiles were latent until the `javascript-parser` bridge stopped
+dropping prefix operators (it had been emitting the bare operand); this change
+ships alongside that fix. Added 10 emitter unit tests.
+
 ## [0.17.0] - 2026-06-20
 
 ### Added — CLOC23: emit `for (… of …)`

--- a/code/packages/rust/closure-emitter/Cargo.toml
+++ b/code/packages/rust/closure-emitter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-emitter"
-version = "0.17.0"
+version = "0.18.0"
 edition = "2021"
 description = "JavaScript code emitter for the Closure Compiler clone. Per CLOC07's emit contract. Takes a finalized Program + sidecar and produces output JavaScript text + companion source map. Runs after every pass in the pipeline."
 

--- a/code/packages/rust/closure-emitter/src/lib.rs
+++ b/code/packages/rust/closure-emitter/src/lib.rs
@@ -974,15 +974,34 @@ impl<'a> Emitter<'a> {
         self.maybe_map(&u.cv);
         let s = unary_op_str(u.operator);
         self.write_str(s);
-        // Word-shaped ops (typeof / void / delete) need a space
-        // before their argument; symbol-shaped ops don't.
+        // Two things can go wrong between a prefix operator and its
+        // argument; both produce a *miscompile*, not just ugly output.
+        //
+        // 1. Word-shaped ops (`typeof` / `void` / `delete`) need a space
+        //    so the operator name doesn't fuse with the operand
+        //    (`typeofx` is one identifier).
+        //
+        // 2. Sign ops (`-` / `+`) need a space when the argument would
+        //    print a leading same-sign character, or the two signs fuse
+        //    into the *decrement / increment* token: `-(-a)` must print
+        //    `- -a`, never `--a` (which JS parses as `--a`, pre-decrement
+        //    of `a`). See `arg_starts_with_sign`.
         if matches!(
             u.operator,
             UnaryOperator::TypeOf | UnaryOperator::Void | UnaryOperator::Delete
         ) {
             self.required_ws();
+        } else if let Some(sign) = sign_op_char(u.operator) {
+            if arg_starts_with_sign(&u.argument, sign) {
+                self.required_ws();
+            }
         }
-        self.emit_expression(&u.argument);
+        // Emit the argument at unary binding strength so that any
+        // lower-precedence operand (binary, logical, conditional,
+        // assignment, sequence) is parenthesised. Without this,
+        // `!(a == b)` printed as `!a == b`, which JS reparses as
+        // `(!a) == b` — a different program.
+        self.emit_expression_inner(&u.argument, PREC_UNARY);
     }
 
     fn emit_assignment(&mut self, a: &AssignmentExpression) {
@@ -1295,6 +1314,39 @@ fn expr_prec(e: &Expression) -> u8 {
     }
 }
 
+/// The single character a *sign* prefix operator prints, or `None` for
+/// every other unary operator. Only `-` and `+` can fuse with a same-sign
+/// leading character in the argument to form the `--` / `++` token.
+fn sign_op_char(op: UnaryOperator) -> Option<char> {
+    match op {
+        UnaryOperator::Negate => Some('-'),
+        UnaryOperator::Plus => Some('+'),
+        _ => None,
+    }
+}
+
+/// Would the unary argument `e`, emitted at `PREC_UNARY`, begin with the
+/// character `sign` (`-` or `+`)? Used by [`emit_unary`] to decide whether
+/// a separating space is required to avoid the `--` / `++` token fusion.
+///
+/// The argument is emitted at unary precedence, so anything that binds
+/// *looser* than unary is parenthesised and therefore begins with `(`
+/// (no fusion possible). The only operands that print a leading sign
+/// without parens are:
+///   * a nested unary with the same sign — `-(-a)` → inner prints `-a`;
+///   * a negative numeric literal — `format_js_number` prints the
+///     leading `-` (e.g. a constant-folded `-5`).
+/// A `+` literal never prints a leading `+`, and a `BigIntLiteral`'s value
+/// is always non-negative (the `-` of `-5n` is a `UnaryExpression`), so
+/// only the nested-unary case matters for `+` and bigints cannot fuse.
+fn arg_starts_with_sign(e: &Expression, sign: char) -> bool {
+    match e {
+        Expression::UnaryExpression(u) => sign_op_char(u.operator) == Some(sign),
+        Expression::NumericLiteral(n) => sign == '-' && n.value.is_sign_negative(),
+        _ => false,
+    }
+}
+
 fn binary_op_str(op: BinaryOperator) -> &'static str {
     use BinaryOperator::*;
     match op {
@@ -1543,6 +1595,22 @@ mod tests {
     fn boolean(v: bool) -> Expression {
         Expression::BooleanLiteral(BooleanLiteral { cv: None, value: v })
     }
+    fn binary(op: BinaryOperator, left: Expression, right: Expression) -> Expression {
+        Expression::BinaryExpression(BinaryExpression {
+            cv: None,
+            operator: op,
+            left: Box::new(left),
+            right: Box::new(right),
+        })
+    }
+    fn unary(op: UnaryOperator, arg: Expression) -> Expression {
+        Expression::UnaryExpression(UnaryExpression {
+            cv: None,
+            operator: op,
+            prefix: true,
+            argument: Box::new(arg),
+        })
+    }
 
     fn emit_default(prog: Program) -> EmitOutput {
         let sidecar = Sidecar::new();
@@ -1745,6 +1813,84 @@ mod tests {
         let prog = program().with_body(vec![stmt(e)]);
         let out = emit_default(prog);
         assert_eq!(out.code, "typeof \"x\";");
+    }
+
+    // ---- prefix-unary precedence + token-adjacency ----------
+    //
+    // These pin the two miscompiles that the bridge fix unmasked: a unary
+    // operator over a lower-precedence operand must parenthesise it, and
+    // `-`/`+` over a same-sign operand must keep a separating space so the
+    // pair never fuses into the `--`/`++` token.
+
+    #[test]
+    fn not_over_equality_parenthesises() {
+        // `!(a == b)` must NOT print `!a == b` (which reparses as `(!a) == b`).
+        let e = unary(UnaryOperator::Not, binary(BinaryOperator::Eq, ident("a"), ident("b")));
+        assert_eq!(emit_expr(e), "!(a == b);");
+    }
+
+    #[test]
+    fn negate_over_addition_parenthesises() {
+        let e = unary(UnaryOperator::Negate, binary(BinaryOperator::Add, ident("a"), ident("b")));
+        assert_eq!(emit_expr(e), "-(a + b);");
+    }
+
+    #[test]
+    fn bitnot_over_bitor_parenthesises() {
+        let e = unary(UnaryOperator::BitNot, binary(BinaryOperator::BitOr, ident("a"), ident("b")));
+        assert_eq!(emit_expr(e), "~(a | b);");
+    }
+
+    #[test]
+    fn unary_over_identifier_needs_no_parens() {
+        assert_eq!(emit_expr(unary(UnaryOperator::Not, ident("a"))), "!a;");
+    }
+
+    #[test]
+    fn double_not_does_not_parenthesise() {
+        // `!!a` — equal precedence, no parens, and `!!` never fuses.
+        let e = unary(UnaryOperator::Not, unary(UnaryOperator::Not, ident("a")));
+        assert_eq!(emit_expr(e), "!!a;");
+    }
+
+    #[test]
+    fn negate_over_negate_keeps_separating_space() {
+        // `-(-a)` must print `- -a`, never `--a` (pre-decrement of `a`).
+        let e = unary(UnaryOperator::Negate, unary(UnaryOperator::Negate, ident("a")));
+        assert_eq!(emit_expr(e), "- -a;");
+    }
+
+    #[test]
+    fn plus_over_plus_keeps_separating_space() {
+        // `+(+a)` must print `+ +a`, never `++a` (pre-increment of `a`).
+        let e = unary(UnaryOperator::Plus, unary(UnaryOperator::Plus, ident("a")));
+        assert_eq!(emit_expr(e), "+ +a;");
+    }
+
+    #[test]
+    fn negate_over_negative_literal_keeps_space() {
+        // A folded `-(-5)` would print `5`, but an un-folded negative literal
+        // under a `-` must still separate: `- -5`, never `--5`.
+        let e = unary(UnaryOperator::Negate, num(-5.0));
+        assert_eq!(emit_expr(e), "- -5;");
+    }
+
+    #[test]
+    fn not_over_negate_needs_no_space() {
+        // `!` and `-` don't fuse, so `!-a` needs neither parens nor a space.
+        let e = unary(UnaryOperator::Not, unary(UnaryOperator::Negate, ident("a")));
+        assert_eq!(emit_expr(e), "!-a;");
+    }
+
+    #[test]
+    fn negate_inside_multiply_needs_no_parens() {
+        // `-x * y`: unary binds tighter than `*`, so no parens around `-x`.
+        let e = binary(
+            BinaryOperator::Mul,
+            unary(UnaryOperator::Negate, ident("x")),
+            ident("y"),
+        );
+        assert_eq!(emit_expr(e), "-x * y;");
     }
 
     // ---- variable + function declarations -------------------

--- a/code/packages/rust/javascript-parser/CHANGELOG.md
+++ b/code/packages/rust/javascript-parser/CHANGELOG.md
@@ -2,6 +2,41 @@
 
 All notable changes to the `coding-adventures-javascript-parser` crate will be documented in this file.
 
+## [0.17.0] - 2026-06-21
+
+### Fixed — prefix unary operators were silently dropped by the bridge
+
+`convert_unary_expression` discriminated the two `unary_expression` grammar
+alternatives —
+
+```text
+unary_expression = postfix_expression
+                 | ("delete"|"void"|"typeof"|PLUS|MINUS|TILDE|BANG) unary_expression
+```
+
+— by counting AST **child nodes** (`if node_children(node).len() == 1 { …
+pass-through … }`). But the prefix operator is a **token** child, and
+`node_children` deliberately returns only `ASTNodeOrToken::Node`s, so *both*
+alternatives expose exactly one AST child node. Every prefix-operator form was
+therefore mis-classified as a pass-through and the bridge returned the bare
+operand:
+
+| source | bridged AST (before) | bridged AST (after) |
+|--------|----------------------|---------------------|
+| `!a`   | `a`                  | `!a`                |
+| `-b`   | `b`                  | `-b`                |
+| `~c`   | `c`                  | `~c`                |
+| `typeof x` | `x`              | `typeof x`          |
+
+This was a **miscompile** at SIMPLE/ADVANCED (the levels that run the bridge),
+not a missed optimization — WHITESPACE_ONLY kept the operators because it never
+builds the typed AST.
+
+The discriminator is now the **presence of a recognized prefix-operator token**
+(new `unary_operator_from_str` helper), independent of the child-node count.
+Added bridge regression tests for each operator, double-negation nesting, and
+the pass-through (no-operator) case.
+
 ## [0.16.0] - 2026-06-21
 
 ### Added — CLOC26 Phase 2: ASI line-terminator rule (Rule 1)

--- a/code/packages/rust/javascript-parser/Cargo.toml
+++ b/code/packages/rust/javascript-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-javascript-parser"
-version = "0.16.0"
+version = "0.17.0"
 edition = "2021"
 description = "JavaScript parser — parses JavaScript source code against any ECMAScript edition (es1 through es2025) using the grammar-driven parser. Includes correlation-vector plumbing per CLOC03 and a typed-AST bridge (GrammarASTNode → javascript_ast::Program) per CLOC12.136."
 

--- a/code/packages/rust/javascript-parser/src/bridge.rs
+++ b/code/packages/rust/javascript-parser/src/bridge.rs
@@ -1303,17 +1303,54 @@ fn convert_unary_expression(node: &GrammarASTNode) -> Result<Expression, BridgeE
     // unary_expression = postfix_expression
     //                  | "delete" | "void" | "typeof" | PLUS | MINUS | TILDE | BANG
     //                    unary_expression
-    let nodes = node_children(node);
-    if nodes.len() == 1 {
-        return convert_expression(nodes[0]); // pass-through
-    }
-    // Has a prefix operator token.
-    let op_tok = node.children.iter().find_map(|c| match c {
-        ASTNodeOrToken::Token(t) => Some(t.value.as_str()),
+    //
+    // BUG HISTORY — *why this is not a simple child-count switch.* The
+    // prefix operator (`!`, `-`, `typeof`, …) is a **token** child, and the
+    // operand is an **AST-node** child. `node_children` deliberately drops
+    // token children (it returns only `ASTNodeOrToken::Node`s), so BOTH
+    // grammar alternatives expose *exactly one* AST child node:
+    //
+    //     postfix_expression           → children = [ Node(operand) ]
+    //     "!" unary_expression         → children = [ Token("!"), Node(operand) ]
+    //                                                              ^^^^^^^^^^^^^
+    //                                     node_children() = [ Node(operand) ]  (len 1)
+    //
+    // The earlier `if node_children(node).len() == 1 { pass-through }`
+    // therefore mis-classified *every* prefix-operator form as a
+    // pass-through and silently returned the bare operand — `!a` emitted as
+    // `a`, `-b` as `b`, `~c` as `c`, `typeof x` as `x`. That is a
+    // **miscompile** (SIMPLE/ADVANCED), not a missed optimization:
+    // WHITESPACE_ONLY kept the operator because it never runs the bridge.
+    //
+    // The correct discriminator is the *presence of a recognized prefix
+    // operator token*, independent of how many AST child nodes there are.
+    let op = node.children.iter().find_map(|c| match c {
+        ASTNodeOrToken::Token(t) => unary_operator_from_str(t.value.as_str()),
         _ => None,
     });
-    let op_str = op_tok.ok_or_else(|| internal(node, "unary_expression: missing operator token"))?;
-    let op = match op_str {
+    let nodes = node_children(node);
+    let arg_n = nodes
+        .first()
+        .ok_or_else(|| internal(node, "unary_expression: missing argument"))?;
+    match op {
+        // No prefix operator token ⇒ this is the `postfix_expression`
+        // alternative; pass the single operand straight through.
+        None => convert_expression(arg_n),
+        Some(operator) => Ok(Expression::UnaryExpression(UnaryExpression {
+            cv: None,
+            operator,
+            prefix: true,
+            argument: Box::new(convert_expression(arg_n)?),
+        })),
+    }
+}
+
+/// Map a prefix-operator token's text to its [`UnaryOperator`]. Returns
+/// `None` for any token that is not a unary prefix operator (the operand
+/// of a `postfix_expression` pass-through, for instance), which lets the
+/// caller use "did we find an operator?" as the alternative-discriminator.
+fn unary_operator_from_str(s: &str) -> Option<UnaryOperator> {
+    Some(match s {
         "-" => UnaryOperator::Negate,
         "+" => UnaryOperator::Plus,
         "!" => UnaryOperator::Not,
@@ -1321,17 +1358,8 @@ fn convert_unary_expression(node: &GrammarASTNode) -> Result<Expression, BridgeE
         "typeof" => UnaryOperator::TypeOf,
         "void" => UnaryOperator::Void,
         "delete" => UnaryOperator::Delete,
-        _ => return Err(internal(node, format!("unknown unary op '{op_str}'"))),
-    };
-    let arg_n = nodes
-        .first()
-        .ok_or_else(|| internal(node, "unary_expression: missing argument"))?;
-    Ok(Expression::UnaryExpression(UnaryExpression {
-        cv: None,
-        operator: op,
-        prefix: true,
-        argument: Box::new(convert_expression(arg_n)?),
-    }))
+        _ => return None,
+    })
 }
 
 // -------------------------------------------------------------------------
@@ -2174,6 +2202,107 @@ mod tests {
             }
             _ => panic!("expected ExpressionStatement"),
         }
+    }
+
+    // -----------------------------------------------------------------------
+    // Prefix unary expressions — regression for the operator-drop miscompile.
+    //
+    // The bridge used to discriminate the two `unary_expression` grammar
+    // alternatives by counting AST child *nodes*, but the operator is a
+    // *token* (filtered out by `node_children`), so both alternatives look
+    // like a single child and every prefix operator was silently dropped
+    // (`!a` bridged to bare `a`). These tests pin that each operator now
+    // survives as a `UnaryExpression` with the correct `operator`.
+    // -----------------------------------------------------------------------
+
+    /// Pull the single expression out of a one-statement program.
+    fn only_expr(p: &Program) -> &Expression {
+        match &p.body[0] {
+            ProgramItem::Statement(Statement::Tagged(
+                coding_adventures_javascript_ast::statement::TaggedStatement::ExpressionStatement(es),
+            )) => &es.expression,
+            _ => panic!("expected a single ExpressionStatement"),
+        }
+    }
+
+    fn assert_prefix_unary(src: &str, expected_op: UnaryOperator) {
+        let p = bridge_ok(src);
+        match only_expr(&p) {
+            Expression::UnaryExpression(u) => {
+                assert_eq!(
+                    u.operator, expected_op,
+                    "operator mismatch for {src:?}: got {:?}",
+                    u.operator
+                );
+                assert!(u.prefix, "prefix flag must be set for {src:?}");
+            }
+            other => panic!("expected UnaryExpression for {src:?}, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn prefix_not_survives_bridge() {
+        assert_prefix_unary("!a;", UnaryOperator::Not);
+    }
+
+    #[test]
+    fn prefix_negate_survives_bridge() {
+        assert_prefix_unary("-a;", UnaryOperator::Negate);
+    }
+
+    #[test]
+    fn prefix_plus_survives_bridge() {
+        assert_prefix_unary("+a;", UnaryOperator::Plus);
+    }
+
+    #[test]
+    fn prefix_bitnot_survives_bridge() {
+        assert_prefix_unary("~a;", UnaryOperator::BitNot);
+    }
+
+    #[test]
+    fn prefix_typeof_survives_bridge() {
+        assert_prefix_unary("typeof a;", UnaryOperator::TypeOf);
+    }
+
+    #[test]
+    fn prefix_void_survives_bridge() {
+        assert_prefix_unary("void a;", UnaryOperator::Void);
+    }
+
+    #[test]
+    fn prefix_delete_survives_bridge() {
+        assert_prefix_unary("delete a.b;", UnaryOperator::Delete);
+    }
+
+    #[test]
+    fn double_negation_nests_two_unaries() {
+        // `!!a` must bridge to Unary(Not, Unary(Not, a)), not collapse.
+        let p = bridge_ok("!!a;");
+        match only_expr(&p) {
+            Expression::UnaryExpression(outer) => {
+                assert_eq!(outer.operator, UnaryOperator::Not);
+                match outer.argument.as_ref() {
+                    Expression::UnaryExpression(inner) => {
+                        assert_eq!(inner.operator, UnaryOperator::Not);
+                        assert!(matches!(inner.argument.as_ref(), Expression::Identifier(_)));
+                    }
+                    other => panic!("expected inner UnaryExpression, got {other:?}"),
+                }
+            }
+            other => panic!("expected outer UnaryExpression, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn unary_pass_through_is_not_wrapped() {
+        // The `postfix_expression` alternative (no operator token) must NOT
+        // be wrapped in a UnaryExpression — `a;` stays a bare identifier.
+        let p = bridge_ok("a;");
+        assert!(
+            matches!(only_expr(&p), Expression::Identifier(_)),
+            "pass-through operand must not gain a spurious UnaryExpression"
+        );
     }
 
     // -----------------------------------------------------------------------

--- a/code/programs/rust/closurec/CHANGELOG.md
+++ b/code/programs/rust/closurec/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 All notable changes to the `coding-adventures-closurec` binary will be documented in this file.
 
+## [0.161.0] - 2026-06-21
+
+### Fixed — prefix unary operators no longer dropped at SIMPLE/ADVANCED
+
+A program whose statements used a prefix unary operator on a non-foldable
+operand — `!a`, `-b`, `~c`, `typeof x`, etc. — was **miscompiled** at SIMPLE
+and ADVANCED: the operator silently vanished (`report(!a, -b, ~c)` became
+`report(a, b, c)`). The root cause was in the `javascript-parser` bridge, which
+mis-classified every prefix-operator form as a grammar pass-through and returned
+the bare operand. WHITESPACE_ONLY was unaffected (it runs no typed pipeline).
+
+Fixing the bridge unmasked two emitter precedence/printing bugs that this
+release also fixes (`coding-adventures-closure-emitter` 0.18.0): `!(a == b)`
+now keeps its parentheses (was `!a == b`, a different program), and `-(-a)` /
+`+(+a)` print with a separating space (`- -a` / `+ +a`) instead of fusing into
+the `--` / `++` decrement/increment token.
+
+New end-to-end fixture `tests/diff/simple-unary-preserve` proves all prefix
+operators survive the SIMPLE pipeline (with a whitespace-fallback guard and an
+explicit `!(a == b)` parenthesisation check). Pulls in
+`coding-adventures-javascript-parser` 0.17.0 and
+`coding-adventures-closure-emitter` 0.18.0.
+
 ## [0.160.0] - 2026-06-21
 
 ### Changed — CLOC26 Phase 2: optimize newline-separated, semicolon-free source

--- a/code/programs/rust/closurec/Cargo.toml
+++ b/code/programs/rust/closurec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closurec"
-version = "0.160.0"
+version = "0.161.0"
 edition = "2021"
 description = "closurec — CLI driver for the Closure Compiler clone. Mirrors the upstream Java Closure Compiler's command-line flag surface (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility. Per CLOC08."
 

--- a/code/programs/rust/closurec/cli.spec.json
+++ b/code/programs/rust/closurec/cli.spec.json
@@ -2,7 +2,7 @@
   "cli_builder_spec_version": "1.0",
   "name": "closurec",
   "description": "closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.",
-  "version": "0.160.0",
+  "version": "0.161.0",
   "parsing_mode": "gnu",
   "flags": [
     { "id": "browser_featureset_year", "long": "browser_featureset_year", "type": "integer", "default": 0, "description": "Shortcut for defining goog.FEATURESET_YEAR=YYYY (minimum 2012)." },

--- a/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
@@ -2,7 +2,7 @@
 
 closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.
 
-Version: 0.160.0
+Version: 0.161.0
 
 ## Flags
 

--- a/code/programs/rust/closurec/tests/diff/simple-unary-preserve/README.md
+++ b/code/programs/rust/closurec/tests/diff/simple-unary-preserve/README.md
@@ -1,0 +1,41 @@
+# Fixture: `simple-unary-preserve`
+
+End-to-end oracle for the **prefix-unary-operator-drop miscompile** fix
+(bridge + emitter).
+
+| File | Role |
+|------|------|
+| `flags.txt` | CLI args: `--compilation_level SIMPLE --js input/a.js` |
+| `input/a.js` | Side-effecting `var` inits + a `report(...)` call using `!`, `-`, `~`, and `!(a == b)` |
+| `expected.stdout` | The optimized output (see below) |
+
+```text
+var a=first();var b=second();var c=third();report(!a,-b,~c,!(a == b));
+```
+
+## What this proves
+
+* **Prefix operators survive the typed pipeline.** Before the fix, the bridge
+  discriminated the two `unary_expression` grammar alternatives by counting AST
+  *child nodes*; because the operator is a *token* (filtered out by
+  `node_children`), every prefix-operator form looked like a pass-through and
+  the operator was silently dropped — `!a` → `a`, `-b` → `b`, `~c` → `c`. That
+  is a **miscompile** at SIMPLE/ADVANCED. The operators now round-trip.
+
+* **Precedence is preserved.** `!(a == b)` keeps its parentheses. Emitting
+  `!a == b` would reparse as `(!a) == b` — a different program. `emit_unary`
+  now emits its argument at unary binding strength so any lower-precedence
+  operand is parenthesised.
+
+* **This is the SIMPLE optimizer, not the WHITESPACE_ONLY fallback.** The
+  unused `var dead = 4 + 5;` is removed by the typed pipeline. Its absence in
+  the output proves the program reached the SIMPLE passes (WHITESPACE_ONLY
+  keeps every byte, including `dead`).
+
+## Why side-effecting initializers
+
+`a`, `b`, `c` are bound to call results (`first()` / `second()` / `third()`),
+which the constant-folder cannot evaluate, so the operands stay as identifiers
+and the unary operators remain real prefix operators rather than folding to
+literals. This keeps the regression target — *the operator itself* — visible in
+the output.

--- a/code/programs/rust/closurec/tests/diff/simple-unary-preserve/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/simple-unary-preserve/expected.stdout
@@ -1,0 +1,1 @@
+var a=first();var b=second();var c=third();report(!a,-b,~c,!(a == b));

--- a/code/programs/rust/closurec/tests/diff/simple-unary-preserve/flags.txt
+++ b/code/programs/rust/closurec/tests/diff/simple-unary-preserve/flags.txt
@@ -1,0 +1,4 @@
+--compilation_level
+SIMPLE
+--js
+tests/diff/simple-unary-preserve/input/a.js

--- a/code/programs/rust/closurec/tests/diff/simple-unary-preserve/input/a.js
+++ b/code/programs/rust/closurec/tests/diff/simple-unary-preserve/input/a.js
@@ -1,0 +1,29 @@
+// Regression oracle for the prefix-unary-operator-drop miscompile.
+//
+// The bridge (`javascript-parser/src/bridge.rs`) used to discriminate the two
+// `unary_expression` grammar alternatives by counting AST *child nodes*. But
+// the prefix operator (`!`, `-`, `~`, `typeof`, `void`, `delete`) is a *token*
+// child, which `node_children` filters out — so every prefix-operator form
+// looked like a bare pass-through and the operator was silently DROPPED:
+//
+//   !a   bridged to   a          // negation lost — a *miscompile*, not a
+//   -b   bridged to   b          // missed optimization
+//   ~c   bridged to   c
+//
+// WHITESPACE_ONLY kept the operators (it never runs the bridge), so the bug
+// only showed at SIMPLE/ADVANCED — exactly where correctness matters most.
+//
+// `a`, `b`, `c` come from side-effecting calls, so they are NOT foldable and
+// the unary operators stay as real prefix operators over identifiers. The
+// unused `dead` binding is removed by the typed pipeline — its disappearance
+// proves this output came from the SIMPLE optimizer, not the WHITESPACE_ONLY
+// fallback. And `!(a == b)` must keep its parentheses: emitting `!a == b`
+// would reparse as `(!a) == b`, a different program.
+//
+// At SIMPLE this becomes:
+//   var a=first();var b=second();var c=third();report(!a,-b,~c,!(a == b));
+var a = first();
+var b = second();
+var c = third();
+var dead = 4 + 5;
+report(!a, -b, ~c, !(a == b));

--- a/code/programs/rust/closurec/tests/diff_simple_unary_preserve.rs
+++ b/code/programs/rust/closurec/tests/diff_simple_unary_preserve.rs
@@ -1,0 +1,96 @@
+//! Integration test for the `tests/diff/simple-unary-preserve/` fixture.
+//!
+//! Regression oracle for the **prefix-unary-operator-drop miscompile**. The
+//! bridge (`javascript-parser/src/bridge.rs`) discriminated the two
+//! `unary_expression` grammar alternatives by counting AST child *nodes*; the
+//! operator is a *token* (filtered out by `node_children`), so every
+//! prefix-operator form looked like a pass-through and the operator was
+//! silently dropped — `!a` → `a`, `-b` → `b`, `~c` → `c`. That is a
+//! **miscompile** at SIMPLE/ADVANCED (WHITESPACE_ONLY kept the operators
+//! because it never runs the bridge).
+//!
+//! At SIMPLE the fixture optimizes to:
+//!
+//! ```text
+//! var a=first();var b=second();var c=third();report(!a,-b,~c,!(a == b));
+//! ```
+
+use std::process::Command;
+
+const BINARY: &str = env!("CARGO_BIN_EXE_closurec");
+
+fn read_flags() -> Vec<String> {
+    let raw = std::fs::read_to_string("tests/diff/simple-unary-preserve/flags.txt")
+        .expect("read flags.txt");
+    raw.lines()
+        .filter(|l| !l.is_empty())
+        .map(|s| s.to_string())
+        .collect()
+}
+
+#[test]
+fn simple_unary_preserve_fixture_matches_expected_stdout() {
+    let flags = read_flags();
+    let out = Command::new(BINARY)
+        .args(&flags)
+        .output()
+        .expect("run closurec");
+
+    assert!(
+        out.status.success(),
+        "exit: {:?}, stderr: {}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stderr),
+    );
+
+    let actual = String::from_utf8_lossy(&out.stdout);
+    let expected = std::fs::read_to_string("tests/diff/simple-unary-preserve/expected.stdout")
+        .expect("read expected.stdout");
+    assert_eq!(
+        actual.trim_end_matches('\n'),
+        expected.trim_end_matches('\n'),
+        "mismatch.\nflags: {flags:?}\nactual:\n{actual}\nexpected:\n{expected}",
+    );
+}
+
+/// The prefix operators must all survive into the output. Before the bridge
+/// fix each of these vanished, so asserting their presence is the direct
+/// regression guard against the operator-drop miscompile.
+#[test]
+fn simple_unary_preserve_keeps_every_prefix_operator() {
+    let out = Command::new(BINARY)
+        .args(read_flags())
+        .output()
+        .expect("run closurec");
+    let actual = String::from_utf8_lossy(&out.stdout);
+
+    assert!(actual.contains("!a"), "logical-not operator dropped; got:\n{actual}");
+    assert!(actual.contains("-b"), "unary-minus operator dropped; got:\n{actual}");
+    assert!(actual.contains("~c"), "bitwise-not operator dropped; got:\n{actual}");
+    // `!(a == b)` must keep its parens — `!a == b` would reparse as
+    // `(!a) == b`, a different program.
+    assert!(
+        actual.contains("!(a == b)"),
+        "negated-equality lost its parentheses (precedence miscompile); got:\n{actual}",
+    );
+}
+
+/// Regression guard: the output must NOT be the WHITESPACE_ONLY fallback. The
+/// unused `var dead = 4 + 5;` is removed only by the typed pipeline, so its
+/// absence proves the SIMPLE optimizer ran (and therefore the bridge ran, and
+/// the operators survived *it*). WHITESPACE_ONLY keeps `dead` verbatim.
+#[test]
+fn simple_unary_preserve_did_not_fall_back_to_whitespace_only() {
+    let out = Command::new(BINARY)
+        .args(read_flags())
+        .output()
+        .expect("run closurec");
+    let actual = String::from_utf8_lossy(&out.stdout);
+
+    assert!(
+        !actual.contains("dead"),
+        "expected the unused `dead` binding to be removed by the typed pipeline \
+         (proving this is the SIMPLE optimizer, not the whitespace fallback); \
+         got:\n{actual}",
+    );
+}


### PR DESCRIPTION
## Summary

Fixes a **miscompile** in the closurec SIMPLE/ADVANCED pipeline: every prefix unary operator (`!`, `-`, `~`, `typeof`, `void`, `delete`) was silently **dropped**.

```
!a   →  a          -b   →  b          ~c   →  c
report(!a, -b, ~c)  →  report(a, b, c)
```

WHITESPACE_ONLY was unaffected (it never builds the typed AST), so the bug hid in exactly the levels where correctness matters most.

### Root cause (bridge)

`convert_unary_expression` discriminated the two `unary_expression` grammar alternatives by counting AST **child nodes**:

```
unary_expression = postfix_expression                         // [ Node(operand) ]
                 | ("!"|"-"|"~"|"typeof"|…) unary_expression  // [ Token("!"), Node(operand) ]
```

But the operator is a **token** child, which `node_children` filters out — so *both* alternatives expose exactly one AST child node. The `if node_children(node).len() == 1 { pass-through }` therefore mis-classified every prefix-operator form as a pass-through and returned the bare operand. Now discriminates on the **presence of a recognized prefix-operator token** (new `unary_operator_from_str`).

### Two emitter bugs unmasked by the fix (also fixed here)

Once the operator survived to the emitter, two latent `emit_unary` bugs became visible — both miscompiles:

| AST            | before    | after       | why                                   |
|----------------|-----------|-------------|---------------------------------------|
| `!(a == b)`    | `!a == b` | `!(a == b)` | `!a == b` reparses as `(!a) == b`     |
| `-(a + b)`     | `-a + b`  | `-(a + b)`  | precedence                            |
| `-(-a)`        | `--a`     | `- -a`      | `--a` is pre-decrement of `a`         |
| `+(+a)`        | `++a`     | `+ +a`      | `++a` is pre-increment of `a`         |

- **Precedence**: argument now emitted at `PREC_UNARY` so lower-precedence operands are parenthesised.
- **Token fusion**: a sign op followed by a same-sign operand now gets a separating space (`sign_op_char` / `arg_starts_with_sign`). `!`/`~` never fuse; `!!a` stays paren-free.

## Tests

- **9** bridge regression tests (each operator + double-negation nesting + the no-operator pass-through).
- **10** emitter precedence/adjacency tests.
- New closurec e2e fixture `tests/diff/simple-unary-preserve` with a whitespace-fallback guard and an explicit `!(a == b)` parenthesisation check.
- Full closurec suite: **737 pass, 0 fail**, no golden-fixture regressions.

## Versions

- `coding-adventures-javascript-parser` 0.16.0 → 0.17.0
- `coding-adventures-closure-emitter` 0.17.0 → 0.18.0
- `coding-adventures-closurec` 0.160.0 → 0.161.0 (+ `cli.spec.json` + help-markdown fixture)

Security review: passed (Rust, no findings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)