### PR TITLE
feat(constant-fold): fold string-literal `.length` to its UTF-16 length

### DIFF
--- a/code/packages/rust/closure-pass-constant-fold/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-constant-fold/CHANGELOG.md
@@ -2,6 +2,39 @@
 
 All notable changes to the `coding-adventures-closure-pass-constant-fold` crate will be documented in this file.
 
+## [0.19.0] - 2026-06-22
+
+### Added — string-literal `.length` folding (`"hello".length` → `5`)
+
+`fold_expression` now folds the `.length` of a **string literal** to a numeric
+literal, via the new `fold_member` helper:
+
+| before        | after | reasoning                                       |
+|---------------|-------|-------------------------------------------------|
+| `"hello".length` | `5` | five UTF-16 code units                          |
+| `"".length`      | `0` | empty string                                    |
+| `"💩".length`    | `2` | one astral char = a UTF-16 surrogate pair       |
+| `("a"+"b").length` | `2` | object folds to `"ab"` first, then `.length`  |
+
+JavaScript's `String#length` is the count of **UTF-16 code units** (ECMAScript
+String exotic objects), not Unicode scalar values or bytes — so the fold uses
+`str::encode_utf16().count()`, which expands astral-plane characters
+(U+10000…U+10FFFF) to a surrogate pair, matching V8/SpiderMonkey exactly.
+`.count()` is total and allocation-free; it cannot panic.
+
+The fold is deliberately narrow — **dotted, non-computed `"...".length` only**:
+the object must fold to a `StringLiteral`, and the access must be non-`computed`
+with an `Identifier` property named `length`. `s.length` on an identifier,
+`"x".charCodeAt`, and the computed form `"abc"["length"]` all pass through
+unchanged (the first needs the runtime value of `s`; the last would mean
+reasoning about arbitrary computed keys). The fold emits a correlation-vector
+contribution like every other fold.
+
+Five new unit tests (`fold_string_literal_length`,
+`fold_string_length_counts_utf16_code_units_not_scalars`,
+`length_on_identifier_does_not_fold`, `non_length_property_on_string_does_not_fold`,
+`computed_string_length_does_not_fold`).
+
 ## [0.18.0] - 2026-06-22
 
 ### Added — unary bitwise NOT folding (`~5` → `-6`)

--- a/code/packages/rust/closure-pass-constant-fold/Cargo.toml
+++ b/code/packages/rust/closure-pass-constant-fold/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-constant-fold"
-version = "0.18.0"
+version = "0.19.0"
 edition = "2021"
 description = "Constant-folding optimization pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Folds compile-time-evaluable expressions like `2 + 3 → 5`."
 

--- a/code/packages/rust/closure-pass-constant-fold/src/lib.rs
+++ b/code/packages/rust/closure-pass-constant-fold/src/lib.rs
@@ -30,6 +30,7 @@
 //! null  ?? expr      →  expr
 //! 0     ?? expr      →  0                       (zero is not nullish)
 //! true  ? a : b      →  a                       (ConditionalExpression with literal test)
+//! "hi".length        →  2                       (string-literal .length, UTF-16 units)
 //! ```
 //!
 //! And recurses through every child node, so `1 + (2 * 3) → 1 + 6 → 7`
@@ -472,12 +473,7 @@ fn fold_expression(expr: &Expression, st: &mut FoldState) -> Expression {
             callee: Box::new(fold_expression(&c.callee, st)),
             arguments: c.arguments.iter().map(|a| fold_expression(a, st)).collect(),
         }),
-        Expression::MemberExpression(m) => Expression::MemberExpression(MemberExpression {
-            cv: m.cv.clone(),
-            object: Box::new(fold_expression(&m.object, st)),
-            property: Box::new(fold_expression(&m.property, st)),
-            computed: m.computed,
-        }),
+        Expression::MemberExpression(m) => fold_member(m, st),
         Expression::ArrayExpression(a) => Expression::ArrayExpression(ArrayExpression {
             cv: a.cv.clone(),
             elements: a
@@ -511,6 +507,62 @@ fn fold_expression(expr: &Expression, st: &mut FoldState) -> Expression {
                 .collect(),
         }),
     }
