### PR TITLE
feat(vm-core): execute typed module globals — VM + JIT (E6 layer 1)

### DIFF
--- a/code/packages/rust/jit-core/tests/e6_globals_jit.rs
+++ b/code/packages/rust/jit-core/tests/e6_globals_jit.rs
@@ -1,0 +1,55 @@
+//! LANG-FULL E6 (layer 1) — module globals through the JIT tier.
+//!
+//! The JIT (`JITCore` + `GenericCirJit`) monitors a `VMCore`: cold functions
+//! interpret on the VM (now global-aware), hot ones promote to the compiled
+//! backend. A function that uses an op the compiler doesn't lower stays
+//! interpreted rather than failing. This test confirms a cross-function global
+//! program runs to the right answer through the full JIT path — the JIT column
+//! of E6 layer 1.
+
+use interpreter_ir::function::IIRFunction;
+use interpreter_ir::instr::{IIRInstr, Operand};
+use interpreter_ir::module::IIRModule;
+use jit_core::core::JITCore;
+use jit_core::GenericCirJit;
+use vm_core::core::VMCore;
+use vm_core::value::Value;
+
+fn ins(op: &str, dest: Option<&str>, srcs: Vec<Operand>, ty: &str) -> IIRInstr {
+    IIRInstr::new(op, dest.map(|s| s.to_string()), srcs, ty)
+}
+
+#[test]
+fn global_shared_across_functions_runs_on_jit() {
+    let mut module = IIRModule::new("e6jit", "e6jit");
+    // main: g := 41; return bump()
+    module.add_or_replace(IIRFunction::new(
+        "main",
+        vec![],
+        "i64",
+        vec![
+            ins("const", Some("seed"), vec![Operand::Int(41)], "i64"),
+            ins("global_store", None, vec![Operand::Str("g".into()), Operand::Var("seed".into())], "void"),
+            ins("call", Some("res"), vec![Operand::Var("bump".into())], "i64"),
+            ins("ret", None, vec![Operand::Var("res".into())], "i64"),
+        ],
+    ));
+    // bump: g := g + 1; return g
+    module.add_or_replace(IIRFunction::new(
+        "bump",
+        vec![],
+        "i64",
+        vec![
+            ins("global_load", Some("cur"), vec![Operand::Str("g".into())], "i64"),
+            ins("const", Some("one"), vec![Operand::Int(1)], "i64"),
+            ins("add", Some("nxt"), vec![Operand::Var("cur".into()), Operand::Var("one".into())], "i64"),
+            ins("global_store", None, vec![Operand::Str("g".into()), Operand::Var("nxt".into())], "void"),
+            ins("ret", None, vec![Operand::Var("nxt".into())], "i64"),
+        ],
+    ));
+
+    let mut vm = VMCore::new();
+    let mut jit = JITCore::new(&mut vm, Box::new(GenericCirJit::new()));
+    let result = jit.execute_with_jit(&mut vm, &mut module, "main", &[]).unwrap();
+    assert_eq!(result, Some(Value::Int(42)));
+}

--- a/code/packages/rust/vm-core/CHANGELOG.md
+++ b/code/packages/rust/vm-core/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog — vm-core
 
+## [0.8.0] — 2026-06-22 (LANG-FULL E6 layer 1 — typed module globals)
+
+### Added
+- **`global_load` / `global_store`** — the VM now executes the *lowered, typed*
+  global IIR ops over a new name-keyed `globals: HashMap<String, Value>`:
+  - `global_store("g", %v)` writes; `global_load("g") -> %dest` reads.
+  - The global name is an `Operand::Str` literal (never resolved as a register).
+  - A global that was never written reads as `Int(0)` — matching the zero-init
+    the code-gen backends give their `_twig_globals` slots / static fields.
+  - This is **distinct** from the dynamic `call_builtin "global_get"/"global_set"`
+    table the Twig front-end uses; these typed ops are what a statically-typed
+    frontend (e.g. ALGOL procedures over an enclosing-block variable, E6's proof
+    program) emits directly — so such globals now run on the VM.
+- Because the **JIT** (`JITCore` + `GenericCirJit`) cold-interprets on this VM
+  (only hot functions promote, and a global-using function the compiler doesn't
+  lower simply stays interpreted), the **JIT column gets globals for free** —
+  covered by a `jit-core` integration test.
+
+### Verified
+- `tests/e6_globals.rs`: a cross-function program (`main` seeds `g`, a separate
+  `bump` reads/increments/writes it) ⇒ 42; an unwritten global reads as 0.
+- `jit-core/tests/e6_globals_jit.rs`: the same program runs to 42 through the
+  full JIT path.
+
 ## [0.7.0] — 2026-06-20 (LANG-FULL E5 — bounds-checked arrays)
 
 ### Added — `alloc_array` / `array_len` / `array_get` / `array_set`

