### PR TITLE
feat(sir-runtime-oop): Numeric/Symbol/nil catalogs + to_s/inspect (M1c)

### DIFF
--- a/code/packages/python/sir-runtime-oop/CHANGELOG.md
+++ b/code/packages/python/sir-runtime-oop/CHANGELOG.md
@@ -2,6 +2,46 @@
 
 All notable changes to `coding-adventures-sir-runtime-oop` are documented here.
 
+## [0.1.5] - 2026-06-22
+
+### Added
+
+Built-in method dispatch, part 5 — the **`Integer`/`Float`**, **`Symbol`**, and
+**`nil`/`true`/`false`** catalogs (per `code/specs/sir-method-dispatch.md`, item
+M1c), completing the M1c primitive surface:
+
+- **Numeric** (`int`/`float`): `abs`, `to_i`, `to_f`, `even?`, `odd?`, `zero?`,
+  `positive?`, `negative?`, `succ`/`next`, `pred`, `floor`, `ceil`, `round`
+  (half **away from zero**, unlike Python's banker's rounding), `gcd`, `pow`/`**`,
+  `digits`; block forms `times`, `upto`, `downto`, `step`.
+- **Symbol** (`sir-runtime-core` `Symbol`): `to_s`, `to_sym`, `length`/`size`,
+  `upcase`/`downcase` (return a new interned symbol), `inspect`, `empty?`.
+- **`to_s`/`inspect` are now universal `Object` methods** (Ruby display forms):
+  `nil.to_s == ""` / `nil.inspect == "nil"`, `true.to_s == "true"`, numbers and
+  symbols print faithfully, and an `Array`/`Hash` renders `"[1, 2]"` / `"{:k=>v}"`.
+  This means **`nil`/`true`/`false` need no catalog of their own** (`nil.to_a`
+  already returns `[]`). Added **`Array#join`** (elements via `to_s`, default sep
+  `""`).
+- Dispatch orders the `bool` check **before** `int` (a Python `bool` is an `int`
+  subclass) so `True`/`False` resolve only the `Object` methods, never the numeric
+  catalog.
+
+`respond_to?` reports each new catalog honestly; out-of-catalog stays `nil`.
+
+### Security / robustness
+
+- **`**`/`pow` and `digits` bound hostile bignums.** A repeat/exponent count can
+  come from untrusted input; Python ints are arbitrary precision, so
+  `2 ** (10 ** 9)` would allocate ~125 MB. `**` now refuses an integer result
+  past a ~1M-bit budget (returns `0`); `digits` refuses an over-budget bignum;
+  float overflow returns `inf` instead of raising.
+- **`to_s`/`inspect`/`join` are cycle- and depth-safe.** A self-referential
+  `Array`/`Hash` renders `[...]`/`{...}` (Ruby's behaviour) and depth is capped,
+  so a cyclic or deeply-nested structure can no longer raise `RecursionError`.
+- **Numeric methods never raise on `inf`/`nan`.** `to_i`/`even?`/`odd?`/`gcd`/
+  `floor`/`ceil`/`round`/`digits` degrade gracefully rather than raising
+  `OverflowError`, upholding the never-raise-on-the-OO-surface invariant.
+
 ## [0.1.4] - 2026-06-22
 
 ### Added

--- a/code/packages/python/sir-runtime-oop/README.md
+++ b/code/packages/python/sir-runtime-oop/README.md
@@ -60,8 +60,13 @@ the **non-block `Array`** surface — `length`/`size`/`count`, `first`/`last`,
 **M1c**) the **`String`** catalog (`length`, `upcase`/`downcase`/`capitalize`,
 `reverse`, `strip`/`lstrip`/`rstrip`, `chomp`, `chars`/`bytes`, `split`,
 `include?`/`start_with?`/`end_with?`/`index`, `replace`, `sub`/`gsub` *literal*,
-`to_i`/`to_f`/`to_sym`, `empty?`, `*`/`+`, `each_char`). The Numeric/Symbol
-catalogs land in follow-up releases.
+`to_i`/`to_f`/`to_sym`, `empty?`, `*`/`+`, `each_char`); and (item **M1c**) the
+**`Integer`/`Float`** catalog (`abs`, `to_i`/`to_f`, `even?`/`odd?`/`zero?`/
+`positive?`/`negative?`, `succ`/`pred`, `floor`/`ceil`/`round`, `gcd`, `pow`/`**`,
+`digits`, and block `times`/`upto`/`downto`/`step`), the **`Symbol`** catalog
+(`to_s`/`to_sym`/`length`/`upcase`/`downcase`/`inspect`), and universal
+**`to_s`/`inspect`** Ruby display forms (so `nil`/`true`/`false` need no catalog)
+plus **`Array#join`**.
 
 ## Honest v0 limitation
 

--- a/code/packages/python/sir-runtime-oop/src/coding_adventures_sir_runtime_oop/oop.py
+++ b/code/packages/python/sir-runtime-oop/src/coding_adventures_sir_runtime_oop/oop.py
@@ -31,6 +31,7 @@ receivers into method bodies (out of scope for the backend).  See
 
 from __future__ import annotations
 
+import math
 import re
 from collections.abc import Callable
 from typing import Any
@@ -39,8 +40,8 @@ from typing import Any
 # reaches us as a trailing ``Closure`` from ``sir-runtime-core``; ``apply`` calls
 # it with proc-lenient arity, and ``truthy`` applies SIR truthiness (only
 # ``False``/``nil`` are falsy) to predicate results.  ``intern`` mints the
-# :class:`Symbol` that ``String#to_sym`` returns.
-from coding_adventures_sir_runtime_core import Closure, apply, intern, truthy
+# :class:`Symbol` that ``String#to_sym`` / ``Symbol#upcase`` return.
+from coding_adventures_sir_runtime_core import Closure, Symbol, apply, intern, truthy
 
 # The SIR universal value type at this package's boundary.
 Val = Any
@@ -237,6 +238,10 @@ def _class_name_arg(arg: Val) -> str:
 _MISS = object()
 
 # Universal methods available on *every* receiver (Ruby's ``Object``/``Kernel``).
+# ``to_s``/``inspect`` render Ruby display forms (see :func:`_ruby_to_s` /
+# :func:`_ruby_inspect`); they live here so ``nil``/``true``/``false`` need no
+# catalog of their own (``nil.to_s == ""``, ``true.to_s == "true"``,
+# ``nil.inspect == "nil"``), and ``nil.to_a == []`` is handled below.
 _OBJECT_METHODS = frozenset(
     {
         "nil?",
@@ -250,6 +255,8 @@ _OBJECT_METHODS = frozenset(
         "clone",
         "itself",
         "to_a",
+        "to_s",
+        "inspect",
     }
 )
 
@@ -281,6 +288,7 @@ _ARRAY_METHODS = frozenset(
         "compact",
         "empty?",
         "to_a",
+        "join",
     }
 )
 
