### PR TITLE
feat(visicalc-qt): sort a range in the Qt demo

### DIFF
--- a/demo/visicalc-qt/InfiniteSheet.qml
+++ b/demo/visicalc-qt/InfiniteSheet.qml
@@ -285,6 +285,24 @@ Item {
                 }
                 Rectangle { Layout.preferredWidth: 1; Layout.fillHeight: true; Layout.topMargin: 4; Layout.bottomMargin: 4; color: sheet.cLine }
 
+                // ── Sort (reorder the budget block A1:E4 by the selected column) ──
+                // Each row moves as a record; the E-column SUM formulas travel with
+                // their row (refs shift), so every total stays correct. The key
+                // column is the selection clamped into the block's columns A..E.
+                ToolButton {
+                    text: "▲ Sort"
+                    ToolTip.visible: hovered
+                    ToolTip.text: "Sort the budget block A1:E4 by the selected column, ascending (rows move as records; formulas track)"
+                    onClicked: if (doc) doc.sortRange("A1", "E4", Math.min(5, Math.max(1, doc.infCol)), true)
+                }
+                ToolButton {
+                    text: "▼ Sort"
+                    ToolTip.visible: hovered
+                    ToolTip.text: "Sort the budget block A1:E4 by the selected column, descending"
+                    onClicked: if (doc) doc.sortRange("A1", "E4", Math.min(5, Math.max(1, doc.infCol)), false)
+                }
+                Rectangle { Layout.preferredWidth: 1; Layout.fillHeight: true; Layout.topMargin: 4; Layout.bottomMargin: 4; color: sheet.cLine }
+
                 // ── History (undo / redo) ──
                 ToolButton {
                     text: "↶ Undo"

--- a/demo/visicalc-qt/src/SpreadsheetModel.cpp
+++ b/demo/visicalc-qt/src/SpreadsheetModel.cpp
@@ -335,6 +335,25 @@ void SpreadsheetModel::setFormatInf(const QString &code) {
     emit revisionChanged();
 }
 
+// Range sort: the engine reorders the rows of the rectangle by the computed
+// values in `keyCol`, moving each row as a record (moved formulas' relative refs
+// shift with their row; absolute pin; formats ride along) — sc_sort_range
+// returns 1 when applied (or already sorted), 0 for a no-op. The QByteArray
+// locals are NAMED so the UTF-8 buffers outlive the C call, and `keyCol` is
+// clamped to >= 0 before the unsigned cast (same guard the structural edits use).
+bool SpreadsheetModel::sortRange(const QString &start, const QString &end, int keyCol, bool ascending) {
+    const QByteArray s = start.toUtf8();
+    const QByteArray e = end.toUtf8();
+    const uint32_t key = static_cast<uint32_t>(keyCol < 0 ? 0 : keyCol);
+    const int ok = sc_sort_range(session_, s.constData(), e.constData(), key, ascending ? 1 : 0);
+    recompute();        // keep the 5×5 parity grid in sync too
+    computeExtent();
+    revision_++;
+    emit changed();
+    emit revisionChanged();
+    return ok != 0;
+}
+
 // Clipboard: copy/cut capture the inclusive rectangle into the engine's
 // clipboard; paste places it (the whole block's references shift by the
 // destination's offset). The QByteArray locals are NAMED so the UTF-8 buffers

--- a/demo/visicalc-qt/src/SpreadsheetModel.h
+++ b/demo/visicalc-qt/src/SpreadsheetModel.h
@@ -131,6 +131,13 @@ public:
     // the stored value is unchanged; the engine renders it through the code.
     // Recomputes the grid + bumps `revision` so the visible rows re-fetch.
     Q_INVOKABLE void setFormatInf(const QString &code);
+    // Range sort: reorder the ROWS of the rectangle `start`..`end` by the
+    // computed values in `keyCol` (1-based, inside the rectangle), ascending or
+    // descending. Each row moves as a record; the engine shifts moved formulas'
+    // references with their row and carries formats. Returns true when a sort was
+    // applied (or the range was already sorted), false for a no-op (malformed
+    // address / out-of-range key / oversized range). Recomputes + bumps revision.
+    Q_INVOKABLE bool sortRange(const QString &start, const QString &end, int keyCol, bool ascending);
     // Clipboard: copy/cut capture the inclusive rectangle `start`..`end` (a
     // whole-block copy that pastes as a unit); paste places the block so its
     // top-left lands at `dstStart`, shifting the block's references by the

--- a/demo/visicalc-qt/test/tst_window.cpp
+++ b/demo/visicalc-qt/test/tst_window.cpp
@@ -28,6 +28,7 @@ private slots:
     void undoRedoWalksHistory();
     void structuralInsertDeleteShiftsReferences();
     void numberFormatAppliesToSelectedCell();
+    void sortRangeReordersRowsByKeyColumn();
 };
 
 // Helper: the display string at window (1-based) cell (row, col), given the
