### PR TITLE
feat(mycin-diuretic): ADJ-only diuretic site-of-action recall library (4 edges)

### DIFF
--- a/code/specs/data/mycin-2026/recall/diuretic-site-edges.adj
+++ b/code/specs/data/mycin-2026/recall/diuretic-site-edges.adj
@@ -1,0 +1,72 @@
+% ============================================================================
+% diuretic-site-edges — the diuretic site-of-action knowledge-graph (MYCIN-2026 DIURETIC).
+% ============================================================================
+% A high-yield renal-pharmacology board domain: a diuretic (named drug OR drug
+% class) and the nephron segment where it acts. "Loop diuretics act on which
+% nephron segment?" becomes the binding query
+%     ? diuretic_site(loop_diuretic, $Segment).
+%
+% Direction note: the relation is diuretic -> nephron segment (`diuretic_site`),
+% the board direction — you name a diuretic and must recall WHERE along the
+% nephron it works (proximal tubule / thick ascending limb / distal convoluted
+% tubule / collecting duct). Each subject here maps to one canonical segment, so a
+% query binds a single answer. What matters for grounding is that one
+% self-contained span names BOTH the diuretic AND its segment in the same sentence.
+%
+% Subject granularity is SPAN-FAITHFUL, not uniform: where the cited sentence
+% names a drug CLASS ("Loop diuretics ...", "Thiazide diuretics ...", "carbonic
+% anhydrase inhibitors ...") the subject atom is the class (loop_diuretic,
+% thiazide, carbonic_anhydrase_inhibitor); where it names an individual drug
+% ("Amiloride ...") the subject atom is that drug (amiloride). The atom always
+% matches the concept the span actually names — we do not promote a class span to
+% a specific drug it never mentions.
+%
+% This file is the SHIPPED ARTIFACT and the SOLE source of truth — no generator,
+% no JSON, no manifest (a pure ADJ-only recall domain, like NERVE/EXOTOXIN/EMBRYO).
+% Each fact is a `relate` clause whose byte-provenance lives INLINE:
+%     source   — the VERBATIM span copied from the cited page (byte-stable: it
+%                appears character-for-character in the page's normalized text;
+%                every span here was independently re-fetched and confirmed).
+%     locator  — the URL the span was read from (NCBI StatPearls / Bookshelf).
+%     trust    — authoritative (a primary, citable reference).
+% An LLM (or a human) recalls a fact by writing a tiny query .adj that `import`s
+% this library and asks a binding query — see diuretic-site-recall.query.adj.
+% Nothing here is asserted "from memory": every edge is defended by a span a reader
+% can re-fetch and check.
+% (See feedback_nothing_human_authored, feedback_adj_only_shipped_artifacts.)
+% ============================================================================
+
+dictionary diuretic_vocab {
+    define diuretic : entity   surface "diuretic drug or class", "named diuretic"
+    define segment  : entity   surface "nephron segment", "site of action"
+
+    define diuretic_site : relation from diuretic to segment  % the nephron segment a diuretic acts on
+}
+
+rulebook diuretic_facts {
+    use diuretic_vocab
+
+    % --- loop diuretics -> thick ascending limb --------------------------------
+    relate diuretic_site(loop_diuretic, thick_ascending_limb)
+        source "Loop diuretics induce its effect by competing with chloride to bind to the Na-K-2Cl (NKCC2) cotransporter at the apical membrane of the thick ascending limb of the loop of Henle and blocking the cotransporter, which inhibits the reabsorption of sodium and chloride."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK546656/"
+        trust authoritative
+
+    % --- thiazide diuretics -> distal convoluted tubule ------------------------
+    relate diuretic_site(thiazide, distal_convoluted_tubule)
+        source "Thiazide diuretics exert their diuretic effect via blockage of the sodium-chloride (Na+/Cl-) channel in the proximal segment of the distal convoluted tubule (DCT)."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK532918/"
+        trust authoritative
+
+    % --- amiloride -> collecting duct (ENaC, distal nephron) -------------------
+    relate diuretic_site(amiloride, collecting_duct)
+        source "Amiloride works by inhibiting the epithelial sodium channels (ENaC) in the distal nephron (distal convoluted tubule and cortical collecting duct), lung, and colon."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK542303/"
+        trust authoritative
+
+    % --- carbonic anhydrase inhibitors -> proximal tubule ----------------------
+    relate diuretic_site(carbonic_anhydrase_inhibitor, proximal_tubule)
+        source "Proximal RTA in adults may also result from carbonic anhydrase inhibitors, which impair proximal bicarbonate reabsorption without affecting the reabsorption of other proximal tubule solutes."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK519044/"
+        trust authoritative
+}

