### PR TITLE
feat(visicalc-swiftui): sort a range in the SwiftUI demo

### DIFF
--- a/demo/visicalc-swiftui/Sources/CSpreadsheetEngine/include/spreadsheet.h
+++ b/demo/visicalc-swiftui/Sources/CSpreadsheetEngine/include/spreadsheet.h
@@ -75,6 +75,16 @@ void  sc_copy(ScSession *s, const char *start, const char *end);
 void  sc_cut(ScSession *s, const char *start, const char *end);
 int   sc_paste(ScSession *s, const char *dst_start);
 
+/* Sort the rows of the inclusive rectangle start..end by the computed values in
+   key_col (a 1-based absolute column index inside the rectangle). ascending is a
+   flag (0 = descending, non-zero = ascending). Each row moves as a record; moved
+   formulas have their relative references shifted with their row, formats ride
+   along. Returns 1 when a valid sort is applied (or the range was already sorted),
+   0 for a malformed address, an out-of-range key_col, an empty/single-row range,
+   or an oversized rectangle. The host re-reads via sc_get_window afterwards. */
+int   sc_sort_range(ScSession *s, const char *start, const char *end,
+                    uint32_t key_col, int ascending);
+
 /* Save / load. sc_serialize() returns a self-contained JSON document holding the
    workbook's SOURCE (formula text + typed literals) and per-cell formats — not the
    computed values, which recompute on load (small file, can't disagree with itself).

--- a/demo/visicalc-swiftui/Sources/VisiCalc/Engine.swift
+++ b/demo/visicalc-swiftui/Sources/VisiCalc/Engine.swift
@@ -48,6 +48,17 @@ final class SpreadsheetSession {
         sc_fill(handle, src, dstStart, dstEnd)
     }
 
+    /// Range sort: reorder the rows of the rectangle `start`..`end` by the
+    /// computed values in `keyCol` (1-based, inside the rectangle), ascending or
+    /// descending. Each row moves as a record; the engine shifts moved formulas'
+    /// references with their row and carries formats. Returns true when a sort was
+    /// applied (or the range was already sorted), false for a no-op (malformed
+    /// address / out-of-range key / oversized range). Reaches `sc_sort_range` —
+    /// the same path every backend drives.
+    func sortRange(_ start: String, _ end: String, _ keyCol: UInt32, _ ascending: Bool) -> Bool {
+        sc_sort_range(handle, start, end, keyCol, ascending ? 1 : 0) != 0
+    }
+
     /// Structural edits: insert / delete `count` rows or columns at the 1-based
     /// position `at`. The engine shifts every formula reference at or after the
     /// band (a reference whose whole band is deleted becomes `#REF!`), then

--- a/demo/visicalc-swiftui/Sources/VisiCalc/InfiniteGrid.swift
+++ b/demo/visicalc-swiftui/Sources/VisiCalc/InfiniteGrid.swift
@@ -174,6 +174,21 @@ final class WindowedSheetModel: ObservableObject {
         revision += 1
     }
 
+    /// Range sort: reorder the rows of the seeded budget block A1:E4 by the
+    /// SELECTED column (clamped into the block's columns A..E = 1...5), ascending
+    /// or descending. Each row moves as a record; the E-column SUM formulas travel
+    /// with their row (the engine shifts their refs), so every total stays correct.
+    /// Returns false for a no-op (already sorted / bad args). Bumps `revision` so
+    /// the visible rows re-fetch. The SwiftUI sibling of the web/Qt/Flutter/Compose/
+    /// XAML "Sort" group.
+    @discardableResult
+    func sortBlock(_ ascending: Bool) -> Bool {
+        let keyCol = UInt32(min(5, max(1, selectedCol)))
+        let ok = session.sortRange("A1", "E4", keyCol, ascending)
+        revision += 1
+        return ok
+    }
+
     /// Clipboard: copy/cut the selected cell, then paste it at the selection. The
     /// engine shifts the pasted formula's relative references by the
     /// destination's offset, pins absolute (`$`) refs, carries the format; a cut
@@ -400,6 +415,12 @@ struct InfiniteGridView: View {
                 .help("Format the selected cell as currency (display only)")
             Button("Gen") { model.applyFormat("") }
                 .help("Clear the number format (back to General)")
+            toolSep
+            // ── Sort (reorder the budget block A1:E4 by the selected column) ──
+            Button("▲ Sort") { model.sortBlock(true) }
+                .help("Sort the budget block A1:E4 by the selected column, ascending (rows move as records; formulas track)")
+            Button("▼ Sort") { model.sortBlock(false) }
+                .help("Sort the budget block A1:E4 by the selected column, descending")
             toolSep
             // ── History (undo / redo). The buttons gate off canUndo/canRedo,
             // re-evaluated whenever `revision` (a @Published) bumps after an edit.

--- a/demo/visicalc-swiftui/Tests/VisiCalcTests/WindowedModelTests.swift
+++ b/demo/visicalc-swiftui/Tests/VisiCalcTests/WindowedModelTests.swift
@@ -227,4 +227,26 @@ final class WindowedModelTests: XCTestCase {
         m.applyFormat("")
         XCTAssertEqual(m.rowCells(1)[7], "1234")
     }
+
+    /// Range sort (the ▲/▼ Sort buttons drive sortBlock): reorder the seeded
+    /// budget block A1:E4 by the selected column. The default seed has column A =
+    /// 15,8,12,4 (rows 1..4, unformatted) and each E cell = SUM(row) formatted
+    /// "#,##0.00". Sorting by column A ascending moves each row as a record — col
+    /// A becomes 4,8,12,15 and every E total travels with its row (the engine
+    /// shifts the moved SUM formulas' refs). Descending reverses it.
+    func testSortRangeReordersRowsByKeyColumn() {
+        let m = WindowedSheetModel()
+        // Pre-sort: column A rows 1..4 = 15,8,12,4 (selection defaults to A1).
+        XCTAssertEqual(m.window(rows: 1...4, cols: 1...1).map { $0[0] }, ["15", "8", "12", "4"])
+        // Ascending by column A → 4,8,12,15.
+        XCTAssertTrue(m.sortBlock(true))
+        XCTAssertEqual(m.window(rows: 1...4, cols: 1...1).map { $0[0] }, ["4", "8", "12", "15"])
+        // Each row's E total tracked its row (formatted "#,##0.00").
+        XCTAssertEqual(m.window(rows: 1...1, cols: 5...5)[0][0], "35.00")  // 4+11+3+17
+        XCTAssertEqual(m.window(rows: 4...4, cols: 5...5)[0][0], "38.00")  // 15+3+12+8
+        // Descending reverses the key order.
+        XCTAssertTrue(m.sortBlock(false))
+        XCTAssertEqual(m.window(rows: 1...1, cols: 1...1)[0][0], "15")
+        XCTAssertEqual(m.window(rows: 4...4, cols: 1...1)[0][0], "4")
+    }
 }


### PR DESCRIPTION
## What

**Fifth and last** native backend of the sort-a-range rollout (after Qt [#6543](https://github.com/adhithyan15/coding-adventures/pull/6543), Flutter [#6544](https://github.com/adhithyan15/coding-adventures/pull/6544), Compose [#6545](https://github.com/adhithyan15/coding-adventures/pull/6545), XAML [#6548](https://github.com/adhithyan15/coding-adventures/pull/6548)) — completes sort across **all 6 backends**. Adds a **"Sort"** toolbar group (▲ Sort / ▼ Sort) sorting the seeded budget block **A1:E4** by the **selected column** (clamped into A..E), ascending/descending, via a new `SpreadsheetSession.sortRange` over `sc_sort_range`.

Each row moves as a **record** — the E-column `SUM` formulas travel with their row (engine shifts the refs), so every total stays correct. Same implicit `String`→`char*` bridging as `setFormat`/`fill`; the model's `sortBlock` clamps the key column to `1...5`.

## Verification

Re-vendored the capi: refreshed the **tracked** C header (`Sources/CSpreadsheetEngine/include/spreadsheet.h` now declares `sc_sort_range`) + the macOS static lib. **`swift build` + `swift test` → all pass**, incl. the new `testSortRangeReordersRowsByKeyColumn`: A col `15,8,12,4` → `4,8,12,15` with E totals `35.00`/`38.00` tracking their rows; descending reverses. Security review **passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)