### PR TITLE
feat(mycin-immuno): ground Job syndrome (hyper-IgE) → STAT3

### DIFF
--- a/code/specs/data/mycin-2026/recall/immuno-edges.adj
+++ b/code/specs/data/mycin-2026/recall/immuno-edges.adj
@@ -117,4 +117,10 @@ rulebook immuno_facts {
         source "Chediak-Higashi syndrome (CHS) is a rare autosomal recessive multisystem disorder caused by mutations in the LYST gene, leading to impaired lysosomal trafficking and dysfunctional organelle formation."
         locator "https://www.ncbi.nlm.nih.gov/books/NBK507881/"
         trust authoritative
+
+    % --- EXPAND: Job syndrome (autosomal-dominant hyper-IgE) molecular lesion is STAT3 --
+    relate gene_defect(job_syndrome, stat3)
+        source "Job syndrome is due to a mutation in the STAT3 gene in more than two-thirds of cases (70%)."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK525947/"
+        trust authoritative
 }

--- a/code/specs/data/mycin-2026/recall/immuno-recall.query.adj
+++ b/code/specs/data/mycin-2026/recall/immuno-recall.query.adj
@@ -27,3 +27,4 @@ import "immuno-edges.adj"
 ? gene_defect(wiskott_aldrich_syndrome, $Gene)         % expect was (expand)
 ? deficiency_of(hereditary_angioedema, $Component)     % expect c1_inhibitor (expand)
 ? gene_defect(chediak_higashi_syndrome, $Gene)         % expect lyst (expand)
+? gene_defect(job_syndrome, $Gene)                     % expect stat3 (expand)

--- a/code/specs/data/mycin-2026/recall/test_immuno_recall.py
+++ b/code/specs/data/mycin-2026/recall/test_immuno_recall.py
@@ -44,6 +44,7 @@ EXPECTED = [
     ("wiskott_aldrich_syndrome", "gene_defect", "was"),              # expand (NBK539838)
     ("hereditary_angioedema", "deficiency_of", "c1_inhibitor"),      # expand (NBK482266)
     ("chediak_higashi_syndrome", "gene_defect", "lyst"),             # expand (NBK507881)
+    ("job_syndrome", "gene_defect", "stat3"),                        # expand (NBK525947)
 ]
 VAR = {"mediated_by": "Mediator", "associated_hla": "HLA",
        "gene_defect": "Gene", "deficiency_of": "Component"}


### PR DESCRIPTION
## What
New immunodeficiency edge, grounded from StatPearls NBK525947:

- **gene_defect(job_syndrome, stat3)**:
  > Job syndrome is due to a mutation in the STAT3 gene in more than two-thirds of cases (70%).

## Changes (data-only)
- `immuno-edges.adj` +1 `relate`; `immuno-recall.query.adj` +1; `test_immuno_recall.py` EXPECTED +1 (`rheumatoid_arthritis` negative control unchanged)

## Verification
- `test_immuno_recall: 3/3 passed`; ruff clean; data-only security review passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)