@@ -387,6 +395,51 @@ _STRING_METHODS = frozenset(
 # Block-taking ``String`` methods (M1c); ``each_char`` yields one character.
 _STRING_BLOCK_METHODS = frozenset({"each_char"})
 
+# Non-block ``Integer`` / ``Float`` methods (M1c).  A Ruby ``Integer`` is a
+# Python ``int`` and ``Float`` a ``float`` — but ``bool`` is a subclass of
+# ``int`` in Python, so :func:`call_method` routes ``True``/``False`` to the
+# universal ``Object`` methods (``true.to_s == "true"``) *before* this catalog.
+_NUMERIC_METHODS = frozenset(
+    {
+        "abs",
+        "to_i",
+        "to_f",
+        "even?",
+        "odd?",
+        "zero?",
+        "positive?",
+        "negative?",
+        "succ",
+        "next",
+        "pred",
+        "floor",
+        "ceil",
+        "round",
+        "gcd",
+        "pow",
+        "**",
+        "digits",
+    }
+)
+
+# Block-taking ``Integer`` methods (M1c): each invokes the block N times.
+_NUMERIC_BLOCK_METHODS = frozenset({"times", "upto", "downto", "step"})
+
+# ``Symbol`` methods (M1c).  A Ruby ``Symbol`` is a ``sir-runtime-core``
+# :class:`Symbol`; ``upcase``/``downcase`` return a *new* interned symbol.
+_SYMBOL_METHODS = frozenset(
+    {
+        "to_s",
+        "to_sym",
+        "length",
+        "size",
+        "upcase",
+        "downcase",
+        "inspect",
+        "empty?",
+    }
+)
+
 
 def _method_name(arg: Val) -> str:
     """Coerce a ``respond_to?`` argument (a :class:`Symbol`, ``":m"``-ish string,
@@ -404,10 +457,17 @@ def _responds_to(recv: Val, name: str) -> bool:
         return True
     if name in _OBJECT_METHODS:
         return True
-    # ``str`` is checked before ``list``/``dict`` would be irrelevant (a str is
-    # neither), but note bools are ints — order vs Array/Hash does not collide.
+    # ``str`` is checked before ``list``/``dict`` (a str is neither).  ``bool`` is
+    # a subclass of ``int`` so it is excluded from the numeric check — bools only
+    # resolve the universal ``Object`` methods (handled above).
     if isinstance(recv, str):
         return name in _STRING_METHODS or name in _STRING_BLOCK_METHODS
+    if isinstance(recv, Symbol):
+        return name in _SYMBOL_METHODS
+    if isinstance(recv, bool):
+        return False
+    if isinstance(recv, (int, float)):
+        return name in _NUMERIC_METHODS or name in _NUMERIC_BLOCK_METHODS
     if isinstance(recv, list):
         return name in _ARRAY_METHODS or name in _ARRAY_BLOCK_METHODS
     if isinstance(recv, dict):
@@ -470,6 +530,10 @@ def _object_method(recv: Val, name: str, args: list[Val]) -> Val:
         if isinstance(recv, list):
             return recv
         return _MISS
+    if name == "to_s":
+        return _ruby_to_s(recv)
+    if name == "inspect":
+        return _ruby_inspect(recv)
     return _MISS
 
 
@@ -528,6 +592,10 @@ def _array_method(recv: list[Val], name: str, args: list[Val]) -> Val:
         return len(recv) == 0
     if name == "to_a":
         return recv
+    if name == "join":
+        # Ruby ``Array#join``: elements rendered with ``to_s`` (default sep "").
+        sep = args[0] if args else ""
+        return sep.join(_ruby_to_s(item) for item in recv)
     return _MISS
 
 
@@ -783,6 +851,231 @@ def _string_block_method(recv: str, name: str, block: Closure) -> Val:
     return _MISS
 
 
+# ── Ruby display forms (to_s / inspect) ──────────────────────────────────────
+#
+# ``sir-runtime-core``'s ``to_display`` renders *Lisp* forms (``nil``, ``#t``,
+# ``#f``), so it is wrong for Ruby's ``to_s``/``inspect``.  These two helpers
+# implement Ruby's surface: ``nil.to_s == ""`` but ``nil.inspect == "nil"``;
+# booleans print ``true``/``false``; a symbol's ``to_s`` is its bare name and
+# ``inspect`` prefixes ``:``; an ``Array``'s ``to_s`` equals its ``inspect``
+# (``"[1, 2]"``); a ``Hash`` renders ``{:k=>v}``.  String escaping in ``inspect``
+# is the v0 naive form (wrap in quotes; no backslash escaping yet).
+
+
+def _ruby_to_s(v: Val) -> str:
+    """Ruby ``to_s`` display form of ``v``."""
+    if v is None:
+        return ""
+    if isinstance(v, bool):
+        return "true" if v else "false"
+    if isinstance(v, Symbol):
+        return v.name
+    if isinstance(v, str):
+        return v
+    if isinstance(v, (list, dict)):
+        return _ruby_inspect(v)
+    return str(v)
+
+
+def _ruby_inspect(v: Val, seen: set[int] | None = None, depth: int = 0) -> str:
+    """Ruby ``inspect`` display form of ``v``.
+
+    ``seen`` (a set of container ``id``s) and ``depth`` make this safe on
+    self-referential or deeply-nested structures: a cycle renders ``[...]`` /
+    ``{...}`` (matching Ruby) instead of recursing forever, and depth is capped
+    at :data:`_MAX_DISPLAY_DEPTH` so a deep acyclic structure cannot blow the
+    stack.  Both keep the never-raise invariant."""
+    if seen is None:
+        seen = set()
+    if v is None:
+        return "nil"
+    if isinstance(v, bool):
+        return "true" if v else "false"
+    if isinstance(v, Symbol):
+        return ":" + v.name
+    if isinstance(v, str):
+        return '"' + v + '"'
+    if isinstance(v, list):
+        if id(v) in seen or depth > _MAX_DISPLAY_DEPTH:
+            return "[...]"
+        seen.add(id(v))
+        body = ", ".join(_ruby_inspect(item, seen, depth + 1) for item in v)
+        seen.discard(id(v))
+        return "[" + body + "]"
+    if isinstance(v, dict):
+        if id(v) in seen or depth > _MAX_DISPLAY_DEPTH:
+            return "{...}"
+        seen.add(id(v))
+        body = ", ".join(
+            f"{_ruby_inspect(k, seen, depth + 1)}=>{_ruby_inspect(val, seen, depth + 1)}"
+            for k, val in v.items()
+        )
+        seen.discard(id(v))
+        return "{" + body + "}"
+    return str(v)
+
+
+# ── Numeric (Integer / Float) catalog ────────────────────────────────────────
+
+
+# Bit-length budget bounding the size of values ``**``/``pow`` will materialise
+# and ``digits`` will walk.  Exponents come from untrusted input (e.g.
+# ``gets.to_i``), and Python ints are arbitrary precision, so ``2 ** (10 ** 9)``
+# would allocate ~125 MB and block the interpreter.  ~1M bits (~128 KB / ~315k
+# decimal digits) is far above any legitimate use yet bounds a hostile operand.
+# Mirrors the ``String#*`` ``_MAX_REPEAT_LEN`` precedent.
+_MAX_POW_BITS = 1 << 20
+
+# Recursion bound for ``to_s``/``inspect``/``join`` on nested containers; a
+# deeply-nested (or — caught separately by identity tracking — cyclic) structure
+# would otherwise blow the Python stack (``RecursionError`` reaches the OO
+# surface, violating the never-raise invariant).
+_MAX_DISPLAY_DEPTH = 100
+
+
+def _ruby_round(x: float) -> int:
+    """Ruby ``Float#round`` (no digits): round half **away from zero** — unlike
+    Python's banker's rounding, ``2.5.round == 3`` and ``-2.5.round == -3``."""
+    return math.floor(x + 0.5) if x >= 0 else math.ceil(x - 0.5)
+
+
+def _safe_pow(base: Val, exp: Val) -> Val:
+    """``base ** exp`` with a bignum guard.  An integer result whose approximate
+    bit-length exceeds :data:`_MAX_POW_BITS` is refused (returns ``0``) rather
+    than allocating gigabytes; a float overflow returns ``inf`` instead of
+    raising — both honour the never-raise-on-the-OO-surface invariant."""
+    if isinstance(base, int) and isinstance(exp, int):
+        if exp > 0 and base not in (0, 1, -1) and exp * base.bit_length() > _MAX_POW_BITS:
+            return 0
+        return base ** exp
+    try:
+        return base ** exp
+    except OverflowError:
+        return math.inf
+
+
+def _digits(n: int) -> list[int]:
+    """Ruby ``Integer#digits``: base-10 digits, least-significant first.  A
+    hostile bignum past :data:`_MAX_POW_BITS` is refused (``[0]``) so it cannot
+    build a multi-hundred-megabyte list."""
+    n = abs(n)
+    if n == 0 or n.bit_length() > _MAX_POW_BITS:
+        return [0]
+    out: list[int] = []
+    while n > 0:
+        out.append(n % 10)
+        n //= 10
+    return out
+
+
+def _numeric_method(recv: Val, name: str, args: list[Val]) -> Val:
+    """Non-block ``Integer``/``Float`` methods.  Returns :data:`_MISS` if ``name``
+    is not a catalogued numeric method."""
+    # ``int()`` raises ``OverflowError``/``ValueError`` on ``inf``/``nan``; the
+    # int-coercing methods below degrade to a safe value there rather than
+    # raising (never-raise-on-the-OO-surface invariant).
+    if isinstance(recv, float) and not math.isfinite(recv):
+        if name == "to_i":
+            return 0
+        if name in ("even?", "odd?"):
+            return False
+        if name == "gcd":
+            return 0
+    if name == "abs":
+        return abs(recv)
+    if name == "to_i":
+        return int(recv)
+    if name == "to_f":
+        return float(recv)
+    if name == "even?":
+        return int(recv) % 2 == 0
+    if name == "odd?":
+        return int(recv) % 2 != 0
+    if name == "zero?":
+        return recv == 0
+    if name == "positive?":
+        return recv > 0
+    if name == "negative?":
+        return recv < 0
+    if name in ("succ", "next"):
+        return recv + 1
+    if name == "pred":
+        return recv - 1
+    # ``floor``/``ceil``/``round`` raise on a non-finite float in Python; return
+    # the receiver unchanged there (never-raise floor for ``inf``/``nan``).
+    if name == "floor":
+        return recv if isinstance(recv, float) and not math.isfinite(recv) else math.floor(recv)
+    if name == "ceil":
+        return recv if isinstance(recv, float) and not math.isfinite(recv) else math.ceil(recv)
+    if name == "round":
+        if isinstance(recv, int) or (isinstance(recv, float) and not math.isfinite(recv)):
+            return recv
+        return _ruby_round(recv)
+    if name == "gcd":
+        return math.gcd(int(recv), int(args[0]))
+    if name in ("pow", "**"):
+        return _safe_pow(recv, args[0])
+    if name == "digits":
+        if isinstance(recv, float) and not math.isfinite(recv):
+            return [0]
+        return _digits(int(recv))
+    return _MISS
+
+
+def _numeric_block_method(recv: Val, name: str, args: list[Val], block: Closure) -> Val:
+    """Block-taking ``Integer`` methods (``times``/``upto``/``downto``/``step``);
+    each returns the receiver.  Returns :data:`_MISS` otherwise."""
+    if name == "times":
+        for i in range(int(recv)):
+            apply(block, [i])
+        return recv
+    if name == "upto":
+        for i in range(int(recv), int(args[0]) + 1):
+            apply(block, [i])
+        return recv
+    if name == "downto":
+        for i in range(int(recv), int(args[0]) - 1, -1):
+            apply(block, [i])
+        return recv
+    if name == "step":
+        limit = args[0]
+        stride = args[1] if len(args) > 1 else 1
+        value = recv
+        if stride > 0:
+            while value <= limit:
+                apply(block, [value])
+                value += stride
+        elif stride < 0:
+            while value >= limit:
+                apply(block, [value])
+                value += stride
+        return recv
+    return _MISS
+
+
+# ── Symbol catalog ───────────────────────────────────────────────────────────
+
+
+def _symbol_method(recv: Symbol, name: str, args: list[Val]) -> Val:
+    """``Symbol`` methods.  Returns :data:`_MISS` if ``name`` is not catalogued.
+    ``upcase``/``downcase`` return a *new* interned symbol (Ruby semantics)."""
+    if name == "to_s":
+        return recv.name
+    if name == "to_sym":
+        return recv
+    if name in ("length", "size"):
+        return len(recv.name)
+    if name == "upcase":
+        return intern(recv.name.upper())
+    if name == "downcase":
+        return intern(recv.name.lower())
+    if name == "inspect":
+        return ":" + recv.name
+    if name == "empty?":
+        return len(recv.name) == 0
+    return _MISS
+
+
 def call_method(recv: Val, name: str, *args: Val) -> Val:
     """Dispatch method ``name`` on ``recv``.
 
@@ -821,6 +1114,22 @@ def call_method(recv: Val, name: str, *args: Val) -> Val:
             if result is not _MISS:
                 return result
         result = _string_method(recv, name, arg_list)
+        if result is not _MISS:
+            return result
+    elif isinstance(recv, Symbol):
+        result = _symbol_method(recv, name, arg_list)
+        if result is not _MISS:
+            return result
+    elif isinstance(recv, bool):
+        # bool is a subclass of int — skip the numeric catalog so True/False
+        # resolve only the universal Object methods (true.to_s == "true").
+        pass
+    elif isinstance(recv, (int, float)):
+        if name in _NUMERIC_BLOCK_METHODS and arg_list and isinstance(arg_list[-1], Closure):
+            result = _numeric_block_method(recv, name, arg_list[:-1], arg_list[-1])
+            if result is not _MISS:
+                return result
+        result = _numeric_method(recv, name, arg_list)
         if result is not _MISS:
             return result
     elif isinstance(recv, list):

--- a/code/packages/python/sir-runtime-oop/tests/test_oop.py
+++ b/code/packages/python/sir-runtime-oop/tests/test_oop.py
@@ -475,3 +475,147 @@ def test_string_respond_to_and_nil_floor() -> None:
     # Universal Object methods still resolve on a String receiver.
     assert oop.call_method("x", "nil?") is False
     assert oop.call_method("x", "class") == "String"
+
+
+# ── built-in method catalog: Numeric (Integer/Float) (M1c) ────────────────────
+
+
+def test_numeric_predicates_and_sign() -> None:
+    assert oop.call_method(4, "even?") is True
+    assert oop.call_method(3, "odd?") is True
+    assert oop.call_method(0, "zero?") is True
+    assert oop.call_method(5, "positive?") is True
+    assert oop.call_method(-5, "negative?") is True
+    assert oop.call_method(-7, "abs") == 7
+    assert oop.call_method(-3.5, "abs") == 3.5
+
+
+def test_numeric_conversions_and_steps() -> None:
+    assert oop.call_method(3.9, "to_i") == 3
+    assert oop.call_method(4, "to_f") == 4.0
+    assert oop.call_method(5, "succ") == 6
+    assert oop.call_method(5, "next") == 6
+    assert oop.call_method(5, "pred") == 4
+
+
+def test_numeric_floor_ceil_round() -> None:
+    assert oop.call_method(3.2, "floor") == 3
+    assert oop.call_method(3.2, "ceil") == 4
+    assert oop.call_method(7, "floor") == 7
+    # Ruby rounds half away from zero (unlike Python banker's rounding).
+    assert oop.call_method(2.5, "round") == 3
+    assert oop.call_method(-2.5, "round") == -3
+    assert oop.call_method(5, "round") == 5
+
+
+def test_numeric_gcd_pow_digits() -> None:
+    assert oop.call_method(12, "gcd", 18) == 6
+    assert oop.call_method(2, "**", 10) == 1024
+    assert oop.call_method(2, "pow", 5) == 32
+    assert oop.call_method(123, "digits") == [3, 2, 1]
+    assert oop.call_method(0, "digits") == [0]
+
+
+def test_numeric_to_s() -> None:
+    assert oop.call_method(42, "to_s") == "42"
+    assert oop.call_method(3.14, "to_s") == "3.14"
+    assert oop.call_method(7, "inspect") == "7"
+
+
+def test_numeric_block_times_upto_downto_step() -> None:
+    seen: list[Val] = []
+    assert oop.call_method(3, "times", Closure(seen.append)) == 3
+    assert seen == [0, 1, 2]
+    up: list[Val] = []
+    oop.call_method(1, "upto", 4, Closure(up.append))
+    assert up == [1, 2, 3, 4]
+    down: list[Val] = []
+    oop.call_method(3, "downto", 1, Closure(down.append))
+    assert down == [3, 2, 1]
+    step: list[Val] = []
+    oop.call_method(0, "step", 10, 5, Closure(step.append))
+    assert step == [0, 5, 10]
+
+
+def test_numeric_respond_to_and_nil_floor() -> None:
+    assert oop.call_method(5, "respond_to?", "even?") is True
+    assert oop.call_method(5, "respond_to?", "times") is True
+    assert oop.call_method(5, "respond_to?", "bit_length") is False
+    assert oop.call_method(5, "bit_length") is None
+    # A block method called without a block bottoms out at the nil floor.
+    assert oop.call_method(5, "times") is None
+
+
+# ── built-in method catalog: Symbol (M1c) ─────────────────────────────────────
+
+
+def test_symbol_methods() -> None:
+    sym = oop.call_method("hello", "to_sym")
+    assert oop.call_method(sym, "to_s") == "hello"
+    assert oop.call_method(sym, "length") == 5
+    assert oop.call_method(sym, "size") == 5
+    assert oop.call_method(sym, "inspect") == ":hello"
+    assert oop.call_method(sym, "empty?") is False
+    up = oop.call_method(sym, "upcase")
+    assert getattr(up, "name", None) == "HELLO"
+    down = oop.call_method(oop.call_method("ABC", "to_sym"), "downcase")
+    assert getattr(down, "name", None) == "abc"
+    assert oop.call_method(sym, "to_sym") is sym
+
+
+# ── built-in method catalog: nil / true / false + to_s/inspect (M1c) ──────────
+
+
+def test_nil_true_false_to_s_inspect() -> None:
+    assert oop.call_method(None, "to_s") == ""
+    assert oop.call_method(None, "inspect") == "nil"
+    assert oop.call_method(None, "to_a") == []
+    assert oop.call_method(True, "to_s") == "true"
+    assert oop.call_method(False, "to_s") == "false"
+    assert oop.call_method(True, "inspect") == "true"
+    # bool resolves only Object methods, never the numeric catalog.
+    assert oop.call_method(True, "respond_to?", "even?") is False
+    assert oop.call_method(True, "even?") is None
+
+
+def test_object_to_s_inspect_collections() -> None:
+    assert oop.call_method([1, 2, 3], "to_s") == "[1, 2, 3]"
+    assert oop.call_method(["a", "b"], "inspect") == '["a", "b"]'
+    assert oop.call_method("hi", "inspect") == '"hi"'
+    assert oop.call_method("hi", "to_s") == "hi"
+
+
+def test_array_join() -> None:
+    assert oop.call_method([1, 2, 3], "join") == "123"
+    assert oop.call_method([1, 2, 3], "join", "-") == "1-2-3"
+    assert oop.call_method(["a", "b"], "join", ", ") == "a, b"
+
+
+def test_pow_and_digits_bound_hostile_bignums() -> None:
+    # A hostile exponent would allocate gigabytes; pow refuses (0) rather than
+    # hanging, and digits never builds a giant list — neither raises.
+    assert oop.call_method(2, "**", 10**9) == 0
+    assert oop.call_method(2, "pow", 64) == 2**64  # legitimate values still work
+    over_budget = 1 << (1 << 20)  # a >1M-bit integer, past the digits budget
+    assert oop.call_method(over_budget, "digits") == [0]  # refused
+    assert oop.call_method(123, "digits") == [3, 2, 1]
+
+
+def test_numeric_methods_never_raise_on_non_finite() -> None:
+    inf = float("inf")
+    # int-coercing methods degrade gracefully on inf/nan instead of raising.
+    assert oop.call_method(inf, "to_i") == 0
+    assert oop.call_method(inf, "even?") is False
+    assert oop.call_method(inf, "gcd", 6) == 0
+    assert oop.call_method(inf, "floor") == inf
+    assert oop.call_method(inf, "round") == inf
+    assert oop.call_method(inf, "digits") == [0]
+
+
+def test_inspect_handles_cycles_without_raising() -> None:
+    a: list[Val] = []
+    a.append(a)  # self-referential array
+    assert oop.call_method(a, "inspect") == "[[...]]"
+    h: dict[Val, Val] = {}
+    h["self"] = h
+    assert oop.call_method(h, "inspect") == '{"self"=>{...}}'

--- a/code/packages/typescript/sir-runtime-oop/CHANGELOG.md
+++ b/code/packages/typescript/sir-runtime-oop/CHANGELOG.md
@@ -2,6 +2,47 @@
 
 All notable changes to `@coding-adventures/sir-runtime-oop` are documented here.
 
+## [0.1.5] - 2026-06-22
+
+### Added
+
+Built-in method dispatch, part 5 — the **`Integer`/`Float`**, **`Symbol`**, and
+**`nil`/`true`/`false`** catalogs (per `code/specs/sir-method-dispatch.md`, item
+M1c), completing the M1c primitive surface:
+
+- **Numeric** (`number`): `abs`, `to_i`, `to_f`, `even?`, `odd?`, `zero?`,
+  `positive?`, `negative?`, `succ`/`next`, `pred`, `floor`, `ceil`, `round`
+  (half **away from zero**, unlike JS `Math.round`), `gcd`, `pow`/`**`, `digits`;
+  block forms `times`, `upto`, `downto`, `step`.
+- **Symbol** (`sir-runtime-core` `Sym`): `to_s`, `to_sym`, `length`/`size`,
+  `upcase`/`downcase` (return a new interned symbol), `inspect`, `empty?`.
+- **`to_s`/`inspect` are now universal `Object` methods** (Ruby display forms):
+  `nil.to_s == ""` / `nil.inspect == "nil"`, `true.to_s == "true"`, numbers and
+  symbols print faithfully, and an `Array`/`Map` renders `"[1, 2]"` / `"{:k=>v}"`.
+  This means **`null`/`true`/`false` need no catalog of their own** (`nil.to_a`
+  already returns `[]`). Added **`Array#join`** (elements via `to_s`, default sep
+  `""`).
+- `boolean` is a distinct `typeof` from `number`, so `true`/`false` resolve only
+  the `Object` methods, never the numeric catalog.
+
+`respond_to?` reports each new catalog honestly; out-of-catalog stays `null`.
+
+### Security / robustness
+
+- **`digits` guards a non-finite receiver.** `2 ** 1e9` saturates to `Infinity`
+  in IEEE-754; `digits(Infinity)` would otherwise spin forever, so it now returns
+  `[0]`. (Integer `**`/`pow` saturate to `Infinity` in O(1) — no bignum DoS as in
+  the Python backend.)
+- **`to_s`/`inspect`/`join` are cycle- and depth-safe.** A self-referential
+  `Array`/`Map` renders `[...]`/`{...}` (Ruby's behaviour) and depth is capped, so
+  a cyclic or deeply-nested structure can no longer overflow the stack.
+
+### Known v0 limitation
+
+JavaScript cannot distinguish `3.0` from `3` (both `number`), so a whole-valued
+Ruby `Float` prints as an integer via `to_s`/`inspect` — documented, matching the
+existing `classOf` `Integer`/`Float` split.
+
 ## [0.1.4] - 2026-06-22
 
 ### Added

--- a/code/packages/typescript/sir-runtime-oop/README.md
+++ b/code/packages/typescript/sir-runtime-oop/README.md
@@ -60,8 +60,14 @@ methods `each`, `each_with_index`, `map`/`collect`, `select`/`filter`, `reject`,
 `select`/…); and (item **M1c**) the **`String`** catalog (`length`,
 `upcase`/`downcase`/`capitalize`, `reverse`, `strip`/`lstrip`/`rstrip`, `chomp`,
 `chars`/`bytes`, `split`, `include?`/`start_with?`/`end_with?`/`index`, `replace`,
-`sub`/`gsub` *literal*, `to_i`/`to_f`/`to_sym`, `empty?`, `*`/`+`, `each_char`).
-The Numeric/Symbol catalogs land in follow-up releases.
+`sub`/`gsub` *literal*, `to_i`/`to_f`/`to_sym`, `empty?`, `*`/`+`, `each_char`);
+and (item **M1c**) the **`Integer`/`Float`** catalog (`abs`, `to_i`/`to_f`,
+`even?`/`odd?`/`zero?`/`positive?`/`negative?`, `succ`/`pred`,
+`floor`/`ceil`/`round`, `gcd`, `pow`/`**`, `digits`, and block
+`times`/`upto`/`downto`/`step`), the **`Symbol`** catalog
+(`to_s`/`to_sym`/`length`/`upcase`/`downcase`/`inspect`), and universal
+**`to_s`/`inspect`** Ruby display forms (so `null`/`true`/`false` need no catalog)
+plus **`Array#join`**.
 
 ## Honest v0 limitation
 

