### PR TITLE
[codex] Render SPICE WRDATA rawfile options

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 ### Added
 
+- **Deck WRDATA rawfile option rendering artifacts** —
+  selected `run_deck_analysis()` WRDATA artifacts now carry accepted
+  `.control` rawfile/data-write option inventories through stable
+  `Options` / `RawfileOptionList` summary columns and render
+  `wr_vecnames` / `wr_singlescale` intent as deterministic `VectorNames` /
+  `Scale` metadata in the in-memory data file, matching Rust and TypeScript.
+
 - **Deck WRDATA ASCII artifacts** —
   selected `run_deck_analysis()` executions now expose deterministic in-memory
   ASCII data-file artifacts for accepted `.control` `wrdata <file> ...`

--- a/code/packages/python/spice-engine/README.md
+++ b/code/packages/python/spice-engine/README.md
@@ -67,7 +67,7 @@ print(result.diagnostics.solver)   # "dense_real" or "sparse_real"
 | `resolve_deck_outputs`, `format_deck_*_table`, `format_deck_table_csv`, `format_deck_table_json`, `deck_table_records` | `.SAVE` / `.PROBE` / `.PRINT` / `.PLOT` output | Parsed deck-selected OP, DC sweep, AC, and transient tables plus deterministic CSV/JSON/record conversion |
 | `format_deck_run_artifact_table`, `format_deck_run_artifact_csv`, `format_deck_run_artifact_json` | Deck execution artifact | Stable selected-run row, table, analysis-directive, output-probe, output-directive, measurement, Fourier, control-command, and diagnostic count/name lists |
 | `format_deck_rawfile_ascii`, `format_deck_rawfile_artifact_table`, `format_deck_rawfile_artifact_csv`, `format_deck_rawfile_artifact_json` | `.control write` artifact | Deterministic in-memory ASCII rawfile text plus stable rawfile artifact table/CSV/JSON exports |
-| `format_deck_wrdata_ascii`, `format_deck_wrdata_artifact_table`, `format_deck_wrdata_artifact_csv`, `format_deck_wrdata_artifact_json` | `.control wrdata` artifact | Deterministic in-memory ASCII data-file text plus stable WRDATA artifact table/CSV/JSON exports |
+| `format_deck_wrdata_ascii`, `format_deck_wrdata_artifact_table`, `format_deck_wrdata_artifact_csv`, `format_deck_wrdata_artifact_json` | `.control wrdata` artifact | Deterministic in-memory ASCII data-file text plus stable option-aware WRDATA artifact table/CSV/JSON exports |
 | `measure_transient_probe`, `measure_dc_sweep_probe`, `measure_ac_sweep_probe`, `format_measurement_table` | `.MEASURE` output | Stable scalar transient, DC sweep, and AC sweep probe measurements |
 
 `diode_at_temperature()`, `bjt_at_temperature()`, `mosfet_at_temperature()`,
@@ -133,7 +133,9 @@ summaries; filesystem writes remain metadata-only.
 Accepted `.control` rawfile output options (`set filetype=ascii`,
 `set wr_vecnames`, `set wr_singlescale`, and `set appendwrite`) are surfaced as
 `rawfile_option_count` / `rawfile_options` execution fields and as
-`RawfileOptions` / `RawfileOptionList` artifact fields.
+`RawfileOptions` / `RawfileOptionList` artifact fields. WRDATA artifacts also
+carry the same option inventories and render `wr_vecnames` / `wr_singlescale`
+intent as stable `VectorNames` / `Scale` metadata in the in-memory data file.
 Existing `.control` body policy diagnostics flow into those selected-run
 artifact `Diagnostics` / `DiagnosticCodeList` fields and through the same
 run-artifact table, CSV, JSON, and `table_artifacts` records.

--- a/code/packages/python/spice-engine/src/spice_engine/engine.py
+++ b/code/packages/python/spice-engine/src/spice_engine/engine.py
@@ -2393,6 +2393,8 @@ class DeckWrdataArtifact:
     marker: str
     probe_count: int
     probes: list[str]
+    option_count: int
+    options: list[str]
     datafile: str
 
 
