### PR TITLE
feat(mycin-onco): big batch — 7 high-yield tumor markers (7→14 edges)

### DIFF
--- a/code/specs/data/mycin-2026/recall/onco-edges.adj
+++ b/code/specs/data/mycin-2026/recall/onco-edges.adj
@@ -87,4 +87,51 @@ rulebook onco_facts {
         source "In addition, hCG testing can aid in the diagnosis of certain cancers, such as choriocarcinoma and some extra-uterine malignancies."
         locator "https://www.ncbi.nlm.nih.gov/books/NBK532950/"
         trust authoritative
+
+    % ------------------------------------------------------------------------
+    % BATCH: high-yield tumor markers, each grounded to a self-contained verbatim
+    % NCBI Bookshelf span naming both the neoplasm and the marker. (breast_cancer
+    % -> CA 15-3 and multiple_myeloma -> beta-2-microglobulin declined: no single
+    % NBK span names the spelled-out disease with the marker — backlog, not stretched.)
+    % ------------------------------------------------------------------------
+
+    % Pancreatic cancer — CA 19-9 and CEA (one span names both markers).
+    relate tumor_marker(pancreatic_cancer, ca_19_9)
+        source "Tumor markers associated with pancreatic cancer include CEA and CA 19-9."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK518996/"
+        trust authoritative
+    relate tumor_marker(pancreatic_cancer, cea)
+        source "Tumor markers associated with pancreatic cancer include CEA and CA 19-9."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK518996/"
+        trust authoritative
+
+    % Small cell lung cancer — neuron-specific enolase (NSE).
+    relate tumor_marker(small_cell_lung_cancer, neuron_specific_enolase)
+        source "This study aims to evaluate the association of serum neuron-specific enolase (NSE) levels with the prognosis of small cell lung cancer (SCLC)."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK153280/"
+        trust authoritative
+
+    % Neuroendocrine tumors — chromogranin A.
+    relate tumor_marker(neuroendocrine_tumor, chromogranin_a)
+        source "Chromogranin A is a widely used neuroendocrine tumor marker."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK537344/"
+        trust authoritative
+
+    % Melanoma — S100 (immunohistochemical marker of melanocytic differentiation).
+    relate tumor_marker(melanoma, s100)
+        source "Immunohistochemical stains, such as S100, Melan-A, and human melanoma black-45 (HMB-45), aid in confirming melanocytic differentiation and distinguishing melanoma from other tumors."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK459367/"
+        trust authoritative
+
+    % Yolk sac tumor (endodermal sinus tumor) — alpha-fetoprotein.
+    relate tumor_marker(yolk_sac_tumor, alpha_fetoprotein)
+        source "Immunohistochemical staining can support the diagnosis of yolk sac tumors, as almost all cases stain positively for alpha-fetoprotein (AFP)."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK563163/"
+        trust authoritative
+
+    % Gastrointestinal stromal tumor (GIST) — CD117 (KIT).
+    relate tumor_marker(gastrointestinal_stromal_tumor, cd117)
+        source "Immunohistochemically, GISTs typically express KIT (CD117), which is a highly sensitive and specific diagnostic marker."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK554541/"
+        trust authoritative
 }

--- a/code/specs/data/mycin-2026/recall/onco-recall.query.adj
+++ b/code/specs/data/mycin-2026/recall/onco-recall.query.adj
@@ -20,3 +20,10 @@ import "onco-edges.adj"
 ? tumor_marker(colorectal_cancer, $Marker)             % expect cea (expand)
 ? tumor_marker(prostate_cancer, $Marker)               % expect psa (expand)
 ? tumor_marker(choriocarcinoma, $Marker)               % expect hcg (expand)
