### PR TITLE
feat(mycin-pharm): ground idarucizumab (dabigatran) + dimercaprol (arsenic) antidotes

### DIFF
--- a/code/specs/data/mycin-2026/recall/pharm-edges.adj
+++ b/code/specs/data/mycin-2026/recall/pharm-edges.adj
@@ -162,4 +162,14 @@ rulebook pharm_facts {
         source "Penicillamine is a copper chelator derived from penicillin."
         locator "https://www.ncbi.nlm.nih.gov/books/NBK513316/"
         trust authoritative
+    % --- EXPAND: idarucizumab reverses the anticoagulant dabigatran --------------
+    relate antidote_for(dabigatran_toxicity, idarucizumab)
+        source "Idarucizumab is an anti-dabigatran monoclonal antibody fragment used in patients treated with dabigatran presenting with life-threatening bleeding."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK560651/"
+        trust authoritative
+    % --- EXPAND: dimercaprol (BAL) chelates arsenic / heavy metals ---------------
+    relate antidote_for(arsenic_poisoning, dimercaprol)
+        source "Dimercaprol is a medication used to treat toxic exposure to arsenic, mercury, gold, and lead."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK549804/"
+        trust authoritative
 }

--- a/code/specs/data/mycin-2026/recall/pharm-recall.query.adj
+++ b/code/specs/data/mycin-2026/recall/pharm-recall.query.adj
@@ -32,3 +32,5 @@ import "pharm-edges.adj"
 ? antidote_for(methemoglobinemia, $Antidote)          % expect methylene_blue (expand)
 ? antidote_for(lead_poisoning, $Antidote)             % expect succimer (expand)
 ? antidote_for(copper_toxicity, $Antidote)           % expect penicillamine (expand)
+? antidote_for(dabigatran_toxicity, $Antidote)       % expect idarucizumab (expand)
+? antidote_for(arsenic_poisoning, $Antidote)         % expect dimercaprol (expand)

--- a/code/specs/data/mycin-2026/recall/test_pharm_recall.py
+++ b/code/specs/data/mycin-2026/recall/test_pharm_recall.py
@@ -51,6 +51,8 @@ EXPECTED = [
     ("methemoglobinemia", "antidote_for", "methylene_blue"),      # expand (NBK557593)
     ("lead_poisoning", "antidote_for", "succimer"),               # expand (NBK541097)
     ("copper_toxicity", "antidote_for", "penicillamine"),         # expand (NBK513316)
+    ("dabigatran_toxicity", "antidote_for", "idarucizumab"),      # expand (NBK560651)
+    ("arsenic_poisoning", "antidote_for", "dimercaprol"),         # expand (NBK549804)
 ]
 VAR = {"drug_class": "Class", "mechanism": "MOA", "adverse_effect": "Effect",
        "antidote_for": "Antidote"}


### PR DESCRIPTION
## What
Two more grounded antidote pairs (fresh subjects, no multi-value ambiguity):

- **antidote_for(dabigatran_toxicity, idarucizumab)** [NBK560651]:
  > Idarucizumab is an anti-dabigatran monoclonal antibody fragment used in patients treated with dabigatran presenting with life-threatening bleeding.
- **antidote_for(arsenic_poisoning, dimercaprol)** [NBK549804]:
  > Dimercaprol is a medication used to treat toxic exposure to arsenic, mercury, gold, and lead.

## Changes (data-only)
- `pharm-edges.adj` +2 `relate`; `pharm-recall.query.adj` +2; `test_pharm_recall.py` EXPECTED +2

## Verification
- `test_pharm_recall: 3/3 passed`; ruff clean; data-only security review passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)