### PR TITLE
feat(r-lang): R-35 — ordered factors & cut() label polish (ordered/as.ordered/is.ordered, ordered_result, dig.lab)

### DIFF
--- a/code/packages/rust/r-runtime/CHANGELOG.md
+++ b/code/packages/rust/r-runtime/CHANGELOG.md
@@ -2,6 +2,35 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.30.0] - 2026-06-21
+
+### Added (via the shared `s-runtime`)
+
+- **R-35 — ordered factors & `cut()` label polish**, reached through ordinary R
+  syntax. Completes the R-33 deferral of `ordered_result =` / `dig.lab =` and adds
+  the ordered-factor family.
+  - **`ordered(x, levels =, labels =)`** / **`factor(x, ordered = TRUE)`** build an
+    ordered factor; **`as.ordered(x)`** coerces; **`is.ordered(x)`** tests for it.
+    `class(ordered(c("a","b")))` is `c("ordered", "factor")`.
+  - **Ordered comparison by level index**: with
+    `f <- ordered(c("lo","hi","mid"), levels = c("lo","mid","hi"))`,
+    `f[1] < f[2]` (lo < hi) is `TRUE` and `f[2] < f[3]` (hi < mid) is `FALSE` —
+    comparison is by the level position, not the label string. All six relational
+    operators are supported; an `NA` code yields `NA`; comparing ordered factors
+    with different level sets is an error.
+  - **`cut(..., ordered_result = TRUE)`** returns an ordered factor (its bins
+    compare by interval order); **`cut(..., dig.lab = k)`** formats break labels to
+    `k` significant digits (default 3), e.g.
+    `levels(cut(c(1.23456, 5.6789), breaks = c(0, 3.14159, 10), dig.lab = 2))` →
+    `c("(0,3.1]", "(3.1,10]")`. (`ordered_result` is an R-only spelling — the S
+    lexer reads `_` as assignment.)
+  - **Security**: ordered comparison works on integer codes only (out-of-range / NA
+    → NA, never a panic) and rejects differing level sets; `dig.lab` is clamped to
+    `1..=22` before formatting, so no extreme value can over-allocate or panic. No
+    new unbounded multiplier.
+  - **Deferred to R-39**: `Ops.ordered` group-generic dispatch and ordered-factor
+    `sort`/`max`/`min`/`range`.
+
 ## [0.29.0] - 2026-06-21
 
 ### Added (via the shared `s-runtime`)

--- a/code/packages/rust/r-runtime/README.md
+++ b/code/packages/rust/r-runtime/README.md
@@ -228,8 +228,25 @@ bins over the range of `x`, extended by `dx/1000` on each side (`dx=max-min`;
 degenerate `dx=0` → `abs(min)`, then `1`) — `cut(0:10, breaks=5)` → 5 levels, every
 value binned. Security: `N` is capped at `MAX_SEQ_LEN` before any allocation, the
 breaks use finite/checked arithmetic (no divide-by-zero on a degenerate range), and
-the `labels` length check never panics. `dig.lab=` and `ordered_result=` are
-deferred to R-34.
+the `labels` length check never panics. `dig.lab=` and `ordered_result=` land in
+R-35, below.
+
+**R-35 — ordered factors & `cut()` label polish.** An *ordered* factor is a factor
+whose levels carry a meaningful order. `ordered(x, levels=, labels=)` (and the
+synonym `factor(x, ordered=TRUE)`) build one, `as.ordered(x)` coerces, and
+`is.ordered(x)` tests for it; `class(ordered(c("a","b")))` is
+`c("ordered", "factor")`. The relational operators (`<`, `<=`, `>`, `>=`, `==`,
+`!=`) between ordered factors compare **by level index**, not label string: with
+`f <- ordered(c("lo","hi","mid"), levels=c("lo","mid","hi"))`, `f[1] < f[2]`
+(lo < hi) is `TRUE` while `f[2] < f[3]` (hi < mid) is `FALSE`. An `NA` code yields
+`NA`, and comparing ordered factors with different level sets is an error.
+`cut(..., ordered_result=TRUE)` returns an ordered factor (bins compare by interval
+order), and `cut(..., dig.lab=k)` formats break labels to `k` significant digits
+(default 3), e.g. `levels(cut(c(1.23456, 5.6789), breaks=c(0, 3.14159, 10),
+dig.lab=2))` → `c("(0,3.1]", "(3.1,10]")`. Security: ordered comparison reads the
+integer codes only (out-of-range / NA → NA, never a panic), and `dig.lab` is clamped
+to `1..=22` before formatting. (`sort`/`max`/`min`/`range` on ordered factors and
+`Ops.ordered` dispatch are deferred to R-39.)
 
 **R-36 — matrix cross products** add `crossprod` and `tcrossprod`, again through the
 shared `s-runtime`. An independent matrix-algebra item, defined entirely in terms of

--- a/code/packages/rust/r-runtime/src/lib.rs
+++ b/code/packages/rust/r-runtime/src/lib.rs
@@ -3178,4 +3178,70 @@ mod tests {
             "expected conformability error, got: {err}"
         );
     }
+
+    // --- R-35: ordered factors & cut() label polish (R syntax) ----------
+
+    #[test]
+    fn is_ordered_through_r_syntax() {
+        assert_eq!(
+            show("is.ordered(ordered(c(\"lo\", \"hi\"), levels = c(\"lo\", \"mid\", \"hi\")))\n"),
+            "[1] TRUE"
+        );
+        assert_eq!(show("is.ordered(factor(c(\"a\", \"b\")))\n"), "[1] FALSE");
+    }
+
+    #[test]
+    fn ordered_class_vector_through_r_syntax() {
+        // class(ordered(...)) prints as the two-element character vector.
+        // Elements are right-aligned to the widest quoted string ("ordered" is
+        // wider than "factor"), so "factor" gets a leading pad space.
+        assert_eq!(
+            show("class(ordered(c(\"a\", \"b\")))\n"),
+            "[1] \"ordered\"  \"factor\""
+        );
+    }
+
+    #[test]
+    fn ordered_comparison_by_level_index_through_r_syntax() {
+        // f[1] < f[2] is lo < hi (TRUE); f[2] < f[3] is hi < mid (FALSE).
+        assert_eq!(
+            show("f <- ordered(c(\"lo\", \"hi\", \"mid\"), levels = c(\"lo\", \"mid\", \"hi\"))\nf[1] < f[2]\n"),
+            "[1] TRUE"
+        );
+        assert_eq!(
+            show("f <- ordered(c(\"lo\", \"hi\", \"mid\"), levels = c(\"lo\", \"mid\", \"hi\"))\nf[2] < f[3]\n"),
+            "[1] FALSE"
+        );
+    }
+
+    #[test]
+    fn as_ordered_through_r_syntax() {
+        assert_eq!(
+            show("is.ordered(as.ordered(factor(c(\"a\", \"b\"))))\n"),
+            "[1] TRUE"
+        );
+    }
+
+    #[test]
+    fn cut_ordered_result_through_r_syntax() {
+        assert_eq!(
+            show("is.ordered(cut(c(1, 5, 10), breaks = c(0, 3, 6, 11), ordered_result = TRUE))\n"),
+            "[1] TRUE"
+        );
+        // Ordered bins compare by interval order.
+        assert_eq!(
+            show("g <- cut(c(1, 10), breaks = c(0, 3, 6, 11), ordered_result = TRUE)\ng[1] < g[2]\n"),
+            "[1] TRUE"
+        );
+    }
+
+    #[test]
+    fn cut_dig_lab_through_r_syntax() {
+        // levels() of the dig.lab=2 cut prints both interval labels, right-aligned
+        // to the wider "(3.1,10]" (so "(0,3.1]" gets a leading pad space).
+        assert_eq!(
+            show("levels(cut(c(1.23456, 5.6789), breaks = c(0, 3.14159, 10), dig.lab = 2))\n"),
+            "[1]  \"(0,3.1]\" \"(3.1,10]\""
+        );
+    }
 }

--- a/code/packages/rust/s-runtime/CHANGELOG.md
+++ b/code/packages/rust/s-runtime/CHANGELOG.md
@@ -2,6 +2,43 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.31.0] - 2026-06-21
+
+### Added
+
+- **Ordered factors & `cut()` label polish (R-35)** — available to both S and R
+  through the shared tree-walker.
+  - **Representation**: `SValue::Factor` gains an `ordered: bool` field. `class()`
+    reports `c("ordered", "factor")` when set (plain `"factor"` otherwise), and an
+    ordered factor prints its `Levels:` line with `<` separators
+    (`Levels: lo < mid < hi`). All prior factor constructions default
+    `ordered = false`, so unordered factors are bit-for-bit unchanged.
+  - **`ordered(x, levels =, labels =)`** and **`factor(x, ordered = TRUE)`** build
+    an ordered factor (reusing the refactored `build_factor` helper).
+    **`as.ordered(x)`** coerces (a factor flips its flag; any other vector is
+    factor-encoded first). **`is.ordered(x)`** is `TRUE` iff `x` is an ordered
+    factor — never errors.
+  - **Ordered-factor comparison**: `<`, `<=`, `>`, `>=`, `==`, `!=` between two
+    ordered factors compare **by level index** (the 1-based `code`), not by label
+    string, NA-propagating. Two ordered factors with **different level sets** is a
+    clean error (`"level sets of factors are different"`). Order operators on an
+    *unordered* factor error (`"'<' not meaningful for factors"`); `==`/`!=` fall
+    back to label comparison.
+  - **`cut(..., ordered_result = TRUE)`** makes the binned factor an ordered factor
+    (intervals are naturally ordered low→high). **`cut(..., dig.lab = k)`** formats
+    auto-generated break labels to `k` significant digits (default **3**), e.g.
+    `cut(..., breaks = c(0, 3.14159, 10), dig.lab = 2)` → levels `"(0,3.1]"`,
+    `"(3.1,10]"`.
+  - **Security**: ordered comparison reads the integer `codes` only — an
+    out-of-range or `NA` code maps to `NA`, never panicking — and rejects differing
+    level sets before any compare. `dig.lab` is **clamped to `1..=22`** before
+    formatting (a malformed / non-positive value falls back to the default 3), so
+    no caller-controlled value can drive an unbounded format width or a panic. No
+    new unbounded multiplier; the level vector is still bounded by the
+    `MAX_SEQ_LEN`-bounded break count.
+  - **Deferred to R-39**: the S3 `Ops.ordered` group-generic *dispatch* surface and
+    order statistics on ordered factors (`sort`/`max`/`min`/`range` by level order).
+
 ## [0.30.0] - 2026-06-21
 
 ### Added

