### PR TITLE
feat(closurec): string padStart/padEnd fold at SIMPLE/ADVANCED

### DIFF
--- a/code/packages/rust/closure-pass-constant-fold/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-constant-fold/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 All notable changes to the `coding-adventures-closure-pass-constant-fold` crate will be documented in this file.
 
+## [0.28.0] - 2026-06-22
+
+### Added — fold `"x".padStart(target[, pad])` / `padEnd(...)` on string literals
+
+`String.prototype.padStart` / `padEnd` (ECMAScript §22.1.3.16 / §22.1.3.17) now
+fold to a string literal when the receiver is a string literal, the target
+length is a non-negative integer literal, and the optional pad is a string
+literal (default a single space): `"5".padStart(3, "0")` → `"005"`,
+`"abc".padEnd(6)` → `"abc   "`, `"abc".padStart(6, "12")` → `"121abc"` (the pad
+repeats and truncates to the shortfall). A string already at or over the target
+is returned unchanged. A new `fold_string_pad` helper works in UTF-16 code
+units.
+
+Conservative scope, with a **denial-of-service guard**: declines (leaves the
+call) for no argument or more than two, a non-integer target, a non-string-
+literal pad, a target over `MAX_PAD_UNITS` (100 000) UTF-16 code units, or a
+fill truncation that would split a surrogate pair into a lone surrogate (a valid
+JS string but not a Rust `String` — the same guard `slice`/`charAt` use). 6 new
+unit tests with V8-derived oracle values.
+
+> Version note: bumped to 0.28.0 — above the merged `repeat` fold (0.26.0) and
+> the open numeric `toString(radix)` fold (0.27.0, PR #6560) — so the parallel
+> branches don't collide on the version line.
+
 ## [0.26.0] - 2026-06-22
 
 ### Added — fold `"ab".repeat(count)` on string literals

--- a/code/packages/rust/closure-pass-constant-fold/Cargo.toml
+++ b/code/packages/rust/closure-pass-constant-fold/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-constant-fold"
-version = "0.26.0"
+version = "0.28.0"
 edition = "2021"
 description = "Constant-folding optimization pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Folds compile-time-evaluable expressions like `2 + 3 → 5`."
 

--- a/code/packages/rust/closure-pass-constant-fold/src/lib.rs
+++ b/code/packages/rust/closure-pass-constant-fold/src/lib.rs
@@ -591,6 +591,34 @@ fn fold_call(c: &CallExpression, st: &mut FoldState) -> Expression {
                         return stamp_literal_cv(FoldedLiteral::String(result), new_cv);
                     }
                 }
