### PR TITLE
feat(mycin-pharm): ground penicillamine→copper antidote

### DIFF
--- a/code/specs/data/mycin-2026/recall/pharm-edges.adj
+++ b/code/specs/data/mycin-2026/recall/pharm-edges.adj
@@ -157,4 +157,9 @@ rulebook pharm_facts {
         source "A variety of chelating agents alone or in combination can be used depending on the severity of clinical presentation and the patient's blood lead concentration, including succimer, calcium disodium ethylenediaminetetraacetic acid (EDTA), and British anti-Lewisite (BAL, also known as dimercaprol)."
         locator "https://www.ncbi.nlm.nih.gov/books/NBK541097/"
         trust authoritative
+    % --- EXPAND: penicillamine chelates copper (copper overload / Wilson disease) --
+    relate antidote_for(copper_toxicity, penicillamine)
+        source "Penicillamine is a copper chelator derived from penicillin."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK513316/"
+        trust authoritative
 }

--- a/code/specs/data/mycin-2026/recall/pharm-recall.query.adj
+++ b/code/specs/data/mycin-2026/recall/pharm-recall.query.adj
@@ -31,3 +31,4 @@ import "pharm-edges.adj"
 ? antidote_for(beta_blocker_overdose, $Antidote)      % expect glucagon (expand)
 ? antidote_for(methemoglobinemia, $Antidote)          % expect methylene_blue (expand)
 ? antidote_for(lead_poisoning, $Antidote)             % expect succimer (expand)
+? antidote_for(copper_toxicity, $Antidote)           % expect penicillamine (expand)

--- a/code/specs/data/mycin-2026/recall/test_pharm_recall.py
+++ b/code/specs/data/mycin-2026/recall/test_pharm_recall.py
@@ -50,6 +50,7 @@ EXPECTED = [
     ("beta_blocker_overdose", "antidote_for", "glucagon"),        # expand (NBK448097)
     ("methemoglobinemia", "antidote_for", "methylene_blue"),      # expand (NBK557593)
     ("lead_poisoning", "antidote_for", "succimer"),               # expand (NBK541097)
+    ("copper_toxicity", "antidote_for", "penicillamine"),         # expand (NBK513316)
 ]
 VAR = {"drug_class": "Class", "mechanism": "MOA", "adverse_effect": "Effect",
        "antidote_for": "Antidote"}


### PR DESCRIPTION
## What

Fifth toxicology-antidote expansion: **antidote_for(copper_toxicity, penicillamine)** — NBK513316:
> Penicillamine is a copper chelator derived from penicillin.

`antidote_for` now covers **15** board-classic pairs. Physostigmine→anticholinergic and sodium-bicarbonate→TCA were checked this round but **deferred** (honest scope): their StatPearls pages hedge physostigmine as a secondary option and state the sodium-bicarbonate indication without naming TCA in one self-contained span.

## Changes (data-only)
- `pharm-edges.adj` +1 `relate`; `pharm-recall.query.adj` +1 query; `test_pharm_recall.py` EXPECTED +1 (`ibuprofen` negative control unchanged)

## Verification
- `test_pharm_recall: 3/3 passed`; ruff clean; data-only security review passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)