### PR TITLE
feat(cloc26-asi): Phase 3 — restricted productions (return/throw/break/continue/yield)

### DIFF
--- a/code/packages/rust/javascript-parser/CHANGELOG.md
+++ b/code/packages/rust/javascript-parser/CHANGELOG.md
@@ -2,6 +2,45 @@
 
 All notable changes to the `coding-adventures-javascript-parser` crate will be documented in this file.
 
+## [0.19.0] - 2026-06-22
+
+### Added — ASI Phase 3: restricted productions (Rule 3)
+
+A new proactive pre-pass, `force_restricted_semicolons`, run *before* the
+retry-on-error loop in `parse_with_asi`. It forces an automatic semicolon
+immediately after a restricted keyword (`return`/`throw`/`break`/`continue`/
+`yield`) whose argument is pushed onto the next line — the ECMAScript §12.10.1
+"no LineTerminator here" rule.
+
+This is the first ASI rule that must change a parse the grammar *already
+accepts*: because the grammar is newline-blind, `return ⏎ a + b` would otherwise
+parse as `return a + b` and closurec would re-emit that — a silent **miscompile**
+(JS semantics are `return; a + b`). The retry-on-error harness (Rules 1/2) can
+never see this, since the bad parse *succeeds*, so Rule 3 needs its own
+forward-scanning pass.
+
+Safety is preserved by the same lever as Rules 1/2: an insertion is made **only
+when a line terminator actually follows the keyword** (`TOKEN_PRECEDED_BY_NEWLINE`
+on the next token), so every valid single-line `return x;` is byte-identical.
+Context guards keep a `return` that is really a *property name* from being
+mis-split:
+
+- **member access** — a `.`/`?.` before the keyword (`a.return`, `a?.return`)
+  demotes it to a property; declined.
+- **property key / label** — a `:` after the keyword (`{return: 1}`) marks it as
+  an object key; declined.
+- **already terminated** — a `;`/`}` after the keyword needs no extra `;`
+  (Rule 2 covers the `}`); declined.
+
+The pre-pass is idempotent and allocation-free on any stream containing no
+restricted keyword. `yield` only triggers where the lexer classifies it as a
+genuine keyword (inside a generator); as an ordinary identifier it is left to
+Rule 1, which already splits it correctly. Postfix `++`/`--` restricted
+productions remain a documented follow-up.
+
+8 new unit tests cover each keyword, the same-line no-op, every guard, the
+double-insert guard at `}`, idempotence, and the allocation-free fast path.
+
 ## [0.18.0] - 2026-06-21
 
 ### Changed — ASI Rule 1 reads the lexer's newline flag (limitation removed)

--- a/code/packages/rust/javascript-parser/Cargo.toml
+++ b/code/packages/rust/javascript-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-javascript-parser"
-version = "0.18.0"
+version = "0.19.0"
 edition = "2021"
 description = "JavaScript parser — parses JavaScript source code against any ECMAScript edition (es1 through es2025) using the grammar-driven parser. Includes correlation-vector plumbing per CLOC03 and a typed-AST bridge (GrammarASTNode → javascript_ast::Program) per CLOC12.136."
 

--- a/code/packages/rust/javascript-parser/src/asi.rs
+++ b/code/packages/rust/javascript-parser/src/asi.rs
@@ -48,6 +48,40 @@
 //! The cost is re-parsing once per inserted semicolon (O(insertions × n)). For a
 //! build-time minifier this is acceptable; a batched single-pass insertion is a
 //! possible future optimization, but correctness-by-construction comes first.
