### PR TITLE
feat(mycin-immuno): ground Chediak-Higashi syndrome (LYST gene)

### DIFF
--- a/code/specs/data/mycin-2026/recall/immuno-edges.adj
+++ b/code/specs/data/mycin-2026/recall/immuno-edges.adj
@@ -111,4 +111,10 @@ rulebook immuno_facts {
         source "Hereditary angioedema (HAE) is an autosomal dominant disease caused by the lack of or a dysfunctional C1-inhibitor protein."
         locator "https://www.ncbi.nlm.nih.gov/books/NBK482266/"
         trust authoritative
+
+    % --- EXPAND: Chediak-Higashi syndrome molecular lesion is the LYST gene -----
+    relate gene_defect(chediak_higashi_syndrome, lyst)
+        source "Chediak-Higashi syndrome (CHS) is a rare autosomal recessive multisystem disorder caused by mutations in the LYST gene, leading to impaired lysosomal trafficking and dysfunctional organelle formation."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK507881/"
+        trust authoritative
 }

--- a/code/specs/data/mycin-2026/recall/immuno-recall.query.adj
+++ b/code/specs/data/mycin-2026/recall/immuno-recall.query.adj
@@ -26,3 +26,4 @@ import "immuno-edges.adj"
 ? gene_defect(x_linked_scid, $Gene)                    % expect il2rg (expand)
 ? gene_defect(wiskott_aldrich_syndrome, $Gene)         % expect was (expand)
 ? deficiency_of(hereditary_angioedema, $Component)     % expect c1_inhibitor (expand)
+? gene_defect(chediak_higashi_syndrome, $Gene)         % expect lyst (expand)

--- a/code/specs/data/mycin-2026/recall/test_immuno_recall.py
+++ b/code/specs/data/mycin-2026/recall/test_immuno_recall.py
@@ -43,6 +43,7 @@ EXPECTED = [
     ("x_linked_scid", "gene_defect", "il2rg"),                       # expand (NBK562182)
     ("wiskott_aldrich_syndrome", "gene_defect", "was"),              # expand (NBK539838)
     ("hereditary_angioedema", "deficiency_of", "c1_inhibitor"),      # expand (NBK482266)
+    ("chediak_higashi_syndrome", "gene_defect", "lyst"),             # expand (NBK507881)
 ]
 VAR = {"mediated_by": "Mediator", "associated_hla": "HLA",
        "gene_defect": "Gene", "deficiency_of": "Component"}


### PR DESCRIPTION
## What
New immunodeficiency edge, grounded from StatPearls NBK507881:

- **gene_defect(chediak_higashi_syndrome, lyst)**:
  > Chediak-Higashi syndrome (CHS) is a rare autosomal recessive multisystem disorder caused by mutations in the LYST gene, leading to impaired lysosomal trafficking and dysfunctional organelle formation.

## Changes (data-only)
- `immuno-edges.adj` +1 `relate`; `immuno-recall.query.adj` +1; `test_immuno_recall.py` EXPECTED +1 (`rheumatoid_arthritis` negative control unchanged)

## Verification
- `test_immuno_recall: 3/3 passed`; ruff clean; data-only security review passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)