### PR TITLE
feat(mycin-immuno): ground type II hypersensitivity (IgG/IgM) + X-linked SCID (IL2RG)

### DIFF
--- a/code/specs/data/mycin-2026/recall/immuno-edges.adj
+++ b/code/specs/data/mycin-2026/recall/immuno-edges.adj
@@ -85,4 +85,18 @@ rulebook immuno_facts {
         source "Type III or immune complex-mediated hypersensitivity: Circulating antigen-antibody complexes deposit in tissues, activating complement and recruiting neutrophils, leading to inflammation and tissue injury, causing conditions such as serum sickness, systemic lupus erythematosus (SLE), post-streptococcal glomerulonephritis (PSGN), and hypersensitivity vasculitides such as IgA vasculitis or cryoglobulinemia."
         locator "https://www.ncbi.nlm.nih.gov/books/NBK559122/"
         trust authoritative
+
+    % --- EXPAND: type II hypersensitivity is antibody (IgG/IgM)-mediated --------
+    % One span names the reaction AND its IgG/IgM antibody effector.
+    relate mediated_by(type_ii_hypersensitivity, igg_igm_antibodies)
+        source "Type II hypersensitivity reactions are antibody-mediated immune processes in which immunoglobulin G (IgG) or immunoglobulin M (IgM) antibodies bind to antigens on cell surfaces or within the extracellular matrix."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK563264/"
+        trust authoritative
+
+    % --- EXPAND: X-linked SCID molecular lesion is the IL2RG gene --------------
+    % One span names the disorder AND the mutated gene (common gamma chain).
+    relate gene_defect(x_linked_scid, il2rg)
+        source "X-SCID results from mutations in the IL2RG gene encoding the common gamma chain cytokine receptor subunit, which is essential for multiple interleukin signaling pathways."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK562182/"
+        trust authoritative
 }

--- a/code/specs/data/mycin-2026/recall/immuno-recall.query.adj
+++ b/code/specs/data/mycin-2026/recall/immuno-recall.query.adj
@@ -22,3 +22,5 @@ import "immuno-edges.adj"
 ? gene_defect(digeorge_syndrome, $Gene)                    % expect chromosome_22q11_2_deletion
 ? associated_hla(celiac_disease, $HLA)                 % expect hla_dq2 (expand)
 ? mediated_by(type_iii_hypersensitivity, $Mediator)    % expect immune_complexes (expand)
+? mediated_by(type_ii_hypersensitivity, $Mediator)     % expect igg_igm_antibodies (expand)
+? gene_defect(x_linked_scid, $Gene)                    % expect il2rg (expand)

--- a/code/specs/data/mycin-2026/recall/test_immuno_recall.py
+++ b/code/specs/data/mycin-2026/recall/test_immuno_recall.py
@@ -39,6 +39,8 @@ EXPECTED = [
     ("digeorge_syndrome", "gene_defect", "chromosome_22q11_2_deletion"),
     ("celiac_disease", "associated_hla", "hla_dq2"),                 # expand (NBK441900)
     ("type_iii_hypersensitivity", "mediated_by", "immune_complexes"),  # expand (NBK559122)
+    ("type_ii_hypersensitivity", "mediated_by", "igg_igm_antibodies"),  # expand (NBK563264)
+    ("x_linked_scid", "gene_defect", "il2rg"),                       # expand (NBK562182)
 ]
 VAR = {"mediated_by": "Mediator", "associated_hla": "HLA",
        "gene_defect": "Gene", "deficiency_of": "Component"}


### PR DESCRIPTION
## What

Two more grounded immunology edges:

- **mediated_by(type_ii_hypersensitivity, igg_igm_antibodies)** [NBK563264]:
  > Type II hypersensitivity reactions are antibody-mediated immune processes in which immunoglobulin G (IgG) or immunoglobulin M (IgM) antibodies bind to antigens on cell surfaces or within the extracellular matrix.
- **gene_defect(x_linked_scid, il2rg)** [NBK562182]:
  > X-SCID results from mutations in the IL2RG gene encoding the common gamma chain cytokine receptor subunit, which is essential for multiple interleukin signaling pathways.

Each span names both endpoints in one self-contained authoritative sentence.

## Changes (data-only)
- `immuno-edges.adj` +2 `relate`; `immuno-recall.query.adj` +2; `test_immuno_recall.py` EXPECTED +2 (`rheumatoid_arthritis` negative control unchanged)

## Verification
- `test_immuno_recall: 3/3 passed`; ruff clean; data-only security review passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)