### PR TITLE
Add smart-home runtime maintenance plan tools

### DIFF
--- a/code/packages/rust/chief-of-staff-smart-home-tools/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/CHANGELOG.md
@@ -257,6 +257,10 @@ All notable changes to this package will be documented in this file.
   `smart_home.get_runtime_maintenance_action_summary` over the D23 runtime read
   facade so Chief of Staff jobs can inspect execution-ordered maintenance
   actions without owning platform mutation logic.
+- Added `smart_home.list_runtime_maintenance_plans` and
+  `smart_home.get_runtime_maintenance_plan_summary` over the D23 runtime read
+  facade so Chief of Staff jobs can group execution actions into schedulable
+  maintenance plans without owning platform mutation logic.
 - Added `smart_home.list_workers` and
   `smart_home.get_worker_heartbeat_schedule` over the D23 runtime read facade
   so Chief of Staff jobs can inspect supervised bridge workers and heartbeat

--- a/code/packages/rust/chief-of-staff-smart-home-tools/README.md
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/README.md
@@ -93,7 +93,7 @@ Chief of Staff job/session/agent
   -> runtime snapshot, desired-state, and pairing-session inventory reads
   -> desired-state target set/clear through runtime authorization
   -> non-mutating supervision plan previews
-  -> supervision remediation and runtime maintenance-window/action reads
+  -> supervision remediation and runtime maintenance-window/action/plan reads
   -> authorized desired-state reconciliation and supervision ticks
   -> supervised worker inventory and heartbeat schedule reads
   -> device command acceptance
@@ -276,6 +276,8 @@ Chief of Staff job/session/agent
 - `smart_home.get_runtime_maintenance_window_summary`
 - `smart_home.list_runtime_maintenance_actions`
 - `smart_home.get_runtime_maintenance_action_summary`
+- `smart_home.list_runtime_maintenance_plans`
+- `smart_home.get_runtime_maintenance_plan_summary`
 - `smart_home.reconcile_desired_states`
 - `smart_home.run_supervision_tick`
 - `smart_home.pair_bridge`

--- a/code/packages/rust/chief-of-staff-smart-home-tools/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/src/lib.rs
@@ -328,6 +328,10 @@ pub const SMART_HOME_LIST_RUNTIME_MAINTENANCE_ACTIONS_TOOL_ID: &str =
     "smart_home.list_runtime_maintenance_actions";
 pub const SMART_HOME_GET_RUNTIME_MAINTENANCE_ACTION_SUMMARY_TOOL_ID: &str =
     "smart_home.get_runtime_maintenance_action_summary";
+pub const SMART_HOME_LIST_RUNTIME_MAINTENANCE_PLANS_TOOL_ID: &str =
+    "smart_home.list_runtime_maintenance_plans";
+pub const SMART_HOME_GET_RUNTIME_MAINTENANCE_PLAN_SUMMARY_TOOL_ID: &str =
+    "smart_home.get_runtime_maintenance_plan_summary";
 pub const SMART_HOME_SET_DESIRED_STATE_TOOL_ID: &str = "smart_home.set_desired_state";
 pub const SMART_HOME_CLEAR_DESIRED_STATE_TOOL_ID: &str = "smart_home.clear_desired_state";
 pub const SMART_HOME_LIST_PAIRING_SESSIONS_TOOL_ID: &str = "smart_home.list_pairing_sessions";
