### PR TITLE
feat(mycin-immuno): ground Wiskott-Aldrich (WAS) + hereditary angioedema (C1-inhibitor)

### DIFF
--- a/code/specs/data/mycin-2026/recall/immuno-edges.adj
+++ b/code/specs/data/mycin-2026/recall/immuno-edges.adj
@@ -99,4 +99,16 @@ rulebook immuno_facts {
         source "X-SCID results from mutations in the IL2RG gene encoding the common gamma chain cytokine receptor subunit, which is essential for multiple interleukin signaling pathways."
         locator "https://www.ncbi.nlm.nih.gov/books/NBK562182/"
         trust authoritative
+
+    % --- EXPAND: Wiskott-Aldrich syndrome molecular lesion is the WAS gene ------
+    relate gene_defect(wiskott_aldrich_syndrome, was)
+        source "The etiology of Wiskott-Aldrich syndrome is mutations in the WAS gene responsible for the production of WAS protein involved in cellular signaling and immunological synapse formation."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK539838/"
+        trust authoritative
+
+    % --- EXPAND: hereditary angioedema is C1-inhibitor deficiency ---------------
+    relate deficiency_of(hereditary_angioedema, c1_inhibitor)
+        source "Hereditary angioedema (HAE) is an autosomal dominant disease caused by the lack of or a dysfunctional C1-inhibitor protein."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK482266/"
+        trust authoritative
 }

--- a/code/specs/data/mycin-2026/recall/immuno-recall.query.adj
+++ b/code/specs/data/mycin-2026/recall/immuno-recall.query.adj
@@ -24,3 +24,5 @@ import "immuno-edges.adj"
 ? mediated_by(type_iii_hypersensitivity, $Mediator)    % expect immune_complexes (expand)
 ? mediated_by(type_ii_hypersensitivity, $Mediator)     % expect igg_igm_antibodies (expand)
 ? gene_defect(x_linked_scid, $Gene)                    % expect il2rg (expand)
+? gene_defect(wiskott_aldrich_syndrome, $Gene)         % expect was (expand)
+? deficiency_of(hereditary_angioedema, $Component)     % expect c1_inhibitor (expand)

--- a/code/specs/data/mycin-2026/recall/test_immuno_recall.py
+++ b/code/specs/data/mycin-2026/recall/test_immuno_recall.py
@@ -41,6 +41,8 @@ EXPECTED = [
     ("type_iii_hypersensitivity", "mediated_by", "immune_complexes"),  # expand (NBK559122)
     ("type_ii_hypersensitivity", "mediated_by", "igg_igm_antibodies"),  # expand (NBK563264)
     ("x_linked_scid", "gene_defect", "il2rg"),                       # expand (NBK562182)
+    ("wiskott_aldrich_syndrome", "gene_defect", "was"),              # expand (NBK539838)
+    ("hereditary_angioedema", "deficiency_of", "c1_inhibitor"),      # expand (NBK482266)
 ]
 VAR = {"mediated_by": "Mediator", "associated_hla": "HLA",
        "gene_defect": "Gene", "deficiency_of": "Component"}


### PR DESCRIPTION
## What
Two more grounded immunodeficiency edges:

- **gene_defect(wiskott_aldrich_syndrome, was)** [NBK539838]:
  > The etiology of Wiskott-Aldrich syndrome is mutations in the WAS gene responsible for the production of WAS protein involved in cellular signaling and immunological synapse formation.
- **deficiency_of(hereditary_angioedema, c1_inhibitor)** [NBK482266]:
  > Hereditary angioedema (HAE) is an autosomal dominant disease caused by the lack of or a dysfunctional C1-inhibitor protein.

## Changes (data-only)
- `immuno-edges.adj` +2 `relate`; `immuno-recall.query.adj` +2; `test_immuno_recall.py` EXPECTED +2 (`rheumatoid_arthritis` negative control unchanged)

## Verification
- `test_immuno_recall: 3/3 passed`; ruff clean; data-only security review passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)