### PR TITLE
feat(sir-runtime-oop): built-in method dispatch — non-block Array + Object (M1a)

### DIFF
--- a/code/packages/python/sir-runtime-oop/CHANGELOG.md
+++ b/code/packages/python/sir-runtime-oop/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 All notable changes to `coding-adventures-sir-runtime-oop` are documented here.
 
+## [0.1.1] - 2026-06-22
+
+### Added
+
+Built-in method dispatch, part 1 — non-block `Array` + universal `Object`
+methods (per `code/specs/sir-method-dispatch.md`, item M1a). Before this,
+`call_method` returned `nil` for every method outside `is_a?`/`kind_of?`/
+`instance_of?`/`class` + the `define_method` table, so `[1,2,3].reverse`
+evaluated to nil instead of running.
+
+- **Resolution order** in `call_method` is now reflective built-ins → user
+  `define_method` table → built-in catalog → `nil` floor.
+- **Array (non-block):** `length`/`size`/`count`, `first`/`last` (±count),
+  `include?`, `index`, `push`/`append`/`<<`, `pop`, `shift`, `unshift`/`prepend`,
+  `reverse`, `sort`, `min`, `max`, `sum`, `uniq`, `flatten`, `compact`, `empty?`,
+  `to_a`. Mutating methods mutate in place and return the Ruby-specified value;
+  `reverse`/`sort` are non-mutating.
+- **Object (universal):** `nil?`, `==`, `!=`, `equal?`, `respond_to?`, `freeze`,
+  `frozen?`, `dup`/`clone`, `itself`, `to_a` (nil→`[]`).
+- **`respond_to?` is honest** — reports true only for names dispatch actually
+  resolves, so an out-of-catalog method is both `nil` *and* `respond_to? == False`.
+
+Deferred to follow-ups: block-taking methods (`each`/`map`/`select`/…, need the
+`sir-runtime-core` `apply` dependency) and the Hash/String/Numeric/Symbol catalogs.
+
 ## [0.1.0] - 2026-06-13
 
 ### Added

