### PR TITLE
feat(sir-runtime-oop): String method catalog (M1c-String)

### DIFF
--- a/code/packages/python/sir-runtime-oop/CHANGELOG.md
+++ b/code/packages/python/sir-runtime-oop/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to `coding-adventures-sir-runtime-oop` are documented here.
 
+## [0.1.4] - 2026-06-22
+
+### Added
+
+Built-in method dispatch, part 4 — the **`String`** catalog (per
+`code/specs/sir-method-dispatch.md`, item M1c; a Ruby `String` is a Python `str`,
+which is **immutable**, so every method is non-mutating and returns a fresh
+value):
+
+- Non-block: `length`/`size`, `upcase`, `downcase`, `capitalize`, `reverse`,
+  `strip`/`lstrip`/`rstrip`, `chomp` (default line-ending or explicit suffix),
+  `chars`, `bytes` (UTF-8), `split` (whitespace default or literal separator),
+  `include?`, `start_with?`, `end_with?`, `index` (nil when absent), `replace`,
+  `sub`/`gsub` (**literal** — pattern matched as a plain substring, replacement
+  inserted verbatim with no `\1`/`&` back-reference expansion), `to_i`/`to_f`
+  (leading-numeric, `0`/`0.0` when none — never raising), `to_sym` (interns a
+  `sir-runtime-core` `Symbol`), `empty?`, `*` (repeat), `+` (concat).
+- Block: `each_char` — applied via `sir-runtime-core` `apply`.
+
+`respond_to?` reports the String methods; out-of-catalog stays `nil`. Universal
+`Object` methods still resolve on a String receiver.
+
 ## [0.1.3] - 2026-06-22
 
 ### Added

--- a/code/packages/python/sir-runtime-oop/README.md
+++ b/code/packages/python/sir-runtime-oop/README.md
@@ -55,9 +55,13 @@ the **non-block `Array`** surface — `length`/`size`/`count`, `first`/`last`,
 `map`/`collect`, `select`/`filter`, `reject`, `reduce`/`inject`, `find`/`detect`,
 `flat_map`, `any?`/`all?`/`none?` — a trailing `Closure` block is applied via
 `sir-runtime-core`'s `apply` (proc-lenient), predicates routed through SIR
-`truthy`; and (item **M1c**) the **`Hash`** catalog
-(`keys`/`values`/`has_key?`/`fetch`/`merge`/`each`/`map`/`select`/…). The
-String/Numeric/Symbol catalogs land in follow-up releases.
+`truthy`; (item **M1c**) the **`Hash`** catalog
+(`keys`/`values`/`has_key?`/`fetch`/`merge`/`each`/`map`/`select`/…); and (item
+**M1c**) the **`String`** catalog (`length`, `upcase`/`downcase`/`capitalize`,
+`reverse`, `strip`/`lstrip`/`rstrip`, `chomp`, `chars`/`bytes`, `split`,
+`include?`/`start_with?`/`end_with?`/`index`, `replace`, `sub`/`gsub` *literal*,
+`to_i`/`to_f`/`to_sym`, `empty?`, `*`/`+`, `each_char`). The Numeric/Symbol
+catalogs land in follow-up releases.
 
 ## Honest v0 limitation
 

--- a/code/packages/python/sir-runtime-oop/src/coding_adventures_sir_runtime_oop/oop.py
+++ b/code/packages/python/sir-runtime-oop/src/coding_adventures_sir_runtime_oop/oop.py
@@ -31,14 +31,16 @@ receivers into method bodies (out of scope for the backend).  See
 
 from __future__ import annotations
 
+import re
 from collections.abc import Callable
 from typing import Any
 
 # Block-taking catalog methods (each/map/select/…) invoke a Ruby block.  A block
 # reaches us as a trailing ``Closure`` from ``sir-runtime-core``; ``apply`` calls
 # it with proc-lenient arity, and ``truthy`` applies SIR truthiness (only
-# ``False``/``nil`` are falsy) to predicate results.
-from coding_adventures_sir_runtime_core import Closure, apply, truthy
+# ``False``/``nil`` are falsy) to predicate results.  ``intern`` mints the
+# :class:`Symbol` that ``String#to_sym`` returns.
+from coding_adventures_sir_runtime_core import Closure, apply, intern, truthy
 
 # The SIR universal value type at this package's boundary.
 Val = Any
@@ -345,6 +347,46 @@ _HASH_BLOCK_METHODS = frozenset(
     }
 )
 
