### PR TITLE
feat(mycin-exotoxin): ADJ-only bacterial-exotoxin mechanism recall library (6 edges)

### DIFF
--- a/code/specs/data/mycin-2026/recall/exotoxin-edges.adj
+++ b/code/specs/data/mycin-2026/recall/exotoxin-edges.adj
@@ -1,0 +1,87 @@
+% ============================================================================
+% exotoxin-edges — the bacterial-exotoxin mechanism knowledge-graph (MYCIN-2026 EXOTOXIN).
+% ============================================================================
+% A high-yield clinical-microbiology board domain: a named bacterial exotoxin
+% and its molecular mechanism of action. "Diphtheria toxin acts by which
+% mechanism?" becomes the binding query
+%     ? exotoxin_action(diphtheria_toxin, $Mechanism).
+%
+% Direction note: the relation is toxin -> mechanism (`exotoxin_action`), the
+% board direction — you name a toxin and must recall HOW it injures the host
+% cell (which target it modifies and with what biochemical reaction). Several
+% toxins converge on the same biochemical move (ADP-ribosylation of a target),
+% but each toxin modifies a DIFFERENT target, so each query binds a single
+% answer. What matters for grounding is that one self-contained span names BOTH
+% the toxin AND its mechanism in the same sentence.
+%
+% This file is the SHIPPED ARTIFACT and the SOLE source of truth — no generator,
+% no JSON, no manifest (a pure ADJ-only recall domain, like EMBRYO/TOX/PSYCH/MSK).
+% Each fact is a `relate` clause whose byte-provenance lives INLINE:
+%     source   — the VERBATIM span copied from the cited page (byte-stable: it
+%                appears character-for-character in the page's normalized text;
+%                every span here was independently re-fetched and confirmed).
+%     locator  — the URL the span was read from (NCBI StatPearls / Bookshelf).
+%     trust    — authoritative (a primary, citable reference).
+% An LLM (or a human) recalls a fact by writing a tiny query .adj that `import`s
+% this library and asks a binding query — see exotoxin-recall.query.adj. Nothing
+% here is asserted "from memory": every edge is defended by a span a reader can
+% re-fetch and check.
+% (See feedback_nothing_human_authored, feedback_adj_only_shipped_artifacts.)
+%
+% Mechanism atoms are faithful to the cited span: diphtheria and exotoxin-A-class
+% toxins ADP-ribosylate elongation factor 2 (atom adp_ribosylation_of_ef2);
+% Shiga toxin's cited span states ribosome binding -> protein-synthesis
+% inhibition without naming the 60S subunit, so its atom is the span-faithful
+% inhibition_of_protein_synthesis (not the finer 60S detail). Cholera toxin and
+% the ETEC heat-labile toxin both raise cAMP via adenylate cyclase; cholera's
+% span names the Gs ADP-ribosylation step explicitly so it carries the more
+% specific activation_of_gs_adenylate_cyclase atom, the heat-labile span names
+% only adenylate-cyclase stimulation so it carries activation_of_adenylate_cyclase.
+% ============================================================================
+
+dictionary exotoxin_vocab {
+    define toxin     : entity   surface "bacterial exotoxin", "named toxin"
+    define mechanism : entity   surface "mechanism of action", "molecular target modified"
+
+    define exotoxin_action : relation from toxin to mechanism  % how the toxin injures the host cell
+}
+
+rulebook exotoxin_facts {
+    use exotoxin_vocab
+
+    % --- diphtheria toxin -> ADP-ribosylation of EF-2 --------------------------
+    relate exotoxin_action(diphtheria_toxin, adp_ribosylation_of_ef2)
+        source "Fragment A catalyzes the NAD+-dependent ADP-ribosylation of elongation factor 2, thereby inhibiting protein synthesis in eukaryotic cells."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK7971/"
+        trust authoritative
+
+    % --- Shiga toxin -> inhibition of protein synthesis (ribosome) -------------
+    relate exotoxin_action(shiga_toxin, inhibition_of_protein_synthesis)
+        source "The Shiga toxin/Gb3 complex binds to cell ribosomes, inhibiting protein synthesis and causing apoptosis; inflammatory cytokines are also produced."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK556038/"
+        trust authoritative
+
+    % --- cholera toxin -> ADP-ribosylation of Gs (adenylate cyclase) -----------
+    relate exotoxin_action(cholera_toxin, activation_of_gs_adenylate_cyclase)
+        source "Cholera toxin is produced, which ADP-ribosylates the Gs subunit of the G protein complex in the gut epithelium."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK470232/"
+        trust authoritative
+
+    % --- ETEC heat-labile toxin -> adenylate cyclase / cAMP --------------------
+    relate exotoxin_action(heat_labile_enterotoxin, activation_of_adenylate_cyclase)
+        source "Heat-labile toxin stimulates adenylate cyclase, leading to increased intracellular cyclic adenosine monophosphate (cAMP) and subsequent chloride secretion from intestinal crypt cells."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK564298/"
+        trust authoritative
+
+    % --- pertussis toxin -> ADP-ribosylation of Gi -----------------------------
+    relate exotoxin_action(pertussis_toxin, adp_ribosylation_of_gi)
+        source "The S1 subunit of pertussis toxin ADP-ribosylates the Cys352 of protein Gi (GTP-binding protein), as well as the corresponding cysteine of protein Gα and of transducin."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK7813/"
+        trust authoritative
+
+    % --- tetanospasmin -> blocks inhibitory neurotransmitter release -----------
+    relate exotoxin_action(tetanospasmin, blocks_inhibitory_neurotransmitter_release)
+        source "Within the CNS, tetanospasmin blocks the release of the neurotransmitters gamma amino butyric acid (GABA) and glycine from inhibitory interneurons within the spinal cord and brain stem."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK482484/"
+        trust authoritative
+}