+% --- BATCH: high-yield tumor markers ---
+? tumor_marker(pancreatic_cancer, $Marker)             % expect ca_19_9 / cea (expand)
+? tumor_marker(small_cell_lung_cancer, $Marker)        % expect neuron_specific_enolase (expand)
+? tumor_marker(neuroendocrine_tumor, $Marker)          % expect chromogranin_a (expand)
+? tumor_marker(melanoma, $Marker)                      % expect s100 (expand)
+? tumor_marker(yolk_sac_tumor, $Marker)                % expect alpha_fetoprotein (expand)
+? tumor_marker(gastrointestinal_stromal_tumor, $Marker)  % expect cd117 (expand)

--- a/code/specs/data/mycin-2026/recall/test_onco_recall.py
+++ b/code/specs/data/mycin-2026/recall/test_onco_recall.py
@@ -36,6 +36,13 @@ EXPECTED = {
     "colorectal_cancer": {"cea"},                        # expand (NBK578172)
     "prostate_cancer": {"psa"},                          # expand (NBK470550)
     "choriocarcinoma": {"hcg"},                           # expand (NBK532950)
+    # --- BATCH: high-yield tumor markers ---
+    "pancreatic_cancer": {"ca_19_9", "cea"},              # expand (NBK518996)
+    "small_cell_lung_cancer": {"neuron_specific_enolase"},  # expand (NBK153280)
+    "neuroendocrine_tumor": {"chromogranin_a"},           # expand (NBK537344)
+    "melanoma": {"s100"},                                 # expand (NBK459367)
+    "yolk_sac_tumor": {"alpha_fetoprotein"},              # expand (NBK563163)
+    "gastrointestinal_stromal_tumor": {"cd117"},          # expand (NBK554541)
 }
 REL = "tumor_marker"
 VAR = "Marker"
@@ -99,8 +106,8 @@ def test_unknown_neoplasm_abstains() -> None:
     fd, path = tempfile.mkstemp(suffix=".adj", prefix=".onco_q_", dir=HERE)
     try:
         with os.fdopen(fd, "w") as fh:
-            # pancreatic_cancer is not in the library → must abstain
-            fh.write(f'import "onco-edges.adj"\n? {REL}(pancreatic_cancer, ${VAR})\n')
+            # glioblastoma is not in the library → must abstain
+            fh.write(f'import "onco-edges.adj"\n? {REL}(glioblastoma, ${VAR})\n')
         res = _run(Path(path))
         r = res["recall"][0] if res["recall"] else None
         assert r is not None and r["abstained"], "an ungrounded neoplasm must abstain"


### PR DESCRIPTION
## What

Doubles the MYCIN-2026 **ONCO** recall library — **7 → 14 grounded edges** — adding 6 high-yield neoplasms (pancreatic cancer carries both CA 19-9 and CEA from one span), each defended by a self-contained verbatim NCBI Bookshelf span naming both endpoints.

| neoplasm | marker(s) | source |
|---|---|---|
| pancreatic cancer | CA 19-9, CEA | NBK518996 |
| small cell lung cancer | neuron-specific enolase | NBK153280 |
| neuroendocrine tumor | chromogranin A | NBK537344 |
| melanoma | S100 | NBK459367 |
| yolk sac tumor | alpha-fetoprotein | NBK563163 |
| GIST | CD117 (KIT) | NBK554541 |

### Honestly declined (checked + documented, not stretched)
- **breast cancer → CA 15-3** and **multiple myeloma → β2-microglobulin** — no single NCBI Bookshelf sentence names the spelled-out disease together with the marker (the clean phrasings live in PMC journal articles or use the "MM" abbreviation). Backlog for a clean NBK span.

## Verify
- `test_onco_recall` **3/3** — the native adj-lang engine binds **all 14** markers via the worked query file (incl. the multi-marker pancreatic & medullary-thyroid neoplasms), each with an `authoritative` citation + real source span + `ncbi.nlm.nih.gov` locator; an off-vocabulary neoplasm (glioblastoma) abstains.
- `ruff` clean; data-only security review passed.

Negative-control note: the abstention probe was `pancreatic_cancer`, which this batch now grounds — repointed to `glioblastoma` (no classic serum tumor marker) so the test stays meaningful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)