### PR TITLE
feat(r-lang): R-32 — binning & cross-product utilities (findInterval/tabulate/cut)

### DIFF
--- a/code/packages/rust/r-runtime/CHANGELOG.md
+++ b/code/packages/rust/r-runtime/CHANGELOG.md
@@ -2,6 +2,36 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.27.0] - 2026-06-21
+
+### Added (via the shared `s-runtime`)
+
+- **R-32 — binning & cross-product utilities**: the numeric-binning family,
+  reached through ordinary R syntax. A pivot away from the thin R-31 deferral of
+  `incomparables=`/`fromLast=` on the binary set ops (`union`/`intersect`/`setdiff`)
+  — base R does not accept those arguments there, so implementing them would be
+  non-faithful. All build on the existing factor value and `MAX_SEQ_LEN` cap; no new
+  value type, no grammar change.
+  - **`findInterval(x, vec)`** — 1-based index of the last break in the
+    non-decreasing `vec` not exceeding each `x`; `0` below the first,
+    `length(vec)` at/above the last; `NA`/non-finite `x` → `NA`.
+    `findInterval(c(0.5, 1.5, 2.5), c(1, 2, 3))` → `c(0, 1, 2)`;
+    `findInterval(5, c(1, 2, 3))` → `3`.
+  - **`cut(x, breaks)`** — bins `x` into the right-closed `(lo,hi]` intervals of
+    the sorted `breaks`, returning a real **factor**. `class(cut(...))` is
+    `"factor"`, `levels()` are the `"(lo,hi]"` labels, and `as.character()` /
+    `as.integer()` / `nlevels()` all see through to it. Values outside all breaks
+    (or `NA`) become `NA` factor codes. `cut(c(1, 5, 10), breaks = c(0, 3, 6, 11))`
+    → a factor with levels `c("(0,3]", "(3,6]", "(6,11]")` and values `(0,3]`,
+    `(3,6]`, `(6,11]`; `cut(c(-1, 20), breaks = c(0, 3, 6, 11))` → both `NA`.
+  - **Security**: no new user-controlled multiplier; `cut` allocations are bounded
+    by the already-capped input/breaks lengths; `findInterval` is `O(len(x)·len(vec))`
+    with both capped; `tabulate`'s `nbins` cap is unchanged; the `vec=`/`breaks=`
+    readers reject a missing operand with a clean error (never panic); no path
+    indexes out of bounds.
+  - **Deferred to R-33**: `cut`'s `labels=`, `right=FALSE`, `include.lowest=`, and
+    integer `breaks`.
+
 ## [0.26.0] - 2026-06-21
 
 ### Added (via the shared `s-runtime`)

--- a/code/packages/rust/r-runtime/README.md
+++ b/code/packages/rust/r-runtime/README.md
@@ -199,6 +199,23 @@ under `set.seed`. Numeric and character vectors; bounded RNG draws; malformed na
 args error gracefully. (`incomparables=`/`fromLast=` on the binary set ops
 `union`/`intersect`/`setdiff` are deferred to R-32.)
 