+//!
+//! # Phase 3: restricted productions (Rule 3) — why retry-on-error is not enough
+//!
+//! Rules 1 and 2 only ever fire on a *parse failure*, which is what makes them
+//! safe (a program that already parses is untouched). The **restricted
+//! productions** are different and more dangerous, because the offending program
+//! parses *successfully into the wrong tree*:
+//!
+//! ```text
+//!   return
+//!     a + b
+//! ```
+//!
+//! ECMAScript §12.10.1 forbids a line terminator between `return` and its
+//! argument, so this is `return; a + b;` (an empty return followed by an
+//! expression statement) — **not** `return a + b;`. closurec's grammar spells
+//! `return` as `RETURN expr? SEMICOLON` and is *blind to newlines* (the lexer
+//! discards them as trivia), so it greedily parses `return a + b` and would
+//! re-emit exactly that: a silent **miscompile** that changes what the program
+//! returns.
+//!
+//! Because the bad parse *succeeds*, the retry-on-error loop never sees it. So
+//! Rule 3 must run as a **proactive pre-pass** ([`force_restricted_semicolons`])
+//! that scans the stream *before* the first parse and inserts a `;` immediately
+//! after a restricted keyword whose argument is pushed onto the next line. The
+//! five restricted keywords are `return`, `throw`, `break`, `continue`, `yield`.
+//!
+//! Safety still holds by the same lever as Rules 1/2 — **we only insert when a
+//! line terminator actually follows the keyword** ([`TOKEN_PRECEDED_BY_NEWLINE`]
+//! on the *next* token). A valid `return x;` keeps its argument on the same line,
+//! so the flag is clear and we never touch it; the only streams whose parse we
+//! change are exactly the ones JS semantics say we *must* change. Context guards
+//! (below) keep a `return` that is really a *property name* (`a.return`,
+//! `{return: 1}`) from being mistaken for the statement keyword.
 
 use coding_adventures_javascript_tokens::EsVersion;
 use lexer::token::{Token, TokenType, TOKEN_PRECEDED_BY_NEWLINE};
