### PR TITLE
feat(closurec): string repeat fold at SIMPLE/ADVANCED

### DIFF
--- a/code/packages/rust/closure-pass-constant-fold/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-constant-fold/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 All notable changes to the `coding-adventures-closure-pass-constant-fold` crate will be documented in this file.
 
+## [0.26.0] - 2026-06-22
+
+### Added — fold `"ab".repeat(count)` on string literals
+
+`String.prototype.repeat` (ECMAScript §22.1.3.18) now folds to a string literal
+when the receiver is a string literal and the single argument is a non-negative
+integer literal: `"ab".repeat(3)` → `"ababab"`, `"x".repeat(0)` → `""`. A new
+`fold_string_repeat` helper concatenates the whole receiver `count` times —
+unlike `slice` it can never split a surrogate pair, since the string is
+duplicated, not cut.
+
+Conservative scope, with an explicit **denial-of-service guard**: declines
+(leaves the call) for a negative count (JS throws a `RangeError`, which folding
+would erase), a fractional/non-finite/non-literal count, or a result that would
+exceed `MAX_REPEAT_UNITS` (100 000) UTF-16 code units — `"x".repeat(1e9)` is a
+valid program but must not be materialized into a gigabyte literal at compile
+time. `checked_mul` keeps the length computation itself from overflowing. 6 new
+unit tests.
+
+> Version note: bumped to 0.26.0 — above the merged `slice` fold (0.24.0) and
+> the open numeric `toString(radix)` fold (0.25.0, PR #6560) — so the parallel
+> branches don't collide on the version line.
+
 ## [0.24.0] - 2026-06-22
 
 ### Added — fold `"abcd".slice(start[, end])` on string literals

--- a/code/packages/rust/closure-pass-constant-fold/Cargo.toml
+++ b/code/packages/rust/closure-pass-constant-fold/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-constant-fold"
-version = "0.24.0"
+version = "0.26.0"
 edition = "2021"
 description = "Constant-folding optimization pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Folds compile-time-evaluable expressions like `2 + 3 → 5`."
 

--- a/code/packages/rust/closure-pass-constant-fold/src/lib.rs
+++ b/code/packages/rust/closure-pass-constant-fold/src/lib.rs
@@ -569,6 +569,28 @@ fn fold_call(c: &CallExpression, st: &mut FoldState) -> Expression {
                         return stamp_literal_cv(FoldedLiteral::String(result), new_cv);
                     }
                 }
