### PR TITLE
feat(dartmouth-basic): DIM integer arrays (BA3, enabler E5)

### DIFF
--- a/code/packages/rust/dartmouth-basic-iir-compiler/CHANGELOG.md
+++ b/code/packages/rust/dartmouth-basic-iir-compiler/CHANGELOG.md
@@ -30,6 +30,12 @@ and two `array_get`s feeding the `add`, printing `42`.
 - **Undeclared use is a clean error**: subscripting a name that was never
   `DIM`med returns `Unsupported` rather than miscompiling against an undefined
   handle register.
+- **Bounded + panic-free**: a `DIM` bound is validated against `MAX_DIM_BOUND`
+  (2^24) *before* the `f64`→`i64` cast, so an oversized or non-finite literal
+  (e.g. `DIM A(1E30)`, which a bare `as i64` cast would saturate to `i64::MAX`
+  and then overflow on the `+ 1` element count) is a clean `Unsupported` error,
+  never a debug-build panic or a release-build wrapped/garbage length. The
+  element-count `+ 1` also uses `checked_add` as a second guard.
 - **Verified by RUNNING** the straight-line array program across the matrix
   (`lang-aot` `tests/lang_matrix.rs`): the managed runtimes bounds-check natively
   (JVM `int[]`/`iastore`/`iaload`, CLR `int32[]`/`stelem`/`ldelem`), the static

--- a/code/packages/rust/dartmouth-basic-iir-compiler/CHANGELOG.md
+++ b/code/packages/rust/dartmouth-basic-iir-compiler/CHANGELOG.md
@@ -1,5 +1,41 @@
 # Changelog — `dartmouth-basic-iir-compiler`
 
+## 0.7.0 — 2026-06-21 — `DIM` arrays (LANG-FULL BA3, enabler E5)
+
+### Added — one-dimensional integer arrays (`DIM A(n)` + subscripted `A(i)`)
+
+`DIM` was previously an `UnsupportedStatement` and a subscripted variable `A(I)`
+was a deferred `Unsupported` error. BASIC arrays now lower to the shared IIR
+array ops (the *same* `alloc_array` / `array_set` / `array_get` ALGOL's E5 arrays
+use), so they run on every backend E5 already supports:
+
+```basic
+10 DIM A(3)
+20 LET A(1) = 40
+30 LET A(2) = 2
+40 PRINT A(1) + A(2)
+50 END
+```
+
+⇒ `alloc_array A = 4` (see below) then `array_set A, 1, 40` / `array_set A, 2, 2`
+and two `array_get`s feeding the `add`, printing `42`.
+
+- **`DIM A(n)` → `alloc_array`** — Dartmouth BASIC arrays are **0-based and
+  inclusive**: `DIM A(3)` declares `A(0)..A(3)`, so the element count is
+  `n + 1` (here `4`). `DIM A(3), B(2)` declares both in one statement. The
+  handle lives in the register named after the array.
+- **`LET A(i) = e` → `array_set`** and **`A(i)` in an expression → `array_get`**.
+  The subscript is used **directly** as the 0-based IIR index — no lower-bound
+  subtraction (contrast ALGOL's `array A[lo:hi]`, which subtracts `lo`).
+- **Undeclared use is a clean error**: subscripting a name that was never
+  `DIM`med returns `Unsupported` rather than miscompiling against an undefined
+  handle register.
+- **Verified by RUNNING** the straight-line array program across the matrix
+  (`lang-aot` `tests/lang_matrix.rs`): the managed runtimes bounds-check natively
+  (JVM `int[]`/`iastore`/`iaload`, CLR `int32[]`/`stelem`/`ldelem`), the static
+  backends use the length-prefixed block + explicit bounds-trap (LLVM/WASM/
+  NativeAot). 7 new unit tests cover the lowering shape + the error paths.
+
 ## 0.6.0 — 2026-06-20 — `DEF FN` user-defined functions (LANG-FULL BA5)
 
 ### Added — single-line user-defined functions (`DEF FNx(P) = expr`)

--- a/code/packages/rust/dartmouth-basic-iir-compiler/Cargo.toml
+++ b/code/packages/rust/dartmouth-basic-iir-compiler/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "dartmouth-basic-iir-compiler"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
-description = "Dartmouth BASIC frontend for the LANG VM AOT chain — lowers parsed BASIC into interpreter_ir::IIRModule (i64 integer programs only in V1).  v0.2.0: ships BasicCirJit — a real bytecode JIT backend for jit-core.  v0.3.0: backend_compat e2e tests prove BASIC's IIR is accepted by every IIR-to-{wasm,jvm,clr,beam} validator.  v0.4.0: threads real source positions through IIRFunction::source_map for line-based debugger breakpoints."
+description = "Dartmouth BASIC frontend for the LANG VM AOT chain — lowers parsed BASIC into interpreter_ir::IIRModule (i64 integer programs only in V1).  v0.2.0: ships BasicCirJit — a real bytecode JIT backend for jit-core.  v0.3.0: backend_compat e2e tests prove BASIC's IIR is accepted by every IIR-to-{wasm,jvm,clr,beam} validator.  v0.4.0: threads real source positions through IIRFunction::source_map for line-based debugger breakpoints.  v0.7.0: DIM arrays (BA3 / enabler E5) — DIM/subscripted-LET/subscripted-read lower to the shared alloc_array/array_set/array_get ops, 0-based inclusive."
 
 [dependencies]
 coding-adventures-dartmouth-basic-parser = { path = "../dartmouth-basic-parser" }

--- a/code/packages/rust/dartmouth-basic-iir-compiler/README.md
+++ b/code/packages/rust/dartmouth-basic-iir-compiler/README.md
@@ -36,18 +36,21 @@ just use `lang-aot foo.bas`, which does the routing for you).
 
 ## V1 scope
 
