### PR TITLE
feat(algol): `sign` standard function on all 7 backends (LANG-FULL AL8, PR-2)

### DIFF
--- a/code/packages/rust/algol-iir-compiler/CHANGELOG.md
+++ b/code/packages/rust/algol-iir-compiler/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Changelog
 
+## 0.9.0 — 2026-06-22 — `sign` standard function (LANG-FULL AL8, PR-2)
+
+The second ALGOL 60 standard function (§3.2.4), **`sign`**, building on the
+`abs` machinery from 0.8.0.
+
+- `sign(E)` is the *signum*: `+1` if `E > 0`, `-1` if `E < 0`, `0` if `E = 0`.
+  Unlike `abs`, the **result is always `integer`** regardless of the operand's
+  type — `sign(-2.5)` is the integer `-1` (no real→integer coercion needed at
+  the use site).  The operand may be `integer` or `real`.
+- It lowers to the nested conditional `if E > 0 then 1 else if E < 0 then -1
+  else 0`: a `cmp_gt` then a `cmp_lt` against a typed zero (compared at the
+  operand width), with three `i64` constants moved into one result slot — the
+  same store-per-branch shape (no SSA phi) `abs` uses, so it **runs on all seven
+  backends** (native-AOT/LLVM/WASM/JVM/CLR/VM/JIT).  `E` is evaluated once.
+- Same name-based, overridable resolution as `abs`: a user `procedure sign`
+  wins over the built-in.
+- **Verified by RUNNING:** a `lang_matrix.rs` cell — `43 + sign(0 - 1)` ⇒ exit
+  **42** (the negative branch) — executes on every backend; plus 8 inline tests
+  (positive / negative / zero integer `sign`, positive / negative real `sign`
+  yielding an integer, composition with `abs`, the user-override case, and the
+  wrong-arity rejection).
+
+`entier` (floor of a real → integer) needs a float-floor+convert that is not a
+portable IIR op, and `sqrt`/`sin`/`cos`/… need a runtime math library on every
+backend; those are later AL8 slices.
+
 ## 0.8.0 — 2026-06-22 — `abs` standard function (LANG-FULL AL8, PR-1)
 
 ALGOL 60 *standard functions* (§3.2.4) are built into the language rather than

--- a/code/packages/rust/algol-iir-compiler/Cargo.toml
+++ b/code/packages/rust/algol-iir-compiler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "algol-iir-compiler"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 description = "ALGOL 60 scalar frontend for the LANG VM Rust chain, lowering parsed ALGOL into interpreter_ir::IIRModule. v0.3.0 adds switches (computed goto) + conditional designational expressions, and fixes comparison lowering to use the i64 operand width so ALGOL comparisons run on the code-gen backends. v0.2.0 added typed procedures with value parameters."
 

--- a/code/packages/rust/algol-iir-compiler/README.md
+++ b/code/packages/rust/algol-iir-compiler/README.md
@@ -60,8 +60,12 @@ built in: `abs(E)` is the absolute value of `E`, keeping its type
 still redeclare its own `procedure abs`, which then wins — and lowers inline to
 `if E < 0 then -E else E` (a compare against zero, then a negated or
 pass-through move into one result slot), so it **runs on all 7 backends**;
-`abs(0 - 42)` ⇒ `42`. The other standard functions (`sign`, `entier`, then
-`sqrt`/`sin`/`cos`/…) are not implemented yet.
+`abs(0 - 42)` ⇒ `42`. **`sign`** is the second (algol-iir-compiler 0.9.0):
+`sign(E)` is `+1`/`-1`/`0` for a positive/negative/zero operand and, unlike
+`abs`, always yields an **`integer`** (`sign(-2.5)` is the integer `-1`). It
+lowers the same way — `if E > 0 then 1 else if E < 0 then -1 else 0` — and
+also runs on every backend; `43 + sign(0 - 1)` ⇒ `42`. The remaining standard
+functions (`entier`, then `sqrt`/`sin`/`cos`/…) are not implemented yet.
 
 `real` values lower to the IIR `f64` type and **run on the VM and JIT today**
 (LANG-FULL AL1 / enabler E3 phase 1); `2.5 * 2.0`, `7.0 / 2.0`, and real

