### PR TITLE
feat(visicalc-flutter): sort a range in the Flutter demo

### DIFF
--- a/demo/visicalc-flutter/lib/engine.dart
+++ b/demo/visicalc-flutter/lib/engine.dart
@@ -73,6 +73,13 @@ typedef _FillC = Void Function(
 typedef _FillD = void Function(
     Pointer<Void>, Pointer<Uint8>, Pointer<Uint8>, Pointer<Uint8>);
 
+// sc_sort_range(session, start, end, key_col, ascending) → int (1 applied / was
+// already sorted, 0 no-op). Two A1 strings + a 1-based key column + a flag.
+typedef _SortRangeC = Int32 Function(
+    Pointer<Void>, Pointer<Uint8>, Pointer<Uint8>, Uint32, Int32);
+typedef _SortRangeD = int Function(
+    Pointer<Void>, Pointer<Uint8>, Pointer<Uint8>, int, int);
+
 // sc_insert_rows / sc_delete_rows / sc_insert_cols / sc_delete_cols(session, at,
 // count) → void. Structural edits at a 1-based position; the engine shifts
 // formula references across the band.
@@ -102,6 +109,7 @@ class SpreadsheetSession {
   late final _WindowD _getDisplayWindow;
   late final _SetFormatD _setFormatFn;
   late final _FillD _fillFn;
+  late final _SortRangeD _sortRangeFn;
   late final _ClipD _copyFn;
   late final _ClipD _cutFn;
   late final _PasteD _pasteFn;
@@ -138,6 +146,7 @@ class SpreadsheetSession {
     _getDisplayWindow = _lib.lookupFunction<_WindowC, _WindowD>('sc_get_display_window');
     _setFormatFn = _lib.lookupFunction<_SetFormatC, _SetFormatD>('sc_set_format');
     _fillFn = _lib.lookupFunction<_FillC, _FillD>('sc_fill');
+    _sortRangeFn = _lib.lookupFunction<_SortRangeC, _SortRangeD>('sc_sort_range');
     _copyFn = _lib.lookupFunction<_ClipC, _ClipD>('sc_copy');
     _cutFn = _lib.lookupFunction<_ClipC, _ClipD>('sc_cut');
     _pasteFn = _lib.lookupFunction<_PasteC, _PasteD>('sc_paste');
@@ -311,6 +320,24 @@ class SpreadsheetSession {
       _fillFn(_handle, srcPtr, startPtr, endPtr);
     } finally {
       _freeCString(srcPtr);
+      _freeCString(startPtr);
+      _freeCString(endPtr);
+    }
+  }
+
+  /// Sort the rows of the inclusive rectangle [start]..[end] by the computed
+  /// values in [keyCol] (1-based, inside the rectangle), ascending/descending.
+  /// Each row moves as a record; the engine shifts moved formulas' references
+  /// with their row and carries formats. Returns true when a sort was applied
+  /// (or the range was already sorted), false for a no-op (malformed address /
+  /// out-of-range key / oversized range). [keyCol] is clamped into the u32 range
+  /// before crossing the C ABI (Dart `int` is 64-bit; the C param is `Uint32`).
+  bool sortRange(String start, String end, int keyCol, bool ascending) {
+    final startPtr = _toCString(start);
+    final endPtr = _toCString(end);
+    try {
+      return _sortRangeFn(_handle, startPtr, endPtr, _u32(keyCol), ascending ? 1 : 0) == 1;
+    } finally {
       _freeCString(startPtr);
       _freeCString(endPtr);
     }
@@ -644,6 +671,18 @@ class InfiniteSheetModel {
   /// stored value is unchanged; the engine renders it through the code, so a
   /// fresh rowCells read shows the formatted string.
   void applyFormat(String code) => _session.setFormat(infAddress, code);
+
+  /// Range sort: reorder the rows of the seeded budget block A1:E4 by the
+  /// SELECTED column (clamped into the block's columns A..E = 1..5), ascending
+  /// or descending. Each row moves as a record; the E-column SUM formulas travel
+  /// with their row (the engine shifts their refs), so every total stays correct.
+  /// Returns false for a no-op (already sorted / bad args). Regrows the extent.
+  bool sortBlock(bool ascending) {
+    final keyCol = selCol < 1 ? 1 : (selCol > 5 ? 5 : selCol);
+    final ok = _session.sortRange('A1', 'E4', keyCol, ascending);
+    computeExtent();
+    return ok;
+  }
 
   /// Structural edits: insert / delete the selected cell's row or column. The
   /// engine shifts every formula reference at or after the band (a reference

--- a/demo/visicalc-flutter/lib/infinite_grid.dart
+++ b/demo/visicalc-flutter/lib/infinite_grid.dart
@@ -193,6 +193,10 @@ class _InfiniteGridState extends State<InfiniteGrid> {
   // setState rebuild re-reads the row and shows the formatted string.
   void _applyFormat(String code) => setState(() => _model.applyFormat(code));
 
+  // Range sort: reorder the budget block A1:E4 by the selected column,
+  // ascending/descending. A setState rebuild re-reads the reordered rows.
+  void _sortBlock(bool ascending) => setState(() => _model.sortBlock(ascending));
+
   // A compact, modern toolbar button (rounded chip with hover/down/disabled
   // states) — the Flutter analog of the web demo's segmented controls and the
   // Qt port's `component ToolButton`. `enabled: null` disables it (Undo/Redo/
@@ -354,6 +358,15 @@ class _InfiniteGridState extends State<InfiniteGrid> {
           const SizedBox(width: 6),
           _toolButton('Gen', "Clear the selected cell's format (General)",
               () => _applyFormat('')),
+          _toolSep(),
+          // ── Sort (reorder the budget block A1:E4 by the selected column) ──
+          _toolButton('▲ Sort',
+              'Sort the budget block A1:E4 by the selected column, ascending (rows move as records; formulas track)',
+              () => _sortBlock(true)),
+          const SizedBox(width: 6),
+          _toolButton('▼ Sort',
+              'Sort the budget block A1:E4 by the selected column, descending',
+              () => _sortBlock(false)),
           _toolSep(),
           // ── History (undo / redo) ──
           _toolButton('↶ Undo', 'Undo the last edit', _undo,

--- a/demo/visicalc-flutter/test/window_test.dart
+++ b/demo/visicalc-flutter/test/window_test.dart
@@ -274,5 +274,37 @@ void main() {
       expect(m.redoEdit(), isTrue);
       expect(m.rowCells(1)[7], '16');
     });
+
+    // Range sort (the ▲/▼ Sort buttons drive the model's sortBlock →
+    // session.sortRange): reorder the budget block A1:E4 by a key column. Each
+    // row moves as a record — the E-column SUM formulas travel with their row
+    // (the engine shifts the refs), so every total stays correct.
+    test('sortRange reorders the budget rows by a key column', () {
+      final s = SpreadsheetSession();
+      addTearDown(s.dispose);
+      // Budget block A1:E4: column A = 15,8,12,4; each E cell totals its row.
+      const cells = {
+        'A1': '15', 'B1': '3', 'C1': '12', 'D1': '8', 'E1': '=SUM(A1:D1)',
+        'A2': '8', 'B2': '14', 'C2': '7', 'D2': '22', 'E2': '=SUM(A2:D2)',
+        'A3': '12', 'B3': '9', 'C3': '18', 'D3': '6', 'E3': '=SUM(A3:D3)',
+        'A4': '4', 'B4': '11', 'C4': '3', 'D4': '17', 'E4': '=SUM(A4:D4)',
+      };
+      cells.forEach(s.setCell);
+      // Pre-sort: column A rows 1..4 = 15,8,12,4.
+      expect(s.window(1, 1, 4, 1).map((r) => r[0]).toList(), ['15', '8', '12', '4']);
+      // Sort A1:E4 by column A ascending → 4,8,12,15.
+      expect(s.sortRange('A1', 'E4', 1, true), isTrue);
+      expect(s.window(1, 1, 4, 1).map((r) => r[0]).toList(), ['4', '8', '12', '15']);
+      // Each row's E total tracked its row (E = SUM of that row's A..D).
+      expect(s.window(1, 5, 1, 5)[0][0], '35'); // 4+11+3+17
+      expect(s.window(4, 5, 4, 5)[0][0], '38'); // 15+3+12+8
+      // Descending reverses the key order.
+      expect(s.sortRange('A1', 'E4', 1, false), isTrue);
+      expect(s.window(1, 1, 1, 1)[0][0], '15');
+      expect(s.window(4, 1, 4, 1)[0][0], '4');
+      // Bad args are a no-op returning false (no crash).
+      expect(s.sortRange('A1', 'A1', 1, true), isFalse); // single-row range
+      expect(s.sortRange('A1', 'E4', 9, true), isFalse); // key column outside range
+    });
   });
 }


### PR DESCRIPTION
## What

Second native backend of the sort-a-range rollout (after Qt [#6543](https://github.com/adhithyan15/coding-adventures/pull/6543)). Adds a **"Sort"** toolbar group (▲ Sort / ▼ Sort) that sorts the seeded budget block **A1:E4** by the **selected column** (clamped into A..E), ascending/descending, over a new `dart:ffi` `sortRange` binding to `sc_sort_range`.

Each row moves as a **record** — the E-column `SUM` formulas travel with their row (engine shifts the refs), so every total stays correct. Reuses the existing `_toCString`/`_freeCString` try/finally marshalling + `_u32` clamp; the model's `sortBlock` clamps the key column to 1..5.

## Verification

Re-vendored the capi cdylib (`native/libspreadsheet_capi.dylib` now carries `sc_sort_range`). **`flutter test` → 15/15 model + 3/3 widget pass**, incl. the new `sortRange reorders the budget rows by a key column` (A col `15,8,12,4` → `4,8,12,15`, E totals track rows `35`/`38`, desc reverses, single-row + out-of-range-key rejected). **`flutter analyze` clean**. Security review **passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)