-Integer-only programs.  Floats truncate to i64; strings, GOSUB,
-arrays, and READ/DATA are deferred to V2.  See
-[CHANGELOG.md](CHANGELOG.md) for the full table.
+Integer-only programs.  Floats truncate to i64; strings, GOSUB, and
+READ/DATA are deferred to V2.  See [CHANGELOG.md](CHANGELOG.md) for the
+full table.
 
-`LET`, `PRINT`, `IF … THEN <line>`, `GOTO`, `FOR`/`NEXT`, and `DEF FN`
-single-line user functions lower to the shared IIR and RUN on
-native / LLVM / WASM / JVM / CLR / VM / JIT.  LANG-FULL BA0 fixed the comparison
-operand-width hint that had broken control flow on LLVM/WASM; BA5 added
-`DEF FNx(X) = expr` (lowered to a sibling `IIRFunction` + `call`, like ALGOL's
-value procedures).  A `DEF` body may reference only its own parameter — global
-access from inside a function needs enabler E6 (see
-`code/specs/LANG-FULL-IMPLEMENTATION.md`).
+`LET`, `PRINT`, `IF … THEN <line>`, `GOTO`, `FOR`/`NEXT`, `DEF FN`
+single-line user functions, and `DIM` arrays lower to the shared IIR and
+RUN on native / LLVM / WASM / JVM / CLR / VM / JIT.  LANG-FULL BA0 fixed the
+comparison operand-width hint that had broken control flow on LLVM/WASM; BA5
+added `DEF FNx(X) = expr` (lowered to a sibling `IIRFunction` + `call`, like
+ALGOL's value procedures); **BA3** added one-dimensional integer arrays —
+`DIM A(n)` → `alloc_array` (0-based and inclusive, so `n + 1` elements),
+`LET A(i) = e` → `array_set`, and `A(i)` in an expression → `array_get`, the
+same shared array ops ALGOL's E5 arrays run on every backend.  A `DEF` body may
+reference only its own parameter — global access from inside a function needs
+enabler E6 (see `code/specs/LANG-FULL-IMPLEMENTATION.md`).
 
 ## Spec
 

--- a/code/packages/rust/dartmouth-basic-iir-compiler/src/lib.rs
+++ b/code/packages/rust/dartmouth-basic-iir-compiler/src/lib.rs
@@ -460,9 +460,16 @@ impl Compiler {
                     "DIM {name}({max_sub}) — array bound must be non-negative")));
             }
             // Element count = max subscript + 1 (inclusive, 0-based).
+            // `dim_decl_bound` already rejects bounds above `MAX_DIM_BOUND`, so
+            // this `+ 1` cannot overflow; the `checked_add` is a belt-and-braces
+            // guard that keeps the compile path panic-free regardless.
+            let count = max_sub.checked_add(1).ok_or_else(|| {
+                CompileError::Unsupported(format!(
+                    "DIM {name}({max_sub}) — array bound too large"))
+            })?;
             let len = self.fresh_temp();
             self.emit("const", Some(&len),
-                vec![Operand::Int(max_sub + 1)], "i64");
+                vec![Operand::Int(count)], "i64");
             self.emit("alloc_array", Some(&name),
                 vec![Operand::Var(len)], "array<i64>");
             self.arrays.insert(name);
@@ -989,19 +996,41 @@ fn array_target_name(var: &GrammarASTNode) -> Result<String, CompileError> {
     })
 }
 
