### PR TITLE
feat(sir-runtime-oop): block-taking Array/Enumerable method dispatch (M1b)

### DIFF
--- a/code/packages/python/sir-runtime-oop/BUILD
+++ b/code/packages/python/sir-runtime-oop/BUILD
@@ -1,4 +1,6 @@
 uv venv --quiet --clear
+uv pip install -e ../sir-runtime-pairs --quiet
+uv pip install -e ../sir-runtime-core --quiet
 uv pip install -e .[dev] --quiet
 .venv/bin/python -m ruff check src tests
 .venv/bin/python -m mypy

--- a/code/packages/python/sir-runtime-oop/BUILD_windows
+++ b/code/packages/python/sir-runtime-oop/BUILD_windows
@@ -1,4 +1,6 @@
 uv venv --quiet --clear
+uv pip install -e ..\sir-runtime-pairs --quiet
+uv pip install -e ..\sir-runtime-core --quiet
 uv pip install -e .[dev] --quiet
 .venv\Scripts\python.exe -m ruff check src tests
 .venv\Scripts\python.exe -m mypy

--- a/code/packages/python/sir-runtime-oop/CHANGELOG.md
+++ b/code/packages/python/sir-runtime-oop/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 All notable changes to `coding-adventures-sir-runtime-oop` are documented here.
 
+## [0.1.2] - 2026-06-22
+
+### Added
+
+Built-in method dispatch, part 2 — **block-taking `Array`/`Enumerable` methods**
+(per `code/specs/sir-method-dispatch.md`, item M1b):
+`each`, `each_with_index`, `map`/`collect`, `select`/`filter`, `reject`,
+`reduce`/`inject` (with/without initial), `find`/`detect`, `flat_map`,
+`any?`/`all?`/`none?`. A trailing `Closure` block is applied via
+`sir-runtime-core`'s `apply` (proc-lenient arity); predicate results route
+through SIR `truthy` (only `false`/`nil` are falsy, so `0`/`""` are kept).
+`respond_to?` now reports these method names.
+
+### Changed
+
+- Adds a dependency on **`coding-adventures-sir-runtime-core`** (for `apply`,
+  `Closure`, `truthy`); wired via `[tool.uv.sources]` + leaf-to-root BUILD
+  install (pairs → core → self).
+- A block method invoked **without** a block still bottoms out at `nil` (Ruby
+  returns an `Enumerator`; v0 floor, documented).
+
 ## [0.1.1] - 2026-06-22
 
 ### Added

--- a/code/packages/python/sir-runtime-oop/README.md
+++ b/code/packages/python/sir-runtime-oop/README.md
@@ -50,9 +50,12 @@ the **non-block `Array`** surface — `length`/`size`/`count`, `first`/`last`,
 `include?`, `index`, `push`/`<<`/`pop`/`shift`/`unshift`, `reverse`, `sort`,
 `min`/`max`/`sum`, `uniq`/`flatten`/`compact`, `empty?`, `to_a` — and the
 **universal `Object`** methods `nil?`, `==`, `!=`, `equal?`, `respond_to?`,
-`freeze`/`frozen?`, `dup`/`clone`, `itself`, `to_a`. Block-taking methods
-(`each`/`map`/`select`/…) and the Hash/String/Numeric/Symbol catalogs land in
-follow-up releases.
+`freeze`/`frozen?`, `dup`/`clone`, `itself`, `to_a`; and (item **M1b**)
+**block-taking `Array`/`Enumerable`** methods `each`, `each_with_index`,
+`map`/`collect`, `select`/`filter`, `reject`, `reduce`/`inject`, `find`/`detect`,
+`flat_map`, `any?`/`all?`/`none?` — a trailing `Closure` block is applied via
+`sir-runtime-core`'s `apply` (proc-lenient), predicates routed through SIR
+`truthy`. The Hash/String/Numeric/Symbol catalogs land in follow-up releases.
 
 ## Honest v0 limitation
 

--- a/code/packages/python/sir-runtime-oop/pyproject.toml
+++ b/code/packages/python/sir-runtime-oop/pyproject.toml
@@ -7,7 +7,7 @@ name = "coding-adventures-sir-runtime-oop"
 version = "0.1.0"
 description = "OOP runtime for Semantic-IR-emitted Python — class registry, is_a?/ancestry, instance- and class-variable stores, reflective method dispatch"
 requires-python = ">=3.12"
-dependencies = []
+dependencies = ["coding-adventures-sir-runtime-core"]
 license = "MIT"
 authors = [{ name = "Adhithya Rajasekaran" }]
 readme = "README.md"
@@ -29,6 +29,9 @@ Documentation = "https://github.com/adhithyan15/coding-adventures/tree/main/code
 
 [project.optional-dependencies]
 dev = ["pytest>=8.0", "pytest-cov>=5.0", "ruff>=0.4", "mypy>=1.10"]
+
+[tool.uv.sources]
+coding-adventures-sir-runtime-core = { path = "../sir-runtime-core", editable = true }
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/coding_adventures_sir_runtime_oop"]

