### PR TITLE
feat(visicalc-xaml): port the dark modern-spreadsheet UI polish to XAML

### DIFF
--- a/demo/visicalc-xaml/Engine.cs
+++ b/demo/visicalc-xaml/Engine.cs
@@ -476,6 +476,10 @@ public sealed class InfiniteSheetModel : IDisposable
     /// The A1 address of the selected cell (e.g. `"Z1000"`).
     public string InfAddress => $"{_session.ColumnLetters((uint)SelCol)}{SelRow}";
 
+    /// The engine's per-edit revision clock — bumps on every mutation. The
+    /// status footer shows it so the live recompute is visible while scrolling.
+    public ulong Revision => _session.CurrentRevision();
+
     /// One row's display strings (columns 1..TotalCols) — what a virtualized
     /// `ListView` item renders. A single engine `get_window` over a 1×N strip;
     /// returns an empty list if the request was rejected/oversized.

--- a/demo/visicalc-xaml/InfiniteSheet.xaml
+++ b/demo/visicalc-xaml/InfiniteSheet.xaml
@@ -16,6 +16,15 @@
      gutter is its own virtualized ListView slaved to the body's vertical scroll,
      and the column-letter header follows the body's horizontal pan.
 
+     Visually this mirrors the reference design language from the web demo
+     (demo/visicalc-html/infinite.html) — a dark, modern-spreadsheet surface built
+     from a small set of color tokens: an address pill + `fx` marker + a formula
+     field with an accent focus ring, segmented tool-button groups, zebra row
+     banding, a 2px accent selection ring with accent-tinted row/col headers, and a
+     hairline status footer. The same token set the Qt / Flutter / Compose ports
+     use. The button hover/pressed chrome is recolored by overriding the WinUI
+     Button theme brushes in Resources below (no custom ControlTemplate needed).
+
      NOTE: WinUI 3 (Windows App SDK) is Windows-only, so this view is built and
      run on Windows; this macOS checkout cannot `dotnet build` it. The
      engine-backed logic it drives (InfiniteSheetModel) is proven by the
@@ -25,89 +34,137 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
 
-    <Grid Background="#1E1E1E" Padding="8">
+    <UserControl.Resources>
+        <!-- Recolor the tool-button chip across all visual states by overriding the
+             stock WinUI Button theme brushes (resolved up the tree). This gives the
+             dark surface + hover/pressed/disabled chrome without a custom template. -->
+        <SolidColorBrush x:Key="ButtonBackground" Color="#21252C"/>
+        <SolidColorBrush x:Key="ButtonBackgroundPointerOver" Color="#2B313A"/>
+        <SolidColorBrush x:Key="ButtonBackgroundPressed" Color="#14171C"/>
+        <SolidColorBrush x:Key="ButtonBackgroundDisabled" Color="#21252C"/>
+        <SolidColorBrush x:Key="ButtonForeground" Color="#E8EAED"/>
+        <SolidColorBrush x:Key="ButtonForegroundPointerOver" Color="#FFFFFF"/>
+        <SolidColorBrush x:Key="ButtonForegroundPressed" Color="#E8EAED"/>
+        <SolidColorBrush x:Key="ButtonForegroundDisabled" Color="#9AA3B2"/>
+        <SolidColorBrush x:Key="ButtonBorderBrush" Color="#3A404B"/>
+        <SolidColorBrush x:Key="ButtonBorderBrushPointerOver" Color="#3A404B"/>
+        <SolidColorBrush x:Key="ButtonBorderBrushPressed" Color="#3A404B"/>
+        <SolidColorBrush x:Key="ButtonBorderBrushDisabled" Color="#2C313A"/>
+
+        <!-- A compact tool-button chip (rounded; the segmented-control look). -->
+        <Style x:Key="ToolChip" TargetType="Button">
+            <Setter Property="Height" Value="30"/>
+            <Setter Property="Padding" Value="11,0,11,0"/>
+            <Setter Property="BorderThickness" Value="1"/>
+            <Setter Property="CornerRadius" Value="5"/>
+            <Setter Property="FontSize" Value="12"/>
+            <Setter Property="FontFamily" Value="Consolas"/>
+            <Setter Property="VerticalAlignment" Value="Center"/>
+        </Style>
+    </UserControl.Resources>
+
+    <!-- Whole surface reads as one considered dark panel. -->
+    <Grid Background="#16181D" Padding="0">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
 
