### PR TITLE
feat(r-lang): R-37 — string utility completeness (strtoi base=0L, trimws whitespace=)

### DIFF
--- a/code/packages/rust/r-runtime/CHANGELOG.md
+++ b/code/packages/rust/r-runtime/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.33.0] - 2026-06-21
+
+### Added (via the shared `s-runtime`)
+
+- **R-37 — string-utility completeness**: the two options deferred from R-34 now
+  ship, reached through ordinary R syntax. No new builtins; the existing `strtoi`
+  and `trimws` handlers are extended in place.
+  - **`strtoi(x, base = 0L)`** — `base = 0L` infers each string's radix from its
+    prefix, C `strtol`-style: `0x`/`0X` → hex, a leading `0` + digit → octal, a
+    lone `"0"` → zero, else decimal. `strtoi("0x1F", 0L)` → `31`;
+    `strtoi("010", 0L)` → `8`; `strtoi("12", 0L)` → `12`; `strtoi("0", 0L)` → `0`.
+    An invalid octal digit (`strtoi("08", 0L)`) or an empty digit run
+    (`strtoi("0x", 0L)`) → `NA`. Explicit bases 2..36 are unchanged.
+  - **`trimws(x, whitespace = "[ \t\r\n]")`** — a new keyword-only `whitespace =`
+    argument, interpreted as a **regex** (faithful to base R ≥ 3.6) via the same
+    RE2 engine `grepl`/`gsub` use. `trimws("xxhixx", whitespace = "x")` → `"hi"`;
+    `trimws("xxhix", whitespace = "x", which = "left")` → `"hix"`. The default
+    whitespace, `which`, and `NA` behavior are unchanged.
+  - **Security**: base-0 parsing reuses checked-`i64` accumulation (overflow →
+    `NA`); `whitespace =` slicing uses regex-reported `char`-boundary offsets
+    (UTF-8 safe) and RE2's linear-time matching (no ReDoS); an invalid pattern is
+    a clean error. Nothing in the string-utility family remains deferred.
+
 ## [0.32.0] - 2026-06-21
 
 ### Added (via the shared `s-runtime`)

