### PR TITLE
feat(visicalc-html): per-cell number formatting in the web demo

### DIFF
--- a/demo/visicalc-html/README.md
+++ b/demo/visicalc-html/README.md
@@ -45,6 +45,11 @@ it through a C ABI.)
 > reference at or after the band so dependents keep pointing at their precedents
 > (`=A1+A2` with a row inserted above becomes `=A1+A3`); a reference whose whole
 > band is deleted becomes `#REF!`.
+> The **.00 / % / $ / Gen** buttons apply a number **format** to the selected cell
+> (`workbook.setFormat` with an Excel-style code: `#,##0.00`, `0.0%`,
+> `$#,##0.00`, or `""` to clear). The format is display-only — the engine renders
+> the stored value through the code (`getDisplayWindow`), so `15` shows as
+> `15.00` / `1500.0%` / `$15.00` without changing the underlying number.
 > Headless proof: `node scripts/verify-infinite.mjs` replays the exact windowing
 > math against the committed WASM bundle and asserts the render stays bounded,
 > the formatted display strings are correct, a formula 1000 rows down is
@@ -68,7 +73,7 @@ page's `:root` so the whole surface reads as one considered panel:
   formula field use the mono font.
 - **Toolbar** — an address **pill**, an `fx` marker, then a grown formula field
   with an accent **focus ring**; actions are **segmented button groups**
-  (drag-fill · clipboard · file · structure · history) separated by thin rules,
+  (drag-fill · clipboard · file · structure · format · history) separated by thin rules,
   each with hover/active/disabled states.
 - **Grid** — subtle **zebra** row banding, a 2-px **accent selection ring**, and
   the selected cell's **row + column headers tint to the accent** so the

--- a/demo/visicalc-html/infinite.html
+++ b/demo/visicalc-html/infinite.html
@@ -191,6 +191,13 @@
         <button id="delCol" title="Delete the selected cell's column (references shift left; refs into it become #REF!)">− Col</button>
       </div>
       <span class="sep"></span>
+      <div class="grp" role="group" aria-label="Format">
+        <button id="fmtDecimal" title="Format the selected cell with thousands separators + 2 decimals (#,##0.00)">.00</button>
+        <button id="fmtPercent" title="Format the selected cell as a percent (0.0%)">%</button>
+        <button id="fmtCurrency" title="Format the selected cell as currency ($#,##0.00)">$</button>
+        <button id="fmtGeneral" title="Clear the selected cell's format (General)">Gen</button>
+      </div>
+      <span class="sep"></span>
       <div class="grp" role="group" aria-label="History">
         <button id="undoBtn" title="Undo the last edit">↶ Undo</button>
         <button id="redoBtn" title="Redo the last undone edit">↷ Redo</button>
@@ -405,6 +412,20 @@
       render();
       statusEl.innerHTML += " &nbsp;·&nbsp; deleted column " + esc(workbook.columnLetters(selCol));
     });
+
+    // Number formatting: attach an Excel-style format code to the selected cell.
+    // The code is display-only — the stored value is unchanged, the engine just
+    // renders it differently (getDisplayWindow applies the code). "" clears it.
+    function applyFormat(code, label) {
+      var a = a1(selRow, selCol);
+      workbook.setFormat(a, code);
+      render();
+      statusEl.innerHTML += " &nbsp;·&nbsp; formatted " + esc(a) + " as " + esc(label);
+    }
+    document.getElementById("fmtDecimal").addEventListener("click", function () { applyFormat("#,##0.00", "#,##0.00"); });
+    document.getElementById("fmtPercent").addEventListener("click", function () { applyFormat("0.0%", "0.0%"); });
+    document.getElementById("fmtCurrency").addEventListener("click", function () { applyFormat("$#,##0.00", "$#,##0.00"); });
+    document.getElementById("fmtGeneral").addEventListener("click", function () { applyFormat("", "General"); });
 
     // Save / load: serialize the whole workbook to a single JSON document and
     // stash it in the browser's localStorage; Load deserializes it back. The

--- a/demo/visicalc-html/scripts/verify-infinite.mjs
+++ b/demo/visicalc-html/scripts/verify-infinite.mjs
@@ -230,5 +230,23 @@ ok(wbc.getRaw("C1") === "=(B1*3)" || wbc.getRaw("C1") === "=B1*3",
   `insertCols shifted the formula's column refs: ${wbc.getRaw("C1")}`);
 ok(wbc.getDisplayWindow(1, 3, 1, 3).cells[0][0] === "15", "insertCols: formula moved to C1, still = 15");
 
+// Number formatting (the .00 / % / $ / Gen buttons): setFormat attaches an
+// Excel-style code to a cell; it's display-only (the stored value is unchanged),
+// and getDisplayWindow renders through it. "" clears the format back to General.
+const wbf = sandbox.window.SpreadsheetEngine.createSpreadsheet();
+wbf.setCell("A1", "1234");
+const fmtDisp = () => wbf.getDisplayWindow(1, 1, 1, 1).cells[0][0];
+ok(fmtDisp() === "1234", `unformatted: ${fmtDisp()}`);
+wbf.setFormat("A1", "#,##0.00");
+ok(fmtDisp() === "1,234.00", `#,##0.00 → ${fmtDisp()}`);
+wbf.setFormat("A1", "0.0%");
+ok(fmtDisp() === "123400.0%", `0.0% → ${fmtDisp()}`);
+wbf.setFormat("A1", "$#,##0.00");
+ok(fmtDisp() === "$1,234.00", `$#,##0.00 → ${fmtDisp()}`);
+wbf.setFormat("A1", "");
+ok(fmtDisp() === "1234", `cleared (General) → ${fmtDisp()}`);
+// The format is display-only: the raw stored value never changed.
+ok(wbf.getRaw("A1") === "1234", `raw value untouched by formatting: ${wbf.getRaw("A1")}`);
+
 console.log(fail === 0 ? "\nALL PASS" : `\n${fail} FAILURE(S)`);
 process.exit(fail ? 1 : 0);


### PR DESCRIPTION
## What

Starts the **per-cell number formatting** feature (the next item after insert/delete). The engine's `setFormat` primitive is wired through every facade but currently only the demos' *seed* uses it — this gives the **user** control over a cell's display format. First of the 6-backend rollout (**web** → Qt → Flutter → Compose → XAML → SwiftUI).

## Changes

- **`infinite.html`** — a new **"Format"** segmented toolbar group between Structure and History: **.00** (`#,##0.00`), **%** (`0.0%`), **$** (`$#,##0.00`), **Gen** (clears) — each applies a fixed Excel format code to the selected cell via `workbook.setFormat`, then re-renders. Display-only: the engine renders the stored value through the code (`getDisplayWindow`), so the underlying number is unchanged.
- **`scripts/verify-infinite.mjs`** — a format proof: set `1234`, apply each code (→ `1,234.00` / `123400.0%` / `$1,234.00` / cleared `1234`), and assert the raw stored value is untouched.
- **README** — documents the buttons + the display-only semantics.

## Verification

- `node scripts/verify-infinite.mjs` — **ALL PASS** incl. the new format cases.
- **Live** (preview server): the 4 buttons render, **no console errors**, and on A1 (=15): `.00`→`15.00`, `%`→`1500.0%`, `$`→`$15.00`, `Gen`→`15` — verified via DOM eval. This validates the design for the native ports to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)