-        <!-- Formula bar: the selected cell's address + an editable source line,
-             plus "Fill ↓ 10" and Copy / Cut / Paste controls. -->
-        <Grid Grid.Row="0" Margin="0,0,0,6">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="64"/>
-                <ColumnDefinition Width="*"/>
-                <ColumnDefinition Width="Auto"/>
-            </Grid.ColumnDefinitions>
-            <TextBlock x:Name="AddressText" Grid.Column="0"
-                       VerticalAlignment="Center"
-                       Foreground="#9D9D9D" FontSize="12" FontFamily="Consolas"/>
-            <TextBox x:Name="FormulaBox" Grid.Column="1" Height="28"
-                     Background="#2D2D30" Foreground="#CCCCCC" BorderBrush="#3F3F46"
-                     FontSize="13" FontFamily="Consolas"
-                     KeyDown="FormulaBox_KeyDown"/>
-            <!-- Drag-fill + clipboard controls. -->
-            <StackPanel Grid.Column="2" Orientation="Horizontal">
-                <Button x:Name="FillButton" Margin="8,0,0,0" Height="28"
-                        Background="#2D2D30" Foreground="#CCCCCC" BorderBrush="#3F3F46"
-                        BorderThickness="1" FontSize="12" FontFamily="Consolas"
-                        Content="Fill ↓ 10"
-                        ToolTipService.ToolTip="Replicate the selected cell into the 10 rows below it"
-                        Click="FillButton_Click"/>
-                <Button x:Name="CopyButton" Margin="8,0,0,0" Height="28"
-                        Background="#2D2D30" Foreground="#CCCCCC" BorderBrush="#3F3F46"
-                        BorderThickness="1" FontSize="12" FontFamily="Consolas"
-                        Content="Copy"
-                        ToolTipService.ToolTip="Copy the selected cell to the clipboard"
-                        Click="CopyButton_Click"/>
-                <Button x:Name="CutButton" Margin="8,0,0,0" Height="28"
-                        Background="#2D2D30" Foreground="#CCCCCC" BorderBrush="#3F3F46"
-                        BorderThickness="1" FontSize="12" FontFamily="Consolas"
-                        Content="Cut"
-                        ToolTipService.ToolTip="Cut the selected cell (cleared when you paste)"
-                        Click="CutButton_Click"/>
-                <Button x:Name="PasteButton" Margin="8,0,0,0" Height="28"
-                        Background="#2D2D30" Foreground="#CCCCCC" BorderBrush="#3F3F46"
-                        BorderThickness="1" FontSize="12" FontFamily="Consolas"
-                        Content="Paste"
-                        ToolTipService.ToolTip="Paste the clipboard at the selected cell, shifting relative references"
-                        Click="PasteButton_Click"/>
-                <Button x:Name="SaveButton" Margin="8,0,0,0" Height="28"
-                        Background="#2D2D30" Foreground="#CCCCCC" BorderBrush="#3F3F46"
-                        BorderThickness="1" FontSize="12" FontFamily="Consolas"
-                        Content="Save"
-                        ToolTipService.ToolTip="Serialize the whole workbook to memory"
-                        Click="SaveButton_Click"/>
-                <Button x:Name="LoadButton" Margin="8,0,0,0" Height="28"
-                        Background="#2D2D30" Foreground="#CCCCCC" BorderBrush="#3F3F46"
-                        BorderThickness="1" FontSize="12" FontFamily="Consolas"
-                        Content="Load"
-                        ToolTipService.ToolTip="Restore the workbook from the last save"
-                        Click="LoadButton_Click"/>
-                <Button x:Name="UndoButton" Margin="8,0,0,0" Height="28"
-                        Background="#2D2D30" Foreground="#CCCCCC" BorderBrush="#3F3F46"
-                        BorderThickness="1" FontSize="12" FontFamily="Consolas"
-                        Content="Undo"
-                        ToolTipService.ToolTip="Undo the last edit"
-                        Click="UndoButton_Click"/>
-                <Button x:Name="RedoButton" Margin="8,0,0,0" Height="28"
-                        Background="#2D2D30" Foreground="#CCCCCC" BorderBrush="#3F3F46"
-                        BorderThickness="1" FontSize="12" FontFamily="Consolas"
-                        Content="Redo"
-                        ToolTipService.ToolTip="Redo the last undone edit"
-                        Click="RedoButton_Click"/>
-            </StackPanel>
-        </Grid>
+        <!-- Formula bar: a rounded panel holding the address pill, an `fx` marker,
+             the editable source line (accent focus ring), and segmented button
+             groups (drag-fill · clipboard · file · history) divided by thin rules. -->
+        <Border Grid.Row="0" Margin="10,10,10,6" Padding="8"
+                Background="#1B1E24" BorderBrush="#2C313A" BorderThickness="1" CornerRadius="8">
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto"/>
+                    <ColumnDefinition Width="Auto"/>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="Auto"/>
+                </Grid.ColumnDefinitions>
 