+                // ---- padStart(target[, pad]) / padEnd(target[, pad]) ----
+                //
+                // `"5".padStart(3, "0")` → `"005"`, `"abc".padEnd(6)` →
+                // `"abc   "` (ECMAScript §22.1.3.16/17). Pads the string to a
+                // target length (in UTF-16 code units) with a fill string
+                // (default a single space), repeated and truncated to fit.
+                // `fold_string_pad` declines for a non-integer target, a
+                // non-string-literal pad, a target over the size cap, or a
+                // truncation that would leave a lone surrogate.
+                else if id.name == "padStart" || id.name == "padEnd" {
+                    let at_start = id.name == "padStart";
+                    if let Some(result) = fold_string_pad(&s.value, &arguments, at_start) {
+                        let parent = c.cv.clone();
+                        let args_src = arguments
+                            .iter()
+                            .map(|a| match a {
+                                Expression::NumericLiteral(n) => format_js_number(n.value),
+                                Expression::StringLiteral(p) => format!("\"{}\"", p.value),
+                                _ => "?".to_string(),
+                            })
+                            .collect::<Vec<_>>()
+                            .join(",");
+                        let before = format!("\"{}\".{}({})", s.value, id.name, args_src);
+                        let after = format!("\"{}\"", result);
+                        let new_cv = st.fork_cv(&parent, &before, &after);
+                        return stamp_literal_cv(FoldedLiteral::String(result), new_cv);
+                    }
+                }
                 // ---- zero-argument casing methods (ASCII-only) ----
                 else if arguments.is_empty() {
                     let cased = match id.name.as_str() {
@@ -811,6 +839,80 @@ fn fold_string_repeat(value: &str, args: &[Expression]) -> Option<String> {
         Some(total) if total <= MAX_REPEAT_UNITS => Some(value.repeat(count as usize)),
         _ => None,
     }
+}
+
+/// Compute `value.padStart(target[, pad])` (when `at_start`) or
+/// `value.padEnd(target[, pad])` at compile time, or `None` when it cannot be
+/// folded soundly (ECMAScript §22.1.3.16 / §22.1.3.17).
+///
+/// JS pads to `target` **UTF-16 code units** with a fill string (default a
+/// single space `" "`), formed by repeating `pad` and truncating it to exactly
+/// the shortfall. `"5".padStart(3, "0")` → `"005"`, `"abc".padEnd(6)` →
+/// `"abc   "`, `"abc".padStart(6, "12")` → `"121abc"` (the `"12"` repeats to
+/// `"121"`). If the string is already `>= target`, it is returned unchanged.
+///
+/// We decline (return `None`, leaving the call for the runtime) when:
+/// - there is no argument, or more than two;
+/// - the target is not a non-negative integer literal (no `ToLength` coercion);
+/// - the pad argument is present but not a string literal;
+/// - the target exceeds `MAX_PAD_UNITS` (a denial-of-service guard against
+///   materializing a huge literal at compile time); or
+/// - truncating the fill would split a surrogate pair, leaving a lone surrogate
+///   the result `String` cannot hold (`String::from_utf16` fails) — the same
+///   conservative guard `slice`/`charAt` use.
+fn fold_string_pad(value: &str, args: &[Expression], at_start: bool) -> Option<String> {
+    /// Cap on the padded result's length, in UTF-16 code units.
+    const MAX_PAD_UNITS: u64 = 100_000;
+
+    if args.is_empty() || args.len() > 2 {
+        return None;
+    }
+    // arg 0: target length — a non-negative integer literal.
+    let target = match &args[0] {
+        Expression::NumericLiteral(n)
+            if n.value.is_finite() && n.value.fract() == 0.0 && n.value >= 0.0 =>
+        {
+            n.value as u64
+        }
+        _ => return None,
+    };
+    if target > MAX_PAD_UNITS {
+        return None;
+    }
+    // arg 1: pad string — a string literal, defaulting to a single space.
+    let pad: &str = match args.get(1) {
+        None => " ",
+        Some(Expression::StringLiteral(p)) => &p.value,
+        Some(_) => return None,
+    };
+
+    let s_units: Vec<u16> = value.encode_utf16().collect();
+    let s_len = s_units.len() as u64;
+    // Already long enough (or an empty pad can't extend it) → unchanged.
+    if target <= s_len {
+        return Some(value.to_string());
+    }
+    let pad_units: Vec<u16> = pad.encode_utf16().collect();
+    if pad_units.is_empty() {
+        return Some(value.to_string());
+    }
+
+    // Build the filler by repeating `pad` and truncating to the shortfall.
+    let fill_len = (target - s_len) as usize;
+    let mut filler: Vec<u16> = Vec::with_capacity(fill_len);
+    while filler.len() < fill_len {
+        let take = (fill_len - filler.len()).min(pad_units.len());
+        filler.extend_from_slice(&pad_units[..take]);
+    }
+
+    // Concatenate (filler before or after the string) and reject a result that
+    // a Rust `String` cannot hold (a truncation-induced lone surrogate).
+    let result_units: Vec<u16> = if at_start {
+        filler.iter().chain(s_units.iter()).copied().collect()
+    } else {
+        s_units.iter().chain(filler.iter()).copied().collect()
+    };
+    String::from_utf16(&result_units).ok()
 }
 
 // ---------------------------------------------------------------------
@@ -3256,6 +3358,109 @@ mod tests {
         });
         let (out, _, changed, _) = run_pass(program_with_expr(c, true));
         assert!(!changed, "s.repeat(3) must not fold");
