### PR TITLE
feat(x86-simulator): group-3 (not/neg/div/idiv) + broader matrix coverage (S4)

### DIFF
--- a/code/packages/rust/x86-simulator/CHANGELOG.md
+++ b/code/packages/rust/x86-simulator/CHANGELOG.md
@@ -1,5 +1,34 @@
 # Changelog — x86-simulator
 
+## 0.4.0 — 2026-06-21 — group-3 (`not`/`neg`/`div`/`idiv`) + broader matrix coverage (x86-sim PR-S4)
+
+Broadens the **local** LANG-FULL x86_64 coverage from S3's 7 cells to 15 by
+running more matrix programs through the simulator — which surfaced a real
+missing opcode and added it.
+
+### Added
+- **Group-3 `0xF7` + `cqo`** — the opcodes the `x86_64-backend` emits for the IIR
+  `not`/`neg`/division ops, which S1–S3 never decoded (a Nib `~0` / Oct
+  `out(1, ~0)` trapped with `DecodeError { opcode: 0xF7 }`):
+  - `not r/m64` (`0xF7 /2`) — bitwise complement, no flag effects;
+  - `neg r/m64` (`0xF7 /3`) — two's-complement negate, flags as `sub 0, dst`;
+  - `div`/`idiv r/m64` (`0xF7 /6` unsigned, `/7` signed) — divides the full
+    128-bit `rdx:rax` pair, quotient → `rax`, remainder → `rdx`;
+  - `cqo` (`0x48 0x99`) — sign-extend `rax` into `rdx:rax` (the `idiv` preamble).
+- **`Trap::DivideError`** — divide-by-zero **and** quotient-overflow (e.g.
+  `i64::MIN / -1`) raise the `#DE` analogue, fail-closed like every other fault.
+- **8 new matrix cells** in `tests/lang_matrix_x86.rs`, each a verbatim matrix
+  program run on the x86_64 column locally: Twig top-level `define`s; Nib u8
+  saturating-add wrap and `~` complement; ALGOL switch/computed-goto and the
+  `for`-loop sum-of-squares array; Dartmouth BASIC `PRINT` and `FOR`/`NEXT`
+  (stdout-captured via the host shims); Oct `out(1, ~0)` (the cell that exposed
+  the `0xF7` gap). New `run_capturing_stdout` helper for the print programs.
+
+### Verified
+- The `not` op now runs end-to-end (Nib + Oct); `neg`/`div`/`idiv`/`cqo` get
+  direct decode + execute unit tests (quotient/remainder, signed negatives,
+  div-by-zero and signed-overflow traps). 39 tests (24 unit + 15 matrix).
+
 ## 0.3.0 — 2026-06-21 — local LANG-FULL x86_64 matrix column (x86-sim PR-S3)
 
 Wires the simulator into the LANG-FULL matrix: a new integration test drives the

--- a/code/packages/rust/x86-simulator/CHANGELOG.md
+++ b/code/packages/rust/x86-simulator/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.4.0 — 2026-06-21 — group-3 (`not`/`neg`/`div`/`idiv`) + broader matrix coverage (x86-sim PR-S4)
 
-Broadens the **local** LANG-FULL x86_64 coverage from S3's 7 cells to 15 by
+Broadens the **local** LANG-FULL x86_64 coverage from S3's 7 cells to 17 by
 running more matrix programs through the simulator — which surfaced a real
 missing opcode and added it.
 
@@ -23,11 +23,16 @@ missing opcode and added it.
   `for`-loop sum-of-squares array; Dartmouth BASIC `PRINT` and `FOR`/`NEXT`
   (stdout-captured via the host shims); Oct `out(1, ~0)` (the cell that exposed
   the `0xF7` gap). New `run_capturing_stdout` helper for the print programs.
+- **Division end-to-end** — a Nib unsigned `84 / 2` (lowers to `xor rdx,rdx;
+  div rcx`) and an ALGOL signed `85 div 2` (`cqo; idiv rcx`), both ⇒ 42, so the
+  group-3 division path is exercised from real backend output, not just the unit
+  tests.
 
 ### Verified
-- The `not` op now runs end-to-end (Nib + Oct); `neg`/`div`/`idiv`/`cqo` get
-  direct decode + execute unit tests (quotient/remainder, signed negatives,
-  div-by-zero and signed-overflow traps). 39 tests (24 unit + 15 matrix).
+- The `not` and `div`/`idiv` ops now run end-to-end (Nib + Oct + ALGOL);
+  `neg`/`cqo` and the division corner cases get direct decode + execute unit
+  tests (quotient/remainder, signed negatives, div-by-zero, signed-overflow, and
+  the crafted `i128::MIN / -1`). 42 tests (25 unit + 17 matrix).
 
 ## 0.3.0 — 2026-06-21 — local LANG-FULL x86_64 matrix column (x86-sim PR-S3)
 

