### PR TITLE
feat(mycin-gi): batch — 4 high-yield GI/hepatobiliary biopsy findings (7→11 edges)

### DIFF
--- a/code/specs/data/mycin-2026/recall/gi-edges.adj
+++ b/code/specs/data/mycin-2026/recall/gi-edges.adj
@@ -97,4 +97,38 @@ rulebook gi_facts {
         source "PSC is histologically characterized by concentric, lamellar periductal fibrosis—often referred to as \"onion-skin\" fibrosis."
         locator "https://www.ncbi.nlm.nih.gov/books/NBK537181/"
         trust authoritative
+
+    % ------------------------------------------------------------------------
+    % BATCH: high-yield GI/hepatobiliary biopsy findings, each grounded to a
+    % self-contained verbatim NCBI Bookshelf span naming both the finding and
+    % the disease. (Declined — no single NBK self-contained span: noncaseating
+    % granulomas->Crohn [NBK says "Nonnecrotic" when naming Crohn], PAS-positive
+    % macrophages->Whipple [split sentences], ground-glass hepatocytes->HBV
+    % [no NBK uses "ground glass"]. Backlog, not stretched.)
+    % ------------------------------------------------------------------------
+
+    % Signet ring cells — diffuse-type gastric cancer.
+    relate biopsy_finding_in(signet_ring_cells, gastric_cancer)
+        source "Diffuse-type tumors exhibit markedly aberrant cells with little or no gland formation and occasionally contain signet ring cells (see Image. Diffuse Carcinoma of the Stomach) characterized by cytoplasmic mucin with an eccentrically placed nucleus (see Images. Diffuse Gastric Cancer and Signet Ring Carcinoma)."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK459142/"
+        trust authoritative
+
+    % Florid duct lesion — primary biliary cholangitis (page uses the former
+    % name "primary biliary cirrhosis").
+    relate biopsy_finding_in(florid_duct_lesion, primary_biliary_cholangitis)
+        source "Histopathological evidence of primary biliary cirrhosis (nonsuppurative destructive cholangitis or \"florid duct lesion\" and destruction of interlobular bile ducts with a predominance of lymphocytic infiltration)."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK459209/"
+        trust authoritative
+
+    % Cowdry type A intranuclear inclusions — HSV esophagitis (pathognomonic).
+    relate biopsy_finding_in(cowdry_a_inclusions, herpes_esophagitis)
+        source "Multinucleated giant cells with ballooning and degeneration of squamous cells with Cowdry type A inclusion is pathognomonic diagnosis finding for HSV esophagitis and Large cells with both intracytoplasmic inclusions and amphophilic intranuclear inclusions are seen in CMV esophagitis."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK442012/"
+        trust authoritative
+
+    % Pseudomembranes — pseudomembranous (C difficile) colitis.
+    relate biopsy_finding_in(pseudomembranes, pseudomembranous_colitis)
+        source "Colonoscopies of patients with pseudomembranous colitis demonstrate inflamed colonic mucosa characterized by raised yellowish, occasionally hemorrhagic nodules or plaques that congregate into widespread, pseudomembranes on the surface of the colonic mucosa."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK470319/"
+        trust authoritative
 }

--- a/code/specs/data/mycin-2026/recall/gi-recall.query.adj
+++ b/code/specs/data/mycin-2026/recall/gi-recall.query.adj
@@ -20,3 +20,8 @@ import "gi-edges.adj"
 ? biopsy_finding_in(eosinophils_15_per_hpf, $Disease)     % expect eosinophilic_esophagitis
 ? biopsy_finding_in(crypt_abscesses, $Disease)            % expect ulcerative_colitis (backfill)
 ? biopsy_finding_in(onion_skin_fibrosis, $Disease)        % expect primary_sclerosing_cholangitis
