### PR TITLE
feat(x86-sim): PR-S2 — SSE2 scalar doubles (run x86_64 f64 codegen locally)

### DIFF
--- a/code/packages/rust/x86-simulator/CHANGELOG.md
+++ b/code/packages/rust/x86-simulator/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog — x86-simulator
 
+## 0.2.0 — 2026-06-21 — SSE2 scalar doubles + `movabs`/`setcc` (x86-sim PR-S2)
+
+Runs the x86_64-backend's **floating-point** (ALGOL `real` / LANG-FULL E3) output
+locally, on top of the S1 integer core.
+
+### Added
+- **XMM scalar-double SSE2**: `movsd` (load `F2 0F 10` / store `F2 0F 11` / reg-reg),
+  `addsd`/`subsd`/`mulsd`/`divsd` (`F2 0F 58/5C/59/5E`), and `ucomisd`
+  (`66 0F 2E`) with the x86 ZF/PF/CF flag semantics (unordered/NaN → ZF=PF=CF=1).
+  Computed in `f64` over the low lane of the `xmm` register file.
+- **`movabs r64, imm64`** (`0xB8+rd` REX.W) — the full 64-bit immediate the backend
+  uses to materialise an `f64` constant's bit pattern before `movsd`-ing it into XMM
+  (missed by S1, which only handled the `imm32` `mov`).
+- **`setcc r/m8`** (`0F 90..9F`) — the byte-setting half of a comparison; an `f64`
+  `=` lowers to `ucomisd; sete; movzx; setnp; movzx; and` (ordered-equal), all of
+  which the simulator now executes.
+- The mandatory-prefix (`F2`/`F3`/`66`) decode path that precedes `0F` for SSE.
+
+### Verified
+- Decodes `movabs`/`movsd`/`mulsd`/`ucomisd`/`sete` from real backend bytes.
+- **End-to-end**: compiles `2.5 * 2.0 == 5.0` and `7.0 / 2.0 < 4.0` with the real
+  `x86_64-backend` and runs the SSE2 machine code → exit **1** (true), locally on
+  aarch64. 20 tests.
+
 ## 0.1.0 — 2026-06-21 — integer core + MachineCodeHarness (x86-sim PR-S1)
 
 The first runnable slice: a Rust runtime simulator that decodes and executes the

--- a/code/packages/rust/x86-simulator/Cargo.toml
+++ b/code/packages/rust/x86-simulator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "x86-simulator"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "x86/x86-64 runtime simulator — decode + execute machine code, and run the x86_64-backend's emitted code locally (host-arch-independent)"
 

--- a/code/packages/rust/x86-simulator/README.md
+++ b/code/packages/rust/x86-simulator/README.md
@@ -20,11 +20,14 @@ The subset the `x86_64-encoder` emits (and growing):
 - **Integer ALU**: `add` / `sub` / `cmp` / `and` / `or` / `xor` / `test` (reg and
   imm forms), `shl` / `shr` / `sar`, `imul` — all with full CF/ZF/SF/OF/PF flags.
 - **Control flow**: `jmp`, `jcc` (all 16 conditions), `call` / `ret`, `push` /
-  `pop`, and `ud2` → an illegal-instruction **trap** (how an E5 out-of-bounds
-  array access aborts).
+  `pop`, `setcc`, and `ud2` → an illegal-instruction **trap** (how an E5
+  out-of-bounds array access aborts).
+- **SSE2 scalar double** (ALGOL `real` / E3): `movsd` (load/store/reg), `addsd` /
+  `subsd` / `mulsd` / `divsd`, `ucomisd`, and `movabs r64, imm64` — enough to run
+  the backend's `f64` arithmetic + comparison output.
 
-Pending phases: SSE2 scalar doubles (`movsd`/`addsd`/`ucomisd`/`cvt*`, for E3
-ALGOL `real`), and 32-bit x86. Anything unimplemented is a clean `DecodeError`.
+Pending phases: `cvtsi2sd` / `cvttsd2si` (int↔float), and 32-bit x86. Anything
+unimplemented is a clean `DecodeError`.
 
 ## How to use it
 

