### PR TITLE
feat(visicalc-xaml): per-cell number formatting in the XAML demo

### DIFF
--- a/demo/visicalc-xaml/Engine.cs
+++ b/demo/visicalc-xaml/Engine.cs
@@ -560,6 +560,12 @@ public sealed class InfiniteSheetModel : IDisposable
     public void InsertCol() { _session.InsertCols(SelCol, 1); ComputeExtent(); }
     public void DeleteCol() { _session.DeleteCols(SelCol, 1); ComputeExtent(); }
 
+    /// Number formatting: attach an Excel-style format code to the selected cell
+    /// ("#,##0.00", "0.0%", "$#,##0.00", or "" to clear). Display-only — the
+    /// stored value is unchanged; the engine renders it through the code, so a
+    /// fresh RowCells read shows the formatted string.
+    public void ApplyFormat(string code) => _session.SetFormat(InfAddress, code);
+
     /// Clipboard: copy/cut the selected cell, then paste it at the selection. The
     /// engine shifts the pasted formula's relative references by the destination's
     /// offset, pins absolute (`$`) refs, carries the format; a cut clears the

--- a/demo/visicalc-xaml/InfiniteSheet.xaml
+++ b/demo/visicalc-xaml/InfiniteSheet.xaml
@@ -161,6 +161,24 @@
                             ToolTipService.ToolTip="Delete the selected cell's column (references shift left; refs into it become #REF!)"
                             Click="DelColButton_Click"/>
                     <Border Width="1" Height="22" Margin="6,0,6,0" Background="#2C313A"/>
+                    <!-- Format (apply a number format to the selected cell) -->
+                    <Button x:Name="FmtDecimalButton" Style="{StaticResource ToolChip}" Margin="0,0,6,0"
+                            Content=".00"
+                            ToolTipService.ToolTip="Format the selected cell with thousands separators + 2 decimals (#,##0.00)"
+                            Click="FmtDecimalButton_Click"/>
+                    <Button x:Name="FmtPercentButton" Style="{StaticResource ToolChip}" Margin="0,0,6,0"
+                            Content="%"
+                            ToolTipService.ToolTip="Format the selected cell as a percent (0.0%)"
+                            Click="FmtPercentButton_Click"/>
+                    <Button x:Name="FmtCurrencyButton" Style="{StaticResource ToolChip}" Margin="0,0,6,0"
+                            Content="$"
+                            ToolTipService.ToolTip="Format the selected cell as currency ($#,##0.00)"
+                            Click="FmtCurrencyButton_Click"/>
+                    <Button x:Name="FmtGeneralButton" Style="{StaticResource ToolChip}"
+                            Content="Gen"
+                            ToolTipService.ToolTip="Clear the selected cell's format (General)"
+                            Click="FmtGeneralButton_Click"/>
+                    <Border Width="1" Height="22" Margin="6,0,6,0" Background="#2C313A"/>
                     <!-- History (undo / redo) -->
                     <Button x:Name="UndoButton" Style="{StaticResource ToolChip}" Margin="0,0,6,0"
                             Content="↶ Undo"

--- a/demo/visicalc-xaml/InfiniteSheet.xaml.cs
+++ b/demo/visicalc-xaml/InfiniteSheet.xaml.cs
@@ -251,6 +251,14 @@ public sealed partial class InfiniteSheet : UserControl
         RepaintRealizedRows();
     }
 
+    /// Number formatting: apply an Excel-style code to the selected cell. The
+    /// format is display-only — the stored value is unchanged; repaint the
+    /// realized rows so the formatted string shows.
+    private void FmtDecimalButton_Click(object sender, RoutedEventArgs e) { _model.ApplyFormat("#,##0.00"); RepaintRealizedRows(); }
+    private void FmtPercentButton_Click(object sender, RoutedEventArgs e) { _model.ApplyFormat("0.0%"); RepaintRealizedRows(); }
+    private void FmtCurrencyButton_Click(object sender, RoutedEventArgs e) { _model.ApplyFormat("$#,##0.00"); RepaintRealizedRows(); }
+    private void FmtGeneralButton_Click(object sender, RoutedEventArgs e) { _model.ApplyFormat(""); RepaintRealizedRows(); }
+
     /// Clipboard: copy/cut the selected cell, then paste it at the selection. The
     /// engine shifts the pasted formula's relative refs by the destination's
     /// offset, pins absolute ($) refs, carries the format; a cut clears the source

