### PR TITLE
[codex] Add SPICE rawfile probe inventories

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 ### Added
 
+- **Deck rawfile probe inventory artifacts** —
+  selected `run_deck_analysis()` rawfile artifact summaries now carry
+  `MatchedProbes` / `MatchedProbeList` and `UnmatchedProbes` /
+  `UnmatchedProbeList` columns, and `write <rawfile> <probes...>` artifacts now
+  keep only requested matching vector columns in deterministic in-memory
+  rawfile output, matching Rust and TypeScript.
+
 - **Deck WRDATA unmatched probe artifacts** —
   selected `run_deck_analysis()` WRDATA artifact summaries now carry
   `MatchedProbes` / `MatchedProbeList` and `UnmatchedProbes` /

--- a/code/packages/python/spice-engine/README.md
+++ b/code/packages/python/spice-engine/README.md
@@ -66,7 +66,7 @@ print(result.diagnostics.solver)   # "dense_real" or "sparse_real"
 | `format_dc_table`, `format_transient_table` | `.PRINT` / `.PLOT` output | Stable tabular node voltages and branch currents |
 | `resolve_deck_outputs`, `format_deck_*_table`, `format_deck_table_csv`, `format_deck_table_json`, `deck_table_records` | `.SAVE` / `.PROBE` / `.PRINT` / `.PLOT` output | Parsed deck-selected OP, DC sweep, AC, and transient tables plus deterministic CSV/JSON/record conversion |
 | `format_deck_run_artifact_table`, `format_deck_run_artifact_csv`, `format_deck_run_artifact_json` | Deck execution artifact | Stable selected-run row, table, analysis-directive, output-probe, output-directive, measurement, Fourier, control-command, and diagnostic count/name lists |
-| `format_deck_rawfile_ascii`, `format_deck_rawfile_artifact_table`, `format_deck_rawfile_artifact_csv`, `format_deck_rawfile_artifact_json` | `.control write` artifact | Deterministic in-memory ASCII rawfile text plus stable rawfile artifact table/CSV/JSON exports |
+| `format_deck_rawfile_ascii`, `format_deck_rawfile_artifact_table`, `format_deck_rawfile_artifact_csv`, `format_deck_rawfile_artifact_json` | `.control write` artifact | Deterministic in-memory ASCII rawfile text plus stable probe-aware rawfile artifact table/CSV/JSON exports |
 | `format_deck_wrdata_ascii`, `format_deck_wrdata_artifact_table`, `format_deck_wrdata_artifact_csv`, `format_deck_wrdata_artifact_json` | `.control wrdata` artifact | Deterministic in-memory ASCII data-file text plus stable option-aware WRDATA artifact table/CSV/JSON exports |
 | `measure_transient_probe`, `measure_dc_sweep_probe`, `measure_ac_sweep_probe`, `format_measurement_table` | `.MEASURE` output | Stable scalar transient, DC sweep, and AC sweep probe measurements |
 
@@ -125,8 +125,8 @@ Accepted `.control` `write` / `wrdata` rawfile/data-write markers are surfaced
 as `write_marker_count` / `write_markers` execution fields and as
 `WriteMarkers` / `WriteMarkerList` artifact fields without serializing files.
 Accepted `write <rawfile> ...` markers also produce deterministic in-memory
-ASCII rawfile artifacts on `rawfile_artifacts`, with stable table, CSV, JSON,
-and header-keyed record summaries. Accepted `wrdata <file> ...` markers
+ASCII rawfile artifacts on `rawfile_artifacts`, with stable probe-aware table,
+CSV, JSON, and header-keyed record summaries. Accepted `wrdata <file> ...` markers
 produce deterministic in-memory ASCII data-file artifacts on
 `wrdata_artifacts`, with stable table, CSV, JSON, and header-keyed record
 summaries; filesystem writes remain metadata-only.
