### PR TITLE
feat(closurec): negation push — !(a==b)→a!=b at SIMPLE/ADVANCED

### DIFF
--- a/code/packages/rust/closure-pass-constant-fold/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-constant-fold/CHANGELOG.md
@@ -2,6 +2,32 @@
 
 All notable changes to the `coding-adventures-closure-pass-constant-fold` crate will be documented in this file.
 
+## [0.17.0] - 2026-06-21
+
+### Added — negation push for (in)equality (`!(a == b)` → `a != b`)
+
+`fold_unary` now rewrites a logical-not over an (in)equality comparison into the
+inverted comparison (upstream Closure's `PeepholeMinimizeConditions`):
+
+| before        | after        |
+|---------------|--------------|
+| `!(a == b)`   | `a != b`     |
+| `!(a != b)`   | `a == b`     |
+| `!(a === b)`  | `a !== b`    |
+| `!(a !== b)`  | `a === b`    |
+
+Sound for these four operators **only**, because `!=`/`!==` are *defined* as the
+boolean negation of `==`/`===` (ECMAScript §13.10) — both sides yield booleans,
+so the rewrite is value-identical in every context. Relational operators
+(`<`/`<=`/`>`/`>=`) are deliberately **not** inverted: `!(a < b)` is not
+`a >= b` when an operand is `NaN` (`!(NaN < 1)` is `true`, `NaN >= 1` is
+`false`). The literal-fold path still runs first, so `!(1 == 1)` folds to
+`false` rather than `1 != 1`. The rewrite emits a correlation-vector
+contribution via `fork_cv`. New helper `invert_equality_operator`; 6 unit tests.
+
+> Only reachable now that the `javascript-parser` bridge stopped dropping the
+> `!` operator (it had emitted the bare comparison) — see closurec 0.161.0.
+
 ## [0.16.0] - 2026-06-20
 
 ### Added — CLOC23: fold inside `for`-`of`

--- a/code/packages/rust/closure-pass-constant-fold/Cargo.toml
+++ b/code/packages/rust/closure-pass-constant-fold/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-constant-fold"
-version = "0.16.0"
+version = "0.17.0"
 edition = "2021"
 description = "Constant-folding optimization pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Folds compile-time-evaluable expressions like `2 + 3 → 5`."
 

--- a/code/packages/rust/closure-pass-constant-fold/src/lib.rs
+++ b/code/packages/rust/closure-pass-constant-fold/src/lib.rs
@@ -1257,12 +1257,52 @@ fn fold_unary(u: &UnaryExpression, st: &mut FoldState) -> Expression {
         return stamp_literal_cv(value, new_cv);
     }
 
+    // Negation push (upstream Closure's `PeepholeMinimizeConditions`):
+    //   !(a == b)   →  a != b          !(a != b)   →  a == b
+    //   !(a === b)  →  a !== b         !(a !== b)  →  a === b
+    //
+    // Sound for the four (in)equality operators ONLY, because `!=`/`!==` are
+    // *defined* as the boolean negation of `==`/`===` (ECMAScript §13.10): both
+    // `!` and these operators yield booleans, so the rewrite is value-identical
+    // in every context. Relational operators (`<`/`<=`/`>`/`>=`) are deliberately
+    // NOT inverted — `!(a < b)` is NOT `a >= b` when an operand is `NaN`
+    // (`!(NaN < 1)` is `true` but `NaN >= 1` is `false`).
+    if u.operator == UnaryOperator::Not {
+        if let Expression::BinaryExpression(b) = &arg {
+            if let Some(inverted) = invert_equality_operator(b.operator) {
+                let parent = u.cv.clone();
+                let before = format!("!(x {} y)", op_label(b.operator));
+                let after = format!("x {} y", op_label(inverted));
+                let new_cv = st.fork_cv(&parent, &before, &after);
+                return Expression::BinaryExpression(BinaryExpression {
+                    cv: new_cv,
+                    operator: inverted,
+                    left: b.left.clone(),
+                    right: b.right.clone(),
+                });
+            }
+        }
+    }
+
     Expression::UnaryExpression(UnaryExpression {
         cv: u.cv.clone(),
         operator: u.operator,
         prefix: u.prefix,
         argument: Box::new(arg),
     })
+}
+
+/// The negation of an (in)equality operator, or `None` for any operator whose
+/// `!`-negation is NOT a single other operator. Only the four equality forms
+/// qualify; relational operators do not (NaN breaks `!(a<b)` ≡ `a>=b`).
+fn invert_equality_operator(op: BinaryOperator) -> Option<BinaryOperator> {
+    match op {
+        BinaryOperator::Eq => Some(BinaryOperator::NotEq),
+        BinaryOperator::NotEq => Some(BinaryOperator::Eq),
+        BinaryOperator::StrictEq => Some(BinaryOperator::StrictNotEq),
+        BinaryOperator::StrictNotEq => Some(BinaryOperator::StrictEq),
+        _ => None,
+    }
 }
 
 // ---------------------------------------------------------------------
