### PR TITLE
feat(r-lang): R-36 — crossprod & tcrossprod (matrix cross products)

### DIFF
--- a/code/packages/rust/r-runtime/CHANGELOG.md
+++ b/code/packages/rust/r-runtime/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.28.0] - 2026-06-21
+
+### Added (via the shared `s-runtime`)
+
+- **R-36 — matrix cross products**: `crossprod` and `tcrossprod`, reached through
+  ordinary R syntax. An independent matrix-algebra item, defined **entirely in
+  terms of the existing R-11 `t()` transpose and `%*%` matrix product** — no new
+  linear algebra, no new value type, no grammar change.
+  - **`crossprod(x, y)`** = `t(x) %*% y`; **`crossprod(x)`** = `t(x) %*% x`
+    (the Gram matrix `X'X`). **`tcrossprod(x, y)`** = `x %*% t(y)`;
+    **`tcrossprod(x)`** = `x %*% t(x)` (`XX'`). The second argument defaults to the
+    first.
+  - `crossprod(matrix(c(1,2,3,4), nrow=2))` → `[[5,11],[11,25]]`;
+    `tcrossprod(...)` of the same → `[[10,14],[14,20]]`. Non-square
+    `B = matrix(1:6, nrow=2)`: `dim(crossprod(B))` is `c(3,3)`,
+    `dim(tcrossprod(B))` is `c(2,2)`. A non-conformable pair (e.g.
+    `crossprod(A, matrix(1:6, nrow=3))`) raises the same `"non-conformable
+    arguments"` error `%*%` raises.
+  - **Security**: no new user-controlled multiplier — the impl reuses the `%*%`
+    handler's existing `MAX_SEQ_LEN` allocation guard and conformability check, so
+    there is no unchecked `nrow*ncol` multiply and no out-of-bounds path; the new
+    code is just two argument-shuffling wrappers.
+
 ## [0.27.0] - 2026-06-21
 
 ### Added (via the shared `s-runtime`)

--- a/code/packages/rust/r-runtime/README.md
+++ b/code/packages/rust/r-runtime/README.md
@@ -216,6 +216,18 @@ already-capped input/breaks lengths; missing operands error gracefully. (`cut`'s
 `labels=`/`right=FALSE`/`include.lowest=` and integer `breaks` are deferred to
 R-33.)
 