--- a/code/specs/data/mycin-2026/recall/exotoxin-recall.query.adj
+++ b/code/specs/data/mycin-2026/recall/exotoxin-recall.query.adj
@@ -1,0 +1,22 @@
+% ============================================================================
+% exotoxin-recall.query.adj — a worked recall query over the exotoxin library.
+% ============================================================================
+% The shape an LLM (or a clinician) produces to ANSWER a "this toxin acts by
+% which mechanism?" question: it states no microbiology fact — it only `import`s
+% the grounded library and asks binding queries. The native adj-lang engine
+% resolves each `?` against the imported `relate` edges and returns the binding
+% + the citing clause's source/locator/trust. All knowledge is in the library;
+% none is here.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli exotoxin-recall.query.adj
+% ============================================================================
+
+import "exotoxin-edges.adj"
+
+? exotoxin_action(diphtheria_toxin, $Mechanism)        % expect adp_ribosylation_of_ef2
+? exotoxin_action(shiga_toxin, $Mechanism)             % expect inhibition_of_protein_synthesis
+? exotoxin_action(cholera_toxin, $Mechanism)           % expect activation_of_gs_adenylate_cyclase
+? exotoxin_action(heat_labile_enterotoxin, $Mechanism) % expect activation_of_adenylate_cyclase
+? exotoxin_action(pertussis_toxin, $Mechanism)         % expect adp_ribosylation_of_gi
+? exotoxin_action(tetanospasmin, $Mechanism)           % expect blocks_inhibitory_neurotransmitter_release

