### PR TITLE
feat(lang-full): E8 numeric conversions PR-1 — interpreter-ir + vm-core + JIT

### DIFF
--- a/code/packages/rust/interpreter-ir/CHANGELOG.md
+++ b/code/packages/rust/interpreter-ir/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog — interpreter-ir
 
+## [0.8.0] — 2026-06-22 (LANG-FULL E8 — numeric conversion opcodes, PR-1)
+
+Defines the three `integer`↔`real` conversion opcodes in the shared op-classifier
+(`opcodes.rs`), so downstream passes recognise them as a category (spec
+`code/specs/lang-full-e8-numeric-conversions.md`).
+
+- New **`is_conversion(op)`** predicate covering `int_to_real`,
+  `real_to_int_trunc`, `real_to_int_floor` — distinct from the width-masking
+  `is_coercion` (`cast`/`type_assert`) because these change the numeric
+  *representation* and the `real → integer` direction traps on out-of-range.
+- All three registered in `is_value_producing` (each yields a `dest`).
+- Doctest + the existing category coverage stays exhaustive (no silent gaps).
+
 ## [0.7.0] — 2026-06-20 (LANG-FULL E5 — array primitive)
 
 ### Added — `array<T>` type + four array opcodes

--- a/code/packages/rust/interpreter-ir/Cargo.toml
+++ b/code/packages/rust/interpreter-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "interpreter-ir"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
 description = "InterpreterIR (IIR) — the bytecode for the LANG JIT/AOT pipeline"
 

--- a/code/packages/rust/interpreter-ir/src/opcodes.rs
+++ b/code/packages/rust/interpreter-ir/src/opcodes.rs
@@ -282,6 +282,28 @@ pub fn is_coercion(op: &str) -> bool {
     matches!(op, "cast" | "type_assert")
 }
 
+/// Numeric conversions between `integer` and `real` (LANG-FULL E8).
+///
+/// Unlike the width-masking `cast` (`is_coercion`), these change the numeric
+/// *representation*, and the `real → integer` direction traps (fail-closed) on
+/// a non-finite or out-of-range operand rather than wrapping.
+///
+/// | Opcode | Direction | Rounding |
+/// |--------|-----------|----------|
+/// | `int_to_real`       | `i64` → `f64` | exact (IEEE-754) |
+/// | `real_to_int_trunc` | `f64` → `i64` | toward zero (`INT()`) |
+/// | `real_to_int_floor` | `f64` → `i64` | toward −∞ (ALGOL `entier`) |
+///
+/// ```
+/// use interpreter_ir::opcodes::is_conversion;
+/// assert!(is_conversion("int_to_real"));
+/// assert!(is_conversion("real_to_int_floor"));
+/// assert!(!is_conversion("cast"));
+/// ```
+pub fn is_conversion(op: &str) -> bool {
+    matches!(op, "int_to_real" | "real_to_int_trunc" | "real_to_int_floor")
+}
+
 /// Heap / GC operations (LANG16).
 ///
 /// Programs that never allocate never emit these — GC overhead is zero.