@@ -2500,6 +2540,115 @@ mod tests {
     }
 
     // ------------------- pipeline integration ------------------------
+
+    // ------------------- negation push (`!(a == b)` → `a != b`) ----------
+
+    /// `!( left <op> right )` over two identifiers, traced.
+    fn not_of_binary(op: BinaryOperator) -> Expression {
+        Expression::UnaryExpression(UnaryExpression {
+            cv: Some("not.1".to_string()),
+            operator: UnaryOperator::Not,
+            prefix: true,
+            argument: Box::new(Expression::BinaryExpression(BinaryExpression {
+                cv: Some("bin.1".to_string()),
+                operator: op,
+                left: Box::new(ident("a")),
+                right: Box::new(ident("b")),
+            })),
+        })
+    }
+
+    fn assert_negation_pushes(input_op: BinaryOperator, expected_op: BinaryOperator) {
+        let (out, contribs, changed, _) = run_pass(program_with_expr(not_of_binary(input_op), true));
+        assert!(changed, "negation push should report a change for {input_op:?}");
+        match extract_expr(&out) {
+            Expression::BinaryExpression(b) => {
+                assert_eq!(
+                    b.operator, expected_op,
+                    "{input_op:?} should invert to {expected_op:?}, got {:?}",
+                    b.operator
+                );
+                // Operands are preserved, and the `!` wrapper is gone.
+                assert!(matches!(b.left.as_ref(), Expression::Identifier(i) if i.name == "a"));
+                assert!(matches!(b.right.as_ref(), Expression::Identifier(i) if i.name == "b"));
+            }
+            other => panic!("expected BinaryExpression, got {other:?}"),
+        }
+        // The rewrite must leave a correlation-vector contribution.
+        assert!(
+            contribs.iter().any(|c| c.source == "constant-fold"),
+            "negation push must emit a CV contribution"
+        );
+    }
+
+    #[test]
+    fn negation_pushes_through_loose_equality() {
+        assert_negation_pushes(BinaryOperator::Eq, BinaryOperator::NotEq);
+    }
+
+    #[test]
+    fn negation_pushes_through_loose_inequality() {
+        assert_negation_pushes(BinaryOperator::NotEq, BinaryOperator::Eq);
+    }
+
+    #[test]
+    fn negation_pushes_through_strict_equality() {
+        assert_negation_pushes(BinaryOperator::StrictEq, BinaryOperator::StrictNotEq);
+    }
+
+    #[test]
+    fn negation_pushes_through_strict_inequality() {
+        assert_negation_pushes(BinaryOperator::StrictNotEq, BinaryOperator::StrictEq);
+    }
+
+    #[test]
+    fn negation_does_not_push_through_relational_operators() {
+        // `!(a < b)` must NOT become `a >= b` — they differ when an operand
+        // is NaN (`!(NaN < 1)` is `true`, `NaN >= 1` is `false`). The `!`
+        // wrapper must survive unchanged.
+        for op in [
+            BinaryOperator::Lt,
+            BinaryOperator::LtEq,
+            BinaryOperator::Gt,
+            BinaryOperator::GtEq,
+        ] {
+            let (out, _contribs, _changed, _) =
+                run_pass(program_with_expr(not_of_binary(op), true));
+            match extract_expr(&out) {
+                Expression::UnaryExpression(u) => {
+                    assert_eq!(u.operator, UnaryOperator::Not, "outer `!` must survive for {op:?}");
+                    assert!(
+                        matches!(u.argument.as_ref(), Expression::BinaryExpression(b) if b.operator == op),
+                        "inner relational op {op:?} must be unchanged"
+                    );
+                }
+                other => panic!("expected the `!` to survive for {op:?}, got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn negation_of_equality_with_foldable_operands_still_folds_to_literal() {
+        // `!(1 == 1)` should fold to the boolean `false` (the literal path),
+        // not push to `1 != 1`. The literal fold runs first.
+        let expr = Expression::UnaryExpression(UnaryExpression {
+            cv: Some("not.1".to_string()),
+            operator: UnaryOperator::Not,
+            prefix: true,
+            argument: Box::new(Expression::BinaryExpression(BinaryExpression {
+                cv: Some("bin.1".to_string()),
+                operator: BinaryOperator::Eq,
+                left: Box::new(num(1.0, None)),
+                right: Box::new(num(1.0, None)),
+            })),
+        });
+        let (out, _contribs, changed, _) = run_pass(program_with_expr(expr, true));
+        assert!(changed);
+        match extract_expr(&out) {
+            Expression::BooleanLiteral(b) => assert!(!b.value, "!(1 == 1) is false"),
+            other => panic!("expected BooleanLiteral(false), got {other:?}"),
+        }
+    }
 
     #[test]
     fn integrates_with_pass_pipeline_as_solo_pass() {

--- a/code/programs/rust/closurec/CHANGELOG.md
+++ b/code/programs/rust/closurec/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to the `coding-adventures-closurec` binary will be documented in this file.
 
+## [0.162.0] - 2026-06-21
+
+### Added — negation push (`!(a == b)` → `a != b`) at SIMPLE/ADVANCED
+
+Pulls in `coding-adventures-closure-pass-constant-fold` 0.17.0, which rewrites a
+logical-not over an (in)equality comparison into the inverted comparison:
+`!(a == b)` → `a != b`, `!(a === b)` → `a !== b` (and the inverses). Relational
+operators are left intact — `!(a < b)` is **not** `a >= b` under `NaN`.
+
+New e2e fixture `tests/diff/simple-negation-fold` proves the equality push and
+the relational NaN-safety guard (with a whitespace-fallback guard). The
+`simple-unary-preserve` fixture's precedence case was switched from `!(a == b)`
+to `!(a < b)` so the negation push doesn't rewrite it (it still exercises the
+unary-precedence parenthesisation).
+
+> Only reachable now that prefix operators survive the bridge (0.161.0) — before
+> that, the `!` vanished before the optimizer could see the comparison.
+
 ## [0.161.0] - 2026-06-21
 
 ### Fixed — prefix unary operators no longer dropped at SIMPLE/ADVANCED

--- a/code/programs/rust/closurec/Cargo.toml
+++ b/code/programs/rust/closurec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closurec"
-version = "0.161.0"
+version = "0.162.0"
 edition = "2021"
 description = "closurec — CLI driver for the Closure Compiler clone. Mirrors the upstream Java Closure Compiler's command-line flag surface (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility. Per CLOC08."
 

--- a/code/programs/rust/closurec/cli.spec.json
+++ b/code/programs/rust/closurec/cli.spec.json
@@ -2,7 +2,7 @@
   "cli_builder_spec_version": "1.0",
   "name": "closurec",
   "description": "closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.",
-  "version": "0.161.0",
+  "version": "0.162.0",
   "parsing_mode": "gnu",
   "flags": [
     { "id": "browser_featureset_year", "long": "browser_featureset_year", "type": "integer", "default": 0, "description": "Shortcut for defining goog.FEATURESET_YEAR=YYYY (minimum 2012)." },

--- a/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
@@ -2,7 +2,7 @@
 
 closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.
 
-Version: 0.161.0
+Version: 0.162.0
 
 ## Flags
 

--- a/code/programs/rust/closurec/tests/diff/simple-negation-fold/README.md
+++ b/code/programs/rust/closurec/tests/diff/simple-negation-fold/README.md
@@ -1,0 +1,37 @@
+# Fixture: `simple-negation-fold`
+
+End-to-end oracle for the **negation-push** optimization (upstream Closure's
+`PeepholeMinimizeConditions`): `!(a == b)` → `a != b`.
+
+| File | Role |
+|------|------|
+| `flags.txt` | CLI args: `--compilation_level SIMPLE --js input/a.js` |
+| `input/a.js` | `report(!(a == b), !(a === b), !(a < b))` over non-foldable operands |
+| `expected.stdout` | The optimized output (see below) |
+
+```text
+var a=first();var b=second();report(a != b,a !== b,!(a < b));
+```
+
+## What this proves
+
+* **Negation pushes through equality.** `!(a == b)` → `a != b` and
+  `!(a === b)` → `a !== b`. Sound because `!=`/`!==` are *defined* as the
+  boolean negation of `==`/`===` (ECMAScript §13.10).
+
+* **Relational operators are NOT inverted.** `!(a < b)` stays `!(a < b)` — it
+  is **not** `a >= b`, which would be wrong when an operand is `NaN`
+  (`!(NaN < 1)` is `true`, `NaN >= 1` is `false`). This is the NaN-safety
+  guard. (It also exercises the unary-precedence fix: the `!` keeps its
+  parentheses around `a < b`.)
+
+* **This is the SIMPLE optimizer, not the WHITESPACE_ONLY fallback.** The
+  unused `var dead = 8 + 9;` is removed by the typed pipeline; its absence
+  proves the program reached the SIMPLE passes.
+
+## Why side-effecting initializers
+
+`a`, `b` are bound to call results (`first()` / `second()`), which the
+constant-folder cannot evaluate, so the equality comparison survives as a real
+binary expression rather than folding to a boolean literal — keeping the
+negation-push rewrite visible in the output.

--- a/code/programs/rust/closurec/tests/diff/simple-negation-fold/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/simple-negation-fold/expected.stdout
@@ -1,0 +1,1 @@
+var a=first();var b=second();report(a != b,a !== b,!(a < b));

--- a/code/programs/rust/closurec/tests/diff/simple-negation-fold/flags.txt
+++ b/code/programs/rust/closurec/tests/diff/simple-negation-fold/flags.txt
@@ -1,0 +1,4 @@
+--compilation_level
+SIMPLE
+--js
+tests/diff/simple-negation-fold/input/a.js

--- a/code/programs/rust/closurec/tests/diff/simple-negation-fold/input/a.js
+++ b/code/programs/rust/closurec/tests/diff/simple-negation-fold/input/a.js
@@ -1,0 +1,21 @@
+// Regression oracle for the negation-push optimization
+// (upstream Closure's PeepholeMinimizeConditions):
+//
+//   !(a == b)   →  a != b          !(a === b)  →  a !== b
+//
+// Sound for the four (in)equality operators only — `!=`/`!==` are *defined*
+// as the boolean negation of `==`/`===`. Relational operators are NOT
+// inverted: `!(a < b)` is not `a >= b` when an operand is NaN, so the `!`
+// over `a < b` must survive verbatim.
+//
+// `a`, `b` come from side-effecting calls so they don't fold to literals,
+// keeping the equality comparison (and thus the rewrite) visible. The unused
+// `dead` binding is removed by the typed pipeline, proving this is the SIMPLE
+// optimizer rather than the WHITESPACE_ONLY fallback.
+//
+// At SIMPLE this becomes:
+//   var a=first();var b=second();report(a != b,a !== b,!(a < b));
+var a = first();
+var b = second();
+var dead = 8 + 9;
+report(!(a == b), !(a === b), !(a < b));

--- a/code/programs/rust/closurec/tests/diff/simple-unary-preserve/README.md
+++ b/code/programs/rust/closurec/tests/diff/simple-unary-preserve/README.md
@@ -6,11 +6,11 @@ End-to-end oracle for the **prefix-unary-operator-drop miscompile** fix
 | File | Role |
 |------|------|
 | `flags.txt` | CLI args: `--compilation_level SIMPLE --js input/a.js` |
-| `input/a.js` | Side-effecting `var` inits + a `report(...)` call using `!`, `-`, `~`, and `!(a == b)` |
+| `input/a.js` | Side-effecting `var` inits + a `report(...)` call using `!`, `-`, `~`, and `!(a < b)` |
 | `expected.stdout` | The optimized output (see below) |
 
 ```text
-var a=first();var b=second();var c=third();report(!a,-b,~c,!(a == b));
+var a=first();var b=second();var c=third();report(!a,-b,~c,!(a < b));
 ```
 
 ## What this proves
@@ -22,8 +22,8 @@ var a=first();var b=second();var c=third();report(!a,-b,~c,!(a == b));
   the operator was silently dropped — `!a` → `a`, `-b` → `b`, `~c` → `c`. That
   is a **miscompile** at SIMPLE/ADVANCED. The operators now round-trip.
 
-* **Precedence is preserved.** `!(a == b)` keeps its parentheses. Emitting
-  `!a == b` would reparse as `(!a) == b` — a different program. `emit_unary`
+* **Precedence is preserved.** `!(a < b)` keeps its parentheses. Emitting
+  `!a < b` would reparse as `(!a) < b` — a different program. `emit_unary`
   now emits its argument at unary binding strength so any lower-precedence
   operand is parenthesised.
 

--- a/code/programs/rust/closurec/tests/diff/simple-unary-preserve/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/simple-unary-preserve/expected.stdout
@@ -1,1 +1,1 @@
-var a=first();var b=second();var c=third();report(!a,-b,~c,!(a == b));
+var a=first();var b=second();var c=third();report(!a,-b,~c,!(a < b));

--- a/code/programs/rust/closurec/tests/diff/simple-unary-preserve/input/a.js
+++ b/code/programs/rust/closurec/tests/diff/simple-unary-preserve/input/a.js
@@ -17,13 +17,16 @@
 // the unary operators stay as real prefix operators over identifiers. The
 // unused `dead` binding is removed by the typed pipeline — its disappearance
 // proves this output came from the SIMPLE optimizer, not the WHITESPACE_ONLY
-// fallback. And `!(a == b)` must keep its parentheses: emitting `!a == b`
-// would reparse as `(!a) == b`, a different program.
+// fallback. And `!(a < b)` must keep its parentheses: emitting `!a < b`
+// would reparse as `(!a) < b`, a different program. (A relational operator is
+// used here rather than `==` so the negation-push optimization — which would
+// rewrite `!(a == b)` to `a != b` — leaves it intact; relational negations are
+// not inverted, since `!(a < b)` ≠ `a >= b` under NaN.)
 //
 // At SIMPLE this becomes:
-//   var a=first();var b=second();var c=third();report(!a,-b,~c,!(a == b));
+//   var a=first();var b=second();var c=third();report(!a,-b,~c,!(a < b));
 var a = first();
 var b = second();
 var c = third();
 var dead = 4 + 5;
-report(!a, -b, ~c, !(a == b));
+report(!a, -b, ~c, !(a < b));

--- a/code/programs/rust/closurec/tests/diff_simple_negation_fold.rs
+++ b/code/programs/rust/closurec/tests/diff_simple_negation_fold.rs
@@ -1,0 +1,99 @@
+//! Integration test for the `tests/diff/simple-negation-fold/` fixture.
+//!
+//! End-to-end oracle for the **negation-push** optimization in
+//! `closure-pass-constant-fold` (upstream Closure's
+//! `PeepholeMinimizeConditions`): `!(a == b)` → `a != b`,
+//! `!(a === b)` → `a !== b`. Sound for the four (in)equality operators only —
+//! relational operators are NOT inverted because `!(a < b)` ≠ `a >= b` when an
+//! operand is `NaN`.
+//!
+//! At SIMPLE the fixture optimizes to:
+//!
+//! ```text
+//! var a=first();var b=second();report(a != b,a !== b,!(a < b));
+//! ```
+
+use std::process::Command;
+
+const BINARY: &str = env!("CARGO_BIN_EXE_closurec");
+
+fn read_flags() -> Vec<String> {
+    let raw = std::fs::read_to_string("tests/diff/simple-negation-fold/flags.txt")
+        .expect("read flags.txt");
+    raw.lines()
+        .filter(|l| !l.is_empty())
+        .map(|s| s.to_string())
+        .collect()
+}
+
+#[test]
+fn simple_negation_fold_fixture_matches_expected_stdout() {
+    let flags = read_flags();
+    let out = Command::new(BINARY)
+        .args(&flags)
+        .output()
+        .expect("run closurec");
+
+    assert!(
+        out.status.success(),
+        "exit: {:?}, stderr: {}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stderr),
+    );
+
+    let actual = String::from_utf8_lossy(&out.stdout);
+    let expected = std::fs::read_to_string("tests/diff/simple-negation-fold/expected.stdout")
+        .expect("read expected.stdout");
+    assert_eq!(
+        actual.trim_end_matches('\n'),
+        expected.trim_end_matches('\n'),
+        "mismatch.\nflags: {flags:?}\nactual:\n{actual}\nexpected:\n{expected}",
+    );
+}
+
+/// The equality negations must be pushed in, and the relational negation must
+/// be left intact (NaN-safety).
+#[test]
+fn simple_negation_fold_pushes_equality_but_not_relational() {
+    let out = Command::new(BINARY)
+        .args(read_flags())
+        .output()
+        .expect("run closurec");
+    let actual = String::from_utf8_lossy(&out.stdout);
+
+    assert!(
+        actual.contains("a != b"),
+        "`!(a == b)` should push to `a != b`; got:\n{actual}",
+    );
+    assert!(
+        actual.contains("a !== b"),
+        "`!(a === b)` should push to `a !== b`; got:\n{actual}",
+    );
+    // Relational stays negated — never rewritten to `a >= b` (NaN-unsafe).
+    assert!(
+        actual.contains("!(a < b)"),
+        "`!(a < b)` must survive verbatim (NaN-safety); got:\n{actual}",
+    );
+    assert!(
+        !actual.contains("a >= b"),
+        "`!(a < b)` must NOT become `a >= b`; got:\n{actual}",
+    );
+}
+
+/// Regression guard: the output must NOT be the WHITESPACE_ONLY fallback. The
+/// unused `var dead = 8 + 9;` is removed only by the typed pipeline.
+#[test]
+fn simple_negation_fold_did_not_fall_back_to_whitespace_only() {
+    let out = Command::new(BINARY)
+        .args(read_flags())
+        .output()
+        .expect("run closurec");
+    let actual = String::from_utf8_lossy(&out.stdout);
+
+    assert!(
+        !actual.contains("dead"),
+        "expected the unused `dead` binding to be removed by the typed pipeline \
+         (proving this is the SIMPLE optimizer, not the whitespace fallback); \
+         got:\n{actual}",
+    );
+}

--- a/code/programs/rust/closurec/tests/diff_simple_unary_preserve.rs
+++ b/code/programs/rust/closurec/tests/diff_simple_unary_preserve.rs
@@ -12,7 +12,7 @@
 //! At SIMPLE the fixture optimizes to:
 //!
 //! ```text
-//! var a=first();var b=second();var c=third();report(!a,-b,~c,!(a == b));
+//! var a=first();var b=second();var c=third();report(!a,-b,~c,!(a < b));
 //! ```
 
 use std::process::Command;
@@ -67,11 +67,11 @@ fn simple_unary_preserve_keeps_every_prefix_operator() {
     assert!(actual.contains("!a"), "logical-not operator dropped; got:\n{actual}");
     assert!(actual.contains("-b"), "unary-minus operator dropped; got:\n{actual}");
     assert!(actual.contains("~c"), "bitwise-not operator dropped; got:\n{actual}");
-    // `!(a == b)` must keep its parens — `!a == b` would reparse as
-    // `(!a) == b`, a different program.
+    // `!(a < b)` must keep its parens — `!a < b` would reparse as
+    // `(!a) < b`, a different program.
     assert!(
-        actual.contains("!(a == b)"),
-        "negated-equality lost its parentheses (precedence miscompile); got:\n{actual}",
+        actual.contains("!(a < b)"),
+        "negated-relational lost its parentheses (precedence miscompile); got:\n{actual}",
     );
 }
 


### PR DESCRIPTION
## Summary

Adds the **negation-push** optimization (upstream Closure's `PeepholeMinimizeConditions`) to `closure-pass-constant-fold`: a logical-not over an (in)equality comparison is rewritten as the inverted comparison.

| before        | after        |
|---------------|--------------|
| `!(a == b)`   | `a != b`     |
| `!(a != b)`   | `a == b`     |
| `!(a === b)`  | `a !== b`    |
| `!(a !== b)`  | `a === b`    |

### Soundness

Sound for these four operators **only**: `!=`/`!==` are *defined* as the boolean negation of `==`/`===` (ECMAScript §13.10), so the rewrite is value-identical in every context. Relational operators (`<`/`<=`/`>`/`>=`) are deliberately **not** inverted — `!(a < b)` is **not** `a >= b` when an operand is `NaN` (`!(NaN < 1)` is `true`, `NaN >= 1` is `false`). The literal-fold path still runs first, so `!(1 == 1)` folds to `false` rather than `1 != 1`. The rewrite appends a correlation-vector contribution via `fork_cv`.

> **Depends on [#6413](https://github.com/adhithyan15/coding-adventures/pull/6413) (merged):** this optimization is only reachable because the bridge now preserves the `!` operator — before that fix, the `!` was dropped before the optimizer could see the comparison.

## Tests

- **6** constant-fold unit tests: each equality inversion, the relational no-op (all four `<`/`<=`/`>`/`>=`), and literal-fold-still-wins (`!(1 == 1)` → `false`).
- New closurec e2e fixture `tests/diff/simple-negation-fold`: equality push + relational NaN-safety guard + whitespace-fallback guard.
- The `simple-unary-preserve` fixture's precedence case moved from `!(a == b)` to `!(a < b)` so the new fold doesn't rewrite it (it still exercises unary-precedence parenthesisation).
- Full closurec suite: **740 pass, 0 fail**.

## Versions

- `coding-adventures-closure-pass-constant-fold` 0.16.0 → 0.17.0
- `coding-adventures-closurec` 0.161.0 → 0.162.0 (+ `cli.spec.json` + help-markdown fixture)

Security review: passed (Rust, no findings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)