### PR TITLE
feat(mycin-micro): ground Listeria monocytogenes (gram-positive rod)

### DIFF
--- a/code/specs/data/mycin-2026/recall/micro-edges.adj
+++ b/code/specs/data/mycin-2026/recall/micro-edges.adj
@@ -138,4 +138,15 @@ rulebook micro_facts {
         source "Diarrhea and pseudomembranous colitis, characteristic symptoms of C difficile infection, result from clostridial glycosylation exotoxins—toxin A (TcdA), an enterotoxin, and toxin B (TcdB), which is cytotoxic."
         locator "https://www.ncbi.nlm.nih.gov/books/NBK431054/"
         trust authoritative
+
+    % --- Listeria monocytogenes (gram-positive rod) -----------------------------
+    % One span names BOTH the gram reaction and the shape (rod = bacillus) for the organism.
+    relate gram_stain(listeria_monocytogenes, gram_positive)
+        source "Listeria monocytogenes is a gram-positive, facultative anaerobic, intracellular rod with widespread environmental distribution, commonly found in soil, water, and vegetation, and capable of transient colonization of the human and animal gastrointestinal tract."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK534838/"
+        trust authoritative
+    relate morphology(listeria_monocytogenes, bacilli)
+        source "Listeria monocytogenes is a gram-positive, facultative anaerobic, intracellular rod with widespread environmental distribution, commonly found in soil, water, and vegetation, and capable of transient colonization of the human and animal gastrointestinal tract."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK534838/"
+        trust authoritative
 }

--- a/code/specs/data/mycin-2026/recall/micro-recall.query.adj
+++ b/code/specs/data/mycin-2026/recall/micro-recall.query.adj
@@ -25,3 +25,5 @@ import "micro-edges.adj"
 ? causes(helicobacter_pylori, $Disease)                % expect peptic_ulcer_disease (expand)
 ? gram_stain(clostridioides_difficile, $Result)        % expect gram_positive (expand)
 ? causes(clostridioides_difficile, $Disease)           % expect pseudomembranous_colitis (expand)
+? gram_stain(listeria_monocytogenes, $Result)          % expect gram_positive (expand)
+? morphology(listeria_monocytogenes, $Shape)           % expect bacilli (expand)

--- a/code/specs/data/mycin-2026/recall/test_micro_recall.py
+++ b/code/specs/data/mycin-2026/recall/test_micro_recall.py
@@ -50,6 +50,8 @@ EXPECTED = [
     ("helicobacter_pylori", "causes", "peptic_ulcer_disease"),       # expand (NBK534233)
     ("clostridioides_difficile", "gram_stain", "gram_positive"),      # expand (NBK431054)
     ("clostridioides_difficile", "causes", "pseudomembranous_colitis"),  # expand (NBK431054)
+    ("listeria_monocytogenes", "gram_stain", "gram_positive"),       # expand (NBK534838)
+    ("listeria_monocytogenes", "morphology", "bacilli"),             # expand (NBK534838)
 ]
 
 


### PR DESCRIPTION
## What
New microbiology organism — two grounded edges from one self-contained StatPearls span (NBK534838) naming both endpoints:

- **gram_stain(listeria_monocytogenes, gram_positive)**
- **morphology(listeria_monocytogenes, bacilli)**
  > Listeria monocytogenes is a gram-positive, facultative anaerobic, intracellular rod with widespread environmental distribution…

(rod = bacillus, consistent with the existing E. coli / Pseudomonas morphology mapping)

## Changes (data-only)
- `micro-edges.adj` +2 `relate`; `micro-recall.query.adj` +2; `test_micro_recall.py` EXPECTED +2 (`treponema_pallidum` negative control unchanged)

## Verification
- `test_micro_recall: 3/3 passed`; ruff clean; data-only security review passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)