-        <!-- Column-letter header (frozen vertically, follows horizontal pan). -->
-        <Grid Grid.Row="1" Margin="0,0,0,0">
+                <!-- Address pill. -->
+                <Border Grid.Column="0" Width="46" Height="30" CornerRadius="5"
+                        Background="#21252C" BorderBrush="#3A404B" BorderThickness="1">
+                    <TextBlock x:Name="AddressText"
+                               HorizontalAlignment="Center" VerticalAlignment="Center"
+                               Foreground="#E8EAED" FontSize="12" FontWeight="SemiBold"
+                               FontFamily="Consolas"/>
+                </Border>
+
+                <!-- fx marker. -->
+                <TextBlock Grid.Column="1" Text="fx" Margin="6,0,6,0"
+                           VerticalAlignment="Center"
+                           Foreground="#9AA3B2" FontSize="12" FontStyle="Italic"
+                           FontFamily="Consolas"/>
+
+                <!-- Formula field — accent focus ring on edit (toggled in code-behind). -->
+                <Border x:Name="FormulaFieldBorder" Grid.Column="2" Height="30" CornerRadius="5"
+                        Background="#0F1115" BorderBrush="#3A404B" BorderThickness="1">
+                    <TextBox x:Name="FormulaBox"
+                             Background="Transparent" BorderThickness="0"
+                             Foreground="#E8EAED" FontSize="13" FontFamily="Consolas"
+                             VerticalAlignment="Center"
+                             GotFocus="FormulaBox_GotFocus" LostFocus="FormulaBox_LostFocus"
+                             KeyDown="FormulaBox_KeyDown"/>
+                </Border>
+
+                <!-- Segmented button groups, separated by thin rules. -->
+                <StackPanel Grid.Column="3" Orientation="Horizontal" Margin="6,0,0,0">
+                    <!-- Drag-fill -->
+                    <Button x:Name="FillButton" Style="{StaticResource ToolChip}"
+                            Content="↓ Fill 10"
+                            ToolTipService.ToolTip="Replicate the selected cell into the 10 rows below it"
+                            Click="FillButton_Click"/>
+                    <Border Width="1" Height="22" Margin="6,0,6,0" Background="#2C313A"/>
+                    <!-- Clipboard -->
+                    <Button x:Name="CopyButton" Style="{StaticResource ToolChip}" Margin="0,0,6,0"
+                            Content="Copy"
+                            ToolTipService.ToolTip="Copy the selected cell to the clipboard"
+                            Click="CopyButton_Click"/>
+                    <Button x:Name="CutButton" Style="{StaticResource ToolChip}" Margin="0,0,6,0"
+                            Content="Cut"
+                            ToolTipService.ToolTip="Cut the selected cell (cleared when you paste)"
+                            Click="CutButton_Click"/>
+                    <Button x:Name="PasteButton" Style="{StaticResource ToolChip}"
+                            Content="Paste"
+                            ToolTipService.ToolTip="Paste the clipboard at the selected cell, shifting relative references"
+                            Click="PasteButton_Click"/>
+                    <Border Width="1" Height="22" Margin="6,0,6,0" Background="#2C313A"/>
+                    <!-- File (save / load) -->
+                    <Button x:Name="SaveButton" Style="{StaticResource ToolChip}" Margin="0,0,6,0"
+                            Content="Save"
+                            ToolTipService.ToolTip="Serialize the whole workbook to memory"
+                            Click="SaveButton_Click"/>
+                    <Button x:Name="LoadButton" Style="{StaticResource ToolChip}"
+                            Content="Load"
+                            ToolTipService.ToolTip="Restore the workbook from the last save"
+                            Click="LoadButton_Click"/>
+                    <Border Width="1" Height="22" Margin="6,0,6,0" Background="#2C313A"/>
+                    <!-- History (undo / redo) -->
+                    <Button x:Name="UndoButton" Style="{StaticResource ToolChip}" Margin="0,0,6,0"
+                            Content="↶ Undo"
+                            ToolTipService.ToolTip="Undo the last edit"
+                            Click="UndoButton_Click"/>
+                    <Button x:Name="RedoButton" Style="{StaticResource ToolChip}"
+                            Content="↷ Redo"
+                            ToolTipService.ToolTip="Redo the last undone edit"
+                            Click="RedoButton_Click"/>
+                </StackPanel>
+            </Grid>
+        </Border>
+
+        <!-- Column-letter header (frozen vertically, follows horizontal pan). The
+             selected column's header tints to the accent (rebuilt on selection). -->
+        <Grid Grid.Row="1" Margin="10,0,10,0">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="64"/>
                 <ColumnDefinition Width="*"/>
             </Grid.ColumnDefinitions>
