### PR TITLE
test(x86-sim): ALGOL `abs` runs on the simulator (LANG-FULL AL8 follow-up)

### DIFF
--- a/code/packages/rust/x86-simulator/CHANGELOG.md
+++ b/code/packages/rust/x86-simulator/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog — x86-simulator
 
+## 0.7.4 — 2026-06-22 — ALGOL `abs` cell (LANG-FULL AL8 follow-up)
+
+Adds an executed matrix cell `algol_abs_runs_on_x86_sim`: the ALGOL `abs`
+standard function (LANG-FULL AL8, merged) run as real x86_64 machine code on the
+simulator — `abs(0 - 42)` ⇒ exit `42`. This is the first cell to exercise the
+**compare-and-branch-into-a-merged-result** lowering (`cmp_lt` + `jmp_if_false`
++ negated/pass-through `mov` into one slot) from native code: existing ALGOL
+cells branch for `for`/`switch` control flow but never merge a *value* back out
+of two arms. Test-only; no library change.
+
 ## 0.7.3 — 2026-06-22 — Dartmouth BASIC `DIM` array cell (LANG-FULL BA3 follow-up)
 
 Adds an executed matrix cell `basic_array_runs_on_x86_sim`: a Dartmouth BASIC

--- a/code/packages/rust/x86-simulator/Cargo.toml
+++ b/code/packages/rust/x86-simulator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "x86-simulator"
-version = "0.7.3"
+version = "0.7.4"
 edition = "2021"
 description = "x86/x86-64 runtime simulator — decode + execute machine code, and run the x86_64-backend's emitted code locally (host-arch-independent)"
 

--- a/code/packages/rust/x86-simulator/tests/lang_matrix_x86.rs
+++ b/code/packages/rust/x86-simulator/tests/lang_matrix_x86.rs
@@ -384,6 +384,20 @@ fn algol_signed_division_runs_on_x86_sim() {
     assert_eq!(run_on_x86_sim(Language::Algol60, src), 42);
 }
 
+/// ALGOL — the **`abs` standard function** (LANG-FULL AL8) on the x86_64 backend.
+/// `abs` lowers to `if E < 0 then -E else E` — a `cmp_lt` against zero, a
+/// `jmp_if_false`, and a negated vs pass-through `mov` into one slot.  This is
+/// the first matrix cell to run that **compare-and-branch-into-a-merged-result**
+/// shape from real x86_64 machine code on the simulator (the existing ALGOL
+/// cells branch for control flow — `for`/`switch` — but don't merge a value back
+/// out of two arms).  `abs(0 - 42)` = 42 ⇒ exit 42 proves the negated arm and
+/// the join produce correct native code.
+#[test]
+fn algol_abs_runs_on_x86_sim() {
+    let src = "begin integer result; result := abs(0 - 42) end";
+    assert_eq!(run_on_x86_sim(Language::Algol60, src), 42);
+}
+
 /// Brainfuck — build 65 on the tape and `putchar` it (`++++++++[>++++++++<-]>+.`
 /// ⇒ stdout `A`).  Exercises the **byte-tape** opcode surface the arithmetic
 /// programs never touch: `__twig_alloc_bytes` for the tape, 8-bit load/store


### PR DESCRIPTION
## What

Adds the matrix cell `algol_abs_runs_on_x86_sim`: the ALGOL `abs` standard function ([#6559](https://github.com/adhithyan15/coding-adventures/pull/6559), merged) run as **real x86_64 machine code on the simulator** — `abs(0 - 42)` ⇒ exit `42`.

## Why

`abs` lowers to `if E < 0 then -E else E` — a `cmp_lt` against zero, a `jmp_if_false`, and a negated-vs-pass-through `mov` into one result slot. This is the **first matrix cell to run that compare-and-branch-into-a-merged-result shape from native code**: the existing ALGOL x86-sim cells branch for control flow (`for`/`switch`) but never merge a *value* back out of two arms. Confirms both the negated arm and the join produce correct x86_64 machine code locally — no Intel hardware / CI round-trip.

## Scope

Test-only. No library/`src` change. Bumps `x86-simulator` 0.7.3 → 0.7.4 for the changelog entry. Lives in `lang_matrix_x86.rs` (not the cross-backend `lang_matrix.rs`).

## Verification

- `cargo test -p x86-simulator --test lang_matrix_x86` — **26 passed, 0 failed**.
- Security review: PASSED (test-only, fixed input).

🤖 Generated with [Claude Code](https://claude.com/claude-code)