### PR TITLE
feat(mycin-genetics): ground hereditary hemochromatosis (autosomal recessive; HFE)

### DIFF
--- a/code/specs/data/mycin-2026/recall/genetics-edges.adj
+++ b/code/specs/data/mycin-2026/recall/genetics-edges.adj
@@ -148,4 +148,14 @@ rulebook genetics_facts {
         source "Wilson disease is an autosomal recessive condition caused by 1 of several mutations in ATP7B gene which encodes the ATP7B protein transporter on the long arm of chromosome 13 (13q) responsible for excreting excess copper into bile and out of the body."
         locator "https://www.ncbi.nlm.nih.gov/books/NBK441990/"
         trust authoritative
+
+    % --- EXPAND: hereditary hemochromatosis (autosomal recessive; HFE gene) -----------
+    relate inheritance(hereditary_hemochromatosis, autosomal_recessive)
+        source "This is considered the classic form of hereditary hemochromatosis, is inherited in an autosomal recessive fashion, and disproportionately affects males."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK430862/"
+        trust authoritative
+    relate gene_defect(hereditary_hemochromatosis, hfe)
+        source "Type 1 hereditary hemochromatosis occurs in patients who are typically homozygous for loss-of-function mutations in HFE."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK430862/"
+        trust authoritative
 }

--- a/code/specs/data/mycin-2026/recall/genetics-recall.query.adj
+++ b/code/specs/data/mycin-2026/recall/genetics-recall.query.adj
@@ -33,3 +33,5 @@ import "genetics-edges.adj"
 ? trinucleotide_repeat(friedreich_ataxia, $Repeat)     % expect gaa (expand)
 ? inheritance(wilson_disease, $Pattern)                % expect autosomal_recessive (expand)
 ? gene_defect(wilson_disease, $Gene)                   % expect atp7b (expand)
+? inheritance(hereditary_hemochromatosis, $Pattern)    % expect autosomal_recessive (expand)
+? gene_defect(hereditary_hemochromatosis, $Gene)       % expect hfe (expand)

--- a/code/specs/data/mycin-2026/recall/test_genetics_recall.py
+++ b/code/specs/data/mycin-2026/recall/test_genetics_recall.py
@@ -52,6 +52,8 @@ EXPECTED = [
     ("friedreich_ataxia", "trinucleotide_repeat", "gaa"),            # expand (NBK563199)
     ("wilson_disease", "inheritance", "autosomal_recessive"),        # expand (NBK441990)
     ("wilson_disease", "gene_defect", "atp7b"),                      # expand (NBK441990)
+    ("hereditary_hemochromatosis", "inheritance", "autosomal_recessive"),  # expand (NBK430862)
+    ("hereditary_hemochromatosis", "gene_defect", "hfe"),            # expand (NBK430862)
 ]
 VAR = {"inheritance": "Pattern", "gene_defect": "Gene",
        "trinucleotide_repeat": "Repeat", "imprinting": "Parent"}


### PR DESCRIPTION
## What
Hereditary hemochromatosis — two grounded edges from StatPearls NBK430862:

- **inheritance(hereditary_hemochromatosis, autosomal_recessive)**:
  > This is considered the classic form of hereditary hemochromatosis, is inherited in an autosomal recessive fashion, and disproportionately affects males.
- **gene_defect(hereditary_hemochromatosis, hfe)**:
  > Type 1 hereditary hemochromatosis occurs in patients who are typically homozygous for loss-of-function mutations in HFE.

## Changes (data-only)
- `genetics-edges.adj` +2 `relate`; `genetics-recall.query.adj` +2; `test_genetics_recall.py` EXPECTED +2 (`ehlers_danlos_syndrome` negative control unchanged)

## Verification
- `test_genetics_recall: 3/3 passed`; ruff clean; data-only security review passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)