-            <Border Grid.Column="0" Width="64" Height="26"
-                    Background="#2D2D30" BorderBrush="#3F3F46" BorderThickness="0.5"/>
+            <Border Grid.Column="0" Width="64" Height="28"
+                    Background="#20242B" BorderBrush="#2C313A" BorderThickness="0.5"/>
             <ScrollViewer x:Name="HeaderScroll" Grid.Column="1"
                           HorizontalScrollMode="Enabled" HorizontalScrollBarVisibility="Hidden"
                           VerticalScrollMode="Disabled" VerticalScrollBarVisibility="Disabled">
@@ -116,7 +173,7 @@
         </Grid>
 
         <!-- Body: row-number gutter (frozen left) + virtualized cell grid. -->
-        <Grid Grid.Row="2">
+        <Grid Grid.Row="2" Margin="10,0,10,0">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="64"/>
                 <ColumnDefinition Width="*"/>
@@ -132,8 +189,8 @@
                 <ListView.ItemContainerStyle>
                     <Style TargetType="ListViewItem">
                         <Setter Property="Padding" Value="0"/>
-                        <Setter Property="MinHeight" Value="24"/>
-                        <Setter Property="Height" Value="24"/>
+                        <Setter Property="MinHeight" Value="26"/>
+                        <Setter Property="Height" Value="26"/>
                         <Setter Property="HorizontalContentAlignment" Value="Stretch"/>
                     </Style>
                 </ListView.ItemContainerStyle>
