### PR TITLE
feat(mycin-nerve): ADJ-only peripheral-nerve-lesion recall library (8 edges)

### DIFF
--- a/code/specs/data/mycin-2026/recall/nerve-injury-edges.adj
+++ b/code/specs/data/mycin-2026/recall/nerve-injury-edges.adj
@@ -1,0 +1,95 @@
+% ============================================================================
+% nerve-injury-edges — the peripheral-nerve-lesion knowledge-graph (MYCIN-2026 NERVE).
+% ============================================================================
+% A high-yield clinical-neuroanatomy board domain: a named peripheral (or cranial)
+% nerve and the classic clinical sign its injury produces. "Injury to the radial
+% nerve produces which sign?" becomes the binding query
+%     ? nerve_lesion_sign(radial_nerve, $Sign).
+%
+% Direction note: the relation is nerve -> sign (`nerve_lesion_sign`), the board
+% direction — you name the injured nerve and must recall its localizing clinical
+% sign (wrist drop, claw hand, winged scapula, foot drop, ...). Each nerve here
+% maps to one canonical localizing sign, so a query binds a single answer. What
+% matters for grounding is that one self-contained span names BOTH the nerve AND
+% its sign in the same sentence.
+%
+% This file is the SHIPPED ARTIFACT and the SOLE source of truth — no generator,
+% no JSON, no manifest (a pure ADJ-only recall domain, like EXOTOXIN/EMBRYO/TOX).
+% Each fact is a `relate` clause whose byte-provenance lives INLINE:
+%     source   — the VERBATIM span copied from the cited page (byte-stable: it
+%                appears character-for-character in the page's normalized RUNNING
+%                text; every span here was independently re-fetched and confirmed,
+%                and figure-caption spans truncated by the page UI were rejected
+%                in favour of a clean body sentence — see the ulnar edge).
+%     locator  — the URL the span was read from (NCBI StatPearls / Bookshelf).
+%     trust    — authoritative (a primary, citable reference).
+% An LLM (or a human) recalls a fact by writing a tiny query .adj that `import`s
+% this library and asks a binding query — see nerve-injury-recall.query.adj.
+% Nothing here is asserted "from memory": every edge is defended by a span a reader
+% can re-fetch and check.
+% (See feedback_nothing_human_authored, feedback_adj_only_shipped_artifacts.)
+%
+% Faithful atoms: the foot-drop span names the DEEP FIBULAR nerve (the dorsiflexion
+% branch of the common peroneal/fibular nerve), so its subject atom is the
+% span-faithful deep_fibular_nerve, not the broader common_peroneal_nerve — the
+% atom matches the concept the cited sentence actually names.
+% ============================================================================
+
+dictionary nerve_vocab {
+    define nerve : entity   surface "peripheral nerve", "injured nerve"
+    define sign  : entity   surface "clinical sign", "localizing deficit"
+
+    define nerve_lesion_sign : relation from nerve to sign  % the sign a nerve injury produces
+}
+
+rulebook nerve_facts {
+    use nerve_vocab
+
+    % --- radial nerve -> wrist drop --------------------------------------------
+    relate nerve_lesion_sign(radial_nerve, wrist_drop)
+        source "Wrist drop is a disabling clinical condition resulting from dysfunction of the radial nerve, a major peripheral nerve that provides motor innervation to the extensor muscles of the wrist and fingers and sensory innervation to the dorsum of the hand."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK532993/"
+        trust authoritative
+
+    % --- median nerve -> hand of benediction -----------------------------------
+    relate nerve_lesion_sign(median_nerve, hand_of_benediction)
+        source "A low median nerve lesion can manifest as a positive Benediction sign when attempting to make a fist, given its role in innervating the muscles responsible for flexing the first to third fingers."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK554458/"
+        trust authoritative
+
+    % --- ulnar nerve -> ulnar claw hand (clean body sentence, not a caption) ----
+    relate nerve_lesion_sign(ulnar_nerve, ulnar_claw_hand)
+        source "Motor complaints may include weakness/paralysis of the intrinsic muscles of the hand innervated by the ulnar nerve, which may present as a weakening of the handgrip and clawing of the fourth and fifth digits."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK431063/"
+        trust authoritative
+
+    % --- long thoracic nerve -> winged scapula ---------------------------------
+    relate nerve_lesion_sign(long_thoracic_nerve, winged_scapula)
+        source "When the long thoracic nerve is injured, a phenomenon known as winging of the scapula results."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK535396/"
+        trust authoritative
+
+    % --- recurrent laryngeal nerve -> vocal cord paralysis ---------------------
+    relate nerve_lesion_sign(recurrent_laryngeal_nerve, vocal_cord_paralysis)
+        source "Injury to the recurrent laryngeal nerve has the potential to cause unilateral vocal cord paralysis."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK560832/"
+        trust authoritative
+
+    % --- facial nerve (CN VII) -> facial paralysis -----------------------------
+    relate nerve_lesion_sign(facial_nerve, facial_paralysis)
+        source "Bell palsy is the most common paralysis of the seventh cranial nerve, with an onset that is typically rapid and hemifacial."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK482290/"
+        trust authoritative
+
+    % --- superior gluteal nerve -> Trendelenburg gait --------------------------
+    relate nerve_lesion_sign(superior_gluteal_nerve, trendelenburg_gait)
+        source "Damage to the superior gluteal nerve results in paralysis of the gluteus medius muscle resulting in a characteristic gait on walking and standing known as the Trendelenburg gait."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK535408/"
+        trust authoritative
+
+    % --- deep fibular nerve -> foot drop (span names the deep fibular branch) ---
+    relate nerve_lesion_sign(deep_fibular_nerve, foot_drop)
+        source "Clinically, the deep fibular nerve is most commonly associated with foot drop, a consequence of impaired dorsiflexion."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK526033/"
+        trust authoritative
+}