--- a/code/packages/python/sir-runtime-oop/README.md
+++ b/code/packages/python/sir-runtime-oop/README.md
@@ -37,6 +37,23 @@ _sir_oop.call_method(d, "is_a?", "Animal")        # True
 _sir_oop.cvar_set("@@count", 0)                   # @@count = 0
 ```
 
+## Built-in method dispatch
+
+`recv.meth(args…)` reaches the backend as `BuiltinCall("__method__", …)` and is
+dispatched by `call_method`, in order: reflective built-ins
+(`is_a?`/`kind_of?`/`instance_of?`/`class`) → user `define_method` table →
+built-in catalog → `nil` floor. `respond_to?` reports exactly which names
+resolve, so an out-of-catalog method is both `nil` *and* `respond_to? == False`.
+
+The catalog currently covers (item **M1a** of `code/specs/sir-method-dispatch.md`)
+the **non-block `Array`** surface — `length`/`size`/`count`, `first`/`last`,
+`include?`, `index`, `push`/`<<`/`pop`/`shift`/`unshift`, `reverse`, `sort`,
+`min`/`max`/`sum`, `uniq`/`flatten`/`compact`, `empty?`, `to_a` — and the
+**universal `Object`** methods `nil?`, `==`, `!=`, `equal?`, `respond_to?`,
+`freeze`/`frozen?`, `dup`/`clone`, `itself`, `to_a`. Block-taking methods
+(`each`/`map`/`select`/…) and the Hash/String/Numeric/Symbol catalogs land in
+follow-up releases.
+
 ## Honest v0 limitation
 
 Because the frontend does not thread receivers into method bodies, the *current

--- a/code/packages/python/sir-runtime-oop/src/coding_adventures_sir_runtime_oop/oop.py
+++ b/code/packages/python/sir-runtime-oop/src/coding_adventures_sir_runtime_oop/oop.py
@@ -204,13 +204,228 @@ def _class_name_arg(arg: Val) -> str:
     return arg if isinstance(arg, str) else class_of(arg)
 
 
-def call_method(recv: Val, name: str, *args: Val) -> Val:
-    """Dispatch reflective method ``name`` on ``recv``.
+# ── Built-in method catalog (SIR method-dispatch spec, M1) ───────────────────
+#
+# ``recv.meth(args…)`` reaches the backend as ``BuiltinCall("__method__",
+# [recv, "meth", …])`` and is dispatched here.  Before this catalog every method
+# outside the reflective four (``is_a?`` etc.) + the ``define_method`` table
+# returned ``nil`` — so ``[1,2,3].reverse`` evaluated to nil instead of running.
+# This catalog gives the everyday Ruby built-ins their faithful native behaviour,
+# dispatched by the receiver's runtime type.  See
+# ``code/specs/sir-method-dispatch.md``.
+#
+# **This file (M1a) covers the *non-block* Array surface plus the universal
+# Object methods.**  Block-taking methods (``each``/``map``/``select``/…) and the
+# Hash/String/Numeric/Symbol catalogs arrive in follow-up PRs that take the
+# ``sir-runtime-core`` ``apply`` dependency for proc-lenient block invocation.
+#
+# Resolution order (see :func:`call_method`): reflective built-ins → user
+# ``define_method`` table → this catalog → ``nil`` floor.  ``respond_to?`` reports
+# catalog membership honestly, so an out-of-catalog method is both ``nil`` *and*
+# ``respond_to? == False``.
 
-    Handles the built-ins the SIR frontend emits as ``__method__`` calls —
-    ``is_a?``/``kind_of?``/``instance_of?`` (predicate against a class) and
-    ``class`` (the class name) — then falls back to a :func:`define_method`
-    table, returning ``None`` (nil) for an unknown method rather than raising.
+# Sentinel meaning "this name is not in the catalog for this receiver" — distinct
+# from a catalog method that legitimately returns ``None`` (Ruby ``nil``).
+_MISS = object()
+
+# Universal methods available on *every* receiver (Ruby's ``Object``/``Kernel``).
+_OBJECT_METHODS = frozenset(
+    {
+        "nil?",
+        "==",
+        "!=",
+        "equal?",
+        "respond_to?",
+        "freeze",
+        "frozen?",
+        "dup",
+        "clone",
+        "itself",
+        "to_a",
+    }
+)
+
+# Non-block ``Array`` methods (M1a).  Block methods (``each``/``map``/…) land in
+# a later PR; they are deliberately absent here so ``respond_to?`` stays honest.
+_ARRAY_METHODS = frozenset(
+    {
+        "length",
+        "size",
+        "count",
+        "first",
+        "last",
+        "include?",
+        "index",
+        "push",
+        "append",
+        "<<",
+        "pop",
+        "shift",
+        "unshift",
+        "prepend",
+        "reverse",
+        "sort",
+        "min",
+        "max",
+        "sum",
+        "uniq",
+        "flatten",
+        "compact",
+        "empty?",
+        "to_a",
+    }
+)
+
+
+def _method_name(arg: Val) -> str:
+    """Coerce a ``respond_to?`` argument (a :class:`Symbol`, ``":m"``-ish string,
+    or bare name) to the plain method name used as the catalog key."""
+    name = getattr(arg, "name", None)
+    return name if isinstance(name, str) else str(arg)
+
+
+def _responds_to(recv: Val, name: str) -> bool:
+    """Whether dispatch on ``recv`` resolves ``name`` — across the reflective
+    built-ins, the ``define_method`` table, and the type-specific catalog."""
+    if name in ("is_a?", "kind_of?", "instance_of?", "class"):
+        return True
+    if name in _methods:
+        return True
+    if name in _OBJECT_METHODS:
+        return True
+    return isinstance(recv, list) and name in _ARRAY_METHODS
+
+
+def _flatten(seq: Val) -> list[Val]:
+    """Recursively flatten nested lists (Ruby ``Array#flatten``)."""
+    out: list[Val] = []
+    for item in seq:
+        if isinstance(item, list):
+            out.extend(_flatten(item))
+        else:
+            out.append(item)
+    return out
+
+
+def _uniq(seq: list[Val]) -> list[Val]:
+    """Order-preserving de-duplication (Ruby ``Array#uniq``)."""
+    out: list[Val] = []
+    for item in seq:
+        if item not in out:
+            out.append(item)
+    return out
+
+
+def _object_method(recv: Val, name: str, args: list[Val]) -> Val:
+    """Universal ``Object`` methods.  Returns :data:`_MISS` if ``name`` is not a
+    universal method."""
+    if name == "nil?":
+        return recv is None
+    if name == "==":
+        return recv == args[0]
+    if name == "!=":
+        return recv != args[0]
+    if name == "equal?":
+        return recv is args[0]
+    if name == "respond_to?":
+        return _responds_to(recv, _method_name(args[0]))
+    if name == "itself":
+        return recv
+    if name in ("freeze",):
+        # No true immutability in v0 — identity-returning, matching Ruby's API
+        # shape (``freeze`` returns the receiver).
+        return recv
+    if name == "frozen?":
+        # v0: nothing is frozen except the always-frozen immutable primitives.
+        return recv is None or isinstance(recv, (bool, int, float))
+    if name in ("dup", "clone"):
+        if isinstance(recv, list):
+            return list(recv)
+        if isinstance(recv, dict):
+            return dict(recv)
+        return recv
+    if name == "to_a":
+        # Ruby: nil.to_a == [], Array#to_a == self; other receivers fall through.
+        if recv is None:
+            return []
+        if isinstance(recv, list):
+            return recv
+        return _MISS
+    return _MISS
+
+
+def _array_method(recv: list[Val], name: str, args: list[Val]) -> Val:
+    """Non-block ``Array`` methods.  Returns :data:`_MISS` if ``name`` is not a
+    catalogued array method."""
+    if name in ("length", "size"):
+        return len(recv)
+    if name == "count":
+        return recv.count(args[0]) if args else len(recv)
+    if name == "first":
+        if args:
+            return recv[: args[0]]
+        return recv[0] if recv else None
+    if name == "last":
+        if args:
+            return recv[-args[0] :] if args[0] else []
+        return recv[-1] if recv else None
+    if name == "include?":
+        return args[0] in recv
+    if name == "index":
+        return recv.index(args[0]) if args[0] in recv else None
+    if name in ("push", "append"):
+        recv.extend(args)
+        return recv
+    if name == "<<":
+        recv.append(args[0])
+        return recv
+    if name == "pop":
+        return recv.pop() if recv else None
+    if name == "shift":
+        return recv.pop(0) if recv else None
+    if name in ("unshift", "prepend"):
+        recv[:0] = args
+        return recv
+    if name == "reverse":
+        return list(reversed(recv))
+    if name == "sort":
+        return sorted(recv)
+    if name == "min":
+        return min(recv) if recv else None
+    if name == "max":
+        return max(recv) if recv else None
+    if name == "sum":
+        total: Val = args[0] if args else 0
+        for item in recv:
+            total = total + item
+        return total
+    if name == "uniq":
+        return _uniq(recv)
+    if name == "flatten":
+        return _flatten(recv)
+    if name == "compact":
+        return [item for item in recv if item is not None]
+    if name == "empty?":
+        return len(recv) == 0
+    if name == "to_a":
+        return recv
+    return _MISS
+
+
+def call_method(recv: Val, name: str, *args: Val) -> Val:
+    """Dispatch method ``name`` on ``recv``.
+
+    Resolution order:
+
+    1. **Reflective built-ins** the SIR frontend emits as ``__method__`` calls —
+       ``is_a?``/``kind_of?``/``instance_of?`` (predicate against a class) and
+       ``class`` (the class name).
+    2. The user :func:`define_method` table.
+    3. The **built-in method catalog** (universal ``Object`` methods, and — when
+       ``recv`` is a list — the non-block ``Array`` methods).
+    4. ``None`` (Ruby ``nil``) for anything still unresolved — the honest floor.
+       :func:`_responds_to` reports exactly which names resolve, so an
+       out-of-catalog method is both ``nil`` and ``respond_to? == False``.
 
     The class argument to a predicate may arrive as a class-name **string** or as
     a value whose class is taken; ``instance_of?`` requires an exact
@@ -222,8 +437,21 @@ def call_method(recv: Val, name: str, *args: Val) -> Val:
         return class_of(recv) == _class_name_arg(args[0])
     if name == "class":
         return class_of(recv)
+
     fn = _methods.get(name)
-    return fn(recv, list(args)) if fn is not None else None
+    if fn is not None:
+        return fn(recv, list(args))
+
+    arg_list = list(args)
+    if isinstance(recv, list):
+        result = _array_method(recv, name, arg_list)
+        if result is not _MISS:
+            return result
+    result = _object_method(recv, name, arg_list)
+    if result is not _MISS:
+        return result
+
+    return None
 
 
 def reset_oop() -> None:

--- a/code/packages/python/sir-runtime-oop/tests/test_oop.py
+++ b/code/packages/python/sir-runtime-oop/tests/test_oop.py
@@ -141,3 +141,116 @@ def test_sir_instance_carries_class_tag_and_empty_ivar_bag() -> None:
     i = oop.SirInstance("Widget")
     assert i.sir_class == "Widget"
     assert i.ivars == {}
+
+
+# ── built-in method catalog: non-block Array (M1a) ────────────────────────────
+
+
+def test_array_length_size_count() -> None:
+    assert oop.call_method([1, 2, 3], "length") == 3
+    assert oop.call_method([1, 2, 3], "size") == 3
+    assert oop.call_method([1, 2, 3], "count") == 3
+    assert oop.call_method([1, 2, 2, 3], "count", 2) == 2
+
+
+def test_array_first_last_with_and_without_count() -> None:
+    assert oop.call_method([1, 2, 3], "first") == 1
+    assert oop.call_method([1, 2, 3], "last") == 3
+    assert oop.call_method([1, 2, 3], "first", 2) == [1, 2]
+    assert oop.call_method([1, 2, 3], "last", 2) == [2, 3]
+    assert oop.call_method([], "first") is None
+    assert oop.call_method([], "last") is None
+    assert oop.call_method([1, 2], "last", 0) == []
+
+
+def test_array_include_and_index() -> None:
+    assert oop.call_method([1, 2, 3], "include?", 2) is True
+    assert oop.call_method([1, 2, 3], "include?", 9) is False
+    assert oop.call_method([1, 2, 3], "index", 3) == 2
+    assert oop.call_method([1, 2, 3], "index", 9) is None
+
+
+def test_array_mutating_push_pop_shift_unshift() -> None:
+    a = [1, 2]
+    assert oop.call_method(a, "push", 3) == [1, 2, 3]
+    assert a == [1, 2, 3]
+    assert oop.call_method(a, "<<", 4) == [1, 2, 3, 4]
+    assert oop.call_method(a, "pop") == 4
+    assert a == [1, 2, 3]
+    assert oop.call_method(a, "shift") == 1
+    assert a == [2, 3]
+    assert oop.call_method(a, "unshift", 0) == [0, 2, 3]
+
+
+def test_array_reverse_sort_minmax_sum() -> None:
+    assert oop.call_method([1, 2, 3], "reverse") == [3, 2, 1]
+    assert oop.call_method([3, 1, 2], "sort") == [1, 2, 3]
+    assert oop.call_method([3, 1, 2], "min") == 1
+    assert oop.call_method([3, 1, 2], "max") == 3
+    assert oop.call_method([1, 2, 3], "sum") == 6
+    assert oop.call_method([1, 2, 3], "sum", 10) == 16
+    assert oop.call_method([], "min") is None
+
+
+def test_array_reverse_is_nonmutating() -> None:
+    a = [1, 2, 3]
+    assert oop.call_method(a, "reverse") == [3, 2, 1]
+    assert a == [1, 2, 3]
+
+
+def test_array_uniq_flatten_compact_empty() -> None:
+    assert oop.call_method([1, 1, 2, 3, 3], "uniq") == [1, 2, 3]
+    assert oop.call_method([1, [2, [3, 4]], 5], "flatten") == [1, 2, 3, 4, 5]
+    assert oop.call_method([1, None, 2, None], "compact") == [1, 2]
+    assert oop.call_method([], "empty?") is True
+    assert oop.call_method([1], "empty?") is False
+
+
+# ── built-in method catalog: universal Object (M1a) ───────────────────────────
+
+
+def test_object_nil_eq_and_identity() -> None:
+    assert oop.call_method(None, "nil?") is True
+    assert oop.call_method(0, "nil?") is False
+    assert oop.call_method([1, 2], "==", [1, 2]) is True
+    assert oop.call_method([1, 2], "==", [1, 3]) is False
+    assert oop.call_method(1, "!=", 2) is True
+    x = [1]
+    assert oop.call_method(x, "equal?", x) is True
+    assert oop.call_method([1], "equal?", [1]) is False
+
+
+def test_object_dup_clone_itself_freeze() -> None:
+    a = [1, 2]
+    dup = oop.call_method(a, "dup")
+    assert dup == [1, 2]
+    assert dup is not a
+    assert oop.call_method(5, "itself") == 5
+    assert oop.call_method(a, "freeze") is a
+    assert oop.call_method(5, "frozen?") is True
+    assert oop.call_method([1], "frozen?") is False
+
+
+def test_to_a_on_nil_and_array() -> None:
+    assert oop.call_method(None, "to_a") == []
+    a = [1, 2]
+    assert oop.call_method(a, "to_a") is a
+
+
+# ── respond_to? honesty + nil floor (M1a) ─────────────────────────────────────
+
+
+def test_respond_to_reports_catalog_membership() -> None:
+    assert oop.call_method([1], "respond_to?", "reverse") is True
+    assert oop.call_method([1], "respond_to?", "nil?") is True
+    assert oop.call_method([1], "respond_to?", "is_a?") is True
+    # An out-of-catalog method (block method not yet implemented in M1a):
+    assert oop.call_method([1], "respond_to?", "map") is False
+    # Symbol-style argument is accepted via its name.
+    assert oop.call_method([1], "respond_to?", oop.class_of) is False
+
+
+def test_unknown_method_returns_nil_not_raise() -> None:
+    assert oop.call_method([1, 2, 3], "map") is None
+    assert oop.call_method("hi", "upcase") is None
+    assert oop.call_method(5, "times") is None

--- a/code/packages/typescript/sir-runtime-oop/CHANGELOG.md
+++ b/code/packages/typescript/sir-runtime-oop/CHANGELOG.md
@@ -2,6 +2,33 @@
 
 All notable changes to `@coding-adventures/sir-runtime-oop` are documented here.
 
+## [0.1.1] - 2026-06-22
+
+### Added
+
+Built-in method dispatch, part 1 — non-block `Array` + universal `Object`
+methods (per `code/specs/sir-method-dispatch.md`, item M1a). Before this,
+`callMethod` returned `null` for every method outside `is_a?`/`kind_of?`/
+`instance_of?`/`class` + the `defineMethod` table, so `[1,2,3].reverse`
+evaluated to nil instead of running.
+
+- **Resolution order** in `callMethod` is now reflective built-ins → user
+  `defineMethod` table → built-in catalog → `null` floor.
+- **Array (non-block):** `length`/`size`/`count`, `first`/`last` (±count),
+  `include?`, `index`, `push`/`append`/`<<`, `pop`, `shift`, `unshift`/`prepend`,
+  `reverse`, `sort`, `min`, `max`, `sum`, `uniq`, `flatten`, `compact`, `empty?`,
+  `to_a`. Mutating methods mutate in place and return the Ruby-specified value;
+  `reverse`/`sort` are non-mutating. `include?`/`index`/`==` use deep value
+  equality (Ruby `==`).
+- **Object (universal):** `nil?`, `==`, `!=`, `equal?`, `respond_to?`, `freeze`,
+  `frozen?`, `dup`/`clone`, `itself`, `to_a` (nil→`[]`).
+- **`respond_to?` is honest** — reports true only for names dispatch actually
+  resolves, so an out-of-catalog method is both `null` *and* `respond_to? == false`.
+
+Deferred to follow-ups: block-taking methods (`each`/`map`/`select`/…, need the
+`@coding-adventures/sir-runtime-core` `apply` dependency) and the
+Hash/String/Numeric/Symbol catalogs.
+
 ## [0.1.0] - 2026-06-13
 
 ### Added

--- a/code/packages/typescript/sir-runtime-oop/README.md
+++ b/code/packages/typescript/sir-runtime-oop/README.md
@@ -37,6 +37,23 @@ __SirOop.callMethod(d, "is_a?", "Animal");     // true
 __SirOop.cvarSet("@@count", 0);                // @@count = 0
 ```
 
