### PR TITLE
feat(algol): `abs` standard function on all 7 backends (LANG-FULL AL8)

### DIFF
--- a/code/packages/rust/algol-iir-compiler/CHANGELOG.md
+++ b/code/packages/rust/algol-iir-compiler/CHANGELOG.md
@@ -1,5 +1,34 @@
 # Changelog
 
+## 0.8.0 — 2026-06-22 — `abs` standard function (LANG-FULL AL8, PR-1)
+
+ALGOL 60 *standard functions* (§3.2.4) are built into the language rather than
+user-declared procedures.  This release adds the first one, **`abs`**.
+
+- `abs(E)` yields the absolute value of `E`, preserving its numeric type
+  (`integer`→`integer`, `real`→`real`).  It lowers inline to the value of
+  `if E < 0 then -E else E`: a `cmp_lt` against a typed zero, then a
+  `jmp_if_false` choosing between a negated (`0 - E`, i.e. `sub`/`fsub`) and a
+  pass-through `mov` into a single result slot.  This is the same store-per-branch
+  shape the conditional-expression lowering already runs on **all seven backends**
+  (native-AOT/LLVM/WASM/JVM/CLR/VM/JIT) — no backend learns anything about `abs`;
+  it is compare + branch + subtract in the shared IIR.  `E` is evaluated once.
+- **Resolution is name-based and overridable.** A standard function has no
+  `proc_sigs` entry, so a call resolves to the built-in only when the name is
+  *not* a user-declared procedure — a program that redeclares `procedure abs`
+  gets its own version, exactly as the Report permits.
+- **No grammar change.** `abs(x)` already parses as a `proc_call`; only the
+  IIR-compiler's call lowering changed.
+- **Verified by RUNNING:** a new `lang_matrix.rs` cell — `result := abs(0 - 42)`
+  ⇒ exit **42** — executes on every backend; plus 9 inline tests (negative /
+  positive / zero / composed integer `abs`, negative / positive real `abs`, the
+  lowers-to-branches-not-a-call structural check, the user-override case, and the
+  wrong-arity rejection).
+
+`sign`/`entier`/`sqrt`/`sin`/`cos`/… follow in later AL8 slices (the
+transcendentals need a runtime math library on every backend; the pure-IIR
+`abs`/`sign`/`entier` come first).
+
 ## 0.7.0 — 2026-06-22 — `own` variables: static lifetime (LANG-FULL AL6)
 
 ALGOL 60's `own` declarations (`own integer n`) now lower to **module globals**,

--- a/code/packages/rust/algol-iir-compiler/Cargo.toml
+++ b/code/packages/rust/algol-iir-compiler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "algol-iir-compiler"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
 description = "ALGOL 60 scalar frontend for the LANG VM Rust chain, lowering parsed ALGOL into interpreter_ir::IIRModule. v0.3.0 adds switches (computed goto) + conditional designational expressions, and fixes comparison lowering to use the i64 operand width so ALGOL comparisons run on the code-gen backends. v0.2.0 added typed procedures with value parameters."
 

--- a/code/packages/rust/algol-iir-compiler/README.md
+++ b/code/packages/rust/algol-iir-compiler/README.md
@@ -54,6 +54,15 @@ procedures' `own n` stay independent — and is **not** re-zeroed on entry, so i
 accumulates: `own integer n; n := n + d` called three times with `d = 1` yields
 `1`, `2`, `3`. Runs on all 7 backends.
 
+Since **LANG-FULL AL8** the **standard function `abs`** (ALGOL 60 §3.2.4) is
+built in: `abs(E)` is the absolute value of `E`, keeping its type
+(`integer`→`integer`, `real`→`real`). It is resolved by name — a program may
+still redeclare its own `procedure abs`, which then wins — and lowers inline to
+`if E < 0 then -E else E` (a compare against zero, then a negated or
+pass-through move into one result slot), so it **runs on all 7 backends**;
+`abs(0 - 42)` ⇒ `42`. The other standard functions (`sign`, `entier`, then
+`sqrt`/`sin`/`cos`/…) are not implemented yet.
+
 `real` values lower to the IIR `f64` type and **run on the VM and JIT today**
 (LANG-FULL AL1 / enabler E3 phase 1); `2.5 * 2.0`, `7.0 / 2.0`, and real
 comparisons execute as IEEE-754 doubles. There is no implicit `integer`→`real`