--- a/code/packages/rust/vm-core/Cargo.toml
+++ b/code/packages/rust/vm-core/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "vm-core"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
-description = "Generic register interpreter for InterpreterIR — the vm-core of the LANG pipeline.  v0.5.0 (LANG-FULL E2 — register width & wrap, backend 1/6): integer arithmetic / bitwise / shift handlers now mask their result to the width named by the instruction's type_hint (u4→&0xF, u8→&0xFF, u16, u32), so a u8-typed `add` of 200+100 yields 44 and `~x` on a u8 flips 8 bits — the register-arithmetic analogue of the existing byte-tape store_byte mask, on top of the legacy whole-module u8_wrap flag.  v0.4.0 (LANG-MATRIX Phase V): adds the byte-tape ops alloc_bytes/load_byte/store_byte over the flat memory address space (a cell is memory[base+idx], store_byte masks to a byte for Brainfuck's 8-bit wrap), so the generic VM runs Brainfuck — every matrix language now runs on this one register interpreter."
+description = "Generic register interpreter for InterpreterIR — the vm-core of the LANG pipeline.  v0.8.0 (LANG-FULL E6 layer 1 — typed module globals): executes the lowered `global_load`/`global_store` IIR ops over a name-keyed `globals` map (a never-written global reads as 0, matching the code-gen backends' zero-init slots) — distinct from the dynamic `call_builtin \"global_get/set\"` table, so a statically-typed frontend's typed globals run on the VM (and JIT, via cold interpretation).  v0.5.0 (LANG-FULL E2 — register width & wrap, backend 1/6): integer arithmetic / bitwise / shift handlers now mask their result to the width named by the instruction's type_hint (u4→&0xF, u8→&0xFF, u16, u32), so a u8-typed `add` of 200+100 yields 44 and `~x` on a u8 flips 8 bits — the register-arithmetic analogue of the existing byte-tape store_byte mask, on top of the legacy whole-module u8_wrap flag.  v0.4.0 (LANG-MATRIX Phase V): adds the byte-tape ops alloc_bytes/load_byte/store_byte over the flat memory address space (a cell is memory[base+idx], store_byte masks to a byte for Brainfuck's 8-bit wrap), so the generic VM runs Brainfuck — every matrix language now runs on this one register interpreter."
 
 [lib]
 name = "vm_core"