+}
+
+// ---------------------------------------------------------------------
+// Member access
+// ---------------------------------------------------------------------
+
+/// Folds the one member-access form whose value is known at compile time:
+/// the `.length` of a string literal.
+///
+/// ```text
+///   "hello".length   →  5
+///   "".length        →  0
+///   "💩".length      →  2     (one astral char = two UTF-16 code units)
+/// ```
+///
+/// JavaScript's `String#length` is the number of **UTF-16 code units**, NOT
+/// Unicode scalar values or bytes (ECMAScript §22.1.3.1 / String exotic
+/// objects). Rust's [`str::encode_utf16`] yields exactly those code units —
+/// astral-plane characters (U+10000…U+10FFFF) expand to a surrogate pair, so
+/// `"💩".length` is `2`, matching V8/SpiderMonkey. `.count()` is total and
+/// allocation-free; it cannot panic.
+///
+/// We fold **only** the dotted, non-computed form `"...".length`:
+/// - The object must fold to a `StringLiteral` (so the value is known).
+/// - The access must be non-`computed` and the property an `Identifier`
+///   named `length`. We deliberately leave the computed form `"..."["length"]`
+///   alone — it is vanishingly rare in real code and folding it would mean
+///   reasoning about arbitrary computed keys (`s[k]`), which needs the runtime
+///   value of `k`. Keeping the surface narrow keeps the fold obviously sound.
+/// - Anything else (identifier objects like `s.length`, other properties like
+///   `"x".charCodeAt`) falls through unchanged; we still recurse into the
+///   object and property so nested constants inside them fold.
+fn fold_member(m: &MemberExpression, st: &mut FoldState) -> Expression {
+    // Recurse first, so e.g. `("a" + "b").length` sees the folded `"ab"`.
+    let object = fold_expression(&m.object, st);
+    let property = fold_expression(&m.property, st);
+
+    if !m.computed {
+        if let (Expression::StringLiteral(s), Expression::Identifier(id)) = (&object, &property) {
+            if id.name == "length" {
+                let len = s.value.encode_utf16().count() as f64;
+                let parent = m.cv.clone();
+                let before = format!("\"{}\".length", s.value);
+                let after = format_js_number(len);
+                let new_cv = st.fork_cv(&parent, &before, &after);
+                return stamp_literal_cv(FoldedLiteral::Number(len), new_cv);
+            }
+        }
+    }
+
+    Expression::MemberExpression(MemberExpression {
+        cv: m.cv.clone(),
+        object: Box::new(object),
+        property: Box::new(property),
+        computed: m.computed,
+    })
 }
 
 // ---------------------------------------------------------------------