+% --- BATCH: high-yield GI/hepatobiliary biopsy findings ---
+? biopsy_finding_in(signet_ring_cells, $Disease)          % expect gastric_cancer (expand)
+? biopsy_finding_in(florid_duct_lesion, $Disease)         % expect primary_biliary_cholangitis (expand)
+? biopsy_finding_in(cowdry_a_inclusions, $Disease)        % expect herpes_esophagitis (expand)
+? biopsy_finding_in(pseudomembranes, $Disease)            % expect pseudomembranous_colitis (expand)

--- a/code/specs/data/mycin-2026/recall/test_gi_recall.py
+++ b/code/specs/data/mycin-2026/recall/test_gi_recall.py
@@ -36,6 +36,11 @@ EXPECTED = {
     "eosinophils_15_per_hpf": "eosinophilic_esophagitis",
     "crypt_abscesses": "ulcerative_colitis",            # primary-source backfill (NBK470312)
     "onion_skin_fibrosis": "primary_sclerosing_cholangitis",  # NBK537181 (PSC abbrev defined on page)
+    # --- BATCH: high-yield GI/hepatobiliary biopsy findings ---
+    "signet_ring_cells": "gastric_cancer",                # expand (NBK459142)
+    "florid_duct_lesion": "primary_biliary_cholangitis",  # expand (NBK459209)
+    "cowdry_a_inclusions": "herpes_esophagitis",          # expand (NBK442012)
+    "pseudomembranes": "pseudomembranous_colitis",        # expand (NBK470319)
 }
 REL = "biopsy_finding_in"
 VAR = "Disease"
@@ -99,8 +104,8 @@ def test_unknown_finding_abstains() -> None:
     fd, path = tempfile.mkstemp(suffix=".adj", prefix=".gi_q_", dir=HERE)
     try:
         with os.fdopen(fd, "w") as fh:
-            # signet_ring_cells is not in the library → must abstain
-            fh.write(f'import "gi-edges.adj"\n? {REL}(signet_ring_cells, ${VAR})\n')
+            # cobblestone_mucosa is not in the library → must abstain
+            fh.write(f'import "gi-edges.adj"\n? {REL}(cobblestone_mucosa, ${VAR})\n')
         res = _run(Path(path))
         r = res["recall"][0] if res["recall"] else None
         assert r is not None and r["abstained"], "an ungrounded finding must abstain"


### PR DESCRIPTION
## What

Expands the MYCIN-2026 **GI** recall library **7 → 11 grounded edges** with 4 high-yield biopsy/histology findings, each defended by a self-contained verbatim NCBI Bookshelf span naming both the finding and the disease.

| biopsy finding | disease | source |
|---|---|---|
| signet ring cells | gastric cancer (diffuse-type) | NBK459142 |
| florid duct lesion | primary biliary cholangitis | NBK459209 |
| Cowdry type A inclusions | HSV esophagitis | NBK442012 |
| pseudomembranes | pseudomembranous colitis | NBK470319 |

### Honestly declined (checked + documented, not stretched)
No single NCBI Bookshelf sentence names both endpoints:
- **noncaseating granulomas → Crohn** — NBK names Crohn with "Nonnecrotic granulomas", or says "noncaseating granuloma" without naming Crohn in the same sentence.
- **PAS-positive macrophages → Whipple** — NBK splits the two across sentences; the combined phrasing exists only in PMC journal articles (not a Bookshelf source).
- **ground-glass hepatocytes → hepatitis B** — no NCBI Bookshelf page uses the term "ground glass."

## Verify
- `test_gi_recall` **3/3** — the native adj-lang engine binds **all 11** diagnoses via the worked query file, each with an `authoritative` citation + real source span + `ncbi.nlm.nih.gov` locator; an off-vocabulary finding (cobblestone_mucosa) abstains.
- `ruff` clean; data-only security review passed.

Negative-control note: the abstention probe was `signet_ring_cells`, which this batch now grounds — repointed to `cobblestone_mucosa` so the test stays meaningful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)