+/// The largest array subscript `DIM` will accept.  BASIC arrays are tiny in
+/// practice; this cap keeps the bound (a) exactly representable in `f64` (well
+/// under 2^53, so the parse→cast round-trip is lossless) and (b) far from
+/// `i64::MAX`, so the `+ 1` element-count computation can never overflow.  A
+/// bound above this is a clean `Unsupported` error, never a panic.
+const MAX_DIM_BOUND: i64 = 16_777_216; // 2^24 elements — generous for BASIC
+
 /// The integer bound `n` in a `dim_decl = NAME LPAREN NUMBER RPAREN`.  The
 /// grammar pins the bound to a `NUMBER` literal (not an arbitrary expression),
 /// so we read it straight from the token rather than emitting code to compute
-/// it.  Truncates a float spelling to `i64` for consistency with how the rest
-/// of this integer-only V1 treats `NUMBER`.
+/// it.
+///
+/// A `NUMBER` token can spell an arbitrarily large or fractional value, so we
+/// validate the parsed `f64` *before* casting: the bare `as i64` cast saturates
+/// (e.g. `1e30 as i64` → `i64::MAX`), which would otherwise sail past a naive
+/// range check and overflow the later `+ 1`.  We therefore reject non-finite,
+/// negative, and out-of-`MAX_DIM_BOUND`-range values up front; only an in-range
+/// value reaches the (now lossless) `as i64` cast.  A fractional spelling is
+/// truncated toward zero, consistent with how this integer-only V1 treats every
+/// other `NUMBER`.
 fn dim_decl_bound(decl: &GrammarASTNode) -> Result<i64, CompileError> {
     for c in &decl.children {
         if let ASTNodeOrToken::Token(t) = c {
             if t.effective_type_name() == "NUMBER" {
-                return Ok(t.value.trim().parse::<f64>()
-                    .map(|f| f as i64)
-                    .map_err(|_| CompileError::Malformed(format!(
-                        "DIM bound `{}` is not a number", t.value)))?);
+                let raw = t.value.trim();
+                let f = raw.parse::<f64>().map_err(|_| CompileError::Malformed(
+                    format!("DIM bound `{raw}` is not a number")))?;
+                if !f.is_finite() || f < 0.0 || f > MAX_DIM_BOUND as f64 {
+                    return Err(CompileError::Unsupported(format!(
+                        "DIM bound `{raw}` is out of the supported range \
+                         0..={MAX_DIM_BOUND}")));
+                }
+                // In range and non-negative ⇒ this `as i64` truncates the
+                // fractional part without saturation or overflow.
+                return Ok(f as i64);
             }
         }
     }
@@ -1499,6 +1528,19 @@ mod tests {
         match err {
             CompileError::Unsupported(msg) => assert!(msg.contains("DIM")),
             other => panic!("expected Unsupported(DIM…), got {other:?}"),
+        }
+    }
+
+    /// A `DIM` bound far larger than `MAX_DIM_BOUND` (here spelled in
+    /// scientific notation, which the bare `as i64` cast would *saturate* to
+    /// `i64::MAX` and then overflow on the `+ 1`) must be a clean `Unsupported`
+    /// error — never a panic or a wrapped/garbage length.
+    #[test]
+    fn oversized_dim_bound_is_unsupported_not_a_panic() {
+        let err = compile("10 DIM A(1E30)\n20 END\n").unwrap_err();
+        match err {
+            CompileError::Unsupported(msg) => assert!(msg.contains("range")),
+            other => panic!("expected Unsupported(range…), got {other:?}"),
         }
     }
 

--- a/code/packages/rust/dartmouth-basic-iir-compiler/src/lib.rs
+++ b/code/packages/rust/dartmouth-basic-iir-compiler/src/lib.rs
@@ -30,7 +30,9 @@
 //! | `REM …`        | no-op |
 //! | `GOSUB` / `RETURN` | **deferred** — V1 returns `UnsupportedStatement` |
 //! | `READ` / `DATA` / `RESTORE` | **deferred** — needs data pool |
-//! | `DIM` / arrays | **deferred** — needs LANG76 byte memory ops |
+//! | `DIM A(n)`     | `alloc_array A = <n+1>` (0-based, inclusive) — BA3 / E5 |
+//! | `LET A(i)=e`   | `<eval i → x>; <eval e → v>; array_set A, x, v` (BA3) |
+//! | `A(i)` (rvalue) | `<eval i → x>; array_get A, x -> t` (BA3) |
 //! | `STOP`         | same as `END` for V1 |
 //! | `DEF FNx(P)=e` | sibling `IIRFunction` + `call` (BA5); `FNx(arg)` → `call` |
 //!
@@ -42,8 +44,9 @@
 //! ## Variables
 //!
 //! BASIC's `A..Z` and `A0..Z9` variable names map 1:1 to IIR slot
-//! names — the IIR compiler emits them directly.  Array references
-//! (`A(I)`) are deferred to V2.
+//! names — the IIR compiler emits them directly.  An array `A` (declared
+//! with `DIM A(n)`) uses the same-named register to hold its *handle*; a
+//! scalar `A` and an array `A` are distinct variables in Dartmouth BASIC.
 
 #![warn(missing_docs)]
 #![warn(rust_2018_idioms)]
@@ -212,6 +215,14 @@ struct Compiler {
     /// reference is a clean `Unsupported` error rather than an
     /// undefined-register miscompile.  `None` while lowering `main`.
     current_fn_param: Option<String>,
+    /// Names declared as arrays via `DIM` (BA3 / enabler **E5**).  Each
+    /// name maps to the IIR register holding the array *handle* — we use
+    /// the BASIC variable name itself as that register (an array `A` and a
+    /// scalar `A` are different variables in Dartmouth BASIC, and tiny
+    /// programs never collide them).  Membership also tells the `LET` and
+    /// expression paths whether a subscripted `A(I)` is a real array
+    /// access (→ `array_set`/`array_get`) or an undeclared use (an error).
+    arrays: std::collections::HashSet<String>,
 }
 
 impl Default for Compiler {
@@ -226,6 +237,7 @@ impl Default for Compiler {
             functions: Vec::new(),
             defined_fns: std::collections::HashSet::new(),
             current_fn_param: None,
+            arrays: std::collections::HashSet::new(),
         }
     }
 }
