### PR TITLE
feat(visicalc-html): insert / delete rows & columns in the web demo

### DIFF
--- a/demo/visicalc-html/README.md
+++ b/demo/visicalc-html/README.md
@@ -39,13 +39,21 @@ it through a C ABI.)
 > (`workbook.undo`/`redo`, gated by `canUndo`/`canRedo`): every edit is
 > reversible, a restored formula recomputes live, and a fresh edit forks history
 > (drops the redo branch).
+> The **+ Row / − Row / + Col / − Col** buttons are **structural edits**
+> (`workbook.insertRows`/`deleteRows`/`insertCols`/`deleteCols`): insert or
+> delete the selected cell's row/column, and the engine shifts every formula
+> reference at or after the band so dependents keep pointing at their precedents
+> (`=A1+A2` with a row inserted above becomes `=A1+A3`); a reference whose whole
+> band is deleted becomes `#REF!`.
 > Headless proof: `node scripts/verify-infinite.mjs` replays the exact windowing
 > math against the committed WASM bundle and asserts the render stays bounded,
 > the formatted display strings are correct, a formula 1000 rows down is
 > reachable, the gaps are empty (sparse), an edit's diff reaches the far cell
 > that depends on it, a save → mutate → load round trip restores the
-> workbook (formulas recompute live; garbage input is rejected), and an
-> undo/redo walk reverses two edits then replays them with the formula live.
+> workbook (formulas recompute live; garbage input is rejected), an
+> undo/redo walk reverses two edits then replays them with the formula live, and
+> an insert/delete row & column round trip shifts a formula's references (and
+> turns a reference into `#REF!` when its row is deleted).
 
 ## Design language
 
@@ -60,8 +68,8 @@ page's `:root` so the whole surface reads as one considered panel:
   formula field use the mono font.
 - **Toolbar** — an address **pill**, an `fx` marker, then a grown formula field
   with an accent **focus ring**; actions are **segmented button groups**
-  (drag-fill · clipboard · file · history) separated by thin rules, each with
-  hover/active/disabled states.
+  (drag-fill · clipboard · file · structure · history) separated by thin rules,
+  each with hover/active/disabled states.
 - **Grid** — subtle **zebra** row banding, a 2-px **accent selection ring**, and
   the selected cell's **row + column headers tint to the accent** so the
   cursor's position reads at a glance.

--- a/demo/visicalc-html/infinite.html
+++ b/demo/visicalc-html/infinite.html
@@ -184,6 +184,13 @@
         <button id="loadBook" title="Reload the workbook from the last saved snapshot">Load</button>
       </div>
       <span class="sep"></span>
+      <div class="grp" role="group" aria-label="Structure">
+        <button id="insRow" title="Insert a row above the selected cell (references shift down)">+ Row</button>
+        <button id="delRow" title="Delete the selected cell's row (references shift up; refs into it become #REF!)">− Row</button>
+        <button id="insCol" title="Insert a column left of the selected cell (references shift right)">+ Col</button>
+        <button id="delCol" title="Delete the selected cell's column (references shift left; refs into it become #REF!)">− Col</button>
+      </div>
+      <span class="sep"></span>
       <div class="grp" role="group" aria-label="History">
         <button id="undoBtn" title="Undo the last edit">↶ Undo</button>
         <button id="redoBtn" title="Redo the last undone edit">↷ Redo</button>
@@ -372,6 +379,31 @@
         diff.changed.length + " cell(s): " + diff.changed.slice(0, 8).join(", ");
       render();
       statusEl.innerHTML += " &nbsp;·&nbsp; pasted at " + esc(dst) + " → " + esc(note);
