### PR TITLE
feat(closurec): string slice fold at SIMPLE/ADVANCED

### DIFF
--- a/code/packages/rust/closure-pass-constant-fold/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-constant-fold/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to the `coding-adventures-closure-pass-constant-fold` crate will be documented in this file.
 
+## [0.24.0] - 2026-06-22
+
+### Added — fold `"abcd".slice(start[, end])` on string literals
+
+`String.prototype.slice` (ECMAScript §22.1.3.22) now folds to a string literal
+when the receiver is a string literal and the (0, 1, or 2) arguments are integer
+literals: `"abcd".slice(1, 3)` → `"bc"`, `"abcd".slice(1)` → `"bcd"`,
+`"abcd".slice(-2)` → `"cd"`, `"abcd".slice(0, -1)` → `"abc"`,
+`"abcd".slice(2, 1)` → `""`, `"abc".slice()` → `"abc"`. A new `fold_string_slice`
+helper implements the spec's clamp-and-half-open-range over UTF-16 code units (a
+negative index counts from the end).
+
+UTF-16 indexing means `"💩ab".slice(2)` → `"ab"` (the astral char is two units).
+Conservative scope: declines (leaves the call) for more than two arguments, a
+non-integer-literal argument, an identifier receiver, or a cut that would split
+a surrogate pair into a lone surrogate (a valid JS string but not a Rust
+`String` — the same guard `charAt` uses). 6 new unit tests.
+
+> Version note: bumped to 0.24.0 (skipping 0.23.0, reserved by the concurrently
+> -developed numeric `toString(radix)` fold) so the parallel branches don't
+> collide on the version line.
+
 ## [0.22.0] - 2026-06-22
 
 ### Added — fold `"haystack".indexOf("needle")` on string literals

--- a/code/packages/rust/closure-pass-constant-fold/Cargo.toml
+++ b/code/packages/rust/closure-pass-constant-fold/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-constant-fold"
-version = "0.22.0"
+version = "0.24.0"
 edition = "2021"
 description = "Constant-folding optimization pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Folds compile-time-evaluable expressions like `2 + 3 → 5`."
 