--- a/code/specs/data/mycin-2026/recall/diuretic-site-recall.query.adj
+++ b/code/specs/data/mycin-2026/recall/diuretic-site-recall.query.adj
@@ -1,0 +1,20 @@
+% ============================================================================
+% diuretic-site-recall.query.adj — a worked recall query over the diuretic library.
+% ============================================================================
+% The shape an LLM (or a clinician) produces to ANSWER a "this diuretic acts on
+% which nephron segment?" question: it states no pharmacology fact — it only
+% `import`s the grounded library and asks binding queries. The native adj-lang
+% engine resolves each `?` against the imported `relate` edges and returns the
+% binding + the citing clause's source/locator/trust. All knowledge is in the
+% library; none is here.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli diuretic-site-recall.query.adj
+% ============================================================================
+
+import "diuretic-site-edges.adj"
+
+? diuretic_site(loop_diuretic, $Segment)              % expect thick_ascending_limb
+? diuretic_site(thiazide, $Segment)                   % expect distal_convoluted_tubule
+? diuretic_site(amiloride, $Segment)                  % expect collecting_duct
+? diuretic_site(carbonic_anhydrase_inhibitor, $Segment) % expect proximal_tubule

--- a/code/specs/data/mycin-2026/recall/test_diuretic_site_recall.py
+++ b/code/specs/data/mycin-2026/recall/test_diuretic_site_recall.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""test_diuretic_site_recall.py — the ADJ-only diuretic site-of-action recall library (MYCIN-2026 DIURETIC).
+
+A new pure-ADJ recall domain (high-yield renal-pharmacology board content): a diuretic
+(named drug or drug class) and the nephron segment where it acts. `diuretic-site-edges.adj`
+is the SOLE source of truth — facts + byte-provenance inline, no Python gate, no JSON,
+no manifest. This test pins the property that matters: the native adj-lang engine, given a
+query .adj that only `import`s the library and asks binding queries
+(`diuretic-site-recall.query.adj` — the shape an LLM produces), binds the grounded segment
+for each diuretic, each carrying an AUTHORITATIVE citation with a real source span +
+locator. Knowledge lives in ADJ; the engine answers.
+
+If the native CLI isn't built (a Python-only CI lane), the engine-backed checks skip —
+the file-shape checks (every clause grounded, no authored-debt) still run.
+
+Run:  python3 test_diuretic_site_recall.py
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+ADJ = HERE / "diuretic-site-edges.adj"
+QUERY = HERE / "diuretic-site-recall.query.adj"
+CLI = HERE.parents[3] / "packages" / "rust" / "target" / "debug" / "adj-lang-cli"
+
+# Every grounded edge: diuretic (drug or class) -> the nephron segment the library binds.
+# Subject granularity is span-faithful: class atoms where the cited sentence names the
+# class, drug atoms where it names the drug. Each subject binds exactly one segment.
+EXPECTED = {
+    "loop_diuretic": "thick_ascending_limb",                  # NBK546656
+    "thiazide": "distal_convoluted_tubule",                   # NBK532918
+    "amiloride": "collecting_duct",                           # NBK542303
+    "carbonic_anhydrase_inhibitor": "proximal_tubule",        # NBK519044
+}
+REL = "diuretic_site"
+VAR = "Segment"
+
+
+def _cli_available() -> bool:
+    return CLI.exists()
+
+
+def _run(program: Path) -> dict:
+    out = subprocess.run([str(CLI), str(program)], capture_output=True, text=True,
+                         cwd=str(HERE), timeout=60)
+    assert out.returncode == 0, f"adj-lang-cli failed: {out.stderr}"
+    return json.loads(out.stdout)
+
+
+# ---- 1. the ADJ file is the artifact — every clause grounded, no authored-debt ----
+
+def test_library_is_pure_adj_and_fully_grounded() -> None:
+    text = ADJ.read_text()
+    assert "trust consensus" not in text, "DIURETIC ships no authored-debt; ground or omit"
+    assert "[FLAG:" not in text
+    edge_count = len(EXPECTED)  # 4
+    assert text.count("    relate ") == edge_count
+    assert text.count("trust authoritative") == edge_count
+    assert text.count('\n        locator "') == edge_count
+    assert text.count('\n        source "') == edge_count
+    # every locator is an NCBI primary source
+    for line in text.splitlines():
+        line = line.strip()
+        if line.startswith("locator "):
+            assert "https://www.ncbi.nlm.nih.gov/" in line, f"non-NCBI locator: {line}"
+    assert not (HERE / "diuretic_site_edge_ground.py").exists()
+    assert not (HERE / "diuretic-site-edge-grounding.json").exists()
+    assert not (HERE / "diuretic-site-edge-manifest.json").exists()
+
+
+# ---- 2. the engine binds each segment, each with an authoritative citation ---------
+
+def test_engine_binds_every_segment_with_authoritative_citation() -> None:
+    if not _cli_available():
+        return
+    result = _run(QUERY)
+    by_query = {r["query"]: r for r in result["recall"]}
+    for diuretic, segment in EXPECTED.items():
+        q = f"{REL}({diuretic}, {VAR})"
+        r = by_query.get(q)
+        assert r is not None and not r["abstained"], f"{q} abstained — edge missing?"
+        bound = {}
+        for a in r["answers"]:
+            bound[a["bindings"][VAR]] = (a.get("citations") or [{}])[0]
+        assert set(bound) == {segment}, f"{diuretic}: bound {set(bound)} != {{{segment}}}"
+        cite = bound[segment]
+        assert cite.get("trust") == "authoritative", f"{diuretic}/{segment} not authoritative"
+        assert cite.get("source"), f"{diuretic}/{segment} has no source span"
+        assert cite.get("locator", "").startswith("https://www.ncbi.nlm.nih.gov/")
+
+
+# ---- 3. an off-vocabulary diuretic abstains, never fabricates -----------------------
+
+def test_unknown_diuretic_abstains() -> None:
+    if not _cli_available():
+        return
+    import os
+    import tempfile
+    fd, path = tempfile.mkstemp(suffix=".adj", prefix=".diuretic_q_", dir=HERE)
+    try:
+        with os.fdopen(fd, "w") as fh:
+            # spironolactone is not in the library (aldosterone antagonist) -> must abstain
+            fh.write(f'import "diuretic-site-edges.adj"\n? {REL}(spironolactone, ${VAR})\n')
+        res = _run(Path(path))
+        r = res["recall"][0] if res["recall"] else None
+        assert r is not None and r["abstained"], "an ungrounded diuretic must abstain"
+    finally:
+        os.unlink(path)
+
+
+def _run_all() -> int:
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    failed = 0
+    for t in tests:
+        try:
+            t()
+            print(f"  PASS  {t.__name__}")
+        except AssertionError as exc:
+            failed += 1
+            print(f"  FAIL  {t.__name__}: {exc}")
+    print(f"\ntest_diuretic_site_recall: {len(tests) - failed}/{len(tests)} passed")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(_run_all())