--- a/code/packages/rust/x86-simulator/Cargo.toml
+++ b/code/packages/rust/x86-simulator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "x86-simulator"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 description = "x86/x86-64 runtime simulator — decode + execute machine code, and run the x86_64-backend's emitted code locally (host-arch-independent)"
 

--- a/code/packages/rust/x86-simulator/README.md
+++ b/code/packages/rust/x86-simulator/README.md
@@ -61,12 +61,12 @@ as the exit code (the same convention as `run_native` / `run_wasm`).
 On an Apple-Silicon host the matrix's `NativeAot` cell only ever builds+runs the
 *aarch64* backend; this test exercises the **x86_64** column end-to-end —
 **locally on aarch64**, retro-verifying columns the matrix could previously
-execute only on x86 CI. The 15 cells span Twig (const/arithmetic/`define`),
-Nib (u8 wrap, `~` complement), ALGOL (procedure call, switch/computed-goto, E3
-`real` SSE2 floats, E5 arrays straight-line and in a `for` loop), Oct (`out`,
-`~`), and Dartmouth BASIC (`PRINT`, `FOR`/`NEXT` — stdout-captured via the host
-shims). Adding the Nib/Oct `~` cells is what surfaced the missing group-3
-`0xF7` opcode that this crate now decodes.
+execute only on x86 CI. The 17 cells span Twig (const/arithmetic/`define`),
+Nib (u8 wrap, `~` complement, unsigned division), ALGOL (procedure call,
+switch/computed-goto, signed `div`, E3 `real` SSE2 floats, E5 arrays straight-
+line and in a `for` loop), Oct (`out`, `~`), and Dartmouth BASIC (`PRINT`,
+`FOR`/`NEXT` — stdout-captured via the host shims). Adding the Nib/Oct `~` cells
+is what surfaced the missing group-3 `0xF7` opcode that this crate now decodes.
 
 ## Safety
 

--- a/code/packages/rust/x86-simulator/README.md
+++ b/code/packages/rust/x86-simulator/README.md
@@ -19,6 +19,9 @@ The subset the `x86_64-encoder` emits (and growing):
   `movzx reg,byte[mem]`, `lea reg,[mem]` (incl. RIP-relative); REX/ModRM/SIB.
 - **Integer ALU**: `add` / `sub` / `cmp` / `and` / `or` / `xor` / `test` (reg and
   imm forms), `shl` / `shr` / `sar`, `imul` — all with full CF/ZF/SF/OF/PF flags.
+- **Group-3 + division**: `not` / `neg` (`0xF7 /2`,`/3`), `div` / `idiv`
+  (`0xF7 /6`,`/7`, dividing the 128-bit `rdx:rax` pair), and `cqo` (`rax`→`rdx:rax`
+  sign-extend). Divide-by-zero / quotient-overflow raise a `#DE` **trap**.
 - **Control flow**: `jmp`, `jcc` (all 16 conditions), `call` / `ret`, `push` /
   `pop`, `setcc`, and `ud2` → an illegal-instruction **trap** (how an E5
   out-of-bounds array access aborts).
@@ -56,10 +59,14 @@ as the exit code (the same convention as `run_native` / `run_wasm`).
 **real** AOT pipeline (`compile_source_to_iir` → `infer_types` → `aot_specialise`
 → `x86_64-backend`) and *runs the emitted x86_64 machine code* on this simulator.
 On an Apple-Silicon host the matrix's `NativeAot` cell only ever builds+runs the
-*aarch64* backend; this test exercises the **x86_64** column end-to-end — Twig
-arithmetic, an ALGOL procedure call (internal `call` relocations), E3 `real`
-SSE2 floats, and an E5 native bounded array — **locally on aarch64**, retro-
-verifying the two columns the matrix could previously execute only on x86 CI.
+*aarch64* backend; this test exercises the **x86_64** column end-to-end —
+**locally on aarch64**, retro-verifying columns the matrix could previously
+execute only on x86 CI. The 15 cells span Twig (const/arithmetic/`define`),
+Nib (u8 wrap, `~` complement), ALGOL (procedure call, switch/computed-goto, E3
+`real` SSE2 floats, E5 arrays straight-line and in a `for` loop), Oct (`out`,
+`~`), and Dartmouth BASIC (`PRINT`, `FOR`/`NEXT` — stdout-captured via the host
+shims). Adding the Nib/Oct `~` cells is what surfaced the missing group-3
+`0xF7` opcode that this crate now decodes.
 
 ## Safety
 

