### PR TITLE
Add smart-home runtime maintenance action tools

### DIFF
--- a/code/packages/rust/chief-of-staff-smart-home-tools/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/CHANGELOG.md
@@ -253,6 +253,10 @@ All notable changes to this package will be documented in this file.
   `smart_home.get_runtime_maintenance_window_summary` over the D23 runtime read
   facade so Chief of Staff jobs can group supervision remediation work into
   schedulable maintenance windows without owning platform mutation logic.
+- Added `smart_home.list_runtime_maintenance_actions` and
+  `smart_home.get_runtime_maintenance_action_summary` over the D23 runtime read
+  facade so Chief of Staff jobs can inspect execution-ordered maintenance
+  actions without owning platform mutation logic.
 - Added `smart_home.list_workers` and
   `smart_home.get_worker_heartbeat_schedule` over the D23 runtime read facade
   so Chief of Staff jobs can inspect supervised bridge workers and heartbeat

--- a/code/packages/rust/chief-of-staff-smart-home-tools/README.md
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/README.md
@@ -93,7 +93,7 @@ Chief of Staff job/session/agent
   -> runtime snapshot, desired-state, and pairing-session inventory reads
   -> desired-state target set/clear through runtime authorization
   -> non-mutating supervision plan previews
-  -> supervision remediation and runtime maintenance-window reads
+  -> supervision remediation and runtime maintenance-window/action reads
   -> authorized desired-state reconciliation and supervision ticks
   -> supervised worker inventory and heartbeat schedule reads
   -> device command acceptance
@@ -274,6 +274,8 @@ Chief of Staff job/session/agent
 - `smart_home.get_supervision_plan`
 - `smart_home.list_runtime_maintenance_windows`
 - `smart_home.get_runtime_maintenance_window_summary`
+- `smart_home.list_runtime_maintenance_actions`
+- `smart_home.get_runtime_maintenance_action_summary`
 - `smart_home.reconcile_desired_states`
 - `smart_home.run_supervision_tick`
 - `smart_home.pair_bridge`

--- a/code/packages/rust/chief-of-staff-smart-home-tools/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/src/lib.rs
@@ -324,6 +324,10 @@ pub const SMART_HOME_LIST_RUNTIME_MAINTENANCE_WINDOWS_TOOL_ID: &str =
     "smart_home.list_runtime_maintenance_windows";
 pub const SMART_HOME_GET_RUNTIME_MAINTENANCE_WINDOW_SUMMARY_TOOL_ID: &str =
     "smart_home.get_runtime_maintenance_window_summary";
+pub const SMART_HOME_LIST_RUNTIME_MAINTENANCE_ACTIONS_TOOL_ID: &str =
+    "smart_home.list_runtime_maintenance_actions";
+pub const SMART_HOME_GET_RUNTIME_MAINTENANCE_ACTION_SUMMARY_TOOL_ID: &str =
+    "smart_home.get_runtime_maintenance_action_summary";
 pub const SMART_HOME_SET_DESIRED_STATE_TOOL_ID: &str = "smart_home.set_desired_state";
 pub const SMART_HOME_CLEAR_DESIRED_STATE_TOOL_ID: &str = "smart_home.clear_desired_state";
 pub const SMART_HOME_LIST_PAIRING_SESSIONS_TOOL_ID: &str = "smart_home.list_pairing_sessions";