+    });
+
+    // Structural edits: insert / delete the selected cell's row or column. The
+    // engine shifts every formula reference at or after the band and recomputes;
+    // a reference whose entire band is deleted becomes #REF!. We operate on a
+    // single row/column at the cursor (the engine handles any count).
+    document.getElementById("insRow").addEventListener("click", function () {
+      workbook.insertRows(selRow, 1);
+      render();
+      statusEl.innerHTML += " &nbsp;·&nbsp; inserted a row at " + selRow;
+    });
+    document.getElementById("delRow").addEventListener("click", function () {
+      workbook.deleteRows(selRow, 1);
+      render();
+      statusEl.innerHTML += " &nbsp;·&nbsp; deleted row " + selRow;
+    });
+    document.getElementById("insCol").addEventListener("click", function () {
+      workbook.insertCols(selCol, 1);
+      render();
+      statusEl.innerHTML += " &nbsp;·&nbsp; inserted a column at " + esc(workbook.columnLetters(selCol));
+    });
+    document.getElementById("delCol").addEventListener("click", function () {
+      workbook.deleteCols(selCol, 1);
+      render();
+      statusEl.innerHTML += " &nbsp;·&nbsp; deleted column " + esc(workbook.columnLetters(selCol));
     });
 
     // Save / load: serialize the whole workbook to a single JSON document and

--- a/demo/visicalc-html/scripts/verify-infinite.mjs
+++ b/demo/visicalc-html/scripts/verify-infinite.mjs
@@ -194,5 +194,41 @@ wbh.undo(); // back to A1=1, B1 gone
 wbh.setCell("C1", "9");
 ok(wbh.canRedo() === false, "a fresh edit clears the redo branch");
 
+// Structural edits (the + Row / − Row / + Col / − Col buttons): inserting and
+// deleting rows shifts every formula reference across the band, and deleting a
+// referenced band turns that reference into #REF!. Fresh session for clarity.
+const wbs = sandbox.window.SpreadsheetEngine.createSpreadsheet();
+wbs.setCell("A1", "10");
+wbs.setCell("A2", "20");
+wbs.setCell("A3", "=A1+A2"); // 30
+ok(wbs.getDisplayWindow(3, 1, 3, 1).cells[0][0] === "30", "A3 = A1+A2 = 30 before any structural edit");
+// Insert a row at row 2: the old A2/A3 shift down to A3/A4, the inserted row is
+// blank, and the formula's refs shift with their cells (=A1+A2 → =A1+A3).
+// The engine's formula printer parenthesizes binary ops (=A1+A3 prints as
+// "=(A1+A3)"), so compare with the parens stripped.
+const bareRaw = (a1) => wbs.getRaw(a1).replace(/[()]/g, "");
+wbs.insertRows(2, 1);
+ok(wbs.getDisplayWindow(2, 1, 2, 1).cells[0][0] === "", "insertRows(2): the inserted row 2 is blank");
+ok(bareRaw("A4") === "=A1+A3", `insertRows shifted the formula's refs: ${wbs.getRaw("A4")}`);
+ok(wbs.getDisplayWindow(4, 1, 4, 1).cells[0][0] === "30", "insertRows: formula moved to A4, still = 30");
+// Delete that inserted row: everything shifts back to where it started.
+wbs.deleteRows(2, 1);
+ok(bareRaw("A3") === "=A1+A2", `deleteRows shifted the formula's refs back: ${wbs.getRaw("A3")}`);
+ok(wbs.getDisplayWindow(3, 1, 3, 1).cells[0][0] === "30", "deleteRows: formula back at A3, = 30");
+// Delete row 1 (a row the formula references): the surviving A2 shifts up to A1,
+// the formula shifts up to A2, and its now-destroyed A1 reference becomes #REF!.
+wbs.deleteRows(1, 1);
+ok(wbs.getDisplayWindow(2, 1, 2, 1).cells[0][0] === "#REF!",
+  `deleting a referenced row yields #REF!: ${wbs.getDisplayWindow(2, 1, 2, 1).cells[0][0]}`);
+// Columns shift the same way: a formula one column right of an inserted column
+// keeps pointing at its precedents.
+const wbc = sandbox.window.SpreadsheetEngine.createSpreadsheet();
+wbc.setCell("A1", "5");
+wbc.setCell("B1", "=A1*3"); // 15
+wbc.insertCols(1, 1); // insert a column at A: A1→B1, B1(formula)→C1, refs shift
+ok(wbc.getRaw("C1") === "=(B1*3)" || wbc.getRaw("C1") === "=B1*3",
+  `insertCols shifted the formula's column refs: ${wbc.getRaw("C1")}`);
+ok(wbc.getDisplayWindow(1, 3, 1, 3).cells[0][0] === "15", "insertCols: formula moved to C1, still = 15");
+
 console.log(fail === 0 ? "\nALL PASS" : `\n${fail} FAILURE(S)`);
 process.exit(fail ? 1 : 0);