--- a/code/packages/rust/x86-simulator/src/decode.rs
+++ b/code/packages/rust/x86-simulator/src/decode.rs
@@ -51,6 +51,17 @@ pub enum Instr {
     Shift { op: ShiftOp, dst: Operand, amount: u8 },
     /// `imul reg, rm` (two-operand).
     Imul { dst: Reg, src: Operand },
+    /// `not r/m64` — bitwise complement (group-3 `0xF7 /2`). No flags.
+    Not { dst: Operand },
+    /// `neg r/m64` — two's-complement negate (group-3 `0xF7 /3`). Sets flags
+    /// as `sub 0, dst`.
+    Neg { dst: Operand },
+    /// `div`/`idiv r/m64` (group-3 `0xF7 /6` unsigned, `/7` signed) — divides
+    /// the `rdx:rax` pair by the operand: quotient → `rax`, remainder → `rdx`.
+    Div { divisor: Operand, signed: bool },
+    /// `cqo` (`0x48 0x99`) — sign-extend `rax` into `rdx:rax` (the standard
+    /// `idiv` preamble).
+    Cqo,
     /// `jmp rel` (absolute target already resolved from rip+rel).
     Jmp(i64),
     /// `jcc rel` — relative displacement; the condition nibble is `cond`.
@@ -164,6 +175,8 @@ pub fn decode(code: &[u8], off: usize) -> Result<Decoded, Trap> {
     match op {
         0xC3 => return Ok(Decoded { instr: Instr::Ret, len: p - off }),
         0x90 => return Ok(Decoded { instr: Instr::Nop, len: p - off }),
+        // cqo — sign-extend rax into rdx:rax (REX.W 0x99). No operands.
+        0x99 => return Ok(Decoded { instr: Instr::Cqo, len: p - off }),
         // jmp rel8 / rel32
         0xEB => { let r = at(p)? as i8 as i64; p += 1; return Ok(Decoded { instr: Instr::Jmp(rel_target(p, r)), len: p - off }); }
         0xE9 => { let r = read_i32(code, p)? as i64; p += 4; return Ok(Decoded { instr: Instr::Jmp(rel_target(p, r)), len: p - off }); }
@@ -270,6 +283,20 @@ pub fn decode(code: &[u8], off: usize) -> Result<Decoded, Trap> {
             let sop = match m.reg & 0x7 { 4 => ShiftOp::Shl, 5 => ShiftOp::Shr, 7 => ShiftOp::Sar,
                 other => return Err(Trap::DecodeError { offset: off as u64, opcode: 0xC0 | other }) };
             Ok(Decoded { instr: Instr::Shift { op: sop, dst: m.rm, amount: amt }, len: np + 1 - off })
+        }
+        // group-3 r/m64 — /reg selects: 2=not, 3=neg, 6=div, 7=idiv.
+        // (/0,/1=test imm, /4=mul, /5=imul aren't emitted by the backend.)
+        0xF7 => {
+            let (m, np) = modrm(code, p, rex_r, rex_x, rex_b)?;
+            let instr = match m.reg & 0x7 {
+                2 => Instr::Not { dst: m.rm },
+                3 => Instr::Neg { dst: m.rm },
+                6 => Instr::Div { divisor: m.rm, signed: false },
+                7 => Instr::Div { divisor: m.rm, signed: true },
+                // /0,/1 (test imm) /4 (mul) /5 (imul) — not emitted by the backend.
+                _ => return Err(Trap::DecodeError { offset: off as u64, opcode: 0xF7 }),
+            };
+            Ok(Decoded { instr, len: np - off })
         }
         other => Err(Trap::DecodeError { offset: (p - 1) as u64, opcode: other }),
     }
@@ -384,6 +411,26 @@ mod tests {
             dst: Operand::Mem { base: Some(Reg::Rbp), index: None, scale: 1, disp: -8, rip: false },
             src: Operand::Reg(Reg::Rax) });
         assert_eq!(instrs.last(), Some(&Instr::Ret));
+    }
+
+    #[test]
+    fn group3_and_cqo_decode() {
+        // The exact bytes the x86_64-encoder emits (REX.W 0x48 prefix, mod=11
+        // register-direct, reg field selects the group-3 op).
+        // not rax  = 48 F7 D0 (/2, rm=rax)
+        assert_eq!(decode(&[0x48, 0xF7, 0xD0], 0).unwrap().instr,
+                   Instr::Not { dst: Operand::Reg(Reg::Rax) });
+        // neg rax  = 48 F7 D8 (/3)
+        assert_eq!(decode(&[0x48, 0xF7, 0xD8], 0).unwrap().instr,
+                   Instr::Neg { dst: Operand::Reg(Reg::Rax) });
+        // div rcx  = 48 F7 F1 (/6, rm=rcx, unsigned)
+        assert_eq!(decode(&[0x48, 0xF7, 0xF1], 0).unwrap().instr,
+                   Instr::Div { divisor: Operand::Reg(Reg::Rcx), signed: false });
+        // idiv rcx = 48 F7 F9 (/7, signed)
+        assert_eq!(decode(&[0x48, 0xF7, 0xF9], 0).unwrap().instr,
+                   Instr::Div { divisor: Operand::Reg(Reg::Rcx), signed: true });
+        // cqo      = 48 99
+        assert_eq!(decode(&[0x48, 0x99], 0).unwrap().instr, Instr::Cqo);
     }
 
     #[test]