@@ -152,13 +209,21 @@
                     <ListView.ItemContainerStyle>
                         <Style TargetType="ListViewItem">
                             <Setter Property="Padding" Value="0"/>
-                            <Setter Property="MinHeight" Value="24"/>
-                            <Setter Property="Height" Value="24"/>
+                            <Setter Property="MinHeight" Value="26"/>
+                            <Setter Property="Height" Value="26"/>
                             <Setter Property="HorizontalContentAlignment" Value="Stretch"/>
                         </Style>
                     </ListView.ItemContainerStyle>
                 </ListView>
             </ScrollViewer>
         </Grid>
+
+        <!-- Status line: a hairline-separated footer echoing the live virtual-grid
+             size and the per-edit revision clock (mirrors the sibling demos). -->
+        <StackPanel Grid.Row="3" Margin="10,0,10,10">
+            <Border Height="1" Background="#2C313A"/>
+            <TextBlock x:Name="StatusText" Margin="0,6,0,0"
+                       Foreground="#9AA3B2" FontSize="12" FontFamily="Consolas"/>
+        </StackPanel>
     </Grid>
 </UserControl>

--- a/demo/visicalc-xaml/InfiniteSheet.xaml.cs
+++ b/demo/visicalc-xaml/InfiniteSheet.xaml.cs
@@ -35,14 +35,24 @@ namespace Mosaic.Generated;
 
 public sealed partial class InfiniteSheet : UserControl
 {
-    private const double ColW = 90, RowH = 24, GutterW = 64, HeadH = 26;
+    // Roomier geometry, to match the web reference.
+    private const double ColW = 92, RowH = 26, GutterW = 64, HeadH = 28;
 
-    private static readonly SolidColorBrush Bg = New(0x1E, 0x1E, 0x1E);
-    private static readonly SolidColorBrush Chrome = New(0x2D, 0x2D, 0x30);
-    private static readonly SolidColorBrush BorderC = New(0x3F, 0x3F, 0x46);
-    private static readonly SolidColorBrush Ink = New(0xCC, 0xCC, 0xCC);
-    private static readonly SolidColorBrush Dim = New(0x9D, 0x9D, 0x9D);
-    private static readonly SolidColorBrush Sel = New(0x09, 0x47, 0x71);
+    // ── Design tokens ──────────────────────────────────────────────────
+    // Mirror demo/visicalc-html/infinite.html's palette so every VisiCalc backend
+    // reads as one considered surface (dark modern spreadsheet). Same token set as
+    // the Qt / Flutter / Compose ports.
+    private static readonly SolidColorBrush Bg = New(0x16, 0x18, 0x1D); // base cell
+    private static readonly SolidColorBrush Panel = New(0x1B, 0x1E, 0x24); // zebra band
+    private static readonly SolidColorBrush Line = New(0x2C, 0x31, 0x3A); // hairline borders
+    private static readonly SolidColorBrush LineStrong = New(0x3A, 0x40, 0x4B); // control borders
+    private static readonly SolidColorBrush Head = New(0x20, 0x24, 0x2B); // row/col headers
+    private static readonly SolidColorBrush HeadSel = New(0x2B, 0x33, 0x40); // header of selected row/col
+    private static readonly SolidColorBrush Ink = New(0xE8, 0xEA, 0xED); // primary text
+    private static readonly SolidColorBrush Muted = New(0x9A, 0xA3, 0xB2); // labels, headers
+    private static readonly SolidColorBrush Accent = New(0x4A, 0xA3, 0xFF); // selection + focus
+    private static readonly SolidColorBrush White = New(0xFF, 0xFF, 0xFF);
+    private static readonly SolidColorBrush Sel = New(0x21, 0x34, 0x4A); // selected-cell fill
     private static readonly FontFamily Mono = new("Consolas");
 
     private readonly InfiniteSheetModel _model = new();
@@ -83,11 +93,12 @@ public sealed partial class InfiniteSheet : UserControl
                 _gutterInnerSv?.ChangeView(null, _bodyInnerSv.VerticalOffset, null, true);
     }
 