@@ -2399,6 +2403,24 @@ impl SmartHomeToolBridge {
                 SMART_HOME_GET_RUNTIME_MAINTENANCE_WINDOW_SUMMARY_TOOL_ID => {
                     let query = runtime_maintenance_window_query(&arguments)?;
                     get_runtime_maintenance_window_summary_output_handler_output(
+                        &mut runtime,
+                        principal_id,
+                        now_ms,
+                        query,
+                    )
+                }
+                SMART_HOME_LIST_RUNTIME_MAINTENANCE_ACTIONS_TOOL_ID => {
+                    let query = runtime_maintenance_action_query(&arguments)?;
+                    list_runtime_maintenance_actions_output_handler_output(
+                        &mut runtime,
+                        principal_id,
+                        now_ms,
+                        query,
+                    )
+                }
+                SMART_HOME_GET_RUNTIME_MAINTENANCE_ACTION_SUMMARY_TOOL_ID => {
+                    let query = runtime_maintenance_action_query(&arguments)?;
+                    get_runtime_maintenance_action_summary_output_handler_output(
                         &mut runtime,
                         principal_id,
                         now_ms,
@@ -6134,6 +6156,8 @@ pub fn smart_home_tool_definitions() -> Vec<ToolDefinition> {
         get_supervision_remediation_summary_definition(),
         list_runtime_maintenance_windows_definition(),
         get_runtime_maintenance_window_summary_definition(),
+        list_runtime_maintenance_actions_definition(),
+        get_runtime_maintenance_action_summary_definition(),
         set_desired_state_definition(),
         clear_desired_state_definition(),
         list_pairing_sessions_definition(),
@@ -7131,6 +7155,70 @@ fn get_runtime_maintenance_window_summary_definition() -> ToolDefinition {
         "Summarize schedulable Chief-visible maintenance windows for D23 supervision, state refresh, reconciliation, and discovery work.",
         runtime_maintenance_window_query_schema(),
         runtime_maintenance_window_summary_output_schema(),
+    )
+}
+
+fn runtime_maintenance_action_query_schema() -> JsonSchema {
+    object_schema(
+        vec![
+            SchemaProperty::new("window_kind", JsonSchema::String),
+            SchemaProperty::new("window_kinds", string_array_schema()),
+            SchemaProperty::new("remediation_kind", JsonSchema::String),
+            SchemaProperty::new("remediation_kinds", string_array_schema()),
+            SchemaProperty::new("risk_lane", JsonSchema::String),
+            SchemaProperty::new("recommended_tool", JsonSchema::String),
+            SchemaProperty::new("max_priority", JsonSchema::Integer),
+            SchemaProperty::new("blocked_only", JsonSchema::Boolean),
+            SchemaProperty::new("requires_attention_only", JsonSchema::Boolean),
+            SchemaProperty::new("limit", JsonSchema::Integer),
+        ],
+        vec![],
+        false,
+    )
+}
+
+fn runtime_maintenance_action_list_output_schema() -> JsonSchema {
+    object_schema(
+        vec![
+            SchemaProperty::new(
+                "runtime_maintenance_actions",
+                JsonSchema::Array {
+                    items: Box::new(JsonSchema::Any),
+                },
+            ),
+            SchemaProperty::new("summary", JsonSchema::Any),
+            SchemaProperty::new("count", JsonSchema::Integer),
+        ],
+        vec!["runtime_maintenance_actions", "summary", "count"],
+        false,
+    )
+}
+
+fn runtime_maintenance_action_summary_output_schema() -> JsonSchema {
+    object_schema(
+        vec![SchemaProperty::new("summary", JsonSchema::Any)],
+        vec!["summary"],
+        false,
+    )
+}
+
+fn list_runtime_maintenance_actions_definition() -> ToolDefinition {
+    read_definition(
+        SMART_HOME_LIST_RUNTIME_MAINTENANCE_ACTIONS_TOOL_ID,
+        "List smart-home runtime maintenance actions",
+        "List Chief action rows derived from D23 runtime supervision remediation without mutating the runtime.",
+        runtime_maintenance_action_query_schema(),
+        runtime_maintenance_action_list_output_schema(),
+    )
+}
+
+fn get_runtime_maintenance_action_summary_definition() -> ToolDefinition {
+    read_definition(
+        SMART_HOME_GET_RUNTIME_MAINTENANCE_ACTION_SUMMARY_TOOL_ID,
+        "Summarize smart-home runtime maintenance actions",
+        "Summarize Chief action rows derived from runtime maintenance windows and D23 supervision remediation.",
+        runtime_maintenance_action_query_schema(),
+        runtime_maintenance_action_summary_output_schema(),
     )
 }
 
@@ -8464,6 +8552,45 @@ fn runtime_maintenance_window_query(
             .into_iter()
             .map(|kind| parse_runtime_maintenance_window_kind(&kind))
             .collect::<Result<Vec<_>, _>>()?,
+        risk_lane: optional_string(arguments, "risk_lane")?,
+        recommended_tool: optional_string(arguments, "recommended_tool")?,
+        max_priority: optional_u64(arguments, "max_priority")?.map(|value| value as u8),
+        blocked_only: optional_bool(arguments, "blocked_only")?.unwrap_or(false),
+        requires_attention_only: optional_bool(arguments, "requires_attention_only")?
+            .unwrap_or(false),
+        limit: optional_u64(arguments, "limit")?.map(|value| value as usize),
+    })
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct RuntimeMaintenanceActionQuery {
+    window_kinds: Vec<RuntimeMaintenanceWindowKind>,
+    remediation_kinds: Vec<SupervisionRemediationKind>,
+    risk_lane: Option<String>,
+    recommended_tool: Option<String>,
+    max_priority: Option<u8>,
+    blocked_only: bool,
+    requires_attention_only: bool,
+    limit: Option<usize>,
+}
+
+fn runtime_maintenance_action_query(
+    arguments: &JsonValue,
+) -> Result<RuntimeMaintenanceActionQuery, ToolCallError> {
+    let _ = expect_object(arguments)?;
+    Ok(RuntimeMaintenanceActionQuery {
+        window_kinds: optional_string_list(arguments, "window_kind", "window_kinds")?
+            .into_iter()
+            .map(|kind| parse_runtime_maintenance_window_kind(&kind))
+            .collect::<Result<Vec<_>, _>>()?,
+        remediation_kinds: optional_string_list(
+            arguments,
+            "remediation_kind",
+            "remediation_kinds",
+        )?
+        .into_iter()
+        .map(|kind| parse_supervision_remediation_kind(&kind))
+        .collect::<Result<Vec<_>, _>>()?,
         risk_lane: optional_string(arguments, "risk_lane")?,
         recommended_tool: optional_string(arguments, "recommended_tool")?,
         max_priority: optional_u64(arguments, "max_priority")?.map(|value| value as u8),
@@ -35705,6 +35832,324 @@ fn runtime_maintenance_window_matches(
     true
 }
 
+#[derive(Debug, Clone, PartialEq)]
+struct RuntimeMaintenanceActionRow {
+    action_id: String,
+    remediation_id: String,
+    window_id: String,
+    window_kind: RuntimeMaintenanceWindowKind,
+    remediation_kind: SupervisionRemediationKind,
+    priority: u8,
+    execution_order: usize,
+    recommended_tool: &'static str,
+    recommended_action: &'static str,
+    bridge_id: Option<BridgeId>,
+    device_id: Option<DeviceId>,
+    entity_id: Option<EntityId>,
+    worker_id: Option<DiscoveryWorkerId>,
+    integration_id: Option<IntegrationId>,
+    capability_id: Option<CapabilityId>,
+    reason: &'static str,
+    due_at_ms: Option<u64>,
+    planned_at_ms: Option<u64>,
+    overdue_by_ms: Option<u64>,
+    risk_lane: &'static str,
+    risk_action: &'static str,
+    blocked: bool,
+    requires_attention: bool,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+struct RuntimeMaintenanceActionSummary {
+    total_actions: usize,
+    critical_recovery_actions: usize,
+    state_refresh_actions: usize,
+    desired_state_reconciliation_actions: usize,
+    discovery_worker_run_actions: usize,
+    blocked_actions: usize,
+    requires_attention_actions: usize,
+    overdue_actions: usize,
+    bridge_count: usize,
+    entity_count: usize,
+    worker_count: usize,
+    first_due_at_ms: Option<u64>,
+    max_overdue_by_ms: Option<u64>,
+    highest_priority: Option<u8>,
+}
+
+impl RuntimeMaintenanceActionSummary {
+    fn from_rows(rows: &[RuntimeMaintenanceActionRow]) -> Self {
+        let mut summary = Self::default();
+        let mut bridge_ids = BTreeSet::new();
+        let mut entity_ids = BTreeSet::new();
+        let mut worker_ids = BTreeSet::new();
+
+        for row in rows {
+            summary.total_actions += 1;
+            if row.blocked {
+                summary.blocked_actions += 1;
+            }
+            if row.requires_attention {
+                summary.requires_attention_actions += 1;
+            }
+            if row.overdue_by_ms.is_some_and(|overdue| overdue > 0) {
+                summary.overdue_actions += 1;
+            }
+            if let Some(bridge_id) = &row.bridge_id {
+                bridge_ids.insert(bridge_id.as_str().to_string());
+            }
+            if let Some(entity_id) = &row.entity_id {
+                entity_ids.insert(entity_id.as_str().to_string());
+            }
+            if let Some(worker_id) = &row.worker_id {
+                worker_ids.insert(worker_id.as_str().to_string());
+            }
+            summary.first_due_at_ms = min_optional_u64(summary.first_due_at_ms, row.due_at_ms);
+            summary.max_overdue_by_ms =
+                max_optional_u64(summary.max_overdue_by_ms, row.overdue_by_ms);
+            summary.highest_priority =
+                min_optional_u8(summary.highest_priority, Some(row.priority));
+
+            match row.window_kind {
+                RuntimeMaintenanceWindowKind::CriticalRecovery => {
+                    summary.critical_recovery_actions += 1;
+                }
+                RuntimeMaintenanceWindowKind::StateRefresh => summary.state_refresh_actions += 1,
+                RuntimeMaintenanceWindowKind::DesiredStateReconciliation => {
+                    summary.desired_state_reconciliation_actions += 1;
+                }
+                RuntimeMaintenanceWindowKind::DiscoveryWorkerRun => {
+                    summary.discovery_worker_run_actions += 1;
+                }
+            }
+        }
+
+        summary.bridge_count = bridge_ids.len();
+        summary.entity_count = entity_ids.len();
+        summary.worker_count = worker_ids.len();
+        summary
+    }
+
+    fn requires_attention(&self) -> bool {
+        self.requires_attention_actions > 0
+    }
+
+    fn has_blockers(&self) -> bool {
+        self.blocked_actions > 0
+    }
+
+    fn has_overdue_actions(&self) -> bool {
+        self.overdue_actions > 0
+    }
+}
+
+fn list_runtime_maintenance_actions_output_handler_output(
+    runtime: &mut SmartHomeRuntime,
+    principal_id: AgentId,
+    now_ms: u64,
+    query: RuntimeMaintenanceActionQuery,
+) -> Result<ToolHandlerOutput, ToolCallError> {
+    let (mut rows, summary) =
+        runtime_maintenance_action_rows(runtime, principal_id, now_ms, &query)?;
+    if let Some(limit) = query.limit {
+        rows.truncate(limit);
+    }
+
+    Ok(ToolHandlerOutput::new(object([
+        (
+            "runtime_maintenance_actions",
+            JsonValue::Array(rows.iter().map(runtime_maintenance_action_json).collect()),
+        ),
+        ("summary", runtime_maintenance_action_summary_json(&summary)),
+        ("count", integer(rows.len() as i64)),
+    ]))
+    .with_event(
+        ToolEventKind::Progress,
+        object([
+            ("operation", string("list_runtime_maintenance_actions")),
+            ("count", integer(rows.len() as i64)),
+            ("total_actions", integer(summary.total_actions as i64)),
+            (
+                "requires_attention_actions",
+                integer(summary.requires_attention_actions as i64),
+            ),
+            ("blocked_actions", integer(summary.blocked_actions as i64)),
+            ("overdue_actions", integer(summary.overdue_actions as i64)),
+        ]),
+    ))
+}
+
+fn get_runtime_maintenance_action_summary_output_handler_output(
+    runtime: &mut SmartHomeRuntime,
+    principal_id: AgentId,
+    now_ms: u64,
+    query: RuntimeMaintenanceActionQuery,
+) -> Result<ToolHandlerOutput, ToolCallError> {
+    let (_, summary) = runtime_maintenance_action_rows(runtime, principal_id, now_ms, &query)?;
+
+    Ok(ToolHandlerOutput::new(object([(
+        "summary",
+        runtime_maintenance_action_summary_json(&summary),
+    )]))
+    .with_event(
+        ToolEventKind::Progress,
+        object([
+            (
+                "operation",
+                string("get_runtime_maintenance_action_summary"),
+            ),
+            ("total_actions", integer(summary.total_actions as i64)),
+            (
+                "requires_attention_actions",
+                integer(summary.requires_attention_actions as i64),
+            ),
+            ("blocked_actions", integer(summary.blocked_actions as i64)),
+            ("overdue_actions", integer(summary.overdue_actions as i64)),
+        ]),
+    ))
+}
+
+fn runtime_maintenance_action_rows(
+    runtime: &mut SmartHomeRuntime,
+    principal_id: AgentId,
+    now_ms: u64,
+    query: &RuntimeMaintenanceActionQuery,
+) -> Result<
+    (
+        Vec<RuntimeMaintenanceActionRow>,
+        RuntimeMaintenanceActionSummary,
+    ),
+    ToolCallError,
+> {
+    let observation_output = runtime
+        .execute_read_tool(
+            principal_id,
+            RuntimeReadToolRequest::ObserveSupervision,
+            now_ms,
+        )
+        .map_err(runtime_error)?;
+    let RuntimeReadToolOutput::SupervisionObservation(observation) = observation_output else {
+        return Err(ToolCallError {
+            kind: ToolErrorKind::ToolExecutionError,
+            message: "runtime maintenance actions expected supervision observation output"
+                .to_string(),
+            details: JsonValue::Null,
+        });
+    };
+
+    let remediation_rows = supervision_remediation_rows_from_observation(&observation);
+    let mut actions = remediation_rows
+        .iter()
+        .map(RuntimeMaintenanceActionRow::from_remediation)
+        .collect::<Vec<_>>();
+    actions.retain(|row| runtime_maintenance_action_matches(row, query));
+    actions.sort_by(|left, right| {
+        left.priority
+            .cmp(&right.priority)
+            .then_with(|| right.blocked.cmp(&left.blocked))
+            .then_with(|| right.requires_attention.cmp(&left.requires_attention))
+            .then_with(|| left.due_at_ms.cmp(&right.due_at_ms))
+            .then_with(|| left.action_id.cmp(&right.action_id))
+    });
+    for (index, row) in actions.iter_mut().enumerate() {
+        row.execution_order = index + 1;
+    }
+    let summary = RuntimeMaintenanceActionSummary::from_rows(&actions);
+    Ok((actions, summary))
+}
+
+impl RuntimeMaintenanceActionRow {
+    fn from_remediation(row: &SupervisionRemediationRow) -> Self {
+        let window_kind = runtime_maintenance_window_kind_for_remediation(row.remediation_kind);
+        Self {
+            action_id: format!("maintenance_action:{}", row.remediation_id),
+            remediation_id: row.remediation_id.clone(),
+            window_id: runtime_maintenance_window_kind_label(window_kind).to_string(),
+            window_kind,
+            remediation_kind: row.remediation_kind,
+            priority: runtime_maintenance_window_priority(window_kind),
+            execution_order: 0,
+            recommended_tool: runtime_maintenance_window_recommended_tool(window_kind),
+            recommended_action: row.risk_action,
+            bridge_id: row.bridge_id.clone(),
+            device_id: row.device_id.clone(),
+            entity_id: row.entity_id.clone(),
+            worker_id: row.worker_id.clone(),
+            integration_id: row.integration_id.clone(),
+            capability_id: row.capability_id.clone(),
+            reason: row.reason,
+            due_at_ms: row.due_at_ms,
+            planned_at_ms: row.planned_at_ms,
+            overdue_by_ms: row.overdue_by_ms,
+            risk_lane: row.risk_lane,
+            risk_action: row.risk_action,
+            blocked: row.blocked,
+            requires_attention: row.requires_attention,
+        }
+    }
+}
+
+fn runtime_maintenance_window_kind_for_remediation(
+    remediation_kind: SupervisionRemediationKind,
+) -> RuntimeMaintenanceWindowKind {
+    match remediation_kind {
+        SupervisionRemediationKind::PairingExpiry
+        | SupervisionRemediationKind::WorkerRestart
+        | SupervisionRemediationKind::WorkerHeartbeat
+        | SupervisionRemediationKind::DiscoveryWorkerRecovery => {
+            RuntimeMaintenanceWindowKind::CriticalRecovery
+        }
+        SupervisionRemediationKind::StateRefresh => RuntimeMaintenanceWindowKind::StateRefresh,
+        SupervisionRemediationKind::DesiredStateReconciliation => {
+            RuntimeMaintenanceWindowKind::DesiredStateReconciliation
+        }
+        SupervisionRemediationKind::DiscoveryWorkerRun => {
+            RuntimeMaintenanceWindowKind::DiscoveryWorkerRun
+        }
+    }
+}
+
+fn runtime_maintenance_action_matches(
+    row: &RuntimeMaintenanceActionRow,
+    query: &RuntimeMaintenanceActionQuery,
+) -> bool {
+    if !query.window_kinds.is_empty() && !query.window_kinds.contains(&row.window_kind) {
+        return false;
+    }
+    if !query.remediation_kinds.is_empty()
+        && !query.remediation_kinds.contains(&row.remediation_kind)
+    {
+        return false;
+    }
+    if query
+        .risk_lane
+        .as_ref()
+        .is_some_and(|risk_lane| row.risk_lane != risk_lane.as_str())
+    {
+        return false;
+    }
+    if query
+        .recommended_tool
+        .as_ref()
+        .is_some_and(|recommended_tool| row.recommended_tool != recommended_tool.as_str())
+    {
+        return false;
+    }
+    if query
+        .max_priority
+        .is_some_and(|max_priority| row.priority > max_priority)
+    {
+        return false;
+    }
+    if query.blocked_only && !row.blocked {
+        return false;
+    }
+    if query.requires_attention_only && !row.requires_attention {
+        return false;
+    }
+    true
+}
+
 fn min_optional_u64(left: Option<u64>, right: Option<u64>) -> Option<u64> {
     match (left, right) {
         (Some(left), Some(right)) => Some(left.min(right)),
@@ -59616,6 +60061,155 @@ fn runtime_maintenance_window_summary_json(summary: &RuntimeMaintenanceWindowSum
     ])
 }
 
+fn runtime_maintenance_action_json(row: &RuntimeMaintenanceActionRow) -> JsonValue {
+    object([
+        ("action_id", string(&row.action_id)),
+        ("remediation_id", string(&row.remediation_id)),
+        ("window_id", string(&row.window_id)),
+        (
+            "window_kind",
+            string(runtime_maintenance_window_kind_label(row.window_kind)),
+        ),
+        (
+            "remediation_kind",
+            string(supervision_remediation_kind_label(row.remediation_kind)),
+        ),
+        ("priority", integer(row.priority as i64)),
+        ("execution_order", integer(row.execution_order as i64)),
+        ("recommended_tool", string(row.recommended_tool)),
+        ("recommended_action", string(row.recommended_action)),
+        (
+            "bridge_id",
+            row.bridge_id
+                .as_ref()
+                .map(|value| string(value.as_str()))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "device_id",
+            row.device_id
+                .as_ref()
+                .map(|value| string(value.as_str()))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "entity_id",
+            row.entity_id
+                .as_ref()
+                .map(|value| string(value.as_str()))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "worker_id",
+            row.worker_id
+                .as_ref()
+                .map(|value| string(value.as_str()))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "integration_id",
+            row.integration_id
+                .as_ref()
+                .map(|value| string(value.as_str()))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "capability_id",
+            row.capability_id
+                .as_ref()
+                .map(|value| string(value.as_str()))
+                .unwrap_or(JsonValue::Null),
+        ),
+        ("reason", string(row.reason)),
+        (
+            "due_at_ms",
+            row.due_at_ms
+                .map(|value| integer(value as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "planned_at_ms",
+            row.planned_at_ms
+                .map(|value| integer(value as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "overdue_by_ms",
+            row.overdue_by_ms
+                .map(|value| integer(value as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        ("risk_lane", string(row.risk_lane)),
+        ("risk_action", string(row.risk_action)),
+        ("blocked", JsonValue::Bool(row.blocked)),
+        (
+            "requires_attention",
+            JsonValue::Bool(row.requires_attention),
+        ),
+    ])
+}
+
+fn runtime_maintenance_action_summary_json(summary: &RuntimeMaintenanceActionSummary) -> JsonValue {
+    object([
+        ("total_actions", integer(summary.total_actions as i64)),
+        (
+            "critical_recovery_actions",
+            integer(summary.critical_recovery_actions as i64),
+        ),
+        (
+            "state_refresh_actions",
+            integer(summary.state_refresh_actions as i64),
+        ),
+        (
+            "desired_state_reconciliation_actions",
+            integer(summary.desired_state_reconciliation_actions as i64),
+        ),
+        (
+            "discovery_worker_run_actions",
+            integer(summary.discovery_worker_run_actions as i64),
+        ),
+        ("blocked_actions", integer(summary.blocked_actions as i64)),
+        (
+            "requires_attention_actions",
+            integer(summary.requires_attention_actions as i64),
+        ),
+        ("overdue_actions", integer(summary.overdue_actions as i64)),
+        ("bridge_count", integer(summary.bridge_count as i64)),
+        ("entity_count", integer(summary.entity_count as i64)),
+        ("worker_count", integer(summary.worker_count as i64)),
+        (
+            "first_due_at_ms",
+            summary
+                .first_due_at_ms
+                .map(|value| integer(value as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "max_overdue_by_ms",
+            summary
+                .max_overdue_by_ms
+                .map(|value| integer(value as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "highest_priority",
+            summary
+                .highest_priority
+                .map(|value| integer(value as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "requires_attention",
+            JsonValue::Bool(summary.requires_attention()),
+        ),
+        ("has_blockers", JsonValue::Bool(summary.has_blockers())),
+        (
+            "has_overdue_actions",
+            JsonValue::Bool(summary.has_overdue_actions()),
+        ),
+    ])
+}
+
 fn event_log_summary_json(summary: &RuntimeEventLogSummary) -> JsonValue {
     object([
         ("total_events", integer(summary.total_events as i64)),
@@ -66361,7 +66955,7 @@ mod tests {
         let definitions = smart_home_tool_definitions();
         let export = ToolCatalogExport::from_definitions(definitions.iter());
 
-        assert_eq!(definitions.len(), 258);
+        assert_eq!(definitions.len(), 260);
         assert!(
             export.ok(),
             "tool export validation failed: {:?}",
@@ -67098,9 +67692,15 @@ mod tests {
         assert!(export
             .tool_ids()
             .contains(&SMART_HOME_GET_RUNTIME_MAINTENANCE_WINDOW_SUMMARY_TOOL_ID));
+        assert!(export
+            .tool_ids()
+            .contains(&SMART_HOME_LIST_RUNTIME_MAINTENANCE_ACTIONS_TOOL_ID));
+        assert!(export
+            .tool_ids()
+            .contains(&SMART_HOME_GET_RUNTIME_MAINTENANCE_ACTION_SUMMARY_TOOL_ID));
         assert_eq!(
             export.summary.required_capability_count("smart_home:read"),
-            250
+            252
         );
         assert_eq!(
             export
@@ -67947,11 +68547,11 @@ mod tests {
         let tool_catalog_summary = field(tool_catalog_summary_output, "summary").unwrap();
         assert_eq!(
             field(tool_catalog_summary, "total_tools"),
-            Some(&integer(258))
+            Some(&integer(260))
         );
         assert_eq!(
             field(tool_catalog_summary, "read_tools"),
-            Some(&integer(250))
+            Some(&integer(252))
         );
         assert_eq!(
             field(tool_catalog_summary, "risky_tool_count"),
@@ -82355,6 +82955,200 @@ mod tests {
             runtime.borrow().registry().counts().authorization_decisions,
             2,
             "maintenance window list and summary both authorize through runtime read tools"
+        );
+    }
+
+    #[test]
+    fn runtime_maintenance_action_tools_expand_supervision_pressure_end_to_end() {
+        let runtime = Rc::new(RefCell::new(hue_lighting_runtime()));
+        runtime
+            .borrow_mut()
+            .registry_mut()
+            .apply_state_snapshot(StateSnapshot {
+                entity_id: EntityId::trusted("entity-light-1"),
+                value: Value::Object(vec![("light.on_off".to_string(), Value::Bool(true))]),
+                source: StateSource::Poll,
+                observed_at_ms: 1_000,
+                received_at_ms: 1_000,
+                expires_at_ms: None,
+                confidence: StateConfidence::Confirmed,
+            })
+            .unwrap();
+        runtime
+            .borrow_mut()
+            .upsert_desired_state(
+                DesiredEntityState::new(
+                    EntityId::trusted("entity-light-1"),
+                    vec![StateDelta {
+                        capability_id: CapabilityId::trusted("light.on_off"),
+                        value: Value::Bool(false),
+                    }],
+                )
+                .requested_by("agent:scene-planner"),
+            )
+            .unwrap();
+        runtime
+            .borrow_mut()
+            .supervisor_mut()
+            .register_worker(SupervisedBridgeWorker::new(
+                BridgeId::trusted("bridge-1"),
+                IntegrationId::trusted("hue"),
+                1_000,
+                250,
+            ));
+        let discovery_worker_id = DiscoveryWorkerId::trusted("hue-mdns-maintenance-actions");
+        runtime
+            .borrow_mut()
+            .register_discovery_worker_schedule(
+                ScheduledDiscoveryWorker::new(
+                    discovery_worker_id.clone(),
+                    IntegrationId::trusted("hue"),
+                    DiscoveryWorkerKind::MdnsScan,
+                    5_000,
+                    250,
+                    1_100,
+                )
+                .with_retry_backoff(500, 2_000, 2)
+                .with_source(DiscoverySource::Mdns)
+                .with_network_interface("en0")
+                .with_metadata(MDNS_DISCOVERY_SERVICE_TYPE_METADATA_KEY, "_hue._tcp.local"),
+            )
+            .unwrap();
+        runtime
+            .borrow_mut()
+            .mark_discovery_worker_started(&discovery_worker_id, 1_200)
+            .unwrap();
+        let mut failed_run = DiscoveryWorkerRun::new(
+            discovery_worker_id.clone(),
+            IntegrationId::trusted("hue"),
+            DiscoveryWorkerKind::MdnsScan,
+            1_200,
+            1_260,
+        );
+        failed_run.push_failure(
+            DiscoveryWorkerFailure::new(DiscoverySource::Mdns, "multicast route unavailable")
+                .unwrap(),
+        );
+        runtime
+            .borrow_mut()
+            .record_scheduled_discovery_worker_run(&failed_run, 1_260, 500)
+            .unwrap();
+        runtime.borrow_mut().registry_mut().upsert_capability_grant(
+            CapabilityGrant::for_all_smart_home(
+                CapabilityGrantId::trusted("grant-smart-home"),
+                AgentId::trusted(AGENT_ID),
+                PrivilegeTier::HumanApproval,
+                "user:test",
+                1_000,
+            ),
+        );
+        let bridge = SmartHomeToolBridge::new(runtime.clone(), AgentId::trusted(AGENT_ID));
+        let mut tool_runtime = InMemoryToolRuntime::new();
+        bridge.register_all(&mut tool_runtime).unwrap();
+
+        let list_request = request(
+            "call-list-runtime-maintenance-actions",
+            SMART_HOME_LIST_RUNTIME_MAINTENANCE_ACTIONS_TOOL_ID,
+            object([
+                ("requires_attention_only", JsonValue::Bool(true)),
+                ("blocked_only", JsonValue::Bool(true)),
+                ("max_priority", integer(1)),
+                ("limit", integer(10)),
+            ]),
+            2_000,
+        );
+        let list_trace = tool_runtime.invoke_with_events(&list_request);
+        assert!(list_trace.result.ok);
+        assert_eq!(list_trace.summary().progress_event_count, 1);
+        let list_output = list_trace.result.output.as_ref().unwrap();
+        let actions = field(list_output, "runtime_maintenance_actions").unwrap();
+        let summary = field(list_output, "summary").unwrap();
+        assert!(
+            array_len(actions).unwrap() >= 4,
+            "maintenance actions should expand the runtime remediation queue"
+        );
+        assert!(
+            integer_value(field(summary, "total_actions").unwrap()).unwrap() >= 4,
+            "summary should count the filtered, untruncated action queue"
+        );
+        assert!(
+            integer_value(field(summary, "critical_recovery_actions").unwrap()).unwrap() >= 2,
+            "critical recovery should include bridge and discovery repair actions"
+        );
+        assert!(
+            integer_value(field(summary, "state_refresh_actions").unwrap()).unwrap() >= 1,
+            "fixture leaves at least one entity without observed state"
+        );
+        assert_eq!(
+            field(summary, "desired_state_reconciliation_actions"),
+            Some(&integer(1))
+        );
+        assert!(
+            integer_value(field(summary, "blocked_actions").unwrap()).unwrap() >= 4,
+            "blocked remediation work should remain visible at action level"
+        );
+        assert_eq!(field(summary, "has_blockers"), Some(&JsonValue::Bool(true)));
+        assert_eq!(
+            field(summary, "has_overdue_actions"),
+            Some(&JsonValue::Bool(true))
+        );
+
+        let JsonValue::Array(rows) = actions else {
+            panic!("runtime_maintenance_actions should be an array");
+        };
+        assert!(rows.iter().any(|row| field(row, "remediation_kind")
+            == Some(&string("worker_restart"))
+            && field(row, "window_kind") == Some(&string("critical_recovery"))
+            && field(row, "recommended_tool")
+                == Some(&string(SMART_HOME_RUN_SUPERVISION_TICK_TOOL_ID))
+            && field(row, "bridge_id") == Some(&string("bridge-1"))
+            && field(row, "priority") == Some(&integer(0))
+            && field(row, "blocked") == Some(&JsonValue::Bool(true))));
+        assert!(rows.iter().any(|row| field(row, "remediation_kind")
+            == Some(&string("desired_state_reconciliation"))
+            && field(row, "window_kind") == Some(&string("desired_state_reconciliation"))
+            && field(row, "recommended_tool")
+                == Some(&string(SMART_HOME_RECONCILE_DESIRED_STATES_TOOL_ID))
+            && field(row, "entity_id") == Some(&string("entity-light-1"))
+            && field(row, "capability_id") == Some(&string("light.on_off"))
+            && field(row, "recommended_action") == Some(&string("reconcile_desired_state"))));
+        assert!(
+            rows.iter()
+                .all(|row| { integer_value(field(row, "execution_order").unwrap()).unwrap() >= 1 }),
+            "action rows should expose a stable execution order"
+        );
+
+        let summary_request = request(
+            "call-runtime-maintenance-action-summary",
+            SMART_HOME_GET_RUNTIME_MAINTENANCE_ACTION_SUMMARY_TOOL_ID,
+            object([
+                ("window_kind", string("desired_state_reconciliation")),
+                ("blocked_only", JsonValue::Bool(true)),
+            ]),
+            2_001,
+        );
+        let summary_trace = tool_runtime.invoke_with_events(&summary_request);
+        assert!(summary_trace.result.ok);
+        assert_eq!(summary_trace.summary().progress_event_count, 1);
+        let summary_output = summary_trace.result.output.as_ref().unwrap();
+        let rollup = field(summary_output, "summary").unwrap();
+        assert_eq!(field(rollup, "total_actions"), Some(&integer(1)));
+        assert_eq!(
+            field(rollup, "desired_state_reconciliation_actions"),
+            Some(&integer(1))
+        );
+        assert_eq!(field(rollup, "has_blockers"), Some(&JsonValue::Bool(true)));
+
+        let mut journal = ToolExecutionJournal::new();
+        journal.record_trace(list_request, list_trace);
+        journal.record_trace(summary_request, summary_trace);
+        let journal_summary = journal.summary();
+        assert_eq!(journal_summary.invocation_count, 2);
+        assert_eq!(journal_summary.completed_count, 2);
+        assert_eq!(
+            runtime.borrow().registry().counts().authorization_decisions,
+            2,
+            "maintenance action list and summary both authorize through runtime read tools"
         );
     }
 

--- a/code/packages/rust/smart-home-core/CHANGELOG.md
+++ b/code/packages/rust/smart-home-core/CHANGELOG.md
@@ -261,6 +261,9 @@ All notable changes to this package will be documented in this file.
 - `smart_home.list_runtime_maintenance_windows` and
   `smart_home.get_runtime_maintenance_window_summary` tool descriptors for
   read-only Chief maintenance windows derived from runtime supervision work.
+- `smart_home.list_runtime_maintenance_actions` and
+  `smart_home.get_runtime_maintenance_action_summary` tool descriptors for
+  read-only Chief maintenance actions derived from runtime supervision work.
 - `smart_home.reconcile_desired_states` and `smart_home.run_supervision_tick`
   tool descriptors for authorized runtime supervision execution.
 - Health and command-result status helpers for shared supervision/read-side

--- a/code/packages/rust/smart-home-core/README.md
+++ b/code/packages/rust/smart-home-core/README.md
@@ -174,6 +174,8 @@ Current scope:
 - D18D supervision planning tool descriptor for non-mutating due-work previews
 - D18D runtime maintenance-window descriptors for Chief-visible grouped
   supervision work
+- D18D runtime maintenance-action descriptors for Chief-visible execution
+  planning over supervision work
 - D18D supervision execution tool descriptors for authorized desired-state
   reconciliation and runtime supervision ticks
 - compact smart-home tool catalog summaries for read-side inspection

--- a/code/packages/rust/smart-home-core/src/lib.rs
+++ b/code/packages/rust/smart-home-core/src/lib.rs
@@ -1692,6 +1692,8 @@ pub enum SmartHomeTool {
     GetSupervisionRemediationSummary,
     ListRuntimeMaintenanceWindows,
     GetRuntimeMaintenanceWindowSummary,
+    ListRuntimeMaintenanceActions,
+    GetRuntimeMaintenanceActionSummary,
     SetDesiredState,
     ClearDesiredState,
     ListPairingSessions,
@@ -2397,6 +2399,12 @@ impl SmartHomeTool {
             }
             Self::GetRuntimeMaintenanceWindowSummary => {
                 read_tool("smart_home.get_runtime_maintenance_window_summary")
+            }
+            Self::ListRuntimeMaintenanceActions => {
+                read_tool("smart_home.list_runtime_maintenance_actions")
+            }
+            Self::GetRuntimeMaintenanceActionSummary => {
+                read_tool("smart_home.get_runtime_maintenance_action_summary")
             }
             Self::SetDesiredState => ToolDescriptor {
                 tool_id: "smart_home.set_desired_state",
@@ -3195,6 +3203,8 @@ pub fn smart_home_tool_catalog() -> Vec<ToolDescriptor> {
         SmartHomeTool::GetSupervisionRemediationSummary,
         SmartHomeTool::ListRuntimeMaintenanceWindows,
         SmartHomeTool::GetRuntimeMaintenanceWindowSummary,
+        SmartHomeTool::ListRuntimeMaintenanceActions,
+        SmartHomeTool::GetRuntimeMaintenanceActionSummary,
         SmartHomeTool::SetDesiredState,
         SmartHomeTool::ClearDesiredState,
         SmartHomeTool::ListPairingSessions,
@@ -4001,7 +4011,7 @@ mod tests {
             .find(|tool| tool.tool_id == "smart_home.command")
             .unwrap();
 
-        assert_eq!(catalog.len(), 258);
+        assert_eq!(catalog.len(), 260);
         assert!(catalog
             .iter()
             .any(|tool| tool.tool_id == "smart_home.list_command_risk_audit"
@@ -4050,6 +4060,14 @@ mod tests {
             && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
         assert!(catalog.iter().any(|tool| tool.tool_id
             == "smart_home.get_runtime_maintenance_window_summary"
+            && tool.side_effects == ToolSideEffects::Read
+            && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
+        assert!(catalog.iter().any(|tool| tool.tool_id
+            == "smart_home.list_runtime_maintenance_actions"
+            && tool.side_effects == ToolSideEffects::Read
+            && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
+        assert!(catalog.iter().any(|tool| tool.tool_id
+            == "smart_home.get_runtime_maintenance_action_summary"
             && tool.side_effects == ToolSideEffects::Read
             && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
         assert!(catalog
@@ -5018,15 +5036,15 @@ mod tests {
         let summary = smart_home_tool_catalog_summary();
         let pair_bridge = SmartHomeTool::PairBridge.descriptor();
 
-        assert_eq!(summary.total_tools, 258);
-        assert_eq!(summary.read_tools, 250);
+        assert_eq!(summary.total_tools, 260);
+        assert_eq!(summary.read_tools, 252);
         assert_eq!(summary.write_tools, 2);
         assert_eq!(summary.external_tools, 6);
-        assert_eq!(summary.read_only_tier_tools, 250);
+        assert_eq!(summary.read_only_tier_tools, 252);
         assert_eq!(summary.low_risk_tier_tools, 6);
         assert_eq!(summary.high_risk_tier_tools, 0);
         assert_eq!(summary.human_approval_tier_tools, 2);
-        assert_eq!(summary.total_required_capabilities, 258);
+        assert_eq!(summary.total_required_capabilities, 260);
         assert_eq!(summary.risky_tool_count(), 8);
         assert_eq!(summary.approval_gated_tool_count(), 2);
         assert!(pair_bridge.requires_human_approval());


### PR DESCRIPTION
## Summary
- add shared smart-home descriptors for runtime maintenance action list and summary tools
- expose Chief read-only action rows derived from D23 supervision remediation and maintenance windows
- cover action listing/summary with an end-to-end smart-home tool test and update docs/changelogs

## Validation
- cargo fmt -p smart-home-core -p chief-of-staff-smart-home-tools --check
- cargo test -p smart-home-core
- cargo test -p smart-home-integration-catalog
- cargo test -p hue-core
- cargo test -p smart-home-runtime
- cargo test -p smart-home-testkit
- cargo test -p smart-home-local-http
- cargo test -p smart-home-discovery
- cargo test -p chief-of-staff-smart-home-tools
- cargo test -p smart-home-runtime discover_tool -- --nocapture
- sh BUILD in smart-home-core
- sh BUILD in smart-home-integration-catalog
- sh BUILD in hue-core
- sh BUILD in smart-home-runtime
- sh BUILD in smart-home-testkit
- sh BUILD in smart-home-local-http
- sh BUILD in smart-home-discovery
- sh BUILD in chief-of-staff-smart-home-tools
