### PR TITLE
feat(mycin-derm): batch — 6 high-yield dermatology skin findings (7→13 edges)

### DIFF
--- a/code/specs/data/mycin-2026/recall/derm-edges.adj
+++ b/code/specs/data/mycin-2026/recall/derm-edges.adj
@@ -91,4 +91,47 @@ rulebook derm_facts {
         source "In most cases, however, patients develop symptoms of Lyme disease, with erythema migrans being the most common initial manifestation."
         locator "https://www.ncbi.nlm.nih.gov/books/NBK431066/"
         trust authoritative
+
+    % ------------------------------------------------------------------------
+    % BATCH: high-yield dermatology skin findings, each grounded to a self-
+    % contained verbatim NCBI Bookshelf span naming both the finding and disease.
+    % (Declined — no single NBK self-contained span: dewdrop-on-rose-petal->
+    % varicella [disease not in-sentence], honey-colored crust->impetigo [only a
+    % negating sentence co-occurs], Wickham striae->lichen planus [split], malar
+    % rash->SLE [verbatim not reproducible], port-wine stain->Sturge-Weber [the
+    % NBK span is a shared-GNAQ-mutation statement, not "finding in disease"].)
+    % ------------------------------------------------------------------------
+
+    % Dermatomyositis triad — one StatPearls sentence names heliotrope rash,
+    % Gottron papules, AND the shawl sign together (NBK562290).
+    relate skin_finding_in(heliotrope_rash, dermatomyositis)
+        source "Dermatomyositis is associated with other symptoms mainly skin manifestations including a purple rash on the eyelids called heliotrope rash, an erythematous scaly rash appears on the dorsum of the fingers called Gottron's papules, a reddish rash appears on the shoulder and the back known as Shawl sign, besides interstitial lung disease, Gastrointestinal vasculitis, and paraneoplastic syndrome underlying malignancy."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK562290/"
+        trust authoritative
+    relate skin_finding_in(gottron_papules, dermatomyositis)
+        source "Dermatomyositis is associated with other symptoms mainly skin manifestations including a purple rash on the eyelids called heliotrope rash, an erythematous scaly rash appears on the dorsum of the fingers called Gottron's papules, a reddish rash appears on the shoulder and the back known as Shawl sign, besides interstitial lung disease, Gastrointestinal vasculitis, and paraneoplastic syndrome underlying malignancy."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK562290/"
+        trust authoritative
+    relate skin_finding_in(shawl_sign, dermatomyositis)
+        source "Dermatomyositis is associated with other symptoms mainly skin manifestations including a purple rash on the eyelids called heliotrope rash, an erythematous scaly rash appears on the dorsum of the fingers called Gottron's papules, a reddish rash appears on the shoulder and the back known as Shawl sign, besides interstitial lung disease, Gastrointestinal vasculitis, and paraneoplastic syndrome underlying malignancy."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK562290/"
+        trust authoritative
+
+    % Café-au-lait macules — neurofibromatosis type 1.
+    relate skin_finding_in(cafe_au_lait_macules, neurofibromatosis_type_1)
+        source "Cafe-au-lait macules and neurofibromas are the distinguishing features of NF1."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK459358/"
+        trust authoritative
+
+    % Ash-leaf spots — tuberous sclerosis.
+    relate skin_finding_in(ash_leaf_spots, tuberous_sclerosis)
+        source "The presence of three or more ash leaf spots should raise suspicion of tuberous sclerosis."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK563245/"
+        trust authoritative
+
+    % Koplik spots — pathognomonic of measles (buccal mucosa).
+    relate skin_finding_in(koplik_spots, measles)
+        source "Koplik spots are the peculiar spots present on the buccal mucosa and are considered a diagnostic/pathognomic feature of measles/rubeola in the pre-eruptive stage."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK549793/"
+        trust authoritative
 }

