### PR TITLE
feat(sir-runtime-oop): Hash method dispatch (M1c)

### DIFF
--- a/code/packages/python/sir-runtime-oop/CHANGELOG.md
+++ b/code/packages/python/sir-runtime-oop/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to `coding-adventures-sir-runtime-oop` are documented here.
 
+## [0.1.3] - 2026-06-22
+
+### Added
+
+Built-in method dispatch, part 3 — the **`Hash`** catalog (per
+`code/specs/sir-method-dispatch.md`, item M1c; Hash is a Python `dict`):
+
+- Non-block: `keys`, `values`, `has_key?`/`key?`/`include?`/`member?`,
+  `has_value?`/`value?`, `fetch` (with optional default), `size`/`length`,
+  `empty?`, `to_a` (`[[k, v], …]`), `dig` (single-level v0), `store`/`[]=`,
+  `merge` (new dict), `delete`, `clear`, `invert`.
+- Block (block receives `[key, value]`): `each`/`each_pair`, `each_key`,
+  `each_value`, `map`, `select`/`filter`, `reject` — applied via
+  `sir-runtime-core` `apply`, predicates through SIR `truthy`.
+
+`respond_to?` reports the Hash methods; out-of-catalog stays `nil`. Universal
+`Object` methods still resolve on a Hash receiver.
+
 ## [0.1.2] - 2026-06-22
 
 ### Added

--- a/code/packages/python/sir-runtime-oop/README.md
+++ b/code/packages/python/sir-runtime-oop/README.md
@@ -55,7 +55,9 @@ the **non-block `Array`** surface — `length`/`size`/`count`, `first`/`last`,
 `map`/`collect`, `select`/`filter`, `reject`, `reduce`/`inject`, `find`/`detect`,
 `flat_map`, `any?`/`all?`/`none?` — a trailing `Closure` block is applied via
 `sir-runtime-core`'s `apply` (proc-lenient), predicates routed through SIR
-`truthy`. The Hash/String/Numeric/Symbol catalogs land in follow-up releases.
+`truthy`; and (item **M1c**) the **`Hash`** catalog
+(`keys`/`values`/`has_key?`/`fetch`/`merge`/`each`/`map`/`select`/…). The
+String/Numeric/Symbol catalogs land in follow-up releases.
 
 ## Honest v0 limitation
 

--- a/code/packages/python/sir-runtime-oop/src/coding_adventures_sir_runtime_oop/oop.py
+++ b/code/packages/python/sir-runtime-oop/src/coding_adventures_sir_runtime_oop/oop.py
@@ -305,6 +305,46 @@ _ARRAY_BLOCK_METHODS = frozenset(
     }
 )
 
