### PR TITLE
feat(visicalc-swiftui): per-cell number formatting in the SwiftUI demo

### DIFF
--- a/demo/visicalc-swiftui/README.md
+++ b/demo/visicalc-swiftui/README.md
@@ -110,6 +110,12 @@ or delete the selected cell's row/column, and the engine shifts every formula
 reference at or after the band so dependents keep pointing at their precedents
 (`=A1+A2` with a row inserted above becomes `=A1+A3`); a reference whose whole band
 is deleted becomes `#REF!`.
+The **Format** buttons (`.00` · `%` · `$` · `Gen`) apply an Excel-style
+number-format code to the selected cell's *display only*
+(`WindowedSheetModel.applyFormat` over the C ABI's `sc_set_format`): `.00` →
+`#,##0.00` (`1234` → `1,234.00`), `%` → `0.0%`, `$` → `$#,##0.00`, and `Gen` →
+`""` (clears, back to General). The stored value is untouched — `getRaw` still
+returns the source and dependent formulas keep computing on the real number.
 
 ### Visual design
 

--- a/demo/visicalc-swiftui/Sources/VisiCalc/InfiniteGrid.swift
+++ b/demo/visicalc-swiftui/Sources/VisiCalc/InfiniteGrid.swift
@@ -161,6 +161,19 @@ final class WindowedSheetModel: ObservableObject {
         revision += 1
     }
 
+    /// Number format: apply an Excel-style format code to the selected cell's
+    /// DISPLAY only — the stored value is untouched, so `getRaw` still returns
+    /// the original source and dependent formulas keep computing on the real
+    /// number. An empty code clears the format (back to General). The engine's
+    /// display window then renders the cell through the code (`1234` + `#,##0.00`
+    /// → `"1,234.00"`). Bump `revision` so the visible rows re-fetch. The SwiftUI
+    /// sibling of the web demo's "Format" group and the Qt/Flutter/Compose/XAML
+    /// `applyFormat`.
+    func applyFormat(_ code: String) {
+        session.setFormat(address(selectedRow, selectedCol), code)
+        revision += 1
+    }
+
     /// Clipboard: copy/cut the selected cell, then paste it at the selection. The
     /// engine shifts the pasted formula's relative references by the
     /// destination's offset, pins absolute (`$`) refs, carries the format; a cut
@@ -375,6 +388,18 @@ struct InfiniteGridView: View {
                 .help("Insert a column left of the selected cell (references shift right)")
             Button("− Col") { model.deleteCol() }
                 .help("Delete the selected cell's column (references shift left; refs into it become #REF!)")
+            toolSep
+            // ── Format (apply an Excel-style number-format code to the selected
+            // cell's DISPLAY; the stored value is untouched). Fixed codes:
+            // thousands+2dp, percent, currency, and General (clears).
+            Button(".00") { model.applyFormat("#,##0.00") }
+                .help("Format the selected cell as 1,234.00 (display only)")
+            Button("%") { model.applyFormat("0.0%") }
+                .help("Format the selected cell as a percentage (display only)")
+            Button("$") { model.applyFormat("$#,##0.00") }
+                .help("Format the selected cell as currency (display only)")
+            Button("Gen") { model.applyFormat("") }
+                .help("Clear the number format (back to General)")
             toolSep
             // ── History (undo / redo). The buttons gate off canUndo/canRedo,
             // re-evaluated whenever `revision` (a @Published) bumps after an edit.

--- a/demo/visicalc-swiftui/Tests/VisiCalcTests/WindowedModelTests.swift
+++ b/demo/visicalc-swiftui/Tests/VisiCalcTests/WindowedModelTests.swift
@@ -197,4 +197,34 @@ final class WindowedModelTests: XCTestCase {
         m.setCell("A1", "7")
         XCTAssertFalse(m.canRedo())
     }
+
+    /// Number format applies to the selected cell's DISPLAY only — the stored
+    /// value is untouched, so `getRaw` still returns the source and the
+    /// display window renders the cell through the format code. The SwiftUI
+    /// proof of the cross-backend "Format" toolbar group.
+    func testApplyFormatChangesDisplayNotValue() {
+        let m = WindowedSheetModel()
+        // Put a plain number in a clear cell (H1, col 8). Unformatted it reads "1234".
+        m.select(row: 1, col: 8)
+        m.formulaText = "1234"
+        m.commitFormula()
+        XCTAssertEqual(m.rowCells(1)[7], "1234")
+
+        // Thousands + 2 decimals.
+        m.select(row: 1, col: 8); m.applyFormat("#,##0.00")
+        XCTAssertEqual(m.rowCells(1)[7], "1,234.00")
+        // Percent (1234 → 123400.0%).
+        m.applyFormat("0.0%")
+        XCTAssertEqual(m.rowCells(1)[7], "123400.0%")
+        // Currency.
+        m.applyFormat("$#,##0.00")
+        XCTAssertEqual(m.rowCells(1)[7], "$1,234.00")
+        // The raw stored value is never mutated by formatting: re-selecting H1
+        // loads its source (not its formatted display) into the formula bar.
+        m.select(row: 1, col: 8)
+        XCTAssertEqual(m.formulaText, "1234")
+        // Clearing the format (empty code) returns to General.
+        m.applyFormat("")
+        XCTAssertEqual(m.rowCells(1)[7], "1234")
+    }
 }


### PR DESCRIPTION
## What

**Sixth and last** backend of the per-cell number-formatting rollout: web [#6517](https://github.com/adhithyan15/coding-adventures/pull/6517) → Qt [#6523](https://github.com/adhithyan15/coding-adventures/pull/6523) → Flutter [#6524](https://github.com/adhithyan15/coding-adventures/pull/6524) → Compose [#6527](https://github.com/adhithyan15/coding-adventures/pull/6527) → XAML [#6528](https://github.com/adhithyan15/coding-adventures/pull/6528) → **SwiftUI**.

## Changes

- **`InfiniteGrid.swift`** — `WindowedSheetModel.applyFormat(code)` reusing the **existing** `SpreadsheetSession.setFormat` (`sc_set_format`; no new FFI binding) on the selected cell, then bumps `revision`. Display-only.
- A **"Format"** segmented toolbar group (`.00` / `%` / `$` / `Gen`) applying `#,##0.00` / `0.0%` / `$#,##0.00` / `""` (clear), reusing `ChipButtonStyle`.
- **`WindowedModelTests.swift`** — `testApplyFormatChangesDisplayNotValue`: set `H1=1234`, apply each code (→ `1,234.00` / `123400.0%` / `$1,234.00`), re-select to assert the raw source is still `1234`, then clear with `""`.

## Verification

`swift build` + `swift test` → **14/14 pass**. Security review passed (no new FFI; fixed literal codes; reuses the vetted String→C-string path). Matches the web design validated live in #6517.

🤖 Generated with [Claude Code](https://claude.com/claude-code)