### PR TITLE
feat(visicalc-qt): per-cell number formatting in the Qt demo

### DIFF
--- a/demo/visicalc-qt/InfiniteSheet.qml
+++ b/demo/visicalc-qt/InfiniteSheet.qml
@@ -257,6 +257,34 @@ Item {
                 }
                 Rectangle { Layout.preferredWidth: 1; Layout.fillHeight: true; Layout.topMargin: 4; Layout.bottomMargin: 4; color: sheet.cLine }
 
+                // ── Format (apply a number format to the selected cell) ──
+                // Display-only: the engine renders the stored value through the code.
+                ToolButton {
+                    text: ".00"
+                    ToolTip.visible: hovered
+                    ToolTip.text: "Format the selected cell with thousands separators + 2 decimals (#,##0.00)"
+                    onClicked: if (doc) doc.setFormatInf("#,##0.00")
+                }
+                ToolButton {
+                    text: "%"
+                    ToolTip.visible: hovered
+                    ToolTip.text: "Format the selected cell as a percent (0.0%)"
+                    onClicked: if (doc) doc.setFormatInf("0.0%")
+                }
+                ToolButton {
+                    text: "$"
+                    ToolTip.visible: hovered
+                    ToolTip.text: "Format the selected cell as currency ($#,##0.00)"
+                    onClicked: if (doc) doc.setFormatInf("$#,##0.00")
+                }
+                ToolButton {
+                    text: "Gen"
+                    ToolTip.visible: hovered
+                    ToolTip.text: "Clear the selected cell's format (General)"
+                    onClicked: if (doc) doc.setFormatInf("")
+                }
+                Rectangle { Layout.preferredWidth: 1; Layout.fillHeight: true; Layout.topMargin: 4; Layout.bottomMargin: 4; color: sheet.cLine }
+
                 // ── History (undo / redo) ──
                 ToolButton {
                     text: "↶ Undo"

--- a/demo/visicalc-qt/src/SpreadsheetModel.cpp
+++ b/demo/visicalc-qt/src/SpreadsheetModel.cpp
@@ -321,6 +321,20 @@ void SpreadsheetModel::fill(const QString &src, const QString &dstStart, const Q
     emit revisionChanged();
 }
 
+// Number formatting: attach an Excel-style format code to the selected cell. The
+// code is display-only — the stored value is unchanged; the engine renders it
+// through the code (sc_get_display_window). An empty code clears the format. The
+// QByteArray locals are NAMED so the UTF-8 buffers outlive the C call.
+void SpreadsheetModel::setFormatInf(const QString &code) {
+    const QByteArray a1 = infAddress().toUtf8();
+    const QByteArray c = code.toUtf8();
+    sc_set_format(session_, a1.constData(), c.constData());
+    recompute();
+    revision_++;
+    emit changed();
+    emit revisionChanged();
+}
+
 // Clipboard: copy/cut capture the inclusive rectangle into the engine's
 // clipboard; paste places it (the whole block's references shift by the
 // destination's offset). The QByteArray locals are NAMED so the UTF-8 buffers

--- a/demo/visicalc-qt/src/SpreadsheetModel.h
+++ b/demo/visicalc-qt/src/SpreadsheetModel.h
@@ -126,6 +126,11 @@ public:
     // `dstStart`..`dstEnd` (relative refs shift, absolute pin, format carried);
     // resizes the extent and bumps `revision` so the visible rows re-fetch.
     Q_INVOKABLE void fill(const QString &src, const QString &dstStart, const QString &dstEnd);
+    // Number formatting: attach an Excel-style format code (e.g. "#,##0.00",
+    // "0.0%", "$#,##0.00", or "" to clear) to the selected cell. Display-only —
+    // the stored value is unchanged; the engine renders it through the code.
+    // Recomputes the grid + bumps `revision` so the visible rows re-fetch.
+    Q_INVOKABLE void setFormatInf(const QString &code);
     // Clipboard: copy/cut capture the inclusive rectangle `start`..`end` (a
     // whole-block copy that pastes as a unit); paste places the block so its
     // top-left lands at `dstStart`, shifting the block's references by the

--- a/demo/visicalc-qt/test/tst_window.cpp
+++ b/demo/visicalc-qt/test/tst_window.cpp
@@ -27,6 +27,7 @@ private slots:
     void saveLoadRoundTrips();
     void undoRedoWalksHistory();
     void structuralInsertDeleteShiftsReferences();
+    void numberFormatAppliesToSelectedCell();
 };
 
 // Helper: the display string at window (1-based) cell (row, col), given the