+# Non-block ``Hash`` methods (M1c).  Hash is a Python ``dict``.
+_HASH_METHODS = frozenset(
+    {
+        "keys",
+        "values",
+        "has_key?",
+        "key?",
+        "include?",
+        "member?",
+        "has_value?",
+        "value?",
+        "fetch",
+        "size",
+        "length",
+        "empty?",
+        "to_a",
+        "dig",
+        "store",
+        "[]=",
+        "merge",
+        "delete",
+        "clear",
+        "invert",
+    }
+)
+
+# Block-taking ``Hash`` methods (M1c); the block receives ``[key, value]``.
+_HASH_BLOCK_METHODS = frozenset(
+    {
+        "each",
+        "each_pair",
+        "map",
+        "select",
+        "filter",
+        "reject",
+        "each_key",
+        "each_value",
+    }
+)
+
 
 def _method_name(arg: Val) -> str:
     """Coerce a ``respond_to?`` argument (a :class:`Symbol`, ``":m"``-ish string,
@@ -324,6 +364,8 @@ def _responds_to(recv: Val, name: str) -> bool:
         return True
     if isinstance(recv, list):
         return name in _ARRAY_METHODS or name in _ARRAY_BLOCK_METHODS
+    if isinstance(recv, dict):
+        return name in _HASH_METHODS or name in _HASH_BLOCK_METHODS
     return False
 
 
@@ -496,6 +538,70 @@ def _array_block_method(recv: list[Val], name: str, args: list[Val], block: Clos
     return _MISS
 
 
+def _hash_method(recv: dict[Val, Val], name: str, args: list[Val]) -> Val:
+    """Non-block ``Hash`` methods (Hash is a ``dict``).  Returns :data:`_MISS` if
+    ``name`` is not a catalogued hash method."""
+    if name == "keys":
+        return list(recv.keys())
+    if name == "values":
+        return list(recv.values())
+    if name in ("has_key?", "key?", "include?", "member?"):
+        return args[0] in recv
+    if name in ("has_value?", "value?"):
+        return args[0] in recv.values()
+    if name == "fetch":
+        if args[0] in recv:
+            return recv[args[0]]
+        return args[1] if len(args) > 1 else None
+    if name in ("size", "length"):
+        return len(recv)
+    if name == "empty?":
+        return len(recv) == 0
+    if name == "to_a":
+        return [[key, value] for key, value in recv.items()]
+    if name == "dig":
+        # v0: single-level dig; nested dig is a documented follow-up.
+        return recv.get(args[0])
+    if name in ("store", "[]="):
+        recv[args[0]] = args[1]
+        return args[1]
+    if name == "merge":
+        return {**recv, **args[0]}
+    if name == "delete":
+        return recv.pop(args[0], None)
+    if name == "clear":
+        recv.clear()
+        return recv
+    if name == "invert":
+        return {value: key for key, value in recv.items()}
+    return _MISS
+
+
+def _hash_block_method(recv: dict[Val, Val], name: str, block: Closure) -> Val:
+    """Block-taking ``Hash`` methods; the block receives ``[key, value]`` (or a
+    single key/value for ``each_key``/``each_value``).  Returns :data:`_MISS` if
+    ``name`` is not a hash block method."""
+    if name in ("each", "each_pair"):
+        for key, value in list(recv.items()):
+            apply(block, [key, value])
+        return recv
+    if name == "each_key":
+        for key in list(recv.keys()):
+            apply(block, [key])
+        return recv
+    if name == "each_value":
+        for value in list(recv.values()):
+            apply(block, [value])
+        return recv
+    if name == "map":
+        return [apply(block, [key, value]) for key, value in recv.items()]
+    if name in ("select", "filter"):
+        return {k: v for k, v in recv.items() if truthy(apply(block, [k, v]))}
+    if name == "reject":
+        return {k: v for k, v in recv.items() if not truthy(apply(block, [k, v]))}
+    return _MISS
+
+
 def call_method(recv: Val, name: str, *args: Val) -> Val:
     """Dispatch method ``name`` on ``recv``.
 
@@ -535,6 +641,14 @@ def call_method(recv: Val, name: str, *args: Val) -> Val:
             if result is not _MISS:
                 return result
         result = _array_method(recv, name, arg_list)
+        if result is not _MISS:
+            return result
+    elif isinstance(recv, dict):
+        if name in _HASH_BLOCK_METHODS and arg_list and isinstance(arg_list[-1], Closure):
+            result = _hash_block_method(recv, name, arg_list[-1])
+            if result is not _MISS:
+                return result
+        result = _hash_method(recv, name, arg_list)
         if result is not _MISS:
             return result
     result = _object_method(recv, name, arg_list)

--- a/code/packages/python/sir-runtime-oop/tests/test_oop.py
+++ b/code/packages/python/sir-runtime-oop/tests/test_oop.py
@@ -315,3 +315,78 @@ def test_any_all_none_use_sir_truthiness() -> None:
 def test_select_uses_sir_truthiness_not_python() -> None:
     # SIR truthiness: only False/None are falsy, so 0 and "" are KEPT.
     assert oop.call_method([0, 1, None, 2], "select", Closure(lambda x: x)) == [0, 1, 2]