@@ -2474,6 +2476,7 @@ class DeckAnalysisExecution:
         wrdata_artifacts = list(self.wrdata_artifacts) or _deck_wrdata_artifacts(
             self.table,
             self.write_markers,
+            self.rawfile_options,
         )
         object.__setattr__(
             self, "wrdata_artifact_count", len(wrdata_artifacts)
@@ -3009,19 +3012,28 @@ def format_deck_rawfile_artifact_json(
 def format_deck_wrdata_ascii(
     table: str,
     probes: Iterable[str] = (),
+    rawfile_options: Iterable[str] = (),
 ) -> str:
     """Format a selected deck table as deterministic in-memory WRDATA text."""
 
     rows = table.splitlines()
     if not rows:
         return ""
-    return "\n".join(
-        [
-            "# SPICE deck wrdata artifact",
-            "Probes: " + ";".join(probes),
-            *rows,
-        ]
-    ) + "\n"
+    columns = rows[0].split("\t")
+    options = list(rawfile_options)
+    lines = [
+        "# SPICE deck wrdata artifact",
+        "Probes: " + ";".join(probes),
+    ]
+    if options:
+        lines.append("Options: " + ";".join(options))
+    normalized_options = {option.casefold() for option in options}
+    if "set wr_vecnames" in normalized_options:
+        lines.append("VectorNames: " + ";".join(columns))
+    if "set wr_singlescale" in normalized_options and columns:
+        lines.append("Scale: " + columns[0])
+    lines.extend(rows)
+    return "\n".join(lines) + "\n"
 
 
 def _deck_wrdata_marker_parts(marker: str) -> tuple[str, list[str]] | None:
@@ -3034,8 +3046,10 @@ def _deck_wrdata_marker_parts(marker: str) -> tuple[str, list[str]] | None:
 def _deck_wrdata_artifacts(
     table: str,
     write_markers: Iterable[str],
+    rawfile_options: Iterable[str] = (),
 ) -> list[DeckWrdataArtifact]:
     artifacts: list[DeckWrdataArtifact] = []
+    options = list(rawfile_options)
     for marker in write_markers:
         parts = _deck_wrdata_marker_parts(marker)
         if parts is None:
@@ -3047,7 +3061,9 @@ def _deck_wrdata_artifacts(
                 marker=marker,
                 probe_count=len(probes),
                 probes=probes,
-                datafile=format_deck_wrdata_ascii(table, probes),
+                option_count=len(options),
+                options=list(options),
+                datafile=format_deck_wrdata_ascii(table, probes, options),
             )
         )
     return artifacts
@@ -3058,6 +3074,8 @@ _DECK_WRDATA_ARTIFACT_COLUMNS = [
     "Marker",
     "Probes",
     "ProbeList",
+    "Options",
+    "RawfileOptionList",
     "Bytes",
 ]
 
@@ -3068,6 +3086,8 @@ def _deck_wrdata_artifact_cells(artifact: DeckWrdataArtifact) -> list[str]:
         artifact.marker,
         str(artifact.probe_count),
         ";".join(artifact.probes),
+        str(artifact.option_count),
+        ";".join(artifact.options),
         str(len(artifact.datafile.encode())),
     ]
 

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -7456,8 +7456,15 @@ let gain = 2
     assert execution.wrdata_artifacts[0].marker == "wrdata out.dat V(in)"
     assert execution.wrdata_artifacts[0].probe_count == 1
     assert execution.wrdata_artifacts[0].probes == ["V(in)"]
+    assert execution.wrdata_artifacts[0].option_count == len(
+        expected_rawfile_options
+    )
+    assert execution.wrdata_artifacts[0].options == expected_rawfile_options
     assert "# SPICE deck wrdata artifact\n" in execution.wrdata_artifacts[0].datafile
     assert "Probes: V(in)\n" in execution.wrdata_artifacts[0].datafile
+    assert "Options: " + rawfile_option_list + "\n" in execution.wrdata_artifacts[0].datafile
+    assert "VectorNames: Index;V(in)\n" in execution.wrdata_artifacts[0].datafile
+    assert "Scale: Index\n" in execution.wrdata_artifacts[0].datafile
     assert "Index\tV(in)\n" in execution.wrdata_artifacts[0].datafile
     assert "0\t1.000000e+00\n" in execution.wrdata_artifacts[0].datafile
     wrdata_record = execution.wrdata_artifact_records[0]
@@ -7465,6 +7472,8 @@ let gain = 2
     assert wrdata_record["Marker"] == "wrdata out.dat V(in)"
     assert wrdata_record["Probes"] == "1"
     assert wrdata_record["ProbeList"] == "V(in)"
+    assert wrdata_record["Options"] == str(len(expected_rawfile_options))
+    assert wrdata_record["RawfileOptionList"] == rawfile_option_list
     assert wrdata_record["Bytes"] == str(
         len(execution.wrdata_artifacts[0].datafile.encode())
     )
@@ -7478,6 +7487,9 @@ let gain = 2
         execution.wrdata_artifacts
     )
     assert json.loads(execution.wrdata_artifact_json)[0]["ProbeList"] == "V(in)"
+    assert json.loads(execution.wrdata_artifact_json)[0]["RawfileOptionList"] == (
+        rawfile_option_list
+    )
     assert execution.diagnostic_count == len(expected_codes)
     assert execution.diagnostic_codes == expected_codes
     assert execution.run_artifacts[0].control_line_count == len(expected_control_lines)

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- Carry accepted `.control` rawfile/data-write option inventories through
+  WRDATA artifact `Options` / `RawfileOptionList` summary columns, and render
+  `wr_vecnames` / `wr_singlescale` intent as deterministic `VectorNames` /
+  `Scale` metadata in in-memory WRDATA data files, matching Python and
+  TypeScript.
 - Expose deterministic in-memory ASCII data-file artifacts for accepted
   `.control` `wrdata <file> ...` markers from selected `run_deck_analysis`
   execution results as `wrdata_artifact_count`, `wrdata_artifacts`,