--- a/code/specs/data/mycin-2026/recall/derm-recall.query.adj
+++ b/code/specs/data/mycin-2026/recall/derm-recall.query.adj
@@ -20,3 +20,10 @@ import "derm-edges.adj"
 ? skin_finding_in(nikolsky_sign, $Disease)        % expect pemphigus_vulgaris (expand)
 ? skin_finding_in(sandpaper_rash, $Disease)       % expect scarlet_fever (expand)
 ? skin_finding_in(erythema_migrans, $Disease)     % expect lyme_disease (expand)
+% --- BATCH: high-yield dermatology skin findings ---
+? skin_finding_in(heliotrope_rash, $Disease)      % expect dermatomyositis (expand)
+? skin_finding_in(gottron_papules, $Disease)      % expect dermatomyositis (expand)
+? skin_finding_in(shawl_sign, $Disease)           % expect dermatomyositis (expand)
+? skin_finding_in(cafe_au_lait_macules, $Disease) % expect neurofibromatosis_type_1 (expand)
+? skin_finding_in(ash_leaf_spots, $Disease)       % expect tuberous_sclerosis (expand)
+? skin_finding_in(koplik_spots, $Disease)         % expect measles (expand)

--- a/code/specs/data/mycin-2026/recall/test_derm_recall.py
+++ b/code/specs/data/mycin-2026/recall/test_derm_recall.py
@@ -37,6 +37,13 @@ EXPECTED = {
     "nikolsky_sign": "pemphigus_vulgaris",   # expand (NBK560860)
     "sandpaper_rash": "scarlet_fever",       # expand (NBK507889)
     "erythema_migrans": "lyme_disease",      # expand (NBK431066)
+    # --- BATCH: high-yield dermatology skin findings ---
+    "heliotrope_rash": "dermatomyositis",         # expand (NBK562290)
+    "gottron_papules": "dermatomyositis",         # expand (NBK562290)
+    "shawl_sign": "dermatomyositis",              # expand (NBK562290)
+    "cafe_au_lait_macules": "neurofibromatosis_type_1",  # expand (NBK459358)
+    "ash_leaf_spots": "tuberous_sclerosis",       # expand (NBK563245)
+    "koplik_spots": "measles",                    # expand (NBK549793)
 }
 REL = "skin_finding_in"
 VAR = "Disease"


### PR DESCRIPTION
## What

Expands the MYCIN-2026 **DERM** recall library **7 → 13 grounded edges** with 6 high-yield skin findings, each defended by a self-contained verbatim NCBI Bookshelf span naming both the finding and the disease.

| skin finding | disease | source |
|---|---|---|
| heliotrope rash | dermatomyositis | NBK562290 |
| Gottron papules | dermatomyositis | NBK562290 |
| shawl sign | dermatomyositis | NBK562290 |
| café-au-lait macules | neurofibromatosis type 1 | NBK459358 |
| ash-leaf spots | tuberous sclerosis | NBK563245 |
| Koplik spots | measles | NBK549793 |

The dermatomyositis triad is grounded from **one StatPearls sentence** that names heliotrope rash, Gottron papules, and the shawl sign together with the disease — a single written span, three edges (write-once / use-many).

### Honestly declined (checked + documented, not stretched)
No single NCBI Bookshelf self-contained sentence names both endpoints:
- **dewdrop-on-rose-petal → varicella** (disease not in the dewdrop sentence)
- **honey-colored crust → impetigo** (the only co-occurring sentence is a *negation* — "Bullous impetigo does not form a honey-colored crust")
- **Wickham striae → lichen planus** (split across adjacent sentences)
- **malar rash → SLE** (verbatim not reliably reproducible; remains the abstain control)
- **port-wine stain → Sturge-Weber** (NBK span is a shared-GNAQ-mutation statement, not a "finding in disease" assertion)

## Verify
- `test_derm_recall` **3/3** — the native adj-lang engine binds **all 13** diagnoses via the worked query file, each with an `authoritative` citation + real source span + `ncbi.nlm.nih.gov` locator; an off-vocabulary finding (malar_rash) abstains.
- `ruff` clean; data-only security review passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)