### PR TITLE
feat(visicalc-xaml): sort a range in the XAML demo

### DIFF
--- a/demo/visicalc-xaml/Engine.cs
+++ b/demo/visicalc-xaml/Engine.cs
@@ -67,6 +67,13 @@ internal static class ScNative
         [MarshalAs(UnmanagedType.LPUTF8Str)] string src,
         [MarshalAs(UnmanagedType.LPUTF8Str)] string dstStart,
         [MarshalAs(UnmanagedType.LPUTF8Str)] string dstEnd);
+    // sc_sort_range(session, start, end, key_col, ascending) → int (1 applied /
+    // already sorted, 0 no-op). Two A1 strings + a 1-based key column + a flag.
+    [DllImport("spreadsheet_capi")]
+    internal static extern int sc_sort_range(IntPtr s,
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string start,
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string end,
+        uint keyCol, int ascending);
     // sc_copy / sc_cut(session, start, end) → void (clipboard capture; two A1 strings).
     [DllImport("spreadsheet_capi")]
     internal static extern void sc_copy(IntPtr s,
@@ -163,6 +170,16 @@ public sealed class SpreadsheetSession : IDisposable
     /// every dependent. Reaches sc_fill — the same path every other backend drives.
     public void Fill(string src, string dstStart, string dstEnd) =>
         ScNative.sc_fill(_handle, src, dstStart, dstEnd);
+
+    /// Range sort: reorder the rows of the rectangle `start`..`end` by the
+    /// computed values in `keyCol` (1-based, inside the rectangle), ascending or
+    /// descending. Each row moves as a record; the engine shifts moved formulas'
+    /// references with their row and carries formats. Returns true when a sort was
+    /// applied (or the range was already sorted), false for a no-op. `keyCol` is
+    /// clamped to ≥ 0 before the uint cast; the engine validates it lies inside
+    /// the rectangle. Reaches sc_sort_range — the same path every backend drives.
+    public bool SortRange(string start, string end, int keyCol, bool ascending) =>
+        ScNative.sc_sort_range(_handle, start, end, (uint)Math.Max(0, keyCol), ascending ? 1 : 0) != 0;
 
     /// Structural edits: insert / delete `count` rows or columns at the 1-based
     /// position `at`. The engine shifts every formula reference at or after the
@@ -565,6 +582,19 @@ public sealed class InfiniteSheetModel : IDisposable
     /// stored value is unchanged; the engine renders it through the code, so a
     /// fresh RowCells read shows the formatted string.
     public void ApplyFormat(string code) => _session.SetFormat(InfAddress, code);
+
+    /// Range sort: reorder the rows of the seeded budget block A1:E4 by the
+    /// SELECTED column (clamped into the block's columns A..E = 1..5), ascending
+    /// or descending. Each row moves as a record; the E-column SUM formulas travel
+    /// with their row (the engine shifts their refs), so every total stays correct.
+    /// Returns false for a no-op (already sorted / bad args). Regrows the extent.
+    public bool SortBlock(bool ascending)
+    {
+        int keyCol = Math.Clamp(SelCol, 1, 5);
+        bool ok = _session.SortRange("A1", "E4", keyCol, ascending);
+        ComputeExtent();
+        return ok;
+    }
 
     /// Clipboard: copy/cut the selected cell, then paste it at the selection. The
     /// engine shifts the pasted formula's relative references by the destination's

--- a/demo/visicalc-xaml/InfiniteSheet.xaml
+++ b/demo/visicalc-xaml/InfiniteSheet.xaml
@@ -179,6 +179,16 @@
                             ToolTipService.ToolTip="Clear the selected cell's format (General)"
                             Click="FmtGeneralButton_Click"/>
                     <Border Width="1" Height="22" Margin="6,0,6,0" Background="#2C313A"/>
+                    <!-- Sort (reorder the budget block A1:E4 by the selected column) -->
+                    <Button x:Name="SortAscButton" Style="{StaticResource ToolChip}" Margin="0,0,6,0"
+                            Content="▲ Sort"
+                            ToolTipService.ToolTip="Sort the budget block A1:E4 by the selected column, ascending (rows move as records; formulas track)"
+                            Click="SortAscButton_Click"/>
+                    <Button x:Name="SortDescButton" Style="{StaticResource ToolChip}"
+                            Content="▼ Sort"
+                            ToolTipService.ToolTip="Sort the budget block A1:E4 by the selected column, descending"
+                            Click="SortDescButton_Click"/>
+                    <Border Width="1" Height="22" Margin="6,0,6,0" Background="#2C313A"/>
                     <!-- History (undo / redo) -->
                     <Button x:Name="UndoButton" Style="{StaticResource ToolChip}" Margin="0,0,6,0"
                             Content="↶ Undo"

--- a/demo/visicalc-xaml/InfiniteSheet.xaml.cs
+++ b/demo/visicalc-xaml/InfiniteSheet.xaml.cs
@@ -259,6 +259,13 @@ public sealed partial class InfiniteSheet : UserControl
     private void FmtCurrencyButton_Click(object sender, RoutedEventArgs e) { _model.ApplyFormat("$#,##0.00"); RepaintRealizedRows(); }
     private void FmtGeneralButton_Click(object sender, RoutedEventArgs e) { _model.ApplyFormat(""); RepaintRealizedRows(); }
 
+    /// Range sort: reorder the budget block A1:E4 by the selected column,
+    /// ascending/descending. Each row moves as a record — the E-column SUM
+    /// formulas travel with their row and the engine shifts their refs, so every
+    /// total stays correct. Repaint the realized rows to show the new order.
+    private void SortAscButton_Click(object sender, RoutedEventArgs e) { _model.SortBlock(true); RepaintRealizedRows(); }
+    private void SortDescButton_Click(object sender, RoutedEventArgs e) { _model.SortBlock(false); RepaintRealizedRows(); }
+
     /// Clipboard: copy/cut the selected cell, then paste it at the selection. The
     /// engine shifts the pasted formula's relative refs by the destination's
     /// offset, pins absolute ($) refs, carries the format; a cut clears the source

--- a/demo/visicalc-xaml/test/Program.cs
+++ b/demo/visicalc-xaml/test/Program.cs
@@ -244,5 +244,30 @@ using (var fmt = new SpreadsheetSession())
     Check("fmt raw untouched", fmt.GetRaw("A1"), "1234"); // display-only
 }
 