--- a/code/packages/rust/closure-pass-constant-fold/src/lib.rs
+++ b/code/packages/rust/closure-pass-constant-fold/src/lib.rs
@@ -543,8 +543,34 @@ fn fold_call(c: &CallExpression, st: &mut FoldState) -> Expression {
             if let (Expression::StringLiteral(s), Expression::Identifier(id)) =
                 (m.object.as_ref(), m.property.as_ref())
             {
+                // ---- slice(start[, end]) → substring ----
+                //
+                // `"abcd".slice(1, 3)` → `"bc"`, `"abcd".slice(1)` → `"bcd"`,
+                // `"abcd".slice(-2)` → `"cd"`, `"abc".slice()` → `"abc"`
+                // (ECMAScript §22.1.3.22). Indices are UTF-16 code units;
+                // negatives count from the end. Computed by `fold_string_slice`
+                // below, which returns `None` (leaving the call) for a
+                // non-integer-literal argument, more than two arguments, or a
+                // cut that would split a surrogate pair into a lone surrogate.
+                if id.name == "slice" {
+                    if let Some(result) = fold_string_slice(&s.value, &arguments) {
+                        let parent = c.cv.clone();
+                        let args_src = arguments
+                            .iter()
+                            .map(|a| match a {
+                                Expression::NumericLiteral(n) => format_js_number(n.value),
+                                _ => "?".to_string(),
+                            })
+                            .collect::<Vec<_>>()
+                            .join(",");
+                        let before = format!("\"{}\".slice({})", s.value, args_src);
+                        let after = format!("\"{}\"", result);
+                        let new_cv = st.fork_cv(&parent, &before, &after);
+                        return stamp_literal_cv(FoldedLiteral::String(result), new_cv);
+                    }
+                }
                 // ---- zero-argument casing methods (ASCII-only) ----
-                if arguments.is_empty() {
+                else if arguments.is_empty() {
                     let cased = match id.name.as_str() {
                         "toUpperCase" if s.value.is_ascii() => Some(s.value.to_ascii_uppercase()),
                         "toLowerCase" if s.value.is_ascii() => Some(s.value.to_ascii_lowercase()),
@@ -659,6 +685,71 @@ fn fold_call(c: &CallExpression, st: &mut FoldState) -> Expression {
         callee: Box::new(callee),
         arguments,
     })
+}
+
+/// Compute `value.slice(args…)` at compile time, or `None` when it cannot be
+/// folded soundly (ECMAScript §22.1.3.22, `String.prototype.slice`).
+///
+/// `slice` works in **UTF-16 code units**, so we index into `encode_utf16()`
+/// (an astral char is two units). The algorithm, matching the spec:
+///
+/// 1. `start` (default `0`) and `end` (default the length) are each clamped:
+///    a negative index counts from the end (`len + idx`, floored at `0`); a
+///    non-negative one is capped at `len`.
+/// 2. the result is the half-open range `[start, max(start, end))` — empty when
+///    `start >= end`.
+///
+/// We decline (return `None`, leaving the call for the runtime) when:
+/// - there are more than two arguments;
+/// - any *given* argument is not a finite integer literal (we don't model
+///   `ToInteger` coercion of arbitrary values); or
+/// - the cut would split a surrogate pair, yielding a lone surrogate that a
+///   Rust `String` cannot hold (`String::from_utf16` fails) — the same
+///   conservative guard `charAt` uses.
+fn fold_string_slice(value: &str, args: &[Expression]) -> Option<String> {
+    if args.len() > 2 {
+        return None;
+    }
+    // A provided argument must be a finite integer literal (any sign).
+    let to_int = |e: &Expression| -> Option<i64> {
+        match e {
+            Expression::NumericLiteral(n)
+                if n.value.is_finite()
+                    && n.value.fract() == 0.0
+                    && n.value.abs() < 9_007_199_254_740_992.0 =>
+            {
+                Some(n.value as i64)
+            }
+            _ => None,
+        }
+    };
+
+    let units: Vec<u16> = value.encode_utf16().collect();
+    let len = units.len() as i64;
+    let clamp = |idx: i64| -> i64 {
+        if idx < 0 {
+            (len + idx).max(0)
+        } else {
+            idx.min(len)
+        }
+    };
+
+    let start = match args.first() {
+        None => 0,
+        Some(e) => clamp(to_int(e)?),
+    };
+    let end = match args.get(1) {
+        None => len,
+        Some(e) => clamp(to_int(e)?),
+    };
+
+    let lo = start as usize;
+    let hi = end.max(start) as usize; // empty range when end < start
+    if lo >= hi {
+        return Some(String::new());
+    }
+    // A lone surrogate (split pair) can't be a Rust String — decline.
+    String::from_utf16(&units[lo..hi]).ok()
 }
 
 // ---------------------------------------------------------------------
@@ -2913,6 +3004,106 @@ mod tests {
         let c = call1(ident("s"), "indexOf", string("x", None));
         let (out, _, changed, _) = run_pass(program_with_expr(c, true));
         assert!(!changed, "s.indexOf(\"x\") must not fold");
+        assert!(matches!(extract_expr(&out), Expression::CallExpression(_)));
+    }
+
+    // ------------------- slice (substring) ---------------------------
+
+    /// Build `"<recv>".slice(<args…>)` from numeric literal arguments.
+    fn slice_call(recv: &str, args: &[f64]) -> Expression {
+        Expression::CallExpression(CallExpression {
+            cv: Some("c.cv".to_string()),
+            callee: Box::new(member(string(recv, None), "slice")),
+            arguments: args.iter().map(|&a| num(a, None)).collect(),
+        })
+    }
+
+    #[test]
+    fn fold_string_slice_two_args() {
+        // Positive, negative, and end-before-start (→ empty).
+        for (recv, args, expect) in [
+            ("abcd", vec![1.0, 3.0], "bc"),
+            ("abcd", vec![0.0, -1.0], "abc"),
+            ("abcd", vec![-2.0], "cd"),
+            ("abcd", vec![1.0], "bcd"),
+            ("abcd", vec![2.0, 1.0], ""),
+            ("abcd", vec![10.0], ""),
+        ] {
+            let c = slice_call(recv, &args);
+            let (out, _, changed, _) = run_pass(program_with_expr(c, true));
+            assert!(changed, "\"{recv}\".slice({args:?}) should fold");
+            match extract_expr(&out) {
+                Expression::StringLiteral(s) => {
+                    assert_eq!(s.value, expect, "\"{recv}\".slice({args:?})")
+                }
+                other => panic!("expected \"{expect}\"; got {:?}", other),
+            }
+        }
+    }
+
+    #[test]
+    fn fold_string_slice_no_args_is_identity() {
+        // `"abc".slice()` → "abc" (whole string).
+        let c = Expression::CallExpression(CallExpression {
+            cv: Some("c.cv".to_string()),
+            callee: Box::new(member(string("abc", None), "slice")),
+            arguments: vec![],
+        });
+        let (out, _, changed, _) = run_pass(program_with_expr(c, true));
+        assert!(changed, "\"abc\".slice() should fold");
+        match extract_expr(&out) {
+            Expression::StringLiteral(s) => assert_eq!(s.value, "abc"),
+            other => panic!("expected \"abc\"; got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn slice_counts_utf16_units() {
+        // "💩" is two UTF-16 units; "💩ab".slice(2) drops the astral char and
+        // keeps "ab" — proving UTF-16 (not scalar) indexing.
+        let c = slice_call("💩ab", &[2.0]);
+        let (out, _, _, _) = run_pass(program_with_expr(c, true));
+        match extract_expr(&out) {
+            Expression::StringLiteral(s) => assert_eq!(s.value, "ab"),
+            other => panic!("expected \"ab\"; got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn slice_splitting_a_surrogate_pair_does_not_fold() {
+        // "💩".slice(0, 1) would be a lone high surrogate — a valid JS string
+        // but not a Rust `String`, so we decline (conservative, like charAt).
+        let c = slice_call("💩", &[0.0, 1.0]);
+        let (out, _, changed, _) = run_pass(program_with_expr(c, true));
+        assert!(!changed, "slice splitting a surrogate pair must not fold");
+        assert!(matches!(extract_expr(&out), Expression::CallExpression(_)));
+    }
+
+    #[test]
+    fn slice_non_integer_or_too_many_args_does_not_fold() {
+        // Fractional argument: don't model ToInteger coercion.
+        let frac = slice_call("abcd", &[1.5]);
+        let (out, _, changed, _) = run_pass(program_with_expr(frac, true));
+        assert!(!changed, "fractional slice index must not fold");
+
+        // Three arguments: not the slice signature we model.
+        let three = slice_call("abcd", &[0.0, 1.0, 2.0]);
+        let (out2, _, changed2, _) = run_pass(program_with_expr(three, true));
+        assert!(!changed2, "three-arg slice must not fold");
+        assert!(matches!(extract_expr(&out), Expression::CallExpression(_)));
+        assert!(matches!(extract_expr(&out2), Expression::CallExpression(_)));
+    }
+
+    #[test]
+    fn slice_on_identifier_receiver_does_not_fold() {
+        // `s.slice(1)` needs the runtime value of `s`.
+        let c = Expression::CallExpression(CallExpression {
+            cv: Some("c.cv".to_string()),
+            callee: Box::new(member(ident("s"), "slice")),
+            arguments: vec![num(1.0, None)],
+        });
+        let (out, _, changed, _) = run_pass(program_with_expr(c, true));
+        assert!(!changed, "s.slice(1) must not fold");
         assert!(matches!(extract_expr(&out), Expression::CallExpression(_)));
     }
 

--- a/code/programs/rust/closurec/CHANGELOG.md
+++ b/code/programs/rust/closurec/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 All notable changes to the `coding-adventures-closurec` binary will be documented in this file.
 
+## [0.173.0] - 2026-06-22
+
+### Added — string `slice` fold at SIMPLE/ADVANCED
+
+Pulls in `coding-adventures-closure-pass-constant-fold` 0.24.0, which folds
+`String#slice` on a string literal with integer-literal arguments to a string
+literal: `"abcd".slice(1, 3)` → `"bc"`. JS `slice` indexes by UTF-16 code unit
+over the half-open range `[start, end)`; negative arguments count from the end
+and both ends clamp to `[0, length]`. Zero, one, or two integer-literal
+arguments fold; a non-integer argument, more than two arguments, an identifier
+receiver, or a cut that would split a surrogate pair (yielding a lone
+surrogate) all pass through unfolded — matching `charAt`'s conservative stance.
+
+New e2e fixture `tests/diff/simple-fold-slice` (and integration test
+`diff_simple_fold_slice.rs`): `var s = "abcd".slice(1, 3); report(s);` →
+`var s="bc";report(s);`, with a whitespace-fallback guard proving the fold
+comes from the SIMPLE typed pipeline. The full existing fixture suite remains
+byte-for-byte unchanged.
+
+> Version note: bumped to 0.173.0 to sit above main (closurec 0.171.0) and the
+> concurrently-open numeric `toString([radix])` fold branch (closurec 0.172.0,
+> PR #6560), so the parallel branches never collide on the version line.
+
 ## [0.171.0] - 2026-06-22
 
 ### Added — string `indexOf` fold at SIMPLE/ADVANCED

--- a/code/programs/rust/closurec/Cargo.toml
+++ b/code/programs/rust/closurec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closurec"
-version = "0.171.0"
+version = "0.173.0"
 edition = "2021"
 description = "closurec — CLI driver for the Closure Compiler clone. Mirrors the upstream Java Closure Compiler's command-line flag surface (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility. Per CLOC08."
 

--- a/code/programs/rust/closurec/cli.spec.json
+++ b/code/programs/rust/closurec/cli.spec.json
@@ -2,7 +2,7 @@
   "cli_builder_spec_version": "1.0",
   "name": "closurec",
   "description": "closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.",
-  "version": "0.171.0",
+  "version": "0.173.0",
   "parsing_mode": "gnu",
   "flags": [
     { "id": "browser_featureset_year", "long": "browser_featureset_year", "type": "integer", "default": 0, "description": "Shortcut for defining goog.FEATURESET_YEAR=YYYY (minimum 2012)." },

--- a/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
@@ -2,7 +2,7 @@
 
 closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.
 
-Version: 0.171.0
+Version: 0.173.0
 
 ## Flags
 

--- a/code/programs/rust/closurec/tests/diff/simple-fold-slice/README.md
+++ b/code/programs/rust/closurec/tests/diff/simple-fold-slice/README.md
@@ -1,0 +1,28 @@
+# Fixture: `simple-fold-slice`
+
+End-to-end oracle for string-slicing folding (`String#slice`) at
+`--compilation_level SIMPLE`.
+
+| File | Role |
+|------|------|
+| `flags.txt` | CLI args: `--compilation_level SIMPLE --js input/a.js` |
+| `input/a.js` | `var s = "abcd".slice(1, 3); report(s);` |
+| `expected.stdout` | The folded output: `var s="bc";report(s);` |
+
+The SIMPLE level runs the typed-AST optimization pipeline, whose
+`constant-fold` pass folds `slice` on a string literal with integer-literal
+arguments: `"abcd".slice(1, 3)` → `"bc"`. JS `slice` indexes by UTF-16 code
+unit over a half-open range `[start, end)`; negative arguments count from the
+end, and both ends clamp to `[0, length]`. Zero, one, or two integer-literal
+arguments fold; non-integer args, more than two args, an identifier receiver,
+or a cut that would split a surrogate pair (yielding a lone surrogate) are left
+alone — matching `charAt`'s conservative stance. The same input under
+`WHITESPACE_ONLY` keeps `"abcd".slice(1, 3)` unfolded.
+
+Regenerate the expected file after an intentional behavior change:
+
+```sh
+cargo run -- --compilation_level SIMPLE \
+    --js tests/diff/simple-fold-slice/input/a.js \
+    > tests/diff/simple-fold-slice/expected.stdout
+```

--- a/code/programs/rust/closurec/tests/diff/simple-fold-slice/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/simple-fold-slice/expected.stdout
@@ -1,0 +1,1 @@
+var s="bc";report(s);

--- a/code/programs/rust/closurec/tests/diff/simple-fold-slice/flags.txt
+++ b/code/programs/rust/closurec/tests/diff/simple-fold-slice/flags.txt
@@ -1,0 +1,4 @@
+--compilation_level
+SIMPLE
+--js
+tests/diff/simple-fold-slice/input/a.js

--- a/code/programs/rust/closurec/tests/diff/simple-fold-slice/input/a.js
+++ b/code/programs/rust/closurec/tests/diff/simple-fold-slice/input/a.js
@@ -1,0 +1,14 @@
+// SIMPLE-level string-slicing fold (String#slice).
+//
+// `"<string>".slice(<start>[, <end>])` is compile-time-evaluable on a string
+// literal with integer-literal arguments; the `constant-fold` pass collapses
+// it to the substring (JS `String.prototype.slice`). `slice` indexes by
+// UTF-16 code unit, with negative arguments counting from the end. Here
+// `"abcd".slice(1, 3)` selects the half-open range `[1, 3)` → `"bc"`. Under
+// WHITESPACE_ONLY the call survives; under SIMPLE it folds to `"bc"`.
+//
+// The value flows into `report(...)` so it stays referenced — otherwise
+// remove-unused-vars (the last SIMPLE pass) would delete the declaration and
+// the fold would not be observable.
+var s = "abcd".slice(1, 3);
+report(s);

--- a/code/programs/rust/closurec/tests/diff_simple_fold_slice.rs
+++ b/code/programs/rust/closurec/tests/diff_simple_fold_slice.rs
@@ -1,0 +1,84 @@
+//! Integration test for the `tests/diff/simple-fold-slice/` fixture.
+//!
+//! End-to-end oracle for string `slice` folding in
+//! `closure-pass-constant-fold`: `"abcd".slice(1, 3)` collapses to the string
+//! literal `"bc"` (JS `String.prototype.slice`).
+//!
+//! At SIMPLE the fixture optimizes to:
+//!
+//! ```text
+//! var s="bc";report(s);
+//! ```
+
+use std::process::Command;
+
+const BINARY: &str = env!("CARGO_BIN_EXE_closurec");
+
+fn read_flags() -> Vec<String> {
+    let raw = std::fs::read_to_string("tests/diff/simple-fold-slice/flags.txt")
+        .expect("read flags.txt");
+    raw.lines()
+        .filter(|l| !l.is_empty())
+        .map(|s| s.to_string())
+        .collect()
+}
+
+#[test]
+fn simple_fold_slice_fixture_matches_expected_stdout() {
+    let flags = read_flags();
+    let out = Command::new(BINARY)
+        .args(&flags)
+        .output()
+        .expect("run closurec");
+
+    assert!(
+        out.status.success(),
+        "exit: {:?}, stderr: {}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stderr),
+    );
+
+    let actual = String::from_utf8_lossy(&out.stdout);
+    let expected = std::fs::read_to_string("tests/diff/simple-fold-slice/expected.stdout")
+        .expect("read expected.stdout");
+    assert_eq!(
+        actual.trim_end_matches('\n'),
+        expected.trim_end_matches('\n'),
+        "mismatch.\nflags: {flags:?}\nactual:\n{actual}\nexpected:\n{expected}",
+    );
+}
+
+/// `"abcd".slice(1, 3)` must fold to the string literal `"bc"` — no method call
+/// should remain in the output.
+#[test]
+fn simple_fold_slice_folds_to_string_literal() {
+    let out = Command::new(BINARY)
+        .args(read_flags())
+        .output()
+        .expect("run closurec");
+    let actual = String::from_utf8_lossy(&out.stdout);
+
+    assert!(actual.contains("\"bc\""), "should fold to \"bc\"; got:\n{actual}");
+    assert!(
+        !actual.contains("slice"),
+        "no `slice` call should remain after folding; got:\n{actual}",
+    );
+}
+
+/// Regression guard: the output must be the SIMPLE typed pipeline, not the
+/// `WHITESPACE_ONLY` fallback (which would leave `"abcd".slice(1, 3)` intact).
+#[test]
+fn simple_fold_slice_did_not_fall_back_to_whitespace_only() {
+    let out = Command::new(BINARY)
+        .args(read_flags())
+        .output()
+        .expect("run closurec");
+    let actual = String::from_utf8_lossy(&out.stdout);
+
+    assert!(
+        !actual.contains("abcd"),
+        "expected the string literal to be folded away by the typed pipeline \
+         (proving this is the SIMPLE optimizer, not the whitespace fallback); \
+         got:\n{actual}",
+    );
+}


### PR DESCRIPTION
## What

Constant-folds `String#slice` on a string literal with integer-literal arguments at SIMPLE/ADVANCED:

- `"abcd".slice(1, 3)` → `"bc"`
- `"abcd".slice(1)` → `"bcd"`
- `"abcd".slice(-2)` → `"cd"` (negative counts from the end)
- `"abc".slice()` → `"abc"` (identity)
- `"abcd".slice(2, 1)` → `""` (end < start → empty)
- `"abcd".slice(0, -1)` → `"abc"`

JS `slice` indexes by **UTF-16 code unit** over the half-open range `[start, end)`; negative args count from the end and both ends clamp to `[0, length]` (ECMAScript §22.1.3.22).

## Conservative declines (call left intact)

- More than two arguments
- A non-integer / non-finite / ≥2^53 literal argument (we don't model `ToInteger` coercion of arbitrary values)
- An identifier (non-literal) receiver
- A cut that would split a surrogate pair into a lone surrogate (a valid JS string but not a Rust `String`) — same guard `charAt` uses

## Tests

- 6 new unit tests in `closure-pass-constant-fold` (positive/negative/empty ranges, UTF-16 unit counting, surrogate-split decline, non-integer/too-many-args decline, identifier-receiver decline)
- New e2e fixture `tests/diff/simple-fold-slice` + integration test `diff_simple_fold_slice.rs`: `var s = "abcd".slice(1, 3); report(s);` → `var s="bc";report(s);`, with a whitespace-fallback guard proving the fold comes from the SIMPLE typed pipeline
- Full existing fixture suite byte-for-byte unchanged

## Versions

- `closure-pass-constant-fold` 0.22.0 → 0.24.0 (0.23 reserved by the open radix branch #6560)
- `closurec` 0.171.0 → 0.173.0 (above main 0.171 and the open radix branch 0.172/#6560)

Inline security review passed (bounds of the UTF-16 slice traced; clamp constrains both endpoints to `[0, len]`, no OOB panic, casts exact under the 2^53 filter).

🤖 Generated with [Claude Code](https://claude.com/claude-code)