@@ -348,6 +370,10 @@ pub fn is_value_producing(op: &str) -> bool {
                 | "array_get"
                 // Global variable read (LANG32)
                 | "global_load"
+                // Numeric conversions integer↔real (LANG-FULL E8)
+                | "int_to_real"
+                | "real_to_int_trunc"
+                | "real_to_int_floor"
                 // Closure allocation and application (LANG34)
                 | "alloc_closure"
                 | "call_closure"

--- a/code/packages/rust/jit-core/tests/e8_conversions_jit.rs
+++ b/code/packages/rust/jit-core/tests/e8_conversions_jit.rs
@@ -1,0 +1,74 @@
+//! LANG-FULL E8 — numeric conversions (`integer` ↔ `real`) through the JIT tier.
+//!
+//! The JIT (`JITCore` + `GenericCirJit`) monitors a `VMCore`: cold functions
+//! interpret on the VM, hot ones promote to the compiled backend. A function
+//! using an op the compiler doesn't lower stays interpreted rather than
+//! failing — exactly how E5 arrays and E6 globals get the JIT column for free.
+//! The new `int_to_real`/`real_to_int_trunc`/`real_to_int_floor` ops inherit the
+//! same way; this confirms a program that round-trips integer→real→integer runs
+//! to the right answer through the full JIT path.
+
+use interpreter_ir::function::IIRFunction;
+use interpreter_ir::instr::{IIRInstr, Operand};
+use interpreter_ir::module::IIRModule;
+use jit_core::core::JITCore;
+use jit_core::GenericCirJit;
+use vm_core::core::VMCore;
+use vm_core::value::Value;
+
+fn ins(op: &str, dest: Option<&str>, srcs: Vec<Operand>, ty: &str) -> IIRInstr {
+    IIRInstr::new(op, dest.map(|s| s.to_string()), srcs, ty)
+}
+
+/// `main`: take `45`, widen it to `45.0`, subtract `2.7` (→ `42.3`), then
+/// `entier` (floor) it back to an integer ⇒ `42`. Exercises BOTH directions —
+/// `int_to_real` then `real_to_int_floor` — plus an f64 `sub` in between, all on
+/// the JIT tier.
+#[test]
+fn int_real_round_trip_with_floor_runs_on_jit() {
+    let mut module = IIRModule::new("e8jit", "e8jit");
+    module.add_or_replace(IIRFunction::new(
+        "main",
+        vec![],
+        "i64",
+        vec![
+            ins("const", Some("i"), vec![Operand::Int(45)], "i64"),
+            ins("int_to_real", Some("fi"), vec![Operand::Var("i".into())], "f64"),
+            ins("const", Some("d"), vec![Operand::Float(2.7)], "f64"),
+            ins("sub", Some("diff"), vec![Operand::Var("fi".into()), Operand::Var("d".into())], "f64"),
+            ins("real_to_int_floor", Some("r"), vec![Operand::Var("diff".into())], "i64"),
+            ins("ret", None, vec![Operand::Var("r".into())], "i64"),
+        ],
+    ));
+
+    let mut vm = VMCore::new();
+    let mut jit = JITCore::new(&mut vm, Box::new(GenericCirJit::new()));
+    let result = jit.execute_with_jit(&mut vm, &mut module, "main", &[]).unwrap();
+    assert_eq!(result, Some(Value::Int(42))); // floor(45.0 - 2.7) = floor(42.3) = 42
+}
+
+/// Truncation toward zero differs from floor for a negative operand:
+/// `trunc(-2.9) = -2`, so `44 + trunc(-2.9) = 42`. Confirms the `_trunc` variant
+/// is wired distinctly from `_floor` on the JIT tier (`floor(-2.9)` would be -3
+/// → 41).
+#[test]
+fn real_to_int_trunc_runs_on_jit() {
+    let mut module = IIRModule::new("e8jit", "e8jit");
+    module.add_or_replace(IIRFunction::new(
+        "main",
+        vec![],
+        "i64",
+        vec![
+            ins("const", Some("d"), vec![Operand::Float(-2.9)], "f64"),
+            ins("real_to_int_trunc", Some("t"), vec![Operand::Var("d".into())], "i64"),
+            ins("const", Some("base"), vec![Operand::Int(44)], "i64"),
+            ins("add", Some("r"), vec![Operand::Var("base".into()), Operand::Var("t".into())], "i64"),
+            ins("ret", None, vec![Operand::Var("r".into())], "i64"),
+        ],
+    ));
+
+    let mut vm = VMCore::new();
+    let mut jit = JITCore::new(&mut vm, Box::new(GenericCirJit::new()));
+    let result = jit.execute_with_jit(&mut vm, &mut module, "main", &[]).unwrap();
+    assert_eq!(result, Some(Value::Int(42))); // 44 + trunc(-2.9) = 44 + (-2) = 42
+}

--- a/code/packages/rust/vm-core/CHANGELOG.md
+++ b/code/packages/rust/vm-core/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog — vm-core
 
+## [0.9.0] — 2026-06-22 (LANG-FULL E8 — numeric conversions, PR-1)
+
+Reference VM semantics for the three `integer`↔`real` conversion opcodes
+(spec `code/specs/lang-full-e8-numeric-conversions.md`). E3 gave the VM f64
+*arithmetic*; these are the convert opcodes that sit next to it — every backend
+has a one-instruction equivalent, and this is the behaviour they must agree
+with.
+
+- **`int_to_real`** — `i64` → `f64` (IEEE-754, exact for |x| < 2⁵³).
+- **`real_to_int_trunc`** — `f64` → `i64` rounding toward **zero** (C / BASIC
+  `INT()`): `2.7 → 2`, `-2.7 → -2`.
+- **`real_to_int_floor`** — `f64` → `i64` rounding toward **−∞** (ALGOL
+  `entier`): `2.7 → 2`, `-2.7 → -3`.
+- Both `real_to_int_*` **trap** (fail-closed, like array-bounds and
+  divide-by-zero) on a NaN/±∞ or out-of-`i64`-range operand — never a silent
+  wrap. The range check is exact (`i64::MAX` is unrepresentable as `f64`, so the
+  bound is `< 2⁶³` via `-(i64::MIN as f64)`).
+- 5 unit tests (each direction + rounding-sign + the NaN/∞ and out-of-range
+  traps); the JIT tier inherits all three via cold-interpret (proved by
+  `jit-core/tests/e8_conversions_jit.rs`, an integer→real→integer round trip).
+
 ## [0.8.0] — 2026-06-22 (LANG-FULL E6 layer 1 — typed module globals)
 
 ### Added

--- a/code/packages/rust/vm-core/Cargo.toml
+++ b/code/packages/rust/vm-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vm-core"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 description = "Generic register interpreter for InterpreterIR — the vm-core of the LANG pipeline.  v0.8.0 (LANG-FULL E6 layer 1 — typed module globals): executes the lowered `global_load`/`global_store` IIR ops over a name-keyed `globals` map (a never-written global reads as 0, matching the code-gen backends' zero-init slots) — distinct from the dynamic `call_builtin \"global_get/set\"` table, so a statically-typed frontend's typed globals run on the VM (and JIT, via cold interpretation).  v0.5.0 (LANG-FULL E2 — register width & wrap, backend 1/6): integer arithmetic / bitwise / shift handlers now mask their result to the width named by the instruction's type_hint (u4→&0xF, u8→&0xFF, u16, u32), so a u8-typed `add` of 200+100 yields 44 and `~x` on a u8 flips 8 bits — the register-arithmetic analogue of the existing byte-tape store_byte mask, on top of the legacy whole-module u8_wrap flag.  v0.4.0 (LANG-MATRIX Phase V): adds the byte-tape ops alloc_bytes/load_byte/store_byte over the flat memory address space (a cell is memory[base+idx], store_byte masks to a byte for Brainfuck's 8-bit wrap), so the generic VM runs Brainfuck — every matrix language now runs on this one register interpreter."
 

--- a/code/packages/rust/vm-core/src/core.rs
+++ b/code/packages/rust/vm-core/src/core.rs
@@ -1144,6 +1144,70 @@ mod tests {
         assert_eq!(r, Value::Float(-2.5));
     }
 
+    // ---- E8: numeric conversions (integer ↔ real) ----
+
+    /// Run a single unary conversion `op` on a constant operand and return the
+    /// raw `Value` (or the error). `lit` is the input constant, `in_ty`/`ret_ty`
+    /// its IIR types.
+    fn run_convert(
+        op: &str,
+        lit: Operand,
+        in_ty: &str,
+        ret_ty: &str,
+    ) -> Result<Value, crate::errors::VMError> {
+        let fn_ = IIRFunction::new(
+            "main", vec![], ret_ty,
+            vec![
+                IIRInstr::new("const", Some("a".into()), vec![lit], in_ty),
+                IIRInstr::new(op, Some("r".into()), vec![Operand::Var("a".into())], ret_ty),
+                IIRInstr::new("ret", None, vec![Operand::Var("r".into())], ret_ty),
+            ],
+        );
+        let mut m = IIRModule::new("test", "test");
+        m.add_or_replace(fn_);
+        VMCore::new().execute(&mut m, "main", &[]).map(|o| o.unwrap())
+    }
+
+    #[test]
+    fn int_to_real_widens_exactly() {
+        assert_eq!(run_convert("int_to_real", Operand::Int(3), "i64", "f64").unwrap(), Value::Float(3.0));
+        assert_eq!(run_convert("int_to_real", Operand::Int(-7), "i64", "f64").unwrap(), Value::Float(-7.0));
+        assert_eq!(run_convert("int_to_real", Operand::Int(0), "i64", "f64").unwrap(), Value::Float(0.0));
+    }
+
+    #[test]
+    fn real_to_int_trunc_rounds_toward_zero() {
+        // Truncation: positive and negative both round toward zero.
+        assert_eq!(run_convert("real_to_int_trunc", Operand::Float(2.7), "f64", "i64").unwrap(), Value::Int(2));
+        assert_eq!(run_convert("real_to_int_trunc", Operand::Float(-2.7), "f64", "i64").unwrap(), Value::Int(-2));
+        assert_eq!(run_convert("real_to_int_trunc", Operand::Float(5.0), "f64", "i64").unwrap(), Value::Int(5));
+    }
+
+    #[test]
+    fn real_to_int_floor_rounds_toward_neg_inf() {
+        // Floor (ALGOL entier): a negative non-integer rounds DOWN, the key
+        // difference from truncation — entier(-2.7) = -3, not -2.
+        assert_eq!(run_convert("real_to_int_floor", Operand::Float(2.7), "f64", "i64").unwrap(), Value::Int(2));
+        assert_eq!(run_convert("real_to_int_floor", Operand::Float(-2.7), "f64", "i64").unwrap(), Value::Int(-3));
+        assert_eq!(run_convert("real_to_int_floor", Operand::Float(-3.0), "f64", "i64").unwrap(), Value::Int(-3));
+    }
+
+    #[test]
+    fn real_to_int_traps_on_nan_and_infinity() {
+        // Fail-closed (like array bounds / divide-by-zero), never a garbage int.
+        assert!(run_convert("real_to_int_trunc", Operand::Float(f64::NAN), "f64", "i64").is_err());
+        assert!(run_convert("real_to_int_floor", Operand::Float(f64::INFINITY), "f64", "i64").is_err());
+        assert!(run_convert("real_to_int_trunc", Operand::Float(f64::NEG_INFINITY), "f64", "i64").is_err());
+    }
+
+    #[test]
+    fn real_to_int_traps_on_out_of_range() {
+        // 2^63 and beyond does not fit i64 — trap rather than saturate/wrap.
+        let two_pow_63 = 9_223_372_036_854_775_808.0_f64; // = 2^63 = -(i64::MIN as f64)
+        assert!(run_convert("real_to_int_trunc", Operand::Float(two_pow_63), "f64", "i64").is_err());
+        assert!(run_convert("real_to_int_floor", Operand::Float(-1e30), "f64", "i64").is_err());
+    }
+
     // ---- E5: bounds-checked arrays ----
 
     /// Helper: build `main` from instrs returning `ret_ty`, run, return result.

--- a/code/packages/rust/vm-core/src/dispatch.rs
+++ b/code/packages/rust/vm-core/src/dispatch.rs
@@ -1092,6 +1092,90 @@ fn handle_type_assert(ctx: &mut DispatchCtx, instr: &IIRInstr) -> Result<Option<
 }
 
 // ---------------------------------------------------------------------------