--- a/code/packages/typescript/sir-runtime-oop/src/index.ts
+++ b/code/packages/typescript/sir-runtime-oop/src/index.ts
@@ -38,7 +38,7 @@
 // reaches us as a trailing `Closure` from sir-runtime-core; `apply` calls it with
 // proc-lenient arity, and `truthy` applies SIR truthiness (only `false`/`nil` are
 // falsy) to predicate results.
-import { apply, Closure, intern, truthy } from "@coding-adventures/sir-runtime-core";
+import { apply, Closure, intern, isSymbol, truthy } from "@coding-adventures/sir-runtime-core";
 
 /**
  * The SIR universal value type at this package's boundary.  Kept as `unknown`'s
@@ -226,6 +226,10 @@ export function defineMethod(name: string, fn: (recv: Val, args: Val[]) => Val):
 // from a catalog method that legitimately returns `null` (Ruby `nil`).
 const MISS: unique symbol = Symbol("sir-oop-miss");
 
+// `to_s`/`inspect` render Ruby display forms (see `rubyToS`/`rubyInspect`); they
+// live here so `null`/`true`/`false` need no catalog of their own
+// (`nil.to_s == ""`, `true.to_s == "true"`, `nil.inspect == "nil"`), with
+// `nil.to_a == []` handled below.
 const OBJECT_METHODS = new Set<string>([
   "nil?",
   "==",
@@ -238,6 +242,8 @@ const OBJECT_METHODS = new Set<string>([
   "clone",
   "itself",
   "to_a",
+  "to_s",
+  "inspect",
 ]);
 
 // Non-block `Array` methods (M1a); block methods land in a later PR, kept absent
@@ -267,6 +273,7 @@ const ARRAY_METHODS = new Set<string>([
   "compact",
   "empty?",
   "to_a",
+  "join",
 ]);
 
 // Block-taking `Array`/`Enumerable` methods (M1b); each invokes a trailing
@@ -363,6 +370,46 @@ const STRING_METHODS = new Set<string>([
 // Block-taking `String` methods (M1c); `each_char` yields one character.
 const STRING_BLOCK_METHODS = new Set<string>(["each_char"]);
 
+// Non-block `Integer`/`Float` methods (M1c).  Both are JS `number`; `boolean` is
+// a *separate* `typeof`, so `callMethod` routes `true`/`false` to the universal
+// `Object` methods (`true.to_s == "true"`) and never into this catalog.
+const NUMERIC_METHODS = new Set<string>([
+  "abs",
+  "to_i",
+  "to_f",
+  "even?",
+  "odd?",
+  "zero?",
+  "positive?",
+  "negative?",
+  "succ",
+  "next",
+  "pred",
+  "floor",
+  "ceil",
+  "round",
+  "gcd",
+  "pow",
+  "**",
+  "digits",
+]);
+
+// Block-taking `Integer` methods (M1c): each invokes the block N times.
+const NUMERIC_BLOCK_METHODS = new Set<string>(["times", "upto", "downto", "step"]);
+
+// `Symbol` methods (M1c). A Ruby `Symbol` is a sir-runtime-core `Sym`;
+// `upcase`/`downcase` return a *new* interned symbol.
+const SYMBOL_METHODS = new Set<string>([
+  "to_s",
+  "to_sym",
+  "length",
+  "size",
+  "upcase",
+  "downcase",
+  "inspect",
+  "empty?",
+]);
+
 /** SIR value equality used by `include?`/`index`/`==` — `===` for primitives,
  * structural for arrays and `Map`s (Ruby `==` is deep). */
 function valEq(a: Val, b: Val): boolean {
@@ -398,6 +445,14 @@ function respondsTo(recv: Val, name: string): boolean {
   if (methods.has(name)) return true;
   if (OBJECT_METHODS.has(name)) return true;
   if (typeof recv === "string" && (STRING_METHODS.has(name) || STRING_BLOCK_METHODS.has(name))) {
+    return true;
+  }
+  if (isSymbol(recv) && SYMBOL_METHODS.has(name)) return true;
+  // `boolean` is a distinct typeof — bools resolve only the Object methods above.
+  if (
+    typeof recv === "number" &&
+    (NUMERIC_METHODS.has(name) || NUMERIC_BLOCK_METHODS.has(name))
+  ) {
     return true;
   }
   if (Array.isArray(recv) && (ARRAY_METHODS.has(name) || ARRAY_BLOCK_METHODS.has(name))) {
@@ -461,6 +516,10 @@ function objectMethod(recv: Val, name: string, args: Val[]): Val | typeof MISS {
       if (recv === null || recv === undefined) return [];
       if (Array.isArray(recv)) return recv;
       return MISS;
+    case "to_s":
+      return rubyToS(recv);
+    case "inspect":
+      return rubyInspect(recv);
     default:
       return MISS;
   }
@@ -525,6 +584,11 @@ function arrayMethod(recv: Val[], name: string, args: Val[]): Val | typeof MISS 
       return recv.length === 0;
     case "to_a":
       return recv;
+    case "join": {
+      // Ruby `Array#join`: elements rendered with `to_s` (default sep "").
+      const sep = args.length > 0 ? args[0] : "";
+      return recv.map((item: Val) => rubyToS(item)).join(sep);
+    }
     default:
       return MISS;
   }
@@ -807,6 +871,195 @@ function stringBlockMethod(recv: string, name: string, block: Closure): Val | ty
   }
 }
 
