### PR TITLE
feat(visicalc-compose): sort a range in the Compose demo

### DIFF
--- a/demo/visicalc-compose/src/main/kotlin/Engine.kt
+++ b/demo/visicalc-compose/src/main/kotlin/Engine.kt
@@ -50,6 +50,9 @@ class SpreadsheetSession(libraryPath: String = resolveLibraryPath()) : AutoClose
     private val scSetFormat = handle("sc_set_format", FunctionDescriptor.ofVoid(ptr, ptr, ptr))
     // sc_fill(session, src, dst_start, dst_end) -> void (drag-fill; three A1 strings).
     private val scFill = handle("sc_fill", FunctionDescriptor.ofVoid(ptr, ptr, ptr, ptr))
+    // sc_sort_range(session, start, end, key_col, ascending) -> int (1 applied /
+    // already sorted, 0 no-op). Two A1 strings + a 1-based key column + a flag.
+    private val scSortRange = handle("sc_sort_range", FunctionDescriptor.of(i32, ptr, ptr, ptr, i32, i32))
     // sc_copy / sc_cut(session, start, end) -> void (clipboard capture; two A1 strings).
     private val scCopy = handle("sc_copy", FunctionDescriptor.ofVoid(ptr, ptr, ptr))
     private val scCut = handle("sc_cut", FunctionDescriptor.ofVoid(ptr, ptr, ptr))
@@ -151,6 +154,24 @@ class SpreadsheetSession(libraryPath: String = resolveLibraryPath()) : AutoClose
             a.allocateUtf8String(dstEnd),
         )
     }
+
+    /// Range sort: reorder the rows of the rectangle [start]..[end] by the
+    /// computed values in [keyCol] (1-based, inside the rectangle), ascending or
+    /// descending. Each row moves as a record; the engine shifts moved formulas'
+    /// references with their row and carries formats. Returns true when a sort was
+    /// applied (or the range was already sorted), false for a no-op. [keyCol] is
+    /// clamped to ≥ 0 before the call (Kotlin Int maxes below u32, so no high-end
+    /// truncation); the engine validates it lies inside the rectangle.
+    fun sortRange(start: String, end: String, keyCol: Int, ascending: Boolean): Boolean =
+        Arena.ofConfined().use { a ->
+            (scSortRange.invoke(
+                session,
+                a.allocateUtf8String(start),
+                a.allocateUtf8String(end),
+                maxOf(0, keyCol),
+                if (ascending) 1 else 0,
+            ) as Int) != 0
+        }
 
     /// Structural edits: insert / delete [count] rows or columns at the 1-based
     /// position [at]. The engine shifts every formula reference at or after the
