### PR TITLE
feat(mycin-genetics): ground phenylketonuria gene defect (PAH)

### DIFF
--- a/code/specs/data/mycin-2026/recall/genetics-edges.adj
+++ b/code/specs/data/mycin-2026/recall/genetics-edges.adj
@@ -168,4 +168,13 @@ rulebook genetics_facts {
         source "Tay-Sachs disease is an autosomal recessive disorder caused by a mutation in HEXA, which encodes the enzymes beta-hexosaminidase A."
         locator "https://www.ncbi.nlm.nih.gov/books/NBK564432/"
         trust authoritative
+
+    % --- EXPAND: phenylketonuria gene defect — the PAH gene (phenylalanine hydroxylase) --
+    % The span names the disease and "the gene encoding phenylalanine hydroxylase" (PAH).
+    % inheritance(autosomal_recessive) declined: the page states it in a separate sentence
+    % anaphoric to "The disorder", not a self-contained both-endpoints span.
+    relate gene_defect(phenylketonuria, pah)
+        source "Phenylketonuria, also known as phenylalanine hydroxylase deficiency, is an inborn error of metabolism most commonly caused by pathogenic or pathogenic variants in the gene encoding phenylalanine hydroxylase—the hepatic enzyme that converts phenylalanine to tyrosine."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK535378/"
+        trust authoritative
 }

--- a/code/specs/data/mycin-2026/recall/genetics-recall.query.adj
+++ b/code/specs/data/mycin-2026/recall/genetics-recall.query.adj
@@ -37,3 +37,4 @@ import "genetics-edges.adj"
 ? gene_defect(hereditary_hemochromatosis, $Gene)       % expect hfe (expand)
 ? inheritance(tay_sachs_disease, $Pattern)             % expect autosomal_recessive (expand)
 ? gene_defect(tay_sachs_disease, $Gene)                % expect hexa (expand)
+? gene_defect(phenylketonuria, $Gene)                  % expect pah (expand)

--- a/code/specs/data/mycin-2026/recall/test_genetics_recall.py
+++ b/code/specs/data/mycin-2026/recall/test_genetics_recall.py
@@ -56,6 +56,7 @@ EXPECTED = [
     ("hereditary_hemochromatosis", "gene_defect", "hfe"),            # expand (NBK430862)
     ("tay_sachs_disease", "inheritance", "autosomal_recessive"),     # expand (NBK564432)
     ("tay_sachs_disease", "gene_defect", "hexa"),                    # expand (NBK564432)
+    ("phenylketonuria", "gene_defect", "pah"),                       # expand (NBK535378)
 ]
 VAR = {"inheritance": "Pattern", "gene_defect": "Gene",
        "trinucleotide_repeat": "Repeat", "imprinting": "Parent"}


### PR DESCRIPTION
## What
Phenylketonuria gene defect, grounded from StatPearls NBK535378:

- **gene_defect(phenylketonuria, pah)**:
  > Phenylketonuria, also known as phenylalanine hydroxylase deficiency, is an inborn error of metabolism most commonly caused by pathogenic or pathogenic variants in the gene encoding phenylalanine hydroxylase—the hepatic enzyme that converts phenylalanine to tyrosine.

`inheritance(autosomal_recessive)` declined — the page states it in a separate sentence anaphoric to "The disorder", not a self-contained both-endpoints span (honest scope).

## Changes (data-only)
- `genetics-edges.adj` +1 `relate`; `genetics-recall.query.adj` +1; `test_genetics_recall.py` EXPECTED +1 (`ehlers_danlos_syndrome` negative control unchanged)

## Verification
- `test_genetics_recall: 3/3 passed`; ruff clean; data-only security review passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)