--- a/code/packages/rust/spice-engine/README.md
+++ b/code/packages/rust/spice-engine/README.md
@@ -206,7 +206,9 @@ summaries; filesystem writes remain metadata-only.
 Accepted `.control` rawfile output options (`set filetype=ascii`,
 `set wr_vecnames`, `set wr_singlescale`, and `set appendwrite`) are surfaced as
 `rawfile_option_count` / `rawfile_options` execution fields and as
-`RawfileOptions` / `RawfileOptionList` artifact fields.
+`RawfileOptions` / `RawfileOptionList` artifact fields. WRDATA artifacts also
+carry the same option inventories and render `wr_vecnames` / `wr_singlescale`
+intent as stable `VectorNames` / `Scale` metadata in the in-memory data file.
 Existing `.control` body policy diagnostics flow into those selected-run artifact `Diagnostics` /
 `DiagnosticCodeList` fields and through the same run-artifact table, CSV, JSON,
 and `table_artifacts` records. `format_deck_table_csv` also converts any stable

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -3475,6 +3475,8 @@ pub struct DeckWrdataArtifact {
     pub marker: String,
     pub probe_count: usize,
     pub probes: Vec<String>,
+    pub option_count: usize,
+    pub options: Vec<String>,
     pub datafile: String,
 }
 
@@ -10704,16 +10706,43 @@ pub fn format_deck_rawfile_artifact_json(artifacts: &[DeckRawfileArtifact]) -> S
     format!("[{}]\n", records)
 }
 
-pub fn format_deck_wrdata_ascii(table: &str, probes: &[String]) -> String {
+pub fn format_deck_wrdata_ascii(
+    table: &str,
+    probes: &[String],
+    rawfile_options: &[String],
+) -> String {
     let rows = table.lines().collect::<Vec<_>>();
     if rows.is_empty() {
         return String::new();
     }
-    format!(
-        "# SPICE deck wrdata artifact\nProbes: {}\n{}\n",
-        probes.join(";"),
-        rows.join("\n")
-    )
+    let columns = rows[0].split('\t').collect::<Vec<_>>();
+    let mut lines = vec![
+        "# SPICE deck wrdata artifact".to_string(),
+        format!("Probes: {}", probes.join(";")),
+    ];
+    if !rawfile_options.is_empty() {
+        lines.push(format!("Options: {}", rawfile_options.join(";")));
+    }
+    let normalized_options = rawfile_options
+        .iter()
+        .map(|option| option.to_ascii_lowercase())
+        .collect::<Vec<_>>();
+    if normalized_options
+        .iter()
+        .any(|option| option == "set wr_vecnames")
+    {
+        lines.push(format!("VectorNames: {}", columns.join(";")));
+    }
+    if normalized_options
+        .iter()
+        .any(|option| option == "set wr_singlescale")
+    {
+        if let Some(scale) = columns.first() {
+            lines.push(format!("Scale: {scale}"));
+        }
+    }
+    lines.extend(rows.iter().map(|row| (*row).to_string()));
+    format!("{}\n", lines.join("\n"))
 }
 
 fn deck_wrdata_marker_parts(marker: &str) -> Option<(String, Vec<String>)> {
@@ -10731,7 +10760,11 @@ fn deck_wrdata_marker_parts(marker: &str) -> Option<(String, Vec<String>)> {
     ))
 }
 
-fn deck_wrdata_artifacts(table: &str, write_markers: &[String]) -> Vec<DeckWrdataArtifact> {
+fn deck_wrdata_artifacts(
+    table: &str,
+    write_markers: &[String],
+    rawfile_options: &[String],
+) -> Vec<DeckWrdataArtifact> {
     write_markers
         .iter()
         .filter_map(|marker| {
@@ -10740,14 +10773,24 @@ fn deck_wrdata_artifacts(table: &str, write_markers: &[String]) -> Vec<DeckWrdat
                 target,
                 marker: marker.clone(),
                 probe_count: probes.len(),
-                datafile: format_deck_wrdata_ascii(table, &probes),
+                option_count: rawfile_options.len(),
+                options: rawfile_options.to_vec(),
+                datafile: format_deck_wrdata_ascii(table, &probes, rawfile_options),
                 probes,
             })
         })
         .collect()
 }
 
