### PR TITLE
feat(mycin-resp): expand occupational-lung recall 5→13 (HP, asthma, bronchiolitis, radon, siderosis)

### DIFF
--- a/code/specs/data/mycin-2026/recall/resp-edges.adj
+++ b/code/specs/data/mycin-2026/recall/resp-edges.adj
@@ -8,12 +8,22 @@
 %     ? inhalation_causes(silica, $Disease).
 %
 % Direction note: the relation is exposure -> disease (`inhalation_causes`), the board
-% direction — the history gives the dust/fiber exposure and you must name the
-% pneumoconiosis. The cited spans are written disease-first ("Silicosis is occupational
-% pneumoconiosis caused by inhalation of crystalline silicon dioxide"; "Berylliosis ...
-% is a granulomatous disease caused by exposure to beryllium") — what matters for
-% grounding is that one self-contained span names BOTH the exposure AND the disease. Each
-% exposure here maps to one canonical pneumoconiosis, so a query binds a single answer.
+% direction — the history gives the dust/fiber/fume/gas exposure and you must name the
+% occupational lung disease. The cited spans are written disease-first ("Silicosis is
+% occupational pneumoconiosis caused by inhalation of crystalline silicon dioxide";
+% "Berylliosis ... is a granulomatous disease caused by exposure to beryllium") — what
+% matters for grounding is that one self-contained span names BOTH the exposure AND the
+% disease. Each exposure here maps to one canonical lung disease, so a query binds a
+% single answer.
+%
+% Scope note: the domain started as classic dust/fiber pneumoconioses (silicosis,
+% asbestosis, berylliosis, byssinosis, coal workers' pneumoconiosis) and now spans the
+% broader board topic of occupational/environmental lung disease — hypersensitivity
+% pneumonitis (farmer's lung, bird fancier's lung, bagassosis), inhalational airway and
+% parenchymal injury (silo filler's disease from nitrogen dioxide, bronchiolitis
+% obliterans from diacetyl, occupational asthma from diisocyanates), an inhaled metal
+% deposition disease (siderosis from iron), and an inhaled carcinogen (radon -> lung
+% cancer). The relation and the single-answer property are unchanged.
 %
 % This file is the SHIPPED ARTIFACT and the SOLE source of truth — no generator, no
 % JSON, no manifest (the twelfth ADJ-only recall domain; eighth Tier-2 organ-system
@@ -22,6 +32,8 @@
 %     source   — the VERBATIM span copied from the cited page (byte-stable: it appears
 %                character-for-character in the page's normalized text).
 %     locator  — the URL the span was read from (NCBI StatPearls / Bookshelf, NIH).
+%                (NCBI StatPearls / Bookshelf, NIH, the CDC/NIOSH program, or
+%                NCBI PubMed Central for the one disease with no StatPearls chapter.)
 %     trust    — authoritative (a primary, citable reference).
 % An LLM (or a human) recalls a fact by writing a tiny query .adj that `import`s this
 % library and asks a binding query — see resp-recall.query.adj. Nothing here is asserted
@@ -76,5 +88,77 @@ rulebook resp_facts {
     relate inhalation_causes(coal_dust, coal_workers_pneumoconiosis)
         source "Coal workers' pneumoconiosis or black lung is caused by inhaling coal mine dust and can be severe."
         locator "https://www.cdc.gov/niosh/cwhsp/about/index.html"
+        trust authoritative
+
+    % ------------------------------------------------------------------------
+    % BATCH: occupational/environmental lung disease beyond the dust/fiber
+    % pneumoconioses — each grounded to a self-contained verbatim NCBI span
+    % (StatPearls/Bookshelf, or NCBI's PubMed Central for the welder's-lung
+    % case where no StatPearls chapter exists) naming BOTH the inhaled agent
+    % AND the disease.
+    % (Declined — no single self-contained NCBI span names both endpoints:
+    %  talc->talcosis [no StatPearls "Talcosis" chapter; only PMC case reports
+    %  and IARC monographs]; aluminum->aluminosis [no NCBI Bookshelf page uses
+    %  "aluminosis"/"Shaver" or qualifies "aluminum pneumoconiosis" in one
+    %  sentence]; cobalt/hard metal->hard metal lung disease [disease-named
+    %  sentences omit the metal; metal-named sentences abbreviate the disease
+    %  as HMD/HMLD]; zinc oxide->metal fume fever [the cause and the disease
+    %  name sit in adjacent but separate sentences on NBK583199]; grain
+    %  dust->extrinsic allergic alveolitis [the only span lists five syndromes
+    %  at once, so it binds no single canonical answer]. Also held: asbestos
+    %  ->mesothelioma — a real, well-grounded malignancy edge (NBK519530), but
+    %  `asbestos` already binds asbestosis here and the single-answer test
+    %  forbids a second binding for one exposure; it returns when the harness
+    %  supports a multi-answer exposure.)
+    % ------------------------------------------------------------------------
+
+    % Hypersensitivity pneumonitis — thermophilic actinomycetes (moldy hay) -> farmer's lung.
+    relate inhalation_causes(thermophilic_actinomycetes, farmers_lung)
+        source "The most common organism leading to farmer's lung are thermophilic actinomycetes like Micropolyspora faeni, Thermoactinomyces vulgaris, and fungi like Aspergillus."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK557580/"
+        trust authoritative
+
+    % Hypersensitivity pneumonitis — avian (bird) antigens -> bird fancier's lung.
+    relate inhalation_causes(bird_antigens, bird_fanciers_lung)
+        source "Bird or Pigeon fancier's lung: Caused by exposure to organic antigens in bird (particularly pigeon) excreta."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK499918/"
+        trust authoritative
+
+    % Hypersensitivity pneumonitis — moldy sugarcane fiber (bagasse) -> bagassosis.
+    relate inhalation_causes(bagasse, bagassosis)
+        source "Bagassosis develops as a result of exposure and inhalation of bagasse, the residual fibrous material following sugar extraction from sugar cane."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK554444/"
+        trust authoritative
+
+    % Nitrogen dioxide from fresh silage -> silo filler's disease.
+    relate inhalation_causes(nitrogen_dioxide, silo_fillers_disease)
+        source "The classic example of nitrogen dioxide toxicity is known as “silo filler’s disease,” which occurs when nitrogen dioxide forms during the decomposition of silage and is subsequently inhaled."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK554539/"
+        trust authoritative
+
+    % Diacetyl (butter-flavoring vapor) -> bronchiolitis obliterans (popcorn lung).
+    relate inhalation_causes(diacetyl, bronchiolitis_obliterans)
+        source "Other etiologies of bronchiolitis obliterans include exposure to inhaled toxins and gases, including sulfur mustard gas, nitrogen oxides, diacetyl (used as popcorn flavoring), fly ash, and fiberglass."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK441865/"
+        trust authoritative
+
+    % Diisocyanates (spray paints / polyurethane) -> occupational asthma.
+    relate inhalation_causes(diisocyanates, occupational_asthma)
+        source "Contact with various high- and low-molecular-weight compounds found in insects, plants, latex, gums, diisocyanates, anhydrides, wood dust, and solder fluxes, which are associated with occupational asthma"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK430901/"
+        trust authoritative
+
+    % Inhaled iron dust/fumes (welding) -> pulmonary siderosis (welder's lung).
+    % Grounded to an NCBI PubMed Central case report; no StatPearls chapter on
+    % siderosis exists, so the primary peer-reviewed literature is the authority.
+    relate inhalation_causes(iron, siderosis)
+        source "Pulmonary siderosis (PS), also known as welder's lung, is caused by the inhalation of iron dust or fumes."
+        locator "https://pmc.ncbi.nlm.nih.gov/articles/PMC12832015/"
+        trust authoritative
+
+    % Inhaled radon gas -> lung cancer (second-leading cause overall).
+    relate inhalation_causes(radon, lung_cancer)
+        source "Radon exposure is the second-leading cause of lung cancer overall and the number one cause in nonsmokers."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK562321/"
         trust authoritative
 }

--- a/code/specs/data/mycin-2026/recall/resp-recall.query.adj
+++ b/code/specs/data/mycin-2026/recall/resp-recall.query.adj
@@ -18,3 +18,12 @@ import "resp-edges.adj"
 ? inhalation_causes(beryllium, $Disease)    % expect berylliosis
 ? inhalation_causes(cotton_dust, $Disease)  % expect byssinosis
 ? inhalation_causes(coal_dust, $Disease)    % expect coal_workers_pneumoconiosis
+% --- BATCH: occupational/environmental lung disease beyond pneumoconioses ---
+? inhalation_causes(thermophilic_actinomycetes, $Disease)  % expect farmers_lung (expand)
+? inhalation_causes(bird_antigens, $Disease)               % expect bird_fanciers_lung (expand)
+? inhalation_causes(bagasse, $Disease)                     % expect bagassosis (expand)
+? inhalation_causes(nitrogen_dioxide, $Disease)            % expect silo_fillers_disease (expand)
+? inhalation_causes(diacetyl, $Disease)                    % expect bronchiolitis_obliterans (expand)
+? inhalation_causes(diisocyanates, $Disease)               % expect occupational_asthma (expand)
+? inhalation_causes(iron, $Disease)                        % expect siderosis (expand)
+? inhalation_causes(radon, $Disease)                       % expect lung_cancer (expand)

--- a/code/specs/data/mycin-2026/recall/test_resp_recall.py
+++ b/code/specs/data/mycin-2026/recall/test_resp_recall.py
@@ -28,18 +28,36 @@ ADJ = HERE / "resp-edges.adj"
 QUERY = HERE / "resp-recall.query.adj"
 CLI = HERE.parents[3] / "packages" / "rust" / "target" / "debug" / "adj-lang-cli"
 
-# Every grounded edge: occupational exposure -> the pneumoconiosis the library binds.
+# Every grounded edge: inhaled occupational/environmental exposure -> the lung disease
+# the library binds. The domain began as classic dust/fiber pneumoconioses and now spans
+# the broader board topic (hypersensitivity pneumonitis, inhalational airway/parenchymal
+# injury, an inhaled metal deposition disease, and an inhaled carcinogen).
 EXPECTED = {
     "silica": "silicosis",
     "asbestos": "asbestosis",
     "beryllium": "berylliosis",
     "cotton_dust": "byssinosis",
     "coal_dust": "coal_workers_pneumoconiosis",
+    # --- BATCH: occupational/environmental lung disease beyond pneumoconioses ---
+    "thermophilic_actinomycetes": "farmers_lung",        # expand (NBK557580)
+    "bird_antigens": "bird_fanciers_lung",               # expand (NBK499918)
+    "bagasse": "bagassosis",                             # expand (NBK554444)
+    "nitrogen_dioxide": "silo_fillers_disease",          # expand (NBK554539)
+    "diacetyl": "bronchiolitis_obliterans",              # expand (NBK441865)
+    "diisocyanates": "occupational_asthma",              # expand (NBK430901)
+    "iron": "siderosis",                                 # expand (PMC12832015)
+    "radon": "lung_cancer",                              # expand (NBK562321)
 }
 # Every edge cites a primary authority; we accept any of the recognized authoritative
-# hosts (NCBI StatPearls/Bookshelf and CDC/NIOSH), not a single hardcoded domain — the
-# primary-source-first policy grounds an edge wherever the clean both-endpoints span lives.
-_AUTH_HOSTS = ("https://www.ncbi.nlm.nih.gov/", "https://www.cdc.gov/")
+# NCBI/federal hosts (StatPearls/Bookshelf, PubMed Central, and CDC/NIOSH), not a single
+# hardcoded domain — the primary-source-first policy grounds an edge wherever the clean
+# both-endpoints span lives. PMC (pmc.ncbi.nlm.nih.gov) is the home of the one edge
+# (siderosis/welder's lung) that has no StatPearls chapter.
+_AUTH_HOSTS = (
+    "https://www.ncbi.nlm.nih.gov/",
+    "https://pmc.ncbi.nlm.nih.gov/",
+    "https://www.cdc.gov/",
+)
 REL = "inhalation_causes"
 VAR = "Disease"
 
@@ -61,7 +79,7 @@ def test_library_is_pure_adj_and_fully_grounded() -> None:
     text = ADJ.read_text()
     assert "trust consensus" not in text, "RESP ships no authored-debt; ground or omit"
     assert "[FLAG:" not in text
-    edge_count = len(EXPECTED)  # 4
+    edge_count = len(EXPECTED)  # 13
     assert text.count("    relate ") == edge_count
     assert text.count("trust authoritative") == edge_count
     assert text.count('\n        locator "') == edge_count


### PR DESCRIPTION
## Summary
Expands the MYCIN-2026 **RESP** recall library (`code/specs/data/mycin-2026/recall/resp-edges.adj`) from 5 → **13** byte-grounded edges, broadening the relation `inhalation_causes` from the classic dust/fiber pneumoconioses into the full board topic of occupational/environmental lung disease.

8 new edges, each defended by **one self-contained verbatim NCBI span** naming BOTH the inhaled agent AND the disease:

| exposure | disease | source |
|---|---|---|
| thermophilic_actinomycetes | farmer's lung (HP) | NBK557580 |
| bird_antigens | bird fancier's lung (HP) | NBK499918 |
| bagasse | bagassosis (HP) | NBK554444 |
| nitrogen_dioxide | silo filler's disease | NBK554539 |
| diacetyl | bronchiolitis obliterans (popcorn lung) | NBK441865 |
| diisocyanates | occupational asthma | NBK430901 |
| iron | siderosis (welder's lung) | PMC12832015 |
| radon | lung cancer | NBK562321 |

## Notes
- Siderosis has no StatPearls chapter → grounded to an NCBI **PubMed Central** case report; the test's authoritative-host allowlist gains `pmc.ncbi.nlm.nih.gov`.
- Relation + single-answer property unchanged — each exposure binds exactly one disease; off-vocabulary control (`tobacco_smoke`) still abstains.
- **Honest deferrals** documented inline (no clean single-span NCBI source): talc→talcosis, aluminum→aluminosis, cobalt→hard-metal lung disease, zinc oxide→metal fume fever, grain dust→extrinsic allergic alveolitis. Held: asbestos→mesothelioma (real, NBK519530) — would make `asbestos` multi-answer and break the single-bind test.

## Verification
- `cargo build -p adj-lang-cli` ✓
- `test_resp_recall.py` → **3/3** (engine binds all 13 with authoritative citations; control abstains) ✓
- `ruff check` clean ✓
- Security review passed (static data + list-argv subprocess, no injection surface) ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)