@@ -65,7 +99,10 @@ pub fn parse_with_asi(
     let grammar = crate::_grammar::parser_grammar(version.as_str())
         .expect("compiled JavaScript parser grammar missing supported version");
 
-    let mut tokens = tokens;
+    // Phase 3 (restricted productions) runs FIRST, as a proactive pre-pass: the
+    // offending streams parse successfully into the wrong tree, so the
+    // retry-on-error loop below would never see them. See the module docs.
+    let mut tokens = force_restricted_semicolons(tokens);
     // Each insertion adds exactly one token and (when it helps) lets the parser
     // advance past one more `}`/EOF, so the number of useful insertions is
     // bounded by the token count. The `+ 1` covers the final EOF position.
@@ -113,6 +150,101 @@ pub fn parse_with_asi(
     // Budget exhausted (pathological input). Return the final outcome so the
     // caller sees a real error rather than a silent wrong parse.
     GrammarParser::new(tokens, grammar).parse()
+}
+
+/// The five ECMAScript "restricted production" keywords (§12.10.1): a line
+/// terminator is **not allowed** between the keyword and what follows it, so a
+/// newline there forces ASI. `break`/`continue` take an optional label;
+/// `return`/`throw`/`yield` take an optional (for `throw`, required) argument —
+/// but the rule is identical for our purposes: a newline immediately after the
+/// keyword ends the statement right there.
+const RESTRICTED_KEYWORDS: [&str; 5] = ["return", "throw", "break", "continue", "yield"];
+
+/// **Phase 3 — restricted productions.** Scan `tokens` and insert a `;`
+/// immediately after any restricted keyword (`return`/`throw`/`break`/
+/// `continue`/`yield`) whose *following* token begins on a new line
+/// ([`TOKEN_PRECEDED_BY_NEWLINE`]). Runs as a pre-pass because the offending
+/// stream parses *successfully into the wrong tree* (see module docs), so the
+/// retry-on-error loop never gets a chance to fix it.
+///
+/// This is the one ASI rule that changes a parse the grammar already accepts, so
+/// it is deliberately conservative. An insertion is made only when **all** hold:
+///
+/// 1. the token is genuinely the restricted *keyword* — matched on the lexer's
+///    keyword classification (`type_name`/`type_`), not merely the text, so a
+///    same-spelled identifier never qualifies;
+/// 2. it is **not a property access** — the previous significant token is not
+///    `.` or `?.` (`a.return`, `a?.return` name a property, not a statement);
+/// 3. there *is* a next token and it carries `TOKEN_PRECEDED_BY_NEWLINE`; and
+/// 4. that next token is not already a statement terminator / non-argument —
+///    `;`, `}`, or `:` (a `:` means we are looking at a property key or label
+///    such as `{return: 1}`, never a restricted statement, so we leave it).
+///
+/// Because (3) requires a real newline after the keyword, every valid
+/// single-line `return x;` / `throw e;` is untouched: the lever that keeps
+/// Rules 1/2 byte-identical keeps Rule 3 byte-identical too.
+fn force_restricted_semicolons(tokens: Vec<Token>) -> Vec<Token> {
+    // Fast path: a stream with no restricted keyword at all (the common case for
+    // expression-heavy minifier input) is returned untouched, allocation-free.
+    if !tokens.iter().any(is_restricted_keyword_token) {
+        return tokens;
+    }
+
+    let mut out: Vec<Token> = Vec::with_capacity(tokens.len() + 2);
+    for (i, tok) in tokens.iter().enumerate() {
+        out.push(tok.clone());
+
+        if !is_restricted_keyword_token(tok) {
+            continue;
+        }
+        // Guard (2): a property name after `.`/`?.` is not the keyword.
+        if i > 0 && is_member_access_dot(&tokens[i - 1]) {
+            continue;
+        }
+        // Guards (3)+(4): need a next token, on a new line, that actually starts
+        // an argument/statement (not `;` / `}` / `:`).
+        match tokens.get(i + 1) {
+            Some(next)
+                if next.flags.unwrap_or(0) & TOKEN_PRECEDED_BY_NEWLINE != 0
+                    && !ends_or_keys_statement(next) =>
+            {
+                out.push(synthetic_semicolon(next));
+            }
+            _ => {}
+        }
+    }
+    out
+}
+
+/// Is `tok` one of the restricted keywords, *classified as a keyword by the
+/// lexer* (`TokenType::Keyword`) — not a same-spelled identifier, string, or
+/// number? The JavaScript lexer tags every reserved word with
+/// `TokenType::Keyword`, so a precise type check is enough and is what keeps a
+/// variable or property literally named `return` from ever qualifying.
+///
+/// Note `yield` is only a reserved word inside a generator; where the lexer
+/// classifies it as an ordinary `Name` (identifier) this returns `false` and we
+/// do nothing — which is correct, because there the retry-on-error loop already
+/// splits `yield`⏎`x` as two identifier statements via Rule 1. We only force the
+/// split when `yield` is a genuine keyword.
+fn is_restricted_keyword_token(tok: &Token) -> bool {
+    tok.type_ == TokenType::Keyword && RESTRICTED_KEYWORDS.contains(&tok.value.as_str())
+}
+
+/// A member-access dot (`.`) or optional-chaining (`?.`) — the token that, when
+/// it *precedes* a restricted keyword, demotes it to an ordinary property name.
+fn is_member_access_dot(tok: &Token) -> bool {
+    tok.value == "." || tok.value == "?." || matches!(tok.type_, TokenType::Dot)
+}
+
+/// Does `tok` already terminate the statement (`;`, `}`) or mark the keyword as a
+/// property key / label (`:`)? In any of these cases the restricted-production
+/// insertion is unnecessary or wrong, so we decline it.
+fn ends_or_keys_statement(tok: &Token) -> bool {
+    matches!(tok.type_, TokenType::Semicolon | TokenType::RBrace | TokenType::Colon)
+        || tok.value == ";"
+        || tok.value == "}"
+        || tok.value == ":"
 }
 
 /// Does an ASI insertion apply *before the token at `idx`* (which the parser
@@ -317,5 +449,91 @@ mod tests {
             parses_with_asi(src),
             "string-ending statement before a newline now recovers via the flag"
         );
+    }
+
+    // --- Phase 3: restricted productions (Rule 3) ------------------------
+    //
+    // These are the dangerous cases: the offending stream parses *successfully
+    // into the wrong tree*, so we assert on the inserted-token stream directly
+    // (not just "does it parse"), and we count synthetic semicolons.
+
+    /// How many `;` does the Phase-3 pre-pass force into `src`?
+    fn forced_semis(src: &str) -> usize {
+        let before = tokenize(src);
+        let after = force_restricted_semicolons(before.clone());
+        after.len() - before.len()
+    }
+
+    #[test]
+    fn return_then_newline_argument_is_split() {
+        // `return ⏎ a + b` is `return; a + b` in JS, NOT `return a + b`. The
+        // grammar is newline-blind and would mis-merge it, so Phase 3 must force
+        // a `;` right after `return`.
+        let src = "function f(){return\na + b}";
+        assert_eq!(forced_semis(src), 1, "exactly one `;` forced after return");
+        // And the split makes the (otherwise mis-parsing-into-wrong-tree) input
+        // parse as two statements.
+        assert!(parses_with_asi(src));
+    }
+
+    #[test]
+    fn return_with_same_line_argument_is_untouched() {
+        // The byte-identity lever: a valid single-line `return a + b;` has no
+        // newline after `return`, so Phase 3 forces nothing.
+        let src = "function f(){return a + b;}";
+        assert_eq!(forced_semis(src), 0, "valid same-line return is untouched");
+        assert!(parses_without_asi(src), "precondition: already valid");
+    }
+
+    #[test]
+    fn throw_break_continue_after_newline_are_split() {
+        // All five restricted keywords behave alike: a newline immediately after
+        // ends the statement. (`throw;` is itself illegal, but forcing the split
+        // is still correct — closurec then declines to mis-merge and the illegal
+        // input degrades to a byte-identical passthrough.)
+        assert_eq!(forced_semis("throw\ne"), 1, "throw split");
+        assert_eq!(forced_semis("for(;;){break\nx}"), 1, "break split");
+        assert_eq!(forced_semis("for(;;){continue\nx}"), 1, "continue split");
+    }
+
+    #[test]
+    fn member_access_named_return_is_not_split() {
+        // `a.return` names a *property*; the `.` demotes the keyword. Even with a
+        // newline after it, Phase 3 must not insert.
+        assert_eq!(forced_semis("a.return\nb"), 0, "property access, not a keyword");
+        assert_eq!(forced_semis("a?.return\nb"), 0, "optional-chained property");
+    }
+
+    #[test]
+    fn property_key_named_return_is_not_split() {
+        // `{return: 1}` uses `return` as an object key — the following `:` marks
+        // it, so Phase 3 declines (guard 4).
+        assert_eq!(forced_semis("x = {return:\n1}"), 0, "object key, not a keyword");
+    }
+
+    #[test]
+    fn return_then_close_brace_is_not_double_inserted() {
+        // `return ⏎ }` already terminates at the `}` (Rule 2 covers it); Phase 3
+        // must not also force a `;`, which would be redundant.
+        assert_eq!(forced_semis("function f(){return\n}"), 0, "close brace already terminates");
+        // Still parses (empty return via Rule 2 on the `}`).
+        assert!(parses_with_asi("function f(){return\n}"));
+    }
+
+    #[test]
+    fn restricted_split_is_idempotent() {
+        // Running the pre-pass twice inserts no more than running it once: after
+        // the first `;`, the keyword's next token is the synthetic `;` (which
+        // `ends_or_keys_statement` declines), so the second pass is a no-op.
+        let once = force_restricted_semicolons(tokenize("function f(){return\na}"));
+        let twice = force_restricted_semicolons(once.clone());
+        assert_eq!(once.len(), twice.len(), "Phase 3 pre-pass is idempotent");
+    }
+
+    #[test]
+    fn no_restricted_keyword_is_an_allocation_free_passthrough() {
+        // The fast path: a stream with no restricted keyword returns unchanged.
+        let src = "var a = 1\nvar b = 2";
+        assert_eq!(forced_semis(src), 0);
     }
 }