+## Built-in method dispatch
+
+`recv.meth(args…)` reaches the backend as `BuiltinCall("__method__", …)` and is
+dispatched by `callMethod`, in order: reflective built-ins
+(`is_a?`/`kind_of?`/`instance_of?`/`class`) → user `defineMethod` table →
+built-in catalog → `null` floor. `respond_to?` reports exactly which names
+resolve, so an out-of-catalog method is both `null` *and* `respond_to? == false`.
+
+The catalog currently covers (item **M1a** of `code/specs/sir-method-dispatch.md`)
+the **non-block `Array`** surface — `length`/`size`/`count`, `first`/`last`,
+`include?`, `index`, `push`/`<<`/`pop`/`shift`/`unshift`, `reverse`, `sort`,
+`min`/`max`/`sum`, `uniq`/`flatten`/`compact`, `empty?`, `to_a` — and the
+**universal `Object`** methods `nil?`, `==`, `!=`, `equal?`, `respond_to?`,
+`freeze`/`frozen?`, `dup`/`clone`, `itself`, `to_a`. `include?`/`index`/`==` use
+deep value equality. Block-taking methods (`each`/`map`/`select`/…) and the
+Hash/String/Numeric/Symbol catalogs land in follow-up releases.
+
 ## Honest v0 limitation
 
 Because the frontend does not thread receivers into method bodies, the *current

