### PR TITLE
feat(r-lang): R-33 — cut() option completeness (labels/right/include.lowest/integer breaks)

### DIFF
--- a/code/packages/rust/r-runtime/CHANGELOG.md
+++ b/code/packages/rust/r-runtime/CHANGELOG.md
@@ -2,6 +2,46 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.28.0] - 2026-06-21
+
+### Added (via the shared `s-runtime`)
+
+- **R-33 — `cut()` option completeness**: the four options deferred from R-32,
+  reached through ordinary R syntax. All extend the R-32 `cut` handler in place
+  (same `findInterval`-backed scan, same factor builder); no new value type, no
+  grammar change.
+  - **`labels =`** — `labels = FALSE` returns the **integer bin codes** as a plain
+    numeric vector (NOT a factor): `cut(c(1, 2, 5), breaks = c(0, 3, 6), labels =
+    FALSE)` → `c(1, 1, 2)`, `class(...)` is `"numeric"`. A character `labels`
+    vector is used verbatim as the factor levels and **must** have length
+    `length(breaks) - 1`, else a clean error (`lengths of 'breaks' and 'labels'
+    differ`): `cut(c(1, 5, 10), breaks = c(0, 3, 6, 11), labels = c("lo", "mid",
+    "hi"))` → a factor with levels `c("lo", "mid", "hi")`. Absent / `labels = TRUE`
+    keeps the auto-generated interval labels.
+  - **`right = FALSE`** — left-closed `[lo, hi)` intervals instead of the default
+    right-closed `(lo, hi]`; auto-labels become `"[lo,hi)"`. `cut(c(1, 3), breaks =
+    c(0, 3, 6), right = FALSE)` → `1 ∈ [0,3)`, `3 ∈ [3,6)`. (The interval scan also
+    now honours the boundary convention exactly: under the default `right = TRUE`,
+    `x` equal to an interior break lands in the *lower* `(lo,hi]` interval.)
+  - **`include.lowest = TRUE`** — fold the extreme break into the adjacent interval:
+    the lowest break (`right = TRUE`) or the highest (`right = FALSE`), so that
+    boundary value bins instead of going `NA`. `cut(c(0, 1, 2), breaks = c(0, 1, 2),
+    include.lowest = TRUE)` → `0` lands in the first interval.
+  - **integer `breaks`** — a single number `N` requests `N` equal-width bins over
+    the range of `x`, with the range extended by `dx/1000` on each side
+    (`dx = max - min`; a degenerate all-equal `x` falls back to `abs(min)`, then
+    `1`). `cut(0:10, breaks = 5)` → a factor with 5 levels covering the extended
+    `0..10` range; every value gets a non-`NA` bin. (Note: `cut(x, breaks = c(5))`
+    is now this equal-width form, matching base R, rather than "fewer than two
+    breaks → all `NA`".)
+  - **Security**: `N` is capped at `MAX_SEQ_LEN` **before** any break/level vector
+    is built (a huge `N` errors, not allocates); the equal-width breaks use
+    finite/checked arithmetic so a degenerate range never divides by zero; the
+    `labels` length check returns a clean `Err` (never panics); `labels = FALSE`
+    allocates no factor. No new user-controlled multiplier.
+  - **Deferred to R-34**: `dig.lab=` (auto-label significant digits) and
+    `ordered_result=` (an ordered factor result).
+
 ## [0.27.0] - 2026-06-21
 
 ### Added (via the shared `s-runtime`)

--- a/code/packages/rust/r-runtime/README.md
+++ b/code/packages/rust/r-runtime/README.md
@@ -212,9 +212,24 @@ sorted `breaks` and returns a real **factor**: `class(cut(...))` is `"factor"`,
 `nlevels()` all see through to it (`cut(c(1,5,10), breaks=c(0,3,6,11))` → a factor
 with levels `"(0,3]","(3,6]","(6,11]"` and values `(0,3]`,`(3,6]`,`(6,11]`); values
 outside all breaks → `NA`. Built on `findInterval`; allocations bounded by the
-already-capped input/breaks lengths; missing operands error gracefully. (`cut`'s
-`labels=`/`right=FALSE`/`include.lowest=` and integer `breaks` are deferred to
-R-33.)
+already-capped input/breaks lengths; missing operands error gracefully.
+
+**R-33 — `cut()` option completeness.** `cut` now takes the four options that were
+deferred from R-32. `labels=FALSE` returns the **integer bin codes** as a plain
+numeric vector (not a factor) — `cut(c(1,2,5), breaks=c(0,3,6), labels=FALSE)` →
+`c(1,1,2)`; a character `labels` vector becomes the factor levels and must match
+`length(breaks)-1` (else an error) — `cut(c(1,5,10), breaks=c(0,3,6,11),
+labels=c("lo","mid","hi"))`. `right=FALSE` switches to left-closed `[lo,hi)`
+intervals (labels `"[lo,hi)"`) — `cut(c(1,3), breaks=c(0,3,6), right=FALSE)` →
+`[0,3)`,`[3,6)`. `include.lowest=TRUE` folds the extreme break (the lowest for
+`right=TRUE`, the highest for `right=FALSE`) into the adjacent interval so it bins
+instead of going `NA`. A single-number `breaks` is the **equal-width** form: `N`
+bins over the range of `x`, extended by `dx/1000` on each side (`dx=max-min`;
+degenerate `dx=0` → `abs(min)`, then `1`) — `cut(0:10, breaks=5)` → 5 levels, every
+value binned. Security: `N` is capped at `MAX_SEQ_LEN` before any allocation, the
+breaks use finite/checked arithmetic (no divide-by-zero on a degenerate range), and
+the `labels` length check never panics. `dig.lab=` and `ordered_result=` are
+deferred to R-34.
 
 ## Usage
 

--- a/code/packages/rust/r-runtime/src/lib.rs
+++ b/code/packages/rust/r-runtime/src/lib.rs
@@ -2823,9 +2823,11 @@ mod tests {
         // Empty inputs yield empty results, not panics.
         assert_eq!(eval_r("findInterval(c(), c(1, 2))\n").unwrap().length(), 0);
         assert_eq!(eval_r("cut(c(), breaks = c(0, 1, 2))\n").unwrap().length(), 0);
-        // Fewer than two breaks means zero intervals: every value is NA.
+        // A single-element `breaks` is the equal-width-bin form (R-33): breaks = 5
+        // means 5 bins over the range of x, so both values get a non-NA code.
         let v = nums("as.integer(cut(c(1, 2), breaks = c(5)))\n");
-        assert!(v.iter().all(|x| x.is_nan()));
+        assert_eq!(v.len(), 2);
+        assert!(v.iter().all(|x| !x.is_nan()));
     }
 
     // --- R-33: cut() option completeness --------------------------------
@@ -2854,13 +2856,15 @@ mod tests {
 
     #[test]
     fn r33_cut_labels_false_returns_integer_codes() {
-        // labels=FALSE returns the plain integer bin codes c(1,1,2) — NOT a factor.
+        // labels=FALSE returns the plain integer bin codes — NOT a factor.
+        // 1,2 ∈ (0,3] (code 1); 5 ∈ (3,6] (code 2). (Right-closed: 3 itself would
+        // also be code 1, so we use 5 to demonstrate a second bin.)
         assert_eq!(
-            nums("cut(c(1, 2, 3), breaks = c(0, 3, 6), labels = FALSE)\n"),
+            nums("cut(c(1, 2, 5), breaks = c(0, 3, 6), labels = FALSE)\n"),
             vec![1.0, 1.0, 2.0]
         );
         assert_eq!(
-            show("class(cut(c(1, 2, 3), breaks = c(0, 3, 6), labels = FALSE))\n"),
+            show("class(cut(c(1, 2, 5), breaks = c(0, 3, 6), labels = FALSE))\n"),
             "[1] \"numeric\""
         );
     }

--- a/code/packages/rust/r-runtime/src/lib.rs
+++ b/code/packages/rust/r-runtime/src/lib.rs
@@ -2828,6 +2828,79 @@ mod tests {
         assert!(v.iter().all(|x| x.is_nan()));
     }
 
+    // --- R-33: cut() option completeness --------------------------------
+
+    #[test]
+    fn r33_cut_custom_labels_replace_interval_strings() {
+        // labels= supplies the level names verbatim (length must match #intervals).
+        assert_eq!(
+            names_of(
+                "levels(cut(c(1, 5, 10), breaks = c(0, 3, 6, 11), labels = c(\"lo\", \"mid\", \"hi\")))\n"
+            ),
+            vec!["lo", "mid", "hi"]
+        );
+        assert_eq!(
+            names_of(
+                "as.character(cut(c(1, 5, 10), breaks = c(0, 3, 6, 11), labels = c(\"lo\", \"mid\", \"hi\")))\n"
+            ),
+            vec!["lo", "mid", "hi"]
+        );
+        // A labels vector of the wrong length is an error, not a panic.
+        assert!(eval_r(
+            "cut(c(1, 5, 10), breaks = c(0, 3, 6, 11), labels = c(\"lo\", \"hi\"))\n"
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn r33_cut_labels_false_returns_integer_codes() {
+        // labels=FALSE returns the plain integer bin codes c(1,1,2) — NOT a factor.
+        assert_eq!(
+            nums("cut(c(1, 2, 3), breaks = c(0, 3, 6), labels = FALSE)\n"),
+            vec![1.0, 1.0, 2.0]
+        );
+        assert_eq!(
+            show("class(cut(c(1, 2, 3), breaks = c(0, 3, 6), labels = FALSE))\n"),
+            "[1] \"numeric\""
+        );
+    }
+
+    #[test]
+    fn r33_cut_right_false_is_left_closed() {
+        // right=FALSE → [lo,hi): 1 ∈ [0,3), 3 ∈ [3,6).
+        assert_eq!(
+            names_of("levels(cut(c(1, 3), breaks = c(0, 3, 6), right = FALSE))\n"),
+            vec!["[0,3)", "[3,6)"]
+        );
+        assert_eq!(
+            names_of("as.character(cut(c(1, 3), breaks = c(0, 3, 6), right = FALSE))\n"),
+            vec!["[0,3)", "[3,6)"]
+        );
+    }
+
+    #[test]
+    fn r33_cut_include_lowest_folds_boundary() {
+        // include.lowest=TRUE folds breaks[1] (0) into the first interval instead
+        // of leaving it NA.
+        let v = nums(
+            "as.integer(cut(c(0, 1, 2), breaks = c(0, 1, 2), include.lowest = TRUE))\n",
+        );
+        assert_eq!(v[0], 1.0); // 0 folded into (0,1]
+        assert!(!v[0].is_nan());
+    }
+
+    #[test]
+    fn r33_cut_integer_breaks_makes_n_bins() {
+        // cut(0:10, breaks=5): a factor with 5 levels covering the extended range,
+        // every value binned (non-NA).
+        assert_eq!(nums("nlevels(cut(0:10, breaks = 5))\n"), vec![5.0]);
+        let v = nums("as.integer(cut(0:10, breaks = 5))\n");
+        assert_eq!(v.len(), 11);
+        assert!(v.iter().all(|x| !x.is_nan()));
+        // A huge N is rejected (MAX_SEQ_LEN guard), not allocated.
+        assert!(eval_r("cut(0:10, breaks = 1e9)\n").is_err());
+    }
+
     #[test]
     fn r28_malformed_inputs_do_not_panic() {
         // outer with a non-callable FUN → clean error, no panic.

--- a/code/packages/rust/s-runtime/CHANGELOG.md
+++ b/code/packages/rust/s-runtime/CHANGELOG.md
@@ -2,6 +2,39 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.29.0] - 2026-06-21
+
+### Added
+
+- **`cut()` option completeness (R-33)** — the four options deferred from R-32,
+  available to both S and R through the shared tree-walker. All extend the R-32
+  `cut` handler in place (same interval scan, same `SValue::Factor` builder); no
+  new value type, no new cap.
+  - **`labels =`** — `labels = FALSE` returns the **integer bin codes** as a plain
+    numeric vector (no factor allocation). A character `labels` vector is used
+    verbatim as the levels and must have length `length(breaks) - 1` (else a clean
+    `BadArgs` error). Absent / `labels = TRUE` keeps the auto-generated interval
+    labels. `strip_wrappers` peels `Classed`/`Named`/`Attributed` so we can tell
+    `FALSE`/`TRUE` from a character vector.
+  - **`right = FALSE`** — left-closed `[lo, hi)` intervals (the index becomes
+    `#{breaks <= x}` rather than `#{breaks < x}`); auto-labels become `"[lo,hi)"`
+    via the new `cut_interval_label` helper. The default `right = TRUE` scan now
+    also honours the `(lo,hi]` boundary convention exactly (an `x` equal to an
+    interior break lands in the lower interval).
+  - **`include.lowest = TRUE`** — folds the single extreme boundary value (the
+    lowest break for `right = TRUE`, the highest for `right = FALSE`) into the
+    adjacent interval so it bins instead of going `NA`.
+  - **integer `breaks`** — a single number `N` requests `N` equal-width bins over
+    the range of `x`, extended by `dx/1000` each side (`dx = max - min`; degenerate
+    `dx == 0` falls back to `abs(min)`, then `1`) — see `equal_width_breaks`.
+  - The new `cut_code` helper centralises the per-value interval logic shared by the
+    factor and `labels = FALSE` paths.
+  - **Security**: `N` is capped at `MAX_SEQ_LEN` **before** any vector is built;
+    the equal-width breaks use finite/checked arithmetic (no divide-by-zero on a
+    degenerate range); the `labels` length check returns `Err`, never panics. No new
+    user-controlled multiplier.
+  - **Deferred to R-34**: `dig.lab=` and `ordered_result=`.
+
 ## [0.28.0] - 2026-06-21
 
 ### Added

--- a/code/packages/rust/s-runtime/README.md
+++ b/code/packages/rust/s-runtime/README.md
@@ -238,8 +238,21 @@ a hand-written loop. See [What "S-flavored" means here](#what-s-flavored-means-h
   (`cut(c(1,5,10), breaks=c(0,3,6,11))` → levels `"(0,3]","(3,6]","(6,11]"` with
   values `(0,3]`,`(3,6]`,`(6,11]`); values outside all breaks → `NA`. Built on
   `findInterval`; allocations bounded by the already-capped input/breaks lengths;
-  missing operands error gracefully. (`cut`'s `labels=`/`right=FALSE`/
-  `include.lowest=` and integer `breaks` are deferred to R-33.)
+  missing operands error gracefully.
+- **`cut()` option completeness** (R-33): the four options deferred from R-32, all
+  layered onto the same interval scan. `labels=FALSE` returns the **integer bin
+  codes** as a plain numeric vector (not a factor); a character `labels` vector
+  becomes the levels and must match `length(breaks)-1` (else an error); absent /
+  `TRUE` keeps the auto labels. `right=FALSE` gives left-closed `[lo,hi)` intervals
+  (`"[lo,hi)"` labels), and the default `right=TRUE` scan now honours the `(lo,hi]`
+  boundary convention exactly. `include.lowest=TRUE` folds the extreme break (lowest
+  for `right=TRUE`, highest for `right=FALSE`) into the adjacent interval. A
+  single-number `breaks` is the **equal-width** form: `N` bins over the range of `x`,
+  extended by `dx/1000` each side (`dx=max-min`; degenerate `dx=0` → `abs(min)`, then
+  `1`). `N` is capped at `MAX_SEQ_LEN` before any allocation and the breaks use
+  finite/checked arithmetic, so a huge `N` or a degenerate range is rejected/handled
+  rather than over-allocating or dividing by zero. (`dig.lab=` and `ordered_result=`
+  are deferred to R-34.)
 - The **`d`/`p`/`q`/`r` distribution family** (R-8) over `statistics-core`:
   density/CDF/quantile/sampling for the normal, uniform, and exponential
   distributions, plus `set.seed` for a reproducible per-session RNG.

--- a/code/packages/rust/s-runtime/src/builtins.rs
+++ b/code/packages/rust/s-runtime/src/builtins.rs
@@ -4412,6 +4412,90 @@ fn format_break(b: f64) -> String {
     }
 }
 
+/// Build the auto-generated interval label for the `i`-th interval (0-based) of
+/// `breaks`, respecting `right`: right-closed intervals print `"(lo,hi]"`,
+/// left-closed `[lo,hi)`. (R-33 — extends the R-32 right-closed-only formatter.)
+fn cut_interval_label(breaks: &[f64], i: usize, right: bool) -> String {
+    let lo = format_break(breaks[i]);
+    let hi = format_break(breaks[i + 1]);
+    if right {
+        format!("({lo},{hi}]")
+    } else {
+        format!("[{lo},{hi})")
+    }
+}
+
+/// Derive the `breaks` vector when `cut` is called with a **single number** `n`
+/// (the number of equal-width bins). Mirrors R's `cut.default`: take the range of
+/// the finite values of `x`, extend it by `dx/1000` on each side so the extreme
+/// data points sit strictly inside the outer bins, then lay down `n + 1` equally
+/// spaced breakpoints. Returns a `BadArgs`/`Index` error (never panics or
+/// allocates a giant vector) when `n` is non-finite, `< 1`, or would exceed
+/// `MAX_SEQ_LEN`, or when `x` has no finite values.
+///
+/// ```text
+///   rx = (min, max) over the finite x          dx = max - min
+///   if dx == 0: dx = |min|; if still 0: dx = 1   (degenerate all-equal x)
+///   lo = min - dx/1000      hi = max + dx/1000
+///   breaks[j] = lo + j * (hi - lo)/n   for j in 0..=n
+/// ```
+fn equal_width_breaks(x: &Double, n_f: f64) -> SResult<Vec<f64>> {
+    // `n` must be a finite, positive whole number. R rounds the requested bin
+    // count toward the nearest integer; we require it to be at least 1.
+    if !n_f.is_finite() || n_f < 1.0 {
+        return Err(SError::BadArgs(
+            "cut: invalid number of intervals".to_string(),
+        ));
+    }
+    // Guard the bin count BEFORE building any vector: a huge `n` would otherwise
+    // allocate `n + 1` breaks and `n` level strings. `MAX_SEQ_LEN` is the same cap
+    // every other length-amplifying builtin honours.
+    if n_f > MAX_SEQ_LEN as f64 {
+        return Err(SError::Index(format!(
+            "cut: number of intervals too large (limit {MAX_SEQ_LEN})"
+        )));
+    }
+    let n = n_f as usize;
+
+    // The range over the finite (non-NA, non-infinite) values of `x`.
+    let mut lo = f64::INFINITY;
+    let mut hi = f64::NEG_INFINITY;
+    for v in x.iter() {
+        if v.is_finite() {
+            lo = lo.min(v);
+            hi = hi.max(v);
+        }
+    }
+    if !lo.is_finite() || !hi.is_finite() {
+        return Err(SError::BadArgs(
+            "cut: 'x' has no finite values to bin".to_string(),
+        ));
+    }
+
+    // Extend the range by 0.1% on each side. A degenerate (all-equal) range has
+    // `dx == 0`; R falls back to `abs(min)`, then to `1`, so the bins stay finite
+    // and we never divide by zero when computing the step.
+    let mut dx = hi - lo;
+    if dx == 0.0 {
+        dx = lo.abs();
+        if dx == 0.0 {
+            dx = 1.0;
+        }
+    }
+    let pad = dx / 1000.0;
+    let lo = lo - pad;
+    let hi = hi + pad;
+
+    // `n + 1` equally spaced breakpoints. `n >= 1` so the step denominator is
+    // non-zero and finite (lo/hi are finite by construction).
+    let step = (hi - lo) / n as f64;
+    let mut breaks = Vec::with_capacity(n + 1);
+    for j in 0..=n {
+        breaks.push(lo + j as f64 * step);
+    }
+    Ok(breaks)
+}
+
 /// `cut(x, breaks)` — bin the numeric vector `x` into the intervals delimited by
 /// the **sorted** breakpoint vector `breaks`, returning a **factor**.
 ///
@@ -4432,44 +4516,187 @@ fn format_break(b: f64) -> String {
 /// The whole job reduces to `findInterval`: the interval index `i` is the 1-based
 /// factor code precisely when `1 <= i <= k-1`; the boundary indices `0` (below the
 /// first break) and `k` (at/above the last) — and any `NA` `x` — map to a `NA`
-/// code. `labels=`, `right=FALSE`, `include.lowest=`, and integer `breaks` are
-/// deferred to R-33.
+/// code.
+///
+/// **R-33 options** (all layered onto the same scan, none changing the default):
+///
+/// - **`right = FALSE`** — left-closed intervals `[lo, hi)`. Where the default
+///   counts breaks `<= x` (so `x == break` lands in the bin it *closes*), the
+///   left-closed scan counts breaks `< x` (so `x == break` lands in the bin it
+///   *opens*). We get this by negating each value (`-x` against `-breaks`,
+///   reversed) — but more simply, by adjusting the interval lookup below.
+/// - **`include.lowest = TRUE`** — fold the extreme break into the adjacent
+///   interval. Right-closed: an `x` equal to `breaks[0]` (which would otherwise be
+///   "below the first interval") is pulled into interval 1. Left-closed: an `x`
+///   equal to `breaks[k-1]` (otherwise "at/above the last") is pulled into the
+///   last interval.
+/// - **`labels = FALSE`** — return the **integer bin codes** as a plain numeric
+///   vector (not a factor). `labels = <character>` — use those strings as the
+///   factor levels (length must equal the number of intervals).
+/// - **integer `breaks`** — a single number `N` requests `N` equal-width bins over
+///   the (slightly extended) range of `x` (see [`equal_width_breaks`]).
 fn b_cut(_interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
     let x = first_positional(args)?.as_double()?;
-    let breaks: Vec<f64> = second_arg(args, "breaks", "cut")?
-        .as_double()?
-        .iter()
-        .collect();
+
+    // `right` (default TRUE) and `include.lowest` (default FALSE) are read as
+    // logical flags; a malformed value is a clean error via `truthy`.
+    let right = named_flag(args, "right", true)?;
+    let include_lowest = named_flag(args, "include.lowest", false)?;
+
+    // `breaks` may be the usual breakpoint vector OR a single number `N` (number
+    // of equal-width bins). R treats `length(breaks) == 1` as the bin-count form.
+    let breaks_val = second_arg(args, "breaks", "cut")?;
+    let breaks_double = breaks_val.as_double()?;
+    let breaks: Vec<f64> = if breaks_double.len() == 1 {
+        // Single number → derive equal-width breakpoints over the range of `x`.
+        // (Honours the MAX_SEQ_LEN cap and degenerate-range fallback internally.)
+        let n = breaks_double.get_value(0).unwrap_or(na_real());
+        equal_width_breaks(&x, n)?
+    } else {
+        breaks_double.iter().collect()
+    };
 
     // `k - 1` intervals; with fewer than two breaks there are none, so every
     // value is unbinned (NA). `saturating_sub` keeps this from underflowing.
     let n_intervals = breaks.len().saturating_sub(1);
 
-    // The level labels are "(lo,hi]" for each adjacent break pair.
-    let levels: Vec<String> = (0..n_intervals)
-        .map(|i| {
-            format!(
-                "({},{}]",
-                format_break(breaks[i]),
-                format_break(breaks[i + 1])
-            )
-        })
-        .collect();
-
-    // Each value's 1-based interval index (via the shared kernel, binary-searching
-    // the leading non-NA run of `breaks`) is its factor code when it lands in
-    // `1..=n_intervals`; otherwise (below the first break, at/above the last, or
-    // NA) the code is `None` → a `<NA>` factor element.
+    // Each value's 1-based interval code (or `None` for out-of-range / NA).
     let prefix = &breaks[..break_prefix_len(&breaks)];
     let codes: Vec<Option<u32>> = x
         .iter()
-        .map(|xi| match find_interval_index(xi, prefix) {
-            Some(i) if i >= 1 && i <= n_intervals => Some(i as u32),
-            _ => None,
-        })
+        .map(|xi| cut_code(xi, prefix, &breaks, n_intervals, right, include_lowest))
         .collect();
 
+    // `labels = FALSE` short-circuits to the bare integer codes — no factor.
+    if let Some(arg) = args.iter().find(|a| a.name.as_deref() == Some("labels")) {
+        if let SValue::Logical(v) = strip_wrappers(&arg.value) {
+            if matches!(v.first(), Some(Some(false))) {
+                let out: Vec<f64> = codes
+                    .iter()
+                    .map(|c| c.map(|k| k as f64).unwrap_or_else(na_real))
+                    .collect();
+                return Ok(SValue::doubles(out));
+            }
+        }
+    }
+
+    // Otherwise build the factor levels: custom `labels` (validated length) or the
+    // auto-generated interval strings (respecting `right`).
+    let levels = cut_levels(args, &breaks, n_intervals, right)?;
+
     Ok(SValue::Factor { codes, levels })
+}
+
+/// The 1-based factor code for a single value under `cut`'s interval rules, or
+/// `None` (→ `<NA>`) when the value falls in no interval. Centralises the
+/// `right` / `include.lowest` logic shared by the factor and `labels=FALSE`
+/// paths.
+fn cut_code(
+    xi: f64,
+    prefix: &[f64],
+    breaks: &[f64],
+    n_intervals: usize,
+    right: bool,
+    include_lowest: bool,
+) -> Option<u32> {
+    if n_intervals == 0 || is_na_real(xi) || !xi.is_finite() {
+        return None;
+    }
+    // The 1-based interval index is a count of breakpoints below `xi`, with the
+    // comparison decided by which end is closed:
+    //
+    //   right = TRUE   (lo, hi]  →  interval i contains `breaks[i-1] < x <= breaks[i]`
+    //                              →  index = #{breaks strictly < x}
+    //   right = FALSE  [lo, hi)  →  interval i contains `breaks[i-1] <= x < breaks[i]`
+    //                              →  index = #{breaks <= x}
+    //
+    // (Both are `partition_point` binary searches over the sorted non-NA prefix.)
+    // For an `x` exactly on an *interior* break the two rules disagree by one,
+    // which is precisely the `(lo,hi]` vs `[lo,hi)` boundary convention.
+    let idx = if right {
+        prefix.partition_point(|&b| b < xi)
+    } else {
+        prefix.partition_point(|&b| b <= xi)
+    };
+
+    if idx >= 1 && idx <= n_intervals {
+        return Some(idx as u32);
+    }
+
+    // `include.lowest`: fold the single extreme boundary value into the adjacent
+    // interval (the only point that the strict end-convention leaves unbinned).
+    if include_lowest {
+        if right {
+            // Right-closed: `x == breaks[0]` gives index 0 (below the first
+            // interval) — pull it into interval 1, making the first bin `[lo,hi]`.
+            if xi == breaks[0] {
+                return Some(1);
+            }
+        } else {
+            // Left-closed: `x == breaks[k]` gives index k = n_intervals + 1 (at/above
+            // the last) — pull it into the last interval, making it `[lo,hi]`.
+            if xi == breaks[n_intervals] {
+                return Some(n_intervals as u32);
+            }
+        }
+    }
+    None
+}
+
+/// Build the factor levels for `cut`: a custom `labels = <character>` vector
+/// (whose length must equal `n_intervals`) when supplied, otherwise the
+/// auto-generated `"(lo,hi]"` / `"[lo,hi)"` interval strings.
+fn cut_levels(
+    args: &[Arg],
+    breaks: &[f64],
+    n_intervals: usize,
+    right: bool,
+) -> SResult<Vec<String>> {
+    if let Some(arg) = args.iter().find(|a| a.name.as_deref() == Some("labels")) {
+        let stripped = strip_wrappers(&arg.value);
+        // `labels = TRUE` (or absent) means "use the auto labels"; only a non-
+        // logical value is taken as a custom label vector. `labels = FALSE` is
+        // handled by the caller before we ever get here.
+        let is_logical_flag = matches!(stripped, SValue::Logical(_));
+        if !is_logical_flag && !matches!(stripped, SValue::Null) {
+            let labels: Vec<String> = arg
+                .value
+                .as_character()
+                .into_iter()
+                .map(|o| o.unwrap_or_else(|| "NA".to_string()))
+                .collect();
+            if labels.len() != n_intervals {
+                return Err(SError::BadArgs(
+                    "lengths of 'breaks' and 'labels' differ".to_string(),
+                ));
+            }
+            return Ok(labels);
+        }
+    }
+    Ok((0..n_intervals)
+        .map(|i| cut_interval_label(breaks, i, right))
+        .collect())
+}
+
+/// Read a named logical flag (`right`, `include.lowest`) with a default. A
+/// malformed value surfaces as a clean error via `truthy` rather than a panic.
+fn named_flag(args: &[Arg], name: &str, default: bool) -> SResult<bool> {
+    match args.iter().find(|a| a.name.as_deref() == Some(name)) {
+        Some(arg) => arg.value.truthy(),
+        None => Ok(default),
+    }
+}
+
+/// Peel `Classed` / `Named` / `Attributed` wrappers off a value so we can inspect
+/// its underlying variant (used to tell `labels = FALSE`/`TRUE` from a character
+/// label vector).
+fn strip_wrappers(v: &SValue) -> &SValue {
+    match v {
+        SValue::Classed { inner, .. }
+        | SValue::Named { values: inner, .. }
+        | SValue::Attributed { inner, .. } => strip_wrappers(inner),
+        other => other,
+    }
 }
 
 fn builtin(name: &str, func: fn(&Interpreter, &[Arg]) -> SResult<SValue>) -> SValue {

--- a/code/packages/rust/s-runtime/src/builtins.rs
+++ b/code/packages/rust/s-runtime/src/builtins.rs
@@ -4520,11 +4520,10 @@ fn equal_width_breaks(x: &Double, n_f: f64) -> SResult<Vec<f64>> {
 ///
 /// **R-33 options** (all layered onto the same scan, none changing the default):
 ///
-/// - **`right = FALSE`** — left-closed intervals `[lo, hi)`. Where the default
-///   counts breaks `<= x` (so `x == break` lands in the bin it *closes*), the
-///   left-closed scan counts breaks `< x` (so `x == break` lands in the bin it
-///   *opens*). We get this by negating each value (`-x` against `-breaks`,
-///   reversed) — but more simply, by adjusting the interval lookup below.
+/// - **`right = FALSE`** — left-closed intervals `[lo, hi)`. The default
+///   right-closed `(lo, hi]` lookup counts breaks strictly `< x` (so `x == break`
+///   lands in the bin it *closes*); the left-closed lookup counts breaks `<= x`
+///   (so `x == break` lands in the bin it *opens*). See [`cut_code`].
 /// - **`include.lowest = TRUE`** — fold the extreme break into the adjacent
 ///   interval. Right-closed: an `x` equal to `breaks[0]` (which would otherwise be
 ///   "below the first interval") is pulled into interval 1. Left-closed: an `x`

--- a/code/packages/rust/s-runtime/src/builtins.rs
+++ b/code/packages/rust/s-runtime/src/builtins.rs
@@ -4487,8 +4487,17 @@ fn equal_width_breaks(x: &Double, n_f: f64) -> SResult<Vec<f64>> {
     let hi = hi + pad;
 
     // `n + 1` equally spaced breakpoints. `n >= 1` so the step denominator is
-    // non-zero and finite (lo/hi are finite by construction).
+    // non-zero and finite. Extreme-magnitude `x` can still overflow the extended
+    // range to `±inf` (e.g. `dx = hi - lo` overflowing), which would make the
+    // breaks `NaN`/`inf`; reject that up front so every emitted break is finite
+    // (no garbage `"(NaN,NaN]"` levels, and the downstream scan only ever sees
+    // sorted finite breaks).
     let step = (hi - lo) / n as f64;
+    if !lo.is_finite() || !hi.is_finite() || !step.is_finite() {
+        return Err(SError::BadArgs(
+            "cut: range of 'x' is too large to bin".to_string(),
+        ));
+    }
     let mut breaks = Vec::with_capacity(n + 1);
     for j in 0..=n {
         breaks.push(lo + j as f64 * step);

--- a/code/packages/rust/s-runtime/src/lib.rs
+++ b/code/packages/rust/s-runtime/src/lib.rs
@@ -2241,3 +2241,167 @@ mod r30_ordering {
         );
     }
 }
+
+#[cfg(test)]
+mod r33_cut_options {
+    //! R-33 — `cut()` option completeness (exercised through **S** syntax; the
+    //! shared tree-walker is language-neutral so R inherits identical behaviour).
+    //! Covers `labels=` (custom + `FALSE`), `right=FALSE`, `include.lowest=`, and
+    //! integer `breaks` (N equal-width bins over the extended range of `x`).
+    use super::*;
+
+    /// The factor codes recovered via `as.integer` (NaN for `<NA>`).
+    fn codes(src: &str) -> Vec<f64> {
+        match eval_s(src).unwrap().strip_names() {
+            SValue::Double(d) => d.data().to_vec(),
+            other => panic!("expected double, got {}", other.type_name()),
+        }
+    }
+
+    /// The character elements of a (possibly classed) result.
+    fn strs(src: &str) -> Vec<String> {
+        eval_s(src)
+            .unwrap()
+            .as_character()
+            .into_iter()
+            .map(|o| o.unwrap_or_else(|| "NA".to_string()))
+            .collect()
+    }
+
+    // --- labels= (custom character vector) ------------------------------
+
+    #[test]
+    fn labels_custom_replaces_auto_interval_strings() {
+        // labels= supplies the level names verbatim; the binning is unchanged.
+        assert_eq!(
+            strs("levels(cut(c(1, 5, 10), breaks = c(0, 3, 6, 11), labels = c(\"lo\", \"mid\", \"hi\")))\n"),
+            vec!["lo", "mid", "hi"]
+        );
+        assert_eq!(
+            strs("as.character(cut(c(1, 5, 10), breaks = c(0, 3, 6, 11), labels = c(\"lo\", \"mid\", \"hi\")))\n"),
+            vec!["lo", "mid", "hi"]
+        );
+        // It is still a real factor.
+        assert_eq!(
+            strs("class(cut(c(1, 5, 10), breaks = c(0, 3, 6, 11), labels = c(\"lo\", \"mid\", \"hi\")))\n"),
+            vec!["factor"]
+        );
+    }
+
+    #[test]
+    fn labels_wrong_length_is_a_graceful_error() {
+        // length(labels) must equal length(breaks)-1 (= 3 here); 2 is an error.
+        assert!(eval_s(
+            "cut(c(1, 5, 10), breaks = c(0, 3, 6, 11), labels = c(\"lo\", \"hi\"))\n"
+        )
+        .is_err());
+    }
+
+    // --- labels = FALSE (integer codes, NOT a factor) -------------------
+
+    #[test]
+    fn labels_false_returns_integer_codes_not_a_factor() {
+        // labels=FALSE yields the plain integer bin codes c(1,1,2).
+        assert_eq!(
+            codes("cut(c(1, 2, 3), breaks = c(0, 3, 6), labels = FALSE)\n"),
+            vec![1.0, 1.0, 2.0]
+        );
+        // The result is a bare numeric vector — class() is "numeric", not "factor".
+        assert_eq!(
+            strs("class(cut(c(1, 2, 3), breaks = c(0, 3, 6), labels = FALSE))\n"),
+            vec!["numeric"]
+        );
+    }
+
+    #[test]
+    fn labels_false_out_of_range_is_na() {
+        // Values outside the breaks still become NA codes under labels=FALSE.
+        let v = codes("cut(c(-1, 20), breaks = c(0, 3, 6, 11), labels = FALSE)\n");
+        assert!(v[0].is_nan());
+        assert!(v[1].is_nan());
+    }
+
+    // --- right = FALSE (left-closed [lo,hi)) ----------------------------
+
+    #[test]
+    fn right_false_uses_left_closed_intervals_and_labels() {
+        // 1 ∈ [0,3), 3 ∈ [3,6): a left-closed value lands in the bin it opens.
+        assert_eq!(
+            strs("levels(cut(c(1, 3), breaks = c(0, 3, 6), right = FALSE))\n"),
+            vec!["[0,3)", "[3,6)"]
+        );
+        assert_eq!(
+            strs("as.character(cut(c(1, 3), breaks = c(0, 3, 6), right = FALSE))\n"),
+            vec!["[0,3)", "[3,6)"]
+        );
+    }
+
+    #[test]
+    fn right_false_boundary_goes_up_not_down() {
+        // Contrast with the default: under right=TRUE, 3 ∈ (0,3] (bin 1); under
+        // right=FALSE, 3 ∈ [3,6) (bin 2).
+        assert_eq!(
+            codes("as.integer(cut(c(3), breaks = c(0, 3, 6)))\n"),
+            vec![1.0]
+        );
+        assert_eq!(
+            codes("as.integer(cut(c(3), breaks = c(0, 3, 6), right = FALSE))\n"),
+            vec![2.0]
+        );
+    }
+
+    // --- include.lowest = TRUE ------------------------------------------
+
+    #[test]
+    fn include_lowest_folds_the_lowest_break_into_the_first_interval() {
+        // Without include.lowest, x == breaks[1] (here 0) is below (0,1] → NA.
+        let plain = codes("as.integer(cut(c(0, 1, 2), breaks = c(0, 1, 2)))\n");
+        assert!(plain[0].is_nan());
+        // With include.lowest=TRUE, 0 lands in the first interval (code 1).
+        let inc = codes(
+            "as.integer(cut(c(0, 1, 2), breaks = c(0, 1, 2), include.lowest = TRUE))\n",
+        );
+        assert_eq!(inc[0], 1.0);
+        assert_eq!(inc[1], 1.0); // 1 ∈ (0,1]
+        assert_eq!(inc[2], 2.0); // 2 ∈ (1,2]
+    }
+
+    #[test]
+    fn include_lowest_with_right_false_folds_the_highest_break() {
+        // right=FALSE makes the last bin [hi-1,hi); include.lowest folds breaks[k]
+        // (here 2) into it instead of NA.
+        let v = codes(
+            "as.integer(cut(c(0, 2), breaks = c(0, 1, 2), right = FALSE, include.lowest = TRUE))\n",
+        );
+        assert_eq!(v[0], 1.0); // 0 ∈ [0,1)
+        assert_eq!(v[1], 2.0); // 2 folded into [1,2]
+    }
+
+    // --- integer breaks (N equal-width bins) ----------------------------
+
+    #[test]
+    fn integer_breaks_makes_n_equal_width_bins() {
+        // cut(0:10, breaks=5): 5 levels spanning the slightly-extended 0..10 range.
+        assert_eq!(codes("nlevels(cut(0:10, breaks = 5))\n"), vec![5.0]);
+        // Every one of the 11 values gets a non-NA bin (the range extension puts
+        // the endpoints strictly inside the outer bins).
+        let v = codes("as.integer(cut(0:10, breaks = 5))\n");
+        assert_eq!(v.len(), 11);
+        assert!(v.iter().all(|x| !x.is_nan()));
+    }
+
+    #[test]
+    fn integer_breaks_degenerate_all_equal_does_not_divide_by_zero() {
+        // All-equal x has dx==0; the abs(min)/1 fallback keeps the bins finite and
+        // every value still lands in a non-NA bin (no panic, no NaN break).
+        let v = codes("as.integer(cut(c(5, 5, 5), breaks = 3))\n");
+        assert_eq!(v.len(), 3);
+        assert!(v.iter().all(|x| !x.is_nan()));
+    }
+
+    #[test]
+    fn integer_breaks_huge_n_is_rejected_not_allocated() {
+        // A huge N must error (MAX_SEQ_LEN guard), not attempt a giant allocation.
+        assert!(eval_s("cut(0:10, breaks = 1e9)\n").is_err());
+    }
+}

--- a/code/packages/rust/s-runtime/src/lib.rs
+++ b/code/packages/rust/s-runtime/src/lib.rs
@@ -2301,14 +2301,15 @@ mod r33_cut_options {
 
     #[test]
     fn labels_false_returns_integer_codes_not_a_factor() {
-        // labels=FALSE yields the plain integer bin codes c(1,1,2).
+        // labels=FALSE yields the plain integer bin codes. 1,2 ∈ (0,3] (code 1);
+        // 5 ∈ (3,6] (code 2). (Right-closed, so 3 itself is code 1; use 5 here.)
         assert_eq!(
-            codes("cut(c(1, 2, 3), breaks = c(0, 3, 6), labels = FALSE)\n"),
+            codes("cut(c(1, 2, 5), breaks = c(0, 3, 6), labels = FALSE)\n"),
             vec![1.0, 1.0, 2.0]
         );
         // The result is a bare numeric vector — class() is "numeric", not "factor".
         assert_eq!(
-            strs("class(cut(c(1, 2, 3), breaks = c(0, 3, 6), labels = FALSE))\n"),
+            strs("class(cut(c(1, 2, 5), breaks = c(0, 3, 6), labels = FALSE))\n"),
             vec!["numeric"]
         );
     }

--- a/code/packages/rust/s-runtime/src/lib.rs
+++ b/code/packages/rust/s-runtime/src/lib.rs
@@ -2405,4 +2405,11 @@ mod r33_cut_options {
         // A huge N must error (MAX_SEQ_LEN guard), not attempt a giant allocation.
         assert!(eval_s("cut(0:10, breaks = 1e9)\n").is_err());
     }
+
+    #[test]
+    fn integer_breaks_extreme_range_is_rejected_not_nan() {
+        // An x range so wide that the extended range overflows to ±inf is a clean
+        // error rather than NaN/inf breaks (no garbage levels, no panic).
+        assert!(eval_s("cut(c(-1.8e308, 1.8e308), breaks = 5)\n").is_err());
+    }
 }

--- a/code/specs/R00-r-language.md
+++ b/code/specs/R00-r-language.md
@@ -1123,12 +1123,65 @@ unchanged.
     when absent.
   - **Scope outcome / deferred to R-33.** `findInterval`, `tabulate`, and `cut`
     (default right-closed `(lo,hi]` intervals with auto-generated labels) ship
-    **solidly**. **Deferred to R-33:** `cut`'s `labels =` (custom level labels),
-    `right = FALSE` (left-closed `[lo,hi)` intervals), `include.lowest =` (fold the
-    extreme endpoint into the adjacent interval), and `breaks` given as a single
-    integer (number of equal-width bins). These are pure extensions of the same
-    `findInterval`-backed core. The `%o%` infix alias for `outer` remains open for a
-    later grammar pass.
+    **solidly** in R-32.
+
+- **R-33 — `cut()` option completeness** *(this PR)*. Extends the R-32 `cut`
+  handler in place (same `findInterval`-backed kernel, same factor builder) with
+  the four deferred options. None of them change the default behaviour; they are
+  pure refinements layered onto the existing interval scan.
+  - **`labels =`** — three forms:
+    - **absent / `labels = TRUE`** — the auto-generated interval strings (the
+      R-32 default), `"(lo,hi]"` (or `"[lo,hi)"` when `right = FALSE`).
+    - **a character vector** — used verbatim as the factor levels. Its length
+      **must equal the number of intervals** (`length(breaks) - 1`); otherwise
+      `cut` raises an error (`"lengths of 'breaks' and 'labels' differ"`).
+      `cut(c(1,5,10), breaks=c(0,3,6,11), labels=c("lo","mid","hi"))` → a factor
+      with levels `c("lo","mid","hi")`.
+    - **`labels = FALSE`** — return the **integer bin codes** (a plain numeric
+      vector, *not* a factor). Out-of-range / `NA` values become `NA`.
+      `cut(c(1,2,3), breaks=c(0,3,6), labels=FALSE)` → `c(1,1,2)`.
+  - **`right = FALSE`** — left-closed intervals `[lo, hi)` rather than the
+    default right-closed `(lo, hi]`. The bin scan switches from "largest break
+    `<= x`" to "number of breaks `< x`", and the auto-labels become `"[lo,hi)"`.
+    `cut(c(1,3), breaks=c(0,3,6), right=FALSE)` → `1 ∈ "[0,3)"`, `3 ∈ "[3,6)"`.
+  - **`include.lowest = TRUE`** — include the extreme boundary value in the
+    closest interval. With `right = TRUE` (default) the **lowest** break is folded
+    into the first interval (so `x == breaks[1]` lands in interval 1 instead of
+    `NA`); with `right = FALSE` the **highest** break is folded into the last
+    interval (so `x == breaks[k]` lands in interval `k-1`). Default `FALSE`.
+    `cut(c(0,1,2), breaks=c(0,1,2), include.lowest=TRUE)` → `0` lands in the first
+    interval rather than `NA`.
+  - **integer `breaks` (a single number `N`)** — divide the **range of `x`** into
+    `N` equal-width intervals. R's `cut.default` extends the range by 0.1 % on each
+    side so the extreme data points sit strictly inside the outer bins; we
+    replicate that exactly:
+    ```text
+      rx = range(x, na.rm = TRUE)         # = (min, max) over finite x
+      dx = rx.max - rx.min
+      if dx == 0:                          # degenerate (all x equal)
+          dx = abs(rx.min)                 # R: abs(rx[1L]); if still 0, dx = 1
+          if dx == 0: dx = 1
+      lo = rx.min - dx/1000
+      hi = rx.max + dx/1000
+      breaks = N+1 equally spaced points from lo to hi   # N equal-width bins
+    ```
+    `N` is bounded by `MAX_SEQ_LEN` (a huge `N` → huge levels vector is rejected,
+    not allocated) and the spacing is computed with checked/finite arithmetic so a
+    degenerate range never divides by zero. `cut(0:10, breaks=5)` → a factor with
+    5 levels spanning the slightly-extended `0..10` range; every value gets a
+    non-`NA` bin.
+  - **Security.** `N` for integer breaks is capped at `MAX_SEQ_LEN` before any
+    allocation; the equal-width break vector is built with finite/checked
+    arithmetic (degenerate all-equal `x` is handled without divide-by-zero);
+    `labels` length validation returns a clean `Err` (never panics); `labels =
+    FALSE` returns a numeric vector with no factor allocation. No new
+    user-controlled multiplier beyond the existing `MAX_SEQ_LEN`-bounded input and
+    break lengths.
+  - **Scope outcome / deferred to R-34.** `labels =` (incl. `FALSE`),
+    `right = FALSE`, `include.lowest =`, and integer `breaks` ship **solidly**.
+    **Deferred to R-34:** `dig.lab =` (significant-digit control of auto-label
+    formatting) and `ordered_result =` (an ordered factor result). The `%o%` infix
+    alias for `outer` remains open for a later grammar pass.
 
 ## §4 Reuse strategy
 

--- a/code/specs/S00-s-language.md
+++ b/code/specs/S00-s-language.md
@@ -501,9 +501,26 @@ essential: `switch("a", a = stop("no"), b = "ok")` must not raise, and a
      `levels` are the auto-generated `"(lo,hi]"` labels; values outside all intervals
      (or `NA`) get a `NA` code. Built directly on `findInterval` (the interval index
      is the level code), so `levels()`/`as.integer()`/`as.character()`/`table()` all
-     work on the result. `labels=`, `right=FALSE`, `include.lowest=`, and integer
-     `breaks` are **deferred to R-33**. The existing `tabulate(bin, nbins)` (R-28)
+     work on the result. The existing `tabulate(bin, nbins)` (R-28)
      rounds out the family (its `nbins` stays capped at `MAX_SEQ_LEN`).
+8. **`cut()` option completeness (R-33, shared builtin).** The R-32 `cut` handler
+   gains four options, all layered onto the same `find_interval_index` kernel and
+   factor builder:
+   - **`labels =`** — `labels = FALSE` returns the **integer bin codes** (a plain
+     numeric vector, not a factor); a character vector of length `length(breaks)-1`
+     is used verbatim as the levels (a length mismatch is a clean error); absent /
+     `TRUE` keeps the auto-generated interval labels.
+   - **`right = FALSE`** — left-closed `[lo,hi)` intervals (the scan counts breaks
+     strictly `< x` instead of `<= x`); auto-labels become `"[lo,hi)"`.
+   - **`include.lowest = TRUE`** — folds the extreme boundary (the lowest break for
+     `right = TRUE`, the highest for `right = FALSE`) into the adjacent interval so
+     `x == breaks[1]` (resp. `breaks[k]`) bins instead of going `NA`.
+   - **integer `breaks` (a single number `N`)** — `N` equal-width bins over the
+     range of `x`, with the range extended by `dx/1000` on each side
+     (`dx = max-min`, degenerate `dx == 0` falling back to `abs(min)` then `1`).
+     `N` is capped at `MAX_SEQ_LEN` before the break vector is built; the spacing
+     uses finite/checked arithmetic so a degenerate range never divides by zero.
+   `dig.lab=` and `ordered_result=` are **deferred to R-34**.
 
 ## §10 References
 


### PR DESCRIPTION
## R-33 — `cut()` option completeness

Extends the R-32 `cut` handler (shared `s-runtime/src/builtins.rs`, reused by R through the language-neutral tree-walker) with the four options deferred from R-32. All four layer onto the same interval scan and factor builder — no new value type, no grammar change.

### Additions

- **`labels =`**
  - `labels = FALSE` returns the **integer bin codes** as a plain numeric vector (NOT a factor): `cut(c(1,2,5), breaks=c(0,3,6), labels=FALSE)` → `c(1,1,2)`, `class(...)` is `"numeric"`.
  - a character `labels` vector is used verbatim as the factor levels and must have length `length(breaks)-1` (else a clean error, `lengths of 'breaks' and 'labels' differ`): `cut(c(1,5,10), breaks=c(0,3,6,11), labels=c("lo","mid","hi"))`.
  - absent / `labels = TRUE` keeps the auto-generated interval labels.
- **`right = FALSE`** — left-closed `[lo,hi)` intervals (labels `"[lo,hi)"`): `cut(c(1,3), breaks=c(0,3,6), right=FALSE)` → `1 ∈ [0,3)`, `3 ∈ [3,6)`. The default `right = TRUE` scan now also honours the `(lo,hi]` boundary convention exactly (an `x` equal to an interior break lands in the lower interval).
- **`include.lowest = TRUE`** — folds the extreme break (the lowest for `right=TRUE`, the highest for `right=FALSE`) into the adjacent interval so it bins instead of going `NA`: `cut(c(0,1,2), breaks=c(0,1,2), include.lowest=TRUE)` → `0` lands in the first interval.
- **integer `breaks`** — a single number `N` requests `N` equal-width bins over the range of `x`. `cut(0:10, breaks=5)` → 5 levels, every value binned.

### Integer-breaks range-extension formula

Mirrors R's `cut.default`:

```
rx = range(x, na.rm = TRUE)          # (min, max) over finite x
dx = rx.max - rx.min
if dx == 0:  dx = abs(rx.min);  if still 0:  dx = 1   # degenerate all-equal x
lo = rx.min - dx/1000
hi = rx.max + dx/1000
breaks = N+1 equally spaced points from lo to hi      # N equal-width bins
```

(Note: `cut(x, breaks = c(5))` is now this equal-width form, matching base R, rather than the old R-32 "fewer than two breaks → all NA". One pre-existing test was updated accordingly.)

### Security

- `N` is capped at `MAX_SEQ_LEN` (and `inf`/`NaN`/`<1` rejected) **before** any break/level vector is allocated.
- The equal-width breaks use finite/checked arithmetic — a degenerate all-equal range never divides by zero, and an extreme-magnitude range that would overflow to `±inf` is rejected (`cut: range of 'x' is too large to bin`) so every emitted break is finite.
- The `labels` length check returns a clean `Err`, never panics; `labels = FALSE` allocates no factor.
- Security review by a Rust sub-agent: no CRITICAL/HIGH/MEDIUM findings; the one LOW (non-finite breaks) was fixed in this PR.

### Tests

s-runtime `r33_cut_options` module + r-runtime R-syntax integration tests cover: custom labels, `labels=FALSE` integer codes (class `"numeric"`), wrong-length-labels error, left-closed `[lo,hi)` labels + boundary direction, `include.lowest` folding (both `right` modes), integer breaks (N bins, degenerate all-equal x, huge-N rejection, extreme-range rejection). Full suites green: **s-runtime 253**, **r-runtime 249**.

### Deferred to R-34

`dig.lab=` (auto-label significant digits) and `ordered_result=` (ordered factor result).

🤖 Generated with [Claude Code](https://claude.com/claude-code)