@@ -480,6 +501,18 @@ class InfiniteSheetModel(
     /// stored value is unchanged; the engine renders it through the code, so a
     /// fresh rowCells read shows the formatted string.
     fun applyFormat(code: String) = session.setFormat(infAddress(), code)
+
+    /// Range sort: reorder the rows of the seeded budget block A1:E4 by the
+    /// SELECTED column (clamped into the block's columns A..E = 1..5), ascending
+    /// or descending. Each row moves as a record; the E-column SUM formulas travel
+    /// with their row (the engine shifts their refs), so every total stays correct.
+    /// Returns false for a no-op (already sorted / bad args). Regrows the extent.
+    fun sortBlock(ascending: Boolean): Boolean {
+        val keyCol = selCol.coerceIn(1, 5)
+        val ok = session.sortRange("A1", "E4", keyCol, ascending)
+        computeExtent()
+        return ok
+    }
 
     /// Clipboard: copy/cut the selected cell, then paste it at the selection. The
     /// engine shifts the pasted formula's relative references by the

--- a/demo/visicalc-compose/src/main/kotlin/InfiniteSheet.kt
+++ b/demo/visicalc-compose/src/main/kotlin/InfiniteSheet.kt
@@ -196,6 +196,10 @@ fun InfiniteSheet() {
     // only — bump rev so the visible rows re-read and show the formatted string.
     fun applyFormat(code: String) { model.applyFormat(code); rev++ }
 
+    // Range sort: reorder the budget block A1:E4 by the selected column,
+    // ascending/descending. Bump rev so the reordered rows re-read.
+    fun sortBlock(ascending: Boolean) { model.sortBlock(ascending); rev++ }
+
     Column(modifier = Modifier.fillMaxSize().background(BG)) {
         // ── Formula bar: a panel holding the address pill, an `fx` marker, the
         // editable source line (with an accent focus ring), and segmented button
@@ -297,6 +301,11 @@ fun InfiniteSheet() {
             toolButton("$") { applyFormat("\$#,##0.00") }
             Spacer(Modifier.width(6.dp))
             toolButton("Gen") { applyFormat("") }
+            toolSep()
+            // ── Sort (reorder the budget block A1:E4 by the selected column) ──
+            toolButton("▲ Sort") { sortBlock(true) }
+            Spacer(Modifier.width(6.dp))
+            toolButton("▼ Sort") { sortBlock(false) }
             toolSep()
             // ── History (undo / redo). Reading `rev` re-evaluates canUndo/canRedo
             // on every edit so the buttons gate live.

--- a/demo/visicalc-compose/test/EngineSmoke.kt
+++ b/demo/visicalc-compose/test/EngineSmoke.kt
@@ -238,6 +238,28 @@ fun main() {
     check("fmt raw untouched", fmt.getRaw("A1"), "1234") // display-only
     fmt.close()
 
+    // Range sort (the ▲/▼ Sort buttons drive sortRange): reorder the budget block
+    // A1:E4 by a key column. Each row moves as a record — the E-column SUM formulas
+    // travel with their row (the engine shifts the refs), so totals stay correct.
+    val so = SpreadsheetSession()
+    for ((a, v) in listOf(
+        "A1" to "15", "B1" to "3", "C1" to "12", "D1" to "8", "E1" to "=SUM(A1:D1)",
+        "A2" to "8", "B2" to "14", "C2" to "7", "D2" to "22", "E2" to "=SUM(A2:D2)",
+        "A3" to "12", "B3" to "9", "C3" to "18", "D3" to "6", "E3" to "=SUM(A3:D3)",
+        "A4" to "4", "B4" to "11", "C4" to "3", "D4" to "17", "E4" to "=SUM(A4:D4)",
+    )) so.setCell(a, v)
+    check("sort pre A1", so.window(1, 1, 1, 1)[0][0], "15")
+    check("sort applied asc", so.sortRange("A1", "E4", 1, true).toString(), "true")
+    check("sort A1 asc", so.window(1, 1, 1, 1)[0][0], "4")    // col A → 4,8,12,15
+    check("sort A4 asc", so.window(4, 1, 4, 1)[0][0], "15")
+    check("sort E1 asc", so.window(1, 5, 1, 5)[0][0], "35")   // E tracks row: 4+11+3+17
+    check("sort E4 asc", so.window(4, 5, 4, 5)[0][0], "38")   // 15+3+12+8
+    check("sort applied desc", so.sortRange("A1", "E4", 1, false).toString(), "true")
+    check("sort A1 desc", so.window(1, 1, 1, 1)[0][0], "15")
+    check("sort single-row no-op", so.sortRange("A1", "A1", 1, true).toString(), "false")
+    check("sort bad key no-op", so.sortRange("A1", "E4", 9, true).toString(), "false")
+    so.close()
+
     println(if (failures == 0) "\nALL PASS" else "\n$failures FAILURE(S)")
     kotlin.system.exitProcess(if (failures == 0) 0 else 1)
 }


### PR DESCRIPTION
## What

Third native backend of the sort-a-range rollout (after Qt [#6543](https://github.com/adhithyan15/coding-adventures/pull/6543), Flutter [#6544](https://github.com/adhithyan15/coding-adventures/pull/6544)). Adds a **"Sort"** toolbar group (▲ Sort / ▼ Sort) sorting the seeded budget block **A1:E4** by the **selected column** (clamped into A..E), ascending/descending, via a new **FFM downcall** `sortRange` to `sc_sort_range`.

Each row moves as a **record** — the E-column `SUM` formulas travel with their row (engine shifts the refs), so every total stays correct. Same `Arena.ofConfined().use { allocateUtf8String }` marshalling as `fill`/`setFormat` + `maxOf(0,·)` clamp; the model's `sortBlock` clamps the key column to 1..5.

## Verification

Re-vendored the capi cdylib (now carries `sc_sort_range`). **`scripts/verify.sh` (kotlinc + FFM) → ALL PASS**, incl. the new sort checks: A col `15,8,12,4` → `4,8,12,15` with E totals `35`/`38` tracking their rows; descending reverses; single-row + out-of-range-key → `false`. Security review **passed** (Arena-scoped native strings; clamped key column).

🤖 Generated with [Claude Code](https://claude.com/claude-code)