### PR TITLE
feat(basic): `READ`/`DATA`/`RESTORE` on all 7 backends (LANG-FULL BA6)

### DIFF
--- a/code/packages/rust/dartmouth-basic-iir-compiler/CHANGELOG.md
+++ b/code/packages/rust/dartmouth-basic-iir-compiler/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog — `dartmouth-basic-iir-compiler`
 
+## 0.8.0 — 2026-06-22 — `READ` / `DATA` / `RESTORE` (LANG-FULL BA6)
+
+`READ`, `DATA`, and `RESTORE` were `UnsupportedStatement` rejections; they now
+lower onto the **E5 array** substrate (no new IIR op, no enabler needed):
+
+- A pre-pass gathers every `DATA` numeric literal across the whole program in
+  line-number order into a pool. The pool is materialised **once at the top of
+  `main`** as an `array<i64>` (`alloc_array` + one `array_set` per value) plus
+  an `__basic_data_ptr` register seeded to 0. Because the program is a single
+  `main` function (no `GOSUB`), the pointer lives in a register and persists
+  across `READ`s — no module global needed.
+- `READ var {, var}` fetches `array_get pool, __basic_data_ptr` into each target
+  (a scalar `mov`, or an `array_set` for `READ A(I)`) and advances the pointer
+  (`__basic_data_ptr := __basic_data_ptr + 1`). Reading past the pool traps via
+  the bounds-checked `array_get` — the "out of DATA" runtime error.
+- `RESTORE` rewinds the pointer to 0; `DATA` itself emits nothing at its line.
+- **Limitations:** integer `DATA` only (a real/`f64` value is a clean
+  `Unsupported` error — a follow-up, like integer-only `DIM` arrays); `READ`/
+  `RESTORE` with no `DATA` in the program is a clean error.
+
+Verified by **running**: a `lang_matrix.rs` cell (`DATA 21 / READ A / RESTORE /
+READ B / PRINT A+B` ⇒ `42`, proving sequential consumption *and* the rewind)
+runs on **all 7 backends**; plus JIT-run tests (`READ X` ⇒ 42; `READ A,B` +
+`RESTORE` + `READ C` ⇒ 10,20,10) and four structural unit tests.
+
 ## 0.7.0 — 2026-06-21 — `DIM` arrays (LANG-FULL BA3, enabler E5)
 
 ### Added — one-dimensional integer arrays (`DIM A(n)` + subscripted `A(i)`)

--- a/code/packages/rust/dartmouth-basic-iir-compiler/Cargo.toml
+++ b/code/packages/rust/dartmouth-basic-iir-compiler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dartmouth-basic-iir-compiler"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
 description = "Dartmouth BASIC frontend for the LANG VM AOT chain — lowers parsed BASIC into interpreter_ir::IIRModule (i64 integer programs only in V1).  v0.2.0: ships BasicCirJit — a real bytecode JIT backend for jit-core.  v0.3.0: backend_compat e2e tests prove BASIC's IIR is accepted by every IIR-to-{wasm,jvm,clr,beam} validator.  v0.4.0: threads real source positions through IIRFunction::source_map for line-based debugger breakpoints.  v0.7.0: DIM arrays (BA3 / enabler E5) — DIM/subscripted-LET/subscripted-read lower to the shared alloc_array/array_set/array_get ops, 0-based inclusive."
 

--- a/code/packages/rust/dartmouth-basic-iir-compiler/README.md
+++ b/code/packages/rust/dartmouth-basic-iir-compiler/README.md
@@ -36,21 +36,24 @@ just use `lang-aot foo.bas`, which does the routing for you).
 
 ## V1 scope
 
-Integer-only programs.  Floats truncate to i64; strings, GOSUB, and
-READ/DATA are deferred to V2.  See [CHANGELOG.md](CHANGELOG.md) for the
-full table.
+Integer-only programs.  Floats truncate to i64; strings and GOSUB are
+deferred to V2.  See [CHANGELOG.md](CHANGELOG.md) for the full table.
 
 `LET`, `PRINT`, `IF … THEN <line>`, `GOTO`, `FOR`/`NEXT`, `DEF FN`
