### PR TITLE
[codex] Expose SPICE WRDATA probe inventories

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 ### Added
 
+- **Deck WRDATA unmatched probe artifacts** —
+  selected `run_deck_analysis()` WRDATA artifact summaries now carry
+  `MatchedProbes` / `MatchedProbeList` and `UnmatchedProbes` /
+  `UnmatchedProbeList` columns so ignored `wrdata` probe names remain
+  auditable in stable table, CSV, JSON, and record exports, matching Rust and
+  TypeScript.
+
 - **Deck WRDATA probe column artifacts** —
   `format_deck_wrdata_ascii()` now treats explicit `wrdata <file> <probes...>`
   probe lists as data-file column selectors, preserving the scale column plus

--- a/code/packages/python/spice-engine/README.md
+++ b/code/packages/python/spice-engine/README.md
@@ -137,7 +137,9 @@ Accepted `.control` rawfile output options (`set filetype=ascii`,
 carry the same option inventories and render `wr_vecnames` / `wr_singlescale`
 intent as stable `VectorNames` / `Scale` metadata in the in-memory data file.
 When a `wrdata` marker names probes, its data file keeps the scale column plus
-only the requested matching probe columns.
+only the requested matching probe columns, while WRDATA artifact summaries keep
+matched and unmatched probe inventories in stable table, CSV, JSON, and record
+exports.
 Existing `.control` body policy diagnostics flow into those selected-run
 artifact `Diagnostics` / `DiagnosticCodeList` fields and through the same
 run-artifact table, CSV, JSON, and `table_artifacts` records.

--- a/code/packages/python/spice-engine/src/spice_engine/engine.py
+++ b/code/packages/python/spice-engine/src/spice_engine/engine.py
@@ -2393,6 +2393,10 @@ class DeckWrdataArtifact:
     marker: str
     probe_count: int
     probes: list[str]
+    matched_probe_count: int
+    matched_probes: list[str]
+    unmatched_probe_count: int
+    unmatched_probes: list[str]
     option_count: int
     options: list[str]
     datafile: str
@@ -3042,17 +3046,7 @@ def _deck_wrdata_project_rows(rows: list[str], probes: list[str]) -> list[str]:
     columns = rows[0].split("\t")
     if not probes:
         return rows
-    selected_indices: list[int] = []
-    if columns:
-        selected_indices.append(0)
-    normalized_columns = [column.casefold() for column in columns]
-    for probe in probes:
-        normalized_probe = probe.casefold()
-        if normalized_probe not in normalized_columns:
-            continue
-        index = normalized_columns.index(normalized_probe)
-        if index not in selected_indices:
-            selected_indices.append(index)
+    selected_indices, _, _ = _deck_wrdata_probe_inventory(columns, probes)
     projected_rows: list[str] = []
     for row in rows:
         cells = row.split("\t")
@@ -3063,6 +3057,28 @@ def _deck_wrdata_project_rows(rows: list[str], probes: list[str]) -> list[str]:
             )
         )
     return projected_rows
+
+
+def _deck_wrdata_probe_inventory(
+    columns: list[str],
+    probes: list[str],
+) -> tuple[list[int], list[str], list[str]]:
+    selected_indices: list[int] = []
+    matched_probes: list[str] = []
+    unmatched_probes: list[str] = []
+    if columns:
+        selected_indices.append(0)
+    normalized_columns = [column.casefold() for column in columns]
+    for probe in probes:
+        normalized_probe = probe.casefold()
+        if normalized_probe not in normalized_columns:
+            unmatched_probes.append(probe)
+            continue
+        index = normalized_columns.index(normalized_probe)
+        if index not in selected_indices:
+            selected_indices.append(index)
+            matched_probes.append(columns[index])
+    return selected_indices, matched_probes, unmatched_probes
 
 
 def _deck_wrdata_marker_parts(marker: str) -> tuple[str, list[str]] | None:
@@ -3079,17 +3095,24 @@ def _deck_wrdata_artifacts(
 ) -> list[DeckWrdataArtifact]:
     artifacts: list[DeckWrdataArtifact] = []
     options = list(rawfile_options)
+    rows = table.splitlines()
+    columns = rows[0].split("\t") if rows else []
     for marker in write_markers:
         parts = _deck_wrdata_marker_parts(marker)
         if parts is None:
             continue
         target, probes = parts