+**R-36 — matrix cross products** add `crossprod` and `tcrossprod`, again through the
+shared `s-runtime`. An independent matrix-algebra item, defined entirely in terms of
+the existing R-11 `t()` transpose and `%*%` matrix product (no new linear algebra).
+`crossprod(x, y)` = `t(x) %*% y` and `crossprod(x)` = `t(x) %*% x` (the Gram matrix
+`X'X`); `tcrossprod(x, y)` = `x %*% t(y)` and `tcrossprod(x)` = `x %*% t(x)` (`XX'`).
+The second argument defaults to the first. `crossprod(matrix(c(1,2,3,4), nrow=2))`
+→ `[[5,11],[11,25]]`; `tcrossprod(...)` of the same → `[[10,14],[14,20]]`; for
+`B = matrix(1:6, nrow=2)`, `dim(crossprod(B))` is `c(3,3)` and `dim(tcrossprod(B))`
+is `c(2,2)`. A non-conformable pair raises the same `"non-conformable arguments"`
+error `%*%` raises. Because the impl reuses the `%*%` handler, it inherits its
+`MAX_SEQ_LEN` allocation guard and conformability check — no new unbounded multiplier.
+
 ## Usage
 
 ```rust

--- a/code/packages/rust/r-runtime/src/lib.rs
+++ b/code/packages/rust/r-runtime/src/lib.rs
@@ -3019,4 +3019,86 @@ mod tests {
         let b = nums("set.seed(1)\nrank(c(3, 1, 3), ties.method = \"random\")\n");
         assert_eq!(a, b);
     }
+
+    // --- R-36: crossprod / tcrossprod (R syntax) ------------------------
+
+    /// Evaluate `src` (R syntax), expect a `Matrix`, return `(column-major data,
+    /// nrow, ncol)`.
+    fn matrix_data(src: &str) -> (Vec<f64>, usize, usize) {
+        match eval_r(src).unwrap() {
+            SValue::Matrix { data, nrow, ncol } => (data.data().to_vec(), nrow, ncol),
+            other => panic!("expected matrix, got {}", other.type_name()),
+        }
+    }
+
+    #[test]
+    fn crossprod_one_arg() {
+        // A = matrix(c(1,2,3,4), nrow=2). crossprod(A) = t(A)%*%A = [[5,11],[11,25]].
+        let (data, nrow, ncol) = matrix_data("crossprod(matrix(c(1,2,3,4), nrow = 2))\n");
+        assert_eq!((nrow, ncol), (2, 2));
+        assert_eq!(data, vec![5.0, 11.0, 11.0, 25.0]);
+        // dim() agrees.
+        assert_eq!(
+            nums("dim(crossprod(matrix(c(1,2,3,4), nrow = 2)))\n"),
+            vec![2.0, 2.0]
+        );
+    }
+
+    #[test]
+    fn crossprod_two_arg_equals_one_arg() {
+        assert_eq!(
+            nums("A <- matrix(c(1,2,3,4), nrow = 2)\nc(crossprod(A, A))\n"),
+            nums("A <- matrix(c(1,2,3,4), nrow = 2)\nc(crossprod(A))\n"),
+        );
+        // And both equal the explicit t(A) %*% A.
+        assert_eq!(
+            nums("A <- matrix(c(1,2,3,4), nrow = 2)\nc(crossprod(A))\n"),
+            nums("A <- matrix(c(1,2,3,4), nrow = 2)\nc(t(A) %*% A)\n"),
+        );
+    }
+
+    #[test]
+    fn tcrossprod_one_arg() {
+        // tcrossprod(A) = A %*% t(A) = [[10,14],[14,20]].
+        let (data, nrow, ncol) = matrix_data("tcrossprod(matrix(c(1,2,3,4), nrow = 2))\n");
+        assert_eq!((nrow, ncol), (2, 2));
+        assert_eq!(data, vec![10.0, 14.0, 14.0, 20.0]);
+        assert_eq!(
+            nums("A <- matrix(c(1,2,3,4), nrow = 2)\nc(tcrossprod(A))\n"),
+            nums("A <- matrix(c(1,2,3,4), nrow = 2)\nc(A %*% t(A))\n"),
+        );
+    }
+
+    #[test]
+    fn crossprod_nonsquare_dims() {
+        // B = matrix(1:6, nrow=2) is 2x3. crossprod(B) -> 3x3; tcrossprod(B) -> 2x2.
+        assert_eq!(
+            nums("dim(crossprod(matrix(1:6, nrow = 2)))\n"),
+            vec![3.0, 3.0]
+        );
+        assert_eq!(
+            nums("dim(tcrossprod(matrix(1:6, nrow = 2)))\n"),
+            vec![2.0, 2.0]
+        );
+        // Spot-check entries: crossprod(B)[1,1] = 1*1+2*2 = 5;
+        // tcrossprod(B)[1,1] = 1*1+3*3+5*5 = 35.
+        let (cp, _, _) = matrix_data("crossprod(matrix(1:6, nrow = 2))\n");
+        assert_eq!(cp[0], 5.0);
+        let (tcp, _, _) = matrix_data("tcrossprod(matrix(1:6, nrow = 2))\n");
+        assert_eq!(tcp[0], 35.0);
+    }
+
+    #[test]
+    fn crossprod_nonconformable_errors() {
+        // t(A) is 2x2; multiplying by a 3-row matrix is non-conformable, the
+        // same error %*% raises.
+        let err = eval_r(
+            "A <- matrix(c(1,2,3,4), nrow = 2)\nC <- matrix(1:6, nrow = 3)\ncrossprod(A, C)\n",
+        )
+        .unwrap_err();
+        assert!(
+            format!("{err}").contains("non-conformable"),
+            "expected conformability error, got: {err}"
+        );
+    }
 }

