### PR TITLE
feat(constant-fold): fold unary `~` (BitNot) on numeric literals

### DIFF
--- a/code/packages/rust/closure-pass-constant-fold/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-constant-fold/CHANGELOG.md
@@ -2,6 +2,35 @@
 
 All notable changes to the `coding-adventures-closure-pass-constant-fold` crate will be documented in this file.
 
+## [0.18.0] - 2026-06-22
+
+### Added — unary bitwise NOT folding (`~5` → `-6`)
+
+`fold_unary` now folds the unary `~` operator on a `NumericLiteral` under ES
+`ToInt32` semantics (ECMAScript §13.5.6 `BitwiseNOT`):
+
+| before  | after | reasoning                                   |
+|---------|-------|---------------------------------------------|
+| `~5`    | `-6`  | `~ToInt32(5)  = ~5  = -6`                    |
+| `~-1`   | `0`   | `~ToInt32(-1) = ~-1 =  0`                    |
+| `~5.9`  | `-6`  | `ToInt32` truncates toward zero first → `~5` |
+| `~~9`   | `9`   | double complement is the `ToInt32` identity (folds bottom-up in one walk) |
+
+This was the lone bitwise gap: the binary `&`/`|`/`^`/`<<`/`>>`/`>>>` operators
+already fold via [`to_int32`]/[`to_uint32`] (CLOC15.D), and `~` now reuses the
+very same `to_int32` coercion so the unary and binary bitwise paths stay
+bit-for-bit consistent. Rust's prefix `!` on `i32` *is* the two's-complement
+bitwise NOT, matching JS exactly.
+
+Folding is restricted to a `NumericLiteral` argument: `~x` for an identifier or
+call needs the runtime value, and `~"5"`/`~true` would require string/boolean
+`ToNumber` coercion that the conservative fold-set deliberately leaves to a
+later phase. The fold emits a correlation-vector contribution like every other
+fold, so `~5 → -6 → emitted token` stays traceable.
+
+Two new unit tests (`fold_bitwise_not_on_numeric_literal`,
+`bitwise_not_on_identifier_does_not_fold`).
+
 ## [0.17.0] - 2026-06-21
 
 ### Added — negation push for (in)equality (`!(a == b)` → `a != b`)

--- a/code/packages/rust/closure-pass-constant-fold/Cargo.toml
+++ b/code/packages/rust/closure-pass-constant-fold/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-constant-fold"
-version = "0.17.0"
+version = "0.18.0"
 edition = "2021"
 description = "Constant-folding optimization pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Folds compile-time-evaluable expressions like `2 + 3 → 5`."
 

--- a/code/packages/rust/closure-pass-constant-fold/src/lib.rs
+++ b/code/packages/rust/closure-pass-constant-fold/src/lib.rs
@@ -18,6 +18,7 @@
 //! 7 % 3              →  1
 //! 2 ** 8             →  256
 //! -3                 →  -3                      (UnaryExpression on NumericLiteral)
+//! ~5                 →  -6                      (bitwise NOT, ES ToInt32)
 //! !true              →  false
 //! 1 < 2              →  true                    (numeric comparison)
 //! "a" === "a"        →  true                    (strict equality, same type)
@@ -41,10 +42,12 @@
 //!   Phase 1.x.
 //! - `void` — produces ES `undefined`, same gap as above.
 //! - `delete` — has observable side effects.
-//! - Bitwise (`&`, `|`, `^`, `<<`, `>>`, `>>>`) — NOW FOLDED on two numeric
-//!   literals (CLOC15.D) via ES `ToInt32`/`ToUint32` 32-bit semantics. See
-//!   [`to_int32`] / [`to_uint32`]; `>>>` yields an unsigned result that can
-//!   exceed `i32::MAX`.
+//! - Bitwise binary (`&`, `|`, `^`, `<<`, `>>`, `>>>`) — NOW FOLDED on two
+//!   numeric literals (CLOC15.D) via ES `ToInt32`/`ToUint32` 32-bit
+//!   semantics. See [`to_int32`] / [`to_uint32`]; `>>>` yields an unsigned
+//!   result that can exceed `i32::MAX`. The unary bitwise NOT (`~`) is also
+//!   folded on a numeric literal, reusing [`to_int32`] so it stays
+//!   bit-for-bit consistent with the binary operators.
 //! - Equality between non-matching literal types (`1 == "1"` is `true`
 //!   but `1 === "1"` is `false`). The pass folds equality only when
 //!   both literals are the *same* JS type; mixed-type comparisons are
