### PR TITLE
[codex] Add mesh disposition action readiness summary

### DIFF
--- a/code/packages/rust/smart-home-integration-catalog/CHANGELOG.md
+++ b/code/packages/rust/smart-home-integration-catalog/CHANGELOG.md
@@ -185,6 +185,9 @@ All notable changes to this package will be documented in this file.
 - `IntegrationMeshReleaseTicketHandoffExecutionWorkOrderGuardrailAuditClearanceActionEvidenceReviewDispositionAction`
   and summary helpers for turning clearance evidence-review dispositions into
   repair, operator, review, lineage, and release handoff actions.
+- `IntegrationMeshReleaseTicketHandoffGuardrailAuditClearanceActionEvidenceReviewDispositionActionReadinessSummary`
+  and helpers for combining disposition readiness with disposition-action
+  counts and next action pointers.
 - `IntegrationMeshReleaseTicketHandoffGuardrailAuditClearanceActionEvidenceReviewDispositionReadinessSummary`
   and helpers for combining clearance evidence-review readiness with
   disposition outcomes.

--- a/code/packages/rust/smart-home-integration-catalog/README.md
+++ b/code/packages/rust/smart-home-integration-catalog/README.md
@@ -166,6 +166,9 @@ runtime and Chief of Staff tools a typed catalog for:
 - mesh release ticket handoff guardrail audit clearance action evidence review
   disposition readiness summaries that combine evidence-review readiness with
   disposition outcomes and next disposition pointers
+- mesh release ticket handoff guardrail audit clearance action evidence review
+  disposition-action readiness summaries that combine disposition readiness
+  with action counts and next disposition-action pointers
 - mesh release ticket handoff work-order guardrail readiness summaries that
   combine work-order readiness with guardrail counts and first actionable
   handoff work

