### PR TITLE
feat(x86-simulator): run module-global programs locally via _twig_globals (S8)

### DIFF
--- a/code/packages/rust/x86-simulator/CHANGELOG.md
+++ b/code/packages/rust/x86-simulator/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Changelog — x86-simulator
 
+## 0.7.0 — 2026-06-22 — module globals (`_twig_globals`) run locally (x86-sim PR-S8)
+
+The harness now resolves the **`_twig_globals` data symbol**, so an x86_64
+program that reads/writes a module global runs on the simulator — closing the
+last gap before the `_twig_globals`-using programs (E6 captured scalars, O3 Oct
+`static`, AL6 ALGOL `own`) could only be executed on real Intel hardware / CI.
+
+- The x86_64 backend lowers `global_load`/`global_store` to `lea rax, [rip +
+  _twig_globals]` + a `mov` at `[rax + slot*8]`, recorded as a `PcRel32`
+  relocation against `_twig_globals`. The harness reserves a zeroed
+  **`_twig_globals` region** (512 × 8-byte slots) between the code and the heap
+  and patches that `PcRel32` to its base — the same PC-relative fixup the real
+  linker applies (`R_X86_64_PC32`), mirroring `code-packager`'s `.data` section.
+  Globals zero-init at load (the whole address space starts zeroed), which is
+  exactly the unwritten-global / `own` / `static` semantics.
+- The matrix harness (`lang_matrix_x86.rs`) now compiles each function with
+  `compile_function_with_globals` over a slot map collected from the module
+  (`collect_global_slots`, replicating `twig-aot`'s), instead of the
+  empty-global-map `compile_function_with_relocs`. Programs with no globals emit
+  no such reloc, so the pre-globals cells are unchanged.
+- **Executed proof:** the LANG-FULL **E6** program — a procedure `incr` sharing
+  an enclosing-block `counter` (`counter := 40; result := incr(2)`) — runs on
+  the **real x86_64 bytes** locally ⇒ exit **42**, the same value the matrix's
+  NativeAot column asserts. (Oct `static`/ALGOL `own` cells reuse this exact
+  path and can be added once their frontend PRs land on main.)
+
 ## 0.6.0 — 2026-06-21 — stdin (`getchar`) + Brainfuck cat runs locally (x86-sim PR-S6)
 
 Completes the Brainfuck story: the stdin-driven `,` programs now run on the

--- a/code/packages/rust/x86-simulator/Cargo.toml
+++ b/code/packages/rust/x86-simulator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "x86-simulator"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 description = "x86/x86-64 runtime simulator — decode + execute machine code, and run the x86_64-backend's emitted code locally (host-arch-independent)"
 
@@ -15,3 +15,5 @@ jit-core = { path = "../jit-core" }
 # for the LANG-FULL matrix's `NativeAot` x86_64 column.
 lang-aot = { path = "../lang-aot" }
 aot-core = { path = "../aot-core" }
+# For walking an `IIRModule` to assign module-global slots (E6/O3/AL6 globals).
+interpreter-ir = { path = "../interpreter-ir" }

--- a/code/packages/rust/x86-simulator/README.md
+++ b/code/packages/rust/x86-simulator/README.md
@@ -49,10 +49,14 @@ let exit_code = sim.run()?;   // executes the real x86_64 machine code
 ```
 
 The harness lays the function bytes into a flat sandboxed address space, patches
-internal `call` relocations, routes external calls (`__twig_alloc_bytes` via a
-bump heap, `putchar` / `print_i64` via captured I/O) to host shims, sets up a
-stack with a return sentinel, and runs from the entry — returning `rax & 0xFF`
-as the exit code (the same convention as `run_native` / `run_wasm`).
+internal `call` relocations, resolves the **`_twig_globals` data symbol** (a
+zeroed 512-slot region between the code and heap — the `PcRel32` `lea` to it is
+patched the same way the real linker would), routes external calls
+(`__twig_alloc_bytes` via a bump heap, `putchar` / `print_i64` via captured I/O)
+to host shims, sets up a stack with a return sentinel, and runs from the entry —
+returning `rax & 0xFF` as the exit code (the same convention as `run_native` /
+`run_wasm`). With `_twig_globals` support, programs that use **module globals**
+(LANG-FULL E6 captured scalars, O3 Oct `static`, AL6 ALGOL `own`) run locally.
 
 ## Running the LANG-FULL matrix's x86_64 column locally
 
@@ -62,10 +66,10 @@ as the exit code (the same convention as `run_native` / `run_wasm`).
 On an Apple-Silicon host the matrix's `NativeAot` cell only ever builds+runs the
 *aarch64* backend; this test exercises the **x86_64** column end-to-end —
 **locally on aarch64**, retro-verifying columns the matrix could previously
-execute only on x86 CI. The 21 cells span Twig (const/arithmetic/`define`),
+execute only on x86 CI. The cells span Twig (const/arithmetic/`define`),
 Nib (u8 wrap, `~` complement, unsigned division), ALGOL (procedure call,
 switch/computed-goto, signed `div`, E3 `real` SSE2 floats, E5 arrays straight-
-line and in a `for` loop), Oct (`out`, `~`), Dartmouth BASIC (`PRINT`,
+line and in a `for` loop, **E6 module globals**), Oct (`out`, `~`), Dartmouth BASIC (`PRINT`,
 `FOR`/`NEXT` — stdout-captured via the host shims), and Brainfuck (`.` over a
 byte tape, plus `,`-driven stdin: increment, echo, and cat — fed via
 `MachineCodeHarness::stdin`). Each new language exposed a missing opcode — the

--- a/code/packages/rust/x86-simulator/src/harness.rs
+++ b/code/packages/rust/x86-simulator/src/harness.rs
@@ -67,6 +67,19 @@ const STACK_BOTTOM: u64 = 0x8_0000; // heap may grow up to here
 const RETURN_SENTINEL: u64 = 0xDEAD_0000_0000_0000;
 const STEP_LIMIT: u64 = 10_000_000;
 
+/// The data symbol the x86_64 backend emits for module globals (LANG-FULL E6 /
+/// O3 / AL6). `global_load`/`global_store` lower to `lea rax, [rip +
+/// _twig_globals]` + `mov` at `[rax + slot*8]`, recorded as a `PcRel32`
+/// relocation against this symbol. On a real target the linker points it at a
+/// zeroed `.data`/`.bss` block (`code-packager`); the harness does the same.
+const GLOBALS_SYMBOL: &str = "_twig_globals";
+
+/// Size of the zeroed `_twig_globals` data region the harness reserves between
+/// the code and the heap — 512 eight-byte slots, far more than any matrix
+/// program declares. Globals zero-init at load (the whole address space starts
+/// zeroed), which is exactly the `own`/`static`/unwritten-global semantics.
+const GLOBALS_SIZE: u64 = 512 * 8;
+
 impl MachineCodeHarness {
     /// A fresh, empty harness.
     pub fn new() -> Self {
@@ -113,9 +126,18 @@ impl MachineCodeHarness {
 
         let entry_off = *fn_offset.get(entry).ok_or_else(|| BuildError::NoSuchEntry(entry.to_string()))?;
 
-        // 2. Resolve relocations: an internal call (symbol is a function in this
-        //    module) is patched so its decoded target lands on the callee; an
-        //    external call stays in the `externals` map for a host shim.
+        // The `_twig_globals` data region sits just past the code (16-aligned),
+        // and the heap starts past it. Its runtime address is needed to patch
+        // the RIP-relative `lea` that loads the globals base.
+        let globals_base = ((CODE_BASE + code.len() as u64) + 15) & !15;
+
+        // 2. Resolve relocations. Three dispositions, by symbol:
+        //    - a function in this module → an internal `call`, patch the rel32
+        //      so the decoded target lands on the callee;
+        //    - `_twig_globals` → a RIP-relative `lea` to the data region, patch
+        //      the disp32 to point at `globals_base`;
+        //    - anything else → an external runtime call, kept in `externals`
+        //      for a host shim.
         let mut externals: HashMap<usize, String> = HashMap::new();
         for (patch_off, symbol) in relocs {
             if let Some(&target) = fn_offset.get(&symbol) {
@@ -123,15 +145,24 @@ impl MachineCodeHarness {
                 let rel = (target as i64) - (patch_off as i64 + 4);
                 let bytes = (rel as i32).to_le_bytes();
                 code[patch_off..patch_off + 4].copy_from_slice(&bytes);
+            } else if symbol == GLOBALS_SYMBOL {
+                // disp32 = globals_base - next_ip, where next_ip is the runtime
+                // address just past the disp32 field: CODE_BASE + patch_off + 4.
+                // So `lea` loads `globals_base` into the register. Same PC-relative
+                // formula the linker applies for an `R_X86_64_PC32` against the
+                // `_twig_globals` data symbol.
+                let disp = (globals_base as i64) - (CODE_BASE as i64 + patch_off as i64 + 4);
+                let bytes = (disp as i32).to_le_bytes();
+                code[patch_off..patch_off + 4].copy_from_slice(&bytes);
             } else {
                 externals.insert(patch_off, symbol);
             }
         }
 
-        // 3. Lay out memory: code at CODE_BASE, then the bump heap up to
-        //    STACK_BOTTOM, then the stack from STACK_BOTTOM..STACK_TOP. The code
-        //    must fit below the heap window, else the layout is invalid.
-        let heap_base = ((CODE_BASE + code.len() as u64) + 15) & !15;
+        // 3. Lay out memory: code at CODE_BASE, then the zeroed `_twig_globals`
+        //    region, then the bump heap up to STACK_BOTTOM, then the stack from
+        //    STACK_BOTTOM..STACK_TOP. Everything must fit below the heap window.
+        let heap_base = ((globals_base + GLOBALS_SIZE) + 15) & !15;
         if heap_base >= STACK_BOTTOM {
             return Err(BuildError::CodeTooLarge { code_len: code.len(), capacity: STACK_BOTTOM - CODE_BASE });
         }

--- a/code/packages/rust/x86-simulator/tests/lang_matrix_x86.rs
+++ b/code/packages/rust/x86-simulator/tests/lang_matrix_x86.rs
@@ -19,12 +19,39 @@
 //! the x86_64 bytes* rather than the host's aarch64 bytes — a genuine retro-
 //! verification of E5 native arrays and E3 native floats on the x86_64 backend.
 
+use std::collections::HashMap;
+
 use aot_core::infer::infer_types;
 use aot_core::specialise::aot_specialise;
 use jit_core::backend::FunctionContext;
 use lang_aot::{compile_source_to_iir, Language};
-use x86_64_backend::{compile_function_with_relocs, X86_64Abi};
+use x86_64_backend::{compile_function_with_globals, X86_64Abi};
 use x86_simulator::harness::{MachineCodeHarness, Reloc};
+
+/// Assign each distinct module-global name (as it appears in a `global_load` /
+/// `global_store`) a stable 8-byte slot index, in first-seen order. This mirrors
+/// `twig-aot::collect_global_slots` — the x86_64 backend turns slot `i` into the
+/// byte offset `i*8` from the `_twig_globals` base, and the harness reserves a
+/// zeroed `_twig_globals` region the same `lea`/`mov` then addresses. Replicated
+/// here (a few lines) rather than taking a `twig-aot` dependency just for tests.
+fn collect_global_slots(module: &interpreter_ir::IIRModule) -> HashMap<String, usize> {
+    let mut slots = HashMap::new();
+    let mut next = 0usize;
+    for f in &module.functions {
+        for instr in &f.instructions {
+            if instr.op == "global_load" || instr.op == "global_store" {
+                if let Some(name) = instr.srcs.first().and_then(|o| o.as_str_lit()) {
+                    slots.entry(name.to_string()).or_insert_with(|| {
+                        let s = next;
+                        next += 1;
+                        s
+                    });
+                }
+            }
+        }
+    }
+    slots
+}
 
 /// A compiled function: its name, x86_64 machine-code bytes, and the external
 /// relocations (cross-function `call`s and runtime-symbol calls) the harness
@@ -57,6 +84,13 @@ fn compile_to_x86_functions(lang: Language, src: &str) -> (Vec<X86Function>, Str
     let module = compile_source_to_iir(lang, src, "matrix_x86")
         .expect("frontend should lower the matrix program to IIR");
 
+    // Module globals (E6/O3/AL6): each `global_load`/`global_store` name gets a
+    // slot; the backend lowers an access to `lea rax,[rip+_twig_globals]` + a
+    // `mov` at `[rax + slot*8]`, recorded as a `PcRel32` reloc the harness
+    // resolves to its zeroed `_twig_globals` region. Empty map ⇒ no global ops
+    // ⇒ no such reloc (the pre-globals programs are unchanged).
+    let global_slots = collect_global_slots(&module);
+
     let mut funcs = Vec::with_capacity(module.functions.len());
     for fn_ in &module.functions {
         let ctx = FunctionContext {
@@ -66,7 +100,7 @@ fn compile_to_x86_functions(lang: Language, src: &str) -> (Vec<X86Function>, Str
         };
         let inferred = infer_types(fn_);
         let cir = aot_specialise(fn_, Some(&inferred));
-        let (bytes, relocs) = compile_function_with_relocs(&ctx, &cir, X86_64Abi::SysV)
+        let (bytes, relocs) = compile_function_with_globals(&ctx, &cir, X86_64Abi::SysV, &global_slots)
             .expect("x86_64-backend should compile the specialised CIR");
         funcs.push(X86Function {
             name: fn_.name.clone(),
@@ -152,6 +186,28 @@ fn algol_procedure_call_runs_on_x86_sim() {
                sq := x * x; result := sq(7) end";
     assert_eq!(run_on_x86_sim(Language::Algol60, src), 49);
 }
+
+/// ALGOL 60 — a **module global** shared between a procedure and its enclosing
+/// block (LANG-FULL enabler **E6**).  `counter` is read+written by `incr` and
+/// seeded by the block, so the frontend materialises it as a `_twig_globals`
+/// slot: `incr` does `lea rax,[rip+_twig_globals]` + `mov`s at `[rax+0]`, the
+/// block likewise.  This is the FIRST x86-sim cell to exercise a `PcRel32`
+/// relocation against the globals data symbol — the harness resolves it to its
+/// zeroed `_twig_globals` region.  `counter := 40; result := incr(2)` ⇒ 42,
+/// run on the real x86_64 bytes locally (the same exit code the matrix's
+/// NativeAot column asserts for this E6 program).
+#[test]
+fn algol_module_global_runs_on_x86_sim() {
+    let src = "begin integer counter, result; \
+               integer procedure incr(x); value x; integer x; \
+                  incr := counter := counter + x; \
+               counter := 40; \
+               result := incr(2) end";
+    assert_eq!(run_on_x86_sim(Language::Algol60, src), 42);
+}
+// (An Oct `static` (O3) and ALGOL `own` (AL6) cell can be added once their
+// frontend PRs land on main; both reuse the exact same `_twig_globals` path
+// this E6 cell exercises, so the harness support added here already covers them.)
 
 /// ALGOL 60 — **E3 real arithmetic + equality** (`r := 2.5 * 2.0; if r = 5.0`
 /// ⇒ 42).  Runs the x86_64 backend's **SSE2** output (`movabs`/`movsd`/`mulsd`/

--- a/code/specs/x86-runtime-simulator.md
+++ b/code/specs/x86-runtime-simulator.md
@@ -179,7 +179,16 @@ This harness is what `lang_matrix.rs` calls to run the x86_64 column locally.
    Brainfuck IIR's negative-clamp halts a `,[.,]` cat at end-of-input. Three
    stdin Brainfuck cells (`,+.`/`,.,.`/`,[.,]`) run on the x86_64 column locally.
    No new opcode needed. (x86-simulator 0.6.0.)
-7. **S7 — 32-bit x86 (i386)**: operand/address-size handling + 32-bit decode, as
+7. **S8 — module globals (`_twig_globals`)**: ✅ done. The harness resolves the
+   `_twig_globals` data symbol — it reserves a zeroed 512-slot region between the
+   code and heap and patches the backend's `PcRel32` reloc (`lea rax, [rip +
+   _twig_globals]`) to its base, the same fixup the real linker applies. The
+   matrix harness now compiles with `compile_function_with_globals` over a slot
+   map collected from the module. Proof: the E6 program (`incr` sharing an
+   enclosing `counter`, `result := incr(2)`) runs on the x86_64 bytes locally ⇒
+   42. Unblocks running every `_twig_globals`-using program (E6/O3/AL6) locally.
+   (x86-simulator 0.7.0.)
+8. **S7 — 32-bit x86 (i386)**: operand/address-size handling + 32-bit decode, as
    educational coverage (not on the run-our-codegen critical path — no matrix
    program emits 32-bit x86, so it's unit-tested against hand-assembled bytes).
 


### PR DESCRIPTION
## x86-sim S8 — resolve the `_twig_globals` data symbol

The x86-simulator runs the LANG-FULL matrix's `NativeAot` x86_64 column **locally on aarch64** (no Intel hardware / CI round-trip). It covered every cell *except* those using **module globals** — the `_twig_globals` data symbol was unresolved, so the E6 captured-scalar / O3 Oct `static` / AL6 ALGOL `own` programs could only execute on real Intel hardware. This closes that gap.

### What changed (x86-simulator 0.7.0)
- The x86_64 backend lowers `global_load`/`global_store` to `lea rax, [rip + _twig_globals]` + a `mov` at `[rax + slot*8]`, recorded as a `PcRel32` relocation. The harness now **reserves a zeroed `_twig_globals` region** (512 × 8-byte slots) between the code and the heap, and patches that `PcRel32` to its base — the same PC-relative fixup the real linker applies (`R_X86_64_PC32`), mirroring `code-packager`'s `.data` section. Globals zero-init at load (the address space starts zeroed) = the unwritten-global / `own` / `static` semantics.
- The matrix harness compiles each function with `compile_function_with_globals` over a slot map collected from the module (`collect_global_slots`, replicating twig-aot's), instead of the empty-map `compile_function_with_relocs`. **No-globals programs emit no such reloc, so the pre-globals cells are byte-for-byte unchanged.**

### Executed proof
The LANG-FULL **E6** program — `incr` sharing an enclosing-block `counter` (`counter := 40; result := incr(2)`) — runs on the **real x86_64 bytes** on the simulator ⇒ exit **42**, the value the matrix's NativeAot column asserts. All 54 x86-simulator tests green.

### Verification
- New test `algol_module_global_runs_on_x86_sim` → 42.
- All existing cells (Twig/Nib/ALGOL/Oct/BASIC/Brainfuck + E3 floats + E5 arrays) unchanged and green.
- Security review PASSED (disp32 fixup bounded well within i32 by the `CodeTooLarge` guard; no OOB write — the `patch_offset+4 ≤ fn_len` invariant still guards the new branch; `Memory` bounds-checks every guest access as the sandbox boundary).

The Oct `static` (O3) and ALGOL `own` (AL6) cells reuse this exact path and can be added once their frontend PRs (#6532 / #6535) land on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)