@@ -1245,7 +1248,32 @@ fn fold_unary(u: &UnaryExpression, st: &mut FoldState) -> Expression {
                 _ => None,
             }
         }
-        // Skipped: BitNot (int32 coercion), Delete (side effects).
+        UnaryOperator::BitNot => {
+            // `~<numeric literal>` → bitwise complement under ES `ToInt32`
+            // semantics (ECMAScript §13.5.6 `BitwiseNOT`):
+            //
+            //   ~5      →  -6        (~ToInt32(5)  = ~5  = -6)
+            //   ~-1     →   0        (~ToInt32(-1) = ~-1 =  0)
+            //   ~5.9    →  -6        (truncate toward zero first → ~5)
+            //   ~NaN    →  -1        (ToInt32(NaN) = 0, ~0 = -1)
+            //   ~2.5e10 →  fold of the 32-bit-wrapped operand
+            //
+            // The binary bitwise operators (`&`, `|`, `^`) already fold via
+            // [`to_int32`] (see `fold_binary`); the unary `~` was the lone
+            // bitwise gap and reuses the very same coercion so the two stay
+            // bit-for-bit consistent. Rust's prefix `!` on `i32` *is* the
+            // two's-complement bitwise NOT, matching JS exactly. We fold only
+            // a `NumericLiteral` argument — `~x` for an identifier or call
+            // needs the runtime value, and `~"5"`/`~true` would require
+            // string/boolean ToNumber coercion that the conservative fold-set
+            // deliberately leaves to a later phase.
+            if let Expression::NumericLiteral(n) = &arg {
+                Some(FoldedLiteral::Number((!to_int32(n.value)) as f64))
+            } else {
+                None
+            }
+        }
+        // Skipped: Delete (side effects).
         _ => None,
     };
 
@@ -2254,6 +2282,73 @@ mod tests {
             Expression::NumericLiteral(n) => assert_eq!(n.value, 1.0),
             other => panic!("expected 1; got {:?}", other),
         }
