### PR TITLE
test(x86-simulator): ALGOL `own` global runs locally (LANG-FULL AL6 follow-up)

### DIFF
--- a/code/packages/rust/x86-simulator/CHANGELOG.md
+++ b/code/packages/rust/x86-simulator/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog — x86-simulator
 
+## 0.7.2 — 2026-06-22 — ALGOL `own` global cell (LANG-FULL AL6 follow-up)
+
+Adds the executed matrix cell `algol_own_variable_runs_on_x86_sim`: an ALGOL
+`own integer n` (LANG-FULL AL6, merged) inside `bump` persists across calls —
+`bump(1)+bump(1)+bump(1)` accumulates 1+2+3 = 6 on the one `_twig_globals` slot
+(a non-`own` local gives 3) ⇒ exit `6`, run on the real x86_64 bytes. With the
+E6 (`algol_module_global_…`) and O3 (`oct_static_global_…`, 0.7.1) cells, all
+three module-global frontends now execute locally on the x86_64 backend via the
+S8 `_twig_globals` path. Test-only; no library change.
+
 ## 0.7.1 — 2026-06-22 — Oct `static` global cell (LANG-FULL O3 follow-up)
 
 Adds an executed matrix cell `oct_static_global_runs_on_x86_sim`: an Oct

--- a/code/packages/rust/x86-simulator/Cargo.toml
+++ b/code/packages/rust/x86-simulator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "x86-simulator"
-version = "0.7.1"
+version = "0.7.2"
 edition = "2021"
 description = "x86/x86-64 runtime simulator — decode + execute machine code, and run the x86_64-backend's emitted code locally (host-arch-independent)"
 

--- a/code/packages/rust/x86-simulator/tests/lang_matrix_x86.rs
+++ b/code/packages/rust/x86-simulator/tests/lang_matrix_x86.rs
@@ -333,6 +333,23 @@ fn oct_static_global_runs_on_x86_sim() {
     assert_eq!(out, "42");
 }
 
+/// ALGOL 60 — an **`own` static-lifetime variable** (LANG-FULL AL6) on the
+/// x86_64 backend.  `bump`'s `own integer n` is a module global (the same
+/// `_twig_globals` slot mechanism, S8) that persists across calls:
+/// `bump(1) + bump(1) + bump(1)` accumulates 1 + 2 + 3 = 6 on the one cell.  A
+/// non-`own` local (a register) would give 3 — so 6 proves the global survived
+/// the three real x86_64 `call`s, executed on the simulator.  Together with
+/// `algol_module_global_runs_on_x86_sim` (E6) and `oct_static_global_…` (O3)
+/// this exercises all three module-global frontends locally.
+#[test]
+fn algol_own_variable_runs_on_x86_sim() {
+    let src = "begin integer result; \
+               integer procedure bump(d); value d; integer d; \
+                  begin own integer n; n := n + d; bump := n end; \
+               result := bump(1) + bump(1) + bump(1) end";
+    assert_eq!(run_on_x86_sim(Language::Algol60, src), 6);
+}
+
 /// Nib — **unsigned division** (`84 / 2` ⇒ exit 42).  The `div` op lowers to the
 /// x86 unsigned-division sequence `xor rdx,rdx; div rcx` — exercising the
 /// group-3 `0xF7 /6` end-to-end (S4's unit tests cover `div` in isolation; this


### PR DESCRIPTION
## ALGOL `own` static-lifetime variable, executed on the x86-simulator

Follow-up now that **AL6** ([#6535](https://github.com/adhithyan15/coding-adventures/pull/6535), ALGOL `own` variables) and **S8** ([#6539](https://github.com/adhithyan15/coding-adventures/pull/6539), `_twig_globals` simulator support) have merged. The Oct counterpart ([#6541](https://github.com/adhithyan15/coding-adventures/pull/6541)) already landed.

Adds the executed cell `algol_own_variable_runs_on_x86_sim`:
```algol
integer procedure bump(d); value d; integer d;
  begin own integer n; n := n + d; bump := n end;
result := bump(1) + bump(1) + bump(1)   ' ⇒ 1+2+3 = 6
```
`bump`'s `own integer n` lives in the `_twig_globals` data region and persists across the three real x86_64 `call`s, run on the simulator ⇒ exit **6**. A non-`own` local would give 3.

With the existing **E6** (`algol_module_global_…`) and **O3** (`oct_static_global_…`) cells, **all three module-global frontends now execute locally** on the x86_64 backend — no Intel hardware.

**Test-only** (x86-simulator 0.7.2); reuses the S8 path. All x86-simulator tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)