### PR TITLE
feat(mycin-cardio): ground continuous machinery murmur -> patent ductus arteriosus

### DIFF
--- a/code/specs/data/mycin-2026/recall/cardio-edges.adj
+++ b/code/specs/data/mycin-2026/recall/cardio-edges.adj
@@ -89,4 +89,12 @@ rulebook cardio_facts {
         source "Mitral stenosis is a diastolic murmur, best heard at the left 5th midclavicular line."
         locator "https://www.ncbi.nlm.nih.gov/books/NBK525958/"
         trust authoritative
+
+    % --- EXPAND: continuous "machinery" murmur -> patent ductus arteriosus -----------
+    % PDA = patent ductus arteriosus (page-defined abbreviation). One self-contained span
+    % names the lesion's murmur as a continuous "machinery" murmur, grounding this edge.
+    relate murmur_indicates(continuous_machinery, patent_ductus_arteriosus)
+        source "The classic PDA murmur is a continuous, \"machinery\" murmur below the clavicle, radiating to the back, although it can also manifest as a systolic or holosystolic murmur."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK430758/"
+        trust authoritative
 }

--- a/code/specs/data/mycin-2026/recall/cardio-recall.query.adj
+++ b/code/specs/data/mycin-2026/recall/cardio-recall.query.adj
@@ -19,3 +19,4 @@ import "cardio-edges.adj"
 ? murmur_indicates(holosystolic_left_lower_sternal, $Lesion)   % expect tricuspid_regurgitation
 ? murmur_indicates(decrescendo_diastolic, $Lesion)             % expect aortic_regurgitation
 ? murmur_indicates(diastolic_apical, $Lesion)                  % expect mitral_stenosis
+? murmur_indicates(continuous_machinery, $Lesion)              % expect patent_ductus_arteriosus (expand)

--- a/code/specs/data/mycin-2026/recall/test_cardio_recall.py
+++ b/code/specs/data/mycin-2026/recall/test_cardio_recall.py
@@ -35,6 +35,7 @@ EXPECTED = {
     "holosystolic_left_lower_sternal": "tricuspid_regurgitation",
     "decrescendo_diastolic": "aortic_regurgitation",
     "diastolic_apical": "mitral_stenosis",
+    "continuous_machinery": "patent_ductus_arteriosus",  # expand (NBK430758)
 }
 REL = "murmur_indicates"
 VAR = "Lesion"
@@ -98,8 +99,9 @@ def test_unknown_murmur_abstains() -> None:
     fd, path = tempfile.mkstemp(suffix=".adj", prefix=".cardio_q_", dir=HERE)
     try:
         with os.fdopen(fd, "w") as fh:
-            # continuous_machinery (PDA) is not in the library → must abstain
-            fh.write(f'import "cardio-edges.adj"\n? {REL}(continuous_machinery, ${VAR})\n')
+            # to_and_fro murmur is not in the library → must abstain (continuous_machinery
+            # is now grounded to PDA, so the negative control moved to a still-absent murmur)
+            fh.write(f'import "cardio-edges.adj"\n? {REL}(to_and_fro, ${VAR})\n')
         res = _run(Path(path))
         r = res["recall"][0] if res["recall"] else None
         assert r is not None and r["abstained"], "an ungrounded murmur must abstain"


### PR DESCRIPTION
## What
The classic PDA murmur, grounded from StatPearls NBK430758:

- **murmur_indicates(continuous_machinery, patent_ductus_arteriosus)**:
  > The classic PDA murmur is a continuous, "machinery" murmur below the clavicle, radiating to the back…

PDA = patent ductus arteriosus (page-defined abbreviation). Because `continuous_machinery` is now grounded, the test's negative-control murmur is repointed to a still-absent murmur (`to_and_fro`) so the abstention check stays meaningful.

## Changes (data-only)
- `cardio-edges.adj` +1 `relate`; `cardio-recall.query.adj` +1; `test_cardio_recall.py` EXPECTED +1; control → `to_and_fro`

## Verification
- `test_cardio_recall: 3/3 passed`; ruff clean; data-only security review passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)