@@ -136,10 +136,10 @@ Accepted `.control` rawfile output options (`set filetype=ascii`,
 `RawfileOptions` / `RawfileOptionList` artifact fields. WRDATA artifacts also
 carry the same option inventories and render `wr_vecnames` / `wr_singlescale`
 intent as stable `VectorNames` / `Scale` metadata in the in-memory data file.
-When a `wrdata` marker names probes, its data file keeps the scale column plus
-only the requested matching probe columns, while WRDATA artifact summaries keep
-matched and unmatched probe inventories in stable table, CSV, JSON, and record
-exports.
+When a `write` or `wrdata` marker names probes, its in-memory artifact keeps
+the scale column plus only the requested matching probe columns, while artifact
+summaries keep matched and unmatched probe inventories in stable table, CSV,
+JSON, and record exports.
 Existing `.control` body policy diagnostics flow into those selected-run
 artifact `Diagnostics` / `DiagnosticCodeList` fields and through the same
 run-artifact table, CSV, JSON, and `table_artifacts` records.

--- a/code/packages/python/spice-engine/src/spice_engine/engine.py
+++ b/code/packages/python/spice-engine/src/spice_engine/engine.py
@@ -2380,6 +2380,10 @@ class DeckRawfileArtifact:
     marker: str
     probe_count: int
     probes: list[str]
+    matched_probe_count: int
+    matched_probes: list[str]
+    unmatched_probe_count: int
+    unmatched_probes: list[str]
     option_count: int
     options: list[str]
     rawfile: str
@@ -2876,11 +2880,22 @@ def format_deck_rawfile_ascii(
 ) -> str:
     """Format a selected deck table as deterministic in-memory ASCII rawfile text."""
 
+    return _format_deck_rawfile_ascii(table, analysis, rawfile_options, ())
+
+
+def _format_deck_rawfile_ascii(
+    table: str,
+    analysis: str,
+    rawfile_options: Iterable[str],
+    probes: Iterable[str],
+) -> str:
     rows = table.splitlines()
     if not rows:
         return ""
-    columns = rows[0].split("\t")
-    data_rows = [row.split("\t") for row in rows[1:]]
+    probe_list = list(probes)
+    projected_rows = _deck_rawfile_project_rows(rows, probe_list)
+    columns = projected_rows[0].split("\t")
+    data_rows = [row.split("\t") for row in projected_rows[1:]]
     lines = [
         f"Title: SPICE deck {analysis} result",
         "Date: deterministic",
@@ -2900,6 +2915,45 @@ def format_deck_rawfile_ascii(
     return "\n".join(lines) + "\n"
 
 
+def _deck_rawfile_project_rows(rows: list[str], probes: list[str]) -> list[str]:
+    columns = rows[0].split("\t")
+    if not probes:
+        return rows
+    selected_indices, _, _ = _deck_rawfile_probe_inventory(columns, probes)
+    projected_rows: list[str] = []
+    for row in rows:
+        cells = row.split("\t")
+        projected_rows.append(
+            "\t".join(
+                cells[index] if index < len(cells) else ""
+                for index in selected_indices
+            )
+        )
+    return projected_rows
+
+
+def _deck_rawfile_probe_inventory(
+    columns: list[str],
+    probes: list[str],
+) -> tuple[list[int], list[str], list[str]]:
+    selected_indices: list[int] = []
+    matched_probes: list[str] = []
+    unmatched_probes: list[str] = []
+    if columns:
+        selected_indices.append(0)
+    normalized_columns = [column.casefold() for column in columns]
+    for probe in probes:
+        normalized_probe = probe.casefold()
+        if normalized_probe not in normalized_columns:
+            unmatched_probes.append(probe)
+            continue
+        index = normalized_columns.index(normalized_probe)
+        if index not in selected_indices:
+            selected_indices.append(index)
+            matched_probes.append(columns[index])
+    return selected_indices, matched_probes, unmatched_probes
+
+
 def _deck_write_marker_parts(marker: str) -> tuple[str, list[str]] | None:
     parts = marker.split()
     if len(parts) < 2 or parts[0] != "write":
@@ -2914,22 +2968,30 @@ def _deck_rawfile_artifacts(
     rawfile_options: Iterable[str],
 ) -> list[DeckRawfileArtifact]:
     options = list(rawfile_options)
-    rawfile = format_deck_rawfile_ascii(table, plan.analysis, options)
+    rows = table.splitlines()
+    columns = rows[0].split("\t") if rows else []
     artifacts: list[DeckRawfileArtifact] = []
     for marker in write_markers:
         parts = _deck_write_marker_parts(marker)
         if parts is None:
             continue
         target, probes = parts
+        _, matched_probes, unmatched_probes = _deck_rawfile_probe_inventory(
+            columns, probes
+        )
         artifacts.append(
             DeckRawfileArtifact(
                 target=target,
                 marker=marker,
                 probe_count=len(probes),
                 probes=probes,
+                matched_probe_count=len(matched_probes),
+                matched_probes=matched_probes,
+                unmatched_probe_count=len(unmatched_probes),
+                unmatched_probes=unmatched_probes,
                 option_count=len(options),
                 options=list(options),
-                rawfile=rawfile,
+                rawfile=_format_deck_rawfile_ascii(table, plan.analysis, options, probes),
             )
         )
     return artifacts
@@ -2940,6 +3002,10 @@ _DECK_RAWFILE_ARTIFACT_COLUMNS = [
     "Marker",
     "Probes",
     "ProbeList",
+    "MatchedProbes",
+    "MatchedProbeList",
+    "UnmatchedProbes",
+    "UnmatchedProbeList",
     "Options",
     "RawfileOptionList",
     "Bytes",
@@ -2952,6 +3018,10 @@ def _deck_rawfile_artifact_cells(artifact: DeckRawfileArtifact) -> list[str]:
         artifact.marker,
         str(artifact.probe_count),
         ";".join(artifact.probes),
+        str(artifact.matched_probe_count),
+        ";".join(artifact.matched_probes),
+        str(artifact.unmatched_probe_count),
+        ";".join(artifact.unmatched_probes),
         str(artifact.option_count),
         ";".join(artifact.options),
         str(len(artifact.rawfile.encode())),

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -7402,7 +7402,7 @@ set wr_vecnames
 set wr_singlescale
 set appendwrite
 .set WR_VECNAMES
-write out.raw V(in)
+write out.raw V(in) V(missing)
 wrdata out.dat V(in) V(missing)
 source other.cir
 cd /tmp
@@ -7424,7 +7424,7 @@ let gain = 2
     expected_control_lines = [".save V(in)", ".probe V(in)"]
     control_line_list = ";".join(expected_control_lines)
     expected_write_markers = [
-        "write out.raw V(in)",
+        "write out.raw V(in) V(missing)",
         "wrdata out.dat V(in) V(missing)",
     ]
     write_marker_list = ";".join(expected_write_markers)
@@ -7445,9 +7445,13 @@ let gain = 2
     assert execution.rawfile_options == expected_rawfile_options
     assert execution.rawfile_artifact_count == 1
     assert execution.rawfile_artifacts[0].target == "out.raw"
-    assert execution.rawfile_artifacts[0].marker == "write out.raw V(in)"
-    assert execution.rawfile_artifacts[0].probe_count == 1
-    assert execution.rawfile_artifacts[0].probes == ["V(in)"]
+    assert execution.rawfile_artifacts[0].marker == "write out.raw V(in) V(missing)"
+    assert execution.rawfile_artifacts[0].probe_count == 2
+    assert execution.rawfile_artifacts[0].probes == ["V(in)", "V(missing)"]
+    assert execution.rawfile_artifacts[0].matched_probe_count == 1
+    assert execution.rawfile_artifacts[0].matched_probes == ["V(in)"]
+    assert execution.rawfile_artifacts[0].unmatched_probe_count == 1
+    assert execution.rawfile_artifacts[0].unmatched_probes == ["V(missing)"]
     assert execution.rawfile_artifacts[0].option_count == len(
         expected_rawfile_options
     )
@@ -7458,9 +7462,13 @@ let gain = 2
     assert "0\t0\t1.000000e+00\n" in execution.rawfile_artifacts[0].rawfile
     rawfile_record = execution.rawfile_artifact_records[0]
     assert rawfile_record["Target"] == "out.raw"
-    assert rawfile_record["Marker"] == "write out.raw V(in)"
-    assert rawfile_record["Probes"] == "1"
-    assert rawfile_record["ProbeList"] == "V(in)"
+    assert rawfile_record["Marker"] == "write out.raw V(in) V(missing)"
+    assert rawfile_record["Probes"] == "2"
+    assert rawfile_record["ProbeList"] == "V(in);V(missing)"
+    assert rawfile_record["MatchedProbes"] == "1"
+    assert rawfile_record["MatchedProbeList"] == "V(in)"
+    assert rawfile_record["UnmatchedProbes"] == "1"
+    assert rawfile_record["UnmatchedProbeList"] == "V(missing)"
     assert rawfile_record["Options"] == str(len(expected_rawfile_options))
     assert rawfile_record["RawfileOptionList"] == rawfile_option_list
     assert rawfile_record["Bytes"] == str(
@@ -7478,6 +7486,10 @@ let gain = 2
     assert json.loads(execution.rawfile_artifact_json)[0]["RawfileOptionList"] == (
         rawfile_option_list
     )
+    rawfile_json = json.loads(execution.rawfile_artifact_json)[0]
+    assert rawfile_json["ProbeList"] == "V(in);V(missing)"
+    assert rawfile_json["MatchedProbeList"] == "V(in)"
+    assert rawfile_json["UnmatchedProbeList"] == "V(missing)"
     assert execution.wrdata_artifact_count == 1
     assert execution.wrdata_artifacts[0].target == "out.dat"
     assert execution.wrdata_artifacts[0].marker == "wrdata out.dat V(in) V(missing)"

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- Carry matched and unmatched `write <rawfile> <probes...>` probe inventories
+  through rawfile artifact `MatchedProbes` / `MatchedProbeList` and
+  `UnmatchedProbes` / `UnmatchedProbeList` summary columns, and keep only
+  requested matching vector columns in deterministic in-memory rawfile output,
+  matching Python and TypeScript.
 - Carry matched and unmatched `wrdata <file> <probes...>` probe inventories
   through WRDATA artifact `MatchedProbes` / `MatchedProbeList` and
   `UnmatchedProbes` / `UnmatchedProbeList` summary columns, matching Python and

--- a/code/packages/rust/spice-engine/README.md
+++ b/code/packages/rust/spice-engine/README.md
@@ -198,8 +198,8 @@ Accepted `.control` `write` / `wrdata` rawfile/data-write markers are surfaced
 as `write_marker_count` / `write_markers` execution fields and as
 `WriteMarkers` / `WriteMarkerList` artifact fields without serializing files.
 Accepted `write <rawfile> ...` markers also produce deterministic in-memory
-ASCII rawfile artifacts on `rawfile_artifacts`, with stable table, CSV, JSON,
-and header-keyed record summaries. Accepted `wrdata <file> ...` markers
+ASCII rawfile artifacts on `rawfile_artifacts`, with stable probe-aware table,
+CSV, JSON, and header-keyed record summaries. Accepted `wrdata <file> ...` markers
 produce deterministic in-memory ASCII data-file artifacts on
 `wrdata_artifacts`, with stable table, CSV, JSON, and header-keyed record
 summaries; filesystem writes remain metadata-only.
@@ -209,10 +209,10 @@ Accepted `.control` rawfile output options (`set filetype=ascii`,
 `RawfileOptions` / `RawfileOptionList` artifact fields. WRDATA artifacts also
 carry the same option inventories and render `wr_vecnames` / `wr_singlescale`
 intent as stable `VectorNames` / `Scale` metadata in the in-memory data file.
-When a `wrdata` marker names probes, its data file keeps the scale column plus
-only the requested matching probe columns, while WRDATA artifact summaries keep
-matched and unmatched probe inventories in stable table, CSV, JSON, and record
-exports.
+When a `write` or `wrdata` marker names probes, its in-memory artifact keeps
+the scale column plus only the requested matching probe columns, while artifact
+summaries keep matched and unmatched probe inventories in stable table, CSV,
+JSON, and record exports.
 Existing `.control` body policy diagnostics flow into those selected-run artifact `Diagnostics` /
 `DiagnosticCodeList` fields and through the same run-artifact table, CSV, JSON,
 and `table_artifacts` records. `format_deck_table_csv` also converts any stable

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -3464,6 +3464,10 @@ pub struct DeckRawfileArtifact {
     pub marker: String,
     pub probe_count: usize,
     pub probes: Vec<String>,
+    pub matched_probe_count: usize,
+    pub matched_probes: Vec<String>,
+    pub unmatched_probe_count: usize,
+    pub unmatched_probes: Vec<String>,
     pub option_count: usize,
     pub options: Vec<String>,
     pub rawfile: String,
@@ -10554,12 +10558,22 @@ pub fn format_deck_rawfile_ascii(
     analysis: &str,
     rawfile_options: &[String],
 ) -> String {
+    format_deck_rawfile_ascii_with_probes(table, analysis, rawfile_options, &[])
+}
+
+fn format_deck_rawfile_ascii_with_probes(
+    table: &str,
+    analysis: &str,
+    rawfile_options: &[String],
+    probes: &[String],
+) -> String {
     let rows = table.lines().collect::<Vec<_>>();
-    let Some(header) = rows.first() else {
+    if rows.is_empty() {
         return String::new();
-    };
-    let columns = header.split('\t').collect::<Vec<_>>();
-    let data_rows = rows
+    }
+    let projected_rows = deck_rawfile_project_rows(&rows, probes);
+    let columns = projected_rows[0].split('\t').collect::<Vec<_>>();
+    let data_rows = projected_rows
         .iter()
         .skip(1)
         .map(|row| row.split('\t').collect::<Vec<_>>())
@@ -10589,6 +10603,50 @@ pub fn format_deck_rawfile_ascii(
     format!("{}\n", lines.join("\n"))
 }
 
+fn deck_rawfile_project_rows(rows: &[&str], probes: &[String]) -> Vec<String> {
+    let columns = rows[0].split('\t').collect::<Vec<_>>();
+    if probes.is_empty() {
+        return rows.iter().map(|row| (*row).to_string()).collect();
+    }
+    let (selected_indices, _, _) = deck_rawfile_probe_inventory(&columns, probes);
+    rows.iter()
+        .map(|row| {
+            let cells = row.split('\t').collect::<Vec<_>>();
+            selected_indices
+                .iter()
+                .map(|index| cells.get(*index).copied().unwrap_or(""))
+                .collect::<Vec<_>>()
+                .join("\t")
+        })
+        .collect()
+}
+
+fn deck_rawfile_probe_inventory(
+    columns: &[&str],
+    probes: &[String],
+) -> (Vec<usize>, Vec<String>, Vec<String>) {
+    let mut selected_indices = Vec::new();
+    let mut matched_probes = Vec::new();
+    let mut unmatched_probes = Vec::new();
+    if !columns.is_empty() {
+        selected_indices.push(0);
+    }
+    for probe in probes {
+        if let Some(index) = columns
+            .iter()
+            .position(|column| column.eq_ignore_ascii_case(probe))
+        {
+            if !selected_indices.contains(&index) {
+                selected_indices.push(index);
+                matched_probes.push(columns[index].to_string());
+            }
+        } else {
+            unmatched_probes.push(probe.clone());
+        }
+    }
+    (selected_indices, matched_probes, unmatched_probes)
+}
+
 fn deck_write_marker_parts(marker: &str) -> Option<(String, Vec<String>)> {
     let parts = marker.split_whitespace().collect::<Vec<_>>();
     if parts.len() < 2 || parts[0] != "write" {
@@ -10610,19 +10668,35 @@ fn deck_rawfile_artifacts(
     write_markers: &[String],
     rawfile_options: &[String],
 ) -> Vec<DeckRawfileArtifact> {
-    let rawfile = format_deck_rawfile_ascii(table, &plan.analysis, rawfile_options);
+    let rows = table.lines().collect::<Vec<_>>();
+    let columns = rows
+        .first()
+        .map(|row| row.split('\t').collect::<Vec<_>>())
+        .unwrap_or_default();
     write_markers
         .iter()
         .filter_map(|marker| {
             let (target, probes) = deck_write_marker_parts(marker)?;
+            let (_, matched_probes, unmatched_probes) =
+                deck_rawfile_probe_inventory(&columns, &probes);
+            let rawfile = format_deck_rawfile_ascii_with_probes(
+                table,
+                &plan.analysis,
+                rawfile_options,
+                &probes,
+            );
             Some(DeckRawfileArtifact {
                 target,
                 marker: marker.clone(),
                 probe_count: probes.len(),
+                matched_probe_count: matched_probes.len(),
+                matched_probes,
+                unmatched_probe_count: unmatched_probes.len(),
+                unmatched_probes,
                 probes,
                 option_count: rawfile_options.len(),
                 options: rawfile_options.to_vec(),
-                rawfile: rawfile.clone(),
+                rawfile,
             })
         })
         .collect()
@@ -10633,6 +10707,10 @@ const DECK_RAWFILE_ARTIFACT_COLUMNS: &[&str] = &[
     "Marker",
     "Probes",
     "ProbeList",
+    "MatchedProbes",
+    "MatchedProbeList",
+    "UnmatchedProbes",
+    "UnmatchedProbeList",
     "Options",
     "RawfileOptionList",
     "Bytes",
@@ -10644,6 +10722,10 @@ fn deck_rawfile_artifact_cells(artifact: &DeckRawfileArtifact) -> Vec<String> {
         artifact.marker.clone(),
         artifact.probe_count.to_string(),
         artifact.probes.join(";"),
+        artifact.matched_probe_count.to_string(),
+        artifact.matched_probes.join(";"),
+        artifact.unmatched_probe_count.to_string(),
+        artifact.unmatched_probes.join(";"),
         artifact.option_count.to_string(),
         artifact.options.join(";"),
         artifact.rawfile.len().to_string(),

--- a/code/packages/rust/spice-engine/tests/transient_tests.rs
+++ b/code/packages/rust/spice-engine/tests/transient_tests.rs
@@ -2761,7 +2761,7 @@ set wr_vecnames
 set wr_singlescale
 set appendwrite
 .set WR_VECNAMES
-write out.raw V(in)
+write out.raw V(in) V(missing)
 wrdata out.dat V(in) V(missing)
 source other.cir
 cd /tmp
@@ -2783,7 +2783,7 @@ let gain = 2
     let expected_control_lines = vec![".save V(in)".to_string(), ".probe V(in)".to_string()];
     let control_line_list = expected_control_lines.join(";");
     let expected_write_markers = vec![
-        "write out.raw V(in)".to_string(),
+        "write out.raw V(in) V(missing)".to_string(),
         "wrdata out.dat V(in) V(missing)".to_string(),
     ];
     let write_marker_list = expected_write_markers.join(";");
@@ -2808,9 +2808,22 @@ let gain = 2
     assert_eq!(execution.rawfile_options, expected_rawfile_options);
     assert_eq!(execution.rawfile_artifact_count, 1);
     assert_eq!(execution.rawfile_artifacts[0].target, "out.raw");
-    assert_eq!(execution.rawfile_artifacts[0].marker, "write out.raw V(in)");
-    assert_eq!(execution.rawfile_artifacts[0].probe_count, 1);
-    assert_eq!(execution.rawfile_artifacts[0].probes, vec!["V(in)"]);
+    assert_eq!(
+        execution.rawfile_artifacts[0].marker,
+        "write out.raw V(in) V(missing)"
+    );
+    assert_eq!(execution.rawfile_artifacts[0].probe_count, 2);
+    assert_eq!(
+        execution.rawfile_artifacts[0].probes,
+        vec!["V(in)", "V(missing)"]
+    );
+    assert_eq!(execution.rawfile_artifacts[0].matched_probe_count, 1);
+    assert_eq!(execution.rawfile_artifacts[0].matched_probes, vec!["V(in)"]);
+    assert_eq!(execution.rawfile_artifacts[0].unmatched_probe_count, 1);
+    assert_eq!(
+        execution.rawfile_artifacts[0].unmatched_probes,
+        vec!["V(missing)"]
+    );
     assert_eq!(
         execution.rawfile_artifacts[0].option_count,
         expected_rawfile_options.len()
@@ -2841,7 +2854,43 @@ let gain = 2
         execution.rawfile_artifact_records[0]
             .get("Marker")
             .map(String::as_str),
-        Some("write out.raw V(in)")
+        Some("write out.raw V(in) V(missing)")
+    );
+    assert_eq!(
+        execution.rawfile_artifact_records[0]
+            .get("Probes")
+            .map(String::as_str),
+        Some("2")
+    );
+    assert_eq!(
+        execution.rawfile_artifact_records[0]
+            .get("ProbeList")
+            .map(String::as_str),
+        Some("V(in);V(missing)")
+    );
+    assert_eq!(
+        execution.rawfile_artifact_records[0]
+            .get("MatchedProbes")
+            .map(String::as_str),
+        Some("1")
+    );
+    assert_eq!(
+        execution.rawfile_artifact_records[0]
+            .get("MatchedProbeList")
+            .map(String::as_str),
+        Some("V(in)")
+    );
+    assert_eq!(
+        execution.rawfile_artifact_records[0]
+            .get("UnmatchedProbes")
+            .map(String::as_str),
+        Some("1")
+    );
+    assert_eq!(
+        execution.rawfile_artifact_records[0]
+            .get("UnmatchedProbeList")
+            .map(String::as_str),
+        Some("V(missing)")
     );
     assert_eq!(
         execution.rawfile_artifact_records[0]

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- Carry matched and unmatched `write <rawfile> <probes...>` probe inventories
+  through rawfile artifact `MatchedProbes` / `MatchedProbeList` and
+  `UnmatchedProbes` / `UnmatchedProbeList` summary columns, and keep only
+  requested matching vector columns in deterministic in-memory rawfile output,
+  matching Python and Rust.
 - Carry matched and unmatched `wrdata <file> <probes...>` probe inventories
   through WRDATA artifact `MatchedProbes` / `MatchedProbeList` and
   `UnmatchedProbes` / `UnmatchedProbeList` summary columns, matching Python and

--- a/code/packages/typescript/spice-engine/README.md
+++ b/code/packages/typescript/spice-engine/README.md
@@ -114,8 +114,8 @@ Accepted `.control` `write` / `wrdata` rawfile/data-write markers are surfaced
 as `writeMarkerCount` / `writeMarkers` execution fields and as `WriteMarkers` /
 `WriteMarkerList` artifact fields without serializing files.
 Accepted `write <rawfile> ...` markers also produce deterministic in-memory
-ASCII rawfile artifacts on `rawfileArtifacts`, with stable table, CSV, JSON,
-and header-keyed record summaries. Accepted `wrdata <file> ...` markers
+ASCII rawfile artifacts on `rawfileArtifacts`, with stable probe-aware table,
+CSV, JSON, and header-keyed record summaries. Accepted `wrdata <file> ...` markers
 produce deterministic in-memory ASCII data-file artifacts on
 `wrdataArtifacts`, with stable table, CSV, JSON, and header-keyed record
 summaries; filesystem writes remain metadata-only.
@@ -125,10 +125,10 @@ Accepted `.control` rawfile output options (`set filetype=ascii`,
 `RawfileOptions` / `RawfileOptionList` artifact fields. WRDATA artifacts also
 carry the same option inventories and render `wr_vecnames` / `wr_singlescale`
 intent as stable `VectorNames` / `Scale` metadata in the in-memory data file.
-When a `wrdata` marker names probes, its data file keeps the scale column plus
-only the requested matching probe columns, while WRDATA artifact summaries keep
-matched and unmatched probe inventories in stable table, CSV, JSON, and record
-exports.
+When a `write` or `wrdata` marker names probes, its in-memory artifact keeps
+the scale column plus only the requested matching probe columns, while artifact
+summaries keep matched and unmatched probe inventories in stable table, CSV,
+JSON, and record exports.
 Existing
 `.control` body policy diagnostics flow into those selected-run artifact `Diagnostics` /
 `DiagnosticCodeList` fields and through the same run-artifact table, CSV, JSON,

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -717,6 +717,10 @@ export interface DeckRawfileArtifact {
   readonly marker: string;
   readonly probeCount: number;
   readonly probes: readonly string[];
+  readonly matchedProbeCount: number;
+  readonly matchedProbes: readonly string[];
+  readonly unmatchedProbeCount: number;
+  readonly unmatchedProbes: readonly string[];
   readonly optionCount: number;
   readonly options: readonly string[];
   readonly rawfile: string;
@@ -8311,12 +8315,22 @@ export function formatDeckRawfileAscii(
   analysis: DeckAnalysisPlan["analysis"],
   rawfileOptions: readonly string[] = [],
 ): string {
+  return formatDeckRawfileAsciiForProbes(table, analysis, rawfileOptions, []);
+}
+
+function formatDeckRawfileAsciiForProbes(
+  table: string,
+  analysis: DeckAnalysisPlan["analysis"],
+  rawfileOptions: readonly string[],
+  probes: readonly string[],
+): string {
   const rows = deckTableRows(table);
   if (rows.length === 0) {
     return "";
   }
-  const columns = rows[0]!.split("\t");
-  const dataRows = rows.slice(1).map((row) => row.split("\t"));
+  const projectedRows = deckRawfileProjectRows(rows, probes);
+  const columns = projectedRows[0]!.split("\t");
+  const dataRows = projectedRows.slice(1).map((row) => row.split("\t"));
   const lines = [
     `Title: SPICE deck ${analysis} result`,
     "Date: deterministic",
@@ -8338,6 +8352,45 @@ export function formatDeckRawfileAscii(
   return `${lines.join("\n")}\n`;
 }
 
+function deckRawfileProjectRows(rows: readonly string[], probes: readonly string[]): string[] {
+  const columns = rows[0]!.split("\t");
+  if (probes.length === 0) {
+    return [...rows];
+  }
+  const { selectedIndices } = deckRawfileProbeInventory(columns, probes);
+  return rows.map((row) => {
+    const cells = row.split("\t");
+    return selectedIndices.map((index) => cells[index] ?? "").join("\t");
+  });
+}
+
+function deckRawfileProbeInventory(
+  columns: readonly string[],
+  probes: readonly string[],
+): {
+  selectedIndices: number[];
+  matchedProbes: string[];
+  unmatchedProbes: string[];
+} {
+  const selectedIndices: number[] = [];
+  const matchedProbes: string[] = [];
+  const unmatchedProbes: string[] = [];
+  if (columns.length > 0) {
+    selectedIndices.push(0);
+  }
+  const normalizedColumns = columns.map((column) => column.toLowerCase());
+  for (const probe of probes) {
+    const index = normalizedColumns.indexOf(probe.toLowerCase());
+    if (index !== -1 && !selectedIndices.includes(index)) {
+      selectedIndices.push(index);
+      matchedProbes.push(columns[index]!);
+    } else if (index === -1) {
+      unmatchedProbes.push(probe);
+    }
+  }
+  return { selectedIndices, matchedProbes, unmatchedProbes };
+}
+
 function deckWriteMarkerParts(marker: string): { target: string; probes: string[] } | undefined {
   const parts = marker.trim().split(/\s+/u);
   if (parts.length < 2 || parts[0] !== "write") {
@@ -8355,20 +8408,34 @@ function deckRawfileArtifacts(
   writeMarkers: readonly string[],
   rawfileOptions: readonly string[],
 ): DeckRawfileArtifact[] {
-  const rawfile = formatDeckRawfileAscii(table, plan.analysis, rawfileOptions);
+  const rows = deckTableRows(table);
+  const columns = rows[0]?.split("\t") ?? [];
   return writeMarkers.flatMap((marker) => {
     const parts = deckWriteMarkerParts(marker);
     if (parts === undefined) {
       return [];
     }
+    const { matchedProbes, unmatchedProbes } = deckRawfileProbeInventory(
+      columns,
+      parts.probes,
+    );
     return [{
       target: parts.target,
       marker,
       probeCount: parts.probes.length,
       probes: [...parts.probes],
+      matchedProbeCount: matchedProbes.length,
+      matchedProbes,
+      unmatchedProbeCount: unmatchedProbes.length,
+      unmatchedProbes,
       optionCount: rawfileOptions.length,
       options: [...rawfileOptions],
-      rawfile,
+      rawfile: formatDeckRawfileAsciiForProbes(
+        table,
+        plan.analysis,
+        rawfileOptions,
+        parts.probes,
+      ),
     }];
   });
 }
@@ -8378,6 +8445,10 @@ const DECK_RAWFILE_ARTIFACT_COLUMNS = [
   "Marker",
   "Probes",
   "ProbeList",
+  "MatchedProbes",
+  "MatchedProbeList",
+  "UnmatchedProbes",
+  "UnmatchedProbeList",
   "Options",
   "RawfileOptionList",
   "Bytes",
@@ -8389,6 +8460,10 @@ function deckRawfileArtifactCells(artifact: DeckRawfileArtifact): string[] {
     artifact.marker,
     String(artifact.probeCount),
     artifact.probes.join(";"),
+    String(artifact.matchedProbeCount),
+    artifact.matchedProbes.join(";"),
+    String(artifact.unmatchedProbeCount),
+    artifact.unmatchedProbes.join(";"),
     String(artifact.optionCount),
     artifact.options.join(";"),
     String(artifact.rawfile.length),

--- a/code/packages/typescript/spice-engine/tests/transient.test.ts
+++ b/code/packages/typescript/spice-engine/tests/transient.test.ts
@@ -2071,7 +2071,7 @@ set wr_vecnames
 set wr_singlescale
 set appendwrite
 .set WR_VECNAMES
-write out.raw V(in)
+write out.raw V(in) V(missing)
 wrdata out.dat V(in) V(missing)
 source other.cir
 cd /tmp
@@ -2093,7 +2093,7 @@ let gain = 2
     const expectedControlLines = [".save V(in)", ".probe V(in)"];
     const controlLineList = expectedControlLines.join(";");
     const expectedWriteMarkers = [
-      "write out.raw V(in)",
+      "write out.raw V(in) V(missing)",
       "wrdata out.dat V(in) V(missing)",
     ];
     const writeMarkerList = expectedWriteMarkers.join(";");
@@ -2114,9 +2114,13 @@ let gain = 2
     expect(execution.rawfileOptions).toEqual(expectedRawfileOptions);
     expect(execution.rawfileArtifactCount).toBe(1);
     expect(execution.rawfileArtifacts[0]?.target).toBe("out.raw");
-    expect(execution.rawfileArtifacts[0]?.marker).toBe("write out.raw V(in)");
-    expect(execution.rawfileArtifacts[0]?.probeCount).toBe(1);
-    expect(execution.rawfileArtifacts[0]?.probes).toEqual(["V(in)"]);
+    expect(execution.rawfileArtifacts[0]?.marker).toBe("write out.raw V(in) V(missing)");
+    expect(execution.rawfileArtifacts[0]?.probeCount).toBe(2);
+    expect(execution.rawfileArtifacts[0]?.probes).toEqual(["V(in)", "V(missing)"]);
+    expect(execution.rawfileArtifacts[0]?.matchedProbeCount).toBe(1);
+    expect(execution.rawfileArtifacts[0]?.matchedProbes).toEqual(["V(in)"]);
+    expect(execution.rawfileArtifacts[0]?.unmatchedProbeCount).toBe(1);
+    expect(execution.rawfileArtifacts[0]?.unmatchedProbes).toEqual(["V(missing)"]);
     expect(execution.rawfileArtifacts[0]?.optionCount).toBe(expectedRawfileOptions.length);
     expect(execution.rawfileArtifacts[0]?.options).toEqual(expectedRawfileOptions);
     expect(execution.rawfileArtifacts[0]?.rawfile).toContain("Title: SPICE deck op result\n");
@@ -2125,9 +2129,13 @@ let gain = 2
     expect(execution.rawfileArtifacts[0]?.rawfile).toContain("0\t0\t1.000000e+00\n");
     const rawfileRecord = execution.rawfileArtifactRecords[0]!;
     expect(rawfileRecord["Target"]).toBe("out.raw");
-    expect(rawfileRecord["Marker"]).toBe("write out.raw V(in)");
-    expect(rawfileRecord["Probes"]).toBe("1");
-    expect(rawfileRecord["ProbeList"]).toBe("V(in)");
+    expect(rawfileRecord["Marker"]).toBe("write out.raw V(in) V(missing)");
+    expect(rawfileRecord["Probes"]).toBe("2");
+    expect(rawfileRecord["ProbeList"]).toBe("V(in);V(missing)");
+    expect(rawfileRecord["MatchedProbes"]).toBe("1");
+    expect(rawfileRecord["MatchedProbeList"]).toBe("V(in)");
+    expect(rawfileRecord["UnmatchedProbes"]).toBe("1");
+    expect(rawfileRecord["UnmatchedProbeList"]).toBe("V(missing)");
     expect(rawfileRecord["Options"]).toBe(String(expectedRawfileOptions.length));
     expect(rawfileRecord["RawfileOptionList"]).toBe(rawfileOptionList);
     expect(rawfileRecord["Bytes"]).toBe(String(execution.rawfileArtifacts[0]?.rawfile.length));
@@ -2143,6 +2151,10 @@ let gain = 2
     expect(JSON.parse(execution.rawfileArtifactJson)[0].RawfileOptionList).toBe(
       rawfileOptionList,
     );
+    const rawfileJson = JSON.parse(execution.rawfileArtifactJson)[0];
+    expect(rawfileJson.ProbeList).toBe("V(in);V(missing)");
+    expect(rawfileJson.MatchedProbeList).toBe("V(in)");
+    expect(rawfileJson.UnmatchedProbeList).toBe("V(missing)");
     expect(execution.wrdataArtifactCount).toBe(1);
     expect(execution.wrdataArtifacts[0]?.target).toBe("out.dat");
     expect(execution.wrdataArtifacts[0]?.marker).toBe(

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -118,7 +118,9 @@ downstream tools to compare.
      through the same direct selected-execution fields and selected-run
      artifact exports; accepted `.control` `write <rawfile> ...` markers now
      also produce deterministic in-memory ASCII rawfile artifacts with stable
-     table, CSV, compact JSON, and host-native record summaries, and accepted
+     table, CSV, compact JSON, and host-native record summaries, and explicit
+     `write` probe lists now select the emitted in-memory rawfile vector
+     columns and carry matched/unmatched probe inventories, and accepted
      `.control` `wrdata <file> ...` markers now produce deterministic
      in-memory ASCII data-file artifacts with matching stable table, CSV,
      compact JSON, and host-native record summaries, and WRDATA artifacts now
@@ -1079,6 +1081,15 @@ downstream tools to compare.
     - Stable WRDATA artifact table, CSV, compact JSON, and host-native record
       exports make ignored `wrdata` probe names auditable while keeping
       filesystem writes metadata-only.
+
+99. Deck rawfile write probe artifact inventories.
+    - Status: completed in this deck rawfile write probe artifact slice.
+    - Python, Rust, and TypeScript rawfile artifact summaries now expose stable
+      matched and unmatched probe counts/lists beside the requested `write`
+      probe list.
+    - In-memory ASCII rawfile artifacts now keep the scale column plus matching
+      requested vector columns, while stable table, CSV, compact JSON, and
+      host-native record exports make ignored `write` probe names auditable.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- Make `.control write <rawfile> [probes...]` rawfile artifacts probe-aware across the Python, Rust, and TypeScript SPICE engines.
- Project in-memory RAWFILE ASCII output to the scale column plus requested matching probe/vector columns, while preserving the requested probe list.
- Export stable matched/unmatched probe inventories in rawfile artifact records and docs, and mark the slice complete in the full implementation plan.

## Verification
- `PYTHONPATH=".../code/packages/python/spice-engine/src:.../code/packages/python/spice-netlist-parser/src:.../code/packages/python/mosfet-models/src:.../code/packages/python/device-physics/src" /Users/adhithya/.local/share/mise/installs/python/3.12.13/bin/python -m pytest code/packages/python/spice-engine/tests/test_engine.py`
- `/Users/adhithya/.local/share/mise/installs/python/3.12.13/bin/python -m ruff check code/packages/python/spice-engine/src/spice_engine/engine.py code/packages/python/spice-engine/tests/test_engine.py`
- `cargo fmt --manifest-path code/packages/rust/spice-engine/Cargo.toml -- --check`
- `cargo test --manifest-path code/packages/rust/spice-engine/Cargo.toml`
- `npm --prefix code/packages/typescript/spice-engine test`
- `npm --prefix code/packages/typescript/spice-engine run build`
- `git diff --check`