--- a/code/specs/data/mycin-2026/recall/nerve-injury-recall.query.adj
+++ b/code/specs/data/mycin-2026/recall/nerve-injury-recall.query.adj
@@ -1,0 +1,24 @@
+% ============================================================================
+% nerve-injury-recall.query.adj — a worked recall query over the nerve-lesion library.
+% ============================================================================
+% The shape an LLM (or a clinician) produces to ANSWER a "this nerve injury
+% produces which sign?" question: it states no neuroanatomy fact — it only
+% `import`s the grounded library and asks binding queries. The native adj-lang
+% engine resolves each `?` against the imported `relate` edges and returns the
+% binding + the citing clause's source/locator/trust. All knowledge is in the
+% library; none is here.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli nerve-injury-recall.query.adj
+% ============================================================================
+
+import "nerve-injury-edges.adj"
+
+? nerve_lesion_sign(radial_nerve, $Sign)              % expect wrist_drop
+? nerve_lesion_sign(median_nerve, $Sign)              % expect hand_of_benediction
+? nerve_lesion_sign(ulnar_nerve, $Sign)               % expect ulnar_claw_hand
+? nerve_lesion_sign(long_thoracic_nerve, $Sign)       % expect winged_scapula
+? nerve_lesion_sign(recurrent_laryngeal_nerve, $Sign) % expect vocal_cord_paralysis
+? nerve_lesion_sign(facial_nerve, $Sign)              % expect facial_paralysis
+? nerve_lesion_sign(superior_gluteal_nerve, $Sign)    % expect trendelenburg_gait
+? nerve_lesion_sign(deep_fibular_nerve, $Sign)        % expect foot_drop