-single-line user functions, and `DIM` arrays lower to the shared IIR and
+single-line user functions, `DIM` arrays, and `READ`/`DATA`/`RESTORE` lower to the shared IIR and
 RUN on native / LLVM / WASM / JVM / CLR / VM / JIT.  LANG-FULL BA0 fixed the
 comparison operand-width hint that had broken control flow on LLVM/WASM; BA5
 added `DEF FNx(X) = expr` (lowered to a sibling `IIRFunction` + `call`, like
 ALGOL's value procedures); **BA3** added one-dimensional integer arrays —
 `DIM A(n)` → `alloc_array` (0-based and inclusive, so `n + 1` elements),
 `LET A(i) = e` → `array_set`, and `A(i)` in an expression → `array_get`, the
-same shared array ops ALGOL's E5 arrays run on every backend.  A `DEF` body may
-reference only its own parameter — global access from inside a function needs
-enabler E6 (see `code/specs/LANG-FULL-IMPLEMENTATION.md`).
+same shared array ops ALGOL's E5 arrays run on every backend; **BA6** added
+`READ`/`DATA`/`RESTORE` on top of that array substrate — a pre-pass gathers all
+`DATA` integers into a pool materialised at the top of `main` as an `array<i64>`
+plus a read-pointer register, `READ` does `array_get pool, ptr` + `ptr := ptr +
+1`, and `RESTORE` resets the pointer.  A `DEF` body may reference only its own
+parameter — global access from inside a function needs enabler E6 (see
+`code/specs/LANG-FULL-IMPLEMENTATION.md`).
 
 ## Spec
 

--- a/code/packages/rust/dartmouth-basic-iir-compiler/src/lib.rs
+++ b/code/packages/rust/dartmouth-basic-iir-compiler/src/lib.rs
@@ -223,6 +223,16 @@ struct Compiler {
     /// expression paths whether a subscripted `A(I)` is a real array
     /// access (→ `array_set`/`array_get`) or an undeclared use (an error).
     arrays: std::collections::HashSet<String>,
+    /// The `DATA` pool (BA6): every numeric literal from every `DATA`
+    /// statement, gathered in line-number order by a pre-pass.  `READ`
+    /// consumes these sequentially through a run-time pointer; `RESTORE`
+    /// rewinds the pointer.  Because the BASIC program is a single `main`
+    /// function (no `GOSUB` yet), the pool is materialised once at the top of
+    /// `main` as an `array<i64>` ([[E5]] arrays) plus an `i64` pointer
+    /// register — no module global is needed.  Integer literals only in v1;
+    /// a real (`f64`) DATA value is a follow-up (the i64 value model, like
+    /// integer `DIM` arrays).
+    data_pool: Vec<i64>,
 }
 
 impl Default for Compiler {
@@ -238,6 +248,7 @@ impl Default for Compiler {
             defined_fns: std::collections::HashSet::new(),
             current_fn_param: None,
             arrays: std::collections::HashSet::new(),
+            data_pool: Vec::new(),
         }
     }
 }
@@ -308,6 +319,22 @@ impl Compiler {
                 }
             }
         }