@@ -374,7 +386,7 @@ impl Compiler {
             "read_stmt"    => Err(CompileError::UnsupportedStatement("READ".into())),
             "data_stmt"    => Err(CompileError::UnsupportedStatement("DATA".into())),
             "restore_stmt" => Err(CompileError::UnsupportedStatement("RESTORE".into())),
-            "dim_stmt"     => Err(CompileError::UnsupportedStatement("DIM".into())),
+            "dim_stmt"     => self.emit_dim(stmt),
             "def_stmt"     => self.emit_def(stmt),
             other => Err(CompileError::Malformed(
                 format!("unknown statement `{other}`"))),
@@ -385,14 +397,76 @@ impl Compiler {
 
     fn emit_let(&mut self, stmt: &GrammarASTNode) -> Result<(), CompileError> {
         // `LET` KEYWORD, `variable` node, `EQ` token, `expr` node.
-        let var_name = extract_let_variable_name(stmt)?;
+        let var_node = child_nodes(stmt).into_iter()
+            .find(|n| n.rule_name == "variable")
+            .ok_or_else(|| CompileError::Malformed("LET missing variable".into()))?;
         let expr_node = child_nodes(stmt).into_iter()
             .find(|n| n.rule_name == "expr")
             .ok_or_else(|| CompileError::Malformed("LET missing expr".into()))?;
+
+        // `LET A(I) = e` stores into an array element (BA3 / E5); `LET x = e`
+        // is a plain register move.  We compute the right-hand side *first* in
+        // both cases so the index expression's temporaries don't interleave
+        // with it confusingly — the order is irrelevant to correctness (no
+        // shared state) but keeps the emitted IR readable.
+        if let Some(index_expr) = array_subscript_index(var_node) {
+            let name = array_target_name(var_node)?;
+            if !self.arrays.contains(&name) {
+                return Err(CompileError::Unsupported(format!(
+                    "assignment to `{name}(...)` but `{name}` was never DIMmed \
+                     — declare it with `DIM {name}(n)` first")));
+            }
+            let idx = self.emit_expr(index_expr)?;
+            let val = self.emit_expr(expr_node)?;
+            // `array_set handle, idx, value` — BASIC subscripts are already
+            // 0-based (`DIM A(N)` gives `A(0)..A(N)`), so the subscript IS the
+            // IIR index; no lower-bound subtraction (unlike ALGOL's `[lo:hi]`).
+            self.emit("array_set", None,
+                vec![Operand::Var(name), Operand::Var(idx), Operand::Var(val)],
+                "i64");
+            return Ok(());
+        }
+
+        let var_name = scalar_variable_name(var_node)?;
         let val = self.emit_expr(expr_node)?;
         // `mov_i64 dest = src` — the backend handles this via `emit_binop`/etc.
         self.emit("mov", Some(&var_name),
                   vec![Operand::Var(val)], "i64");
+        Ok(())
+    }
+
+    /// Lower `DIM A(n) [, B(m) …]` to one `alloc_array` per declared name
+    /// (BA3 / enabler **E5**).
+    ///
+    /// Dartmouth BASIC arrays are **0-based and inclusive**: `DIM A(10)`
+    /// declares the eleven elements `A(0)` through `A(10)`.  So the element
+    /// count `alloc_array` needs is `n + 1`, and a subscript needs no
+    /// adjustment — `A(I)` indexes element `I` directly.  (Contrast ALGOL's
+    /// `array A[lo:hi]`, which carries an arbitrary lower bound and subtracts
+    /// it on every access.)  Each handle lives in the register named after the
+    /// BASIC array, and the name is recorded so `LET`/expression subscripts
+    /// resolve to `array_set`/`array_get`.
+    fn emit_dim(&mut self, stmt: &GrammarASTNode) -> Result<(), CompileError> {
+        for decl in child_nodes(stmt).into_iter()
+            .filter(|n| n.rule_name == "dim_decl")
+        {
+            // `dim_decl = NAME LPAREN NUMBER RPAREN`.
+            let name = first_name_token_value(decl).ok_or_else(|| {
+                CompileError::Malformed("DIM decl missing array name".into())
+            })?;
+            let max_sub = dim_decl_bound(decl)?;
+            if max_sub < 0 {
+                return Err(CompileError::Unsupported(format!(
+                    "DIM {name}({max_sub}) — array bound must be non-negative")));
+            }
+            // Element count = max subscript + 1 (inclusive, 0-based).
+            let len = self.fresh_temp();
+            self.emit("const", Some(&len),
+                vec![Operand::Int(max_sub + 1)], "i64");
+            self.emit("alloc_array", Some(&name),
+                vec![Operand::Var(len)], "array<i64>");
+            self.arrays.insert(name);
+        }
         Ok(())
     }
 
@@ -730,6 +804,20 @@ impl Compiler {
                         "built-in function `{}` (needs E3 reals)", t.value)));
                 }
                 ASTNodeOrToken::Node(n) if n.rule_name == "variable" => {
+                    // `A(I)` reads an array element (BA3 / E5) → `array_get`.
+                    if let Some(index_expr) = array_subscript_index(n) {
+                        let name = array_target_name(n)?;
+                        if !self.arrays.contains(&name) {
+                            return Err(CompileError::Unsupported(format!(
+                                "`{name}(...)` is read but `{name}` was never \
+                                 DIMmed — declare it with `DIM {name}(n)` first")));
+                        }
+                        let idx = self.emit_expr(index_expr)?;
+                        let dest = self.fresh_temp();
+                        self.emit("array_get", Some(&dest),
+                            vec![Operand::Var(name), Operand::Var(idx)], "i64");
+                        return Ok(dest);
+                    }
                     let name = scalar_variable_name(n)?;
                     // Inside a `DEF` body, only the formal parameter is in
                     // scope.  Referencing any other variable would read an
@@ -883,13 +971,41 @@ fn extract_line_num(line: &GrammarASTNode) -> Option<i64> {
     None
 }
 
-fn extract_let_variable_name(stmt: &GrammarASTNode)
-    -> Result<String, CompileError>
-{
-    let var = child_nodes(stmt).into_iter()
-        .find(|n| n.rule_name == "variable")
-        .ok_or_else(|| CompileError::Malformed("LET missing variable".into()))?;
-    scalar_variable_name(var)
+/// If `var` is a *subscripted* variable `A(I)` (`variable = NAME LPAREN expr
+/// RPAREN`), return its index `expr` node; for the scalar form (`NAME`) return
+/// `None`.  This is the single place that distinguishes an array access from a
+/// plain variable — both the `LET` write path and the expression read path use
+/// it (BA3 / enabler **E5**).
+fn array_subscript_index(var: &GrammarASTNode) -> Option<&GrammarASTNode> {
+    child_nodes(var).into_iter().find(|n| n.rule_name == "expr")
+}
+
+/// The array name of a subscripted `variable` node `A(I)` — the leading NAME
+/// token.  (`scalar_variable_name` deliberately rejects the subscripted form,
+/// so the array paths use this instead.)
+fn array_target_name(var: &GrammarASTNode) -> Result<String, CompileError> {
+    first_name_token_value(var).ok_or_else(|| {
+        CompileError::Malformed("subscripted variable missing NAME token".into())
+    })
+}
+
+/// The integer bound `n` in a `dim_decl = NAME LPAREN NUMBER RPAREN`.  The
+/// grammar pins the bound to a `NUMBER` literal (not an arbitrary expression),
+/// so we read it straight from the token rather than emitting code to compute
+/// it.  Truncates a float spelling to `i64` for consistency with how the rest
+/// of this integer-only V1 treats `NUMBER`.
+fn dim_decl_bound(decl: &GrammarASTNode) -> Result<i64, CompileError> {
+    for c in &decl.children {
+        if let ASTNodeOrToken::Token(t) = c {
+            if t.effective_type_name() == "NUMBER" {
+                return Ok(t.value.trim().parse::<f64>()
+                    .map(|f| f as i64)
+                    .map_err(|_| CompileError::Malformed(format!(
+                        "DIM bound `{}` is not a number", t.value)))?);
+            }
+        }
+    }
+    Err(CompileError::Malformed("DIM decl missing NUMBER bound".into()))
 }
 
 fn scalar_variable_name(var: &GrammarASTNode)
@@ -1301,5 +1417,120 @@ mod tests {
             i.op == "call_builtin" && i.srcs.first().and_then(|s| match s {
                 Operand::Var(n) => Some(n.as_str()), _ => None,
             }) == Some("print_i64")));
+    }
+
+    // -----------------------------------------------------------------------
+    // BA3 — DIM arrays (enabler E5)
+    // -----------------------------------------------------------------------
+
+    fn var_name(op: Option<&Operand>) -> Option<&str> {
+        match op {
+            Some(Operand::Var(n)) => Some(n.as_str()),
+            _ => None,
+        }
+    }
+
+    /// `DIM A(5)` lowers to `alloc_array A = <len>` where the length is the
+    /// **inclusive** element count `5 + 1 = 6` (BASIC arrays are 0-based:
+    /// `A(0)..A(5)`).
+    #[test]
+    fn compiles_dim_to_alloc_array() {
+        let m = compile("10 DIM A(5)\n20 END\n").expect("ok");
+        let body = &m.functions[0].instructions;
+        let alloc = body.iter().find(|i| i.op == "alloc_array")
+            .expect("DIM produces an alloc_array");
+        assert_eq!(alloc.dest.as_deref(), Some("A"));
+        assert_eq!(alloc.type_hint, "array<i64>");
+        // Its length operand is a register that was `const 6`.
+        let len_reg = var_name(alloc.srcs.first()).expect("alloc_array len reg");
+        assert!(body.iter().any(|i|
+            i.op == "const" && i.dest.as_deref() == Some(len_reg)
+                && matches!(i.srcs.first(), Some(Operand::Int(6)))),
+            "expected `const 6` feeding the alloc_array length");
+    }
+
+    /// `DIM A(3), B(2)` declares two arrays in one statement → two
+    /// `alloc_array`s with lengths 4 and 3.
+    #[test]
+    fn compiles_multi_dim_to_two_alloc_arrays() {
+        let m = compile("10 DIM A(3), B(2)\n20 END\n").expect("ok");
+        let body = &m.functions[0].instructions;
+        let allocs: Vec<_> = body.iter().filter(|i| i.op == "alloc_array").collect();
+        assert_eq!(allocs.len(), 2);
+        assert_eq!(allocs[0].dest.as_deref(), Some("A"));
+        assert_eq!(allocs[1].dest.as_deref(), Some("B"));
+    }
+
+    /// `LET A(2) = 7` lowers to `array_set A, idx, val` with the subscript
+    /// used **directly** as the 0-based index (no lower-bound subtraction).
+    #[test]
+    fn compiles_array_assignment_to_array_set() {
+        let m = compile("10 DIM A(5)\n20 LET A(2) = 7\n30 END\n").expect("ok");
+        let body = &m.functions[0].instructions;
+        let set = body.iter().find(|i| i.op == "array_set")
+            .expect("LET A(i)=e produces an array_set");
+        assert_eq!(set.type_hint, "i64");
+        assert_eq!(var_name(set.srcs.first()), Some("A"));
+        assert_eq!(set.srcs.len(), 3, "array_set takes handle, index, value");
+        // The index register was `const 2`, used as-is (BASIC is 0-based).
+        let idx_reg = var_name(set.srcs.get(1)).expect("index reg");
+        assert!(body.iter().any(|i|
+            i.op == "const" && i.dest.as_deref() == Some(idx_reg)
+                && matches!(i.srcs.first(), Some(Operand::Int(2)))));
+    }
+
+    /// `LET X = A(2)` reads an element → `array_get A, idx → dest`.
+    #[test]
+    fn compiles_array_read_to_array_get() {
+        let m = compile("10 DIM A(5)\n20 LET X = A(2)\n30 END\n").expect("ok");
+        let body = &m.functions[0].instructions;
+        let get = body.iter().find(|i| i.op == "array_get")
+            .expect("reading A(i) produces an array_get");
+        assert_eq!(get.type_hint, "i64");
+        assert_eq!(var_name(get.srcs.first()), Some("A"));
+        assert!(get.dest.is_some(), "array_get writes a destination register");
+    }
+
+    /// Storing into an array that was never `DIM`med is a clean error, not a
+    /// miscompile against an undefined handle register.
+    #[test]
+    fn undeclared_array_write_is_unsupported() {
+        let err = compile("10 LET A(2) = 7\n20 END\n").unwrap_err();
+        match err {
+            CompileError::Unsupported(msg) => assert!(msg.contains("DIM")),
+            other => panic!("expected Unsupported(DIM…), got {other:?}"),
+        }
+    }
+
+    /// Reading an array that was never `DIM`med is likewise an error.
+    #[test]
+    fn undeclared_array_read_is_unsupported() {
+        let err = compile("10 LET X = A(2)\n20 END\n").unwrap_err();
+        match err {
+            CompileError::Unsupported(msg) => assert!(msg.contains("DIM")),
+            other => panic!("expected Unsupported(DIM…), got {other:?}"),
+        }
+    }
+
+    /// End-to-end shape: fill an array in a loop and sum it back — the canonical
+    /// E5 program.  Confirms the alloc/set/get ops all appear and the subscript
+    /// expression (a variable `I`) flows through as the index.
+    #[test]
+    fn compiles_array_fill_and_sum_program() {
+        let src = "10 DIM A(3)\n\
+                   20 FOR I = 0 TO 3\n\
+                   30 LET A(I) = I\n\
+                   40 NEXT I\n\
+                   50 LET S = 0\n\
+                   60 FOR I = 0 TO 3\n\
+                   70 LET S = S + A(I)\n\
+                   80 NEXT I\n\
+                   90 PRINT S\n\
+                   99 END\n";
+        let m = compile(src).expect("ok");
+        let body = &m.functions[0].instructions;
+        assert!(body.iter().any(|i| i.op == "alloc_array"));
+        assert!(body.iter().any(|i| i.op == "array_set" && var_name(i.srcs.first()) == Some("A")));
+        assert!(body.iter().any(|i| i.op == "array_get" && var_name(i.srcs.first()) == Some("A")));
     }
 }