-    // ── Header (built once) ──────────────────────────────────────────
+    // ── Header (rebuilt on selection so the selected column tints to accent) ──
     private void BuildHeader()
     {
+        HeaderPanel.Children.Clear();
         for (int c = 1; c <= _model.TotalCols; c++)
-            HeaderPanel.Children.Add(ChromeCell(ColW, HeadH, _model.ColumnLetters(c)));
+            HeaderPanel.Children.Add(ChromeCell(ColW, HeadH, _model.ColumnLetters(c), _model.SelCol == c));
     }
 
     // ── Virtualized body + gutter population ─────────────────────────
@@ -103,16 +114,19 @@ public sealed partial class InfiniteSheet : UserControl
     {
         if (args.InRecycleQueue) return;
         int rowNum = (int)args.Item;
-        args.ItemContainer.Content = ChromeCell(GutterW, RowH, rowNum.ToString());
+        // The selected row's gutter label tints to the accent.
+        args.ItemContainer.Content = ChromeCell(GutterW, RowH, rowNum.ToString(), _model.SelRow == rowNum);
         args.Handled = true;
     }
 
     /// One body row: a horizontal strip of tappable cells. A single engine read
-    /// (RowCells) fills the whole row.
+    /// (RowCells) fills the whole row. Selected → accent fill + 2px accent ring;
+    /// otherwise a zebra band (even rows take the panel tint).
     private StackPanel BuildRow(int rowNum)
     {
         var sp = new StackPanel { Orientation = Orientation.Horizontal };
         IReadOnlyList<string> cells = _model.RowCells(rowNum);
+        SolidColorBrush band = rowNum % 2 == 0 ? Panel : Bg;
         for (int c = 1; c <= _model.TotalCols; c++)
         {
             string text = (c - 1) < cells.Count ? cells[c - 1] : string.Empty;
@@ -122,18 +136,19 @@ public sealed partial class InfiniteSheet : UserControl
             {
                 Width = ColW,
                 Height = RowH,
-                Background = selected ? Sel : Bg,
-                BorderBrush = BorderC,
-                BorderThickness = new Thickness(0.5),
+                Background = selected ? Sel : band,
+                BorderBrush = selected ? Accent : Line,
+                BorderThickness = new Thickness(selected ? 2 : 0.5),
                 Child = new TextBlock
                 {
                     Text = text,
-                    Foreground = Ink,
+                    Foreground = selected ? White : Ink,
                     FontSize = 12,
                     FontFamily = Mono,
+                    FontWeight = selected ? FontWeights.SemiBold : FontWeights.Normal,
                     HorizontalAlignment = HorizontalAlignment.Right,
                     VerticalAlignment = VerticalAlignment.Center,
-                    Margin = new Thickness(0, 0, 4, 0),
+                    Margin = new Thickness(0, 0, 6, 0),
                     TextTrimming = TextTrimming.CharacterEllipsis,
                 },
             };
@@ -143,19 +158,22 @@ public sealed partial class InfiniteSheet : UserControl
         return sp;
     }
 
-    private Border ChromeCell(double w, double h, string text) => new()
+    /// A frozen header/gutter cell. When [selected] (its row/column holds the
+    /// cursor) it tints to the accent.
+    private Border ChromeCell(double w, double h, string text, bool selected = false) => new()
     {
         Width = w,
         Height = h,
-        Background = Chrome,
-        BorderBrush = BorderC,
+        Background = selected ? HeadSel : Head,
+        BorderBrush = Line,
         BorderThickness = new Thickness(0.5),
         Child = new TextBlock
         {
             Text = text,
-            Foreground = Dim,
-            FontSize = 12,
+            Foreground = selected ? Accent : Muted,
+            FontSize = 11,
             FontFamily = Mono,
+            FontWeight = FontWeights.SemiBold,
             HorizontalAlignment = HorizontalAlignment.Center,
             VerticalAlignment = VerticalAlignment.Center,
         },
@@ -176,6 +194,20 @@ public sealed partial class InfiniteSheet : UserControl
         RefreshFormulaBar();
         RepaintRealizedRows();
         e.Handled = true;
+    }
+
+    // The formula field's accent focus ring: thicken + tint the wrapping border
+    // while the box has focus (the WinUI analog of the web demo's :focus ring).
+    private void FormulaBox_GotFocus(object sender, RoutedEventArgs e)
+    {
+        FormulaFieldBorder.BorderBrush = Accent;
+        FormulaFieldBorder.BorderThickness = new Thickness(2);
+    }
+
+    private void FormulaBox_LostFocus(object sender, RoutedEventArgs e)
+    {
+        FormulaFieldBorder.BorderBrush = LineStrong;
+        FormulaFieldBorder.BorderThickness = new Thickness(1);
     }
 
     /// Drag-fill: replicate the selected cell into the 10 rows below it. The
@@ -249,19 +281,31 @@ public sealed partial class InfiniteSheet : UserControl
         AddressText.Text = _model.InfAddress;
         FormulaBox.Text = _model.Formula;
         RefreshHistoryButtons();
+        UpdateStatus();
     }
 