+// E8 — numeric conversions (`integer` ↔ `real`)
+//
+// E3 gave the VM f64 *arithmetic*; these are the convert opcodes that sit next
+// to it (see `code/specs/lang-full-e8-numeric-conversions.md`).  Every backend
+// has a one-instruction equivalent (`sitofp`/`fptosi`/`floor`, `i2d`/`d2l`,
+// `conv.r8`/`conv.i8`, `cvtsi2sd`/`cvttsd2si`/`roundsd`, `scvtf`/`fcvtzs`/
+// `frintm`); this is the VM's reference semantics they must agree with.
+// ---------------------------------------------------------------------------
+
+/// Convert an already-rounded integral `f64` to `i64`, trapping (fail-closed,
+/// like the array-bounds and divide-by-zero traps) on a non-finite operand or
+/// one outside the `i64` range — never a silent wrap or garbage integer.  The
+/// caller passes a value that has *already* been `trunc()`'d or `floor()`'d, so
+/// `t` is integral; this only range-checks and casts.
+///
+/// The bounds are written so the rejection is **exact**: `i64::MIN as f64` is
+/// exactly −2⁶³, but `i64::MAX` (2⁶³−1) is not representable as an `f64`, so
+/// `i64::MAX as f64` rounds *up* to 2⁶³.  Comparing against `-(i64::MIN as f64)`
+/// (= +2⁶³) therefore rejects 2⁶³ and above; the largest accepted value is the
+/// greatest integral `f64` strictly below 2⁶³.  (`t as i64` for an in-range
+/// integral `t` is exact — Rust's saturating cast never fires here.)
+fn real_to_i64_checked(t: f64) -> Result<i64, VMError> {
+    if !t.is_finite() {
+        return Err(VMError::Custom(
+            "real_to_int: operand is not finite".into(),
+        ));
+    }
+    if t < i64::MIN as f64 || t >= -(i64::MIN as f64) {
+        return Err(VMError::Custom(format!(
+            "real_to_int: {t} is outside the i64 range"
+        )));
+    }
+    Ok(t as i64)
+}
+
+/// `int_to_real` — widen an `i64` to `f64` (IEEE-754 round-to-nearest-even;
+/// exact for |x| < 2⁵³).
+fn handle_int_to_real(ctx: &mut DispatchCtx, instr: &IIRInstr) -> Result<Option<Value>, VMError> {
+    let n = {
+        let frame = ctx.frames.last().ok_or_else(|| VMError::Custom("no frame".into()))?;
+        resolve_src(frame, &instr.srcs, 0)?
+            .as_i64()
+            .ok_or_else(|| VMError::Custom("int_to_real: operand is not an integer".into()))?
+    };
+    let result = Value::Float(n as f64);
+    if let Some(dest) = &instr.dest {
+        ctx.frames.last_mut().unwrap().assign(dest, result.clone());
+    }
+    Ok(Some(result))
+}
+
+/// `real_to_int_trunc` — round a `real` toward **zero** (C / most BASIC
+/// `INT()`): `2.7 → 2`, `-2.7 → -2`.  Traps on NaN/±∞/out-of-range.
+fn handle_real_to_int_trunc(ctx: &mut DispatchCtx, instr: &IIRInstr) -> Result<Option<Value>, VMError> {
+    let f = {
+        let frame = ctx.frames.last().ok_or_else(|| VMError::Custom("no frame".into()))?;
+        resolve_src(frame, &instr.srcs, 0)?
+            .as_f64()
+            .ok_or_else(|| VMError::Custom("real_to_int_trunc: operand is not a real".into()))?
+    };
+    let result = Value::Int(real_to_i64_checked(f.trunc())?);
+    if let Some(dest) = &instr.dest {
+        ctx.frames.last_mut().unwrap().assign(dest, result.clone());
+    }
+    Ok(Some(result))
+}
+
+/// `real_to_int_floor` — round a `real` toward **−∞** (ALGOL `entier`):
+/// `2.7 → 2`, `-2.7 → -3`.  Traps on NaN/±∞/out-of-range.
+fn handle_real_to_int_floor(ctx: &mut DispatchCtx, instr: &IIRInstr) -> Result<Option<Value>, VMError> {
+    let f = {
+        let frame = ctx.frames.last().ok_or_else(|| VMError::Custom("no frame".into()))?;
+        resolve_src(frame, &instr.srcs, 0)?
+            .as_f64()
+            .ok_or_else(|| VMError::Custom("real_to_int_floor: operand is not a real".into()))?
+    };
+    let result = Value::Int(real_to_i64_checked(f.floor())?);
+    if let Some(dest) = &instr.dest {
+        ctx.frames.last_mut().unwrap().assign(dest, result.clone());
+    }
+    Ok(Some(result))
+}
+
+// ---------------------------------------------------------------------------
 // Standard opcode dispatch table
 // ---------------------------------------------------------------------------
 