+
+
+# ── built-in method catalog: Hash (M1c) ───────────────────────────────────────
+
+
+def test_hash_keys_values_size_empty() -> None:
+    h = {"a": 1, "b": 2}
+    assert oop.call_method(h, "keys") == ["a", "b"]
+    assert oop.call_method(h, "values") == [1, 2]
+    assert oop.call_method(h, "size") == 2
+    assert oop.call_method(h, "length") == 2
+    assert oop.call_method(h, "empty?") is False
+    assert oop.call_method({}, "empty?") is True
+
+
+def test_hash_key_value_membership() -> None:
+    h = {"a": 1}
+    assert oop.call_method(h, "has_key?", "a") is True
+    assert oop.call_method(h, "key?", "z") is False
+    assert oop.call_method(h, "include?", "a") is True
+    assert oop.call_method(h, "member?", "a") is True
+    assert oop.call_method(h, "has_value?", 1) is True
+    assert oop.call_method(h, "value?", 9) is False
+
+
+def test_hash_fetch_dig_to_a() -> None:
+    h = {"a": 1, "b": 2}
+    assert oop.call_method(h, "fetch", "a") == 1
+    assert oop.call_method(h, "fetch", "z") is None
+    assert oop.call_method(h, "fetch", "z", 99) == 99
+    assert oop.call_method(h, "dig", "b") == 2
+    assert oop.call_method(h, "to_a") == [["a", 1], ["b", 2]]
+
+
+def test_hash_store_merge_delete_clear_invert() -> None:
+    h = {"a": 1}
+    assert oop.call_method(h, "store", "b", 2) == 2
+    assert h == {"a": 1, "b": 2}
+    assert oop.call_method(h, "[]=", "c", 3) == 3
+    assert oop.call_method({"a": 1}, "merge", {"b": 2}) == {"a": 1, "b": 2}
+    assert oop.call_method(h, "delete", "a") == 1
+    assert "a" not in h
+    assert oop.call_method({"a": 1, "b": 2}, "invert") == {1: "a", 2: "b"}
+    cleared = {"a": 1}
+    assert oop.call_method(cleared, "clear") == {}
+
+
+def test_hash_block_each_map_select_reject() -> None:
+    seen: list[Val] = []
+    h = {"a": 1, "b": 2}
+    result = oop.call_method(h, "each", Closure(lambda k, v: seen.append((k, v))))
+    assert seen == [("a", 1), ("b", 2)]
+    assert result is h
+    assert oop.call_method(h, "map", Closure(lambda k, v: f"{k}={v}")) == ["a=1", "b=2"]
+    assert oop.call_method(h, "select", Closure(lambda k, v: v > 1)) == {"b": 2}
+    assert oop.call_method(h, "reject", Closure(lambda k, v: v > 1)) == {"a": 1}
+
+
+def test_hash_each_key_each_value() -> None:
+    ks: list[Val] = []
+    vs: list[Val] = []
+    h = {"a": 1, "b": 2}
+    oop.call_method(h, "each_key", Closure(ks.append))
+    oop.call_method(h, "each_value", Closure(vs.append))
+    assert ks == ["a", "b"]
+    assert vs == [1, 2]
+
+
+def test_hash_respond_to_and_nil_floor() -> None:
+    assert oop.call_method({"a": 1}, "respond_to?", "keys") is True
+    assert oop.call_method({"a": 1}, "respond_to?", "each") is True
+    assert oop.call_method({"a": 1}, "respond_to?", "transform_keys") is False
+    assert oop.call_method({"a": 1}, "transform_keys") is None
+    # Universal Object methods still resolve on a Hash receiver.
+    assert oop.call_method({"a": 1}, "nil?") is False

--- a/code/packages/typescript/sir-runtime-oop/CHANGELOG.md
+++ b/code/packages/typescript/sir-runtime-oop/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to `@coding-adventures/sir-runtime-oop` are documented here.
 
+## [0.1.3] - 2026-06-22
+
+### Added
+
+Built-in method dispatch, part 3 — the **`Hash`** catalog (per
+`code/specs/sir-method-dispatch.md`, item M1c; Hash is a JS `Map`):
+
+- Non-block: `keys`, `values`, `has_key?`/`key?`/`include?`/`member?`,
+  `has_value?`/`value?` (deep value equality), `fetch` (with optional default),
+  `size`/`length`, `empty?`, `to_a` (`[[k, v], …]`), `dig` (single-level v0),
+  `store`/`[]=`, `merge` (new `Map`), `delete`, `clear`, `invert`.
+- Block (block receives `[key, value]`): `each`/`each_pair`, `each_key`,
+  `each_value`, `map`, `select`/`filter`, `reject` — applied via
+  `@coding-adventures/sir-runtime-core` `apply`, predicates through SIR `truthy`.
+
+`respond_to?` reports the Hash methods; out-of-catalog stays `null`. Universal
+`Object` methods still resolve on a Hash receiver.
+
 ## [0.1.2] - 2026-06-22
 
 ### Added