+# Non-block ``String`` methods (M1c).  A Ruby ``String`` is a Python ``str``,
+# which is **immutable** — so every method here is non-mutating and returns a
+# fresh value (Ruby's bang-free methods do the same; the in-place ``upcase!``
+# family is out of v0 scope).  ``sub``/``gsub`` here are the *literal* forms:
+# the pattern is matched as a plain substring, never a regex, and the replacement
+# is inserted verbatim (no ``\1``/``&`` back-reference expansion).
+_STRING_METHODS = frozenset(
+    {
+        "length",
+        "size",
+        "upcase",
+        "downcase",
+        "capitalize",
+        "reverse",
+        "strip",
+        "lstrip",
+        "rstrip",
+        "chomp",
+        "chars",
+        "bytes",
+        "split",
+        "include?",
+        "start_with?",
+        "end_with?",
+        "index",
+        "replace",
+        "sub",
+        "gsub",
+        "to_i",
+        "to_f",
+        "to_sym",
+        "empty?",
+        "*",
+        "+",
+    }
+)
+
+# Block-taking ``String`` methods (M1c); ``each_char`` yields one character.
+_STRING_BLOCK_METHODS = frozenset({"each_char"})
+
 
 def _method_name(arg: Val) -> str:
     """Coerce a ``respond_to?`` argument (a :class:`Symbol`, ``":m"``-ish string,
@@ -362,6 +404,10 @@ def _responds_to(recv: Val, name: str) -> bool:
         return True
     if name in _OBJECT_METHODS:
         return True
+    # ``str`` is checked before ``list``/``dict`` would be irrelevant (a str is
+    # neither), but note bools are ints — order vs Array/Hash does not collide.
+    if isinstance(recv, str):
+        return name in _STRING_METHODS or name in _STRING_BLOCK_METHODS
     if isinstance(recv, list):
         return name in _ARRAY_METHODS or name in _ARRAY_BLOCK_METHODS
     if isinstance(recv, dict):
@@ -602,6 +648,141 @@ def _hash_block_method(recv: dict[Val, Val], name: str, block: Closure) -> Val:
     return _MISS
 
 
+# Leading-numeric extractors for ``String#to_i`` / ``String#to_f``.  Ruby parses
+# an optional sign and the longest leading numeric run, ignoring surrounding
+# whitespace, and yields ``0`` / ``0.0`` when nothing numeric leads — never an
+# error (unlike Python's ``int()``/``float()``, which raise).
+_INT_PREFIX = re.compile(r"[+-]?\d+")
+_FLOAT_PREFIX = re.compile(r"[+-]?(?:\d+\.?\d*|\.\d+)(?:[eE][+-]?\d+)?")
+
+
+def _str_to_i(s: str) -> int:
+    """Ruby ``String#to_i``: leading integer, else ``0``."""
+    match = _INT_PREFIX.match(s.strip())
+    return int(match.group()) if match else 0
+
+
+def _str_to_f(s: str) -> float:
+    """Ruby ``String#to_f``: leading float, else ``0.0``."""
+    match = _FLOAT_PREFIX.match(s.strip())
+    return float(match.group()) if match else 0.0
+
+
+# Upper bound on the character count ``String#*`` will produce.  A repeat count
+# can come from untrusted input (e.g. ``gets.to_i``); without a cap a hostile
+# count would attempt a multi-gigabyte allocation (``MemoryError``).  Past the
+# cap we yield the empty string rather than raise — honouring the runtime's
+# "never raise on the OO surface" invariant.
+_MAX_REPEAT_LEN = 100_000_000
+
+
+def _str_repeat(s: str, count: Val) -> str:
+    """Ruby ``String#*``: ``s`` repeated ``count`` times.
+
+    Non-positive counts yield ``""`` (Ruby raises ``ArgumentError`` on a negative
+    count, but the runtime floor is to never raise), and an over-large product is
+    clamped to :data:`_MAX_REPEAT_LEN` characters to bound a DoS from a hostile
+    count.
+    """
+    n = int(count) if isinstance(count, (int, float)) else 0
+    if n <= 0 or not s:
+        return ""
+    if len(s) * n > _MAX_REPEAT_LEN:
+        n = _MAX_REPEAT_LEN // len(s)
+    return s * n
+
+
+def _chomp(s: str, sep: Val) -> str:
+    """Ruby ``String#chomp``: drop a trailing record separator.
+
+    With an explicit ``sep`` argument, drop exactly that trailing suffix; with no
+    argument, drop one trailing ``\\r\\n``, ``\\n``, or ``\\r`` (Ruby's default
+    line ending handling).
+    """
+    if sep is not None:
+        return s[: -len(sep)] if sep and s.endswith(sep) else s
+    if s.endswith("\r\n"):
+        return s[:-2]
+    if s.endswith(("\n", "\r")):
+        return s[:-1]
+    return s
+
+
+def _string_method(recv: str, name: str, args: list[Val]) -> Val:
+    """Non-block ``String`` methods.  Returns :data:`_MISS` if ``name`` is not a
+    catalogued string method.  Every result is a fresh value — ``str`` is
+    immutable, so nothing mutates ``recv`` in place."""
+    if name in ("length", "size"):
+        return len(recv)
+    if name == "upcase":
+        return recv.upper()
+    if name == "downcase":
+        return recv.lower()
+    if name == "capitalize":
+        # Ruby: first char upcased, the rest downcased — exactly ``str.capitalize``.
+        return recv.capitalize()
+    if name == "reverse":
+        return recv[::-1]
+    if name == "strip":
+        return recv.strip()
+    if name == "lstrip":
+        return recv.lstrip()
+    if name == "rstrip":
+        return recv.rstrip()
+    if name == "chomp":
+        return _chomp(recv, args[0] if args else None)
+    if name == "chars":
+        return list(recv)
+    if name == "bytes":
+        return list(recv.encode("utf-8"))
+    if name == "split":
+        # No argument ⇒ split on runs of whitespace (Ruby's awk-style default);
+        # with a separator ⇒ split on that literal substring.
+        return recv.split(args[0]) if args else recv.split()
+    if name == "include?":
+        return args[0] in recv
+    if name == "start_with?":
+        return recv.startswith(args[0])
+    if name == "end_with?":
+        return recv.endswith(args[0])
+    if name == "index":
+        pos = recv.find(args[0])
+        return pos if pos >= 0 else None
+    if name == "replace":
+        # Ruby ``String#replace`` overwrites the whole content; for an immutable
+        # ``str`` that is just the replacement value.
+        return args[0]
+    if name == "sub":
+        # Literal first-occurrence replacement; ``str.replace`` is verbatim (no
+        # back-reference expansion), so there is no ``$&`` foot-gun here.
+        return recv.replace(args[0], args[1], 1)
+    if name == "gsub":
+        return recv.replace(args[0], args[1])
+    if name == "to_i":
+        return _str_to_i(recv)
+    if name == "to_f":
+        return _str_to_f(recv)
+    if name == "to_sym":
+        return intern(recv)
+    if name == "empty?":
+        return len(recv) == 0
+    if name == "*":
+        return _str_repeat(recv, args[0])
+    if name == "+":
+        return recv + args[0]
+    return _MISS
+
+
+def _string_block_method(recv: str, name: str, block: Closure) -> Val:
+    """Block-taking ``String`` methods.  Returns :data:`_MISS` if ``name`` is not
+    a string block method."""
+    if name == "each_char":
+        for char in recv:
+            apply(block, [char])
+        return recv
+    return _MISS
+
+
 def call_method(recv: Val, name: str, *args: Val) -> Val:
     """Dispatch method ``name`` on ``recv``.
 
@@ -633,7 +814,16 @@ def call_method(recv: Val, name: str, *args: Val) -> Val:
         return fn(recv, list(args))
 
     arg_list = list(args)
-    if isinstance(recv, list):
+    if isinstance(recv, str):
+        # A block method (each_char) dispatches only with a trailing Closure.
+        if name in _STRING_BLOCK_METHODS and arg_list and isinstance(arg_list[-1], Closure):
+            result = _string_block_method(recv, name, arg_list[-1])
+            if result is not _MISS:
+                return result
+        result = _string_method(recv, name, arg_list)
+        if result is not _MISS:
+            return result
+    elif isinstance(recv, list):
         # A block method (each/map/…) is dispatched only when an actual trailing
         # Closure block is present; the block is split off the positional args.
         if name in _ARRAY_BLOCK_METHODS and arg_list and isinstance(arg_list[-1], Closure):

--- a/code/packages/python/sir-runtime-oop/tests/test_oop.py
+++ b/code/packages/python/sir-runtime-oop/tests/test_oop.py
@@ -255,7 +255,9 @@ def test_unknown_method_returns_nil_not_raise() -> None:
     # A block method called WITHOUT a block bottoms out at nil (Ruby returns an
     # Enumerator; v0 floor is nil — see spec).
     assert oop.call_method([1, 2, 3], "map") is None
-    assert oop.call_method("hi", "upcase") is None
+    # An out-of-catalog String method (scan needs a regex engine — later PR).
+    assert oop.call_method("hi", "scan") is None
+    # Numeric has no catalog yet (M1c-Numeric), so every method is the nil floor.
     assert oop.call_method(5, "times") is None
 
 
@@ -390,3 +392,86 @@ def test_hash_respond_to_and_nil_floor() -> None:
     assert oop.call_method({"a": 1}, "transform_keys") is None
     # Universal Object methods still resolve on a Hash receiver.
     assert oop.call_method({"a": 1}, "nil?") is False
+
+
+# ── built-in method catalog: String (M1c) ─────────────────────────────────────
+
+
+def test_string_length_case_reverse() -> None:
+    assert oop.call_method("hello", "length") == 5
+    assert oop.call_method("hello", "size") == 5
+    assert oop.call_method("hello", "upcase") == "HELLO"
+    assert oop.call_method("HELLO", "downcase") == "hello"
+    assert oop.call_method("hello world", "capitalize") == "Hello world"
+    assert oop.call_method("abc", "reverse") == "cba"
+
+
+def test_string_strip_family_and_chomp() -> None:
+    assert oop.call_method("  hi  ", "strip") == "hi"
+    assert oop.call_method("  hi  ", "lstrip") == "hi  "
+    assert oop.call_method("  hi  ", "rstrip") == "  hi"
+    assert oop.call_method("line\n", "chomp") == "line"
+    assert oop.call_method("line\r\n", "chomp") == "line"
+    assert oop.call_method("hello", "chomp", "lo") == "hel"
+    assert oop.call_method("hello", "chomp") == "hello"
+
+
+def test_string_chars_bytes_split() -> None:
+    assert oop.call_method("abc", "chars") == ["a", "b", "c"]
+    assert oop.call_method("AB", "bytes") == [65, 66]
+    assert oop.call_method("a,b,c", "split", ",") == ["a", "b", "c"]
+    assert oop.call_method("a  b\tc", "split") == ["a", "b", "c"]
+
+
+def test_string_predicates_and_index() -> None:
+    assert oop.call_method("hello", "include?", "ell") is True
+    assert oop.call_method("hello", "start_with?", "he") is True
+    assert oop.call_method("hello", "end_with?", "lo") is True
+    assert oop.call_method("hello", "index", "l") == 2
+    assert oop.call_method("hello", "index", "z") is None
+    assert oop.call_method("", "empty?") is True
+    assert oop.call_method("x", "empty?") is False
+
+
+def test_string_replace_sub_gsub_are_literal() -> None:
+    assert oop.call_method("old", "replace", "new") == "new"
+    assert oop.call_method("a.a.a", "sub", "a", "X") == "X.a.a"
+    assert oop.call_method("a.a.a", "gsub", "a", "X") == "X.X.X"
+    # Literal — a replacement containing regex/backref syntax is inserted verbatim.
+    assert oop.call_method("ab", "gsub", "a", "$&") == "$&b"
+
+
+def test_string_to_i_to_f_to_sym() -> None:
+    assert oop.call_method("42abc", "to_i") == 42
+    assert oop.call_method("  -7", "to_i") == -7
+    assert oop.call_method("nope", "to_i") == 0
+    assert oop.call_method("3.14xyz", "to_f") == 3.14
+    assert oop.call_method("nope", "to_f") == 0.0
+    sym = oop.call_method("name", "to_sym")
+    assert getattr(sym, "name", None) == "name"
+
+
+def test_string_repeat_and_concat() -> None:
+    assert oop.call_method("ab", "*", 3) == "ababab"
+    assert oop.call_method("foo", "+", "bar") == "foobar"
+    # Non-positive counts yield "" (never raise); a hostile count is capped.
+    assert oop.call_method("ab", "*", 0) == ""
+    assert oop.call_method("ab", "*", -5) == ""
+    assert len(oop.call_method("ab", "*", 10**9)) <= 100_000_000
+
+
+def test_string_each_char_block() -> None:
+    seen: list[Val] = []
+    result = oop.call_method("abc", "each_char", Closure(seen.append))
+    assert seen == ["a", "b", "c"]
+    assert result == "abc"
+
+
+def test_string_respond_to_and_nil_floor() -> None:
+    assert oop.call_method("x", "respond_to?", "upcase") is True
+    assert oop.call_method("x", "respond_to?", "each_char") is True
+    assert oop.call_method("x", "respond_to?", "scan") is False
+    assert oop.call_method("x", "scan") is None
+    # Universal Object methods still resolve on a String receiver.
+    assert oop.call_method("x", "nil?") is False
+    assert oop.call_method("x", "class") == "String"

--- a/code/packages/typescript/sir-runtime-oop/CHANGELOG.md
+++ b/code/packages/typescript/sir-runtime-oop/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 All notable changes to `@coding-adventures/sir-runtime-oop` are documented here.
 
+## [0.1.4] - 2026-06-22
+
+### Added
+
+Built-in method dispatch, part 4 — the **`String`** catalog (per
+`code/specs/sir-method-dispatch.md`, item M1c; a Ruby `String` is a JS `string`,
+which is **immutable**, so every method is non-mutating and returns a fresh
+value):
+
+- Non-block: `length`/`size`, `upcase`, `downcase`, `capitalize`, `reverse`,
+  `strip`/`lstrip`/`rstrip`, `chomp` (default line-ending or explicit suffix),
+  `chars`, `bytes` (UTF-8), `split` (whitespace default or literal separator),
+  `include?`, `start_with?`, `end_with?`, `index` (null when absent), `replace`,
+  `sub`/`gsub` (**literal** — pattern matched as a plain substring, replacement
+  inserted verbatim; deliberately side-steps `String.prototype.replace`'s
+  special-replacement parsing of `$&`/`$1`/`$$`), `to_i`/`to_f` (leading-numeric,
+  `0` when none — never `NaN`), `to_sym` (interns a `@coding-adventures/sir-runtime-core`
+  `Sym`), `empty?`, `*` (repeat), `+` (concat).
+- Block: `each_char` — applied via `@coding-adventures/sir-runtime-core` `apply`.
+
+`respond_to?` reports the String methods; out-of-catalog stays `null`. Universal
+`Object` methods still resolve on a String receiver.
+
 ## [0.1.3] - 2026-06-22
 
 ### Added

--- a/code/packages/typescript/sir-runtime-oop/README.md
+++ b/code/packages/typescript/sir-runtime-oop/README.md
@@ -55,9 +55,13 @@ deep value equality); and (item **M1b**) **block-taking `Array`/`Enumerable`**
 methods `each`, `each_with_index`, `map`/`collect`, `select`/`filter`, `reject`,
 `reduce`/`inject`, `find`/`detect`, `flat_map`, `any?`/`all?`/`none?` — a trailing
 `Closure` block is applied via `@coding-adventures/sir-runtime-core`'s `apply`
-(proc-lenient), predicates routed through SIR `truthy`; and (item **M1c**) the
+(proc-lenient), predicates routed through SIR `truthy`; (item **M1c**) the
 **`Hash`** catalog (`keys`/`values`/`has_key?`/`fetch`/`merge`/`each`/`map`/
-`select`/…). The String/Numeric/Symbol catalogs land in follow-up releases.
+`select`/…); and (item **M1c**) the **`String`** catalog (`length`,
+`upcase`/`downcase`/`capitalize`, `reverse`, `strip`/`lstrip`/`rstrip`, `chomp`,
+`chars`/`bytes`, `split`, `include?`/`start_with?`/`end_with?`/`index`, `replace`,
+`sub`/`gsub` *literal*, `to_i`/`to_f`/`to_sym`, `empty?`, `*`/`+`, `each_char`).
+The Numeric/Symbol catalogs land in follow-up releases.
 
 ## Honest v0 limitation
 

--- a/code/packages/typescript/sir-runtime-oop/src/index.ts
+++ b/code/packages/typescript/sir-runtime-oop/src/index.ts
@@ -38,7 +38,7 @@
 // reaches us as a trailing `Closure` from sir-runtime-core; `apply` calls it with
 // proc-lenient arity, and `truthy` applies SIR truthiness (only `false`/`nil` are
 // falsy) to predicate results.
-import { apply, Closure, truthy } from "@coding-adventures/sir-runtime-core";
+import { apply, Closure, intern, truthy } from "@coding-adventures/sir-runtime-core";
 
 /**
  * The SIR universal value type at this package's boundary.  Kept as `unknown`'s
@@ -325,6 +325,44 @@ const HASH_BLOCK_METHODS = new Set<string>([
   "each_value",
 ]);
 
+// Non-block `String` methods (M1c).  A Ruby `String` is a JS `string`, which is
+// **immutable** — so every method here is non-mutating and returns a fresh value
+// (the in-place `upcase!` family is out of v0 scope).  `sub`/`gsub` here are the
+// *literal* forms: the pattern is matched as a plain substring (never a regex)
+// and the replacement is inserted verbatim — crucially side-stepping JS's
+// `String.prototype.replace` special-replacement parsing (`$&`, `$1`, `$$`).
+const STRING_METHODS = new Set<string>([
+  "length",
+  "size",
+  "upcase",
+  "downcase",
+  "capitalize",
+  "reverse",
+  "strip",
+  "lstrip",
+  "rstrip",
+  "chomp",
+  "chars",
+  "bytes",
+  "split",
+  "include?",
+  "start_with?",
+  "end_with?",
+  "index",
+  "replace",
+  "sub",
+  "gsub",
+  "to_i",
+  "to_f",
+  "to_sym",
+  "empty?",
+  "*",
+  "+",
+]);
+
+// Block-taking `String` methods (M1c); `each_char` yields one character.
+const STRING_BLOCK_METHODS = new Set<string>(["each_char"]);
+
 /** SIR value equality used by `include?`/`index`/`==` — `===` for primitives,
  * structural for arrays and `Map`s (Ruby `==` is deep). */
 function valEq(a: Val, b: Val): boolean {
@@ -359,6 +397,9 @@ function respondsTo(recv: Val, name: string): boolean {
   }
   if (methods.has(name)) return true;
   if (OBJECT_METHODS.has(name)) return true;
+  if (typeof recv === "string" && (STRING_METHODS.has(name) || STRING_BLOCK_METHODS.has(name))) {
+    return true;
+  }
   if (Array.isArray(recv) && (ARRAY_METHODS.has(name) || ARRAY_BLOCK_METHODS.has(name))) {
     return true;
   }
@@ -631,6 +672,141 @@ function hashBlockMethod(recv: Map<Val, Val>, name: string, block: Closure): Val
   }
 }
 
+// Leading-numeric extractors for `String#to_i` / `String#to_f`.  Ruby parses an
+// optional sign and the longest leading numeric run, ignoring surrounding
+// whitespace, and yields `0` / `0.0` when nothing numeric leads — never an error
+// (unlike JS `Number(...)`, which yields `NaN`).
+const INT_PREFIX = /^[+-]?\d+/;
+const FLOAT_PREFIX = /^[+-]?(?:\d+\.?\d*|\.\d+)(?:[eE][+-]?\d+)?/;
+
+function strToI(s: string): number {
+  const match = INT_PREFIX.exec(s.trim());
+  return match ? parseInt(match[0], 10) : 0;
+}
+
+function strToF(s: string): number {
+  const match = FLOAT_PREFIX.exec(s.trim());
+  return match ? parseFloat(match[0]) : 0.0;
+}
+
+// Upper bound on the character count `String#*` will produce.  A repeat count
+// can come from untrusted input (e.g. `gets.to_i`); without a cap, `repeat`
+// throws `RangeError: Invalid string length` (a host-implementation leak) or
+// attempts a huge allocation.  Past the cap we yield `""` rather than throw —
+// honouring the runtime's "never crash on the OO surface" invariant.
+const MAX_REPEAT_LEN = 100_000_000;
+
+function strRepeat(s: string, count: Val): string {
+  const n = typeof count === "number" ? Math.trunc(count) : 0;
+  if (n <= 0 || s.length === 0) return "";
+  const capped = s.length * n > MAX_REPEAT_LEN ? Math.floor(MAX_REPEAT_LEN / s.length) : n;
+  return s.repeat(capped);
+}
+
+/** Ruby `String#chomp`: drop a trailing record separator.  With an explicit
+ * `sep`, drop exactly that suffix; with none, drop one trailing `\r\n`, `\n`, or
+ * `\r` (Ruby's default line-ending handling). */
+function chompStr(s: string, sep: Val): string {
+  if (sep !== null && sep !== undefined) {
+    return sep && s.endsWith(sep) ? s.slice(0, -(sep as string).length) : s;
+  }
+  if (s.endsWith("\r\n")) return s.slice(0, -2);
+  if (s.endsWith("\n") || s.endsWith("\r")) return s.slice(0, -1);
+  return s;
+}
+
+/** Non-block `String` methods.  Returns `MISS` if `name` is not catalogued.
+ * Every result is a fresh value — JS strings are immutable, so nothing mutates
+ * `recv` in place. */
+function stringMethod(recv: string, name: string, args: Val[]): Val | typeof MISS {
+  switch (name) {
+    case "length":
+    case "size":
+      return recv.length;
+    case "upcase":
+      return recv.toUpperCase();
+    case "downcase":
+      return recv.toLowerCase();
+    case "capitalize":
+      // Ruby: first char upcased, the rest downcased.
+      return recv.length === 0 ? recv : recv.charAt(0).toUpperCase() + recv.slice(1).toLowerCase();
+    case "reverse":
+      return [...recv].reverse().join("");
+    case "strip":
+      return recv.trim();
+    case "lstrip":
+      return recv.trimStart();
+    case "rstrip":
+      return recv.trimEnd();
+    case "chomp":
+      return chompStr(recv, args.length > 0 ? args[0] : null);
+    case "chars":
+      return [...recv];
+    case "bytes":
+      return [...new TextEncoder().encode(recv)];
+    case "split": {
+      // No argument ⇒ split on runs of whitespace (Ruby's awk-style default,
+      // dropping leading/trailing empties); with a separator ⇒ literal split.
+      if (args.length === 0) {
+        const trimmed = recv.trim();
+        return trimmed === "" ? [] : trimmed.split(/\s+/);
+      }
+      return recv.split(args[0]);
+    }
+    case "include?":
+      return recv.includes(args[0]);
+    case "start_with?":
+      return recv.startsWith(args[0]);
+    case "end_with?":
+      return recv.endsWith(args[0]);
+    case "index": {
+      const i = recv.indexOf(args[0]);
+      return i === -1 ? null : i;
+    }
+    case "replace":
+      // Ruby `String#replace` overwrites the whole content; for an immutable
+      // string that is just the replacement value.
+      return args[0];
+    case "sub": {
+      // Literal first-occurrence replacement — done by index, so the
+      // replacement is inserted verbatim (no `$&`/`$1` expansion).
+      const search = args[0] as string;
+      const idx = recv.indexOf(search);
+      return idx === -1 ? recv : recv.slice(0, idx) + args[1] + recv.slice(idx + search.length);
+    }
+    case "gsub":
+      // Literal global replacement via split/join — immune to special-replacement
+      // parsing that `String.prototype.replaceAll` would apply to a string arg.
+      return recv.split(args[0]).join(args[1]);
+    case "to_i":
+      return strToI(recv);
+    case "to_f":
+      return strToF(recv);
+    case "to_sym":
+      return intern(recv);
+    case "empty?":
+      return recv.length === 0;
+    case "*":
+      return strRepeat(recv, args[0]);
+    case "+":
+      return recv + args[0];
+    default:
+      return MISS;
+  }
+}
+
+/** Block-taking `String` methods.  Returns `MISS` if `name` is not a string
+ * block method. */
+function stringBlockMethod(recv: string, name: string, block: Closure): Val | typeof MISS {
+  switch (name) {
+    case "each_char":
+      for (const ch of recv) apply(block, [ch]);
+      return recv;
+    default:
+      return MISS;
+  }
+}
+
 /**
  * Dispatch method `name` on `recv`.  Resolution order:
  *
@@ -660,7 +836,16 @@ export function callMethod(recv: Val, name: string, ...args: Val[]): Val {
   const m = methods.get(name);
   if (m) return m(recv, args);
 
-  if (Array.isArray(recv)) {
+  if (typeof recv === "string") {
+    // A block method (each_char) dispatches only with a trailing Closure.
+    const last = args[args.length - 1];
+    if (STRING_BLOCK_METHODS.has(name) && args.length > 0 && last instanceof Closure) {
+      const blkResult = stringBlockMethod(recv, name, last);
+      if (blkResult !== MISS) return blkResult;
+    }
+    const strResult = stringMethod(recv, name, args);
+    if (strResult !== MISS) return strResult;
+  } else if (Array.isArray(recv)) {
     // A block method (each/map/…) is dispatched only when an actual trailing
     // Closure block is present; the block is split off the positional args.
     const last = args[args.length - 1];

--- a/code/packages/typescript/sir-runtime-oop/tests/oop.test.ts
+++ b/code/packages/typescript/sir-runtime-oop/tests/oop.test.ts
@@ -254,7 +254,9 @@ describe("respond_to? honesty + nil floor (M1a)", () => {
   it("unknown method returns nil, never throws", () => {
     // A block method called WITHOUT a block bottoms out at nil (v0 floor).
     expect(callMethod([1, 2, 3], "map")).toBeNull();
-    expect(callMethod("hi", "upcase")).toBeNull();
+    // An out-of-catalog String method (scan needs a regex engine — later PR).
+    expect(callMethod("hi", "scan")).toBeNull();
+    // Numeric has no catalog yet (M1c-Numeric), so every method is the nil floor.
     expect(callMethod(5, "times")).toBeNull();
   });
 });
@@ -397,5 +399,87 @@ describe("built-in method catalog: Hash (M1c)", () => {
     expect(callMethod(h, "respond_to?", "transform_keys")).toBe(false);
     expect(callMethod(h, "transform_keys")).toBeNull();
     expect(callMethod(h, "nil?")).toBe(false);
+  });
+});
+
+describe("built-in method catalog: String (M1c)", () => {
+  it("length / case / reverse", () => {
+    expect(callMethod("hello", "length")).toBe(5);
+    expect(callMethod("hello", "size")).toBe(5);
+    expect(callMethod("hello", "upcase")).toBe("HELLO");
+    expect(callMethod("HELLO", "downcase")).toBe("hello");
+    expect(callMethod("hello world", "capitalize")).toBe("Hello world");
+    expect(callMethod("abc", "reverse")).toBe("cba");
+  });
+
+  it("strip family and chomp", () => {
+    expect(callMethod("  hi  ", "strip")).toBe("hi");
+    expect(callMethod("  hi  ", "lstrip")).toBe("hi  ");
+    expect(callMethod("  hi  ", "rstrip")).toBe("  hi");
+    expect(callMethod("line\n", "chomp")).toBe("line");
+    expect(callMethod("line\r\n", "chomp")).toBe("line");
+    expect(callMethod("hello", "chomp", "lo")).toBe("hel");
+    expect(callMethod("hello", "chomp")).toBe("hello");
+  });
+
+  it("chars / bytes / split", () => {
+    expect(callMethod("abc", "chars")).toEqual(["a", "b", "c"]);
+    expect(callMethod("AB", "bytes")).toEqual([65, 66]);
+    expect(callMethod("a,b,c", "split", ",")).toEqual(["a", "b", "c"]);
+    expect(callMethod("a  b\tc", "split")).toEqual(["a", "b", "c"]);
+  });
+
+  it("predicates and index", () => {
+    expect(callMethod("hello", "include?", "ell")).toBe(true);
+    expect(callMethod("hello", "start_with?", "he")).toBe(true);
+    expect(callMethod("hello", "end_with?", "lo")).toBe(true);
+    expect(callMethod("hello", "index", "l")).toBe(2);
+    expect(callMethod("hello", "index", "z")).toBeNull();
+    expect(callMethod("", "empty?")).toBe(true);
+    expect(callMethod("x", "empty?")).toBe(false);
+  });
+
+  it("replace / sub / gsub are literal (no $& expansion)", () => {
+    expect(callMethod("old", "replace", "new")).toBe("new");
+    expect(callMethod("a.a.a", "sub", "a", "X")).toBe("X.a.a");
+    expect(callMethod("a.a.a", "gsub", "a", "X")).toBe("X.X.X");
+    // A replacement containing regex/backref syntax is inserted verbatim.
+    expect(callMethod("ab", "gsub", "a", "$&")).toBe("$&b");
+  });
+
+  it("to_i / to_f / to_sym", () => {
+    expect(callMethod("42abc", "to_i")).toBe(42);
+    expect(callMethod("  -7", "to_i")).toBe(-7);
+    expect(callMethod("nope", "to_i")).toBe(0);
+    expect(callMethod("3.14xyz", "to_f")).toBe(3.14);
+    expect(callMethod("nope", "to_f")).toBe(0);
+    const sym = callMethod("name", "to_sym") as { name?: string };
+    expect(sym.name).toBe("name");
+  });
+
+  it("repeat (*) and concat (+)", () => {
+    expect(callMethod("ab", "*", 3)).toBe("ababab");
+    expect(callMethod("foo", "+", "bar")).toBe("foobar");
+    // Non-positive counts yield "" (never throw); a hostile count is capped,
+    // never a RangeError ("Invalid string length").
+    expect(callMethod("ab", "*", 0)).toBe("");
+    expect(callMethod("ab", "*", -5)).toBe("");
+    expect((callMethod("ab", "*", 1e9) as string).length).toBeLessThanOrEqual(100_000_000);
+  });
+
+  it("each_char runs the block and returns the receiver", () => {
+    const seen: Val[] = [];
+    const result = callMethod("abc", "each_char", new Closure((ch: Val) => seen.push(ch)));
+    expect(seen).toEqual(["a", "b", "c"]);
+    expect(result).toBe("abc");
+  });
+
+  it("respond_to? honesty + nil floor", () => {
+    expect(callMethod("x", "respond_to?", "upcase")).toBe(true);
+    expect(callMethod("x", "respond_to?", "each_char")).toBe(true);
+    expect(callMethod("x", "respond_to?", "scan")).toBe(false);
+    expect(callMethod("x", "scan")).toBeNull();
+    expect(callMethod("x", "nil?")).toBe(false);
+    expect(callMethod("x", "class")).toBe("String");
   });
 });


### PR DESCRIPTION
## M1c-String — Ruby `String` method catalog

Fourth slice of the **M1** built-in method-dispatch work
(`code/specs/sir-method-dispatch.md`), adding the Ruby `String` catalog to
`sir-runtime-oop` in **both** backends (Python `oop.py`, TypeScript `index.ts`),
mirroring the existing Array/Hash dispatch shape. Follows the merged M1a
(non-block Array + Object), M1b (block Array), and M1c-Hash (#6505).

A Ruby `String` is a Python `str` / JS `string` — both immutable — so every
method is **non-mutating** and returns a fresh value.

### Methods

- **Non-block:** `length`/`size`, `upcase`, `downcase`, `capitalize`, `reverse`,
  `strip`/`lstrip`/`rstrip`, `chomp` (default line-ending or explicit suffix),
  `chars`, `bytes` (UTF-8), `split` (whitespace default or literal separator),
  `include?`, `start_with?`, `end_with?`, `index` (nil/null when absent),
  `replace`, `sub`/`gsub` (**literal** — pattern matched as a plain substring,
  replacement inserted verbatim), `to_i`/`to_f` (leading-numeric, `0`/`0.0` when
  none — never raising/`NaN`), `to_sym` (interns a `sir-runtime-core` Symbol),
  `empty?`, `*` (repeat), `+` (concat).
- **Block:** `each_char`.

`respond_to?` reports the String methods honestly; out-of-catalog stays
nil/null. Universal `Object` methods still resolve on a String receiver. The two
M1a "out-of-catalog" assertions that used `"hi".upcase` (now resolved) were
repointed at `scan` (needs a regex engine — a later PR).

### Faithfulness / security notes

- `sub`/`gsub` are **literal**: the TS form uses `indexOf`+slice / `split`+`join`
  rather than `String.prototype.replace`, deliberately side-stepping the
  `$&`/`$1`/`$$` special-replacement foot-gun (a replacement of `"$&"` is
  inserted verbatim — covered by a test).
- `String#*` **clamps its repeat count**: non-positive yields `""`, and an
  over-large product is bounded to 100M chars, so a hostile count (e.g. from
  `gets.to_i`) cannot trigger a Python `MemoryError` or a JS
  `RangeError: Invalid string length`, honouring the runtime's
  never-raise-on-the-OO-surface invariant. (Raised by the security review;
  fixed before push.)

### Verification

- **Python:** 49 pytest, ruff, `mypy --strict` — all clean; 97% coverage.
- **TypeScript:** 48 vitest, `tsc --noEmit` strict — all clean.
- `/security-review` (sub-agent) passed: no CRITICAL/HIGH/MEDIUM; the one LOW DoS
  finding (`String#*`) was fixed before pushing.
- CHANGELOG bumped to 0.1.4 (both); READMEs updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
