### PR TITLE
feat(mycin-genetics): ground Marfan syndrome gene (FBN1)

### DIFF
--- a/code/specs/data/mycin-2026/recall/genetics-edges.adj
+++ b/code/specs/data/mycin-2026/recall/genetics-edges.adj
@@ -110,4 +110,12 @@ rulebook genetics_facts {
         source "Friedreich ataxia results from loss-of-function mutations in the frataxin (FXN) gene, located in the centromeric region of chromosome 9q (9q13 to 21.1)."
         locator "https://www.ncbi.nlm.nih.gov/books/NBK563199/"
         trust authoritative
+
+    % --- EXPAND: Marfan syndrome gene (FBN1) — rounds out the existing AD edge -------
+    % The page's defined abbreviation MFS = Marfan syndrome; this declarative names the
+    % FBN1 gene as the de-novo-mutation cause, grounding the gene_defect edge.
+    relate gene_defect(marfan_syndrome, fbn1)
+        source "While most individuals with MFS have an affected parent, 25% of patients develop the disease due to a de novo mutation involving the gene (FBN1) encoding the connective tissue protein fibrillin-1."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK537339/"
+        trust authoritative
 }

--- a/code/specs/data/mycin-2026/recall/genetics-recall.query.adj
+++ b/code/specs/data/mycin-2026/recall/genetics-recall.query.adj
@@ -26,3 +26,4 @@ import "genetics-edges.adj"
 ? trinucleotide_repeat(myotonic_dystrophy, $Repeat)    % expect ctg (expand)
 ? gene_defect(myotonic_dystrophy, $Gene)               % expect dmpk (expand)
 ? gene_defect(friedreich_ataxia, $Gene)                % expect fxn (expand)
+? gene_defect(marfan_syndrome, $Gene)                  % expect fbn1 (expand)

--- a/code/specs/data/mycin-2026/recall/test_genetics_recall.py
+++ b/code/specs/data/mycin-2026/recall/test_genetics_recall.py
@@ -45,6 +45,7 @@ EXPECTED = [
     ("myotonic_dystrophy", "trinucleotide_repeat", "ctg"),           # expand (NBK557446)
     ("myotonic_dystrophy", "gene_defect", "dmpk"),                   # expand (NBK557446)
     ("friedreich_ataxia", "gene_defect", "fxn"),                     # expand (NBK563199)
+    ("marfan_syndrome", "gene_defect", "fbn1"),                      # expand (NBK537339)
 ]
 VAR = {"inheritance": "Pattern", "gene_defect": "Gene",
        "trinucleotide_repeat": "Repeat", "imprinting": "Parent"}


### PR DESCRIPTION
## What

Rounds out the existing Marfan autosomal-dominant edge with its gene defect: **gene_defect(marfan_syndrome, fbn1)** — NBK537339 (MFS = the page's defined abbreviation):
> While most individuals with MFS have an affected parent, 25% of patients develop the disease due to a de novo mutation involving the gene (FBN1) encoding the connective tissue protein fibrillin-1.

**Honest scope:** the DMD X-linked-recessive inheritance edge is deferred — the StatPearls span states inheritance in a separate anaphoric "It is inherited…" sentence, not alongside "Duchenne muscular dystrophy" in one self-contained span.

## Changes (data-only)
- `genetics-edges.adj` +1 `relate`; `genetics-recall.query.adj` +1 query; `test_genetics_recall.py` EXPECTED +1 (`ehlers_danlos_syndrome` negative control unchanged)

## Verification
- `test_genetics_recall: 3/3 passed`; ruff clean; data-only security review passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)