### PR TITLE
feat(mycin-cc3c): fluoroquinolone contraindicated in myasthenia gravis (front-2)

### DIFF
--- a/code/specs/data/mycin-2026/board/board-scorecard.json
+++ b/code/specs/data/mycin-2026/board/board-scorecard.json
@@ -1,7 +1,7 @@
 {
   "summary": {
-    "total": 154,
-    "correct": 147,
+    "total": 155,
+    "correct": 148,
     "abstained": 7,
     "wrong": 0,
     "by_tactic": {
@@ -11,7 +11,7 @@
         "wrong": 0
       },
       "management": {
-        "correct": 7,
+        "correct": 8,
         "abstained": 0,
         "wrong": 0
       },
@@ -565,6 +565,14 @@
     },
     {
       "id": "mgmt_g6pd",
+      "tactic": "management",
+      "gold": "ceftriaxone+vancomycin",
+      "answer": "ceftriaxone+vancomycin",
+      "outcome": "correct",
+      "trust": null
+    },
+    {
+      "id": "mgmt_myasthenia",
       "tactic": "management",
       "gold": "ceftriaxone+vancomycin",
       "answer": "ceftriaxone+vancomycin",

--- a/code/specs/data/mycin-2026/board/items.json
+++ b/code/specs/data/mycin-2026/board/items.json
@@ -77,6 +77,7 @@
     {"id": "mgmt_betalactam_allergic","domain": "meningitis_tx", "tactic": "management", "chart": [["age_band", "adult", "adult"], ["allergy", "betalactam", "anaphylaxis to multiple beta-lactams (whole-class)"]],       "gold": "INFEASIBLE"},
     {"id": "mgmt_hepatorenal",       "domain": "meningitis_tx", "tactic": "management", "chart": [["age_band", "adult", "58-year-old"], ["hepatic_status", "hepatic_moderate", "Child-Pugh B cirrhosis"], ["renal_status", "renal_moderate", "CrCl 38 mL/min"]], "gold": ["ceftriaxone", "vancomycin"]},
     {"id": "mgmt_g6pd",              "domain": "meningitis_tx", "tactic": "management", "chart": [["age_band", "adult", "26-year-old"], ["comorbidity", "g6pd_deficiency", "known G6PD deficiency"]], "gold": ["ceftriaxone", "vancomycin"]},
+    {"id": "mgmt_myasthenia",        "domain": "meningitis_tx", "tactic": "management", "chart": [["age_band", "adult", "38-year-old"], ["comorbidity", "myasthenia_gravis", "history of myasthenia gravis"]], "gold": ["ceftriaxone", "vancomycin"]},
 
     {"id": "micro_saureus_gram",   "domain": "micro", "tactic": "recall", "relation": "gram_stain", "subject": "staphylococcus_aureus",    "var": "Result",  "gold": "gram_positive"},
     {"id": "micro_saureus_shape",  "domain": "micro", "tactic": "recall", "relation": "morphology", "subject": "staphylococcus_aureus",    "var": "Shape",   "gold": "cocci"},

--- a/code/specs/data/mycin-2026/grounding/treatment-constraints-grounding.json
+++ b/code/specs/data/mycin-2026/grounding/treatment-constraints-grounding.json
@@ -288,6 +288,33 @@
         "final_verdict": "grounded"
       },
       "spider_status": "grounded"
+    },
+    {
+      "id": "ci_fluoroquinolone_myasthenia",
+      "kind": "contraindication",
+      "claim": "Fluoroquinolones (e.g. moxifloxacin) are contraindicated in patients with myasthenia gravis because they may exacerbate muscle weakness (FDA boxed warning).",
+      "grounded": {
+        "id": "ci_fluoroquinolone_myasthenia",
+        "verdict": "grounded",
+        "direction_correct": true,
+        "byte_quote": "Avoid ciprofloxacin and its fluoroquinolone class in patients with myasthenia gravis because it may exacerbate muscle weaknesses.",
+        "resolved_url": "https://www.ncbi.nlm.nih.gov/books/NBK535454/",
+        "source_title": "Ciprofloxacin — StatPearls (NCBI Bookshelf), Adverse Effects / Contraindications",
+        "value_found": "StatPearls states to avoid ciprofloxacin and its fluoroquinolone class in myasthenia gravis due to risk of exacerbating muscle weakness; mirrors the FDA fluoroquinolone boxed warning (MG exacerbation).",
+        "discards": [
+          "Per-drug fluoroquinolone pages (moxifloxacin NBK599511, levofloxacin NBK545180, ofloxacin NBK549837) also state the MG contraindication, but they name a single drug; the ciprofloxacin page's span names the fluoroquinolone CLASS, which is the right granularity for the class_contraindicated_in fact — one authoritative class-level copy kept.",
+          "Secondary drug-reference/aggregator pages excluded by design (primary StatPearls/FDA only)."
+        ],
+        "note": "ENTAILED. The cited span names the fluoroquinolone CLASS + myasthenia gravis + the harm (exacerbation of muscle weakness) in one declarative, grounding class_contraindicated_in(fluoroquinolone, myasthenia_gravis) directionally. The FDA fluoroquinolone boxed warning lists MG exacerbation, so 'avoid/contraindicated' is label-accurate."
+      },
+      "verify": {
+        "id": "ci_fluoroquinolone_myasthenia",
+        "byte_stable": true,
+        "reextracted_value": "The StatPearls Ciprofloxacin page states verbatim: \"Avoid ciprofloxacin and its fluoroquinolone class in patients with myasthenia gravis because it may exacerbate muscle weaknesses.\"",
+        "refute_attempt": "Attempted refutation: is this only a ciprofloxacin claim, not class-wide? No — the span explicitly says 'and its fluoroquinolone class', and the per-drug moxifloxacin/levofloxacin/ofloxacin pages independently state the same MG contraindication, consistent with the FDA class boxed warning. The class-level fact is supported.",
+        "final_verdict": "grounded"
+      },
+      "spider_status": "grounded"
     }
   ]
 }