+
+        // Pre-pass — gather the `DATA` pool (BA6).  Every `DATA` statement's
+        // numeric literals are collected across the whole program in
+        // line-number order (the children are already in source order), so a
+        // `READ` on an earlier line can consume a value from a `DATA` on a
+        // later line — exactly the BASIC semantics.
+        for child in &ast.children {
+            if let ASTNodeOrToken::Node(line) = child {
+                if line.rule_name == "line" {
+                    self.collect_data(line)?;
+                }
+            }
+        }
+        // Materialise the pool once at the top of `main`: an `array<i64>` of
+        // the literals plus the `__basic_data_ptr` register initialised to 0.
+        self.emit_data_pool_init();
 
         // Walk every `line` child, in order.
         for child in &ast.children {
@@ -383,9 +410,12 @@ impl Compiler {
             // Explicitly-deferred V1 statements.
             "gosub_stmt"   => Err(CompileError::UnsupportedStatement("GOSUB".into())),
             "return_stmt"  => Err(CompileError::UnsupportedStatement("RETURN".into())),
-            "read_stmt"    => Err(CompileError::UnsupportedStatement("READ".into())),
-            "data_stmt"    => Err(CompileError::UnsupportedStatement("DATA".into())),
-            "restore_stmt" => Err(CompileError::UnsupportedStatement("RESTORE".into())),
+            "read_stmt"    => self.emit_read(stmt),
+            // A `DATA` statement emits nothing at its position — its values
+            // were gathered into the pool by the `collect_data` pre-pass and
+            // materialised once at the top of `main` (BA6).
+            "data_stmt"    => Ok(()),
+            "restore_stmt" => self.emit_restore(),
             "dim_stmt"     => self.emit_dim(stmt),
             "def_stmt"     => self.emit_def(stmt),
             other => Err(CompileError::Malformed(
@@ -474,6 +504,135 @@ impl Compiler {
                 vec![Operand::Var(len)], "array<i64>");
             self.arrays.insert(name);
         }
+        Ok(())
+    }
+
+    /// BA6 pre-pass: append a `DATA` statement's numeric literals to
+    /// [`data_pool`].  Called once per line before any statement is lowered,
+    /// so the pool ends up in line-number (source) order.  Integer literals
+    /// only — a non-integer `DATA` value is a clean `Unsupported` error (real
+    /// DATA is a follow-up, like integer-only `DIM` arrays).
+    fn collect_data(&mut self, line: &GrammarASTNode) -> Result<(), CompileError> {
+        let Some(stmt) = child_nodes(line).into_iter()
+            .find(|n| n.rule_name == "statement")
+        else { return Ok(()); };
+        let Some(inner) = child_nodes(stmt).into_iter().next() else { return Ok(()); };
+        if inner.rule_name != "data_stmt" { return Ok(()); }
+        // `data_stmt = "DATA" NUMBER { COMMA NUMBER }` — collect every NUMBER
+        // token (the `DATA` keyword and `,` separators are not NUMBERs).
+        for c in &inner.children {
+            if let ASTNodeOrToken::Token(t) = c {
+                if t.effective_type_name() != "NUMBER" { continue; }
+                let raw = t.value.trim();
+                let f = raw.parse::<f64>().map_err(|_| CompileError::Malformed(
+                    format!("DATA value `{raw}` is not a number")))?;
+                if !f.is_finite() || f.fract() != 0.0 {
+                    return Err(CompileError::Unsupported(format!(
+                        "non-integer DATA value `{raw}` — only integer DATA is \
+                         supported so far (real DATA is a follow-up)")));
+                }
+                // `f.fract() == 0.0` and finite, so the cast is exact for any
+                // value an `f64` can represent; guard the i64 range explicitly.
+                if f < i64::MIN as f64 || f > i64::MAX as f64 {
+                    return Err(CompileError::Unsupported(format!(
+                        "DATA value `{raw}` is out of the i64 range")));
+                }
+                self.data_pool.push(f as i64);
+            }
+        }
+        Ok(())
+    }
+
+    /// BA6: materialise the gathered `DATA` pool at the top of `main`.  Emits
+    /// nothing when there is no `DATA`.  Otherwise allocates an `array<i64>`
+    /// of the literals (one `array_set` per value) and seeds the read pointer
+    /// `__basic_data_ptr` to 0.  Both live in `main`'s register file — the
+    /// program is a single function, so no module global is needed for the
+    /// pointer to persist across `READ`s.
+    fn emit_data_pool_init(&mut self) {
+        if self.data_pool.is_empty() {
+            return;
+        }
+        let count = self.data_pool.len() as i64;
+        let len = self.fresh_temp();
+        self.emit("const", Some(&len), vec![Operand::Int(count)], "i64");
+        self.emit("alloc_array", Some(BASIC_DATA_ARRAY),
+            vec![Operand::Var(len.clone())], "array<i64>");
+        // Fill the pool.  `self.data_pool` is cloned to a local first so the
+        // immutable borrow doesn't clash with the `&mut self` emits.
+        let values: Vec<i64> = self.data_pool.clone();
+        for (i, value) in values.into_iter().enumerate() {
+            let idx = self.fresh_temp();
+            self.emit("const", Some(&idx), vec![Operand::Int(i as i64)], "i64");
+            let val = self.fresh_temp();
+            self.emit("const", Some(&val), vec![Operand::Int(value)], "i64");
+            self.emit("array_set", None,
+                vec![Operand::Var(BASIC_DATA_ARRAY.into()),
+                     Operand::Var(idx), Operand::Var(val)], "i64");
+        }
+        // Read pointer starts at the first value.
+        let zero = self.fresh_temp();
+        self.emit("const", Some(&zero), vec![Operand::Int(0)], "i64");
+        self.emit("mov", Some(BASIC_DATA_PTR),
+            vec![Operand::Var(zero)], "i64");
+    }
+
+    /// BA6: `READ var { , var }` — consume the next `DATA` value(s) through
+    /// the run-time pointer.  Each variable gets `array_get __basic_data,
+    /// __basic_data_ptr`, then the pointer is advanced by 1.  Reading past the
+    /// end of the pool traps (the bounds-checked `array_get`), which is the
+    /// "out of DATA" run-time error.  A scalar target is a `mov`; an array
+    /// element `READ A(I)` is an `array_set` (BA3).
+    fn emit_read(&mut self, stmt: &GrammarASTNode) -> Result<(), CompileError> {
+        if self.data_pool.is_empty() {
+            return Err(CompileError::Unsupported(
+                "READ with no DATA statement in the program".into()));
+        }
+        for var_node in child_nodes(stmt).into_iter()
+            .filter(|n| n.rule_name == "variable")
+        {
+            // Fetch `__basic_data[__basic_data_ptr]`.
+            let value = self.fresh_temp();
+            self.emit("array_get", Some(&value),
+                vec![Operand::Var(BASIC_DATA_ARRAY.into()),
+                     Operand::Var(BASIC_DATA_PTR.into())], "i64");
+            // Store it into the target — array element or scalar.
+            if let Some(index_expr) = array_subscript_index(var_node) {
+                let name = array_target_name(var_node)?;
+                if !self.arrays.contains(&name) {
+                    return Err(CompileError::Unsupported(format!(
+                        "READ into `{name}(...)` but `{name}` was never DIMmed")));
+                }
+                let idx = self.emit_expr(index_expr)?;
+                self.emit("array_set", None,
+                    vec![Operand::Var(name), Operand::Var(idx),
+                         Operand::Var(value)], "i64");
+            } else {
+                let target = scalar_variable_name(var_node)?;
+                self.emit("mov", Some(&target),
+                    vec![Operand::Var(value)], "i64");
+            }
+            // Advance the pointer: `__basic_data_ptr = __basic_data_ptr + 1`.
+            let one = self.fresh_temp();
+            self.emit("const", Some(&one), vec![Operand::Int(1)], "i64");
+            self.emit("add", Some(BASIC_DATA_PTR),
+                vec![Operand::Var(BASIC_DATA_PTR.into()), Operand::Var(one)],
+                "i64");
+        }
+        Ok(())
+    }
+
+    /// BA6: `RESTORE` — rewind the `DATA` read pointer to the first value.
+    fn emit_restore(&mut self) -> Result<(), CompileError> {
+        if self.data_pool.is_empty() {
+            // RESTORE with no DATA is harmless in BASIC (nothing to rewind);
+            // keep it a clean error so a typo'd program isn't silently a no-op.
+            return Err(CompileError::Unsupported(
+                "RESTORE with no DATA statement in the program".into()));
+        }
+        let zero = self.fresh_temp();
+        self.emit("const", Some(&zero), vec![Operand::Int(0)], "i64");
+        self.emit("mov", Some(BASIC_DATA_PTR), vec![Operand::Var(zero)], "i64");
         Ok(())
     }
 
@@ -1003,6 +1162,13 @@ fn array_target_name(var: &GrammarASTNode) -> Result<String, CompileError> {
 /// bound above this is a clean `Unsupported` error, never a panic.
 const MAX_DIM_BOUND: i64 = 16_777_216; // 2^24 elements — generous for BASIC
 
+/// The IIR register holding the `DATA` pool array handle (BA6).  Underscore-
+/// and lowercase-bearing, so it can never collide with a BASIC variable (which
+/// is an uppercase letter + optional digit, e.g. `A`, `X7`).
+const BASIC_DATA_ARRAY: &str = "__basic_data";
+/// The IIR register holding the `READ`/`RESTORE` pointer into the pool (BA6).
+const BASIC_DATA_PTR: &str = "__basic_data_ptr";
+
 /// The integer bound `n` in a `dim_decl = NAME LPAREN NUMBER RPAREN`.  The
 /// grammar pins the bound to a `NUMBER` literal (not an arbitrary expression),
 /// so we read it straight from the token rather than emitting code to compute
@@ -1446,6 +1612,60 @@ mod tests {
             i.op == "call_builtin" && i.srcs.first().and_then(|s| match s {
                 Operand::Var(n) => Some(n.as_str()), _ => None,
             }) == Some("print_i64")));
+    }
+
+    // -----------------------------------------------------------------------
+    // BA6 — READ / DATA / RESTORE (data pool over E5 arrays)
+    // -----------------------------------------------------------------------
+
+    /// `DATA` + `READ` lowers to: an `alloc_array` for the pool, `array_set`s
+    /// filling it, an `array_get` per `READ`, and the pointer advance (`add`).
+    #[test]
+    fn read_data_lowers_to_pool_array_and_get() {
+        let m = compile("10 DATA 7, 8\n20 READ X\n30 PRINT X\n40 END\n").expect("ok");
+        let body = &m.functions[0].instructions;
+        assert!(body.iter().any(|i| i.op == "alloc_array"),
+            "DATA must materialise a pool array; got {:?}",
+            body.iter().map(|i| &i.op).collect::<Vec<_>>());
+        // Two DATA values ⇒ two array_set fills.
+        assert_eq!(body.iter().filter(|i| i.op == "array_set").count(), 2,
+            "two DATA values should produce two array_set fills");
+        // READ reads through the pointer (array_get) and advances it (add).
+        assert!(body.iter().any(|i| i.op == "array_get"), "READ must array_get");
+        assert!(body.iter().any(|i| i.op == "add"
+            && i.dest.as_deref() == Some("__basic_data_ptr")),
+            "READ must advance __basic_data_ptr with an add");
+    }
+
+    /// `RESTORE` resets the pointer to 0 with a `mov` of a `const 0`.
+    #[test]
+    fn restore_resets_pointer_to_zero() {
+        let m = compile("10 DATA 1\n20 READ X\n30 RESTORE\n40 READ Y\n50 END\n").expect("ok");
+        let body = &m.functions[0].instructions;
+        // The RESTORE `mov __basic_data_ptr = <const 0 reg>` exists; find a mov
+        // into the pointer whose source const is 0 (the init also does this, so
+        // there are at least two — one init + one RESTORE).
+        let ptr_movs = body.iter().filter(|i| i.op == "mov"
+            && i.dest.as_deref() == Some("__basic_data_ptr")).count();
+        assert!(ptr_movs >= 2,
+            "expected the init mov plus a RESTORE mov into the pointer; got {ptr_movs}");
+    }
+
+    /// `READ`/`RESTORE` with no `DATA` in the program is a clean error, not a
+    /// miscompile that reads an uninitialised pointer.
+    #[test]
+    fn read_without_data_errors() {
+        let err = compile("10 READ X\n20 END\n").unwrap_err();
+        assert!(matches!(err, CompileError::Unsupported(_)),
+            "READ with no DATA should be Unsupported, got {err:?}");
+    }
+
+    /// A non-integer `DATA` value is rejected (real DATA is a follow-up).
+    #[test]
+    fn non_integer_data_errors() {
+        let err = compile("10 DATA 3.5\n20 READ X\n30 END\n").unwrap_err();
+        assert!(matches!(err, CompileError::Unsupported(_)),
+            "non-integer DATA should be Unsupported, got {err:?}");
     }
 
     // -----------------------------------------------------------------------

--- a/code/packages/rust/dartmouth-basic-iir-compiler/src/lib.rs
+++ b/code/packages/rust/dartmouth-basic-iir-compiler/src/lib.rs
@@ -533,7 +533,13 @@ impl Compiler {
                 }
                 // `f.fract() == 0.0` and finite, so the cast is exact for any
                 // value an `f64` can represent; guard the i64 range explicitly.
-                if f < i64::MIN as f64 || f > i64::MAX as f64 {
+                // The bounds are written so the rejection is EXACT: `i64::MIN as
+                // f64` is exactly -2^63, but `i64::MAX as f64` rounds *up* to
+                // 2^63 (i64::MAX = 2^63-1 isn't representable), so comparing
+                // against `-(i64::MIN as f64)` (= +2^63) rejects 2^63 and above
+                // rather than admitting that single boundary value (which would
+                // otherwise saturate to i64::MAX through the cast).
+                if f < i64::MIN as f64 || f >= -(i64::MIN as f64) {
                     return Err(CompileError::Unsupported(format!(
                         "DATA value `{raw}` is out of the i64 range")));
                 }

--- a/code/packages/rust/dartmouth-basic-iir-compiler/tests/jit_smoke.rs
+++ b/code/packages/rust/dartmouth-basic-iir-compiler/tests/jit_smoke.rs
@@ -96,6 +96,37 @@ fn jit_basic_let_arithmetic_print() {
         "expected [42] from 30 + 12, got {got:?}");
 }
 
+/// BA6 — `READ` / `DATA`: a single value flows from the DATA pool into a
+/// variable.  `10 DATA 42 / 20 READ X / 30 PRINT X / 40 END` ⇒ [42].
+#[test]
+fn jit_basic_read_data_single() {
+    let src = "10 DATA 42\n\
+               20 READ X\n\
+               30 PRINT X\n\
+               40 END\n";
+    let got = jit_execute_and_capture_prints(src);
+    assert_eq!(got, vec![42], "READ X from DATA 42 should print 42, got {got:?}");
+}
+
+/// BA6 — multi-`READ` advances the pointer, and `RESTORE` rewinds it.  The
+/// pool is `10, 20, 30`; `READ A, B` takes 10 and 20; after `RESTORE`, `READ C`
+/// takes 10 again.  ⇒ prints 10, 20, 10 — proving sequential consumption *and*
+/// the rewind.
+#[test]
+fn jit_basic_read_restore_rewinds() {
+    let src = "10 DATA 10, 20, 30\n\
+               20 READ A, B\n\
+               30 PRINT A\n\
+               40 PRINT B\n\
+               50 RESTORE\n\
+               60 READ C\n\
+               70 PRINT C\n\
+               80 END\n";
+    let got = jit_execute_and_capture_prints(src);
+    assert_eq!(got, vec![10, 20, 10],
+        "READ A,B then RESTORE then READ C should print 10,20,10, got {got:?}");
+}
+
 /// FOR / NEXT loop: `10 FOR I = 1 TO 3 / 20 PRINT I / 30 NEXT I / 40 END`
 /// should print 1, 2, 3 in order.  Exercises label / jmp_if_false /
 /// add / jmp under the JIT interpreter.

--- a/code/packages/rust/lang-aot/tests/lang_matrix.rs
+++ b/code/packages/rust/lang-aot/tests/lang_matrix.rs
@@ -881,6 +881,24 @@ const PROGRAMS: &[Prog] = &[
         expect: Expect::Stdout("42"),
         backends: &[NativeAot, Llvm, Wasm, Jvm, Clr, Vm, Jit],
     },
+    // Dartmouth BASIC — *`READ` / `DATA` / `RESTORE`* (LANG-FULL BA6). The `DATA`
+    // pool is materialised once at the top of `main` as an `array<i64>` (the same
+    // E5 array ops BA3 uses) plus an `__basic_data_ptr` register seeded to 0;
+    // `READ` does `array_get pool, ptr` then `ptr := ptr + 1`, and `RESTORE` resets
+    // `ptr := 0`. Here `DATA 21` is a one-value pool: `READ A` takes 21 and advances
+    // the pointer; `RESTORE` rewinds it; `READ B` therefore takes 21 *again* — so
+    // `PRINT A + B` ⇒ 42, observably proving sequential consumption AND the rewind
+    // in one program. Straight-line (no loop), so it runs on all 7 backends exactly
+    // like the BA3 array cell — no new IIR op (pure frontend lowering onto the E5
+    // array substrate). A non-rewinding READ would read past the 1-element pool and
+    // trap, so 42 also proves the pointer/RESTORE arithmetic is correct.
+    Prog {
+        lang: Language::DartmouthBasic,
+        ext: "bas",
+        src: "10 DATA 21\n20 READ A\n30 RESTORE\n40 READ B\n50 PRINT A + B\n60 END\n",
+        expect: Expect::Stdout("42"),
+        backends: &[NativeAot, Llvm, Wasm, Jvm, Clr, Vm, Jit],
+    },
 ];
 
 /// Is a usable native linker present on this host? On Linux/macOS the AOT path uses