@@ -1143,6 +1227,9 @@ pub(crate) fn lookup_standard(op: &str) -> Option<StdHandlerFn> {
         "io_out"       => Some(handle_io_out),
         "cast"         => Some(handle_cast),
         "type_assert"  => Some(handle_type_assert),
+        "int_to_real"       => Some(handle_int_to_real),
+        "real_to_int_trunc" => Some(handle_real_to_int_trunc),
+        "real_to_int_floor" => Some(handle_real_to_int_floor),
         // `call` is handled specially (needs jit_handlers) — see dispatch loop.
         _              => None,
     }

--- a/code/specs/LANG-FULL-IMPLEMENTATION.md
+++ b/code/specs/LANG-FULL-IMPLEMENTATION.md
@@ -234,6 +234,21 @@ multiple languages; close an enabler before the features that depend on it.
     stack on top.
 - **E7 — Subroutine / return-stack.** `GOSUB`/`RETURN` and procedure call/return —
   likely expressible with existing `call`/`ret`; confirm and add if needed.
+- **E8 — Numeric conversions (`integer` ↔ `real`).** ◑ *Spec signed off
+  ([`lang-full-e8-numeric-conversions.md`](lang-full-e8-numeric-conversions.md)); implementation in progress.*
+  Three ops (`int_to_real`, `real_to_int_trunc`, `real_to_int_floor`); `real→int`
+  traps out-of-range. Unblocks **AL8 `entier`** (floor), int→real **coercion**,
+  BASIC **`INT()`** / **BA7**.
+  - ✅ **PR-1 — interpreter-ir + vm-core + JIT** (interpreter-ir 0.8.0,
+    vm-core 0.9.0). `is_conversion` classifier + value-producing registration;
+    VM reference semantics (range-checked, fail-closed trap on NaN/∞/overflow);
+    JIT inherits via cold-interpret. 5 vm-core unit tests + a jit-core
+    integer→real→integer round-trip.
+  - ☐ **PR-2..6** — LLVM (`sitofp`/`fptosi`/`llvm.floor`), WASM
+    (`convert`/`trunc_sat`/`floor`), JVM (`i2d`/`d2l`/`Math.floor`), CLR
+    (`conv.r8`/`conv.i8`/`Math::Floor`), native (aarch64 `scvtf`/`fcvtzs`/`frintm`
+    + x86_64 `cvtsi2sd`/`cvttsd2si`/`roundsd`, + x86-sim cell). Each RUN-verified.
+  - ☐ **PR-7 — ALGOL `entier`** frontend slice + matrix proof on all 7 backends.
 
 ---
 


