### PR TITLE
feat(visicalc-swiftui): insert / delete rows & columns in the SwiftUI demo

### DIFF
--- a/demo/visicalc-swiftui/README.md
+++ b/demo/visicalc-swiftui/README.md
@@ -103,6 +103,13 @@ The **Undo / Redo** buttons walk the engine's snapshot history
 they disable at the history ends via `canUndo`/`canRedo` (re-evaluated whenever
 `revision`, a `@Published`, bumps). Every edit is reversible and a restored
 formula recomputes live.
+The **+ Row / − Row / + Col / − Col** buttons are **structural edits**
+(`WindowedSheetModel.insertRow`/`deleteRow`/`insertCol`/`deleteCol` over the C
+ABI's `sc_insert_rows`/`sc_delete_rows`/`sc_insert_cols`/`sc_delete_cols`): insert
+or delete the selected cell's row/column, and the engine shifts every formula
+reference at or after the band so dependents keep pointing at their precedents
+(`=A1+A2` with a row inserted above becomes `=A1+A3`); a reference whose whole band
+is deleted becomes `#REF!`.
 
 ### Visual design
 

--- a/demo/visicalc-swiftui/Sources/VisiCalc/Engine.swift
+++ b/demo/visicalc-swiftui/Sources/VisiCalc/Engine.swift
@@ -48,6 +48,16 @@ final class SpreadsheetSession {
         sc_fill(handle, src, dstStart, dstEnd)
     }
 
+    /// Structural edits: insert / delete `count` rows or columns at the 1-based
+    /// position `at`. The engine shifts every formula reference at or after the
+    /// band (a reference whose whole band is deleted becomes `#REF!`), then
+    /// recomputes. `at`/`count` are clamped to ≥ 0 before the UInt32 conversion
+    /// so a negative can't trap / wrap into a huge unsigned band.
+    func insertRows(_ at: Int, _ count: Int) { sc_insert_rows(handle, UInt32(max(0, at)), UInt32(max(0, count))) }
+    func deleteRows(_ at: Int, _ count: Int) { sc_delete_rows(handle, UInt32(max(0, at)), UInt32(max(0, count))) }
+    func insertCols(_ at: Int, _ count: Int) { sc_insert_cols(handle, UInt32(max(0, at)), UInt32(max(0, count))) }
+    func deleteCols(_ at: Int, _ count: Int) { sc_delete_cols(handle, UInt32(max(0, at)), UInt32(max(0, count))) }
+
     /// Copy the inclusive rectangle `start`..`end` into the clipboard — a
     /// whole-block copy that pastes as a unit. The source is untouched; the
     /// buffer survives any number of pastes. Reaches `sc_copy`.

--- a/demo/visicalc-swiftui/Sources/VisiCalc/InfiniteGrid.swift
+++ b/demo/visicalc-swiftui/Sources/VisiCalc/InfiniteGrid.swift
@@ -141,6 +141,26 @@ final class WindowedSheetModel: ObservableObject {
         revision += 1
     }
 
+    /// Structural edits: insert / delete the selected cell's row or column. The
+    /// engine shifts every formula reference at or after the band (a reference
+    /// whose whole band is deleted becomes `#REF!`) and recomputes; resize the
+    /// extent and bump `revision` so the visible rows re-fetch. Operate on a
+    /// single row/column at the cursor. The SwiftUI sibling of the Qt/Flutter/
+    /// Compose/XAML "+ Row / − Row / + Col / − Col" controls.
+    func insertRow() { session.insertRows(selectedRow, 1); afterStructural() }
+    func deleteRow() { session.deleteRows(selectedRow, 1); afterStructural() }
+    func insertCol() { session.insertCols(selectedCol, 1); afterStructural() }
+    func deleteCol() { session.deleteCols(selectedCol, 1); afterStructural() }
+
+    /// Shared tail for a structural edit: regrow the extent, re-read the (now
+    /// possibly moved/blanked) selected cell's source into the formula bar, and
+    /// bump `revision` so the visible rows re-fetch.
+    private func afterStructural() {
+        resize()
+        formulaText = session.getRaw(address(selectedRow, selectedCol))
+        revision += 1
+    }
+
     /// Clipboard: copy/cut the selected cell, then paste it at the selection. The
     /// engine shifts the pasted formula's relative references by the
     /// destination's offset, pins absolute (`$`) refs, carries the format; a cut
@@ -345,6 +365,16 @@ struct InfiniteGridView: View {
             Button("Load") { if !savedSnapshot.isEmpty { model.loadBook(savedSnapshot) } }
                 .disabled(savedSnapshot.isEmpty)
                 .help("Restore the workbook from the last save")
+            toolSep
+            // ── Structure (insert / delete the selected row or column) ──
+            Button("+ Row") { model.insertRow() }
+                .help("Insert a row above the selected cell (references shift down)")
+            Button("− Row") { model.deleteRow() }
+                .help("Delete the selected cell's row (references shift up; refs into it become #REF!)")
+            Button("+ Col") { model.insertCol() }
+                .help("Insert a column left of the selected cell (references shift right)")
+            Button("− Col") { model.deleteCol() }
+                .help("Delete the selected cell's column (references shift left; refs into it become #REF!)")
             toolSep
             // ── History (undo / redo). The buttons gate off canUndo/canRedo,
             // re-evaluated whenever `revision` (a @Published) bumps after an edit.

--- a/demo/visicalc-swiftui/Tests/VisiCalcTests/WindowedModelTests.swift
+++ b/demo/visicalc-swiftui/Tests/VisiCalcTests/WindowedModelTests.swift
@@ -75,6 +75,50 @@ final class WindowedModelTests: XCTestCase {
         XCTAssertEqual(m.rowCells(1)[8], "20") // I1 source untouched
     }
 
+    /// Structural edits (the + Row / − Row / + Col / − Col buttons drive
+    /// insertRow/deleteRow/insertCol/deleteCol): inserting and deleting
+    /// rows/columns shifts every formula reference across the band, and deleting a
+    /// referenced band turns that reference into #REF!.
+    func testStructuralInsertDeleteShiftsReferences() {
+        let m = WindowedSheetModel()
+        // The engine parenthesizes binary ops on re-emit ("=(H1+H3)"), so strip
+        // parens before comparing the source the formula bar shows.
+        func bare(_ s: String) -> String { s.replacingOccurrences(of: "(", with: "").replacingOccurrences(of: ")", with: "") }
+        m.setCell("H1", "10")
+        m.setCell("H2", "20")
+        m.setCell("H3", "=H1+H2") // 30
+        XCTAssertEqual(m.rowCells(3)[7], "30")
+
+        // Insert a row at row 2: H2/H3 shift down to H3/H4, row 2 is blank, and
+        // the formula's refs shift with their cells (=H1+H2 → =H1+H3).
+        m.select(row: 2, col: 8); m.insertRow()
+        XCTAssertEqual(m.rowCells(2)[7], "")    // inserted row blank
+        XCTAssertEqual(m.rowCells(4)[7], "30")  // formula at H4
+        m.select(row: 4, col: 8)
+        XCTAssertEqual(bare(m.formulaText), "=H1+H3")
+
+        // Delete that inserted row: everything shifts back.
+        m.select(row: 2, col: 8); m.deleteRow()
+        XCTAssertEqual(m.rowCells(3)[7], "30")
+        m.select(row: 3, col: 8)
+        XCTAssertEqual(bare(m.formulaText), "=H1+H2")
+
+        // Delete row 1 (referenced by the formula): H2 shifts up to H1, the formula
+        // shifts up to H2, and its destroyed H1 reference becomes #REF!.
+        m.select(row: 1, col: 8); m.deleteRow()
+        XCTAssertEqual(m.rowCells(2)[7], "#REF!")
+
+        // Columns shift the same way: K1=5, L1 = K1*3 = 15; insert a column at K
+        // and the formula (now at M1) keeps pointing at its precedent (now L1).
+        let c = WindowedSheetModel()
+        c.setCell("K1", "5")
+        c.setCell("L1", "=K1*3")
+        c.select(row: 1, col: 11); c.insertCol() // col 11 = K
+        XCTAssertEqual(c.rowCells(1)[12], "15")  // M1 (col 13 → index 12)
+        c.select(row: 1, col: 13)
+        XCTAssertEqual(bare(c.formulaText), "=L1*3")
+    }
+
     /// Clipboard copy/cut/paste shifts a formula and moves a cut.
     func testClipboardCopyCutPaste() {
         let m = WindowedSheetModel()


### PR DESCRIPTION
## What

The **sixth and final** backend of the **insert / delete rows & columns** rollout (web [#6492](https://github.com/adhithyan15/coding-adventures/pull/6492) → Qt [#6496](https://github.com/adhithyan15/coding-adventures/pull/6496) → Flutter [#6501](https://github.com/adhithyan15/coding-adventures/pull/6501) → Compose [#6504](https://github.com/adhithyan15/coding-adventures/pull/6504) → XAML [#6508](https://github.com/adhithyan15/coding-adventures/pull/6508) → **SwiftUI**). Engine + facades already implement structural edits; this wires them through the **C ABI** (the tracked `CSpreadsheetEngine` header already declares the four `sc_*` funcs — no re-vendor).

## Changes

- **`Engine.swift`** — four `SpreadsheetSession` methods `insertRows/deleteRows/insertCols/deleteCols(at, count)` over the C funcs, with `at`/`count` clamped ≥ 0 **before** the `UInt32` conversion (which traps on negative).
- **`InfiniteGrid.swift`** — four `WindowedSheetModel` methods `insertRow/deleteRow/insertCol/deleteCol` on the selected row/col + a shared `afterStructural()` (resize + re-read the moved/blanked selected cell's source into the formula bar + bump `revision`); a **"Structure"** segmented toolbar group (+ Row / − Row / + Col / − Col) reusing `ChipButtonStyle`.
- **`Tests/WindowedModelTests.swift`** — a structural-edit proof: insert a row above a formula (`=H1+H2` → `=H1+H3`, value preserved), delete it back, delete a referenced row (⇒ `#REF!`), and a column insert that shifts column refs.

## Verification

- `swift build` — compiles the view against the real SwiftUI APIs.
- `swift test` — **13/13 pass** (incl. the new `testStructuralInsertDeleteShiftsReferences`). The Structure buttons reuse the `Button` + `ChipButtonStyle` component already verified live in the SwiftUI UI-polish PR.

With this, **insert/delete rows & columns is complete across all 6 backends** (web/Qt/Flutter/Compose/XAML/SwiftUI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)