### PR TITLE
feat(mycin-tox): new ADJ-only toxidrome recall domain — 6 grounded toxidrome→agent edges

### DIFF
--- a/code/specs/data/mycin-2026/recall/test_tox_recall.py
+++ b/code/specs/data/mycin-2026/recall/test_tox_recall.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""test_tox_recall.py — the ADJ-only toxidrome recall library (MYCIN-2026 TOX).
+
+A new pure-ADJ recall domain (core emergency-medicine/pharmacology board content):
+the classic toxidrome and the agent class that causes it. `tox-edges.adj` is the SOLE
+source of truth — facts + byte-provenance inline, no Python gate, no JSON, no manifest.
+This test pins the property that matters: the native adj-lang engine, given a query .adj
+that only `import`s the library and asks binding queries (`tox-recall.query.adj` — the
+shape an LLM produces), binds the grounded agent for each toxidrome, each carrying an
+AUTHORITATIVE citation with a real source span + locator. Knowledge lives in ADJ; the
+engine answers.
+
+If the native CLI isn't built (a Python-only CI lane), the engine-backed checks skip —
+the file-shape checks (every clause grounded, no authored-debt) still run.
+
+Run:  python3 test_tox_recall.py
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+ADJ = HERE / "tox-edges.adj"
+QUERY = HERE / "tox-recall.query.adj"
+CLI = HERE.parents[3] / "packages" / "rust" / "target" / "debug" / "adj-lang-cli"
+
+# Every grounded edge: toxidrome -> the agent class the library binds for it.
+EXPECTED = {
+    "cholinergic_toxidrome": "organophosphates",                  # NBK539783
+    "anticholinergic_toxidrome": "tricyclic_antidepressants",     # NBK534798
+    "sympathomimetic_toxidrome": "cocaine_amphetamines",          # NBK430757
+    "opioid_toxidrome": "opioids",                                # NBK470415
+    "serotonin_syndrome": "monoamine_oxidase_inhibitors",         # NBK482377
+    "sedative_hypnotic_toxidrome": "benzodiazepines",             # NBK482238
+}
+REL = "toxidrome_caused_by"
+VAR = "Agent"
+
+
+def _cli_available() -> bool:
+    return CLI.exists()
+
+
+def _run(program: Path) -> dict:
+    out = subprocess.run([str(CLI), str(program)], capture_output=True, text=True,
+                         cwd=str(HERE), timeout=60)
+    assert out.returncode == 0, f"adj-lang-cli failed: {out.stderr}"
+    return json.loads(out.stdout)
+
+
+# ---- 1. the ADJ file is the artifact — every clause grounded, no authored-debt ----
+
+def test_library_is_pure_adj_and_fully_grounded() -> None:
+    text = ADJ.read_text()
+    assert "trust consensus" not in text, "TOX ships no authored-debt; ground or omit"
+    assert "[FLAG:" not in text
+    edge_count = len(EXPECTED)  # 6
+    assert text.count("    relate ") == edge_count
+    assert text.count("trust authoritative") == edge_count
+    assert text.count('\n        locator "') == edge_count
+    assert text.count('\n        source "') == edge_count
+    # every locator is an NCBI primary source
+    for line in text.splitlines():
+        line = line.strip()
+        if line.startswith("locator "):
+            assert "https://www.ncbi.nlm.nih.gov/" in line, f"non-NCBI locator: {line}"
+    assert not (HERE / "tox_edge_ground.py").exists()
+    assert not (HERE / "tox-edge-grounding.json").exists()
+    assert not (HERE / "tox-edge-manifest.json").exists()
+
+
+# ---- 2. the engine binds each agent, each with an authoritative citation ----------
+
+def test_engine_binds_every_agent_with_authoritative_citation() -> None:
+    if not _cli_available():
+        return
+    result = _run(QUERY)
+    by_query = {r["query"]: r for r in result["recall"]}
+    for toxidrome, agent in EXPECTED.items():
+        q = f"{REL}({toxidrome}, {VAR})"
+        r = by_query.get(q)
+        assert r is not None and not r["abstained"], f"{q} abstained — edge missing?"
+        bound = {}
+        for a in r["answers"]:
+            bound[a["bindings"][VAR]] = (a.get("citations") or [{}])[0]
+        assert set(bound) == {agent}, f"{toxidrome}: bound {set(bound)} != {{{agent}}}"
+        cite = bound[agent]
+        assert cite.get("trust") == "authoritative", f"{toxidrome}/{agent} not authoritative"
+        assert cite.get("source"), f"{toxidrome}/{agent} has no source span"
+        assert cite.get("locator", "").startswith("https://www.ncbi.nlm.nih.gov/")
+
+
+# ---- 3. an off-vocabulary toxidrome abstains, never fabricates ----------------------
+
+def test_unknown_toxidrome_abstains() -> None:
+    if not _cli_available():
+        return
+    import os
+    import tempfile
+    fd, path = tempfile.mkstemp(suffix=".adj", prefix=".tox_q_", dir=HERE)
+    try:
+        with os.fdopen(fd, "w") as fh:
+            # salicylate_toxicity is not in the library (held — see header) -> must abstain
+            fh.write(f'import "tox-edges.adj"\n? {REL}(salicylate_toxicity, ${VAR})\n')
+        res = _run(Path(path))
+        r = res["recall"][0] if res["recall"] else None
+        assert r is not None and r["abstained"], "an ungrounded toxidrome must abstain"
+    finally:
+        os.unlink(path)
+
+
+def _run_all() -> int:
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    failed = 0
+    for t in tests:
+        try:
+            t()
+            print(f"  PASS  {t.__name__}")
+        except AssertionError as exc:
+            failed += 1
+            print(f"  FAIL  {t.__name__}: {exc}")
+    print(f"\ntest_tox_recall: {len(tests) - failed}/{len(tests)} passed")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(_run_all())

