### PR TITLE
feat(mycin-neuro): ground cerebellar localization (midline→imbalance, hemisphere→incoordination)

### DIFF
--- a/code/specs/data/mycin-2026/recall/neuro-edges.adj
+++ b/code/specs/data/mycin-2026/recall/neuro-edges.adj
@@ -82,4 +82,16 @@ rulebook neuro_facts {
         source "Adult-onset Huntington disease is typically characterized by early striatal atrophy in the caudate."
         locator "https://www.ncbi.nlm.nih.gov/books/NBK559166/"
         trust authoritative
+
+    % --- EXPAND: cerebellar localization — one span names BOTH lesion sites ----------
+    % Midline (vermis) vs hemispheric cerebellar lesions produce distinct deficits; the
+    % single declarative below names both endpoints for each edge.
+    relate lesion_causes(midline_cerebellum, imbalance)
+        source "Therefore, any midline cerebellar lesions manifest as imbalance, while hemispheric cerebellar lesions result mainly in incoordination."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK562317/"
+        trust authoritative
+    relate lesion_causes(cerebellar_hemisphere, incoordination)
+        source "Therefore, any midline cerebellar lesions manifest as imbalance, while hemispheric cerebellar lesions result mainly in incoordination."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK562317/"
+        trust authoritative
 }

--- a/code/specs/data/mycin-2026/recall/neuro-recall.query.adj
+++ b/code/specs/data/mycin-2026/recall/neuro-recall.query.adj
@@ -19,3 +19,5 @@ import "neuro-edges.adj"
 ? lesion_causes(substantia_nigra, $Deficit)     % expect parkinson_disease
 ? lesion_causes(subthalamic_nucleus, $Deficit)  % expect hemiballismus
 ? lesion_causes(caudate_nucleus, $Deficit)      % expect huntington_disease
+? lesion_causes(midline_cerebellum, $Deficit)   % expect imbalance (expand)
+? lesion_causes(cerebellar_hemisphere, $Deficit) % expect incoordination (expand)

--- a/code/specs/data/mycin-2026/recall/test_neuro_recall.py
+++ b/code/specs/data/mycin-2026/recall/test_neuro_recall.py
@@ -35,6 +35,8 @@ EXPECTED = {
     "substantia_nigra": "parkinson_disease",
     "subthalamic_nucleus": "hemiballismus",
     "caudate_nucleus": "huntington_disease",
+    "midline_cerebellum": "imbalance",              # expand (NBK562317)
+    "cerebellar_hemisphere": "incoordination",      # expand (NBK562317)
 }
 REL = "lesion_causes"
 VAR = "Deficit"


### PR DESCRIPTION
## What
Classic cerebellar localization — two lesion→deficit edges grounded by ONE self-contained StatPearls span (NBK562317) naming both sites and both deficits:

- **lesion_causes(midline_cerebellum, imbalance)**
- **lesion_causes(cerebellar_hemisphere, incoordination)**
  > Therefore, any midline cerebellar lesions manifest as imbalance, while hemispheric cerebellar lesions result mainly in incoordination.

## Changes (data-only)
- `neuro-edges.adj` +2 `relate`; `neuro-recall.query.adj` +2; `test_neuro_recall.py` EXPECTED +2 (`hippocampus` negative control unchanged)

## Verification
- `test_neuro_recall: 3/3 passed`; ruff clean; data-only security review passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)