### PR TITLE
feat(wolfram): W-18 — pattern-matching builtins (MatchQ/Cases/FreeQ)

### DIFF
--- a/code/packages/rust/wolfram-repl/src/lib.rs
+++ b/code/packages/rust/wolfram-repl/src/lib.rs
@@ -287,6 +287,62 @@ mod tests {
     }
 
     #[test]
+    fn w18_pattern_matching_evaluates_end_to_end() {
+        // Parsed from real source, so the `_`/`_Integer`/`_Real` spellings go
+        // through the lowerer (`_Integer` → `Blank[Integer]`) and the held
+        // pattern handlers. (W-18: MatchQ / Cases / FreeQ.)
+        let mut r = WolframRepl::new();
+        // MatchQ.
+        assert!(matches!(
+            r.feed("MatchQ[2, _]"),
+            ReplResponse::Output(t) if t.contains("True")
+        ));
+        assert!(matches!(
+            r.feed("MatchQ[2, _Integer]"),
+            ReplResponse::Output(t) if t.contains("True")
+        ));
+        assert!(matches!(
+            r.feed("MatchQ[2, 3]"),
+            ReplResponse::Output(t) if t.contains("False")
+        ));
+        // A float is _Real, not _Integer.
+        assert!(matches!(
+            r.feed("MatchQ[2.0, _Integer]"),
+            ReplResponse::Output(t) if t.contains("False")
+        ));
+        // Cases filters; `_Integer` drops the real.
+        assert!(matches!(
+            r.feed("Cases[{1, 2, 3, 4}, _]"),
+            ReplResponse::Output(t) if t.contains("{1, 2, 3, 4}")
+        ));
+        assert!(matches!(
+            r.feed("Cases[{1, 2, 3}, 2]"),
+            ReplResponse::Output(t) if t.contains("{2}")
+        ));
+        assert!(matches!(
+            r.feed("Cases[{1, 2.0, 3}, _Integer]"),
+            ReplResponse::Output(t) if t.contains("{1, 3}")
+        ));
+        // FreeQ — membership and nested-head occurrence.
+        assert!(matches!(
+            r.feed("FreeQ[{1, 2, 3}, 2]"),
+            ReplResponse::Output(t) if t.contains("False")
+        ));
+        assert!(matches!(
+            r.feed("FreeQ[{1, 2, 3}, 5]"),
+            ReplResponse::Output(t) if t.contains("True")
+        ));
+        assert!(matches!(
+            r.feed("FreeQ[f[g[2]], g]"),
+            ReplResponse::Output(t) if t.contains("False")
+        ));
+        assert!(matches!(
+            r.feed("FreeQ[f[g[2]], h]"),
+            ReplResponse::Output(t) if t.contains("True")
+        ));
+    }
+
+    #[test]
     fn continues_while_a_bracket_is_open() {
         let mut r = WolframRepl::new();
         assert_eq!(r.feed("f[1,"), ReplResponse::NeedMore); // open bracket

--- a/code/packages/rust/wolfram-runtime/CHANGELOG.md
+++ b/code/packages/rust/wolfram-runtime/CHANGELOG.md
@@ -4,6 +4,76 @@ All notable changes to `wolfram-runtime` are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/) and this project uses
 [Semantic Versioning](https://semver.org/).
 
+## [0.13.0] — 2026-06-21
+
+The **W-18** deliverable (MA04 §19): Wolfram's **pattern-matching predicates**
+`MatchQ`, `Cases`, and `FreeQ`, lowered onto the same substrate as the rest of
+the lane. All ordinary `Head[args]` forms — **no grammar change**; only the
+`wolfram-runtime` builtin handler table grows. The three heads are **held** (a
+new `PATTERN_HEADS` set folded into the `WolframBackend` hold set alongside the
+W-7/W-8/W-14 held heads) so the **pattern** argument arrives **literal** — a
+pattern is a *form*, not a value, exactly as `Switch` relies on. Each handler
+evaluates **only its subject**.
+
+### Added (pattern-matching predicates)
+
+- **`MatchQ[expr, patt]`** — `True` iff `expr` matches `patt`, else `False`.
+  `MatchQ[2, _]` → `True`, `MatchQ[2, _Integer]` → `True`, `MatchQ[2, 2]` →
+  `True`, `MatchQ[2, 3]` → `False`. The subject is evaluated; the pattern stays
+  literal. Wrong arity is left **unevaluated**.
+- **`Cases[list, patt]`** — the `List` of `list`'s elements that match `patt`,
+  dropping non-matches. `Cases[{1, 2, 3, 4}, _]` → `{1, 2, 3, 4}`,
+  `Cases[{1, 2, 3}, 2]` → `{2}`, `Cases[{1, 2.0, 3}, _Integer]` → `{1, 3}`. A
+  **non-list** first argument (or wrong arity) is left unevaluated. The result
+  inherits the input's `MAX_LIST_LENGTH` bound.
+- **`FreeQ[expr, form]`** — `True` iff `form` occurs **nowhere** within `expr`
+  (recursively — the root, every `Apply` head, and every argument), else
+  `False`. `FreeQ[{1, 2, 3}, 2]` → `False`, `FreeQ[{1, 2, 3}, 5]` → `True`,
+  `FreeQ[f[g[2]], g]` → `False`, `FreeQ[f[g[2]], h]` → `True`.
+
+### Pattern subset and matcher
+
+The supported pattern vocabulary is a literal (structural equality via the W-13
+`same_element` comparator), `_` (`Blank[]`, the catch-all), and a head-typed
+`_h` (`Blank[h]`, matching iff the subject's Wolfram head is `h`). A single
+panic-free `pattern_matches` primitive extends the W-14 `Switch` matcher by
+**enforcing** the `Blank[h]` head constraint that `Switch` ignored — the one
+capability W-18 needed beyond W-14. The lowerer turns `_Integer` →
+`Blank[Integer]`, `_Real` → `Blank[Real]`, `_Symbol` → `Blank[Symbol]`, and the
+head map sends an `Integer` atom → head `Integer`, a `Float` atom → head `Real`,
+a symbol → head `Symbol`; so `MatchQ[2.0, _Integer]` is `False` (a float is
+`_Real`).
+
+### Robustness
+
+- **`FreeQ` recursion is depth-bounded** (`FREEQ_MAX_DEPTH = 512`): the tree is
+  already size-bounded by the parser's nesting cap and `MAX_LIST_LENGTH`, and at
+  the cap the walk stops descending and reports "occurs" conservatively, so a
+  crafted over-deep input yields a **safe bounded answer instead of a stack
+  overflow** — never a panic.
+- **Heterogeneous atom comparison is total** — comparing across `Integer` /
+  `Float` / `Symbol` / `String` / `Rational` kinds simply reports no match and
+  never panics.
+
+### Deferred to W-19 (MA04 §19.6)
+
+The richer pattern algebra is **explicitly out of scope** for W-18: named
+patterns `x_` (`Pattern[x, Blank[]]`, capture binding), alternatives `a | b`
+(`Alternatives`), conditions `patt /; t`, `PatternTest`, blank sequences `__`
+(`BlankSequence`), and replacement `/.` / `Replace`. A named blank
+`Pattern[x, Blank[…]]` falls through to the literal branch and simply fails to
+match an evaluated value (rather than mis-binding) — the safe documented W-18
+behaviour until W-19 adds capture binding.
+
+### Tests
+
+- 9 handler-level unit tests in `wolfram-runtime` (literal / blank / head-typed,
+  the Integer-vs-Real head distinction, `Cases` filtering plus empty / non-list,
+  `FreeQ` membership / nesting plus the depth-bound no-overflow guard and
+  heterogeneous no-panic case, wrong-arity-unevaluated for `MatchQ`/`FreeQ`).
+- 1 end-to-end `wolfram-repl` test exercising the real `_Integer` / `_Real`
+  lowering through parse → lower → eval.
+
 ## [0.12.0] — 2026-06-20
 
 The **W-15** deliverable (MA04 §18): Wolfram's **numeric & integer math**

--- a/code/packages/rust/wolfram-runtime/Cargo.toml
+++ b/code/packages/rust/wolfram-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-wolfram-runtime"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 description = "Wolfram Language runtime — lowers M-expressions to symbolic-ir and evaluates via symbolic-vm"
 license = "MIT"

--- a/code/packages/rust/wolfram-runtime/README.md
+++ b/code/packages/rust/wolfram-runtime/README.md
@@ -12,7 +12,8 @@ See the spec: [`code/specs/MA04-wolfram-language.md`](../../../specs/MA04-wolfra
 iteration constructs), §11 (W-8 local scoping), §12 (W-9 list-manipulation
 builtins), §13 (W-10 functional-iteration combinators), §14 (W-11 pure
 functions), §15 (W-12 string builtins), §16 (W-13 list set operations), §17
-(W-14 conditionals & predicates), and §18 (W-15 numeric & integer math).
+(W-14 conditionals & predicates), §18 (W-15 numeric & integer math), and §19
+(W-18 pattern-matching predicates).
 
 ## What it does
 
@@ -157,6 +158,13 @@ assert_eq!(eval("Quotient[-7, 2]\n").unwrap(), "Out[1]= -4\n"); // toward −∞
 assert_eq!(eval("Sqrt[16]\n").unwrap(), "Out[1]= 4\n");       // exact perfect square
 // Sqrt[2] stays symbolic; the float is on demand via N:
 assert_eq!(eval("Sqrt[2]\n").unwrap(), "Out[1]= Sqrt[2]\n");
+
+// W-18 pattern matching — MatchQ/Cases/FreeQ (held: the pattern stays literal):
+assert_eq!(eval("MatchQ[2, _Integer]\n").unwrap(), "Out[1]= True\n");
+assert_eq!(eval("MatchQ[2.0, _Integer]\n").unwrap(), "Out[1]= False\n"); // a float is _Real
+assert_eq!(eval("Cases[{1, 2.0, 3}, _Integer]\n").unwrap(), "Out[1]= {1, 3}\n");
+assert_eq!(eval("FreeQ[f[g[2]], g]\n").unwrap(), "Out[1]= False\n");     // g occurs nested
+assert_eq!(eval("FreeQ[{1, 2, 3}, 5]\n").unwrap(), "Out[1]= True\n");
 
 // Stateful (bindings and definitions persist):
 let mut s = WolframSession::new();
@@ -462,6 +470,41 @@ wrapping or panicking. Every malformed form (wrong arity, non-numeric or
 non-integer argument, division by zero) is left unevaluated — the fail-soft
 contract every head since W-5 follows.
 
+**W-18** adds the **pattern-matching predicates** `MatchQ`, `Cases`, and `FreeQ`.
+They are **held** (a new `PATTERN_HEADS` set folded into the `WolframBackend`
+held set, alongside the W-7/W-8/W-14 held heads) so the **pattern** argument
+arrives **literal** — a pattern is a *form*, not a value, exactly as `Switch`
+relies on. Each handler evaluates **only its subject** and matches against the
+literal pattern through a single panic-free `pattern_matches` primitive that
+extends the W-14 `Switch` matcher by **enforcing** the `Blank[h]` head
+constraint, reusing the W-13 `same_element` comparator for literals.
+
+| Head | Example | Result |
+|------|---------|--------|
+| `MatchQ` | `MatchQ[2, _]` / `MatchQ[2, _Integer]` | `True` / `True` |
+| `MatchQ` | `MatchQ[2, 3]` / `MatchQ[2.0, _Integer]` | `False` / `False` |
+| `Cases` | `Cases[{1, 2, 3, 4}, _]` | `{1, 2, 3, 4}` |
+| `Cases` | `Cases[{1, 2, 3}, 2]` / `Cases[{1, 2.0, 3}, _Integer]` | `{2}` / `{1, 3}` |
+| `FreeQ` | `FreeQ[{1, 2, 3}, 2]` / `FreeQ[{1, 2, 3}, 5]` | `False` / `True` |
+| `FreeQ` | `FreeQ[f[g[2]], g]` / `FreeQ[f[g[2]], h]` | `False` / `True` |
+
+The **supported pattern subset** is deliberately small: a literal (structural
+equality), `_` (`Blank[]`, the catch-all), and a head-typed `_h` (`Blank[h]`,
+matching iff the subject's Wolfram head is `h`). The lowerer turns `_Integer` →
+`Blank[Integer]`, `_Real` → `Blank[Real]`, `_Symbol` → `Blank[Symbol]`, and the
+matcher's head map sends an `Integer` atom to head `Integer`, a `Float` atom to
+head `Real`, and a symbol to head `Symbol` — so `MatchQ[2.0, _Integer]` is
+`False` (a float is `_Real`, not `_Integer`). `FreeQ` recurses the whole
+expression tree (the root, every `Apply` head, every argument) **depth-bounded**
+(`FREEQ_MAX_DEPTH`) so a crafted over-deep input yields a safe bounded answer
+rather than overflowing the stack; heterogeneous atom comparison is total and
+never panics; result lists inherit the input's `MAX_LIST_LENGTH` bound. Wrong
+arity, and a non-list first argument to `Cases`, are left **unevaluated**.
+
+The richer pattern algebra — named patterns `x_`, alternatives `a | b`,
+conditions `patt /; t`, `PatternTest`, sequences `__`, and replacement
+`/.` / `Replace` — is **deferred to W-19** (MA04 §19.6).
+
 A `;` at the end of a line suppresses that result's display (the notebook
 convention) but the statement still runs and still advances the `Out[n]` counter.
 
@@ -524,6 +567,14 @@ session-rebuild so a panic becomes a clean `Err` rather than a crash.
   otherwise symbolic (`N[Sqrt[2]]` for the float). `Mod`/`Power`/`N` reused
   unchanged; `Sqrt` overrides the inner backend's eager-numericising one. No
   grammar change.
+- **W-18** (this crate) — the `MatchQ`/`Cases`/`FreeQ` pattern-matching
+  predicates (held — the pattern argument stays literal), built on a single
+  panic-free `pattern_matches` primitive that extends the W-14 `Switch` matcher
+  to enforce `Blank[h]` head constraints and reuses the W-13 `same_element`
+  comparator for literals. Supported subset: literal, `_` (`Blank[]`), head-typed
+  `_h` (`Blank[h]`); `FreeQ`'s recursive tree walk is depth-bounded. Named
+  patterns / alternatives / conditions / sequences / replacement deferred to
+  W-19. No grammar change.
 - **Future** — the full `cas-*` function surface under Wolfram names
   (`Simplify`, `Expand`, `Factor`, `Solve`, …).
 

--- a/code/packages/rust/wolfram-runtime/src/backend.rs
+++ b/code/packages/rust/wolfram-runtime/src/backend.rs
@@ -37,7 +37,9 @@ use symbolic_vm::SymbolicBackend;
 
 use symbolic_ir::{apply, IRApply, IRNode, ADD, AND, MUL, OR};
 
-use crate::builtins::{build_wolfram_builtins, CONDITIONAL_HEADS, ITERATION_HEADS, SCOPING_HEADS};
+use crate::builtins::{
+    build_wolfram_builtins, CONDITIONAL_HEADS, ITERATION_HEADS, PATTERN_HEADS, SCOPING_HEADS,
+};
 use crate::lower::{FUNCTION_HEAD, SLOT_HEAD, SLOT_SEQUENCE_HEAD};
 
 /// The Wolfram evaluation backend: a [`SymbolicBackend`] plus the W-5 built-in
@@ -89,6 +91,13 @@ impl WolframBackend {
         // have a side effect) must never run. `If` is already in the inner held
         // set, so it is not added here.
         for head in CONDITIONAL_HEADS {
+            held.insert(head.to_string());
+        }
+        // W-18 pattern-matching heads (`MatchQ`, `Cases`, `FreeQ`) must be held
+        // so the PATTERN argument arrives literal — a pattern is a form, not a
+        // value (`MatchQ[2, 1+1]` matches `Plus[1,1]`, not `2`). Each handler
+        // evaluates only its subject. (MA04 §19.4.)
+        for head in PATTERN_HEADS {
             held.insert(head.to_string());
         }
         // W-11: the inner backend's rules followed by the pure-function

--- a/code/packages/rust/wolfram-runtime/src/builtins.rs
+++ b/code/packages/rust/wolfram-runtime/src/builtins.rs
@@ -222,6 +222,17 @@ pub fn build_wolfram_builtins() -> HashMap<String, Handler> {
     m.insert("GCD".to_string(), handler_fn(gcd_handler));
     m.insert("LCM".to_string(), handler_fn(lcm_handler));
     m.insert("Sqrt".to_string(), handler_fn(sqrt_handler));
+
+    // W-18 pattern-matching predicates (MA04 §19). HELD (see `PATTERN_HEADS`):
+    // each handler evaluates ONLY its subject and matches against the *literal*
+    // pattern, reusing the single `pattern_matches` primitive (the W-14
+    // `form_matches` extended to enforce `Blank[h]` head constraints). Only
+    // literals, `_` (`Blank[]`), and head-typed `_h` (`Blank[h]`) are supported;
+    // named patterns / alternatives / conditions / replacement are deferred to
+    // W-19. Registered as a NEW contiguous block to minimise merge churn.
+    m.insert("MatchQ".to_string(), handler_fn(match_q_handler));
+    m.insert("Cases".to_string(), handler_fn(cases_handler));
+    m.insert("FreeQ".to_string(), handler_fn(free_q_handler));
     m
 }
 
@@ -267,6 +278,21 @@ pub const SCOPING_HEADS: [&str; 3] = ["With", "Module", "Block"];
 /// (unevaluated), and only the selected value is evaluated. `If` already lives in
 /// the inner backend's held set, so it is not repeated here. (MA04 §17.2.)
 pub const CONDITIONAL_HEADS: [&str; 2] = ["Which", "Switch"];
+
+/// The W-18 pattern-matching heads (`MatchQ`, `Cases`, `FreeQ`), which must be
+/// **held** (args not pre-evaluated) so that the *pattern* argument arrives
+/// **literal**. The [`WolframBackend`](crate::backend::WolframBackend) folds
+/// these into its `hold_heads` set (union with the inner held set,
+/// [`ITERATION_HEADS`], [`SCOPING_HEADS`], and [`CONDITIONAL_HEADS`]).
+///
+/// Why held? A pattern is a *form*, not a value: `MatchQ[2, 1 + 1]` must match
+/// against the literal form `Plus[1, 1]`, not the evaluated `2` — exactly the
+/// held-form semantics `Switch` relies on (MA04 §17.2). Each handler evaluates
+/// only the *subject* (the first argument — the expression / list / expr being
+/// tested) via `vm.eval`, and never touches the pattern. A `Blank[h]` survives
+/// evaluation unchanged regardless (no `Blank` handler exists), but holding makes
+/// the literal-pattern contract explicit and uniform with `Switch`. (MA04 §19.4.)
+pub const PATTERN_HEADS: [&str; 3] = ["MatchQ", "Cases", "FreeQ"];
 
 // ---------------------------------------------------------------------------
 // List inspection — Length / First / Last / Part
@@ -1615,6 +1641,173 @@ fn form_matches(form: &IRNode, subject: &IRNode) -> bool {
 /// `h` is accepted but not enforced in this subset (MA04 §17.3).
 fn is_blank(node: &IRNode) -> bool {
     matches!(node, IRNode::Apply(app) if matches!(&app.head, IRNode::Symbol(s) if s == BLANK))
+}
+
+// ---------------------------------------------------------------------------
+// W-18 pattern-matching predicates — MatchQ / Cases / FreeQ (MA04 §19)
+// ---------------------------------------------------------------------------
+//
+// The single match primitive shared by all three heads. It promotes W-14's
+// `form_matches` (used by `Switch`) by *enforcing* the `Blank[h]` head
+// constraint that `Switch` ignored — the one capability W-18 needs that the
+// W-14 matcher lacked. The supported pattern vocabulary is deliberately small
+// (MA04 §19.2):
+//
+//   pattern          matches `subject` when …
+//   ───────────────  ─────────────────────────────────────────────────────────
+//   `_`  (Blank[])   always — the catch-all
+//   `_h` (Blank[h])  the subject's Wolfram head is exactly `h`
+//   literal          the pattern is structurally equal to the subject under the
+//                    W-13 `same_element` comparator (so `2` ≠ `2.0`, `f[1]`
+//                    matches `f[1]` recursively)
+//
+// Everything richer — named patterns `x_`, alternatives `a|b`, conditions
+// `patt/;t`, `PatternTest`, sequences `__`, replacement `/.` — is DEFERRED to
+// W-19 (MA04 §19.6). A `Pattern[x, Blank[…]]` (a *named* blank) is NOT an
+// `is_blank` node, so it falls through to the literal branch and only matches an
+// identical `Pattern[…]` subject — which never occurs for an evaluated value, so
+// a named pattern simply fails to match here rather than mis-binding. That is the
+// safe, documented W-18 behaviour until W-19 adds capture binding.
+
+/// The maximum recursion depth `FreeQ`'s tree walk will descend before reporting
+/// "not free here" conservatively. The expression tree is already bounded by the
+/// parser's nesting cap and `MAX_LIST_LENGTH`, so reaching this depth means a
+/// pathologically nested *crafted* input; the cap turns a potential stack
+/// overflow into a safe, bounded answer (MA04 §19.3).
+const FREEQ_MAX_DEPTH: usize = 512;
+
+/// The single match primitive (MA04 §19.2). True iff `subject` matches `pattern`
+/// within the W-18 supported subset: `pattern` is `Blank[]` (catch-all),
+/// `Blank[h]` (subject's head must be `h`), or a literal structurally equal to
+/// `subject` under [`same_element`]. Total and panic-free.
+fn pattern_matches(pattern: &IRNode, subject: &IRNode) -> bool {
+    if let IRNode::Apply(app) = pattern {
+        if matches!(&app.head, IRNode::Symbol(s) if s == BLANK) {
+            return match app.args.as_slice() {
+                // `_` — Blank[] — matches anything.
+                [] => true,
+                // `_h` — Blank[h] — matches iff the subject's Wolfram head is `h`.
+                [IRNode::Symbol(h)] => wolfram_head_name(subject) == h.as_str(),
+                // Any other Blank shape is outside the W-18 subset → no match.
+                _ => false,
+            };
+        }
+    }
+    // A literal (or an unsupported pattern node): structural equality only.
+    same_element(pattern, subject)
+}
+
+/// The **Wolfram head name** of a node, as a `Blank[h]` head constraint sees it.
+/// Atoms have fixed heads (`Integer`, `Real`, `Symbol`, `String`, `Rational`);
+/// a compound `Apply` reports its own head symbol (so `f[2]` has head `f`), or
+/// the empty string for the rare computed (non-symbol) head — which then matches
+/// no named head constraint. This is the inverse of how `_Integer`/`_Real`/`_Symbol`
+/// lower (MA04 §19.2): `_Real` is `Blank[Real]`, and a `Float` node's head is
+/// `Real`, so they line up.
+fn wolfram_head_name(node: &IRNode) -> &str {
+    match node {
+        IRNode::Integer(_) => "Integer",
+        IRNode::Float(_) => "Real",
+        IRNode::Rational(_, _) => "Rational",
+        IRNode::Str(_) => "String",
+        IRNode::Symbol(_) => "Symbol",
+        IRNode::Apply(app) => match &app.head {
+            IRNode::Symbol(s) => s.as_str(),
+            // A computed head (e.g. `(f[g])[x]`) has no symbol name; it matches
+            // no `Blank[h]` head constraint.
+            _ => "",
+        },
+    }
+}
+
+/// `MatchQ[expr, patt]` → `True` if `expr` matches `patt`, else `False`
+/// (MA04 §19.1). A thin wrapper over [`pattern_matches`]. HELD: the *subject*
+/// (`args[0]`) is evaluated here; the *pattern* (`args[1]`) stays literal. Any
+/// first argument is a valid expression to test, so `MatchQ` always reduces to a
+/// boolean; only the wrong arity leaves it unevaluated.
+fn match_q_handler(vm: &mut VM, expr: IRApply) -> IRNode {
+    if expr.args.len() != 2 {
+        return unevaluated(expr);
+    }
+    let subject = vm.eval(expr.args[0].clone());
+    let pattern = &expr.args[1];
+    bool_symbol(pattern_matches(pattern, &subject))
+}
+
+/// `Cases[list, patt]` → the `List[…]` of `list`'s elements that match `patt`,
+/// dropping non-matches (MA04 §19.1). HELD: the *list* (`args[0]`) is evaluated
+/// here; the *pattern* (`args[1]`) stays literal. A non-list first argument (or
+/// wrong arity) leaves the whole form unevaluated — "the elements of a non-list"
+/// is undefined. The input list is already bounded by `MAX_LIST_LENGTH`; the
+/// filtered result is no larger, so no new cap is needed.
+fn cases_handler(vm: &mut VM, expr: IRApply) -> IRNode {
+    if expr.args.len() != 2 {
+        return unevaluated(expr);
+    }
+    let subject = vm.eval(expr.args[0].clone());
+    let Some(elems) = list_elements(&subject) else {
+        return unevaluated(expr);
+    };
+    let pattern = expr.args[1].clone();
+    let kept: Vec<IRNode> = elems
+        .into_iter()
+        .filter(|e| pattern_matches(&pattern, e))
+        .collect();
+    apply(sym(LIST), kept)
+}
+
+/// `FreeQ[expr, form]` → `True` if `form` occurs **nowhere** within `expr`
+/// (recursively — including `expr` itself, every `Apply` head, and every
+/// argument), else `False` (MA04 §19.1, §19.3). HELD: the *expr* (`args[0]`) is
+/// evaluated here; the *form* (`args[1]`) stays literal. Any first argument is a
+/// valid expression to search, so `FreeQ` always reduces to a boolean; only the
+/// wrong arity leaves it unevaluated.
+fn free_q_handler(vm: &mut VM, expr: IRApply) -> IRNode {
+    if expr.args.len() != 2 {
+        return unevaluated(expr);
+    }
+    let subject = vm.eval(expr.args[0].clone());
+    let form = &expr.args[1];
+    // "Free of" is the negation of "occurs somewhere".
+    bool_symbol(!form_occurs_in(form, &subject, 0))
+}
+
+/// True if `form` matches `node` or any sub-part of `node` (the `Apply` head and
+/// every argument), recursed depth-first. Depth-bounded by [`FREEQ_MAX_DEPTH`]:
+/// at the cap we stop descending and report `true` ("occurs / not provably free")
+/// conservatively, so a crafted deeply nested input can never overflow the stack
+/// — `FreeQ` then answers `False` (the safe, non-panicking direction). The tree
+/// is otherwise size-bounded by `MAX_LIST_LENGTH` and the parser's nesting cap,
+/// so the cap is only reachable by pathological crafted input (MA04 §19.3).
+fn form_occurs_in(form: &IRNode, node: &IRNode, depth: usize) -> bool {
+    // Does the whole node match? (Checked at every level, including the root.)
+    if pattern_matches(form, node) {
+        return true;
+    }
+    // Depth guard: stop descending rather than risk a stack overflow. Reporting
+    // "occurs" here is conservative — it can only flip a `True` (free) to `False`
+    // (not free) on a crafted over-deep input, never panic.
+    if depth >= FREEQ_MAX_DEPTH {
+        return true;
+    }
+    // Otherwise descend into a compound node's head and arguments.
+    if let IRNode::Apply(app) = node {
+        if form_occurs_in(form, &app.head, depth + 1) {
+            return true;
+        }
+        return app
+            .args
+            .iter()
+            .any(|arg| form_occurs_in(form, arg, depth + 1));
+    }
+    // An atom that did not match itself contains nothing further.
+    false
+}
+
+/// Map a Rust `bool` to the Wolfram `True`/`False` symbol — the single
+/// boolean-result convention shared by `MatchQ`/`FreeQ` (and the W-14 predicates).
+fn bool_symbol(b: bool) -> IRNode {
+    sym(if b { "True" } else { "False" })
 }
 
 /// `Boole[True]` → `1`, `Boole[False]` → `0`; anything else (a non-boolean
@@ -4793,5 +4986,160 @@ mod tests {
         assert_eq!(eval_full(apply(sym("Sqrt"), vec![int(2)])), apply(sym("Sqrt"), vec![int(2)]));
         assert_eq!(eval_full(apply(sym("GCD"), vec![int(12), int(18)])), int(6));
         assert_eq!(eval_full(apply(sym("Round"), vec![flt(2.5)])), int(2));
+    }
+
+    // -----------------------------------------------------------------------
+    // W-18 pattern-matching predicates — MatchQ / Cases / FreeQ
+    // -----------------------------------------------------------------------
+    //
+    // These handlers are HELD (`PATTERN_HEADS`), so we route through `eval_full`
+    // (the real `WolframBackend`, which installs the hold set) and build the
+    // pattern argument as a *literal* `Blank` node directly — exactly the shape
+    // `lower.rs` produces for `_` (`Blank[]`) and `_h` (`Blank[h]`). The bare
+    // `_` helper `blank()` is shared with the W-14 Switch tests above.
+
+    /// `_h` — `Blank[h]`, a head-typed blank (e.g. `Blank[Integer]` for `_Integer`).
+    fn blank_h(h: &str) -> IRNode {
+        apply(sym(BLANK), vec![sym(h)])
+    }
+
+    #[test]
+    fn match_q_literal_blank_and_head_typed() {
+        // `MatchQ[2, _]` → True (the catch-all).
+        assert_eq!(eval_full(apply(sym("MatchQ"), vec![int(2), blank()])), sym("True"));
+        // `MatchQ[2, _Integer]` → True (head `Integer` matches an `Integer` atom).
+        assert_eq!(
+            eval_full(apply(sym("MatchQ"), vec![int(2), blank_h("Integer")])),
+            sym("True")
+        );
+        // `MatchQ[2, 2]` → True (literal structural equality).
+        assert_eq!(eval_full(apply(sym("MatchQ"), vec![int(2), int(2)])), sym("True"));
+        // `MatchQ[2, 3]` → False (distinct literals).
+        assert_eq!(eval_full(apply(sym("MatchQ"), vec![int(2), int(3)])), sym("False"));
+    }
+
+    #[test]
+    fn match_q_integer_real_head_distinction() {
+        // `MatchQ[2.0, _Integer]` → False: a `Float`'s Wolfram head is `Real`,
+        // not `Integer`, so the `Blank[Integer]` constraint fails.
+        assert_eq!(
+            eval_full(apply(sym("MatchQ"), vec![flt(2.0), blank_h("Integer")])),
+            sym("False")
+        );
+        // `MatchQ[2.0, _Real]` → True: `Float` ↔ head `Real`.
+        assert_eq!(
+            eval_full(apply(sym("MatchQ"), vec![flt(2.0), blank_h("Real")])),
+            sym("True")
+        );
+        // `MatchQ[x, _Symbol]` → True: a `Symbol`'s head is `Symbol`.
+        assert_eq!(
+            eval_full(apply(sym("MatchQ"), vec![sym("x"), blank_h("Symbol")])),
+            sym("True")
+        );
+        // A head-typed blank against a compound: `MatchQ[f[1], _f]` → True.
+        assert_eq!(
+            eval_full(apply(sym("MatchQ"), vec![apply(sym("f"), vec![int(1)]), blank_h("f")])),
+            sym("True")
+        );
+    }
+
+    #[test]
+    fn match_q_wrong_arity_stays_unevaluated() {
+        // One argument is not a valid `MatchQ` call → echoes unevaluated.
+        assert_eq!(
+            eval_full(apply(sym("MatchQ"), vec![int(2)])),
+            apply(sym("MatchQ"), vec![int(2)])
+        );
+    }
+
+    #[test]
+    fn cases_filters_by_pattern() {
+        let l4 = list(vec![int(1), int(2), int(3), int(4)]);
+        // `Cases[{1,2,3,4}, _]` → every element (catch-all).
+        assert_eq!(
+            eval_full(apply(sym("Cases"), vec![l4.clone(), blank()])),
+            l4.clone()
+        );
+        // `Cases[{1,2,3}, 2]` → {2} (literal match keeps only equal elements).
+        assert_eq!(
+            eval_full(apply(sym("Cases"), vec![list(vec![int(1), int(2), int(3)]), int(2)])),
+            list(vec![int(2)])
+        );
+        // `Cases[{1, 2.0, 3}, _Integer]` → {1, 3}: the `Float` 2.0 has head `Real`
+        // and is dropped; only the two `Integer` atoms survive.
+        assert_eq!(
+            eval_full(apply(
+                sym("Cases"),
+                vec![list(vec![int(1), flt(2.0), int(3)]), blank_h("Integer")]
+            )),
+            list(vec![int(1), int(3)])
+        );
+    }
+
+    #[test]
+    fn cases_empty_and_non_list() {
+        // Empty list → empty list (no elements to keep).
+        assert_eq!(
+            eval_full(apply(sym("Cases"), vec![list(vec![]), blank()])),
+            list(vec![])
+        );
+        // A non-list first argument leaves the whole form unevaluated.
+        assert_eq!(
+            eval_full(apply(sym("Cases"), vec![int(5), blank()])),
+            apply(sym("Cases"), vec![int(5), blank()])
+        );
+    }
+
+    #[test]
+    fn free_q_membership_and_nesting() {
+        let l = list(vec![int(1), int(2), int(3)]);
+        // `FreeQ[{1,2,3}, 2]` → False (2 occurs as an element).
+        assert_eq!(eval_full(apply(sym("FreeQ"), vec![l.clone(), int(2)])), sym("False"));
+        // `FreeQ[{1,2,3}, 5]` → True (5 is absent).
+        assert_eq!(eval_full(apply(sym("FreeQ"), vec![l, int(5)])), sym("True"));
+        // `FreeQ[f[g[2]], g]` → False: the symbol `g` appears as a nested head.
+        let fg2 = apply(sym("f"), vec![apply(sym("g"), vec![int(2)])]);
+        assert_eq!(
+            eval_full(apply(sym("FreeQ"), vec![fg2.clone(), sym("g")])),
+            sym("False")
+        );
+        // `FreeQ[f[g[2]], h]` → True: `h` does not occur anywhere.
+        assert_eq!(eval_full(apply(sym("FreeQ"), vec![fg2, sym("h")])), sym("True"));
+    }
+
+    #[test]
+    fn free_q_deeply_nested_input_is_bounded_no_overflow() {
+        // Craft an expression nested far deeper than FREEQ_MAX_DEPTH: `f[f[f[…x…]]]`.
+        // The depth guard turns a potential stack overflow into a bounded answer
+        // (it reports "occurs" at the cap), so this must NOT panic.
+        let mut nested = sym("x");
+        for _ in 0..(FREEQ_MAX_DEPTH + 50) {
+            nested = apply(sym("f"), vec![nested]);
+        }
+        // `h` is genuinely absent, but past the cap we conservatively answer
+        // False (not provably free). Either way: no panic, a Boolean result.
+        let out = eval_full(apply(sym("FreeQ"), vec![nested, sym("h")]));
+        assert!(out == sym("True") || out == sym("False"));
+    }
+
+    #[test]
+    fn free_q_wrong_arity_stays_unevaluated() {
+        assert_eq!(
+            eval_full(apply(sym("FreeQ"), vec![int(2)])),
+            apply(sym("FreeQ"), vec![int(2)])
+        );
+    }
+
+    #[test]
+    fn pattern_matches_heterogeneous_does_not_panic() {
+        // Comparing across atom kinds (Integer vs Float vs Symbol vs String)
+        // must be total and never panic — it simply reports no match.
+        assert!(!pattern_matches(&int(2), &flt(2.0)));
+        assert!(!pattern_matches(&flt(2.0), &int(2)));
+        assert!(!pattern_matches(&sym("x"), &int(2)));
+        assert!(!pattern_matches(&str_node("x"), &sym("x")));
+        // A Blank with an unsupported (non-symbol head) shape never matches.
+        let weird_blank = apply(sym(BLANK), vec![int(1), int(2)]);
+        assert!(!pattern_matches(&weird_blank, &int(1)));
     }
 }

--- a/code/specs/MA04-wolfram-language.md
+++ b/code/specs/MA04-wolfram-language.md
@@ -1418,6 +1418,125 @@ applications. W-15 touches only `wolfram-runtime`'s builtin handler table; the
 lexer, parser, and grammar files are untouched. `Mod`, `Power`, and `N` are
 reused unchanged.
 
+## §19 W-18 pattern-matching builtins — `MatchQ`, `Cases`, `FreeQ` (implemented)
+
+W-14's `Switch` introduced the first taste of pattern matching: a `form_matches`
+helper that decides whether an evaluated subject equals a literal form *or* is a
+catch-all `Blank[]`. W-18 promotes that idea into three first-class
+**pattern-matching predicates** every introductory Wolfram session reaches for:
+`MatchQ` (does this expression match this pattern?), `Cases` (keep the list
+elements that match), and `FreeQ` (does this form appear *anywhere* inside?).
+
+Like every head since W-5 these are ordinary `Head[args]` applications — **no
+grammar change**. W-18 touches only `wolfram-runtime`'s builtin handler table
+(`builtins.rs`) and the `WolframBackend` held set (`backend.rs`).
+
+### §19.1 What W-18 adds
+
+| Head      | Arity | Held? | Result                                                                  |
+|-----------|-------|-------|------------------------------------------------------------------------|
+| `MatchQ`  | 2     | yes   | `True` if `expr` matches `patt`, else `False`                           |
+| `Cases`   | 2     | yes   | the `List[…]` of `list`'s elements that match `patt` (non-matches dropped) |
+| `FreeQ`   | 2     | yes   | `True` if `form` occurs **nowhere** in `expr` (recursively), else `False` |
+
+Worked examples (the W-18 acceptance tests):
+
+```
+MatchQ[2, _]                        (* → True  — _ matches anything           *)
+MatchQ[2, _Integer]                 (* → True  — 2 has head Integer           *)
+MatchQ[2.0, _Integer]              (* → False — 2.0 has head Real, not Integer*)
+MatchQ[2, 3]                        (* → False — literals differ              *)
+MatchQ[2, 2]                        (* → True  — literals equal               *)
+Cases[{1, 2, 3, 4}, _]              (* → {1, 2, 3, 4} — every element matches  *)
+Cases[{1, 2, 3}, 2]                 (* → {2} — only the literal 2 matches      *)
+Cases[{1, 2.0, 3}, _Integer]        (* → {1, 3} — 2.0 is Real, dropped         *)
+FreeQ[{1, 2, 3}, 2]                 (* → False — 2 occurs                      *)
+FreeQ[{1, 2, 3}, 5]                 (* → True  — 5 never occurs                *)
+FreeQ[f[g[2]], g]                   (* → False — g occurs as the inner head    *)
+FreeQ[f[g[2]], h]                   (* → True  — h occurs nowhere              *)
+```
+
+### §19.2 The supported-pattern subset (and the single match primitive)
+
+W-18 deliberately ships a **small, solid** pattern vocabulary — exactly what the
+W-14 matcher already understood, promoted to *enforce* the head constraint that
+`Switch` treated as a no-op:
+
+* **literal patterns** — any non-`Blank` node; matches iff it is *structurally
+  equal* to the subject under the W-13 `same_element` comparator (so `2` and
+  `2.0` stay distinct, `f[1]` matches `f[1]` recursively);
+* **`_` (`Blank[]`)** — the catch-all; matches any subject;
+* **head-typed blanks `_Integer`/`_Real`/`_Symbol`/`_h` (`Blank[h]`)** — matches
+  iff the subject's *Wolfram head* is exactly `h`. The head of each atom is
+  fixed: `Integer → Integer`, `Float → Real`, `Symbol → Symbol`, `Str → String`,
+  `Rational → Rational`; a compound `Apply` reports its own head symbol (so
+  `f[2]` matches `_f`). This is the **one divergence from W-14**: `Switch`
+  treated `Blank[h]` as a plain catch-all (head ignored); W-18 *enforces* the
+  head so `Cases[{1, 2.0, 3}, _Integer]` correctly drops the `Real`.
+
+All three builtins funnel through a single match primitive, `pattern_matches`,
+which is the W-14 `form_matches` extended with head-constraint enforcement. There
+is no second matcher — `MatchQ` is a one-line wrapper, `Cases` filters a list
+through it, and `FreeQ` walks every subnode through it.
+
+### §19.3 `FreeQ` — the recursive walk and its depth bound
+
+`FreeQ[expr, form]` answers "does `form` occur *nowhere* in `expr`?" by checking
+`pattern_matches(form, node)` at **every** node of `expr` — the whole expression,
+each `Apply` head, and every argument, recursively. The first match short-circuits
+to `False`; if the walk completes with no match the answer is `True`.
+
+The recursion is **depth-bounded** (`FREEQ_MAX_DEPTH`, 512) so a crafted deeply
+nested input cannot overflow the stack: at the cap the walk reports "not free
+here" conservatively rather than recursing further, and the surrounding tree is
+already size-bounded by the parser's nesting cap and `MAX_LIST_LENGTH`. No new
+allocation beyond the bounded traversal occurs; `Cases`/`MatchQ` iterate
+already-materialised, `MAX_LIST_LENGTH`-bounded lists.
+
+### §19.4 Held, with the subject evaluated; the pattern stays literal
+
+`MatchQ`, `Cases`, and `FreeQ` join the `WolframBackend` held set (alongside
+`If`, the W-7 iteration heads, the W-8 scoping heads, and the W-14 conditionals).
+Holding keeps the **pattern** argument literal — `MatchQ[2, 1 + 1]` must match
+against the *form* `Plus[1, 1]`, not the evaluated `2`, exactly as `Switch`
+matches held forms (MA04 §17.2). Each handler then evaluates only the *subject*
+(or list / expr) itself via `vm.eval`, never the pattern. `Blank[h]` survives
+evaluation unchanged regardless (no `Blank` handler exists), but holding makes
+the literal-pattern contract explicit and uniform with `Switch`.
+
+### §19.5 The "I can't reduce this" contract
+
+Following the established convention, each W-18 handler echoes the application
+**unchanged** (never panicking) on malformed input: wrong arity (`MatchQ[2]`,
+`Cases[{1}]`), or — for `Cases` — a non-list first argument (`Cases[5, _]` stays
+unevaluated, since "the elements of `5`" is undefined). `MatchQ`/`FreeQ` accept
+*any* first argument (an atom is a valid expression to test), so they always
+reduce to `True`/`False`. No W-18 head panics on heterogeneous element
+comparison — `same_element` is total and panic-free (built on `f64::total_cmp`).
+
+### §19.6 Deferred to W-19 (explicitly out of scope)
+
+W-18 ships the three core predicates over the *existing* matcher capability and
+**defers** the rest of Wolfram's pattern algebra — none of the following is
+supported, and each is left unevaluated / treated as a literal as appropriate:
+
+* **named patterns** `x_` (`Pattern[x, Blank[]]`) — binding match captures;
+* **alternatives** `a | b` (`Alternatives`);
+* **conditions** `patt /; test` (`Condition`) and **`PatternTest`** `patt ? fn`;
+* **`Repeated`** `patt..`, **`BlankSequence`** `__`, **`BlankNullSequence`** `___`;
+* **replacement** `expr /. rules`, `Replace`, `ReplaceAll`, `ReplaceRepeated`.
+
+These build on the same `pattern_matches` primitive but require capture binding,
+backtracking, and rule application that balloon the matcher well beyond the W-18
+core; they are scheduled for **W-19**.
+
+### §19.7 No grammar change
+
+`MatchQ[…]`, `Cases[…]`, and `FreeQ[…]` are ordinary `Head[args]` applications.
+W-18 touches only `wolfram-runtime`'s builtin handler table and the held set; the
+lexer, parser, and grammar files are untouched. The `Blank`/`Pattern` node
+vocabulary is reused unchanged from `cas-pattern-matching`.
+
 ### §6 References
 
 Internal: [`HML00`](HML00-historical-math-languages-roadmap.md),


### PR DESCRIPTION
## W-18 — Wolfram pattern-matching predicates

Implements MA04 §19 in `wolfram-runtime`: the pattern-matching predicates **`MatchQ`**, **`Cases`**, and **`FreeQ`**. All ordinary `Head[args]` forms — **no grammar change**; only the builtin handler table grows. The spec (MA04 §19) was committed first.

### Additions
- **`MatchQ[expr, patt]`** → `True`/`False`. `MatchQ[2, _]`→`True`, `MatchQ[2, _Integer]`→`True`, `MatchQ[2, 2]`→`True`, `MatchQ[2, 3]`→`False`.
- **`Cases[list, patt]`** → the `List` of matching elements. `Cases[{1,2,3,4}, _]`→`{1,2,3,4}`, `Cases[{1,2,3}, 2]`→`{2}`, `Cases[{1,2.0,3}, _Integer]`→`{1,3}`.
- **`FreeQ[expr, form]`** → `True` iff `form` occurs nowhere in `expr` (recursive). `FreeQ[{1,2,3},2]`→`False`, `FreeQ[{1,2,3},5]`→`True`, `FreeQ[f[g[2]],g]`→`False`, `FreeQ[f[g[2]],h]`→`True`.
- The three heads are **held** (new `PATTERN_HEADS` folded into the `WolframBackend` hold set) so the **pattern** argument arrives **literal** — a pattern is a form, not a value (as `Switch` relies on). Each handler evaluates only its subject.
- A single panic-free `pattern_matches` primitive extends the W-14 `Switch` matcher by **enforcing** the `Blank[h]` head constraint, reusing the W-13 `same_element` comparator for literals.

### Supported pattern subset
Literal (structural equality), `_` (`Blank[]`, catch-all), and head-typed `_h` (`Blank[h]`). The lowerer turns `_Integer`→`Blank[Integer]`, `_Real`→`Blank[Real]`, `_Symbol`→`Blank[Symbol]`; the matcher's head map sends an `Integer` atom→`Integer`, a `Float`→`Real`, a symbol→`Symbol`. So `MatchQ[2.0, _Integer]`→`False` (a float is `_Real`).

### Deferred to W-19 (MA04 §19.6)
Named patterns `x_`, alternatives `a|b`, conditions `patt/;t`, `PatternTest`, blank sequences `__`, and replacement `/.`/`Replace`. A named blank falls through to the literal branch and simply fails to match an evaluated value rather than mis-binding.

### Robustness
- `FreeQ`'s recursive tree walk is **depth-bounded** (`FREEQ_MAX_DEPTH = 512`): a crafted over-deep input yields a safe bounded answer rather than a stack overflow.
- Heterogeneous atom comparison is total and never panics.
- `Cases` output inherits the input's `MAX_LIST_LENGTH` bound (it's a filter, never additive).

### Tests
- 9 handler-level unit tests in `wolfram-runtime` (literal/blank/head-typed, Integer-vs-Real head distinction, `Cases` filtering + empty/non-list, `FreeQ` membership/nesting + depth-bound no-overflow + heterogeneous no-panic, wrong-arity unevaluated).
- 1 end-to-end `wolfram-repl` test through the real `_Integer`/`_Real` lowering (parse→lower→eval).

All green via `cargo test -p coding-adventures-wolfram-runtime -p coding-adventures-wolfram-repl`. A Rust security sub-agent reviewed the diff: no CRITICAL/HIGH issues introduced by W-18 (panic-free, size-bounded, correctly held, FreeQ recursion capped).

### Coordination
Independent of in-flight **W-16** but touches the same files (`builtins.rs` handler table, `CHANGELOG.md`) — may need trivial conflict resolution at merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)