### PR TITLE
feat(x86-simulator): stdin (getchar) + Brainfuck cat runs locally (S6)

### DIFF
--- a/code/packages/rust/x86-simulator/CHANGELOG.md
+++ b/code/packages/rust/x86-simulator/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog — x86-simulator
 
+## 0.6.0 — 2026-06-21 — stdin (`getchar`) + Brainfuck cat runs locally (x86-sim PR-S6)
+
+Completes the Brainfuck story: the stdin-driven `,` programs now run on the
+x86_64 column locally. No new opcode was needed — only a real `getchar`.
+
+### Added
+- **`getchar` reads a stdin buffer** — the `Simulator` gains an `input: Vec<u8>`
+  consumed front-to-back; `getchar` returns the next byte, or EOF (`-1`) once
+  drained. Returning `-1` (not `0`) matches the libc/native convention, so the
+  Brainfuck IIR's negative-`getchar`→0 clamp halts a `,[.,]` cat loop at
+  end-of-input exactly as it does on the real native backend.
+- **`MachineCodeHarness::stdin(&[u8])`** — supplies that buffer (defaults to
+  empty, i.e. immediate EOF, so existing programs are unchanged).
+- **3 stdin Brainfuck matrix cells**: `,+.` (input `A` ⇒ `B`), `,.,.` (echo
+  `Hi` ⇒ `Hi`), and `,[.,]` (cat `Hi` ⇒ `Hi`) — run on the x86_64 column
+  locally via a new `run_with_stdin` helper.
+
+### Verified
+- Cat (`,[.,]`) reads+prints until the simulator's EOF threads through the
+  backend's clamp and halts the loop. 53 tests (28 unit + 21 matrix + 4
+  lib/harness).
+
 ## 0.5.0 — 2026-06-21 — byte-tape store + Brainfuck runs locally (x86-sim PR-S5)
 
 Continues the coverage-mining pattern (S4): running a **Brainfuck** program

--- a/code/packages/rust/x86-simulator/Cargo.toml
+++ b/code/packages/rust/x86-simulator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "x86-simulator"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 description = "x86/x86-64 runtime simulator — decode + execute machine code, and run the x86_64-backend's emitted code locally (host-arch-independent)"
 

--- a/code/packages/rust/x86-simulator/README.md
+++ b/code/packages/rust/x86-simulator/README.md
@@ -62,13 +62,15 @@ as the exit code (the same convention as `run_native` / `run_wasm`).
 On an Apple-Silicon host the matrix's `NativeAot` cell only ever builds+runs the
 *aarch64* backend; this test exercises the **x86_64** column end-to-end —
 **locally on aarch64**, retro-verifying columns the matrix could previously
-execute only on x86 CI. The 18 cells span Twig (const/arithmetic/`define`),
+execute only on x86 CI. The 21 cells span Twig (const/arithmetic/`define`),
 Nib (u8 wrap, `~` complement, unsigned division), ALGOL (procedure call,
 switch/computed-goto, signed `div`, E3 `real` SSE2 floats, E5 arrays straight-
 line and in a `for` loop), Oct (`out`, `~`), Dartmouth BASIC (`PRINT`,
 `FOR`/`NEXT` — stdout-captured via the host shims), and Brainfuck (`.` over a
-byte tape). Each new language exposed a missing opcode — the Nib/Oct `~` cells
-surfaced group-3 `0xF7`, and the Brainfuck cell surfaced the `0x88` byte store —
+byte tape, plus `,`-driven stdin: increment, echo, and cat — fed via
+`MachineCodeHarness::stdin`). Each new language exposed a missing opcode — the
+Nib/Oct `~` cells surfaced group-3 `0xF7`, and the Brainfuck cell surfaced the
+`0x88` byte store —
 which this crate now decodes.
 
 ## Safety

--- a/code/packages/rust/x86-simulator/src/harness.rs
+++ b/code/packages/rust/x86-simulator/src/harness.rs
@@ -55,6 +55,8 @@ impl std::error::Error for BuildError {}
 #[derive(Default)]
 pub struct MachineCodeHarness {
     funcs: Vec<(String, Vec<u8>, Vec<Reloc>)>,
+    /// Bytes the built `Simulator` will hand to `getchar`, in order.
+    input: Vec<u8>,
 }
 
 // Layout constants for the flat address space.