--- a/code/programs/rust/closurec/CHANGELOG.md
+++ b/code/programs/rust/closurec/CHANGELOG.md
@@ -2,6 +2,34 @@
 
 All notable changes to the `coding-adventures-closurec` binary will be documented in this file.
 
+## [0.170.0] - 2026-06-22
+
+### Added — ASI Phase 3: restricted productions (Rule 3) end-to-end
+
+Pulls in `coding-adventures-javascript-parser` 0.19.0, whose new
+`force_restricted_semicolons` pre-pass forces an automatic semicolon after a
+restricted keyword (`return`/`throw`/`break`/`continue`/`yield`) whose argument
+is pushed to the next line — the ECMAScript §12.10.1 "no LineTerminator here"
+rule. Because closurec's grammar is newline-blind, `return` ⏎ `42` previously
+parsed (and re-emitted) as `return 42`, a silent **miscompile**; it is now
+correctly `return; 42` (the `42` becoming a dead statement the SIMPLE pipeline
+drops).
+
+New e2e fixture `tests/diff/simple-asi-restricted` (and integration test
+`diff_simple_asi_restricted.rs`): `function f(){return` ⏎ `42}` ⏎ `report(f())`
+→ `function f(){return};report(f());`. The absence of `42` is the double proof —
+the restricted production was honored *and* the SIMPLE typed pipeline ran (the
+`WHITESPACE_ONLY` re-stitcher would emit `function f(){return 42}`). The full
+existing fixture suite remains byte-for-byte unchanged.
+
+Context guards keep a `return` that is really a property name (`a.return`,
+`{return: 1}`) from being mis-split; postfix `++`/`--` restricted productions
+are a documented follow-up.
+
+> Version note: bumped to 0.170.0 to sit above the concurrently-developed
+> `simple-fold-charat` branch (0.169.0) and the merged ASI Rule-1 release
+> (0.168.0), so the parallel branches never collide on the version line.
+
 ## [0.168.0] - 2026-06-22
 
 ### Changed — ASI Rule 1 now handles string/template-ending statements