--- a/code/packages/rust/s-runtime/CHANGELOG.md
+++ b/code/packages/rust/s-runtime/CHANGELOG.md
@@ -2,6 +2,33 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.29.0] - 2026-06-21
+
+### Added
+
+- **Matrix cross products (R-36)** — `crossprod` and `tcrossprod`, available to
+  both S and R through the shared tree-walker. An independent matrix-algebra item
+  (not part of the binning/set-op chains), defined **entirely in terms of the
+  existing R-11 `t()` transpose and `%*%` matrix product** — no new linear algebra,
+  no new value type.
+  - **`crossprod(x, y)`** = `t(x) %*% y`; **`crossprod(x)`** (one argument) =
+    `t(x) %*% x` (the unscaled Gram matrix `X'X`). The second argument defaults to
+    the first.
+  - **`tcrossprod(x, y)`** = `x %*% t(y)`; **`tcrossprod(x)`** (one argument) =
+    `x %*% t(x)` (`XX'`). The "t" prefix transposes the *second* operand.
+  - Worked column-major example: `A = matrix(c(1,2,3,4), nrow=2)` gives
+    `crossprod(A)` = `[[5,11],[11,25]]` and `tcrossprod(A)` = `[[10,14],[14,20]]`.
+    Non-square `B = matrix(1:6, nrow=2)` (2×3) gives `crossprod(B)` 3×3 and
+    `tcrossprod(B)` 2×2.
+  - **Reuse / security**: the implementation calls the public `t()` builtin (`b_t`,
+    via a `transpose_value` helper) and the evaluator's `matrix_multiply` (the `%*%`
+    handler, newly exposed `pub(crate)`). It therefore inherits that handler's
+    already-reviewed `MAX_SEQ_LEN` allocation guard on the `nrow*ncol` result (no
+    unchecked multiply → OOM), the `"non-conformable arguments"` error raised before
+    any indexing, the column-major `array_runtime` fast path, and NA propagation.
+    The new surface is just the two argument-shuffling wrappers; a bare vector flows
+    through `%*%`'s existing vector promotion.
+
 ## [0.28.0] - 2026-06-21
 
 ### Added

--- a/code/packages/rust/s-runtime/README.md
+++ b/code/packages/rust/s-runtime/README.md
@@ -240,6 +240,16 @@ a hand-written loop. See [What "S-flavored" means here](#what-s-flavored-means-h
   `findInterval`; allocations bounded by the already-capped input/breaks lengths;
   missing operands error gracefully. (`cut`'s `labels=`/`right=FALSE`/
   `include.lowest=` and integer `breaks` are deferred to R-33.)
+- **Matrix cross products** (R-36): **`crossprod(x, y)`** = `t(x) %*% y` and
+  **`crossprod(x)`** = `t(x) %*% x` (the Gram matrix `X'X`); **`tcrossprod(x, y)`** =
+  `x %*% t(y)` and **`tcrossprod(x)`** = `x %*% t(x)` (`XX'`). The second argument
+  defaults to the first. Defined purely in terms of the existing R-11 `t()` and
+  `%*%` — the implementation calls the public `t()` builtin and the evaluator's
+  `matrix_multiply`, so it inherits that handler's `MAX_SEQ_LEN` allocation guard
+  and `"non-conformable arguments"` error (no new linear algebra, no unchecked
+  `nrow*ncol` multiply). `crossprod(matrix(c(1,2,3,4), nrow=2))` →
+  `[[5,11],[11,25]]`; `tcrossprod` of the same → `[[10,14],[14,20]]`; non-square
+  `matrix(1:6, nrow=2)` gives a 3×3 `crossprod` and 2×2 `tcrossprod`.
 - The **`d`/`p`/`q`/`r` distribution family** (R-8) over `statistics-core`:
   density/CDF/quantile/sampling for the normal, uniform, and exponential
   distributions, plus `set.seed` for a reproducible per-session RNG.

--- a/code/packages/rust/s-runtime/src/builtins.rs
+++ b/code/packages/rust/s-runtime/src/builtins.rs
@@ -250,6 +250,10 @@ pub fn install(env: &Env) {
     define(env, "matrix", builtin("matrix", b_matrix));
     define(env, "t", builtin("t", b_t));
     define(env, "apply", builtin("apply", b_apply));
+    // Matrix cross products (R-36): `t(x) %*% y` and `x %*% t(y)`. Both reuse
+    // the `t()` transpose and the `%*%` product above — no new linear algebra.
+    define(env, "crossprod", builtin("crossprod", b_crossprod));
+    define(env, "tcrossprod", builtin("tcrossprod", b_tcrossprod));
 
     // Matrix linear algebra (R-12).
     define(env, "diag", builtin("diag", b_diag));
@@ -553,6 +557,112 @@ fn b_t(_interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
             })
         }
     }
