### PR TITLE
feat(mycin-psych): new ADJ-only psychopharmacology recall domain — 6 grounded drug→adverse-effect edges

### DIFF
--- a/code/specs/data/mycin-2026/recall/psych-edges.adj
+++ b/code/specs/data/mycin-2026/recall/psych-edges.adj
@@ -1,0 +1,90 @@
+% ============================================================================
+% psych-edges — the psychopharmacology adverse-effect graph (MYCIN-2026 PSYCH).
+% ============================================================================
+% A high-yield psychiatry board domain: the psychotropic drug (or drug class) and
+% the characteristic adverse effect it causes. "A patient on clozapine — what is the
+% feared adverse effect?" becomes the binding query
+%     ? drug_adverse_effect(clozapine, $Effect).
+%
+% Direction note: the relation is drug -> effect (`drug_adverse_effect`), the board
+% direction — the history names the drug and you must name its signature toxicity.
+% The cited spans read either way ("clozapine is the adverse effect of
+% agranulocytosis..."; "MAOIs can trigger a hypertensive crisis...") — what matters
+% for grounding is that one self-contained span AFFIRMATIVELY names BOTH the drug AND
+% the effect. Each drug here maps to one canonical adverse effect, so a query binds a
+% single answer.
+%
+% This file is the SHIPPED ARTIFACT and the SOLE source of truth — no generator, no
+% JSON, no manifest (a pure ADJ-only recall domain, like MSK/OPHTHO/ECG/URINE). Each
+% fact is a `relate` clause whose byte-provenance lives INLINE:
+%     source   — the VERBATIM span copied from the cited page (byte-stable: it
+%                appears character-for-character in the page's normalized text;
+%                where the span quotes a token, the inner ASCII quotes are
+%                backslash-escaped so the ADJ string still parses).
+%     locator  — the URL the span was read from (NCBI StatPearls / Bookshelf).
+%     trust    — authoritative (a primary, citable reference).
+% An LLM (or a human) recalls a fact by writing a tiny query .adj that `import`s
+% this library and asks a binding query — see psych-recall.query.adj. Nothing here
+% is asserted "from memory": every edge is defended by a span a reader can re-fetch
+% and check.
+% (See feedback_nothing_human_authored, feedback_adj_only_shipped_artifacts.)
+%
+% Faithful atoms: where the page names the drug-class only by its mechanism, the
+% atom follows the span — dopamine_receptor_antagonists (= antipsychotics) for NMS,
+% and the effect for TCA overdose is qrs_prolongation (the exact phrase the page
+% uses), not the broader word "cardiotoxicity".
+%
+% Honest scope: only drugs whose page states the association in a clean self-
+% contained AFFIRMATIVE span (both drug AND the spelled-out effect named) are
+% included. Deferred (re-checked): haloperidol -> tardive dyskinesia (NBK560892
+% names the drug only beside the abbreviation "TD", never the spelled-out effect) —
+% reused as the off-vocabulary abstention control; lamotrigine -> Stevens-Johnson
+% syndrome (NBK470442 splits the drug name from the SJS mention).
+% ============================================================================
+
+dictionary psych_vocab {
+    define drug   : entity   surface "psychotropic drug", "drug class"
+    define effect : entity   surface "adverse effect", "drug toxicity"
+
+    define drug_adverse_effect : relation from drug to effect  % the signature toxicity a psychotropic causes
+}
+
+rulebook psych_facts {
+    use psych_vocab
+
+    % --- lithium -> nephrogenic diabetes insipidus -----------------------------
+    relate drug_adverse_effect(lithium, nephrogenic_diabetes_insipidus)
+        source "Chronic therapy with lithium can precipitate nephrogenic diabetes insipidus, which might elicit a cascade of symptoms and signs of lithium toxicity."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK499992/"
+        trust authoritative
+
+    % --- clozapine -> agranulocytosis ------------------------------------------
+    relate drug_adverse_effect(clozapine, agranulocytosis)
+        source "One of the most significant concerns for clozapine is the adverse effect of agranulocytosis, which requires cessation of therapy and hematology consultation."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK535399/"
+        trust authoritative
+
+    % --- valproate (valproic acid) -> hepatotoxicity ---------------------------
+    relate drug_adverse_effect(valproate, hepatotoxicity)
+        source "Acute valproate toxicity can result in dose-related and reversible hepatotoxicity."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK560898/"
+        trust authoritative
+
+    % --- MAOIs -> hypertensive crisis (tyramine reaction) ----------------------
+    relate drug_adverse_effect(maoi, hypertensive_crisis)
+        source "MAOIs can trigger a hypertensive crisis if patients consume foods or beverages high in tyramine or are exposed to specific pharmacologic agents."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK539848/"
+        trust authoritative
+
+    % --- tricyclic antidepressants -> QRS prolongation (overdose cardiotoxicity) -
+    relate drug_adverse_effect(tricyclic_antidepressants, qrs_prolongation)
+        source "The characteristic QRS prolongation seen in TCA overdose occurs secondary to prolongation of phase \"0\" of the myocardial action potential."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK430931/"
+        trust authoritative
+
+    % --- dopamine-receptor antagonists (antipsychotics) -> neuroleptic malignant syndrome -
+    relate drug_adverse_effect(dopamine_receptor_antagonists, neuroleptic_malignant_syndrome)
+        source "Neuroleptic malignant syndrome (NMS) is a life-threatening syndrome associated with the use of dopamine-receptor antagonist medications or with rapid withdrawal of dopaminergic medications."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK482282/"
+        trust authoritative
+}

--- a/code/specs/data/mycin-2026/recall/psych-recall.query.adj
+++ b/code/specs/data/mycin-2026/recall/psych-recall.query.adj
@@ -1,0 +1,22 @@
+% ============================================================================
+% psych-recall.query.adj — a worked recall query over the psychopharmacology library.
+% ============================================================================
+% The shape an LLM (or a clinician) produces to ANSWER a "what is this drug's
+% signature adverse effect?" question: it states no psychiatry fact — it only
+% `import`s the grounded library and asks binding queries. The native adj-lang
+% engine resolves each `?` against the imported `relate` edges and returns the
+% binding + the citing clause's source/locator/trust. All knowledge is in the
+% library; none is here.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli psych-recall.query.adj
+% ============================================================================
+
+import "psych-edges.adj"
+
+? drug_adverse_effect(lithium, $Effect)                        % expect nephrogenic_diabetes_insipidus
+? drug_adverse_effect(clozapine, $Effect)                      % expect agranulocytosis
+? drug_adverse_effect(valproate, $Effect)                      % expect hepatotoxicity
+? drug_adverse_effect(maoi, $Effect)                           % expect hypertensive_crisis
+? drug_adverse_effect(tricyclic_antidepressants, $Effect)      % expect qrs_prolongation
+? drug_adverse_effect(dopamine_receptor_antagonists, $Effect)  % expect neuroleptic_malignant_syndrome

--- a/code/specs/data/mycin-2026/recall/test_psych_recall.py
+++ b/code/specs/data/mycin-2026/recall/test_psych_recall.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""test_psych_recall.py — the ADJ-only psychopharmacology recall library (MYCIN-2026 PSYCH).
+
+A new pure-ADJ recall domain (high-yield psychiatry board content): the psychotropic
+drug (or class) and the characteristic adverse effect it causes. `psych-edges.adj` is the
+SOLE source of truth — facts + byte-provenance inline, no Python gate, no JSON, no
+manifest. This test pins the property that matters: the native adj-lang engine, given a
+query .adj that only `import`s the library and asks binding queries (`psych-recall.query.adj`
+— the shape an LLM produces), binds the grounded adverse effect for each drug, each
+carrying an AUTHORITATIVE citation with a real source span + locator. Knowledge lives in
+ADJ; the engine answers.
+
+If the native CLI isn't built (a Python-only CI lane), the engine-backed checks skip —
+the file-shape checks (every clause grounded, no authored-debt) still run.
+
+Run:  python3 test_psych_recall.py
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+ADJ = HERE / "psych-edges.adj"
+QUERY = HERE / "psych-recall.query.adj"
+CLI = HERE.parents[3] / "packages" / "rust" / "target" / "debug" / "adj-lang-cli"
+
+# Every grounded edge: psychotropic drug -> the adverse effect the library binds.
+EXPECTED = {
+    "lithium": "nephrogenic_diabetes_insipidus",                       # NBK499992
+    "clozapine": "agranulocytosis",                                    # NBK535399
+    "valproate": "hepatotoxicity",                                     # NBK560898
+    "maoi": "hypertensive_crisis",                                     # NBK539848
+    "tricyclic_antidepressants": "qrs_prolongation",                   # NBK430931
+    "dopamine_receptor_antagonists": "neuroleptic_malignant_syndrome",  # NBK482282
+}
+REL = "drug_adverse_effect"
+VAR = "Effect"
+
+
+def _cli_available() -> bool:
+    return CLI.exists()
+
+
+def _run(program: Path) -> dict:
+    out = subprocess.run([str(CLI), str(program)], capture_output=True, text=True,
+                         cwd=str(HERE), timeout=60)
+    assert out.returncode == 0, f"adj-lang-cli failed: {out.stderr}"
+    return json.loads(out.stdout)
+
+
+# ---- 1. the ADJ file is the artifact — every clause grounded, no authored-debt ----
+
+def test_library_is_pure_adj_and_fully_grounded() -> None:
+    text = ADJ.read_text()
+    assert "trust consensus" not in text, "PSYCH ships no authored-debt; ground or omit"
+    assert "[FLAG:" not in text
+    edge_count = len(EXPECTED)  # 6
+    assert text.count("    relate ") == edge_count
+    assert text.count("trust authoritative") == edge_count
+    assert text.count('\n        locator "') == edge_count
+    assert text.count('\n        source "') == edge_count
+    # every locator is an NCBI primary source
+    for line in text.splitlines():
+        line = line.strip()
+        if line.startswith("locator "):
+            assert "https://www.ncbi.nlm.nih.gov/" in line, f"non-NCBI locator: {line}"
+    assert not (HERE / "psych_edge_ground.py").exists()
+    assert not (HERE / "psych-edge-grounding.json").exists()
+    assert not (HERE / "psych-edge-manifest.json").exists()
+
+
+# ---- 2. the engine binds each adverse effect, each with an authoritative citation ----
+
+def test_engine_binds_every_effect_with_authoritative_citation() -> None:
+    if not _cli_available():
+        return
+    result = _run(QUERY)
+    by_query = {r["query"]: r for r in result["recall"]}
+    for drug, effect in EXPECTED.items():
+        q = f"{REL}({drug}, {VAR})"
+        r = by_query.get(q)
+        assert r is not None and not r["abstained"], f"{q} abstained — edge missing?"
+        bound = {}
+        for a in r["answers"]:
+            bound[a["bindings"][VAR]] = (a.get("citations") or [{}])[0]
+        assert set(bound) == {effect}, f"{drug}: bound {set(bound)} != {{{effect}}}"
+        cite = bound[effect]
+        assert cite.get("trust") == "authoritative", f"{drug}/{effect} not authoritative"
+        assert cite.get("source"), f"{drug}/{effect} has no source span"
+        assert cite.get("locator", "").startswith("https://www.ncbi.nlm.nih.gov/")
+
+
+# ---- 3. an off-vocabulary drug abstains, never fabricates ---------------------------
+
+def test_unknown_drug_abstains() -> None:
+    if not _cli_available():
+        return
+    import os
+    import tempfile
+    fd, path = tempfile.mkstemp(suffix=".adj", prefix=".psych_q_", dir=HERE)
+    try:
+        with os.fdopen(fd, "w") as fh:
+            # haloperidol is not in the library (deferred — see header) -> must abstain
+            fh.write(f'import "psych-edges.adj"\n? {REL}(haloperidol, ${VAR})\n')
+        res = _run(Path(path))
+        r = res["recall"][0] if res["recall"] else None
+        assert r is not None and r["abstained"], "an ungrounded drug must abstain"
+    finally:
+        os.unlink(path)
+
+
+def _run_all() -> int:
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    failed = 0
+    for t in tests:
+        try:
+            t()
+            print(f"  PASS  {t.__name__}")
+        except AssertionError as exc:
+            failed += 1
+            print(f"  FAIL  {t.__name__}: {exc}")
+    print(f"\ntest_psych_recall: {len(tests) - failed}/{len(tests)} passed")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(_run_all())


### PR DESCRIPTION
## Summary
Adds a **brand-new pure-ADJ recall domain** for **psychopharmacology** — a high-yield psychiatry board topic previously absent from MYCIN-2026. The relation `drug_adverse_effect(drug, effect)` maps a psychotropic drug (or class) to its signature toxicity.

6 byte-grounded edges, each defended by a single self-contained verbatim **NCBI StatPearls** span affirmatively naming BOTH drug AND effect:

| drug | adverse effect | source |
|---|---|---|
| lithium | nephrogenic diabetes insipidus | NBK499992 |
| clozapine | agranulocytosis | NBK535399 |
| valproate | hepatotoxicity | NBK560898 |
| MAOIs | hypertensive crisis | NBK539848 |
| tricyclic antidepressants | QRS prolongation | NBK430931 |
| dopamine-receptor antagonists | neuroleptic malignant syndrome | NBK482282 |

## Notes
- **Faithful atoms**: where the page names the drug-class only by mechanism, the atom follows the span — `dopamine_receptor_antagonists` (= antipsychotics) for NMS; and the TCA-overdose effect is `qrs_prolongation` (the exact phrase the page uses), not the broader word "cardiotoxicity".
- The TCA source quotes `phase "0"` of the action potential; inner ASCII quotes are backslash-escaped so the ADJ string parses — engine round-trips them faithfully (verified).
- Ships as the standard trio; self-contained (no `board_eval` coupling, no manifest, no JSON). CI auto-discovers `recall/test_*.py`.
- **Honest deferrals** documented inline: haloperidol→tardive dyskinesia (NBK560892 uses the abbreviation "TD") — reused as the abstention control; lamotrigine→Stevens-Johnson syndrome (NBK470442 splits them).

## Verification
- `cargo build -p adj-lang-cli` ✓
- `test_psych_recall.py` → **3/3** (engine binds all 6 with authoritative NCBI citations; control abstains) ✓
- `ruff check` clean ✓
- Security review passed ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)