--- a/code/programs/rust/closurec/Cargo.toml
+++ b/code/programs/rust/closurec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closurec"
-version = "0.168.0"
+version = "0.170.0"
 edition = "2021"
 description = "closurec — CLI driver for the Closure Compiler clone. Mirrors the upstream Java Closure Compiler's command-line flag surface (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility. Per CLOC08."
 

--- a/code/programs/rust/closurec/cli.spec.json
+++ b/code/programs/rust/closurec/cli.spec.json
@@ -2,7 +2,7 @@
   "cli_builder_spec_version": "1.0",
   "name": "closurec",
   "description": "closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.",
-  "version": "0.168.0",
+  "version": "0.170.0",
   "parsing_mode": "gnu",
   "flags": [
     { "id": "browser_featureset_year", "long": "browser_featureset_year", "type": "integer", "default": 0, "description": "Shortcut for defining goog.FEATURESET_YEAR=YYYY (minimum 2012)." },

--- a/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
@@ -2,7 +2,7 @@
 
 closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.
 
-Version: 0.168.0
+Version: 0.170.0
 
 ## Flags
 

--- a/code/programs/rust/closurec/tests/diff/simple-asi-restricted/README.md
+++ b/code/programs/rust/closurec/tests/diff/simple-asi-restricted/README.md
@@ -1,0 +1,39 @@
+# Fixture: `simple-asi-restricted`
+
+End-to-end oracle for **ASI Phase 3 — restricted productions** (ECMAScript
+§12.10.1) at `--compilation_level SIMPLE`.
+
+| File | Role |
+|------|------|
+| `flags.txt` | CLI args: `--compilation_level SIMPLE --js input/a.js` |
+| `input/a.js` | `function f(){return` ⏎ `42}` ⏎ `report(f())` |
+| `expected.stdout` | `function f(){return};report(f());` |
+
+A line terminator is **not allowed** between `return` and its argument, so
+
+```js
+function f(){return
+42}
+```
+
+is `function f(){ return; 42; }` — an empty return followed by the (now dead)
+expression statement `42` — **not** `return 42`. closurec's grammar is
+newline-blind, so without Phase 3 it would parse `return 42` and re-emit it: a
+silent miscompile that changes what `f` returns. The Phase-3 pre-pass
+(`force_restricted_semicolons` in `javascript-parser`) forces the semicolon, the
+typed SIMPLE pipeline then drops the dead `42`, and the output is
+`function f(){return};report(f());`.
+
+The **absence of `42`** is the double proof: it is gone only because (a) the
+restricted production was honored (`return` did not swallow it) and (b) the
+SIMPLE typed pipeline ran (the `WHITESPACE_ONLY` re-stitcher cannot remove it —
+it would emit `function f(){return 42}`, the very miscompile this guards
+against).
+
+Regenerate the expected file after an intentional behavior change:
+
+```sh
+cargo run -- --compilation_level SIMPLE \
+    --js tests/diff/simple-asi-restricted/input/a.js \
+    > tests/diff/simple-asi-restricted/expected.stdout
+```

--- a/code/programs/rust/closurec/tests/diff/simple-asi-restricted/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/simple-asi-restricted/expected.stdout
@@ -1,0 +1,1 @@
+function f(){return};report(f());

--- a/code/programs/rust/closurec/tests/diff/simple-asi-restricted/flags.txt
+++ b/code/programs/rust/closurec/tests/diff/simple-asi-restricted/flags.txt
@@ -1,0 +1,4 @@
+--compilation_level
+SIMPLE
+--js
+tests/diff/simple-asi-restricted/input/a.js

--- a/code/programs/rust/closurec/tests/diff/simple-asi-restricted/input/a.js
+++ b/code/programs/rust/closurec/tests/diff/simple-asi-restricted/input/a.js
@@ -1,0 +1,3 @@
+function f(){return
+42}
+report(f())

--- a/code/programs/rust/closurec/tests/diff_simple_asi_restricted.rs
+++ b/code/programs/rust/closurec/tests/diff_simple_asi_restricted.rs
@@ -1,0 +1,109 @@
+//! Integration test for the `tests/diff/simple-asi-restricted/` fixture.
+//!
+//! End-to-end oracle for **ASI Phase 3 — restricted productions** (ECMAScript
+//! §12.10.1). A line terminator is not allowed between `return` and its
+//! argument, so
+//!
+//! ```text
+//! function f(){return
+//! 42}
+//! ```
+//!
+//! is `function f(){ return; 42; }` (empty return + a now-dead expression
+//! statement), NOT `return 42`. closurec's grammar is newline-blind, so without
+//! the Phase-3 pre-pass it would parse `return 42` and re-emit it — a silent
+//! miscompile. At SIMPLE the fixture optimizes to:
+//!
+//! ```text
+//! function f(){return};report(f());
+//! ```
+//!
+//! The dead `42` is gone, which is the double proof: it can only disappear if
+//! (a) the restricted production was honored and (b) the SIMPLE *typed* pipeline
+//! ran — the `WHITESPACE_ONLY` re-stitcher would instead emit
+//! `function f(){return 42}`, the very miscompile this guards against.
+
+use std::process::Command;
+
+const BINARY: &str = env!("CARGO_BIN_EXE_closurec");
+
+fn read_flags() -> Vec<String> {
+    let raw = std::fs::read_to_string("tests/diff/simple-asi-restricted/flags.txt")
+        .expect("read flags.txt");
+    raw.lines()
+        .filter(|l| !l.is_empty())
+        .map(|s| s.to_string())
+        .collect()
+}
+
+#[test]
+fn simple_asi_restricted_fixture_matches_expected_stdout() {
+    let flags = read_flags();
+    let out = Command::new(BINARY)
+        .args(&flags)
+        .output()
+        .expect("run closurec");
+
+    assert!(
+        out.status.success(),
+        "exit: {:?}, stderr: {}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stderr),
+    );
+
+    let actual = String::from_utf8_lossy(&out.stdout);
+    let expected = std::fs::read_to_string("tests/diff/simple-asi-restricted/expected.stdout")
+        .expect("read expected.stdout");
+    assert_eq!(
+        actual.trim_end_matches('\n'),
+        expected.trim_end_matches('\n'),
+        "mismatch.\nflags: {flags:?}\nactual:\n{actual}\nexpected:\n{expected}",
+    );
+}
+
+/// The restricted production must be honored: `return` does NOT swallow the `42`
+/// on the next line, so the dead expression is dropped and `42` is absent.
+#[test]
+fn simple_asi_restricted_does_not_merge_return_with_next_line() {
+    let out = Command::new(BINARY)
+        .args(read_flags())
+        .output()
+        .expect("run closurec");
+    let actual = String::from_utf8_lossy(&out.stdout);
+
+    assert!(
+        !actual.contains("42"),
+        "the dead `42` after `return` must be dropped (restricted production \
+         honored, typed pipeline ran); got:\n{actual}",
+    );
+    assert!(
+        !actual.contains("return 42"),
+        "`return 42` would be the miscompile this fixture guards against; \
+         got:\n{actual}",
+    );
+}
+
+/// Regression guard: the output must be the SIMPLE typed pipeline, not the
+/// `WHITESPACE_ONLY` fallback (which re-stitches `return 42` and cannot drop the
+/// dead `42`).
+#[test]
+fn simple_asi_restricted_did_not_fall_back_to_whitespace_only() {
+    let out = Command::new(BINARY)
+        .args(read_flags())
+        .output()
+        .expect("run closurec");
+    let actual = String::from_utf8_lossy(&out.stdout);
+
+    // The typed pipeline removed the dead statement; the whitespace fallback
+    // never can (it only strips whitespace), so its presence proves the typed
+    // path. `report(f())` survives because it has an observable effect.
+    assert!(
+        actual.contains("report(f())"),
+        "the live call must survive; got:\n{actual}",
+    );
+    assert!(
+        !actual.contains("return 42"),
+        "expected the typed pipeline to split `return` from `42`, proving this \
+         is the SIMPLE optimizer, not the whitespace fallback; got:\n{actual}",
+    );
+}

--- a/code/specs/CLOC26-asi.md
+++ b/code/specs/CLOC26-asi.md
@@ -200,10 +200,42 @@ workaround and the string-predecessor limitation are both gone. (Shipped with
 `lexer` 0.6.0 / `javascript-parser` 0.17.0; fixture
 `closurec/tests/diff/simple-asi-string-newline`.)
 
-**Phase 3 — restricted productions (Rule 3).** Force ASI after
-`return`/`throw`/`break`/`continue`/`yield` + newline, and around postfix
-`++`/`--`. Adversarial miscompile tests. This is the highest-risk phase and is
-deliberately last.
+**Phase 3 — restricted productions (Rule 3). ✅ SHIPPED (keywords).** Force ASI
+after `return`/`throw`/`break`/`continue`/`yield` when their argument is pushed
+onto the next line. This is the one rule the **retry-on-error harness cannot
+catch**, because the offending stream parses *successfully into the wrong tree*:
+the grammar is newline-blind, so `return` ⏎ `a + b` parses as `return a + b` and
+closurec would re-emit exactly that — a silent **miscompile** (JS semantics are
+`return; a + b`). The bad parse *succeeds*, so Rules 1/2 never see it.
+
+Rule 3 therefore runs as a **proactive forward-scan pre-pass**
+(`force_restricted_semicolons`, executed *before* the retry loop in
+`parse_with_asi`). It inserts a `;` immediately after a restricted keyword whose
+*next* token carries `TOKEN_PRECEDED_BY_NEWLINE`. Safety holds by the same lever
+as Rules 1/2: the insertion is gated on a real line terminator after the
+keyword, so every valid single-line `return x;` is byte-identical and the full
+existing fixture suite is unchanged. Context guards keep a keyword that is really
+a *property name* from being mis-split:
+
+* **member access** — a `.`/`?.` before the keyword (`a.return`) names a
+  property; declined.
+* **property key / label** — a `:` after the keyword (`{return: 1}`) marks an
+  object key; declined.
+* **already terminated** — a `;`/`}` after the keyword needs no extra `;` (Rule
+  2 covers the `}`); declined.
+
+`yield` only triggers where the lexer classifies it as a genuine keyword (inside
+a generator); as an ordinary identifier it is left to Rule 1, which already
+splits it. Shipped with `javascript-parser` 0.19.0 (8 new unit tests) and
+closurec fixture `simple-asi-restricted` (`function f(){return` ⏎ `42}` →
+`function f(){return};report(f());` — the dead `42` is dropped only because the
+restriction was honored *and* the typed pipeline ran).
+
+**Postfix `++`/`--` restricted production — deferred follow-up.** `a` ⏎ `++b` is
+`a; ++b` (a prefix increment), not `a++ b`; honoring it needs the same proactive
+treatment but keyed on the operator's predecessor being a left-hand side. It is
+the trickier half and is split into its own future PR; the keyword cases above
+are the high-value slice.
 
 **Phase 4 (optional) — remove the semicolon workaround** from any fixture inputs
 that only had explicit semicolons to avoid the fallback, and add a CHANGELOG note


### PR DESCRIPTION
## ASI Phase 3 — restricted productions (ECMAScript §12.10.1)

The final ASI rule, and the first that **must change a parse the grammar already accepts**. A line terminator is not allowed between a restricted keyword and its argument, so:

```js
function f(){return
42}
```

is `function f(){ return; 42; }` — **not** `return 42`. closurec's grammar is newline-blind, so without this it parses `return 42` and re-emits it: a silent **miscompile** that changes what `f` returns.

### Why a new pre-pass (not the retry-on-error harness)
Rules 1/2 only fire on a parse *failure*, which is what keeps them safe. But the restricted-production stream parses *successfully into the wrong tree*, so the retry loop never sees it. Phase 3 therefore runs as a **proactive forward-scan pre-pass** (`force_restricted_semicolons`) *before* the first parse, inserting a `;` after a restricted keyword whose next token carries `TOKEN_PRECEDED_BY_NEWLINE`.

### Safety — same lever as Rules 1/2
Insertion is gated on a **real newline after the keyword**, so every valid single-line `return x;` is byte-identical and the full existing fixture suite is unchanged. Context guards keep a keyword that is really a property name from being mis-split:
- **member access** — `.`/`?.` before (`a.return`, `a?.return`) → declined
- **property key / label** — `:` after (`{return: 1}`) → declined
- **already terminated** — `;`/`}` after (Rule 2 covers `}`) → declined

`yield` only triggers where the lexer classifies it as a genuine keyword (generator context); as an identifier it's left to Rule 1, which already splits it.

### Scope
Restricted **keywords** (`return`/`throw`/`break`/`continue`/`yield`). Postfix `++`/`--` restricted productions are a documented follow-up (they need the same treatment keyed on the operator's predecessor).

### Tests
- **javascript-parser 0.19.0** — 8 new unit tests (each keyword, same-line no-op, every guard, double-insert-at-`}` guard, idempotence, allocation-free fast path); all 21 asi tests green.
- **closurec 0.170.0** — new e2e fixture `simple-asi-restricted` + integration test `diff_simple_asi_restricted.rs` (3 assertions). `function f(){return`⏎`42}`⏎`report(f())` → `function f(){return};report(f());`. The absence of `42` is the double proof: the restriction was honored *and* the SIMPLE typed pipeline ran (WHITESPACE_ONLY would emit `function f(){return 42}`).
- Full closurec suite: 680 lib + all fixtures byte-identical/green.
- Spec `CLOC26-asi.md` Phase 3 section updated to the concrete design.

Version bumped to 0.170.0 to sit above the concurrent `simple-fold-charat` (0.169) and merged ASI-Rule1 (0.168) branches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)