--- a/code/packages/rust/algol-iir-compiler/src/lib.rs
+++ b/code/packages/rust/algol-iir-compiler/src/lib.rs
@@ -956,11 +956,23 @@ impl Compiler {
             .map(|t| t.value.clone())
             .ok_or_else(|| CompileError::Malformed("call has no procedure name".into()))?;
 
-        let sig = self
-            .proc_sigs
-            .get(&name)
-            .cloned()
-            .ok_or_else(|| CompileError::Type(format!("call to undeclared procedure {name:?}")))?;
+        // ALGOL 60 §3.2.4 *standard functions* (`abs`, `sign`, `entier`, …) are
+        // built into the language, not user-declared procedures, so they have no
+        // `proc_sigs` entry.  A program may still legally *redeclare* one as its
+        // own procedure — so we only fall back to the built-in when the name is
+        // not a user-declared procedure.  This keeps the override semantics the
+        // Report grants while making `abs(x)` work out of the box.
+        let sig = match self.proc_sigs.get(&name).cloned() {
+            Some(sig) => sig,
+            None => {
+                if let Some(result) = self.try_emit_standard_function(&name, node)? {
+                    return Ok(result);
+                }
+                return Err(CompileError::Type(format!(
+                    "call to undeclared procedure {name:?}"
+                )));
+            }
+        };
 
         let actuals: Vec<&GrammarASTNode> = match first_direct_node(node, "actual_params") {
             Some(ap) => direct_nodes(ap)
@@ -1004,6 +1016,128 @@ impl Compiler {
             slot: dest,
             ty: sig.ret,
         })
+    }
+
+    /// Resolve a *standard function* call (ALGOL 60 §3.2.4) by name.  Returns
+    /// `Ok(Some(value))` if `name` is a built-in we lower inline, `Ok(None)` if
+    /// it is not a standard function (so the caller raises the usual
+    /// "undeclared procedure" error).
+    ///
+    /// AL8 PR-1 implements only `abs`.  `sign`/`entier`/`sqrt`/`sin`/`cos`/…
+    /// land in later slices (the transcendentals need a runtime math library on
+    /// every backend; `abs`/`sign`/`entier` are pure IIR and come first).
+    fn try_emit_standard_function(
+        &mut self,
+        name: &str,
+        node: &GrammarASTNode,
+    ) -> Result<Option<ExprValue>, CompileError> {
+        match name {
+            "abs" => Ok(Some(self.emit_abs(node)?)),
+            _ => Ok(None),
+        }
+    }
+
+    /// Extract the actual-parameter expressions of a standard-function call —
+    /// the same `actual_params → expression*` shape `emit_call_common` reads.
+    fn standard_fn_actuals<'n>(&self, node: &'n GrammarASTNode) -> Vec<&'n GrammarASTNode> {
+        match first_direct_node(node, "actual_params") {
+            Some(ap) => direct_nodes(ap)
+                .into_iter()
+                .filter(|n| n.rule_name == "expression")
+                .collect(),
+            None => Vec::new(),
+        }
+    }
+
+    /// `abs(E)` — absolute value, preserving `E`'s numeric type
+    /// (`integer`→`integer`, `real`→`real`).  We lower it to the value of the
+    /// conditional expression `if E < 0 then -E else E`, using the *exact*
+    /// `jmp_if_false` / `mov`-into-`dest` shape `emit_conditional_branches`
+    /// uses.  Writing `dest` once per branch (store-per-branch, never an SSA
+    /// phi) is what lets the result merge identically on all seven backends —
+    /// the VM/JIT and the stack machines treat `dest` as a slot, and the LLVM
+    /// backend promotes a twice-assigned temp to an `alloca` (the same
+    /// reassigned-value path E-LLVM-1 hardened).  `E` is evaluated **once**
+    /// (its slot is read by the test, the negation, and the else branch), so
+    /// `abs` has no double-evaluation surprise even if `E` has side effects.
+    ///
+    /// ```text
+    ///        t := E                 ; evaluate the operand once
+    ///        cond := t < 0          ; cmp_lt at the operand width
+    ///        jmp_if_false cond, else
+    ///        neg := 0 - t           ; -t  (i64 sub / f64 fsub)
+    ///        dest := neg
+    ///        jmp end
+    ///   else: dest := t
+    ///   end:  (dest holds |E|)
+    /// ```
+    fn emit_abs(&mut self, node: &GrammarASTNode) -> Result<ExprValue, CompileError> {
+        let actuals = self.standard_fn_actuals(node);
+        if actuals.len() != 1 {
+            return Err(CompileError::Type(format!(
+                "standard function abs expects 1 argument, got {}",
+                actuals.len()
+            )));
+        }
+        let value = self.emit_expr(actuals[0])?;
+        let ty = match value.ty {
+            ScalarType::Integer | ScalarType::Real => value.ty,
+            ScalarType::Boolean => {
+                return Err(CompileError::Type(
+                    "standard function abs requires a numeric argument".into(),
+                ))
+            }
+        };
+
+        // cond := (value < 0), compared at the operand width (see the relational
+        // lowering in `emit_binary`: the hint is the operand type, not `bool`).
+        let zero = self.emit_const(ty, ty.default_operand());
+        let cond = self.fresh_temp();
+        self.emit(IIRInstr::new(
+            "cmp_lt",
+            Some(cond.clone()),
+            vec![Operand::Var(value.slot.clone()), Operand::Var(zero)],
+            ty.iir(),
+        ));
+
+        let else_label = self.fresh_label("abs_else");
+        let end_label = self.fresh_label("abs_end");
+        let dest = self.fresh_temp();
+
+        self.emit(IIRInstr::new(
+            "jmp_if_false",
+            None,
+            vec![Operand::Var(cond), Operand::Var(else_label.clone())],
+            "void",
+        ));
+        // then: dest := -value
+        let neg = self.emit_unary_minus(ExprValue {
+            slot: value.slot.clone(),
+            ty,
+        })?;
+        self.emit(IIRInstr::new(
+            "mov",
+            Some(dest.clone()),
+            vec![Operand::Var(neg.slot)],
+            ty.iir(),
+        ));
+        self.emit(IIRInstr::new(
+            "jmp",
+            None,
+            vec![Operand::Var(end_label.clone())],
+            "void",
+        ));
+        // else: dest := value
+        self.emit_label(&else_label);
+        self.emit(IIRInstr::new(
+            "mov",
+            Some(dest.clone()),
+            vec![Operand::Var(value.slot)],
+            ty.iir(),
+        ));
+        self.emit_label(&end_label);
+
+        Ok(ExprValue { slot: dest, ty })
     }
 
     fn emit_statement(&mut self, node: &GrammarASTNode) -> Result<(), CompileError> {
@@ -2806,6 +2940,91 @@ mod tests {
     fn compiles_and_runs_boolean_conditional_expression() {
         let src = "begin boolean flag; integer result; flag := true; if if flag then true else false then result := 42 else result := 1 end";
         assert_eq!(run_i64(src), 42);
+    }
+
+    // ── AL8 — standard functions (§3.2.4) ───────────────────────────────────
+
+    #[test]
+    fn abs_of_negative_integer_runs() {
+        // |0 - 42| = 42, preserving `integer`.
+        assert_eq!(run_i64("begin integer result; result := abs(0 - 42) end"), 42);
+    }
+
+    #[test]
+    fn abs_of_positive_integer_is_identity() {
+        // The else branch: a non-negative argument passes through unchanged.
+        assert_eq!(run_i64("begin integer result; result := abs(42) end"), 42);
+    }
+
+    #[test]
+    fn abs_of_zero_is_zero() {
+        // Boundary: `0 < 0` is false ⇒ else branch ⇒ 0 (not `-0`).
+        assert_eq!(run_i64("begin integer result; result := abs(0) end"), 0);
+    }
+
+    #[test]
+    fn abs_composes_in_an_expression() {
+        // `abs` is a value expression like any other — usable mid-arithmetic.
+        assert_eq!(
+            run_i64("begin integer result; result := 40 + abs(0 - 2) end"),
+            42
+        );
+    }
+
+    #[test]
+    fn abs_of_negative_real_runs() {
+        // Real `abs` lowers the negation to `fsub` and compares at `f64` width.
+        assert_eq!(
+            run_f64("begin real result; result := abs(0.0 - 3.5) end"),
+            3.5
+        );
+    }
+
+    #[test]
+    fn abs_of_positive_real_is_identity() {
+        assert_eq!(run_f64("begin real result; result := abs(3.5) end"), 3.5);
+    }
+
+    #[test]
+    fn abs_lowers_to_branches_not_a_call() {
+        // The built-in must NOT emit a `call abs` (there is no such procedure):
+        // it lowers inline to a compare + conditional negate.
+        let module = compile_source("begin integer result; result := abs(0 - 1) end", "test")
+            .expect("abs compiles");
+        let main = module
+            .functions
+            .iter()
+            .find(|f| f.name == "main")
+            .expect("has main");
+        assert!(
+            main.instructions.iter().any(|i| i.op == "cmp_lt"),
+            "abs should compare the operand against zero"
+        );
+        assert!(
+            !main
+                .instructions
+                .iter()
+                .any(|i| i.op == "call" && i.srcs.first().and_then(|o| o.as_str_lit()) == Some("abs")),
+            "abs must not lower to a procedure call"
+        );
+    }
+
+    #[test]
+    fn user_declared_abs_overrides_the_builtin() {
+        // The Report lets a program redeclare a standard function.  A user
+        // `procedure abs` returning `x + 1` must win over the built-in, so
+        // `abs(41)` ⇒ 42 (the built-in would give 41).
+        let src = "begin integer result; \
+                   integer procedure abs(x); value x; integer x; abs := x + 1; \
+                   result := abs(41) end";
+        assert_eq!(run_i64(src), 42);
+    }
+
+    #[test]
+    fn abs_rejects_wrong_arity() {
+        let err = compile_source("begin integer result; result := abs(1, 2) end", "test")
+            .expect_err("two-argument abs is a type error");
+        assert!(format!("{err:?}").contains("abs expects 1 argument"));
     }
 
     #[test]

--- a/code/packages/rust/lang-aot/tests/lang_matrix.rs
+++ b/code/packages/rust/lang-aot/tests/lang_matrix.rs
@@ -495,6 +495,22 @@ const PROGRAMS: &[Prog] = &[
         expect: Expect::Exit(2),
         backends: &[NativeAot, Llvm, Wasm, Jvm, Clr, Vm, Jit],
     },
+    // ALGOL 60 — the `abs` **standard function** (§3.2.4, LANG-FULL AL8). `abs`
+    // is built into the language, not a user procedure, so `algol-iir-compiler`
+    // resolves it by name and lowers `abs(0 - 42)` inline to the value of
+    // `if (0-42) < 0 then -(0-42) else (0-42)` — a `cmp_lt` against zero, then a
+    // `jmp_if_false` choosing between a negated and a pass-through `mov` into one
+    // result slot (the store-per-branch shape the conditional-expression lowering
+    // already runs on every backend). No backend learns anything about `abs`: it
+    // is compare + branch + subtract in the shared IIR, so |−42| = 42 ⇒ exit 42
+    // on native-AOT / LLVM / WASM / JVM / CLR / VM / JIT alike.
+    Prog {
+        lang: Language::Algol60,
+        ext: "alg",
+        src: "begin integer result; result := abs(0 - 42) end",
+        expect: Expect::Exit(42),
+        backends: &[NativeAot, Llvm, Wasm, Jvm, Clr, Vm, Jit],
+    },
     // ALGOL 60 — a *typed procedure with a value parameter* (`integer procedure
     // sq(x); value x; integer x; sq := x*x`) called from the main block:
     // `result := sq(7)` ⇒ exit 49.  `algol-iir-compiler` lowers the procedure

--- a/code/specs/LANG-FULL-IMPLEMENTATION.md
+++ b/code/specs/LANG-FULL-IMPLEMENTATION.md
@@ -14,7 +14,7 @@ program per language**, and each frontend is a **deliberate subset**:
 | Brainfuck | one 1-loop "print A" | all 8 ops are correct **but cat/Hello-World/nested-multiply run only on the VM/JIT**, never on the code-gen backends |
 | Dartmouth BASIC | `PRINT 42` | integer-only: no `GOSUB`, strings, `^`; has `FOR`/`NEXT`, `IF`/`GOTO`, `DEF FN` (BA5), `DIM` arrays (BA3), `READ`/`DATA`/`RESTORE` (BA6) — all run on every backend |
 | Oct | `let`/`if` | rejects **all 10 Intel-8008 intrinsics** (its raison d'être); `&&`/`||` short-circuit ✅ (O1), u8 wrap + `~` ✅ (O2), `static` module globals ✅ (O3); intrinsics remain |
-| ALGOL 60 | `result := 17 mod 5` → 2 | `integer`/`real`/`boolean` scalars, typed procedures, switches, 1-D arrays, `own` static-lifetime variables ✅ (AL6, all 7 backends); arrays + reals run on VM/JIT only so far; no call-by-name, strings, multidim arrays |
+| ALGOL 60 | `result := 17 mod 5` → 2 | `integer`/`real`/`boolean` scalars, typed procedures, switches, 1-D arrays, `own` static-lifetime variables ✅ (AL6, all 7 backends), `abs` standard function ✅ (AL8, all 7 backends); arrays + reals run on VM/JIT only so far; no call-by-name, strings, multidim arrays |
 
 **Goal of this campaign:** make every language a *full* implementation —
 every construct in its grammar lowered to the shared IIR, running correctly on
@@ -443,7 +443,13 @@ backend immediately) come before the enabler-dependent items.
   has drifted ahead of the compiled grammar in other rules; resync is follow-up.)
 - ☐ **AL7** — ⚠ call-by-name (Jensen-style expression thunks). **Hardest item in the
   campaign — design pass + user check before implementing.**
-- ☐ **AL8** — standard functions (`abs`/`sign`/`entier`/`sqrt`/`sin`/`cos`/… — needs **E3**).
+- ◑ **AL8** — standard functions (§3.2.4). **`abs` ✅** (algol-iir-compiler 0.8.0):
+  built-in resolved by name (overridable by a user `procedure abs`), lowered inline
+  to `if E < 0 then -E else E` — `cmp_lt` + `jmp_if_false` + negated/pass-through
+  `mov` into one slot — preserving `integer`/`real`. Verified by RUNNING
+  `abs(0 - 42)` ⇒ 42 on native/LLVM/WASM/JVM/CLR/VM/JIT. **Remaining:** `sign`,
+  `entier` (pure IIR, next), then `sqrt`/`sin`/`cos`/`ln`/`exp` (need a cross-backend
+  runtime math library).
 
 ### Twig
 - ✅ **TW1** — variadic arithmetic typed lowering. An all-`i64` `(+ a b c …)` /


### PR DESCRIPTION
## What

Adds ALGOL 60's first **standard function** (§3.2.4), **`abs`**, to `algol-iir-compiler`. `abs(E)` yields |E| preserving its numeric type (`integer`→`integer`, `real`→`real`).

## How

- **Name-based, overridable resolution.** Standard functions aren't user procedures, so they have no `proc_sigs` entry. `emit_call_common` falls back to the built-in **only when the name is not a user-declared procedure** — so a program that redeclares its own `procedure abs` wins, exactly as the Report permits.
- **Inline lowering, no new IIR / no backend changes.** `abs(E)` becomes the value of `if E < 0 then -E else E`: a `cmp_lt` against a typed zero, then `jmp_if_false` choosing between a negated (`0 - E` → `sub`/`fsub`) and a pass-through `mov` into one result slot. This is the same store-per-branch shape (no SSA phi) the conditional-expression lowering already runs on every backend — so no backend learns anything about `abs`. `E` is evaluated once.
- **No grammar change** — `abs(x)` already parses as a `proc_call`; only the compiler's call lowering changed (sidesteps the grammar-regen path entirely).

## Verification — run on real toolchains

- New `lang_matrix.rs` cell: `begin integer result; result := abs(0 - 42) end` ⇒ **exit 42** on **native-AOT / LLVM / WASM / JVM / CLR / VM / JIT**. Full matrix green (`matrix_every_proven_cell_agrees` + `proven_columns_do_not_silently_skip`, 38.9s).
- 9 inline tests: negative / positive / zero / composed integer `abs`; negative / positive real `abs`; a structural check that it lowers to branches **not** a `call abs`; the user-override case; wrong-arity rejection. Full crate suite green (68 tests).
- Security review: PASSED (no panics on source input — `actuals[0]` indexed only after the arity guard; no unsafe/unwrap; IR-building only).

## Scope

`algol-iir-compiler` 0.7.0 → 0.8.0. Roadmap **AL8** marked partial (◑): `abs` done; `sign`/`entier` (pure IIR) next, then `sqrt`/`sin`/`cos`/… (need a cross-backend runtime math library).

🤖 Generated with [Claude Code](https://claude.com/claude-code)