--- a/demo/visicalc-xaml/README.md
+++ b/demo/visicalc-xaml/README.md
@@ -172,6 +172,11 @@ or delete the selected cell's row/column, and the engine shifts every formula
 reference at or after the band so dependents keep pointing at their precedents
 (`=A1+A2` with a row inserted above becomes `=A1+A3`); a reference whose whole band
 is deleted becomes `#REF!`.
+The **.00 / % / $ / Gen** buttons apply a number **format** to the selected cell
+(`InfiniteSheetModel.ApplyFormat` over the C ABI's `sc_set_format`, with the code
+`#,##0.00`, `0.0%`, `$#,##0.00`, or `""` to clear). The format is display-only —
+the engine renders the stored value through the code, so the underlying number is
+unchanged.
 
 `InfiniteSheetModel` (in `Engine.cs`, WinUI-free) seeds far-flung sparse cells
 (`Z1000`, `BA50`, `BB50`) and derives the extent from `UsedRange()` + a margin

--- a/demo/visicalc-xaml/test/Program.cs
+++ b/demo/visicalc-xaml/test/Program.cs
@@ -225,5 +225,24 @@ using (var sc = new SpreadsheetSession())
     Check("struct insertCol shifted refs", Bare(sc.GetRaw("M1")), "=L1*3");
 }
 
+// ── Number formatting (the .00 / % / $ / Gen buttons drive SetFormat): applying
+// a format code changes only how the cell DISPLAYS; the stored value is
+// unchanged. An empty code clears the format back to General.
+using (var fmt = new SpreadsheetSession())
+{
+    fmt.SetCell("A1", "1234");
+    string Disp() => fmt.Window(1, 1, 1, 1)[0][0];
+    Check("fmt unformatted", Disp(), "1234");
+    fmt.SetFormat("A1", "#,##0.00");
+    Check("fmt #,##0.00", Disp(), "1,234.00");
+    fmt.SetFormat("A1", "0.0%");
+    Check("fmt 0.0%", Disp(), "123400.0%");
+    fmt.SetFormat("A1", "$#,##0.00");
+    Check("fmt $", Disp(), "$1,234.00");
+    fmt.SetFormat("A1", "");
+    Check("fmt cleared", Disp(), "1234");
+    Check("fmt raw untouched", fmt.GetRaw("A1"), "1234"); // display-only
+}
+
 Console.WriteLine(failures == 0 ? "\nALL PASS" : $"\n{failures} FAILURE(S)");
 return failures == 0 ? 0 : 1;


### PR DESCRIPTION
## What

Fifth backend of the **per-cell number formatting** rollout (web [#6517](https://github.com/adhithyan15/coding-adventures/pull/6517) → Qt [#6523](https://github.com/adhithyan15/coding-adventures/pull/6523) → Flutter [#6524](https://github.com/adhithyan15/coding-adventures/pull/6524) → Compose [#6527](https://github.com/adhithyan15/coding-adventures/pull/6527) → **XAML** → SwiftUI).

## Changes

- **`Engine.cs`** — `InfiniteSheetModel.ApplyFormat(code)` reusing the **existing** `SpreadsheetSession.SetFormat` (no new `DllImport`) on the selected cell. Display-only.
- **`InfiniteSheet.xaml`** — a **"Format"** segmented toolbar group (`.00` / `%` / `$` / `Gen`) applying `#,##0.00` / `0.0%` / `$#,##0.00` / `""` (clear), reusing the `ToolChip` style.
- **`InfiniteSheet.xaml.cs`** — four `Click` handlers (`ApplyFormat` + `RepaintRealizedRows`).
- **`test/Program.cs`** — a `SetFormat` proof: set `1234`, apply each code (→ `1,234.00` / `123400.0%` / `$1,234.00` / cleared `1234`), assert the raw stored value is untouched.

## Verification

The WinUI view is **Windows-only** — this macOS checkout cannot `dotnet build` it (the documented boundary), so it's hand-authored. The engine-backed model is proven cross-platform by **`scripts/verify.sh`** (the `test/` console harness P/Invoking the engine) — **ALL PASS** incl. the new format cases. Matches the web design validated live in #6517.

🤖 Generated with [Claude Code](https://claude.com/claude-code)