--- a/code/packages/rust/smart-home-integration-catalog/src/lib.rs
+++ b/code/packages/rust/smart-home-integration-catalog/src/lib.rs
@@ -13127,6 +13127,461 @@ impl
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IntegrationMeshReleaseTicketHandoffGuardrailAuditClearanceActionEvidenceReviewDispositionActionReadinessSummary {
+    pub release_ticket_handoff_guardrail_audit_clearance_action_evidence_review_disposition_readiness_summary:
+        Box<IntegrationMeshReleaseTicketHandoffGuardrailAuditClearanceActionEvidenceReviewDispositionReadinessSummary>,
+    pub release_ticket_handoff_execution_work_order_guardrail_audit_clearance_action_evidence_review_disposition_action_summary:
+        Box<IntegrationMeshReleaseTicketHandoffExecutionWorkOrderGuardrailAuditClearanceActionEvidenceReviewDispositionActionSummary>,
+    pub total_clearance_actions: usize,
+    pub total_action_evidence: usize,
+    pub total_evidence_reviews: usize,
+    pub total_review_dispositions: usize,
+    pub total_review_disposition_actions: usize,
+    pub required_disposition_actions: usize,
+    pub release_blocking_disposition_actions: usize,
+    pub operator_required_disposition_actions: usize,
+    pub review_required_disposition_actions: usize,
+    pub dispatch_required_disposition_actions: usize,
+    pub execution_required_disposition_actions: usize,
+    pub repair_disposition_actions: usize,
+    pub operator_handoff_disposition_actions: usize,
+    pub review_gate_disposition_actions: usize,
+    pub lineage_gap_disposition_actions: usize,
+    pub release_handoff_disposition_actions: usize,
+    pub lineage_complete_disposition_actions: usize,
+    pub first_review_disposition_action_key: Option<String>,
+    pub first_required_disposition_action_key: Option<String>,
+    pub first_repair_disposition_action_key: Option<String>,
+    pub first_operator_handoff_disposition_action_key: Option<String>,
+    pub first_review_gate_disposition_action_key: Option<String>,
+    pub first_lineage_gap_disposition_action_key: Option<String>,
+    pub first_release_handoff_disposition_action_key: Option<String>,
+    pub first_review_disposition_key: Option<String>,
+    pub first_evidence_review_key: Option<String>,
+    pub first_action_evidence_key: Option<String>,
+    pub first_clearance_action_key: Option<String>,
+    pub first_clearance_key: Option<String>,
+    pub first_work_order_key: Option<String>,
+    pub first_ticket_key: Option<String>,
+    pub first_disposition_action_kind: Option<
+        IntegrationMeshReleaseTicketHandoffExecutionWorkOrderGuardrailAuditClearanceActionEvidenceReviewDispositionActionKind,
+    >,
+    pub first_disposition_kind: Option<
+        IntegrationMeshReleaseTicketHandoffExecutionWorkOrderGuardrailAuditClearanceActionEvidenceReviewDispositionKind,
+    >,
+    pub first_review_kind: Option<
+        IntegrationMeshReleaseTicketHandoffExecutionWorkOrderGuardrailAuditClearanceActionEvidenceReviewKind,
+    >,
+    pub first_evidence_kind: Option<
+        IntegrationMeshReleaseTicketHandoffExecutionWorkOrderGuardrailAuditClearanceActionEvidenceKind,
+    >,
+    pub first_clearance_action_kind: Option<
+        IntegrationMeshReleaseTicketHandoffExecutionWorkOrderGuardrailAuditClearanceActionKind,
+    >,
+    pub first_clearance_kind:
+        Option<IntegrationMeshReleaseTicketHandoffExecutionWorkOrderGuardrailAuditClearanceKind>,
+    pub first_handoff_lane: Option<IntegrationMeshReleaseDispatchTicketHandoffLane>,
+    pub first_check_kind: Option<IntegrationMeshReleaseReadinessCheckKind>,
+    pub first_check_status: Option<IntegrationMeshReleaseReadinessStatus>,
+    pub next_review_disposition_action_key: Option<String>,
+    pub next_review_disposition_key: Option<String>,
+    pub next_evidence_review_key: Option<String>,
+    pub next_action_evidence_key: Option<String>,
+    pub next_clearance_action_key: Option<String>,
+    pub next_work_order_key: Option<String>,
+    pub next_ticket_key: Option<String>,
+    pub next_check_kind: Option<IntegrationMeshReleaseReadinessCheckKind>,
+    pub next_check_status: Option<IntegrationMeshReleaseReadinessStatus>,
+    pub next_handoff_lane: Option<IntegrationMeshReleaseDispatchTicketHandoffLane>,
+    pub release_ticket_handoff_guardrail_audit_clearance_action_evidence_review_dispositions_ready:
+        bool,
+    pub release_handoff_execution_work_order_guardrail_audit_clearance_action_evidence_review_disposition_actions_ready: bool,
+    pub release_ticket_handoff_guardrail_audit_clearance_action_evidence_review_disposition_actions_ready:
+        bool,
+}
+
+impl
+    IntegrationMeshReleaseTicketHandoffGuardrailAuditClearanceActionEvidenceReviewDispositionActionReadinessSummary
+{
+    pub fn from_summaries(
+        release_ticket_handoff_guardrail_audit_clearance_action_evidence_review_disposition_readiness_summary: IntegrationMeshReleaseTicketHandoffGuardrailAuditClearanceActionEvidenceReviewDispositionReadinessSummary,
+        release_ticket_handoff_execution_work_order_guardrail_audit_clearance_action_evidence_review_disposition_action_summary: IntegrationMeshReleaseTicketHandoffExecutionWorkOrderGuardrailAuditClearanceActionEvidenceReviewDispositionActionSummary,
+    ) -> Self {
+        let release_ticket_handoff_guardrail_audit_clearance_action_evidence_review_dispositions_ready =
+            release_ticket_handoff_guardrail_audit_clearance_action_evidence_review_disposition_readiness_summary
+                .ready_for_release_ticket_handoff_guardrail_audit_clearance_action_evidence_review_dispositions();
+        let release_handoff_execution_work_order_guardrail_audit_clearance_action_evidence_review_disposition_actions_ready =
+            release_ticket_handoff_execution_work_order_guardrail_audit_clearance_action_evidence_review_disposition_action_summary
+                .release_handoff_execution_work_order_guardrail_audit_clearance_action_evidence_review_disposition_actions_ready;
+        let release_ticket_handoff_guardrail_audit_clearance_action_evidence_review_disposition_actions_ready =
+            release_ticket_handoff_guardrail_audit_clearance_action_evidence_review_dispositions_ready
+                && release_handoff_execution_work_order_guardrail_audit_clearance_action_evidence_review_disposition_actions_ready;
+        let next_action_requires_attention =
+            release_ticket_handoff_execution_work_order_guardrail_audit_clearance_action_evidence_review_disposition_action_summary
+                .requires_attention();
+        let next_action_key = if next_action_requires_attention {
+            release_ticket_handoff_execution_work_order_guardrail_audit_clearance_action_evidence_review_disposition_action_summary
+                .first_required_action_key
+                .clone()
+                .or_else(|| {
+                    release_ticket_handoff_execution_work_order_guardrail_audit_clearance_action_evidence_review_disposition_action_summary
+                        .first_action_key
+                        .clone()
+                })
+        } else {
+            None
+        };
+        let next_disposition_key = if next_action_requires_attention {
+            release_ticket_handoff_execution_work_order_guardrail_audit_clearance_action_evidence_review_disposition_action_summary
+                .first_disposition_key
+                .clone()
+        } else {
+            None
+        };
+        let next_review_key = if next_action_requires_attention {
+            release_ticket_handoff_execution_work_order_guardrail_audit_clearance_action_evidence_review_disposition_action_summary
+                .first_review_key
+                .clone()
+        } else {
+            None
+        };
+        let next_evidence_key = if next_action_requires_attention {
+            release_ticket_handoff_execution_work_order_guardrail_audit_clearance_action_evidence_review_disposition_action_summary
+                .first_evidence_key
+                .clone()
+        } else {
+            None
+        };
+        let next_clearance_action_key = if next_action_requires_attention {
+            release_ticket_handoff_execution_work_order_guardrail_audit_clearance_action_evidence_review_disposition_action_summary
+                .first_clearance_action_key
+                .clone()
+        } else {
+            None
+        };
+        let next_work_order_key = if next_action_requires_attention {
+            release_ticket_handoff_execution_work_order_guardrail_audit_clearance_action_evidence_review_disposition_action_summary
+                .first_work_order_key
+                .clone()
+        } else {
+            None
+        };
+        let next_ticket_key = if next_action_requires_attention {
+            release_ticket_handoff_execution_work_order_guardrail_audit_clearance_action_evidence_review_disposition_action_summary
+                .first_ticket_key
+                .clone()
+        } else {
+            None
+        };
+        let next_check_kind = if next_action_requires_attention {
+            release_ticket_handoff_execution_work_order_guardrail_audit_clearance_action_evidence_review_disposition_action_summary
+                .first_check_kind
+        } else {
+            None
+        };
+        let next_check_status = if next_action_requires_attention {
+            release_ticket_handoff_execution_work_order_guardrail_audit_clearance_action_evidence_review_disposition_action_summary
+                .first_check_status
+        } else {
+            None
+        };
+        let next_handoff_lane = if next_action_requires_attention {
+            release_ticket_handoff_execution_work_order_guardrail_audit_clearance_action_evidence_review_disposition_action_summary
+                .first_handoff_lane
+        } else {
+            None
+        };
+
+        Self {
+            total_clearance_actions:
+                release_ticket_handoff_guardrail_audit_clearance_action_evidence_review_disposition_readiness_summary
+                    .total_clearance_actions,
+            total_action_evidence:
+                release_ticket_handoff_guardrail_audit_clearance_action_evidence_review_disposition_readiness_summary
+                    .total_action_evidence,
+            total_evidence_reviews:
+                release_ticket_handoff_guardrail_audit_clearance_action_evidence_review_disposition_readiness_summary
+                    .total_evidence_reviews,
+            total_review_dispositions:
+                release_ticket_handoff_guardrail_audit_clearance_action_evidence_review_disposition_readiness_summary
+                    .total_review_dispositions,
+            total_review_disposition_actions:
+                release_ticket_handoff_execution_work_order_guardrail_audit_clearance_action_evidence_review_disposition_action_summary
+                    .total_actions,
+            required_disposition_actions:
+                release_ticket_handoff_execution_work_order_guardrail_audit_clearance_action_evidence_review_disposition_action_summary
+                    .required_actions,
+            release_blocking_disposition_actions:
+                release_ticket_handoff_execution_work_order_guardrail_audit_clearance_action_evidence_review_disposition_action_summary
+                    .release_blocking_actions,
+            operator_required_disposition_actions:
+                release_ticket_handoff_execution_work_order_guardrail_audit_clearance_action_evidence_review_disposition_action_summary
+                    .operator_required_actions,
+            review_required_disposition_actions:
+                release_ticket_handoff_execution_work_order_guardrail_audit_clearance_action_evidence_review_disposition_action_summary
+                    .review_required_actions,
+            dispatch_required_disposition_actions:
+                release_ticket_handoff_execution_work_order_guardrail_audit_clearance_action_evidence_review_disposition_action_summary
+                    .dispatch_required_actions,
+            execution_required_disposition_actions:
+                release_ticket_handoff_execution_work_order_guardrail_audit_clearance_action_evidence_review_disposition_action_summary
+                    .execution_required_actions,
+            repair_disposition_actions:
+                release_ticket_handoff_execution_work_order_guardrail_audit_clearance_action_evidence_review_disposition_action_summary
+                    .repair_actions,
+            operator_handoff_disposition_actions:
+                release_ticket_handoff_execution_work_order_guardrail_audit_clearance_action_evidence_review_disposition_action_summary
+                    .operator_handoff_actions,
+            review_gate_disposition_actions:
+                release_ticket_handoff_execution_work_order_guardrail_audit_clearance_action_evidence_review_disposition_action_summary
+                    .review_gate_actions,
+            lineage_gap_disposition_actions:
+                release_ticket_handoff_execution_work_order_guardrail_audit_clearance_action_evidence_review_disposition_action_summary
+                    .lineage_gap_actions,
+            release_handoff_disposition_actions:
+                release_ticket_handoff_execution_work_order_guardrail_audit_clearance_action_evidence_review_disposition_action_summary
+                    .release_handoff_actions,
+            lineage_complete_disposition_actions:
+                release_ticket_handoff_execution_work_order_guardrail_audit_clearance_action_evidence_review_disposition_action_summary
+                    .lineage_complete_actions,
+            first_review_disposition_action_key:
+                release_ticket_handoff_execution_work_order_guardrail_audit_clearance_action_evidence_review_disposition_action_summary
+                    .first_action_key
+                    .clone(),
+            first_required_disposition_action_key:
+                release_ticket_handoff_execution_work_order_guardrail_audit_clearance_action_evidence_review_disposition_action_summary
+                    .first_required_action_key
+                    .clone(),
+            first_repair_disposition_action_key:
+                release_ticket_handoff_execution_work_order_guardrail_audit_clearance_action_evidence_review_disposition_action_summary
+                    .first_repair_action_key
+                    .clone(),
+            first_operator_handoff_disposition_action_key:
+                release_ticket_handoff_execution_work_order_guardrail_audit_clearance_action_evidence_review_disposition_action_summary
+                    .first_operator_handoff_action_key
+                    .clone(),
+            first_review_gate_disposition_action_key:
+                release_ticket_handoff_execution_work_order_guardrail_audit_clearance_action_evidence_review_disposition_action_summary
+                    .first_review_gate_action_key
+                    .clone(),
+            first_lineage_gap_disposition_action_key:
+                release_ticket_handoff_execution_work_order_guardrail_audit_clearance_action_evidence_review_disposition_action_summary
+                    .first_lineage_gap_action_key
+                    .clone(),
+            first_release_handoff_disposition_action_key:
+                release_ticket_handoff_execution_work_order_guardrail_audit_clearance_action_evidence_review_disposition_action_summary
+                    .first_release_handoff_action_key
+                    .clone(),
+            first_review_disposition_key:
+                release_ticket_handoff_execution_work_order_guardrail_audit_clearance_action_evidence_review_disposition_action_summary
+                    .first_disposition_key
+                    .clone(),
+            first_evidence_review_key:
+                release_ticket_handoff_execution_work_order_guardrail_audit_clearance_action_evidence_review_disposition_action_summary
+                    .first_review_key
+                    .clone(),
+            first_action_evidence_key:
+                release_ticket_handoff_execution_work_order_guardrail_audit_clearance_action_evidence_review_disposition_action_summary
+                    .first_evidence_key
+                    .clone(),
+            first_clearance_action_key:
+                release_ticket_handoff_execution_work_order_guardrail_audit_clearance_action_evidence_review_disposition_action_summary
+                    .first_clearance_action_key
+                    .clone(),
+            first_clearance_key:
+                release_ticket_handoff_execution_work_order_guardrail_audit_clearance_action_evidence_review_disposition_action_summary
+                    .first_clearance_key
+                    .clone(),
+            first_work_order_key:
+                release_ticket_handoff_execution_work_order_guardrail_audit_clearance_action_evidence_review_disposition_action_summary
+                    .first_work_order_key
+                    .clone(),
+            first_ticket_key:
+                release_ticket_handoff_execution_work_order_guardrail_audit_clearance_action_evidence_review_disposition_action_summary
+                    .first_ticket_key
+                    .clone(),
+            first_disposition_action_kind:
+                release_ticket_handoff_execution_work_order_guardrail_audit_clearance_action_evidence_review_disposition_action_summary
+                    .first_disposition_action_kind,
+            first_disposition_kind:
+                release_ticket_handoff_execution_work_order_guardrail_audit_clearance_action_evidence_review_disposition_action_summary
+                    .first_disposition_kind,
+            first_review_kind:
+                release_ticket_handoff_execution_work_order_guardrail_audit_clearance_action_evidence_review_disposition_action_summary
+                    .first_review_kind,
+            first_evidence_kind:
+                release_ticket_handoff_execution_work_order_guardrail_audit_clearance_action_evidence_review_disposition_action_summary
+                    .first_evidence_kind,
+            first_clearance_action_kind:
+                release_ticket_handoff_execution_work_order_guardrail_audit_clearance_action_evidence_review_disposition_action_summary
+                    .first_clearance_action_kind,
+            first_clearance_kind:
+                release_ticket_handoff_execution_work_order_guardrail_audit_clearance_action_evidence_review_disposition_action_summary
+                    .first_clearance_kind,
+            first_handoff_lane:
+                release_ticket_handoff_execution_work_order_guardrail_audit_clearance_action_evidence_review_disposition_action_summary
+                    .first_handoff_lane,
+            first_check_kind:
+                release_ticket_handoff_execution_work_order_guardrail_audit_clearance_action_evidence_review_disposition_action_summary
+                    .first_check_kind,
+            first_check_status:
+                release_ticket_handoff_execution_work_order_guardrail_audit_clearance_action_evidence_review_disposition_action_summary
+                    .first_check_status,
+            next_review_disposition_action_key: next_action_key,
+            next_review_disposition_key: next_disposition_key.or_else(|| {
+                release_ticket_handoff_guardrail_audit_clearance_action_evidence_review_disposition_readiness_summary
+                    .next_review_disposition_key
+                    .clone()
+            }),
+            next_evidence_review_key: next_review_key.or_else(|| {
+                release_ticket_handoff_guardrail_audit_clearance_action_evidence_review_disposition_readiness_summary
+                    .next_evidence_review_key
+                    .clone()
+            }),
+            next_action_evidence_key: next_evidence_key.or_else(|| {
+                release_ticket_handoff_guardrail_audit_clearance_action_evidence_review_disposition_readiness_summary
+                    .next_action_evidence_key
+                    .clone()
+            }),
+            next_clearance_action_key: next_clearance_action_key.or_else(|| {
+                release_ticket_handoff_guardrail_audit_clearance_action_evidence_review_disposition_readiness_summary
+                    .next_clearance_action_key
+                    .clone()
+            }),
+            next_work_order_key: next_work_order_key.or_else(|| {
+                release_ticket_handoff_guardrail_audit_clearance_action_evidence_review_disposition_readiness_summary
+                    .next_work_order_key
+                    .clone()
+            }),
+            next_ticket_key: next_ticket_key.or_else(|| {
+                release_ticket_handoff_guardrail_audit_clearance_action_evidence_review_disposition_readiness_summary
+                    .next_ticket_key
+                    .clone()
+            }),
+            next_check_kind: next_check_kind.or(
+                release_ticket_handoff_guardrail_audit_clearance_action_evidence_review_disposition_readiness_summary
+                    .next_check_kind,
+            ),
+            next_check_status: next_check_status.or(
+                release_ticket_handoff_guardrail_audit_clearance_action_evidence_review_disposition_readiness_summary
+                    .next_check_status,
+            ),
+            next_handoff_lane: next_handoff_lane.or(
+                release_ticket_handoff_guardrail_audit_clearance_action_evidence_review_disposition_readiness_summary
+                    .next_handoff_lane,
+            ),
+            release_ticket_handoff_guardrail_audit_clearance_action_evidence_review_dispositions_ready,
+            release_handoff_execution_work_order_guardrail_audit_clearance_action_evidence_review_disposition_actions_ready,
+            release_ticket_handoff_guardrail_audit_clearance_action_evidence_review_disposition_actions_ready,
+            release_ticket_handoff_guardrail_audit_clearance_action_evidence_review_disposition_readiness_summary:
+                Box::new(
+                    release_ticket_handoff_guardrail_audit_clearance_action_evidence_review_disposition_readiness_summary,
+                ),
+            release_ticket_handoff_execution_work_order_guardrail_audit_clearance_action_evidence_review_disposition_action_summary:
+                Box::new(
+                    release_ticket_handoff_execution_work_order_guardrail_audit_clearance_action_evidence_review_disposition_action_summary,
+                ),
+        }
+    }
+
+    pub fn has_review_disposition_actions(&self) -> bool {
+        self.total_review_disposition_actions > 0
+    }
+
+    pub fn ready_for_release_ticket_handoff_guardrail_audit_clearance_action_evidence_review_disposition_actions(
+        &self,
+    ) -> bool {
+        self.release_ticket_handoff_guardrail_audit_clearance_action_evidence_review_dispositions_ready
+            && self.release_handoff_execution_work_order_guardrail_audit_clearance_action_evidence_review_disposition_actions_ready
+            && self.release_ticket_handoff_guardrail_audit_clearance_action_evidence_review_disposition_actions_ready
+            && !self.requires_attention()
+    }
+
+    pub fn has_required_actions(&self) -> bool {
+        self.required_disposition_actions > 0
+    }
+
+    pub fn has_blockers(&self) -> bool {
+        self.release_blocking_disposition_actions > 0
+            || self.repair_disposition_actions > 0
+            || self
+                .release_ticket_handoff_guardrail_audit_clearance_action_evidence_review_disposition_readiness_summary
+                .has_blockers()
+            || self
+                .release_ticket_handoff_execution_work_order_guardrail_audit_clearance_action_evidence_review_disposition_action_summary
+                .has_blockers()
+    }
+
+    pub fn has_review_work(&self) -> bool {
+        self.review_required_disposition_actions > 0
+            || self.review_gate_disposition_actions > 0
+            || self
+                .release_ticket_handoff_guardrail_audit_clearance_action_evidence_review_disposition_readiness_summary
+                .has_review_work()
+            || self
+                .release_ticket_handoff_execution_work_order_guardrail_audit_clearance_action_evidence_review_disposition_action_summary
+                .needs_review()
+    }
+
+    pub fn needs_operator(&self) -> bool {
+        self.operator_required_disposition_actions > 0
+            || self.operator_handoff_disposition_actions > 0
+            || self
+                .release_ticket_handoff_guardrail_audit_clearance_action_evidence_review_disposition_readiness_summary
+                .needs_operator()
+            || self
+                .release_ticket_handoff_execution_work_order_guardrail_audit_clearance_action_evidence_review_disposition_action_summary
+                .needs_operator()
+    }
+
+    pub fn has_lineage_gaps(&self) -> bool {
+        self.lineage_gap_disposition_actions > 0
+            || self
+                .release_ticket_handoff_guardrail_audit_clearance_action_evidence_review_disposition_readiness_summary
+                .has_lineage_gaps()
+            || self
+                .release_ticket_handoff_execution_work_order_guardrail_audit_clearance_action_evidence_review_disposition_action_summary
+                .has_lineage_gaps()
+    }
+
+    pub fn has_release_handoff_actions(&self) -> bool {
+        self.release_handoff_disposition_actions > 0
+    }
+
+    pub fn has_complete_lineage(&self) -> bool {
+        self.lineage_complete_disposition_actions == self.total_review_disposition_actions
+            && self
+                .release_ticket_handoff_execution_work_order_guardrail_audit_clearance_action_evidence_review_disposition_action_summary
+                .has_complete_lineage()
+    }
+
+    pub fn requires_execution(&self) -> bool {
+        self.execution_required_disposition_actions > 0
+            || self
+                .release_ticket_handoff_guardrail_audit_clearance_action_evidence_review_disposition_readiness_summary
+                .requires_execution()
+    }
+
+    pub fn requires_attention(&self) -> bool {
+        self.requires_execution()
+            || self.dispatch_required_disposition_actions > 0
+            || self.has_required_actions()
+            || self.has_blockers()
+            || self.has_review_work()
+            || self.needs_operator()
+            || self.has_lineage_gaps()
+            || self
+                .release_ticket_handoff_guardrail_audit_clearance_action_evidence_review_disposition_readiness_summary
+                .requires_attention()
+            || self
+                .release_ticket_handoff_execution_work_order_guardrail_audit_clearance_action_evidence_review_disposition_action_summary
+                .requires_attention()
+            || !self
+                .release_ticket_handoff_guardrail_audit_clearance_action_evidence_review_disposition_actions_ready
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct IntegrationCatalogEntry {
     pub integration_id: IntegrationId,
     pub display_name: String,
@@ -35828,6 +36283,49 @@ pub fn mesh_release_ticket_handoff_guardrail_audit_clearance_action_evidence_rev
     )
 }
 
+pub fn mesh_release_ticket_handoff_guardrail_audit_clearance_action_evidence_review_disposition_action_readiness_summary_for_catalog(
+    catalog: &[IntegrationCatalogEntry],
+    available_primitives: &[PrimitiveFamily],
+    allowed_capabilities: &[CapabilityId],
+    enabled_integrations: &[IntegrationId],
+) -> IntegrationMeshReleaseTicketHandoffGuardrailAuditClearanceActionEvidenceReviewDispositionActionReadinessSummary
+{
+    let release_ticket_handoff_guardrail_audit_clearance_action_evidence_review_disposition_readiness_summary =
+        mesh_release_ticket_handoff_guardrail_audit_clearance_action_evidence_review_disposition_readiness_summary_for_catalog(
+            catalog,
+            available_primitives,
+            allowed_capabilities,
+            enabled_integrations,
+        );
+    let release_ticket_handoff_execution_work_order_guardrail_audit_clearance_action_evidence_review_disposition_action_summary =
+        mesh_release_ticket_handoff_execution_work_order_guardrail_audit_clearance_action_evidence_review_disposition_action_summary_for_catalog(
+            catalog,
+            available_primitives,
+            allowed_capabilities,
+            enabled_integrations,
+        );
+
+    IntegrationMeshReleaseTicketHandoffGuardrailAuditClearanceActionEvidenceReviewDispositionActionReadinessSummary::from_summaries(
+        release_ticket_handoff_guardrail_audit_clearance_action_evidence_review_disposition_readiness_summary,
+        release_ticket_handoff_execution_work_order_guardrail_audit_clearance_action_evidence_review_disposition_action_summary,
+    )
+}
+
+pub fn mesh_release_ticket_handoff_guardrail_audit_clearance_action_evidence_review_disposition_action_readiness_summary(
+    available_primitives: &[PrimitiveFamily],
+    allowed_capabilities: &[CapabilityId],
+    enabled_integrations: &[IntegrationId],
+) -> IntegrationMeshReleaseTicketHandoffGuardrailAuditClearanceActionEvidenceReviewDispositionActionReadinessSummary
+{
+    let catalog = first_party_catalog();
+    mesh_release_ticket_handoff_guardrail_audit_clearance_action_evidence_review_disposition_action_readiness_summary_for_catalog(
+        &catalog,
+        available_primitives,
+        allowed_capabilities,
+        enabled_integrations,
+    )
+}
+
 fn mesh_protocol_catalog_entries(
     catalog: &[IntegrationCatalogEntry],
 ) -> Vec<IntegrationCatalogEntry> {
@@ -50067,6 +50565,265 @@ mod tests {
         assert!(!summary.has_review_work());
         assert!(!summary.needs_operator());
         assert!(!summary.has_lineage_gaps());
+        assert!(!summary.requires_execution());
+        assert!(!summary.requires_attention());
+    }
+
+    #[test]
+    fn mesh_release_ticket_handoff_guardrail_audit_clearance_action_evidence_review_disposition_action_readiness_surfaces_action_attention(
+    ) {
+        let available_primitives = vec![
+            PrimitiveFamily::Usb,
+            PrimitiveFamily::SerialController,
+            PrimitiveFamily::Radio802154,
+            PrimitiveFamily::Supervision,
+        ];
+        let allowed_capabilities = vec![CapabilityId::trusted("smart_home.read")];
+        let summary =
+            mesh_release_ticket_handoff_guardrail_audit_clearance_action_evidence_review_disposition_action_readiness_summary(
+                &available_primitives,
+                &allowed_capabilities,
+                &[],
+            );
+
+        assert_eq!(summary.total_clearance_actions, 5);
+        assert_eq!(summary.total_action_evidence, 5);
+        assert_eq!(summary.total_evidence_reviews, 5);
+        assert_eq!(summary.total_review_dispositions, 5);
+        assert_eq!(summary.total_review_disposition_actions, 5);
+        assert_eq!(summary.required_disposition_actions, 5);
+        assert_eq!(summary.release_blocking_disposition_actions, 3);
+        assert_eq!(summary.operator_required_disposition_actions, 4);
+        assert_eq!(summary.review_required_disposition_actions, 2);
+        assert_eq!(summary.dispatch_required_disposition_actions, 5);
+        assert_eq!(summary.execution_required_disposition_actions, 5);
+        assert_eq!(summary.repair_disposition_actions, 3);
+        assert_eq!(summary.operator_handoff_disposition_actions, 0);
+        assert_eq!(summary.review_gate_disposition_actions, 2);
+        assert_eq!(summary.lineage_gap_disposition_actions, 0);
+        assert_eq!(summary.release_handoff_disposition_actions, 0);
+        assert_eq!(summary.lineage_complete_disposition_actions, 5);
+        assert_eq!(
+            summary.first_review_disposition_action_key,
+            Some(
+                "release-ticket-handoff-execution-work-order-guardrail-audit-clearance-action-evidence-review-disposition-action-01-schedule_release_blocker_repair-substrate_actions"
+                    .to_string()
+            )
+        );
+        assert_eq!(
+            summary.first_required_disposition_action_key,
+            summary.first_review_disposition_action_key
+        );
+        assert_eq!(
+            summary.first_repair_disposition_action_key,
+            summary.first_review_disposition_action_key
+        );
+        assert_eq!(summary.first_operator_handoff_disposition_action_key, None);
+        assert_eq!(
+            summary.first_review_gate_disposition_action_key,
+            Some(
+                "release-ticket-handoff-execution-work-order-guardrail-audit-clearance-action-evidence-review-disposition-action-02-complete_evidence_review-evidence_remediation"
+                    .to_string()
+            )
+        );
+        assert_eq!(summary.first_lineage_gap_disposition_action_key, None);
+        assert_eq!(summary.first_release_handoff_disposition_action_key, None);
+        assert_eq!(
+            summary.first_review_disposition_key,
+            Some(
+                "release-ticket-handoff-execution-work-order-guardrail-audit-clearance-action-evidence-review-disposition-01-repair_release_blocker-substrate_actions"
+                    .to_string()
+            )
+        );
+        assert_eq!(
+            summary.first_disposition_action_kind,
+            Some(
+                IntegrationMeshReleaseTicketHandoffExecutionWorkOrderGuardrailAuditClearanceActionEvidenceReviewDispositionActionKind::ScheduleReleaseBlockerRepair
+            )
+        );
+        assert_eq!(
+            summary.first_disposition_kind,
+            Some(
+                IntegrationMeshReleaseTicketHandoffExecutionWorkOrderGuardrailAuditClearanceActionEvidenceReviewDispositionKind::RepairReleaseBlocker
+            )
+        );
+        assert_eq!(
+            summary.first_review_kind,
+            Some(
+                IntegrationMeshReleaseTicketHandoffExecutionWorkOrderGuardrailAuditClearanceActionEvidenceReviewKind::BlockerReview
+            )
+        );
+        assert_eq!(
+            summary.first_evidence_kind,
+            Some(
+                IntegrationMeshReleaseTicketHandoffExecutionWorkOrderGuardrailAuditClearanceActionEvidenceKind::BlockerEvidence
+            )
+        );
+        assert_eq!(
+            summary.first_clearance_action_kind,
+            Some(
+                IntegrationMeshReleaseTicketHandoffExecutionWorkOrderGuardrailAuditClearanceActionKind::RepairReleaseBlocker
+            )
+        );
+        assert_eq!(
+            summary.first_clearance_kind,
+            Some(
+                IntegrationMeshReleaseTicketHandoffExecutionWorkOrderGuardrailAuditClearanceKind::ReleaseBlocked
+            )
+        );
+        assert_eq!(
+            summary.first_handoff_lane,
+            Some(IntegrationMeshReleaseDispatchTicketHandoffLane::Repair)
+        );
+        assert_eq!(
+            summary.first_check_kind,
+            Some(IntegrationMeshReleaseReadinessCheckKind::SubstrateActions)
+        );
+        assert_eq!(
+            summary.first_check_status,
+            Some(IntegrationMeshReleaseReadinessStatus::Blocked)
+        );
+        assert_eq!(
+            summary.next_review_disposition_action_key,
+            summary.first_review_disposition_action_key
+        );
+        assert_eq!(
+            summary.next_review_disposition_key,
+            summary.first_review_disposition_key
+        );
+        assert_eq!(
+            summary.next_evidence_review_key,
+            summary.first_evidence_review_key
+        );
+        assert_eq!(
+            summary.next_action_evidence_key,
+            summary.first_action_evidence_key
+        );
+        assert_eq!(
+            summary.next_clearance_action_key,
+            summary.first_clearance_action_key
+        );
+        assert_eq!(summary.next_work_order_key, summary.first_work_order_key);
+        assert_eq!(summary.next_ticket_key, summary.first_ticket_key);
+        assert_eq!(summary.next_check_kind, summary.first_check_kind);
+        assert_eq!(summary.next_check_status, summary.first_check_status);
+        assert_eq!(summary.next_handoff_lane, summary.first_handoff_lane);
+        assert!(
+            !summary
+                .release_ticket_handoff_guardrail_audit_clearance_action_evidence_review_dispositions_ready
+        );
+        assert!(
+            !summary
+                .release_handoff_execution_work_order_guardrail_audit_clearance_action_evidence_review_disposition_actions_ready
+        );
+        assert!(!summary
+            .release_ticket_handoff_guardrail_audit_clearance_action_evidence_review_disposition_actions_ready);
+        assert!(!summary
+            .ready_for_release_ticket_handoff_guardrail_audit_clearance_action_evidence_review_disposition_actions());
+        assert!(summary.has_review_disposition_actions());
+        assert!(summary.has_required_actions());
+        assert!(summary.has_blockers());
+        assert!(summary.has_review_work());
+        assert!(summary.needs_operator());
+        assert!(!summary.has_lineage_gaps());
+        assert!(!summary.has_release_handoff_actions());
+        assert!(summary.has_complete_lineage());
+        assert!(summary.requires_execution());
+        assert!(summary.requires_attention());
+    }
+
+    #[test]
+    fn mesh_release_ticket_handoff_guardrail_audit_clearance_action_evidence_review_disposition_action_readiness_marks_release_ready(
+    ) {
+        let catalog = vec![hue_entry()];
+        let allowed_capabilities = vec![
+            CapabilityId::trusted("smart_home.read"),
+            CapabilityId::trusted("smart_home.command.light"),
+            CapabilityId::trusted("smart_home.pair"),
+        ];
+        let summary =
+            mesh_release_ticket_handoff_guardrail_audit_clearance_action_evidence_review_disposition_action_readiness_summary_for_catalog(
+                &catalog,
+                all_primitive_families(),
+                &allowed_capabilities,
+                &[],
+            );
+
+        assert_eq!(summary.total_clearance_actions, 5);
+        assert_eq!(summary.total_action_evidence, 5);
+        assert_eq!(summary.total_evidence_reviews, 5);
+        assert_eq!(summary.total_review_dispositions, 5);
+        assert_eq!(summary.total_review_disposition_actions, 5);
+        assert_eq!(summary.required_disposition_actions, 0);
+        assert_eq!(summary.release_blocking_disposition_actions, 0);
+        assert_eq!(summary.operator_required_disposition_actions, 0);
+        assert_eq!(summary.review_required_disposition_actions, 0);
+        assert_eq!(summary.dispatch_required_disposition_actions, 0);
+        assert_eq!(summary.execution_required_disposition_actions, 0);
+        assert_eq!(summary.repair_disposition_actions, 0);
+        assert_eq!(summary.operator_handoff_disposition_actions, 0);
+        assert_eq!(summary.review_gate_disposition_actions, 0);
+        assert_eq!(summary.lineage_gap_disposition_actions, 0);
+        assert_eq!(summary.release_handoff_disposition_actions, 5);
+        assert_eq!(summary.lineage_complete_disposition_actions, 5);
+        assert_eq!(
+            summary.first_review_disposition_action_key,
+            Some(
+                "release-ticket-handoff-execution-work-order-guardrail-audit-clearance-action-evidence-review-disposition-action-01-release_ticket_handoff-substrate_actions"
+                    .to_string()
+            )
+        );
+        assert_eq!(summary.first_required_disposition_action_key, None);
+        assert_eq!(summary.first_repair_disposition_action_key, None);
+        assert_eq!(summary.first_operator_handoff_disposition_action_key, None);
+        assert_eq!(summary.first_review_gate_disposition_action_key, None);
+        assert_eq!(summary.first_lineage_gap_disposition_action_key, None);
+        assert_eq!(
+            summary.first_release_handoff_disposition_action_key,
+            summary.first_review_disposition_action_key
+        );
+        assert_eq!(
+            summary.first_disposition_action_kind,
+            Some(
+                IntegrationMeshReleaseTicketHandoffExecutionWorkOrderGuardrailAuditClearanceActionEvidenceReviewDispositionActionKind::ReleaseTicketHandoff
+            )
+        );
+        assert_eq!(
+            summary.first_disposition_kind,
+            Some(
+                IntegrationMeshReleaseTicketHandoffExecutionWorkOrderGuardrailAuditClearanceActionEvidenceReviewDispositionKind::ReleaseReady
+            )
+        );
+        assert_eq!(summary.next_review_disposition_action_key, None);
+        assert_eq!(summary.next_review_disposition_key, None);
+        assert_eq!(summary.next_evidence_review_key, None);
+        assert_eq!(summary.next_action_evidence_key, None);
+        assert_eq!(summary.next_clearance_action_key, None);
+        assert_eq!(summary.next_work_order_key, None);
+        assert_eq!(summary.next_ticket_key, None);
+        assert_eq!(summary.next_check_kind, None);
+        assert_eq!(summary.next_check_status, None);
+        assert_eq!(summary.next_handoff_lane, None);
+        assert!(
+            summary
+                .release_ticket_handoff_guardrail_audit_clearance_action_evidence_review_dispositions_ready
+        );
+        assert!(
+            summary
+                .release_handoff_execution_work_order_guardrail_audit_clearance_action_evidence_review_disposition_actions_ready
+        );
+        assert!(summary
+            .release_ticket_handoff_guardrail_audit_clearance_action_evidence_review_disposition_actions_ready);
+        assert!(summary
+            .ready_for_release_ticket_handoff_guardrail_audit_clearance_action_evidence_review_disposition_actions());
+        assert!(summary.has_review_disposition_actions());
+        assert!(!summary.has_required_actions());
+        assert!(!summary.has_blockers());
+        assert!(!summary.has_review_work());
+        assert!(!summary.needs_operator());
+        assert!(!summary.has_lineage_gaps());
+        assert!(summary.has_release_handoff_actions());
+        assert!(summary.has_complete_lineage());
         assert!(!summary.requires_execution());
         assert!(!summary.requires_attention());
     }


### PR DESCRIPTION
Summary:
- Add a release ticket handoff disposition-action readiness summary that composes disposition readiness with the new action queue.
- Surface action counts, first/next disposition-action pointers, and attention helpers for repair, review, operator, lineage, and release-handoff work.
- Document the new readiness helper in the smart-home integration catalog README and changelog.

Validation:
- cargo fmt --check
- git diff --check
- cargo test mesh_release_ticket_handoff_guardrail_audit_clearance_action_evidence_review_disposition_action_readiness -- --nocapture
- cargo test