+    }
+
+    #[test]
+    fn fold_bitwise_not_on_numeric_literal() {
+        // ~5 → -6  (~ToInt32(5) = ~5 = -6)
+        let bn = Expression::UnaryExpression(UnaryExpression {
+            cv: Some("u.bn".to_string()),
+            operator: UnaryOperator::BitNot,
+            prefix: true,
+            argument: Box::new(num(5.0, None)),
+        });
+        let (out, _, changed, _) = run_pass(program_with_expr(bn, true));
+        assert!(changed, "~5 should fold");
+        match extract_expr(&out) {
+            Expression::NumericLiteral(n) => assert_eq!(n.value, -6.0),
+            other => panic!("expected -6; got {:?}", other),
+        }
+
+        // ~5.9 → -6  (ToInt32 truncates toward zero first → ~5)
+        let bn_frac = Expression::UnaryExpression(UnaryExpression {
+            cv: Some("u.bnf".to_string()),
+            operator: UnaryOperator::BitNot,
+            prefix: true,
+            argument: Box::new(num(5.9, None)),
+        });
+        let (out, _, _, _) = run_pass(program_with_expr(bn_frac, true));
+        match extract_expr(&out) {
+            Expression::NumericLiteral(n) => assert_eq!(n.value, -6.0),
+            other => panic!("expected -6; got {:?}", other),
+        }
+
+        // ~(-1) → 0. The inner `-1` is itself a Negate unary that folds to a
+        // NumericLiteral first, then the outer `~` folds bottom-up in one walk.
+        let inner_neg = Expression::UnaryExpression(UnaryExpression {
+            cv: Some("u.bn.inner".to_string()),
+            operator: UnaryOperator::Negate,
+            prefix: true,
+            argument: Box::new(num(1.0, None)),
+        });
+        let bn_neg = Expression::UnaryExpression(UnaryExpression {
+            cv: Some("u.bn.neg".to_string()),
+            operator: UnaryOperator::BitNot,
+            prefix: true,
+            argument: Box::new(inner_neg),
+        });
+        let (out, _, _, _) = run_pass(program_with_expr(bn_neg, true));
+        match extract_expr(&out) {
+            Expression::NumericLiteral(n) => assert_eq!(n.value, 0.0),
+            other => panic!("expected 0; got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn bitwise_not_on_identifier_does_not_fold() {
+        // `~x` needs the runtime value of `x`, so the unary stays put.
+        let bn = Expression::UnaryExpression(UnaryExpression {
+            cv: Some("u.bnx".to_string()),
+            operator: UnaryOperator::BitNot,
+            prefix: true,
+            argument: Box::new(ident("x")),
+        });
+        let (out, _, changed, _) = run_pass(program_with_expr(bn, true));
+        assert!(!changed, "~x must not fold");
+        assert!(matches!(
+            extract_expr(&out),
+            Expression::UnaryExpression(_)
+        ));
     }
 
     // ------------------- logical (short-circuit) ---------------------

--- a/code/programs/rust/closurec/CHANGELOG.md
+++ b/code/programs/rust/closurec/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to the `coding-adventures-closurec` binary will be documented in this file.
 
+## [0.163.0] - 2026-06-22
+
+### Added — unary bitwise NOT folding (`~5` → `-6`) at SIMPLE/ADVANCED
+
+Pulls in `coding-adventures-closure-pass-constant-fold` 0.18.0, which folds the
+unary `~` operator on a numeric literal under ES `ToInt32` semantics: `~5` →
+`-6`, `~-1` → `0`, `~5.9` → `-6`, `~~9` → `9`. This reuses the same `to_int32`
+coercion the binary bitwise operators already use, so the two stay bit-for-bit
+consistent.
+
+New e2e fixture `tests/diff/simple-fold-bitnot` (and integration test
+`diff_simple_fold_bitnot.rs`) is the end-to-end oracle, with a
+whitespace-fallback guard proving the fold comes from the SIMPLE typed pipeline.
+
+The `--help_markdown` golden fixture was regenerated for the version bump
+(`Version: 0.163.0`).
+
 ## [0.162.0] - 2026-06-21
 
 ### Added — negation push (`!(a == b)` → `a != b`) at SIMPLE/ADVANCED

--- a/code/programs/rust/closurec/Cargo.toml
+++ b/code/programs/rust/closurec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closurec"
-version = "0.162.0"
+version = "0.163.0"
 edition = "2021"
 description = "closurec — CLI driver for the Closure Compiler clone. Mirrors the upstream Java Closure Compiler's command-line flag surface (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility. Per CLOC08."
 

--- a/code/programs/rust/closurec/cli.spec.json
+++ b/code/programs/rust/closurec/cli.spec.json
@@ -2,7 +2,7 @@
   "cli_builder_spec_version": "1.0",
   "name": "closurec",
   "description": "closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.",
-  "version": "0.162.0",
+  "version": "0.163.0",
   "parsing_mode": "gnu",
   "flags": [
     { "id": "browser_featureset_year", "long": "browser_featureset_year", "type": "integer", "default": 0, "description": "Shortcut for defining goog.FEATURESET_YEAR=YYYY (minimum 2012)." },

--- a/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
@@ -2,7 +2,7 @@
 
 closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.
 
-Version: 0.162.0
+Version: 0.163.0
 
 ## Flags
 

--- a/code/programs/rust/closurec/tests/diff/simple-fold-bitnot/README.md
+++ b/code/programs/rust/closurec/tests/diff/simple-fold-bitnot/README.md
@@ -1,0 +1,35 @@
+# Fixture: `simple-fold-bitnot`
+
+End-to-end oracle for unary bitwise-NOT folding at
+`--compilation_level SIMPLE`.
+
+| File | Role |
+|------|------|
+| `flags.txt` | CLI args: `--compilation_level SIMPLE --js input/a.js` |
+| `input/a.js` | Four `var` declarations whose initializers are `~<numeric literal>` expressions |
+| `expected.stdout` | The folded output: `var a=-6;var b=0;var c=-6;var d=9;report(a,b,c,d);` |
+
+The SIMPLE level runs the typed-AST optimization pipeline, whose
+`constant-fold` pass now folds the unary `~` operator on a numeric
+literal under ES `ToInt32` semantics — reusing the very same `to_int32`
+coercion that the binary `&`/`|`/`^` operators already use, so the two
+stay bit-for-bit consistent:
+
+```
+~5    →  -6   (~ToInt32(5)  = ~5  = -6)
+~-1   →   0   (~ToInt32(-1) = ~-1 =  0)
+~5.9  →  -6   (ToInt32 truncates toward zero first → ~5)
+~~9   →   9   (double complement is the ToInt32 identity; folds
+               bottom-up in one walk: ~9 → -10, then ~-10 → 9)
+```
+
+The same input under `WHITESPACE_ONLY` keeps `~5` etc. unfolded (that
+level never runs the typed pipeline).
+
+Regenerate the expected file after an intentional behavior change:
+
+```sh
+cargo run -- --compilation_level SIMPLE \
+    --js tests/diff/simple-fold-bitnot/input/a.js \
+    > tests/diff/simple-fold-bitnot/expected.stdout
+```

--- a/code/programs/rust/closurec/tests/diff/simple-fold-bitnot/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/simple-fold-bitnot/expected.stdout
@@ -1,0 +1,1 @@
+var a=-6;var b=0;var c=-6;var d=9;report(a,b,c,d);

--- a/code/programs/rust/closurec/tests/diff/simple-fold-bitnot/flags.txt
+++ b/code/programs/rust/closurec/tests/diff/simple-fold-bitnot/flags.txt
@@ -1,0 +1,4 @@
+--compilation_level
+SIMPLE
+--js
+tests/diff/simple-fold-bitnot/input/a.js

--- a/code/programs/rust/closurec/tests/diff/simple-fold-bitnot/input/a.js
+++ b/code/programs/rust/closurec/tests/diff/simple-fold-bitnot/input/a.js
@@ -1,0 +1,22 @@
+// SIMPLE-level unary bitwise-NOT folding.
+//
+// `~<numeric literal>` is a compile-time-evaluable expression that the
+// `constant-fold` pass now collapses under ES `ToInt32` semantics
+// (the same coercion the binary `&`/`|`/`^` operators already use).
+// Under WHITESPACE_ONLY these would survive as `~5`, `~-1`, `~5.9`;
+// under SIMPLE they fold to their value:
+//
+//   ~5    →  -6   (~ToInt32(5)  = ~5  = -6)
+//   ~-1   →   0   (~ToInt32(-1) = ~-1 =  0)
+//   ~5.9  →  -6   (ToInt32 truncates toward zero first → ~5)
+//   ~~9   →   9   (double complement is the ToInt32 identity; folds
+//                  bottom-up in one walk: ~9 → -10, then ~-10 → 9)
+//
+// The values flow into `report(...)` so they stay referenced —
+// otherwise remove-unused-vars (the last SIMPLE pass) would delete the
+// whole declarations and the fold would not be observable.
+var a = ~5;
+var b = ~-1;
+var c = ~5.9;
+var d = ~~9;
+report(a, b, c, d);

--- a/code/programs/rust/closurec/tests/diff_simple_fold_bitnot.rs
+++ b/code/programs/rust/closurec/tests/diff_simple_fold_bitnot.rs
@@ -1,0 +1,88 @@
+//! Integration test for the `tests/diff/simple-fold-bitnot/` fixture.
+//!
+//! End-to-end oracle for unary bitwise-NOT folding in
+//! `closure-pass-constant-fold`: `~<numeric literal>` collapses under ES
+//! `ToInt32` semantics (the same `to_int32` coercion the binary `&`/`|`/`^`
+//! operators already use, so the two stay bit-for-bit consistent).
+//!
+//! At SIMPLE the fixture optimizes to:
+//!
+//! ```text
+//! var a=-6;var b=0;var c=-6;var d=9;report(a,b,c,d);
+//! ```
+
+use std::process::Command;
+
+const BINARY: &str = env!("CARGO_BIN_EXE_closurec");
+
+fn read_flags() -> Vec<String> {
+    let raw = std::fs::read_to_string("tests/diff/simple-fold-bitnot/flags.txt")
+        .expect("read flags.txt");
+    raw.lines()
+        .filter(|l| !l.is_empty())
+        .map(|s| s.to_string())
+        .collect()
+}
+
+#[test]
+fn simple_fold_bitnot_fixture_matches_expected_stdout() {
+    let flags = read_flags();
+    let out = Command::new(BINARY)
+        .args(&flags)
+        .output()
+        .expect("run closurec");
+
+    assert!(
+        out.status.success(),
+        "exit: {:?}, stderr: {}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stderr),
+    );
+
+    let actual = String::from_utf8_lossy(&out.stdout);
+    let expected = std::fs::read_to_string("tests/diff/simple-fold-bitnot/expected.stdout")
+        .expect("read expected.stdout");
+    assert_eq!(
+        actual.trim_end_matches('\n'),
+        expected.trim_end_matches('\n'),
+        "mismatch.\nflags: {flags:?}\nactual:\n{actual}\nexpected:\n{expected}",
+    );
+}
+
+/// Each `~<literal>` must fold to its ES `ToInt32`-complement value, including
+/// the double-complement `~~9 → 9` (which folds bottom-up in one walk).
+#[test]
+fn simple_fold_bitnot_folds_each_literal() {
+    let out = Command::new(BINARY)
+        .args(read_flags())
+        .output()
+        .expect("run closurec");
+    let actual = String::from_utf8_lossy(&out.stdout);
+
+    assert!(actual.contains("a=-6"), "~5 should fold to -6; got:\n{actual}");
+    assert!(actual.contains("b=0"), "~-1 should fold to 0; got:\n{actual}");
+    assert!(actual.contains("c=-6"), "~5.9 should fold to -6; got:\n{actual}");
+    assert!(actual.contains("d=9"), "~~9 should fold to 9; got:\n{actual}");
+    // The unfolded form must not survive the typed pipeline.
+    assert!(
+        !actual.contains('~'),
+        "no `~` should remain after folding; got:\n{actual}",
+    );
+}
+
+/// Regression guard: the output must be the SIMPLE typed pipeline, not the
+/// WHITESPACE_ONLY fallback (which would leave `~5` etc. intact).
+#[test]
+fn simple_fold_bitnot_did_not_fall_back_to_whitespace_only() {
+    let out = Command::new(BINARY)
+        .args(read_flags())
+        .output()
+        .expect("run closurec");
+    let actual = String::from_utf8_lossy(&out.stdout);
+
+    assert!(
+        !actual.contains("~5"),
+        "expected `~5` to be folded by the typed pipeline (proving this is the \
+         SIMPLE optimizer, not the whitespace fallback); got:\n{actual}",
+    );
+}


### PR DESCRIPTION
## What

Closes the lone unary bitwise gap in `closure-pass-constant-fold`. The binary bitwise operators (`&` `|` `^` `<<` `>>` `>>>`) already fold on two numeric literals via ES `ToInt32` (CLOC15.D); `fold_unary` now folds the unary `~` on a `NumericLiteral` too, **reusing the very same `to_int32` coercion** so the unary and binary bitwise paths stay bit-for-bit consistent.

| before  | after | reasoning |
|---------|-------|-----------|
| `~5`    | `-6`  | `~ToInt32(5)  = ~5  = -6` |
| `~-1`   | `0`   | `~ToInt32(-1) = ~-1 =  0` |
| `~5.9`  | `-6`  | `ToInt32` truncates toward zero first → `~5` |
| `~~9`   | `9`   | double complement is the `ToInt32` identity (folds bottom-up in one walk) |

Rust's prefix `!` on `i32` *is* the two's-complement bitwise NOT, matching JS exactly. Folding is restricted to a numeric-literal argument — `~x` for an identifier/call needs the runtime value, and `~"5"`/`~true` need `ToNumber` coercion that the conservative fold-set leaves to a later phase.

## Scope
- `closure-pass-constant-fold` 0.17.0 → 0.18.0 — new `BitNot` match arm in `fold_unary` + 2 unit tests (`fold_bitwise_not_on_numeric_literal`, `bitwise_not_on_identifier_does_not_fold`).
- `closurec` 0.162.0 → 0.163.0 — new e2e fixture `tests/diff/simple-fold-bitnot` + `diff_simple_fold_bitnot.rs` (with a whitespace-fallback guard); `--help_markdown` golden regenerated for the version bump.

## Verification
- constant-fold: 52 unit tests pass (incl. the 2 new).
- closurec: full suite green (incl. new fixture, help-markdown, version-string).
- Downstream consumer pass crates (emitter, fold-control-flow, collapse-properties, inline, inline-variables, dce) re-run green.
- Security review: PASSED (`to_int32` is total over all f64; no panic/overflow; sound arithmetic).

No lexer/parser/ASI/bridge files touched — independent of the in-flight ASI PR #6400.

🤖 Generated with [Claude Code](https://claude.com/claude-code)