### PR TITLE
feat(mycin-genetics): ground Tay-Sachs disease (autosomal recessive; HEXA)

### DIFF
--- a/code/specs/data/mycin-2026/recall/genetics-edges.adj
+++ b/code/specs/data/mycin-2026/recall/genetics-edges.adj
@@ -158,4 +158,14 @@ rulebook genetics_facts {
         source "Type 1 hereditary hemochromatosis occurs in patients who are typically homozygous for loss-of-function mutations in HFE."
         locator "https://www.ncbi.nlm.nih.gov/books/NBK430862/"
         trust authoritative
+
+    % --- EXPAND: Tay-Sachs disease (autosomal recessive; HEXA gene) — one span both ---
+    relate inheritance(tay_sachs_disease, autosomal_recessive)
+        source "Tay-Sachs disease is an autosomal recessive disorder caused by a mutation in HEXA, which encodes the enzymes beta-hexosaminidase A."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK564432/"
+        trust authoritative
+    relate gene_defect(tay_sachs_disease, hexa)
+        source "Tay-Sachs disease is an autosomal recessive disorder caused by a mutation in HEXA, which encodes the enzymes beta-hexosaminidase A."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK564432/"
+        trust authoritative
 }

--- a/code/specs/data/mycin-2026/recall/genetics-recall.query.adj
+++ b/code/specs/data/mycin-2026/recall/genetics-recall.query.adj
@@ -35,3 +35,5 @@ import "genetics-edges.adj"
 ? gene_defect(wilson_disease, $Gene)                   % expect atp7b (expand)
 ? inheritance(hereditary_hemochromatosis, $Pattern)    % expect autosomal_recessive (expand)
 ? gene_defect(hereditary_hemochromatosis, $Gene)       % expect hfe (expand)
+? inheritance(tay_sachs_disease, $Pattern)             % expect autosomal_recessive (expand)
+? gene_defect(tay_sachs_disease, $Gene)                % expect hexa (expand)

--- a/code/specs/data/mycin-2026/recall/test_genetics_recall.py
+++ b/code/specs/data/mycin-2026/recall/test_genetics_recall.py
@@ -54,6 +54,8 @@ EXPECTED = [
     ("wilson_disease", "gene_defect", "atp7b"),                      # expand (NBK441990)
     ("hereditary_hemochromatosis", "inheritance", "autosomal_recessive"),  # expand (NBK430862)
     ("hereditary_hemochromatosis", "gene_defect", "hfe"),            # expand (NBK430862)
+    ("tay_sachs_disease", "inheritance", "autosomal_recessive"),     # expand (NBK564432)
+    ("tay_sachs_disease", "gene_defect", "hexa"),                    # expand (NBK564432)
 ]
 VAR = {"inheritance": "Pattern", "gene_defect": "Gene",
        "trinucleotide_repeat": "Repeat", "imprinting": "Parent"}


### PR DESCRIPTION
## What
Tay-Sachs disease — two grounded edges from one self-contained StatPearls span (NBK564432) naming both endpoints:

- **inheritance(tay_sachs_disease, autosomal_recessive)**
- **gene_defect(tay_sachs_disease, hexa)**
  > Tay-Sachs disease is an autosomal recessive disorder caused by a mutation in HEXA, which encodes the enzymes beta-hexosaminidase A.

## Changes (data-only)
- `genetics-edges.adj` +2 `relate`; `genetics-recall.query.adj` +2; `test_genetics_recall.py` EXPECTED +2 (`ehlers_danlos_syndrome` negative control unchanged)

## Verification
- `test_genetics_recall: 3/3 passed`; ruff clean; data-only security review passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)