--- a/code/packages/rust/lang-aot/tests/lang_matrix.rs
+++ b/code/packages/rust/lang-aot/tests/lang_matrix.rs
@@ -784,6 +784,27 @@ const PROGRAMS: &[Prog] = &[
         expect: Expect::Stdout("49"),
         backends: &[NativeAot, Llvm, Wasm, Jvm, Clr, Vm, Jit],
     },
+    // Dartmouth BASIC — *one-dimensional integer arrays* (LANG-FULL BA3, enabler
+    // **E5**). `DIM A(3)` lowers to an IIR `alloc_array` (element count `3 + 1`,
+    // since BASIC arrays are **0-based and inclusive**: `A(0)..A(3)`). `LET
+    // A(1) := 40` / `A(2) := 2` are `array_set`s and `PRINT A(1) + A(2)` reads
+    // them back with two `array_get`s ⇒ prints 42.  These are the *same* IIR
+    // array ops ALGOL's E5 arrays emit, so BASIC arrays run on every backend E5
+    // already supports — straight-line (no loop), so the JVM's BA-JVM-1
+    // loop+print StackMapTable follow-up doesn't apply, and all 7 backends run:
+    // the managed runtimes (JVM `int[]`/`iastore`/`iaload`, CLR `int32[]`/
+    // `stelem`/`ldelem`) bounds-check natively, while the static backends
+    // (LLVM/WASM/NativeAot) use the length-prefixed `[i64 len][elems…]` block
+    // with an explicit bounds `cmp`+trap.  `dartmouth-basic-iir-compiler` lowers
+    // `DIM`/subscripted-`LET`/subscripted-read; the subscript is used directly
+    // as the 0-based index (no lower-bound subtraction, unlike ALGOL `[lo:hi]`).
+    Prog {
+        lang: Language::DartmouthBasic,
+        ext: "bas",
+        src: "10 DIM A(3)\n20 LET A(1) = 40\n30 LET A(2) = 2\n40 PRINT A(1) + A(2)\n50 END\n",
+        expect: Expect::Stdout("42"),
+        backends: &[NativeAot, Llvm, Wasm, Jvm, Clr, Vm, Jit],
+    },
 ];
 
 /// Is a usable native linker present on this host? On Linux/macOS the AOT path uses