+}
+
+/// Transpose a single value by reusing the public `t()` builtin (`b_t`). We wrap
+/// `value` back into a one-element `Arg` slice — exactly the shape `b_t` expects
+/// — so `crossprod`/`tcrossprod` get *identical* transpose semantics (matrix →
+/// swapped dims; bare vector → `1×n` row matrix) with zero duplicated logic.
+fn transpose_value(interp: &Interpreter, value: &SValue) -> SResult<SValue> {
+    let one = [Arg {
+        name: None,
+        value: value.clone(),
+    }];
+    b_t(interp, &one)
+}
+
+/// `crossprod(x, y)` = `t(x) %*% y`; `crossprod(x)` (one argument) = `t(x) %*% x`.
+///
+/// This is the *Gram matrix* operation that shows up everywhere in statistics:
+/// for a data matrix `X` whose columns are variables, `crossprod(X)` is the
+/// (unscaled) `X'X` — the column-by-column dot products, the heart of a
+/// least-squares normal equation `X'X b = X'y`.
+///
+/// ## Worked example (column-major, as R stores matrices)
+///
+/// `A = matrix(c(1, 2, 3, 4), nrow = 2)` is
+///
+/// ```text
+///       col1 col2
+/// row1   1    3
+/// row2   2    4
+/// ```
+///
+/// Its transpose `t(A)` is
+///
+/// ```text
+///       col1 col2
+/// row1   1    2
+/// row2   3    4
+/// ```
+///
+/// so `crossprod(A) = t(A) %*% A` =
+///
+/// ```text
+/// [ 1*1+2*2  1*3+2*4 ]   [  5  11 ]
+/// [ 3*1+4*2  3*3+4*4 ] = [ 11  25 ]
+/// ```
+///
+/// ## Implementation
+///
+/// We do **not** reimplement multiply or transpose. We call the public `t()`
+/// (`b_t`, via `transpose_value`) for the transpose and the evaluator's
+/// `matrix_multiply` for the product. That means we inherit, for free:
+///   * the `MAX_SEQ_LEN` allocation guard on `nrow * ncol` (no unchecked
+///     multiply → OOM),
+///   * the `"non-conformable arguments"` error when inner dims disagree,
+///   * the column-major `array_runtime` fast path and NA propagation.
+///
+/// The second argument is optional and defaults to `x` (the one-argument form),
+/// matching R. Inner dims always conform in the one-argument case because
+/// `t(x)` has as many columns as `x` has rows.
+fn b_crossprod(interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
+    let x = first_positional(args)?;
+    let y_owned;
+    let y = match nth_positional(args, 1) {
+        Some(y) => y,
+        None => {
+            // crossprod(x) ≡ crossprod(x, x): the second operand is x itself.
+            y_owned = x.clone();
+            &y_owned
+        }
+    };
+    let xt = transpose_value(interp, x)?;
+    interp.matrix_multiply(&xt, y)
+}
+
+/// `tcrossprod(x, y)` = `x %*% t(y)`; `tcrossprod(x)` (one argument) =
+/// `x %*% t(x)`.
+///
+/// The "t" is for *transposed*: where `crossprod` transposes the **first**
+/// operand, `tcrossprod` transposes the **second**. For a data matrix `X` whose
+/// rows are observations, `tcrossprod(X)` is the `XX'` of pairwise row dot
+/// products (a Gram matrix over observations rather than variables).
+///
+/// ## Worked example (same `A` as `crossprod`)
+///
+/// `tcrossprod(A) = A %*% t(A)` =
+///
+/// ```text
+/// [ 1*1+3*3  1*2+3*4 ]   [ 10  14 ]
+/// [ 2*1+4*3  2*2+4*4 ] = [ 14  20 ]
+/// ```
+///
+/// As with `crossprod`, the multiply and transpose are *reused*, not rebuilt,
+/// so the allocation guard, conformability error, and NA rules all carry over.
+fn b_tcrossprod(interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
+    let x = first_positional(args)?;
+    let y_owned;
+    let y = match nth_positional(args, 1) {
+        Some(y) => y,
+        None => {
+            // tcrossprod(x) ≡ tcrossprod(x, x).
+            y_owned = x.clone();
+            &y_owned
+        }
+    };
+    let yt = transpose_value(interp, y)?;
+    interp.matrix_multiply(x, &yt)
 }
 
 /// `apply(X, MARGIN, FUN, …)` — apply `FUN` to each row (`MARGIN = 1`) or column