@@ -282,6 +283,28 @@ void TstWindow::structuralInsertDeleteShiftsReferences() {
     QCOMPARE(m2.window(1, 13, 1, 13).at(0).toList().at(0).toString(), QStringLiteral("15")); // M1
     m2.selectInf(1, 13);
     QCOMPARE(QString(m2.infFormula()).remove('(').remove(')'), QStringLiteral("=L1*3"));
+}
+
+// Number formatting (the .00 / % / $ / Gen controls drive model.setFormatInf):
+// applying a format code changes only how the selected cell DISPLAYS; the stored
+// value is unchanged. An empty code clears the format.
+void TstWindow::numberFormatAppliesToSelectedCell() {
+    SpreadsheetModel m;
+    m.setCell("H1", "1234"); // col 8, away from the budget
+    m.selectInf(1, 8);
+    auto disp = [&m]() { return m.window(1, 8, 1, 8).at(0).toList().at(0).toString(); };
+    QCOMPARE(disp(), QStringLiteral("1234")); // unformatted
+    m.setFormatInf(QStringLiteral("#,##0.00"));
+    QCOMPARE(disp(), QStringLiteral("1,234.00"));
+    m.setFormatInf(QStringLiteral("0.0%"));
+    QCOMPARE(disp(), QStringLiteral("123400.0%"));
+    m.setFormatInf(QStringLiteral("$#,##0.00"));
+    QCOMPARE(disp(), QStringLiteral("$1,234.00"));
+    m.setFormatInf(QString()); // clear → General
+    QCOMPARE(disp(), QStringLiteral("1234"));
+    // The format is display-only: the stored source never changed.
+    m.selectInf(1, 8);
+    QCOMPARE(m.infFormula(), QStringLiteral("1234"));
 }
 
 QTEST_MAIN(TstWindow)


### PR DESCRIPTION
## What

Second backend of the **per-cell number formatting** rollout (web [#6517](https://github.com/adhithyan15/coding-adventures/pull/6517) → **Qt** → Flutter → Compose → XAML → SwiftUI). Surfaces the engine's `setFormat` primitive (used today only by the seed) as a user-facing control.

## Changes

- **`SpreadsheetModel.{h,cpp}`** — a `Q_INVOKABLE setFormatInf(code)` calling `sc_set_format` on the selected cell, recompute + bump `revision`. The `QByteArray` locals are **named** so the UTF-8 buffers outlive the C call (no dangling temporary). Display-only — the stored value is unchanged.
- **`InfiniteSheet.qml`** — a **"Format"** segmented toolbar group (`.00` / `%` / `$` / `Gen`) applying `#,##0.00` / `0.0%` / `$#,##0.00` / `""` (clear), reusing the `ToolButton` component.
- **`test/tst_window.cpp`** — a format proof: set `1234`, apply each code (→ `1,234.00` / `123400.0%` / `$1,234.00` / cleared `1234`), and assert the stored source is untouched.

## Verification

- `tst_window` (qmake) — **12/12 PASS** incl. the new `numberFormatAppliesToSelectedCell`.
- Full app builds clean (`qmake` + `make`) with **no QML errors**. Matches the web design validated live in #6517.

🤖 Generated with [Claude Code](https://claude.com/claude-code)