--- a/code/specs/LANG-FULL-IMPLEMENTATION.md
+++ b/code/specs/LANG-FULL-IMPLEMENTATION.md
@@ -12,7 +12,7 @@ program per language**, and each frontend is a **deliberate subset**:
 | Twig | `42` | rich Lisp frontend, but only typed int-arith/`if` clears the backend validators; lists/lambdas/strings/`print`/symbols need the VM only |
 | Nib | `double(21)` → 42 | no `*` `/`, no `for`, no bitwise, no `&&`/`||`, no `const`/`static`; u4/u8 collapse to i64 (no wrap) |
 | Brainfuck | one 1-loop "print A" | all 8 ops are correct **but cat/Hello-World/nested-multiply run only on the VM/JIT**, never on the code-gen backends |
-| Dartmouth BASIC | `PRINT 42` | integer-only: no `GOSUB`, strings, `READ`/`DATA`, `^`; has `FOR`/`NEXT`, `IF`/`GOTO`, `DEF FN` (BA5), `DIM` arrays (BA3) — all run on every backend |
+| Dartmouth BASIC | `PRINT 42` | integer-only: no `GOSUB`, strings, `^`; has `FOR`/`NEXT`, `IF`/`GOTO`, `DEF FN` (BA5), `DIM` arrays (BA3), `READ`/`DATA`/`RESTORE` (BA6) — all run on every backend |
 | Oct | `let`/`if` | rejects **all 10 Intel-8008 intrinsics** (its raison d'être); `&&`/`||` short-circuit ✅ (O1), u8 wrap + `~` ✅ (O2), `static` module globals ✅ (O3); intrinsics remain |
 | ALGOL 60 | `result := 17 mod 5` → 2 | `integer`/`real`/`boolean` scalars, typed procedures, switches, 1-D arrays, `own` static-lifetime variables ✅ (AL6, all 7 backends); arrays + reals run on VM/JIT only so far; no call-by-name, strings, multidim arrays |
 
@@ -385,7 +385,15 @@ backend immediately) come before the enabler-dependent items.
   i64), keeping cross-function call signatures consistent (lang-aot 0.94.0). **Limits:** one
   numeric parameter; body references its parameter only (globals need **E6**); built-in
   maths fns (`SIN`/`ABS`/…) need **E3**.