--- a/code/packages/rust/x86-simulator/src/execute.rs
+++ b/code/packages/rust/x86-simulator/src/execute.rs
@@ -183,10 +183,18 @@ pub fn exec_one(
                 // The 128-bit `rdx:rax` pattern interpreted as a signed integer.
                 let n = dividend as i128;
                 let divisor_i = d as i64 as i128;
-                let q = n / divisor_i;
-                let r = n % divisor_i;
-                // x86 raises `#DE` when the quotient doesn't fit the 64-bit dest
-                // (e.g. `i64::MIN / -1` ⇒ +2^63).  Model that as a divide error.
+                // `checked_div`/`checked_rem` return `None` exactly on the one
+                // overflowing case `i128::MIN / -1` (divide-by-zero is already
+                // excluded above).  That case is unreachable from real backend
+                // output (it always `cqo`s, so `rdx:rax` sign-extends a 64-bit
+                // value), but a crafted register state could hit it — so trap
+                // rather than panic, keeping the sandbox fail-closed.
+                let (q, r) = match (n.checked_div(divisor_i), n.checked_rem(divisor_i)) {
+                    (Some(q), Some(r)) => (q, r),
+                    _ => return Err(Trap::DivideError(instr_off as u64)),
+                };
+                // x86 also raises `#DE` when the quotient doesn't fit the 64-bit
+                // dest (e.g. `i64::MIN / -1` ⇒ +2^63).
                 if q < i64::MIN as i128 || q > i64::MAX as i128 {
                     return Err(Trap::DivideError(instr_off as u64));
                 }
@@ -384,6 +392,20 @@ mod tests {
         let mut st = CpuState::default();
         st.set(Reg::Rax, i64::MIN as u64);
         exec(&mut st, &Instr::Cqo).unwrap();
+        st.set(Reg::Rcx, (-1i64) as u64);
+        let err = exec(&mut st, &Instr::Div { divisor: Operand::Reg(Reg::Rcx), signed: true }).unwrap_err();
+        assert!(matches!(err, Trap::DivideError(_)));
+    }
+
+    #[test]
+    fn i128_min_dividend_div_neg1_traps_not_panics() {
+        // A *crafted* rdx:rax = i128::MIN (rdx top bit set, rax = 0) divided by
+        // -1 overflows the i128 division itself — must trap, never panic. (Real
+        // backend output can't reach this because it always `cqo`s first; this
+        // guards the sandbox against arbitrary register state.)
+        let mut st = CpuState::default();
+        st.set(Reg::Rdx, 0x8000_0000_0000_0000);
+        st.set(Reg::Rax, 0);
         st.set(Reg::Rcx, (-1i64) as u64);
         let err = exec(&mut st, &Instr::Div { divisor: Operand::Reg(Reg::Rcx), signed: true }).unwrap_err();
         assert!(matches!(err, Trap::DivideError(_)));

--- a/code/packages/rust/x86-simulator/src/execute.rs
+++ b/code/packages/rust/x86-simulator/src/execute.rs
@@ -150,6 +150,61 @@ pub fn exec_one(
             st.set(*dst, a.wrapping_mul(b));
             Ok(Flow::Next)
         }
+        Instr::Not { dst } => {
+            // Bitwise complement; `not` does NOT touch flags (unlike `neg`).
+            let v = read_op(st, mem, dst, next_ip, 8)?;
+            write_op(st, mem, dst, next_ip, 8, !v)?;
+            Ok(Flow::Next)
+        }
+        Instr::Neg { dst } => {
+            // Two's-complement negate == `sub 0, dst`, including its flag effects.
+            let v = read_op(st, mem, dst, next_ip, 8)?;
+            let (res, flags) = sub_with_flags(0, v);
+            st.flags = flags;
+            write_op(st, mem, dst, next_ip, 8, res)?;
+            Ok(Flow::Next)
+        }
+        Instr::Cqo => {
+            // Sign-extend rax into rdx: rdx becomes all-ones iff rax is negative.
+            let hi = if (st.get(Reg::Rax) as i64) < 0 { u64::MAX } else { 0 };
+            st.set(Reg::Rdx, hi);
+            Ok(Flow::Next)
+        }
+        Instr::Div { divisor, signed } => {
+            let d = read_op(st, mem, divisor, next_ip, 8)?;
+            if d == 0 {
+                return Err(Trap::DivideError(instr_off as u64));
+            }
+            let lo = st.get(Reg::Rax);
+            let hi = st.get(Reg::Rdx);
+            // The dividend is the 128-bit `rdx:rax` pair.
+            let dividend = ((hi as u128) << 64) | (lo as u128);
+            let (quot, rem) = if *signed {
+                // The 128-bit `rdx:rax` pattern interpreted as a signed integer.
+                let n = dividend as i128;
+                let divisor_i = d as i64 as i128;
+                let q = n / divisor_i;
+                let r = n % divisor_i;
+                // x86 raises `#DE` when the quotient doesn't fit the 64-bit dest
+                // (e.g. `i64::MIN / -1` ⇒ +2^63).  Model that as a divide error.
+                if q < i64::MIN as i128 || q > i64::MAX as i128 {
+                    return Err(Trap::DivideError(instr_off as u64));
+                }
+                (q as u64, r as u64)
+            } else {
+                let divisor_u = d as u128;
+                let q = dividend / divisor_u;
+                let r = dividend % divisor_u;
+                // Unsigned `#DE` when the quotient overflows 64 bits.
+                if q > u64::MAX as u128 {
+                    return Err(Trap::DivideError(instr_off as u64));
+                }
+                (q as u64, r as u64)
+            };
+            st.set(Reg::Rax, quot);
+            st.set(Reg::Rdx, rem);
+            Ok(Flow::Next)
+        }
         // ── SSE2 scalar double ────────────────────────────────────────────────
         Instr::MovsdLoad { xmm, src } => {
             let v = f64::from_bits(read_op(st, mem, src, next_ip, 8)?);
@@ -239,4 +294,98 @@ fn apply_alu(st: &mut CpuState, mem: &mut Memory, op: AluOp, dst: &Operand, next
         write_op(st, mem, dst, next_ip, 8, res)?;
     }
     Ok(Flow::Next)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Run a single register-only instruction against a fresh CPU and return the
+    /// mutated state.  A tiny scratch `Memory` satisfies the signature; these ops
+    /// never touch it.
+    fn exec(st: &mut CpuState, ins: &Instr) -> Result<Flow, Trap> {
+        let mut mem = Memory::new(64, 0, 0);
+        exec_one(st, &mut mem, ins, 0, 0, 0)
+    }
+
+    #[test]
+    fn not_complements_without_touching_flags() {
+        let mut st = CpuState::default();
+        st.set(Reg::Rax, 0);
+        st.flags = Flags { zf: true, cf: true, ..Flags::default() };
+        exec(&mut st, &Instr::Not { dst: Operand::Reg(Reg::Rax) }).unwrap();
+        assert_eq!(st.get(Reg::Rax), u64::MAX); // ~0
+        // `not` must leave flags untouched (unlike `neg`).
+        assert!(st.flags.zf && st.flags.cf);
+    }
+
+    #[test]
+    fn neg_negates_and_sets_flags() {
+        let mut st = CpuState::default();
+        st.set(Reg::Rax, 5);
+        exec(&mut st, &Instr::Neg { dst: Operand::Reg(Reg::Rax) }).unwrap();
+        assert_eq!(st.get(Reg::Rax) as i64, -5);
+        // neg of a non-zero value sets CF (it is `sub 0, x`).
+        assert!(st.flags.cf);
+        // neg 0 ⇒ 0, ZF set, CF clear.
+        st.set(Reg::Rax, 0);
+        exec(&mut st, &Instr::Neg { dst: Operand::Reg(Reg::Rax) }).unwrap();
+        assert_eq!(st.get(Reg::Rax), 0);
+        assert!(st.flags.zf && !st.flags.cf);
+    }
+
+    #[test]
+    fn cqo_sign_extends_rax_into_rdx() {
+        let mut st = CpuState::default();
+        st.set(Reg::Rax, (-7i64) as u64);
+        exec(&mut st, &Instr::Cqo).unwrap();
+        assert_eq!(st.get(Reg::Rdx), u64::MAX); // negative ⇒ all ones
+        st.set(Reg::Rax, 7);
+        exec(&mut st, &Instr::Cqo).unwrap();
+        assert_eq!(st.get(Reg::Rdx), 0); // non-negative ⇒ zero
+    }
+
+    #[test]
+    fn unsigned_div_yields_quotient_and_remainder() {
+        // rdx:rax = 17, rcx = 5 ⇒ rax=3, rdx=2.
+        let mut st = CpuState::default();
+        st.set(Reg::Rdx, 0);
+        st.set(Reg::Rax, 17);
+        st.set(Reg::Rcx, 5);
+        exec(&mut st, &Instr::Div { divisor: Operand::Reg(Reg::Rcx), signed: false }).unwrap();
+        assert_eq!(st.get(Reg::Rax), 3);
+        assert_eq!(st.get(Reg::Rdx), 2);
+    }
+
+    #[test]
+    fn signed_idiv_handles_negatives() {
+        // -17 / 5 ⇒ quotient -3, remainder -2 (truncated toward zero).
+        let mut st = CpuState::default();
+        st.set(Reg::Rax, (-17i64) as u64);
+        exec(&mut st, &Instr::Cqo).unwrap(); // sign-extend into rdx
+        st.set(Reg::Rcx, 5);
+        exec(&mut st, &Instr::Div { divisor: Operand::Reg(Reg::Rcx), signed: true }).unwrap();
+        assert_eq!(st.get(Reg::Rax) as i64, -3);
+        assert_eq!(st.get(Reg::Rdx) as i64, -2);
+    }
+
+    #[test]
+    fn divide_by_zero_traps() {
+        let mut st = CpuState::default();
+        st.set(Reg::Rax, 1);
+        st.set(Reg::Rcx, 0);
+        let err = exec(&mut st, &Instr::Div { divisor: Operand::Reg(Reg::Rcx), signed: false }).unwrap_err();
+        assert!(matches!(err, Trap::DivideError(_)));
+    }
+
+    #[test]
+    fn signed_overflow_div_traps() {
+        // i64::MIN / -1 overflows the quotient ⇒ #DE, like real hardware.
+        let mut st = CpuState::default();
+        st.set(Reg::Rax, i64::MIN as u64);
+        exec(&mut st, &Instr::Cqo).unwrap();
+        st.set(Reg::Rcx, (-1i64) as u64);
+        let err = exec(&mut st, &Instr::Div { divisor: Operand::Reg(Reg::Rcx), signed: true }).unwrap_err();
+        assert!(matches!(err, Trap::DivideError(_)));
+    }
 }

--- a/code/packages/rust/x86-simulator/src/trap.rs
+++ b/code/packages/rust/x86-simulator/src/trap.rs
@@ -21,6 +21,9 @@ pub enum Trap {
     UnresolvedExternal(String),
     /// Execution ran longer than the step budget (runaway-loop backstop).
     StepLimitExceeded,
+    /// `div`/`idiv` by zero, or a quotient that overflows the destination — the
+    /// `#DE` divide-error fault on real hardware (carries the instruction offset).
+    DivideError(u64),
 }
 
 impl std::fmt::Display for Trap {
@@ -32,6 +35,7 @@ impl std::fmt::Display for Trap {
                 write!(f, "undecoded opcode {opcode:#04x} at {offset:#x}"),
             Trap::UnresolvedExternal(s) => write!(f, "unresolved external symbol {s:?}"),
             Trap::StepLimitExceeded => write!(f, "step limit exceeded"),
+            Trap::DivideError(a) => write!(f, "divide error (#DE) at {a:#x}"),
         }
     }
 }

--- a/code/packages/rust/x86-simulator/tests/lang_matrix_x86.rs
+++ b/code/packages/rust/x86-simulator/tests/lang_matrix_x86.rs
@@ -259,3 +259,21 @@ fn oct_complement_runs_on_x86_sim() {
     let (_code, out) = run_capturing_stdout(Language::Oct, "fn main() { out(1, ~0); }");
     assert_eq!(out, "255");
 }
+
+/// Nib — **unsigned division** (`84 / 2` ⇒ exit 42).  The `div` op lowers to the
+/// x86 unsigned-division sequence `xor rdx,rdx; div rcx` — exercising the
+/// group-3 `0xF7 /6` end-to-end (S4's unit tests cover `div` in isolation; this
+/// runs it from real backend output).
+#[test]
+fn nib_unsigned_division_runs_on_x86_sim() {
+    assert_eq!(run_on_x86_sim(Language::Nib, "fn main() -> u8 { return 84 / 2; }"), 42);
+}
+
+/// ALGOL — **signed integer division** (`85 div 2` ⇒ exit 42).  ALGOL's `div`
+/// lowers to the signed sequence `cqo; idiv rcx` — exercising `0xF7 /7` + `cqo`
+/// end-to-end (the `idiv`/`cqo` path S4 otherwise only unit-tests).
+#[test]
+fn algol_signed_division_runs_on_x86_sim() {
+    let src = "begin integer result; result := 85 div 2 end";
+    assert_eq!(run_on_x86_sim(Language::Algol60, src), 42);
+}

--- a/code/packages/rust/x86-simulator/tests/lang_matrix_x86.rs
+++ b/code/packages/rust/x86-simulator/tests/lang_matrix_x86.rs
@@ -99,6 +99,25 @@ fn run_on_x86_sim(lang: Language, src: &str) -> i32 {
     sim.run().expect("x86_64 machine code should run to a clean ret")
 }
 
+/// Like [`run_on_x86_sim`] but also returns whatever the program printed via the
+/// host `print_i64` / `putchar` shims — for the matrix's stdout-asserting cells
+/// (BASIC `PRINT`, Oct `out`, …) whose observable result is text, not an exit
+/// code.
+fn run_capturing_stdout(lang: Language, src: &str) -> (i32, String) {
+    let (funcs, entry) = compile_to_x86_functions(lang, src);
+    let mut builder = MachineCodeHarness::new();
+    for f in &funcs {
+        builder = builder.function(&f.name, &f.bytes, &f.relocs);
+    }
+    let mut sim = builder
+        .build(&entry)
+        .expect("harness should lay out + link the matrix program");
+    let code = sim.run().expect("x86_64 machine code should run to a clean ret");
+    let out = String::from_utf8(sim.stdout.clone())
+        .expect("captured stdout should be valid UTF-8");
+    (code, out)
+}
+
 // ===========================================================================
 // The cells — each `src` is a verbatim copy of a `lang_matrix.rs` NativeAot
 // cell; each `assert_eq!` is the same exit code the matrix asserts.
@@ -166,4 +185,77 @@ fn algol_static_array_runs_on_x86_sim() {
     let src = "begin integer array A[1:3]; integer result; \
                A[1] := 40; A[3] := 2; result := A[1] + A[3] end";
     assert_eq!(run_on_x86_sim(Language::Algol60, src), 42);
+}
+
+// ===========================================================================
+// S4 — broader coverage: more matrix programs run on the x86_64 column locally.
+// (Exploratory batch — confirm which the current opcode set already handles.)
+// ===========================================================================
+
+/// Twig — top-level value `define`s summed (`(define x 40)(define y 2)(+ x y)`
+/// ⇒ 42).  Exercises multiple typed registers in `main`.
+#[test]
+fn twig_define_runs_on_x86_sim() {
+    assert_eq!(run_on_x86_sim(Language::Twig, "(define x 40) (define y 2) (+ x y)"), 42);
+}
+
+/// Nib — `u8` saturating-add wrap guard (`200 +? 100` clamps to 255 ⇒ exit 1).
+/// Exercises a narrow add + a clamp branch (`cmp`/`jcc`) at u8 width.
+#[test]
+fn nib_u8_wrap_runs_on_x86_sim() {
+    let src = "fn main() -> u8 { let x: u8 = 200 +? 100; if x == 255 { return 1; } return 0; }";
+    assert_eq!(run_on_x86_sim(Language::Nib, src), 1);
+}
+
+/// Nib — unary `~` complement at u8 width (`~0` ⇒ 255 ⇒ exit 1).  Exercises the
+/// `not` op + the u8 value mask.
+#[test]
+fn nib_complement_runs_on_x86_sim() {
+    let src = "fn main() -> u8 { let x: u8 = ~0; if x == 255 { return 1; } return 0; }";
+    assert_eq!(run_on_x86_sim(Language::Nib, src), 1);
+}
+
+/// ALGOL — a switch / computed goto (`goto s[3]` ⇒ exit 49).  Exercises the
+/// 1-based index compare chain + multiple `jmp`/`jcc`/`label`s.
+#[test]
+fn algol_switch_runs_on_x86_sim() {
+    let src = "begin integer result; switch s := a1, a2, a3; integer i; i := 3; \
+               goto s[i]; a1: result := 1; goto done; a2: result := 2; goto done; \
+               a3: result := 49; done: end";
+    assert_eq!(run_on_x86_sim(Language::Algol60, src), 49);
+}
+
+/// ALGOL — `for`-loop sum of squares into an array (`1+4+9+16+25` ⇒ exit 55).
+/// Exercises a counted loop + `array_set`/`array_get` inside it.
+#[test]
+fn algol_for_loop_array_runs_on_x86_sim() {
+    let src = "begin integer array A[1:5]; integer i, result; \
+               for i := 1 step 1 until 5 do A[i] := i * i; \
+               result := 0; \
+               for i := 1 step 1 until 5 do result := result + A[i] end";
+    assert_eq!(run_on_x86_sim(Language::Algol60, src), 55);
+}
+
+/// Dartmouth BASIC — `PRINT 42` ⇒ stdout `42` via the `print_i64` host shim.
+#[test]
+fn basic_print_runs_on_x86_sim() {
+    let (_code, out) = run_capturing_stdout(Language::DartmouthBasic, "10 PRINT 42\n20 END\n");
+    assert_eq!(out, "42");
+}
+
+/// Dartmouth BASIC — `FOR`/`NEXT` accumulator summing 1..5 ⇒ stdout `15`.
+#[test]
+fn basic_for_loop_runs_on_x86_sim() {
+    let src = "10 LET S = 0\n20 FOR I = 1 TO 5\n30 LET S = S + I\n40 NEXT I\n50 PRINT S\n60 END\n";
+    let (_code, out) = run_capturing_stdout(Language::DartmouthBasic, src);
+    assert_eq!(out, "15");
+}
+
+/// Oct — bitwise complement (the `not` op → x86 `0xF7 /2`) printed via `out`
+/// (`fn main() { out(1, ~0); }` ⇒ stdout `255`, the u8-masked `-1`).  This is
+/// the cell that surfaced the missing group-3 `0xF7` opcode in the simulator.
+#[test]
+fn oct_complement_runs_on_x86_sim() {
+    let (_code, out) = run_capturing_stdout(Language::Oct, "fn main() { out(1, ~0); }");
+    assert_eq!(out, "255");
 }

--- a/code/specs/x86-runtime-simulator.md
+++ b/code/specs/x86-runtime-simulator.md
@@ -157,8 +157,18 @@ This harness is what `lang_matrix.rs` calls to run the x86_64 column locally.
    `lang_matrix.rs` (which would couple the matrix harness to a dev-dep on this
    crate), the run path lives in this crate's own integration test, keeping the
    "run our x86_64 codegen" capability self-contained where the simulator is.
-4. **S4 — 32-bit x86 (i386)**: operand/address-size handling + 32-bit decode, as
-   educational coverage (not on the run-our-codegen critical path).
+4. **S4 — group-3 opcodes + broader matrix coverage**: ✅ done. Running 8 more
+   matrix programs through the simulator (`tests/lang_matrix_x86.rs`, now 15
+   cells: Twig `define`, Nib u8-wrap/`~`, ALGOL switch + `for`-loop array, Oct
+   `out`/`~`, BASIC `PRINT`/`FOR`) surfaced a missing opcode: the backend's
+   `not`/`neg`/`div`/`idiv` lower to **group-3 `0xF7`** (+ `cqo` `0x99`), which
+   S1–S3 never decoded. Added them (dividing the 128-bit `rdx:rax` pair) plus a
+   `#DE` `Trap::DivideError` for divide-by-zero / quotient-overflow. This is the
+   pattern the simulator is *for*: broadening coverage flushes out real codegen
+   gaps the byte tests didn't. (x86-simulator 0.4.0.)
+5. **S5 — 32-bit x86 (i386)**: operand/address-size handling + 32-bit decode, as
+   educational coverage (not on the run-our-codegen critical path — no matrix
+   program emits 32-bit x86, so it's unit-tested against hand-assembled bytes).
 
 ## Open questions (for §0 sign-off)
 


### PR DESCRIPTION
## What

Broadens the **local** LANG-FULL x86_64 coverage the S3 simulator unlocked — from 7 cells to **15** — by running more matrix programs through the simulator on aarch64. Doing so immediately surfaced a **real missing opcode** and added it. That's exactly what the simulator is for: more coverage flushes out codegen gaps the x86_64-backend's byte tests never exercised.

## The gap it found

A Nib `~0` / Oct `out(1, ~0)` program trapped with `DecodeError { opcode: 0xF7 }`. The x86_64-backend lowers the IIR `not`/`neg`/division ops to the **group-3 `0xF7`** family (+ `cqo` `0x99`), which S1–S3 never decoded.

## Added

- **`not r/m64`** (`0xF7 /2`) — bitwise complement, no flags.
- **`neg r/m64`** (`0xF7 /3`) — two's-complement negate, flags as `sub 0, dst`.
- **`div`/`idiv r/m64`** (`0xF7 /6` unsigned, `/7` signed) — divides the full 128-bit `rdx:rax` pair, quotient→`rax`, remainder→`rdx`.
- **`cqo`** (`0x48 0x99`) — sign-extend `rax` into `rdx:rax` (the `idiv` preamble).
- **`Trap::DivideError`** — divide-by-zero **and** quotient-overflow raise the `#DE` analogue, fail-closed.
- **8 new matrix cells**: Twig `define`; Nib u8-wrap + `~`; ALGOL switch/computed-goto + `for`-loop sum-of-squares array; Dartmouth BASIC `PRINT` + `FOR`/`NEXT` (stdout-captured via a new `run_capturing_stdout` helper); Oct `out`/`~`.

## Tests / security

- **40 tests** (25 unit + 15 matrix). `not` runs end-to-end (Nib + Oct); `neg`/`div`/`idiv`/`cqo` get direct decode + execute unit tests (quotient/remainder, signed negatives, div-by-zero + signed-overflow traps).
- Security review (2 rounds): found + fixed a MEDIUM — the signed `idiv` divided **before** the range guard, so a crafted `rdx:rax = i128::MIN ÷ -1` panicked on i128 overflow. Now uses `checked_div`/`checked_rem` → clean `#DE` trap (real backend output can't reach it — it always `cqo`s — but the sandbox must never panic). Regression test added.

## Spec

`x86-runtime-simulator.md`: S4 = this; 32-bit x86 (i386) renumbered to S5 (educational — no matrix program emits 32-bit, so it's unit-tested vs hand-assembled bytes). x86-simulator 0.4.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)