### PR TITLE
feat(x86-simulator): byte-tape store (0x88) + Brainfuck runs locally (S5)

### DIFF
--- a/code/packages/rust/x86-simulator/CHANGELOG.md
+++ b/code/packages/rust/x86-simulator/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog — x86-simulator
 
+## 0.5.0 — 2026-06-21 — byte-tape store + Brainfuck runs locally (x86-sim PR-S5)
+
+Continues the coverage-mining pattern (S4): running a **Brainfuck** program
+through the simulator surfaced two more gaps, now closed.
+
+### Added
+- **`mov r/m8, r8` (`0x88`)** — the 8-bit `store_byte` the byte-tape ops emit
+  (`mov [base], src8`), which S1–S4 never decoded (a Brainfuck `.` trapped with
+  `DecodeError { opcode: 0x88 }`). A register destination keeps its upper bytes;
+  a memory destination is a single-byte store.
+- **`__twig_putchar` / `__twig_getchar` host-shim aliases** — the backend emits
+  the runtime-prefixed symbols; the shims previously matched only the bare
+  `putchar`/`getchar` (so Brainfuck output trapped `UnresolvedExternal`).
+- **Brainfuck matrix cell** — `++++++++[>++++++++<-]>+.` ⇒ stdout `A`, run on the
+  x86_64 column locally. Exercises the byte-tape surface the arithmetic programs
+  never touched: `__twig_alloc_bytes` for the tape, the `[...]` loop, the 8-bit
+  store, and `putchar`. (Stdin-driven Brainfuck — `,[.,]` cat — still pends an
+  input-buffer in the harness; `getchar` returns EOF for now.)
+
+### Verified
+- Brainfuck runs end-to-end; `0x88` gets direct decode + execute unit tests
+  (register masked-write keeps upper bytes; memory single-byte store leaves the
+  neighbour untouched). 50 tests (28 unit + 18 matrix + 4 lib/harness).
+
 ## 0.4.0 — 2026-06-21 — group-3 (`not`/`neg`/`div`/`idiv`) + broader matrix coverage (x86-sim PR-S4)
 
 Broadens the **local** LANG-FULL x86_64 coverage from S3's 7 cells to 17 by

--- a/code/packages/rust/x86-simulator/Cargo.toml
+++ b/code/packages/rust/x86-simulator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "x86-simulator"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 description = "x86/x86-64 runtime simulator — decode + execute machine code, and run the x86_64-backend's emitted code locally (host-arch-independent)"
 

--- a/code/packages/rust/x86-simulator/README.md
+++ b/code/packages/rust/x86-simulator/README.md
@@ -16,7 +16,8 @@ shape) and uses the ISA semantics in
 The subset the `x86_64-encoder` emits (and growing):
 
 - **Moves / addressing**: `mov` reg↔reg, reg↔`[base+disp]`, `mov reg,imm32`,
-  `movzx reg,byte[mem]`, `lea reg,[mem]` (incl. RIP-relative); REX/ModRM/SIB.
+  `movzx reg,byte[mem]`, `mov byte[mem],reg8` (`0x88` — the byte-tape store),
+  `lea reg,[mem]` (incl. RIP-relative); REX/ModRM/SIB.
 - **Integer ALU**: `add` / `sub` / `cmp` / `and` / `or` / `xor` / `test` (reg and
   imm forms), `shl` / `shr` / `sar`, `imul` — all with full CF/ZF/SF/OF/PF flags.
 - **Group-3 + division**: `not` / `neg` (`0xF7 /2`,`/3`), `div` / `idiv`
@@ -61,12 +62,14 @@ as the exit code (the same convention as `run_native` / `run_wasm`).
 On an Apple-Silicon host the matrix's `NativeAot` cell only ever builds+runs the
 *aarch64* backend; this test exercises the **x86_64** column end-to-end —
 **locally on aarch64**, retro-verifying columns the matrix could previously
