### PR TITLE
feat(constant-fold): fold ASCII string `.toUpperCase()`/`.toLowerCase()`

### DIFF
--- a/code/packages/rust/closure-pass-constant-fold/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-constant-fold/CHANGELOG.md
@@ -2,6 +2,37 @@
 
 All notable changes to the `coding-adventures-closure-pass-constant-fold` crate will be documented in this file.
 
+## [0.20.0] - 2026-06-22
+
+### Added — ASCII string-casing folds (`"abc".toUpperCase()` → `"ABC"`)
+
+`fold_expression` now folds the no-argument string-casing methods on a string
+literal, via the new `fold_call` helper:
+
+| before                | after   |
+|-----------------------|---------|
+| `"abc".toUpperCase()` | `"ABC"` |
+| `"ABC".toLowerCase()` | `"abc"` |
+| `"".toUpperCase()`    | `""`    |
+
+**ASCII-only.** The fold fires only when the literal `is_ascii()`, using Rust's
+`to_ascii_uppercase`/`to_ascii_lowercase`. ASCII case mapping is
+locale-independent and byte-for-byte identical between Rust and JavaScript, so
+the fold is exactly sound. Non-ASCII strings are deliberately left alone — JS
+`toUpperCase`/`toLowerCase` use full Unicode default case mapping with
+length-changing special cases (`ß` → `SS`, final sigma `ς`) that a conservative
+fold-set shouldn't reproduce here, so `"é".toUpperCase()` stays a call.
+
+Narrow surface: only the dotted, zero-argument form on a string literal folds.
+`s.toUpperCase()` on an identifier, an argument (`"x".toUpperCase(1)`), the
+computed form `"x"["toUpperCase"]()`, and unmodelled methods (`"x".trim()`) all
+pass through unchanged. The fold emits a correlation-vector contribution.
+
+Six new unit tests (`fold_ascii_string_to_upper_and_lower_case`,
+`non_ascii_string_casing_does_not_fold`, `string_casing_on_identifier_does_not_fold`,
+`string_casing_with_argument_does_not_fold`, `computed_string_casing_does_not_fold`,
+`unknown_string_method_does_not_fold`).
+
 ## [0.19.0] - 2026-06-22
 
 ### Added — string-literal `.length` folding (`"hello".length` → `5`)

--- a/code/packages/rust/closure-pass-constant-fold/Cargo.toml
+++ b/code/packages/rust/closure-pass-constant-fold/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-constant-fold"
-version = "0.19.0"
+version = "0.20.0"
 edition = "2021"
 description = "Constant-folding optimization pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Folds compile-time-evaluable expressions like `2 + 3 → 5`."
 

--- a/code/packages/rust/closure-pass-constant-fold/src/lib.rs
+++ b/code/packages/rust/closure-pass-constant-fold/src/lib.rs
@@ -31,6 +31,7 @@
 //! 0     ?? expr      →  0                       (zero is not nullish)
 //! true  ? a : b      →  a                       (ConditionalExpression with literal test)
 //! "hi".length        →  2                       (string-literal .length, UTF-16 units)
+//! "ab".toUpperCase() →  "AB"                     (ASCII string casing methods)
 //! ```
 //!
 //! And recurses through every child node, so `1 + (2 * 3) → 1 + 6 → 7`
@@ -468,11 +469,7 @@ fn fold_expression(expr: &Expression, st: &mut FoldState) -> Expression {
                 right: Box::new(fold_expression(&a.right, st)),
             })
         }
-        Expression::CallExpression(c) => Expression::CallExpression(CallExpression {
-            cv: c.cv.clone(),
-            callee: Box::new(fold_expression(&c.callee, st)),
-            arguments: c.arguments.iter().map(|a| fold_expression(a, st)).collect(),
-        }),
+        Expression::CallExpression(c) => fold_call(c, st),
         Expression::MemberExpression(m) => fold_member(m, st),
         Expression::ArrayExpression(a) => Expression::ArrayExpression(ArrayExpression {
             cv: a.cv.clone(),
@@ -507,6 +504,66 @@ fn fold_expression(expr: &Expression, st: &mut FoldState) -> Expression {
                 .collect(),
         }),
     }