--- a/code/packages/python/sir-runtime-oop/src/coding_adventures_sir_runtime_oop/oop.py
+++ b/code/packages/python/sir-runtime-oop/src/coding_adventures_sir_runtime_oop/oop.py
@@ -34,6 +34,12 @@ from __future__ import annotations
 from collections.abc import Callable
 from typing import Any
 
+# Block-taking catalog methods (each/map/select/…) invoke a Ruby block.  A block
+# reaches us as a trailing ``Closure`` from ``sir-runtime-core``; ``apply`` calls
+# it with proc-lenient arity, and ``truthy`` applies SIR truthiness (only
+# ``False``/``nil`` are falsy) to predicate results.
+from coding_adventures_sir_runtime_core import Closure, apply, truthy
+
 # The SIR universal value type at this package's boundary.
 Val = Any
 
@@ -276,6 +282,29 @@ _ARRAY_METHODS = frozenset(
     }
 )
 
+# Block-taking ``Array`` / ``Enumerable`` methods (M1b).  Each invokes a trailing
+# ``Closure`` block via :func:`apply`.  Listed in :func:`_responds_to` so
+# ``respond_to?`` reports them, and dispatched in :func:`_array_block_method`.
+_ARRAY_BLOCK_METHODS = frozenset(
+    {
+        "each",
+        "each_with_index",
+        "map",
+        "collect",
+        "select",
+        "filter",
+        "reject",
+        "reduce",
+        "inject",
+        "find",
+        "detect",
+        "flat_map",
+        "any?",
+        "all?",
+        "none?",
+    }
+)
+
 
 def _method_name(arg: Val) -> str:
     """Coerce a ``respond_to?`` argument (a :class:`Symbol`, ``":m"``-ish string,
@@ -293,7 +322,9 @@ def _responds_to(recv: Val, name: str) -> bool:
         return True
     if name in _OBJECT_METHODS:
         return True
-    return isinstance(recv, list) and name in _ARRAY_METHODS
+    if isinstance(recv, list):
+        return name in _ARRAY_METHODS or name in _ARRAY_BLOCK_METHODS
+    return False
 
 
 def _flatten(seq: Val) -> list[Val]:
@@ -412,6 +443,59 @@ def _array_method(recv: list[Val], name: str, args: list[Val]) -> Val:
     return _MISS
 
 
+def _array_block_method(recv: list[Val], name: str, args: list[Val], block: Closure) -> Val:
+    """Block-taking ``Array``/``Enumerable`` methods.  ``block`` is applied via
+    :func:`apply` (proc-lenient); predicate results route through SIR
+    :func:`truthy`.  Returns :data:`_MISS` if ``name`` is not a block method."""
+    if name == "each":
+        for item in recv:
+            apply(block, [item])
+        return recv
+    if name == "each_with_index":
+        for index, item in enumerate(recv):
+            apply(block, [item, index])
+        return recv
+    if name in ("map", "collect"):
+        return [apply(block, [item]) for item in recv]
+    if name in ("select", "filter"):
+        return [item for item in recv if truthy(apply(block, [item]))]
+    if name == "reject":
+        return [item for item in recv if not truthy(apply(block, [item]))]
+    if name in ("reduce", "inject"):
+        if args:
+            acc: Val = args[0]
+            rest = recv
+        elif recv:
+            acc = recv[0]
+            rest = recv[1:]
+        else:
+            return None
+        for item in rest:
+            acc = apply(block, [acc, item])
+        return acc
+    if name in ("find", "detect"):
+        for item in recv:
+            if truthy(apply(block, [item])):
+                return item
+        return None
+    if name == "flat_map":
+        out: list[Val] = []
+        for item in recv:
+            mapped = apply(block, [item])
+            if isinstance(mapped, list):
+                out.extend(mapped)
+            else:
+                out.append(mapped)
+        return out
+    if name == "any?":
+        return any(truthy(apply(block, [item])) for item in recv)
+    if name == "all?":
+        return all(truthy(apply(block, [item])) for item in recv)
+    if name == "none?":
+        return not any(truthy(apply(block, [item])) for item in recv)
+    return _MISS
+
+
 def call_method(recv: Val, name: str, *args: Val) -> Val:
     """Dispatch method ``name`` on ``recv``.
 
@@ -444,6 +528,12 @@ def call_method(recv: Val, name: str, *args: Val) -> Val:
 
     arg_list = list(args)
     if isinstance(recv, list):
+        # A block method (each/map/…) is dispatched only when an actual trailing
+        # Closure block is present; the block is split off the positional args.
+        if name in _ARRAY_BLOCK_METHODS and arg_list and isinstance(arg_list[-1], Closure):
+            result = _array_block_method(recv, name, arg_list[:-1], arg_list[-1])
+            if result is not _MISS:
+                return result
         result = _array_method(recv, name, arg_list)
         if result is not _MISS:
             return result

