### PR TITLE
feat(visicalc-xaml): insert / delete rows & columns in the XAML demo

### DIFF
--- a/demo/visicalc-xaml/Engine.cs
+++ b/demo/visicalc-xaml/Engine.cs
@@ -80,6 +80,13 @@ internal static class ScNative
     [DllImport("spreadsheet_capi")]
     internal static extern int sc_paste(IntPtr s,
         [MarshalAs(UnmanagedType.LPUTF8Str)] string dstStart);
+    // sc_insert_rows / sc_delete_rows / sc_insert_cols / sc_delete_cols(session,
+    // at, count) → void. Structural edits at a 1-based position; the engine
+    // shifts every formula reference across the band.
+    [DllImport("spreadsheet_capi")] internal static extern void sc_insert_rows(IntPtr s, uint at, uint count);
+    [DllImport("spreadsheet_capi")] internal static extern void sc_delete_rows(IntPtr s, uint at, uint count);
+    [DllImport("spreadsheet_capi")] internal static extern void sc_insert_cols(IntPtr s, uint at, uint count);
+    [DllImport("spreadsheet_capi")] internal static extern void sc_delete_cols(IntPtr s, uint at, uint count);
     // sc_serialize(session) → char* (workbook source + formats as JSON);
     // sc_deserialize(session, data) → int (1 loaded, 0 malformed/unsupported).
     [DllImport("spreadsheet_capi")] internal static extern IntPtr sc_serialize(IntPtr s);
@@ -156,6 +163,20 @@ public sealed class SpreadsheetSession : IDisposable
     /// every dependent. Reaches sc_fill — the same path every other backend drives.
     public void Fill(string src, string dstStart, string dstEnd) =>
         ScNative.sc_fill(_handle, src, dstStart, dstEnd);
+
+    /// Structural edits: insert / delete `count` rows or columns at the 1-based
+    /// position `at`. The engine shifts every formula reference at or after the
+    /// band (a reference whose whole band is deleted becomes `#REF!`), then
+    /// recomputes. `at`/`count` are clamped to ≥ 0 before the uint cast so a
+    /// negative can't wrap to a huge unsigned band.
+    public void InsertRows(int at, int count) =>
+        ScNative.sc_insert_rows(_handle, (uint)Math.Max(0, at), (uint)Math.Max(0, count));
+    public void DeleteRows(int at, int count) =>
+        ScNative.sc_delete_rows(_handle, (uint)Math.Max(0, at), (uint)Math.Max(0, count));
+    public void InsertCols(int at, int count) =>
+        ScNative.sc_insert_cols(_handle, (uint)Math.Max(0, at), (uint)Math.Max(0, count));
+    public void DeleteCols(int at, int count) =>
+        ScNative.sc_delete_cols(_handle, (uint)Math.Max(0, at), (uint)Math.Max(0, count));
 
     /// Copy the inclusive rectangle `start`..`end` into the clipboard — a
     /// whole-block copy that pastes as a unit. The source is untouched; the
@@ -529,6 +550,15 @@ public sealed class InfiniteSheetModel : IDisposable
         _session.Fill(InfAddress, $"{col}{first}", $"{col}{last}");
         ComputeExtent();
     }
+
+    /// Structural edits: insert / delete the selected cell's row or column. The
+    /// engine shifts every formula reference at or after the band (a reference
+    /// whose whole band is deleted becomes `#REF!`) and recomputes; regrow the
+    /// extent so the view re-reads. Operate on a single row/column at the cursor.
+    public void InsertRow() { _session.InsertRows(SelRow, 1); ComputeExtent(); }
+    public void DeleteRow() { _session.DeleteRows(SelRow, 1); ComputeExtent(); }
+    public void InsertCol() { _session.InsertCols(SelCol, 1); ComputeExtent(); }
+    public void DeleteCol() { _session.DeleteCols(SelCol, 1); ComputeExtent(); }
 
     /// Clipboard: copy/cut the selected cell, then paste it at the selection. The
     /// engine shifts the pasted formula's relative references by the destination's

--- a/demo/visicalc-xaml/InfiniteSheet.xaml
+++ b/demo/visicalc-xaml/InfiniteSheet.xaml
@@ -143,6 +143,24 @@
                             ToolTipService.ToolTip="Restore the workbook from the last save"
                             Click="LoadButton_Click"/>
                     <Border Width="1" Height="22" Margin="6,0,6,0" Background="#2C313A"/>