-    /// Rebuild only the currently-realized body rows so selection highlight and
-    /// recomputed values show. ContainerFromItem returns null for virtualized
-    /// (off-screen) rows, so this touches just what's on screen.
+    /// The hairline footer: the live virtual-grid size + the per-edit revision
+    /// clock (mirrors the web/Qt/Flutter/Compose status lines).
+    private void UpdateStatus() =>
+        StatusText.Text =
+            $"Virtual grid: {_model.TotalRows} rows × {_model.TotalCols} cols  ·  revision {_model.Revision}";
+
+    /// Rebuild only the currently-realized rows (body + gutter) and the header so
+    /// the selection highlight, accent-tinted row/column headers, and recomputed
+    /// values show. ContainerFromItem returns null for virtualized (off-screen)
+    /// rows, so this touches just what's on screen.
     private void RepaintRealizedRows()
     {
         foreach (int rowNum in _rowNumbers)
         {
-            if (BodyList.ContainerFromItem(rowNum) is ListViewItem { Content: StackPanel } item)
-                item.Content = BuildRow(rowNum);
+            if (BodyList.ContainerFromItem(rowNum) is ListViewItem { Content: StackPanel } bodyItem)
+                bodyItem.Content = BuildRow(rowNum);
+            if (GutterList.ContainerFromItem(rowNum) is ListViewItem { Content: Border } gutterItem)
+                gutterItem.Content = ChromeCell(GutterW, RowH, rowNum.ToString(), _model.SelRow == rowNum);
         }
+        BuildHeader(); // re-tint the selected column's header
         RefreshHistoryButtons(); // fill/paste mutate the doc → re-gate Undo/Redo
+        UpdateStatus();
     }
 
     // ── Scroll sync ──────────────────────────────────────────────────

--- a/demo/visicalc-xaml/README.md
+++ b/demo/visicalc-xaml/README.md
@@ -170,6 +170,27 @@ edit is reversible and a restored formula recomputes live.
 (`Z1000`, `BA50`, `BB50`) and derives the extent from `UsedRange()` + a margin
 (saturated in `long` then clamped to `int`, guarding the u32-overflow case).
 