+// ── Ruby display forms (to_s / inspect) ──────────────────────────────────────
+//
+// sir-runtime-core's `toDisplay` renders *Lisp* forms (`nil`, `#t`, `#f`), so it
+// is wrong for Ruby's `to_s`/`inspect`.  These helpers implement Ruby's surface:
+// `nil.to_s == ""` but `nil.inspect == "nil"`; booleans print `true`/`false`; a
+// symbol's `to_s` is its bare name and `inspect` prefixes `:`; an Array's `to_s`
+// equals its `inspect` (`"[1, 2]"`); a Hash (Map) renders `{:k=>v}`.  String
+// escaping in `inspect` is the v0 naive form (wrap in quotes; no escaping yet).
+//
+// NB: JS cannot distinguish `3.0` from `3` (both `number`, `Number.isInteger`),
+// so a whole-valued Float prints as an integer — a documented v0 limitation.
+
+function rubyToS(v: Val): string {
+  if (v === null || v === undefined) return "";
+  if (typeof v === "boolean") return v ? "true" : "false";
+  if (isSymbol(v)) return v.name as string;
+  if (typeof v === "string") return v;
+  if (Array.isArray(v) || v instanceof Map) return rubyInspect(v);
+  return String(v);
+}
+
+/** `seen` (a set of container references) and `depth` make this safe on
+ * self-referential or deeply-nested structures: a cycle renders `[...]` /
+ * `{...}` (matching Ruby) instead of recursing forever, and depth is capped at
+ * `MAX_DISPLAY_DEPTH` so a deep acyclic structure cannot overflow the stack. */
+function rubyInspect(v: Val, seen: Set<object> = new Set<object>(), depth = 0): string {
+  if (v === null || v === undefined) return "nil";
+  if (typeof v === "boolean") return v ? "true" : "false";
+  if (isSymbol(v)) return ":" + (v.name as string);
+  if (typeof v === "string") return '"' + v + '"';
+  if (Array.isArray(v)) {
+    if (seen.has(v) || depth > MAX_DISPLAY_DEPTH) return "[...]";
+    seen.add(v);
+    const body = v.map((item: Val) => rubyInspect(item, seen, depth + 1)).join(", ");
+    seen.delete(v);
+    return "[" + body + "]";
+  }
+  if (v instanceof Map) {
+    if (seen.has(v) || depth > MAX_DISPLAY_DEPTH) return "{...}";
+    seen.add(v);
+    const body = [...v]
+      .map(([k, val]: [Val, Val]) =>
+        `${rubyInspect(k, seen, depth + 1)}=>${rubyInspect(val, seen, depth + 1)}`,
+      )
+      .join(", ");
+    seen.delete(v);
+    return "{" + body + "}";
+  }
+  return String(v);
+}
+
+// ── Numeric (Integer / Float) catalog ────────────────────────────────────────
+
+function gcdInt(a: number, b: number): number {
+  let x = Math.abs(Math.trunc(a));
+  let y = Math.abs(Math.trunc(b));
+  while (y !== 0) {
+    [x, y] = [y, x % y];
+  }
+  return x;
+}
+
+// Recursion bound for `to_s`/`inspect`/`join` on nested containers (cycles are
+// caught separately by identity tracking); past it, render a placeholder rather
+// than overflowing the stack — honouring the never-crash invariant.
+const MAX_DISPLAY_DEPTH = 100;
+
+function digitsOf(n: number): number[] {
+  // `2 ** 1e9` saturates to `Infinity` in IEEE-754; guard so the loop below
+  // (which never reaches 0 for a non-finite value) cannot spin forever.
+  if (!Number.isFinite(n)) return [0];
+  let m = Math.abs(Math.trunc(n));
+  if (m === 0) return [0];
+  const out: number[] = [];
+  while (m > 0) {
+    out.push(m % 10);
+    m = Math.floor(m / 10);
+  }
+  return out;
+}
+
+/** Ruby round: half **away from zero** (`2.5 -> 3`, `-2.5 -> -3`), unlike JS
+ * `Math.round` which rounds half toward +Infinity. */
+function rubyRound(x: number): number {
+  return x >= 0 ? Math.floor(x + 0.5) : Math.ceil(x - 0.5);
+}
+
+/** Non-block `Integer`/`Float` methods.  Returns `MISS` if not catalogued. */
+function numericMethod(recv: number, name: string, args: Val[]): Val | typeof MISS {
+  switch (name) {
+    case "abs":
+      return Math.abs(recv);
+    case "to_i":
+      return Math.trunc(recv);
+    case "to_f":
+      return recv;
+    case "even?":
+      return recv % 2 === 0;
+    case "odd?":
+      return recv % 2 !== 0;
+    case "zero?":
+      return recv === 0;
+    case "positive?":
+      return recv > 0;
+    case "negative?":
+      return recv < 0;
+    case "succ":
+    case "next":
+      return recv + 1;
+    case "pred":
+      return recv - 1;
+    case "floor":
+      return Math.floor(recv);
+    case "ceil":
+      return Math.ceil(recv);
+    case "round":
+      return Number.isInteger(recv) ? recv : rubyRound(recv);
+    case "gcd":
+      return gcdInt(recv, args[0]);
+    case "pow":
+    case "**":
+      return recv ** args[0];
+    case "digits":
+      return digitsOf(recv);
+    default:
+      return MISS;
+  }
+}
+
+/** Block-taking `Integer` methods (`times`/`upto`/`downto`/`step`); each returns
+ * the receiver.  Returns `MISS` otherwise. */
+function numericBlockMethod(
+  recv: number,
+  name: string,
+  args: Val[],
+  block: Closure,
+): Val | typeof MISS {
+  switch (name) {
+    case "times":
+      for (let i = 0; i < Math.trunc(recv); i++) apply(block, [i]);
+      return recv;
+    case "upto":
+      for (let i = recv; i <= args[0]; i++) apply(block, [i]);
+      return recv;
+    case "downto":
+      for (let i = recv; i >= args[0]; i--) apply(block, [i]);
+      return recv;
+    case "step": {
+      const limit = args[0];
+      const stride = args.length > 1 ? args[1] : 1;
+      if (stride > 0) {
+        for (let i = recv; i <= limit; i += stride) apply(block, [i]);
+      } else if (stride < 0) {
+        for (let i = recv; i >= limit; i += stride) apply(block, [i]);
+      }
+      return recv;
+    }
+    default:
+      return MISS;
+  }
+}
+
+// ── Symbol catalog ───────────────────────────────────────────────────────────
+
+/** `Symbol` methods. `upcase`/`downcase` return a *new* interned symbol (Ruby
+ * semantics). Returns `MISS` if not catalogued. */
+function symbolMethod(recv: Val, name: string): Val | typeof MISS {
+  const sym = recv.name as string;
+  switch (name) {
+    case "to_s":
+      return sym;
+    case "to_sym":
+      return recv;
+    case "length":
+    case "size":
+      return sym.length;
+    case "upcase":
+      return intern(sym.toUpperCase());
+    case "downcase":
+      return intern(sym.toLowerCase());
+    case "inspect":
+      return ":" + sym;
+    case "empty?":
+      return sym.length === 0;
+    default:
+      return MISS;
+  }
+}
+
 /**
  * Dispatch method `name` on `recv`.  Resolution order:
  *
@@ -845,6 +1098,17 @@ export function callMethod(recv: Val, name: string, ...args: Val[]): Val {
     }
     const strResult = stringMethod(recv, name, args);
     if (strResult !== MISS) return strResult;
+  } else if (isSymbol(recv)) {
+    const symResult = symbolMethod(recv, name);
+    if (symResult !== MISS) return symResult;
+  } else if (typeof recv === "number") {
+    const last = args[args.length - 1];
+    if (NUMERIC_BLOCK_METHODS.has(name) && args.length > 0 && last instanceof Closure) {
+      const blkResult = numericBlockMethod(recv, name, args.slice(0, -1), last);
+      if (blkResult !== MISS) return blkResult;
+    }
+    const numResult = numericMethod(recv, name, args);
+    if (numResult !== MISS) return numResult;
   } else if (Array.isArray(recv)) {
     // A block method (each/map/…) is dispatched only when an actual trailing
     // Closure block is present; the block is split off the positional args.

--- a/code/packages/typescript/sir-runtime-oop/tests/oop.test.ts
+++ b/code/packages/typescript/sir-runtime-oop/tests/oop.test.ts
@@ -483,3 +483,126 @@ describe("built-in method catalog: String (M1c)", () => {
     expect(callMethod("x", "class")).toBe("String");
   });
 });
+
+describe("built-in method catalog: Numeric (Integer/Float) (M1c)", () => {
+  it("predicates and sign", () => {
+    expect(callMethod(4, "even?")).toBe(true);
+    expect(callMethod(3, "odd?")).toBe(true);
+    expect(callMethod(0, "zero?")).toBe(true);
+    expect(callMethod(5, "positive?")).toBe(true);
+    expect(callMethod(-5, "negative?")).toBe(true);
+    expect(callMethod(-7, "abs")).toBe(7);
+    expect(callMethod(-3.5, "abs")).toBe(3.5);
+  });
+
+  it("conversions and succ/pred", () => {
+    expect(callMethod(3.9, "to_i")).toBe(3);
+    expect(callMethod(4, "to_f")).toBe(4);
+    expect(callMethod(5, "succ")).toBe(6);
+    expect(callMethod(5, "next")).toBe(6);
+    expect(callMethod(5, "pred")).toBe(4);
+  });
+
+  it("floor / ceil / round (half away from zero)", () => {
+    expect(callMethod(3.2, "floor")).toBe(3);
+    expect(callMethod(3.2, "ceil")).toBe(4);
+    expect(callMethod(7, "floor")).toBe(7);
+    expect(callMethod(2.5, "round")).toBe(3);
+    expect(callMethod(-2.5, "round")).toBe(-3);
+    expect(callMethod(5, "round")).toBe(5);
+  });
+
+  it("gcd / pow / digits", () => {
+    expect(callMethod(12, "gcd", 18)).toBe(6);
+    expect(callMethod(2, "**", 10)).toBe(1024);
+    expect(callMethod(2, "pow", 5)).toBe(32);
+    expect(callMethod(123, "digits")).toEqual([3, 2, 1]);
+    expect(callMethod(0, "digits")).toEqual([0]);
+  });
+
+  it("to_s / inspect", () => {
+    expect(callMethod(42, "to_s")).toBe("42");
+    expect(callMethod(3.14, "to_s")).toBe("3.14");
+    expect(callMethod(7, "inspect")).toBe("7");
+  });
+
+  it("block times / upto / downto / step", () => {
+    const seen: Val[] = [];
+    expect(callMethod(3, "times", new Closure((i: Val) => seen.push(i)))).toBe(3);
+    expect(seen).toEqual([0, 1, 2]);
+    const up: Val[] = [];
+    callMethod(1, "upto", 4, new Closure((i: Val) => up.push(i)));
+    expect(up).toEqual([1, 2, 3, 4]);
+    const down: Val[] = [];
+    callMethod(3, "downto", 1, new Closure((i: Val) => down.push(i)));
+    expect(down).toEqual([3, 2, 1]);
+    const step: Val[] = [];
+    callMethod(0, "step", 10, 5, new Closure((i: Val) => step.push(i)));
+    expect(step).toEqual([0, 5, 10]);
+  });
+
+  it("respond_to? honesty + nil floor", () => {
+    expect(callMethod(5, "respond_to?", "even?")).toBe(true);
+    expect(callMethod(5, "respond_to?", "times")).toBe(true);
+    expect(callMethod(5, "respond_to?", "bit_length")).toBe(false);
+    expect(callMethod(5, "bit_length")).toBeNull();
+    expect(callMethod(5, "times")).toBeNull(); // block method without a block
+  });
+});
+
+describe("built-in method catalog: Symbol (M1c)", () => {
+  it("to_s / length / inspect / upcase / downcase", () => {
+    const sym = callMethod("hello", "to_sym");
+    expect(callMethod(sym, "to_s")).toBe("hello");
+    expect(callMethod(sym, "length")).toBe(5);
+    expect(callMethod(sym, "size")).toBe(5);
+    expect(callMethod(sym, "inspect")).toBe(":hello");
+    expect(callMethod(sym, "empty?")).toBe(false);
+    expect((callMethod(sym, "upcase") as { name: string }).name).toBe("HELLO");
+    const abc = callMethod("ABC", "to_sym");
+    expect((callMethod(abc, "downcase") as { name: string }).name).toBe("abc");
+    expect(callMethod(sym, "to_sym")).toBe(sym);
+  });
+});
+
+describe("nil / true / false + Object to_s/inspect (M1c)", () => {
+  it("nil / true / false display", () => {
+    expect(callMethod(null, "to_s")).toBe("");
+    expect(callMethod(null, "inspect")).toBe("nil");
+    expect(callMethod(null, "to_a")).toEqual([]);
+    expect(callMethod(true, "to_s")).toBe("true");
+    expect(callMethod(false, "to_s")).toBe("false");
+    expect(callMethod(true, "inspect")).toBe("true");
+    // boolean resolves only Object methods, never the numeric catalog.
+    expect(callMethod(true, "respond_to?", "even?")).toBe(false);
+    expect(callMethod(true, "even?")).toBeNull();
+  });
+
+  it("Object to_s / inspect on collections and strings", () => {
+    expect(callMethod([1, 2, 3], "to_s")).toBe("[1, 2, 3]");
+    expect(callMethod(["a", "b"], "inspect")).toBe('["a", "b"]');
+    expect(callMethod("hi", "inspect")).toBe('"hi"');
+    expect(callMethod("hi", "to_s")).toBe("hi");
+  });
+
+  it("Array#join", () => {
+    expect(callMethod([1, 2, 3], "join")).toBe("123");
+    expect(callMethod([1, 2, 3], "join", "-")).toBe("1-2-3");
+    expect(callMethod(["a", "b"], "join", ", ")).toBe("a, b");
+  });
+
+  it("digits on a non-finite number does not hang", () => {
+    // `2 ** 1e9` saturates to Infinity in JS; digits must not spin forever.
+    expect(callMethod(2 ** 1e9, "digits")).toEqual([0]);
+    expect(callMethod(123, "digits")).toEqual([3, 2, 1]);
+  });
+
+  it("inspect handles cycles without overflowing the stack", () => {
+    const a: Val[] = [];
+    a.push(a); // self-referential array
+    expect(callMethod(a, "inspect")).toBe("[[...]]");
+    const m = new Map<Val, Val>();
+    m.set("self", m);
+    expect(callMethod(m, "inspect")).toBe('{"self"=>{...}}');
+  });
+});


### PR DESCRIPTION
## M1c-Numeric — Ruby `Integer`/`Float`, `Symbol`, `nil`/`true`/`false` catalogs

Completes the **M1c** primitive surface of the M1 built-in method-dispatch work
(`code/specs/sir-method-dispatch.md`), adding the remaining scalar catalogs to
`sir-runtime-oop` in **both** backends (Python `oop.py`, TypeScript `index.ts`).
Follows the merged M1a (Array+Object), M1b (block Array), M1c-Hash (#6505), and
M1c-String (#6519).

### Methods

- **Numeric** (`int`/`float` | `number`): `abs`, `to_i`, `to_f`, `even?`, `odd?`,
  `zero?`, `positive?`, `negative?`, `succ`/`next`, `pred`, `floor`, `ceil`,
  `round` (half **away from zero**, the Ruby rule), `gcd`, `pow`/`**`, `digits`;
  block forms `times`, `upto`, `downto`, `step`.
- **Symbol**: `to_s`, `to_sym`, `length`/`size`, `upcase`/`downcase` (return a new
  interned symbol), `inspect`, `empty?`.
- **`to_s`/`inspect` are now universal `Object` methods** rendering Ruby display
  forms (`nil.to_s == ""` / `nil.inspect == "nil"`, `true.to_s == "true"`,
  `"[1, 2]"`, `"{:k=>v}"`), so **`nil`/`true`/`false` need no catalog of their
  own**. Added **`Array#join`** (elements via `to_s`).

`respond_to?` reports each catalog honestly; out-of-catalog stays nil/null.
Dispatch orders the `bool` check before the numeric one in Python (a `bool` is an
`int` subclass) so `True`/`False` resolve only the `Object` methods.

### Security / robustness (raised by `/security-review`, fixed before push)

- **Bignum DoS bounded.** A count/exponent can come from untrusted input and
  Python ints are arbitrary precision, so `2 ** (10 ** 9)` would allocate
  ~125 MB. `**` now refuses an integer result past a ~1M-bit budget (returns
  `0`), `digits` refuses over-budget bignums, float overflow returns `inf`. TS
  `**` saturates to `Infinity` natively (no bignum); `digits(Infinity)` is
  guarded so it cannot spin forever.
- **`to_s`/`inspect`/`join` are cycle- and depth-safe** in both backends: a
  self-referential `Array`/`Hash`/`Map` renders `[...]`/`{...}` (Ruby's
  behaviour) and depth is capped, so a cyclic or deeply-nested structure can no
  longer raise `RecursionError` / overflow the stack.
- **Python numeric methods never raise on `inf`/`nan`** (`to_i`/`even?`/`odd?`/
  `gcd`/`floor`/`ceil`/`round`/`digits` degrade gracefully), upholding the
  never-raise-on-the-OO-surface invariant.

Two security rounds: round 1 found 1 HIGH (bignum) + 1 MEDIUM (recursion); round
2 confirmed both remediated with no regressions — **PASSED**.

### Verification

- **Python:** 63 pytest, ruff, `mypy --strict` — clean; 96% coverage.
- **TypeScript:** 61 vitest, `tsc --noEmit` strict — clean.
- CHANGELOG bumped to 0.1.5 (both); READMEs updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