### PR DESCRIPTION
## What

First slice of the **E8 numeric-conversions** arc (spec signed off in [#6576](https://github.com/adhithyan15/coding-adventures/pull/6576)). Defines the three `integer`↔`real` conversion opcodes and gives them **reference VM semantics** (+ JIT for free). E3 gave the VM f64 *arithmetic*; these are the convert opcodes that sit next to it — every backend has a one-instruction equivalent, and this is the behaviour they must agree with.

| Opcode | Direction | Rounding |
|--------|-----------|----------|
| `int_to_real`       | `i64` → `f64` | exact (IEEE-754) |
| `real_to_int_trunc` | `f64` → `i64` | toward zero (`INT()`) |
| `real_to_int_floor` | `f64` → `i64` | toward −∞ (ALGOL `entier`) |

## Decisions (from the spec's §7, no review notes left)

- **Three distinct op names** rather than one immediate-mode op — matches the existing IIR convention where comparison variants are distinct names (`cmp_lt`/`cmp_gt`/…), avoiding new immediate-operand machinery. The spec explicitly left this latitude.
- **Trap on overflow** (fail-closed) — `real → int` traps on NaN/±∞/out-of-`i64`-range, never a silent wrap, consistent with array-bounds and divide-by-zero. The range check is **exact** (`i64::MAX` is unrepresentable as `f64`, so the bound is `< 2⁶³` via `-(i64::MIN as f64)`; the lower bound is exactly −2⁶³).
- **Op only, no coercion** in E8 (per §7.3).

## Changes

- **interpreter-ir 0.8.0** — `is_conversion(op)` classifier (distinct from the width-masking `is_coercion`); all three registered in `is_value_producing`. Doctest; category coverage stays exhaustive.
- **vm-core 0.9.0** — the three handlers + `real_to_i64_checked` (range-checked, fail-closed). 5 unit tests (each direction, rounding sign, NaN/∞ trap, out-of-range trap).
- **jit-core** — the JIT inherits all three via cold-interpret (E5/E6 pattern); a new `e8_conversions_jit.rs` proves an integer→real→integer round trip (`floor(45.0 − 2.7) = 42`) plus the distinct `_trunc` variant, both through the full JIT path.

## Verification

- `cargo test -p interpreter-ir -p vm-core -p jit-core` — **all green** (interpreter-ir 85 + doctests, vm-core 66, jit-core e8 round-trip).
- `lang-aot` (pulls every backend + frontend) builds clean — the interpreter-ir change is **purely additive** (new classifier + match arm), breaking no downstream consumer.
- Security review: **PASSED** (no `unsafe`; float-boundary math empirically verified — no off-by-one, no UB, no fail-open).

## Miri note

This touches `interpreter-ir`, a `twig-vm` dependency. The diff adds **zero `unsafe`** (additive classifier + safe handlers), so there is no UB surface for Miri to catch. The blocking per-PR Miri targets (`lang-runtime-core`/`lispy-runtime`) don't depend on `interpreter-ir`; twig-vm's Miri is the nightly/informational one and will still exercise it. Happy to run `scripts/miri-twig-vm.sh` if you'd like belt-and-suspenders.

## Next (E8 arc)

PR-2..6 lower the ops on each backend (LLVM/WASM/JVM/CLR/native + x86-sim cell); PR-7 is the ALGOL `entier` frontend slice + matrix proof. Unblocks `entier`, int→real coercion, BASIC `INT()`/BA7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)