--- a/code/specs/data/mycin-2026/recall/test_exotoxin_recall.py
+++ b/code/specs/data/mycin-2026/recall/test_exotoxin_recall.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""test_exotoxin_recall.py — the ADJ-only bacterial-exotoxin recall library (MYCIN-2026 EXOTOXIN).
+
+A new pure-ADJ recall domain (high-yield clinical-microbiology board content): a
+named bacterial exotoxin and its molecular mechanism of action. `exotoxin-edges.adj`
+is the SOLE source of truth — facts + byte-provenance inline, no Python gate, no JSON,
+no manifest. This test pins the property that matters: the native adj-lang engine,
+given a query .adj that only `import`s the library and asks binding queries
+(`exotoxin-recall.query.adj` — the shape an LLM produces), binds the grounded
+mechanism for each toxin, each carrying an AUTHORITATIVE citation with a real source
+span + locator. Knowledge lives in ADJ; the engine answers.
+
+If the native CLI isn't built (a Python-only CI lane), the engine-backed checks skip —
+the file-shape checks (every clause grounded, no authored-debt) still run.
+
+Run:  python3 test_exotoxin_recall.py
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+ADJ = HERE / "exotoxin-edges.adj"
+QUERY = HERE / "exotoxin-recall.query.adj"
+CLI = HERE.parents[3] / "packages" / "rust" / "target" / "debug" / "adj-lang-cli"
+
+# Every grounded edge: bacterial exotoxin -> the mechanism the library binds.
+# Several toxins ADP-ribosylate a target, but each modifies a DIFFERENT target,
+# so each toxin still binds exactly one mechanism — the single-answer property holds.
+EXPECTED = {
+    "diphtheria_toxin": "adp_ribosylation_of_ef2",                       # NBK7971
+    "shiga_toxin": "inhibition_of_protein_synthesis",                    # NBK556038
+    "cholera_toxin": "activation_of_gs_adenylate_cyclase",              # NBK470232
+    "heat_labile_enterotoxin": "activation_of_adenylate_cyclase",        # NBK564298
+    "pertussis_toxin": "adp_ribosylation_of_gi",                         # NBK7813
+    "tetanospasmin": "blocks_inhibitory_neurotransmitter_release",       # NBK482484
+}
+REL = "exotoxin_action"
+VAR = "Mechanism"
+
+
+def _cli_available() -> bool:
+    return CLI.exists()
+
+
+def _run(program: Path) -> dict:
+    out = subprocess.run([str(CLI), str(program)], capture_output=True, text=True,
+                         cwd=str(HERE), timeout=60)
+    assert out.returncode == 0, f"adj-lang-cli failed: {out.stderr}"
+    return json.loads(out.stdout)
+
+
+# ---- 1. the ADJ file is the artifact — every clause grounded, no authored-debt ----
+
+def test_library_is_pure_adj_and_fully_grounded() -> None:
+    text = ADJ.read_text()
+    assert "trust consensus" not in text, "EXOTOXIN ships no authored-debt; ground or omit"
+    assert "[FLAG:" not in text
+    edge_count = len(EXPECTED)  # 6
+    assert text.count("    relate ") == edge_count
+    assert text.count("trust authoritative") == edge_count
+    assert text.count('\n        locator "') == edge_count
+    assert text.count('\n        source "') == edge_count
+    # every locator is an NCBI primary source
+    for line in text.splitlines():
+        line = line.strip()
+        if line.startswith("locator "):
+            assert "https://www.ncbi.nlm.nih.gov/" in line, f"non-NCBI locator: {line}"
+    assert not (HERE / "exotoxin_edge_ground.py").exists()
+    assert not (HERE / "exotoxin-edge-grounding.json").exists()
+    assert not (HERE / "exotoxin-edge-manifest.json").exists()
+
+
+# ---- 2. the engine binds each mechanism, each with an authoritative citation -------
+
+def test_engine_binds_every_mechanism_with_authoritative_citation() -> None:
+    if not _cli_available():
+        return
+    result = _run(QUERY)
+    by_query = {r["query"]: r for r in result["recall"]}
+    for toxin, mechanism in EXPECTED.items():
+        q = f"{REL}({toxin}, {VAR})"
+        r = by_query.get(q)
+        assert r is not None and not r["abstained"], f"{q} abstained — edge missing?"
+        bound = {}
+        for a in r["answers"]:
+            bound[a["bindings"][VAR]] = (a.get("citations") or [{}])[0]
+        assert set(bound) == {mechanism}, f"{toxin}: bound {set(bound)} != {{{mechanism}}}"
+        cite = bound[mechanism]
+        assert cite.get("trust") == "authoritative", f"{toxin}/{mechanism} not authoritative"
+        assert cite.get("source"), f"{toxin}/{mechanism} has no source span"
+        assert cite.get("locator", "").startswith("https://www.ncbi.nlm.nih.gov/")
+
+
+# ---- 3. an off-vocabulary toxin abstains, never fabricates --------------------------
+
+def test_unknown_toxin_abstains() -> None:
+    if not _cli_available():
+        return
+    import os
+    import tempfile
+    fd, path = tempfile.mkstemp(suffix=".adj", prefix=".exotoxin_q_", dir=HERE)
+    try:
+        with os.fdopen(fd, "w") as fh:
+            # exotoxin_a (Pseudomonas) is not in the library -> must abstain, never fabricate
+            fh.write(f'import "exotoxin-edges.adj"\n? {REL}(exotoxin_a, ${VAR})\n')
+        res = _run(Path(path))
+        r = res["recall"][0] if res["recall"] else None
+        assert r is not None and r["abstained"], "an ungrounded toxin must abstain"
+    finally:
+        os.unlink(path)
+
+
+def _run_all() -> int:
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    failed = 0
+    for t in tests:
+        try:
+            t()
+            print(f"  PASS  {t.__name__}")
+        except AssertionError as exc:
+            failed += 1
+            print(f"  FAIL  {t.__name__}: {exc}")
+    print(f"\ntest_exotoxin_recall: {len(tests) - failed}/{len(tests)} passed")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(_run_all())