--- a/code/packages/python/sir-runtime-oop/tests/test_oop.py
+++ b/code/packages/python/sir-runtime-oop/tests/test_oop.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import pytest
+from coding_adventures_sir_runtime_core import Closure
 
 import coding_adventures_sir_runtime_oop as oop
+from coding_adventures_sir_runtime_oop import Val
 
 
 @pytest.fixture(autouse=True)
@@ -244,13 +246,72 @@ def test_respond_to_reports_catalog_membership() -> None:
     assert oop.call_method([1], "respond_to?", "reverse") is True
     assert oop.call_method([1], "respond_to?", "nil?") is True
     assert oop.call_method([1], "respond_to?", "is_a?") is True
-    # An out-of-catalog method (block method not yet implemented in M1a):
-    assert oop.call_method([1], "respond_to?", "map") is False
-    # Symbol-style argument is accepted via its name.
-    assert oop.call_method([1], "respond_to?", oop.class_of) is False
+    assert oop.call_method([1], "respond_to?", "map") is True  # block method (M1b)
+    # An out-of-catalog method:
+    assert oop.call_method([1], "respond_to?", "each_slice") is False
 
 
 def test_unknown_method_returns_nil_not_raise() -> None:
+    # A block method called WITHOUT a block bottoms out at nil (Ruby returns an
+    # Enumerator; v0 floor is nil — see spec).
     assert oop.call_method([1, 2, 3], "map") is None
     assert oop.call_method("hi", "upcase") is None
     assert oop.call_method(5, "times") is None
+
+
+# ── built-in method catalog: block-taking Array/Enumerable (M1b) ──────────────
+
+
+def test_each_runs_block_and_returns_receiver() -> None:
+    seen: list[Val] = []
+    a = [1, 2, 3]
+    result = oop.call_method(a, "each", Closure(seen.append))
+    assert seen == [1, 2, 3]
+    assert result is a
+
+
+def test_each_with_index() -> None:
+    pairs: list[Val] = []
+    oop.call_method(["a", "b"], "each_with_index", Closure(lambda x, i: pairs.append((x, i))))
+    assert pairs == [("a", 0), ("b", 1)]
+
+
+def test_map_collect_and_select_filter_reject() -> None:
+    assert oop.call_method([1, 2, 3], "map", Closure(lambda x: x * 2)) == [2, 4, 6]
+    assert oop.call_method([1, 2, 3], "collect", Closure(lambda x: x + 1)) == [2, 3, 4]
+    assert oop.call_method([1, 2, 3, 4], "select", Closure(lambda x: x % 2 == 0)) == [2, 4]
+    assert oop.call_method([1, 2, 3, 4], "filter", Closure(lambda x: x > 2)) == [3, 4]
+    assert oop.call_method([1, 2, 3, 4], "reject", Closure(lambda x: x % 2 == 0)) == [1, 3]
+
+
+def test_reduce_inject_with_and_without_initial() -> None:
+    assert oop.call_method([1, 2, 3, 4], "reduce", Closure(lambda a, b: a + b)) == 10
+    assert oop.call_method([1, 2, 3], "inject", 100, Closure(lambda a, b: a + b)) == 106
+    assert oop.call_method([], "reduce", Closure(lambda a, b: a + b)) is None
+
+
+def test_find_detect_and_flat_map() -> None:
+    assert oop.call_method([1, 2, 3, 4], "find", Closure(lambda x: x > 2)) == 3
+    assert oop.call_method([1, 2], "detect", Closure(lambda x: x > 9)) is None
+    assert oop.call_method([1, 2, 3], "flat_map", Closure(lambda x: [x, x * 10])) == [
+        1,
+        10,
+        2,
+        20,
+        3,
+        30,
+    ]
+
+
+def test_any_all_none_use_sir_truthiness() -> None:
+    assert oop.call_method([1, 2, 3], "any?", Closure(lambda x: x > 2)) is True
+    assert oop.call_method([1, 2, 3], "any?", Closure(lambda x: x > 9)) is False
+    assert oop.call_method([2, 4, 6], "all?", Closure(lambda x: x % 2 == 0)) is True
+    assert oop.call_method([2, 3], "all?", Closure(lambda x: x % 2 == 0)) is False
+    assert oop.call_method([1, 2, 3], "none?", Closure(lambda x: x > 9)) is True
+    assert oop.call_method([1, 2, 3], "none?", Closure(lambda x: x > 2)) is False
+
+
+def test_select_uses_sir_truthiness_not_python() -> None:
+    # SIR truthiness: only False/None are falsy, so 0 and "" are KEPT.
+    assert oop.call_method([0, 1, None, 2], "select", Closure(lambda x: x)) == [0, 1, 2]

--- a/code/packages/typescript/sir-runtime-oop/BUILD
+++ b/code/packages/typescript/sir-runtime-oop/BUILD
@@ -4,7 +4,9 @@ _targets = [
     ts_library(
         name = "sir-runtime-oop",
         srcs = ["src/**/*.ts", "tests/**/*.ts"],
-        deps = [],
+        # Transitive file: deps must ALL be listed (npm install does not
+        # recursively install file deps' own file deps): core + its pairs dep.
+        deps = ["typescript/sir-runtime-core", "typescript/sir-runtime-pairs"],
         test_runner = "vitest",
     ),
 ]