+#### Visual design
+
+`InfiniteSheet.xaml` / `.xaml.cs` mirror the **reference visual language** defined
+by the web demo (`demo/visicalc-html/infinite.html`) so every VisiCalc backend
+reads as one considered dark, modern-spreadsheet surface — the same token set the
+Qt, Flutter, and Compose ports use. The palette lives in a small set of
+`SolidColorBrush` design tokens at the top of the code-behind (`Bg`/`Panel`/
+`Line`/`LineStrong`/`Head`/`HeadSel`/`Ink`/`Muted`/`Accent`/`Sel`), echoing the
+web demo's CSS custom properties. From those it builds: a panel-wrapped **toolbar**
+with an address **pill**, an italic `fx` marker, then a grown formula field with
+an accent **focus ring** (the wrapping `Border` thickens + tints to the accent on
+`GotFocus`); the actions are **segmented button groups** (drag-fill · clipboard ·
+file · history) — a rounded `ToolChip` button style whose hover/pressed/disabled
+chrome is recolored by overriding the stock WinUI `Button*` theme brushes in
+`UserControl.Resources` (no custom `ControlTemplate`) — separated by thin rules.
+The grid gets subtle **zebra** row banding (`rowNum % 2`), a 2-px **accent
+selection ring**, and the selected cell's **row + column headers tint to the
+accent** (the header is rebuilt and the realized gutter rows repainted on
+selection); a hairline-separated **status footer** echoes the live virtual-grid
+size and revision.
+
 ### Verification
 
 The WinUI view itself is Windows-only — this macOS checkout cannot `dotnet


### PR DESCRIPTION
## What

Ports the **reference visual language** (web demo `demo/visicalc-html/infinite.html`, #6411; Qt #6417; Flutter #6419; Compose #6426) to the **WinUI 3 / XAML** `InfiniteSheet`, so every VisiCalc backend reads as one considered dark, modern-spreadsheet surface. Fifth backend in the UI-polish rollout (web → Qt → Flutter → Compose → **XAML** → SwiftUI).

## Changes

**`InfiniteSheet.xaml`** — toolbar wrapped in a rounded panel: address **pill**, italic **`fx`** marker, a grown formula field inside a `Border` that becomes a 2px **accent focus ring** on edit, and the actions regrouped into **segmented button groups** (drag-fill · clipboard · file · history) separated by thin rules. A rounded `ToolChip` `Button` style; the hover/pressed/disabled chrome is recolored by **overriding the stock WinUI `Button*` theme brushes** in `UserControl.Resources` (no custom `ControlTemplate`). Adds a hairline status-footer row.

**`InfiniteSheet.xaml.cs`** — design-token `SolidColorBrush` palette (`Bg`/`Panel`/`Line`/`LineStrong`/`Head`/`HeadSel`/`Ink`/`Muted`/`Accent`/`Sel`) mirroring the web demo's CSS custom properties + roomier geometry. `BuildRow` gains **zebra** banding + a 2px **accent selection ring** + bold white selected text; `ChromeCell` gains a `selected` param so the selected **row + column headers tint to the accent** (header rebuilt + realized gutter rows repainted on selection); `FormulaBox` GotFocus/LostFocus toggle the field's accent ring; a `UpdateStatus` **status footer** echoes the virtual-grid size + revision.

**`Engine.cs`** — add `ulong Revision => _session.CurrentRevision()` on `InfiniteSheetModel` for the footer.

## No behavior change

The existing engine calls (`CommitInf`/`FillDown`/`CopyCell`/`CutCell`/`PasteCell`/`SaveBook`/`LoadBook`/`UndoEdit`/`RedoEdit`) are only re-skinned, not rewired.

## Verification

The WinUI view is **Windows-only** — this macOS checkout cannot `dotnet build` it (the documented boundary), so it's hand-authored against the existing patterns. The engine-backed model it drives is proven cross-platform by **`scripts/verify.sh`** (the `test/` console harness P/Invoking the engine) — **ALL PASS**, including the new `Revision` accessor riding the same session. `verify.sh` asserts the formatted display strings (`38.00`/`169.00`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)