### PR TITLE
feat(mycin-micro): ground Klebsiella pneumoniae (gram-negative)

### DIFF
--- a/code/specs/data/mycin-2026/recall/micro-edges.adj
+++ b/code/specs/data/mycin-2026/recall/micro-edges.adj
@@ -149,4 +149,12 @@ rulebook micro_facts {
         source "Listeria monocytogenes is a gram-positive, facultative anaerobic, intracellular rod with widespread environmental distribution, commonly found in soil, water, and vegetation, and capable of transient colonization of the human and animal gastrointestinal tract."
         locator "https://www.ncbi.nlm.nih.gov/books/NBK534838/"
         trust authoritative
+
+    % --- Klebsiella pneumoniae (gram-negative) ----------------------------------
+    % One span names the organism AND its gram reaction. (morphology declined: the page
+    % calls it a "bacillus" only in a historical clause anaphoric to "The bacterium".)
+    relate gram_stain(klebsiella_pneumoniae, gram_negative)
+        source "Klebsiella pneumoniae is a gram-negative, encapsulated, non-motile bacterium found in the environment"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK519004/"
+        trust authoritative
 }

--- a/code/specs/data/mycin-2026/recall/micro-recall.query.adj
+++ b/code/specs/data/mycin-2026/recall/micro-recall.query.adj
@@ -27,3 +27,4 @@ import "micro-edges.adj"
 ? causes(clostridioides_difficile, $Disease)           % expect pseudomembranous_colitis (expand)
 ? gram_stain(listeria_monocytogenes, $Result)          % expect gram_positive (expand)
 ? morphology(listeria_monocytogenes, $Shape)           % expect bacilli (expand)
+? gram_stain(klebsiella_pneumoniae, $Result)           % expect gram_negative (expand)

--- a/code/specs/data/mycin-2026/recall/test_micro_recall.py
+++ b/code/specs/data/mycin-2026/recall/test_micro_recall.py
@@ -52,6 +52,7 @@ EXPECTED = [
     ("clostridioides_difficile", "causes", "pseudomembranous_colitis"),  # expand (NBK431054)
     ("listeria_monocytogenes", "gram_stain", "gram_positive"),       # expand (NBK534838)
     ("listeria_monocytogenes", "morphology", "bacilli"),             # expand (NBK534838)
+    ("klebsiella_pneumoniae", "gram_stain", "gram_negative"),        # expand (NBK519004)
 ]
 
 


### PR DESCRIPTION
## What
New microbiology organism, grounded from StatPearls NBK519004:

- **gram_stain(klebsiella_pneumoniae, gram_negative)**:
  > Klebsiella pneumoniae is a gram-negative, encapsulated, non-motile bacterium found in the environment

(morphology declined — the page names "bacillus" only in a historical clause anaphoric to "The bacterium"; honest scope, ground or omit.)

## Changes (data-only)
- `micro-edges.adj` +1 `relate`; `micro-recall.query.adj` +1; `test_micro_recall.py` EXPECTED +1 (`treponema_pallidum` negative control unchanged)

## Verification
- `test_micro_recall: 3/3 passed`; ruff clean; data-only security review passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)