--- a/code/specs/data/mycin-2026/treatment/antibiotics/chart_to_cop.py
+++ b/code/specs/data/mycin-2026/treatment/antibiotics/chart_to_cop.py
@@ -120,6 +120,9 @@ _CONTEXT_FROM_FACT = {
     # the fluoroquinolone (moxifloxacin) is QT-prolonging — both already grounded in the rulebook.
     ("comorbidity", "g6pd_deficiency"): "g6pd_deficiency",
     ("comorbidity", "qt_prolongation"): "qt_prolongation",
+    # myasthenia gravis → the fluoroquinolone (moxifloxacin) can exacerbate muscle weakness
+    # (FDA boxed warning) — grounded class_contraindicated_in(fluoroquinolone, myasthenia_gravis).
+    ("comorbidity", "myasthenia_gravis"): "myasthenia_gravis",
 }
 
 # CC-4: a chart `objective_priority` fact → the (w_cost, w_tox) objective blend the

--- a/code/specs/data/mycin-2026/treatment/antibiotics/contraindication-manifest.json
+++ b/code/specs/data/mycin-2026/treatment/antibiotics/contraindication-manifest.json
@@ -69,6 +69,16 @@
       "source": "Avoid moxifloxacin hydrochloride in patients with the following risk factors due to the lack of clinical experience with the drug in these patient populations: Known prolongation of the QT interval; Uncorrected hypokalemia or hypomagnesemia; Class IA (for example, quinidine, procainamide) or Class III (for example, amiodarone, sotalol) antiarrhythmic agents.",
       "url": "https://dailymed.nlm.nih.gov/dailymed/drugInfo.cfm?setid=3c442cca-47f5-48e5-b718-c09413911687"
     },
+    "class_contraindicated_in__fluoroquinolone__myasthenia_gravis": {
+      "relation": "class_contraindicated_in",
+      "subject": "fluoroquinolone",
+      "context": "myasthenia_gravis",
+      "grounding_id": "ci_fluoroquinolone_myasthenia",
+      "verdict": "ACCEPT",
+      "trust": "authoritative",
+      "source": "Avoid ciprofloxacin and its fluoroquinolone class in patients with myasthenia gravis because it may exacerbate muscle weaknesses.",
+      "url": "https://www.ncbi.nlm.nih.gov/books/NBK535454/"
+    },
     "drug_contraindicated_in__tmp_smx__pregnancy": {
       "relation": "drug_contraindicated_in",
       "subject": "tmp_smx",
@@ -130,5 +140,5 @@
       "grounding_id": null
     }
   },
-  "hash": "c63c38b0d2e27b31"
+  "hash": "5d46e8fe60c02e13"
 }