--- a/code/specs/data/mycin-2026/recall/test_nerve_injury_recall.py
+++ b/code/specs/data/mycin-2026/recall/test_nerve_injury_recall.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""test_nerve_injury_recall.py — the ADJ-only peripheral-nerve-lesion recall library (MYCIN-2026 NERVE).
+
+A new pure-ADJ recall domain (high-yield clinical-neuroanatomy board content): a named
+peripheral/cranial nerve and the classic clinical sign its injury produces.
+`nerve-injury-edges.adj` is the SOLE source of truth — facts + byte-provenance inline,
+no Python gate, no JSON, no manifest. This test pins the property that matters: the
+native adj-lang engine, given a query .adj that only `import`s the library and asks
+binding queries (`nerve-injury-recall.query.adj` — the shape an LLM produces), binds
+the grounded sign for each nerve, each carrying an AUTHORITATIVE citation with a real
+source span + locator. Knowledge lives in ADJ; the engine answers.
+
+If the native CLI isn't built (a Python-only CI lane), the engine-backed checks skip —
+the file-shape checks (every clause grounded, no authored-debt) still run.
+
+Run:  python3 test_nerve_injury_recall.py
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+ADJ = HERE / "nerve-injury-edges.adj"
+QUERY = HERE / "nerve-injury-recall.query.adj"
+CLI = HERE.parents[3] / "packages" / "rust" / "target" / "debug" / "adj-lang-cli"
+
+# Every grounded edge: peripheral/cranial nerve -> the localizing sign the library binds.
+# Each nerve maps to one canonical sign, so each query binds exactly one answer.
+EXPECTED = {
+    "radial_nerve": "wrist_drop",                          # NBK532993
+    "median_nerve": "hand_of_benediction",                 # NBK554458
+    "ulnar_nerve": "ulnar_claw_hand",                      # NBK431063
+    "long_thoracic_nerve": "winged_scapula",               # NBK535396
+    "recurrent_laryngeal_nerve": "vocal_cord_paralysis",   # NBK560832
+    "facial_nerve": "facial_paralysis",                    # NBK482290
+    "superior_gluteal_nerve": "trendelenburg_gait",        # NBK535408
+    "deep_fibular_nerve": "foot_drop",                     # NBK526033
+}
+REL = "nerve_lesion_sign"
+VAR = "Sign"
+
+
+def _cli_available() -> bool:
+    return CLI.exists()
+
+
+def _run(program: Path) -> dict:
+    out = subprocess.run([str(CLI), str(program)], capture_output=True, text=True,
+                         cwd=str(HERE), timeout=60)
+    assert out.returncode == 0, f"adj-lang-cli failed: {out.stderr}"
+    return json.loads(out.stdout)
+
+
+# ---- 1. the ADJ file is the artifact — every clause grounded, no authored-debt ----
+
+def test_library_is_pure_adj_and_fully_grounded() -> None:
+    text = ADJ.read_text()
+    assert "trust consensus" not in text, "NERVE ships no authored-debt; ground or omit"
+    assert "[FLAG:" not in text
+    edge_count = len(EXPECTED)  # 8
+    assert text.count("    relate ") == edge_count
+    assert text.count("trust authoritative") == edge_count
+    assert text.count('\n        locator "') == edge_count
+    assert text.count('\n        source "') == edge_count
+    # every locator is an NCBI primary source
+    for line in text.splitlines():
+        line = line.strip()
+        if line.startswith("locator "):
+            assert "https://www.ncbi.nlm.nih.gov/" in line, f"non-NCBI locator: {line}"
+    assert not (HERE / "nerve_injury_edge_ground.py").exists()
+    assert not (HERE / "nerve-injury-edge-grounding.json").exists()
+    assert not (HERE / "nerve-injury-edge-manifest.json").exists()
+
+
+# ---- 2. the engine binds each sign, each with an authoritative citation ------------
+
+def test_engine_binds_every_sign_with_authoritative_citation() -> None:
+    if not _cli_available():
+        return
+    result = _run(QUERY)
+    by_query = {r["query"]: r for r in result["recall"]}
+    for nerve, sign in EXPECTED.items():
+        q = f"{REL}({nerve}, {VAR})"
+        r = by_query.get(q)
+        assert r is not None and not r["abstained"], f"{q} abstained — edge missing?"
+        bound = {}
+        for a in r["answers"]:
+            bound[a["bindings"][VAR]] = (a.get("citations") or [{}])[0]
+        assert set(bound) == {sign}, f"{nerve}: bound {set(bound)} != {{{sign}}}"
+        cite = bound[sign]
+        assert cite.get("trust") == "authoritative", f"{nerve}/{sign} not authoritative"
+        assert cite.get("source"), f"{nerve}/{sign} has no source span"
+        assert cite.get("locator", "").startswith("https://www.ncbi.nlm.nih.gov/")
+
+
+# ---- 3. an off-vocabulary nerve abstains, never fabricates --------------------------
+
+def test_unknown_nerve_abstains() -> None:
+    if not _cli_available():
+        return
+    import os
+    import tempfile
+    fd, path = tempfile.mkstemp(suffix=".adj", prefix=".nerve_q_", dir=HERE)
+    try:
+        with os.fdopen(fd, "w") as fh:
+            # femoral_nerve is not in the library (knee-extension deficit) -> must abstain
+            fh.write(f'import "nerve-injury-edges.adj"\n? {REL}(femoral_nerve, ${VAR})\n')
+        res = _run(Path(path))
+        r = res["recall"][0] if res["recall"] else None
+        assert r is not None and r["abstained"], "an ungrounded nerve must abstain"
+    finally:
+        os.unlink(path)
+
+
+def _run_all() -> int:
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    failed = 0
+    for t in tests:
+        try:
+            t()
+            print(f"  PASS  {t.__name__}")
+        except AssertionError as exc:
+            failed += 1
+            print(f"  FAIL  {t.__name__}: {exc}")
+    print(f"\ntest_nerve_injury_recall: {len(tests) - failed}/{len(tests)} passed")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(_run_all())