--- a/code/specs/data/mycin-2026/recall/tox-edges.adj
+++ b/code/specs/data/mycin-2026/recall/tox-edges.adj
@@ -1,0 +1,91 @@
+% ============================================================================
+% tox-edges — the toxidrome knowledge-graph (MYCIN-2026 TOX).
+% ============================================================================
+% A core emergency-medicine/pharmacology board domain: the classic toxidrome
+% (the recognizable cluster of vital-sign and exam findings of a poisoning) and
+% the agent class that causes it. "A patient with miosis, respiratory depression,
+% and CNS depression — which toxidrome / agent?" reduces to the binding query
+%     ? toxidrome_caused_by(opioid_toxidrome, $Agent).
+%
+% Direction note: the relation is toxidrome -> agent (`toxidrome_caused_by`), the
+% board direction — you recognize the toxidrome at the bedside and must name the
+% culprit drug class. The cited spans read agent-first or toxidrome-first ("The
+% most common cause of cholinergic toxicity ... is exposure to organophosphate ...
+% insecticides"; "Opiate overdose also leads to respiratory depression ... and
+% miosis") — what matters for grounding is that one self-contained span names BOTH
+% the toxidrome AND the causative agent. Each toxidrome here maps to one canonical
+% agent class, so a query binds a single answer.
+%
+% This file is the SHIPPED ARTIFACT and the SOLE source of truth — no generator, no
+% JSON, no manifest (a pure ADJ-only recall domain, like PSYCH/MSK/OPHTHO/ECG/URINE).
+% Each fact is a `relate` clause whose byte-provenance lives INLINE:
+%     source   — the VERBATIM span copied from the cited page (byte-stable: it
+%                appears character-for-character in the page's normalized text).
+%     locator  — the URL the span was read from (NCBI StatPearls / Bookshelf).
+%     trust    — authoritative (a primary, citable reference).
+% An LLM (or a human) recalls a fact by writing a tiny query .adj that `import`s
+% this library and asks a binding query — see tox-recall.query.adj. Nothing here is
+% asserted "from memory": every edge is defended by a span a reader can re-fetch and
+% check.
+% (See feedback_nothing_human_authored, feedback_adj_only_shipped_artifacts.)
+%
+% Faithful atoms: where a page co-names the toxidrome only with a specific agent,
+% the atom follows the span — anticholinergic_toxidrome -> tricyclic_antidepressants
+% (the page's self-contained sentence names TCAs), and serotonin_syndrome ->
+% monoamine_oxidase_inhibitors (the only self-contained co-naming sentence names
+% MAOIs as the most severe cause).
+%
+% Honest scope: only toxidromes whose page states the association in a clean self-
+% contained AFFIRMATIVE span (both toxidrome AND agent named) are included. Held:
+% salicylate (aspirin) toxicity — well grounded (NBK519032: "Aspirin causes high
+% anion gap metabolic acidosis and respiratory alkalosis."), but that edge is
+% agent->lab-pattern, the opposite direction of this toxidrome->agent relation, so
+% it is reused as the off-vocabulary abstention control rather than mixed in here.
+% ============================================================================
+
+dictionary tox_vocab {
+    define toxidrome : entity   surface "toxidrome", "poisoning syndrome"
+    define agent     : entity   surface "causative agent", "drug or toxin class"
+
+    define toxidrome_caused_by : relation from toxidrome to agent  % the agent class a toxidrome points to
+}
+
+rulebook tox_facts {
+    use tox_vocab
+
+    % --- cholinergic toxidrome -> organophosphates -----------------------------
+    relate toxidrome_caused_by(cholinergic_toxidrome, organophosphates)
+        source "The most common cause of cholinergic toxicity worldwide is exposure to organophosphate and carbamate insecticides."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK539783/"
+        trust authoritative
+
+    % --- anticholinergic toxidrome -> tricyclic antidepressants ----------------
+    relate toxidrome_caused_by(anticholinergic_toxidrome, tricyclic_antidepressants)
+        source "Pure anticholinergic toxicity versus mixed toxicity, as seen with tricyclic antidepressants and phenothiazines, should be considered."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK534798/"
+        trust authoritative
+
+    % --- sympathomimetic toxidrome -> cocaine / amphetamines -------------------
+    relate toxidrome_caused_by(sympathomimetic_toxidrome, cocaine_amphetamines)
+        source "The etiology of acute sympathomimetic toxicity is exposure to a stimulant, with the most commonly encountered being amphetamines, cocaine, arylcyclohexylamines such as phencyclidine, and cathinones."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK430757/"
+        trust authoritative
+
+    % --- opioid toxidrome -> opioids -------------------------------------------
+    relate toxidrome_caused_by(opioid_toxidrome, opioids)
+        source "Opiate overdose also leads to respiratory depression, generalized central nervous system (CNS) impairment, and miosis."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK470415/"
+        trust authoritative
+
+    % --- serotonin syndrome -> monoamine oxidase inhibitors --------------------
+    relate toxidrome_caused_by(serotonin_syndrome, monoamine_oxidase_inhibitors)
+        source "Monoamine oxidase inhibitors are a class of antidepressants that inhibit the metabolism of serotonin and, when implicated in serotonin syndrome, tend to cause the most severe cases."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK482377/"
+        trust authoritative
+
+    % --- sedative-hypnotic toxidrome -> benzodiazepines ------------------------
+    relate toxidrome_caused_by(sedative_hypnotic_toxidrome, benzodiazepines)
+        source "Patients with benzodiazepine toxicity will primarily present with central nervous system depression ranging from mild drowsiness to a coma-like, stuporous state."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK482238/"
+        trust authoritative
+}

--- a/code/specs/data/mycin-2026/recall/tox-recall.query.adj
+++ b/code/specs/data/mycin-2026/recall/tox-recall.query.adj
@@ -1,0 +1,21 @@
+% ============================================================================
+% tox-recall.query.adj — a worked recall query over the toxidrome library.
+% ============================================================================
+% The shape an LLM (or a clinician) produces to ANSWER a "this toxidrome is caused
+% by which agent class?" question: it states no toxicology fact — it only `import`s
+% the grounded library and asks binding queries. The native adj-lang engine resolves
+% each `?` against the imported `relate` edges and returns the binding + the citing
+% clause's source/locator/trust. All knowledge is in the library; none is here.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli tox-recall.query.adj
+% ============================================================================
+
+import "tox-edges.adj"
+
+? toxidrome_caused_by(cholinergic_toxidrome, $Agent)        % expect organophosphates
+? toxidrome_caused_by(anticholinergic_toxidrome, $Agent)    % expect tricyclic_antidepressants
+? toxidrome_caused_by(sympathomimetic_toxidrome, $Agent)    % expect cocaine_amphetamines
+? toxidrome_caused_by(opioid_toxidrome, $Agent)             % expect opioids
+? toxidrome_caused_by(serotonin_syndrome, $Agent)           % expect monoamine_oxidase_inhibitors
+? toxidrome_caused_by(sedative_hypnotic_toxidrome, $Agent)  % expect benzodiazepines


### PR DESCRIPTION
## Summary
Adds a **brand-new pure-ADJ recall domain** for **toxidromes** — a core emergency-medicine/pharmacology board topic previously absent from MYCIN-2026. The relation `toxidrome_caused_by(toxidrome, agent)` maps a recognizable poisoning syndrome to the agent class that causes it.

6 byte-grounded edges, each defended by a single self-contained verbatim **NCBI StatPearls** span naming BOTH toxidrome AND agent:

| toxidrome | agent class | source |
|---|---|---|
| cholinergic | organophosphates | NBK539783 |
| anticholinergic | tricyclic antidepressants | NBK534798 |
| sympathomimetic | cocaine / amphetamines | NBK430757 |
| opioid | opioids | NBK470415 |
| serotonin syndrome | monoamine oxidase inhibitors | NBK482377 |
| sedative-hypnotic | benzodiazepines | NBK482238 |

## Notes
- **Faithful atoms**: where a page co-names the toxidrome only with a specific agent, the atom follows the span — anticholinergic→TCAs, serotonin syndrome→MAOIs (the only self-contained co-naming sentence names MAOIs as the most severe cause).
- Ships as the standard trio; self-contained (no `board_eval` coupling, no manifest, no JSON). CI auto-discovers `recall/test_*.py`.
- **Held**: salicylate (aspirin) toxicity is well grounded (NBK519032) but is agent→lab-pattern — the *opposite* direction of this toxidrome→agent relation — so it's reused as the abstention control rather than mixed in.

## Verification
- `cargo build -p adj-lang-cli` ✓
- `test_tox_recall.py` → **3/3** (engine binds all 6 with authoritative NCBI citations; `salicylate_toxicity` control abstains) ✓
- `ruff check` clean ✓
- Security review passed ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)