--- a/code/specs/LANG-FULL-IMPLEMENTATION.md
+++ b/code/specs/LANG-FULL-IMPLEMENTATION.md
@@ -12,7 +12,7 @@ program per language**, and each frontend is a **deliberate subset**:
 | Twig | `42` | rich Lisp frontend, but only typed int-arith/`if` clears the backend validators; lists/lambdas/strings/`print`/symbols need the VM only |
 | Nib | `double(21)` → 42 | no `*` `/`, no `for`, no bitwise, no `&&`/`||`, no `const`/`static`; u4/u8 collapse to i64 (no wrap) |
 | Brainfuck | one 1-loop "print A" | all 8 ops are correct **but cat/Hello-World/nested-multiply run only on the VM/JIT**, never on the code-gen backends |
-| Dartmouth BASIC | `PRINT 42` | integer-only: no `GOSUB`, strings, arrays, `DEF FN`, `READ`/`DATA`, `^`; loops/IF/GOTO execute only on the VM/JIT |
+| Dartmouth BASIC | `PRINT 42` | integer-only: no `GOSUB`, strings, `READ`/`DATA`, `^`; has `FOR`/`NEXT`, `IF`/`GOTO`, `DEF FN` (BA5), `DIM` arrays (BA3) — all run on every backend |
 | Oct | `let`/`if` | rejects **all 10 Intel-8008 intrinsics** (its raison d'être); `&&`/`||` short-circuit ✅ (O1), u8 wrap + `~` ✅ (O2); intrinsics + `static` remain |
 | ALGOL 60 | `result := 17 mod 5` → 2 | `integer`/`real`/`boolean` scalars, typed procedures, switches, and 1-D arrays (arrays + reals run on VM/JIT only so far); no call-by-name, strings, multidim arrays, `own` |
 
@@ -341,7 +341,14 @@ backend immediately) come before the enabler-dependent items.
   to the matrix JVM column.
 - ☐ **BA1** — `GOSUB` / `RETURN` (needs **E7**).
 - ☐ **BA2** — multi-item `PRINT`, `;`/`,` separators, more relops.
