### PR TITLE
feat(mycin-ophtho): new ADJ-only ophthalmology recall domain — 12 grounded eye-finding→diagnosis edges

### DIFF
--- a/code/specs/data/mycin-2026/recall/ophtho-edges.adj
+++ b/code/specs/data/mycin-2026/recall/ophtho-edges.adj
@@ -1,0 +1,135 @@
+% ============================================================================
+% ophtho-edges — the ophthalmology finding knowledge-graph (MYCIN-2026 OPHTHO).
+% ============================================================================
+% A high-yield ophthalmology/internal-medicine board domain: the eye finding
+% (fundoscopic sign, pupillary reflex, corneal/lens finding) and the diagnosis it
+% points to. "Fundoscopy shows a cherry-red spot — what is the diagnosis?" becomes
+% the binding query
+%     ? eye_finding_indicates(cherry_red_spot, $Diagnosis).
+%
+% Direction note: the relation is finding -> diagnosis (`eye_finding_indicates`),
+% the board direction — you SEE the eye finding and must name the diagnosis. The
+% cited spans read either way ("Kayser-Fleischer rings are a common ... finding in
+% patients with Wilson disease"; "the most common presenting features of
+% retinoblastoma include leukocoria") — what matters for grounding is that one
+% self-contained span names BOTH the eye finding AND the diagnosis. Each finding
+% here maps to one canonical diagnosis, so a query binds a single answer.
+%
+% This file is the SHIPPED ARTIFACT and the SOLE source of truth — no generator, no
+% JSON, no manifest (a pure ADJ-only recall domain, like ECG/URINE/RESP/DERM). Each
+% fact is a `relate` clause whose byte-provenance lives INLINE:
+%     source   — the VERBATIM span copied from the cited page (byte-stable: it
+%                appears character-for-character in the page's normalized text).
+%     locator  — the URL the span was read from (NCBI StatPearls / Bookshelf, or
+%                NCBI PubMed Central for the one finding with no StatPearls span).
+%     trust    — authoritative (a primary, citable reference).
+% An LLM (or a human) recalls a fact by writing a tiny query .adj that `import`s
+% this library and asks a binding query — see ophtho-recall.query.adj. Nothing here
+% is asserted "from memory": every edge is defended by a span a reader can re-fetch
+% and check.
+% (See feedback_nothing_human_authored, feedback_adj_only_shipped_artifacts.)
+%
+% Write-once / use-many: the four hypertensive-retinopathy findings (cotton wool
+% spots, flame-shaped hemorrhages, arteriovenous crossing changes, macular star)
+% are all minted from ONE NBK525980 sentence that lists them together — one grounded
+% span, four edges. Papilledema also appears in that sentence but is deliberately
+% NOT bound to hypertensive retinopathy here: it already binds increased
+% intracranial pressure (NBK538295), and the single-answer property forbids a second
+% binding for one finding.
+%
+% Honest scope: only findings whose page states the association in a clean self-
+% contained AFFIRMATIVE span (both endpoints named; a negating/caveat sentence does
+% not count) are included. Deferred (re-checked): Hollenhorst plaque -> carotid
+% atherosclerosis (NBK470445 splits the spelled-out plaque name from the carotid
+% source; the carotid-origin sentence abbreviates to "HPs") — reused as the off-
+% vocabulary abstention control.
+% ============================================================================
+
+dictionary ophtho_vocab {
+    define finding   : entity   surface "eye finding", "ophthalmologic sign"
+    define diagnosis : entity   surface "ocular or systemic diagnosis", "condition"
+
+    define eye_finding_indicates : relation from finding to diagnosis  % the diagnosis an eye finding points to
+}
+
+rulebook ophtho_facts {
+    use ophtho_vocab
+
+    % --- cherry red spot -> central retinal artery occlusion (CRAO) ------------
+    relate eye_finding_indicates(cherry_red_spot, central_retinal_artery_occlusion)
+        source "Retinal whitening and a cherry-red spot are important manifestations of acute CRAO."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK539841/"
+        trust authoritative
+
+    % --- Roth spots -> infective endocarditis (NCBI PMC; no StatPearls span) ----
+    relate eye_finding_indicates(roth_spots, infective_endocarditis)
+        source "Roth's spots are not pathognomonic for infective endocarditis but are suggestive of the diagnosis."
+        locator "https://pmc.ncbi.nlm.nih.gov/articles/PMC7417078/"
+        trust authoritative
+
+    % --- leukocoria (white pupillary reflex) -> retinoblastoma ------------------
+    relate eye_finding_indicates(leukocoria, retinoblastoma)
+        source "The most common presenting features of retinoblastoma include leukocoria, strabismus, eye redness or pain, visual impairment, and proptosis."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK545276/"
+        trust authoritative
+
+    % --- optic disc cupping (raised cup-to-disc ratio) -> glaucoma --------------
+    relate eye_finding_indicates(optic_disc_cupping, glaucoma)
+        source "A cup-to-disc ratio greater than 0.5 is often associated with glaucoma, and initial loss is typically observed in the inferotemporal and superotemporal poles of the optic disc."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK441887/"
+        trust authoritative
+
+    % --- Kayser-Fleischer rings -> Wilson disease ------------------------------
+    relate eye_finding_indicates(kayser_fleischer_rings, wilson_disease)
+        source "Kayser-Fleischer rings are a common ophthalmological finding in patients with Wilson disease—a genetic disorder that affects copper metabolism in the body."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK459187/"
+        trust authoritative
+
+    % --- papilledema -> increased intracranial pressure ------------------------
+    relate eye_finding_indicates(papilledema, increased_intracranial_pressure)
+        source "Papilledema is characterized by swelling of the optic disc resulting from elevated intracranial pressure (ICP), which can arise from multiple causes."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK538295/"
+        trust authoritative
+
+    % --- retinal neovascularization -> proliferative diabetic retinopathy ------
+    relate eye_finding_indicates(retinal_neovascularization, proliferative_diabetic_retinopathy)
+        source "In proliferative diabetic retinopathy, many of the changes seen in NPDR are present in addition to neovascularization that extends along the surface of the retina or into the vitreous cavity."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK278967/"
+        trust authoritative
+
+    % --- superior (supero-temporal) lens dislocation -> Marfan syndrome --------
+    relate eye_finding_indicates(superior_lens_dislocation, marfan_syndrome)
+        source "A bilateral supero-temporal lens displacement is seen in Marfan syndrome."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK578193/"
+        trust authoritative
+
+    % ------------------------------------------------------------------------
+    % WRITE-ONCE / USE-MANY: the four findings below are all named in ONE
+    % NBK525980 sentence enumerating the key features of hypertensive
+    % retinopathy — one grounded span, four edges.
+    % ------------------------------------------------------------------------
+
+    % --- cotton wool spots -> hypertensive retinopathy -------------------------
+    relate eye_finding_indicates(cotton_wool_spots, hypertensive_retinopathy)
+        source "Key features of hypertensive retinopathy include arteriovenous crossing changes, cotton wool spots, flame-shaped peripapillary hemorrhages, optic disc swelling (papilledema), and macular star formation."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK525980/"
+        trust authoritative
+
+    % --- flame-shaped hemorrhages -> hypertensive retinopathy (same span) ------
+    relate eye_finding_indicates(flame_shaped_hemorrhages, hypertensive_retinopathy)
+        source "Key features of hypertensive retinopathy include arteriovenous crossing changes, cotton wool spots, flame-shaped peripapillary hemorrhages, optic disc swelling (papilledema), and macular star formation."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK525980/"
+        trust authoritative
+
+    % --- arteriovenous crossing changes (AV nicking) -> hypertensive retinopathy (same span) -
+    relate eye_finding_indicates(arteriovenous_crossing_changes, hypertensive_retinopathy)
+        source "Key features of hypertensive retinopathy include arteriovenous crossing changes, cotton wool spots, flame-shaped peripapillary hemorrhages, optic disc swelling (papilledema), and macular star formation."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK525980/"
+        trust authoritative
+
+    % --- macular star -> hypertensive retinopathy (same span) ------------------
+    relate eye_finding_indicates(macular_star, hypertensive_retinopathy)
+        source "Key features of hypertensive retinopathy include arteriovenous crossing changes, cotton wool spots, flame-shaped peripapillary hemorrhages, optic disc swelling (papilledema), and macular star formation."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK525980/"
+        trust authoritative
+}

--- a/code/specs/data/mycin-2026/recall/ophtho-recall.query.adj
+++ b/code/specs/data/mycin-2026/recall/ophtho-recall.query.adj
@@ -1,0 +1,27 @@
+% ============================================================================
+% ophtho-recall.query.adj — a worked recall query over the ophthalmology library.
+% ============================================================================
+% The shape an LLM (or a clinician) produces to ANSWER a "this eye finding means
+% which diagnosis?" question: it states no ophthalmology fact — it only `import`s
+% the grounded library and asks binding queries. The native adj-lang engine resolves
+% each `?` against the imported `relate` edges and returns the binding + the citing
+% clause's source/locator/trust. All knowledge is in the library; none is here.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli ophtho-recall.query.adj
+% ============================================================================
+
+import "ophtho-edges.adj"
+
+? eye_finding_indicates(cherry_red_spot, $Diagnosis)                % expect central_retinal_artery_occlusion
+? eye_finding_indicates(roth_spots, $Diagnosis)                    % expect infective_endocarditis
+? eye_finding_indicates(leukocoria, $Diagnosis)                    % expect retinoblastoma
+? eye_finding_indicates(optic_disc_cupping, $Diagnosis)            % expect glaucoma
+? eye_finding_indicates(kayser_fleischer_rings, $Diagnosis)        % expect wilson_disease
+? eye_finding_indicates(papilledema, $Diagnosis)                   % expect increased_intracranial_pressure
+? eye_finding_indicates(retinal_neovascularization, $Diagnosis)    % expect proliferative_diabetic_retinopathy
+? eye_finding_indicates(superior_lens_dislocation, $Diagnosis)     % expect marfan_syndrome
+? eye_finding_indicates(cotton_wool_spots, $Diagnosis)             % expect hypertensive_retinopathy
+? eye_finding_indicates(flame_shaped_hemorrhages, $Diagnosis)      % expect hypertensive_retinopathy
+? eye_finding_indicates(arteriovenous_crossing_changes, $Diagnosis) % expect hypertensive_retinopathy
+? eye_finding_indicates(macular_star, $Diagnosis)                  % expect hypertensive_retinopathy

--- a/code/specs/data/mycin-2026/recall/test_ophtho_recall.py
+++ b/code/specs/data/mycin-2026/recall/test_ophtho_recall.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+"""test_ophtho_recall.py — the ADJ-only ophthalmology recall library (MYCIN-2026 OPHTHO).
+
+A new pure-ADJ recall domain (high-yield ophthalmology/IM board content): the eye
+finding (fundoscopic sign, pupillary reflex, corneal/lens finding) and the diagnosis it
+points to. `ophtho-edges.adj` is the SOLE source of truth — facts + byte-provenance
+inline, no Python gate, no JSON, no manifest. This test pins the property that matters:
+the native adj-lang engine, given a query .adj that only `import`s the library and asks
+binding queries (`ophtho-recall.query.adj` — the shape an LLM produces), binds the
+grounded diagnosis for each eye finding, each carrying an AUTHORITATIVE citation with a
+real source span + locator. Knowledge lives in ADJ; the engine answers.
+
+If the native CLI isn't built (a Python-only CI lane), the engine-backed checks skip —
+the file-shape checks (every clause grounded, no authored-debt) still run.
+
+Run:  python3 test_ophtho_recall.py
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+ADJ = HERE / "ophtho-edges.adj"
+QUERY = HERE / "ophtho-recall.query.adj"
+CLI = HERE.parents[3] / "packages" / "rust" / "target" / "debug" / "adj-lang-cli"
+
+# Every grounded edge: eye finding -> the diagnosis the library binds for it.
+EXPECTED = {
+    "cherry_red_spot": "central_retinal_artery_occlusion",   # NBK539841
+    "roth_spots": "infective_endocarditis",                  # PMC7417078
+    "leukocoria": "retinoblastoma",                          # NBK545276
+    "optic_disc_cupping": "glaucoma",                        # NBK441887
+    "kayser_fleischer_rings": "wilson_disease",              # NBK459187
+    "papilledema": "increased_intracranial_pressure",       # NBK538295
+    "retinal_neovascularization": "proliferative_diabetic_retinopathy",  # NBK278967
+    "superior_lens_dislocation": "marfan_syndrome",          # NBK578193
+    # --- write-once / use-many: four findings from ONE NBK525980 span ---
+    "cotton_wool_spots": "hypertensive_retinopathy",         # NBK525980
+    "flame_shaped_hemorrhages": "hypertensive_retinopathy",  # NBK525980 (same span)
+    "arteriovenous_crossing_changes": "hypertensive_retinopathy",  # NBK525980 (same span)
+    "macular_star": "hypertensive_retinopathy",              # NBK525980 (same span)
+}
+# Every edge cites a primary NCBI authority; we accept StatPearls/Bookshelf and
+# PubMed Central (the Roth-spots edge has no StatPearls span and lives on PMC).
+_AUTH_HOSTS = (
+    "https://www.ncbi.nlm.nih.gov/",
+    "https://pmc.ncbi.nlm.nih.gov/",
+)
+REL = "eye_finding_indicates"
+VAR = "Diagnosis"
+
+
+def _cli_available() -> bool:
+    return CLI.exists()
+
+
+def _run(program: Path) -> dict:
+    out = subprocess.run([str(CLI), str(program)], capture_output=True, text=True,
+                         cwd=str(HERE), timeout=60)
+    assert out.returncode == 0, f"adj-lang-cli failed: {out.stderr}"
+    return json.loads(out.stdout)
+
+
+# ---- 1. the ADJ file is the artifact — every clause grounded, no authored-debt ----
+
+def test_library_is_pure_adj_and_fully_grounded() -> None:
+    text = ADJ.read_text()
+    assert "trust consensus" not in text, "OPHTHO ships no authored-debt; ground or omit"
+    assert "[FLAG:" not in text
+    edge_count = len(EXPECTED)  # 12
+    assert text.count("    relate ") == edge_count
+    assert text.count("trust authoritative") == edge_count
+    assert text.count('\n        locator "') == edge_count
+    assert text.count('\n        source "') == edge_count
+    # every locator is a recognized NCBI primary host
+    for line in text.splitlines():
+        line = line.strip()
+        if line.startswith("locator "):
+            assert any(h in line for h in _AUTH_HOSTS), f"non-NCBI locator: {line}"
+    assert not (HERE / "ophtho_edge_ground.py").exists()
+    assert not (HERE / "ophtho-edge-grounding.json").exists()
+    assert not (HERE / "ophtho-edge-manifest.json").exists()
+
+
+# ---- 2. the engine binds each diagnosis, each with an authoritative citation ----
+
+def test_engine_binds_every_diagnosis_with_authoritative_citation() -> None:
+    if not _cli_available():
+        return
+    result = _run(QUERY)
+    by_query = {r["query"]: r for r in result["recall"]}
+    for finding, diagnosis in EXPECTED.items():
+        q = f"{REL}({finding}, {VAR})"
+        r = by_query.get(q)
+        assert r is not None and not r["abstained"], f"{q} abstained — edge missing?"
+        bound = {}
+        for a in r["answers"]:
+            bound[a["bindings"][VAR]] = (a.get("citations") or [{}])[0]
+        assert set(bound) == {diagnosis}, f"{finding}: bound {set(bound)} != {{{diagnosis}}}"
+        cite = bound[diagnosis]
+        assert cite.get("trust") == "authoritative", f"{finding}/{diagnosis} not authoritative"
+        assert cite.get("source"), f"{finding}/{diagnosis} has no source span"
+        assert cite.get("locator", "").startswith(_AUTH_HOSTS), f"{finding} locator not a primary host"
+
+
+# ---- 3. an off-vocabulary finding abstains, never fabricates -----------------------
+
+def test_unknown_finding_abstains() -> None:
+    if not _cli_available():
+        return
+    import os
+    import tempfile
+    fd, path = tempfile.mkstemp(suffix=".adj", prefix=".ophtho_q_", dir=HERE)
+    try:
+        with os.fdopen(fd, "w") as fh:
+            # hollenhorst_plaque is not in the library (deferred — see header) -> must abstain
+            fh.write(f'import "ophtho-edges.adj"\n? {REL}(hollenhorst_plaque, ${VAR})\n')
+        res = _run(Path(path))
+        r = res["recall"][0] if res["recall"] else None
+        assert r is not None and r["abstained"], "an ungrounded finding must abstain"
+    finally:
+        os.unlink(path)
+
+
+def _run_all() -> int:
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    failed = 0
+    for t in tests:
+        try:
+            t()
+            print(f"  PASS  {t.__name__}")
+        except AssertionError as exc:
+            failed += 1
+            print(f"  FAIL  {t.__name__}: {exc}")
+    print(f"\ntest_ophtho_recall: {len(tests) - failed}/{len(tests)} passed")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(_run_all())


### PR DESCRIPTION
## Summary
Adds a **brand-new pure-ADJ recall domain** for **ophthalmology** — a high-yield ophthalmology/IM board topic previously absent from MYCIN-2026. The relation `eye_finding_indicates(finding, diagnosis)` maps an eye finding (fundoscopic sign, pupillary reflex, corneal/lens finding) to the diagnosis it points to.

12 byte-grounded edges, each defended by a single self-contained verbatim NCBI span naming BOTH the finding AND the diagnosis:

| eye finding | diagnosis | source |
|---|---|---|
| cherry red spot | central retinal artery occlusion | NBK539841 |
| Roth spots | infective endocarditis | PMC7417078 |
| leukocoria | retinoblastoma | NBK545276 |
| optic disc cupping | glaucoma | NBK441887 |
| Kayser-Fleischer rings | Wilson disease | NBK459187 |
| papilledema | increased intracranial pressure | NBK538295 |
| retinal neovascularization | proliferative diabetic retinopathy | NBK278967 |
| superior lens dislocation | Marfan syndrome | NBK578193 |
| cotton wool spots | hypertensive retinopathy | NBK525980 |
| flame-shaped hemorrhages | hypertensive retinopathy | NBK525980 *(same span)* |
| AV crossing changes | hypertensive retinopathy | NBK525980 *(same span)* |
| macular star | hypertensive retinopathy | NBK525980 *(same span)* |

## Notes
- **Write-once / use-many**: the four hypertensive-retinopathy findings are minted from **one** NBK525980 sentence listing them together — one grounded span, four edges. Papilledema also appears in that sentence but is deliberately bound only to increased ICP (single-answer property forbids a second binding).
- **Faithfulness over recall**: the cherry-red-spot edge was re-grounded after the first span (*"some CRAO may not show a cherry red spot"*) proved to be a negating caveat; the shipped span affirmatively associates it with CRAO. Roth spots has no StatPearls span → grounded to NCBI **PubMed Central** (allowlist accepts `pmc.ncbi.nlm.nih.gov`).
- Ships as the standard trio; self-contained (no `board_eval` coupling, no manifest, no JSON). CI auto-discovers `recall/test_*.py`. Deferred: Hollenhorst plaque→carotid atherosclerosis (NBK470445 splits the terms) — reused as the abstention control.

## Verification
- `cargo build -p adj-lang-cli` ✓
- `test_ophtho_recall.py` → **3/3** (engine binds all 12 with authoritative NCBI citations; control abstains) ✓
- `ruff check` clean ✓
- Security review passed ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)