### PR TITLE
feat(mycin-micro): ground Bacillus anthracis (gram-positive rod)

### DIFF
--- a/code/specs/data/mycin-2026/recall/micro-edges.adj
+++ b/code/specs/data/mycin-2026/recall/micro-edges.adj
@@ -157,4 +157,15 @@ rulebook micro_facts {
         source "Klebsiella pneumoniae is a gram-negative, encapsulated, non-motile bacterium found in the environment"
         locator "https://www.ncbi.nlm.nih.gov/books/NBK519004/"
         trust authoritative
+
+    % --- Bacillus anthracis (gram-positive rod; causes anthrax) ------------------
+    % One span names BOTH the gram reaction and the shape (rod = bacillus) for the organism.
+    relate gram_stain(bacillus_anthracis, gram_positive)
+        source "Bacillus anthracis is a gram-positive spore-forming rod that produces anthrax toxin resulting in an ulcer with a black eschar."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK470553/"
+        trust authoritative
+    relate morphology(bacillus_anthracis, bacilli)
+        source "Bacillus anthracis is a gram-positive spore-forming rod that produces anthrax toxin resulting in an ulcer with a black eschar."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK470553/"
+        trust authoritative
 }

--- a/code/specs/data/mycin-2026/recall/micro-recall.query.adj
+++ b/code/specs/data/mycin-2026/recall/micro-recall.query.adj
@@ -28,3 +28,5 @@ import "micro-edges.adj"
 ? gram_stain(listeria_monocytogenes, $Result)          % expect gram_positive (expand)
 ? morphology(listeria_monocytogenes, $Shape)           % expect bacilli (expand)
 ? gram_stain(klebsiella_pneumoniae, $Result)           % expect gram_negative (expand)
+? gram_stain(bacillus_anthracis, $Result)              % expect gram_positive (expand)
+? morphology(bacillus_anthracis, $Shape)               % expect bacilli (expand)

--- a/code/specs/data/mycin-2026/recall/test_micro_recall.py
+++ b/code/specs/data/mycin-2026/recall/test_micro_recall.py
@@ -53,6 +53,8 @@ EXPECTED = [
     ("listeria_monocytogenes", "gram_stain", "gram_positive"),       # expand (NBK534838)
     ("listeria_monocytogenes", "morphology", "bacilli"),             # expand (NBK534838)
     ("klebsiella_pneumoniae", "gram_stain", "gram_negative"),        # expand (NBK519004)
+    ("bacillus_anthracis", "gram_stain", "gram_positive"),           # expand (NBK470553)
+    ("bacillus_anthracis", "morphology", "bacilli"),                 # expand (NBK470553)
 ]
 
 


### PR DESCRIPTION
## What
New microbiology organism — two grounded edges from one self-contained StatPearls span (NBK470553) naming both endpoints:

- **gram_stain(bacillus_anthracis, gram_positive)**
- **morphology(bacillus_anthracis, bacilli)**
  > Bacillus anthracis is a gram-positive spore-forming rod that produces anthrax toxin resulting in an ulcer with a black eschar.

## Changes (data-only)
- `micro-edges.adj` +2 `relate`; `micro-recall.query.adj` +2; `test_micro_recall.py` EXPECTED +2 (`treponema_pallidum` negative control unchanged)

## Verification
- `test_micro_recall: 3/3 passed`; ruff clean; data-only security review passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)