--- a/code/packages/typescript/sir-runtime-oop/CHANGELOG.md
+++ b/code/packages/typescript/sir-runtime-oop/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 All notable changes to `@coding-adventures/sir-runtime-oop` are documented here.
 
+## [0.1.2] - 2026-06-22
+
+### Added
+
+Built-in method dispatch, part 2 — **block-taking `Array`/`Enumerable` methods**
+(per `code/specs/sir-method-dispatch.md`, item M1b):
+`each`, `each_with_index`, `map`/`collect`, `select`/`filter`, `reject`,
+`reduce`/`inject` (with/without initial), `find`/`detect`, `flat_map`,
+`any?`/`all?`/`none?`. A trailing `Closure` block is applied via
+`@coding-adventures/sir-runtime-core`'s `apply` (proc-lenient arity); predicate
+results route through SIR `truthy` (only `false`/`nil` are falsy, so `0`/`""` are
+kept). `respond_to?` now reports these method names.
+
+### Changed
+
+- Adds a dependency on **`@coding-adventures/sir-runtime-core`** (for `apply`,
+  `Closure`, `truthy`). Its transitive `sir-runtime-pairs` dep is also listed as a
+  direct dep (npm does not recursively install file deps' own file deps).
+- A block method invoked **without** a block still bottoms out at `null` (Ruby
+  returns an `Enumerator`; v0 floor, documented).
+
 ## [0.1.1] - 2026-06-22
 
 ### Added

--- a/code/packages/typescript/sir-runtime-oop/README.md
+++ b/code/packages/typescript/sir-runtime-oop/README.md
@@ -50,8 +50,12 @@ the **non-block `Array`** surface — `length`/`size`/`count`, `first`/`last`,
 `include?`, `index`, `push`/`<<`/`pop`/`shift`/`unshift`, `reverse`, `sort`,
 `min`/`max`/`sum`, `uniq`/`flatten`/`compact`, `empty?`, `to_a` — and the
 **universal `Object`** methods `nil?`, `==`, `!=`, `equal?`, `respond_to?`,
-`freeze`/`frozen?`, `dup`/`clone`, `itself`, `to_a`. `include?`/`index`/`==` use
-deep value equality. Block-taking methods (`each`/`map`/`select`/…) and the
+`freeze`/`frozen?`, `dup`/`clone`, `itself`, `to_a` (`include?`/`index`/`==` use
+deep value equality); and (item **M1b**) **block-taking `Array`/`Enumerable`**
+methods `each`, `each_with_index`, `map`/`collect`, `select`/`filter`, `reject`,
+`reduce`/`inject`, `find`/`detect`, `flat_map`, `any?`/`all?`/`none?` — a trailing
+`Closure` block is applied via `@coding-adventures/sir-runtime-core`'s `apply`
+(proc-lenient), predicates routed through SIR `truthy`. The
 Hash/String/Numeric/Symbol catalogs land in follow-up releases.
 
 ## Honest v0 limitation

--- a/code/packages/typescript/sir-runtime-oop/package-lock.json
+++ b/code/packages/typescript/sir-runtime-oop/package-lock.json
@@ -8,6 +8,33 @@
       "name": "@coding-adventures/sir-runtime-oop",
       "version": "0.1.0",
       "license": "MIT",
+      "dependencies": {
+        "@coding-adventures/sir-runtime-core": "file:../sir-runtime-core",
+        "@coding-adventures/sir-runtime-pairs": "file:../sir-runtime-pairs"
+      },
+      "devDependencies": {
+        "@vitest/coverage-v8": "^4.1.0",
+        "typescript": "^5.0.0",
+        "vitest": "^4.1.0"
+      }
+    },
+    "../sir-runtime-core": {
+      "name": "@coding-adventures/sir-runtime-core",
+      "version": "0.1.3",
+      "license": "MIT",
+      "dependencies": {
+        "@coding-adventures/sir-runtime-pairs": "file:../sir-runtime-pairs"
+      },
+      "devDependencies": {
+        "@vitest/coverage-v8": "^4.1.0",
+        "typescript": "^5.0.0",
+        "vitest": "^4.1.0"
+      }
+    },
+    "../sir-runtime-pairs": {
+      "name": "@coding-adventures/sir-runtime-pairs",
+      "version": "0.1.0",
+      "license": "MIT",
       "devDependencies": {
         "@vitest/coverage-v8": "^4.1.0",
         "typescript": "^5.0.0",
@@ -73,6 +100,14 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/@coding-adventures/sir-runtime-core": {
+      "resolved": "../sir-runtime-core",
+      "link": true
+    },
+    "node_modules/@coding-adventures/sir-runtime-pairs": {
+      "resolved": "../sir-runtime-pairs",
+      "link": true
     },
     "node_modules/@emnapi/core": {
       "version": "1.10.0",
@@ -491,14 +526,14 @@
       "license": "MIT"
     },
     "node_modules/@vitest/coverage-v8": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.8.tgz",
-      "integrity": "sha512-lt3kovsyHwYe00wq4D1ti0Z974fWj4NLp6siqiyEufUpyFwK9Yhi7rBhac9JL5aA0zoMrJqc4vYPZRUnI7l7nw==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.9.tgz",
+      "integrity": "sha512-G9/lgqibheLVBDRuya45EbsEXTYcWoSG+TLg7i2axuzx0Eq62eXn+aWXyaVdV5vKvFSWd6ywcX8hA7la9Pvu8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
-        "@vitest/utils": "4.1.8",
+        "@vitest/utils": "4.1.9",
         "ast-v8-to-istanbul": "^1.0.0",
         "istanbul-lib-coverage": "^3.2.2",
         "istanbul-lib-report": "^3.0.1",
@@ -512,8 +547,8 @@
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
-        "@vitest/browser": "4.1.8",
-        "vitest": "4.1.8"
+        "@vitest/browser": "4.1.9",
+        "vitest": "4.1.9"
       },
       "peerDependenciesMeta": {
         "@vitest/browser": {
@@ -522,16 +557,16 @@
       }
     },
     "node_modules/@vitest/expect": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.8.tgz",