+                    <!-- Structure (insert / delete the selected row or column) -->
+                    <Button x:Name="InsRowButton" Style="{StaticResource ToolChip}" Margin="0,0,6,0"
+                            Content="+ Row"
+                            ToolTipService.ToolTip="Insert a row above the selected cell (references shift down)"
+                            Click="InsRowButton_Click"/>
+                    <Button x:Name="DelRowButton" Style="{StaticResource ToolChip}" Margin="0,0,6,0"
+                            Content="− Row"
+                            ToolTipService.ToolTip="Delete the selected cell's row (references shift up; refs into it become #REF!)"
+                            Click="DelRowButton_Click"/>
+                    <Button x:Name="InsColButton" Style="{StaticResource ToolChip}" Margin="0,0,6,0"
+                            Content="+ Col"
+                            ToolTipService.ToolTip="Insert a column left of the selected cell (references shift right)"
+                            Click="InsColButton_Click"/>
+                    <Button x:Name="DelColButton" Style="{StaticResource ToolChip}"
+                            Content="− Col"
+                            ToolTipService.ToolTip="Delete the selected cell's column (references shift left; refs into it become #REF!)"
+                            Click="DelColButton_Click"/>
+                    <Border Width="1" Height="22" Margin="6,0,6,0" Background="#2C313A"/>
                     <!-- History (undo / redo) -->
                     <Button x:Name="UndoButton" Style="{StaticResource ToolChip}" Margin="0,0,6,0"
                             Content="↶ Undo"

--- a/demo/visicalc-xaml/InfiniteSheet.xaml.cs
+++ b/demo/visicalc-xaml/InfiniteSheet.xaml.cs
@@ -219,6 +219,38 @@ public sealed partial class InfiniteSheet : UserControl
         RepaintRealizedRows();
     }
 
+    /// Structural edits: insert / delete the selected cell's row or column. The
+    /// engine shifts every formula reference across the band and recomputes; a
+    /// reference whose whole band is deleted becomes #REF!. Re-sync the formula
+    /// bar (the selected cell's content may have moved) and repaint the rows.
+    private void InsRowButton_Click(object sender, RoutedEventArgs e)
+    {
+        _model.InsertRow();
+        RefreshFormulaBar();
+        RepaintRealizedRows();
+    }
+
+    private void DelRowButton_Click(object sender, RoutedEventArgs e)
+    {
+        _model.DeleteRow();
+        RefreshFormulaBar();
+        RepaintRealizedRows();
+    }
+
+    private void InsColButton_Click(object sender, RoutedEventArgs e)
+    {
+        _model.InsertCol();
+        RefreshFormulaBar();
+        RepaintRealizedRows();
+    }
+
+    private void DelColButton_Click(object sender, RoutedEventArgs e)
+    {
+        _model.DeleteCol();
+        RefreshFormulaBar();
+        RepaintRealizedRows();
+    }
+
     /// Clipboard: copy/cut the selected cell, then paste it at the selection. The
     /// engine shifts the pasted formula's relative refs by the destination's
     /// offset, pins absolute ($) refs, carries the format; a cut clears the source

