### PR TITLE
feat(sir): variadic parameter kinds — Param.kind + *args/**kwargs emit (M3)

### DIFF
--- a/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to the `ruby-to-semantic-ir` crate will be documented in this file.
 
+## [0.96.0] - 2026-06-22
+
+### Added (M3 — faithful variadic def parameters)
+
+- `def f(*rest)` and `def g(**opts)` now lower to a `Param` whose new
+  `kind` field is `ParamKind::Rest` / `ParamKind::KwRest` instead of dropping
+  the `*` / `**` prefix and emitting a bare positional `Param`. All three
+  def-param lowering paths (`lower_def_statement`, the singleton-def path, and
+  the endless-def path) detect the leading prefix token and set the kind;
+  ordinary positionals stay `Required`. The lossy-limitation comment is
+  removed. No grammar change (the parser already accepts `*`/`**` on def
+  params). Closes the def side of variadics; the call side (`f(*arr)`) was
+  already handled by Q9c.
+
 ## [0.95.0] - 2026-06-21
 
 ### Added (RB2 — `yield` inside a hoisted block captures the enclosing block)

--- a/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
@@ -61,7 +61,7 @@ pub fn compile_source(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use semantic_ir::{Effect, Expr, Scope, Stmt};
+    use semantic_ir::{Effect, Expr, ParamKind, Scope, Stmt};
 
     fn lower(src: &str) -> semantic_ir::Module {
         compile_source(src, "test").expect("lowering succeeded")
@@ -258,6 +258,46 @@ mod tests {
         // `main` is still present and exported.
         assert!(m.functions.iter().any(|f| f.name == "main"));
         assert!(m.exports.iter().any(|e| e.name == "main"));
+    }
+
+    #[test]
+    fn def_rest_param_lowers_to_kind_rest() {
+        // M3: `def f(*r); end` → one Param whose kind is Rest (previously the
+        // splat prefix was dropped and the param lowered as Required).
+        let m = lower("def f(*r)\nend\n");
+        let f = m.functions.iter().find(|f| f.name == "f").expect("fn f");
+        assert_eq!(f.params.len(), 1);
+        assert_eq!(f.params[0].name, "r");
+        assert_eq!(f.params[0].kind, ParamKind::Rest);
+    }
+
+    #[test]
+    fn def_kwrest_param_lowers_to_kind_kwrest() {
+        // M3: `def g(**o); end` → one Param whose kind is KwRest.
+        let m = lower("def g(**o)\nend\n");
+        let g = m.functions.iter().find(|f| f.name == "g").expect("fn g");
+        assert_eq!(g.params.len(), 1);
+        assert_eq!(g.params[0].name, "o");
+        assert_eq!(g.params[0].kind, ParamKind::KwRest);
+    }
+
+    #[test]
+    fn def_required_then_rest_preserves_order_and_kinds() {
+        // M3: `def h(a, *r); end` → [Required(a), Rest(r)].
+        let m = lower("def h(a, *r)\nend\n");
+        let h = m.functions.iter().find(|f| f.name == "h").expect("fn h");
+        assert_eq!(h.params.len(), 2);
+        assert_eq!(h.params[0].kind, ParamKind::Required);
+        assert_eq!(h.params[1].name, "r");
+        assert_eq!(h.params[1].kind, ParamKind::Rest);
+    }
+
+    #[test]
+    fn def_plain_param_stays_required() {
+        // Regression: an ordinary positional param keeps kind Required.
+        let m = lower("def k(a)\nend\n");
+        let k = m.functions.iter().find(|f| f.name == "k").expect("fn k");
+        assert_eq!(k.params[0].kind, ParamKind::Required);
     }
 
     #[test]

--- a/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
@@ -14,7 +14,7 @@ use lexer::token::{Token, TokenType};
 use parser::grammar_parser::{ASTNodeOrToken, GrammarASTNode};
 use semantic_ir::{
     Block, Capture, CaptureValue, Effect, EffectSet, ExportName, Expr, Feature, FeatureManifest,
-    Function, Metadata, Module, Param, RescueClause, Scope, Span, Stmt,
+    Function, Metadata, Module, Param, ParamKind, RescueClause, Scope, Span, Stmt,
 };
 
 /// A failure encountered during Ruby → SIR lowering.
@@ -3023,6 +3023,7 @@ impl Lowerer {
             func.params.push(Param {
                 name: BLOCK_PARAM_NAME.to_string(),
                 sir_type: None,
+                kind: ParamKind::Required,
                 span,
             });
             // The synthesized parameter is untyped (`sir_type: None`),
@@ -3663,10 +3664,9 @@ impl Lowerer {
         let name = name_token.value.clone();
 
         // Parameter list — same `params` rule shape as `def_statement`.
-        // Reuse the same extraction (find each `param` subnode, skip
-        // splat-prefix Token, take the identifier Name).  See the
-        // matching code in `lower_def_statement` for the lossy-splat
-        // v0 limitation.
+        // Reuse the same extraction (find each `param` subnode, detect the
+        // `*`/`**` splat prefix → ParamKind, take the identifier Name).  See
+        // the matching code in `lower_def_statement` (M3).
         let params_node = node.children.iter().find_map(|c| match c {
             ASTNodeOrToken::Node(n) if n.rule_name == "params" => Some(n),
             _ => None,
@@ -3676,6 +3676,11 @@ impl Lowerer {
                 .iter()
                 .filter_map(|c| match c {
                     ASTNodeOrToken::Node(param_node) if param_node.rule_name == "param" => {
+                        let kind = param_node.children.iter().find_map(|cc| match cc {
+                            ASTNodeOrToken::Token(t) if t.value == "**" => Some(ParamKind::KwRest),
+                            ASTNodeOrToken::Token(t) if t.value == "*" => Some(ParamKind::Rest),
+                            _ => None,
+                        });
                         param_node.children.iter().find_map(|cc| match cc {
                             ASTNodeOrToken::Token(t)
                                 if matches!(t.type_, TokenType::Name)
@@ -3685,6 +3690,7 @@ impl Lowerer {
                                 Some(Param {
                                     name: t.value.clone(),
                                     sir_type: None,
+                                    kind: kind.unwrap_or(ParamKind::Required),
                                     span: self.span_of_token(t),
                                 })
                             }
@@ -3791,15 +3797,12 @@ impl Lowerer {
         // detect the splat prefix from its leading Token (`*` or `**`,
         // both with `value` set), and extract the parameter Name.
         //
-        // v0 limitation: the splat-ness of a param is LOST at the SIR
-        // level.  Param has no variadic flag, so a splat param lowers
-        // to a regular Param with the bare Name (no `*` prefix in
-        // `name`).  Downstream emitters therefore treat the parameter
-        // as positional rather than variadic — a deferred correctness
-        // limitation tracked for a future SIR phase.  The grammar +
-        // parse round-trip is correct; the lossy SIR shape only
-        // matters when generating target source for a Ruby program
-        // that actually relies on variadic semantics.
+        // M3: the splat-ness of a param is now preserved on the SIR
+        // `Param.kind`.  A `*rest` param lowers to `ParamKind::Rest`,
+        // `**opts` to `ParamKind::KwRest`, everything else
+        // `ParamKind::Required` — so the backends can emit faithful
+        // `*args`/`**kwargs` (Python) / `...rest` (TypeScript).  See
+        // `code/specs/sir-variadic-params.md`.
         let params_node = node.children.iter().find_map(|c| match c {
             ASTNodeOrToken::Node(n) if n.rule_name == "params" => Some(n),
             _ => None,
@@ -3809,13 +3812,17 @@ impl Lowerer {
                 .iter()
                 .filter_map(|c| match c {
                     ASTNodeOrToken::Node(param_node) if param_node.rule_name == "param" => {
-                        // Find the parameter Name token, skipping the
-                        // optional `*`/`**` splat prefix.  Both the
-                        // prefix and the identifier land on Name-typed
-                        // tokens (the 1.8-baseline state machine
-                        // coalesces `**` into one Name token with value
-                        // `"**"`, and `*` is technically a Star token
-                        // but defensive value-filter covers both).
+                        // Detect the leading `*`/`**` splat prefix (the
+                        // 1.8-baseline state machine coalesces `**` into one
+                        // Name token with value `"**"`; `*` is a Star token,
+                        // but a defensive value match covers either spelling).
+                        let kind = param_node.children.iter().find_map(|cc| match cc {
+                            ASTNodeOrToken::Token(t) if t.value == "**" => Some(ParamKind::KwRest),
+                            ASTNodeOrToken::Token(t) if t.value == "*" => Some(ParamKind::Rest),
+                            _ => None,
+                        });
+                        // The parameter Name token is the one that is not the
+                        // `*`/`**` prefix.
                         param_node.children.iter().find_map(|cc| match cc {
                             ASTNodeOrToken::Token(t)
                                 if matches!(t.type_, TokenType::Name)
@@ -3825,6 +3832,7 @@ impl Lowerer {
                                 Some(Param {
                                     name: t.value.clone(),
                                     sir_type: None,
+                                    kind: kind.unwrap_or(ParamKind::Required),
                                     span: self.span_of_token(t),
                                 })
                             }
@@ -5457,6 +5465,7 @@ impl Lowerer {
                             params.push(Param {
                                 name: t.value.clone(),
                                 sir_type: None,
+                                kind: ParamKind::Required,
                                 span: self.span_of_token(t),
                             });
                         }
@@ -5481,6 +5490,7 @@ impl Lowerer {
                     params.push(Param {
                         name: format!("_{n}"),
                         sir_type: None,
+                        kind: ParamKind::Required,
                         span: self.span_of(inner),
                     });
                 }
@@ -5493,6 +5503,7 @@ impl Lowerer {
                 params.push(Param {
                     name: "it".to_string(),
                     sir_type: None,
+                    kind: ParamKind::Required,
                     span: self.span_of(inner),
                 });
             }
@@ -5723,7 +5734,13 @@ impl Lowerer {
                     ASTNodeOrToken::Node(param_node)
                         if param_node.rule_name == "param" =>
                     {
-                        // Skip splat-prefix tokens; pick the bare NAME.
+                        // M3: detect the `*`/`**` splat prefix → ParamKind,
+                        // then pick the bare NAME token.
+                        let kind = param_node.children.iter().find_map(|cc| match cc {
+                            ASTNodeOrToken::Token(t) if t.value == "**" => Some(ParamKind::KwRest),
+                            ASTNodeOrToken::Token(t) if t.value == "*" => Some(ParamKind::Rest),
+                            _ => None,
+                        });
                         param_node.children.iter().find_map(|cc| match cc {
                             ASTNodeOrToken::Token(t)
                                 if matches!(t.type_, TokenType::Name)
@@ -5733,6 +5750,7 @@ impl Lowerer {
                                 Some(Param {
                                     name: t.value.clone(),
                                     sir_type: None,
+                                    kind: kind.unwrap_or(ParamKind::Required),
                                     span: self.span_of_token(t),
                                 })
                             }

--- a/code/packages/rust/semantic-ir-to-go/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-go/src/emit.rs
@@ -561,7 +561,7 @@ fn quote_go_string(s: &str) -> String {
 mod tests {
     use super::*;
     use semantic_ir::{
-        EffectSet, FeatureManifest, Metadata, Param, Span,
+        EffectSet, FeatureManifest, Metadata, Param, ParamKind, Span,
     };
 
     fn s() -> Span {
@@ -638,7 +638,7 @@ mod tests {
         };
         let f = Function {
             name: "id".into(),
-            params: vec![Param { name: "x".into(), sir_type: None, span: s() }],
+            params: vec![Param { name: "x".into(), kind: ParamKind::Required, sir_type: None, span: s() }],
             return_type: None,
             captures: vec![],
             body,

--- a/code/packages/rust/semantic-ir-to-python/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-python/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## 0.1.21 — variadic parameter emission (`*args` / `**kwargs`) (M3)
+
+A `Param` carrying the new SIR `ParamKind` now emits Python's native variadic
+forms: `Rest` → `*name`, `KwRest` → `**name`; `Required` is unchanged. So
+`def f(a, *rest, **opts); end` emits `def f(a, *rest, **opts):`.
+
+- **Rest-param list normalization.** Python's `*rest` binds a *tuple*, but SIR
+  sequence semantics (and Ruby's `*rest`, an `Array`) require a *list* — every
+  downstream sequence op (`len`, indexing, dispatched `.map`/`.length`) is keyed
+  to `list`. Each `Rest` param is therefore rebound to a `list(...)` in the
+  function prologue. (`**opts` already binds a `dict`, matching SIR's map, so
+  no fixup.)
+- **OOP import gating widened.** `uses_oop` now also fires on the `__method__`
+  and `__scope__` dispatch builtins, not only the OOP *features* — so a
+  class-less dispatch program (`"hi".upcase`, or a rest param used as an Array)
+  imports `sir-runtime-oop`. Previously such modules emitted an undefined
+  `_sir_oop_call_method` call.
+- Execution-proof: `def f(*a); a.length; end; print f(1, 2, 3)` → `3` through a
+  real interpreter (skips gracefully if absent). The shared run harness now
+  names its temp file uniquely per call so concurrent proofs don't collide.
+
 ## 0.1.20 — `&:sym` symbol-to-proc on dispatched calls (M2)
 
 A `&:sym` block argument on a method-dispatch call (`recv.map(&:to_s)`) now

--- a/code/packages/rust/semantic-ir-to-python/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-python/src/emit.rs
@@ -12,7 +12,7 @@ use std::collections::{BTreeSet, HashMap};
 use std::fmt::Write;
 
 use semantic_ir::{
-    Block, Expr, Feature, Function, Global, Module, Scope, Stmt,
+    Block, Expr, Feature, Function, Global, Module, ParamKind, Scope, Stmt,
 };
 
 use crate::runtime::RUNTIME;
@@ -29,6 +29,14 @@ fn uses_oop(m: &Module) -> bool {
     ]
     .iter()
     .any(|f| m.manifest.contains(*f))
+        // Method dispatch (`recv.meth(args)` → `BuiltinCall("__method__", …)`)
+        // and scoped lookups (`A::B` → `BuiltinCall("__scope__", …)`) both route
+        // through `_sir_oop_call_method`/the OOP runtime even when the module
+        // declares no class/module of its own — e.g. `"hi".upcase` or, post-M3,
+        // a rest param used as an Array (`def f(*a); a.length; end`). Gate the
+        // OOP import on those builtins too, else the emitted call is undefined.
+        || module_uses_builtin(m, "__method__")
+        || module_uses_builtin(m, "__scope__")
 }
 
 /// True if the module uses exception handling, in which case the emitted
@@ -301,9 +309,32 @@ fn emit_function(out: &mut String, f: &Function) {
             out.push_str(", ");
         }
         first = false;
+        // M3 variadic kinds map to Python's native variadic forms:
+        //   Rest   (`*rest`)  → `*rest`   (collects trailing positionals)
+        //   KwRest (`**opts`) → `**opts`  (collects trailing keywords)
+        // Both are faithful in Python; only the construction differs.
+        match p.kind {
+            ParamKind::Rest => out.push('*'),
+            ParamKind::KwRest => out.push_str("**"),
+            ParamKind::Required => {}
+        }
         out.push_str(&sanitize_ident(&p.name));
     }
     out.push_str("):\n");
+
+    // M3 Rest-param normalization. Python's `*rest` binds a *tuple*, but SIR
+    // sequence semantics (and Ruby's `*rest`, which is an `Array`) require a
+    // *list* — every downstream sequence op (`len`, indexing, dispatched
+    // `.map`/`.length`, …) is keyed to `list`. So rebind each Rest param to a
+    // list in the function prologue. (`**opts` already binds a `dict`, which
+    // matches SIR's map representation, so KwRest needs no fixup.)
+    let pad = indent_str(1);
+    for p in &f.params {
+        if p.kind == ParamKind::Rest {
+            let name = sanitize_ident(&p.name);
+            let _ = writeln!(out, "{pad}{name} = list({name})");
+        }
+    }
 
     emit_function_body(out, &f.body, 1);
 }
@@ -1481,7 +1512,7 @@ mod tests {
         };
         let f = Function {
             name: "id".into(),
-            params: vec![Param { name: "x".into(), sir_type: None, span: s() }],
+            params: vec![Param { name: "x".into(), sir_type: None, kind: ParamKind::Required, span: s() }],
             return_type: None,
             captures: vec![],
             body,
@@ -1493,6 +1524,29 @@ mod tests {
         emit_function(&mut out, &f);
         assert!(out.contains("def id(x):"));
         assert!(out.contains("return x"));
+    }
+
+    #[test]
+    fn emit_variadic_params_native_star_forms() {
+        // M3: `def f(a, *rest, **opts); end` → Python `def f(a, *rest, **opts):`
+        // — both variadic kinds have faithful native Python forms.
+        let f = Function {
+            name: "f".into(),
+            params: vec![
+                Param { name: "a".into(), sir_type: None, kind: ParamKind::Required, span: s() },
+                Param { name: "rest".into(), sir_type: None, kind: ParamKind::Rest, span: s() },
+                Param { name: "opts".into(), sir_type: None, kind: ParamKind::KwRest, span: s() },
+            ],
+            return_type: None,
+            captures: vec![],
+            body: Block { stmts: vec![], value: Expr::NilLit { span: s() }, span: s() },
+            effects: EffectSet::PURE,
+            metadata: Metadata::new(),
+            span: s(),
+        };
+        let mut out = String::new();
+        emit_function(&mut out, &f);
+        assert!(out.contains("def f(a, *rest, **opts):"), "got: {out}");
     }
 
     #[test]

--- a/code/packages/rust/semantic-ir-to-python/src/lib.rs
+++ b/code/packages/rust/semantic-ir-to-python/src/lib.rs
@@ -205,10 +205,18 @@ mod tests {
         let pythonpath = std::env::join_paths([
             py_root.join("sir-runtime-core/src"),
             py_root.join("sir-runtime-pairs/src"),
+            py_root.join("sir-runtime-oop/src"),
         ])
         .expect("join PYTHONPATH");
 
-        let file = std::env::temp_dir().join(format!("sir_rb3_{}.py", std::process::id()));
+        // Unique per call: the process id alone collides when several
+        // execution-proof tests run concurrently in the same test binary (they
+        // would clobber each other's temp file). A per-call atomic counter
+        // disambiguates.
+        static SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+        let nonce = SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        let file = std::env::temp_dir()
+            .join(format!("sir_rb3_{}_{}.py", std::process::id(), nonce));
         std::fs::write(&file, source).expect("write temp python");
         let out = std::process::Command::new(exe)
             .arg(&file)
@@ -256,6 +264,22 @@ mod tests {
         // captured block reaches `outer`'s caller block at runtime.
         if let Some(stdout) = run_emitted_python(&a.source) {
             assert_eq!(stdout, "1\n2\n", "emitted python printed unexpected output");
+        }
+    }
+
+    #[test]
+    fn end_to_end_variadic_rest_collects_args_py() {
+        // M3 execution-proof: `def f(*a); a.length; end; puts f(1, 2, 3)` →
+        // the splat param collects the three positional arguments, so the
+        // dispatched `length` reports `3`. Proves the emitted `def f(*a):`
+        // binds variadics at runtime, not just on paper.
+        let src = "def f(*a)\n  a.length\nend\nprint f(1, 2, 3)\n";
+        let module = ruby_to_semantic_ir::compile_source(src, "demo").expect("lower ruby");
+        let a = compile(&module).expect("compile to python");
+        assert!(a.source.contains("def f(*a):"), "got:\n{}", a.source);
+        assert!(a.source.contains("a = list(a)"), "rest param must normalize to list; got:\n{}", a.source);
+        if let Some(stdout) = run_emitted_python(&a.source) {
+            assert_eq!(stdout, "3\n", "emitted python printed unexpected output");
         }
     }
 

--- a/code/packages/rust/semantic-ir-to-rust/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-rust/src/emit.rs
@@ -668,7 +668,7 @@ fn quote_rs_string(s: &str) -> String {
 mod tests {
     use super::*;
     use semantic_ir::{
-        EffectSet, FeatureManifest, Metadata, Param, Span,
+        EffectSet, FeatureManifest, Metadata, Param, ParamKind, Span,
     };
 
     fn s() -> Span {
@@ -913,7 +913,7 @@ mod tests {
         };
         let f = Function {
             name: "id".into(),
-            params: vec![Param { name: "x".into(), sir_type: None, span: s() }],
+            params: vec![Param { name: "x".into(), kind: ParamKind::Required, sir_type: None, span: s() }],
             return_type: None,
             captures: vec![],
             body,

--- a/code/packages/rust/semantic-ir-to-typescript/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-typescript/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## 0.1.20 — variadic parameter emission (`...rest`) (M3)
+
+A `Param` carrying the new SIR `ParamKind` now emits TypeScript's variadic
+forms: `Rest` → `...name: __Sir.Val[]` (native JS rest, already a real Array =
+SIR sequence); `Required` is unchanged. So `def f(a, *rest); end` emits
+`function f(a: __Sir.Val, ...rest: __Sir.Val[])`.
+
+- **KwRest v0 object fallback.** JavaScript has no keyword-argument call form,
+  so a `KwRest` (`**opts`) def parameter has no faithful native declaration. v0
+  emits it as a trailing ordinary object parameter (`opts: __Sir.Val`) — the
+  call side (Q10f) already collapses `**h` into a single merged trailing
+  object, so this binds it. Documented limitation; mirrors the TS double-splat
+  call-position treatment.
+- **OOP import gating widened.** `uses_oop` now also fires on the `__method__`
+  and `__scope__` dispatch builtins, not only the OOP *features* — so a
+  class-less dispatch program (`"hi".upcase`, or a rest param used as an Array)
+  imports `@coding-adventures/sir-runtime-oop`.
+
 ## 0.1.19 — `&:sym` symbol-to-proc on dispatched calls (M2)
 
 A `&:sym` block argument on a method-dispatch call (`recv.map(&:to_s)`) now

--- a/code/packages/rust/semantic-ir-to-typescript/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-typescript/src/emit.rs
@@ -21,7 +21,7 @@ use std::collections::HashSet;
 use std::fmt::Write;
 
 use semantic_ir::{
-    Block, Expr, Feature, Function, Global, Module, Scope, Stmt,
+    Block, Expr, Feature, Function, Global, Module, ParamKind, Scope, Stmt,
 };
 
 use crate::runtime::RUNTIME;
@@ -38,6 +38,14 @@ fn uses_oop(m: &Module) -> bool {
     ]
     .iter()
     .any(|f| m.manifest.contains(*f))
+        // Method dispatch (`recv.meth(args)` → `BuiltinCall("__method__", …)`)
+        // and scoped lookups (`A::B` → `BuiltinCall("__scope__", …)`) both route
+        // through the OOP runtime even when the module declares no class/module
+        // of its own — e.g. `"hi".upcase` or, post-M3, a rest param used as an
+        // Array (`def f(*a); a.length; end`). Gate the OOP import on those
+        // builtins too, else the emitted call is undefined.
+        || module_uses_builtin(m, "__method__")
+        || module_uses_builtin(m, "__scope__")
 }
 
 /// True if the module uses exception handling, in which case the emitted
@@ -294,7 +302,23 @@ fn emit_function(out: &mut String, f: &Function) {
             out.push_str(", ");
         }
         first = false;
-        let _ = write!(out, "{}: __Sir.Val", sanitize_ident(&p.name));
+        // M3 variadic kinds in TypeScript:
+        //   Rest   (`*rest`)  → `...rest: __Sir.Val[]`  (native JS rest)
+        //   KwRest (`**opts`) → `opts: __Sir.Val`        (v0 object fallback)
+        // JavaScript has no keyword-argument call form, so a KwRest def
+        // parameter has no faithful native declaration. v0: emit it as a
+        // trailing ordinary object parameter — the call side (Q10f) already
+        // collapses `**h` into a single merged trailing object, so this binds
+        // that object. (Documented limitation; mirrors the TS double-splat
+        // call-position treatment.)
+        match p.kind {
+            ParamKind::Rest => {
+                let _ = write!(out, "...{}: __Sir.Val[]", sanitize_ident(&p.name));
+            }
+            ParamKind::Required | ParamKind::KwRest => {
+                let _ = write!(out, "{}: __Sir.Val", sanitize_ident(&p.name));
+            }
+        }
     }
     out.push_str("): __Sir.Val {\n");
 
@@ -1678,7 +1702,7 @@ mod tests {
         };
         let f = Function {
             name: "id".into(),
-            params: vec![Param { name: "x".into(), sir_type: None, span: s() }],
+            params: vec![Param { name: "x".into(), sir_type: None, kind: ParamKind::Required, span: s() }],
             return_type: None,
             captures: vec![],
             body,
@@ -1690,6 +1714,34 @@ mod tests {
         emit_function(&mut out, &f);
         assert!(out.contains("function id(x: __Sir.Val): __Sir.Val"));
         assert!(out.contains("return x;"));
+    }
+
+    #[test]
+    fn emit_variadic_params_rest_native_kwrest_object_fallback() {
+        // M3: `def f(a, *rest, **opts); end` → TS
+        // `function f(a: __Sir.Val, ...rest: __Sir.Val[], opts: __Sir.Val)`.
+        // Rest is native JS rest; KwRest has no faithful JS form (no kwargs),
+        // so v0 emits it as a trailing ordinary object parameter.
+        let f = Function {
+            name: "f".into(),
+            params: vec![
+                Param { name: "a".into(), sir_type: None, kind: ParamKind::Required, span: s() },
+                Param { name: "rest".into(), sir_type: None, kind: ParamKind::Rest, span: s() },
+                Param { name: "opts".into(), sir_type: None, kind: ParamKind::KwRest, span: s() },
+            ],
+            return_type: None,
+            captures: vec![],
+            body: Block { stmts: vec![], value: Expr::NilLit { span: s() }, span: s() },
+            effects: EffectSet::PURE,
+            metadata: Metadata::new(),
+            span: s(),
+        };
+        let mut out = String::new();
+        emit_function(&mut out, &f);
+        assert!(
+            out.contains("function f(a: __Sir.Val, ...rest: __Sir.Val[], opts: __Sir.Val)"),
+            "got: {out}"
+        );
     }
 
     #[test]

--- a/code/packages/rust/semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir/CHANGELOG.md
@@ -2,6 +2,32 @@
 
 All notable changes to the `semantic-ir` crate are documented here.
 
+## 0.11.0 — SIR19: variadic parameter kinds (`Param.kind` / `ParamKind`) (M3)
+
+Closes the def-side variadic limitation: previously a splat parameter
+(`def f(*rest)` / `def g(**opts)`) lost its splat-ness at the SIR level and
+lowered to an ordinary positional `Param`, so the emitted Python/TypeScript
+declared a fixed positional parameter and a variadic call (`f(1, 2, 3)`) broke.
+
+### Added
+
+- `ParamKind` enum — `Required` (default), `Rest` (`*rest`), `KwRest`
+  (`**opts`) — re-exported from the crate root.
+- `Param.kind: ParamKind` — a new field on `Param`. Every in-tree construction
+  sets it explicitly.
+- Validator rules (`validate`): at most one `Rest` and at most one `KwRest`
+  per parameter list, and ordering — required positionals precede the lone
+  `Rest`, which precedes the lone `KwRest`. The reserved trailing block
+  parameter `__sir_block__` (Q9e) is exempt (always `Required`, always last).
+- Text printer renders `*name` / `**name` for the two variadic kinds so a
+  round-tripped module preserves splat-ness.
+
+### Changed
+
+- Every literal `Param { … }` construction (smoke tests, printer tests) now
+  sets `kind`. Backends read params by field access, so the added field does
+  not affect their reads — only constructions.
+
 ## 0.10.0 — SIR18: string interpolation (`Expr::StrConcat`)
 
 Introduced by the Ruby frontend's Phase 20b (`"a#{x}b"` interpolation).

--- a/code/packages/rust/semantic-ir/src/lib.rs
+++ b/code/packages/rust/semantic-ir/src/lib.rs
@@ -66,7 +66,7 @@ pub use manifest::{Feature, FeatureManifest};
 pub use metadata::{Metadata, CURRENT_SIR_VERSION};
 pub use nodes::{
     Block, Capture, CaptureValue, ExportName, Expr, Function, Global, Import, ImportName, Module,
-    Param, RescueClause, Scope, Stmt,
+    Param, ParamKind, RescueClause, Scope, Stmt,
 };
 pub use span::Span;
 pub use text::{print_block, print_expr, print_function, print_module};
@@ -114,6 +114,7 @@ mod smoke {
             params: vec![Param {
                 name: "x".into(),
                 sir_type: None,
+                kind: ParamKind::Required,
                 span: Span::synthetic(),
             }],
             return_type: None,

--- a/code/packages/rust/semantic-ir/src/nodes.rs
+++ b/code/packages/rust/semantic-ir/src/nodes.rs
@@ -124,11 +124,30 @@ pub struct Function {
     pub span: Span,
 }
 
+/// How a parameter binds its arguments (M3 — see
+/// `code/specs/sir-variadic-params.md`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum ParamKind {
+    /// An ordinary positional parameter (`x`). The default for every
+    /// parameter that is not a splat.
+    #[default]
+    Required,
+    /// A rest parameter (`*rest`) — collects trailing positional arguments
+    /// into a sequence.
+    Rest,
+    /// A keyword-rest parameter (`**opts`) — collects trailing keyword
+    /// arguments into a map.
+    KwRest,
+}
+
 /// A function parameter.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Param {
     pub name: String,
     pub sir_type: Option<SirType>,
+    /// The binding kind (`Required` by default; `Rest`/`KwRest` for the
+    /// `*rest`/`**opts` variadic forms — M3).
+    pub kind: ParamKind,
     pub span: Span,
 }
 

--- a/code/packages/rust/semantic-ir/src/text/printer.rs
+++ b/code/packages/rust/semantic-ir/src/text/printer.rs
@@ -100,7 +100,15 @@ fn print_function_indented(out: &mut String, f: &Function, indent: usize) {
         if i > 0 {
             out.push(' ');
         }
-        let _ = write!(out, "({} {})", p.name, type_or_any(p.sir_type.as_ref()));
+        // Variadic kinds render with a Ruby-faithful prefix so a
+        // round-tripped module preserves splat-ness: `*rest` for a Rest
+        // param, `**opts` for a KwRest param, plain `name` otherwise.
+        let prefix = match p.kind {
+            ParamKind::Required => "",
+            ParamKind::Rest => "*",
+            ParamKind::KwRest => "**",
+        };
+        let _ = write!(out, "({}{} {})", prefix, p.name, type_or_any(p.sir_type.as_ref()));
     }
     let _ = write!(out, ") {}", type_or_any(f.return_type.as_ref()));
     if !f.captures.is_empty() {
@@ -687,8 +695,8 @@ mod tests {
         let f = Function {
             name: "add".into(),
             params: vec![
-                Param { name: "x".into(), sir_type: None, span: s() },
-                Param { name: "y".into(), sir_type: None, span: s() },
+                Param { name: "x".into(), sir_type: None, kind: ParamKind::Required, span: s() },
+                Param { name: "y".into(), sir_type: None, kind: ParamKind::Required, span: s() },
             ],
             return_type: None,
             captures: vec![],
@@ -704,6 +712,40 @@ mod tests {
         let text = print_module(&m);
         assert!(text.contains("(function add ((x any) (y any)) any (effects pure)"));
         assert!(text.contains("(builtin-call + (effects pure) (var-ref x param) (var-ref y param))"));
+    }
+
+    #[test]
+    fn print_variadic_params_render_splat_prefix() {
+        // M3: a Rest param renders `*name`, a KwRest param renders `**name`,
+        // so round-tripping preserves splat-ness. `def f(a, *rest, **opts)`.
+        let body = Block {
+            stmts: vec![],
+            value: Expr::NilLit { span: s() },
+            span: s(),
+        };
+        let f = Function {
+            name: "f".into(),
+            params: vec![
+                Param { name: "a".into(), sir_type: None, kind: ParamKind::Required, span: s() },
+                Param { name: "rest".into(), sir_type: None, kind: ParamKind::Rest, span: s() },
+                Param { name: "opts".into(), sir_type: None, kind: ParamKind::KwRest, span: s() },
+            ],
+            return_type: None,
+            captures: vec![],
+            body,
+            effects: EffectSet::PURE,
+            metadata: Metadata::new(),
+            span: s(),
+        };
+        let m = module_with(
+            vec![f],
+            FeatureManifest::from_features(&[Feature::DynamicTyping]),
+        );
+        let text = print_module(&m);
+        assert!(
+            text.contains("(function f ((a any) (*rest any) (**opts any)) any"),
+            "got: {text}"
+        );
     }
 
     #[test]

--- a/code/packages/rust/semantic-ir/src/validator.rs
+++ b/code/packages/rust/semantic-ir/src/validator.rs
@@ -219,6 +219,67 @@ impl<'m> ValidatorState<'m> {
             }
         }
 
+        // Variadic-parameter well-formedness (M3). A Ruby-faithful, v0-light
+        // rule set over `kind`:
+        //   - at most one `Rest` (`*rest`) parameter;
+        //   - at most one `KwRest` (`**opts`) parameter;
+        //   - ordering: required positionals come first, then the lone Rest,
+        //     then the lone KwRest. A Required after a Rest, or anything after
+        //     a KwRest, is a structural error (not a panic).
+        // Truth table for the offending transitions we reject:
+        //   prev\cur | Required | Rest     | KwRest
+        //   Rest     | ERROR    | (dup)    | ok
+        //   KwRest   | ERROR    | ERROR    | (dup)
+        let mut rest_seen = false;
+        let mut kwrest_seen = false;
+        for p in &f.params {
+            match p.kind {
+                ParamKind::Rest => {
+                    if rest_seen {
+                        self.error(
+                            format!("more than one rest parameter (`*{}`)", p.name),
+                            &p.span,
+                        );
+                    }
+                    if kwrest_seen {
+                        self.error(
+                            format!("rest parameter `*{}` must precede the keyword-rest parameter", p.name),
+                            &p.span,
+                        );
+                    }
+                    rest_seen = true;
+                }
+                ParamKind::KwRest => {
+                    if kwrest_seen {
+                        self.error(
+                            format!("more than one keyword-rest parameter (`**{}`)", p.name),
+                            &p.span,
+                        );
+                    }
+                    kwrest_seen = true;
+                }
+                ParamKind::Required => {
+                    // The reserved trailing block parameter (Q9e) is always
+                    // Required and always appended last — after any variadic
+                    // params — so it is exempt from the ordering rule.
+                    if p.name == "__sir_block__" {
+                        continue;
+                    }
+                    if kwrest_seen {
+                        self.error(
+                            format!("required parameter `{}` must precede the keyword-rest parameter", p.name),
+                            &p.span,
+                        );
+                    } else if rest_seen {
+                        self.error(
+                            format!("required parameter `{}` must precede the rest parameter", p.name),
+                            &p.span,
+                        );
+                    }
+                }
+            }
+        }
+
         let mut capture_names: HashSet<String> = HashSet::new();
         for c in &f.captures {
             if !capture_names.insert(c.name.clone()) {
@@ -789,6 +850,102 @@ mod tests {
         });
         let r = validate(&m);
         assert!(!r.is_ok());
+    }
+
+    /// Build a single-function module whose function has `params` and a
+    /// trivial nil body — for exercising the M3 variadic ordering rules.
+    fn module_with_params(params: Vec<Param>) -> Module {
+        let mut m = empty_module(FeatureManifest::from_features(&[Feature::DynamicTyping]));
+        m.functions.push(Function {
+            name: "f".into(),
+            params,
+            return_type: None,
+            captures: vec![],
+            body: Block {
+                stmts: vec![],
+                value: Expr::NilLit { span: s() },
+                span: s(),
+            },
+            effects: EffectSet::PURE,
+            metadata: Metadata::new(),
+            span: s(),
+        });
+        m
+    }
+
+    fn p(name: &str, kind: ParamKind) -> Param {
+        Param { name: name.into(), sir_type: None, kind, span: s() }
+    }
+
+    #[test]
+    fn variadic_params_in_canonical_order_are_valid() {
+        // def f(a, *rest, **opts) — required, then one Rest, then one KwRest.
+        let m = module_with_params(vec![
+            p("a", ParamKind::Required),
+            p("rest", ParamKind::Rest),
+            p("opts", ParamKind::KwRest),
+        ]);
+        let r = validate(&m);
+        assert!(r.is_ok(), "expected ok, got {:?}", r.issues);
+    }
+
+    #[test]
+    fn two_rest_params_is_error() {
+        let m = module_with_params(vec![
+            p("a", ParamKind::Rest),
+            p("b", ParamKind::Rest),
+        ]);
+        let r = validate(&m);
+        assert!(!r.is_ok());
+        assert!(r.errors().any(|i| i.message.contains("more than one rest")));
+    }
+
+    #[test]
+    fn two_kwrest_params_is_error() {
+        let m = module_with_params(vec![
+            p("a", ParamKind::KwRest),
+            p("b", ParamKind::KwRest),
+        ]);
+        let r = validate(&m);
+        assert!(!r.is_ok());
+        assert!(r.errors().any(|i| i.message.contains("more than one keyword-rest")));
+    }
+
+    #[test]
+    fn kwrest_before_rest_is_error() {
+        // def f(**opts, *rest) — Rest must precede KwRest.
+        let m = module_with_params(vec![
+            p("opts", ParamKind::KwRest),
+            p("rest", ParamKind::Rest),
+        ]);
+        let r = validate(&m);
+        assert!(!r.is_ok());
+        assert!(r.errors().any(|i| i.message.contains("must precede the keyword-rest")));
+    }
+
+    #[test]
+    fn required_after_rest_is_error() {
+        // def f(*rest, a) — a required positional after the rest param.
+        let m = module_with_params(vec![
+            p("rest", ParamKind::Rest),
+            p("a", ParamKind::Required),
+        ]);
+        let r = validate(&m);
+        assert!(!r.is_ok());
+        assert!(r.errors().any(|i| i.message.contains("must precede the rest")));
+    }
+
+    #[test]
+    fn reserved_block_param_after_rest_is_exempt() {
+        // The Q9e trailing block param is always Required and always last,
+        // appearing after any variadic params — and must NOT trigger the
+        // ordering rule. def f(*rest) { yield } → params [*rest, __sir_block__].
+        let m = module_with_params(vec![
+            p("rest", ParamKind::Rest),
+            p("__sir_block__", ParamKind::Required),
+        ]);
+        let r = validate(&m);
+        assert!(r.is_ok(), "expected ok, got {:?}", r.issues);
     }
 
     #[test]

--- a/code/packages/rust/twig-to-semantic-ir/src/lower.rs
+++ b/code/packages/rust/twig-to-semantic-ir/src/lower.rs
@@ -358,6 +358,7 @@ impl Lowerer {
             params: lam.params.iter().map(|p| Param {
                 name: p.clone(),
                 sir_type: None,
+                kind: semantic_ir::ParamKind::Required,
                 span: self.span_at(lam.line, lam.column),
             }).collect(),
             return_type: None,
@@ -627,6 +628,7 @@ impl Lowerer {
             params: lam.params.iter().map(|p| Param {
                 name: p.clone(),
                 sir_type: None,
+                kind: semantic_ir::ParamKind::Required,
                 span: span.clone(),
             }).collect(),
             return_type: None,

--- a/code/specs/sir-variadic-params.md
+++ b/code/specs/sir-variadic-params.md
@@ -109,6 +109,27 @@ def params).
 - `cargo test -p semantic-ir -p ruby-to-semantic-ir -p semantic-ir-to-python -p semantic-ir-to-typescript`
   (plus a compile check of the go/rust backends).
 
+## Implementation notes (divergence from the original spec)
+
+Two faithfulness refinements surfaced during implementation and were added
+beyond the table above:
+
+- **Python Rest-param list normalization.** Python's `*rest` binds a *tuple*,
+  but SIR sequence semantics (and Ruby's `*rest`, an `Array`) require a *list* —
+  every downstream sequence op (`len`, indexing, dispatched `.map`/`.length`)
+  is keyed to `list`. So the Python backend rebinds each `Rest` param to
+  `list(...)` in the function prologue. (`**opts` already binds a `dict`,
+  matching SIR's map, so no fixup. TypeScript's `...rest` is already a real JS
+  `Array` = SIR sequence, so it needs none either.)
+- **OOP-import gating widened.** Making a rest param *useful* means calling
+  Array methods on it (`def f(*a); a.length; end`), which is method dispatch
+  (`BuiltinCall("__method__", …)`). Both backends' `uses_oop` previously gated
+  the `sir-runtime-oop` import only on the OOP *features* (Classes/Modules/…),
+  so a class-less dispatch program emitted an undefined `call_method`. `uses_oop`
+  now also fires on the `__method__` / `__scope__` dispatch builtins. (Pre-existing
+  latent gap, fixed here because M3's execution-proof is the first class-less
+  dispatch program exercised end-to-end.)
+
 ## Out of scope (documented, honest)
 
 - Required-keyword params (`def f(a:)`) and optional-with-default params


### PR DESCRIPTION
## M3 — variadic parameter kinds for SIR `Param`

Implements [`code/specs/sir-variadic-params.md`](code/specs/sir-variadic-params.md) (spec merged in #6552). Closes the **def-side variadic limitation**: `def f(*rest)` / `def g(**opts)` previously lost their splat-ness at the SIR level (lowered to a bare positional `Param`), so the emitted Python/TypeScript declared a fixed positional parameter and a variadic call (`f(1, 2, 3)`) broke. The call side (`f(*arr)`) was already handled by Q9c.

### Core (`semantic-ir`)
- New `ParamKind { Required (default) / Rest / KwRest }` enum + `Param.kind` field, re-exported from the crate root.
- Validator: ≤1 `Rest`, ≤1 `KwRest`, and ordering (required → `Rest` → `KwRest`). The reserved trailing block param `__sir_block__` (Q9e) is exempt.
- Text printer renders `*name` / `**name` for the variadic kinds.

### Frontend (`ruby-to-semantic-ir`)
- All three def-param lowering paths set `kind` from the `*`/`**` prefix token they previously skipped; the lossy-limitation comment is removed. No grammar change.

### Backends
- **Python**: `Rest` → `*name`, `KwRest` → `**name`. Rest params are rebound to `list(...)` in the prologue — Python's `*rest` binds a *tuple* but SIR sequence semantics (and Ruby's `*rest`, an Array) require a *list*.
- **TypeScript**: `Rest` → `...name: __Sir.Val[]` (native); `KwRest` → trailing object param (v0 fallback — JS has no kwargs).
- **Both**: `uses_oop` import gate widened to also fire on the `__method__`/`__scope__` dispatch builtins, so a class-less dispatch program (`"hi".upcase`, or a rest param used as an Array) imports `sir-runtime-oop`. Pre-existing latent gap surfaced by M3's execution-proof.
- **Go/Rust** backends compile against the new field (they read params by field access) — deferred for faithful variadic emission.

### Tests
- Core: validator ordering rules (two-rest, kwrest-before-rest, required-after-rest, `__sir_block__` exemption), printer round-trip.
- Frontend: lowering assertions (`*r`→`Rest`, `**o`→`KwRest`, `a, *r`→`[Required, Rest]`, plain→`Required`).
- Backends: emitted-shape (py `def f(a, *rest, **opts):`, ts `function f(a, ...rest, opts)`) + Python **execution-proof** `def f(*a); a.length; end; print f(1,2,3)` → `3` (skips gracefully if no interpreter). Run harness temp file now uniquely named per call to avoid concurrent-test collisions.

`cargo test -p semantic-ir -p ruby-to-semantic-ir -p semantic-ir-to-python -p semantic-ir-to-typescript -p twig-to-semantic-ir` green; Go/Rust backends compile. Spec updated with the two implementation divergences (list-normalization, oop gating).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