-      "integrity": "sha512-h3nDO677RDLEGlBxyQ5CW8RlMThSKSRLUePLOx09gNIWRL40edgA1GCZSZgf1W55MFAG6/Sw14KeaAnqv0NKdQ==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.9.tgz",
+      "integrity": "sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.1.0",
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "4.1.8",
-        "@vitest/utils": "4.1.8",
+        "@vitest/spy": "4.1.9",
+        "@vitest/utils": "4.1.9",
         "chai": "^6.2.2",
         "tinyrainbow": "^3.1.0"
       },
@@ -540,13 +575,13 @@
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.8.tgz",
-      "integrity": "sha512-LEiN/xe4OSIbKe9HQIp5OC24agGD9J5CnmMgsLohVVoOPWL9a2sBoR6VBx43jQZb7Kr1l4RCuyCJzcAa0+dojw==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.9.tgz",
+      "integrity": "sha512-EVkXzBjrPGM+cK8/ANWgBrkUCfJfb38/EfTSO8h7pWvKkyPkpWxvR7BkD2MyItMF62C97zAEoqdpUixwR/e+Rw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "4.1.8",
+        "@vitest/spy": "4.1.9",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.21"
       },
@@ -567,9 +602,9 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.8.tgz",
-      "integrity": "sha512-9GasEBxpZ1VYIpqHf/0+YGg121uSNwCKOJqIrTwWP/TB7DmFCiaBpNl3aPZzoLWfWkuqhbH8vJIVobZkvdo2cA==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.9.tgz",
+      "integrity": "sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -580,13 +615,13 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.8.tgz",
-      "integrity": "sha512-EmVxeBAfMJvycdjd6Hm+RbFBbA9fKvo0Kx37hNpBYoYeavH3RNsBXWDooR1mgD52dCrxIIuP7UotpfiwOikvcg==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.9.tgz",
+      "integrity": "sha512-KXLMDtc7oe70+3mJfGrPUWPesswH+3sTxAMAMl8DG7I8IUQT4XW718dY5ID3vPUcmlu27CcKfY4P3h3I29SLJg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "4.1.8",
+        "@vitest/utils": "4.1.9",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -594,14 +629,14 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.8.tgz",
-      "integrity": "sha512-acfZboRmAIf05DEKcBQy33VXojFJjtUdLyo7oOmV9kebb2xdU01UknNiPuPZoJZQyO7DF0gZdTGTpeAzET9QPQ==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.9.tgz",
+      "integrity": "sha512-Jc7RKGNBo8Z28WYIm0Niej4xdSPByRf6mU58VpHQkd6Zh05rlnA+twjbK5HyeIGHxrzsc3mJgS43uM0CZKzaIA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.8",
-        "@vitest/utils": "4.1.8",
+        "@vitest/pretty-format": "4.1.9",
+        "@vitest/utils": "4.1.9",
         "magic-string": "^0.30.21",
         "pathe": "^2.0.3"
       },
@@ -610,9 +645,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.8.tgz",
-      "integrity": "sha512-6EevtBp6OZOPF7bmz36HrGMeP3txgVSrgebWxHOafDXGkhIzfXK14f8KF6MuFfgXXUeHxmpD3BQxkV00/3s5mA==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.9.tgz",
+      "integrity": "sha512-fHpsS6mIi+PiEW+vcRVOMkX1oSaPKne3VOclSFICPcGOmfKgXPU5iAah+wcNcj2xPrCCmfq99IDGf+EojhhvhA==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -620,13 +655,13 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.8.tgz",
-      "integrity": "sha512-uOJamYALNhfJ6iolExyQM40yIQwDqYnkKtQ5VCiSe17E33H0aQ/u+1GlRuz4LZBk6Mm3sg90G9hEbmEt37C1Zg==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.9.tgz",
+      "integrity": "sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.8",
+        "@vitest/pretty-format": "4.1.9",
         "convert-source-map": "^2.0.0",
         "tinyrainbow": "^3.1.0"
       },
