### PR TITLE
feat(mycin-micro): ground Helicobacter pylori (gram-negative, spiral, peptic ulcer)

### DIFF
--- a/code/specs/data/mycin-2026/recall/micro-edges.adj
+++ b/code/specs/data/mycin-2026/recall/micro-edges.adj
@@ -112,4 +112,19 @@ rulebook micro_facts {
         source "Streptococcus pneumoniae is a gram-positive, lancet-shaped bacterium and a cause of community-acquired pneumonia"
         locator "https://www.ncbi.nlm.nih.gov/books/NBK470537/"
         trust authoritative
+
+    % --- Helicobacter pylori (gram-negative, spiral; causes peptic ulcer) -------
+    % One span names the gram reaction AND the spiral shape; a second names the disease.
+    relate gram_stain(helicobacter_pylori, gram_negative)
+        source "Helicobacter pylori (H. pylori) is a gram-negative spiral-shaped bacterium"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK534233/"
+        trust authoritative
+    relate morphology(helicobacter_pylori, spiral)
+        source "Helicobacter pylori (H. pylori) is a gram-negative spiral-shaped bacterium"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK534233/"
+        trust authoritative
+    relate causes(helicobacter_pylori, peptic_ulcer_disease)
+        source "H. pylori is the most important cause for chronic or atrophic gastritis, peptic ulcer, gastric lymphoma, and gastric carcinoma"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK534233/"
+        trust authoritative
 }

--- a/code/specs/data/mycin-2026/recall/micro-recall.query.adj
+++ b/code/specs/data/mycin-2026/recall/micro-recall.query.adj
@@ -20,3 +20,6 @@ import "micro-edges.adj"
 ? causes(vibrio_cholerae, $Disease)                 % expect cholera
 ? gram_stain(escherichia_coli, $Result)             % expect gram_negative
 ? causes(streptococcus_pneumoniae, $Disease)        % expect community_acquired_pneumonia
+? gram_stain(helicobacter_pylori, $Result)             % expect gram_negative (expand)
+? morphology(helicobacter_pylori, $Shape)              % expect spiral (expand)
+? causes(helicobacter_pylori, $Disease)                % expect peptic_ulcer_disease (expand)

--- a/code/specs/data/mycin-2026/recall/test_micro_recall.py
+++ b/code/specs/data/mycin-2026/recall/test_micro_recall.py
@@ -45,6 +45,9 @@ EXPECTED = [
     ("pseudomonas_aeruginosa", "morphology", "bacilli"),
     ("streptococcus_pneumoniae", "gram_stain", "gram_positive"),
     ("streptococcus_pneumoniae", "causes", "community_acquired_pneumonia"),
+    ("helicobacter_pylori", "gram_stain", "gram_negative"),          # expand (NBK534233)
+    ("helicobacter_pylori", "morphology", "spiral"),                 # expand (NBK534233)
+    ("helicobacter_pylori", "causes", "peptic_ulcer_disease"),       # expand (NBK534233)
 ]
 
 


### PR DESCRIPTION
## What

New microbiology organism — three grounded edges from the StatPearls H. pylori page (NBK534233):

- **gram_stain(helicobacter_pylori, gram_negative)** + **morphology(helicobacter_pylori, spiral)** — one span names both:
  > Helicobacter pylori (H. pylori) is a gram-negative spiral-shaped bacterium
- **causes(helicobacter_pylori, peptic_ulcer_disease)**:
  > H. pylori is the most important cause for chronic or atrophic gastritis, peptic ulcer, gastric lymphoma, and gastric carcinoma

## Changes (data-only)
- `micro-edges.adj` +3 `relate`; `micro-recall.query.adj` +3; `test_micro_recall.py` EXPECTED +3 (`treponema_pallidum` negative control unchanged)

## Verification
- `test_micro_recall: 3/3 passed`; ruff clean; data-only security review passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)