+                // ---- repeat(count) → the string concatenated `count` times ----
+                //
+                // `"ab".repeat(3)` → `"ababab"` (ECMAScript §22.1.3.18). The
+                // count must be a non-negative integer literal; `fold_string_repeat`
+                // declines (leaves the call) for a negative count (JS throws a
+                // `RangeError`), a fractional/non-literal count, or a result
+                // whose length would exceed a fixed cap — the cap keeps the
+                // optimizer from materializing a megabyte string at compile time
+                // (an algorithmic-blowup / DoS guard).
+                else if id.name == "repeat" {
+                    if let Some(result) = fold_string_repeat(&s.value, &arguments) {
+                        let parent = c.cv.clone();
+                        let count_src = match arguments.first() {
+                            Some(Expression::NumericLiteral(n)) => format_js_number(n.value),
+                            _ => "?".to_string(),
+                        };
+                        let before = format!("\"{}\".repeat({})", s.value, count_src);
+                        let after = format!("\"{}\"", result);
+                        let new_cv = st.fork_cv(&parent, &before, &after);
+                        return stamp_literal_cv(FoldedLiteral::String(result), new_cv);
+                    }
+                }
                 // ---- zero-argument casing methods (ASCII-only) ----
                 else if arguments.is_empty() {
                     let cased = match id.name.as_str() {
@@ -750,6 +772,45 @@ fn fold_string_slice(value: &str, args: &[Expression]) -> Option<String> {
     }
     // A lone surrogate (split pair) can't be a Rust String — decline.
     String::from_utf16(&units[lo..hi]).ok()
+}
+
+/// Compute `value.repeat(count)` at compile time, or `None` when it cannot be
+/// folded soundly (ECMAScript §22.1.3.18, `String.prototype.repeat`).
+///
+/// `repeat` concatenates the whole receiver `count` times, so — unlike `slice`
+/// — it never splits a surrogate pair: the UTF-8 string is simply duplicated.
+/// We require exactly one **non-negative integer literal** argument:
+/// `"ab".repeat(3)` → `"ababab"`, `"x".repeat(0)` → `""`.
+///
+/// We decline (return `None`, leaving the call for the runtime) when:
+/// - the argument is missing, fractional, non-finite, or not a numeric literal
+///   (we don't model `ToInteger` coercion of arbitrary values);
+/// - the count is negative — JS throws a `RangeError`, which we must not erase
+///   by folding to a value; or
+/// - the materialized result would exceed `MAX_REPEAT_UNITS` UTF-16 code units.
+///   `"x".repeat(1e9)` is a valid program, but expanding it at compile time
+///   would balloon the output (and the optimizer's memory) — an
+///   algorithmic-blowup / DoS guard. `checked_mul` also stops the length
+///   computation itself from overflowing.
+fn fold_string_repeat(value: &str, args: &[Expression]) -> Option<String> {
+    /// Cap on the folded result's length, in UTF-16 code units. Past this we
+    /// leave `repeat` for the runtime rather than materialize a huge literal.
+    const MAX_REPEAT_UNITS: u64 = 100_000;
+
+    let n = match args {
+        [Expression::NumericLiteral(n)] => n,
+        _ => return None,
+    };
+    if !(n.value.is_finite() && n.value.fract() == 0.0 && n.value >= 0.0) {
+        return None;
+    }
+    let count = n.value as u64;
+    let unit_len = value.encode_utf16().count() as u64;
+    // Decline on overflow (None from checked_mul) or when over the cap.
+    match unit_len.checked_mul(count) {
+        Some(total) if total <= MAX_REPEAT_UNITS => Some(value.repeat(count as usize)),
+        _ => None,
+    }
 }
 
 // ---------------------------------------------------------------------
@@ -3104,6 +3165,97 @@ mod tests {
         });
         let (out, _, changed, _) = run_pass(program_with_expr(c, true));
         assert!(!changed, "s.slice(1) must not fold");