@@ -1118,9 +1153,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.15",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
+      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
       "dev": true,
       "funding": [
         {
@@ -1241,9 +1276,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.8.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
-      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -1442,19 +1477,19 @@
       }
     },
     "node_modules/vitest": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.8.tgz",
-      "integrity": "sha512-flY6ScbCIt9HThs+C5HS7jvGOB560DJtk/Z15IQROTA6zEy49Nh8T/dofWTQL+n3vswqn87sbJNiuqw1SDp5Ig==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.9.tgz",
+      "integrity": "sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "4.1.8",
-        "@vitest/mocker": "4.1.8",
-        "@vitest/pretty-format": "4.1.8",
-        "@vitest/runner": "4.1.8",
-        "@vitest/snapshot": "4.1.8",
-        "@vitest/spy": "4.1.8",
-        "@vitest/utils": "4.1.8",
+        "@vitest/expect": "4.1.9",
+        "@vitest/mocker": "4.1.9",
+        "@vitest/pretty-format": "4.1.9",
+        "@vitest/runner": "4.1.9",
+        "@vitest/snapshot": "4.1.9",
+        "@vitest/spy": "4.1.9",
+        "@vitest/utils": "4.1.9",
         "es-module-lexer": "^2.0.0",
         "expect-type": "^1.3.0",
         "magic-string": "^0.30.21",
@@ -1482,12 +1517,12 @@
         "@edge-runtime/vm": "*",
         "@opentelemetry/api": "^1.9.0",
         "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.1.8",
-        "@vitest/browser-preview": "4.1.8",
-        "@vitest/browser-webdriverio": "4.1.8",
-        "@vitest/coverage-istanbul": "4.1.8",
-        "@vitest/coverage-v8": "4.1.8",
-        "@vitest/ui": "4.1.8",
+        "@vitest/browser-playwright": "4.1.9",
+        "@vitest/browser-preview": "4.1.9",
+        "@vitest/browser-webdriverio": "4.1.9",
+        "@vitest/coverage-istanbul": "4.1.9",
+        "@vitest/coverage-v8": "4.1.9",
+        "@vitest/ui": "4.1.9",
         "happy-dom": "*",
         "jsdom": "*",
         "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"

--- a/code/packages/typescript/sir-runtime-oop/package.json
+++ b/code/packages/typescript/sir-runtime-oop/package.json
@@ -20,6 +20,10 @@
   ],
   "author": "Adhithya Rajasekaran",
   "license": "MIT",
+  "dependencies": {
+    "@coding-adventures/sir-runtime-core": "file:../sir-runtime-core",
+    "@coding-adventures/sir-runtime-pairs": "file:../sir-runtime-pairs"
+  },
   "devDependencies": {
     "typescript": "^5.0.0",
     "vitest": "^4.1.0",

--- a/code/packages/typescript/sir-runtime-oop/src/index.ts
+++ b/code/packages/typescript/sir-runtime-oop/src/index.ts
@@ -34,6 +34,12 @@
 // into method bodies (out of scope for the backend).  See
 // `code/specs/sir-runtime.md`.
 
+// Block-taking catalog methods (each/map/select/…) invoke a Ruby block.  A block
+// reaches us as a trailing `Closure` from sir-runtime-core; `apply` calls it with
+// proc-lenient arity, and `truthy` applies SIR truthiness (only `false`/`nil` are
+// falsy) to predicate results.
+import { apply, Closure, truthy } from "@coding-adventures/sir-runtime-core";
+
 /**
  * The SIR universal value type at this package's boundary.  Kept as `unknown`'s
  * permissive sibling so emitted code can pass `@coding-adventures/sir-runtime-core`
@@ -263,6 +269,26 @@ const ARRAY_METHODS = new Set<string>([
   "to_a",
 ]);
 
+// Block-taking `Array`/`Enumerable` methods (M1b); each invokes a trailing
+// `Closure` block via `apply`. Listed so `respond_to?` reports them.
+const ARRAY_BLOCK_METHODS = new Set<string>([
+  "each",
+  "each_with_index",
+  "map",
+  "collect",
+  "select",
+  "filter",
+  "reject",
+  "reduce",
+  "inject",
+  "find",
+  "detect",
+  "flat_map",
+  "any?",
+  "all?",
+  "none?",
+]);
+
 /** SIR value equality used by `include?`/`index`/`==` — `===` for primitives,
  * structural for arrays and `Map`s (Ruby `==` is deep). */
 function valEq(a: Val, b: Val): boolean {
@@ -297,7 +323,9 @@ function respondsTo(recv: Val, name: string): boolean {
   }
   if (methods.has(name)) return true;
   if (OBJECT_METHODS.has(name)) return true;
-  if (Array.isArray(recv) && ARRAY_METHODS.has(name)) return true;
+  if (Array.isArray(recv) && (ARRAY_METHODS.has(name) || ARRAY_BLOCK_METHODS.has(name))) {
+    return true;
+  }
   return false;
 }
 
@@ -422,6 +450,72 @@ function arrayMethod(recv: Val[], name: string, args: Val[]): Val | typeof MISS 
   }
 }
 