--- a/code/packages/typescript/sir-runtime-oop/README.md
+++ b/code/packages/typescript/sir-runtime-oop/README.md
@@ -55,8 +55,9 @@ deep value equality); and (item **M1b**) **block-taking `Array`/`Enumerable`**
 methods `each`, `each_with_index`, `map`/`collect`, `select`/`filter`, `reject`,
 `reduce`/`inject`, `find`/`detect`, `flat_map`, `any?`/`all?`/`none?` — a trailing
 `Closure` block is applied via `@coding-adventures/sir-runtime-core`'s `apply`
-(proc-lenient), predicates routed through SIR `truthy`. The
-Hash/String/Numeric/Symbol catalogs land in follow-up releases.
+(proc-lenient), predicates routed through SIR `truthy`; and (item **M1c**) the
+**`Hash`** catalog (`keys`/`values`/`has_key?`/`fetch`/`merge`/`each`/`map`/
+`select`/…). The String/Numeric/Symbol catalogs land in follow-up releases.
 
 ## Honest v0 limitation
 

--- a/code/packages/typescript/sir-runtime-oop/src/index.ts
+++ b/code/packages/typescript/sir-runtime-oop/src/index.ts
@@ -289,6 +289,42 @@ const ARRAY_BLOCK_METHODS = new Set<string>([
   "none?",
 ]);
 
