### PR TITLE
test(x86-sim): ALGOL `sign` runs on the simulator (LANG-FULL AL8 follow-up)

### DIFF
--- a/code/packages/rust/x86-simulator/CHANGELOG.md
+++ b/code/packages/rust/x86-simulator/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog — x86-simulator
 
+## 0.7.5 — 2026-06-22 — ALGOL `sign` cell (LANG-FULL AL8 follow-up)
+
+Adds an executed matrix cell `algol_sign_runs_on_x86_sim`: the ALGOL `sign`
+standard function (LANG-FULL AL8, merged) run as real x86_64 machine code on the
+simulator — `43 + sign(0 - 1)` ⇒ exit `42`. Where the `algol_abs` cell (0.7.4)
+merges a value out of **two** branch arms, `sign` lowers to a *nested* conditional
+(`if E>0 then 1 else if E<0 then -1 else 0`) and merges across **three** arms — so
+this is the first cell to run a three-way value-merge from native code. With the
+abs cell, both AL8 standard functions now execute locally on the x86_64 backend.
+Test-only; no library change.
+
 ## 0.7.4 — 2026-06-22 — ALGOL `abs` cell (LANG-FULL AL8 follow-up)
 
 Adds an executed matrix cell `algol_abs_runs_on_x86_sim`: the ALGOL `abs`

--- a/code/packages/rust/x86-simulator/Cargo.toml
+++ b/code/packages/rust/x86-simulator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "x86-simulator"
-version = "0.7.4"
+version = "0.7.5"
 edition = "2021"
 description = "x86/x86-64 runtime simulator — decode + execute machine code, and run the x86_64-backend's emitted code locally (host-arch-independent)"
 

--- a/code/packages/rust/x86-simulator/tests/lang_matrix_x86.rs
+++ b/code/packages/rust/x86-simulator/tests/lang_matrix_x86.rs
@@ -398,6 +398,21 @@ fn algol_abs_runs_on_x86_sim() {
     assert_eq!(run_on_x86_sim(Language::Algol60, src), 42);
 }
 
+/// ALGOL — the **`sign` standard function** (LANG-FULL AL8) on the x86_64
+/// backend.  `sign` lowers to the *nested* conditional `if E > 0 then 1 else
+/// if E < 0 then -1 else 0` — two compares (`cmp_gt`, `cmp_lt`) and three
+/// `i64` constants moved into one slot across three branch arms.  Where the
+/// `algol_abs` cell merges a value out of **two** arms, this runs the **three**-
+/// way merge from real x86_64 machine code.  `43 + sign(0 - 1)` = 43 + (-1) =
+/// 42 ⇒ exit 42 proves the negative arm (-1) and the join produce correct
+/// native code.  Together with `algol_abs_runs_on_x86_sim` this exercises both
+/// AL8 standard functions locally on the x86_64 backend.
+#[test]
+fn algol_sign_runs_on_x86_sim() {
+    let src = "begin integer result; result := 43 + sign(0 - 1) end";
+    assert_eq!(run_on_x86_sim(Language::Algol60, src), 42);
+}
+
 /// Brainfuck — build 65 on the tape and `putchar` it (`++++++++[>++++++++<-]>+.`
 /// ⇒ stdout `A`).  Exercises the **byte-tape** opcode surface the arithmetic
 /// programs never touch: `__twig_alloc_bytes` for the tape, 8-bit load/store


### PR DESCRIPTION
## What

Adds the matrix cell `algol_sign_runs_on_x86_sim`: the ALGOL `sign` standard function ([#6567](https://github.com/adhithyan15/coding-adventures/pull/6567), merged) run as **real x86_64 machine code on the simulator** — `43 + sign(0 - 1)` ⇒ exit `42`.

## Why

Completes the AL8 local-execution story (the `abs` cell merged in [#6568](https://github.com/adhithyan15/coding-adventures/pull/6568)). `sign` lowers to a *nested* conditional — `if E > 0 then 1 else if E < 0 then -1 else 0` — so where the `abs` cell merges a value out of **two** branch arms, this runs the **three**-way value-merge from native code (two `cmp`s + three `i64` consts into one slot). `43 + (-1) = 42` exercises the negative arm and the join.

## Scope

Test-only. No library/`src` change. Bumps `x86-simulator` 0.7.4 → 0.7.5 for the changelog entry. Lives in `lang_matrix_x86.rs`.

## Verification

- `cargo test -p x86-simulator --test lang_matrix_x86` — **27 passed, 0 failed**.
- Security review: PASSED (test-only, fixed input).

🤖 Generated with [Claude Code](https://claude.com/claude-code)