### PR TITLE
feat(visicalc-compose): insert / delete rows & columns in the Compose demo

### DIFF
--- a/demo/visicalc-compose/README.md
+++ b/demo/visicalc-compose/README.md
@@ -104,6 +104,13 @@ The **Undo / Redo** buttons walk the engine's snapshot history
 (`InfiniteSheetModel.undoEdit`/`redoEdit` over the C ABI's `sc_undo`/`sc_redo`);
 they disable at the history ends via `canUndo`/`canRedo`. Every edit is
 reversible and a restored formula recomputes live.
+The **+ Row / − Row / + Col / − Col** buttons are **structural edits**
+(`InfiniteSheetModel.insertRow`/`deleteRow`/`insertCol`/`deleteCol` over the C
+ABI's `sc_insert_rows`/`sc_delete_rows`/`sc_insert_cols`/`sc_delete_cols`): insert
+or delete the selected cell's row/column, and the engine shifts every formula
+reference at or after the band so dependents keep pointing at their precedents
+(`=A1+A2` with a row inserted above becomes `=A1+A3`); a reference whose whole band
+is deleted becomes `#REF!`.
 `InfiniteSheetModel` (in `Engine.kt`) seeds far-flung
 sparse cells (`Z1000`, `BA50`, `BB50`) and derives the extent from `usedRange()`
 + a margin.

--- a/demo/visicalc-compose/src/main/kotlin/Engine.kt
+++ b/demo/visicalc-compose/src/main/kotlin/Engine.kt
@@ -55,6 +55,13 @@ class SpreadsheetSession(libraryPath: String = resolveLibraryPath()) : AutoClose
     private val scCut = handle("sc_cut", FunctionDescriptor.ofVoid(ptr, ptr, ptr))
     // sc_paste(session, dst_start) -> int (1 applied, 0 no-op).
     private val scPaste = handle("sc_paste", FunctionDescriptor.of(i32, ptr, ptr))
+    // sc_insert_rows / sc_delete_rows / sc_insert_cols / sc_delete_cols(session,
+    // at, count) -> void. Structural edits at a 1-based position; the engine
+    // shifts every formula reference across the band.
+    private val scInsertRows = handle("sc_insert_rows", FunctionDescriptor.ofVoid(ptr, i32, i32))
+    private val scDeleteRows = handle("sc_delete_rows", FunctionDescriptor.ofVoid(ptr, i32, i32))
+    private val scInsertCols = handle("sc_insert_cols", FunctionDescriptor.ofVoid(ptr, i32, i32))
+    private val scDeleteCols = handle("sc_delete_cols", FunctionDescriptor.ofVoid(ptr, i32, i32))
     // sc_serialize(session) -> char* (workbook source + formats as JSON);
     // sc_deserialize(session, data) -> int (1 loaded, 0 malformed/unsupported).
     private val scSerialize = handle("sc_serialize", FunctionDescriptor.of(ptr, ptr))
@@ -144,6 +151,17 @@ class SpreadsheetSession(libraryPath: String = resolveLibraryPath()) : AutoClose
             a.allocateUtf8String(dstEnd),
         )
     }
+
+    /// Structural edits: insert / delete [count] rows or columns at the 1-based
+    /// position [at]. The engine shifts every formula reference at or after the
+    /// band (a reference whose whole band is deleted becomes `#REF!`), then
+    /// recomputes. [at]/[count] are clamped to ≥ 0 before the call so a negative
+    /// can't reach the u32 C ABI as a huge unsigned band (Kotlin Int maxes below
+    /// u32, so no high-end truncation).
+    fun insertRows(at: Int, count: Int) = scInsertRows.invoke(session, maxOf(0, at), maxOf(0, count))
+    fun deleteRows(at: Int, count: Int) = scDeleteRows.invoke(session, maxOf(0, at), maxOf(0, count))
+    fun insertCols(at: Int, count: Int) = scInsertCols.invoke(session, maxOf(0, at), maxOf(0, count))
+    fun deleteCols(at: Int, count: Int) = scDeleteCols.invoke(session, maxOf(0, at), maxOf(0, count))
 
     /// Copy the inclusive rectangle [start]..[end] into the clipboard — a
     /// whole-block copy that pastes as a unit. The source is untouched; the
@@ -447,6 +465,15 @@ class InfiniteSheetModel(
         session.fill(infAddress(), first, last)
         computeExtent()
     }
+
+    /// Structural edits: insert / delete the selected cell's row or column. The
+    /// engine shifts every formula reference at or after the band (a reference
+    /// whose whole band is deleted becomes `#REF!`) and recomputes; regrow the
+    /// extent so the view re-reads. Operate on a single row/column at the cursor.
+    fun insertRow() { session.insertRows(selRow, 1); computeExtent() }
+    fun deleteRow() { session.deleteRows(selRow, 1); computeExtent() }
+    fun insertCol() { session.insertCols(selCol, 1); computeExtent() }
+    fun deleteCol() { session.deleteCols(selCol, 1); computeExtent() }
 
     /// Clipboard: copy/cut the selected cell, then paste it at the selection. The
     /// engine shifts the pasted formula's relative references by the

--- a/demo/visicalc-compose/src/main/kotlin/InfiniteSheet.kt
+++ b/demo/visicalc-compose/src/main/kotlin/InfiniteSheet.kt
@@ -183,6 +183,15 @@ fun InfiniteSheet() {
         rev++
     }
 
