### PR TITLE
feat(closurec): constant-fold "haystack".indexOf("needle") on string literals

### DIFF
--- a/code/packages/rust/closure-pass-constant-fold/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-constant-fold/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to the `coding-adventures-closure-pass-constant-fold` crate will be documented in this file.
 
+## [0.22.0] - 2026-06-22
+
+### Added — fold `"haystack".indexOf("needle")` on string literals
+
+The single-argument `String#indexOf` (ECMAScript §22.1.3.8) now folds to a
+numeric literal when both receiver and needle are string literals:
+`"abcabc".indexOf("b")` → `1`, an absent needle → `-1`, and the empty needle →
+`0`. The result is the **UTF-16 code-unit** index, not a byte or scalar index:
+Rust's `str::find` returns a UTF-8 byte offset, so the matched prefix is
+re-measured with `encode_utf16().count()` — `"💩x".indexOf("x")` → `2`
+(matching V8), where a naive byte index would be `4` and a char index `1`. For
+ASCII the indices coincide.
+
+Conservative scope: only the single-argument form folds. The two-argument
+`fromIndex` overload (`"abc".indexOf("b", 1)`) and an identifier/expression
+receiver pass through unchanged. 5 new unit tests (found/not-found, empty
+needle, UTF-16 counting, two-arg passthrough, identifier-receiver passthrough).
+
 ## [0.21.0] - 2026-06-22
 
 ### Added — string indexing folds (`"abc".charCodeAt(0)` → `97`, `"abc".charAt(1)` → `"b"`)

--- a/code/packages/rust/closure-pass-constant-fold/Cargo.toml
+++ b/code/packages/rust/closure-pass-constant-fold/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-constant-fold"
-version = "0.21.0"
+version = "0.22.0"
 edition = "2021"
 description = "Constant-folding optimization pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Folds compile-time-evaluable expressions like `2 + 3 → 5`."
 

--- a/code/packages/rust/closure-pass-constant-fold/src/lib.rs
+++ b/code/packages/rust/closure-pass-constant-fold/src/lib.rs
@@ -558,7 +558,13 @@ fn fold_call(c: &CallExpression, st: &mut FoldState) -> Expression {
                         return stamp_literal_cv(FoldedLiteral::String(result), new_cv);
                     }
                 }
-                // ---- single-integer-index methods: charCodeAt / charAt ----
+                // ---- single-argument string methods ----
+                //
+                // Two shapes share the one-argument arm, dispatched on the
+                // argument's literal kind:
+                //
+                //   * a NUMERIC index   → `charCodeAt` / `charAt` (below);
+                //   * a STRING needle   → `indexOf` (the `else if` further down).
                 //
                 // JS indexes a string by UTF-16 *code unit*, so we index into
                 // `encode_utf16()` (an astral char occupies two units). The
@@ -608,6 +614,39 @@ fn fold_call(c: &CallExpression, st: &mut FoldState) -> Expression {
                                 }
                                 _ => {}
                             }
+                        }
+                    }
+                    // ---- substring search: indexOf ----
+                    //
+                    // `"haystack".indexOf("needle")` → the UTF-16 code-unit
+                    // index of the first occurrence, or `-1` when absent
+                    // (ECMAScript §22.1.3.8, the one-argument form). Both
+                    // receiver and needle must be string literals.
+                    //
+                    // Rust's `str::find` returns a *byte* offset into the UTF-8
+                    // haystack; JS reports the index in *UTF-16 code units*, so
+                    // we re-measure the matched prefix with `encode_utf16()`
+                    // (an astral char before the hit counts as two units). For
+                    // ASCII the two indices coincide; the conversion keeps
+                    // `"💩x".indexOf("x")` → `2`, matching V8. An empty needle
+                    // yields `0` (`"abc".indexOf("")` is `0`), exactly as
+                    // `str::find("")` returns `Some(0)`.
+                    //
+                    // Only the single-argument form folds; the `fromIndex`
+                    // overload (`"abc".indexOf("b", 1)`) lands in the 2-arg
+                    // arm and passes through unchanged.
+                    else if let Expression::StringLiteral(needle) = &arguments[0] {
+                        if id.name == "indexOf" {
+                            let value = match s.value.find(&needle.value) {
+                                Some(byte) => s.value[..byte].encode_utf16().count() as f64,
+                                None => -1.0,
+                            };
+                            let parent = c.cv.clone();
+                            let before =
+                                format!("\"{}\".indexOf(\"{}\")", s.value, needle.value);
+                            let after = format_js_number(value);
+                            let new_cv = st.fork_cv(&parent, &before, &after);
+                            return stamp_literal_cv(FoldedLiteral::Number(value), new_cv);
                         }
                     }
                 }
