### PR TITLE
feat(sir): &:sym symbol-to-proc on dispatched calls (M2)

### DIFF
--- a/code/packages/python/sir-runtime-oop/CHANGELOG.md
+++ b/code/packages/python/sir-runtime-oop/CHANGELOG.md
@@ -2,6 +2,37 @@
 
 All notable changes to `coding-adventures-sir-runtime-oop` are documented here.
 
+## [0.1.6] - 2026-06-22
+
+### Added
+
+**`Symbol#to_proc` (`&:sym`) — `sym_to_proc`** (per `code/specs/sir-method-dispatch.md`,
+item M2). New `sym_to_proc(sym) -> Closure`: builds a `sir-runtime-core`
+`Closure` equivalent to Ruby's `sym.to_proc`, so a `&:sym` block argument on a
+dispatched call works — `[1, 2, 3].map(&:to_s)` now evaluates to
+`["1", "2", "3"]`.
+
+- The Ruby→SIR frontend lowers `&:sym` to `block_pass(SymLit("sym"))`; the
+  backend emits the surviving envelope as `_sir_oop_sym_to_proc(intern("sym"))`,
+  and the resulting `Closure` is driven by the block-taking catalog methods
+  (`map`/`select`/`each`/…) through `apply` exactly like a `{ }` block.
+- The closure's `arity` is `None` (variadic), so `apply` forwards a block
+  method's arguments unadjusted: the first becomes the **receiver**, the rest
+  are forwarded as method arguments. This matches `&:sym`'s Ruby arity (one
+  required receiver plus a rest) — correct for the one-arg (`map`) and two-arg
+  (`include?`-style) shapes alike.
+- The proc body dispatches through `call_method`, so an **out-of-catalog method
+  bottoms out at `nil`** rather than raising — the never-raise-on-the-OO-surface
+  invariant holds for the proc body too. A bare string name is accepted
+  defensively in addition to a `Symbol`.
+
+### Known v0 limitation
+
+Arithmetic/comparison operators (`&:+`, `&:<`) are emitted as **native**
+operations, not routed through the dispatch catalog, so `inject(&:+)` is not yet
+supported (the proc would resolve `+` to `nil`). Operator dispatch is tracked in
+the later numeric-fidelity item.
+
 ## [0.1.5] - 2026-06-22
 
 ### Added

--- a/code/packages/python/sir-runtime-oop/README.md
+++ b/code/packages/python/sir-runtime-oop/README.md
@@ -68,6 +68,16 @@ the **non-block `Array`** surface — `length`/`size`/`count`, `first`/`last`,
 **`to_s`/`inspect`** Ruby display forms (so `nil`/`true`/`false` need no catalog)
 plus **`Array#join`**.
 
+### `&:sym` symbol-to-proc (item **M2**)
+
+`sym_to_proc(sym)` builds the `Closure` Ruby's `Symbol#to_proc` returns, so a
+`&:sym` block argument works — `[1, 2, 3].map(&:to_s)` → `["1", "2", "3"]`. The
+backend emits a `&:sym` block-pass on a dispatched call as
+`_sir_oop_sym_to_proc(intern("sym"))`; applying the closure dispatches the named
+method on its first argument (the rest forwarded), through `call_method`, so an
+unknown method still bottoms out at `nil`. Operator symbols (`&:+`) are native
+arithmetic, not in the dispatch catalog — a documented v0 boundary.
+
 ## Honest v0 limitation
 
 Because the frontend does not thread receivers into method bodies, the *current

