### PR TITLE
feat(visicalc-flutter): insert / delete rows & columns in the Flutter demo

### DIFF
--- a/demo/visicalc-flutter/README.md
+++ b/demo/visicalc-flutter/README.md
@@ -135,7 +135,13 @@ engine recomputes on load, so a loaded formula stays live. The **Undo / Redo**
 buttons walk the engine's snapshot history (`InfiniteSheetModel.undoEdit`/
 `redoEdit` over the C ABI's `sc_undo`/`sc_redo`); they disable at the history
 ends via `canUndo`/`canRedo`. Every edit is reversible and a restored formula
-recomputes live. `InfiniteSheetModel`
+recomputes live. The **+ Row / − Row / + Col / − Col** buttons are **structural
+edits** (`InfiniteSheetModel.insertRow`/`deleteRow`/`insertCol`/`deleteCol` over
+the C ABI's `sc_insert_rows`/`sc_delete_rows`/`sc_insert_cols`/`sc_delete_cols`):
+insert or delete the selected cell's row/column, and the engine shifts every
+formula reference at or after the band so dependents keep pointing at their
+precedents (`=A1+A2` with a row inserted above becomes `=A1+A3`); a reference
+whose whole band is deleted becomes `#REF!`. `InfiniteSheetModel`
 (in `lib/engine.dart`) seeds far-flung sparse cells (`Z1000`, `BA50`, `BB50`) so
 there's something to scroll to, and derives the extent from `usedRange()` + a
 margin.
@@ -151,8 +157,9 @@ echoing the web demo's CSS custom properties rather than scattering ARGB values.
 From those it builds: a panel-wrapped **toolbar** with an address **pill**, an
 italic `fx` marker, then a grown formula field with an accent **focus ring**
 (driven by a `FocusNode`); the actions are **segmented button groups** (drag-fill
-· clipboard · file · history) — a reusable `_ToolButton` chip with hover/pressed/
-disabled states — separated by thin rules. The grid gets subtle **zebra** row
+· clipboard · file · structure · history) — a reusable `_ToolButton` chip with
+hover/pressed/disabled states — separated by thin rules; the bar scrolls
+horizontally so the controls never overflow a narrow window. The grid gets subtle **zebra** row
 banding, a 2-px **accent selection ring**, and the selected cell's **row + column
 headers tint to the accent**; a hairline-separated **status footer** echoes the
 live virtual-grid size and revision.