-- ☐ **BA3** — arrays / `DIM` (needs **E5**).
+- ✅ **BA3** — arrays / `DIM` (enabler **E5**). `DIM A(n)` lowers to `alloc_array`
+  (BASIC arrays are 0-based + inclusive, so `n + 1` elements); `LET A(i) = e` →
+  `array_set` and `A(i)` rvalues → `array_get`, with the subscript used directly as
+  the 0-based index (no lower-bound subtraction, unlike ALGOL `[lo:hi]`). These are
+  the same shared array ops ALGOL's E5 arrays use, so BASIC arrays RUN on all 7
+  backends — verified by a straight-line array program (`DIM A(3); A(1)=40; A(2)=2;
+  PRINT A(1)+A(2)` ⇒ `42`) in `lang-aot/tests/lang_matrix.rs`. (`dartmouth-basic-iir-compiler`
+  0.7.0.) Undeclared subscript use is a clean `Unsupported` error.
 - ☐ **BA4** — strings + string PRINT (needs **E4**).
 - ✅ **BA5** — `DEF FN` single-line user functions. `DEF FNx(P) = expr` lowers to a
   sibling `IIRFunction` (one numeric param, `FullyTyped`) and `FNx(arg)` lowers to the


### PR DESCRIPTION
## What

Adds one-dimensional integer arrays to the Dartmouth BASIC frontend (LANG-FULL **BA3**, enabler **E5**). `DIM` was previously an `UnsupportedStatement` and subscripted `A(I)` a deferred error.

