### PR TITLE
feat(mycin-genetics): ground myotonic dystrophy & Friedreich ataxia edges

### DIFF
--- a/code/specs/data/mycin-2026/recall/genetics-edges.adj
+++ b/code/specs/data/mycin-2026/recall/genetics-edges.adj
@@ -92,4 +92,22 @@ rulebook genetics_facts {
         source "Mutations in the dystrophin gene result in diseases known as dystrophinopathies, which encompass Duchenne muscular dystrophy, Becker muscular dystrophy, and an intermediate form."
         locator "https://www.ncbi.nlm.nih.gov/books/NBK482346/"
         trust authoritative
+
+    % --- EXPAND: myotonic dystrophy (CTG expansion in DMPK) — one span names both --
+    % The page's defined abbreviation DM1 = myotonic dystrophy type 1; one declarative
+    % names the CTG repeat AND the DMPK gene, grounding both edges.
+    relate trinucleotide_repeat(myotonic_dystrophy, ctg)
+        source "DM1 is caused by expansion of cytosine-thymine-guanine (CTG) repeat in the 3'-untranslated region of the DM1 protein kinase (DMPK) gene on chromosome 19q13.3."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK557446/"
+        trust authoritative
+    relate gene_defect(myotonic_dystrophy, dmpk)
+        source "DM1 is caused by expansion of cytosine-thymine-guanine (CTG) repeat in the 3'-untranslated region of the DM1 protein kinase (DMPK) gene on chromosome 19q13.3."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK557446/"
+        trust authoritative
+
+    % --- EXPAND: Friedreich ataxia (FXN gene) ---------------------------
+    relate gene_defect(friedreich_ataxia, fxn)
+        source "Friedreich ataxia results from loss-of-function mutations in the frataxin (FXN) gene, located in the centromeric region of chromosome 9q (9q13 to 21.1)."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK563199/"
+        trust authoritative
 }

--- a/code/specs/data/mycin-2026/recall/genetics-recall.query.adj
+++ b/code/specs/data/mycin-2026/recall/genetics-recall.query.adj
@@ -23,3 +23,6 @@ import "genetics-edges.adj"
 ? inheritance(cystic_fibrosis, $Pattern)               % expect autosomal_recessive (expand)
 ? gene_defect(cystic_fibrosis, $Gene)                  % expect cftr (expand)
 ? gene_defect(duchenne_muscular_dystrophy, $Gene)      % expect dystrophin (expand)
+? trinucleotide_repeat(myotonic_dystrophy, $Repeat)    % expect ctg (expand)
+? gene_defect(myotonic_dystrophy, $Gene)               % expect dmpk (expand)
+? gene_defect(friedreich_ataxia, $Gene)                % expect fxn (expand)

--- a/code/specs/data/mycin-2026/recall/test_genetics_recall.py
+++ b/code/specs/data/mycin-2026/recall/test_genetics_recall.py
@@ -42,6 +42,9 @@ EXPECTED = [
     ("cystic_fibrosis", "inheritance", "autosomal_recessive"),       # expand (NBK493206)
     ("cystic_fibrosis", "gene_defect", "cftr"),                      # expand (NBK493206)
     ("duchenne_muscular_dystrophy", "gene_defect", "dystrophin"),    # expand (NBK482346)
+    ("myotonic_dystrophy", "trinucleotide_repeat", "ctg"),           # expand (NBK557446)
+    ("myotonic_dystrophy", "gene_defect", "dmpk"),                   # expand (NBK557446)
+    ("friedreich_ataxia", "gene_defect", "fxn"),                     # expand (NBK563199)
 ]
 VAR = {"inheritance": "Pattern", "gene_defect": "Gene",
        "trinucleotide_repeat": "Repeat", "imprinting": "Parent"}


### PR DESCRIPTION
## What

Expands the genetics recall library with three grounded edges, each defended by a clean StatPearls span:

- **trinucleotide_repeat(myotonic_dystrophy, ctg)** + **gene_defect(myotonic_dystrophy, dmpk)** — NBK557446 (one span grounds both; **DM1** = the page's defined abbreviation for myotonic dystrophy type 1):
  > DM1 is caused by expansion of cytosine-thymine-guanine (CTG) repeat in the 3'-untranslated region of the DM1 protein kinase (DMPK) gene on chromosome 19q13.3.
- **gene_defect(friedreich_ataxia, fxn)** — NBK563199:
  > Friedreich ataxia results from loss-of-function mutations in the frataxin (FXN) gene, located in the centromeric region of chromosome 9q (9q13 to 21.1).

**Honest scope:** the Friedreich **GAA-repeat** edge is deferred — every StatPearls span found names the GAA expansion via an anaphoric "this condition"/"FRDA" rather than spelling "Friedreich ataxia" alongside "GAA" in one self-contained sentence. Grounding it would over-reach the both-endpoints rule.

## Changes (data-only)

- `genetics-edges.adj` — +3 `relate` clauses (inline source+locator)
- `genetics-recall.query.adj` — +3 binding queries
- `test_genetics_recall.py` — `EXPECTED` +3; `ehlers_danlos_syndrome` negative-control abstain test unchanged

## Verification

- `test_genetics_recall: 3/3 passed`; ruff clean; data-only security review passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)