--- a/code/packages/rust/x86-simulator/src/decode.rs
+++ b/code/packages/rust/x86-simulator/src/decode.rs
@@ -62,7 +62,30 @@ pub enum Instr {
     Ud2,
     /// `nop`.
     Nop,
+    // ── SSE2 scalar double (LANG-FULL E3 — ALGOL `real`) ──────────────────────
+    /// `movsd xmm, m64` — load a double into the low lane of an XMM register.
+    MovsdLoad { xmm: u8, src: Operand },
+    /// `movsd m64, xmm` — store the low double of an XMM register.
+    MovsdStore { dst: Operand, xmm: u8 },
+    /// `movsd xmm, xmm` — copy the low double (register form).
+    MovsdRr { dst: u8, src: u8 },
+    /// `addsd`/`subsd`/`mulsd`/`divsd xmm, xmm/m64`.
+    SseArith { op: SseOp, dst: u8, src: XmmRm },
+    /// `ucomisd xmm, xmm/m64` — unordered compare, sets CF/ZF/PF (OF/SF/AF=0).
+    Ucomisd { a: u8, b: XmmRm },
+    /// `setcc r/m8` — set the low byte to 1 if the condition holds, else 0.
+    Setcc { cond: u8, dst: Operand },
 }
+
+/// SSE2 scalar-double arithmetic ops.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[allow(missing_docs)]
+pub enum SseOp { Add, Sub, Mul, Div }
+
+/// An XMM source: either a register (by number 0..15) or a memory operand.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[allow(missing_docs)]
+pub enum XmmRm { Xmm(u8), Mem(Operand) }
 
 /// Integer ALU ops we decode (all set flags).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -88,6 +111,16 @@ pub fn decode(code: &[u8], off: usize) -> Result<Decoded, Trap> {
     let at = |p: usize| -> Result<u8, Trap> {
         code.get(p).copied().ok_or(Trap::DecodeError { offset: p as u64, opcode: 0 })
     };
+
+    // ── Mandatory SSE prefix (F2/F3/66) — comes *before* REX ─────────────────
+    // SSE2 scalar ops are `prefix 0F op`: `F2` = scalar-double, `66` = packed/
+    // compare-double. We only need to remember which one preceded the `0F`.
+    let mut sse_prefix: Option<u8> = None;
+    let pb = at(p)?;
+    if pb == 0xF2 || pb == 0xF3 || pb == 0x66 {
+        sse_prefix = Some(pb);
+        p += 1;
+    }
 
     // ── REX prefix ──────────────────────────────────────────────────────────
     let mut rex_w = false;
@@ -118,6 +151,16 @@ pub fn decode(code: &[u8], off: usize) -> Result<Decoded, Trap> {
         return Ok(Decoded { instr: Instr::Pop(r), len: p - off });
     }
 