--- a/code/packages/rust/vm-core/src/core.rs
+++ b/code/packages/rust/vm-core/src/core.rs
@@ -128,6 +128,17 @@ pub struct VMCore {
     /// Flat address-space memory (used by `load_mem` / `store_mem` / I/O).
     memory: HashMap<i64, Value>,
 
+    /// Module-level global variables (LANG-FULL E6), keyed by name.
+    /// `global_store("g", v)` writes here; `global_load("g")` reads it (a
+    /// never-written global reads as `Value::Int(0)`, matching the zero-init the
+    /// code-gen backends give their `_twig_globals` slots). This is distinct
+    /// from `memory` (addressed by `i64`) and from the dynamic
+    /// `call_builtin "global_set"/"global_get"` table the Twig front-end uses —
+    /// these are the *lowered, typed* `global_load`/`global_store` IIR ops a
+    /// statically-typed frontend (ALGOL procedures over an enclosing variable)
+    /// emits directly.
+    globals: HashMap<String, Value>,
+
     /// Heap of bounds-checked arrays (LANG-FULL E5). `alloc_array` pushes a new
     /// `Vec<Value>` and binds its 0-based index as the array *handle* (an
     /// `i64`); `array_get`/`array_set` index the `Vec` with a range check, and
@@ -191,6 +202,7 @@ impl VMCore {
             max_instructions: None, // unlimited — trusted code path
             frames: Vec::new(),
             memory: HashMap::new(),
+            globals: HashMap::new(),
             arrays: Vec::new(),
             jit_handlers: HashMap::new(),
             extra_opcodes: HashMap::new(),
@@ -313,6 +325,7 @@ impl VMCore {
             module_fns: &mut module.functions,
             builtins: &self.builtins,
             memory: &mut self.memory,
+            globals: &mut self.globals,
             arrays: &mut self.arrays,
             u8_wrap: self.u8_wrap,
             max_frames: self.max_frames,
@@ -386,6 +399,7 @@ impl VMCore {
             module_fns: &mut module.functions,
             builtins: &self.builtins,
             memory: &mut self.memory,
+            globals: &mut self.globals,
             arrays: &mut self.arrays,
             u8_wrap: self.u8_wrap,
             max_frames: self.max_frames,

--- a/code/packages/rust/vm-core/src/dispatch.rs
+++ b/code/packages/rust/vm-core/src/dispatch.rs
@@ -54,6 +54,9 @@ pub struct DispatchCtx<'a> {
     pub frames: &'a mut Vec<VMFrame>,
     pub module_fns: &'a mut Vec<interpreter_ir::function::IIRFunction>,
     pub memory: &'a mut HashMap<i64, Value>,
+    /// Module-level globals (LANG-FULL E6), keyed by name. `global_store`/
+    /// `global_load` read+write here. See [`crate::core::VMCore`].
+    pub globals: &'a mut HashMap<String, Value>,
     /// Heap of bounds-checked arrays (LANG-FULL E5). Indexed by the array
     /// *handle* (`alloc_array`'s 0-based result). See [`crate::core::VMCore`].
     pub arrays: &'a mut Vec<Vec<Value>>,
@@ -674,6 +677,43 @@ fn handle_store_mem(ctx: &mut DispatchCtx, instr: &IIRInstr) -> Result<Option<Va
     Ok(None)
 }
 
+// Module globals (LANG-FULL E6) ---------------------------------------------
+//
+// `global_load("g") -> %dest` reads the module global named `g`; `global_store
+// ("g", %v)` writes it. The name is an `Operand::Str` literal (NOT a register —
+// it must never be looked up in the frame), mirroring how the code-gen backends
+// carry it. A global that was never stored reads as `Int(0)`, matching the
+// zero-initialised `_twig_globals` slots / static fields the other backends use.
+
+/// Extract the string-literal global name at `srcs[idx]`.
+fn global_name(instr: &IIRInstr, idx: usize) -> Result<String, VMError> {
+    match instr.srcs.get(idx) {
+        Some(Operand::Str(s)) => Ok(s.clone()),
+        other => Err(VMError::Custom(format!(
+            "global op expected a string name at srcs[{idx}], got {other:?}"
+        ))),
+    }
+}
+
+fn handle_global_load(ctx: &mut DispatchCtx, instr: &IIRInstr) -> Result<Option<Value>, VMError> {
+    let name = global_name(instr, 0)?;
+    let value = ctx.globals.get(&name).cloned().unwrap_or(Value::Int(0));
+    if let Some(dest) = &instr.dest {
+        ctx.frames.last_mut().unwrap().assign(dest, value.clone());
+    }
+    Ok(Some(value))
+}
+
+fn handle_global_store(ctx: &mut DispatchCtx, instr: &IIRInstr) -> Result<Option<Value>, VMError> {
+    let name = global_name(instr, 0)?;
+    let value = {
+        let frame = ctx.frames.last().ok_or_else(|| VMError::Custom("no frame".into()))?;
+        resolve_src(frame, &instr.srcs, 1)?
+    };
+    ctx.globals.insert(name, value);
+    Ok(None)
+}
+
 // Byte-tape memory (the shared-IIR byte buffer) ----------------------------
 //
 // `alloc_bytes` / `load_byte` / `store_byte` are the lowered byte-tape ops that
@@ -1092,6 +1132,8 @@ pub(crate) fn lookup_standard(op: &str) -> Option<StdHandlerFn> {
         "alloc_bytes"  => Some(handle_alloc_bytes),
         "load_byte"    => Some(handle_load_byte),
         "store_byte"   => Some(handle_store_byte),
+        "global_load"  => Some(handle_global_load),
+        "global_store" => Some(handle_global_store),
         "alloc_array"  => Some(handle_alloc_array),
         "array_len"    => Some(handle_array_len),
         "array_get"    => Some(handle_array_get),

--- a/code/packages/rust/vm-core/tests/e6_globals.rs
+++ b/code/packages/rust/vm-core/tests/e6_globals.rs
@@ -1,0 +1,78 @@
+//! LANG-FULL E6 (layer 1) — typed module globals read/written from a function.
+//!
+//! Confirms `vm-core` executes the lowered `global_load`/`global_store` IIR ops
+//! (the typed ops a statically-typed frontend emits directly — distinct from the
+//! Twig dynamic `call_builtin "global_get"/"global_set"` path). The program below
+//! mirrors the ALGOL proof program: `main` seeds a global, a *separate* function
+//! `bump` reads it, increments it, and writes it back — so the global genuinely
+//! outlives `main`'s frame and is shared across functions.
+
+use interpreter_ir::function::IIRFunction;
+use interpreter_ir::instr::{IIRInstr, Operand};
+use interpreter_ir::module::IIRModule;
+use vm_core::core::VMCore;
+use vm_core::value::Value;
+
+fn ins(op: &str, dest: Option<&str>, srcs: Vec<Operand>, ty: &str) -> IIRInstr {
+    IIRInstr::new(op, dest.map(|s| s.to_string()), srcs, ty)
+}
+
+/// `bump`: `g := g + 1; return g`. Reads + writes the global `g`.
+fn bump_fn() -> IIRFunction {
+    IIRFunction::new(
+        "bump",
+        vec![],
+        "i64",
+        vec![
+            ins("global_load", Some("cur"), vec![Operand::Str("g".into())], "i64"),
+            ins("const", Some("one"), vec![Operand::Int(1)], "i64"),
+            ins("add", Some("nxt"), vec![Operand::Var("cur".into()), Operand::Var("one".into())], "i64"),
+            ins("global_store", None, vec![Operand::Str("g".into()), Operand::Var("nxt".into())], "void"),
+            ins("ret", None, vec![Operand::Var("nxt".into())], "i64"),
+        ],
+    )
+}
+
+/// `main`: `g := 41; return bump()`  ⇒ 42.
+fn main_fn() -> IIRFunction {
+    IIRFunction::new(
+        "main",
+        vec![],
+        "i64",
+        vec![
+            ins("const", Some("seed"), vec![Operand::Int(41)], "i64"),
+            ins("global_store", None, vec![Operand::Str("g".into()), Operand::Var("seed".into())], "void"),
+            ins("call", Some("res"), vec![Operand::Var("bump".into())], "i64"),
+            ins("ret", None, vec![Operand::Var("res".into())], "i64"),
+        ],
+    )
+}
+
+#[test]
+fn global_shared_across_functions_yields_42() {
+    let mut module = IIRModule::new("e6", "e6");
+    module.add_or_replace(main_fn());
+    module.add_or_replace(bump_fn());
+    let mut vm = VMCore::new();
+    let result = vm.execute(&mut module, "main", &[]).unwrap();
+    assert_eq!(result, Some(Value::Int(42)));
+}
+
+/// A global that was never written reads as 0 (the zero-init convention the
+/// code-gen backends give their `_twig_globals` slots / static fields).
+#[test]
+fn unwritten_global_reads_as_zero() {
+    let f = IIRFunction::new(
+        "main",
+        vec![],
+        "i64",
+        vec![
+            ins("global_load", Some("v"), vec![Operand::Str("never_set".into())], "i64"),
+            ins("ret", None, vec![Operand::Var("v".into())], "i64"),
+        ],
+    );
+    let mut module = IIRModule::new("e6z", "e6z");
+    module.add_or_replace(f);
+    let mut vm = VMCore::new();
+    assert_eq!(vm.execute(&mut module, "main", &[]).unwrap(), Some(Value::Int(0)));
+}


### PR DESCRIPTION
## What

First implementation slice of **E6 layer 1** (typed module globals accessible from functions — see [`lang-full-e6-globals.md`](https://github.com/adhithyan15/coding-adventures/pull/6490)).

**Survey finding:** `vm-core` and `jit-core` had **no** handling of the lowered `global_load`/`global_store` IIR ops — on those tiers Twig globals work *only* via the dynamic `call_builtin "global_get"/"global_set"` table, not the typed ops a statically-typed frontend emits. So VM/JIT needed real support, not just verification.

## Changes

- **vm-core**: a new name-keyed `globals: HashMap<String, Value>` on `VMCore`, threaded through `DispatchCtx`; `global_load`/`global_store` handlers + dispatch arms.
  - The global name is an `Operand::Str` literal (**never** resolved as a register).
  - A never-written global reads as `Int(0)` — matching the code-gen backends' zero-init `_twig_globals` slots / static fields.
  - Distinct from the dynamic `call_builtin` global table.
- **JIT**: `JITCore` cold-interprets on this VM (only hot functions promote; a function using an op `GenericCirJit` doesn't lower stays interpreted), so the **JIT column gets globals for free**.

## Verified by running

A cross-function program — `main` seeds `g`; a *separate* `bump` reads/increments/writes it ⇒ **42**; an unwritten global ⇒ **0** — on **both**:
- the VM (`vm-core/tests/e6_globals.rs`)
- the full JIT path (`jit-core/tests/e6_globals_jit.rs`)

vm-core 0.8.0. Security review passed (globals are keyed by compile-time string literals, a finite set — no unbounded-growth cap needed unlike `memory`'s runtime-`i64` keys).

## Next E6 slices

`iir-to-llvm`, `iir-to-jvm`, `iir-to-cil` (the rejecting code-gen backends), the ALGOL enclosing-scope frontend, then the all-7-backend matrix proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)