### PR TITLE
feat(mycin-pharm): ground digoxin & warfarin antidotes (toxicology recall)

### DIFF
--- a/code/specs/data/mycin-2026/recall/pharm-edges.adj
+++ b/code/specs/data/mycin-2026/recall/pharm-edges.adj
@@ -98,4 +98,16 @@ rulebook pharm_facts {
         source "Protamine is a medication used to reverse and neutralize the anticoagulant effects of heparin."
         locator "https://www.ncbi.nlm.nih.gov/books/NBK547753/"
         trust authoritative
+
+    % --- EXPAND: digoxin immune Fab reverses digoxin toxicity ----------
+    relate antidote_for(digoxin_toxicity, digoxin_immune_fab)
+        source "Digoxin immune Fab is an antidote for digoxin toxicity, a condition typically observed in patients with atrial fibrillation and underlying heart failure."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK556101/"
+        trust authoritative
+
+    % --- EXPAND: vitamin K reverses warfarin-associated coagulopathy ----
+    relate antidote_for(warfarin_toxicity, vitamin_k)
+        source "Oral vitamin K lowers the international normalized ratio more rapidly than subcutaneous vitamin K in the treatment of warfarin-associated coagulopathy."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK557622/"
+        trust authoritative
 }

--- a/code/specs/data/mycin-2026/recall/pharm-recall.query.adj
+++ b/code/specs/data/mycin-2026/recall/pharm-recall.query.adj
@@ -21,3 +21,5 @@ import "pharm-edges.adj"
 ? antidote_for(acetaminophen_poisoning, $Antidote)  % expect acetylcysteine
 ? antidote_for(opioid_toxicity, $Antidote)       % expect naloxone
 ? antidote_for(heparin_overdose, $Antidote)      % expect protamine (expand)
+? antidote_for(digoxin_toxicity, $Antidote)      % expect digoxin_immune_fab (expand)
+? antidote_for(warfarin_toxicity, $Antidote)     % expect vitamin_k (expand)

--- a/code/specs/data/mycin-2026/recall/test_pharm_recall.py
+++ b/code/specs/data/mycin-2026/recall/test_pharm_recall.py
@@ -40,6 +40,8 @@ EXPECTED = [
     ("opioid_toxicity", "antidote_for", "naloxone"),
     ("benzodiazepine_overdose", "antidote_for", "flumazenil"),
     ("heparin_overdose", "antidote_for", "protamine"),   # expand (NBK547753)
+    ("digoxin_toxicity", "antidote_for", "digoxin_immune_fab"),   # expand (NBK556101)
+    ("warfarin_toxicity", "antidote_for", "vitamin_k"),           # expand (NBK557622)
 ]
 VAR = {"drug_class": "Class", "mechanism": "MOA", "adverse_effect": "Effect",
        "antidote_for": "Antidote"}


### PR DESCRIPTION
## What

Expands the pharmacology recall library's `antidote_for` relation with two high-yield **toxicology** pairs:

- **antidote_for(digoxin_toxicity, digoxin_immune_fab)** — NBK556101:
  > Digoxin immune Fab is an antidote for digoxin toxicity, a condition typically observed in patients with atrial fibrillation and underlying heart failure.
- **antidote_for(warfarin_toxicity, vitamin_k)** — NBK557622:
  > Oral vitamin K lowers the international normalized ratio more rapidly than subcutaneous vitamin K in the treatment of warfarin-associated coagulopathy.

Both are `trust authoritative`, each defended by a single self-contained StatPearls span naming the poisoning **and** the antidote. They join the existing antidotes (naloxone/opioid, flumazenil/benzo, acetylcysteine/acetaminophen, protamine/heparin) — toxicology antidotes are a high-yield board category and `antidote_for` already exists, so this is a clean **expansion**, not a new domain.

## Changes (data-only)

- `pharm-edges.adj` — +2 `relate` clauses (inline source+locator)
- `pharm-recall.query.adj` — +2 binding queries
- `test_pharm_recall.py` — `EXPECTED` +2; `ibuprofen` negative-control abstain test unchanged

## Verification

- `test_pharm_recall: 3/3 passed` (engine binds `digoxin_immune_fab` / `vitamin_k` with authoritative citations; `relate` count == EXPECTED; off-vocabulary drug abstains)
- ruff clean; data-only security review passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)