### PR DESCRIPTION
## What

A new pure-ADJ recall domain for MYCIN-2026: **diuretic → nephron segment of action** — high-yield renal-pharmacology board content. Follows the established ADJ-only pattern (NERVE/EXOTOXIN/EMBRYO): the shipped `.adj` library is the sole source of truth — no Python generator, no JSON, no manifest.

Each fact is a `relate diuretic_site(<diuretic>, <segment>)` clause carrying byte-provenance inline (verbatim NCBI source span + locator + `trust authoritative`). An LLM recalls by importing the library and asking a binding query; the native adj-lang engine resolves it.

## Edges (4) — each span independently re-fetched & confirmed verbatim

| diuretic | nephron segment | source |
|---|---|---|
| loop_diuretic | thick_ascending_limb | NBK546656 |
| thiazide | distal_convoluted_tubule | NBK532918 |
| amiloride | collecting_duct | NBK542303 |
| carbonic_anhydrase_inhibitor | proximal_tubule | NBK519044 |

**Subject granularity is span-faithful**, not uniform: where the cited sentence names a drug *class* ("Loop diuretics…", "Thiazide diuretics…", "carbonic anhydrase inhibitors…") the subject atom is the class; where it names an individual drug ("Amiloride…") the subject is the drug. The atom always matches the concept the span actually names — a class span is never promoted to a specific drug it never mentions.

## Tests

`test_diuretic_site_recall.py` (3 tests, all pass with the native CLI built): every clause grounded (no authored-debt, NCBI locators only); engine binds each segment with an authoritative citation; an off-vocabulary diuretic (`spironolactone`) **abstains** rather than fabricating. Auto-discovered by `.github/workflows/mycin-2026.yml`.

## Deferred (genuine, not dropped)

`acetazolamide`, `spironolactone`, `mannitol` — no fetched StatPearls page carries a single self-contained sentence naming the **drug** as subject together with its nephron segment (acetazolamide's site appears only under the "carbonic anhydrase inhibitors" class noun, captured here; spironolactone's only segment-naming sentence has "aldosterone" as subject; mannitol's only segment span names "osmotic diuretics" generically). To be re-grounded against alternate primary sources in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)