### PR TITLE
fix(algol): for-loop guard compares at i64 operand width (ALGOL for runs on LLVM)

### DIFF
--- a/code/packages/rust/algol-iir-compiler/CHANGELOG.md
+++ b/code/packages/rust/algol-iir-compiler/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## 0.5.1 — Fix: `for`-loop guard compares at operand width (ALGOL `for` runs on LLVM)
+
+The `for … step … until` loop-guard comparisons (the step-sign check and the
+ascending/descending bound checks) were emitted with `type_hint = "bool"` — the
+boolean *result* type — instead of the integer *operand* width. A code-gen
+backend reads a comparison's `type_hint` as its operand type, so on **LLVM**
+(`iir-to-llvm`'s `lower_cmp`) this produced the invalid `icmp i1 <i64>, <i64>`
+that `clang` rejects, leaving ALGOL `for` loops un-runnable on LLVM (they worked
+on VM/JIT/JVM/CLR, which infer operand types differently). The three guards now
+carry `"i64"`, matching the regular relational path (which already tags the cmp
+with `lhs.ty.iir()`).
+
+Effect: ALGOL `for`-loop programs now compile to valid LLVM IR and **run via
+`clang`**. The E5 sum-of-squares array `Prog` (two `for` loops over an array,
+exit 55) — previously LLVM-deferred — now runs on the LLVM matrix column. New
+regression test asserts the guards compare at `i64`, not `bool`.
+
 ## 0.5.0 — One-dimensional arrays (LANG-FULL enabler E5 / AL2)
 
 Array declarations and subscripts were rejected ("array variables/subscripts").

--- a/code/packages/rust/algol-iir-compiler/Cargo.toml
+++ b/code/packages/rust/algol-iir-compiler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "algol-iir-compiler"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 description = "ALGOL 60 scalar frontend for the LANG VM Rust chain, lowering parsed ALGOL into interpreter_ir::IIRModule. v0.3.0 adds switches (computed goto) + conditional designational expressions, and fixes comparison lowering to use the i64 operand width so ALGOL comparisons run on the code-gen backends. v0.2.0 added typed procedures with value parameters."
 

--- a/code/packages/rust/algol-iir-compiler/src/lib.rs
+++ b/code/packages/rust/algol-iir-compiler/src/lib.rs
@@ -1390,7 +1390,13 @@ impl Compiler {
             "cmp_ge",
             Some(step_non_negative.clone()),
             vec![Operand::Var(step.slot.clone()), Operand::Var(zero)],
-            "bool",
+            // The guard compares **integer** operands (step vs 0), so the
+            // comparison's `type_hint` is the *operand* width `i64` — not the
+            // boolean *result* type. A code-gen backend (LLVM `lower_cmp`) reads
+            // this hint as the `icmp` operand type, so `"bool"` would emit the
+            // invalid `icmp i1 <i64>, <i64>`. This mirrors the regular relational
+            // path, which already tags the cmp with `lhs.ty.iir()`.
+            "i64",
         ));
         self.emit(IIRInstr::new(
             "jmp_if_false",
@@ -1410,7 +1416,7 @@ impl Compiler {
                 Operand::Var(var_name.to_string()),
                 Operand::Var(limit.slot.clone()),
             ],
-            "bool",
+            "i64", // operand width (loop var vs limit, both integer) — see above
         ));
         self.emit(IIRInstr::new(
             "jmp_if_false",
@@ -1434,7 +1440,7 @@ impl Compiler {
                 Operand::Var(var_name.to_string()),
                 Operand::Var(limit.slot.clone()),
             ],
-            "bool",
+            "i64", // operand width (loop var vs limit, both integer) — see above
         ));
         self.emit(IIRInstr::new(
             "jmp_if_false",
@@ -2466,6 +2472,25 @@ mod tests {
     fn compiles_and_runs_for_step_until_sum() {
         let src = "begin integer i, result; result := 0; for i := 1 step 1 until 10 do result := result + i end";
         assert_eq!(run_i64(src), 55);
+    }
+
+    /// The `for … step … until` loop-guard comparisons must carry the **operand**
+    /// type (`i64`), not the boolean result type — a code-gen backend reads the
+    /// `type_hint` as the comparison operand width, so `"bool"` produced the
+    /// invalid `icmp i1 <i64>, <i64>` that broke ALGOL `for` loops on LLVM.
+    #[test]
+    fn for_loop_guard_compares_at_operand_width_not_bool() {
+        let src = "begin integer i, result; result := 0; for i := 1 step 1 until 5 do result := result + i end";
+        let module = compile_source(src, "test").unwrap();
+        let main = &module.functions[0];
+        let guard_cmps: Vec<&IIRInstr> = main.instructions.iter()
+            .filter(|i| matches!(i.op.as_str(), "cmp_le" | "cmp_ge"))
+            .collect();
+        assert!(!guard_cmps.is_empty(), "the for-loop emits step-sign and bound guards");
+        for c in guard_cmps {
+            assert_eq!(c.type_hint, "i64",
+                "guard {:?} must compare at i64 (its integer operands), not {:?}", c.op, c.type_hint);
+        }
     }
 
     #[test]

--- a/code/packages/rust/lang-aot/tests/lang_matrix.rs
+++ b/code/packages/rust/lang-aot/tests/lang_matrix.rs
@@ -569,12 +569,14 @@ const PROGRAMS: &[Prog] = &[
     // `alloc_array`→`newarr System.Int32`, `array_set`→`stelem.i4`, `array_get`→
     // `ldelem.i4`, `array_len`→`ldlen`+`conv.i4`, with CoreCLR's native bounds check
     // (OOB → `System.IndexOutOfRangeException`). Both managed runtimes give E5's trap
-    // for free. The handle is a reference local. (This `for`-loop cell stays on the
-    // managed backends; the **LLVM** array proof is the straight-line cell below —
-    // an ALGOL `for` loop hits a *separate*, pre-existing LLVM-only lowering bug in
-    // `iir-to-llvm` — an `i1`-typed loop-guard `icmp` over `i64` operands, emitted
-    // twice — that is unrelated to E5 and tracked as a follow-up.) The native
-    // x86_64/aarch64 static backends join in E5 PR-4b/4c.
+    // for free. The handle is a reference local. On **LLVM** (`iir-to-llvm`) it now
+    // runs too: the ALGOL `for`-loop guard formerly emitted an `i1`-typed `icmp`
+    // over `i64` operands (it tagged the comparison with the boolean *result* type
+    // instead of the operand width) — `clang` rejected that IR, so this cell was VM/
+    // JIT/JVM/CLR only. Fixed in `algol-iir-compiler` (the guard now compares at
+    // `i64`, like every other relation), and the `for`-loop sum-of-squares now
+    // compiles + runs via `clang` → exit 55. (NativeAot/WASM lower arrays but the
+    // for-loop path is the LLVM-specific cmp lowering this exercises.)
     Prog {
         lang: Language::Algol60,
         ext: "alg",
@@ -583,7 +585,7 @@ const PROGRAMS: &[Prog] = &[
                result := 0; \
                for i := 1 step 1 until 5 do result := result + A[i] end",
         expect: Expect::Exit(55),
-        backends: &[Vm, Jit, Jvm, Clr],
+        backends: &[Vm, Jit, Jvm, Clr, Llvm],
     },
     // ALGOL 60 — *straight-line* 1-D integer array (LANG-FULL E5, the **LLVM**
     // static-array proof — PR-4a). `A[1] := 40; A[3] := 2; result := A[1] + A[3]`

--- a/code/specs/LANG-FULL-IMPLEMENTATION.md
+++ b/code/specs/LANG-FULL-IMPLEMENTATION.md
@@ -374,8 +374,9 @@ backend immediately) come before the enabler-dependent items.
   JVM native `int[]` (PR-3a), CLR native `int32[]` on real `dotnet` (PR-3b), LLVM static `@calloc`+
   `llvm.trap` via `clang` (PR-4a), WASM linear-memory+`unreachable` via `wasm-runtime` (PR-4b),
   and **native** x86_64/aarch64 `__twig_alloc_bytes`+`ud2`/`udf` trap (PR-4c — aarch64 local,
-  x86_64 CI). The for-loop array Prog joins LLVM after a separate ALGOL-for-loop→LLVM fix.
-  Multidim + array params + `f64` native elements are follow-up.
+  x86_64 CI). The for-loop sum-of-squares array Prog now runs on LLVM too (the ALGOL-for-loop
+  guard-type fix landed in `algol-iir-compiler` 0.5.1). Multidim + array params + `f64` native
+  elements are follow-up.
 - ✅ **AL3** — typed procedures with value parameters. `integer procedure sq(x);
   value x; integer x; sq := x*x; result := sq(7)` ⇒ exit 49, **verified by running**
   across native/LLVM/WASM/JVM/CLR/VM/JIT (`lang-aot` `lang_matrix.rs`). Lowered to a

--- a/code/specs/lang-full-e5-arrays.md
+++ b/code/specs/lang-full-e5-arrays.md
@@ -191,8 +191,9 @@ merge before the next:
    - **4a — LLVM** ✅ **done** (`iir-to-llvm` 0.14.0): `alloc_array`→`@calloc`
      `[i64 len][elems…]`, `array_get/set`→`icmp uge`+`br` to `llvm.trap` then typed
      `getelementptr`+`load`/`store`, `array_len`→load header. A straight-line ALGOL
-     array program runs via `clang` (exit 42). *(The for-loop array Prog awaits a
-     separate ALGOL-for-loop→LLVM fix before joining the LLVM column.)*
+     array program runs via `clang` (exit 42). *(The for-loop sum-of-squares array
+     Prog also runs on LLVM now — the ALGOL-for-loop→LLVM guard-type fix landed in
+     `algol-iir-compiler` 0.5.1.)*
    - **4b — WASM** ✅ **done** (`iir-to-wasm` 0.16.0): linear-memory length-prefixed
      `[i64 len][elems…]` via a `__array_bump` global; `array_get/set` emit `i64.ge_u`
      → `if … unreachable` (the trap) then `i64.load`/`i64.store` at offset 8;


### PR DESCRIPTION
## Fix: ALGOL `for` loops now run on LLVM

A latent, LLVM-only bug surfaced during E5 (it blocked the for-loop array `Prog` from the LLVM matrix column). The `for … step … until` loop-guard comparisons — the step-sign check and the ascending/descending bound checks — were emitted with `type_hint = "bool"` (the boolean **result** type) instead of the integer **operand** width.

A code-gen backend reads a comparison's `type_hint` as its operand type, so on **LLVM** (`iir-to-llvm`'s `lower_cmp`) this produced the invalid `icmp i1 <i64>, <i64>` that `clang` rejects. ALGOL `for` loops were un-runnable on LLVM — they worked on VM/JIT/JVM/CLR, which infer operand types differently, so no test had exercised the LLVM path before E5.

The three guards now carry `"i64"`, matching the regular relational path (which already tags the cmp with `lhs.ty.iir()` — that's why E3 `real` comparisons always worked on LLVM).

### Verified — *runs via `clang`*
- `for i := 1 step 1 until 5 do result := result + i` → valid `icmp i64` IR, compiles + runs → **exit 15**.
- The **E5 sum-of-squares array `Prog`** (two `for` loops over an array) — previously LLVM-deferred in [PR-4a](https://github.com/adhithyan15/coding-adventures/pull/6393) because of this bug — now runs on the LLVM matrix column (**exit 55**); added `Llvm` to its backend list.
- New regression test asserts the guards compare at `i64`, not `bool`.
- Cleared the for-loop→LLVM caveats in the E5 spec + roadmap.

Footnote: the "emitted twice" duplicate-`icmp` I noted earlier turned out to be a *display artifact* of the invalid IR — confirmed absent (no duplicate `%def`s in the now-valid output).

### Security
`/security-review` → **PASSED**. Pure `type_hint` string change (`"bool"` → `"i64"`); no `unsafe`/IO/panic, no parsing change. `i64` is the correct operand width (the guards compare integer loop variables/limits).

🤖 Generated with [Claude Code](https://claude.com/claude-code)