### PR TITLE
feat(mycin-embryo): new ADJ-only embryology recall domain — 8 grounded structure→origin edges

### DIFF
--- a/code/specs/data/mycin-2026/recall/embryo-edges.adj
+++ b/code/specs/data/mycin-2026/recall/embryo-edges.adj
@@ -1,0 +1,99 @@
+% ============================================================================
+% embryo-edges — the developmental-origin knowledge-graph (MYCIN-2026 EMBRYO).
+% ============================================================================
+% A high-yield embryology board domain: the adult structure (cell, organ, tissue)
+% and the embryonic precursor it derives from. "The adrenal medulla derives from
+% which embryonic origin?" becomes the binding query
+%     ? embryonic_origin(adrenal_medulla, $Origin).
+%
+% Direction note: the relation is structure -> origin (`embryonic_origin`), the
+% board direction — you name an adult structure and must recall its developmental
+% precursor (germ layer / neural crest / pharyngeal pouch / embryonic structure).
+% The cited spans read origin-first or structure-first ("The neural crest also gives
+% rise to ... chromaffin cells of the adrenal medulla ..."; "The neurohypophysis ...
+% develops from the neuroectodermal infundibulum") — what matters for grounding is
+% that one self-contained span names BOTH the structure AND its origin. Each
+% structure here maps to one canonical origin, so a query binds a single answer
+% (multiple structures may share an origin — four neural-crest derivatives here).
+%
+% This file is the SHIPPED ARTIFACT and the SOLE source of truth — no generator, no
+% JSON, no manifest (a pure ADJ-only recall domain, like TOX/PSYCH/MSK/OPHTHO/ECG).
+% Each fact is a `relate` clause whose byte-provenance lives INLINE:
+%     source   — the VERBATIM span copied from the cited page (byte-stable: it
+%                appears character-for-character in the page's normalized text).
+%     locator  — the URL the span was read from (NCBI StatPearls / Bookshelf).
+%     trust    — authoritative (a primary, citable reference).
+% An LLM (or a human) recalls a fact by writing a tiny query .adj that `import`s
+% this library and asks a binding query — see embryo-recall.query.adj. Nothing here
+% is asserted "from memory": every edge is defended by a span a reader can re-fetch
+% and check.
+% (See feedback_nothing_human_authored, feedback_adj_only_shipped_artifacts.)
+%
+% Write-once / use-many: the thymus and the inferior parathyroid are BOTH minted
+% from ONE NBK557724 sentence ("The third pharyngeal pouch develops into the thymus
+% and the inferior portion of the parathyroid.") — one grounded span, two edges.
+% ============================================================================
+
+dictionary embryo_vocab {
+    define structure : entity   surface "adult structure", "cell or organ"
+    define origin    : entity   surface "embryonic origin", "developmental precursor"
+
+    define embryonic_origin : relation from structure to origin  % the precursor a structure derives from
+}
+
+rulebook embryo_facts {
+    use embryo_vocab
+
+    % --- adrenal medulla -> neural crest ---------------------------------------
+    relate embryonic_origin(adrenal_medulla, neural_crest)
+        source "The neural crest also gives rise to Schwann cells, chromaffin cells of the adrenal medulla, inner ear, cornea, odontoblasts, melanoblasts, pharyngeal arches, and the meninges of the brain and spinal cord."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK539836/"
+        trust authoritative
+
+    % --- melanocytes -> neural crest -------------------------------------------
+    relate embryonic_origin(melanocytes, neural_crest)
+        source "Neural crest cells are precursors to a wide variety of tissues, including the ectodermal derivatives of melanocytes, sensory and autonomic ganglion neurons, and Schwann cells."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK547700/"
+        trust authoritative
+
+    % --- Schwann cells -> neural crest -----------------------------------------
+    relate embryonic_origin(schwann_cells, neural_crest)
+        source "Schwann cells embryologically derive from the neural crest."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK544316/"
+        trust authoritative
+
+    % --- thyroid parafollicular (C) cells -> neural crest ----------------------
+    relate embryonic_origin(parafollicular_c_cells, neural_crest)
+        source "Unlike other thyroid neoplasms, MTC is a neuroendocrine tumor because C cells, arising from ultimobranchial bodies, are derived from neural crest tissue."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK519054/"
+        trust authoritative
+
+    % --- posterior pituitary (neurohypophysis) -> neuroectoderm ----------------
+    relate embryonic_origin(posterior_pituitary, neuroectoderm)
+        source "The neurohypophysis, also called the posterior pituitary gland, develops from the neuroectodermal infundibulum."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK526130/"
+        trust authoritative
+
+    % --- diaphragm (central tendon) -> septum transversum ----------------------
+    relate embryonic_origin(diaphragm, septum_transversum)
+        source "During this period, the central tendon is formed from the anterior septum transversum, which then merges with the pleuroperitoneal folds on the sides and the dorsal mesentery of the esophagus in the center, creating the initial structure of the diaphragm."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK560497/"
+        trust authoritative
+
+    % ------------------------------------------------------------------------
+    % WRITE-ONCE / USE-MANY: thymus + inferior parathyroid, both from ONE
+    % NBK557724 sentence naming the third pharyngeal pouch's two derivatives.
+    % ------------------------------------------------------------------------
+
+    % --- thymus -> third pharyngeal pouch --------------------------------------
+    relate embryonic_origin(thymus, third_pharyngeal_pouch)
+        source "The third pharyngeal pouch develops into the thymus and the inferior portion of the parathyroid."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK557724/"
+        trust authoritative
+
+    % --- inferior parathyroid -> third pharyngeal pouch (same span) ------------
+    relate embryonic_origin(inferior_parathyroid, third_pharyngeal_pouch)
+        source "The third pharyngeal pouch develops into the thymus and the inferior portion of the parathyroid."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK557724/"
+        trust authoritative
+}

--- a/code/specs/data/mycin-2026/recall/embryo-recall.query.adj
+++ b/code/specs/data/mycin-2026/recall/embryo-recall.query.adj
@@ -1,0 +1,24 @@
+% ============================================================================
+% embryo-recall.query.adj — a worked recall query over the embryology library.
+% ============================================================================
+% The shape an LLM (or a clinician) produces to ANSWER a "this structure derives
+% from which embryonic origin?" question: it states no embryology fact — it only
+% `import`s the grounded library and asks binding queries. The native adj-lang
+% engine resolves each `?` against the imported `relate` edges and returns the
+% binding + the citing clause's source/locator/trust. All knowledge is in the
+% library; none is here.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli embryo-recall.query.adj
+% ============================================================================
+
+import "embryo-edges.adj"
+
+? embryonic_origin(adrenal_medulla, $Origin)         % expect neural_crest
+? embryonic_origin(melanocytes, $Origin)             % expect neural_crest
+? embryonic_origin(schwann_cells, $Origin)           % expect neural_crest
+? embryonic_origin(parafollicular_c_cells, $Origin)  % expect neural_crest
+? embryonic_origin(posterior_pituitary, $Origin)     % expect neuroectoderm
+? embryonic_origin(diaphragm, $Origin)               % expect septum_transversum
+? embryonic_origin(thymus, $Origin)                  % expect third_pharyngeal_pouch
+? embryonic_origin(inferior_parathyroid, $Origin)    % expect third_pharyngeal_pouch

--- a/code/specs/data/mycin-2026/recall/test_embryo_recall.py
+++ b/code/specs/data/mycin-2026/recall/test_embryo_recall.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""test_embryo_recall.py — the ADJ-only embryology recall library (MYCIN-2026 EMBRYO).
+
+A new pure-ADJ recall domain (high-yield embryology board content): the adult
+structure and the embryonic precursor it derives from. `embryo-edges.adj` is the SOLE
+source of truth — facts + byte-provenance inline, no Python gate, no JSON, no manifest.
+This test pins the property that matters: the native adj-lang engine, given a query .adj
+that only `import`s the library and asks binding queries (`embryo-recall.query.adj` — the
+shape an LLM produces), binds the grounded origin for each structure, each carrying an
+AUTHORITATIVE citation with a real source span + locator. Knowledge lives in ADJ; the
+engine answers.
+
+If the native CLI isn't built (a Python-only CI lane), the engine-backed checks skip —
+the file-shape checks (every clause grounded, no authored-debt) still run.
+
+Run:  python3 test_embryo_recall.py
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+ADJ = HERE / "embryo-edges.adj"
+QUERY = HERE / "embryo-recall.query.adj"
+CLI = HERE.parents[3] / "packages" / "rust" / "target" / "debug" / "adj-lang-cli"
+
+# Every grounded edge: adult structure -> the embryonic origin the library binds.
+# Several structures share an origin (four neural-crest derivatives); each structure
+# still binds exactly one origin, so the single-answer property holds.
+EXPECTED = {
+    "adrenal_medulla": "neural_crest",                # NBK539836
+    "melanocytes": "neural_crest",                    # NBK547700
+    "schwann_cells": "neural_crest",                  # NBK544316
+    "parafollicular_c_cells": "neural_crest",         # NBK519054
+    "posterior_pituitary": "neuroectoderm",           # NBK526130
+    "diaphragm": "septum_transversum",                # NBK560497
+    # --- write-once / use-many: both from ONE NBK557724 span ---
+    "thymus": "third_pharyngeal_pouch",               # NBK557724
+    "inferior_parathyroid": "third_pharyngeal_pouch",  # NBK557724 (same span)
+}
+REL = "embryonic_origin"
+VAR = "Origin"
+
+
+def _cli_available() -> bool:
+    return CLI.exists()
+
+
+def _run(program: Path) -> dict:
+    out = subprocess.run([str(CLI), str(program)], capture_output=True, text=True,
+                         cwd=str(HERE), timeout=60)
+    assert out.returncode == 0, f"adj-lang-cli failed: {out.stderr}"
+    return json.loads(out.stdout)
+
+
+# ---- 1. the ADJ file is the artifact — every clause grounded, no authored-debt ----
+
+def test_library_is_pure_adj_and_fully_grounded() -> None:
+    text = ADJ.read_text()
+    assert "trust consensus" not in text, "EMBRYO ships no authored-debt; ground or omit"
+    assert "[FLAG:" not in text
+    edge_count = len(EXPECTED)  # 8
+    assert text.count("    relate ") == edge_count
+    assert text.count("trust authoritative") == edge_count
+    assert text.count('\n        locator "') == edge_count
+    assert text.count('\n        source "') == edge_count
+    # every locator is an NCBI primary source
+    for line in text.splitlines():
+        line = line.strip()
+        if line.startswith("locator "):
+            assert "https://www.ncbi.nlm.nih.gov/" in line, f"non-NCBI locator: {line}"
+    assert not (HERE / "embryo_edge_ground.py").exists()
+    assert not (HERE / "embryo-edge-grounding.json").exists()
+    assert not (HERE / "embryo-edge-manifest.json").exists()
+
+
+# ---- 2. the engine binds each origin, each with an authoritative citation ----------
+
+def test_engine_binds_every_origin_with_authoritative_citation() -> None:
+    if not _cli_available():
+        return
+    result = _run(QUERY)
+    by_query = {r["query"]: r for r in result["recall"]}
+    for structure, origin in EXPECTED.items():
+        q = f"{REL}({structure}, {VAR})"
+        r = by_query.get(q)
+        assert r is not None and not r["abstained"], f"{q} abstained — edge missing?"
+        bound = {}
+        for a in r["answers"]:
+            bound[a["bindings"][VAR]] = (a.get("citations") or [{}])[0]
+        assert set(bound) == {origin}, f"{structure}: bound {set(bound)} != {{{origin}}}"
+        cite = bound[origin]
+        assert cite.get("trust") == "authoritative", f"{structure}/{origin} not authoritative"
+        assert cite.get("source"), f"{structure}/{origin} has no source span"
+        assert cite.get("locator", "").startswith("https://www.ncbi.nlm.nih.gov/")
+
+
+# ---- 3. an off-vocabulary structure abstains, never fabricates ----------------------
+
+def test_unknown_structure_abstains() -> None:
+    if not _cli_available():
+        return
+    import os
+    import tempfile
+    fd, path = tempfile.mkstemp(suffix=".adj", prefix=".embryo_q_", dir=HERE)
+    try:
+        with os.fdopen(fd, "w") as fh:
+            # anterior_pituitary is not in the library (oral ectoderm/Rathke pouch) -> must abstain
+            fh.write(f'import "embryo-edges.adj"\n? {REL}(anterior_pituitary, ${VAR})\n')
+        res = _run(Path(path))
+        r = res["recall"][0] if res["recall"] else None
+        assert r is not None and r["abstained"], "an ungrounded structure must abstain"
+    finally:
+        os.unlink(path)
+
+
+def _run_all() -> int:
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    failed = 0
+    for t in tests:
+        try:
+            t()
+            print(f"  PASS  {t.__name__}")
+        except AssertionError as exc:
+            failed += 1
+            print(f"  FAIL  {t.__name__}: {exc}")
+    print(f"\ntest_embryo_recall: {len(tests) - failed}/{len(tests)} passed")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(_run_all())


### PR DESCRIPTION
## Summary
Adds a **brand-new pure-ADJ recall domain** for **developmental origins** — a high-yield embryology board topic previously absent from MYCIN-2026. The relation `embryonic_origin(structure, origin)` maps an adult structure to the embryonic precursor it derives from.

8 byte-grounded edges, each defended by a single self-contained verbatim **NCBI StatPearls** span naming BOTH structure AND origin:

| structure | embryonic origin | source |
|---|---|---|
| adrenal medulla | neural crest | NBK539836 |
| melanocytes | neural crest | NBK547700 |
| Schwann cells | neural crest | NBK544316 |
| parafollicular (C) cells | neural crest | NBK519054 |
| posterior pituitary | neuroectoderm | NBK526130 |
| diaphragm | septum transversum | NBK560497 |
| thymus | third pharyngeal pouch | NBK557724 |
| inferior parathyroid | third pharyngeal pouch | NBK557724 *(same span)* |

## Notes
- **Write-once / use-many**: thymus + inferior parathyroid are both minted from **one** NBK557724 sentence naming the third pharyngeal pouch's two derivatives. Four structures share the neural-crest origin; each structure still binds exactly one origin (single-answer property holds).
- Ships as the standard trio; self-contained (no `board_eval` coupling, no manifest, no JSON). CI auto-discovers `recall/test_*.py`.
- Abstention control = `anterior_pituitary` (oral ectoderm / Rathke pouch — not in this library).

## Verification
- `cargo build -p adj-lang-cli` ✓
- `test_embryo_recall.py` → **3/3** (engine binds all 8 with authoritative NCBI citations; control abstains) ✓
- `ruff check` clean ✓
- Security review passed ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)