### PR TITLE
feat(mycin-neuro): big batch — 9 high-yield neuroanatomy localizations (8→17 edges)

### DIFF
--- a/code/specs/data/mycin-2026/recall/neuro-edges.adj
+++ b/code/specs/data/mycin-2026/recall/neuro-edges.adj
@@ -94,4 +94,66 @@ rulebook neuro_facts {
         source "Therefore, any midline cerebellar lesions manifest as imbalance, while hemispheric cerebellar lesions result mainly in incoordination."
         locator "https://www.ncbi.nlm.nih.gov/books/NBK562317/"
         trust authoritative
+
+    % ------------------------------------------------------------------------
+    % BATCH: high-yield neuroanatomy localizations (lesion site -> deficit), each
+    % grounded to a self-contained verbatim NCBI Bookshelf span naming both the
+    % structure and the deficit/syndrome it produces. (optic_chiasm ->
+    % bitemporal_hemianopia declined: NBK545213/NBK542287 have no single span that
+    % both names the chiasm and states it CAUSES the defect — left out, not stretched.)
+    % ------------------------------------------------------------------------
+
+    % Mammillary bodies (diencephalon) — the amnesia of Wernicke-Korsakoff.
+    relate lesion_causes(mammillary_bodies, wernicke_korsakoff_syndrome)
+        source "The amnesia associated with Wernicke-Korsakoff syndrome results from atrophy of diencephalic structures (thalamus, hypothalamus, and mammillary bodies)."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK430729/"
+        trust authoritative
+
+    % Amygdala (bilateral temporal) — Klüver-Bucy syndrome.
+    relate lesion_causes(amygdala, kluver_bucy_syndrome)
+        source "Kluver-Bucy syndrome (KBS) is a rare neuropsychiatric disorder due to lesions affecting bilateral temporal lobes, especially the hippocampus and amygdala."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK544221/"
+        trust authoritative
+
+    % Hippocampus — anterograde amnesia (no new memories).
+    relate lesion_causes(hippocampus, anterograde_amnesia)
+        source "A lesion in the hippocampus can cause anterograde amnesia and the inability to make new memories."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK537247/"
+        trust authoritative
+
+    % Medial longitudinal fasciculus — internuclear ophthalmoplegia.
+    relate lesion_causes(medial_longitudinal_fasciculus, internuclear_ophthalmoplegia)
+        source "Internuclear ophthalmoplegia is an ocular movement disorder caused by a lesion of the medial longitudinal fasciculus."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK441970/"
+        trust authoritative
+
+    % Posterior limb of the internal capsule — pure motor hemiparesis (lacunar).
+    relate lesion_causes(internal_capsule, pure_motor_hemiparesis)
+        source "Pure motor hemiparesis involves the posterior limb of the internal capsule, corona radiata, or ventral pons."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK563216/"
+        trust authoritative
+
+    % Dominant (left) parietal lobe / angular gyrus — Gerstmann syndrome.
+    relate lesion_causes(dominant_parietal_lobe, gerstmann_syndrome)
+        source "Gerstmann's syndrome is caused by specific brain lesions which affect the posterior lobule of the parietal lobe in the dominant hemisphere, which is usually in the left hemisphere but in some patients it could be the right, especially the angular gyrus and adjacent structures (at the confluence of parietal, temporal and occipital lobes), some studies showed that it's caused not only by lesion in the mentioned area but also in the left middle frontal lobe of the dominant hemisphere."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK519528/"
+        trust authoritative
+
+    % Nondominant (right) parietal lobe — hemispatial neglect.
+    relate lesion_causes(nondominant_parietal_lobe, hemispatial_neglect)
+        source "Damage to the non-dominant parietal lobe (usually right) leads to agnosia of the contralateral side of the world, also known as hemispatial neglect syndrome."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK537247/"
+        trust authoritative
+
+    % Frontal lobe (prefrontal cortex) — frontal lobe syndrome (personality change).
+    relate lesion_causes(frontal_lobe, personality_change)
+        source "Frontal lobe syndrome is characterized by impairments in executive function, behavior, emotion, motivation, and personality resulting from damage to the frontal lobes, particularly the prefrontal cortex and its associated neural networks."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK532981/"
+        trust authoritative
+
+    % Posterior (dorsal) columns — loss of vibration and proprioception.
+    relate lesion_causes(posterior_columns, loss_of_proprioception)
+        source "The classic clinical features of Brown-Séquard syndrome include contralateral loss of pain and temperature (spinothalamic tract), ipsilateral hemiparesis (corticospinal tract), and ipsilateral loss of vibration and proprioception (posterior column pathway)."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK507888/"
+        trust authoritative
 }

--- a/code/specs/data/mycin-2026/recall/neuro-recall.query.adj
+++ b/code/specs/data/mycin-2026/recall/neuro-recall.query.adj
@@ -21,3 +21,13 @@ import "neuro-edges.adj"
 ? lesion_causes(caudate_nucleus, $Deficit)      % expect huntington_disease
 ? lesion_causes(midline_cerebellum, $Deficit)   % expect imbalance (expand)
 ? lesion_causes(cerebellar_hemisphere, $Deficit) % expect incoordination (expand)
