### PR TITLE
feat(r-lang): R-44 — base Date support (Sys.Date/as.Date/format.Date/difftime/weekdays)

### DIFF
--- a/code/packages/rust/r-runtime/CHANGELOG.md
+++ b/code/packages/rust/r-runtime/CHANGELOG.md
@@ -2,6 +2,38 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.34.0] - 2026-06-22
+
+### Added (via the shared `s-runtime`)
+
+- **Base R Date support (R-44)** — R's first calendar type, reached through
+  ordinary R syntax. A **`Date`** is a numeric vector of **days since the Unix
+  epoch 1970-01-01** carrying class `"Date"` (the existing transparent
+  `Classed` wrapper — no new value kind), so coercions and arithmetic see
+  straight through to the day count.
+  - **`as.Date(x, format = "%Y-%m-%d")`** — parse a character vector (default
+    `"%Y-%m-%d"`, or `"%Y/%m/%d"` etc. via `format =`), or wrap a numeric vector
+    as days-since-epoch. `class(as.Date("2021-03-14"))` → `"Date"`;
+    `as.numeric(as.Date("1970-01-02"))` → `1`; `as.numeric(as.Date("1969-12-31"))`
+    → `-1`. Malformed strings (`as.Date("not-a-date")`) → `NA`, never a panic.
+  - **`format(d)` / `format.Date(d, fmt)`** — render to a string (`%Y`/`%m`/`%d`/
+    `%j`, default `"%Y-%m-%d"`). `format(as.Date("2021-03-14"))` → `"2021-03-14"`.
+  - **`Sys.Date()`** — today as a Date (wall clock; non-deterministic, so only its
+    class/structure is asserted in tests).
+  - **`d1 - d2` and `difftime(d1, d2)`** — difference in **days**.
+    `as.Date("2021-03-20") - as.Date("2021-03-14")` → `6`.
+  - **`weekdays(d)`** — `weekdays(as.Date("1970-01-01"))` → `"Thursday"`;
+    `weekdays(as.Date("2021-03-14"))` → `"Sunday"`.
+  - **`as.numeric` / `as.double`** — base coercions yielding a Date's
+    days-since-epoch (and a factor's codes).
+  - **Security**: untrusted date strings parse with bounded `i64` accumulation
+    (no overflow on crafted years); impossible days rejected via a civil
+    round-trip; weekday/day-of-year math uses `rem_euclid` (safe on pre-epoch
+    negatives). Malformed input → `NA`, never a panic.
+  - **Deferred to R-45**: full `strptime`/`strftime` fields; `POSIXct`/`POSIXlt`
+    date-times and timezones; `seq.Date`; `months()`/`quarters()`; non-day
+    `difftime` units.
+
 ## [0.33.0] - 2026-06-21
 
 ### Added (via the shared `s-runtime`)

--- a/code/packages/rust/r-runtime/README.md
+++ b/code/packages/rust/r-runtime/README.md
@@ -301,6 +301,31 @@ over-large product errors rather than OOMing, and `0×n`/`m×0` inputs give an e
 result with no out-of-bounds access. The R `%x%` infix alias (`X %x% Y`) needs
 lexer/grammar work and is deferred to **R-40**; this ships the function form only.
 
+**R-44 — base R Date support** adds R's first calendar type, again through the
+shared `s-runtime`. A **`Date`** is *not* a new value kind: it is a numeric vector
+of **days since the Unix epoch 1970-01-01** carrying class `"Date"` (the existing
+transparent `Classed` wrapper), so coercions and arithmetic already see through to
+the day count. `as.Date(x, format=)` parses a character vector (default ISO
+`"%Y-%m-%d"`, or `"%Y/%m/%d"` etc. via `format=`) or wraps a numeric vector as
+days-since-epoch (`as.Date(0)` → 1970-01-01); a malformed string
+(`as.Date("not-a-date")`, `as.Date("2021-02-30")`) → `NA`, never a panic.
+`class(as.Date("2021-03-14"))` → `"Date"`; `as.numeric(as.Date("1970-01-02"))` →
+`1`; `as.numeric(as.Date("1969-12-31"))` → `-1`. `format(d)` / `format.Date(d, fmt)`
+render with `%Y`/`%m`/`%d`/`%j` (default `"%Y-%m-%d"`):
+`format(as.Date("2021-03-14"))` → `"2021-03-14"`. `Sys.Date()` is today (wall
+clock; non-deterministic, so only its class/structure is asserted). `d1 - d2` and
+`difftime(d1, d2)` give the difference in **days** (`as.Date("2021-03-20") -
+as.Date("2021-03-14")` → `6`). `weekdays(d)` names the day, anchored on the fact
+that 1970-01-01 was a Thursday — `weekdays(as.Date("1970-01-01"))` → `"Thursday"`,
+`weekdays(as.Date("2021-03-14"))` → `"Sunday"`. The calendar uses Howard Hinnant's
+dependency-free `days_from_civil`/`civil_from_days` algorithms (leap years and
+pre-epoch dates handled). Parse safety: untrusted strings parse with bounded `i64`
+accumulation (no overflow on crafted years), impossible days are rejected via a
+civil round-trip, and weekday/day-of-year modulo uses `rem_euclid` (safe on
+pre-epoch negatives). Deferred to **R-45**: full `strptime`/`strftime` fields,
+`POSIXct`/`POSIXlt` date-times and timezones, `seq.Date`, `months()`/`quarters()`,
+and `difftime` units other than days.
+
 ## Usage
 
 ```rust

--- a/code/packages/rust/r-runtime/src/lib.rs
+++ b/code/packages/rust/r-runtime/src/lib.rs
@@ -3376,4 +3376,67 @@ mod tests {
             "[1]  \"(0,3.1]\" \"(3.1,10]\""
         );
     }
+
+    // --- R-44: base R Date support (through R syntax) ------------------------
+
+    #[test]
+    fn date_class_through_r_syntax() {
+        assert_eq!(show("class(as.Date(\"2021-03-14\"))\n"), "[1] \"Date\"");
+    }
+
+    #[test]
+    fn date_as_numeric_through_r_syntax() {
+        assert_eq!(nums("as.numeric(as.Date(\"1970-01-01\"))\n"), vec![0.0]);
+        assert_eq!(nums("as.numeric(as.Date(\"1970-01-02\"))\n"), vec![1.0]);
+        assert_eq!(nums("as.numeric(as.Date(\"1969-12-31\"))\n"), vec![-1.0]);
+    }
+
+    #[test]
+    fn date_format_round_trip_through_r_syntax() {
+        assert_eq!(
+            show("format(as.Date(\"2021-03-14\"))\n"),
+            "[1] \"2021-03-14\""
+        );
+        assert_eq!(
+            show("format(as.Date(\"2000-02-29\"))\n"),
+            "[1] \"2000-02-29\""
+        );
+    }
+
+    #[test]
+    fn date_slash_format_through_r_syntax() {
+        assert_eq!(
+            nums("as.numeric(as.Date(\"2021/03/14\", format = \"%Y/%m/%d\"))\n"),
+            nums("as.numeric(as.Date(\"2021-03-14\"))\n")
+        );
+    }
+
+    #[test]
+    fn date_malformed_is_na_through_r_syntax() {
+        assert_eq!(show("as.numeric(as.Date(\"not-a-date\"))\n"), "[1] NA");
+    }
+
+    #[test]
+    fn date_subtraction_through_r_syntax() {
+        assert_eq!(
+            nums("as.Date(\"2021-03-20\") - as.Date(\"2021-03-14\")\n"),
+            vec![6.0]
+        );
+    }
+
+    #[test]
+    fn weekdays_through_r_syntax() {
+        assert_eq!(
+            show("weekdays(as.Date(\"1970-01-01\"))\n"),
+            "[1] \"Thursday\""
+        );
+        assert_eq!(show("weekdays(as.Date(\"2021-03-14\"))\n"), "[1] \"Sunday\"");
+    }
+
+    #[test]
+    fn sys_date_structure_through_r_syntax() {
+        // Non-deterministic: assert only class + single numeric.
+        assert_eq!(show("class(Sys.Date())\n"), "[1] \"Date\"");
+        assert_eq!(nums("length(Sys.Date())\n"), vec![1.0]);
+    }
 }

--- a/code/packages/rust/s-runtime/CHANGELOG.md
+++ b/code/packages/rust/s-runtime/CHANGELOG.md
@@ -41,9 +41,13 @@ All notable changes to this project will be documented in this file.
     era/year-of-era/day-of-era algorithms (leap years and negative dates handled).
   - **Security**: untrusted date strings parse with **bounded `i64`** digit
     accumulation (a digit cap rejects absurd years before the day arithmetic can
-    overflow); impossible days are rejected via a civil round-trip; malformed
-    input → `NA`. All weekday / day-of-year modulo uses `rem_euclid` (Rust `%`
-    can go negative on pre-epoch counts).
+    overflow); a directly-supplied numeric day count is clamped to ±1e11 days
+    (→ `NA` if out of range), so `as.Date(1e300)` cannot saturate to `i64::MAX`
+    and overflow the civil kernel — `format`/`weekdays` defend the same bound, so
+    a hand-built `structure(1e300, class="Date")` is also safe. Impossible days
+    are rejected via a civil round-trip; malformed input → `NA`. All weekday /
+    day-of-year modulo uses `rem_euclid` (Rust `%` can go negative on pre-epoch
+    counts).
   - **Deferred to R-45**: full `strptime`/`strftime` fields (`%B`/`%A`/`%H`/…);
     `POSIXct`/`POSIXlt` date-times and timezones; `seq.Date`;
     `months()`/`quarters()`; `difftime` units other than days.

--- a/code/packages/rust/s-runtime/CHANGELOG.md
+++ b/code/packages/rust/s-runtime/CHANGELOG.md
@@ -2,6 +2,52 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.35.0] - 2026-06-22
+
+### Added
+
+- **Base R Date support (R-44)** — the first calendar type, reused verbatim by
+  the R frontend through the shared tree-walker. A **`Date`** is **not** a new
+  value kind: it is an ordinary numeric vector of **days since the Unix epoch
+  1970-01-01** carrying the S3 class `"Date"`, modelled with the existing
+  transparent `SValue::Classed { inner: Double, class: ["Date"] }` wrapper. No new
+  `SValue` variant is introduced, so every coercion (`as_double`/`as_character`)
+  and the `arithmetic` kernel already see straight through to the day count.
+  - **`as.Date(x, format = "%Y-%m-%d")`** — parse a character vector (default ISO
+    `"%Y-%m-%d"`, or `"%Y/%m/%d"` and similar via `format =`; recognised fields
+    `%Y`/`%m`/`%d` plus literal separators), or wrap a numeric vector directly as
+    days-since-epoch (`as.Date(0)` → 1970-01-01). Unparseable / out-of-range
+    strings (e.g. `"not-a-date"`, `"2021-02-30"`) become `NA`, never a panic.
+    Vectorised.
+  - **`format.Date(d, format = "%Y-%m-%d")` and the `format()` generic** —
+    render a Date back to a string with `%Y`/`%m`/`%d`/`%j` (day-of-year);
+    `format()` detects the `"Date"` class and dispatches to the Date renderer.
+    `format(as.Date("2000-02-29"))` → `"2000-02-29"`.
+  - **`Sys.Date()`** — today's date as a length-1 Date, read from
+    `SystemTime::now()` (days since `UNIX_EPOCH`; a pre-epoch clock is handled
+    without panic). Non-deterministic, so tested for structure only.
+  - **`difftime(d1, d2)` and `d1 - d2`** — the difference in **days** (numeric).
+    Subtraction needs no special case (the wrapper is transparent to
+    `arithmetic`); `difftime` is the named builtin form (days unit only).
+  - **`weekdays(d)`** — the English weekday name (`"Monday"`..`"Sunday"`),
+    anchored on the historical fact that 1970-01-01 was a Thursday, with
+    `(days + 4).rem_euclid(7)` so pre-epoch (negative) day counts never panic.
+  - **`as.numeric` / `as.double`** — added as base coercions (drop a class to a
+    plain numeric; a factor coerces by its codes), so `as.numeric(date)` returns
+    the raw days-since-epoch.
+  - **Civil-date kernel** — two pure, dependency-free helpers,
+    `days_from_civil(y, m, d)` and its exact inverse `civil_from_days(z)`,
+    implement the proleptic Gregorian calendar with Howard Hinnant's
+    era/year-of-era/day-of-era algorithms (leap years and negative dates handled).
+  - **Security**: untrusted date strings parse with **bounded `i64`** digit
+    accumulation (a digit cap rejects absurd years before the day arithmetic can
+    overflow); impossible days are rejected via a civil round-trip; malformed
+    input → `NA`. All weekday / day-of-year modulo uses `rem_euclid` (Rust `%`
+    can go negative on pre-epoch counts).
+  - **Deferred to R-45**: full `strptime`/`strftime` fields (`%B`/`%A`/`%H`/…);
+    `POSIXct`/`POSIXlt` date-times and timezones; `seq.Date`;
+    `months()`/`quarters()`; `difftime` units other than days.
+
 ## [0.34.0] - 2026-06-21
 
 ### Added

--- a/code/packages/rust/s-runtime/README.md
+++ b/code/packages/rust/s-runtime/README.md
@@ -309,6 +309,25 @@ a hand-written loop. See [What "S-flavored" means here](#what-s-flavored-means-h
   inputs give an empty result, no OOB). `kronecker(matrix(c(1,2,3,4), nrow=2),
   matrix(c(0,1,1,0), nrow=2))` is a 4×4 block matrix; `kronecker(matrix(5), Y)`
   is `5·Y`. The R `%x%` infix alias is deferred to R-40 (grammar work).
+- **Base R Date support** (R-44): a **`Date`** is a numeric vector of **days since
+  the Unix epoch 1970-01-01** carrying class `"Date"` — modelled with the existing
+  transparent `SValue::Classed { inner: Double, class: ["Date"] }` wrapper, so
+  **no new value variant** and every coercion / `arithmetic` call sees through to
+  the day count. **`as.Date(x, format=)`** parses a character vector (default
+  `"%Y-%m-%d"`, or `"%Y/%m/%d"` etc. via `format=`, fields `%Y`/`%m`/`%d`) or wraps
+  a numeric as days-since-epoch; malformed/out-of-range strings → `NA`, never a
+  panic. **`format.Date(d, format=)`** and the **`format()`** generic render with
+  `%Y`/`%m`/`%d`/`%j`. **`Sys.Date()`** is today (wall clock; tested for structure
+  only). **`difftime(d1, d2)`** and **`d1 - d2`** give the difference in **days**.
+  **`weekdays(d)`** names the day (anchored on 1970-01-01 = Thursday,
+  `(days+4).rem_euclid(7)` so pre-epoch counts never panic). **`as.numeric`** /
+  **`as.double`** added as base coercions (a Date → days-since-epoch; a factor →
+  codes). The calendar uses Howard Hinnant's dependency-free
+  `days_from_civil`/`civil_from_days` (leap years and negative dates handled).
+  Parse safety: bounded `i64` digit accumulation rejects absurd years before
+  overflow; impossible days rejected via a civil round-trip. Deferred to R-45:
+  full `strptime`/`strftime`, `POSIXct`/`POSIXlt` & timezones, `seq.Date`,
+  `months()`/`quarters()`, non-day `difftime` units.
 - The **`d`/`p`/`q`/`r` distribution family** (R-8) over `statistics-core`:
   density/CDF/quantile/sampling for the normal, uniform, and exponential
   distributions, plus `set.seed` for a reproducible per-session RNG.

--- a/code/packages/rust/s-runtime/src/builtins.rs
+++ b/code/packages/rust/s-runtime/src/builtins.rs
@@ -246,6 +246,19 @@ pub fn install(env: &Env) {
     define(env, "nlevels", builtin("nlevels", b_nlevels));
     define(env, "as.character", builtin("as.character", b_as_character));
     define(env, "as.integer", builtin("as.integer", b_as_integer));
+    // R-44 — `as.numeric` (a base coercion; needed so `as.numeric(date)`
+    // returns the raw days-since-epoch, and generally to drop a class to plain
+    // numeric). `as.double` is R's exact synonym.
+    define(env, "as.numeric", builtin("as.numeric", b_as_numeric));
+    define(env, "as.double", builtin("as.double", b_as_numeric));
+
+    // R-44 — base R Date support. A Date is days-since-epoch (1970-01-01)
+    // carried by the transparent `SValue::Classed` wrapper with class "Date".
+    define(env, "as.Date", builtin("as.Date", b_as_date));
+    define(env, "Sys.Date", builtin("Sys.Date", b_sys_date));
+    define(env, "format.Date", builtin("format.Date", b_format_date));
+    define(env, "difftime", builtin("difftime", b_difftime));
+    define(env, "weekdays", builtin("weekdays", b_weekdays));
 
     // v2 — data frames.
     define(env, "data.frame", builtin("data.frame", b_data_frame));
@@ -1520,6 +1533,362 @@ fn b_as_integer(_interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
             ))
         }
     }
+}
+
+/// `as.numeric(x)` / `as.double(x)` — coerce to a plain numeric vector, **dropping
+/// any class** (R-44). For a `Date` this returns its raw days-since-epoch: the
+/// `Classed` wrapper is transparent to `as_double`, so we simply re-wrap the
+/// coerced doubles as a bare `Double` (the class is gone). A factor coerces by its
+/// integer codes — matching `as.numeric(factor(...))` in R, which returns the
+/// codes, not the labels.
+fn b_as_numeric(_interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
+    match first_positional(args)? {
+        // A factor's numeric form is its 1-based codes (NA-preserving), exactly
+        // like `as.integer` — never the labels (those would be NA under as.double).
+        SValue::Factor { codes, .. } => Ok(SValue::doubles(
+            codes
+                .iter()
+                .map(|c| c.map(|k| k as f64).unwrap_or_else(na_real))
+                .collect(),
+        )),
+        other => Ok(SValue::Double(other.as_double()?)),
+    }
+}
+
+// ===========================================================================
+// R-44 — base R Date support
+// ===========================================================================
+//
+// In R a `Date` is *not* a distinct value kind: it is an ordinary numeric vector
+// holding the count of **days since the Unix epoch 1970-01-01**, carrying the S3
+// class attribute "Date". We model it with the existing transparent
+// `SValue::Classed { inner: Double, class: ["Date"] }` wrapper — no new SValue
+// variant — so every coercion (`as_double`/`as_character`) and the `arithmetic`
+// kernel already see straight through to the day count. The only Date-aware code
+// is parsing, rendering, and the small civil-date kernel below.
+//
+//   day 0  = 1970-01-01 (a Thursday)
+//   day 1  = 1970-01-02
+//   day -1 = 1969-12-31
+//
+// ---------------------------------------------------------------------------
+// The civil-date kernel (Howard Hinnant's algorithms — no new dependency)
+// ---------------------------------------------------------------------------
+//
+// These two pure functions convert between a (year, month, day) civil date and a
+// signed day count relative to the epoch. They implement the **proleptic
+// Gregorian calendar** (the Gregorian rules projected backward through all of
+// history, including before 1582), and are exact inverses of one another. The
+// trick is to shift the start of the year to **March**, so the leap day
+// (February 29) lands at the *end* of the year-of-era and never disturbs the
+// month-length pattern; an "era" is a 400-year cycle (exactly 146097 days), which
+// is the calendar's repeat period.
+
+/// Days from the civil date `(y, m, d)` to the Unix epoch 1970-01-01.
+///
+/// Hinnant's `days_from_civil`. `i64` throughout so distant or pre-epoch years can
+/// never overflow within the (bounded) year range the parser admits. Examples:
+/// `(1970,1,1) → 0`, `(1970,1,2) → 1`, `(1969,12,31) → -1`, `(2000,2,29) → 11016`.
+fn days_from_civil(y: i64, m: i64, d: i64) -> i64 {
+    // Shift the year so it starts in March: Jan/Feb belong to the *previous* year.
+    let y = if m <= 2 { y - 1 } else { y };
+    // The era is the 400-year cycle this year falls in (floored toward -inf).
+    let era = if y >= 0 { y } else { y - 399 } / 400;
+    let yoe = y - era * 400; // year of era, 0..=399
+                             // Day of year counting from March 1 (mar=0 … feb=364/365).
+    let doy = (153 * (if m > 2 { m - 3 } else { m + 9 }) + 2) / 5 + d - 1;
+    // Day of era, 0..=146096.
+    let doe = yoe * 365 + yoe / 4 - yoe / 100 + doy;
+    // 719468 = days from 0000-03-01 to 1970-01-01 — shifts the result to the epoch.
+    era * 146097 + doe - 719468
+}
+
+/// The civil date `(y, m, d)` for a day count `z` relative to 1970-01-01.
+///
+/// Hinnant's `civil_from_days` — the exact inverse of [`days_from_civil`]. Examples:
+/// `0 → (1970,1,1)`, `-1 → (1969,12,31)`, `11016 → (2000,2,29)`.
+fn civil_from_days(z: i64) -> (i64, i64, i64) {
+    let z = z + 719468; // re-base onto 0000-03-01
+    let era = if z >= 0 { z } else { z - 146096 } / 146097;
+    let doe = z - era * 146097; // day of era, 0..=146096
+                                // Year of era, 0..=399.
+    let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146096) / 365;
+    let y = yoe + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100); // day of year (Mar-based), 0..=365
+    let mp = (5 * doy + 2) / 153; // month, shifted (0 = March … 11 = February)
+    let d = doy - (153 * mp + 2) / 5 + 1; // day of month, 1..=31
+    let m = if mp < 10 { mp + 3 } else { mp - 9 }; // un-shift to 1..=12
+    let y = if m <= 2 { y + 1 } else { y }; // Jan/Feb roll into the next civil year
+    (y, m, d)
+}
+
+/// The largest number of decimal digits we will accumulate for any single date
+/// field while parsing. A year is at most 4–6 digits in practice; capping the run
+/// length means a crafted string of a million '9's can never overflow the `i64`
+/// accumulation or hang — it simply fails to parse (→ NA). 9 digits keeps `i64`
+/// far from overflow while still admitting any realistic year.
+const MAX_DATE_DIGITS: usize = 9;
+
+/// Is `x` a Date — a value whose (explicit) class vector contains "Date"?
+fn is_date(x: &SValue) -> bool {
+    class_of(x).iter().any(|c| c == "Date")
+}
+
+/// Wrap a vector of day counts (NA-aware doubles) as a `Date` — class "Date" over
+/// a plain `Double`. This is the single constructor every Date-producing builtin
+/// funnels through.
+fn make_date(days: Vec<f64>) -> SValue {
+    SValue::Classed {
+        inner: Box::new(SValue::doubles(days)),
+        class: vec!["Date".to_string()],
+    }
+}
+
+/// Parse one non-negative integer field of at most [`MAX_DATE_DIGITS`] digits from
+/// `chars` starting at `idx`, advancing `idx` past it. Returns `None` (→ the whole
+/// parse fails → NA) on no digits or an over-long run. Accumulates in `i64` so it
+/// cannot overflow within the digit cap.
+fn parse_uint_field(chars: &[char], idx: &mut usize) -> Option<i64> {
+    let start = *idx;
+    let mut val: i64 = 0;
+    while *idx < chars.len() && chars[*idx].is_ascii_digit() {
+        if *idx - start >= MAX_DATE_DIGITS {
+            return None; // absurdly long run — refuse rather than risk overflow
+        }
+        val = val * 10 + (chars[*idx] as i64 - '0' as i64);
+        *idx += 1;
+    }
+    if *idx == start {
+        None // no digits where a number was required
+    } else {
+        Some(val)
+    }
+}
+
+/// Parse one date `string` against a `format` pattern (supporting `%Y`, `%m`, `%d`
+/// and literal characters), returning days-since-epoch — or `None` (→ NA) on any
+/// mismatch, missing field, or out-of-range value. Never panics on crafted input.
+fn parse_date_str(string: &str, format: &str) -> Option<i64> {
+    let chars: Vec<char> = string.chars().collect();
+    let fmt: Vec<char> = format.chars().collect();
+    let (mut ci, mut fi) = (0usize, 0usize);
+    // We require year + month + day to all appear; track each as we read them.
+    let (mut year, mut month, mut day): (Option<i64>, Option<i64>, Option<i64>) =
+        (None, None, None);
+
+    while fi < fmt.len() {
+        if fmt[fi] == '%' && fi + 1 < fmt.len() {
+            match fmt[fi + 1] {
+                'Y' => year = Some(parse_uint_field(&chars, &mut ci)?),
+                'm' => month = Some(parse_uint_field(&chars, &mut ci)?),
+                'd' => day = Some(parse_uint_field(&chars, &mut ci)?),
+                // An unsupported conversion in the format → no parse (NA), rather
+                // than silently misreading. (Full %B/%A/… land in R-45.)
+                _ => return None,
+            }
+            fi += 2;
+        } else {
+            // A literal format character must match the input exactly.
+            if ci >= chars.len() || chars[ci] != fmt[fi] {
+                return None;
+            }
+            ci += 1;
+            fi += 1;
+        }
+    }
+    // Any unconsumed input is a mismatch (trailing garbage → NA).
+    if ci != chars.len() {
+        return None;
+    }
+
+    let (y, m, d) = (year?, month?, day?);
+    // Range-check the calendar fields. `days_from_civil` is total over i64, but a
+    // nonsense month/day would otherwise round-trip to a *different* date, so we
+    // reject anything outside the real calendar. (Day-of-month is validated by a
+    // round-trip below — the simplest correct check.)
+    if !(1..=12).contains(&m) || !(1..=31).contains(&d) {
+        return None;
+    }
+    let z = days_from_civil(y, m, d);
+    // Round-trip to reject impossible days like 2021-02-30 (which the raw formula
+    // would happily fold into March): the day is valid iff it reconstructs exactly.
+    if civil_from_days(z) != (y, m, d) {
+        return None;
+    }
+    Some(z)
+}
+
+/// Render one day count `z` to a string under `format` (`%Y`, `%m`, `%d`, `%j`,
+/// and literals). Total — never panics; pre-epoch counts work via the i64 kernel.
+fn format_date_days(z: i64, format: &str) -> String {
+    let (y, m, d) = civil_from_days(z);
+    let fmt: Vec<char> = format.chars().collect();
+    let mut out = String::new();
+    let mut fi = 0;
+    while fi < fmt.len() {
+        if fmt[fi] == '%' && fi + 1 < fmt.len() {
+            match fmt[fi + 1] {
+                'Y' => out.push_str(&y.to_string()),
+                'm' => out.push_str(&format!("{m:02}")),
+                'd' => out.push_str(&format!("{d:02}")),
+                'j' => {
+                    // Day of year, 001..366 = (this day) − (Jan 1 of the same year) + 1.
+                    let doy = z - days_from_civil(y, 1, 1) + 1;
+                    out.push_str(&format!("{doy:03}"));
+                }
+                other => {
+                    // Unknown conversion: emit it literally (forgiving), e.g. a
+                    // stray "%q" renders as "%q". Full coverage lands in R-45.
+                    out.push('%');
+                    out.push(other);
+                }
+            }
+            fi += 2;
+        } else {
+            out.push(fmt[fi]);
+            fi += 1;
+        }
+    }
+    out
+}
+
+/// `as.Date(x, format = "%Y-%m-%d")` — build a `Date` (R-44).
+///
+/// - **Character `x`:** each element is parsed against `format` (default ISO
+///   `"%Y-%m-%d"`; pass e.g. `format = "%Y/%m/%d"`). Unparseable / out-of-range
+///   strings become `NA` — never a panic.
+/// - **Numeric `x`:** taken directly as days-since-epoch (`as.Date(0)` is
+///   1970-01-01). An `origin =` other than the epoch is deferred (R-45); we use
+///   1970-01-01.
+///
+/// Vectorised; the result always carries class "Date".
+fn b_as_date(_interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
+    let x = first_positional(args)?;
+    // Already a Date? Return as-is (idempotent), seeing through the wrapper.
+    if is_date(x) {
+        return Ok(x.clone());
+    }
+    let format = named_str(args, "format").unwrap_or_else(|| "%Y-%m-%d".to_string());
+
+    // The peeled value decides character-parse vs numeric-wrap. A character vector
+    // parses; anything coercible to double is taken as raw day counts.
+    let days: Vec<f64> = match peel_structural(x) {
+        SValue::Character(strs) => strs
+            .iter()
+            .map(|opt| match opt {
+                Some(s) => parse_date_str(s, &format)
+                    .map(|z| z as f64)
+                    .unwrap_or_else(na_real),
+                None => na_real(),
+            })
+            .collect(),
+        other => {
+            // Numeric (or coercible) input → days since epoch, truncated to whole
+            // days (R stores Dates as doubles but they are integral here).
+            let d = other.as_double()?;
+            d.iter()
+                .map(|v| if is_na_real(v) { na_real() } else { v.trunc() })
+                .collect()
+        }
+    };
+    Ok(make_date(days))
+}
+
+/// `Sys.Date()` — today's date as a length-1 `Date` (R-44).
+///
+/// The runtime has **no deterministic clock hook** (there is no `Sys.time`/`now`
+/// abstraction to reuse), so we read the wall clock directly. The duration since
+/// `UNIX_EPOCH` divided by 86400 seconds is the day count; a clock set *before*
+/// the epoch yields a negative count, handled without panic. Because the value is
+/// non-deterministic, tests assert only its structure (class "Date" + a single
+/// finite numeric), never the exact day.
+fn b_sys_date(_interp: &Interpreter, _args: &[Arg]) -> SResult<SValue> {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    let now = SystemTime::now();
+    // `duration_since` is Err if `now` precedes the epoch; handle both directions
+    // so a misconfigured clock can never panic.
+    let days = match now.duration_since(UNIX_EPOCH) {
+        Ok(dur) => (dur.as_secs() / 86_400) as i64,
+        Err(e) => -((e.duration().as_secs().div_ceil(86_400)) as i64),
+    };
+    Ok(make_date(vec![days as f64]))
+}
+
+/// `format.Date(d, format = "%Y-%m-%d")` — render a `Date` to a character vector
+/// (R-44). Supported fields: `%Y`, `%m`, `%d`, `%j` (day-of-year). `NA` days stay
+/// `NA`. Vectorised. Reached directly and via the `format()` generic's dispatch.
+fn b_format_date(_interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
+    let x = first_positional(args)?;
+    // The format may be the named `format =` or the second positional argument
+    // (`format(d, "%Y/%m/%d")`), defaulting to ISO.
+    let format = named_str(args, "format")
+        .or_else(|| {
+            nth_positional(args, 1).and_then(|v| v.as_character().into_iter().next().flatten())
+        })
+        .unwrap_or_else(|| "%Y-%m-%d".to_string());
+
+    let days = x.as_double()?;
+    let out: Vec<Option<String>> = days
+        .iter()
+        .map(|v| {
+            if is_na_real(v) {
+                None
+            } else {
+                Some(format_date_days(v.trunc() as i64, &format))
+            }
+        })
+        .collect();
+    Ok(SValue::Character(out))
+}
+
+/// `difftime(time1, time2)` — the difference `time1 − time2` in **days**, as a
+/// numeric vector (R-44). In base R this returns a `"difftime"` object; here the
+/// only supported unit is days, so we return the plain numeric day difference
+/// (units other than days are deferred to R-45). Recycles and propagates `NA`
+/// through the shared `arithmetic` kernel — which already sees through the Date
+/// wrappers — so this is a thin, faithful wrapper.
+fn b_difftime(_interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
+    let t1 = nth_positional(args, 0)
+        .ok_or_else(|| SError::BadArgs("difftime: missing time1".into()))?;
+    let t2 = nth_positional(args, 1)
+        .ok_or_else(|| SError::BadArgs("difftime: missing time2".into()))?;
+    crate::value::arithmetic("-", t1, t2)
+}
+
+/// `weekdays(d)` — the English weekday name of each `Date` (R-44).
+///
+/// The anchor is the historical fact that **1970-01-01 (day 0) was a Thursday**.
+/// Indexing the names from Sunday=0, day 0 (Thursday) is index 4, so the weekday
+/// index is `(days + 4).rem_euclid(7)`. We use `rem_euclid` — *not* `%` — because
+/// Rust's `%` returns a **negative** remainder for negative (pre-epoch) day
+/// counts, which would panic on `Vec` indexing; `rem_euclid` always lands in
+/// `0..7`. `NA` days yield `NA`.
+fn b_weekdays(_interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
+    const NAMES: [&str; 7] = [
+        "Sunday",
+        "Monday",
+        "Tuesday",
+        "Wednesday",
+        "Thursday",
+        "Friday",
+        "Saturday",
+    ];
+    let days = first_positional(args)?.as_double()?;
+    let out: Vec<Option<String>> = days
+        .iter()
+        .map(|v| {
+            if is_na_real(v) {
+                None
+            } else {
+                let z = v.trunc() as i64;
+                // Day 0 = Thursday = index 4 (Sunday-based). rem_euclid keeps the
+                // index in 0..7 even for negative z (pre-epoch).
+                let idx = (z + 4).rem_euclid(7) as usize;
+                Some(NAMES[idx].to_string())
+            }
+        })
+        .collect();
+    Ok(SValue::Character(out))
 }
 
 // ===========================================================================
@@ -4005,6 +4374,12 @@ fn format_number_nsmall(x: f64, nsmall: usize, big_mark: &str) -> String {
 /// out). `NA` renders as the string `"NA"`.
 fn b_format(_interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
     let x = first_positional(args)?;
+    // R-44: `format()` is an S3 generic. A value carrying class "Date" routes to
+    // the Date renderer (`format.Date`) — so `format(as.Date("2021-03-14"))`
+    // yields "2021-03-14" rather than the bare day count.
+    if is_date(x) {
+        return b_format_date(_interp, args);
+    }
     let nsmall = named_count(args, "nsmall").unwrap_or(0);
     let min_width = named_count(args, "width").unwrap_or(0);
     let big_mark = named_str(args, "big.mark").unwrap_or_default();
@@ -5960,5 +6335,117 @@ fn describe(err: StatsError) -> String {
         StatsError::EmptyInput { .. } => "argument has length zero".to_string(),
         StatsError::DomainError { what, .. } => what,
         other => format!("{other:?}"),
+    }
+}
+
+// ===========================================================================
+// R-44 — unit tests for the civil-date kernel and the Date parse/format helpers
+// ===========================================================================
+//
+// The end-to-end Date builtins (`as.Date`, `format`, `weekdays`, `difftime`,
+// `Sys.Date`) are exercised through R/S syntax in the `lib.rs` test module and in
+// `r-runtime`. Here we test the *pure* kernel and parse/format helpers directly,
+// since they are private to this module — especially the round-trip invariant
+// `civil_from_days(days_from_civil(y,m,d)) == (y,m,d)` over leap and pre-epoch
+// dates, and the parse-safety guards (malformed → None, never a panic).
+#[cfg(test)]
+mod date_tests {
+    use super::*;
+
+    /// Known fixed points: the epoch and its neighbours, anchoring the convention
+    /// that day 0 is 1970-01-01 and day -1 is the day before.
+    #[test]
+    fn epoch_anchor_points() {
+        assert_eq!(days_from_civil(1970, 1, 1), 0);
+        assert_eq!(days_from_civil(1970, 1, 2), 1);
+        assert_eq!(days_from_civil(1969, 12, 31), -1);
+        assert_eq!(civil_from_days(0), (1970, 1, 1));
+        assert_eq!(civil_from_days(1), (1970, 1, 2));
+        assert_eq!(civil_from_days(-1), (1969, 12, 31));
+    }
+
+    /// The exact-inverse invariant across leap days, century boundaries, and
+    /// deep pre-epoch / post-epoch dates — the property that makes the kernel
+    /// trustworthy.
+    #[test]
+    fn civil_days_round_trip() {
+        let cases = [
+            (1970, 1, 1),
+            (1969, 12, 31),
+            (2000, 2, 29), // leap day (divisible by 400)
+            (2020, 2, 29), // leap day (divisible by 4, not 100)
+            (1900, 3, 1),  // 1900 is NOT a leap year (divisible by 100, not 400)
+            (2021, 3, 14),
+            (1, 1, 1),
+            (1899, 12, 31),
+            (2400, 12, 31),
+            (-1, 12, 31), // proleptic, year before year 0
+        ];
+        for (y, m, d) in cases {
+            let z = days_from_civil(y, m, d);
+            assert_eq!(
+                civil_from_days(z),
+                (y, m, d),
+                "round-trip failed for {y}-{m}-{d} (z={z})"
+            );
+        }
+    }
+
+    /// 1900 was not a leap year (the divisible-by-100-but-not-400 rule), so
+    /// 1900-02-28 + 1 day is March 1, not February 29.
+    #[test]
+    fn non_leap_century() {
+        let feb28 = days_from_civil(1900, 2, 28);
+        assert_eq!(civil_from_days(feb28 + 1), (1900, 3, 1));
+    }
+
+    #[test]
+    fn parse_iso_default() {
+        assert_eq!(parse_date_str("1970-01-01", "%Y-%m-%d"), Some(0));
+        assert_eq!(parse_date_str("1970-01-02", "%Y-%m-%d"), Some(1));
+        assert_eq!(parse_date_str("1969-12-31", "%Y-%m-%d"), Some(-1));
+        assert_eq!(parse_date_str("2021-03-14", "%Y-%m-%d"), Some(18700));
+    }
+
+    #[test]
+    fn parse_slash_format() {
+        assert_eq!(
+            parse_date_str("2021/03/14", "%Y/%m/%d"),
+            parse_date_str("2021-03-14", "%Y-%m-%d")
+        );
+    }
+
+    /// Malformed, out-of-range, and adversarial inputs must all yield `None`
+    /// (→ NA at the builtin level) and never panic or overflow.
+    #[test]
+    fn parse_rejects_garbage() {
+        assert_eq!(parse_date_str("not-a-date", "%Y-%m-%d"), None);
+        assert_eq!(parse_date_str("2021-13-01", "%Y-%m-%d"), None); // month 13
+        assert_eq!(parse_date_str("2021-02-30", "%Y-%m-%d"), None); // impossible day
+        assert_eq!(parse_date_str("2021-00-10", "%Y-%m-%d"), None); // month 0
+        assert_eq!(parse_date_str("2021-03-14 ", "%Y-%m-%d"), None); // trailing space
+        assert_eq!(parse_date_str("2021-03", "%Y-%m-%d"), None); // missing day
+        assert_eq!(parse_date_str("", "%Y-%m-%d"), None); // empty
+                                                          // A million digits cannot overflow i64 — the digit cap refuses it.
+        let huge = "9".repeat(1_000_000);
+        assert_eq!(parse_date_str(&format!("{huge}-01-01"), "%Y-%m-%d"), None);
+    }
+
+    #[test]
+    fn format_iso_and_fields() {
+        assert_eq!(format_date_days(0, "%Y-%m-%d"), "1970-01-01");
+        assert_eq!(format_date_days(18700, "%Y-%m-%d"), "2021-03-14");
+        // Leap-day round-trip through the formatter.
+        let leap = days_from_civil(2000, 2, 29);
+        assert_eq!(format_date_days(leap, "%Y-%m-%d"), "2000-02-29");
+        // %j day-of-year: Jan 1 is 001; Mar 14 2021 (non-leap) is day 73.
+        assert_eq!(format_date_days(days_from_civil(2021, 1, 1), "%j"), "001");
+        assert_eq!(format_date_days(18700, "%j"), "073");
+    }
+
+    /// Negative (pre-epoch) day counts must format without panicking.
+    #[test]
+    fn format_pre_epoch() {
+        assert_eq!(format_date_days(-1, "%Y-%m-%d"), "1969-12-31");
     }
 }

--- a/code/packages/rust/s-runtime/src/builtins.rs
+++ b/code/packages/rust/s-runtime/src/builtins.rs
@@ -1629,6 +1629,33 @@ fn civil_from_days(z: i64) -> (i64, i64, i64) {
 /// far from overflow while still admitting any realistic year.
 const MAX_DATE_DIGITS: usize = 9;
 
+/// The largest magnitude (in days) we admit for a `Date`'s day count. Beyond this
+/// the civil-date kernel's internal multiplications/additions (`z + 719468`,
+/// `era * 146097`, `z - days_from_civil(y, 1, 1)`) could approach `i64` overflow,
+/// and a `weekdays`/`format` call would panic (debug) or wrap to a nonsense date
+/// (release). ±1e11 days is year ≈ ±270 million — astronomically beyond any real
+/// use — yet keeps every kernel operation comfortably inside `i64`. This is the
+/// numeric counterpart to [`MAX_DATE_DIGITS`]: the string parser caps the *year*,
+/// this caps a directly-supplied *day count* (`as.Date(1e300)`), so **neither**
+/// untrusted path can drive an out-of-range `z` into the kernel.
+const MAX_DATE_DAYS: i64 = 100_000_000_000;
+
+/// Clamp-or-reject a raw day count: `Some(z)` if it is finite and within
+/// [`MAX_DATE_DAYS`], else `None` (→ NA). Used at every boundary where an
+/// untrusted `f64` becomes a Date day count, so the civil kernel only ever sees
+/// in-range values and can never overflow.
+fn checked_date_days(v: f64) -> Option<i64> {
+    if is_na_real(v) || !v.is_finite() {
+        return None;
+    }
+    let z = v.trunc();
+    if z.abs() > MAX_DATE_DAYS as f64 {
+        None
+    } else {
+        Some(z as i64)
+    }
+}
+
 /// Is `x` a Date — a value whose (explicit) class vector contains "Date"?
 fn is_date(x: &SValue) -> bool {
     class_of(x).iter().any(|c| c == "Date")
@@ -1784,10 +1811,17 @@ fn b_as_date(_interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
             .collect(),
         other => {
             // Numeric (or coercible) input → days since epoch, truncated to whole
-            // days (R stores Dates as doubles but they are integral here).
+            // days (R stores Dates as doubles but they are integral here). An
+            // out-of-range or non-finite count (e.g. `as.Date(1e300)`) becomes NA
+            // rather than saturating to `i64::MAX` and overflowing the kernel — the
+            // numeric counterpart to the string parser's digit cap.
             let d = other.as_double()?;
             d.iter()
-                .map(|v| if is_na_real(v) { na_real() } else { v.trunc() })
+                .map(|v| {
+                    checked_date_days(v)
+                        .map(|z| z as f64)
+                        .unwrap_or_else(na_real)
+                })
                 .collect()
         }
     };
@@ -1830,13 +1864,10 @@ fn b_format_date(_interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
     let days = x.as_double()?;
     let out: Vec<Option<String>> = days
         .iter()
-        .map(|v| {
-            if is_na_real(v) {
-                None
-            } else {
-                Some(format_date_days(v.trunc() as i64, &format))
-            }
-        })
+        // `checked_date_days` rejects NA / non-finite / out-of-range counts → NA,
+        // so an out-of-range day (e.g. a hand-built `structure(1e300, class="Date")`)
+        // can never overflow the civil kernel in `format_date_days`.
+        .map(|v| checked_date_days(v).map(|z| format_date_days(z, &format)))
         .collect();
     Ok(SValue::Character(out))
 }
@@ -1877,15 +1908,14 @@ fn b_weekdays(_interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
     let out: Vec<Option<String>> = days
         .iter()
         .map(|v| {
-            if is_na_real(v) {
-                None
-            } else {
-                let z = v.trunc() as i64;
+            // `checked_date_days` rejects NA / non-finite / out-of-range counts → NA,
+            // so `z + 4` below can never overflow (which would panic for i64::MAX).
+            checked_date_days(v).map(|z| {
                 // Day 0 = Thursday = index 4 (Sunday-based). rem_euclid keeps the
                 // index in 0..7 even for negative z (pre-epoch).
                 let idx = (z + 4).rem_euclid(7) as usize;
-                Some(NAMES[idx].to_string())
-            }
+                NAMES[idx].to_string()
+            })
         })
         .collect();
     Ok(SValue::Character(out))

--- a/code/packages/rust/s-runtime/src/lib.rs
+++ b/code/packages/rust/s-runtime/src/lib.rs
@@ -1434,6 +1434,115 @@ mod tests {
             vec![1.0]
         );
     }
+
+    // --- R-44: base R Date support (through S syntax) -------------------------
+
+    /// The character elements of a (possibly classed) result, NA → "NA".
+    fn date_strs(src: &str) -> Vec<String> {
+        eval_s(src)
+            .unwrap()
+            .as_character()
+            .into_iter()
+            .map(|o| o.unwrap_or_else(|| "NA".to_string()))
+            .collect()
+    }
+
+    #[test]
+    fn date_class_is_date() {
+        assert_eq!(date_strs("class(as.Date(\"2021-03-14\"))\n"), vec!["Date"]);
+    }
+
+    #[test]
+    fn date_as_numeric_is_days_since_epoch() {
+        assert_eq!(nums("as.numeric(as.Date(\"1970-01-01\"))\n"), vec![0.0]);
+        assert_eq!(nums("as.numeric(as.Date(\"1970-01-02\"))\n"), vec![1.0]);
+        assert_eq!(nums("as.numeric(as.Date(\"1969-12-31\"))\n"), vec![-1.0]);
+    }
+
+    #[test]
+    fn date_format_round_trips() {
+        assert_eq!(show("format(as.Date(\"2021-03-14\"))\n"), "[1] \"2021-03-14\"");
+        // Leap day survives the parse → format round-trip.
+        assert_eq!(show("format(as.Date(\"2000-02-29\"))\n"), "[1] \"2000-02-29\"");
+    }
+
+    #[test]
+    fn date_numeric_origin_is_epoch() {
+        // as.Date(0) is 1970-01-01; as.Date(1) is the next day.
+        assert_eq!(show("format(as.Date(0))\n"), "[1] \"1970-01-01\"");
+        assert_eq!(show("format(as.Date(1))\n"), "[1] \"1970-01-02\"");
+    }
+
+    #[test]
+    fn date_slash_format_parses() {
+        assert_eq!(
+            nums("as.numeric(as.Date(\"2021/03/14\", format = \"%Y/%m/%d\"))\n"),
+            nums("as.numeric(as.Date(\"2021-03-14\"))\n")
+        );
+    }
+
+    #[test]
+    fn date_malformed_is_na() {
+        // An unparseable string becomes NA — never an error/panic.
+        assert_eq!(show("as.numeric(as.Date(\"not-a-date\"))\n"), "[1] NA");
+        assert_eq!(show("as.numeric(as.Date(\"2021-02-30\"))\n"), "[1] NA");
+    }
+
+    #[test]
+    fn date_subtraction_is_day_count() {
+        assert_eq!(
+            nums("as.Date(\"2021-03-20\") - as.Date(\"2021-03-14\")\n"),
+            vec![6.0]
+        );
+        // difftime() is the named form, same result in days.
+        assert_eq!(
+            nums("difftime(as.Date(\"2021-03-20\"), as.Date(\"2021-03-14\"))\n"),
+            vec![6.0]
+        );
+    }
+
+    #[test]
+    fn weekdays_anchor_and_names() {
+        // 1970-01-01 was a Thursday (the anchor).
+        assert_eq!(date_strs("weekdays(as.Date(\"1970-01-01\"))\n"), vec!["Thursday"]);
+        assert_eq!(date_strs("weekdays(as.Date(\"2021-03-14\"))\n"), vec!["Sunday"]);
+        // Pre-epoch (negative day count) must not panic.
+        assert_eq!(
+            date_strs("weekdays(as.Date(\"1969-12-31\"))\n"),
+            vec!["Wednesday"]
+        );
+    }
+
+    #[test]
+    fn date_format_day_of_year() {
+        assert_eq!(
+            show("format(as.Date(\"2021-03-14\"), \"%j\")\n"),
+            "[1] \"073\""
+        );
+    }
+
+    #[test]
+    fn date_is_vectorized() {
+        assert_eq!(
+            nums("as.numeric(as.Date(c(\"1970-01-01\", \"1970-01-03\")))\n"),
+            vec![0.0, 2.0]
+        );
+        assert_eq!(
+            date_strs("weekdays(as.Date(c(\"1970-01-01\", \"1970-01-02\")))\n"),
+            vec!["Thursday", "Friday"]
+        );
+    }
+
+    #[test]
+    fn sys_date_structure_only() {
+        // Non-deterministic value: assert only its class and that it is a single
+        // finite numeric — never an exact day.
+        assert_eq!(date_strs("class(Sys.Date())\n"), vec!["Date"]);
+        assert_eq!(nums("length(Sys.Date())\n"), vec![1.0]);
+        let day = nums("as.numeric(Sys.Date())\n");
+        assert_eq!(day.len(), 1);
+        assert!(day[0].is_finite());
+    }
 }
 
 #[cfg(test)]

--- a/code/packages/rust/s-runtime/src/lib.rs
+++ b/code/packages/rust/s-runtime/src/lib.rs
@@ -1534,6 +1534,21 @@ mod tests {
     }
 
     #[test]
+    fn date_extreme_numeric_is_na_not_overflow() {
+        // A huge / non-finite day count must become NA (the numeric counterpart to
+        // the string digit cap) — never an i64-overflow panic in the civil kernel.
+        assert_eq!(show("as.numeric(as.Date(1e300))\n"), "[1] NA");
+        assert_eq!(show("format(as.Date(1e300))\n"), "[1] NA");
+        assert_eq!(show("weekdays(as.Date(1e300))\n"), "[1] NA");
+        assert_eq!(show("format(as.Date(-1e300), \"%j\")\n"), "[1] NA");
+        // A hand-built classed "Date" with an out-of-range raw count is also safe.
+        assert_eq!(
+            show("weekdays(structure(1e300, class = \"Date\"))\n"),
+            "[1] NA"
+        );
+    }
+
+    #[test]
     fn sys_date_structure_only() {
         // Non-deterministic value: assert only its class and that it is a single
         // finite numeric — never an exact day.

--- a/code/specs/R00-r-language.md
+++ b/code/specs/R00-r-language.md
@@ -1404,6 +1404,61 @@ unchanged.
     ≥ 3.6) by reusing the existing RE2-based `regex` engine. Nothing in the family
     remains deferred.
 
+- **R-44 — base R Date support** *(this PR)*. A first calendar type. In R a
+  **`Date`** is *not* a new value kind: it is an ordinary numeric vector — the
+  count of **days since the Unix epoch `1970-01-01`** — carrying the S3 class
+  attribute `"Date"`. We model it with the existing transparent
+  `SValue::Classed { inner: Double, class: ["Date"] }` wrapper (the same R-13/S-v2
+  machinery factors and explicit S3 classes already use), so **no new `SValue`
+  variant** is introduced and every coercion (`as_double`, `as_character`,
+  `as_logical`) already sees straight through to the day count. Concretely:
+  - **`Sys.Date()`** — today's date as a length-1 `Date`. The runtime has no
+    pre-existing deterministic clock hook (no `Sys.time`/`now` abstraction exists
+    yet), so this reads the wall clock via `std::time::SystemTime::now()` and
+    converts the elapsed duration to whole days since the epoch (`UNIX_EPOCH`).
+    A clock before the epoch (negative duration) is handled without panic. Because
+    the value is non-deterministic, tests assert only its **structure** — `class()`
+    is `"Date"` and it is a single finite numeric — never an exact day.
+  - **`as.Date(x, format =)`** — parse a **character** vector to `Date`, or wrap a
+    **numeric** vector as days-since-epoch directly (`as.Date(0)` → `1970-01-01`).
+    Character parsing supports the default ISO `"%Y-%m-%d"` and, via `format =`,
+    at least `"%Y/%m/%d"`; the recognised fields are `%Y` (year), `%m` (month),
+    `%d` (day), plus literal separators. Unparseable / malformed / out-of-range
+    strings become `NA` (**never** a panic). Vectorised over the input.
+  - **`format.Date(d, format =)` / `format(d, fmt)`** — render a `Date` back to a
+    string. The default format is `"%Y-%m-%d"`; the supported fields are `%Y`,
+    `%m`, `%d`, and `%j` (zero-padded day-of-year, 001..366). `format()` detects
+    the `"Date"` class and dispatches to the Date renderer; on any other value it
+    is unchanged.
+  - **`difftime(d1, d2)` and `d1 - d2`** — the difference in **days** between two
+    `Date`s, as a numeric. Subtraction needs no special case: `arithmetic("-", …)`
+    already coerces both operands through `as_double` (the `Classed` wrapper is
+    transparent), so `as.Date("2021-03-20") - as.Date("2021-03-14")` is `6`
+    automatically. `difftime` is the named builtin form (units = days only here).
+    `as.numeric(d)` yields the raw days-since-epoch.
+  - **`weekdays(d)`** — the English weekday name (`"Monday"`..`"Sunday"`). The
+    anchor is the historical fact that **`1970-01-01` was a Thursday**; the index
+    is `(days + 3).rem_euclid(7)` so **pre-epoch (negative) day counts** map
+    correctly (Rust's `%` can go negative — `rem_euclid` cannot).
+  - **The civil-date kernel.** Two pure helpers implement the calendar with **no
+    new dependency**, using Howard Hinnant's well-known algorithms:
+    `days_from_civil(y, m, d)` → days since the epoch (handles the proleptic
+    Gregorian calendar, leap years, and negative/pre-epoch dates via the
+    era/year-of-era/day-of-era decomposition), and `civil_from_days(z)` → `(y, m,
+    d)`. They are exact inverses; round-trips are unit-tested across leap days
+    (`2000-02-29`, `2020-02-29`) and pre-epoch dates (`1969-12-31` → `-1`).
+  - **Parse-safety.** Untrusted date strings are parsed with **bounded** integer
+    accumulation in `i64` (a digit cap rejects absurd years before they can
+    overflow the day arithmetic; the civil conversion uses `i64` throughout), so
+    no crafted string can overflow or panic — it degrades to `NA`. All weekday /
+    day-of-year modulo math uses `rem_euclid` so negative day counts never panic.
+  - **Deferred to R-45.** Full `strptime`/`strftime` field coverage (`%B`, `%A`,
+    `%H`, `%M`, `%S`, `%p`, locale names, …); `POSIXct`/`POSIXlt` date-*times* and
+    timezones; `seq.Date`; `months()` / `quarters()`; and `difftime` units other
+    than days. The core (`as.Date` for `%Y-%m-%d`/`%Y/%m/%d`, `Sys.Date`,
+    `format.Date` for `%Y`/`%m`/`%d`/`%j`, Date subtraction + `difftime` in days,
+    and `weekdays`) ships **solidly** here.
+
 ## §4 Reuse strategy
 
 - **Lexer/parser:** the grammar-tools framework, exactly as S uses it. `r.tokens`

--- a/code/specs/S00-s-language.md
+++ b/code/specs/S00-s-language.md
@@ -620,6 +620,45 @@ essential: `switch("a", a = stop("no"), b = "ok")` must not raise, and a
      prefix — `0x`/`0X` → hex, a leading `0` followed by another digit → octal (so
      `"08"` → `NA`), a lone `"0"` → zero, otherwise decimal. `strtoi("0x1F", 0L)` →
      `31`; `strtoi("010", 0L)` → `8`; `strtoi("12", 0L)` → `12`.
+11. **Base R Date support (R-44, shared builtins).** `s-runtime` gains the base R
+   calendar type and its builtins, which R (R-44) reuses verbatim through the
+   shared tree-walker. A **`Date`** introduces **no new `SValue` variant**: it is a
+   numeric vector of **days since the Unix epoch `1970-01-01`** wrapped in the
+   existing transparent `SValue::Classed { inner: Double, class: ["Date"] }`
+   (the same wrapper explicit S3 classes already use). Because `Classed` is
+   see-through, every coercion (`as_double`/`as_character`/`as_logical`) and the
+   `arithmetic` kernel already reach the day count with no special case.
+   - **The civil-date kernel.** Two pure, dependency-free helpers implement the
+     proleptic Gregorian calendar with Howard Hinnant's algorithms:
+     `days_from_civil(y, m, d)` → days since the epoch (era / year-of-era /
+     day-of-era decomposition; handles leap years and negative/pre-epoch dates)
+     and its exact inverse `civil_from_days(z)` → `(y, m, d)`. Round-trips are
+     unit-tested across leap days (`2000-02-29`, `2020-02-29`) and pre-epoch dates
+     (`1969-12-31` → `-1`).
+   - **`as.Date(x, format =)`** — parse a character vector (default `"%Y-%m-%d"`,
+     or `"%Y/%m/%d"` etc. via `format =`, recognising `%Y`/`%m`/`%d` + literals),
+     or wrap a numeric vector as days-since-epoch directly. Malformed / out-of-range
+     input → `NA`. Vectorised.
+   - **`format.Date(d, format =)` / `format(d, fmt)`** — render a `Date` to a
+     string; default `"%Y-%m-%d"`, fields `%Y`/`%m`/`%d`/`%j` (day-of-year). The
+     shared `format` builtin detects the `"Date"` class and dispatches here.
+   - **`Sys.Date()`** — today as a length-1 `Date`. There is no pre-existing
+     deterministic clock in the runtime, so this reads `SystemTime::now()` and
+     converts to whole days since `UNIX_EPOCH` (pre-epoch handled without panic).
+     Non-deterministic, so tested only for structure (class + single numeric).
+   - **`difftime(d1, d2)` / `d1 - d2`** — difference in **days** (numeric).
+     Subtraction needs no special case (the `Classed` wrapper is transparent to
+     `arithmetic`). `as.numeric(d)` returns the raw day count; **`as.numeric`** is
+     added as a base coercion (drops the class, reusing `as_double`).
+   - **`weekdays(d)`** — English weekday name; anchored on `1970-01-01 = Thursday`
+     with `(days + 3).rem_euclid(7)` so pre-epoch (negative) counts never panic.
+   - **Security.** Untrusted date strings parse with **bounded `i64`** digit
+     accumulation (a digit cap rejects absurd years before the day arithmetic can
+     overflow); malformed/over-range input → `NA`, never a panic. All weekday /
+     day-of-year modulo uses `rem_euclid` (Rust `%` can go negative).
+   - **Deferred to R-45.** Full `strptime`/`strftime` fields (`%B`/`%A`/`%H`/…);
+     `POSIXct`/`POSIXlt` date-times & timezones; `seq.Date`; `months()`/`quarters()`;
+     `difftime` units other than days.
 
 ## §10 References
 


### PR DESCRIPTION
## R-44 — base R Date support

Adds R's first calendar type to the shared `s-runtime` tree-walker (reused
verbatim by `r-runtime`), reachable through both S and R syntax.

### Date representation
A **`Date`** is **not** a new value kind. It is an ordinary numeric vector of
**days since the Unix epoch `1970-01-01`** carrying the S3 class `"Date"`,
modelled with the existing transparent
`SValue::Classed { inner: Double, class: ["Date"] }` wrapper (the same machinery
factors and explicit S3 classes already use). **No new `SValue` variant** — so
every coercion (`as_double`/`as_character`) and the `arithmetic` kernel already
see straight through to the day count. Day 0 = 1970-01-01, day 1 = 1970-01-02,
day -1 = 1969-12-31.

### Builtins
- **`as.Date(x, format = "%Y-%m-%d")`** — parse a character vector (default ISO
  `"%Y-%m-%d"`, or `"%Y/%m/%d"` and similar via `format =`; fields `%Y`/`%m`/`%d`
  + literal separators) or wrap a numeric vector directly as days-since-epoch
  (`as.Date(0)` → 1970-01-01). Malformed / out-of-range strings → `NA`.
- **`format.Date(d, format =)` and the `format()` generic** — render with
  `%Y`/`%m`/`%d`/`%j` (day-of-year), default `"%Y-%m-%d"`. `format()` detects the
  `"Date"` class and dispatches.
- **`Sys.Date()`** — today, from `SystemTime::now()` (days since `UNIX_EPOCH`,
  pre-epoch handled). Non-deterministic — tested for structure only.
- **`difftime(d1, d2)` and `d1 - d2`** — difference in **days** (numeric).
- **`weekdays(d)`** — English weekday name, anchored on 1970-01-01 = Thursday.
- **`as.numeric` / `as.double`** — base coercions (a Date → days-since-epoch; a
  factor → codes), so `as.numeric(date)` returns the raw day count.

### Civil-date algorithm (no new dependency)
Two pure helpers implement the proleptic Gregorian calendar with Howard
Hinnant's well-known algorithms: `days_from_civil(y, m, d)` (era / year-of-era /
day-of-era decomposition; handles leap years and negative/pre-epoch dates) and
its exact inverse `civil_from_days(z)`. Round-trips are unit-tested across leap
days (2000-02-29, 2020-02-29), the 1900 non-leap century, and pre-epoch dates
(1969-12-31 → -1).

### Parse-safety guards
- Untrusted date **strings** parse with **bounded `i64`** digit accumulation
  (`MAX_DATE_DIGITS` caps the year before the day arithmetic can overflow);
  impossible days (e.g. 2021-02-30) are rejected via a civil round-trip;
  malformed input → `NA`, never a panic.
- A directly-supplied **numeric** day count is clamped to ±1e11 days
  (`checked_date_days`, → `NA` if out of range), so `as.Date(1e300)` cannot
  saturate to `i64::MAX` and overflow the civil kernel. `format`/`weekdays`
  defend the same bound, so a hand-built `structure(1e300, class="Date")` is also
  safe. (Found and fixed during security review.)
- All weekday / day-of-year modulo uses `rem_euclid` (Rust `%` can go negative on
  pre-epoch counts).

### Deferred to R-45
Full `strptime`/`strftime` field coverage (`%B`/`%A`/`%H`/`%M`/`%S`/…);
`POSIXct`/`POSIXlt` date-times and timezones; `seq.Date`; `months()`/`quarters()`;
and `difftime` units other than days.

### Tests
`cargo test -p coding-adventures-s-runtime -p coding-adventures-r-runtime` — all
green. s-runtime: 312 lib tests (incl. the civil-date kernel + parse/format
guards as direct unit tests) + 278 doc/value/error; r-runtime: 278 (Date
behaviour through R syntax). Security review passed (HIGH overflow finding fixed
and re-reviewed clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)