--- a/code/packages/rust/r-runtime/README.md
+++ b/code/packages/rust/r-runtime/README.md
@@ -261,8 +261,17 @@ base=10L)` parses integers in bases 2..36 the way C `strtol` does — leading
 whitespace and a sign, a `0x` prefix for base 16, the whole string consumed, and
 `NA` for an empty string, garbage, an out-of-range digit, or a base outside 2..36
 (`strtoi("FF", 16L)` → `255`; `strtoi(c("7","8"), 8L)` → `c(7, NA)`). Parsing uses
-checked `i64` arithmetic, so overflow yields `NA` rather than a panic. (`strtoi`'s
-`base=0L` auto-detection and a custom `trimws(whitespace=)` are deferred to R-36.)
+checked `i64` arithmetic, so overflow yields `NA` rather than a panic.
+
+**R-37 — string-utility completeness** finishes the family. `strtoi(x, base=0L)`
+auto-detects each string's radix from its prefix, C `strtol`-style — `0x`/`0X` →
+hex, a leading `0` + digit → octal, a lone `"0"` → zero, else decimal
+(`strtoi("0x1F", 0L)` → `31`; `strtoi("010", 0L)` → `8`; `strtoi("12", 0L)` → `12`;
+`strtoi("08", 0L)` → `NA`). `trimws(x, whitespace=)` adds a keyword-only
+`whitespace=` argument, interpreted as a **regex** (default `"[ \t\r\n]"`, faithful
+to base R ≥ 3.6) via the same RE2 engine `grepl`/`gsub` use, anchored to the trimmed
+edge (`trimws("xxhixx", whitespace="x")` → `"hi"`). RE2's linear-time matching rules
+out ReDoS, and slicing is on `char`-boundary offsets (UTF-8 safe).
 
 **R-36 — matrix cross products** add `crossprod` and `tcrossprod`, again through the
 shared `s-runtime`. An independent matrix-algebra item, defined entirely in terms of

--- a/code/packages/rust/r-runtime/src/lib.rs
+++ b/code/packages/rust/r-runtime/src/lib.rs
@@ -258,6 +258,39 @@ mod tests {
         assert_eq!(nums("strtoi(\"FF\", 16L) + 1\n"), vec![256.0]);
     }
 
+    // --- R-37: strtoi base = 0L auto-detection through R syntax ---------------
+
+    #[test]
+    fn r37_strtoi_base0() {
+        // 0x / 0X prefix -> hex.
+        assert_eq!(nums("strtoi(\"0x1F\", 0L)\n"), vec![31.0]);
+        assert_eq!(nums("strtoi(\"0X1f\", 0L)\n"), vec![31.0]);
+        // Leading 0 -> octal; lone 0 -> zero; no prefix -> decimal.
+        assert_eq!(nums("strtoi(\"010\", 0L)\n"), vec![8.0]);
+        assert_eq!(nums("strtoi(\"12\", 0L)\n"), vec![12.0]);
+        assert_eq!(nums("strtoi(\"0\", 0L)\n"), vec![0.0]);
+        // Invalid octal digit and empty-after-prefix -> NA.
+        assert_eq!(show("strtoi(\"08\", 0L)\n"), "[1] NA");
+        assert_eq!(show("strtoi(\"0x\", 0L)\n"), "[1] NA");
+        // Explicit bases still work unchanged.
+        assert_eq!(nums("strtoi(\"FF\", 16L)\n"), vec![255.0]);
+    }
+
+    // --- R-37: trimws(whitespace =) through R syntax --------------------------
+
+    #[test]
+    fn r37_trimws_whitespace() {
+        assert_eq!(show("trimws(\"xxhixx\", whitespace = \"x\")\n"), "[1] \"hi\"");
+        assert_eq!(
+            show("trimws(\"xxhix\", which = \"left\", whitespace = \"x\")\n"),
+            "[1] \"hix\""
+        );
+        // Default whitespace unchanged.
+        assert_eq!(show("trimws(\"  hi  \")\n"), "[1] \"hi\"");
+        // NA propagation preserved.
+        assert_eq!(show("trimws(NA, whitespace = \"x\")\n"), "[1] NA");
+    }
+
     #[test]
     fn lists_through_r_syntax() {
         // list() with $ access; lapply -> list; strsplit -> list of char vectors.

--- a/code/packages/rust/s-runtime/CHANGELOG.md
+++ b/code/packages/rust/s-runtime/CHANGELOG.md
@@ -2,6 +2,37 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.34.0] - 2026-06-21
+
+### Added
+
+- **String-utility completeness (R-37)** — the two options deferred from R-34 now
+  ship, extending the existing `strtoi`/`trimws` handlers in place (no new
+  builtins, no grammar change).
+  - **`strtoi(x, base = 0L)` auto-detection** — when `base` is `0`, the radix of
+    each string is inferred from its post-sign prefix, exactly as C
+    `strtol(…, 0)`: a `0x`/`0X` prefix → hexadecimal; a leading `0` followed by at
+    least one more digit → octal; a lone `"0"` → decimal zero; anything else →
+    decimal. Because octal is parsed in base 8, an out-of-range digit after a
+    leading `0` is `NA` (`strtoi("08", 0L)` → `NA`), and a bare `"0x"` (no digits)
+    → `NA`. `strtoi("0x1F", 0L)` → `31`; `strtoi("010", 0L)` → `8`;
+    `strtoi("12", 0L)` → `12`; `strtoi("0", 0L)` → `0`. Explicit bases 2..36 are
+    unchanged; a `base` outside `{0} ∪ 2..36` still makes every element `NA`.
+  - **`trimws(x, whitespace = "[ \t\r\n]")`** — a new keyword-only `whitespace =`
+    argument selecting the set of characters to strip. It is a **regular
+    expression** (faithful to base R ≥ 3.6), compiled with the same RE2-based
+    `regex` engine `grepl`/`gsub` use and anchored to the trimmed edge
+    (`^(?:p)+` for the left, `(?:p)+$` for the right). `trimws("xxhixx",
+    whitespace = "x")` → `"hi"`; `trimws("..a..", whitespace = "[.]")` → `"a"`. The
+    default and `which`/`NA` behavior are unchanged.
+  - **Security**: base-0 parsing reuses the checked-`i64` accumulation (overflow →
+    `NA`, never a panic) and rejects empty digit runs (e.g. `"0x"`) as `NA`;
+    `whitespace =` slicing uses the regex-reported byte offsets (always `char`
+    boundaries), so multibyte input is UTF-8 safe, and RE2's guaranteed
+    linear-time matching means a crafted `whitespace =` pattern cannot cause
+    catastrophic backtracking (no ReDoS). An invalid `whitespace =` pattern is a
+    clean `Err`.
+
 ## [0.33.0] - 2026-06-21
 
 ### Added

--- a/code/packages/rust/s-runtime/README.md
+++ b/code/packages/rust/s-runtime/README.md
@@ -266,8 +266,14 @@ a hand-written loop. See [What "S-flavored" means here](#what-s-flavored-means-h
   bases 2..36 (`strtol`-style: leading whitespace + sign, `0x` prefix for base 16,
   full-consume, `NA` for garbage / out-of-range digit / base outside 2..36), with
   checked `i64` accumulation (overflow → `NA`, never a panic).
-  (`strtoi(base=0L)` auto-detection and a custom `trimws(whitespace=)` are deferred
-  to R-36.)
+- **String-utility completeness** (R-37): `strtoi(x, base=0L)` auto-detects each
+  string's radix from its prefix, C `strtol`-style — `0x`/`0X` → hex, a leading `0`
+  + digit → octal, a lone `"0"` → zero, else decimal (`strtoi("0x1F", 0L)` → `31`;
+  `strtoi("010", 0L)` → `8`; `strtoi("08", 0L)` → `NA`). `trimws(x, whitespace=)`
+  gains a keyword-only `whitespace=` argument, interpreted as a **regex** (default
+  `"[ \t\r\n]"`, base-R faithful) via the same RE2 engine `grepl`/`gsub` use,
+  anchored to the trimmed edge (`trimws("xxhixx", whitespace="x")` → `"hi"`). RE2's
+  linear-time matching rules out ReDoS; slicing is on `char`-boundary offsets.
 - **Ordered factors & `cut()` label polish** (R-35): an *ordered* factor is a factor
   whose levels carry a meaningful order — `SValue::Factor` gains an `ordered: bool`
   field, so `class()` reports `c("ordered", "factor")` when set (and the `Levels:`

--- a/code/packages/rust/s-runtime/src/builtins.rs
+++ b/code/packages/rust/s-runtime/src/builtins.rs
@@ -3403,26 +3403,41 @@ fn b_ends_with(_interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
     affix_test(args, "suffix", |s, p| s.ends_with(p))
 }
 
-/// A single ASCII/Unicode whitespace character per R's default `trimws` class
-/// `[ \t\r\n]`. We match exactly those four so behavior is locale-free and
-/// predictable (we deliberately do *not* use `char::is_whitespace`, which would
-/// also strip e.g. form-feed and the Unicode spaces).
-fn is_trim_ws(c: char) -> bool {
-    matches!(c, ' ' | '\t' | '\r' | '\n')
-}
+/// Base R's default `trimws` whitespace class, `[ \t\r\n]` — a space, tab, CR,
+/// and LF. Used verbatim when no `whitespace =` argument is supplied (R-37). We
+/// keep it as the literal regex source (rather than `char::is_whitespace`) so the
+/// default and the custom path share one code route and stay locale-free.
+const TRIMWS_DEFAULT_WS: &str = "[ \t\r\n]";
 
-/// `trimws(x, which = "both")` — strip leading and/or trailing whitespace from
-/// each element. `which` is the second positional or the `which =` named arg and
-/// must be one of `"both"`, `"left"`, `"right"`; anything else is a clean error.
-/// `NA` elements pass through unchanged. Char-based, so UTF-8 safe.
+/// `trimws(x, which = "both", whitespace = "[ \t\r\n]")` — strip leading and/or
+/// trailing whitespace from each element. `which` is the second positional or the
+/// `which =` named arg and must be one of `"both"`, `"left"`, `"right"`; anything
+/// else is a clean error. `NA` elements pass through unchanged.
+///
+/// **`whitespace =` (R-37).** The set of characters to strip is a *regular
+/// expression* (faithful to base R ≥ 3.6), defaulting to [`TRIMWS_DEFAULT_WS`].
+/// We compile it once with the same RE2-based `regex` engine `grepl`/`gsub` use,
+/// wrapped as a non-capturing group repeated one-or-more times and anchored to the
+/// edge being trimmed: `^(?:p)+` for the left, `(?:p)+$` for the right. Only a run
+/// of the class at the very start/end is removed; interior matches are untouched.
+/// Because RE2 matches in guaranteed linear time with no backtracking, no
+/// `whitespace =` pattern can cause catastrophic backtracking (no ReDoS). An
+/// invalid pattern is a clean `Err`. All slicing uses the byte offset that the
+/// regex itself reports for a whole-`char` match, so multibyte input is UTF-8 safe.
 fn b_trimws(_interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
     let x = first_positional(args)?.as_character();
     // `which =` named arg wins; else the second positional; else "both".
+    // (`whitespace` is keyword-only, so it never collides with the positional.)
     let which = args
         .iter()
         .find(|a| a.name.as_deref() == Some("which"))
         .map(|a| &a.value)
-        .or_else(|| nth_positional(args, 1))
+        .or_else(|| {
+            args.iter()
+                .filter(|a| a.name.is_none())
+                .nth(1)
+                .map(|a| &a.value)
+        })
         .map(|v| v.as_character())
         .and_then(|c| c.into_iter().next().flatten())
         .unwrap_or_else(|| "both".to_string());
@@ -3438,16 +3453,46 @@ fn b_trimws(_interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
         }
     };
 
+    // The `whitespace =` pattern (keyword-only); default is R's `[ \t\r\n]`.
+    let ws = args
+        .iter()
+        .find(|a| a.name.as_deref() == Some("whitespace"))
+        .map(|a| a.value.as_character())
+        .and_then(|c| c.into_iter().next().flatten())
+        .unwrap_or_else(|| TRIMWS_DEFAULT_WS.to_string());
+
+    // Compile each edge's anchored matcher *once* (not per element). A bad pattern
+    // surfaces here as a clean error before we touch any data.
+    let left_re = if trim_left {
+        Some(compile(&format!("^(?:{ws})+"), false)?)
+    } else {
+        None
+    };
+    let right_re = if trim_right {
+        Some(compile(&format!("(?:{ws})+$"), false)?)
+    } else {
+        None
+    };
+
     let out = x
         .into_iter()
         .map(|o| {
             o.map(|s| {
                 let mut t: &str = &s;
-                if trim_left {
-                    t = t.trim_start_matches(is_trim_ws);
+                // Strip a leading run: the match (if any) starts at byte 0, so we
+                // keep the tail after `m.end()` — a regex-reported byte boundary,
+                // hence always a valid UTF-8 char boundary.
+                if let Some(re) = &left_re {
+                    if let Some(m) = re.find(t) {
+                        t = &t[m.end()..];
+                    }
                 }
-                if trim_right {
-                    t = t.trim_end_matches(is_trim_ws);
+                // Strip a trailing run: the `$`-anchored match ends at the string
+                // end, so we keep the head before `m.start()` (also a char boundary).
+                if let Some(re) = &right_re {
+                    if let Some(m) = re.find(t) {
+                        t = &t[..m.start()];
+                    }
                 }
                 t.to_string()
             })
@@ -3515,10 +3560,11 @@ fn b_chartr(_interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
 ///     (including trailing whitespace) makes the element `NA`;
 ///   * an empty (or sign-only / prefix-only) string is `NA`;
 ///   * a digit outside the base's range makes the element `NA`;
-///   * a `base` outside 2..36 makes **every** element `NA`.
+///   * a `base` outside `{0} ∪ 2..36` makes **every** element `NA`.
 ///
-/// `base = 0L` auto-detection is deferred to R-36. Accumulation is `i64`-checked,
-/// so a long all-digits string overflows to `NA` rather than panicking.
+/// `base = 0L` auto-detects each string's radix from its prefix (R-37; see
+/// [`parse_strtoi`]). Accumulation is `i64`-checked, so a long all-digits string
+/// overflows to `NA` rather than panicking.
 fn b_strtoi(_interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
     let x = first_positional(args)?.as_character();
     let base = args
@@ -3543,15 +3589,28 @@ fn b_strtoi(_interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
 }
 
 /// Parse a single string for [`b_strtoi`]. Returns `None` (→ `NA`) for any base
-/// outside 2..=36, an empty/garbage string, an out-of-range digit, or an `i64`
-/// overflow. Never panics: every step is a `checked_*` arithmetic op or a bounded
-/// `char` scan.
+/// outside `{0} ∪ 2..=36`, an empty/garbage string, an out-of-range digit, or an
+/// `i64` overflow. Never panics: every step is a `checked_*` arithmetic op or a
+/// bounded `char` scan.
+///
+/// **`base == 0` (R-37).** The radix is inferred from the post-sign prefix, exactly
+/// as C `strtol(…, 0)`:
+///
+/// | post-sign prefix        | inferred base | example         |
+/// |-------------------------|---------------|-----------------|
+/// | `0x` / `0X` + hex digits | 16           | `"0x1F"` → 31   |
+/// | `0` + another digit      | 8            | `"010"` → 8     |
+/// | exactly `"0"`            | 10 (value 0) | `"0"` → 0       |
+/// | anything else            | 10           | `"12"` → 12     |
+///
+/// Because octal is then parsed in base 8, a stray `8`/`9` after a leading `0`
+/// (e.g. `"08"`) is an out-of-range digit and yields `None`. A bare `0x`/`0X`
+/// with no following digits also yields `None` (empty digit run).
 fn parse_strtoi(s: &str, base: i64) -> Option<i64> {
-    // Base must be representable and in 2..=36; anything else is NA.
-    if !(2..=36).contains(&base) {
+    // Base must be representable and in {0} ∪ 2..=36; anything else is NA.
+    if base != 0 && !(2..=36).contains(&base) {
         return None;
     }
-    let base = base as u32;
 
     // Skip leading ASCII whitespace (strtol's `isspace`), then read an optional
     // sign. We work on the char iterator so multibyte tails can't desync indices.
@@ -3561,13 +3620,20 @@ fn parse_strtoi(s: &str, base: i64) -> Option<i64> {
         None => (false, trimmed.strip_prefix('+').unwrap_or(trimmed)),
     };
 
-    // For base 16, an optional `0x`/`0X` prefix is allowed (strtol convention).
-    let digits = if base == 16 {
-        rest.strip_prefix("0x")
+    // Resolve the effective base and strip any radix prefix from the digit run.
+    //   * base 0  → auto-detect from the prefix (R-37);
+    //   * base 16 → tolerate an optional `0x`/`0X` prefix (strtol convention);
+    //   * otherwise → the digits are taken literally.
+    let (base, digits) = if base == 0 {
+        detect_base0_prefix(rest)
+    } else if base == 16 {
+        let d = rest
+            .strip_prefix("0x")
             .or_else(|| rest.strip_prefix("0X"))
-            .unwrap_or(rest)
+            .unwrap_or(rest);
+        (16u32, d)
     } else {
-        rest
+        (base as u32, rest)
     };
 
     // Require at least one digit, and the *entire* remainder to be valid digits
@@ -3584,6 +3650,34 @@ fn parse_strtoi(s: &str, base: i64) -> Option<i64> {
         acc = acc.checked_neg()?;
     }
     Some(acc)
+}
+
+/// `strtoi(x, base = 0L)` prefix detection (R-37). Given the post-sign remainder
+/// `rest`, return `(effective_base, digit_run)`:
+///
+///   * a `0x`/`0X` prefix → base 16, with the prefix stripped;
+///   * a leading `0` *followed by at least one more character* → base 8, with the
+///     leading `0` stripped (so `"010"` parses the run `"10"` in base 8 → 8, and
+///     `"08"` parses `"8"` in base 8 → an out-of-range digit → `NA`);
+///   * a lone `"0"` → base 10, digit run `"0"` (the number zero);
+///   * anything else → base 10, digits taken as-is.
+///
+/// Pure prefix inspection (no allocation); the caller does the actual digit scan
+/// and so still rejects an empty digit run (e.g. a bare `"0x"`) as `NA`.
+fn detect_base0_prefix(rest: &str) -> (u32, &str) {
+    if let Some(d) = rest.strip_prefix("0x").or_else(|| rest.strip_prefix("0X")) {
+        (16, d)
+    } else if let Some(d) = rest.strip_prefix('0') {
+        // A leading `0` with more text behind it is octal; a lone "0" is decimal
+        // zero (octal "" would be an empty run → NA, which is wrong for "0").
+        if d.is_empty() {
+            (10, rest) // exactly "0": decimal, value 0.
+        } else {
+            (8, d) // octal: parse the digits after the leading 0.
+        }
+    } else {
+        (10, rest)
+    }
 }
 
 /// Hard cap on any single field width or precision (1 MiB). A user-supplied

--- a/code/packages/rust/s-runtime/src/lib.rs
+++ b/code/packages/rust/s-runtime/src/lib.rs
@@ -690,6 +690,70 @@ mod tests {
         assert_eq!(show("strtoi(\"10\", 1)\n"), "[1] NA");
     }
 
+    // --- R-37: strtoi base = 0 auto-detection -------------------------------
+    // NOTE: the s-runtime lexer reads a trailing `L` as the assignment operator,
+    // so these tests pass base 0 as a plain integer (the r-runtime tests use 0L).
+
+    #[test]
+    fn strtoi_base0_autodetects_radix() {
+        // 0x / 0X prefix -> hexadecimal.
+        assert_eq!(nums("strtoi(\"0x1F\", 0)\n"), vec![31.0]);
+        assert_eq!(nums("strtoi(\"0X1f\", 0)\n"), vec![31.0]);
+        // Leading 0 followed by octal digits -> octal.
+        assert_eq!(nums("strtoi(\"010\", 0)\n"), vec![8.0]);
+        assert_eq!(nums("strtoi(\"077\", 0)\n"), vec![63.0]);
+        // No 0 prefix -> decimal.
+        assert_eq!(nums("strtoi(\"12\", 0)\n"), vec![12.0]);
+        // A lone "0" is the number zero, not an empty octal.
+        assert_eq!(nums("strtoi(\"0\", 0)\n"), vec![0.0]);
+        // Sign is honored before prefix detection.
+        assert_eq!(nums("strtoi(\"-0x10\", 0)\n"), vec![-16.0]);
+        assert_eq!(nums("strtoi(\"-010\", 0)\n"), vec![-8.0]);
+    }
+
+    #[test]
+    fn strtoi_base0_invalid_octal_and_empty_prefix_are_na() {
+        // 8 is not an octal digit; a leading 0 makes "08" octal -> NA.
+        assert_eq!(show("strtoi(\"08\", 0)\n"), "[1] NA");
+        assert_eq!(show("strtoi(\"09\", 0)\n"), "[1] NA");
+        // A 0x prefix with no following digits -> NA.
+        assert_eq!(show("strtoi(\"0x\", 0)\n"), "[1] NA");
+        // Empty string -> NA.
+        assert_eq!(show("strtoi(\"\", 0)\n"), "[1] NA");
+        // Vectorized: decimal ok, bad octal NA.
+        assert_eq!(show("strtoi(c(\"12\", \"08\"), 0)\n"), "[1] 12 NA");
+    }
+
+    // --- R-37: trimws(whitespace =) regex argument --------------------------
+
+    #[test]
+    fn trimws_custom_whitespace_regex() {
+        // A literal character class via the whitespace = argument.
+        assert_eq!(show("trimws(\"xxhixx\", whitespace = \"x\")\n"), "[1] \"hi\"");
+        // which = left only strips the leading run.
+        assert_eq!(
+            show("trimws(\"xxhix\", which = \"left\", whitespace = \"x\")\n"),
+            "[1] \"hix\""
+        );
+        // which = right only strips the trailing run.
+        assert_eq!(
+            show("trimws(\"xxhix\", which = \"right\", whitespace = \"x\")\n"),
+            "[1] \"xxhi\""
+        );
+        // A genuine regex class.
+        assert_eq!(show("trimws(\"..a..\", whitespace = \"[.]\")\n"), "[1] \"a\"");
+        // Default whitespace still works when whitespace = is omitted.
+        assert_eq!(show("trimws(\"  hi  \")\n"), "[1] \"hi\"");
+        // NA propagates with a custom whitespace.
+        assert_eq!(show("trimws(NA, whitespace = \"x\")\n"), "[1] NA");
+    }
+
+    #[test]
+    fn trimws_bad_whitespace_regex_errors() {
+        // An unbalanced bracket is an invalid regex -> clean Err, not a panic.
+        assert!(eval_s("trimws(\"x\", whitespace = \"[\")\n").is_err());
+    }
+
     #[test]
     fn sprintf_formatting() {
         assert_eq!(show("sprintf(\"%d apples\", 3)\n"), "[1] \"3 apples\"");

--- a/code/specs/R00-r-language.md
+++ b/code/specs/R00-r-language.md
@@ -1344,12 +1344,21 @@ unchanged.
     `startsWith(NA, "a")` → `NA`.
   - **`endsWith(x, suffix)`** — the trailing-edge analogue, same recycling and NA
     rules. `endsWith(c("file.txt","file.csv"), ".txt")` → `c(TRUE, FALSE)`.
-  - **`trimws(x, which = "both")`** — strip leading and/or trailing whitespace from
-    each element. `which ∈ {"both","left","right"}` (read as the second positional
-    or the `which =` named arg); any other value is a clean error. Whitespace is
-    R's default class `[ \t\r\n]`. `trimws("  hi  ")` → `"hi"`;
-    `trimws("  hi  ", "left")` → `"hi  "`; `trimws("  hi  ", "right")` → `"  hi"`;
-    `trimws(NA)` → `NA`. Char-based, UTF-8 safe.
+  - **`trimws(x, which = "both", whitespace = "[ \t\r\n]")`** — strip leading and/or
+    trailing whitespace from each element. `which ∈ {"both","left","right"}` (read as
+    the second positional or the `which =` named arg); any other value is a clean
+    error. `trimws("  hi  ")` → `"hi"`; `trimws("  hi  ", "left")` → `"hi  "`;
+    `trimws("  hi  ", "right")` → `"  hi"`; `trimws(NA)` → `NA`. Char-based, UTF-8 safe.
+    - **`whitespace =` (R-37).** The set of characters to strip is a **regular
+      expression**, defaulting to R's class `"[ \t\r\n]"`. We compile it with the
+      same RE2-based `regex` engine `grepl`/`gsub` use, anchoring it (`^(?:…)+` for
+      the left edge, `(?:…)+$` for the right edge) so only a run of the matched class
+      at the very start/end is removed. Because RE2 matches in guaranteed linear time
+      with no backtracking, a crafted `whitespace=` pattern **cannot** trigger
+      catastrophic backtracking (no ReDoS). An invalid pattern is a clean error.
+      `trimws("xxhixx", whitespace = "x")` → `"hi"`;
+      `trimws("xxhix", whitespace = "x", which = "left")` → `"hix"`;
+      `trimws("..a..", whitespace = "[.]")` → `"a"`. `NA` propagates.
   - **`chartr(old, new, x)`** — translate characters: each char of `x` that appears
     at position *i* of `old` becomes the char at position *i* of `new`. `old` and
     `new` are **length-one** character scalars and must have **equal `nchar`**, else
@@ -1357,9 +1366,10 @@ unchanged.
     Unicode `char`, so multibyte `old`/`new`/`x` work and never panic.
     `chartr("abc", "xyz", "cab")` → `"zxy"`. Vectorized over `x`; `NA` element → `NA`.
   - **`strtoi(x, base = 10L)`** — parse each string as an integer in the given
-    `base` (an integer in **2..36**, read as the second positional or `base =`),
-    returning a **double** vector (this subset has no distinct integer type), with
-    `NA` for anything unparseable. Semantics follow C `strtol` as R does:
+    `base` (an integer in **2..36** *or* the special value `0L`, read as the second
+    positional or `base =`), returning a **double** vector (this subset has no
+    distinct integer type), with `NA` for anything unparseable. Semantics follow C
+    `strtol` as R does:
     - Leading ASCII whitespace is skipped; an optional `+`/`-` sign is honored.
     - For **base 16**, an optional `0x`/`0X` prefix is accepted (e.g.
       `strtoi("0xFF", 16L)` → `255`); for other bases the digits are taken literally.
@@ -1367,7 +1377,16 @@ unchanged.
       (including trailing whitespace) yields `NA`. An empty string yields `NA`.
     - A digit outside the base's range makes the element `NA`
       (`strtoi(c("7","8"), 8L)` → `c(7, NA)`; `strtoi("z", 16L)` → `NA`).
-    - A `base` outside **2..36** makes **every** element `NA` (matching base R's
+    - **`base = 0L` auto-detection (R-37).** When `base` is `0`, the radix of each
+      string is inferred from its prefix, exactly as C `strtol(…, 0)`: after the
+      optional sign, a `0x`/`0X` prefix selects **hexadecimal**; a leading `0`
+      followed by at least one more digit selects **octal**; a lone `"0"` is the
+      number zero; anything else is **decimal**. Because octal is then parsed in
+      base 8, a digit `8`/`9` after a leading `0` is out of range and yields `NA`
+      (`strtoi("08", 0L)` → `NA`, matching base R). A prefix with no following
+      digits (`strtoi("0x", 0L)`) yields `NA`. Examples: `strtoi("0x1F", 0L)` → `31`;
+      `strtoi("010", 0L)` → `8`; `strtoi("12", 0L)` → `12`; `strtoi("0", 0L)` → `0`.
+    - A `base` outside **{0} ∪ 2..36** makes **every** element `NA` (matching base R's
       `strtol`-driven behavior — it does *not* error).
     Examples: `strtoi("FF", 16L)` → `255`; `strtoi("10", 2L)` → `2`;
     `strtoi(c("7","8"), 8L)` → `c(7, NA)`.
@@ -1377,12 +1396,13 @@ unchanged.
     a fixed length cap, so a long all-digits string cannot overflow or hang
     (overflow → `NA`, never a panic). Recycling length is the max of the (bounded)
     input lengths; an empty input recycles to length 0.
-  - **Scope outcome / deferred to R-36.** `startsWith`, `endsWith`, `trimws`,
-    `chartr`, and `strtoi` (explicit bases **2..36**) ship **solidly**. **Deferred to
-    R-36:** `strtoi`'s `base = 0L` auto-detection (C `strtol`'s convention where a
-    `0x` prefix selects base 16 and a leading `0` selects base 8) — a self-contained
-    extension of the same parser. `trimws`'s custom `whitespace =` regex argument
-    (R ≥ 3.6) is likewise deferred; the default class covers the common case.
+  - **Scope outcome.** `startsWith`, `endsWith`, `trimws`, `chartr`, and `strtoi`
+    (explicit bases **2..36**) shipped **solidly** in **R-34**. **R-37** completes the
+    family: `strtoi`'s `base = 0L` prefix auto-detection (C `strtol`'s convention where
+    a `0x` prefix selects base 16 and a leading `0` selects base 8) and `trimws`'s
+    custom `whitespace =` argument, interpreted as a **regex** (faithful to base R
+    ≥ 3.6) by reusing the existing RE2-based `regex` engine. Nothing in the family
+    remains deferred.
 
 ## §4 Reuse strategy
 
@@ -1425,7 +1445,7 @@ making them non-faithful; `cut`'s `labels=`/`right=FALSE`/`include.lowest=` and 
 `breaks` are deferred to **R-33**; the independent string-utility family
 (`startsWith`, `endsWith`, `trimws`, `chartr`, `strtoi` over explicit bases 2..36)
 lands in **R-34**, with `strtoi`'s `base = 0L` auto-detection and `trimws`'s custom
-`whitespace=` argument deferred to **R-36**; namespaces and `library()`
+`whitespace=` argument completing the family in **R-37**; namespaces and `library()`
 (so `baseenv()` aliases the
 global env for now); the C interface; graphics. These layer on later, following
 ST00.

--- a/code/specs/S00-s-language.md
+++ b/code/specs/S00-s-language.md
@@ -598,20 +598,28 @@ essential: `switch("a", a = stop("no"), b = "ok")` must not raise, and a
      `TRUE` where `x[i]` begins/ends with the (recycled) `prefix[i]`/`suffix[i]`.
      Both arguments are **recycled** to the longer length; `NA` in either position
      → `NA`. Implemented with `str::starts_with`/`ends_with` (code-point safe).
-   - **`trimws(x, which = "both")`** — strip leading and/or trailing whitespace
-     (`[ \t\r\n]`) from each element; `which ∈ {"both","left","right"}` (second
-     positional or `which =`), any other value a clean `Err`. `NA` → `NA`.
+   - **`trimws(x, which = "both", whitespace = "[ \t\r\n]")`** — strip leading and/or
+     trailing whitespace from each element; `which ∈ {"both","left","right"}` (second
+     positional or `which =`), any other value a clean `Err`. `NA` → `NA`. The
+     **`whitespace =`** argument (R-37) is a **regex** (default `"[ \t\r\n]"`),
+     compiled with the same RE2-based `regex` engine `grepl`/`gsub` use and anchored
+     to the matched edge (`^(?:p)+` / `(?:p)+$`); RE2's linear-time matching rules out
+     ReDoS. `trimws("xxhixx", whitespace = "x")` → `"hi"`. An invalid pattern is a
+     clean `Err`.
    - **`chartr(old, new, x)`** — translate each char of `x` found at position *i* of
      `old` to position *i* of `new`. `old`/`new` are length-one and must have equal
      `nchar`, else an `Err`. Vectorized over `x`; `NA` → `NA`.
-   - **`strtoi(x, base = 10L)`** — parse each string as an integer in `base` (2..36,
-     second positional or `base =`), returning a `Double` vector (`NA` for
-     unparseable). Follows C `strtol`: leading whitespace and an optional sign are
-     honored, base 16 accepts an `0x`/`0X` prefix, the whole remaining string must be
-     consumed (trailing garbage → `NA`), an empty string → `NA`, an out-of-range
-     digit → `NA`, and a `base` outside 2..36 makes every element `NA`. Parsing uses
-     checked `i64` accumulation (overflow → `NA`, never a panic); `base = 0L`
-     auto-detection is **deferred to R-36**.
+   - **`strtoi(x, base = 10L)`** — parse each string as an integer in `base` (2..36
+     *or* the special `0`, second positional or `base =`), returning a `Double` vector
+     (`NA` for unparseable). Follows C `strtol`: leading whitespace and an optional
+     sign are honored, base 16 accepts an `0x`/`0X` prefix, the whole remaining string
+     must be consumed (trailing garbage → `NA`), an empty string → `NA`, an
+     out-of-range digit → `NA`, and a `base` outside `{0} ∪ 2..36` makes every element
+     `NA`. Parsing uses checked `i64` accumulation (overflow → `NA`, never a panic).
+     **`base = 0L` auto-detection (R-37):** the radix is inferred from each string's
+     prefix — `0x`/`0X` → hex, a leading `0` followed by another digit → octal (so
+     `"08"` → `NA`), a lone `"0"` → zero, otherwise decimal. `strtoi("0x1F", 0L)` →
+     `31`; `strtoi("010", 0L)` → `8`; `strtoi("12", 0L)` → `12`.
 
 ## §10 References
 


### PR DESCRIPTION
## R-37 — string utility completeness

Completes the string-utility family started in R-34 by shipping the two options
deferred there. Both extend the existing `strtoi`/`trimws` handlers in
`s-runtime/src/builtins.rs` in place (no new builtins, no grammar change); R reaches
them through the shared tree-walker.

### Additions

**`strtoi(x, base = 0L)` prefix auto-detection.** When `base` is `0`, the radix of
each string is inferred from its **post-sign prefix**, exactly as C `strtol(…, 0)`:

| post-sign prefix          | inferred base | example          |
|---------------------------|---------------|------------------|
| `0x` / `0X` + hex digits   | 16           | `strtoi("0x1F", 0L)` → `31` |
| `0` + at least one digit   | 8 (octal)    | `strtoi("010", 0L)` → `8`   |
| exactly `"0"`              | 10 (zero)    | `strtoi("0", 0L)` → `0`     |
| anything else              | 10 (decimal) | `strtoi("12", 0L)` → `12`   |

Because octal is then parsed in base 8, an out-of-range digit after a leading `0`
yields `NA` (`strtoi("08", 0L)` → `NA`, matching base R), and a bare `"0x"` with no
following digits → `NA` (empty digit run). Explicit bases **2..36** are unchanged;
a `base` outside `{0} ∪ 2..36` still makes every element `NA`.

**`trimws(x, whitespace = "[ \t\r\n]")`.** A new **keyword-only** `whitespace=`
argument selecting the set of characters to strip.

### trimws charclass-vs-regex decision: **regex**

The scope guard said to use a full regex engine if one is *already* available, else
fall back to a literal character-class. A regex engine **is** already a crate
dependency: `s-runtime`'s `Cargo.toml` has `regex = "1"`, and R-7's `grepl`/`gsub`
already expose a `compile()` helper. So `whitespace=` is interpreted as a **regular
expression** (faithful to base R ≥ 3.6), not a literal charclass. It is compiled
once per edge with that same RE2 engine and anchored to the trimmed edge:
`^(?:p)+` for the left, `(?:p)+$` for the right. Examples:
`trimws("xxhixx", whitespace="x")` → `"hi"`;
`trimws("xxhix", whitespace="x", which="left")` → `"hix"`;
`trimws("..a..", whitespace="[.]")` → `"a"`. The default whitespace, `which`, and
`NA` behavior are unchanged.

### Deferrals

**None.** Choosing the regex interpretation means nothing in the string-utility
family remains deferred — base R's `whitespace=` *is* a regex, so this is fully
faithful rather than a charclass approximation.

### Safety

- strtoi base-0 reuses the existing **checked-`i64`** accumulation (overflow → `NA`,
  never a panic) and rejects empty digit runs (`"0x"`) as `NA`. All prefix splitting
  uses char-aware `strip_prefix`, so multibyte input can't be split mid code point.
- trimws slicing uses the **regex-reported byte offsets** (always char boundaries),
  so multibyte input is UTF-8 safe; RE2's guaranteed **linear-time** matching rules
  out catastrophic backtracking (no ReDoS); an invalid `whitespace=` pattern is a
  clean `Err`. The `which` positional lookup now filters to unnamed args so a
  keyword-only `whitespace=` can't be misread as the second positional.
- A Rust security sub-agent reviewed the full diff and found **no** CRITICAL/HIGH/
  MEDIUM/LOW issues.

### Tests

`cargo test -p coding-adventures-s-runtime -p coding-adventures-r-runtime`:
**292 s-runtime** + **270 r-runtime** unit tests pass (new R-37 cases for base-0
radix detection — hex/octal/decimal/zero/signed prefixes, invalid octal, empty
prefix, vectorized mix — and `whitespace=` — literal class, which=left/right, `[.]`
class, default fallback, NA, invalid-regex error).

Specs (`R00`, `S00`), CHANGELOGs, and READMEs for both crates updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)