@@ -2348,6 +2400,100 @@ mod tests {
         assert!(matches!(
             extract_expr(&out),
             Expression::UnaryExpression(_)
+        ));
+    }
+
+    // ------------------- member access (`.length`) -------------------
+
+    /// Build a non-computed `<object>.<name>` member expression.
+    fn member(object: Expression, name: &str) -> Expression {
+        Expression::MemberExpression(MemberExpression {
+            cv: Some("m.cv".to_string()),
+            object: Box::new(object),
+            property: Box::new(ident(name)),
+            computed: false,
+        })
+    }
+
+    #[test]
+    fn fold_string_literal_length() {
+        // "abc".length → 3
+        let m = member(string("abc", None), "length");
+        let (out, _, changed, _) = run_pass(program_with_expr(m, true));
+        assert!(changed, "\"abc\".length should fold");
+        match extract_expr(&out) {
+            Expression::NumericLiteral(n) => assert_eq!(n.value, 3.0),
+            other => panic!("expected 3; got {:?}", other),
+        }
+
+        // "".length → 0
+        let m0 = member(string("", None), "length");
+        let (out, _, _, _) = run_pass(program_with_expr(m0, true));
+        match extract_expr(&out) {
+            Expression::NumericLiteral(n) => assert_eq!(n.value, 0.0),
+            other => panic!("expected 0; got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn fold_string_length_counts_utf16_code_units_not_scalars() {
+        // "💩" (U+1F4A9, an astral-plane char) is ONE Unicode scalar but TWO
+        // UTF-16 code units, so JS `"💩".length` is 2 — not 1. This guards the
+        // encode_utf16() choice against a naive `.chars().count()`.
+        let m = member(string("💩", None), "length");
+        let (out, _, _, _) = run_pass(program_with_expr(m, true));
+        match extract_expr(&out) {
+            Expression::NumericLiteral(n) => assert_eq!(n.value, 2.0),
+            other => panic!("expected 2 (UTF-16 units); got {:?}", other),
+        }
+
+        // A BMP combining sequence "é" written as e + U+0301 is two code units.
+        let m2 = member(string("e\u{0301}", None), "length");
+        let (out, _, _, _) = run_pass(program_with_expr(m2, true));
+        match extract_expr(&out) {
+            Expression::NumericLiteral(n) => assert_eq!(n.value, 2.0),
+            other => panic!("expected 2; got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn length_on_identifier_does_not_fold() {
+        // `s.length` needs the runtime value of `s`, so it stays a member expr.
+        let m = member(ident("s"), "length");
+        let (out, _, changed, _) = run_pass(program_with_expr(m, true));
+        assert!(!changed, "s.length must not fold");
+        assert!(matches!(
+            extract_expr(&out),
+            Expression::MemberExpression(_)
+        ));
+    }
+
+    #[test]
+    fn non_length_property_on_string_does_not_fold() {
+        // `"abc".charCodeAt` is not `.length`; it must pass through untouched.
+        let m = member(string("abc", None), "charCodeAt");
+        let (out, _, changed, _) = run_pass(program_with_expr(m, true));
+        assert!(!changed, "\"abc\".charCodeAt must not fold");
+        assert!(matches!(
+            extract_expr(&out),
+            Expression::MemberExpression(_)
+        ));
+    }
+
+    #[test]
+    fn computed_string_length_does_not_fold() {
+        // `"abc"["length"]` is the computed form — deliberately left alone.
+        let m = Expression::MemberExpression(MemberExpression {
+            cv: Some("m.cv".to_string()),
+            object: Box::new(string("abc", None)),
+            property: Box::new(string("length", None)),
+            computed: true,
+        });
+        let (out, _, changed, _) = run_pass(program_with_expr(m, true));
+        assert!(!changed, "computed \"abc\"[\"length\"] must not fold");
+        assert!(matches!(
+            extract_expr(&out),
+            Expression::MemberExpression(_)
         ));
     }
 

--- a/code/programs/rust/closurec/CHANGELOG.md
+++ b/code/programs/rust/closurec/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to the `coding-adventures-closurec` binary will be documented in this file.
 
+## [0.165.0] - 2026-06-22
+
+### Added — string-literal `.length` folding at SIMPLE/ADVANCED
+
+Pulls in `coding-adventures-closure-pass-constant-fold` 0.19.0, which folds the
+`.length` of a string literal to a number: `"hello".length` → `5`, `"".length`
+→ `0`, `"💩".length` → `2` (UTF-16 code-unit count, matching JS `String#length`).
+Only the dotted non-computed form on a string literal folds; `s.length` on an
+identifier and `"abc"["length"]` are left alone.
+
+New e2e fixture `tests/diff/simple-fold-strlen` (and integration test
+`diff_simple_fold_strlen.rs`) is the end-to-end oracle, with a
+whitespace-fallback guard proving the fold comes from the SIMPLE typed pipeline.
+
+> Version note: bumped to 0.165.0 (skipping 0.164.0, which is reserved by the
+> concurrently-developed ASI Rule-1 string-newline release) so the two parallel
+> branches don't collide on the version line.
+
 ## [0.163.0] - 2026-06-22
 
 ### Added — unary bitwise NOT folding (`~5` → `-6`) at SIMPLE/ADVANCED

--- a/code/programs/rust/closurec/Cargo.toml
+++ b/code/programs/rust/closurec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closurec"
-version = "0.163.0"
+version = "0.165.0"
 edition = "2021"
 description = "closurec — CLI driver for the Closure Compiler clone. Mirrors the upstream Java Closure Compiler's command-line flag surface (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility. Per CLOC08."
 

--- a/code/programs/rust/closurec/cli.spec.json
+++ b/code/programs/rust/closurec/cli.spec.json
@@ -2,7 +2,7 @@
   "cli_builder_spec_version": "1.0",
   "name": "closurec",
   "description": "closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.",
-  "version": "0.163.0",
+  "version": "0.165.0",
   "parsing_mode": "gnu",
   "flags": [
     { "id": "browser_featureset_year", "long": "browser_featureset_year", "type": "integer", "default": 0, "description": "Shortcut for defining goog.FEATURESET_YEAR=YYYY (minimum 2012)." },

--- a/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
@@ -2,7 +2,7 @@
 
 closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.
 
-Version: 0.163.0
+Version: 0.165.0
 
 ## Flags
 

--- a/code/programs/rust/closurec/tests/diff/simple-fold-strlen/README.md
+++ b/code/programs/rust/closurec/tests/diff/simple-fold-strlen/README.md
@@ -1,0 +1,24 @@
+# Fixture: `simple-fold-strlen`
+
+End-to-end oracle for string-literal `.length` folding at
+`--compilation_level SIMPLE`.
+
+| File | Role |
+|------|------|
+| `flags.txt` | CLI args: `--compilation_level SIMPLE --js input/a.js` |
+| `input/a.js` | `var n = "hello".length; report(n);` |
+| `expected.stdout` | The folded output: `var n=5;report(n);` |
+
+The SIMPLE level runs the typed-AST optimization pipeline, whose
+`constant-fold` pass folds the `.length` of a string literal to its
+UTF-16 code-unit count (JS `String#length` semantics): `"hello".length`
+→ `5`. The same input under `WHITESPACE_ONLY` keeps `"hello".length`
+unfolded (that level never runs the typed pipeline).
+
+Regenerate the expected file after an intentional behavior change:
+
+```sh
+cargo run -- --compilation_level SIMPLE \
+    --js tests/diff/simple-fold-strlen/input/a.js \
+    > tests/diff/simple-fold-strlen/expected.stdout
+```

--- a/code/programs/rust/closurec/tests/diff/simple-fold-strlen/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/simple-fold-strlen/expected.stdout
@@ -1,0 +1,1 @@
+var n=5;report(n);

--- a/code/programs/rust/closurec/tests/diff/simple-fold-strlen/flags.txt
+++ b/code/programs/rust/closurec/tests/diff/simple-fold-strlen/flags.txt
@@ -1,0 +1,4 @@
+--compilation_level
+SIMPLE
+--js
+tests/diff/simple-fold-strlen/input/a.js

--- a/code/programs/rust/closurec/tests/diff/simple-fold-strlen/input/a.js
+++ b/code/programs/rust/closurec/tests/diff/simple-fold-strlen/input/a.js
@@ -1,0 +1,12 @@
+// SIMPLE-level string-literal `.length` folding.
+//
+// `"<string>".length` is a compile-time-evaluable expression that the
+// `constant-fold` pass collapses to the UTF-16 code-unit count (JS
+// `String#length` semantics). Under WHITESPACE_ONLY it survives as
+// `"hello".length`; under SIMPLE it folds to `5`.
+//
+// The value flows into `report(...)` so it stays referenced — otherwise
+// remove-unused-vars (the last SIMPLE pass) would delete the declaration
+// and the fold would not be observable.
+var n = "hello".length;
+report(n);

--- a/code/programs/rust/closurec/tests/diff_simple_fold_strlen.rs
+++ b/code/programs/rust/closurec/tests/diff_simple_fold_strlen.rs
@@ -1,0 +1,83 @@
+//! Integration test for the `tests/diff/simple-fold-strlen/` fixture.
+//!
+//! End-to-end oracle for string-literal `.length` folding in
+//! `closure-pass-constant-fold`: `"hello".length` collapses to its UTF-16
+//! code-unit count (JS `String#length` semantics).
+//!
+//! At SIMPLE the fixture optimizes to:
+//!
+//! ```text
+//! var n=5;report(n);
+//! ```
+
+use std::process::Command;
+
+const BINARY: &str = env!("CARGO_BIN_EXE_closurec");
+
+fn read_flags() -> Vec<String> {
+    let raw = std::fs::read_to_string("tests/diff/simple-fold-strlen/flags.txt")
+        .expect("read flags.txt");
+    raw.lines()
+        .filter(|l| !l.is_empty())
+        .map(|s| s.to_string())
+        .collect()
+}
+
+#[test]
+fn simple_fold_strlen_fixture_matches_expected_stdout() {
+    let flags = read_flags();
+    let out = Command::new(BINARY)
+        .args(&flags)
+        .output()
+        .expect("run closurec");
+
+    assert!(
+        out.status.success(),
+        "exit: {:?}, stderr: {}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stderr),
+    );
+
+    let actual = String::from_utf8_lossy(&out.stdout);
+    let expected = std::fs::read_to_string("tests/diff/simple-fold-strlen/expected.stdout")
+        .expect("read expected.stdout");
+    assert_eq!(
+        actual.trim_end_matches('\n'),
+        expected.trim_end_matches('\n'),
+        "mismatch.\nflags: {flags:?}\nactual:\n{actual}\nexpected:\n{expected}",
+    );
+}
+
+/// `"hello".length` must fold to the literal `5` — no `.length` left in output.
+#[test]
+fn simple_fold_strlen_folds_to_numeric_literal() {
+    let out = Command::new(BINARY)
+        .args(read_flags())
+        .output()
+        .expect("run closurec");
+    let actual = String::from_utf8_lossy(&out.stdout);
+
+    assert!(actual.contains("n=5"), "\"hello\".length should fold to 5; got:\n{actual}");
+    assert!(
+        !actual.contains(".length"),
+        "no `.length` should remain after folding; got:\n{actual}",
+    );
+}
+
+/// Regression guard: the output must be the SIMPLE typed pipeline, not the
+/// WHITESPACE_ONLY fallback (which would leave `"hello".length` intact).
+#[test]
+fn simple_fold_strlen_did_not_fall_back_to_whitespace_only() {
+    let out = Command::new(BINARY)
+        .args(read_flags())
+        .output()
+        .expect("run closurec");
+    let actual = String::from_utf8_lossy(&out.stdout);
+
+    assert!(
+        !actual.contains("\"hello\""),
+        "expected the string literal to be folded away by the typed pipeline \
+         (proving this is the SIMPLE optimizer, not the whitespace fallback); \
+         got:\n{actual}",
+    );
+}


### PR DESCRIPTION
## What

`fold_expression` now folds the `.length` of a **string literal** to a numeric literal, via the new `fold_member` helper:

| before | after | reasoning |
|--------|-------|-----------|
| `"hello".length` | `5` | five UTF-16 code units |
| `"".length` | `0` | empty string |
| `"💩".length` | `2` | one astral char = a UTF-16 surrogate pair |
| `("a"+"b").length` | `2` | object folds to `"ab"` first, then `.length` |

JavaScript's `String#length` counts **UTF-16 code units** (ECMAScript String exotic objects), so the fold uses `str::encode_utf16().count()` — total, allocation-free, panic-free, and matching V8/SpiderMonkey on astral-plane characters.

## Scope (narrow + sound)
Only the **dotted, non-computed** `"...".length` form folds. `s.length` on an identifier, `"x".charCodeAt`, and the computed form `"abc"["length"]` all pass through unchanged (the first needs `s`'s runtime value; the last would mean reasoning about arbitrary computed keys). Emits a correlation-vector contribution like every other fold.

- `closure-pass-constant-fold` 0.18.0 → 0.19.0 — new `fold_member` + 5 unit tests (incl. an astral-plane UTF-16 guard against a naive `.chars().count()`).
- `closurec` 0.163.0 → **0.165.0** — new e2e fixture `tests/diff/simple-fold-strlen` + `diff_simple_fold_strlen.rs` (whitespace-fallback guard); help-markdown golden regenerated. Version **leapfrogs 0.164.0** (reserved by the concurrently-developed ASI Rule-1 branch #6400) so the two don't collide on the version line.

## Verification
- constant-fold: 57 unit tests pass (5 new).
- closurec: full suite green (new fixture, help-markdown, version-string).
- Downstream consumer pass crates (emitter, fold-control-flow, collapse-properties, inline, inline-variables, dce) re-run green.
- Security review: PASSED on changed code (`encode_utf16().count()` total/panic-free; sound UTF-16 semantics). One INFO-level **pre-existing** parser gap noted for follow-up: lone-surrogate `\uXXXX` escapes decode to literal text in the bridge (affects all string folds equally, out of scope here).

No lexer/parser/ASI/bridge files touched — independent of the in-flight ASI PR #6400.

🤖 Generated with [Claude Code](https://claude.com/claude-code)