--- a/demo/visicalc-html/vendor/spreadsheet-engine-wasm.js
+++ b/demo/visicalc-html/vendor/spreadsheet-engine-wasm.js
@@ -169,6 +169,15 @@ var __SPREADSHEET_WASM_B64__ = "AGFzbQEAAAABqAIrYAF/AX9gAX8AYAJ/fwF/YAJ/fwBgA39/
           canUndo: () => ex.can_undo() === 1,
           canRedo: () => ex.can_redo() === 1,
 
+          // Structural edits: insert / delete `count` rows or columns at a
+          // 1-based position. The engine shifts every formula reference at or
+          // after the band (a ref inside a deleted band becomes #REF!), then
+          // recomputes. Re-read the window afterwards.
+          insertRows: (at, count) => ex.insert_rows(at >>> 0, count >>> 0),
+          deleteRows: (at, count) => ex.delete_rows(at >>> 0, count >>> 0),
+          insertCols: (at, count) => ex.insert_cols(at >>> 0, count >>> 0),
+          deleteCols: (at, count) => ex.delete_cols(at >>> 0, count >>> 0),
+
           // Viewport primitive — render only the visible window of an unbounded
           // sheet. 1-based inclusive coords.
           getWindow: (row0, col0, row1, col1) =>


### PR DESCRIPTION
## What

Starts the next cross-cutting feature (chosen by you): **insert / delete rows & columns**. The engine + all 3 facades **already implement** structural edits with full reference-shifting (`spreadsheet-core` `StructuralEdit`, core-wasm `insert_rows`/…, capi `sc_insert_rows`/…, wasm `insert_rows`/…). This PR rolls the capability out to the **demos**, web first — same shape as the fill / clipboard / save-load / undo-redo rollouts (web → Qt → Flutter → Compose → XAML → SwiftUI, one PR each).

## Changes

- **`vendor/spreadsheet-engine-wasm.js`** — four thin loader wrappers (`insertRows`/`deleteRows`/`insertCols`/`deleteCols`) forwarding two `u32`s to the already-exported WASM functions. The committed bundle **already exports** `insert_rows`/`delete_rows`/`insert_cols`/`delete_cols` (verified via `WebAssembly.Module.exports`), so **no `.wasm` rebuild** was needed.
- **`infinite.html`** — a new **"Structure"** segmented toolbar group (**+ Row / − Row / + Col / − Col**) between File and History, with click handlers that insert/delete the selected cell's row/column and re-render. The engine shifts every formula reference at or after the band so dependents keep pointing at their precedents; a reference whose whole band is deleted becomes `#REF!`.
- **`scripts/verify-infinite.mjs`** — a structural-edit proof: insert a row above a formula (`=A1+A2` → `=A1+A3`, value preserved), delete it back, then delete a referenced row (⇒ `#REF!`), plus a column insert that shifts a formula's column refs.
- **README** — document the new buttons + the headless assertion.

## Verification

- `node scripts/verify-infinite.mjs` — **ALL PASS** (incl. the new structural cases: `=(A1+A3)`, `=(A1+A2)`, `#REF!`, `=(B1*3)`).
- **Live** (preview server): all 4 buttons render, **no console errors**, and inserting a row at row 1 shifts the seeded budget down a row (`A1=15`/`E1=38.00` → row 2) with the formula totals intact — verified via DOM eval + screenshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)