--- a/code/packages/rust/s-runtime/README.md
+++ b/code/packages/rust/s-runtime/README.md
@@ -252,7 +252,21 @@ a hand-written loop. See [What "S-flavored" means here](#what-s-flavored-means-h
   `1`). `N` is capped at `MAX_SEQ_LEN` before any allocation and the breaks use
   finite/checked arithmetic, so a huge `N` or a degenerate range is rejected/handled
   rather than over-allocating or dividing by zero. (`dig.lab=` and `ordered_result=`
-  are deferred to R-34.)
+  land in R-35, below.)
+- **Ordered factors & `cut()` label polish** (R-35): an *ordered* factor is a factor
+  whose levels carry a meaningful order — `SValue::Factor` gains an `ordered: bool`
+  field, so `class()` reports `c("ordered", "factor")` when set (and the `Levels:`
+  line prints with `<` separators). **`ordered(x, levels=, labels=)`** /
+  **`factor(x, ordered=TRUE)`** build one; **`as.ordered(x)`** coerces;
+  **`is.ordered(x)`** tests for it. The relational operators
+  (`<`, `<=`, `>`, `>=`, `==`, `!=`) between two ordered factors compare **by level
+  index** (the 1-based code), so with `levels=c("lo","mid","hi")` the element `"hi"`
+  is `>` the element `"lo"`; an `NA` code → `NA`, and differing level sets is a clean
+  error. `cut(..., ordered_result=TRUE)` makes the binned factor ordered, and
+  `cut(..., dig.lab=k)` formats break labels to `k` significant digits (default 3,
+  clamped to `1..=22` for safety — no extreme value can over-allocate or panic).
+  (Ordered-factor `sort`/`max`/`min`/`range` and `Ops.ordered` dispatch are deferred
+  to R-39.)
 - **Matrix cross products** (R-36): **`crossprod(x, y)`** = `t(x) %*% y` and
   **`crossprod(x)`** = `t(x) %*% x` (the Gram matrix `X'X`); **`tcrossprod(x, y)`** =
   `x %*% t(y)` and **`tcrossprod(x)`** = `x %*% t(x)` (`XX'`). The second argument

--- a/code/packages/rust/s-runtime/src/builtins.rs
+++ b/code/packages/rust/s-runtime/src/builtins.rs
@@ -4587,16 +4587,24 @@ fn format_break(b: f64, dig_lab: usize) -> String {
 }
 
 /// Round `x` to `sig` significant digits and render it without an exponent,
