### PR TITLE
test(x86-simulator): Oct `static` + ALGOL `own` global cells (O3/AL6 follow-up)

### DIFF
--- a/code/packages/rust/x86-simulator/CHANGELOG.md
+++ b/code/packages/rust/x86-simulator/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog — x86-simulator
 
+## 0.7.1 — 2026-06-22 — Oct `static` global cell (LANG-FULL O3 follow-up)
+
+Adds an executed matrix cell `oct_static_global_runs_on_x86_sim`: an Oct
+top-level `static counter` (LANG-FULL O3, merged) shared across functions —
+`bump()` increments it twice, `main` prints it via `out` ⇒ stdout `42`. Runs
+the real Oct frontend's x86_64 output on the simulator, exercising the
+`_twig_globals` data-region support added in 0.7.0 (S8) from a second frontend
+(the Oct counterpart to the ALGOL E6 cell). Test-only; no library change.
+
 ## 0.7.0 — 2026-06-22 — module globals (`_twig_globals`) run locally (x86-sim PR-S8)
 
 The harness now resolves the **`_twig_globals` data symbol**, so an x86_64

--- a/code/packages/rust/x86-simulator/Cargo.toml
+++ b/code/packages/rust/x86-simulator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "x86-simulator"
-version = "0.7.0"
+version = "0.7.1"
 edition = "2021"
 description = "x86/x86-64 runtime simulator — decode + execute machine code, and run the x86_64-backend's emitted code locally (host-arch-independent)"
 

--- a/code/packages/rust/x86-simulator/tests/lang_matrix_x86.rs
+++ b/code/packages/rust/x86-simulator/tests/lang_matrix_x86.rs
@@ -316,6 +316,23 @@ fn oct_complement_runs_on_x86_sim() {
     assert_eq!(out, "255");
 }
 
+/// Oct — a **`static` module global** (LANG-FULL O3) on the x86_64 backend.
+/// `counter` is a top-level `static` shared across functions: it lives in the
+/// `_twig_globals` data region (S8), `bump()` — a *separate* function —
+/// increments it twice, and `main` prints it (`out` → stdout) ⇒ `42`. This is
+/// the Oct counterpart to `algol_module_global_runs_on_x86_sim`: the same
+/// `lea [rip+_twig_globals]` + `mov [rax+slot*8]` lowering, exercised from a
+/// real Oct frontend's output on the simulator. A per-function register would
+/// print `40`; `42` proves the global persisted across the two `bump` calls.
+#[test]
+fn oct_static_global_runs_on_x86_sim() {
+    let src = "static counter: u8 = 40; \
+               fn bump() { counter = counter + 1; } \
+               fn main() { bump(); bump(); out(1, counter); }";
+    let (_code, out) = run_capturing_stdout(Language::Oct, src);
+    assert_eq!(out, "42");
+}
+
 /// Nib — **unsigned division** (`84 / 2` ⇒ exit 42).  The `div` op lowers to the
 /// x86 unsigned-division sequence `xor rdx,rdx; div rcx` — exercising the
 /// group-3 `0xF7 /6` end-to-end (S4's unit tests cover `div` in isolation; this


### PR DESCRIPTION
## Oct `static` module global, executed on the x86-simulator

A small follow-up now that both **S8** ([#6539](https://github.com/adhithyan15/coding-adventures/pull/6539), `_twig_globals` data-region support in the simulator) and **O3** ([#6532](https://github.com/adhithyan15/coding-adventures/pull/6532), Oct top-level `static` globals) have merged.

Adds the executed cell `oct_static_global_runs_on_x86_sim`:
```oct
static counter: u8 = 40;
fn bump() { counter = counter + 1; }   // a separate function
fn main() { bump(); bump(); out(1, counter); }
```
The real Oct frontend's **x86_64 machine code** runs on the simulator; `bump()` increments the shared `_twig_globals` slot twice and `main` prints it via `out` ⇒ stdout **42**. A per-function register would print 40; 42 proves the global persisted across the two calls.

This is the **Oct counterpart** to the existing `algol_module_global_runs_on_x86_sim` (E6) cell — same `lea [rip+_twig_globals]` + `mov [rax+slot*8]` lowering, exercised from a second frontend, locally on aarch64 with no Intel hardware.

**Test-only** (x86-simulator 0.7.1) — reuses the path S8 added; no library change. All x86-simulator tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)