@@ -74,6 +76,14 @@ impl MachineCodeHarness {
     /// Add a compiled function (name, machine-code bytes, relocations).
     pub fn function(mut self, name: &str, bytes: &[u8], relocs: &[Reloc]) -> Self {
         self.funcs.push((name.to_string(), bytes.to_vec(), relocs.to_vec()));
+        self
+    }
+
+    /// Supply the bytes the program will read via `getchar` (e.g. a Brainfuck
+    /// `,` program's stdin).  Consumed in order; once drained, `getchar` returns
+    /// EOF.  Defaults to empty (every `getchar` sees EOF) when not called.
+    pub fn stdin(mut self, input: &[u8]) -> Self {
+        self.input = input.to_vec();
         self
     }
 
@@ -140,6 +150,8 @@ impl MachineCodeHarness {
             state,
             mem,
             stdout: Vec::new(),
+            input: self.input,
+            input_pos: 0,
             code,
             code_base: CODE_BASE,
             externals,

--- a/code/packages/rust/x86-simulator/src/lib.rs
+++ b/code/packages/rust/x86-simulator/src/lib.rs
@@ -56,6 +56,11 @@ pub struct Simulator {
     pub mem: Memory,
     /// Captured bytes written by host I/O shims (`putchar`/`print_i64`).
     pub stdout: Vec<u8>,
+    /// Bytes the program reads via `getchar`, consumed front-to-back; once
+    /// exhausted, `getchar` returns EOF (`-1`). Empty by default.
+    input: Vec<u8>,
+    /// How many `input` bytes have been consumed so far.
+    input_pos: usize,
     /// The concatenated code bytes (relocations already patched).
     code: Vec<u8>,
     /// Where the code region begins in `mem`.
@@ -135,8 +140,17 @@ impl Simulator {
                 self.stdout.push(c);
                 self.state.set(Reg::Rax, c as u64);
             }
-            // `int getchar()` — no stdin in v1; returns EOF (-1).
-            "__twig_getchar" | "getchar" => { self.state.set(Reg::Rax, u64::MAX); }
+            // `int getchar()` — consume the next input byte, or EOF (`-1`) once
+            // the buffer is drained.  Returning `-1` (not 0) matches the libc /
+            // native convention; the Brainfuck IIR clamps a negative `getchar`
+            // to 0 itself, so a `,[.,]` cat loop halts at end-of-input.
+            "__twig_getchar" | "getchar" => {
+                let r = match self.input.get(self.input_pos) {
+                    Some(&b) => { self.input_pos += 1; b as u64 }
+                    None => u64::MAX, // EOF (-1)
+                };
+                self.state.set(Reg::Rax, r);
+            }
             // `void __twig_print_i64(i64)` — print the decimal value.
             "__twig_print_i64" | "__print_i64" | "print_i64" => {
                 let v = self.state.get(Reg::Rdi) as i64;

--- a/code/packages/rust/x86-simulator/tests/lang_matrix_x86.rs
+++ b/code/packages/rust/x86-simulator/tests/lang_matrix_x86.rs
@@ -287,3 +287,40 @@ fn brainfuck_putchar_runs_on_x86_sim() {
     let (_code, out) = run_capturing_stdout(Language::Brainfuck, "++++++++[>++++++++<-]>+.");
     assert_eq!(out, "A");
 }
+
+/// Like [`run_capturing_stdout`] but feeds `input` to the program's `getchar`
+/// (the harness stdin buffer) — for the Brainfuck `,` programs.
+fn run_with_stdin(lang: Language, src: &str, input: &[u8]) -> String {
+    let (funcs, entry) = compile_to_x86_functions(lang, src);
+    let mut builder = MachineCodeHarness::new().stdin(input);
+    for f in &funcs {
+        builder = builder.function(&f.name, &f.bytes, &f.relocs);
+    }
+    let mut sim = builder
+        .build(&entry)
+        .expect("harness should lay out + link the matrix program");
+    sim.run().expect("x86_64 machine code should run to a clean ret");
+    String::from_utf8(sim.stdout.clone()).expect("stdout should be valid UTF-8")
+}
+
+/// Brainfuck — **read a byte from stdin**, `+`, print (`,+.` with input `A` ⇒
+/// `B`).  Exercises the `getchar` host shim consuming a real input byte.
+#[test]
+fn brainfuck_stdin_increment_runs_on_x86_sim() {
+    assert_eq!(run_with_stdin(Language::Brainfuck, ",+.", b"A"), "B");
+}
+
+/// Brainfuck — **echo two bytes** (`,.,.` with input `Hi` ⇒ `Hi`).
+#[test]
+fn brainfuck_stdin_echo_runs_on_x86_sim() {
+    assert_eq!(run_with_stdin(Language::Brainfuck, ",.,.", b"Hi"), "Hi");
+}
+
+/// Brainfuck — **cat until EOF** (`,[.,]` with input `Hi` ⇒ `Hi`).  The `[...]`
+/// loop reads+prints until `getchar` returns EOF, which the Brainfuck IIR clamps
+/// to a 0 cell so the loop halts — so this also checks the simulator's EOF (`-1`)
+/// convention threads correctly through the backend's clamp.
+#[test]
+fn brainfuck_cat_runs_on_x86_sim() {
+    assert_eq!(run_with_stdin(Language::Brainfuck, ",[.,]", b"Hi"), "Hi");
+}

--- a/code/specs/x86-runtime-simulator.md
+++ b/code/specs/x86-runtime-simulator.md
@@ -171,8 +171,15 @@ This harness is what `lang_matrix.rs` calls to run the x86_64 column locally.
    (`0x88`)** the byte-tape `store_byte` emits (S1–S4 only had the `movzx` load
    side), plus the `__twig_putchar`/`__twig_getchar` host-shim aliases. Added
    both; Brainfuck now runs on the x86_64 column locally. (Stdin-driven cat
-   `,[.,]` still pends an input buffer in the harness.) (x86-simulator 0.5.0.)
-6. **S6 — 32-bit x86 (i386)**: operand/address-size handling + 32-bit decode, as
+   `,[.,]` still pends an input buffer in the harness — added in S6.)
+   (x86-simulator 0.5.0.)
+6. **S6 — stdin (`getchar`) + Brainfuck cat**: ✅ done. The `Simulator` gains an
+   `input` buffer (`MachineCodeHarness::stdin`); `getchar` consumes it and returns
+   EOF (`-1`) when drained — matching the libc/native convention, so the
+   Brainfuck IIR's negative-clamp halts a `,[.,]` cat at end-of-input. Three
+   stdin Brainfuck cells (`,+.`/`,.,.`/`,[.,]`) run on the x86_64 column locally.
+   No new opcode needed. (x86-simulator 0.6.0.)
+7. **S7 — 32-bit x86 (i386)**: operand/address-size handling + 32-bit decode, as
    educational coverage (not on the run-our-codegen critical path — no matrix
    program emits 32-bit x86, so it's unit-tested against hand-assembled bytes).
 


### PR DESCRIPTION
## What

Completes the Brainfuck story on the local x86_64 column: the stdin-driven `,` programs now run. **No new opcode** was needed — only a real `getchar`.

## Added

- **`getchar` reads a stdin buffer** — the `Simulator` gains an `input: Vec<u8>` consumed front-to-back; `getchar` returns the next byte, or EOF (`-1`) once drained. Returning `-1` (not `0`) matches the libc/native convention, so the Brainfuck IIR's negative-`getchar`→0 clamp halts a `,[.,]` cat loop at end-of-input exactly as on the real native backend.
- **`MachineCodeHarness::stdin(&[u8])`** — supplies that buffer (defaults to empty = immediate EOF, so existing programs are unchanged).
- **3 stdin Brainfuck matrix cells** via a new `run_with_stdin` helper: `,+.` (input `A` ⇒ `B`), `,.,.` (echo `Hi` ⇒ `Hi`), `,[.,]` (cat `Hi` ⇒ `Hi`).

## Tests / security

- **53 tests** (28 unit + 21 matrix + 4 lib/harness). The cat cell verifies the simulator's EOF threads correctly through the backend's clamp to halt the loop.
- Security review passed (1 round): `getchar` consumes via bounds-safe `.get()`, `input_pos` is monotonic and capped at `len()` (no overflow), buffer is fixed at build (no growth), shim touches only `rax`.

## Notes

`x86-simulator` 0.6.0. Spec: S6 = this; 32-bit x86 (i386) renumbered to S7 (still the lone remaining educational item — no matrix program emits 32-bit). With this, **every matrix language now runs on the x86_64 column locally on aarch64.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)