+// Non-block `Hash` methods (M1c). Hash is a JS `Map`.
+const HASH_METHODS = new Set<string>([
+  "keys",
+  "values",
+  "has_key?",
+  "key?",
+  "include?",
+  "member?",
+  "has_value?",
+  "value?",
+  "fetch",
+  "size",
+  "length",
+  "empty?",
+  "to_a",
+  "dig",
+  "store",
+  "[]=",
+  "merge",
+  "delete",
+  "clear",
+  "invert",
+]);
+
+// Block-taking `Hash` methods (M1c); the block receives `[key, value]`.
+const HASH_BLOCK_METHODS = new Set<string>([
+  "each",
+  "each_pair",
+  "map",
+  "select",
+  "filter",
+  "reject",
+  "each_key",
+  "each_value",
+]);
+
 /** SIR value equality used by `include?`/`index`/`==` — `===` for primitives,
  * structural for arrays and `Map`s (Ruby `==` is deep). */
 function valEq(a: Val, b: Val): boolean {
@@ -324,6 +360,9 @@ function respondsTo(recv: Val, name: string): boolean {
   if (methods.has(name)) return true;
   if (OBJECT_METHODS.has(name)) return true;
   if (Array.isArray(recv) && (ARRAY_METHODS.has(name) || ARRAY_BLOCK_METHODS.has(name))) {
+    return true;
+  }
+  if (recv instanceof Map && (HASH_METHODS.has(name) || HASH_BLOCK_METHODS.has(name))) {
     return true;
   }
   return false;
@@ -516,6 +555,82 @@ function arrayBlockMethod(
   }
 }
 
+/** Non-block `Hash` methods (Hash is a `Map`). Returns `MISS` if not catalogued. */
+function hashMethod(recv: Map<Val, Val>, name: string, args: Val[]): Val | typeof MISS {
+  switch (name) {
+    case "keys":
+      return [...recv.keys()];
+    case "values":
+      return [...recv.values()];
+    case "has_key?":
+    case "key?":
+    case "include?":
+    case "member?":
+      return recv.has(args[0]);
+    case "has_value?":
+    case "value?":
+      return [...recv.values()].some((v: Val) => valEq(v, args[0]));
+    case "fetch":
+      if (recv.has(args[0])) return recv.get(args[0]);
+      return args.length > 1 ? args[1] : null;
+    case "size":
+    case "length":
+      return recv.size;
+    case "empty?":
+      return recv.size === 0;
+    case "to_a":
+      return [...recv.entries()].map(([k, v]: [Val, Val]) => [k, v]);
+    case "dig":
+      // v0: single-level dig.
+      return recv.has(args[0]) ? recv.get(args[0]) : null;
+    case "store":
+    case "[]=":
+      recv.set(args[0], args[1]);
+      return args[1];
+    case "merge":
+      return new Map<Val, Val>([...recv, ...(args[0] as Map<Val, Val>)]);
+    case "delete": {
+      if (!recv.has(args[0])) return null;
+      const v = recv.get(args[0]);
+      recv.delete(args[0]);
+      return v;
+    }
+    case "clear":
+      recv.clear();
+      return recv;
+    case "invert":
+      return new Map<Val, Val>([...recv].map(([k, v]: [Val, Val]) => [v, k]));
+    default:
+      return MISS;
+  }
+}
+
+/** Block-taking `Hash` methods; the block receives `[key, value]` (or a single
+ * key/value for `each_key`/`each_value`). Returns `MISS` if not a block method. */
+function hashBlockMethod(recv: Map<Val, Val>, name: string, block: Closure): Val | typeof MISS {
+  switch (name) {
+    case "each":
+    case "each_pair":
+      for (const [k, v] of [...recv]) apply(block, [k, v]);
+      return recv;
+    case "each_key":
+      for (const k of [...recv.keys()]) apply(block, [k]);
+      return recv;
+    case "each_value":
+      for (const v of [...recv.values()]) apply(block, [v]);
+      return recv;
+    case "map":
+      return [...recv].map(([k, v]: [Val, Val]) => apply(block, [k, v]));
+    case "select":
+    case "filter":
+      return new Map<Val, Val>([...recv].filter(([k, v]: [Val, Val]) => truthy(apply(block, [k, v]))));
+    case "reject":
+      return new Map<Val, Val>([...recv].filter(([k, v]: [Val, Val]) => !truthy(apply(block, [k, v]))));
+    default:
+      return MISS;
+  }
+}
+
 /**
  * Dispatch method `name` on `recv`.  Resolution order:
  *
@@ -555,6 +670,14 @@ export function callMethod(recv: Val, name: string, ...args: Val[]): Val {
     }
     const arrResult = arrayMethod(recv, name, args);
     if (arrResult !== MISS) return arrResult;
+  } else if (recv instanceof Map) {
+    const last = args[args.length - 1];
+    if (HASH_BLOCK_METHODS.has(name) && args.length > 0 && last instanceof Closure) {
+      const blkResult = hashBlockMethod(recv, name, last);
+      if (blkResult !== MISS) return blkResult;
+    }
+    const hashResult = hashMethod(recv, name, args);
+    if (hashResult !== MISS) return hashResult;
   }
   const objResult = objectMethod(recv, name, args);
   if (objResult !== MISS) return objResult;

--- a/code/packages/typescript/sir-runtime-oop/tests/oop.test.ts
+++ b/code/packages/typescript/sir-runtime-oop/tests/oop.test.ts
@@ -312,3 +312,90 @@ describe("built-in method catalog: block-taking Array/Enumerable (M1b)", () => {
     expect(callMethod([0, 1, null, 2], "select", new Closure((x: Val) => x))).toEqual([0, 1, 2]);
   });
 });
+
+describe("built-in method catalog: Hash (M1c)", () => {
+  it("keys / values / size / empty?", () => {
+    const h = new Map<Val, Val>([["a", 1], ["b", 2]]);
+    expect(callMethod(h, "keys")).toEqual(["a", "b"]);
+    expect(callMethod(h, "values")).toEqual([1, 2]);
+    expect(callMethod(h, "size")).toBe(2);
+    expect(callMethod(h, "length")).toBe(2);
+    expect(callMethod(h, "empty?")).toBe(false);
+    expect(callMethod(new Map(), "empty?")).toBe(true);
+  });
+
+  it("key/value membership", () => {
+    const h = new Map<Val, Val>([["a", 1]]);
+    expect(callMethod(h, "has_key?", "a")).toBe(true);
+    expect(callMethod(h, "key?", "z")).toBe(false);
+    expect(callMethod(h, "include?", "a")).toBe(true);
+    expect(callMethod(h, "member?", "a")).toBe(true);
+    expect(callMethod(h, "has_value?", 1)).toBe(true);
+    expect(callMethod(h, "value?", 9)).toBe(false);
+  });
+
+  it("fetch / dig / to_a", () => {
+    const h = new Map<Val, Val>([["a", 1], ["b", 2]]);
+    expect(callMethod(h, "fetch", "a")).toBe(1);
+    expect(callMethod(h, "fetch", "z")).toBeNull();
+    expect(callMethod(h, "fetch", "z", 99)).toBe(99);
+    expect(callMethod(h, "dig", "b")).toBe(2);
+    expect(callMethod(h, "to_a")).toEqual([
+      ["a", 1],
+      ["b", 2],
+    ]);
+  });
+
+  it("store / merge / delete / clear / invert", () => {
+    const h = new Map<Val, Val>([["a", 1]]);
+    expect(callMethod(h, "store", "b", 2)).toBe(2);
+    expect(h.get("b")).toBe(2);
+    expect(callMethod(h, "[]=", "c", 3)).toBe(3);
+    const merged = callMethod(new Map<Val, Val>([["a", 1]]), "merge", new Map<Val, Val>([["b", 2]]));
+    expect([...(merged as Map<Val, Val>).entries()]).toEqual([
+      ["a", 1],
+      ["b", 2],
+    ]);
+    expect(callMethod(h, "delete", "a")).toBe(1);
+    expect(h.has("a")).toBe(false);
+    const inv = callMethod(new Map<Val, Val>([["a", 1]]), "invert") as Map<Val, Val>;
+    expect(inv.get(1)).toBe("a");
+    const cleared = new Map<Val, Val>([["a", 1]]);
+    expect((callMethod(cleared, "clear") as Map<Val, Val>).size).toBe(0);
+  });
+
+  it("block each / map / select / reject", () => {
+    const seen: Val[] = [];
+    const h = new Map<Val, Val>([["a", 1], ["b", 2]]);
+    const result = callMethod(h, "each", new Closure((k: Val, v: Val) => seen.push([k, v])));
+    expect(seen).toEqual([
+      ["a", 1],
+      ["b", 2],
+    ]);
+    expect(result).toBe(h);
+    expect(callMethod(h, "map", new Closure((k: Val, v: Val) => `${k}=${v}`))).toEqual(["a=1", "b=2"]);
+    const sel = callMethod(h, "select", new Closure((k: Val, v: Val) => v > 1)) as Map<Val, Val>;
+    expect([...sel.entries()]).toEqual([["b", 2]]);
+    const rej = callMethod(h, "reject", new Closure((k: Val, v: Val) => v > 1)) as Map<Val, Val>;
+    expect([...rej.entries()]).toEqual([["a", 1]]);
+  });
+
+  it("each_key / each_value", () => {
+    const ks: Val[] = [];
+    const vs: Val[] = [];
+    const h = new Map<Val, Val>([["a", 1], ["b", 2]]);
+    callMethod(h, "each_key", new Closure((k: Val) => ks.push(k)));
+    callMethod(h, "each_value", new Closure((v: Val) => vs.push(v)));
+    expect(ks).toEqual(["a", "b"]);
+    expect(vs).toEqual([1, 2]);
+  });
+
+  it("respond_to? honesty + nil floor", () => {
+    const h = new Map<Val, Val>([["a", 1]]);
+    expect(callMethod(h, "respond_to?", "keys")).toBe(true);
+    expect(callMethod(h, "respond_to?", "each")).toBe(true);
+    expect(callMethod(h, "respond_to?", "transform_keys")).toBe(false);
+    expect(callMethod(h, "transform_keys")).toBeNull();
+    expect(callMethod(h, "nil?")).toBe(false);
+  });
+});


### PR DESCRIPTION
## What
Third slice of **M1 — built-in method dispatch**: the **`Hash`** catalog now executes in
both `sir-runtime-oop` backends. `h.keys`, `h.fetch`, `h.merge`, `h.each { |k,v| … }`,
`h.map`/`select`/`reject` run instead of returning `nil`. Hash is a Python `dict` / JS `Map`.

## Methods
- **Non-block:** `keys`, `values`, `has_key?`/`key?`/`include?`/`member?`, `has_value?`/`value?`,
  `fetch` (optional default), `size`/`length`, `empty?`, `to_a`, `dig` (single-level v0),
  `store`/`[]=`, `merge` (new dict/Map), `delete`, `clear`, `invert`.
- **Block (receives `[key, value]`):** `each`/`each_pair`, `each_key`, `each_value`, `map`,
  `select`/`filter`, `reject` — applied via `sir-runtime-core` `apply`, predicates through SIR `truthy`.

`respond_to?` reports the Hash methods; out-of-catalog stays `nil`; universal `Object` methods
still resolve on a Hash receiver. No new dependency (core was wired in M1b).

## Verification
- Python: 40 tests pass, `ruff` + `mypy --strict` clean, 96% coverage.
- TypeScript: 39 vitest pass, `tsc --noEmit` clean.
- Security review: passed (`Map`/`dict` `store`/`merge`/`invert` are prototype-pollution-immune;
  closed-allowlist dispatch, no eval/reflection).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
