### PR TITLE
feat(visicalc-compose): per-cell number formatting in the Compose demo

### DIFF
--- a/demo/visicalc-compose/README.md
+++ b/demo/visicalc-compose/README.md
@@ -111,6 +111,11 @@ or delete the selected cell's row/column, and the engine shifts every formula
 reference at or after the band so dependents keep pointing at their precedents
 (`=A1+A2` with a row inserted above becomes `=A1+A3`); a reference whose whole band
 is deleted becomes `#REF!`.
+The **.00 / % / $ / Gen** buttons apply a number **format** to the selected cell
+(`InfiniteSheetModel.applyFormat` over the C ABI's `sc_set_format`, with the code
+`#,##0.00`, `0.0%`, `$#,##0.00`, or `""` to clear). The format is display-only —
+the engine renders the stored value through the code, so the underlying number is
+unchanged.
 `InfiniteSheetModel` (in `Engine.kt`) seeds far-flung
 sparse cells (`Z1000`, `BA50`, `BB50`) and derives the extent from `usedRange()`
 + a margin.

--- a/demo/visicalc-compose/src/main/kotlin/Engine.kt
+++ b/demo/visicalc-compose/src/main/kotlin/Engine.kt
@@ -475,6 +475,12 @@ class InfiniteSheetModel(
     fun insertCol() { session.insertCols(selCol, 1); computeExtent() }
     fun deleteCol() { session.deleteCols(selCol, 1); computeExtent() }
 
+    /// Number formatting: attach an Excel-style format code to the selected cell
+    /// ("#,##0.00", "0.0%", "$#,##0.00", or "" to clear). Display-only — the
+    /// stored value is unchanged; the engine renders it through the code, so a
+    /// fresh rowCells read shows the formatted string.
+    fun applyFormat(code: String) = session.setFormat(infAddress(), code)
+
     /// Clipboard: copy/cut the selected cell, then paste it at the selection. The
     /// engine shifts the pasted formula's relative references by the
     /// destination's offset, pins absolute (`$`) refs, carries the format; a cut

--- a/demo/visicalc-compose/src/main/kotlin/InfiniteSheet.kt
+++ b/demo/visicalc-compose/src/main/kotlin/InfiniteSheet.kt
@@ -192,6 +192,10 @@ fun InfiniteSheet() {
     fun insertCol() { model.insertCol(); formula = model.formula; rev++ }
     fun deleteCol() { model.deleteCol(); formula = model.formula; rev++ }
 
+    // Number formatting: apply an Excel-style code to the selected cell. Display-
+    // only — bump rev so the visible rows re-read and show the formatted string.
+    fun applyFormat(code: String) { model.applyFormat(code); rev++ }
+
     Column(modifier = Modifier.fillMaxSize().background(BG)) {
         // ── Formula bar: a panel holding the address pill, an `fx` marker, the
         // editable source line (with an accent focus ring), and segmented button
@@ -284,6 +288,15 @@ fun InfiniteSheet() {
             toolButton("+ Col") { insertCol() }
             Spacer(Modifier.width(6.dp))
             toolButton("− Col") { deleteCol() }
+            toolSep()
+            // ── Format (apply a number format to the selected cell) ──
+            toolButton(".00") { applyFormat("#,##0.00") }
+            Spacer(Modifier.width(6.dp))
+            toolButton("%") { applyFormat("0.0%") }
+            Spacer(Modifier.width(6.dp))
+            toolButton("$") { applyFormat("\$#,##0.00") }
+            Spacer(Modifier.width(6.dp))
+            toolButton("Gen") { applyFormat("") }
             toolSep()
             // ── History (undo / redo). Reading `rev` re-evaluates canUndo/canRedo
             // on every edit so the buttons gate live.

--- a/demo/visicalc-compose/test/EngineSmoke.kt
+++ b/demo/visicalc-compose/test/EngineSmoke.kt
@@ -221,6 +221,23 @@ fun main() {
     check("struct insertCol shifted refs", sc.getRaw("M1").replace("(", "").replace(")", ""), "=L1*3")
     sc.close()
 
+    // Number formatting (the .00 / % / $ / Gen buttons drive setFormat): applying
+    // a format code changes only how the cell DISPLAYS; the stored value is
+    // unchanged. An empty code clears the format back to General.
+    val fmt = SpreadsheetSession()
+    fmt.setCell("A1", "1234")
+    check("fmt unformatted", fmt.window(1, 1, 1, 1)[0][0], "1234")
+    fmt.setFormat("A1", "#,##0.00")
+    check("fmt #,##0.00", fmt.window(1, 1, 1, 1)[0][0], "1,234.00")
+    fmt.setFormat("A1", "0.0%")
+    check("fmt 0.0%", fmt.window(1, 1, 1, 1)[0][0], "123400.0%")
+    fmt.setFormat("A1", "\$#,##0.00")
+    check("fmt $", fmt.window(1, 1, 1, 1)[0][0], "\$1,234.00")
+    fmt.setFormat("A1", "")
+    check("fmt cleared", fmt.window(1, 1, 1, 1)[0][0], "1234")
+    check("fmt raw untouched", fmt.getRaw("A1"), "1234") // display-only
+    fmt.close()
+
     println(if (failures == 0) "\nALL PASS" else "\n$failures FAILURE(S)")
     kotlin.system.exitProcess(if (failures == 0) 0 else 1)
 }


### PR DESCRIPTION
## What

Fourth backend of the **per-cell number formatting** rollout (web [#6517](https://github.com/adhithyan15/coding-adventures/pull/6517) → Qt [#6523](https://github.com/adhithyan15/coding-adventures/pull/6523) → Flutter [#6524](https://github.com/adhithyan15/coding-adventures/pull/6524) → **Compose** → XAML → SwiftUI). Surfaces the engine's `setFormat` primitive (used today only by the seed) as a user control.

## Changes

- **`Engine.kt`** — `InfiniteSheetModel.applyFormat(code)` reusing the **existing** `SpreadsheetSession.setFormat` (no new FFM handle) on the selected cell. Display-only.
- **`InfiniteSheet.kt`** — a **"Format"** segmented toolbar group (`.00` / `%` / `$` / `Gen`) applying `#,##0.00` / `0.0%` / `$#,##0.00` / `""` (clear), bumping `rev` so the visible rows re-read.
- **`test/EngineSmoke.kt`** — a `setFormat` proof: set `1234`, apply each code (→ `1,234.00` / `123400.0%` / `$1,234.00` / cleared `1234`), assert the raw stored value is untouched.

## Verification

- `scripts/verify.sh` (kotlinc + FFM) — **ALL PASS** incl. the new format cases.
- `gradle compileKotlin` — **BUILD SUCCESSFUL**. Matches the web design validated live in #6517.

🤖 Generated with [Claude Code](https://claude.com/claude-code)