-const DECK_WRDATA_ARTIFACT_COLUMNS: &[&str] = &["Target", "Marker", "Probes", "ProbeList", "Bytes"];
+const DECK_WRDATA_ARTIFACT_COLUMNS: &[&str] = &[
+    "Target",
+    "Marker",
+    "Probes",
+    "ProbeList",
+    "Options",
+    "RawfileOptionList",
+    "Bytes",
+];
 
 fn deck_wrdata_artifact_cells(artifact: &DeckWrdataArtifact) -> Vec<String> {
     vec![
@@ -10755,6 +10798,8 @@ fn deck_wrdata_artifact_cells(artifact: &DeckWrdataArtifact) -> Vec<String> {
         artifact.marker.clone(),
         artifact.probe_count.to_string(),
         artifact.probes.join(";"),
+        artifact.option_count.to_string(),
+        artifact.options.join(";"),
         artifact.datafile.len().to_string(),
     ]
 }
@@ -10991,7 +11036,7 @@ pub fn run_deck_analysis(
             let rawfile_artifact_csv = format_deck_rawfile_artifact_csv(&rawfile_artifacts);
             let rawfile_artifact_json = format_deck_rawfile_artifact_json(&rawfile_artifacts);
             let rawfile_artifact_records = deck_rawfile_artifact_records(&rawfile_artifacts);
-            let wrdata_artifacts = deck_wrdata_artifacts(&table, &write_markers);
+            let wrdata_artifacts = deck_wrdata_artifacts(&table, &write_markers, &rawfile_options);
             let wrdata_artifact_table = format_deck_wrdata_artifact_table(&wrdata_artifacts);
             let wrdata_artifact_csv = format_deck_wrdata_artifact_csv(&wrdata_artifacts);
             let wrdata_artifact_json = format_deck_wrdata_artifact_json(&wrdata_artifacts);
@@ -11080,7 +11125,7 @@ pub fn run_deck_analysis(
             let rawfile_artifact_csv = format_deck_rawfile_artifact_csv(&rawfile_artifacts);
             let rawfile_artifact_json = format_deck_rawfile_artifact_json(&rawfile_artifacts);
             let rawfile_artifact_records = deck_rawfile_artifact_records(&rawfile_artifacts);
-            let wrdata_artifacts = deck_wrdata_artifacts(&table, &write_markers);
+            let wrdata_artifacts = deck_wrdata_artifacts(&table, &write_markers, &rawfile_options);
             let wrdata_artifact_table = format_deck_wrdata_artifact_table(&wrdata_artifacts);
             let wrdata_artifact_csv = format_deck_wrdata_artifact_csv(&wrdata_artifacts);
             let wrdata_artifact_json = format_deck_wrdata_artifact_json(&wrdata_artifacts);
@@ -11170,7 +11215,7 @@ pub fn run_deck_analysis(
             let rawfile_artifact_csv = format_deck_rawfile_artifact_csv(&rawfile_artifacts);
             let rawfile_artifact_json = format_deck_rawfile_artifact_json(&rawfile_artifacts);
             let rawfile_artifact_records = deck_rawfile_artifact_records(&rawfile_artifacts);
-            let wrdata_artifacts = deck_wrdata_artifacts(&table, &write_markers);
+            let wrdata_artifacts = deck_wrdata_artifacts(&table, &write_markers, &rawfile_options);
             let wrdata_artifact_table = format_deck_wrdata_artifact_table(&wrdata_artifacts);
             let wrdata_artifact_csv = format_deck_wrdata_artifact_csv(&wrdata_artifacts);
             let wrdata_artifact_json = format_deck_wrdata_artifact_json(&wrdata_artifacts);
@@ -11263,7 +11308,7 @@ pub fn run_deck_analysis(
             let rawfile_artifact_csv = format_deck_rawfile_artifact_csv(&rawfile_artifacts);
             let rawfile_artifact_json = format_deck_rawfile_artifact_json(&rawfile_artifacts);
             let rawfile_artifact_records = deck_rawfile_artifact_records(&rawfile_artifacts);
-            let wrdata_artifacts = deck_wrdata_artifacts(&table, &write_markers);
+            let wrdata_artifacts = deck_wrdata_artifacts(&table, &write_markers, &rawfile_options);
             let wrdata_artifact_table = format_deck_wrdata_artifact_table(&wrdata_artifacts);
             let wrdata_artifact_csv = format_deck_wrdata_artifact_csv(&wrdata_artifacts);
             let wrdata_artifact_json = format_deck_wrdata_artifact_json(&wrdata_artifacts);
@@ -11350,7 +11395,7 @@ pub fn run_deck_analysis(
             let rawfile_artifact_csv = format_deck_rawfile_artifact_csv(&rawfile_artifacts);
             let rawfile_artifact_json = format_deck_rawfile_artifact_json(&rawfile_artifacts);
             let rawfile_artifact_records = deck_rawfile_artifact_records(&rawfile_artifacts);
-            let wrdata_artifacts = deck_wrdata_artifacts(&table, &write_markers);
+            let wrdata_artifacts = deck_wrdata_artifacts(&table, &write_markers, &rawfile_options);
             let wrdata_artifact_table = format_deck_wrdata_artifact_table(&wrdata_artifacts);
             let wrdata_artifact_csv = format_deck_wrdata_artifact_csv(&wrdata_artifacts);
             let wrdata_artifact_json = format_deck_wrdata_artifact_json(&wrdata_artifacts);
@@ -11435,7 +11480,7 @@ pub fn run_deck_analysis(
             let rawfile_artifact_csv = format_deck_rawfile_artifact_csv(&rawfile_artifacts);
             let rawfile_artifact_json = format_deck_rawfile_artifact_json(&rawfile_artifacts);
             let rawfile_artifact_records = deck_rawfile_artifact_records(&rawfile_artifacts);
-            let wrdata_artifacts = deck_wrdata_artifacts(&table, &write_markers);
+            let wrdata_artifacts = deck_wrdata_artifacts(&table, &write_markers, &rawfile_options);
             let wrdata_artifact_table = format_deck_wrdata_artifact_table(&wrdata_artifacts);
             let wrdata_artifact_csv = format_deck_wrdata_artifact_csv(&wrdata_artifacts);
             let wrdata_artifact_json = format_deck_wrdata_artifact_json(&wrdata_artifacts);
@@ -11532,7 +11577,7 @@ pub fn run_deck_analysis(
             let rawfile_artifact_csv = format_deck_rawfile_artifact_csv(&rawfile_artifacts);
             let rawfile_artifact_json = format_deck_rawfile_artifact_json(&rawfile_artifacts);
             let rawfile_artifact_records = deck_rawfile_artifact_records(&rawfile_artifacts);
-            let wrdata_artifacts = deck_wrdata_artifacts(&table, &write_markers);
+            let wrdata_artifacts = deck_wrdata_artifacts(&table, &write_markers, &rawfile_options);
             let wrdata_artifact_table = format_deck_wrdata_artifact_table(&wrdata_artifacts);
             let wrdata_artifact_csv = format_deck_wrdata_artifact_csv(&wrdata_artifacts);
             let wrdata_artifact_json = format_deck_wrdata_artifact_json(&wrdata_artifacts);

--- a/code/packages/rust/spice-engine/tests/transient_tests.rs
+++ b/code/packages/rust/spice-engine/tests/transient_tests.rs
@@ -2771,6 +2771,7 @@ let gain = 2
         "set wr_vecnames".to_string(),
     ];
     let rawfile_option_list = expected_rawfile_options.join(";");
+    let rawfile_option_count = expected_rawfile_options.len().to_string();
 
     assert_eq!(execution.control_line_count, expected_control_lines.len());
     assert_eq!(execution.control_lines, expected_control_lines);
@@ -2848,12 +2849,29 @@ let gain = 2
     assert_eq!(execution.wrdata_artifacts[0].marker, "wrdata out.dat V(in)");
     assert_eq!(execution.wrdata_artifacts[0].probe_count, 1);
     assert_eq!(execution.wrdata_artifacts[0].probes, vec!["V(in)"]);
+    assert_eq!(
+        execution.wrdata_artifacts[0].option_count,
+        expected_rawfile_options.len()
+    );
+    assert_eq!(
+        execution.wrdata_artifacts[0].options,
+        expected_rawfile_options
+    );
     assert!(execution.wrdata_artifacts[0]
         .datafile
         .contains("# SPICE deck wrdata artifact\n"));
     assert!(execution.wrdata_artifacts[0]
         .datafile
         .contains("Probes: V(in)\n"));
+    assert!(execution.wrdata_artifacts[0]
+        .datafile
+        .contains(&format!("Options: {rawfile_option_list}\n")));
+    assert!(execution.wrdata_artifacts[0]
+        .datafile
+        .contains("VectorNames: Index;V(in)\n"));
+    assert!(execution.wrdata_artifacts[0]
+        .datafile
+        .contains("Scale: Index\n"));
     assert!(execution.wrdata_artifacts[0]
         .datafile
         .contains("Index\tV(in)\n"));
@@ -2877,6 +2895,18 @@ let gain = 2
             .get("ProbeList")
             .map(String::as_str),
         Some("V(in)")
+    );
+    assert_eq!(
+        execution.wrdata_artifact_records[0]
+            .get("Options")
+            .map(String::as_str),
+        Some(rawfile_option_count.as_str())
+    );
+    assert_eq!(
+        execution.wrdata_artifact_records[0]
+            .get("RawfileOptionList")
+            .map(String::as_str),
+        Some(rawfile_option_list.as_str())
     );
     let wrdata_bytes = execution.wrdata_artifacts[0].datafile.len().to_string();
     assert_eq!(

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Carry accepted `.control` rawfile/data-write option inventories through
+  WRDATA artifact `Options` / `RawfileOptionList` summary columns, and render
+  `wr_vecnames` / `wr_singlescale` intent as deterministic `VectorNames` /
+  `Scale` metadata in in-memory WRDATA data files, matching Python and Rust.
 - Expose deterministic in-memory ASCII data-file artifacts for accepted
   `.control` `wrdata <file> ...` markers from selected `runDeckAnalysis`
   execution results as `wrdataArtifactCount`, `wrdataArtifacts`,

--- a/code/packages/typescript/spice-engine/README.md
+++ b/code/packages/typescript/spice-engine/README.md
@@ -122,7 +122,10 @@ summaries; filesystem writes remain metadata-only.
 Accepted `.control` rawfile output options (`set filetype=ascii`,
 `set wr_vecnames`, `set wr_singlescale`, and `set appendwrite`) are surfaced as
 `rawfileOptionCount` / `rawfileOptions` execution fields and as
-`RawfileOptions` / `RawfileOptionList` artifact fields. Existing
+`RawfileOptions` / `RawfileOptionList` artifact fields. WRDATA artifacts also
+carry the same option inventories and render `wr_vecnames` / `wr_singlescale`
+intent as stable `VectorNames` / `Scale` metadata in the in-memory data file.
+Existing
 `.control` body policy diagnostics flow into those selected-run artifact `Diagnostics` /
 `DiagnosticCodeList` fields and through the same run-artifact table, CSV, JSON,
 and `tableArtifacts` records. `formatDeckTableCsv` also converts any stable tab-separated deck table to

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -727,6 +727,8 @@ export interface DeckWrdataArtifact {
   readonly marker: string;
   readonly probeCount: number;
   readonly probes: readonly string[];
+  readonly optionCount: number;
+  readonly options: readonly string[];
   readonly datafile: string;
 }
 
@@ -8429,12 +8431,29 @@ export function formatDeckRawfileArtifactJson(
 export function formatDeckWrdataAscii(
   table: string,
   probes: readonly string[] = [],
+  rawfileOptions: readonly string[] = [],
 ): string {
   const rows = deckTableRows(table);
   if (rows.length === 0) {
     return "";
   }
-  return `# SPICE deck wrdata artifact\nProbes: ${probes.join(";")}\n${rows.join("\n")}\n`;
+  const columns = rows[0]!.split("\t");
+  const lines = [
+    "# SPICE deck wrdata artifact",
+    `Probes: ${probes.join(";")}`,
+  ];
+  if (rawfileOptions.length > 0) {
+    lines.push(`Options: ${rawfileOptions.join(";")}`);
+  }
+  const normalizedOptions = new Set(rawfileOptions.map((option) => option.toLowerCase()));
+  if (normalizedOptions.has("set wr_vecnames")) {
+    lines.push(`VectorNames: ${columns.join(";")}`);
+  }
+  if (normalizedOptions.has("set wr_singlescale") && columns.length > 0) {
+    lines.push(`Scale: ${columns[0]}`);
+  }
+  lines.push(...rows);
+  return `${lines.join("\n")}\n`;
 }
 
 function deckWrdataMarkerParts(marker: string): { target: string; probes: string[] } | undefined {
@@ -8451,6 +8470,7 @@ function deckWrdataMarkerParts(marker: string): { target: string; probes: string
 function deckWrdataArtifacts(
   table: string,
   writeMarkers: readonly string[],
+  rawfileOptions: readonly string[],
 ): DeckWrdataArtifact[] {
   return writeMarkers.flatMap((marker) => {
     const parts = deckWrdataMarkerParts(marker);
@@ -8462,7 +8482,9 @@ function deckWrdataArtifacts(
       marker,
       probeCount: parts.probes.length,
       probes: [...parts.probes],
-      datafile: formatDeckWrdataAscii(table, parts.probes),
+      optionCount: rawfileOptions.length,
+      options: [...rawfileOptions],
+      datafile: formatDeckWrdataAscii(table, parts.probes, rawfileOptions),
     }];
   });
 }
@@ -8472,6 +8494,8 @@ const DECK_WRDATA_ARTIFACT_COLUMNS = [
   "Marker",
   "Probes",
   "ProbeList",
+  "Options",
+  "RawfileOptionList",
   "Bytes",
 ] as const;
 
@@ -8481,6 +8505,8 @@ function deckWrdataArtifactCells(artifact: DeckWrdataArtifact): string[] {
     artifact.marker,
     String(artifact.probeCount),
     artifact.probes.join(";"),
+    String(artifact.optionCount),
+    artifact.options.join(";"),
     String(artifact.datafile.length),
   ];
 }
@@ -8617,7 +8643,7 @@ export function runDeckAnalysis(
     const rawfileArtifactCsv = formatDeckRawfileArtifactCsv(rawfileArtifacts);
     const rawfileArtifactJson = formatDeckRawfileArtifactJson(rawfileArtifacts);
     const rawfileArtifactRecords = deckRawfileArtifactRecords(rawfileArtifacts);
-    const wrdataArtifacts = deckWrdataArtifacts(table, writeMarkers);
+    const wrdataArtifacts = deckWrdataArtifacts(table, writeMarkers, rawfileOptions);
     const wrdataArtifactTable = formatDeckWrdataArtifactTable(wrdataArtifacts);
     const wrdataArtifactCsv = formatDeckWrdataArtifactCsv(wrdataArtifacts);
     const wrdataArtifactJson = formatDeckWrdataArtifactJson(wrdataArtifacts);
@@ -8705,7 +8731,7 @@ export function runDeckAnalysis(
     const rawfileArtifactCsv = formatDeckRawfileArtifactCsv(rawfileArtifacts);
     const rawfileArtifactJson = formatDeckRawfileArtifactJson(rawfileArtifacts);
     const rawfileArtifactRecords = deckRawfileArtifactRecords(rawfileArtifacts);
-    const wrdataArtifacts = deckWrdataArtifacts(table, writeMarkers);
+    const wrdataArtifacts = deckWrdataArtifacts(table, writeMarkers, rawfileOptions);
     const wrdataArtifactTable = formatDeckWrdataArtifactTable(wrdataArtifacts);
     const wrdataArtifactCsv = formatDeckWrdataArtifactCsv(wrdataArtifacts);
     const wrdataArtifactJson = formatDeckWrdataArtifactJson(wrdataArtifacts);
@@ -8804,7 +8830,7 @@ export function runDeckAnalysis(
     const rawfileArtifactCsv = formatDeckRawfileArtifactCsv(rawfileArtifacts);
     const rawfileArtifactJson = formatDeckRawfileArtifactJson(rawfileArtifacts);
     const rawfileArtifactRecords = deckRawfileArtifactRecords(rawfileArtifacts);
-    const wrdataArtifacts = deckWrdataArtifacts(table, writeMarkers);
+    const wrdataArtifacts = deckWrdataArtifacts(table, writeMarkers, rawfileOptions);
     const wrdataArtifactTable = formatDeckWrdataArtifactTable(wrdataArtifacts);
     const wrdataArtifactCsv = formatDeckWrdataArtifactCsv(wrdataArtifacts);
     const wrdataArtifactJson = formatDeckWrdataArtifactJson(wrdataArtifacts);
@@ -8898,7 +8924,7 @@ export function runDeckAnalysis(
     const rawfileArtifactCsv = formatDeckRawfileArtifactCsv(rawfileArtifacts);
     const rawfileArtifactJson = formatDeckRawfileArtifactJson(rawfileArtifacts);
     const rawfileArtifactRecords = deckRawfileArtifactRecords(rawfileArtifacts);
-    const wrdataArtifacts = deckWrdataArtifacts(table, writeMarkers);
+    const wrdataArtifacts = deckWrdataArtifacts(table, writeMarkers, rawfileOptions);
     const wrdataArtifactTable = formatDeckWrdataArtifactTable(wrdataArtifacts);
     const wrdataArtifactCsv = formatDeckWrdataArtifactCsv(wrdataArtifacts);
     const wrdataArtifactJson = formatDeckWrdataArtifactJson(wrdataArtifacts);
@@ -8982,7 +9008,7 @@ export function runDeckAnalysis(
     const rawfileArtifactCsv = formatDeckRawfileArtifactCsv(rawfileArtifacts);
     const rawfileArtifactJson = formatDeckRawfileArtifactJson(rawfileArtifacts);
     const rawfileArtifactRecords = deckRawfileArtifactRecords(rawfileArtifacts);
-    const wrdataArtifacts = deckWrdataArtifacts(table, writeMarkers);
+    const wrdataArtifacts = deckWrdataArtifacts(table, writeMarkers, rawfileOptions);
     const wrdataArtifactTable = formatDeckWrdataArtifactTable(wrdataArtifacts);
     const wrdataArtifactCsv = formatDeckWrdataArtifactCsv(wrdataArtifacts);
     const wrdataArtifactJson = formatDeckWrdataArtifactJson(wrdataArtifacts);
@@ -9065,7 +9091,7 @@ export function runDeckAnalysis(
     const rawfileArtifactCsv = formatDeckRawfileArtifactCsv(rawfileArtifacts);
     const rawfileArtifactJson = formatDeckRawfileArtifactJson(rawfileArtifacts);
     const rawfileArtifactRecords = deckRawfileArtifactRecords(rawfileArtifacts);
-    const wrdataArtifacts = deckWrdataArtifacts(table, writeMarkers);
+    const wrdataArtifacts = deckWrdataArtifacts(table, writeMarkers, rawfileOptions);
     const wrdataArtifactTable = formatDeckWrdataArtifactTable(wrdataArtifacts);
     const wrdataArtifactCsv = formatDeckWrdataArtifactCsv(wrdataArtifacts);
     const wrdataArtifactJson = formatDeckWrdataArtifactJson(wrdataArtifacts);
@@ -9158,7 +9184,7 @@ export function runDeckAnalysis(
     const rawfileArtifactCsv = formatDeckRawfileArtifactCsv(rawfileArtifacts);
     const rawfileArtifactJson = formatDeckRawfileArtifactJson(rawfileArtifacts);
     const rawfileArtifactRecords = deckRawfileArtifactRecords(rawfileArtifacts);
-    const wrdataArtifacts = deckWrdataArtifacts(table, writeMarkers);
+    const wrdataArtifacts = deckWrdataArtifacts(table, writeMarkers, rawfileOptions);
     const wrdataArtifactTable = formatDeckWrdataArtifactTable(wrdataArtifacts);
     const wrdataArtifactCsv = formatDeckWrdataArtifactCsv(wrdataArtifacts);
     const wrdataArtifactJson = formatDeckWrdataArtifactJson(wrdataArtifacts);

--- a/code/packages/typescript/spice-engine/tests/transient.test.ts
+++ b/code/packages/typescript/spice-engine/tests/transient.test.ts
@@ -2120,10 +2120,19 @@ let gain = 2
     expect(execution.wrdataArtifacts[0]?.marker).toBe("wrdata out.dat V(in)");
     expect(execution.wrdataArtifacts[0]?.probeCount).toBe(1);
     expect(execution.wrdataArtifacts[0]?.probes).toEqual(["V(in)"]);
+    expect(execution.wrdataArtifacts[0]?.optionCount).toBe(expectedRawfileOptions.length);
+    expect(execution.wrdataArtifacts[0]?.options).toEqual(expectedRawfileOptions);
     expect(execution.wrdataArtifacts[0]?.datafile).toContain(
       "# SPICE deck wrdata artifact\n",
     );
     expect(execution.wrdataArtifacts[0]?.datafile).toContain("Probes: V(in)\n");
+    expect(execution.wrdataArtifacts[0]?.datafile).toContain(
+      `Options: ${rawfileOptionList}\n`,
+    );
+    expect(execution.wrdataArtifacts[0]?.datafile).toContain(
+      "VectorNames: Index;V(in)\n",
+    );
+    expect(execution.wrdataArtifacts[0]?.datafile).toContain("Scale: Index\n");
     expect(execution.wrdataArtifacts[0]?.datafile).toContain("Index\tV(in)\n");
     expect(execution.wrdataArtifacts[0]?.datafile).toContain("0\t1.000000e+00\n");
     const wrdataRecord = execution.wrdataArtifactRecords[0]!;
@@ -2131,6 +2140,8 @@ let gain = 2
     expect(wrdataRecord["Marker"]).toBe("wrdata out.dat V(in)");
     expect(wrdataRecord["Probes"]).toBe("1");
     expect(wrdataRecord["ProbeList"]).toBe("V(in)");
+    expect(wrdataRecord["Options"]).toBe(String(expectedRawfileOptions.length));
+    expect(wrdataRecord["RawfileOptionList"]).toBe(rawfileOptionList);
     expect(wrdataRecord["Bytes"]).toBe(String(execution.wrdataArtifacts[0]?.datafile.length));
     expect(execution.wrdataArtifactTable).toBe(
       formatDeckWrdataArtifactTable(execution.wrdataArtifacts),
@@ -2142,6 +2153,9 @@ let gain = 2
       formatDeckWrdataArtifactJson(execution.wrdataArtifacts),
     );
     expect(JSON.parse(execution.wrdataArtifactJson)[0].ProbeList).toBe("V(in)");
+    expect(JSON.parse(execution.wrdataArtifactJson)[0].RawfileOptionList).toBe(
+      rawfileOptionList,
+    );
     expect(execution.diagnosticCount).toBe(expectedCodes.length);
     expect(execution.diagnosticCodes).toEqual(expectedCodes);
     expect(execution.runArtifacts[0]?.controlLineCount).toBe(expectedControlLines.length);

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -121,8 +121,10 @@ downstream tools to compare.
      table, CSV, compact JSON, and host-native record summaries, and accepted
      `.control` `wrdata <file> ...` markers now produce deterministic
      in-memory ASCII data-file artifacts with matching stable table, CSV,
-     compact JSON, and host-native record summaries while filesystem writes
-     remain metadata-only.
+     compact JSON, and host-native record summaries, and WRDATA artifacts now
+     carry accepted rawfile/data-write option inventories plus deterministic
+     `wr_vecnames` / `wr_singlescale` rendering metadata while filesystem
+     writes remain metadata-only.
    - Expand remaining deck-controlled analyses toward full SPICE compatibility
      while keeping unsupported control-flow diagnostics explicit.
 
@@ -1048,6 +1050,16 @@ downstream tools to compare.
     - Each selected execution exposes WRDATA artifact count/list metadata plus
       stable WRDATA artifact table, CSV, compact JSON, and host-native record
       summaries while filesystem writes remain metadata-only.
+
+96. Deck WRDATA rawfile option rendering artifacts.
+    - Status: completed in this deck WRDATA rawfile option rendering artifact
+      slice.
+    - Python, Rust, and TypeScript WRDATA artifacts now carry accepted
+      rawfile/data-write option inventories through stable `Options` /
+      `RawfileOptionList` summary fields.
+    - In-memory WRDATA data files now render deterministic `VectorNames` and
+      `Scale` metadata when accepted `set wr_vecnames` and `set wr_singlescale`
+      controls are present, while filesystem writes remain metadata-only.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- carry accepted rawfile/data-write options into WRDATA artifact summary records
- render deterministic `Options`, `VectorNames`, and `Scale` metadata in in-memory WRDATA data files when `wr_vecnames` / `wr_singlescale` are present
- document the completed SPICE slice across Python, Rust, TypeScript, and the full implementation plan

## Validation
- `/Users/adhithya/.local/share/mise/installs/python/3.12.13/bin/python -m ruff check code/packages/python/spice-engine/src/spice_engine/engine.py code/packages/python/spice-engine/tests/test_engine.py`
- `PYTHONPATH="/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-spice-deck-rawfile-option-rendering-artifacts/code/packages/python/spice-engine/src:/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-spice-deck-rawfile-option-rendering-artifacts/code/packages/python/spice-netlist-parser/src:/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-spice-deck-rawfile-option-rendering-artifacts/code/packages/python/mosfet-models/src:/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-spice-deck-rawfile-option-rendering-artifacts/code/packages/python/device-physics/src" /Users/adhithya/.local/share/mise/installs/python/3.12.13/bin/python -m pytest code/packages/python/spice-engine/tests/test_engine.py`
- `cargo fmt --manifest-path code/packages/rust/spice-engine/Cargo.toml -- --check`
- `cargo test --manifest-path code/packages/rust/spice-engine/Cargo.toml`
- `npm --prefix code/packages/typescript/spice-engine test`
- `npm --prefix code/packages/typescript/spice-engine run build`
- `git diff --check`