### PR TITLE
feat(visicalc-qt): insert / delete rows & columns in the Qt demo

### DIFF
--- a/demo/visicalc-qt/InfiniteSheet.qml
+++ b/demo/visicalc-qt/InfiniteSheet.qml
@@ -228,6 +228,35 @@ Item {
                 }
                 Rectangle { Layout.preferredWidth: 1; Layout.fillHeight: true; Layout.topMargin: 4; Layout.bottomMargin: 4; color: sheet.cLine }
 
+                // ── Structure (insert / delete the selected row or column) ──
+                // The engine shifts every formula reference across the band; a
+                // reference whose whole band is deleted becomes #REF!.
+                ToolButton {
+                    text: "+ Row"
+                    ToolTip.visible: hovered
+                    ToolTip.text: "Insert a row above the selected cell (references shift down)"
+                    onClicked: if (doc) doc.insertRows(doc.infRow, 1)
+                }
+                ToolButton {
+                    text: "− Row"
+                    ToolTip.visible: hovered
+                    ToolTip.text: "Delete the selected cell's row (references shift up; refs into it become #REF!)"
+                    onClicked: if (doc) doc.deleteRows(doc.infRow, 1)
+                }
+                ToolButton {
+                    text: "+ Col"
+                    ToolTip.visible: hovered
+                    ToolTip.text: "Insert a column left of the selected cell (references shift right)"
+                    onClicked: if (doc) doc.insertCols(doc.infCol, 1)
+                }
+                ToolButton {
+                    text: "− Col"
+                    ToolTip.visible: hovered
+                    ToolTip.text: "Delete the selected cell's column (references shift left; refs into it become #REF!)"
+                    onClicked: if (doc) doc.deleteCols(doc.infCol, 1)
+                }
+                Rectangle { Layout.preferredWidth: 1; Layout.fillHeight: true; Layout.topMargin: 4; Layout.bottomMargin: 4; color: sheet.cLine }
+
                 // ── History (undo / redo) ──
                 ToolButton {
                     text: "↶ Undo"

--- a/demo/visicalc-qt/src/SpreadsheetModel.cpp
+++ b/demo/visicalc-qt/src/SpreadsheetModel.cpp
@@ -353,6 +353,52 @@ bool SpreadsheetModel::paste(const QString &dstStart) {
     return applied;
 }
 
+// Structural edits: insert / delete rows or columns at a 1-based position. The
+// engine shifts every formula reference at or after the band (a reference whose
+// whole band is deleted becomes #REF!) and recomputes; we then rebuild the grid,
+// regrow the extent, and bump `revision` so the visible rows re-fetch. `at`/`count`
+// arrive as int from QML — clamp the count to ≥ 0 before the u32 cast so a stray
+// negative can't wrap to a huge unsigned band.
+void SpreadsheetModel::insertRows(int at, int count) {
+    sc_insert_rows(session_, static_cast<uint32_t>(at < 0 ? 0 : at),
+                   static_cast<uint32_t>(count < 0 ? 0 : count));
+    recompute();
+    computeExtent();
+    revision_++;
+    emit changed();
+    emit revisionChanged();
+}
+
+void SpreadsheetModel::deleteRows(int at, int count) {
+    sc_delete_rows(session_, static_cast<uint32_t>(at < 0 ? 0 : at),
+                   static_cast<uint32_t>(count < 0 ? 0 : count));
+    recompute();
+    computeExtent();
+    revision_++;
+    emit changed();
+    emit revisionChanged();
+}
+
+void SpreadsheetModel::insertCols(int at, int count) {
+    sc_insert_cols(session_, static_cast<uint32_t>(at < 0 ? 0 : at),
+                   static_cast<uint32_t>(count < 0 ? 0 : count));
+    recompute();
+    computeExtent();
+    revision_++;
+    emit changed();
+    emit revisionChanged();
+}
+
+void SpreadsheetModel::deleteCols(int at, int count) {
+    sc_delete_cols(session_, static_cast<uint32_t>(at < 0 ? 0 : at),
+                   static_cast<uint32_t>(count < 0 ? 0 : count));
+    recompute();
+    computeExtent();
+    revision_++;
+    emit changed();
+    emit revisionChanged();
+}
+
 // Save: serialize the whole workbook (source + formats) to a JSON document. The
 // host stores the returned string wherever it likes (a file, QSettings, …); the
 // engine owns no I/O. takeString frees the C string with the engine's allocator.

--- a/demo/visicalc-qt/src/SpreadsheetModel.h
+++ b/demo/visicalc-qt/src/SpreadsheetModel.h
@@ -135,6 +135,15 @@ public:
     Q_INVOKABLE void copy(const QString &start, const QString &end);
     Q_INVOKABLE void cut(const QString &start, const QString &end);
     Q_INVOKABLE bool paste(const QString &dstStart);
+    // Structural edits: insert / delete `count` rows or columns at the 1-based
+    // position `at`. The engine shifts every formula reference at or after the
+    // band so dependents keep pointing at their precedents (a reference whose
+    // whole band is deleted becomes #REF!), then recomputes; these resize the
+    // extent and bump `revision` so the visible rows re-fetch.
+    Q_INVOKABLE void insertRows(int at, int count);
+    Q_INVOKABLE void deleteRows(int at, int count);
+    Q_INVOKABLE void insertCols(int at, int count);
+    Q_INVOKABLE void deleteCols(int at, int count);
     // Save / load: serialize() returns a self-contained JSON document of the
     // workbook's SOURCE (formula text + typed literals) + per-cell formats — not
     // the computed values, which recompute on load. deserialize() replaces the

--- a/demo/visicalc-qt/test/tst_window.cpp
+++ b/demo/visicalc-qt/test/tst_window.cpp
@@ -26,6 +26,7 @@ private slots:
     void clipboardCopyCutPaste();
     void saveLoadRoundTrips();
     void undoRedoWalksHistory();
+    void structuralInsertDeleteShiftsReferences();
 };
 
 // Helper: the display string at window (1-based) cell (row, col), given the