### PR DESCRIPTION
## What

A new pure-ADJ recall domain for MYCIN-2026: **peripheral/cranial nerve injury → classic localizing sign** — high-yield clinical-neuroanatomy board content. Follows the established ADJ-only pattern (EXOTOXIN/EMBRYO/TOX/PSYCH): the shipped `.adj` library is the sole source of truth — no Python generator, no JSON, no manifest.

Each fact is a `relate nerve_lesion_sign(<nerve>, <sign>)` clause carrying byte-provenance inline (verbatim NCBI source span + locator + `trust authoritative`). An LLM recalls by importing the library and asking a binding query; the native adj-lang engine resolves it.

## Edges (8) — each span independently re-fetched & confirmed verbatim against the page's running text

| nerve | sign | source |
|---|---|---|
| radial_nerve | wrist_drop | NBK532993 |
| median_nerve | hand_of_benediction | NBK554458 |
| ulnar_nerve | ulnar_claw_hand | NBK431063 |
| long_thoracic_nerve | winged_scapula | NBK535396 |
| recurrent_laryngeal_nerve | vocal_cord_paralysis | NBK560832 |
| facial_nerve | facial_paralysis | NBK482290 |
| superior_gluteal_nerve | trendelenburg_gait | NBK535408 |
| deep_fibular_nerve | foot_drop | NBK526033 |

## Faithfulness notes

- **ulnar**: first grounded from a figure caption the page UI truncates with "(more...)" — not byte-stable against the fetchable text — so re-grounded to a clean **body** sentence (NBK431063, cubital tunnel).
- **foot drop**: the cited span names the **deep fibular nerve** (the dorsiflexion branch), so the subject atom is the span-faithful `deep_fibular_nerve`, not the broader `common_peroneal_nerve`.

## Tests

`test_nerve_injury_recall.py` (3 tests, all pass with the native CLI built): every clause grounded (no authored-debt, NCBI locators only); engine binds each sign with an authoritative citation; an off-vocabulary nerve (`femoral_nerve`) **abstains** rather than fabricating. Auto-discovered by `.github/workflows/mycin-2026.yml`.

## Deferred (genuine, not dropped)

`axillary_nerve`, `tibial_nerve`, `femoral_nerve`, `common_peroneal_nerve` — sources split the nerve name and its deficit across separate/anaphoric sentences (or only the "CPN" abbreviation co-occurs with foot drop). To be re-grounded against alternate primary sources in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)