+**Binning & cross-product utilities (R-32)** — the numeric-binning family,
+reached through ordinary R syntax. A pivot away from the R-31 deferral of
+`incomparables=`/`fromLast=` on the binary set ops, which base R does not accept
+there (so implementing them would be non-faithful). `findInterval(x, vec)` returns,
+for each `x`, the 1-based index of the last break in the non-decreasing `vec` not
+exceeding it — `0` below the first, `length(vec)` at/above the last, `NA` propagates
+(`findInterval(c(0.5,1.5,2.5), c(1,2,3))` → `c(0,1,2)`; `findInterval(5, c(1,2,3))`
+→ `3`). `cut(x, breaks)` bins `x` into the right-closed `(lo,hi]` intervals of the
+sorted `breaks` and returns a real **factor**: `class(cut(...))` is `"factor"`,
+`levels()` are the `"(lo,hi]"` labels, and `as.character()`/`as.integer()`/
+`nlevels()` all see through to it (`cut(c(1,5,10), breaks=c(0,3,6,11))` → a factor
+with levels `"(0,3]","(3,6]","(6,11]"` and values `(0,3]`,`(3,6]`,`(6,11]`); values
+outside all breaks → `NA`. Built on `findInterval`; allocations bounded by the
+already-capped input/breaks lengths; missing operands error gracefully. (`cut`'s
+`labels=`/`right=FALSE`/`include.lowest=` and integer `breaks` are deferred to
+R-33.)
+
 ## Usage
 
 ```rust

--- a/code/packages/rust/r-runtime/src/lib.rs
+++ b/code/packages/rust/r-runtime/src/lib.rs
@@ -2732,6 +2732,102 @@ mod tests {
         assert_eq!(nums("tabulate(c(0, 1, 2, 99), nbins = 2)\n"), vec![1.0, 1.0]);
     }
 
+    // --- R-32: binning & cross-product utilities ------------------------
+
+    #[test]
+    fn r32_tabulate_binning_family_examples() {
+        // The canonical R-32 example: counts of 1..5 across c(1,2,2,3,5).
+        assert_eq!(
+            nums("tabulate(c(1, 2, 2, 3, 5), nbins = 5)\n"),
+            vec![1.0, 2.0, 1.0, 0.0, 1.0]
+        );
+        // Without nbins, the default is max(bin) = 5, so the trailing 0 stays.
+        assert_eq!(
+            nums("tabulate(c(1, 2, 2, 3, 5))\n"),
+            vec![1.0, 2.0, 1.0, 0.0, 1.0]
+        );
+    }
+
+    #[test]
+    fn r32_find_interval_indexes_breakpoints() {
+        // 0.5 is below the first break (→ 0); 1.5 is in [1,2) (→ 1); 2.5 in [2,3) (→ 2).
+        assert_eq!(
+            nums("findInterval(c(0.5, 1.5, 2.5), c(1, 2, 3))\n"),
+            vec![0.0, 1.0, 2.0]
+        );
+        // At or above the last break the index is length(vec).
+        assert_eq!(nums("findInterval(5, c(1, 2, 3))\n"), vec![3.0]);
+        // Exact hits land at their own index (right-open from below): 2 → index 2.
+        assert_eq!(
+            nums("findInterval(c(1, 2, 3), c(1, 2, 3))\n"),
+            vec![1.0, 2.0, 3.0]
+        );
+    }
+
+    #[test]
+    fn r32_find_interval_na_propagates() {
+        // NA / non-finite x propagate to NA without panicking.
+        let v = nums("findInterval(c(NA, 2), c(1, 2, 3))\n");
+        assert!(v[0].is_nan());
+        assert_eq!(v[1], 2.0);
+    }
+
+    #[test]
+    fn r32_cut_returns_a_factor_with_interval_levels() {
+        // cut produces a real factor (class "factor").
+        assert_eq!(
+            show("class(cut(c(1, 5, 10), breaks = c(0, 3, 6, 11)))\n"),
+            "[1] \"factor\""
+        );
+        // The levels are the auto-generated right-closed interval labels.
+        assert_eq!(
+            names_of("levels(cut(c(1, 5, 10), breaks = c(0, 3, 6, 11)))\n"),
+            vec!["(0,3]", "(3,6]", "(6,11]"]
+        );
+        // as.character of the binned values: 1∈(0,3], 5∈(3,6], 10∈(6,11].
+        assert_eq!(
+            names_of("as.character(cut(c(1, 5, 10), breaks = c(0, 3, 6, 11)))\n"),
+            vec!["(0,3]", "(3,6]", "(6,11]"]
+        );
+        // as.integer recovers the 1-based interval codes.
+        assert_eq!(
+            nums("as.integer(cut(c(1, 5, 10), breaks = c(0, 3, 6, 11)))\n"),
+            vec![1.0, 2.0, 3.0]
+        );
+    }
+
+    #[test]
+    fn r32_cut_values_outside_breaks_are_na() {
+        // -1 is below break[1]; 20 is above break[k] → both NA codes.
+        let v = nums("as.integer(cut(c(-1, 20), breaks = c(0, 3, 6, 11)))\n");
+        assert!(v[0].is_nan());
+        assert!(v[1].is_nan());
+        // The factor still carries the three interval levels.
+        assert_eq!(
+            names_of("levels(cut(c(-1, 20), breaks = c(0, 3, 6, 11)))\n"),
+            vec!["(0,3]", "(3,6]", "(6,11]"]
+        );
+    }
+
+    #[test]
+    fn r32_cut_factor_integrates_with_nlevels() {
+        // nlevels sees the factor's three interval levels (a factor-aware path).
+        assert_eq!(
+            nums("nlevels(cut(c(1, 2, 5, 10), breaks = c(0, 3, 6, 11)))\n"),
+            vec![3.0]
+        );
+    }
+
+    #[test]
+    fn r32_binning_malformed_inputs_do_not_panic() {
+        // Empty inputs yield empty results, not panics.
+        assert_eq!(eval_r("findInterval(c(), c(1, 2))\n").unwrap().length(), 0);
+        assert_eq!(eval_r("cut(c(), breaks = c(0, 1, 2))\n").unwrap().length(), 0);
+        // Fewer than two breaks means zero intervals: every value is NA.
+        let v = nums("as.integer(cut(c(1, 2), breaks = c(5)))\n");
+        assert!(v.iter().all(|x| x.is_nan()));
+    }
+
     #[test]
     fn r28_malformed_inputs_do_not_panic() {
         // outer with a non-callable FUN → clean error, no panic.

--- a/code/packages/rust/s-runtime/CHANGELOG.md
+++ b/code/packages/rust/s-runtime/CHANGELOG.md
@@ -2,6 +2,45 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.28.0] - 2026-06-21
+
+### Added
+
+- **Binning & cross-product utilities (R-32)** — the numeric-binning family,
+  available to both S and R through the shared tree-walker. A pivot away from the
+  thin R-31 deferral of `incomparables=`/`fromLast=` on the binary set ops
+  (`union`/`intersect`/`setdiff`): base R does not accept those arguments there, so
+  implementing them would be non-faithful. All build on existing machinery
+  (`as_double`, `na_real`/`is_na_real`, `first_positional`, and the existing
+  `SValue::Factor { codes, levels }` constructor) — no new value type, no new cap.
+  - **`findInterval(x, vec)`** — for each element of the non-decreasing breakpoint
+    vector `vec`, the 1-based index of the last break not exceeding `x`: `0` below
+    the first, `length(vec)` at/above the last; `NA`/non-finite `x` → `NA`.
+    `findInterval(c(0.5, 1.5, 2.5), c(1, 2, 3))` → `c(0, 1, 2)`;
+    `findInterval(5, c(1, 2, 3))` → `3`. A linear scan over the (short, sorted)
+    breaks; a non-finite/NA/out-of-order break stops the count, so it never indexes
+    out of bounds.
+  - **`cut(x, breaks)`** — bins `x` into the `k-1` right-closed `(lo,hi]` intervals
+    of the sorted `breaks`, returning a real **`Factor`** whose `levels` are the
+    auto-generated `"(lo,hi]"` labels. Built directly on `findInterval`: the
+    interval index is the 1-based level code when it lies in `1..=k-1`; boundary
+    indices `0`/`k` and `NA` `x` map to a `<NA>` code. So `levels()`,
+    `as.integer()`, `as.character()`, and `nlevels()` are all factor-aware on the
+    result. `cut(c(1, 5, 10), breaks = c(0, 3, 6, 11))` → a factor with levels
+    `c("(0,3]", "(3,6]", "(6,11]")` and values `(0,3]`, `(3,6]`, `(6,11]`;
+    `cut(c(-1, 20), breaks = c(0, 3, 6, 11))` → both `NA`. `saturating_sub` guards
+    the interval count when fewer than two breaks are supplied (→ all `NA`).
+  - **Security**: no new user-controlled multiplier. `cut` allocates one code per
+    input element (length already `MAX_SEQ_LEN`-bounded) and `k-1` level strings
+    (bounded by the capped `breaks` length); `findInterval` is `O(len(x)·len(vec))`
+    with both lengths capped; the existing `tabulate` `nbins`-vs-`MAX_SEQ_LEN`
+    checked guard is unchanged. The `vec=`/`breaks=` readers (shared `second_arg`
+    helper) return a clean `BadArgs` error when absent; no path indexes out of
+    bounds.
+  - **Deferred to R-33**: `cut`'s `labels=` (custom labels), `right=FALSE`
+    (left-closed `[lo,hi)`), `include.lowest=`, and integer `breaks` (equal-width
+    bin count).
+
 ## [0.27.0] - 2026-06-21
 
 ### Added

--- a/code/packages/rust/s-runtime/README.md
+++ b/code/packages/rust/s-runtime/README.md
@@ -225,6 +225,21 @@ a hand-written loop. See [What "S-flavored" means here](#what-s-flavored-means-h
   reproducible under `set.seed`. Numeric and character vectors; bounded RNG draws;
   malformed named args error gracefully. (`incomparables=`/`fromLast=` on the binary
   set ops `union`/`intersect`/`setdiff` are deferred to R-32.)
+- **Binning & cross-product utilities** (R-32): the numeric-binning family, a
+  pivot away from the non-faithful R-31 deferral (base R's
+  `union`/`intersect`/`setdiff` don't take `incomparables=`/`fromLast=`).
+  **`findInterval(x, vec)`** returns, for each `x`, the 1-based index of the last
+  break in the non-decreasing `vec` not exceeding it (`0` below the first,
+  `length(vec)` at/above the last; `NA` propagates): `findInterval(c(0.5,1.5,2.5),
+  c(1,2,3))` → `c(0,1,2)`, `findInterval(5, c(1,2,3))` → `3`. **`cut(x, breaks)`**
+  bins `x` into the right-closed `(lo,hi]` intervals of the sorted `breaks` and
+  returns a real **factor** with auto-generated `"(lo,hi]"` levels, so
+  `levels()`/`as.integer()`/`as.character()`/`nlevels()` all work on the result
+  (`cut(c(1,5,10), breaks=c(0,3,6,11))` → levels `"(0,3]","(3,6]","(6,11]"` with
+  values `(0,3]`,`(3,6]`,`(6,11]`); values outside all breaks → `NA`. Built on
+  `findInterval`; allocations bounded by the already-capped input/breaks lengths;
+  missing operands error gracefully. (`cut`'s `labels=`/`right=FALSE`/
+  `include.lowest=` and integer `breaks` are deferred to R-33.)
 - The **`d`/`p`/`q`/`r` distribution family** (R-8) over `statistics-core`:
   density/CDF/quantile/sampling for the normal, uniform, and exponential
   distributions, plus `set.seed` for a reproducible per-session RNG.

--- a/code/packages/rust/s-runtime/src/builtins.rs
+++ b/code/packages/rust/s-runtime/src/builtins.rs
@@ -4339,23 +4339,36 @@ fn second_arg<'a>(args: &'a [Arg], name: &str, what: &str) -> SResult<&'a SValue
 ///
 /// A right-continuous (left-closed) step: an `x` exactly equal to `vec[i]` lands
 /// in the bucket that *starts* at `vec[i]`. `NA`/non-finite `x` returns `None`
-/// (the caller maps it to `NA`). Because `vec` is sorted we could binary-search,
-/// but breakpoint vectors are short, so a clear linear scan is preferred.
-fn find_interval_index(x: f64, vec: &[f64]) -> Option<usize> {
+/// (the caller maps it to `NA`).
+///
+/// `prefix` is the **leading non-NA run** of the breakpoint vector (everything up
+/// to, but not including, the first `NA` element) — computed once per call by
+/// [`break_prefix_len`]. Within that run the breaks are assumed sorted, so we use
+/// `partition_point` (a binary search) rather than a linear scan: this turns the
+/// whole `findInterval(x, vec)` / `cut` cost from `O(len(x) · len(vec))` into
+/// `O(len(x) · log(len(vec)))`, which matters because both lengths can reach
+/// `MAX_SEQ_LEN` (≈ 16.7M) — a quadratic scan there would be a CPU-amplification
+/// hazard for untrusted programs. Trimming to the non-NA prefix preserves the
+/// "first `NA` breakpoint stops the count" behaviour of the original linear form.
+fn find_interval_index(x: f64, prefix: &[f64]) -> Option<usize> {
     if is_na_real(x) || !x.is_finite() {
         return None;
     }
-    // Count breakpoints `<= x`. The first NA/non-finite breakpoint (or one that
-    // breaks monotonicity) simply stops the count — we never index out of bounds.
-    let mut idx = 0usize;
-    for &b in vec {
-        if !is_na_real(b) && b <= x {
-            idx += 1;
-        } else {
-            break;
-        }
-    }
-    Some(idx)
+    // The number of breaks `<= x` — equivalently the first index whose break is
+    // strictly greater than `x`. `partition_point` requires the predicate to be
+    // partitioned (all-true then all-false), which holds for a sorted prefix.
+    Some(prefix.partition_point(|&b| b <= x))
+}
+
+/// The length of the leading non-`NA` run of a breakpoint vector. `find_interval`
+/// and `cut` only ever consider breaks before the first `NA` (an `NA` break acts
+/// as a hard stop, matching the original linear scan), so the binary search runs
+/// over `&breaks[..break_prefix_len(breaks)]`.
+fn break_prefix_len(breaks: &[f64]) -> usize {
+    breaks
+        .iter()
+        .position(|&b| is_na_real(b))
+        .unwrap_or(breaks.len())
 }
 
 /// `findInterval(x, vec)` — for each element of `x`, the index of the last
@@ -4373,10 +4386,13 @@ fn b_find_interval(_interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
         .as_double()?
         .iter()
         .collect();
+    // The binary search runs over the leading non-NA run only (an NA break stops
+    // the count). Computed once, reused for every element of `x`.
+    let prefix = &vec[..break_prefix_len(&vec)];
 
     let out: Vec<f64> = x
         .iter()
-        .map(|xi| match find_interval_index(xi, &vec) {
+        .map(|xi| match find_interval_index(xi, prefix) {
             Some(i) => i as f64,
             None => na_real(),
         })
@@ -4440,12 +4456,14 @@ fn b_cut(_interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
         })
         .collect();
 
-    // Each value's 1-based interval index (via the shared kernel) is its factor
-    // code when it lands in `1..=n_intervals`; otherwise (below the first break,
-    // at/above the last, or NA) the code is `None` → a `<NA>` factor element.
+    // Each value's 1-based interval index (via the shared kernel, binary-searching
+    // the leading non-NA run of `breaks`) is its factor code when it lands in
+    // `1..=n_intervals`; otherwise (below the first break, at/above the last, or
+    // NA) the code is `None` → a `<NA>` factor element.
+    let prefix = &breaks[..break_prefix_len(&breaks)];
     let codes: Vec<Option<u32>> = x
         .iter()
-        .map(|xi| match find_interval_index(xi, &breaks) {
+        .map(|xi| match find_interval_index(xi, prefix) {
             Some(i) if i >= 1 && i <= n_intervals => Some(i as u32),
             _ => None,
         })

--- a/code/packages/rust/s-runtime/src/builtins.rs
+++ b/code/packages/rust/s-runtime/src/builtins.rs
@@ -137,6 +137,15 @@ pub fn install(env: &Env) {
     define(env, "split", builtin("split", b_split));
     define(env, "tabulate", builtin("tabulate", b_tabulate));
 
+    // Binning & cross-product utilities (R-32) — build on the factor value (R-13)
+    // and reuse `tabulate`'s allocation discipline.
+    define(
+        env,
+        "findInterval",
+        builtin("findInterval", b_find_interval),
+    );
+    define(env, "cut", builtin("cut", b_cut));
+
     // Regular expressions (R-7).
     define(env, "grepl", builtin("grepl", b_grepl));
     define(env, "grep", builtin("grep", b_grep));
@@ -4293,6 +4302,156 @@ fn b_tabulate(_interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
         }
     }
     Ok(SValue::doubles(counts))
+}
+
+/// The second positional argument (used by `findInterval` and `cut` for their
+/// `vec` / `breaks` operand), or the value of the given `name`d argument if
+/// present. Returns a `BadArgs` error (never panics) when neither is supplied.
+fn second_arg<'a>(args: &'a [Arg], name: &str, what: &str) -> SResult<&'a SValue> {
+    args.iter()
+        .find(|a| a.name.as_deref() == Some(name))
+        .map(|a| &a.value)
+        .or_else(|| {
+            args.iter()
+                .filter(|a| a.name.is_none())
+                .nth(1)
+                .map(|a| &a.value)
+        })
+        .ok_or_else(|| SError::BadArgs(format!("{what}: argument \"{name}\" is missing")))
+}
+
+/// `find_interval_index(x, vec)` — the shared kernel behind `findInterval` (and,
+/// transitively, `cut`).
+///
+/// `vec` is a **non-decreasing** vector of breakpoints. For a single value `x`
+/// we return the 1-based count of breakpoints that do **not exceed** `x` — i.e.
+/// the largest `i` with `vec[i] <= x`:
+///
+/// ```text
+///   vec = [1, 2, 3]
+///
+///   x        : -inf .. 1   1 .. 2   2 .. 3   3 .. +inf
+///   result   :     0         1        2         3
+///                  |         |        |         |
+///   meaning  :  below      in       in       at/above
+///              first      [1,2)    [2,3)     last break
+/// ```
+///
+/// A right-continuous (left-closed) step: an `x` exactly equal to `vec[i]` lands
+/// in the bucket that *starts* at `vec[i]`. `NA`/non-finite `x` returns `None`
+/// (the caller maps it to `NA`). Because `vec` is sorted we could binary-search,
+/// but breakpoint vectors are short, so a clear linear scan is preferred.
+fn find_interval_index(x: f64, vec: &[f64]) -> Option<usize> {
+    if is_na_real(x) || !x.is_finite() {
+        return None;
+    }
+    // Count breakpoints `<= x`. The first NA/non-finite breakpoint (or one that
+    // breaks monotonicity) simply stops the count — we never index out of bounds.
+    let mut idx = 0usize;
+    for &b in vec {
+        if !is_na_real(b) && b <= x {
+            idx += 1;
+        } else {
+            break;
+        }
+    }
+    Some(idx)
+}
+
+/// `findInterval(x, vec)` — for each element of `x`, the index of the last
+/// breakpoint in the non-decreasing `vec` that does not exceed it (see
+/// [`find_interval_index`]). `0` below the first break, `length(vec)` at or above
+/// the last; `NA`/non-finite `x` → `NA`.
+///
+/// ```text
+///   findInterval(c(0.5, 1.5, 2.5), c(1, 2, 3))  ->  c(0, 1, 2)
+///   findInterval(5,                c(1, 2, 3))  ->  3
+/// ```
+fn b_find_interval(_interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
+    let x = first_positional(args)?.as_double()?;
+    let vec: Vec<f64> = second_arg(args, "vec", "findInterval")?
+        .as_double()?
+        .iter()
+        .collect();
+
+    let out: Vec<f64> = x
+        .iter()
+        .map(|xi| match find_interval_index(xi, &vec) {
+            Some(i) => i as f64,
+            None => na_real(),
+        })
+        .collect();
+    Ok(SValue::doubles(out))
+}
+
+/// Format a numeric breakpoint for an interval label the way R's `cut` does for
+/// "nice" small integers: drop a trailing `.0` so `3.0` prints as `3`, but keep
+/// genuine fractions (`3.5`). This keeps the auto-generated levels readable
+/// (`"(0,3]"` rather than `"(0,3.0]"`).
+fn format_break(b: f64) -> String {
+    if b.is_finite() && b.fract() == 0.0 && b.abs() < 1e15 {
+        format!("{}", b as i64)
+    } else {
+        format!("{b}")
+    }
+}
+
+/// `cut(x, breaks)` — bin the numeric vector `x` into the intervals delimited by
+/// the **sorted** breakpoint vector `breaks`, returning a **factor**.
+///
+/// With `k = length(breaks)` breakpoints there are `k - 1` intervals. The default
+/// intervals are **right-closed** `(lo, hi]`, and the auto-generated level labels
+/// are exactly `"(lo,hi]"`:
+///
+/// ```text
+///   breaks = [0, 3, 6, 11]            levels = ["(0,3]", "(3,6]", "(6,11]"]
+///
+///   x = 1   -> findInterval = 1 -> code 1 -> "(0,3]"
+///   x = 5   -> findInterval = 2 -> code 2 -> "(3,6]"
+///   x = 10  -> findInterval = 3 -> code 3 -> "(6,11]"
+///   x = -1  -> findInterval = 0 -> out of range -> NA
+///   x = 20  -> findInterval = 4 (= k) -> out of range -> NA
+/// ```
+///
+/// The whole job reduces to `findInterval`: the interval index `i` is the 1-based
+/// factor code precisely when `1 <= i <= k-1`; the boundary indices `0` (below the
+/// first break) and `k` (at/above the last) — and any `NA` `x` — map to a `NA`
+/// code. `labels=`, `right=FALSE`, `include.lowest=`, and integer `breaks` are
+/// deferred to R-33.
+fn b_cut(_interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
+    let x = first_positional(args)?.as_double()?;
+    let breaks: Vec<f64> = second_arg(args, "breaks", "cut")?
+        .as_double()?
+        .iter()
+        .collect();
+
+    // `k - 1` intervals; with fewer than two breaks there are none, so every
+    // value is unbinned (NA). `saturating_sub` keeps this from underflowing.
+    let n_intervals = breaks.len().saturating_sub(1);
+
+    // The level labels are "(lo,hi]" for each adjacent break pair.
+    let levels: Vec<String> = (0..n_intervals)
+        .map(|i| {
+            format!(
+                "({},{}]",
+                format_break(breaks[i]),
+                format_break(breaks[i + 1])
+            )
+        })
+        .collect();
+
+    // Each value's 1-based interval index (via the shared kernel) is its factor
+    // code when it lands in `1..=n_intervals`; otherwise (below the first break,
+    // at/above the last, or NA) the code is `None` → a `<NA>` factor element.
+    let codes: Vec<Option<u32>> = x
+        .iter()
+        .map(|xi| match find_interval_index(xi, &breaks) {
+            Some(i) if i >= 1 && i <= n_intervals => Some(i as u32),
+            _ => None,
+        })
+        .collect();
+
+    Ok(SValue::Factor { codes, levels })
 }
 
 fn builtin(name: &str, func: fn(&Interpreter, &[Arg]) -> SResult<SValue>) -> SValue {

--- a/code/specs/R00-r-language.md
+++ b/code/specs/R00-r-language.md
@@ -1077,6 +1077,59 @@ unchanged.
     pass — and the `fromLast =` argument on those same binary set ops. The `%o%` infix
     alias for `outer` remains open for a later grammar pass.
 
+- **R-32 — binning & cross-product utilities** *(this PR)*. A **pivot** away from
+  the R-31 deferral of `incomparables=`/`fromLast=` on the binary set ops
+  (`union`/`intersect`/`setdiff`): on inspection base R's `union`/`intersect`/`setdiff`
+  do **not** accept those arguments at all (only the `{set,union,...}` generics and
+  `duplicated`/`unique` do), so wiring them onto the binary set ops would be
+  **non-faithful**. R-32 instead lands a coherent, faithful adjacent unit — the
+  numeric-binning family — all in the shared `s-runtime` (R reuses them verbatim
+  through the shared tree-walker). They build on the existing factor value
+  (`SValue::Factor { codes, levels }`, the R-13 factor type) and the existing
+  `MAX_SEQ_LEN` cap; no new value type is introduced.
+  - **`findInterval(x, vec)`** — the primitive the others build on. `vec` must be
+    **non-decreasing** (a sorted vector of breakpoints). For each element of `x` it
+    returns the largest index `i` (1-based) such that `vec[i] <= x`, i.e. the count of
+    breakpoints that do not exceed `x`: `0` when `x < vec[1]`, `length(vec)` when
+    `x >= vec[length(vec)]`. Implemented as a linear scan (`vec` is assumed short and
+    sorted); `NA`/non-finite `x` propagate to `NA`. Worked examples:
+    `findInterval(c(0.5, 1.5, 2.5), c(1, 2, 3))` is `c(0, 1, 2)`;
+    `findInterval(5, c(1, 2, 3))` is `3`.
+  - **`tabulate(bin, nbins)`** — unchanged from R-28 (already shipped); listed here as
+    part of the binning family. Counts integer codes `1..nbins`; codes `<= 0` or
+    `> nbins` are ignored; `nbins` defaults to `max(bin)` and is capped at
+    `MAX_SEQ_LEN`. `tabulate(c(1,2,2,3,5), nbins = 5)` is `c(1, 2, 1, 0, 1)`.
+  - **`cut(x, breaks)`** — bin a numeric vector `x` into the intervals delimited by
+    the **sorted** breakpoint vector `breaks`, returning a **`factor`** (a real
+    `SValue::Factor`, so `levels()`, `as.integer()`, `as.character()`, and `table()`
+    all work on the result). With `k = length(breaks)` breakpoints there are `k - 1`
+    intervals; the default intervals are **right-closed** `(lo, hi]`, and the
+    auto-generated level labels are exactly `"(lo,hi]"` formatted from the numeric
+    breakpoints. An element that falls in no interval — `x <= breaks[1]` or
+    `x > breaks[k]`, or `NA`/non-finite — maps to a `NA` factor code (printed `<NA>`),
+    not to a level. `cut` is implemented **on top of `findInterval`**: the interval
+    index is `findInterval(x, breaks)`, which is the 1-based level code when it lies in
+    `1..k-1` and `NA` (out of range) otherwise. Worked example:
+    `cut(c(1, 5, 10), breaks = c(0, 3, 6, 11))` is a factor with levels
+    `c("(0,3]", "(3,6]", "(6,11]")` and values `(0,3]`, `(3,6]`, `(6,11]`;
+    `cut(c(-1, 20), breaks = c(0, 3, 6, 11))` is `NA, NA` (both outside the breaks).
+  - **Output-size caps (security).** No new unbounded multiplier. `cut` allocates one
+    output code per input element (length already `MAX_SEQ_LEN`-bounded) and `k - 1`
+    level strings (bounded by the `breaks` length, itself capped). `findInterval` is
+    `O(len(x) * len(vec))` with both lengths capped. `tabulate` keeps its existing
+    `nbins`-vs-`MAX_SEQ_LEN` checked guard. Named-arg readers reject malformed values
+    gracefully (`Err`, never panic): `breaks` is read through `as_double` (NA/empty is
+    a clean error or empty result), and the deferred options below are simply ignored
+    when absent.
+  - **Scope outcome / deferred to R-33.** `findInterval`, `tabulate`, and `cut`
+    (default right-closed `(lo,hi]` intervals with auto-generated labels) ship
+    **solidly**. **Deferred to R-33:** `cut`'s `labels =` (custom level labels),
+    `right = FALSE` (left-closed `[lo,hi)` intervals), `include.lowest =` (fold the
+    extreme endpoint into the adjacent interval), and `breaks` given as a single
+    integer (number of equal-width bins). These are pure extensions of the same
+    `findInterval`-backed core. The `%o%` infix alias for `outer` remains open for a
+    later grammar pass.
+
 ## §4 Reuse strategy
 
 - **Lexer/parser:** the grammar-tools framework, exactly as S uses it. `r.tokens`
@@ -1111,8 +1164,11 @@ refinements (multi-key `order(x, y, ...)`, `rank`'s `ties.method` =
 `average`/`min`/`max`/`first`, `duplicated(fromLast=)`, `anyDuplicated`) land in
 **R-30**; the set-op & ordering refinements (`incomparables=` on
 `duplicated`/`anyDuplicated`/`unique`, `unique(fromLast=)`, and `rank`'s `"random"`
-tie method) land in **R-31**, with `incomparables=`/`fromLast=` on the binary set ops
-(`union`/`intersect`/`setdiff`) deferred to **R-32**; namespaces and `library()`
+tie method) land in **R-31**; the binning & cross-product utilities (`findInterval`,
+`cut` returning a factor) land in **R-32** — a pivot away from `incomparables=`/`fromLast=`
+on the binary set ops (`union`/`intersect`/`setdiff`), which base R does not accept there,
+making them non-faithful; `cut`'s `labels=`/`right=FALSE`/`include.lowest=` and integer
+`breaks` are deferred to **R-33**; namespaces and `library()`
 (so `baseenv()` aliases the
 global env for now); the C interface; graphics. These layer on later, following
 ST00.