@@ -235,6 +236,52 @@ void TstWindow::undoRedoWalksHistory() {
     QVERIFY(m.canRedo());
     m.setCell("A1", "7");
     QVERIFY(!m.canRedo());
+}
+
+// Structural edits (the + Row / − Row / + Col / − Col controls drive
+// model.insertRows/deleteRows/insertCols/deleteCols): inserting and deleting
+// rows/columns shifts every formula reference across the band, and deleting a
+// referenced band turns that reference into #REF!.
+void TstWindow::structuralInsertDeleteShiftsReferences() {
+    SpreadsheetModel m;
+    // A fresh column away from the seeded budget: H1=10, H2=20, H3 = H1+H2 = 30.
+    m.setCell("H1", "10");
+    m.setCell("H2", "20");
+    m.setCell("H3", "=H1+H2");
+    QCOMPARE(m.window(3, 8, 3, 8).at(0).toList().at(0).toString(), QStringLiteral("30"));
+
+    // The engine's formula printer parenthesizes binary ops ("=(H1+H3)"), so
+    // compare the selected cell's source with the parens stripped.
+    auto bareFormula = [&m]() { return QString(m.infFormula()).remove('(').remove(')'); };
+
+    // Insert a row at row 2: H2/H3 shift down to H3/H4, row 2 is blank, and the
+    // formula's refs shift with their cells (=H1+H2 → =H1+H3).
+    m.insertRows(2, 1);
+    QCOMPARE(m.window(2, 8, 2, 8).at(0).toList().at(0).toString(), QString());          // inserted row blank
+    QCOMPARE(m.window(4, 8, 4, 8).at(0).toList().at(0).toString(), QStringLiteral("30")); // formula at H4
+    m.selectInf(4, 8);
+    QCOMPARE(bareFormula(), QStringLiteral("=H1+H3"));
+
+    // Delete that inserted row: everything shifts back.
+    m.deleteRows(2, 1);
+    QCOMPARE(m.window(3, 8, 3, 8).at(0).toList().at(0).toString(), QStringLiteral("30"));
+    m.selectInf(3, 8);
+    QCOMPARE(bareFormula(), QStringLiteral("=H1+H2"));
+
+    // Delete row 1 (referenced by the formula): H2 shifts up to H1, the formula
+    // shifts up to H2, and its destroyed H1 reference becomes #REF!.
+    m.deleteRows(1, 1);
+    QCOMPARE(m.window(2, 8, 2, 8).at(0).toList().at(0).toString(), QStringLiteral("#REF!"));
+
+    // Columns shift the same way: K1=5, L1 = K1*3 = 15. Insert a column at K and
+    // the formula (now at M1) keeps pointing at its precedent (now L1).
+    SpreadsheetModel m2;
+    m2.setCell("K1", "5");
+    m2.setCell("L1", "=K1*3");
+    m2.insertCols(11, 1); // col 11 = K
+    QCOMPARE(m2.window(1, 13, 1, 13).at(0).toList().at(0).toString(), QStringLiteral("15")); // M1
+    m2.selectInf(1, 13);
+    QCOMPARE(QString(m2.infFormula()).remove('(').remove(')'), QStringLiteral("=L1*3"));
 }
 
 QTEST_MAIN(TstWindow)


### PR DESCRIPTION
## What

Second backend of the **insert / delete rows & columns** rollout (web [#6492](https://github.com/adhithyan15/coding-adventures/pull/6492) → **Qt** → Flutter → Compose → XAML → SwiftUI). The engine + capi already implement structural edits with full reference-shifting; this wires them into the Qt demo. The vendored `libspreadsheet_capi.a` **already exports** `sc_insert_rows`/`sc_delete_rows`/`sc_insert_cols`/`sc_delete_cols` (verified with `nm`) — **no re-vendor** needed.

## Changes

- **`SpreadsheetModel.{h,cpp}`** — four `Q_INVOKABLE` methods `insertRows`/`deleteRows`/`insertCols`/`deleteCols(int at, int count)` over the C ABI, mirroring `fill()` (recompute + regrow extent + bump `revision` + emit). `at`/`count` are **clamped to ≥ 0 before the `uint32_t` cast** so a stray negative can't wrap to a huge unsigned band.
- **`InfiniteSheet.qml`** — a new **"Structure"** segmented toolbar group (**+ Row / − Row / + Col / − Col**) between File and History, operating on the selected cell's row/col. Reuses the existing `ToolButton` component + separator.
- **`test/tst_window.cpp`** — a structural-edit proof: insert a row above a formula (`=H1+H2` → `=H1+H3`, value preserved), delete it back, delete a referenced row (⇒ `#REF!`), and a column insert that shifts a formula's column refs.

## Verification

- `tst_window` (qmake) — **11/11 PASS** incl. the new `structuralInsertDeleteShiftsReferences` case.
- Full app builds clean (`qmake` + `make`) with **no QML errors**. The Structure group reuses the `ToolButton` component already verified to render live in the Qt UI-polish PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)