### PR TITLE
feat(mycin-genetics): Angelman (maternal/UBE3A) + Friedreich AR & GAA repeat

### DIFF
--- a/code/specs/data/mycin-2026/recall/genetics-edges.adj
+++ b/code/specs/data/mycin-2026/recall/genetics-edges.adj
@@ -21,8 +21,9 @@
 % Honest scope: relations chosen so the cited span NAMES both endpoints. gene_defect
 % reuses the same relation the IMMUNO library uses (the engine binds any grounded
 % `relate(rel, args)`); the disorders here are disjoint from immunology's. Edges with
-% no clean self-contained span (e.g. Marfan→FBN1, where the page's FBN1 mentions are
-% citation titles or negative-finding clauses) are deferred rather than over-claimed.
+% no clean self-contained span are deferred rather than over-claimed — currently the
+% Duchenne→X-linked-recessive inheritance edge (the page states the inheritance in a
+% separate anaphoric "It is inherited..." sentence, not alongside the disease name).
 % ============================================================================
 
 dictionary genetics_vocab {
@@ -117,5 +118,24 @@ rulebook genetics_facts {
     relate gene_defect(marfan_syndrome, fbn1)
         source "While most individuals with MFS have an affected parent, 25% of patients develop the disease due to a de novo mutation involving the gene (FBN1) encoding the connective tissue protein fibrillin-1."
         locator "https://www.ncbi.nlm.nih.gov/books/NBK537339/"
+        trust authoritative
+    % --- EXPAND: Angelman syndrome (maternal imprinting; UBE3A) — PWS counterpart ---
+    relate imprinting(angelman_syndrome, maternal)
+        source "Angelman syndrome is a rare neurodevelopmental disorder caused by loss of maternal UBE3A expression on chromosome 15q11.2–q13"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK560870/"
+        trust authoritative
+    relate gene_defect(angelman_syndrome, ube3a)
+        source "Angelman syndrome is a rare neurodevelopmental disorder caused by loss of maternal UBE3A expression on chromosome 15q11.2–q13"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK560870/"
+        trust authoritative
+
+    % --- EXPAND: Friedreich ataxia inheritance + GAA repeat (one span names both) ----
+    relate inheritance(friedreich_ataxia, autosomal_recessive)
+        source "Friedreich ataxia is an autosomal recessive neurodegenerative disorder caused by guanine-adenine-adenine repeat expansion in the frataxin gene, leading to mitochondrial dysfunction."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK563199/"
+        trust authoritative
+    relate trinucleotide_repeat(friedreich_ataxia, gaa)
+        source "Friedreich ataxia is an autosomal recessive neurodegenerative disorder caused by guanine-adenine-adenine repeat expansion in the frataxin gene, leading to mitochondrial dysfunction."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK563199/"
         trust authoritative
 }

--- a/code/specs/data/mycin-2026/recall/genetics-recall.query.adj
+++ b/code/specs/data/mycin-2026/recall/genetics-recall.query.adj
@@ -27,3 +27,7 @@ import "genetics-edges.adj"
 ? gene_defect(myotonic_dystrophy, $Gene)               % expect dmpk (expand)
 ? gene_defect(friedreich_ataxia, $Gene)                % expect fxn (expand)
 ? gene_defect(marfan_syndrome, $Gene)                  % expect fbn1 (expand)
+? imprinting(angelman_syndrome, $Parent)               % expect maternal (expand)
+? gene_defect(angelman_syndrome, $Gene)                % expect ube3a (expand)
+? inheritance(friedreich_ataxia, $Pattern)             % expect autosomal_recessive (expand)
+? trinucleotide_repeat(friedreich_ataxia, $Repeat)     % expect gaa (expand)

--- a/code/specs/data/mycin-2026/recall/test_genetics_recall.py
+++ b/code/specs/data/mycin-2026/recall/test_genetics_recall.py
@@ -46,6 +46,10 @@ EXPECTED = [
     ("myotonic_dystrophy", "gene_defect", "dmpk"),                   # expand (NBK557446)
     ("friedreich_ataxia", "gene_defect", "fxn"),                     # expand (NBK563199)
     ("marfan_syndrome", "gene_defect", "fbn1"),                      # expand (NBK537339)
+    ("angelman_syndrome", "imprinting", "maternal"),                 # expand (NBK560870)
+    ("angelman_syndrome", "gene_defect", "ube3a"),                   # expand (NBK560870)
+    ("friedreich_ataxia", "inheritance", "autosomal_recessive"),     # expand (NBK563199)
+    ("friedreich_ataxia", "trinucleotide_repeat", "gaa"),            # expand (NBK563199)
 ]
 VAR = {"inheritance": "Pattern", "gene_defect": "Gene",
        "trinucleotide_repeat": "Repeat", "imprinting": "Parent"}


### PR DESCRIPTION
## What

Four grounded genetics edges, each from a clean StatPearls both-endpoints span:

- **imprinting(angelman_syndrome, maternal)** + **gene_defect(angelman_syndrome, ube3a)** — NBK560870 (one span; the classic Prader-Willi imprinting counterpart):
  > Angelman syndrome is a rare neurodevelopmental disorder caused by loss of maternal UBE3A expression on chromosome 15q11.2–q13
- **inheritance(friedreich_ataxia, autosomal_recessive)** + **trinucleotide_repeat(friedreich_ataxia, gaa)** — NBK563199:
  > Friedreich ataxia is an autosomal recessive neurodegenerative disorder caused by guanine-adenine-adenine repeat expansion in the frataxin gene, leading to mitochondrial dysfunction.

  This finally grounds the **GAA repeat** that an earlier PR deferred — this declarative names "Friedreich ataxia" alongside the GAA expansion in one self-contained sentence (the earlier candidate spans were anaphoric).

Also corrected the stale header note (Marfan→FBN1 is now grounded as of #6436; the currently-deferred edge is Duchenne→X-linked-recessive).

## Changes (data-only)
- `genetics-edges.adj` +4 `relate` (+ header note fix); `genetics-recall.query.adj` +4; `test_genetics_recall.py` EXPECTED +4 (`ehlers_danlos_syndrome` negative control unchanged)

## Verification
- `test_genetics_recall: 3/3 passed`; ruff clean; data-only security review passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)