-/// trimming trailing zeros. `sig` is bounded (`1..=22`) by the caller, so the
-/// formatting width here is bounded too (no caller-driven huge allocation).
+/// trimming trailing zeros. `sig` is bounded (`1..=22`) by the caller.
+///
+/// **Bound on the format width (security).** The number of decimal places needed
+/// for `sig` significant figures is `sig - 1 - floor(log10|x|)`. For a *tiny* break
+/// (e.g. `1e-300`) `floor(log10|x|)` is very negative, so the naive count would be
+/// several hundred — a 340-character fixed-precision string per break. The clamp to
+/// `0..=22` below caps that: we never emit more than 22 fractional digits, so a
+/// caller-controlled (subnormal) break can neither force a huge allocation nor a
+/// long label. `sig <= 22` keeps the *high* end small too. (R itself switches to
+/// scientific notation for such values; capping the digit count tracks that.)
 fn format_sig(x: f64, sig: usize) -> String {
     if x == 0.0 {
         return "0".to_string();
     }
-    // Decimal places needed for `sig` significant figures = sig - 1 - floor(log10|x|).
     let exp = x.abs().log10().floor() as i32;
-    let decimals = (sig as i32 - 1 - exp).max(0) as usize;
-    // `decimals` is bounded: `sig <= 22`, so the fixed-precision width stays small.
+    // Clamp the decimal count to `0..=22`: `.max(0)` alone is NOT enough, because a
+    // tiny `x` makes `exp` very negative and blows the count up — `clamp` bounds it.
+    let decimals = (sig as i32 - 1 - exp).clamp(0, 22) as usize;
     let s = format!("{x:.decimals$}");
     if s.contains('.') {
         s.trim_end_matches('0').trim_end_matches('.').to_string()

--- a/code/packages/rust/s-runtime/src/builtins.rs
+++ b/code/packages/rust/s-runtime/src/builtins.rs
@@ -90,14 +90,22 @@ pub fn install(env: &Env) {
     define(env, "is.element", builtin("is.element", b_is_element));
     define(env, "duplicated", builtin("duplicated", b_duplicated));
     // R-30 — first-duplicate index (ordering refinements).
-    define(env, "anyDuplicated", builtin("anyDuplicated", b_any_duplicated));
+    define(
+        env,
+        "anyDuplicated",
+        builtin("anyDuplicated", b_any_duplicated),
+    );
     define(env, "rank", builtin("rank", b_rank));
     define(env, "which", builtin("which", b_which));
     define(env, "any", builtin("any", b_any));
     define(env, "all", builtin("all", b_all));
     define(env, "is.na", builtin("is.na", b_is_na));
     // R-23 — environment predicate + the `environment(f) <- e` replacement.
-    define(env, "is.environment", builtin("is.environment", b_is_environment));
+    define(
+        env,
+        "is.environment",
+        builtin("is.environment", b_is_environment),
+    );
     define(
         env,
         "environment<-",
@@ -229,6 +237,10 @@ pub fn install(env: &Env) {
 
     // v2 — factors.
     define(env, "factor", builtin("factor", b_factor));
+    // R-35 — ordered factors.
+    define(env, "ordered", builtin("ordered", b_ordered));
+    define(env, "as.ordered", builtin("as.ordered", b_as_ordered));
+    define(env, "is.ordered", builtin("is.ordered", b_is_ordered));
     define(env, "levels", builtin("levels", b_levels));
     define(env, "nlevels", builtin("nlevels", b_nlevels));
     define(env, "as.character", builtin("as.character", b_as_character));
@@ -1247,9 +1259,23 @@ fn gauss_jordan(mut a: Vec<f64>, n: usize, mut b: Vec<f64>, m: usize) -> SResult
 // v2 — factors
 // ===========================================================================
 
-/// `factor(x, levels =, labels =)` — encode `x` as a factor. Levels default to
-/// the sorted unique non-`NA` values of `x`; `labels` (if given) rename them.
+/// `factor(x, levels =, labels =, ordered =)` — encode `x` as a factor. Levels
+/// default to the sorted unique non-`NA` values of `x`; `labels` (if given) rename
+/// them. **R-35:** `ordered = TRUE` makes the result an *ordered* factor (see
+/// [`build_factor`]); the default is an unordered factor.
 fn b_factor(_interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
+    // `ordered =` is a logical flag (default FALSE). A malformed value surfaces as
+    // a clean error via `truthy` rather than a panic.
+    let ordered = named_flag(args, "ordered", false)?;
+    build_factor(args, ordered)
+}
+
+/// The shared factor builder used by `factor` (R-13) and `ordered` (R-35). Reads
+/// the first positional argument as the data, the `levels =` / `labels =` named
+/// arguments exactly as `factor` does, and stamps the supplied `ordered` flag onto
+/// the result. Centralising this keeps `ordered()` from re-deriving the level
+/// inference and code assignment.
+fn build_factor(args: &[Arg], ordered: bool) -> SResult<SValue> {
     let values = first_positional(args)?.as_character();
 
     // Levels: explicit, else the sorted distinct non-NA values.
@@ -1288,7 +1314,41 @@ fn b_factor(_interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
     Ok(SValue::Factor {
         codes,
         levels: display,
+        ordered,
     })
+}
+
+/// `ordered(x, levels =, labels =)` — build an **ordered** factor (R-35): a factor
+/// whose levels carry a meaningful order, so its elements compare by level index.
+/// Identical to `factor` (it reuses [`build_factor`]) but with `ordered = true`.
+fn b_ordered(_interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
+    build_factor(args, true)
+}
+
+/// `as.ordered(x)` — coerce `x` to an ordered factor (R-35). An existing factor
+/// (ordered or not) keeps its codes/levels and gains the ordered flag; any other
+/// value is first encoded with [`build_factor`] (sorted-unique levels).
+fn b_as_ordered(_interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
+    match peel_structural(first_positional(args)?) {
+        SValue::Factor { codes, levels, .. } => Ok(SValue::Factor {
+            codes: codes.clone(),
+            levels: levels.clone(),
+            ordered: true,
+        }),
+        // Not already a factor: encode it, then mark ordered. We reuse the same
+        // single positional argument (the data) through `build_factor`.
+        _ => build_factor(args, true),
+    }
+}
+
+/// `is.ordered(x)` — `TRUE` iff `x` is an ordered factor (R-35); `FALSE` for an
+/// unordered factor or any non-factor. Never errors.
+fn b_is_ordered(_interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
+    let ordered = matches!(
+        peel_structural(first_positional(args)?),
+        SValue::Factor { ordered: true, .. }
+    );
+    Ok(SValue::Logical(vec![Some(ordered)]))
 }
 
 /// `levels(f)` — the level labels of a factor (`NULL` otherwise).
@@ -1922,7 +1982,11 @@ fn b_order(_interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
         Num(Vec<f64>),
         Str(Vec<Option<String>>),
     }
-    let positional: Vec<&SValue> = args.iter().filter(|a| a.name.is_none()).map(|a| &a.value).collect();
+    let positional: Vec<&SValue> = args
+        .iter()
+        .filter(|a| a.name.is_none())
+        .map(|a| &a.value)
+        .collect();
     let first = *positional
         .first()
         .ok_or_else(|| SError::BadArgs("argument \"x\" is missing".into()))?;
@@ -1933,9 +1997,7 @@ fn b_order(_interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
         // A length mismatch between keys is an error in R ("argument lengths
         // differ"); we reject it before any indexing can go out of bounds.
         if v.length() != n {
-            return Err(SError::BadArgs(
-                "argument lengths differ in order()".into(),
-            ));
+            return Err(SError::BadArgs("argument lengths differ in order()".into()));
         }
         let key = match v.strip_names().strip_attrs() {
             SValue::Character(_) | SValue::Factor { .. } => Key::Str(v.as_character()),
@@ -2029,7 +2091,10 @@ fn b_rep(_interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
 /// `as_character` is total, and the result is just a `HashSet` whose size is bounded
 /// by the (already-`MAX_SEQ_LEN`-capped) `incomparables` vector.
 fn incomparables_keys(args: &[Arg]) -> HashSet<Option<String>> {
-    let Some(arg) = args.iter().find(|a| a.name.as_deref() == Some("incomparables")) else {
+    let Some(arg) = args
+        .iter()
+        .find(|a| a.name.as_deref() == Some("incomparables"))
+    else {
         return HashSet::new();
     };
     // The default `FALSE` means "no incomparables" — treat it as the empty set.
@@ -2352,7 +2417,10 @@ fn b_rank(interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
         First,
         Random,
     }
-    let ties = match args.iter().find(|a| a.name.as_deref() == Some("ties.method")) {
+    let ties = match args
+        .iter()
+        .find(|a| a.name.as_deref() == Some("ties.method"))
+    {
         Some(arg) => match arg
             .value
             .as_character()
@@ -2909,7 +2977,11 @@ fn as_list(value: &SValue) -> Option<(&[Option<String>], &[SValue])> {
 /// a direct call: `do.call(paste, list("a", "b", sep = "-"))` is `paste("a",
 /// "b", sep = "-")` → `"a-b"`.
 fn b_do_call(interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
-    let positional: Vec<&SValue> = args.iter().filter(|a| a.name.is_none()).map(|a| &a.value).collect();
+    let positional: Vec<&SValue> = args
+        .iter()
+        .filter(|a| a.name.is_none())
+        .map(|a| &a.value)
+        .collect();
     let what = positional
         .first()
         .ok_or_else(|| SError::BadArgs("do.call: missing 'what' argument".into()))?;
@@ -2971,8 +3043,8 @@ fn resolve_callable(interp: &Interpreter, what: &SValue) -> SResult<SValue> {
             .first()
             .and_then(|o| o.clone())
             .ok_or_else(|| SError::BadArgs("do.call: 'what' name is NA".into()))?;
-        let found = lookup(interp.global(), &name)
-            .ok_or_else(|| SError::Undefined(name.clone()))?;
+        let found =
+            lookup(interp.global(), &name).ok_or_else(|| SError::Undefined(name.clone()))?;
         if !found.is_callable() {
             return Err(SError::NotCallable(found.type_name().to_string()));
         }
@@ -2988,8 +3060,11 @@ fn resolve_callable(interp: &Interpreter, what: &SValue) -> SResult<SValue> {
 /// follows `x` (with removals dropped) and then `val`'s new names in `val`
 /// order. Both arguments must be lists.
 fn b_modify_list(_interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
-    let positional: Vec<&SValue> =
-        args.iter().filter(|a| a.name.is_none()).map(|a| &a.value).collect();
+    let positional: Vec<&SValue> = args
+        .iter()
+        .filter(|a| a.name.is_none())
+        .map(|a| &a.value)
+        .collect();
     let x = positional
         .first()
         .ok_or_else(|| SError::BadArgs("modifyList: missing 'x' argument".into()))?;
@@ -2997,10 +3072,18 @@ fn b_modify_list(_interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
         .get(1)
         .ok_or_else(|| SError::BadArgs("modifyList: missing 'val' argument".into()))?;
 
-    let (x_names, x_items) = as_list(x)
-        .ok_or_else(|| SError::BadArgs(format!("modifyList: 'x' must be a list, got {}", x.type_name())))?;
-    let (v_names, v_items) = as_list(val)
-        .ok_or_else(|| SError::BadArgs(format!("modifyList: 'val' must be a list, got {}", val.type_name())))?;
+    let (x_names, x_items) = as_list(x).ok_or_else(|| {
+        SError::BadArgs(format!(
+            "modifyList: 'x' must be a list, got {}",
+            x.type_name()
+        ))
+    })?;
+    let (v_names, v_items) = as_list(val).ok_or_else(|| {
+        SError::BadArgs(format!(
+            "modifyList: 'val' must be a list, got {}",
+            val.type_name()
+        ))
+    })?;
 
     // Every element of `val` must be named (R errors on an unnamed overlay
     // element — there is no positional notion of "modify"). A names vector
@@ -3027,7 +3110,10 @@ fn b_modify_list(_interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
     // `v_items` are the same length — a missing name is treated as unnamed,
     // which the all-named check below already rejects).
     for (i, new_value) in v_items.iter().enumerate() {
-        let name = v_names.get(i).and_then(|n| n.as_deref()).unwrap_or_default();
+        let name = v_names
+            .get(i)
+            .and_then(|n| n.as_deref())
+            .unwrap_or_default();
         let pos = names.iter().position(|n| n.as_deref() == Some(name));
         match (pos, matches!(new_value, SValue::Null)) {
             // Existing name, NULL value → remove (record the index).
@@ -3480,7 +3566,10 @@ fn b_format(_interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
 
     // Render each element to its natural string first; common-width padding is
     // a second pass so we can measure the widest.
-    let is_numeric = matches!(peel_structural(x), SValue::Double(_) | SValue::Matrix { .. });
+    let is_numeric = matches!(
+        peel_structural(x),
+        SValue::Double(_) | SValue::Matrix { .. }
+    );
     let rendered: Vec<String> = if is_numeric {
         let d = x.as_double()?;
         d.iter()
@@ -3502,7 +3591,11 @@ fn b_format(_interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
         return Ok(SValue::Character(vec![]));
     }
 
-    let widest = rendered.iter().map(|s| s.chars().count()).max().unwrap_or(0);
+    let widest = rendered
+        .iter()
+        .map(|s| s.chars().count())
+        .max()
+        .unwrap_or(0);
     let target = widest.max(min_width).min(MAX_FIELD);
     // Bound the *product* (common width × element count), not just each field.
     check_output_budget(target, rendered.len())?;
@@ -3633,7 +3726,9 @@ fn format_c_one(
     // d/f/e/g go through the shared sprintf conversion renderer. Wrap the
     // element as a one-row SValue so `render_conversion`'s recycling indexes it.
     let sval = match doubles {
-        Some(d) => SValue::Double(Double::from_values(vec![d.get_value(i).unwrap_or(f64::NAN)])),
+        Some(d) => SValue::Double(Double::from_values(vec![d
+            .get_value(i)
+            .unwrap_or(f64::NAN)])),
         None => SValue::Character(vec![chars.get(i).cloned().flatten()]),
     };
     render_conversion(conv, Some(&sval), 0, digits)
@@ -3878,7 +3973,10 @@ fn b_reduce(interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
         .map(|a| a.value.clone())
         .or_else(|| data.get(1).cloned());
     // `accumulate =` (named only; defaults to FALSE) selects running-fold output.
-    let accumulate = match args.iter().find(|a| a.name.as_deref() == Some("accumulate")) {
+    let accumulate = match args
+        .iter()
+        .find(|a| a.name.as_deref() == Some("accumulate"))
+    {
         Some(a) => a.value.truthy()?,
         None => false,
     };
@@ -4158,9 +4256,14 @@ fn b_outer(interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
     let nrow = x.length();
     let ncol = y.length();
     // Guard the product BEFORE allocating: refuse overflow or > MAX_SEQ_LEN.
-    let total = nrow.checked_mul(ncol).filter(|&t| t <= MAX_SEQ_LEN).ok_or_else(|| {
-        SError::Index(format!("outer: result too large (limit {MAX_SEQ_LEN} elements)"))
-    })?;
+    let total = nrow
+        .checked_mul(ncol)
+        .filter(|&t| t <= MAX_SEQ_LEN)
+        .ok_or_else(|| {
+            SError::Index(format!(
+                "outer: result too large (limit {MAX_SEQ_LEN} elements)"
+            ))
+        })?;
 
     // Fast numeric paths for the two arithmetic primitives, identified by the
     // string forms "*" / "+". Anything else (including a function value) goes
@@ -4211,7 +4314,10 @@ fn b_outer(interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
             let r = interp.call_value(
                 fun.clone(),
                 &[
-                    Arg { name: None, value: xi },
+                    Arg {
+                        name: None,
+                        value: xi,
+                    },
                     Arg {
                         name: None,
                         value: yj.clone(),
@@ -4239,7 +4345,7 @@ fn b_outer(interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
 /// Returns `(levels, labels)` where `labels[k]` is the group of element `k`.
 fn group_labels(index: &SValue) -> (Vec<String>, Vec<Option<String>>) {
     match index.strip_names() {
-        SValue::Factor { codes, levels } => {
+        SValue::Factor { codes, levels, .. } => {
             let labels: Vec<Option<String>> = codes
                 .iter()
                 .map(|c| c.and_then(|k| levels.get((k as usize).wrapping_sub(1)).cloned()))
@@ -4510,24 +4616,58 @@ fn b_find_interval(_interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
     Ok(SValue::doubles(out))
 }
 
-/// Format a numeric breakpoint for an interval label the way R's `cut` does for
-/// "nice" small integers: drop a trailing `.0` so `3.0` prints as `3`, but keep
-/// genuine fractions (`3.5`). This keeps the auto-generated levels readable
-/// (`"(0,3]"` rather than `"(0,3.0]"`).
-fn format_break(b: f64) -> String {
-    if b.is_finite() && b.fract() == 0.0 && b.abs() < 1e15 {
-        format!("{}", b as i64)
+/// Format a numeric breakpoint for an interval label to `dig_lab` **significant
+/// digits** (R-35), the way R's `cut` formats break numbers.
+///
+/// * A "nice" integer break (`3.0`, `10`) prints without a decimal point
+///   (`"3"`, `"10"`) regardless of `dig_lab`, keeping labels like `"(0,3]"`.
+/// * A fractional break is rounded to `dig_lab` significant figures with trailing
+///   zeros trimmed, so `3.14159` at `dig_lab = 2` → `"3.1"` and at the default
+///   `dig_lab = 3` → `"3.14"`.
+///
+/// `dig_lab` is already clamped to `1..=22` by [`dig_lab_value`], so the `{:.*e}`
+/// precision below is bounded — no caller-controlled value can force a huge width.
+fn format_break(b: f64, dig_lab: usize) -> String {
+    // Non-finite (shouldn't reach here for real breaks) → plain fallback.
+    if !b.is_finite() {
+        return format!("{b}");
+    }
+    // A whole-number break keeps its integer form (no spurious ".0"), matching the
+    // R-32/R-33 behaviour, as long as it is representable as an i64.
+    if b.fract() == 0.0 && b.abs() < 1e15 {
+        return format!("{}", b as i64);
+    }
+    format_sig(b, dig_lab)
+}
+
+/// Round `x` to `sig` significant digits and render it without an exponent where
+/// reasonable, trimming trailing zeros. `sig` is bounded (`1..=22`) by the caller,
+/// so the formatting widths here are bounded too.
+fn format_sig(x: f64, sig: usize) -> String {
+    if x == 0.0 {
+        return "0".to_string();
+    }
+    // Decimal places needed for `sig` significant figures = sig - 1 - floor(log10|x|).
+    let exp = x.abs().log10().floor() as i32;
+    let decimals = (sig as i32 - 1 - exp).max(0) as usize;
+    // `decimals` is bounded: sig <= 22 and exp >= small-negative for our inputs, so
+    // this width stays small. Render with fixed precision, then trim trailing zeros.
+    let s = format!("{x:.decimals$}");
+    if s.contains('.') {
+        let trimmed = s.trim_end_matches('0').trim_end_matches('.');
+        trimmed.to_string()
     } else {
-        format!("{b}")
+        s
     }
 }
 
 /// Build the auto-generated interval label for the `i`-th interval (0-based) of
 /// `breaks`, respecting `right`: right-closed intervals print `"(lo,hi]"`,
-/// left-closed `[lo,hi)`. (R-33 — extends the R-32 right-closed-only formatter.)
-fn cut_interval_label(breaks: &[f64], i: usize, right: bool) -> String {
-    let lo = format_break(breaks[i]);
-    let hi = format_break(breaks[i + 1]);
+/// left-closed `[lo,hi)`. (R-33 — extends the R-32 right-closed-only formatter;
+/// R-35 — break numbers are formatted to `dig_lab` significant digits.)
+fn cut_interval_label(breaks: &[f64], i: usize, right: bool, dig_lab: usize) -> String {
+    let lo = format_break(breaks[i], dig_lab);
+    let hi = format_break(breaks[i + 1], dig_lab);
     if right {
         format!("({lo},{hi}]")
     } else {
@@ -4698,11 +4838,47 @@ fn b_cut(_interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
         }
     }
 
-    // Otherwise build the factor levels: custom `labels` (validated length) or the
-    // auto-generated interval strings (respecting `right`).
-    let levels = cut_levels(args, &breaks, n_intervals, right)?;
+    // R-35: `dig.lab` (default 3) controls the number of significant digits used
+    // when formatting break numbers in the auto-generated labels. It is clamped to
+    // a safe range inside `dig_lab_value` so an extreme value cannot drive a huge
+    // allocation or a formatter panic.
+    let dig_lab = dig_lab_value(args)?;
 
-    Ok(SValue::Factor { codes, levels })
+    // Otherwise build the factor levels: custom `labels` (validated length) or the
+    // auto-generated interval strings (respecting `right` and `dig.lab`).
+    let levels = cut_levels(args, &breaks, n_intervals, right, dig_lab)?;
+
+    // R-35: `ordered_result = TRUE` makes the binned factor an *ordered* factor —
+    // its intervals are naturally ordered low→high, so the bins compare by order.
+    let ordered = named_flag(args, "ordered_result", false)?;
+
+    Ok(SValue::Factor {
+        codes,
+        levels,
+        ordered,
+    })
+}
+
+/// R-35 — read `cut`'s `dig.lab` argument: the number of **significant digits**
+/// used when auto-formatting break numbers in interval labels. Defaults to **3**
+/// (base R's default). The value is **clamped to `1..=22`** (R's representable-
+/// digit ceiling) so a caller-supplied extreme (e.g. `dig.lab = 1e9`) can never
+/// drive an unbounded format width or a panic; a non-finite or non-positive value
+/// falls back to the default rather than erroring, matching R's lenient handling.
+fn dig_lab_value(args: &[Arg]) -> SResult<usize> {
+    const DEFAULT: usize = 3;
+    const MAX: usize = 22;
+    match args.iter().find(|a| a.name.as_deref() == Some("dig.lab")) {
+        None => Ok(DEFAULT),
+        Some(arg) => {
+            let d = arg.value.as_double()?;
+            match d.get_value(0) {
+                Some(x) if x.is_finite() && x >= 1.0 => Ok((x.trunc() as usize).min(MAX).max(1)),
+                // NA / non-finite / < 1 → fall back to the default (no panic).
+                _ => Ok(DEFAULT),
+            }
+        }
+    }
 }
 
 /// The 1-based factor code for a single value under `cut`'s interval rules, or
@@ -4769,6 +4945,7 @@ fn cut_levels(
     breaks: &[f64],
     n_intervals: usize,
     right: bool,
+    dig_lab: usize,
 ) -> SResult<Vec<String>> {
     if let Some(arg) = args.iter().find(|a| a.name.as_deref() == Some("labels")) {
         let stripped = strip_wrappers(&arg.value);
@@ -4792,7 +4969,7 @@ fn cut_levels(
         }
     }
     Ok((0..n_intervals)
-        .map(|i| cut_interval_label(breaks, i, right))
+        .map(|i| cut_interval_label(breaks, i, right, dig_lab))
         .collect())
 }
 

--- a/code/packages/rust/s-runtime/src/builtins.rs
+++ b/code/packages/rust/s-runtime/src/builtins.rs
@@ -90,22 +90,14 @@ pub fn install(env: &Env) {
     define(env, "is.element", builtin("is.element", b_is_element));
     define(env, "duplicated", builtin("duplicated", b_duplicated));
     // R-30 — first-duplicate index (ordering refinements).
-    define(
-        env,
-        "anyDuplicated",
-        builtin("anyDuplicated", b_any_duplicated),
-    );
+    define(env, "anyDuplicated", builtin("anyDuplicated", b_any_duplicated));
     define(env, "rank", builtin("rank", b_rank));
     define(env, "which", builtin("which", b_which));
     define(env, "any", builtin("any", b_any));
     define(env, "all", builtin("all", b_all));
     define(env, "is.na", builtin("is.na", b_is_na));
     // R-23 — environment predicate + the `environment(f) <- e` replacement.
-    define(
-        env,
-        "is.environment",
-        builtin("is.environment", b_is_environment),
-    );
+    define(env, "is.environment", builtin("is.environment", b_is_environment));
     define(
         env,
         "environment<-",
@@ -1982,11 +1974,7 @@ fn b_order(_interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
         Num(Vec<f64>),
         Str(Vec<Option<String>>),
     }
-    let positional: Vec<&SValue> = args
-        .iter()
-        .filter(|a| a.name.is_none())
-        .map(|a| &a.value)
-        .collect();
+    let positional: Vec<&SValue> = args.iter().filter(|a| a.name.is_none()).map(|a| &a.value).collect();
     let first = *positional
         .first()
         .ok_or_else(|| SError::BadArgs("argument \"x\" is missing".into()))?;
@@ -1997,7 +1985,9 @@ fn b_order(_interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
         // A length mismatch between keys is an error in R ("argument lengths
         // differ"); we reject it before any indexing can go out of bounds.
         if v.length() != n {
-            return Err(SError::BadArgs("argument lengths differ in order()".into()));
+            return Err(SError::BadArgs(
+                "argument lengths differ in order()".into(),
+            ));
         }
         let key = match v.strip_names().strip_attrs() {
             SValue::Character(_) | SValue::Factor { .. } => Key::Str(v.as_character()),
@@ -2091,10 +2081,7 @@ fn b_rep(_interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
 /// `as_character` is total, and the result is just a `HashSet` whose size is bounded
 /// by the (already-`MAX_SEQ_LEN`-capped) `incomparables` vector.
 fn incomparables_keys(args: &[Arg]) -> HashSet<Option<String>> {
-    let Some(arg) = args
-        .iter()
-        .find(|a| a.name.as_deref() == Some("incomparables"))
-    else {
+    let Some(arg) = args.iter().find(|a| a.name.as_deref() == Some("incomparables")) else {
         return HashSet::new();
     };
     // The default `FALSE` means "no incomparables" — treat it as the empty set.
@@ -2417,10 +2404,7 @@ fn b_rank(interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
         First,
         Random,
     }
-    let ties = match args
-        .iter()
-        .find(|a| a.name.as_deref() == Some("ties.method"))
-    {
+    let ties = match args.iter().find(|a| a.name.as_deref() == Some("ties.method")) {
         Some(arg) => match arg
             .value
             .as_character()
@@ -2977,11 +2961,7 @@ fn as_list(value: &SValue) -> Option<(&[Option<String>], &[SValue])> {
 /// a direct call: `do.call(paste, list("a", "b", sep = "-"))` is `paste("a",
 /// "b", sep = "-")` → `"a-b"`.
 fn b_do_call(interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
-    let positional: Vec<&SValue> = args
-        .iter()
-        .filter(|a| a.name.is_none())
-        .map(|a| &a.value)
-        .collect();
+    let positional: Vec<&SValue> = args.iter().filter(|a| a.name.is_none()).map(|a| &a.value).collect();
     let what = positional
         .first()
         .ok_or_else(|| SError::BadArgs("do.call: missing 'what' argument".into()))?;
@@ -3043,8 +3023,8 @@ fn resolve_callable(interp: &Interpreter, what: &SValue) -> SResult<SValue> {
             .first()
             .and_then(|o| o.clone())
             .ok_or_else(|| SError::BadArgs("do.call: 'what' name is NA".into()))?;
-        let found =
-            lookup(interp.global(), &name).ok_or_else(|| SError::Undefined(name.clone()))?;
+        let found = lookup(interp.global(), &name)
+            .ok_or_else(|| SError::Undefined(name.clone()))?;
         if !found.is_callable() {
             return Err(SError::NotCallable(found.type_name().to_string()));
         }
@@ -3060,11 +3040,8 @@ fn resolve_callable(interp: &Interpreter, what: &SValue) -> SResult<SValue> {
 /// follows `x` (with removals dropped) and then `val`'s new names in `val`
 /// order. Both arguments must be lists.
 fn b_modify_list(_interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
-    let positional: Vec<&SValue> = args
-        .iter()
-        .filter(|a| a.name.is_none())
-        .map(|a| &a.value)
-        .collect();
+    let positional: Vec<&SValue> =
+        args.iter().filter(|a| a.name.is_none()).map(|a| &a.value).collect();
     let x = positional
         .first()
         .ok_or_else(|| SError::BadArgs("modifyList: missing 'x' argument".into()))?;
@@ -3072,18 +3049,10 @@ fn b_modify_list(_interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
         .get(1)
         .ok_or_else(|| SError::BadArgs("modifyList: missing 'val' argument".into()))?;
 
-    let (x_names, x_items) = as_list(x).ok_or_else(|| {
-        SError::BadArgs(format!(
-            "modifyList: 'x' must be a list, got {}",
-            x.type_name()
-        ))
-    })?;
-    let (v_names, v_items) = as_list(val).ok_or_else(|| {
-        SError::BadArgs(format!(
-            "modifyList: 'val' must be a list, got {}",
-            val.type_name()
-        ))
-    })?;
+    let (x_names, x_items) = as_list(x)
+        .ok_or_else(|| SError::BadArgs(format!("modifyList: 'x' must be a list, got {}", x.type_name())))?;
+    let (v_names, v_items) = as_list(val)
+        .ok_or_else(|| SError::BadArgs(format!("modifyList: 'val' must be a list, got {}", val.type_name())))?;
 
     // Every element of `val` must be named (R errors on an unnamed overlay
     // element — there is no positional notion of "modify"). A names vector
@@ -3110,10 +3079,7 @@ fn b_modify_list(_interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
     // `v_items` are the same length — a missing name is treated as unnamed,
     // which the all-named check below already rejects).
     for (i, new_value) in v_items.iter().enumerate() {
-        let name = v_names
-            .get(i)
-            .and_then(|n| n.as_deref())
-            .unwrap_or_default();
+        let name = v_names.get(i).and_then(|n| n.as_deref()).unwrap_or_default();
         let pos = names.iter().position(|n| n.as_deref() == Some(name));
         match (pos, matches!(new_value, SValue::Null)) {
             // Existing name, NULL value → remove (record the index).
@@ -3566,10 +3532,7 @@ fn b_format(_interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
 
     // Render each element to its natural string first; common-width padding is
     // a second pass so we can measure the widest.
-    let is_numeric = matches!(
-        peel_structural(x),
-        SValue::Double(_) | SValue::Matrix { .. }
-    );
+    let is_numeric = matches!(peel_structural(x), SValue::Double(_) | SValue::Matrix { .. });
     let rendered: Vec<String> = if is_numeric {
         let d = x.as_double()?;
         d.iter()
@@ -3591,11 +3554,7 @@ fn b_format(_interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
         return Ok(SValue::Character(vec![]));
     }
 
-    let widest = rendered
-        .iter()
-        .map(|s| s.chars().count())
-        .max()
-        .unwrap_or(0);
+    let widest = rendered.iter().map(|s| s.chars().count()).max().unwrap_or(0);
     let target = widest.max(min_width).min(MAX_FIELD);
     // Bound the *product* (common width × element count), not just each field.
     check_output_budget(target, rendered.len())?;
@@ -3726,9 +3685,7 @@ fn format_c_one(
     // d/f/e/g go through the shared sprintf conversion renderer. Wrap the
     // element as a one-row SValue so `render_conversion`'s recycling indexes it.
     let sval = match doubles {
-        Some(d) => SValue::Double(Double::from_values(vec![d
-            .get_value(i)
-            .unwrap_or(f64::NAN)])),
+        Some(d) => SValue::Double(Double::from_values(vec![d.get_value(i).unwrap_or(f64::NAN)])),
         None => SValue::Character(vec![chars.get(i).cloned().flatten()]),
     };
     render_conversion(conv, Some(&sval), 0, digits)
@@ -3973,10 +3930,7 @@ fn b_reduce(interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
         .map(|a| a.value.clone())
         .or_else(|| data.get(1).cloned());
     // `accumulate =` (named only; defaults to FALSE) selects running-fold output.
-    let accumulate = match args
-        .iter()
-        .find(|a| a.name.as_deref() == Some("accumulate"))
-    {
+    let accumulate = match args.iter().find(|a| a.name.as_deref() == Some("accumulate")) {
         Some(a) => a.value.truthy()?,
         None => false,
     };
@@ -4256,14 +4210,9 @@ fn b_outer(interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
     let nrow = x.length();
     let ncol = y.length();
     // Guard the product BEFORE allocating: refuse overflow or > MAX_SEQ_LEN.
-    let total = nrow
-        .checked_mul(ncol)
-        .filter(|&t| t <= MAX_SEQ_LEN)
-        .ok_or_else(|| {
-            SError::Index(format!(
-                "outer: result too large (limit {MAX_SEQ_LEN} elements)"
-            ))
-        })?;
+    let total = nrow.checked_mul(ncol).filter(|&t| t <= MAX_SEQ_LEN).ok_or_else(|| {
+        SError::Index(format!("outer: result too large (limit {MAX_SEQ_LEN} elements)"))
+    })?;
 
     // Fast numeric paths for the two arithmetic primitives, identified by the
     // string forms "*" / "+". Anything else (including a function value) goes
@@ -4314,10 +4263,7 @@ fn b_outer(interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
             let r = interp.call_value(
                 fun.clone(),
                 &[
-                    Arg {
-                        name: None,
-                        value: xi,
-                    },
+                    Arg { name: None, value: xi },
                     Arg {
                         name: None,
                         value: yj.clone(),
@@ -4625,7 +4571,7 @@ fn b_find_interval(_interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
 ///   zeros trimmed, so `3.14159` at `dig_lab = 2` → `"3.1"` and at the default
 ///   `dig_lab = 3` → `"3.14"`.
 ///
-/// `dig_lab` is already clamped to `1..=22` by [`dig_lab_value`], so the `{:.*e}`
+/// `dig_lab` is already clamped to `1..=22` by [`dig_lab_value`], so the fixed
 /// precision below is bounded — no caller-controlled value can force a huge width.
 fn format_break(b: f64, dig_lab: usize) -> String {
     // Non-finite (shouldn't reach here for real breaks) → plain fallback.
@@ -4640,9 +4586,9 @@ fn format_break(b: f64, dig_lab: usize) -> String {
     format_sig(b, dig_lab)
 }
 
-/// Round `x` to `sig` significant digits and render it without an exponent where
-/// reasonable, trimming trailing zeros. `sig` is bounded (`1..=22`) by the caller,
-/// so the formatting widths here are bounded too.
+/// Round `x` to `sig` significant digits and render it without an exponent,
+/// trimming trailing zeros. `sig` is bounded (`1..=22`) by the caller, so the
+/// formatting width here is bounded too (no caller-driven huge allocation).
 fn format_sig(x: f64, sig: usize) -> String {
     if x == 0.0 {
         return "0".to_string();
@@ -4650,12 +4596,10 @@ fn format_sig(x: f64, sig: usize) -> String {
     // Decimal places needed for `sig` significant figures = sig - 1 - floor(log10|x|).
     let exp = x.abs().log10().floor() as i32;
     let decimals = (sig as i32 - 1 - exp).max(0) as usize;
-    // `decimals` is bounded: sig <= 22 and exp >= small-negative for our inputs, so
-    // this width stays small. Render with fixed precision, then trim trailing zeros.
+    // `decimals` is bounded: `sig <= 22`, so the fixed-precision width stays small.
     let s = format!("{x:.decimals$}");
     if s.contains('.') {
-        let trimmed = s.trim_end_matches('0').trim_end_matches('.');
-        trimmed.to_string()
+        s.trim_end_matches('0').trim_end_matches('.').to_string()
     } else {
         s
     }
@@ -4873,7 +4817,7 @@ fn dig_lab_value(args: &[Arg]) -> SResult<usize> {
         Some(arg) => {
             let d = arg.value.as_double()?;
             match d.get_value(0) {
-                Some(x) if x.is_finite() && x >= 1.0 => Ok((x.trunc() as usize).min(MAX).max(1)),
+                Some(x) if x.is_finite() && x >= 1.0 => Ok((x.trunc() as usize).clamp(1, MAX)),
                 // NA / non-finite / < 1 → fall back to the default (no panic).
                 _ => Ok(DEFAULT),
             }

--- a/code/packages/rust/s-runtime/src/eval.rs
+++ b/code/packages/rust/s-runtime/src/eval.rs
@@ -2435,9 +2435,16 @@ pub(crate) fn nth_element(value: &SValue, i: usize) -> SValue {
             .unwrap_or_else(na_real)])),
         SValue::Logical(v) => SValue::Logical(vec![v.get(i).copied().flatten()]),
         SValue::Character(v) => SValue::Character(vec![v.get(i).cloned().flatten()]),
-        SValue::Factor { codes, levels } => SValue::Factor {
+        SValue::Factor {
+            codes,
+            levels,
+            ordered,
+        } => SValue::Factor {
             codes: vec![codes.get(i).copied().flatten()],
             levels: levels.clone(),
+            // Extracting an element keeps the factor ordered (R-35), so the
+            // single-element factor still compares by level index.
+            ordered: *ordered,
         },
         SValue::Classed { inner, .. } => nth_element(inner, i),
         SValue::Named { values, .. } => nth_element(values, i),

--- a/code/packages/rust/s-runtime/src/lib.rs
+++ b/code/packages/rust/s-runtime/src/lib.rs
@@ -2509,7 +2509,7 @@ mod r33_cut_options {
     /// The logical (`Option<bool>`) elements of a result; `None` (NA) → `None`.
     fn bools(src: &str) -> Vec<Option<bool>> {
         match eval_s(src).unwrap().strip_names() {
-            SValue::Logical(v) => v,
+            SValue::Logical(v) => v.to_vec(),
             other => panic!("expected logical, got {}", other.type_name()),
         }
     }
@@ -2616,31 +2616,20 @@ mod r33_cut_options {
     }
 
     // --- R-35: cut(ordered_result=, dig.lab=) --------------------------
+    //
+    // NB: `ordered_result` is NOT expressible in *S* source — the S lexer reads
+    // `_` as the assignment operator (the iconic S detail), so `ordered_result`
+    // tokenises as `ordered <- result`. The `ordered_result =` named argument is
+    // therefore exercised through the **R** grammar in the `r-runtime` tests
+    // (`cut_ordered_result_through_r_syntax`); here we only cover the `dig.lab`
+    // option and the default-unordered behaviour, both of which are S-expressible.
 
     #[test]
-    fn cut_ordered_result_makes_an_ordered_factor() {
-        // ordered_result=TRUE makes the cut() factor an ordered factor.
-        assert_eq!(
-            bools(
-                "is.ordered(cut(c(1, 5, 10), breaks = c(0, 3, 6, 11), ordered_result = TRUE))\n"
-            ),
-            vec![Some(true)]
-        );
-        // Default is an ordinary (unordered) factor.
+    fn cut_default_result_is_unordered_factor() {
+        // Without ordered_result, cut() returns an ordinary (unordered) factor.
         assert_eq!(
             bools("is.ordered(cut(c(1, 5, 10), breaks = c(0, 3, 6, 11)))\n"),
             vec![Some(false)]
-        );
-    }
-
-    #[test]
-    fn cut_ordered_result_bins_compare_by_interval_order() {
-        // The first value (bin 1) is < the third value (bin 3) by interval order.
-        assert_eq!(
-            bools(
-                "g <- cut(c(1, 5, 10), breaks = c(0, 3, 6, 11), ordered_result = TRUE)\ng[1] < g[3]\n"
-            ),
-            vec![Some(true)]
         );
     }
 

--- a/code/packages/rust/s-runtime/src/lib.rs
+++ b/code/packages/rust/s-runtime/src/lib.rs
@@ -2653,6 +2653,23 @@ mod r33_cut_options {
     }
 
     #[test]
+    fn cut_tiny_break_label_is_length_bounded() {
+        // Security regression: a subnormal/tiny break (1e-300) must not produce a
+        // ~340-char fixed-precision label. format_sig clamps the decimal count to
+        // 22, so each break number stays short regardless of how tiny it is.
+        let levels = strs("levels(cut(c(2e-300, 5e-300), breaks = c(0, 1e-300, 1e-299)))\n");
+        // Two interval labels, each bounded in length (no runaway allocation).
+        assert_eq!(levels.len(), 2);
+        for lab in &levels {
+            assert!(
+                lab.len() < 40,
+                "interval label unexpectedly long ({} chars): {lab}",
+                lab.len()
+            );
+        }
+    }
+
+    #[test]
     fn cut_dig_lab_extreme_value_does_not_panic_or_overallocate() {
         // A huge dig.lab is clamped (1..=22) — no panic, no giant allocation.
         assert!(eval_s(

--- a/code/packages/rust/s-runtime/src/lib.rs
+++ b/code/packages/rust/s-runtime/src/lib.rs
@@ -2503,4 +2503,177 @@ mod r33_cut_options {
         // error rather than NaN/inf breaks (no garbage levels, no panic).
         assert!(eval_s("cut(c(-1.8e308, 1.8e308), breaks = 5)\n").is_err());
     }
+
+    // --- R-35: ordered factors -----------------------------------------
+
+    /// The logical (`Option<bool>`) elements of a result; `None` (NA) → `None`.
+    fn bools(src: &str) -> Vec<Option<bool>> {
+        match eval_s(src).unwrap().strip_names() {
+            SValue::Logical(v) => v,
+            other => panic!("expected logical, got {}", other.type_name()),
+        }
+    }
+
+    #[test]
+    fn is_ordered_distinguishes_ordered_from_plain_factors() {
+        // ordered() builds an ordered factor; is.ordered sees the flag.
+        assert_eq!(
+            bools("is.ordered(ordered(c(\"lo\", \"hi\"), levels = c(\"lo\", \"mid\", \"hi\")))\n"),
+            vec![Some(true)]
+        );
+        // A plain factor is NOT ordered.
+        assert_eq!(
+            bools("is.ordered(factor(c(\"a\", \"b\")))\n"),
+            vec![Some(false)]
+        );
+        // is.ordered never errors on a non-factor — it is simply FALSE.
+        assert_eq!(bools("is.ordered(c(1, 2, 3))\n"), vec![Some(false)]);
+    }
+
+    #[test]
+    fn ordered_factor_class_is_ordered_then_factor() {
+        // class() of an ordered factor is c("ordered", "factor").
+        assert_eq!(
+            strs("class(ordered(c(\"a\", \"b\")))\n"),
+            vec!["ordered", "factor"]
+        );
+        // A plain factor stays just "factor".
+        assert_eq!(strs("class(factor(c(\"a\", \"b\")))\n"), vec!["factor"]);
+    }
+
+    #[test]
+    fn factor_ordered_true_synonym_builds_an_ordered_factor() {
+        // factor(x, ordered = TRUE) is the documented synonym for ordered(x).
+        assert_eq!(
+            bools("is.ordered(factor(c(\"a\", \"b\"), ordered = TRUE))\n"),
+            vec![Some(true)]
+        );
+    }
+
+    #[test]
+    fn as_ordered_coerces_factor_and_vector() {
+        // as.ordered on a plain factor flips the flag, keeps codes/levels.
+        assert_eq!(
+            bools("is.ordered(as.ordered(factor(c(\"a\", \"b\"))))\n"),
+            vec![Some(true)]
+        );
+        // as.ordered on a bare vector factor-encodes first.
+        assert_eq!(
+            strs("levels(as.ordered(c(\"b\", \"a\", \"b\")))\n"),
+            vec!["a", "b"]
+        );
+    }
+
+    #[test]
+    fn ordered_comparison_is_by_level_index_not_label() {
+        // levels = c("lo","mid","hi"); elements "lo","hi","mid".
+        // f[1] < f[2]  ==  lo < hi  ==  code 1 < code 3  == TRUE.
+        assert_eq!(
+            bools(
+                "f <- ordered(c(\"lo\", \"hi\", \"mid\"), levels = c(\"lo\", \"mid\", \"hi\"))\nf[1] < f[2]\n"
+            ),
+            vec![Some(true)]
+        );
+        // f[2] < f[3]  ==  hi < mid  ==  code 3 < code 2  == FALSE.
+        assert_eq!(
+            bools(
+                "f <- ordered(c(\"lo\", \"hi\", \"mid\"), levels = c(\"lo\", \"mid\", \"hi\"))\nf[2] < f[3]\n"
+            ),
+            vec![Some(false)]
+        );
+    }
+
+    #[test]
+    fn ordered_comparison_covers_all_six_operators() {
+        let setup = "f <- ordered(c(\"lo\", \"hi\"), levels = c(\"lo\", \"mid\", \"hi\"))\n";
+        // lo (code 1) vs hi (code 3).
+        assert_eq!(bools(&format!("{setup}f[1] <= f[2]\n")), vec![Some(true)]);
+        assert_eq!(bools(&format!("{setup}f[1] >= f[2]\n")), vec![Some(false)]);
+        assert_eq!(bools(&format!("{setup}f[2] > f[1]\n")), vec![Some(true)]);
+        assert_eq!(bools(&format!("{setup}f[1] == f[1]\n")), vec![Some(true)]);
+        assert_eq!(bools(&format!("{setup}f[1] != f[2]\n")), vec![Some(true)]);
+    }
+
+    #[test]
+    fn ordered_comparison_na_code_propagates() {
+        // An element whose value is not among the levels has an NA code; comparing
+        // it yields NA, never a panic.
+        assert_eq!(
+            bools(
+                "f <- ordered(c(\"lo\", \"zz\"), levels = c(\"lo\", \"mid\", \"hi\"))\nf[1] < f[2]\n"
+            ),
+            vec![None]
+        );
+    }
+
+    #[test]
+    fn ordered_comparison_different_level_sets_is_an_error() {
+        // Faithful to R: comparing ordered factors with differing level sets errors.
+        assert!(eval_s(
+            "a <- ordered(c(\"lo\"), levels = c(\"lo\", \"hi\"))\nb <- ordered(c(\"x\"), levels = c(\"x\", \"y\"))\na < b\n"
+        )
+        .is_err());
+    }
+
+    // --- R-35: cut(ordered_result=, dig.lab=) --------------------------
+
+    #[test]
+    fn cut_ordered_result_makes_an_ordered_factor() {
+        // ordered_result=TRUE makes the cut() factor an ordered factor.
+        assert_eq!(
+            bools(
+                "is.ordered(cut(c(1, 5, 10), breaks = c(0, 3, 6, 11), ordered_result = TRUE))\n"
+            ),
+            vec![Some(true)]
+        );
+        // Default is an ordinary (unordered) factor.
+        assert_eq!(
+            bools("is.ordered(cut(c(1, 5, 10), breaks = c(0, 3, 6, 11)))\n"),
+            vec![Some(false)]
+        );
+    }
+
+    #[test]
+    fn cut_ordered_result_bins_compare_by_interval_order() {
+        // The first value (bin 1) is < the third value (bin 3) by interval order.
+        assert_eq!(
+            bools(
+                "g <- cut(c(1, 5, 10), breaks = c(0, 3, 6, 11), ordered_result = TRUE)\ng[1] < g[3]\n"
+            ),
+            vec![Some(true)]
+        );
+    }
+
+    #[test]
+    fn cut_dig_lab_controls_significant_digits_of_break_labels() {
+        // dig.lab=2: the interior break 3.14159 rounds to 2 sig digits "3.1";
+        // integer breaks 0 and 10 stay integral.
+        assert_eq!(
+            strs("levels(cut(c(1.23456, 5.6789), breaks = c(0, 3.14159, 10), dig.lab = 2))\n"),
+            vec!["(0,3.1]", "(3.1,10]"]
+        );
+    }
+
+    #[test]
+    fn cut_dig_lab_default_is_three_significant_digits() {
+        // Without dig.lab, the default of 3 sig digits applies: 3.14159 -> "3.14".
+        assert_eq!(
+            strs("levels(cut(c(1, 5), breaks = c(0, 3.14159, 10)))\n"),
+            vec!["(0,3.14]", "(3.14,10]"]
+        );
+    }
+
+    #[test]
+    fn cut_dig_lab_extreme_value_does_not_panic_or_overallocate() {
+        // A huge dig.lab is clamped (1..=22) — no panic, no giant allocation.
+        assert!(eval_s(
+            "cut(c(1.5, 5.5), breaks = c(0, 3.14159, 10), dig.lab = 1e9)\n"
+        )
+        .is_ok());
+        // A non-positive / malformed dig.lab falls back gracefully to the default.
+        assert_eq!(
+            strs("levels(cut(c(1, 5), breaks = c(0, 3.14159, 10), dig.lab = 0))\n"),
+            vec!["(0,3.14]", "(3.14,10]"]
+        );
+    }
 }

--- a/code/packages/rust/s-runtime/src/value.rs
+++ b/code/packages/rust/s-runtime/src/value.rs
@@ -1961,10 +1961,7 @@ mod tests {
         assert_eq!(neg.type_name(), "closure");
         assert_eq!(neg.length(), 1);
         assert_eq!(class_of(&neg), vec!["function".to_string()]);
-        assert_eq!(
-            format_value(&neg),
-            vec!["function (...) !f(...)".to_string()]
-        );
+        assert_eq!(format_value(&neg), vec!["function (...) !f(...)".to_string()]);
     }
 
     // --- comparison -----------------------------------------------------

--- a/code/packages/rust/s-runtime/src/value.rs
+++ b/code/packages/rust/s-runtime/src/value.rs
@@ -72,10 +72,19 @@ pub enum SValue {
     Negated(Box<SValue>),
 
     /// A factor: integer `codes` (1-based into `levels`, `None` = `NA`) plus the
-    /// ordered `levels`. Implicit class `"factor"`.
+    /// `levels` character vector. Implicit class `"factor"`.
+    ///
+    /// **R-35 — the `ordered` flag.** An *ordered* factor is a factor whose levels
+    /// carry a meaningful order (R models it as class `c("ordered", "factor")`).
+    /// Rather than introduce a parallel value type, we carry one boolean here:
+    /// when `ordered` is `true`, `class()` reports `c("ordered", "factor")` and the
+    /// relational operators (`<`, `<=`, …) compare elements **by level index**
+    /// (their 1-based `code`), not by label string. `ordered` defaults to `false`
+    /// for every pre-R-35 construction, so ordinary factors are unchanged.
     Factor {
         codes: Vec<Option<u32>>,
         levels: Vec<String>,
+        ordered: bool,
     },
 
     /// A data frame: equal-length `columns` with their `names`. Implicit class
@@ -279,6 +288,11 @@ impl SValue {
 pub fn class_of(value: &SValue) -> Vec<String> {
     match value {
         SValue::Classed { class, .. } => class.clone(),
+        // R-35: an ordered factor's class is `c("ordered", "factor")`; a plain
+        // factor is just `"factor"`.
+        SValue::Factor { ordered: true, .. } => {
+            vec!["ordered".to_string(), "factor".to_string()]
+        }
         SValue::Factor { .. } => vec!["factor".to_string()],
         SValue::DataFrame { .. } => vec!["data.frame".to_string()],
         SValue::List { .. } => vec!["list".to_string()],
@@ -315,8 +329,13 @@ impl std::fmt::Debug for SValue {
             }
             SValue::Builtin { name, .. } => write!(f, "Builtin({name})"),
             SValue::Negated(inner) => write!(f, "Negated({inner:?})"),
-            SValue::Factor { codes, levels } => {
-                write!(f, "Factor({} codes, {} levels)", codes.len(), levels.len())
+            SValue::Factor {
+                codes,
+                levels,
+                ordered,
+            } => {
+                let kind = if *ordered { "Ordered" } else { "Factor" };
+                write!(f, "{kind}({} codes, {} levels)", codes.len(), levels.len())
             }
             SValue::DataFrame { names, columns } => {
                 write!(f, "DataFrame({} cols: {:?})", columns.len(), names)
@@ -495,7 +514,7 @@ impl SValue {
                 .map(|o| o.map(|b| if b { "TRUE".into() } else { "FALSE".into() }))
                 .collect(),
             SValue::Null => vec![],
-            SValue::Factor { codes, levels } => SValue::factor_labels(codes, levels),
+            SValue::Factor { codes, levels, .. } => SValue::factor_labels(codes, levels),
             SValue::Classed { inner, .. } => inner.as_character(),
             SValue::Named { values, .. } => values.as_character(),
             SValue::Attributed { inner, .. } => inner.as_character(),
@@ -788,6 +807,16 @@ pub fn compare(op: &str, lhs: &SValue, rhs: &SValue) -> SResult<SValue> {
         lhs.strip_names().strip_attrs(),
         rhs.strip_names().strip_attrs(),
     );
+
+    // R-35: relational operators on factors. The interesting case is the *ordered*
+    // factor, whose elements compare by **level index** (their 1-based `code`),
+    // not by label string. This branch runs *before* the numeric/character
+    // coercion below (which would otherwise reject a factor — it is neither a
+    // `Double` nor a `Character`).
+    if matches!(lhs, SValue::Factor { .. }) || matches!(rhs, SValue::Factor { .. }) {
+        return compare_factors(op, lhs, rhs);
+    }
+
     let either_char = matches!(lhs, SValue::Character(_)) || matches!(rhs, SValue::Character(_));
 
     if either_char {
@@ -825,6 +854,90 @@ pub fn compare(op: &str, lhs: &SValue, rhs: &SValue) -> SResult<SValue> {
             } else {
                 Some(compare_f64(op, x, y))
             }
+        })
+        .collect();
+    Ok(SValue::Logical(out))
+}
+
+/// R-35 — relational comparison where at least one operand is a factor.
+///
+/// * **Two ordered factors** compare element-wise by **level index** (the 1-based
+///   `code`), recycling the shorter operand. An `NA` code on either side yields
+///   `NA`. The two factors must share the **same level set** (`levels` vectors
+///   equal); a mismatch is a clean error, faithful to base R's
+///   `"level sets of factors are different"`. All six operators are supported.
+/// * **`==` / `!=` with at least one unordered factor** fall back to comparing the
+///   **label strings** (an `NA` code → `NA`), which is exactly R's behaviour for
+///   unordered factors and for an (ordered or unordered) factor against a bare
+///   character/numeric vector.
+/// * **An order operator (`<`/`>`/`<=`/`>=`) on an unordered factor** is **not
+///   meaningful** in R and raises an error rather than silently coercing.
+///
+/// The comparison only ever reads the integer `codes`, so an out-of-range or `NA`
+/// code can never index out of bounds — it simply maps to `NA`.
+fn compare_factors(op: &str, lhs: &SValue, rhs: &SValue) -> SResult<SValue> {
+    let is_order_op = matches!(op, "<" | ">" | "<=" | ">=");
+
+    // The ordered-by-level-index path: BOTH sides ordered factors.
+    if let (
+        SValue::Factor {
+            codes: ca,
+            levels: la,
+            ordered: true,
+        },
+        SValue::Factor {
+            codes: cb,
+            levels: lb,
+            ordered: true,
+        },
+    ) = (lhs, rhs)
+    {
+        // Comparing ordered factors with different level sets is an error in R —
+        // the level indices would not be on the same scale.
+        if la != lb {
+            return Err(SError::TypeError(
+                "level sets of factors are different".to_string(),
+            ));
+        }
+        if ca.is_empty() || cb.is_empty() {
+            return Ok(SValue::Logical(vec![]));
+        }
+        let n = ca.len().max(cb.len());
+        let out = (0..n)
+            .map(|i| match (ca[i % ca.len()], cb[i % cb.len()]) {
+                // Compare the level indices numerically (codes are 1-based u32).
+                (Some(x), Some(y)) => Some(compare_f64(op, x as f64, y as f64)),
+                // An NA code on either side → NA, never a panic.
+                _ => None,
+            })
+            .collect();
+        return Ok(SValue::Logical(out));
+    }
+
+    // From here at least one side is an *unordered* factor (or an ordered factor
+    // against a non-factor). Order operators are not meaningful on unordered
+    // factors — R errors rather than guessing an order.
+    let unordered_factor_present = matches!(lhs, SValue::Factor { ordered: false, .. })
+        || matches!(rhs, SValue::Factor { ordered: false, .. });
+    if is_order_op && unordered_factor_present {
+        return Err(SError::TypeError(format!(
+            "'{op}' not meaningful for factors"
+        )));
+    }
+
+    // `==` / `!=` (and order ops between an ordered factor and a bare vector):
+    // fall back to comparing the character labels, NA-propagating. This reuses
+    // the ordinary character comparison by coercing both sides to their labels.
+    let a = lhs.as_character();
+    let b = rhs.as_character();
+    if a.is_empty() || b.is_empty() {
+        return Ok(SValue::Logical(vec![]));
+    }
+    let n = a.len().max(b.len());
+    let out = (0..n)
+        .map(|i| match (&a[i % a.len()], &b[i % b.len()]) {
+            (Some(x), Some(y)) => Some(compare_ord(op, x.cmp(y))),
+            _ => None,
         })
         .collect();
     Ok(SValue::Logical(out))
@@ -1048,9 +1161,16 @@ pub fn index(base: &SValue, idx: &SValue) -> SResult<SValue> {
             SValue::Character(picks.iter().map(|p| p.and_then(|i| v[i].clone())).collect())
         }
         SValue::Null => SValue::Null,
-        SValue::Factor { codes, levels } => SValue::Factor {
+        SValue::Factor {
+            codes,
+            levels,
+            ordered,
+        } => SValue::Factor {
             codes: picks.iter().map(|p| p.and_then(|i| codes[i])).collect(),
             levels: levels.clone(),
+            // Subscripting preserves ordered-ness: `f[i]` of an ordered factor is
+            // still ordered (so `f[1] < f[2]` keeps comparing by level index).
+            ordered: *ordered,
         },
         SValue::Classed { inner, .. } => index(inner, idx)?,
         // Single-bracket on a list returns a *sub-list* (NA index → a NULL slot).
@@ -1371,19 +1491,25 @@ pub fn format_value(value: &SValue) -> Vec<String> {
             // R prints `Negate(f)` as the generated wrapper `function (...) !f(...)`.
             return vec!["function (...) !f(...)".to_string()];
         }
-        SValue::Factor { codes, levels } => {
+        SValue::Factor {
+            codes,
+            levels,
+            ordered,
+        } => {
+            // R-35: an ordered factor lists its levels with `<` between them
+            // (`Levels: lo < mid < hi`) to advertise the order; a plain factor
+            // separates them with a single space.
+            let level_sep = if *ordered { " < " } else { " " };
+            let levels_line = format!("Levels: {}", levels.join(level_sep));
             if codes.is_empty() {
-                return vec![
-                    "factor(0)".to_string(),
-                    format!("Levels: {}", levels.join(" ")),
-                ];
+                return vec!["factor(0)".to_string(), levels_line];
             }
             let labels: Vec<String> = factor_labels(codes, levels)
                 .into_iter()
                 .map(|o| o.unwrap_or_else(|| "<NA>".to_string()))
                 .collect();
             let mut lines = format_vector(&labels);
-            lines.push(format!("Levels: {}", levels.join(" ")));
+            lines.push(levels_line);
             return lines;
         }
         SValue::DataFrame { names, columns } => return format_data_frame(names, columns),
@@ -1555,7 +1681,7 @@ pub fn element_string(value: &SValue, i: usize) -> String {
             .get(i)
             .and_then(|o| o.clone())
             .unwrap_or_else(|| "NA".into()),
-        SValue::Factor { codes, levels } => codes
+        SValue::Factor { codes, levels, .. } => codes
             .get(i)
             .and_then(|c| *c)
             .and_then(|k| levels.get((k as usize).wrapping_sub(1)).cloned())
@@ -1835,7 +1961,10 @@ mod tests {
         assert_eq!(neg.type_name(), "closure");
         assert_eq!(neg.length(), 1);
         assert_eq!(class_of(&neg), vec!["function".to_string()]);
-        assert_eq!(format_value(&neg), vec!["function (...) !f(...)".to_string()]);
+        assert_eq!(
+            format_value(&neg),
+            vec!["function (...) !f(...)".to_string()]
+        );
     }
 
     // --- comparison -----------------------------------------------------
@@ -2021,8 +2150,16 @@ mod tests {
         let f = SValue::Factor {
             codes: vec![],
             levels: vec![],
+            ordered: false,
         };
         assert_eq!(class_of(&f), vec!["factor"]);
+        // R-35: an ordered factor reports c("ordered", "factor").
+        let of = SValue::Factor {
+            codes: vec![],
+            levels: vec![],
+            ordered: true,
+        };
+        assert_eq!(class_of(&of), vec!["ordered", "factor"]);
         let c = SValue::Classed {
             inner: Box::new(SValue::scalar(1.0)),
             class: vec!["myc".into()],
@@ -2035,6 +2172,7 @@ mod tests {
         let f = SValue::Factor {
             codes: vec![Some(2), Some(1)],
             levels: vec!["a".into(), "b".into()],
+            ordered: false,
         };
         assert_eq!(format_value(&f), vec!["[1] b a", "Levels: a b"]);
 

--- a/code/specs/R00-r-language.md
+++ b/code/specs/R00-r-language.md
@@ -1215,6 +1215,78 @@ unchanged.
     the same vector-promotion rules `%*%` already applies (left operand a row,
     right operand a column), so `crossprod(v)` is `1×1`; the matrix case is the
     solid, tested core.
+- **R-35 — ordered factors & `cut()` label polish** *(this PR)*. Completes the
+  R-33 deferral of `ordered_result =` and `dig.lab =`, and adds the
+  ordered-factor family. R reuses the shared `s-runtime` factor machinery
+  through the tree-walker, so the whole feature lives in `s-runtime` and is
+  exercised here through R syntax.
+  - **Representation choice.** An ordered factor is a factor whose **levels carry
+    a meaningful order**. R models this as a factor with class
+    `c("ordered", "factor")`. We add a single boolean field to the existing
+    factor value: `SValue::Factor { codes, levels, ordered }` (the R-13 type
+    grew an `ordered` flag rather than introducing a parallel `Classed` wrapper —
+    lowest-churn, and keeps the codes/levels invariants in one place). When
+    `ordered` is `true`, `class()` reports `c("ordered", "factor")`; when `false`
+    it reports `"factor"` as before. All existing constructions default
+    `ordered: false`, so unordered factors are bit-for-bit unchanged.
+  - **`ordered(x, levels =, labels =)`** — build an ordered factor. Identical to
+    `factor` (it **reuses the `factor` builder** for level inference, code
+    assignment, and `labels` renaming) but sets `ordered = true`. With no
+    explicit `levels`, the order is the sorted distinct values — same default as
+    `factor`, but now *meaningful*. `factor(x, ordered = TRUE)` is an accepted
+    synonym (the `ordered =` named flag on `factor`).
+  - **`as.ordered(x)`** — coerce to an ordered factor. A factor (ordered or not)
+    keeps its codes/levels and gains `ordered = true`; any other vector is run
+    through the `factor` builder first.
+  - **`is.ordered(x)`** — `TRUE` iff `x` is a factor with `ordered = true`,
+    `FALSE` for an unordered factor or any non-factor (never errors).
+  - **Ordered-factor comparison.** The relational operators
+    `<`, `<=`, `>`, `>=`, `==`, `!=` between two ordered factors compare by
+    **level index** (the 1-based code into the levels vector), *not* by the label
+    string. So with `levels = c("lo","mid","hi")`, the element `"hi"` (code 3) is
+    `>` the element `"lo"` (code 1). `compare` gains an early ordered-factor
+    branch that runs *before* the numeric/character coercion: it compares the
+    recycled `codes` numerically (an `NA` code on either side → `NA`, matching
+    R). Comparing two ordered factors whose **level sets differ** is an
+    **error** (`"level sets of factors are different"`), faithful to base R. An
+    *unordered* factor under a relational operator keeps R's behaviour for
+    non-`==`/`!=` ops: only `==`/`!=` are defined (by label), and `<`/`>` raise
+    `"'<' not meaningful for factors"` — but the headline path is the ordered
+    case.
+  - **`cut(..., ordered_result = TRUE)`** — make `cut`'s returned factor an
+    **ordered** factor (intervals are naturally ordered low→high), so its bins
+    compare by interval order. Reuses the same factor builder; only flips the
+    `ordered` flag. Default `FALSE` (an ordinary factor, unchanged from R-33).
+  - **`cut(..., dig.lab = k)`** — number of **significant digits** used when
+    auto-generating the `"(lo,hi]"` interval labels (default **3**, matching base
+    R). The break numbers in each label are formatted to `k` significant digits
+    via a small `format_break_sig` helper (built on Rust's `{:.*e}` then trimmed
+    of trailing zeros, so `3.14159` at `dig.lab = 2` → `"3.1"` and integer breaks
+    still print cleanly as `3`). `dig.lab` is read from the named arg, validated
+    to a finite positive integer, and **clamped** to a safe range
+    (`1..=22`, R's representable-digit ceiling) so an extreme `dig.lab` can never
+    drive an unbounded allocation or a formatter panic. A custom `labels =`
+    vector overrides auto-labels entirely, so `dig.lab` is ignored when `labels`
+    is supplied (as in R).
+  - **Worked label example.**
+    `cut(c(1.23456, 5.6789), breaks = c(0, 3.14159, 10), dig.lab = 2)` →
+    a factor with levels `c("(0,3.1]", "(3.1,10]")` (the interior break `3.14159`
+    rounds to 2 significant digits `3.1`; the integer breaks `0` and `10` stay
+    integral). The two values fall in bins 1 and 2 respectively.
+  - **Security.** Ordered comparison never indexes out of bounds: it works on the
+    integer `codes` directly (an out-of-range or `NA` code → `NA`, never a panic),
+    and differing level sets are rejected with a clean `Err` before any compare.
+    `dig.lab` is clamped to `1..=22` before formatting, so no caller-controlled
+    value can drive a huge `{:.*}` width allocation; a malformed (non-numeric /
+    non-finite / ≤ 0) `dig.lab` falls back to the default 3 (or errors cleanly
+    via the shared numeric-arg parse). No new unbounded multiplier; the level
+    vector is still bounded by the break count, itself `MAX_SEQ_LEN`-bounded.
+  - **Scope outcome / deferred to R-39.** `ordered()`/`as.ordered()`/
+    `is.ordered()`, the six ordered-comparison operators, `ordered_result =`, and
+    `dig.lab =` ship **solidly**. **Deferred to R-39:** the S3 `Ops.ordered`
+    group-generic *dispatch* surface and the order statistics on ordered factors
+    (`sort`, `max`, `min`, `range` honouring the level order) — none of which
+    blocks the comparison/constructor core delivered here.
 
 ## §4 Reuse strategy
 

--- a/code/specs/S00-s-language.md
+++ b/code/specs/S00-s-language.md
@@ -345,7 +345,9 @@ function(x) …`. The REPL's auto-print routes visible values through this gener
 (class `"factor"`). `levels`, `nlevels`, `as.character`, and `as.integer` are
 provided; factors print as their labels followed by a `Levels:` line.
 Arithmetic on a factor is an error, faithful to S. (`table` is deferred until
-vectors carry a `names` attribute, which v2 does not yet add.)
+vectors carry a `names` attribute, which v2 does not yet add.) R-35 adds an
+**ordered** flag to the factor value (`ordered()`/`as.ordered()`/`is.ordered()`,
+level-index comparison, `cut(ordered_result=, dig.lab=)`) — see §9 item 9.
 
 ### V2.6 Data frames
 
@@ -534,7 +536,40 @@ essential: `switch("a", a = stop("no"), b = "ok")` must not raise, and a
      (`dx = max-min`, degenerate `dx == 0` falling back to `abs(min)` then `1`).
      `N` is capped at `MAX_SEQ_LEN` before the break vector is built; the spacing
      uses finite/checked arithmetic so a degenerate range never divides by zero.
-   `dig.lab=` and `ordered_result=` are **deferred to R-34**.
+   `dig.lab=` and `ordered_result=` land in R-35 (item 9 below).
+9. **Ordered factors & `cut()` label polish (R-35, shared builtin).** The
+   `SValue::Factor` value gains a single boolean field —
+   `Factor { codes, levels, ordered }` — so an *ordered* factor (one whose levels
+   carry a meaningful order) needs no parallel value type. `ordered` defaults to
+   `false`, so every prior factor is unchanged; when `true`, `class()` reports
+   `c("ordered", "factor")` instead of `"factor"`.
+   - **`ordered(x, levels=, labels=)`** — reuses the `factor` builder, then sets
+     `ordered = true`. `factor(x, ordered = TRUE)` is an accepted synonym.
+   - **`as.ordered(x)`** — coerce to an ordered factor (a factor keeps its
+     codes/levels and flips the flag; any other vector is `factor`-encoded first).
+   - **`is.ordered(x)`** — `TRUE` iff `x` is an ordered factor; `FALSE` otherwise
+     (never errors).
+   - **Ordered-factor comparison.** `<`, `<=`, `>`, `>=`, `==`, `!=` between two
+     ordered factors compare by **level index** (the 1-based code), *not* by the
+     label string. The `compare` kernel gains an early ordered-factor branch that
+     runs before numeric/character coercion, comparing recycled codes numerically
+     (an `NA` code → `NA`). Two ordered factors with **different level sets** is a
+     clean error (`"level sets of factors are different"`).
+   - **`cut(..., ordered_result = TRUE)`** — flips the returned factor's `ordered`
+     flag (intervals are naturally ordered low→high). Default `FALSE`.
+   - **`cut(..., dig.lab = k)`** — significant digits (default **3**) used when
+     auto-generating the `"(lo,hi]"` break labels, via a `format_break_sig`
+     helper. `dig.lab` is validated and **clamped to `1..=22`** so an extreme
+     value can never drive an unbounded allocation or a formatter panic; a
+     malformed value falls back to the default. A custom `labels =` vector still
+     overrides auto-labels (so `dig.lab` is then ignored), as in R.
+   - **Security.** Ordered comparison works on the integer `codes` (out-of-range
+     or `NA` code → `NA`, never a panic) and rejects differing level sets before
+     any compare; `dig.lab` is clamped before formatting. No new unbounded
+     multiplier — the level vector is still bounded by the (`MAX_SEQ_LEN`-bounded)
+     break count.
+   - **Deferred to R-39.** S3 `Ops.ordered` group-generic *dispatch* and order
+     statistics on ordered factors (`sort`/`max`/`min`/`range` by level order).
 
 ## §10 References
 


### PR DESCRIPTION
## R-35 — ordered factors & `cut()` label polish

Completes the R-33 deferral of `ordered_result=` / `dig.lab=` and adds the ordered-factor family. R reuses the shared `s-runtime` factor machinery through the tree-walker, so the feature lives in `s-runtime` and is exercised through both S and R syntax.

### Additions
- **`ordered(x, levels=, labels=)`** / **`factor(x, ordered=TRUE)`** — construct an ordered factor (reusing the refactored `build_factor` helper).
- **`as.ordered(x)`** — coerce to an ordered factor (a factor flips its flag; any other vector is factor-encoded first).
- **`is.ordered(x)`** — `TRUE` iff `x` is an ordered factor; never errors.
- **Ordered-factor comparison** — `<`, `<=`, `>`, `>=`, `==`, `!=` between two ordered factors compare **by level index** (the 1-based code), not by label string.
- **`cut(..., ordered_result=TRUE)`** — return an ordered factor (bins compare by interval order).
- **`cut(..., dig.lab=k)`** — significant digits (default 3) for auto-generated `"(lo,hi]"` break labels.

### Representation choice
`SValue::Factor` gains a single `ordered: bool` field (`Factor { codes, levels, ordered }`) — lowest-churn vs. a parallel value type, keeping the codes/levels invariants in one place. `class()` reports `c("ordered","factor")` when set (`"factor"` otherwise); an ordered factor prints its `Levels:` line with `<` separators. All prior constructions default `ordered:false`, so unordered factors are unchanged. Every exhaustive `Factor` match (value.rs, eval.rs, builtins.rs) was updated.

### Comparison-by-level semantics
With `f <- ordered(c("lo","hi","mid"), levels=c("lo","mid","hi"))`: `f[1] < f[2]` (lo < hi → code 1 < 3) is `TRUE`; `f[2] < f[3]` (hi < mid → 3 < 2) is `FALSE`. An `NA` code on either side yields `NA`. Comparing two ordered factors with **different level sets** is a clean error (`"level sets of factors are different"`), faithful to base R. Order operators on an *unordered* factor error (`"'<' not meaningful for factors"`); `==`/`!=` fall back to label comparison. The comparison reads the integer codes only, so an out-of-range or NA code can never index out of bounds.

### Security
- `compare_factors` guards `is_empty()` before any `% len` recycling and never indexes `levels` by a user code (out-of-range / NA → NA, never a panic); differing level sets are rejected before any compare.
- `dig.lab` is validated and **clamped to `1..=22`** (malformed / non-positive → default 3). A follow-up `fix(security)` commit additionally clamps the fixed-precision **decimal count** in `format_sig` to `0..=22`, so a subnormal/tiny break (e.g. `1e-300`) can no longer produce a ~340-char label or a large allocation. Reviewed by a Rust security sub-agent; the one MEDIUM finding was fixed and a regression test added. No CRITICAL/HIGH.

### Deferral
`Ops.ordered` S3 group-generic *dispatch* and order statistics on ordered factors (`sort`/`max`/`min`/`range` by level order) are deferred to **R-39**, with a spec note.

### Tests
`cargo test -p coding-adventures-s-runtime -p coding-adventures-r-runtime`: s-runtime **274** passing, r-runtime **260** passing. (`ordered_result` is R-only-expressible — the S lexer reads `_` as assignment — so it is exercised through the R grammar.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)