### PR TITLE
feat(mycin-micro): ground Clostridioides difficile (gram-positive; pseudomembranous colitis)

### DIFF
--- a/code/specs/data/mycin-2026/recall/micro-edges.adj
+++ b/code/specs/data/mycin-2026/recall/micro-edges.adj
@@ -127,4 +127,15 @@ rulebook micro_facts {
         source "H. pylori is the most important cause for chronic or atrophic gastritis, peptic ulcer, gastric lymphoma, and gastric carcinoma"
         locator "https://www.ncbi.nlm.nih.gov/books/NBK534233/"
         trust authoritative
+
+    % --- Clostridioides difficile (gram-positive; causes pseudomembranous colitis) ---
+    % One span names the gram reaction; a second names the disease it causes.
+    relate gram_stain(clostridioides_difficile, gram_positive)
+        source "Clostridioides difficile, formerly Clostridium difficile, is a gram-positive and spore-forming bacterium."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK431054/"
+        trust authoritative
+    relate causes(clostridioides_difficile, pseudomembranous_colitis)
+        source "Diarrhea and pseudomembranous colitis, characteristic symptoms of C difficile infection, result from clostridial glycosylation exotoxins—toxin A (TcdA), an enterotoxin, and toxin B (TcdB), which is cytotoxic."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK431054/"
+        trust authoritative
 }

--- a/code/specs/data/mycin-2026/recall/micro-recall.query.adj
+++ b/code/specs/data/mycin-2026/recall/micro-recall.query.adj
@@ -23,3 +23,5 @@ import "micro-edges.adj"
 ? gram_stain(helicobacter_pylori, $Result)             % expect gram_negative (expand)
 ? morphology(helicobacter_pylori, $Shape)              % expect spiral (expand)
 ? causes(helicobacter_pylori, $Disease)                % expect peptic_ulcer_disease (expand)
+? gram_stain(clostridioides_difficile, $Result)        % expect gram_positive (expand)
+? causes(clostridioides_difficile, $Disease)           % expect pseudomembranous_colitis (expand)

--- a/code/specs/data/mycin-2026/recall/test_micro_recall.py
+++ b/code/specs/data/mycin-2026/recall/test_micro_recall.py
@@ -48,6 +48,8 @@ EXPECTED = [
     ("helicobacter_pylori", "gram_stain", "gram_negative"),          # expand (NBK534233)
     ("helicobacter_pylori", "morphology", "spiral"),                 # expand (NBK534233)
     ("helicobacter_pylori", "causes", "peptic_ulcer_disease"),       # expand (NBK534233)
+    ("clostridioides_difficile", "gram_stain", "gram_positive"),      # expand (NBK431054)
+    ("clostridioides_difficile", "causes", "pseudomembranous_colitis"),  # expand (NBK431054)
 ]
 
 


### PR DESCRIPTION
## What
New microbiology organism — two grounded edges from StatPearls NBK431054:

- **gram_stain(clostridioides_difficile, gram_positive)**:
  > Clostridioides difficile, formerly Clostridium difficile, is a gram-positive and spore-forming bacterium.
- **causes(clostridioides_difficile, pseudomembranous_colitis)**:
  > Diarrhea and pseudomembranous colitis, characteristic symptoms of C difficile infection, result from clostridial glycosylation exotoxins…

## Changes (data-only)
- `micro-edges.adj` +2 `relate`; `micro-recall.query.adj` +2; `test_micro_recall.py` EXPECTED +2 (`treponema_pallidum` negative control unchanged)

## Verification
- `test_micro_recall: 3/3 passed`; ruff clean; data-only security review passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)