--- a/demo/visicalc-flutter/lib/engine.dart
+++ b/demo/visicalc-flutter/lib/engine.dart
@@ -73,6 +73,12 @@ typedef _FillC = Void Function(
 typedef _FillD = void Function(
     Pointer<Void>, Pointer<Uint8>, Pointer<Uint8>, Pointer<Uint8>);
 
+// sc_insert_rows / sc_delete_rows / sc_insert_cols / sc_delete_cols(session, at,
+// count) → void. Structural edits at a 1-based position; the engine shifts
+// formula references across the band.
+typedef _StructC = Void Function(Pointer<Void>, Uint32, Uint32);
+typedef _StructD = void Function(Pointer<Void>, int, int);
+
 // sc_copy / sc_cut(session, start, end) → void (clipboard capture; two A1 strings).
 typedef _ClipC = Void Function(Pointer<Void>, Pointer<Uint8>, Pointer<Uint8>);
 typedef _ClipD = void Function(Pointer<Void>, Pointer<Uint8>, Pointer<Uint8>);
@@ -99,6 +105,10 @@ class SpreadsheetSession {
   late final _ClipD _copyFn;
   late final _ClipD _cutFn;
   late final _PasteD _pasteFn;
+  late final _StructD _insertRowsFn;
+  late final _StructD _deleteRowsFn;
+  late final _StructD _insertColsFn;
+  late final _StructD _deleteColsFn;
   // Save / load: sc_serialize(session) → char* (same shape as the no-arg reads);
   // sc_deserialize(session, data) → int (same shape as sc_paste: session + one
   // string → 1/0).
@@ -131,6 +141,10 @@ class SpreadsheetSession {
     _copyFn = _lib.lookupFunction<_ClipC, _ClipD>('sc_copy');
     _cutFn = _lib.lookupFunction<_ClipC, _ClipD>('sc_cut');
     _pasteFn = _lib.lookupFunction<_PasteC, _PasteD>('sc_paste');
+    _insertRowsFn = _lib.lookupFunction<_StructC, _StructD>('sc_insert_rows');
+    _deleteRowsFn = _lib.lookupFunction<_StructC, _StructD>('sc_delete_rows');
+    _insertColsFn = _lib.lookupFunction<_StructC, _StructD>('sc_insert_cols');
+    _deleteColsFn = _lib.lookupFunction<_StructC, _StructD>('sc_delete_cols');
     _serializeFn = _lib.lookupFunction<_NoArgC, _NoArgD>('sc_serialize');
     _deserializeFn = _lib.lookupFunction<_PasteC, _PasteD>('sc_deserialize');
     _undoFn = _lib.lookupFunction<_FlagC, _FlagD>('sc_undo');
@@ -301,6 +315,25 @@ class SpreadsheetSession {
       _freeCString(endPtr);
     }
   }
+
+  /// Structural edits: insert / delete [count] rows or columns at the 1-based
+  /// position [at]. The engine shifts every formula reference at or after the
+  /// band (a reference whose whole band is deleted becomes `#REF!`), then
+  /// recomputes. [at]/[count] are clamped into the u32 range before crossing the
+  /// C ABI: clamping the LOW end stops a negative wrapping to a huge unsigned
+  /// band, and clamping the HIGH end stops a 64-bit Dart int silently truncating
+  /// to its low 32 bits (Dart `int` is 64-bit; the C param is `Uint32`).
+  void insertRows(int at, int count) =>
+      _insertRowsFn(_handle, _u32(at), _u32(count));
+  void deleteRows(int at, int count) =>
+      _deleteRowsFn(_handle, _u32(at), _u32(count));
+  void insertCols(int at, int count) =>
+      _insertColsFn(_handle, _u32(at), _u32(count));
+  void deleteCols(int at, int count) =>
+      _deleteColsFn(_handle, _u32(at), _u32(count));
+
+  // Clamp a Dart (64-bit) int into the unsigned 32-bit range the C ABI expects.
+  static int _u32(int v) => v < 0 ? 0 : (v > 0xFFFFFFFF ? 0xFFFFFFFF : v);
 
   /// Copy the inclusive rectangle [start]..[end] into the clipboard — a
   /// whole-block copy that pastes as a unit. The source is untouched; the buffer
@@ -603,6 +636,30 @@ class InfiniteSheetModel {
     final first = '$col${selRow + 1}';
     final last = '$col${selRow + rows}';
     _session.fill(infAddress, first, last);
+    computeExtent();
+  }
+
+  /// Structural edits: insert / delete the selected cell's row or column. The
+  /// engine shifts every formula reference at or after the band (a reference
+  /// whose whole band is deleted becomes `#REF!`) and recomputes; regrow the
+  /// extent so the view re-reads. Operate on a single row/column at the cursor.
+  void insertRow() {
+    _session.insertRows(selRow, 1);
+    computeExtent();
+  }
+
+  void deleteRow() {
+    _session.deleteRows(selRow, 1);
+    computeExtent();
+  }
+
+  void insertCol() {
+    _session.insertCols(selCol, 1);
+    computeExtent();
+  }
+
+  void deleteCol() {
+    _session.deleteCols(selCol, 1);
     computeExtent();
   }
 

--- a/demo/visicalc-flutter/lib/infinite_grid.dart
+++ b/demo/visicalc-flutter/lib/infinite_grid.dart
@@ -167,6 +167,27 @@ class _InfiniteGridState extends State<InfiniteGrid> {
     setState(() => _formulaCtrl.text = _model.formula);
   }
 
+  // Structural edits: insert / delete the selected cell's row or column. The
+  // engine shifts every formula reference across the band and recomputes; a
+  // reference whose whole band is deleted becomes #REF!. The grid re-reads and
+  // the formula bar re-syncs (the moved/destroyed source may differ).
+  void _insertRow() => setState(() {
+        _model.insertRow();
+        _formulaCtrl.text = _model.formula;
+      });
+  void _deleteRow() => setState(() {
+        _model.deleteRow();
+        _formulaCtrl.text = _model.formula;
+      });
+  void _insertCol() => setState(() {
+        _model.insertCol();
+        _formulaCtrl.text = _model.formula;
+      });
+  void _deleteCol() => setState(() {
+        _model.deleteCol();
+        _formulaCtrl.text = _model.formula;
+      });
+
   // A compact, modern toolbar button (rounded chip with hover/down/disabled
   // states) — the Flutter analog of the web demo's segmented controls and the
   // Qt port's `component ToolButton`. `enabled: null` disables it (Undo/Redo/
@@ -218,7 +239,11 @@ class _InfiniteGridState extends State<InfiniteGrid> {
         border: Border.all(color: _cLine),
         borderRadius: BorderRadius.circular(8),
       ),
-      child: Row(
+      // The toolbar holds many controls; let it scroll horizontally so it never
+      // overflows on a narrow window.
+      child: SingleChildScrollView(
+        scrollDirection: Axis.horizontal,
+        child: Row(
         children: [
           // Address pill.
           Container(
@@ -247,8 +272,10 @@ class _InfiniteGridState extends State<InfiniteGrid> {
                   fontStyle: FontStyle.italic,
                   fontFamily: _mono)),
           const SizedBox(width: 6),
-          // Formula field — accent focus ring on edit.
-          Expanded(
+          // Formula field — accent focus ring on edit. A fixed width (rather than
+          // Expanded) so it composes inside the horizontally-scrolling toolbar.
+          SizedBox(
+            width: 280,
             child: Container(
               height: 30,
               padding: const EdgeInsets.symmetric(horizontal: 8),
@@ -294,6 +321,21 @@ class _InfiniteGridState extends State<InfiniteGrid> {
           _toolButton('Load', 'Restore the workbook from the last save', _load,
               enabled: _savedSnapshot.isNotEmpty),
           _toolSep(),
+          // ── Structure (insert / delete the selected row or column) ──
+          _toolButton('+ Row',
+              'Insert a row above the selected cell (references shift down)', _insertRow),
+          const SizedBox(width: 6),
+          _toolButton('− Row',
+              "Delete the selected cell's row (references shift up; refs into it become #REF!)",
+              _deleteRow),
+          const SizedBox(width: 6),
+          _toolButton('+ Col',
+              'Insert a column left of the selected cell (references shift right)', _insertCol),
+          const SizedBox(width: 6),
+          _toolButton('− Col',
+              "Delete the selected cell's column (references shift left; refs into it become #REF!)",
+              _deleteCol),
+          _toolSep(),
           // ── History (undo / redo) ──
           _toolButton('↶ Undo', 'Undo the last edit', _undo,
               enabled: _model.canUndo),
@@ -301,6 +343,7 @@ class _InfiniteGridState extends State<InfiniteGrid> {
           _toolButton('↷ Redo', 'Redo the last undone edit', _redo,
               enabled: _model.canRedo),
         ],
+        ),
       ),
     );
   }

--- a/demo/visicalc-flutter/test/window_test.dart
+++ b/demo/visicalc-flutter/test/window_test.dart
@@ -97,6 +97,42 @@ void main() {
       s.setCell('C1', '9');
       expect(s.canRedo(), isFalse);
     });
+
+    test('insert / delete rows & columns shift formula references', () {
+      final s = SpreadsheetSession();
+      s.setCell('A1', '10');
+      s.setCell('A2', '20');
+      s.setCell('A3', '=A1+A2'); // 30
+      expect(s.window(3, 1, 3, 1)[0][0], '30');
+
+      // Insert a row at 2: A2/A3 shift down to A3/A4, row 2 blank, and the
+      // formula's refs shift with their cells (=A1+A2 → =A1+A3). The engine
+      // parenthesizes binary ops on re-emit, so strip parens to compare.
+      String bare(String a1) => s.getRaw(a1).replaceAll(RegExp(r'[()]'), '');
+      s.insertRows(2, 1);
+      expect(s.window(2, 1, 2, 1)[0][0], ''); // inserted row blank
+      expect(s.window(4, 1, 4, 1)[0][0], '30'); // formula at A4
+      expect(bare('A4'), '=A1+A3');
+
+      // Delete that inserted row: everything shifts back.
+      s.deleteRows(2, 1);
+      expect(s.window(3, 1, 3, 1)[0][0], '30');
+      expect(bare('A3'), '=A1+A2');
+
+      // Delete row 1 (referenced by the formula): its A1 reference is destroyed
+      // (→ #REF!) while the survivor shifts up.
+      s.deleteRows(1, 1);
+      expect(s.window(2, 1, 2, 1)[0][0], '#REF!');
+
+      // Columns shift the same way: K1=5, L1 = K1*3 = 15. Insert a column at K
+      // and the formula (now at M1) keeps pointing at its precedent (now L1).
+      final c = SpreadsheetSession();
+      c.setCell('K1', '5');
+      c.setCell('L1', '=K1*3');
+      c.insertCols(11, 1); // col 11 = K
+      expect(c.window(1, 13, 1, 13)[0][0], '15'); // M1
+      expect(c.getRaw('M1').replaceAll(RegExp(r'[()]'), ''), '=L1*3');
+    });
   });
 
   // The infinite-view binding layer (InfiniteGrid drives these): one engine read


### PR DESCRIPTION
## What

Third backend of the **insert / delete rows & columns** rollout (web [#6492](https://github.com/adhithyan15/coding-adventures/pull/6492) → Qt [#6496](https://github.com/adhithyan15/coding-adventures/pull/6496) → **Flutter** → Compose → XAML → SwiftUI). Engine + facades already implement structural edits; this wires them through **dart:ffi**. The vendored `native/libspreadsheet_capi.dylib` **already exports** the four `sc_*` symbols (`nm` check) — **no re-vendor**.

## Changes

- **`lib/engine.dart`** — a `_StructC/_StructD` FFI typedef + four lookups, four `SpreadsheetSession` methods `insertRows/deleteRows/insertCols/deleteCols(int at, int count)`, and four `InfiniteSheetModel` convenience methods `insertRow/deleteRow/insertCol/deleteCol` on the selected row/col (mirroring `fillDown`). `at`/`count` are clamped into the u32 range (`_u32`) before the FFI marshal — the low clamp stops a negative wrapping to a huge band, the **high clamp stops a 64-bit Dart int truncating** to its low 32 bits (addresses the security review's LOW finding).
- **`lib/infinite_grid.dart`** — a **"Structure"** segmented toolbar group (+ Row / − Row / + Col / − Col) + handlers. The 4 extra controls overflowed the toolbar `Row` at the test viewport, so the bar is now wrapped in a **horizontal `SingleChildScrollView`** (formula field → fixed 280px, since `Expanded` can't live in an unbounded-width scroll) — it never overflows a narrow window now.
- **`test/window_test.dart`** — a structural-edit proof: insert a row above a formula (`=A1+A2` → `=A1+A3`, value preserved), delete it back, delete a referenced row (⇒ `#REF!`), and a column insert that shifts column refs.

## Verification

- `flutter analyze` — clean.
- `flutter test` — **19/19 pass** (the overflow fix also cleared the 3 widget tests that the new buttons had broken). No macOS runner, so the widget test — which pumps the real `InfiniteGrid` tree on the live dart:ffi engine — is the canonical headless proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)