### PR TITLE
feat(mycin-pharm): ground organophosphate & toxic-alcohol antidotes (toxicology recall)

### DIFF
--- a/code/specs/data/mycin-2026/recall/pharm-edges.adj
+++ b/code/specs/data/mycin-2026/recall/pharm-edges.adj
@@ -110,4 +110,16 @@ rulebook pharm_facts {
         source "Oral vitamin K lowers the international normalized ratio more rapidly than subcutaneous vitamin K in the treatment of warfarin-associated coagulopathy."
         locator "https://www.ncbi.nlm.nih.gov/books/NBK557622/"
         trust authoritative
+
+    % --- EXPAND: atropine is the primary treatment for organophosphate poisoning ----
+    relate antidote_for(organophosphate_poisoning, atropine)
+        source "The primary treatment for organophosphate poisoning involves atropine, which competes with acetylcholine at the muscarinic receptors."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK470430/"
+        trust authoritative
+
+    % --- EXPAND: fomepizole is the antidote of choice for toxic alcohol poisoning --
+    relate antidote_for(toxic_alcohol_poisoning, fomepizole)
+        source "Fomepizole is the antidote of choice for patients who present early after toxic alcohol exposure."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK482121/"
+        trust authoritative
 }

--- a/code/specs/data/mycin-2026/recall/pharm-recall.query.adj
+++ b/code/specs/data/mycin-2026/recall/pharm-recall.query.adj
@@ -23,3 +23,5 @@ import "pharm-edges.adj"
 ? antidote_for(heparin_overdose, $Antidote)      % expect protamine (expand)
 ? antidote_for(digoxin_toxicity, $Antidote)      % expect digoxin_immune_fab (expand)
 ? antidote_for(warfarin_toxicity, $Antidote)     % expect vitamin_k (expand)
+? antidote_for(organophosphate_poisoning, $Antidote)  % expect atropine (expand)
+? antidote_for(toxic_alcohol_poisoning, $Antidote)    % expect fomepizole (expand)

--- a/code/specs/data/mycin-2026/recall/test_pharm_recall.py
+++ b/code/specs/data/mycin-2026/recall/test_pharm_recall.py
@@ -42,6 +42,8 @@ EXPECTED = [
     ("heparin_overdose", "antidote_for", "protamine"),   # expand (NBK547753)
     ("digoxin_toxicity", "antidote_for", "digoxin_immune_fab"),   # expand (NBK556101)
     ("warfarin_toxicity", "antidote_for", "vitamin_k"),           # expand (NBK557622)
+    ("organophosphate_poisoning", "antidote_for", "atropine"),    # expand (NBK470430)
+    ("toxic_alcohol_poisoning", "antidote_for", "fomepizole"),    # expand (NBK482121)
 ]
 VAR = {"drug_class": "Class", "mechanism": "MOA", "adverse_effect": "Effect",
        "antidote_for": "Antidote"}


### PR DESCRIPTION
## What

Second toxicology-antidote expansion of the pharm recall library, two high-yield board pairs:

- **antidote_for(organophosphate_poisoning, atropine)** — NBK470430:
  > The primary treatment for organophosphate poisoning involves atropine, which competes with acetylcholine at the muscarinic receptors.
- **antidote_for(toxic_alcohol_poisoning, fomepizole)** — NBK482121:
  > Fomepizole is the antidote of choice for patients who present early after toxic alcohol exposure.

Both `trust authoritative`, each a single self-contained StatPearls span naming the poisoning **and** the antidote. They join the existing antidotes (naloxone/opioid, flumazenil/benzo, acetylcysteine/acetaminophen, protamine/heparin, digoxin_immune_fab/digoxin, vitamin_k/warfarin) — same `antidote_for` relation, no new domain.

## Changes (data-only)

- `pharm-edges.adj` — +2 `relate` clauses (inline source+locator)
- `pharm-recall.query.adj` — +2 binding queries
- `test_pharm_recall.py` — `EXPECTED` +2; `ibuprofen` negative-control abstain test unchanged

## Verification

- `test_pharm_recall: 3/3 passed` (engine binds `atropine` / `fomepizole` with authoritative citations; `relate` count == EXPECTED; off-vocabulary drug abstains)
- ruff clean; data-only security review passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)