-- ☐ **BA6** — `READ` / `DATA` / `RESTORE`.
+- ✅ **BA6** — `READ` / `DATA` / `RESTORE` (`dartmouth-basic-iir-compiler` 0.8.0).
+  Lowers onto the **E5 array** substrate — no new IIR op, no enabler: a pre-pass
+  gathers all `DATA` integer literals (line order) into a pool materialised once at
+  the top of `main` as an `array<i64>` + a `__basic_data_ptr` register (a register,
+  not a global, since the program is one `main` function). `READ` does `array_get
+  pool, ptr` + `ptr := ptr + 1`; `RESTORE` resets `ptr := 0`; out-of-DATA traps via
+  the bounds-checked `array_get`. **Runs on all 7 backends**: `DATA 21 / READ A /
+  RESTORE / READ B / PRINT A+B` ⇒ 42 (proves sequential consumption + rewind).
+  Integer DATA only (real DATA = follow-up).
 - ☐ **BA7** — floating-point (needs **E3**).
 
 ### ALGOL 60


### PR DESCRIPTION
## LANG-FULL BA6 — Dartmouth BASIC `READ` / `DATA` / `RESTORE`

`READ`, `DATA`, and `RESTORE` were `UnsupportedStatement` rejections. They now lower onto the **E5 array** substrate — **no new IIR op, no enabler needed**.

