### PR TITLE
feat(mycin-pharm): ground cyanide, methotrexate & iron antidotes (toxicology recall)

### DIFF
--- a/code/specs/data/mycin-2026/recall/pharm-edges.adj
+++ b/code/specs/data/mycin-2026/recall/pharm-edges.adj
@@ -122,4 +122,22 @@ rulebook pharm_facts {
         source "Fomepizole is the antidote of choice for patients who present early after toxic alcohol exposure."
         locator "https://www.ncbi.nlm.nih.gov/books/NBK482121/"
         trust authoritative
+
+    % --- EXPAND: hydroxocobalamin is the antidote for cyanide poisoning ------------
+    relate antidote_for(cyanide_poisoning, hydroxocobalamin)
+        source "Hydroxocobalamin can serve as an antidote for cyanide poisoning."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK557632/"
+        trust authoritative
+
+    % --- EXPAND: leucovorin (folinic acid) rescues methotrexate toxicity -----------
+    relate antidote_for(methotrexate_toxicity, leucovorin)
+        source "Leucovorin is FDA indicated after high dose methotrexate therapy in osteosarcoma to decrease the toxic effects of methotrexate or counter the toxic effects of folate antagonists."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK553114/"
+        trust authoritative
+
+    % --- EXPAND: deferoxamine chelates iron in iron toxicity -----------------------
+    relate antidote_for(iron_toxicity, deferoxamine)
+        source "Deferoxamine, a chelating agent that can remove iron from tissues and free iron from plasma, is indicated in patients with systemic toxicity, metabolic acidosis, worsening symptoms, or a serum iron level predictive of moderate or severe toxicity."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK459224/"
+        trust authoritative
 }

--- a/code/specs/data/mycin-2026/recall/pharm-recall.query.adj
+++ b/code/specs/data/mycin-2026/recall/pharm-recall.query.adj
@@ -25,3 +25,6 @@ import "pharm-edges.adj"
 ? antidote_for(warfarin_toxicity, $Antidote)     % expect vitamin_k (expand)
 ? antidote_for(organophosphate_poisoning, $Antidote)  % expect atropine (expand)
 ? antidote_for(toxic_alcohol_poisoning, $Antidote)    % expect fomepizole (expand)
+? antidote_for(cyanide_poisoning, $Antidote)          % expect hydroxocobalamin (expand)
+? antidote_for(methotrexate_toxicity, $Antidote)      % expect leucovorin (expand)
+? antidote_for(iron_toxicity, $Antidote)              % expect deferoxamine (expand)

--- a/code/specs/data/mycin-2026/recall/test_pharm_recall.py
+++ b/code/specs/data/mycin-2026/recall/test_pharm_recall.py
@@ -44,6 +44,9 @@ EXPECTED = [
     ("warfarin_toxicity", "antidote_for", "vitamin_k"),           # expand (NBK557622)
     ("organophosphate_poisoning", "antidote_for", "atropine"),    # expand (NBK470430)
     ("toxic_alcohol_poisoning", "antidote_for", "fomepizole"),    # expand (NBK482121)
+    ("cyanide_poisoning", "antidote_for", "hydroxocobalamin"),    # expand (NBK557632)
+    ("methotrexate_toxicity", "antidote_for", "leucovorin"),      # expand (NBK553114)
+    ("iron_toxicity", "antidote_for", "deferoxamine"),            # expand (NBK459224)
 ]
 VAR = {"drug_class": "Class", "mechanism": "MOA", "adverse_effect": "Effect",
        "antidote_for": "Antidote"}


### PR DESCRIPTION
## What

Third toxicology-antidote expansion of the pharm recall library, three high-yield board pairs:

- **antidote_for(cyanide_poisoning, hydroxocobalamin)** — NBK557632: "Hydroxocobalamin can serve as an antidote for cyanide poisoning."
- **antidote_for(methotrexate_toxicity, leucovorin)** — NBK553114: "Leucovorin is FDA indicated after high dose methotrexate therapy in osteosarcoma to decrease the toxic effects of methotrexate or counter the toxic effects of folate antagonists."
- **antidote_for(iron_toxicity, deferoxamine)** — NBK459224: "Deferoxamine, a chelating agent that can remove iron from tissues and free iron from plasma, is indicated in patients with systemic toxicity, …"

Each `trust authoritative`, single self-contained StatPearls span naming the poisoning + antidote. The `antidote_for` relation now covers **11** board-classic pairs (naloxone, flumazenil, acetylcysteine, protamine, digoxin_immune_fab, vitamin_k, atropine, fomepizole, hydroxocobalamin, leucovorin, deferoxamine).

## Changes (data-only)

- `pharm-edges.adj` — +3 `relate` clauses (inline source+locator)
- `pharm-recall.query.adj` — +3 binding queries
- `test_pharm_recall.py` — `EXPECTED` +3; `ibuprofen` negative-control abstain test unchanged

## Verification

- `test_pharm_recall: 3/3 passed`; ruff clean; data-only security review passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)