### PR TITLE
test(x86-sim): BASIC DIM array runs on the simulator (LANG-FULL BA3 follow-up)

### DIFF
--- a/code/packages/rust/x86-simulator/CHANGELOG.md
+++ b/code/packages/rust/x86-simulator/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog — x86-simulator
 
+## 0.7.2 — 2026-06-22 — Dartmouth BASIC `DIM` array cell (LANG-FULL BA3 follow-up)
+
+Adds an executed matrix cell `basic_array_runs_on_x86_sim`: a Dartmouth BASIC
+`DIM A(3)` array (LANG-FULL BA3, merged) filled by `LET A(i) = …` and summed
+back via `A(i)` reads ⇒ stdout `42`. Runs the real BASIC frontend's x86_64
+output on the simulator, exercising the shared `alloc_array`/`array_set`/
+`array_get` ops (E5) through the **BASIC** lowering path — the BASIC counterpart
+to `algol_static_array_runs_on_x86_sim`. Test-only; no library change.
+
 ## 0.7.1 — 2026-06-22 — Oct `static` global cell (LANG-FULL O3 follow-up)
 
 Adds an executed matrix cell `oct_static_global_runs_on_x86_sim`: an Oct

--- a/code/packages/rust/x86-simulator/Cargo.toml
+++ b/code/packages/rust/x86-simulator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "x86-simulator"
-version = "0.7.1"
+version = "0.7.2"
 edition = "2021"
 description = "x86/x86-64 runtime simulator — decode + execute machine code, and run the x86_64-backend's emitted code locally (host-arch-independent)"
 

--- a/code/packages/rust/x86-simulator/tests/lang_matrix_x86.rs
+++ b/code/packages/rust/x86-simulator/tests/lang_matrix_x86.rs
@@ -307,6 +307,22 @@ fn basic_for_loop_runs_on_x86_sim() {
     assert_eq!(out, "15");
 }
 
+/// Dartmouth BASIC — a **`DIM` array** (LANG-FULL BA3) on the x86_64 backend.
+/// `DIM A(3)` reserves a 4-element (0..3 inclusive) integer array; each
+/// `LET A(i) = e` is an `array_set` and each `A(i)` read is a bounds-checked
+/// `array_get` — the *same* shared array ops `algol_static_array_…` exercises,
+/// but reached through the **BASIC** frontend's lowering rather than ALGOL's.
+/// `A(1)+A(2)+A(3)` = 10 + 20 + 12 ⇒ stdout `42`, proving the BASIC array path
+/// produces correct native machine code (not just the ALGOL one already
+/// covered by `algol_static_array` / `algol_for_loop_array`).
+#[test]
+fn basic_array_runs_on_x86_sim() {
+    let src = "10 DIM A(3)\n20 LET A(1) = 10\n30 LET A(2) = 20\n\
+               40 LET A(3) = 12\n50 PRINT A(1) + A(2) + A(3)\n60 END\n";
+    let (_code, out) = run_capturing_stdout(Language::DartmouthBasic, src);
+    assert_eq!(out, "42");
+}
+
 /// Oct — bitwise complement (the `not` op → x86 `0xF7 /2`) printed via `out`
 /// (`fn main() { out(1, ~0); }` ⇒ stdout `255`, the u8-masked `-1`).  This is
 /// the cell that surfaced the missing group-3 `0xF7` opcode in the simulator.


### PR DESCRIPTION
## What

Adds the matrix cell `basic_array_runs_on_x86_sim` to `x86-simulator`'s `lang_matrix_x86.rs`: a Dartmouth BASIC `DIM A(3)` array program, filled with `LET A(i) = …` and summed back via `A(i)` reads, run as **real x86_64 machine code on the simulator** ⇒ stdout `42`.

## Why

x86-sim already runs ALGOL arrays (`algol_static_array`, `algol_for_loop_array`) and BASIC scalars (`basic_print`, `basic_for_loop`), but had **no BASIC array** cell. BA3 (BASIC `DIM` arrays) has been merged for a while; this proves the **BASIC frontend's** array lowering — the shared E5 `alloc_array` / `array_set` / `array_get` ops — produces correct native code, distinct from the ALGOL array path already covered. `10 + 20 + 12 = 42` confirms both `array_set` and the bounds-checked `array_get` end-to-end.

## Scope

Test-only. No library/`src` change. Bumps `x86-simulator` 0.7.1 → 0.7.2 for the changelog entry. Lives in `lang_matrix_x86.rs` (not the cross-backend `lang_matrix.rs`), so it does not touch the LANG-FULL matrix file or roadmap.

## Verification

- `cargo test -p x86-simulator --test lang_matrix_x86` — **24 passed, 0 failed** (new cell + all existing cells).
- Security review: PASSED (test-only, fixed input — no new surface).

🤖 Generated with [Claude Code](https://claude.com/claude-code)