--- a/code/packages/rust/algol-iir-compiler/src/lib.rs
+++ b/code/packages/rust/algol-iir-compiler/src/lib.rs
@@ -1023,9 +1023,11 @@ impl Compiler {
     /// it is not a standard function (so the caller raises the usual
     /// "undeclared procedure" error).
     ///
-    /// AL8 PR-1 implements only `abs`.  `sign`/`entier`/`sqrt`/`sin`/`cos`/…
-    /// land in later slices (the transcendentals need a runtime math library on
-    /// every backend; `abs`/`sign`/`entier` are pure IIR and come first).
+    /// Implemented so far: `abs` (PR-1) and `sign` (PR-2) — both pure IIR
+    /// (compare + branch + move/const).  `entier` (floor of a real → integer)
+    /// needs a float-floor+convert that is not a portable IIR op, and
+    /// `sqrt`/`sin`/`cos`/… need a runtime math library on every backend; those
+    /// land in later slices.
     fn try_emit_standard_function(
         &mut self,
         name: &str,
@@ -1033,6 +1035,7 @@ impl Compiler {
     ) -> Result<Option<ExprValue>, CompileError> {
         match name {
             "abs" => Ok(Some(self.emit_abs(node)?)),
+            "sign" => Ok(Some(self.emit_sign(node)?)),
             _ => Ok(None),
         }
     }
@@ -1138,6 +1141,133 @@ impl Compiler {
         self.emit_label(&end_label);
 
         Ok(ExprValue { slot: dest, ty })
+    }
+
+    /// `sign(E)` — the *signum*: `+1` if `E > 0`, `-1` if `E < 0`, `0` if
+    /// `E = 0` (ALGOL 60 §3.2.4).  Unlike `abs`, the **result is always
+    /// `integer`** regardless of the operand's type — `sign(-2.5)` is the
+    /// integer `-1`.  The operand may be `integer` or `real`; the comparisons
+    /// run at the operand width (the `0` we compare against is typed to match),
+    /// but every value `dest` receives is an `i64` constant.
+    ///
+    /// It lowers to the nested conditional `if E > 0 then 1 else if E < 0 then
+    /// -1 else 0`, written with the same store-per-branch `dest` discipline as
+    /// `abs` (one `mov`/`const` into `dest` per path, no SSA phi), so it runs
+    /// identically on all seven backends.  `E` is evaluated once.
+    ///
+    /// ```text
+    ///        t := E                  ; evaluate the operand once
+    ///        gt := t > 0             ; cmp_gt at the operand width
+    ///        jmp_if_false gt, neg?   ; not positive → test the sign
+    ///        dest := 1
+    ///        jmp end
+    ///   neg?: lt := t < 0
+    ///        jmp_if_false lt, zero   ; not negative (and not positive) → 0
+    ///        dest := -1
+    ///        jmp end
+    ///   zero: dest := 0
+    ///   end:  (dest holds sign E, an integer)
+    /// ```
+    fn emit_sign(&mut self, node: &GrammarASTNode) -> Result<ExprValue, CompileError> {
+        let actuals = self.standard_fn_actuals(node);
+        if actuals.len() != 1 {
+            return Err(CompileError::Type(format!(
+                "standard function sign expects 1 argument, got {}",
+                actuals.len()
+            )));
+        }
+        let value = self.emit_expr(actuals[0])?;
+        let operand_ty = match value.ty {
+            ScalarType::Integer | ScalarType::Real => value.ty,
+            ScalarType::Boolean => {
+                return Err(CompileError::Type(
+                    "standard function sign requires a numeric argument".into(),
+                ))
+            }
+        };
+
+        // The result is always an integer; the three outcomes are i64 consts.
+        let dest = self.fresh_temp();
+        let neg_label = self.fresh_label("sign_neg");
+        let zero_label = self.fresh_label("sign_zero");
+        let end_label = self.fresh_label("sign_end");
+
+        // gt := (value > 0), compared at the operand width.
+        let zero_operand = self.emit_const(operand_ty, operand_ty.default_operand());
+        let gt = self.fresh_temp();
+        self.emit(IIRInstr::new(
+            "cmp_gt",
+            Some(gt.clone()),
+            vec![Operand::Var(value.slot.clone()), Operand::Var(zero_operand)],
+            operand_ty.iir(),
+        ));
+        self.emit(IIRInstr::new(
+            "jmp_if_false",
+            None,
+            vec![Operand::Var(gt), Operand::Var(neg_label.clone())],
+            "void",
+        ));
+        // positive ⇒ dest := 1
+        let one = self.emit_const(ScalarType::Integer, Operand::Int(1));
+        self.emit(IIRInstr::new(
+            "mov",
+            Some(dest.clone()),
+            vec![Operand::Var(one)],
+            "i64",
+        ));
+        self.emit(IIRInstr::new(
+            "jmp",
+            None,
+            vec![Operand::Var(end_label.clone())],
+            "void",
+        ));
+
+        // neg?: lt := (value < 0)
+        self.emit_label(&neg_label);
+        let zero_operand2 = self.emit_const(operand_ty, operand_ty.default_operand());
+        let lt = self.fresh_temp();
+        self.emit(IIRInstr::new(
+            "cmp_lt",
+            Some(lt.clone()),
+            vec![Operand::Var(value.slot), Operand::Var(zero_operand2)],
+            operand_ty.iir(),
+        ));
+        self.emit(IIRInstr::new(
+            "jmp_if_false",
+            None,
+            vec![Operand::Var(lt), Operand::Var(zero_label.clone())],
+            "void",
+        ));
+        // negative ⇒ dest := -1
+        let minus_one = self.emit_const(ScalarType::Integer, Operand::Int(-1));
+        self.emit(IIRInstr::new(
+            "mov",
+            Some(dest.clone()),
+            vec![Operand::Var(minus_one)],
+            "i64",
+        ));
+        self.emit(IIRInstr::new(
+            "jmp",
+            None,
+            vec![Operand::Var(end_label.clone())],
+            "void",
+        ));
+
+        // zero ⇒ dest := 0
+        self.emit_label(&zero_label);
+        let zero_result = self.emit_const(ScalarType::Integer, Operand::Int(0));
+        self.emit(IIRInstr::new(
+            "mov",
+            Some(dest.clone()),
+            vec![Operand::Var(zero_result)],
+            "i64",
+        ));
+        self.emit_label(&end_label);
+
+        Ok(ExprValue {
+            slot: dest,
+            ty: ScalarType::Integer,
+        })
     }
 
     fn emit_statement(&mut self, node: &GrammarASTNode) -> Result<(), CompileError> {
@@ -3025,6 +3155,68 @@ mod tests {
         let err = compile_source("begin integer result; result := abs(1, 2) end", "test")
             .expect_err("two-argument abs is a type error");
         assert!(format!("{err:?}").contains("abs expects 1 argument"));
+    }
+
+    #[test]
+    fn sign_of_positive_is_one() {
+        assert_eq!(run_i64("begin integer result; result := sign(7) end"), 1);
+    }
+
+    #[test]
+    fn sign_of_negative_is_minus_one() {
+        // `sign` returns -1, which as an exit code wraps to 255, so we test via
+        // arithmetic: 43 + sign(0 - 9) = 43 + (-1) = 42.
+        assert_eq!(
+            run_i64("begin integer result; result := 43 + sign(0 - 9) end"),
+            42
+        );
+    }
+
+    #[test]
+    fn sign_of_zero_is_zero() {
+        assert_eq!(run_i64("begin integer result; result := sign(0) end"), 0);
+    }
+
+    #[test]
+    fn sign_of_real_is_an_integer() {
+        // The operand is `real`, but `sign` yields the *integer* 1 — usable in
+        // an integer context with no real→integer coercion needed.
+        assert_eq!(
+            run_i64("begin integer result; result := sign(2.5) end"),
+            1
+        );
+    }
+
+    #[test]
+    fn sign_of_negative_real_is_minus_one() {
+        assert_eq!(
+            run_i64("begin integer result; result := 43 + sign(0.0 - 2.5) end"),
+            42
+        );
+    }
+
+    #[test]
+    fn sign_composes_with_abs() {
+        // |sign(-4)| = |-1| = 1 — two standard functions nested.
+        assert_eq!(
+            run_i64("begin integer result; result := 41 + abs(sign(0 - 4)) end"),
+            42
+        );
+    }
+
+    #[test]
+    fn user_declared_sign_overrides_the_builtin() {
+        let src = "begin integer result; \
+                   integer procedure sign(x); value x; integer x; sign := x + 1; \
+                   result := sign(41) end";
+        assert_eq!(run_i64(src), 42);
+    }
+
+    #[test]
+    fn sign_rejects_wrong_arity() {
+        let err = compile_source("begin integer result; result := sign(1, 2) end", "test")
+            .expect_err("two-argument sign is a type error");
+        assert!(format!("{err:?}").contains("sign expects 1 argument"));
     }
 
     #[test]

--- a/code/packages/rust/lang-aot/tests/lang_matrix.rs
+++ b/code/packages/rust/lang-aot/tests/lang_matrix.rs
@@ -511,6 +511,20 @@ const PROGRAMS: &[Prog] = &[
         expect: Expect::Exit(42),
         backends: &[NativeAot, Llvm, Wasm, Jvm, Clr, Vm, Jit],
     },
+    // ALGOL 60 — the `sign` **standard function** (§3.2.4, LANG-FULL AL8). Like
+    // `abs`, `sign` is built in and resolved by name; it lowers to the nested
+    // conditional `if E > 0 then 1 else if E < 0 then -1 else 0` — three `i64`
+    // constants moved into one result slot (store-per-branch, no phi). `sign`
+    // always returns an `integer` regardless of operand type. `sign(0 - 1) = -1`,
+    // so `43 + sign(0 - 1)` = 42 ⇒ exit 42 — exercising the negative branch on
+    // native-AOT / LLVM / WASM / JVM / CLR / VM / JIT.
+    Prog {
+        lang: Language::Algol60,
+        ext: "alg",
+        src: "begin integer result; result := 43 + sign(0 - 1) end",
+        expect: Expect::Exit(42),
+        backends: &[NativeAot, Llvm, Wasm, Jvm, Clr, Vm, Jit],
+    },
     // ALGOL 60 — a *typed procedure with a value parameter* (`integer procedure
     // sq(x); value x; integer x; sq := x*x`) called from the main block:
     // `result := sq(7)` ⇒ exit 49.  `algol-iir-compiler` lowers the procedure

--- a/code/specs/LANG-FULL-IMPLEMENTATION.md
+++ b/code/specs/LANG-FULL-IMPLEMENTATION.md
@@ -14,7 +14,7 @@ program per language**, and each frontend is a **deliberate subset**:
 | Brainfuck | one 1-loop "print A" | all 8 ops are correct **but cat/Hello-World/nested-multiply run only on the VM/JIT**, never on the code-gen backends |
 | Dartmouth BASIC | `PRINT 42` | integer-only: no `GOSUB`, strings, `^`; has `FOR`/`NEXT`, `IF`/`GOTO`, `DEF FN` (BA5), `DIM` arrays (BA3), `READ`/`DATA`/`RESTORE` (BA6) — all run on every backend |
 | Oct | `let`/`if` | rejects **all 10 Intel-8008 intrinsics** (its raison d'être); `&&`/`||` short-circuit ✅ (O1), u8 wrap + `~` ✅ (O2), `static` module globals ✅ (O3); intrinsics remain |
-| ALGOL 60 | `result := 17 mod 5` → 2 | `integer`/`real`/`boolean` scalars, typed procedures, switches, 1-D arrays, `own` static-lifetime variables ✅ (AL6, all 7 backends), `abs` standard function ✅ (AL8, all 7 backends); arrays + reals run on VM/JIT only so far; no call-by-name, strings, multidim arrays |
+| ALGOL 60 | `result := 17 mod 5` → 2 | `integer`/`real`/`boolean` scalars, typed procedures, switches, 1-D arrays, `own` static-lifetime variables ✅ (AL6, all 7 backends), `abs`/`sign` standard functions ✅ (AL8, all 7 backends); arrays + reals run on VM/JIT only so far; no call-by-name, strings, multidim arrays |
 
 **Goal of this campaign:** make every language a *full* implementation —
 every construct in its grammar lowered to the shared IIR, running correctly on
@@ -443,13 +443,16 @@ backend immediately) come before the enabler-dependent items.
   has drifted ahead of the compiled grammar in other rules; resync is follow-up.)
 - ☐ **AL7** — ⚠ call-by-name (Jensen-style expression thunks). **Hardest item in the
   campaign — design pass + user check before implementing.**
-- ◑ **AL8** — standard functions (§3.2.4). **`abs` ✅** (algol-iir-compiler 0.8.0):
-  built-in resolved by name (overridable by a user `procedure abs`), lowered inline
-  to `if E < 0 then -E else E` — `cmp_lt` + `jmp_if_false` + negated/pass-through
-  `mov` into one slot — preserving `integer`/`real`. Verified by RUNNING
-  `abs(0 - 42)` ⇒ 42 on native/LLVM/WASM/JVM/CLR/VM/JIT. **Remaining:** `sign`,
-  `entier` (pure IIR, next), then `sqrt`/`sin`/`cos`/`ln`/`exp` (need a cross-backend
-  runtime math library).
+- ◑ **AL8** — standard functions (§3.2.4). **`abs` ✅** (algol-iir-compiler 0.8.0)
+  and **`sign` ✅** (0.9.0): both built-in, resolved by name (overridable by a user
+  `procedure`), lowered inline to compares + `jmp_if_false` + `mov`-into-one-slot
+  (store-per-branch, no phi). `abs(E)` = `if E<0 then -E else E` (preserves
+  `integer`/`real`); `sign(E)` = `if E>0 then 1 else if E<0 then -1 else 0` (always
+  `integer`). Verified by RUNNING `abs(0-42)`⇒42 and `43+sign(0-1)`⇒42 on
+  native/LLVM/WASM/JVM/CLR/VM/JIT. **Remaining:** `entier` (floor of a real → integer:
+  needs a float-floor+convert, not a portable IIR op — closer to the transcendentals
+  than to abs/sign), then `sqrt`/`sin`/`cos`/`ln`/`exp` (need a cross-backend runtime
+  math library).
 
 ### Twig
 - ✅ **TW1** — variadic arithmetic typed lowering. An all-`i64` `(+ a b c …)` /


### PR DESCRIPTION
## What

Adds ALGOL 60's second **standard function** (§3.2.4), **`sign`**, building on the `abs` machinery from [#6559](https://github.com/adhithyan15/coding-adventures/pull/6559). `sign(E)` is the *signum*: `+1` if `E > 0`, `-1` if `E < 0`, `0` if `E = 0`.

## How

- **Always returns `integer`** — unlike `abs`, the result type is `integer` regardless of the operand's type, so `sign(-2.5)` is the integer `-1` (usable in an integer context with no coercion). The operand may be `integer` or `real`.
- **Same lowering template as `abs`** — resolved by name in `try_emit_standard_function` (overridable by a user `procedure sign`), lowered inline to `if E > 0 then 1 else if E < 0 then -1 else 0`: a `cmp_gt` then a `cmp_lt` against a typed zero (compared at the operand width), with three `i64` constants moved into one result slot — the store-per-branch shape (no SSA phi) that runs identically on every backend. `E` is evaluated once. **No new IIR ops, no backend changes, no grammar change.**

## Verification — run on real toolchains

- New `lang_matrix.rs` cell: `begin integer result; result := 43 + sign(0 - 1) end` ⇒ **exit 42** (exercising the negative branch, `-1`) on **native-AOT / LLVM / WASM / JVM / CLR / VM / JIT**. Full matrix green (50.6s).
- 8 inline tests: positive / negative / zero integer `sign`; positive / negative real `sign` yielding an integer; composition with `abs` (`abs(sign(-4)) = 1`); user-override; wrong-arity. Full crate suite green (76 tests).
- Security review: PASSED.

## Scope

`algol-iir-compiler` 0.8.0 → 0.9.0. Roadmap **AL8** now shows `abs` + `sign` done. **Remaining:** `entier` (floor of a real → integer — needs a float-floor+convert, not a portable IIR op), then `sqrt`/`sin`/`cos`/… (need a cross-backend runtime math library).

🤖 Generated with [Claude Code](https://claude.com/claude-code)