+% --- BATCH: high-yield neuroanatomy localizations ---
+? lesion_causes(mammillary_bodies, $Deficit)               % expect wernicke_korsakoff_syndrome (expand)
+? lesion_causes(amygdala, $Deficit)                        % expect kluver_bucy_syndrome (expand)
+? lesion_causes(hippocampus, $Deficit)                     % expect anterograde_amnesia (expand)
+? lesion_causes(medial_longitudinal_fasciculus, $Deficit)  % expect internuclear_ophthalmoplegia (expand)
+? lesion_causes(internal_capsule, $Deficit)                % expect pure_motor_hemiparesis (expand)
+? lesion_causes(dominant_parietal_lobe, $Deficit)          % expect gerstmann_syndrome (expand)
+? lesion_causes(nondominant_parietal_lobe, $Deficit)       % expect hemispatial_neglect (expand)
+? lesion_causes(frontal_lobe, $Deficit)                    % expect personality_change (expand)
+? lesion_causes(posterior_columns, $Deficit)               % expect loss_of_proprioception (expand)

--- a/code/specs/data/mycin-2026/recall/test_neuro_recall.py
+++ b/code/specs/data/mycin-2026/recall/test_neuro_recall.py
@@ -37,6 +37,16 @@ EXPECTED = {
     "caudate_nucleus": "huntington_disease",
     "midline_cerebellum": "imbalance",              # expand (NBK562317)
     "cerebellar_hemisphere": "incoordination",      # expand (NBK562317)
+    # --- BATCH: high-yield neuroanatomy localizations ---
+    "mammillary_bodies": "wernicke_korsakoff_syndrome",   # expand (NBK430729)
+    "amygdala": "kluver_bucy_syndrome",                   # expand (NBK544221)
+    "hippocampus": "anterograde_amnesia",                 # expand (NBK537247)
+    "medial_longitudinal_fasciculus": "internuclear_ophthalmoplegia",  # expand (NBK441970)
+    "internal_capsule": "pure_motor_hemiparesis",         # expand (NBK563216)
+    "dominant_parietal_lobe": "gerstmann_syndrome",       # expand (NBK519528)
+    "nondominant_parietal_lobe": "hemispatial_neglect",   # expand (NBK537247)
+    "frontal_lobe": "personality_change",                 # expand (NBK532981)
+    "posterior_columns": "loss_of_proprioception",        # expand (NBK507888)
 }
 REL = "lesion_causes"
 VAR = "Deficit"
@@ -100,8 +110,8 @@ def test_unknown_site_abstains() -> None:
     fd, path = tempfile.mkstemp(suffix=".adj", prefix=".neuro_q_", dir=HERE)
     try:
         with os.fdopen(fd, "w") as fh:
-            # hippocampus is not in the library → must abstain
-            fh.write(f'import "neuro-edges.adj"\n? {REL}(hippocampus, ${VAR})\n')
+            # pineal_gland is not in the library → must abstain
+            fh.write(f'import "neuro-edges.adj"\n? {REL}(pineal_gland, ${VAR})\n')
         res = _run(Path(path))
         r = res["recall"][0] if res["recall"] else None
         assert r is not None and r["abstained"], "an ungrounded lesion site must abstain"


### PR DESCRIPTION
## What

Doubles the MYCIN-2026 **NEURO** recall library — **8 → 17 grounded edges** — adding 9 Step-1-staple lesion-site → deficit localizations, each defended by a self-contained verbatim NCBI Bookshelf span naming both the structure and the deficit/syndrome.

| lesion site | deficit | source |
|---|---|---|
| mammillary bodies | Wernicke-Korsakoff syndrome | NBK430729 |
| amygdala (bilateral) | Klüver-Bucy syndrome | NBK544221 |
| hippocampus | anterograde amnesia | NBK537247 |
| medial longitudinal fasciculus | internuclear ophthalmoplegia | NBK441970 |
| internal capsule (posterior limb) | pure motor hemiparesis | NBK563216 |
| dominant parietal lobe / angular gyrus | Gerstmann syndrome | NBK519528 |
| nondominant parietal lobe | hemispatial neglect | NBK537247 |
| frontal lobe (prefrontal) | frontal lobe syndrome (personality change) | NBK532981 |
| posterior (dorsal) columns | loss of proprioception/vibration | NBK507888 |

### Honestly declined (checked + documented, not stretched)
- **optic chiasm → bitemporal hemianopia** — NBK545213/NBK542287 have no single span that both names the chiasm and states it *causes* the field defect (the causal sentence refers to it only as "this condition"). Left out rather than stretched.

## Verify
- `test_neuro_recall` **3/3** — the native adj-lang engine binds **all 17** deficits via the worked query file, each with an `authoritative` citation + real source span + `ncbi.nlm.nih.gov` locator; an off-vocabulary site (pineal_gland) abstains.
- `ruff` clean; data-only security review passed.

Negative-control note: the abstention test's probe site was `hippocampus`, which this batch now grounds — repointed to `pineal_gland` (still ungrounded) so the test stays meaningful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)