+/** Block-taking `Array`/`Enumerable` methods.  `block` is applied via `apply`
+ * (proc-lenient); predicate results route through SIR `truthy`.  Returns `MISS`
+ * if `name` is not a block method. */
+function arrayBlockMethod(
+  recv: Val[],
+  name: string,
+  args: Val[],
+  block: Closure,
+): Val | typeof MISS {
+  switch (name) {
+    case "each":
+      for (const item of recv) apply(block, [item]);
+      return recv;
+    case "each_with_index":
+      recv.forEach((item: Val, index: number) => apply(block, [item, index]));
+      return recv;
+    case "map":
+    case "collect":
+      return recv.map((item: Val) => apply(block, [item]));
+    case "select":
+    case "filter":
+      return recv.filter((item: Val) => truthy(apply(block, [item])));
+    case "reject":
+      return recv.filter((item: Val) => !truthy(apply(block, [item])));
+    case "reduce":
+    case "inject": {
+      let acc: Val;
+      let rest: Val[];
+      if (args.length > 0) {
+        acc = args[0];
+        rest = recv;
+      } else if (recv.length > 0) {
+        acc = recv[0];
+        rest = recv.slice(1);
+      } else {
+        return null;
+      }
+      for (const item of rest) acc = apply(block, [acc, item]);
+      return acc;
+    }
+    case "find":
+    case "detect":
+      for (const item of recv) {
+        if (truthy(apply(block, [item]))) return item;
+      }
+      return null;
+    case "flat_map": {
+      const out: Val[] = [];
+      for (const item of recv) {
+        const mapped = apply(block, [item]);
+        if (Array.isArray(mapped)) out.push(...mapped);
+        else out.push(mapped);
+      }
+      return out;
+    }
+    case "any?":
+      return recv.some((item: Val) => truthy(apply(block, [item])));
+    case "all?":
+      return recv.every((item: Val) => truthy(apply(block, [item])));
+    case "none?":
+      return !recv.some((item: Val) => truthy(apply(block, [item])));
+    default:
+      return MISS;
+  }
+}
+
 /**
  * Dispatch method `name` on `recv`.  Resolution order:
  *
@@ -452,6 +546,13 @@ export function callMethod(recv: Val, name: string, ...args: Val[]): Val {
   if (m) return m(recv, args);
 
   if (Array.isArray(recv)) {
+    // A block method (each/map/…) is dispatched only when an actual trailing
+    // Closure block is present; the block is split off the positional args.
+    const last = args[args.length - 1];
+    if (ARRAY_BLOCK_METHODS.has(name) && args.length > 0 && last instanceof Closure) {
+      const blkResult = arrayBlockMethod(recv, name, args.slice(0, -1), last);
+      if (blkResult !== MISS) return blkResult;
+    }
     const arrResult = arrayMethod(recv, name, args);
     if (arrResult !== MISS) return arrResult;
   }

--- a/code/packages/typescript/sir-runtime-oop/tests/oop.test.ts
+++ b/code/packages/typescript/sir-runtime-oop/tests/oop.test.ts
@@ -1,4 +1,6 @@
 import { beforeEach, describe, expect, it } from "vitest";
+import { Closure } from "@coding-adventures/sir-runtime-core";
+import type { Val } from "../src/index.js";
 import {
   callMethod,
   classOf,
@@ -245,12 +247,68 @@ describe("respond_to? honesty + nil floor (M1a)", () => {
     expect(callMethod([1], "respond_to?", "reverse")).toBe(true);
     expect(callMethod([1], "respond_to?", "nil?")).toBe(true);
     expect(callMethod([1], "respond_to?", "is_a?")).toBe(true);
-    expect(callMethod([1], "respond_to?", "map")).toBe(false);
+    expect(callMethod([1], "respond_to?", "map")).toBe(true); // block method (M1b)
+    expect(callMethod([1], "respond_to?", "each_slice")).toBe(false);
   });
 
   it("unknown method returns nil, never throws", () => {
+    // A block method called WITHOUT a block bottoms out at nil (v0 floor).
     expect(callMethod([1, 2, 3], "map")).toBeNull();
     expect(callMethod("hi", "upcase")).toBeNull();
     expect(callMethod(5, "times")).toBeNull();
+  });
+});
+
+describe("built-in method catalog: block-taking Array/Enumerable (M1b)", () => {
+  it("each runs the block and returns the receiver", () => {
+    const seen: Val[] = [];
+    const a = [1, 2, 3];
+    const result = callMethod(a, "each", new Closure((x: Val) => seen.push(x)));
+    expect(seen).toEqual([1, 2, 3]);
+    expect(result).toBe(a);
+  });
+
+  it("each_with_index", () => {
+    const pairs: Val[] = [];
+    callMethod(["a", "b"], "each_with_index", new Closure((x: Val, i: Val) => pairs.push([x, i])));
+    expect(pairs).toEqual([
+      ["a", 0],
+      ["b", 1],
+    ]);
+  });
+
+  it("map/collect, select/filter, reject", () => {
+    expect(callMethod([1, 2, 3], "map", new Closure((x: Val) => x * 2))).toEqual([2, 4, 6]);
+    expect(callMethod([1, 2, 3], "collect", new Closure((x: Val) => x + 1))).toEqual([2, 3, 4]);
+    expect(callMethod([1, 2, 3, 4], "select", new Closure((x: Val) => x % 2 === 0))).toEqual([2, 4]);
+    expect(callMethod([1, 2, 3, 4], "filter", new Closure((x: Val) => x > 2))).toEqual([3, 4]);
+    expect(callMethod([1, 2, 3, 4], "reject", new Closure((x: Val) => x % 2 === 0))).toEqual([1, 3]);
+  });
+
+  it("reduce/inject with and without initial", () => {
+    expect(callMethod([1, 2, 3, 4], "reduce", new Closure((a: Val, b: Val) => a + b))).toBe(10);
+    expect(callMethod([1, 2, 3], "inject", 100, new Closure((a: Val, b: Val) => a + b))).toBe(106);
+    expect(callMethod([], "reduce", new Closure((a: Val, b: Val) => a + b))).toBeNull();
+  });
+
+  it("find/detect and flat_map", () => {
+    expect(callMethod([1, 2, 3, 4], "find", new Closure((x: Val) => x > 2))).toBe(3);
+    expect(callMethod([1, 2], "detect", new Closure((x: Val) => x > 9))).toBeNull();
+    expect(callMethod([1, 2, 3], "flat_map", new Closure((x: Val) => [x, x * 10]))).toEqual([
+      1, 10, 2, 20, 3, 30,
+    ]);
+  });
+
+  it("any?/all?/none? use SIR truthiness", () => {
+    expect(callMethod([1, 2, 3], "any?", new Closure((x: Val) => x > 2))).toBe(true);
+    expect(callMethod([1, 2, 3], "any?", new Closure((x: Val) => x > 9))).toBe(false);
+    expect(callMethod([2, 4, 6], "all?", new Closure((x: Val) => x % 2 === 0))).toBe(true);
+    expect(callMethod([2, 3], "all?", new Closure((x: Val) => x % 2 === 0))).toBe(false);
+    expect(callMethod([1, 2, 3], "none?", new Closure((x: Val) => x > 9))).toBe(true);
+    expect(callMethod([1, 2, 3], "none?", new Closure((x: Val) => x > 2))).toBe(false);
+  });
+
+  it("select uses SIR truthiness (0 and '' are truthy)", () => {
+    expect(callMethod([0, 1, null, 2], "select", new Closure((x: Val) => x))).toEqual([0, 1, 2]);
   });
 });


### PR DESCRIPTION
## What
Second slice of **M1 — built-in method dispatch**: the **block-taking `Array`/`Enumerable`**
methods now execute in both `sir-runtime-oop` backends. `[1,2,3].map { |x| x*2 }`, `.select`,
`.reduce`, `.find`, `.any?`, `.each` etc. run instead of returning `nil`.

## Methods
`each`, `each_with_index`, `map`/`collect`, `select`/`filter`, `reject`, `reduce`/`inject`
(with/without initial), `find`/`detect`, `flat_map`, `any?`/`all?`/`none?`.

## How
- A trailing `Closure` block is split off the positional args and applied via
  `sir-runtime-core` `apply()` (proc-lenient arity); predicate results route through SIR
  `truthy` (only `false`/`nil` falsy → `0`/`""` are kept).
- `respond_to?` now reports these names; a block method called **without** a block bottoms out
  at `nil` (Ruby returns an Enumerator; v0 floor, documented).

## Dependency wiring
Adds `sir-runtime-oop` → `sir-runtime-core`:
- Python: `[tool.uv.sources]` + leaf-to-root BUILD (`pairs → core → self`).
- TypeScript: package.json `file:` deps for **both** core and its transitive `pairs` (npm does
  not recursively install file deps; per `typescript_library.star` + lessons.md), `ts_library`
  `deps` updated, package-lock refreshed.

## Verification
- Python: 33 tests pass, `ruff` + `mypy --strict` clean, 96% coverage.
- TypeScript: 32 vitest pass, `tsc --noEmit` clean (CI-equivalent single `npm install`).
- Security review: passed (closed-allowlist dispatch; blocks are compiler `Closure`s applied via
  `apply`, no eval/reflection/proto-pollution).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
