### PR TITLE
feat(mycin-genetics): ground Wilson disease (autosomal recessive; ATP7B)

### DIFF
--- a/code/specs/data/mycin-2026/recall/genetics-edges.adj
+++ b/code/specs/data/mycin-2026/recall/genetics-edges.adj
@@ -138,4 +138,14 @@ rulebook genetics_facts {
         source "Friedreich ataxia is an autosomal recessive neurodegenerative disorder caused by guanine-adenine-adenine repeat expansion in the frataxin gene, leading to mitochondrial dysfunction."
         locator "https://www.ncbi.nlm.nih.gov/books/NBK563199/"
         trust authoritative
+
+    % --- EXPAND: Wilson disease (autosomal recessive; ATP7B) — one span names both ----
+    relate inheritance(wilson_disease, autosomal_recessive)
+        source "Wilson disease is an autosomal recessive condition caused by 1 of several mutations in ATP7B gene which encodes the ATP7B protein transporter on the long arm of chromosome 13 (13q) responsible for excreting excess copper into bile and out of the body."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK441990/"
+        trust authoritative
+    relate gene_defect(wilson_disease, atp7b)
+        source "Wilson disease is an autosomal recessive condition caused by 1 of several mutations in ATP7B gene which encodes the ATP7B protein transporter on the long arm of chromosome 13 (13q) responsible for excreting excess copper into bile and out of the body."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK441990/"
+        trust authoritative
 }

--- a/code/specs/data/mycin-2026/recall/genetics-recall.query.adj
+++ b/code/specs/data/mycin-2026/recall/genetics-recall.query.adj
@@ -31,3 +31,5 @@ import "genetics-edges.adj"
 ? gene_defect(angelman_syndrome, $Gene)                % expect ube3a (expand)
 ? inheritance(friedreich_ataxia, $Pattern)             % expect autosomal_recessive (expand)
 ? trinucleotide_repeat(friedreich_ataxia, $Repeat)     % expect gaa (expand)
+? inheritance(wilson_disease, $Pattern)                % expect autosomal_recessive (expand)
+? gene_defect(wilson_disease, $Gene)                   % expect atp7b (expand)

--- a/code/specs/data/mycin-2026/recall/test_genetics_recall.py
+++ b/code/specs/data/mycin-2026/recall/test_genetics_recall.py
@@ -50,6 +50,8 @@ EXPECTED = [
     ("angelman_syndrome", "gene_defect", "ube3a"),                   # expand (NBK560870)
     ("friedreich_ataxia", "inheritance", "autosomal_recessive"),     # expand (NBK563199)
     ("friedreich_ataxia", "trinucleotide_repeat", "gaa"),            # expand (NBK563199)
+    ("wilson_disease", "inheritance", "autosomal_recessive"),        # expand (NBK441990)
+    ("wilson_disease", "gene_defect", "atp7b"),                      # expand (NBK441990)
 ]
 VAR = {"inheritance": "Pattern", "gene_defect": "Gene",
        "trinucleotide_repeat": "Repeat", "imprinting": "Parent"}


### PR DESCRIPTION
## What
New genetics disease — two grounded edges from one self-contained StatPearls span (NBK441990) that names both endpoints:

- **inheritance(wilson_disease, autosomal_recessive)**
- **gene_defect(wilson_disease, atp7b)**
  > Wilson disease is an autosomal recessive condition caused by 1 of several mutations in ATP7B gene which encodes the ATP7B protein transporter on the long arm of chromosome 13 (13q)…

## Changes (data-only)
- `genetics-edges.adj` +2 `relate`; `genetics-recall.query.adj` +2; `test_genetics_recall.py` EXPECTED +2 (`ehlers_danlos_syndrome` negative control unchanged)

## Verification
- `test_genetics_recall: 3/3 passed`; ruff clean; data-only security review passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)