+        assert!(matches!(extract_expr(&out), Expression::CallExpression(_)));
+    }
+
+    // ------------------- padStart / padEnd ---------------------------
+
+    /// Build `"<recv>".<method>(<target>[, "<pad>"])`.
+    fn pad_call(recv: &str, method: &str, target: f64, pad: Option<&str>) -> Expression {
+        let mut arguments = vec![num(target, None)];
+        if let Some(p) = pad {
+            arguments.push(string(p, None));
+        }
+        Expression::CallExpression(CallExpression {
+            cv: Some("c.cv".to_string()),
+            callee: Box::new(member(string(recv, None), method)),
+            arguments,
+        })
+    }
+
+    #[test]
+    fn fold_string_pad_basic() {
+        // (recv, method, target, pad, expect) — oracle values from V8.
+        for (recv, method, target, pad, expect) in [
+            ("abc", "padStart", 6.0, None, "   abc"),     // default space pad
+            ("abc", "padStart", 6.0, Some("*"), "***abc"),
+            ("abc", "padEnd", 6.0, Some("*"), "abc***"),
+            ("abc", "padStart", 2.0, Some("*"), "abc"),   // already long enough
+            ("abc", "padStart", 6.0, Some("12"), "121abc"), // repeats + truncates
+            ("abc", "padEnd", 8.0, Some("xy"), "abcxyxyx"),
+            ("abc", "padStart", 6.0, Some(""), "abc"),    // empty pad → unchanged
+            ("5", "padStart", 3.0, Some("0"), "005"),     // zero-pad
+        ] {
+            let c = pad_call(recv, method, target, pad);
+            let (out, _, changed, _) = run_pass(program_with_expr(c, true));
+            assert!(changed, "\"{recv}\".{method}({target}, {pad:?}) should fold");
+            match extract_expr(&out) {
+                Expression::StringLiteral(s) => assert_eq!(
+                    s.value, expect,
+                    "\"{recv}\".{method}({target}, {pad:?})"
+                ),
+                other => panic!("expected \"{expect}\"; got {:?}", other),
+            }
+        }
+    }
+
+    #[test]
+    fn pad_counts_utf16_units() {
+        // "💩" is two UTF-16 units, so "💩".padEnd(4, "x") adds two → "💩xx".
+        let c = pad_call("💩", "padEnd", 4.0, Some("x"));
+        let (out, _, _, _) = run_pass(program_with_expr(c, true));
+        match extract_expr(&out) {
+            Expression::StringLiteral(s) => assert_eq!(s.value, "💩xx"),
+            other => panic!("expected \"💩xx\"; got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn pad_truncating_a_surrogate_pair_does_not_fold() {
+        // pad "💩" (2 units) truncated to a 1-unit shortfall is a lone high
+        // surrogate — a valid JS string but not a Rust `String`, so decline.
+        let c = pad_call("abc", "padStart", 4.0, Some("💩"));
+        let (out, _, changed, _) = run_pass(program_with_expr(c, true));
+        assert!(!changed, "pad truncating a surrogate pair must not fold");
+        assert!(matches!(extract_expr(&out), Expression::CallExpression(_)));
+    }
+
+    #[test]
+    fn pad_over_size_cap_does_not_fold() {
+        // target 200_000 > 100_000 cap — DoS guard declines.
+        let c = pad_call("abc", "padStart", 200_000.0, Some("*"));
+        let (out, _, changed, _) = run_pass(program_with_expr(c, true));
+        assert!(!changed, "pad over the size cap must not fold");
+        assert!(matches!(extract_expr(&out), Expression::CallExpression(_)));
+    }
+
+    #[test]
+    fn pad_non_integer_target_or_non_literal_pad_does_not_fold() {
+        // Fractional target: don't model ToLength coercion.
+        let frac = pad_call("abc", "padStart", 5.5, Some("*"));
+        let (out, _, changed, _) = run_pass(program_with_expr(frac, true));
+        assert!(!changed, "fractional pad target must not fold");
+
+        // Non-literal pad (a numeric pad arg) — only string-literal pads fold.
+        let numpad = Expression::CallExpression(CallExpression {
+            cv: Some("c.cv".to_string()),
+            callee: Box::new(member(string("abc", None), "padStart")),
+            arguments: vec![num(6.0, None), num(0.0, None)],
+        });
+        let (out2, _, changed2, _) = run_pass(program_with_expr(numpad, true));
+        assert!(!changed2, "non-string-literal pad must not fold");
+        assert!(matches!(extract_expr(&out), Expression::CallExpression(_)));
+        assert!(matches!(extract_expr(&out2), Expression::CallExpression(_)));
+    }
+
+    #[test]
+    fn pad_on_identifier_receiver_does_not_fold() {
+        // `s.padStart(5)` needs the runtime value of `s`.
+        let c = Expression::CallExpression(CallExpression {
+            cv: Some("c.cv".to_string()),
+            callee: Box::new(member(ident("s"), "padStart")),
+            arguments: vec![num(5.0, None)],
+        });
+        let (out, _, changed, _) = run_pass(program_with_expr(c, true));
+        assert!(!changed, "s.padStart(5) must not fold");
         assert!(matches!(extract_expr(&out), Expression::CallExpression(_)));
     }
 

--- a/code/programs/rust/closurec/CHANGELOG.md
+++ b/code/programs/rust/closurec/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to the `coding-adventures-closurec` binary will be documented in this file.
 
+## [0.177.0] - 2026-06-22
+
+### Added — string `padStart` / `padEnd` fold at SIMPLE/ADVANCED
+
+Pulls in `coding-adventures-closure-pass-constant-fold` 0.28.0, which folds
+`String#padStart` / `padEnd` on a string literal with an integer-literal target
+length and an optional string-literal pad (default a single space):
+`"5".padStart(3, "0")` → `"005"`, `"abc".padEnd(6)` → `"abc   "`,
+`"abc".padStart(6, "12")` → `"121abc"`. A non-integer target, a non-literal pad,
+a target over the optimizer's 100 000-code-unit cap (a denial-of-service guard),
+and a fill that would split a surrogate pair all pass through unfolded.
+
+New e2e fixture `tests/diff/simple-fold-pad` (and integration test
+`diff_simple_fold_pad.rs`): `var s = "5".padStart(3, "0"); report(s);` →
+`var s="005";report(s);`, with a whitespace-fallback guard proving the fold
+comes from the SIMPLE typed pipeline. The full existing fixture suite remains
+byte-for-byte unchanged.
+
+> Version note: bumped to 0.177.0 to sit above main (closurec 0.175.0) and the
+> concurrently-open numeric `toString([radix])` fold branch (closurec 0.176.0,
+> PR #6560), so the parallel branches never collide on the version line.
+
 ## [0.175.0] - 2026-06-22
 
 ### Added — string `repeat` fold at SIMPLE/ADVANCED

--- a/code/programs/rust/closurec/Cargo.toml
+++ b/code/programs/rust/closurec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closurec"
-version = "0.175.0"
+version = "0.177.0"
 edition = "2021"
 description = "closurec — CLI driver for the Closure Compiler clone. Mirrors the upstream Java Closure Compiler's command-line flag surface (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility. Per CLOC08."
 

--- a/code/programs/rust/closurec/cli.spec.json
+++ b/code/programs/rust/closurec/cli.spec.json
@@ -2,7 +2,7 @@
   "cli_builder_spec_version": "1.0",
   "name": "closurec",
   "description": "closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.",
-  "version": "0.175.0",
+  "version": "0.177.0",
   "parsing_mode": "gnu",
   "flags": [
     { "id": "browser_featureset_year", "long": "browser_featureset_year", "type": "integer", "default": 0, "description": "Shortcut for defining goog.FEATURESET_YEAR=YYYY (minimum 2012)." },

--- a/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
@@ -2,7 +2,7 @@
 
 closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.
 
-Version: 0.175.0
+Version: 0.177.0
 
 ## Flags
 

--- a/code/programs/rust/closurec/tests/diff/simple-fold-pad/README.md
+++ b/code/programs/rust/closurec/tests/diff/simple-fold-pad/README.md
@@ -1,0 +1,28 @@
+# Fixture: `simple-fold-pad`
+
+End-to-end oracle for string-padding folding (`String#padStart` / `padEnd`) at
+`--compilation_level SIMPLE`.
+
+| File | Role |
+|------|------|
+| `flags.txt` | CLI args: `--compilation_level SIMPLE --js input/a.js` |
+| `input/a.js` | `var s = "5".padStart(3, "0"); report(s);` |
+| `expected.stdout` | The folded output: `var s="005";report(s);` |
+
+The SIMPLE level runs the typed-AST optimization pipeline, whose
+`constant-fold` pass folds `padStart`/`padEnd` on a string literal with an
+integer-literal target length and a string-literal pad (default a single
+space): `"5".padStart(3, "0")` → `"005"`. The pad is repeated and truncated to
+the shortfall, measured in UTF-16 code units. A string already at or over the
+target is returned unchanged. A non-integer target, a non-literal pad, a target
+over the optimizer's 100 000-code-unit cap (a denial-of-service guard), or a
+fill that would split a surrogate pair all pass through. The same input under
+`WHITESPACE_ONLY` keeps `"5".padStart(3, "0")` unfolded.
+
+Regenerate the expected file after an intentional behavior change:
+
+```sh
+cargo run -- --compilation_level SIMPLE \
+    --js tests/diff/simple-fold-pad/input/a.js \
+    > tests/diff/simple-fold-pad/expected.stdout
+```

--- a/code/programs/rust/closurec/tests/diff/simple-fold-pad/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/simple-fold-pad/expected.stdout
@@ -1,0 +1,1 @@
+var s="005";report(s);

--- a/code/programs/rust/closurec/tests/diff/simple-fold-pad/flags.txt
+++ b/code/programs/rust/closurec/tests/diff/simple-fold-pad/flags.txt
@@ -1,0 +1,4 @@
+--compilation_level
+SIMPLE
+--js
+tests/diff/simple-fold-pad/input/a.js

--- a/code/programs/rust/closurec/tests/diff/simple-fold-pad/input/a.js
+++ b/code/programs/rust/closurec/tests/diff/simple-fold-pad/input/a.js
@@ -1,0 +1,17 @@
+// SIMPLE-level string-padding fold (String#padStart / padEnd).
+//
+// `"<string>".padStart(<target>[, <pad>])` is compile-time-evaluable on a
+// string literal with an integer-literal target length and an optional
+// string-literal pad; the `constant-fold` pass collapses it to the padded
+// string (JS `String.prototype.padStart`). The pad string (default a single
+// space) is repeated and truncated to fill the shortfall. Here
+// `"5".padStart(3, "0")` → `"005"`. A non-integer target, a non-literal pad,
+// a target over the optimizer's size cap, or a fill that would split a
+// surrogate pair are left for the runtime. Under WHITESPACE_ONLY the call
+// survives; under SIMPLE it folds.
+//
+// The value flows into `report(...)` so it stays referenced — otherwise
+// remove-unused-vars (the last SIMPLE pass) would delete the declaration and
+// the fold would not be observable.
+var s = "5".padStart(3, "0");
+report(s);

--- a/code/programs/rust/closurec/tests/diff_simple_fold_pad.rs
+++ b/code/programs/rust/closurec/tests/diff_simple_fold_pad.rs
@@ -1,0 +1,84 @@
+//! Integration test for the `tests/diff/simple-fold-pad/` fixture.
+//!
+//! End-to-end oracle for string `padStart`/`padEnd` folding in
+//! `closure-pass-constant-fold`: `"5".padStart(3, "0")` collapses to the string
+//! literal `"005"` (JS `String.prototype.padStart`).
+//!
+//! At SIMPLE the fixture optimizes to:
+//!
+//! ```text
+//! var s="005";report(s);
+//! ```
+
+use std::process::Command;
+
+const BINARY: &str = env!("CARGO_BIN_EXE_closurec");
+
+fn read_flags() -> Vec<String> {
+    let raw = std::fs::read_to_string("tests/diff/simple-fold-pad/flags.txt")
+        .expect("read flags.txt");
+    raw.lines()
+        .filter(|l| !l.is_empty())
+        .map(|s| s.to_string())
+        .collect()
+}
+
+#[test]
+fn simple_fold_pad_fixture_matches_expected_stdout() {
+    let flags = read_flags();
+    let out = Command::new(BINARY)
+        .args(&flags)
+        .output()
+        .expect("run closurec");
+
+    assert!(
+        out.status.success(),
+        "exit: {:?}, stderr: {}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stderr),
+    );
+
+    let actual = String::from_utf8_lossy(&out.stdout);
+    let expected = std::fs::read_to_string("tests/diff/simple-fold-pad/expected.stdout")
+        .expect("read expected.stdout");
+    assert_eq!(
+        actual.trim_end_matches('\n'),
+        expected.trim_end_matches('\n'),
+        "mismatch.\nflags: {flags:?}\nactual:\n{actual}\nexpected:\n{expected}",
+    );
+}
+
+/// `"5".padStart(3, "0")` must fold to the string literal `"005"` — no method
+/// call should remain in the output.
+#[test]
+fn simple_fold_pad_folds_to_string_literal() {
+    let out = Command::new(BINARY)
+        .args(read_flags())
+        .output()
+        .expect("run closurec");
+    let actual = String::from_utf8_lossy(&out.stdout);
+
+    assert!(actual.contains("\"005\""), "should fold to \"005\"; got:\n{actual}");
+    assert!(
+        !actual.contains("padStart"),
+        "no `padStart` call should remain after folding; got:\n{actual}",
+    );
+}
+
+/// Regression guard: the output must be the SIMPLE typed pipeline, not the
+/// `WHITESPACE_ONLY` fallback (which would leave `"5".padStart(3, "0")` intact).
+#[test]
+fn simple_fold_pad_did_not_fall_back_to_whitespace_only() {
+    let out = Command::new(BINARY)
+        .args(read_flags())
+        .output()
+        .expect("run closurec");
+    let actual = String::from_utf8_lossy(&out.stdout);
+
+    assert!(
+        !actual.contains(".padStart"),
+        "expected the call to be folded away by the typed pipeline \
+         (proving this is the SIMPLE optimizer, not the whitespace fallback); \
+         got:\n{actual}",
+    );
+}


### PR DESCRIPTION
## What

Constant-folds `String#padStart` / `padEnd` on a string literal with an integer-literal target length and an optional string-literal pad at SIMPLE/ADVANCED:

- `"5".padStart(3, "0")` → `"005"`
- `"abc".padEnd(6)` → `"abc   "` (default single-space pad)
- `"abc".padStart(6, "12")` → `"121abc"` (pad repeats + truncates to the shortfall)
- `"abc".padStart(2, "*")` → `"abc"` (already at/over target → unchanged)

Padding is measured in **UTF-16 code units** (ECMAScript §22.1.3.16/17), matching JS. Oracle values for every test case were taken from V8 (`node`).

> Note: I started on `(N).toFixed(n)` but JS `toFixed` uses round-half-up while Rust's float formatting uses round-half-to-even — they diverge on exact-halfway doubles (`(0.5).toFixed(0)` → JS `"1"` vs Rust `"0"`; `(2.5).toFixed(0)` → JS `"3"` vs Rust `"2"`). Making that provably sound needs exact halfway-detection, so I shipped the fully-sound `padStart`/`padEnd` instead.

## Conservative declines (call left intact)

- No argument, or more than two
- A non-integer / non-finite / negative target (no `ToLength` modeling)
- A non-string-literal pad argument
- **DoS guard:** a target over 100 000 UTF-16 code units (`f64→u64` saturates, so a huge target can't bypass the cap)
- A fill truncation that would split a surrogate pair into a lone surrogate (same guard `slice`/`charAt` use)

## Tests

- 6 new unit tests in `closure-pass-constant-fold` (V8-derived oracles; UTF-16 counting; surrogate-split decline; over-cap decline; fractional-target/non-literal-pad declines; identifier-receiver decline)
- New e2e fixture `tests/diff/simple-fold-pad` + integration test `diff_simple_fold_pad.rs`: `var s = "5".padStart(3, "0"); report(s);` → `var s="005";report(s);`, with a whitespace-fallback guard
- Full existing fixture suite byte-for-byte unchanged

## Versions

- `closure-pass-constant-fold` 0.26.0 → 0.28.0 (0.27 reserved by the open radix branch #6560)
- `closurec` 0.175.0 → 0.177.0 (above main 0.175 and the open radix branch 0.176/#6560)

Inline security review passed (cap unbypassable, fill loop terminates and stays in bounds, no panic paths).

🤖 Generated with [Claude Code](https://claude.com/claude-code)