@@ -2421,6 +2425,24 @@ impl SmartHomeToolBridge {
                 SMART_HOME_GET_RUNTIME_MAINTENANCE_ACTION_SUMMARY_TOOL_ID => {
                     let query = runtime_maintenance_action_query(&arguments)?;
                     get_runtime_maintenance_action_summary_output_handler_output(
+                        &mut runtime,
+                        principal_id,
+                        now_ms,
+                        query,
+                    )
+                }
+                SMART_HOME_LIST_RUNTIME_MAINTENANCE_PLANS_TOOL_ID => {
+                    let query = runtime_maintenance_plan_query(&arguments)?;
+                    list_runtime_maintenance_plans_output_handler_output(
+                        &mut runtime,
+                        principal_id,
+                        now_ms,
+                        query,
+                    )
+                }
+                SMART_HOME_GET_RUNTIME_MAINTENANCE_PLAN_SUMMARY_TOOL_ID => {
+                    let query = runtime_maintenance_plan_query(&arguments)?;
+                    get_runtime_maintenance_plan_summary_output_handler_output(
                         &mut runtime,
                         principal_id,
                         now_ms,
@@ -6158,6 +6180,8 @@ pub fn smart_home_tool_definitions() -> Vec<ToolDefinition> {
         get_runtime_maintenance_window_summary_definition(),
         list_runtime_maintenance_actions_definition(),
         get_runtime_maintenance_action_summary_definition(),
+        list_runtime_maintenance_plans_definition(),
+        get_runtime_maintenance_plan_summary_definition(),
         set_desired_state_definition(),
         clear_desired_state_definition(),
         list_pairing_sessions_definition(),
@@ -7219,6 +7243,70 @@ fn get_runtime_maintenance_action_summary_definition() -> ToolDefinition {
         "Summarize Chief action rows derived from runtime maintenance windows and D23 supervision remediation.",
         runtime_maintenance_action_query_schema(),
         runtime_maintenance_action_summary_output_schema(),
+    )
+}
+
+fn runtime_maintenance_plan_query_schema() -> JsonSchema {
+    object_schema(
+        vec![
+            SchemaProperty::new("window_kind", JsonSchema::String),
+            SchemaProperty::new("window_kinds", string_array_schema()),
+            SchemaProperty::new("remediation_kind", JsonSchema::String),
+            SchemaProperty::new("remediation_kinds", string_array_schema()),
+            SchemaProperty::new("risk_lane", JsonSchema::String),
+            SchemaProperty::new("recommended_tool", JsonSchema::String),
+            SchemaProperty::new("max_priority", JsonSchema::Integer),
+            SchemaProperty::new("blocked_only", JsonSchema::Boolean),
+            SchemaProperty::new("requires_attention_only", JsonSchema::Boolean),
+            SchemaProperty::new("limit", JsonSchema::Integer),
+        ],
+        vec![],
+        false,
+    )
+}
+
+fn runtime_maintenance_plan_list_output_schema() -> JsonSchema {
+    object_schema(
+        vec![
+            SchemaProperty::new(
+                "runtime_maintenance_plans",
+                JsonSchema::Array {
+                    items: Box::new(JsonSchema::Any),
+                },
+            ),
+            SchemaProperty::new("summary", JsonSchema::Any),
+            SchemaProperty::new("count", JsonSchema::Integer),
+        ],
+        vec!["runtime_maintenance_plans", "summary", "count"],
+        false,
+    )
+}
+
+fn runtime_maintenance_plan_summary_output_schema() -> JsonSchema {
+    object_schema(
+        vec![SchemaProperty::new("summary", JsonSchema::Any)],
+        vec!["summary"],
+        false,
+    )
+}
+
+fn list_runtime_maintenance_plans_definition() -> ToolDefinition {
+    read_definition(
+        SMART_HOME_LIST_RUNTIME_MAINTENANCE_PLANS_TOOL_ID,
+        "List smart-home runtime maintenance plans",
+        "List Chief maintenance plan records that group D23 supervision remediation actions by runtime maintenance window without mutating the runtime.",
+        runtime_maintenance_plan_query_schema(),
+        runtime_maintenance_plan_list_output_schema(),
+    )
+}
+
+fn get_runtime_maintenance_plan_summary_definition() -> ToolDefinition {
+    read_definition(
+        SMART_HOME_GET_RUNTIME_MAINTENANCE_PLAN_SUMMARY_TOOL_ID,
+        "Summarize smart-home runtime maintenance plans",
+        "Summarize grouped Chief maintenance plans derived from D23 runtime supervision remediation action rows.",
+        runtime_maintenance_plan_query_schema(),
+        runtime_maintenance_plan_summary_output_schema(),
     )
 }
 
@@ -8579,6 +8667,60 @@ fn runtime_maintenance_action_query(
 ) -> Result<RuntimeMaintenanceActionQuery, ToolCallError> {
     let _ = expect_object(arguments)?;
     Ok(RuntimeMaintenanceActionQuery {
+        window_kinds: optional_string_list(arguments, "window_kind", "window_kinds")?
+            .into_iter()
+            .map(|kind| parse_runtime_maintenance_window_kind(&kind))
+            .collect::<Result<Vec<_>, _>>()?,
+        remediation_kinds: optional_string_list(
+            arguments,
+            "remediation_kind",
+            "remediation_kinds",
+        )?
+        .into_iter()
+        .map(|kind| parse_supervision_remediation_kind(&kind))
+        .collect::<Result<Vec<_>, _>>()?,
+        risk_lane: optional_string(arguments, "risk_lane")?,
+        recommended_tool: optional_string(arguments, "recommended_tool")?,
+        max_priority: optional_u64(arguments, "max_priority")?.map(|value| value as u8),
+        blocked_only: optional_bool(arguments, "blocked_only")?.unwrap_or(false),
+        requires_attention_only: optional_bool(arguments, "requires_attention_only")?
+            .unwrap_or(false),
+        limit: optional_u64(arguments, "limit")?.map(|value| value as usize),
+    })
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct RuntimeMaintenancePlanQuery {
+    window_kinds: Vec<RuntimeMaintenanceWindowKind>,
+    remediation_kinds: Vec<SupervisionRemediationKind>,
+    risk_lane: Option<String>,
+    recommended_tool: Option<String>,
+    max_priority: Option<u8>,
+    blocked_only: bool,
+    requires_attention_only: bool,
+    limit: Option<usize>,
+}
+
+impl RuntimeMaintenancePlanQuery {
+    fn action_query(&self) -> RuntimeMaintenanceActionQuery {
+        RuntimeMaintenanceActionQuery {
+            window_kinds: self.window_kinds.clone(),
+            remediation_kinds: self.remediation_kinds.clone(),
+            risk_lane: self.risk_lane.clone(),
+            recommended_tool: self.recommended_tool.clone(),
+            max_priority: self.max_priority,
+            blocked_only: self.blocked_only,
+            requires_attention_only: self.requires_attention_only,
+            limit: None,
+        }
+    }
+}
+
+fn runtime_maintenance_plan_query(
+    arguments: &JsonValue,
+) -> Result<RuntimeMaintenancePlanQuery, ToolCallError> {
+    let _ = expect_object(arguments)?;
+    Ok(RuntimeMaintenancePlanQuery {
         window_kinds: optional_string_list(arguments, "window_kind", "window_kinds")?
             .into_iter()
             .map(|kind| parse_runtime_maintenance_window_kind(&kind))
@@ -36150,6 +36292,355 @@ fn runtime_maintenance_action_matches(
     true
 }
 
+#[derive(Debug, Clone, PartialEq)]
+struct RuntimeMaintenancePlanRow {
+    plan_id: String,
+    window_id: String,
+    window_kind: RuntimeMaintenanceWindowKind,
+    priority: u8,
+    execution_order: usize,
+    status: &'static str,
+    risk_lane: &'static str,
+    recommended_tool: &'static str,
+    recommended_action: &'static str,
+    action_count: usize,
+    blocked_action_count: usize,
+    requires_attention_count: usize,
+    overdue_action_count: usize,
+    bridge_ids: Vec<String>,
+    entity_ids: Vec<String>,
+    worker_ids: Vec<String>,
+    first_due_at_ms: Option<u64>,
+    max_overdue_by_ms: Option<u64>,
+    next_action_ids: Vec<String>,
+    remediation_ids: Vec<String>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+struct RuntimeMaintenancePlanSummary {
+    total_plans: usize,
+    critical_recovery_plans: usize,
+    state_refresh_plans: usize,
+    desired_state_reconciliation_plans: usize,
+    discovery_worker_run_plans: usize,
+    total_actions: usize,
+    blocked_actions: usize,
+    requires_attention_actions: usize,
+    overdue_actions: usize,
+    bridge_count: usize,
+    entity_count: usize,
+    worker_count: usize,
+    first_due_at_ms: Option<u64>,
+    max_overdue_by_ms: Option<u64>,
+    highest_priority: Option<u8>,
+}
+
+impl RuntimeMaintenancePlanSummary {
+    fn from_rows(rows: &[RuntimeMaintenancePlanRow]) -> Self {
+        let mut summary = Self::default();
+        let mut bridge_ids = BTreeSet::new();
+        let mut entity_ids = BTreeSet::new();
+        let mut worker_ids = BTreeSet::new();
+
+        for row in rows {
+            summary.total_plans += 1;
+            summary.total_actions += row.action_count;
+            summary.blocked_actions += row.blocked_action_count;
+            summary.requires_attention_actions += row.requires_attention_count;
+            summary.overdue_actions += row.overdue_action_count;
+            for bridge_id in &row.bridge_ids {
+                bridge_ids.insert(bridge_id.clone());
+            }
+            for entity_id in &row.entity_ids {
+                entity_ids.insert(entity_id.clone());
+            }
+            for worker_id in &row.worker_ids {
+                worker_ids.insert(worker_id.clone());
+            }
+            summary.first_due_at_ms =
+                min_optional_u64(summary.first_due_at_ms, row.first_due_at_ms);
+            summary.max_overdue_by_ms =
+                max_optional_u64(summary.max_overdue_by_ms, row.max_overdue_by_ms);
+            summary.highest_priority =
+                min_optional_u8(summary.highest_priority, Some(row.priority));
+
+            match row.window_kind {
+                RuntimeMaintenanceWindowKind::CriticalRecovery => {
+                    summary.critical_recovery_plans += 1;
+                }
+                RuntimeMaintenanceWindowKind::StateRefresh => summary.state_refresh_plans += 1,
+                RuntimeMaintenanceWindowKind::DesiredStateReconciliation => {
+                    summary.desired_state_reconciliation_plans += 1;
+                }
+                RuntimeMaintenanceWindowKind::DiscoveryWorkerRun => {
+                    summary.discovery_worker_run_plans += 1;
+                }
+            }
+        }
+
+        summary.bridge_count = bridge_ids.len();
+        summary.entity_count = entity_ids.len();
+        summary.worker_count = worker_ids.len();
+        summary
+    }
+
+    fn requires_attention(&self) -> bool {
+        self.requires_attention_actions > 0
+    }
+
+    fn has_blockers(&self) -> bool {
+        self.blocked_actions > 0
+    }
+
+    fn has_overdue_actions(&self) -> bool {
+        self.overdue_actions > 0
+    }
+}
+
+fn list_runtime_maintenance_plans_output_handler_output(
+    runtime: &mut SmartHomeRuntime,
+    principal_id: AgentId,
+    now_ms: u64,
+    query: RuntimeMaintenancePlanQuery,
+) -> Result<ToolHandlerOutput, ToolCallError> {
+    let (mut rows, summary) = runtime_maintenance_plan_rows(runtime, principal_id, now_ms, &query)?;
+    if let Some(limit) = query.limit {
+        rows.truncate(limit);
+    }
+
+    Ok(ToolHandlerOutput::new(object([
+        (
+            "runtime_maintenance_plans",
+            JsonValue::Array(rows.iter().map(runtime_maintenance_plan_json).collect()),
+        ),
+        ("summary", runtime_maintenance_plan_summary_json(&summary)),
+        ("count", integer(rows.len() as i64)),
+    ]))
+    .with_event(
+        ToolEventKind::Progress,
+        object([
+            ("operation", string("list_runtime_maintenance_plans")),
+            ("count", integer(rows.len() as i64)),
+            ("total_plans", integer(summary.total_plans as i64)),
+            ("total_actions", integer(summary.total_actions as i64)),
+            (
+                "requires_attention_actions",
+                integer(summary.requires_attention_actions as i64),
+            ),
+            ("blocked_actions", integer(summary.blocked_actions as i64)),
+            ("overdue_actions", integer(summary.overdue_actions as i64)),
+        ]),
+    ))
+}
+
+fn get_runtime_maintenance_plan_summary_output_handler_output(
+    runtime: &mut SmartHomeRuntime,
+    principal_id: AgentId,
+    now_ms: u64,
+    query: RuntimeMaintenancePlanQuery,
+) -> Result<ToolHandlerOutput, ToolCallError> {
+    let (_, summary) = runtime_maintenance_plan_rows(runtime, principal_id, now_ms, &query)?;
+
+    Ok(ToolHandlerOutput::new(object([(
+        "summary",
+        runtime_maintenance_plan_summary_json(&summary),
+    )]))
+    .with_event(
+        ToolEventKind::Progress,
+        object([
+            ("operation", string("get_runtime_maintenance_plan_summary")),
+            ("total_plans", integer(summary.total_plans as i64)),
+            ("total_actions", integer(summary.total_actions as i64)),
+            (
+                "requires_attention_actions",
+                integer(summary.requires_attention_actions as i64),
+            ),
+            ("blocked_actions", integer(summary.blocked_actions as i64)),
+            ("overdue_actions", integer(summary.overdue_actions as i64)),
+        ]),
+    ))
+}
+
+fn runtime_maintenance_plan_rows(
+    runtime: &mut SmartHomeRuntime,
+    principal_id: AgentId,
+    now_ms: u64,
+    query: &RuntimeMaintenancePlanQuery,
+) -> Result<
+    (
+        Vec<RuntimeMaintenancePlanRow>,
+        RuntimeMaintenancePlanSummary,
+    ),
+    ToolCallError,
+> {
+    let observation_output = runtime
+        .execute_read_tool(
+            principal_id,
+            RuntimeReadToolRequest::ObserveSupervision,
+            now_ms,
+        )
+        .map_err(runtime_error)?;
+    let RuntimeReadToolOutput::SupervisionObservation(observation) = observation_output else {
+        return Err(ToolCallError {
+            kind: ToolErrorKind::ToolExecutionError,
+            message: "runtime maintenance plans expected supervision observation output"
+                .to_string(),
+            details: JsonValue::Null,
+        });
+    };
+
+    let action_query = query.action_query();
+    let remediation_rows = supervision_remediation_rows_from_observation(&observation);
+    let mut actions = remediation_rows
+        .iter()
+        .map(RuntimeMaintenanceActionRow::from_remediation)
+        .filter(|row| runtime_maintenance_action_matches(row, &action_query))
+        .collect::<Vec<_>>();
+    actions.sort_by(|left, right| {
+        left.priority
+            .cmp(&right.priority)
+            .then_with(|| right.blocked.cmp(&left.blocked))
+            .then_with(|| right.requires_attention.cmp(&left.requires_attention))
+            .then_with(|| left.due_at_ms.cmp(&right.due_at_ms))
+            .then_with(|| left.action_id.cmp(&right.action_id))
+    });
+    for (index, row) in actions.iter_mut().enumerate() {
+        row.execution_order = index + 1;
+    }
+
+    let mut plans = runtime_maintenance_plan_rows_from_actions(&actions);
+    plans.sort_by(|left, right| {
+        left.priority
+            .cmp(&right.priority)
+            .then_with(|| right.blocked_action_count.cmp(&left.blocked_action_count))
+            .then_with(|| {
+                right
+                    .requires_attention_count
+                    .cmp(&left.requires_attention_count)
+            })
+            .then_with(|| left.first_due_at_ms.cmp(&right.first_due_at_ms))
+            .then_with(|| left.plan_id.cmp(&right.plan_id))
+    });
+    for (index, row) in plans.iter_mut().enumerate() {
+        row.execution_order = index + 1;
+    }
+
+    let summary = RuntimeMaintenancePlanSummary::from_rows(&plans);
+    Ok((plans, summary))
+}
+
+fn runtime_maintenance_plan_rows_from_actions(
+    actions: &[RuntimeMaintenanceActionRow],
+) -> Vec<RuntimeMaintenancePlanRow> {
+    [
+        RuntimeMaintenanceWindowKind::CriticalRecovery,
+        RuntimeMaintenanceWindowKind::StateRefresh,
+        RuntimeMaintenanceWindowKind::DesiredStateReconciliation,
+        RuntimeMaintenanceWindowKind::DiscoveryWorkerRun,
+    ]
+    .into_iter()
+    .filter_map(|kind| {
+        let grouped_actions = actions
+            .iter()
+            .filter(|row| row.window_kind == kind)
+            .collect::<Vec<_>>();
+        RuntimeMaintenancePlanRow::from_actions(kind, &grouped_actions)
+    })
+    .collect()
+}
+
+impl RuntimeMaintenancePlanRow {
+    fn from_actions(
+        kind: RuntimeMaintenanceWindowKind,
+        actions: &[&RuntimeMaintenanceActionRow],
+    ) -> Option<Self> {
+        if actions.is_empty() {
+            return None;
+        }
+
+        let mut bridge_ids = BTreeSet::new();
+        let mut entity_ids = BTreeSet::new();
+        let mut worker_ids = BTreeSet::new();
+        let mut first_due_at_ms: Option<u64> = None;
+        let mut max_overdue_by_ms: Option<u64> = None;
+
+        for action in actions {
+            if let Some(bridge_id) = &action.bridge_id {
+                bridge_ids.insert(bridge_id.as_str().to_string());
+            }
+            if let Some(entity_id) = &action.entity_id {
+                entity_ids.insert(entity_id.as_str().to_string());
+            }
+            if let Some(worker_id) = &action.worker_id {
+                worker_ids.insert(worker_id.as_str().to_string());
+            }
+            first_due_at_ms = min_optional_u64(first_due_at_ms, action.due_at_ms);
+            max_overdue_by_ms = max_optional_u64(max_overdue_by_ms, action.overdue_by_ms);
+        }
+
+        let blocked_action_count = actions.iter().filter(|action| action.blocked).count();
+        let requires_attention_count = actions
+            .iter()
+            .filter(|action| action.requires_attention)
+            .count();
+        let overdue_action_count = actions
+            .iter()
+            .filter(|action| action.overdue_by_ms.is_some_and(|overdue| overdue > 0))
+            .count();
+        let label = runtime_maintenance_window_kind_label(kind);
+
+        Some(Self {
+            plan_id: format!("maintenance_plan:{label}"),
+            window_id: label.to_string(),
+            window_kind: kind,
+            priority: runtime_maintenance_window_priority(kind),
+            execution_order: 0,
+            status: runtime_maintenance_plan_status(
+                blocked_action_count,
+                requires_attention_count,
+                overdue_action_count,
+            ),
+            risk_lane: runtime_maintenance_window_risk_lane(kind),
+            recommended_tool: runtime_maintenance_window_recommended_tool(kind),
+            recommended_action: runtime_maintenance_window_recommended_action(kind),
+            action_count: actions.len(),
+            blocked_action_count,
+            requires_attention_count,
+            overdue_action_count,
+            bridge_ids: bridge_ids.into_iter().collect(),
+            entity_ids: entity_ids.into_iter().collect(),
+            worker_ids: worker_ids.into_iter().collect(),
+            first_due_at_ms,
+            max_overdue_by_ms,
+            next_action_ids: actions
+                .iter()
+                .take(5)
+                .map(|action| action.action_id.clone())
+                .collect(),
+            remediation_ids: actions
+                .iter()
+                .map(|action| action.remediation_id.clone())
+                .collect(),
+        })
+    }
+}
+
+fn runtime_maintenance_plan_status(
+    blocked_action_count: usize,
+    requires_attention_count: usize,
+    overdue_action_count: usize,
+) -> &'static str {
+    if blocked_action_count > 0 {
+        "blocked"
+    } else if overdue_action_count > 0 {
+        "overdue"
+    } else if requires_attention_count > 0 {
+        "attention_required"
+    } else {
+        "ready"
+    }
+}
+
 fn min_optional_u64(left: Option<u64>, right: Option<u64>) -> Option<u64> {
     match (left, right) {
         (Some(left), Some(right)) => Some(left.min(right)),
@@ -60210,6 +60701,145 @@ fn runtime_maintenance_action_summary_json(summary: &RuntimeMaintenanceActionSum
     ])
 }
 
+fn runtime_maintenance_plan_json(row: &RuntimeMaintenancePlanRow) -> JsonValue {
+    object([
+        ("plan_id", string(&row.plan_id)),
+        ("window_id", string(&row.window_id)),
+        (
+            "window_kind",
+            string(runtime_maintenance_window_kind_label(row.window_kind)),
+        ),
+        ("priority", integer(row.priority as i64)),
+        ("execution_order", integer(row.execution_order as i64)),
+        ("status", string(row.status)),
+        ("risk_lane", string(row.risk_lane)),
+        ("recommended_tool", string(row.recommended_tool)),
+        ("recommended_action", string(row.recommended_action)),
+        ("action_count", integer(row.action_count as i64)),
+        (
+            "blocked_action_count",
+            integer(row.blocked_action_count as i64),
+        ),
+        (
+            "requires_attention_count",
+            integer(row.requires_attention_count as i64),
+        ),
+        (
+            "overdue_action_count",
+            integer(row.overdue_action_count as i64),
+        ),
+        ("bridge_count", integer(row.bridge_ids.len() as i64)),
+        ("entity_count", integer(row.entity_ids.len() as i64)),
+        ("worker_count", integer(row.worker_ids.len() as i64)),
+        (
+            "bridge_ids",
+            JsonValue::Array(row.bridge_ids.iter().map(string).collect()),
+        ),
+        (
+            "entity_ids",
+            JsonValue::Array(row.entity_ids.iter().map(string).collect()),
+        ),
+        (
+            "worker_ids",
+            JsonValue::Array(row.worker_ids.iter().map(string).collect()),
+        ),
+        (
+            "first_due_at_ms",
+            row.first_due_at_ms
+                .map(|value| integer(value as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "max_overdue_by_ms",
+            row.max_overdue_by_ms
+                .map(|value| integer(value as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "next_action_ids",
+            JsonValue::Array(row.next_action_ids.iter().map(string).collect()),
+        ),
+        (
+            "remediation_ids",
+            JsonValue::Array(row.remediation_ids.iter().map(string).collect()),
+        ),
+        (
+            "requires_attention",
+            JsonValue::Bool(row.requires_attention_count > 0),
+        ),
+        (
+            "has_blockers",
+            JsonValue::Bool(row.blocked_action_count > 0),
+        ),
+        (
+            "has_overdue_actions",
+            JsonValue::Bool(row.overdue_action_count > 0),
+        ),
+    ])
+}
+
+fn runtime_maintenance_plan_summary_json(summary: &RuntimeMaintenancePlanSummary) -> JsonValue {
+    object([
+        ("total_plans", integer(summary.total_plans as i64)),
+        (
+            "critical_recovery_plans",
+            integer(summary.critical_recovery_plans as i64),
+        ),
+        (
+            "state_refresh_plans",
+            integer(summary.state_refresh_plans as i64),
+        ),
+        (
+            "desired_state_reconciliation_plans",
+            integer(summary.desired_state_reconciliation_plans as i64),
+        ),
+        (
+            "discovery_worker_run_plans",
+            integer(summary.discovery_worker_run_plans as i64),
+        ),
+        ("total_actions", integer(summary.total_actions as i64)),
+        ("blocked_actions", integer(summary.blocked_actions as i64)),
+        (
+            "requires_attention_actions",
+            integer(summary.requires_attention_actions as i64),
+        ),
+        ("overdue_actions", integer(summary.overdue_actions as i64)),
+        ("bridge_count", integer(summary.bridge_count as i64)),
+        ("entity_count", integer(summary.entity_count as i64)),
+        ("worker_count", integer(summary.worker_count as i64)),
+        (
+            "first_due_at_ms",
+            summary
+                .first_due_at_ms
+                .map(|value| integer(value as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "max_overdue_by_ms",
+            summary
+                .max_overdue_by_ms
+                .map(|value| integer(value as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "highest_priority",
+            summary
+                .highest_priority
+                .map(|value| integer(value as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "requires_attention",
+            JsonValue::Bool(summary.requires_attention()),
+        ),
+        ("has_blockers", JsonValue::Bool(summary.has_blockers())),
+        (
+            "has_overdue_actions",
+            JsonValue::Bool(summary.has_overdue_actions()),
+        ),
+    ])
+}
+
 fn event_log_summary_json(summary: &RuntimeEventLogSummary) -> JsonValue {
     object([
         ("total_events", integer(summary.total_events as i64)),
@@ -66955,7 +67585,7 @@ mod tests {
         let definitions = smart_home_tool_definitions();
         let export = ToolCatalogExport::from_definitions(definitions.iter());
 
-        assert_eq!(definitions.len(), 260);
+        assert_eq!(definitions.len(), 262);
         assert!(
             export.ok(),
             "tool export validation failed: {:?}",
@@ -67698,9 +68328,15 @@ mod tests {
         assert!(export
             .tool_ids()
             .contains(&SMART_HOME_GET_RUNTIME_MAINTENANCE_ACTION_SUMMARY_TOOL_ID));
+        assert!(export
+            .tool_ids()
+            .contains(&SMART_HOME_LIST_RUNTIME_MAINTENANCE_PLANS_TOOL_ID));
+        assert!(export
+            .tool_ids()
+            .contains(&SMART_HOME_GET_RUNTIME_MAINTENANCE_PLAN_SUMMARY_TOOL_ID));
         assert_eq!(
             export.summary.required_capability_count("smart_home:read"),
-            252
+            254
         );
         assert_eq!(
             export
@@ -68313,6 +68949,29 @@ mod tests {
             smart_home_tool_definition(SMART_HOME_GET_SUPERVISION_REMEDIATION_SUMMARY_TOOL_ID)
                 .is_some()
         );
+        assert!(
+            smart_home_tool_definition(SMART_HOME_LIST_RUNTIME_MAINTENANCE_WINDOWS_TOOL_ID)
+                .is_some()
+        );
+        assert!(smart_home_tool_definition(
+            SMART_HOME_GET_RUNTIME_MAINTENANCE_WINDOW_SUMMARY_TOOL_ID
+        )
+        .is_some());
+        assert!(
+            smart_home_tool_definition(SMART_HOME_LIST_RUNTIME_MAINTENANCE_ACTIONS_TOOL_ID)
+                .is_some()
+        );
+        assert!(smart_home_tool_definition(
+            SMART_HOME_GET_RUNTIME_MAINTENANCE_ACTION_SUMMARY_TOOL_ID
+        )
+        .is_some());
+        assert!(
+            smart_home_tool_definition(SMART_HOME_LIST_RUNTIME_MAINTENANCE_PLANS_TOOL_ID).is_some()
+        );
+        assert!(smart_home_tool_definition(
+            SMART_HOME_GET_RUNTIME_MAINTENANCE_PLAN_SUMMARY_TOOL_ID
+        )
+        .is_some());
         assert!(smart_home_tool_definition(SMART_HOME_COMPLETE_PAIRING_TOOL_ID).is_some());
         assert!(smart_home_tool_definition(SMART_HOME_REPORT_EVENT_TOOL_ID).is_some());
         assert!(smart_home_tool_definition(SMART_HOME_LIST_ROOMS_TOOL_ID).is_some());
@@ -68547,11 +69206,11 @@ mod tests {
         let tool_catalog_summary = field(tool_catalog_summary_output, "summary").unwrap();
         assert_eq!(
             field(tool_catalog_summary, "total_tools"),
-            Some(&integer(260))
+            Some(&integer(262))
         );
         assert_eq!(
             field(tool_catalog_summary, "read_tools"),
-            Some(&integer(252))
+            Some(&integer(254))
         );
         assert_eq!(
             field(tool_catalog_summary, "risky_tool_count"),
@@ -83149,6 +83808,201 @@ mod tests {
             runtime.borrow().registry().counts().authorization_decisions,
             2,
             "maintenance action list and summary both authorize through runtime read tools"
+        );
+    }
+
+    #[test]
+    fn runtime_maintenance_plan_tools_group_action_pressure_end_to_end() {
+        let runtime = Rc::new(RefCell::new(hue_lighting_runtime()));
+        runtime
+            .borrow_mut()
+            .registry_mut()
+            .apply_state_snapshot(StateSnapshot {
+                entity_id: EntityId::trusted("entity-light-1"),
+                value: Value::Object(vec![("light.on_off".to_string(), Value::Bool(true))]),
+                source: StateSource::Poll,
+                observed_at_ms: 1_000,
+                received_at_ms: 1_000,
+                expires_at_ms: None,
+                confidence: StateConfidence::Confirmed,
+            })
+            .unwrap();
+        runtime
+            .borrow_mut()
+            .upsert_desired_state(
+                DesiredEntityState::new(
+                    EntityId::trusted("entity-light-1"),
+                    vec![StateDelta {
+                        capability_id: CapabilityId::trusted("light.on_off"),
+                        value: Value::Bool(false),
+                    }],
+                )
+                .requested_by("agent:scene-planner"),
+            )
+            .unwrap();
+        runtime
+            .borrow_mut()
+            .supervisor_mut()
+            .register_worker(SupervisedBridgeWorker::new(
+                BridgeId::trusted("bridge-1"),
+                IntegrationId::trusted("hue"),
+                1_000,
+                250,
+            ));
+        let discovery_worker_id = DiscoveryWorkerId::trusted("hue-mdns-maintenance-plans");
+        runtime
+            .borrow_mut()
+            .register_discovery_worker_schedule(
+                ScheduledDiscoveryWorker::new(
+                    discovery_worker_id.clone(),
+                    IntegrationId::trusted("hue"),
+                    DiscoveryWorkerKind::MdnsScan,
+                    5_000,
+                    250,
+                    1_100,
+                )
+                .with_retry_backoff(500, 2_000, 2)
+                .with_source(DiscoverySource::Mdns)
+                .with_network_interface("en0")
+                .with_metadata(MDNS_DISCOVERY_SERVICE_TYPE_METADATA_KEY, "_hue._tcp.local"),
+            )
+            .unwrap();
+        runtime
+            .borrow_mut()
+            .mark_discovery_worker_started(&discovery_worker_id, 1_200)
+            .unwrap();
+        let mut failed_run = DiscoveryWorkerRun::new(
+            discovery_worker_id.clone(),
+            IntegrationId::trusted("hue"),
+            DiscoveryWorkerKind::MdnsScan,
+            1_200,
+            1_260,
+        );
+        failed_run.push_failure(
+            DiscoveryWorkerFailure::new(DiscoverySource::Mdns, "multicast route unavailable")
+                .unwrap(),
+        );
+        runtime
+            .borrow_mut()
+            .record_scheduled_discovery_worker_run(&failed_run, 1_260, 500)
+            .unwrap();
+        runtime.borrow_mut().registry_mut().upsert_capability_grant(
+            CapabilityGrant::for_all_smart_home(
+                CapabilityGrantId::trusted("grant-smart-home"),
+                AgentId::trusted(AGENT_ID),
+                PrivilegeTier::HumanApproval,
+                "user:test",
+                1_000,
+            ),
+        );
+        let bridge = SmartHomeToolBridge::new(runtime.clone(), AgentId::trusted(AGENT_ID));
+        let mut tool_runtime = InMemoryToolRuntime::new();
+        bridge.register_all(&mut tool_runtime).unwrap();
+
+        let list_request = request(
+            "call-list-runtime-maintenance-plans",
+            SMART_HOME_LIST_RUNTIME_MAINTENANCE_PLANS_TOOL_ID,
+            object([
+                ("requires_attention_only", JsonValue::Bool(true)),
+                ("blocked_only", JsonValue::Bool(true)),
+                ("max_priority", integer(1)),
+                ("limit", integer(10)),
+            ]),
+            2_000,
+        );
+        let list_trace = tool_runtime.invoke_with_events(&list_request);
+        assert!(list_trace.result.ok);
+        assert_eq!(list_trace.summary().progress_event_count, 1);
+        let list_output = list_trace.result.output.as_ref().unwrap();
+        let plans = field(list_output, "runtime_maintenance_plans").unwrap();
+        let summary = field(list_output, "summary").unwrap();
+        assert!(
+            array_len(plans).unwrap() >= 3,
+            "maintenance plans should group critical recovery, state refresh, and desired-state action pressure"
+        );
+        assert!(
+            integer_value(field(summary, "total_plans").unwrap()).unwrap() >= 3,
+            "summary should count the filtered, untruncated plan set"
+        );
+        assert_eq!(field(summary, "critical_recovery_plans"), Some(&integer(1)));
+        assert!(
+            integer_value(field(summary, "state_refresh_plans").unwrap()).unwrap() >= 1,
+            "fixture leaves at least one state refresh plan"
+        );
+        assert_eq!(
+            field(summary, "desired_state_reconciliation_plans"),
+            Some(&integer(1))
+        );
+        assert!(
+            integer_value(field(summary, "total_actions").unwrap()).unwrap() >= 4,
+            "maintenance plans should retain the underlying action count"
+        );
+        assert!(
+            integer_value(field(summary, "blocked_actions").unwrap()).unwrap() >= 4,
+            "blocked remediation work should remain visible at plan level"
+        );
+        assert_eq!(field(summary, "has_blockers"), Some(&JsonValue::Bool(true)));
+        assert_eq!(
+            field(summary, "has_overdue_actions"),
+            Some(&JsonValue::Bool(true))
+        );
+
+        let JsonValue::Array(rows) = plans else {
+            panic!("runtime_maintenance_plans should be an array");
+        };
+        assert!(rows.iter().any(|row| field(row, "window_kind")
+            == Some(&string("critical_recovery"))
+            && field(row, "status") == Some(&string("blocked"))
+            && field(row, "recommended_tool")
+                == Some(&string(SMART_HOME_RUN_SUPERVISION_TICK_TOOL_ID))
+            && field(row, "priority") == Some(&integer(0))
+            && integer_value(field(row, "action_count").unwrap()).unwrap() >= 2
+            && array_len(field(row, "next_action_ids").unwrap()).unwrap() >= 2));
+        assert!(rows.iter().any(|row| field(row, "window_kind")
+            == Some(&string("desired_state_reconciliation"))
+            && field(row, "recommended_tool")
+                == Some(&string(SMART_HOME_RECONCILE_DESIRED_STATES_TOOL_ID))
+            && field(row, "entity_count") == Some(&integer(1))
+            && field(row, "recommended_action") == Some(&string("reconcile_desired_state"))
+            && field(row, "has_blockers") == Some(&JsonValue::Bool(true))));
+        assert!(
+            rows.iter()
+                .all(|row| { integer_value(field(row, "execution_order").unwrap()).unwrap() >= 1 }),
+            "plan rows should expose a stable execution order"
+        );
+
+        let summary_request = request(
+            "call-runtime-maintenance-plan-summary",
+            SMART_HOME_GET_RUNTIME_MAINTENANCE_PLAN_SUMMARY_TOOL_ID,
+            object([
+                ("window_kind", string("desired_state_reconciliation")),
+                ("blocked_only", JsonValue::Bool(true)),
+            ]),
+            2_001,
+        );
+        let summary_trace = tool_runtime.invoke_with_events(&summary_request);
+        assert!(summary_trace.result.ok);
+        assert_eq!(summary_trace.summary().progress_event_count, 1);
+        let summary_output = summary_trace.result.output.as_ref().unwrap();
+        let rollup = field(summary_output, "summary").unwrap();
+        assert_eq!(field(rollup, "total_plans"), Some(&integer(1)));
+        assert_eq!(field(rollup, "total_actions"), Some(&integer(1)));
+        assert_eq!(
+            field(rollup, "desired_state_reconciliation_plans"),
+            Some(&integer(1))
+        );
+        assert_eq!(field(rollup, "has_blockers"), Some(&JsonValue::Bool(true)));
+
+        let mut journal = ToolExecutionJournal::new();
+        journal.record_trace(list_request, list_trace);
+        journal.record_trace(summary_request, summary_trace);
+        let journal_summary = journal.summary();
+        assert_eq!(journal_summary.invocation_count, 2);
+        assert_eq!(journal_summary.completed_count, 2);
+        assert_eq!(
+            runtime.borrow().registry().counts().authorization_decisions,
+            2,
+            "maintenance plan list and summary both authorize through runtime read tools"
         );
     }
 

--- a/code/packages/rust/smart-home-core/CHANGELOG.md
+++ b/code/packages/rust/smart-home-core/CHANGELOG.md
@@ -264,6 +264,9 @@ All notable changes to this package will be documented in this file.
 - `smart_home.list_runtime_maintenance_actions` and
   `smart_home.get_runtime_maintenance_action_summary` tool descriptors for
   read-only Chief maintenance actions derived from runtime supervision work.
+- `smart_home.list_runtime_maintenance_plans` and
+  `smart_home.get_runtime_maintenance_plan_summary` tool descriptors for
+  read-only Chief maintenance plans derived from runtime supervision work.
 - `smart_home.reconcile_desired_states` and `smart_home.run_supervision_tick`
   tool descriptors for authorized runtime supervision execution.
 - Health and command-result status helpers for shared supervision/read-side

--- a/code/packages/rust/smart-home-core/README.md
+++ b/code/packages/rust/smart-home-core/README.md
@@ -176,6 +176,8 @@ Current scope:
   supervision work
 - D18D runtime maintenance-action descriptors for Chief-visible execution
   planning over supervision work
+- D18D runtime maintenance-plan descriptors for Chief-visible grouped execution
+  plans over supervision work
 - D18D supervision execution tool descriptors for authorized desired-state
   reconciliation and runtime supervision ticks
 - compact smart-home tool catalog summaries for read-side inspection

--- a/code/packages/rust/smart-home-core/src/lib.rs
+++ b/code/packages/rust/smart-home-core/src/lib.rs
@@ -1694,6 +1694,8 @@ pub enum SmartHomeTool {
     GetRuntimeMaintenanceWindowSummary,
     ListRuntimeMaintenanceActions,
     GetRuntimeMaintenanceActionSummary,
+    ListRuntimeMaintenancePlans,
+    GetRuntimeMaintenancePlanSummary,
     SetDesiredState,
     ClearDesiredState,
     ListPairingSessions,
@@ -2405,6 +2407,12 @@ impl SmartHomeTool {
             }
             Self::GetRuntimeMaintenanceActionSummary => {
                 read_tool("smart_home.get_runtime_maintenance_action_summary")
+            }
+            Self::ListRuntimeMaintenancePlans => {
+                read_tool("smart_home.list_runtime_maintenance_plans")
+            }
+            Self::GetRuntimeMaintenancePlanSummary => {
+                read_tool("smart_home.get_runtime_maintenance_plan_summary")
             }
             Self::SetDesiredState => ToolDescriptor {
                 tool_id: "smart_home.set_desired_state",
@@ -3205,6 +3213,8 @@ pub fn smart_home_tool_catalog() -> Vec<ToolDescriptor> {
         SmartHomeTool::GetRuntimeMaintenanceWindowSummary,
         SmartHomeTool::ListRuntimeMaintenanceActions,
         SmartHomeTool::GetRuntimeMaintenanceActionSummary,
+        SmartHomeTool::ListRuntimeMaintenancePlans,
+        SmartHomeTool::GetRuntimeMaintenancePlanSummary,
         SmartHomeTool::SetDesiredState,
         SmartHomeTool::ClearDesiredState,
         SmartHomeTool::ListPairingSessions,
@@ -4011,7 +4021,7 @@ mod tests {
             .find(|tool| tool.tool_id == "smart_home.command")
             .unwrap();
 
-        assert_eq!(catalog.len(), 260);
+        assert_eq!(catalog.len(), 262);
         assert!(catalog
             .iter()
             .any(|tool| tool.tool_id == "smart_home.list_command_risk_audit"
@@ -4068,6 +4078,14 @@ mod tests {
             && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
         assert!(catalog.iter().any(|tool| tool.tool_id
             == "smart_home.get_runtime_maintenance_action_summary"
+            && tool.side_effects == ToolSideEffects::Read
+            && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
+        assert!(catalog.iter().any(|tool| tool.tool_id
+            == "smart_home.list_runtime_maintenance_plans"
+            && tool.side_effects == ToolSideEffects::Read
+            && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
+        assert!(catalog.iter().any(|tool| tool.tool_id
+            == "smart_home.get_runtime_maintenance_plan_summary"
             && tool.side_effects == ToolSideEffects::Read
             && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
         assert!(catalog
@@ -5036,15 +5054,15 @@ mod tests {
         let summary = smart_home_tool_catalog_summary();
         let pair_bridge = SmartHomeTool::PairBridge.descriptor();
 
-        assert_eq!(summary.total_tools, 260);
-        assert_eq!(summary.read_tools, 252);
+        assert_eq!(summary.total_tools, 262);
+        assert_eq!(summary.read_tools, 254);
         assert_eq!(summary.write_tools, 2);
         assert_eq!(summary.external_tools, 6);
-        assert_eq!(summary.read_only_tier_tools, 252);
+        assert_eq!(summary.read_only_tier_tools, 254);
         assert_eq!(summary.low_risk_tier_tools, 6);
         assert_eq!(summary.high_risk_tier_tools, 0);
         assert_eq!(summary.human_approval_tier_tools, 2);
-        assert_eq!(summary.total_required_capabilities, 260);
+        assert_eq!(summary.total_required_capabilities, 262);
         assert_eq!(summary.risky_tool_count(), 8);
         assert_eq!(summary.approval_gated_tool_count(), 2);
         assert!(pair_bridge.requires_human_approval());


### PR DESCRIPTION
## Summary
- add shared smart-home descriptors for runtime maintenance plan list and summary tools
- expose Chief read-only maintenance plan records that group D23 supervision remediation actions by maintenance window
- cover plan listing/summary with an end-to-end smart-home tool test and update docs/changelogs

## Validation
- cargo fmt -p smart-home-core -p chief-of-staff-smart-home-tools --check
- cargo test -p smart-home-core
- cargo test -p smart-home-integration-catalog
- cargo test -p hue-core
- cargo test -p smart-home-runtime
- cargo test -p smart-home-testkit
- cargo test -p smart-home-local-http
- cargo test -p smart-home-discovery
- cargo test -p chief-of-staff-smart-home-tools
- cargo test -p smart-home-runtime discover_tool -- --nocapture
- sh BUILD in smart-home-core
- sh BUILD in smart-home-integration-catalog
- sh BUILD in hue-core
- sh BUILD in smart-home-runtime
- sh BUILD in smart-home-testkit
- sh BUILD in smart-home-local-http
- sh BUILD in smart-home-discovery
- sh BUILD in chief-of-staff-smart-home-tools