+// ── Range sort (the ▲/▼ Sort buttons drive SortRange): reorder the budget block
+// A1:E4 by a key column. Each row moves as a record — the E-column SUM formulas
+// travel with their row (the engine shifts the refs), so every total stays
+// correct after the reorder.
+using (var so = new SpreadsheetSession())
+{
+    foreach (var (a, v) in new[]
+    {
+        ("A1", "15"), ("B1", "3"), ("C1", "12"), ("D1", "8"), ("E1", "=SUM(A1:D1)"),
+        ("A2", "8"), ("B2", "14"), ("C2", "7"), ("D2", "22"), ("E2", "=SUM(A2:D2)"),
+        ("A3", "12"), ("B3", "9"), ("C3", "18"), ("D3", "6"), ("E3", "=SUM(A3:D3)"),
+        ("A4", "4"), ("B4", "11"), ("C4", "3"), ("D4", "17"), ("E4", "=SUM(A4:D4)"),
+    }) so.SetCell(a, v);
+    Check("sort pre A1", so.Window(1, 1, 1, 1)[0][0], "15");
+    Check("sort applied asc", so.SortRange("A1", "E4", 1, true).ToString(), "True");
+    Check("sort A1 asc", so.Window(1, 1, 1, 1)[0][0], "4");    // col A → 4,8,12,15
+    Check("sort A4 asc", so.Window(4, 1, 4, 1)[0][0], "15");
+    Check("sort E1 asc", so.Window(1, 5, 1, 5)[0][0], "35");   // E tracks row: 4+11+3+17
+    Check("sort E4 asc", so.Window(4, 5, 4, 5)[0][0], "38");   // 15+3+12+8
+    Check("sort applied desc", so.SortRange("A1", "E4", 1, false).ToString(), "True");
+    Check("sort A1 desc", so.Window(1, 1, 1, 1)[0][0], "15");
+    Check("sort single-row no-op", so.SortRange("A1", "A1", 1, true).ToString(), "False");
+    Check("sort bad key no-op", so.SortRange("A1", "E4", 9, true).ToString(), "False");
+}
+
 Console.WriteLine(failures == 0 ? "\nALL PASS" : $"\n{failures} FAILURE(S)");
 return failures == 0 ? 0 : 1;


### PR DESCRIPTION
## What

Fourth native backend of the sort-a-range rollout (after Qt [#6543](https://github.com/adhithyan15/coding-adventures/pull/6543), Flutter [#6544](https://github.com/adhithyan15/coding-adventures/pull/6544), Compose [#6545](https://github.com/adhithyan15/coding-adventures/pull/6545)). Adds a **"Sort"** toolbar group (▲ Sort / ▼ Sort) sorting the seeded budget block **A1:E4** by the **selected column** (clamped into A..E), ascending/descending, via a new **P/Invoke** `sc_sort_range`.

Each row moves as a **record** — the E-column `SUM` formulas travel with their row (engine shifts the refs), so every total stays correct. Same `[MarshalAs(LPUTF8Str)]` marshalling as `sc_fill` + `(uint)Math.Max(0,·)` clamp; the model's `SortBlock` clamps the key column to 1..5.

## Verification

The WinUI view is **Windows-only** (this macOS checkout can't `dotnet build` it — the documented boundary), so the Sort buttons + handlers are hand-authored; the engine-backed model is proven cross-platform by **`scripts/verify.sh`** (the `test/` console harness P/Invoking the engine) → **ALL PASS**, incl. the new sort block: A col `15,8,12,4` → `4,8,12,15` with E totals `35`/`38` tracking rows; descending reverses; single-row + out-of-range-key → `False`. Re-vendored the capi (now carries `sc_sort_range`). Security review **passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)