### PR DESCRIPTION
## What

A new pure-ADJ recall domain for MYCIN-2026: **bacterial exotoxin → molecular mechanism of action** — high-yield clinical-microbiology board content. Follows the established ADJ-only pattern (EMBRYO/TOX/PSYCH/MSK): the shipped `.adj` library is the sole source of truth — no Python generator, no JSON, no manifest.

Each fact is a `relate exotoxin_action(<toxin>, <mechanism>)` clause carrying byte-provenance inline (verbatim NCBI source span + locator + `trust authoritative`). An LLM recalls by importing the library and asking a binding query; the native adj-lang engine resolves it and returns the citing clause.

## Edges (6) — each span independently re-fetched & confirmed verbatim

| toxin | mechanism | source |
|---|---|---|
| diphtheria_toxin | adp_ribosylation_of_ef2 | NBK7971 |
| shiga_toxin | inhibition_of_protein_synthesis | NBK556038 |
| cholera_toxin | activation_of_gs_adenylate_cyclase | NBK470232 |
| heat_labile_enterotoxin | activation_of_adenylate_cyclase | NBK564298 |
| pertussis_toxin | adp_ribosylation_of_gi | NBK7813 |
| tetanospasmin | blocks_inhibitory_neurotransmitter_release | NBK482484 |

Mechanism atoms are **span-faithful**: Shiga's cited span names ribosome binding → protein-synthesis inhibition without the 60S detail, so it carries `inhibition_of_protein_synthesis`; cholera names the Gs ADP-ribosylation step explicitly while the heat-labile span names only adenylate-cyclase stimulation.

## Tests

`test_exotoxin_recall.py` (3 tests, all pass with the native CLI built):
1. every clause grounded, no authored-debt, NCBI locators only;
2. engine binds each mechanism with an authoritative citation (source + NCBI locator);
3. an off-vocabulary toxin (Pseudomonas `exotoxin_a`, deliberately absent) **abstains** rather than fabricating.

Auto-discovered by `.github/workflows/mycin-2026.yml` (`recall/test_*.py`).

## Deferred (genuine, not dropped)

`pseudomonas_exotoxin_a`, `tsst_1` (superantigen), `botulinum_toxin`, C. perfringens alpha-toxin — no single self-contained affirmative NCBI sentence names both endpoints (sources split the toxin name and its mechanism across anaphoric sentences). To be re-grounded against alternate primary sources in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)