BASIC arrays lower to the **same shared IIR array ops** ALGOL's E5 arrays use, so they run on every backend E5 already supports:

- **`DIM A(n)` → `alloc_array A = n+1`** — Dartmouth BASIC arrays are **0-based and inclusive** (`DIM A(3)` ⇒ `A(0)..A(3)`, 4 elements). `DIM A(3), B(2)` declares both.
- **`LET A(i) = e` → `array_set`**, **`A(i)` read → `array_get`** — the subscript is used **directly** as the 0-based index (no lower-bound subtraction, unlike ALGOL `[lo:hi]`).
- **Undeclared subscript use** is a clean `Unsupported` error, not a miscompile against an undefined handle register.

## Verified by RUNNING

`lang-aot/tests/lang_matrix.rs` gains a straight-line array program across **all 7 backends**:

```basic
10 DIM A(3)
20 LET A(1) = 40
30 LET A(2) = 2
40 PRINT A(1) + A(2)
50 END
```
⇒ stdout `42`. Managed runtimes (JVM `int[]`/`iastore`/`iaload`, CLR `int32[]`/`stelem`/`ldelem`) bounds-check natively; static backends (LLVM/WASM/NativeAot) use the length-prefixed block + explicit bounds-trap. No loop, so the JVM BA-JVM-1 loop+print follow-up doesn't apply. Locally the in-repo backends (WASM/VM/JIT + NativeAot aarch64) ran it green; LLVM/JVM/CLR run in CI.

## Robustness / security

A `DIM` bound is validated against `MAX_DIM_BOUND` (2^24) **before** the `f64`→`i64` cast — an oversized/non-finite literal (e.g. `DIM A(1E30)`, which a bare `as i64` cast would saturate to `i64::MAX` then overflow on `+1`) is a clean `Unsupported` error, never a panic/garbage length. `emit_dim` also uses `checked_add`. Found + fixed in security review (1 round); regression test added.

## Tests / docs

- **32 unit tests** (+8 new: lowering shape, multi-DIM, 0-based index, undeclared-use errors, oversized-bound).
- `dartmouth-basic-iir-compiler` 0.7.0. CHANGELOG, README, module-doc table, LANG-FULL roadmap (BA3 ticked) updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)