@@ -2809,6 +2848,71 @@ mod tests {
         let c = call1(ident("s"), "charCodeAt", num(0.0, None));
         let (out, _, changed, _) = run_pass(program_with_expr(c, true));
         assert!(!changed, "s.charCodeAt(0) must not fold");
+        assert!(matches!(extract_expr(&out), Expression::CallExpression(_)));
+    }
+
+    // ------------------- indexOf (substring search) ------------------
+
+    #[test]
+    fn fold_index_of_found_and_not_found() {
+        // `"abcabc".indexOf("b")` → 1 (first occurrence); absent needle → -1.
+        for (hay, needle, expect) in [("abcabc", "b", 1.0), ("abc", "z", -1.0)] {
+            let c = call1(string(hay, None), "indexOf", string(needle, None));
+            let (out, _, changed, _) = run_pass(program_with_expr(c, true));
+            assert!(changed, "\"{hay}\".indexOf(\"{needle}\") should fold");
+            match extract_expr(&out) {
+                Expression::NumericLiteral(n) => assert_eq!(n.value, expect),
+                other => panic!("expected {expect}; got {:?}", other),
+            }
+        }
+    }
+
+    #[test]
+    fn fold_index_of_empty_needle_is_zero() {
+        // JS `"abc".indexOf("")` is 0, matching Rust `str::find("")` → Some(0).
+        let c = call1(string("abc", None), "indexOf", string("", None));
+        let (out, _, changed, _) = run_pass(program_with_expr(c, true));
+        assert!(changed, "indexOf of the empty string should fold to 0");
+        match extract_expr(&out) {
+            Expression::NumericLiteral(n) => assert_eq!(n.value, 0.0),
+            other => panic!("expected 0; got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn fold_index_of_counts_utf16_units_not_bytes() {
+        // "💩" is one astral char = two UTF-16 code units (and four UTF-8
+        // bytes). `"💩x".indexOf("x")` must be 2 (UTF-16 index), NOT 1 (char
+        // index) or 4 (byte index) — proving we re-measure the prefix in
+        // UTF-16, exactly like V8.
+        let c = call1(string("💩x", None), "indexOf", string("x", None));
+        let (out, _, _, _) = run_pass(program_with_expr(c, true));
+        match extract_expr(&out) {
+            Expression::NumericLiteral(n) => assert_eq!(n.value, 2.0),
+            other => panic!("expected 2 (UTF-16 index); got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn index_of_with_from_index_arg_does_not_fold() {
+        // The two-argument `fromIndex` overload lands in the 2-arg arm and is
+        // left for the runtime (we only fold the single-argument form).
+        let c = Expression::CallExpression(CallExpression {
+            cv: Some("c.cv".to_string()),
+            callee: Box::new(member(string("abcabc", None), "indexOf")),
+            arguments: vec![string("b", None), num(2.0, None)],
+        });
+        let (out, _, changed, _) = run_pass(program_with_expr(c, true));
+        assert!(!changed, "two-arg indexOf(needle, fromIndex) must not fold");
+        assert!(matches!(extract_expr(&out), Expression::CallExpression(_)));
+    }
+
+    #[test]
+    fn index_of_on_identifier_receiver_does_not_fold() {
+        // `s.indexOf("x")` needs the runtime value of `s`.
+        let c = call1(ident("s"), "indexOf", string("x", None));
+        let (out, _, changed, _) = run_pass(program_with_expr(c, true));
+        assert!(!changed, "s.indexOf(\"x\") must not fold");
         assert!(matches!(extract_expr(&out), Expression::CallExpression(_)));
     }
 

--- a/code/programs/rust/closurec/CHANGELOG.md
+++ b/code/programs/rust/closurec/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 All notable changes to the `coding-adventures-closurec` binary will be documented in this file.
 
+## [0.171.0] - 2026-06-22
+
+### Added — string `indexOf` fold at SIMPLE/ADVANCED
+
+Pulls in `coding-adventures-closure-pass-constant-fold` 0.22.0, which folds the
+single-argument `String#indexOf` on two string literals to a numeric literal:
+`"abcabc".indexOf("b")` → `1` (the UTF-16 code-unit index of the first
+occurrence), an absent needle → `-1`, the empty needle → `0`. Only the
+one-argument form folds; the `fromIndex` overload and a non-literal receiver
+pass through.
+
+New e2e fixture `tests/diff/simple-fold-indexof` (and integration test
+`diff_simple_fold_indexof.rs`): `var i = "abcabc".indexOf("b"); report(i);` →
+`var i=1;report(i);`, with a whitespace-fallback guard proving the fold comes
+from the SIMPLE typed pipeline. The full existing fixture suite remains
+byte-for-byte unchanged.
+
+> Version note: bumped to 0.171.0 to sit above the concurrently-developed ASI
+> Phase-3 branch (closurec 0.170.0) and the merged charat fold (0.169.0), so the
+> parallel branches never collide on the version line.
+
 ## [0.169.0] - 2026-06-22
 
 ### Added — string indexing folds (`charCodeAt`/`charAt`) at SIMPLE/ADVANCED

--- a/code/programs/rust/closurec/Cargo.toml
+++ b/code/programs/rust/closurec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closurec"
-version = "0.169.0"
+version = "0.171.0"
 edition = "2021"
 description = "closurec — CLI driver for the Closure Compiler clone. Mirrors the upstream Java Closure Compiler's command-line flag surface (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility. Per CLOC08."
 

--- a/code/programs/rust/closurec/cli.spec.json
+++ b/code/programs/rust/closurec/cli.spec.json
@@ -2,7 +2,7 @@
   "cli_builder_spec_version": "1.0",
   "name": "closurec",
   "description": "closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.",
-  "version": "0.169.0",
+  "version": "0.171.0",
   "parsing_mode": "gnu",
   "flags": [
     { "id": "browser_featureset_year", "long": "browser_featureset_year", "type": "integer", "default": 0, "description": "Shortcut for defining goog.FEATURESET_YEAR=YYYY (minimum 2012)." },

--- a/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
@@ -2,7 +2,7 @@
 
 closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.
 
-Version: 0.169.0
+Version: 0.171.0
 
 ## Flags
 

--- a/code/programs/rust/closurec/tests/diff/simple-fold-indexof/README.md
+++ b/code/programs/rust/closurec/tests/diff/simple-fold-indexof/README.md
@@ -1,0 +1,26 @@
+# Fixture: `simple-fold-indexof`
+
+End-to-end oracle for string-literal `indexOf` folding at
+`--compilation_level SIMPLE`.
+
+| File | Role |
+|------|------|
+| `flags.txt` | CLI args: `--compilation_level SIMPLE --js input/a.js` |
+| `input/a.js` | `var i = "abcabc".indexOf("b"); report(i);` |
+| `expected.stdout` | The folded output: `var i=1;report(i);` |
+
+The SIMPLE level runs the typed-AST optimization pipeline, whose `constant-fold`
+pass folds the single-argument `String#indexOf` on two string literals:
+`"abcabc".indexOf("b")` → `1` (the **UTF-16 code-unit** index of the first
+occurrence). An absent needle folds to `-1` and the empty needle to `0`. Only
+the one-argument form folds — the `fromIndex` overload
+(`"abc".indexOf("b", 1)`) and a non-literal receiver pass through. The same
+input under `WHITESPACE_ONLY` keeps `"abcabc".indexOf("b")` unfolded.
+
+Regenerate the expected file after an intentional behavior change:
+
+```sh
+cargo run -- --compilation_level SIMPLE \
+    --js tests/diff/simple-fold-indexof/input/a.js \
+    > tests/diff/simple-fold-indexof/expected.stdout
+```

--- a/code/programs/rust/closurec/tests/diff/simple-fold-indexof/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/simple-fold-indexof/expected.stdout
@@ -1,0 +1,1 @@
+var i=1;report(i);

--- a/code/programs/rust/closurec/tests/diff/simple-fold-indexof/flags.txt
+++ b/code/programs/rust/closurec/tests/diff/simple-fold-indexof/flags.txt
@@ -1,0 +1,4 @@
+--compilation_level
+SIMPLE
+--js
+tests/diff/simple-fold-indexof/input/a.js

--- a/code/programs/rust/closurec/tests/diff/simple-fold-indexof/input/a.js
+++ b/code/programs/rust/closurec/tests/diff/simple-fold-indexof/input/a.js
@@ -1,0 +1,2 @@
+var i = "abcabc".indexOf("b");
+report(i);

--- a/code/programs/rust/closurec/tests/diff_simple_fold_indexof.rs
+++ b/code/programs/rust/closurec/tests/diff_simple_fold_indexof.rs
@@ -1,0 +1,85 @@
+//! Integration test for the `tests/diff/simple-fold-indexof/` fixture.
+//!
+//! End-to-end oracle for string-literal `indexOf` folding in
+//! `closure-pass-constant-fold`: `"abcabc".indexOf("b")` collapses to the
+//! UTF-16 code-unit index of the first occurrence (JS `String#indexOf`).
+//!
+//! At SIMPLE the fixture optimizes to:
+//!
+//! ```text
+//! var i=1;report(i);
+//! ```
+
+use std::process::Command;
+
+const BINARY: &str = env!("CARGO_BIN_EXE_closurec");
+
+fn read_flags() -> Vec<String> {
+    let raw = std::fs::read_to_string("tests/diff/simple-fold-indexof/flags.txt")
+        .expect("read flags.txt");
+    raw.lines()
+        .filter(|l| !l.is_empty())
+        .map(|s| s.to_string())
+        .collect()
+}
+
+#[test]
+fn simple_fold_indexof_fixture_matches_expected_stdout() {
+    let flags = read_flags();
+    let out = Command::new(BINARY)
+        .args(&flags)
+        .output()
+        .expect("run closurec");
+
+    assert!(
+        out.status.success(),
+        "exit: {:?}, stderr: {}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stderr),
+    );
+
+    let actual = String::from_utf8_lossy(&out.stdout);
+    let expected = std::fs::read_to_string("tests/diff/simple-fold-indexof/expected.stdout")
+        .expect("read expected.stdout");
+    assert_eq!(
+        actual.trim_end_matches('\n'),
+        expected.trim_end_matches('\n'),
+        "mismatch.\nflags: {flags:?}\nactual:\n{actual}\nexpected:\n{expected}",
+    );
+}
+
+/// `"abcabc".indexOf("b")` must fold to the literal `1` — no method call should
+/// remain in the output.
+#[test]
+fn simple_fold_indexof_folds_to_numeric_literal() {
+    let out = Command::new(BINARY)
+        .args(read_flags())
+        .output()
+        .expect("run closurec");
+    let actual = String::from_utf8_lossy(&out.stdout);
+
+    assert!(actual.contains("i=1"), "should fold to 1; got:\n{actual}");
+    assert!(
+        !actual.contains("indexOf"),
+        "no `indexOf` call should remain after folding; got:\n{actual}",
+    );
+}
+
+/// Regression guard: the output must be the SIMPLE typed pipeline, not the
+/// `WHITESPACE_ONLY` fallback (which would leave `"abcabc".indexOf("b")`
+/// intact).
+#[test]
+fn simple_fold_indexof_did_not_fall_back_to_whitespace_only() {
+    let out = Command::new(BINARY)
+        .args(read_flags())
+        .output()
+        .expect("run closurec");
+    let actual = String::from_utf8_lossy(&out.stdout);
+
+    assert!(
+        !actual.contains("\"abcabc\""),
+        "expected the string literal to be folded away by the typed pipeline \
+         (proving this is the SIMPLE optimizer, not the whitespace fallback); \
+         got:\n{actual}",
+    );
+}


### PR DESCRIPTION
## String `indexOf` fold

The single-argument `String#indexOf` (ECMAScript §22.1.3.8) now folds to a numeric literal when both receiver and needle are string literals:

| Input | Folds to |
|-------|----------|
| `"abcabc".indexOf("b")` | `1` |
| `"abc".indexOf("z")` (absent) | `-1` |
| `"abc".indexOf("")` (empty needle) | `0` |

The result is the **UTF-16 code-unit** index, not a byte or scalar index. Rust's `str::find` returns a UTF-8 byte offset, so the matched prefix is re-measured with `encode_utf16().count()` — `"💩x".indexOf("x")` → `2` (matching V8), where a naive byte index would be `4` and a char index `1`. For ASCII the indices coincide.

### Conservative scope
Only the single-argument form folds. The two-argument `fromIndex` overload (`"abc".indexOf("b", 1)`) lands in the 2-arg arm and an identifier/expression receiver both pass through unchanged.

### Tests
- **constant-fold 0.22.0** — 5 new unit tests: found/not-found, empty needle, UTF-16 counting (`"💩x".indexOf("x")`→2), two-arg passthrough, identifier-receiver passthrough.
- **closurec 0.171.0** — new e2e fixture `simple-fold-indexof` + integration test `diff_simple_fold_indexof.rs` (3 assertions). `var i = "abcabc".indexOf("b"); report(i);` → `var i=1;report(i);`, with a whitespace-fallback guard proving the fold comes from the SIMPLE typed pipeline.
- Full closurec suite byte-identical/green. Security review passed (pure `str::find` + `encode_utf16`; no panic — `str::find` returns a valid char boundary; input-bounded).

Version bumped to closurec 0.171.0 / constant-fold 0.22.0 to sit above the concurrent ASI Phase-3 branch (closurec 0.170) and the merged charat fold (0.169).

🤖 Generated with [Claude Code](https://claude.com/claude-code)