+    // Structural edits: insert / delete the selected cell's row or column. The
+    // engine shifts every formula reference across the band and recomputes; a
+    // reference whose whole band is deleted becomes #REF!. Bump rev so the
+    // visible rows re-read and re-sync the formula bar.
+    fun insertRow() { model.insertRow(); formula = model.formula; rev++ }
+    fun deleteRow() { model.deleteRow(); formula = model.formula; rev++ }
+    fun insertCol() { model.insertCol(); formula = model.formula; rev++ }
+    fun deleteCol() { model.deleteCol(); formula = model.formula; rev++ }
+
     Column(modifier = Modifier.fillMaxSize().background(BG)) {
         // ── Formula bar: a panel holding the address pill, an `fx` marker, the
         // editable source line (with an accent focus ring), and segmented button
@@ -266,6 +275,15 @@ fun InfiniteSheet() {
             toolButton("Save") { saveBook() }
             Spacer(Modifier.width(6.dp))
             toolButton("Load", enabled = savedSnapshot.isNotEmpty()) { loadBook() }
+            toolSep()
+            // ── Structure (insert / delete the selected row or column) ──
+            toolButton("+ Row") { insertRow() }
+            Spacer(Modifier.width(6.dp))
+            toolButton("− Row") { deleteRow() }
+            Spacer(Modifier.width(6.dp))
+            toolButton("+ Col") { insertCol() }
+            Spacer(Modifier.width(6.dp))
+            toolButton("− Col") { deleteCol() }
             toolSep()
             // ── History (undo / redo). Reading `rev` re-evaluates canUndo/canRedo
             // on every edit so the buttons gate live.

--- a/demo/visicalc-compose/test/EngineSmoke.kt
+++ b/demo/visicalc-compose/test/EngineSmoke.kt
@@ -196,6 +196,31 @@ fun main() {
     check("fresh edit clears redo", ur.canRedo().toString(), "false")
     ur.close()
 
+    // Structural edits (the + Row / − Row / + Col / − Col buttons drive
+    // insertRows/deleteRows/insertCols/deleteCols): inserting and deleting
+    // rows/columns shifts every formula reference across the band, and deleting a
+    // referenced band turns that reference into #REF!. The engine parenthesizes
+    // binary ops on re-emit ("=(A1+A3)"), so compare with parens stripped.
+    val st = SpreadsheetSession()
+    st.setCell("A1", "10"); st.setCell("A2", "20"); st.setCell("A3", "=A1+A2") // 30
+    check("struct A3 before", st.window(3, 1, 3, 1)[0][0], "30")
+    st.insertRows(2, 1)
+    check("struct inserted row blank", st.window(2, 1, 2, 1)[0][0], "")
+    check("struct formula at A4", st.window(4, 1, 4, 1)[0][0], "30")
+    check("struct insert shifted refs", st.getRaw("A4").replace("(", "").replace(")", ""), "=A1+A3")
+    st.deleteRows(2, 1)
+    check("struct delete shifted back", st.getRaw("A3").replace("(", "").replace(")", ""), "=A1+A2")
+    st.deleteRows(1, 1) // delete the referenced row 1 → A1 ref destroyed
+    check("struct deleted ref is #REF!", st.window(2, 1, 2, 1)[0][0], "#REF!")
+    st.close()
+    // Columns shift the same way: K1=5, L1 = K1*3 = 15; insert a col at K → M1.
+    val sc = SpreadsheetSession()
+    sc.setCell("K1", "5"); sc.setCell("L1", "=K1*3")
+    sc.insertCols(11, 1) // col 11 = K
+    check("struct insertCol value", sc.window(1, 13, 1, 13)[0][0], "15") // M1
+    check("struct insertCol shifted refs", sc.getRaw("M1").replace("(", "").replace(")", ""), "=L1*3")
+    sc.close()
+
     println(if (failures == 0) "\nALL PASS" else "\n$failures FAILURE(S)")
     kotlin.system.exitProcess(if (failures == 0) 0 else 1)
 }


### PR DESCRIPTION
## What

Fourth backend of the **insert / delete rows & columns** rollout (web [#6492](https://github.com/adhithyan15/coding-adventures/pull/6492) → Qt [#6496](https://github.com/adhithyan15/coding-adventures/pull/6496) → Flutter [#6501](https://github.com/adhithyan15/coding-adventures/pull/6501) → **Compose** → XAML → SwiftUI). Engine + facades already implement structural edits; this wires them through **Java FFM**. The vendored `native/libspreadsheet_capi.dylib` **already exports** the four `sc_*` symbols (`nm` check) — **no re-vendor**.

## Changes

- **`Engine.kt`** — four FFM downcall handles (`ofVoid(ptr, i32, i32)`) + four `SpreadsheetSession` methods `insertRows/deleteRows/insertCols/deleteCols` (clamp `at`/`count` ≥ 0 before the call — Kotlin `Int` maxes below u32, so no high-end truncation) + four `InfiniteSheetModel` convenience methods `insertRow/deleteRow/insertCol/deleteCol` on the selected row/col (`computeExtent` so the view re-reads), mirroring `fillDown`.
- **`InfiniteSheet.kt`** — a **"Structure"** segmented toolbar group (+ Row / − Row / + Col / − Col) between File and History.
- **`test/EngineSmoke.kt`** — a structural-edit proof: insert a row above a formula (`=A1+A2` → `=A1+A3`, value preserved), delete it back, delete a referenced row (⇒ `#REF!`), and a column insert that shifts column refs.

## Verification

- `scripts/verify.sh` (kotlinc + FFM) — **ALL PASS** incl. the new struct cases.
- `gradle compileKotlin` — **BUILD SUCCESSFUL** (`InfiniteSheet.kt` compiles against the real Compose Desktop APIs). A live GUI needs `gradle run`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)