### PR TITLE
feat(mycin-msk): new ADJ-only musculoskeletal special-test recall domain — 7 grounded test→diagnosis edges

### DIFF
--- a/code/specs/data/mycin-2026/recall/msk-edges.adj
+++ b/code/specs/data/mycin-2026/recall/msk-edges.adj
@@ -1,0 +1,92 @@
+% ============================================================================
+% msk-edges — the musculoskeletal special-test knowledge-graph (MYCIN-2026 MSK).
+% ============================================================================
+% A high-yield orthopedics/sports-medicine board domain: the physical-examination
+% special test (a named provocative maneuver) and the diagnosis it points to. "The
+% Lachman test is positive — what injury?" becomes the binding query
+%     ? special_test_indicates(lachman_test, $Diagnosis).
+%
+% Direction note: the relation is test -> diagnosis (`special_test_indicates`), the
+% board direction — a named maneuver is positive and you must name the lesion. The
+% cited spans read either way ("The Lachman test ... assess[es] the integrity of the
+% anterior cruciate ligament"; "A positive Trendelenburg sign usually indicates
+% weakness in the hip abductor muscles") — what matters for grounding is that one
+% self-contained span names BOTH the test AND the diagnosis. Each test here maps to
+% one canonical diagnosis, so a query binds a single answer (two distinct tests may
+% point to the same diagnosis — e.g. Phalen and Tinel both -> carpal tunnel).
+%
+% This file is the SHIPPED ARTIFACT and the SOLE source of truth — no generator, no
+% JSON, no manifest (a pure ADJ-only recall domain, like OPHTHO/ECG/URINE/RESP).
+% Each fact is a `relate` clause whose byte-provenance lives INLINE:
+%     source   — the VERBATIM span copied from the cited page (byte-stable: it
+%                appears character-for-character in the page's normalized text).
+%     locator  — the URL the span was read from (NCBI StatPearls / Bookshelf).
+%     trust    — authoritative (a primary, citable reference).
+% An LLM (or a human) recalls a fact by writing a tiny query .adj that `import`s
+% this library and asks a binding query — see msk-recall.query.adj. Nothing here is
+% asserted "from memory": every edge is defended by a span a reader can re-fetch and
+% check.
+% (See feedback_nothing_human_authored, feedback_adj_only_shipped_artifacts.)
+%
+% Honest scope: only tests whose page states the association in a clean self-
+% contained span (both test AND diagnosis named) are included. Deferred (re-checked,
+% the test and the lesion appear only in separate adjacent sentences):
+%   Thompson test -> Achilles tendon rupture (NBK430844 says "suspected rupture",
+%     never "Achilles tendon rupture" alongside "Thompson") — reused as the off-
+%     vocabulary abstention control;
+%   drop arm test -> rotator cuff tear (NBK547664/NBK531506/NBK441844/NBK532270 all
+%     split the maneuver from the tear).
+% ============================================================================
+
+dictionary msk_vocab {
+    define test      : entity   surface "special test", "provocative maneuver"
+    define diagnosis : entity   surface "musculoskeletal diagnosis", "injury or lesion"
+
+    define special_test_indicates : relation from test to diagnosis  % the lesion a positive test points to
+}
+
+rulebook msk_facts {
+    use msk_vocab
+
+    % --- McMurray test -> meniscal tear ----------------------------------------
+    relate special_test_indicates(mcmurray_test, meniscal_tear)
+        source "Regarding lateral meniscus tears, the McMurray test was the most sensitive (56.2%), while all other tests were equally specific."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK470549/"
+        trust authoritative
+
+    % --- Lachman test -> anterior cruciate ligament (ACL) tear -----------------
+    relate special_test_indicates(lachman_test, acl_tear)
+        source "The Lachman test is a physical examination maneuver used to assess the integrity of the anterior cruciate ligament in a suspected anterior cruciate ligament (ACL) injury."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK554415/"
+        trust authoritative
+
+    % --- Finkelstein test -> De Quervain tenosynovitis -------------------------
+    relate special_test_indicates(finkelstein_test, de_quervain_tenosynovitis)
+        source "Finkelstein's test is more reliable in diagnosing De Quervain tenosynovitis than the Eichhoff's test, but studies that have tested the reliability of the Finkelstein's test are currently very limited."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK539768/"
+        trust authoritative
+
+    % --- Phalen test -> carpal tunnel syndrome ---------------------------------
+    relate special_test_indicates(phalen_test, carpal_tunnel_syndrome)
+        source "Studies have also shown that Tinel's Sign is less useful in evaluating carpal tunnel syndrome compared to other provocative tests, such as Phalen's or Durkan's tests, which have a greater sensitivity and specificity."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK555934/"
+        trust authoritative
+
+    % --- Tinel sign -> carpal tunnel syndrome (distinct test, same diagnosis) ---
+    relate special_test_indicates(tinel_sign, carpal_tunnel_syndrome)
+        source "Although it is most associated with carpal tunnel syndrome, the Hoffman-Tinel sign is generalized, and an examiner can also elicit it in other known neuropathies such as tarsal tunnel syndrome, cubital tunnel syndrome, or Guyon canal syndrome."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK555934/"
+        trust authoritative
+
+    % --- Spurling test -> cervical radiculopathy -------------------------------
+    relate special_test_indicates(spurling_test, cervical_radiculopathy)
+        source "The Spurling test is a well-recognized provocative test that is routinely used in the evaluation of neck pain and cervical radiculopathy."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK493152/"
+        trust authoritative
+
+    % --- Trendelenburg sign -> hip abductor (gluteus medius) weakness ----------
+    relate special_test_indicates(trendelenburg_sign, hip_abductor_weakness)
+        source "A positive Trendelenburg sign usually indicates weakness in the hip abductor muscles, which consists of the gluteus medius and gluteus minimus."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK555987/"
+        trust authoritative
+}

--- a/code/specs/data/mycin-2026/recall/msk-recall.query.adj
+++ b/code/specs/data/mycin-2026/recall/msk-recall.query.adj
@@ -1,0 +1,23 @@
+% ============================================================================
+% msk-recall.query.adj — a worked recall query over the musculoskeletal library.
+% ============================================================================
+% The shape an LLM (or a clinician) produces to ANSWER a "this special test is
+% positive — which injury?" question: it states no orthopedics fact — it only
+% `import`s the grounded library and asks binding queries. The native adj-lang
+% engine resolves each `?` against the imported `relate` edges and returns the
+% binding + the citing clause's source/locator/trust. All knowledge is in the
+% library; none is here.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli msk-recall.query.adj
+% ============================================================================
+
+import "msk-edges.adj"
+
+? special_test_indicates(mcmurray_test, $Diagnosis)        % expect meniscal_tear
+? special_test_indicates(lachman_test, $Diagnosis)         % expect acl_tear
+? special_test_indicates(finkelstein_test, $Diagnosis)     % expect de_quervain_tenosynovitis
+? special_test_indicates(phalen_test, $Diagnosis)          % expect carpal_tunnel_syndrome
+? special_test_indicates(tinel_sign, $Diagnosis)           % expect carpal_tunnel_syndrome
+? special_test_indicates(spurling_test, $Diagnosis)        % expect cervical_radiculopathy
+? special_test_indicates(trendelenburg_sign, $Diagnosis)   % expect hip_abductor_weakness

--- a/code/specs/data/mycin-2026/recall/test_msk_recall.py
+++ b/code/specs/data/mycin-2026/recall/test_msk_recall.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""test_msk_recall.py — the ADJ-only musculoskeletal special-test recall library (MYCIN-2026 MSK).
+
+A new pure-ADJ recall domain (high-yield orthopedics/sports-medicine board content): the
+named physical-exam special test and the diagnosis it points to. `msk-edges.adj` is the
+SOLE source of truth — facts + byte-provenance inline, no Python gate, no JSON, no
+manifest. This test pins the property that matters: the native adj-lang engine, given a
+query .adj that only `import`s the library and asks binding queries (`msk-recall.query.adj`
+— the shape an LLM produces), binds the grounded diagnosis for each special test, each
+carrying an AUTHORITATIVE citation with a real source span + locator. Knowledge lives in
+ADJ; the engine answers.
+
+If the native CLI isn't built (a Python-only CI lane), the engine-backed checks skip —
+the file-shape checks (every clause grounded, no authored-debt) still run.
+
+Run:  python3 test_msk_recall.py
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+ADJ = HERE / "msk-edges.adj"
+QUERY = HERE / "msk-recall.query.adj"
+CLI = HERE.parents[3] / "packages" / "rust" / "target" / "debug" / "adj-lang-cli"
+
+# Every grounded edge: special test -> the diagnosis the library binds for it.
+# Two distinct tests may share a diagnosis (Phalen + Tinel -> carpal tunnel); each
+# test still binds exactly one diagnosis, so the single-answer property holds.
+EXPECTED = {
+    "mcmurray_test": "meniscal_tear",                 # NBK470549
+    "lachman_test": "acl_tear",                       # NBK554415
+    "finkelstein_test": "de_quervain_tenosynovitis",  # NBK539768
+    "phalen_test": "carpal_tunnel_syndrome",          # NBK555934
+    "tinel_sign": "carpal_tunnel_syndrome",           # NBK555934
+    "spurling_test": "cervical_radiculopathy",        # NBK493152
+    "trendelenburg_sign": "hip_abductor_weakness",    # NBK555987
+}
+REL = "special_test_indicates"
+VAR = "Diagnosis"
+
+
+def _cli_available() -> bool:
+    return CLI.exists()
+
+
+def _run(program: Path) -> dict:
+    out = subprocess.run([str(CLI), str(program)], capture_output=True, text=True,
+                         cwd=str(HERE), timeout=60)
+    assert out.returncode == 0, f"adj-lang-cli failed: {out.stderr}"
+    return json.loads(out.stdout)
+
+
+# ---- 1. the ADJ file is the artifact — every clause grounded, no authored-debt ----
+
+def test_library_is_pure_adj_and_fully_grounded() -> None:
+    text = ADJ.read_text()
+    assert "trust consensus" not in text, "MSK ships no authored-debt; ground or omit"
+    assert "[FLAG:" not in text
+    edge_count = len(EXPECTED)  # 7
+    assert text.count("    relate ") == edge_count
+    assert text.count("trust authoritative") == edge_count
+    assert text.count('\n        locator "') == edge_count
+    assert text.count('\n        source "') == edge_count
+    # every locator is an NCBI primary source
+    for line in text.splitlines():
+        line = line.strip()
+        if line.startswith("locator "):
+            assert "https://www.ncbi.nlm.nih.gov/" in line, f"non-NCBI locator: {line}"
+    assert not (HERE / "msk_edge_ground.py").exists()
+    assert not (HERE / "msk-edge-grounding.json").exists()
+    assert not (HERE / "msk-edge-manifest.json").exists()
+
+
+# ---- 2. the engine binds each diagnosis, each with an authoritative citation ----
+
+def test_engine_binds_every_diagnosis_with_authoritative_citation() -> None:
+    if not _cli_available():
+        return
+    result = _run(QUERY)
+    by_query = {r["query"]: r for r in result["recall"]}
+    for test, diagnosis in EXPECTED.items():
+        q = f"{REL}({test}, {VAR})"
+        r = by_query.get(q)
+        assert r is not None and not r["abstained"], f"{q} abstained — edge missing?"
+        bound = {}
+        for a in r["answers"]:
+            bound[a["bindings"][VAR]] = (a.get("citations") or [{}])[0]
+        assert set(bound) == {diagnosis}, f"{test}: bound {set(bound)} != {{{diagnosis}}}"
+        cite = bound[diagnosis]
+        assert cite.get("trust") == "authoritative", f"{test}/{diagnosis} not authoritative"
+        assert cite.get("source"), f"{test}/{diagnosis} has no source span"
+        assert cite.get("locator", "").startswith("https://www.ncbi.nlm.nih.gov/")
+
+
+# ---- 3. an off-vocabulary test abstains, never fabricates ---------------------------
+
+def test_unknown_test_abstains() -> None:
+    if not _cli_available():
+        return
+    import os
+    import tempfile
+    fd, path = tempfile.mkstemp(suffix=".adj", prefix=".msk_q_", dir=HERE)
+    try:
+        with os.fdopen(fd, "w") as fh:
+            # thompson_test is not in the library (deferred — see header) -> must abstain
+            fh.write(f'import "msk-edges.adj"\n? {REL}(thompson_test, ${VAR})\n')
+        res = _run(Path(path))
+        r = res["recall"][0] if res["recall"] else None
+        assert r is not None and r["abstained"], "an ungrounded test must abstain"
+    finally:
+        os.unlink(path)
+
+
+def _run_all() -> int:
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    failed = 0
+    for t in tests:
+        try:
+            t()
+            print(f"  PASS  {t.__name__}")
+        except AssertionError as exc:
+            failed += 1
+            print(f"  FAIL  {t.__name__}: {exc}")
+    print(f"\ntest_msk_recall: {len(tests) - failed}/{len(tests)} passed")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(_run_all())


### PR DESCRIPTION
## Summary
Adds a **brand-new pure-ADJ recall domain** for **orthopedic / sports-medicine special tests** — a high-yield physical-exam board topic previously absent from MYCIN-2026. The relation `special_test_indicates(test, diagnosis)` maps a named provocative maneuver to the lesion it points to.

7 byte-grounded edges, each defended by a single self-contained verbatim **NCBI StatPearls** span naming BOTH test AND diagnosis:

| special test | diagnosis | source |
|---|---|---|
| McMurray test | meniscal tear | NBK470549 |
| Lachman test | ACL tear | NBK554415 |
| Finkelstein test | De Quervain tenosynovitis | NBK539768 |
| Phalen test | carpal tunnel syndrome | NBK555934 |
| Tinel sign | carpal tunnel syndrome | NBK555934 |
| Spurling test | cervical radiculopathy | NBK493152 |
| Trendelenburg sign | hip abductor weakness | NBK555987 |

## Notes
- Two distinct tests (**Phalen, Tinel**) point to the same diagnosis (carpal tunnel syndrome); each test still binds exactly one diagnosis, so the single-answer property holds.
- Ships as the standard trio; self-contained (no `board_eval` coupling, no manifest, no JSON). CI auto-discovers `recall/test_*.py`.
- **Honest deferrals** documented inline (test & lesion only in separate adjacent sentences): Thompson test→Achilles tendon rupture (NBK430844 says "suspected rupture" only) — reused as the abstention control; drop arm test→rotator cuff tear.

## Verification
- `cargo build -p adj-lang-cli` ✓
- `test_msk_recall.py` → **3/3** (engine binds all 7 with authoritative NCBI citations; control abstains) ✓
- `ruff check` clean ✓
- Security review passed ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)