@@ -305,6 +306,39 @@ void TstWindow::numberFormatAppliesToSelectedCell() {
     // The format is display-only: the stored source never changed.
     m.selectInf(1, 8);
     QCOMPARE(m.infFormula(), QStringLiteral("1234"));
+}
+
+// Range sort (the ▲/▼ Sort buttons): reorder the budget block A1:E4 by a key
+// column. The default seed has column A = 15,8,12,4 (rows 1..4) and each E cell
+// is =SUM(A:D) for its row. Sorting by column A ascending moves each row as a
+// record — column A becomes 4,8,12,15 and every E total travels with its row
+// (the engine shifts the moved SUM formulas' refs). Descending reverses it.
+void TstWindow::sortRangeReordersRowsByKeyColumn() {
+    SpreadsheetModel m;
+    auto colA = [&m](int row) { return m.window(row, 1, row, 1).at(0).toList().at(0).toString(); };
+    auto colE = [&m](int row) { return m.window(row, 5, row, 5).at(0).toList().at(0).toString(); };
+    // Pre-sort seed order.
+    QCOMPARE(colA(1), QStringLiteral("15"));
+    QCOMPARE(colA(4), QStringLiteral("4"));
+
+    // Ascending by column A (keyCol = 1): rows reorder to 4,8,12,15.
+    QVERIFY(m.sortRange("A1", "E4", 1, true));
+    QCOMPARE(colA(1), QStringLiteral("4"));
+    QCOMPARE(colA(2), QStringLiteral("8"));
+    QCOMPARE(colA(3), QStringLiteral("12"));
+    QCOMPARE(colA(4), QStringLiteral("15"));
+    // Each row's E total tracked its row (E = SUM of that row's A..D), formatted.
+    QCOMPARE(colE(1), QStringLiteral("35.00"));  // 4+11+3+17
+    QCOMPARE(colE(4), QStringLiteral("38.00"));  // 15+3+12+8
+
+    // Descending reverses the key order.
+    QVERIFY(m.sortRange("A1", "E4", 1, false));
+    QCOMPARE(colA(1), QStringLiteral("15"));
+    QCOMPARE(colA(4), QStringLiteral("4"));
+
+    // Bad args are a no-op returning false (no crash).
+    QVERIFY(!m.sortRange("A1", "A1", 1, true));   // single-row range
+    QVERIFY(!m.sortRange("A1", "E4", 9, true));   // key column outside the range
 }
 
 QTEST_MAIN(TstWindow)


### PR DESCRIPTION
## What

First **native** backend of the sort-a-range rollout (the merged web demo proved the UX). Adds a **"Sort"** toolbar group (▲ Sort / ▼ Sort) to `InfiniteSheet.qml` that sorts the seeded budget block **A1:E4** by the **selected column** (clamped into A..E), ascending/descending, via a new `SpreadsheetModel::sortRange` `Q_INVOKABLE` wrapping the engine's `sc_sort_range` (spreadsheet-core 0.10.0, now on `main`).

Each row moves as a **record**: the E-column `SUM` formulas travel with their row (engine shifts the refs), so every total stays correct. `sortRange` returns `bool` (false = no-op for already-sorted / bad args). Named `QByteArray` locals so the UTF-8 buffers outlive the C call; `keyCol` clamped `>= 0` before the unsigned cast.

## Verification

Re-vendored the capi (now carries `sc_sort_range`). **`qmake && make && ./tst_window` → 13/13 pass**, including the new `sortRangeReordersRowsByKeyColumn`: seed budget (A col `15,8,12,4`), sort by col 1 asc → A col `4,8,12,15` with E totals tracking their rows (`35.00`/`38.00`); descending reverses; single-row + out-of-range-key rejected. Security review **passed** (FFI string lifetime + clamped cast; the range is a fixed literal from QML).

🤖 Generated with [Claude Code](https://claude.com/claude-code)