+}
+
+// ---------------------------------------------------------------------
+// Method calls
+// ---------------------------------------------------------------------
+
+/// Folds the no-argument string-casing methods on a string literal:
+///
+/// ```text
+///   "abc".toUpperCase()   →  "ABC"
+///   "ABC".toLowerCase()   →  "abc"
+///   "".toUpperCase()      →  ""
+/// ```
+///
+/// **ASCII-only.** We fold only when the literal `is_ascii()`, using Rust's
+/// `to_ascii_uppercase`/`to_ascii_lowercase`. ASCII case mapping is
+/// locale-independent and byte-for-byte identical between Rust and JavaScript,
+/// so the fold is exactly sound. Non-ASCII strings are deliberately left
+/// alone: JS `toUpperCase`/`toLowerCase` use full Unicode default case
+/// mapping with context-sensitive special cases (final sigma `ς`, German `ß`
+/// → `SS`, locale-independent but length-changing) that a conservative
+/// fold-set shouldn't try to reproduce here — `"é".toUpperCase()` stays a call.
+///
+/// Only the dotted, zero-argument form on a string literal folds. An argument
+/// (`"x".toUpperCase(1)` — ignored by the runtime but we stay conservative),
+/// the computed form `"x"["toUpperCase"]()`, and a method on a non-literal
+/// (`s.toUpperCase()`) all pass through unchanged. We still recurse into the
+/// callee and arguments so nested constants inside them fold.
+fn fold_call(c: &CallExpression, st: &mut FoldState) -> Expression {
+    let callee = fold_expression(&c.callee, st);
+    let arguments: Vec<Expression> = c.arguments.iter().map(|a| fold_expression(a, st)).collect();
+
+    if arguments.is_empty() {
+        if let Expression::MemberExpression(m) = &callee {
+            if !m.computed {
+                if let (Expression::StringLiteral(s), Expression::Identifier(id)) =
+                    (m.object.as_ref(), m.property.as_ref())
+                {
+                    let cased = match id.name.as_str() {
+                        "toUpperCase" if s.value.is_ascii() => Some(s.value.to_ascii_uppercase()),
+                        "toLowerCase" if s.value.is_ascii() => Some(s.value.to_ascii_lowercase()),
+                        _ => None,
+                    };
+                    if let Some(result) = cased {
+                        let parent = c.cv.clone();
+                        let before = format!("\"{}\".{}()", s.value, id.name);
+                        let after = format!("\"{}\"", result);
+                        let new_cv = st.fork_cv(&parent, &before, &after);
+                        return stamp_literal_cv(FoldedLiteral::String(result), new_cv);
+                    }
+                }
+            }
+        }
+    }
+
+    Expression::CallExpression(CallExpression {
+        cv: c.cv.clone(),
+        callee: Box::new(callee),
+        arguments,
+    })
 }
 
 // ---------------------------------------------------------------------
@@ -2495,6 +2552,107 @@ mod tests {
             extract_expr(&out),
             Expression::MemberExpression(_)
         ));