--- a/code/specs/data/mycin-2026/treatment/antibiotics/contraindications.adj
+++ b/code/specs/data/mycin-2026/treatment/antibiotics/contraindications.adj
@@ -58,6 +58,10 @@ rulebook contraindications {
         source "Avoid moxifloxacin hydrochloride in patients with the following risk factors due to the lack of clinical experience with the drug in these patient populations: Known prolongation of the QT interval; Uncorrected hypokalemia or hypomagnesemia; Class IA (for example, quinidine, procainamide) or Class III (for example, amiodarone, sotalol) antiarrhythmic agents."
         locator "https://dailymed.nlm.nih.gov/dailymed/drugInfo.cfm?setid=3c442cca-47f5-48e5-b718-c09413911687"
         trust authoritative
+    relate class_contraindicated_in(fluoroquinolone, myasthenia_gravis)
+        source "Avoid ciprofloxacin and its fluoroquinolone class in patients with myasthenia gravis because it may exacerbate muscle weaknesses."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK535454/"
+        trust authoritative
 
     % --- grounded DRUG-level contraindications ------------------------------
     relate drug_contraindicated_in(tmp_smx, pregnancy)

--- a/code/specs/data/mycin-2026/treatment/antibiotics/contraindications_build.py
+++ b/code/specs/data/mycin-2026/treatment/antibiotics/contraindications_build.py
@@ -107,6 +107,11 @@ CLASS_CONTRA: list[tuple[str, str, str, str]] = [
     ("ci_fluoroquinolone_qt", "fluoroquinolone", "qt_prolongation",
      "Fluoroquinolones (e.g. moxifloxacin) prolong the QT interval and should be avoided in "
      "patients with known QT prolongation."),
+    # CC-3c comorbidity family (class route): myasthenia gravis → the fluoroquinolone can
+    # exacerbate muscle weakness (FDA boxed warning). Same generic class rule, new context.
+    ("ci_fluoroquinolone_myasthenia", "fluoroquinolone", "myasthenia_gravis",
+     "Fluoroquinolones (e.g. moxifloxacin) are avoided in myasthenia gravis because they may "
+     "exacerbate muscle weakness."),
 ]
 
 # Drug-level contraindications: (grounding_id, drug, context, authored_fallback_quote).

--- a/code/specs/data/mycin-2026/treatment/antibiotics/test_contraindications.py
+++ b/code/specs/data/mycin-2026/treatment/antibiotics/test_contraindications.py
@@ -112,6 +112,19 @@ def test_g6pd_deficiency_excludes_the_sulfonamide():
     assert "glucose-6-phosphate dehydrogenase" in info["source"]
 
 
+def test_myasthenia_gravis_excludes_the_fluoroquinolone():
+    cli = _cli_or_skip()
+    # CC-3c comorbidity family (class route): myasthenia gravis excludes the fluoroquinolone
+    # (moxifloxacin) — the FDA boxed warning — via the SAME generic class rule that fires for
+    # pregnancy / qt_prolongation, proving the mechanism is context-driven, not hardcoded.
+    out = ci.derive_contraindications(cli, {"myasthenia_gravis"})
+    assert set(out) == {"moxifloxacin"}, out
+    info = out["moxifloxacin"]
+    assert info["context"] == "myasthenia_gravis"
+    assert info["trust"] == "authoritative" and info["source"]
+    assert "myasthenia gravis" in info["source"]
+
+
 # --------------------------------------------------------------------------
 # CC-3b — β-lactam allergy is SIDE-CHAIN-scoped, not class-wide.
 # --------------------------------------------------------------------------


### PR DESCRIPTION
## What

Extends the **CC-3c comorbidity-exclusion** family (front-2: diagnostics + constraints) with a new grounded contraindication: **a fluoroquinolone (moxifloxacin) is contraindicated in myasthenia gravis** (FDA boxed warning — risk of exacerbating muscle weakness).

It fires through the **same generic class-route derivation rule** already used for pregnancy and QT prolongation — no new engine logic, just one grounded fact + one context mapping. The reasoning lives in the ADJ rulebook; Python only maps a chart comorbidity to an active context and reads the engine's derived exclusion.

## Grounding (primary-source-first)

StatPearls Ciprofloxacin (NBK535454) — one declarative naming the fluoroquinolone **class** + myasthenia gravis + the harm:

> Avoid ciprofloxacin and its fluoroquinolone class in patients with myasthenia gravis because it may exacerbate muscle weaknesses.

- locator: https://www.ncbi.nlm.nih.gov/books/NBK535454/ · trust: authoritative

## Changes

- `grounding/treatment-constraints-grounding.json` — +record `ci_fluoroquinolone_myasthenia` (verdict grounded; byte_quote + resolved_url + verify block).
- `contraindications_build.py` — +`CLASS_CONTRA` row → `contraindications.adj` regenerated (5 grounded ACCEPT, 0 authored-debt) + manifest.
- `chart_to_cop.py` — +`_CONTEXT_FROM_FACT` row (comorbidity `myasthenia_gravis` → active context).
- `board/items.json` — +`mgmt_myasthenia` (adult + MG; gold `ceftriaxone+vancomycin` — verifies the new context does **not** break the standard meningitis regimen, since moxifloxacin isn't in that gold). `board-scorecard.json` regenerated.
- `test_contraindications.py` — +1 engine-derivation test.

## Verification

- `test_contraindications` **17/17** (engine derives `moxifloxacin` excluded in `myasthenia_gravis` via the generic class rule, carrying the grounded byte-quote).
- `test_board_eval` **12/12**; scorecard total 154→155, correct 147→148, management 7→8, **wrong stays 0** (100% defensibility maintained).
- ruff clean; security review passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)