--- a/code/specs/S00-s-language.md
+++ b/code/specs/S00-s-language.md
@@ -488,6 +488,22 @@ essential: `switch("a", a = stop("no"), b = "ok")` must not raise, and a
    `environment()`, bounded by the same `MAX_ENVIRONMENTS` cap. `parent.frame(n)`
    **clamps** to the global env past the bottom of the stack rather than indexing
    out of bounds.
+7. **Binning & cross-product utilities (R-32, shared builtins).** `s-runtime`
+   gains two binning builtins that R (R-32) reuses verbatim through the shared
+   tree-walker; both are pure functions over the existing `r-vector` `Double` and
+   the existing `SValue::Factor` value, so no new value type or cap is added.
+   - **`findInterval(x, vec)`** — for a **non-decreasing** breakpoint vector `vec`,
+     the 1-based index of the last breakpoint not exceeding each `x` (`0` below the
+     first, `length(vec)` at/above the last); `NA`/non-finite `x` → `NA`. A linear
+     scan, `O(len(x)·len(vec))` with both lengths `MAX_SEQ_LEN`-bounded.
+   - **`cut(x, breaks)`** — bins `x` into the `k-1` right-closed intervals `(lo,hi]`
+     of the sorted `breaks` (length `k`), returning a real `SValue::Factor` whose
+     `levels` are the auto-generated `"(lo,hi]"` labels; values outside all intervals
+     (or `NA`) get a `NA` code. Built directly on `findInterval` (the interval index
+     is the level code), so `levels()`/`as.integer()`/`as.character()`/`table()` all
+     work on the result. `labels=`, `right=FALSE`, `include.lowest=`, and integer
+     `breaks` are **deferred to R-33**. The existing `tabulate(bin, nbins)` (R-28)
+     rounds out the family (its `nbins` stays capped at `MAX_SEQ_LEN`).
 
 ## §10 References
 