--- a/code/packages/typescript/sir-runtime-oop/src/index.ts
+++ b/code/packages/typescript/sir-runtime-oop/src/index.ts
@@ -197,12 +197,241 @@ export function defineMethod(name: string, fn: (recv: Val, args: Val[]) => Val):
   methods.set(name, fn);
 }
 
+// ── Built-in method catalog (SIR method-dispatch spec, M1) ───────────────────
+//
+// `recv.meth(args…)` reaches the backend as `BuiltinCall("__method__", [recv,
+// "meth", …])` and is dispatched here.  Before this catalog every method outside
+// the reflective four + the `defineMethod` table returned `null` — so
+// `[1,2,3].reverse` evaluated to nil instead of running.  This catalog gives the
+// everyday Ruby built-ins their faithful native behaviour, dispatched by the
+// receiver's runtime type.  See `code/specs/sir-method-dispatch.md`.
+//
+// **This file (M1a) covers the *non-block* Array surface plus the universal
+// Object methods.**  Block-taking methods (`each`/`map`/`select`/…) and the
+// Hash/String/Numeric/Symbol catalogs arrive in follow-up PRs that take the
+// `@coding-adventures/sir-runtime-core` `apply` dependency for proc-lenient block
+// invocation.
+//
+// Resolution order (see `callMethod`): reflective built-ins → user `defineMethod`
+// table → this catalog → `null` floor.  `respond_to?` reports catalog membership
+// honestly, so an out-of-catalog method is both `null` and `respond_to? == false`.
+
+// Sentinel meaning "this name is not in the catalog for this receiver" — distinct
+// from a catalog method that legitimately returns `null` (Ruby `nil`).
+const MISS: unique symbol = Symbol("sir-oop-miss");
+
+const OBJECT_METHODS = new Set<string>([
+  "nil?",
+  "==",
+  "!=",
+  "equal?",
+  "respond_to?",
+  "freeze",
+  "frozen?",
+  "dup",
+  "clone",
+  "itself",
+  "to_a",
+]);
+
+// Non-block `Array` methods (M1a); block methods land in a later PR, kept absent
+// here so `respond_to?` stays honest.
+const ARRAY_METHODS = new Set<string>([
+  "length",
+  "size",
+  "count",
+  "first",
+  "last",
+  "include?",
+  "index",
+  "push",
+  "append",
+  "<<",
+  "pop",
+  "shift",
+  "unshift",
+  "prepend",
+  "reverse",
+  "sort",
+  "min",
+  "max",
+  "sum",
+  "uniq",
+  "flatten",
+  "compact",
+  "empty?",
+  "to_a",
+]);
+
+/** SIR value equality used by `include?`/`index`/`==` — `===` for primitives,
+ * structural for arrays and `Map`s (Ruby `==` is deep). */
+function valEq(a: Val, b: Val): boolean {
+  if (a === b) return true;
+  if (Array.isArray(a) && Array.isArray(b)) {
+    return a.length === b.length && a.every((x: Val, i: number) => valEq(x, b[i]));
+  }
+  if (a instanceof Map && b instanceof Map) {
+    if (a.size !== b.size) return false;
+    for (const [k, v] of a) {
+      if (!b.has(k) || !valEq(v, b.get(k))) return false;
+    }
+    return true;
+  }
+  return false;
+}
+
+/** Coerce a `respond_to?` argument (a core `Symbol`, `":m"`-ish string, or bare
+ * name) to the plain method name used as the catalog key. */
+function methodNameArg(arg: Val): string {
+  if (arg !== null && typeof arg === "object" && typeof arg.name === "string") {
+    return arg.name as string;
+  }
+  return String(arg);
+}
+
+/** Whether dispatch on `recv` resolves `name` — across the reflective built-ins,
+ * the `defineMethod` table, and the type-specific catalog. */
+function respondsTo(recv: Val, name: string): boolean {
+  if (name === "is_a?" || name === "kind_of?" || name === "instance_of?" || name === "class") {
+    return true;
+  }
+  if (methods.has(name)) return true;
+  if (OBJECT_METHODS.has(name)) return true;
+  if (Array.isArray(recv) && ARRAY_METHODS.has(name)) return true;
+  return false;
+}
+
+function flattenArray(seq: Val[]): Val[] {
+  const out: Val[] = [];
+  for (const item of seq) {
+    if (Array.isArray(item)) out.push(...flattenArray(item));
+    else out.push(item);
+  }
+  return out;
+}
+
+function uniqArray(seq: Val[]): Val[] {
+  const out: Val[] = [];
+  for (const item of seq) {
+    if (!out.some((x: Val) => valEq(x, item))) out.push(item);
+  }
+  return out;
+}
+
+/** Universal `Object` methods.  Returns `MISS` if `name` is not universal. */
+function objectMethod(recv: Val, name: string, args: Val[]): Val | typeof MISS {
+  switch (name) {
+    case "nil?":
+      return recv === null || recv === undefined;
+    case "==":
+      return valEq(recv, args[0]);
+    case "!=":
+      return !valEq(recv, args[0]);
+    case "equal?":
+      return recv === args[0];
+    case "respond_to?":
+      return respondsTo(recv, methodNameArg(args[0]));
+    case "itself":
+      return recv;
+    case "freeze":
+      // No true immutability in v0 — identity-returning, matching Ruby's shape.
+      return recv;
+    case "frozen?":
+      return (
+        recv === null ||
+        recv === undefined ||
+        typeof recv === "number" ||
+        typeof recv === "boolean"
+      );
+    case "dup":
+    case "clone":
+      if (Array.isArray(recv)) return [...recv];
+      if (recv instanceof Map) return new Map(recv);
+      return recv;
+    case "to_a":
+      // Ruby: nil.to_a == [], Array#to_a == self; others fall through.
+      if (recv === null || recv === undefined) return [];
+      if (Array.isArray(recv)) return recv;
+      return MISS;
+    default:
+      return MISS;
+  }
+}
+
+/** Non-block `Array` methods.  Returns `MISS` if `name` is not catalogued. */
+function arrayMethod(recv: Val[], name: string, args: Val[]): Val | typeof MISS {
+  switch (name) {
+    case "length":
+    case "size":
+      return recv.length;
+    case "count":
+      return args.length > 0 ? recv.filter((x: Val) => valEq(x, args[0])).length : recv.length;
+    case "first":
+      if (args.length > 0) return recv.slice(0, args[0]);
+      return recv.length > 0 ? recv[0] : null;
+    case "last":
+      if (args.length > 0) return args[0] ? recv.slice(-args[0]) : [];
+      return recv.length > 0 ? recv[recv.length - 1] : null;
+    case "include?":
+      return recv.some((x: Val) => valEq(x, args[0]));
+    case "index": {
+      const i = recv.findIndex((x: Val) => valEq(x, args[0]));
+      return i === -1 ? null : i;
+    }
+    case "push":
+    case "append":
+      recv.push(...args);
+      return recv;
+    case "<<":
+      recv.push(args[0]);
+      return recv;
+    case "pop":
+      return recv.length > 0 ? recv.pop() : null;
+    case "shift":
+      return recv.length > 0 ? recv.shift() : null;
+    case "unshift":
+    case "prepend":
+      recv.unshift(...args);
+      return recv;
+    case "reverse":
+      return [...recv].reverse();
+    case "sort":
+      // `<`/`>` ordering keeps numbers numeric (JS default sort is lexicographic).
+      return [...recv].sort((a: Val, b: Val) => (a < b ? -1 : a > b ? 1 : 0));
+    case "min":
+      return recv.length > 0 ? recv.reduce((a: Val, b: Val) => (b < a ? b : a)) : null;
+    case "max":
+      return recv.length > 0 ? recv.reduce((a: Val, b: Val) => (b > a ? b : a)) : null;
+    case "sum": {
+      let total: Val = args.length > 0 ? args[0] : 0;
+      for (const item of recv) total = total + item;
+      return total;
+    }
+    case "uniq":
+      return uniqArray(recv);
+    case "flatten":
+      return flattenArray(recv);
+    case "compact":
+      return recv.filter((x: Val) => x !== null && x !== undefined);
+    case "empty?":
+      return recv.length === 0;
+    case "to_a":
+      return recv;
+    default:
+      return MISS;
+  }
+}
+
 /**
- * Dispatch reflective method `name` on `recv`.  Handles the built-ins the SIR
- * frontend emits as `__method__` calls — `is_a?`/`kind_of?`/`instance_of?`
- * (predicate against a class) and `class` (the class name) — then falls back to
- * a `defineMethod` table, returning `null` (nil) for an unknown method rather
- * than throwing.
+ * Dispatch method `name` on `recv`.  Resolution order:
+ *
+ * 1. **Reflective built-ins** the SIR frontend emits as `__method__` calls —
+ *    `is_a?`/`kind_of?`/`instance_of?` (predicate against a class) and `class`.
+ * 2. The user `defineMethod` table.
+ * 3. The **built-in method catalog** (universal `Object` methods, and — when
+ *    `recv` is an array — the non-block `Array` methods).
+ * 4. `null` (Ruby `nil`) for anything still unresolved — the honest floor;
+ *    `respond_to?` reports exactly which names resolve.
  *
  * The class argument to a predicate may arrive as a class-name **string** or as
  * a value whose class is taken; `instance_of?` additionally requires an exact
@@ -211,19 +440,25 @@ export function defineMethod(name: string, fn: (recv: Val, args: Val[]) => Val):
 export function callMethod(recv: Val, name: string, ...args: Val[]): Val {
   switch (name) {
     case "is_a?":
-    case "kind_of?": {
+    case "kind_of?":
       return isA(recv, classNameArg(args[0]));
-    }
-    case "instance_of?": {
+    case "instance_of?":
       return classOf(recv) === classNameArg(args[0]);
-    }
     case "class":
       return classOf(recv);
-    default: {
-      const m = methods.get(name);
-      return m ? m(recv, args) : null;
-    }
   }
+
+  const m = methods.get(name);
+  if (m) return m(recv, args);
+
+  if (Array.isArray(recv)) {
+    const arrResult = arrayMethod(recv, name, args);
+    if (arrResult !== MISS) return arrResult;
+  }
+  const objResult = objectMethod(recv, name, args);
+  if (objResult !== MISS) return objResult;
+
+  return null;
 }
 
 function classNameArg(arg: Val): string {

--- a/code/packages/typescript/sir-runtime-oop/tests/oop.test.ts
+++ b/code/packages/typescript/sir-runtime-oop/tests/oop.test.ts
@@ -145,3 +145,112 @@ describe("SirInstance", () => {
     expect(i.ivars.size).toBe(0);
   });
 });
+
+describe("built-in method catalog: non-block Array (M1a)", () => {
+  it("length / size / count", () => {
+    expect(callMethod([1, 2, 3], "length")).toBe(3);
+    expect(callMethod([1, 2, 3], "size")).toBe(3);
+    expect(callMethod([1, 2, 3], "count")).toBe(3);
+    expect(callMethod([1, 2, 2, 3], "count", 2)).toBe(2);
+  });
+
+  it("first / last with and without count", () => {
+    expect(callMethod([1, 2, 3], "first")).toBe(1);
+    expect(callMethod([1, 2, 3], "last")).toBe(3);
+    expect(callMethod([1, 2, 3], "first", 2)).toEqual([1, 2]);
+    expect(callMethod([1, 2, 3], "last", 2)).toEqual([2, 3]);
+    expect(callMethod([], "first")).toBeNull();
+    expect(callMethod([], "last")).toBeNull();
+    expect(callMethod([1, 2], "last", 0)).toEqual([]);
+  });
+
+  it("include? / index (value equality)", () => {
+    expect(callMethod([1, 2, 3], "include?", 2)).toBe(true);
+    expect(callMethod([1, 2, 3], "include?", 9)).toBe(false);
+    expect(callMethod([[1], [2]], "include?", [2])).toBe(true);
+    expect(callMethod([1, 2, 3], "index", 3)).toBe(2);
+    expect(callMethod([1, 2, 3], "index", 9)).toBeNull();
+  });
+
+  it("mutating push / << / pop / shift / unshift", () => {
+    const a: number[] = [1, 2];
+    expect(callMethod(a, "push", 3)).toEqual([1, 2, 3]);
+    expect(a).toEqual([1, 2, 3]);
+    expect(callMethod(a, "<<", 4)).toEqual([1, 2, 3, 4]);
+    expect(callMethod(a, "pop")).toBe(4);
+    expect(a).toEqual([1, 2, 3]);
+    expect(callMethod(a, "shift")).toBe(1);
+    expect(a).toEqual([2, 3]);
+    expect(callMethod(a, "unshift", 0)).toEqual([0, 2, 3]);
+  });
+
+  it("reverse / sort / min / max / sum", () => {
+    expect(callMethod([1, 2, 3], "reverse")).toEqual([3, 2, 1]);
+    expect(callMethod([3, 1, 2], "sort")).toEqual([1, 2, 3]);
+    expect(callMethod([10, 2, 30], "sort")).toEqual([2, 10, 30]);
+    expect(callMethod([3, 1, 2], "min")).toBe(1);
+    expect(callMethod([3, 1, 2], "max")).toBe(3);
+    expect(callMethod([1, 2, 3], "sum")).toBe(6);
+    expect(callMethod([1, 2, 3], "sum", 10)).toBe(16);
+    expect(callMethod([], "min")).toBeNull();
+  });
+
+  it("reverse / sort are non-mutating", () => {
+    const a = [1, 2, 3];
+    expect(callMethod(a, "reverse")).toEqual([3, 2, 1]);
+    expect(a).toEqual([1, 2, 3]);
+  });
+
+  it("uniq / flatten / compact / empty?", () => {
+    expect(callMethod([1, 1, 2, 3, 3], "uniq")).toEqual([1, 2, 3]);
+    expect(callMethod([1, [2, [3, 4]], 5], "flatten")).toEqual([1, 2, 3, 4, 5]);
+    expect(callMethod([1, null, 2, null], "compact")).toEqual([1, 2]);
+    expect(callMethod([], "empty?")).toBe(true);
+    expect(callMethod([1], "empty?")).toBe(false);
+  });
+});
+
+describe("built-in method catalog: universal Object (M1a)", () => {
+  it("nil? / == / != / equal?", () => {
+    expect(callMethod(null, "nil?")).toBe(true);
+    expect(callMethod(0, "nil?")).toBe(false);
+    expect(callMethod([1, 2], "==", [1, 2])).toBe(true);
+    expect(callMethod([1, 2], "==", [1, 3])).toBe(false);
+    expect(callMethod(1, "!=", 2)).toBe(true);
+    const x = [1];
+    expect(callMethod(x, "equal?", x)).toBe(true);
+    expect(callMethod([1], "equal?", [1])).toBe(false);
+  });
+
+  it("dup / clone / itself / freeze / frozen?", () => {
+    const a = [1, 2];
+    const dup = callMethod(a, "dup");
+    expect(dup).toEqual([1, 2]);
+    expect(dup).not.toBe(a);
+    expect(callMethod(5, "itself")).toBe(5);
+    expect(callMethod(a, "freeze")).toBe(a);
+    expect(callMethod(5, "frozen?")).toBe(true);
+    expect(callMethod([1], "frozen?")).toBe(false);
+  });
+
+  it("to_a on nil and array", () => {
+    expect(callMethod(null, "to_a")).toEqual([]);
+    const a = [1, 2];
+    expect(callMethod(a, "to_a")).toBe(a);
+  });
+});
+
+describe("respond_to? honesty + nil floor (M1a)", () => {
+  it("respond_to? reports catalog membership", () => {
+    expect(callMethod([1], "respond_to?", "reverse")).toBe(true);
+    expect(callMethod([1], "respond_to?", "nil?")).toBe(true);
+    expect(callMethod([1], "respond_to?", "is_a?")).toBe(true);
+    expect(callMethod([1], "respond_to?", "map")).toBe(false);
+  });
+
+  it("unknown method returns nil, never throws", () => {
+    expect(callMethod([1, 2, 3], "map")).toBeNull();
+    expect(callMethod("hi", "upcase")).toBeNull();
+    expect(callMethod(5, "times")).toBeNull();
+  });
+});


### PR DESCRIPTION
## What
First slice of **M1 — faithful built-in method dispatch** (`code/specs/sir-method-dispatch.md`).
Implements the **non-block `Array`** catalog + the **universal `Object`** methods in both
`sir-runtime-oop` backends (Python + TypeScript).

## Why
`call_method`/`callMethod` returned `nil` for every method outside `is_a?`/`kind_of?`/
`instance_of?`/`class` + the `define_method` table, so `[1,2,3].reverse`, `.include?`,
`.sum`, `arr.dup`, `x.nil?` all evaluated to nil instead of running — the reported
method-dispatch boundary. This closes the non-block Array + Object portion of it.

## Changes
- Resolution order: reflective builtins → `define_method` table → **built-in catalog** → `nil` floor.
- **Array (non-block):** length/size/count, first/last (±count), include?, index, push/append/`<<`/
  pop/shift/unshift/prepend, reverse, sort, min, max, sum, uniq, flatten, compact, empty?, to_a.
- **Object (universal):** nil?, ==, !=, equal?, respond_to?, freeze, frozen?, dup/clone, itself, to_a.
- **`respond_to?` is honest** — true only for names dispatch resolves; out-of-catalog = `nil` AND `respond_to? == false`.
- No new dependency (block methods + Hash/String/Numeric/Symbol deferred to follow-ups that take the `sir-runtime-core` `apply` dep).

## Verification
- Python: 26 tests pass, `ruff` + `mypy --strict` clean, 96% coverage.
- TypeScript: 25 vitest pass, `tsc --noEmit` clean.
- Security review: passed (closed allowlist dispatch, no `getattr(recv,name)`/`recv[name]` reflection; no proto-pollution sink).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
