### PR TITLE
feat(mycin-pharm): ground pyridoxine (vitamin B6) antidote for isoniazid overdose

### DIFF
--- a/code/specs/data/mycin-2026/recall/pharm-edges.adj
+++ b/code/specs/data/mycin-2026/recall/pharm-edges.adj
@@ -172,4 +172,9 @@ rulebook pharm_facts {
         source "Dimercaprol is a medication used to treat toxic exposure to arsenic, mercury, gold, and lead."
         locator "https://www.ncbi.nlm.nih.gov/books/NBK549804/"
         trust authoritative
+    % --- EXPAND: pyridoxine (vitamin B6) is the antidote for isoniazid overdose --
+    relate antidote_for(isoniazid_toxicity, pyridoxine)
+        source "In cases of poisoning resulting from ingesting more than 10 grams of isoniazid (INH), an equal amount of pyridoxine (vitamin B6) should be administered as an antidote."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK557436/"
+        trust authoritative
 }

--- a/code/specs/data/mycin-2026/recall/pharm-recall.query.adj
+++ b/code/specs/data/mycin-2026/recall/pharm-recall.query.adj
@@ -34,3 +34,4 @@ import "pharm-edges.adj"
 ? antidote_for(copper_toxicity, $Antidote)           % expect penicillamine (expand)
 ? antidote_for(dabigatran_toxicity, $Antidote)       % expect idarucizumab (expand)
 ? antidote_for(arsenic_poisoning, $Antidote)         % expect dimercaprol (expand)
+? antidote_for(isoniazid_toxicity, $Antidote)        % expect pyridoxine (expand)

--- a/code/specs/data/mycin-2026/recall/test_pharm_recall.py
+++ b/code/specs/data/mycin-2026/recall/test_pharm_recall.py
@@ -53,6 +53,7 @@ EXPECTED = [
     ("copper_toxicity", "antidote_for", "penicillamine"),         # expand (NBK513316)
     ("dabigatran_toxicity", "antidote_for", "idarucizumab"),      # expand (NBK560651)
     ("arsenic_poisoning", "antidote_for", "dimercaprol"),         # expand (NBK549804)
+    ("isoniazid_toxicity", "antidote_for", "pyridoxine"),         # expand (NBK557436)
 ]
 VAR = {"drug_class": "Class", "mechanism": "MOA", "adverse_effect": "Effect",
        "antidote_for": "Antidote"}


### PR DESCRIPTION
## What
The classic INH-toxicity antidote, grounded from StatPearls NBK557436:

- **antidote_for(isoniazid_toxicity, pyridoxine)**:
  > In cases of poisoning resulting from ingesting more than 10 grams of isoniazid (INH), an equal amount of pyridoxine (vitamin B6) should be administered as an antidote.

Fresh subject — no multi-valued `antidote_for` ambiguity.

## Changes (data-only)
- `pharm-edges.adj` +1 `relate`; `pharm-recall.query.adj` +1; `test_pharm_recall.py` EXPECTED +1

## Verification
- `test_pharm_recall: 3/3 passed`; ruff clean; data-only security review passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)