--- a/code/packages/rust/s-runtime/src/eval.rs
+++ b/code/packages/rust/s-runtime/src/eval.rs
@@ -783,7 +783,12 @@ impl Interpreter {
     /// `a %*% b` — the matrix product (column-major). A bare vector on the left
     /// is taken as a `1×n` row; on the right as an `n×1` column (so `v %*% w` is
     /// the dot product), matching R's conformability rules. NA propagates.
-    fn matrix_multiply(&self, lhs: &SValue, rhs: &SValue) -> SResult<SValue> {
+    ///
+    /// Exposed `pub(crate)` so the `crossprod`/`tcrossprod` builtins (R-36) can
+    /// reuse the *same* product — including its allocation guard (`MAX_SEQ_LEN`),
+    /// its conformability error, and its `array_runtime` fast path — instead of
+    /// reimplementing the inner loops.
+    pub(crate) fn matrix_multiply(&self, lhs: &SValue, rhs: &SValue) -> SResult<SValue> {
         let (ad, am, ak) = match lhs {
             SValue::Matrix { data, nrow, ncol } => (data.clone(), *nrow, *ncol),
             other => {

--- a/code/packages/rust/s-runtime/src/lib.rs
+++ b/code/packages/rust/s-runtime/src/lib.rs
@@ -2240,4 +2240,95 @@ mod r30_ordering {
             vec![3.0, 1.0, 2.0]
         );
     }
+
+    // --- R-36: crossprod / tcrossprod -----------------------------------
+
+    /// Evaluate `src`, expect a `Matrix`, and return `(column-major data, nrow,
+    /// ncol)`. Used to assert both the shape and the exact entries of a cross
+    /// product without leaning on print formatting.
+    fn matrix_data(src: &str) -> (Vec<f64>, usize, usize) {
+        match eval_s(src).unwrap() {
+            SValue::Matrix { data, nrow, ncol } => (data.data().to_vec(), nrow, ncol),
+            other => panic!("expected matrix, got {}", other.type_name()),
+        }
+    }
+
+    #[test]
+    fn crossprod_one_arg_is_t_x_times_x() {
+        // A = matrix(c(1,2,3,4), nrow = 2) is column-major col1=(1,2) col2=(3,4).
+        // crossprod(A) = t(A) %*% A = [[5, 11], [11, 25]] (column-major 5,11,11,25).
+        let (data, nrow, ncol) = matrix_data("crossprod(matrix(c(1,2,3,4), nrow = 2))\n");
+        assert_eq!((nrow, ncol), (2, 2));
+        assert_eq!(data, vec![5.0, 11.0, 11.0, 25.0]);
+    }
+
+    #[test]
+    fn crossprod_two_arg_matches_one_arg() {
+        // crossprod(A, A) must equal crossprod(A).
+        assert_eq!(
+            nums("A <- matrix(c(1,2,3,4), nrow = 2)\nc(crossprod(A, A))\n"),
+            nums("A <- matrix(c(1,2,3,4), nrow = 2)\nc(crossprod(A))\n"),
+        );
+    }
+
+    #[test]
+    fn crossprod_equals_explicit_t_and_matmul() {
+        // Definitional identity: crossprod(A) == t(A) %*% A, entry for entry.
+        assert_eq!(
+            nums("A <- matrix(c(1,2,3,4), nrow = 2)\nc(crossprod(A))\n"),
+            nums("A <- matrix(c(1,2,3,4), nrow = 2)\nc(t(A) %*% A)\n"),
+        );
+    }
+
+    #[test]
+    fn tcrossprod_one_arg_is_x_times_t_x() {
+        // tcrossprod(A) = A %*% t(A) = [[10, 14], [14, 20]] (column-major 10,14,14,20).
+        let (data, nrow, ncol) = matrix_data("tcrossprod(matrix(c(1,2,3,4), nrow = 2))\n");
+        assert_eq!((nrow, ncol), (2, 2));
+        assert_eq!(data, vec![10.0, 14.0, 14.0, 20.0]);
+    }
+
+    #[test]
+    fn tcrossprod_equals_explicit_matmul_and_t() {
+        assert_eq!(
+            nums("A <- matrix(c(1,2,3,4), nrow = 2)\nc(tcrossprod(A))\n"),
+            nums("A <- matrix(c(1,2,3,4), nrow = 2)\nc(A %*% t(A))\n"),
+        );
+    }
+
+    #[test]
+    fn crossprod_nonsquare_gives_ncol_by_ncol() {
+        // B = matrix(1:6, nrow = 2) is 2x3, column-major col1=(1,2) col2=(3,4) col3=(5,6).
+        // crossprod(B) = t(B) %*% B is 3x3; e.g. entry (1,1) = 1*1+2*2 = 5,
+        // entry (1,3) = 1*5+2*6 = 17.
+        let (data, nrow, ncol) = matrix_data("crossprod(matrix(1:6, nrow = 2))\n");
+        assert_eq!((nrow, ncol), (3, 3));
+        assert_eq!(data[0], 5.0); // (1,1)
+        assert_eq!(data[2 * 3], 17.0); // (1,3): col index 2, row 0 → 2*3 + 0
+    }
+
+    #[test]
+    fn tcrossprod_nonsquare_gives_nrow_by_nrow() {
+        // tcrossprod(B) = B %*% t(B) is 2x2.
+        // (1,1) = 1*1+3*3+5*5 = 35; (2,2) = 2*2+4*4+6*6 = 56.
+        let (data, nrow, ncol) = matrix_data("tcrossprod(matrix(1:6, nrow = 2))\n");
+        assert_eq!((nrow, ncol), (2, 2));
+        assert_eq!(data[0], 35.0); // (1,1)
+        assert_eq!(data[1 * 2 + 1], 56.0); // (2,2): col 1, row 1
+    }
+
+    #[test]
+    fn crossprod_dimension_mismatch_errors_like_matmul() {
+        // crossprod(A, B): t(A) is 2x2, B is 2x3 → t(A) %*% B is fine (2x3),
+        // so use a genuinely non-conformable pair. t(A) is 2x2; multiply by a
+        // 3-row matrix to force the same "non-conformable arguments" error %*% raises.
+        let err = eval_s(
+            "A <- matrix(c(1,2,3,4), nrow = 2)\nC <- matrix(1:6, nrow = 3)\ncrossprod(A, C)\n",
+        )
+        .unwrap_err();
+        assert!(
+            format!("{err}").contains("non-conformable"),
+            "expected a conformability error, got: {err}"
+        );
+    }
 }

--- a/code/specs/R00-r-language.md
+++ b/code/specs/R00-r-language.md
@@ -1129,6 +1129,39 @@ unchanged.
     integer (number of equal-width bins). These are pure extensions of the same
     `findInterval`-backed core. The `%o%` infix alias for `outer` remains open for a
     later grammar pass.
+- **R-36 — `crossprod` / `tcrossprod` (matrix cross products)** *(this PR)*. An
+  **independent matrix-algebra item** (not part of the binning/cut/set-op chains):
+  the two cross-product convenience functions that statistics code reaches for
+  constantly, landed in the shared `s-runtime` (R reuses them verbatim through the
+  shared tree-walker). Both are defined **entirely in terms of the existing R-11
+  `t()` transpose and R-11 `%*%` matrix product** — no new linear algebra, no new
+  value type:
+  - **`crossprod(x, y)`** = `t(x) %*% y`; **`crossprod(x)`** (one argument) =
+    `t(x) %*% x` (the unscaled Gram matrix `X'X`, the heart of a least-squares
+    normal equation). The second argument defaults to the first.
+  - **`tcrossprod(x, y)`** = `x %*% t(y)`; **`tcrossprod(x)`** (one argument) =
+    `x %*% t(x)` (the `XX'` of pairwise row dot products). The "t" prefix means
+    the *second* operand is transposed (vs. `crossprod`, which transposes the
+    first).
+  - **Worked example (column-major, as R stores matrices).**
+    `A = matrix(c(1,2,3,4), nrow = 2)` is col1=(1,2), col2=(3,4). Then
+    `crossprod(A) = t(A) %*% A = [[5, 11], [11, 25]]` and
+    `tcrossprod(A) = A %*% t(A) = [[10, 14], [14, 20]]`. Non-square:
+    `B = matrix(1:6, nrow = 2)` (2×3) gives `crossprod(B)` 3×3 and `tcrossprod(B)`
+    2×2.
+  - **Reuse, not reimplementation (security).** The implementation calls the
+    public `t()` builtin (`b_t`) for the transpose and the evaluator's
+    `matrix_multiply` (the `%*%` handler, exposed `pub(crate)` for this) for the
+    product. It therefore **inherits** that handler's already-reviewed safety
+    properties: the `MAX_SEQ_LEN` allocation guard on the `nrow * ncol` result
+    (no unchecked multiply → OOM), the `"non-conformable arguments"` error raised
+    *before* any indexing when inner dimensions disagree (so `crossprod(A, C)` for
+    a non-conformable `C` is the same clean error `%*%` raises), the column-major
+    `array_runtime` fast path, and NA propagation. The new surface is just the
+    two argument-shuffling wrappers. As in R, a bare numeric vector flows through
+    the same vector-promotion rules `%*%` already applies (left operand a row,
+    right operand a column), so `crossprod(v)` is `1×1`; the matrix case is the
+    solid, tested core.
 
 ## §4 Reuse strategy
 

--- a/code/specs/S00-s-language.md
+++ b/code/specs/S00-s-language.md
@@ -312,6 +312,20 @@ needs a string assignment target: `"%between%" <- function(x, r) x >= r[1] & x <
   supported. Deferred to **R-32**: `incomparables=`/`fromLast=` on the binary set ops
   (`union`/`intersect`/`setdiff`), whose R semantics are ambiguous enough to warrant
   their own pass.
+- **Matrix cross products** *(R-36)*: `crossprod`/`tcrossprod`, defined purely in
+  terms of the existing R-11 `t()` transpose and `%*%` matrix product (no new
+  linear algebra, no new value type). **`crossprod(x, y)` = `t(x) %*% y`** and
+  **`crossprod(x)` = `t(x) %*% x`** (the Gram matrix `X'X`); **`tcrossprod(x, y)` =
+  `x %*% t(y)`** and **`tcrossprod(x)` = `x %*% t(x)`** (`XX'`). The second argument
+  defaults to the first. The implementation calls the public `t()` builtin (`b_t`)
+  and the evaluator's `matrix_multiply` (the `%*%` handler, exposed `pub(crate)`),
+  so it **inherits** that handler's `MAX_SEQ_LEN` allocation guard on the
+  `nrow * ncol` result and its `"non-conformable arguments"` error (raised before
+  any indexing when inner dims disagree) — no new unbounded multiplier, no OOB.
+  `crossprod(matrix(c(1,2,3,4), nrow=2))` is `[[5,11],[11,25]]`;
+  `tcrossprod` of the same is `[[10,14],[14,20]]`. As in R a bare vector flows
+  through `%*%`'s existing vector promotion (left = row, right = column); the
+  dense-matrix case is the solid, tested core.
 - **Apply family:** `sapply(x, f)` / `lapply(x, f)` map a function over elements
   (`sapply` simplifies length-1 atomic results to a vector).
 


### PR DESCRIPTION
## R-36 — `crossprod` / `tcrossprod`

An **independent matrix-algebra item** (not part of the cut/string/set-op chains): the two matrix cross-product convenience functions that statistics code reaches for constantly. Implemented in the shared `s-runtime` so **both S and R** get them through the shared tree-walker.

### Additions

- **`crossprod(x, y)`** = `t(x) %*% y`; **`crossprod(x)`** (one argument) = `t(x) %*% x` (the unscaled Gram matrix `X'X`).
- **`tcrossprod(x, y)`** = `x %*% t(y)`; **`tcrossprod(x)`** (one argument) = `x %*% t(x)` (`XX'`). The "t" prefix transposes the *second* operand.
- The second argument defaults to the first in both.

### The equivalences (and reuse of existing machinery)

These are defined **entirely in terms of the existing R-11 `t()` transpose and `%*%` matrix product** — **no new linear algebra, no new value type**:

- transpose reuses the public `t()` builtin (`b_t`) via a small `transpose_value` helper that re-wraps the value into the one-element `Arg` slice `b_t` expects;
- the product reuses the evaluator's `matrix_multiply` (the `%*%` handler), newly exposed `pub(crate)` for this.

Because the product is reused, the new functions inherit `matrix_multiply`'s already-reviewed safety properties: the `MAX_SEQ_LEN` allocation guard on the `nrow*ncol` result (no unchecked multiply → OOM), the `"non-conformable arguments"` error raised **before any indexing**, the column-major `array_runtime` fast path, and NA propagation. The new surface is just the two argument-shuffling wrappers.

### Worked examples (column-major)

- `A = matrix(c(1,2,3,4), nrow=2)` → `crossprod(A)` = `[[5,11],[11,25]]`, `tcrossprod(A)` = `[[10,14],[14,20]]`.
- Non-square `B = matrix(1:6, nrow=2)` (2×3) → `crossprod(B)` is 3×3, `tcrossprod(B)` is 2×2.
- `crossprod(A, C)` with a non-conformable `C` raises the same conformability error `%*%` raises.

### Tests

- `s-runtime`: 8 new unit tests (S semantics) — 249 tests pass.
- `r-runtime`: 5 new integration tests (R syntax, incl. `dim()` shape assertions and the mismatch error) — 249 tests pass.

### Scope

Dense-matrix `crossprod`/`tcrossprod` (1-arg and 2-arg) ship solidly. A bare numeric vector flows through `%*%`'s existing vector promotion (left = row, right = column), as in R; the matrix case is the solid, tested core. No deferrals.

### Security

Reviewed via a Rust security sub-agent over `git diff origin/main...HEAD`: **passed** — no CRITICAL/HIGH/MEDIUM findings. Confirmed no new unguarded `rows*cols` multiply (all allocation flows through the reused `matrix_multiply` guard), conformability checked before indexing, no panic on degenerate/empty/vector input, no unsafe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)