+        assert!(matches!(extract_expr(&out), Expression::CallExpression(_)));
+    }
+
+    // ------------------- repeat (concatenation) ----------------------
+
+    /// Build `"<recv>".repeat(<count>)`.
+    fn repeat_call(recv: &str, count: f64) -> Expression {
+        Expression::CallExpression(CallExpression {
+            cv: Some("c.cv".to_string()),
+            callee: Box::new(member(string(recv, None), "repeat")),
+            arguments: vec![num(count, None)],
+        })
+    }
+
+    #[test]
+    fn fold_string_repeat_basic() {
+        for (recv, count, expect) in [
+            ("ab", 3.0, "ababab"),
+            ("x", 5.0, "xxxxx"),
+            ("ab", 0.0, ""),  // count 0 → empty
+            ("", 9.0, ""),    // empty receiver → empty
+            ("é", 2.0, "éé"), // multibyte char duplicated whole, never split
+        ] {
+            let c = repeat_call(recv, count);
+            let (out, _, changed, _) = run_pass(program_with_expr(c, true));
+            assert!(changed, "\"{recv}\".repeat({count}) should fold");
+            match extract_expr(&out) {
+                Expression::StringLiteral(s) => {
+                    assert_eq!(s.value, expect, "\"{recv}\".repeat({count})")
+                }
+                other => panic!("expected \"{expect}\"; got {:?}", other),
+            }
+        }
+    }
+
+    #[test]
+    fn repeat_negative_count_does_not_fold() {
+        // JS `"ab".repeat(-1)` throws RangeError — folding would erase the throw.
+        let c = repeat_call("ab", -1.0);
+        let (out, _, changed, _) = run_pass(program_with_expr(c, true));
+        assert!(!changed, "negative repeat count must not fold");
+        assert!(matches!(extract_expr(&out), Expression::CallExpression(_)));
+    }
+
+    #[test]
+    fn repeat_fractional_count_does_not_fold() {
+        // We don't model ToInteger coercion (`"ab".repeat(2.5)` → 2 in JS).
+        let c = repeat_call("ab", 2.5);
+        let (out, _, changed, _) = run_pass(program_with_expr(c, true));
+        assert!(!changed, "fractional repeat count must not fold");
+    }
+
+    #[test]
+    fn repeat_over_size_cap_does_not_fold() {
+        // 10-unit string * 50_000 = 500_000 units > 100_000 cap — DoS guard
+        // declines rather than materialize a half-megabyte literal at compile
+        // time. Just under the cap folds.
+        let over = repeat_call("0123456789", 50_000.0);
+        let (out, _, changed, _) = run_pass(program_with_expr(over, true));
+        assert!(!changed, "repeat over the size cap must not fold");
+        assert!(matches!(extract_expr(&out), Expression::CallExpression(_)));
+
+        let under = repeat_call("0123456789", 10_000.0); // 100_000 units, == cap
+        let (out2, _, changed2, _) = run_pass(program_with_expr(under, true));
+        assert!(changed2, "repeat exactly at the cap should fold");
+        match extract_expr(&out2) {
+            Expression::StringLiteral(s) => assert_eq!(s.value.len(), 100_000),
+            other => panic!("expected a 100_000-byte literal; got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn repeat_huge_count_does_not_overflow_or_fold() {
+        // `"x".repeat(1e18)` — checked_mul keeps the length math from
+        // overflowing; the call is left for the runtime.
+        let c = repeat_call("x", 1e18);
+        let (out, _, changed, _) = run_pass(program_with_expr(c, true));
+        assert!(!changed, "huge repeat count must not fold (no overflow)");
+        assert!(matches!(extract_expr(&out), Expression::CallExpression(_)));
+    }
+
+    #[test]
+    fn repeat_on_identifier_receiver_does_not_fold() {
+        // `s.repeat(3)` needs the runtime value of `s`.
+        let c = Expression::CallExpression(CallExpression {
+            cv: Some("c.cv".to_string()),
+            callee: Box::new(member(ident("s"), "repeat")),
+            arguments: vec![num(3.0, None)],
+        });
+        let (out, _, changed, _) = run_pass(program_with_expr(c, true));
+        assert!(!changed, "s.repeat(3) must not fold");
         assert!(matches!(extract_expr(&out), Expression::CallExpression(_)));
     }
 

--- a/code/programs/rust/closurec/CHANGELOG.md
+++ b/code/programs/rust/closurec/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 All notable changes to the `coding-adventures-closurec` binary will be documented in this file.
 
+## [0.175.0] - 2026-06-22
+
+### Added — string `repeat` fold at SIMPLE/ADVANCED
+
+Pulls in `coding-adventures-closure-pass-constant-fold` 0.26.0, which folds
+`String#repeat` on a string literal with a non-negative integer-literal count
+to a string literal: `"ab".repeat(3)` → `"ababab"`, `"x".repeat(0)` → `""`. A
+negative count (JS `RangeError`), a fractional/non-literal count, and a result
+over the optimizer's 100 000-code-unit cap (a denial-of-service guard against
+materializing a huge literal at compile time) all pass through unfolded.
+
+New e2e fixture `tests/diff/simple-fold-repeat` (and integration test
+`diff_simple_fold_repeat.rs`): `var s = "ab".repeat(3); report(s);` →
+`var s="ababab";report(s);`, with a whitespace-fallback guard proving the fold
+comes from the SIMPLE typed pipeline. The full existing fixture suite remains
+byte-for-byte unchanged.
+
+> Version note: bumped to 0.175.0 to sit above main (closurec 0.173.0) and the
+> concurrently-open numeric `toString([radix])` fold branch (closurec 0.174.0,
+> PR #6560), so the parallel branches never collide on the version line.
+
 ## [0.173.0] - 2026-06-22
 
 ### Added — string `slice` fold at SIMPLE/ADVANCED

--- a/code/programs/rust/closurec/Cargo.toml
+++ b/code/programs/rust/closurec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closurec"
-version = "0.173.0"
+version = "0.175.0"
 edition = "2021"
 description = "closurec — CLI driver for the Closure Compiler clone. Mirrors the upstream Java Closure Compiler's command-line flag surface (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility. Per CLOC08."
 

--- a/code/programs/rust/closurec/cli.spec.json
+++ b/code/programs/rust/closurec/cli.spec.json
@@ -2,7 +2,7 @@
   "cli_builder_spec_version": "1.0",
   "name": "closurec",
   "description": "closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.",
-  "version": "0.173.0",
+  "version": "0.175.0",
   "parsing_mode": "gnu",
   "flags": [
     { "id": "browser_featureset_year", "long": "browser_featureset_year", "type": "integer", "default": 0, "description": "Shortcut for defining goog.FEATURESET_YEAR=YYYY (minimum 2012)." },

--- a/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
@@ -2,7 +2,7 @@
 
 closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.
 
-Version: 0.173.0
+Version: 0.175.0
 
 ## Flags
 

--- a/code/programs/rust/closurec/tests/diff/simple-fold-repeat/README.md
+++ b/code/programs/rust/closurec/tests/diff/simple-fold-repeat/README.md
@@ -1,0 +1,27 @@
+# Fixture: `simple-fold-repeat`
+
+End-to-end oracle for string-repeat folding (`String#repeat`) at
+`--compilation_level SIMPLE`.
+
+| File | Role |
+|------|------|
+| `flags.txt` | CLI args: `--compilation_level SIMPLE --js input/a.js` |
+| `input/a.js` | `var s = "ab".repeat(3); report(s);` |
+| `expected.stdout` | The folded output: `var s="ababab";report(s);` |
+
+The SIMPLE level runs the typed-AST optimization pipeline, whose
+`constant-fold` pass folds `repeat` on a string literal with a non-negative
+integer-literal count: `"ab".repeat(3)` → `"ababab"`. The receiver is
+concatenated `count` times, so — unlike `slice` — there is no surrogate-pair
+hazard. A negative count (JS `RangeError`), a fractional/non-literal count, or a
+result over the optimizer's 100 000-code-unit cap (a denial-of-service guard
+against materializing a huge literal at compile time) all pass through. The same
+input under `WHITESPACE_ONLY` keeps `"ab".repeat(3)` unfolded.
+
+Regenerate the expected file after an intentional behavior change:
+
+```sh
+cargo run -- --compilation_level SIMPLE \
+    --js tests/diff/simple-fold-repeat/input/a.js \
+    > tests/diff/simple-fold-repeat/expected.stdout
+```

--- a/code/programs/rust/closurec/tests/diff/simple-fold-repeat/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/simple-fold-repeat/expected.stdout
@@ -1,0 +1,1 @@
+var s="ababab";report(s);

--- a/code/programs/rust/closurec/tests/diff/simple-fold-repeat/flags.txt
+++ b/code/programs/rust/closurec/tests/diff/simple-fold-repeat/flags.txt
@@ -1,0 +1,4 @@
+--compilation_level
+SIMPLE
+--js
+tests/diff/simple-fold-repeat/input/a.js

--- a/code/programs/rust/closurec/tests/diff/simple-fold-repeat/input/a.js
+++ b/code/programs/rust/closurec/tests/diff/simple-fold-repeat/input/a.js
@@ -1,0 +1,14 @@
+// SIMPLE-level string-repeat fold (String#repeat).
+//
+// `"<string>".repeat(<count>)` is compile-time-evaluable on a string literal
+// with a non-negative integer-literal count; the `constant-fold` pass collapses
+// it to the receiver concatenated `count` times (JS `String.prototype.repeat`).
+// Here `"ab".repeat(3)` → `"ababab"`. A negative count (JS `RangeError`), a
+// fractional count, or a result over the optimizer's size cap is left for the
+// runtime. Under WHITESPACE_ONLY the call survives; under SIMPLE it folds.
+//
+// The value flows into `report(...)` so it stays referenced — otherwise
+// remove-unused-vars (the last SIMPLE pass) would delete the declaration and
+// the fold would not be observable.
+var s = "ab".repeat(3);
+report(s);

--- a/code/programs/rust/closurec/tests/diff_simple_fold_repeat.rs
+++ b/code/programs/rust/closurec/tests/diff_simple_fold_repeat.rs
@@ -1,0 +1,84 @@
+//! Integration test for the `tests/diff/simple-fold-repeat/` fixture.
+//!
+//! End-to-end oracle for string `repeat` folding in
+//! `closure-pass-constant-fold`: `"ab".repeat(3)` collapses to the string
+//! literal `"ababab"` (JS `String.prototype.repeat`).
+//!
+//! At SIMPLE the fixture optimizes to:
+//!
+//! ```text
+//! var s="ababab";report(s);
+//! ```
+
+use std::process::Command;
+
+const BINARY: &str = env!("CARGO_BIN_EXE_closurec");
+
+fn read_flags() -> Vec<String> {
+    let raw = std::fs::read_to_string("tests/diff/simple-fold-repeat/flags.txt")
+        .expect("read flags.txt");
+    raw.lines()
+        .filter(|l| !l.is_empty())
+        .map(|s| s.to_string())
+        .collect()
+}
+
+#[test]
+fn simple_fold_repeat_fixture_matches_expected_stdout() {
+    let flags = read_flags();
+    let out = Command::new(BINARY)
+        .args(&flags)
+        .output()
+        .expect("run closurec");
+
+    assert!(
+        out.status.success(),
+        "exit: {:?}, stderr: {}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stderr),
+    );
+
+    let actual = String::from_utf8_lossy(&out.stdout);
+    let expected = std::fs::read_to_string("tests/diff/simple-fold-repeat/expected.stdout")
+        .expect("read expected.stdout");
+    assert_eq!(
+        actual.trim_end_matches('\n'),
+        expected.trim_end_matches('\n'),
+        "mismatch.\nflags: {flags:?}\nactual:\n{actual}\nexpected:\n{expected}",
+    );
+}
+
+/// `"ab".repeat(3)` must fold to the string literal `"ababab"` — no method call
+/// should remain in the output.
+#[test]
+fn simple_fold_repeat_folds_to_string_literal() {
+    let out = Command::new(BINARY)
+        .args(read_flags())
+        .output()
+        .expect("run closurec");
+    let actual = String::from_utf8_lossy(&out.stdout);
+
+    assert!(actual.contains("\"ababab\""), "should fold to \"ababab\"; got:\n{actual}");
+    assert!(
+        !actual.contains("repeat"),
+        "no `repeat` call should remain after folding; got:\n{actual}",
+    );
+}
+
+/// Regression guard: the output must be the SIMPLE typed pipeline, not the
+/// `WHITESPACE_ONLY` fallback (which would leave `"ab".repeat(3)` intact).
+#[test]
+fn simple_fold_repeat_did_not_fall_back_to_whitespace_only() {
+    let out = Command::new(BINARY)
+        .args(read_flags())
+        .output()
+        .expect("run closurec");
+    let actual = String::from_utf8_lossy(&out.stdout);
+
+    assert!(
+        !actual.contains(".repeat"),
+        "expected the call to be folded away by the typed pipeline \
+         (proving this is the SIMPLE optimizer, not the whitespace fallback); \
+         got:\n{actual}",
+    );
+}


### PR DESCRIPTION
## What

Constant-folds `String#repeat` on a string literal with a non-negative integer-literal count at SIMPLE/ADVANCED:

- `"ab".repeat(3)` → `"ababab"`
- `"x".repeat(0)` → `""`

The receiver is concatenated `count` times (ECMAScript §22.1.3.18). Unlike `slice`, `repeat` never splits a surrogate pair — the whole string is duplicated.

## Conservative declines (call left intact)

- Negative count — JS throws a `RangeError`; folding would erase the throw
- Fractional / non-finite / non-literal count (we don't model `ToInteger` coercion)
- **DoS guard:** a result exceeding 100 000 UTF-16 code units. `"x".repeat(1e9)` is valid JS but must not be expanded into a huge literal at compile time. `checked_mul` also prevents the length computation from overflowing.

## Tests

- 6 new unit tests in `closure-pass-constant-fold` (basic cases incl. empty receiver + multibyte; negative/fractional/identifier-receiver declines; over-cap + exactly-at-cap; huge-count no-overflow)
- New e2e fixture `tests/diff/simple-fold-repeat` + integration test `diff_simple_fold_repeat.rs`: `var s = "ab".repeat(3); report(s);` → `var s="ababab";report(s);`, with a whitespace-fallback guard
- Full existing fixture suite byte-for-byte unchanged

## Versions

- `closure-pass-constant-fold` 0.24.0 → 0.26.0 (0.25 reserved by the open radix branch #6560)
- `closurec` 0.173.0 → 0.175.0 (above main 0.173 and the open radix branch 0.174/#6560)

Inline security review passed: the DoS cap is sound and cannot be bypassed (f64→u64 saturates; the only uncapped path is the empty receiver, where `"".repeat(n)` allocates nothing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)