### PR DESCRIPTION
## R-32 — binning & cross-product utilities

A **pivot** away from the thin R-31 deferral of `incomparables=`/`fromLast=` on the binary set ops. On inspection, base R's `union`/`intersect`/`setdiff` do **not** accept those arguments at all (only the dedup/ranking family — `duplicated`/`unique` — and the `{set,union,...}` generics do), so wiring them onto the binary set ops would be **non-faithful**. R-32 instead lands a coherent, faithful adjacent unit: the numeric-binning family, implemented in the shared `s-runtime` so both S and R get it through the shared tree-walker.

### Additions (in `s-runtime`, exercised through R syntax in `r-runtime`)

- **`findInterval(x, vec)`** — the primitive the others build on. For a non-decreasing breakpoint vector `vec`, returns for each `x` the 1-based index of the last break not exceeding it: `0` below the first, `length(vec)` at/above the last; `NA`/non-finite `x` → `NA`. `findInterval(c(0.5,1.5,2.5), c(1,2,3))` → `c(0,1,2)`; `findInterval(5, c(1,2,3))` → `3`.
- **`cut(x, breaks)`** — bins `x` into the `k-1` right-closed `(lo,hi]` intervals of the sorted `breaks`, **returning a real `SValue::Factor`** whose levels are the auto-generated `"(lo,hi]"` labels. Built directly on `findInterval` (the interval index is the 1-based level code). Because it's a genuine factor, `levels()`, `as.integer()`, `as.character()`, and `nlevels()` all work on the result. `cut(c(1,5,10), breaks=c(0,3,6,11))` → a factor with levels `"(0,3]","(3,6]","(6,11]"` and values `(0,3]`,`(3,6]`,`(6,11]`. Values outside all breaks (or `NA`) → `NA` codes (`cut(c(-1,20), breaks=c(0,3,6,11))` → both `NA`).
- **`tabulate(bin, nbins)`** — already shipped in R-28; reused as the family primitive (its `nbins` stays capped at `MAX_SEQ_LEN`). `tabulate(c(1,2,2,3,5), nbins=5)` → `c(1,2,1,0,1)`.