+        _, matched_probes, unmatched_probes = _deck_wrdata_probe_inventory(columns, probes)
         artifacts.append(
             DeckWrdataArtifact(
                 target=target,
                 marker=marker,
                 probe_count=len(probes),
                 probes=probes,
+                matched_probe_count=len(matched_probes),
+                matched_probes=matched_probes,
+                unmatched_probe_count=len(unmatched_probes),
+                unmatched_probes=unmatched_probes,
                 option_count=len(options),
                 options=list(options),
                 datafile=format_deck_wrdata_ascii(table, probes, options),
@@ -3103,6 +3126,10 @@ _DECK_WRDATA_ARTIFACT_COLUMNS = [
     "Marker",
     "Probes",
     "ProbeList",
+    "MatchedProbes",
+    "MatchedProbeList",
+    "UnmatchedProbes",
+    "UnmatchedProbeList",
     "Options",
     "RawfileOptionList",
     "Bytes",
@@ -3115,6 +3142,10 @@ def _deck_wrdata_artifact_cells(artifact: DeckWrdataArtifact) -> list[str]:
         artifact.marker,
         str(artifact.probe_count),
         ";".join(artifact.probes),
+        str(artifact.matched_probe_count),
+        ";".join(artifact.matched_probes),
+        str(artifact.unmatched_probe_count),
+        ";".join(artifact.unmatched_probes),
         str(artifact.option_count),
         ";".join(artifact.options),
         str(len(artifact.datafile.encode())),

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -7403,7 +7403,7 @@ set wr_singlescale
 set appendwrite
 .set WR_VECNAMES
 write out.raw V(in)
-wrdata out.dat V(in)
+wrdata out.dat V(in) V(missing)
 source other.cir
 cd /tmp
 if v(in) > 0
@@ -7423,7 +7423,10 @@ let gain = 2
     code_list = ";".join(expected_codes)
     expected_control_lines = [".save V(in)", ".probe V(in)"]
     control_line_list = ";".join(expected_control_lines)
-    expected_write_markers = ["write out.raw V(in)", "wrdata out.dat V(in)"]
+    expected_write_markers = [
+        "write out.raw V(in)",
+        "wrdata out.dat V(in) V(missing)",
+    ]
     write_marker_list = ";".join(expected_write_markers)
     expected_rawfile_options = [
         "set filetype=ascii",
@@ -7477,15 +7480,19 @@ let gain = 2
     )
     assert execution.wrdata_artifact_count == 1
     assert execution.wrdata_artifacts[0].target == "out.dat"
-    assert execution.wrdata_artifacts[0].marker == "wrdata out.dat V(in)"
-    assert execution.wrdata_artifacts[0].probe_count == 1
-    assert execution.wrdata_artifacts[0].probes == ["V(in)"]
+    assert execution.wrdata_artifacts[0].marker == "wrdata out.dat V(in) V(missing)"
+    assert execution.wrdata_artifacts[0].probe_count == 2
+    assert execution.wrdata_artifacts[0].probes == ["V(in)", "V(missing)"]
+    assert execution.wrdata_artifacts[0].matched_probe_count == 1
+    assert execution.wrdata_artifacts[0].matched_probes == ["V(in)"]
+    assert execution.wrdata_artifacts[0].unmatched_probe_count == 1
+    assert execution.wrdata_artifacts[0].unmatched_probes == ["V(missing)"]
     assert execution.wrdata_artifacts[0].option_count == len(
         expected_rawfile_options
     )
     assert execution.wrdata_artifacts[0].options == expected_rawfile_options
     assert "# SPICE deck wrdata artifact\n" in execution.wrdata_artifacts[0].datafile
-    assert "Probes: V(in)\n" in execution.wrdata_artifacts[0].datafile
+    assert "Probes: V(in);V(missing)\n" in execution.wrdata_artifacts[0].datafile
     assert "Options: " + rawfile_option_list + "\n" in execution.wrdata_artifacts[0].datafile
     assert "VectorNames: Index;V(in)\n" in execution.wrdata_artifacts[0].datafile
     assert "Scale: Index\n" in execution.wrdata_artifacts[0].datafile
@@ -7493,9 +7500,13 @@ let gain = 2
     assert "0\t1.000000e+00\n" in execution.wrdata_artifacts[0].datafile
     wrdata_record = execution.wrdata_artifact_records[0]
     assert wrdata_record["Target"] == "out.dat"
-    assert wrdata_record["Marker"] == "wrdata out.dat V(in)"
-    assert wrdata_record["Probes"] == "1"
-    assert wrdata_record["ProbeList"] == "V(in)"
+    assert wrdata_record["Marker"] == "wrdata out.dat V(in) V(missing)"
+    assert wrdata_record["Probes"] == "2"
+    assert wrdata_record["ProbeList"] == "V(in);V(missing)"
+    assert wrdata_record["MatchedProbes"] == "1"
+    assert wrdata_record["MatchedProbeList"] == "V(in)"
+    assert wrdata_record["UnmatchedProbes"] == "1"
+    assert wrdata_record["UnmatchedProbeList"] == "V(missing)"
     assert wrdata_record["Options"] == str(len(expected_rawfile_options))
     assert wrdata_record["RawfileOptionList"] == rawfile_option_list
     assert wrdata_record["Bytes"] == str(
@@ -7510,10 +7521,11 @@ let gain = 2
     assert execution.wrdata_artifact_json == format_deck_wrdata_artifact_json(
         execution.wrdata_artifacts
     )
-    assert json.loads(execution.wrdata_artifact_json)[0]["ProbeList"] == "V(in)"
-    assert json.loads(execution.wrdata_artifact_json)[0]["RawfileOptionList"] == (
-        rawfile_option_list
-    )
+    wrdata_json = json.loads(execution.wrdata_artifact_json)[0]
+    assert wrdata_json["ProbeList"] == "V(in);V(missing)"
+    assert wrdata_json["MatchedProbeList"] == "V(in)"
+    assert wrdata_json["UnmatchedProbeList"] == "V(missing)"
+    assert wrdata_json["RawfileOptionList"] == rawfile_option_list
     assert execution.diagnostic_count == len(expected_codes)
     assert execution.diagnostic_codes == expected_codes
     assert execution.run_artifacts[0].control_line_count == len(expected_control_lines)

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Carry matched and unmatched `wrdata <file> <probes...>` probe inventories
+  through WRDATA artifact `MatchedProbes` / `MatchedProbeList` and
+  `UnmatchedProbes` / `UnmatchedProbeList` summary columns, matching Python and
+  TypeScript.
 - Treat explicit `wrdata <file> <probes...>` probe lists as in-memory data-file
   column selectors in `format_deck_wrdata_ascii`, preserving the scale column
   plus requested matching probe columns in deterministic WRDATA output,

--- a/code/packages/rust/spice-engine/README.md
+++ b/code/packages/rust/spice-engine/README.md
@@ -210,7 +210,9 @@ Accepted `.control` rawfile output options (`set filetype=ascii`,
 carry the same option inventories and render `wr_vecnames` / `wr_singlescale`
 intent as stable `VectorNames` / `Scale` metadata in the in-memory data file.
 When a `wrdata` marker names probes, its data file keeps the scale column plus
-only the requested matching probe columns.
+only the requested matching probe columns, while WRDATA artifact summaries keep
+matched and unmatched probe inventories in stable table, CSV, JSON, and record
+exports.
 Existing `.control` body policy diagnostics flow into those selected-run artifact `Diagnostics` /
 `DiagnosticCodeList` fields and through the same run-artifact table, CSV, JSON,
 and `table_artifacts` records. `format_deck_table_csv` also converts any stable

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -3475,6 +3475,10 @@ pub struct DeckWrdataArtifact {
     pub marker: String,
     pub probe_count: usize,
     pub probes: Vec<String>,
+    pub matched_probe_count: usize,
+    pub matched_probes: Vec<String>,
+    pub unmatched_probe_count: usize,
+    pub unmatched_probes: Vec<String>,
     pub option_count: usize,
     pub options: Vec<String>,
     pub datafile: String,
@@ -10751,20 +10755,7 @@ fn deck_wrdata_project_rows(rows: &[&str], probes: &[String]) -> Vec<String> {
     if probes.is_empty() {
         return rows.iter().map(|row| (*row).to_string()).collect();
     }
-    let mut selected_indices = Vec::new();
-    if !columns.is_empty() {
-        selected_indices.push(0);
-    }
-    for probe in probes {
-        if let Some(index) = columns
-            .iter()
-            .position(|column| column.eq_ignore_ascii_case(probe))
-        {
-            if !selected_indices.contains(&index) {
-                selected_indices.push(index);
-            }
-        }
-    }
+    let (selected_indices, _, _) = deck_wrdata_probe_inventory(&columns, probes);
     rows.iter()
         .map(|row| {
             let cells = row.split('\t').collect::<Vec<_>>();
@@ -10775,6 +10766,32 @@ fn deck_wrdata_project_rows(rows: &[&str], probes: &[String]) -> Vec<String> {
                 .join("\t")
         })
         .collect()
+}
+
+fn deck_wrdata_probe_inventory(
+    columns: &[&str],
+    probes: &[String],
+) -> (Vec<usize>, Vec<String>, Vec<String>) {
+    let mut selected_indices = Vec::new();
+    let mut matched_probes = Vec::new();
+    let mut unmatched_probes = Vec::new();
+    if !columns.is_empty() {
+        selected_indices.push(0);
+    }
+    for probe in probes {
+        if let Some(index) = columns
+            .iter()
+            .position(|column| column.eq_ignore_ascii_case(probe))
+        {
+            if !selected_indices.contains(&index) {
+                selected_indices.push(index);
+                matched_probes.push(columns[index].to_string());
+            }
+        } else {
+            unmatched_probes.push(probe.clone());
+        }
+    }
+    (selected_indices, matched_probes, unmatched_probes)
 }
 
 fn deck_wrdata_marker_parts(marker: &str) -> Option<(String, Vec<String>)> {
@@ -10797,14 +10814,25 @@ fn deck_wrdata_artifacts(
     write_markers: &[String],
     rawfile_options: &[String],
 ) -> Vec<DeckWrdataArtifact> {
+    let rows = table.lines().collect::<Vec<_>>();
+    let columns = rows
+        .first()
+        .map(|row| row.split('\t').collect::<Vec<_>>())
+        .unwrap_or_default();
     write_markers
         .iter()
         .filter_map(|marker| {
             let (target, probes) = deck_wrdata_marker_parts(marker)?;
+            let (_, matched_probes, unmatched_probes) =
+                deck_wrdata_probe_inventory(&columns, &probes);
             Some(DeckWrdataArtifact {
                 target,
                 marker: marker.clone(),
                 probe_count: probes.len(),
+                matched_probe_count: matched_probes.len(),
+                matched_probes,
+                unmatched_probe_count: unmatched_probes.len(),
+                unmatched_probes,
                 option_count: rawfile_options.len(),
                 options: rawfile_options.to_vec(),
                 datafile: format_deck_wrdata_ascii(table, &probes, rawfile_options),
@@ -10819,6 +10847,10 @@ const DECK_WRDATA_ARTIFACT_COLUMNS: &[&str] = &[
     "Marker",
     "Probes",
     "ProbeList",
+    "MatchedProbes",
+    "MatchedProbeList",
+    "UnmatchedProbes",
+    "UnmatchedProbeList",
     "Options",
     "RawfileOptionList",
     "Bytes",
@@ -10830,6 +10862,10 @@ fn deck_wrdata_artifact_cells(artifact: &DeckWrdataArtifact) -> Vec<String> {
         artifact.marker.clone(),
         artifact.probe_count.to_string(),
         artifact.probes.join(";"),
+        artifact.matched_probe_count.to_string(),
+        artifact.matched_probes.join(";"),
+        artifact.unmatched_probe_count.to_string(),
+        artifact.unmatched_probes.join(";"),
         artifact.option_count.to_string(),
         artifact.options.join(";"),
         artifact.datafile.len().to_string(),

--- a/code/packages/rust/spice-engine/tests/transient_tests.rs
+++ b/code/packages/rust/spice-engine/tests/transient_tests.rs
@@ -2762,7 +2762,7 @@ set wr_singlescale
 set appendwrite
 .set WR_VECNAMES
 write out.raw V(in)
-wrdata out.dat V(in)
+wrdata out.dat V(in) V(missing)
 source other.cir
 cd /tmp
 if v(in) > 0
@@ -2784,7 +2784,7 @@ let gain = 2
     let control_line_list = expected_control_lines.join(";");
     let expected_write_markers = vec![
         "write out.raw V(in)".to_string(),
-        "wrdata out.dat V(in)".to_string(),
+        "wrdata out.dat V(in) V(missing)".to_string(),
     ];
     let write_marker_list = expected_write_markers.join(";");
     let expected_rawfile_options = vec![
@@ -2870,9 +2870,22 @@ let gain = 2
     );
     assert_eq!(execution.wrdata_artifact_count, 1);
     assert_eq!(execution.wrdata_artifacts[0].target, "out.dat");
-    assert_eq!(execution.wrdata_artifacts[0].marker, "wrdata out.dat V(in)");
-    assert_eq!(execution.wrdata_artifacts[0].probe_count, 1);
-    assert_eq!(execution.wrdata_artifacts[0].probes, vec!["V(in)"]);
+    assert_eq!(
+        execution.wrdata_artifacts[0].marker,
+        "wrdata out.dat V(in) V(missing)"
+    );
+    assert_eq!(execution.wrdata_artifacts[0].probe_count, 2);
+    assert_eq!(
+        execution.wrdata_artifacts[0].probes,
+        vec!["V(in)", "V(missing)"]
+    );
+    assert_eq!(execution.wrdata_artifacts[0].matched_probe_count, 1);
+    assert_eq!(execution.wrdata_artifacts[0].matched_probes, vec!["V(in)"]);
+    assert_eq!(execution.wrdata_artifacts[0].unmatched_probe_count, 1);
+    assert_eq!(
+        execution.wrdata_artifacts[0].unmatched_probes,
+        vec!["V(missing)"]
+    );
     assert_eq!(
         execution.wrdata_artifacts[0].option_count,
         expected_rawfile_options.len()
@@ -2886,7 +2899,7 @@ let gain = 2
         .contains("# SPICE deck wrdata artifact\n"));
     assert!(execution.wrdata_artifacts[0]
         .datafile
-        .contains("Probes: V(in)\n"));
+        .contains("Probes: V(in);V(missing)\n"));
     assert!(execution.wrdata_artifacts[0]
         .datafile
         .contains(&format!("Options: {rawfile_option_list}\n")));
@@ -2912,13 +2925,37 @@ let gain = 2
         execution.wrdata_artifact_records[0]
             .get("Marker")
             .map(String::as_str),
-        Some("wrdata out.dat V(in)")
+        Some("wrdata out.dat V(in) V(missing)")
     );
     assert_eq!(
         execution.wrdata_artifact_records[0]
             .get("ProbeList")
             .map(String::as_str),
+        Some("V(in);V(missing)")
+    );
+    assert_eq!(
+        execution.wrdata_artifact_records[0]
+            .get("MatchedProbes")
+            .map(String::as_str),
+        Some("1")
+    );
+    assert_eq!(
+        execution.wrdata_artifact_records[0]
+            .get("MatchedProbeList")
+            .map(String::as_str),
         Some("V(in)")
+    );
+    assert_eq!(
+        execution.wrdata_artifact_records[0]
+            .get("UnmatchedProbes")
+            .map(String::as_str),
+        Some("1")
+    );
+    assert_eq!(
+        execution.wrdata_artifact_records[0]
+            .get("UnmatchedProbeList")
+            .map(String::as_str),
+        Some("V(missing)")
     );
     assert_eq!(
         execution.wrdata_artifact_records[0]

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Carry matched and unmatched `wrdata <file> <probes...>` probe inventories
+  through WRDATA artifact `MatchedProbes` / `MatchedProbeList` and
+  `UnmatchedProbes` / `UnmatchedProbeList` summary columns, matching Python and
+  Rust.
 - Treat explicit `wrdata <file> <probes...>` probe lists as in-memory data-file
   column selectors in `formatDeckWrdataAscii`, preserving the scale column plus
   requested matching probe columns in deterministic WRDATA output, matching

--- a/code/packages/typescript/spice-engine/README.md
+++ b/code/packages/typescript/spice-engine/README.md
@@ -126,7 +126,9 @@ Accepted `.control` rawfile output options (`set filetype=ascii`,
 carry the same option inventories and render `wr_vecnames` / `wr_singlescale`
 intent as stable `VectorNames` / `Scale` metadata in the in-memory data file.
 When a `wrdata` marker names probes, its data file keeps the scale column plus
-only the requested matching probe columns.
+only the requested matching probe columns, while WRDATA artifact summaries keep
+matched and unmatched probe inventories in stable table, CSV, JSON, and record
+exports.
 Existing
 `.control` body policy diagnostics flow into those selected-run artifact `Diagnostics` /
 `DiagnosticCodeList` fields and through the same run-artifact table, CSV, JSON,

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -727,6 +727,10 @@ export interface DeckWrdataArtifact {
   readonly marker: string;
   readonly probeCount: number;
   readonly probes: readonly string[];
+  readonly matchedProbeCount: number;
+  readonly matchedProbes: readonly string[];
+  readonly unmatchedProbeCount: number;
+  readonly unmatchedProbes: readonly string[];
   readonly optionCount: number;
   readonly options: readonly string[];
   readonly datafile: string;
@@ -8462,7 +8466,24 @@ function deckWrdataProjectRows(rows: readonly string[], probes: readonly string[
   if (probes.length === 0) {
     return [...rows];
   }
+  const { selectedIndices } = deckWrdataProbeInventory(columns, probes);
+  return rows.map((row) => {
+    const cells = row.split("\t");
+    return selectedIndices.map((index) => cells[index] ?? "").join("\t");
+  });
+}
+
+function deckWrdataProbeInventory(
+  columns: readonly string[],
+  probes: readonly string[],
+): {
+  selectedIndices: number[];
+  matchedProbes: string[];
+  unmatchedProbes: string[];
+} {
   const selectedIndices: number[] = [];
+  const matchedProbes: string[] = [];
+  const unmatchedProbes: string[] = [];
   if (columns.length > 0) {
     selectedIndices.push(0);
   }
@@ -8471,12 +8492,12 @@ function deckWrdataProjectRows(rows: readonly string[], probes: readonly string[
     const index = normalizedColumns.indexOf(probe.toLowerCase());
     if (index !== -1 && !selectedIndices.includes(index)) {
       selectedIndices.push(index);
+      matchedProbes.push(columns[index]!);
+    } else if (index === -1) {
+      unmatchedProbes.push(probe);
     }
   }
-  return rows.map((row) => {
-    const cells = row.split("\t");
-    return selectedIndices.map((index) => cells[index] ?? "").join("\t");
-  });
+  return { selectedIndices, matchedProbes, unmatchedProbes };
 }
 
 function deckWrdataMarkerParts(marker: string): { target: string; probes: string[] } | undefined {
@@ -8495,16 +8516,26 @@ function deckWrdataArtifacts(
   writeMarkers: readonly string[],
   rawfileOptions: readonly string[],
 ): DeckWrdataArtifact[] {
+  const rows = deckTableRows(table);
+  const columns = rows[0]?.split("\t") ?? [];
   return writeMarkers.flatMap((marker) => {
     const parts = deckWrdataMarkerParts(marker);
     if (parts === undefined) {
       return [];
     }
+    const { matchedProbes, unmatchedProbes } = deckWrdataProbeInventory(
+      columns,
+      parts.probes,
+    );
     return [{
       target: parts.target,
       marker,
       probeCount: parts.probes.length,
       probes: [...parts.probes],
+      matchedProbeCount: matchedProbes.length,
+      matchedProbes,
+      unmatchedProbeCount: unmatchedProbes.length,
+      unmatchedProbes,
       optionCount: rawfileOptions.length,
       options: [...rawfileOptions],
       datafile: formatDeckWrdataAscii(table, parts.probes, rawfileOptions),
@@ -8517,6 +8548,10 @@ const DECK_WRDATA_ARTIFACT_COLUMNS = [
   "Marker",
   "Probes",
   "ProbeList",
+  "MatchedProbes",
+  "MatchedProbeList",
+  "UnmatchedProbes",
+  "UnmatchedProbeList",
   "Options",
   "RawfileOptionList",
   "Bytes",
@@ -8528,6 +8563,10 @@ function deckWrdataArtifactCells(artifact: DeckWrdataArtifact): string[] {
     artifact.marker,
     String(artifact.probeCount),
     artifact.probes.join(";"),
+    String(artifact.matchedProbeCount),
+    artifact.matchedProbes.join(";"),
+    String(artifact.unmatchedProbeCount),
+    artifact.unmatchedProbes.join(";"),
     String(artifact.optionCount),
     artifact.options.join(";"),
     String(artifact.datafile.length),

--- a/code/packages/typescript/spice-engine/tests/transient.test.ts
+++ b/code/packages/typescript/spice-engine/tests/transient.test.ts
@@ -2072,7 +2072,7 @@ set wr_singlescale
 set appendwrite
 .set WR_VECNAMES
 write out.raw V(in)
-wrdata out.dat V(in)
+wrdata out.dat V(in) V(missing)
 source other.cir
 cd /tmp
 if v(in) > 0
@@ -2092,7 +2092,10 @@ let gain = 2
     const codeList = expectedCodes.join(";");
     const expectedControlLines = [".save V(in)", ".probe V(in)"];
     const controlLineList = expectedControlLines.join(";");
-    const expectedWriteMarkers = ["write out.raw V(in)", "wrdata out.dat V(in)"];
+    const expectedWriteMarkers = [
+      "write out.raw V(in)",
+      "wrdata out.dat V(in) V(missing)",
+    ];
     const writeMarkerList = expectedWriteMarkers.join(";");
     const expectedRawfileOptions = [
       "set filetype=ascii",
@@ -2142,15 +2145,23 @@ let gain = 2
     );
     expect(execution.wrdataArtifactCount).toBe(1);
     expect(execution.wrdataArtifacts[0]?.target).toBe("out.dat");
-    expect(execution.wrdataArtifacts[0]?.marker).toBe("wrdata out.dat V(in)");
-    expect(execution.wrdataArtifacts[0]?.probeCount).toBe(1);
-    expect(execution.wrdataArtifacts[0]?.probes).toEqual(["V(in)"]);
+    expect(execution.wrdataArtifacts[0]?.marker).toBe(
+      "wrdata out.dat V(in) V(missing)",
+    );
+    expect(execution.wrdataArtifacts[0]?.probeCount).toBe(2);
+    expect(execution.wrdataArtifacts[0]?.probes).toEqual(["V(in)", "V(missing)"]);
+    expect(execution.wrdataArtifacts[0]?.matchedProbeCount).toBe(1);
+    expect(execution.wrdataArtifacts[0]?.matchedProbes).toEqual(["V(in)"]);
+    expect(execution.wrdataArtifacts[0]?.unmatchedProbeCount).toBe(1);
+    expect(execution.wrdataArtifacts[0]?.unmatchedProbes).toEqual(["V(missing)"]);
     expect(execution.wrdataArtifacts[0]?.optionCount).toBe(expectedRawfileOptions.length);
     expect(execution.wrdataArtifacts[0]?.options).toEqual(expectedRawfileOptions);
     expect(execution.wrdataArtifacts[0]?.datafile).toContain(
       "# SPICE deck wrdata artifact\n",
     );
-    expect(execution.wrdataArtifacts[0]?.datafile).toContain("Probes: V(in)\n");
+    expect(execution.wrdataArtifacts[0]?.datafile).toContain(
+      "Probes: V(in);V(missing)\n",
+    );
     expect(execution.wrdataArtifacts[0]?.datafile).toContain(
       `Options: ${rawfileOptionList}\n`,
     );
@@ -2162,9 +2173,13 @@ let gain = 2
     expect(execution.wrdataArtifacts[0]?.datafile).toContain("0\t1.000000e+00\n");
     const wrdataRecord = execution.wrdataArtifactRecords[0]!;
     expect(wrdataRecord["Target"]).toBe("out.dat");
-    expect(wrdataRecord["Marker"]).toBe("wrdata out.dat V(in)");
-    expect(wrdataRecord["Probes"]).toBe("1");
-    expect(wrdataRecord["ProbeList"]).toBe("V(in)");
+    expect(wrdataRecord["Marker"]).toBe("wrdata out.dat V(in) V(missing)");
+    expect(wrdataRecord["Probes"]).toBe("2");
+    expect(wrdataRecord["ProbeList"]).toBe("V(in);V(missing)");
+    expect(wrdataRecord["MatchedProbes"]).toBe("1");
+    expect(wrdataRecord["MatchedProbeList"]).toBe("V(in)");
+    expect(wrdataRecord["UnmatchedProbes"]).toBe("1");
+    expect(wrdataRecord["UnmatchedProbeList"]).toBe("V(missing)");
     expect(wrdataRecord["Options"]).toBe(String(expectedRawfileOptions.length));
     expect(wrdataRecord["RawfileOptionList"]).toBe(rawfileOptionList);
     expect(wrdataRecord["Bytes"]).toBe(String(execution.wrdataArtifacts[0]?.datafile.length));
@@ -2177,10 +2192,11 @@ let gain = 2
     expect(execution.wrdataArtifactJson).toBe(
       formatDeckWrdataArtifactJson(execution.wrdataArtifacts),
     );
-    expect(JSON.parse(execution.wrdataArtifactJson)[0].ProbeList).toBe("V(in)");
-    expect(JSON.parse(execution.wrdataArtifactJson)[0].RawfileOptionList).toBe(
-      rawfileOptionList,
-    );
+    const wrdataJson = JSON.parse(execution.wrdataArtifactJson)[0];
+    expect(wrdataJson.ProbeList).toBe("V(in);V(missing)");
+    expect(wrdataJson.MatchedProbeList).toBe("V(in)");
+    expect(wrdataJson.UnmatchedProbeList).toBe("V(missing)");
+    expect(wrdataJson.RawfileOptionList).toBe(rawfileOptionList);
     expect(execution.diagnosticCount).toBe(expectedCodes.length);
     expect(execution.diagnosticCodes).toEqual(expectedCodes);
     expect(execution.runArtifacts[0]?.controlLineCount).toBe(expectedControlLines.length);

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -125,7 +125,8 @@ downstream tools to compare.
      carry accepted rawfile/data-write option inventories plus deterministic
      `wr_vecnames` / `wr_singlescale` rendering metadata, and explicit
      `wrdata` probe lists now select the emitted in-memory data-file columns
-     while filesystem writes remain metadata-only.
+     and carry matched/unmatched probe inventories while filesystem writes
+     remain metadata-only.
    - Expand remaining deck-controlled analyses toward full SPICE compatibility
      while keeping unsupported control-flow diagnostics explicit.
 
@@ -1070,6 +1071,14 @@ downstream tools to compare.
     - In-memory WRDATA data files preserve the scale column plus requested
       matching probe columns in marker order, while filesystem writes remain
       metadata-only.
+
+98. Deck WRDATA unmatched probe artifact inventories.
+    - Status: completed in this deck WRDATA unmatched probe artifact slice.
+    - Python, Rust, and TypeScript WRDATA artifact summaries now expose stable
+      matched and unmatched probe counts/lists beside the requested probe list.
+    - Stable WRDATA artifact table, CSV, compact JSON, and host-native record
+      exports make ignored `wrdata` probe names auditable while keeping
+      filesystem writes metadata-only.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- Add matched and unmatched probe inventories to Python, Rust, and TypeScript WRDATA artifact shapes.
- Extend stable WRDATA artifact table, CSV, JSON, and record exports with matched/unmatched probe count/list columns.
- Cover a `wrdata` marker with one emitted probe and one ignored probe across the cross-language deck execution tests, and mark the SPICE plan slice complete.

## Verification
- `/Users/adhithya/.local/share/mise/installs/python/3.12.13/bin/python -m ruff check code/packages/python/spice-engine/src/spice_engine/engine.py code/packages/python/spice-engine/tests/test_engine.py`
- `PYTHONPATH="/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-spice-deck-wrdata-unknown-probe-artifacts/code/packages/python/spice-engine/src:/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-spice-deck-wrdata-unknown-probe-artifacts/code/packages/python/spice-netlist-parser/src:/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-spice-deck-wrdata-unknown-probe-artifacts/code/packages/python/mosfet-models/src:/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-spice-deck-wrdata-unknown-probe-artifacts/code/packages/python/device-physics/src" /Users/adhithya/.local/share/mise/installs/python/3.12.13/bin/python -m pytest code/packages/python/spice-engine/tests/test_engine.py`
- `cargo fmt --manifest-path code/packages/rust/spice-engine/Cargo.toml -- --check && cargo test --manifest-path code/packages/rust/spice-engine/Cargo.toml`
- `npm --prefix code/packages/typescript/spice-engine test`
- `npm --prefix code/packages/typescript/spice-engine run build`
- `git diff --check`