+    }
+
+    // ------------------- string casing methods -----------------------
+
+    /// Build a zero-argument method call `<object>.<name>()`.
+    fn call0(object: Expression, name: &str) -> Expression {
+        Expression::CallExpression(CallExpression {
+            cv: Some("c.cv".to_string()),
+            callee: Box::new(member(object, name)),
+            arguments: vec![],
+        })
+    }
+
+    #[test]
+    fn fold_ascii_string_to_upper_and_lower_case() {
+        // "abc".toUpperCase() → "ABC"
+        let up = call0(string("abc", None), "toUpperCase");
+        let (out, _, changed, _) = run_pass(program_with_expr(up, true));
+        assert!(changed, "\"abc\".toUpperCase() should fold");
+        match extract_expr(&out) {
+            Expression::StringLiteral(s) => assert_eq!(s.value, "ABC"),
+            other => panic!("expected \"ABC\"; got {:?}", other),
+        }
+
+        // "ABC".toLowerCase() → "abc"
+        let lo = call0(string("ABC", None), "toLowerCase");
+        let (out, _, _, _) = run_pass(program_with_expr(lo, true));
+        match extract_expr(&out) {
+            Expression::StringLiteral(s) => assert_eq!(s.value, "abc"),
+            other => panic!("expected \"abc\"; got {:?}", other),
+        }
+
+        // "".toUpperCase() → ""
+        let empty = call0(string("", None), "toUpperCase");
+        let (out, _, _, _) = run_pass(program_with_expr(empty, true));
+        match extract_expr(&out) {
+            Expression::StringLiteral(s) => assert_eq!(s.value, ""),
+            other => panic!("expected empty string; got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn non_ascii_string_casing_does_not_fold() {
+        // JS toUpperCase on non-ASCII uses full Unicode case mapping (e.g.
+        // "é" → "É", "ß" → "SS"); we conservatively leave non-ASCII to a later
+        // phase, so the call must survive untouched.
+        let up = call0(string("é", None), "toUpperCase");
+        let (out, _, changed, _) = run_pass(program_with_expr(up, true));
+        assert!(!changed, "non-ASCII \"é\".toUpperCase() must not fold");
+        assert!(matches!(extract_expr(&out), Expression::CallExpression(_)));
+    }
+
+    #[test]
+    fn string_casing_on_identifier_does_not_fold() {
+        // `s.toUpperCase()` needs the runtime value of `s`.
+        let up = call0(ident("s"), "toUpperCase");
+        let (out, _, changed, _) = run_pass(program_with_expr(up, true));
+        assert!(!changed, "s.toUpperCase() must not fold");
+        assert!(matches!(extract_expr(&out), Expression::CallExpression(_)));
+    }
+
+    #[test]
+    fn string_casing_with_argument_does_not_fold() {
+        // An argument makes us stay conservative (the runtime ignores it, but
+        // we don't model that): `"abc".toUpperCase(1)` survives.
+        let up = Expression::CallExpression(CallExpression {
+            cv: Some("c.cv".to_string()),
+            callee: Box::new(member(string("abc", None), "toUpperCase")),
+            arguments: vec![num(1.0, None)],
+        });
+        let (out, _, changed, _) = run_pass(program_with_expr(up, true));
+        assert!(!changed, "\"abc\".toUpperCase(1) must not fold");
+        assert!(matches!(extract_expr(&out), Expression::CallExpression(_)));
+    }
+
+    #[test]
+    fn computed_string_casing_does_not_fold() {
+        // `"abc"["toUpperCase"]()` is the computed form — left alone.
+        let callee = Expression::MemberExpression(MemberExpression {
+            cv: Some("m.cv".to_string()),
+            object: Box::new(string("abc", None)),
+            property: Box::new(string("toUpperCase", None)),
+            computed: true,
+        });
+        let up = Expression::CallExpression(CallExpression {
+            cv: Some("c.cv".to_string()),
+            callee: Box::new(callee),
+            arguments: vec![],
+        });
+        let (out, _, changed, _) = run_pass(program_with_expr(up, true));
+        assert!(!changed, "computed casing call must not fold");
+        assert!(matches!(extract_expr(&out), Expression::CallExpression(_)));
+    }
+
+    #[test]
+    fn unknown_string_method_does_not_fold() {
+        // `"abc".trim()` is not a casing method we model — pass through.
+        let t = call0(string("  abc  ", None), "trim");
+        let (out, _, changed, _) = run_pass(program_with_expr(t, true));
+        assert!(!changed, "\"...\".trim() must not fold");
+        assert!(matches!(extract_expr(&out), Expression::CallExpression(_)));
     }
 
     // ------------------- logical (short-circuit) ---------------------

--- a/code/programs/rust/closurec/CHANGELOG.md
+++ b/code/programs/rust/closurec/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to the `coding-adventures-closurec` binary will be documented in this file.
 
+## [0.167.0] - 2026-06-22
+
+### Added — ASCII string-casing folds at SIMPLE/ADVANCED
+
+Pulls in `coding-adventures-closure-pass-constant-fold` 0.20.0, which folds the
+no-argument string-casing methods on a string literal: `"abc".toUpperCase()` →
+`"ABC"`, `"ABC".toLowerCase()` → `"abc"`. ASCII-only (locale-independent,
+byte-for-byte equal to JS); non-ASCII strings, identifier receivers, the
+computed form, and any-argument calls are all left alone.
+
+New e2e fixture `tests/diff/simple-fold-strcase` (and integration test
+`diff_simple_fold_strcase.rs`) is the end-to-end oracle, with a
+whitespace-fallback guard proving the fold comes from the SIMPLE typed pipeline.
+
+> Version note: bumped to 0.167.0 (skipping 0.166.0, reserved by the
+> concurrently-developed ASI Rule-1 string-newline branch) so the parallel
+> branches don't collide on the version line.
+
 ## [0.165.0] - 2026-06-22
 
 ### Added — string-literal `.length` folding at SIMPLE/ADVANCED

--- a/code/programs/rust/closurec/Cargo.toml
+++ b/code/programs/rust/closurec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closurec"
-version = "0.165.0"
+version = "0.167.0"
 edition = "2021"
 description = "closurec — CLI driver for the Closure Compiler clone. Mirrors the upstream Java Closure Compiler's command-line flag surface (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility. Per CLOC08."
 

--- a/code/programs/rust/closurec/cli.spec.json
+++ b/code/programs/rust/closurec/cli.spec.json
@@ -2,7 +2,7 @@
   "cli_builder_spec_version": "1.0",
   "name": "closurec",
   "description": "closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.",
-  "version": "0.165.0",
+  "version": "0.167.0",
   "parsing_mode": "gnu",
   "flags": [
     { "id": "browser_featureset_year", "long": "browser_featureset_year", "type": "integer", "default": 0, "description": "Shortcut for defining goog.FEATURESET_YEAR=YYYY (minimum 2012)." },

--- a/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
@@ -2,7 +2,7 @@
 
 closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.
 
-Version: 0.165.0
+Version: 0.167.0
 
 ## Flags
 

--- a/code/programs/rust/closurec/tests/diff/simple-fold-strcase/README.md
+++ b/code/programs/rust/closurec/tests/diff/simple-fold-strcase/README.md
@@ -1,0 +1,26 @@
+# Fixture: `simple-fold-strcase`
+
+End-to-end oracle for ASCII string-casing folding at
+`--compilation_level SIMPLE`.
+
+| File | Role |
+|------|------|
+| `flags.txt` | CLI args: `--compilation_level SIMPLE --js input/a.js` |
+| `input/a.js` | `var s = "hello".toUpperCase(); report(s);` |
+| `expected.stdout` | The folded output: `var s="HELLO";report(s);` |
+
+The SIMPLE level runs the typed-AST optimization pipeline, whose
+`constant-fold` pass folds the no-argument `.toUpperCase()` / `.toLowerCase()`
+methods on an **ASCII** string literal to the cased string (ASCII case mapping
+is locale-independent and byte-for-byte equal to JavaScript): `"hello"`
+→ `"HELLO"`. Non-ASCII receivers, identifier receivers, the computed form, and
+any-argument calls are left alone. The same input under `WHITESPACE_ONLY` keeps
+`"hello".toUpperCase()` unfolded.
+
+Regenerate the expected file after an intentional behavior change:
+
+```sh
+cargo run -- --compilation_level SIMPLE \
+    --js tests/diff/simple-fold-strcase/input/a.js \
+    > tests/diff/simple-fold-strcase/expected.stdout
+```

--- a/code/programs/rust/closurec/tests/diff/simple-fold-strcase/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/simple-fold-strcase/expected.stdout
@@ -1,0 +1,1 @@
+var s="HELLO";report(s);

--- a/code/programs/rust/closurec/tests/diff/simple-fold-strcase/flags.txt
+++ b/code/programs/rust/closurec/tests/diff/simple-fold-strcase/flags.txt
@@ -1,0 +1,4 @@
+--compilation_level
+SIMPLE
+--js
+tests/diff/simple-fold-strcase/input/a.js

--- a/code/programs/rust/closurec/tests/diff/simple-fold-strcase/input/a.js
+++ b/code/programs/rust/closurec/tests/diff/simple-fold-strcase/input/a.js
@@ -1,0 +1,13 @@
+// SIMPLE-level ASCII string-casing fold.
+//
+// `"<ascii>".toUpperCase()` / `.toLowerCase()` are compile-time-evaluable on
+// a string literal; the `constant-fold` pass collapses them (ASCII case
+// mapping is locale-independent and matches JS exactly). Under WHITESPACE_ONLY
+// the call survives as `"hello".toUpperCase()`; under SIMPLE it folds to
+// `"HELLO"`.
+//
+// The value flows into `report(...)` so it stays referenced — otherwise
+// remove-unused-vars (the last SIMPLE pass) would delete the declaration and
+// the fold would not be observable.
+var s = "hello".toUpperCase();
+report(s);

--- a/code/programs/rust/closurec/tests/diff_simple_fold_strcase.rs
+++ b/code/programs/rust/closurec/tests/diff_simple_fold_strcase.rs
@@ -1,0 +1,84 @@
+//! Integration test for the `tests/diff/simple-fold-strcase/` fixture.
+//!
+//! End-to-end oracle for ASCII string-casing folding in
+//! `closure-pass-constant-fold`: `"hello".toUpperCase()` collapses to the cased
+//! string literal (ASCII case mapping, locale-independent, equal to JS).
+//!
+//! At SIMPLE the fixture optimizes to:
+//!
+//! ```text
+//! var s="HELLO";report(s);
+//! ```
+
+use std::process::Command;
+
+const BINARY: &str = env!("CARGO_BIN_EXE_closurec");
+
+fn read_flags() -> Vec<String> {
+    let raw = std::fs::read_to_string("tests/diff/simple-fold-strcase/flags.txt")
+        .expect("read flags.txt");
+    raw.lines()
+        .filter(|l| !l.is_empty())
+        .map(|s| s.to_string())
+        .collect()
+}
+
+#[test]
+fn simple_fold_strcase_fixture_matches_expected_stdout() {
+    let flags = read_flags();
+    let out = Command::new(BINARY)
+        .args(&flags)
+        .output()
+        .expect("run closurec");
+
+    assert!(
+        out.status.success(),
+        "exit: {:?}, stderr: {}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stderr),
+    );
+
+    let actual = String::from_utf8_lossy(&out.stdout);
+    let expected = std::fs::read_to_string("tests/diff/simple-fold-strcase/expected.stdout")
+        .expect("read expected.stdout");
+    assert_eq!(
+        actual.trim_end_matches('\n'),
+        expected.trim_end_matches('\n'),
+        "mismatch.\nflags: {flags:?}\nactual:\n{actual}\nexpected:\n{expected}",
+    );
+}
+
+/// `"hello".toUpperCase()` must fold to the literal `"HELLO"` — no method call
+/// should remain in the output.
+#[test]
+fn simple_fold_strcase_folds_to_cased_literal() {
+    let out = Command::new(BINARY)
+        .args(read_flags())
+        .output()
+        .expect("run closurec");
+    let actual = String::from_utf8_lossy(&out.stdout);
+
+    assert!(actual.contains("\"HELLO\""), "should fold to \"HELLO\"; got:\n{actual}");
+    assert!(
+        !actual.contains("toUpperCase"),
+        "no `toUpperCase` call should remain after folding; got:\n{actual}",
+    );
+}
+
+/// Regression guard: the output must be the SIMPLE typed pipeline, not the
+/// WHITESPACE_ONLY fallback (which would leave `"hello".toUpperCase()` intact).
+#[test]
+fn simple_fold_strcase_did_not_fall_back_to_whitespace_only() {
+    let out = Command::new(BINARY)
+        .args(read_flags())
+        .output()
+        .expect("run closurec");
+    let actual = String::from_utf8_lossy(&out.stdout);
+
+    assert!(
+        !actual.contains("\"hello\""),
+        "expected the lowercase literal to be folded away by the typed pipeline \
+         (proving this is the SIMPLE optimizer, not the whitespace fallback); \
+         got:\n{actual}",
+    );
+}


### PR DESCRIPTION
## What

`fold_expression` now folds the no-argument string-casing methods on a **string literal**, via the new `fold_call` helper:

| before | after |
|--------|-------|
| `"abc".toUpperCase()` | `"ABC"` |
| `"ABC".toLowerCase()` | `"abc"` |
| `"".toUpperCase()` | `""` |

## Soundness (ASCII-only)
The fold fires **only when the literal `is_ascii()`**, using Rust's `to_ascii_uppercase`/`to_ascii_lowercase`. ASCII case mapping is locale-independent and byte-for-byte identical between Rust and JavaScript. Non-ASCII strings are deliberately left alone — JS `toUpperCase`/`toLowerCase` use full Unicode default case mapping with length-changing special cases (`ß` → `SS`, final sigma) that a conservative fold-set shouldn't reproduce, so `"é".toUpperCase()` stays a call. The receiver is a literal (no construction side effects), the builtin is pure, and zero args means no dropped side effects → the rewrite is value- and side-effect-identical.

## Scope (narrow)
Only the dotted, zero-argument form on a string literal folds. `s.toUpperCase()` on an identifier, an argument (`"x".toUpperCase(1)`), the computed form `"x"["toUpperCase"]()`, and unmodelled methods (`"x".trim()`) all pass through unchanged. Emits a correlation-vector contribution.

- `closure-pass-constant-fold` 0.19.0 → 0.20.0 — new `fold_call` + 6 unit tests (incl. non-ASCII / identifier / argument / computed / unknown-method negatives).
- `closurec` 0.165.0 → **0.167.0** (skips 0.166.0, reserved by the concurrent ASI Rule-1 branch #6400) — new e2e fixture `tests/diff/simple-fold-strcase` + `diff_simple_fold_strcase.rs` (whitespace-fallback guard); help-markdown golden regenerated.

## Verification
- constant-fold: 63 unit tests pass (6 new).
- closurec: full suite green (new fixture, help-markdown, version-string).
- Downstream consumer pass crates (emitter, fold-control-flow, collapse-properties, inline, inline-variables, dce) re-run green.
- Security review: PASSED (total/panic-free; ASCII guard keeps it sound; `format!` is CV-metadata only).

No lexer/parser/ASI/bridge files touched — independent of the in-flight ASI PR #6400.

🤖 Generated with [Claude Code](https://claude.com/claude-code)