--- a/demo/visicalc-xaml/README.md
+++ b/demo/visicalc-xaml/README.md
@@ -165,6 +165,13 @@ The **Undo / Redo** buttons walk the engine's snapshot history
 (`InfiniteSheetModel.UndoEdit`/`RedoEdit` over the C ABI's `sc_undo`/`sc_redo`);
 they enable/disable off `CanUndo`/`CanRedo` (refreshed after every edit). Every
 edit is reversible and a restored formula recomputes live.
+The **+ Row / − Row / + Col / − Col** buttons are **structural edits**
+(`InfiniteSheetModel.InsertRow`/`DeleteRow`/`InsertCol`/`DeleteCol` over the C
+ABI's `sc_insert_rows`/`sc_delete_rows`/`sc_insert_cols`/`sc_delete_cols`): insert
+or delete the selected cell's row/column, and the engine shifts every formula
+reference at or after the band so dependents keep pointing at their precedents
+(`=A1+A2` with a row inserted above becomes `=A1+A3`); a reference whose whole band
+is deleted becomes `#REF!`.
 
 `InfiniteSheetModel` (in `Engine.cs`, WinUI-free) seeds far-flung sparse cells
 (`Z1000`, `BA50`, `BB50`) and derives the extent from `UsedRange()` + a margin

--- a/demo/visicalc-xaml/test/Program.cs
+++ b/demo/visicalc-xaml/test/Program.cs
@@ -198,5 +198,32 @@ using (var ur = new SpreadsheetSession())
     Check("fresh edit clears redo", ur.CanRedo().ToString(), "False");
 }
 
+// ── Structural edits (the + Row / − Row / + Col / − Col buttons drive
+// InsertRows/DeleteRows/InsertCols/DeleteCols): inserting and deleting
+// rows/columns shifts every formula reference across the band, and deleting a
+// referenced band turns that reference into #REF!. The engine parenthesizes
+// binary ops on re-emit ("=(A1+A3)"), so compare with parens stripped.
+static string Bare(string s) => s.Replace("(", "").Replace(")", "");
+using (var st = new SpreadsheetSession())
+{
+    st.SetCell("A1", "10"); st.SetCell("A2", "20"); st.SetCell("A3", "=A1+A2"); // 30
+    Check("struct A3 before", st.Window(3, 1, 3, 1)[0][0], "30");
+    st.InsertRows(2, 1);
+    Check("struct inserted row blank", st.Window(2, 1, 2, 1)[0][0], "");
+    Check("struct formula at A4", st.Window(4, 1, 4, 1)[0][0], "30");
+    Check("struct insert shifted refs", Bare(st.GetRaw("A4")), "=A1+A3");
+    st.DeleteRows(2, 1);
+    Check("struct delete shifted back", Bare(st.GetRaw("A3")), "=A1+A2");
+    st.DeleteRows(1, 1); // delete the referenced row 1 → A1 ref destroyed
+    Check("struct deleted ref is #REF!", st.Window(2, 1, 2, 1)[0][0], "#REF!");
+}
+using (var sc = new SpreadsheetSession())
+{
+    sc.SetCell("K1", "5"); sc.SetCell("L1", "=K1*3");
+    sc.InsertCols(11, 1); // col 11 = K → formula moves to M1, refs shift
+    Check("struct insertCol value", sc.Window(1, 13, 1, 13)[0][0], "15"); // M1
+    Check("struct insertCol shifted refs", Bare(sc.GetRaw("M1")), "=L1*3");
+}
+
 Console.WriteLine(failures == 0 ? "\nALL PASS" : $"\n{failures} FAILURE(S)");
 return failures == 0 ? 0 : 1;


### PR DESCRIPTION
## What

Fifth backend of the **insert / delete rows & columns** rollout (web [#6492](https://github.com/adhithyan15/coding-adventures/pull/6492) → Qt [#6496](https://github.com/adhithyan15/coding-adventures/pull/6496) → Flutter [#6501](https://github.com/adhithyan15/coding-adventures/pull/6501) → Compose [#6504](https://github.com/adhithyan15/coding-adventures/pull/6504) → **XAML** → SwiftUI). Engine + facades already implement structural edits; this wires them through **P/Invoke**.

## Changes

- **`Engine.cs`** — four `[DllImport]` decls (`sc_insert_rows`/…`(IntPtr, uint, uint)`) + four `SpreadsheetSession` methods `InsertRows/DeleteRows/InsertCols/DeleteCols` (clamp `at`/`count` ≥ 0 before the `int→uint` cast so a negative can't wrap to a huge unsigned band) + four `InfiniteSheetModel` methods `InsertRow/DeleteRow/InsertCol/DeleteCol` on the selected row/col (`ComputeExtent` so the view re-reads).
- **`InfiniteSheet.xaml`** — a **"Structure"** segmented toolbar group (+ Row / − Row / + Col / − Col) between File and History (reuses the `ToolChip` style).
- **`InfiniteSheet.xaml.cs`** — four `Click` handlers (model call + `RefreshFormulaBar` + `RepaintRealizedRows`).
- **`test/Program.cs`** — a structural-edit proof: insert a row above a formula (`=A1+A2` → `=A1+A3`, value preserved), delete it back, delete a referenced row (⇒ `#REF!`), and a column insert that shifts column refs.

## Verification

The WinUI view is **Windows-only** — this macOS checkout cannot `dotnet build` it (the documented boundary), so it's hand-authored against the existing patterns. The engine-backed model it drives is proven cross-platform by **`scripts/verify.sh`** (the `test/` console harness P/Invoking the engine) — **ALL PASS** incl. the new structural cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)