+    // movabs r64, imm64  (0xB8+rd with REX.W) — loads a full 64-bit immediate,
+    // e.g. an `f64` constant's bit pattern before it is `movsd`'d into an XMM.
+    if rex_w && (0xB8..=0xBF).contains(&op) {
+        let r = Reg::from_index((op - 0xB8) | ((rex_b as u8) << 3));
+        let b = code.get(p..p + 8).ok_or(Trap::DecodeError { offset: p as u64, opcode: op })?;
+        let imm = i64::from_le_bytes([b[0], b[1], b[2], b[3], b[4], b[5], b[6], b[7]]);
+        p += 8;
+        return Ok(Decoded { instr: Instr::MovImm { dst: Operand::Reg(r), imm }, len: p - off });
+    }
+
     match op {
         0xC3 => return Ok(Decoded { instr: Instr::Ret, len: p - off }),
         0x90 => return Ok(Decoded { instr: Instr::Nop, len: p - off }),
@@ -133,6 +176,37 @@ pub fn decode(code: &[u8], off: usize) -> Result<Decoded, Trap> {
     // Two-byte 0F opcodes.
     if op == 0x0F {
         let op2 = at(p)?; p += 1;
+
+        // SSE2 scalar double (a mandatory F2/66 prefix preceded the 0F).
+        if let Some(pfx) = sse_prefix {
+            let (m, np) = modrm(code, p, rex_r, rex_x, rex_b)?;
+            let xmm = m.reg; // ModRM.reg is the XMM register number
+            let rm_xmm = match m.rm {
+                Operand::Reg(r) => XmmRm::Xmm(r as u8),
+                mem => XmmRm::Mem(mem),
+            };
+            let instr = match (pfx, op2) {
+                // F2 0F 10 — movsd xmm, xmm/m64 (load)
+                (0xF2, 0x10) => match rm_xmm {
+                    XmmRm::Xmm(s) => Instr::MovsdRr { dst: xmm, src: s },
+                    XmmRm::Mem(mem) => Instr::MovsdLoad { xmm, src: mem },
+                },
+                // F2 0F 11 — movsd xmm/m64, xmm (store)
+                (0xF2, 0x11) => match rm_xmm {
+                    XmmRm::Xmm(s) => Instr::MovsdRr { dst: s, src: xmm },
+                    XmmRm::Mem(mem) => Instr::MovsdStore { dst: mem, xmm },
+                },
+                (0xF2, 0x58) => Instr::SseArith { op: SseOp::Add, dst: xmm, src: rm_xmm },
+                (0xF2, 0x5C) => Instr::SseArith { op: SseOp::Sub, dst: xmm, src: rm_xmm },
+                (0xF2, 0x59) => Instr::SseArith { op: SseOp::Mul, dst: xmm, src: rm_xmm },
+                (0xF2, 0x5E) => Instr::SseArith { op: SseOp::Div, dst: xmm, src: rm_xmm },
+                // 66 0F 2E — ucomisd xmm, xmm/m64 (also 0F 2F comisd; same here)
+                (0x66, 0x2E) | (0x66, 0x2F) => Instr::Ucomisd { a: xmm, b: rm_xmm },
+                _ => return Err(Trap::DecodeError { offset: (p - 1) as u64, opcode: op2 }),
+            };
+            return Ok(Decoded { instr, len: np - off });
+        }
+
         match op2 {
             0x0B => return Ok(Decoded { instr: Instr::Ud2, len: p - off }),
             0xAF => { // imul r64, r/m64
@@ -147,6 +221,10 @@ pub fn decode(code: &[u8], off: usize) -> Result<Decoded, Trap> {
             0x80..=0x8F => { // jcc rel32
                 let r = read_i32(code, p)? as i64; p += 4;
                 return Ok(Decoded { instr: Instr::Jcc { cond: op2 - 0x80, rel: rel_target(p, r) }, len: p - off });
+            }
+            0x90..=0x9F => { // setcc r/m8
+                let (m, np) = modrm(code, p, rex_r, rex_x, rex_b)?; p = np;
+                return Ok(Decoded { instr: Instr::Setcc { cond: op2 - 0x90, dst: m.rm }, len: p - off });
             }
             other => return Err(Trap::DecodeError { offset: (p - 1) as u64, opcode: other }),
         }
@@ -314,5 +392,25 @@ mod tests {
         // jb rel8 +5  (0x72 0x05)
         let d = decode(&[0x72, 0x05], 0).unwrap();
         assert_eq!(d.instr, Instr::Jcc { cond: 0x2, rel: 7 }); // 2 (len) + 5
+    }
+
+    #[test]
+    fn sse2_and_movabs_decode() {
+        // movabs rax, 0x4004000000000000  (2.5)  — 48 B8 <imm64>
+        let d = decode(&[0x48, 0xB8, 0,0,0,0,0,0,0x04,0x40], 0).unwrap();
+        assert_eq!(d.instr, Instr::MovImm { dst: Operand::Reg(Reg::Rax), imm: 0x4004_0000_0000_0000u64 as i64 });
+        assert_eq!(d.len, 10);
+        // movsd xmm0, [rbp-8]  — F2 0F 10 85 F8 FF FF FF
+        let d = decode(&[0xF2, 0x0F, 0x10, 0x85, 0xF8, 0xFF, 0xFF, 0xFF], 0).unwrap();
+        assert_eq!(d.instr, Instr::MovsdLoad { xmm: 0, src: Operand::Mem { base: Some(Reg::Rbp), index: None, scale: 1, disp: -8, rip: false } });
+        // mulsd xmm0, xmm1  — F2 0F 59 C1
+        assert_eq!(decode(&[0xF2, 0x0F, 0x59, 0xC1], 0).unwrap().instr,
+                   Instr::SseArith { op: SseOp::Mul, dst: 0, src: XmmRm::Xmm(1) });
+        // ucomisd xmm0, xmm1  — 66 0F 2E C1
+        assert_eq!(decode(&[0x66, 0x0F, 0x2E, 0xC1], 0).unwrap().instr,
+                   Instr::Ucomisd { a: 0, b: XmmRm::Xmm(1) });
+        // sete al  — 40 0F 94 C0   (cond 4 = E)
+        assert_eq!(decode(&[0x40, 0x0F, 0x94, 0xC0], 0).unwrap().instr,
+                   Instr::Setcc { cond: 0x4, dst: Operand::Reg(Reg::Rax) });
     }
 }

--- a/code/packages/rust/x86-simulator/src/execute.rs
+++ b/code/packages/rust/x86-simulator/src/execute.rs
@@ -4,11 +4,30 @@
 //! result; the other ALU ops write back. Control-flow instructions return a
 //! [`Flow`] the step loop acts on.
 
-use crate::decode::{AluOp, Instr, Operand, ShiftOp};
+use crate::decode::{AluOp, Instr, Operand, ShiftOp, SseOp, XmmRm};
 use crate::flags::{add_with_flags, logic_flags, sub_with_flags};
-use crate::state::{CpuState, Reg};
+use crate::state::{CpuState, Flags, Reg};
 use crate::memory::Memory;
 use crate::trap::Trap;
+
+/// Read the scalar `f64` in the low lane of XMM register `n`.
+fn read_xmm(st: &CpuState, n: u8) -> f64 {
+    f64::from_bits(st.xmm[n as usize] as u64)
+}
+
+/// Write a scalar `f64` into the low lane of XMM register `n` (high lane kept).
+fn write_xmm(st: &mut CpuState, n: u8, v: f64) {
+    let hi = st.xmm[n as usize] & (!0u128 << 64);
+    st.xmm[n as usize] = hi | (v.to_bits() as u128);
+}
+
+/// Read an XMM-or-memory source as an `f64`.
+fn read_xmmrm(st: &CpuState, mem: &Memory, src: &XmmRm, next_ip: u64) -> Result<f64, Trap> {
+    match src {
+        XmmRm::Xmm(n) => Ok(read_xmm(st, *n)),
+        XmmRm::Mem(op) => Ok(f64::from_bits(mem.load(effective_addr(st, op, next_ip), 8)?)),
+    }
+}
 
 /// What the step loop should do after an instruction.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -129,6 +148,61 @@ pub fn exec_one(
             let a = st.get(*dst);
             let b = read_op(st, mem, src, next_ip, 8)?;
             st.set(*dst, a.wrapping_mul(b));
+            Ok(Flow::Next)
+        }
+        // ── SSE2 scalar double ────────────────────────────────────────────────
+        Instr::MovsdLoad { xmm, src } => {
+            let v = f64::from_bits(read_op(st, mem, src, next_ip, 8)?);
+            write_xmm(st, *xmm, v);
+            Ok(Flow::Next)
+        }
+        Instr::MovsdStore { dst, xmm } => {
+            let bits = read_xmm(st, *xmm).to_bits();
+            write_op(st, mem, dst, next_ip, 8, bits)?;
+            Ok(Flow::Next)
+        }
+        Instr::MovsdRr { dst, src } => {
+            let v = read_xmm(st, *src);
+            write_xmm(st, *dst, v);
+            Ok(Flow::Next)
+        }
+        Instr::SseArith { op, dst, src } => {
+            let a = read_xmm(st, *dst);
+            let b = read_xmmrm(st, mem, src, next_ip)?;
+            let r = match op {
+                SseOp::Add => a + b,
+                SseOp::Sub => a - b,
+                SseOp::Mul => a * b,
+                SseOp::Div => a / b,
+            };
+            write_xmm(st, *dst, r);
+            Ok(Flow::Next)
+        }
+        Instr::Ucomisd { a, b } => {
+            let x = read_xmm(st, *a);
+            let y = read_xmmrm(st, mem, b, next_ip)?;
+            // x86 `ucomisd` sets ZF/PF/CF; OF/SF/AF cleared. Unordered (NaN) sets
+            // ZF=PF=CF=1; otherwise PF=0 and ZF/CF encode the ordering.
+            st.flags = if x.is_nan() || y.is_nan() {
+                Flags { zf: true, pf: true, cf: true, ..Flags::default() }
+            } else if x < y {
+                Flags { cf: true, ..Flags::default() }
+            } else if x > y {
+                Flags::default()
+            } else {
+                Flags { zf: true, ..Flags::default() }
+            };
+            Ok(Flow::Next)
+        }
+        Instr::Setcc { cond, dst } => {
+            let c = crate::flags::Cond::from_nibble(*cond);
+            let bit = crate::flags::condition_holds(c, &st.flags) as u64;
+            // setcc writes only the low byte; keep the upper bits (a `movzx`
+            // typically follows). For a register dst that means a masked write.
+            match dst {
+                Operand::Reg(r) => { let v = (st.get(*r) & !0xFF) | bit; st.set(*r, v); }
+                Operand::Mem { .. } => write_op(st, mem, dst, next_ip, 1, bit)?,
+            }
             Ok(Flow::Next)
         }
         Instr::Jmp(t) => Ok(Flow::Jump(code_base.wrapping_add(*t as u64))),

--- a/code/packages/rust/x86-simulator/src/harness.rs
+++ b/code/packages/rust/x86-simulator/src/harness.rs
@@ -90,7 +90,7 @@ impl MachineCodeHarness {
             code.extend_from_slice(bytes);
             for r in rs {
                 // The rel32 site must lie within this function's bytes.
-                if r.patch_offset.checked_add(4).map_or(true, |e| e > bytes.len()) {
+                if r.patch_offset.checked_add(4).is_none_or(|e| e > bytes.len()) {
                     return Err(BuildError::BadReloc {
                         symbol: r.symbol.clone(),
                         patch_offset: r.patch_offset,

--- a/code/packages/rust/x86-simulator/tests/sse_floats.rs
+++ b/code/packages/rust/x86-simulator/tests/sse_floats.rs
@@ -1,0 +1,41 @@
+use jit_core::backend::FunctionContext;
+use jit_core::cir::{CIRInstr, CIROperand};
+use x86_64_backend::{compile_function_with_relocs, X86_64Abi};
+use x86_simulator::harness::{MachineCodeHarness, Reloc};
+fn run(cir: Vec<CIRInstr>) -> i32 {
+    let ctx = FunctionContext { name: "main", params: &[], return_type: "u64" };
+    let (bytes, relocs) = compile_function_with_relocs(&ctx, &cir, X86_64Abi::SysV).unwrap();
+    let relocs: Vec<Reloc> = relocs.into_iter().map(|r| Reloc { patch_offset: r.patch_offset, symbol: r.symbol }).collect();
+    MachineCodeHarness::new().function("main", &bytes, &relocs).build("main").unwrap().run().unwrap()
+}
+#[test]
+fn f64_mul_and_compare_runs_locally() {
+    let f = |op:&str,d:Option<&str>,s:Vec<CIROperand>,t:&str| CIRInstr{op:op.into(),dest:d.map(Into::into),srcs:s,ty:t.into(),deopt_to:None};
+    let v=|n:&str| CIROperand::Var(n.into());
+    // c = 2.5 * 2.0 (=5.0); d = (c == 5.0); ret d  → exit 1
+    let cir = vec![
+        f("const_f64",Some("a"),vec![CIROperand::Float(2.5)],"f64"),
+        f("const_f64",Some("b"),vec![CIROperand::Float(2.0)],"f64"),
+        f("mul_f64",Some("c"),vec![v("a"),v("b")],"f64"),
+        f("const_f64",Some("five"),vec![CIROperand::Float(5.0)],"f64"),
+        f("cmp_eq_f64",Some("d"),vec![v("c"),v("five")],"f64"),
+        f("ret_u64",None,vec![v("d")],"u64"),
+    ];
+    assert_eq!(run(cir), 1, "2.5*2.0 == 5.0 → true; simulator runs real x86_64 SSE2 codegen");
+}
+
+#[test]
+fn f64_div_runs_locally() {
+    let f = |op:&str,d:Option<&str>,s:Vec<CIROperand>,t:&str| CIRInstr{op:op.into(),dest:d.map(Into::into),srcs:s,ty:t.into(),deopt_to:None};
+    let v=|n:&str| CIROperand::Var(n.into());
+    // (7.0 / 2.0 < 4.0) → true → exit 1
+    let cir = vec![
+        f("const_f64",Some("a"),vec![CIROperand::Float(7.0)],"f64"),
+        f("const_f64",Some("b"),vec![CIROperand::Float(2.0)],"f64"),
+        f("div_f64",Some("c"),vec![v("a"),v("b")],"f64"),
+        f("const_f64",Some("four"),vec![CIROperand::Float(4.0)],"f64"),
+        f("cmp_lt_f64",Some("d"),vec![v("c"),v("four")],"f64"),
+        f("ret_u64",None,vec![v("d")],"u64"),
+    ];
+    assert_eq!(run(cir), 1, "7.0/2.0 = 3.5 < 4.0 → true");
+}


### PR DESCRIPTION
## x86-sim PR-S2 — the simulator now runs x86_64 **floating-point** codegen locally

Builds on [S1 #6412](https://github.com/adhithyan15/coding-adventures/pull/6412) (integer core, merged). Adds SSE2 scalar-double support so the `x86_64-backend`'s ALGOL `real` / E3 floating-point output runs locally on aarch64.

### `x86-simulator` 0.1.0 → 0.2.0
- **SSE2 scalar double** over the `xmm[16]` register file: `movsd` (load `F2 0F 10` / store `F2 0F 11` / reg-reg), `addsd`/`subsd`/`mulsd`/`divsd` (`F2 0F 58/5C/59/5E`), `ucomisd` (`66 0F 2E`) with the x86 ZF/PF/CF flag rules (unordered/NaN → ZF=PF=CF=1). Computed in `f64`.
- **`movabs r64, imm64`** (`0xB8+rd` REX.W) — the full 64-bit immediate the backend uses to materialise an `f64` constant's bit pattern before `movsd`-ing it into XMM (S1 only had the `imm32` `mov`).
- **`setcc r/m8`** (`0F 90..9F`) — an `f64` `=` lowers to `ucomisd; sete; movzx; setnp; movzx; and` (ordered-equal), all now executed.
- The mandatory-prefix (`F2`/`F3`/`66`) decode path before `0F`.

### Verified — *runs real f64 backend output*
- Decodes `movabs`/`movsd`/`mulsd`/`ucomisd`/`sete` from real backend bytes.
- **End-to-end**: compiles `2.5 * 2.0 == 5.0` and `7.0 / 2.0 < 4.0` with the **real** `x86_64-backend` and runs the SSE2 machine code → exit **1** (true), locally on aarch64. 20 tests; clippy clean.

### Security
`/security-review` → **PASSED**. Same sandboxed surface as S1: `movabs` reads are bounds-checked (`code.get`), XMM indices proven `0..15` (ModRM reg masked), `f64` arithmetic/`ucomisd` are panic-free, SSE memory operands route through the bounds-checked `Memory`, no `unsafe`. Fail-closed (`DecodeError`/`Trap`) on any blob.

### Next
**S3** — wire a local `run_x86_sim` matrix path + **retro-verify the E5 native-array and E3-float x86_64 codegen locally** (the whole point: run the x86_64 column on this aarch64 machine). **S4** — 32-bit x86; `cvtsi2sd`/`cvttsd2si` as needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)