-execute only on x86 CI. The 17 cells span Twig (const/arithmetic/`define`),
+execute only on x86 CI. The 18 cells span Twig (const/arithmetic/`define`),
 Nib (u8 wrap, `~` complement, unsigned division), ALGOL (procedure call,
 switch/computed-goto, signed `div`, E3 `real` SSE2 floats, E5 arrays straight-
-line and in a `for` loop), Oct (`out`, `~`), and Dartmouth BASIC (`PRINT`,
-`FOR`/`NEXT` — stdout-captured via the host shims). Adding the Nib/Oct `~` cells
-is what surfaced the missing group-3 `0xF7` opcode that this crate now decodes.
+line and in a `for` loop), Oct (`out`, `~`), Dartmouth BASIC (`PRINT`,
+`FOR`/`NEXT` — stdout-captured via the host shims), and Brainfuck (`.` over a
+byte tape). Each new language exposed a missing opcode — the Nib/Oct `~` cells
+surfaced group-3 `0xF7`, and the Brainfuck cell surfaced the `0x88` byte store —
+which this crate now decodes.
 
 ## Safety
 

--- a/code/packages/rust/x86-simulator/src/decode.rs
+++ b/code/packages/rust/x86-simulator/src/decode.rs
@@ -41,6 +41,10 @@ pub enum Instr {
     MovImm { dst: Operand, imm: i64 },
     /// `movzx reg64, byte [mem]`.
     Movzx { dst: Reg, src: Operand },
+    /// `mov r/m8, r8` (`0x88`) — store the low byte of `src` into `dst` (the
+    /// byte-tape `store_byte`; e.g. Brainfuck cells). A register `dst` keeps its
+    /// upper bytes.
+    MovByteStore { dst: Operand, src: Reg },
     /// `lea reg, mem`.
     Lea { dst: Reg, src: Operand },
     /// Integer ALU `op dst, src` (dst is reg or mem, src reg/mem/imm).
@@ -245,6 +249,8 @@ pub fn decode(code: &[u8], off: usize) -> Result<Decoded, Trap> {
 
     // ModRM-based one-byte opcodes.
     match op {
+        // mov r/m8, r8 — store the low byte of the reg-field register into r/m.
+        0x88 => { let (m, np) = modrm(code, p, rex_r, rex_x, rex_b)?; Ok(Decoded { instr: Instr::MovByteStore { dst: m.rm, src: reg_of(m.reg) }, len: np - off }) }
         0x89 => { let (m, np) = modrm(code, p, rex_r, rex_x, rex_b)?; Ok(Decoded { instr: Instr::Mov { dst: m.rm, src: Operand::Reg(reg_of(m.reg)) }, len: np - off }) }
         0x8B => { let (m, np) = modrm(code, p, rex_r, rex_x, rex_b)?; Ok(Decoded { instr: Instr::Mov { dst: Operand::Reg(reg_of(m.reg)), src: m.rm }, len: np - off }) }
         0x8D => { let (m, np) = modrm(code, p, rex_r, rex_x, rex_b)?; Ok(Decoded { instr: Instr::Lea { dst: reg_of(m.reg), src: m.rm }, len: np - off }) }
@@ -431,6 +437,17 @@ mod tests {
                    Instr::Div { divisor: Operand::Reg(Reg::Rcx), signed: true });
         // cqo      = 48 99
         assert_eq!(decode(&[0x48, 0x99], 0).unwrap().instr, Instr::Cqo);
+    }
+
+    #[test]
+    fn byte_store_decodes() {
+        // The encoder emits `REX(0x40) 88 ModRM(mod=00, reg=src, rm=base)`.
+        // 0x40 0x88 0x08 = mov byte [rax], cl  (reg=cl=1, rm=rax=0, mod=00).
+        assert_eq!(decode(&[0x40, 0x88, 0x08], 0).unwrap().instr,
+                   Instr::MovByteStore {
+                       dst: Operand::Mem { base: Some(Reg::Rax), index: None, scale: 1, disp: 0, rip: false },
+                       src: Reg::Rcx,
+                   });
     }
 
     #[test]

--- a/code/packages/rust/x86-simulator/src/execute.rs
+++ b/code/packages/rust/x86-simulator/src/execute.rs
@@ -116,6 +116,17 @@ pub fn exec_one(
             st.set(*dst, v & 0xFF);
             Ok(Flow::Next)
         }
+        Instr::MovByteStore { dst, src } => {
+            // Store the low byte of `src` into `dst`.  For a register `dst` only
+            // the low 8 bits change (the rest are preserved); for memory it is a
+            // single-byte store.
+            let b = st.get(*src) & 0xFF;
+            match dst {
+                Operand::Reg(r) => { let v = (st.get(*r) & !0xFF) | b; st.set(*r, v); }
+                Operand::Mem { .. } => write_op(st, mem, dst, next_ip, 1, b)?,
+            }
+            Ok(Flow::Next)
+        }
         Instr::Lea { dst, src } => {
             let a = effective_addr(st, src, next_ip);
             st.set(*dst, a);
@@ -409,5 +420,28 @@ mod tests {
         st.set(Reg::Rcx, (-1i64) as u64);
         let err = exec(&mut st, &Instr::Div { divisor: Operand::Reg(Reg::Rcx), signed: true }).unwrap_err();
         assert!(matches!(err, Trap::DivideError(_)));
+    }
+
+    #[test]
+    fn byte_store_to_register_keeps_upper_bytes() {
+        // `mov r/m8, r8` into a register touches only the low byte.
+        let mut st = CpuState::default();
+        st.set(Reg::Rax, 0xDEAD_BEEF_0000_00FF);
+        st.set(Reg::Rcx, 0x42);
+        exec(&mut st, &Instr::MovByteStore { dst: Operand::Reg(Reg::Rax), src: Reg::Rcx }).unwrap();
+        assert_eq!(st.get(Reg::Rax), 0xDEAD_BEEF_0000_0042); // only low byte changed
+    }
+
+    #[test]
+    fn byte_store_to_memory_writes_one_byte() {
+        let mut st = CpuState::default();
+        let mut mem = Memory::new(64, 0, 0);
+        st.set(Reg::Rax, 8); // address
+        st.set(Reg::Rcx, 0x1_2345); // only 0x45 should land
+        mem.store(8, 8, 0xFFFF_FFFF_FFFF_FFFF).unwrap(); // pre-fill the word
+        let dst = Operand::Mem { base: Some(Reg::Rax), index: None, scale: 1, disp: 0, rip: false };
+        exec_one(&mut st, &mut mem, &Instr::MovByteStore { dst, src: Reg::Rcx }, 0, 0, 0).unwrap();
+        assert_eq!(mem.load(8, 1).unwrap(), 0x45); // single byte written
+        assert_eq!(mem.load(9, 1).unwrap(), 0xFF); // neighbour untouched
     }
 }

--- a/code/packages/rust/x86-simulator/src/lib.rs
+++ b/code/packages/rust/x86-simulator/src/lib.rs
@@ -127,14 +127,16 @@ impl Simulator {
                 let ptr = self.mem.alloc(n)?;
                 self.state.set(Reg::Rax, ptr);
             }
-            // `int putchar(int c)` — capture the byte.
-            "putchar" => {
+            // `int putchar(int c)` — capture the byte.  The backend emits the
+            // runtime-prefixed `__twig_putchar`; libc-style `putchar` is accepted
+            // too (same shim, like the `print_i64` aliases below).
+            "__twig_putchar" | "putchar" => {
                 let c = self.state.get(Reg::Rdi) as u8;
                 self.stdout.push(c);
                 self.state.set(Reg::Rax, c as u64);
             }
             // `int getchar()` — no stdin in v1; returns EOF (-1).
-            "getchar" => { self.state.set(Reg::Rax, u64::MAX); }
+            "__twig_getchar" | "getchar" => { self.state.set(Reg::Rax, u64::MAX); }
             // `void __twig_print_i64(i64)` — print the decimal value.
             "__twig_print_i64" | "__print_i64" | "print_i64" => {
                 let v = self.state.get(Reg::Rdi) as i64;

--- a/code/packages/rust/x86-simulator/tests/lang_matrix_x86.rs
+++ b/code/packages/rust/x86-simulator/tests/lang_matrix_x86.rs
@@ -277,3 +277,13 @@ fn algol_signed_division_runs_on_x86_sim() {
     let src = "begin integer result; result := 85 div 2 end";
     assert_eq!(run_on_x86_sim(Language::Algol60, src), 42);
 }
+
+/// Brainfuck — build 65 on the tape and `putchar` it (`++++++++[>++++++++<-]>+.`
+/// ⇒ stdout `A`).  Exercises the **byte-tape** opcode surface the arithmetic
+/// programs never touch: `__twig_alloc_bytes` for the tape, 8-bit load/store
+/// (`load_byte`/`store_byte`), a `[...]` loop, and the `putchar` host shim.
+#[test]
+fn brainfuck_putchar_runs_on_x86_sim() {
+    let (_code, out) = run_capturing_stdout(Language::Brainfuck, "++++++++[>++++++++<-]>+.");
+    assert_eq!(out, "A");
+}

--- a/code/specs/x86-runtime-simulator.md
+++ b/code/specs/x86-runtime-simulator.md
@@ -166,7 +166,13 @@ This harness is what `lang_matrix.rs` calls to run the x86_64 column locally.
    `#DE` `Trap::DivideError` for divide-by-zero / quotient-overflow. This is the
    pattern the simulator is *for*: broadening coverage flushes out real codegen
    gaps the byte tests didn't. (x86-simulator 0.4.0.)
-5. **S5 — 32-bit x86 (i386)**: operand/address-size handling + 32-bit decode, as
+5. **S5 — byte-tape store + Brainfuck**: ✅ done. Running a Brainfuck program
+   (`++++++++[>++++++++<-]>+.` ⇒ `A`) surfaced the **8-bit store `mov r/m8, r8`
+   (`0x88`)** the byte-tape `store_byte` emits (S1–S4 only had the `movzx` load
+   side), plus the `__twig_putchar`/`__twig_getchar` host-shim aliases. Added
+   both; Brainfuck now runs on the x86_64 column locally. (Stdin-driven cat
+   `,[.,]` still pends an input buffer in the harness.) (x86-simulator 0.5.0.)
+6. **S6 — 32-bit x86 (i386)**: operand/address-size handling + 32-bit decode, as
    educational coverage (not on the run-our-codegen critical path — no matrix
    program emits 32-bit x86, so it's unit-tested against hand-assembled bytes).
 


### PR DESCRIPTION
## What

Continues the coverage-mining pattern (S3 → S4 → S5): running a **Brainfuck** program through the simulator surfaced two more x86_64-codegen gaps the byte tests never exercised, now closed.

A Brainfuck `.` (putchar over a byte tape) trapped first with `DecodeError { opcode: 0x88 }`, then `UnresolvedExternal("__twig_putchar")`.

## Added

- **`mov r/m8, r8`** (`0x88`) — the 8-bit `store_byte` the byte-tape ops emit (`mov [base], src8`). S1–S4 only had the `movzx` *load* side. A register destination keeps its upper bytes; a memory destination is a single bounds-checked byte store.
- **`__twig_putchar` / `__twig_getchar`** host-shim aliases — the backend emits the runtime-prefixed symbols; the shims previously matched only bare `putchar`/`getchar` (like the existing `print_i64` aliases).
- **Brainfuck matrix cell** — `++++++++[>++++++++<-]>+.` ⇒ stdout `A`, run on the x86_64 column **locally on aarch64**. Exercises the byte-tape surface (`__twig_alloc_bytes` tape, `[...]` loop, `0x88` store, `putchar`) the arithmetic programs never touched.

## Tests / security

- **50 tests** (28 unit + 18 matrix + 4 lib/harness). Direct decode + execute unit tests for `0x88` (register masked-write preserves upper bytes; memory single-byte store leaves the neighbour untouched).
- Security review passed (1 round): no panic/overflow/out-of-bounds — the byte store routes through the existing bounds-checked `write_op` width-1 path, register access is by fixed enum index.

## Notes

Stdin-driven Brainfuck (`,[.,]` cat) still pends an input buffer in the harness (`getchar` returns EOF for now). `x86-simulator` 0.5.0. Spec: S5 = this; 32-bit x86 renumbered to S6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)