### PR TITLE
feat(mycin-immuno): celiac→HLA-DQ2 + type III hypersensitivity→immune complexes

### DIFF
--- a/code/specs/data/mycin-2026/recall/immuno-edges.adj
+++ b/code/specs/data/mycin-2026/recall/immuno-edges.adj
@@ -73,4 +73,16 @@ rulebook immuno_facts {
         source "Approximately 90% of DiGeorge syndrome cases result from a microdeletion on the long arm of chromosome 22 at the 11.2 locus, typically involving a 3-megabase region between low copy repeats LCR22A and LCR22D."
         locator "https://www.ncbi.nlm.nih.gov/books/NBK549798/"
         trust authoritative
+
+    % --- EXPAND: celiac disease ~ HLA-DQ2 (HLA association) ---------------------
+    relate associated_hla(celiac_disease, hla_dq2)
+        source "The primary genetic predisposition is associated with specific human leukocyte antigen (HLA) class II genes, particularly HLA-DQ2 and HLA-DQ8, which are found in nearly all individuals with celiac disease."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK441900/"
+        trust authoritative
+
+    % --- EXPAND: type III hypersensitivity is immune-complex-mediated -----------
+    relate mediated_by(type_iii_hypersensitivity, immune_complexes)
+        source "Type III or immune complex-mediated hypersensitivity: Circulating antigen-antibody complexes deposit in tissues, activating complement and recruiting neutrophils, leading to inflammation and tissue injury, causing conditions such as serum sickness, systemic lupus erythematosus (SLE), post-streptococcal glomerulonephritis (PSGN), and hypersensitivity vasculitides such as IgA vasculitis or cryoglobulinemia."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK559122/"
+        trust authoritative
 }

--- a/code/specs/data/mycin-2026/recall/immuno-recall.query.adj
+++ b/code/specs/data/mycin-2026/recall/immuno-recall.query.adj
@@ -20,3 +20,5 @@ import "immuno-edges.adj"
 ? deficiency_of(chronic_granulomatous_disease, $Component) % expect nadph_oxidase
 ? deficiency_of(digeorge_syndrome, $Component)             % expect t_cells
 ? gene_defect(digeorge_syndrome, $Gene)                    % expect chromosome_22q11_2_deletion
+? associated_hla(celiac_disease, $HLA)                 % expect hla_dq2 (expand)
+? mediated_by(type_iii_hypersensitivity, $Mediator)    % expect immune_complexes (expand)

--- a/code/specs/data/mycin-2026/recall/test_immuno_recall.py
+++ b/code/specs/data/mycin-2026/recall/test_immuno_recall.py
@@ -37,6 +37,8 @@ EXPECTED = [
     ("chronic_granulomatous_disease", "deficiency_of", "nadph_oxidase"),
     ("digeorge_syndrome", "deficiency_of", "t_cells"),
     ("digeorge_syndrome", "gene_defect", "chromosome_22q11_2_deletion"),
+    ("celiac_disease", "associated_hla", "hla_dq2"),                 # expand (NBK441900)
+    ("type_iii_hypersensitivity", "mediated_by", "immune_complexes"),  # expand (NBK559122)
 ]
 VAR = {"mediated_by": "Mediator", "associated_hla": "HLA",
        "gene_defect": "Gene", "deficiency_of": "Component"}


### PR DESCRIPTION
## What

Two high-yield immunology recall edges, each from a clean StatPearls both-endpoints span:

- **associated_hla(celiac_disease, hla_dq2)** — NBK441900:
  > The primary genetic predisposition is associated with specific human leukocyte antigen (HLA) class II genes, particularly HLA-DQ2 and HLA-DQ8, which are found in nearly all individuals with celiac disease.
- **mediated_by(type_iii_hypersensitivity, immune_complexes)** — NBK559122 (completes the hypersensitivity set alongside the existing type I→IgE and type IV→T-cells):
  > Type III or immune complex-mediated hypersensitivity: Circulating antigen-antibody complexes deposit in tissues, activating complement and recruiting neutrophils…

## Changes (data-only)
- `immuno-edges.adj` +2 `relate`; `immuno-recall.query.adj` +2; `test_immuno_recall.py` EXPECTED +2 (`rheumatoid_arthritis` negative control unchanged)

## Verification
- `test_immuno_recall: 3/3 passed`; ruff clean; data-only security review passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)