--- a/code/packages/python/sir-runtime-oop/src/coding_adventures_sir_runtime_oop/__init__.py
+++ b/code/packages/python/sir-runtime-oop/src/coding_adventures_sir_runtime_oop/__init__.py
@@ -38,6 +38,7 @@ from .oop import (
     push_self,
     reset_oop,
     superclass_of,
+    sym_to_proc,
 )
 
 __all__ = [
@@ -57,4 +58,5 @@ __all__ = [
     "push_self",
     "reset_oop",
     "superclass_of",
+    "sym_to_proc",
 ]

--- a/code/packages/python/sir-runtime-oop/src/coding_adventures_sir_runtime_oop/oop.py
+++ b/code/packages/python/sir-runtime-oop/src/coding_adventures_sir_runtime_oop/oop.py
@@ -1157,6 +1157,45 @@ def call_method(recv: Val, name: str, *args: Val) -> Val:
     return None
 
 
+# --- Symbol#to_proc (&:sym) ------------------------------------------------
+#
+# Ruby's ``&:sym`` block argument converts a ``Symbol`` into a block via
+# ``Symbol#to_proc``: the resulting proc calls the named method on its first
+# argument, forwarding any remaining arguments.  So ``[1, 2, 3].map(&:to_s)``
+# is ``[1, 2, 3].map { |x| x.to_s }`` and ``[1, 2].inject(&:+)`` is
+# ``inject { |acc, x| acc + x }``.
+#
+# The Ruby→SIR frontend lowers ``&:sym`` to ``block_pass(SymLit("sym"))``;
+# the backend emits the surviving ``block_pass`` envelope as a call to this
+# helper (``_sir_oop_sym_to_proc(intern("sym"))``), which yields a
+# :class:`Closure` the block-taking catalog methods (``map``/``select``/…)
+# drive through :func:`apply` exactly like a ``{ }`` block.
+#
+# The closure's ``arity`` is ``None`` (variadic): ``apply`` then passes a
+# block method's arguments through unadjusted, so the *first* becomes the
+# receiver and the rest are forwarded as method arguments.  That matches
+# Ruby's ``&:sym`` arity (one required receiver plus a rest) and makes the
+# one-arg (``map``) and two-arg (``inject``) shapes both correct.
+
+
+def sym_to_proc(sym: Val) -> Closure:
+    """Build a :class:`Closure` equivalent to Ruby's ``sym.to_proc``.
+
+    ``sym`` is normally a ``sir-runtime-core`` :class:`Symbol` (the emitted
+    ``intern("name")``); a bare string is accepted defensively.  Applying the
+    returned closure to ``[recv, *rest]`` dispatches ``recv.name(*rest)``
+    through :func:`call_method`, so an out-of-catalog method bottoms out at
+    ``nil`` rather than raising — upholding the never-raise-on-the-OO-surface
+    invariant for the proc body too.
+    """
+    method = sym.name if isinstance(sym, Symbol) else str(sym)
+
+    def _invoke(recv: Val, *rest: Val) -> Val:
+        return call_method(recv, method, *rest)
+
+    return Closure(_invoke, arity=None)
+
+
 def reset_oop() -> None:
     """Reset all OOP runtime state — class registry, self stack, instance/class
     variable stores, and the method table.  Primarily for test isolation.

--- a/code/packages/python/sir-runtime-oop/tests/test_oop.py
+++ b/code/packages/python/sir-runtime-oop/tests/test_oop.py
@@ -619,3 +619,51 @@ def test_inspect_handles_cycles_without_raising() -> None:
     h: dict[Val, Val] = {}
     h["self"] = h
     assert oop.call_method(h, "inspect") == '{"self"=>{...}}'
+
+
+# ── Symbol#to_proc (&:sym) — M2 ───────────────────────────────────────────────
+
+
+def test_sym_to_proc_maps_over_array_via_apply() -> None:
+    from coding_adventures_sir_runtime_core import apply, intern
+
+    proc = oop.sym_to_proc(intern("to_s"))
+    assert isinstance(proc, Closure)
+    # [1, 2, 3].map(&:to_s) — map drives the proc through apply with one arg.
+    assert [apply(proc, [x]) for x in [1, 2, 3]] == ["1", "2", "3"]
+
+
+def test_sym_to_proc_forwards_extra_args_to_method() -> None:
+    from coding_adventures_sir_runtime_core import apply, intern
+
+    # A two-arg apply binds the first as receiver and forwards the rest as
+    # method arguments: ["hello", "ell"] → "hello".include?("ell").  (This is
+    # the arity shape `inject`/`each_with_index` blocks rely on; arithmetic
+    # operators like `&:+` are native, not in the dispatch catalog — out of
+    # scope for M2.)
+    proc = oop.sym_to_proc(intern("include?"))
+    assert apply(proc, ["hello", "ell"]) is True
+    assert apply(proc, ["hello", "xyz"]) is False
+
+
+def test_sym_to_proc_accepts_bare_string_name() -> None:
+    from coding_adventures_sir_runtime_core import apply
+
+    proc = oop.sym_to_proc("upcase")
+    assert apply(proc, ["hi"]) == "HI"
+
+
+def test_sym_to_proc_out_of_catalog_method_returns_nil() -> None:
+    from coding_adventures_sir_runtime_core import apply, intern
+
+    # An unknown method bottoms out at nil (never-raise OO surface).
+    proc = oop.sym_to_proc(intern("no_such_method"))
+    assert apply(proc, [42]) is None
+
+
+def test_sym_to_proc_drives_array_block_method_dispatch() -> None:
+    from coding_adventures_sir_runtime_core import intern
+
+    # End-to-end through call_method: [1, 2, 3].map(&:to_s).
+    proc = oop.sym_to_proc(intern("to_s"))
+    assert oop.call_method([1, 2, 3], "map", proc) == ["1", "2", "3"]

--- a/code/packages/rust/semantic-ir-to-python/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-python/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## 0.1.20 — `&:sym` symbol-to-proc on dispatched calls (M2)
+
+A `&:sym` block argument on a method-dispatch call (`recv.map(&:to_s)`) now
+emits working code. The Ruby→SIR frontend lowers `&:sym` to
+`block_pass(SymLit("sym"))`; the Q9f normalization unwraps `block_pass` only at
+*user-method* `DirectCall` sites, so a block-pass to a `__method__` dispatch
+call reached the backend intact and previously rendered as a broken
+`call_builtin("block_pass", …)`. `emit_arg` and the `__method__` argument loop
+now recognize the surviving envelope:
+
+- `block_pass(SymLit("m"))` → `_sir_oop_sym_to_proc(_sir_intern("m"))` — the
+  `Symbol#to_proc` runtime helper returns a `Closure` that calls `recv.m(*rest)`;
+- `block_pass(<other>)` → the inner operand, unwrapped (the proc *is* the block).
+
+Adds `sym_to_proc as _sir_oop_sym_to_proc` to the OOP runtime import header.
+New tests `sym_block_pass_on_dispatch_emits_sym_to_proc`,
+`proc_block_pass_on_dispatch_unwraps_to_value`,
+`sym_block_pass_as_plain_arg_emits_sym_to_proc`. Requires
+`coding-adventures-sir-runtime-oop` ≥ 0.1.6. Operator symbols (`&:+`) remain a
+documented v0 boundary (native arithmetic, not dispatched).
+
 ## 0.1.19 — `defined?(recv.meth)` → "method" (Q10h)
 
 `defined?` over a method-call operand `recv.meth` — the `__method__` dispatch

--- a/code/packages/rust/semantic-ir-to-python/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-python/src/emit.rs
@@ -805,7 +805,41 @@ fn emit_arg(out: &mut String, a: &Expr, indent: usize) {
             return;
         }
     }
+    if try_emit_block_pass(out, a, indent) {
+        return;
+    }
     emit_expr(out, a, indent);
+}
+
+/// Emit a `&expr` block-pass argument that survived frontend normalization
+/// (M2).  The Ruby frontend wraps a `&`-prefixed block argument as
+/// `BuiltinCall("block_pass", [inner])`.  Q9f unwraps it at *user-method*
+/// `DirectCall` sites, but a block-pass to a **method-dispatch** call
+/// (`recv.map(&:to_s)`) reaches the backend intact inside the `__method__`
+/// envelope.  Two inner shapes matter:
+///
+/// | inner | emitted | meaning |
+/// |---|---|---|
+/// | `SymLit("m")` (`&:m`) | `_sir_oop_sym_to_proc(intern("m"))` | `Symbol#to_proc` — a block calling `recv.m(*rest)` |
+/// | any other (`&proc`)   | `<inner>` (unwrapped) | the operand already *is* the proc/block value |
+///
+/// Returns `true` when it handled a `block_pass` envelope (so the caller does
+/// not also `emit_expr` it).  A malformed envelope (not exactly one operand)
+/// is left for the generic path.
+fn try_emit_block_pass(out: &mut String, a: &Expr, indent: usize) -> bool {
+    if let Expr::BuiltinCall { name, args, .. } = a {
+        if name == "block_pass" && args.len() == 1 {
+            if let Expr::SymLit { .. } = &args[0] {
+                out.push_str("_sir_oop_sym_to_proc(");
+                emit_expr(out, &args[0], indent);
+                out.push(')');
+            } else {
+                emit_expr(out, &args[0], indent);
+            }
+            return true;
+        }
+    }
+    false
 }
 
 fn emit_builtin_call(out: &mut String, name: &str, args: &[Expr], indent: usize) {
@@ -828,6 +862,10 @@ fn emit_builtin_call(out: &mut String, name: &str, args: &[Expr], indent: usize)
                     Expr::VarRef { name: cn, scope: Scope::Const, .. } if is_class_pred && i == 0 => {
                         out.push_str(&quote_py_string(cn));
                     }
+                    // A `&:sym` / `&proc` block argument on a dispatched call
+                    // (`recv.map(&:to_s)`) survives as a `block_pass` envelope
+                    // (Q9f only unwraps these at user-method DirectCalls).
+                    _ if try_emit_block_pass(out, a, indent) => {}
                     _ => emit_expr(out, a, indent),
                 }
             }
@@ -1523,5 +1561,68 @@ mod tests {
         assert!(out.contains("(x := 1)"));
         assert!(out.contains("_sir_plus(x, 2)"));
         assert!(out.ends_with(")[-1]"));
+    }
+
+    // M2 — `&:sym` symbol-to-proc on a method-dispatch call.
+
+    fn method_call(recv: Expr, meth: &str, extra: Vec<Expr>) -> Expr {
+        let mut args = vec![recv, Expr::StrLit { value: meth.into(), span: s() }];
+        args.extend(extra);
+        Expr::BuiltinCall {
+            name: "__method__".into(),
+            args,
+            effects: EffectSet::PURE,
+            span: s(),
+        }
+    }
+
+    fn block_pass(inner: Expr) -> Expr {
+        Expr::BuiltinCall {
+            name: "block_pass".into(),
+            args: vec![inner],
+            effects: EffectSet::PURE,
+            span: s(),
+        }
+    }
+
+    #[test]
+    fn sym_block_pass_on_dispatch_emits_sym_to_proc() {
+        // arr.map(&:to_s) → callMethod(arr, "map", sym_to_proc(intern("to_s")))
+        let e = method_call(
+            Expr::VarRef { name: "arr".into(), scope: Scope::Local, span: s() },
+            "map",
+            vec![block_pass(Expr::SymLit { name: "to_s".into(), span: s() })],
+        );
+        let mut out = String::new();
+        emit_expr(&mut out, &e, 0);
+        assert_eq!(
+            out,
+            r#"_sir_oop_call_method(arr, "map", _sir_oop_sym_to_proc(_sir_intern("to_s")))"#
+        );
+    }
+
+    #[test]
+    fn proc_block_pass_on_dispatch_unwraps_to_value() {
+        // arr.each(&p) → callMethod(arr, "each", p) — the proc IS the block.
+        let e = method_call(
+            Expr::VarRef { name: "arr".into(), scope: Scope::Local, span: s() },
+            "each",
+            vec![block_pass(Expr::VarRef {
+                name: "p".into(),
+                scope: Scope::Local,
+                span: s(),
+            })],
+        );
+        let mut out = String::new();
+        emit_expr(&mut out, &e, 0);
+        assert_eq!(out, r#"_sir_oop_call_method(arr, "each", p)"#);
+    }
+
+    #[test]
+    fn sym_block_pass_as_plain_arg_emits_sym_to_proc() {
+        // The general emit_arg path also handles a surviving block_pass.
+        let mut out = String::new();
+        emit_arg(&mut out, &block_pass(Expr::SymLit { name: "upcase".into(), span: s() }), 0);
+        assert_eq!(out, r#"_sir_oop_sym_to_proc(_sir_intern("upcase"))"#);
     }
 }

--- a/code/packages/rust/semantic-ir-to-python/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-python/src/runtime.rs
@@ -23,6 +23,7 @@ from coding_adventures_sir_runtime_oop import (
     cvar_get as _sir_oop_cvar_get,
     cvar_set as _sir_oop_cvar_set,
     call_method as _sir_oop_call_method,
+    sym_to_proc as _sir_oop_sym_to_proc,
 )
 "##;
 

--- a/code/packages/rust/semantic-ir-to-typescript/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-typescript/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## 0.1.19 — `&:sym` symbol-to-proc on dispatched calls (M2)
+
+A `&:sym` block argument on a method-dispatch call (`recv.map(&:to_s)`) now
+emits working code. The Ruby→SIR frontend lowers `&:sym` to
+`block_pass(SymLit("sym"))`; the Q9f normalization unwraps `block_pass` only at
+*user-method* `DirectCall` sites, so a block-pass to a `__method__` dispatch
+call reached the backend intact and previously rendered as a broken
+`callBuiltin("block_pass", …)`. `emit_arg` and the `__method__` argument loop
+now recognize the surviving envelope:
+
+- `block_pass(SymLit("m"))` → `__SirOop.symToProc(__Sir.intern("m"))` — the
+  `Symbol#to_proc` runtime helper returns a `Closure` that calls `recv.m(...rest)`;
+- `block_pass(<other>)` → the inner operand, unwrapped (the proc *is* the block).
+
+The `__SirOop` namespace import already covers the new helper (no header
+change). New tests `sym_block_pass_on_dispatch_emits_sym_to_proc`,
+`proc_block_pass_on_dispatch_unwraps_to_value`,
+`sym_block_pass_as_plain_arg_emits_sym_to_proc`. Requires
+`@coding-adventures/sir-runtime-oop` ≥ 0.1.6. Operator symbols (`&:+`) remain a
+documented v0 boundary (native arithmetic, not dispatched).
+
 ## 0.1.18 — `defined?(recv.meth)` → "method" (Q10h)
 
 `defined?` over a method-call operand `recv.meth` — the `__method__` dispatch

--- a/code/packages/rust/semantic-ir-to-typescript/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-typescript/src/emit.rs
@@ -927,7 +927,41 @@ fn emit_arg(out: &mut String, a: &Expr, indent: usize) {
             return;
         }
     }
+    if try_emit_block_pass(out, a, indent) {
+        return;
+    }
     emit_expr(out, a, indent);
+}
+
+/// Emit a `&expr` block-pass argument that survived frontend normalization
+/// (M2).  The Ruby frontend wraps a `&`-prefixed block argument as
+/// `BuiltinCall("block_pass", [inner])`.  Q9f unwraps it at *user-method*
+/// `DirectCall` sites, but a block-pass to a **method-dispatch** call
+/// (`recv.map(&:to_s)`) reaches the backend intact inside the `__method__`
+/// envelope.  Two inner shapes matter:
+///
+/// | inner | emitted | meaning |
+/// |---|---|---|
+/// | `SymLit("m")` (`&:m`) | `__SirOop.symToProc(intern("m"))` | `Symbol#to_proc` — a block calling `recv.m(...rest)` |
+/// | any other (`&proc`)   | `<inner>` (unwrapped) | the operand already *is* the proc/block value |
+///
+/// Returns `true` when it handled a `block_pass` envelope (so the caller does
+/// not also `emit_expr` it).  A malformed envelope (not exactly one operand)
+/// is left for the generic path.
+fn try_emit_block_pass(out: &mut String, a: &Expr, indent: usize) -> bool {
+    if let Expr::BuiltinCall { name, args, .. } = a {
+        if name == "block_pass" && args.len() == 1 {
+            if let Expr::SymLit { .. } = &args[0] {
+                out.push_str("__SirOop.symToProc(");
+                emit_expr(out, &args[0], indent);
+                out.push(')');
+            } else {
+                emit_expr(out, &args[0], indent);
+            }
+            return true;
+        }
+    }
+    false
 }
 
 /// Is this argument a `**h` double-splat marker (`BuiltinCall("double_splat",
@@ -1011,6 +1045,10 @@ fn emit_builtin_call(out: &mut String, name: &str, args: &[Expr], indent: usize)
                     Expr::VarRef { name: cn, scope: Scope::Const, .. } if is_class_pred && i == 0 => {
                         out.push_str(&quote_ts_string(cn));
                     }
+                    // A `&:sym` / `&proc` block argument on a dispatched call
+                    // (`recv.map(&:to_s)`) survives as a `block_pass` envelope
+                    // (Q9f only unwraps these at user-method DirectCalls).
+                    _ if try_emit_block_pass(out, a, indent) => {}
                     _ => emit_expr(out, a, indent),
                 }
             }
@@ -1708,5 +1746,68 @@ mod tests {
         // Crucially the SymLit form is suppressed in favour of the
         // direct assignment.
         assert!(!out.contains("intern"));
+    }
+
+    // M2 — `&:sym` symbol-to-proc on a method-dispatch call.
+
+    fn method_call(recv: Expr, meth: &str, extra: Vec<Expr>) -> Expr {
+        let mut args = vec![recv, Expr::StrLit { value: meth.into(), span: s() }];
+        args.extend(extra);
+        Expr::BuiltinCall {
+            name: "__method__".into(),
+            args,
+            effects: EffectSet::PURE,
+            span: s(),
+        }
+    }
+
+    fn block_pass(inner: Expr) -> Expr {
+        Expr::BuiltinCall {
+            name: "block_pass".into(),
+            args: vec![inner],
+            effects: EffectSet::PURE,
+            span: s(),
+        }
+    }
+
+    #[test]
+    fn sym_block_pass_on_dispatch_emits_sym_to_proc() {
+        // arr.map(&:to_s) → callMethod(arr, "map", symToProc(intern("to_s")))
+        let e = method_call(
+            Expr::VarRef { name: "arr".into(), scope: Scope::Local, span: s() },
+            "map",
+            vec![block_pass(Expr::SymLit { name: "to_s".into(), span: s() })],
+        );
+        let mut out = String::new();
+        emit_expr(&mut out, &e, 0);
+        assert_eq!(
+            out,
+            r#"__SirOop.callMethod(arr, "map", __SirOop.symToProc(__Sir.intern("to_s")))"#
+        );
+    }
+
+    #[test]
+    fn proc_block_pass_on_dispatch_unwraps_to_value() {
+        // arr.each(&p) → callMethod(arr, "each", p) — the proc IS the block.
+        let e = method_call(
+            Expr::VarRef { name: "arr".into(), scope: Scope::Local, span: s() },
+            "each",
+            vec![block_pass(Expr::VarRef {
+                name: "p".into(),
+                scope: Scope::Local,
+                span: s(),
+            })],
+        );
+        let mut out = String::new();
+        emit_expr(&mut out, &e, 0);
+        assert_eq!(out, r#"__SirOop.callMethod(arr, "each", p)"#);
+    }
+
+    #[test]
+    fn sym_block_pass_as_plain_arg_emits_sym_to_proc() {
+        // The general emit_arg path also handles a surviving block_pass.
+        let mut out = String::new();
+        emit_arg(&mut out, &block_pass(Expr::SymLit { name: "upcase".into(), span: s() }), 0);
+        assert_eq!(out, r#"__SirOop.symToProc(__Sir.intern("upcase"))"#);
     }
 }

--- a/code/packages/typescript/sir-runtime-oop/CHANGELOG.md
+++ b/code/packages/typescript/sir-runtime-oop/CHANGELOG.md
@@ -2,6 +2,36 @@
 
 All notable changes to `@coding-adventures/sir-runtime-oop` are documented here.
 
+## [0.1.6] - 2026-06-22
+
+### Added
+
+**`Symbol#to_proc` (`&:sym`) — `symToProc`** (per `code/specs/sir-method-dispatch.md`,
+item M2). New `symToProc(sym): Closure`: builds a `@coding-adventures/sir-runtime-core`
+`Closure` equivalent to Ruby's `sym.to_proc`, so a `&:sym` block argument on a
+dispatched call works — `[1, 2, 3].map(&:to_s)` now evaluates to
+`["1", "2", "3"]`.
+
+- The Ruby→SIR frontend lowers `&:sym` to `block_pass(SymLit("sym"))`; the
+  backend emits the surviving envelope as `__SirOop.symToProc(intern("sym"))`,
+  and the resulting `Closure` is driven by the block-taking catalog methods
+  (`map`/`select`/`each`/…) through `apply` exactly like a `{ }` block.
+- `apply` forwards a block method's arguments unadjusted: the first becomes the
+  **receiver**, the rest are forwarded as method arguments. This matches
+  `&:sym`'s Ruby arity (one required receiver plus a rest) — correct for the
+  one-arg (`map`) and two-arg (`include?`-style) shapes alike.
+- The proc body dispatches through `callMethod`, so an **out-of-catalog method
+  bottoms out at `null`** rather than throwing — the never-throw-on-the-OO-surface
+  invariant holds for the proc body too. A bare string name is accepted
+  defensively in addition to a `Sym`.
+
+### Known v0 limitation
+
+Arithmetic/comparison operators (`&:+`, `&:<`) are emitted as **native**
+operations, not routed through the dispatch catalog, so `inject(&:+)` is not yet
+supported (the proc would resolve `+` to `null`). Operator dispatch is tracked in
+the later numeric-fidelity item.
+
 ## [0.1.5] - 2026-06-22
 
 ### Added

--- a/code/packages/typescript/sir-runtime-oop/README.md
+++ b/code/packages/typescript/sir-runtime-oop/README.md
@@ -69,6 +69,16 @@ and (item **M1c**) the **`Integer`/`Float`** catalog (`abs`, `to_i`/`to_f`,
 **`to_s`/`inspect`** Ruby display forms (so `null`/`true`/`false` need no catalog)
 plus **`Array#join`**.
 
+### `&:sym` symbol-to-proc (item **M2**)
+
+`symToProc(sym)` builds the `Closure` Ruby's `Symbol#to_proc` returns, so a
+`&:sym` block argument works — `[1, 2, 3].map(&:to_s)` → `["1", "2", "3"]`. The
+backend emits a `&:sym` block-pass on a dispatched call as
+`__SirOop.symToProc(intern("sym"))`; applying the closure dispatches the named
+method on its first argument (the rest forwarded), through `callMethod`, so an
+unknown method still bottoms out at `null`. Operator symbols (`&:+`) are native
+arithmetic, not in the dispatch catalog — a documented v0 boundary.
+
 ## Honest v0 limitation
 
 Because the frontend does not thread receivers into method bodies, the *current

--- a/code/packages/typescript/sir-runtime-oop/src/index.ts
+++ b/code/packages/typescript/sir-runtime-oop/src/index.ts
@@ -1138,6 +1138,27 @@ function classNameArg(arg: Val): string {
   return typeof arg === "string" ? arg : classOf(arg);
 }
 
+// --- Symbol#to_proc (&:sym) ------------------------------------------------
+//
+// Ruby's `&:sym` block argument converts a `Symbol` into a block via
+// `Symbol#to_proc`: the resulting proc calls the named method on its first
+// argument, forwarding any remaining arguments. So `[1, 2, 3].map(&:to_s)` is
+// `[1, 2, 3].map { |x| x.to_s }` and `[1, 2].inject(&:+)` is
+// `inject { |acc, x| acc + x }`.
+//
+// The Ruby→SIR frontend lowers `&:sym` to `block_pass(SymLit("sym"))`; the
+// backend emits the surviving `block_pass` envelope as a call to this helper
+// (`__SirOop.symToProc(intern("sym"))`), which yields a `Closure` the
+// block-taking catalog methods (`map`/`select`/…) drive through `apply`
+// exactly like a `{ }` block. `apply` forwards arguments unadjusted, so the
+// first becomes the receiver and the rest are forwarded as method arguments —
+// faithful to `&:sym`'s arity (one required receiver plus a rest), correct for
+// both the one-arg (`map`) and two-arg (`inject`) shapes.
+export function symToProc(sym: Val): Closure {
+  const method = isSymbol(sym) ? (sym as { name: string }).name : String(sym);
+  return new Closure((recv: Val, ...rest: Val[]): Val => callMethod(recv, method, ...rest));
+}
+
 /**
  * Reset all OOP runtime state — class registry, self stack, instance/class
  * variable stores, and the method table.  Primarily for test isolation.

--- a/code/packages/typescript/sir-runtime-oop/tests/oop.test.ts
+++ b/code/packages/typescript/sir-runtime-oop/tests/oop.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it } from "vitest";
-import { Closure } from "@coding-adventures/sir-runtime-core";
+import { apply, Closure, intern } from "@coding-adventures/sir-runtime-core";
 import type { Val } from "../src/index.js";
 import {
   callMethod,
@@ -17,6 +17,7 @@ import {
   resetOop,
   SirInstance,
   superclassOf,
+  symToProc,
 } from "../src/index.js";
 
 beforeEach(() => {
@@ -604,5 +605,39 @@ describe("nil / true / false + Object to_s/inspect (M1c)", () => {
     const m = new Map<Val, Val>();
     m.set("self", m);
     expect(callMethod(m, "inspect")).toBe('{"self"=>{...}}');
+  });
+
+  // ── Symbol#to_proc (&:sym) — M2 ─────────────────────────────────────────
+
+  it("symToProc maps over an array via apply", () => {
+    const proc = symToProc(intern("to_s"));
+    expect(proc).toBeInstanceOf(Closure);
+    // [1, 2, 3].map(&:to_s) — map drives the proc through apply with one arg.
+    expect([1, 2, 3].map((x) => apply(proc, [x]))).toEqual(["1", "2", "3"]);
+  });
+
+  it("symToProc forwards extra args to the dispatched method", () => {
+    // Two-arg apply binds the first as receiver, forwards the rest:
+    // ["hello", "ell"] → "hello".include?("ell").
+    const proc = symToProc(intern("include?"));
+    expect(apply(proc, ["hello", "ell"])).toBe(true);
+    expect(apply(proc, ["hello", "xyz"])).toBe(false);
+  });
+
+  it("symToProc accepts a bare string name", () => {
+    expect(apply(symToProc("upcase" as unknown as Val), ["hi"])).toBe("HI");
+  });
+
+  it("symToProc bottoms out at nil for an out-of-catalog method", () => {
+    expect(apply(symToProc(intern("no_such_method")), [42])).toBeNull();
+  });
+
+  it("symToProc drives array block-method dispatch end to end", () => {
+    // [1, 2, 3].map(&:to_s) through callMethod.
+    expect(callMethod([1, 2, 3], "map", symToProc(intern("to_s")))).toEqual([
+      "1",
+      "2",
+      "3",
+    ]);
   });
 });

--- a/code/specs/sir-method-dispatch.md
+++ b/code/specs/sir-method-dispatch.md
@@ -9,7 +9,8 @@ plus a `define_method` table and **returns `nil` for every other method**, so
 `arr.each`, `arr.map`, `"x".upcase`, `3.times`, `h.keys`, … all evaluate to nil
 instead of running. This spec defines the bounded, type-dispatched built-in method
 library that makes them execute, and the block-passing contract they rely on. It is
-the foundation `&:sym` (Symbol#to_proc) builds on.
+the foundation `&:sym` (Symbol#to_proc) builds on — **delivered in M2**, see the
+*Symbol#to_proc (`&:sym`)* section below.
 
 This is a runtime-package change only — no `semantic-ir` core or frontend change. The
 frontend already emits `recv.meth(args…)` as `BuiltinCall("__method__", [recv,
@@ -80,10 +81,47 @@ results (`select`/`any?`/…). `to_s`/`inspect`/`join` route non-string parts th
 
 ## Backend wiring
 
-No emit change is required: `recv.meth(args)` already routes to
-`call_method`/`callMethod`. The only backend-visible effect is that `sir-runtime-oop`
-is imported whenever a module uses `__method__` (already the case). The two backends'
-`__method__` arm is unchanged.
+For the **M1** catalog no emit change is required: `recv.meth(args)` already routes
+to `call_method`/`callMethod`, and `sir-runtime-oop` is imported whenever a module
+uses `__method__` (already the case).
+
+**M2** adds one emit-layer rule (see next section): a `&:sym` / `&proc` block
+argument that survives frontend normalization — i.e. a `block_pass` envelope sitting
+in a `__method__` dispatch call's argument list — is recognized by `emit_arg` and the
+`__method__` arm and rewritten to a `symToProc`/unwrapped-proc value.
+
+## Symbol#to_proc (`&:sym`) — M2
+
+Ruby's `&:sym` block argument converts a `Symbol` to a block via `Symbol#to_proc`:
+the proc calls the named method on its first argument, forwarding the rest. So
+`[1, 2, 3].map(&:to_s)` is `[1, 2, 3].map { |x| x.to_s }` and a two-arg block shape
+(`include?`-style) binds the first argument as receiver and forwards the rest.
+
+**Lowering (existing).** The Ruby→SIR frontend lowers a `&`-prefixed block argument
+to `BuiltinCall("block_pass", [inner])`. The Q9f call-site normalization unwraps that
+envelope **only at user-method `DirectCall` sites** (threading the proc as the
+trailing block parameter). A block-pass to a **method-dispatch** call (`recv.meth(&…)`,
+the `__method__` envelope) is *not* normalized — it reaches the backend intact.
+
+**Emit (M2).** `emit_arg` and the `__method__` argument loop recognize a surviving
+`block_pass` envelope:
+
+| inner shape | emitted (py / ts) | meaning |
+|---|---|---|
+| `SymLit("m")` (`&:m`) | `_sir_oop_sym_to_proc(intern("m"))` / `__SirOop.symToProc(intern("m"))` | `Symbol#to_proc` |
+| any other (`&proc`)   | the inner operand, unwrapped | the operand already *is* the proc/block |
+
+**Runtime.** `sir-runtime-oop` gains `sym_to_proc(sym) -> Closure` (py) /
+`symToProc(sym): Closure` (ts): a `sir-runtime-core` `Closure` whose body dispatches
+`call_method(recv, name, *rest)`. Its arity is variadic, so `apply` forwards a block
+method's arguments unadjusted (first = receiver, rest forwarded) — matching `&:sym`'s
+Ruby arity. The body routes through `call_method`, so an out-of-catalog method bottoms
+out at the `nil` floor rather than raising.
+
+**v0 boundary.** Operator symbols (`&:+`, `&:<`) are emitted as **native** arithmetic
+/ comparison, not routed through the dispatch catalog, so `inject(&:+)` is not yet
+supported (the proc would resolve `+` to `nil`). Operator dispatch is tracked with the
+later numeric-fidelity item.
 
 ## Out of scope (documented, honest floor)
 


### PR DESCRIPTION
## M2 — `&:sym` symbol-to-proc on dispatched calls

`[1, 2, 3].map(&:to_s)` now round-trips Ruby → SIR → Python / TypeScript and runs.

### Background
The Ruby→SIR frontend lowers a `&`-prefixed block argument to `BuiltinCall("block_pass", [inner])`. The Q9f call-site normalization unwraps that envelope **only at user-method `DirectCall` sites**; a block-pass to a *method-dispatch* call (the `__method__` envelope, e.g. `recv.map(&:to_s)`) reached the backend intact and previously rendered as a broken `call_builtin("block_pass", …)`. Q10h had documented `&:sym`'s target as the terminal method-dispatch boundary — M2 delivers it now that the M1 catalogs exist.

### Runtime (`sir-runtime-oop`, py + ts)
New `sym_to_proc(sym) -> Closure` / `symToProc(sym): Closure` — Ruby's `Symbol#to_proc`:
- builds a `sir-runtime-core` `Closure` whose body dispatches `call_method(recv, name, *rest)` — first applied arg is the receiver, the rest forwarded;
- variadic arity, so `apply` forwards a block method's arguments unadjusted (correct for one-arg `map` and two-arg `include?`-style shapes);
- the proc body bottoms out at the nil/null floor for an unknown method (never-raise-on-the-OO-surface invariant). Bare-string names accepted defensively.

### Backends (`semantic-ir-to-python` / `-typescript`)
`emit_arg` and the `__method__` argument loop recognize a surviving `block_pass` envelope:
- `block_pass(SymLit("m"))` → `_sir_oop_sym_to_proc(intern("m"))` / `__SirOop.symToProc(intern("m"))`;
- `block_pass(<other>)` → the inner operand, unwrapped (the proc *is* the block).

The py OOP import header gains `sym_to_proc as _sir_oop_sym_to_proc`; TS uses the existing `__SirOop` namespace import (no header change). The symbol name flows through the normal escaped SymLit emit path (`quote_*_string` + `intern`).

### Tests / verification
- Runtime unit tests: py **68 passed** (ruff + mypy --strict clean, 95.8% cov), ts **66 passed** (tsc clean) — map-over-array, arg forwarding, bare-string name, nil floor, end-to-end `callMethod(map)` dispatch.
- Backend emitted-shape tests (py + ts): sym → `sym_to_proc`, proc → unwrap, plain-arg path. `cargo test` both backends green.
- **Execution-proof** (Python, real runtime packages on path): `[1,2,3].map(&:to_s)` → `['1','2','3']`, `["a","bb"].map(&:length)` → `[1, 2]`.
- Security review **passed** (symbol name escaped via SymLit path; dispatch is a Map/dict lookup — no dynamic `getattr`/`eval`/prototype sink).

### Spec
`code/specs/sir-method-dispatch.md` gains a *Symbol#to_proc (`&:sym`)* section; Status updated to mark M2 delivered.

### v0 boundary (documented)
Operator symbols (`&:+`, `&:<`) are emitted as **native** arithmetic/comparison, not routed through the dispatch catalog, so `inject(&:+)` is not yet supported — tracked with the later numeric-fidelity item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
