### PR TITLE
feat(mycin-pharm): ground sugammadex reversal of rocuronium neuromuscular blockade

### DIFF
--- a/code/specs/data/mycin-2026/recall/pharm-edges.adj
+++ b/code/specs/data/mycin-2026/recall/pharm-edges.adj
@@ -177,4 +177,9 @@ rulebook pharm_facts {
         source "In cases of poisoning resulting from ingesting more than 10 grams of isoniazid (INH), an equal amount of pyridoxine (vitamin B6) should be administered as an antidote."
         locator "https://www.ncbi.nlm.nih.gov/books/NBK557436/"
         trust authoritative
+    % --- EXPAND: sugammadex reverses rocuronium (steroidal neuromuscular blockade) --
+    relate antidote_for(rocuronium_toxicity, sugammadex)
+        source "Sugammadex is a modified gamma-cyclodextrin that is used to reverse steroidal non-depolarizing neuromuscular blocking drugs rocuronium and vecuronium."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK470263/"
+        trust authoritative
 }

--- a/code/specs/data/mycin-2026/recall/pharm-recall.query.adj
+++ b/code/specs/data/mycin-2026/recall/pharm-recall.query.adj
@@ -35,3 +35,4 @@ import "pharm-edges.adj"
 ? antidote_for(dabigatran_toxicity, $Antidote)       % expect idarucizumab (expand)
 ? antidote_for(arsenic_poisoning, $Antidote)         % expect dimercaprol (expand)
 ? antidote_for(isoniazid_toxicity, $Antidote)        % expect pyridoxine (expand)
+? antidote_for(rocuronium_toxicity, $Antidote)       % expect sugammadex (expand)

--- a/code/specs/data/mycin-2026/recall/test_pharm_recall.py
+++ b/code/specs/data/mycin-2026/recall/test_pharm_recall.py
@@ -54,6 +54,7 @@ EXPECTED = [
     ("dabigatran_toxicity", "antidote_for", "idarucizumab"),      # expand (NBK560651)
     ("arsenic_poisoning", "antidote_for", "dimercaprol"),         # expand (NBK549804)
     ("isoniazid_toxicity", "antidote_for", "pyridoxine"),         # expand (NBK557436)
+    ("rocuronium_toxicity", "antidote_for", "sugammadex"),        # expand (NBK470263)
 ]
 VAR = {"drug_class": "Class", "mechanism": "MOA", "adverse_effect": "Effect",
        "antidote_for": "Antidote"}


### PR DESCRIPTION
## What
The rocuronium reversal agent, grounded from StatPearls NBK470263:

- **antidote_for(rocuronium_toxicity, sugammadex)**:
  > Sugammadex is a modified gamma-cyclodextrin that is used to reverse steroidal non-depolarizing neuromuscular blocking drugs rocuronium and vecuronium.

Reversal-agent framing parallels the existing idarucizumab/dabigatran edge; fresh subject.

## Changes (data-only)
- `pharm-edges.adj` +1 `relate`; `pharm-recall.query.adj` +1; `test_pharm_recall.py` EXPECTED +1

## Verification
- `test_pharm_recall: 3/3 passed`; ruff clean; data-only security review passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)