### Factor return for `cut`

`cut`'s result is a real `SValue::Factor { codes, levels }` (the R-13 factor type), built with the same constructor `factor(...)` uses — verified by tests asserting `class(...)` is `"factor"` and that `levels()`/`as.integer()`/`as.character()`/`nlevels()` are all factor-aware on the binned output.

### Security

A Rust security sub-agent reviewed the diff and found no CRITICAL/HIGH issues. One LOW item — the original linear breakpoint scan was `O(len(x)·len(vec))`, a CPU-amplification hazard given `MAX_SEQ_LEN = 1<<24` — was hardened: `findInterval`/`cut` now binary-search (`partition_point`) the leading non-NA run of the sorted breaks, computed once per call, giving `O(len(x)·log(len(vec)))` with identical semantics. Cast guards (`format_break`), `saturating_sub` on the interval count, `breaks[i+1]` bounds, NA/empty handling, and the graceful `BadArgs` on a missing operand were confirmed clean.

### Deferred to R-33

`cut`'s `labels=` (custom level labels), `right=FALSE` (left-closed `[lo,hi)`), `include.lowest=`, and `breaks` given as a single integer (equal-width bin count). All are pure extensions of the same `findInterval`-backed core.

### Tests

`cargo test -p coding-adventures-s-runtime -p coding-adventures-r-runtime`: r-runtime **244 passed**, s-runtime **241 passed** (7 new R-32 tests, all green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)