### PR TITLE
feat(visicalc-flutter): per-cell number formatting in the Flutter demo

### DIFF
--- a/demo/visicalc-flutter/README.md
+++ b/demo/visicalc-flutter/README.md
@@ -141,7 +141,12 @@ the C ABI's `sc_insert_rows`/`sc_delete_rows`/`sc_insert_cols`/`sc_delete_cols`)
 insert or delete the selected cell's row/column, and the engine shifts every
 formula reference at or after the band so dependents keep pointing at their
 precedents (`=A1+A2` with a row inserted above becomes `=A1+A3`); a reference
-whose whole band is deleted becomes `#REF!`. `InfiniteSheetModel`
+whose whole band is deleted becomes `#REF!`.
+The **.00 / % / $ / Gen** buttons apply a number **format** to the selected cell
+(`InfiniteSheetModel.applyFormat` over the C ABI's `sc_set_format`, with the code
+`#,##0.00`, `0.0%`, `$#,##0.00`, or `""` to clear). The format is display-only —
+the engine renders the stored value through the code, so the underlying number is
+unchanged. `InfiniteSheetModel`
 (in `lib/engine.dart`) seeds far-flung sparse cells (`Z1000`, `BA50`, `BB50`) so
 there's something to scroll to, and derives the extent from `usedRange()` + a
 margin.

--- a/demo/visicalc-flutter/lib/engine.dart
+++ b/demo/visicalc-flutter/lib/engine.dart
@@ -639,6 +639,12 @@ class InfiniteSheetModel {
     computeExtent();
   }
 
+  /// Number formatting: attach an Excel-style format code to the selected cell
+  /// (`#,##0.00`, `0.0%`, `$#,##0.00`, or `""` to clear). Display-only — the
+  /// stored value is unchanged; the engine renders it through the code, so a
+  /// fresh rowCells read shows the formatted string.
+  void applyFormat(String code) => _session.setFormat(infAddress, code);
+
   /// Structural edits: insert / delete the selected cell's row or column. The
   /// engine shifts every formula reference at or after the band (a reference
   /// whose whole band is deleted becomes `#REF!`) and recomputes; regrow the

--- a/demo/visicalc-flutter/lib/infinite_grid.dart
+++ b/demo/visicalc-flutter/lib/infinite_grid.dart
@@ -188,6 +188,11 @@ class _InfiniteGridState extends State<InfiniteGrid> {
         _formulaCtrl.text = _model.formula;
       });
 
+  // Number formatting: apply an Excel-style format code to the selected cell.
+  // Display-only — the engine renders the stored value through the code, so a
+  // setState rebuild re-reads the row and shows the formatted string.
+  void _applyFormat(String code) => setState(() => _model.applyFormat(code));
+
   // A compact, modern toolbar button (rounded chip with hover/down/disabled
   // states) — the Flutter analog of the web demo's segmented controls and the
   // Qt port's `component ToolButton`. `enabled: null` disables it (Undo/Redo/
@@ -335,6 +340,20 @@ class _InfiniteGridState extends State<InfiniteGrid> {
           _toolButton('− Col',
               "Delete the selected cell's column (references shift left; refs into it become #REF!)",
               _deleteCol),
+          _toolSep(),
+          // ── Format (apply a number format to the selected cell) ──
+          _toolButton('.00',
+              'Format the selected cell with thousands separators + 2 decimals (#,##0.00)',
+              () => _applyFormat('#,##0.00')),
+          const SizedBox(width: 6),
+          _toolButton('%', 'Format the selected cell as a percent (0.0%)',
+              () => _applyFormat('0.0%')),
+          const SizedBox(width: 6),
+          _toolButton('\$', 'Format the selected cell as currency (\$#,##0.00)',
+              () => _applyFormat('\$#,##0.00')),
+          const SizedBox(width: 6),
+          _toolButton('Gen', "Clear the selected cell's format (General)",
+              () => _applyFormat('')),
           _toolSep(),
           // ── History (undo / redo) ──
           _toolButton('↶ Undo', 'Undo the last edit', _undo,

--- a/demo/visicalc-flutter/test/window_test.dart
+++ b/demo/visicalc-flutter/test/window_test.dart
@@ -133,6 +133,23 @@ void main() {
       expect(c.window(1, 13, 1, 13)[0][0], '15'); // M1
       expect(c.getRaw('M1').replaceAll(RegExp(r'[()]'), ''), '=L1*3');
     });
+
+    test('setFormat changes only the display, not the stored value', () {
+      final s = SpreadsheetSession();
+      s.setCell('A1', '1234');
+      String disp() => s.window(1, 1, 1, 1)[0][0];
+      expect(disp(), '1234'); // unformatted
+      s.setFormat('A1', '#,##0.00');
+      expect(disp(), '1,234.00');
+      s.setFormat('A1', '0.0%');
+      expect(disp(), '123400.0%');
+      s.setFormat('A1', '\$#,##0.00');
+      expect(disp(), '\$1,234.00');
+      s.setFormat('A1', ''); // clear → General
+      expect(disp(), '1234');
+      // The format is display-only: the raw stored value never changed.
+      expect(s.getRaw('A1'), '1234');
+    });
   });
 
   // The infinite-view binding layer (InfiniteGrid drives these): one engine read


### PR DESCRIPTION
## What

Third backend of the **per-cell number formatting** rollout (web [#6517](https://github.com/adhithyan15/coding-adventures/pull/6517) → Qt [#6523](https://github.com/adhithyan15/coding-adventures/pull/6523) → **Flutter** → Compose → XAML → SwiftUI). Surfaces the engine's `setFormat` primitive (used today only by the seed) as a user control.

## Changes

- **`lib/engine.dart`** — `InfiniteSheetModel.applyFormat(code)` reusing the **existing** `SpreadsheetSession.setFormat` (no new FFI binding) on the selected cell. Display-only — the stored value is unchanged.
- **`lib/infinite_grid.dart`** — a **"Format"** segmented toolbar group (`.00` / `%` / `$` / `Gen`) applying `#,##0.00` / `0.0%` / `$#,##0.00` / `""` (clear) via a `setState` wrapper; the toolbar already scrolls horizontally so the extra buttons don't overflow.
- **`test/window_test.dart`** — a `setFormat` proof: set `1234`, apply each code (→ `1,234.00` / `123400.0%` / `$1,234.00` / cleared `1234`), and assert the raw stored value is untouched.

## Verification

- `flutter analyze` — clean.
- `flutter test` — **20/20 pass** (the widget test pumps the real `InfiniteGrid` tree on the live dart:ffi engine). Matches the web design validated live in #6517.

🤖 Generated with [Claude Code](https://claude.com/claude-code)