### How it lowers
- A pre-pass gathers every `DATA` integer literal across the program (line order) into a pool, materialised **once at the top of `main`** as an `array<i64>` (`alloc_array` + one `array_set` per value) + a `__basic_data_ptr` register seeded to 0. The program is a single `main` function (no `GOSUB`), so the pointer is a register — **no module global needed**.
- `READ var{,var}` → `array_get pool, ptr` into each target (scalar `mov`, or `array_set` for `READ A(I)`) + `ptr := ptr + 1`. Reading past the pool **traps** via the bounds-checked `array_get` — the "out of DATA" runtime error.
- `RESTORE` → `ptr := 0`. `DATA` emits nothing at its line.

### Proof (runs on all 7 backends → stdout `42`)
```basic
10 DATA 21
20 READ A
30 RESTORE
40 READ B
50 PRINT A + B
60 END
```
`READ A` takes 21 and advances; `RESTORE` rewinds; `READ B` takes 21 **again** ⇒ `A + B = 42`, proving sequential consumption **and** the rewind in one program. (A non-rewinding READ would trap on the 1-element pool, so 42 also proves the pointer/RESTORE arithmetic.)

### Verification
- `dartmouth-basic-iir-compiler` 0.8.0: 4 structural unit tests (pool array + get + pointer-advance; RESTORE reset; READ-without-DATA error; non-integer-DATA error) + 2 **JIT-run** tests (`READ X` ⇒ 42; `READ A,B` + `RESTORE` + `READ C` ⇒ 10,20,10).
- `lang-aot` `lang_matrix.rs`: the proof **runs** on NativeAot/LLVM/WASM/JVM/CLR/VM/JIT → 42; both matrix tests green.
- Security review: PASSED (f64→i64 cast is range-guarded — tightened to an exact rejection per the review; out-of-DATA traps; reserved names can't collide with BASIC vars).

### Limitations
Integer `DATA` only (a real/`f64` value is a clean `Unsupported` error — a follow-up, like integer-only `DIM` arrays); `READ`/`RESTORE` with no `DATA` is a clean error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)