### PR TITLE
[codex] Select SPICE WRDATA probe columns

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ### Added
 
+- **Deck WRDATA probe column artifacts** —
+  `format_deck_wrdata_ascii()` now treats explicit `wrdata <file> <probes...>`
+  probe lists as data-file column selectors, preserving the scale column plus
+  requested matching probe columns in deterministic WRDATA output, matching
+  Rust and TypeScript.
+
 - **Deck WRDATA rawfile option rendering artifacts** —
   selected `run_deck_analysis()` WRDATA artifacts now carry accepted
   `.control` rawfile/data-write option inventories through stable

--- a/code/packages/python/spice-engine/README.md
+++ b/code/packages/python/spice-engine/README.md
@@ -136,6 +136,8 @@ Accepted `.control` rawfile output options (`set filetype=ascii`,
 `RawfileOptions` / `RawfileOptionList` artifact fields. WRDATA artifacts also
 carry the same option inventories and render `wr_vecnames` / `wr_singlescale`
 intent as stable `VectorNames` / `Scale` metadata in the in-memory data file.
+When a `wrdata` marker names probes, its data file keeps the scale column plus
+only the requested matching probe columns.
 Existing `.control` body policy diagnostics flow into those selected-run
 artifact `Diagnostics` / `DiagnosticCodeList` fields and through the same
 run-artifact table, CSV, JSON, and `table_artifacts` records.

--- a/code/packages/python/spice-engine/src/spice_engine/engine.py
+++ b/code/packages/python/spice-engine/src/spice_engine/engine.py
@@ -3019,11 +3019,13 @@ def format_deck_wrdata_ascii(
     rows = table.splitlines()
     if not rows:
         return ""
-    columns = rows[0].split("\t")
+    probe_list = list(probes)
+    projected_rows = _deck_wrdata_project_rows(rows, probe_list)
+    columns = projected_rows[0].split("\t")
     options = list(rawfile_options)
     lines = [
         "# SPICE deck wrdata artifact",
-        "Probes: " + ";".join(probes),
+        "Probes: " + ";".join(probe_list),
     ]
     if options:
         lines.append("Options: " + ";".join(options))
@@ -3032,8 +3034,35 @@ def format_deck_wrdata_ascii(
         lines.append("VectorNames: " + ";".join(columns))
     if "set wr_singlescale" in normalized_options and columns:
         lines.append("Scale: " + columns[0])
-    lines.extend(rows)
+    lines.extend(projected_rows)
     return "\n".join(lines) + "\n"
+
+
+def _deck_wrdata_project_rows(rows: list[str], probes: list[str]) -> list[str]:
+    columns = rows[0].split("\t")
+    if not probes:
+        return rows
+    selected_indices: list[int] = []
+    if columns:
+        selected_indices.append(0)
+    normalized_columns = [column.casefold() for column in columns]
+    for probe in probes:
+        normalized_probe = probe.casefold()
+        if normalized_probe not in normalized_columns:
+            continue
+        index = normalized_columns.index(normalized_probe)
+        if index not in selected_indices:
+            selected_indices.append(index)
+    projected_rows: list[str] = []
+    for row in rows:
+        cells = row.split("\t")
+        projected_rows.append(
+            "\t".join(
+                cells[index] if index < len(cells) else ""
+                for index in selected_indices
+            )
+        )
+    return projected_rows
 
 
 def _deck_wrdata_marker_parts(marker: str) -> tuple[str, list[str]] | None:

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -226,6 +226,7 @@ from spice_engine import (
     format_deck_wrdata_artifact_csv,
     format_deck_wrdata_artifact_json,
     format_deck_wrdata_artifact_table,
+    format_deck_wrdata_ascii,
     format_digital_bridge_schedule_table,
     format_digital_event_stream_table,
     format_digital_event_stream_vcd,
@@ -6708,6 +6709,29 @@ def test_text_output_tables_are_stable_for_dc_and_transient_results() -> None:
         "Index\tTime\tV(in)\tV(out)\tI(V1)\n"
         "0\t0.000000e+00\t0.000000e+00\t0.000000e+00\t0.000000e+00\n"
         "1\t1.000000e-03\t1.000000e+00\t5.000000e-01\t-5.000000e-04\n"
+    )
+
+
+def test_deck_wrdata_ascii_selects_marker_probe_columns() -> None:
+    table = (
+        "Index\tV(in)\tI(V1)\n"
+        "0\t1.000000e+00\t-1.000000e-03\n"
+        "1\t2.000000e+00\t-2.000000e-03\n"
+    )
+
+    assert format_deck_wrdata_ascii(
+        table,
+        ["I(V1)"],
+        ["set wr_vecnames", "set wr_singlescale"],
+    ) == (
+        "# SPICE deck wrdata artifact\n"
+        "Probes: I(V1)\n"
+        "Options: set wr_vecnames;set wr_singlescale\n"
+        "VectorNames: Index;I(V1)\n"
+        "Scale: Index\n"
+        "Index\tI(V1)\n"
+        "0\t-1.000000e-03\n"
+        "1\t-2.000000e-03\n"
     )
 
 

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Treat explicit `wrdata <file> <probes...>` probe lists as in-memory data-file
+  column selectors in `format_deck_wrdata_ascii`, preserving the scale column
+  plus requested matching probe columns in deterministic WRDATA output,
+  matching Python and TypeScript.
 - Carry accepted `.control` rawfile/data-write option inventories through
   WRDATA artifact `Options` / `RawfileOptionList` summary columns, and render
   `wr_vecnames` / `wr_singlescale` intent as deterministic `VectorNames` /

--- a/code/packages/rust/spice-engine/README.md
+++ b/code/packages/rust/spice-engine/README.md
@@ -209,6 +209,8 @@ Accepted `.control` rawfile output options (`set filetype=ascii`,
 `RawfileOptions` / `RawfileOptionList` artifact fields. WRDATA artifacts also
 carry the same option inventories and render `wr_vecnames` / `wr_singlescale`
 intent as stable `VectorNames` / `Scale` metadata in the in-memory data file.
+When a `wrdata` marker names probes, its data file keeps the scale column plus
+only the requested matching probe columns.
 Existing `.control` body policy diagnostics flow into those selected-run artifact `Diagnostics` /
 `DiagnosticCodeList` fields and through the same run-artifact table, CSV, JSON,
 and `table_artifacts` records. `format_deck_table_csv` also converts any stable

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -10715,7 +10715,8 @@ pub fn format_deck_wrdata_ascii(
     if rows.is_empty() {
         return String::new();
     }
-    let columns = rows[0].split('\t').collect::<Vec<_>>();
+    let projected_rows = deck_wrdata_project_rows(&rows, probes);
+    let columns = projected_rows[0].split('\t').collect::<Vec<_>>();
     let mut lines = vec![
         "# SPICE deck wrdata artifact".to_string(),
         format!("Probes: {}", probes.join(";")),
@@ -10741,8 +10742,39 @@ pub fn format_deck_wrdata_ascii(
             lines.push(format!("Scale: {scale}"));
         }
     }
-    lines.extend(rows.iter().map(|row| (*row).to_string()));
+    lines.extend(projected_rows);
     format!("{}\n", lines.join("\n"))
+}
+
+fn deck_wrdata_project_rows(rows: &[&str], probes: &[String]) -> Vec<String> {
+    let columns = rows[0].split('\t').collect::<Vec<_>>();
+    if probes.is_empty() {
+        return rows.iter().map(|row| (*row).to_string()).collect();
+    }
+    let mut selected_indices = Vec::new();
+    if !columns.is_empty() {
+        selected_indices.push(0);
+    }
+    for probe in probes {
+        if let Some(index) = columns
+            .iter()
+            .position(|column| column.eq_ignore_ascii_case(probe))
+        {
+            if !selected_indices.contains(&index) {
+                selected_indices.push(index);
+            }
+        }
+    }
+    rows.iter()
+        .map(|row| {
+            let cells = row.split('\t').collect::<Vec<_>>();
+            selected_indices
+                .iter()
+                .map(|index| cells.get(*index).copied().unwrap_or(""))
+                .collect::<Vec<_>>()
+                .join("\t")
+        })
+        .collect()
 }
 
 fn deck_wrdata_marker_parts(marker: &str) -> Option<(String, Vec<String>)> {

--- a/code/packages/rust/spice-engine/tests/transient_tests.rs
+++ b/code/packages/rust/spice-engine/tests/transient_tests.rs
@@ -12,7 +12,7 @@ use spice_engine::{
     format_deck_rawfile_artifact_table, format_deck_run_artifact_csv,
     format_deck_run_artifact_json, format_deck_run_artifact_table, format_deck_table_csv,
     format_deck_table_json, format_deck_transient_table, format_deck_wrdata_artifact_csv,
-    format_deck_wrdata_artifact_json, format_deck_wrdata_artifact_table,
+    format_deck_wrdata_artifact_json, format_deck_wrdata_artifact_table, format_deck_wrdata_ascii,
     format_digital_bridge_schedule_table, format_digital_event_stream_table,
     format_digital_event_table, format_distortion_table, format_fourier_table,
     format_measurement_table, format_pole_zero_table, format_pss_table, format_transient_table,
@@ -1664,6 +1664,30 @@ fn text_output_tables_are_stable_for_dc_and_transient_results() {
     assert_eq!(
         format_transient_table(&points, &["V(vin)", "V(mid)", "I(V1)"]).unwrap(),
         "Index\tTime\tV(vin)\tV(mid)\tI(V1)\n0\t1.000000e-03\t1.000000e+01\t5.000000e+00\t-5.000000e-03\n1\t2.000000e-03\t1.000000e+01\t5.000000e+00\t-5.000000e-03\n"
+    );
+}
+
+#[test]
+fn deck_wrdata_ascii_selects_marker_probe_columns() {
+    let table =
+        "Index\tV(in)\tI(V1)\n0\t1.000000e+00\t-1.000000e-03\n1\t2.000000e+00\t-2.000000e-03\n";
+    assert_eq!(
+        format_deck_wrdata_ascii(
+            table,
+            &["I(V1)".to_string()],
+            &[
+                "set wr_vecnames".to_string(),
+                "set wr_singlescale".to_string()
+            ],
+        ),
+        "# SPICE deck wrdata artifact\n\
+Probes: I(V1)\n\
+Options: set wr_vecnames;set wr_singlescale\n\
+VectorNames: Index;I(V1)\n\
+Scale: Index\n\
+Index\tI(V1)\n\
+0\t-1.000000e-03\n\
+1\t-2.000000e-03\n"
     );
 }
 

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Treat explicit `wrdata <file> <probes...>` probe lists as in-memory data-file
+  column selectors in `formatDeckWrdataAscii`, preserving the scale column plus
+  requested matching probe columns in deterministic WRDATA output, matching
+  Python and Rust.
 - Carry accepted `.control` rawfile/data-write option inventories through
   WRDATA artifact `Options` / `RawfileOptionList` summary columns, and render
   `wr_vecnames` / `wr_singlescale` intent as deterministic `VectorNames` /

--- a/code/packages/typescript/spice-engine/README.md
+++ b/code/packages/typescript/spice-engine/README.md
@@ -125,6 +125,8 @@ Accepted `.control` rawfile output options (`set filetype=ascii`,
 `RawfileOptions` / `RawfileOptionList` artifact fields. WRDATA artifacts also
 carry the same option inventories and render `wr_vecnames` / `wr_singlescale`
 intent as stable `VectorNames` / `Scale` metadata in the in-memory data file.
+When a `wrdata` marker names probes, its data file keeps the scale column plus
+only the requested matching probe columns.
 Existing
 `.control` body policy diagnostics flow into those selected-run artifact `Diagnostics` /
 `DiagnosticCodeList` fields and through the same run-artifact table, CSV, JSON,

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -8437,7 +8437,8 @@ export function formatDeckWrdataAscii(
   if (rows.length === 0) {
     return "";
   }
-  const columns = rows[0]!.split("\t");
+  const projectedRows = deckWrdataProjectRows(rows, probes);
+  const columns = projectedRows[0]!.split("\t");
   const lines = [
     "# SPICE deck wrdata artifact",
     `Probes: ${probes.join(";")}`,
@@ -8452,8 +8453,30 @@ export function formatDeckWrdataAscii(
   if (normalizedOptions.has("set wr_singlescale") && columns.length > 0) {
     lines.push(`Scale: ${columns[0]}`);
   }
-  lines.push(...rows);
+  lines.push(...projectedRows);
   return `${lines.join("\n")}\n`;
+}
+
+function deckWrdataProjectRows(rows: readonly string[], probes: readonly string[]): string[] {
+  const columns = rows[0]!.split("\t");
+  if (probes.length === 0) {
+    return [...rows];
+  }
+  const selectedIndices: number[] = [];
+  if (columns.length > 0) {
+    selectedIndices.push(0);
+  }
+  const normalizedColumns = columns.map((column) => column.toLowerCase());
+  for (const probe of probes) {
+    const index = normalizedColumns.indexOf(probe.toLowerCase());
+    if (index !== -1 && !selectedIndices.includes(index)) {
+      selectedIndices.push(index);
+    }
+  }
+  return rows.map((row) => {
+    const cells = row.split("\t");
+    return selectedIndices.map((index) => cells[index] ?? "").join("\t");
+  });
 }
 
 function deckWrdataMarkerParts(marker: string): { target: string; probes: string[] } | undefined {

--- a/code/packages/typescript/spice-engine/tests/transient.test.ts
+++ b/code/packages/typescript/spice-engine/tests/transient.test.ts
@@ -53,6 +53,7 @@ import {
   formatDeckWrdataArtifactCsv,
   formatDeckWrdataArtifactJson,
   formatDeckWrdataArtifactTable,
+  formatDeckWrdataAscii,
   formatDeckTransientTable,
   formatDigitalBridgeScheduleTable,
   formatDigitalEventStreamTable,
@@ -1450,6 +1451,30 @@ describe("transient", () => {
       "Index\tTime\tV(mid)\tV(vin)\tI(V1)\n" +
         "0\t1.000000e-03\t5.000000e+00\t1.000000e+01\t-5.000000e-03\n" +
         "1\t2.000000e-03\t5.000000e+00\t1.000000e+01\t-5.000000e-03\n",
+    );
+  });
+
+  it("selects marker probe columns in WRDATA ASCII output", () => {
+    const table =
+      "Index\tV(in)\tI(V1)\n" +
+      "0\t1.000000e+00\t-1.000000e-03\n" +
+      "1\t2.000000e+00\t-2.000000e-03\n";
+
+    expect(
+      formatDeckWrdataAscii(
+        table,
+        ["I(V1)"],
+        ["set wr_vecnames", "set wr_singlescale"],
+      ),
+    ).toBe(
+      "# SPICE deck wrdata artifact\n" +
+        "Probes: I(V1)\n" +
+        "Options: set wr_vecnames;set wr_singlescale\n" +
+        "VectorNames: Index;I(V1)\n" +
+        "Scale: Index\n" +
+        "Index\tI(V1)\n" +
+        "0\t-1.000000e-03\n" +
+        "1\t-2.000000e-03\n",
     );
   });
 

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -123,8 +123,9 @@ downstream tools to compare.
      in-memory ASCII data-file artifacts with matching stable table, CSV,
      compact JSON, and host-native record summaries, and WRDATA artifacts now
      carry accepted rawfile/data-write option inventories plus deterministic
-     `wr_vecnames` / `wr_singlescale` rendering metadata while filesystem
-     writes remain metadata-only.
+     `wr_vecnames` / `wr_singlescale` rendering metadata, and explicit
+     `wrdata` probe lists now select the emitted in-memory data-file columns
+     while filesystem writes remain metadata-only.
    - Expand remaining deck-controlled analyses toward full SPICE compatibility
      while keeping unsupported control-flow diagnostics explicit.
 
@@ -1060,6 +1061,15 @@ downstream tools to compare.
     - In-memory WRDATA data files now render deterministic `VectorNames` and
       `Scale` metadata when accepted `set wr_vecnames` and `set wr_singlescale`
       controls are present, while filesystem writes remain metadata-only.
+
+97. Deck WRDATA probe column artifacts.
+    - Status: completed in this deck WRDATA probe column artifact slice.
+    - Python, Rust, and TypeScript `format_deck_wrdata_ascii` /
+      `formatDeckWrdataAscii` helpers now treat explicit
+      `wrdata <file> <probes...>` marker probes as data-file column selectors.
+    - In-memory WRDATA data files preserve the scale column plus requested
+      matching probe columns in marker order, while filesystem writes remain
+      metadata-only.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- Project deck WRDATA ASCII artifacts to the scale column plus requested `wrdata <file> <probes...>` columns in Python, Rust, and TypeScript.
- Keep WRDATA vector/scale metadata aligned with the projected data-file columns while filesystem writes remain metadata-only.
- Document the completed full-SPICE backlog slice and package changelogs/readmes.

## Verification
- `/Users/adhithya/.local/share/mise/installs/python/3.12.13/bin/python -m ruff check code/packages/python/spice-engine/src/spice_engine/engine.py code/packages/python/spice-engine/tests/test_engine.py`
- `PYTHONPATH="/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-spice-deck-wrdata-probe-columns/code/packages/python/spice-engine/src:/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-spice-deck-wrdata-probe-columns/code/packages/python/spice-netlist-parser/src:/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-spice-deck-wrdata-probe-columns/code/packages/python/mosfet-models/src:/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-spice-deck-wrdata-probe-columns/code/packages/python/device-physics/src" /Users/adhithya/.local/share/mise/installs/python/3.12.13/bin/python -m pytest code/packages/python/spice-engine/tests/test_engine.py`
- `cargo fmt --manifest-path code/packages/rust/spice-engine/Cargo.toml -- --check && cargo test --manifest-path code/packages/rust/spice-engine/Cargo.toml`
- `npm --prefix code/packages/typescript/spice-engine test`
- `npm --prefix code/packages/typescript/spice-engine run build`
- `git diff --check`