### PR TITLE
feat(mycin-pharm): ground glucagon, methylene blue & succimer antidotes

### DIFF
--- a/code/specs/data/mycin-2026/recall/pharm-edges.adj
+++ b/code/specs/data/mycin-2026/recall/pharm-edges.adj
@@ -140,4 +140,21 @@ rulebook pharm_facts {
         source "Deferoxamine, a chelating agent that can remove iron from tissues and free iron from plasma, is indicated in patients with systemic toxicity, metabolic acidosis, worsening symptoms, or a serum iron level predictive of moderate or severe toxicity."
         locator "https://www.ncbi.nlm.nih.gov/books/NBK459224/"
         trust authoritative
+    % --- EXPAND: glucagon is the treatment of choice for beta-blocker overdose -----
+    relate antidote_for(beta_blocker_overdose, glucagon)
+        source "Although there have been no controlled trials to prove the efficacy of glucagon in poisoning beta-blocker overdose, glucagon is considered as a useful treatment of choice."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK448097/"
+        trust authoritative
+
+    % --- EXPAND: methylene blue is the FDA-approved treatment for methemoglobinemia -
+    relate antidote_for(methemoglobinemia, methylene_blue)
+        source "Methylene blue is approved by the Food and Drug Administration (FDA) as a treatment for acquired methemoglobinemia, a condition in which hemoglobin iron is oxidized from the ferrous (Fe2+) to ferric (Fe3+) state."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK557593/"
+        trust authoritative
+
+    % --- EXPAND: succimer (DMSA) chelates lead in lead poisoning -------------------
+    relate antidote_for(lead_poisoning, succimer)
+        source "A variety of chelating agents alone or in combination can be used depending on the severity of clinical presentation and the patient's blood lead concentration, including succimer, calcium disodium ethylenediaminetetraacetic acid (EDTA), and British anti-Lewisite (BAL, also known as dimercaprol)."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK541097/"
+        trust authoritative
 }

--- a/code/specs/data/mycin-2026/recall/pharm-recall.query.adj
+++ b/code/specs/data/mycin-2026/recall/pharm-recall.query.adj
@@ -28,3 +28,6 @@ import "pharm-edges.adj"
 ? antidote_for(cyanide_poisoning, $Antidote)          % expect hydroxocobalamin (expand)
 ? antidote_for(methotrexate_toxicity, $Antidote)      % expect leucovorin (expand)
 ? antidote_for(iron_toxicity, $Antidote)              % expect deferoxamine (expand)
+? antidote_for(beta_blocker_overdose, $Antidote)      % expect glucagon (expand)
+? antidote_for(methemoglobinemia, $Antidote)          % expect methylene_blue (expand)
+? antidote_for(lead_poisoning, $Antidote)             % expect succimer (expand)

--- a/code/specs/data/mycin-2026/recall/test_pharm_recall.py
+++ b/code/specs/data/mycin-2026/recall/test_pharm_recall.py
@@ -47,6 +47,9 @@ EXPECTED = [
     ("cyanide_poisoning", "antidote_for", "hydroxocobalamin"),    # expand (NBK557632)
     ("methotrexate_toxicity", "antidote_for", "leucovorin"),      # expand (NBK553114)
     ("iron_toxicity", "antidote_for", "deferoxamine"),            # expand (NBK459224)
+    ("beta_blocker_overdose", "antidote_for", "glucagon"),        # expand (NBK448097)
+    ("methemoglobinemia", "antidote_for", "methylene_blue"),      # expand (NBK557593)
+    ("lead_poisoning", "antidote_for", "succimer"),               # expand (NBK541097)
 ]
 VAR = {"drug_class": "Class", "mechanism": "MOA", "adverse_effect": "Effect",
        "antidote_for": "Antidote"}


### PR DESCRIPTION
## What

Fourth toxicology-antidote expansion, three high-yield board pairs (clean StatPearls spans):

- **antidote_for(beta_blocker_overdose, glucagon)** — NBK448097
- **antidote_for(methemoglobinemia, methylene_blue)** — NBK557593
- **antidote_for(lead_poisoning, succimer)** — NBK541097

`antidote_for` now covers **14** board-classic pairs. Data-only; `ibuprofen` negative-control abstain unchanged.

## Verification
- `test_pharm_recall: 3/3 passed`; ruff clean; data-only security review passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)